### PR TITLE
bug 9755, fix duplicated Gramps IDs on Gedcom import

### DIFF
--- a/data/tests/imp_sample.ged
+++ b/data/tests/imp_sample.ged
@@ -21,6 +21,7 @@
 1 NAME Anna /Hansdotter/
 2 GIVN Anna
 2 SURN Hansdotter
+2 NOTE Hans daughter? N0000
 1 SEX F
 1 BIRT
 2 TYPE Birth of Anna Hansdotter
@@ -30,14 +31,17 @@
 2 TYPE Death of Anna Hansdotter
 2 DATE 29 SEP 1945
 2 PLAC Sparks, Washoe Co., NV
+2 NOTE Her eulogy was great! N0001
 1 FAMS @F3@
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+1 NOTE Inline note should get ID N0002
 0 @I1@ INDI
 1 NAME Keith Lloyd /Smith/
 2 GIVN Keith Lloyd
 2 SURN Smith
+2 NOTE @N7@
 1 SEX M
 1 BIRT
 2 TYPE Birth of Keith Lloyd Smith
@@ -47,6 +51,7 @@
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+1 NOTE Keith Lloyd Smith inline N0003
 0 @I10@ INDI
 1 NAME Hans Peter /Smith/
 2 GIVN Hans Peter
@@ -66,6 +71,7 @@
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+1 NOTE Hans Peter Smith inline N0004
 0 @I11@ INDI
 1 NAME Hanna /Smith/
 2 GIVN Hanna
@@ -79,6 +85,7 @@
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+1 NOTE Hanna Smith inline N0005
 0 @I12@ INDI
 1 NAME Herman Julius /Nielsen/
 2 GIVN Herman Julius
@@ -95,6 +102,7 @@
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+1 NOTE Herman Julius Nielsen N0006
 0 @I13@ INDI
 1 NAME Evelyn /Michaels/
 2 GIVN Evelyn
@@ -107,6 +115,7 @@
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+1 NOTE Evelyn Michaels N0007
 0 @I14@ INDI
 1 NAME Marjorie Lee /Smith/
 2 GIVN Marjorie Lee
@@ -246,18 +255,26 @@
 2 TYPE Birth of Hjalmar Smith
 2 DATE 31 JAN 1893
 2 PLAC Rønne, Bornholm, Denmark
+1 BIRT Y
 1 DEAT
 2 TYPE Death of Hjalmar Smith
 2 DATE 25 SEP 1894
 2 PLAC Rønne, Bornholm, Denmark
+1 DEAT Y
 1 FAMC @F3@
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+1 ALIA @I22@
+1 ALIA James /Smith/
+1 NAME Jimmy Smith
+1 TITL Sir Jimmy Smith
+2 DATE 5 OCT 1874
+2 PLAC Rønne, Bornholm, Denmark
 0 @I22@ INDI
 1 NAME Martin /Smith/
-2 GIVN Martin
 2 SURN Smith
+2 GIVN Martin
 1 SEX M
 1 BIRT
 2 TYPE Birth of Martin Smith
@@ -275,17 +292,29 @@
 1 FAMS @F2@
 1 NOTE @N0002@
 1 CHAN
+1 RESN locked
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
 0 @I23@ INDI
+1 NAME Astrid Shermanna /Augusta/
+2 GIVN Astrid Shermanna
+2 SURN Augusta
+1 NAME Star /Augusta/
+2 GIVN Star
+2 SURN Augusta
+2 TYPE AKA
+2 DATE FROM 1889 TO 1898
 1 NAME Astrid Shermanna Augusta /Smith/
 2 GIVN Astrid Shermanna Augusta
 2 SURN Smith
+2 TYPE MARRIED
+2 NPFX Dr.
 1 SEX F
 1 BIRT
 2 TYPE Birth of Astrid Shermanna Augusta Smith
 2 DATE 31 JAN 1889
 2 PLAC Rønne, Bornholm, Denmark
+2 FAMC @F3@
 1 DEAT
 2 TYPE Death of Astrid Shermanna Augusta Smith
 2 DATE 21 DEC 1963
@@ -318,6 +347,9 @@
 2 DATE 7 DEC 1862
 2 PLAC Gladsax, Kristianstad Län, Sweden
 1 FAMC @F2@
+2 NOTE A FAMC note
+2 PEDI birth
+2 SOUR @S2@
 1 FAMS @F3@
 1 CHAN
 2 DATE 21 DEC 2007
@@ -326,6 +358,7 @@
 1 NAME Marta /Ericsdotter/
 2 GIVN Marta
 2 SURN Ericsdotter
+2 _MARN Smith
 1 SEX F
 1 BIRT
 2 TYPE Birth of Marta Ericsdotter
@@ -335,6 +368,17 @@
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+1 FACT Housekeeper
+2 TYPE Skills
+1 CONL
+2 DATE 1790
+1 ENDL
+2 DATE 1795
+1 SLGC
+2 DATE 1796
+2 PLAC Sweden
+3 FORM Country
+2 FAMC @F1@
 0 @I26@ INDI
 1 NAME Kirsti Marie /Smith/
 2 GIVN Kirsti Marie
@@ -532,6 +576,8 @@
 2 GIVN Edwin Michael
 2 SURN Smith
 2 SOUR @S1@
+3 DATA
+4 TEXT Record for Edwin Michael Smith
 1 SEX M
 1 BIRT
 2 TYPE Birth of Edwin Michael Smith
@@ -742,6 +788,7 @@
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+1 _STAT
 0 @F11@ FAM
 1 HUSB @I3@
 1 WIFE @I28@
@@ -749,9 +796,20 @@
 2 TYPE Marriage of Magnes Smith and Anna Streiffert
 2 DATE 24 AUG 1884
 2 PLAC Rønne, Bornholm, Denmark
+3 MAP
+4 LATI N55.1010
+4 LONG E14.7083
+3 OBJE
+4 FILE Magnes&Anna_smiths_marr_cert.jpg
+3 SOUR @S0@
+2 OBJE
+3 FILE Magnes&Anna_smiths_marr_cert.jpg
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+1 EVEN Celebration
+2 TYPE MARB
+2 DATE 24 AUG 1883
 0 @F12@ FAM
 1 HUSB @I18@
 1 WIFE @I34@
@@ -765,6 +823,11 @@
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+1 SLGS
+2 PLAC Sparks, Washoe Co., NV
+1 NCHI 2
+1 OBJE
+2 FILE John&Alice_smiths_marr_cert.jpg
 0 @F13@ FAM
 1 HUSB @I37@
 1 WIFE @I30@
@@ -772,10 +835,18 @@
 2 TYPE Marriage of Edwin Michael Smith and Janice Ann Adams
 2 DATE 27 MAY 1995
 2 PLAC San Ramon, Conta Costa Co., CA
+2 _WITN @I18@
+3 TYPE WITNESS_OF_MARRIAGE
 1 ENGA
 2 TYPE Engagement of Edwin Michael Smith and Janice Ann Adams
 2 DATE 5 OCT 1994
+2 TIME 2:00pm
+2 AGNC Lovely ring presentation
+2 _WITN George Smorge
+2 _PRIV
+2 NOTE Description: Engagement of Edwin Michael Smith and Janice Ann Adams
 2 PLAC San Francisco, San Francisco Co., CA
+2 _UID 123456
 1 CHIL @I5@
 1 CHIL @I2@
 1 CHAN
@@ -887,11 +958,16 @@
 3 TIME 01:35:26
 0 @S1@ SOUR
 1 TITL Birth Certificate
+1 REPO Invalid REPO Name
+2 NOTE Invalid REPO (Name instead of xref)
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+1 TEXT Source text of Birth cert
 0 @S2@ SOUR
 1 TITL Birth Records
+1 REPO
+2 NOTE Invalid REPO (no name)
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
@@ -943,4 +1019,5 @@
 0 @N0004@ NOTE But Aunt Martha still keeps the original!
 0 @N0005@ NOTE The repository reference from the source is important
 0 @N0006@ NOTE Some note on the repo
+0 @N7@ NOTE 'Smith': a very common name
 0 TRLR

--- a/data/tests/imp_sample.gramps
+++ b/data/tests/imp_sample.gramps
@@ -3,536 +3,564 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-08-29" version="5.0.0-alpha1"/>
+    <created date="2016-10-19" version="5.0.0-alpha1"/>
     <researcher>
       <resname>Alex Roitman,,,</resname>
       <resaddr>Not Provided</resaddr>
     </researcher>
   </header>
   <events>
-    <event handle="_0000000200000002" change="1472500318" id="E0000">
+    <event handle="_0000000300000003" change="1476889475" id="E0000">
       <type>Birth</type>
       <dateval val="1864-10-02"/>
-      <place hlink="_0000000300000003"/>
+      <place hlink="_0000000400000004"/>
       <description>Birth of Anna Hansdotter</description>
     </event>
-    <event handle="_0000000400000004" change="1472500318" id="E0001">
+    <event handle="_0000000500000005" change="1476889475" id="E0001">
       <type>Death</type>
       <dateval val="1945-09-29"/>
-      <place hlink="_0000000500000005"/>
+      <place hlink="_0000000700000007"/>
       <description>Death of Anna Hansdotter</description>
+      <noteref hlink="_0000000600000006"/>
     </event>
-    <event handle="_0000000800000008" change="1472500318" id="E0002">
+    <event handle="_0000000c0000000c" change="1476889475" id="E0002">
       <type>Birth</type>
       <dateval val="1966-08-11"/>
-      <place hlink="_0000000900000009"/>
+      <place hlink="_0000000d0000000d"/>
       <description>Birth of Keith Lloyd Smith</description>
     </event>
-    <event handle="_0000000c0000000c" change="1472500318" id="E0003">
+    <event handle="_0000001100000011" change="1476889475" id="E0003">
       <type>Birth</type>
       <dateval val="1904-04-17"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001200000012"/>
       <description>Birth of Hans Peter Smith</description>
     </event>
-    <event handle="_0000000e0000000e" change="1472500318" id="E0004">
+    <event handle="_0000001300000013" change="1476889475" id="E0004">
       <type>Death</type>
       <dateval val="1977-01-29"/>
-      <place hlink="_0000000900000009"/>
+      <place hlink="_0000000d0000000d"/>
       <description>Death of Hans Peter Smith</description>
     </event>
-    <event handle="_0000001200000012" change="1472500318" id="E0005">
+    <event handle="_0000001800000018" change="1476889475" id="E0005">
       <type>Birth</type>
       <dateval val="1821-01-29"/>
-      <place hlink="_0000001300000013"/>
+      <place hlink="_0000001900000019"/>
       <description>Birth of Hanna Smith</description>
     </event>
-    <event handle="_0000001600000016" change="1472500318" id="E0006">
+    <event handle="_0000001d0000001d" change="1476889475" id="E0006">
       <type>Birth</type>
       <dateval val="1889-08-31"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001200000012"/>
       <description>Birth of Herman Julius Nielsen</description>
     </event>
-    <event handle="_0000001700000017" change="1472500318" id="E0007">
+    <event handle="_0000001e0000001e" change="1476889475" id="E0007">
       <type>Death</type>
       <dateval val="1945"/>
       <description>Death of Herman Julius Nielsen</description>
     </event>
-    <event handle="_0000001a0000001a" change="1472500318" id="E0008">
+    <event handle="_0000002200000022" change="1476889475" id="E0008">
       <type>Birth</type>
       <dateval val="1897" type="about"/>
       <description>Birth of Evelyn Michaels</description>
     </event>
-    <event handle="_0000001d0000001d" change="1472500318" id="E0009">
+    <event handle="_0000002600000026" change="1476889475" id="E0009">
       <type>Birth</type>
       <dateval val="1934-11-04"/>
-      <place hlink="_0000001e0000001e"/>
+      <place hlink="_0000002700000027"/>
       <description>Birth of Marjorie Lee Smith</description>
     </event>
-    <event handle="_0000002100000021" change="1472500318" id="E0010">
+    <event handle="_0000002a0000002a" change="1476889475" id="E0010">
       <type>Birth</type>
       <dateval val="1897-09-11"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001200000012"/>
       <description>Birth of Gus Smith</description>
     </event>
-    <event handle="_0000002200000022" change="1472500318" id="E0011">
+    <event handle="_0000002b0000002b" change="1476889475" id="E0011">
       <type>Death</type>
       <dateval val="1963-10-21"/>
-      <place hlink="_0000000900000009"/>
+      <place hlink="_0000000d0000000d"/>
       <description>Death of Gus Smith</description>
     </event>
-    <event handle="_0000002400000024" change="1472500318" id="E0012">
+    <event handle="_0000002d0000002d" change="1476889475" id="E0012">
       <type>Birth</type>
       <dateval val="1907-11-05"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001200000012"/>
       <description>Birth of Jennifer Anderson</description>
     </event>
-    <event handle="_0000002500000025" change="1472500318" id="E0013">
+    <event handle="_0000002e0000002e" change="1476889475" id="E0013">
       <type>Death</type>
       <dateval val="1985-05-29"/>
