### PR TITLE
New WHERE clause format as Python function: replaces Django-style 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,8 @@ script:
  # --exclude=TestUser because of older version of mock
  #                    without configure_mock
  # python -c "import sys; print(sys.path)"
- # need to find search path for nostests' python
- - locate bin/python3 
- - PYTHONPATH=.:/home/travis/virtualenv/python3.4.2/lib/python34.zip:/home/travis/virtualenv/python3.4.2/lib/python3.4:/home/travis/virtualenv/python3.4.2/lib/python3.4/plat-linux:/home/travis/virtualenv/python3.4.2/lib/python3.4/lib-dynload:/opt/python/3.4.2/lib/python3.4:/opt/python/3.4.2/lib/python3.4/plat-linux:/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages:/usr/lib/python3/dist-packages/:/usr/lib/python3/site-packages/ python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
+ # need to find search path for nosetests' python
+ - PYTHONPATH=.:/home/travis/virtualenv/python3.4.2/lib/python34.zip:/home/travis/virtualenv/python3.4.2/lib/python3.4:/home/travis/virtualenv/python3.4.2/lib/python3.4/plat-linux:/home/travis/virtualenv/python3.4.2/lib/python3.4/lib-dynload:/opt/python/3.4.2/lib/python3.4:/opt/python/3.4.2/lib/python3.4/plat-linux:/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages:/usr/lib/python3/dist-packages/:/usr/lib/python3/site-packages/:/usr/lib/python3.4:/usr/lib/python3.4/plat-x86_64-linux-gnu:/usr/lib/python3.4/lib-dynload python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
 after_success:
  - codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
  # - cd $TRAVIS_BUILD_DIR
  # $TRAVIS_BUILD_DIR is set to the location of the cloned repository:
  # for example: /home/travis/build/gramps-project/gramps
- - git clone https://github.com/srossross/meta
+ - git clone -b master https://github.com/srossross/meta
  - python setup.py build
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 install:
  - travis_retry pip install --upgrade pillow
  - travis_retry pip install pyicu==1.8
- - travis_retry python3 -m pip install meta --user
+ - travis_retry python3 -m pip install meta
  
  # - cd $TRAVIS_BUILD_DIR
  # $TRAVIS_BUILD_DIR is set to the location of the cloned repository:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,9 @@ before_script:
 script:
  # --exclude=TestUser because of older version of mock
  #                    without configure_mock
- - python -c "import nose; print(nose)"
- - PYTHONPATH=/usr/lib/python3/dist-packages/ python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
+ # - python -c "import nose; print(nose)"
+ - echo $PYTHONPATH
+ - PYTHONPATH=/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/:/usr/lib/python3/dist-packages/ python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
 
 after_success:
  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 language: python
 python:
  - 3.4
-sudo: true
+sudo: false
 cache: pip
 addons:
   apt:
@@ -24,13 +24,16 @@ addons:
     - python3-nose
     - python3-mock
 
+virtualenv:
+  system_site_packages: true
+
 before_install:
  - pip install --upgrade pip
-# - pip install --upgrade setuptools wheel nose coverage codecov
+ - pip install --upgrade setuptools wheel nose coverage codecov
 
 install:
-# - travis_retry pip install --upgrade pillow
-# - travis_retry pip install pyicu==1.8
+ - travis_retry pip install --upgrade pillow
+ - travis_retry pip install pyicu==1.8
  - travis_retry pip install meta
  
  # - cd $TRAVIS_BUILD_DIR
@@ -42,14 +45,10 @@ before_script:
 #    - sudo Xvfb :99 -ac &
 #    - export DISPLAY=:99
  - mkdir -p ~/.gramps/grampsdb/
- - sudo cp -r /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/meta /usr/lib/python3/site-packages/
 
 script:
  # --exclude=TestUser because of older version of mock
  #                    without configure_mock
- # python -c "import sys; print(sys.path)"
- # need to find search path for nosetests' python
- - nosetests --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
+ - python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
 after_success:
  - codecov
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@
 #   http://lint.travis-ci.org/
 
 language: python
-python:
- - 3.4
 sudo: false
-cache: pip
+
+python:
+  - 3.4
+
 addons:
   apt:
     packages:
@@ -24,9 +25,13 @@ addons:
     - python3-nose
     - python3-mock
 
-virtualenv:
-  system_site_packages: true
-
+matrix:
+  include:
+    - python: 3.4
+      env: USE_DEBUG=1
+      sudo: true
+      dist: trusty
+ 
 before_install:
  - pip install --upgrade pip
  - pip install --upgrade setuptools wheel nose coverage codecov
