### PR TITLE
3068: Wrong reference number for "same person as" in detdescendantreport

### DIFF
--- a/gramps/plugins/textreport/detdescendantreport.py
+++ b/gramps/plugins/textreport/detdescendantreport.py
@@ -195,7 +195,11 @@ class DetDescendantReport(Report):
     def apply_henry_filter(self,person_handle, index, pid, cur_gen=1):
         if (not person_handle) or (cur_gen > self.max_generations):
             return
-        self.dnumber[person_handle] = pid
+        if person_handle in self.dnumber:
+            if self.dnumber[person_handle] > pid:
+                self.dnumber[person_handle] = pid
+        else:
+            self.dnumber[person_handle] = pid
         self.map[index] = person_handle
 
         if len(self.gen_keys) < cur_gen:


### PR DESCRIPTION
I tried this on several databases. It works for me.
I have only one question : Is the henry notation always correct with this patch ?