### PR TITLE
bug 9694, fix Gedcom import with no VERSion (very old Gedcom) crash

### DIFF
--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -7267,7 +7267,7 @@ class GedcomParser(UpdateCallback):
             if self.__level_is_finished(line, state.level+1):
                 break
             elif line.token == TOKEN_VERS:
-                if line.data[0] != "5":
+                if (not line.data) or line.data[0] != "5":
                     self.__add_msg(_("GEDCOM version not supported"),
                                    line, state)
                 if self.use_def_src:


### PR DESCRIPTION
This bug occurred when a very old Gedcom was imported.  The VERS field was blank, rather than 5.5 or similar.
It was suggested by Sam that we add a message "GEDCOM version number not stated (VERS 5.5 or VERS 5.5.1 only supported) - Import aborted", but I decided for this rare case that we need not make more work for translators.  Feel free to argue ;-)

BTW, the import doesn't actually abort, but attempts to go on anyway, which may generate a lot of additional import errors reported to the user, depending on just how old the file is.