@@ -50,5 +55,6 @@ script:
  # --exclude=TestUser because of older version of mock
  #                    without configure_mock
  - python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
+
 after_success:
  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,10 @@ before_script:
 script:
  # --exclude=TestUser because of older version of mock
  #                    without configure_mock
- - python -c "import sys; print(sys.path)"
- - PYTHONPATH=/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/:/home/travis/virtualenv/python3.4.2/lib/python3.4/dist-packages/:/usr/lib/python3/dist-packages/ python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
-
+ # python -c "import sys; print(sys.path)"
+ # need to find search path for nostests' python
+ - locate bin/python3 
+ - PYTHONPATH=.:/home/travis/virtualenv/python3.4.2/lib/python34.zip:/home/travis/virtualenv/python3.4.2/lib/python3.4:/home/travis/virtualenv/python3.4.2/lib/python3.4/plat-linux:/home/travis/virtualenv/python3.4.2/lib/python3.4/lib-dynload:/opt/python/3.4.2/lib/python3.4:/opt/python/3.4.2/lib/python3.4/plat-linux:/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages:/usr/lib/python3/dist-packages/:/usr/lib/python3/site-packages/ python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
 after_success:
  - codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 language: python
 python:
  - 3.4
-sudo: false
+sudo: true
 cache: pip
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 install:
  - travis_retry pip install --upgrade pillow
  - travis_retry pip install pyicu==1.8
- - travis_retry python3 -m pip install meta
+ - travis_retry pip install meta
  
  # - cd $TRAVIS_BUILD_DIR
  # $TRAVIS_BUILD_DIR is set to the location of the cloned repository:
@@ -46,7 +46,7 @@ before_script:
 script:
  # --exclude=TestUser because of older version of mock
  #                    without configure_mock
- - nosetests3 --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
+ - python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
 
 after_success:
  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
  #                    without configure_mock
  # python -c "import sys; print(sys.path)"
  # need to find search path for nosetests' python
- - PYTHONPATH=.:/home/travis/virtualenv/python3.4.2/lib/python34.zip:/home/travis/virtualenv/python3.4.2/lib/python3.4:/home/travis/virtualenv/python3.4.2/lib/python3.4/plat-linux:/home/travis/virtualenv/python3.4.2/lib/python3.4/lib-dynload:/opt/python/3.4.2/lib/python3.4:/opt/python/3.4.2/lib/python3.4/plat-linux:/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages:/usr/lib/python3/dist-packages/:/usr/lib/python3/site-packages/:/usr/lib/python3.4:/usr/lib/python3.4/plat-x86_64-linux-gnu:/usr/lib/python3.4/lib-dynload python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
+ - PYTHONPATH=.:/home/travis/virtualenv/python3.4.2/lib/python34.zip:/home/travis/virtualenv/python3.4.2/lib/python3.4:/home/travis/virtualenv/python3.4.2/lib/python3.4/plat-linux:/home/travis/virtualenv/python3.4.2/lib/python3.4/lib-dynload:/opt/python/3.4.2/lib/python3.4:/opt/python/3.4.2/lib/python3.4/plat-linux:/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages:/usr/lib/python3/dist-packages/:/usr/lib/python3/site-packages/:/usr/lib/python3.4:/usr/lib/python3.4/plat-x86_64-linux-gnu:/usr/lib/python3.4/lib-dynload:/usr/lib/python3/dist-packages/bsddb3/ python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
 after_success:
  - codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ before_script:
 script:
  # --exclude=TestUser because of older version of mock
  #                    without configure_mock
+ - python -c "import nose; print(nose)"
  - PYTHONPATH=/usr/lib/python3/dist-packages/ python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,20 +30,20 @@ matrix:
     - python: 3.4
       sudo: true
       dist: trusty
- 
-before_install:
- #- pip install --upgrade pip
- #- pip install --upgrade setuptools wheel nose coverage codecov
 
-install:
- #- travis_retry pip install --upgrade pillow
- #- travis_retry pip install pyicu==1.8
- - travis_retry sudo pip3 install meta
+      before_install:
+        #- pip install --upgrade pip
+        #- pip install --upgrade setuptools wheel nose coverage codecov
+
+      install:
+        #- travis_retry pip install --upgrade pillow
+	#- travis_retry pip install pyicu==1.8
+	- travis_retry sudo pip3 install meta
+	- python setup.py build
  
  # - cd $TRAVIS_BUILD_DIR
  # $TRAVIS_BUILD_DIR is set to the location of the cloned repository:
  # for example: /home/travis/build/gramps-project/gramps
