### PR TITLE
Improve test coverage in the Gedcom importer

### DIFF
--- a/data/tests/imp_PhonFax_dfs.ged
+++ b/data/tests/imp_PhonFax_dfs.ged
@@ -10,14 +10,20 @@
 3 FAX (801) 705-7001
 3 EMAIL help@ancestry.com
 3 WWW http://www.ancestry.com
+2 DATA FTM Source data
+3 COPR Copyright 2999
+2 DATE 1 JAN 1111
 1 DEST GED55
 1 DATE 01 MAR 2016
 1 CHAR UTF-8
+1 CHAR UTF-8
+2 VERS 1.1
 1 FILE D:\Family Tree Maker\imp_FTM_LINK.ged
 1 SUBM @SUBM@
+2 NAME The Tester
 1 GEDC
 2 VERS 5.5
-2 FORM LINEAGE-LINKED
+2 FORM Lineage-Linked
 0 @SUBM@ SUBM
 1 NAME The Subm /Tester/
 1 ADDR 123 Main St., Winslow, PA, 12345

--- a/data/tests/imp_PhonFax_dfs.gramps
+++ b/data/tests/imp_PhonFax_dfs.gramps
@@ -3,7 +3,7 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-08-29" version="5.0.0-alpha1"/>
+    <created date="2016-10-23" version="5.0.0-alpha1"/>
     <researcher>
       <resname>The Subm /Tester/</resname>
       <resaddr>123 Main St.</resaddr>
@@ -14,28 +14,31 @@
       <resemail>mrstester@gmail.com</resemail>
     </researcher>
   </header>
+  <tags>
+    <tag handle="_0000000400000004" change="1" name="Imported" color="#000000000000" priority="0"/>
+  </tags>
   <events>
-    <event handle="_0000000700000007" change="1472500308" id="E0000">
+    <event handle="_0000000800000008" change="1" id="E0000">
       <type>Birth</type>
       <dateval val="1954-12-29"/>
-      <place hlink="_0000000800000008"/>
+      <place hlink="_0000000900000009"/>
       <attribute type="Phone" value="440-871-3400"/>
       <attribute type="Phone" value="800-871-3400"/>
       <attribute type="EMAIL" value="thetester@gmail.com"/>
       <attribute type="FAX" value="440-123-4567"/>
       <attribute type="WWW" value="http://thetester.com"/>
     </event>
-    <event handle="_0000000c0000000c" change="1472500308" id="E0001">
+    <event handle="_0000000d0000000d" change="1" id="E0001">
       <type>Residence</type>
       <dateval val="1954-12-30"/>
-      <place hlink="_0000000e0000000e"/>
+      <place hlink="_0000000f0000000f"/>
       <attribute type="Phone" value="440-871-3401"/>
       <attribute type="EMAIL" value="mrstester@gmail.com"/>
       <attribute type="FAX" value="440-321-4568"/>
       <attribute type="WWW" value="http://mrstester.com"/>
-      <noteref hlink="_0000000d0000000d"/>
+      <noteref hlink="_0000000e0000000e"/>
     </event>
-    <event handle="_0000001100000011" change="1472500308" id="E0002">
+    <event handle="_0000001200000012" change="1" id="E0002">
       <type>Residence</type>
       <dateval val="1964"/>
       <attribute type="Phone" value="440-871-3402"/>
@@ -45,22 +48,23 @@
     </event>
   </events>
   <people>
-    <person handle="_0000000600000006" change="1472500308" id="I0000">
+    <person handle="_0000000700000007" change="1" id="I0000">
       <gender>U</gender>
       <name type="Birth Name">
         <first>The</first>
         <surname>Tester</surname>
       </name>
-      <eventref hlink="_0000000700000007" role="Primary"/>
-      <citationref hlink="_0000000900000009"/>
+      <eventref hlink="_0000000800000008" role="Primary"/>
+      <citationref hlink="_0000000a0000000a"/>
+      <tagref hlink="_0000000400000004"/>
     </person>
-    <person handle="_0000000a0000000a" change="1472500308" id="I0001">
+    <person handle="_0000000b0000000b" change="1" id="I0001">
       <gender>U</gender>
       <name type="Birth Name">
         <first>Mrs</first>
         <surname>Tester</surname>
       </name>
-      <eventref hlink="_0000000c0000000c" role="Primary"/>
+      <eventref hlink="_0000000d0000000d" role="Primary"/>
       <address>
         <street>123 Main St.</street>
         <city>Winslow</city>
@@ -72,85 +76,91 @@
       <url  href="mrstester@gmail.com" type="E-mail"/>
       <url  href="440-321-4568" type="FAX"/>
       <url  href="http://mrstester.com" type="Web Home"/>
-      <noteref hlink="_0000000b0000000b"/>
-      <citationref hlink="_0000000f0000000f"/>
+      <noteref hlink="_0000000c0000000c"/>
+      <citationref hlink="_0000001000000010"/>
+      <tagref hlink="_0000000400000004"/>
     </person>
-    <person handle="_0000001000000010" change="1472500308" id="I0002">
+    <person handle="_0000001100000011" change="1" id="I0002">
       <gender>U</gender>
       <name type="Birth Name">
         <first>Tom</first>
         <surname>Tester</surname>
       </name>
-      <eventref hlink="_0000001100000011" role="Primary"/>
-      <citationref hlink="_0000001200000012"/>
+      <eventref hlink="_0000001200000012" role="Primary"/>
+      <citationref hlink="_0000001300000013"/>
+      <tagref hlink="_0000000400000004"/>
     </person>
   </people>
   <citations>
-    <citation handle="_0000000900000009" change="1472500308" id="C0000">
+    <citation handle="_0000000a0000000a" change="1" id="C0000">
       <confidence>2</confidence>
       <sourceref hlink="_0000000300000003"/>
     </citation>
-    <citation handle="_0000000f0000000f" change="1472500308" id="C0001">
+    <citation handle="_0000001000000010" change="1" id="C0001">
       <confidence>2</confidence>
       <sourceref hlink="_0000000300000003"/>
     </citation>
-    <citation handle="_0000001200000012" change="1472500308" id="C0002">
+    <citation handle="_0000001300000013" change="1" id="C0002">
       <confidence>2</confidence>
       <sourceref hlink="_0000000300000003"/>
     </citation>
   </citations>
   <sources>
-    <source handle="_0000000300000003" change="1472500308" id="S0000">
+    <source handle="_0000000300000003" change="1" id="S0000">
       <stitle>Import from imp_FTM_LINK.ged</stitle>
+      <sauthor>The Tester</sauthor>
       <srcattribute type="Approved system identification" value="FTM"/>
       <srcattribute type="Version number of software product" value="Family Tree Maker (22.0.0.1410)"/>
       <srcattribute type="Name of software product" value="Family Tree Maker for Windows"/>
+      <srcattribute type="Name of source data" value="FTM Source data"/>
+      <srcattribute type="Copyright of source data" value="Copyright 2999"/>
       <srcattribute type="Generated By" value="Family Tree Maker for Windows Family Tree Maker (22.0.0.1410)"/>
       <srcattribute type="Creation date of GEDCOM" value="2016-03-01"/>
+      <srcattribute type="Character set and version" value="UTF-8 1.1"/>
       <srcattribute type="GEDCOM version" value="5.5"/>
-      <srcattribute type="GEDCOM form" value="LINEAGE-LINKED"/>
+      <srcattribute type="GEDCOM form" value="Lineage-Linked"/>
       <reporef hlink="_0000000100000001" medium="Unknown"/>
-      <reporef hlink="_0000000400000004" medium="Unknown"/>
+      <reporef hlink="_0000000500000005" medium="Unknown"/>
     </source>
-    <source handle="_0000001300000013" change="1472500308" id="S0006">
+    <source handle="_0000001400000014" change="1" id="S0006">
       <stitle>Ohio Births, 1958-2002</stitle>
-      <reporef hlink="_0000001400000014" medium="Book"/>
+      <reporef hlink="_0000001500000015" medium="Book"/>
     </source>
   </sources>
   <places>
-    <placeobj handle="_0000000800000008" change="1472500308" id="P0000" type="Street">
+    <placeobj handle="_0000000900000009" change="1" id="P0000" type="Street">
       <ptitle>123 High St, Cleveland, Cuyahoga, Ohio, USA, 44140</ptitle>
       <code>44140</code>
       <pname value="123 High St"/>
-      <placeref hlink="_0000001a0000001a"/>
+      <placeref hlink="_0000001b0000001b"/>
     </placeobj>
-    <placeobj handle="_0000000e0000000e" change="1472500308" id="P0001" type="Address">
+    <placeobj handle="_0000000f0000000f" change="1" id="P0001" type="Address">
       <ptitle>123 Main St., Winslow, PA, 12345</ptitle>
       <pname value="123 Main St., Winslow, PA, 12345"/>
       <location street="123 Main St." city="Winslow" state="PA" postal="12345"/>
     </placeobj>
-    <placeobj handle="_0000001700000017" change="1472500308" id="P0002" type="Country">
+    <placeobj handle="_0000001800000018" change="1" id="P0002" type="Country">
       <ptitle>USA</ptitle>
       <pname value="USA"/>
     </placeobj>
-    <placeobj handle="_0000001800000018" change="1472500308" id="P0003" type="State">
+    <placeobj handle="_0000001900000019" change="1" id="P0003" type="State">
       <ptitle>Ohio, USA</ptitle>
       <pname value="Ohio"/>
-      <placeref hlink="_0000001700000017"/>
-    </placeobj>
-    <placeobj handle="_0000001900000019" change="1472500308" id="P0004" type="County">
-      <ptitle>Cuyahoga, Ohio, USA</ptitle>
-      <pname value="Cuyahoga"/>
       <placeref hlink="_0000001800000018"/>
     </placeobj>
-    <placeobj handle="_0000001a0000001a" change="1472500308" id="P0005" type="City">
+    <placeobj handle="_0000001a0000001a" change="1" id="P0004" type="County">
+      <ptitle>Cuyahoga, Ohio, USA</ptitle>
+      <pname value="Cuyahoga"/>
+      <placeref hlink="_0000001900000019"/>
+    </placeobj>
+    <placeobj handle="_0000001b0000001b" change="1" id="P0005" type="City">
       <ptitle>Cleveland, Cuyahoga, Ohio, USA</ptitle>
       <pname value="Cleveland"/>
-      <placeref hlink="_0000001900000019"/>
+      <placeref hlink="_0000001a0000001a"/>
     </placeobj>
   </places>
   <repositories>
-    <repository handle="_0000000100000001" change="1472500308" id="R0000">
+    <repository handle="_0000000100000001" change="1" id="R0000">
       <rname>Business that produced the product: Ancestry.com</rname>
       <type>GEDCOM data</type>
       <address>
@@ -161,7 +171,7 @@
       <url  href="help@ancestry.com" type="E-mail"/>
       <url  href="http://www.ancestry.com" type="Web Home"/>
     </repository>
-    <repository handle="_0000000400000004" change="1472500308" id="R0001">
+    <repository handle="_0000000500000005" change="1" id="R0001">
       <rname>SUBM (Submitter): (@SUBM@) The Subm /Tester/</rname>
       <type>GEDCOM data</type>
       <address>
@@ -174,9 +184,9 @@
       <url  href="mrstester@gmail.com" type="E-mail"/>
       <url  href="440-321-4568" type="FAX"/>
       <url  href="http://mrstester.com" type="Web Home"/>
-      <noteref hlink="_0000000500000005"/>
+      <noteref hlink="_0000000600000006"/>
     </repository>
-    <repository handle="_0000001400000014" change="1472500308" id="R0002">
+    <repository handle="_0000001500000015" change="1" id="R0002">
       <rname>Testers Repository</rname>
       <type>Library</type>
       <address>
@@ -186,40 +196,45 @@
       <url  href="tester_repo@osf.com" type="E-mail"/>
       <url  href="987-654-3210" type="FAX"/>
       <url  href="http://www.tester_repo.com" type="Web Home"/>
-      <noteref hlink="_0000001500000015"/>
       <noteref hlink="_0000001600000016"/>
+      <noteref hlink="_0000001700000017"/>
     </repository>
   </repositories>
   <notes>
-    <note handle="_0000000200000002" change="1472500308" id="N0000" type="GEDCOM import">
+    <note handle="_0000000200000002" change="1" id="N0000" type="GEDCOM import">
       <text>Records not imported into HEAD (header):
 
-Only one phone number supported                                     Line     9: 3 PHON (800) 705-7000</text>
+Only one phone number supported                                     Line     9: 3 PHON (800) 705-7000
+Line ignored as not understood                                      Line    15: 2 DATE 1111-01-01
+GEDCOM FORM should be in uppercase                                  Line    26: 2 FORM Lineage-Linked</text>
       <style name="fontface" value="Monospace">
-        <range start="0" end="144"/>
+        <range start="0" end="344"/>
       </style>
     </note>
-    <note handle="_0000000500000005" change="1472500308" id="N0001" type="GEDCOM import">
+    <note handle="_0000000600000006" change="1" id="N0001" type="GEDCOM import">
       <text>Records not imported into SUBM (Submitter): (@SUBM@) The Subm /Tester/:
 
-Only one phone number supported                                     Line    29: 1 PHON 800-871-3401</text>
+Only one phone number supported                                     Line    35: 1 PHON 800-871-3401</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="173"/>
       </style>
     </note>
-    <note handle="_0000000b0000000b" change="1472500308" id="N0002" type="Person Note">
+    <note handle="_0000000c0000000c" change="1" id="N0002" type="Person Note">
       <text>Address with PHON,FAX,EMAIL,WWW. attached directly to person is not legal Gedcom, but allowed here.</text>
+      <tagref hlink="_0000000400000004"/>
     </note>
-    <note handle="_0000000d0000000d" change="1472500308" id="N0003" type="Event Note">
+    <note handle="_0000000e0000000e" change="1" id="N0003" type="Event Note">
       <text>Address as event is legal, with PHON,FAX,EMAIL,WWW</text>
+      <tagref hlink="_0000000400000004"/>
     </note>
-    <note handle="_0000001500000015" change="1472500308" id="N0004" type="Repository Note">
+    <note handle="_0000001600000016" change="1" id="N0004" type="Repository Note">
       <text>The repository record</text>
+      <tagref hlink="_0000000400000004"/>
     </note>
-    <note handle="_0000001600000016" change="1472500308" id="N0005" type="GEDCOM import">
+    <note handle="_0000001700000017" change="1" id="N0005" type="GEDCOM import">
       <text>Records not imported into REPO (repository) Gramps ID R0002:
 
-Only one phone number supported                                     Line    87: 1 PHON 800-765-4321</text>
+Only one phone number supported                                     Line    93: 1 PHON 800-765-4321</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="162"/>
       </style>

--- a/data/tests/imp_notetest_dfs.gramps
+++ b/data/tests/imp_notetest_dfs.gramps
@@ -3,182 +3,190 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-08-29" version="5.0.0-alpha1"/>
+    <created date="2016-10-23" version="5.0.0-alpha1"/>
     <researcher>
       <resname>John A. Tester</resname>
     </researcher>
   </header>
+  <tags>
+    <tag handle="_0000000500000005" change="1" name="Imported" color="#000000000000" priority="0"/>
+  </tags>
   <events>
-    <event handle="_0000000e0000000e" change="1472505121" id="E0000">
+    <event handle="_0000000f0000000f" change="1" id="E0000">
       <type>TEST</type>
       <description>person</description>
     </event>
-    <event handle="_0000000f0000000f" change="1472505121" id="E0001">
+    <event handle="_0000001000000010" change="1" id="E0001">
       <type>Birth</type>
       <dateval val="1900-06-15"/>
-      <place hlink="_0000001300000013"/>
-      <noteref hlink="_0000001000000010"/>
+      <place hlink="_0000001400000014"/>
+      <noteref hlink="_0000001100000011"/>
     </event>
-    <event handle="_0000001400000014" change="1472505121" id="E0002">
+    <event handle="_0000001500000015" change="1" id="E0002">
       <type>Death</type>
-      <noteref hlink="_0000001500000015"/>
+      <noteref hlink="_0000001600000016"/>
     </event>
-    <event handle="_0000001d0000001d" change="1472505121" id="E0003">
+    <event handle="_0000001e0000001e" change="1" id="E0003">
       <type>Who knows OBJE REFN TYPE</type>
       <description>REFN</description>
     </event>
-    <event handle="_0000002600000026" change="1472505121" id="E0004">
+    <event handle="_0000002700000027" change="1" id="E0004">
       <type>Birth</type>
       <dateval val="1901-06-15"/>
     </event>
-    <event handle="_0000002700000027" change="1472505121" id="E0005">
+    <event handle="_0000002800000028" change="1" id="E0005">
       <type>Death</type>
       <dateval val="1975-07-05"/>
     </event>
-    <event handle="_0000002d0000002d" change="1472505121" id="E0006">
+    <event handle="_0000002e0000002e" change="1" id="E0006">
       <type>Birth</type>
       <dateval val="1922-06-15"/>
     </event>
-    <event handle="_0000002e0000002e" change="1472505121" id="E0007">
+    <event handle="_0000002f0000002f" change="1" id="E0007">
       <type>Death</type>
       <dateval val="1994-07-05"/>
     </event>
-    <event handle="_0000003a0000003a" change="1472505122" id="E0008">
+    <event handle="_0000003b0000003b" change="1" id="E0008">
       <type>TEST</type>
       <description>family</description>
     </event>
   </events>
   <people>
-    <person handle="_0000000d0000000d" change="979250406" id="I0001">
+    <person handle="_0000000e0000000e" change="979250406" id="I0001">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Tom</first>
         <surname>Tester</surname>
       </name>
-      <eventref hlink="_0000000e0000000e" role="Primary"/>
       <eventref hlink="_0000000f0000000f" role="Primary"/>
-      <eventref hlink="_0000001400000014" role="Primary"/>
-      <eventref hlink="_0000001d0000001d" role="Primary"/>
-      <objref hlink="_0000001e0000001e"/>
+      <eventref hlink="_0000001000000010" role="Primary"/>
+      <eventref hlink="_0000001500000015" role="Primary"/>
+      <eventref hlink="_0000001e0000001e" role="Primary"/>
+      <objref hlink="_0000001f0000001f"/>
       <attribute type="RIN" value="123456 Person"/>
       <attribute type="REFN" value="98765 for PERSON"/>
       <url  href="http://homepages.rootsweb.com/~pmcbride/gedcom/55gctoc.htm" type="Web Home" description="GEDCOM 5.5 documentation web site"/>
-      <parentin hlink="_0000001600000016"/>
-      <noteref hlink="_0000001700000017"/>
+      <parentin hlink="_0000001700000017"/>
       <noteref hlink="_0000001800000018"/>
       <noteref hlink="_0000001900000019"/>
       <noteref hlink="_0000001a0000001a"/>
-      <noteref hlink="_0000002000000020"/>
-      <citationref hlink="_0000001f0000001f"/>
+      <noteref hlink="_0000001b0000001b"/>
+      <noteref hlink="_0000002100000021"/>
+      <citationref hlink="_0000002000000020"/>
+      <tagref hlink="_0000000500000005"/>
     </person>
-    <person handle="_0000002500000025" change="1472505121" id="I0002">
+    <person handle="_0000002600000026" change="1" id="I0002">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Mrs</first>
         <surname>Tester</surname>
       </name>
-      <eventref hlink="_0000002600000026" role="Primary"/>
       <eventref hlink="_0000002700000027" role="Primary"/>
-      <parentin hlink="_0000001600000016"/>
-      <noteref hlink="_0000002800000028"/>
-      <noteref hlink="_0000002a0000002a"/>
-      <citationref hlink="_0000002900000029"/>
+      <eventref hlink="_0000002800000028" role="Primary"/>
+      <parentin hlink="_0000001700000017"/>
+      <noteref hlink="_0000002900000029"/>
+      <noteref hlink="_0000002b0000002b"/>
+      <citationref hlink="_0000002a0000002a"/>
+      <tagref hlink="_0000000500000005"/>
     </person>
-    <person handle="_0000002b0000002b" change="1472505121" id="I0003">
+    <person handle="_0000002c0000002c" change="1" id="I0003">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Ed</first>
         <surname>Tester</surname>
         <nick>Eddie</nick>
-        <noteref hlink="_0000002c0000002c"/>
+        <noteref hlink="_0000002d0000002d"/>
       </name>
-      <eventref hlink="_0000002d0000002d" role="Primary"/>
       <eventref hlink="_0000002e0000002e" role="Primary"/>
+      <eventref hlink="_0000002f0000002f" role="Primary"/>
       <lds_ord type="baptism">
         <dateval val="-005-05-05"/>
         <temple val="SLAKE"/>
-        <place hlink="_0000002f0000002f"/>
-        <noteref hlink="_0000003000000030"/>
-        <noteref hlink="_0000003300000033"/>
-        <citationref hlink="_0000003200000032"/>
+        <place hlink="_0000003000000030"/>
+        <noteref hlink="_0000003100000031"/>
+        <noteref hlink="_0000003400000034"/>
+        <citationref hlink="_0000003300000033"/>
       </lds_ord>
-      <childof hlink="_0000001600000016"/>
-      <personref hlink="_0000003400000034" rel="">
-        <noteref hlink="_0000003500000035"/>
+      <childof hlink="_0000001700000017"/>
+      <personref hlink="_0000003500000035" rel="">
+        <noteref hlink="_0000003600000036"/>
       </personref>
