### PR TITLE
bug 9522; fix fault when viewing family events with event gramplet

### DIFF
--- a/gramps/plugins/gramplet/events.py
+++ b/gramps/plugins/gramplet/events.py
@@ -179,7 +179,6 @@ class PersonEvents(Events):
         Return True if the gramplet has data, else return False.
         """
         if active_person:
-            self.cached_start_date = self.get_start_date()
             if active_person.get_event_ref_list():
                 return True
             for family_handle in active_person.get_family_handle_list():
@@ -187,8 +186,6 @@ class PersonEvents(Events):
                 if family:
                     for event_ref in family.get_event_ref_list():
                         return True
-        else:
-            self.cached_start_date = None
         return False
 
     def main(self): # return false finishes
@@ -207,11 +204,14 @@ class PersonEvents(Events):
         """
         active_person = self.dbstate.db.get_person_from_handle(active_handle)
         if active_person:
+            self.cached_start_date = self.get_start_date()
             for event_ref in active_person.get_event_ref_list():
                 self.add_event_ref(event_ref)
             for family_handle in active_person.get_family_handle_list():
                 family = self.dbstate.db.get_family_from_handle(family_handle)
                 self.display_family(family, active_person)
+        else:
+            self.cached_start_date = None
         self.set_has_data(self.model.count > 0)
 
     def display_family(self, family, active_person):
@@ -276,6 +276,7 @@ class FamilyEvents(Events):
         Display the events for the active family.
         """
         active_family = self.dbstate.db.get_family_from_handle(active_handle)
+        self.cached_start_date = self.get_start_date()
         for event_ref in active_family.get_event_ref_list():
             self.add_event_ref(event_ref)
         self.set_has_data(self.model.count > 0)


### PR DESCRIPTION
events gramplet in family view error: 'FamilyEvents' object has no attribute 'cached_start_date'

The event gramplet apparently had poor performance when lots of events were attached to a single person.  An attempt was made to improve that performance by 'caching' a start date; otherwise the start date lookup occurred 2_n_n times during a person display.
But the event gramplet also handled families; and that code was apparently not tested.
In addition to the fault when viewing families, it appears that the original fix for person events is not working right.
It seems that the fix 'cached' a start date, but that the cached start date was only set to the first person viewed.  Any other persons events had the wrong ages (based on the first person viewed).

I think I figured out a way past this that still allows the 'cacheing' of the start dates (and reduces the 2_n_n lookups to n).  I aslo applied the fix to the families part of the event viewer. 
