### PR TITLE
bug 9771; fix missing right-click menu items on gallerytab

### DIFF
--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -437,7 +437,7 @@ class ConfigureDialog(ManagedWindow):
         return combo
 
     def add_slider(self, grid, label, index, constant, range, callback=None,
-                   config=None):
+                   config=None, width=1):
         """
         A slider allowing the selection of an integer within a specified range.
         :param range: A tuple containing the minimum and maximum allowed values.
@@ -455,7 +455,7 @@ class ConfigureDialog(ManagedWindow):
         slider.set_value_pos(Gtk.PositionType.BOTTOM)
         slider.connect('value-changed', callback, constant)
         grid.attach(lwidget, 1, index, 1, 1)
-        grid.attach(slider, 2, index, 1, 1)
+        grid.attach(slider, 2, index, width, 1)
         return slider
 
     def add_spinner(self, grid, label, index, constant, range, callback=None,

--- a/gramps/gui/editors/displaytabs/embeddedlist.py
+++ b/gramps/gui/editors/displaytabs/embeddedlist.py
@@ -139,25 +139,20 @@ class EmbeddedList(ButtonTab):
         """
         Create the list needed to populate the right popup action
         An entry is
-            ( needs_write_access, image, title, function)
-        If image == False, then only text label with title is shown
-        If image == True, and image is a tuple (stock_id, text), the image
-            of the stock id (eg 'gramps-family') is shown, and the label text
-            If image is not a tuple, then it should be a stock_id, and the
-            image is shown, with label the default stock_id label.
+            ( needs_write_access, title, function)
         """
         if self.share_btn:
             itemlist = [
-                (True, _('_Add'), 'list-add', self.add_button_clicked),
-                (True,  _('Share'), None, self.share_button_clicked),
-                (False, _('_Edit'), 'gtk-edit', self.edit_button_clicked),
-                (True, _('_Remove'), 'list-remove', self.del_button_clicked),
+                (True, _('_Add'), self.add_button_clicked),
+                (True,  _('Share'), self.share_button_clicked),
+                (False, _('_Edit'), self.edit_button_clicked),
+                (True, _('_Remove'), self.del_button_clicked),
                 ]
         else:
             itemlist = [
-                (True, _('_Add'), 'list-add', self.add_button_clicked),
-                (False, _('_Edit'), 'gtk-edit', self.edit_button_clicked),
-                (True, _('_Remove'), 'list-remove', self.del_button_clicked),
+                (True, _('_Add'), self.add_button_clicked),
+                (False, _('_Edit'), self.edit_button_clicked),
+                (True, _('_Remove'), self.del_button_clicked),
             ]
         return itemlist
 
@@ -171,13 +166,8 @@ class EmbeddedList(ButtonTab):
         """
         self.__store_menu = Gtk.Menu() #need to keep reference or menu disappears
         menu = self.__store_menu
-        for (need_write, title, icon_name, func) in self.get_popup_menu_items():
-            if icon_name:
-                item = Gtk.ImageMenuItem.new_with_mnemonic(title)
-                img = Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.MENU)
-                item.set_image(img)
-            else:
-                item = Gtk.MenuItem.new_with_mnemonic(title)
+        for (need_write, title, func) in self.get_popup_menu_items():
+            item = Gtk.MenuItem.new_with_mnemonic(title)
             item.connect('activate', func)
             if need_write and self.dbstate.db.readonly:
                 item.set_sensitive(False)

--- a/gramps/gui/editors/displaytabs/gallerytab.py
+++ b/gramps/gui/editors/displaytabs/gallerytab.py
@@ -69,7 +69,6 @@ _ = glocale.translation.gettext
 #-------------------------------------------------------------------------
 def make_launcher(path, uistate):
     return lambda x: open_file_with_default_application(path, uistate)
-
 #-------------------------------------------------------------------------
 #
 # GalleryTab
@@ -125,26 +124,24 @@ class GalleryTab(ButtonTab, DbGUIElement):
 
     def right_click(self, obj, event):
         itemlist = [
-            (True, True, 'list-add', self.add_button_clicked),
-            (True, False, _('Share'), self.share_button_clicked),
-            (False,True, 'gtk-edit', self.edit_button_clicked),
-            (True, True, 'list-remove', self.del_button_clicked),
+            (True, _('_Add'), self.add_button_clicked),
+            (True, _('Share'), self.share_button_clicked),
+            (False, _('_Edit'), self.edit_button_clicked),
+            (True, _('_Remove'), self.del_button_clicked),
             ]
 
         self.menu = Gtk.Menu()
+        self.menu.set_reserve_toggle_size(False)
 
         ref_obj = self.dbstate.db.get_media_from_handle(obj.ref)
         media_path = media_path_full(self.dbstate.db, ref_obj.get_path())
         if media_path:
-            item = Gtk.ImageMenuItem(_('View'))
-            img = Gtk.Image()
-            img.set_from_icon_name("gramps-viewmedia", Gtk.IconSize.MENU)
-            item.set_image(img)
+            item = Gtk.MenuItem.new_with_mnemonic(_('_View'))
             item.connect('activate', make_launcher(media_path, self.uistate))
             item.show()
             self.menu.append(item)
             mfolder, mfile = os.path.split(media_path)
-            item = Gtk.MenuItem(label=_('Open Containing _Folder'))
+            item = Gtk.MenuItem.new_with_mnemonic(_('Open Containing _Folder'))
             item.connect('activate', make_launcher(mfolder, self.uistate))
             item.show()
             self.menu.append(item)
