### PR TITLE
Gdk.Cursor.new() deprecation fixes

### DIFF
--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -110,6 +110,7 @@ BACKEND_COL = 7
 RCS_BUTTON = {True : _('_Extract'), False : _('_Archive')}
 
 class Information(ManagedWindow):
+
     def __init__(self, uistate, data, parent):
         super().__init__(uistate, [], self)
         self.window = Gtk.Dialog()
@@ -153,6 +154,9 @@ class DbManager(CLIDbManager):
         }
 
     ERROR = ErrorDialog
+
+    BUSY_CURSOR = Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                             Gdk.CursorType.WATCH)
 
     def __init__(self, uistate, dbstate, parent=None):
         """
@@ -936,7 +940,7 @@ class DbManager(CLIDbManager):
         message
         """
         self.msg.set_label(msg)
-        self.top.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
+        self.top.get_window().set_cursor(self.BUSY_CURSOR)
         while Gtk.events_pending():
             Gtk.main_iteration()
 

--- a/gramps/gui/displaystate.py
+++ b/gramps/gui/displaystate.py
@@ -386,7 +386,8 @@ class DisplayState(Callback):
         'Note': _("No active note"),
         }
 
-    BUSY_CURSOR = Gdk.Cursor.new(Gdk.CursorType.WATCH)
+    BUSY_CURSOR = Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                             Gdk.CursorType.WATCH)
 
     def __init__(self, window, status, uimanager, viewmanager=None):
 

--- a/gramps/gui/plug/_windows.py
+++ b/gramps/gui/plug/_windows.py
@@ -759,8 +759,12 @@ class ToolManagedWindowBase(ManagedWindow):
         self.results_text.connect('motion-notify-event',
                                   self.on_motion)
         self.tags = []
-        self.link_cursor = Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR)
-        self.standard_cursor = Gdk.Cursor.new(Gdk.CursorType.XTERM)
+        self.link_cursor = \
+            Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                       Gdk.CursorType.LEFT_PTR)
+        self.standard_cursor = \
+            Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                       Gdk.CursorType.XTERM)
 
         self.setup_other_frames()
         self.set_current_frame(self.initial_frame())

--- a/gramps/gui/plug/export/_exportassistant.py
+++ b/gramps/gui/plug/export/_exportassistant.py
@@ -95,9 +95,6 @@ class ExportAssistant(Gtk.Assistant, ManagedWindow) :
     __gsignals__ = {"apply": "override", "cancel": "override",
                     "close": "override", "prepare": "override"}
 
-    BUSY_CURSOR = Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
-                                             Gdk.CursorType.WATCH)
-
     def __init__(self,dbstate,uistate):
         """
         Set up the assistant, and build all the possible assistant pages.
@@ -628,8 +625,11 @@ class ExportAssistant(Gtk.Assistant, ManagedWindow) :
                    a part of ManagedWindow
 
         """
+        BUSY_CURSOR = Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                                 Gdk.CursorType.WATCH)
+
         if value:
-            self.get_window().set_cursor(self.BUSY_CURSOR)
+            self.get_window().set_cursor(BUSY_CURSOR)
             #self.set_sensitive(0)
         else:
             self.get_window().set_cursor(None)

--- a/gramps/gui/plug/export/_exportassistant.py
+++ b/gramps/gui/plug/export/_exportassistant.py
@@ -95,6 +95,9 @@ class ExportAssistant(Gtk.Assistant, ManagedWindow) :
     __gsignals__ = {"apply": "override", "cancel": "override",
                     "close": "override", "prepare": "override"}
 
+    BUSY_CURSOR = Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                             Gdk.CursorType.WATCH)
+
     def __init__(self,dbstate,uistate):
         """
         Set up the assistant, and build all the possible assistant pages.
@@ -626,7 +629,7 @@ class ExportAssistant(Gtk.Assistant, ManagedWindow) :
 
         """
         if value:
-            self.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
+            self.get_window().set_cursor(self.BUSY_CURSOR)
             #self.set_sensitive(0)
         else:
             self.get_window().set_cursor(None)

