### PR TITLE
Gedcom import Notes get NoteType appropriate to object

### DIFF
--- a/data/tests/imp_CustTags.gramps
+++ b/data/tests/imp_CustTags.gramps
@@ -3,7 +3,7 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-08-02" version="5.0.0-alpha1"/>
+    <created date="2016-08-29" version="5.0.0-alpha1"/>
     <researcher>
       <resname>The Subm /Tester/</resname>
       <resaddr>123 Main St.</resaddr>
@@ -13,56 +13,56 @@
     </researcher>
   </header>
   <events>
-    <event handle="_0000000500000005" change="1470145667" id="E0000">
+    <event handle="_0000000500000005" change="1472500305" id="E0000">
       <type>Birth</type>
       <dateval val="1954-12-29"/>
       <place hlink="_0000000600000006"/>
     </event>
-    <event handle="_0000000700000007" change="1470145667" id="E0001">
+    <event handle="_0000000700000007" change="1472500305" id="E0001">
       <type>Circumcision</type>
       <dateval val="1955-01-11"/>
       <place hlink="_0000000800000008"/>
     </event>
-    <event handle="_0000000900000009" change="1470145667" id="E0002">
+    <event handle="_0000000900000009" change="1472500305" id="E0002">
       <type>Elected</type>
       <dateval val="1980"/>
       <place hlink="_0000000a0000000a"/>
       <description>Small town</description>
     </event>
-    <event handle="_0000000c0000000c" change="1470145667" id="E0003">
+    <event handle="_0000000c0000000c" change="1472500305" id="E0003">
       <type>_XYZ</type>
       <dateval val="1979"/>
       <description>He should keep his zipper closed</description>
     </event>
-    <event handle="_0000000d0000000d" change="1470145667" id="E0004">
+    <event handle="_0000000d0000000d" change="1472500305" id="E0004">
       <type>Independence Day</type>
       <dateval val="1981-07-04"/>
       <description>Celebration</description>
     </event>
-    <event handle="_0000000f0000000f" change="1470145667" id="E0005">
+    <event handle="_0000000f0000000f" change="1472500305" id="E0005">
       <type>Residence</type>
       <dateval val="1954-12-30"/>
       <place hlink="_0000001100000011"/>
       <noteref hlink="_0000001000000010"/>
     </event>
-    <event handle="_0000001300000013" change="1470145667" id="E0006">
+    <event handle="_0000001300000013" change="1472500305" id="E0006">
       <type>Marriage</type>
       <dateval val="1970"/>
       <place hlink="_0000001400000014"/>
     </event>
-    <event handle="_0000001500000015" change="1470145667" id="E0007">
+    <event handle="_0000001500000015" change="1472500305" id="E0007">
       <type>_INFIDELITY</type>
       <dateval val="1979"/>
       <place hlink="_0000001600000016"/>
     </event>
-    <event handle="_0000001700000017" change="1470145667" id="E0008">
+    <event handle="_0000001700000017" change="1472500305" id="E0008">
       <type>Separation</type>
       <dateval val="1980"/>
       <place hlink="_0000001800000018"/>
     </event>
   </events>
   <people>
-    <person handle="_0000000100000001" change="1470145667" id="I0000">
+    <person handle="_0000000100000001" change="1472500305" id="I0000">
       <gender>U</gender>
       <name type="Birth Name">
         <first>The</first>
@@ -76,7 +76,7 @@
       <eventref hlink="_0000000d0000000d" role="Primary"/>
       <parentin hlink="_0000000b0000000b"/>
     </person>
-    <person handle="_0000000e0000000e" change="1470145667" id="I0001">
+    <person handle="_0000000e0000000e" change="1472500305" id="I0001">
       <gender>U</gender>
       <name type="Birth Name">
         <first>Mrs</first>
@@ -85,7 +85,7 @@
       <eventref hlink="_0000000f0000000f" role="Primary"/>
       <parentin hlink="_0000000b0000000b"/>
     </person>
-    <person handle="_0000001200000012" change="1470145667" id="I0002">
+    <person handle="_0000001200000012" change="1472500305" id="I0002">
       <gender>U</gender>
       <name type="Birth Name">
         <first>Tom</first>
@@ -95,7 +95,7 @@
     </person>
   </people>
   <families>
-    <family handle="_0000000b0000000b" change="1470145667" id="F4211">
+    <family handle="_0000000b0000000b" change="1472500305" id="F4211">
       <rel type="Married"/>
       <father hlink="_0000000100000001"/>
       <mother hlink="_0000000e0000000e"/>
@@ -106,7 +106,7 @@
     </family>
   </families>
   <citations>
-    <citation handle="_0000000400000004" change="1470145667" id="C0000">
+    <citation handle="_0000000400000004" change="1472500305" id="C0000">
       <page>777, record for The Tester</page>
       <confidence>2</confidence>
       <noteref hlink="_0000000300000003"/>
@@ -114,67 +114,67 @@
     </citation>
   </citations>
   <sources>
-    <source handle="_0000000200000002" change="1470145667" id="S0006">
+    <source handle="_0000000200000002" change="1472500305" id="S0006">
       <stitle>Ohio Births, 1958-2002</stitle>
       <reporef hlink="_0000001900000019" medium="Book"/>
     </source>
   </sources>
   <places>
-    <placeobj handle="_0000000600000006" change="1470145667" id="P0000" type="Street">
+    <placeobj handle="_0000000600000006" change="1472500305" id="P0000" type="Street">
       <ptitle>123 High St, Cleveland, Cuyahoga, Ohio, USA, 44140</ptitle>
       <code>44140</code>
       <pname value="123 High St"/>
       <placeref hlink="_0000001e0000001e"/>
     </placeobj>
-    <placeobj handle="_0000000800000008" change="1470145667" id="P0001" type="Street">
+    <placeobj handle="_0000000800000008" change="1472500305" id="P0001" type="Street">
       <ptitle>456 Main St, Cleveland, Cuyahoga, Ohio, USA, 44140</ptitle>
       <code>44140</code>
       <pname value="456 Main St"/>
       <placeref hlink="_0000001e0000001e"/>
     </placeobj>
-    <placeobj handle="_0000000a0000000a" change="1470145667" id="P0002" type="Unknown">
+    <placeobj handle="_0000000a0000000a" change="1472500305" id="P0002" type="Unknown">
       <ptitle>Littetown, Smallcounty, Ohio, USA</ptitle>
       <pname value="Littetown, Smallcounty, Ohio, USA"/>
     </placeobj>
-    <placeobj handle="_0000001100000011" change="1470145667" id="P0003" type="Address">
+    <placeobj handle="_0000001100000011" change="1472500305" id="P0003" type="Address">
       <ptitle>123 Main St., Winslow, PA, 12345</ptitle>
       <pname value="123 Main St., Winslow, PA, 12345"/>
       <location street="123 Main St." city="Winslow" state="PA" postal="12345"/>
     </placeobj>
-    <placeobj handle="_0000001400000014" change="1470145667" id="P0004" type="Unknown">
+    <placeobj handle="_0000001400000014" change="1472500305" id="P0004" type="Unknown">
       <ptitle>St Rafaels Church, Bay Village, Cuyahoga, Ohio, USA</ptitle>
       <pname value="St Rafaels Church, Bay Village, Cuyahoga, Ohio, USA"/>
     </placeobj>
-    <placeobj handle="_0000001600000016" change="1470145667" id="P0005" type="Unknown">
+    <placeobj handle="_0000001600000016" change="1472500305" id="P0005" type="Unknown">
       <ptitle>Of Ill Repute, Shaker Heights, Ohio, USA</ptitle>
       <pname value="Of Ill Repute, Shaker Heights, Ohio, USA"/>
     </placeobj>
-    <placeobj handle="_0000001800000018" change="1470145667" id="P0006" type="Unknown">
+    <placeobj handle="_0000001800000018" change="1472500305" id="P0006" type="Unknown">
       <ptitle>Cuyahoga, OHIO, USA</ptitle>
       <pname value="Cuyahoga, OHIO, USA"/>
     </placeobj>
-    <placeobj handle="_0000001b0000001b" change="1470145667" id="P0007" type="Country">
+    <placeobj handle="_0000001b0000001b" change="1472500305" id="P0007" type="Country">
       <ptitle>USA</ptitle>
       <pname value="USA"/>
     </placeobj>
-    <placeobj handle="_0000001c0000001c" change="1470145667" id="P0008" type="State">
+    <placeobj handle="_0000001c0000001c" change="1472500305" id="P0008" type="State">
       <ptitle>Ohio, USA</ptitle>
       <pname value="Ohio"/>
       <placeref hlink="_0000001b0000001b"/>
     </placeobj>
-    <placeobj handle="_0000001d0000001d" change="1470145667" id="P0009" type="County">
+    <placeobj handle="_0000001d0000001d" change="1472500305" id="P0009" type="County">
       <ptitle>Cuyahoga, Ohio, USA</ptitle>
       <pname value="Cuyahoga"/>
       <placeref hlink="_0000001c0000001c"/>
     </placeobj>
-    <placeobj handle="_0000001e0000001e" change="1470145667" id="P0010" type="City">
+    <placeobj handle="_0000001e0000001e" change="1472500305" id="P0010" type="City">
       <ptitle>Cleveland, Cuyahoga, Ohio, USA</ptitle>
       <pname value="Cleveland"/>
       <placeref hlink="_0000001d0000001d"/>
     </placeobj>
   </places>
   <repositories>
-    <repository handle="_0000001900000019" change="1470145667" id="R0001">
+    <repository handle="_0000001900000019" change="1472500305" id="R0001">
       <rname>Testers Repository</rname>
       <type>Library</type>
       <address>
@@ -184,13 +184,13 @@
     </repository>
   </repositories>
   <notes>
-    <note handle="_0000000300000003" change="1470145667" id="N0000" type="Citation Justification">
+    <note handle="_0000000300000003" change="1472500305" id="N0000" type="Citation Justification">
       <text>Because it’s good</text>
     </note>
-    <note handle="_0000001000000010" change="1470145667" id="N0001" type="General">
+    <note handle="_0000001000000010" change="1472500305" id="N0001" type="Event Note">
       <text>Address as event is legal, with PHON,FAX,EMAIL,WWW</text>
     </note>
-    <note handle="_0000001a0000001a" change="1470145667" id="N0002" type="General">
+    <note handle="_0000001a0000001a" change="1472500305" id="N0002" type="Repository Note">
       <text>Testers Repository Record</text>
     </note>
   </notes>

--- a/data/tests/imp_FTM_16dec2015a-mod1.gramps
+++ b/data/tests/imp_FTM_16dec2015a-mod1.gramps
@@ -3,41 +3,41 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-05-23" version="GrampsAIO64-4.2.1-2"/>
+    <created date="2016-08-29" version="5.0.0-alpha1"/>
     <researcher>
     </researcher>
   </header>
   <events>
-    <event handle="_0000000500000005" change="1464018002" id="E0000">
+    <event handle="_0000000500000005" change="1472500305" id="E0000">
       <type>Birth</type>
       <dateval val="1816"/>
       <place hlink="_0000000700000007"/>
       <citationref hlink="_0000000600000006"/>
     </event>
-    <event handle="_0000000800000008" change="1464018002" id="E0001">
+    <event handle="_0000000800000008" change="1472500305" id="E0001">
       <type>Residence</type>
       <dateval val="1850"/>
       <place hlink="_0000000a0000000a"/>
       <citationref hlink="_0000000900000009"/>
     </event>
-    <event handle="_0000000b0000000b" change="1464018002" id="E0002">
+    <event handle="_0000000b0000000b" change="1472500305" id="E0002">
       <type>Death</type>
       <datestr val="1850/1860"/>
       <place hlink="_0000000c0000000c"/>
     </event>
-    <event handle="_0000000f0000000f" change="1464018002" id="E0003">
+    <event handle="_0000000f0000000f" change="1472500305" id="E0003">
       <type>Marriage</type>
       <dateval val="1841" type="about"/>
       <place hlink="_0000001000000010"/>
     </event>
-    <event handle="_0000001100000011" change="1464018002" id="E0004">
+    <event handle="_0000001100000011" change="1472500305" id="E0004">
       <type>Marriage</type>
       <dateval val="1847-08"/>
       <place hlink="_0000001200000012"/>
     </event>
   </events>
   <people>
-    <person handle="_0000000100000001" change="1464018002" id="I0278">
+    <person handle="_0000000100000001" change="1472500305" id="I0278">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Andrew</first>
@@ -54,13 +54,13 @@
     </person>
   </people>
   <families>
-    <family handle="_0000000d0000000d" change="1464018002" id="F0073">
+    <family handle="_0000000d0000000d" change="1472500305" id="F0073">
       <rel type="Married"/>
       <father hlink="_0000000100000001"/>
       <eventref hlink="_0000000f0000000f" role="Family"/>
       <childref hlink="_0000000100000001"/>
     </family>
-    <family handle="_0000000e0000000e" change="1464018002" id="F0074">
+    <family handle="_0000000e0000000e" change="1472500305" id="F0074">
       <rel type="Married"/>
       <father hlink="_0000000100000001"/>
       <eventref hlink="_0000001100000011" role="Family"/>
@@ -68,19 +68,19 @@
     </family>
   </families>
   <citations>
-    <citation handle="_0000000400000004" change="1464018002" id="C0000">
+    <citation handle="_0000000400000004" change="1472500305" id="C0000">
       <page>Year: 1850; Census Place: District 14, Cape Girardeau, Missouri; Roll: M432_394; Page: 435B; Image: 248</page>
       <confidence>2</confidence>
       <objref hlink="_0000000300000003"/>
       <sourceref hlink="_0000000200000002"/>
     </citation>
-    <citation handle="_0000000600000006" change="1464018002" id="C0001">
+    <citation handle="_0000000600000006" change="1472500305" id="C0001">
       <page>Year: 1850; Census Place: District 14, Cape Girardeau, Missouri; Roll: M432_394; Page: 435B; Image: 248</page>
       <confidence>2</confidence>
       <objref hlink="_0000000300000003"/>
       <sourceref hlink="_0000000200000002"/>
     </citation>
-    <citation handle="_0000000900000009" change="1464018002" id="C0002">
+    <citation handle="_0000000900000009" change="1472500305" id="C0002">
       <page>Year: 1850; Census Place: District 14, Cape Girardeau, Missouri; Roll: M432_394; Page: 435B; Image: 248</page>
       <confidence>2</confidence>
       <objref hlink="_0000000300000003"/>
@@ -88,7 +88,7 @@
     </citation>
   </citations>
   <sources>
-    <source handle="_0000000200000002" change="1464018002" id="S0029">
+    <source handle="_0000000200000002" change="1472500305" id="S0029">
       <stitle>1850 United States Federal Census</stitle>
       <sauthor>Ancestry.com</sauthor>
       <spubinfo>Name: Ancestry.com Operations, Inc.; Location: Provo, UT, USA; Date: 2009;</spubinfo>
@@ -96,42 +96,42 @@
     </source>
   </sources>
   <places>
-    <placeobj handle="_0000000700000007" change="1464018002" id="P0000" type="Unknown">
+    <placeobj handle="_0000000700000007" change="1472500305" id="P0000" type="Unknown">
       <ptitle>Tennessee, USA</ptitle>
       <pname value="Tennessee, USA"/>
     </placeobj>
-    <placeobj handle="_0000000a0000000a" change="1464018002" id="P0001" type="Unknown">
+    <placeobj handle="_0000000a0000000a" change="1472500305" id="P0001" type="Unknown">
       <ptitle>District 14, Cape Girardeau, Missouri, USA</ptitle>
       <pname value="District 14, Cape Girardeau, Missouri, USA"/>
     </placeobj>
-    <placeobj handle="_0000000c0000000c" change="1464018002" id="P0002" type="Unknown">
+    <placeobj handle="_0000000c0000000c" change="1472500305" id="P0002" type="Unknown">
       <ptitle>Bollinger Co. MO</ptitle>
       <pname value="Bollinger Co. MO"/>
     </placeobj>
-    <placeobj handle="_0000001000000010" change="1464018002" id="P0003" type="Unknown">
+    <placeobj handle="_0000001000000010" change="1472500305" id="P0003" type="Unknown">
       <ptitle>Union Co.?, IL</ptitle>
       <pname value="Union Co.?, IL"/>
     </placeobj>
-    <placeobj handle="_0000001200000012" change="1464018002" id="P0004" type="Unknown">
+    <placeobj handle="_0000001200000012" change="1472500305" id="P0004" type="Unknown">
       <ptitle>Wayne, Missouri, United States</ptitle>
       <pname value="Wayne, Missouri, United States"/>
     </placeobj>
   </places>
   <objects>
-    <object handle="_0000000300000003" change="1464018002" id="M159">
+    <object handle="_0000000300000003" change="1472500305" id="M159">
       <file src="1850 United States Federal Census(11)-1.jpg" mime="image/jpeg" description="1850 United States Federal Census"/>
       <noteref hlink="_0000001400000014"/>
       <noteref hlink="_0000001500000015"/>
     </object>
-    <object handle="_0000001600000016" change="1464018002" id="M158">
+    <object handle="_0000001600000016" change="1472500305" id="M158">
       <file src="D:/Users/PRC/Downloads/1850 United States Federal Census(11)-1.jpg" mime="image/jpeg" description="D:\Users\PRC\Downloads\1850 United States Federal Census(11)-1.jpg"/>
     </object>
-    <object handle="_0000001700000017" change="1464018002" id="M157">
+    <object handle="_0000001700000017" change="1472500305" id="M157">
       <file src="http://1.gravatar.com/avatar/77e02a3c8c665155ad1acaac8c2742e0?s=120&amp;d=mm&amp;r=pg" mime="unknown" description="http://1.gravatar.com/avatar/77e02a3c8c665155ad1acaac8c2742e0?s=120&amp;d=mm&amp;r=pg"/>
     </object>
   </objects>
   <repositories>
-    <repository handle="_0000001300000013" change="1464018002" id="R0001">
+    <repository handle="_0000001300000013" change="1472500305" id="R0001">
       <rname>Ancestry.com</rname>
       <type>Library</type>
       <address>
@@ -140,10 +140,10 @@
     </repository>
   </repositories>
   <notes>
-    <note handle="_0000001400000014" change="1464018002" id="N0000" type="General">
+    <note handle="_0000001400000014" change="1472500305" id="N0000" type="Media Note">
       <text>Year: 1850; Census Place: District 14, Cape Girardeau, Missouri; Roll: M432_394; Page: 435B; Image: 248</text>
     </note>
-    <note handle="_0000001500000015" change="1464018002" id="N0001" type="GEDCOM import">
+    <note handle="_0000001500000015" change="1472500305" id="N0001" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M159:
 
 Could not import 1850 United States Federal Census(11)-1.jpg        Line    70: 1 FILE 1850 United States Federal Census(11)-1.jpg</text>

--- a/data/tests/imp_FTM_PHOTO.gramps
+++ b/data/tests/imp_FTM_PHOTO.gramps
@@ -3,12 +3,12 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-07-26" version="GrampsAIO64-4.2.1-2"/>
+    <created date="2016-08-29" version="5.0.0-alpha1"/>
     <researcher>
     </researcher>
   </header>
   <people>
-    <person handle="_0000000100000001" change="1469548537" id="I0001">
+    <person handle="_0000000100000001" change="1472500306" id="I0001">
       <gender>U</gender>
       <name type="Birth Name">
         <first>The</first>
@@ -21,7 +21,7 @@
       <objref hlink="_0000000700000007"/>
       <noteref hlink="_0000000200000002"/>
     </person>
-    <person handle="_0000000800000008" change="1469548537" id="I0002">
+    <person handle="_0000000800000008" change="1472500306" id="I0002">
       <gender>U</gender>
       <name type="Birth Name">
         <first>She</first>
@@ -35,7 +35,7 @@
       <noteref hlink="_0000000900000009"/>
       <noteref hlink="_0000000a0000000a"/>
     </person>
-    <person handle="_0000001000000010" change="1469548537" id="I0003">
+    <person handle="_0000001000000010" change="1472500306" id="I0003">
       <gender>U</gender>
       <name type="Birth Name">
         <first>Edwin</first>
@@ -49,44 +49,44 @@
     </person>
   </people>
   <objects>
-    <object handle="_0000000300000003" change="1469548537" id="M1">
+    <object handle="_0000000300000003" change="1472500306" id="M1">
       <file src="O1.jpg" mime="image/jpeg" description="Ferry Arriving 1910"/>
       <noteref hlink="_0000000b0000000b"/>
     </object>
-    <object handle="_0000000400000004" change="1469548537" id="M2">
+    <object handle="_0000000400000004" change="1472500306" id="M2">
       <file src="O2.jpg" mime="image/jpeg" description="B&amp;W Kids"/>
       <noteref hlink="_0000000c0000000c"/>
     </object>
