### PR TITLE
fix the name map of tags in DictionaryDb

### DIFF
--- a/gramps/plugins/database/dictionarydb.py
+++ b/gramps/plugins/database/dictionarydb.py
@@ -520,6 +520,11 @@ class DictionaryDb(DbGeneric):
         emit = None
         if tag.handle in self.tag_map:
             emit = "tag-update"
+            existing_names = [existing_name for existing_name, existing_tag in
+                    self._tag_name_dict.items()
+                    if existing_tag.handle == tag.handle]
+            for existing_name in existing_names:
+                del self._tag_name_dict[existing_name]
             self._tag_dict[tag.handle] = tag
             self._tag_name_dict[tag.name] = tag
         else:

--- a/gramps/plugins/database/dictionarydb.py
+++ b/gramps/plugins/database/dictionarydb.py
@@ -520,11 +520,9 @@ class DictionaryDb(DbGeneric):
         emit = None
         if tag.handle in self.tag_map:
             emit = "tag-update"
-            existing_names = [existing_name for existing_name, existing_tag in
-                    self._tag_name_dict.items()
-                    if existing_tag.handle == tag.handle]
-            for existing_name in existing_names:
-                del self._tag_name_dict[existing_name]
+            for old_name, old_tag in list(self._tag_name_dict.items()):
+                if old_tag.handle == tag.handle:
+                    del self._tag_name_dict[old_name]
             self._tag_dict[tag.handle] = tag
             self._tag_name_dict[tag.name] = tag
         else:


### PR DESCRIPTION
DictionaryDb had a bug where the same tag could end up in the name
mapping multiple times. This was most easily seen when loading a gramps
xml into a DictionaryDb, where an extra entry with the tag name of ''
would be created and would ultimately be referencing the last-created
Tag (also referenced by its proper tag name). This change makes sure
that when editing a tag, any existing references in the name mapping are
deleted before adding.