### PR TITLE
Gedcom import media improvements part 2

### DIFF
--- a/data/tests/imp_FTM_PHOTO.ged
+++ b/data/tests/imp_FTM_PHOTO.ged
@@ -7,12 +7,12 @@
 4 CONT Provo, UT 84604
 3 PHON (801) 705-7000
 1 DEST GED55
-1 DATE 11 DEC 2013
+1 DATE 26 JUL 2016
 1 CHAR UTF-8
-1 FILE D:\Family Tree Maker\imp_FTM_OCCU_bug.ged
+1 FILE D:\Family Tree Maker\imp_FTM_PHOTO.ged
 1 SUBM @SUBM@
 1 GEDC
-2 VERS 5.5
+2 VERS 5.5.1
 2 FORM LINEAGE-LINKED
 0 @SUBM@ SUBM
 0 @I1@ INDI
@@ -24,6 +24,16 @@
 1 OBJE @M3@
 1 OBJE @M4@
 1 OBJE @M5@
+0 @I2@ INDI
+1 NAME She /Tester/
+1 NOTE The primary photo should be a girl eating 04.jpg or Gid:M4
+1 OBJE @M1@
+1 OBJE @M2@
+1 OBJE @M3@
+1 OBJE @M4@
+2 _PRIM Y
+3 WHAT ???
+1 OBJE @M5@
 0 @M1@ OBJE
 1 FILE O1.jpg
 2 TITL Ferry Arriving 1910
@@ -33,11 +43,26 @@
 0 @M3@ OBJE
 1 FILE O3.jpg
 2 TITL Sourpuss in Hat
-1 NOTE Should be the selected primary photo
 0 @M4@ OBJE
 1 FILE O4.jpg
 2 TITL Girl Eating
 0 @M5@ OBJE
 1 FILE O5.jpg
 2 TITL Edwin & Janice Smith
+0 @I3@ INDI
+1 NAME Edwin /Tester/
+1 NOTE The primary photo should be a male of pair 05.jpg
+1 OBJE
+2 FILE O3.jpg
+3 FORM jpeg
+2 TITL Sourpuss in Hat
+1 OBJE
+2 FILE O4.jpg
+3 FORM jpeg
+2 TITL Girl Eating
+1 OBJE
+2 FILE O5.jpg
+3 FORM jpeg
+2 TITL Edwin & Janice Smith
+2 _PRIM Y
 0 TRLR

--- a/data/tests/imp_FTM_PHOTO.gramps
+++ b/data/tests/imp_FTM_PHOTO.gramps
@@ -3,12 +3,12 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-07-14" version="5.0.0-alpha1"/>
+    <created date="2016-07-26" version="GrampsAIO64-4.2.1-2"/>
     <researcher>
     </researcher>
   </header>
   <people>
-    <person handle="_0000000100000001" change="1468535650" id="I0001">
+    <person handle="_0000000100000001" change="1469548537" id="I0001">
       <gender>U</gender>
       <name type="Birth Name">
         <first>The</first>
@@ -21,75 +21,130 @@
       <objref hlink="_0000000700000007"/>
       <noteref hlink="_0000000200000002"/>
     </person>
+    <person handle="_0000000800000008" change="1469548537" id="I0002">
+      <gender>U</gender>
+      <name type="Birth Name">
+        <first>She</first>
+        <surname>Tester</surname>
+      </name>
+      <objref hlink="_0000000600000006"/>
+      <objref hlink="_0000000300000003"/>
+      <objref hlink="_0000000400000004"/>
+      <objref hlink="_0000000500000005"/>
+      <objref hlink="_0000000700000007"/>
+      <noteref hlink="_0000000900000009"/>
+      <noteref hlink="_0000000a0000000a"/>
+    </person>
+    <person handle="_0000001000000010" change="1469548537" id="I0003">
+      <gender>U</gender>
+      <name type="Birth Name">
+        <first>Edwin</first>
+        <surname>Tester</surname>
+      </name>
+      <objref hlink="_0000001400000014"/>
+      <objref hlink="_0000001200000012"/>
+      <objref hlink="_0000001300000013"/>
+      <noteref hlink="_0000001100000011"/>
+      <noteref hlink="_0000001500000015"/>
+    </person>
   </people>
   <objects>
-    <object handle="_0000000300000003" change="1468535650" id="M1">
+    <object handle="_0000000300000003" change="1469548537" id="M1">
       <file src="O1.jpg" mime="image/jpeg" description="Ferry Arriving 1910"/>
-      <noteref hlink="_0000000800000008"/>
-    </object>
-    <object handle="_0000000400000004" change="1468535650" id="M2">
-      <file src="O2.jpg" mime="image/jpeg" description="B&amp;W Kids"/>
-      <noteref hlink="_0000000900000009"/>
-    </object>
-    <object handle="_0000000500000005" change="1468535650" id="M3">
-      <file src="O3.jpg" mime="image/jpeg" description="Sourpuss in Hat"/>
-      <noteref hlink="_0000000a0000000a"/>
       <noteref hlink="_0000000b0000000b"/>
     </object>
-    <object handle="_0000000600000006" change="1468535650" id="M4">
-      <file src="O4.jpg" mime="image/jpeg" description="Girl Eating"/>
+    <object handle="_0000000400000004" change="1469548537" id="M2">
+      <file src="O2.jpg" mime="image/jpeg" description="B&amp;W Kids"/>
       <noteref hlink="_0000000c0000000c"/>
     </object>
-    <object handle="_0000000700000007" change="1468535650" id="M5">
-      <file src="O5.jpg" mime="image/jpeg" description="Edwin &amp; Janice Smith"/>
+    <object handle="_0000000500000005" change="1469548537" id="M3">
+      <file src="O3.jpg" mime="image/jpeg" description="Sourpuss in Hat"/>
       <noteref hlink="_0000000d0000000d"/>
+    </object>
+    <object handle="_0000000600000006" change="1469548537" id="M4">
+      <file src="O4.jpg" mime="image/jpeg" description="Girl Eating"/>
+      <noteref hlink="_0000000e0000000e"/>
+    </object>
+    <object handle="_0000000700000007" change="1469548537" id="M5">
+      <file src="O5.jpg" mime="image/jpeg" description="Edwin &amp; Janice Smith"/>
+      <noteref hlink="_0000000f0000000f"/>
+    </object>
+    <object handle="_0000001200000012" change="1469548537" id="O0000">
+      <file src="O3.jpg" mime="image/jpeg" description="Sourpuss in Hat"/>
+    </object>
+    <object handle="_0000001300000013" change="1469548537" id="O0001">
+      <file src="O4.jpg" mime="image/jpeg" description="Girl Eating"/>
+    </object>
+    <object handle="_0000001400000014" change="1469548537" id="O0002">
+      <file src="O5.jpg" mime="image/jpeg" description="Edwin &amp; Janice Smith"/>
     </object>
   </objects>
   <notes>
-    <note handle="_0000000200000002" change="1468535650" id="N0000" type="General">
+    <note handle="_0000000200000002" change="1469548537" id="N0000" type="General">
       <text>The primary photo should be a male Sourpuss in a Hat 03.jpg or Gid:M3</text>
     </note>