-      <place hlink="_0000000900000009"/>
+      <place hlink="_0000000d0000000d"/>
       <description>Death of Jennifer Anderson</description>
     </event>
-    <event handle="_0000002700000027" change="1472500318" id="E0014">
+    <event handle="_0000003000000030" change="1476889475" id="E0014">
       <type>Birth</type>
       <dateval val="1910-05-02"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001200000012"/>
       <description>Birth of Lillie Harriet Jones</description>
     </event>
-    <event handle="_0000002800000028" change="1472500318" id="E0015">
+    <event handle="_0000003100000031" change="1476889475" id="E0015">
       <type>Death</type>
       <dateval val="1990-06-26"/>
       <description>Death of Lillie Harriet Jones</description>
     </event>
-    <event handle="_0000002a0000002a" change="1472500318" id="E0016">
+    <event handle="_0000003300000033" change="1476889475" id="E0016">
       <type>Birth</type>
       <dateval val="1932-01-30"/>
-      <place hlink="_0000000900000009"/>
+      <place hlink="_0000000d0000000d"/>
       <description>Birth of John Hjalmar Smith</description>
     </event>
-    <event handle="_0000002d0000002d" change="1472500318" id="E0017">
+    <event handle="_0000003600000036" change="1476889475" id="E0017">
       <type>Birth</type>
       <dateval val="1963-08-28"/>
-      <place hlink="_0000000900000009"/>
+      <place hlink="_0000000d0000000d"/>
       <description>Birth of Eric Lloyd Smith</description>
     </event>
-    <event handle="_0000002e0000002e" change="1472500318" id="E0018">
+    <event handle="_0000003700000037" change="1476889475" id="E0018">
       <type>Adopted</type>
     </event>
-    <event handle="_0000003100000031" change="1472500318" id="E0019">
+    <event handle="_0000003a0000003a" change="1476889475" id="E0019">
       <type>Birth</type>
       <dateval val="1998-04-12"/>
-      <place hlink="_0000003200000032"/>
+      <place hlink="_0000003b0000003b"/>
       <description>Birth of Amber Marie Smith</description>
     </event>
-    <event handle="_0000003300000033" change="1472500318" id="E0020">
+    <event handle="_0000003c0000003c" change="1476889475" id="E0020">
       <type>Christening</type>
       <dateval val="1998-04-26"/>
-      <place hlink="_0000003400000034"/>
+      <place hlink="_0000003d0000003d"/>
       <description>Christening of Amber Marie Smith</description>
     </event>
-    <event handle="_0000003700000037" change="1472500318" id="E0021">
+    <event handle="_0000004000000040" change="1476889475" id="E0021">
       <type>Birth</type>
       <dateval val="1899-12-20"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001200000012"/>
       <description>Birth of Carl Emil Smith</description>
     </event>
-    <event handle="_0000003800000038" change="1472500318" id="E0022">
+    <event handle="_0000004100000041" change="1476889475" id="E0022">
       <type>Death</type>
       <dateval val="1959-01-28"/>
-      <place hlink="_0000001e0000001e"/>
+      <place hlink="_0000002700000027"/>
       <description>Death of Carl Emil Smith</description>
       <attribute type="Cause" value="Bad breath"/>
     </event>
-    <event handle="_0000003a0000003a" change="1472500318" id="E0023">
+    <event handle="_0000004300000043" change="1476889475" id="E0023">
       <type>Birth</type>
       <dateval val="1893-01-31"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001200000012"/>
       <description>Birth of Hjalmar Smith</description>
     </event>
-    <event handle="_0000003b0000003b" change="1472500318" id="E0024">
+    <event handle="_0000004400000044" change="1476889475" id="E0024">
+      <type>Birth</type>
+    </event>
+    <event handle="_0000004500000045" change="1476889475" id="E0025">
       <type>Death</type>
       <dateval val="1894-09-25"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001200000012"/>
       <description>Death of Hjalmar Smith</description>
     </event>
-    <event handle="_0000003d0000003d" change="1472500318" id="E0025">
+    <event handle="_0000004600000046" change="1476889475" id="E0026">
+      <type>Death</type>
+    </event>
+    <event handle="_0000004800000048" change="1476889475" id="E0027">
+      <type>Nobility Title</type>
+      <dateval val="1874-10-05"/>
+      <place hlink="_0000001200000012"/>
+      <description>Sir Jimmy Smith</description>
+    </event>
+    <event handle="_0000004900000049" change="1476889475" id="E0028">
       <type>Birth</type>
       <dateval val="1830-11-19"/>
-      <place hlink="_0000001300000013"/>
+      <place hlink="_0000001900000019"/>
       <description>Birth of Martin Smith</description>
     </event>
-    <event handle="_0000003e0000003e" change="1472500318" id="E0026">
+    <event handle="_0000004a0000004a" change="1476889475" id="E0029">
       <type>Death</type>
       <daterange start="1899" stop="1905"/>
-      <place hlink="_0000003f0000003f"/>
+      <place hlink="_0000004b0000004b"/>
       <description>Death of Martin Smith</description>
     </event>
-    <event handle="_0000004000000040" change="1472500318" id="E0027">
+    <event handle="_0000004c0000004c" change="1476889475" id="E0030">
       <type>Baptism</type>
       <dateval val="1830-11-23"/>
-      <place hlink="_0000001300000013"/>
+      <place hlink="_0000001900000019"/>
       <description>Baptism of Martin Smith</description>
     </event>
-    <event handle="_0000004400000044" change="1472500318" id="E0028">
+    <event handle="_0000004f0000004f" change="1476889475" id="E0031">
+      <type>DATE</type>
+      <description>2007-12-21</description>
+      <attribute type="Time" value="01:35:26"/>
+    </event>
+    <event handle="_0000005100000051" change="1476889475" id="E0032">
       <type>Birth</type>
       <dateval val="1889-01-31"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001200000012"/>
       <description>Birth of Astrid Shermanna Augusta Smith</description>
     </event>
-    <event handle="_0000004500000045" change="1472500318" id="E0029">
+    <event handle="_0000005200000052" change="1476889475" id="E0033">
       <type>Death</type>
       <dateval val="1963-12-21"/>
-      <place hlink="_0000000900000009"/>
+      <place hlink="_0000000d0000000d"/>
       <description>Death of Astrid Shermanna Augusta Smith</description>
     </event>
-    <event handle="_0000004700000047" change="1472500318" id="E0030">
+    <event handle="_0000005400000054" change="1476889475" id="E0034">
       <type>Birth</type>
       <dateval val="1862-11-28"/>
-      <place hlink="_0000004800000048"/>
+      <place hlink="_0000005500000055"/>
       <description>Birth of Gustaf Smith, Sr.</description>
     </event>
-    <event handle="_0000004900000049" change="1472500318" id="E0031">
+    <event handle="_0000005600000056" change="1476889475" id="E0035">
       <type>Death</type>
       <dateval val="1930-07-23" type="before"/>
-      <place hlink="_0000000500000005"/>
+      <place hlink="_0000000700000007"/>
       <description>Death of Gustaf Smith, Sr.</description>
     </event>
-    <event handle="_0000004a0000004a" change="1472500318" id="E0032">
+    <event handle="_0000005700000057" change="1476889475" id="E0036">
       <type>Immi</type>
       <dateval val="1908-05-21"/>
-      <place hlink="_0000004b0000004b"/>
+      <place hlink="_0000005800000058"/>
     </event>
-    <event handle="_0000004c0000004c" change="1472500318" id="E0033">
+    <event handle="_0000005900000059" change="1476889475" id="E0037">
       <type>Christening</type>
       <dateval val="1862-12-07"/>
-      <place hlink="_0000001300000013"/>
+      <place hlink="_0000001900000019"/>
       <description>Christening of Gustaf Smith, Sr.</description>
     </event>
-    <event handle="_0000004e0000004e" change="1472500318" id="E0034">
+    <event handle="_0000005e0000005e" change="1476889475" id="E0038">
       <type>Birth</type>
       <dateval val="1775" type="about"/>
-      <place hlink="_0000003f0000003f"/>
+      <place hlink="_0000004b0000004b"/>
       <description>Birth of Marta Ericsdotter</description>
     </event>
-    <event handle="_0000005100000051" change="1472500318" id="E0035">
+    <event handle="_0000006200000062" change="1476889475" id="E0039">
       <type>Birth</type>
       <dateval val="1886-12-15"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001200000012"/>
       <description>Birth of Kirsti Marie Smith</description>
     </event>
-    <event handle="_0000005200000052" change="1472500318" id="E0036">
+    <event handle="_0000006300000063" change="1476889475" id="E0040">
       <type>Death</type>
       <dateval val="1966-07-18"/>
-      <place hlink="_0000000900000009"/>
+      <place hlink="_0000000d0000000d"/>
       <description>Death of Kirsti Marie Smith</description>
     </event>
-    <event handle="_0000005500000055" change="1472500318" id="E0037">
+    <event handle="_0000006600000066" change="1476889475" id="E0041">
       <type>Birth</type>
       <dateval val="1770" type="about"/>
-      <place hlink="_0000003f0000003f"/>
+      <place hlink="_0000004b0000004b"/>
       <description>Birth of Ingeman Smith</description>
     </event>
-    <event handle="_0000005700000057" change="1472500318" id="E0038">
+    <event handle="_0000006800000068" change="1476889475" id="E0042">
       <type>Birth</type>
       <dateval val="1860-09-23"/>
-      <place hlink="_0000005800000058"/>
+      <place hlink="_0000006900000069"/>
       <description>Birth of Anna Streiffert</description>
     </event>
-    <event handle="_0000005900000059" change="1472500318" id="E0039">
+    <event handle="_0000006a0000006a" change="1476889475" id="E0043">
       <type>Death</type>
       <dateval val="1927-02-02"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001200000012"/>
       <description>Death of Anna Streiffert</description>
     </event>
-    <event handle="_0000005c0000005c" change="1472500318" id="E0040">
+    <event handle="_0000006d0000006d" change="1476889475" id="E0044">
       <type>Birth</type>
       <dateval val="1966" type="after"/>
-      <place hlink="_0000000900000009"/>
+      <place hlink="_0000000d0000000d"/>
       <description>Birth of Craig Peter Smith</description>
     </event>
-    <event handle="_0000005d0000005d" change="1472500318" id="E0041">
+    <event handle="_0000006e0000006e" change="1476889475" id="E0045">
       <type>Census</type>
       <description>Census of Craig Peter Smith</description>
-      <noteref hlink="_0000005e0000005e"/>
+      <noteref hlink="_0000006f0000006f"/>
     </event>
-    <event handle="_0000006000000060" change="1472500318" id="E0042">
+    <event handle="_0000007100000071" change="1476889475" id="E0046">
       <type>Birth</type>
       <dateval val="1858-10-06"/>
-      <place hlink="_0000006100000061"/>
+      <place hlink="_0000007200000072"/>
       <description>Birth of Magnes Smith</description>
     </event>
-    <event handle="_0000006200000062" change="1472500318" id="E0043">
+    <event handle="_0000007300000073" change="1476889475" id="E0047">
       <type>Death</type>
       <dateval val="1910-02-20"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001200000012"/>
       <description>Death of Magnes Smith</description>
     </event>
-    <event handle="_0000006400000064" change="1472500318" id="E0044">
+    <event handle="_0000007500000075" change="1476889475" id="E0048">
       <type>Birth</type>
       <dateval val="1965-08-26"/>
-      <place hlink="_0000006500000065"/>
+      <place hlink="_0000007600000076"/>
       <description>Birth of Janice Ann Adams</description>
     </event>
-    <event handle="_0000006600000066" change="1472500318" id="E0045">
+    <event handle="_0000007700000077" change="1476889475" id="E0049">
       <type>Occupation</type>
       <description>Retail Manager</description>
     </event>
-    <event handle="_0000006700000067" change="1472500318" id="E0046">
+    <event handle="_0000007800000078" change="1476889475" id="E0050">
       <type>Degree</type>
       <dateval val="1988"/>
       <description>Business Management</description>
     </event>
-    <event handle="_0000006900000069" change="1472500318" id="E0047">
+    <event handle="_0000007a0000007a" change="1476889475" id="E0051">
       <type>Birth</type>
       <dateval val="1903-06-03"/>
-      <place hlink="_0000006a0000006a"/>
+      <place hlink="_0000007b0000007b"/>
       <description>Birth of Marjorie Ohman</description>
     </event>
-    <event handle="_0000006b0000006b" change="1472500318" id="E0048">
+    <event handle="_0000007c0000007c" change="1476889475" id="E0052">
       <type>Death</type>
       <dateval val="1980-06-22"/>
-      <place hlink="_0000001e0000001e"/>
+      <place hlink="_0000002700000027"/>
       <description>Death of Marjorie Ohman</description>
     </event>
