### PR TITLE
Bug 9414 fix empty Place Alternate Names on import

### DIFF
--- a/gramps/gen/lib/place.py
+++ b/gramps/gen/lib/place.py
@@ -631,9 +631,13 @@ class Place(CitationBase, NoteBase, MediaBase, UrlBase, PrimaryObject):
         :param acquisition: instance to merge
         :type acquisition: :class:'~.place.Place
         """
-        if acquisition.name and (acquisition.name not in self.alt_names):
-            self.alt_names.append(acquisition.name)
+        if acquisition.name.value:
+            if acquisition.name != self.name:
+                if acquisition.name not in self.alt_names:
+                    self.alt_names.append(acquisition.name)
 
         for addendum in acquisition.alt_names:
-            if addendum not in self.alt_names:
-                self.alt_names.append(addendum)
+            if addendum.value:
+                if addendum != self.name:
+                    if addendum not in self.alt_names:
+                        self.alt_names.append(addendum)


### PR DESCRIPTION
The Place Alternate Names can acquire blank entries when importing from GEDCOM.
It seems likely that this can occur under other circumstances since this is common code. I cannot reproduce via the GUI since the GUI checks for blank place name before ('OK').
Original code tests for 'acquisition.name' which is always true since Place.__init__ puts PlaceName object here. I think this should be 'if acquisition.name.value'  this would check for an actual assignment, not just an empty entry.
This also insures that we don't add a primary name or empty alt_name entry to the alt_names list.

An separate PR patch to the merge unit test titled bug 9448 enables/includes test code for this.

P.S. this is an update of an earlier PR which I cancelled.