### PR TITLE
Medi2 42

### DIFF
--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -4104,9 +4104,6 @@ class GedcomParser(UpdateCallback):
         state.person.add_address(addr)
         self.__skip_subordinate_levels(state.level+1, state)
 
-
-
-
     def __person_email(self, line, state):
         """
         O INDI


### PR DESCRIPTION
Same as PR 204 except for Gramps42
This PR supports a variety of changes to Media support, mostly having to do with embedded OBJE tag lines.
I intend to commit this myself (with new commit privileges), but will wait for several days in case there are comments.

Support v5.5.1 OBJE/FORM/MEDI tag on embedded OBJE
Change OBJE/BLOB tag from "not understood" to "Recognized but not supported"
Detect multiple FILEs in a single embedded OBJE >> v5.5.1 feature not supported
Changed OBJE/FORM/TYPE to internationalize the data (same as SourceMediaType)
Corrected XREF/OBJE/FORM to correctly save and use its value (was a typo in original code) and to accept any case.
Added test for missing title on embedded OBJE, and use filename if missing.
Added test for missing FILE on XREF style OBJE, with warning like the embedded OBJE.
Support _PRIM tag to handle primary photo for Legacy Family Tree, Ancestral Quest, Family Origins, MyHeritage Family Tree Builder, and others.
Some of these changes would have required making patches to six different nearly identical pieces of code. So I combined the similar methods and the two functions they called into a single function.
Added function to check for a subordinate line with a specific tag, and report unexpected lines as not understood. Used that function in OBJE/REFN/TYPE and OBJE/_PRIM processing.
Test files imp_FTM_PHOTO.ged and imp_MediaTest.ged have been updated to include testing on these changes.