--- a/gramps/gui/widgets/expandcollapsearrow.py
+++ b/gramps/gui/widgets/expandcollapsearrow.py
@@ -46,7 +46,8 @@ from gramps.gen.constfunc import has_display
 #
 #-------------------------------------------------------------------------
 if has_display():
-    HAND_CURSOR = Gdk.Cursor.new(Gdk.CursorType.HAND2)
+    HAND_CURSOR = Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                             Gdk.CursorType.HAND2)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gui/widgets/grabbers.py
+++ b/gramps/gui/widgets/grabbers.py
@@ -197,14 +197,30 @@ GRABBERS_SWITCH = [
 
 # cursors
 try:
-    CURSOR_UPPER = Gdk.Cursor.new(Gdk.CursorType.TOP_SIDE)
-    CURSOR_LOWER = Gdk.Cursor.new(Gdk.CursorType.BOTTOM_SIDE)
-    CURSOR_LEFT = Gdk.Cursor.new(Gdk.CursorType.LEFT_SIDE)
-    CURSOR_RIGHT = Gdk.Cursor.new(Gdk.CursorType.RIGHT_SIDE)
-    CURSOR_UPPER_LEFT = Gdk.Cursor.new(Gdk.CursorType.TOP_LEFT_CORNER)
-    CURSOR_UPPER_RIGHT = Gdk.Cursor.new(Gdk.CursorType.TOP_RIGHT_CORNER)
-    CURSOR_LOWER_LEFT = Gdk.Cursor.new(Gdk.CursorType.BOTTOM_LEFT_CORNER)
-    CURSOR_LOWER_RIGHT = Gdk.Cursor.new(Gdk.CursorType.BOTTOM_RIGHT_CORNER)
+    CURSOR_UPPER = \
+        Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                   Gdk.CursorType.TOP_SIDE)
+    CURSOR_LOWER = \
+        Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                   Gdk.CursorType.BOTTOM_SIDE)
+    CURSOR_LEFT = \
+        Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                   Gdk.CursorType.LEFT_SIDE)
+    CURSOR_RIGHT = \
+        Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                   Gdk.CursorType.RIGHT_SIDE)
+    CURSOR_UPPER_LEFT = \
+        Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                   Gdk.CursorType.TOP_LEFT_CORNER)
+    CURSOR_UPPER_RIGHT = \
+        Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                   Gdk.CursorType.TOP_RIGHT_CORNER)
+    CURSOR_LOWER_LEFT = \
+        Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                   Gdk.CursorType.BOTTOM_LEFT_CORNER)
+    CURSOR_LOWER_RIGHT = \
+        Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                   Gdk.CursorType.BOTTOM_RIGHT_CORNER)
 except:
     CURSOR_UPPER = None
     CURSOR_LOWER = None

--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -372,8 +372,12 @@ class GuiGramplet:
         self.pui = None # user code
         self.tooltips_text = None
 
-        self.link_cursor = Gdk.Cursor.new(Gdk.CursorType.LEFT_PTR)
-        self.standard_cursor = Gdk.Cursor.new(Gdk.CursorType.XTERM)
+        self.link_cursor = \
+            Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                       Gdk.CursorType.LEFT_PTR)
+        self.standard_cursor = \
+            Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                       Gdk.CursorType.XTERM)
 
         self.scrolledwindow = None
         self.textview = None

--- a/gramps/gui/widgets/labels.py
+++ b/gramps/gui/widgets/labels.py
@@ -56,7 +56,8 @@ from ..utils import rgb_to_hex
 #
 #-------------------------------------------------------------------------
 if has_display():
-    HAND_CURSOR = Gdk.Cursor.new(Gdk.CursorType.HAND2)
+    HAND_CURSOR = Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                             Gdk.CursorType.HAND2)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/plugins/tool/removeunused.py
+++ b/gramps/plugins/tool/removeunused.py
@@ -61,6 +61,9 @@ class RemoveUnused(tool.Tool, ManagedWindow, UpdateCallback):
     OBJ_TYPE_COL = 3
     OBJ_HANDLE_COL = 4
 
