### PR TITLE
Support for FTM and others Custom Gedcom Event Tags on import

### DIFF
--- a/data/tests/imp_CustTags.ged
+++ b/data/tests/imp_CustTags.ged
@@ -1,0 +1,82 @@
+0 HEAD
+1 SOUR FTM
+2 VERS Family Tree Maker (22.0.0.1410)
+2 NAME Family Tree Maker for Windows
+2 CORP Ancestry.com
+3 ADDR 360 W 4800 N
+4 CONT Provo, UT 84604
+1 DEST GED55
+1 DATE 01 MAR 2016
+1 CHAR UTF-8
+1 FILE D:\Family Tree Maker\imp_FTM_LINK.ged
+1 SUBM @SUBM@
+1 GEDC
+2 VERS 5.5
+2 FORM LINEAGE-LINKED
+0 @SUBM@ SUBM
+1 NAME The Subm /Tester/
+1 ADDR 123 Main St., Winslow, PA, 12345
+2 ADR1 123 Main St.
+2 CITY Winslow
+2 STAE PA
+2 POST 12345
+0 @I0@ INDI
+1 NAME The /Tester/
+2 SOUR @S6@
+3 PAGE 777, record for The Tester
+3 _JUST Because it’s good
+1 BIRT
+2 DATE 29 DEC 1954
+2 PLAC 123 High St, Cleveland, Cuyahoga, Ohio, USA, 44140
+3 FORM Street, City, County, State, Country, Zip code
+1 _CIRC
+2 DATE 11 JAN 1955
+2 PLAC 456 Main St, Cleveland, Cuyahoga, Ohio, USA, 44140
+3 FORM Street, City, County, State, Country, Zip code
+1 _ELEC Mayor
+2 TYPE Small town
+2 DATE 1980
+2 PLAC Littetown, Smallcounty, Ohio, USA
+1 FAMS @F4211@
+1 _XYZ He should keep his zipper closed
+2 DATE 1979
+1 EVEN Celebration
+2 TYPE Independence Day
+2 DATE 4 JUL 1981
+0 @I1@ INDI
+1 NAME Mrs /Tester/
+1 RESI
+2 DATE 30 DEC 1954
+2 ADDR 123 Main St., Winslow, PA, 12345
+3 ADR1 123 Main St.
+3 CITY Winslow
+3 STAE PA
+3 POST 12345
+2 NOTE Address as event is legal, with PHON,FAX,EMAIL,WWW
+1 FAMS @F4211@
+0 @I2@ INDI
+1 NAME Tom /Tester/
+1 FAMC @F4211@
+0 @F4211@ FAM
+1 HUSB @I0@
+1 WIFE @I1@
+1 CHIL @I2@
+2 _FREL Natural
+2 _MREL Natural
+1 MARR
+2 DATE 1970
+2 PLAC St Rafaels Church, Bay Village, Cuyahoga, Ohio, USA
+1 _INFIDELITY
+2 DATE 1979
+2 PLAC Of Ill Repute, Shaker Heights, Ohio, USA
+1 _SEPR
+2 DATE 1980
+2 PLAC Cuyahoga, OHIO, USA
+0 @S6@ SOUR
+1 TITL Ohio Births, 1958-2002
+1 REPO @R1@
+0 @R1@ REPO
+1 NAME Testers Repository
+1 ADDR 123 High St., OSF village, CA, USA
+1 NOTE Testers Repository Record
+0 TRLR