-      <noteref hlink="_0000003700000037"/>
-      <citationref hlink="_0000003600000036"/>
+      <noteref hlink="_0000003800000038"/>
+      <citationref hlink="_0000003700000037"/>
+      <tagref hlink="_0000000500000005"/>
     </person>
-    <person handle="_0000003400000034" change="1472505121" id="I0004">
+    <person handle="_0000003500000035" change="1" id="I0004">
       <gender>U</gender>
       <name type="Birth Name">
         <first>George</first>
         <surname>Testee</surname>
-        <noteref hlink="_0000003800000038"/>
+        <noteref hlink="_0000003900000039"/>
       </name>
-      <citationref hlink="_0000003900000039"/>
+      <citationref hlink="_0000003a0000003a"/>
+      <tagref hlink="_0000000500000005"/>
     </person>
   </people>
   <families>
-    <family handle="_0000001600000016" change="1472505121" id="F0001">
+    <family handle="_0000001700000017" change="1" id="F0001">
       <rel type="Unknown"/>
-      <father hlink="_0000000d0000000d"/>
-      <mother hlink="_0000002500000025"/>
-      <eventref hlink="_0000003a0000003a" role="Family"/>
-      <childref hlink="_0000002b0000002b"/>
-      <noteref hlink="_0000003d0000003d"/>
+      <father hlink="_0000000e0000000e"/>
+      <mother hlink="_0000002600000026"/>
+      <eventref hlink="_0000003b0000003b" role="Family"/>
+      <childref hlink="_0000002c0000002c"/>
       <noteref hlink="_0000003e0000003e"/>
-      <noteref hlink="_0000004300000043"/>
-      <citationref hlink="_0000003c0000003c"/>
-      <citationref hlink="_0000004200000042"/>
+      <noteref hlink="_0000003f0000003f"/>
+      <noteref hlink="_0000004400000044"/>
+      <citationref hlink="_0000003d0000003d"/>
+      <citationref hlink="_0000004300000043"/>
+      <tagref hlink="_0000000500000005"/>
     </family>
   </families>
   <citations>
-    <citation handle="_0000001f0000001f" change="1472505121" id="C0000">
+    <citation handle="_0000002000000020" change="1" id="C0000">
       <confidence>2</confidence>
       <sourceref hlink="_0000000400000004"/>
     </citation>
-    <citation handle="_0000002300000023" change="1472505121" id="C0001">
+    <citation handle="_0000002400000024" change="1" id="C0001">
       <confidence>2</confidence>
       <sourceref hlink="_0000000400000004"/>
     </citation>
-    <citation handle="_0000002900000029" change="1472505121" id="C0002">
+    <citation handle="_0000002a0000002a" change="1" id="C0002">
       <confidence>2</confidence>
       <sourceref hlink="_0000000400000004"/>
     </citation>
-    <citation handle="_0000003200000032" change="1472505121" id="C0003">
+    <citation handle="_0000003300000033" change="1" id="C0003">
       <confidence>2</confidence>
-      <sourceref hlink="_0000003100000031"/>
+      <sourceref hlink="_0000003200000032"/>
     </citation>
-    <citation handle="_0000003600000036" change="1472505121" id="C0004">
-      <confidence>2</confidence>
-      <sourceref hlink="_0000000400000004"/>
-    </citation>
-    <citation handle="_0000003900000039" change="1472505121" id="C0005">
+    <citation handle="_0000003700000037" change="1" id="C0004">
       <confidence>2</confidence>
       <sourceref hlink="_0000000400000004"/>
     </citation>
-    <citation handle="_0000003c0000003c" change="1472505122" id="C0006">
+    <citation handle="_0000003a0000003a" change="1" id="C0005">
       <confidence>2</confidence>
-      <sourceref hlink="_0000003b0000003b"/>
+      <sourceref hlink="_0000000400000004"/>
     </citation>
-    <citation handle="_0000004200000042" change="1472505122" id="C0007">
+    <citation handle="_0000003d0000003d" change="1" id="C0006">
+      <confidence>2</confidence>
+      <sourceref hlink="_0000003c0000003c"/>
+    </citation>
+    <citation handle="_0000004300000043" change="1" id="C0007">
       <dateval val="1900-12-31"/>
       <page>42</page>
       <confidence>0</confidence>
-      <noteref hlink="_0000003f0000003f"/>
       <noteref hlink="_0000004000000040"/>
       <noteref hlink="_0000004100000041"/>
-      <sourceref hlink="_0000003b0000003b"/>
+      <noteref hlink="_0000004200000042"/>
+      <sourceref hlink="_0000003c0000003c"/>
     </citation>
   </citations>
   <sources>
-    <source handle="_0000000400000004" change="1472505121" id="S0000">
+    <source handle="_0000000400000004" change="1" id="S0000">
       <stitle>Import from imp_notetest.ged</stitle>
       <spubinfo>Tom Tester 2016</spubinfo>
       <noteref hlink="_0000000200000002"/>
-      <noteref hlink="_0000000500000005"/>
       <noteref hlink="_0000000600000006"/>
+      <noteref hlink="_0000000700000007"/>
       <srcattribute type="Approved system identification" value="GEDitCOM"/>
       <srcattribute type="Name of software product" value="GEDitCOM"/>
       <srcattribute type="Version number of software product" value="2.9.4"/>
@@ -192,71 +200,72 @@
       <srcattribute type="Submission: Submitter" value="@SUBMITTER@"/>
       <srcattribute type="Submission: Family file" value="NameOfFamilyFile"/>
       <reporef hlink="_0000000100000001" medium="Unknown"/>
-      <reporef hlink="_0000000b0000000b" medium="Unknown"/>
+      <reporef hlink="_0000000c0000000c" medium="Unknown"/>
     </source>
-    <source handle="_0000003100000031" change="1472505121" id="SOURCE1">
+    <source handle="_0000003200000032" change="1" id="SOURCE1">
       <stitle>@SOURCE1@</stitle>
     </source>
-    <source handle="_0000003b0000003b" change="1472505122" id="S0001">
+    <source handle="_0000003c0000003c" change="1" id="S0001">
       <stitle>Note Test file Source: Tester</stitle>
-      <noteref hlink="_0000004600000046"/>
       <noteref hlink="_0000004700000047"/>
-      <reporef hlink="_0000004400000044" medium="Book">
-        <noteref hlink="_0000004500000045"/>
+      <noteref hlink="_0000004800000048"/>
+      <reporef hlink="_0000004500000045" medium="Book">
+        <noteref hlink="_0000004600000046"/>
       </reporef>
     </source>
   </sources>
   <places>
-    <placeobj handle="_0000001300000013" change="1472505121" id="P0000" type="Address">
+    <placeobj handle="_0000001400000014" change="1" id="P0000" type="Address">
       <ptitle>123 main, Norwalk, Ohio, USA</ptitle>
       <pname value="123 main, Norwalk, Ohio, USA"/>
       <location street="123 main, Norwalk, Ohio, USA"/>
-      <noteref hlink="_0000001100000011"/>
       <noteref hlink="_0000001200000012"/>
+      <noteref hlink="_0000001300000013"/>
     </placeobj>
-    <placeobj handle="_0000002f0000002f" change="1472505121" id="P0001" type="Unknown">
+    <placeobj handle="_0000003000000030" change="1" id="P0001" type="Unknown">
       <ptitle>Salt Lake City</ptitle>
       <pname value="Salt Lake City"/>
     </placeobj>
   </places>
   <objects>
-    <object handle="_0000001e0000001e" change="979250406" id="M1">
+    <object handle="_0000001f0000001f" change="979250406" id="M1">
       <file src="photo.jpg" mime="image/jpeg" description="Tom Tester's photo"/>
       <attribute type="Media-Type" value="Film"/>
       <attribute type="RIN" value="123456"/>
       <attribute type="REFN" value="98765">
-        <noteref hlink="_0000002200000022"/>
+        <noteref hlink="_0000002300000023"/>
       </attribute>
-      <noteref hlink="_0000002400000024"/>
-      <citationref hlink="_0000002300000023"/>
+      <noteref hlink="_0000002500000025"/>
+      <citationref hlink="_0000002400000024"/>
+      <tagref hlink="_0000000500000005"/>
     </object>
   </objects>
   <repositories>
-    <repository handle="_0000000100000001" change="1472505121" id="R0000">
+    <repository handle="_0000000100000001" change="1" id="R0000">
       <rname>Business that produced the product: RSAC Software</rname>
       <type>GEDCOM data</type>
     </repository>
-    <repository handle="_0000000b0000000b" change="1472505121" id="R0001">
+    <repository handle="_0000000c0000000c" change="1" id="R0001">
       <rname>SUBM (Submitter): (@SUBMITTER@) John A. Tester</rname>
       <type>GEDCOM data</type>
       <address>
       </address>
-      <noteref hlink="_0000000900000009"/>
       <noteref hlink="_0000000a0000000a"/>
-      <noteref hlink="_0000000c0000000c"/>
+      <noteref hlink="_0000000b0000000b"/>
+      <noteref hlink="_0000000d0000000d"/>
     </repository>
-    <repository handle="_0000004400000044" change="1472505122" id="R0002">
+    <repository handle="_0000004500000045" change="1" id="R0002">
       <rname>The Testers repository</rname>
       <type>Library</type>
-      <noteref hlink="_0000004800000048"/>
       <noteref hlink="_0000004900000049"/>
+      <noteref hlink="_0000004a0000004a"/>
     </repository>
   </repositories>
   <notes>
-    <note handle="_0000000200000002" change="1472505121" id="N0000" type="Source Note">
+    <note handle="_0000000200000002" change="1" id="N0000" type="Source Note">
       <text>Header note</text>
     </note>
-    <note handle="_0000000300000003" change="1472505121" id="N0001" type="GEDCOM import">
+    <note handle="_0000000300000003" change="1" id="N0001" type="GEDCOM import">
       <text>Records not imported into HEAD (header):
 
 Line ignored as not understood                                      Line    18: 2 TEST Header Note
@@ -266,13 +275,14 @@ Skipped subordinate line                                            Line    20: 
         <range start="0" end="327"/>
       </style>
     </note>
-    <note handle="_0000000500000005" change="1472505121" id="N0002" type="Source Note">
+    <note handle="_0000000600000006" change="1" id="N0002" type="Source Note">
       <text>Submission Note</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000000600000006" change="979250406" id="N0003" type="Source Note">
+    <note handle="_0000000700000007" change="979250406" id="N0003" type="Source Note">
       <text>Submission xref note</text>
     </note>
-    <note handle="_0000000700000007" change="1472505121" id="N0004" type="GEDCOM import">
+    <note handle="_0000000800000008" change="1" id="N0004" type="GEDCOM import">
       <text>Records not imported into Top Level:
 
 Line ignored as not understood                                      Line    26: 2 TEST Submission Note
@@ -283,7 +293,7 @@ Line ignored as not understood                                      Line    29: 
         <range start="0" end="425"/>
       </style>
     </note>
-    <note handle="_0000000800000008" change="1472505121" id="N0005" type="GEDCOM import">
+    <note handle="_0000000900000009" change="1" id="N0005" type="GEDCOM import">
       <text>Records not imported into NOTE Gramps ID N0003:
 
 Tag recognized but not supported                                    Line    32: 1 RIN Submission Note RIN
@@ -295,13 +305,14 @@ Line ignored as not understood                                      Line    39: 
         <range start="0" end="586"/>
       </style>
     </note>
-    <note handle="_0000000900000009" change="1472505121" id="N0006" type="Repository Note">
+    <note handle="_0000000a0000000a" change="1" id="N0006" type="Repository Note">
       <text>Submitter Note</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000000a0000000a" change="1472505121" id="N0007" type="Repository Note">
+    <note handle="_0000000b0000000b" change="1" id="N0007" type="Repository Note">
       <text>Submitter xref note</text>
     </note>
-    <note handle="_0000000c0000000c" change="1472505121" id="N0008" type="GEDCOM import">
+    <note handle="_0000000d0000000d" change="1" id="N0008" type="GEDCOM import">
       <text>Records not imported into SUBM (Submitter): (@SUBMITTER@) John A. Tester:
 
 Line ignored as not understood                                      Line    43: 2 TEST Submitter Note
@@ -312,37 +323,44 @@ Line ignored as not understood                                      Line    46: 
         <range start="0" end="460"/>
       </style>
     </note>
-    <note handle="_0000001000000010" change="1472505121" id="N0009" type="Event Note">
+    <note handle="_0000001100000011" change="1" id="N0009" type="Event Note">
       <text>Birth Event note</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000001100000011" change="1472505121" id="N0010" type="Place Note">
+    <note handle="_0000001200000012" change="1" id="N0010" type="Place Note">
       <text>Location Note</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000001200000012" change="1472505121" id="N0011" type="Place Note">
+    <note handle="_0000001300000013" change="1" id="N0011" type="Place Note">
       <text>Location Note 2</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000001500000015" change="1472505121" id="N0012" type="Event Note">
+    <note handle="_0000001600000016" change="1" id="N0012" type="Event Note">
       <text>Death Event xref note</text>
     </note>
-    <note handle="_0000001700000017" change="1472505121" id="N0013" type="Person Note">
+    <note handle="_0000001800000018" change="1" id="N0013" type="Person Note">
       <text>FAMS Note</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000001800000018" change="1472505121" id="N0014" type="Person Note">
+    <note handle="_0000001900000019" change="1" id="N0014" type="Person Note">
       <text>FAMS Note 2</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000001900000019" change="1472505121" id="N0015" type="Person Note">
+    <note handle="_0000001a0000001a" change="1" id="N0015" type="Person Note">
       <text>Tom Tester xref note</text>
     </note>
-    <note handle="_0000001a0000001a" change="1472505121" id="N0016" type="Person Note">
+    <note handle="_0000001b0000001b" change="1" id="N0016" type="Person Note">
       <text>Tom Tester Note</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000001b0000001b" change="1472505121" id="N0017" type="Media Note">
+    <note handle="_0000001c0000001c" change="1" id="N0017" type="Media Note">
       <text>Media Note</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000001c0000001c" change="979250406" id="N0018" type="Media Note">
+    <note handle="_0000001d0000001d" change="979250406" id="N0018" type="Media Note">
       <text>Media xref note</text>
     </note>
-    <note handle="_0000002000000020" change="1472505121" id="N0019" type="GEDCOM import">
+    <note handle="_0000002100000021" change="1" id="N0019" type="GEDCOM import">
       <text>Records not imported into INDI (individual) Gramps ID I0001:
 
 Empty note ignored                                                  Line    54: 2 NOTE 
@@ -369,7 +387,7 @@ Skipped subordinate line                                            Line    91: 
         <range start="0" end="2009"/>
       </style>
     </note>
-    <note handle="_0000002100000021" change="1472505121" id="N0020" type="GEDCOM import">
+    <note handle="_0000002200000022" change="1" id="N0020" type="GEDCOM import">
       <text>Records not imported into NOTE Gramps ID N0018:
 
 Tag recognized but not supported                                    Line   103: 1 RIN 123456
@@ -383,10 +401,10 @@ Skipped subordinate line                                            Line   112: 
         <range start="0" end="741"/>
       </style>
     </note>
-    <note handle="_0000002200000022" change="1472505121" id="N0021" type="REFN-TYPE">
+    <note handle="_0000002300000023" change="1" id="N0021" type="REFN-TYPE">
       <text>Who knows REFN TYPE</text>
     </note>
-    <note handle="_0000002400000024" change="1472505121" id="N0022" type="GEDCOM import">
+    <note handle="_0000002500000025" change="1" id="N0022" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M1:
 
 Could not import photo.jpg                                          Line   114: 1 FILE photo.jpg</text>
@@ -394,10 +412,11 @@ Could not import photo.jpg                                          Line   114: 
         <range start="0" end="164"/>
       </style>
     </note>
-    <note handle="_0000002800000028" change="979250406" id="N0023" type="Person Note">
+    <note handle="_0000002900000029" change="979250406" id="N0023" type="Person Note">
       <text>Family Spouse reference Note</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000002a0000002a" change="1472505121" id="N0024" type="GEDCOM import">
+    <note handle="_0000002b0000002b" change="1" id="N0024" type="GEDCOM import">
       <text>Records not imported into INDI (individual) Gramps ID I0002:
 
 Empty note ignored                                                  Line   132: 2 NOTE 
@@ -406,19 +425,22 @@ Skipped subordinate line                                            Line   133: 
         <range start="0" end="248"/>
       </style>
     </note>
-    <note handle="_0000002c0000002c" change="979250406" id="N0025" type="General">
+    <note handle="_0000002d0000002d" change="979250406" id="N0025" type="General">
       <text>Name note</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000003000000030" change="1472505121" id="N0026" type="LDS Note">
+    <note handle="_0000003100000031" change="1" id="N0026" type="LDS Note">
       <text>Place note</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000003300000033" change="1472505122" id="N0027" type="LDS Note">
+    <note handle="_0000003400000034" change="1" id="N0027" type="LDS Note">
       <text>LDS xref note</text>
     </note>
-    <note handle="_0000003500000035" change="979250406" id="N0028" type="Association Note">
+    <note handle="_0000003600000036" change="979250406" id="N0028" type="Association Note">
       <text>Association link note</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000003700000037" change="1472505121" id="N0029" type="GEDCOM import">
+    <note handle="_0000003800000038" change="1" id="N0029" type="GEDCOM import">
       <text>Records not imported into INDI (individual) Gramps ID I0003:
 
 Empty note ignored                                                  Line   141: 2 NOTE 
@@ -430,25 +452,29 @@ Skipped subordinate line                                            Line   168: 
         <range start="0" end="538"/>
       </style>
     </note>
-    <note handle="_0000003800000038" change="979250406" id="N0030" type="General">
+    <note handle="_0000003900000039" change="979250406" id="N0030" type="General">
       <text>Just for association</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000003d0000003d" change="1472505122" id="N0031" type="Family Note">
+    <note handle="_0000003e0000003e" change="1" id="N0031" type="Family Note">
       <text>Family xref note</text>
     </note>
-    <note handle="_0000003e0000003e" change="979250406" id="N0032" type="Family Note">
+    <note handle="_0000003f0000003f" change="979250406" id="N0032" type="Family Note">
       <text>Family note</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000003f0000003f" change="1472505122" id="N0033" type="Citation">
+    <note handle="_0000004000000040" change="1" id="N0033" type="Citation">
       <text>Citation Data Note</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000004000000040" change="1472505122" id="N0034" type="Source text">
+    <note handle="_0000004100000041" change="1" id="N0034" type="Source text">
       <text>A sample text from a source of this family</text>
     </note>
-    <note handle="_0000004100000041" change="979250406" id="N0035" type="Citation">
+    <note handle="_0000004200000042" change="979250406" id="N0035" type="Citation">
       <text>A note this citation is on the FAMILY record.</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000004300000043" change="1472505122" id="N0036" type="GEDCOM import">
+    <note handle="_0000004400000044" change="1" id="N0036" type="GEDCOM import">
       <text>Records not imported into FAM (family) Gramps ID F0001:
 
 Line ignored as not understood                                      Line   183: 2 TEST Family Note
@@ -461,13 +487,15 @@ Line ignored as not understood                                      Line   196: 
         <range start="0" end="645"/>
       </style>
     </note>
-    <note handle="_0000004500000045" change="979250406" id="N0037" type="Repository Reference Note">
+    <note handle="_0000004600000046" change="979250406" id="N0037" type="Repository Reference Note">
       <text>A short note about the repository link.</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000004600000046" change="979250406" id="N0038" type="Source Note">
+    <note handle="_0000004700000047" change="979250406" id="N0038" type="Source Note">
       <text>note embedded in the SOURCE Record</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000004700000047" change="1472505122" id="N0039" type="GEDCOM import">
+    <note handle="_0000004800000048" change="1" id="N0039" type="GEDCOM import">
       <text>Records not imported into SOUR (source) Gramps ID S0001:
 
 Line ignored as not understood                                      Line   206: 1 TEST source
@@ -479,10 +507,11 @@ Skipped subordinate line                                            Line   215: 
         <range start="0" end="524"/>
       </style>
     </note>
-    <note handle="_0000004800000048" change="1472505122" id="N0040" type="Repository Note">
+    <note handle="_0000004900000049" change="1" id="N0040" type="Repository Note">
       <text>Repository Note</text>
+      <tagref hlink="_0000000500000005"/>
     </note>
-    <note handle="_0000004900000049" change="1472505122" id="N0041" type="GEDCOM import">
+    <note handle="_0000004a0000004a" change="1" id="N0041" type="GEDCOM import">
       <text>Records not imported into REPO (repository) Gramps ID R0002:
 
 Line ignored as not understood                                      Line   223: 1 TEST Repo

--- a/data/tests/imp_sample.ged
+++ b/data/tests/imp_sample.ged
@@ -1,31 +1,65 @@
 0 HEAD
-1 SOUR Gramps
+1 SOUR LEGACY
 2 VERS 3.3.0
-2 NAME Gramps
+2 NAME LEGACY
 1 DATE 27 DEC 2010
 2 TIME 15:35:24
 1 SUBM @SUBM@
