### PR TITLE
Bug 9430 GEDCOM import PLAC or ADDR attached Notes etc. are lost

### DIFF
--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -5417,6 +5417,8 @@ class GedcomParser(UpdateCallback):
             self.__parse_level(sub_state, self.event_place_map,
                              self.__undefined)
             state.msg += sub_state.msg
+        # merge notes etc into place
+        state.place.merge(sub_state.place)
 
     def __event_place_note(self, line, state):
         """
@@ -5572,7 +5574,7 @@ class GedcomParser(UpdateCallback):
                 place.add_alternate_locations(location)
 
         # merge notes etc into place
-        place.merge(sub_state.place)
+        state.place.merge(sub_state.place)
 
     def __add_location(self, place, location):
         """


### PR DESCRIPTION
This is same as previous PR, but applies to master.

GEDCOM (and gramps) allows notes, sources, and media to be attached to places. In many cases these are lost.
In libgedcom.py __event_place, after parsing the sub-levels for notes etc, the sub_state was never merged back into the main state. In __event_addr, the merge was attempted, but the original code did the merge into an object called 'place' which, depending on the code path taken, was sometimes equal to state.place, and sometimes not. When not, the notes etc. were lost.