### PR TITLE
This fix makes Place GID vs place name consistent across runs for Gedcom import

### DIFF
--- a/gramps/plugins/lib/libplaceimport.py
+++ b/gramps/plugins/lib/libplaceimport.py
@@ -21,6 +21,7 @@
 """
 Helper class for importing places.
 """
+from _collections import OrderedDict
 
 #-------------------------------------------------------------------------
 #
@@ -41,7 +42,7 @@ class PlaceImport:
     def __init__(self, db):
         self.db = db
         self.loc2handle = {}
-        self.handle2loc = {}
+        self.handle2loc = OrderedDict()
 
     def store_location(self, location, handle):
         """

--- a/gramps/plugins/lib/libplaceimport.py
+++ b/gramps/plugins/lib/libplaceimport.py
@@ -21,7 +21,7 @@
 """
 Helper class for importing places.
 """
-from _collections import OrderedDict
+from collections import OrderedDict
 
 #-------------------------------------------------------------------------
 #


### PR DESCRIPTION
Another issue with tests failing due to different results when using dict; as in "for something in dict".
Mostly a normal dict produces the same results each run, but sometimes not (not clear why, perhaps memory layout, or garbage collection differences).
Change to OrderedDict makes result consistent because OrderedDict returns entries in insertion order.