### PR TITLE
Make trailing whitespace an error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 install:
  - travis_retry pip install --upgrade pillow
  - travis_retry pip install pyicu==1.8
- 
+
  # - cd $TRAVIS_BUILD_DIR
  # $TRAVIS_BUILD_DIR is set to the location of the cloned repository:
  # for example: /home/travis/build/gramps-project/gramps
@@ -47,6 +47,10 @@ script:
  # --exclude=TestUser because of older version of mock
  #                    without configure_mock
  - PYTHONPATH=meta GRAMPS_RESOURCES=. nosetests3 --nologcapture --with-coverage --cover-package=gramps --exclude=TestcaseGenerator --exclude=vcard --exclude=merge_ref_test  --exclude=user_test gramps
+ - if git --no-pager grep --color -n --full-name '[ 	]$' -- \*.py; then
+     echo "ERROR - Trailing whitespace found in source file(s)";
+     exit 1;
+   fi
 
 after_success:
  - codecov

--- a/data/man/update_man.py
+++ b/data/man/update_man.py
@@ -24,7 +24,7 @@
 """
 update_man.py for command line documentation.
 
-Examples: 
+Examples:
    python update_man.py -t
 
       Tests if 'sphinx' and 'python' are well configured.
@@ -49,7 +49,7 @@ DATE = ''
 # You can set these variables from the command line.
 SPHINXBUILD   = 'sphinx-build'
 
-if sys.platform == 'win32':          
+if sys.platform == 'win32':
     pythonCmd = os.path.join(sys.prefix, 'bin', 'python.exe')
     sphinxCmd = os.path.join(sys.prefix, 'bin', 'sphinx-build.exe')
 elif sys.platform in ['linux2', 'darwin', 'cygwin']:
@@ -70,13 +70,13 @@ def tests():
         os.system('''%(program)s -V''' % {'program': pythonCmd})
     except:
         print ('Please, install python')
-        
+
     try:
         print("\n=================='Sphinx-build'=============================\n")
         os.system('''%(program)s''' % {'program': sphinxCmd})
     except:
         print ('Please, install sphinx')
-        
+
     if not DOCUTILS:
         print('\nNo docutils support, cannot use -m/--man and -o/--odt arguments.')
 
@@ -85,49 +85,49 @@ def main():
     The utility for handling documentation stuff.
     What is need by Gramps, nothing more.
     """