- - python setup.py build
 
 before_script:
 #    - sudo Xvfb :99 -ac &

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@ addons:
 
 before_install:
  - pip install --upgrade pip
- - pip install --upgrade setuptools wheel nose coverage codecov
+# - pip install --upgrade setuptools wheel nose coverage codecov
 
 install:
- - travis_retry pip install --upgrade pillow
- - travis_retry pip install pyicu==1.8
+# - travis_retry pip install --upgrade pillow
+# - travis_retry pip install pyicu==1.8
  - travis_retry pip install meta
  
  # - cd $TRAVIS_BUILD_DIR
@@ -42,14 +42,14 @@ before_script:
 #    - sudo Xvfb :99 -ac &
 #    - export DISPLAY=:99
  - mkdir -p ~/.gramps/grampsdb/
- - dpkg-query -L python3-bsddb3
+ - sudo cp -r /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/meta /usr/lib/python3/site-packages/
 
 script:
  # --exclude=TestUser because of older version of mock
  #                    without configure_mock
  # python -c "import sys; print(sys.path)"
  # need to find search path for nosetests' python
- - PYTHONPATH=/home/travis/virtualenv/python3.4.2/lib/python3.4:/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages nosetests --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
+ - nosetests --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
 after_success:
  - codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
       install:
         #- travis_retry pip install --upgrade pillow
 	#- travis_retry pip install pyicu==1.8
-	- travis_retry sudo pip3 install meta
+	- travis_retry sudo pip install meta
 	- python setup.py build
  
  # - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
  #                    without configure_mock
  # python -c "import sys; print(sys.path)"
  # need to find search path for nosetests' python
- - PYTHONPATH=.:/home/travis/virtualenv/python3.4.2/lib/python34.zip:/home/travis/virtualenv/python3.4.2/lib/python3.4:/home/travis/virtualenv/python3.4.2/lib/python3.4/plat-linux:/home/travis/virtualenv/python3.4.2/lib/python3.4/lib-dynload:/opt/python/3.4.2/lib/python3.4:/opt/python/3.4.2/lib/python3.4/plat-linux:/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages:/usr/lib/python3/dist-packages/:/usr/lib/python3/site-packages/:/usr/lib/python3.4:/usr/lib/python3.4/plat-x86_64-linux-gnu:/usr/lib/python3.4/lib-dynload:/usr/lib/python3/dist-packages/bsddb3/ python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
+ - PYTHONPATH=/home/travis/virtualenv/python3.4.2/lib/python3.4:/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages: nosetests --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
 after_success:
  - codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_install:
 install:
  - travis_retry pip install --upgrade pillow
  - travis_retry pip install pyicu==1.8
+ - travis_retry python3 -m pip install meta --user
  
  # - cd $TRAVIS_BUILD_DIR
  # $TRAVIS_BUILD_DIR is set to the location of the cloned repository:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
  #                    without configure_mock
  # python -c "import sys; print(sys.path)"
  # need to find search path for nosetests' python
- - PYTHONPATH=/home/travis/virtualenv/python3.4.2/lib/python3.4:/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages: nosetests --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
+ - PYTHONPATH=/home/travis/virtualenv/python3.4.2/lib/python3.4:/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages nosetests --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
 after_success:
  - codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,12 @@ before_script:
 #    - sudo Xvfb :99 -ac &
 #    - export DISPLAY=:99
  - mkdir -p ~/.gramps/grampsdb/
+ - dpkg-query -L python3-bsddb3
 
 script:
  # --exclude=TestUser because of older version of mock
  #                    without configure_mock
- - python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
+ - PYTHONPATH=/usr/lib/python3/dist-packages/ python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
 
 after_success:
  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@
 #   http://lint.travis-ci.org/
 
 language: python
-sudo: false
-
 python:
-  - 3.4
-
+ - 3.4
+sudo: false
+cache: pip
 addons:
   apt:
     packages:
@@ -25,25 +24,19 @@ addons:
     - python3-nose
     - python3-mock
 
-matrix:
-  include:
-    - python: 3.4
-      sudo: true
-      dist: trusty
+before_install:
+ #- pip install --upgrade pip
+ #- pip install --upgrade setuptools wheel nose coverage codecov
 
-      before_install:
-        #- pip install --upgrade pip
-        #- pip install --upgrade setuptools wheel nose coverage codecov
-
-      install:
-        #- travis_retry pip install --upgrade pillow
-	#- travis_retry pip install pyicu==1.8
-	- travis_retry sudo pip install meta
-	- python setup.py build
+install:
+ #- travis_retry pip install --upgrade pillow
+ #- travis_retry pip install pyicu==1.8
  
  # - cd $TRAVIS_BUILD_DIR
  # $TRAVIS_BUILD_DIR is set to the location of the cloned repository:
  # for example: /home/travis/build/gramps-project/gramps