-    <event handle="_0000006d0000006d" change="1472500318" id="E0049">
+    <event handle="_0000007e0000007e" change="1476889475" id="E0053">
       <type>Birth</type>
       <dateval val="1966-07-02"/>
-      <place hlink="_0000006e0000006e"/>
+      <place hlink="_0000007f0000007f"/>
       <description>Birth of Darcy Horne</description>
     </event>
-    <event handle="_0000007000000070" change="1472500318" id="E0050">
+    <event handle="_0000008100000081" change="1476889475" id="E0054">
       <type>Birth</type>
       <dateval val="1935-03-13"/>
-      <place hlink="_0000000900000009"/>
+      <place hlink="_0000000d0000000d"/>
       <description>Birth of Lloyd Smith</description>
     </event>
-    <event handle="_0000007200000072" change="1472500318" id="E0051">
+    <event handle="_0000008300000083" change="1476889475" id="E0055">
       <type>Birth</type>
       <dateval val="1933-11-22"/>
-      <place hlink="_0000000500000005"/>
+      <place hlink="_0000000700000007"/>
       <description>Birth of Alice Paula Perkins</description>
     </event>
-    <event handle="_0000007400000074" change="1472500318" id="E0052">
+    <event handle="_0000008500000085" change="1476889475" id="E0056">
       <type>Birth</type>
       <dateval val="1991-09-16"/>
-      <place hlink="_0000007500000075"/>
+      <place hlink="_0000008600000086"/>
       <description>Birth of Lars Peter Smith</description>
     </event>
-    <event handle="_0000007600000076" change="1472500318" id="E0053">
+    <event handle="_0000008700000087" change="1476889475" id="E0057">
       <type>Adopted</type>
     </event>
-    <event handle="_0000007800000078" change="1472500318" id="E0054">
+    <event handle="_0000008900000089" change="1476889475" id="E0058">
       <type>Birth</type>
       <dateval val="1800-09-14"/>
-      <place hlink="_0000001300000013"/>
+      <place hlink="_0000001900000019"/>
       <description>Birth of Elna Jefferson</description>
     </event>
-    <event handle="_0000007900000079" change="1472500318" id="E0055">
+    <event handle="_0000008a0000008a" change="1476889475" id="E0059">
       <type>Death</type>
-      <place hlink="_0000003f0000003f"/>
+      <place hlink="_0000004b0000004b"/>
       <description>Death of Elna Jefferson</description>
     </event>
-    <event handle="_0000007a0000007a" change="1472500318" id="E0056">
+    <event handle="_0000008b0000008b" change="1476889475" id="E0060">
       <type>Christening</type>
       <dateval val="1800-09-16"/>
-      <place hlink="_0000001300000013"/>
+      <place hlink="_0000001900000019"/>
       <description>Christening of Elna Jefferson</description>
     </event>
-    <event handle="_0000007e0000007e" change="1472500318" id="E0057">
+    <event handle="_0000009000000090" change="1476889475" id="E0061">
       <type>Birth</type>
       <dateval val="1961-05-24"/>
-      <place hlink="_0000008100000081"/>
+      <place hlink="_0000009300000093"/>
       <description>Birth of Edwin Michael Smith</description>
-      <citationref hlink="_0000008000000080"/>
+      <citationref hlink="_0000009200000092"/>
     </event>
-    <event handle="_0000008200000082" change="1472500318" id="E0058">
+    <event handle="_0000009400000094" change="1476889475" id="E0062">
       <type>Occupation</type>
       <description>Software Engineer</description>
-      <noteref hlink="_0000008300000083"/>
+      <noteref hlink="_0000009500000095"/>
     </event>
-    <event handle="_0000008400000084" change="1472500318" id="E0059">
+    <event handle="_0000009600000096" change="1476889475" id="E0063">
       <type>Education</type>
       <daterange start="1979" stop="1984"/>
-      <place hlink="_0000008500000085"/>
+      <place hlink="_0000009700000097"/>
       <description>Education of Edwin Michael Smith</description>
     </event>
-    <event handle="_0000008600000086" change="1472500318" id="E0060">
+    <event handle="_0000009800000098" change="1476889475" id="E0064">
       <type>Degree</type>
       <dateval val="1984"/>
       <description>B.S.E.E.</description>
     </event>
-    <event handle="_0000008800000088" change="1472500318" id="E0061">
+    <event handle="_0000009a0000009a" change="1476889475" id="E0065">
       <type>Birth</type>
       <dateval val="1832-11-29"/>
-      <place hlink="_0000008900000089"/>
+      <place hlink="_0000009b0000009b"/>
       <description>Birth of Kerstina Hansdotter</description>
     </event>
-    <event handle="_0000008a0000008a" change="1472500318" id="E0062">
+    <event handle="_0000009c0000009c" change="1476889475" id="E0066">
       <type>Death</type>
       <dateval val="1908" type="before"/>
-      <place hlink="_0000003f0000003f"/>
+      <place hlink="_0000004b0000004b"/>
       <description>Death of Kerstina Hansdotter</description>
     </event>
-    <event handle="_0000008c0000008c" change="1472500318" id="E0063">
+    <event handle="_0000009e0000009e" change="1476889475" id="E0067">
       <type>Birth</type>
       <daterange start="1794" stop="1796"/>
-      <place hlink="_0000008d0000008d"/>
+      <place hlink="_0000009f0000009f"/>
       <description>Birth of Martin Smith</description>
     </event>
-    <event handle="_0000008e0000008e" change="1472500318" id="E0064">
+    <event handle="_000000a0000000a0" change="1476889475" id="E0068">
       <type>Death</type>
-      <place hlink="_0000003f0000003f"/>
+      <place hlink="_0000004b0000004b"/>
       <description>Death of Martin Smith</description>
     </event>
-    <event handle="_0000009000000090" change="1472500318" id="E0065">
+    <event handle="_000000a2000000a2" change="1476889475" id="E0069">
       <type>Birth</type>
       <dateval val="1826-01-29"/>
-      <place hlink="_0000001300000013"/>
+      <place hlink="_0000001900000019"/>
       <description>Birth of Ingeman Smith</description>
     </event>
-    <event handle="_0000009200000092" change="1472500318" id="E0066">
+    <event handle="_000000a4000000a4" change="1476889475" id="E0070">
       <type>Birth</type>
       <dateval val="1960-02-05"/>
-      <place hlink="_0000008100000081"/>
+      <place hlink="_0000009300000093"/>
       <description>Birth of Marjorie Alice Smith</description>
     </event>
-    <event handle="_0000009400000094" change="1472500318" id="E0067">
+    <event handle="_000000a6000000a6" change="1476889475" id="E0071">
       <type>Birth</type>
       <dateval val="1935-12-02"/>
       <description>Birth of Janis Elaine Green</description>
     </event>
-    <event handle="_0000009600000096" change="1472500318" id="E0068">
+    <event handle="_000000a8000000a8" change="1476889475" id="E0072">
       <type>Birth</type>
       <dateval val="1996-06-26"/>
-      <place hlink="_0000003200000032"/>
+      <place hlink="_0000003b0000003b"/>
       <description>Birth of Mason Michael Smith</description>
     </event>
-    <event handle="_0000009700000097" change="1472500318" id="E0069">
+    <event handle="_000000a9000000a9" change="1476889475" id="E0073">
       <type>Christening</type>
       <dateval val="1996-07-10"/>
-      <place hlink="_0000003400000034"/>
+      <place hlink="_0000003d0000003d"/>
       <description>Christening of Mason Michael Smith</description>
     </event>
-    <event handle="_0000009900000099" change="1472500318" id="E0070">
+    <event handle="_000000ab000000ab" change="1476889475" id="E0074">
       <type>Birth</type>
       <dateval val="1886" type="about"/>
       <description>Birth of Edwin Willard</description>
     </event>
-    <event handle="_0000009b0000009b" change="1472500318" id="E0071">
+    <event handle="_000000ad000000ad" change="1476889475" id="E0075">
       <type>Birth</type>
       <dateval val="1823" type="after"/>
-      <place hlink="_0000001300000013"/>
+      <place hlink="_0000001900000019"/>
       <description>Birth of Ingar Smith</description>
     </event>
-    <event handle="_0000009d0000009d" change="1472500318" id="E0072">
+    <event handle="_000000af000000af" change="1476889475" id="E0076">
       <type>Birth</type>
       <dateval val="1895-04-07"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001200000012"/>
       <description>Birth of Hjalmar Smith</description>
     </event>
-    <event handle="_0000009e0000009e" change="1472500318" id="E0073">
+    <event handle="_000000b0000000b0" change="1476889475" id="E0077">
       <type>Death</type>
       <dateval val="1975-06-26"/>
-      <place hlink="_0000001e0000001e"/>
+      <place hlink="_0000002700000027"/>
       <description>Death of Hjalmar Smith</description>
     </event>
-    <event handle="_0000009f0000009f" change="1472500318" id="E0074">
+    <event handle="_000000b1000000b1" change="1476889475" id="E0078">
       <type>Baptism</type>
       <dateval val="1895-06-03"/>
-      <place hlink="_000000a0000000a0"/>
+      <place hlink="_000000b2000000b2"/>
       <description>Baptism of Hjalmar Smith</description>
     </event>
-    <event handle="_000000a1000000a1" change="1472500318" id="E0075">
+    <event handle="_000000b3000000b3" change="1476889475" id="E0079">
       <type>Immi</type>
       <dateval val="1912-11-14"/>
-      <place hlink="_0000004b0000004b"/>
+      <place hlink="_0000005800000058"/>
     </event>
-    <event handle="_000000a4000000a4" change="1472500318" id="E0076">
+    <event handle="_000000b6000000b6" change="1476889475" id="E0080">
       <type>Birth</type>
       <dateval val="1860-09-27"/>
-      <place hlink="_0000006100000061"/>
+      <place hlink="_0000007200000072"/>
       <description>Birth of Emil Smith</description>
     </event>
-    <event handle="_000000a5000000a5" change="1472500318" id="E0077">
+    <event handle="_000000b7000000b7" change="1476889475" id="E0081">
       <type>Marriage</type>
       <dateval val="1816" type="about"/>
-      <place hlink="_0000001300000013"/>
+      <place hlink="_0000001900000019"/>
       <description>Marriage of Martin Smith and Elna Jefferson</description>
     </event>
-    <event handle="_000000a6000000a6" change="1472500318" id="E0078">
+    <event handle="_000000b8000000b8" change="1476889475" id="E0082">
       <type>Marriage</type>
       <dateval val="1790" type="about"/>
-      <place hlink="_0000003f0000003f"/>
+      <place hlink="_0000004b0000004b"/>
       <description>Marriage of Ingeman Smith and Marta Ericsdotter</description>
     </event>
-    <event handle="_000000a7000000a7" change="1472500318" id="E0079">
+    <event handle="_000000b9000000b9" change="1476889475" id="E0083">
       <type>Marriage</type>
       <dateval val="1986-07-12"/>
-      <place hlink="_000000a8000000a8"/>
+      <place hlink="_000000ba000000ba"/>
       <description>Marriage of Eric Lloyd Smith and Darcy Horne</description>
     </event>
-    <event handle="_000000a9000000a9" change="1472500318" id="E0080">
+    <event handle="_000000bb000000bb" change="1476889475" id="E0084">
       <type>Marriage</type>
       <dateval val="1884-08-24"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001200000012"/>
       <description>Marriage of Magnes Smith and Anna Streiffert</description>
+      <objref hlink="_000000bc000000bc"/>
     </event>
-    <event handle="_000000aa000000aa" change="1472500318" id="E0081">
+    <event handle="_000000bf000000bf" change="1476889475" id="E0085">
+      <type>Marriage Banns</type>
+      <dateval val="1883-08-24"/>
+      <description>Celebration</description>
+    </event>
+    <event handle="_000000c1000000c1" change="1476889475" id="E0086">
       <type>Marriage</type>
       <dateval val="1954-06-04"/>
-      <place hlink="_0000000500000005"/>
+      <place hlink="_0000000700000007"/>
       <description>Marriage of John Hjalmar Smith and Alice Paula Perkins</description>
-      <citationref hlink="_000000ac000000ac"/>
+      <citationref hlink="_000000c2000000c2"/>
     </event>
-    <event handle="_000000ad000000ad" change="1472500318" id="E0082">
+    <event handle="_000000c6000000c6" change="1476889475" id="E0087">
       <type>Marriage</type>
       <dateval val="1995-05-27"/>
-      <place hlink="_000000ae000000ae"/>
+      <place hlink="_000000c7000000c7"/>
       <description>Marriage of Edwin Michael Smith and Janice Ann Adams</description>
     </event>
-    <event handle="_000000af000000af" change="1472500318" id="E0083">
+    <event handle="_000000c8000000c8" change="1476889475" id="E0088" priv="1">
       <type>Engagement</type>
       <dateval val="1994-10-05"/>
-      <place hlink="_0000000900000009"/>
+      <place hlink="_0000000d0000000d"/>
       <description>Engagement of Edwin Michael Smith and Janice Ann Adams</description>
