### PR TITLE
A few Deprecation warnings handled

### DIFF
--- a/gramps/gui/widgets/styledtexteditor.py
+++ b/gramps/gui/widgets/styledtexteditor.py
@@ -71,8 +71,9 @@ from ..actiongroup import ActionGroup
 #
 #-------------------------------------------------------------------------
 if has_display():
-    HAND_CURSOR = Gdk.Cursor.new(Gdk.CursorType.HAND2)
-    REGULAR_CURSOR = Gdk.Cursor.new(Gdk.CursorType.XTERM)
+    display = Gdk.Display.get_default()
+    HAND_CURSOR = Gdk.Cursor.new_for_display(display, Gdk.CursorType.HAND2)
+    REGULAR_CURSOR = Gdk.Cursor.new_for_display(display, Gdk.CursorType.XTERM)
 
 FORMAT_TOOLBAR = '''
 <ui>

--- a/gramps/plugins/importer/importgedcom.py
+++ b/gramps/plugins/importer/importgedcom.py
@@ -45,10 +45,8 @@ from gramps.gen.utils.libformatting import ImportInfo
 # Manager->Reload is executed, not only is the top-level exportgedcom file
 # reloaded, but also the dependent libgedcom. This ensures that testing can have
 # a quick turnround, without having to restart Gramps.
-module = __import__("gramps.plugins.lib.libgedcom",
-                    fromlist=["gramps.plugins.lib"])   # why o why ?? as above!
-import imp
-imp.reload(module)
+import importlib
+importlib.reload(libgedcom)
 
 from gramps.gen.config import config
 

--- a/gramps/plugins/importer/importgedcom.py
+++ b/gramps/plugins/importer/importgedcom.py
@@ -45,8 +45,10 @@ from gramps.gen.utils.libformatting import ImportInfo
 # Manager->Reload is executed, not only is the top-level exportgedcom file
 # reloaded, but also the dependent libgedcom. This ensures that testing can have
 # a quick turnround, without having to restart Gramps.
-import importlib
-importlib.reload(libgedcom)
+module = __import__("gramps.plugins.lib.libgedcom",
+                    fromlist=["gramps.plugins.lib"])   # why o why ?? as above!
+import imp
+imp.reload(module)
 
 from gramps.gen.config import config
 

--- a/gramps/plugins/importer/importvcard.py
+++ b/gramps/plugins/importer/importvcard.py
@@ -289,7 +289,7 @@ class VCardParser:
                 # Included cause VCards made by Gramps have this prop.
                 pass
             else:
-                LOG.warn("Token >%s< unknown. line skipped: %s" %
+                LOG.warning("Token >%s< unknown. line skipped: %s" %
                         (fields[0],line))
 
     def finish_person(self):
@@ -303,8 +303,8 @@ class VCardParser:
         """A VCard for another person is started."""
         if self.person is not None:
             self.finish_person()
-            LOG.warn("BEGIN property not properly closed by END property, "
-                     "Gramps can't cope with nested VCards.")
+            LOG.warning("BEGIN property not properly closed by END property, "
+                        "Gramps can't cope with nested VCards.")
         self.person = Person()
         self.formatted_name = ''
         self.name_parts = ''
@@ -333,15 +333,15 @@ class VCardParser:
         Returns True on success, False on failure.
         """
         if not self.name_parts.strip():
-            LOG.warn("VCard is malformed missing the compulsory N property, "
-                    "so there is no name; skip it.")
+            LOG.warning("VCard is malformed missing the compulsory N property,"
+                        " so there is no name; skip it.")
             return False
         if not self.formatted_name:
-            LOG.warn("VCard is malformed missing the compulsory FN property, "
-                    "get name from N alone.")
+            LOG.warning("VCard is malformed missing the compulsory FN property"
+                        ", get name from N alone.")
         data_fields = self.split_unescaped(self.name_parts, ';')
         if len(data_fields) != 5:
-            LOG.warn("VCard is malformed wrong number of name components.")
+            LOG.warning("VCard is malformed wrong number of name components.")
 
         name = Name()
         name.set_type(NameType(NameType.BIRTH))


### PR DESCRIPTION
importgedcom.py changed the imp.reload to use the importlib library, which has been available since Python3.1.
importvcard.py changed the logger.warn() to logger.warning() which has been available since the logger was included into Python.
styledtexeditor.py changed gdk_cursor_new; it has been deprecated since version 3.16, gdk_cursor_new_for_display() has been available since v2.2