### PR TITLE
Make place type in Place Reference Editor editable, add tooltip (maintenance/gramps41)

### DIFF
--- a/gramps/gui/glade/editplaceref.glade
+++ b/gramps/gui/glade/editplaceref.glade
@@ -350,11 +350,13 @@
                     <child>
                       <object class="GtkComboBox" id="place_type">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can_focus">True</property>
+                        <property name="tooltip_text" translatable="yes">What type of place this is. Eg 'Country', 'City', ... .</property>
                         <property name="has_entry">True</property>
                         <child internal-child="entry">
                           <object class="GtkEntry" id="combobox-entry">
-                            <property name="can_focus">False</property>
+                            <property name="can_focus">True</property>
+                            <property name="overwrite_mode">True</property>
                           </object>
                         </child>
                       </object>


### PR DESCRIPTION
The place type field in the Place Editor is editable and has a tooltip. This simple change adds these properties in the Place *Reference* Editor (maintenance/gramps41 branch).