-    <object handle="_0000000500000005" change="1469548537" id="M3">
+    <object handle="_0000000500000005" change="1472500306" id="M3">
       <file src="O3.jpg" mime="image/jpeg" description="Sourpuss in Hat"/>
       <noteref hlink="_0000000d0000000d"/>
     </object>
-    <object handle="_0000000600000006" change="1469548537" id="M4">
+    <object handle="_0000000600000006" change="1472500306" id="M4">
       <file src="O4.jpg" mime="image/jpeg" description="Girl Eating"/>
       <noteref hlink="_0000000e0000000e"/>
     </object>
-    <object handle="_0000000700000007" change="1469548537" id="M5">
+    <object handle="_0000000700000007" change="1472500306" id="M5">
       <file src="O5.jpg" mime="image/jpeg" description="Edwin &amp; Janice Smith"/>
       <noteref hlink="_0000000f0000000f"/>
     </object>
-    <object handle="_0000001200000012" change="1469548537" id="O0000">
+    <object handle="_0000001200000012" change="1472500306" id="O0000">
       <file src="O3.jpg" mime="image/jpeg" description="Sourpuss in Hat"/>
     </object>
-    <object handle="_0000001300000013" change="1469548537" id="O0001">
+    <object handle="_0000001300000013" change="1472500306" id="O0001">
       <file src="O4.jpg" mime="image/jpeg" description="Girl Eating"/>
     </object>
-    <object handle="_0000001400000014" change="1469548537" id="O0002">
+    <object handle="_0000001400000014" change="1472500306" id="O0002">
       <file src="O5.jpg" mime="image/jpeg" description="Edwin &amp; Janice Smith"/>
     </object>
   </objects>
   <notes>
-    <note handle="_0000000200000002" change="1469548537" id="N0000" type="General">
+    <note handle="_0000000200000002" change="1472500306" id="N0000" type="Person Note">
       <text>The primary photo should be a male Sourpuss in a Hat 03.jpg or Gid:M3</text>
     </note>
-    <note handle="_0000000900000009" change="1469548537" id="N0001" type="General">
+    <note handle="_0000000900000009" change="1472500306" id="N0001" type="Person Note">
       <text>The primary photo should be a girl eating 04.jpg or Gid:M4</text>
     </note>
-    <note handle="_0000000a0000000a" change="1469548537" id="N0002" type="GEDCOM import">
+    <note handle="_0000000a0000000a" change="1472500306" id="N0002" type="GEDCOM import">
       <text>Records not imported into INDI (individual) Gramps ID I0002:
 
 Line ignored as not understood                                      Line    35: 3 WHAT ???</text>
@@ -94,7 +94,7 @@ Line ignored as not understood                                      Line    35: 
         <range start="0" end="153"/>
       </style>
     </note>
-    <note handle="_0000000b0000000b" change="1469548537" id="N0003" type="GEDCOM import">
+    <note handle="_0000000b0000000b" change="1472500306" id="N0003" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M1:
 
 Could not import O1.jpg                                             Line    38: 1 FILE O1.jpg</text>
@@ -102,7 +102,7 @@ Could not import O1.jpg                                             Line    38: 
         <range start="0" end="161"/>
       </style>
     </note>
-    <note handle="_0000000c0000000c" change="1469548537" id="N0004" type="GEDCOM import">
+    <note handle="_0000000c0000000c" change="1472500306" id="N0004" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M2:
 
 Could not import O2.jpg                                             Line    41: 1 FILE O2.jpg</text>
@@ -110,7 +110,7 @@ Could not import O2.jpg                                             Line    41: 
         <range start="0" end="161"/>
       </style>
     </note>
-    <note handle="_0000000d0000000d" change="1469548537" id="N0005" type="GEDCOM import">
+    <note handle="_0000000d0000000d" change="1472500306" id="N0005" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M3:
 
 Could not import O3.jpg                                             Line    44: 1 FILE O3.jpg</text>
@@ -118,7 +118,7 @@ Could not import O3.jpg                                             Line    44: 
         <range start="0" end="161"/>
       </style>
     </note>
-    <note handle="_0000000e0000000e" change="1469548537" id="N0006" type="GEDCOM import">
+    <note handle="_0000000e0000000e" change="1472500306" id="N0006" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M4:
 
 Could not import O4.jpg                                             Line    47: 1 FILE O4.jpg</text>
@@ -126,7 +126,7 @@ Could not import O4.jpg                                             Line    47: 
         <range start="0" end="161"/>
       </style>
     </note>
-    <note handle="_0000000f0000000f" change="1469548537" id="N0007" type="GEDCOM import">
+    <note handle="_0000000f0000000f" change="1472500306" id="N0007" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M5:
 
 Could not import O5.jpg                                             Line    50: 1 FILE O5.jpg</text>
@@ -134,10 +134,10 @@ Could not import O5.jpg                                             Line    50: 
         <range start="0" end="161"/>
       </style>
     </note>
-    <note handle="_0000001100000011" change="1469548537" id="N0008" type="General">
+    <note handle="_0000001100000011" change="1472500306" id="N0008" type="Person Note">
       <text>The primary photo should be a male of pair 05.jpg</text>
     </note>
-    <note handle="_0000001500000015" change="1469548537" id="N0009" type="GEDCOM import">
+    <note handle="_0000001500000015" change="1472500306" id="N0009" type="GEDCOM import">
       <text>Records not imported into INDI (individual) Gramps ID I0003:
 
 Could not import O3.jpg                                             Line    55: 1 OBJE 

--- a/data/tests/imp_Latin_1_CR.gramps
+++ b/data/tests/imp_Latin_1_CR.gramps
@@ -3,29 +3,22 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-05-24" version="GrampsAIO64-4.2.1-2"/>
+    <created date="2016-08-29" version="5.0.0-alpha1"/>
     <researcher>
-      <resname>Paul Culley</resname>
-      <resaddr>11210 Olde Mint House Ln</resaddr>
-      <rescity>Tomball</rescity>
-      <resstate>Tx</resstate>
-      <rescountry>USA</rescountry>
-      <respostal>77375</respostal>
-      <resemail>paulr2787@gmail.com</resemail>
     </researcher>
   </header>
   <events>
-    <event handle="_0000000200000002" change="1464119858" id="E0000">
+    <event handle="_0000000200000002" change="1472500306" id="E0000">
       <type>Birth</type>
       <dateval val="1955"/>
     </event>
-    <event handle="_0000000300000003" change="1464119858" id="E0001">
+    <event handle="_0000000300000003" change="1472500306" id="E0001">
       <type>Death</type>
       <dateval val="2017"/>
     </event>
   </events>
   <people>
-    <person handle="_0000000100000001" change="1464119858" id="I0001">
+    <person handle="_0000000100000001" change="1472500306" id="I0001">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Paul</first>
@@ -37,7 +30,7 @@
     </person>
   </people>
   <notes>
-    <note handle="_0000000400000004" change="1464119858" id="N0000" type="General">
+    <note handle="_0000000400000004" change="1472500306" id="N0000" type="Person Note">
       <text>Table of Latin_1, ISO-8859-1 characters
 32 [ ]
 33 [!]

--- a/data/tests/imp_Latin_1_CRLF.gramps
+++ b/data/tests/imp_Latin_1_CRLF.gramps
@@ -3,29 +3,22 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-05-24" version="GrampsAIO64-4.2.1-2"/>
+    <created date="2016-08-29" version="5.0.0-alpha1"/>
     <researcher>
-      <resname>Paul Culley</resname>
-      <resaddr>11210 Olde Mint House Ln</resaddr>
-      <rescity>Tomball</rescity>
-      <resstate>Tx</resstate>
-      <rescountry>USA</rescountry>
-      <respostal>77375</respostal>
-      <resemail>paulr2787@gmail.com</resemail>
     </researcher>
   </header>
   <events>
-    <event handle="_0000000200000002" change="1464119858" id="E0000">
+    <event handle="_0000000200000002" change="1472500306" id="E0000">
       <type>Birth</type>
       <dateval val="1955"/>
     </event>
-    <event handle="_0000000300000003" change="1464119858" id="E0001">
+    <event handle="_0000000300000003" change="1472500306" id="E0001">
       <type>Death</type>
       <dateval val="2017"/>
     </event>
   </events>
   <people>
-    <person handle="_0000000100000001" change="1464119858" id="I0001">
+    <person handle="_0000000100000001" change="1472500306" id="I0001">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Paul</first>
@@ -37,7 +30,7 @@
     </person>
   </people>
   <notes>
-    <note handle="_0000000400000004" change="1464119858" id="N0000" type="General">
+    <note handle="_0000000400000004" change="1472500306" id="N0000" type="Person Note">
       <text>Table of Latin_1, ISO-8859-1 characters
 32 [ ]
 33 [!]

--- a/data/tests/imp_Latin_1_LF.gramps
+++ b/data/tests/imp_Latin_1_LF.gramps
@@ -3,29 +3,22 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-05-24" version="GrampsAIO64-4.2.1-2"/>
+    <created date="2016-08-29" version="5.0.0-alpha1"/>
     <researcher>
-      <resname>Paul Culley</resname>
-      <resaddr>11210 Olde Mint House Ln</resaddr>
-      <rescity>Tomball</rescity>
-      <resstate>Tx</resstate>
-      <rescountry>USA</rescountry>
-      <respostal>77375</respostal>
-      <resemail>paulr2787@gmail.com</resemail>
     </researcher>
   </header>
   <events>
-    <event handle="_0000000200000002" change="1464119858" id="E0000">
+    <event handle="_0000000200000002" change="1472500307" id="E0000">
       <type>Birth</type>
       <dateval val="1955"/>
     </event>
-    <event handle="_0000000300000003" change="1464119858" id="E0001">
+    <event handle="_0000000300000003" change="1472500307" id="E0001">
       <type>Death</type>
       <dateval val="2017"/>
     </event>
   </events>
   <people>
-    <person handle="_0000000100000001" change="1464119858" id="I0001">
+    <person handle="_0000000100000001" change="1472500307" id="I0001">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Paul</first>
@@ -37,7 +30,7 @@
     </person>
   </people>
   <notes>
-    <note handle="_0000000400000004" change="1464119858" id="N0000" type="General">
+    <note handle="_0000000400000004" change="1472500307" id="N0000" type="Person Note">
       <text>Table of Latin_1, ISO-8859-1 characters
 32 [ ]
 33 [!]

--- a/data/tests/imp_MediaTest.gramps
+++ b/data/tests/imp_MediaTest.gramps
@@ -3,19 +3,12 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-07-26" version="5.0.0-alpha1"/>
+    <created date="2016-08-29" version="5.0.0-alpha1"/>
     <researcher>
-      <resname>Paul Culley</resname>
-      <resaddr>11210 Olde Mint House Ln</resaddr>
-      <rescity>Tomball</rescity>
-      <resstate>Tx</resstate>
-      <rescountry>USA</rescountry>
-      <respostal>77375</respostal>
-      <resemail>paulr2787@gmail.com</resemail>
     </researcher>
   </header>
   <people>
-    <person handle="_0000000100000001" change="1469558671" id="I0001">
+    <person handle="_0000000100000001" change="1472500307" id="I0001">
       <gender>U</gender>
       <name type="Birth Name">
         <first>The</first>
@@ -36,12 +29,12 @@
     </person>
   </people>
   <citations>
-    <citation handle="_0000001b0000001b" change="1469558671" id="C0000">
+    <citation handle="_0000001b0000001b" change="1472500307" id="C0000">
       <confidence>0</confidence>
       <noteref hlink="_0000001a0000001a"/>
       <sourceref hlink="_0000001900000019"/>
     </citation>
-    <citation handle="_0000002500000025" change="1469558671" id="C0001">
+    <citation handle="_0000002500000025" change="1472500307" id="C0001">
       <dateval val="2014-06-07"/>
       <page>77, 78 discussion of multimedia link with two files</page>
       <confidence>4</confidence>
@@ -50,17 +43,17 @@
     </citation>
   </citations>
   <sources>
-    <source handle="_0000001900000019" change="1469558671" id="S0002">
+    <source handle="_0000001900000019" change="1472500307" id="S0002">
       <stitle>A Great Photographer</stitle>
     </source>
-    <source handle="_0000002300000023" change="1469558671" id="S0001">
+    <source handle="_0000002300000023" change="1472500307" id="S0001">
       <stitle>The Testers personal files</stitle>
       <sauthor>The Tester</sauthor>
       <spubinfo>Name: Tester Publishing Operations, Inc.; Location: OSF world</spubinfo>
     </source>
   </sources>
   <objects>
-    <object handle="_0000000300000003" change="1469558671" id="O0000">
+    <object handle="_0000000300000003" change="1472500307" id="O0000">
       <file src="test_emb_55.jpg" mime="image/jpeg" description="Multimedia link embedded form v5.5"/>
       <noteref hlink="_0000000200000002"/>
     </object>
@@ -89,12 +82,12 @@
       <noteref hlink="_0000001c0000001c"/>
       <citationref hlink="_0000001b0000001b"/>
     </object>
-    <object handle="_0000000800000008" change="1469558671" id="O0001">
+    <object handle="_0000000800000008" change="1472500307" id="O0001">
       <file src="test_emb_551.jpg" mime="image/jpeg" description="Multimedia link embedded form v5.5.1"/>
       <attribute type="Media-Type" value="Photo"/>
       <noteref hlink="_0000000700000007"/>
     </object>
-    <object handle="_0000000900000009" change="1469558671" id="M5">
+    <object handle="_0000000900000009" change="1472500307" id="M5">
       <file src="test.jpg" mime="image/jpeg" description="Multimedia link to linked form FTM style file"/>
       <noteref hlink="_0000001d0000001d"/>
       <noteref hlink="_0000001e0000001e"/>
@@ -112,25 +105,25 @@
       <noteref hlink="_0000002600000026"/>
       <citationref hlink="_0000002500000025"/>
     </object>
-    <object handle="_0000000c0000000c" change="1469558671" id="O0002">
+    <object handle="_0000000c0000000c" change="1472500307" id="O0002">
       <file src="http://www.geni.com/photo/view?photo_id=6000000001341319061" mime="unknown" description="Multimedia link embedded form v5.5 URL"/>
       <noteref hlink="_0000000b0000000b"/>
     </object>
-    <object handle="_0000000d0000000d" change="1469558671" id="M7">
+    <object handle="_0000000d0000000d" change="1472500307" id="M7">
       <file src="http://s6.postimg.org/8i2erq27l/Preserve_Record_Numbers_Option.png" mime="image/png" description="Multimedia link to linked form v5.5.1 with URL"/>
       <attribute type="Media-Type" value="Photo"/>
     </object>
-    <object handle="_0000000e0000000e" change="1469558671" id="M8">
+    <object handle="_0000000e0000000e" change="1472500307" id="M8">
       <file src="No_path_No_Title_NoForm.jpg" mime="image/jpeg" description="No_path_No_Title_NoForm.jpg"/>
       <noteref hlink="_0000002700000027"/>
     </object>
-    <object handle="_0000001300000013" change="1469558671" id="M2">
+    <object handle="_0000001300000013" change="1472500307" id="M2">
       <file src="" mime="" description="2nd blob Multimedia link to linked form v5.5 blob"/>
       <noteref hlink="_0000001400000014"/>
     </object>
   </objects>
   <notes>
-    <note handle="_0000000200000002" change="1469558671" id="N0010" type="General">
+    <note handle="_0000000200000002" change="1472500307" id="N0010" type="Media Note">
       <text>Media note test: Multimedia link embedded form v5.5
 n OBJE {1:1} p.55
 +1 FORM &lt;MULTIMEDIA_FORMAT&gt; {1:1} p.48
@@ -138,7 +131,7 @@ n OBJE {1:1} p.55
 +1 FILE &lt;MULTIMEDIA_FILE_REFERENCE&gt; {1:1} p.47
 +1 &lt;&lt;NOTE_STRUCTURE&gt;&gt; {0:M} p.33</text>
     </note>
-    <note handle="_0000000700000007" change="1469558671" id="N0014" type="General">
+    <note handle="_0000000700000007" change="1472500307" id="N0014" type="Media Note">
       <text>Media note test: Multimedia link embedded form v5.5.1
 This note is not in the 5.5.1 spec, but is an obvious extrapolation from 5.5.
 n OBJE
@@ -147,10 +140,10 @@ n OBJE
 +3 MEDI &lt;SOURCE_MEDIA_TYPE&gt; {0:1} p.62
 +1 TITL &lt;DESCRIPTIVE_TITLE&gt; {0:1} p.48</text>
     </note>
-    <note handle="_0000000b0000000b" change="1469558671" id="N0018" type="General">
+    <note handle="_0000000b0000000b" change="1472500307" id="N0018" type="Media Note">
       <text>Multimedia embedded 2nd copy v5.5</text>
     </note>
-    <note handle="_0000000f0000000f" change="1469558671" id="N0000" type="GEDCOM import">
+    <note handle="_0000000f0000000f" change="1472500307" id="N0000" type="GEDCOM import">
       <text>Records not imported into INDI (individual) Gramps ID I0001:
 
 Could not import test_emb_55.jpg                                    Line    18: 1 OBJE 
@@ -160,10 +153,10 @@ Could not import test_emb_55.jpg                                    Line    34: 
         <range start="0" end="326"/>
       </style>
     </note>
-    <note handle="_0000001000000010" change="1469558671" id="N0001" type="REFN-TYPE">
+    <note handle="_0000001000000010" change="1472500307" id="N0001" type="REFN-TYPE">
       <text>SOMETEXT</text>
     </note>
-    <note handle="_0000001100000011" change="1469558671" id="N0011" type="General">
+    <note handle="_0000001100000011" change="1472500307" id="N0011" type="Media Note">
       <text>Media note test: Multimedia link to linked form v5.5 blob
 n @XREF:OBJE@ OBJE {1:1}
 +1 FORM &lt;MULTIMEDIA_FORMAT&gt; {1:1} p.48  
@@ -177,7 +170,7 @@ n @XREF:OBJE@ OBJE {1:1}
 +1 RIN &lt;AUTOMATED_RECORD_ID&gt; {0:1} p.38
 +1 &lt;&lt;CHANGE_DATE&gt;&gt; {0:1} p.29</text>
     </note>
-    <note handle="_0000001200000012" change="1469558671" id="N0002" type="GEDCOM import">
+    <note handle="_0000001200000012" change="1472500307" id="N0002" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M1:
 
 Tag recognized but not supported                                    Line    49: 1 BLOB 
@@ -194,7 +187,7 @@ Filename omitted                                                    Line    46: 
         <range start="0" end="1367"/>
       </style>
     </note>
-    <note handle="_0000001400000014" change="1469558671" id="N0003" type="GEDCOM import">
+    <note handle="_0000001400000014" change="1472500307" id="N0003" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M2:
 
 Tag recognized but not supported                                    Line    68: 1 BLOB 
@@ -204,7 +197,7 @@ Filename omitted                                                    Line    65: 
         <range start="0" end="400"/>
       </style>
     </note>
-    <note handle="_0000001500000015" change="1469558671" id="N0012" type="General">
+    <note handle="_0000001500000015" change="1472500307" id="N0012" type="Media Note">
       <text>Media note test: Multimedia link to linked form Gramps style v5.5ish file
 n @XREF:OBJE@ OBJE {1:1}
 +1 FORM &lt;MULTIMEDIA_FORMAT&gt; {1:1} p.48  
@@ -212,7 +205,7 @@ n @XREF:OBJE@ OBJE {1:1}
 +1 FILE &lt;MULTIMEDIA_FILE_REFERENCE&gt; {1:1} p.47
 +1 &lt;&lt;NOTE_STRUCTURE&gt;&gt; {0:M} p.33</text>
     </note>
-    <note handle="_0000001600000016" change="1469558671" id="N0004" type="GEDCOM import">
+    <note handle="_0000001600000016" change="1472500307" id="N0004" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M3:
 
 Could not import test.jpg                                           Line    73: 1 FILE test.jpg</text>
@@ -220,10 +213,10 @@ Could not import test.jpg                                           Line    73: 
         <range start="0" end="163"/>
       </style>
     </note>
-    <note handle="_0000001700000017" change="1469558671" id="N0005" type="REFN-TYPE">
+    <note handle="_0000001700000017" change="1472500307" id="N0005" type="REFN-TYPE">
       <text>SOMETEXT</text>
     </note>
-    <note handle="_0000001800000018" change="1469558671" id="N0013" type="General">
+    <note handle="_0000001800000018" change="1472500307" id="N0013" type="Media Note">
       <text>Media note test: Multimedia link to linked form v5.5.1 file
 n @XREF:OBJE@ OBJE {1:1}
 +1 FILE &lt;MULTIMEDIA_FILE_REFN&gt; {1:M} p.54