@@ -152,7 +149,7 @@ class GalleryTab(ButtonTab, DbGUIElement):
             item.show()
             self.menu.append(item)
 
-            item = Gtk.MenuItem(_('Make Active Media'))
+            item = Gtk.MenuItem.new_with_mnemonic(_('_Make Active Media'))
             item.connect('activate', lambda obj: self.uistate.set_active(ref_obj.handle, "Media"))
             item.show()
             self.menu.append(item)
@@ -160,13 +157,8 @@ class GalleryTab(ButtonTab, DbGUIElement):
             item.show()
             self.menu.append(item)
 
-        for (needs_write_access, image, title, func) in itemlist:
-            if image:
-                item = Gtk.ImageMenuItem()
-                img = Gtk.Image.new_from_icon_name(title, Gtk.IconSize.MENU)
-                item.set_image(img)
-            else:
-                item = Gtk.MenuItem(label=title)
+        for (needs_write_access, title, func) in itemlist:
+            item = Gtk.MenuItem.new_with_mnemonic(title)
             item.connect('activate', func)
             if needs_write_access and self.dbstate.db.readonly:
                 item.set_sensitive(False)

--- a/gramps/gui/plug/report/_bookdialog.py
+++ b/gramps/gui/plug/report/_bookdialog.py
@@ -613,28 +613,26 @@ class BookSelector(ManagedWindow):
         else:
             sensitivity = 0
         entries = [
-            (_('_Up'), 'go-up', self.on_up_clicked, sensitivity),
-            (_('_Down'), 'go-down', self.on_down_clicked, sensitivity),
-            (_("Setup"), None, self.on_setup_clicked, sensitivity),
-            (_('_Remove'), 'list-remove', self.on_remove_clicked, sensitivity),
-            ('', None, None, 0),
-            (_('_Clear'), 'edit-clear', self.on_clear_clicked, 1),
-            (_('_Save'), 'document-save', self.on_save_clicked, 1),
-            (_('_Open'), 'document-open', self.on_open_clicked, 1),
-            (_("Edit"), None, self.on_edit_clicked, 1),
+            (_('_Up'), self.on_up_clicked, sensitivity),
+            (_('_Down'), self.on_down_clicked, sensitivity),
+            (_("Setup"), self.on_setup_clicked, sensitivity),
+            (_('_Remove'), self.on_remove_clicked, sensitivity),
+            ('', None, 0),
+            (_('Clear the book'), self.on_clear_clicked, 1),
+            (_('_Save'), self.on_save_clicked, 1),
+            (_('_Open'), self.on_open_clicked, 1),
+            (_("_Edit"), self.on_edit_clicked, 1),
         ]
 
         self.menu1 = Gtk.Menu() # TODO could this be just a local "menu ="?
-        self.menu1.set_title(_('Book Menu'))
-        for title, icon_name, callback, sensitivity in entries:
-            if icon_name:
-                item = Gtk.ImageMenuItem.new_with_mnemonic(title)
-                img = Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.MENU)
-                item.set_image(img)
-            else:
-                item = Gtk.MenuItem.new_with_mnemonic(title)
+        self.menu1.set_reserve_toggle_size(False)
+        for title, callback, sensitivity in entries:
+            item = Gtk.MenuItem.new_with_mnemonic(title)
+            Gtk.Label.new_with_mnemonic
             if callback:
                 item.connect("activate", callback)
+            else:
+                item = Gtk.SeparatorMenuItem()
             item.set_sensitive(sensitivity)
             item.show()
             self.menu1.append(item)
@@ -649,18 +647,13 @@ class BookSelector(ManagedWindow):
         else:
             sensitivity = 0
         entries = [
-            (_('_Add'), 'list-add', self.on_add_clicked, sensitivity),
+            (_('_Add'), self.on_add_clicked, sensitivity),
         ]
 
         self.menu2 = Gtk.Menu() # TODO could this be just a local "menu ="?
-        self.menu2.set_title(_('Available Items Menu'))
-        for title, icon_name, callback, sensitivity in entries:
-            if icon_name:
-                item = Gtk.ImageMenuItem.new_with_mnemonic(title)
-                img = Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.MENU)
-                item.set_image(img)
-            else:
-                item = Gtk.MenuItem.new_with_mnemonic(title)
+        self.menu2.set_reserve_toggle_size(False)
+        for title, callback, sensitivity in entries:
+            item = Gtk.MenuItem.new_with_mnemonic(title)
             if callback:
                 item.connect("activate", callback)
             item.set_sensitive(sensitivity)

--- a/gramps/gui/widgets/fanchart.py
+++ b/gramps/gui/widgets/fanchart.py
@@ -1561,32 +1561,25 @@ class FanChartGrampsGUI:
         #store menu for GTK3 to avoid it being destroyed before showing
         self.menu = Gtk.Menu()
         menu = self.menu
-        menu.set_title(_('People Menu'))
+        self.menu.set_reserve_toggle_size(False)
 
         person = self.dbstate.db.get_person_from_handle(person_handle)
         if not person:
             return 0
 
-        go_image = Gtk.Image.new_from_icon_name('go-jump', Gtk.IconSize.MENU)
-        go_image.show()
-        go_item = Gtk.ImageMenuItem(name_displayer.display(person))
-        go_item.set_image(go_image)
+        go_item = Gtk.MenuItem(label=name_displayer.display(person))
         go_item.connect("activate", self.on_childmenu_changed, person_handle)
         go_item.show()
         menu.append(go_item)
 