+      <attribute type="Time" value="2:00pm"/>
+      <attribute type="Agency" value="Lovely ring presentation"/>
+      <attribute type="Witness" value="George Smorge"/>
+      <attribute type="_UID" value="123456"/>
     </event>
-    <event handle="_000000b0000000b0" change="1472500318" id="E0084">
+    <event handle="_000000c9000000c9" change="1476889475" id="E0089">
       <type>Marriage</type>
       <dateval val="1856" type="about"/>
       <description>Marriage of Martin Smith and Kerstina Hansdotter</description>
     </event>
-    <event handle="_000000b1000000b1" change="1472500318" id="E0085">
+    <event handle="_000000ca000000ca" change="1476889475" id="E0090">
       <type>Marriage</type>
       <dateval val="1885-11-27"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001200000012"/>
       <description>Marriage of Gustaf Smith, Sr. and Anna Hansdotter</description>
     </event>
-    <event handle="_000000b2000000b2" change="1472500318" id="E0086">
+    <event handle="_000000cb000000cb" change="1476889475" id="E0091">
       <type>Marriage</type>
       <dateval val="1910" type="about"/>
       <description>Marriage of Edwin Willard and Kirsti Marie Smith</description>
     </event>
-    <event handle="_000000b3000000b3" change="1472500318" id="E0087">
+    <event handle="_000000cc000000cc" change="1476889475" id="E0092">
       <type>Marriage</type>
       <dateval val="1912-11-30"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001200000012"/>
       <description>Marriage of Herman Julius Nielsen and Astrid Shermanna Augusta Smith</description>
     </event>
-    <event handle="_000000b4000000b4" change="1472500318" id="E0088">
+    <event handle="_000000cd000000cd" change="1476889475" id="E0093">
       <type>Marriage</type>
       <dateval val="1927-10-31"/>
-      <place hlink="_0000001e0000001e"/>
+      <place hlink="_0000002700000027"/>
       <description>Marriage of Hjalmar Smith and Marjorie Ohman</description>
     </event>
-    <event handle="_000000b5000000b5" change="1472500318" id="E0089">
+    <event handle="_000000ce000000ce" change="1476889475" id="E0094">
       <type>Marriage</type>
       <dateval val="1920" type="about"/>
       <description>Marriage of Gus Smith and Evelyn Michaels</description>
     </event>
-    <event handle="_000000b6000000b6" change="1472500318" id="E0090">
+    <event handle="_000000cf000000cf" change="1476889475" id="E0095">
       <type>Marriage</type>
       <dateval val="1958-08-10"/>
-      <place hlink="_0000000900000009"/>
+      <place hlink="_0000000d0000000d"/>
       <description>Marriage of Lloyd Smith and Janis Elaine Green</description>
     </event>
   </events>
@@ -542,684 +570,777 @@
       <name type="Birth Name">
         <first>Anna</first>
         <surname>Hansdotter</surname>
+        <noteref hlink="_0000000200000002"/>
       </name>
-      <eventref hlink="_0000000200000002" role="Primary"/>
-      <eventref hlink="_0000000400000004" role="Primary"/>
-      <parentin hlink="_0000000600000006"/>
+      <eventref hlink="_0000000300000003" role="Primary"/>
+      <eventref hlink="_0000000500000005" role="Primary"/>
+      <parentin hlink="_0000000800000008"/>
+      <noteref hlink="_0000000900000009"/>
     </person>
-    <person handle="_0000000700000007" change="1198222526" id="I0001">
+    <person handle="_0000000a0000000a" change="1198222526" id="I0001">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Keith Lloyd</first>
         <surname>Smith</surname>
+        <noteref hlink="_0000000b0000000b"/>
       </name>
-      <eventref hlink="_0000000800000008" role="Primary"/>
-      <childof hlink="_0000000a0000000a"/>
+      <eventref hlink="_0000000c0000000c" role="Primary"/>
+      <childof hlink="_0000000e0000000e"/>
+      <noteref hlink="_0000000f0000000f"/>
     </person>
-    <person handle="_0000000b0000000b" change="1198222526" id="I0010">
+    <person handle="_0000001000000010" change="1198222526" id="I0010">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Hans Peter</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000000c0000000c" role="Primary"/>
-      <eventref hlink="_0000000e0000000e" role="Primary"/>
-      <childof hlink="_0000000600000006"/>
-      <parentin hlink="_0000000f0000000f"/>
-      <parentin hlink="_0000001000000010"/>
+      <eventref hlink="_0000001100000011" role="Primary"/>
+      <eventref hlink="_0000001300000013" role="Primary"/>
+      <childof hlink="_0000000800000008"/>
+      <parentin hlink="_0000001400000014"/>
+      <parentin hlink="_0000001500000015"/>
+      <noteref hlink="_0000001600000016"/>
     </person>
-    <person handle="_0000001100000011" change="1198222526" id="I0011">
+    <person handle="_0000001700000017" change="1198222526" id="I0011">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Hanna</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000001200000012" role="Primary"/>
-      <childof hlink="_0000001400000014"/>
+      <eventref hlink="_0000001800000018" role="Primary"/>
+      <childof hlink="_0000001a0000001a"/>
+      <noteref hlink="_0000001b0000001b"/>
     </person>
-    <person handle="_0000001500000015" change="1198222526" id="I0012">
+    <person handle="_0000001c0000001c" change="1198222526" id="I0012">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Herman Julius</first>
         <surname>Nielsen</surname>
       </name>
-      <eventref hlink="_0000001600000016" role="Primary"/>
-      <eventref hlink="_0000001700000017" role="Primary"/>
-      <parentin hlink="_0000001800000018"/>
+      <eventref hlink="_0000001d0000001d" role="Primary"/>
+      <eventref hlink="_0000001e0000001e" role="Primary"/>
+      <parentin hlink="_0000001f0000001f"/>
+      <noteref hlink="_0000002000000020"/>
     </person>
-    <person handle="_0000001900000019" change="1198222526" id="I0013">
+    <person handle="_0000002100000021" change="1198222526" id="I0013">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Evelyn</first>
         <surname>Michaels</surname>
       </name>
-      <eventref hlink="_0000001a0000001a" role="Primary"/>
-      <parentin hlink="_0000001b0000001b"/>
+      <eventref hlink="_0000002200000022" role="Primary"/>
+      <parentin hlink="_0000002300000023"/>
+      <noteref hlink="_0000002400000024"/>
     </person>
-    <person handle="_0000001c0000001c" change="1198222526" id="I0014">
+    <person handle="_0000002500000025" change="1198222526" id="I0014">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Marjorie Lee</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000001d0000001d" role="Primary"/>
-      <childof hlink="_0000001f0000001f"/>
+      <eventref hlink="_0000002600000026" role="Primary"/>
+      <childof hlink="_0000002800000028"/>
     </person>
-    <person handle="_0000002000000020" change="1198222526" id="I0015">
+    <person handle="_0000002900000029" change="1198222526" id="I0015">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Gus</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000002100000021" role="Primary"/>
-      <eventref hlink="_0000002200000022" role="Primary"/>
-      <childof hlink="_0000000600000006"/>
-      <parentin hlink="_0000001b0000001b"/>
+      <eventref hlink="_0000002a0000002a" role="Primary"/>
+      <eventref hlink="_0000002b0000002b" role="Primary"/>
+      <childof hlink="_0000000800000008"/>
+      <parentin hlink="_0000002300000023"/>
     </person>
-    <person handle="_0000002300000023" change="1198222526" id="I0016">
+    <person handle="_0000002c0000002c" change="1198222526" id="I0016">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Jennifer</first>
         <surname>Anderson</surname>
       </name>
-      <eventref hlink="_0000002400000024" role="Primary"/>
-      <eventref hlink="_0000002500000025" role="Primary"/>
-      <parentin hlink="_0000001000000010"/>
+      <eventref hlink="_0000002d0000002d" role="Primary"/>
+      <eventref hlink="_0000002e0000002e" role="Primary"/>
+      <parentin hlink="_0000001500000015"/>
     </person>
-    <person handle="_0000002600000026" change="1198222526" id="I0017">
+    <person handle="_0000002f0000002f" change="1198222526" id="I0017">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Lillie Harriet</first>
         <surname>Jones</surname>
       </name>
-      <eventref hlink="_0000002700000027" role="Primary"/>
-      <eventref hlink="_0000002800000028" role="Primary"/>
-      <parentin hlink="_0000000f0000000f"/>
+      <eventref hlink="_0000003000000030" role="Primary"/>
+      <eventref hlink="_0000003100000031" role="Primary"/>
+      <parentin hlink="_0000001400000014"/>
     </person>
-    <person handle="_0000002900000029" change="1198222526" id="I0018">
+    <person handle="_0000003200000032" change="1476889475" id="I0018">
       <gender>M</gender>
       <name type="Birth Name">
         <first>John Hjalmar</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000002a0000002a" role="Primary"/>
-      <childof hlink="_0000001f0000001f"/>
-      <parentin hlink="_0000002b0000002b"/>
+      <eventref hlink="_0000003300000033" role="Primary"/>
+      <eventref hlink="_000000c6000000c6" role="Witness"/>
+      <childof hlink="_0000002800000028"/>
+      <parentin hlink="_0000003400000034"/>
     </person>
-    <person handle="_0000002c0000002c" change="1198222526" id="I0019">
+    <person handle="_0000003500000035" change="1198222526" id="I0019">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Eric Lloyd</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000002d0000002d" role="Primary"/>
-      <eventref hlink="_0000002e0000002e" role="Primary"/>
-      <childof hlink="_0000000a0000000a"/>
-      <parentin hlink="_0000002f0000002f"/>
+      <eventref hlink="_0000003600000036" role="Primary"/>
+      <eventref hlink="_0000003700000037" role="Primary"/>
+      <childof hlink="_0000000e0000000e"/>
+      <parentin hlink="_0000003800000038"/>
     </person>
-    <person handle="_0000003000000030" change="1198222526" id="I0002">
+    <person handle="_0000003900000039" change="1198222526" id="I0002">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Amber Marie</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000003100000031" role="Primary"/>
-      <eventref hlink="_0000003300000033" role="Primary"/>
-      <childof hlink="_0000003500000035"/>
+      <eventref hlink="_0000003a0000003a" role="Primary"/>
+      <eventref hlink="_0000003c0000003c" role="Primary"/>
+      <childof hlink="_0000003e0000003e"/>
     </person>
-    <person handle="_0000003600000036" change="1198222526" id="I0020">
+    <person handle="_0000003f0000003f" change="1198222526" id="I0020">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Carl Emil</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000003700000037" role="Primary"/>
-      <eventref hlink="_0000003800000038" role="Primary"/>
-      <childof hlink="_0000000600000006"/>
+      <eventref hlink="_0000004000000040" role="Primary"/>
+      <eventref hlink="_0000004100000041" role="Primary"/>
+      <childof hlink="_0000000800000008"/>
     </person>
-    <person handle="_0000003900000039" change="1198222526" id="I0021">
+    <person handle="_0000004200000042" change="1198222526" id="I0021">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Hjalmar</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000003a0000003a" role="Primary"/>
-      <eventref hlink="_0000003b0000003b" role="Primary"/>
-      <childof hlink="_0000000600000006"/>
+      <name alt="1" type="Also Known As">
+        <first>James</first>
+        <surname>Smith</surname>
+      </name>
+      <name alt="1" type="Also Known As">
+        <first>Jimmy Smith</first>
+      </name>
+      <eventref hlink="_0000004300000043" role="Primary"/>
+      <eventref hlink="_0000004400000044" role="Primary"/>
+      <eventref hlink="_0000004500000045" role="Primary"/>
+      <eventref hlink="_0000004600000046" role="Primary"/>
+      <eventref hlink="_0000004800000048" role="Primary"/>
+      <childof hlink="_0000000800000008"/>
+      <personref hlink="_0000004700000047" rel="Alias"/>
     </person>
-    <person handle="_0000003c0000003c" change="1198222526" id="I0022">
+    <person handle="_0000004700000047" change="1476889475" id="I0022">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Martin</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000003d0000003d" role="Primary"/>
-      <eventref hlink="_0000003e0000003e" role="Primary"/>
-      <eventref hlink="_0000004000000040" role="Primary"/>
-      <childof hlink="_0000001400000014"/>
-      <parentin hlink="_0000004100000041"/>
-      <noteref hlink="_0000004200000042"/>
+      <eventref hlink="_0000004900000049" role="Primary"/>
+      <eventref hlink="_0000004a0000004a" role="Primary"/>
+      <eventref hlink="_0000004c0000004c" role="Primary"/>
+      <eventref hlink="_0000004f0000004f" role="Primary"/>
+      <attribute type="RESN" value=""/>
+      <childof hlink="_0000001a0000001a"/>
+      <parentin hlink="_0000004d0000004d"/>
+      <noteref hlink="_0000004e0000004e"/>
     </person>