-1 FILE gramps33/example/gedcom/sample.ged
+1 SUBN @SUBN@
+1 FILE sample.ged
 1 COPR Copyright (c) 2010 Alex Roitman,,,.
 1 GEDC
 2 VERS 5.5
 2 FORM LINEAGE-LINKED
+2 FORM NOT LINEAGE-LINKED
 1 CHAR UTF-8
+2 VERS 1.1
 1 LANG French
 0 @SUBM@ SUBM
 1 NAME Alex Roitman,,,
 1 ADDR Not Provided
 2 CONT Not Provided
 2 ADR1 Not Provided
+2 NOTE No address provided (note not supported)
+0 @SUBN@ SUBN
+1 TEMP Mormon Temple
+1 ANCE 4
+1 DESC 4
+1 ORDI Yes
+0 @F3@ FAM
+1 HUSB @I24@
+1 WIFE @I0@
+1 MARR
+2 TYPE Marriage of Gustaf Smith, Sr. and Anna Hansdotter
+2 DATE 27 NOV 1885
+2 PLAC Rønne, Bornholm, Denmark
+1 CHIL @I26@
+1 CHIL @I23@
+1 CHIL @I21@
+1 CHIL @I8@
+1 CHIL @I15@
+1 CHIL @I20@
+1 CHIL @I10@
+1 CHAN
+2 DATE 21 DEC 2007
+3 TIME 01:35
+2 SOUR Not really allowed here
+1 RIN 987456321
+1 OBJE
+2 TITL No filename for this one 
 0 @I0@ INDI
 1 NAME Anna /Hansdotter/
 2 GIVN Anna
 2 SURN Hansdotter
+2 SPFX Vrow
+2 SURN Smith
+2 _AKA Anna Smith
+2 _AKA Hanna
 2 NOTE Hans daughter? N0000
 1 SEX F
 1 BIRT
 2 TYPE Birth of Anna Hansdotter
-2 DATE 2 OCT 1864
+2 DATE EST 2 OCT 1864
 2 PLAC Löderup, Malmöhus Län, Sweden
 1 DEAT
 2 TYPE Death of Anna Hansdotter
@@ -34,9 +68,10 @@
 2 NOTE Her eulogy was great! N0001
 1 FAMS @F3@
 1 CHAN
-2 DATE 21 DEC 2007
+2 DATE 21 DEC 1900
 3 TIME 01:35:26
 1 NOTE Inline note should get ID N0002
+1 _PHOTO @M1@
 0 @I1@ INDI
 1 NAME Keith Lloyd /Smith/
 2 GIVN Keith Lloyd
@@ -120,6 +155,8 @@
 1 NAME Marjorie Lee /Smith/
 2 GIVN Marjorie Lee
 2 SURN Smith
+1 NAME Margie
+2 TYPE Nickname
 1 SEX F
 1 BIRT
 2 TYPE Birth of Marjorie Lee Smith
@@ -160,6 +197,16 @@
 2 TYPE Death of Jennifer Anderson
 2 DATE 29 MAY 1985
 2 PLAC San Francisco, San Francisco Co., CA
+1 RESI
+2 DATE 1980
+2 ADDR 459 Main St., The Village, San Francisco, CA, USA
+3 ADR1 456 Main St
+3 ADR1 456 Main St again
+3 ADR2 The Village
+3 CITY San Francisco
+3 CTRY USA
+3 PHON 555-666-7777
+3 STAE CA
 1 FAMS @F14@
 1 CHAN
 2 DATE 21 DEC 2007
@@ -194,6 +241,11 @@
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+1 SSN 987-555-4444
+2 TYPE first generaton
+2 SOUR @S999@
+3 PAGE SSN docs pg 999
+2 NOTE Person Attribute Note on SSN
 0 @I19@ INDI
 1 NAME Eric Lloyd /Smith/
 2 GIVN Eric Lloyd
@@ -354,6 +406,9 @@
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+1 ASSO @I23@
+2 RELA Friend
+2 SOUR @S2@
 0 @I25@ INDI
 1 NAME Marta /Ericsdotter/
 2 GIVN Marta
@@ -371,10 +426,13 @@
 1 FACT Housekeeper
 2 TYPE Skills
 1 CONL
+2 TEMP STOCK code
 2 DATE 1790
 1 ENDL
+2 TEMP Stockholm
 2 DATE 1795
 1 SLGC
+2 TEMP Stockholm, Sweden
 2 DATE 1796
 2 PLAC Sweden
 3 FORM Country
@@ -404,7 +462,7 @@
 1 SEX M
 1 BIRT
 2 TYPE Birth of Ingeman Smith
-2 DATE ABT 1770
+2 DATE ABT @#DGREGORIAN@ 1770
 2 PLAC Sweden
 1 FAMS @F1@
 1 CHAN
@@ -447,11 +505,13 @@
 1 NAME Magnes /Smith/
 2 GIVN Magnes
 2 SURN Smith
-1 SEX M
+1 SSN 987-654-3210
+1 SEX X
 1 BIRT
 2 TYPE Birth of Magnes Smith
 2 DATE 6 OCT 1858
 2 PLAC Simrishamn, Kristianstad Län, Sweden
+2 RIN 789654123
 1 DEAT
 2 TYPE Death of Magnes Smith
 2 DATE 20 FEB 1910
@@ -470,6 +530,8 @@
 2 TYPE Birth of Janice Ann Adams
 2 DATE 26 AUG 1965
 2 PLAC Fremont, Alameda Co., CA
+2 CAUS fooling around
+3 SOUR @S0@
 1 OCCU Retail Manager
 1 _DEG
 2 TYPE Business Management
@@ -539,6 +601,8 @@
 1 NAME Lars Peter /Smith/
 2 GIVN Lars Peter
 2 SURN Smith
+2 _ADPN Jones
+2 _ADPN Pete Jones
 1 SEX M
 1 BIRT
 2 TYPE Birth of Lars Peter Smith
@@ -694,7 +758,7 @@
 1 SEX M
 1 BIRT
 2 TYPE Birth of Edwin Willard
-2 DATE ABT 1886
+2 DATE BET @#DHEBREW@ AAV 1886 AND @#DHEBREW@ ELUL 1897
 1 FAMS @F4@
 1 CHAN
 2 DATE 21 DEC 2007
@@ -752,12 +816,19 @@
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+1 RESI At the boarding school
+2 DATE FROM @#DGREGORIAN@ 1873 TO 1878
+2 PLAC Oronoko, Berrien, Michigan, USA
+1 RESI At the hebrew boarding school
+2 DATE FROM 1873 TO @#DHEBREW@ 1878
+2 PLAC Shemps
+3 FORM home
 0 @F0@ FAM
 1 HUSB @I39@
 1 WIFE @I36@
 1 MARR
 2 TYPE Marriage of Martin Smith and Elna Jefferson
-2 DATE ABT 1816
+2 DATE BET @#DGREGORIAN@ 1816 AND 1817
 2 PLAC Gladsax, Kristianstad Län, Sweden
 1 CHIL @I11@
 1 CHIL @I7@
@@ -771,8 +842,12 @@
 1 WIFE @I25@
 1 MARR
 2 TYPE Marriage of Ingeman Smith and Marta Ericsdotter
-2 DATE ABT 1790
+2 DATE BET 1789 AND @#DHEBREW@ 1790
 2 PLAC Sweden
+2 HUSB
+3 AGE 17
+2 WIFE
+3 AGE 18
 1 CHIL @I39@
 1 CHAN
 2 DATE 21 DEC 2007
@@ -785,6 +860,7 @@
 2 DATE 12 JUL 1986
 2 PLAC Woodland, Yolo Co., CA
 1 CHIL @I35@
+2 _STAT
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
@@ -858,32 +934,17 @@
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+1 EVEN Common law marriage
+2 TYPE Civil
 0 @F2@ FAM
 1 HUSB @I22@
 1 WIFE @I38@
 1 MARR
 2 TYPE Marriage of Martin Smith and Kerstina Hansdotter
-2 DATE ABT 1856
+2 DATE FROM @#DGREGORIAN@ 1856 TO @#DGREGORIAN@ 1857
 1 CHIL @I3@
 1 CHIL @I9@
 1 CHIL @I24@
-1 CHAN
-2 DATE 21 DEC 2007
-3 TIME 01:35:26
-0 @F3@ FAM
-1 HUSB @I24@
-1 WIFE @I0@
-1 MARR
-2 TYPE Marriage of Gustaf Smith, Sr. and Anna Hansdotter
-2 DATE 27 NOV 1885
-2 PLAC Rønne, Bornholm, Denmark
-1 CHIL @I26@
-1 CHIL @I23@
-1 CHIL @I21@
-1 CHIL @I8@
-1 CHIL @I15@
-1 CHIL @I20@
-1 CHIL @I10@
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
@@ -921,7 +982,7 @@
 0 @F7@ FAM
 1 HUSB @I15@
 1 WIFE @I13@
-1 MARR
+1 MARR Civil Union
 2 TYPE Marriage of Gus Smith and Evelyn Michaels
 2 DATE ABT 1920
 1 CHAN
@@ -937,12 +998,15 @@
 1 CHIL @I19@
 1 CHIL @I1@
 1 CHIL @I29@
+2 ADOP
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+1 ADDR 123 Main st, Grantville, Virginia, USA
 0 @F9@ FAM
 1 HUSB @I10@
 1 WIFE @I17@
+1 MARR Unmarried
 1 CHIL @I33@
 1 CHAN
 2 DATE 21 DEC 2007
@@ -977,9 +1041,15 @@
 2 CALN CA-123-LL-456_Num/ber
 3 MEDI Film
 1 NOTE @N0005@
+1 ABBR goodstuff
+1 DATA
+2 AGNC NYC Public Library
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26
+0 @S4@ SOUR
+1 PERI Our Family Tree
+1 RIN 987456321
 0 @R0002@ REPO
 1 NAME New York Public Library
 1 ADDR 5th Ave at 42 street
@@ -988,13 +1058,27 @@
 2 STAE New York
 2 POST 11111
 2 CTRY USA
+1 CHAN
+2 DATE 01 JAN 2000
+3 TIME 00:00:00
 0 @R0003@ REPO
 1 NAME Aunt Martha's Attic
-1 ADDR 123 Main St
+1 ADDR 123 Main St, Someville, ST, USA
 2 ADR1 123 Main St
+2 ADR2 LittleVillage
 2 CITY Someville
 2 STAE ST
 2 CTRY USA
+2 DATE 25 DEC 1971
+2 SOUR @S0@
+3 DATE 26 DEC 1971
+3 REFN blah blah
+4 TYPE who knows
+3 EVEN housecleaning
+4 ROLE sorter
+3 OBJE
+4 FILE Attic_photo.jpg
+2 NOTE A note on this address
 1 WWW http://library.gramps-project.org
 1 NOTE @N0006@
 0 @N0000@ NOTE Witness name: John Doe
@@ -1019,5 +1103,10 @@
 0 @N0004@ NOTE But Aunt Martha still keeps the original!
 0 @N0005@ NOTE The repository reference from the source is important
 0 @N0006@ NOTE Some note on the repo
-0 @N7@ NOTE 'Smith': a very common name
+0 XXX an unknown token at level 0
+0 SUBM @SUBM@
+0 @S4@ SOUR A weird source (one line) format
+1 @X1@ XXX and unknown token xref definition
 0 TRLR
+
+The end

--- a/data/tests/imp_sample.gramps
+++ b/data/tests/imp_sample.gramps
@@ -3,754 +3,645 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-10-19" version="5.0.0-alpha1"/>
+    <created date="2016-10-24" version="5.0.0-alpha1"/>
     <researcher>
       <resname>Alex Roitman,,,</resname>
       <resaddr>Not Provided</resaddr>
     </researcher>
   </header>
   <events>
-    <event handle="_0000000300000003" change="1476889475" id="E0000">
+    <event handle="_0000000600000006" change="1" id="E0000">
+      <type>Marriage</type>
+      <dateval val="1885-11-27"/>
+      <place hlink="_0000000700000007"/>
+      <description>Marriage of Gustaf Smith, Sr. and Anna Hansdotter</description>
+    </event>
+    <event handle="_0000001200000012" change="1" id="E0001">
       <type>Birth</type>
-      <dateval val="1864-10-02"/>
-      <place hlink="_0000000400000004"/>
+      <dateval val="1864-10-02" quality="estimated"/>
+      <place hlink="_0000001300000013"/>
       <description>Birth of Anna Hansdotter</description>
     </event>
-    <event handle="_0000000500000005" change="1476889475" id="E0001">
+    <event handle="_0000001400000014" change="1" id="E0002">
       <type>Death</type>
       <dateval val="1945-09-29"/>
-      <place hlink="_0000000700000007"/>
+      <place hlink="_0000001600000016"/>
       <description>Death of Anna Hansdotter</description>
-      <noteref hlink="_0000000600000006"/>
+      <noteref hlink="_0000001500000015"/>
     </event>
-    <event handle="_0000000c0000000c" change="1476889475" id="E0002">
+    <event handle="_0000001b0000001b" change="1" id="E0003">
       <type>Birth</type>
       <dateval val="1966-08-11"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001c0000001c"/>
       <description>Birth of Keith Lloyd Smith</description>
     </event>
-    <event handle="_0000001100000011" change="1476889475" id="E0003">
+    <event handle="_0000001f0000001f" change="1" id="E0004">
       <type>Birth</type>
       <dateval val="1904-04-17"/>
-      <place hlink="_0000001200000012"/>
+      <place hlink="_0000000700000007"/>
       <description>Birth of Hans Peter Smith</description>
     </event>
-    <event handle="_0000001300000013" change="1476889475" id="E0004">
+    <event handle="_0000002000000020" change="1" id="E0005">
       <type>Death</type>
       <dateval val="1977-01-29"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001c0000001c"/>
       <description>Death of Hans Peter Smith</description>
     </event>
-    <event handle="_0000001800000018" change="1476889475" id="E0005">
+    <event handle="_0000002500000025" change="1" id="E0006">
       <type>Birth</type>
       <dateval val="1821-01-29"/>
-      <place hlink="_0000001900000019"/>
+      <place hlink="_0000002600000026"/>
       <description>Birth of Hanna Smith</description>
     </event>
-    <event handle="_0000001d0000001d" change="1476889475" id="E0006">
+    <event handle="_0000002a0000002a" change="1" id="E0007">
       <type>Birth</type>
       <dateval val="1889-08-31"/>
-      <place hlink="_0000001200000012"/>
+      <place hlink="_0000000700000007"/>
       <description>Birth of Herman Julius Nielsen</description>
     </event>
-    <event handle="_0000001e0000001e" change="1476889475" id="E0007">
+    <event handle="_0000002b0000002b" change="1" id="E0008">
       <type>Death</type>
       <dateval val="1945"/>
       <description>Death of Herman Julius Nielsen</description>
     </event>
-    <event handle="_0000002200000022" change="1476889475" id="E0008">
+    <event handle="_0000002f0000002f" change="1" id="E0009">
       <type>Birth</type>
       <dateval val="1897" type="about"/>
       <description>Birth of Evelyn Michaels</description>
     </event>
-    <event handle="_0000002600000026" change="1476889475" id="E0009">
+    <event handle="_0000003300000033" change="1" id="E0010">
       <type>Birth</type>
       <dateval val="1934-11-04"/>
-      <place hlink="_0000002700000027"/>
+      <place hlink="_0000003400000034"/>
       <description>Birth of Marjorie Lee Smith</description>
     </event>
-    <event handle="_0000002a0000002a" change="1476889475" id="E0010">
+    <event handle="_0000003600000036" change="1" id="E0011">
       <type>Birth</type>
       <dateval val="1897-09-11"/>
-      <place hlink="_0000001200000012"/>
+      <place hlink="_0000000700000007"/>
       <description>Birth of Gus Smith</description>
     </event>
-    <event handle="_0000002b0000002b" change="1476889475" id="E0011">
+    <event handle="_0000003700000037" change="1" id="E0012">
       <type>Death</type>
       <dateval val="1963-10-21"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001c0000001c"/>
       <description>Death of Gus Smith</description>
     </event>
-    <event handle="_0000002d0000002d" change="1476889475" id="E0012">
+    <event handle="_0000003900000039" change="1" id="E0013">
       <type>Birth</type>
       <dateval val="1907-11-05"/>
-      <place hlink="_0000001200000012"/>
+      <place hlink="_0000000700000007"/>
       <description>Birth of Jennifer Anderson</description>
     </event>
-    <event handle="_0000002e0000002e" change="1476889475" id="E0013">
+    <event handle="_0000003a0000003a" change="1" id="E0014">
       <type>Death</type>
       <dateval val="1985-05-29"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001c0000001c"/>
       <description>Death of Jennifer Anderson</description>
     </event>
-    <event handle="_0000003000000030" change="1476889475" id="E0014">
+    <event handle="_0000003b0000003b" change="1" id="E0015">
+      <type>Residence</type>
+      <dateval val="1980"/>
+      <place hlink="_0000003c0000003c"/>
+    </event>
+    <event handle="_0000003f0000003f" change="1" id="E0016">
       <type>Birth</type>
       <dateval val="1910-05-02"/>
-      <place hlink="_0000001200000012"/>
+      <place hlink="_0000000700000007"/>
       <description>Birth of Lillie Harriet Jones</description>
     </event>
-    <event handle="_0000003100000031" change="1476889475" id="E0015">
+    <event handle="_0000004000000040" change="1" id="E0017">
       <type>Death</type>
       <dateval val="1990-06-26"/>
       <description>Death of Lillie Harriet Jones</description>
     </event>
-    <event handle="_0000003300000033" change="1476889475" id="E0016">
+    <event handle="_0000004200000042" change="1" id="E0018">
       <type>Birth</type>
       <dateval val="1932-01-30"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001c0000001c"/>
       <description>Birth of John Hjalmar Smith</description>
     </event>
-    <event handle="_0000003600000036" change="1476889475" id="E0017">
+    <event handle="_0000004900000049" change="1" id="E0019">
       <type>Birth</type>
       <dateval val="1963-08-28"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001c0000001c"/>
       <description>Birth of Eric Lloyd Smith</description>
     </event>
-    <event handle="_0000003700000037" change="1476889475" id="E0018">
+    <event handle="_0000004a0000004a" change="1" id="E0020">
       <type>Adopted</type>
     </event>
-    <event handle="_0000003a0000003a" change="1476889475" id="E0019">
+    <event handle="_0000004d0000004d" change="1" id="E0021">
       <type>Birth</type>
       <dateval val="1998-04-12"/>
-      <place hlink="_0000003b0000003b"/>
+      <place hlink="_0000004e0000004e"/>
       <description>Birth of Amber Marie Smith</description>
     </event>
-    <event handle="_0000003c0000003c" change="1476889475" id="E0020">
+    <event handle="_0000004f0000004f" change="1" id="E0022">
       <type>Christening</type>
       <dateval val="1998-04-26"/>
-      <place hlink="_0000003d0000003d"/>
+      <place hlink="_0000005000000050"/>
       <description>Christening of Amber Marie Smith</description>
     </event>
-    <event handle="_0000004000000040" change="1476889475" id="E0021">
+    <event handle="_0000005200000052" change="1" id="E0023">
       <type>Birth</type>
       <dateval val="1899-12-20"/>
-      <place hlink="_0000001200000012"/>
+      <place hlink="_0000000700000007"/>
       <description>Birth of Carl Emil Smith</description>
     </event>
-    <event handle="_0000004100000041" change="1476889475" id="E0022">
+    <event handle="_0000005300000053" change="1" id="E0024">
       <type>Death</type>
       <dateval val="1959-01-28"/>
-      <place hlink="_0000002700000027"/>
+      <place hlink="_0000003400000034"/>
       <description>Death of Carl Emil Smith</description>
       <attribute type="Cause" value="Bad breath"/>
     </event>
-    <event handle="_0000004300000043" change="1476889475" id="E0023">
+    <event handle="_0000005400000054" change="1" id="E0025">
       <type>Birth</type>
       <dateval val="1893-01-31"/>
-      <place hlink="_0000001200000012"/>
+      <place hlink="_0000000700000007"/>
       <description>Birth of Hjalmar Smith</description>
     </event>
-    <event handle="_0000004400000044" change="1476889475" id="E0024">
+    <event handle="_0000005500000055" change="1" id="E0026">
       <type>Birth</type>
     </event>
-    <event handle="_0000004500000045" change="1476889475" id="E0025">
+    <event handle="_0000005600000056" change="1" id="E0027">
       <type>Death</type>
       <dateval val="1894-09-25"/>
-      <place hlink="_0000001200000012"/>
+      <place hlink="_0000000700000007"/>
       <description>Death of Hjalmar Smith</description>
     </event>
-    <event handle="_0000004600000046" change="1476889475" id="E0026">
+    <event handle="_0000005700000057" change="1" id="E0028">
       <type>Death</type>
     </event>
-    <event handle="_0000004800000048" change="1476889475" id="E0027">
+    <event handle="_0000005900000059" change="1" id="E0029">
       <type>Nobility Title</type>
       <dateval val="1874-10-05"/>
-      <place hlink="_0000001200000012"/>
+      <place hlink="_0000000700000007"/>
       <description>Sir Jimmy Smith</description>
     </event>
-    <event handle="_0000004900000049" change="1476889475" id="E0028">
+    <event handle="_0000005a0000005a" change="1" id="E0030">
       <type>Birth</type>
       <dateval val="1830-11-19"/>
