### PR TITLE
DB-API: Getting a handle that doesn't exist now raises error, like BSDDB

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -52,6 +52,7 @@ from gramps.gen.db import (DbReadBase, DbWriteBase, DbTxn, DbUndo,
                            SOURCE_KEY, EVENT_KEY, MEDIA_KEY,
                            PLACE_KEY, REPOSITORY_KEY, NOTE_KEY,
                            TAG_KEY, eval_order_by)
+from gramps.gen.errors import HandleError
 from gramps.gen.db.base import QuerySet
 from gramps.gen.utils.callback import Callback
 from gramps.gen.updatecallback import UpdateCallback
@@ -1164,52 +1165,92 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
     def get_event_from_handle(self, handle):
         if isinstance(handle, bytes):
             handle = str(handle, "utf-8")
-        return Event.create(self._get_raw_event_data(handle))
+        data = self._get_raw_event_data(handle)
+        if data:
+            return Event.create(data)
+        else:
+            raise HandleError('Handle %s not found' % handle)
 
     def get_family_from_handle(self, handle):
         if isinstance(handle, bytes):
             handle = str(handle, "utf-8")
-        return Family.create(self._get_raw_family_data(handle))
+        data = self._get_raw_family_data(handle)
+        if data:
+            return Family.create(data)
+        else:
+            raise HandleError('Handle %s not found' % handle)
 
     def get_repository_from_handle(self, handle):
         if isinstance(handle, bytes):
             handle = str(handle, "utf-8")
-        return Repository.create(self._get_raw_repository_data(handle))
+        data = self._get_raw_repository_data(handle)
+        if data:
+            return Repository.create(data)
+        else:
+            raise HandleError('Handle %s not found' % handle)
 
     def get_person_from_handle(self, handle):
         if isinstance(handle, bytes):
             handle = str(handle, "utf-8")
-        return Person.create(self._get_raw_person_data(handle))
+        data = self._get_raw_person_data(handle)
+        if data:
+            return Person.create(data)
+        else:
+            raise HandleError('Handle %s not found' % handle)
 
     def get_place_from_handle(self, handle):
         if isinstance(handle, bytes):
             handle = str(handle, "utf-8")
-        return Place.create(self._get_raw_place_data(handle))
+        data = self._get_raw_place_data(handle)
+        if data:
+            return Place.create(data)
+        else:
+            raise HandleError('Handle %s not found' % handle)
 
     def get_citation_from_handle(self, handle):
         if isinstance(handle, bytes):
             handle = str(handle, "utf-8")
-        return Citation.create(self._get_raw_citation_data(handle))
+        data = self._get_raw_citation_data(handle)
+        if data:
+            return Citation.create(data)
+        else:
+            raise HandleError('Handle %s not found' % handle)
 
     def get_source_from_handle(self, handle):
         if isinstance(handle, bytes):
             handle = str(handle, "utf-8")
-        return Source.create(self._get_raw_source_data(handle))
+        data = self._get_raw_source_data(handle)
+        if data:
+            return Source.create(data)
+        else:
+            raise HandleError('Handle %s not found' % handle)
 
     def get_note_from_handle(self, handle):
         if isinstance(handle, bytes):
             handle = str(handle, "utf-8")
-        return Note.create(self._get_raw_note_data(handle))
+        data = self._get_raw_note_data(handle)
+        if data:
+            return Note.create(data)
+        else:
+            raise HandleError('Handle %s not found' % handle)
 
     def get_media_from_handle(self, handle):
         if isinstance(handle, bytes):
             handle = str(handle, "utf-8")
-        return Media.create(self._get_raw_media_data(handle))
+        data = self._get_raw_media_data(handle)
+        if data:
+            return Media.create(data)
+        else:
+            raise HandleError('Handle %s not found' % handle)
 
     def get_tag_from_handle(self, handle):
         if isinstance(handle, bytes):
             handle = str(handle, "utf-8")
-        return Tag.create(self._get_raw_tag_data(handle))
+        data = self._get_raw_tag_data(handle)
+        if data:
+            return Tag.create(data)
+        else:
+            raise HandleError('Handle %s not found' % handle)
 
     def get_default_person(self):
         handle = self.get_default_handle()

--- a/gramps/gen/filters/rules/person/_isduplicatedancestorof.py
+++ b/gramps/gen/filters/rules/person/_isduplicatedancestorof.py
@@ -66,14 +66,15 @@ class IsDuplicatedAncestorOf(Rule):
 
     def init_ancestor_list(self, db, person):
         fam_id = person.get_main_parents_family_handle()
-        fam = db.get_family_from_handle(fam_id)
-        if fam:
-            f_id = fam.get_father_handle()
-            m_id = fam.get_mother_handle()
-            if m_id:
-                self.mother_side(db, db.get_person_from_handle(m_id))
-            if f_id:
-                self.father_side(db, db.get_person_from_handle(f_id))
+        if fam_id:
+            fam = db.get_family_from_handle(fam_id)
+            if fam:
+                f_id = fam.get_father_handle()
+                m_id = fam.get_mother_handle()
+                if m_id:
+                    self.mother_side(db, db.get_person_from_handle(m_id))
+                if f_id:
+                    self.father_side(db, db.get_person_from_handle(f_id))
 
     def mother_side(self, db, person):
         if person and person.handle in self.map:

--- a/gramps/gen/filters/rules/person/_isduplicatedancestorof.py
+++ b/gramps/gen/filters/rules/person/_isduplicatedancestorof.py
@@ -33,6 +33,7 @@ _ = glocale.translation.gettext
 #
 #-------------------------------------------------------------------------
 from .. import Rule
+from gramps.gen.errors import HandleError
 
 #-------------------------------------------------------------------------
 #
@@ -66,7 +67,11 @@ class IsDuplicatedAncestorOf(Rule):
 
     def init_ancestor_list(self, db, person):
         fam_id = person.get_main_parents_family_handle()
-        fam = db.get_family_from_handle(fam_id)
+        try:
+            fam = db.get_family_from_handle(fam_id)
+        except HandleError:
+            # no such family; ignore
+            fam = None
         if fam:
             f_id = fam.get_father_handle()
             m_id = fam.get_mother_handle()

--- a/gramps/gen/filters/rules/person/_isduplicatedancestorof.py
+++ b/gramps/gen/filters/rules/person/_isduplicatedancestorof.py
@@ -33,7 +33,6 @@ _ = glocale.translation.gettext
 #
 #-------------------------------------------------------------------------
 from .. import Rule
-from gramps.gen.errors import HandleError
 
 #-------------------------------------------------------------------------
 #
@@ -67,11 +66,7 @@ class IsDuplicatedAncestorOf(Rule):
 
     def init_ancestor_list(self, db, person):
         fam_id = person.get_main_parents_family_handle()
-        try:
-            fam = db.get_family_from_handle(fam_id)
-        except HandleError:
-            # no such family; ignore
-            fam = None
+        fam = db.get_family_from_handle(fam_id)
         if fam:
             f_id = fam.get_father_handle()
             m_id = fam.get_mother_handle()


### PR DESCRIPTION
Attempting to get data from the database for a handle, but the handle does not exist, will now raise an exception.