-    <person handle="_0000004300000043" change="1198222526" id="I0023">
+    <person handle="_0000005000000050" change="1198222526" id="I0023">
       <gender>F</gender>
       <name type="Birth Name">
+        <first>Astrid Shermanna</first>
+        <surname>Augusta</surname>
+      </name>
+      <name alt="1" type="Also Known As">
+        <first>Star</first>
+        <surname>Augusta</surname>
+        <datespan start="1889" stop="1898"/>
+      </name>
+      <name alt="1" type="Married Name">
         <first>Astrid Shermanna Augusta</first>
         <surname>Smith</surname>
+        <title>Dr.</title>
       </name>
-      <eventref hlink="_0000004400000044" role="Primary"/>
-      <eventref hlink="_0000004500000045" role="Primary"/>
-      <childof hlink="_0000000600000006"/>
-      <parentin hlink="_0000001800000018"/>
+      <eventref hlink="_0000005100000051" role="Primary"/>
+      <eventref hlink="_0000005200000052" role="Primary"/>
+      <childof hlink="_0000000800000008"/>
+      <parentin hlink="_0000001f0000001f"/>
     </person>
-    <person handle="_0000004600000046" change="1198222526" id="I0024">
+    <person handle="_0000005300000053" change="1198222526" id="I0024">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Gustaf</first>
         <surname>Smith</surname>
         <suffix>Sr.</suffix>
       </name>
-      <eventref hlink="_0000004700000047" role="Primary"/>
-      <eventref hlink="_0000004900000049" role="Primary"/>
-      <eventref hlink="_0000004a0000004a" role="Primary"/>
-      <eventref hlink="_0000004c0000004c" role="Primary"/>
-      <childof hlink="_0000004100000041"/>
-      <parentin hlink="_0000000600000006"/>
+      <eventref hlink="_0000005400000054" role="Primary"/>
+      <eventref hlink="_0000005600000056" role="Primary"/>
+      <eventref hlink="_0000005700000057" role="Primary"/>
+      <eventref hlink="_0000005900000059" role="Primary"/>
+      <childof hlink="_0000004d0000004d"/>
+      <parentin hlink="_0000000800000008"/>
+      <noteref hlink="_0000005a0000005a"/>
+      <citationref hlink="_0000005c0000005c"/>
     </person>
-    <person handle="_0000004d0000004d" change="1198222526" id="I0025">
+    <person handle="_0000005d0000005d" change="1198222526" id="I0025">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Marta</first>
         <surname>Ericsdotter</surname>
       </name>
-      <eventref hlink="_0000004e0000004e" role="Primary"/>
-      <parentin hlink="_0000004f0000004f"/>
+      <name alt="1" type="Married Name">
+        <first>Marta</first>
+        <surname>Smith</surname>
+      </name>
+      <eventref hlink="_0000005e0000005e" role="Primary"/>
+      <lds_ord type="confirmation">
+        <dateval val="1790"/>
+      </lds_ord>
+      <lds_ord type="endowment">
+        <dateval val="1795"/>
+      </lds_ord>
+      <lds_ord type="sealed_to_parents">
+        <dateval val="1796"/>
+        <place hlink="_0000006000000060"/>
+        <sealed_to hlink="_0000005f0000005f"/>
+      </lds_ord>
+      <attribute type="Skills" value="Housekeeper"/>
+      <parentin hlink="_0000005f0000005f"/>
     </person>
-    <person handle="_0000005000000050" change="1198222526" id="I0026">
+    <person handle="_0000006100000061" change="1198222526" id="I0026">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Kirsti Marie</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000005100000051" role="Primary"/>
-      <eventref hlink="_0000005200000052" role="Primary"/>
-      <childof hlink="_0000000600000006"/>
-      <parentin hlink="_0000005300000053"/>
+      <eventref hlink="_0000006200000062" role="Primary"/>
+      <eventref hlink="_0000006300000063" role="Primary"/>
+      <childof hlink="_0000000800000008"/>
+      <parentin hlink="_0000006400000064"/>
     </person>
-    <person handle="_0000005400000054" change="1198222526" id="I0027">
+    <person handle="_0000006500000065" change="1198222526" id="I0027">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Ingeman</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000005500000055" role="Primary"/>
-      <parentin hlink="_0000004f0000004f"/>
+      <eventref hlink="_0000006600000066" role="Primary"/>
+      <parentin hlink="_0000005f0000005f"/>
     </person>
-    <person handle="_0000005600000056" change="1198222526" id="I0028">
+    <person handle="_0000006700000067" change="1198222526" id="I0028">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Anna</first>
         <surname>Streiffert</surname>
       </name>
-      <eventref hlink="_0000005700000057" role="Primary"/>
-      <eventref hlink="_0000005900000059" role="Primary"/>
-      <parentin hlink="_0000005a0000005a"/>
+      <eventref hlink="_0000006800000068" role="Primary"/>
+      <eventref hlink="_0000006a0000006a" role="Primary"/>
+      <parentin hlink="_0000006b0000006b"/>
     </person>
-    <person handle="_0000005b0000005b" change="1198222526" id="I0029">
+    <person handle="_0000006c0000006c" change="1198222526" id="I0029">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Craig Peter</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000005c0000005c" role="Primary"/>
-      <eventref hlink="_0000005d0000005d" role="Primary"/>
-      <childof hlink="_0000000a0000000a"/>
+      <eventref hlink="_0000006d0000006d" role="Primary"/>
+      <eventref hlink="_0000006e0000006e" role="Primary"/>
+      <childof hlink="_0000000e0000000e"/>
     </person>
-    <person handle="_0000005f0000005f" change="1198222526" id="I0003">
+    <person handle="_0000007000000070" change="1198222526" id="I0003">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Magnes</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000006000000060" role="Primary"/>
-      <eventref hlink="_0000006200000062" role="Primary"/>
-      <childof hlink="_0000004100000041"/>
-      <parentin hlink="_0000005a0000005a"/>
+      <eventref hlink="_0000007100000071" role="Primary"/>
+      <eventref hlink="_0000007300000073" role="Primary"/>
+      <childof hlink="_0000004d0000004d"/>
+      <parentin hlink="_0000006b0000006b"/>
     </person>
-    <person handle="_0000006300000063" change="1198222526" id="I0030">
+    <person handle="_0000007400000074" change="1198222526" id="I0030">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Janice Ann</first>
         <surname>Adams</surname>
       </name>
-      <eventref hlink="_0000006400000064" role="Primary"/>
-      <eventref hlink="_0000006600000066" role="Primary"/>
-      <eventref hlink="_0000006700000067" role="Primary"/>
-      <parentin hlink="_0000003500000035"/>
+      <eventref hlink="_0000007500000075" role="Primary"/>
+      <eventref hlink="_0000007700000077" role="Primary"/>
+      <eventref hlink="_0000007800000078" role="Primary"/>
+      <parentin hlink="_0000003e0000003e"/>
     </person>
-    <person handle="_0000006800000068" change="1198222526" id="I0031">
+    <person handle="_0000007900000079" change="1198222526" id="I0031">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Marjorie</first>
         <surname>Ohman</surname>
       </name>
-      <eventref hlink="_0000006900000069" role="Primary"/>
-      <eventref hlink="_0000006b0000006b" role="Primary"/>
-      <parentin hlink="_0000001f0000001f"/>
+      <eventref hlink="_0000007a0000007a" role="Primary"/>
+      <eventref hlink="_0000007c0000007c" role="Primary"/>
+      <parentin hlink="_0000002800000028"/>
     </person>
-    <person handle="_0000006c0000006c" change="1198222526" id="I0032">
+    <person handle="_0000007d0000007d" change="1198222526" id="I0032">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Darcy</first>
         <surname>Horne</surname>
       </name>
-      <eventref hlink="_0000006d0000006d" role="Primary"/>
-      <parentin hlink="_0000002f0000002f"/>
+      <eventref hlink="_0000007e0000007e" role="Primary"/>
+      <parentin hlink="_0000003800000038"/>
     </person>
-    <person handle="_0000006f0000006f" change="1198222526" id="I0033">
+    <person handle="_0000008000000080" change="1198222526" id="I0033">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Lloyd</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000007000000070" role="Primary"/>
-      <childof hlink="_0000000f0000000f"/>
-      <parentin hlink="_0000000a0000000a"/>
+      <eventref hlink="_0000008100000081" role="Primary"/>
+      <childof hlink="_0000001400000014"/>
+      <parentin hlink="_0000000e0000000e"/>
     </person>
-    <person handle="_0000007100000071" change="1198222526" id="I0034">
+    <person handle="_0000008200000082" change="1198222526" id="I0034">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Alice Paula</first>
         <surname>Perkins</surname>
       </name>
-      <eventref hlink="_0000007200000072" role="Primary"/>
-      <parentin hlink="_0000002b0000002b"/>
+      <eventref hlink="_0000008300000083" role="Primary"/>
+      <parentin hlink="_0000003400000034"/>
     </person>
-    <person handle="_0000007300000073" change="1198222526" id="I0035">
+    <person handle="_0000008400000084" change="1198222526" id="I0035">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Lars Peter</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000007400000074" role="Primary"/>
-      <eventref hlink="_0000007600000076" role="Primary"/>
-      <childof hlink="_0000002f0000002f"/>
+      <eventref hlink="_0000008500000085" role="Primary"/>
+      <eventref hlink="_0000008700000087" role="Primary"/>
+      <childof hlink="_0000003800000038"/>
     </person>
-    <person handle="_0000007700000077" change="1198222526" id="I0036">
+    <person handle="_0000008800000088" change="1198222526" id="I0036">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Elna</first>
         <surname>Jefferson</surname>
       </name>
-      <eventref hlink="_0000007800000078" role="Primary"/>
-      <eventref hlink="_0000007900000079" role="Primary"/>
-      <eventref hlink="_0000007a0000007a" role="Primary"/>
-      <parentin hlink="_0000001400000014"/>
+      <eventref hlink="_0000008900000089" role="Primary"/>
+      <eventref hlink="_0000008a0000008a" role="Primary"/>
+      <eventref hlink="_0000008b0000008b" role="Primary"/>
+      <parentin hlink="_0000001a0000001a"/>
     </person>
-    <person handle="_0000007b0000007b" change="1198222526" id="I0037">
+    <person handle="_0000008c0000008c" change="1198222526" id="I0037">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Edwin Michael</first>
         <surname>Smith</surname>
-        <citationref hlink="_0000007d0000007d"/>
+        <citationref hlink="_0000008f0000008f"/>
       </name>
-      <eventref hlink="_0000007e0000007e" role="Primary"/>
-      <eventref hlink="_0000008200000082" role="Primary">
+      <eventref hlink="_0000009000000090" role="Primary"/>
+      <eventref hlink="_0000009400000094" role="Primary">
         <attribute type="Age" value="23"/>
       </eventref>
-      <eventref hlink="_0000008400000084" role="Primary"/>
-      <eventref hlink="_0000008600000086" role="Primary"/>
-      <childof hlink="_0000002b0000002b"/>
-      <parentin hlink="_0000003500000035"/>
+      <eventref hlink="_0000009600000096" role="Primary"/>
+      <eventref hlink="_0000009800000098" role="Primary"/>
+      <childof hlink="_0000003400000034"/>
+      <parentin hlink="_0000003e0000003e"/>
     </person>
-    <person handle="_0000008700000087" change="1198222526" id="I0038">
+    <person handle="_0000009900000099" change="1198222526" id="I0038">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Kerstina</first>
         <surname>Hansdotter</surname>
       </name>
-      <eventref hlink="_0000008800000088" role="Primary"/>
-      <eventref hlink="_0000008a0000008a" role="Primary"/>
-      <parentin hlink="_0000004100000041"/>
+      <eventref hlink="_0000009a0000009a" role="Primary"/>
+      <eventref hlink="_0000009c0000009c" role="Primary"/>
+      <parentin hlink="_0000004d0000004d"/>
     </person>
-    <person handle="_0000008b0000008b" change="1198222526" id="I0039">
+    <person handle="_0000009d0000009d" change="1198222526" id="I0039">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Martin</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000008c0000008c" role="Primary"/>
-      <eventref hlink="_0000008e0000008e" role="Primary"/>
-      <childof hlink="_0000004f0000004f"/>
-      <parentin hlink="_0000001400000014"/>
+      <eventref hlink="_0000009e0000009e" role="Primary"/>
+      <eventref hlink="_000000a0000000a0" role="Primary"/>
+      <childof hlink="_0000005f0000005f"/>
+      <parentin hlink="_0000001a0000001a"/>
     </person>
-    <person handle="_0000008f0000008f" change="1198222526" id="I0004">
+    <person handle="_000000a1000000a1" change="1198222526" id="I0004">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Ingeman</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000009000000090" role="Primary"/>
-      <childof hlink="_0000001400000014"/>
+      <eventref hlink="_000000a2000000a2" role="Primary"/>
+      <childof hlink="_0000001a0000001a"/>
     </person>
