### PR TITLE
Bug9767 Fix LDS editor for 'Family' related issues

### DIFF
--- a/gramps/gui/editors/editldsord.py
+++ b/gramps/gui/editors/editldsord.py
@@ -179,6 +179,9 @@ class EditLdsOrd(EditSecondary):
         self.parents_label = self.top.get_object('parents_label')
         self.parents = self.top.get_object('parents')
         self.parents_select = self.top.get_object('parents_select')
+        image = self.parents_select.get_child()
+        image.set_from_icon_name('gtk-index', Gtk.IconSize.BUTTON)
+        self.parents_select.set_tooltip_text(_('Select Family'))
 
         self.priv = PrivacyButton(
             self.top.get_object("private"),
@@ -230,22 +233,21 @@ class EditLdsOrd(EditSecondary):
             self.db.readonly)
         self.track_ref_for_deletion('status_menu')
 
-        self.ord_type_changed()
         self.update_parent_label()
 
+    def _post_init(self):
+        self.ord_type_changed()
+
     def ord_type_changed(self):
-        if self.obj.get_type() == LdsOrd.BAPTISM:
-            self.parents.hide()
-            self.parents_label.hide()
-            self.parents_select.hide()
-        elif self.obj.get_type() == LdsOrd.ENDOWMENT:
-            self.parents.hide()
-            self.parents_label.hide()
-            self.parents_select.hide()
-        elif self.obj.get_type() == LdsOrd.SEAL_TO_PARENTS:
+        if self.obj.get_type() == LdsOrd.SEAL_TO_PARENTS:
             self.parents.show()
             self.parents_label.show()
             self.parents_select.show()
+        else:
+            self.parents.hide()
+            self.parents_label.hide()
+            self.parents_select.hide()
+
         new_data = [(item[1],item[0]) for item in LdsOrd._STATUS_MAP
                     if item[0] in _DATA_MAP[self.obj.get_type()] ]
         self.status_menu.change_menu(new_data)
@@ -353,6 +355,11 @@ class EditFamilyLdsOrd(EditSecondary):
                         _('LDS Ordinance Editor'))
         self.share_btn = self.top.get_object('share_place')
         self.add_del_btn = self.top.get_object('add_del_place')
+
+    def _post_init(self):
+        self.parents.hide()
+        self.parents_label.hide()
+        self.parents_select.hide()
 
     def _connect_signals(self):
         self.define_cancel_button(self.top.get_object('cancel'))

--- a/gramps/gui/editors/editldsord.py
+++ b/gramps/gui/editors/editldsord.py
@@ -179,9 +179,6 @@ class EditLdsOrd(EditSecondary):
         self.parents_label = self.top.get_object('parents_label')
         self.parents = self.top.get_object('parents')
         self.parents_select = self.top.get_object('parents_select')
-        image = self.parents_select.get_child()
-        image.set_from_icon_name('gtk-index', Gtk.IconSize.BUTTON)
-        self.parents_select.set_tooltip_text(_('Select Family'))
 
         self.priv = PrivacyButton(
             self.top.get_object("private"),


### PR DESCRIPTION
Several problems fixed in LDS ordinance editors:

1) ~~On newer versions of GTK+ the Family select ICON was not visible.  It appears that Gramps never assigned an icon to the Family select button.  As near as I can tell the only reason this ever worked was that there was a 'feature' (bug?) in GTK+ that allowed the most recently defined image ICON value to be used in object images if there was none defined at all.  I suspect that this 'feature' disappeared in more recent versions of GTK+ (the icon was visible in GTK+ 3.16.7, but is gone in 3.18.2 and newer.).~~
Already fixed in https://github.com/gramps-project/gramps/commit/22c1bd4e1c61de62df099b355e473e91afecfa90

2) The Person LDS editor was trying to hide the 'Family' line whenever any LDS type was not SEAL_TO_PARENTS, but this didn't always work.  The if-elif set missed the CONFIRMATION value; which then left the 'Family' line showing or not, depending on the last LDS type shown.

3) On the Person LDS editor when the dialog was first activated, the 'Family' line was always shown, because after executing the 'hide', command the last thing the init code did was 'show' everything again.

4) On the Family LDS editor, the parent line was always shown, it should not have been, because the only option was 'Sealed to Spouse' and there is no need for the 'Family' there.

Sorry, no automated test for this; that is a much larger project for another day.  Suggestions are appreciated.  I manually tested on Windows and Linux for each issue listed above; seems to work.