-    <note handle="_0000000800000008" change="1468535650" id="N0001" type="GEDCOM import">
+    <note handle="_0000000900000009" change="1469548537" id="N0001" type="General">
+      <text>The primary photo should be a girl eating 04.jpg or Gid:M4</text>
+    </note>
+    <note handle="_0000000a0000000a" change="1469548537" id="N0002" type="GEDCOM import">
+      <text>Records not imported into INDI (individual) Gramps ID I0002:
+
+Line ignored as not understood                                      Line    35: 3 WHAT ???</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="153"/>
+      </style>
+    </note>
+    <note handle="_0000000b0000000b" change="1469548537" id="N0003" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M1:
 
-Could not import O1.jpg                                             Line    28: 1 FILE O1.jpg</text>
+Could not import O1.jpg                                             Line    38: 1 FILE O1.jpg</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="161"/>
       </style>
     </note>
-    <note handle="_0000000900000009" change="1468535650" id="N0002" type="GEDCOM import">
+    <note handle="_0000000c0000000c" change="1469548537" id="N0004" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M2:
 
-Could not import O2.jpg                                             Line    31: 1 FILE O2.jpg</text>
+Could not import O2.jpg                                             Line    41: 1 FILE O2.jpg</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="161"/>
       </style>
     </note>
-    <note handle="_0000000a0000000a" change="1468535650" id="N0003" type="General">
-      <text>Should be the selected primary photo</text>
-    </note>
-    <note handle="_0000000b0000000b" change="1468535650" id="N0004" type="GEDCOM import">
+    <note handle="_0000000d0000000d" change="1469548537" id="N0005" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M3:
 
-Could not import O3.jpg                                             Line    34: 1 FILE O3.jpg</text>
+Could not import O3.jpg                                             Line    44: 1 FILE O3.jpg</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="161"/>
       </style>
     </note>
-    <note handle="_0000000c0000000c" change="1468535650" id="N0005" type="GEDCOM import">
+    <note handle="_0000000e0000000e" change="1469548537" id="N0006" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M4:
 
-Could not import O4.jpg                                             Line    38: 1 FILE O4.jpg</text>
+Could not import O4.jpg                                             Line    47: 1 FILE O4.jpg</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="161"/>
       </style>
     </note>
-    <note handle="_0000000d0000000d" change="1468535650" id="N0006" type="GEDCOM import">
+    <note handle="_0000000f0000000f" change="1469548537" id="N0007" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M5:
 
-Could not import O5.jpg                                             Line    41: 1 FILE O5.jpg</text>
+Could not import O5.jpg                                             Line    50: 1 FILE O5.jpg</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="161"/>
+      </style>
+    </note>
+    <note handle="_0000001100000011" change="1469548537" id="N0008" type="General">
+      <text>The primary photo should be a male of pair 05.jpg</text>
+    </note>
+    <note handle="_0000001500000015" change="1469548537" id="N0009" type="GEDCOM import">
+      <text>Records not imported into INDI (individual) Gramps ID I0003:
+
+Could not import O3.jpg                                             Line    55: 1 OBJE 
+Could not import O4.jpg                                             Line    59: 1 OBJE 
+Could not import O5.jpg                                             Line    63: 1 OBJE</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="326"/>
       </style>
     </note>
   </notes>

--- a/data/tests/imp_MediaTest.ged
+++ b/data/tests/imp_MediaTest.ged
@@ -4,7 +4,7 @@
 2 NAME The Tester
 1 DATE 4 JUN 2016
 2 TIME 10:19:42
-1 FILE D:\Users\PRC\Documents\Family Tree Maker\Gramps Export raw.ged
+1 FILE D:\Users\PRC\Documents\imp_MediaTest.ged
 1 COPR Copyright (c) 2016 The Tester.
 1 GEDC
 2 VERS 5.5.1
@@ -36,6 +36,13 @@
 2 TITL Multimedia link embedded form v5.5 2nd copy
 2 FILE test_emb_55.jpg
 2 NOTE @N0018@
+1 OBJE
+2 FORM text/html
+2 TITL Multimedia link embedded form v5.5 URL
+2 FILE  http://www.geni.com/photo/view?photo_id=6000000001341319061
+2 NOTE @N0018@
+1 OBJE @M7@
+1 OBJE @M8@
 0 @M1@ OBJE
 1 FORM jpeg
 1 TITL Multimedia link to linked form v5.5 blob
@@ -100,7 +107,7 @@
 2 FORM jpeg
 3 TYPE photo
 2 TITL Multimedia link to linked form v5.5.1 with two files(2)
-1 REFN Ref1234567M4
+1 REFN Ref1234567M6
 2 TYPE SOMETEXT
 1 NOTE @N0017@
 1 SOUR @S1@
@@ -108,11 +115,18 @@
 2 DATA
 3 DATE 7 JUN 2014
 3 TEXT A source who shall remain un-named
-2 QUAY 0
-1 RIN ID098765M4
+2 QUAY 3
+1 RIN ID098765M6
 1 CHAN
-2 DATE 24 MAY 1987
-3 TIME 14:38:01
+2 DATE 26 MAY 1987
+3 TIME 14:40:01
+0 @M7@ OBJE
+1 FILE  http://s6.postimg.org/8i2erq27l/Preserve_Record_Numbers_Option.png
+2 FORM png
+3 TYPE photo
+2 TITL Multimedia link to linked form v5.5.1 with URL
+0 @M8@ OBJE
+1 FILE No_path_No_Title_NoForm.jpg
 0 @S1@ SOUR
 1 AUTH The Tester
 1 TITL The Testers personal files

--- a/data/tests/imp_MediaTest.gramps
+++ b/data/tests/imp_MediaTest.gramps
@@ -3,7 +3,7 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-07-11" version="GrampsAIO64-4.2.1-2"/>
+    <created date="2016-07-26" version="5.0.0-alpha1"/>
     <researcher>
       <resname>Paul Culley</resname>
       <resaddr>11210 Olde Mint House Ln</resaddr>
@@ -15,7 +15,7 @@
     </researcher>
   </header>
   <people>
-    <person handle="_0000000100000001" change="1468254344" id="I0001">
+    <person handle="_0000000100000001" change="1469558671" id="I0001">
       <gender>U</gender>
       <name type="Birth Name">
         <first>The</first>
@@ -29,90 +29,108 @@
       <objref hlink="_0000000900000009"/>
       <objref hlink="_0000000a0000000a"/>
       <objref hlink="_0000000300000003"/>
-      <noteref hlink="_0000000c0000000c"/>
+      <objref hlink="_0000000c0000000c"/>
+      <objref hlink="_0000000d0000000d"/>
+      <objref hlink="_0000000e0000000e"/>
+      <noteref hlink="_0000000f0000000f"/>
     </person>
   </people>
   <citations>
-    <citation handle="_0000001800000018" change="1468254344" id="C0000">
+    <citation handle="_0000001b0000001b" change="1469558671" id="C0000">
       <confidence>0</confidence>
-      <noteref hlink="_0000001700000017"/>
-      <sourceref hlink="_0000001600000016"/>
+      <noteref hlink="_0000001a0000001a"/>
+      <sourceref hlink="_0000001900000019"/>
     </citation>
-    <citation handle="_0000002200000022" change="1468254344" id="C0001">
+    <citation handle="_0000002500000025" change="1469558671" id="C0001">
       <dateval val="2014-06-07"/>
       <page>77, 78 discussion of multimedia link with two files</page>
-      <confidence>0</confidence>
-      <noteref hlink="_0000002100000021"/>
-      <sourceref hlink="_0000002000000020"/>
+      <confidence>4</confidence>
+      <noteref hlink="_0000002400000024"/>
+      <sourceref hlink="_0000002300000023"/>
     </citation>
   </citations>
   <sources>
