### PR TITLE
Add compression option on XML export

### DIFF
--- a/gramps/gui/plug/export/__init__.py
+++ b/gramps/gui/plug/export/__init__.py
@@ -22,3 +22,4 @@
 
 from ._exportassistant import ExportAssistant
 from ._exportoptions import WriterOptionBox
+from ._exportoptions import WriterOptionBoxWithCompression

--- a/gramps/gui/plug/export/_exportoptions.py
+++ b/gramps/gui/plug/export/_exportoptions.py
@@ -45,6 +45,18 @@ from gramps.gen.proxy import (PrivateProxyDb,
                               FilterProxyDb,
                               ReferencedBySelectionProxyDb)
 
+#-------------------------------------------------------------------------
+#
+# Attempt to load the GZIP library. Some version of python do not seem
+# to be compiled with this available.
+#
+#-------------------------------------------------------------------------
+try:
+    import gzip
+    _gzip_ok = 1
+except:
+    _gzip_ok = 0
+
 class Progress(object):
     """
     Mirros the same interface that the ExportAssistant uses in the
@@ -722,3 +734,29 @@ class WriterOptionBox(object):
                 row += 1
 
         return model
+
+class WriterOptionBoxWithCompression(WriterOptionBox):
+    """
+    Extends the WriterOptionBox with option for using compression.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.use_compression = _gzip_ok
+        self.use_compression_check = None
+
+    def get_use_compression(self):
+        return self.use_compression
+
+    def get_option_box(self):
+        from gi.repository import Gtk
+        option_box = super().get_option_box()
+        self.use_compression_check = Gtk.CheckButton(label=_("Use Compression"))
+        self.use_compression_check.set_active(1)
+        self.use_compression_check.set_sensitive(_gzip_ok)
+        option_box.pack_start(self.use_compression_check, False, True, 0)
+        return option_box
+
+    def parse_options(self):
+        super().parse_options()
+        if self.use_compression_check:
+            self.use_compression = self.use_compression_check.get_active()

--- a/gramps/plugins/export/export.gpr.py
+++ b/gramps/plugins/export/export.gpr.py
@@ -146,7 +146,7 @@ plg.status = STABLE
 plg.fname = 'exportxml.py'
 plg.ptype = EXPORT
 plg.export_function = 'export_data'
-plg.export_options = 'WriterOptionBox'
+plg.export_options = 'WriterOptionBoxWithCompression'
 plg.export_options_title = _('Gramps XML export options')
 plg.extension = "gramps"
 

--- a/gramps/plugins/export/exportxml.py
+++ b/gramps/plugins/export/exportxml.py
@@ -62,7 +62,7 @@ from gramps.gen.updatecallback import UpdateCallback
 from gramps.gen.db.exceptions import DbWriteFailure
 from gramps.version import VERSION
 from gramps.gen.constfunc import win
-from gramps.gui.plug.export import WriterOptionBox
+from gramps.gui.plug.export import WriterOptionBox, WriterOptionBoxWithCompression
 import gramps.plugins.lib.libgrampsxml as libgrampsxml
 
 #-------------------------------------------------------------------------
@@ -162,9 +162,9 @@ class GrampsXmlWriter(UpdateCallback):
                     try:
                         g = gzip.open(filename,"wb")
                     except:
-                        g = open(filename,"w")
+                        g = open(filename,"wb")
                 else:
-                    g = open(filename,"w")
+                    g = open(filename,"wb")
             except IOError as msg:
                 LOG.warn(str(msg))
                 raise DbWriteFailure(_('Failure writing %s') % filename,
@@ -1331,6 +1331,7 @@ def export_data(database, filename, user, option_box=None):
     if option_box:
         option_box.parse_options()
         database = option_box.get_filtered_database(database)
+        compress = compress and option_box.get_use_compression()
 
     g = XmlWriter(database, user, 0, compress)
     return g.write(filename)


### PR DESCRIPTION
The write options needed to include "binary" to allow the system to write to the stream. 