### PR TITLE
Update Check & Repair tool & Test Case Generator tool to fix bad alternative Place names

### DIFF
--- a/gramps/plugins/test/test_tools.py
+++ b/gramps/plugins/test/test_tools.py
@@ -1,0 +1,168 @@
+#! /usr/bin/env python3
+"""
+Gramps - a GTK+/GNOME based genealogy program
+
+Copyright (c) 2016 Gramps Development Team
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+"""
+
+import os
+import sys
+import codecs
+import unittest
+import random
+
+from gramps.test.test_util import Gramps
+from gramps.gen.const import DATA_DIR
+from gramps.cli.user import User
+from gramps.gen.utils.id import set_det_id
+from gramps.gen import const
+from gramps.gen.utils.config import config
+
+TREE_NAME = "Test_tooltest"
+TEST_DIR = os.path.abspath(os.path.join(DATA_DIR, "tests"))
+const.myrand = random.Random()
+
+
+def call(*args):
+    """ Call Gramps to perform the action with out and err captured """
+    if __debug__:
+        print ("call: %s", args)
+    gramps = Gramps(user=User(auto_accept=True, quiet=True))
+    # gramps = Gramps(user=User(auto_accept=True))
+    out, err = gramps.run(*args)
+    # print("out:", out, "err:", err)
+    return out, err
+
+
+def check_res(out, err, expected, do_out=True):
+    """
+    compare the output with the expected
+    """
+    # return all([(line in out) for line in expect])
+    retval = True
+    for line in expected:
+        if line in (out if do_out else err):
+            continue
+        else:
+            print("*** Expected: '%s', not found" % line)
+            retval = False
+    if not retval:
+        if do_out:
+            print("*** The following was the actual stdout:\n%s"
+                  "*** The following was the stderr:\n%s"
+                  "*** End of stderr" % (out, err))
+        else:
+            print("*** The following was the actual stderr:\n%s"
+                  "*** The following was the stdout:\n%s"
+                  "*** End of stdout" % (err, out))
+    return retval
+
+
+class ToolControl(unittest.TestCase):
+    """
+    These tests run some of the tools used to maintain Gramps db
+    """
+    def setUp(self):
+        self.db_backend = config.get('database.backend')
+        call("--config=database.backend:bsddb", "-y", "-q", "--remove", TREE_NAME)
+
+    def tearDown(self):
+        config.set('database.backend', self.db_backend)
+        call("-y", "-q", "--remove", TREE_NAME)
+
+    def test_tcg_and_check_and_repair(self):
+        """
+        Run a 'Test Case Generator' and 'Check & Repair Database' test.
+        Note that the 'Test Case Generator" uses a lot of random numbers to
+        generate its test cases.  This makes it less than ideal for a
+        predictable unit test.  Still it contains good code for testing the
+        'Check and Repair' tool.  So I force the random functions to be
+        predictable by seeding it with a fixed number.  I also used the
+        'Deterministic ID' function to make the usual db handle generation
+        stop using random numbers and potentially reduce Gramps version to
+        version issues.
+        """
+        # the TCG creates bad strings with illegal characters, so we need to
+        # ignore them when we print the results
+        try:
+            sys.stderr = codecs.getwriter(sys.getdefaultencoding()) \
+                (sys.stderr.buffer, 'replace')
+            sys.stdout = codecs.getwriter(sys.getdefaultencoding()) \
+                (sys.stdout.buffer, 'replace')
+        except:
+            pass
+        tst_file = os.path.join(TEST_DIR, "data.gramps")
+        set_det_id(True)
+        # the following line assumes that TCG has run through init code, where
+        # it puts 'myrand', a 'Random' class object, into the 'const' module so
+        # we can access it here.
+        const.myrand.seed(1234, version=1)
+        # print(const.myrand.random())
+#         out, err = call("-s")
+#         expect = ["bsddb"]
+#         check_res(out, err, expect, do_out=True)
+        out, err = call("-C", TREE_NAME, "-q",
+                        "--import", tst_file)
+        expect = ["Opened successfully!",
+                  "data.gramps, format gramps.",
+                  "Cleaning up."]
+        self.assertTrue(check_res(out, err, expect, do_out=False))
+        self.assertEqual(out, "")
+        out, err = call("-O", TREE_NAME,
+                        "-y", "-q", "-a", "tool", "-p",
+                        "name=testcasegenerator,bugs=1,persons=0,"
+                        "add_linebreak=0,add_serial=0,"
+                        "long_names=0,lowlevel=0,person_count=20,"
+                        "specialchars=0")
+        expect = ["Opened successfully!",
+                  "Performing action: tool.",
+                  "Using options string: name=testcasegenerator,bugs=1",
+                  "Cleaning up."]
+        self.assertTrue(check_res(out, err, expect, do_out=False))
+        expect = ["person count 41"]
+        self.assertTrue(check_res(out, err, expect, do_out=True))
+        out, err = call("-O", TREE_NAME,
+                        "-y", "-a", "tool", "-p", "name=check")
+        expect = ["7 broken child/family links were fixed",
+                  "4 broken spouse/family links were fixed",
+                  "1 place alternate names fixed",
+                  "10 media objects were referenced, but not found",
+                  "References to 10 media objects were kept",
+                  "3 events were referenced, but not found",
+                  "1 invalid birth event name was fixed",
+                  "1 invalid death event name was fixed",
+                  "2 places were referenced, but not found",
+                  "13 citations were referenced, but not found",
+                  "16 sources were referenced, but not found",
+                  "7 empty objects removed",
+                  "1 person objects",
+                  "1 family objects",
+                  "1 event objects",
+                  "1 source objects",
+                  "0 media objects",
+                  "0 place objects",
+                  "1 repository objects",
+                  "1 note objects"]
+        self.assertTrue(check_res(out, err, expect, do_out=True))
+        expect = ["Opened successfully!",
+                  "Performing action: tool.",
+                  "Using options string: name=check",
+                  "Cleaning up."]
+        self.assertTrue(check_res(out, err, expect, do_out=False))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/plugins/tool/check.py
+++ b/gramps/plugins/tool/check.py
@@ -171,6 +171,7 @@ class Check(tool.BatchTool):
             # then going to be deleted.
             checker.cleanup_empty_objects()
             checker.fix_encoding()
+            checker.fix_alt_place_names()
             checker.fix_ctrlchars_in_notes()
             checker.cleanup_missing_photos(cli)
             checker.cleanup_deleted_name_formats()
@@ -246,6 +247,7 @@ class CheckIntegrity:
         self.removed_name_format = []
         self.empty_objects = defaultdict(list)
         self.replaced_sourceref = []
+        self.place_errors = 0
         self.last_img_dir = config.get('behavior.addmedia-image-dir')
         self.progress = ProgressMeter(_('Checking Database'), '',
                                       parent=self.parent_window)
@@ -409,6 +411,38 @@ class CheckIntegrity:
             self.progress.step()
         if error_count == 0:
             logging.info('    OK: no ctrl characters in notes found')