-        edit_item = Gtk.ImageMenuItem.new_with_mnemonic(_('_Edit'))
-        img = Gtk.Image.new_from_icon_name('gtk-edit', Gtk.IconSize.MENU)
-        edit_item.set_image(img)
+        edit_item = Gtk.MenuItem.new_with_mnemonic(_('_Edit'))
         edit_item.connect("activate", self.edit_person_cb, person_handle)
         edit_item.show()
         menu.append(edit_item)
         if family_handle:
             family = self.dbstate.db.get_family_from_handle(family_handle)
-            edit_fam_item = Gtk.ImageMenuItem()
-            img = Gtk.Image.new_from_icon_name('gtk-edit', Gtk.IconSize.MENU)
-            edit_fam_item.set_image(img)
-            edit_fam_item.set_label(_("Edit family"))
+            edit_fam_item = Gtk.MenuItem()
+            edit_fam_item.set_label(label=_("Edit family"))
             edit_fam_item.connect("activate", self.edit_fam_cb, family_handle)
             edit_fam_item.show()
             menu.append(edit_fam_item)
@@ -1601,19 +1594,14 @@ class FanChartGrampsGUI:
                 lenfams = len(partner.get_family_handle_list())
                 if lenfams in [0, 1]:
                     lenfams = len(partner.get_parent_family_handle_list())
-            reord_fam_item = Gtk.ImageMenuItem()
-            img = Gtk.Image.new_from_icon_name('view-sort-ascending',
-                                               Gtk.IconSize.MENU)
-            reord_fam_item.set_image(img)
-            reord_fam_item.set_label(_("Reorder families"))
+            reord_fam_item = Gtk.MenuItem()
+            reord_fam_item.set_label(label=_("Reorder families"))
             reord_fam_item.connect("activate", self.reord_fam_cb, parth)
             reord_fam_item.set_sensitive(lenfams > 1)
             reord_fam_item.show()
             menu.append(reord_fam_item)
 
-        clipboard_item = Gtk.ImageMenuItem.new_with_mnemonic(_('_Copy'))
-        img = Gtk.Image.new_from_icon_name('edit-copy', Gtk.IconSize.MENU)
-        clipboard_item.set_image(img)
+        clipboard_item = Gtk.MenuItem.new_with_mnemonic(_('_Copy'))
         clipboard_item.connect("activate", self.copy_person_to_clipboard_cb,
                                person_handle)
         clipboard_item.show()
@@ -1642,11 +1630,9 @@ class FanChartGrampsGUI:
                 no_spouses = 0
                 item.set_submenu(Gtk.Menu())
                 sp_menu = item.get_submenu()
+                sp_menu.set_reserve_toggle_size(False)
 
-            go_image = Gtk.Image.new_from_icon_name('go-jump', Gtk.IconSize.MENU)
-            go_image.show()
-            sp_item = Gtk.ImageMenuItem(name_displayer.display(spouse))
-            sp_item.set_image(go_image)
+            sp_item = Gtk.MenuItem(label=name_displayer.display(spouse))
             linked_persons.append(sp_id)
             sp_item.connect("activate", self.on_childmenu_changed, sp_id)
             sp_item.show()
@@ -1677,16 +1663,14 @@ class FanChartGrampsGUI:
                     no_siblings = 0
                     item.set_submenu(Gtk.Menu())
                     sib_menu = item.get_submenu()
+                    sib_menu.set_reserve_toggle_size(False)
 
                 if find_children(self.dbstate.db,sib):
                     label = Gtk.Label(label='<b><i>%s</i></b>' % escape(name_displayer.display(sib)))
                 else:
                     label = Gtk.Label(label=escape(name_displayer.display(sib)))
 
-                go_image = Gtk.Image.new_from_icon_name('go-jump', Gtk.IconSize.MENU)
-                go_image.show()
-                sib_item = Gtk.ImageMenuItem()
-                sib_item.set_image(go_image)
+                sib_item = Gtk.MenuItem()
                 label.set_use_markup(True)
                 label.show()
                 label.set_halign(Gtk.Align.START)
@@ -1714,16 +1698,14 @@ class FanChartGrampsGUI:
                 no_children = 0
                 item.set_submenu(Gtk.Menu())
                 child_menu = item.get_submenu()
+                child_menu.set_reserve_toggle_size(False)
 
             if find_children(self.dbstate.db,child):
                 label = Gtk.Label(label='<b><i>%s</i></b>' % escape(name_displayer.display(child)))
             else:
                 label = Gtk.Label(label=escape(name_displayer.display(child)))
 
-            go_image = Gtk.Image.new_from_icon_name('go-jump', Gtk.IconSize.MENU)
-            go_image.show()
-            child_item = Gtk.ImageMenuItem()
-            child_item.set_image(go_image)
+            child_item = Gtk.MenuItem()
             label.set_use_markup(True)
             label.show()
             label.set_halign(Gtk.Align.START)
@@ -1742,6 +1724,7 @@ class FanChartGrampsGUI:
         item = Gtk.MenuItem(label=_("Parents"))
         item.set_submenu(Gtk.Menu())
         par_menu = item.get_submenu()
+        par_menu.set_reserve_toggle_size(False)
         no_parents = 1
         par_list = find_parents(self.dbstate.db,person)
         for par_id in par_list:
@@ -1759,10 +1742,7 @@ class FanChartGrampsGUI:
             else:
                 label = Gtk.Label(label=escape(name_displayer.display(par)))
 
