### PR TITLE
Bug 9665 Gedcom import exception processing fixes

### DIFF
--- a/data/tests/imp_notetest_dfs.ged
+++ b/data/tests/imp_notetest_dfs.ged
@@ -1,0 +1,227 @@
+0 HEAD
+1 SOUR GEDitCOM
+2 NAME GEDitCOM
+2 VERS 2.9.4
+2 CORP RSAC Software
+1 SUBM @SUBMITTER@
+1 SUBN @SUBMISSION@
+1 DEST ANSTFILE
+1 DATE 1 JAN 1998
+2 TIME 13:57:24.80
+1 FILE imp_notetest.ged
+1 COPR Tom Tester 2016
+1 GEDC
+2 VERS 5.5
+2 FORM LINEAGE-LINKED
+1 LANG English
+1 NOTE Header note
+2 TEST Header Note
+1 NOTE
+2 TEST Empty Note
+1 CHAR UTF8
+0 @SUBMISSION@ SUBN
+1 SUBM @SUBMITTER@
+1 FAMF NameOfFamilyFile
+1 NOTE Submission Note
+2 TEST Submission Note
+1 NOTE
+2 TEST Empty Note
+1 TEST submission
+1 NOTE @N2@
+0 @N2@ NOTE Submission xref note
+1 RIN Submission Note RIN
+1 REFN Submission Note REFN
+2 TYPE Submission Note REFN TYPE
+1 SOUR Submission note source
+1 CHAN
+2 DATE 11 Jan 2001
+3 TIME 16:00:06
+1 TEST on XREF Note
+0 @SUBMITTER@ SUBM
+1 NAME John A. Tester
+1 NOTE Submitter Note
+2 TEST Submitter Note
+1 NOTE
+2 TEST Empty Note
+1 TEST Submitter
+1 NOTE @N3@
+0 @N3@ NOTE Submitter xref note
+0 @I1@ INDI
+1 NAME Tom /Tester/
+1 TEST person
+1 SEX M
+1 BIRT
+2 NOTE
+3 NOTE Empty note subordinate (Should be skipped)
+3 TEST Empty Note
+2 NOTE Birth Event note
+3 TEST 123456 Event Note
+2 DATE 15 JUN 1900
+2 ADDR 123 main, Norwalk, Ohio, USA
+3 NOTE Location Note
+4 TEST Location Note
+3 TEST Location
+3 NOTE Location Note 2
+1 DEAT
+2 NOTE
+3 TEST Empty Note
+2 NOTE
+3 TEST Empty Note
+2 NOTE @N5@
+1 FAMS @F1@
+2 NOTE FAMS Note
+3 TEST FAMS Note
+4 TEST skip on FAMS Note
+2 TEST FAMS
+2 NOTE FAMS Note 2
+1 NOTE @N4@
+1 NOTE Tom Tester Note
+2 TEST Person Note
+1 OBJE
+2 FORM URL
+2 TEST media
+2 TITL GEDCOM 5.5 documentation web site
+2 FILE http://homepages.rootsweb.com/~pmcbride/gedcom/55gctoc.htm
+2 NOTE
+3 TEST Empty Note
+2 NOTE Media Note
+3 TEST 123456 Note
+1 RIN 123456 Person
+1 REFN 98765 for PERSON
+2 TEST REFN
+2 TYPE Who knows OBJE REFN TYPE
+1 CHAN
+2 DATE 11 Jan 2001
+3 TIME 16:00:06
+2 NOTE @N6@
+2 NOTE
+3 TEST Empty Note
+1 OBJE @M1@
+0 @N4@ NOTE Tom Tester xref note
+0 @N5@ NOTE Death Event xref note
+0 @N6@ NOTE Media xref note
+1 RIN 123456
+1 REFN 98765
+2 TYPE Who knows REFN TYPE
+1 CHAN
+2 DATE 11 Jan 2001
+3 TIME 16:00:06
+2 NOTE Note on a change on a note!!!
+3 CHAN
+4 DATE 11 Jan 2001
+5 TIME 16:00:06
+0 @M1@ OBJE
+1 FILE photo.jpg
+2 FORM jpeg
+3 TYPE Film
+2 TITL Tom Tester's photo
+1 RIN 123456
+1 REFN 98765
+2 TYPE Who knows REFN TYPE
+1 CHAN
+2 DATE 11 Jan 2001
+3 TIME 16:00:06
+0 @I2@ INDI
+1 NAME Mrs /Tester/
+1 SEX F
+1 BIRT
+2 DATE 15 JUN 1901
+1 DEAT
+2 DATE 5 JUL 1975
+1 FAMS @F1@
+2 NOTE
+3 TEST Empty Note
+2 NOTE Family Spouse reference Note
+3 CHAN
+4 DATE 11 Jan 2001
+5 TIME 16:00:06
+0 @I3@ INDI
+1 NAME Ed /Tester/
+2 NICK Eddie
+2 NOTE
+3 TEST Empty Note
+2 NOTE Name note
+3 CHAN
+4 DATE 11 Jan 2001
+5 TIME 16:00:06
+1 SEX M
+1 BIRT
+2 DATE 15 JUN 1922
+1 DEAT
+2 DATE 5 JUL 1994
+1 FAMC @F1@
+1 BAPL
+2 DATE 5 MAY 0005 B.C.
+2 PLAC Salt Lake City
+3 NOTE Place note
+2 STAT Cleared
+2 TEMP SLAKE
+2 SOUR @SOURCE1@
+2 NOTE @N8@
+1 ASSO @I4@
+2 NOTE Association link note
+3 TEST Accociation note
+3 CHAN
+4 DATE 11 Jan 2001
+5 TIME 16:00:06
+2 NOTE
+3 TEST Empty Note
+0 @I4@ INDI
+1 NAME George /Testee/
+2 NOTE Just for association
+3 CHAN
+4 DATE 11 Jan 2001
+5 TIME 16:00:06
+0 @F1@ FAM
+1 HUSB @I1@
+1 TEST family
+1 WIFE @I2@
+1 CHIL @I3@
+1 SOUR @S1@
+1 NOTE @N7@
+1 NOTE Family note
+2 TEST Family Note
+2 CHAN
+3 DATE 11 Jan 2001
+4 TIME 16:00:06
+1 NOTE
+2 TEST Empty Note
+1 SOUR @S1@
+2 TEST citation
+2 PAGE 42
+2 DATA
+3 DATE 31 DEC 1900
+3 TEST Citation Data
+3 NOTE Citation Data Note
+4 TEST Citation Data Note
+3 TEXT A sample text from a source of this family
+2 QUAY 0
+2 NOTE A note this citation is on the FAMILY record.
+3 CHAN
+4 DATE 11 Jan 2001
+5 TIME 16:00:06
+0 @N7@ NOTE Family xref note
+0 @S1@ SOUR
+1 TITL Note Test file Source: Tester
+1 TEST source
+1 REPO @R1@
+2 NOTE
+3 TEST Empty Note
+2 NOTE A short note about the repository link.
+3 CHAN
+4 DATE 11 Jan 2001
+5 TIME 16:00:06
+1 NOTE
+2 TEST Empty Note
+1 NOTE note embedded in the SOURCE Record
+2 CHAN
+3 DATE 11 Jan 2001
+4 TIME 16:00:06
+0 @N8@ NOTE LDS xref note
+0 @R1@ REPO
+1 NAME The Testers repository
+1 TEST Repo
+1 NOTE
+2 TEST Empty Note
+1 NOTE Repository Note
+0 TRLR

