### PR TITLE
9642 Adjust GedcomStageOne notes Parsing

### DIFF
--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -8122,7 +8122,7 @@ class GedcomStageOne:
             self.lcnt += 1
 
             try:
-                data = line.split(None, 2) + ['']
+                data = line.split(None, 3) + ['']
                 (level, key, value) = data[:3]
                 level = int(level)
                 key = key.strip()


### PR DESCRIPTION
Minor fix.

In libgedcom.py's class GedcomStageOne Parsing of Tags noticed that the zero level NOTE tag is the only one that leaks its content.

Which is probably not what is desired, especially when:
* you have alot of NOTE's in your GEDCOM file

and the whole purpose of GedcomStageOne is a quick first pass over the GEDCOM!

https://gramps-project.org/bugs/view.php?id=9462