### PR TITLE
bug 9581 Gedcom import of FTM .ged file containing _LINK tags not supported

### DIFF
--- a/data/tests/imp_FTM_LINK.ged
+++ b/data/tests/imp_FTM_LINK.ged
@@ -1,0 +1,41 @@
+0 HEAD
+1 SOUR FTM
+2 VERS Family Tree Maker (22.0.0.1410)
+2 NAME Family Tree Maker for Windows
+2 CORP Ancestry.com
+3 ADDR 360 W 4800 N
+4 CONT Provo, UT 84604
+3 PHON (801) 705-7000
+1 DEST GED55
+1 DATE 01 MAR 2016
+1 CHAR UTF-8
+1 FILE D:\Family Tree Maker\imp_FTM_LINK.ged
+1 SUBM @SUBM@
+1 GEDC
+2 VERS 5.5
+2 FORM LINEAGE-LINKED
+0 @SUBM@ SUBM
+0 @I937@ INDI
+1 NAME François Joseph /Raffath/
+2 SOUR @S241@
+3 _LINK http://gw.geneanet.org/danynogue2?lang=en&pz=anny+lise+marie&nz=le+vaillant&ocz=0&p=francois+joseph&n=raffath&oc=6
+0 @I1@ INDI
+1 NAME Michael /Sullivan/
+2 SOUR @S118@
+3 PAGE GS Film number: 2342492  Frame Number:   Digital Folder Number: 
+4 CONC 4208243  Image Number:  339  Reference ID:  p 493 rn 9850
+3 DATA
+4 TEXT Name: Michael Sullivan  Race (Original):   Age (Expanded):  25 years  
+5 CONC Birth Year:  1866  Birthplace:  Ireland  Spouse's Name:  Nellie 
+5 CONC Moynahan  Spouse's Race (Original):   Spouse's Age 
+5 CONC (Expanded):  25 years  Spouse's Birth Year:  1866  Spouse's 
+5 CONC Birthplace:  Ireland  Event Date:  04 Nov 1891  Event Place:  Wayne, 
+5 CONC Michigan  Father's Name: Michael Sullivan  Mother's Name: 
+5 CONC Julia Brosnahan  Spouse's Father's Name: Mich. Moynahan  
+5 CONC Spouse's Mother's Name: Ellen Quinlan
+3 _LINK https://familysearch.org/pal:/MM9.1.1/N3XS-1BL
+0 @S118@ SOUR
+1 TITL Michigan, Marriages, 1868-1925
+0 @S241@ SOUR
+1 TITL Daniel NOGUE family tree
+0 TRLR

--- a/data/tests/imp_FTM_LINK.gramps
+++ b/data/tests/imp_FTM_LINK.gramps
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE database PUBLIC "-//Gramps//DTD Gramps XML 1.7.1//EN"
+"http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
+<database xmlns="http://gramps-project.org/xml/1.7.1/">
+  <header>
+    <created date="2016-07-15" version="5.0.0-alpha1"/>
+    <researcher>
+    </researcher>
+  </header>
+  <people>
+    <person handle="_0000000100000001" change="1468601029" id="I0937">
+      <gender>U</gender>
+      <name type="Birth Name">
+        <first>François Joseph</first>
+        <surname>Raffath</surname>
+        <citationref hlink="_0000000400000004"/>
+      </name>
+    </person>
+    <person handle="_0000000500000005" change="1468601031" id="I0001">
+      <gender>U</gender>
+      <name type="Birth Name">
+        <first>Michael</first>
+        <surname>Sullivan</surname>
+        <citationref hlink="_0000000900000009"/>
+      </name>
+    </person>
+  </people>
+  <citations>
+    <citation handle="_0000000400000004" change="1468601029" id="C0000">
+      <confidence>2</confidence>
+      <noteref hlink="_0000000300000003"/>
+      <sourceref hlink="_0000000200000002"/>
+    </citation>
+    <citation handle="_0000000900000009" change="1468601031" id="C0001">
+      <page>GS Film number: 2342492  Frame Number:   Digital Folder Number:4208243  Image Number:  339  Reference ID:  p 493 rn 9850</page>
+      <confidence>2</confidence>
+      <noteref hlink="_0000000700000007"/>
+      <noteref hlink="_0000000800000008"/>
+      <sourceref hlink="_0000000600000006"/>
+    </citation>
+  </citations>
+  <sources>
+    <source handle="_0000000200000002" change="1468600989" id="S0241">
+      <stitle>Daniel NOGUE family tree</stitle>
+    </source>
+    <source handle="_0000000600000006" change="1468601030" id="S0118">
+      <stitle>Michigan, Marriages, 1868-1925</stitle>
+    </source>
+  </sources>
+  <notes>
+    <note handle="_0000000300000003" change="1468601025" id="N0000" type="Citation">
+      <text>http://gw.geneanet.org/danynogue2?lang=en&amp;pz=anny+lise+marie&amp;nz=le+vaillant&amp;ocz=0&amp;p=francois+joseph&amp;n=raffath&amp;oc=6</text>
+      <style name="link" value="http://gw.geneanet.org/danynogue2?lang=en&amp;pz=anny+lise+marie&amp;nz=le+vaillant&amp;ocz=0&amp;p=francois+joseph&amp;n=raffath&amp;oc=6">
+        <range start="0" end="114"/>
+      </style>
+    </note>
+    <note handle="_0000000700000007" change="1468601030" id="N0001" type="Source text">
+      <text>Name: Michael Sullivan  Race (Original):   Age (Expanded):  25 yearsBirth Year:  1866  Birthplace:  Ireland  Spouse's Name:  Nellie Moynahan  Spouse's Race (Original):   Spouse's Age (Expanded):  25 years  Spouse's Birth Year:  1866  Spouse's Birthplace:  Ireland  Event Date:  04 Nov 1891  Event Place:  Wayne, Michigan  Father's Name: Michael Sullivan  Mother's Name: Julia Brosnahan  Spouse's Father's Name: Mich. Moynahan  Spouse's Mother's Name: Ellen Quinlan</text>
+    </note>
+    <note handle="_0000000800000008" change="1468601031" id="N0002" type="Citation">
+      <text>https://familysearch.org/pal:/MM9.1.1/N3XS-1BL</text>
+      <style name="link" value="https://familysearch.org/pal:/MM9.1.1/N3XS-1BL">
+        <range start="0" end="46"/>
+      </style>
+    </note>
+  </notes>
+</database>