--- a/data/tests/imp_notetest_dfs.gramps
+++ b/data/tests/imp_notetest_dfs.gramps
@@ -1,0 +1,489 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE database PUBLIC "-//Gramps//DTD Gramps XML 1.7.1//EN"
+"http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
+<database xmlns="http://gramps-project.org/xml/1.7.1/">
+  <header>
+    <created date="2016-08-29" version="5.0.0-alpha1"/>
+    <researcher>
+      <resname>John A. Tester</resname>
+    </researcher>
+  </header>
+  <events>
+    <event handle="_0000000c0000000c" change="1472480894" id="E0000">
+      <type>TEST</type>
+      <description>person</description>
+    </event>
+    <event handle="_0000000d0000000d" change="1472480894" id="E0001">
+      <type>Birth</type>
+      <dateval val="1900-06-15"/>
+      <place hlink="_0000001100000011"/>
+      <noteref hlink="_0000000e0000000e"/>
+    </event>
+    <event handle="_0000001200000012" change="1472480894" id="E0002">
+      <type>Death</type>
+      <noteref hlink="_0000001300000013"/>
+    </event>
+    <event handle="_0000001a0000001a" change="1472480894" id="E0003">
+      <type>Who knows OBJE REFN TYPE</type>
+      <description>REFN</description>
+    </event>
+    <event handle="_0000002400000024" change="1472480894" id="E0004">
+      <type>Birth</type>
+      <dateval val="1901-06-15"/>
+    </event>
+    <event handle="_0000002500000025" change="1472480894" id="E0005">
+      <type>Death</type>
+      <dateval val="1975-07-05"/>
+    </event>
+    <event handle="_0000002b0000002b" change="1472480894" id="E0006">
+      <type>Birth</type>
+      <dateval val="1922-06-15"/>
+    </event>
+    <event handle="_0000002c0000002c" change="1472480894" id="E0007">
+      <type>Death</type>
+      <dateval val="1994-07-05"/>
+    </event>
+    <event handle="_0000003800000038" change="1472480894" id="E0008">
+      <type>TEST</type>
+      <description>family</description>
+    </event>
+  </events>
+  <people>
+    <person handle="_0000000b0000000b" change="979250406" id="I0001">
+      <gender>M</gender>
+      <name type="Birth Name">
+        <first>Tom</first>
+        <surname>Tester</surname>
+      </name>
+      <eventref hlink="_0000000c0000000c" role="Primary"/>
+      <eventref hlink="_0000000d0000000d" role="Primary"/>
+      <eventref hlink="_0000001200000012" role="Primary"/>
+      <eventref hlink="_0000001a0000001a" role="Primary"/>
+      <objref hlink="_0000001b0000001b"/>
+      <attribute type="RIN" value="123456 Person"/>
+      <attribute type="REFN" value="98765 for PERSON"/>
+      <url  href="http://homepages.rootsweb.com/~pmcbride/gedcom/55gctoc.htm" type="Web Home" description="GEDCOM 5.5 documentation web site"/>
+      <parentin hlink="_0000001400000014"/>
+      <noteref hlink="_0000001500000015"/>
+      <noteref hlink="_0000001600000016"/>
+      <noteref hlink="_0000001700000017"/>
+      <noteref hlink="_0000001800000018"/>
+      <noteref hlink="_0000001d0000001d"/>
+      <citationref hlink="_0000001c0000001c"/>
+    </person>
+    <person handle="_0000002300000023" change="1472480894" id="I0002">
+      <gender>F</gender>
+      <name type="Birth Name">
+        <first>Mrs</first>
+        <surname>Tester</surname>
+      </name>
+      <eventref hlink="_0000002400000024" role="Primary"/>
+      <eventref hlink="_0000002500000025" role="Primary"/>
+      <parentin hlink="_0000001400000014"/>
+      <noteref hlink="_0000002600000026"/>
+      <noteref hlink="_0000002800000028"/>
+      <citationref hlink="_0000002700000027"/>
+    </person>
+    <person handle="_0000002900000029" change="1472480894" id="I0003">
+      <gender>M</gender>
+      <name type="Birth Name">
+        <first>Ed</first>
+        <surname>Tester</surname>
+        <nick>Eddie</nick>
+        <noteref hlink="_0000002a0000002a"/>
+      </name>
+      <eventref hlink="_0000002b0000002b" role="Primary"/>
+      <eventref hlink="_0000002c0000002c" role="Primary"/>
+      <lds_ord type="baptism">
+        <dateval val="-005-05-05"/>
+        <temple val="SLAKE"/>
+        <place hlink="_0000002d0000002d"/>
+        <noteref hlink="_0000002e0000002e"/>
+        <noteref hlink="_0000003100000031"/>
+        <citationref hlink="_0000003000000030"/>
+      </lds_ord>
+      <childof hlink="_0000001400000014"/>
+      <personref hlink="_0000003200000032" rel="">
+        <noteref hlink="_0000003300000033"/>
+      </personref>
+      <noteref hlink="_0000003500000035"/>
+      <citationref hlink="_0000003400000034"/>
+    </person>
+    <person handle="_0000003200000032" change="1472480894" id="I0004">
+      <gender>U</gender>
+      <name type="Birth Name">
+        <first>George</first>
+        <surname>Testee</surname>
+        <noteref hlink="_0000003600000036"/>
+      </name>
+      <citationref hlink="_0000003700000037"/>
+    </person>
+  </people>
+  <families>
+    <family handle="_0000001400000014" change="1472480894" id="F0001">
+      <rel type="Unknown"/>
+      <father hlink="_0000000b0000000b"/>
+      <mother hlink="_0000002300000023"/>
+      <eventref hlink="_0000003800000038" role="Family"/>
+      <childref hlink="_0000002900000029"/>
+      <noteref hlink="_0000003b0000003b"/>
+      <noteref hlink="_0000003c0000003c"/>
+      <noteref hlink="_0000004100000041"/>
+      <citationref hlink="_0000003a0000003a"/>
+      <citationref hlink="_0000004000000040"/>
+    </family>
+  </families>
+  <citations>
+    <citation handle="_0000001c0000001c" change="1472480894" id="C0000">
+      <confidence>2</confidence>
+      <sourceref hlink="_0000000400000004"/>
+    </citation>
+    <citation handle="_0000002100000021" change="1472480894" id="C0001">
+      <confidence>2</confidence>
+      <sourceref hlink="_0000000400000004"/>
+    </citation>
+    <citation handle="_0000002700000027" change="1472480894" id="C0002">
+      <confidence>2</confidence>
+      <sourceref hlink="_0000000400000004"/>
+    </citation>
+    <citation handle="_0000003000000030" change="1472480894" id="C0003">
+      <confidence>2</confidence>
+      <sourceref hlink="_0000002f0000002f"/>
+    </citation>
+    <citation handle="_0000003400000034" change="1472480894" id="C0004">
+      <confidence>2</confidence>
+      <sourceref hlink="_0000000400000004"/>
+    </citation>
+    <citation handle="_0000003700000037" change="1472480894" id="C0005">
+      <confidence>2</confidence>
+      <sourceref hlink="_0000000400000004"/>
+    </citation>
+    <citation handle="_0000003a0000003a" change="1472480894" id="C0006">
+      <confidence>2</confidence>
+      <sourceref hlink="_0000003900000039"/>
+    </citation>
+    <citation handle="_0000004000000040" change="1472480894" id="C0007">
+      <dateval val="1900-12-31"/>
+      <page>42</page>
+      <confidence>0</confidence>
+      <noteref hlink="_0000003d0000003d"/>
+      <noteref hlink="_0000003e0000003e"/>
+      <noteref hlink="_0000003f0000003f"/>
+      <sourceref hlink="_0000003900000039"/>
+    </citation>
+  </citations>
+  <sources>
+    <source handle="_0000000400000004" change="1472480894" id="S0000">
+      <stitle>Import from imp_notetest.ged</stitle>
+      <spubinfo>Tom Tester 2016</spubinfo>
+      <noteref hlink="_0000000200000002"/>
+      <srcattribute type="Approved system identification" value="GEDitCOM"/>
+      <srcattribute type="Name of software product" value="GEDitCOM"/>
+      <srcattribute type="Version number of software product" value="2.9.4"/>
+      <srcattribute type="Generated By" value="GEDitCOM 2.9.4"/>
+      <srcattribute type="Submission record identifier" value="SUBN"/>
+      <srcattribute type="Creation date and time of GEDCOM" value="1998-01-01 13:57:24.80"/>
+      <srcattribute type="GEDCOM version" value="5.5"/>
+      <srcattribute type="GEDCOM form" value="LINEAGE-LINKED"/>
+      <srcattribute type="Language of GEDCOM text" value="English"/>
+      <srcattribute type="Character set" value="UTF8"/>
+      <srcattribute type="Submission: Submitter" value="@SUBMITTER@"/>
+      <srcattribute type="Submission: Family file" value="NameOfFamilyFile"/>
+      <reporef hlink="_0000000100000001" medium="Unknown"/>
+      <reporef hlink="_0000000800000008" medium="Unknown"/>
+    </source>
+    <source handle="_0000002f0000002f" change="1472480894" id="SOURCE1">
+      <stitle>@SOURCE1@</stitle>
+    </source>
+    <source handle="_0000003900000039" change="1472480894" id="S0001">
+      <stitle>Note Test file Source: Tester</stitle>
+      <noteref hlink="_0000004400000044"/>
+      <noteref hlink="_0000004500000045"/>
+      <reporef hlink="_0000004200000042" medium="Book">
+        <noteref hlink="_0000004300000043"/>
+      </reporef>
+    </source>
+  </sources>
+  <places>
+    <placeobj handle="_0000001100000011" change="1472480894" id="P0000" type="Address">
+      <ptitle>123 main, Norwalk, Ohio, USA</ptitle>
+      <pname value="123 main, Norwalk, Ohio, USA"/>
+      <location street="123 main, Norwalk, Ohio, USA"/>
+      <noteref hlink="_0000000f0000000f"/>
+      <noteref hlink="_0000001000000010"/>
+    </placeobj>
+    <placeobj handle="_0000002d0000002d" change="1472480894" id="P0001" type="Unknown">
+      <ptitle>Salt Lake City</ptitle>
+      <pname value="Salt Lake City"/>
+    </placeobj>
+  </places>
+  <objects>
+    <object handle="_0000001b0000001b" change="979250406" id="M1">
+      <file src="photo.jpg" mime="image/jpeg" description="Tom Tester's photo"/>
+      <attribute type="Media-Type" value="Film"/>
+      <attribute type="RIN" value="123456"/>
+      <attribute type="REFN" value="98765">
+        <noteref hlink="_0000002000000020"/>
+      </attribute>
+      <noteref hlink="_0000002200000022"/>
+      <citationref hlink="_0000002100000021"/>
+    </object>
+  </objects>
+  <repositories>
+    <repository handle="_0000000100000001" change="1472480894" id="R0000">
+      <rname>Business that produced the product: RSAC Software</rname>
+      <type>GEDCOM data</type>
+    </repository>
+    <repository handle="_0000000800000008" change="1472480894" id="R0001">
+      <rname>SUBM (Submitter): (@SUBMITTER@) John A. Tester</rname>
+      <type>GEDCOM data</type>
+      <address>
+      </address>
+      <noteref hlink="_0000000900000009"/>
+    </repository>
+    <repository handle="_0000004200000042" change="1472480894" id="R0002">
+      <rname>The Testers repository</rname>
+      <type>Library</type>
+      <noteref hlink="_0000004600000046"/>
+      <noteref hlink="_0000004700000047"/>
+    </repository>
+  </repositories>
+  <notes>
+    <note handle="_0000000200000002" change="1472480894" id="N0000" type="General">
+      <text>Header note</text>
+    </note>
+    <note handle="_0000000300000003" change="1472480894" id="N0001" type="GEDCOM import">
+      <text>Records not imported into HEAD (header):
+
+Line ignored as not understood                                      Line    18: 2 TEST Header Note
+Empty note ignored                                                  Line    19: 1 NOTE 
+Skipped subordinate line                                            Line    20: 2 TEST Empty Note</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="327"/>
+      </style>
+    </note>
+    <note handle="_0000000500000005" change="1472480894" id="N0002" type="GEDCOM import">
+      <text>Records not imported into Top Level:
+
+Line ignored as not understood                                      Line    25: 1 NOTE Submission Note
+Skipped subordinate line                                            Line    26: 2 TEST Submission Note
+Line ignored as not understood                                      Line    27: 1 NOTE 
+Skipped subordinate line                                            Line    28: 2 TEST Empty Note
+Line ignored as not understood                                      Line    29: 1 TEST submission
+Line ignored as not understood                                      Line    30: 1 NOTE N2</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="618"/>
+      </style>
+    </note>
+    <note handle="_0000000600000006" change="979250406" id="N0003" type="General">
+      <text>Submission xref note</text>
+    </note>
+    <note handle="_0000000700000007" change="1472480894" id="N0004" type="GEDCOM import">
+      <text>Records not imported into NOTE Gramps ID N0003:
+
+Tag recognized but not supported                                    Line    32: 1 RIN Submission Note RIN
+Tag recognized but not supported                                    Line    33: 1 REFN Submission Note REFN
+Skipped subordinate line                                            Line    34: 2 TYPE Submission Note REFN TYPE
+Tag recognized but not supported                                    Line    35: 1 SOUR Submission note source
+Line ignored as not understood                                      Line    39: 1 TEST on XREF Note</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="586"/>
+      </style>
+    </note>
+    <note handle="_0000000900000009" change="1472480894" id="N0005" type="GEDCOM import">
+      <text>Records not imported into SUBM (Submitter): (@SUBMITTER@) John A. Tester:
+
+Line ignored as not understood                                      Line    42: 1 NOTE Submitter Note
+Skipped subordinate line                                            Line    43: 2 TEST Submitter Note
+Line ignored as not understood                                      Line    44: 1 NOTE 
+Skipped subordinate line                                            Line    45: 2 TEST Empty Note
+Line ignored as not understood                                      Line    46: 1 TEST Submitter
+Line ignored as not understood                                      Line    47: 1 NOTE N3</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="652"/>
+      </style>
+    </note>
+    <note handle="_0000000a0000000a" change="1472480894" id="N0006" type="General">
+      <text>Submitter xref note</text>
+    </note>
+    <note handle="_0000000e0000000e" change="1472480894" id="N0007" type="General">
+      <text>Birth Event note</text>
+    </note>
+    <note handle="_0000000f0000000f" change="1472480894" id="N0008" type="General">
+      <text>Location Note</text>
+    </note>
+    <note handle="_0000001000000010" change="1472480894" id="N0009" type="General">
+      <text>Location Note 2</text>
+    </note>
+    <note handle="_0000001300000013" change="1472480894" id="N0010" type="General">
+      <text>Death Event xref note</text>
+    </note>
+    <note handle="_0000001500000015" change="1472480894" id="N0011" type="General">
+      <text>FAMS Note</text>
+    </note>
+    <note handle="_0000001600000016" change="1472480894" id="N0012" type="General">
+      <text>FAMS Note 2</text>
+    </note>
+    <note handle="_0000001700000017" change="1472480894" id="N0013" type="General">
+      <text>Tom Tester xref note</text>
+    </note>
+    <note handle="_0000001800000018" change="1472480894" id="N0014" type="General">
+      <text>Tom Tester Note</text>
+    </note>
+    <note handle="_0000001900000019" change="1472480894" id="N0015" type="General">
+      <text>Media Note</text>
+    </note>
+    <note handle="_0000001d0000001d" change="1472480894" id="N0016" type="GEDCOM import">
+      <text>Records not imported into INDI (individual) Gramps ID I0001:
+
+Empty event note ignored                                            Line    54: 2 NOTE 
+Skipped subordinate line                                            Line    55: 3 NOTE Empty note subordinate (Should be skipped)
+Skipped subordinate line                                            Line    56: 3 TEST Empty Note
+Skipped subordinate line                                            Line    58: 3 TEST 123456 Event Note
+Line ignored as not understood                                      Line    62: 4 TEST Location Note
+Line ignored as not understood                                      Line    63: 3 TEST Location
+Empty event note ignored                                            Line    66: 2 NOTE 
+Skipped subordinate line                                            Line    67: 3 TEST Empty Note
+Empty event note ignored                                            Line    68: 2 NOTE 
+Skipped subordinate line                                            Line    69: 3 TEST Empty Note
+Line ignored as not understood                                      Line    73: 3 TEST FAMS Note
+Skipped subordinate line                                            Line    74: 4 TEST skip on FAMS Note
+Line ignored as not understood                                      Line    75: 2 TEST FAMS
+Line ignored as not understood                                      Line    79: 2 TEST Person Note
+Line ignored as not understood                                      Line    82: 2 TEST media
+Empty note ignored                                                  Line    85: 2 NOTE 
+Skipped subordinate line                                            Line    86: 3 TEST Empty Note
+Line ignored as not understood                                      Line    88: 3 TEST 123456 Note
+Line ignored as not understood                                      Line    96: 2 NOTE N6
+Skipped subordinate line                                            Line    98: 3 TEST Empty Note</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="2011"/>
+      </style>
+    </note>
+    <note handle="_0000001e0000001e" change="979250406" id="N0017" type="General">
+      <text>Media xref note</text>
+    </note>
+    <note handle="_0000001f0000001f" change="1472480894" id="N0018" type="GEDCOM import">
+      <text>Records not imported into NOTE Gramps ID N0017:
+
+Tag recognized but not supported                                    Line   103: 1 RIN 123456
+Tag recognized but not supported                                    Line   104: 1 REFN 98765
+Skipped subordinate line                                            Line   105: 2 TYPE Who knows REFN TYPE
+Skipped subordinate line                                            Line   110: 3 CHAN 
+Skipped subordinate line                                            Line   111: 4 DATE 2001-01-11
+Skipped subordinate line                                            Line   112: 5 TIME 16:00:06</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="624"/>
+      </style>
+    </note>
+    <note handle="_0000002000000020" change="1472480894" id="N0019" type="REFN-TYPE">
+      <text>Who knows REFN TYPE</text>
+    </note>
+    <note handle="_0000002200000022" change="1472480894" id="N0020" type="GEDCOM import">
+      <text>Records not imported into OBJE (multi-media object) Gramps ID M1:
+
+Could not import photo.jpg                                          Line   114: 1 FILE photo.jpg</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="164"/>
+      </style>
+    </note>
+    <note handle="_0000002600000026" change="979250406" id="N0021" type="General">
+      <text>Family Spouse reference Note</text>
+    </note>
+    <note handle="_0000002800000028" change="1472480894" id="N0022" type="GEDCOM import">
+      <text>Records not imported into INDI (individual) Gramps ID I0002:
+
+Empty note ignored                                                  Line   132: 2 NOTE 
+Skipped subordinate line                                            Line   133: 3 TEST Empty Note</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="248"/>
+      </style>
+    </note>
+    <note handle="_0000002a0000002a" change="979250406" id="N0023" type="General">
+      <text>Name note</text>
+    </note>
+    <note handle="_0000002e0000002e" change="1472480894" id="N0024" type="General">
+      <text>Place note</text>
+    </note>
+    <note handle="_0000003100000031" change="1472480894" id="N0025" type="General">
+      <text>LDS xref note</text>
+    </note>
+    <note handle="_0000003300000033" change="979250406" id="N0026" type="General">
+      <text>Association link note</text>
+    </note>
+    <note handle="_0000003500000035" change="1472480894" id="N0027" type="GEDCOM import">
+      <text>Records not imported into INDI (individual) Gramps ID I0003:
+
+Empty note ignored                                                  Line   141: 2 NOTE 
+Skipped subordinate line                                            Line   142: 3 TEST Empty Note
+Line ignored as not understood                                      Line   163: 3 TEST Accociation note
+Empty note ignored                                                  Line   167: 2 NOTE 
+Skipped subordinate line                                            Line   168: 3 TEST Empty Note</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="538"/>
+      </style>
+    </note>
+    <note handle="_0000003600000036" change="979250406" id="N0028" type="General">
+      <text>Just for association</text>
+    </note>
+    <note handle="_0000003b0000003b" change="1472480894" id="N0029" type="General">
+      <text>Family xref note</text>
+    </note>
+    <note handle="_0000003c0000003c" change="979250406" id="N0030" type="General">
+      <text>Family note</text>
+    </note>
+    <note handle="_0000003d0000003d" change="1472480894" id="N0031" type="General">
+      <text>Citation Data Note</text>
+    </note>
+    <note handle="_0000003e0000003e" change="1472480894" id="N0032" type="Source text">
+      <text>A sample text from a source of this family</text>
+    </note>
+    <note handle="_0000003f0000003f" change="979250406" id="N0033" type="General">
+      <text>A note this citation is on the FAMILY record.</text>
+    </note>
+    <note handle="_0000004100000041" change="1472480894" id="N0034" type="GEDCOM import">
+      <text>Records not imported into FAM (family) Gramps ID F0001:
+
+Line ignored as not understood                                      Line   183: 2 TEST Family Note
+Empty note ignored                                                  Line   187: 1 NOTE 
+Skipped subordinate line                                            Line   188: 2 TEST Empty Note
+Line ignored as not understood                                      Line   190: 2 TEST citation
+Line ignored as not understood                                      Line   194: 3 TEST Citation Data
+Line ignored as not understood                                      Line   196: 4 TEST Citation Data Note</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="645"/>
+      </style>
+    </note>
+    <note handle="_0000004300000043" change="979250406" id="N0035" type="General">
+      <text>A short note about the repository link.</text>
+    </note>
+    <note handle="_0000004400000044" change="979250406" id="N0036" type="General">
+      <text>note embedded in the SOURCE Record</text>
+    </note>
+    <note handle="_0000004500000045" change="1472480894" id="N0037" type="GEDCOM import">
+      <text>Records not imported into SOUR (source) Gramps ID S0001:
+
+Line ignored as not understood                                      Line   206: 1 TEST source
+Empty note ignored                                                  Line   208: 2 NOTE 
+Skipped subordinate line                                            Line   209: 3 TEST Empty Note
+Empty note ignored                                                  Line   214: 1 NOTE 
+Skipped subordinate line                                            Line   215: 2 TEST Empty Note</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="524"/>
+      </style>
+    </note>
+    <note handle="_0000004600000046" change="1472480894" id="N0038" type="General">
+      <text>Repository Note</text>
+    </note>
+    <note handle="_0000004700000047" change="1472480894" id="N0039" type="GEDCOM import">
+      <text>Records not imported into REPO (repository) Gramps ID R0002:
+
+Line ignored as not understood                                      Line   223: 1 TEST Repo
+Empty note ignored                                                  Line   224: 1 NOTE 
+Skipped subordinate line                                            Line   225: 2 TEST Empty Note</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="340"/>
+      </style>
+    </note>
+  </notes>
+</database>


### PR DESCRIPTION
This PR changes the methods to always use the exception line's Gedcom 'level' as the indicator to skip any lexically subordinate lines.  For the widely used '__ignore()' method, It also performs a check on the token for the line and modifies the message to indicate "not supported", versus "not understood", the distinction being that valid Gedcom may generate "not supported" messages, and invalid (or customized Gedcom) would generate "not understood".
A call to __not_recognized() that was not executable was removed.

The exception processing for the Gedcom parser (when unexpected Tags or defined tags in unexpected places are found) should report the error, and skip any lexically subordinate lines (as these would be dependent on the exception line to make sense).
Current code tries to track the 'state' of the Gedcom processing (which is mostly the same as the lexical level).  But not always.  In the cases where the lexical level and state level differ, the authors have tried to compensate by manually adjusting the level used in exception processing.  In a few cases they did not get it right.