### PR TITLE
fix name_displayer.add_name_format so it won't create duplicates

### DIFF
--- a/gramps/gen/display/name.py
+++ b/gramps/gen/display/name.py
@@ -433,6 +433,9 @@ class NameDisplay:
         self.set_default_format(self.get_default_format())
 
     def add_name_format(self, name, fmt_str):
+        for num in self.name_formats:
+            if fmt_str in self.name_formats.get(num):
+                return num
         num = -1
         while num in self.name_formats:
             num -= 1


### PR DESCRIPTION
I found a small bug caused in part by the fan chart code [https://github.com/gramps-project/gramps/pull/222](https://github.com/gramps-project/gramps/pull/222) Seems if you run the three types of fan chart (normal, descendant, 2-way) you end up with three copies of new name formats (Edit/Preferences/Display Name format: then Edit the name formats) and see 'Surname' and ''Given Suffix" more than once. I think the bug has been there forever,

This checks if the name format is already present, and returns the number of the format if so.  Other wise add as before.