-      <place hlink="_0000001900000019"/>
+      <place hlink="_0000002600000026"/>
       <description>Birth of Martin Smith</description>
     </event>
-    <event handle="_0000004a0000004a" change="1476889475" id="E0029">
+    <event handle="_0000005b0000005b" change="1" id="E0031">
       <type>Death</type>
       <daterange start="1899" stop="1905"/>
-      <place hlink="_0000004b0000004b"/>
+      <place hlink="_0000005c0000005c"/>
       <description>Death of Martin Smith</description>
     </event>
-    <event handle="_0000004c0000004c" change="1476889475" id="E0030">
+    <event handle="_0000005d0000005d" change="1" id="E0032">
       <type>Baptism</type>
       <dateval val="1830-11-23"/>
-      <place hlink="_0000001900000019"/>
+      <place hlink="_0000002600000026"/>
       <description>Baptism of Martin Smith</description>
     </event>
-    <event handle="_0000004f0000004f" change="1476889475" id="E0031">
+    <event handle="_0000006000000060" change="1" id="E0033">
       <type>DATE</type>
       <description>2007-12-21</description>
       <attribute type="Time" value="01:35:26"/>
     </event>
-    <event handle="_0000005100000051" change="1476889475" id="E0032">
+    <event handle="_0000006100000061" change="1" id="E0034">
       <type>Birth</type>
       <dateval val="1889-01-31"/>
-      <place hlink="_0000001200000012"/>
+      <place hlink="_0000000700000007"/>
       <description>Birth of Astrid Shermanna Augusta Smith</description>
     </event>
-    <event handle="_0000005200000052" change="1476889475" id="E0033">
+    <event handle="_0000006200000062" change="1" id="E0035">
       <type>Death</type>
       <dateval val="1963-12-21"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001c0000001c"/>
       <description>Death of Astrid Shermanna Augusta Smith</description>
     </event>
-    <event handle="_0000005400000054" change="1476889475" id="E0034">
+    <event handle="_0000006300000063" change="1" id="E0036">
       <type>Birth</type>
       <dateval val="1862-11-28"/>
-      <place hlink="_0000005500000055"/>
+      <place hlink="_0000006400000064"/>
       <description>Birth of Gustaf Smith, Sr.</description>
     </event>
-    <event handle="_0000005600000056" change="1476889475" id="E0035">
+    <event handle="_0000006500000065" change="1" id="E0037">
       <type>Death</type>
       <dateval val="1930-07-23" type="before"/>
-      <place hlink="_0000000700000007"/>
+      <place hlink="_0000001600000016"/>
       <description>Death of Gustaf Smith, Sr.</description>
     </event>
-    <event handle="_0000005700000057" change="1476889475" id="E0036">
+    <event handle="_0000006600000066" change="1" id="E0038">
       <type>Immi</type>
       <dateval val="1908-05-21"/>
-      <place hlink="_0000005800000058"/>
+      <place hlink="_0000006700000067"/>
     </event>
-    <event handle="_0000005900000059" change="1476889475" id="E0037">
+    <event handle="_0000006800000068" change="1" id="E0039">
       <type>Christening</type>
       <dateval val="1862-12-07"/>
-      <place hlink="_0000001900000019"/>
+      <place hlink="_0000002600000026"/>
       <description>Christening of Gustaf Smith, Sr.</description>
     </event>
-    <event handle="_0000005e0000005e" change="1476889475" id="E0038">
+    <event handle="_0000006e0000006e" change="1" id="E0040">
       <type>Birth</type>
       <dateval val="1775" type="about"/>
-      <place hlink="_0000004b0000004b"/>
+      <place hlink="_0000005c0000005c"/>
       <description>Birth of Marta Ericsdotter</description>
     </event>
-    <event handle="_0000006200000062" change="1476889475" id="E0039">
+    <event handle="_0000007100000071" change="1" id="E0041">
       <type>Birth</type>
       <dateval val="1886-12-15"/>
-      <place hlink="_0000001200000012"/>
+      <place hlink="_0000000700000007"/>
       <description>Birth of Kirsti Marie Smith</description>
     </event>
-    <event handle="_0000006300000063" change="1476889475" id="E0040">
+    <event handle="_0000007200000072" change="1" id="E0042">
       <type>Death</type>
       <dateval val="1966-07-18"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001c0000001c"/>
       <description>Death of Kirsti Marie Smith</description>
     </event>
-    <event handle="_0000006600000066" change="1476889475" id="E0041">
+    <event handle="_0000007500000075" change="1" id="E0043">
       <type>Birth</type>
       <dateval val="1770" type="about"/>
-      <place hlink="_0000004b0000004b"/>
+      <place hlink="_0000005c0000005c"/>
       <description>Birth of Ingeman Smith</description>
     </event>
-    <event handle="_0000006800000068" change="1476889475" id="E0042">
+    <event handle="_0000007700000077" change="1" id="E0044">
       <type>Birth</type>
       <dateval val="1860-09-23"/>
-      <place hlink="_0000006900000069"/>
+      <place hlink="_0000007800000078"/>
       <description>Birth of Anna Streiffert</description>
     </event>
-    <event handle="_0000006a0000006a" change="1476889475" id="E0043">
+    <event handle="_0000007900000079" change="1" id="E0045">
       <type>Death</type>
       <dateval val="1927-02-02"/>
-      <place hlink="_0000001200000012"/>
+      <place hlink="_0000000700000007"/>
       <description>Death of Anna Streiffert</description>
     </event>
-    <event handle="_0000006d0000006d" change="1476889475" id="E0044">
+    <event handle="_0000007c0000007c" change="1" id="E0046">
       <type>Birth</type>
       <dateval val="1966" type="after"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001c0000001c"/>
       <description>Birth of Craig Peter Smith</description>
     </event>
-    <event handle="_0000006e0000006e" change="1476889475" id="E0045">
+    <event handle="_0000007d0000007d" change="1" id="E0047">
       <type>Census</type>
       <description>Census of Craig Peter Smith</description>
-      <noteref hlink="_0000006f0000006f"/>
+      <noteref hlink="_0000007e0000007e"/>
     </event>
-    <event handle="_0000007100000071" change="1476889475" id="E0046">
+    <event handle="_0000008000000080" change="1" id="E0048">
       <type>Birth</type>
       <dateval val="1858-10-06"/>
-      <place hlink="_0000007200000072"/>
+      <place hlink="_0000008100000081"/>
       <description>Birth of Magnes Smith</description>
+      <attribute type="RIN" value="789654123"/>
     </event>
-    <event handle="_0000007300000073" change="1476889475" id="E0047">
+    <event handle="_0000008200000082" change="1" id="E0049">
       <type>Death</type>
       <dateval val="1910-02-20"/>
-      <place hlink="_0000001200000012"/>
+      <place hlink="_0000000700000007"/>
       <description>Death of Magnes Smith</description>
     </event>
-    <event handle="_0000007500000075" change="1476889475" id="E0048">
+    <event handle="_0000008400000084" change="1" id="E0050">
       <type>Birth</type>
       <dateval val="1965-08-26"/>
-      <place hlink="_0000007600000076"/>
+      <place hlink="_0000008700000087"/>
       <description>Birth of Janice Ann Adams</description>
+      <attribute type="Cause" value="fooling around">
+        <citationref hlink="_0000008600000086"/>
+      </attribute>
     </event>
-    <event handle="_0000007700000077" change="1476889475" id="E0049">
+    <event handle="_0000008800000088" change="1" id="E0051">
       <type>Occupation</type>
       <description>Retail Manager</description>
     </event>
-    <event handle="_0000007800000078" change="1476889475" id="E0050">
+    <event handle="_0000008900000089" change="1" id="E0052">
       <type>Degree</type>
       <dateval val="1988"/>
       <description>Business Management</description>
     </event>
-    <event handle="_0000007a0000007a" change="1476889475" id="E0051">
+    <event handle="_0000008b0000008b" change="1" id="E0053">
       <type>Birth</type>
       <dateval val="1903-06-03"/>
-      <place hlink="_0000007b0000007b"/>
+      <place hlink="_0000008c0000008c"/>
       <description>Birth of Marjorie Ohman</description>
     </event>
-    <event handle="_0000007c0000007c" change="1476889475" id="E0052">
+    <event handle="_0000008d0000008d" change="1" id="E0054">
       <type>Death</type>
       <dateval val="1980-06-22"/>
-      <place hlink="_0000002700000027"/>
+      <place hlink="_0000003400000034"/>
       <description>Death of Marjorie Ohman</description>
     </event>
-    <event handle="_0000007e0000007e" change="1476889475" id="E0053">
+    <event handle="_0000008f0000008f" change="1" id="E0055">
       <type>Birth</type>
       <dateval val="1966-07-02"/>
-      <place hlink="_0000007f0000007f"/>
+      <place hlink="_0000009000000090"/>
       <description>Birth of Darcy Horne</description>
     </event>
-    <event handle="_0000008100000081" change="1476889475" id="E0054">
+    <event handle="_0000009200000092" change="1" id="E0056">
       <type>Birth</type>
       <dateval val="1935-03-13"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001c0000001c"/>
       <description>Birth of Lloyd Smith</description>
     </event>
-    <event handle="_0000008300000083" change="1476889475" id="E0055">
+    <event handle="_0000009400000094" change="1" id="E0057">
       <type>Birth</type>
       <dateval val="1933-11-22"/>
-      <place hlink="_0000000700000007"/>
+      <place hlink="_0000001600000016"/>
       <description>Birth of Alice Paula Perkins</description>
     </event>
-    <event handle="_0000008500000085" change="1476889475" id="E0056">
+    <event handle="_0000009600000096" change="1" id="E0058">
       <type>Birth</type>
       <dateval val="1991-09-16"/>
-      <place hlink="_0000008600000086"/>
+      <place hlink="_0000009700000097"/>
       <description>Birth of Lars Peter Smith</description>
     </event>
-    <event handle="_0000008700000087" change="1476889475" id="E0057">
+    <event handle="_0000009800000098" change="1" id="E0059">
       <type>Adopted</type>
     </event>
-    <event handle="_0000008900000089" change="1476889475" id="E0058">
+    <event handle="_0000009a0000009a" change="1" id="E0060">
       <type>Birth</type>
       <dateval val="1800-09-14"/>
-      <place hlink="_0000001900000019"/>
+      <place hlink="_0000002600000026"/>
       <description>Birth of Elna Jefferson</description>
     </event>
-    <event handle="_0000008a0000008a" change="1476889475" id="E0059">
+    <event handle="_0000009b0000009b" change="1" id="E0061">
       <type>Death</type>
-      <place hlink="_0000004b0000004b"/>
+      <place hlink="_0000005c0000005c"/>
       <description>Death of Elna Jefferson</description>
     </event>
-    <event handle="_0000008b0000008b" change="1476889475" id="E0060">
+    <event handle="_0000009c0000009c" change="1" id="E0062">
       <type>Christening</type>
       <dateval val="1800-09-16"/>
-      <place hlink="_0000001900000019"/>
+      <place hlink="_0000002600000026"/>
       <description>Christening of Elna Jefferson</description>
     </event>
-    <event handle="_0000009000000090" change="1476889475" id="E0061">
+    <event handle="_000000a1000000a1" change="1" id="E0063">
       <type>Birth</type>
       <dateval val="1961-05-24"/>
-      <place hlink="_0000009300000093"/>
+      <place hlink="_000000a4000000a4"/>
       <description>Birth of Edwin Michael Smith</description>
-      <citationref hlink="_0000009200000092"/>
+      <citationref hlink="_000000a3000000a3"/>
     </event>
-    <event handle="_0000009400000094" change="1476889475" id="E0062">
+    <event handle="_000000a5000000a5" change="1" id="E0064">
       <type>Occupation</type>
       <description>Software Engineer</description>
-      <noteref hlink="_0000009500000095"/>
+      <noteref hlink="_000000a6000000a6"/>
     </event>
-    <event handle="_0000009600000096" change="1476889475" id="E0063">
+    <event handle="_000000a7000000a7" change="1" id="E0065">
       <type>Education</type>
       <daterange start="1979" stop="1984"/>
-      <place hlink="_0000009700000097"/>
+      <place hlink="_000000a8000000a8"/>
       <description>Education of Edwin Michael Smith</description>
     </event>
-    <event handle="_0000009800000098" change="1476889475" id="E0064">
+    <event handle="_000000a9000000a9" change="1" id="E0066">
       <type>Degree</type>
       <dateval val="1984"/>
       <description>B.S.E.E.</description>
     </event>
-    <event handle="_0000009a0000009a" change="1476889475" id="E0065">
+    <event handle="_000000ab000000ab" change="1" id="E0067">
       <type>Birth</type>
       <dateval val="1832-11-29"/>
-      <place hlink="_0000009b0000009b"/>
+      <place hlink="_000000ac000000ac"/>
       <description>Birth of Kerstina Hansdotter</description>
     </event>
-    <event handle="_0000009c0000009c" change="1476889475" id="E0066">
+    <event handle="_000000ad000000ad" change="1" id="E0068">
       <type>Death</type>
       <dateval val="1908" type="before"/>
-      <place hlink="_0000004b0000004b"/>
+      <place hlink="_0000005c0000005c"/>
       <description>Death of Kerstina Hansdotter</description>
     </event>
-    <event handle="_0000009e0000009e" change="1476889475" id="E0067">
+    <event handle="_000000af000000af" change="1" id="E0069">
       <type>Birth</type>
       <daterange start="1794" stop="1796"/>
-      <place hlink="_0000009f0000009f"/>
+      <place hlink="_000000b0000000b0"/>
       <description>Birth of Martin Smith</description>
     </event>
-    <event handle="_000000a0000000a0" change="1476889475" id="E0068">
+    <event handle="_000000b1000000b1" change="1" id="E0070">
       <type>Death</type>
-      <place hlink="_0000004b0000004b"/>
+      <place hlink="_0000005c0000005c"/>
       <description>Death of Martin Smith</description>
     </event>
-    <event handle="_000000a2000000a2" change="1476889475" id="E0069">
+    <event handle="_000000b3000000b3" change="1" id="E0071">
       <type>Birth</type>
       <dateval val="1826-01-29"/>
-      <place hlink="_0000001900000019"/>
+      <place hlink="_0000002600000026"/>
       <description>Birth of Ingeman Smith</description>
     </event>
-    <event handle="_000000a4000000a4" change="1476889475" id="E0070">
+    <event handle="_000000b5000000b5" change="1" id="E0072">
       <type>Birth</type>
       <dateval val="1960-02-05"/>
-      <place hlink="_0000009300000093"/>
+      <place hlink="_000000a4000000a4"/>
       <description>Birth of Marjorie Alice Smith</description>
     </event>
-    <event handle="_000000a6000000a6" change="1476889475" id="E0071">
+    <event handle="_000000b7000000b7" change="1" id="E0073">
       <type>Birth</type>
       <dateval val="1935-12-02"/>
       <description>Birth of Janis Elaine Green</description>
     </event>
-    <event handle="_000000a8000000a8" change="1476889475" id="E0072">
+    <event handle="_000000b9000000b9" change="1" id="E0074">
       <type>Birth</type>
       <dateval val="1996-06-26"/>
-      <place hlink="_0000003b0000003b"/>
+      <place hlink="_0000004e0000004e"/>
       <description>Birth of Mason Michael Smith</description>
     </event>
-    <event handle="_000000a9000000a9" change="1476889475" id="E0073">
+    <event handle="_000000ba000000ba" change="1" id="E0075">
       <type>Christening</type>
       <dateval val="1996-07-10"/>
-      <place hlink="_0000003d0000003d"/>
+      <place hlink="_0000005000000050"/>
       <description>Christening of Mason Michael Smith</description>
     </event>
-    <event handle="_000000ab000000ab" change="1476889475" id="E0074">
+    <event handle="_000000bc000000bc" change="1" id="E0076">
       <type>Birth</type>
-      <dateval val="1886" type="about"/>
+      <daterange start="1886-12" stop="1897-13" cformat="Hebrew"/>
       <description>Birth of Edwin Willard</description>
     </event>
-    <event handle="_000000ad000000ad" change="1476889475" id="E0075">
+    <event handle="_000000be000000be" change="1" id="E0077">
       <type>Birth</type>
       <dateval val="1823" type="after"/>
-      <place hlink="_0000001900000019"/>
+      <place hlink="_0000002600000026"/>
       <description>Birth of Ingar Smith</description>
     </event>
-    <event handle="_000000af000000af" change="1476889475" id="E0076">
+    <event handle="_000000bf000000bf" change="1" id="E0078">
       <type>Birth</type>
       <dateval val="1895-04-07"/>
-      <place hlink="_0000001200000012"/>
+      <place hlink="_0000000700000007"/>
       <description>Birth of Hjalmar Smith</description>
     </event>
-    <event handle="_000000b0000000b0" change="1476889475" id="E0077">
+    <event handle="_000000c0000000c0" change="1" id="E0079">
       <type>Death</type>
       <dateval val="1975-06-26"/>
-      <place hlink="_0000002700000027"/>
+      <place hlink="_0000003400000034"/>
       <description>Death of Hjalmar Smith</description>
     </event>
-    <event handle="_000000b1000000b1" change="1476889475" id="E0078">
+    <event handle="_000000c1000000c1" change="1" id="E0080">
       <type>Baptism</type>
       <dateval val="1895-06-03"/>
-      <place hlink="_000000b2000000b2"/>
+      <place hlink="_000000c2000000c2"/>
       <description>Baptism of Hjalmar Smith</description>
     </event>
-    <event handle="_000000b3000000b3" change="1476889475" id="E0079">
+    <event handle="_000000c3000000c3" change="1" id="E0081">
       <type>Immi</type>
       <dateval val="1912-11-14"/>
-      <place hlink="_0000005800000058"/>
+      <place hlink="_0000006700000067"/>
     </event>
-    <event handle="_000000b6000000b6" change="1476889475" id="E0080">
+    <event handle="_000000c6000000c6" change="1" id="E0082">
       <type>Birth</type>
       <dateval val="1860-09-27"/>
-      <place hlink="_0000007200000072"/>
+      <place hlink="_0000008100000081"/>
       <description>Birth of Emil Smith</description>
     </event>
-    <event handle="_000000b7000000b7" change="1476889475" id="E0081">
+    <event handle="_000000c7000000c7" change="1" id="E0083">
+      <type>Residence</type>
+      <datespan start="1873" stop="1878"/>
+      <place hlink="_000000c8000000c8"/>
+      <description>At the boarding school</description>
+    </event>
+    <event handle="_000000c9000000c9" change="1" id="E0084">
+      <type>Residence</type>
+      <datestr val="from 1873 to  &lt;hebrew&gt;1878"/>
+      <place hlink="_000000ca000000ca"/>
+      <description>At the hebrew boarding school</description>
+    </event>
+    <event handle="_000000cb000000cb" change="1" id="E0085">
       <type>Marriage</type>
-      <dateval val="1816" type="about"/>
-      <place hlink="_0000001900000019"/>
+      <daterange start="1816" stop="1817"/>
+      <place hlink="_0000002600000026"/>
       <description>Marriage of Martin Smith and Elna Jefferson</description>
     </event>
-    <event handle="_000000b8000000b8" change="1476889475" id="E0082">
+    <event handle="_000000cc000000cc" change="1" id="E0086">
       <type>Marriage</type>
-      <dateval val="1790" type="about"/>
-      <place hlink="_0000004b0000004b"/>
+      <datestr val="between 1789 and  &lt;hebrew&gt;1790"/>
+      <place hlink="_0000005c0000005c"/>
       <description>Marriage of Ingeman Smith and Marta Ericsdotter</description>
     </event>
-    <event handle="_000000b9000000b9" change="1476889475" id="E0083">
+    <event handle="_000000cd000000cd" change="1" id="E0087">
       <type>Marriage</type>
       <dateval val="1986-07-12"/>
-      <place hlink="_000000ba000000ba"/>
+      <place hlink="_000000ce000000ce"/>
       <description>Marriage of Eric Lloyd Smith and Darcy Horne</description>
     </event>
-    <event handle="_000000bb000000bb" change="1476889475" id="E0084">
+    <event handle="_000000d0000000d0" change="1" id="E0088">
       <type>Marriage</type>
       <dateval val="1884-08-24"/>
-      <place hlink="_0000001200000012"/>
+      <place hlink="_0000000700000007"/>
       <description>Marriage of Magnes Smith and Anna Streiffert</description>
-      <objref hlink="_000000bc000000bc"/>
+      <objref hlink="_000000d1000000d1"/>
     </event>
-    <event handle="_000000bf000000bf" change="1476889475" id="E0085">
+    <event handle="_000000d3000000d3" change="1" id="E0089">
       <type>Marriage Banns</type>
       <dateval val="1883-08-24"/>
       <description>Celebration</description>
     </event>
-    <event handle="_000000c1000000c1" change="1476889475" id="E0086">
+    <event handle="_000000d5000000d5" change="1" id="E0090">
       <type>Marriage</type>
       <dateval val="1954-06-04"/>
-      <place hlink="_0000000700000007"/>
+      <place hlink="_0000001600000016"/>
       <description>Marriage of John Hjalmar Smith and Alice Paula Perkins</description>
-      <citationref hlink="_000000c2000000c2"/>
+      <citationref hlink="_000000d6000000d6"/>
     </event>
