### PR TITLE
9450: LivingProxyDB leaves data in when back references followed

### DIFF
--- a/gramps/gen/proxy/living.py
+++ b/gramps/gen/proxy/living.py
@@ -336,14 +336,32 @@ class LivingProxyDb(ProxyDbBase):
         """
         handle_itr = self.db.find_backlink_handles(handle, include_classes)
         for (class_name, handle) in handle_itr:
-            if class_name == "Person" and self.mode != self.MODE_INCLUDE_ALL:
+            if self.mode == self.MODE_INCLUDE_ALL:
+                yield (class_name, handle)
+            elif class_name == 'Person':
                 ## Don't get backlinks to living people at all
                 person = self.db.get_person_from_handle(handle)
                 if person and not self.__is_living(person):
                     yield (class_name, handle)
+            elif class_name == 'Family':
+                ## Don't get backlinks to families with a living parent
+                father = mother = None
+                family = self.db.get_family_from_handle(handle)
+                father_handle = family.get_father_handle()
+                mother_handle = family.get_mother_handle()
+                if father_handle:
+                    father = self.db.get_person_from_handle(father_handle)
+                if mother_handle:
+                    mother = self.db.get_person_from_handle(mother_handle)
+                father_not_living = father and not self.__is_living(father)
+                mother_not_living = mother and not self.__is_living(mother)
+                if ((father is None and mother is None) or # shouldn't happen
+                    (father is None and mother_not_living) or # could
+                    (mother is None and father_not_living) or # could
+                    (father_not_living and mother_not_living)): # could
+                    yield (class_name, handle)
             else:
                 yield (class_name, handle)
-        return
 
     def __is_living(self, person):
         """

--- a/gramps/gen/proxy/living.py
+++ b/gramps/gen/proxy/living.py
@@ -336,10 +336,13 @@ class LivingProxyDb(ProxyDbBase):
         """
         handle_itr = self.db.find_backlink_handles(handle, include_classes)
         for (class_name, handle) in handle_itr:
-            if class_name == 'Person':
-                if not self.get_person_from_handle(handle):
-                    continue
-            yield (class_name, handle)
+            if class_name == "Person" and self.mode != self.MODE_INCLUDE_ALL:
+                ## Don't get backlinks to living people at all
+                person = self.db.get_person_from_handle(handle)
+                if person and not self.__is_living(person):
+                    yield (class_name, handle)
+            else:
+                yield (class_name, handle)
         return
 
     def __is_living(self, person):

--- a/gramps/plugins/database/dbapi.py
+++ b/gramps/plugins/database/dbapi.py
@@ -600,7 +600,6 @@ class DBAPI(DbGeneric):
     def commit_person(self, person, trans, change_time=None):
         emit = None
         old_person = None
-        person.change = int(change_time or time.time())
         if person.handle in self.person_map:
             emit = "person-update"
             old_person = self.get_person_from_handle(person.handle)
@@ -692,7 +691,6 @@ class DBAPI(DbGeneric):
     def commit_family(self, family, trans, change_time=None):
         emit = None
         old_family = None
-        family.change = int(change_time or time.time())
         if family.handle in self.family_map:
             emit = "family-update"
             old_family = self.get_family_from_handle(family.handle).serialize()
@@ -756,7 +754,6 @@ class DBAPI(DbGeneric):
     def commit_citation(self, citation, trans, change_time=None):
         emit = None
         old_citation = None
-        citation.change = int(change_time or time.time())
         if citation.handle in self.citation_map:
             emit = "citation-update"
             old_citation = self.get_citation_from_handle(citation.handle).serialize()
@@ -802,7 +799,6 @@ class DBAPI(DbGeneric):
     def commit_source(self, source, trans, change_time=None):
         emit = None
         old_source = None
-        source.change = int(change_time or time.time())
         if source.handle in self.source_map:
             emit = "source-update"
             old_source = self.get_source_from_handle(source.handle).serialize()
@@ -850,7 +846,6 @@ class DBAPI(DbGeneric):
     def commit_repository(self, repository, trans, change_time=None):
         emit = None
         old_repository = None
-        repository.change = int(change_time or time.time())
         if repository.handle in self.repository_map:
             emit = "repository-update"
             old_repository = self.get_repository_from_handle(repository.handle).serialize()
@@ -886,7 +881,6 @@ class DBAPI(DbGeneric):
     def commit_note(self, note, trans, change_time=None):
         emit = None
         old_note = None
-        note.change = int(change_time or time.time())
         if note.handle in self.note_map:
             emit = "note-update"
             old_note = self.get_note_from_handle(note.handle).serialize()
@@ -919,7 +913,6 @@ class DBAPI(DbGeneric):
     def commit_place(self, place, trans, change_time=None):
         emit = None
         old_place = None
-        place.change = int(change_time or time.time())
         if place.handle in self.place_map:
             emit = "place-update"
             old_place = self.get_place_from_handle(place.handle).serialize()
@@ -966,7 +959,6 @@ class DBAPI(DbGeneric):
     def commit_event(self, event, trans, change_time=None):
         emit = None
         old_event = None
-        event.change = int(change_time or time.time())
         if event.handle in self.event_map:
             emit = "event-update"
             old_event = self.get_event_from_handle(event.handle).serialize()
@@ -1008,7 +1000,6 @@ class DBAPI(DbGeneric):
 
     def commit_tag(self, tag, trans, change_time=None):
         emit = None
-        tag.change = int(change_time or time.time())
         if tag.handle in self.tag_map:
             emit = "tag-update"
             self.dbapi.execute("""UPDATE tag SET blob_data = ?,
