### PR TITLE
bug 9458, fix Import Vcard can create multiple surnames with all selected as 'Primary'

### DIFF
--- a/data/tests/imp_vcard.difs
+++ b/data/tests/imp_vcard.difs
@@ -1,5 +1,0 @@
-Mismatch on file: imp_vcard.vcf
-Person: I0019  handle=0000001800000018
-  Diff on: Person, primary_name, surname list #2, primary
-    <class 'bool'>: True
-    <class 'bool'>: False

--- a/gramps/plugins/importer/importvcard.py
+++ b/gramps/plugins/importer/importvcard.py
@@ -384,6 +384,7 @@ class VCardParser:
                 surname.set_surname(sname.strip())
                 surname.set_prefix(prefix.strip())
                 name.add_surname(surname)
+            name.set_primary_surname()
 
         if len(data_fields) > 1 and data_fields[1].strip():
             given_name = ' '.join(self.unesc(


### PR DESCRIPTION
Found this bug a while ago, but saw it come to the first page of the tracker again, so decided to fix it.
I've had an 'exception' on my test cases for a while to exempt this bug from stopping the import tests, so all I had to do there was remove the 'imp_vcard.difs' to remove the exception.