### PR TITLE
bug 9818 allow merging of families with one or more parents in common

### DIFF
--- a/gramps/gen/merge/mergefamilyquery.py
+++ b/gramps/gen/merge/mergefamilyquery.py
@@ -134,15 +134,23 @@ class MergeFamilyQuery:
 
         with DbTxn(_('Merge Family'), self.database) as trans:
 
-            phoenix_father = self.database.get_person_from_handle(self.phoenix_fh)
-            titanic_father = self.database.get_person_from_handle(self.titanic_fh)
-            self.merge_person(phoenix_father, titanic_father, 'father', trans)
+            if self.phoenix_fh != self.titanic_fh:
+                phoenix_father = self.database.get_person_from_handle(
+                    self.phoenix_fh)
+                titanic_father = self.database.get_person_from_handle(
+                    self.titanic_fh)
+                self.merge_person(phoenix_father, titanic_father,
+                                  'father', trans)
 
-            phoenix_mother = self.database.get_person_from_handle(self.phoenix_mh)
-            titanic_mother = self.database.get_person_from_handle(self.titanic_mh)
+            if self.phoenix_mh != self.titanic_mh:
+                phoenix_mother = self.database.get_person_from_handle(
+                    self.phoenix_mh)
+                titanic_mother = self.database.get_person_from_handle(
+                    self.titanic_mh)
+                self.merge_person(phoenix_mother, titanic_mother,
+                                  'mother', trans)
             self.phoenix = self.database.get_family_from_handle(new_handle)
             self.titanic = self.database.get_family_from_handle(old_handle)
-            self.merge_person(phoenix_mother, titanic_mother, 'mother', trans)
 
             phoenix_father = self.database.get_person_from_handle(self.phoenix_fh)
             phoenix_mother = self.database.get_person_from_handle(self.phoenix_mh)


### PR DESCRIPTION
Family merge fails with "Cannot merge people" with "Spouses cannot be merged. To merge these people, you must first break the relationship between them."

This can occur if a user tries to merge two families where at least one of the parents is common (same parent person handle) between the two families.

This results in the current code trying to merge a person with himself.

The family merge code calls the person merge code for each parent; the writer of the person merge code did not expect anyone to try to merge the person with himself (cannot be done by GUI).

So a simple test to make sure a parent to be merged is himself before calling the merge code can eliminate the problem.