@@ -1034,7 +1025,6 @@ class DBAPI(DbGeneric):
     def commit_media(self, media, trans, change_time=None):
         emit = None
         old_media = None
-        media.change = int(change_time or time.time())
         if media.handle in self.media_map:
             emit = "media-update"
             old_media = self.get_media_from_handle(media.handle).serialize()

--- a/gramps/plugins/database/dbapi.py
+++ b/gramps/plugins/database/dbapi.py
@@ -600,6 +600,7 @@ class DBAPI(DbGeneric):
     def commit_person(self, person, trans, change_time=None):
         emit = None
         old_person = None
+        person.change = int(change_time or time.time())
         if person.handle in self.person_map:
             emit = "person-update"
             old_person = self.get_person_from_handle(person.handle)
@@ -691,6 +692,7 @@ class DBAPI(DbGeneric):
     def commit_family(self, family, trans, change_time=None):
         emit = None
         old_family = None
+        family.change = int(change_time or time.time())
         if family.handle in self.family_map:
             emit = "family-update"
             old_family = self.get_family_from_handle(family.handle).serialize()
@@ -754,6 +756,7 @@ class DBAPI(DbGeneric):
     def commit_citation(self, citation, trans, change_time=None):
         emit = None
         old_citation = None
+        citation.change = int(change_time or time.time())
         if citation.handle in self.citation_map:
             emit = "citation-update"
             old_citation = self.get_citation_from_handle(citation.handle).serialize()
@@ -799,6 +802,7 @@ class DBAPI(DbGeneric):
     def commit_source(self, source, trans, change_time=None):
         emit = None
         old_source = None
+        source.change = int(change_time or time.time())
         if source.handle in self.source_map:
             emit = "source-update"
             old_source = self.get_source_from_handle(source.handle).serialize()
@@ -846,6 +850,7 @@ class DBAPI(DbGeneric):
     def commit_repository(self, repository, trans, change_time=None):
         emit = None
         old_repository = None
+        repository.change = int(change_time or time.time())
         if repository.handle in self.repository_map:
             emit = "repository-update"
             old_repository = self.get_repository_from_handle(repository.handle).serialize()
@@ -881,6 +886,7 @@ class DBAPI(DbGeneric):
     def commit_note(self, note, trans, change_time=None):
         emit = None
         old_note = None
+        note.change = int(change_time or time.time())
         if note.handle in self.note_map:
             emit = "note-update"
             old_note = self.get_note_from_handle(note.handle).serialize()
@@ -913,6 +919,7 @@ class DBAPI(DbGeneric):
     def commit_place(self, place, trans, change_time=None):
         emit = None
         old_place = None
+        place.change = int(change_time or time.time())
         if place.handle in self.place_map:
             emit = "place-update"
             old_place = self.get_place_from_handle(place.handle).serialize()
@@ -959,6 +966,7 @@ class DBAPI(DbGeneric):
     def commit_event(self, event, trans, change_time=None):
         emit = None
         old_event = None
+        event.change = int(change_time or time.time())
         if event.handle in self.event_map:
             emit = "event-update"
             old_event = self.get_event_from_handle(event.handle).serialize()
@@ -1000,6 +1008,7 @@ class DBAPI(DbGeneric):
 
     def commit_tag(self, tag, trans, change_time=None):
         emit = None
+        tag.change = int(change_time or time.time())
         if tag.handle in self.tag_map:
             emit = "tag-update"
             self.dbapi.execute("""UPDATE tag SET blob_data = ?,
@@ -1025,6 +1034,7 @@ class DBAPI(DbGeneric):
     def commit_media(self, media, trans, change_time=None):
         emit = None
         old_media = None
+        media.change = int(change_time or time.time())
         if media.handle in self.media_map:
             emit = "media-update"
             old_media = self.get_media_from_handle(media.handle).serialize()


### PR DESCRIPTION
Although these options are about replace a living person's name, the name won't show at all on certain reports, like place_report. See bug for more info.