--- a/data/tests/imp_FTM_LINK.gramps
+++ b/data/tests/imp_FTM_LINK.gramps
@@ -3,12 +3,12 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-07-15" version="5.0.0-alpha1"/>
+    <created date="2016-07-16" version="5.0.0-alpha1"/>
     <researcher>
     </researcher>
   </header>
   <people>
-    <person handle="_0000000100000001" change="1468601029" id="I0937">
+    <person handle="_0000000100000001" change="1468687774" id="I0937">
       <gender>U</gender>
       <name type="Birth Name">
         <first>François Joseph</first>
@@ -16,7 +16,7 @@
         <citationref hlink="_0000000400000004"/>
       </name>
     </person>
-    <person handle="_0000000500000005" change="1468601031" id="I0001">
+    <person handle="_0000000500000005" change="1468687774" id="I0001">
       <gender>U</gender>
       <name type="Birth Name">
         <first>Michael</first>
@@ -26,13 +26,13 @@
     </person>
   </people>
   <citations>
-    <citation handle="_0000000400000004" change="1468601029" id="C0000">
+    <citation handle="_0000000400000004" change="1468687774" id="C0000">
       <confidence>2</confidence>
       <noteref hlink="_0000000300000003"/>
       <sourceref hlink="_0000000200000002"/>
     </citation>
-    <citation handle="_0000000900000009" change="1468601031" id="C0001">
-      <page>GS Film number: 2342492  Frame Number:   Digital Folder Number:4208243  Image Number:  339  Reference ID:  p 493 rn 9850</page>
+    <citation handle="_0000000900000009" change="1468687774" id="C0001">
+      <page>GS Film number: 2342492  Frame Number:   Digital Folder Number: 4208243  Image Number:  339  Reference ID:  p 493 rn 9850</page>
       <confidence>2</confidence>
       <noteref hlink="_0000000700000007"/>
       <noteref hlink="_0000000800000008"/>
@@ -40,24 +40,24 @@
     </citation>
   </citations>
   <sources>
-    <source handle="_0000000200000002" change="1468600989" id="S0241">
+    <source handle="_0000000200000002" change="1468687774" id="S0241">
       <stitle>Daniel NOGUE family tree</stitle>
     </source>
-    <source handle="_0000000600000006" change="1468601030" id="S0118">
+    <source handle="_0000000600000006" change="1468687774" id="S0118">
       <stitle>Michigan, Marriages, 1868-1925</stitle>
     </source>
   </sources>
   <notes>
-    <note handle="_0000000300000003" change="1468601025" id="N0000" type="Citation">
+    <note handle="_0000000300000003" change="1468687774" id="N0000" type="Citation">
       <text>http://gw.geneanet.org/danynogue2?lang=en&amp;pz=anny+lise+marie&amp;nz=le+vaillant&amp;ocz=0&amp;p=francois+joseph&amp;n=raffath&amp;oc=6</text>
       <style name="link" value="http://gw.geneanet.org/danynogue2?lang=en&amp;pz=anny+lise+marie&amp;nz=le+vaillant&amp;ocz=0&amp;p=francois+joseph&amp;n=raffath&amp;oc=6">
         <range start="0" end="114"/>
       </style>
     </note>