+    BUSY_CURSOR = Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                             Gdk.CursorType.WATCH)
+
     def __init__(self, dbstate, user, options_class, name, callback=None):
         uistate = user.uistate
         self.title = _('Unused Objects')
@@ -236,7 +239,7 @@ class RemoveUnused(tool.Tool, ManagedWindow, UpdateCallback):
 
         self.uistate.set_busy_cursor(True)
         self.uistate.progress.show()
-        self.window.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
+        self.window.get_window().set_cursor(self.BUSY_CURSOR)
 
         self.real_model.clear()
         self.collect_unused()

--- a/gramps/plugins/tool/verify.py
+++ b/gramps/plugins/tool/verify.py
@@ -258,10 +258,6 @@ def get_marriage_date(db, family):
 #-------------------------------------------------------------------------
 class Verify(tool.Tool, ManagedWindow, UpdateCallback):
 
-    BUSY_CURSOR = Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
-                                             Gdk.CursorType.WATCH)
-
-
     def __init__(self, dbstate, user, options_class, name, callback=None):
         uistate = user.uistate
         self.label = _('Data Verify tool')
@@ -353,9 +349,11 @@ class Verify(tool.Tool, ManagedWindow, UpdateCallback):
 
         self.uistate.set_busy_cursor(True)
         self.uistate.progress.show()
-        self.window.get_window().set_cursor(self.BUSY_CURSOR)
+        BUSY_CURSOR = Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                                 Gdk.CursorType.WATCH)
+        self.window.get_window().set_cursor(BUSY_CURSOR)
         try:
-            self.vr.window.get_window().set_cursor(self.BUSY_CURSOR)
+            self.vr.window.get_window().set_cursor(BUSY_CURSOR)
         except AttributeError:
             pass
 

--- a/gramps/plugins/tool/verify.py
+++ b/gramps/plugins/tool/verify.py
@@ -258,6 +258,10 @@ def get_marriage_date(db, family):
 #-------------------------------------------------------------------------
 class Verify(tool.Tool, ManagedWindow, UpdateCallback):
 
+    BUSY_CURSOR = Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                             Gdk.CursorType.WATCH)
+
+
     def __init__(self, dbstate, user, options_class, name, callback=None):
         uistate = user.uistate
         self.label = _('Data Verify tool')
@@ -349,9 +353,9 @@ class Verify(tool.Tool, ManagedWindow, UpdateCallback):
 
         self.uistate.set_busy_cursor(True)
         self.uistate.progress.show()
-        self.window.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
+        self.window.get_window().set_cursor(self.BUSY_CURSOR)
         try:
-            self.vr.window.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
+            self.vr.window.get_window().set_cursor(self.BUSY_CURSOR)
         except AttributeError:
             pass
 

--- a/gramps/plugins/view/pedigreeview.py
+++ b/gramps/plugins/view/pedigreeview.py
@@ -508,6 +508,10 @@ class PedigreeView(NavigationView):
         ('interface.pedview-show-unknown-people', True),
         )
 
+    FLEUR_CURSOR = Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
+                                              Gdk.CursorType.FLEUR)
+
+
     def __init__(self, pdata, dbstate, uistate, nav_group=0):
         NavigationView.__init__(self, _('Pedigree'), pdata, dbstate, uistate,
                                 PersonBookmarks, nav_group)
@@ -1325,7 +1329,7 @@ class PedigreeView(NavigationView):
         or call option menu.
         """
         if event.button == 1 and event.type == Gdk.EventType.BUTTON_PRESS:
-            widget.get_window().set_cursor(Gdk.Cursor.new(Gdk.CursorType.FLEUR))
+            widget.get_window().set_cursor(self.FLEUR_CURSOR)
             self._last_x = event.x
             self._last_y = event.y
             self._in_move = True


### PR DESCRIPTION
Gdk.Cursor.new(CURSOR) -> Gdk.Cursor.new_for_display(Gdk.Display.get_default(), CURSOR)
Had to break up a lot of long lines, and in some places I defined the cursor at the top of the Class.  

I tested each change by setting a breakpoint at the set_cursor() call which used the defined cursor, and exercising Gramps until the breakpoint triggered.  Found a few self created bugs that way.