@@ -237,10 +230,10 @@ n @XREF:OBJE@ OBJE {1:1}
 +1 &lt;&lt;SOURCE_CITATION&gt;&gt; {0:M} p.39
 +1 &lt;&lt;CHANGE_DATE&gt;&gt; {0:1} p.31</text>
     </note>
-    <note handle="_0000001a0000001a" change="1469558671" id="N0006" type="Source text">
+    <note handle="_0000001a0000001a" change="1472500307" id="N0006" type="Source text">
       <text>who shall remain un-named</text>
     </note>
-    <note handle="_0000001c0000001c" change="1469558671" id="N0007" type="GEDCOM import">
+    <note handle="_0000001c0000001c" change="1472500307" id="N0007" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M4:
 
 Could not import test.jpg                                           Line    79: 1 FILE test.jpg</text>
@@ -248,14 +241,14 @@ Could not import test.jpg                                           Line    79: 
         <range start="0" end="163"/>
       </style>
     </note>
-    <note handle="_0000001d0000001d" change="1469558671" id="N0008" type="Media Note">
+    <note handle="_0000001d0000001d" change="1472500307" id="N0008" type="Media Note">
       <text>A fine gentelman was he, upstanding in his community and a great believer in the testing of open source software.</text>
     </note>
-    <note handle="_0000001e0000001e" change="1469558671" id="N0015" type="General">
+    <note handle="_0000001e0000001e" change="1472500307" id="N0015" type="Media Note">
       <text>A note on the FTM media, to see how this integrates...  The DATE line is bad; it doesnt follow Gedcom standard at all, and includes the time.
 The TEXT line comes from the FTM media description.  This is the media Note.</text>
     </note>
-    <note handle="_0000001f0000001f" change="1469558671" id="N0016" type="General">
+    <note handle="_0000001f0000001f" change="1472500307" id="N0016" type="Media Note">
       <text>Multimedia link to linked form FTM style
 n @XREF:OBJE@ OBJE {1:1}
 +1 FILE &lt;MULTIMEDIA_FILE_REFN&gt; {1:M} p.54
@@ -264,7 +257,7 @@ n @XREF:OBJE@ OBJE {1:1}
 +2 TEXT text string from FTM media description sometimes populated from exif comments
 +1 &lt;&lt;NOTE_STRUCTURE&gt;&gt; {0:M} p.33</text>
     </note>
-    <note handle="_0000002000000020" change="1469558671" id="N0009" type="GEDCOM import">
+    <note handle="_0000002000000020" change="1472500307" id="N0009" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M5:
 
 Could not import test.jpg                                           Line    94: 1 FILE test.jpg</text>
@@ -272,16 +265,16 @@ Could not import test.jpg                                           Line    94: 
         <range start="0" end="163"/>
       </style>
     </note>
-    <note handle="_0000002100000021" change="1469558671" id="N0017" type="REFN-TYPE">
+    <note handle="_0000002100000021" change="1472500307" id="N0017" type="REFN-TYPE">
       <text>SOMETEXT</text>
     </note>
-    <note handle="_0000002200000022" change="1469558671" id="N0019" type="General">
+    <note handle="_0000002200000022" change="1472500307" id="N0019" type="Media Note">
       <text>Multimedia link to linked form v5.5.1 with two files</text>
     </note>
-    <note handle="_0000002400000024" change="1469558671" id="N0020" type="Source text">
+    <note handle="_0000002400000024" change="1472500307" id="N0020" type="Source text">
       <text>A source who shall remain un-named</text>
     </note>
-    <note handle="_0000002600000026" change="1469558671" id="N0021" type="GEDCOM import">
+    <note handle="_0000002600000026" change="1472500307" id="N0021" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M6:
 
 Could not import test.jpg                                           Line   102: 1 FILE test.jpg
@@ -293,7 +286,7 @@ Skipped subordinate line                                            Line   109: 
         <range start="0" end="588"/>
       </style>
     </note>
-    <note handle="_0000002700000027" change="1469558671" id="N0022" type="GEDCOM import">
+    <note handle="_0000002700000027" change="1472500307" id="N0022" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M8:
 
 Could not import No_path_No_Title_NoForm.jpg                        Line   129: 1 FILE No_path_No_Title_NoForm.jpg</text>

--- a/data/tests/imp_MixInlineXrefNote.gramps
+++ b/data/tests/imp_MixInlineXrefNote.gramps
@@ -3,19 +3,12 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-05-25" version="5.0.0"/>
+    <created date="2016-08-29" version="5.0.0-alpha1"/>
     <researcher>
-      <resname>Paul Culley</resname>
-      <resaddr>11210 Olde Mint House Ln</resaddr>
-      <rescity>Tomball</rescity>
-      <resstate>Tx</resstate>
-      <rescountry>USA</rescountry>
-      <respostal>77375</respostal>
-      <resemail>paulr2787@gmail.com</resemail>
     </researcher>
   </header>
   <people>
-    <person handle="_0000000100000001" change="1464191690" id="I0001">
+    <person handle="_0000000100000001" change="1472500307" id="I0001">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Living1</first>
@@ -25,7 +18,7 @@
       <noteref hlink="_0000000400000004"/>
       <citationref hlink="_0000000600000006"/>
     </person>
-    <person handle="_0000000700000007" change="1464191690" id="I0000">
+    <person handle="_0000000700000007" change="1472500307" id="I0000">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Living01</first>
@@ -34,37 +27,37 @@
     </person>
   </people>
   <citations>
-    <citation handle="_0000000600000006" change="1464191690" id="C0000">
+    <citation handle="_0000000600000006" change="1472500307" id="C0000">
       <confidence>2</confidence>
       <sourceref hlink="_0000000500000005"/>
     </citation>
-    <citation handle="_0000000900000009" change="1464191690" id="C0001">
+    <citation handle="_0000000900000009" change="1472500307" id="C0001">
       <confidence>2</confidence>
       <sourceref hlink="_0000000800000008"/>
     </citation>
   </citations>
   <sources>
-    <source handle="_0000000500000005" change="1464191690" id="S0004">
+    <source handle="_0000000500000005" change="1472500307" id="S0004">
       <stitle>Inline Source 1</stitle>
     </source>
-    <source handle="_0000000800000008" change="1464191690" id="S0005">
+    <source handle="_0000000800000008" change="1472500307" id="S0005">
       <stitle>inline Source 2</stitle>
     </source>
-    <source handle="_0000000a0000000a" change="1464191690" id="S0002">
+    <source handle="_0000000a0000000a" change="1472500307" id="S0002">
       <stitle>Source S1</stitle>
     </source>
-    <source handle="_0000000b0000000b" change="1464191690" id="S0003">
+    <source handle="_0000000b0000000b" change="1472500307" id="S0003">
       <stitle>Source S01</stitle>
     </source>
   </sources>
   <notes>
-    <note handle="_0000000200000002" change="1464191690" id="N0000" type="General">
+    <note handle="_0000000200000002" change="1472500307" id="N0000" type="Person Note">
       <text>Inline 0</text>
     </note>
-    <note handle="_0000000300000003" change="1464191690" id="N0001" type="General">
+    <note handle="_0000000300000003" change="1472500307" id="N0001" type="Person Note">
       <text>XREF N0</text>
     </note>
-    <note handle="_0000000400000004" change="1464191690" id="N0002" type="General">
+    <note handle="_0000000400000004" change="1472500307" id="N0002" type="Person Note">
       <text>Inline 1</text>
     </note>
   </notes>

--- a/data/tests/imp_PhonFax_dfs.gramps
+++ b/data/tests/imp_PhonFax_dfs.gramps
@@ -3,7 +3,7 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-08-23" version="5.0.0-alpha1"/>
+    <created date="2016-08-29" version="5.0.0-alpha1"/>
     <researcher>
       <resname>The Subm /Tester/</resname>
       <resaddr>123 Main St.</resaddr>
@@ -15,7 +15,7 @@
     </researcher>
   </header>
   <events>
-    <event handle="_0000000700000007" change="1471971539" id="E0000">
+    <event handle="_0000000700000007" change="1472500308" id="E0000">
       <type>Birth</type>
       <dateval val="1954-12-29"/>
       <place hlink="_0000000800000008"/>
@@ -25,7 +25,7 @@
       <attribute type="FAX" value="440-123-4567"/>
       <attribute type="WWW" value="http://thetester.com"/>
     </event>
-    <event handle="_0000000c0000000c" change="1471971539" id="E0001">
+    <event handle="_0000000c0000000c" change="1472500308" id="E0001">
       <type>Residence</type>
       <dateval val="1954-12-30"/>
       <place hlink="_0000000e0000000e"/>
@@ -35,7 +35,7 @@
       <attribute type="WWW" value="http://mrstester.com"/>
       <noteref hlink="_0000000d0000000d"/>
     </event>
-    <event handle="_0000001100000011" change="1471971539" id="E0002">
+    <event handle="_0000001100000011" change="1472500308" id="E0002">
       <type>Residence</type>
       <dateval val="1964"/>
       <attribute type="Phone" value="440-871-3402"/>
@@ -45,7 +45,7 @@
     </event>
   </events>
   <people>
-    <person handle="_0000000600000006" change="1471971539" id="I0000">
+    <person handle="_0000000600000006" change="1472500308" id="I0000">
       <gender>U</gender>
       <name type="Birth Name">
         <first>The</first>
@@ -54,7 +54,7 @@
       <eventref hlink="_0000000700000007" role="Primary"/>
       <citationref hlink="_0000000900000009"/>
     </person>
-    <person handle="_0000000a0000000a" change="1471971539" id="I0001">
+    <person handle="_0000000a0000000a" change="1472500308" id="I0001">
       <gender>U</gender>
       <name type="Birth Name">
         <first>Mrs</first>
@@ -75,7 +75,7 @@
       <noteref hlink="_0000000b0000000b"/>
       <citationref hlink="_0000000f0000000f"/>
     </person>
-    <person handle="_0000001000000010" change="1471971539" id="I0002">
+    <person handle="_0000001000000010" change="1472500308" id="I0002">
       <gender>U</gender>
       <name type="Birth Name">
         <first>Tom</first>
@@ -86,21 +86,21 @@
     </person>
   </people>
   <citations>
-    <citation handle="_0000000900000009" change="1471971539" id="C0000">
+    <citation handle="_0000000900000009" change="1472500308" id="C0000">
       <confidence>2</confidence>
       <sourceref hlink="_0000000300000003"/>
     </citation>
-    <citation handle="_0000000f0000000f" change="1471971539" id="C0001">
+    <citation handle="_0000000f0000000f" change="1472500308" id="C0001">
       <confidence>2</confidence>
       <sourceref hlink="_0000000300000003"/>
     </citation>
-    <citation handle="_0000001200000012" change="1471971539" id="C0002">
+    <citation handle="_0000001200000012" change="1472500308" id="C0002">
       <confidence>2</confidence>
       <sourceref hlink="_0000000300000003"/>
     </citation>
   </citations>
   <sources>
-    <source handle="_0000000300000003" change="1471971539" id="S0000">
+    <source handle="_0000000300000003" change="1472500308" id="S0000">
       <stitle>Import from imp_FTM_LINK.ged</stitle>
       <srcattribute type="Approved system identification" value="FTM"/>
       <srcattribute type="Version number of software product" value="Family Tree Maker (22.0.0.1410)"/>
@@ -112,45 +112,45 @@
       <reporef hlink="_0000000100000001" medium="Unknown"/>
       <reporef hlink="_0000000400000004" medium="Unknown"/>
     </source>
-    <source handle="_0000001300000013" change="1471971539" id="S0006">
+    <source handle="_0000001300000013" change="1472500308" id="S0006">
       <stitle>Ohio Births, 1958-2002</stitle>
       <reporef hlink="_0000001400000014" medium="Book"/>
     </source>
   </sources>
   <places>
-    <placeobj handle="_0000000800000008" change="1471971539" id="P0000" type="Street">
+    <placeobj handle="_0000000800000008" change="1472500308" id="P0000" type="Street">
       <ptitle>123 High St, Cleveland, Cuyahoga, Ohio, USA, 44140</ptitle>
       <code>44140</code>
       <pname value="123 High St"/>
       <placeref hlink="_0000001a0000001a"/>
     </placeobj>
-    <placeobj handle="_0000000e0000000e" change="1471971539" id="P0001" type="Address">
+    <placeobj handle="_0000000e0000000e" change="1472500308" id="P0001" type="Address">
       <ptitle>123 Main St., Winslow, PA, 12345</ptitle>
       <pname value="123 Main St., Winslow, PA, 12345"/>
       <location street="123 Main St." city="Winslow" state="PA" postal="12345"/>
     </placeobj>
-    <placeobj handle="_0000001700000017" change="1471971539" id="P0002" type="Country">
+    <placeobj handle="_0000001700000017" change="1472500308" id="P0002" type="Country">
       <ptitle>USA</ptitle>
       <pname value="USA"/>
     </placeobj>
-    <placeobj handle="_0000001800000018" change="1471971539" id="P0003" type="State">
+    <placeobj handle="_0000001800000018" change="1472500308" id="P0003" type="State">
       <ptitle>Ohio, USA</ptitle>
       <pname value="Ohio"/>
       <placeref hlink="_0000001700000017"/>
     </placeobj>
-    <placeobj handle="_0000001900000019" change="1471971539" id="P0004" type="County">
+    <placeobj handle="_0000001900000019" change="1472500308" id="P0004" type="County">
       <ptitle>Cuyahoga, Ohio, USA</ptitle>
       <pname value="Cuyahoga"/>
       <placeref hlink="_0000001800000018"/>
     </placeobj>
-    <placeobj handle="_0000001a0000001a" change="1471971539" id="P0005" type="City">
+    <placeobj handle="_0000001a0000001a" change="1472500308" id="P0005" type="City">
       <ptitle>Cleveland, Cuyahoga, Ohio, USA</ptitle>
       <pname value="Cleveland"/>
       <placeref hlink="_0000001900000019"/>
     </placeobj>
   </places>
   <repositories>
-    <repository handle="_0000000100000001" change="1471971539" id="R0000">
+    <repository handle="_0000000100000001" change="1472500308" id="R0000">
       <rname>Business that produced the product: Ancestry.com</rname>
       <type>GEDCOM data</type>
       <address>
@@ -161,7 +161,7 @@
       <url  href="help@ancestry.com" type="E-mail"/>
       <url  href="http://www.ancestry.com" type="Web Home"/>
     </repository>
-    <repository handle="_0000000400000004" change="1471971539" id="R0001">
+    <repository handle="_0000000400000004" change="1472500308" id="R0001">
       <rname>SUBM (Submitter): (@SUBM@) The Subm /Tester/</rname>
       <type>GEDCOM data</type>
       <address>
@@ -176,7 +176,7 @@
       <url  href="http://mrstester.com" type="Web Home"/>
       <noteref hlink="_0000000500000005"/>
     </repository>
-    <repository handle="_0000001400000014" change="1471971539" id="R0002">
+    <repository handle="_0000001400000014" change="1472500308" id="R0002">
       <rname>Testers Repository</rname>
       <type>Library</type>
       <address>
@@ -191,7 +191,7 @@
     </repository>
   </repositories>
   <notes>
-    <note handle="_0000000200000002" change="1471971539" id="N0000" type="GEDCOM import">
+    <note handle="_0000000200000002" change="1472500308" id="N0000" type="GEDCOM import">
       <text>Records not imported into HEAD (header):
 
 Only one phone number supported                                     Line     9: 3 PHON (800) 705-7000</text>
@@ -199,7 +199,7 @@ Only one phone number supported                                     Line     9: 
         <range start="0" end="144"/>
       </style>
     </note>
-    <note handle="_0000000500000005" change="1471971539" id="N0001" type="GEDCOM import">
+    <note handle="_0000000500000005" change="1472500308" id="N0001" type="GEDCOM import">
       <text>Records not imported into SUBM (Submitter): (@SUBM@) The Subm /Tester/:
 
 Only one phone number supported                                     Line    29: 1 PHON 800-871-3401</text>
@@ -207,16 +207,16 @@ Only one phone number supported                                     Line    29: 
         <range start="0" end="173"/>
       </style>
     </note>
-    <note handle="_0000000b0000000b" change="1471971539" id="N0002" type="General">
+    <note handle="_0000000b0000000b" change="1472500308" id="N0002" type="Person Note">
       <text>Address with PHON,FAX,EMAIL,WWW. attached directly to person is not legal Gedcom, but allowed here.</text>
     </note>
-    <note handle="_0000000d0000000d" change="1471971539" id="N0003" type="General">
+    <note handle="_0000000d0000000d" change="1472500308" id="N0003" type="Event Note">
       <text>Address as event is legal, with PHON,FAX,EMAIL,WWW</text>
     </note>
-    <note handle="_0000001500000015" change="1471971539" id="N0004" type="General">
+    <note handle="_0000001500000015" change="1472500308" id="N0004" type="Repository Note">
       <text>The repository record</text>
     </note>
-    <note handle="_0000001600000016" change="1471971539" id="N0005" type="GEDCOM import">
+    <note handle="_0000001600000016" change="1472500308" id="N0005" type="GEDCOM import">
       <text>Records not imported into REPO (repository) Gramps ID R0002:
 
 Only one phone number supported                                     Line    87: 1 PHON 800-765-4321</text>

--- a/data/tests/imp_bug_8322_test.gramps
+++ b/data/tests/imp_bug_8322_test.gramps
@@ -3,169 +3,162 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-05-23" version="GrampsAIO64-4.2.1-2"/>
+    <created date="2016-08-29" version="5.0.0-alpha1"/>
     <researcher>
-      <resname>Paul Culley</resname>
-      <resaddr>11210 Olde Mint House Ln</resaddr>
-      <rescity>Tomball</rescity>
-      <resstate>Tx</resstate>
-      <rescountry>USA</rescountry>
-      <respostal>77375</respostal>
-      <resemail>paulr2787@gmail.com</resemail>
     </researcher>
   </header>
   <events>
-    <event handle="_0000000200000002" change="1464033808" id="E0000">
+    <event handle="_0000000200000002" change="1472500316" id="E0000">
       <type>Residence</type>
       <dateval val="1960"/>
       <place hlink="_0000000500000005"/>
     </event>
-    <event handle="_0000000600000006" change="1464033808" id="E0001">
+    <event handle="_0000000600000006" change="1472500316" id="E0001">
       <type>Residence</type>
       <dateval val="1961"/>
       <place hlink="_0000000900000009"/>
     </event>
-    <event handle="_0000000a0000000a" change="1464033808" id="E0002">
+    <event handle="_0000000a0000000a" change="1472500316" id="E0002">
       <type>Residence</type>
       <dateval val="1962"/>
       <place hlink="_0000000400000004"/>
     </event>
-    <event handle="_0000000c0000000c" change="1464033808" id="E0003">
+    <event handle="_0000000c0000000c" change="1472500316" id="E0003">
       <type>Residence</type>
       <dateval val="1962"/>
       <place hlink="_0000000e0000000e"/>
     </event>
-    <event handle="_0000000f0000000f" change="1464033808" id="E0004">
+    <event handle="_0000000f0000000f" change="1472500316" id="E0004">
       <type>Residence</type>
       <dateval val="1963"/>
       <place hlink="_0000001100000011"/>
     </event>
-    <event handle="_0000001200000012" change="1464033808" id="E0005">
+    <event handle="_0000001200000012" change="1472500316" id="E0005">
       <type>Residence</type>
       <dateval val="1964"/>
       <place hlink="_0000001400000014"/>
     </event>
-    <event handle="_0000001500000015" change="1464033808" id="E0006">
+    <event handle="_0000001500000015" change="1472500316" id="E0006">
       <type>Residence</type>
       <dateval val="1965"/>
       <place hlink="_0000001600000016"/>
     </event>
-    <event handle="_0000001700000017" change="1464033808" id="E0007">
+    <event handle="_0000001700000017" change="1472500316" id="E0007">
       <type>Residence</type>
       <dateval val="1966"/>
       <place hlink="_0000001400000014"/>
     </event>
-    <event handle="_0000001900000019" change="1464033808" id="E0008">
+    <event handle="_0000001900000019" change="1472500316" id="E0008">
       <type>Residence</type>
       <dateval val="1967"/>
       <place hlink="_0000001c0000001c"/>
     </event>
-    <event handle="_0000001d0000001d" change="1464033808" id="E0009">
+    <event handle="_0000001d0000001d" change="1472500316" id="E0009">
       <type>Residence</type>
       <dateval val="1968"/>
       <place hlink="_0000002100000021"/>
     </event>
-    <event handle="_0000002200000022" change="1464033808" id="E0010">
+    <event handle="_0000002200000022" change="1472500316" id="E0010">
       <type>Residence</type>
       <dateval val="1971"/>
       <place hlink="_0000002400000024"/>
     </event>