-    <note handle="_0000000700000007" change="1468601030" id="N0001" type="Source text">
-      <text>Name: Michael Sullivan  Race (Original):   Age (Expanded):  25 yearsBirth Year:  1866  Birthplace:  Ireland  Spouse's Name:  Nellie Moynahan  Spouse's Race (Original):   Spouse's Age (Expanded):  25 years  Spouse's Birth Year:  1866  Spouse's Birthplace:  Ireland  Event Date:  04 Nov 1891  Event Place:  Wayne, Michigan  Father's Name: Michael Sullivan  Mother's Name: Julia Brosnahan  Spouse's Father's Name: Mich. Moynahan  Spouse's Mother's Name: Ellen Quinlan</text>
+    <note handle="_0000000700000007" change="1468687774" id="N0001" type="Source text">
+      <text>Name: Michael Sullivan  Race (Original):   Age (Expanded):  25 years  Birth Year:  1866  Birthplace:  Ireland  Spouse's Name:  Nellie Moynahan  Spouse's Race (Original):   Spouse's Age (Expanded):  25 years  Spouse's Birth Year:  1866  Spouse's Birthplace:  Ireland  Event Date:  04 Nov 1891  Event Place:  Wayne, Michigan  Father's Name: Michael Sullivan  Mother's Name: Julia Brosnahan  Spouse's Father's Name: Mich. Moynahan  Spouse's Mother's Name: Ellen Quinlan</text>
     </note>
-    <note handle="_0000000800000008" change="1468601031" id="N0002" type="Citation">
+    <note handle="_0000000800000008" change="1468687774" id="N0002" type="Citation">
       <text>https://familysearch.org/pal:/MM9.1.1/N3XS-1BL</text>
       <style name="link" value="https://familysearch.org/pal:/MM9.1.1/N3XS-1BL">
         <range start="0" end="46"/>

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -268,6 +268,7 @@ TOKEN__MARN = 129
 TOKEN__ADPN = 130
 TOKEN__FSFTID = 131
 TOKEN__PHOTO = 132
+TOKEN__LINK = 133
 
 TOKENS = {
     "HEAD"         : TOKEN_HEAD,    "MEDI"         : TOKEN_MEDI,
@@ -374,7 +375,7 @@ TOKENS = {
     "_URL"           : TOKEN_URL,   "URL"           : TOKEN_URL,
     "_MAR"           : TOKEN__MAR,  "_MARN"         : TOKEN__MARN,
     "_ADPN"          : TOKEN__ADPN, "_FSFTID"       : TOKEN__FSFTID,
-    "_PHOTO"        : TOKEN__PHOTO,
+    "_LINK"          : TOKEN__LINK, "_PHOTO"        : TOKEN__PHOTO,
 }
 
 ADOPT_NONE         = 0
@@ -2313,6 +2314,7 @@ class GedcomParser(UpdateCallback):
             TOKEN_NOTE   : self.__citation_note,
             TOKEN_RNOTE  : self.__citation_note,
             TOKEN_TEXT   : self.__citation_data_text,
+            TOKEN__LINK  : self.__citation_link,
             }
         self.func_list.append(self.citation_parse_tbl)
 
@@ -6168,6 +6170,22 @@ class GedcomParser(UpdateCallback):
         note.set_type(NoteType.SOURCE_TEXT)
         self.dbase.add_note(note, self.trans)
 
+        state.citation.add_note(note.get_handle())
+
+    def __citation_link(self, line, state):
+        """
+        Not legal GEDCOM - added to support FTM, converts the _LINK tag to a
+        note with styled text so link can be followed in reports etc.
+        """
+        note = Note()
+        tags = StyledTextTag(StyledTextTagType.LINK,
+                             line.data,
+                             [(0, len(line.data))])
+        note.set_styledtext(StyledText(line.data, [tags]))
+        gramps_id = self.dbase.find_next_note_gramps_id()
+        note.set_gramps_id(gramps_id)
+        note.set_type(NoteType.CITATION)
+        self.dbase.add_note(note, self.trans)
         state.citation.add_note(note.get_handle())
 
     def __citation_data_note(self, line, state):


### PR DESCRIPTION
FTM uses the non-standard _LINK tag to provide a url for citations. A gedcom fragment shows the usage below:
<pre>0 @I937@ INDI
1 NAME François Joseph /Raffath/
2 SOUR @S241@
3 _LINK http://gw.geneanet.org/danynogue2?lang=en&pz=anny+lise+marie&nz=le+vaillant&ocz=0&p=francois+joseph&n=raffath&oc=6</pre>
Gramps currently (incorrectly) says this is "recognized but not supported". Actually should really be "ignored as not understood".

This PR converts this to a Note, with appropriate markup for the link attached to the citation.