### PR TITLE
Bug 9414 fix empty Place Alternate Names on import

### DIFF
--- a/gramps/gen/lib/place.py
+++ b/gramps/gen/lib/place.py
@@ -577,7 +577,7 @@ class Place(CitationBase, NoteBase, MediaBase, UrlBase, PrimaryObject):
         :param acquisition: instance to merge
         :type acquisition: :class:'~.place.Place
         """
-        if acquisition.name and (acquisition.name not in self.alt_names):
+        if acquisition.name.value and (acquisition.name not in self.alt_names):
             self.alt_names.append(acquisition.name)
 
         for addendum in acquisition.alt_names:


### PR DESCRIPTION
The if acquisition.name is always true since Place.__init__ puts PlaceName object here. This should be
"if acquisition.name.value "
this would check for an actual assignment, not just an empty entry.