-    <event handle="_000000c6000000c6" change="1476889475" id="E0087">
+    <event handle="_000000da000000da" change="1" id="E0091">
       <type>Marriage</type>
       <dateval val="1995-05-27"/>
-      <place hlink="_000000c7000000c7"/>
+      <place hlink="_000000db000000db"/>
       <description>Marriage of Edwin Michael Smith and Janice Ann Adams</description>
     </event>
-    <event handle="_000000c8000000c8" change="1476889475" id="E0088" priv="1">
+    <event handle="_000000dc000000dc" change="1" id="E0092" priv="1">
       <type>Engagement</type>
       <dateval val="1994-10-05"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001c0000001c"/>
       <description>Engagement of Edwin Michael Smith and Janice Ann Adams</description>
       <attribute type="Time" value="2:00pm"/>
       <attribute type="Agency" value="Lovely ring presentation"/>
       <attribute type="Witness" value="George Smorge"/>
       <attribute type="_UID" value="123456"/>
     </event>
-    <event handle="_000000c9000000c9" change="1476889475" id="E0089">
+    <event handle="_000000dd000000dd" change="1" id="E0093">
+      <type>Civil</type>
+      <description>Common law marriage</description>
+    </event>
+    <event handle="_000000de000000de" change="1" id="E0094">
       <type>Marriage</type>
-      <dateval val="1856" type="about"/>
+      <datespan start="1856" stop="1857"/>
       <description>Marriage of Martin Smith and Kerstina Hansdotter</description>
     </event>
-    <event handle="_000000ca000000ca" change="1476889475" id="E0090">
-      <type>Marriage</type>
-      <dateval val="1885-11-27"/>
-      <place hlink="_0000001200000012"/>
-      <description>Marriage of Gustaf Smith, Sr. and Anna Hansdotter</description>
-    </event>
-    <event handle="_000000cb000000cb" change="1476889475" id="E0091">
+    <event handle="_000000df000000df" change="1" id="E0095">
       <type>Marriage</type>
       <dateval val="1910" type="about"/>
       <description>Marriage of Edwin Willard and Kirsti Marie Smith</description>
     </event>
-    <event handle="_000000cc000000cc" change="1476889475" id="E0092">
+    <event handle="_000000e0000000e0" change="1" id="E0096">
       <type>Marriage</type>
       <dateval val="1912-11-30"/>
-      <place hlink="_0000001200000012"/>
+      <place hlink="_0000000700000007"/>
       <description>Marriage of Herman Julius Nielsen and Astrid Shermanna Augusta Smith</description>
     </event>
-    <event handle="_000000cd000000cd" change="1476889475" id="E0093">
+    <event handle="_000000e1000000e1" change="1" id="E0097">
       <type>Marriage</type>
       <dateval val="1927-10-31"/>
-      <place hlink="_0000002700000027"/>
+      <place hlink="_0000003400000034"/>
       <description>Marriage of Hjalmar Smith and Marjorie Ohman</description>
     </event>
-    <event handle="_000000ce000000ce" change="1476889475" id="E0094">
+    <event handle="_000000e2000000e2" change="1" id="E0098">
       <type>Marriage</type>
       <dateval val="1920" type="about"/>
       <description>Marriage of Gus Smith and Evelyn Michaels</description>
     </event>
-    <event handle="_000000cf000000cf" change="1476889475" id="E0095">
+    <event handle="_000000e3000000e3" change="1" id="E0099">
       <type>Marriage</type>
       <dateval val="1958-08-10"/>
-      <place hlink="_0000000d0000000d"/>
+      <place hlink="_0000001c0000001c"/>
       <description>Marriage of Lloyd Smith and Janis Elaine Green</description>
+    </event>
+    <event handle="_000000e5000000e5" change="1" id="E0100">
+      <type>Marriage</type>
     </event>
   </events>
   <people>
-    <person handle="_0000000100000001" change="1198222526" id="I0000">
+    <person handle="_0000000400000004" change="1198222526" id="I0024">
+      <gender>M</gender>
+      <name type="Birth Name">
+        <first>Gustaf</first>
+        <surname>Smith</surname>
+        <suffix>Sr.</suffix>
+      </name>
+      <eventref hlink="_0000006300000063" role="Primary"/>
+      <eventref hlink="_0000006500000065" role="Primary"/>
+      <eventref hlink="_0000006600000066" role="Primary"/>
+      <eventref hlink="_0000006800000068" role="Primary"/>
+      <childof hlink="_0000005e0000005e"/>
+      <parentin hlink="_0000000300000003"/>
+      <personref hlink="_0000000900000009" rel="Friend">
+        <citationref hlink="_0000006c0000006c"/>
+      </personref>
+      <noteref hlink="_0000006900000069"/>
+      <citationref hlink="_0000006b0000006b"/>
+    </person>
+    <person handle="_0000000500000005" change="1" id="I0000">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Anna</first>
-        <surname>Hansdotter</surname>
-        <noteref hlink="_0000000200000002"/>
-      </name>
-      <eventref hlink="_0000000300000003" role="Primary"/>
-      <eventref hlink="_0000000500000005" role="Primary"/>
-      <parentin hlink="_0000000800000008"/>
-      <noteref hlink="_0000000900000009"/>
-    </person>
-    <person handle="_0000000a0000000a" change="1198222526" id="I0001">
-      <gender>M</gender>
-      <name type="Birth Name">
-        <first>Keith Lloyd</first>
-        <surname>Smith</surname>
-        <noteref hlink="_0000000b0000000b"/>
-      </name>
-      <eventref hlink="_0000000c0000000c" role="Primary"/>
-      <childof hlink="_0000000e0000000e"/>
-      <noteref hlink="_0000000f0000000f"/>
-    </person>
-    <person handle="_0000001000000010" change="1198222526" id="I0010">
-      <gender>M</gender>
-      <name type="Birth Name">
-        <first>Hans Peter</first>
-        <surname>Smith</surname>
-      </name>
-      <eventref hlink="_0000001100000011" role="Primary"/>
-      <eventref hlink="_0000001300000013" role="Primary"/>
-      <childof hlink="_0000000800000008"/>
-      <parentin hlink="_0000001400000014"/>
-      <parentin hlink="_0000001500000015"/>
-      <noteref hlink="_0000001600000016"/>
-    </person>
-    <person handle="_0000001700000017" change="1198222526" id="I0011">
-      <gender>F</gender>
-      <name type="Birth Name">
-        <first>Hanna</first>
-        <surname>Smith</surname>
-      </name>
-      <eventref hlink="_0000001800000018" role="Primary"/>
-      <childof hlink="_0000001a0000001a"/>
-      <noteref hlink="_0000001b0000001b"/>
-    </person>
-    <person handle="_0000001c0000001c" change="1198222526" id="I0012">
-      <gender>M</gender>
-      <name type="Birth Name">
-        <first>Herman Julius</first>
-        <surname>Nielsen</surname>
-      </name>
-      <eventref hlink="_0000001d0000001d" role="Primary"/>
-      <eventref hlink="_0000001e0000001e" role="Primary"/>
-      <parentin hlink="_0000001f0000001f"/>
-      <noteref hlink="_0000002000000020"/>
-    </person>
-    <person handle="_0000002100000021" change="1198222526" id="I0013">
-      <gender>F</gender>
-      <name type="Birth Name">
-        <first>Evelyn</first>
-        <surname>Michaels</surname>
-      </name>
-      <eventref hlink="_0000002200000022" role="Primary"/>
-      <parentin hlink="_0000002300000023"/>
-      <noteref hlink="_0000002400000024"/>
-    </person>
-    <person handle="_0000002500000025" change="1198222526" id="I0014">
-      <gender>F</gender>
-      <name type="Birth Name">
-        <first>Marjorie Lee</first>
-        <surname>Smith</surname>
-      </name>
-      <eventref hlink="_0000002600000026" role="Primary"/>
-      <childof hlink="_0000002800000028"/>
-    </person>
-    <person handle="_0000002900000029" change="1198222526" id="I0015">
-      <gender>M</gender>
-      <name type="Birth Name">
-        <first>Gus</first>
-        <surname>Smith</surname>
-      </name>
-      <eventref hlink="_0000002a0000002a" role="Primary"/>
-      <eventref hlink="_0000002b0000002b" role="Primary"/>
-      <childof hlink="_0000000800000008"/>
-      <parentin hlink="_0000002300000023"/>
-    </person>
-    <person handle="_0000002c0000002c" change="1198222526" id="I0016">
-      <gender>F</gender>
-      <name type="Birth Name">
-        <first>Jennifer</first>
-        <surname>Anderson</surname>
-      </name>
-      <eventref hlink="_0000002d0000002d" role="Primary"/>
-      <eventref hlink="_0000002e0000002e" role="Primary"/>
-      <parentin hlink="_0000001500000015"/>
-    </person>
-    <person handle="_0000002f0000002f" change="1198222526" id="I0017">
-      <gender>F</gender>
-      <name type="Birth Name">
-        <first>Lillie Harriet</first>
-        <surname>Jones</surname>
-      </name>
-      <eventref hlink="_0000003000000030" role="Primary"/>
-      <eventref hlink="_0000003100000031" role="Primary"/>
-      <parentin hlink="_0000001400000014"/>
-    </person>
-    <person handle="_0000003200000032" change="1476889475" id="I0018">
-      <gender>M</gender>
-      <name type="Birth Name">
-        <first>John Hjalmar</first>
-        <surname>Smith</surname>
-      </name>
-      <eventref hlink="_0000003300000033" role="Primary"/>
-      <eventref hlink="_000000c6000000c6" role="Witness"/>
-      <childof hlink="_0000002800000028"/>
-      <parentin hlink="_0000003400000034"/>
-    </person>
-    <person handle="_0000003500000035" change="1198222526" id="I0019">
-      <gender>M</gender>
-      <name type="Birth Name">
-        <first>Eric Lloyd</first>
-        <surname>Smith</surname>
-      </name>
-      <eventref hlink="_0000003600000036" role="Primary"/>
-      <eventref hlink="_0000003700000037" role="Primary"/>
-      <childof hlink="_0000000e0000000e"/>
-      <parentin hlink="_0000003800000038"/>
-    </person>
-    <person handle="_0000003900000039" change="1198222526" id="I0002">
-      <gender>F</gender>
-      <name type="Birth Name">
-        <first>Amber Marie</first>
-        <surname>Smith</surname>
-      </name>
-      <eventref hlink="_0000003a0000003a" role="Primary"/>
-      <eventref hlink="_0000003c0000003c" role="Primary"/>
-      <childof hlink="_0000003e0000003e"/>
-    </person>
-    <person handle="_0000003f0000003f" change="1198222526" id="I0020">
-      <gender>M</gender>
-      <name type="Birth Name">
-        <first>Carl Emil</first>
-        <surname>Smith</surname>
-      </name>
-      <eventref hlink="_0000004000000040" role="Primary"/>
-      <eventref hlink="_0000004100000041" role="Primary"/>
-      <childof hlink="_0000000800000008"/>
-    </person>
-    <person handle="_0000004200000042" change="1198222526" id="I0021">
-      <gender>M</gender>
-      <name type="Birth Name">
-        <first>Hjalmar</first>
-        <surname>Smith</surname>
+        <surname prefix="Vrow">Smith</surname>
+        <noteref hlink="_0000001100000011"/>
       </name>
       <name alt="1" type="Also Known As">
-        <first>James</first>
+        <first>Anna</first>
         <surname>Smith</surname>
       </name>
-      <name alt="1" type="Also Known As">
-        <first>Jimmy Smith</first>
-      </name>
-      <eventref hlink="_0000004300000043" role="Primary"/>
-      <eventref hlink="_0000004400000044" role="Primary"/>
-      <eventref hlink="_0000004500000045" role="Primary"/>
-      <eventref hlink="_0000004600000046" role="Primary"/>
-      <eventref hlink="_0000004800000048" role="Primary"/>
-      <childof hlink="_0000000800000008"/>
-      <personref hlink="_0000004700000047" rel="Alias"/>
+      <eventref hlink="_0000001200000012" role="Primary"/>
+      <eventref hlink="_0000001400000014" role="Primary"/>
+      <objref hlink="_0000001800000018"/>
+      <attribute type="Nickname" value="Hanna"/>
+      <parentin hlink="_0000000300000003"/>
+      <noteref hlink="_0000001700000017"/>
     </person>
-    <person handle="_0000004700000047" change="1476889475" id="I0022">
-      <gender>M</gender>
+    <person handle="_0000000800000008" change="1198222526" id="I0026">
+      <gender>F</gender>
       <name type="Birth Name">
-        <first>Martin</first>
+        <first>Kirsti Marie</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000004900000049" role="Primary"/>
-      <eventref hlink="_0000004a0000004a" role="Primary"/>
-      <eventref hlink="_0000004c0000004c" role="Primary"/>
-      <eventref hlink="_0000004f0000004f" role="Primary"/>
-      <attribute type="RESN" value=""/>
-      <childof hlink="_0000001a0000001a"/>
-      <parentin hlink="_0000004d0000004d"/>
-      <noteref hlink="_0000004e0000004e"/>
+      <eventref hlink="_0000007100000071" role="Primary"/>
+      <eventref hlink="_0000007200000072" role="Primary"/>
+      <childof hlink="_0000000300000003"/>
+      <parentin hlink="_0000007300000073"/>
     </person>
-    <person handle="_0000005000000050" change="1198222526" id="I0023">
+    <person handle="_0000000900000009" change="1198222526" id="I0023">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Astrid Shermanna</first>
@@ -766,28 +657,209 @@
         <surname>Smith</surname>
         <title>Dr.</title>
       </name>
-      <eventref hlink="_0000005100000051" role="Primary"/>
-      <eventref hlink="_0000005200000052" role="Primary"/>
-      <childof hlink="_0000000800000008"/>
-      <parentin hlink="_0000001f0000001f"/>
+      <eventref hlink="_0000006100000061" role="Primary"/>
+      <eventref hlink="_0000006200000062" role="Primary"/>
+      <childof hlink="_0000000300000003"/>
+      <parentin hlink="_0000002c0000002c"/>
     </person>
-    <person handle="_0000005300000053" change="1198222526" id="I0024">
+    <person handle="_0000000a0000000a" change="1198222526" id="I0021">
       <gender>M</gender>
       <name type="Birth Name">
-        <first>Gustaf</first>
+        <first>Hjalmar</first>
         <surname>Smith</surname>
-        <suffix>Sr.</suffix>
+      </name>
+      <name alt="1" type="Also Known As">
+        <first>James</first>
+        <surname>Smith</surname>
+      </name>
+      <name alt="1" type="Also Known As">
+        <first>Jimmy Smith</first>
       </name>
       <eventref hlink="_0000005400000054" role="Primary"/>
+      <eventref hlink="_0000005500000055" role="Primary"/>
       <eventref hlink="_0000005600000056" role="Primary"/>
       <eventref hlink="_0000005700000057" role="Primary"/>
       <eventref hlink="_0000005900000059" role="Primary"/>
-      <childof hlink="_0000004d0000004d"/>
-      <parentin hlink="_0000000800000008"/>
-      <noteref hlink="_0000005a0000005a"/>
-      <citationref hlink="_0000005c0000005c"/>
+      <childof hlink="_0000000300000003"/>
+      <personref hlink="_0000005800000058" rel="Alias"/>
     </person>
-    <person handle="_0000005d0000005d" change="1198222526" id="I0025">
+    <person handle="_0000000b0000000b" change="1198222526" id="I0008">
+      <gender>M</gender>
+      <name type="Birth Name">
+        <first>Hjalmar</first>
+        <surname>Smith</surname>
+      </name>
+      <eventref hlink="_000000bf000000bf" role="Primary"/>
+      <eventref hlink="_000000c0000000c0" role="Primary"/>
+      <eventref hlink="_000000c1000000c1" role="Primary"/>
+      <eventref hlink="_000000c3000000c3" role="Primary"/>
+      <childof hlink="_0000000300000003"/>
+      <parentin hlink="_0000003500000035"/>
+      <noteref hlink="_000000c4000000c4"/>
+    </person>
+    <person handle="_0000000c0000000c" change="1198222526" id="I0015">
+      <gender>M</gender>
+      <name type="Birth Name">
+        <first>Gus</first>
+        <surname>Smith</surname>
+      </name>
+      <eventref hlink="_0000003600000036" role="Primary"/>
+      <eventref hlink="_0000003700000037" role="Primary"/>
+      <childof hlink="_0000000300000003"/>
+      <parentin hlink="_0000003000000030"/>
+    </person>
+    <person handle="_0000000d0000000d" change="1198222526" id="I0020">
+      <gender>M</gender>
+      <name type="Birth Name">
+        <first>Carl Emil</first>
+        <surname>Smith</surname>
+      </name>
+      <eventref hlink="_0000005200000052" role="Primary"/>
+      <eventref hlink="_0000005300000053" role="Primary"/>
+      <childof hlink="_0000000300000003"/>
+    </person>
+    <person handle="_0000000e0000000e" change="1198222526" id="I0010">
+      <gender>M</gender>
+      <name type="Birth Name">
+        <first>Hans Peter</first>
+        <surname>Smith</surname>
+      </name>
+      <eventref hlink="_0000001f0000001f" role="Primary"/>
+      <eventref hlink="_0000002000000020" role="Primary"/>
+      <childof hlink="_0000000300000003"/>
+      <parentin hlink="_0000002100000021"/>
+      <parentin hlink="_0000002200000022"/>
+      <noteref hlink="_0000002300000023"/>
+    </person>
+    <person handle="_0000001900000019" change="1198222526" id="I0001">
+      <gender>M</gender>
+      <name type="Birth Name">
+        <first>Keith Lloyd</first>
+        <surname>Smith</surname>
+        <noteref hlink="_0000001a0000001a"/>
+      </name>
+      <eventref hlink="_0000001b0000001b" role="Primary"/>
+      <childof hlink="_0000001d0000001d"/>
+      <noteref hlink="_0000001e0000001e"/>
+    </person>
+    <person handle="_0000002400000024" change="1198222526" id="I0011">
+      <gender>F</gender>
+      <name type="Birth Name">
+        <first>Hanna</first>
+        <surname>Smith</surname>
+      </name>
+      <eventref hlink="_0000002500000025" role="Primary"/>
+      <childof hlink="_0000002700000027"/>
+      <noteref hlink="_0000002800000028"/>
+    </person>
+    <person handle="_0000002900000029" change="1198222526" id="I0012">
+      <gender>M</gender>
+      <name type="Birth Name">
+        <first>Herman Julius</first>
+        <surname>Nielsen</surname>
+      </name>
+      <eventref hlink="_0000002a0000002a" role="Primary"/>
+      <eventref hlink="_0000002b0000002b" role="Primary"/>
+      <parentin hlink="_0000002c0000002c"/>
+      <noteref hlink="_0000002d0000002d"/>
+    </person>
+    <person handle="_0000002e0000002e" change="1198222526" id="I0013">
+      <gender>F</gender>
+      <name type="Birth Name">
+        <first>Evelyn</first>
+        <surname>Michaels</surname>
+      </name>
+      <eventref hlink="_0000002f0000002f" role="Primary"/>
+      <parentin hlink="_0000003000000030"/>
+      <noteref hlink="_0000003100000031"/>
+    </person>
+    <person handle="_0000003200000032" change="1198222526" id="I0014">
+      <gender>F</gender>
+      <name type="Birth Name">
+        <first>Marjorie Lee</first>
+        <surname>Smith</surname>
+      </name>
+      <name alt="1" type="Nickname">
+        <first>Margie</first>
+      </name>
+      <eventref hlink="_0000003300000033" role="Primary"/>
+      <childof hlink="_0000003500000035"/>
+    </person>
+    <person handle="_0000003800000038" change="1198222526" id="I0016">
+      <gender>F</gender>
+      <name type="Birth Name">
+        <first>Jennifer</first>
+        <surname>Anderson</surname>
+      </name>
+      <eventref hlink="_0000003900000039" role="Primary"/>
+      <eventref hlink="_0000003a0000003a" role="Primary"/>
+      <eventref hlink="_0000003b0000003b" role="Primary"/>
+      <parentin hlink="_0000002200000022"/>
+      <noteref hlink="_0000003d0000003d"/>
+    </person>
+    <person handle="_0000003e0000003e" change="1198222526" id="I0017">
+      <gender>F</gender>
+      <name type="Birth Name">
+        <first>Lillie Harriet</first>
+        <surname>Jones</surname>
+      </name>
+      <eventref hlink="_0000003f0000003f" role="Primary"/>
+      <eventref hlink="_0000004000000040" role="Primary"/>
+      <parentin hlink="_0000002100000021"/>
+    </person>
+    <person handle="_0000004100000041" change="1" id="I0018">
+      <gender>M</gender>
+      <name type="Birth Name">
+        <first>John Hjalmar</first>
+        <surname>Smith</surname>
+      </name>
+      <eventref hlink="_0000004200000042" role="Primary"/>
+      <eventref hlink="_000000da000000da" role="Witness"/>
+      <attribute type="Social Security Number" value="987-555-4444">
+        <citationref hlink="_0000004500000045"/>
+        <noteref hlink="_0000004600000046"/>
+      </attribute>
+      <childof hlink="_0000003500000035"/>
+      <parentin hlink="_0000004300000043"/>
+      <noteref hlink="_0000004700000047"/>
+    </person>
+    <person handle="_0000004800000048" change="1198222526" id="I0019">
+      <gender>M</gender>
+      <name type="Birth Name">
+        <first>Eric Lloyd</first>
+        <surname>Smith</surname>
+      </name>
+      <eventref hlink="_0000004900000049" role="Primary"/>
+      <eventref hlink="_0000004a0000004a" role="Primary"/>
+      <childof hlink="_0000001d0000001d"/>
+      <parentin hlink="_0000004b0000004b"/>
+    </person>
+    <person handle="_0000004c0000004c" change="1198222526" id="I0002">
+      <gender>F</gender>
+      <name type="Birth Name">
+        <first>Amber Marie</first>
+        <surname>Smith</surname>
+      </name>
+      <eventref hlink="_0000004d0000004d" role="Primary"/>
+      <eventref hlink="_0000004f0000004f" role="Primary"/>
+      <childof hlink="_0000005100000051"/>
+    </person>
+    <person handle="_0000005800000058" change="1" id="I0022">
+      <gender>M</gender>
+      <name type="Birth Name">
+        <first>Martin</first>
+        <surname>Smith</surname>
+      </name>
+      <eventref hlink="_0000005a0000005a" role="Primary"/>
+      <eventref hlink="_0000005b0000005b" role="Primary"/>
+      <eventref hlink="_0000005d0000005d" role="Primary"/>
+      <eventref hlink="_0000006000000060" role="Primary"/>
+      <attribute type="RESN" value=""/>
+      <childof hlink="_0000002700000027"/>
+      <parentin hlink="_0000005e0000005e"/>
+      <noteref hlink="_0000005f0000005f"/>
+    </person>
+    <person handle="_0000006d0000006d" change="1198222526" id="I0025">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Marta</first>
@@ -797,550 +869,604 @@
         <first>Marta</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000005e0000005e" role="Primary"/>