-            go_image = Gtk.Image.new_from_icon_name('go-jump', Gtk.IconSize.MENU)
-            go_image.show()
-            par_item = Gtk.ImageMenuItem()
-            par_item.set_image(go_image)
+            par_item = Gtk.MenuItem()
             label.set_use_markup(True)
             label.show()
             label.set_halign(Gtk.Align.START)
@@ -1774,9 +1754,7 @@ class FanChartGrampsGUI:
 
         if no_parents:
             #show an add button
-            add_item = Gtk.ImageMenuItem.new_with_mnemonic(_('_Add'))
-            img = Gtk.Image.new_from_icon_name('list-add', Gtk.IconSize.MENU)
-            add_item.set_image(img)
+            add_item = Gtk.MenuItem.new_with_mnemonic(_('_Add'))
             add_item.connect("activate", self.on_add_parents, person_handle)
             add_item.show()
             par_menu.append(add_item)
@@ -1799,13 +1777,11 @@ class FanChartGrampsGUI:
                 no_related = 0
                 item.set_submenu(Gtk.Menu())
                 per_menu = item.get_submenu()
+                per_menu.set_reserve_toggle_size(False)
 
             label = Gtk.Label(label=escape(name_displayer.display(per)))
 
-            go_image = Gtk.Image.new_from_icon_name('go-jump', Gtk.IconSize.MENU)
-            go_image.show()
-            per_item = Gtk.ImageMenuItem()
-            per_item.set_image(go_image)
+            per_item = Gtk.MenuItem()
             label.set_use_markup(True)
             label.show()
             label.set_halign(Gtk.Align.START)
@@ -1820,14 +1796,13 @@ class FanChartGrampsGUI:
         menu.append(item)
 
         #we now construct an add menu
-        item = Gtk.MenuItem(label=_("Add"))
+        item = Gtk.MenuItem.new_with_mnemonic(_("_Add"))
         item.set_submenu(Gtk.Menu())
         add_menu = item.get_submenu()
+        add_menu.set_reserve_toggle_size(False)
         if family_handle:
             # allow to add a child to this family
-            add_child_item = Gtk.ImageMenuItem()
-            img = Gtk.Image.new_from_icon_name('list-add', Gtk.IconSize.MENU)
-            add_child_item.set_image(img)
+            add_child_item = Gtk.MenuItem()
             add_child_item.set_label(_("Add child to family"))
             add_child_item.connect("activate", self.add_child_to_fam_cb,
                                    family_handle)
@@ -1835,18 +1810,14 @@ class FanChartGrampsGUI:
             add_menu.append(add_child_item)
         elif person_handle:
             #allow to add a partner to this person
-            add_partner_item = Gtk.ImageMenuItem()
-            img = Gtk.Image.new_from_icon_name('list-add', Gtk.IconSize.MENU)
-            add_partner_item.set_image(img)
+            add_partner_item = Gtk.MenuItem()
             add_partner_item.set_label(_("Add partner to person"))
             add_partner_item.connect("activate", self.add_partner_to_pers_cb,
                                    person_handle)
             add_partner_item.show()
             add_menu.append(add_partner_item)
 
-        add_pers_item = Gtk.ImageMenuItem()
-        img = Gtk.Image.new_from_icon_name('list-add', Gtk.IconSize.MENU)
-        add_pers_item.set_image(img)
+        add_pers_item = Gtk.MenuItem()
         add_pers_item.set_label(_("Add a person"))
         add_pers_item.connect("activate", self.add_person_cb)
         add_pers_item.show()

--- a/gramps/plugins/gramplet/descendant.py
+++ b/gramps/plugins/gramplet/descendant.py
@@ -105,17 +105,19 @@ class Descendant(Gramplet):
         (model, iter_) = treeview.get_selection().get_selected()
         sensitivity = 1 if iter_ else 0
         menu = Gtk.Menu()
-        menu.set_title(_('Descendent Menu'))
+        menu.set_reserve_toggle_size(False)
         entries = [
             (_("Edit"), lambda obj: self.cb_double_click(treeview),
              sensitivity),
             (None, None, 0),
             (_("Copy all"), lambda obj: self.on_copy_all(treeview), 1),
         ]
-        for stock_id, callback, sensitivity in entries:
-            item = Gtk.ImageMenuItem(stock_id)
+        for title, callback, sensitivity in entries:
+            item = Gtk.MenuItem(label=title)
             if callback:
                 item.connect("activate", callback)
+            else:
+                item = Gtk.SeparatorMenuItem()
             item.set_sensitive(sensitivity)
             item.show()
             menu.append(item)

