### PR TITLE
bug 9787; fix right-click menus crash caused by PR268

### DIFF
--- a/gramps/gui/editors/displaytabs/embeddedlist.py
+++ b/gramps/gui/editors/displaytabs/embeddedlist.py
@@ -166,6 +166,7 @@ class EmbeddedList(ButtonTab):
         """
         self.__store_menu = Gtk.Menu() #need to keep reference or menu disappears
         menu = self.__store_menu
+        menu.set_reserve_toggle_size(False)
         for (need_write, title, func) in self.get_popup_menu_items():
             item = Gtk.MenuItem.new_with_mnemonic(title)
             item.connect('activate', func)

--- a/gramps/gui/editors/displaytabs/eventembedlist.py
+++ b/gramps/gui/editors/displaytabs/eventembedlist.py
@@ -311,8 +311,8 @@ class EventEmbedList(DbGUIElement, GroupEmbeddedList):
             return GroupEmbeddedList.get_popup_menu_items(self)
         else:
             return [
-                (True, _('_Add'), 'list-add', self.add_button_clicked),
-                (False, _('_Edit'), 'gtk-edit', self.edit_button_clicked),
+                (True, _('_Add'), self.add_button_clicked),
+                (False, _('_Edit'), self.edit_button_clicked),
                 ]
 
     def _non_native_change(self):

--- a/gramps/gui/editors/displaytabs/nameembedlist.py
+++ b/gramps/gui/editors/displaytabs/nameembedlist.py
@@ -119,15 +119,15 @@ class NameEmbedList(GroupEmbeddedList):
     def get_popup_menu_items(self):
         if self._tmpgroup == self._WORKGROUP:
             return [
-                (True, _('_Add'), 'list-add', self.add_button_clicked),
-                (False, _('_Edit'), 'gtk-edit', self.edit_button_clicked),
-                (True, _('_Remove'), 'list-remove', self.del_button_clicked),
-                (True, _('Set as default name'), None, self.name_button_clicked),
+                (True, _('_Add'), self.add_button_clicked),
+                (False, _('_Edit'), self.edit_button_clicked),
+                (True, _('_Remove'), self.del_button_clicked),
+                (True, _('Set as default name'), self.name_button_clicked),
                 ]
         else:
             return [
-                (True, _('_Add'), 'list-add', self.add_button_clicked),
-                (False,_('_Edit'), 'gtk-edit', self.edit_button_clicked),
+                (True, _('_Add'), self.add_button_clicked),
+                (False,_('_Edit'), self.edit_button_clicked),
                 ]
 
     def name_button_clicked(self, obj):

--- a/gramps/gui/editors/displaytabs/webembedlist.py
+++ b/gramps/gui/editors/displaytabs/webembedlist.py
@@ -112,10 +112,10 @@ class WebEmbedList(EmbeddedList):
 
     def get_popup_menu_items(self):
         return [
-            (True, _('_Add'), 'list-add', self.add_button_clicked),
-            (False, _('_Edit'), 'gtk-edit', self.edit_button_clicked),
-            (True, _('_Remove'), 'list-remove', self.del_button_clicked),
-            (True, _('_Jump to'), 'go-jump', self.jump_button_clicked),
+            (True, _('_Add'), self.add_button_clicked),
+            (False, _('_Edit'), self.edit_button_clicked),
+            (True, _('_Remove'), self.del_button_clicked),
+            (True, _('_Jump to'), self.jump_button_clicked),
             ]
 
     def jump_button_clicked(self, obj):

--- a/gramps/gui/editors/editfamily.py
+++ b/gramps/gui/editors/editfamily.py
@@ -144,13 +144,11 @@ class ChildEmbedList(EmbeddedList):
 
     def get_popup_menu_items(self):
         return [
-            (False, _('Edit child'), 'gtk-edit',
-                                            self.edit_child_button_clicked),
-            (True, _('_Add'), 'list-add', self.add_button_clicked),
-            (True, _('Add an existing child'), None, self.share_button_clicked),
-            (False, _('Edit relationship'), 'gtk-edit',
-                                            self.edit_button_clicked),
-            (True, _('_Remove'), 'list-remove', self.del_button_clicked),
+            (False, _('Edit child'), self.edit_child_button_clicked),
+            (True, _('_Add'), self.add_button_clicked),
+            (True, _('Add an existing child'), self.share_button_clicked),
+            (False, _('Edit relationship'), self.edit_button_clicked),
+            (True, _('_Remove'), self.del_button_clicked),
             ]
 
     def get_middle_click(self):


### PR DESCRIPTION
PR268 removed icons from right-click menus in a lot of places.   I did not spot that some of the changes were to classes that were inherited. So I need to edit the inheriting classes as well where they overrode the method.