### PR TITLE
Handle citation objects in glocale.trans_objclass

### DIFF
--- a/gramps/gen/utils/grampslocale.py
+++ b/gramps/gen/utils/grampslocale.py
@@ -835,6 +835,8 @@ class GrampsLocale(object):
             return _("the source")
         elif objclass == "filter":
             return _("the filter")
+        elif objclass == "citation":
+            return _("the citation")
         else:
             return _("See details")
 


### PR DESCRIPTION
Without this right clicking on a citation in the clipboard
gives options like "Make See Details active" which don't make
an awful lot of sense.