+      <eventref hlink="_0000006e0000006e" role="Primary"/>
       <lds_ord type="confirmation">
         <dateval val="1790"/>
+        <temple val="STOCK"/>
       </lds_ord>
       <lds_ord type="endowment">
         <dateval val="1795"/>
+        <temple val="Stockholm"/>
       </lds_ord>
       <lds_ord type="sealed_to_parents">
         <dateval val="1796"/>
-        <place hlink="_0000006000000060"/>
-        <sealed_to hlink="_0000005f0000005f"/>
+        <temple val="STOCK"/>
+        <place hlink="_0000007000000070"/>
+        <sealed_to hlink="_0000006f0000006f"/>
       </lds_ord>
       <attribute type="Skills" value="Housekeeper"/>
-      <parentin hlink="_0000005f0000005f"/>
+      <parentin hlink="_0000006f0000006f"/>
     </person>
-    <person handle="_0000006100000061" change="1198222526" id="I0026">
-      <gender>F</gender>
-      <name type="Birth Name">
-        <first>Kirsti Marie</first>
-        <surname>Smith</surname>
-      </name>
-      <eventref hlink="_0000006200000062" role="Primary"/>
-      <eventref hlink="_0000006300000063" role="Primary"/>
-      <childof hlink="_0000000800000008"/>
-      <parentin hlink="_0000006400000064"/>
-    </person>
-    <person handle="_0000006500000065" change="1198222526" id="I0027">
+    <person handle="_0000007400000074" change="1198222526" id="I0027">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Ingeman</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000006600000066" role="Primary"/>
-      <parentin hlink="_0000005f0000005f"/>
+      <eventref hlink="_0000007500000075" role="Primary"/>
+      <parentin hlink="_0000006f0000006f"/>
     </person>
-    <person handle="_0000006700000067" change="1198222526" id="I0028">
+    <person handle="_0000007600000076" change="1198222526" id="I0028">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Anna</first>
         <surname>Streiffert</surname>
       </name>
-      <eventref hlink="_0000006800000068" role="Primary"/>
-      <eventref hlink="_0000006a0000006a" role="Primary"/>
-      <parentin hlink="_0000006b0000006b"/>
+      <eventref hlink="_0000007700000077" role="Primary"/>
+      <eventref hlink="_0000007900000079" role="Primary"/>
+      <parentin hlink="_0000007a0000007a"/>
     </person>
-    <person handle="_0000006c0000006c" change="1198222526" id="I0029">
+    <person handle="_0000007b0000007b" change="1198222526" id="I0029">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Craig Peter</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000006d0000006d" role="Primary"/>
-      <eventref hlink="_0000006e0000006e" role="Primary"/>
-      <childof hlink="_0000000e0000000e"/>
+      <eventref hlink="_0000007c0000007c" role="Primary"/>
+      <eventref hlink="_0000007d0000007d" role="Primary"/>
+      <childof hlink="_0000001d0000001d"/>
     </person>
-    <person handle="_0000007000000070" change="1198222526" id="I0003">
-      <gender>M</gender>
+    <person handle="_0000007f0000007f" change="1198222526" id="I0003">
+      <gender>U</gender>
       <name type="Birth Name">
         <first>Magnes</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000007100000071" role="Primary"/>
-      <eventref hlink="_0000007300000073" role="Primary"/>
-      <childof hlink="_0000004d0000004d"/>
-      <parentin hlink="_0000006b0000006b"/>
+      <eventref hlink="_0000008000000080" role="Primary"/>
+      <eventref hlink="_0000008200000082" role="Primary"/>
+      <attribute type="Social Security Number" value="987-654-3210"/>
+      <childof hlink="_0000005e0000005e"/>
+      <parentin hlink="_0000007a0000007a"/>
     </person>
-    <person handle="_0000007400000074" change="1198222526" id="I0030">
+    <person handle="_0000008300000083" change="1198222526" id="I0030">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Janice Ann</first>
         <surname>Adams</surname>
       </name>
-      <eventref hlink="_0000007500000075" role="Primary"/>
-      <eventref hlink="_0000007700000077" role="Primary"/>
-      <eventref hlink="_0000007800000078" role="Primary"/>
-      <parentin hlink="_0000003e0000003e"/>
+      <eventref hlink="_0000008400000084" role="Primary"/>
+      <eventref hlink="_0000008800000088" role="Primary"/>
+      <eventref hlink="_0000008900000089" role="Primary"/>
+      <parentin hlink="_0000005100000051"/>
     </person>
-    <person handle="_0000007900000079" change="1198222526" id="I0031">
+    <person handle="_0000008a0000008a" change="1198222526" id="I0031">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Marjorie</first>
         <surname>Ohman</surname>
       </name>
-      <eventref hlink="_0000007a0000007a" role="Primary"/>
-      <eventref hlink="_0000007c0000007c" role="Primary"/>
-      <parentin hlink="_0000002800000028"/>
+      <eventref hlink="_0000008b0000008b" role="Primary"/>
+      <eventref hlink="_0000008d0000008d" role="Primary"/>
+      <parentin hlink="_0000003500000035"/>
     </person>
-    <person handle="_0000007d0000007d" change="1198222526" id="I0032">
+    <person handle="_0000008e0000008e" change="1198222526" id="I0032">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Darcy</first>
         <surname>Horne</surname>
       </name>
-      <eventref hlink="_0000007e0000007e" role="Primary"/>
-      <parentin hlink="_0000003800000038"/>
+      <eventref hlink="_0000008f0000008f" role="Primary"/>
+      <parentin hlink="_0000004b0000004b"/>
     </person>
-    <person handle="_0000008000000080" change="1198222526" id="I0033">
+    <person handle="_0000009100000091" change="1198222526" id="I0033">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Lloyd</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000008100000081" role="Primary"/>
-      <childof hlink="_0000001400000014"/>
-      <parentin hlink="_0000000e0000000e"/>
+      <eventref hlink="_0000009200000092" role="Primary"/>
+      <childof hlink="_0000002100000021"/>
+      <parentin hlink="_0000001d0000001d"/>
     </person>
-    <person handle="_0000008200000082" change="1198222526" id="I0034">
+    <person handle="_0000009300000093" change="1198222526" id="I0034">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Alice Paula</first>
         <surname>Perkins</surname>
       </name>
-      <eventref hlink="_0000008300000083" role="Primary"/>
-      <parentin hlink="_0000003400000034"/>
+      <eventref hlink="_0000009400000094" role="Primary"/>
+      <parentin hlink="_0000004300000043"/>
     </person>
-    <person handle="_0000008400000084" change="1198222526" id="I0035">
+    <person handle="_0000009500000095" change="1198222526" id="I0035">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Lars Peter</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000008500000085" role="Primary"/>
-      <eventref hlink="_0000008700000087" role="Primary"/>
-      <childof hlink="_0000003800000038"/>
+      <name alt="1" type="Adopted">
+        <first>Lars Peter</first>
+        <surname>Jones</surname>
+      </name>
+      <name alt="1" type="Adopted">
+        <first>Pete Jones</first>
+      </name>
+      <eventref hlink="_0000009600000096" role="Primary"/>
+      <eventref hlink="_0000009800000098" role="Primary"/>
+      <childof hlink="_0000004b0000004b"/>
     </person>
-    <person handle="_0000008800000088" change="1198222526" id="I0036">
+    <person handle="_0000009900000099" change="1198222526" id="I0036">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Elna</first>
         <surname>Jefferson</surname>
       </name>
-      <eventref hlink="_0000008900000089" role="Primary"/>
-      <eventref hlink="_0000008a0000008a" role="Primary"/>
-      <eventref hlink="_0000008b0000008b" role="Primary"/>
-      <parentin hlink="_0000001a0000001a"/>
+      <eventref hlink="_0000009a0000009a" role="Primary"/>
+      <eventref hlink="_0000009b0000009b" role="Primary"/>
+      <eventref hlink="_0000009c0000009c" role="Primary"/>
+      <parentin hlink="_0000002700000027"/>
     </person>
-    <person handle="_0000008c0000008c" change="1198222526" id="I0037">
+    <person handle="_0000009d0000009d" change="1198222526" id="I0037">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Edwin Michael</first>
         <surname>Smith</surname>
-        <citationref hlink="_0000008f0000008f"/>
+        <citationref hlink="_000000a0000000a0"/>
       </name>
-      <eventref hlink="_0000009000000090" role="Primary"/>
-      <eventref hlink="_0000009400000094" role="Primary">
+      <eventref hlink="_000000a1000000a1" role="Primary"/>
+      <eventref hlink="_000000a5000000a5" role="Primary">
         <attribute type="Age" value="23"/>
       </eventref>
-      <eventref hlink="_0000009600000096" role="Primary"/>
-      <eventref hlink="_0000009800000098" role="Primary"/>
-      <childof hlink="_0000003400000034"/>
-      <parentin hlink="_0000003e0000003e"/>
+      <eventref hlink="_000000a7000000a7" role="Primary"/>
+      <eventref hlink="_000000a9000000a9" role="Primary"/>
+      <childof hlink="_0000004300000043"/>
+      <parentin hlink="_0000005100000051"/>
     </person>
-    <person handle="_0000009900000099" change="1198222526" id="I0038">
+    <person handle="_000000aa000000aa" change="1198222526" id="I0038">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Kerstina</first>
         <surname>Hansdotter</surname>
       </name>
-      <eventref hlink="_0000009a0000009a" role="Primary"/>
-      <eventref hlink="_0000009c0000009c" role="Primary"/>
-      <parentin hlink="_0000004d0000004d"/>
+      <eventref hlink="_000000ab000000ab" role="Primary"/>
+      <eventref hlink="_000000ad000000ad" role="Primary"/>
+      <parentin hlink="_0000005e0000005e"/>
     </person>
-    <person handle="_0000009d0000009d" change="1198222526" id="I0039">
+    <person handle="_000000ae000000ae" change="1198222526" id="I0039">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Martin</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_0000009e0000009e" role="Primary"/>
-      <eventref hlink="_000000a0000000a0" role="Primary"/>
-      <childof hlink="_0000005f0000005f"/>
-      <parentin hlink="_0000001a0000001a"/>
+      <eventref hlink="_000000af000000af" role="Primary"/>
+      <eventref hlink="_000000b1000000b1" role="Primary"/>
+      <childof hlink="_0000006f0000006f"/>
+      <parentin hlink="_0000002700000027"/>
     </person>
-    <person handle="_000000a1000000a1" change="1198222526" id="I0004">
+    <person handle="_000000b2000000b2" change="1198222526" id="I0004">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Ingeman</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_000000a2000000a2" role="Primary"/>
-      <childof hlink="_0000001a0000001a"/>
+      <eventref hlink="_000000b3000000b3" role="Primary"/>
+      <childof hlink="_0000002700000027"/>
     </person>
-    <person handle="_000000a3000000a3" change="1198222526" id="I0040">
+    <person handle="_000000b4000000b4" change="1198222526" id="I0040">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Marjorie Alice</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_000000a4000000a4" role="Primary"/>
-      <childof hlink="_0000003400000034"/>
+      <eventref hlink="_000000b5000000b5" role="Primary"/>
+      <childof hlink="_0000004300000043"/>
     </person>
-    <person handle="_000000a5000000a5" change="1198222526" id="I0041">
+    <person handle="_000000b6000000b6" change="1198222526" id="I0041">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Janis Elaine</first>
         <surname>Green</surname>
       </name>
-      <eventref hlink="_000000a6000000a6" role="Primary"/>
-      <parentin hlink="_0000000e0000000e"/>
+      <eventref hlink="_000000b7000000b7" role="Primary"/>
+      <parentin hlink="_0000001d0000001d"/>
     </person>
-    <person handle="_000000a7000000a7" change="1198222526" id="I0005">
+    <person handle="_000000b8000000b8" change="1198222526" id="I0005">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Mason Michael</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_000000a8000000a8" role="Primary"/>
-      <eventref hlink="_000000a9000000a9" role="Primary"/>
-      <childof hlink="_0000003e0000003e"/>
+      <eventref hlink="_000000b9000000b9" role="Primary"/>
+      <eventref hlink="_000000ba000000ba" role="Primary"/>
+      <childof hlink="_0000005100000051"/>
     </person>
-    <person handle="_000000aa000000aa" change="1198222526" id="I0006">
+    <person handle="_000000bb000000bb" change="1198222526" id="I0006">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Edwin</first>
         <surname>Willard</surname>
       </name>
-      <eventref hlink="_000000ab000000ab" role="Primary"/>
-      <parentin hlink="_0000006400000064"/>
+      <eventref hlink="_000000bc000000bc" role="Primary"/>
+      <parentin hlink="_0000007300000073"/>
     </person>
-    <person handle="_000000ac000000ac" change="1198222526" id="I0007">
+    <person handle="_000000bd000000bd" change="1198222526" id="I0007">
       <gender>F</gender>
       <name type="Birth Name">
         <first>Ingar</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_000000ad000000ad" role="Primary"/>
-      <childof hlink="_0000001a0000001a"/>
+      <eventref hlink="_000000be000000be" role="Primary"/>
+      <childof hlink="_0000002700000027"/>
     </person>
-    <person handle="_000000ae000000ae" change="1198222526" id="I0008">
-      <gender>M</gender>
-      <name type="Birth Name">
-        <first>Hjalmar</first>
-        <surname>Smith</surname>
-      </name>
-      <eventref hlink="_000000af000000af" role="Primary"/>
-      <eventref hlink="_000000b0000000b0" role="Primary"/>
-      <eventref hlink="_000000b1000000b1" role="Primary"/>
-      <eventref hlink="_000000b3000000b3" role="Primary"/>
-      <childof hlink="_0000000800000008"/>
-      <parentin hlink="_0000002800000028"/>
-      <noteref hlink="_000000b4000000b4"/>
-    </person>
-    <person handle="_000000b5000000b5" change="1198222526" id="I0009">
+    <person handle="_000000c5000000c5" change="1198222526" id="I0009">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Emil</first>
         <surname>Smith</surname>
       </name>
-      <eventref hlink="_000000b6000000b6" role="Primary"/>
-      <childof hlink="_0000004d0000004d"/>
+      <eventref hlink="_000000c6000000c6" role="Primary"/>
+      <eventref hlink="_000000c7000000c7" role="Primary"/>
+      <eventref hlink="_000000c9000000c9" role="Primary"/>
+      <childof hlink="_0000005e0000005e"/>
     </person>
   </people>
   <families>
-    <family handle="_0000000800000008" change="1198222526" id="F0003">
+    <family handle="_0000000300000003" change="1" id="F0003">
       <rel type="Married"/>
-      <father hlink="_0000005300000053"/>
-      <mother hlink="_0000000100000001"/>
-      <eventref hlink="_000000ca000000ca" role="Family"/>
-      <childref hlink="_0000006100000061"/>
-      <childref hlink="_0000005000000050"/>
-      <childref hlink="_0000004200000042"/>
-      <childref hlink="_000000ae000000ae"/>
-      <childref hlink="_0000002900000029"/>
-      <childref hlink="_0000003f0000003f"/>
-      <childref hlink="_0000001000000010"/>
-    </family>
-    <family handle="_0000000e0000000e" change="1198222526" id="F0008">
-      <rel type="Married"/>
-      <father hlink="_0000008000000080"/>
-      <mother hlink="_000000a5000000a5"/>
-      <eventref hlink="_000000cf000000cf" role="Family"/>
-      <childref hlink="_0000003500000035" mrel="Adopted" frel="Adopted"/>
+      <father hlink="_0000000400000004"/>
+      <mother hlink="_0000000500000005"/>
+      <eventref hlink="_0000000600000006" role="Family"/>
+      <objref hlink="_0000000f0000000f"/>
+      <childref hlink="_0000000800000008"/>
+      <childref hlink="_0000000900000009"/>
       <childref hlink="_0000000a0000000a"/>
-      <childref hlink="_0000006c0000006c"/>
+      <childref hlink="_0000000b0000000b"/>
+      <childref hlink="_0000000c0000000c"/>
+      <childref hlink="_0000000d0000000d"/>
+      <childref hlink="_0000000e0000000e"/>
+      <attribute type="RIN" value="987456321"/>
+      <noteref hlink="_0000001000000010"/>
     </family>
-    <family handle="_0000001400000014" change="1198222526" id="F0009">
+    <family handle="_0000001d0000001d" change="1198222526" id="F0008">
+      <rel type="Married"/>
+      <father hlink="_0000009100000091"/>
+      <mother hlink="_000000b6000000b6"/>
+      <eventref hlink="_000000e3000000e3" role="Family"/>
+      <childref hlink="_0000004800000048" mrel="Adopted" frel="Adopted"/>
+      <childref hlink="_0000001900000019"/>
+      <childref hlink="_0000007b0000007b" mrel="Adopted" frel="Adopted"/>
+      <noteref hlink="_000000e4000000e4"/>
+    </family>
+    <family handle="_0000002100000021" change="1198222526" id="F0009">
+      <rel type="Unmarried"/>
+      <father hlink="_0000000e0000000e"/>
+      <mother hlink="_0000003e0000003e"/>
+      <eventref hlink="_000000e5000000e5" role="Family"/>
+      <childref hlink="_0000009100000091"/>
+    </family>
+    <family handle="_0000002200000022" change="1198222526" id="F0014">
       <rel type="Unknown"/>
-      <father hlink="_0000001000000010"/>
-      <mother hlink="_0000002f0000002f"/>
-      <childref hlink="_0000008000000080"/>
+      <father hlink="_0000000e0000000e"/>
+      <mother hlink="_0000003800000038"/>
+      <eventref hlink="_000000dd000000dd" role="Primary"/>
     </family>
-    <family handle="_0000001500000015" change="1198222526" id="F0014">
-      <rel type="Unknown"/>
-      <father hlink="_0000001000000010"/>
-      <mother hlink="_0000002c0000002c"/>
-    </family>
-    <family handle="_0000001a0000001a" change="1198222526" id="F0000">
-      <rel type="Married"/>
-      <father hlink="_0000009d0000009d"/>
-      <mother hlink="_0000008800000088"/>
-      <eventref hlink="_000000b7000000b7" role="Family"/>
-      <childref hlink="_0000001700000017"/>
-      <childref hlink="_000000ac000000ac"/>
-      <childref hlink="_000000a1000000a1"/>
-      <childref hlink="_0000004700000047"/>
-    </family>
-    <family handle="_0000001f0000001f" change="1198222526" id="F0005">
-      <rel type="Married"/>
-      <father hlink="_0000001c0000001c"/>
-      <mother hlink="_0000005000000050"/>
-      <eventref hlink="_000000cc000000cc" role="Family"/>
-    </family>
-    <family handle="_0000002300000023" change="1198222526" id="F0007">
-      <rel type="Married"/>
-      <father hlink="_0000002900000029"/>
-      <mother hlink="_0000002100000021"/>
-      <eventref hlink="_000000ce000000ce" role="Family"/>
-    </family>
-    <family handle="_0000002800000028" change="1198222526" id="F0006">
+    <family handle="_0000002700000027" change="1198222526" id="F0000">
       <rel type="Married"/>
       <father hlink="_000000ae000000ae"/>