-    <event handle="_0000002500000025" change="1464033808" id="E0011">
+    <event handle="_0000002500000025" change="1472500316" id="E0011">
       <type>Residence</type>
       <dateval val="1972"/>
       <place hlink="_0000002400000024"/>
     </event>
-    <event handle="_0000002800000028" change="1464033808" id="E0012">
+    <event handle="_0000002800000028" change="1472500316" id="E0012">
       <type>Residence</type>
       <dateval val="1973"/>
       <place hlink="_0000002a0000002a"/>
     </event>
-    <event handle="_0000002b0000002b" change="1464033808" id="E0013">
+    <event handle="_0000002b0000002b" change="1472500316" id="E0013">
       <type>Residence</type>
       <dateval val="1973"/>
       <place hlink="_0000002400000024"/>
     </event>
-    <event handle="_0000002d0000002d" change="1464033808" id="E0014">
+    <event handle="_0000002d0000002d" change="1472500316" id="E0014">
       <type>Residence</type>
       <dateval val="1974"/>
       <place hlink="_0000002f0000002f"/>
     </event>
-    <event handle="_0000003000000030" change="1464033808" id="E0015">
+    <event handle="_0000003000000030" change="1472500316" id="E0015">
       <type>Residence</type>
       <dateval val="1975"/>
       <place hlink="_0000003200000032"/>
     </event>
-    <event handle="_0000003300000033" change="1464033808" id="E0016">
+    <event handle="_0000003300000033" change="1472500316" id="E0016">
       <type>Residence</type>
       <dateval val="1976"/>
       <place hlink="_0000003700000037"/>
     </event>
-    <event handle="_0000003800000038" change="1464033808" id="E0017">
+    <event handle="_0000003800000038" change="1472500316" id="E0017">
       <type>Residence</type>
       <dateval val="1977"/>
       <place hlink="_0000003a0000003a"/>
     </event>
-    <event handle="_0000003b0000003b" change="1464033808" id="E0018">
+    <event handle="_0000003b0000003b" change="1472500316" id="E0018">
       <type>Residence</type>
       <dateval val="1966"/>
       <place hlink="_0000003e0000003e"/>
     </event>
-    <event handle="_0000003f0000003f" change="1464033808" id="E0019">
+    <event handle="_0000003f0000003f" change="1472500316" id="E0019">
       <type>Residence</type>
       <dateval val="1969"/>
       <place hlink="_0000004200000042"/>
     </event>
-    <event handle="_0000004300000043" change="1464033808" id="E0020">
+    <event handle="_0000004300000043" change="1472500316" id="E0020">
       <type>Residence</type>
       <dateval val="1978"/>
       <place hlink="_0000004500000045"/>
     </event>
-    <event handle="_0000004600000046" change="1464033808" id="E0021">
+    <event handle="_0000004600000046" change="1472500316" id="E0021">
       <type>Residence</type>
       <dateval val="1979"/>
       <place hlink="_0000004800000048"/>
     </event>
-    <event handle="_0000004900000049" change="1464033808" id="E0022">
+    <event handle="_0000004900000049" change="1472500316" id="E0022">
       <type>Residence</type>
       <dateval val="1984"/>
       <place hlink="_0000004b0000004b"/>
     </event>
-    <event handle="_0000004c0000004c" change="1464033808" id="E0023">
+    <event handle="_0000004c0000004c" change="1472500316" id="E0023">
       <type>Residence</type>
       <dateval val="1984"/>
       <place hlink="_0000004400000044"/>
     </event>
-    <event handle="_0000004d0000004d" change="1464033808" id="E0024">
+    <event handle="_0000004d0000004d" change="1472500316" id="E0024">
       <type>Residence</type>
       <dateval val="1984"/>
       <place hlink="_0000004e0000004e"/>
     </event>
-    <event handle="_0000004f0000004f" change="1464033808" id="E0025">
+    <event handle="_0000004f0000004f" change="1472500316" id="E0025">
       <type>Residence</type>
       <dateval val="1984"/>
       <place hlink="_0000004b0000004b"/>
     </event>
-    <event handle="_0000005100000051" change="1464033808" id="E0026">
+    <event handle="_0000005100000051" change="1472500316" id="E0026">
       <type>Residence</type>
       <dateval val="1988"/>
       <place hlink="_0000005300000053"/>
     </event>
-    <event handle="_0000005400000054" change="1464033808" id="E0027">
+    <event handle="_0000005400000054" change="1472500316" id="E0027">
       <type>Residence</type>
       <dateval val="1994"/>
       <place hlink="_0000005200000052"/>
     </event>
-    <event handle="_0000005600000056" change="1464033808" id="E0028">
+    <event handle="_0000005600000056" change="1472500316" id="E0028">
       <type>Residence</type>
       <dateval val="1994"/>
       <place hlink="_0000005800000058"/>
     </event>
-    <event handle="_0000005900000059" change="1464033808" id="E0029">
+    <event handle="_0000005900000059" change="1472500316" id="E0029">
       <type>Residence</type>
       <dateval val="1988"/>
       <place hlink="_0000005b0000005b"/>
     </event>
-    <event handle="_0000005c0000005c" change="1464033808" id="E0030">
+    <event handle="_0000005c0000005c" change="1472500316" id="E0030">
       <type>Residence</type>
       <dateval val="1994"/>
       <place hlink="_0000005d0000005d"/>
@@ -213,76 +206,76 @@
     </person>
   </people>
   <places>
-    <placeobj handle="_0000000400000004" change="1464033808" id="P0000" type="Unknown">
+    <placeobj handle="_0000000400000004" change="1472500316" id="P0000" type="Unknown">
       <ptitle>the place</ptitle>
       <pname value="the place"/>
       <noteref hlink="_0000000700000007"/>
       <noteref hlink="_0000000b0000000b"/>
     </placeobj>
-    <placeobj handle="_0000000500000005" change="1464033808" id="P0001" type="Detail">
+    <placeobj handle="_0000000500000005" change="1472500316" id="P0001" type="Detail">
       <ptitle>the address</ptitle>
       <pname value="the address"/>
       <placeref hlink="_0000000400000004"/>
       <noteref hlink="_0000000300000003"/>
     </placeobj>
-    <placeobj handle="_0000000900000009" change="1464033808" id="P0002" type="Detail">
+    <placeobj handle="_0000000900000009" change="1472500316" id="P0002" type="Detail">
       <ptitle>the address</ptitle>
       <pname value="the address"/>
       <placeref hlink="_0000000400000004"/>
       <noteref hlink="_0000000800000008"/>
     </placeobj>
-    <placeobj handle="_0000000e0000000e" change="1464033808" id="P0003" type="Detail">
+    <placeobj handle="_0000000e0000000e" change="1472500316" id="P0003" type="Detail">
       <ptitle>another address</ptitle>
       <pname value="another address"/>
       <placeref hlink="_0000000400000004"/>
       <noteref hlink="_0000000d0000000d"/>
     </placeobj>
-    <placeobj handle="_0000001100000011" change="1464033808" id="P0004" type="Detail">
+    <placeobj handle="_0000001100000011" change="1472500316" id="P0004" type="Detail">
       <ptitle>another address</ptitle>
       <pname value="another address"/>
       <placeref hlink="_0000000400000004"/>
       <noteref hlink="_0000001000000010"/>
     </placeobj>
-    <placeobj handle="_0000001400000014" change="1464033808" id="P0005" type="Address">
+    <placeobj handle="_0000001400000014" change="1472500316" id="P0005" type="Address">
       <ptitle>the place</ptitle>
       <pname value="the place"/>
       <location street="the address"/>
       <noteref hlink="_0000001300000013"/>
       <noteref hlink="_0000001800000018"/>
     </placeobj>
-    <placeobj handle="_0000001600000016" change="1464033808" id="P0006" type="Address">
+    <placeobj handle="_0000001600000016" change="1472500316" id="P0006" type="Address">
       <ptitle>the address</ptitle>
       <pname value="the address"/>
       <location street="the address"/>
     </placeobj>
-    <placeobj handle="_0000001b0000001b" change="1464033808" id="P0007" type="Detail">
+    <placeobj handle="_0000001b0000001b" change="1472500316" id="P0007" type="Detail">
       <ptitle>the address</ptitle>
       <pname value="the address"/>
       <placeref hlink="_0000000400000004"/>
     </placeobj>
-    <placeobj handle="_0000001c0000001c" change="1464033808" id="P0008" type="Detail">
+    <placeobj handle="_0000001c0000001c" change="1472500316" id="P0008" type="Detail">
       <ptitle>second address</ptitle>
       <pname value="second address"/>
       <placeref hlink="_0000001b0000001b"/>
       <noteref hlink="_0000001a0000001a"/>
     </placeobj>
-    <placeobj handle="_0000001f0000001f" change="1464033808" id="P0009" type="Address">
+    <placeobj handle="_0000001f0000001f" change="1472500316" id="P0009" type="Address">
       <ptitle>the place 2</ptitle>
       <pname value="the place 2"/>
       <location street="the address 2"/>
     </placeobj>
-    <placeobj handle="_0000002000000020" change="1464033808" id="P0010" type="Detail">
+    <placeobj handle="_0000002000000020" change="1472500316" id="P0010" type="Detail">
       <ptitle>second address</ptitle>
       <pname value="second address"/>
       <placeref hlink="_0000001f0000001f"/>
       <noteref hlink="_0000001e0000001e"/>
     </placeobj>
-    <placeobj handle="_0000002100000021" change="1464033808" id="P0011" type="Detail">
+    <placeobj handle="_0000002100000021" change="1472500316" id="P0011" type="Detail">
       <ptitle>a third address ignored again</ptitle>
       <pname value="a third address ignored again"/>
       <placeref hlink="_0000002000000020"/>
     </placeobj>
-    <placeobj handle="_0000002400000024" change="1464033808" id="P0012" type="Address">
+    <placeobj handle="_0000002400000024" change="1472500316" id="P0012" type="Address">
       <ptitle>place test</ptitle>
       <pname value="place test"/>
       <location street="address place test"/>
@@ -291,203 +284,203 @@
       <noteref hlink="_0000002700000027"/>
       <noteref hlink="_0000002c0000002c"/>
     </placeobj>
-    <placeobj handle="_0000002a0000002a" change="1464033808" id="P0013" type="Address">
+    <placeobj handle="_0000002a0000002a" change="1472500316" id="P0013" type="Address">
       <ptitle>address place test</ptitle>
       <pname value="address place test"/>
       <location street="address place test"/>
       <noteref hlink="_0000002900000029"/>
     </placeobj>
-    <placeobj handle="_0000002f0000002f" change="1464033808" id="P0014" type="Address">
+    <placeobj handle="_0000002f0000002f" change="1472500316" id="P0014" type="Address">
       <ptitle>different place test</ptitle>
       <pname value="different place test"/>
       <location street="address place test"/>
       <noteref hlink="_0000002e0000002e"/>
     </placeobj>
-    <placeobj handle="_0000003200000032" change="1464033808" id="P0015" type="Detail">
+    <placeobj handle="_0000003200000032" change="1472500316" id="P0015" type="Detail">
       <ptitle>address place test</ptitle>
       <pname value="address place test"/>
       <placeref hlink="_0000000400000004"/>
       <noteref hlink="_0000003100000031"/>
     </placeobj>
-    <placeobj handle="_0000003500000035" change="1464033808" id="P0016" type="Unknown">
+    <placeobj handle="_0000003500000035" change="1472500316" id="P0016" type="Unknown">
       <ptitle>a new place</ptitle>
       <pname value="a new place"/>
     </placeobj>
-    <placeobj handle="_0000003600000036" change="1464033808" id="P0017" type="Detail">
+    <placeobj handle="_0000003600000036" change="1472500316" id="P0017" type="Detail">
       <ptitle>address place test</ptitle>
       <pname value="address place test"/>
       <placeref hlink="_0000003500000035"/>
       <noteref hlink="_0000003400000034"/>
     </placeobj>
-    <placeobj handle="_0000003700000037" change="1464033808" id="P0018" type="Detail">
+    <placeobj handle="_0000003700000037" change="1472500316" id="P0018" type="Detail">
       <ptitle>plus an address just for good measure also ignored</ptitle>
       <pname value="plus an address just for good measure also ignored"/>
       <placeref hlink="_0000003600000036"/>
     </placeobj>
-    <placeobj handle="_0000003a0000003a" change="1464033808" id="P0019" type="Address">
+    <placeobj handle="_0000003a0000003a" change="1472500316" id="P0019" type="Address">
       <ptitle>address with no place</ptitle>
       <pname value="address with no place"/>
       <location street="address with no place"/>
       <noteref hlink="_0000003900000039"/>
     </placeobj>
-    <placeobj handle="_0000003d0000003d" change="1464033808" id="P0020" type="Unknown">
+    <placeobj handle="_0000003d0000003d" change="1472500316" id="P0020" type="Unknown">
       <ptitle>Woerden, Zuid-Holland, Netherlands</ptitle>
       <pname value="Woerden, Zuid-Holland, Netherlands"/>
       <noteref hlink="_0000003c0000003c"/>
     </placeobj>
-    <placeobj handle="_0000003e0000003e" change="1464033808" id="P0021" type="Detail">
+    <placeobj handle="_0000003e0000003e" change="1472500316" id="P0021" type="Detail">
       <ptitle>Kromwijkerkade 63</ptitle>
       <pname value="Kromwijkerkade 63"/>
       <placeref hlink="_0000003d0000003d"/>
     </placeobj>
-    <placeobj handle="_0000004100000041" change="1464033808" id="P0022" type="Unknown">
+    <placeobj handle="_0000004100000041" change="1472500316" id="P0022" type="Unknown">
       <ptitle>Hasselt, Overijssel, Netherlands</ptitle>
       <pname value="Hasselt, Overijssel, Netherlands"/>
     </placeobj>
-    <placeobj handle="_0000004200000042" change="1464033808" id="P0023" type="Detail">
+    <placeobj handle="_0000004200000042" change="1472500316" id="P0023" type="Detail">
       <ptitle>Prinsenstraat 69</ptitle>
       <pname value="Prinsenstraat 69"/>
       <placeref hlink="_0000004100000041"/>
       <noteref hlink="_0000004000000040"/>
     </placeobj>
-    <placeobj handle="_0000004400000044" change="1464033808" id="P0024" type="Unknown">
+    <placeobj handle="_0000004400000044" change="1472500316" id="P0024" type="Unknown">
       <ptitle>Enschede, Overijssel, Netherlands</ptitle>
       <pname value="Enschede, Overijssel, Netherlands"/>
     </placeobj>
-    <placeobj handle="_0000004500000045" change="1464033808" id="P0025" type="Detail">
+    <placeobj handle="_0000004500000045" change="1472500316" id="P0025" type="Detail">
       <ptitle>Calslaan 26-52</ptitle>
       <pname value="Calslaan 26-52"/>
       <placeref hlink="_0000004400000044"/>
     </placeobj>
-    <placeobj handle="_0000004800000048" change="1464033808" id="P0026" type="Detail">
+    <placeobj handle="_0000004800000048" change="1472500316" id="P0026" type="Detail">
       <ptitle>Calslaan 26-44</ptitle>
       <pname value="Calslaan 26-44"/>
       <placeref hlink="_0000004400000044"/>
       <noteref hlink="_0000004700000047"/>
     </placeobj>
-    <placeobj handle="_0000004b0000004b" change="1464033808" id="P0027" type="Address">
+    <placeobj handle="_0000004b0000004b" change="1472500316" id="P0027" type="Address">
       <ptitle>Enschede, Overijssel, Netherlands</ptitle>
       <pname value="Enschede, Overijssel, Netherlands"/>
       <location street="Calslaan 26-61"/>
       <noteref hlink="_0000004a0000004a"/>
       <noteref hlink="_0000005000000050"/>
     </placeobj>
-    <placeobj handle="_0000004e0000004e" change="1464033808" id="P0028" type="Address">
+    <placeobj handle="_0000004e0000004e" change="1472500316" id="P0028" type="Address">
       <ptitle>Calslaan 26-61</ptitle>
       <pname value="Calslaan 26-61"/>
       <location street="Calslaan 26-61"/>
     </placeobj>
-    <placeobj handle="_0000005200000052" change="1464033808" id="P0029" type="Unknown">
+    <placeobj handle="_0000005200000052" change="1472500316" id="P0029" type="Unknown">
       <ptitle>Amsterdam, Noord-Holland, Netherlands</ptitle>
       <pname value="Amsterdam, Noord-Holland, Netherlands"/>
       <noteref hlink="_0000005500000055"/>
     </placeobj>
-    <placeobj handle="_0000005300000053" change="1464033808" id="P0030" type="Detail">
+    <placeobj handle="_0000005300000053" change="1472500316" id="P0030" type="Detail">
       <ptitle>Papendrechtstraat 37</ptitle>
       <pname value="Papendrechtstraat 37"/>
       <placeref hlink="_0000005200000052"/>
     </placeobj>
-    <placeobj handle="_0000005800000058" change="1464033808" id="P0031" type="Detail">
+    <placeobj handle="_0000005800000058" change="1472500316" id="P0031" type="Detail">
       <ptitle>Olympiaplein 46-2</ptitle>
       <pname value="Olympiaplein 46-2"/>
       <placeref hlink="_0000005200000052"/>
       <noteref hlink="_0000005700000057"/>
     </placeobj>
-    <placeobj handle="_0000005b0000005b" change="1464033808" id="P0032" type="Detail">
+    <placeobj handle="_0000005b0000005b" change="1472500316" id="P0032" type="Detail">
       <ptitle>Papendrechtstraat 37</ptitle>
       <pname value="Papendrechtstraat 37"/>
       <placeref hlink="_0000005200000052"/>
       <noteref hlink="_0000005a0000005a"/>
     </placeobj>
-    <placeobj handle="_0000005d0000005d" change="1464033808" id="P0033" type="Address">
+    <placeobj handle="_0000005d0000005d" change="1472500316" id="P0033" type="Address">
       <ptitle>Amsterdam, Noord-Holland, Netherlands</ptitle>
       <pname value="Amsterdam, Noord-Holland, Netherlands"/>
       <location street="remembered address that should be set into place"/>
     </placeobj>
   </places>
   <notes>
-    <note handle="_0000000300000003" change="1464033808" id="N0000" type="General">
+    <note handle="_0000000300000003" change="1472500316" id="N0000" type="Place Note">
       <text>the place created not previously used so changed to add the address; __event_addr(len==0, place is None)</text>
     </note>
-    <note handle="_0000000700000007" change="1464033808" id="N0001" type="General">
+    <note handle="_0000000700000007" change="1472500316" id="N0001" type="Place Note">
       <text>check that this note is retained when the place is deleted. it should be merged into place</text>
     </note>
-    <note handle="_0000000800000008" change="1464033808" id="N0002" type="General">
+    <note handle="_0000000800000008" change="1472500316" id="N0002" type="Place Note">
       <text>the place created and then deleted and old data reused; __event_addr(len==0, place is not None)</text>
     </note>
-    <note handle="_0000000b0000000b" change="1464033808" id="N0003" type="General">
+    <note handle="_0000000b0000000b" change="1472500316" id="N0003" type="Place Note">
       <text>setup the place</text>
     </note>
-    <note handle="_0000000d0000000d" change="1464033808" id="N0004" type="General">
+    <note handle="_0000000d0000000d" change="1472500316" id="N0004" type="Place Note">
       <text>the place already exists; but now set doesn't match ; __event_addr(len!=0, place is None)</text>
     </note>
-    <note handle="_0000001000000010" change="1464033808" id="N0005" type="General">
+    <note handle="_0000001000000010" change="1472500316" id="N0005" type="Place Note">
       <text>the place already exists but now set matches; __event_addr(len!=0, place is not None)</text>
     </note>
-    <note handle="_0000001300000013" change="1464033808" id="N0006" type="General">
+    <note handle="_0000001300000013" change="1472500316" id="N0006" type="Place Note">
       <text>the address created, then destroyed as we find a matching set; __event_addr(no place_handle, create place)</text>
     </note>
-    <note handle="_0000001800000018" change="1464033808" id="N0007" type="General">
+    <note handle="_0000001800000018" change="1472500316" id="N0007" type="Place Note">
       <text>address reused, then destroyed as we find a matching set; __event_addr(no place_handle, place found)</text>
     </note>
-    <note handle="_0000001a0000001a" change="1464033808" id="N0008" type="General">
+    <note handle="_0000001a0000001a" change="1472500316" id="N0008" type="Place Note">
       <text>second address ignored</text>
     </note>
-    <note handle="_0000001e0000001e" change="1464033808" id="N0009" type="General">
+    <note handle="_0000001e0000001e" change="1472500316" id="N0009" type="Place Note">
       <text>second address ignored again</text>
     </note>
