### PR TITLE
Default locale: only consider the values of LC_ALL, LANG, and LANGUAGE

### DIFF
--- a/gramps/gen/utils/grampslocale.py
+++ b/gramps/gen/utils/grampslocale.py
@@ -294,13 +294,12 @@ class GrampsLocale(object):
         _failure = False
         try:
             locale.setlocale(locale.LC_ALL, '')
-            if not _check_locale(locale.getlocale()):
-                if not _check_locale(locale.getdefaultlocale()):
-                    LOG.debug("Usable locale not found, localization settings ignored.");
-                    self.lang = 'C'
-                    self.encoding = 'ascii'
-                    self.language = ['en']
-                    _failure = True
+            if not _check_locale(locale.getdefaultlocale(envvars=('LC_ALL', 'LANG', 'LANGUAGE'))):
+                LOG.debug("Usable locale not found, localization settings ignored.");
+                self.lang = 'C'
+                self.encoding = 'ascii'
+                self.language = ['en']
+                _failure = True
 
         except locale.Error as err:
             LOG.debug("Locale error %s, localization settings ignored.",


### PR DESCRIPTION
Default arguments of locale.getdefaultlocale() consider the value
of LC_CTYPE in addition to the three aforementioned all-category
variables, which under certain conditions (LC_CTYPE set, LC_ALL and
the rest of LC_FOO unset) would result in the locale set in LC_CTYPE
(which should only affect interpretation of byte sequences as
characters) spilling over to other locale categories handled by the
GrampsLocale object. The most visible effect of that spill was that
with LC_ALL, LANG, LANGUAGE and LC_MESSAGES unset but LC_CTYPE set,
Gramps would start using the wrong UI language.

Fixed by removing extra call to locale.getlocale() and passing custom
envvars argument to locale.getdefaultlocale().