### PR TITLE
Small fix in import script

### DIFF
--- a/gramps/gui/dbloader.py
+++ b/gramps/gui/dbloader.py
@@ -168,7 +168,7 @@ class DbLoader(CLIDbLoader):
         import_dialog.set_current_folder(default_dir)
         while True:
             response = import_dialog.run()
-            if response == Gtk.ResponseType.CANCEL:
+            if response in (Gtk.ResponseType.CANCEL, Gtk.ResponseType.DELETE_EVENT):
                 break
             elif response == Gtk.ResponseType.OK:
                 filename = conv_to_unicode(import_dialog.get_filename())

--- a/gramps/plugins/view/view.gpr.py
+++ b/gramps/plugins/view/view.gpr.py
@@ -196,7 +196,6 @@ authors = ["The Gramps project"],
 authors_email = ["http://gramps-project.org"],
 category = ("People", _("People")),
 viewclass = 'PersonListView',
-order = START,
 stock_icon = 'gramps-tree-list',
   )
   
@@ -212,7 +211,6 @@ authors = ["The Gramps project"],
 authors_email = ["http://gramps-project.org"],
 category = ("Places", _("Places")),
 viewclass = 'PlaceListView',
-order = START,
 stock_icon = 'gramps-tree-list',
   )
 
@@ -229,6 +227,7 @@ authors_email = [""],
 category = ("Places", _("Places")),
 viewclass = 'PlaceTreeView',
 stock_icon = 'gramps-tree-group',
+order = START,
   )
 
 register(VIEW, 


### PR DESCRIPTION
The file dialogue created by clicking Family Trees -> import would not close properly when the x was pressed; rather, the user had to click cancel.