-    <source handle="_0000001600000016" change="1468254344" id="S0002">
+    <source handle="_0000001900000019" change="1469558671" id="S0002">
       <stitle>A Great Photographer</stitle>
     </source>
-    <source handle="_0000002000000020" change="1468254344" id="S0001">
+    <source handle="_0000002300000023" change="1469558671" id="S0001">
       <stitle>The Testers personal files</stitle>
       <sauthor>The Tester</sauthor>
       <spubinfo>Name: Tester Publishing Operations, Inc.; Location: OSF world</spubinfo>
     </source>
   </sources>
   <objects>
-    <object handle="_0000000300000003" change="1468254344" id="O0000">
+    <object handle="_0000000300000003" change="1469558671" id="O0000">
       <file src="test_emb_55.jpg" mime="image/jpeg" description="Multimedia link embedded form v5.5"/>
       <noteref hlink="_0000000200000002"/>
     </object>
     <object handle="_0000000400000004" change="548708291" id="M1">
       <file src="" mime="" description="Multimedia link to linked form v5.5 blob"/>
       <attribute type="REFN" value="Ref12345M1">
-        <noteref hlink="_0000000d0000000d"/>
+        <noteref hlink="_0000001000000010"/>
       </attribute>
       <attribute type="RIN" value="ID09876M1"/>
-      <noteref hlink="_0000000e0000000e"/>
-      <noteref hlink="_0000000f0000000f"/>
+      <noteref hlink="_0000001100000011"/>
+      <noteref hlink="_0000001200000012"/>
     </object>
     <object handle="_0000000500000005" change="548797681" id="M3">
       <file src="test.jpg" mime="image/jpeg" description="Multimedia link to linked form Gramps style v5.5ish file"/>
-      <noteref hlink="_0000001200000012"/>
-      <noteref hlink="_0000001300000013"/>
+      <noteref hlink="_0000001500000015"/>
+      <noteref hlink="_0000001600000016"/>
     </object>
     <object handle="_0000000600000006" change="548883481" id="M4">
-      <file src="test.jpg" mime="image/jpeg" description="test.jpg"/>
+      <file src="test.jpg" mime="image/jpeg" description="Multimedia link to linked form v5.5.1 file"/>
+      <attribute type="Media-Type" value="Photo"/>
       <attribute type="REFN" value="Ref1234567M4">
-        <noteref hlink="_0000001400000014"/>
+        <noteref hlink="_0000001700000017"/>
       </attribute>
       <attribute type="RIN" value="ID098765M4"/>
-      <noteref hlink="_0000001500000015"/>
-      <noteref hlink="_0000001900000019"/>
-      <citationref hlink="_0000001800000018"/>
+      <noteref hlink="_0000001800000018"/>
+      <noteref hlink="_0000001c0000001c"/>
+      <citationref hlink="_0000001b0000001b"/>
     </object>
-    <object handle="_0000000800000008" change="1468254344" id="O0001">
+    <object handle="_0000000800000008" change="1469558671" id="O0001">
       <file src="test_emb_551.jpg" mime="image/jpeg" description="Multimedia link embedded form v5.5.1"/>
+      <attribute type="Media-Type" value="Photo"/>
       <noteref hlink="_0000000700000007"/>
     </object>
-    <object handle="_0000000900000009" change="1468254344" id="M5">
+    <object handle="_0000000900000009" change="1469558671" id="M5">
       <file src="test.jpg" mime="image/jpeg" description="Multimedia link to linked form FTM style file"/>
-      <noteref hlink="_0000001a0000001a"/>
-      <noteref hlink="_0000001b0000001b"/>
-      <noteref hlink="_0000001c0000001c"/>
       <noteref hlink="_0000001d0000001d"/>
-    </object>
-    <object handle="_0000000a0000000a" change="548883481" id="M6">
-      <file src="test.jpg" mime="image/jpeg" description="test.jpg"/>
-      <attribute type="REFN" value="Ref1234567M4">
-        <noteref hlink="_0000001e0000001e"/>
-      </attribute>
-      <attribute type="RIN" value="ID098765M4"/>
+      <noteref hlink="_0000001e0000001e"/>
       <noteref hlink="_0000001f0000001f"/>
-      <noteref hlink="_0000002300000023"/>
-      <citationref hlink="_0000002200000022"/>
+      <noteref hlink="_0000002000000020"/>
     </object>
-    <object handle="_0000001000000010" change="1468254344" id="M2">
+    <object handle="_0000000a0000000a" change="549056401" id="M6">
+      <file src="test.jpg" mime="image/jpeg" description="Multimedia link to linked form v5.5.1 with two files(1)"/>
+      <attribute type="Media-Type" value="Photo"/>
+      <attribute type="REFN" value="Ref1234567M6">
+        <noteref hlink="_0000002100000021"/>
+      </attribute>
+      <attribute type="RIN" value="ID098765M6"/>
+      <noteref hlink="_0000002200000022"/>
+      <noteref hlink="_0000002600000026"/>
+      <citationref hlink="_0000002500000025"/>
+    </object>
+    <object handle="_0000000c0000000c" change="1469558671" id="O0002">
+      <file src="http://www.geni.com/photo/view?photo_id=6000000001341319061" mime="unknown" description="Multimedia link embedded form v5.5 URL"/>
+      <noteref hlink="_0000000b0000000b"/>
+    </object>
+    <object handle="_0000000d0000000d" change="1469558671" id="M7">
+      <file src="http://s6.postimg.org/8i2erq27l/Preserve_Record_Numbers_Option.png" mime="image/png" description="Multimedia link to linked form v5.5.1 with URL"/>
+      <attribute type="Media-Type" value="Photo"/>
+    </object>
+    <object handle="_0000000e0000000e" change="1469558671" id="M8">
+      <file src="No_path_No_Title_NoForm.jpg" mime="image/jpeg" description="No_path_No_Title_NoForm.jpg"/>
+      <noteref hlink="_0000002700000027"/>
+    </object>
+    <object handle="_0000001300000013" change="1469558671" id="M2">
       <file src="" mime="" description="2nd blob Multimedia link to linked form v5.5 blob"/>
-      <noteref hlink="_0000001100000011"/>
+      <noteref hlink="_0000001400000014"/>
     </object>
   </objects>
   <notes>
-    <note handle="_0000000200000002" change="1468254344" id="N0010" type="General">
+    <note handle="_0000000200000002" change="1469558671" id="N0010" type="General">
       <text>Media note test: Multimedia link embedded form v5.5
 n OBJE {1:1} p.55
 +1 FORM &lt;MULTIMEDIA_FORMAT&gt; {1:1} p.48
@@ -120,7 +138,7 @@ n OBJE {1:1} p.55
 +1 FILE &lt;MULTIMEDIA_FILE_REFERENCE&gt; {1:1} p.47
 +1 &lt;&lt;NOTE_STRUCTURE&gt;&gt; {0:M} p.33</text>
     </note>
-    <note handle="_0000000700000007" change="1468254344" id="N0014" type="General">
+    <note handle="_0000000700000007" change="1469558671" id="N0014" type="General">
       <text>Media note test: Multimedia link embedded form v5.5.1
 This note is not in the 5.5.1 spec, but is an obvious extrapolation from 5.5.
 n OBJE
@@ -129,21 +147,23 @@ n OBJE
 +3 MEDI &lt;SOURCE_MEDIA_TYPE&gt; {0:1} p.62
 +1 TITL &lt;DESCRIPTIVE_TITLE&gt; {0:1} p.48</text>
     </note>