+ - git clone https://github.com/srossross/meta
+ - python setup.py build
 
 before_script:
 #    - sudo Xvfb :99 -ac &
@@ -53,7 +46,8 @@ before_script:
 script:
  # --exclude=TestUser because of older version of mock
  #                    without configure_mock
- - python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
+ - PYTHONPATH=meta nosetests3 --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
 
 after_success:
  - codecov
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,8 @@ before_script:
 script:
  # --exclude=TestUser because of older version of mock
  #                    without configure_mock
- # - python -c "import nose; print(nose)"
- - echo $PYTHONPATH
- - PYTHONPATH=/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/:/usr/lib/python3/dist-packages/ python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
+ - python -c "import sys; print(sys.path)"
+ - PYTHONPATH=/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/:/home/travis/virtualenv/python3.4.2/lib/python3.4/dist-packages/:/usr/lib/python3/dist-packages/ python -m nose --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
 
 after_success:
  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,18 +28,17 @@ addons:
 matrix:
   include:
     - python: 3.4
-      env: USE_DEBUG=1
       sudo: true
       dist: trusty
  
 before_install:
- - pip install --upgrade pip
- - pip install --upgrade setuptools wheel nose coverage codecov
+ #- pip install --upgrade pip
+ #- pip install --upgrade setuptools wheel nose coverage codecov
 
 install:
- - travis_retry pip install --upgrade pillow
- - travis_retry pip install pyicu==1.8
- - travis_retry pip install meta
+ #- travis_retry pip install --upgrade pillow
+ #- travis_retry pip install pyicu==1.8
+ - travis_retry sudo pip3 install meta
  
  # - cd $TRAVIS_BUILD_DIR
  # $TRAVIS_BUILD_DIR is set to the location of the cloned repository:

