### PR TITLE
8888 'Family Tree(Manager)' add Help button (glade) and help link

### DIFF
--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -82,16 +82,20 @@ from .glade import Glade
 from gramps.gen.db.exceptions import DbException
 from gramps.gen.config import config
 from gramps.gui.listmodel import ListModel
-
-_RETURN = Gdk.keyval_from_name("Return")
-_KP_ENTER = Gdk.keyval_from_name("KP_Enter")
-
+from gramps.gui.display import display_help
+from gramps.gen.const import URL_MANUAL_PAGE
 
 #-------------------------------------------------------------------------
 #
 # constants
 #
 #-------------------------------------------------------------------------
+
+WIKI_HELP_PAGE = _('%s_-_Manage_Family_Trees') % URL_MANUAL_PAGE
+WIKI_HELP_SEC = _('Family_Trees_manager_window')
+
+_RETURN = Gdk.keyval_from_name("Return")
+_KP_ENTER = Gdk.keyval_from_name("KP_Enter")
 
 ARCHIVE       = "rev.gramps"
 ARCHIVE_V     = "rev.gramps,v"
@@ -200,8 +204,15 @@ class DbManager(CLIDbManager):
         self.top.connect('drag_motion', drag_motion)
         self.top.connect('drag_drop', drop_cb)
 
+        self.define_help_button(self.glade.get_object('help'),
+                WIKI_HELP_PAGE, WIKI_HELP_SEC)
+
         if _RCS_FOUND:
             self.rcs.connect('clicked', self.__rcs)
+
+    def define_help_button(self, button, webpage='', section=''):
+        button.connect('clicked', lambda x: display_help(webpage,
+                                                               section))
 
     def __button_press(self, obj, event):
         """

--- a/gramps/gui/glade/dbman.glade
+++ b/gramps/gui/glade/dbman.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.16.1 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkDialog" id="comment">
@@ -63,6 +63,8 @@
               <packing>
                 <property name="left_attach">1</property>
                 <property name="top_attach">0</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -76,6 +78,8 @@
               <packing>
                 <property name="left_attach">1</property>
                 <property name="top_attach">1</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -146,6 +150,22 @@
                 <property name="expand">False</property>
                 <property name="fill">False</property>
                 <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="help">
+                <property name="label" translatable="yes">_Help</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>
@@ -330,6 +350,7 @@
     <action-widgets>
       <action-widget response="-7">cancel</action-widget>
       <action-widget response="-5">connect</action-widget>
+      <action-widget response="-11">help</action-widget>
     </action-widgets>
   </object>
 </interface>


### PR DESCRIPTION
My attempt at modifying a glade dialog to add a Help button.

While it works and goes to the help page, I'm not quite sure why the dialog is also dismissed?

https://gramps-project.org/bugs/view.php?id=8888 