### PR TITLE
9443: Gramps not appearing in Gnome Software

### DIFF
--- a/data/gramps.appdata.xml.in
+++ b/data/gramps.appdata.xml.in
@@ -1,18 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<application>
-<id type="desktop">gramps.desktop</id>
-<licence>CC0</licence>
-<description>
-<_p>Gramps is a genealogy program that is both intuitive for hobbyists and feature-complete for professional genealogists.</_p>
-<_p>It gives you the ability to record the many details of the life of an individual as well as the complex relationships between various people, places and events.</_p>
-<_p>All of your research is kept organized, searchable and as precise as you need it to be.</_p>
-</description>
-<url type="homepage">http://gramps-project.org/</url>
-<screenshots>
-<screenshot width="1226" height="740">http://www.gramps-project.org/wiki/images/5/5f/AppData1.png</screenshot>
-<screenshot width="1226" height="740">http://www.gramps-project.org/wiki/images/6/68/AppData2.png</screenshot>
-<screenshot type="default" width="1226" height="740">http://www.gramps-project.org/wiki/images/e/e9/AppData3.png</screenshot>
-<screenshot width="1226" height="740">http://www.gramps-project.org/wiki/images/6/68/AppData4.png</screenshot>
-<screenshot width="1226" height="740">http://www.gramps-project.org/wiki/images/5/50/AppData5.png</screenshot>
-</screenshots>
-</application>
+<component type="desktop">
+  <id>gramps.desktop</id>
+  <metadata_license>CC0</metadata_license>
+  <name>Gramps</name>
+  <summary>Genealogical research program</summary>
+
+  <description>
+    <p>Gramps is a genealogy program that is both intuitive for hobbyists and feature-complete for professional genealogists.</p>
+    <p>It gives you the ability to record the many details of the life of an individual as well as the complex relationships between various people, places and events.</p>
+    <p>All of your research is kept organized, searchable and as precise as you need it to be.</p>
+  </description>
+
+  <url type="homepage">https://gramps-project.org/</url>
+  <url type="bugtracker">https://gramps-project.org/bugs/</url>
+  <url type="help">https://gramps-project.org/wiki/index.php?title=Main_page</url>
+  <project_license>GPL-2.0+</project_license>
+  <developer_name>Gramps Development Team</developer_name>
+
+  <screenshots>
+    <screenshot width="1226" height="740">http://www.gramps-project.org/wiki/images/5/5f/AppData1.png</screenshot>
+    <screenshot width="1226" height="740">http://www.gramps-project.org/wiki/images/6/68/AppData2.png</screenshot>
+    <screenshot type="default" width="1226" height="740">http://www.gramps-project.org/wiki/images/e/e9/AppData3.png</screenshot>
+    <screenshot width="1226" height="740">http://www.gramps-project.org/wiki/images/6/68/AppData4.png</screenshot>
+    <screenshot width="1226" height="740">http://www.gramps-project.org/wiki/images/5/50/AppData5.png</screenshot>
+  </screenshots>
+
+  <provides>
+    <binary>gramps</binary>
+  </provides>
+
+</component>

--- a/setup.py
+++ b/setup.py
@@ -197,7 +197,7 @@ def build_intl(build_cmd):
     merge_files = (('data/gramps.desktop', 'share/applications', '-d'),
                     ('data/gramps.keys', 'share/mime-info', '-k'),
                     ('data/gramps.xml', 'share/mime/packages', '-x'),
-                    ('data/gramps.appdata.xml', 'share/appdata', '-x'))
+                    ('data/gramps.appdata.xml', 'share/metainfo', '-x'))
 
     for filename, target, option in merge_files:
         filenamelocal = convert_path(filename)


### PR DESCRIPTION
I updated the appdata.xml file to the latest version of the specification
(https://www.freedesktop.org/software/appstream/docs/index.html), adding
some new tags in the process.

I also installed the appdata.xml file to the latest location in the
specification.

The XML has bene validated by the appstreamcli validation tool, and the
patch applied in Debian (Gramps 4.2.3).

If it looks OK, it should probably be cherry-picked to the gramps42
maintenance branch.