--- a/gramps/plugins/sidebar/dropdownsidebar.py
+++ b/gramps/plugins/sidebar/dropdownsidebar.py
@@ -123,11 +123,16 @@ class DropdownSidebar(BaseSidebar):
         Called when a view drop-down arrow is clicked.
         """
         self.menu = Gtk.Menu()
+        self.menu.set_reserve_toggle_size(False)
         for item in self.views[cat_num]:
-            menuitem = Gtk.ImageMenuItem(label=item[1])
+            menuitem = Gtk.MenuItem()
+            hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+            label = Gtk.Label(label=item[1])
             image = Gtk.Image.new_from_icon_name(item[2], Gtk.IconSize.MENU)
-            image.show()
-            menuitem.set_image(image)
+            hbox.pack_start(image, False, False, 3)
+            hbox.pack_start(label, False, False, 3)
+            hbox.show_all()
+            menuitem.add(hbox)
             menuitem.connect("activate", self.cb_menu_clicked, cat_num, item[0])
             menuitem.show()
             self.menu.append(menuitem)

--- a/gramps/plugins/view/pedigreeview.py
+++ b/gramps/plugins/view/pedigreeview.py
@@ -260,7 +260,11 @@ class PersonBoxWidgetCairo(_PersonWidgetBase):
         alh = self.get_allocated_height()
         if not self.textlayout:
             self.textlayout = PangoCairo.create_layout(context)
-            self.textlayout.set_font_description(self.get_style().font_desc)
+            # The following seems like it Should work, but it doesn't
+            # font_desc = self.get_style_context().get_property(
+            #     "font", Gtk.StateFlags.NORMAL)
+            font_desc = self.get_style_context().get_font(Gtk.StateFlags.NORMAL)
+            self.textlayout.set_font_description(font_desc)
             self.textlayout.set_markup(self.text, -1)
         size = self.textlayout.get_pixel_size()
         xmin = size[0] + 12
@@ -1103,24 +1107,24 @@ class PedigreeView(NavigationView):
         ########################################################################
         if lst[0]:
             if self.tree_direction == 2:
-                child_arrow = Gtk.ArrowType.LEFT
-                parent_arrow = Gtk.ArrowType.RIGHT
+                child_arrow = "go-previous-symbolic" # Gtk.ArrowType.LEFT
+                parent_arrow = "go-next-symbolic" # Gtk.ArrowType.RIGHT
             elif self.tree_direction == 0:
-                child_arrow = Gtk.ArrowType.UP
-                parent_arrow = Gtk.ArrowType.DOWN
+                child_arrow = "go-up-symbolic" # Gtk.ArrowType.UP
+                parent_arrow = "go-down-symbolic" # Gtk.ArrowType.DOWN
             elif self.tree_direction == 1:
-                child_arrow = Gtk.ArrowType.DOWN
-                parent_arrow = Gtk.ArrowType.UP
+                child_arrow = "go-down-symbolic" # Gtk.ArrowType.DOWN
+                parent_arrow = "go-up-symbolic" # Gtk.ArrowType.UP
             elif self.tree_direction == 3:
-                child_arrow = Gtk.ArrowType.RIGHT
-                parent_arrow = Gtk.ArrowType.LEFT
+                child_arrow = "go-next-symbolic" # Gtk.ArrowType.RIGHT
+                parent_arrow = "go-previous-symbolic" # Gtk.ArrowType.LEFT
             # GTK will reverse the icons for RTL locales, but we force LTR layout of the table,
             # so reverse the arrows back...
             if self.tree_direction in [2,3] and self.scrolledwindow.get_direction() == Gtk.TextDirection.RTL:
                 child_arrow, parent_arrow = parent_arrow, child_arrow
 
-            button = Gtk.Button()
-            button.add(Gtk.Arrow.new(child_arrow, Gtk.ShadowType.IN))
+            button = Gtk.Button.new_from_icon_name(child_arrow,
+                                                  Gtk.IconSize.BUTTON)
             childlist = find_children(self.dbstate.db, lst[0][0])
             if childlist:
                 button.connect("clicked", self.cb_on_show_child_menu)
@@ -1133,7 +1137,8 @@ class PedigreeView(NavigationView):
                                 0, 1, ymid, ymid +1)
 
             button = Gtk.Button()
-            button.add(Gtk.Arrow.new(parent_arrow, Gtk.ShadowType.IN))
+            button = Gtk.Button.new_from_icon_name(parent_arrow,
+                                                  Gtk.IconSize.BUTTON)
             if lst[1]:
                 button.connect("clicked", self.cb_childmenu_changed,
                           lst[1][0].handle)
@@ -1146,7 +1151,8 @@ class PedigreeView(NavigationView):
                                 xmax, xmax+1, ymid-1, ymid+2)
 
             button = Gtk.Button()
-            button.add(Gtk.Arrow.new(parent_arrow, Gtk.ShadowType.IN))
+            button = Gtk.Button.new_from_icon_name(parent_arrow,
+                                                  Gtk.IconSize.BUTTON)
             if lst[2]:
                 button.connect("clicked", self.cb_childmenu_changed,
                           lst[2][0].handle)
@@ -1212,7 +1218,7 @@ class PedigreeView(NavigationView):
         table_widget.show_all()
 
         # Setup scrollbars for view root person
-        window = table_widget.get_parent().get_parent()
+        window = table_widget.get_parent().get_parent().get_parent()
         hadjustment = window.get_hadjustment()
         vadjustment = window.get_vadjustment()
         if self.tree_direction == 2:
@@ -1331,6 +1337,7 @@ class PedigreeView(NavigationView):
     def cb_on_show_option_menu(self, obj, event, data=None):
         """Right click option menu."""
         self.menu = Gtk.Menu()
+        self.menu.set_reserve_toggle_size(False)
         self.add_nav_portion_to_menu(self.menu)
         self.add_settings_to_menu(self.menu)
         self.menu.popup(None, None, None, None, 0, event.time)
@@ -1454,6 +1461,7 @@ class PedigreeView(NavigationView):
                     self.change_active(childlist[0])
             elif len(childlist) > 1:
                 self.my_menu = Gtk.Menu()
+                self.my_menu.set_reserve_toggle_size(False)
                 for child_handle in childlist:
                     child = self.dbstate.db.get_person_from_handle(child_handle)
                     cname = escape(name_displayer.display(child))
@@ -1464,11 +1472,7 @@ class PedigreeView(NavigationView):
                     label.set_use_markup(True)
                     label.show()
                     label.set_halign(Gtk.Align.START)
-                    menuitem = Gtk.ImageMenuItem()
-                    go_image = Gtk.Image.new_from_icon_name('go-jump',
-                                                            Gtk.IconSize.MENU)
-                    go_image.show()
-                    menuitem.set_image(go_image)
+                    menuitem = Gtk.MenuItem()
                     menuitem.add(label)
                     self.my_menu.append(menuitem)
                     menuitem.connect("activate", self.cb_childmenu_changed,
@@ -1554,18 +1558,14 @@ class PedigreeView(NavigationView):
             home_sensitivity = False
             # bug 4884: need to translate the home label
         entries = [
-            (_("Pre_vious"), 'go-previous', self.back_clicked, not hobj.at_front()),
-            (_("_Next"), 'go-next', self.fwd_clicked, not hobj.at_end()),
-            (_("_Home"), 'go-home', self.cb_home, home_sensitivity),
+            (_("Pre_vious"), self.back_clicked, not hobj.at_front()),
+            (_("_Next"), self.fwd_clicked, not hobj.at_end()),
+            (_("_Home"), self.cb_home, home_sensitivity),
         ]
 
-        for label, icon_name, callback, sensitivity in entries:
-            item = Gtk.ImageMenuItem.new_with_mnemonic(label)
+        for label, callback, sensitivity in entries:
+            item = Gtk.MenuItem.new_with_mnemonic(label)
             item.set_sensitive(sensitivity)
-            if icon_name:
-                im = Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.MENU)
-                im.show()
-                item.set_image(im)
             if callback:
                 item.connect("activate", callback)
             item.show()
@@ -1586,16 +1586,14 @@ class PedigreeView(NavigationView):
         item.set_submenu(Gtk.Menu())
         scroll_direction_menu = item.get_submenu()
 
-        entry = Gtk.CheckMenuItem(label=_("Top <-> Bottom"))
-        entry.set_draw_as_radio(True)
+        entry = Gtk.RadioMenuItem(label=_("Top <-> Bottom"))
         entry.connect("activate", self.cb_change_scroll_direction, False)
         if self.scroll_direction == False:
             entry.set_active(True)
         entry.show()
         scroll_direction_menu.append(entry)
 
-        entry = Gtk.CheckMenuItem(_("Left <-> Right"))
-        entry.set_draw_as_radio(True)
+        entry = Gtk.RadioMenuItem(label=_("Left <-> Right"))
         entry.connect("activate", self.cb_change_scroll_direction, True)
         if self.scroll_direction == True:
             entry.set_active(True)
@@ -1610,12 +1608,9 @@ class PedigreeView(NavigationView):
                                          person_handle, family_handle):
         """Builds the menu for a missing parent."""
         self.menu = Gtk.Menu()
-        self.menu.set_title(_('People Menu'))
+        self.menu.set_reserve_toggle_size(False)
 
-        add_item = Gtk.ImageMenuItem.new_with_mnemonic(_('_Add'))
-        img = Gtk.Image.new_from_icon_name('list-add', Gtk.IconSize.MENU)
-        img.show()
-        add_item.set_image(img)
+        add_item = Gtk.MenuItem.new_with_mnemonic(_('_Add'))
         add_item.connect("activate", self.cb_add_parents, person_handle,
                          family_handle)
         add_item.show()
@@ -1639,32 +1634,23 @@ class PedigreeView(NavigationView):
         """
 
         self.menu = Gtk.Menu()
