### PR TITLE
bug 9811; Fix for Relative media path incorrectly calculated for Windows

### DIFF
--- a/gramps/gen/utils/file.py
+++ b/gramps/gen/utils/file.py
@@ -137,12 +137,16 @@ def relative_path(original, base):
     base_list = [_f for _f in base_list if _f]
     target_list = [_f for _f in target_list if _f]
     i = -1
+    # base path is normcase (lower case on Windows) so compare target in lower
+    # on Windows as well
     for i in range(min(len(base_list), len(target_list))):
-        if base_list[i] != target_list[i]: break
+        if base_list[i] != (target_list[i].lower() if win()
+                            else target_list[i]):
+            break
     else:
         #if break did not happen we are here at end, and add 1.
         i += 1
-    rel_list = [os.pardir] * (len(base_list)-i) + target_list[i:]
+    rel_list = [os.pardir] * (len(base_list) - i) + target_list[i:]
     return os.path.join(*rel_list)
 
 def expand_path(path, normalize = True):


### PR DESCRIPTION
This issue (apparently matching base and target initial media paths, did not collapse correctly) was created as a side effect of supporting environment variable expansion in the base media path.
The base media path got 'os.path.normcase()' (on Windows this makes it lower case, since Windows paths are case insensitive). The actual new media path did not get that treatment. So if the initial parts of the path were not all loser case, they would not compare and got the '../..' treatment.

From Bug report:
I have the Base path for relative media path set in preferences as:
C:\Users\Public\Genealogy\Media

While adding a new media file, with Convert to relative path checked, this is what results:
..\..\..\..\Users\Public\Genealogy\Media\Census\1860 ME, Oxford Co, Andover 7.jpg