### PR TITLE
PyGIWarning: importing without specifiying a version first

### DIFF
--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -186,6 +186,8 @@ def show_settings():
     """
     py_str = '%d.%d.%d' % sys.version_info[:3]
     try:
+        import gi
+        gi.require_version('Gtk', '3.0')
         from gi.repository import Gtk
         try:
             gtkver_str = '%d.%d.%d' % (Gtk.get_major_version(),
@@ -236,6 +238,8 @@ def show_settings():
         from gi import Repository
         repository = Repository.get_default()
         if repository.enumerate_versions("OsmGpsMap"):
+            import gi
+            gi.require_version('OsmGpsMap', '1.0')
             from gi.repository import OsmGpsMap as osmgpsmap
             try:
                 osmgpsmap_str = osmgpsmap._version

--- a/gramps/gui/editors/editaddress.py
+++ b/gramps/gui/editors/editaddress.py
@@ -37,6 +37,8 @@ mechanism for the user to edit address information.
 # GTK/Gnome modules
 #
 #-------------------------------------------------------------------------
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
 #-------------------------------------------------------------------------

--- a/gramps/gui/utils.py
+++ b/gramps/gui/utils.py
@@ -42,6 +42,8 @@ _ = glocale.translation.gettext
 # GNOME/GTK
 #
 #-------------------------------------------------------------------------
+import gi
+gi.require_version('PangoCairo', '1.0')
 from gi.repository import PangoCairo
 from gi.repository import GLib
 

--- a/gramps/plugins/gramplet/gramplet.gpr.py
+++ b/gramps/plugins/gramplet/gramplet.gpr.py
@@ -384,6 +384,8 @@ try:
     from gi import Repository
     repository = Repository.get_default()
     if repository.enumerate_versions("GExiv2"):
+        import gi
+        gi.require_version('GExiv2', '0.10')
         from gi.repository import GExiv2
         available = True
     else:


### PR DESCRIPTION
Follow-on from https://gramps-project.org/bugs/view.php?id=8981
This patch was applied in Debian (gramps 42 branch) due to warnings picked
up in the build log and from testing by running gramps from the command
line. I have rebased it on master, as it will probably be a while before the
warnings become errors.