### PR TITLE
bug 1680 fix Gedcom export of illegal level 1 CAUS entries

### DIFF
--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -506,7 +506,7 @@ PERSONALCONSTANTEVENTS = {
     EventType.BAS_MITZVAH      : "BASM",
     EventType.BLESS            : "BLES",
     EventType.BURIAL           : "BURI",
-    EventType.CAUSE_DEATH      : "CAUS",
+    # EventType.CAUSE_DEATH      : "CAUS",  Not legal Gedcom since v5.0
     EventType.ORDINATION       : "ORDN",
     EventType.CENSUS           : "CENS",
     EventType.CHRISTEN         : "CHR" ,


### PR DESCRIPTION
"Cause Of Death" presently exists in gen/lib/eventtype.py and shows in the drop-down list of types when creating an event.
Creating an event of this type appears in the UI similar to a generic event of user-specified type, but if exported as Gedcom it emits invalid Gedcom like
 1 CAUS Y
 2 TYPE boredom
The libgedcom.py file contains a translation dict that converts the Gramps event types to Gedcom types. Removal of the particular translation entry will prevent the export of level 1 (under individual) CAUS tag (which has not been legal since at least Gedcom 5, and arguably not under Gedcom 4.x).
The Gramps Cause of Death Event will then export as legal Gedcom:
0 @I0011@ INDI
1 NAME Mrs /Tester/
2 GIVN Tester
2 SURN Mrs
1 SEX F
1 EVEN Boredom from long life
2 TYPE Cause Of Death
2 DATE 2 SEP 2016

It will also prevent the import of CAUS directly under an individual to the Gramps event. The import will still take place (if it is ever found, not likely IMHO), but it will end up as a Gramps Custom Event, rather than a standard event.

Level 2 CAUS under events (legal Gedcom) would still be fully supported.