### PR TITLE
webkit dependency no longer required, HTML View removed

### DIFF
--- a/README
+++ b/README
@@ -67,12 +67,10 @@ The following packages are optional
 
    ttf-freefont     More font support in the reports
 
-   gir-webkit       Required for the (user-downloadable) HtmlView plugin
-
    goocanvas2       Required for the (user-downloadable) GraphView plugin
 
-No longer needed in 4.1:
-   ?
+No longer needed in 4.2:
+   gir-webkit
 No longer needed in 4.0:
    pygoocanvas, pygtk, pyexiv2
 No longer needed in 3.3:


### PR DESCRIPTION
Just a tidy up of README after noticing the webkit dependency was dropped by Jerome, and the NEWS file mentions that the HTML view has been removed (in the recent 4.2.0 release).

This probably should also be applied to the 4.2 branch.