### PR TITLE
bug 9579 Gedcom import of FTM file with OCCU record crashes import

### DIFF
--- a/data/tests/imp_FTM_OCCU_bug.ged
+++ b/data/tests/imp_FTM_OCCU_bug.ged
@@ -1,0 +1,37 @@
+0 HEAD
+1 SOUR FTM
+2 VERS Family Tree Maker (21.0.0.723)
+2 NAME Family Tree Maker for Windows
+2 CORP Ancestry.com
+3 ADDR 360 W 4800 N
+4 CONT Provo, UT 84604
+3 PHON (801) 705-7000
+1 DEST GED55
+1 DATE 11 DEC 2013
+1 CHAR UTF-8
+1 FILE D:\Family Tree Maker\imp_FTM_OCCU_bug.ged
+1 SUBM @SUBM@
+1 GEDC
+2 VERS 5.5
+2 FORM LINEAGE-LINKED
+0 @SUBM@ SUBM
+0 @I1@ INDI
+1 NAME The /Tester/
+1 OCCU Working at Halle's Department Store
+2 DATE 16 OCT 1946
+2 PLAC Cleveland, Cuyahoga, Ohio, United States of America
+1 OCCU
+2 DATE 06 JUL 1950
+2 PLAC Shoemaker
+1 RELI Methodist
+2 DATE 06 JUL 1940
+1 RELI 
+2 PLAC Lutherin
+2 DATE 06 JUL 1950
+1 _DEG High School
+2 PLAC Norwalk, Ohio, USA
+2 DATE 06 JUL 1935
+1 _DEG 
+2 PLAC Case Western University
+2 DATE 06 JUL 1939
+0 TRLR

--- a/data/tests/imp_FTM_OCCU_bug.gramps
+++ b/data/tests/imp_FTM_OCCU_bug.gramps
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE database PUBLIC "-//Gramps//DTD Gramps XML 1.7.1//EN"
+"http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
+<database xmlns="http://gramps-project.org/xml/1.7.1/">
+  <header>
+    <created date="2016-07-14" version="5.0.0-alpha1"/>
+    <researcher>
+    </researcher>
+  </header>
+  <events>
+    <event handle="_0000000200000002" change="1468508301" id="E0000">
+      <type>Occupation</type>
+      <dateval val="1946-10-16"/>
+      <place hlink="_0000000300000003"/>
+      <description>Working at Halle's Department Store</description>
+    </event>
+    <event handle="_0000000400000004" change="1468508301" id="E0001">
+      <type>Occupation</type>
+      <dateval val="1950-07-06"/>
+      <description>Shoemaker</description>
+    </event>
+    <event handle="_0000000500000005" change="1468508301" id="E0002">
+      <type>Religion</type>
+      <dateval val="1940-07-06"/>
+      <description>Methodist</description>
+    </event>
+    <event handle="_0000000600000006" change="1468508301" id="E0003">
+      <type>Religion</type>
+      <dateval val="1950-07-06"/>
+      <description>Lutherin</description>
+    </event>
+    <event handle="_0000000700000007" change="1468508301" id="E0004">
+      <type>Degree</type>
+      <dateval val="1935-07-06"/>
+      <place hlink="_0000000800000008"/>
+      <description>High School</description>
+    </event>
+    <event handle="_0000000900000009" change="1468508301" id="E0005">
+      <type>Degree</type>
+      <dateval val="1939-07-06"/>
+      <description>Case Western University</description>
+    </event>
+  </events>
+  <people>
+    <person handle="_0000000100000001" change="1468508301" id="I0001">
+      <gender>U</gender>
+      <name type="Birth Name">
+        <first>The</first>
+        <surname>Tester</surname>
+      </name>
+      <eventref hlink="_0000000200000002" role="Primary"/>
+      <eventref hlink="_0000000400000004" role="Primary"/>
+      <eventref hlink="_0000000500000005" role="Primary"/>
+      <eventref hlink="_0000000600000006" role="Primary"/>
+      <eventref hlink="_0000000700000007" role="Primary"/>
+      <eventref hlink="_0000000900000009" role="Primary"/>
+    </person>
+  </people>
+  <places>
+    <placeobj handle="_0000000300000003" change="1468508301" id="P0000" type="Unknown">
+      <ptitle>Cleveland, Cuyahoga, Ohio, United States of America</ptitle>
+      <pname value="Cleveland, Cuyahoga, Ohio, United States of America"/>
+    </placeobj>
+    <placeobj handle="_0000000800000008" change="1468508301" id="P0001" type="Unknown">
+      <ptitle>Norwalk, Ohio, USA</ptitle>
+      <pname value="Norwalk, Ohio, USA"/>
+    </placeobj>
+  </places>
+</database>

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -5447,8 +5447,8 @@ class GedcomParser(UpdateCallback):
             state.msg += sub_state.msg
             if sub_state.pf:                # if we found local PLAC:FORM
                 state.pf = sub_state.pf     # save to override global value
-        # merge notes etc into place
-        state.place.merge(sub_state.place)
+            # merge notes etc into place
+            state.place.merge(sub_state.place)
 
     def __event_place_note(self, line, state):
         """

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -5416,7 +5416,8 @@ class GedcomParser(UpdateCallback):
         @type state: CurrentState
         """
 
-        if self.is_ftw and state.event.type in FTW_BAD_PLACE:
+        if self.is_ftw and (state.event.type in FTW_BAD_PLACE) \
+                and not state.event.get_description():
             state.event.set_description(line.data)
         else:
             title = line.data


### PR DESCRIPTION
A FTM (Family Tree Maker) Gedcom file with the following layout crashes the import:
<pre>1 OCCU
2 DATE 10 OCT 1850
2 PLAC Shoemaker</pre>
This is not legal Gedcom, Gramps Gedcom import contains code that tries to detect this unusual case; unfortunately a recent patch (by myself) broke this.
BTW, FTM has now corrected this issue in versions newer than 22.x.x.xxx, so Gramps original fix should really not be applied with newer Gedcoms by FTM.  So I updated the fix to only make corrections when the description part of the OCCU line is missing.

I include a small test file for import tests module, to demonstrate the bug and fix.