### PR TITLE
bug 9831; fix HandleError when using finddupes tool to merge

### DIFF
--- a/gramps/gui/merge/mergeperson.py
+++ b/gramps/gui/merge/mergeperson.py
@@ -76,8 +76,8 @@ class MergePerson(ManagedWindow):
     Displays a dialog box that allows the persons to be combined into one.
     """
     def __init__(self, dbstate, uistate, handle1, handle2, cb_update=None,
-            expand_context_info=True):
-        ManagedWindow.__init__(self, uistate, [], self.__class__)
+            expand_context_info=True, track=[]):
+        ManagedWindow.__init__(self, uistate, track, self.__class__)
         self.database = dbstate.db
         self.pr1 = self.database.get_person_from_handle(handle1)
         self.pr2 = self.database.get_person_from_handle(handle2)

--- a/gramps/gui/merge/mergeperson.py
+++ b/gramps/gui/merge/mergeperson.py
@@ -75,8 +75,8 @@ class MergePerson(ManagedWindow):
     """
     Displays a dialog box that allows the persons to be combined into one.
     """
-    def __init__(self, dbstate, uistate, handle1, handle2, cb_update=None,
-            expand_context_info=True, track=[]):
+    def __init__(self, dbstate, uistate, track, handle1, handle2,
+                 cb_update=None, expand_context_info=True):
         ManagedWindow.__init__(self, uistate, track, self.__class__)
         self.database = dbstate.db
         self.pr1 = self.database.get_person_from_handle(handle1)

--- a/gramps/plugins/lib/libpersonview.py
+++ b/gramps/plugins/lib/libpersonview.py
@@ -430,7 +430,7 @@ class BasePersonView(ListView):
                         "holding down the control key while clicking on "
                         "the desired person."), parent=self.uistate.window)
         else:
-            MergePerson(self.dbstate, self.uistate, mlist[0], mlist[1])
+            MergePerson(self.dbstate, self.uistate, [], mlist[0], mlist[1])
 
     def tag_updated(self, handle_list):
         """

--- a/gramps/plugins/tool/finddupes.py
+++ b/gramps/plugins/tool/finddupes.py
@@ -616,8 +616,8 @@ class DuplicatePeopleToolMatches(ManagedWindow):
             return
 
         (self.p1,self.p2) = self.list.get_object(iter)
-        MergePerson(self.dbstate, self.uistate, self.p1, self.p2,
-                    self.on_update, True, track=self.track)
+        MergePerson(self.dbstate, self.uistate, self.track, self.p1, self.p2,
+                    self.on_update, True)
 
     def on_update(self):
         if self.db.has_person_handle(self.p1):

--- a/gramps/plugins/tool/finddupes.py
+++ b/gramps/plugins/tool/finddupes.py
@@ -580,7 +580,7 @@ class DuplicatePeopleToolMatches(ManagedWindow):
         self.show()
 
     def build_menu_names(self, obj):
-        return (_("Merge candidates"),None)
+        return (_("Merge candidates"), _("Merge persons"))
 
     def on_help_clicked(self, obj):
         """Display the relevant portion of GRAMPS manual"""
@@ -617,7 +617,7 @@ class DuplicatePeopleToolMatches(ManagedWindow):
 
         (self.p1,self.p2) = self.list.get_object(iter)
         MergePerson(self.dbstate, self.uistate, self.p1, self.p2,
-                    self.on_update, True)
+                    self.on_update, True, track=self.track)
 
     def on_update(self):
         if self.db.has_person_handle(self.p1):


### PR DESCRIPTION
Another in the many HandleErrors that occur because we chose to make an assertion instead of just returning None from db.get_*_from_handle...