### PR TITLE
Add Export Options filter to Vcard Export

### DIFF
--- a/gramps/plugins/export/exportvcard.py
+++ b/gramps/plugins/export/exportvcard.py
@@ -52,6 +52,7 @@ from gramps.gen.const import PROGRAM_NAME
 from gramps.version import VERSION
 from gramps.gen.lib import Date, Person
 from gramps.gen.lib.urltype import UrlType
+from gramps.gui.plug.export import WriterOptionBox
 from gramps.gen.lib.eventtype import EventType
 from gramps.gen.display.name import displayer as _nd
 from gramps.gen.plug.utils import OpenFileOrStdout


### PR DESCRIPTION
While looking at issue [9701](https://gramps-project.org/bugs/view.php?id=9701#c49426) I noticed that  vcard export does not have "Export options" to filter the export like the other export formats.