### PR TITLE
Fix for a None handle lookup in relview

### DIFF
--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -497,7 +497,9 @@ class RelationshipView(NavigationView):
         for old_child in self.header.get_children():
             self.header.remove(old_child)
 
-        person = self.dbstate.db.get_person_from_handle(obj)
+        person = None
+        if obj:
+            person = self.dbstate.db.get_person_from_handle(obj)
         if not person:
             self.family_action.set_sensitive(False)
             self.order_action.set_sensitive(False)


### PR DESCRIPTION
If focusing on the relationship view with an empty tree loaded, an uncaught exception was raised by attempting to call get_person_from_handle with a None handle:

```
Traceback (most recent call last):
  File "dev/gramps/installed/lib64/python3.4/site-packages/gramps/gui/viewmanager.py", line 1011, in view_changed
    self.__change_page(page_num)
  File "dev/gramps/installed/lib64/python3.4/site-packages/gramps/gui/viewmanager.py", line 1024, in __change_page
    self.active_page.set_active()
  File "dev/gramps/installed/lib64/python3.4/site-packages/gramps/gui/views/navigationview.py", line 154, in set_active
    PageView.set_active(self)
  File "dev/gramps/installed/lib64/python3.4/site-packages/gramps/gui/views/pageview.py", line 304, in set_active
    self.build_tree()
  File "dev/gramps/installed/lib64/python3.4/site-packages/gramps/plugins/view/relview.py", line 205, in build_tree
    self.redraw()
  File "dev/gramps/installed/lib64/python3.4/site-packages/gramps/plugins/view/relview.py", line 465, in redraw
    self.change_person(None)
  File "dev/gramps/installed/lib64/python3.4/site-packages/gramps/plugins/view/relview.py", line 470, in change_person
    return self._change_person(obj)
  File "dev/gramps/installed/lib64/python3.4/site-packages/gramps/plugins/view/relview.py", line 500, in _change_person
    person = self.dbstate.db.get_person_from_handle(obj)
  File "dev/gramps/installed/lib64/python3.4/site-packages/gramps/plugins/database/bsddb_support/read.py", line 723, in get_person_from_handle
    return self.get_from_handle(handle, Person, self.person_map)
  File "dev/gramps/installed/lib64/python3.4/site-packages/gramps/plugins/database/bsddb_support/write.py", line 2113, in get_from_handle
    raise HandleError('Handle is None')
gramps.gen.errors.HandleError: Handle is None
```