### PR TITLE
Fix translation confusion on 'View' noun/verb

### DIFF
--- a/gramps/gui/editors/displaytabs/gallerytab.py
+++ b/gramps/gui/editors/displaytabs/gallerytab.py
@@ -60,7 +60,7 @@ from ...ddtargets import DdTargets
 from .buttontab import ButtonTab
 from gramps.gen.const import THUMBSCALE
 from gramps.gen.const import GRAMPS_LOCALE as glocale
-_ = glocale.translation.gettext
+_ = glocale.translation.sgettext
 
 #-------------------------------------------------------------------------
 #
@@ -136,7 +136,8 @@ class GalleryTab(ButtonTab, DbGUIElement):
         ref_obj = self.dbstate.db.get_media_from_handle(obj.ref)
         media_path = media_path_full(self.dbstate.db, ref_obj.get_path())
         if media_path:
-            item = Gtk.MenuItem.new_with_mnemonic(_('_View'))
+            # Translators: _View means "to look at this"
+            item = Gtk.MenuItem.new_with_mnemonic(_('verb:look at this|_View'))
             item.connect('activate', make_launcher(media_path, self.uistate))
             item.show()
             self.menu.append(item)


### PR DESCRIPTION
I previously changed the right-click menu on the gallery tab from icons to text; I apparently did not know that the word 'View' could be confusing in other languages (to look at, vs. something to see).  So tweaked the string to include a hint to translators.