+
+    def fix_alt_place_names(self):
+        """
+        This scans all places and cleans up alternative names.  It removes
+        Blank names, names that are duplicates of the primary name, and
+        duplicates in the alt_names list.
+        """
+        self.progress.set_pass(_('Looking for bad alternate place names'),
+                               self.db.get_number_of_places())
+        logging.info('Looking for bad alternate place names')
+        for bhandle in self.db.place_map.keys():
+            handle = bhandle.decode('utf-8')
+            place = self.db.get_place_from_handle(handle)
+            fixed_alt_names = []
+            fixup = False
+            for name in place.get_alternative_names():
+                if not name.value or \
+                        name == place.name or \
+                        name in fixed_alt_names:
+                    fixup = True
+                    continue
+                fixed_alt_names.append(name)
+            if fixup:
+                place.set_alternative_names(fixed_alt_names)
+                self.db.commit_place(place, self.trans)
+                self.place_errors += 1
+            self.progress.step()
+        if self.place_errors == 0:
+            logging.info('    OK: no bad alternate places found')
+        else:
+            logging.info('    %d bad alternate places found and fixed',
+                         self.place_errors)
 
     def check_for_broken_family_links(self):
         # Check persons referenced by the family objects
@@ -2116,7 +2150,7 @@ class CheckIntegrity:
         empty_objs = sum(len(obj) for obj in self.empty_objects.values())
 
         errors = (photos + efam + blink + plink + slink + rel +
-                  event_invalid + person +
+                  event_invalid + person + self.place_errors +
                   person_references  + family_references + place_references +
                   citation_references + repo_references + media_references  +
                   note_references + tag_references + name_format + empty_objs +
@@ -2231,6 +2265,14 @@ class CheckIntegrity:
                 ngettext("{quantity} corrupted family relationship fixed\n",
                          "{quantity} corrupted family relationships fixed\n",
                          rel).format(quantity=rel)
+                )
+
+        if self.place_errors:
+            self.text.write(
+                # translators: leave all/any {...} untranslated
+                ngettext("{quantity} place alternate name fixed\n",
+                         "{quantity} place alternate names fixed\n",
+                         rel).format(quantity=self.place_errors)
                 )
 
         if person_references:

--- a/gramps/plugins/tool/check.py
+++ b/gramps/plugins/tool/check.py
@@ -751,9 +751,8 @@ class CheckIntegrity:
             photo_desc = obj.get_description()
             if photo_name is not None and photo_name != "" and not find_file(photo_name):
                 if cl:
-                    fn = os.path.basename(photo_name)
                     logging.warning("    FAIL: media file %s was not found." %
-                                    fn)
+                                    photo_name)
                     self.bad_photo.append(ObjectId)
                 else:
                     if missmedia_action == 0:

--- a/gramps/plugins/tool/testcasegenerator.py
+++ b/gramps/plugins/tool/testcasegenerator.py
@@ -57,6 +57,7 @@ from gramps.gen.lib.addressbase import AddressBase
 from gramps.gen.lib.attrbase import AttributeBase
 from gramps.gen.lib.primaryobj import BasicPrimaryObject
 from gramps.gen.lib.citationbase import CitationBase
+from gramps.gen.lib.date import Today
 from gramps.gen.lib.datebase import DateBase
 from gramps.gen.lib.ldsordbase import LdsOrdBase
 from gramps.gen.lib.locationbase import LocationBase
@@ -354,7 +355,7 @@ class TestcaseGenerator(tool.BatchTool):
         if self.options.handler.options_dict['bugs']:
             with self.progress(_('Generating testcases'),
                                _('Generating database errors'),
-                               18) as step:
+                               19) as step:
                 self.generate_data_errors(step)
 
         if self.options.handler.options_dict['persons']:
@@ -397,7 +398,7 @@ class TestcaseGenerator(tool.BatchTool):
 
         self.test_fix_encoding(); step()
         self.test_fix_ctrlchars_in_notes(); step()
-        self.test_cleanup_missing_photos(); step()
+        self.test_fix_alt_place_names(); step()
         self.test_cleanup_deleted_name_formats(); step()
         self.test_cleanup_empty_objects(); step()
         self.test_check_for_broken_family_links(); step()
@@ -505,6 +506,33 @@ class TestcaseGenerator(tool.BatchTool):
             o.set_format(choice( (Note.FLOWED,Note.FORMATTED)))
             o.set_type(self.rand_type(NoteType()))
             self.db.add_note(o, self.trans)
+
+    def test_fix_alt_place_names(self):
+        """
+        Creates a place with a duplicate of primary in alt_names,
+        a blank alt_name, and a duplicate of one of the alt_names. This tests
+        Check.fix_fix_alt_place_names()
+        """
+        with DbTxn(_("Testcase generator step %d") % self.transaction_count,
+                   self.db) as self.trans:
+            self.transaction_count += 1
+
+            plac = Place()
+            pri_name = PlaceName()
+            pri_name.set_value("Primary name")
+            alt_name1 = PlaceName()
+            alt_name1.set_value("Alt name 1")
+            alt_name2 = PlaceName()
+            alt_name2.set_value("Alt name 1")
+            alt_name2.set_language("testish")
+            alt_name3 = PlaceName()
+            alt_name3.set_value("Alt name 1")
+            alt_name3.set_date_object(Today())
+            alt_names = [pri_name, alt_name1, alt_name1, PlaceName(),
+                         alt_name2, alt_name3]
+            plac.set_name(pri_name)
+            plac.set_alternative_names(alt_names)
+            self.db.add_place(plac, self.trans)
 
     def test_cleanup_missing_photos(self):
         pass

--- a/gramps/plugins/tool/testcasegenerator.py
+++ b/gramps/plugins/tool/testcasegenerator.py
@@ -29,10 +29,11 @@
 # standard python modules
 #
 #-------------------------------------------------------------------------
-from random import randint,choice,random
+import sys
+import os
+import random
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
-import time
 
 #-------------------------------------------------------------------------
 #
@@ -85,6 +86,21 @@ from gramps.gen.const import URL_MANUAL_PAGE
 #-------------------------------------------------------------------------
 WIKI_HELP_PAGE = '%s_-_Tools' % URL_MANUAL_PAGE
 WIKI_HELP_SEC = _('Generate_Testcases_for_Persons_and_Families')
