### PR TITLE
8556: ValueError: underlying buffer has been detached

### DIFF
--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -409,18 +409,6 @@ def run():
     else:
         # CLI use of Gramps
 
-        # Ensure that output is encoded correctly to stdout and
-        # stderr. This is much less cumbersome and error-prone than
-        # encoding individual outputs:
-        try:
-            _encoding = sys.stdout.encoding or sys.getdefaultencoding()
-        except:
-            _encoding = "UTF-8"
-        import codecs
-        sys.stdout = codecs.getwriter(_encoding)(sys.stdout.detach(),
-                                                 'backslashreplace')
-        sys.stderr = codecs.getwriter(_encoding)(sys.stderr.detach(),
-                                                 'backslashreplace')
         argpars.print_help()
         argpars.print_usage()
         from .cli.grampscli import startcli

--- a/gramps/plugins/export/exportxml.py
+++ b/gramps/plugins/export/exportxml.py
@@ -126,7 +126,7 @@ class GrampsXmlWriter(UpdateCallback):
         """
         if filename == '-':
             import sys
-            g = sys.stdout
+            g = sys.stdout.buffer
             self.compress = False
         else:
             base = os.path.dirname(filename)


### PR DESCRIPTION
Remove encoding on stdout/stderr.