### PR TITLE
Bug (Feature) 9580 Gedcom import of FTM file containing _PHOTO tags

### DIFF
--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -1626,6 +1626,7 @@ class CurrentState(object):
         self.repo_ref = None
         self.place = None
         self.media = None
+        self.photo = ""             # Person primary photo
 
     def __getattr__(self, name):
         """


### PR DESCRIPTION
Same as PR196, but back ported to gramps42.
FTM uses the _PHOTO custom Gedcom tag to indicate which of several media attached to a person is the primary photo.
Since it is not standard Gedcom, Gramps currently creates an event out of this tag which makes no sense and just messes up the users data. The Gedcom fragment below shows this feature in use.

<pre>0 @I1@ INDI
1 NAME The /Tester/
1 NOTE The primary photo should be a male Sourpuss in a Hat 03.jpg or Gid:M3
1 _PHOTO @M3@
1 OBJE @M1@
1 OBJE @M2@
1 OBJE @M3@
1 OBJE @M4@
1 OBJE @M5@
</pre>
This patch to libgedcom.py detects the tag and shuffles the list of a persons media so that the primary media item is first in line.
This patch includes test files for the 'test imports' module that demonstrate the new feature.