--- a/data/tests/imp_CustTags.gramps
+++ b/data/tests/imp_CustTags.gramps
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE database PUBLIC "-//Gramps//DTD Gramps XML 1.7.1//EN"
+"http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
+<database xmlns="http://gramps-project.org/xml/1.7.1/">
+  <header>
+    <created date="2016-08-02" version="5.0.0-alpha1"/>
+    <researcher>
+      <resname>The Subm /Tester/</resname>
+      <resaddr>123 Main St.</resaddr>
+      <rescity>Winslow</rescity>
+      <resstate>PA</resstate>
+      <respostal>12345</respostal>
+    </researcher>
+  </header>
+  <events>
+    <event handle="_0000000500000005" change="1470145667" id="E0000">
+      <type>Birth</type>
+      <dateval val="1954-12-29"/>
+      <place hlink="_0000000600000006"/>
+    </event>
+    <event handle="_0000000700000007" change="1470145667" id="E0001">
+      <type>Circumcision</type>
+      <dateval val="1955-01-11"/>
+      <place hlink="_0000000800000008"/>
+    </event>
+    <event handle="_0000000900000009" change="1470145667" id="E0002">
+      <type>Elected</type>
+      <dateval val="1980"/>
+      <place hlink="_0000000a0000000a"/>
+      <description>Small town</description>
+    </event>
+    <event handle="_0000000c0000000c" change="1470145667" id="E0003">
+      <type>_XYZ</type>
+      <dateval val="1979"/>
+      <description>He should keep his zipper closed</description>
+    </event>
+    <event handle="_0000000d0000000d" change="1470145667" id="E0004">
+      <type>Independence Day</type>
+      <dateval val="1981-07-04"/>
+      <description>Celebration</description>
+    </event>
+    <event handle="_0000000f0000000f" change="1470145667" id="E0005">
+      <type>Residence</type>
+      <dateval val="1954-12-30"/>
+      <place hlink="_0000001100000011"/>
+      <noteref hlink="_0000001000000010"/>
+    </event>
+    <event handle="_0000001300000013" change="1470145667" id="E0006">
+      <type>Marriage</type>
+      <dateval val="1970"/>
+      <place hlink="_0000001400000014"/>
+    </event>
+    <event handle="_0000001500000015" change="1470145667" id="E0007">
+      <type>_INFIDELITY</type>
+      <dateval val="1979"/>
+      <place hlink="_0000001600000016"/>
+    </event>
+    <event handle="_0000001700000017" change="1470145667" id="E0008">
+      <type>Separation</type>
+      <dateval val="1980"/>
+      <place hlink="_0000001800000018"/>
+    </event>
+  </events>
+  <people>
+    <person handle="_0000000100000001" change="1470145667" id="I0000">
+      <gender>U</gender>
+      <name type="Birth Name">
+        <first>The</first>
+        <surname>Tester</surname>
+        <citationref hlink="_0000000400000004"/>
+      </name>
+      <eventref hlink="_0000000500000005" role="Primary"/>
+      <eventref hlink="_0000000700000007" role="Primary"/>
+      <eventref hlink="_0000000900000009" role="Primary"/>
+      <eventref hlink="_0000000c0000000c" role="Primary"/>
+      <eventref hlink="_0000000d0000000d" role="Primary"/>
+      <parentin hlink="_0000000b0000000b"/>
+    </person>
+    <person handle="_0000000e0000000e" change="1470145667" id="I0001">
+      <gender>U</gender>
+      <name type="Birth Name">
+        <first>Mrs</first>
+        <surname>Tester</surname>
+      </name>
+      <eventref hlink="_0000000f0000000f" role="Primary"/>
+      <parentin hlink="_0000000b0000000b"/>
+    </person>
+    <person handle="_0000001200000012" change="1470145667" id="I0002">
+      <gender>U</gender>
+      <name type="Birth Name">
+        <first>Tom</first>
+        <surname>Tester</surname>
+      </name>
+      <childof hlink="_0000000b0000000b"/>
+    </person>
+  </people>
+  <families>
+    <family handle="_0000000b0000000b" change="1470145667" id="F4211">
+      <rel type="Married"/>
+      <father hlink="_0000000100000001"/>
+      <mother hlink="_0000000e0000000e"/>
+      <eventref hlink="_0000001300000013" role="Family"/>
+      <eventref hlink="_0000001500000015" role="Family"/>
+      <eventref hlink="_0000001700000017" role="Family"/>
+      <childref hlink="_0000001200000012"/>
+    </family>
+  </families>
+  <citations>
+    <citation handle="_0000000400000004" change="1470145667" id="C0000">
+      <page>777, record for The Tester</page>
+      <confidence>2</confidence>
+      <noteref hlink="_0000000300000003"/>
+      <sourceref hlink="_0000000200000002"/>
+    </citation>
+  </citations>
+  <sources>
+    <source handle="_0000000200000002" change="1470145667" id="S0006">
+      <stitle>Ohio Births, 1958-2002</stitle>
+      <reporef hlink="_0000001900000019" medium="Book"/>
+    </source>
+  </sources>
+  <places>
+    <placeobj handle="_0000000600000006" change="1470145667" id="P0000" type="Street">
+      <ptitle>123 High St, Cleveland, Cuyahoga, Ohio, USA, 44140</ptitle>
+      <code>44140</code>
+      <pname value="123 High St"/>
+      <placeref hlink="_0000001e0000001e"/>
+    </placeobj>
+    <placeobj handle="_0000000800000008" change="1470145667" id="P0001" type="Street">
+      <ptitle>456 Main St, Cleveland, Cuyahoga, Ohio, USA, 44140</ptitle>
+      <code>44140</code>
+      <pname value="456 Main St"/>
+      <placeref hlink="_0000001e0000001e"/>
+    </placeobj>
+    <placeobj handle="_0000000a0000000a" change="1470145667" id="P0002" type="Unknown">
+      <ptitle>Littetown, Smallcounty, Ohio, USA</ptitle>
+      <pname value="Littetown, Smallcounty, Ohio, USA"/>
+    </placeobj>
+    <placeobj handle="_0000001100000011" change="1470145667" id="P0003" type="Address">
+      <ptitle>123 Main St., Winslow, PA, 12345</ptitle>
+      <pname value="123 Main St., Winslow, PA, 12345"/>
+      <location street="123 Main St." city="Winslow" state="PA" postal="12345"/>
+    </placeobj>
+    <placeobj handle="_0000001400000014" change="1470145667" id="P0004" type="Unknown">
+      <ptitle>St Rafaels Church, Bay Village, Cuyahoga, Ohio, USA</ptitle>
+      <pname value="St Rafaels Church, Bay Village, Cuyahoga, Ohio, USA"/>
+    </placeobj>
+    <placeobj handle="_0000001600000016" change="1470145667" id="P0005" type="Unknown">
+      <ptitle>Of Ill Repute, Shaker Heights, Ohio, USA</ptitle>
+      <pname value="Of Ill Repute, Shaker Heights, Ohio, USA"/>
+    </placeobj>
+    <placeobj handle="_0000001800000018" change="1470145667" id="P0006" type="Unknown">
+      <ptitle>Cuyahoga, OHIO, USA</ptitle>
+      <pname value="Cuyahoga, OHIO, USA"/>
+    </placeobj>
+    <placeobj handle="_0000001b0000001b" change="1470145667" id="P0007" type="Country">
+      <ptitle>USA</ptitle>
+      <pname value="USA"/>
+    </placeobj>
+    <placeobj handle="_0000001c0000001c" change="1470145667" id="P0008" type="State">
+      <ptitle>Ohio, USA</ptitle>
+      <pname value="Ohio"/>
+      <placeref hlink="_0000001b0000001b"/>
+    </placeobj>
+    <placeobj handle="_0000001d0000001d" change="1470145667" id="P0009" type="County">
+      <ptitle>Cuyahoga, Ohio, USA</ptitle>
+      <pname value="Cuyahoga"/>
+      <placeref hlink="_0000001c0000001c"/>
+    </placeobj>
+    <placeobj handle="_0000001e0000001e" change="1470145667" id="P0010" type="City">
+      <ptitle>Cleveland, Cuyahoga, Ohio, USA</ptitle>
+      <pname value="Cleveland"/>
+      <placeref hlink="_0000001d0000001d"/>
+    </placeobj>
+  </places>
+  <repositories>
+    <repository handle="_0000001900000019" change="1470145667" id="R0001">
+      <rname>Testers Repository</rname>
+      <type>Library</type>
+      <address>
+        <street>123 High St., OSF village, CA, USA</street>
+      </address>
+      <noteref hlink="_0000001a0000001a"/>
+    </repository>
+  </repositories>
+  <notes>
+    <note handle="_0000000300000003" change="1470145667" id="N0000" type="Citation Justification">
+      <text>Because it’s good</text>
+    </note>
+    <note handle="_0000001000000010" change="1470145667" id="N0001" type="General">
+      <text>Address as event is legal, with PHON,FAX,EMAIL,WWW</text>
+    </note>
+    <note handle="_0000001a0000001a" change="1470145667" id="N0002" type="General">
+      <text>Testers Repository Record</text>
+    </note>
+  </notes>
+</database>

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -270,6 +270,7 @@ TOKEN__FSFTID = 131
 TOKEN__PHOTO = 132
 TOKEN__LINK = 133
 TOKEN__PRIM = 134