-        self.menu.set_title(_('People Menu'))
+        self.menu.set_reserve_toggle_size(False)
 
         person = self.dbstate.db.get_person_from_handle(person_handle)
         if not person:
             return 0
 
-        go_image = Gtk.Image.new_from_icon_name('go-jump', Gtk.IconSize.MENU)
-        go_image.show()
-        go_item = Gtk.ImageMenuItem(label=name_displayer.display(person))
-        go_item.set_image(go_image)
+        go_item = Gtk.MenuItem(label=name_displayer.display(person))
         go_item.connect("activate", self.cb_childmenu_changed, person_handle)
         go_item.show()
         self.menu.append(go_item)
 
-        edit_item = Gtk.ImageMenuItem.new_with_mnemonic(_('_Edit'))
-        img = Gtk.Image.new_from_icon_name('gtk-edit', Gtk.IconSize.MENU)
-        img.show()
-        edit_item.set_image(img)
+        edit_item = Gtk.MenuItem.new_with_mnemonic(_('_Edit'))
         edit_item.connect("activate", self.cb_edit_person, person_handle)
         edit_item.show()
         self.menu.append(edit_item)
 
-        clipboard_item = Gtk.ImageMenuItem.new_with_mnemonic(_('_Copy'))
-        img = Gtk.Image.new_from_icon_name('edit-copy', Gtk.IconSize.MENU)
-        img.show()
-        clipboard_item.set_image(img)
+        clipboard_item = Gtk.MenuItem.new_with_mnemonic(_('_Copy'))
         clipboard_item.connect("activate", self.cb_copy_person_to_clipboard,
                                person_handle)
         clipboard_item.show()
@@ -1693,12 +1679,9 @@ class PedigreeView(NavigationView):
                 no_spouses = 0
                 item.set_submenu(Gtk.Menu())
                 sp_menu = item.get_submenu()
+                sp_menu.set_reserve_toggle_size(False)
 
