### PR TITLE
Bug9552 Export to '.wft' file crashes if Unicode characters are present on Windows

### DIFF
--- a/data/tests/exp_sample.wft
+++ b/data/tests/exp_sample.wft
@@ -1,0 +1,44 @@
+Anna Hansdotter;;;;;2/10/1864-29/9/1945
+Keith Lloyd Smith;Lloyd Smith;Janis Green;;;11/8/1966
+Hans Peter Smith;Gustaf Smith;Anna Hansdotter;;;17/4/1904-29/1/1977
+Hanna Smith;Martin Smith0;Elna Jefferson;;;29/1/1821
+Herman Julius Nielsen;;;;;31/8/1889-1945
+Evelyn Michaels;;;;;1897
+Marjorie Lee Smith;Hjalmar Smith0;Marjorie Ohman;;;4/11/1934
+Gus Smith;Gustaf Smith;Anna Hansdotter;;;11/9/1897-21/10/1963
+Jennifer Anderson;;;;;5/11/1907-29/5/1985
+Lillie Harriet Jones;;;;;2/5/1910-26/6/1990
+John Hjalmar Smith;Hjalmar Smith0;Marjorie Ohman;;;30/1/1932
+Eric Lloyd Smith;Lloyd Smith;Janis Green;;;28/8/1963
+Amber Marie Smith;Edwin Smith;Janice Adams;;;12/4/1998
+Carl Emil Smith;Gustaf Smith;Anna Hansdotter;;;20/12/1899-28/1/1959
+Hjalmar Smith;Gustaf Smith;Anna Hansdotter;;;31/1/1893-25/9/1894
+Martin Smith;Martin Smith0;Elna Jefferson;;;19/11/1830-1899
+Astrid Shermanna Augusta Smith;Gustaf Smith;Anna Hansdotter;;;31/1/1889-21/12/1963
+Gustaf Smith, Sr.;Martin Smith;Kerstina Hansdotter;;;28/11/1862-23/7/1930
+Marta Ericsdotter;;;;;1775
+Kirsti Marie Smith;Gustaf Smith;Anna Hansdotter;;;15/12/1886-18/7/1966
+Ingeman Smith;;;;;1770
+Anna Streiffert;;;;;23/9/1860-2/2/1927
+Craig Peter Smith;Lloyd Smith;Janis Green;;;1966
+Magnes Smith;Martin Smith;Kerstina Hansdotter;;;6/10/1858-20/2/1910
+Janice Ann Adams;;;;;26/8/1965
+Marjorie Ohman;;;;;3/6/1903-22/6/1980
+Darcy Horne;;;;;2/7/1966
+Lloyd Smith;Hans Smith;Lillie Jones;;;13/3/1935
+Alice Paula Perkins;;;;;22/11/1933
+Lars Peter Smith;Eric Smith;Darcy Horne;;;16/9/1991
+Elna Jefferson;;;;;14/9/1800-
+Edwin Michael Smith;John Smith;Alice Perkins;;;24/5/1961
+Kerstina Hansdotter;;;;;29/11/1832-1908
+Martin Smith0;Ingeman Smith;Marta Ericsdotter;;;1794-
+Ingeman Smith0;Martin Smith0;Elna Jefferson;;;29/1/1826
+Marjorie Alice Smith0;John Smith;Alice Perkins;;;5/2/1960
+Janis Elaine Green;;;;;2/12/1935
+Mason Michael Smith;Edwin Smith;Janice Adams;;;26/6/1996
+Edwin Willard;;;;;1886
+Ingar Smith;Martin Smith0;Elna Jefferson;;;1823
+Hjalmar Smith0;Gustaf Smith;Anna Hansdotter;;;7/4/1895-26/6/1975
+Emil Smith;Martin Smith;Kerstina Hansdotter;;;27/9/1860
+雪 Ke 柯;Herman Nielsen;Astrid Smith;;;
+ピーター リチミシキスイミ;;;;;

--- a/gramps/plugins/export/exportftree.py
+++ b/gramps/plugins/export/exportftree.py
@@ -121,7 +121,7 @@ class FtreeWriter:
                 id_map[key] = n
             id_name[key] = get_name(pn, sn, count)
 
-        with open(self.filename,"w") as f:
+        with open(self.filename, "w", encoding='utf_8') as f:
 
             for key in self.plist:
                 self.update()

--- a/gramps/plugins/test/test_exports.py
+++ b/gramps/plugins/test/test_exports.py
@@ -223,5 +223,15 @@ class ExportControl(unittest.TestCase):
         if msg:
             self.fail(tst_file + ': ' + msg)
 
+    def test_wft(self):
+        """ Run a Web Family Tree export test """
+        set_format(0)   # Use ISO date for test
+        config.set('preferences.place-auto', True)
+        src_file = 'exp_sample.gramps'
+        tst_file = 'exp_sample.wft'
+        msg = do_it(src_file, tst_file)
+        if msg:
+            self.fail(tst_file + ': ' + msg)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The exportftree.py module, like other modules, opens the file output for text write, leaving everything else at default. So on my Windows, it ends up in cp1252, which does not support all Unicode characters.

After some research I found  [http://freecode.com/projects/familytree_cgi/](url) which is a barely maintained bit of software by Ferenc Bodon and Simon Ward.  It currently supports input via Gedcom, excel, and csv files.

Reason I had a hard time finding it is that it does not use '.wft' files.

Our exporter puts out a '.wft' file that is in fact a csv with (some of) the fields that their importer can read. A user would have to rename the wft file to csv or txt to actually use it.

It appears that at some point the authors decided that the csv import was unwieldy, they now prefer excel, or their own '.ser' format for the working format and have converters for the others to that for use.

Their csv import code is still there in the ExtendedSimonWardFormat.pm module; it appears that at some point they decided to convert to utf-8 for their default.

So if we continue to want to support this, we should put out utf-8 by default as well.
