### PR TITLE
Use CacheProxyDb on reports with LivingProxyDb

### DIFF
--- a/gramps/plugins/drawreport/ancestortree.py
+++ b/gramps/plugins/drawreport/ancestortree.py
@@ -47,6 +47,7 @@ from gramps.gen.plug.docgen import (FontStyle, ParagraphStyle, GraphicsStyle,
                                     FONT_SANS_SERIF, PARA_ALIGN_CENTER)
 from gramps.plugins.lib.libtreebase import *
 from gramps.plugins.lib.librecurse import AscendPerson
+from gramps.gen.proxy import CacheProxyDb
 
 PT2CM = ReportUtils.pt2cm
 #cm2pt = ReportUtils.cm2pt
@@ -550,6 +551,7 @@ class AncestorTree(Report):
         self._locale = self.set_locale(lang)
         stdoptions.run_private_data_option(self, options.menu)
         stdoptions.run_living_people_option(self, options.menu, self._locale)
+        self.database = CacheProxyDb(self.database)
         stdoptions.run_name_format_option(self, options.menu)
         self._nd = self._name_display
 

--- a/gramps/plugins/drawreport/descendtree.py
+++ b/gramps/plugins/drawreport/descendtree.py
@@ -43,6 +43,7 @@ from gramps.gen.plug.report import utils as ReportUtils
 from gramps.gen.plug.docgen import (FontStyle, ParagraphStyle, GraphicsStyle,
                                     FONT_SANS_SERIF, PARA_ALIGN_CENTER)
 from gramps.plugins.lib.libtreebase import *
+from gramps.gen.proxy import CacheProxyDb
 
 PT2CM = ReportUtils.pt2cm
 
@@ -1286,6 +1287,7 @@ class DescendTree(Report):
         self._locale = self.set_locale(lang)
         stdoptions.run_private_data_option(self, options.menu)
         stdoptions.run_living_people_option(self, options.menu, self._locale)
+        self.database = CacheProxyDb(self.database)
         stdoptions.run_name_format_option(self, options.menu)
         self._nd = self._name_display
 

--- a/gramps/plugins/drawreport/fanchart.py
+++ b/gramps/plugins/drawreport/fanchart.py
@@ -58,6 +58,7 @@ from gramps.gen.plug.report import stdoptions
 from gramps.gen.config import config
 from gramps.gen.utils.db import get_birth_or_fallback, get_death_or_fallback
 from gramps.gen.lib import EventType
+from gramps.gen.proxy import CacheProxyDb
 
 #------------------------------------------------------------------------
 #
@@ -179,6 +180,7 @@ class FanChart(Report):
 
         stdoptions.run_private_data_option(self, menu)
         stdoptions.run_living_people_option(self, menu, rlocale)
+        self.database = CacheProxyDb(self.database)
 
         self.max_generations = menu.get_option_by_name('maxgen').get_value()
         self.circle = menu.get_option_by_name('circle').get_value()

--- a/gramps/plugins/drawreport/statisticschart.py
+++ b/gramps/plugins/drawreport/statisticschart.py
@@ -59,6 +59,7 @@ from gramps.gen.plug.report import MenuReportOptions
 from gramps.gen.plug.report import stdoptions
 from gramps.gen.datehandler import parser
 from gramps.gen.display.place import displayer as place_displayer
+from gramps.gen.proxy import CacheProxyDb
 
 #------------------------------------------------------------------------
 #
@@ -745,6 +746,7 @@ class StatisticsChart(Report):
 
         stdoptions.run_private_data_option(self, menu)
         living_opt = stdoptions.run_living_people_option(self, menu, rlocale)
+        self.database = CacheProxyDb(self.database)
 
         get_option_by_name = menu.get_option_by_name
         get_value = lambda name: get_option_by_name(name).get_value()

