### PR TITLE
8471: Set "visable_window" in GtkEventBox to fix transparency.

### DIFF
--- a/gramps/gui/glade/editperson.glade
+++ b/gramps/gui/glade/editperson.glade
@@ -108,6 +108,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="valign">start</property>
+            <property name="visible_window">False</property>
             <child>
               <object class="GtkBox" id="vbox1">
                 <property name="visible">True</property>


### PR DESCRIPTION
Was showing transparent background in a Compiz environment without
this option "visable_window" being explicitly set.  It is already set to False in other dialogs.