### PR TITLE
Bug 9415 Place Alt Names gets duplicated entries

### DIFF
--- a/gramps/gen/lib/placename.py
+++ b/gramps/gen/lib/placename.py
@@ -200,6 +200,12 @@ class PlaceName(SecondaryObject, DateBase):
             else:
                 return EQUAL
 
+    def __eq__(self, other):
+        return self.is_equal(other)
+
+    def __ne__(self, other):
+        return not self.is_equal(other)
+
     def set_value(self, value):
         """
         Set the name for the PlaceName instance.


### PR DESCRIPTION
Code assumed that constructs like
if (new_alt_name not in self.alt_names): ...
will check for duplicates. But the 'not in' python code depends on a '==' check between items. Gramps code never defined the '==' ('__eq__') operation for alt names.