### PR TITLE
fixes for None handle errors: single-parent family

### DIFF
--- a/gramps/gui/widgets/fanchart.py
+++ b/gramps/gui/widgets/fanchart.py
@@ -1632,6 +1632,8 @@ class FanChartGrampsGUI(object):
                 sp_id = family.get_mother_handle()
             else:
                 sp_id = family.get_father_handle()
+            if not sp_id:
+                continue
             spouse = self.dbstate.db.get_person_from_handle(sp_id)
             if not spouse:
                 continue
@@ -1743,6 +1745,8 @@ class FanChartGrampsGUI(object):
         no_parents = 1
         par_list = find_parents(self.dbstate.db,person)
         for par_id in par_list:
+            if not par_id:
+                continue
             par = self.dbstate.db.get_person_from_handle(par_id)
             if not par:
                 continue

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -1056,7 +1056,7 @@ class RelationshipView(NavigationView):
             link_label.show()
             vbox.pack_start(link_label, True, True, 0)
 
-        if self.show_details:
+        if self.show_details and handle:
             value = self.info_string(handle)
             if value:
                 vbox.pack_start(widgets.MarkupLabel(value), True, True, 0)


### PR DESCRIPTION
Fixes for Person lookups with None handles, related to the use of a
single-parent family