### PR TITLE
Fix Bug 9569 Vcard export order is not consistent

### DIFF
--- a/gramps/plugins/export/exportvcard.py
+++ b/gramps/plugins/export/exportvcard.py
@@ -154,7 +154,7 @@ class VCardWriter:
                 self.count = 0
                 self.oldval = 0
                 self.total = self.db.get_number_of_people()
-                for key in self.db.iter_person_handles():
+                for key in sorted(list(self.db.iter_person_handles())):
                     self.write_person(key)
                     self.update()
         return True


### PR DESCRIPTION
On some occasions, the Vcard export output file, exported from a db imported from the same '.gramps' file, puts out data in a different order.

The Python3 code does not provide ordering guarantees on some of its data constructs from run to run, and I have been told that the db.iter_person_handles() also does not guarantee consistent ordering of its return. The results can apparently change from run to run depending on memory layout conditions, garbage collection timing etc.

So we sort the data before export to correct the issue.