-            go_image = Gtk.Image.new_from_icon_name('go-jump',
-                                                    Gtk.IconSize.MENU)
-            go_image.show()
-            sp_item = Gtk.ImageMenuItem(label=name_displayer.display(spouse))
-            sp_item.set_image(go_image)
+            sp_item = Gtk.MenuItem(label=name_displayer.display(spouse))
             linked_persons.append(sp_id)
             sp_item.connect("activate", self.cb_childmenu_changed, sp_id)
             sp_item.show()
@@ -1729,6 +1712,7 @@ class PedigreeView(NavigationView):
                     no_siblings = 0
                     item.set_submenu(Gtk.Menu())
                     sib_menu = item.get_submenu()
+                    sib_menu.set_reserve_toggle_size(False)
 
                 if find_children(self.dbstate.db, sib):
                     label = Gtk.Label(label='<b><i>%s</i></b>'
@@ -1736,11 +1720,7 @@ class PedigreeView(NavigationView):
                 else:
                     label = Gtk.Label(label=escape(name_displayer.display(sib)))
 
-                go_image = Gtk.Image.new_from_icon_name('go-jump',
-                                                        Gtk.IconSize.MENU)
-                go_image.show()
-                sib_item = Gtk.ImageMenuItem()
-                sib_item.set_image(go_image)
+                sib_item = Gtk.MenuItem()
                 label.set_use_markup(True)
                 label.show()
                 label.set_halign(Gtk.Align.START)
@@ -1768,6 +1748,7 @@ class PedigreeView(NavigationView):
                 no_children = 0
                 item.set_submenu(Gtk.Menu())
                 child_menu = item.get_submenu()
+                child_menu.set_reserve_toggle_size(False)
 
             if find_children(self.dbstate.db, child):
                 label = Gtk.Label(label='<b><i>%s</i></b>'
@@ -1775,11 +1756,7 @@ class PedigreeView(NavigationView):
             else:
                 label = Gtk.Label(label=escape(name_displayer.display(child)))
 
-            go_image = Gtk.Image.new_from_icon_name('go-jump',
-                                                    Gtk.IconSize.MENU)
-            go_image.show()
-            child_item = Gtk.ImageMenuItem()
-            child_item.set_image(go_image)
+            child_item = Gtk.MenuItem()
             label.set_use_markup(True)
             label.show()
             label.set_halign(Gtk.Align.START)
@@ -1810,6 +1787,7 @@ class PedigreeView(NavigationView):
                 no_parents = 0
                 item.set_submenu(Gtk.Menu())
                 par_menu = item.get_submenu()
+                par_menu.set_reserve_toggle_size(False)
 
             if find_parents(self.dbstate.db, par):
                 label = Gtk.Label(label='<b><i>%s</i></b>'
@@ -1817,11 +1795,7 @@ class PedigreeView(NavigationView):
             else:
                 label = Gtk.Label(label=escape(name_displayer.display(par)))
 
-            go_image = Gtk.Image.new_from_icon_name('go-jump',
-                                                    Gtk.IconSize.MENU)
-            go_image.show()
-            par_item = Gtk.ImageMenuItem()
-            par_item.set_image(go_image)
+            par_item = Gtk.MenuItem()
             label.set_use_markup(True)
             label.show()
             label.set_halign(Gtk.Align.START)
@@ -1835,7 +1809,8 @@ class PedigreeView(NavigationView):
             if self.tree_style == 2 and not self.show_unknown_people:
                 item.set_submenu(Gtk.Menu())
                 par_menu = item.get_submenu()
-                par_item = Gtk.ImageMenuItem(label=_("Add New Parents..."))
+                par_menu.set_reserve_toggle_size(False)
+                par_item = Gtk.MenuItem(label=_("Add New Parents..."))
                 par_item.connect("activate", self.cb_add_parents, person_handle,
                          family_handle)
                 par_item.show()
@@ -1860,14 +1835,11 @@ class PedigreeView(NavigationView):
                 no_related = 0
                 item.set_submenu(Gtk.Menu())
                 per_menu = item.get_submenu()
+                per_menu.set_reserve_toggle_size(False)
 
             label = Gtk.Label(label=escape(name_displayer.display(per)))
 
-            go_image = Gtk.Image.new_from_icon_name('go-jump',
-                                                    Gtk.IconSize.MENU)
-            go_image.show()
-            per_item = Gtk.ImageMenuItem()
-            per_item.set_image(go_image)
+            per_item = Gtk.MenuItem()
             label.set_use_markup(True)
             label.show()
             label.set_halign(Gtk.Align.START)
@@ -1895,24 +1867,18 @@ class PedigreeView(NavigationView):
     def cb_build_relation_nav_menu(self, obj, event, family_handle):
         """Builds the menu for a parents-child relation line."""
         self.menu = Gtk.Menu()
-        self.menu.set_title(_('Family Menu'))
+        self.menu.set_reserve_toggle_size(False)
 
         family = self.dbstate.db.get_family_from_handle(family_handle)
         if not family:
             return 0
 
-        edit_item = Gtk.ImageMenuItem.new_with_mnemonic(_('_Edit'))
-        img = Gtk.Image.new_from_icon_name('gtk-edit', Gtk.IconSize.MENU)
-        img.show()
-        edit_item.set_image(img)
+        edit_item = Gtk.MenuItem.new_with_mnemonic(_('_Edit'))
         edit_item.connect("activate", self.cb_edit_family, family_handle)
         edit_item.show()
         self.menu.append(edit_item)
 
-        clipboard_item = Gtk.ImageMenuItem.new_with_mnemonic(_('_Copy'))
-        img = Gtk.Image.new_from_icon_name('edit-copy', Gtk.IconSize.MENU)
-        img.show()
-        clipboard_item.set_image(img)
+        clipboard_item = Gtk.MenuItem.new_with_mnemonic(_('_Copy'))
         clipboard_item.connect("activate", self.cb_copy_family_to_clipboard,
                                family_handle)
         clipboard_item.show()

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -567,7 +567,7 @@ class RelationshipView(NavigationView):
         if self._config.get('preferences.releditbtn'):
             button = widgets.IconButton(self.edit_button_press,
                                         person.handle)
-            button.set_tooltip_text(_('Edit %s') % name)
+            button.set_tooltip_text(_('Edit Person (%s)') % name)
         else:
             button = None
         eventbox = Gtk.EventBox()
@@ -989,7 +989,7 @@ class RelationshipView(NavigationView):
                 if self._config.get('preferences.releditbtn'):
                     button = widgets.IconButton(self.edit_button_press,
                                                 handle)
-                    button.set_tooltip_text(_('Edit %s') % name[0])
+                    button.set_tooltip_text(_('Edit Person (%s)') % name[0])
                 else:
                     button = None
                 hbox.pack_start(widgets.LinkBox(link_label, button),
@@ -1046,7 +1046,7 @@ class RelationshipView(NavigationView):
                 link_label.override_background_color(Gtk.StateType.NORMAL, self.color)
             if self._config.get('preferences.releditbtn'):
                 button = widgets.IconButton(self.edit_button_press, handle)
-                button.set_tooltip_text(_('Edit %s') % name[0])
+                button.set_tooltip_text(_('Edit Person (%s)') % name[0])
             else:
                 button = None
             vbox.pack_start(widgets.LinkBox(link_label, button), True, True, 0)
@@ -1170,7 +1170,7 @@ class RelationshipView(NavigationView):
         if child_should_be_linked and self._config.get(
             'preferences.releditbtn'):
             button = widgets.IconButton(self.edit_button_press, handle)
-            button.set_tooltip_text(_('Edit %s') % name[0])
+            button.set_tooltip_text(_('Edit Person (%s)') % name[0])
         else:
             button = None
 
@@ -1265,22 +1265,20 @@ class RelationshipView(NavigationView):
         if button_activated(event, _LEFT_BUTTON):
             self.change_active(handle)
         elif button_activated(event, _RIGHT_BUTTON):
-            self.myMenu = Gtk.Menu()
-            self.myMenu.append(self.build_menu_item(handle))
-            self.myMenu.popup(None, None, None, None, event.button, event.time)
+            self.my_menu = Gtk.Menu()
+            self.my_menu.set_reserve_toggle_size(False)
+            self.my_menu.append(self.build_menu_item(handle))
+            self.my_menu.popup(None, None, None, None, event.button, event.time)
 
     def build_menu_item(self, handle):
         person = self.dbstate.db.get_person_from_handle(handle)
         name = name_displayer.display(person)
 
-        item = Gtk.ImageMenuItem(None)
-        image = Gtk.Image.new_from_icon_name('gtk-edit', Gtk.IconSize.MENU)
-        image.show()
-        label = Gtk.Label(label=_("Edit %s") % name)
+        item = Gtk.MenuItem()
+        label = Gtk.Label(label=_("Edit Person (%s)") % name)
         label.show()
         label.set_halign(Gtk.Align.START)
 
-        item.set_image(image)
         item.add(label)
 
         item.connect('activate', self.edit_menu, handle)


### PR DESCRIPTION
Decided to remove (almost) all the right-click menu icons and make sure that text was present.  The missing text was the cause of the initial bug.

This icons were not being shown due to a Gtk bug in the deprecated Gtk.ImageMenuItem() method.

I did a sweep search of all our code for these right-click menus and tried to patch everything I could find.  The Addons were also searched and will be the subject of another PR.

After icons were removed, I also removed the left side space where the icons used to reside via
`self.menu.set_reserve_toggle_size(False)`

The reason I say 'almost' all menu icons were removed is that the Gramps left sidebar (dropdown version) also used menu icons.  I judged that we would like to keep these.  So the dropdownsidebar got fixed with icons and labels in a box inside of the menu item.

During testing of the updated code, I also observed some additional issues, which I also patched.

1) bookdialog right-click menu got a real menu seperator instead of a large empty space.
2) in pedigreeview, widget `self.get_style().font_desc` was deprecated two ways, I changed to
    `self.get_style_context().get_font(Gtk.StateFlags.NORMAL)`
  unfortunately the `get_font()` is also deprecated, (more recently), but I could not figure out a way to correct this that worked.
3) in pedigreeview, `Gtk.ArrowType` is also deprecated; I switched this out for icons.
4) in pedigreeview, the `window.get_hadjustment()` was pointing to the wrong level of the Gtk hierarchy, a ViewPort rather than the ScrolledWindow.
5) in relview (relationship view) the right-click menu and tooltip were originally labeled with
    `label=_("Edit %s") % name`
At first glance, I thought a persons name started with "Edit Smith, John" so I changed it to
    `label=_("Edit Person (%s)") % name`
so it now looks like "Edit Person (Smith, John)".  The new text string was already in the .pot file so no new translation work for that.
6) in configure.py I added an optional parameter to the add_slide method to allow for a wider slider; I observed it was not possible to slide this on one of the configure dialog boxes for an addon because it was so narrow.

