### PR TITLE
Bug 9416 GEDCOM import PLAC:FORM in local mode doesn't work

### DIFF
--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -5417,6 +5417,8 @@ class GedcomParser(UpdateCallback):
             self.__parse_level(sub_state, self.event_place_map,
                              self.__undefined)
             state.msg += sub_state.msg
+            if sub_state.pf:                # if we found local PLAC:FORM
+                state.pf = sub_state.pf     # save to override global value
 
     def __event_place_note(self, line, state):
         """


### PR DESCRIPTION
GEDCOM can import PLAC lines with a subsidiary FORM line which describes what the comma separated list of place items means. In its global form, GEDCOM puts these in the GEDCOM header, in the local form, the FORM line comes beneath the associated PLAC line.
Gramps import code has code which is meant to deal with this and store the PLAC line with appropriate enclosing Places. 
In the libgedcom.py __event_place code, the FORM line is parsed and handled in a sub_state, however it is not saved in the main state.