### PR TITLE
make EditPrimary, empty_object abstract

### DIFF
--- a/gramps/gui/editors/editprimary.py
+++ b/gramps/gui/editors/editprimary.py
@@ -26,6 +26,7 @@
 #-------------------------------------------------------------------------
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
+import abc
 
 #-------------------------------------------------------------------------
 #
@@ -49,7 +50,7 @@ from ..dialog import SaveDialog
 from gramps.gen.lib import PrimaryObject
 from ..dbguielement import DbGUIElement
 
-class EditPrimary(ManagedWindow, DbGUIElement):
+class EditPrimary(ManagedWindow, DbGUIElement, metaclass=abc.ABCMeta):
 
     QR_CATEGORY = -1
 
@@ -245,12 +246,9 @@ class EditPrimary(ManagedWindow, DbGUIElement):
             self._do_close()
             return False
 
+    @abc.abstractmethod
     def empty_object(self):
-        #empty_object should be overridden in base class and will throw an
-        #exception if it is not because self.empty_object().serialize() is
-        #called and PrimaryObject does not implement serialize(). See
-        #BaseObject.serialize()
-        return PrimaryObject
+        """ empty_object should be overridden in child class """
 
     def data_has_changed(self):
         if self.db.readonly:


### PR DESCRIPTION
I started fixing the issue I independently found which was fixed in 2f31096abdefb773ea4079a6e29a147c51dc3c13 - always do a pull before fixing issues. In addition to the changes in that commit, but I also went one step further in making EditPrimary abstract.

This makes EditPrimary an abstract class using abc.ABCMeta and marks
EditPrimary.empty_object as an abstract method. This moves the error
raised by forgetting to implement empty_object from when something
unsupported is done with its return (like .serialize()) to invocation
time, and provides a more obvious error.