+
+# the following allows test code to access a private copy of the random
+# number generator.  The access is typically used for seeding the generator
+# to make it repeatable across runs.  The private copy is unaffected by other
+# uses of the global random() functions.
+try:
+    from gramps.gen.const import myrand
+except (NameError, ImportError):
+    myrand = random.Random()
+except:
+    print("Unexpected error:", sys.exc_info()[0])
+_random = myrand.random
+_choice = myrand.choice
+_randint = myrand.randint
+
 
 LDS_ORD_BAPT_STATUS = (
         LdsOrd.STATUS_NONE,
@@ -228,11 +244,11 @@ class TestcaseGenerator(tool.BatchTool):
             except AttributeError:
                 death = None
             if not birth and not death:
-                birth = randint(1700,1900)
+                birth = _randint(1700, 1900)
             if birth and not death:
-                death = birth + randint(20,90)
+                death = birth + _randint(20, 90)
             if death and not birth:
-                birth = death - randint(20,90)
+                birth = death - _randint(20, 90)
             self.person_dates[self.person.get_handle()] = (birth,death)
 
             self.persons_todo.append(self.person.get_handle())
@@ -372,9 +388,9 @@ class TestcaseGenerator(tool.BatchTool):
                         self.parents_todo.append( ph)
                     person_h = self.persons_todo.pop(0)
                     self.generate_family(person_h)
-                    if randint(0,3) == 0:
+                    if _randint(0, 3) == 0:
                         self.generate_family(person_h)
-                    if randint(0,7) == 0:
+                    if _randint(0, 7) == 0:
                         self.generate_family(person_h)
                     if self.person_count > self.options.handler.options_dict['person_count']:
                         break
@@ -422,7 +438,7 @@ class TestcaseGenerator(tool.BatchTool):
 
             o = Note()
             o.set("dup 1" + self.rand_text(self.NOTE))
-            o.set_format( choice( (Note.FLOWED,Note.FORMATTED)))
+            o.set_format(_choice((Note.FLOWED, Note.FORMATTED)))
             o.set_type( self.rand_type(NoteType()))
             h = self.db.add_note(o, self.trans)
             print("object %s, handle %s, Gramps_Id %s" % (o, o.handle,
@@ -432,13 +448,13 @@ class TestcaseGenerator(tool.BatchTool):
 
             o = Source()
             o.set_title("dup 2" + self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_author( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_publication_info( self.rand_text(self.LONG))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_abbreviation( self.rand_text(self.SHORT))
-            while randint(0,1) == 1:
+            while _randint(0, 1) == 1:
                 sattr = SrcAttribute()
                 sattr.set_type(self.rand_text(self.SHORT))
                 sattr.set_value(self.rand_text(self.SHORT))
@@ -503,15 +519,16 @@ class TestcaseGenerator(tool.BatchTool):
 
             o = Note()
             o.set("This is a text note with a \x03 control character")
-            o.set_format(choice( (Note.FLOWED,Note.FORMATTED)))
+            o.set_format(_choice((Note.FLOWED, Note.FORMATTED)))
             o.set_type(self.rand_type(NoteType()))
             self.db.add_note(o, self.trans)
 
     def test_fix_alt_place_names(self):
         """
         Creates a place with a duplicate of primary in alt_names,
-        a blank alt_name, and a duplicate of one of the alt_names. This tests
-        Check.fix_fix_alt_place_names()
+        a blank alt_name, and a duplicate of one of the alt_names. Also
+        include two alt names that are almost duplicates, but not quite.
+        This tests Check.fix_alt_place_names()
         """
         with DbTxn(_("Testcase generator step %d") % self.transaction_count,
                    self.db) as self.trans:
@@ -1015,14 +1032,14 @@ class TestcaseGenerator(tool.BatchTool):
         #         Address
         m = Media()
         m.set_description(message)
-        m.set_path(str(ICON))
+        m.set_path(os.path.abspath(str(ICON)))
         m.set_mime_type(get_type(m.get_path()))
-        m.add_citation(choice(c_h_list))
+        m.add_citation(_choice(c_h_list))
         # Media : Attribute
         a = Attribute()
         a.set_type(self.rand_type(AttributeType()))
         a.set_value(message)
-        a.add_citation(choice(c_h_list))
+        a.add_citation(_choice(c_h_list))
         m.add_attribute(a)
         self.db.add_media(m, self.trans)
 
@@ -1034,28 +1051,28 @@ class TestcaseGenerator(tool.BatchTool):
         fam.set_mother_handle(person2_h)
         fam.set_relationship((FamilyRelType.MARRIED,''))
         # Family
-        fam.add_citation(choice(c_h_list))
+        fam.add_citation(_choice(c_h_list))
         # Family : Attribute
         a = Attribute()
         a.set_type(self.rand_type(AttributeType()))
         a.set_value(message)
-        a.add_citation(choice(c_h_list))
+        a.add_citation(_choice(c_h_list))
         fam.add_attribute(a)
         # Family : ChildRef
         child_ref = ChildRef()
         child_ref.set_reference_handle(child_h)
         self.fill_object(child_ref)
-        child_ref.add_citation(choice(c_h_list))
+        child_ref.add_citation(_choice(c_h_list))
         fam.add_child_ref(child_ref)
         # Family : MediaRef
         mr = MediaRef()
         mr.set_reference_handle(m.handle)
-        mr.add_citation(choice(c_h_list))
+        mr.add_citation(_choice(c_h_list))
         # Family : MediaRef : Attribute
         a = Attribute()
         a.set_type(self.rand_type(AttributeType()))
         a.set_value(message)
-        a.add_citation(choice(c_h_list))
+        a.add_citation(_choice(c_h_list))
         mr.add_attribute(a)
         fam.add_media_reference(mr)
         # Family : LDSORD
@@ -1064,10 +1081,9 @@ class TestcaseGenerator(tool.BatchTool):
         # TODO: adapt type and status to family/person
         #if isinstance(o,Person):
         #if isinstance(o,Family):
-        ldsord.set_type( choice(
-            [item[0] for item in LdsOrd._TYPE_MAP] ))
-        ldsord.set_status( randint(0,len(LdsOrd._STATUS_MAP)-1))
-        ldsord.add_citation(choice(c_h_list))
+        ldsord.set_type(_choice([item[0] for item in LdsOrd._TYPE_MAP]))
+        ldsord.set_status(_randint(0, len(LdsOrd._STATUS_MAP)-1))
+        ldsord.add_citation(_choice(c_h_list))
         fam.add_lds_ord(ldsord)
         # Family : EventRef
         e = Event()
@@ -1083,29 +1099,29 @@ class TestcaseGenerator(tool.BatchTool):
         a = Attribute()
         a.set_type(self.rand_type(AttributeType()))
         a.set_value(message)
-        a.add_citation(choice(c_h_list))
+        a.add_citation(_choice(c_h_list))
         er.add_attribute(a)
         fam.add_event_ref(er)
         fam_h = self.db.add_family(fam,self.trans)
         person1 = self.db.get_person_from_handle(person1_h)
         person1.add_family_handle(fam_h)
         # Person
-        person1.add_citation(choice(c_h_list))
+        person1.add_citation(_choice(c_h_list))
         # Person : Name
         alt_name = Name(person1.get_primary_name())
         alt_name.set_first_name(message)
-        alt_name.add_citation(choice(c_h_list))
+        alt_name.add_citation(_choice(c_h_list))
         person1.add_alternate_name(alt_name)
         # Person : Address
         a = Address()
         a.set_street(message)
-        a.add_citation(choice(c_h_list))
+        a.add_citation(_choice(c_h_list))
         person1.add_address(a)
         # Person : Attribute
         a = Attribute()
         a.set_type(self.rand_type(AttributeType()))
         a.set_value(message)
-        a.add_citation(choice(c_h_list))
+        a.add_citation(_choice(c_h_list))
         person1.add_attribute(a)
         # Person : PersonRef
         asso_h = self.generate_person()
@@ -1113,17 +1129,17 @@ class TestcaseGenerator(tool.BatchTool):
         asso.set_reference_handle(asso_h)
         asso.set_relation(self.rand_text(self.SHORT))
         self.fill_object(asso)
-        asso.add_citation(choice(c_h_list))
+        asso.add_citation(_choice(c_h_list))
         person1.add_person_ref(asso)
         # Person : MediaRef
         mr = MediaRef()
         mr.set_reference_handle(m.handle)
-        mr.add_citation(choice(c_h_list))
+        mr.add_citation(_choice(c_h_list))
         # Person : MediaRef : Attribute
         a = Attribute()
         a.set_type(self.rand_type(AttributeType()))
         a.set_value(self.rand_text(self.SHORT))
-        a.add_citation(choice(c_h_list))
+        a.add_citation(_choice(c_h_list))
         mr.add_attribute(a)
         person1.add_media_reference(mr)
         # Person : LDSORD
@@ -1132,10 +1148,10 @@ class TestcaseGenerator(tool.BatchTool):
         # TODO: adapt type and status to family/person
         #if isinstance(o,Person):
         #if isinstance(o,Family):
-        ldsord.set_type( choice(
+        ldsord.set_type(_choice(
             [item[0] for item in LdsOrd._TYPE_MAP] ))
-        ldsord.set_status( randint(0,len(LdsOrd._STATUS_MAP)-1))
-        ldsord.add_citation(choice(c_h_list))
+        ldsord.set_status(_randint(0, len(LdsOrd._STATUS_MAP)-1))
+        ldsord.add_citation(_choice(c_h_list))
         person1.add_lds_ord(ldsord)
         # Person : EventRef
         e = Event()
@@ -1151,7 +1167,7 @@ class TestcaseGenerator(tool.BatchTool):
         a = Attribute()
         a.set_type(self.rand_type(AttributeType()))
         a.set_value(message)
-        a.add_citation(choice(c_h_list))
+        a.add_citation(_choice(c_h_list))
         er.add_attribute(a)
         person1.add_event_ref(er)
         self.db.commit_person(person1,self.trans)
@@ -1163,38 +1179,38 @@ class TestcaseGenerator(tool.BatchTool):
         e.set_description(message)
         e.set_type(EventType.MARRIAGE)
         # Event
-        e.add_citation(choice(c_h_list))
+        e.add_citation(_choice(c_h_list))
         # Event : Attribute
         a = Attribute()
         a.set_type(self.rand_type(AttributeType()))
         a.set_value(message)
-        a.add_citation(choice(c_h_list))
+        a.add_citation(_choice(c_h_list))
         e.add_attribute(a)
         # Event : MediaRef
         mr = MediaRef()
         mr.set_reference_handle(m.handle)
-        mr.add_citation(choice(c_h_list))
+        mr.add_citation(_choice(c_h_list))
         # Event : MediaRef : Attribute
         a = Attribute()
         a.set_type(self.rand_type(AttributeType()))
         a.set_value(self.rand_text(self.SHORT))
-        a.add_citation(choice(c_h_list))
+        a.add_citation(_choice(c_h_list))
         mr.add_attribute(a)
         e.add_media_reference(mr)
         self.db.add_event(e, self.trans)
 
         p = Place()
         p.set_title(message)
-        p.add_citation(choice(c_h_list))
+        p.add_citation(_choice(c_h_list))
         # Place : MediaRef
         mr = MediaRef()
         mr.set_reference_handle(m.handle)
-        mr.add_citation(choice(c_h_list))
+        mr.add_citation(_choice(c_h_list))
         # Place : MediaRef : Attribute
         a = Attribute()
         a.set_type(self.rand_type(AttributeType()))
         a.set_value(self.rand_text(self.SHORT))
-        a.add_citation(choice(c_h_list))
+        a.add_citation(_choice(c_h_list))
         mr.add_attribute(a)
         p.add_media_reference(mr)
         self.db.add_place(p, self.trans)
@@ -1205,7 +1221,7 @@ class TestcaseGenerator(tool.BatchTool):
         # Repository : Address
         a = Address()
         a.set_street(message)
-        a.add_citation(choice(c_h_list))
+        a.add_citation(_choice(c_h_list))
         r.add_address(a)
         self.db.add_repository(r, self.trans)
 
@@ -1230,8 +1246,8 @@ class TestcaseGenerator(tool.BatchTool):
 
         # Gender
         if gender is None:
-            gender = randint(0,1)
-        if randint(0,10) == 1:  # Set some persons to unknown gender
+            gender = _randint(0, 1)
+        if _randint(0, 10) == 1:  # Set some persons to unknown gender
             np.set_gender(Person.UNKNOWN)
         else:
             np.set_gender(gender)
@@ -1251,105 +1267,105 @@ class TestcaseGenerator(tool.BatchTool):
         if firstname2 != firstname:
             alt_name = Name(name)
             self.fill_object( alt_name)
-            if randint(0,2) == 1:
+            if _randint(0, 2) == 1:
                 surname = Surname()
                 surname.set_surname(self.rand_text(self.LASTNAME))
                 alt_name.add_surname(surname)
-            elif randint(0,2) == 1:
+            elif _randint(0, 2) == 1:
                 surname = Surname()
                 surname.set_surname(lastname)
                 alt_name.add_surname(surname)
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 alt_name.set_first_name( firstname2)
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 alt_name.set_title( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 patronymic = Surname()
                 patronymic.set_surname( self.rand_text(self.FIRSTNAME_MALE))
                 patronymic.set_origintype(NameOriginType.PATRONYMIC)
                 alt_name.add_surname(patronymic)
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 alt_name.get_primary_surname().set_prefix( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 alt_name.set_suffix( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 alt_name.set_call_name( self.rand_text(self.FIRSTNAME))
             np.add_alternate_name( alt_name)
         firstname2 = firstname.replace("a", "e").replace("o", "u").replace("r", "p")
         if firstname2 != firstname:
             alt_name = Name(name)
             self.fill_object( alt_name)
-            if randint(0,2) == 1:
+            if _randint(0, 2) == 1:
                 surname = Surname()
                 surname.set_surname(self.rand_text(self.LASTNAME))
                 alt_name.add_surname(surname)
-            elif randint(0,2) == 1:
+            elif _randint(0, 2) == 1:
                 surname = Surname()
                 surname.set_surname(lastname)
                 alt_name.add_surname(surname)
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 alt_name.set_first_name( firstname2)
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 alt_name.set_title( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 patronymic = Surname()
                 patronymic.set_surname(self.rand_text(self.FIRSTNAME_MALE))
                 patronymic.set_origintype(NameOriginType.PATRONYMIC)
                 alt_name.add_surname(patronymic)
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 alt_name.get_primary_surname().set_prefix( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 alt_name.set_suffix( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 alt_name.set_call_name( self.rand_text(self.FIRSTNAME))
             np.add_alternate_name( alt_name)
 
         if not alive_in_year:
-            alive_in_year = randint(1700,2000)
+            alive_in_year = _randint(1700, 2000)
 
-        by = alive_in_year - randint(0,60)
-        dy = alive_in_year + randint(0,60)
+        by = alive_in_year - _randint(0, 60)
+        dy = alive_in_year + _randint(0, 60)
 
         # birth
-        if randint(0,1) == 1:
+        if _randint(0, 1) == 1:
             (birth_year, eref) = self.rand_personal_event( EventType.BIRTH, by,by)
             np.set_birth_ref(eref)
 
         # baptism
-        if randint(0,1) == 1:
+        if _randint(0, 1) == 1:
             (bapt_year, eref) = self.rand_personal_event(
-                choice( (EventType.BAPTISM, EventType.CHRISTEN)), by, by+2)
+                _choice((EventType.BAPTISM, EventType.CHRISTEN)), by, by+2)
             np.add_event_ref(eref)
 
         # death
         death_year = None
-        if randint(0,1) == 1:
+        if _randint(0, 1) == 1:
             (death_year, eref) = self.rand_personal_event( EventType.DEATH, dy,dy)
             np.set_death_ref(eref)
 
         # burial
-        if randint(0,1) == 1:
+        if _randint(0, 1) == 1:
             (bur_year, eref) = self.rand_personal_event(
-                choice( (EventType.BURIAL, EventType.CREMATION)), dy, dy+2)
+                _choice((EventType.BURIAL, EventType.CREMATION)), dy, dy+2)
             np.add_event_ref(eref)
 
         # some other events
-        while randint(0,5) == 1:
+        while _randint(0, 5) == 1:
             (birth_year, eref) = self.rand_personal_event( None, by,dy)
             np.add_event_ref(eref)
 
         # some shared events
         if self.generated_events:
-            while randint(0,5) == 1:
-                e_h = choice(self.generated_events)
+            while _randint(0, 5) == 1:
+                e_h = _choice(self.generated_events)
                 eref = EventRef()
                 self.fill_object( eref)
                 eref.set_reference_handle(e_h)
                 np.add_event_ref(eref)
 
         # PersonRef
-        if randint(0,3) == 1:
-            for i in range(0,randint(1,2)):
+        if _randint(0, 3) == 1:
+            for i in range(0, _randint(1, 2)):
                 if self.person_count > self.options.handler.options_dict['person_count']:
                     break
                 if alive_in_year:
@@ -1361,7 +1377,7 @@ class TestcaseGenerator(tool.BatchTool):
                 asso.set_relation(self.rand_text(self.SHORT))
                 self.fill_object(asso)
                 np.add_person_ref(asso)
-                if randint(0,2) == 0:
+                if _randint(0, 2) == 0:
                     self.persons_todo.append(asso_h)
 
         person_handle = self.db.add_person(np,self.trans)
@@ -1381,10 +1397,10 @@ class TestcaseGenerator(tool.BatchTool):
         alive_in_year = None
         if person1_h in self.person_dates:
             (born, died) = self.person_dates[person1_h]
-            alive_in_year = min( born+randint(10,50), died + randint(-10,10))
+            alive_in_year = min(born+_randint(10, 50), died+_randint(-10, 10))
 
         if person1.get_gender() == 1:
-            if randint(0,7)==1:
+            if _randint(0, 7) == 1:
                 person2_h = None
             else:
                 if alive_in_year:
@@ -1393,7 +1409,7 @@ class TestcaseGenerator(tool.BatchTool):
                     person2_h = self.generate_person(0)
         else:
             person2_h = person1_h
-            if randint(0,7)==1:
+            if _randint(0, 7) == 1:
                 person1_h = None
             else:
                 if alive_in_year:
@@ -1401,9 +1417,9 @@ class TestcaseGenerator(tool.BatchTool):
                 else:
                     person1_h = self.generate_person(1)
 
-        if person1_h and randint(0,2) > 0:
+        if person1_h and _randint(0, 2) > 0:
             self.parents_todo.append(person1_h)
-        if person2_h and randint(0,2) > 0:
+        if person2_h and _randint(0, 2) > 0:
             self.parents_todo.append(person2_h)
 
         with DbTxn(_("Testcase generator step %d") % self.transaction_count,
@@ -1420,13 +1436,13 @@ class TestcaseGenerator(tool.BatchTool):
             event_set = set()
 
             # Generate at least one family event with a probability of 75%
-            if randint(0, 3) > 0:
+            if _randint(0, 3) > 0:
                 (birth_year, eref) = self.rand_family_event(None)
                 fam.add_event_ref(eref)
                 event_set.add(eref.get_reference_handle())
 
             # generate some more events with a lower probability
-            while randint(0, 3) == 1:
+            while _randint(0, 3) == 1:
                 (birth_year, eref) = self.rand_family_event(None)
                 if eref.get_reference_handle() in event_set:
                     continue
@@ -1435,10 +1451,10 @@ class TestcaseGenerator(tool.BatchTool):
 
             # some shared events
             if self.generated_events:
-                while randint(0, 5) == 1:
+                while _randint(0, 5) == 1:
                     typeval = EventType.UNKNOWN
                     while int(typeval) not in self.FAMILY_EVENTS:
-                        e_h = choice(self.generated_events)
+                        e_h = _choice(self.generated_events)
                         typeval = self.db.get_event_from_handle(e_h).get_type()
                     if e_h in event_set:
                         break
@@ -1462,11 +1478,12 @@ class TestcaseGenerator(tool.BatchTool):
 
             lastname = person1.get_primary_name().get_surname()
 
-            for i in range(0,randint(1,10)):
+            for i in range(0, _randint(1, 10)):
                 if self.person_count > self.options.handler.options_dict['person_count']:
                     break
                 if alive_in_year:
-                    child_h = self.generate_person(None, lastname, alive_in_year = alive_in_year + randint( 16+2*i, 30 + 2*i))
+                    child_h = self.generate_person(None, lastname,
+                        alive_in_year=alive_in_year + _randint(16+2*i, 30+2*i))
                 else:
                     child_h = self.generate_person(None, lastname)
                     (born,died) = self.person_dates[child_h]
@@ -1480,7 +1497,7 @@ class TestcaseGenerator(tool.BatchTool):
                 child = self.db.get_person_from_handle(child_h)
                 child.add_parent_family_handle(fam_h)
                 self.db.commit_person(child,self.trans)
-                if randint(0,3) > 0:
+                if _randint(0, 3) > 0:
                     self.persons_todo.append(child_h)
 
     def generate_parents(self,child_h):
@@ -1502,9 +1519,9 @@ class TestcaseGenerator(tool.BatchTool):
             person1_h = self.generate_person(1,lastname)
             person2_h = self.generate_person(0)
 
-        if randint(0,2) > 1:
+        if _randint(0, 2) > 1:
             self.parents_todo.append(person1_h)
-        if randint(0,2) > 1:
+        if _randint(0, 2) > 1:
             self.parents_todo.append(person2_h)
 
         with DbTxn(_("Testcase generator step %d") % self.transaction_count,
@@ -1561,46 +1578,47 @@ class TestcaseGenerator(tool.BatchTool):
         Generates a random date object between the given years start and end
         """
         if not start and not end:
-            start = randint(1700,2000)
+            start = _randint(1700, 2000)
         if start and not end:
-            end = start + randint(0,100)
+            end = start + _randint(0, 100)
         if end and not start:
-            start = end - randint(0,100)
-        year = randint(start,end)
+            start = end - _randint(0, 100)
+        year = _randint(start, end)
 
         ndate = Date()
-        if randint(0,10) == 1:
+        if _randint(0, 10) == 1:
             # Some get a textual date
-            ndate.set_as_text( choice((self.rand_text(self.SHORT),"Unknown","??","Don't know","TODO!")))
+            ndate.set_as_text(_choice((self.rand_text(self.SHORT), "Unknown",
+                                       "??", "Don't know", "TODO!")))
         else:
-            if randint(0,10) == 1:
+            if _randint(0, 10) == 1:
                 # some get an empty date
                 pass
             else:
                 # regular dates
                 calendar = Date.CAL_GREGORIAN
-                quality = choice( (Date.QUAL_NONE,
+                quality = _choice((Date.QUAL_NONE,
                                    Date.QUAL_ESTIMATED,
                                    Date.QUAL_CALCULATED))
-                modifier = choice( (Date.MOD_NONE,
+                modifier = _choice((Date.MOD_NONE,
                                     Date.MOD_BEFORE,
                                     Date.MOD_AFTER,\
                                     Date.MOD_ABOUT,
                                     Date.MOD_RANGE,
                                     Date.MOD_SPAN))
-                day = randint(0,28)
+                day = _randint(0, 28)
                 if day > 0: # avoid days without month
-                    month = randint(1,12)
+                    month = _randint(1, 12)
                 else:
-                    month = randint(0,12)
+                    month = _randint(0, 12)
 
                 if modifier in (Date.MOD_RANGE, Date.MOD_SPAN):
-                    day2 = randint(0,28)
+                    day2 = _randint(0, 28)
                     if day2 > 0:
-                        month2 = randint(1,12)
+                        month2 = _randint(1, 12)
                     else:
-                        month2 = randint(0,12)
-                    year2 = year + randint(1,5)
+                        month2 = _randint(0, 12)
+                    year2 = year + _randint(1, 5)
                     ndate.set(quality,modifier,calendar,(day,month,year,False,day2,month2,year2,False),"")
                 else:
                     ndate.set(quality,modifier,calendar,(day,month,year,False),"")
@@ -1611,7 +1629,7 @@ class TestcaseGenerator(tool.BatchTool):
 
 
         if issubclass(o.__class__, AddressBase):
-            while randint(0,1) == 1:
+            while _randint(0, 1) == 1:
                 a = Address()
                 self.fill_object(a)
                 o.add_address( a)
@@ -1621,119 +1639,120 @@ class TestcaseGenerator(tool.BatchTool):
             o.set_value( self.rand_text(self.SHORT))
 
         if issubclass(o.__class__, AttributeBase):
-            while randint(0,1) == 1:
+            while _randint(0, 1) == 1:
                 a = Attribute()
                 self.fill_object(a)
                 o.add_attribute( a)
 
         if isinstance(o,ChildRef):
-            if randint(0,3) == 1:
+            if _randint(0, 3) == 1:
                 o.set_mother_relation( self.rand_type( ChildRefType()))
-            if randint(0,3) == 1:
+            if _randint(0, 3) == 1:
                 o.set_father_relation( self.rand_type( ChildRefType()))
 
         if issubclass(o.__class__, DateBase):
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 (y,d) = self.rand_date()
                 o.set_date_object( d)
 
         if isinstance(o,Event):
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_description( self.rand_text(self.LONG))
 
         if issubclass(o.__class__, EventRef):
             o.set_role( self.rand_type(EventRoleType()))
 
         if isinstance(o,Family):
-            if randint(0,2) == 1:
+            if _randint(0, 2) == 1:
                 o.set_relationship( self.rand_type(FamilyRelType()))
             else:
                 o.set_relationship(FamilyRelType(FamilyRelType.MARRIED))
 
         if isinstance(o,LdsOrd):
-            if randint(0,1) == 1:
-                o.set_temple( choice(TEMPLES.name_code_data())[1])
+            if _randint(0, 1) == 1:
+                o.set_temple(_choice(TEMPLES.name_code_data())[1])
 
         if issubclass(o.__class__, LdsOrdBase):
-            while randint(0,1) == 1:
+            while _randint(0, 1) == 1:
                 ldsord = LdsOrd()
                 self.fill_object( ldsord)
                 if isinstance(o,Person):
-                    lds_type = choice([item for item in LDS_INDIVIDUAL_ORD] )
+                    lds_type = _choice([item for item in LDS_INDIVIDUAL_ORD])
                 if isinstance(o,Family):
                     lds_type = LDS_SPOUSE_SEALING[0]
                     if self.generated_families:
                         ldsord.set_family_handle(
-                                        choice(self.generated_families))
+                            _choice(self.generated_families))
                 ldsord.set_type(lds_type[0])
-                status = choice(lds_type[1])
+                status = _choice(lds_type[1])
                 if status != LdsOrd.STATUS_NONE:
                     ldsord.set_status(status)
                 o.add_lds_ord( ldsord)
 
         if isinstance(o,Location):
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_parish( self.rand_text(self.SHORT))
 
         if issubclass(o.__class__, LocationBase):
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_street( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_city( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_postal_code( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_phone( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_state( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_country( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_county( self.rand_text(self.SHORT))
 
         if issubclass(o.__class__, MediaBase):
             # FIXME: frequency changed to prevent recursion
-            while randint(0,10) == 1:
+            while _randint(0, 10) == 1:
                 o.add_media_reference( self.fill_object( MediaRef()))
 
         if isinstance(o,Media):
-            if randint(0,3) == 1:
+            if _randint(0, 3) == 1:
                 o.set_description(str(self.rand_text(self.LONG)))
-                path = choice((ICON, LOGO, SPLASH))
+                path = os.path.abspath(_choice((ICON, LOGO, SPLASH)))
                 o.set_path(str(path))
                 mime = get_type(path)
                 o.set_mime_type(mime)
             else:
                 o.set_description(str(self.rand_text(self.SHORT)))
-                o.set_path(str(ICON))
+                o.set_path(os.path.abspath(str(ICON)))
                 o.set_mime_type("image/png")
 
         if isinstance(o,MediaRef):
-            if not self.generated_media or randint(0,10) == 1:
+            if not self.generated_media or _randint(0, 10) == 1:
                 m = Media()
                 self.fill_object(m)
                 self.db.add_media( m, self.trans)
                 self.generated_media.append( m.get_handle())
-            o.set_reference_handle( choice( self.generated_media))
-            if randint(0,1) == 1:
-                o.set_rectangle( (randint(0,200),randint(0,200),randint(0,200),randint(0,200)))
+            o.set_reference_handle(_choice(self.generated_media))
+            if _randint(0, 1) == 1:
+                o.set_rectangle((_randint(0, 200), _randint(0, 200),
+                                 _randint(0, 200), _randint(0, 200)))
 
         if isinstance(o,Name):
             o.set_type( self.rand_type( NameType()))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_title( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 patronymic = Surname()
                 patronymic.set_surname(self.rand_text(self.FIRSTNAME_MALE))
                 patronymic.set_origintype(NameOriginType.PATRONYMIC)
                 o.add_surname(patronymic)
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.get_primary_surname().set_prefix( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_suffix( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_call_name( self.rand_text(self.FIRSTNAME))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_group_as( o.get_surname()[:1])
             # o.set_display_as()
             # o.set_sort_as()
@@ -1744,55 +1763,55 @@ class TestcaseGenerator(tool.BatchTool):
                 o.set( self.rand_text(self.NOTE))
             else:
                 o.set_styledtext(self.rand_text(self.STYLED_TEXT))
-            o.set_format( choice( (Note.FLOWED,Note.FORMATTED)))
+            o.set_format(_choice((Note.FLOWED, Note.FORMATTED)))
             o.set_type(type)
 
         if issubclass(o.__class__, NoteBase):
-            while randint(0,1) == 1:
-                if not self.generated_notes or randint(0,10) == 1:
+            while _randint(0, 1) == 1:
+                if not self.generated_notes or _randint(0, 10) == 1:
                     n = Note()
                     self.fill_object(n)
                     self.db.add_note( n, self.trans)
                     self.generated_notes.append( n.get_handle())
-                n_h = choice(self.generated_notes)
+                n_h = _choice(self.generated_notes)
                 o.add_note(n_h)
 
         if isinstance(o, Place):
             o.set_title(self.rand_text(self.LONG))
             o.set_name(PlaceName(value=self.rand_text(self.SHORT)))
             o.set_code(self.rand_text(self.SHORT))
-            if randint(0, 1) == 1:
-                if randint(0, 4) == 1:
+            if _randint(0, 1) == 1:
+                if _randint(0, 4) == 1:
                     o.set_longitude(self.rand_text(self.SHORT))
                 else:
-                    o.set_longitude(str(random() * 360.0 - 180.0))
-            if randint(0, 1) == 1:
-                if randint(0, 4) == 1:
+                    o.set_longitude(str(_random() * 360.0 - 180.0))
+            if _randint(0, 1) == 1:
+                if _randint(0, 4) == 1:
                     o.set_latitude( self.rand_text(self.SHORT))
                 else:
-                    o.set_latitude(str(random() * 180.0 - 90.0))
-            while randint(0, 1) == 1:
+                    o.set_latitude(str(_random() * 180.0 - 90.0))
+            while _randint(0, 1) == 1:
                 o.add_alternate_locations(self.fill_object(Location()))
 
         if issubclass(o.__class__, PlaceBase):
-            if randint(0, 1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_place_handle(self.rand_place())
 
         if issubclass(o.__class__, BasicPrimaryObject):
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_gramps_id( self.rand_text(self.SHORT))
 
         if issubclass(o.__class__, PrivacyBase):
-            o.set_privacy( randint(0,5) == 1)
+            o.set_privacy( _randint(0, 5) == 1)
 
         if isinstance(o,RepoRef):
-            if not self.generated_repos or randint(0,10) == 1:
+            if not self.generated_repos or _randint(0, 10) == 1:
                 r = Repository()
                 self.fill_object(r)
                 self.db.add_repository( r, self.trans)
                 self.generated_repos.append(r.get_handle())
-            o.set_reference_handle( choice( self.generated_repos))
-            if randint(0,1) == 1:
+            o.set_reference_handle(_choice(self.generated_repos))
+            if _randint(0, 1) == 1:
                 o.set_call_number( self.rand_text(self.SHORT))
             o.set_media_type( self.rand_type(SourceMediaType()))
 
@@ -1802,54 +1821,54 @@ class TestcaseGenerator(tool.BatchTool):
 
         if isinstance(o,Source):
             o.set_title( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_author( self.rand_text(self.SHORT))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_publication_info( self.rand_text(self.LONG))
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_abbreviation( self.rand_text(self.SHORT))
-            while randint(0,1) == 1:
+            while _randint(0, 1) == 1:
                 sattr = SrcAttribute()
                 sattr.set_type(self.rand_text(self.SHORT))
                 sattr.set_value(self.rand_text(self.SHORT))
                 o.add_attribute(sattr)
-            while randint(0,1) == 1:
+            while _randint(0, 1) == 1:
                 r = RepoRef()
                 self.fill_object(r)
                 o.add_repo_reference( r)
 
         if issubclass(o.__class__, CitationBase):
-            while randint(0,1) == 1:
-                if not self.generated_citations or randint(1,10) == 1:
+            while _randint(0, 1) == 1:
+                if not self.generated_citations or _randint(1, 10) == 1:
                     s = Citation()
                     self.fill_object(s)
                     self.db.add_citation( s, self.trans)
                     self.generated_citations.append(s.get_handle())
-                s_h = choice(self.generated_citations)
+                s_h = _choice(self.generated_citations)
                 o.add_citation(s_h)
 
         if isinstance(o,Citation):
-            if not self.generated_sources or randint(0,10) == 1:
+            if not self.generated_sources or _randint(0, 10) == 1:
                 s = Source()
                 self.fill_object(s)
                 self.db.add_source( s, self.trans)
                 self.generated_sources.append( s.get_handle())
-            o.set_reference_handle( choice( self.generated_sources))
-            if randint(0,1) == 1:
+            o.set_reference_handle(_choice(self.generated_sources))
+            if _randint(0, 1) == 1:
                 o.set_page( self.rand_text(self.NUMERIC))
-            #if randint(0,1) == 1:
+            #if _randint(0, 1) == 1:
             #    o.set_text( self.rand_text(self.SHORT))
-            #if randint(0,1) == 1:
+            #if _randint(0, 1) == 1:
             #    (year, d) = self.rand_date( )
             #    o.set_date_object( d)
-            o.set_confidence_level(choice(list(conf_strings.keys())))
+            o.set_confidence_level(_choice(list(conf_strings.keys())))
 
         if issubclass(o.__class__, TagBase):
-            if randint(0,1) == 1:
+            if _randint(0, 1) == 1:
                 o.set_tag_list(self.rand_tags())
 
         if issubclass(o.__class__, UrlBase):
-            while randint(0,1) == 1:
+            while _randint(0, 1) == 1:
                 u = Url()
                 self.fill_object(u)
                 o.add_url(u)
@@ -1893,7 +1912,7 @@ class TestcaseGenerator(tool.BatchTool):
     def rand_type(self, gtype):
         if issubclass(gtype.__class__, GrampsType):
             map = gtype.get_map()
-            key = choice(list(map.keys()))
+            key = _choice(list(map.keys()))
             if key == gtype.get_custom():
                 value = self.rand_text(self.SHORT)
             else:
@@ -1902,21 +1921,21 @@ class TestcaseGenerator(tool.BatchTool):
             return gtype
 
     def rand_place(self):
-        if not self.generated_places or randint(0, 10) == 1:
+        if not self.generated_places or _randint(0, 10) == 1:
             self.generate_place()
-        return choice(self.generated_places)
+        return _choice(self.generated_places)
 
     def generate_place(self):
         parent_handle = None
         for type_num in range(1, 8):
-            if type_num > 1 and randint(1, 3) == 1:
+            if type_num > 1 and _randint(1, 3) == 1:
                 # skip some levels in the place hierarchy
                 continue
             place = Place()
             place.set_type(PlaceType(type_num))
             if parent_handle is not None:
                 self.add_parent_place(place, parent_handle)
-            if type_num > 1 and randint(1, 3) == 1:
+            if type_num > 1 and _randint(1, 3) == 1:
                 # add additional parent place
                 parent_handle = self.find_parent_place(type_num - 1)
                 if parent_handle is not None:
@@ -1929,7 +1948,7 @@ class TestcaseGenerator(tool.BatchTool):
 
     def find_parent_place(self, type_num):
         if len(self.parent_places[type_num]) > 0:
-            return choice(self.parent_places[type_num])
+            return _choice(self.parent_places[type_num])
         else:
             return None
 
@@ -1982,7 +2001,7 @@ class TestcaseGenerator(tool.BatchTool):
             maxsyllables = 5
 
         if type == self.FIRSTNAME:
-            type = choice( (self.FIRSTNAME_MALE,self.FIRSTNAME_FEMALE))
+            type = _choice((self.FIRSTNAME_MALE, self.FIRSTNAME_FEMALE))
 
         if type == self.FIRSTNAME_MALE or type == self.FIRSTNAME_FEMALE:
             syllables = syllables2
@@ -2009,49 +2028,50 @@ class TestcaseGenerator(tool.BatchTool):
             maxwords = 100
 
         if type == self.NUMERIC:
-            if randint(0,1) == 1:
-                return "%d %s" % (randint(1,100), result)
-            if randint(0,1) == 1:
-                return "%d, %d %s" % (randint(1,100), randint(100,1000), result)
-            m = randint(100,1000)
-            return "%d - %d %s" % (m, m+randint(1,5), result)
+            if _randint(0, 1) == 1:
+                return "%d %s" % (_randint(1, 100), result)
+            if _randint(0, 1) == 1:
+                return "%d, %d %s" % (_randint(1, 100), _randint(100, 1000),
+                                      result)
+            m = _randint(100, 1000)
+            return "%d - %d %s" % (m, m+_randint(1, 5), result)
 
-        for i in range(0,randint(minwords,maxwords)):
+        for i in range(0, _randint(minwords, maxwords)):
             if result:
                 result = result + " "
             word = ""
-            for j in range(0,randint(minsyllables,maxsyllables)):
-                word = word + choice(syllables)
+            for j in range(0, _randint(minsyllables, maxsyllables)):
+                word = word + _choice(syllables)
             if type == self.FIRSTNAME_MALE:
-                word = word + choice(("a","e","i","o","u"))
-            if randint(0,3) == 1:
+                word = word + _choice(("a", "e", "i", "o", "u"))
+            if _randint(0, 3) == 1:
                 word = word.title()
             if type == self.NOTE:
-                if randint(0,10) == 1:
+                if _randint(0, 10) == 1:
                     word = "<b>%s</b>" % word
-                elif randint(0,10) == 1:
+                elif _randint(0, 10) == 1:
                     word = "<i>%s</i>" % word
-                elif randint(0,10) == 1:
+                elif _randint(0, 10) == 1:
                     word = "<i>%s</i>" % word
-                if randint(0,20) == 1:
+                if _randint(0, 20) == 1:
                     word = word + "."
-                elif randint(0,30) == 1:
+                elif _randint(0, 30) == 1:
                     word = word + ".\n"
             if type == self.STYLED_TEXT:
                 tags = []
-                if randint(0,10) == 1:
+                if _randint(0, 10) == 1:
                     tags += [StyledTextTag(StyledTextTagType.BOLD, True,
                                                 [(0, len(word))])]
-                elif randint(0,10) == 1:
+                elif _randint(0, 10) == 1:
                     tags += [StyledTextTag(StyledTextTagType.ITALIC, True,
                                                 [(0, len(word))])]
-                elif randint(0,10) == 1:
+                elif _randint(0, 10) == 1:
                     tags += [StyledTextTag(StyledTextTagType.UNDERLINE, True,
                                                 [(0, len(word))])]
                 word = StyledText(word, tags)
-                if randint(0,20) == 1:
+                if _randint(0, 20) == 1:
                     word = word + "."
-                elif randint(0,30) == 1:
+                elif _randint(0, 30) == 1:
                     word = word + ".\n"
             if type == self.STYLED_TEXT:
                 result = StyledText("").join((result, word))
@@ -2059,7 +2079,7 @@ class TestcaseGenerator(tool.BatchTool):
                 result += word
 
         if type == self.LASTNAME:
-            n = randint(0,2)
+            n = _randint(0, 2)
             if n == 0:
                 result = result.title()
             elif n == 1:
@@ -2072,13 +2092,13 @@ class TestcaseGenerator(tool.BatchTool):
         return result
 
     def rand_color(self):
-        return '#%012X' % randint(0, 281474976710655)
+        return '#%012X' % _randint(0, 281474976710655)
 
     def rand_tags(self):
         maxtags = 5
         taglist = []
-        for counter in range(0, randint(1, maxtags)):
-            tag = choice(self.generated_tags)
+        for counter in range(0, _randint(1, maxtags)):
+            tag = _choice(self.generated_tags)
             if tag not in taglist:
                 taglist.append(tag)
         return taglist

--- a/gramps/test/test_util.py
+++ b/gramps/test/test_util.py
@@ -260,6 +260,8 @@ class Gramps:
             args = [sys.executable] + list(args)
             argparser = ArgParser(args)
             argparser.need_gui() # initializes some variables
+            if argparser.errors:
+                print(argparser.errors, file=sys.stderr)
             argparser.print_help()
             argparser.print_usage()
             handler = ArgHandler(self.dbstate, argparser, self.climanager)


### PR DESCRIPTION
The Check & Repair (C&R) tool has been enhanced to fix Place alternate names entries that are blank, or duplicates of each other or primary name.

In order to test the modified C&R, the Test Case Generator (TCG) has been enhanced to create bugs in alt place names like those fixed in C&R above.  I used this to manually create a db and then watch C&R correct the created bugs.

I also used an old version of Gramps (4.2.2) to generate a db with these bugs based on an import of a Gedcom file that exercised the place code (and found the bugs to begin with).  And used C&R to fix them while under observation.

TCG contains some quite useful code already in that it creates bugs that C&R can fix.  In order to use TCG as a test tool, however, it needs to be repeatable.  TCG uses a lot of random number generation to create test cases, names etc.  So I modified TCG to use a private copy of the random number generator, and to expose that random generator where a unit test code can find it to arrange a seed.  Under normal conditions, TCG is not seeded, so remains as random as usual.

I also did a very little pylint cleanup on lines I was already modifying, so the diff shows more in-a-line changes than the search & replace for random/randint/choice accounts for.

I also created a unittest module 'test_tools.py' which currently uses TCG to create a database that C&R can repair.  This module loads a small '.gramps' file to start things off, then seeds TCG's random generator for repeat-ability, and uses TCG to create the db.  Finally I use Gramps again to run C&R.  At each step, expected results are captured and compared.

P.S. I expect that this PR will conflict with an earlier TCG PR (236); I will rebase and correct after that one is accepted.