### PR TITLE
Re-enable selection in the clipboard on a grab_broken event

### DIFF
--- a/gramps/gui/clipboard.py
+++ b/gramps/gui/clipboard.py
@@ -1477,6 +1477,7 @@ class MultiTreeView(Gtk.TreeView):
         Gtk.TreeView.__init__(self)
         self.connect('button_press_event', self.on_button_press)
         self.connect('button_release_event', self.on_button_release)
+        self.connect('grab_broken_event', self.on_grab_broken)
         self.connect('key_press_event', self.key_press_event)
         self.defer_select = False
 
@@ -1576,6 +1577,11 @@ class MultiTreeView(Gtk.TreeView):
             and not (event.x==0 and event.y==0)): # certain drag and drop
             self.set_cursor(target[0], target[1], False)
 
+        self.defer_select=False
+
+    def on_grab_broken(self, widget, event):
+        # re-enable selection
+        self.get_selection().set_select_function(lambda *ignore: True, None)
         self.defer_select=False
 
     def edit_obj(self, objclass, handle):

--- a/gramps/gui/widgets/multitreeview.py
+++ b/gramps/gui/widgets/multitreeview.py
@@ -40,6 +40,7 @@ class MultiTreeView(Gtk.TreeView):
         Gtk.TreeView.__init__(self)
         self.connect('button_press_event', self.on_button_press)
         self.connect('button_release_event', self.on_button_release)
+        self.connect('grab_broken_event', self.on_grab_broken)
         self.connect('key_press_event', self.key_press_event)
         self.defer_select = False
 
@@ -82,3 +83,7 @@ class MultiTreeView(Gtk.TreeView):
 
         self.defer_select=False
 
+    def on_grab_broken(self, widget, event):
+        # re-enable selection
+        self.get_selection().set_select_function(lambda *ignore: True, None)
+        self.defer_select=False


### PR DESCRIPTION
As of GTK 3.18.0 a fake button release event is no longer sent when a DnD completes:

  https://bugzilla.gnome.org/show_bug.cgi?id=749737

As a result we keep selection disabled which then means that the next drag from the clipboard fails to select the dragged object and we wind up trying to drop the old selection instead.