-    <note handle="_0000002300000023" change="1464033808" id="N0010" type="General">
+    <note handle="_0000002300000023" change="1472500316" id="N0010" type="Place Note">
       <text>ADDR created; __event_place finds it but place does not match; __event_place(len==0, place is None)</text>
     </note>
-    <note handle="_0000002600000026" change="1464033808" id="N0011" type="General">
+    <note handle="_0000002600000026" change="1472500316" id="N0011" type="Place Note">
       <text>this note is stored with the old address and then merged into the matching place</text>
     </note>
-    <note handle="_0000002700000027" change="1464033808" id="N0012" type="General">
+    <note handle="_0000002700000027" change="1472500316" id="N0012" type="Place Note">
       <text>ADDR created; __event_place finds it and now place does match; __event_place(len==0, place is not None)</text>
     </note>
-    <note handle="_0000002900000029" change="1464033808" id="N0013" type="General">
+    <note handle="_0000002900000029" change="1472500316" id="N0013" type="Place Note">
       <text>setup address place test</text>
     </note>
-    <note handle="_0000002c0000002c" change="1464033808" id="N0014" type="General">
+    <note handle="_0000002c0000002c" change="1472500316" id="N0014" type="Place Note">
       <text>address place test found; place exists and can be reused; __event_place(len!=0, place is not None)</text>
     </note>
-    <note handle="_0000002e0000002e" change="1464033808" id="N0015" type="General">
+    <note handle="_0000002e0000002e" change="1472500316" id="N0015" type="Place Note">
       <text>address place test found; but matching addr/plac not found; __event_place(len!=0, place is not None)</text>
     </note>
-    <note handle="_0000003100000031" change="1464033808" id="N0016" type="General">
+    <note handle="_0000003100000031" change="1472500316" id="N0016" type="Place Note">
       <text>PLAC occurs first; matching entry found; __event_place(no place handle, place is not None)</text>
     </note>
-    <note handle="_0000003400000034" change="1464033808" id="N0017" type="General">
+    <note handle="_0000003400000034" change="1472500316" id="N0017" type="Place Note">
       <text>PLAC occurs first; matching entry not found; __event_place(no place handle, place is None)</text>
     </note>
-    <note handle="_0000003900000039" change="1464033808" id="N0018" type="General">
+    <note handle="_0000003900000039" change="1472500316" id="N0018" type="Place Note">
       <text>note is stashed with a Place, and then merged into the address</text>
     </note>
-    <note handle="_0000003c0000003c" change="1464033808" id="N0019" type="General">
+    <note handle="_0000003c0000003c" change="1472500316" id="N0019" type="Place Note">
       <text>Place note</text>
     </note>
-    <note handle="_0000004000000040" change="1464033808" id="N0020" type="General">
+    <note handle="_0000004000000040" change="1472500316" id="N0020" type="Place Note">
       <text>ADDR note</text>
     </note>
-    <note handle="_0000004700000047" change="1464033808" id="N0021" type="General">
+    <note handle="_0000004700000047" change="1472500316" id="N0021" type="Place Note">
       <text>PLAC previously encountered, new ADDR, so new Place</text>
     </note>
-    <note handle="_0000004a0000004a" change="1464033808" id="N0022" type="General">
+    <note handle="_0000004a0000004a" change="1472500316" id="N0022" type="Place Note">
       <text>ADDR before PLAC (check ADDR is removed)</text>
     </note>
-    <note handle="_0000005000000050" change="1464033808" id="N0023" type="General">
+    <note handle="_0000005000000050" change="1472500316" id="N0023" type="Place Note">
       <text>ADDR before PLAC (address matches previous one, then needs to be reassigned)</text>
     </note>
-    <note handle="_0000005500000055" change="1464033808" id="N0024" type="General">
+    <note handle="_0000005500000055" change="1472500316" id="N0024" type="Place Note">
       <text>PLAC and no ADDR</text>
     </note>
-    <note handle="_0000005700000057" change="1464033808" id="N0025" type="General">
+    <note handle="_0000005700000057" change="1472500316" id="N0025" type="Place Note">
       <text>PLAC matches previous one, then when ADDR is read need to create a new Place</text>
     </note>
-    <note handle="_0000005a0000005a" change="1464033808" id="N0026" type="General">
+    <note handle="_0000005a0000005a" change="1472500316" id="N0026" type="Place Note">
       <text>PLAC and ADDR match, use existing one</text>
     </note>
-    <note handle="_0000005e0000005e" change="1464033808" id="N0027" type="GEDCOM import">
+    <note handle="_0000005e0000005e" change="1472500316" id="N0027" type="GEDCOM import">
       <text>Records not imported into INDI (individual) Gramps ID I0310:
 
 A second PLAC ignored                                               Line   109: 2 PLAC a second PLACe ignored

--- a/data/tests/imp_cp1252_CR.gramps
+++ b/data/tests/imp_cp1252_CR.gramps
@@ -3,29 +3,22 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-05-24" version="GrampsAIO64-4.2.1-2"/>
+    <created date="2016-08-29" version="5.0.0-alpha1"/>
     <researcher>
-      <resname>Paul Culley</resname>
-      <resaddr>11210 Olde Mint House Ln</resaddr>
-      <rescity>Tomball</rescity>
-      <resstate>Tx</resstate>
-      <rescountry>USA</rescountry>
-      <respostal>77375</respostal>
-      <resemail>paulr2787@gmail.com</resemail>
     </researcher>
   </header>
   <events>
-    <event handle="_0000000200000002" change="1464119792" id="E0000">
+    <event handle="_0000000200000002" change="1472500317" id="E0000">
       <type>Birth</type>
       <dateval val="1830"/>
     </event>
-    <event handle="_0000000300000003" change="1464119792" id="E0001">
+    <event handle="_0000000300000003" change="1472500317" id="E0001">
       <type>Death</type>
       <dateval val="1904"/>
     </event>
   </events>
   <people>
-    <person handle="_0000000100000001" change="1464119792" id="I0001">
+    <person handle="_0000000100000001" change="1472500317" id="I0001">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Jean</first>
@@ -37,7 +30,7 @@
     </person>
   </people>
   <notes>
-    <note handle="_0000000400000004" change="1464119792" id="N0000" type="General">
+    <note handle="_0000000400000004" change="1472500317" id="N0000" type="Person Note">
       <text>Table de caractères Windows cp1252
 32 [ ]
 33 [!]

--- a/data/tests/imp_cp1252_CRLF.gramps
+++ b/data/tests/imp_cp1252_CRLF.gramps
@@ -3,29 +3,22 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-05-24" version="GrampsAIO64-4.2.1-2"/>
+    <created date="2016-08-29" version="5.0.0-alpha1"/>
     <researcher>
-      <resname>Paul Culley</resname>
-      <resaddr>11210 Olde Mint House Ln</resaddr>
-      <rescity>Tomball</rescity>
-      <resstate>Tx</resstate>
-      <rescountry>USA</rescountry>
-      <respostal>77375</respostal>
-      <resemail>paulr2787@gmail.com</resemail>
     </researcher>
   </header>
   <events>
-    <event handle="_0000000200000002" change="1464119792" id="E0000">
+    <event handle="_0000000200000002" change="1472500317" id="E0000">
       <type>Birth</type>
       <dateval val="1830"/>
     </event>
-    <event handle="_0000000300000003" change="1464119792" id="E0001">
+    <event handle="_0000000300000003" change="1472500317" id="E0001">
       <type>Death</type>
       <dateval val="1904"/>
     </event>
   </events>
   <people>
-    <person handle="_0000000100000001" change="1464119792" id="I0001">
+    <person handle="_0000000100000001" change="1472500317" id="I0001">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Jean</first>
@@ -37,7 +30,7 @@
     </person>
   </people>
   <notes>
-    <note handle="_0000000400000004" change="1464119792" id="N0000" type="General">
+    <note handle="_0000000400000004" change="1472500317" id="N0000" type="Person Note">
       <text>Table de caractères Windows cp1252
 32 [ ]
 33 [!]

--- a/data/tests/imp_cp1252_LF.gramps
+++ b/data/tests/imp_cp1252_LF.gramps
@@ -3,29 +3,22 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-05-24" version="GrampsAIO64-4.2.1-2"/>
+    <created date="2016-08-29" version="5.0.0-alpha1"/>
     <researcher>
-      <resname>Paul Culley</resname>
-      <resaddr>11210 Olde Mint House Ln</resaddr>
-      <rescity>Tomball</rescity>
-      <resstate>Tx</resstate>
-      <rescountry>USA</rescountry>
-      <respostal>77375</respostal>
-      <resemail>paulr2787@gmail.com</resemail>
     </researcher>
   </header>
   <events>
-    <event handle="_0000000200000002" change="1464119792" id="E0000">
+    <event handle="_0000000200000002" change="1472500317" id="E0000">
       <type>Birth</type>
       <dateval val="1830"/>
     </event>
-    <event handle="_0000000300000003" change="1464119792" id="E0001">
+    <event handle="_0000000300000003" change="1472500317" id="E0001">
       <type>Death</type>
       <dateval val="1904"/>
     </event>
   </events>
   <people>
-    <person handle="_0000000100000001" change="1464119792" id="I0001">
+    <person handle="_0000000100000001" change="1472500317" id="I0001">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Jean</first>
@@ -37,7 +30,7 @@
     </person>
   </people>
   <notes>
-    <note handle="_0000000400000004" change="1464119792" id="N0000" type="General">
+    <note handle="_0000000400000004" change="1472500317" id="N0000" type="Person Note">
       <text>Table de caractères Windows cp1252
 32 [ ]
 33 [!]

--- a/data/tests/imp_notetest_dfs.ged
+++ b/data/tests/imp_notetest_dfs.ged
@@ -86,6 +86,9 @@
 3 TEST Empty Note
 2 NOTE Media Note
 3 TEST 123456 Note
+2 NOTE @N6@
+2 NOTE
+3 TEST Empty Note
 1 RIN 123456 Person
 1 REFN 98765 for PERSON
 2 TEST REFN
@@ -93,9 +96,6 @@
 1 CHAN
 2 DATE 11 Jan 2001
 3 TIME 16:00:06
-2 NOTE @N6@
-2 NOTE
-3 TEST Empty Note
 1 OBJE @M1@
 0 @N4@ NOTE Tom Tester xref note
 0 @N5@ NOTE Death Event xref note

--- a/data/tests/imp_notetest_dfs.gramps
+++ b/data/tests/imp_notetest_dfs.gramps
@@ -9,174 +9,176 @@
     </researcher>
   </header>
   <events>
-    <event handle="_0000000c0000000c" change="1472480894" id="E0000">
+    <event handle="_0000000e0000000e" change="1472505121" id="E0000">
       <type>TEST</type>
       <description>person</description>
     </event>
-    <event handle="_0000000d0000000d" change="1472480894" id="E0001">
+    <event handle="_0000000f0000000f" change="1472505121" id="E0001">
       <type>Birth</type>
       <dateval val="1900-06-15"/>
-      <place hlink="_0000001100000011"/>
-      <noteref hlink="_0000000e0000000e"/>
+      <place hlink="_0000001300000013"/>
+      <noteref hlink="_0000001000000010"/>
     </event>
-    <event handle="_0000001200000012" change="1472480894" id="E0002">
+    <event handle="_0000001400000014" change="1472505121" id="E0002">
       <type>Death</type>
-      <noteref hlink="_0000001300000013"/>
+      <noteref hlink="_0000001500000015"/>
     </event>
-    <event handle="_0000001a0000001a" change="1472480894" id="E0003">
+    <event handle="_0000001d0000001d" change="1472505121" id="E0003">
       <type>Who knows OBJE REFN TYPE</type>
       <description>REFN</description>
     </event>
-    <event handle="_0000002400000024" change="1472480894" id="E0004">
+    <event handle="_0000002600000026" change="1472505121" id="E0004">
       <type>Birth</type>
       <dateval val="1901-06-15"/>
     </event>
-    <event handle="_0000002500000025" change="1472480894" id="E0005">
+    <event handle="_0000002700000027" change="1472505121" id="E0005">
       <type>Death</type>
       <dateval val="1975-07-05"/>
     </event>
-    <event handle="_0000002b0000002b" change="1472480894" id="E0006">
+    <event handle="_0000002d0000002d" change="1472505121" id="E0006">
       <type>Birth</type>
       <dateval val="1922-06-15"/>
     </event>
-    <event handle="_0000002c0000002c" change="1472480894" id="E0007">
+    <event handle="_0000002e0000002e" change="1472505121" id="E0007">
       <type>Death</type>
       <dateval val="1994-07-05"/>
     </event>
-    <event handle="_0000003800000038" change="1472480894" id="E0008">
+    <event handle="_0000003a0000003a" change="1472505122" id="E0008">
       <type>TEST</type>
       <description>family</description>
     </event>
   </events>
   <people>
-    <person handle="_0000000b0000000b" change="979250406" id="I0001">
+    <person handle="_0000000d0000000d" change="979250406" id="I0001">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Tom</first>
         <surname>Tester</surname>
       </name>
-      <eventref hlink="_0000000c0000000c" role="Primary"/>
-      <eventref hlink="_0000000d0000000d" role="Primary"/>
-      <eventref hlink="_0000001200000012" role="Primary"/>
-      <eventref hlink="_0000001a0000001a" role="Primary"/>
-      <objref hlink="_0000001b0000001b"/>
+      <eventref hlink="_0000000e0000000e" role="Primary"/>
+      <eventref hlink="_0000000f0000000f" role="Primary"/>
+      <eventref hlink="_0000001400000014" role="Primary"/>
+      <eventref hlink="_0000001d0000001d" role="Primary"/>
+      <objref hlink="_0000001e0000001e"/>
       <attribute type="RIN" value="123456 Person"/>
       <attribute type="REFN" value="98765 for PERSON"/>
       <url  href="http://homepages.rootsweb.com/~pmcbride/gedcom/55gctoc.htm" type="Web Home" description="GEDCOM 5.5 documentation web site"/>
-      <parentin hlink="_0000001400000014"/>
-      <noteref hlink="_0000001500000015"/>
-      <noteref hlink="_0000001600000016"/>
+      <parentin hlink="_0000001600000016"/>
       <noteref hlink="_0000001700000017"/>
       <noteref hlink="_0000001800000018"/>
-      <noteref hlink="_0000001d0000001d"/>
-      <citationref hlink="_0000001c0000001c"/>
+      <noteref hlink="_0000001900000019"/>
+      <noteref hlink="_0000001a0000001a"/>
+      <noteref hlink="_0000002000000020"/>
+      <citationref hlink="_0000001f0000001f"/>
     </person>
-    <person handle="_0000002300000023" change="1472480894" id="I0002">
+    <person handle="_0000002500000025" change="1472505121" id="I0002">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Mrs</first>
         <surname>Tester</surname>
       </name>
-      <eventref hlink="_0000002400000024" role="Primary"/>
-      <eventref hlink="_0000002500000025" role="Primary"/>
-      <parentin hlink="_0000001400000014"/>
-      <noteref hlink="_0000002600000026"/>
+      <eventref hlink="_0000002600000026" role="Primary"/>
+      <eventref hlink="_0000002700000027" role="Primary"/>
+      <parentin hlink="_0000001600000016"/>
       <noteref hlink="_0000002800000028"/>
-      <citationref hlink="_0000002700000027"/>
+      <noteref hlink="_0000002a0000002a"/>
+      <citationref hlink="_0000002900000029"/>
     </person>
-    <person handle="_0000002900000029" change="1472480894" id="I0003">
+    <person handle="_0000002b0000002b" change="1472505121" id="I0003">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Ed</first>
         <surname>Tester</surname>
         <nick>Eddie</nick>
-        <noteref hlink="_0000002a0000002a"/>
+        <noteref hlink="_0000002c0000002c"/>
       </name>
-      <eventref hlink="_0000002b0000002b" role="Primary"/>
-      <eventref hlink="_0000002c0000002c" role="Primary"/>
+      <eventref hlink="_0000002d0000002d" role="Primary"/>
+      <eventref hlink="_0000002e0000002e" role="Primary"/>
       <lds_ord type="baptism">
         <dateval val="-005-05-05"/>
         <temple val="SLAKE"/>
-        <place hlink="_0000002d0000002d"/>
-        <noteref hlink="_0000002e0000002e"/>
-        <noteref hlink="_0000003100000031"/>
-        <citationref hlink="_0000003000000030"/>
-      </lds_ord>
-      <childof hlink="_0000001400000014"/>
-      <personref hlink="_0000003200000032" rel="">
+        <place hlink="_0000002f0000002f"/>
+        <noteref hlink="_0000003000000030"/>
         <noteref hlink="_0000003300000033"/>
+        <citationref hlink="_0000003200000032"/>
+      </lds_ord>
+      <childof hlink="_0000001600000016"/>
+      <personref hlink="_0000003400000034" rel="">
+        <noteref hlink="_0000003500000035"/>
       </personref>
-      <noteref hlink="_0000003500000035"/>
-      <citationref hlink="_0000003400000034"/>
+      <noteref hlink="_0000003700000037"/>
+      <citationref hlink="_0000003600000036"/>
     </person>
-    <person handle="_0000003200000032" change="1472480894" id="I0004">
+    <person handle="_0000003400000034" change="1472505121" id="I0004">
       <gender>U</gender>
       <name type="Birth Name">
         <first>George</first>
         <surname>Testee</surname>
-        <noteref hlink="_0000003600000036"/>
+        <noteref hlink="_0000003800000038"/>
       </name>
-      <citationref hlink="_0000003700000037"/>
+      <citationref hlink="_0000003900000039"/>
     </person>
   </people>
   <families>
-    <family handle="_0000001400000014" change="1472480894" id="F0001">
+    <family handle="_0000001600000016" change="1472505121" id="F0001">
       <rel type="Unknown"/>
-      <father hlink="_0000000b0000000b"/>
-      <mother hlink="_0000002300000023"/>
-      <eventref hlink="_0000003800000038" role="Family"/>
-      <childref hlink="_0000002900000029"/>
-      <noteref hlink="_0000003b0000003b"/>
-      <noteref hlink="_0000003c0000003c"/>
-      <noteref hlink="_0000004100000041"/>
-      <citationref hlink="_0000003a0000003a"/>
-      <citationref hlink="_0000004000000040"/>
+      <father hlink="_0000000d0000000d"/>
+      <mother hlink="_0000002500000025"/>
+      <eventref hlink="_0000003a0000003a" role="Family"/>
+      <childref hlink="_0000002b0000002b"/>
+      <noteref hlink="_0000003d0000003d"/>
+      <noteref hlink="_0000003e0000003e"/>
+      <noteref hlink="_0000004300000043"/>
+      <citationref hlink="_0000003c0000003c"/>
+      <citationref hlink="_0000004200000042"/>
     </family>
   </families>
   <citations>
-    <citation handle="_0000001c0000001c" change="1472480894" id="C0000">
+    <citation handle="_0000001f0000001f" change="1472505121" id="C0000">
       <confidence>2</confidence>
       <sourceref hlink="_0000000400000004"/>
     </citation>
-    <citation handle="_0000002100000021" change="1472480894" id="C0001">
+    <citation handle="_0000002300000023" change="1472505121" id="C0001">
       <confidence>2</confidence>
       <sourceref hlink="_0000000400000004"/>
     </citation>
-    <citation handle="_0000002700000027" change="1472480894" id="C0002">
+    <citation handle="_0000002900000029" change="1472505121" id="C0002">
       <confidence>2</confidence>
       <sourceref hlink="_0000000400000004"/>
     </citation>
-    <citation handle="_0000003000000030" change="1472480894" id="C0003">
+    <citation handle="_0000003200000032" change="1472505121" id="C0003">
       <confidence>2</confidence>
-      <sourceref hlink="_0000002f0000002f"/>
+      <sourceref hlink="_0000003100000031"/>
     </citation>
-    <citation handle="_0000003400000034" change="1472480894" id="C0004">
-      <confidence>2</confidence>
-      <sourceref hlink="_0000000400000004"/>
-    </citation>
-    <citation handle="_0000003700000037" change="1472480894" id="C0005">
+    <citation handle="_0000003600000036" change="1472505121" id="C0004">
       <confidence>2</confidence>
       <sourceref hlink="_0000000400000004"/>
     </citation>
-    <citation handle="_0000003a0000003a" change="1472480894" id="C0006">
+    <citation handle="_0000003900000039" change="1472505121" id="C0005">
       <confidence>2</confidence>
-      <sourceref hlink="_0000003900000039"/>
+      <sourceref hlink="_0000000400000004"/>
     </citation>
-    <citation handle="_0000004000000040" change="1472480894" id="C0007">
+    <citation handle="_0000003c0000003c" change="1472505122" id="C0006">
+      <confidence>2</confidence>
+      <sourceref hlink="_0000003b0000003b"/>
+    </citation>
+    <citation handle="_0000004200000042" change="1472505122" id="C0007">
       <dateval val="1900-12-31"/>
       <page>42</page>
       <confidence>0</confidence>