-    <person handle="_0000009100000091" change="1198222526" id="I0040">
+    <person handle="_000000a3000000a3" change="1198222526" id="I0040">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Marjorie Alice</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000009200000092" role="Primary"/>
-      <childof hlink="_0000002b0000002b"/>
+      <eventref hlink="_000000a4000000a4" role="Primary"/>
+      <childof hlink="_0000003400000034"/>
     </person>
-    <person handle="_0000009300000093" change="1198222526" id="I0041">
+    <person handle="_000000a5000000a5" change="1198222526" id="I0041">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Janis Elaine</first>
         <surname>Green</surname>
       </name>
-      <eventref hlink="_0000009400000094" role="Primary"/>
-      <parentin hlink="_0000000a0000000a"/>
+      <eventref hlink="_000000a6000000a6" role="Primary"/>
+      <parentin hlink="_0000000e0000000e"/>
     </person>
-    <person handle="_0000009500000095" change="1198222526" id="I0005">
+    <person handle="_000000a7000000a7" change="1198222526" id="I0005">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Mason Michael</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000009600000096" role="Primary"/>
-      <eventref hlink="_0000009700000097" role="Primary"/>
-      <childof hlink="_0000003500000035"/>
+      <eventref hlink="_000000a8000000a8" role="Primary"/>
+      <eventref hlink="_000000a9000000a9" role="Primary"/>
+      <childof hlink="_0000003e0000003e"/>
     </person>
-    <person handle="_0000009800000098" change="1198222526" id="I0006">
+    <person handle="_000000aa000000aa" change="1198222526" id="I0006">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Edwin</first>
         <surname>Willard</surname>
       </name>
-      <eventref hlink="_0000009900000099" role="Primary"/>
-      <parentin hlink="_0000005300000053"/>
+      <eventref hlink="_000000ab000000ab" role="Primary"/>
+      <parentin hlink="_0000006400000064"/>
     </person>
-    <person handle="_0000009a0000009a" change="1198222526" id="I0007">
+    <person handle="_000000ac000000ac" change="1198222526" id="I0007">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Ingar</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000009b0000009b" role="Primary"/>
-      <childof hlink="_0000001400000014"/>
+      <eventref hlink="_000000ad000000ad" role="Primary"/>
+      <childof hlink="_0000001a0000001a"/>
     </person>
-    <person handle="_0000009c0000009c" change="1198222526" id="I0008">
+    <person handle="_000000ae000000ae" change="1198222526" id="I0008">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Hjalmar</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000009d0000009d" role="Primary"/>
-      <eventref hlink="_0000009e0000009e" role="Primary"/>
-      <eventref hlink="_0000009f0000009f" role="Primary"/>
-      <eventref hlink="_000000a1000000a1" role="Primary"/>
-      <childof hlink="_0000000600000006"/>
-      <parentin hlink="_0000001f0000001f"/>
-      <noteref hlink="_000000a2000000a2"/>
+      <eventref hlink="_000000af000000af" role="Primary"/>
+      <eventref hlink="_000000b0000000b0" role="Primary"/>
+      <eventref hlink="_000000b1000000b1" role="Primary"/>
+      <eventref hlink="_000000b3000000b3" role="Primary"/>
+      <childof hlink="_0000000800000008"/>
+      <parentin hlink="_0000002800000028"/>
+      <noteref hlink="_000000b4000000b4"/>
     </person>
-    <person handle="_000000a3000000a3" change="1198222526" id="I0009">
+    <person handle="_000000b5000000b5" change="1198222526" id="I0009">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Emil</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_000000a4000000a4" role="Primary"/>
-      <childof hlink="_0000004100000041"/>
+      <eventref hlink="_000000b6000000b6" role="Primary"/>
+      <childof hlink="_0000004d0000004d"/>
     </person>
   </people>
   <families>
-    <family handle="_0000000600000006" change="1198222526" id="F0003">
+    <family handle="_0000000800000008" change="1198222526" id="F0003">
       <rel type="Married"/>
-      <father hlink="_0000004600000046"/>
+      <father hlink="_0000005300000053"/>
       <mother hlink="_0000000100000001"/>
-      <eventref hlink="_000000b1000000b1" role="Family"/>
+      <eventref hlink="_000000ca000000ca" role="Family"/>
+      <childref hlink="_0000006100000061"/>
       <childref hlink="_0000005000000050"/>
-      <childref hlink="_0000004300000043"/>
-      <childref hlink="_0000003900000039"/>
-      <childref hlink="_0000009c0000009c"/>
-      <childref hlink="_0000002000000020"/>
-      <childref hlink="_0000003600000036"/>
-      <childref hlink="_0000000b0000000b"/>
-    </family>
-    <family handle="_0000000a0000000a" change="1198222526" id="F0008">
-      <rel type="Married"/>
-      <father hlink="_0000006f0000006f"/>
-      <mother hlink="_0000009300000093"/>
-      <eventref hlink="_000000b6000000b6" role="Family"/>
-      <childref hlink="_0000002c0000002c" mrel="Adopted" frel="Adopted"/>
-      <childref hlink="_0000000700000007"/>
-      <childref hlink="_0000005b0000005b"/>
-    </family>
-    <family handle="_0000000f0000000f" change="1198222526" id="F0009">
-      <rel type="Unknown"/>
-      <father hlink="_0000000b0000000b"/>
-      <mother hlink="_0000002600000026"/>
-      <childref hlink="_0000006f0000006f"/>
-    </family>
-    <family handle="_0000001000000010" change="1198222526" id="F0014">
-      <rel type="Unknown"/>
-      <father hlink="_0000000b0000000b"/>
-      <mother hlink="_0000002300000023"/>
-    </family>
-    <family handle="_0000001400000014" change="1198222526" id="F0000">
-      <rel type="Married"/>
-      <father hlink="_0000008b0000008b"/>
-      <mother hlink="_0000007700000077"/>
-      <eventref hlink="_000000a5000000a5" role="Family"/>
-      <childref hlink="_0000001100000011"/>
-      <childref hlink="_0000009a0000009a"/>
-      <childref hlink="_0000008f0000008f"/>
-      <childref hlink="_0000003c0000003c"/>
-    </family>
-    <family handle="_0000001800000018" change="1198222526" id="F0005">
-      <rel type="Married"/>
-      <father hlink="_0000001500000015"/>
-      <mother hlink="_0000004300000043"/>
-      <eventref hlink="_000000b3000000b3" role="Family"/>
-    </family>
-    <family handle="_0000001b0000001b" change="1198222526" id="F0007">
-      <rel type="Married"/>
-      <father hlink="_0000002000000020"/>
-      <mother hlink="_0000001900000019"/>
-      <eventref hlink="_000000b5000000b5" role="Family"/>
-    </family>
-    <family handle="_0000001f0000001f" change="1198222526" id="F0006">
-      <rel type="Married"/>
-      <father hlink="_0000009c0000009c"/>
-      <mother hlink="_0000006800000068"/>
-      <eventref hlink="_000000b4000000b4" role="Family"/>
+      <childref hlink="_0000004200000042"/>
+      <childref hlink="_000000ae000000ae"/>
       <childref hlink="_0000002900000029"/>
-      <childref hlink="_0000001c0000001c"/>
+      <childref hlink="_0000003f0000003f"/>
+      <childref hlink="_0000001000000010"/>
     </family>
-    <family handle="_0000002b0000002b" change="1198222526" id="F0012">
+    <family handle="_0000000e0000000e" change="1198222526" id="F0008">
+      <rel type="Married"/>
+      <father hlink="_0000008000000080"/>
+      <mother hlink="_000000a5000000a5"/>
+      <eventref hlink="_000000cf000000cf" role="Family"/>
+      <childref hlink="_0000003500000035" mrel="Adopted" frel="Adopted"/>
+      <childref hlink="_0000000a0000000a"/>
+      <childref hlink="_0000006c0000006c"/>
+    </family>
+    <family handle="_0000001400000014" change="1198222526" id="F0009">
+      <rel type="Unknown"/>
+      <father hlink="_0000001000000010"/>
+      <mother hlink="_0000002f0000002f"/>
+      <childref hlink="_0000008000000080"/>
+    </family>
+    <family handle="_0000001500000015" change="1198222526" id="F0014">
+      <rel type="Unknown"/>
+      <father hlink="_0000001000000010"/>
+      <mother hlink="_0000002c0000002c"/>
+    </family>
+    <family handle="_0000001a0000001a" change="1198222526" id="F0000">
+      <rel type="Married"/>
+      <father hlink="_0000009d0000009d"/>
+      <mother hlink="_0000008800000088"/>
+      <eventref hlink="_000000b7000000b7" role="Family"/>
+      <childref hlink="_0000001700000017"/>
+      <childref hlink="_000000ac000000ac"/>
+      <childref hlink="_000000a1000000a1"/>
+      <childref hlink="_0000004700000047"/>
+    </family>
+    <family handle="_0000001f0000001f" change="1198222526" id="F0005">
+      <rel type="Married"/>
+      <father hlink="_0000001c0000001c"/>
+      <mother hlink="_0000005000000050"/>
+      <eventref hlink="_000000cc000000cc" role="Family"/>
+    </family>
+    <family handle="_0000002300000023" change="1198222526" id="F0007">
       <rel type="Married"/>
       <father hlink="_0000002900000029"/>
-      <mother hlink="_0000007100000071"/>
-      <eventref hlink="_000000aa000000aa" role="Family"/>
-      <childref hlink="_0000009100000091"/>
-      <childref hlink="_0000007b0000007b"/>
+      <mother hlink="_0000002100000021"/>
+      <eventref hlink="_000000ce000000ce" role="Family"/>
     </family>
-    <family handle="_0000002f0000002f" change="1198222526" id="F0010">
+    <family handle="_0000002800000028" change="1198222526" id="F0006">
       <rel type="Married"/>
-      <father hlink="_0000002c0000002c"/>
-      <mother hlink="_0000006c0000006c"/>
-      <eventref hlink="_000000a7000000a7" role="Family"/>
-      <childref hlink="_0000007300000073" mrel="Adopted" frel="Adopted"/>
+      <father hlink="_000000ae000000ae"/>
+      <mother hlink="_0000007900000079"/>
+      <eventref hlink="_000000cd000000cd" role="Family"/>
+      <childref hlink="_0000003200000032"/>
+      <childref hlink="_0000002500000025"/>
     </family>
-    <family handle="_0000003500000035" change="1198222526" id="F0013">
+    <family handle="_0000003400000034" change="1198222526" id="F0012">
       <rel type="Married"/>
-      <father hlink="_0000007b0000007b"/>
-      <mother hlink="_0000006300000063"/>
-      <eventref hlink="_000000ad000000ad" role="Family"/>
-      <eventref hlink="_000000af000000af" role="Family"/>
-      <childref hlink="_0000009500000095"/>
-      <childref hlink="_0000003000000030"/>
-    </family>
-    <family handle="_0000004100000041" change="1198222526" id="F0002">
-      <rel type="Married"/>
-      <father hlink="_0000003c0000003c"/>
-      <mother hlink="_0000008700000087"/>
-      <eventref hlink="_000000b0000000b0" role="Family"/>
-      <childref hlink="_0000005f0000005f"/>
+      <father hlink="_0000003200000032"/>
+      <mother hlink="_0000008200000082"/>
+      <eventref hlink="_000000c1000000c1" role="Family"/>
+      <lds_ord type="sealed_to_spouse">
+        <place hlink="_000000c3000000c3"/>
+      </lds_ord>
+      <objref hlink="_000000c4000000c4"/>
       <childref hlink="_000000a3000000a3"/>
-      <childref hlink="_0000004600000046"/>
+      <childref hlink="_0000008c0000008c"/>
+      <attribute type="Number of Children" value="2"/>
+      <noteref hlink="_000000c5000000c5"/>
     </family>
-    <family handle="_0000004f0000004f" change="1198222526" id="F0001">
+    <family handle="_0000003800000038" change="1198222526" id="F0010">
       <rel type="Married"/>
-      <father hlink="_0000005400000054"/>
-      <mother hlink="_0000004d0000004d"/>
-      <eventref hlink="_000000a6000000a6" role="Family"/>
-      <childref hlink="_0000008b0000008b"/>
+      <father hlink="_0000003500000035"/>
+      <mother hlink="_0000007d0000007d"/>
+      <eventref hlink="_000000b9000000b9" role="Family"/>
+      <childref hlink="_0000008400000084" mrel="Adopted" frel="Adopted"/>
+      <attribute type="_STAT" value=""/>
     </family>
-    <family handle="_0000005300000053" change="1198222526" id="F0004">
+    <family handle="_0000003e0000003e" change="1198222526" id="F0013">
       <rel type="Married"/>