--- a/gramps/plugins/drawreport/timeline.py
+++ b/gramps/plugins/drawreport/timeline.py
@@ -45,6 +45,7 @@ from gramps.gen.plug.docgen import (FontStyle, ParagraphStyle, GraphicsStyle,
 from gramps.gen.sort import Sort
 from gramps.gen.config import config
 from gramps.gen.utils.db import get_birth_or_fallback, get_death_or_fallback
+from gramps.gen.proxy import CacheProxyDb
 
 #------------------------------------------------------------------------
 #
@@ -104,6 +105,7 @@ class TimeLine(Report):
 
         stdoptions.run_private_data_option(self, menu)
         living_opt = stdoptions.run_living_people_option(self, menu, rlocale)
+        self.database = CacheProxyDb(self.database)
 
         self.filter = menu.get_option_by_name('filter').get_filter()
         self.fil_name = "(%s)" % self.filter.get_name(rlocale)

--- a/gramps/plugins/graph/gvfamilylines.py
+++ b/gramps/plugins/graph/gvfamilylines.py
@@ -61,6 +61,7 @@ from gramps.gen.plug.menu import (NumberOption, ColorOption, BooleanOption,
                                   SurnameColorOption)
 from gramps.gen.utils.db import get_birth_or_fallback, get_death_or_fallback
 from gramps.gen.utils.location import get_main_location
+from gramps.gen.proxy import CacheProxyDb
 
 #------------------------------------------------------------------------
 #
@@ -319,6 +320,7 @@ class FamilyLinesReport(Report):
 
         stdoptions.run_private_data_option(self, menu)
         stdoptions.run_living_people_option(self, menu, self._locale)
+        self.database = CacheProxyDb(self.database)
         self._db = self.database
 
         # initialize several convenient variables

--- a/gramps/plugins/graph/gvhourglass.py
+++ b/gramps/plugins/graph/gvhourglass.py
@@ -48,6 +48,7 @@ from gramps.gen.plug.report import MenuReportOptions
 from gramps.gen.plug.report import stdoptions
 from gramps.gen.datehandler import get_date
 from gramps.gen.utils.db import get_birth_or_fallback, get_death_or_fallback
+from gramps.gen.proxy import CacheProxyDb
 
 #------------------------------------------------------------------------
 #
@@ -86,6 +87,7 @@ class HourGlassReport(Report):
 
         stdoptions.run_private_data_option(self, menu)
         stdoptions.run_living_people_option(self, menu, locale)
+        self.database = CacheProxyDb(self.database)
         self.__db = self.database
 
         self.__used_people = []

--- a/gramps/plugins/graph/gvrelgraph.py
+++ b/gramps/plugins/graph/gvrelgraph.py
@@ -60,6 +60,7 @@ from gramps.gen.utils.thumbnails import get_thumbnail_path
 from gramps.gen.relationship import get_relationship_calculator
 from gramps.gen.utils.db import get_birth_or_fallback, get_death_or_fallback
 from gramps.gen.display.place import displayer as place_displayer
+from gramps.gen.proxy import CacheProxyDb
 
 #------------------------------------------------------------------------
 #
@@ -130,6 +131,7 @@ class RelGraphReport(Report):
 
         stdoptions.run_private_data_option(self, menu)
         stdoptions.run_living_people_option(self, menu, self._locale)
+        self.database = CacheProxyDb(self.database)
         self._db = self.database
 
         self.includeid = get_value('incid')

--- a/gramps/plugins/textreport/ancestorreport.py
+++ b/gramps/plugins/textreport/ancestorreport.py
@@ -48,6 +48,7 @@ from gramps.gen.plug.report import utils as ReportUtils
 from gramps.gen.plug.report import MenuReportOptions
 from gramps.gen.plug.report import stdoptions
 from gramps.plugins.lib.libnarrate import Narrator
+from gramps.gen.proxy import CacheProxyDb
 
 #------------------------------------------------------------------------
 #
@@ -109,6 +110,8 @@ class AncestorReport(Report):
             raise ReportError(_("Person %s is not in the Database") % pid )
 
         stdoptions.run_name_format_option(self, menu)
+
+        self.database = CacheProxyDb(self.database)
 
         self.__narrator = Narrator(self.database,  use_fulldate=True,
                                    nlocale=rlocale)

--- a/gramps/plugins/textreport/descendreport.py
+++ b/gramps/plugins/textreport/descendreport.py
@@ -55,6 +55,7 @@ from gramps.gen.sort import Sort
 from gramps.gen.utils.db import (get_birth_or_fallback, get_death_or_fallback,
                                  get_marriage_or_fallback,
                                  get_divorce_or_fallback)
+from gramps.gen.proxy import CacheProxyDb
 
 #------------------------------------------------------------------------
 #
@@ -341,6 +342,7 @@ class DescendantReport(Report):
 
         stdoptions.run_private_data_option(self, menu)
         stdoptions.run_living_people_option(self, menu, self._locale)
+        self.database = CacheProxyDb(self.database)
 
         self.max_generations = menu.get_option_by_name('gen').get_value()
         pid = menu.get_option_by_name('pid').get_value()

--- a/gramps/plugins/textreport/detancestralreport.py
+++ b/gramps/plugins/textreport/detancestralreport.py
@@ -59,6 +59,7 @@ from gramps.gen.plug.report import MenuReportOptions
 from gramps.gen.plug.report import stdoptions
 from gramps.plugins.lib.libnarrate import Narrator
 from gramps.gen.display.place import displayer as place_displayer
+from gramps.gen.proxy import CacheProxyDb
 
 #------------------------------------------------------------------------
 #
@@ -124,6 +125,7 @@ class DetAncestorReport(Report):
 
         stdoptions.run_private_data_option(self, menu)
         stdoptions.run_living_people_option(self, menu, self._locale)
+        self.database = CacheProxyDb(self.database)
         self._db = self.database
 
         self.max_generations = get_value('gen')

--- a/gramps/plugins/textreport/detdescendantreport.py
+++ b/gramps/plugins/textreport/detdescendantreport.py
@@ -59,6 +59,7 @@ from gramps.gen.plug.report import MenuReportOptions
 from gramps.gen.plug.report import stdoptions
 from gramps.plugins.lib.libnarrate import Narrator
 from gramps.gen.display.place import displayer as place_displayer
+from gramps.gen.proxy import CacheProxyDb
 
 #------------------------------------------------------------------------
 #
@@ -136,6 +137,7 @@ class DetDescendantReport(Report):
 
         stdoptions.run_private_data_option(self, menu)
         stdoptions.run_living_people_option(self, menu, self._locale)
+        self.database = CacheProxyDb(self.database)
         self.db = self.database
 
         self.max_generations = get_value('gen')

--- a/gramps/plugins/textreport/endoflinereport.py
+++ b/gramps/plugins/textreport/endoflinereport.py
@@ -46,6 +46,7 @@ from gramps.gen.plug.report import utils as ReportUtils
 from gramps.gen.plug.report import MenuReportOptions
 from gramps.gen.plug.report import stdoptions
 from gramps.gen.datehandler import get_date
+from gramps.gen.proxy import CacheProxyDb
 
 #------------------------------------------------------------------------
 #
@@ -80,6 +81,7 @@ class EndOfLineReport(Report):
 
         stdoptions.run_private_data_option(self, menu)
         stdoptions.run_living_people_option(self, menu, rlocale)
+        self.database = CacheProxyDb(self.database)
 
         pid = menu.get_option_by_name('pid').get_value()
         self.center_person = self.database.get_person_from_gramps_id(pid)

--- a/gramps/plugins/textreport/familygroup.py
+++ b/gramps/plugins/textreport/familygroup.py
@@ -49,6 +49,7 @@ from gramps.gen.plug.docgen import (IndexMark, FontStyle, ParagraphStyle,
                                     FONT_SANS_SERIF, FONT_SERIF,
                                     INDEX_TYPE_TOC, PARA_ALIGN_CENTER)
 from gramps.gen.display.place import displayer as place_displayer
+from gramps.gen.proxy import CacheProxyDb
 
 #------------------------------------------------------------------------
 #
@@ -89,6 +90,7 @@ class FamilyGroup(Report):
 
         stdoptions.run_private_data_option(self, menu)
         stdoptions.run_living_people_option(self, menu, self._locale)
+        self.database = CacheProxyDb(self.database)
         self.db = self.database
 
         self.filter = menu.get_option_by_name('filter').get_filter()

--- a/gramps/plugins/textreport/indivcomplete.py
+++ b/gramps/plugins/textreport/indivcomplete.py
@@ -57,6 +57,7 @@ from gramps.gen.plug.report import endnotes as Endnotes
 from gramps.gen.plug.report import stdoptions
 from gramps.gen.utils.file import media_path_full
 from gramps.gen.utils.lds import TEMPLES
+from gramps.gen.proxy import CacheProxyDb
 
 #------------------------------------------------------------------------
 #
@@ -123,6 +124,7 @@ class IndivCompleteReport(Report):
 
         stdoptions.run_private_data_option(self, menu)
         stdoptions.run_living_people_option(self, menu, self._locale)
+        self.database = CacheProxyDb(self.database)
         self._db = self.database
 
         self.use_pagebreak = menu.get_option_by_name('pageben').get_value()

--- a/gramps/plugins/textreport/kinshipreport.py
+++ b/gramps/plugins/textreport/kinshipreport.py
@@ -48,6 +48,7 @@ from gramps.gen.plug.report import utils as ReportUtils
 from gramps.gen.plug.report import MenuReportOptions
 from gramps.gen.plug.report import stdoptions
 from gramps.gen.utils.db import get_birth_or_fallback, get_death_or_fallback
+from gramps.gen.proxy import CacheProxyDb
 
 #------------------------------------------------------------------------
 #
@@ -88,6 +89,7 @@ class KinshipReport(Report):
 
         stdoptions.run_private_data_option(self, menu)
         stdoptions.run_living_people_option(self, menu, rlocale)
+        self.database = CacheProxyDb(self.database)
         self.__db = self.database
 
         self.max_descend = menu.get_option_by_name('maxdescend').get_value()

--- a/gramps/plugins/textreport/placereport.py
+++ b/gramps/plugins/textreport/placereport.py
@@ -50,7 +50,7 @@ from gramps.gen.utils.location import get_location_list
 from gramps.gen.display.place import displayer as place_displayer
 from gramps.gen.lib import PlaceType
 from gramps.gen.errors import ReportError
-from gramps.gen.proxy import LivingProxyDb
+from gramps.gen.proxy import LivingProxyDb, CacheProxyDb
 
 class PlaceReport(Report):
     """
@@ -87,6 +87,7 @@ class PlaceReport(Report):
 
         stdoptions.run_private_data_option(self, menu)
         living_opt = stdoptions.run_living_people_option(self, menu, rlocale)
+        self.database = CacheProxyDb(self.database)
 
         self._lv = menu.get_option_by_name('living_people').get_value()
         for (value, description) in living_opt.get_items(xml_items=True):

--- a/gramps/plugins/textreport/recordsreport.py
+++ b/gramps/plugins/textreport/recordsreport.py
@@ -49,7 +49,7 @@ from gramps.gen.plug.report import MenuReportOptions
 from gramps.gen.plug.report import stdoptions
 from gramps.gen.lib import Span
 from gramps.gen.errors import ReportError
-from gramps.gen.proxy import LivingProxyDb
+from gramps.gen.proxy import LivingProxyDb, CacheProxyDb
 
 #------------------------------------------------------------------------
 #
@@ -99,6 +99,8 @@ class RecordsReport(Report):
             self.include[varname] = menu.get_option_by_name(varname).get_value()
 
         self._nf = stdoptions.run_name_format_option(self, menu)
+
+        self.database = CacheProxyDb(self.database)
 
     def write_report(self):
         """

--- a/gramps/plugins/textreport/summary.py
+++ b/gramps/plugins/textreport/summary.py
@@ -49,6 +49,7 @@ from gramps.gen.plug.docgen import (IndexMark, FontStyle, ParagraphStyle,
                                     PARA_ALIGN_CENTER)
 from gramps.gen.utils.file import media_path_full
 from gramps.gen.datehandler import get_date
+from gramps.gen.proxy import CacheProxyDb
 
 #------------------------------------------------------------------------
 #
@@ -79,6 +80,7 @@ class SummaryReport(Report):
 
         stdoptions.run_private_data_option(self, options.menu)
         stdoptions.run_living_people_option(self, options.menu, rlocale)
+        self.database = CacheProxyDb(self.database)
         self.__db = self.database
 
     def write_report(self):

--- a/gramps/plugins/textreport/tagreport.py
+++ b/gramps/plugins/textreport/tagreport.py
@@ -52,7 +52,7 @@ from gramps.gen.errors import ReportError
 from gramps.gen.datehandler import get_date
 from gramps.gen.utils.db import get_participant_from_event
 from gramps.gen.display.place import displayer as place_displayer
-from gramps.gen.proxy import LivingProxyDb
+from gramps.gen.proxy import LivingProxyDb, CacheProxyDb
 
 #------------------------------------------------------------------------
 #
@@ -103,6 +103,8 @@ class TagReport(Report):
                 _('You must first create a tag before running this report.'))
 
         stdoptions.run_name_format_option(self, menu)
+
+        self.database = CacheProxyDb(self.database)
 
     def write_report(self):
         self.doc.start_paragraph("TR-Title")


### PR DESCRIPTION
This PR inserts the CacheProxyDb into reports after possible proxies, targeting LivingProxyDb.