### PR TITLE
Bug 9561, fix for intermittent plugin recognition via CLI

### DIFF
--- a/gramps/gui/pluginmanager.py
+++ b/gramps/gui/pluginmanager.py
@@ -78,7 +78,7 @@ class GuiPluginManager(Callback):
         Callback.__init__(self)
         self.basemgr = BasePluginManager.get_instance()
         self.__hidden_plugins = set(config.get('plugin.hiddenplugins'))
-        self.__hidden_changed()
+        # self.__hidden_changed() # See bug 9561
 
     def load_plugin(self, pdata):
         if not self.is_loaded(pdata.id):


### PR DESCRIPTION
Email discussion on 
http://gramps.1791082.n4.nabble.com/Plugin-issue-intermittent-error-td4676070.html
During CLI loads of plugins, sometimes the plugin information is lost.  Seems that during load of subsequent plugin, the init code of the plugin triggers imports which eventually try to initialize the GUI plugin manager.  That in turn, clears out some of the data needed by the initial CLI plugin process, as part of a 'hidden plugin' initialization.
I believe that the 'hidden plugin' initialization was not necessary, other code ensures that any 'hidden' plugins remain hidden during GUI and CLI use.