### PR TITLE
fix for bugs 9768 and 9778, nonetype error when merging events or families

### DIFF
--- a/gramps/gui/merge/mergeevent.py
+++ b/gramps/gui/merge/mergeevent.py
@@ -88,10 +88,12 @@ class MergeEvent(ManagedWindow):
             for widget_name in ('date1', 'date2', 'date_btn1', 'date_btn2'):
                 self.get_widget(widget_name).set_sensitive(False)
 
-        place1 = database.get_place_from_handle(
-                self.ev1.get_place_handle())
-        place2 = database.get_place_from_handle(
-                self.ev2.get_place_handle())
+        place1 = self.ev1.get_place_handle()
+        if place1:
+            place1 = database.get_place_from_handle(place1)
+        place2 = self.ev2.get_place_handle()
+        if place2:
+            place2 = database.get_place_from_handle(place2)
         place1 = place1.get_title() if place1 else ""
         place2 = place2.get_title() if place2 else ""
         entry1 = self.get_widget("place1")

--- a/gramps/gui/merge/mergefamily.py
+++ b/gramps/gui/merge/mergefamily.py
@@ -73,8 +73,10 @@ class MergeFamily(ManagedWindow):
         # Detailed selection widgets
         father1 = self.fy1.get_father_handle()
         father2 = self.fy2.get_father_handle()
-        father1 = self.database.get_person_from_handle(father1)
-        father2 = self.database.get_person_from_handle(father2)
+        if father1:
+            father1 = self.database.get_person_from_handle(father1)
+        if father2:
+            father2 = self.database.get_person_from_handle(father2)
         father_id1 = father1.get_gramps_id() if father1 else ""
         father_id2 = father2.get_gramps_id() if father2 else ""
         father1 = name_displayer.display(father1) if father1 else ""
@@ -101,8 +103,10 @@ class MergeFamily(ManagedWindow):
 
         mother1 = self.fy1.get_mother_handle()
         mother2 = self.fy2.get_mother_handle()
-        mother1 = self.database.get_person_from_handle(mother1)
-        mother2 = self.database.get_person_from_handle(mother2)
+        if mother1:
+            mother1 = self.database.get_person_from_handle(mother1)
+        if mother2:
+            mother2 = self.database.get_person_from_handle(mother2)
         mother_id1 = mother1.get_gramps_id() if mother1 else ""
         mother_id2 = mother2.get_gramps_id() if mother2 else ""
         mother1 = name_displayer.display(mother1) if mother1 else ""


### PR DESCRIPTION
These are another example of the issues caused when we decided to raise 'HandleError' whenever a 'None' handle was input. To correct the issue we've been either testing for 'None' before making the call, or surrounding the call with try/except.