### PR TITLE
Bug 9545 and 9546 Vcard export on Windows problems

### DIFF
--- a/gramps/gen/plug/utils.py
+++ b/gramps/gen/plug/utils.py
@@ -397,18 +397,19 @@ def load_addon_file(path, callback=None):
 #-------------------------------------------------------------------------
 class OpenFileOrStdout:
     """Context manager to open a file or stdout for writing."""
-    def __init__(self, filename, encoding=None):
+    def __init__(self, filename, encoding=None, errors=None, newline=None):
         self.filename = filename
         self.filehandle = None
         self.encoding = encoding
+        self.errors = errors
+        self.newline = newline
 
     def __enter__(self):
         if self.filename == '-':
             self.filehandle = sys.stdout
-        elif self.encoding:
-            self.filehandle = open(self.filename, 'w', encoding=self.encoding)
         else:
-            self.filehandle = open(self.filename, 'w')
+            self.filehandle = open(self.filename, 'w', encoding=self.encoding,
+                                   errors=self.errors, newline=self.newline)
         return self.filehandle
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/gramps/plugins/export/exportvcard.py
+++ b/gramps/plugins/export/exportvcard.py
@@ -148,7 +148,8 @@ class VCardWriter:
 
     def export_data(self):
         """Open the file and loop over everyone too write their VCards."""
-        with OpenFileOrStdout(self.filename) as self.filehandle:
+        with OpenFileOrStdout(self.filename, encoding='utf-8',
+                              errors='strict', newline='') as self.filehandle:
             if self.filehandle:
                 self.count = 0
                 self.oldval = 0


### PR DESCRIPTION
On Windows Vcard export was using the default encoding (cp1252 for me), and failing when trying to export some unicode characters.  In addition, the default end of line conversion for Windows from '\n' to '\r\n' was causing the final output to have '\r\r\n' at each line.  The Vcard standard required '\r\n'.

Modified the file open to always write 'utf-8', and do no eol conversion since the Vcard code already had the '\r\n'.

A test module with tests are forthcoming, as soon as a few of these PRs get accepted (so I don't have to design so many versions of test modules, to keep the PRs independent and then have to reconcile them when one or more is accepted).