### PR TITLE
Re-enable selection in MultiTreeView on a drag-end event

### DIFF
--- a/gramps/gui/clipboard.py
+++ b/gramps/gui/clipboard.py
@@ -1479,7 +1479,7 @@ class MultiTreeView(Gtk.TreeView):
         Gtk.TreeView.__init__(self)
         self.connect('button_press_event', self.on_button_press)
         self.connect('button_release_event', self.on_button_release)
-        self.connect('grab_broken_event', self.on_grab_broken)
+        self.connect('drag-end', self.on_drag_end)
         self.connect('key_press_event', self.key_press_event)
         self.defer_select = False
 
@@ -1581,7 +1581,7 @@ class MultiTreeView(Gtk.TreeView):
 
         self.defer_select=False
 
-    def on_grab_broken(self, widget, event):
+    def on_drag_end(self, widget, event):
         # re-enable selection
         self.get_selection().set_select_function(lambda *ignore: True, None)
         self.defer_select=False

--- a/gramps/gui/widgets/multitreeview.py
+++ b/gramps/gui/widgets/multitreeview.py
@@ -40,7 +40,7 @@ class MultiTreeView(Gtk.TreeView):
         Gtk.TreeView.__init__(self)
         self.connect('button_press_event', self.on_button_press)
         self.connect('button_release_event', self.on_button_release)
-        self.connect('grab_broken_event', self.on_grab_broken)
+        self.connect('drag-end', self.on_drag_end)
         self.connect('key_press_event', self.key_press_event)
         self.defer_select = False
 
@@ -83,7 +83,7 @@ class MultiTreeView(Gtk.TreeView):
 
         self.defer_select=False
 
-    def on_grab_broken(self, widget, event):
+    def on_drag_end(self, widget, event):
         # re-enable selection
         self.get_selection().set_select_function(lambda *ignore: True, None)
         self.defer_select=False


### PR DESCRIPTION
In 201f4a5e517ae5d84fbbde95113ecdf9c7e7bb62 we made grab_broken re-enable selection because GTK 3.18 and later no longer send a fake button release event.

The sending of grab broken is an implementation detail of DnD on X based systems however, and at least some GTK backends do not generate this, wayland being one example.

So we now use drag-end instead which is always sent to the source when a DnD operation completes.