-      <father hlink="_0000009800000098"/>
-      <mother hlink="_0000005000000050"/>
-      <eventref hlink="_000000b2000000b2" role="Family"/>
+      <father hlink="_0000008c0000008c"/>
+      <mother hlink="_0000007400000074"/>
+      <eventref hlink="_000000c6000000c6" role="Family"/>
+      <eventref hlink="_000000c8000000c8" role="Family"/>
+      <childref hlink="_000000a7000000a7"/>
+      <childref hlink="_0000003900000039"/>
     </family>
-    <family handle="_0000005a0000005a" change="1198222526" id="F0011">
+    <family handle="_0000004d0000004d" change="1198222526" id="F0002">
       <rel type="Married"/>
-      <father hlink="_0000005f0000005f"/>
-      <mother hlink="_0000005600000056"/>
-      <eventref hlink="_000000a9000000a9" role="Family"/>
+      <father hlink="_0000004700000047"/>
+      <mother hlink="_0000009900000099"/>
+      <eventref hlink="_000000c9000000c9" role="Family"/>
+      <childref hlink="_0000007000000070"/>
+      <childref hlink="_000000b5000000b5"/>
+      <childref hlink="_0000005300000053"/>
+    </family>
+    <family handle="_0000005f0000005f" change="1198222526" id="F0001">
+      <rel type="Married"/>
+      <father hlink="_0000006500000065"/>
+      <mother hlink="_0000005d0000005d"/>
+      <eventref hlink="_000000b8000000b8" role="Family"/>
+      <childref hlink="_0000009d0000009d"/>
+    </family>
+    <family handle="_0000006400000064" change="1198222526" id="F0004">
+      <rel type="Married"/>
+      <father hlink="_000000aa000000aa"/>
+      <mother hlink="_0000006100000061"/>
+      <eventref hlink="_000000cb000000cb" role="Family"/>
+    </family>
+    <family handle="_0000006b0000006b" change="1198222526" id="F0011">
+      <rel type="Married"/>
+      <father hlink="_0000007000000070"/>
+      <mother hlink="_0000006700000067"/>
+      <eventref hlink="_000000bb000000bb" role="Family"/>
+      <eventref hlink="_000000bf000000bf" role="Primary"/>
+      <noteref hlink="_000000c0000000c0"/>
     </family>
   </families>
   <citations>
-    <citation handle="_0000007d0000007d" change="1472500318" id="C0000">
+    <citation handle="_0000005c0000005c" change="1476889475" id="C0000">
       <confidence>2</confidence>
-      <sourceref hlink="_0000007c0000007c"/>
+      <sourceref hlink="_0000005b0000005b"/>
     </citation>
-    <citation handle="_0000008000000080" change="1472500318" id="C0001">
+    <citation handle="_0000008f0000008f" change="1476889475" id="C0001">
       <confidence>2</confidence>
-      <sourceref hlink="_0000007f0000007f"/>
+      <noteref hlink="_0000008e0000008e"/>
+      <sourceref hlink="_0000008d0000008d"/>
     </citation>
-    <citation handle="_000000ac000000ac" change="1472500318" id="C0002">
+    <citation handle="_0000009200000092" change="1476889475" id="C0002">
       <confidence>2</confidence>
-      <sourceref hlink="_000000ab000000ab"/>
+      <sourceref hlink="_0000009100000091"/>
+    </citation>
+    <citation handle="_000000be000000be" change="1476889475" id="C0003">
+      <confidence>2</confidence>
+      <sourceref hlink="_000000bd000000bd"/>
+    </citation>
+    <citation handle="_000000c2000000c2" change="1476889475" id="C0004">
+      <confidence>2</confidence>
+      <sourceref hlink="_000000bd000000bd"/>
     </citation>
   </citations>
   <sources>
-    <source handle="_0000007c0000007c" change="1198222526" id="S0001">
-      <stitle>Birth Certificate</stitle>
-    </source>
-    <source handle="_0000007f0000007f" change="1198222526" id="S0003">
-      <stitle>Birth, Death and Marriage Records</stitle>
-      <noteref hlink="_000000ba000000ba"/>
-      <reporef hlink="_000000b7000000b7" callno="CA-123-LL-456_Num/ber" medium="Film"/>
-    </source>
-    <source handle="_000000ab000000ab" change="1198222526" id="S0000">
-      <stitle>Marriage Certificae</stitle>
-      <noteref hlink="_000000b8000000b8"/>
-      <reporef hlink="_000000b7000000b7" callno="what-321-ever" medium="Photo"/>
-    </source>
-    <source handle="_000000b9000000b9" change="1198222526" id="S0002">
+    <source handle="_0000005b0000005b" change="1198222526" id="S0002">
       <stitle>Birth Records</stitle>
+      <reporef hlink="_000000d5000000d5" medium="Book">
+        <noteref hlink="_000000d6000000d6"/>
+      </reporef>
+    </source>
+    <source handle="_0000008d0000008d" change="1198222526" id="S0001">
+      <stitle>Birth Certificate</stitle>
+      <noteref hlink="_000000d4000000d4"/>
+      <reporef hlink="_000000d2000000d2" medium="Book">
+        <noteref hlink="_000000d3000000d3"/>
+      </reporef>
+    </source>
+    <source handle="_0000009100000091" change="1198222526" id="S0003">
+      <stitle>Birth, Death and Marriage Records</stitle>
+      <noteref hlink="_000000d7000000d7"/>
+      <reporef hlink="_000000d0000000d0" callno="CA-123-LL-456_Num/ber" medium="Film"/>
+    </source>
+    <source handle="_000000bd000000bd" change="1198222526" id="S0000">
+      <stitle>Marriage Certificae</stitle>
+      <noteref hlink="_000000d1000000d1"/>
+      <reporef hlink="_000000d0000000d0" callno="what-321-ever" medium="Photo"/>
     </source>
   </sources>
   <places>
-    <placeobj handle="_0000000300000003" change="1472500318" id="P0000" type="Unknown">
+    <placeobj handle="_0000000400000004" change="1476889475" id="P0000" type="Unknown">
       <ptitle>Löderup, Malmöhus Län, Sweden</ptitle>
       <pname value="Löderup, Malmöhus Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000000500000005" change="1472500318" id="P0001" type="Unknown">
+    <placeobj handle="_0000000700000007" change="1476889475" id="P0001" type="Unknown">
       <ptitle>Sparks, Washoe Co., NV</ptitle>
       <pname value="Sparks, Washoe Co., NV"/>
     </placeobj>
-    <placeobj handle="_0000000900000009" change="1472500318" id="P0002" type="Unknown">
+    <placeobj handle="_0000000d0000000d" change="1476889475" id="P0002" type="Unknown">
       <ptitle>San Francisco, San Francisco Co., CA</ptitle>
       <pname value="San Francisco, San Francisco Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000000d0000000d" change="1472500318" id="P0003" type="Unknown">
+    <placeobj handle="_0000001200000012" change="1476889475" id="P0003" type="Unknown">
       <ptitle>Rønne, Bornholm, Denmark</ptitle>
       <pname value="Rønne, Bornholm, Denmark"/>
+      <objref hlink="_000000bc000000bc"/>
+      <citationref hlink="_000000be000000be"/>
     </placeobj>
-    <placeobj handle="_0000001300000013" change="1472500318" id="P0004" type="Unknown">
+    <placeobj handle="_0000001900000019" change="1476889475" id="P0004" type="Unknown">
       <ptitle>Gladsax, Kristianstad Län, Sweden</ptitle>
       <pname value="Gladsax, Kristianstad Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000001e0000001e" change="1472500318" id="P0005" type="Unknown">
+    <placeobj handle="_0000002700000027" change="1476889475" id="P0005" type="Unknown">
       <ptitle>Reno, Washoe Co., NV</ptitle>
       <pname value="Reno, Washoe Co., NV"/>
     </placeobj>
-    <placeobj handle="_0000003200000032" change="1472500318" id="P0006" type="Unknown">
+    <placeobj handle="_0000003b0000003b" change="1476889475" id="P0006" type="Unknown">
       <ptitle>Hayward, Alameda Co., CA</ptitle>
       <pname value="Hayward, Alameda Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000003400000034" change="1472500318" id="P0007" type="Unknown">
+    <placeobj handle="_0000003d0000003d" change="1476889475" id="P0007" type="Unknown">
       <ptitle>Community Presbyterian Church, Danville, CA</ptitle>
       <pname value="Community Presbyterian Church, Danville, CA"/>
     </placeobj>
-    <placeobj handle="_0000003f0000003f" change="1472500318" id="P0008" type="Unknown">
+    <placeobj handle="_0000004b0000004b" change="1476889475" id="P0008" type="Unknown">
       <ptitle>Sweden</ptitle>
       <pname value="Sweden"/>
     </placeobj>
-    <placeobj handle="_0000004800000048" change="1472500318" id="P0009" type="Unknown">
+    <placeobj handle="_0000005500000055" change="1476889475" id="P0009" type="Unknown">
       <ptitle>Grostorp, Kristianstad Län, Sweden</ptitle>
       <pname value="Grostorp, Kristianstad Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000004b0000004b" change="1472500318" id="P0010" type="Unknown">
+    <placeobj handle="_0000005800000058" change="1476889475" id="P0010" type="Unknown">
       <ptitle>Copenhagen, Denmark</ptitle>
       <pname value="Copenhagen, Denmark"/>
     </placeobj>
-    <placeobj handle="_0000005800000058" change="1472500318" id="P0011" type="Unknown">
+    <placeobj handle="_0000006000000060" change="1476889475" id="P0011" type="Unknown">
+      <ptitle>Sweden</ptitle>
+      <pname value="Sweden"/>
+    </placeobj>
+    <placeobj handle="_0000006900000069" change="1476889475" id="P0012" type="Unknown">
       <ptitle>Hoya/Jona/Hoia, Sweden</ptitle>
       <pname value="Hoya/Jona/Hoia, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000006100000061" change="1472500318" id="P0012" type="Unknown">
+    <placeobj handle="_0000007200000072" change="1476889475" id="P0013" type="Unknown">
       <ptitle>Simrishamn, Kristianstad Län, Sweden</ptitle>
       <pname value="Simrishamn, Kristianstad Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000006500000065" change="1472500318" id="P0013" type="Unknown">
+    <placeobj handle="_0000007600000076" change="1476889475" id="P0014" type="Unknown">
       <ptitle>Fremont, Alameda Co., CA</ptitle>
       <pname value="Fremont, Alameda Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000006a0000006a" change="1472500318" id="P0014" type="Unknown">
+    <placeobj handle="_0000007b0000007b" change="1476889475" id="P0015" type="Unknown">
       <ptitle>Denver, Denver Co., CO</ptitle>
       <pname value="Denver, Denver Co., CO"/>
     </placeobj>
-    <placeobj handle="_0000006e0000006e" change="1472500318" id="P0015" type="Unknown">
+    <placeobj handle="_0000007f0000007f" change="1476889475" id="P0016" type="Unknown">
       <ptitle>Sacramento, Sacramento Co., CA</ptitle>
       <pname value="Sacramento, Sacramento Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000007500000075" change="1472500318" id="P0016" type="Unknown">
+    <placeobj handle="_0000008600000086" change="1476889475" id="P0017" type="Unknown">
       <ptitle>Santa Rosa, Sonoma Co., CA</ptitle>
       <pname value="Santa Rosa, Sonoma Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000008100000081" change="1472500318" id="P0017" type="Unknown">
+    <placeobj handle="_0000009300000093" change="1476889475" id="P0018" type="Unknown">
       <ptitle>San Jose, Santa Clara Co., CA</ptitle>
       <pname value="San Jose, Santa Clara Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000008500000085" change="1472500318" id="P0018" type="Unknown">
+    <placeobj handle="_0000009700000097" change="1476889475" id="P0019" type="Unknown">
       <ptitle>UC Berkeley</ptitle>
       <pname value="UC Berkeley"/>
     </placeobj>
-    <placeobj handle="_0000008900000089" change="1472500318" id="P0019" type="Unknown">
+    <placeobj handle="_0000009b0000009b" change="1476889475" id="P0020" type="Unknown">
       <ptitle>Smestorp, Kristianstad Län, Sweden</ptitle>
       <pname value="Smestorp, Kristianstad Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000008d0000008d" change="1472500318" id="P0020" type="Unknown">
+    <placeobj handle="_0000009f0000009f" change="1476889475" id="P0021" type="Unknown">
       <ptitle>Tommarp, Kristianstad Län, Sweden</ptitle>
       <pname value="Tommarp, Kristianstad Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_000000a0000000a0" change="1472500318" id="P0021" type="Unknown">
+    <placeobj handle="_000000b2000000b2" change="1476889475" id="P0022" type="Unknown">
       <ptitle>Rønne Bornholm, Denmark</ptitle>
       <pname value="Rønne Bornholm, Denmark"/>
     </placeobj>
-    <placeobj handle="_000000a8000000a8" change="1472500318" id="P0022" type="Unknown">
+    <placeobj handle="_000000ba000000ba" change="1476889475" id="P0023" type="Unknown">
       <ptitle>Woodland, Yolo Co., CA</ptitle>
       <pname value="Woodland, Yolo Co., CA"/>
     </placeobj>
