### PR TITLE
bug9240 RTF files show incorrect Unicode characters

### DIFF
--- a/gramps/plugins/docgen/rtfdoc.py
+++ b/gramps/plugins/docgen/rtfdoc.py
@@ -486,7 +486,7 @@ class RTFDoc(BaseDoc, TextDoc):
                 else:
                     # If (uni)code with more than 8 bits:
                     # RTF req valus in decimal, not hex.
-                    self.text += '{\\uc1\\u%d\\uc0}' % ord(i)
+                    self.text += '{\\uc0\\u%d}' % ord(i)
             elif i == '\n':
                 self.text += '\n\\par '
             elif i == '{' or i == '}' or i == '\\':


### PR DESCRIPTION
Original code does not follow RTF spec; '\uc1' means loosely; the following Unicode character will be followed by one byte which represents the standard code page character to be used when the appropriate Unicode character is not available.

Gramps code does not put an alternate character in place, so the appropriate code is \uc0 (no bytes).  The first character of the trailing '\uc0' was sometimes recognized as the 'alternate', leading to garbage.  Some parsers caught this error and ignored it, others did not.