-      <noteref hlink="_0000003d0000003d"/>
-      <noteref hlink="_0000003e0000003e"/>
       <noteref hlink="_0000003f0000003f"/>
-      <sourceref hlink="_0000003900000039"/>
+      <noteref hlink="_0000004000000040"/>
+      <noteref hlink="_0000004100000041"/>
+      <sourceref hlink="_0000003b0000003b"/>
     </citation>
   </citations>
   <sources>
-    <source handle="_0000000400000004" change="1472480894" id="S0000">
+    <source handle="_0000000400000004" change="1472505121" id="S0000">
       <stitle>Import from imp_notetest.ged</stitle>
       <spubinfo>Tom Tester 2016</spubinfo>
       <noteref hlink="_0000000200000002"/>
+      <noteref hlink="_0000000500000005"/>
+      <noteref hlink="_0000000600000006"/>
       <srcattribute type="Approved system identification" value="GEDitCOM"/>
       <srcattribute type="Name of software product" value="GEDitCOM"/>
       <srcattribute type="Version number of software product" value="2.9.4"/>
@@ -190,69 +192,71 @@
       <srcattribute type="Submission: Submitter" value="@SUBMITTER@"/>
       <srcattribute type="Submission: Family file" value="NameOfFamilyFile"/>
       <reporef hlink="_0000000100000001" medium="Unknown"/>
-      <reporef hlink="_0000000800000008" medium="Unknown"/>
+      <reporef hlink="_0000000b0000000b" medium="Unknown"/>
     </source>
-    <source handle="_0000002f0000002f" change="1472480894" id="SOURCE1">
+    <source handle="_0000003100000031" change="1472505121" id="SOURCE1">
       <stitle>@SOURCE1@</stitle>
     </source>
-    <source handle="_0000003900000039" change="1472480894" id="S0001">
+    <source handle="_0000003b0000003b" change="1472505122" id="S0001">
       <stitle>Note Test file Source: Tester</stitle>
-      <noteref hlink="_0000004400000044"/>
-      <noteref hlink="_0000004500000045"/>
-      <reporef hlink="_0000004200000042" medium="Book">
-        <noteref hlink="_0000004300000043"/>
+      <noteref hlink="_0000004600000046"/>
+      <noteref hlink="_0000004700000047"/>
+      <reporef hlink="_0000004400000044" medium="Book">
+        <noteref hlink="_0000004500000045"/>
       </reporef>
     </source>
   </sources>
   <places>
-    <placeobj handle="_0000001100000011" change="1472480894" id="P0000" type="Address">
+    <placeobj handle="_0000001300000013" change="1472505121" id="P0000" type="Address">
       <ptitle>123 main, Norwalk, Ohio, USA</ptitle>
       <pname value="123 main, Norwalk, Ohio, USA"/>
       <location street="123 main, Norwalk, Ohio, USA"/>
-      <noteref hlink="_0000000f0000000f"/>
-      <noteref hlink="_0000001000000010"/>
+      <noteref hlink="_0000001100000011"/>
+      <noteref hlink="_0000001200000012"/>
     </placeobj>
-    <placeobj handle="_0000002d0000002d" change="1472480894" id="P0001" type="Unknown">
+    <placeobj handle="_0000002f0000002f" change="1472505121" id="P0001" type="Unknown">
       <ptitle>Salt Lake City</ptitle>
       <pname value="Salt Lake City"/>
     </placeobj>
   </places>
   <objects>
-    <object handle="_0000001b0000001b" change="979250406" id="M1">
+    <object handle="_0000001e0000001e" change="979250406" id="M1">
       <file src="photo.jpg" mime="image/jpeg" description="Tom Tester's photo"/>
       <attribute type="Media-Type" value="Film"/>
       <attribute type="RIN" value="123456"/>
       <attribute type="REFN" value="98765">
-        <noteref hlink="_0000002000000020"/>
+        <noteref hlink="_0000002200000022"/>
       </attribute>
-      <noteref hlink="_0000002200000022"/>
-      <citationref hlink="_0000002100000021"/>
+      <noteref hlink="_0000002400000024"/>
+      <citationref hlink="_0000002300000023"/>
     </object>
   </objects>
   <repositories>
-    <repository handle="_0000000100000001" change="1472480894" id="R0000">
+    <repository handle="_0000000100000001" change="1472505121" id="R0000">
       <rname>Business that produced the product: RSAC Software</rname>
       <type>GEDCOM data</type>
     </repository>
-    <repository handle="_0000000800000008" change="1472480894" id="R0001">
+    <repository handle="_0000000b0000000b" change="1472505121" id="R0001">
       <rname>SUBM (Submitter): (@SUBMITTER@) John A. Tester</rname>
       <type>GEDCOM data</type>
       <address>
       </address>
       <noteref hlink="_0000000900000009"/>
+      <noteref hlink="_0000000a0000000a"/>
+      <noteref hlink="_0000000c0000000c"/>
     </repository>
-    <repository handle="_0000004200000042" change="1472480894" id="R0002">
+    <repository handle="_0000004400000044" change="1472505122" id="R0002">
       <rname>The Testers repository</rname>
       <type>Library</type>
-      <noteref hlink="_0000004600000046"/>
-      <noteref hlink="_0000004700000047"/>
+      <noteref hlink="_0000004800000048"/>
+      <noteref hlink="_0000004900000049"/>
     </repository>
   </repositories>
   <notes>
-    <note handle="_0000000200000002" change="1472480894" id="N0000" type="General">
+    <note handle="_0000000200000002" change="1472505121" id="N0000" type="Source Note">
       <text>Header note</text>
     </note>
-    <note handle="_0000000300000003" change="1472480894" id="N0001" type="GEDCOM import">
+    <note handle="_0000000300000003" change="1472505121" id="N0001" type="GEDCOM import">
       <text>Records not imported into HEAD (header):
 
 Line ignored as not understood                                      Line    18: 2 TEST Header Note
@@ -262,23 +266,24 @@ Skipped subordinate line                                            Line    20: 
         <range start="0" end="327"/>
       </style>
     </note>
-    <note handle="_0000000500000005" change="1472480894" id="N0002" type="GEDCOM import">
-      <text>Records not imported into Top Level:
-
-Line ignored as not understood                                      Line    25: 1 NOTE Submission Note
-Skipped subordinate line                                            Line    26: 2 TEST Submission Note
-Line ignored as not understood                                      Line    27: 1 NOTE 
-Skipped subordinate line                                            Line    28: 2 TEST Empty Note
-Line ignored as not understood                                      Line    29: 1 TEST submission
-Line ignored as not understood                                      Line    30: 1 NOTE N2</text>
-      <style name="fontface" value="Monospace">
-        <range start="0" end="618"/>
-      </style>
+    <note handle="_0000000500000005" change="1472505121" id="N0002" type="Source Note">
+      <text>Submission Note</text>
     </note>
-    <note handle="_0000000600000006" change="979250406" id="N0003" type="General">
+    <note handle="_0000000600000006" change="979250406" id="N0003" type="Source Note">
       <text>Submission xref note</text>
     </note>
-    <note handle="_0000000700000007" change="1472480894" id="N0004" type="GEDCOM import">
+    <note handle="_0000000700000007" change="1472505121" id="N0004" type="GEDCOM import">
+      <text>Records not imported into Top Level:
+
+Line ignored as not understood                                      Line    26: 2 TEST Submission Note
+Empty note ignored                                                  Line    27: 1 NOTE 
+Skipped subordinate line                                            Line    28: 2 TEST Empty Note
+Line ignored as not understood                                      Line    29: 1 TEST submission</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="425"/>
+      </style>
+    </note>
+    <note handle="_0000000800000008" change="1472505121" id="N0005" type="GEDCOM import">
       <text>Records not imported into NOTE Gramps ID N0003:
 
 Tag recognized but not supported                                    Line    32: 1 RIN Submission Note RIN
@@ -290,61 +295,65 @@ Line ignored as not understood                                      Line    39: 
         <range start="0" end="586"/>
       </style>
     </note>
-    <note handle="_0000000900000009" change="1472480894" id="N0005" type="GEDCOM import">
-      <text>Records not imported into SUBM (Submitter): (@SUBMITTER@) John A. Tester:
-
-Line ignored as not understood                                      Line    42: 1 NOTE Submitter Note
-Skipped subordinate line                                            Line    43: 2 TEST Submitter Note
-Line ignored as not understood                                      Line    44: 1 NOTE 
-Skipped subordinate line                                            Line    45: 2 TEST Empty Note
-Line ignored as not understood                                      Line    46: 1 TEST Submitter
-Line ignored as not understood                                      Line    47: 1 NOTE N3</text>
-      <style name="fontface" value="Monospace">
-        <range start="0" end="652"/>
-      </style>
+    <note handle="_0000000900000009" change="1472505121" id="N0006" type="Repository Note">
+      <text>Submitter Note</text>
     </note>
-    <note handle="_0000000a0000000a" change="1472480894" id="N0006" type="General">
+    <note handle="_0000000a0000000a" change="1472505121" id="N0007" type="Repository Note">
       <text>Submitter xref note</text>
     </note>
-    <note handle="_0000000e0000000e" change="1472480894" id="N0007" type="General">
+    <note handle="_0000000c0000000c" change="1472505121" id="N0008" type="GEDCOM import">
+      <text>Records not imported into SUBM (Submitter): (@SUBMITTER@) John A. Tester:
+
+Line ignored as not understood                                      Line    43: 2 TEST Submitter Note
+Empty note ignored                                                  Line    44: 1 NOTE 
+Skipped subordinate line                                            Line    45: 2 TEST Empty Note
+Line ignored as not understood                                      Line    46: 1 TEST Submitter</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="460"/>
+      </style>
+    </note>
+    <note handle="_0000001000000010" change="1472505121" id="N0009" type="Event Note">
       <text>Birth Event note</text>
     </note>
-    <note handle="_0000000f0000000f" change="1472480894" id="N0008" type="General">
+    <note handle="_0000001100000011" change="1472505121" id="N0010" type="Place Note">
       <text>Location Note</text>
     </note>
-    <note handle="_0000001000000010" change="1472480894" id="N0009" type="General">
+    <note handle="_0000001200000012" change="1472505121" id="N0011" type="Place Note">
       <text>Location Note 2</text>
     </note>
-    <note handle="_0000001300000013" change="1472480894" id="N0010" type="General">
+    <note handle="_0000001500000015" change="1472505121" id="N0012" type="Event Note">
       <text>Death Event xref note</text>
     </note>
-    <note handle="_0000001500000015" change="1472480894" id="N0011" type="General">
+    <note handle="_0000001700000017" change="1472505121" id="N0013" type="Person Note">
       <text>FAMS Note</text>
     </note>
-    <note handle="_0000001600000016" change="1472480894" id="N0012" type="General">
+    <note handle="_0000001800000018" change="1472505121" id="N0014" type="Person Note">
       <text>FAMS Note 2</text>
     </note>
-    <note handle="_0000001700000017" change="1472480894" id="N0013" type="General">
+    <note handle="_0000001900000019" change="1472505121" id="N0015" type="Person Note">
       <text>Tom Tester xref note</text>
     </note>
-    <note handle="_0000001800000018" change="1472480894" id="N0014" type="General">
+    <note handle="_0000001a0000001a" change="1472505121" id="N0016" type="Person Note">
       <text>Tom Tester Note</text>
     </note>
-    <note handle="_0000001900000019" change="1472480894" id="N0015" type="General">
+    <note handle="_0000001b0000001b" change="1472505121" id="N0017" type="Media Note">
       <text>Media Note</text>
     </note>
-    <note handle="_0000001d0000001d" change="1472480894" id="N0016" type="GEDCOM import">
+    <note handle="_0000001c0000001c" change="979250406" id="N0018" type="Media Note">
+      <text>Media xref note</text>
+    </note>
+    <note handle="_0000002000000020" change="1472505121" id="N0019" type="GEDCOM import">
       <text>Records not imported into INDI (individual) Gramps ID I0001:
 
-Empty event note ignored                                            Line    54: 2 NOTE 
+Empty note ignored                                                  Line    54: 2 NOTE 
 Skipped subordinate line                                            Line    55: 3 NOTE Empty note subordinate (Should be skipped)
 Skipped subordinate line                                            Line    56: 3 TEST Empty Note
-Skipped subordinate line                                            Line    58: 3 TEST 123456 Event Note
+Line ignored as not understood                                      Line    58: 3 TEST 123456 Event Note
 Line ignored as not understood                                      Line    62: 4 TEST Location Note
 Line ignored as not understood                                      Line    63: 3 TEST Location
-Empty event note ignored                                            Line    66: 2 NOTE 
+Empty note ignored                                                  Line    66: 2 NOTE 
 Skipped subordinate line                                            Line    67: 3 TEST Empty Note
-Empty event note ignored                                            Line    68: 2 NOTE 
+Empty note ignored                                                  Line    68: 2 NOTE 
 Skipped subordinate line                                            Line    69: 3 TEST Empty Note
 Line ignored as not understood                                      Line    73: 3 TEST FAMS Note
 Skipped subordinate line                                            Line    74: 4 TEST skip on FAMS Note
@@ -354,32 +363,30 @@ Line ignored as not understood                                      Line    82: 
 Empty note ignored                                                  Line    85: 2 NOTE 
 Skipped subordinate line                                            Line    86: 3 TEST Empty Note
 Line ignored as not understood                                      Line    88: 3 TEST 123456 Note
-Line ignored as not understood                                      Line    96: 2 NOTE N6
-Skipped subordinate line                                            Line    98: 3 TEST Empty Note</text>
+Empty note ignored                                                  Line    90: 2 NOTE 
+Skipped subordinate line                                            Line    91: 3 TEST Empty Note</text>
       <style name="fontface" value="Monospace">
-        <range start="0" end="2011"/>
+        <range start="0" end="2009"/>
       </style>
     </note>
-    <note handle="_0000001e0000001e" change="979250406" id="N0017" type="General">
-      <text>Media xref note</text>
-    </note>
-    <note handle="_0000001f0000001f" change="1472480894" id="N0018" type="GEDCOM import">
-      <text>Records not imported into NOTE Gramps ID N0017:
+    <note handle="_0000002100000021" change="1472505121" id="N0020" type="GEDCOM import">
+      <text>Records not imported into NOTE Gramps ID N0018:
 
 Tag recognized but not supported                                    Line   103: 1 RIN 123456
 Tag recognized but not supported                                    Line   104: 1 REFN 98765
 Skipped subordinate line                                            Line   105: 2 TYPE Who knows REFN TYPE
+Tag recognized but not supported                                    Line   109: 2 NOTE Note on a change on a note!!!
 Skipped subordinate line                                            Line   110: 3 CHAN 
 Skipped subordinate line                                            Line   111: 4 DATE 2001-01-11
 Skipped subordinate line                                            Line   112: 5 TIME 16:00:06</text>
       <style name="fontface" value="Monospace">
-        <range start="0" end="624"/>
+        <range start="0" end="741"/>
       </style>
     </note>
-    <note handle="_0000002000000020" change="1472480894" id="N0019" type="REFN-TYPE">
+    <note handle="_0000002200000022" change="1472505121" id="N0021" type="REFN-TYPE">
       <text>Who knows REFN TYPE</text>
     </note>
-    <note handle="_0000002200000022" change="1472480894" id="N0020" type="GEDCOM import">
+    <note handle="_0000002400000024" change="1472505121" id="N0022" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M1:
 
 Could not import photo.jpg                                          Line   114: 1 FILE photo.jpg</text>
@@ -387,10 +394,10 @@ Could not import photo.jpg                                          Line   114: 
         <range start="0" end="164"/>
       </style>
     </note>
-    <note handle="_0000002600000026" change="979250406" id="N0021" type="General">
+    <note handle="_0000002800000028" change="979250406" id="N0023" type="Person Note">
       <text>Family Spouse reference Note</text>
     </note>
-    <note handle="_0000002800000028" change="1472480894" id="N0022" type="GEDCOM import">
+    <note handle="_0000002a0000002a" change="1472505121" id="N0024" type="GEDCOM import">
       <text>Records not imported into INDI (individual) Gramps ID I0002:
 
 Empty note ignored                                                  Line   132: 2 NOTE 
@@ -399,19 +406,19 @@ Skipped subordinate line                                            Line   133: 
         <range start="0" end="248"/>
       </style>
     </note>
-    <note handle="_0000002a0000002a" change="979250406" id="N0023" type="General">
+    <note handle="_0000002c0000002c" change="979250406" id="N0025" type="General">
       <text>Name note</text>
     </note>
-    <note handle="_0000002e0000002e" change="1472480894" id="N0024" type="General">
+    <note handle="_0000003000000030" change="1472505121" id="N0026" type="LDS Note">
       <text>Place note</text>
     </note>
-    <note handle="_0000003100000031" change="1472480894" id="N0025" type="General">
+    <note handle="_0000003300000033" change="1472505122" id="N0027" type="LDS Note">
       <text>LDS xref note</text>
     </note>
-    <note handle="_0000003300000033" change="979250406" id="N0026" type="General">
+    <note handle="_0000003500000035" change="979250406" id="N0028" type="Association Note">
       <text>Association link note</text>
     </note>
-    <note handle="_0000003500000035" change="1472480894" id="N0027" type="GEDCOM import">
+    <note handle="_0000003700000037" change="1472505121" id="N0029" type="GEDCOM import">
       <text>Records not imported into INDI (individual) Gramps ID I0003:
 
 Empty note ignored                                                  Line   141: 2 NOTE 
@@ -423,25 +430,25 @@ Skipped subordinate line                                            Line   168: 
         <range start="0" end="538"/>
       </style>
     </note>
-    <note handle="_0000003600000036" change="979250406" id="N0028" type="General">
+    <note handle="_0000003800000038" change="979250406" id="N0030" type="General">
       <text>Just for association</text>
     </note>
-    <note handle="_0000003b0000003b" change="1472480894" id="N0029" type="General">
+    <note handle="_0000003d0000003d" change="1472505122" id="N0031" type="Family Note">
       <text>Family xref note</text>
     </note>
-    <note handle="_0000003c0000003c" change="979250406" id="N0030" type="General">
+    <note handle="_0000003e0000003e" change="979250406" id="N0032" type="Family Note">
       <text>Family note</text>
     </note>
-    <note handle="_0000003d0000003d" change="1472480894" id="N0031" type="General">
+    <note handle="_0000003f0000003f" change="1472505122" id="N0033" type="Citation">
       <text>Citation Data Note</text>
     </note>
-    <note handle="_0000003e0000003e" change="1472480894" id="N0032" type="Source text">
+    <note handle="_0000004000000040" change="1472505122" id="N0034" type="Source text">
       <text>A sample text from a source of this family</text>
     </note>
-    <note handle="_0000003f0000003f" change="979250406" id="N0033" type="General">
+    <note handle="_0000004100000041" change="979250406" id="N0035" type="Citation">
       <text>A note this citation is on the FAMILY record.</text>
     </note>
-    <note handle="_0000004100000041" change="1472480894" id="N0034" type="GEDCOM import">
+    <note handle="_0000004300000043" change="1472505122" id="N0036" type="GEDCOM import">
       <text>Records not imported into FAM (family) Gramps ID F0001:
 
 Line ignored as not understood                                      Line   183: 2 TEST Family Note
@@ -454,13 +461,13 @@ Line ignored as not understood                                      Line   196: 
         <range start="0" end="645"/>
       </style>
     </note>
-    <note handle="_0000004300000043" change="979250406" id="N0035" type="General">
+    <note handle="_0000004500000045" change="979250406" id="N0037" type="Repository Reference Note">
       <text>A short note about the repository link.</text>
     </note>
-    <note handle="_0000004400000044" change="979250406" id="N0036" type="General">
+    <note handle="_0000004600000046" change="979250406" id="N0038" type="Source Note">
       <text>note embedded in the SOURCE Record</text>
     </note>
-    <note handle="_0000004500000045" change="1472480894" id="N0037" type="GEDCOM import">
+    <note handle="_0000004700000047" change="1472505122" id="N0039" type="GEDCOM import">
       <text>Records not imported into SOUR (source) Gramps ID S0001:
 
 Line ignored as not understood                                      Line   206: 1 TEST source
@@ -472,10 +479,10 @@ Skipped subordinate line                                            Line   215: 
         <range start="0" end="524"/>
       </style>
     </note>
-    <note handle="_0000004600000046" change="1472480894" id="N0038" type="General">
+    <note handle="_0000004800000048" change="1472505122" id="N0040" type="Repository Note">
       <text>Repository Note</text>
     </note>
