### PR TITLE
Bug 9448: Merge unit test for PlaceCheck not working correctly

### DIFF
--- a/gramps/gen/lib/test/merge_test.py
+++ b/gramps/gen/lib/test/merge_test.py
@@ -1389,8 +1389,14 @@ class PlaceCheck(unittest.TestCase, PrivacyBaseTest, MediaBaseTest,
     def setUp(self):
         self.phoenix = Place()
         self.phoenix.set_title('Place 1')
-        self.titanic = Place(self.phoenix)
-        self.ref_obj = Place(self.phoenix)
+        # __init__ copy has bad side effects, don't use it
+        # self.titanic = Place(self.phoenix)
+        self.titanic = Place()
+        self.titanic.set_title('Place 1')
+        # __init__ copy has bad side effects, don't use it
+        # self.ref_obj = Place(self.phoenix)
+        self.ref_obj = Place()
+        self.ref_obj.set_title('Place 1')
         self.amsterdam = PlaceName()
         self.amsterdam.set_value('Amsterdam')
         self.rotterdam = PlaceName()
@@ -1433,9 +1439,11 @@ class PlaceCheck(unittest.TestCase, PrivacyBaseTest, MediaBaseTest,
         self.titanic.add_alternative_name(self.leiden)
         self.ref_obj.set_name(self.amsterdam)
         self.ref_obj.set_type(PlaceType.CITY)
-        self.ref_obj.add_alternative_name(self.amsterdam)
-        self.ref_obj.add_alternative_name(self.rotterdam)
+        # Base name shouldn't be in alt_names list
+        # self.ref_obj.add_alternative_name(self.amsterdam)
+        # alt_names must be in correct order for test to pass
         self.ref_obj.add_alternative_name(self.utrecht)
+        self.ref_obj.add_alternative_name(self.rotterdam)
         self.ref_obj.add_alternative_name(self.leiden)
         self.phoenix.merge(self.titanic)
         self.assertEqual(self.phoenix.serialize(), self.ref_obj.serialize())
@@ -1493,6 +1501,22 @@ class PlaceCheck(unittest.TestCase, PrivacyBaseTest, MediaBaseTest,
         self.ref_obj.set_name(self.amsterdam)
         self.ref_obj.set_type(PlaceType.CITY)
         self.ref_obj.add_alternative_name(self.rotterdam)
+        self.phoenix.merge(self.titanic)
+        self.assertEqual(self.phoenix.serialize(), self.ref_obj.serialize())
+        
+    def test_merge_empty(self):
+        self.phoenix.set_name(self.amsterdam)
+        self.phoenix.set_type(PlaceType.CITY)
+        self.phoenix.add_alternative_name(self.rotterdam)
+        self.titanic.set_title('Place 2')
+        # titanic gets empty name
+        self.titanic.set_type(PlaceType.CITY)
+        self.titanic.add_alternative_name(self.utrecht)
+        self.titanic.add_alternative_name(PlaceName())  # empty alt_name
+        self.ref_obj.set_name(self.amsterdam)
+        self.ref_obj.set_type(PlaceType.CITY)
+        self.ref_obj.add_alternative_name(self.rotterdam)
+        self.ref_obj.add_alternative_name(self.utrecht)
         self.phoenix.merge(self.titanic)
         self.assertEqual(self.phoenix.serialize(), self.ref_obj.serialize())
 


### PR DESCRIPTION
While examining the merge_test.py to add test for bug 9414 and 9415, I realized the code could never fail! I believe the test was written incorrectly. It seems that during setup of the test, the author initialized the 'reference' and 'merge' by copying from the 'merged into' place. I guess this was to make them all have the same name.

Unfortunately, the copying operation in the Place initialize copied the pointer to the alt_places list, rather than the list itself. So any change made to any of the Place objects, alt_places entries, effectively occurred to all at once. So the comparison test always passes no matter what happens to alt_names.  Basically compares 'expected' to 'expected'.

Once that was corrected, I found that the test code 'expected' results for one of the affected tests was out of order and incorrectly included the primary name in the alt_names list.

After correcting this issue, I also added a test to specifically check for bug 9414.

Note: These merge tests will now fail miserably unless the PRs for bug 9414 and 9415 are also applied.