### PR TITLE
bug 8729 place names empty if Gedcom ADDR record contains no street

### DIFF
--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -5572,8 +5572,8 @@ class GedcomParser(UpdateCallback):
             
             # Create the Place Details (it is committed with the event)
             place_detail = Place()
-            place_detail.set_name(PlaceName(value=location.get_street()))
-            place_detail.set_title(location.get_street())
+            place_detail.set_name(PlaceName(value=title))
+            place_detail.set_title(title)
             # For RootsMagic etc. Place Details e.g. address, hospital, cemetary
             place_detail.set_type((PlaceType.CUSTOM, _("Detail")))
             placeref = PlaceRef()


### PR DESCRIPTION
Geni GEDCOM files with the following structure (valid GEDCOM):
  2 PLAC Käkisalmi, Suomi
  2 ADDR
  3 CITY Priozersk
  3 STAE Leningrad Oblast
  3 CTRY Russia

or where PLAC is not filled at all result  in a gramps place that had no name or title.  There is no sign of the city, state, or country at all.
The gramps import was depending on the street name to be present to create a name/title.  An earlier patch created a valid title which contains all of the data, so I used it instead of street in this code path.