-    <note handle="_0000004700000047" change="1472480894" id="N0039" type="GEDCOM import">
+    <note handle="_0000004900000049" change="1472505122" id="N0041" type="GEDCOM import">
       <text>Records not imported into REPO (repository) Gramps ID R0002:
 
 Line ignored as not understood                                      Line   223: 1 TEST Repo

--- a/data/tests/imp_sample.gramps
+++ b/data/tests/imp_sample.gramps
@@ -3,533 +3,533 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-05-22" version="GrampsAIO64-4.2.1-2"/>
+    <created date="2016-08-29" version="5.0.0-alpha1"/>
     <researcher>
       <resname>Alex Roitman,,,</resname>
       <resaddr>Not Provided</resaddr>
     </researcher>
   </header>
   <events>
-    <event handle="_0000000200000002" change="1463929997" id="E0000">
+    <event handle="_0000000200000002" change="1472500318" id="E0000">
       <type>Birth</type>
       <dateval val="1864-10-02"/>
       <place hlink="_0000000300000003"/>
       <description>Birth of Anna Hansdotter</description>
     </event>
-    <event handle="_0000000400000004" change="1463929997" id="E0001">
+    <event handle="_0000000400000004" change="1472500318" id="E0001">
       <type>Death</type>
       <dateval val="1945-09-29"/>
       <place hlink="_0000000500000005"/>
       <description>Death of Anna Hansdotter</description>
     </event>
-    <event handle="_0000000800000008" change="1463929997" id="E0002">
+    <event handle="_0000000800000008" change="1472500318" id="E0002">
       <type>Birth</type>
       <dateval val="1966-08-11"/>
       <place hlink="_0000000900000009"/>
       <description>Birth of Keith Lloyd Smith</description>
     </event>
-    <event handle="_0000000c0000000c" change="1463929997" id="E0003">
+    <event handle="_0000000c0000000c" change="1472500318" id="E0003">
       <type>Birth</type>
       <dateval val="1904-04-17"/>
       <place hlink="_0000000d0000000d"/>
       <description>Birth of Hans Peter Smith</description>
     </event>
-    <event handle="_0000000e0000000e" change="1463929997" id="E0004">
+    <event handle="_0000000e0000000e" change="1472500318" id="E0004">
       <type>Death</type>
       <dateval val="1977-01-29"/>
       <place hlink="_0000000900000009"/>
       <description>Death of Hans Peter Smith</description>
     </event>
-    <event handle="_0000001200000012" change="1463929997" id="E0005">
+    <event handle="_0000001200000012" change="1472500318" id="E0005">
       <type>Birth</type>
       <dateval val="1821-01-29"/>
       <place hlink="_0000001300000013"/>
       <description>Birth of Hanna Smith</description>
     </event>
-    <event handle="_0000001600000016" change="1463929997" id="E0006">
+    <event handle="_0000001600000016" change="1472500318" id="E0006">
       <type>Birth</type>
       <dateval val="1889-08-31"/>
       <place hlink="_0000000d0000000d"/>
       <description>Birth of Herman Julius Nielsen</description>
     </event>
-    <event handle="_0000001700000017" change="1463929997" id="E0007">
+    <event handle="_0000001700000017" change="1472500318" id="E0007">
       <type>Death</type>
       <dateval val="1945"/>
       <description>Death of Herman Julius Nielsen</description>
     </event>
-    <event handle="_0000001a0000001a" change="1463929997" id="E0008">
+    <event handle="_0000001a0000001a" change="1472500318" id="E0008">
       <type>Birth</type>
       <dateval val="1897" type="about"/>
       <description>Birth of Evelyn Michaels</description>
     </event>
-    <event handle="_0000001d0000001d" change="1463929997" id="E0009">
+    <event handle="_0000001d0000001d" change="1472500318" id="E0009">
       <type>Birth</type>
       <dateval val="1934-11-04"/>
       <place hlink="_0000001e0000001e"/>
       <description>Birth of Marjorie Lee Smith</description>
     </event>
-    <event handle="_0000002100000021" change="1463929997" id="E0010">
+    <event handle="_0000002100000021" change="1472500318" id="E0010">
       <type>Birth</type>
       <dateval val="1897-09-11"/>
       <place hlink="_0000000d0000000d"/>
       <description>Birth of Gus Smith</description>
     </event>
-    <event handle="_0000002200000022" change="1463929997" id="E0011">
+    <event handle="_0000002200000022" change="1472500318" id="E0011">
       <type>Death</type>
       <dateval val="1963-10-21"/>
       <place hlink="_0000000900000009"/>
       <description>Death of Gus Smith</description>
     </event>
-    <event handle="_0000002400000024" change="1463929997" id="E0012">
+    <event handle="_0000002400000024" change="1472500318" id="E0012">
       <type>Birth</type>
       <dateval val="1907-11-05"/>
       <place hlink="_0000000d0000000d"/>
       <description>Birth of Jennifer Anderson</description>
     </event>
-    <event handle="_0000002500000025" change="1463929997" id="E0013">
+    <event handle="_0000002500000025" change="1472500318" id="E0013">
       <type>Death</type>
       <dateval val="1985-05-29"/>
       <place hlink="_0000000900000009"/>
       <description>Death of Jennifer Anderson</description>
     </event>
-    <event handle="_0000002700000027" change="1463929997" id="E0014">
+    <event handle="_0000002700000027" change="1472500318" id="E0014">
       <type>Birth</type>
       <dateval val="1910-05-02"/>
       <place hlink="_0000000d0000000d"/>
       <description>Birth of Lillie Harriet Jones</description>
     </event>
-    <event handle="_0000002800000028" change="1463929997" id="E0015">
+    <event handle="_0000002800000028" change="1472500318" id="E0015">
       <type>Death</type>
       <dateval val="1990-06-26"/>
       <description>Death of Lillie Harriet Jones</description>
     </event>
-    <event handle="_0000002a0000002a" change="1463929997" id="E0016">
+    <event handle="_0000002a0000002a" change="1472500318" id="E0016">
       <type>Birth</type>
       <dateval val="1932-01-30"/>
       <place hlink="_0000000900000009"/>
       <description>Birth of John Hjalmar Smith</description>
     </event>
-    <event handle="_0000002d0000002d" change="1463929997" id="E0017">
+    <event handle="_0000002d0000002d" change="1472500318" id="E0017">
       <type>Birth</type>
       <dateval val="1963-08-28"/>
       <place hlink="_0000000900000009"/>
       <description>Birth of Eric Lloyd Smith</description>
     </event>
-    <event handle="_0000002e0000002e" change="1463929997" id="E0018">
+    <event handle="_0000002e0000002e" change="1472500318" id="E0018">
       <type>Adopted</type>
     </event>
-    <event handle="_0000003100000031" change="1463929997" id="E0019">
+    <event handle="_0000003100000031" change="1472500318" id="E0019">
       <type>Birth</type>
       <dateval val="1998-04-12"/>
       <place hlink="_0000003200000032"/>
       <description>Birth of Amber Marie Smith</description>
     </event>
-    <event handle="_0000003300000033" change="1463929997" id="E0020">
+    <event handle="_0000003300000033" change="1472500318" id="E0020">
       <type>Christening</type>
       <dateval val="1998-04-26"/>
       <place hlink="_0000003400000034"/>
       <description>Christening of Amber Marie Smith</description>
     </event>
-    <event handle="_0000003700000037" change="1463929997" id="E0021">
+    <event handle="_0000003700000037" change="1472500318" id="E0021">
       <type>Birth</type>
       <dateval val="1899-12-20"/>
       <place hlink="_0000000d0000000d"/>
       <description>Birth of Carl Emil Smith</description>
     </event>
-    <event handle="_0000003800000038" change="1463929997" id="E0022">
+    <event handle="_0000003800000038" change="1472500318" id="E0022">
       <type>Death</type>
       <dateval val="1959-01-28"/>
       <place hlink="_0000001e0000001e"/>
       <description>Death of Carl Emil Smith</description>
       <attribute type="Cause" value="Bad breath"/>
     </event>
-    <event handle="_0000003a0000003a" change="1463929997" id="E0023">
+    <event handle="_0000003a0000003a" change="1472500318" id="E0023">
       <type>Birth</type>
       <dateval val="1893-01-31"/>
       <place hlink="_0000000d0000000d"/>
       <description>Birth of Hjalmar Smith</description>
     </event>
-    <event handle="_0000003b0000003b" change="1463929997" id="E0024">
+    <event handle="_0000003b0000003b" change="1472500318" id="E0024">
       <type>Death</type>
       <dateval val="1894-09-25"/>
       <place hlink="_0000000d0000000d"/>
       <description>Death of Hjalmar Smith</description>
     </event>
-    <event handle="_0000003d0000003d" change="1463929997" id="E0025">
+    <event handle="_0000003d0000003d" change="1472500318" id="E0025">
       <type>Birth</type>
       <dateval val="1830-11-19"/>
       <place hlink="_0000001300000013"/>
       <description>Birth of Martin Smith</description>
     </event>
-    <event handle="_0000003e0000003e" change="1463929997" id="E0026">
+    <event handle="_0000003e0000003e" change="1472500318" id="E0026">
       <type>Death</type>
       <daterange start="1899" stop="1905"/>
       <place hlink="_0000003f0000003f"/>
       <description>Death of Martin Smith</description>
     </event>
-    <event handle="_0000004000000040" change="1463929997" id="E0027">
+    <event handle="_0000004000000040" change="1472500318" id="E0027">
       <type>Baptism</type>
       <dateval val="1830-11-23"/>
       <place hlink="_0000001300000013"/>
       <description>Baptism of Martin Smith</description>
     </event>
-    <event handle="_0000004400000044" change="1463929997" id="E0028">
+    <event handle="_0000004400000044" change="1472500318" id="E0028">
       <type>Birth</type>
       <dateval val="1889-01-31"/>
       <place hlink="_0000000d0000000d"/>
       <description>Birth of Astrid Shermanna Augusta Smith</description>
     </event>
-    <event handle="_0000004500000045" change="1463929997" id="E0029">
+    <event handle="_0000004500000045" change="1472500318" id="E0029">
       <type>Death</type>
       <dateval val="1963-12-21"/>
       <place hlink="_0000000900000009"/>
       <description>Death of Astrid Shermanna Augusta Smith</description>
     </event>
-    <event handle="_0000004700000047" change="1463929997" id="E0030">
+    <event handle="_0000004700000047" change="1472500318" id="E0030">
       <type>Birth</type>
       <dateval val="1862-11-28"/>
       <place hlink="_0000004800000048"/>
       <description>Birth of Gustaf Smith, Sr.</description>
     </event>
-    <event handle="_0000004900000049" change="1463929997" id="E0031">
+    <event handle="_0000004900000049" change="1472500318" id="E0031">
       <type>Death</type>
       <dateval val="1930-07-23" type="before"/>
       <place hlink="_0000000500000005"/>
       <description>Death of Gustaf Smith, Sr.</description>
     </event>
-    <event handle="_0000004a0000004a" change="1463929997" id="E0032">
+    <event handle="_0000004a0000004a" change="1472500318" id="E0032">
       <type>Immi</type>
       <dateval val="1908-05-21"/>
       <place hlink="_0000004b0000004b"/>
     </event>
-    <event handle="_0000004c0000004c" change="1463929997" id="E0033">
+    <event handle="_0000004c0000004c" change="1472500318" id="E0033">
       <type>Christening</type>
       <dateval val="1862-12-07"/>
       <place hlink="_0000001300000013"/>
       <description>Christening of Gustaf Smith, Sr.</description>
     </event>
-    <event handle="_0000004e0000004e" change="1463929997" id="E0034">
+    <event handle="_0000004e0000004e" change="1472500318" id="E0034">
       <type>Birth</type>
       <dateval val="1775" type="about"/>
       <place hlink="_0000003f0000003f"/>
       <description>Birth of Marta Ericsdotter</description>
     </event>
-    <event handle="_0000005100000051" change="1463929997" id="E0035">
+    <event handle="_0000005100000051" change="1472500318" id="E0035">
       <type>Birth</type>
       <dateval val="1886-12-15"/>
       <place hlink="_0000000d0000000d"/>
       <description>Birth of Kirsti Marie Smith</description>
     </event>
-    <event handle="_0000005200000052" change="1463929997" id="E0036">
+    <event handle="_0000005200000052" change="1472500318" id="E0036">
       <type>Death</type>
       <dateval val="1966-07-18"/>
       <place hlink="_0000000900000009"/>
       <description>Death of Kirsti Marie Smith</description>
     </event>
-    <event handle="_0000005500000055" change="1463929997" id="E0037">
+    <event handle="_0000005500000055" change="1472500318" id="E0037">
       <type>Birth</type>
       <dateval val="1770" type="about"/>
       <place hlink="_0000003f0000003f"/>
       <description>Birth of Ingeman Smith</description>
     </event>
-    <event handle="_0000005700000057" change="1463929997" id="E0038">
+    <event handle="_0000005700000057" change="1472500318" id="E0038">
       <type>Birth</type>
       <dateval val="1860-09-23"/>
       <place hlink="_0000005800000058"/>
       <description>Birth of Anna Streiffert</description>
     </event>
-    <event handle="_0000005900000059" change="1463929997" id="E0039">
+    <event handle="_0000005900000059" change="1472500318" id="E0039">
       <type>Death</type>
       <dateval val="1927-02-02"/>
       <place hlink="_0000000d0000000d"/>
       <description>Death of Anna Streiffert</description>
     </event>
-    <event handle="_0000005c0000005c" change="1463929997" id="E0040">
+    <event handle="_0000005c0000005c" change="1472500318" id="E0040">
       <type>Birth</type>
       <dateval val="1966" type="after"/>
       <place hlink="_0000000900000009"/>
       <description>Birth of Craig Peter Smith</description>
     </event>
-    <event handle="_0000005d0000005d" change="1463929997" id="E0041">
+    <event handle="_0000005d0000005d" change="1472500318" id="E0041">
       <type>Census</type>
       <description>Census of Craig Peter Smith</description>
       <noteref hlink="_0000005e0000005e"/>
     </event>
-    <event handle="_0000006000000060" change="1463929997" id="E0042">
+    <event handle="_0000006000000060" change="1472500318" id="E0042">
       <type>Birth</type>
       <dateval val="1858-10-06"/>
       <place hlink="_0000006100000061"/>
       <description>Birth of Magnes Smith</description>
     </event>
-    <event handle="_0000006200000062" change="1463929997" id="E0043">
+    <event handle="_0000006200000062" change="1472500318" id="E0043">
       <type>Death</type>
       <dateval val="1910-02-20"/>
       <place hlink="_0000000d0000000d"/>
       <description>Death of Magnes Smith</description>
     </event>
-    <event handle="_0000006400000064" change="1463929997" id="E0044">
+    <event handle="_0000006400000064" change="1472500318" id="E0044">
       <type>Birth</type>
       <dateval val="1965-08-26"/>
       <place hlink="_0000006500000065"/>
       <description>Birth of Janice Ann Adams</description>
     </event>
-    <event handle="_0000006600000066" change="1463929997" id="E0045">
+    <event handle="_0000006600000066" change="1472500318" id="E0045">
       <type>Occupation</type>
       <description>Retail Manager</description>
     </event>
-    <event handle="_0000006700000067" change="1463929997" id="E0046">
+    <event handle="_0000006700000067" change="1472500318" id="E0046">
       <type>Degree</type>
       <dateval val="1988"/>
       <description>Business Management</description>
     </event>
-    <event handle="_0000006900000069" change="1463929997" id="E0047">
+    <event handle="_0000006900000069" change="1472500318" id="E0047">
       <type>Birth</type>
       <dateval val="1903-06-03"/>
       <place hlink="_0000006a0000006a"/>
       <description>Birth of Marjorie Ohman</description>
     </event>
-    <event handle="_0000006b0000006b" change="1463929997" id="E0048">
+    <event handle="_0000006b0000006b" change="1472500318" id="E0048">
       <type>Death</type>
       <dateval val="1980-06-22"/>
       <place hlink="_0000001e0000001e"/>
       <description>Death of Marjorie Ohman</description>
     </event>
-    <event handle="_0000006d0000006d" change="1463929997" id="E0049">
+    <event handle="_0000006d0000006d" change="1472500318" id="E0049">
       <type>Birth</type>
       <dateval val="1966-07-02"/>
       <place hlink="_0000006e0000006e"/>
       <description>Birth of Darcy Horne</description>
     </event>
-    <event handle="_0000007000000070" change="1463929997" id="E0050">
+    <event handle="_0000007000000070" change="1472500318" id="E0050">
       <type>Birth</type>
       <dateval val="1935-03-13"/>
       <place hlink="_0000000900000009"/>
       <description>Birth of Lloyd Smith</description>
     </event>
-    <event handle="_0000007200000072" change="1463929997" id="E0051">
+    <event handle="_0000007200000072" change="1472500318" id="E0051">
       <type>Birth</type>
       <dateval val="1933-11-22"/>
       <place hlink="_0000000500000005"/>
       <description>Birth of Alice Paula Perkins</description>
     </event>
-    <event handle="_0000007400000074" change="1463929997" id="E0052">
+    <event handle="_0000007400000074" change="1472500318" id="E0052">
       <type>Birth</type>
       <dateval val="1991-09-16"/>
       <place hlink="_0000007500000075"/>
       <description>Birth of Lars Peter Smith</description>
     </event>
-    <event handle="_0000007600000076" change="1463929997" id="E0053">
+    <event handle="_0000007600000076" change="1472500318" id="E0053">
       <type>Adopted</type>
     </event>
-    <event handle="_0000007800000078" change="1463929997" id="E0054">
+    <event handle="_0000007800000078" change="1472500318" id="E0054">
       <type>Birth</type>
       <dateval val="1800-09-14"/>
       <place hlink="_0000001300000013"/>
       <description>Birth of Elna Jefferson</description>
     </event>
-    <event handle="_0000007900000079" change="1463929997" id="E0055">
+    <event handle="_0000007900000079" change="1472500318" id="E0055">
       <type>Death</type>
       <place hlink="_0000003f0000003f"/>
       <description>Death of Elna Jefferson</description>
     </event>
-    <event handle="_0000007a0000007a" change="1463929997" id="E0056">
+    <event handle="_0000007a0000007a" change="1472500318" id="E0056">
       <type>Christening</type>
       <dateval val="1800-09-16"/>
       <place hlink="_0000001300000013"/>
       <description>Christening of Elna Jefferson</description>
     </event>
-    <event handle="_0000007e0000007e" change="1463929997" id="E0057">
+    <event handle="_0000007e0000007e" change="1472500318" id="E0057">
       <type>Birth</type>
       <dateval val="1961-05-24"/>
       <place hlink="_0000008100000081"/>
       <description>Birth of Edwin Michael Smith</description>
       <citationref hlink="_0000008000000080"/>
     </event>
-    <event handle="_0000008200000082" change="1463929997" id="E0058">
+    <event handle="_0000008200000082" change="1472500318" id="E0058">
       <type>Occupation</type>
       <description>Software Engineer</description>
       <noteref hlink="_0000008300000083"/>
     </event>
-    <event handle="_0000008400000084" change="1463929997" id="E0059">
+    <event handle="_0000008400000084" change="1472500318" id="E0059">
       <type>Education</type>
       <daterange start="1979" stop="1984"/>
       <place hlink="_0000008500000085"/>
       <description>Education of Edwin Michael Smith</description>
     </event>
-    <event handle="_0000008600000086" change="1463929997" id="E0060">
+    <event handle="_0000008600000086" change="1472500318" id="E0060">
       <type>Degree</type>
       <dateval val="1984"/>
       <description>B.S.E.E.</description>
     </event>
-    <event handle="_0000008800000088" change="1463929997" id="E0061">
+    <event handle="_0000008800000088" change="1472500318" id="E0061">
       <type>Birth</type>
       <dateval val="1832-11-29"/>
       <place hlink="_0000008900000089"/>
       <description>Birth of Kerstina Hansdotter</description>
     </event>
-    <event handle="_0000008a0000008a" change="1463929997" id="E0062">
+    <event handle="_0000008a0000008a" change="1472500318" id="E0062">
       <type>Death</type>
       <dateval val="1908" type="before"/>
       <place hlink="_0000003f0000003f"/>
       <description>Death of Kerstina Hansdotter</description>
     </event>
-    <event handle="_0000008c0000008c" change="1463929997" id="E0063">
+    <event handle="_0000008c0000008c" change="1472500318" id="E0063">
       <type>Birth</type>
       <daterange start="1794" stop="1796"/>
       <place hlink="_0000008d0000008d"/>
       <description>Birth of Martin Smith</description>
     </event>
-    <event handle="_0000008e0000008e" change="1463929997" id="E0064">
+    <event handle="_0000008e0000008e" change="1472500318" id="E0064">
       <type>Death</type>
       <place hlink="_0000003f0000003f"/>
       <description>Death of Martin Smith</description>
     </event>