-    
-    parser = ArgumentParser( 
-                         description='This program aims to handle documentation' 
-                                      ' and related translated versions.', 
+
+    parser = ArgumentParser(
+                         description='This program aims to handle documentation'
+                                      ' and related translated versions.',
                          )
-                         
+
     parser.add_argument("-t", "--test",
             action="store_true", dest="test",  default=True,
             help="test if 'python' and 'sphinx' are properly installed")
-    
+
     parser.add_argument("-b", "--build",
             action="store_true", dest="build",  default=False,
             help="build man documentation (via sphinx-build)")
-    
+
     parser.add_argument("-m", "--man",
             action="store_true", dest="man",  default=False,
             help="build man documentation (via docutils)")
-    
+
     parser.add_argument("-o", "--odt",
             action="store_true", dest="odt",  default=False,
             help="build odt documentation (via docutils)")
-                             
+
     args = parser.parse_args()
-    
+
     if args.test:
         tests()
-        
+
     if args.build:
         build()
-        
+
     if args.man and DOCUTILS:
         man()
-        
+
     if args.odt and DOCUTILS:
         odt()
-        
+
 def build():
     """
     Build documentation.
     """
-    
+
     # testing stage
-    
+
     os.system('''%(program)s -b html . _build/html''' % {'program': sphinxCmd})
     os.system('''%(program)s -b htmlhelp . _build/htmlhelp''' % {'program': sphinxCmd})
     if DOCUTILS:
@@ -136,48 +136,48 @@ def build():
     os.system('''%(program)s -b changes . _build/changes''' % {'program': sphinxCmd})
     #os.system('''%(program)s -b linkcheck . _build/linkcheck''' % {'program': sphinxCmd})
     os.system('''%(program)s -b gettext . _build/gettext''' % {'program': sphinxCmd})
-    
+
     for lang in LANGUAGES:
-        os.system('''%(program)s -b html -D language="%(lang)s" master_doc="%(lang)s" %(lang)s %(lang)s''' 
+        os.system('''%(program)s -b html -D language="%(lang)s" master_doc="%(lang)s" %(lang)s %(lang)s'''
                    % {'lang': lang, 'program': sphinxCmd})
-        os.system('''%(program)s -b htmlhelp -D language="%(lang)s" master_doc="%(lang)s" %(lang)s %(lang)s''' 
+        os.system('''%(program)s -b htmlhelp -D language="%(lang)s" master_doc="%(lang)s" %(lang)s %(lang)s'''
                    % {'lang': lang, 'program': sphinxCmd})
         if DOCUTILS:
-            os.system('''%(program)s -b man %(lang)s %(lang)s''' 
+            os.system('''%(program)s -b man %(lang)s %(lang)s'''
                        % {'lang': lang, 'program': sphinxCmd})
-        os.system('''%(program)s -b text -D language="%(lang)s" master_doc="%(lang)s" %(lang)s %(lang)s''' 
+        os.system('''%(program)s -b text -D language="%(lang)s" master_doc="%(lang)s" %(lang)s %(lang)s'''
                    % {'lang': lang, 'program': sphinxCmd})
         # for update/migration
-        os.system('''%(program)s -b gettext -D language="%(lang)s" master_doc="%(lang)s" . _build/gettext/%(lang)s''' 
+        os.system('''%(program)s -b gettext -D language="%(lang)s" master_doc="%(lang)s" . _build/gettext/%(lang)s'''
                    % {'lang': lang, 'program': sphinxCmd})
-                   
+
 def man():
     """
     man file generation via docutils (python)
-    
+
     from docutils.core import publish_cmdline, default_description
     from docutils.writers import manpage
     """
-    
-    os.system('''rst2man en.rst gramps.1''') 
-    
+
+    os.system('''rst2man en.rst gramps.1''')
+
     for lang in LANGUAGES:
-        os.system('''rst2man %(lang)s/%(lang)s.rst -l %(lang)s %(lang)s/gramps.1''' 
+        os.system('''rst2man %(lang)s/%(lang)s.rst -l %(lang)s %(lang)s/gramps.1'''
                    % {'lang': lang})
-                   
+
 def odt():
     """
     odt file generation via docutils (python)
-    
+
     from docutils.core import publish_cmdline_to_binary, default_description
     from docutils.writers.odf_odt import Writer, Reader
     """
-    
-    os.system('''rst2odt en.rst gramps.odt''') 
-    
+
+    os.system('''rst2odt en.rst gramps.odt''')
+
     for lang in LANGUAGES:
-        os.system('''rst2odt %(lang)s/%(lang)s.rst -l %(lang)s %(lang)s/gramps.odt''' 
+        os.system('''rst2odt %(lang)s/%(lang)s.rst -l %(lang)s %(lang)s/gramps.odt'''
                    % {'lang': lang})
-    
+
 if __name__ == "__main__":
     main()

--- a/docs/update_doc.py
+++ b/docs/update_doc.py
@@ -24,7 +24,7 @@
 """
 update_doc.py for Gramps API(s) documentation.
 
-Examples: 
+Examples:
    python update_doc.py -t
 
       Tests if 'sphinx' and 'python' are well configured.
@@ -39,7 +39,7 @@ from argparse import ArgumentParser
 # You can set these variables from the command line.
 SPHINXBUILD   = 'sphinx-build'
 
-if sys.platform == 'win32':          
+if sys.platform == 'win32':
     pythonCmd = os.path.join(sys.prefix, 'bin', 'python.exe')
     sphinxCmd = os.path.join(sys.prefix, 'bin', 'sphinx-build.exe')
 elif sys.platform in ['linux2', 'darwin', 'cygwin']:
@@ -60,7 +60,7 @@ def tests():
         os.system('''%(program)s -V''' % {'program': pythonCmd})
     except:
         print ('Please, install python')
-        
+
     try:
         print("\n=================='Shpinx-build'=============================\n")
         os.system('''%(program)s''' % {'program': sphinxCmd})
@@ -72,38 +72,38 @@ def main():
     The utility for handling documentation stuff.
     What is need by Gramps, nothing more.
     """
-    
-    parser = ArgumentParser( 
-                         description='This program aims to handle manual' 
-                                      ' and translated version.', 
+
+    parser = ArgumentParser(
+                         description='This program aims to handle manual'
+                                      ' and translated version.',
                          )
-                         
+
     parser.add_argument("-t", "--test",
             action="store_true", dest="test",  default=True,
             help="test if 'python' and 'sphinx' are properly installed")
-    
+
     parser.add_argument("-b", "--build",
             action="store_true", dest="build",  default=True,
             help="build documentation")
-                             
+
     args = parser.parse_args()
-    
+
     if args.test:
         tests()
-        
+
     if args.build:
         build()
-        
+
 def build():
     """
     Build documentation.
     """
-    
+
     # testing stage
-    
+
     os.system('''%(program)s -b html . _build/html''' % {'program': sphinxCmd})
     os.system('''%(program)s -b changes . _build/changes''' % {'program': sphinxCmd})
     os.system('''%(program)s -b linkcheck . _build/linkcheck''' % {'program': sphinxCmd})
-       
+
 if __name__ == "__main__":
     main()

--- a/po/test/po_test.py
+++ b/po/test/po_test.py
@@ -9,7 +9,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 #
-# This program is distributed in the hope that it will be useful, 
+# This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
@@ -27,7 +27,7 @@ import unittest
 import os
 import glob
 from test import test_util
-test_util.path_append_parent() 
+test_util.path_append_parent()
 
 def get_potfile(filename):
     with open(filename, "r") as fp:
@@ -62,10 +62,10 @@ class TestPOT(unittest.TestCase):
                     found = True
             if found:
                 self.assertFalse(pathfile[3:] not in excluded_files and
-                                 pathfile[3:] not in self.potfiles, 
+                                 pathfile[3:] not in self.potfiles,
                                  "'%s' is not in POTFILES.in" % (pathfile[3:],))
             else:
-                self.assertTrue(True, "'%s' doesn't contain '%s'" % 
+                self.assertTrue(True, "'%s' doesn't contain '%s'" %
                                 (file, search))
         else:
             self.assertTrue(True, "'%s' doesn't exist" % file)
@@ -88,7 +88,7 @@ class TestMake(unittest.TestCase):
         elif os.path.exists(makefile):
             with open(makefile, "r") as fp:
                 lines = fp.read()
-            self.assertTrue(filename in lines, "'%s' not in %s/Makefile.in" % 
+            self.assertTrue(filename in lines, "'%s' not in %s/Makefile.in" %
                             (filename, path))
         else:
             self.assertTrue(True, "no makefile in '%s'" % dir)
@@ -109,7 +109,7 @@ class TestGetText(unittest.TestCase):
         found = False
         for search in searches:
             found = (search in lines) or found
-        self.assertTrue(found, "'%s' is in POTFILES.in but does not contain '%s'" % 
+        self.assertTrue(found, "'%s' is in POTFILES.in but does not contain '%s'" %
                         (pofile, searches))
 
 class TestDups(unittest.TestCase):
@@ -130,15 +130,15 @@ def suite1():
     Suite of tests designed to see if that if one of a set of phrases
     is in a file, then that file better be in POTFILES.in.
     """
-    suite = unittest.TestSuite()            
+    suite = unittest.TestSuite()
     for dir, subdir, files in os.walk('../../src'):
         for file in files:
             if glob.fnmatch.fnmatch(file,"*.py"):
-                suite.addTest(TestPOT('test_pot_py_%04d', 
+                suite.addTest(TestPOT('test_pot_py_%04d',
                                       dir, file, ["import gettext",
                                                   "import sgettext"]))
             elif glob.fnmatch.fnmatch(file,"*.glade"):
-                suite.addTest(TestPOT('test_pot_glade_%04d', 
+                suite.addTest(TestPOT('test_pot_glade_%04d',
                                       dir, file, ["translatable=\"yes\""]))
             if glob.fnmatch.fnmatch(file,"*.py"):
                 suite.addTest(TestMake('test_make_py_%04d', dir, file))
@@ -162,7 +162,7 @@ def suite2():
             continue
         if glob.fnmatch.fnmatch(potfile,"*.py"):
             suite.addTest(TestGetText('test_gettext_py_%04d', potfile,
-                                      ["import gettext", 
+                                      ["import gettext",
                                        "from gramps.gen.ggettext",
                                        "import sgettext"]))
         elif glob.fnmatch.fnmatch(potfile,"*.glade"):

--- a/po/update_po.py
+++ b/po/update_po.py
@@ -25,7 +25,7 @@
 """
 update_po.py for Gramps translations.
 
-Examples: 
+Examples:
    python update_po.py -t
 
       Tests if 'gettext' and 'python' are well configured.
@@ -291,7 +291,7 @@ def DesktopParse(filename):
     msgid "Genealogy System"
     msgid "Gramps Genealogy System"
     msgid ""
-          "Manage genealogical information, 
+          "Manage genealogical information,
            perform genealogical research and analysis"
     '''
     with open('../data/gramps.desktop.in.h', 'w') as desktop:
@@ -375,7 +375,7 @@ def main():
     parser.add_argument("-c", "--clean",
             action="store_true", dest="clean",  default=False,
             help="remove created files")
-    parser.add_argument("-p", "--pot", 
+    parser.add_argument("-p", "--pot",
             action="store_true", dest="catalog",  default=False,
             help="create a new catalog")
 
@@ -691,7 +691,7 @@ def check(args):
                     % {'lang.po': arg, 'txt': arg[:-3]})
         os.system('''%(python)s ./check_po -s %(lang.po)s > %(lang)s.txt''' \
                     % {'python': pythonCmd, 'lang.po': arg, 'lang': arg[:-3]})
-        os.system('''%(msgfmt)s -c -v %(lang.po)s''' 
+        os.system('''%(msgfmt)s -c -v %(lang.po)s'''
                     % {'msgfmt': msgfmtCmd, 'lang.po': arg})
 
 def untranslated(arg):

--- a/setup.py
+++ b/setup.py
@@ -80,8 +80,8 @@ def intltool_version():
     '''
     if sys.platform == 'win32':
         cmd = ["perl", "-e print qx(intltool-update --version) =~ m/(\d+.\d+.\d+)/;"]
-        try: 
-            ver, ret = subprocess.Popen(cmd ,stdout=subprocess.PIPE, 
+        try:
+            ver, ret = subprocess.Popen(cmd ,stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE, shell=True).communicate()
             ver = ver.decode("utf-8")
             if ver > "":
@@ -121,9 +121,9 @@ def build_trans(build_cmd):
     data_files = build_cmd.distribution.data_files
     for lang in ALL_LINGUAS:
         po_file = os.path.join('po', lang + '.po')
-        mo_file = os.path.join(build_cmd.build_base, 'mo', lang, 'LC_MESSAGES', 
+        mo_file = os.path.join(build_cmd.build_base, 'mo', lang, 'LC_MESSAGES',
                                'gramps.mo')
-        mo_file_unix = (build_cmd.build_base + '/mo/' + lang + 
+        mo_file_unix = (build_cmd.build_base + '/mo/' + lang +
                         '/LC_MESSAGES/gramps.mo')
         mo_dir = os.path.dirname(mo_file)
         if not(os.path.isdir(mo_dir) or os.path.islink(mo_dir)):
@@ -225,20 +225,20 @@ def merge(in_file, out_file, option, po_dir='po', cache=True):
     if (not os.path.exists(out_file) and os.path.exists(in_file)):
         if sys.platform == 'win32':
             cmd = (('set LC_ALL=C && perl -S intltool-merge %(opt)s %(po_dir)s %(in_file)s '
-                '%(out_file)s') % 
-              {'opt' : option, 
+                '%(out_file)s') %
+              {'opt' : option,
                'po_dir' : po_dir,
-               'in_file' : in_file, 
+               'in_file' : in_file,
                'out_file' : out_file})
         else:
             cmd = (('LC_ALL=C intltool-merge %(opt)s %(po_dir)s %(in_file)s '
-                '%(out_file)s') % 
-              {'opt' : option, 
+                '%(out_file)s') %
+              {'opt' : option,
                'po_dir' : po_dir,
-               'in_file' : in_file, 
+               'in_file' : in_file,
                'out_file' : out_file})
         if os.system(cmd) != 0:
-            msg = ('ERROR: %s was not merged into the translation files!\n' % 
+            msg = ('ERROR: %s was not merged into the translation files!\n' %
                     out_file)
             raise SystemExit(msg)
 
@@ -324,27 +324,27 @@ package_core = ['gramps',
                 'gramps.gen.utils',
                 'gramps.gen.utils.docgen',
                 'gramps.test',
-                'gramps.plugins', 
-                'gramps.plugins.database', 
-                'gramps.plugins.database.bsddb_support', 
+                'gramps.plugins',
+                'gramps.plugins.database',
+                'gramps.plugins.database.bsddb_support',
                 'gramps.plugins.database.dbapi_support',
                 'gramps.plugins.database.dbapi_support.defaults',
-                'gramps.plugins.docgen', 
-                'gramps.plugins.drawreport', 
-                'gramps.plugins.export', 
-                'gramps.plugins.gramplet', 
+                'gramps.plugins.docgen',
+                'gramps.plugins.drawreport',
+                'gramps.plugins.export',
+                'gramps.plugins.gramplet',
                 'gramps.plugins.graph',
-                'gramps.plugins.importer', 
-                'gramps.plugins.lib', 
-                'gramps.plugins.lib.maps', 
-                'gramps.plugins.mapservices', 
-                'gramps.plugins.quickview', 
-                'gramps.plugins.rel', 
-                'gramps.plugins.sidebar', 
+                'gramps.plugins.importer',
+                'gramps.plugins.lib',
+                'gramps.plugins.lib.maps',
+                'gramps.plugins.mapservices',
+                'gramps.plugins.quickview',
+                'gramps.plugins.rel',
+                'gramps.plugins.sidebar',
                 'gramps.plugins.textreport',
-                'gramps.plugins.tool', 
-                'gramps.plugins.view', 
-                'gramps.plugins.webreport', 
+                'gramps.plugins.tool',
+                'gramps.plugins.view',
+                'gramps.plugins.webreport',
                 'gramps.plugins.webstuff',
                 ]
 package_gui = ['gramps.gui',
@@ -377,7 +377,7 @@ package_data_core = []
 basedir = os.path.join('gramps', 'plugins')
 for (dirpath, dirnames, filenames) in os.walk(basedir):
     root, subdir = os.path.split(dirpath)
-    if subdir.startswith("."): 
+    if subdir.startswith("."):
         dirnames[:] = []
         continue
     for dirname in dirnames:
@@ -450,20 +450,20 @@ data_files = data_files_core + data_files_gui
 # Setup
 #
 #-------------------------------------------------------------------------
-setup(name = 'gramps', 
+setup(name = 'gramps',
       description = ('Gramps (Genealogical Research and Analysis Management '
-                     'Programming System)'), 
+                     'Programming System)'),
       long_description = ('Gramps (Genealogical Research and Analysis '
                           'Management Programming System) is a full featured '
                           'genealogy program supporting a Python based plugin '
                           'system.'),
-      version = VERSION, 
-      author = 'Donald N. Allingham', 
-      author_email = 'don@gramps-project.org', 
-      maintainer = 'Gramps Development Team', 
-      maintainer_email = 'benny.malengier@gmail.com', 
-      url = 'http://gramps-project.org', 
-      license = 'GPL v2 or greater', 
+      version = VERSION,
+      author = 'Donald N. Allingham',
+      author_email = 'don@gramps-project.org',
+      maintainer = 'Gramps Development Team',
+      maintainer_email = 'benny.malengier@gmail.com',
+      url = 'http://gramps-project.org',
+      license = 'GPL v2 or greater',
       platforms = ['FreeBSD', 'Linux', 'MacOS', 'Windows'],
       cmdclass = {'build': build, 'install': install, 'test': test},
       packages = packages,

--- a/test/GrampsLogger/GtkHandler_Test.py
+++ b/test/GrampsLogger/GtkHandler_Test.py
@@ -42,11 +42,11 @@ class GtkHandlerTest(unittest.TestCase):
 
         rh = RotateHandler(capacity=20)
         rh.setLevel(logging.DEBUG)
-        
+
         gtkh = GtkHandler(rotate_handler=rh)
         gtkh.setLevel(logging.ERROR)
 
-        l = logging.getLogger("GtkHandlerTest")        
+        l = logging.getLogger("GtkHandlerTest")
         l.setLevel(logging.DEBUG)
 
         l.addHandler(rh)
@@ -65,7 +65,7 @@ class GtkHandlerTest(unittest.TestCase):
             Gtk.main_iteration()
 
 
-        
+
 def testSuite():
     suite = unittest.makeSuite(GtkHandlerTest,'test')
     return suite

--- a/test/LosHawlos_dbtest.py
+++ b/test/LosHawlos_dbtest.py
@@ -86,7 +86,7 @@ try:
     add_source( db,"A short test",True,False)
     print "Add person 3"
     add_person( db,"Chris","Connor",True,False)
-    print_db_content( db)    
+    print_db_content( db)
     print "Closing Database file: %s" % filename1
     #db.close()
 
@@ -97,7 +97,7 @@ try:
     add_person( db,"Felix", "Fowler",True,False)
     print "Add person 4"
     add_person( db,"Felix", "Fowler",False,False)
-    print_db_content( db)    
+    print_db_content( db)
     print "Closing Database file: %s" % filename1
     #db.close()
 
@@ -110,7 +110,7 @@ try:
     print "Add source 2 will fail"
     add_source( db,"Bang bang bang",True,True)
 
-    print_db_content( db)    
+    print_db_content( db)
     print "Closing Database file: %s" % filename2
     #db.close()
 finally:

--- a/test/RunAllTests.py
+++ b/test/RunAllTests.py
@@ -25,7 +25,7 @@ Testing framework for performing a variety of unttests for GRAMPS.
 """
 
 import logging
- 
+
 import os
 import sys
 import unittest
@@ -39,9 +39,9 @@ def make_parser():
     usage = "usage: %prog [options]"
     parser = OptionParser(usage)
     parser.add_option("-v", "--verbosity", type="int", dest="verbose_level", default=0,
-                      help="Level of verboseness")  
+                      help="Level of verboseness")
     parser.add_option("-p", "--performance", action="store_true", dest="performance", default=False,
-                      help="Run the performance tests.")  
+                      help="Run the performance tests.")
     return parser
 
 
@@ -50,7 +50,7 @@ def getTestSuites():
     # It just walks the filetree from '.' downwards and returns
     # a tuple per directory of (dirpath,filelist) if the directory
     # contains any test files.
-    
+
     paths = [(f[0],f[2]) for f in os.walk('.') \
              if len ([i for i in f[2] \
                       if i[-8:] == "_Test.py"]) ]
@@ -78,7 +78,7 @@ def allTheTests():
 
 def perfTests():
     return unittest.TestSuite(getTestSuites()[1])
-    
+
 if __name__ == '__main__':
     console = logging.StreamHandler()
     console.setLevel(logging.INFO)
@@ -86,7 +86,7 @@ if __name__ == '__main__':
 
     logger = logging.getLogger('Gramps')
     logger.addHandler(console)
-    
+
     (options,args) = make_parser().parse_args()
 
     if options.verbose_level == 1:


### PR DESCRIPTION
I saw some complaints about this on the mailing list, so this makes trailing whitespace into an error on Travis.

PEP8 would normally complain about trailing whitespace, but until Gramps code is fully PEP8-compliant, you can consider this an intermediary solution to ensuring there's no trailing whitespace.