### PR TITLE
Bug 9416 GEDCOM import PLAC:FORM in local mode doesn't work

### DIFF
--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -5440,6 +5440,8 @@ class GedcomParser(UpdateCallback):
             self.__parse_level(sub_state, self.event_place_map, 
                              self.__undefined)
             state.msg += sub_state.msg
+            if sub_state.pf:                # if we found local PLAC:FORM
+                state.pf = sub_state.pf     # save to override global value
         # merge notes etc into place
         state.place.merge(sub_state.place)
 


### PR DESCRIPTION
GEDCOM can import PLAC lines with a subsidiary FORM line which describes what the comma separated list of place items means. In its global form, GEDCOM puts these in the GEDCOM header, in the local form, the FORM line comes beneath the associated PLAC line.
In the libgedcom.py __event_place code, the FORM line is parsed and handled in a sub_state, however it is not saved in the main state.

Note: PR redone from scratch because rebase did not work...