+TOKEN__JUST = 135
 
 TOKENS = {
     "HEAD"         : TOKEN_HEAD,    "MEDI"         : TOKEN_MEDI,
@@ -377,6 +378,7 @@ TOKENS = {
     "_MAR"           : TOKEN__MAR,  "_MARN"         : TOKEN__MARN,
     "_ADPN"          : TOKEN__ADPN, "_FSFTID"       : TOKEN__FSFTID,
     "_LINK"          : TOKEN__LINK, "_PHOTO"        : TOKEN__PHOTO,
+    "_JUST"          : TOKEN__JUST,  # FTM Citation Quality Justification
 }
 
 ADOPT_NONE         = 0
@@ -511,7 +513,7 @@ PERSONALCONSTANTEVENTS = {
     EventType.DEGREE           : "_DEG",
     EventType.DIV_FILING       : "DIVF",
     EventType.EDUCATION        : "EDUC",
-    EventType.ELECTED          : "",
+    EventType.ELECTED          : "_ELEC",  # FTM custom tag
     EventType.EMIGRATION       : "EMIG",
     EventType.FIRST_COMMUN     : "FCOM",
     EventType.GRADUATION       : "GRAD",
@@ -563,7 +565,40 @@ LDS_STATUS = {
     "SUBMITTED": LdsOrd.STATUS_SUBMITTED,
     "UNCLEARED": LdsOrd.STATUS_UNCLEARED,
     }
-
+# -------------------------------------------------------------------------
+#
+# Custom event friendly names.  These are non-standard GEDCOM "NEW_TAG"
+# tags that start with an '_' i.e. "_DNA".  FTM has several of these, other
+# programs may have more.  If a tag with this format is encountered it is
+# checked in this table for a "friendly" name translation and thereafter is
+# displayed and exported as such.  If the tag is NOT in this table and not
+# otherwise handled by the code, the tag itself is used for display and
+# export.  For example "_XYZ" is not in the table and will be displayed as
+# "_XYZ" and exported as an EVEN.TYPE=_XYZ
+# As Custom entries, they do not appear in GRAMPS Events add choice unless
+# already imported via GEDCOM.
+#
+# -------------------------------------------------------------------------
+CUSTOMEVENTTAGS = {
+    "_CIRC"     : _("Circumcision"),
+    "_COML"     : _("Common Law Marriage"),
+    "_DEST"     : _("Destination"),
+    "_DNA"      : _("DNA"),
+    "_DCAUSE"   : _("Cause of Death"),
+    "_EMPLOY"   : _("Employment"),
+    "_EXCM"     : _("Excommunication"),
+    "_EYC"      : _("Eye Color"),
+    "_FUN"      : _("Funeral"),
+    "_HEIG"     : _("Height"),
+    "_INIT"     : _("Initiatory (LDS)"),
+    "_MILTID"   : _("Military ID"),
+    "_MISN"     : _("Mission (LDS)"),
+    "_NAMS"     : _("Namesake"),
+    "_ORDI"     : _("Ordinance"),
+    "_ORIG"     : _("Origin"),
+    "_SEPR"     : _("Separation"),         # Applies to Families
+    "_WEIG"     : _("Weight"),
+    }
 # table for skipping illegal control chars in GEDCOM import
 # Only 09, 0A, 0D are allowed.
 STRIP_DICT = dict.fromkeys(list(range(9))+list(range(11, 13))+list(range(14, 32)))
@@ -2316,6 +2351,7 @@ class GedcomParser(UpdateCallback):
             TOKEN_RNOTE  : self.__citation_note,
             TOKEN_TEXT   : self.__citation_data_text,
             TOKEN__LINK  : self.__citation_link,
+            TOKEN__JUST  : self.__citation__just,
             }
         self.func_list.append(self.citation_parse_tbl)
 
@@ -3692,10 +3728,12 @@ class GedcomParser(UpdateCallback):
         @type state: CurrentState
         """
         # We can get here when a tag that is not valid in the indi_parse_tbl
-        # parse table is encountered. It is remotely possible that this is
-        # actally a DATE tag, in which case line.data will be a date object, so
-        # we need to convert it back to a string here.
-        event_ref = self.__build_event_pair(state, EventType.CUSTOM,
+        # parse table is encountered. The tag may be of the form "_XXX".  We
+        # try to convert to a friendly name, if fails use the tag itself as
+        # the TYPE in a custom event
+        cust_tag = CUSTOMEVENTTAGS.get(line.token_text, line.token_text)
+        cust_type = EventType((EventType.CUSTOM, cust_tag))
+        event_ref = self.__build_event_pair(state, cust_type,
                                             self.event_parse_tbl,
                                             str(line.data))
         state.person.add_event_ref(event_ref)
@@ -4103,6 +4141,7 @@ class GedcomParser(UpdateCallback):
         addr.set_phone(line.data)
         state.person.add_address(addr)
         self.__skip_subordinate_levels(state.level+1, state)
+
 
     def __person_email(self, line, state):
         """
@@ -5015,11 +5054,20 @@ class GedcomParser(UpdateCallback):
         @param state: The current state
         @type state: CurrentState
         """
+        # We can get here when a tag that is not valid in the family_func
+        # parse table is encountered. The tag may be of the form "_XXX".  We
+        # try to convert to a friendly name, if fails use the tag itself as
+        # the TYPE in a custom event
+        cust_tag = CUSTOMEVENTTAGS.get(line.token_text,line.token_text)
+        cust_type = EventType((EventType.CUSTOM, cust_tag))
         event = Event()
         event_ref = EventRef()
         event_ref.set_role(EventRoleType.FAMILY)
         event.set_gramps_id(self.emapper.find_next())
-        event.set_type(line.data)
+        event.set_type(cust_type)
+        # in case a description ever shows up
+        if line.data and line.data != 'Y':
+            event.set_description(line.data)
         self.dbase.add_event(event, self.trans)
 
         sub_state = CurrentState()
@@ -6267,6 +6315,19 @@ class GedcomParser(UpdateCallback):
         gramps_id = self.dbase.find_next_note_gramps_id()
         note.set_gramps_id(gramps_id)
         note.set_type(NoteType.CITATION)
+        self.dbase.add_note(note, self.trans)
+        state.citation.add_note(note.get_handle())
+
+    def __citation__just(self, line, state):
+        """
+        Not legal GEDCOM - added to support FTM, converts the _JUST tag to a
+        note.  This tag represents the Justification for a source.
+        """
+        note = Note()
+        note.set(line.data)
+        gramps_id = self.dbase.find_next_note_gramps_id()
+        note.set_gramps_id(gramps_id)
+        note.set_type(_("Citation Justification"))
         self.dbase.add_note(note, self.trans)
         state.citation.add_note(note.get_handle())
 


### PR DESCRIPTION
This PR provides support for Custom Event Tags used in Gedcoms.  These tags are typically of the form '_xyz' and are attached to Individuals and Families.  Gedcom allows this type of extension and it has been extensively used by a number of programs.  The PR converts the ones I have been able to identify to 'friendly' names and stores them as Gramps Events with Custom Event types.
The PR also supports tags I have not identified by storing the tag itself ('_xyz') as the Gramps Custom Event type (currently Gramps drops this information).
The '_JUST' tag is also supported, it is Source Citation 'Justification'; I stored this as a comment with the Gramps custom comment name "Citation Justification".

Note: I considered adding these tags to Gramps standard tags lists, but decided not to for now.  

I will commit this myself after a few days unless comments suggest changes.