-    <event handle="_0000009000000090" change="1463929997" id="E0065">
+    <event handle="_0000009000000090" change="1472500318" id="E0065">
       <type>Birth</type>
       <dateval val="1826-01-29"/>
       <place hlink="_0000001300000013"/>
       <description>Birth of Ingeman Smith</description>
     </event>
-    <event handle="_0000009200000092" change="1463929997" id="E0066">
+    <event handle="_0000009200000092" change="1472500318" id="E0066">
       <type>Birth</type>
       <dateval val="1960-02-05"/>
       <place hlink="_0000008100000081"/>
       <description>Birth of Marjorie Alice Smith</description>
     </event>
-    <event handle="_0000009400000094" change="1463929997" id="E0067">
+    <event handle="_0000009400000094" change="1472500318" id="E0067">
       <type>Birth</type>
       <dateval val="1935-12-02"/>
       <description>Birth of Janis Elaine Green</description>
     </event>
-    <event handle="_0000009600000096" change="1463929997" id="E0068">
+    <event handle="_0000009600000096" change="1472500318" id="E0068">
       <type>Birth</type>
       <dateval val="1996-06-26"/>
       <place hlink="_0000003200000032"/>
       <description>Birth of Mason Michael Smith</description>
     </event>
-    <event handle="_0000009700000097" change="1463929997" id="E0069">
+    <event handle="_0000009700000097" change="1472500318" id="E0069">
       <type>Christening</type>
       <dateval val="1996-07-10"/>
       <place hlink="_0000003400000034"/>
       <description>Christening of Mason Michael Smith</description>
     </event>
-    <event handle="_0000009900000099" change="1463929997" id="E0070">
+    <event handle="_0000009900000099" change="1472500318" id="E0070">
       <type>Birth</type>
       <dateval val="1886" type="about"/>
       <description>Birth of Edwin Willard</description>
     </event>
-    <event handle="_0000009b0000009b" change="1463929997" id="E0071">
+    <event handle="_0000009b0000009b" change="1472500318" id="E0071">
       <type>Birth</type>
       <dateval val="1823" type="after"/>
       <place hlink="_0000001300000013"/>
       <description>Birth of Ingar Smith</description>
     </event>
-    <event handle="_0000009d0000009d" change="1463929997" id="E0072">
+    <event handle="_0000009d0000009d" change="1472500318" id="E0072">
       <type>Birth</type>
       <dateval val="1895-04-07"/>
       <place hlink="_0000000d0000000d"/>
       <description>Birth of Hjalmar Smith</description>
     </event>
-    <event handle="_0000009e0000009e" change="1463929997" id="E0073">
+    <event handle="_0000009e0000009e" change="1472500318" id="E0073">
       <type>Death</type>
       <dateval val="1975-06-26"/>
       <place hlink="_0000001e0000001e"/>
       <description>Death of Hjalmar Smith</description>
     </event>
-    <event handle="_0000009f0000009f" change="1463929997" id="E0074">
+    <event handle="_0000009f0000009f" change="1472500318" id="E0074">
       <type>Baptism</type>
       <dateval val="1895-06-03"/>
       <place hlink="_000000a0000000a0"/>
       <description>Baptism of Hjalmar Smith</description>
     </event>
-    <event handle="_000000a1000000a1" change="1463929997" id="E0075">
+    <event handle="_000000a1000000a1" change="1472500318" id="E0075">
       <type>Immi</type>
       <dateval val="1912-11-14"/>
       <place hlink="_0000004b0000004b"/>
     </event>
-    <event handle="_000000a4000000a4" change="1463929997" id="E0076">
+    <event handle="_000000a4000000a4" change="1472500318" id="E0076">
       <type>Birth</type>
       <dateval val="1860-09-27"/>
       <place hlink="_0000006100000061"/>
       <description>Birth of Emil Smith</description>
     </event>
-    <event handle="_000000a5000000a5" change="1463929997" id="E0077">
+    <event handle="_000000a5000000a5" change="1472500318" id="E0077">
       <type>Marriage</type>
       <dateval val="1816" type="about"/>
       <place hlink="_0000001300000013"/>
       <description>Marriage of Martin Smith and Elna Jefferson</description>
     </event>
-    <event handle="_000000a6000000a6" change="1463929997" id="E0078">
+    <event handle="_000000a6000000a6" change="1472500318" id="E0078">
       <type>Marriage</type>
       <dateval val="1790" type="about"/>
       <place hlink="_0000003f0000003f"/>
       <description>Marriage of Ingeman Smith and Marta Ericsdotter</description>
     </event>
-    <event handle="_000000a7000000a7" change="1463929997" id="E0079">
+    <event handle="_000000a7000000a7" change="1472500318" id="E0079">
       <type>Marriage</type>
       <dateval val="1986-07-12"/>
       <place hlink="_000000a8000000a8"/>
       <description>Marriage of Eric Lloyd Smith and Darcy Horne</description>
     </event>
-    <event handle="_000000a9000000a9" change="1463929997" id="E0080">
+    <event handle="_000000a9000000a9" change="1472500318" id="E0080">
       <type>Marriage</type>
       <dateval val="1884-08-24"/>
       <place hlink="_0000000d0000000d"/>
       <description>Marriage of Magnes Smith and Anna Streiffert</description>
     </event>
-    <event handle="_000000aa000000aa" change="1463929997" id="E0081">
+    <event handle="_000000aa000000aa" change="1472500318" id="E0081">
       <type>Marriage</type>
       <dateval val="1954-06-04"/>
       <place hlink="_0000000500000005"/>
       <description>Marriage of John Hjalmar Smith and Alice Paula Perkins</description>
       <citationref hlink="_000000ac000000ac"/>
     </event>
-    <event handle="_000000ad000000ad" change="1463929997" id="E0082">
+    <event handle="_000000ad000000ad" change="1472500318" id="E0082">
       <type>Marriage</type>
       <dateval val="1995-05-27"/>
       <place hlink="_000000ae000000ae"/>
       <description>Marriage of Edwin Michael Smith and Janice Ann Adams</description>
     </event>
-    <event handle="_000000af000000af" change="1463929997" id="E0083">
+    <event handle="_000000af000000af" change="1472500318" id="E0083">
       <type>Engagement</type>
       <dateval val="1994-10-05"/>
       <place hlink="_0000000900000009"/>
       <description>Engagement of Edwin Michael Smith and Janice Ann Adams</description>
     </event>
-    <event handle="_000000b0000000b0" change="1463929997" id="E0084">
+    <event handle="_000000b0000000b0" change="1472500318" id="E0084">
       <type>Marriage</type>
       <dateval val="1856" type="about"/>
       <description>Marriage of Martin Smith and Kerstina Hansdotter</description>
     </event>
-    <event handle="_000000b1000000b1" change="1463929997" id="E0085">
+    <event handle="_000000b1000000b1" change="1472500318" id="E0085">
       <type>Marriage</type>
       <dateval val="1885-11-27"/>
       <place hlink="_0000000d0000000d"/>
       <description>Marriage of Gustaf Smith, Sr. and Anna Hansdotter</description>
     </event>
-    <event handle="_000000b2000000b2" change="1463929997" id="E0086">
+    <event handle="_000000b2000000b2" change="1472500318" id="E0086">
       <type>Marriage</type>
       <dateval val="1910" type="about"/>
       <description>Marriage of Edwin Willard and Kirsti Marie Smith</description>
     </event>
-    <event handle="_000000b3000000b3" change="1463929997" id="E0087">
+    <event handle="_000000b3000000b3" change="1472500318" id="E0087">
       <type>Marriage</type>
       <dateval val="1912-11-30"/>
       <place hlink="_0000000d0000000d"/>
       <description>Marriage of Herman Julius Nielsen and Astrid Shermanna Augusta Smith</description>
     </event>
-    <event handle="_000000b4000000b4" change="1463929997" id="E0088">
+    <event handle="_000000b4000000b4" change="1472500318" id="E0088">
       <type>Marriage</type>
       <dateval val="1927-10-31"/>
       <place hlink="_0000001e0000001e"/>
       <description>Marriage of Hjalmar Smith and Marjorie Ohman</description>
     </event>
-    <event handle="_000000b5000000b5" change="1463929997" id="E0089">
+    <event handle="_000000b5000000b5" change="1472500318" id="E0089">
       <type>Marriage</type>
       <dateval val="1920" type="about"/>
       <description>Marriage of Gus Smith and Evelyn Michaels</description>
     </event>
-    <event handle="_000000b6000000b6" change="1463929997" id="E0090">
+    <event handle="_000000b6000000b6" change="1472500318" id="E0090">
       <type>Marriage</type>
       <dateval val="1958-08-10"/>
       <place hlink="_0000000900000009"/>
@@ -1089,15 +1089,15 @@
     </family>
   </families>
   <citations>
-    <citation handle="_0000007d0000007d" change="1463929997" id="C0000">
+    <citation handle="_0000007d0000007d" change="1472500318" id="C0000">
       <confidence>2</confidence>
       <sourceref hlink="_0000007c0000007c"/>
     </citation>
-    <citation handle="_0000008000000080" change="1463929997" id="C0001">
+    <citation handle="_0000008000000080" change="1472500318" id="C0001">
       <confidence>2</confidence>
       <sourceref hlink="_0000007f0000007f"/>
     </citation>
-    <citation handle="_000000ac000000ac" change="1463929997" id="C0002">
+    <citation handle="_000000ac000000ac" change="1472500318" id="C0002">
       <confidence>2</confidence>
       <sourceref hlink="_000000ab000000ab"/>
     </citation>
@@ -1121,105 +1121,105 @@
     </source>
   </sources>
   <places>
-    <placeobj handle="_0000000300000003" change="1463929997" id="P0000" type="Unknown">
+    <placeobj handle="_0000000300000003" change="1472500318" id="P0000" type="Unknown">
       <ptitle>Löderup, Malmöhus Län, Sweden</ptitle>
       <pname value="Löderup, Malmöhus Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000000500000005" change="1463929997" id="P0001" type="Unknown">
+    <placeobj handle="_0000000500000005" change="1472500318" id="P0001" type="Unknown">
       <ptitle>Sparks, Washoe Co., NV</ptitle>
       <pname value="Sparks, Washoe Co., NV"/>
     </placeobj>
-    <placeobj handle="_0000000900000009" change="1463929997" id="P0002" type="Unknown">
+    <placeobj handle="_0000000900000009" change="1472500318" id="P0002" type="Unknown">
       <ptitle>San Francisco, San Francisco Co., CA</ptitle>
       <pname value="San Francisco, San Francisco Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000000d0000000d" change="1463929997" id="P0003" type="Unknown">
+    <placeobj handle="_0000000d0000000d" change="1472500318" id="P0003" type="Unknown">
       <ptitle>Rønne, Bornholm, Denmark</ptitle>
       <pname value="Rønne, Bornholm, Denmark"/>
     </placeobj>
-    <placeobj handle="_0000001300000013" change="1463929997" id="P0004" type="Unknown">
+    <placeobj handle="_0000001300000013" change="1472500318" id="P0004" type="Unknown">
       <ptitle>Gladsax, Kristianstad Län, Sweden</ptitle>
       <pname value="Gladsax, Kristianstad Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000001e0000001e" change="1463929997" id="P0005" type="Unknown">
+    <placeobj handle="_0000001e0000001e" change="1472500318" id="P0005" type="Unknown">
       <ptitle>Reno, Washoe Co., NV</ptitle>
       <pname value="Reno, Washoe Co., NV"/>
     </placeobj>
-    <placeobj handle="_0000003200000032" change="1463929997" id="P0006" type="Unknown">
+    <placeobj handle="_0000003200000032" change="1472500318" id="P0006" type="Unknown">
       <ptitle>Hayward, Alameda Co., CA</ptitle>
       <pname value="Hayward, Alameda Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000003400000034" change="1463929997" id="P0007" type="Unknown">
+    <placeobj handle="_0000003400000034" change="1472500318" id="P0007" type="Unknown">
       <ptitle>Community Presbyterian Church, Danville, CA</ptitle>
       <pname value="Community Presbyterian Church, Danville, CA"/>
     </placeobj>
-    <placeobj handle="_0000003f0000003f" change="1463929997" id="P0008" type="Unknown">
+    <placeobj handle="_0000003f0000003f" change="1472500318" id="P0008" type="Unknown">
       <ptitle>Sweden</ptitle>
       <pname value="Sweden"/>
     </placeobj>
-    <placeobj handle="_0000004800000048" change="1463929997" id="P0009" type="Unknown">
+    <placeobj handle="_0000004800000048" change="1472500318" id="P0009" type="Unknown">
       <ptitle>Grostorp, Kristianstad Län, Sweden</ptitle>
       <pname value="Grostorp, Kristianstad Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000004b0000004b" change="1463929997" id="P0010" type="Unknown">
+    <placeobj handle="_0000004b0000004b" change="1472500318" id="P0010" type="Unknown">
       <ptitle>Copenhagen, Denmark</ptitle>
       <pname value="Copenhagen, Denmark"/>
     </placeobj>
-    <placeobj handle="_0000005800000058" change="1463929997" id="P0011" type="Unknown">
+    <placeobj handle="_0000005800000058" change="1472500318" id="P0011" type="Unknown">
       <ptitle>Hoya/Jona/Hoia, Sweden</ptitle>
       <pname value="Hoya/Jona/Hoia, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000006100000061" change="1463929997" id="P0012" type="Unknown">
+    <placeobj handle="_0000006100000061" change="1472500318" id="P0012" type="Unknown">
       <ptitle>Simrishamn, Kristianstad Län, Sweden</ptitle>
       <pname value="Simrishamn, Kristianstad Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000006500000065" change="1463929997" id="P0013" type="Unknown">
+    <placeobj handle="_0000006500000065" change="1472500318" id="P0013" type="Unknown">
       <ptitle>Fremont, Alameda Co., CA</ptitle>
       <pname value="Fremont, Alameda Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000006a0000006a" change="1463929997" id="P0014" type="Unknown">
+    <placeobj handle="_0000006a0000006a" change="1472500318" id="P0014" type="Unknown">
       <ptitle>Denver, Denver Co., CO</ptitle>
       <pname value="Denver, Denver Co., CO"/>
     </placeobj>
-    <placeobj handle="_0000006e0000006e" change="1463929997" id="P0015" type="Unknown">
+    <placeobj handle="_0000006e0000006e" change="1472500318" id="P0015" type="Unknown">
       <ptitle>Sacramento, Sacramento Co., CA</ptitle>
       <pname value="Sacramento, Sacramento Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000007500000075" change="1463929997" id="P0016" type="Unknown">
+    <placeobj handle="_0000007500000075" change="1472500318" id="P0016" type="Unknown">
       <ptitle>Santa Rosa, Sonoma Co., CA</ptitle>
       <pname value="Santa Rosa, Sonoma Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000008100000081" change="1463929997" id="P0017" type="Unknown">
+    <placeobj handle="_0000008100000081" change="1472500318" id="P0017" type="Unknown">
       <ptitle>San Jose, Santa Clara Co., CA</ptitle>
       <pname value="San Jose, Santa Clara Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000008500000085" change="1463929997" id="P0018" type="Unknown">
+    <placeobj handle="_0000008500000085" change="1472500318" id="P0018" type="Unknown">
       <ptitle>UC Berkeley</ptitle>
       <pname value="UC Berkeley"/>
     </placeobj>
-    <placeobj handle="_0000008900000089" change="1463929997" id="P0019" type="Unknown">
+    <placeobj handle="_0000008900000089" change="1472500318" id="P0019" type="Unknown">
       <ptitle>Smestorp, Kristianstad Län, Sweden</ptitle>
       <pname value="Smestorp, Kristianstad Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000008d0000008d" change="1463929997" id="P0020" type="Unknown">
+    <placeobj handle="_0000008d0000008d" change="1472500318" id="P0020" type="Unknown">
       <ptitle>Tommarp, Kristianstad Län, Sweden</ptitle>
       <pname value="Tommarp, Kristianstad Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_000000a0000000a0" change="1463929997" id="P0021" type="Unknown">
+    <placeobj handle="_000000a0000000a0" change="1472500318" id="P0021" type="Unknown">
       <ptitle>Rønne Bornholm, Denmark</ptitle>
       <pname value="Rønne Bornholm, Denmark"/>
     </placeobj>
-    <placeobj handle="_000000a8000000a8" change="1463929997" id="P0022" type="Unknown">
+    <placeobj handle="_000000a8000000a8" change="1472500318" id="P0022" type="Unknown">
       <ptitle>Woodland, Yolo Co., CA</ptitle>
       <pname value="Woodland, Yolo Co., CA"/>
     </placeobj>
-    <placeobj handle="_000000ae000000ae" change="1463929997" id="P0023" type="Unknown">
+    <placeobj handle="_000000ae000000ae" change="1472500318" id="P0023" type="Unknown">
       <ptitle>San Ramon, Conta Costa Co., CA</ptitle>
       <pname value="San Ramon, Conta Costa Co., CA"/>
     </placeobj>
   </places>
   <repositories>
-    <repository handle="_000000b7000000b7" change="1463929997" id="R0002">
+    <repository handle="_000000b7000000b7" change="1472500318" id="R0002">
       <rname>New York Public Library</rname>
       <type>Library</type>
       <address>
@@ -1230,7 +1230,7 @@
         <postal>11111</postal>
       </address>
     </repository>
-    <repository handle="_000000bb000000bb" change="1463929997" id="R0003">
+    <repository handle="_000000bb000000bb" change="1472500318" id="R0003">
       <rname>Aunt Martha's Attic</rname>
       <type>Library</type>
       <address>
@@ -1244,30 +1244,30 @@
     </repository>
   </repositories>
   <notes>
-    <note handle="_0000004200000042" change="1463929997" id="N0002" type="General">
+    <note handle="_0000004200000042" change="1472500318" id="N0002" type="Person Note">
       <text>BIOGRAPHY
 Martin was listed as being a Husman, (owning a house as opposed to a farm) in the house records of Gladsax.</text>
     </note>
-    <note handle="_0000005e0000005e" change="1463929997" id="N0000" type="General">
+    <note handle="_0000005e0000005e" change="1472500318" id="N0000" type="Event Note">
       <text>Witness name: John Doe
 Witness comment: This is a simple test.</text>
     </note>
-    <note handle="_0000008300000083" change="1463929997" id="N0001" type="General">
+    <note handle="_0000008300000083" change="1472500318" id="N0001" type="Event Note">
       <text>Witness name: No Name</text>
     </note>
-    <note handle="_000000a2000000a2" change="1463929997" id="N0003" type="General">
+    <note handle="_000000a2000000a2" change="1472500318" id="N0003" type="Person Note">
       <text>BIOGRAPHY
 
 Hjalmar sailed from Copenhagen, Denmark on the OSCAR II, 14 November 1912 arriving in New York 27 November 1912. He was seventeen years old. On the ship passenger list his trade was listed as a Blacksmith.  He came to Reno, Nevada and lived with his sister Marie for a time before settling in Sparks. He worked for Southern Pacific Railroad as a car inspector for a time, then went to work for Standard Oil
 Company. He enlisted in the army at Sparks 7 December 1917 and served as a Corporal in the Medical Corp until his discharge 12 August 1919 at the Presidio in San Francisco, California. Both he and Marjorie are buried in the Masonic Memorial Gardens Mausoleum in Reno, he the 30th June 1975, and she the 25th of June 1980.</text>
     </note>
-    <note handle="_000000b8000000b8" change="1463929997" id="N0004" type="General">
+    <note handle="_000000b8000000b8" change="1472500318" id="N0004" type="Source Note">
       <text>But Aunt Martha still keeps the original!</text>
     </note>
-    <note handle="_000000ba000000ba" change="1463929997" id="N0005" type="General">
+    <note handle="_000000ba000000ba" change="1472500318" id="N0005" type="Source Note">
       <text>The repository reference from the source is important</text>
     </note>
-    <note handle="_000000bc000000bc" change="1463929997" id="N0006" type="General">
+    <note handle="_000000bc000000bc" change="1472500318" id="N0006" type="Repository Note">
       <text>Some note on the repo</text>
     </note>
   </notes>


### PR DESCRIPTION
Gramps has NoteTypes available for Notes; this fix change the Gedcom import to utilize them (They were mostly set to 'General' previously, now set to 'Media', Person', Family' etc.).
Also some refactoring; I modified the __media_ref_note and __event_inline_note processing to utilize the general __parse_note code, rather than having code (and fix) duplication.

__parse_note also was modified to eliminate a no longer used input parameter (level).

Added Gedcom SUBM/NOTE support; note added to the default source (when default source is enabled via preferences).

For Gedcom CHAN/NOTE (Notes on a Change time which we cannot support), modified the code to create the appropriate error message, instead of dropping the note entirely.