-      <mother hlink="_0000007900000079"/>
-      <eventref hlink="_000000cd000000cd" role="Family"/>
-      <childref hlink="_0000003200000032"/>
-      <childref hlink="_0000002500000025"/>
-    </family>
-    <family handle="_0000003400000034" change="1198222526" id="F0012">
-      <rel type="Married"/>
-      <father hlink="_0000003200000032"/>
-      <mother hlink="_0000008200000082"/>
-      <eventref hlink="_000000c1000000c1" role="Family"/>
-      <lds_ord type="sealed_to_spouse">
-        <place hlink="_000000c3000000c3"/>
-      </lds_ord>
-      <objref hlink="_000000c4000000c4"/>
-      <childref hlink="_000000a3000000a3"/>
-      <childref hlink="_0000008c0000008c"/>
-      <attribute type="Number of Children" value="2"/>
-      <noteref hlink="_000000c5000000c5"/>
-    </family>
-    <family handle="_0000003800000038" change="1198222526" id="F0010">
-      <rel type="Married"/>
-      <father hlink="_0000003500000035"/>
-      <mother hlink="_0000007d0000007d"/>
-      <eventref hlink="_000000b9000000b9" role="Family"/>
-      <childref hlink="_0000008400000084" mrel="Adopted" frel="Adopted"/>
-      <attribute type="_STAT" value=""/>
-    </family>
-    <family handle="_0000003e0000003e" change="1198222526" id="F0013">
-      <rel type="Married"/>
-      <father hlink="_0000008c0000008c"/>
-      <mother hlink="_0000007400000074"/>
-      <eventref hlink="_000000c6000000c6" role="Family"/>
-      <eventref hlink="_000000c8000000c8" role="Family"/>
-      <childref hlink="_000000a7000000a7"/>
-      <childref hlink="_0000003900000039"/>
-    </family>
-    <family handle="_0000004d0000004d" change="1198222526" id="F0002">
-      <rel type="Married"/>
-      <father hlink="_0000004700000047"/>
       <mother hlink="_0000009900000099"/>
-      <eventref hlink="_000000c9000000c9" role="Family"/>
-      <childref hlink="_0000007000000070"/>
-      <childref hlink="_000000b5000000b5"/>
-      <childref hlink="_0000005300000053"/>
-    </family>
-    <family handle="_0000005f0000005f" change="1198222526" id="F0001">
-      <rel type="Married"/>
-      <father hlink="_0000006500000065"/>
-      <mother hlink="_0000005d0000005d"/>
-      <eventref hlink="_000000b8000000b8" role="Family"/>
-      <childref hlink="_0000009d0000009d"/>
-    </family>
-    <family handle="_0000006400000064" change="1198222526" id="F0004">
-      <rel type="Married"/>
-      <father hlink="_000000aa000000aa"/>
-      <mother hlink="_0000006100000061"/>
       <eventref hlink="_000000cb000000cb" role="Family"/>
+      <childref hlink="_0000002400000024"/>
+      <childref hlink="_000000bd000000bd"/>
+      <childref hlink="_000000b2000000b2"/>
+      <childref hlink="_0000005800000058"/>
     </family>
-    <family handle="_0000006b0000006b" change="1198222526" id="F0011">
+    <family handle="_0000002c0000002c" change="1198222526" id="F0005">
       <rel type="Married"/>
-      <father hlink="_0000007000000070"/>
-      <mother hlink="_0000006700000067"/>
-      <eventref hlink="_000000bb000000bb" role="Family"/>
-      <eventref hlink="_000000bf000000bf" role="Primary"/>
-      <noteref hlink="_000000c0000000c0"/>
+      <father hlink="_0000002900000029"/>
+      <mother hlink="_0000000900000009"/>
+      <eventref hlink="_000000e0000000e0" role="Family"/>
+    </family>
+    <family handle="_0000003000000030" change="1198222526" id="F0007">
+      <rel type="Married"/>
+      <father hlink="_0000000c0000000c"/>
+      <mother hlink="_0000002e0000002e"/>
+      <eventref hlink="_000000e2000000e2" role="Family"/>
+    </family>
+    <family handle="_0000003500000035" change="1198222526" id="F0006">
+      <rel type="Married"/>
+      <father hlink="_0000000b0000000b"/>
+      <mother hlink="_0000008a0000008a"/>
+      <eventref hlink="_000000e1000000e1" role="Family"/>
+      <childref hlink="_0000004100000041"/>
+      <childref hlink="_0000003200000032"/>
+    </family>
+    <family handle="_0000004300000043" change="1198222526" id="F0012">
+      <rel type="Married"/>
+      <father hlink="_0000004100000041"/>
+      <mother hlink="_0000009300000093"/>
+      <eventref hlink="_000000d5000000d5" role="Family"/>
+      <lds_ord type="sealed_to_spouse">
+        <place hlink="_000000d7000000d7"/>
+      </lds_ord>
+      <objref hlink="_000000d8000000d8"/>
+      <childref hlink="_000000b4000000b4"/>
+      <childref hlink="_0000009d0000009d"/>
+      <attribute type="Number of Children" value="2"/>
+      <noteref hlink="_000000d9000000d9"/>
+    </family>
+    <family handle="_0000004b0000004b" change="1198222526" id="F0010">
+      <rel type="Married"/>
+      <father hlink="_0000004800000048"/>
+      <mother hlink="_0000008e0000008e"/>
+      <eventref hlink="_000000cd000000cd" role="Family"/>
+      <childref hlink="_0000009500000095" mrel="Adopted" frel="Adopted"/>
+      <attribute type="_STAT" value=""/>
+      <noteref hlink="_000000cf000000cf"/>
+    </family>
+    <family handle="_0000005100000051" change="1198222526" id="F0013">
+      <rel type="Married"/>
+      <father hlink="_0000009d0000009d"/>
+      <mother hlink="_0000008300000083"/>
+      <eventref hlink="_000000da000000da" role="Family"/>
+      <eventref hlink="_000000dc000000dc" role="Family"/>
+      <childref hlink="_000000b8000000b8"/>
+      <childref hlink="_0000004c0000004c"/>
+    </family>
+    <family handle="_0000005e0000005e" change="1198222526" id="F0002">
+      <rel type="Married"/>
+      <father hlink="_0000005800000058"/>
+      <mother hlink="_000000aa000000aa"/>
+      <eventref hlink="_000000de000000de" role="Family"/>
+      <childref hlink="_0000007f0000007f"/>
+      <childref hlink="_000000c5000000c5"/>
+      <childref hlink="_0000000400000004"/>
+    </family>
+    <family handle="_0000006f0000006f" change="1198222526" id="F0001">
+      <rel type="Married"/>
+      <father hlink="_0000007400000074"/>
+      <mother hlink="_0000006d0000006d"/>
+      <eventref hlink="_000000cc000000cc" role="Family">
+        <attribute type="Father Age" value="17"/>
+        <attribute type="Mother Age" value="18"/>
+      </eventref>
+      <childref hlink="_000000ae000000ae"/>
+    </family>
+    <family handle="_0000007300000073" change="1198222526" id="F0004">
+      <rel type="Married"/>
+      <father hlink="_000000bb000000bb"/>
+      <mother hlink="_0000000800000008"/>
+      <eventref hlink="_000000df000000df" role="Family"/>
+    </family>
+    <family handle="_0000007a0000007a" change="1198222526" id="F0011">
+      <rel type="Married"/>
+      <father hlink="_0000007f0000007f"/>
+      <mother hlink="_0000007600000076"/>
+      <eventref hlink="_000000d0000000d0" role="Family"/>
+      <eventref hlink="_000000d3000000d3" role="Primary"/>
+      <noteref hlink="_000000d4000000d4"/>
     </family>
   </families>
   <citations>
-    <citation handle="_0000005c0000005c" change="1476889475" id="C0000">
+    <citation handle="_0000004500000045" change="1" id="C0000">
+      <page>SSN docs pg 999</page>
       <confidence>2</confidence>
-      <sourceref hlink="_0000005b0000005b"/>
+      <sourceref hlink="_0000004400000044"/>
     </citation>
-    <citation handle="_0000008f0000008f" change="1476889475" id="C0001">
+    <citation handle="_0000006b0000006b" change="1" id="C0001">
       <confidence>2</confidence>
-      <noteref hlink="_0000008e0000008e"/>
-      <sourceref hlink="_0000008d0000008d"/>
+      <sourceref hlink="_0000006a0000006a"/>
     </citation>
-    <citation handle="_0000009200000092" change="1476889475" id="C0002">
+    <citation handle="_0000006c0000006c" change="1" id="C0002">
       <confidence>2</confidence>
-      <sourceref hlink="_0000009100000091"/>
+      <sourceref hlink="_0000006a0000006a"/>
     </citation>
-    <citation handle="_000000be000000be" change="1476889475" id="C0003">
+    <citation handle="_0000008600000086" change="1" id="C0003">
       <confidence>2</confidence>
-      <sourceref hlink="_000000bd000000bd"/>
+      <sourceref hlink="_0000008500000085"/>
     </citation>
-    <citation handle="_000000c2000000c2" change="1476889475" id="C0004">
+    <citation handle="_000000a0000000a0" change="1" id="C0004">
       <confidence>2</confidence>
-      <sourceref hlink="_000000bd000000bd"/>
+      <noteref hlink="_0000009f0000009f"/>
+      <sourceref hlink="_0000009e0000009e"/>
+    </citation>
+    <citation handle="_000000a3000000a3" change="1" id="C0005">
+      <confidence>2</confidence>
+      <sourceref hlink="_000000a2000000a2"/>
+    </citation>
+    <citation handle="_000000d2000000d2" change="1" id="C0006">
+      <confidence>2</confidence>
+      <sourceref hlink="_0000008500000085"/>
+    </citation>
+    <citation handle="_000000d6000000d6" change="1" id="C0007">
+      <confidence>2</confidence>
+      <sourceref hlink="_0000008500000085"/>
+    </citation>
+    <citation handle="_000000f2000000f2" change="1" id="C0008">
+      <dateval val="1971-12-26"/>
+      <confidence>2</confidence>
+      <objref hlink="_000000f1000000f1"/>
+      <srcattribute type="EVEN" value="housecleaning"/>
+      <srcattribute type="EVEN:ROLE" value="sorter"/>
+      <sourceref hlink="_0000008500000085"/>
     </citation>
   </citations>
   <sources>
-    <source handle="_0000005b0000005b" change="1198222526" id="S0002">
+    <source handle="_0000004400000044" change="1" id="S0999">
+      <stitle>@S999@</stitle>
+    </source>
+    <source handle="_0000006a0000006a" change="1198222526" id="S0002">
       <stitle>Birth Records</stitle>
-      <reporef hlink="_000000d5000000d5" medium="Book">
-        <noteref hlink="_000000d6000000d6"/>
+      <reporef hlink="_000000eb000000eb" medium="Book">
+        <noteref hlink="_000000ec000000ec"/>
       </reporef>
     </source>
-    <source handle="_0000008d0000008d" change="1198222526" id="S0001">
+    <source handle="_0000008500000085" change="1" id="S0000">
+      <stitle>@S0@</stitle>
+      <noteref hlink="_000000e7000000e7"/>
+      <reporef hlink="_000000e6000000e6" callno="what-321-ever" medium="Photo"/>
+    </source>
+    <source handle="_0000009e0000009e" change="1198222526" id="S0001">
       <stitle>Birth Certificate</stitle>
-      <noteref hlink="_000000d4000000d4"/>
-      <reporef hlink="_000000d2000000d2" medium="Book">
-        <noteref hlink="_000000d3000000d3"/>
+      <noteref hlink="_000000ea000000ea"/>
+      <reporef hlink="_000000e8000000e8" medium="Book">
+        <noteref hlink="_000000e9000000e9"/>
       </reporef>
     </source>
-    <source handle="_0000009100000091" change="1198222526" id="S0003">
+    <source handle="_000000a2000000a2" change="1198222526" id="S0003">
       <stitle>Birth, Death and Marriage Records</stitle>
-      <noteref hlink="_000000d7000000d7"/>
-      <reporef hlink="_000000d0000000d0" callno="CA-123-LL-456_Num/ber" medium="Film"/>
+      <sabbrev>goodstuff</sabbrev>
+      <noteref hlink="_000000ed000000ed"/>
+      <noteref hlink="_000000ee000000ee"/>
+      <reporef hlink="_000000e6000000e6" callno="CA-123-LL-456_Num/ber" medium="Film"/>
     </source>
-    <source handle="_000000bd000000bd" change="1198222526" id="S0000">
-      <stitle>Marriage Certificae</stitle>
-      <noteref hlink="_000000d1000000d1"/>
-      <reporef hlink="_000000d0000000d0" callno="what-321-ever" medium="Photo"/>
+    <source handle="_000000ef000000ef" change="1" id="S0004">
+      <stitle>No title - ID S0004</stitle>
+      <srcattribute type="RIN" value="987456321"/>
+    </source>
+    <source handle="_000000f7000000f7" change="1" id="SOUR A weird source (one line) format">
+      <stitle>A weird source (one line) format</stitle>
     </source>
   </sources>
   <places>
-    <placeobj handle="_0000000400000004" change="1476889475" id="P0000" type="Unknown">
+    <placeobj handle="_0000000700000007" change="1" id="P0000" type="Unknown">
+      <ptitle>Rønne, Bornholm, Denmark</ptitle>
+      <pname value="Rønne, Bornholm, Denmark"/>
+      <objref hlink="_000000d1000000d1"/>
+      <citationref hlink="_000000d2000000d2"/>
+    </placeobj>
+    <placeobj handle="_0000001300000013" change="1" id="P0001" type="Unknown">
       <ptitle>Löderup, Malmöhus Län, Sweden</ptitle>
       <pname value="Löderup, Malmöhus Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000000700000007" change="1476889475" id="P0001" type="Unknown">
+    <placeobj handle="_0000001600000016" change="1" id="P0002" type="Unknown">
       <ptitle>Sparks, Washoe Co., NV</ptitle>
       <pname value="Sparks, Washoe Co., NV"/>
     </placeobj>
-    <placeobj handle="_0000000d0000000d" change="1476889475" id="P0002" type="Unknown">
+    <placeobj handle="_0000001c0000001c" change="1" id="P0003" type="Unknown">
       <ptitle>San Francisco, San Francisco Co., CA</ptitle>
       <pname value="San Francisco, San Francisco Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000001200000012" change="1476889475" id="P0003" type="Unknown">
-      <ptitle>Rønne, Bornholm, Denmark</ptitle>
-      <pname value="Rønne, Bornholm, Denmark"/>
-      <objref hlink="_000000bc000000bc"/>
-      <citationref hlink="_000000be000000be"/>
-    </placeobj>
-    <placeobj handle="_0000001900000019" change="1476889475" id="P0004" type="Unknown">
+    <placeobj handle="_0000002600000026" change="1" id="P0004" type="Unknown">
       <ptitle>Gladsax, Kristianstad Län, Sweden</ptitle>
       <pname value="Gladsax, Kristianstad Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000002700000027" change="1476889475" id="P0005" type="Unknown">
+    <placeobj handle="_0000003400000034" change="1" id="P0005" type="Unknown">
       <ptitle>Reno, Washoe Co., NV</ptitle>
       <pname value="Reno, Washoe Co., NV"/>
     </placeobj>
-    <placeobj handle="_0000003b0000003b" change="1476889475" id="P0006" type="Unknown">
+    <placeobj handle="_0000003c0000003c" change="1" id="P0006" type="Address">
+      <ptitle>456 Main St again, The Village, San Francisco, CA, USA</ptitle>
+      <pname value="456 Main St again, The Village, San Francisco, CA, USA"/>
+      <location street="456 Main St again" locality="The Village" city="San Francisco" state="CA" country="USA" phone="555-666-7777"/>
+    </placeobj>
+    <placeobj handle="_0000004e0000004e" change="1" id="P0007" type="Unknown">
       <ptitle>Hayward, Alameda Co., CA</ptitle>
       <pname value="Hayward, Alameda Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000003d0000003d" change="1476889475" id="P0007" type="Unknown">
+    <placeobj handle="_0000005000000050" change="1" id="P0008" type="Unknown">
       <ptitle>Community Presbyterian Church, Danville, CA</ptitle>
       <pname value="Community Presbyterian Church, Danville, CA"/>
     </placeobj>
-    <placeobj handle="_0000004b0000004b" change="1476889475" id="P0008" type="Unknown">
+    <placeobj handle="_0000005c0000005c" change="1" id="P0009" type="Unknown">
       <ptitle>Sweden</ptitle>
       <pname value="Sweden"/>
     </placeobj>
-    <placeobj handle="_0000005500000055" change="1476889475" id="P0009" type="Unknown">
+    <placeobj handle="_0000006400000064" change="1" id="P0010" type="Unknown">
       <ptitle>Grostorp, Kristianstad Län, Sweden</ptitle>
       <pname value="Grostorp, Kristianstad Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000005800000058" change="1476889475" id="P0010" type="Unknown">
+    <placeobj handle="_0000006700000067" change="1" id="P0011" type="Unknown">
       <ptitle>Copenhagen, Denmark</ptitle>
       <pname value="Copenhagen, Denmark"/>
     </placeobj>
-    <placeobj handle="_0000006000000060" change="1476889475" id="P0011" type="Unknown">
+    <placeobj handle="_0000007000000070" change="1" id="P0012" type="Unknown">
       <ptitle>Sweden</ptitle>
       <pname value="Sweden"/>
     </placeobj>
-    <placeobj handle="_0000006900000069" change="1476889475" id="P0012" type="Unknown">
+    <placeobj handle="_0000007800000078" change="1" id="P0013" type="Unknown">
       <ptitle>Hoya/Jona/Hoia, Sweden</ptitle>
       <pname value="Hoya/Jona/Hoia, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000007200000072" change="1476889475" id="P0013" type="Unknown">
+    <placeobj handle="_0000008100000081" change="1" id="P0014" type="Unknown">
       <ptitle>Simrishamn, Kristianstad Län, Sweden</ptitle>
       <pname value="Simrishamn, Kristianstad Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000007600000076" change="1476889475" id="P0014" type="Unknown">
+    <placeobj handle="_0000008700000087" change="1" id="P0015" type="Unknown">
       <ptitle>Fremont, Alameda Co., CA</ptitle>
       <pname value="Fremont, Alameda Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000007b0000007b" change="1476889475" id="P0015" type="Unknown">
+    <placeobj handle="_0000008c0000008c" change="1" id="P0016" type="Unknown">
       <ptitle>Denver, Denver Co., CO</ptitle>
       <pname value="Denver, Denver Co., CO"/>
     </placeobj>
-    <placeobj handle="_0000007f0000007f" change="1476889475" id="P0016" type="Unknown">
+    <placeobj handle="_0000009000000090" change="1" id="P0017" type="Unknown">
       <ptitle>Sacramento, Sacramento Co., CA</ptitle>
       <pname value="Sacramento, Sacramento Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000008600000086" change="1476889475" id="P0017" type="Unknown">
+    <placeobj handle="_0000009700000097" change="1" id="P0018" type="Unknown">
       <ptitle>Santa Rosa, Sonoma Co., CA</ptitle>
       <pname value="Santa Rosa, Sonoma Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000009300000093" change="1476889475" id="P0018" type="Unknown">
+    <placeobj handle="_000000a4000000a4" change="1" id="P0019" type="Unknown">
       <ptitle>San Jose, Santa Clara Co., CA</ptitle>
       <pname value="San Jose, Santa Clara Co., CA"/>
     </placeobj>
-    <placeobj handle="_0000009700000097" change="1476889475" id="P0019" type="Unknown">
+    <placeobj handle="_000000a8000000a8" change="1" id="P0020" type="Unknown">
       <ptitle>UC Berkeley</ptitle>
       <pname value="UC Berkeley"/>
     </placeobj>
-    <placeobj handle="_0000009b0000009b" change="1476889475" id="P0020" type="Unknown">
+    <placeobj handle="_000000ac000000ac" change="1" id="P0021" type="Unknown">
       <ptitle>Smestorp, Kristianstad Län, Sweden</ptitle>
       <pname value="Smestorp, Kristianstad Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_0000009f0000009f" change="1476889475" id="P0021" type="Unknown">
+    <placeobj handle="_000000b0000000b0" change="1" id="P0022" type="Unknown">
       <ptitle>Tommarp, Kristianstad Län, Sweden</ptitle>
       <pname value="Tommarp, Kristianstad Län, Sweden"/>
     </placeobj>
-    <placeobj handle="_000000b2000000b2" change="1476889475" id="P0022" type="Unknown">
+    <placeobj handle="_000000c2000000c2" change="1" id="P0023" type="Unknown">
       <ptitle>Rønne Bornholm, Denmark</ptitle>
       <pname value="Rønne Bornholm, Denmark"/>
     </placeobj>
-    <placeobj handle="_000000ba000000ba" change="1476889475" id="P0023" type="Unknown">
+    <placeobj handle="_000000c8000000c8" change="1" id="P0024" type="Unknown">
+      <ptitle>Oronoko, Berrien, Michigan, USA</ptitle>
+      <pname value="Oronoko, Berrien, Michigan, USA"/>
+    </placeobj>
+    <placeobj handle="_000000ca000000ca" change="1" id="P0025" type="Unknown">
+      <ptitle>Shemps</ptitle>
+      <pname value="Shemps"/>
+    </placeobj>
+    <placeobj handle="_000000ce000000ce" change="1" id="P0026" type="Unknown">
       <ptitle>Woodland, Yolo Co., CA</ptitle>
       <pname value="Woodland, Yolo Co., CA"/>
     </placeobj>
