### PR TITLE
add a filter to the tree of rule filters

### DIFF
--- a/gramps/gui/glade/rule.glade
+++ b/gramps/gui/glade/rule.glade
@@ -835,13 +835,45 @@
                     <property name="shadow_type">in</property>
                     <property name="min_content_width">200</property>
                     <child>
-                      <object class="GtkTreeView" id="ruletree">
-                        <property name="width_request">250</property>
+                      <object class="GtkViewport" id="viewport1">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="enable_search">False</property>
-                        <child internal-child="selection">
-                          <object class="GtkTreeSelection" id="treeview-selection4"/>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkBox" id="box2">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkSearchEntry" id="ruletreefilter">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="primary_icon_name">edit-find-symbolic</property>
+                                <property name="primary_icon_activatable">False</property>
+                                <property name="primary_icon_sensitive">False</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkTreeView" id="ruletree">
+                                <property name="width_request">250</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="enable_search">False</property>
+                                <child internal-child="selection">
+                                  <object class="GtkTreeSelection" id="treeview-selection4"/>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
                         </child>
                       </object>
                     </child>


### PR DESCRIPTION
I can never remember which category filters are in when making a new
rule. This change adds a filter entry above the treeview. As you type,
filters that do not contain the search text (case insensitively) are
made not visible. Categories are always visible, but will no longer
expand if all of their child nodes are hidden.
![2016-03-14_000743_862207991](https://cloud.githubusercontent.com/assets/310024/13737225/d8c0a7d4-e978-11e5-9e9f-58a6c4c162a5.png)
