### PR TITLE
Fix setup.py to remove the double '/' when building man pages.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -180,8 +180,8 @@ def build_man(build_cmd):
                 filename = False
 
             lang = man_dir[8:]
-            src = build_cmd.build_base  + '/data/man/' + lang  + '/gramps.1.gz'
-            target = 'share/man/' + lang + '/man1'
+            src = build_cmd.build_base  + '/data/man' + lang  + '/gramps.1.gz'
+            target = 'share/man' + lang + '/man1'
             data_files.append((target, [src]))
 
             log.info('Compiling %s >> %s.', src, target)


### PR DESCRIPTION
This was resulting in 'share/man//...' showing in the file list generated for system packages.