-    <placeobj handle="_000000c3000000c3" change="1476889475" id="P0024" type="Unknown">
+    <placeobj handle="_000000d7000000d7" change="1" id="P0027" type="Unknown">
       <ptitle>Sparks, Washoe Co., NV</ptitle>
       <pname value="Sparks, Washoe Co., NV"/>
     </placeobj>
-    <placeobj handle="_000000c7000000c7" change="1476889475" id="P0025" type="Unknown">
+    <placeobj handle="_000000db000000db" change="1" id="P0028" type="Unknown">
       <ptitle>San Ramon, Conta Costa Co., CA</ptitle>
       <pname value="San Ramon, Conta Costa Co., CA"/>
     </placeobj>
   </places>
   <objects>
-    <object handle="_000000bc000000bc" change="1476889475" id="O0000">
+    <object handle="_0000000f0000000f" change="1" id="O0000">
+      <file src="." mime="unknown" description="No filename for this one"/>
+    </object>
+    <object handle="_0000001800000018" change="946101600" id="M1">
+      <file src="image-missing.png" mime="image/png" description="Unknown"/>
+      <noteref hlink="_000000f9000000f9"/>
+    </object>
+    <object handle="_000000d1000000d1" change="1" id="O0001">
       <file src="Magnes&amp;Anna_smiths_marr_cert.jpg" mime="unknown" description="Magnes&amp;Anna_smiths_marr_cert.jpg"/>
     </object>
-    <object handle="_000000c4000000c4" change="1476889475" id="O0001">
+    <object handle="_000000d8000000d8" change="1" id="O0002">
       <file src="John&amp;Alice_smiths_marr_cert.jpg" mime="unknown" description="John&amp;Alice_smiths_marr_cert.jpg"/>
+    </object>
+    <object handle="_000000f1000000f1" change="1" id="O0003">
+      <file src="Attic_photo.jpg" mime="unknown" description="Attic_photo.jpg"/>
     </object>
   </objects>
   <repositories>
-    <repository handle="_000000d0000000d0" change="1476889475" id="R0002">
+    <repository handle="_000000e6000000e6" change="946706400" id="R0002">
       <rname>New York Public Library</rname>
       <type>Library</type>
       <address>
@@ -1351,111 +1477,221 @@
         <postal>11111</postal>
       </address>
     </repository>
-    <repository handle="_000000d2000000d2" change="1476889475" id="R0000">
+    <repository handle="_000000e8000000e8" change="1" id="R0000">
       <rname>Invalid REPO Name</rname>
       <type>Library</type>
     </repository>
-    <repository handle="_000000d5000000d5" change="1476889475" id="R0001">
+    <repository handle="_000000eb000000eb" change="1" id="R0001">
       <type>Library</type>
     </repository>
-    <repository handle="_000000d8000000d8" change="1476889475" id="R0003">
+    <repository handle="_000000f0000000f0" change="1" id="R0003">
       <rname>Aunt Martha's Attic</rname>
       <type>Library</type>
       <address>
+        <dateval val="1971-12-25"/>
         <street>123 Main St</street>
+        <locality>LittleVillage</locality>
         <city>Someville</city>
         <state>ST</state>
         <country>USA</country>
+        <noteref hlink="_000000f3000000f3"/>
+        <citationref hlink="_000000f2000000f2"/>
       </address>
       <url  href="http://library.gramps-project.org" type="Web Home"/>
-      <noteref hlink="_000000d9000000d9"/>
+      <noteref hlink="_000000f4000000f4"/>
+      <noteref hlink="_000000f5000000f5"/>
     </repository>
   </repositories>
   <notes>
-    <note handle="_0000000200000002" change="1476889475" id="N0000" type="General">
+    <note handle="_0000000100000001" change="1" id="N0000" type="GEDCOM import">
+      <text>Records not imported into HEAD (header):
+
+GEDCOM FORM not supported                                           Line    14: 2 FORM NOT LINEAGE-LINKED</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="148"/>
+      </style>
+    </note>
+    <note handle="_0000000200000002" change="1" id="N0001" type="GEDCOM import">
+      <text>Records not imported into SUBM (Submitter): (@SUBM@) Alex Roitman,,,:
+
+Line ignored as not understood                                      Line    23: 2 NOTE No address provided (note not supported)</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="199"/>
+      </style>
+    </note>
+    <note handle="_0000001000000010" change="1" id="N0002" type="GEDCOM import">
+      <text>Records not imported into FAM (family) Gramps ID F0003:
+
+Line ignored as not understood                                      Line    46: 2 SOUR Not really allowed here
+Filename omitted                                                    Line    48: 1 OBJE</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="256"/>
+      </style>
+    </note>
+    <note handle="_0000001100000011" change="1" id="N0003" type="General">
       <text>Hans daughter? N0000</text>
     </note>
-    <note handle="_0000000600000006" change="1476889475" id="N0001" type="Event Note">
+    <note handle="_0000001500000015" change="1" id="N0004" type="Event Note">
       <text>Her eulogy was great! N0001</text>
     </note>
-    <note handle="_0000000900000009" change="1476889475" id="N0002" type="Person Note">
+    <note handle="_0000001700000017" change="1" id="N0005" type="Person Note">
       <text>Inline note should get ID N0002</text>
     </note>
-    <note handle="_0000000b0000000b" change="1476889475" id="N0007" type="General">
-      <text>'Smith': a very common name</text>
+    <note handle="_0000001a0000001a" change="946101600" id="N0007" type="Unknown">
+      <text>Unknown, created to replace a missing note object.</text>
+      <style name="link" value="gramps://Note/handle/000000f9000000f9">
+        <range start="9" end="49"/>
+      </style>
     </note>
-    <note handle="_0000000f0000000f" change="1476889475" id="N0003" type="Person Note">
+    <note handle="_0000001e0000001e" change="1" id="N0006" type="Person Note">
       <text>Keith Lloyd Smith inline N0003</text>
     </note>
-    <note handle="_0000001600000016" change="1476889475" id="N0004" type="Person Note">
+    <note handle="_0000002300000023" change="1" id="N0008" type="Person Note">
       <text>Hans Peter Smith inline N0004</text>
     </note>
-    <note handle="_0000001b0000001b" change="1476889475" id="N0005" type="Person Note">
+    <note handle="_0000002800000028" change="1" id="N0009" type="Person Note">
       <text>Hanna Smith inline N0005</text>
     </note>
-    <note handle="_0000002000000020" change="1476889475" id="N0006" type="Person Note">
+    <note handle="_0000002d0000002d" change="1" id="N0010" type="Person Note">
       <text>Herman Julius Nielsen N0006</text>
     </note>
-    <note handle="_0000002400000024" change="1476889475" id="N0008" type="Person Note">
+    <note handle="_0000003100000031" change="1" id="N0011" type="Person Note">
       <text>Evelyn Michaels N0007</text>
     </note>
-    <note handle="_0000004e0000004e" change="1476889475" id="N0009" type="Person Note">
+    <note handle="_0000003d0000003d" change="1" id="N0012" type="GEDCOM import">
+      <text>Records not imported into INDI (individual) Gramps ID I0016:
+
+Warn: ADDR overwritten                                              Line   204: 3 ADR1 456 Main St again
+ADDR element ignored '459 Main St.'                                 Line   202: 2 ADDR 459 Main St., The Village, San Francisco, CA, USA</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="304"/>
+      </style>
+    </note>
+    <note handle="_0000004600000046" change="1" id="N0013" type="Attribute Note">
+      <text>Person Attribute Note on SSN</text>
+    </note>
+    <note handle="_0000004700000047" change="1" id="N0014" type="GEDCOM import">
+      <text>Records not imported into INDI (individual) Gramps ID I0018:
+
+Tag recognized but not supported                                    Line   245: 2 TYPE first generaton</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="165"/>
+      </style>
+    </note>
+    <note handle="_0000005f0000005f" change="1" id="N0015" type="Person Note">
       <text>BIOGRAPHY
 Martin was listed as being a Husman, (owning a house as opposed to a farm) in the house records of Gladsax.</text>
     </note>
-    <note handle="_0000005a0000005a" change="1476889475" id="N0010" type="Person Note">
+    <note handle="_0000006900000069" change="1" id="N0016" type="Person Note">
       <text>A FAMC note</text>
     </note>
-    <note handle="_0000006f0000006f" change="1476889475" id="N0011" type="Event Note">
+    <note handle="_0000007e0000007e" change="1" id="N0017" type="Event Note">
       <text>Witness name: John Doe
 Witness comment: This is a simple test.</text>
     </note>
-    <note handle="_0000008e0000008e" change="1476889475" id="N0012" type="Source text">
+    <note handle="_0000009f0000009f" change="1" id="N0018" type="Source text">
       <text>Record for Edwin Michael Smith</text>
     </note>
-    <note handle="_0000009500000095" change="1476889475" id="N0013" type="Event Note">
+    <note handle="_000000a6000000a6" change="1" id="N0019" type="Event Note">
       <text>Witness name: No Name</text>
     </note>
-    <note handle="_000000b4000000b4" change="1476889475" id="N0014" type="Person Note">
+    <note handle="_000000c4000000c4" change="1" id="N0020" type="Person Note">
       <text>BIOGRAPHY
 
 Hjalmar sailed from Copenhagen, Denmark on the OSCAR II, 14 November 1912 arriving in New York 27 November 1912. He was seventeen years old. On the ship passenger list his trade was listed as a Blacksmith.  He came to Reno, Nevada and lived with his sister Marie for a time before settling in Sparks. He worked for Southern Pacific Railroad as a car inspector for a time, then went to work for Standard Oil
 Company. He enlisted in the army at Sparks 7 December 1917 and served as a Corporal in the Medical Corp until his discharge 12 August 1919 at the Presidio in San Francisco, California. Both he and Marjorie are buried in the Masonic Memorial Gardens Mausoleum in Reno, he the 30th June 1975, and she the 25th of June 1980.</text>
     </note>
-    <note handle="_000000c0000000c0" change="1476889475" id="N0015" type="GEDCOM import">
+    <note handle="_000000cf000000cf" change="1" id="N0021" type="GEDCOM import">
+      <text>Records not imported into FAM (family) Gramps ID F0010:
+
+Tag recognized but not supported                                    Line   863: 2 _STAT</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="146"/>
+      </style>
+    </note>
+    <note handle="_000000d4000000d4" change="1" id="N0022" type="GEDCOM import">
       <text>Records not imported into FAM (family) Gramps ID F0011:
 
-Could not import Magnes&amp;Anna_smiths_marr_cert.jpg                   Line   802: 3 OBJE 
-Could not import Magnes&amp;Anna_smiths_marr_cert.jpg                   Line   805: 2 OBJE</text>
+Could not import Magnes&amp;Anna_smiths_marr_cert.jpg                   Line   878: 3 OBJE 
+Could not import Magnes&amp;Anna_smiths_marr_cert.jpg                   Line   881: 2 OBJE</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="233"/>
       </style>
     </note>
-    <note handle="_000000c5000000c5" change="1476889475" id="N0016" type="GEDCOM import">
+    <note handle="_000000d9000000d9" change="1" id="N0023" type="GEDCOM import">
       <text>Records not imported into FAM (family) Gramps ID F0012:
 
-Could not import John&amp;Alice_smiths_marr_cert.jpg                    Line   829: 1 OBJE</text>
+Could not import John&amp;Alice_smiths_marr_cert.jpg                    Line   905: 1 OBJE</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="145"/>
       </style>
     </note>
-    <note handle="_000000d1000000d1" change="1476889475" id="N0017" type="Source Note">
+    <note handle="_000000e4000000e4" change="1" id="N0024" type="GEDCOM import">
+      <text>Records not imported into FAM (family) Gramps ID F0008:
+
+Tag recognized but not supported                                    Line  1005: 1 ADDR 123 Main st, Grantville, Virginia, USA</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="183"/>
+      </style>
+    </note>
+    <note handle="_000000e7000000e7" change="1" id="N0025" type="Source Note">
       <text>But Aunt Martha still keeps the original!</text>
     </note>
-    <note handle="_000000d3000000d3" change="1476889475" id="N0018" type="Repository Reference Note">
+    <note handle="_000000e9000000e9" change="1" id="N0026" type="Repository Reference Note">
       <text>Invalid REPO (Name instead of xref)</text>
     </note>
-    <note handle="_000000d4000000d4" change="1476889475" id="N0019" type="Source text">
+    <note handle="_000000ea000000ea" change="1" id="N0027" type="Source text">
       <text>Source text of Birth cert</text>
     </note>
-    <note handle="_000000d6000000d6" change="1476889475" id="N0020" type="Repository Reference Note">
+    <note handle="_000000ec000000ec" change="1" id="N0028" type="Repository Reference Note">
       <text>Invalid REPO (no name)</text>
     </note>
-    <note handle="_000000d7000000d7" change="1476889475" id="N0021" type="Source Note">
+    <note handle="_000000ed000000ed" change="1" id="N0029" type="Source Note">
       <text>The repository reference from the source is important</text>
     </note>
-    <note handle="_000000d9000000d9" change="1476889475" id="N0022" type="Repository Note">
+    <note handle="_000000ee000000ee" change="1" id="N0030" type="GEDCOM import">
+      <text>Records not imported into SOUR (source) Gramps ID S0003:
+
+Tag recognized but not supported                                    Line  1045: 1 DATA 
+Skipped subordinate line                                            Line  1046: 2 AGNC NYC Public Library</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="252"/>
+      </style>
+    </note>
+    <note handle="_000000f3000000f3" change="1" id="N0031" type="Address Note">
+      <text>A note on this address</text>
+    </note>
+    <note handle="_000000f4000000f4" change="1" id="N0032" type="Repository Note">
       <text>Some note on the repo</text>
+    </note>
+    <note handle="_000000f5000000f5" change="1" id="N0033" type="GEDCOM import">
+      <text>Records not imported into REPO (repository) Gramps ID R0003:
+
+REFN ignored                                                        Line  1075: 3 REFN blah blah
+Skipped subordinate line                                            Line  1076: 4 TYPE who knows
+Could not import Attic_photo.jpg                                    Line  1079: 3 OBJE</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="344"/>
+      </style>
+    </note>
+    <note handle="_000000f6000000f6" change="1" id="N0034" type="GEDCOM import">
+      <text>Records not imported into Top Level:
+
+Unknown tag                                                         Line  1106: 0 XXX an unknown token at level 0</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="152"/>
+      </style>
+    </note>
+    <note handle="_000000f8000000f8" change="1" id="N0035" type="GEDCOM import">
+      <text>Records not imported into Top Level:
+
+Unknown tag                                                         Line  1109: 1 @X1@ XXX and unknown token xref definition</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="163"/>
+      </style>
+    </note>
+    <note handle="_000000f9000000f9" change="1477325896" id="N0036" type="General">
+      <text>Objects referenced by this note were missing in a file imported on 12/25/1999 12:00:00 AM.</text>
     </note>
   </notes>
 </database>

--- a/gramps/gen/utils/unknown.py
+++ b/gramps/gen/utils/unknown.py
@@ -29,7 +29,7 @@ Make an 'Unknown' primary object
 # Python modules
 #
 #-------------------------------------------------------------------------
-import time
+from time import strftime, localtime, time
 import os
 
 #-------------------------------------------------------------------------
@@ -124,14 +124,14 @@ def make_unknown(class_arg, explanation, class_func, commit_func, transaction,
         obj2 = argv['source_class_func'](argv['source_class_arg'])
         obj2.set_title(_('Unknown'))
         obj2.add_note(explanation)
-        argv['source_commit_func'](obj2, transaction, time.time())
+        argv['source_commit_func'](obj2, transaction, time())
         retval.append(obj2)
         obj.set_reference_handle(obj2.handle)
     elif isinstance(obj, Repository):
         obj.set_name(_('Unknown'))
         obj.set_type(RepositoryType.UNKNOWN)
     elif isinstance(obj, Media):
-        obj.set_path(os.path.join(IMAGE_DIR, "image-missing.png"))
+        obj.set_path("image-missing.png")
         obj.set_mime_type('image/png')
         obj.set_description(_('Unknown'))
     elif isinstance(obj, Note):
@@ -147,7 +147,7 @@ def make_unknown(class_arg, explanation, class_func, commit_func, transaction,
         if not hasattr(make_unknown, 'count'):
             make_unknown.count = 1 #primitive static variable
         obj.set_name(_("Unknown, was missing %(time)s (%(count)d)") % {
-                'time': time.strftime('%x %X', time.localtime()),
+                'time': strftime('%x %X', localtime()),
                 'count': make_unknown.count})
         make_unknown.count += 1
     else:
@@ -155,7 +155,7 @@ def make_unknown(class_arg, explanation, class_func, commit_func, transaction,
 
     if hasattr(obj, 'add_note'):
         obj.add_note(explanation)
-    commit_func(obj, transaction, time.time())
+    commit_func(obj, transaction, time())
     retval.append(obj)
     return retval
 
@@ -167,7 +167,7 @@ def create_explanation_note(dbase):
     """
     note = Note( _('Objects referenced by this note '
                                     'were missing in a file imported on %s.') %
-                                    time.strftime('%x %X', time.localtime()))
+                                    strftime('%x %X', localtime()))
     note.set_handle(create_id())
     note.set_gramps_id(dbase.find_next_note_gramps_id())
     # Use defaults for privacy, format and type.

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -5974,7 +5974,7 @@ class GedcomParser(UpdateCallback):
         @type state: CurrentState
         """
         # The ADDR may already have been parsed by the level above
-        assert state.addr.get_street() == ""
+        # assert state.addr.get_street() == ""
         if state.addr.get_street() != "":
             self.__add_msg(_("Warn: ADDR overwritten"), line, state)
         state.addr.set_street(line.data)

--- a/gramps/plugins/test/test_imports.py
+++ b/gramps/plugins/test/test_imports.py
@@ -25,6 +25,8 @@ import unittest
 import os
 import sys
 import re
+from time import localtime
+from unittest.mock import patch
 #import logging
 
 from gramps.gen.merge.diff import diff_dbs, import_as_dict
@@ -45,6 +47,17 @@ TEST_DIR = os.path.abspath(os.path.join(DATA_DIR, "tests"))
 #  Local Functions
 # ------------------------------------------------------------------
 
+def mock_time(*args):
+    """
+    Mock up a dummy to replace the varying 'time string results'
+    """
+    return 946101600.
+
+def mock_localtime(*args):
+    """
+    Mock up a dummy to replace the varying 'time string results'
+    """
+    return localtime(946101600.)
 
 class CompleteCheck(unittest.TestCase):
     """The test class cases will be dynamically created at import time from
@@ -174,16 +187,27 @@ def make_tst_function(tstfile, file_name):
     """ This is here to support the dynamic function creation.  This creates
     the test function (a method, to be precise).
     """
-    def tst(self):
+
+    @patch('gramps.plugins.db.dbapi.dbapi.time')
+    @patch('gramps.plugins.db.bsddb.write.time')
+    @patch('gramps.gen.utils.unknown.localtime')
+    @patch('gramps.gen.utils.unknown.time')
+    def tst(self, mocktime, mockltime, mockwtime, mockdtime):
         """ This compares the import file with the expected result '.gramps'
         file.
         """
+        mocktime.side_effect = mock_time
+        mockltime.side_effect = mock_localtime
+        mockwtime.side_effect = mock_time
+        mockdtime.side_effect = mock_time
         fn1 = os.path.join(TEST_DIR, tstfile)
         fn2 = os.path.join(TEST_DIR, (file_name + ".gramps"))
         fres = os.path.join(TEMP_DIR, (file_name + ".difs"))
         fout = os.path.join(TEMP_DIR, (file_name + ".gramps"))
         if "_dfs" in tstfile:
             config.set('preferences.default-source', True)
+            config.set('preferences.tag-on-import-format', "Imported")
+            config.set('preferences.tag-on-import', True)
             skp_imp_adds = False
         else:
             skp_imp_adds = True

--- a/gramps/plugins/test/test_imports.py
+++ b/gramps/plugins/test/test_imports.py
@@ -25,7 +25,7 @@ import unittest
 import os
 import sys
 import re
-from time import localtime
+from time import localtime, strptime
 from unittest.mock import patch
 #import logging
 
@@ -57,7 +57,7 @@ def mock_localtime(*args):
     """
     Mock up a dummy to replace the varying 'time string results'
     """
-    return localtime(946101600.)
+    return strptime("25 Dec 1999", "%d %b %Y")
 
 class CompleteCheck(unittest.TestCase):
     """The test class cases will be dynamically created at import time from


### PR DESCRIPTION
This PR is primarily to improve test coverage.  The goal was to test as much of the standard code (as used in normal imports) as possible.  Some unusual conditions are also added, but most exceptions remain untested.

It was necessary to use Mock to keep the test_imports routine from failing on some dates, this in turn required a few changes to the Python imports in the 'unknown.py' module.  I have not figured out how to properly Mock patch standard time.time in an individual module yet unless it imports via the 'from time import time' sytax.  So I changed the module to use that syntax, rather than importing the entire time module via 'import time'.

I also added in the 'tag on import' to the tests when the '_dfs' is part of the file name; this causes Gedcom (or others) to tag imported data (and increase test coverage of that feature).

I commented out an 'assert' statement in libgedcom.py that got executed with the added test coverage; it prevented the test from completing.  Apparently the author thought that that particular code path should not ever be executed.

I found several (minor) issues with the Gedcom importer by doing this process, I will submit bugs and PRs to address these as time permits.