### PR TITLE
Bug9475 GEDCOM import creates inconsistent source gramps IDs

### DIFF
--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -92,7 +92,7 @@ import re
 import time
 import codecs
 from xml.parsers.expat import ParserCreate
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 import string
 from io import StringIO
 from urllib.parse import urlparse
@@ -1896,7 +1896,7 @@ class GedcomParser(UpdateCallback):
         self.fams_map = stage_one.get_fams_map()
 
         self.place_parser = PlaceParser()
-        self.inline_srcs = {}
+        self.inline_srcs = OrderedDict()
         self.media_map = {}
         self.genby = ""
         self.genvers = ""


### PR DESCRIPTION
When the GEDCOM import contains inline sources "2 SOUR 1940 US Census" rather than the usual "2 SOUR @S211@" they can get different gramps IDs on different runs or with different versions of the code.
This makes testing using a 'differences' technique (Does db differ after import from last time it was run? in development) very difficult.

Arguably this is a product enhancement, rather than a bug, since the import is valid regardless of the order of assigned gramps IDs.

 In libgedcom, for this case, source title and handle are stored in a dict for later addition to the db. The problem seems to be that when the dict is iterated for playback, it does not do so consistently in different runs. The python docs say

>"Keys and values are iterated over in an arbitrary order which is non-random, varies across Python implementations, and depends on the dictionary’s history of insertions and deletions. If keys, values and items views are iterated over with no intervening modifications to the dictionary, the order of items will directly correspond."

What it does NOT say is that the order will be the same over different runs. 

This PR switches to OrderedDict to avoid this issue.