-    <note handle="_0000000b0000000b" change="1468254344" id="N0018" type="General">
+    <note handle="_0000000b0000000b" change="1469558671" id="N0018" type="General">
       <text>Multimedia embedded 2nd copy v5.5</text>
     </note>
-    <note handle="_0000000c0000000c" change="1468254344" id="N0000" type="GEDCOM import">
+    <note handle="_0000000f0000000f" change="1469558671" id="N0000" type="GEDCOM import">
       <text>Records not imported into INDI (individual) Gramps ID I0001:
 
-Tag recognized but not supported                                    Line    29: 4 MEDI photo</text>
+Could not import test_emb_55.jpg                                    Line    18: 1 OBJE 
+Could not import test_emb_551.jpg                                   Line    26: 1 OBJE 
+Could not import test_emb_55.jpg                                    Line    34: 1 OBJE</text>
       <style name="fontface" value="Monospace">
-        <range start="0" end="155"/>
+        <range start="0" end="326"/>
       </style>
     </note>
-    <note handle="_0000000d0000000d" change="1468254344" id="N0001" type="REFN-TYPE">
+    <note handle="_0000001000000010" change="1469558671" id="N0001" type="REFN-TYPE">
       <text>SOMETEXT</text>
     </note>
-    <note handle="_0000000e0000000e" change="1468254344" id="N0011" type="General">
+    <note handle="_0000001100000011" change="1469558671" id="N0011" type="General">
       <text>Media note test: Multimedia link to linked form v5.5 blob
 n @XREF:OBJE@ OBJE {1:1}
 +1 FORM &lt;MULTIMEDIA_FORMAT&gt; {1:1} p.48  
@@ -157,10 +177,10 @@ n @XREF:OBJE@ OBJE {1:1}
 +1 RIN &lt;AUTOMATED_RECORD_ID&gt; {0:1} p.38
 +1 &lt;&lt;CHANGE_DATE&gt;&gt; {0:1} p.29</text>
     </note>
-    <note handle="_0000000f0000000f" change="1468254344" id="N0002" type="GEDCOM import">
+    <note handle="_0000001200000012" change="1469558671" id="N0002" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M1:
 
-BLOB ignored                                                        Line    42: 1 BLOB 
+Tag recognized but not supported                                    Line    49: 1 BLOB 
                                                                                        .HM.......k.1..F.jwA.Dzzzzw............A....1.........0U.66..E.8
                                                                                        .......A..k.a6.A.......A..k.........../6....G.......0../..U.....
                                                                                        .w1/m........HC0..../...zzzzzzzz..5zzk..AnA..U..W6U....2rRrRrRrR
@@ -168,21 +188,23 @@ BLOB ignored                                                        Line    42: 
                                                                                        /Dw/.Tvz.E5zzUE9/kHz.Tw2/DzzzEEA.kE2zk5yzk2/zzs21.U2/Dw/.Tw/.Tzy
                                                                                        /.fy/.HzzkHzzzo21Ds00.E2.UE2.U62/.k./Ds0.UE0/Do0..E8/UE2.U62.U9w
                                                                                        /.Tx/.20.jg2/jo2..9u/.0U.6A.zk
-Line ignored as not understood                                      Line    50: 1 OBJE @M2@</text>
+Line ignored as not understood                                      Line    57: 1 OBJE @M2@
+Filename omitted                                                    Line    46: 0 M1 OBJE</text>
       <style name="fontface" value="Monospace">
-        <range start="0" end="1277"/>
+        <range start="0" end="1367"/>
       </style>
     </note>
-    <note handle="_0000001100000011" change="1468254344" id="N0003" type="GEDCOM import">
+    <note handle="_0000001400000014" change="1469558671" id="N0003" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M2:
 
-BLOB ignored                                                        Line    61: 1 BLOB 
-                                                                                       67890gramps doesn't do this anyway, so don't bother doing it right.</text>
+Tag recognized but not supported                                    Line    68: 1 BLOB 
+                                                                                       67890gramps doesn't do this anyway, so don't bother doing it right.
+Filename omitted                                                    Line    65: 0 M2 OBJE</text>
       <style name="fontface" value="Monospace">
-        <range start="0" end="310"/>
+        <range start="0" end="400"/>
       </style>
     </note>
-    <note handle="_0000001200000012" change="1468254344" id="N0012" type="General">
+    <note handle="_0000001500000015" change="1469558671" id="N0012" type="General">
       <text>Media note test: Multimedia link to linked form Gramps style v5.5ish file
 n @XREF:OBJE@ OBJE {1:1}
 +1 FORM &lt;MULTIMEDIA_FORMAT&gt; {1:1} p.48  
@@ -190,18 +212,18 @@ n @XREF:OBJE@ OBJE {1:1}
 +1 FILE &lt;MULTIMEDIA_FILE_REFERENCE&gt; {1:1} p.47
 +1 &lt;&lt;NOTE_STRUCTURE&gt;&gt; {0:M} p.33</text>
     </note>
-    <note handle="_0000001300000013" change="1468254344" id="N0004" type="GEDCOM import">
+    <note handle="_0000001600000016" change="1469558671" id="N0004" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M3:
 
-Could not import test.jpg                                           Line    66: 1 FILE test.jpg</text>
+Could not import test.jpg                                           Line    73: 1 FILE test.jpg</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="163"/>
       </style>
     </note>
-    <note handle="_0000001400000014" change="1468254344" id="N0005" type="REFN-TYPE">
+    <note handle="_0000001700000017" change="1469558671" id="N0005" type="REFN-TYPE">
       <text>SOMETEXT</text>
     </note>
-    <note handle="_0000001500000015" change="1468254344" id="N0013" type="General">
+    <note handle="_0000001800000018" change="1469558671" id="N0013" type="General">
       <text>Media note test: Multimedia link to linked form v5.5.1 file
 n @XREF:OBJE@ OBJE {1:1}
 +1 FILE &lt;MULTIMEDIA_FILE_REFN&gt; {1:M} p.54
@@ -215,27 +237,25 @@ n @XREF:OBJE@ OBJE {1:1}
 +1 &lt;&lt;SOURCE_CITATION&gt;&gt; {0:M} p.39
 +1 &lt;&lt;CHANGE_DATE&gt;&gt; {0:1} p.31</text>
     </note>
-    <note handle="_0000001700000017" change="1468254344" id="N0006" type="Source text">
+    <note handle="_0000001a0000001a" change="1469558671" id="N0006" type="Source text">
       <text>who shall remain un-named</text>
     </note>
-    <note handle="_0000001900000019" change="1468254344" id="N0007" type="GEDCOM import">
+    <note handle="_0000001c0000001c" change="1469558671" id="N0007" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M4:
 
-Could not import test.jpg                                           Line    72: 1 FILE test.jpg
-Skipped subordinate line                                            Line    74: 3 TYPE photo
-Skipped subordinate line                                            Line    75: 2 TITL Multimedia link to linked form v5.5.1 file</text>
+Could not import test.jpg                                           Line    79: 1 FILE test.jpg</text>
       <style name="fontface" value="Monospace">
-        <range start="0" end="386"/>
+        <range start="0" end="163"/>
       </style>
     </note>
-    <note handle="_0000001a0000001a" change="1468254344" id="N0008" type="Media Note">
+    <note handle="_0000001d0000001d" change="1469558671" id="N0008" type="Media Note">
       <text>A fine gentelman was he, upstanding in his community and a great believer in the testing of open source software.</text>
     </note>
