### PR TITLE
Fix bug 9717, XML import with env language other than utf8, has bad progress meter

### DIFF
--- a/gramps/plugins/importer/importxml.py
+++ b/gramps/plugins/importer/importxml.py
@@ -361,9 +361,10 @@ class LineParser:
                 #           will not work properly, going immediately to
                 #           100%.
                 #           It should work correctly from version 3.3.
-                ofile = io.TextIOWrapper(gzip.open(filename, "rb"))
+                ofile = io.TextIOWrapper(gzip.open(filename, "rb"),
+                                         encoding='utf8', errors='replace')
             else:
-                ofile = open(filename, "r")
+                ofile = open(filename, "r", encoding='utf8', errors='replace')
 
             for line in ofile:
                 self.count += 1


### PR DESCRIPTION
If the default python language settings are not utf8 (US Windows has cp1252 for example), then two things happen on XML import when Unicode characters are present in the '.gramps' file:

1. A logging warning: "WARNING:.gen:UpdateCallback with total == 0 created"
2. and the progress meter on XML import does not work.

Gramps XML import has a two pass design. On the first pass, the file is opened in text mode (converted from gzip if necessary), and then lines and persons are counted.
The file open mode is default (no 'decode='). When Unicode characters are encountered (Gramps XML export always uses utf8), an exception is raised, and the line/person counts are defaulted to zero.

This PR changes the first pass to use utf8, and to ignore any errors so the line/person counts work right.

P.S.  I know I keep harping on this, but we have a bug exception when using python 3.2 we deal with (poorly) here.  It could be removed if we standardize on a later version of python.