--- a/gramps/gen/db/test/test_where.py
+++ b/gramps/gen/db/test/test_where.py
@@ -1,0 +1,102 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2016       Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+#
+
+from gramps.gen.db.where import eval_where
+import unittest
+
+##########
+# Tests:
+
+def make_closure(surname):
+    """
+    Test closure.
+    """
+    from gramps.gen.lib import Person
+    return (lambda person: 
+            (person.primary_name.surname_list[0].surname == surname and
+             person.gender == Person.MALE))
+
+class Thing(object):
+    def __init__(self):
+        self.list = ["I0", "I1", "I2"]
+
+    def where(self):
+        return lambda person: person.gramps_id == self.list[1]
+
+class ClosureTest(unittest.TestCase):
+    def check(self, test):
+        result = eval_where(test[0])
+        self.assertTrue(result == test[1], "%s is not %s" % (result, test[1]))
+
+    def test_01(self):
+        self.check(
+            (lambda family: (family.private and 
+                             family.mother_handle.gramps_id != "I0001"), 
+             ['AND', [['private', '==', True], 
+                      ['mother_handle.gramps_id', '!=', 'I0001']]]))
+
+    def test_02(self):
+        self.check(
+            (lambda person: LIKE(person.gramps_id, "I0001"),
+             ['gramps_id', 'LIKE', 'I0001']))
+
+    def test_03(self):
+        self.check(
+            (lambda note: note.gramps_id == "N0001",
+             ['gramps_id', '==', 'N0001']))
+
+    def test_04(self):
+        self.check(
+            (lambda person: person.event_ref_list.ref.gramps_id == "E0001",
+             ['event_ref_list.ref.gramps_id', '==', 'E0001']))
+
+    def test_05(self):
+        self.check(
+            (lambda person: LIKE(person.gramps_id, "I0001") or person.private,
+             ["OR", [['gramps_id', 'LIKE', 'I0001'],
+                     ["private", "==", True]]]))
+
+    def test_06(self):
+        self.check(
+            (lambda person: person.event_ref_list <= 0,
+             ["event_ref_list", "<=", 0]))
+
+    def test_07(self):
+        self.check(
+            (lambda person: person.primary_name.surname_list[0].surname == "Smith",
+             ["primary_name.surname_list.0.surname", "==", "Smith"]))
+
+    def test_08(self):
+        self.check(
+            (make_closure("Smith"),
+             ["AND", [["primary_name.surname_list.0.surname", "==", "Smith"],
+                      ["gender", "==", 1]]]))
+
+    def test_09(self):
+        self.check(
+            [Thing().where(), ["gramps_id", "==", "I1"]])
+
+    def test_10(self):
+        self.check(
+            (lambda person: LIKE(person.gramps_id, "I000%"),
+             ["gramps_id", "LIKE", "I000%"]))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gen/db/where.py
+++ b/gramps/gen/db/where.py
@@ -1,0 +1,151 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2016       Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+#
+
+from meta.asttools import Visitor
+from meta.decompiler import _ast, decompile_func
+
+import copy
+
+class ParseFilter(Visitor):
+    def visitName(self, node):
+        return node.id
+    
+    def visitNum(self, node):
+        return node.n
+        
+    def visitlong(self, node):
+        return node
+
+    def process_expression(self, expr):
+        if isinstance(expr, str):
+            # boolean
+            return [self.process_field(expr), "==", True]
+        elif len(expr) == 3:
+            # (field, op, value)
+            return [self.process_field(expr[0]), 
+                    expr[1], 
+                    self.process_value(expr[2])]
+        else:
+            # list of exprs
+            return [self.process_expression(exp) for
+                    exp in expr]
+
+    def process_value(self, value):
+        try:
+            return eval(value, self.env)
+        except:
+            return value
+
+    def process_field(self, field):
+        field = field.replace("[", ".").replace("]", "")
+        if field.startswith(self.parameter + "."):
+            return field[len(self.parameter) + 1:]
+        else:
+            return field
+
+    def visitCall(self, node):
+        """
+        Handle LIKE()
+        """
+        return [self.process_field(self.visit(node.args[0])), 
+                self.visit(node.func),
+                self.process_value(self.visit(node.args[1]))]
+
+    def visitStr(self, node):
+        return node.s
+
+    def visitlist(self, list):
+        return [self.visit(node) for node in list]
+
+    def visitCompare(self, node):
+        return [self.process_field(self.visit(node.left)), 
+                " ".join(self.visit(node.ops)), 
+                self.process_value(self.visit(node.comparators[0]))]
+
+    def visitAttribute(self, node):
+        return "%s.%s" % (self.visit(node.value), node.attr)
+
+    def get_boolean_op(self, node):
+        if isinstance(node, _ast.And):
+            return "AND"
+        elif isinstance(node, _ast.Or):
+            return "OR"
+        else:
+            raise Exception("invalid boolean")
+
+    def visitNotEq(self, node):
+        return "!="
+
+    def visitLtE(self, node):
+        return "<="
+
+    def visitGtE(self, node):
+        return ">="
+
+    def visitEq(self, node):
+        return "=="
+
+    def visitBoolOp(self, node):
+        """
+        BoolOp: boolean operator
+        """
+        op = self.get_boolean_op(node.op)
+        values = list(node.values)
+        return [op, self.process_expression(
+            [self.visit(value) for value in values])]
+
+    def visitLambda(self, node):
+        self.parameter = self.visit(node.args)[0]
+        return self.visit(node.body)
+
+    def visitarguments(self, node):
+        return [self.visit(arg) for arg in node.args]
+
+    def visitarg(self, node):
+        return node.arg
+
+    def visitSubscript(self, node):
+        return "%s[%s]" % (self.visit(node.value), 
+                          self.visit(node.slice))
+
+    def visitIndex(self, node):
+        return self.visit(node.value)
+
+def make_env(closure):
+    """
+    Create an environment from the closure.
+    """
+    env = copy.copy(closure.__globals__)
+    if closure.__closure__:
+        for i in range(len(closure.__closure__)):
+            env[closure.__code__.co_freevars[i]] = closure.__closure__[i].cell_contents
+    return env
+
+def eval_where(closure):
+    """
+    Given a closure, parse and evaluate it.
+    Return a WHERE expression.
+    """
+    parser = ParseFilter()
+    parser.env = make_env(closure)
+    ast_top = decompile_func(closure)
+    result = parser.visit(ast_top)
+    return result
+


### PR DESCRIPTION
New WHERE clause format as Python function: replaces Django-style parameters.

Based on an idea provided by Gerald Britton.

* WHERE clause can now be a specialized Python function/lambda that takes a gramps.gen.lib primary object, and creates a boolean value.
* Requires Python meta library
* Known limitation: currently can't return boolean property; need to compare to True/False (should be fixable)
* adds a .where() QuerySet to differentiate from .filter() which is real Python code
* removes all of old Django-style where machinery
* adds tests for where functions
* If a filter has a where method, it will use it. This isn't currently used in Gramps yet.
* where clauses are also not used in gramps yet, but can be used in addons, and gramps_connect