-    <note handle="_0000001b0000001b" change="1468254344" id="N0015" type="General">
+    <note handle="_0000001e0000001e" change="1469558671" id="N0015" type="General">
       <text>A note on the FTM media, to see how this integrates...  The DATE line is bad; it doesnt follow Gedcom standard at all, and includes the time.
 The TEXT line comes from the FTM media description.  This is the media Note.</text>
     </note>
-    <note handle="_0000001c0000001c" change="1468254344" id="N0016" type="General">
+    <note handle="_0000001f0000001f" change="1469558671" id="N0016" type="General">
       <text>Multimedia link to linked form FTM style
 n @XREF:OBJE@ OBJE {1:1}
 +1 FILE &lt;MULTIMEDIA_FILE_REFN&gt; {1:M} p.54
@@ -244,35 +264,41 @@ n @XREF:OBJE@ OBJE {1:1}
 +2 TEXT text string from FTM media description sometimes populated from exif comments
 +1 &lt;&lt;NOTE_STRUCTURE&gt;&gt; {0:M} p.33</text>
     </note>
-    <note handle="_0000001d0000001d" change="1468254344" id="N0009" type="GEDCOM import">
+    <note handle="_0000002000000020" change="1469558671" id="N0009" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M5:
 
-Could not import test.jpg                                           Line    87: 1 FILE test.jpg</text>
+Could not import test.jpg                                           Line    94: 1 FILE test.jpg</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="163"/>
       </style>
     </note>
-    <note handle="_0000001e0000001e" change="1468254344" id="N0017" type="REFN-TYPE">
+    <note handle="_0000002100000021" change="1469558671" id="N0017" type="REFN-TYPE">
       <text>SOMETEXT</text>
     </note>
-    <note handle="_0000001f0000001f" change="1468254344" id="N0019" type="General">
+    <note handle="_0000002200000022" change="1469558671" id="N0019" type="General">
       <text>Multimedia link to linked form v5.5.1 with two files</text>
     </note>
-    <note handle="_0000002100000021" change="1468254344" id="N0020" type="Source text">
+    <note handle="_0000002400000024" change="1469558671" id="N0020" type="Source text">
       <text>A source who shall remain un-named</text>
     </note>
-    <note handle="_0000002300000023" change="1468254344" id="N0021" type="GEDCOM import">
+    <note handle="_0000002600000026" change="1469558671" id="N0021" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M6:
 
-Could not import test.jpg                                           Line    95: 1 FILE test.jpg
-Skipped subordinate line                                            Line    97: 3 TYPE photo
-Skipped subordinate line                                            Line    98: 2 TITL Multimedia link to linked form v5.5.1 with two files(1)
-Multiple FILE in a single OBJE ignored                              Line    99: 1 FILE test1.jpg
-Skipped subordinate line                                            Line   100: 2 FORM jpeg
-Skipped subordinate line                                            Line   101: 3 TYPE photo
-Skipped subordinate line                                            Line   102: 2 TITL Multimedia link to linked form v5.5.1 with two files(2)</text>
+Could not import test.jpg                                           Line   102: 1 FILE test.jpg
+Multiple FILE in a single OBJE ignored                              Line   106: 1 FILE test1.jpg
+Skipped subordinate line                                            Line   107: 2 FORM jpeg
+Skipped subordinate line                                            Line   108: 3 TYPE photo
+Skipped subordinate line                                            Line   109: 2 TITL Multimedia link to linked form v5.5.1 with two files(2)</text>
       <style name="fontface" value="Monospace">
-        <range start="0" end="824"/>
+        <range start="0" end="588"/>
+      </style>
+    </note>
+    <note handle="_0000002700000027" change="1469558671" id="N0022" type="GEDCOM import">
+      <text>Records not imported into OBJE (multi-media object) Gramps ID M8:
+
+Could not import No_path_No_Title_NoForm.jpg                        Line   129: 1 FILE No_path_No_Title_NoForm.jpg</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="182"/>
       </style>
     </note>
   </notes>

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -269,6 +269,7 @@ TOKEN__ADPN = 130
 TOKEN__FSFTID = 131
 TOKEN__PHOTO = 132
 TOKEN__LINK = 133