-    <placeobj handle="_000000ae000000ae" change="1472500318" id="P0023" type="Unknown">
+    <placeobj handle="_000000c3000000c3" change="1476889475" id="P0024" type="Unknown">
+      <ptitle>Sparks, Washoe Co., NV</ptitle>
+      <pname value="Sparks, Washoe Co., NV"/>
+    </placeobj>
+    <placeobj handle="_000000c7000000c7" change="1476889475" id="P0025" type="Unknown">
       <ptitle>San Ramon, Conta Costa Co., CA</ptitle>
       <pname value="San Ramon, Conta Costa Co., CA"/>
     </placeobj>
   </places>
+  <objects>
+    <object handle="_000000bc000000bc" change="1476889475" id="O0000">
+      <file src="Magnes&amp;Anna_smiths_marr_cert.jpg" mime="unknown" description="Magnes&amp;Anna_smiths_marr_cert.jpg"/>
+    </object>
+    <object handle="_000000c4000000c4" change="1476889475" id="O0001">
+      <file src="John&amp;Alice_smiths_marr_cert.jpg" mime="unknown" description="John&amp;Alice_smiths_marr_cert.jpg"/>
+    </object>
+  </objects>
   <repositories>
-    <repository handle="_000000b7000000b7" change="1472500318" id="R0002">
+    <repository handle="_000000d0000000d0" change="1476889475" id="R0002">
       <rname>New York Public Library</rname>
       <type>Library</type>
       <address>
@@ -1230,7 +1351,14 @@
         <postal>11111</postal>
       </address>
     </repository>
-    <repository handle="_000000bb000000bb" change="1472500318" id="R0003">
+    <repository handle="_000000d2000000d2" change="1476889475" id="R0000">
+      <rname>Invalid REPO Name</rname>
+      <type>Library</type>
+    </repository>
+    <repository handle="_000000d5000000d5" change="1476889475" id="R0001">
+      <type>Library</type>
+    </repository>
+    <repository handle="_000000d8000000d8" change="1476889475" id="R0003">
       <rname>Aunt Martha's Attic</rname>
       <type>Library</type>
       <address>
@@ -1240,34 +1368,93 @@
         <country>USA</country>
       </address>
       <url  href="http://library.gramps-project.org" type="Web Home"/>
-      <noteref hlink="_000000bc000000bc"/>
+      <noteref hlink="_000000d9000000d9"/>
     </repository>
   </repositories>
   <notes>
-    <note handle="_0000004200000042" change="1472500318" id="N0002" type="Person Note">
+    <note handle="_0000000200000002" change="1476889475" id="N0000" type="General">
+      <text>Hans daughter? N0000</text>
+    </note>
+    <note handle="_0000000600000006" change="1476889475" id="N0001" type="Event Note">
+      <text>Her eulogy was great! N0001</text>
+    </note>
+    <note handle="_0000000900000009" change="1476889475" id="N0002" type="Person Note">
+      <text>Inline note should get ID N0002</text>
+    </note>
+    <note handle="_0000000b0000000b" change="1476889475" id="N0007" type="General">
+      <text>'Smith': a very common name</text>
+    </note>
+    <note handle="_0000000f0000000f" change="1476889475" id="N0003" type="Person Note">
+      <text>Keith Lloyd Smith inline N0003</text>
+    </note>
+    <note handle="_0000001600000016" change="1476889475" id="N0004" type="Person Note">
+      <text>Hans Peter Smith inline N0004</text>
+    </note>
+    <note handle="_0000001b0000001b" change="1476889475" id="N0005" type="Person Note">
+      <text>Hanna Smith inline N0005</text>
+    </note>
+    <note handle="_0000002000000020" change="1476889475" id="N0006" type="Person Note">
+      <text>Herman Julius Nielsen N0006</text>
+    </note>
+    <note handle="_0000002400000024" change="1476889475" id="N0008" type="Person Note">
+      <text>Evelyn Michaels N0007</text>
+    </note>
+    <note handle="_0000004e0000004e" change="1476889475" id="N0009" type="Person Note">
       <text>BIOGRAPHY
 Martin was listed as being a Husman, (owning a house as opposed to a farm) in the house records of Gladsax.</text>
     </note>
-    <note handle="_0000005e0000005e" change="1472500318" id="N0000" type="Event Note">
+    <note handle="_0000005a0000005a" change="1476889475" id="N0010" type="Person Note">
+      <text>A FAMC note</text>
+    </note>
+    <note handle="_0000006f0000006f" change="1476889475" id="N0011" type="Event Note">
       <text>Witness name: John Doe
 Witness comment: This is a simple test.</text>
     </note>
-    <note handle="_0000008300000083" change="1472500318" id="N0001" type="Event Note">
+    <note handle="_0000008e0000008e" change="1476889475" id="N0012" type="Source text">
+      <text>Record for Edwin Michael Smith</text>
+    </note>
+    <note handle="_0000009500000095" change="1476889475" id="N0013" type="Event Note">
       <text>Witness name: No Name</text>
     </note>
-    <note handle="_000000a2000000a2" change="1472500318" id="N0003" type="Person Note">
+    <note handle="_000000b4000000b4" change="1476889475" id="N0014" type="Person Note">
       <text>BIOGRAPHY
 
 Hjalmar sailed from Copenhagen, Denmark on the OSCAR II, 14 November 1912 arriving in New York 27 November 1912. He was seventeen years old. On the ship passenger list his trade was listed as a Blacksmith.  He came to Reno, Nevada and lived with his sister Marie for a time before settling in Sparks. He worked for Southern Pacific Railroad as a car inspector for a time, then went to work for Standard Oil
 Company. He enlisted in the army at Sparks 7 December 1917 and served as a Corporal in the Medical Corp until his discharge 12 August 1919 at the Presidio in San Francisco, California. Both he and Marjorie are buried in the Masonic Memorial Gardens Mausoleum in Reno, he the 30th June 1975, and she the 25th of June 1980.</text>
     </note>
-    <note handle="_000000b8000000b8" change="1472500318" id="N0004" type="Source Note">
+    <note handle="_000000c0000000c0" change="1476889475" id="N0015" type="GEDCOM import">
+      <text>Records not imported into FAM (family) Gramps ID F0011:
+
+Could not import Magnes&amp;Anna_smiths_marr_cert.jpg                   Line   802: 3 OBJE 
+Could not import Magnes&amp;Anna_smiths_marr_cert.jpg                   Line   805: 2 OBJE</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="233"/>
+      </style>
+    </note>
+    <note handle="_000000c5000000c5" change="1476889475" id="N0016" type="GEDCOM import">
+      <text>Records not imported into FAM (family) Gramps ID F0012:
+
+Could not import John&amp;Alice_smiths_marr_cert.jpg                    Line   829: 1 OBJE</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="145"/>
+      </style>
+    </note>
+    <note handle="_000000d1000000d1" change="1476889475" id="N0017" type="Source Note">
       <text>But Aunt Martha still keeps the original!</text>
     </note>
-    <note handle="_000000ba000000ba" change="1472500318" id="N0005" type="Source Note">
+    <note handle="_000000d3000000d3" change="1476889475" id="N0018" type="Repository Reference Note">
+      <text>Invalid REPO (Name instead of xref)</text>
+    </note>
+    <note handle="_000000d4000000d4" change="1476889475" id="N0019" type="Source text">
+      <text>Source text of Birth cert</text>
+    </note>
+    <note handle="_000000d6000000d6" change="1476889475" id="N0020" type="Repository Reference Note">
+      <text>Invalid REPO (no name)</text>
+    </note>
+    <note handle="_000000d7000000d7" change="1476889475" id="N0021" type="Source Note">
       <text>The repository reference from the source is important</text>
     </note>
-    <note handle="_000000bc000000bc" change="1472500318" id="N0006" type="Repository Note">
+    <note handle="_000000d9000000d9" change="1476889475" id="N0022" type="Repository Note">
       <text>Some note on the repo</text>
     </note>
   </notes>

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -2778,12 +2778,11 @@ class GedcomParser(UpdateCallback):
 
     def __find_or_create_note(self, gramps_id):
         """
-        Finds or creates a repository based on the GRAMPS ID. If the ID is
+        Finds or creates a note based on the GRAMPS ID. If the ID is
         already used (is in the db), we return the item in the db. Otherwise,
-        we create a new repository, assign the handle and GRAMPS ID.
-
-        Some GEDCOM "flavors" destroy the specification, and declare the
-        repository inline instead of in a object.
+        we create a new note, assign the handle and GRAMPS ID.
+        If no GRAMPS ID is passed in, we not only make a Note with GID, we
+        commit it.
         """
         note = Note()
         if not gramps_id:
@@ -3347,7 +3346,7 @@ class GedcomParser(UpdateCallback):
         if self.use_def_src:
             repo.set_name(submitter_name)
             repo.set_handle(create_id())
-            repo.set_gramps_id(self.dbase.find_next_repository_gramps_id())
+            repo.set_gramps_id(self.rid_map[""])
 
             addr = Address()
             addr.set_street(state.res.get_address())
@@ -6096,7 +6095,7 @@ class GedcomParser(UpdateCallback):
     def __source_text(self, line, state):
         note = Note()
         note.set(line.data)
-        gramps_id = self.dbase.find_next_note_gramps_id()
+        gramps_id = self.nid_map[""]
         note.set_gramps_id(gramps_id)
         note.set_type(NoteType.SOURCE_TEXT)
         self.dbase.add_note(note, self.trans)
@@ -6106,7 +6105,7 @@ class GedcomParser(UpdateCallback):
     def __citation_data_text(self, line, state):
         note = Note()
         note.set(line.data)
-        gramps_id = self.dbase.find_next_note_gramps_id()
+        gramps_id = self.nid_map[""]
         note.set_gramps_id(gramps_id)
         note.set_type(NoteType.SOURCE_TEXT)
         self.dbase.add_note(note, self.trans)
@@ -6123,7 +6122,7 @@ class GedcomParser(UpdateCallback):
                              line.data,
                              [(0, len(line.data))])
         note.set_styledtext(StyledText(line.data, [tags]))
-        gramps_id = self.dbase.find_next_note_gramps_id()
+        gramps_id = self.nid_map[""]
         note.set_gramps_id(gramps_id)
         note.set_type(NoteType.CITATION)
         self.dbase.add_note(note, self.trans)
@@ -6136,7 +6135,7 @@ class GedcomParser(UpdateCallback):
         """
         note = Note()
         note.set(line.data)
-        gramps_id = self.dbase.find_next_note_gramps_id()
+        gramps_id = self.nid_map[""]
         note.set_gramps_id(gramps_id)
         note.set_type(_("Citation Justification"))
         self.dbase.add_note(note, self.trans)
@@ -6333,7 +6332,7 @@ class GedcomParser(UpdateCallback):
             # This format has no repository name. See http://west-
             # penwith.org.uk/misc/ftmged.htm which points out this is
             # incorrect
-            gid = self.dbase.find_next_repository_gramps_id()
+            gid = self.rid_map[""]
             repo = self.__find_or_create_repository(gid)
             self.dbase.commit_repository(repo, self.trans)
         else:
@@ -6347,7 +6346,7 @@ class GedcomParser(UpdateCallback):
             # non-standard GEDCOM.
             gid = self.repo2id.get(line.data)
             if gid is None:
-                gid = self.dbase.find_next_repository_gramps_id()
+                gid = self.rid_map[""]
             repo = self.__find_or_create_repository(gid)
             self.repo2id[line.data] = repo.get_gramps_id()
             repo.set_name(line.data)
@@ -7524,7 +7523,7 @@ class GedcomParser(UpdateCallback):
             handle = self.inline_srcs.get(title, create_id())
             src = Source()
             src.handle = handle
-            src.gramps_id = self.dbase.find_next_source_gramps_id()
+            src.gramps_id = self.sid_map[""]
             self.inline_srcs[title] = handle
         else:
             src = self.__find_or_create_source(self.sid_map[line.data])


### PR DESCRIPTION
Found this when running the updated 'Check & Repair' tool which now scans for duplicate Gramps IDs.

Gramps tries to use Gedcom @xref@ as Gramps IDs. But they may already be in use, so the importer must track the xref to GIDs in a "swap" table.
In this case, the Gedcom contains a cross reference to a xref that is defined later. The importer examines the xref at first encounter and does a 'find_next_gramps_id', and a check of the 'swap' table to see if it is in use, determines that it is ok to use, saves it, but does not 'commit' it yet.
Later, another Gedcom line wants to create a note, but does not check the swap table, finds the same GID, uses it and commits.
Finally when the xref definition is found the importer uses the GID from the swap table (Which is now duplicated) to commit the xref note.

This bug has been there since before 2007; showing how easily a contributor can mess up if he doesn't fully understand the code. Particularly since the comments don't really explain this stuff very well.

I used an updated imp_sample.ged file to test for this; that file also has quite a few other changes to increase the code coverage, which is why there are so many changes.