### PR TITLE
bug 9549 Chinese characters are not rendered properly in pdf reports

### DIFF
--- a/gramps/gen/config.py
+++ b/gramps/gen/config.py
@@ -294,6 +294,7 @@ register('paths.quick-backup-filename',
 register('preferences.date-format', 0)
 register('preferences.calendar-format-report', 0)
 register('preferences.cprefix', 'C%04d')
+register('preferences.alternate-fonthandler', False)
 register('preferences.default-source', False)
 register('preferences.tag-on-import', False)
 register('preferences.tag-on-import-format', _("Imported %Y/%m/%d %H:%M:%S"))

--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -46,6 +46,7 @@ from .gen.const import APP_GRAMPS, USER_DIRLIST, HOME_DIR
 from .gen.constfunc import mac
 from .version import VERSION_TUPLE
 from .gen.constfunc import win, get_env_var
+from gramps.gen.config import config
 
 #-------------------------------------------------------------------------
 #
@@ -473,6 +474,9 @@ def main():
         resource_path, filename = os.path.split(os.path.abspath(__file__))
         resource_path, dirname = os.path.split(resource_path)
         os.environ['GRAMPS_RESOURCES'] = resource_path
+    if win() and ('PANGOCAIRO_BACKEND' not in os.environ) and \
+            config.get('preferences.alternate-fonthandler'):
+        os.environ['PANGOCAIRO_BACKEND'] = "fontconfig"
     errors = run()
     if errors and isinstance(errors, list):
         for error in errors:

--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -46,7 +46,7 @@ from .gen.const import APP_GRAMPS, USER_DIRLIST, HOME_DIR
 from .gen.constfunc import mac
 from .version import VERSION_TUPLE
 from .gen.constfunc import win, get_env_var
-from gramps.gen.config import config
+from .gen.config import config
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -66,6 +66,7 @@ from gramps.gen.plug.utils import available_updates
 from .plug import PluginWindows
 from gramps.gen.errors import WindowActiveError
 from .spell import HAVE_GTKSPELL
+from gramps.gen.constfunc import win
 _ = glocale.translation.gettext
 
 #-------------------------------------------------------------------------
@@ -1291,6 +1292,12 @@ class GrampsPreferences(ConfigureDialog):
         grid.set_row_spacing(6)
 
         current_line = 0
+        if win():
+            self.add_checkbox(grid,
+                    _('Use alternate Font handler for GUI and Reports (requires restart)'),
+                    current_line, 'preferences.alternate-fonthandler')
+
+            current_line += 1
         self.add_checkbox(grid,
                 _('Add default source on GEDCOM import'),
                 current_line, 'preferences.default-source')

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -1294,7 +1294,8 @@ class GrampsPreferences(ConfigureDialog):
         current_line = 0
         if win():
             self.add_checkbox(grid,
-                    _('Use alternate Font handler for GUI and Reports (requires restart)'),
+                    _('Use alternate Font handler for GUI and Reports '
+                      '(requires restart)'),
                     current_line, 'preferences.alternate-fonthandler')
 
             current_line += 1


### PR DESCRIPTION
This PR allows the user to change the way fonts are handled for the GUI and report backends on Windows systems.  The default rendering uses a PANGOCAIRO_BACKEND called 'win32'.  That code seems to use some older windows api for font selection, and doesn't seem to do a very good job with far eastern Unicode characters for the fonts typically installed in western Windows machines.
By changing the backend to 'fontconfig', the results are much better.  Whoever coded that up did a significantly better job in this area.  I believe that 'fontconfig' is the usual default for Linux machines, or at least on my Ubuntu.
See bug 9549 for some uploaded pdf files showing the difference.  Also should clear bugs 7574, 9240, 9611, and possibly a few others, when the user utilizes the option.

None of this has any effect on Linux systems ('if win()' around all code).

This adds a new Preferences General item 'Use alternate Font handler for GUI and Reports (requires restart)' that appears ONLY on Windows systems.  It also adds the 'preferences.alternate-fonthandler' config item for use by the CLI.