+TOKEN__PRIM = 134
 
 TOKENS = {
     "HEAD"         : TOKEN_HEAD,    "MEDI"         : TOKEN_MEDI,
@@ -362,7 +363,7 @@ TOKENS = {
     "_DETAIL"        : TOKEN_IGNORE,"_PREF"         : TOKEN__PRIMARY,
     "_LKD"           : TOKEN__LKD,  "_DATE"         : TOKEN_IGNORE,
     "_SCBK"          : TOKEN_IGNORE,"_TYPE"         : TOKEN_TYPE,
-    "_PRIM"          : TOKEN_IGNORE,"_SSHOW"        : TOKEN_IGNORE,
+    "_PRIM"          : TOKEN__PRIM, "_SSHOW"        : TOKEN_IGNORE,
     "_PAREN"         : TOKEN_IGNORE,"BLOB"          : TOKEN_BLOB,
     "CONL"           : TOKEN_CONL,  "RESN"          : TOKEN_RESN,
     "_MEDI"          : TOKEN_MEDI,  "_MASTER"       : TOKEN_IGNORE,
@@ -1605,7 +1606,7 @@ class CurrentState:
         self.note = None
         self.lds_ord = None
         self.msg = ""
-        self.primary = False        # _PRIM tag on an INDI.FAMC tag
+        self.primary = False        # _PRIMARY tag on an INDI.FAMC tag
         self.filename = ""
         self.title = ""
         self.addr = None
@@ -2320,10 +2321,12 @@ class GedcomParser(UpdateCallback):
 
         self.media_parse_tbl = {
             TOKEN_FORM   : self.__media_ref_form,
+            TOKEN_MEDI   : self.__media_ref_medi,        # v5.5.1
             TOKEN_TITL   : self.__media_ref_titl,
             TOKEN_FILE   : self.__media_ref_file,
             TOKEN_NOTE   : self.__media_ref_note,
             TOKEN_RNOTE  : self.__media_ref_note,
+            TOKEN__PRIM  : self.__media_ref_prim,        # LFT etc.
             TOKEN_IGNORE : self.__ignore,
         }
         self.func_list.append(self.media_parse_tbl)
@@ -2504,7 +2507,7 @@ class GedcomParser(UpdateCallback):
             TOKEN_NOTE   : self.__obje_note,
             TOKEN_RNOTE  : self.__obje_note,
             TOKEN_SOUR   : self.__obje_sour,
-            TOKEN_BLOB   : self.__obje_blob,
+            TOKEN_BLOB   : self.__ignore,       # v5.5.1 deprecated
             TOKEN_REFN   : self.__obje_refn,
             TOKEN_RIN    : self.__obje_rin,
             TOKEN_CHAN   : self.__obje_chan,
@@ -3061,6 +3064,34 @@ class GedcomParser(UpdateCallback):
 
         self.backoff = False
         return self.groups
+
+    def __chk_subordinate(self, level, state, token):
+        """
+        checks for a single subordinate line with specific token.  If any other
+        lines are present, they are not understood.
+
+        @param level: Current level in the file
+        @type level: int
+        @param state: The current state
+        @type state: CurrentState
+        @param token: The token to search for
+        @type token: int
+        """
+        skips = 0
+        got_line = None
+        while True:
+            line = self.__get_next_line()
+            if self.__level_is_finished(line, level):
+                if skips:
+                    # This improves formatting when there are long sequences of
+                    # skipped lines
+                    self.__add_msg("", None, None)
+                return got_line
+            if line.token == token:
+                got_line = line
+            else:
+                self.__add_msg(_("Line ignored as not understood"), line, state)
+                skips += 1
 
     def __undefined(self, line, state):
         """
@@ -3794,39 +3825,12 @@ class GedcomParser(UpdateCallback):
 
     def __person_object(self, line, state):
         """
-
-        Embedded form
-
-        >   n OBJE @<XREF:OBJE>@ {1:1}
-
-        Linked form
-
-        >   n OBJE {1:1}
-        >   +1 FORM <MULTIMEDIA_FORMAT> {1:1}
-        >   +1 TITL <DESCRIPTIVE_TITLE> {0:1}
-        >   +1 FILE <MULTIMEDIA_FILE_REFERENCE> {1:1}
-        >   +1 <<NOTE_STRUCTURE>> {0:M}
-
         @param line: The current line in GedLine format
         @type line: GedLine
         @param state: The current state
         @type state: CurrentState
         """
-        if line.data and line.data[0] == '@':
-            # Reference to a named multimedia object defined elsewhere
-            gramps_id = self.oid_map[line.data]
-
-            handle = self.__find_media_handle(gramps_id)
-            ref = MediaRef()
-            ref.set_reference_handle(handle)
-            state.person.add_media_reference(ref)
-        else:
-            (form, filename, title, note) = self.__obje(state.level+1, state)
-            if filename == "":
-                self.__add_msg(_("Filename omitted"), line, state)
-            if form == "":
-                self.__add_msg(_("Form omitted"), line, state)
-            self.build_media(state.person, form, filename, title, note)
+        self.__obje(line, state, state.person)
 
     def __person_photo(self, line, state):
         """
@@ -4739,7 +4743,7 @@ class GedcomParser(UpdateCallback):
 
     def __person_famc_primary(self, line, state):
         """
-        Parses the _PRIM tag on an INDI.FAMC tag. This value is stored in
+        Parses the _PRIMARY tag on an INDI.FAMC tag. This value is stored in
         the state record to be used later.
 
         @param line: The current line in GedLine format
@@ -5152,21 +5156,7 @@ class GedcomParser(UpdateCallback):
         @param state: The current state
         @type state: CurrentState
         """
-        if line.data and line.data[0] == '@':
-            # Reference to a named multimedia object defined elsewhere
-            gramps_id = self.oid_map[line.data]
-
-            handle = self.__find_media_handle(gramps_id)
-            ref = MediaRef()
-            ref.set_reference_handle(handle)
-            state.family.add_media_reference(ref)
-        else:
-            (form, filename, title, note) = self.__obje(state.level + 1, state)
-            if filename == "":
-                self.__add_msg(_("Filename omitted"), line, state)
-            if form == "":
-                self.__add_msg(_("Form omitted"), line, state)
-            self.build_media(state.family, form, filename, title, note)
+        self.__obje(line, state, state.family)
 
     def __family_comm(self, line, state):
         """
@@ -5222,30 +5212,118 @@ class GedcomParser(UpdateCallback):
         attr.set_value(line.data)
         state.family.add_attribute(attr)
 
-    def __obje(self, level, state):
+    def __obje(self, line, state, pri_obj):
         """
+       Embedded form
+
+          n OBJE @<XREF:OBJE>@ {1:1}
+          +1 _PRIM <Y/N>       {0:1}                # Indicates primary photo
+
+        Linked form
+
           n  OBJE {1:1}
-          +1 FORM <MULTIMEDIA_FORMAT> {1:1}
+          +1 FORM <MULTIMEDIA_FORMAT> {1:1}         # v5.5 layout
           +1 TITL <DESCRIPTIVE_TITLE> {0:1}
-          +1 FILE <MULTIMEDIA_FILE_REFERENCE> {1:1}
+          +1 FILE <MULTIMEDIA_FILE_REFERENCE> {1:1} # v5.5.1 allows multiple
+            +2 FORM <MULTIMEDIA_FORMAT> {1:1}       # v5.5.1 layout
+              +3 MEDI <SOURCE_MEDIA_TYPE> {0:1}     # v5.5.1 layout
           +1 <<NOTE_STRUCTURE>> {0:M}
+          +1 _PRIM <Y/N>       {0:1}                # Indicates primary photo
 
         @param line: The current line in GedLine format
         @type line: GedLine
         @param state: The current state
         @type state: CurrentState
+        @param pri_obj: The Primary object to which this is attached
+        @type state: Person # or Family, or Source etc.
         """
+        if line.data and line.data[0] == '@':
+            # Reference to a named multimedia object defined elsewhere
+            gramps_id = self.oid_map[line.data]
+            handle = self.__find_media_handle(gramps_id)
+            # check to see if this is a primary photo
+            line = self.__chk_subordinate(state.level+1, state, TOKEN__PRIM)
+            if line and line.data == 'Y':
+                state.photo = handle
+            oref = MediaRef()
+            oref.set_reference_handle(handle)
+            pri_obj.add_media_reference(oref)
+            return
+        #
+        # The remainder of this code is similar in concept to __parse_obje
+        # except that it combines references to the same media file by
+        # comparing path names.  If they are the same, then only the first
+        # is kept.  This does mean that if there are different notes etc. on a
+        # later OBJE, they will be lost.
+        #
         sub_state = CurrentState()
         sub_state.form = ""
+        sub_state.attr = None
         sub_state.filename = ""
         sub_state.title = ""
         sub_state.note = ""
-        sub_state.level = level
+        sub_state.level = state.level + 1
+        sub_state.prim = ""
 
         self.__parse_level(sub_state, self.media_parse_tbl, self.__ignore)
         state.msg += sub_state.msg
-        return (sub_state.form, sub_state.filename, sub_state.title,
-                sub_state.note)
+        if sub_state.filename == "":
+            self.__add_msg(_("Filename omitted"), line, state)
+        # The following lines are commented out because Gramps is NOT a
+        # Gedcom validator!
+        # if sub_state.form == "":
+        #     self.__add_msg(_("Form omitted"), line, state)
+
+        # The following code that detects URL is an older v5.5 usage; the
+        # modern option is to use the EMAIL tag.
+        if isinstance(sub_state.form, str) and sub_state.form == "url":
+            url = Url()
+            url.set_path(sub_state.filename)
+            url.set_description(sub_state.title)
+            url.set_type(UrlType.WEB_HOME)
+            pri_obj.add_url(url)
+        else:
+            # to allow import of references to URLs (especially for import from
+            # geni.com), do not try to find the file if it is blatently a URL
+            res = urlparse(sub_state.filename)
+            if sub_state.filename != '' and \
+                    (res.scheme == '' or res.scheme == 'file'):
+                (valid, path) = self.__find_file(sub_state.filename,
+                                                 self.dir_path)
+                if not valid:
+                    self.__add_msg(_("Could not import %s") %
+                                   sub_state.filename, line, state)
+            else:
+                path = sub_state.filename
+            # Multiple references to the same media silently drops the later
+            # ones, even if title, notes etc.  are different
+            photo_handle = self.media_map.get(path)
+            if photo_handle is None:
+                photo = Media()
+                photo.set_path(path)
+                if sub_state.title:
+                    photo.set_description(sub_state.title)
+                else:
+                    photo.set_description(path)
+                full_path = os.path.abspath(path)
+                if os.path.isfile(full_path):
+                    photo.set_mime_type(get_type(full_path))
+                else:
+                    photo.set_mime_type(MIME_MAP.get(sub_state.form,
+                                                     'unknown'))
+                if sub_state.note:
+                    photo.add_note(sub_state.note)
+                if sub_state.attr:
+                    photo.attribute_list.append(sub_state.attr)
+                self.dbase.add_media(photo, self.trans)
+                self.media_map[path] = photo.handle
+            else:
+                photo = self.dbase.get_media_from_handle(photo_handle)
+            if sub_state.prim == "Y":
+                state.photo = photo.handle
+            oref = MediaRef()
+            oref.set_reference_handle(photo.handle)
+            pri_obj.add_media_reference(oref)
 
     def __media_ref_form(self, line, state):
         """
@@ -5256,7 +5334,22 @@ class GedcomParser(UpdateCallback):
         @param state: The current state
         @type state: CurrentState
         """
-        state.form = line.data
+        state.form = line.data.lower()
+
+    def __media_ref_medi(self, line, state):
+        """
+          +1 MEDI <SOURCE_MEDIA_TYPE> {0:1}   (Photo, Audio, Book, etc.)
+
+        @param line: The current line in GedLine format
+        @type line: GedLine
+        @param state: The current state
+        @type state: CurrentState
+        """
+        state.attr = Attribute()
+        mtype = MEDIA_MAP.get(line.data.lower(),
+                              (SourceMediaType.CUSTOM, line.data))
+        state.attr.set_type(_('Media-Type'))
+        state.attr.set_value(str(SourceMediaType(mtype)))
 
     def __media_ref_titl(self, line, state):
         """
@@ -5278,6 +5371,11 @@ class GedcomParser(UpdateCallback):
         @param state: The current state
         @type state: CurrentState
         """
+        if state.filename != "":
+            self.__add_msg(_("Multiple FILE in a single OBJE ignored"),
+                           line, state)
+            self.__skip_subordinate_levels(state.level+1, state)
+            return
         state.filename = line.data
 
     def __media_ref_note(self, line, state):
@@ -5322,6 +5420,19 @@ class GedcomParser(UpdateCallback):
 
                 self.dbase.commit_note(new_note, self.trans, new_note.change)
                 state.note = new_note.get_handle()
+
+    def __media_ref_prim(self, line, state):
+        """
+          +1 _PRIM <Y/N> {0:1}
+
+        Indicates that this OBJE is the primary photo.
+
+        @param line: The current line in GedLine format
+        @type line: GedLine
+        @param state: The current state
+        @type state: CurrentState
+        """
+        state.prim = line.data
 
     def __family_adopt(self, line, state):
         """
@@ -5380,21 +5491,7 @@ class GedcomParser(UpdateCallback):
         @param state: The current state
         @type state: CurrentState
         """
-        if line.data and line.data[0] == '@':
-            # Reference to a named multimedia object defined elsewhere
-            gramps_id = self.oid_map[line.data]
-
-            handle = self.__find_media_handle(gramps_id)
-            ref = MediaRef()
-            ref.set_reference_handle(handle)
-            state.event.add_media_reference(ref)
-        else:
-            (form, filename, title, note) = self.__obje(state.level + 1, state)
-            if filename == "":
-                self.__add_msg(_("Filename omitted"), line, state)
-            if form == "":
-                self.__add_msg(_("Form omitted"), line, state)
-            self.build_media(state.event, form, filename, title, note)
+        self.__obje(line, state, state.event)
 
     def __event_type(self, line, state):
         """
@@ -5513,22 +5610,7 @@ class GedcomParser(UpdateCallback):
         @param state: The current state
         @type state: CurrentState
         """
-        if line.data and line.data[0] == '@':
-            # Reference to a named multimedia object defined elsewhere
-            gramps_id = self.oid_map[line.data]
-
-            handle = self.__find_media_handle(gramps_id)
-            ref = MediaRef()
-            ref.set_reference_handle(handle)
-            state.place.add_media_reference(ref)
-        else:
-            # FIXME this should probably be level+1
-            (form, filename, title, note) = self.__obje(state.level, state)
-            if filename == "":
-                self.__add_msg(_("Filename omitted"), line, state)
-            if form == "":
-                self.__add_msg(_("Form omitted"), line, state)
-            self.build_media(state.place, form, filename, title, note)
+        self.__obje(line, state, state.place)
 
     def __event_place_sour(self, line, state):
         """
@@ -6200,21 +6282,7 @@ class GedcomParser(UpdateCallback):
         @param state: The current state
         @type state: CurrentState
         """
-        if line.data and line.data[0] == '@':
-            # Reference to a named multimedia object defined elsewhere
-            gramps_id = self.oid_map[line.data]
-
-            handle = self.__find_media_handle(gramps_id)
-            ref = MediaRef()
-            ref.set_reference_handle(handle)
-            state.citation.add_media_reference(ref)
-        else:
-            (form, filename, title, note) = self.__obje(state.level+1, state)
-            if filename == "":
-                self.__add_msg(_("Filename omitted"), line, state)
-            if form == "":
-                self.__add_msg(_("Form omitted"), line, state)
-            self.build_media(state.citation, form, filename, title, note)
+        self.__obje(line, state, state.citation)
 
     def __citation_refn(self, line, state):
         """
@@ -6353,21 +6421,7 @@ class GedcomParser(UpdateCallback):
         @param state: The current state
         @type state: CurrentState
         """
-        if line.data and line.data[0] == '@':
-            # Reference to a named multimedia object defined elsewhere
-            gramps_id = self.oid_map[line.data]
-
-            handle = self.__find_media_handle(gramps_id)
-            ref = MediaRef()
-            ref.set_reference_handle(handle)
-            state.source.add_media_reference(ref)
-        else:
-            (form, filename, title, note) = self.__obje(state.level+1, state)
-            if filename == "":
-                self.__add_msg(_("Filename omitted"), line, state)
-            if form == "":
-                self.__add_msg(_("Form omitted"), line, state)
-            self.build_media(state.source, form, filename, title, note)
+        self.__obje(line, state, state.source)
 
     def __source_chan(self, line, state):
         """
@@ -6594,6 +6648,8 @@ class GedcomParser(UpdateCallback):
 
         self.__parse_level(state, self.obje_func, self.__undefined)
 
+        if state.media.get_path() == "":
+            self.__add_msg(_("Filename omitted"), line, state)
         # Add the default reference if no source has found
         self.__add_default_source(media)
 
@@ -6612,9 +6668,7 @@ class GedcomParser(UpdateCallback):
         @param state: The current state
         @type state: CurrentState
         """
-        # TODO: FIX THIS!!!
-        state.media_form = line.data.strip()
-        self.__skip_subordinate_levels(state.level+1, state)
+        state.form = line.data.lower().strip()
 
     def __obje_file(self, line, state):
         """
@@ -6633,7 +6687,7 @@ class GedcomParser(UpdateCallback):
         res = urlparse(line.data)
         if line.data != '' and (res.scheme == '' or res.scheme == 'file'):
             (file_ok, filename) = self.__find_file(line.data, self.dir_path)
-            if state.media != "URL":
+            if state.form != "url":  # Might not work if FORM doesn't precede FILE
                 if not file_ok:
                     self.__add_msg(_("Could not import %s") % filename, line,
                                    state)
@@ -6699,16 +6753,6 @@ class GedcomParser(UpdateCallback):
         """
         state.media.add_citation(self.handle_source(line, state.level, state))
 
-    def __obje_blob(self, line, state):
-        """
-        @param line: The current line in GedLine format
-        @type line: GedLine
-        @param state: The current state
-        @type state: CurrentState
-        """
-        self.__add_msg(_("BLOB ignored"), line, state)
-        self.__skip_subordinate_levels(state.level+1, state)
-
     def __obje_refn(self, line, state):
         """
         @param line: The current line in GedLine format
@@ -6720,29 +6764,34 @@ class GedcomParser(UpdateCallback):
         attr.set_type(line.token_text)          # Atrribute : REFN
         attr.set_value(line.data)
         # if there is a subsequent TYPE, we add it as a note to the attribute
-        while True:
-            line = self.__get_next_line()
-            if self.__level_is_finished(line, state.level+1):
-                break
-            elif line.token == TOKEN_TYPE:
-                new_note = Note(line.data)
-                new_note.set_gramps_id(self.nid_map[""])
-                new_note.set_handle(create_id())
-                new_note.set_type('REFN-TYPE')
-                self.dbase.commit_note(new_note, self.trans, new_note.change)
-                attr.add_note(new_note.get_handle())
+        line = self.__chk_subordinate(state.level+1, state, TOKEN_TYPE)
+        if line:
+            new_note = Note(line.data)
+            new_note.set_gramps_id(self.nid_map[""])
+            new_note.set_handle(create_id())
+            new_note.set_type('REFN-TYPE')
+            self.dbase.commit_note(new_note, self.trans, new_note.change)
+            attr.add_note(new_note.get_handle())
         state.media.attribute_list.append(attr)
 
     def __obje_type(self, line, state):
         """
+        +1 FILE <MULTIMEDIA_FILE_REFN> {1:M}
+          +2 FORM <MULTIMEDIA_FORMAT> {1:1}
+            +3 TYPE <SOURCE_MEDIA_TYPE> {0:1}   # v5.5.1
+
+        Source_Media_type is one of (Photo, Audio, Book, etc.)
+
         @param line: The current line in GedLine format
         @type line: GedLine
         @param state: The current state
         @type state: CurrentState
         """
         attr = Attribute()
+        mtype = MEDIA_MAP.get(line.data.lower(),
+                              (SourceMediaType.CUSTOM, line.data))
         attr.set_type(_('Media-Type'))
-        attr.set_value(line.data)       # (Photo, Audio, Book, etc.)
+        attr.set_value(str(SourceMediaType(mtype)))
         state.media.attribute_list.append(attr)
 
     def __obje_rin(self, line, state):
@@ -7675,45 +7724,6 @@ class GedcomParser(UpdateCallback):
                 # too far in the future, this gives OverflowError.
                 pass
 
-    def build_media(self, obj, form, filename, title, note):
-        if isinstance(form, str) and form.lower() == "url":
-            url = Url()
-            url.set_path(filename)
-            url.set_description(title)
-            url.set_type(UrlType.WEB_HOME)
-            obj.add_url(url)
-        else:
-            # to allow import of references to URLs (especially for import from
-            # geni.com), do not try to find the files if they are blatently URLs
-            res = urlparse(filename)
-            if filename != '' and (res.scheme == '' or res.scheme == 'file'):
-                (valid, path) = self.__find_file(filename, self.dir_path)
-                if not valid:
-                    self.__add_msg(_("Could not import %s") % filename)
-            else:
-                path = filename
-            # Multiple references to the same media silently drops the later
-            # ones, even if title, notes etc.  are different
-            photo_handle = self.media_map.get(path)
-            if photo_handle is None:
-                photo = Media()
-                photo.set_path(path)
-                photo.set_description(title)
-                full_path = os.path.abspath(path)
-                if os.path.isfile(full_path):
-                    photo.set_mime_type(get_type(full_path))
-                else:
-                    photo.set_mime_type(MIME_MAP.get(form.lower(), 'unknown'))
-                if note:
-                    photo.add_note(note)
-                self.dbase.add_media(photo, self.trans)
-                self.media_map[path] = photo.handle
-            else:
-                photo = self.dbase.get_media_from_handle(photo_handle)
-            oref = MediaRef()
-            oref.set_reference_handle(photo.handle)
-            obj.add_media_reference(oref)
-
     def __build_event_pair(self, state, event_type, event_map, description):
         """
         n TYPE <EVENT_DESCRIPTOR> {0:1} p.*
@@ -7783,26 +7793,42 @@ class GedcomParser(UpdateCallback):
     def __do_photo(self, state):
         """
         Choose the primary photo from the list of media present for this
-        person.  Supports FTM _PHOTO feature.
+        person.  Supports FTM _PHOTO. and others _PRIM feature.
           0 INDI
           +1 _PHOTO @<XREF:OBJE>@ {1:1}
+
+          0 INDI
+            +1 OBJE @<XREF:OBJE>@
+              +2 _PRIM <Y/N>
+
+          0 INDI
+            +1 OBJE
+              +2 FILE primary_photo.jpg
+              +2 _PRIM <Y/N>
+
+        For the _PHOTO varient, state.photo contains the XREF ('@M1@').
+        For the _PRIM varients, state.photo contains the handle.
         Since Gramps currently uses the first media in the list as the
         primary, find the primary photo if already in the list, if present,
         move to beginning.  If not present, add at the beginning.
         This is run after all of the person processing is complete but before
         committing the person.
         """
-        if state.photo:
+        if state.photo.startswith('@'):
             gramps_id = self.oid_map[state.photo]
             handle = self.__find_media_handle(gramps_id)
-            for mref in state.person.media_list:
-                if handle == mref.ref:
-                    state.person.media_list.remove(mref)
-                    state.person.media_list.insert(0, mref)
-                    return
-            mref = MediaRef()
-            mref.set_reference_handle(handle)
-            state.person.media_list.insert(0, mref)
+        elif state.photo:
+            handle = state.photo
+        else:
+            return
+        for mref in state.person.media_list:
+            if handle == mref.ref:
+                state.person.media_list.remove(mref)
+                state.person.media_list.insert(0, mref)
+                return
+        mref = MediaRef()
+        mref.set_reference_handle(handle)
+        state.person.media_list.insert(0, mref)
 
     def __extract_temple(self, line):
         def get_code(code):


### PR DESCRIPTION
This PR supports a variety of changes to Media support, mostly having to do with embedded OBJE tag lines.
I intend to commit this myself (with new commit privileges), but will wait for several days in case there are comments.

- Support v5.5.1 OBJE/FORM/MEDI tag on embedded OBJE
- Change OBJE/BLOB tag from "not understood" to "Recognized but not supported"
- Detect multiple FILEs in a single embedded OBJE >> v5.5.1 feature not supported
- Changed OBJE/FORM/TYPE to internationalize the data (same as SourceMediaType)
- Corrected XREF/OBJE/FORM to correctly save and use its value (was a typo in original code) and to accept any case.
- Added test for missing title on embedded OBJE, and use filename if missing.
- Added test for missing FILE on XREF style OBJE, with warning like the embedded OBJE.
- Support _PRIM tag to handle primary photo for Legacy Family Tree, Ancestral Quest, Family Origins, MyHeritage Family Tree Builder, and others.
- Some of these changes would have required making patches to six different nearly identical pieces of code.  So I combined the similar methods and the two functions they called into a single function.
- Added function to check for a subordinate line with a specific tag, and report unexpected lines as not understood.  Used that function in OBJE/REFN/TYPE and OBJE/_PRIM processing.
- Test files imp_FTM_PHOTO.ged and imp_MediaTest.ged have been updated to include testing on these changes.
