### PR TITLE
Shrink size of Break Lock (and other QuestionDialogs) by setting default width to 760.

### DIFF
--- a/gramps/gen/utils/configmanager.py
+++ b/gramps/gen/utils/configmanager.py
@@ -327,33 +327,29 @@ class ConfigManager:
             filename = self.filename
         if filename:
             try:
-                head = os.path.split( filename )[0]
-                os.makedirs( head )
+                head = os.path.split(filename)[0]
+                os.makedirs(head)
             except OSError as exp:
                 if exp.errno != errno.EEXIST:
                     raise
             try:
                 with open(filename, "w", encoding="utf-8") as key_file:
                     key_file.write(";; Gramps key file\n")
-                    key_file.write((";; Automatically created at %s" %
-                              time.strftime("%Y/%m/%d %H:%M:%S")) + "\n\n")
-                    sections = sorted(self.data)
-                    for section in sections:
-                        key_file.write(("[%s]\n") % section)
-                        keys = sorted(self.data[section])
-                        for key in keys:
+                    key_file.write(";; Automatically created at %s" %
+                                   time.strftime("%Y/%m/%d %H:%M:%S") + "\n\n")
+                    for section in sorted(self.data):
+                        key_file.write("[%s]\n" % section)
+                        for key in sorted(self.data[section]):
                             value = self.data[section][key]
-                            # If it has a default:
+                            default = "" # might be a third-party setting
                             if self.has_default("%s.%s" % (section, key)):
-                                if value == self.get_default("%s.%s" % (section, key)):
+                                if value == self.get_default("%s.%s"
+                                                             % (section, key)):
                                     default = ";;"
-                                else:
-                                    default = ""
-                                if isinstance(value, int):
-                                    value = int(value)
-                                key_file.write(("%s%s=%s\n")% (default,
-                                                               key,
-                                                               repr(value)))
+                            if isinstance(value, int):
+                                value = int(value) # TODO why is this needed?
+                            key_file.write("%s%s=%s\n" % (default, key,
+                                                          repr(value)))
                         key_file.write("\n")
                 # else, no filename given; nothing to save so do nothing quietly
             except IOError as err:

--- a/gramps/gui/managedwindow.py
+++ b/gramps/gui/managedwindow.py
@@ -545,8 +545,8 @@ class ManagedWindow:
 
         Takes care of closing children and removing itself from menu.
         """
+        self._save_position(save_config=False) # the next line will save it
         self._save_size()
-        self._save_position()
         self.clean_up()
         self.uistate.gwm.close_track(self.track)
         self.opened = False
@@ -596,16 +596,19 @@ class ManagedWindow:
             vert_position = config.get(self.vert_position_key)
             self.window.move(horiz_position, vert_position)
 
-    def _save_position(self):
+    def _save_position(self, save_config=True):
         """
         Save the window's position to the config file
+
+        (You can set save_config False if a _save_size() will instantly follow)
         """
         # self.horiz_position_key is set in the subclass (or in setup_configs)
         if self.horiz_position_key is not None:
             (horiz_position, vert_position) = self.window.get_position()
             config.set(self.horiz_position_key, horiz_position)
             config.set(self.vert_position_key, vert_position)
-            config.save()
+            if save_config:
+                config.save()
 
     def setup_configs(self, config_base,
                       default_width, default_height,

--- a/gramps/gui/plug/export/_exportassistant.py
+++ b/gramps/gui/plug/export/_exportassistant.py
@@ -122,7 +122,7 @@ class ExportAssistant(Gtk.Assistant, ManagedWindow) :
         #set_window is present in both parent classes
         ManagedWindow.set_window(self, self, None,
             self.top_title, isWindow=True)
-        self.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
+        self.setup_configs('interface.exportassistant', 760, 500)
 
         #set up callback method for the export plugins
         self.callback = self.pulse_progressbar
@@ -172,7 +172,6 @@ class ExportAssistant(Gtk.Assistant, ManagedWindow) :
         image.set_from_file(SPLASH)
 
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        box.set_size_request(600, -1) # wide enough it won't have to expand
         box.pack_start(image, False, False, 5)
         box.pack_start(label, False, False, 5)
 
@@ -234,7 +233,7 @@ class ExportAssistant(Gtk.Assistant, ManagedWindow) :
     def create_page_options(self):
         # as we do not know yet what to show, we create an empty page
         page = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        page.set_border_width(12)
+        page.set_border_width(0)
         page.set_spacing(12)
 
         page.show_all()
@@ -531,7 +530,11 @@ class ExportAssistant(Gtk.Assistant, ManagedWindow) :
 
     def close(self, *obj) :
         #clean up ManagedWindow menu, then destroy window, bring forward parent
+        real_width, real_height = self.get_size() # "destroy" changes them
+        real_x_pos, real_y_pos = self.get_position() # "destroy" changes them
         Gtk.Assistant.destroy(self)
+        self.move(real_x_pos, real_y_pos) # "close" calls self._save_position()
+        self.resize(real_width, real_height) # "close" calls self._save_size()
         ManagedWindow.close(self,*obj)
 
     def get_intro_text(self):

--- a/gramps/gui/plug/export/_exportassistant.py
+++ b/gramps/gui/plug/export/_exportassistant.py
@@ -79,7 +79,7 @@ _ExportAssistant_pages = {
             'summary'                : 5,
             }
 
-class ExportAssistant(Gtk.Assistant, ManagedWindow) :
+class ExportAssistant(ManagedWindow, Gtk.Assistant):
     """
     This class creates a GTK assistant to guide the user through the various
     Save as/Export options.
@@ -120,8 +120,7 @@ class ExportAssistant(Gtk.Assistant, ManagedWindow) :
         ManagedWindow.__init__(self, uistate, [], self.__class__, modal=True)
 
         #set_window is present in both parent classes
-        ManagedWindow.set_window(self, self, None,
-            self.top_title, isWindow=True)
+        self.set_window(self, None, self.top_title, isWindow=True)
         self.setup_configs('interface.exportassistant', 760, 500)
 
         #set up callback method for the export plugins
@@ -155,7 +154,7 @@ class ExportAssistant(Gtk.Assistant, ManagedWindow) :
         self.set_forward_page_func(self.forward_func, None)
 
         #ManagedWindow show method
-        ManagedWindow.show(self)
+        self.show()
 
     def build_menu_names(self, obj):
         """Override ManagedWindow method."""
@@ -528,15 +527,6 @@ class ExportAssistant(Gtk.Assistant, ManagedWindow) :
         #remember previous page for next time
         self.__previous_page = page_number
 
-    def close(self, *obj) :
-        #clean up ManagedWindow menu, then destroy window, bring forward parent
-        real_width, real_height = self.get_size() # "destroy" changes them
-        real_x_pos, real_y_pos = self.get_position() # "destroy" changes them
-        Gtk.Assistant.destroy(self)
-        self.move(real_x_pos, real_y_pos) # "close" calls self._save_position()
-        self.resize(real_width, real_height) # "close" calls self._save_size()
-        ManagedWindow.close(self,*obj)
-
     def get_intro_text(self):
         return _('Under normal circumstances, Gramps does not require you '
                  'to directly save your changes. All changes you make are '
@@ -625,20 +615,17 @@ class ExportAssistant(Gtk.Assistant, ManagedWindow) :
         self.writestarted = False
 
     def set_busy_cursor(self,value):
-        """Set or unset the busy cursor while saving data.
-
-            Note : self.get_window() is the Gtk.Assistant Gtk.Window, not
-                   a part of ManagedWindow
-
+        """
+        Set or unset the busy cursor while saving data.
         """
         BUSY_CURSOR = Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
                                                  Gdk.CursorType.WATCH)
 
         if value:
-            self.get_window().set_cursor(BUSY_CURSOR)
+            Gtk.Assistant.get_window(self).set_cursor(BUSY_CURSOR)
             #self.set_sensitive(0)
         else:
-            self.get_window().set_cursor(None)
+            Gtk.Assistant.get_window(self).set_cursor(None)
             #self.set_sensitive(1)
 
         while Gtk.events_pending():

--- a/gramps/gui/plug/export/_exportoptions.py
+++ b/gramps/gui/plug/export/_exportoptions.py
@@ -275,12 +275,14 @@ class WriterOptionBox:
         button.set_size_request(107, -1)
         button.connect("clicked", self.show_preview_data)
         button.proxy_name = proxy_name
+        colon = _(':') # translators: needed for French, ignore otherwise
         if proxy_name == "person":
             # Frame Person:
             self.filter_obj = Gtk.ComboBox()
-            label = Gtk.Label(label=_('_Person Filter') + ": ")
+            label = Gtk.Label(label=_('_Person Filter') + colon)
             label.set_halign(Gtk.Align.START)
-            label.set_size_request(150, -1)
+            label.set_size_request(120, -1)
+            label.set_padding(5, 0)
             label.set_use_underline(True)
             label.set_mnemonic_widget(self.filter_obj)
             box = Gtk.Box()
@@ -295,9 +297,10 @@ class WriterOptionBox:
             # Frame Note:
             # Objects for choosing a Note filter:
             self.filter_note = Gtk.ComboBox()
-            label_note = Gtk.Label(label=_('_Note Filter') + ": ")
+            label_note = Gtk.Label(label=_('_Note Filter') + colon)
             label_note.set_halign(Gtk.Align.START)
-            label_note.set_size_request(150, -1)
+            label_note.set_size_request(120, -1)
+            label_note.set_padding(5, 0)
             label_note.set_use_underline(True)
             label_note.set_mnemonic_widget(self.filter_note)
             box = Gtk.Box()
@@ -310,18 +313,20 @@ class WriterOptionBox:
             button.set_tooltip_text(_("Click to see preview after note filter"))
         elif proxy_name == "privacy":
             # Frame 3:
-            label = Gtk.Label(label=_("Privacy Filter") + ":")
+            label = Gtk.Label(label=_("Privacy Filter") + colon)
             label.set_halign(Gtk.Align.START)
-            label.set_size_request(150, -1)
+            label.set_size_request(120, -1)
+            label.set_padding(5, 0)
             box = Gtk.Box()
             box.pack_start(label, False, True, 0)
             box.add(self.private_check)
             button.set_tooltip_text(_("Click to see preview after privacy filter"))
         elif proxy_name == "living":
             # Frame 4:
-            label = Gtk.Label(label=_("Living Filter") + ":")
+            label = Gtk.Label(label=_("Living Filter") + colon)
             label.set_halign(Gtk.Align.START)
-            label.set_size_request(150, -1)
+            label.set_size_request(120, -1)
+            label.set_padding(5, 0)
             box = Gtk.Box()
             box.pack_start(label, False, True, 0)
             self.restrict_option = Gtk.ComboBox()
@@ -330,9 +335,10 @@ class WriterOptionBox:
         elif proxy_name == "reference":
             # Frame 5:
             self.reference_filter = Gtk.ComboBox()
-            label = Gtk.Label(label=_('Reference Filter') + ": ")
+            label = Gtk.Label(label=_('Reference Filter') + colon)
             label.set_halign(Gtk.Align.START)
-            label.set_size_request(150, -1)
+            label.set_size_request(120, -1)
+            label.set_padding(5, 0)
             box = Gtk.Box()
             box.pack_start(label, False, True, 0)
             box.pack_start(self.reference_filter, True, True, 0)

--- a/gramps/gui/plug/quick/_textbufdoc.py
+++ b/gramps/gui/plug/quick/_textbufdoc.py
@@ -61,7 +61,8 @@ class DisplayBuf(ManagedWindow):
                                    buttons=(_('_Close'),
                                              Gtk.ResponseType.CLOSE)),
                         None, title, True)
-        self.window.set_size_request(600,400)
+        self.setup_configs('interface.' + title.lower().replace(' ', ''),
+                           600, 400)
         scrolled_window = Gtk.ScrolledWindow()
         scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC,Gtk.PolicyType.AUTOMATIC)
         document.text_view = Gtk.TextView()

--- a/gramps/plugins/lib/libmetadata.py
+++ b/gramps/plugins/lib/libmetadata.py
@@ -32,6 +32,8 @@ import os
 #
 #-------------------------------------------------------------------------
 from gi.repository import Gtk
+import gi
+gi.require_version('GExiv2', '0.10')
 from gi.repository import GExiv2
 
 #-------------------------------------------------------------------------

--- a/gramps/plugins/tool/check.glade
+++ b/gramps/plugins/tool/check.glade
@@ -4,8 +4,6 @@
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkDialog" id="check">
     <property name="can_focus">False</property>
-    <property name="default_width">450</property>
-    <property name="default_height">400</property>
     <property name="type_hint">dialog</property>
     <signal name="delete-event" handler="on_delete_event" swapped="no"/>
     <child internal-child="vbox">

--- a/gramps/plugins/tool/check.py
+++ b/gramps/plugins/tool/check.py
@@ -173,7 +173,7 @@ class Check(tool.BatchTool):
         # We only do this for the dbdir backend.
         if self.db.__class__.__name__ == 'DbBsddb':
             if cross_table_duplicates(self.db, uistate):
-                Report(uistate, _(
+                CheckReport(uistate, _(
                     "Your Family Tree contains cross table duplicate handles."
                     "\n "
                     "This is bad and can be fixed by making a backup of your\n"
@@ -229,7 +229,7 @@ class Check(tool.BatchTool):
 
         errs = checker.build_report(uistate)
         if errs:
-            Report(uistate, checker.text.getvalue(), cli)
+            CheckReport(uistate, checker.text.getvalue(), cli)
 
 
 # -------------------------------------------------------------------------
@@ -2667,7 +2667,7 @@ class CheckIntegrity:
 # Display the results
 #
 # -------------------------------------------------------------------------
-class Report(ManagedWindow):
+class CheckReport(ManagedWindow):
     """ Report out the results """
     def __init__(self, uistate, text, cli=0):
         if cli:
@@ -2686,6 +2686,7 @@ class Report(ManagedWindow):
                             # topdialog.get_widget("title"),
                             topdialog.get_object("title"),
                             _("Integrity Check Results"))
+            self.setup_configs('interface.checkreport', 450, 400)
 
             self.show()
 

--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -639,7 +639,7 @@ class BasePage:
         @param: place_lat_long -- for use in Family Map Pages. This will be None
         if called from Family pages, which do not create a Family Map
         """
-        family_list = sorted(individual.get_family_handle_list())
+        family_list = individual.get_family_handle_list()
         if not family_list:
             return None
 
@@ -3533,9 +3533,7 @@ class FamilyPages(BasePage):
                             handle_list, key=self.sort_on_name_and_grampsid):
                         person = self.r_db.get_person_from_handle(person_handle)
                         if person:
-                            family_list = sorted(pers_fam_dict[person_handle],
-                                                 key=lambda x: x.get_gramps_id()
-                                                )
+                            family_list = pers_fam_dict[person_handle]
                             first_family = True
                             for family in family_list:
                                 trow = Html("tr")

--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -3533,9 +3533,11 @@ class FamilyPages(BasePage):
                             handle_list, key=self.sort_on_name_and_grampsid):
                         person = self.r_db.get_person_from_handle(person_handle)
                         if person:
-                            family_list = pers_fam_dict[person_handle]
+                            family_list = person.get_family_handle_list()
                             first_family = True
-                            for family in family_list:
+                            for family_handle in family_list:
+                                get_family = self.r_db.get_family_from_handle
+                                family = get_family(family_handle)
                                 trow = Html("tr")
                                 tbody += trow
 

--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -9605,10 +9605,13 @@ class NavWebOptions(MenuReportOptions):
         @param: menu -- The menu for which we add options
         """
         self.__add_report_options(menu)
+        self.__add_report_options_2(menu)
         self.__add_page_generation_options(menu)
+        self.__add_images_generation_options(menu)
         self.__add_privacy_options(menu)
         self.__add_download_options(menu)
         self.__add_advanced_options(menu)
+        self.__add_advanced_options_2(menu)
         self.__add_place_map_options(menu)
         self.__add_others_options(menu)
 
@@ -9657,6 +9660,15 @@ class NavWebOptions(MenuReportOptions):
         self.__update_filters()
 
         stdoptions.add_name_format_option(menu, category_name)
+
+        stdoptions.add_localization_option(menu, category_name)
+
+    def __add_report_options_2(self, menu):
+        """
+        Continue Options on the "Report Options" tab.
+        """
+        category_name = _("Report Options (2)")
+        addopt = partial( menu.add_option, category_name )
 
         ext = EnumeratedListOption(_("File extension"), ".html")
         for etype in _WEB_EXT:
@@ -9718,9 +9730,11 @@ class NavWebOptions(MenuReportOptions):
         self.__graphgens.set_help(_("The number of generations to include in "
                                     "the ancestor graph"))
         addopt("graphgens", self.__graphgens)
-
-        stdoptions.add_localization_option(menu, category_name)
         self.__graph_changed()
+
+        nogid = BooleanOption(_('Suppress Gramps ID'), False)
+        nogid.set_help(_('Whether to include the Gramps ID of objects'))
+        addopt( "nogid", nogid )
 
     def __add_page_generation_options(self, menu):
         """
@@ -9767,6 +9781,13 @@ class NavWebOptions(MenuReportOptions):
         footernote.set_help(_("A note to be used as the page footer"))
         addopt("footernote", footernote)
 
+    def __add_images_generation_options(self, menu):
+        """
+        Options on the "Page Generation" tab.
+        """
+        category_name = _("Images Generation")
+        addopt = partial(menu.add_option, category_name)
+
         self.__gallery = BooleanOption(_("Include images and media objects"),
                                        True)
         self.__gallery.set_help(_('Whether to include '
@@ -9806,10 +9827,6 @@ class NavWebOptions(MenuReportOptions):
         addopt("maxinitialimageheight", self.__maxinitialimageheight)
 
         self.__gallery_changed()
-
-        nogid = BooleanOption(_('Suppress Gramps ID'), False)
-        nogid.set_help(_('Whether to include the Gramps ID of objects'))
-        addopt("nogid", nogid)
 
     def __add_privacy_options(self, menu):
         """
@@ -9908,6 +9925,13 @@ class NavWebOptions(MenuReportOptions):
             _("Whether to include half and/ or "
               "step-siblings with the parents and siblings"))
         addopt('showhalfsiblings', showallsiblings)
+
+    def __add_advanced_options_2(self, menu):
+        """
+        Continue options on the "Advanced" tab.
+        """
+        category_name = _("Advanced Options (2)")
+        addopt = partial(menu.add_option, category_name)
 
         birthorder = BooleanOption(
             _('Sort all children in birth order'), False)

--- a/po/de.po
+++ b/po/de.po
@@ -13,8 +13,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-20 13:00-0700\n"
-"PO-Revision-Date: 2016-06-16 21:26+0100\n"
+"POT-Creation-Date: 2016-12-13 23:37+0100\n"
+"PO-Revision-Date: 2016-12-14 00:44+0100\n"
 "Last-Translator: Mirko Leonhäuser <mirko@leonhaeuser.de>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
 "Language: de\n"
@@ -50,7 +50,7 @@ msgstr ""
 "All deine Recherchen werden organisiert, durchsuchbar und so präzise, wie du "
 "es benötigst aufbewahrt."
 
-#: ../data/gramps.desktop.in.h:1 ../gramps/gui/glade/displaystate.glade:8
+#: ../data/gramps.desktop.in.h:1
 msgid "Gramps"
 msgstr "Gramps"
 
@@ -1130,7 +1130,7 @@ msgstr ""
 "Fehler: Stammbaum '%s' existiert bereits.\n"
 "Die '-C' Option kann nicht verwendet werden."
 
-#: ../gramps/cli/arghandler.py:236
+#: ../gramps/cli/arghandler.py:238
 #, python-format
 msgid ""
 "Error: Input Family Tree \"%s\" does not exist.\n"
@@ -1141,19 +1141,19 @@ msgstr ""
 "Wenn es GEDCOM Gramps-XML oder grdb ist, verwende stattdessen die -i Option "
 "zum Import in einen Stammbaum."
 
-#: ../gramps/cli/arghandler.py:249
+#: ../gramps/cli/arghandler.py:252
 #, python-format
 msgid "Error: Import file %s not found."
 msgstr "FEHLER: die Importdatei %s wurde nicht gefunden."
 
-#: ../gramps/cli/arghandler.py:267
+#: ../gramps/cli/arghandler.py:270
 #, python-format
 msgid "Error: Unrecognized type: \"%(format)s\" for import file: %(filename)s"
 msgstr ""
 "FEHLER: Nicht erkanntes Format: \"%(format)s\" für die Importdatei: "
 "%(filename)s."
 
-#: ../gramps/cli/arghandler.py:287
+#: ../gramps/cli/arghandler.py:290
 #, python-format
 msgid ""
 "WARNING: Output file already exists!\n"
@@ -1164,38 +1164,39 @@ msgstr ""
 "ACHTUNG: Sie wird überschrieben:\n"
 "   %s"
 
-#: ../gramps/cli/arghandler.py:290
+#: ../gramps/cli/arghandler.py:293
 msgid "OK to overwrite?"
 msgstr "Überschreiben o.k.?"
 
-#: ../gramps/cli/arghandler.py:291 ../gramps/cli/clidbman.py:431
+#: ../gramps/cli/arghandler.py:294 ../gramps/cli/clidbman.py:434
 msgid "no"
 msgstr "nein"
 
-#: ../gramps/cli/arghandler.py:291 ../gramps/cli/clidbman.py:431
+#: ../gramps/cli/arghandler.py:294 ../gramps/cli/arghandler.py:295
+#: ../gramps/cli/clidbman.py:434
 msgid "yes"
 msgstr "ja"
 
-#: ../gramps/cli/arghandler.py:293
+#: ../gramps/cli/arghandler.py:297
 #, python-format
 msgid "Will overwrite the existing file: %s"
 msgstr "Überschreibt die bestehende Datei: %s"
 
-#: ../gramps/cli/arghandler.py:313
+#: ../gramps/cli/arghandler.py:317
 #, python-format
 msgid "ERROR: Unrecognized format for export file %s"
 msgstr "FEHLER: Nicht erkanntes Format für die Exportdatei %s."
 
-#: ../gramps/cli/arghandler.py:397
+#: ../gramps/cli/arghandler.py:402
 msgid "List of known Family Trees in your database path\n"
 msgstr "Liste bekannter Stammbäume in deinem Datenbankpfad\n"
 
-#: ../gramps/cli/arghandler.py:405
+#: ../gramps/cli/arghandler.py:410
 #, python-format
 msgid "%(full_DB_path)s with name \"%(f_t_name)s\""
 msgstr "%(full_DB_path)s mit Name \"%(f_t_name)s\""
 
-#: ../gramps/cli/arghandler.py:422 ../gramps/cli/clidbman.py:183
+#: ../gramps/cli/arghandler.py:428 ../gramps/cli/clidbman.py:184
 msgid "Gramps Family Trees:"
 msgstr "Gramps Stammbäume:"
 
@@ -1206,95 +1207,95 @@ msgstr "Gramps Stammbäume:"
 #. constants
 #.
 #. -------------------------------------------------------------------------
-#: ../gramps/cli/arghandler.py:428 ../gramps/cli/arghandler.py:430
-#: ../gramps/cli/arghandler.py:434 ../gramps/cli/arghandler.py:435
-#: ../gramps/cli/arghandler.py:437 ../gramps/cli/clidbman.py:68
-#: ../gramps/cli/clidbman.py:171 ../gramps/cli/clidbman.py:192
-#: ../gramps/gui/clipboard.py:970 ../gramps/gui/configure.py:1473
+#: ../gramps/cli/arghandler.py:434 ../gramps/cli/arghandler.py:436
+#: ../gramps/cli/arghandler.py:441 ../gramps/cli/arghandler.py:442
+#: ../gramps/cli/arghandler.py:444 ../gramps/cli/clidbman.py:69
+#: ../gramps/cli/clidbman.py:172 ../gramps/cli/clidbman.py:193
+#: ../gramps/gui/clipboard.py:970 ../gramps/gui/configure.py:1501
 msgid "Family Tree"
 msgstr "Stammbaum"
 
 #. translators: used in French+Russian, ignore otherwise
-#: ../gramps/cli/arghandler.py:435 ../gramps/cli/arghandler.py:439
+#: ../gramps/cli/arghandler.py:442 ../gramps/cli/arghandler.py:446
 #: ../gramps/gen/plug/report/endnotes.py:199
 #, python-format
 msgid "\"%s\""
 msgstr "\"%s\""
 
-#: ../gramps/cli/arghandler.py:447
+#: ../gramps/cli/arghandler.py:454
 #, python-format
 msgid "Performing action: %s."
 msgstr "Ausführen von Aktion: %s."
 
-#: ../gramps/cli/arghandler.py:449
+#: ../gramps/cli/arghandler.py:458
 #, python-format
 msgid "Using options string: %s"
 msgstr "Verwende Optionstext: %s"
 
-#: ../gramps/cli/arghandler.py:454
+#: ../gramps/cli/arghandler.py:464
 #, python-format
 msgid "Exporting: file %(filename)s, format %(format)s."
 msgstr "Exportiere: Datei %(filename)s, Format %(format)s."
 
-#: ../gramps/cli/arghandler.py:463
+#: ../gramps/cli/arghandler.py:475
 msgid "Cleaning up."
 msgstr "Räume auf."
 
-#: ../gramps/cli/arghandler.py:496
+#: ../gramps/cli/arghandler.py:509
 msgid "Created empty Family Tree successfully"
 msgstr "Leerer Stammbaum erfolgreich erstellt."
 
-#: ../gramps/cli/arghandler.py:499 ../gramps/cli/arghandler.py:524
+#: ../gramps/cli/arghandler.py:512 ../gramps/cli/arghandler.py:538
 msgid "Error opening the file."
 msgstr "Fehler beim Öffnen der Datei."
 
-#: ../gramps/cli/arghandler.py:500 ../gramps/cli/arghandler.py:525
+#: ../gramps/cli/arghandler.py:513 ../gramps/cli/arghandler.py:539
 msgid "Exiting..."
 msgstr "Beenden..."
 
-#: ../gramps/cli/arghandler.py:504
+#: ../gramps/cli/arghandler.py:517
 #, python-format
 msgid "Importing: file %(filename)s, format %(format)s."
 msgstr "Importiere: Datei %(filename)s, Format %(format)s."
 
-#: ../gramps/cli/arghandler.py:522
+#: ../gramps/cli/arghandler.py:536
 msgid "Opened successfully!"
 msgstr "Erfolgreich geöffnet!"
 
-#: ../gramps/cli/arghandler.py:536
+#: ../gramps/cli/arghandler.py:550
 msgid "Database is locked, cannot open it!"
 msgstr "Die Datenbank kann nicht geöffnet werden, sie ist gesperrt!"
 
-#: ../gramps/cli/arghandler.py:537
+#: ../gramps/cli/arghandler.py:551
 #, python-format
 msgid "  Info: %s"
 msgstr " Info: %s"
 
-#: ../gramps/cli/arghandler.py:540
+#: ../gramps/cli/arghandler.py:554
 msgid "Database needs recovery, cannot open it!"
 msgstr ""
 "Die Datenbank kann nicht geöffnet werden, sie benötigt eine "
 "Wiederherstellung!"
 
-#: ../gramps/cli/arghandler.py:591 ../gramps/cli/arghandler.py:639
-#: ../gramps/cli/arghandler.py:686
+#: ../gramps/cli/arghandler.py:605 ../gramps/cli/arghandler.py:654
+#: ../gramps/cli/arghandler.py:701
 msgid "Ignoring invalid options string."
 msgstr "Ignoriere ungültigen Optionstext."
 
 #. name exists, but is not in the list of valid report names
-#: ../gramps/cli/arghandler.py:615
+#: ../gramps/cli/arghandler.py:629
 msgid "Unknown report name."
 msgstr "Unbekannter Berichtname."
 
-#: ../gramps/cli/arghandler.py:617
+#: ../gramps/cli/arghandler.py:631
 #, python-format
 msgid "Report name not given. Please use one of %(donottranslate)s=reportname"
 msgstr ""
 "Der Berichtname ist nicht angegeben. Bitte verwende einen von "
 "%(donottranslate)s=reportname."
 
-#: ../gramps/cli/arghandler.py:621 ../gramps/cli/arghandler.py:669
-#: ../gramps/cli/arghandler.py:702
+#: ../gramps/cli/arghandler.py:635 ../gramps/cli/arghandler.py:683
+#: ../gramps/cli/arghandler.py:717
 #, python-format
 msgid ""
 "%s\n"
@@ -1303,29 +1304,29 @@ msgstr ""
 "%s\n"
 " Verfügbare Namen sind:"
 
-#: ../gramps/cli/arghandler.py:663
+#: ../gramps/cli/arghandler.py:677
 msgid "Unknown tool name."
 msgstr "Unbekannter Werkzeugname."
 
-#: ../gramps/cli/arghandler.py:665
+#: ../gramps/cli/arghandler.py:679
 #, python-format
 msgid "Tool name not given. Please use one of %(donottranslate)s=toolname."
 msgstr ""
 "Der Werkzeugname ist nicht angegeben. Bitte verwende einen von "
 "%(donottranslate)s=toolname."
 
-#: ../gramps/cli/arghandler.py:696
+#: ../gramps/cli/arghandler.py:711
 msgid "Unknown book name."
 msgstr "Unbekannter Buchname."
 
-#: ../gramps/cli/arghandler.py:698
+#: ../gramps/cli/arghandler.py:713
 #, python-format
 msgid "Book name not given. Please use one of %(donottranslate)s=bookname."
 msgstr ""
 "Der Buchname ist nicht angegeben. Bitte verwende einen von "
 "%(donottranslate)s=bookname."
 
-#: ../gramps/cli/arghandler.py:707
+#: ../gramps/cli/arghandler.py:722
 #, python-format
 msgid "Unknown action: %s."
 msgstr "Unbekannte Aktion: %s."
@@ -1522,11 +1523,11 @@ msgstr ""
 "Bemerkung: Die Beispiele sind für die bash Shell\n"
 "Die Syntax kann sich für andere Shells oder Windows ändern.\n"
 
-#: ../gramps/cli/argparser.py:240 ../gramps/cli/argparser.py:403
+#: ../gramps/cli/argparser.py:242 ../gramps/cli/argparser.py:413
 msgid "Error parsing the arguments"
 msgstr "Fehler beim Analysieren der Argumente."
 
-#: ../gramps/cli/argparser.py:242
+#: ../gramps/cli/argparser.py:244
 #, python-format
 msgid ""
 "Error parsing the arguments: %s \n"
@@ -1536,47 +1537,62 @@ msgstr ""
 "Tippe gramps --help für eine Übersicht der Kommandos oder lies die 'man "
 "pages' (Manual)."
 
-#: ../gramps/cli/argparser.py:259
+#: ../gramps/cli/argparser.py:262
 #, python-format
 msgid "Trying to open: %s ..."
 msgstr "Versuche zu öffnen: %s ..."
 
-#: ../gramps/cli/argparser.py:295
+#: ../gramps/cli/argparser.py:299
 #, python-format
 msgid "Unknown action: %s. Ignoring."
 msgstr "Unbekannte Aktion: %s. Ignoriert."
 
-#: ../gramps/cli/argparser.py:304
+#: ../gramps/cli/argparser.py:309
 msgid "setup debugging"
 msgstr "Fehlerbehebung Einrichten"
 
-#: ../gramps/cli/argparser.py:315
+#: ../gramps/cli/argparser.py:320
 #, python-format
 msgid "Gramps config settings from %s:"
 msgstr "Gramps Konfigurationseinstellungen von %s:"
 
-#: ../gramps/cli/argparser.py:348
+#. translators: needed for French, ignore otherwise
+#: ../gramps/cli/argparser.py:343 ../gramps/gen/plug/report/endnotes.py:175
+#: ../gramps/gui/plug/report/_docreportdialog.py:184
+#: ../gramps/gui/plug/report/_docreportdialog.py:235
+#: ../gramps/gui/plug/report/_graphvizreportdialog.py:150
+#: ../gramps/plugins/textreport/familygroup.py:406
+#: ../gramps/plugins/textreport/indivcomplete.py:898
+#: ../gramps/plugins/textreport/indivcomplete.py:900
+#: ../gramps/plugins/textreport/indivcomplete.py:901
+#: ../gramps/plugins/textreport/indivcomplete.py:902
+#: ../gramps/plugins/textreport/indivcomplete.py:903
+#, python-format
+msgid "%s:"
+msgstr "%s:"
+
+#: ../gramps/cli/argparser.py:354
 #, python-format
 msgid "Current Gramps config setting: %(name)s:%(value)s"
 msgstr "Aktuelle Gramps Konfigurationseinstellungen: %(name)s:%(value)s"
 
 #. does a user want the default config value?
-#: ../gramps/cli/argparser.py:355
+#: ../gramps/cli/argparser.py:361
 msgid "DEFAULT"
 msgstr "STANDARD"
 
 #. translators: indent "New" to match "Current"
-#: ../gramps/cli/argparser.py:362
+#: ../gramps/cli/argparser.py:368
 #, python-format
 msgid "    New Gramps config setting: %(name)s:%(value)s"
 msgstr "    Neue Gramps Konfigurationseinstellungen: %(name)s:%(value)s"
 
-#: ../gramps/cli/argparser.py:371
+#: ../gramps/cli/argparser.py:376
 #, python-format
 msgid "Gramps: no such config setting: '%s'"
 msgstr "Gramps: diese Konfigurationseinstellungen gibt es nicht: '%s'"
 
-#: ../gramps/cli/argparser.py:404
+#: ../gramps/cli/argparser.py:414
 #, python-format
 msgid ""
 "Error parsing the arguments: %s \n"
@@ -1586,7 +1602,7 @@ msgstr ""
 "Für die Verwendung im Kommandozeilenmodus gib mindestens eine Eingabedatei "
 "zum Bearbeiten an."
 
-#: ../gramps/cli/clidbman.py:81
+#: ../gramps/cli/clidbman.py:82
 #, python-format
 msgid ""
 "ERROR: %(title)s \n"
@@ -1595,13 +1611,13 @@ msgstr ""
 "FEHLER: %(title)s \n"
 "       %(message)s"
 
-#: ../gramps/cli/clidbman.py:168 ../gramps/cli/clidbman.py:170
+#: ../gramps/cli/clidbman.py:169 ../gramps/cli/clidbman.py:171
 #: ../gramps/gui/clipboard.py:186 ../gramps/gui/clipboard.py:187
-#: ../gramps/gui/plug/_windows.py:483
+#: ../gramps/gui/plug/_windows.py:488
 msgid "Unavailable"
 msgstr "Nicht verfügbar"
 
-#: ../gramps/cli/clidbman.py:172 ../gramps/gen/lib/media.py:195
+#: ../gramps/cli/clidbman.py:173 ../gramps/gen/lib/media.py:195
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:66
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:90
 #: ../gramps/gui/glade/editmedia.glade:289
@@ -1610,48 +1626,48 @@ msgstr "Nicht verfügbar"
 msgid "Path"
 msgstr "Pfad"
 
-#: ../gramps/cli/clidbman.py:173 ../gramps/gen/plug/_pluginreg.py:88
+#: ../gramps/cli/clidbman.py:174 ../gramps/gen/plug/_pluginreg.py:88
 msgid "Database"
 msgstr "Datenbank"
 
-#: ../gramps/cli/clidbman.py:174 ../gramps/gui/dbman.py:389
+#: ../gramps/cli/clidbman.py:175 ../gramps/gui/dbman.py:395
 msgid "Last accessed"
 msgstr "Letzter Zugriff"
 
-#: ../gramps/cli/clidbman.py:175
+#: ../gramps/cli/clidbman.py:176
 msgid "Locked?"
 msgstr "Gesperrt?"
 
-#: ../gramps/cli/clidbman.py:192
+#: ../gramps/cli/clidbman.py:193
 #, python-format
 msgid "Family Tree \"%s\":"
 msgstr "Stammbaum \"%s\":"
 
 #. translators: needed for French, ignore otherwise
-#: ../gramps/cli/clidbman.py:196
+#: ../gramps/cli/clidbman.py:197
 #, python-format
 msgid "   %(item)s: %(summary)s"
 msgstr "   %(item)s: %(summary)s"
 
-#: ../gramps/cli/clidbman.py:282
+#: ../gramps/cli/clidbman.py:283
 #, python-format
 msgid "Starting Import, %s"
 msgstr "Starte Import, %s"
 
-#: ../gramps/cli/clidbman.py:288
+#: ../gramps/cli/clidbman.py:289
 msgid "Import finished..."
 msgstr "Import abgeschlossen..."
 
 #. Create a new database
-#: ../gramps/cli/clidbman.py:375 ../gramps/plugins/importer/importcsv.py:337
+#: ../gramps/cli/clidbman.py:376 ../gramps/plugins/importer/importcsv.py:342
 msgid "Importing data..."
 msgstr "Importiere Daten..."
 
-#: ../gramps/cli/clidbman.py:429
+#: ../gramps/cli/clidbman.py:430
 msgid "Remove family tree warning"
 msgstr "Stammbaum Warnung entfernen"
 
-#: ../gramps/cli/clidbman.py:430
+#: ../gramps/cli/clidbman.py:431
 #, python-format
 msgid ""
 "Are you sure you want to remove the family tree named\n"
@@ -1660,15 +1676,15 @@ msgstr ""
 "Willst du wirklich den Stammbaum  entfernen mit dem Namen\n"
 "\"%s\"?"
 
-#: ../gramps/cli/clidbman.py:438 ../gramps/gui/dbman.py:712
+#: ../gramps/cli/clidbman.py:441 ../gramps/gui/dbman.py:717
 msgid "Could not delete Family Tree"
 msgstr "Der Stammbaum kann nicht gelöscht werden."
 
-#: ../gramps/cli/clidbman.py:452
+#: ../gramps/cli/clidbman.py:455
 msgid "Could not rename Family Tree"
 msgstr "Der Stammbaum kann nicht umbenannt werden."
 
-#: ../gramps/cli/clidbman.py:485
+#: ../gramps/cli/clidbman.py:488
 #, python-format
 msgid ""
 "\n"
@@ -1687,104 +1703,110 @@ msgstr ""
 "    %s\n"
 "\n"
 
-#: ../gramps/cli/clidbman.py:537 ../gramps/gui/configure.py:1347
+#: ../gramps/cli/clidbman.py:540 ../gramps/gui/configure.py:1365
+#: ../gramps/gui/configure.py:1489
 msgid "Never"
 msgstr "Nie"
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/cli/clidbman.py:553
+#: ../gramps/cli/clidbman.py:556
 #, python-format
 msgid "Locked by %s"
 msgstr "Gesperrt durch %s"
 
 #. allow deferred translation of attribute UI strings
-#: ../gramps/cli/clidbman.py:555 ../gramps/gen/lib/attrtype.py:62
+#: ../gramps/cli/clidbman.py:558 ../gramps/gen/lib/attrtype.py:62
 #: ../gramps/gen/lib/childreftype.py:73 ../gramps/gen/lib/eventroletype.py:52
 #: ../gramps/gen/lib/eventtype.py:162 ../gramps/gen/lib/familyreltype.py:47
 #: ../gramps/gen/lib/grampstype.py:33 ../gramps/gen/lib/nameorigintype.py:73
-#: ../gramps/gen/lib/nametype.py:46 ../gramps/gen/lib/notetype.py:71
+#: ../gramps/gen/lib/nametype.py:46 ../gramps/gen/lib/notetype.py:73
 #: ../gramps/gen/lib/placetype.py:63 ../gramps/gen/lib/repotype.py:52
 #: ../gramps/gen/lib/srcattrtype.py:43 ../gramps/gen/lib/srcmediatype.py:56
 #: ../gramps/gen/lib/urltype.py:47 ../gramps/gen/utils/lds.py:80
 #: ../gramps/gen/utils/lds.py:86 ../gramps/gen/utils/unknown.py:119
 #: ../gramps/gen/utils/unknown.py:121 ../gramps/gen/utils/unknown.py:125
 #: ../gramps/gen/utils/unknown.py:131 ../gramps/gen/utils/unknown.py:136
-#: ../gramps/gui/clipboard.py:183 ../gramps/gui/dbman.py:971
+#: ../gramps/gui/clipboard.py:183 ../gramps/gui/dbman.py:978
 #: ../gramps/gui/editors/displaytabs/personrefembedlist.py:125
 #: ../gramps/gui/editors/displaytabs/personrefembedlist.py:143
-#: ../gramps/gui/editors/editmedia.py:180
+#: ../gramps/gui/editors/editmedia.py:178
 #: ../gramps/gui/editors/editmediaref.py:142
-#: ../gramps/plugins/database/bsddb_support/write.py:2556
+#: ../gramps/plugins/db/bsddb/write.py:2481
 #: ../gramps/plugins/gramplet/persondetails.py:208
 #: ../gramps/plugins/gramplet/persondetails.py:214
 #: ../gramps/plugins/gramplet/persondetails.py:216
 #: ../gramps/plugins/gramplet/persondetails.py:217
 #: ../gramps/plugins/gramplet/relativegramplet.py:124
 #: ../gramps/plugins/gramplet/relativegramplet.py:135
-#: ../gramps/plugins/graph/gvfamilylines.py:259
-#: ../gramps/plugins/graph/gvrelgraph.py:788
-#: ../gramps/plugins/lib/maps/geography.py:802
-#: ../gramps/plugins/lib/maps/geography.py:812
-#: ../gramps/plugins/lib/maps/geography.py:813
+#: ../gramps/plugins/graph/gvfamilylines.py:267
+#: ../gramps/plugins/graph/gvrelgraph.py:791
+#: ../gramps/plugins/lib/maps/geography.py:836
+#: ../gramps/plugins/lib/maps/geography.py:846
+#: ../gramps/plugins/lib/maps/geography.py:847
 #: ../gramps/plugins/quickview/all_relations.py:277
 #: ../gramps/plugins/quickview/all_relations.py:294
-#: ../gramps/plugins/textreport/descendreport.py:241
-#: ../gramps/plugins/textreport/detancestralreport.py:202
-#: ../gramps/plugins/textreport/detancestralreport.py:286
-#: ../gramps/plugins/textreport/detancestralreport.py:569
-#: ../gramps/plugins/textreport/detancestralreport.py:571
-#: ../gramps/plugins/textreport/detancestralreport.py:578
-#: ../gramps/plugins/textreport/detancestralreport.py:580
-#: ../gramps/plugins/textreport/detancestralreport.py:595
-#: ../gramps/plugins/textreport/detancestralreport.py:629
-#: ../gramps/plugins/textreport/detancestralreport.py:631
-#: ../gramps/plugins/textreport/detancestralreport.py:638
-#: ../gramps/plugins/textreport/detancestralreport.py:640
-#: ../gramps/plugins/textreport/detancestralreport.py:698
-#: ../gramps/plugins/textreport/detdescendantreport.py:294
-#: ../gramps/plugins/textreport/detdescendantreport.py:387
-#: ../gramps/plugins/textreport/detdescendantreport.py:570
-#: ../gramps/plugins/textreport/detdescendantreport.py:607
-#: ../gramps/plugins/textreport/detdescendantreport.py:609
-#: ../gramps/plugins/textreport/detdescendantreport.py:616
-#: ../gramps/plugins/textreport/detdescendantreport.py:618
-#: ../gramps/plugins/textreport/detdescendantreport.py:644
-#: ../gramps/plugins/textreport/detdescendantreport.py:767
-#: ../gramps/plugins/textreport/indivcomplete.py:84
-#: ../gramps/plugins/textreport/indivcomplete.py:873
-#: ../gramps/plugins/tool/check.py:2135
+#: ../gramps/plugins/textreport/descendreport.py:313
+#: ../gramps/plugins/textreport/detancestralreport.py:203
+#: ../gramps/plugins/textreport/detancestralreport.py:287
+#: ../gramps/plugins/textreport/detancestralreport.py:570
+#: ../gramps/plugins/textreport/detancestralreport.py:572
+#: ../gramps/plugins/textreport/detancestralreport.py:579
+#: ../gramps/plugins/textreport/detancestralreport.py:581
+#: ../gramps/plugins/textreport/detancestralreport.py:596
+#: ../gramps/plugins/textreport/detancestralreport.py:630
+#: ../gramps/plugins/textreport/detancestralreport.py:632
+#: ../gramps/plugins/textreport/detancestralreport.py:639
+#: ../gramps/plugins/textreport/detancestralreport.py:641
+#: ../gramps/plugins/textreport/detancestralreport.py:699
+#: ../gramps/plugins/textreport/detdescendantreport.py:329
+#: ../gramps/plugins/textreport/detdescendantreport.py:427
+#: ../gramps/plugins/textreport/detdescendantreport.py:612
+#: ../gramps/plugins/textreport/detdescendantreport.py:650
+#: ../gramps/plugins/textreport/detdescendantreport.py:652
+#: ../gramps/plugins/textreport/detdescendantreport.py:659
+#: ../gramps/plugins/textreport/detdescendantreport.py:661
+#: ../gramps/plugins/textreport/detdescendantreport.py:687
+#: ../gramps/plugins/textreport/detdescendantreport.py:811
+#: ../gramps/plugins/textreport/indivcomplete.py:86
+#: ../gramps/plugins/textreport/indivcomplete.py:913
+#: ../gramps/plugins/tool/check.py:2356 ../gramps/plugins/tool/check.py:2382
 #: ../gramps/plugins/tool/dumpgenderstats.py:65
 #: ../gramps/plugins/view/geoclose.py:521
-#: ../gramps/plugins/view/geofamclose.py:272
-#: ../gramps/plugins/view/geofamclose.py:713
+#: ../gramps/plugins/view/geofamclose.py:271
+#: ../gramps/plugins/view/geofamclose.py:712
 #: ../gramps/plugins/view/geofamily.py:465
 #: ../gramps/plugins/view/geomoves.py:596
 #: ../gramps/plugins/view/geoperson.py:480
-#: ../gramps/plugins/view/relview.py:458 ../gramps/plugins/view/relview.py:997
-#: ../gramps/plugins/view/relview.py:1054
-#: ../gramps/plugins/webreport/narrativeweb.py:395
-#: ../gramps/plugins/webreport/narrativeweb.py:2597
-#: ../gramps/plugins/webreport/narrativeweb.py:2796
+#: ../gramps/plugins/view/geoplaces.py:525
+#: ../gramps/plugins/view/relview.py:468 ../gramps/plugins/view/relview.py:1008
+#: ../gramps/plugins/view/relview.py:1065
+#: ../gramps/plugins/webreport/narrativeweb.py:2147
+#: ../gramps/plugins/webreport/narrativeweb.py:2176
+#: ../gramps/plugins/webreport/narrativeweb.py:2181
+#: ../gramps/plugins/webreport/narrativeweb.py:2188
+#: ../gramps/plugins/webreport/narrativeweb.py:2583
+#: ../gramps/plugins/webreport/narrativeweb.py:2681
+#: ../gramps/plugins/webreport/narrativeweb.py:2784
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: ../gramps/cli/grampscli.py:83
+#: ../gramps/cli/grampscli.py:84
 #, python-format
 msgid "WARNING: %s"
 msgstr "ACHTUNG: %s"
 
-#: ../gramps/cli/grampscli.py:90 ../gramps/cli/grampscli.py:245
+#: ../gramps/cli/grampscli.py:91 ../gramps/cli/grampscli.py:250
 #, python-format
 msgid "ERROR: %s"
 msgstr "FEHLER: %s"
 
-#: ../gramps/cli/grampscli.py:102 ../gramps/cli/user.py:196
-#: ../gramps/gui/dialog.py:214
+#: ../gramps/cli/grampscli.py:105 ../gramps/cli/user.py:199
+#: ../gramps/gui/dialog.py:217
 msgid "Low level database corruption detected"
 msgstr "Ein interner Datenbankfehler wurde entdeckt."
 
-#: ../gramps/cli/grampscli.py:104 ../gramps/cli/user.py:197
-#: ../gramps/gui/dialog.py:215
+#: ../gramps/cli/grampscli.py:107 ../gramps/cli/user.py:200
+#: ../gramps/gui/dialog.py:218
 msgid ""
 "Gramps has detected a problem in the underlying Berkeley database. This can "
 "be repaired from the Family Tree Manager. Select the database and click on "
@@ -1794,44 +1816,44 @@ msgstr ""
 "Dies kann mit der Stammbaumverwaltung repariert werden. Wähle die Datenbank "
 "und klicke auf die Reparatur-Schaltfläche."
 
-#: ../gramps/cli/grampscli.py:148 ../gramps/gui/dbloader.py:301
+#: ../gramps/cli/grampscli.py:152 ../gramps/gui/dbloader.py:306
 msgid "Read only database"
 msgstr "Schreibgeschützte Datenbank"
 
-#: ../gramps/cli/grampscli.py:149 ../gramps/gui/dbloader.py:242
-#: ../gramps/gui/dbloader.py:302
+#: ../gramps/cli/grampscli.py:153 ../gramps/gui/dbloader.py:247
+#: ../gramps/gui/dbloader.py:307
 msgid "You do not have write access to the selected file."
 msgstr "Du hast keinen Schreibzugriff auf die ausgewählte Datei."
 
-#: ../gramps/cli/grampscli.py:175 ../gramps/cli/grampscli.py:178
-#: ../gramps/cli/grampscli.py:181 ../gramps/cli/grampscli.py:184
-#: ../gramps/cli/grampscli.py:187 ../gramps/cli/grampscli.py:190
-#: ../gramps/cli/grampscli.py:193 ../gramps/cli/grampscli.py:196
-#: ../gramps/cli/grampscli.py:199 ../gramps/gui/dbloader.py:401
-#: ../gramps/gui/dbloader.py:404 ../gramps/gui/dbloader.py:407
-#: ../gramps/gui/dbloader.py:410 ../gramps/gui/dbloader.py:413
+#: ../gramps/cli/grampscli.py:179 ../gramps/cli/grampscli.py:182
+#: ../gramps/cli/grampscli.py:185 ../gramps/cli/grampscli.py:188
+#: ../gramps/cli/grampscli.py:191 ../gramps/cli/grampscli.py:194
+#: ../gramps/cli/grampscli.py:197 ../gramps/cli/grampscli.py:200
+#: ../gramps/cli/grampscli.py:203 ../gramps/gui/dbloader.py:410
+#: ../gramps/gui/dbloader.py:413 ../gramps/gui/dbloader.py:416
+#: ../gramps/gui/dbloader.py:419 ../gramps/gui/dbloader.py:422
 msgid "Cannot open database"
 msgstr "Kann die Datenbank nicht öffnen."
 
-#: ../gramps/cli/grampscli.py:203 ../gramps/gui/dbloader.py:198
-#: ../gramps/gui/dbloader.py:417
+#: ../gramps/cli/grampscli.py:207 ../gramps/gui/dbloader.py:203
+#: ../gramps/gui/dbloader.py:426
 #, python-format
 msgid "Could not open file: %s"
 msgstr "Kann die folgende Datei nicht öffnen: %s"
 
-#: ../gramps/cli/grampscli.py:257
+#: ../gramps/cli/grampscli.py:263
 msgid "Could not load a recent Family Tree."
 msgstr "Kann den letzten Stammbaum nicht laden."
 
-#: ../gramps/cli/grampscli.py:258
+#: ../gramps/cli/grampscli.py:264
 msgid "Family Tree does not exist, as it has been deleted."
 msgstr "Stammbaum existiert nicht, weil er gelöscht wurde."
 
-#: ../gramps/cli/grampscli.py:263
+#: ../gramps/cli/grampscli.py:269
 msgid "The database is locked."
 msgstr "Die Datenbank ist gesperrt."
 
-#: ../gramps/cli/grampscli.py:264
+#: ../gramps/cli/grampscli.py:270
 msgid ""
 "Use the --force-unlock option if you are sure that the database is not in "
 "use."
@@ -1840,114 +1862,114 @@ msgstr ""
 "aktuell nicht verwendet wird."
 
 #. already errors encountered. Show first one on terminal and exit
-#: ../gramps/cli/grampscli.py:342
+#: ../gramps/cli/grampscli.py:350
 #, python-format
 msgid "Error encountered: %s"
 msgstr "Fehler gefunden: %s"
 
-#: ../gramps/cli/grampscli.py:344 ../gramps/cli/grampscli.py:352
+#: ../gramps/cli/grampscli.py:352 ../gramps/cli/grampscli.py:360
 #, python-format
 msgid "  Details: %s"
 msgstr "  Details: %s"
 
-#: ../gramps/cli/grampscli.py:349
+#: ../gramps/cli/grampscli.py:357
 #, python-format
 msgid "Error encountered in argument parsing: %s"
 msgstr "Ein Fehler wurde in der Argumentanalyse gefunden: %s"
 
-#: ../gramps/cli/plug/__init__.py:168
+#: ../gramps/cli/plug/__init__.py:170
 msgid "ERROR: Please specify a person"
 msgstr "FEHLER: Bitte gib eine Person an"
 
-#: ../gramps/cli/plug/__init__.py:193
+#: ../gramps/cli/plug/__init__.py:195
 msgid "ERROR: Please specify a family"
 msgstr "FEHLER: Bitte gib eine Familie an"
 
-#: ../gramps/cli/plug/__init__.py:265
+#: ../gramps/cli/plug/__init__.py:283
 msgid "=filename"
 msgstr "=Dateiname"
 
-#: ../gramps/cli/plug/__init__.py:265
+#: ../gramps/cli/plug/__init__.py:284
 msgid "Output file name. MANDATORY"
 msgstr "Ausgabe Dateiname. NOTWENDIG"
 
-#: ../gramps/cli/plug/__init__.py:266
+#: ../gramps/cli/plug/__init__.py:285
 msgid "=format"
 msgstr "=Format"
 
-#: ../gramps/cli/plug/__init__.py:266
+#: ../gramps/cli/plug/__init__.py:285
 msgid "Output file format."
 msgstr "Ausgabedateiformat."
 
-#: ../gramps/cli/plug/__init__.py:267 ../gramps/cli/plug/__init__.py:268
+#: ../gramps/cli/plug/__init__.py:286 ../gramps/cli/plug/__init__.py:287
 msgid "=name"
 msgstr "=Name"
 
-#: ../gramps/cli/plug/__init__.py:267
+#: ../gramps/cli/plug/__init__.py:286
 msgid "Style name."
 msgstr "Stilname."
 
-#: ../gramps/cli/plug/__init__.py:268
+#: ../gramps/cli/plug/__init__.py:287
 msgid "Paper size name."
 msgstr "Papiergrößenname."
 
-#: ../gramps/cli/plug/__init__.py:269 ../gramps/cli/plug/__init__.py:270
-#: ../gramps/cli/plug/__init__.py:272 ../gramps/cli/plug/__init__.py:274
-#: ../gramps/cli/plug/__init__.py:276
+#: ../gramps/cli/plug/__init__.py:288 ../gramps/cli/plug/__init__.py:289
+#: ../gramps/cli/plug/__init__.py:291 ../gramps/cli/plug/__init__.py:293
+#: ../gramps/cli/plug/__init__.py:295
 msgid "=number"
 msgstr "=Nummer"
 
-#: ../gramps/cli/plug/__init__.py:269
+#: ../gramps/cli/plug/__init__.py:288
 msgid "Paper orientation number."
 msgstr "Papierausrichtungsnummer."
 
-#: ../gramps/cli/plug/__init__.py:270
+#: ../gramps/cli/plug/__init__.py:290
 msgid "Left paper margin"
 msgstr "Linker Papierrand"
 
-#: ../gramps/cli/plug/__init__.py:271 ../gramps/cli/plug/__init__.py:273
-#: ../gramps/cli/plug/__init__.py:275 ../gramps/cli/plug/__init__.py:277
+#: ../gramps/cli/plug/__init__.py:290 ../gramps/cli/plug/__init__.py:292
+#: ../gramps/cli/plug/__init__.py:294 ../gramps/cli/plug/__init__.py:296
 msgid "Size in cm"
 msgstr "Größe in cm"
 
-#: ../gramps/cli/plug/__init__.py:272
+#: ../gramps/cli/plug/__init__.py:292
 msgid "Right paper margin"
 msgstr "Rechter Papierrand"
 
-#: ../gramps/cli/plug/__init__.py:274
+#: ../gramps/cli/plug/__init__.py:294
 msgid "Top paper margin"
 msgstr "Oberer Papierrand"
 
-#: ../gramps/cli/plug/__init__.py:276
+#: ../gramps/cli/plug/__init__.py:296
 msgid "Bottom paper margin"
 msgstr "Unterer Papierrand"
 
-#: ../gramps/cli/plug/__init__.py:278
+#: ../gramps/cli/plug/__init__.py:297
 msgid "=css filename"
 msgstr "=css Dateiname"
 
-#: ../gramps/cli/plug/__init__.py:278
+#: ../gramps/cli/plug/__init__.py:298
 msgid "CSS filename to use, html format only"
 msgstr "Der zu verwendende css Dateiname darf nur im html Format sein."
 
-#: ../gramps/cli/plug/__init__.py:427
+#: ../gramps/cli/plug/__init__.py:445
 #, python-format
 msgid "Unknown option: %s"
 msgstr "Unbekannte Option: %s"
 
-#: ../gramps/cli/plug/__init__.py:428 ../gramps/cli/plug/__init__.py:510
+#: ../gramps/cli/plug/__init__.py:446 ../gramps/cli/plug/__init__.py:527
 msgid "   Valid options are:"
 msgstr "   Gültige Optionen sind:"
 
-#: ../gramps/cli/plug/__init__.py:431 ../gramps/cli/plug/__init__.py:513
-#: ../gramps/cli/plug/__init__.py:590
+#: ../gramps/cli/plug/__init__.py:449 ../gramps/cli/plug/__init__.py:530
+#: ../gramps/cli/plug/__init__.py:610
 #, python-format
 msgid "   Use '%(donottranslate)s' to see description and acceptable values"
 msgstr ""
 "  Verwende '%(donottranslate)s', um eine Beschreibung und gültige Werte zu "
 "sehen."
 
-#: ../gramps/cli/plug/__init__.py:484
+#: ../gramps/cli/plug/__init__.py:502
 #, python-format
 msgid ""
 "Ignoring '%(notranslate1)s=%(notranslate2)s' and using '%(notranslate1)s="
@@ -1956,30 +1978,30 @@ msgstr ""
 "Ignoriere  '%(notranslate1)s=%(notranslate2)s' und verwende "
 "'%(notranslate1)s=%(notranslate3)s'."
 
-#: ../gramps/cli/plug/__init__.py:490
+#: ../gramps/cli/plug/__init__.py:508
 #, python-format
 msgid "Use '%(notranslate)s' to see valid values."
 msgstr "Verwende '%(notranslate)s', um gültige Werte zu sehen."
 
-#: ../gramps/cli/plug/__init__.py:509
+#: ../gramps/cli/plug/__init__.py:526
 #, python-format
 msgid "Ignoring unknown option: %s"
 msgstr "Ignoriere unbekannte Option: %s"
 
-#: ../gramps/cli/plug/__init__.py:579
+#: ../gramps/cli/plug/__init__.py:599
 msgid "   Available options:"
 msgstr "   Verfügbare Optionen:"
 
-#: ../gramps/cli/plug/__init__.py:588
+#: ../gramps/cli/plug/__init__.py:608
 msgid "(no help available)"
 msgstr "(keine Hilfe verfügbar)"
 
-#: ../gramps/cli/plug/__init__.py:596
+#: ../gramps/cli/plug/__init__.py:616
 msgid "   Available values are:"
 msgstr "   Verfügbare Werte sind:"
 
 #. there was a show option given, but the option is invalid
-#: ../gramps/cli/plug/__init__.py:607
+#: ../gramps/cli/plug/__init__.py:627
 #, python-format
 msgid ""
 "option '%(optionname)s' not valid. Use '%(donottranslate)s' to see all valid "
@@ -1988,35 +2010,61 @@ msgstr ""
 "Die Option '%(optionname)s' ist nicht gültig. Verwende '%(donottranslate)s', "
 "um alle gültigen Optionen zu sehen."
 
-#: ../gramps/cli/plug/__init__.py:621
+#: ../gramps/cli/plug/__init__.py:644
 msgid "Failed to write report. "
 msgstr "Das Schreiben des Berichts ist fehlgeschlagen."
 
-#: ../gramps/gen/config.py:298
+#: ../gramps/cli/plug/__init__.py:793
+#, python-format
+msgid "Failed to make '%s' report."
+msgstr "Erstellen des Bericht '%s' fehlgeschlagen."
+
+#: ../gramps/cli/user.py:216 ../gramps/gui/dialog.py:203
+msgid "Error detected in database"
+msgstr "In der Datenbank wurde ein Fehler entdeckt"
+
+#: ../gramps/cli/user.py:217 ../gramps/gui/dialog.py:204
+#, python-format
+msgid ""
+"Gramps has detected an error in the database. This can usually be resolved "
+"by running the \"Check and Repair Database\" tool.\n"
+"\n"
+"If this problem continues to exist after running this tool, please file a "
+"bug report at %(gramps_bugtracker_url)s\n"
+"\n"
+msgstr ""
+"Gramps hat einen Fehler in der Datenbank entdeckt. Dies kann meist durch "
+"Verwendung des Werkzeugs \"Datenbank prüfen und reparieren\" behoben "
+"werden.\n"
+"n\"Wenn der Fehler nach Einsatz dieses Werkzeugs nicht behoben wurde, so "
+"schreibe bitte einen Fehlerbericht auf %(gramps_bugtracker_url)s\n"
+"\n"
+
+#: ../gramps/gen/config.py:240
 msgid "Imported %Y/%m/%d %H:%M:%S"
 msgstr "Importiert %d.%m.%Y %H:%M:%S"
 
-#: ../gramps/gen/config.py:312
+#: ../gramps/gen/config.py:254
 msgid "Missing Given Name"
 msgstr "Fehlender Vorname"
 
-#: ../gramps/gen/config.py:313
+#: ../gramps/gen/config.py:255
 msgid "Missing Record"
 msgstr "Fehlender Datensatz"
 
-#: ../gramps/gen/config.py:314
+#: ../gramps/gen/config.py:256
 msgid "Missing Surname"
 msgstr "Fehlender Nachname"
 
-#: ../gramps/gen/config.py:321 ../gramps/gen/config.py:323
+#: ../gramps/gen/config.py:263 ../gramps/gen/config.py:265
 msgid "[Living]"
 msgstr "[Lebt]"
 
-#: ../gramps/gen/config.py:322
+#: ../gramps/gen/config.py:264
 msgid "Private Record"
 msgstr "Vertraulicher Datensatz"
 
-#: ../gramps/gen/const.py:220
+#: ../gramps/gen/const.py:221
 msgid ""
 "Gramps\n"
 " (Genealogical Research and Analysis Management Programming System)\n"
@@ -2026,11 +2074,11 @@ msgstr ""
 " (Genealogisches Recherche und Analyse Management Programm System)\n"
 "ist ein Programm zur Ahnenforschung."
 
-#: ../gramps/gen/const.py:250
+#: ../gramps/gen/const.py:251
 msgid "surname|none"
 msgstr "Unbekannt"
 
-#: ../gramps/gen/const.py:251
+#: ../gramps/gen/const.py:252
 msgid "given-name|none"
 msgstr "Unbekannt"
 
@@ -2536,31 +2584,31 @@ msgid "alternative month names for December||"
 msgstr "Christmond|Christmonat|Julmond|Dustermond|Heilmond|Heiligenmonat"
 
 #. Must appear in the order indexed by Date.CAL_... numeric constants
-#: ../gramps/gen/datehandler/_datestrings.py:131 ../gramps/gen/lib/date.py:602
+#: ../gramps/gen/datehandler/_datestrings.py:131 ../gramps/gen/lib/date.py:608
 msgid "calendar|Gregorian"
 msgstr "Gregorianisch"
 
-#: ../gramps/gen/datehandler/_datestrings.py:132 ../gramps/gen/lib/date.py:603
+#: ../gramps/gen/datehandler/_datestrings.py:132 ../gramps/gen/lib/date.py:609
 msgid "calendar|Julian"
 msgstr "Julianisch"
 
-#: ../gramps/gen/datehandler/_datestrings.py:133 ../gramps/gen/lib/date.py:604
+#: ../gramps/gen/datehandler/_datestrings.py:133 ../gramps/gen/lib/date.py:610
 msgid "calendar|Hebrew"
 msgstr "Hebräisch"
 
-#: ../gramps/gen/datehandler/_datestrings.py:134 ../gramps/gen/lib/date.py:605
+#: ../gramps/gen/datehandler/_datestrings.py:134 ../gramps/gen/lib/date.py:611
 msgid "calendar|French Republican"
 msgstr "Französisch-Republikanisch"
 
-#: ../gramps/gen/datehandler/_datestrings.py:135 ../gramps/gen/lib/date.py:606
+#: ../gramps/gen/datehandler/_datestrings.py:135 ../gramps/gen/lib/date.py:612
 msgid "calendar|Persian"
 msgstr "Persisch"
 
-#: ../gramps/gen/datehandler/_datestrings.py:136 ../gramps/gen/lib/date.py:607
+#: ../gramps/gen/datehandler/_datestrings.py:136 ../gramps/gen/lib/date.py:613
 msgid "calendar|Islamic"
 msgstr "Islamisch"
 
-#: ../gramps/gen/datehandler/_datestrings.py:137 ../gramps/gen/lib/date.py:608
+#: ../gramps/gen/datehandler/_datestrings.py:137 ../gramps/gen/lib/date.py:614
 msgid "calendar|Swedish"
 msgstr "Schwedisch"
 
@@ -2834,33 +2882,25 @@ msgstr "Freitag"
 msgid "Saturday"
 msgstr "Samstag"
 
-#: ../gramps/gen/db/base.py:1873 ../gramps/gui/widgets/fanchart.py:1831
+#: ../gramps/gen/db/base.py:1789 ../gramps/gui/widgets/fanchart.py:1761
 msgid "Add child to family"
 msgstr "Füge ein Kind zur Familie hinzu."
 
-#: ../gramps/gen/db/base.py:1886 ../gramps/gen/db/base.py:1891
+#: ../gramps/gen/db/base.py:1803 ../gramps/gen/db/base.py:1809
 msgid "Remove child from family"
 msgstr "Entferne ein Kind aus der Familie."
 
-#: ../gramps/gen/db/base.py:1966 ../gramps/gen/db/base.py:1970
+#: ../gramps/gen/db/base.py:1885 ../gramps/gen/db/base.py:1889
 msgid "Remove Family"
 msgstr "Entferne die Familie."
 
-#: ../gramps/gen/db/base.py:2012
+#: ../gramps/gen/db/base.py:1931
 msgid "Remove father from family"
 msgstr "Entferne den Vater aus der Familie."
 
-#: ../gramps/gen/db/base.py:2014
+#: ../gramps/gen/db/base.py:1933
 msgid "Remove mother from family"
 msgstr "Entferne die Mutter aus der Familie."
-
-#: ../gramps/gen/db/base.py:2119
-msgid "Autobackup..."
-msgstr "Automatisches Backup..."
-
-#: ../gramps/gen/db/base.py:2123
-msgid "Error saving backup data"
-msgstr "Fehler beim speichern der Sicherungsdaten."
 
 #: ../gramps/gen/db/exceptions.py:91
 #, python-format
@@ -3100,98 +3140,102 @@ msgstr ""
 "und %(wiki_backup_html_start)seine Sicherung%(html_end)s von deinem "
 "Stammbaum erstellen."
 
-#: ../gramps/gen/db/generic.py:181 ../gramps/gen/db/generic.py:220
-#: ../gramps/gen/db/generic.py:909
-#: ../gramps/plugins/database/bsddb_support/undoredo.py:245
-#: ../gramps/plugins/database/bsddb_support/undoredo.py:282
-#: ../gramps/plugins/database/bsddb_support/write.py:2362
+#: ../gramps/gen/db/generic.py:155 ../gramps/gen/db/generic.py:200
+#: ../gramps/gen/db/generic.py:2137 ../gramps/plugins/db/bsddb/undoredo.py:245
+#: ../gramps/plugins/db/bsddb/undoredo.py:282
+#: ../gramps/plugins/db/bsddb/write.py:2325
 #, python-format
 msgid "_Undo %s"
 msgstr "_Rückgängig %s"
 
-#: ../gramps/gen/db/generic.py:187 ../gramps/gen/db/generic.py:226
-#: ../gramps/plugins/database/bsddb_support/undoredo.py:251
-#: ../gramps/plugins/database/bsddb_support/undoredo.py:288
+#: ../gramps/gen/db/generic.py:160 ../gramps/gen/db/generic.py:206
+#: ../gramps/plugins/db/bsddb/undoredo.py:251
+#: ../gramps/plugins/db/bsddb/undoredo.py:288
 #, python-format
 msgid "_Redo %s"
 msgstr "_Wiederherstellen %s"
 
-#: ../gramps/gen/db/generic.py:2067
-#: ../gramps/plugins/database/bsddb_support/read.py:2086
-#: ../gramps/plugins/database/bsddb_support/write.py:2559
+#: ../gramps/gen/db/generic.py:2569 ../gramps/plugins/db/bsddb/read.py:2071
+#: ../gramps/plugins/db/bsddb/write.py:2484
 msgid "Number of people"
 msgstr "Personenanzahl"
 
-#: ../gramps/gen/db/generic.py:2068
-#: ../gramps/plugins/database/bsddb_support/read.py:2087
-#: ../gramps/plugins/database/bsddb_support/write.py:2560
-#: ../gramps/plugins/gramplet/statsgramplet.py:116
+#: ../gramps/gen/db/generic.py:2570 ../gramps/plugins/db/bsddb/read.py:2072
+#: ../gramps/plugins/db/bsddb/write.py:2485
+#: ../gramps/plugins/gramplet/statsgramplet.py:117
+#: ../gramps/plugins/webreport/narrativeweb.py:8106
+#: ../gramps/plugins/webreport/narrativeweb.py:8172
 msgid "Number of families"
 msgstr "Familienanzahl"
 
-#: ../gramps/gen/db/generic.py:2069
-#: ../gramps/plugins/database/bsddb_support/read.py:2088
-#: ../gramps/plugins/database/bsddb_support/write.py:2561
+#: ../gramps/gen/db/generic.py:2571 ../gramps/plugins/db/bsddb/read.py:2073
+#: ../gramps/plugins/db/bsddb/write.py:2486
+#: ../gramps/plugins/webreport/narrativeweb.py:8133
+#: ../gramps/plugins/webreport/narrativeweb.py:8184
 msgid "Number of sources"
 msgstr "Anzahl der Quellen"
 
-#: ../gramps/gen/db/generic.py:2070
-#: ../gramps/plugins/database/bsddb_support/read.py:2089
-#: ../gramps/plugins/database/bsddb_support/write.py:2562
+#: ../gramps/gen/db/generic.py:2572 ../gramps/plugins/db/bsddb/read.py:2074
+#: ../gramps/plugins/db/bsddb/write.py:2487
+#: ../gramps/plugins/webreport/narrativeweb.py:8137
+#: ../gramps/plugins/webreport/narrativeweb.py:8187
 msgid "Number of citations"
 msgstr "Anzahl der Fundstellen"
 
-#: ../gramps/gen/db/generic.py:2071
-#: ../gramps/plugins/database/bsddb_support/read.py:2090
-#: ../gramps/plugins/database/bsddb_support/write.py:2563
+#: ../gramps/gen/db/generic.py:2573 ../gramps/plugins/db/bsddb/read.py:2075
+#: ../gramps/plugins/db/bsddb/write.py:2488
+#: ../gramps/plugins/webreport/narrativeweb.py:8126
+#: ../gramps/plugins/webreport/narrativeweb.py:8178
 msgid "Number of events"
 msgstr "Anzahl der Ereignisse"
 
-#: ../gramps/gen/db/generic.py:2072
-#: ../gramps/plugins/database/bsddb_support/read.py:2091
-#: ../gramps/plugins/database/bsddb_support/write.py:2564
+#: ../gramps/gen/db/generic.py:2574 ../gramps/plugins/db/bsddb/read.py:2076
+#: ../gramps/plugins/db/bsddb/write.py:2489
 msgid "Number of media"
 msgstr "Anzahl der Medien"
 
-#: ../gramps/gen/db/generic.py:2073
-#: ../gramps/plugins/database/bsddb_support/read.py:2092
-#: ../gramps/plugins/database/bsddb_support/write.py:2565
+#: ../gramps/gen/db/generic.py:2575 ../gramps/plugins/db/bsddb/read.py:2077
+#: ../gramps/plugins/db/bsddb/write.py:2490
+#: ../gramps/plugins/webreport/narrativeweb.py:8129
+#: ../gramps/plugins/webreport/narrativeweb.py:8181
 msgid "Number of places"
 msgstr "Anzahl der Orte"
 
-#: ../gramps/gen/db/generic.py:2074
-#: ../gramps/plugins/database/bsddb_support/read.py:2093
-#: ../gramps/plugins/database/bsddb_support/write.py:2566
+#: ../gramps/gen/db/generic.py:2576 ../gramps/plugins/db/bsddb/read.py:2078
+#: ../gramps/plugins/db/bsddb/write.py:2491
+#: ../gramps/plugins/webreport/narrativeweb.py:8141
+#: ../gramps/plugins/webreport/narrativeweb.py:8190
 msgid "Number of repositories"
 msgstr "Anzahl der Aufbewahrungsorte"
 
-#: ../gramps/gen/db/generic.py:2075
-#: ../gramps/plugins/database/bsddb_support/read.py:2094
-#: ../gramps/plugins/database/bsddb_support/write.py:2567
+#: ../gramps/gen/db/generic.py:2577 ../gramps/plugins/db/bsddb/read.py:2079
+#: ../gramps/plugins/db/bsddb/write.py:2492
 msgid "Number of notes"
 msgstr "Anzahl der Notizen"
 
-#: ../gramps/gen/db/generic.py:2076
-#: ../gramps/plugins/database/bsddb_support/read.py:2095
-#: ../gramps/plugins/database/bsddb_support/write.py:2568
+#: ../gramps/gen/db/generic.py:2578 ../gramps/plugins/db/bsddb/read.py:2080
+#: ../gramps/plugins/db/bsddb/write.py:2493
 msgid "Number of tags"
 msgstr "Anzahl der Markierungen"
 
-#: ../gramps/gen/db/generic.py:2077
-#: ../gramps/plugins/database/bsddb_support/write.py:2569
+#: ../gramps/gen/db/generic.py:2579 ../gramps/plugins/db/bsddb/write.py:2494
 msgid "Data version"
 msgstr "Daten Version"
 
-#: ../gramps/gen/db/generic.py:2078
+#: ../gramps/gen/db/generic.py:2580
 msgid "Backups, count"
 msgstr "Sicherungen, Anzahl"
 
-#: ../gramps/gen/db/generic.py:2079
+#: ../gramps/gen/db/generic.py:2581
 msgid "Backups, last"
 msgstr "Sicherung, letzte"
 
 #. translators: needed for Arabic, ignore otherwise
-#: ../gramps/gen/display/name.py:349 ../gramps/plugins/lib/libtreebase.py:707
+#. need for spacing on the french translation
+#. translators: needed for Arabic, ignore otherwise
+#: ../gramps/gen/display/name.py:349
+#: ../gramps/gui/views/treemodels/placemodel.py:130
+#: ../gramps/plugins/lib/libtreebase.py:707
 msgid ","
 msgstr ","
 
@@ -3204,15 +3248,15 @@ msgid "Surname, Given Suffix"
 msgstr "Nachname, Vorname Suffix"
 
 #: ../gramps/gen/display/name.py:356 ../gramps/gen/utils/keyword.py:55
-#: ../gramps/gui/configure.py:640 ../gramps/gui/configure.py:642
-#: ../gramps/gui/configure.py:647 ../gramps/gui/configure.py:649
-#: ../gramps/gui/configure.py:651 ../gramps/gui/configure.py:652
-#: ../gramps/gui/configure.py:653 ../gramps/gui/configure.py:654
+#: ../gramps/gui/configure.py:645 ../gramps/gui/configure.py:647
+#: ../gramps/gui/configure.py:652 ../gramps/gui/configure.py:654
 #: ../gramps/gui/configure.py:656 ../gramps/gui/configure.py:657
 #: ../gramps/gui/configure.py:658 ../gramps/gui/configure.py:659
-#: ../gramps/gui/configure.py:660 ../gramps/gui/configure.py:661
-#: ../gramps/plugins/export/exportcsv.py:379
-#: ../gramps/plugins/importer/importcsv.py:150
+#: ../gramps/gui/configure.py:661 ../gramps/gui/configure.py:662
+#: ../gramps/gui/configure.py:663 ../gramps/gui/configure.py:664
+#: ../gramps/gui/configure.py:665 ../gramps/gui/configure.py:666
+#: ../gramps/plugins/export/exportcsv.py:353
+#: ../gramps/plugins/importer/importcsv.py:161
 msgid "Given"
 msgstr "Vorname"
 
@@ -3231,102 +3275,102 @@ msgstr "Haupt Nachnamen, Vorname Patronymikon Suffix Präfix"
 msgid "Patronymic, Given"
 msgstr "Vatername, Vorname"
 
-#: ../gramps/gen/display/name.py:594 ../gramps/gen/display/name.py:694
+#: ../gramps/gen/display/name.py:597 ../gramps/gen/display/name.py:697
 msgid "Person|title"
 msgstr "Titel"
 
-#: ../gramps/gen/display/name.py:596 ../gramps/gen/display/name.py:696
-#: ../gramps/plugins/importer/importcsv.py:151
+#: ../gramps/gen/display/name.py:599 ../gramps/gen/display/name.py:699
+#: ../gramps/plugins/importer/importcsv.py:160
 msgid "given"
 msgstr "Vorname"
 
-#: ../gramps/gen/display/name.py:598 ../gramps/gen/display/name.py:698
-#: ../gramps/plugins/importer/importcsv.py:148
+#: ../gramps/gen/display/name.py:601 ../gramps/gen/display/name.py:701
+#: ../gramps/plugins/importer/importcsv.py:157
 msgid "surname"
 msgstr "Nachname"
 
-#: ../gramps/gen/display/name.py:600 ../gramps/gen/display/name.py:700
-#: ../gramps/gui/editors/editperson.py:389
-#: ../gramps/plugins/importer/importcsv.py:157
+#: ../gramps/gen/display/name.py:603 ../gramps/gen/display/name.py:703
+#: ../gramps/gui/editors/editperson.py:388
+#: ../gramps/plugins/importer/importcsv.py:166
 msgid "suffix"
 msgstr "Suffix"
 
-#: ../gramps/gen/display/name.py:602 ../gramps/gen/display/name.py:702
+#: ../gramps/gen/display/name.py:605 ../gramps/gen/display/name.py:705
 msgid "Name|call"
 msgstr "Rufname"
 
-#: ../gramps/gen/display/name.py:605 ../gramps/gen/display/name.py:704
+#: ../gramps/gen/display/name.py:608 ../gramps/gen/display/name.py:707
 msgid "Name|common"
 msgstr "üblich"
 
-#: ../gramps/gen/display/name.py:609 ../gramps/gen/display/name.py:707
+#: ../gramps/gen/display/name.py:612 ../gramps/gen/display/name.py:710
 msgid "initials"
 msgstr "Initialen"
 
-#: ../gramps/gen/display/name.py:612 ../gramps/gen/display/name.py:709
+#: ../gramps/gen/display/name.py:615 ../gramps/gen/display/name.py:712
 msgid "Name|primary"
 msgstr "primär"
 
-#: ../gramps/gen/display/name.py:615 ../gramps/gen/display/name.py:711
+#: ../gramps/gen/display/name.py:618 ../gramps/gen/display/name.py:714
 msgid "primary[pre]"
 msgstr "primär[pri]"
 
-#: ../gramps/gen/display/name.py:618 ../gramps/gen/display/name.py:713
+#: ../gramps/gen/display/name.py:621 ../gramps/gen/display/name.py:716
 msgid "primary[sur]"
 msgstr "primär[Nach]"
 
-#: ../gramps/gen/display/name.py:621 ../gramps/gen/display/name.py:715
+#: ../gramps/gen/display/name.py:624 ../gramps/gen/display/name.py:718
 msgid "primary[con]"
 msgstr "primär[übl]"
 
-#: ../gramps/gen/display/name.py:623 ../gramps/gen/display/name.py:717
+#: ../gramps/gen/display/name.py:626 ../gramps/gen/display/name.py:720
 msgid "patronymic"
 msgstr "Patronymikon"
 
-#: ../gramps/gen/display/name.py:625 ../gramps/gen/display/name.py:719
+#: ../gramps/gen/display/name.py:628 ../gramps/gen/display/name.py:722
 msgid "patronymic[pre]"
 msgstr "Patronymikon[pri]"
 
-#: ../gramps/gen/display/name.py:627 ../gramps/gen/display/name.py:721
+#: ../gramps/gen/display/name.py:630 ../gramps/gen/display/name.py:724
 msgid "patronymic[sur]"
 msgstr "Patronymikon[Nach]"
 
-#: ../gramps/gen/display/name.py:629 ../gramps/gen/display/name.py:723
+#: ../gramps/gen/display/name.py:632 ../gramps/gen/display/name.py:726
 msgid "patronymic[con]"
 msgstr "Patronymikon[übl]"
 
-#: ../gramps/gen/display/name.py:631 ../gramps/gen/display/name.py:725
+#: ../gramps/gen/display/name.py:634 ../gramps/gen/display/name.py:728
 msgid "notpatronymic"
 msgstr "Kein Patronymikon"
 
-#: ../gramps/gen/display/name.py:634 ../gramps/gen/display/name.py:727
+#: ../gramps/gen/display/name.py:637 ../gramps/gen/display/name.py:730
 msgid "Remaining names|rest"
 msgstr "Rest"
 
-#: ../gramps/gen/display/name.py:637 ../gramps/gen/display/name.py:729
-#: ../gramps/gui/editors/editperson.py:410
-#: ../gramps/plugins/importer/importcsv.py:156
+#: ../gramps/gen/display/name.py:640 ../gramps/gen/display/name.py:732
+#: ../gramps/gui/editors/editperson.py:409
+#: ../gramps/plugins/importer/importcsv.py:165
 msgid "prefix"
 msgstr "Präfix"
 
-#: ../gramps/gen/display/name.py:640 ../gramps/gen/display/name.py:731
+#: ../gramps/gen/display/name.py:643 ../gramps/gen/display/name.py:734
 msgid "rawsurnames"
 msgstr "unbearbeitete Nachnamen"
 
-#: ../gramps/gen/display/name.py:642 ../gramps/gen/display/name.py:733
+#: ../gramps/gen/display/name.py:645 ../gramps/gen/display/name.py:736
 msgid "nickname"
 msgstr "Spitzname"
 
-#: ../gramps/gen/display/name.py:644 ../gramps/gen/display/name.py:735
+#: ../gramps/gen/display/name.py:647 ../gramps/gen/display/name.py:738
 msgid "familynick"
 msgstr "Familienspitzname"
 
-#: ../gramps/gen/display/name.py:1096
+#: ../gramps/gen/display/name.py:1117
 #, python-format
 msgid "Wrong name format string %s"
 msgstr "Falsche Namensformatzeichenkette %s"
 
-#: ../gramps/gen/display/name.py:1100
+#: ../gramps/gen/display/name.py:1121
 msgid "ERROR, Edit Name format in Preferences"
 msgstr "FEHLER: Bearbeite das Namenformat in den Einstellungen."
 
@@ -3355,7 +3399,7 @@ msgstr ""
 "FEHLER: Der Filter %s konnte nicht korrekt geladen werden. Überarbeite den "
 "Filter!"
 
-#: ../gramps/gen/filters/rules/_changedsincebase.py:55
+#: ../gramps/gen/filters/rules/_changedsincebase.py:56
 #: ../gramps/gen/filters/rules/_everything.py:45
 #: ../gramps/gen/filters/rules/_hasattributebase.py:51
 #: ../gramps/gen/filters/rules/_hasgallerybase.py:48
@@ -3434,11 +3478,11 @@ msgstr ""
 msgid "General filters"
 msgstr "Allgemeine Filter"
 
-#: ../gramps/gen/filters/rules/_changedsincebase.py:81
+#: ../gramps/gen/filters/rules/_changedsincebase.py:82
 msgid "Wrong format of date-time"
 msgstr "Falsches Format für Datum-Zeit"
 
-#: ../gramps/gen/filters/rules/_changedsincebase.py:82
+#: ../gramps/gen/filters/rules/_changedsincebase.py:83
 #, python-format
 msgid ""
 "Only date-times in the iso format of yyyy-mm-dd hh:mm:ss, where the time "
@@ -3454,8 +3498,8 @@ msgstr ""
 #: ../gramps/gen/filters/rules/media/_hascitation.py:47
 #: ../gramps/gen/filters/rules/person/_hascitation.py:47
 #: ../gramps/gen/filters/rules/place/_hascitation.py:48
-#: ../gramps/gui/glade/mergecitation.glade:213
-#: ../gramps/gui/glade/mergecitation.glade:229
+#: ../gramps/gui/glade/mergecitation.glade:212
+#: ../gramps/gui/glade/mergecitation.glade:228
 msgid "Volume/Page:"
 msgstr "Band/Seite:"
 
@@ -3473,19 +3517,19 @@ msgstr "Band/Seite:"
 #: ../gramps/gen/filters/rules/person/_hasevent.py:49
 #: ../gramps/gen/filters/rules/person/_hasfamilyevent.py:49
 #: ../gramps/gen/filters/rules/place/_hascitation.py:49
-#: ../gramps/gui/editors/filtereditor.py:580
-#: ../gramps/gui/glade/mergecitation.glade:246
-#: ../gramps/gui/glade/mergecitation.glade:262
-#: ../gramps/gui/glade/mergeevent.glade:246
-#: ../gramps/gui/glade/mergeevent.glade:262
-#: ../gramps/gui/glade/mergemedia.glade:279
-#: ../gramps/gui/glade/mergemedia.glade:295
+#: ../gramps/gui/editors/filtereditor.py:579
+#: ../gramps/gui/glade/mergecitation.glade:245
+#: ../gramps/gui/glade/mergecitation.glade:261
+#: ../gramps/gui/glade/mergeevent.glade:245
+#: ../gramps/gui/glade/mergeevent.glade:261
+#: ../gramps/gui/glade/mergemedia.glade:278
+#: ../gramps/gui/glade/mergemedia.glade:294
 msgid "Date:"
 msgstr "Datum:"
 
 #: ../gramps/gen/filters/rules/_hascitationbase.py:51
-#: ../gramps/gui/glade/mergecitation.glade:279
-#: ../gramps/gui/glade/mergecitation.glade:295
+#: ../gramps/gui/glade/mergecitation.glade:278
+#: ../gramps/gui/glade/mergecitation.glade:294
 msgid "Confidence:"
 msgstr "Verlässlichkeit:"
 
@@ -3530,7 +3574,7 @@ msgstr "Ereignisfilter"
 #: ../gramps/gen/filters/rules/person/_hasaddress.py:48
 #: ../gramps/gen/filters/rules/person/_hasassociation.py:48
 #: ../gramps/gen/filters/rules/source/_hasrepository.py:46
-#: ../gramps/gui/editors/filtereditor.py:514
+#: ../gramps/gui/editors/filtereditor.py:513
 msgid "Number must be:"
 msgstr "Die Anzahl muss sein:"
 
@@ -3541,14 +3585,14 @@ msgstr "Die Anzahl muss sein:"
 #: ../gramps/gen/filters/rules/person/_hasaddress.py:48
 #: ../gramps/gen/filters/rules/person/_hasassociation.py:48
 #: ../gramps/gen/filters/rules/source/_hasrepository.py:46
-#: ../gramps/gui/editors/filtereditor.py:509
+#: ../gramps/gui/editors/filtereditor.py:508
 msgid "Number of instances:"
 msgstr "Anzahl der Instanzen:"
 
 #: ../gramps/gen/filters/rules/_hasgrampsid.py:45
 #: ../gramps/gen/filters/rules/family/_isancestorof.py:44
 #: ../gramps/gen/filters/rules/family/_isdescendantof.py:44
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:121
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:125
 #: ../gramps/gen/filters/rules/person/_hascommonancestorwith.py:45
 #: ../gramps/gen/filters/rules/person/_isancestorof.py:44
 #: ../gramps/gen/filters/rules/person/_isdescendantfamilyof.py:49
@@ -3562,7 +3606,7 @@ msgstr "Anzahl der Instanzen:"
 #: ../gramps/gen/filters/rules/person/_matchidof.py:44
 #: ../gramps/gen/filters/rules/person/_relationshippathbetween.py:45
 #: ../gramps/gen/filters/rules/place/_isenclosedby.py:48
-#: ../gramps/gui/editors/filtereditor.py:518
+#: ../gramps/gui/editors/filtereditor.py:517
 #: ../gramps/gui/glade/editplaceref.glade:230
 msgid "ID:"
 msgstr "ID:"
@@ -3576,8 +3620,8 @@ msgstr "ID:"
 #: ../gramps/gen/filters/rules/repository/_matchesnamesubstringof.py:42
 #: ../gramps/gen/filters/rules/source/_hasrepositorycallnumberref.py:43
 #: ../gramps/gen/filters/rules/source/_matchestitlesubstringof.py:42
-#: ../gramps/gui/glade/mergenote.glade:213
-#: ../gramps/gui/glade/mergenote.glade:229
+#: ../gramps/gui/glade/mergenote.glade:212
+#: ../gramps/gui/glade/mergenote.glade:228
 msgid "Text:"
 msgstr "Text:"
 
@@ -3591,12 +3635,12 @@ msgid "Substring:"
 msgstr "Teilzeichenfolge:"
 
 #: ../gramps/gen/filters/rules/_hasreferencecountbase.py:42
-#: ../gramps/gui/editors/filtereditor.py:512
+#: ../gramps/gui/editors/filtereditor.py:511
 msgid "Reference count must be:"
 msgstr "Referenzenanzahl muss sein:"
 
 #: ../gramps/gen/filters/rules/_hasreferencecountbase.py:42
-#: ../gramps/gui/editors/filtereditor.py:508
+#: ../gramps/gui/editors/filtereditor.py:507
 msgid "Reference count:"
 msgstr "Anzahl Referenzen:"
 
@@ -3605,12 +3649,12 @@ msgstr "Anzahl Referenzen:"
 #: ../gramps/gen/filters/rules/media/_hassourceof.py:45
 #: ../gramps/gen/filters/rules/person/_hassourceof.py:45
 #: ../gramps/gen/filters/rules/place/_hassourceof.py:45
-#: ../gramps/gui/editors/filtereditor.py:521
+#: ../gramps/gui/editors/filtereditor.py:520
 msgid "Source ID:"
 msgstr "Quellen-ID:"
 
 #: ../gramps/gen/filters/rules/_matchesfilterbase.py:54
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:121
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:125
 #: ../gramps/gen/filters/rules/person/_hascommonancestorwithfiltermatch.py:47
 #: ../gramps/gen/filters/rules/person/_isancestoroffiltermatch.py:46
 #: ../gramps/gen/filters/rules/person/_ischildoffiltermatch.py:46
@@ -3619,7 +3663,7 @@ msgstr "Quellen-ID:"
 #: ../gramps/gen/filters/rules/person/_isparentoffiltermatch.py:46
 #: ../gramps/gen/filters/rules/person/_issiblingoffiltermatch.py:45
 #: ../gramps/gen/filters/rules/person/_isspouseoffiltermatch.py:46
-#: ../gramps/gui/editors/filtereditor.py:523
+#: ../gramps/gui/editors/filtereditor.py:522
 msgid "Filter name:"
 msgstr "Filtername:"
 
@@ -3632,7 +3676,7 @@ msgstr "Kann den Filter %s in den Anwenderfiltern nicht finden."
 #: ../gramps/gen/filters/rules/_matchessourcefilterbase.py:47
 #: ../gramps/gen/filters/rules/citation/_matchessourcefilter.py:48
 #: ../gramps/gen/filters/rules/event/_matchessourcefilter.py:48
-#: ../gramps/gui/editors/filtereditor.py:531
+#: ../gramps/gui/editors/filtereditor.py:530
 msgid "Source filter name:"
 msgstr "Quellenfiltername:"
 
@@ -3640,9 +3684,9 @@ msgstr "Quellenfiltername:"
 msgid "Miscellaneous filters"
 msgstr "Verschiedene Filter"
 
-#: ../gramps/gen/filters/rules/_rule.py:54 ../gramps/gui/glade/rule.glade:953
+#: ../gramps/gen/filters/rules/_rule.py:54 ../gramps/gui/glade/rule.glade:950
 #: ../gramps/plugins/view/geoclose.py:533
-#: ../gramps/plugins/view/geofamclose.py:725
+#: ../gramps/plugins/view/geofamclose.py:724
 #: ../gramps/plugins/view/geofamily.py:478
 #: ../gramps/plugins/view/geomoves.py:609
 #: ../gramps/plugins/view/geoperson.py:491
@@ -3713,7 +3757,7 @@ msgstr "Liefert Fundstellen, die als vertraulich markiert sind."
 #: ../gramps/gen/filters/rules/person/_matchessourceconfidence.py:43
 #: ../gramps/gen/filters/rules/place/_hascitation.py:50
 #: ../gramps/gen/filters/rules/place/_matchessourceconfidence.py:43
-#: ../gramps/gui/editors/filtereditor.py:577
+#: ../gramps/gui/editors/filtereditor.py:576
 msgid "Confidence level:"
 msgstr "Vertrauensgrad:"
 
@@ -3779,38 +3823,38 @@ msgstr "Passt auf Fundstellen mit einer bestimmten Anzahl von Referenzen"
 #: ../gramps/gui/glade/editplaceref.glade:200
 #: ../gramps/gui/glade/mergedata.glade:759
 #: ../gramps/gui/glade/mergedata.glade:775
-#: ../gramps/gui/glade/mergemedia.glade:213
-#: ../gramps/gui/glade/mergemedia.glade:229
-#: ../gramps/gui/glade/mergeplace.glade:206
-#: ../gramps/gui/glade/mergeplace.glade:221
-#: ../gramps/gui/glade/mergesource.glade:213
-#: ../gramps/gui/glade/mergesource.glade:229
+#: ../gramps/gui/glade/mergemedia.glade:212
+#: ../gramps/gui/glade/mergemedia.glade:228
+#: ../gramps/gui/glade/mergeplace.glade:205
+#: ../gramps/gui/glade/mergeplace.glade:220
+#: ../gramps/gui/glade/mergesource.glade:212
+#: ../gramps/gui/glade/mergesource.glade:228
 msgid "Title:"
 msgstr "Titel:"
 
 #: ../gramps/gen/filters/rules/citation/_hassource.py:49
-#: ../gramps/gui/glade/editcitation.glade:396
+#: ../gramps/gui/glade/editcitation.glade:395
 #: ../gramps/gui/glade/mergedata.glade:792
 #: ../gramps/gui/glade/mergedata.glade:808
-#: ../gramps/gui/glade/mergesource.glade:246
-#: ../gramps/gui/glade/mergesource.glade:262
-#: ../gramps/gui/glade/plugins.glade:192
+#: ../gramps/gui/glade/mergesource.glade:245
+#: ../gramps/gui/glade/mergesource.glade:261
+#: ../gramps/gui/glade/plugins.glade:190
 msgid "Author:"
 msgstr "Autor:"
 
 #: ../gramps/gen/filters/rules/citation/_hassource.py:50
 #: ../gramps/gui/glade/mergedata.glade:825
 #: ../gramps/gui/glade/mergedata.glade:841
-#: ../gramps/gui/glade/mergesource.glade:279
-#: ../gramps/gui/glade/mergesource.glade:295
+#: ../gramps/gui/glade/mergesource.glade:278
+#: ../gramps/gui/glade/mergesource.glade:294
 msgid "Abbreviation:"
 msgstr "Abkürzung:"
 
 #: ../gramps/gen/filters/rules/citation/_hassource.py:51
 #: ../gramps/gui/glade/mergedata.glade:858
 #: ../gramps/gui/glade/mergedata.glade:874
-#: ../gramps/gui/glade/mergesource.glade:312
-#: ../gramps/gui/glade/mergesource.glade:328
+#: ../gramps/gui/glade/mergesource.glade:311
+#: ../gramps/gui/glade/mergesource.glade:327
 msgid "Publication:"
 msgstr "Veröffentlichung:"
 
@@ -3858,7 +3902,7 @@ msgstr ""
 #: ../gramps/gen/filters/rules/place/_hastag.py:48
 #: ../gramps/gen/filters/rules/repository/_hastag.py:48
 #: ../gramps/gen/filters/rules/source/_hastag.py:48
-#: ../gramps/gui/editors/filtereditor.py:573
+#: ../gramps/gui/editors/filtereditor.py:572
 msgid "Tag:"
 msgstr "Markierung:"
 
@@ -3889,7 +3933,7 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/citation/_matchesrepositoryfilter.py:45
 #: ../gramps/gen/filters/rules/source/_matchesrepositoryfilter.py:43
-#: ../gramps/gui/editors/filtereditor.py:533
+#: ../gramps/gui/editors/filtereditor.py:532
 msgid "Repository filter name:"
 msgstr "Aufbewahrungsortfiltername:"
 
@@ -3972,7 +4016,7 @@ msgstr "Liefert Ereignisse, die als vertraulich markiert sind."
 
 #: ../gramps/gen/filters/rules/event/_hasattribute.py:44
 #: ../gramps/gui/editors/filtereditor.py:106
-#: ../gramps/gui/editors/filtereditor.py:546
+#: ../gramps/gui/editors/filtereditor.py:545
 msgid "Event attribute:"
 msgstr "Ereignisattribut:"
 
@@ -4004,7 +4048,7 @@ msgstr "Passt auf Ereignisse mit einer Fundstelle mit einem bestimmten Wert"
 #: ../gramps/gen/filters/rules/event/_hastype.py:45
 #: ../gramps/gen/filters/rules/person/_iswitness.py:44
 #: ../gramps/gui/editors/filtereditor.py:103
-#: ../gramps/gui/editors/filtereditor.py:539
+#: ../gramps/gui/editors/filtereditor.py:538
 msgid "Event type:"
 msgstr "Ereignisart:"
 
@@ -4014,9 +4058,9 @@ msgstr "Ereignisart:"
 #: ../gramps/gen/filters/rules/person/_hasdeath.py:48
 #: ../gramps/gen/filters/rules/person/_hasevent.py:50
 #: ../gramps/gen/filters/rules/person/_hasfamilyevent.py:50
-#: ../gramps/gui/editors/filtereditor.py:506
-#: ../gramps/gui/glade/mergeevent.glade:279
-#: ../gramps/gui/glade/mergeevent.glade:295
+#: ../gramps/gui/editors/filtereditor.py:505
+#: ../gramps/gui/glade/mergeevent.glade:278
+#: ../gramps/gui/glade/mergeevent.glade:294
 msgid "Place:"
 msgstr "Ort:"
 
@@ -4026,8 +4070,8 @@ msgstr "Ort:"
 #: ../gramps/gen/filters/rules/person/_hasdeath.py:48
 #: ../gramps/gen/filters/rules/person/_hasevent.py:51
 #: ../gramps/gen/filters/rules/person/_hasfamilyevent.py:51
-#: ../gramps/gui/glade/mergeevent.glade:312
-#: ../gramps/gui/glade/mergeevent.glade:328
+#: ../gramps/gui/glade/mergeevent.glade:311
+#: ../gramps/gui/glade/mergeevent.glade:327
 msgid "Description:"
 msgstr "Beschreibung:"
 
@@ -4040,7 +4084,7 @@ msgid "Matches events with data of a particular value"
 msgstr "Passt auf Ereignisse mit Daten mit einem bestimmten Wert"
 
 #: ../gramps/gen/filters/rules/event/_hasdayofweek.py:44
-#: ../gramps/gui/editors/filtereditor.py:582
+#: ../gramps/gui/editors/filtereditor.py:581
 msgid "Day of Week:"
 msgstr "Tag der Woche:"
 
@@ -4141,13 +4185,13 @@ msgid "Matches events matched by the specified filter name"
 msgstr "Liefert Ereignisse, die dem gegebenen Filter entsprechen."
 
 #: ../gramps/gen/filters/rules/event/_matchespersonfilter.py:50
-#: ../gramps/gui/editors/filtereditor.py:568
+#: ../gramps/gui/editors/filtereditor.py:567
 msgid "Include Family events:"
 msgstr "Familienereignisse aufnehmen:"
 
 #. filters of another namespace, name may be same as caller!
 #: ../gramps/gen/filters/rules/event/_matchespersonfilter.py:50
-#: ../gramps/gui/editors/filtereditor.py:527
+#: ../gramps/gui/editors/filtereditor.py:526
 msgid "Person filter name:"
 msgstr "Personenfiltername:"
 
@@ -4162,7 +4206,7 @@ msgstr ""
 "entsprechen."
 
 #: ../gramps/gen/filters/rules/event/_matchesplacefilter.py:49
-#: ../gramps/gui/editors/filtereditor.py:535
+#: ../gramps/gui/editors/filtereditor.py:534
 msgid "Place filter name:"
 msgstr "Ortefiltername:"
 
@@ -4207,7 +4251,7 @@ msgstr ""
 "Liefert alle Ereignisse, deren Gramps ID dem regulären Ausdruck entspricht"
 
 #: ../gramps/gen/filters/rules/family/_allfamilies.py:44
-#: ../gramps/gen/plug/report/utils.py:369
+#: ../gramps/gen/plug/report/utils.py:376
 msgid "Every family"
 msgstr "Jede Familie"
 
@@ -4294,7 +4338,7 @@ msgstr ""
 #: ../gramps/gen/filters/rules/family/_hasattribute.py:44
 #: ../gramps/gen/filters/rules/person/_hasfamilyattribute.py:44
 #: ../gramps/gui/editors/filtereditor.py:105
-#: ../gramps/gui/editors/filtereditor.py:544
+#: ../gramps/gui/editors/filtereditor.py:543
 msgid "Family attribute:"
 msgstr "Attribut einer Familie:"
 
@@ -4317,13 +4361,13 @@ msgstr "Passt auf Familien mit einer Fundstelle mit einem bestimmten Wert"
 #: ../gramps/gen/filters/rules/family/_hasevent.py:47
 #: ../gramps/gen/filters/rules/person/_hasfamilyevent.py:48
 #: ../gramps/gui/editors/filtereditor.py:102
-#: ../gramps/gui/editors/filtereditor.py:540
+#: ../gramps/gui/editors/filtereditor.py:539
 msgid "Family event:"
 msgstr "Familiäres Ereignis:"
 
 #: ../gramps/gen/filters/rules/family/_hasevent.py:51
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:83
-#: ../gramps/gui/selectors/selectevent.py:71
+#: ../gramps/gui/selectors/selectevent.py:70
 #: ../gramps/plugins/gramplet/events.py:92
 #: ../gramps/plugins/view/eventview.py:90
 msgid "Main Participants"
@@ -4401,7 +4445,7 @@ msgstr "Liefert Familienobjekte mir vorgegebener Referenzenanzahl"
 #: ../gramps/gen/filters/rules/family/_hasreltype.py:45
 #: ../gramps/gen/filters/rules/person/_hasrelationship.py:46
 #: ../gramps/gui/editors/filtereditor.py:108
-#: ../gramps/gui/editors/filtereditor.py:550
+#: ../gramps/gui/editors/filtereditor.py:549
 msgid "Relationship type:"
 msgstr "Beziehungsart:"
 
@@ -4453,7 +4497,7 @@ msgstr "Liefert Familien mit Zwillingen"
 #: ../gramps/gen/filters/rules/person/_isdescendantfamilyof.py:49
 #: ../gramps/gen/filters/rules/person/_isdescendantof.py:45
 #: ../gramps/gen/filters/rules/place/_isenclosedby.py:48
-#: ../gramps/gui/editors/filtereditor.py:562
+#: ../gramps/gui/editors/filtereditor.py:561
 msgid "Inclusive:"
 msgstr "Einschließlich:"
 
@@ -4607,7 +4651,7 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/media/_hasattribute.py:44
 #: ../gramps/gui/editors/filtereditor.py:107
-#: ../gramps/gui/editors/filtereditor.py:548
+#: ../gramps/gui/editors/filtereditor.py:547
 msgid "Media attribute:"
 msgstr "Medienattribut:"
 
@@ -4640,20 +4684,20 @@ msgstr "Liefert ein Medienobjekt mit einer bestimmten Gramps-ID"
 #: ../gramps/gui/glade/editmediaref.glade:521
 #: ../gramps/gui/glade/editplace.glade:300
 #: ../gramps/gui/glade/editplaceref.glade:303
-#: ../gramps/gui/glade/mergeevent.glade:213
-#: ../gramps/gui/glade/mergeevent.glade:229
-#: ../gramps/gui/glade/mergenote.glade:246
-#: ../gramps/gui/glade/mergenote.glade:262
-#: ../gramps/gui/glade/mergeplace.glade:486
-#: ../gramps/gui/glade/mergeplace.glade:503
-#: ../gramps/gui/glade/mergerepository.glade:246
-#: ../gramps/gui/glade/mergerepository.glade:262
+#: ../gramps/gui/glade/mergeevent.glade:212
+#: ../gramps/gui/glade/mergeevent.glade:228
+#: ../gramps/gui/glade/mergenote.glade:245
+#: ../gramps/gui/glade/mergenote.glade:261
+#: ../gramps/gui/glade/mergeplace.glade:485
+#: ../gramps/gui/glade/mergeplace.glade:502
+#: ../gramps/gui/glade/mergerepository.glade:245
+#: ../gramps/gui/glade/mergerepository.glade:261
 msgid "Type:"
 msgstr "Typ:"
 
 #: ../gramps/gen/filters/rules/media/_hasmedia.py:48
-#: ../gramps/gui/glade/mergemedia.glade:246
-#: ../gramps/gui/glade/mergemedia.glade:262 ../gramps/gui/viewmanager.py:1226
+#: ../gramps/gui/glade/mergemedia.glade:245
+#: ../gramps/gui/glade/mergemedia.glade:261 ../gramps/gui/viewmanager.py:1298
 msgid "Path:"
 msgstr "Pfad:"
 
@@ -4785,7 +4829,7 @@ msgstr "Liefert eine Notiz mit einer bestimmten Gramps-ID"
 #: ../gramps/gen/filters/rules/note/_hasnote.py:47
 #: ../gramps/gen/filters/rules/note/_hastype.py:45
 #: ../gramps/gui/editors/filtereditor.py:109
-#: ../gramps/gui/editors/filtereditor.py:552
+#: ../gramps/gui/editors/filtereditor.py:551
 msgid "Note type:"
 msgstr "Notiztyp:"
 
@@ -4884,19 +4928,19 @@ msgstr "Erstelle einen Unterfilter"
 msgid "Retrieving all sub-filter matches"
 msgstr "Rufe alle Unterfiltertreffer ab"
 
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:122
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:126
 msgid "Relationship path between <person> and people matching <filter>"
 msgstr ""
 "Verwandtschaftspfad zwischen <Person> und Personen entsprechend <Filter>"
 
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:123
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:127
 #: ../gramps/gen/filters/rules/person/_isrelatedwith.py:46
 #: ../gramps/gen/filters/rules/person/_relationshippathbetween.py:47
 #: ../gramps/gen/filters/rules/person/_relationshippathbetweenbookmarks.py:52
 msgid "Relationship filters"
 msgstr "Verwandtschaftsfilter"
 
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:124
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:128
 msgid ""
 "Searches over the database starting from a specified person and returns "
 "everyone between that person and a set of target people specified with a "
@@ -4911,11 +4955,12 @@ msgstr ""
 "Angeheirateten herangezogen werden, sind die einzelnen Pfade nicht unbedingt "
 "die kürzesten. ;-)"
 
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:136
+#. TODO no-parent
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:141
 msgid "Finding relationship paths"
 msgstr "Finde Verwandtschaftspfade"
 
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:137
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:142
 msgid "Evaluating people"
 msgstr "Bewerte Personen"
 
@@ -4974,7 +5019,7 @@ msgstr "Entspricht Personen, mit einer bestimmten Anzahl von Verbindungen"
 
 #: ../gramps/gen/filters/rules/person/_hasattribute.py:44
 #: ../gramps/gui/editors/filtereditor.py:104
-#: ../gramps/gui/editors/filtereditor.py:542
+#: ../gramps/gui/editors/filtereditor.py:541
 msgid "Personal attribute:"
 msgstr "Attribut einer Person:"
 
@@ -5047,7 +5092,7 @@ msgstr "Entspricht den Personen mit bestimmten Todesdaten"
 
 #: ../gramps/gen/filters/rules/person/_hasevent.py:48
 #: ../gramps/gui/editors/filtereditor.py:101
-#: ../gramps/gui/editors/filtereditor.py:539
+#: ../gramps/gui/editors/filtereditor.py:538
 msgid "Personal event:"
 msgstr "Persönliches Ereignis:"
 
@@ -5056,7 +5101,7 @@ msgid "Main Participants:"
 msgstr "Hauptbeteiligte:"
 
 #: ../gramps/gen/filters/rules/person/_hasevent.py:53
-#: ../gramps/gui/editors/filtereditor.py:571
+#: ../gramps/gui/editors/filtereditor.py:570
 msgid "Primary Role:"
 msgstr "Hauptrolle:"
 
@@ -5167,7 +5212,7 @@ msgstr "Entspricht Personen mit einem bestimmten Namen oder Namensteil"
 
 #: ../gramps/gen/filters/rules/person/_hasnameorigintype.py:46
 #: ../gramps/gui/editors/filtereditor.py:111
-#: ../gramps/gui/editors/filtereditor.py:556
+#: ../gramps/gui/editors/filtereditor.py:555
 msgid "Surname origin type:"
 msgstr "Nachnamenherkunftsart:"
 
@@ -5181,7 +5226,7 @@ msgstr "Entspricht Personen mit einer Nachnamenherkunft"
 
 #: ../gramps/gen/filters/rules/person/_hasnametype.py:46
 #: ../gramps/gui/editors/filtereditor.py:110
-#: ../gramps/gui/editors/filtereditor.py:554
+#: ../gramps/gui/editors/filtereditor.py:553
 msgid "Name type:"
 msgstr "Namenstyp:"
 
@@ -5285,7 +5330,7 @@ msgid "Matches people with the particular tag"
 msgstr "Entspricht Personen mit der vorgegebenen Markierung."
 
 #: ../gramps/gen/filters/rules/person/_hastextmatchingsubstringof.py:47
-#: ../gramps/gui/editors/filtereditor.py:564
+#: ../gramps/gui/editors/filtereditor.py:563
 msgid "Case sensitive:"
 msgstr "Groß-/Kleinschreibung:"
 
@@ -5435,9 +5480,11 @@ msgstr ""
 "festgelegten Person sind"
 
 #: ../gramps/gen/filters/rules/person/_isfemale.py:45
-#: ../gramps/plugins/gramplet/statsgramplet.py:107
-#: ../gramps/plugins/graph/gvfamilylines.py:255
-#: ../gramps/plugins/graph/gvrelgraph.py:784
+#: ../gramps/plugins/gramplet/statsgramplet.py:108
+#: ../gramps/plugins/graph/gvfamilylines.py:263
+#: ../gramps/plugins/graph/gvrelgraph.py:787
+#: ../gramps/plugins/webreport/narrativeweb.py:8099
+#: ../gramps/plugins/webreport/narrativeweb.py:8165
 msgid "Females"
 msgstr "Frauen"
 
@@ -5451,7 +5498,7 @@ msgstr "Entspricht allen Frauen"
 #: ../gramps/gen/filters/rules/person/_islessthannthgenerationdescendantof.py:45
 #: ../gramps/gen/filters/rules/person/_ismorethannthgenerationancestorof.py:45
 #: ../gramps/gen/filters/rules/person/_ismorethannthgenerationdescendantof.py:45
-#: ../gramps/gui/editors/filtereditor.py:516
+#: ../gramps/gui/editors/filtereditor.py:515
 msgid "Number of generations:"
 msgstr "Anzahl der Generationen:"
 
@@ -5507,9 +5554,11 @@ msgstr ""
 
 #. -------------------------
 #: ../gramps/gen/filters/rules/person/_ismale.py:45
-#: ../gramps/plugins/gramplet/statsgramplet.py:104
-#: ../gramps/plugins/graph/gvfamilylines.py:251
-#: ../gramps/plugins/graph/gvrelgraph.py:780
+#: ../gramps/plugins/gramplet/statsgramplet.py:105
+#: ../gramps/plugins/graph/gvfamilylines.py:259
+#: ../gramps/plugins/graph/gvrelgraph.py:783
+#: ../gramps/plugins/webreport/narrativeweb.py:8097
+#: ../gramps/plugins/webreport/narrativeweb.py:8163
 msgid "Males"
 msgstr "Männer"
 
@@ -5587,7 +5636,7 @@ msgstr "Entspricht Personen, die bei einem Ereignis Zeuge sind."
 
 #: ../gramps/gen/filters/rules/person/_matcheseventfilter.py:51
 #: ../gramps/gen/filters/rules/place/_matcheseventfilter.py:49
-#: ../gramps/gui/editors/filtereditor.py:529
+#: ../gramps/gui/editors/filtereditor.py:528
 msgid "Event filter name:"
 msgstr "Ereignisfiltername:"
 
@@ -5784,25 +5833,25 @@ msgstr "Entspricht Orten mit einer Fundstelle mit dem vorgebenen Wert."
 #: ../gramps/gui/glade/editfamily.glade:372
 #: ../gramps/gui/glade/editplacename.glade:183
 #: ../gramps/gui/glade/editplaceref.glade:214
-#: ../gramps/gui/glade/mergeperson.glade:224
-#: ../gramps/gui/glade/mergeperson.glade:240
-#: ../gramps/gui/glade/mergeplace.glade:426
-#: ../gramps/gui/glade/mergeplace.glade:443
+#: ../gramps/gui/glade/mergeperson.glade:222
+#: ../gramps/gui/glade/mergeperson.glade:238
+#: ../gramps/gui/glade/mergeplace.glade:425
+#: ../gramps/gui/glade/mergeplace.glade:442
 #: ../gramps/plugins/gramplet/soundgen.py:65
 msgid "Name:"
 msgstr "Name:"
 
 #: ../gramps/gen/filters/rules/place/_hasdata.py:49
 #: ../gramps/gui/editors/filtereditor.py:112
-#: ../gramps/gui/editors/filtereditor.py:558
+#: ../gramps/gui/editors/filtereditor.py:557
 msgid "Place type:"
 msgstr "Ortstyp:"
 
 #: ../gramps/gen/filters/rules/place/_hasdata.py:50
 #: ../gramps/gui/glade/editplace.glade:213
 #: ../gramps/gui/glade/editplaceref.glade:444
-#: ../gramps/gui/glade/mergeplace.glade:546
-#: ../gramps/gui/glade/mergeplace.glade:563
+#: ../gramps/gui/glade/mergeplace.glade:545
+#: ../gramps/gui/glade/mergeplace.glade:562
 msgid "Code:"
 msgstr "Kennung:"
 
@@ -5950,15 +5999,15 @@ msgstr "Liefert Orte mit einem bestimmten Titel"
 
 #: ../gramps/gen/filters/rules/place/_inlatlonneighborhood.py:49
 #: ../gramps/gui/glade/editplaceref.glade:244
-#: ../gramps/gui/glade/mergeplace.glade:237
-#: ../gramps/gui/glade/mergeplace.glade:252
+#: ../gramps/gui/glade/mergeplace.glade:236
+#: ../gramps/gui/glade/mergeplace.glade:251
 msgid "Latitude:"
 msgstr "Breitengrad:"
 
 #: ../gramps/gen/filters/rules/place/_inlatlonneighborhood.py:49
 #: ../gramps/gui/glade/editplaceref.glade:317
-#: ../gramps/gui/glade/mergeplace.glade:268
-#: ../gramps/gui/glade/mergeplace.glade:283
+#: ../gramps/gui/glade/mergeplace.glade:267
+#: ../gramps/gui/glade/mergeplace.glade:282
 msgid "Longitude:"
 msgstr "Längengrad:"
 
@@ -6097,8 +6146,8 @@ msgid "Matches repositories with a certain reference count"
 msgstr "Entspricht Aufbewahrungsorten mit gegebener Anzahl von Referenzen."
 
 #: ../gramps/gen/filters/rules/repository/_hasrepo.py:46
-#: ../gramps/gui/glade/mergerepository.glade:213
-#: ../gramps/gui/glade/mergerepository.glade:229
+#: ../gramps/gui/glade/mergerepository.glade:212
+#: ../gramps/gui/glade/mergerepository.glade:228
 #: ../gramps/gui/merge/mergerepository.py:46
 msgid "repo|Name:"
 msgstr "Name:"
@@ -6322,11 +6371,12 @@ msgstr "Entspricht Quellen, die als vertraulich markiert sind."
 #: ../gramps/gen/lib/eventroletype.py:53 ../gramps/gen/lib/eventtype.py:163
 #: ../gramps/gen/lib/familyreltype.py:48 ../gramps/gen/lib/markertype.py:52
 #: ../gramps/gen/lib/nameorigintype.py:74 ../gramps/gen/lib/nametype.py:47
-#: ../gramps/gen/lib/notetype.py:72 ../gramps/gen/lib/placetype.py:64
+#: ../gramps/gen/lib/notetype.py:74 ../gramps/gen/lib/placetype.py:64
 #: ../gramps/gen/lib/repotype.py:53 ../gramps/gen/lib/srcattrtype.py:44
 #: ../gramps/gen/lib/srcmediatype.py:57 ../gramps/gen/lib/urltype.py:48
 #: ../gramps/gui/autocomp.py:179
-#: ../gramps/plugins/textreport/indivcomplete.py:73
+#: ../gramps/plugins/textreport/indivcomplete.py:75
+#: ../gramps/plugins/view/geoplaces.py:528
 msgid "Custom"
 msgstr "Selbst definiert"
 
@@ -6338,22 +6388,23 @@ msgstr "Gesellschaftsklasse"
 #: ../gramps/gen/lib/attrtype.py:65 ../gramps/gen/lib/media.py:197
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:75
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:67
-#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:101
-#: ../gramps/gui/glade/rule.glade:934
-#: ../gramps/gui/glade/styleeditor.glade:262
+#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:104
+#: ../gramps/gui/glade/rule.glade:931 ../gramps/gui/glade/styleeditor.glade:262
 #: ../gramps/gui/plug/_windows.py:130 ../gramps/gui/plug/_windows.py:239
-#: ../gramps/gui/plug/_windows.py:607 ../gramps/gui/plug/_windows.py:1084
-#: ../gramps/gui/selectors/selectevent.py:74
+#: ../gramps/gui/plug/_windows.py:612 ../gramps/gui/plug/_windows.py:1095
+#: ../gramps/gui/selectors/selectevent.py:73
+#: ../gramps/plugins/gramplet/coordinates.py:90
 #: ../gramps/plugins/gramplet/events.py:86
-#: ../gramps/plugins/lib/libmetadata.py:98
+#: ../gramps/plugins/lib/libmetadata.py:100
 #: ../gramps/plugins/textreport/placereport.py:221
 #: ../gramps/plugins/textreport/placereport.py:298
 #: ../gramps/plugins/tool/sortevents.py:57
 #: ../gramps/plugins/view/eventview.py:82
-#: ../gramps/plugins/webreport/narrativeweb.py:372
-#: ../gramps/plugins/webreport/narrativeweb.py:1038
-#: ../gramps/plugins/webreport/narrativeweb.py:1324
-#: ../gramps/plugins/webreport/narrativeweb.py:2473
+#: ../gramps/plugins/webreport/narrativeweb.py:992
+#: ../gramps/plugins/webreport/narrativeweb.py:1280
+#: ../gramps/plugins/webreport/narrativeweb.py:2459
+#: ../gramps/plugins/webreport/narrativeweb.py:3103
+#: ../gramps/plugins/webreport/narrativeweb.py:5863
 msgid "Description"
 msgstr "Beschreibung"
 
@@ -6374,9 +6425,9 @@ msgid "Social Security Number"
 msgstr "Sozialversicherungsnummer"
 
 #: ../gramps/gen/lib/attrtype.py:70 ../gramps/gen/utils/keyword.py:72
-#: ../gramps/gui/configure.py:643 ../gramps/gui/configure.py:645
-#: ../gramps/gui/configure.py:650 ../gramps/gui/configure.py:657
-#: ../gramps/plugins/tool/patchnames.py:429
+#: ../gramps/gui/configure.py:648 ../gramps/gui/configure.py:650
+#: ../gramps/gui/configure.py:655 ../gramps/gui/configure.py:662
+#: ../gramps/plugins/tool/patchnames.py:430
 msgid "Nickname"
 msgstr "Spitzname"
 
@@ -6413,34 +6464,33 @@ msgstr "Zeuge"
 msgid "Time"
 msgstr "Zeit"
 
-#: ../gramps/gen/lib/childreftype.py:67 ../gramps/gui/configure.py:79
+#: ../gramps/gen/lib/childreftype.py:67 ../gramps/gui/configure.py:81
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:209
-#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:172
+#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:175
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:199
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:155
-#: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:150
+#: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:154
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:245
-#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:172
-#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:167
+#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:176
+#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:171
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:154
-#: ../gramps/plugins/tool/check.py:2185
+#: ../gramps/plugins/tool/check.py:2410
 msgid "None"
 msgstr "Ohne"
 
 #: ../gramps/gen/lib/childreftype.py:68 ../gramps/gen/lib/eventtype.py:165
-#: ../gramps/gui/merge/mergeperson.py:184
+#: ../gramps/gui/merge/mergeperson.py:185
 #: ../gramps/plugins/gramplet/ancestor.py:64
 #: ../gramps/plugins/gramplet/descendant.py:63
 #: ../gramps/plugins/quickview/all_relations.py:270
 #: ../gramps/plugins/quickview/lineage.py:93
-#: ../gramps/plugins/textreport/familygroup.py:315
-#: ../gramps/plugins/textreport/familygroup.py:523
-#: ../gramps/plugins/textreport/familygroup.py:525
+#: ../gramps/plugins/textreport/familygroup.py:316
+#: ../gramps/plugins/textreport/familygroup.py:524
+#: ../gramps/plugins/textreport/familygroup.py:526
 #: ../gramps/plugins/textreport/tagreport.py:166
-#: ../gramps/plugins/view/relview.py:601
-#: ../gramps/plugins/webreport/narrativeweb.py:366
-#: ../gramps/plugins/webreport/narrativeweb.py:3258
-#: ../gramps/plugins/webreport/narrativeweb.py:6073
+#: ../gramps/plugins/view/relview.py:612
+#: ../gramps/plugins/webreport/narrativeweb.py:3252
+#: ../gramps/plugins/webreport/narrativeweb.py:6130
 msgid "Birth"
 msgstr "Geburt"
 
@@ -6466,17 +6516,17 @@ msgstr "Pflegekind"
 #. string if the person is None
 #.
 #. -------------------------------------------------------------------------
-#: ../gramps/gen/lib/date.py:273 ../gramps/gen/lib/date.py:415
+#: ../gramps/gen/lib/date.py:273 ../gramps/gen/lib/date.py:421
 #: ../gramps/gen/mime/_pythonmime.py:48 ../gramps/gen/mime/_pythonmime.py:56
 #: ../gramps/gen/mime/_winmime.py:57 ../gramps/gen/utils/db.py:523
-#: ../gramps/gui/editors/editperson.py:352
+#: ../gramps/gui/editors/editperson.py:351
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:89
 #: ../gramps/gui/merge/mergeperson.py:61
 #: ../gramps/gui/views/treemodels/peoplemodel.py:97
-#: ../gramps/plugins/textreport/indivcomplete.py:610
+#: ../gramps/plugins/textreport/indivcomplete.py:648
 #: ../gramps/plugins/tool/dumpgenderstats.py:35
-#: ../gramps/plugins/view/relview.py:637
-#: ../gramps/plugins/webreport/narrativeweb.py:6265
+#: ../gramps/plugins/view/relview.py:648
+#: ../gramps/plugins/webreport/narrativeweb.py:6329
 msgid "unknown"
 msgstr "Unbekannt"
 
@@ -6509,10 +6559,10 @@ msgid "between"
 msgstr "zwischen"
 
 #: ../gramps/gen/lib/date.py:297 ../gramps/gen/lib/date.py:341
-#: ../gramps/gen/lib/date.py:359 ../gramps/gui/merge/mergefamily.py:150
+#: ../gramps/gen/lib/date.py:359 ../gramps/gui/merge/mergefamily.py:155
 #: ../gramps/plugins/quickview/all_relations.py:282
-#: ../gramps/plugins/view/relview.py:977
-#: ../gramps/plugins/webreport/narrativeweb.py:1240
+#: ../gramps/plugins/view/relview.py:988
+#: ../gramps/plugins/webreport/narrativeweb.py:1195
 msgid "and"
 msgstr "und"
 
@@ -6527,7 +6577,7 @@ msgstr "mehr als etwa"
 #. translators: leave all/any {...} untranslated
 #. round up years
 #. translators: leave all/any {...} untranslated
-#: ../gramps/gen/lib/date.py:420 ../gramps/gen/lib/date.py:427
+#: ../gramps/gen/lib/date.py:426 ../gramps/gen/lib/date.py:433
 #, python-brace-format
 msgid "{number_of} year"
 msgid_plural "{number_of} years"
@@ -6537,12 +6587,12 @@ msgstr[1] "{number_of} Jahre"
 #. translators: needed for Arabic, ignore otherwise
 #. ok we have the children.  Make a title off of them
 #. translators: needed for Arabic, ignore otherwise
-#: ../gramps/gen/lib/date.py:434 ../gramps/gen/lib/date.py:445
+#: ../gramps/gen/lib/date.py:440 ../gramps/gen/lib/date.py:451
 #: ../gramps/gen/plug/report/endnotes.py:118
 #: ../gramps/gen/plug/report/endnotes.py:197
 #: ../gramps/gen/plug/report/endnotes.py:204
 #: ../gramps/gen/plug/report/endnotes.py:210
-#: ../gramps/plugins/drawreport/descendtree.py:350
+#: ../gramps/plugins/drawreport/descendtree.py:352
 #: ../gramps/plugins/gramplet/persondetails.py:231
 #: ../gramps/plugins/gramplet/whatsnext.py:370
 #: ../gramps/plugins/gramplet/whatsnext.py:392
@@ -6554,7 +6604,7 @@ msgid ", "
 msgstr ", "
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/gen/lib/date.py:436
+#: ../gramps/gen/lib/date.py:442
 #, python-brace-format
 msgid "{number_of} month"
 msgid_plural "{number_of} months"
@@ -6562,54 +6612,54 @@ msgstr[0] "{number_of} Monat"
 msgstr[1] "{number_of} Monate"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/gen/lib/date.py:447
+#: ../gramps/gen/lib/date.py:453
 #, python-brace-format
 msgid "{number_of} day"
 msgid_plural "{number_of} days"
 msgstr[0] "{number_of} Tag"
 msgstr[1] "{number_of} Tage"
 
-#: ../gramps/gen/lib/date.py:454
+#: ../gramps/gen/lib/date.py:460
 msgid "0 days"
 msgstr "0 Tage"
 
-#: ../gramps/gen/lib/date.py:1867
+#: ../gramps/gen/lib/date.py:1873
 msgid "date-quality|none"
 msgstr ""
 
-#: ../gramps/gen/lib/date.py:1868
+#: ../gramps/gen/lib/date.py:1874
 msgid "calculated"
 msgstr "berechnet"
 
-#: ../gramps/gen/lib/date.py:1868
+#: ../gramps/gen/lib/date.py:1874
 msgid "estimated"
 msgstr "geschätzt"
 
-#: ../gramps/gen/lib/date.py:1882
+#: ../gramps/gen/lib/date.py:1888
 msgid "date-modifier|none"
 msgstr ""
 
-#: ../gramps/gen/lib/date.py:1883 ../gramps/plugins/lib/libsubstkeyword.py:315
+#: ../gramps/gen/lib/date.py:1889 ../gramps/plugins/lib/libsubstkeyword.py:315
 msgid "about"
 msgstr "um"
 
-#: ../gramps/gen/lib/date.py:1883 ../gramps/plugins/lib/libsubstkeyword.py:314
+#: ../gramps/gen/lib/date.py:1889 ../gramps/plugins/lib/libsubstkeyword.py:314
 msgid "after"
 msgstr "nach"
 
-#: ../gramps/gen/lib/date.py:1883 ../gramps/plugins/lib/libsubstkeyword.py:314
+#: ../gramps/gen/lib/date.py:1889 ../gramps/plugins/lib/libsubstkeyword.py:314
 msgid "before"
 msgstr "vor"
 
-#: ../gramps/gen/lib/date.py:1884
+#: ../gramps/gen/lib/date.py:1890
 msgid "range"
 msgstr "Zeitraum"
 
-#: ../gramps/gen/lib/date.py:1884
+#: ../gramps/gen/lib/date.py:1890
 msgid "span"
 msgstr "Zeitspanne"
 
-#: ../gramps/gen/lib/date.py:1884
+#: ../gramps/gen/lib/date.py:1890
 msgid "textonly"
 msgstr "nur Text"
 
@@ -6655,14 +6705,13 @@ msgstr "Lebensereignisse"
 #. show "> Family: ..." and nothing else
 #. show "V Family: ..." and the rest
 #: ../gramps/gen/lib/eventtype.py:139 ../gramps/gui/clipboard.py:771
-#: ../gramps/gui/configure.py:531
+#: ../gramps/gui/configure.py:536
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:59
 #: ../gramps/gui/editors/displaytabs/personeventembedlist.py:52
-#: ../gramps/gui/editors/editfamily.py:499
-#: ../gramps/gui/editors/editlink.py:91
+#: ../gramps/gui/editors/editfamily.py:499 ../gramps/gui/editors/editlink.py:91
 #: ../gramps/gui/editors/filtereditor.py:294
 #: ../gramps/gui/glade/editldsord.glade:267
-#: ../gramps/plugins/export/exportcsv.py:541
+#: ../gramps/plugins/export/exportcsv.py:515
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:109
 #: ../gramps/plugins/importer/importcsv.py:210
 #: ../gramps/plugins/quickview/all_events.py:80
@@ -6671,9 +6720,9 @@ msgstr "Lebensereignisse"
 #: ../gramps/plugins/quickview/filterbyname.py:240
 #: ../gramps/plugins/quickview/quickview.gpr.py:200
 #: ../gramps/plugins/quickview/references.py:86
-#: ../gramps/plugins/view/relview.py:1368
-#: ../gramps/plugins/view/relview.py:1392
-#: ../gramps/plugins/webreport/narrativeweb.py:3505
+#: ../gramps/plugins/view/relview.py:1378
+#: ../gramps/plugins/view/relview.py:1402
+#: ../gramps/plugins/webreport/narrativeweb.py:3509
 msgid "Family"
 msgstr "Familie"
 
@@ -6698,28 +6747,27 @@ msgid "Legal"
 msgstr "Juristisch"
 
 #: ../gramps/gen/lib/eventtype.py:153 ../gramps/gen/lib/eventtype.py:195
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:437
-#: ../gramps/plugins/webreport/narrativeweb.py:3087
-#: ../gramps/plugins/webreport/narrativeweb.py:7856
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:460
+#: ../gramps/plugins/webreport/narrativeweb.py:3081
+#: ../gramps/plugins/webreport/narrativeweb.py:7927
 msgid "Residence"
 msgstr "Wohnort"
 
 #: ../gramps/gen/lib/eventtype.py:155 ../gramps/gui/glade/mergedata.glade:523
 #: ../gramps/gui/glade/mergedata.glade:610
-#: ../gramps/plugins/lib/maps/placeselection.py:134
-#: ../gramps/plugins/lib/maps/placeselection.py:185
+#: ../gramps/plugins/lib/maps/placeselection.py:135
+#: ../gramps/plugins/lib/maps/placeselection.py:186
 msgid "Other"
 msgstr "Andere"
 
-#: ../gramps/gen/lib/eventtype.py:166 ../gramps/gui/merge/mergeperson.py:188
-#: ../gramps/plugins/textreport/familygroup.py:323
-#: ../gramps/plugins/textreport/familygroup.py:529
-#: ../gramps/plugins/textreport/familygroup.py:531
+#: ../gramps/gen/lib/eventtype.py:166 ../gramps/gui/merge/mergeperson.py:189
+#: ../gramps/plugins/textreport/familygroup.py:324
+#: ../gramps/plugins/textreport/familygroup.py:530
+#: ../gramps/plugins/textreport/familygroup.py:532
 #: ../gramps/plugins/textreport/tagreport.py:172
-#: ../gramps/plugins/view/relview.py:610 ../gramps/plugins/view/relview.py:635
-#: ../gramps/plugins/webreport/narrativeweb.py:370
-#: ../gramps/plugins/webreport/narrativeweb.py:3262
-#: ../gramps/plugins/webreport/narrativeweb.py:6077
+#: ../gramps/plugins/view/relview.py:621 ../gramps/plugins/view/relview.py:646
+#: ../gramps/plugins/webreport/narrativeweb.py:3256
+#: ../gramps/plugins/webreport/narrativeweb.py:6134
 msgid "Death"
 msgstr "Tod"
 
@@ -6846,13 +6894,13 @@ msgstr "Pensionierung"
 msgid "Will"
 msgstr "Testament"
 
-#: ../gramps/gen/lib/eventtype.py:198 ../gramps/gui/merge/mergeperson.py:243
-#: ../gramps/plugins/export/exportcsv.py:498
+#: ../gramps/gen/lib/eventtype.py:198 ../gramps/gui/merge/mergeperson.py:244
+#: ../gramps/plugins/export/exportcsv.py:472
 #: ../gramps/plugins/importer/importcsv.py:218
-#: ../gramps/plugins/textreport/familygroup.py:401
-#: ../gramps/plugins/textreport/familygroup.py:410
-#: ../gramps/plugins/textreport/familygroup.py:601
-#: ../gramps/plugins/webreport/narrativeweb.py:3506
+#: ../gramps/plugins/textreport/familygroup.py:402
+#: ../gramps/plugins/textreport/familygroup.py:411
+#: ../gramps/plugins/textreport/familygroup.py:602
+#: ../gramps/plugins/webreport/narrativeweb.py:3510
 msgid "Marriage"
 msgstr "Hochzeit"
 
@@ -6877,7 +6925,7 @@ msgid "Engagement"
 msgstr "Verlobung"
 
 #: ../gramps/gen/lib/eventtype.py:204
-#: ../gramps/plugins/webreport/narrativeweb.py:3507
+#: ../gramps/plugins/webreport/narrativeweb.py:3511
 msgid "Divorce"
 msgstr "Scheidung"
 
@@ -6893,27 +6941,27 @@ msgstr "Annullierung"
 msgid "Alternate Marriage"
 msgstr "Alternative Hochzeit"
 
-#. cm2pt = ReportUtils.cm2pt
+#. cm2pt = utils.cm2pt
 #. ------------------------------------------------------------------------
 #.
 #. Constants
 #.
 #. ------------------------------------------------------------------------
 #: ../gramps/gen/lib/eventtype.py:211
-#: ../gramps/plugins/drawreport/ancestortree.py:60
-#: ../gramps/plugins/drawreport/descendtree.py:55
+#: ../gramps/plugins/drawreport/ancestortree.py:61
+#: ../gramps/plugins/drawreport/descendtree.py:57
 msgid "birth abbreviation|b."
 msgstr "*"
 
 #: ../gramps/gen/lib/eventtype.py:212
-#: ../gramps/plugins/drawreport/ancestortree.py:61
-#: ../gramps/plugins/drawreport/descendtree.py:56
+#: ../gramps/plugins/drawreport/ancestortree.py:62
+#: ../gramps/plugins/drawreport/descendtree.py:58
 msgid "death abbreviation|d."
 msgstr "†"
 
 #: ../gramps/gen/lib/eventtype.py:213
-#: ../gramps/plugins/drawreport/ancestortree.py:62
-#: ../gramps/plugins/drawreport/descendtree.py:57
+#: ../gramps/plugins/drawreport/ancestortree.py:63
+#: ../gramps/plugins/drawreport/descendtree.py:59
 msgid "marriage abbreviation|m."
 msgstr "oo"
 
@@ -7098,7 +7146,7 @@ msgid "Unmarried"
 msgstr "Unverheiratet"
 
 #: ../gramps/gen/lib/familyreltype.py:51
-#: ../gramps/plugins/webreport/webcal.py:2003
+#: ../gramps/plugins/webreport/webcal.py:2025
 msgid "Married"
 msgstr "Verheiratet"
 
@@ -7131,12 +7179,11 @@ msgstr ""
 msgid "Canceled"
 msgstr "Annulliert"
 
-#. ----------------------------------
 #: ../gramps/gen/lib/ldsord.py:105
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:114
 #: ../gramps/gui/glade/editchildref.glade:250
-#: ../gramps/gui/merge/mergeperson.py:247
-#: ../gramps/plugins/export/exportcsv.py:541
+#: ../gramps/gui/merge/mergeperson.py:248
+#: ../gramps/plugins/export/exportcsv.py:515
 #: ../gramps/plugins/gramplet/children.py:93
 #: ../gramps/plugins/gramplet/children.py:192
 #: ../gramps/plugins/importer/importcsv.py:209
@@ -7197,7 +7244,7 @@ msgstr "Zu erledigen"
 #. 2
 #. add media column
 #: ../gramps/gen/lib/media.py:192 ../gramps/gen/lib/media.py:193
-#: ../gramps/gen/lib/person.py:255 ../gramps/gui/clipboard.py:659
+#: ../gramps/gen/lib/person.py:223 ../gramps/gui/clipboard.py:659
 #: ../gramps/gui/editors/editlink.py:92
 #: ../gramps/gui/editors/filtereditor.py:298
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:110
@@ -7211,18 +7258,18 @@ msgstr "Zu erledigen"
 #: ../gramps/plugins/textreport/tagreport.py:553
 #: ../gramps/plugins/view/mediaview.py:129
 #: ../gramps/plugins/view/view.gpr.py:80 ../gramps/plugins/view/view.gpr.py:88
-#: ../gramps/plugins/webreport/narrativeweb.py:1904
-#: ../gramps/plugins/webreport/narrativeweb.py:1968
-#: ../gramps/plugins/webreport/narrativeweb.py:2029
-#: ../gramps/plugins/webreport/narrativeweb.py:2076
-#: ../gramps/plugins/webreport/narrativeweb.py:2376
-#: ../gramps/plugins/webreport/narrativeweb.py:5032
-#: ../gramps/plugins/webreport/narrativeweb.py:5229
+#: ../gramps/plugins/webreport/narrativeweb.py:1880
+#: ../gramps/plugins/webreport/narrativeweb.py:1946
+#: ../gramps/plugins/webreport/narrativeweb.py:2015
+#: ../gramps/plugins/webreport/narrativeweb.py:2062
+#: ../gramps/plugins/webreport/narrativeweb.py:2362
+#: ../gramps/plugins/webreport/narrativeweb.py:5082
+#: ../gramps/plugins/webreport/narrativeweb.py:5281
 msgid "Media"
 msgstr "Medien"
 
 #. #########################
-#: ../gramps/gen/lib/media.py:194 ../gramps/gen/lib/person.py:246
+#: ../gramps/gen/lib/media.py:194 ../gramps/gen/lib/person.py:214
 #: ../gramps/plugins/importer/importcsv.py:205
 #: ../gramps/plugins/quickview/filterbyname.py:154
 #: ../gramps/plugins/quickview/filterbyname.py:165
@@ -7240,13 +7287,16 @@ msgstr "Medien"
 #: ../gramps/plugins/quickview/filterbyname.py:264
 #: ../gramps/plugins/quickview/filterbyname.py:270
 #: ../gramps/plugins/quickview/filterbyname.py:276
-#: ../gramps/plugins/textreport/familygroup.py:735
+#: ../gramps/plugins/textreport/familygroup.py:739
 #: ../gramps/plugins/tool/findloop.py:103
 #: ../gramps/plugins/tool/findloop.py:107
-#: ../gramps/plugins/webreport/narrativeweb.py:4154
-#: ../gramps/plugins/webreport/narrativeweb.py:4362
-#: ../gramps/plugins/webreport/narrativeweb.py:4905
-#: ../gramps/plugins/webreport/narrativeweb.py:7761
+#: ../gramps/plugins/webreport/narrativeweb.py:2909
+#: ../gramps/plugins/webreport/narrativeweb.py:4197
+#: ../gramps/plugins/webreport/narrativeweb.py:4408
+#: ../gramps/plugins/webreport/narrativeweb.py:4956
+#: ../gramps/plugins/webreport/narrativeweb.py:5461
+#: ../gramps/plugins/webreport/narrativeweb.py:7294
+#: ../gramps/plugins/webreport/narrativeweb.py:7830
 msgid "Gramps ID"
 msgstr "Gramps ID"
 
@@ -7258,63 +7308,57 @@ msgstr "MIME"
 msgid "Checksum"
 msgstr "Prüfsumme"
 
-#. there is no need to add an ending "</script>",
-#. as it will be added automatically by libhtml()
-#. Translatable strings for variables within this plugin
-#. gettext carries a huge footprint with it.
-#: ../gramps/gen/lib/media.py:199 ../gramps/gen/lib/person.py:257
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:563
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:577
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:591
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:605
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:619
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:633
-#: ../gramps/plugins/textreport/indivcomplete.py:423
-#: ../gramps/plugins/textreport/indivcomplete.py:639
-#: ../gramps/plugins/webreport/narrativeweb.py:365
-#: ../gramps/plugins/webreport/narrativeweb.py:844
-#: ../gramps/plugins/webreport/narrativeweb.py:1404
-#: ../gramps/plugins/webreport/narrativeweb.py:1655
+#: ../gramps/gen/lib/media.py:199 ../gramps/gen/lib/person.py:225
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:586
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:600
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:614
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:628
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:642
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:656
+#: ../gramps/plugins/textreport/indivcomplete.py:458
+#: ../gramps/plugins/textreport/indivcomplete.py:677
+#: ../gramps/plugins/webreport/narrativeweb.py:798
+#: ../gramps/plugins/webreport/narrativeweb.py:1361
+#: ../gramps/plugins/webreport/narrativeweb.py:1617
 msgid "Attributes"
 msgstr "Attribute"
 
 #: ../gramps/gen/lib/media.py:200 ../gramps/gen/lib/name.py:201
-#: ../gramps/gen/lib/person.py:260
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:759
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:773
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:787
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:801
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:815
+#: ../gramps/gen/lib/person.py:228
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:782
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:796
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:810
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:824
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:838
 #: ../gramps/plugins/textreport/tagreport.py:802
-#: ../gramps/plugins/view/view.gpr.py:266
-#: ../gramps/plugins/view/view.gpr.py:274
+#: ../gramps/plugins/view/view.gpr.py:281
+#: ../gramps/plugins/view/view.gpr.py:289
 msgid "Citations"
 msgstr "Fundstellen"
 
 #: ../gramps/gen/lib/media.py:201 ../gramps/gen/lib/name.py:202
-#: ../gramps/gen/lib/person.py:261
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:647
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:661
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:675
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:689
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:703
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:717
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:731
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:745
+#: ../gramps/gen/lib/person.py:229
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:670
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:684
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:698
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:712
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:726
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:740
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:754
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:768
 #: ../gramps/plugins/quickview/filterbyname.py:112
 #: ../gramps/plugins/quickview/filterbyname.py:137
-#: ../gramps/plugins/textreport/indivcomplete.py:251
+#: ../gramps/plugins/textreport/indivcomplete.py:260
 #: ../gramps/plugins/textreport/tagreport.py:484
-#: ../gramps/plugins/view/noteview.py:110
-#: ../gramps/plugins/view/view.gpr.py:95
+#: ../gramps/plugins/view/noteview.py:110 ../gramps/plugins/view/view.gpr.py:95
 #: ../gramps/plugins/view/view.gpr.py:103
-#: ../gramps/plugins/webreport/narrativeweb.py:378
-#: ../gramps/plugins/webreport/narrativeweb.py:1039
-#: ../gramps/plugins/webreport/narrativeweb.py:1672
+#: ../gramps/plugins/webreport/narrativeweb.py:993
+#: ../gramps/plugins/webreport/narrativeweb.py:1634
+#: ../gramps/plugins/webreport/narrativeweb.py:7067
 msgid "Notes"
 msgstr "Notizen"
 
-#: ../gramps/gen/lib/media.py:202 ../gramps/gen/lib/person.py:262
+#: ../gramps/gen/lib/media.py:202 ../gramps/gen/lib/person.py:230
 msgid "Last changed"
 msgstr "Zuletzt geändert"
 
@@ -7329,40 +7373,41 @@ msgstr "Zuletzt geändert"
 #: ../gramps/gui/editors/displaytabs/placenameembedlist.py:64
 #: ../gramps/gui/editors/displaytabs/placerefembedlist.py:61
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:113
-#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:104
+#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:107
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:91
 #: ../gramps/gui/glade/editaddress.glade:322
 #: ../gramps/gui/glade/editaddress.glade:332
-#: ../gramps/gui/glade/editcitation.glade:116
-#: ../gramps/gui/glade/editcitation.glade:123
+#: ../gramps/gui/glade/editcitation.glade:115
+#: ../gramps/gui/glade/editcitation.glade:122
 #: ../gramps/gui/glade/editdate.glade:324
 #: ../gramps/gui/glade/editevent.glade:138
 #: ../gramps/gui/glade/editevent.glade:148
 #: ../gramps/gui/glade/editeventref.glade:378
 #: ../gramps/gui/glade/editeventref.glade:388
-#: ../gramps/gui/glade/editldsord.glade:157
-#: ../gramps/gui/glade/editldsord.glade:167
+#: ../gramps/gui/glade/editldsord.glade:155
+#: ../gramps/gui/glade/editldsord.glade:165
 #: ../gramps/gui/glade/editmedia.glade:244
 #: ../gramps/gui/glade/editmedia.glade:254
 #: ../gramps/gui/glade/editmediaref.glade:582
 #: ../gramps/gui/glade/editmediaref.glade:592
-#: ../gramps/gui/glade/editname.glade:572
-#: ../gramps/gui/glade/editname.glade:582
+#: ../gramps/gui/glade/editname.glade:571
+#: ../gramps/gui/glade/editname.glade:581
 #: ../gramps/gui/glade/editplacename.glade:132
 #: ../gramps/gui/glade/editplacename.glade:142
-#: ../gramps/gui/selectors/selectevent.py:72
-#: ../gramps/plugins/export/exportcsv.py:499
-#: ../gramps/plugins/export/exportcsv.py:565
+#: ../gramps/gui/selectors/selectevent.py:71
+#: ../gramps/plugins/export/exportcsv.py:287
+#: ../gramps/plugins/export/exportcsv.py:473
 #: ../gramps/plugins/gramplet/ageondategramplet.py:66
+#: ../gramps/plugins/gramplet/coordinates.py:91
 #: ../gramps/plugins/gramplet/events.py:87
-#: ../gramps/plugins/gramplet/locations.py:86
+#: ../gramps/plugins/gramplet/locations.py:87
 #: ../gramps/plugins/gramplet/personresidence.py:60
 #: ../gramps/plugins/importer/importcsv.py:219
 #: ../gramps/plugins/quickview/onthisday.py:80
 #: ../gramps/plugins/quickview/onthisday.py:81
 #: ../gramps/plugins/quickview/onthisday.py:82
-#: ../gramps/plugins/textreport/indivcomplete.py:458
-#: ../gramps/plugins/textreport/indivcomplete.py:653
+#: ../gramps/plugins/textreport/indivcomplete.py:493
+#: ../gramps/plugins/textreport/indivcomplete.py:691
 #: ../gramps/plugins/textreport/placereport.py:220
 #: ../gramps/plugins/textreport/placereport.py:298
 #: ../gramps/plugins/textreport/tagreport.py:349
@@ -7373,27 +7418,28 @@ msgstr "Zuletzt geändert"
 #: ../gramps/plugins/view/citationtreeview.py:95
 #: ../gramps/plugins/view/eventview.py:85
 #: ../gramps/plugins/view/mediaview.py:98
-#: ../gramps/plugins/webreport/narrativeweb.py:371
-#: ../gramps/plugins/webreport/narrativeweb.py:1036
-#: ../gramps/plugins/webreport/narrativeweb.py:1322
-#: ../gramps/plugins/webreport/narrativeweb.py:1351
-#: ../gramps/plugins/webreport/narrativeweb.py:2602
-#: ../gramps/plugins/webreport/narrativeweb.py:4153
-#: ../gramps/plugins/webreport/narrativeweb.py:5065
-#: ../gramps/plugins/webreport/narrativeweb.py:6700
+#: ../gramps/plugins/webreport/narrativeweb.py:990
+#: ../gramps/plugins/webreport/narrativeweb.py:1277
+#: ../gramps/plugins/webreport/narrativeweb.py:1307
+#: ../gramps/plugins/webreport/narrativeweb.py:1474
+#: ../gramps/plugins/webreport/narrativeweb.py:2588
+#: ../gramps/plugins/webreport/narrativeweb.py:4196
+#: ../gramps/plugins/webreport/narrativeweb.py:5115
+#: ../gramps/plugins/webreport/narrativeweb.py:5484
+#: ../gramps/plugins/webreport/narrativeweb.py:6780
 msgid "Date"
 msgstr "Datum"
 
-#: ../gramps/gen/lib/media.py:204 ../gramps/gen/lib/person.py:263
+#: ../gramps/gen/lib/media.py:204 ../gramps/gen/lib/person.py:231
 #: ../gramps/gui/glade/editfamily.glade:773
 #: ../gramps/gui/glade/editmedia.glade:396
 #: ../gramps/gui/glade/editmediaref.glade:726
-#: ../gramps/gui/glade/editnote.glade:286
-#: ../gramps/gui/glade/editperson.glade:684
-#: ../gramps/gui/selectors/selectnote.py:78
+#: ../gramps/gui/glade/editnote.glade:284
+#: ../gramps/gui/glade/editperson.glade:683
+#: ../gramps/gui/selectors/selectnote.py:77
 #: ../gramps/plugins/lib/libpersonview.py:111
 #: ../gramps/plugins/lib/libplaceview.py:92
-#: ../gramps/plugins/textreport/indivcomplete.py:499
+#: ../gramps/plugins/textreport/indivcomplete.py:534
 #: ../gramps/plugins/tool/notrelated.py:127
 #: ../gramps/plugins/view/citationlistview.py:103
 #: ../gramps/plugins/view/citationtreeview.py:98
@@ -7406,7 +7452,7 @@ msgid "Tags"
 msgstr "Markierungen"
 
 #: ../gramps/gen/lib/media.py:205 ../gramps/gen/lib/name.py:200
-#: ../gramps/gen/lib/person.py:264 ../gramps/gen/proxy/private.py:945
+#: ../gramps/gen/lib/person.py:232 ../gramps/gen/proxy/private.py:945
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:77
 #: ../gramps/gui/editors/displaytabs/attrembedlist.py:64
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:84
@@ -7423,7 +7469,7 @@ msgstr "Markierungen"
 #: ../gramps/gui/glade/editaddress.glade:297
 #: ../gramps/gui/glade/editattribute.glade:153
 #: ../gramps/gui/glade/editchildref.glade:180
-#: ../gramps/gui/glade/editcitation.glade:346
+#: ../gramps/gui/glade/editcitation.glade:345
 #: ../gramps/gui/glade/editevent.glade:355
 #: ../gramps/gui/glade/editeventref.glade:149
 #: ../gramps/gui/glade/editeventref.glade:420
@@ -7431,9 +7477,9 @@ msgstr "Markierungen"
 #: ../gramps/gui/glade/editmedia.glade:332
 #: ../gramps/gui/glade/editmediaref.glade:301
 #: ../gramps/gui/glade/editmediaref.glade:623
-#: ../gramps/gui/glade/editname.glade:156
-#: ../gramps/gui/glade/editnote.glade:235
-#: ../gramps/gui/glade/editperson.glade:418
+#: ../gramps/gui/glade/editname.glade:155
+#: ../gramps/gui/glade/editnote.glade:233
+#: ../gramps/gui/glade/editperson.glade:417
 #: ../gramps/gui/glade/editpersonref.glade:158
 #: ../gramps/gui/glade/editplace.glade:262
 #: ../gramps/gui/glade/editplaceref.glade:365
@@ -7441,15 +7487,15 @@ msgstr "Markierungen"
 #: ../gramps/gui/glade/editreporef.glade:404
 #: ../gramps/gui/glade/editrepository.glade:212
 #: ../gramps/gui/glade/editsource.glade:295
-#: ../gramps/gui/glade/editurl.glade:157
+#: ../gramps/gui/glade/editurl.glade:156
 #: ../gramps/plugins/lib/libpersonview.py:110
 #: ../gramps/plugins/lib/libplaceview.py:91
 #: ../gramps/plugins/view/citationlistview.py:102
 #: ../gramps/plugins/view/citationtreeview.py:97
 #: ../gramps/plugins/view/eventview.py:87
 #: ../gramps/plugins/view/familyview.py:84
-#: ../gramps/plugins/view/mediaview.py:99
-#: ../gramps/plugins/view/noteview.py:82 ../gramps/plugins/view/repoview.py:97
+#: ../gramps/plugins/view/mediaview.py:99 ../gramps/plugins/view/noteview.py:82
+#: ../gramps/plugins/view/repoview.py:97
 #: ../gramps/plugins/view/sourceview.py:87
 msgid "Private"
 msgstr "Vertraulich"
@@ -7459,70 +7505,70 @@ msgstr "Vertraulich"
 #. Handle
 #. Add column with object name
 #: ../gramps/gen/lib/name.py:199 ../gramps/gui/clipboard.py:589
-#: ../gramps/gui/configure.py:510
+#: ../gramps/gui/configure.py:515
 #: ../gramps/gui/editors/displaytabs/backreflist.py:61
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:73
 #: ../gramps/gui/editors/displaytabs/personrefembedlist.py:64
 #: ../gramps/gui/editors/displaytabs/placenameembedlist.py:63
 #: ../gramps/gui/editors/displaytabs/placerefembedlist.py:59
 #: ../gramps/gui/editors/editfamily.py:123
-#: ../gramps/gui/editors/editname.py:311
-#: ../gramps/gui/editors/filtereditor.py:820
-#: ../gramps/gui/editors/filtereditor.py:974
+#: ../gramps/gui/editors/editname.py:310
+#: ../gramps/gui/editors/filtereditor.py:818
+#: ../gramps/gui/editors/filtereditor.py:973
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:126
-#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:101
-#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:100
-#: ../gramps/gui/plug/_guioptions.py:1164 ../gramps/gui/plug/_windows.py:126
-#: ../gramps/gui/plug/_windows.py:1083
-#: ../gramps/gui/plug/report/_bookdialog.py:420
-#: ../gramps/gui/selectors/selectperson.py:94
-#: ../gramps/gui/selectors/selectplace.py:71
-#: ../gramps/gui/views/bookmarks.py:218 ../gramps/gui/views/tags.py:397
+#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:105
+#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:104
+#: ../gramps/gui/plug/_guioptions.py:1165 ../gramps/gui/plug/_windows.py:126
+#: ../gramps/gui/plug/_windows.py:1094
+#: ../gramps/gui/plug/report/_bookdialog.py:372
+#: ../gramps/gui/selectors/selectperson.py:93
+#: ../gramps/gui/selectors/selectplace.py:70
+#: ../gramps/gui/views/bookmarks.py:240 ../gramps/gui/views/tags.py:402
 #: ../gramps/gui/views/treemodels/peoplemodel.py:616
-#: ../gramps/plugins/export/exportcsv.py:563
+#: ../gramps/plugins/export/exportcsv.py:285
 #: ../gramps/plugins/gramplet/ancestor.py:63
 #: ../gramps/plugins/gramplet/backlinks.py:56
 #: ../gramps/plugins/gramplet/descendant.py:62
-#: ../gramps/plugins/gramplet/locations.py:84
+#: ../gramps/plugins/gramplet/locations.py:85
 #: ../gramps/plugins/gramplet/placedetails.py:122
 #: ../gramps/plugins/importer/importcsv.py:222
 #: ../gramps/plugins/lib/libpersonview.py:98
 #: ../gramps/plugins/lib/libplaceview.py:84
 #: ../gramps/plugins/quickview/filterbyname.py:306
-#: ../gramps/plugins/textreport/indivcomplete.py:860
+#: ../gramps/plugins/textreport/indivcomplete.py:900
 #: ../gramps/plugins/textreport/tagreport.py:160
 #: ../gramps/plugins/textreport/tagreport.py:426
 #: ../gramps/plugins/textreport/tagreport.py:654
 #: ../gramps/plugins/tool/dumpgenderstats.py:62
 #: ../gramps/plugins/tool/notrelated.py:124
-#: ../gramps/plugins/tool/removeunused.py:197
-#: ../gramps/plugins/tool/verify.py:542 ../gramps/plugins/view/repoview.py:85
-#: ../gramps/plugins/webreport/narrativeweb.py:7492
+#: ../gramps/plugins/tool/removeunused.py:200
+#: ../gramps/plugins/tool/verify.py:577 ../gramps/plugins/view/repoview.py:85
+#: ../gramps/plugins/webreport/narrativeweb.py:7579
 msgid "Name"
 msgstr "Name"
 
-#: ../gramps/gen/lib/name.py:204 ../gramps/plugins/importer/importcsv.py:149
+#: ../gramps/gen/lib/name.py:204 ../gramps/plugins/importer/importcsv.py:161
 msgid "Given name"
 msgstr "Vorname"
 
 #: ../gramps/gen/lib/name.py:205
-#: ../gramps/plugins/webreport/narrativeweb.py:1898
-#: ../gramps/plugins/webreport/narrativeweb.py:1948
-#: ../gramps/plugins/webreport/narrativeweb.py:1951
-#: ../gramps/plugins/webreport/narrativeweb.py:2011
-#: ../gramps/plugins/webreport/narrativeweb.py:4454
-#: ../gramps/plugins/webreport/narrativeweb.py:4503
+#: ../gramps/plugins/webreport/narrativeweb.py:1874
+#: ../gramps/plugins/webreport/narrativeweb.py:1926
+#: ../gramps/plugins/webreport/narrativeweb.py:1929
+#: ../gramps/plugins/webreport/narrativeweb.py:1997
+#: ../gramps/plugins/webreport/narrativeweb.py:4500
+#: ../gramps/plugins/webreport/narrativeweb.py:4550
 msgid "Surnames"
 msgstr "Nachnamen"
 
 #: ../gramps/gen/lib/name.py:206 ../gramps/gen/utils/keyword.py:60
-#: ../gramps/gui/configure.py:640 ../gramps/gui/configure.py:642
-#: ../gramps/gui/configure.py:644 ../gramps/gui/configure.py:646
-#: ../gramps/gui/configure.py:647 ../gramps/gui/configure.py:652
-#: ../gramps/gui/configure.py:654 ../gramps/gui/configure.py:659
-#: ../gramps/gui/configure.py:661 ../gramps/gui/glade/editperson.glade:230
-#: ../gramps/plugins/export/exportcsv.py:380
-#: ../gramps/plugins/importer/importcsv.py:157
+#: ../gramps/gui/configure.py:645 ../gramps/gui/configure.py:647
+#: ../gramps/gui/configure.py:649 ../gramps/gui/configure.py:651
+#: ../gramps/gui/configure.py:652 ../gramps/gui/configure.py:657
+#: ../gramps/gui/configure.py:659 ../gramps/gui/configure.py:664
+#: ../gramps/gui/configure.py:666 ../gramps/gui/glade/editperson.glade:229
+#: ../gramps/plugins/export/exportcsv.py:354
+#: ../gramps/plugins/importer/importcsv.py:166
 msgid "Suffix"
 msgstr "Suffix"
 
@@ -7533,11 +7579,11 @@ msgstr "Suffix"
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:88
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:87
 #: ../gramps/gui/selectors/selectobject.py:80
-#: ../gramps/gui/selectors/selectplace.py:74
-#: ../gramps/gui/selectors/selectrepository.py:70
-#: ../gramps/gui/selectors/selectsource.py:70
-#: ../gramps/gui/widgets/grampletpane.py:1557
-#: ../gramps/plugins/export/exportcsv.py:563
+#: ../gramps/gui/selectors/selectplace.py:73
+#: ../gramps/gui/selectors/selectrepository.py:69
+#: ../gramps/gui/selectors/selectsource.py:69
+#: ../gramps/gui/widgets/grampletpane.py:1562
+#: ../gramps/plugins/export/exportcsv.py:285
 #: ../gramps/plugins/gramplet/persondetails.py:160
 #: ../gramps/plugins/lib/libplaceview.py:86
 #: ../gramps/plugins/textreport/tagreport.py:420
@@ -7545,7 +7591,7 @@ msgstr "Suffix"
 #: ../gramps/plugins/textreport/tagreport.py:739
 #: ../gramps/plugins/view/mediaview.py:94
 #: ../gramps/plugins/view/sourceview.py:82
-#: ../gramps/plugins/webreport/narrativeweb.py:3045
+#: ../gramps/plugins/webreport/narrativeweb.py:3036
 msgid "Title"
 msgstr "Titel"
 
@@ -7563,23 +7609,24 @@ msgstr "Titel"
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:69
 #: ../gramps/gui/editors/displaytabs/srcattrembedlist.py:63
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:65
-#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:102
+#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:105
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:89
-#: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:98
-#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:102
-#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:101
-#: ../gramps/gui/merge/mergeperson.py:239 ../gramps/gui/plug/_windows.py:119
-#: ../gramps/gui/plug/_windows.py:235 ../gramps/gui/plug/_windows.py:1082
-#: ../gramps/gui/plug/report/_bookdialog.py:421
-#: ../gramps/gui/plug/report/_bookdialog.py:425
-#: ../gramps/gui/selectors/selectevent.py:70
-#: ../gramps/gui/selectors/selectnote.py:77
+#: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:102
+#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:106
+#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:105
+#: ../gramps/gui/merge/mergeperson.py:240 ../gramps/gui/plug/_windows.py:119
+#: ../gramps/gui/plug/_windows.py:235 ../gramps/gui/plug/_windows.py:1093
+#: ../gramps/gui/plug/report/_bookdialog.py:373
+#: ../gramps/gui/plug/report/_bookdialog.py:377
+#: ../gramps/gui/selectors/selectevent.py:69
+#: ../gramps/gui/selectors/selectnote.py:76
 #: ../gramps/gui/selectors/selectobject.py:82
-#: ../gramps/gui/selectors/selectplace.py:73
-#: ../gramps/plugins/export/exportcsv.py:564
+#: ../gramps/gui/selectors/selectplace.py:72
+#: ../gramps/plugins/export/exportcsv.py:286
 #: ../gramps/plugins/gramplet/backlinks.py:55
+#: ../gramps/plugins/gramplet/coordinates.py:89
 #: ../gramps/plugins/gramplet/events.py:85
-#: ../gramps/plugins/gramplet/locations.py:85
+#: ../gramps/plugins/gramplet/locations.py:86
 #: ../gramps/plugins/gramplet/placedetails.py:123
 #: ../gramps/plugins/importer/importcsv.py:223
 #: ../gramps/plugins/lib/libplaceview.py:87
@@ -7590,25 +7637,25 @@ msgstr "Titel"
 #: ../gramps/plugins/quickview/onthisday.py:82
 #: ../gramps/plugins/quickview/references.py:70
 #: ../gramps/plugins/quickview/siblings.py:48
-#: ../gramps/plugins/textreport/indivcomplete.py:457
-#: ../gramps/plugins/textreport/indivcomplete.py:652
+#: ../gramps/plugins/textreport/indivcomplete.py:492
+#: ../gramps/plugins/textreport/indivcomplete.py:690
 #: ../gramps/plugins/textreport/tagreport.py:337
 #: ../gramps/plugins/textreport/tagreport.py:432
 #: ../gramps/plugins/textreport/tagreport.py:501
 #: ../gramps/plugins/textreport/tagreport.py:576
 #: ../gramps/plugins/textreport/tagreport.py:660
-#: ../gramps/plugins/tool/patchnames.py:402
+#: ../gramps/plugins/tool/patchnames.py:403
 #: ../gramps/plugins/tool/sortevents.py:55
 #: ../gramps/plugins/view/eventview.py:84
-#: ../gramps/plugins/view/mediaview.py:96
-#: ../gramps/plugins/view/noteview.py:81 ../gramps/plugins/view/repoview.py:87
-#: ../gramps/plugins/webreport/narrativeweb.py:390
-#: ../gramps/plugins/webreport/narrativeweb.py:1350
-#: ../gramps/plugins/webreport/narrativeweb.py:1670
-#: ../gramps/plugins/webreport/narrativeweb.py:2472
-#: ../gramps/plugins/webreport/narrativeweb.py:3046
-#: ../gramps/plugins/webreport/narrativeweb.py:4152
-#: ../gramps/plugins/webreport/narrativeweb.py:7768
+#: ../gramps/plugins/view/mediaview.py:96 ../gramps/plugins/view/noteview.py:81
+#: ../gramps/plugins/view/repoview.py:87
+#: ../gramps/plugins/webreport/narrativeweb.py:1306
+#: ../gramps/plugins/webreport/narrativeweb.py:1632
+#: ../gramps/plugins/webreport/narrativeweb.py:2458
+#: ../gramps/plugins/webreport/narrativeweb.py:3038
+#: ../gramps/plugins/webreport/narrativeweb.py:4195
+#: ../gramps/plugins/webreport/narrativeweb.py:7750
+#: ../gramps/plugins/webreport/narrativeweb.py:7838
 msgid "Type"
 msgstr "Art"
 
@@ -7624,7 +7671,7 @@ msgstr "Sortieren nach"
 msgid "Display as"
 msgstr "Anzeigen als"
 
-#: ../gramps/gen/lib/name.py:212 ../gramps/plugins/importer/importcsv.py:152
+#: ../gramps/gen/lib/name.py:212 ../gramps/plugins/importer/importcsv.py:162
 msgid "Call name"
 msgstr "Rufname"
 
@@ -7649,13 +7696,13 @@ msgstr "%(surname)s, %(first)s %(suffix)s"
 #. make sure it's translated, so it can be used below, in "combine"
 #. translators: needed for Arabic, ignore otherwise
 #: ../gramps/gen/lib/name.py:520 ../gramps/gen/lib/name.py:535
-#: ../gramps/gen/plug/report/utils.py:249
-#: ../gramps/plugins/graph/gvfamilylines.py:449
-#: ../gramps/plugins/textreport/detancestralreport.py:439
-#: ../gramps/plugins/textreport/detdescendantreport.py:449
-#: ../gramps/plugins/textreport/indivcomplete.py:189
-#: ../gramps/plugins/textreport/indivcomplete.py:197
-#: ../gramps/plugins/textreport/indivcomplete.py:950
+#: ../gramps/gen/plug/report/utils.py:255
+#: ../gramps/plugins/graph/gvfamilylines.py:459
+#: ../gramps/plugins/textreport/detancestralreport.py:440
+#: ../gramps/plugins/textreport/detdescendantreport.py:490
+#: ../gramps/plugins/textreport/indivcomplete.py:198
+#: ../gramps/plugins/textreport/indivcomplete.py:206
+#: ../gramps/plugins/textreport/indivcomplete.py:991
 #, python-format
 msgid "%(str1)s, %(str2)s"
 msgstr "%(str1)s, %(str2)s"
@@ -7679,7 +7726,7 @@ msgid "Surname|Taken"
 msgstr "Angenommen"
 
 #: ../gramps/gen/lib/nameorigintype.py:79 ../gramps/gen/utils/keyword.py:65
-#: ../gramps/gui/configure.py:653
+#: ../gramps/gui/configure.py:658
 msgid "Patronymic"
 msgstr "Patronymikon"
 
@@ -7704,7 +7751,7 @@ msgid "Matrilineal"
 msgstr "Matrilineal"
 
 #: ../gramps/gen/lib/nameorigintype.py:86 ../gramps/gui/clipboard.py:323
-#: ../gramps/gui/plug/_windows.py:612
+#: ../gramps/gui/plug/_windows.py:617
 msgid "Location"
 msgstr "Standort"
 
@@ -7720,17 +7767,17 @@ msgstr "Geburtsname"
 msgid "Married Name"
 msgstr "Name nach der Hochzeit"
 
-#: ../gramps/gen/lib/notetype.py:73 ../gramps/gui/configure.py:1392
+#: ../gramps/gen/lib/notetype.py:75 ../gramps/gui/configure.py:1410
 #: ../gramps/gui/editors/editeventref.py:89
 #: ../gramps/gui/editors/editmediaref.py:106
-#: ../gramps/gui/editors/editplaceref.py:70
-#: ../gramps/gui/editors/editreporef.py:72
+#: ../gramps/gui/editors/editplaceref.py:71
+#: ../gramps/gui/editors/editreporef.py:71
 #: ../gramps/gui/glade/editeventref.glade:183
 #: ../gramps/gui/glade/editeventref.glade:563
 #: ../gramps/gui/glade/editmediaref.glade:342
 #: ../gramps/gui/glade/editmediaref.glade:756
-#: ../gramps/gui/glade/editname.glade:672
-#: ../gramps/gui/glade/editperson.glade:383
+#: ../gramps/gui/glade/editname.glade:671
+#: ../gramps/gui/glade/editperson.glade:382
 #: ../gramps/gui/glade/editplaceref.glade:160
 #: ../gramps/gui/glade/editplaceref.glade:598
 #: ../gramps/gui/glade/editreporef.glade:225
@@ -7739,21 +7786,21 @@ msgstr "Name nach der Hochzeit"
 msgid "General"
 msgstr "Allgemeines"
 
-#: ../gramps/gen/lib/notetype.py:74
+#: ../gramps/gen/lib/notetype.py:76
 msgid "Research"
 msgstr "Forschung"
 
-#: ../gramps/gen/lib/notetype.py:75
+#: ../gramps/gen/lib/notetype.py:77
 msgid "Transcript"
 msgstr "Abschrift"
 
-#: ../gramps/gen/lib/notetype.py:76
+#: ../gramps/gen/lib/notetype.py:78
 msgid "Source text"
 msgstr "Quelltext"
 
 #. 8
-#: ../gramps/gen/lib/notetype.py:77 ../gramps/gui/clipboard.py:490
-#: ../gramps/gui/configure.py:537 ../gramps/gui/editors/editcitation.py:119
+#: ../gramps/gen/lib/notetype.py:79 ../gramps/gui/clipboard.py:490
+#: ../gramps/gui/configure.py:542 ../gramps/gui/editors/editcitation.py:119
 #: ../gramps/gui/editors/editcitation.py:125
 #: ../gramps/gui/editors/editlink.py:98
 #: ../gramps/gui/editors/filtereditor.py:301
@@ -7764,282 +7811,300 @@ msgstr "Quelltext"
 msgid "Citation"
 msgstr "Fundstelle"
 
-#: ../gramps/gen/lib/notetype.py:78 ../gramps/gen/plug/_pluginreg.py:76
+#: ../gramps/gen/lib/notetype.py:80 ../gramps/gen/plug/_pluginreg.py:76
 #: ../gramps/gui/logger/_errorview.py:141
 msgid "Report"
 msgstr "Bericht"
 
-#: ../gramps/gen/lib/notetype.py:79
+#: ../gramps/gen/lib/notetype.py:81
 msgid "Html code"
 msgstr "HTML Code"
 
-#: ../gramps/gen/lib/notetype.py:80
+#: ../gramps/gen/lib/notetype.py:82
 msgid "notetype|To Do"
 msgstr "Zu erledigen"
 
-#: ../gramps/gen/lib/notetype.py:84
+#: ../gramps/gen/lib/notetype.py:83
+msgid "notetype|Link"
+msgstr "Link"
+
+#: ../gramps/gen/lib/notetype.py:87
 msgid "Person Note"
 msgstr "Person Notiz"
 
-#: ../gramps/gen/lib/notetype.py:85
+#: ../gramps/gen/lib/notetype.py:88
 msgid "Name Note"
 msgstr "Namen Notiz"
 
-#: ../gramps/gen/lib/notetype.py:86
+#: ../gramps/gen/lib/notetype.py:89
 msgid "Attribute Note"
 msgstr "Attribut Notiz"
 
-#: ../gramps/gen/lib/notetype.py:87
+#: ../gramps/gen/lib/notetype.py:90
 msgid "Address Note"
 msgstr "Adresse Notiz"
 
-#: ../gramps/gen/lib/notetype.py:88
+#: ../gramps/gen/lib/notetype.py:91
 msgid "Association Note"
 msgstr "Verknüpfung Notiz"
 
-#: ../gramps/gen/lib/notetype.py:89
+#: ../gramps/gen/lib/notetype.py:92
 msgid "LDS Note"
 msgstr "HLT Notiz"
 
-#: ../gramps/gen/lib/notetype.py:90
+#: ../gramps/gen/lib/notetype.py:93
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:117
 msgid "Family Note"
 msgstr "Familiennotiz"
 
-#: ../gramps/gen/lib/notetype.py:91
+#: ../gramps/gen/lib/notetype.py:94
 msgid "Event Note"
 msgstr "Ereignis Notiz"
 
-#: ../gramps/gen/lib/notetype.py:92
+#: ../gramps/gen/lib/notetype.py:95
 msgid "Event Reference Note"
 msgstr "Ereignis-Referenz Notiz"
 
-#: ../gramps/gen/lib/notetype.py:93
+#: ../gramps/gen/lib/notetype.py:96
 msgid "Source Note"
 msgstr "Quelle Notiz"
 
-#: ../gramps/gen/lib/notetype.py:94
+#: ../gramps/gen/lib/notetype.py:97
 msgid "Source Reference Note"
 msgstr "Quellen-Referenz Notiz"
 
-#: ../gramps/gen/lib/notetype.py:95
+#: ../gramps/gen/lib/notetype.py:98
 msgid "Place Note"
 msgstr "Ort Notiz"
 
-#: ../gramps/gen/lib/notetype.py:96
+#: ../gramps/gen/lib/notetype.py:99
 msgid "Repository Note"
 msgstr "Aufbewahrungsort Notiz"
 
-#: ../gramps/gen/lib/notetype.py:97
+#: ../gramps/gen/lib/notetype.py:100
 msgid "Repository Reference Note"
 msgstr "Aufbewahrungsort-Referenz Notiz"
 
-#: ../gramps/gen/lib/notetype.py:98
+#: ../gramps/gen/lib/notetype.py:101
 msgid "Media Note"
 msgstr "Mediennotiz"
 
-#: ../gramps/gen/lib/notetype.py:99
+#: ../gramps/gen/lib/notetype.py:102
 msgid "Media Reference Note"
 msgstr "Medienreferenznotiz"
 
-#: ../gramps/gen/lib/notetype.py:100
+#: ../gramps/gen/lib/notetype.py:103
 msgid "Child Reference Note"
 msgstr "Kind-Referenzen Notiz"
 
-#: ../gramps/gen/lib/person.py:245
+#: ../gramps/gen/lib/person.py:213
 msgid "Handle"
 msgstr "Identifikator"
 
-#: ../gramps/gen/lib/person.py:247 ../gramps/gui/editors/editfamily.py:124
+#: ../gramps/gen/lib/person.py:215 ../gramps/gui/editors/editfamily.py:124
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:128
-#: ../gramps/gui/merge/mergeperson.py:180
-#: ../gramps/gui/selectors/selectperson.py:96
+#: ../gramps/gui/merge/mergeperson.py:181
+#: ../gramps/gui/selectors/selectperson.py:95
 #: ../gramps/plugins/drawreport/statisticschart.py:338
-#: ../gramps/plugins/export/exportcsv.py:381
-#: ../gramps/plugins/importer/importcsv.py:158
+#: ../gramps/plugins/export/exportcsv.py:355
+#: ../gramps/plugins/importer/importcsv.py:167
 #: ../gramps/plugins/lib/libpersonview.py:100
 #: ../gramps/plugins/quickview/siblings.py:48
-#: ../gramps/plugins/textreport/indivcomplete.py:861
-#: ../gramps/plugins/webreport/narrativeweb.py:7222
+#: ../gramps/plugins/textreport/indivcomplete.py:901
+#: ../gramps/plugins/webreport/narrativeweb.py:7305
 msgid "Gender"
 msgstr "Geschlecht"
 
-#: ../gramps/gen/lib/person.py:248
+#: ../gramps/gen/lib/person.py:216
 msgid "Primary name"
 msgstr "Primärer Name"
 
-#: ../gramps/gen/lib/person.py:249
+#: ../gramps/gen/lib/person.py:217
 msgid "Alternate names"
 msgstr "Alternative Namen"
 
-#: ../gramps/gen/lib/person.py:250
+#: ../gramps/gen/lib/person.py:218
 msgid "Death reference index"
 msgstr "Tod Referenzindex"
 
-#: ../gramps/gen/lib/person.py:251
+#: ../gramps/gen/lib/person.py:219
 msgid "Birth reference index"
 msgstr "Geburt Referenzindex"
 
-#: ../gramps/gen/lib/person.py:252
+#: ../gramps/gen/lib/person.py:220
 msgid "Event references"
 msgstr "Ereignisreferenzen"
 
-#: ../gramps/gen/lib/person.py:253
-#: ../gramps/plugins/graph/gvfamilylines.py:264
-#: ../gramps/plugins/graph/gvrelgraph.py:794
+#: ../gramps/gen/lib/person.py:221 ../gramps/plugins/graph/gvfamilylines.py:272
+#: ../gramps/plugins/graph/gvrelgraph.py:797
 #: ../gramps/plugins/quickview/filterbyname.py:94
 #: ../gramps/plugins/quickview/filterbyname.py:119
-#: ../gramps/plugins/textreport/indivcomplete.py:588
+#: ../gramps/plugins/textreport/indivcomplete.py:626
 #: ../gramps/plugins/textreport/tagreport.py:231
 #: ../gramps/plugins/tool/verify.glade:753
 #: ../gramps/plugins/view/familyview.py:114
 #: ../gramps/plugins/view/view.gpr.py:50 ../gramps/plugins/view/view.gpr.py:58
+#: ../gramps/plugins/webreport/narrativeweb.py:647
 #: ../gramps/plugins/webreport/narrativeweb.py:695
-#: ../gramps/plugins/webreport/narrativeweb.py:743
-#: ../gramps/plugins/webreport/narrativeweb.py:1899
-#: ../gramps/plugins/webreport/narrativeweb.py:1956
-#: ../gramps/plugins/webreport/narrativeweb.py:2012
-#: ../gramps/plugins/webreport/narrativeweb.py:3448
+#: ../gramps/plugins/webreport/narrativeweb.py:1875
+#: ../gramps/plugins/webreport/narrativeweb.py:1934
+#: ../gramps/plugins/webreport/narrativeweb.py:1998
+#: ../gramps/plugins/webreport/narrativeweb.py:3452
 msgid "Families"
 msgstr "Familien"
 
-#: ../gramps/gen/lib/person.py:254
+#: ../gramps/gen/lib/person.py:222
 msgid "Parent families"
 msgstr "Eltern Familien"
 
-#: ../gramps/gen/lib/person.py:256 ../gramps/gui/merge/mergeperson.py:254
-#: ../gramps/plugins/textreport/indivcomplete.py:371
-#: ../gramps/plugins/webreport/narrativeweb.py:1471
+#: ../gramps/gen/lib/person.py:224 ../gramps/gui/merge/mergeperson.py:255
+#: ../gramps/plugins/textreport/indivcomplete.py:406
+#: ../gramps/plugins/webreport/narrativeweb.py:1430
 msgid "Addresses"
 msgstr "Adressen"
 
-#: ../gramps/gen/lib/person.py:258
+#: ../gramps/gen/lib/person.py:226
 msgid "Urls"
 msgstr "Urls"
 
-#: ../gramps/gen/lib/person.py:259
+#: ../gramps/gen/lib/person.py:227
 msgid "LDS ordinances"
 msgstr "LDS Ordinationen"
 
-#: ../gramps/gen/lib/person.py:265
+#: ../gramps/gen/lib/person.py:233
 msgid "Person references"
 msgstr "Personreferenzen"
 
-#: ../gramps/gen/lib/person.py:266
+#: ../gramps/gen/lib/person.py:234
 msgid "Probably alive"
 msgstr "Wahrscheinlich am leben"
 
-#: ../gramps/gen/lib/person.py:641
+#: ../gramps/gen/lib/person.py:609
 msgid "Merged Gramps ID"
 msgstr "Zusammengefasste Gramps-ID"
 
-#: ../gramps/gen/lib/placetype.py:65 ../gramps/gui/configure.py:515
+#: ../gramps/gen/lib/placetype.py:65 ../gramps/gui/configure.py:520
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:76
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:59
-#: ../gramps/gui/views/treemodels/placemodel.py:282
-#: ../gramps/plugins/lib/maps/placeselection.py:131
+#: ../gramps/gui/views/treemodels/placemodel.py:283
+#: ../gramps/plugins/lib/maps/placeselection.py:132
+#: ../gramps/plugins/view/geoplaces.py:558
 #: ../gramps/plugins/view/repoview.py:93
-#: ../gramps/plugins/webreport/narrativeweb.py:369
-#: ../gramps/plugins/webreport/narrativeweb.py:3819
+#: ../gramps/plugins/webreport/narrativeweb.py:1481
+#: ../gramps/plugins/webreport/narrativeweb.py:2941
+#: ../gramps/plugins/webreport/narrativeweb.py:2967
+#: ../gramps/plugins/webreport/narrativeweb.py:3825
 msgid "Country"
 msgstr "Land"
 
 #: ../gramps/gen/lib/placetype.py:66
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:58
-#: ../gramps/gui/views/treemodels/placemodel.py:282
-#: ../gramps/plugins/lib/maps/placeselection.py:132
-#: ../gramps/plugins/webreport/narrativeweb.py:3818
+#: ../gramps/gui/views/treemodels/placemodel.py:283
+#: ../gramps/plugins/lib/maps/placeselection.py:133
+#: ../gramps/plugins/view/geoplaces.py:561
 msgid "State"
 msgstr "Bundesland"
 
 #: ../gramps/gen/lib/placetype.py:67
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:57
-#: ../gramps/gui/views/treemodels/placemodel.py:282
-#: ../gramps/plugins/lib/maps/placeselection.py:133
-#: ../gramps/plugins/webreport/narrativeweb.py:368
+#: ../gramps/gui/views/treemodels/placemodel.py:283
+#: ../gramps/plugins/lib/maps/placeselection.py:134
+#: ../gramps/plugins/view/geoplaces.py:564
+#: ../gramps/plugins/webreport/narrativeweb.py:1479
+#: ../gramps/plugins/webreport/narrativeweb.py:2938
+#: ../gramps/plugins/webreport/narrativeweb.py:2964
 msgid "County"
 msgstr "Kreis"
 
-#: ../gramps/gen/lib/placetype.py:68 ../gramps/gui/configure.py:513
+#: ../gramps/gen/lib/placetype.py:68 ../gramps/gui/configure.py:518
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:74
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:56
+#: ../gramps/plugins/view/geoplaces.py:582
 #: ../gramps/plugins/view/repoview.py:91
-#: ../gramps/plugins/webreport/narrativeweb.py:367
+#: ../gramps/plugins/webreport/narrativeweb.py:1477
+#: ../gramps/plugins/webreport/narrativeweb.py:2936
+#: ../gramps/plugins/webreport/narrativeweb.py:2962
 msgid "City"
 msgstr "Stadt"
 
-#: ../gramps/gen/lib/placetype.py:69
+#: ../gramps/gen/lib/placetype.py:69 ../gramps/plugins/view/geoplaces.py:579
 msgid "Parish"
 msgstr "Kirchengemeinde"
 
-#: ../gramps/gen/lib/placetype.py:70 ../gramps/gui/configure.py:512
+#: ../gramps/gen/lib/placetype.py:70 ../gramps/gui/configure.py:517
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:73
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:55
+#: ../gramps/plugins/view/geoplaces.py:531
 #: ../gramps/plugins/view/repoview.py:90
-#: ../gramps/plugins/webreport/narrativeweb.py:376
-#: ../gramps/plugins/webreport/narrativeweb.py:1516
+#: ../gramps/plugins/webreport/narrativeweb.py:1476
+#: ../gramps/plugins/webreport/narrativeweb.py:2935
+#: ../gramps/plugins/webreport/narrativeweb.py:2961
 msgid "Locality"
 msgstr "Lokalität"
 
 #: ../gramps/gen/lib/placetype.py:71
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:72
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:54
+#: ../gramps/plugins/view/geoplaces.py:534
 #: ../gramps/plugins/view/repoview.py:89
-#: ../gramps/plugins/webreport/narrativeweb.py:389
+#: ../gramps/plugins/webreport/narrativeweb.py:1475
+#: ../gramps/plugins/webreport/narrativeweb.py:2934
+#: ../gramps/plugins/webreport/narrativeweb.py:2960
 msgid "Street"
 msgstr "Straße"
 
-#: ../gramps/gen/lib/placetype.py:72
+#: ../gramps/gen/lib/placetype.py:72 ../gramps/plugins/view/geoplaces.py:567
 msgid "Province"
 msgstr "Provinz"
 
-#: ../gramps/gen/lib/placetype.py:73
+#: ../gramps/gen/lib/placetype.py:73 ../gramps/plugins/view/geoplaces.py:570
 msgid "Region"
 msgstr "Region"
 
-#: ../gramps/gen/lib/placetype.py:74
+#: ../gramps/gen/lib/placetype.py:74 ../gramps/plugins/view/geoplaces.py:573
 msgid "Department"
 msgstr "Amt"
 
-#: ../gramps/gen/lib/placetype.py:75
+#: ../gramps/gen/lib/placetype.py:75 ../gramps/plugins/view/geoplaces.py:537
 msgid "Neighborhood"
 msgstr "Viertel"
 
-#: ../gramps/gen/lib/placetype.py:76
+#: ../gramps/gen/lib/placetype.py:76 ../gramps/plugins/view/geoplaces.py:576
 msgid "District"
 msgstr "Bezirk"
 
-#: ../gramps/gen/lib/placetype.py:77
+#: ../gramps/gen/lib/placetype.py:77 ../gramps/plugins/view/geoplaces.py:540
 msgid "Borough"
 msgstr "Borough"
 
-#: ../gramps/gen/lib/placetype.py:78
+#: ../gramps/gen/lib/placetype.py:78 ../gramps/plugins/view/geoplaces.py:588
 msgid "Municipality"
 msgstr "Gemeinde"
 
-#: ../gramps/gen/lib/placetype.py:79
+#: ../gramps/gen/lib/placetype.py:79 ../gramps/plugins/view/geoplaces.py:585
 msgid "Town"
 msgstr "Kleinstadt"
 
-#: ../gramps/gen/lib/placetype.py:80
+#: ../gramps/gen/lib/placetype.py:80 ../gramps/plugins/view/geoplaces.py:543
 msgid "Village"
 msgstr "Dorf"
 
-#: ../gramps/gen/lib/placetype.py:81
+#: ../gramps/gen/lib/placetype.py:81 ../gramps/plugins/view/geoplaces.py:546
 msgid "Hamlet"
 msgstr "Weiler"
 
-#: ../gramps/gen/lib/placetype.py:82
+#: ../gramps/gen/lib/placetype.py:82 ../gramps/plugins/view/geoplaces.py:549
 msgid "Farm"
 msgstr "Hof"
 
-#: ../gramps/gen/lib/placetype.py:83
+#: ../gramps/gen/lib/placetype.py:83 ../gramps/plugins/view/geoplaces.py:552
 msgid "Building"
 msgstr "Gebäude"
 
 #: ../gramps/gen/lib/placetype.py:84 ../gramps/plugins/gramplet/leak.py:89
-#: ../gramps/plugins/webreport/narrativeweb.py:3043
-#: ../gramps/plugins/webreport/narrativeweb.py:4808
+#: ../gramps/plugins/view/geoplaces.py:555
+#: ../gramps/plugins/webreport/narrativeweb.py:3034
+#: ../gramps/plugins/webreport/narrativeweb.py:4859
 msgid "Number"
 msgstr "Standortnummer/Signatur"
 
@@ -8083,7 +8148,7 @@ msgstr "Safe"
 msgid "Audio"
 msgstr "Audio"
 
-#: ../gramps/gen/lib/srcmediatype.py:59 ../gramps/gui/glade/book.glade:9
+#: ../gramps/gen/lib/srcmediatype.py:59 ../gramps/gui/glade/book.glade:7
 msgid "Book"
 msgstr "Buch"
 
@@ -8132,17 +8197,17 @@ msgid "Video"
 msgstr "Video"
 
 #: ../gramps/gen/lib/styledtexttagtype.py:61
-#: ../gramps/gui/widgets/styledtexteditor.py:458
+#: ../gramps/gui/widgets/styledtexteditor.py:459
 msgid "Bold"
 msgstr "Fett"
 
 #: ../gramps/gen/lib/styledtexttagtype.py:62
-#: ../gramps/gui/widgets/styledtexteditor.py:456
+#: ../gramps/gui/widgets/styledtexteditor.py:457
 msgid "Italic"
 msgstr "Kursiv"
 
 #: ../gramps/gen/lib/styledtexttagtype.py:63
-#: ../gramps/gui/widgets/styledtexteditor.py:460
+#: ../gramps/gui/widgets/styledtexteditor.py:461
 msgid "Underline"
 msgstr "Unterstrichen"
 
@@ -8170,7 +8235,7 @@ msgstr "Hochgestellt"
 #: ../gramps/gui/glade/editlink.glade:172
 #: ../gramps/gui/widgets/styledtextbuffer.py:565
 #: ../gramps/gui/widgets/styledtextbuffer.py:605
-#: ../gramps/gui/widgets/styledtexteditor.py:472
+#: ../gramps/gui/widgets/styledtexteditor.py:473
 msgid "Link"
 msgstr "Verknüpfung"
 
@@ -8196,11 +8261,11 @@ msgstr "Websuche"
 msgid "FTP"
 msgstr "FTP"
 
-#: ../gramps/gen/merge/diff.py:188
+#: ../gramps/gen/merge/diff.py:100
 msgid "Family Tree Differences"
 msgstr "Stammbaumunterschiede"
 
-#: ../gramps/gen/merge/diff.py:189
+#: ../gramps/gen/merge/diff.py:101
 msgid "Searching..."
 msgstr "Suche..."
 
@@ -8219,9 +8284,9 @@ msgstr "Ein Elternteil sollte entweder Vater oder Mutter sein."
 #: ../gramps/gen/merge/mergefamilyquery.py:103
 #: ../gramps/gen/merge/mergefamilyquery.py:114
 #: ../gramps/gen/merge/mergepersonquery.py:54
-#: ../gramps/gen/merge/test/merge_ref_test.py:1895
-#: ../gramps/gen/merge/test/merge_ref_test.py:1917
-#: ../gramps/gen/merge/test/merge_ref_test.py:1940
+#: ../gramps/gen/merge/test/merge_ref_test.py:1874
+#: ../gramps/gen/merge/test/merge_ref_test.py:1898
+#: ../gramps/gen/merge/test/merge_ref_test.py:1922
 msgid ""
 "A parent and child cannot be merged. To merge these people, you must first "
 "break the relationship between them."
@@ -8239,8 +8304,7 @@ msgstr "Familien zusammenfassen"
 msgid "Merge Media Objects"
 msgstr "Medienobjekte zusammenfassen"
 
-#: ../gramps/gen/merge/mergenotequery.py:58
-#: ../gramps/gui/merge/mergenote.py:66
+#: ../gramps/gen/merge/mergenotequery.py:58 ../gramps/gui/merge/mergenote.py:66
 msgid "Merge Notes"
 msgstr "Notizen zusammenfassen"
 
@@ -8252,12 +8316,11 @@ msgstr ""
 "Ehepaare können nicht zusammengefasst werden. Um diese Personen "
 "zusammenzufassen, musst du zuerst die Verbindung zwischen ihnen lösen."
 
-#: ../gramps/gen/merge/mergepersonquery.py:117
+#: ../gramps/gen/merge/mergepersonquery.py:118
 msgid "Merge Person"
 msgstr "Personen zusammenfassen"
 
-#: ../gramps/gen/merge/mergepersonquery.py:156
-#: ../gramps/gen/merge/test/merge_ref_test.py:1503
+#: ../gramps/gen/merge/mergepersonquery.py:157
 msgid ""
 "A person with multiple relations with the same spouse is about to be merged. "
 "This is beyond the capabilities of the merge routine. The merge is aborted."
@@ -8266,7 +8329,7 @@ msgstr ""
 "zusammengefasst werden. Dies liegt über den Möglichkeiten der "
 "Zusammenfassungsroutine. Das Zusammenfassen wurde daher abgebrochen."
 
-#: ../gramps/gen/merge/mergepersonquery.py:167
+#: ../gramps/gen/merge/mergepersonquery.py:168
 msgid "Multiple families get merged. This is unusual, the merge is aborted."
 msgstr ""
 "Mehrere Familien wurden zusammengefasst. Dies ist unüblich, das "
@@ -8301,7 +8364,7 @@ msgid "No description was provided"
 msgstr "Keine Beschreibung angegeben"
 
 #: ../gramps/gen/plug/_options.py:386
-#: ../gramps/plugins/textreport/recordsreport.py:162
+#: ../gramps/plugins/textreport/recordsreport.py:163
 #, python-format
 msgid ""
 "Option '%(opt_name)s' is present in %(file)s\n"
@@ -8358,9 +8421,9 @@ msgstr "Beziehungen"
 
 #: ../gramps/gen/plug/_pluginreg.py:86 ../gramps/gen/plug/_pluginreg.py:421
 #: ../gramps/gui/glade/grampletpane.glade:156
-#: ../gramps/gui/widgets/grampletbar.py:625
+#: ../gramps/gui/widgets/grampletbar.py:627
 #: ../gramps/gui/widgets/grampletpane.py:224
-#: ../gramps/gui/widgets/grampletpane.py:966
+#: ../gramps/gui/widgets/grampletpane.py:971
 msgid "Gramplet"
 msgstr "Gramplet"
 
@@ -8371,7 +8434,9 @@ msgstr "Seitenleiste"
 #. add miscellaneous column
 #: ../gramps/gen/plug/_pluginreg.py:512
 #: ../gramps/plugins/gramplet/faqgramplet.py:135
-#: ../gramps/plugins/webreport/narrativeweb.py:2079
+#: ../gramps/plugins/webreport/narrativeweb.py:2065
+#: ../gramps/plugins/webreport/narrativeweb.py:8125
+#: ../gramps/plugins/webreport/narrativeweb.py:8177
 msgid "Miscellaneous"
 msgstr "Sonstiges"
 
@@ -8444,28 +8509,28 @@ msgstr "Datei %s ist bereits geöffnet, erst schließen."
 #: ../gramps/gen/utils/docgen/odstab.py:477
 #: ../gramps/gen/utils/docgen/odstab.py:496
 #: ../gramps/gen/utils/docgen/odstab.py:499
-#: ../gramps/plugins/docgen/asciidoc.py:175
+#: ../gramps/plugins/docgen/asciidoc.py:176
 #: ../gramps/plugins/docgen/cairodoc.py:190
 #: ../gramps/plugins/docgen/cairodoc.py:193
 #: ../gramps/plugins/docgen/odfdoc.py:1136
 #: ../gramps/plugins/docgen/odfdoc.py:1139
 #: ../gramps/plugins/docgen/rtfdoc.py:92 ../gramps/plugins/docgen/rtfdoc.py:95
-#: ../gramps/plugins/docgen/svgdrawdoc.py:88
-#: ../gramps/plugins/docgen/svgdrawdoc.py:90
-#: ../gramps/plugins/export/exportcsv.py:324
-#: ../gramps/plugins/export/exportcsv.py:328
-#: ../gramps/plugins/export/exportgedcom.py:1494
+#: ../gramps/plugins/docgen/svgdrawdoc.py:89
+#: ../gramps/plugins/docgen/svgdrawdoc.py:91
+#: ../gramps/plugins/export/exportcsv.py:260
+#: ../gramps/plugins/export/exportcsv.py:264
+#: ../gramps/plugins/export/exportgedcom.py:1548
 #: ../gramps/plugins/export/exportgeneweb.py:108
 #: ../gramps/plugins/export/exportgeneweb.py:112
 #: ../gramps/plugins/export/exportvcalendar.py:119
 #: ../gramps/plugins/export/exportvcalendar.py:123
-#: ../gramps/plugins/export/exportvcard.py:70
-#: ../gramps/plugins/export/exportvcard.py:74
+#: ../gramps/plugins/export/exportvcard.py:71
+#: ../gramps/plugins/export/exportvcard.py:75
 #: ../gramps/plugins/lib/libhtmlbackend.py:249
 #: ../gramps/plugins/lib/libhtmlbackend.py:253
 #: ../gramps/plugins/lib/libhtmlbackend.py:259
 #: ../gramps/plugins/lib/libhtmlbackend.py:263
-#: ../gramps/plugins/webreport/narrativeweb.py:8157
+#: ../gramps/plugins/webreport/narrativeweb.py:8411
 #, python-format
 msgid "Could not create %s"
 msgstr "Konnte %s nicht erstellen"
@@ -8475,106 +8540,118 @@ msgstr "Konnte %s nicht erstellen"
 #. Private Constants
 #.
 #. -------------------------------------------------------------------------------
-#: ../gramps/gen/plug/docgen/graphdoc.py:64
+#: ../gramps/gen/plug/docgen/graphdoc.py:65
 #: ../gramps/gen/plug/report/stdoptions.py:56
 #: ../gramps/gen/plug/report/stdoptions.py:69
 msgid "Default"
 msgstr "Vorgabe"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:65
+#: ../gramps/gen/plug/docgen/graphdoc.py:66
 msgid "PostScript / Helvetica"
 msgstr "PostScript / Helvetica"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:66
+#: ../gramps/gen/plug/docgen/graphdoc.py:67
 msgid "TrueType / FreeSans"
 msgstr "Truetype / FreeSans"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:68
-#: ../gramps/plugins/view/pedigreeview.py:2030
+#: ../gramps/gen/plug/docgen/graphdoc.py:69
+#: ../gramps/plugins/view/pedigreeview.py:2043
 msgid "Vertical (↓)"
 msgstr "Vertikal (↓)"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:69
-#: ../gramps/plugins/view/pedigreeview.py:2031
+#: ../gramps/gen/plug/docgen/graphdoc.py:70
+#: ../gramps/plugins/view/pedigreeview.py:2044
 msgid "Vertical (↑)"
 msgstr "Vertikal (↑)"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:70
-#: ../gramps/plugins/view/pedigreeview.py:2032
+#: ../gramps/gen/plug/docgen/graphdoc.py:71
+#: ../gramps/plugins/view/pedigreeview.py:2045
 msgid "Horizontal (→)"
 msgstr "Horizontal (→)"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:71
-#: ../gramps/plugins/view/pedigreeview.py:2033
+#: ../gramps/gen/plug/docgen/graphdoc.py:72
+#: ../gramps/plugins/view/pedigreeview.py:2046
 msgid "Horizontal (←)"
 msgstr "Horizontal (←)"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:73
+#: ../gramps/gen/plug/docgen/graphdoc.py:74
 msgid "Bottom, left"
 msgstr "Unten, links"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:74
+#: ../gramps/gen/plug/docgen/graphdoc.py:75
 msgid "Bottom, right"
 msgstr "Unten, rechts"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:75
+#: ../gramps/gen/plug/docgen/graphdoc.py:76
 msgid "Top, left"
 msgstr "Oben, links"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:76
+#: ../gramps/gen/plug/docgen/graphdoc.py:77
 msgid "Top, Right"
 msgstr "Oben, rechts"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:77
+#: ../gramps/gen/plug/docgen/graphdoc.py:78
 msgid "Right, bottom"
 msgstr "Rechts, unten"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:78
+#: ../gramps/gen/plug/docgen/graphdoc.py:79
 msgid "Right, top"
 msgstr "Rechts, oben"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:79
+#: ../gramps/gen/plug/docgen/graphdoc.py:80
 msgid "Left, bottom"
 msgstr "Links, unten"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:80
+#: ../gramps/gen/plug/docgen/graphdoc.py:81
 msgid "Left, top"
 msgstr "Links, oben"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:82
+#: ../gramps/gen/plug/docgen/graphdoc.py:83
 msgid "Compress to minimal size"
 msgstr "Auf minimale Größe komprimieren"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:83
+#: ../gramps/gen/plug/docgen/graphdoc.py:84
 msgid "Fill the given area"
 msgstr "Gegebenen Bereich füllen"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:84
+#: ../gramps/gen/plug/docgen/graphdoc.py:85
 msgid "Expand uniformly"
 msgstr "Gleichmäßig ausdehnen"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:86
-#: ../gramps/gui/glade/styleeditor.glade:1340
+#: ../gramps/gen/plug/docgen/graphdoc.py:87
+#: ../gramps/gui/glade/styleeditor.glade:1343
 msgid "Top"
 msgstr "Oben"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:87
-#: ../gramps/gui/glade/styleeditor.glade:1355
+#: ../gramps/gen/plug/docgen/graphdoc.py:88
+#: ../gramps/gui/glade/styleeditor.glade:1358
 msgid "Bottom"
 msgstr "Unten"
 
+#: ../gramps/gen/plug/docgen/graphdoc.py:90
+msgid "Straight"
+msgstr "Gerade"
+
+#: ../gramps/gen/plug/docgen/graphdoc.py:91
+msgid "Curved"
+msgstr "Gebogen"
+
+#: ../gramps/gen/plug/docgen/graphdoc.py:92
+msgid "Orthogonal"
+msgstr "Rechtwinklig"
+
 #. ###############################
-#: ../gramps/gen/plug/docgen/graphdoc.py:131
+#: ../gramps/gen/plug/docgen/graphdoc.py:136
 msgid "Graphviz Layout"
 msgstr "Graphviz Layout"
 
 #. ###############################
-#: ../gramps/gen/plug/docgen/graphdoc.py:133
-#: ../gramps/gui/widgets/styledtexteditor.py:481
+#: ../gramps/gen/plug/docgen/graphdoc.py:138
+#: ../gramps/gui/widgets/styledtexteditor.py:482
 msgid "Font family"
 msgstr "Schriftfamilie"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:136
+#: ../gramps/gen/plug/docgen/graphdoc.py:141
 msgid ""
 "Choose the font family. If international characters don't show, use FreeSans "
 "font. FreeSans is available from: http://www.nongnu.org/freefont/"
@@ -8583,29 +8660,29 @@ msgstr ""
 "werden, benutze die FreeSans-Schrift. FreeSans ist verfügbar unter: http://"
 "www.nongnu.org/freefont/"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:142
-#: ../gramps/gui/widgets/styledtexteditor.py:493
+#: ../gramps/gen/plug/docgen/graphdoc.py:147
+#: ../gramps/gui/widgets/styledtexteditor.py:494
 msgid "Font size"
 msgstr "Schriftgröße"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:143
+#: ../gramps/gen/plug/docgen/graphdoc.py:148
 msgid "The font size, in points."
 msgstr "Die Schriftgröße in Punkten."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:146
+#: ../gramps/gen/plug/docgen/graphdoc.py:151
 msgid "Graph Direction"
 msgstr "Ausrichtung der Grafik"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:149
+#: ../gramps/gen/plug/docgen/graphdoc.py:154
 msgid "Whether graph goes from top to bottom or left to right."
 msgstr ""
 "Legt fest, ob der Graph von oben nach unten, oder von links nach rechts geht."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:153
+#: ../gramps/gen/plug/docgen/graphdoc.py:158
 msgid "Number of Horizontal Pages"
 msgstr "Horizontale Seitenzahl"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:154
+#: ../gramps/gen/plug/docgen/graphdoc.py:159
 msgid ""
 "Graphviz can create very large graphs by spreading the graph across a "
 "rectangular array of pages. This controls the number pages in the array "
@@ -8616,11 +8693,11 @@ msgstr ""
 "horizontale Anzahl an Seiten vor. Nur gültig für DOT und PDF über "
 "Ghostscript."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:161
+#: ../gramps/gen/plug/docgen/graphdoc.py:166
 msgid "Number of Vertical Pages"
 msgstr "Vertikale Seitenzahl"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:162
+#: ../gramps/gen/plug/docgen/graphdoc.py:167
 msgid ""
 "Graphviz can create very large graphs by spreading the graph across a "
 "rectangular array of pages. This controls the number pages in the array "
@@ -8630,11 +8707,11 @@ msgstr ""
 "rechteckige Fläche aus mehreren Seiten verteilt wird. Dies gibt die "
 "vertikale Anzahl an Seiten vor. Nur gültig für DOT und PDF über Ghostscript."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:169
+#: ../gramps/gen/plug/docgen/graphdoc.py:174
 msgid "Paging Direction"
 msgstr "Seitenwechsel Richtung"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:172
+#: ../gramps/gen/plug/docgen/graphdoc.py:177
 msgid ""
 "The order in which the graph pages are output. This option only applies if "
 "the horizontal pages or vertical pages are greater than 1."
@@ -8642,17 +8719,25 @@ msgstr ""
 "Reihenfolge, in der die Diagrammseiten ausgegeben werden. Diese Option wirkt "
 "nur, wenn die horizontale oder vertikale Seitenzahl größer 1 ist."
 
+#: ../gramps/gen/plug/docgen/graphdoc.py:182
+msgid "Connecting lines"
+msgstr "Verbindungslinien"
+
+#: ../gramps/gen/plug/docgen/graphdoc.py:185
+msgid "How the lines between objects will be drawn."
+msgstr "Wie die Linien zwischen Objekten gezeichnet werden."
+
 #. ###############################
-#: ../gramps/gen/plug/docgen/graphdoc.py:190
+#: ../gramps/gen/plug/docgen/graphdoc.py:201
 msgid "Graphviz Options"
 msgstr "Optionen für Graphviz"
 
 #. ###############################
-#: ../gramps/gen/plug/docgen/graphdoc.py:193
+#: ../gramps/gen/plug/docgen/graphdoc.py:204
 msgid "Aspect ratio"
 msgstr "Streckung"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:196
+#: ../gramps/gen/plug/docgen/graphdoc.py:207
 msgid ""
 "Affects node spacing and scaling of the graph.\n"
 "If the graph is smaller than the print area:\n"
@@ -8683,11 +8768,11 @@ msgstr ""
 "  Ausdehnen verkleinert die Grafik gleichmäßig, damit sie in den "
 "Druckbereich passt."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:212
+#: ../gramps/gen/plug/docgen/graphdoc.py:223
 msgid "DPI"
 msgstr "DPI"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:213
+#: ../gramps/gen/plug/docgen/graphdoc.py:224
 msgid ""
 "Dots per inch.  When creating images such as .gif or .png files for the web, "
 "try numbers such as 100 or 300 DPI.  PostScript and PDF files always use 72 "
@@ -8697,11 +8782,11 @@ msgstr ""
 "erstellst, versuche Werte wie 100 oder 300 DPI. Für PostScript und PDF "
 "Dateien verwende immer 72 DPI."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:220
+#: ../gramps/gen/plug/docgen/graphdoc.py:231
 msgid "Node spacing"
 msgstr "Knotenabstand"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:221
+#: ../gramps/gen/plug/docgen/graphdoc.py:232
 msgid ""
 "The minimum amount of free space, in inches, between individual nodes.  For "
 "vertical graphs, this corresponds to spacing between columns.  For "
@@ -8711,11 +8796,11 @@ msgstr ""
 "Grafen entspricht das dem Abstand zwischen Spalten. Für waagerechte Grafen "
 "entspricht das dem Abstand zwischen Zeilen."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:228
+#: ../gramps/gen/plug/docgen/graphdoc.py:239
 msgid "Rank spacing"
 msgstr "Ebenenabstand"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:229
+#: ../gramps/gen/plug/docgen/graphdoc.py:240
 msgid ""
 "The minimum amount of free space, in inches, between ranks.  For vertical "
 "graphs, this corresponds to spacing between rows.  For horizontal graphs, "
@@ -8725,11 +8810,11 @@ msgstr ""
 "entspricht dies dem Abstand zwischen Zeilen. Für waagerechte Grafen "
 "entspricht das dem Abstand zwischen Spalten."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:236
+#: ../gramps/gen/plug/docgen/graphdoc.py:247
 msgid "Use subgraphs"
 msgstr "Benutze Unterdiagramme"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:237
+#: ../gramps/gen/plug/docgen/graphdoc.py:248
 msgid ""
 "Subgraphs can help Graphviz position spouses together, but with non-trivial "
 "graphs will result in longer lines and larger graphs."
@@ -8740,96 +8825,95 @@ msgstr ""
 
 #. ###############################
 #. 3
-#: ../gramps/gen/plug/docgen/graphdoc.py:244 ../gramps/gui/clipboard.py:394
-#: ../gramps/gui/configure.py:545 ../gramps/gui/editors/editlink.py:93
-#: ../gramps/gui/editors/editmedia.py:98
-#: ../gramps/gui/editors/editmedia.py:183
+#: ../gramps/gen/plug/docgen/graphdoc.py:255 ../gramps/gui/clipboard.py:394
+#: ../gramps/gui/configure.py:550 ../gramps/gui/editors/editlink.py:93
+#: ../gramps/gui/editors/editmedia.py:98 ../gramps/gui/editors/editmedia.py:181
 #: ../gramps/gui/editors/editmediaref.py:145
 #: ../gramps/gui/editors/filtereditor.py:300
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:109
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:115
-#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:106
+#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:109
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:92
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:134
-#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:105
-#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:104
+#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:109
+#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:108
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:91
-#: ../gramps/gui/glade/editnote.glade:328
+#: ../gramps/gui/glade/editnote.glade:326
 #: ../gramps/gui/views/treemodels/mediamodel.py:117
-#: ../gramps/plugins/drawreport/ancestortree.py:975
-#: ../gramps/plugins/drawreport/descendtree.py:1688
-#: ../gramps/plugins/export/exportcsv.py:386
-#: ../gramps/plugins/export/exportcsv.py:499
+#: ../gramps/plugins/drawreport/ancestortree.py:984
+#: ../gramps/plugins/drawreport/descendtree.py:1706
+#: ../gramps/plugins/export/exportcsv.py:360
+#: ../gramps/plugins/export/exportcsv.py:473
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:111
-#: ../gramps/plugins/importer/importcsv.py:160
+#: ../gramps/plugins/importer/importcsv.py:169
 #: ../gramps/plugins/quickview/filterbyname.py:225
 #: ../gramps/plugins/quickview/filterbyname.py:276
 #: ../gramps/plugins/quickview/quickview.gpr.py:205
 #: ../gramps/plugins/quickview/references.py:94
-#: ../gramps/plugins/textreport/familygroup.py:365
-#: ../gramps/plugins/textreport/familygroup.py:427
+#: ../gramps/plugins/textreport/familygroup.py:366
+#: ../gramps/plugins/textreport/familygroup.py:428
 msgid "Note"
 msgstr "Notiz"
 
 #. ###############################
-#: ../gramps/gen/plug/docgen/graphdoc.py:247
+#: ../gramps/gen/plug/docgen/graphdoc.py:258
 msgid "Note to add to the graph"
 msgstr "Notizen zur Grafik hinzufügen."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:249
+#: ../gramps/gen/plug/docgen/graphdoc.py:260
 msgid "This text will be added to the graph."
 msgstr "Dieser Text wird der Grafik hinzugefügt."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:252
+#: ../gramps/gen/plug/docgen/graphdoc.py:263
 msgid "Note location"
 msgstr "Position der Notiz"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:255
+#: ../gramps/gen/plug/docgen/graphdoc.py:266
 msgid "Whether note will appear on top or bottom of the page."
 msgstr "Legt fest, ob die Notiz oben oder unten auf der Seite erscheint."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:259
+#: ../gramps/gen/plug/docgen/graphdoc.py:270
 msgid "Note size"
 msgstr "Notizgröße"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:260
+#: ../gramps/gen/plug/docgen/graphdoc.py:271
 msgid "The size of note text, in points."
 msgstr "Die Größe des Notizentext in Punkten."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:948
+#: ../gramps/gen/plug/docgen/graphdoc.py:961
 msgid "PDF (Ghostscript)"
 msgstr "PDF (Ghostscript)"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:954
+#: ../gramps/gen/plug/docgen/graphdoc.py:967
 msgid "PDF (Graphviz)"
 msgstr "PDF (Graphviz)"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:960
+#: ../gramps/gen/plug/docgen/graphdoc.py:973
 #: ../gramps/plugins/docgen/docgen.gpr.py:158
 msgid "PostScript"
 msgstr "PostScript"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:966
+#: ../gramps/gen/plug/docgen/graphdoc.py:979
 msgid "Structured Vector Graphics (SVG)"
 msgstr "Strukturierte Vektor Grafiken (SVG)"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:972
+#: ../gramps/gen/plug/docgen/graphdoc.py:985
 msgid "Compressed Structured Vector Graphs (SVGZ)"
 msgstr "Komprimierte SVG-Grafik (SVGZ)"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:978
+#: ../gramps/gen/plug/docgen/graphdoc.py:991
 msgid "JPEG image"
 msgstr "JPEG-Grafik"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:984
+#: ../gramps/gen/plug/docgen/graphdoc.py:997
 msgid "GIF image"
 msgstr "GIF-Grafik"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:990
+#: ../gramps/gen/plug/docgen/graphdoc.py:1003
 msgid "PNG image"
 msgstr "PNG-Grafik"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:996
+#: ../gramps/gen/plug/docgen/graphdoc.py:1009
 msgid "Graphviz File"
 msgstr "Graphviz Datei"
 
@@ -8859,9 +8943,8 @@ msgstr "Gültige Werte:"
 #. Private Constants
 #.
 #. ------------------------------------------------------------------------
-#: ../gramps/gen/plug/report/_book.py:69 ../gramps/gui/plug/_dialogs.py:59
-#: ../gramps/gui/plug/report/_bookdialog.py:84
-#: ../gramps/gui/viewmanager.py:111
+#: ../gramps/gen/plug/report/_book.py:71 ../gramps/gui/plug/_dialogs.py:59
+#: ../gramps/gui/plug/report/_bookdialog.py:84 ../gramps/gui/viewmanager.py:111
 msgid "Unsupported"
 msgstr "Nicht unterstützt"
 
@@ -8890,9 +8973,9 @@ msgid "Graphs"
 msgstr "Grafiken"
 
 #: ../gramps/gen/plug/report/_constants.py:53 ../gramps/gui/clipboard.py:637
-#: ../gramps/gui/clipboard.py:645 ../gramps/gui/configure.py:1193
-#: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:97
-#: ../gramps/plugins/textreport/custombooktext.py:129
+#: ../gramps/gui/clipboard.py:645 ../gramps/gui/configure.py:1199
+#: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:101
+#: ../gramps/plugins/textreport/custombooktext.py:132
 #: ../gramps/plugins/textreport/tagreport.py:507
 msgid "Text"
 msgstr "Text"
@@ -8902,9 +8985,9 @@ msgid "Graphics"
 msgstr "Grafiken"
 
 #: ../gramps/gen/plug/report/endnotes.py:61
-#: ../gramps/plugins/textreport/ancestorreport.py:353
-#: ../gramps/plugins/textreport/detancestralreport.py:916
-#: ../gramps/plugins/textreport/detdescendantreport.py:1091
+#: ../gramps/plugins/textreport/ancestorreport.py:362
+#: ../gramps/plugins/textreport/detancestralreport.py:925
+#: ../gramps/plugins/textreport/detdescendantreport.py:1155
 msgid "The style used for the generation header."
 msgstr "Der Stil, der für die Generation Überschriften verwendet wird."
 
@@ -8934,21 +9017,6 @@ msgstr ""
 msgid "Endnotes"
 msgstr "Schlussnotizen"
 
-#. translators: needed for French, ignore otherwise
-#: ../gramps/gen/plug/report/endnotes.py:175
-#: ../gramps/gui/plug/report/_docreportdialog.py:184
-#: ../gramps/gui/plug/report/_docreportdialog.py:235
-#: ../gramps/gui/plug/report/_graphvizreportdialog.py:150
-#: ../gramps/plugins/textreport/familygroup.py:405
-#: ../gramps/plugins/textreport/indivcomplete.py:858
-#: ../gramps/plugins/textreport/indivcomplete.py:860
-#: ../gramps/plugins/textreport/indivcomplete.py:861
-#: ../gramps/plugins/textreport/indivcomplete.py:862
-#: ../gramps/plugins/textreport/indivcomplete.py:863
-#, python-format
-msgid "%s:"
-msgstr "%s:"
-
 #: ../gramps/gen/plug/report/stdoptions.py:54
 msgid "Translation"
 msgstr "Übersetzung"
@@ -8958,13 +9026,13 @@ msgid "The translation to be used for the report."
 msgstr "Die Übersetzung, die für den Bericht verwendet wird."
 
 #. label for the combo
-#: ../gramps/gen/plug/report/stdoptions.py:68 ../gramps/gui/configure.py:974
-#: ../gramps/plugins/webreport/webcal.py:1628
+#: ../gramps/gen/plug/report/stdoptions.py:68 ../gramps/gui/configure.py:980
+#: ../gramps/plugins/webreport/webcal.py:1646
 msgid "Name format"
 msgstr "Namensformat"
 
 #: ../gramps/gen/plug/report/stdoptions.py:73
-#: ../gramps/plugins/webreport/webcal.py:1632
+#: ../gramps/plugins/webreport/webcal.py:1650
 msgid "Select the format to display names"
 msgstr "Wähle das Format zum Anzeigen von Namen."
 
@@ -9017,86 +9085,82 @@ msgstr ""
 "Dies erlaubt dir, die Daten von Personen einzugrenzen, die noch nicht lange "
 "tot sind."
 
-#: ../gramps/gen/plug/report/utils.py:155
-#: ../gramps/plugins/textreport/indivcomplete.py:848
+#: ../gramps/gen/plug/report/utils.py:158
+#: ../gramps/plugins/textreport/indivcomplete.py:888
 #: ../gramps/plugins/textreport/simplebooktitle.py:106
-#: ../gramps/plugins/webreport/narrativeweb.py:2122
-#: ../gramps/plugins/webreport/narrativeweb.py:2337
-#: ../gramps/plugins/webreport/narrativeweb.py:2402
-#: ../gramps/plugins/webreport/narrativeweb.py:2410
+#: ../gramps/plugins/webreport/narrativeweb.py:2108
+#: ../gramps/plugins/webreport/narrativeweb.py:2323
+#: ../gramps/plugins/webreport/narrativeweb.py:2388
+#: ../gramps/plugins/webreport/narrativeweb.py:2396
 msgid "Could not add photo to page"
 msgstr "Das Photo kann zur Seite nicht hinzugefügt werden."
 
-#: ../gramps/gen/plug/report/utils.py:156 ../gramps/gui/utils.py:415
-#: ../gramps/plugins/textreport/indivcomplete.py:852
+#: ../gramps/gen/plug/report/utils.py:159
+#: ../gramps/plugins/textreport/indivcomplete.py:892
 msgid "File does not exist"
 msgstr "Datei existiert nicht"
 
 #. Do this in case of command line options query (show=filter)
-#: ../gramps/gen/plug/report/utils.py:280
+#: ../gramps/gen/plug/report/utils.py:287
 msgid "PERSON"
 msgstr "PERSON"
 
-#: ../gramps/gen/plug/report/utils.py:288
-#: ../gramps/gui/plug/report/_bookdialog.py:151
+#: ../gramps/gen/plug/report/utils.py:295
+#: ../gramps/plugins/textreport/notelinkreport.py:156
+#: ../gramps/plugins/textreport/summary.py:281
 #: ../gramps/plugins/tool/eventcmp.py:156
 msgid "Entire Database"
 msgstr "Gesamte Datenbank"
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/gen/plug/report/utils.py:292
-#: ../gramps/gui/plug/export/_exportoptions.py:442
-#: ../gramps/plugins/textreport/descendreport.py:394
+#: ../gramps/gen/plug/report/utils.py:299
+#: ../gramps/gui/plug/export/_exportoptions.py:451
+#: ../gramps/plugins/textreport/descendreport.py:472
 #, python-format
 msgid "Descendants of %s"
 msgstr "Nachkommen von %s"
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/gen/plug/report/utils.py:296
-#: ../gramps/gen/plug/report/utils.py:373
-#: ../gramps/gui/plug/export/_exportoptions.py:447
+#: ../gramps/gen/plug/report/utils.py:303
+#: ../gramps/gen/plug/report/utils.py:380
+#: ../gramps/gui/plug/export/_exportoptions.py:456
 #, python-format
 msgid "Descendant Families of %s"
 msgstr "Nachkommen von %s und deren Partner"
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/gen/plug/report/utils.py:300
-#: ../gramps/gui/plug/export/_exportoptions.py:452
+#: ../gramps/gen/plug/report/utils.py:307
+#: ../gramps/gui/plug/export/_exportoptions.py:461
 #, python-format
 msgid "Ancestors of %s"
 msgstr "Vorfahren von %s"
 
-#: ../gramps/gen/plug/report/utils.py:303
-#: ../gramps/gui/plug/export/_exportoptions.py:456
+#: ../gramps/gen/plug/report/utils.py:310
+#: ../gramps/gui/plug/export/_exportoptions.py:465
 #, python-format
 msgid "People with common ancestor with %s"
 msgstr "Personen mit gemeinsamen Vorfahren wie %s"
 
-#: ../gramps/gen/plug/report/utils.py:345
-#: ../gramps/gui/plug/_guioptions.py:885
-#: ../gramps/gui/plug/report/_bookdialog.py:176
+#: ../gramps/gen/plug/report/utils.py:352 ../gramps/gui/plug/_guioptions.py:886
 msgid "unknown father"
 msgstr "unbekannter Vater"
 
-#: ../gramps/gen/plug/report/utils.py:351
-#: ../gramps/gui/plug/_guioptions.py:891
-#: ../gramps/gui/plug/report/_bookdialog.py:182
+#: ../gramps/gen/plug/report/utils.py:358 ../gramps/gui/plug/_guioptions.py:892
 msgid "unknown mother"
 msgstr "unbekannte Mutter"
 
-#: ../gramps/gen/plug/report/utils.py:353
-#: ../gramps/gui/plug/_guioptions.py:893
+#: ../gramps/gen/plug/report/utils.py:360 ../gramps/gui/plug/_guioptions.py:894
 #, python-format
 msgid "%(father_name)s and %(mother_name)s (%(family_id)s)"
 msgstr "%(father_name)s und %(mother_name)s (%(family_id)s)"
 
 #. Do this in case of command line options query (show=filter)
-#: ../gramps/gen/plug/report/utils.py:360
+#: ../gramps/gen/plug/report/utils.py:367
 msgid "FAMILY"
 msgstr "FAMILIE"
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/gen/plug/report/utils.py:377
+#: ../gramps/gen/plug/report/utils.py:384
 #, python-format
 msgid "Ancestor Families of %s"
 msgstr "Vorfahrenfamilien von %s"
@@ -9194,7 +9258,7 @@ msgstr ""
 "lösche sie und starte Gramps neu."
 
 #: ../gramps/gen/relationship.py:860
-#: ../gramps/plugins/view/pedigreeview.py:1495
+#: ../gramps/plugins/view/pedigreeview.py:1530
 msgid "Relationship loop detected"
 msgstr "Verwandtschaftsschleife entdeckt"
 
@@ -9222,7 +9286,7 @@ msgid "undefined"
 msgstr "undefiniert"
 
 #: ../gramps/gen/relationship.py:1757
-#: ../gramps/plugins/importer/importcsv.py:217
+#: ../gramps/plugins/importer/importcsv.py:216
 msgid "husband"
 msgstr "Ehemann"
 
@@ -9328,13 +9392,11 @@ msgstr ""
 "Für diese Sprache '%s' ist keine Übersetzung der Familienbeziehungen "
 "verfügbar.Verwende stattdessen Englisch."
 
-#: ../gramps/gen/utils/alive.py:148
-#: ../gramps/plugins/importer/importcsv.py:199
+#: ../gramps/gen/utils/alive.py:148 ../gramps/plugins/importer/importcsv.py:200
 msgid "death date"
 msgstr "Sterbedatum"
 
-#: ../gramps/gen/utils/alive.py:153
-#: ../gramps/plugins/importer/importcsv.py:167
+#: ../gramps/gen/utils/alive.py:153 ../gramps/plugins/importer/importcsv.py:176
 msgid "birth date"
 msgstr "Geburtsdatum"
 
@@ -9603,47 +9665,47 @@ msgstr "Chinesisch (Hong Kong)"
 msgid "Chinese (Traditional)"
 msgstr "Chinesisch (traditionell)"
 
-#: ../gramps/gen/utils/grampslocale.py:831
+#: ../gramps/gen/utils/grampslocale.py:834
 msgid "the person"
 msgstr "die Person"
 
-#: ../gramps/gen/utils/grampslocale.py:833
+#: ../gramps/gen/utils/grampslocale.py:836
 msgid "the family"
 msgstr "die Familie"
 
-#: ../gramps/gen/utils/grampslocale.py:835
+#: ../gramps/gen/utils/grampslocale.py:838
 msgid "the place"
 msgstr "der Ort"
 
-#: ../gramps/gen/utils/grampslocale.py:837
+#: ../gramps/gen/utils/grampslocale.py:840
 msgid "the event"
 msgstr "das Ereignis"
 
-#: ../gramps/gen/utils/grampslocale.py:839
+#: ../gramps/gen/utils/grampslocale.py:842
 msgid "the repository"
 msgstr "der Aufbewahrungsort"
 
-#: ../gramps/gen/utils/grampslocale.py:841
+#: ../gramps/gen/utils/grampslocale.py:844
 msgid "the note"
 msgstr "die Notiz"
 
-#: ../gramps/gen/utils/grampslocale.py:843
+#: ../gramps/gen/utils/grampslocale.py:846
 msgid "the media"
 msgstr "das Medium"
 
-#: ../gramps/gen/utils/grampslocale.py:845
+#: ../gramps/gen/utils/grampslocale.py:848
 msgid "the source"
 msgstr "die Quelle"
 
-#: ../gramps/gen/utils/grampslocale.py:847
+#: ../gramps/gen/utils/grampslocale.py:850
 msgid "the filter"
 msgstr "der Filter"
 
-#: ../gramps/gen/utils/grampslocale.py:849
+#: ../gramps/gen/utils/grampslocale.py:852
 msgid "the citation"
 msgstr "die Fundstelle"
 
-#: ../gramps/gen/utils/grampslocale.py:851
+#: ../gramps/gen/utils/grampslocale.py:854
 msgid "See details"
 msgstr "Siehe Details"
 
@@ -9659,8 +9721,8 @@ msgstr ""
 msgid "Person|TITLE"
 msgstr "TITEL"
 
-#: ../gramps/gen/utils/keyword.py:54 ../gramps/plugins/export/exportcsv.py:381
-#: ../gramps/plugins/tool/patchnames.py:439
+#: ../gramps/gen/utils/keyword.py:54 ../gramps/plugins/export/exportcsv.py:355
+#: ../gramps/plugins/tool/patchnames.py:440
 msgid "Person|Title"
 msgstr "Titel"
 
@@ -9668,28 +9730,28 @@ msgstr "Titel"
 msgid "GIVEN"
 msgstr "VORNAME"
 
-#: ../gramps/gen/utils/keyword.py:56 ../gramps/gui/configure.py:647
-#: ../gramps/gui/configure.py:654 ../gramps/gui/configure.py:656
-#: ../gramps/gui/configure.py:657 ../gramps/gui/configure.py:658
-#: ../gramps/gui/configure.py:659 ../gramps/gui/configure.py:660
+#: ../gramps/gen/utils/keyword.py:56 ../gramps/gui/configure.py:652
+#: ../gramps/gui/configure.py:659 ../gramps/gui/configure.py:661
+#: ../gramps/gui/configure.py:662 ../gramps/gui/configure.py:663
+#: ../gramps/gui/configure.py:664 ../gramps/gui/configure.py:665
 msgid "SURNAME"
 msgstr "NACHNAME"
 
 #. show surname and first name
 #: ../gramps/gen/utils/keyword.py:56 ../gramps/gui/clipboard.py:621
-#: ../gramps/gui/configure.py:640 ../gramps/gui/configure.py:642
-#: ../gramps/gui/configure.py:644 ../gramps/gui/configure.py:646
-#: ../gramps/gui/configure.py:649 ../gramps/gui/configure.py:650
-#: ../gramps/gui/configure.py:651 ../gramps/gui/configure.py:652
+#: ../gramps/gui/configure.py:645 ../gramps/gui/configure.py:647
+#: ../gramps/gui/configure.py:649 ../gramps/gui/configure.py:651
+#: ../gramps/gui/configure.py:654 ../gramps/gui/configure.py:655
+#: ../gramps/gui/configure.py:656 ../gramps/gui/configure.py:657
 #: ../gramps/gui/editors/displaytabs/surnametab.py:74
-#: ../gramps/gui/plug/_guioptions.py:88 ../gramps/gui/plug/_guioptions.py:1492
+#: ../gramps/gui/plug/_guioptions.py:88 ../gramps/gui/plug/_guioptions.py:1493
 #: ../gramps/plugins/drawreport/statisticschart.py:334
-#: ../gramps/plugins/export/exportcsv.py:379
-#: ../gramps/plugins/importer/importcsv.py:147
+#: ../gramps/plugins/export/exportcsv.py:353
+#: ../gramps/plugins/importer/importcsv.py:158
 #: ../gramps/plugins/quickview/filterbyname.py:354
-#: ../gramps/plugins/webreport/narrativeweb.py:3226
-#: ../gramps/plugins/webreport/narrativeweb.py:4503
-#: ../gramps/plugins/webreport/narrativeweb.py:6067
+#: ../gramps/plugins/webreport/narrativeweb.py:3220
+#: ../gramps/plugins/webreport/narrativeweb.py:4549
+#: ../gramps/plugins/webreport/narrativeweb.py:6124
 msgid "Surname"
 msgstr "Nachname"
 
@@ -9705,9 +9767,9 @@ msgstr "Rufname"
 msgid "Name|COMMON"
 msgstr "ÜBLICH"
 
-#: ../gramps/gen/utils/keyword.py:58 ../gramps/gui/configure.py:644
-#: ../gramps/gui/configure.py:646 ../gramps/gui/configure.py:649
-#: ../gramps/gui/configure.py:650 ../gramps/gui/configure.py:656
+#: ../gramps/gen/utils/keyword.py:58 ../gramps/gui/configure.py:649
+#: ../gramps/gui/configure.py:651 ../gramps/gui/configure.py:654
+#: ../gramps/gui/configure.py:655 ../gramps/gui/configure.py:661
 msgid "Name|Common"
 msgstr "Üblich"
 
@@ -9789,7 +9851,7 @@ msgstr "Patronymikon[übl]"
 msgid "RAWSURNAMES"
 msgstr "UNBEARBEITETE NACHNAMEN"
 
-#: ../gramps/gen/utils/keyword.py:69 ../gramps/gui/configure.py:661
+#: ../gramps/gen/utils/keyword.py:69 ../gramps/gui/configure.py:666
 msgid "Rawsurnames"
 msgstr "unbearbeitete Nachnamen"
 
@@ -9807,9 +9869,9 @@ msgstr "PRÄFIX"
 
 #: ../gramps/gen/utils/keyword.py:71
 #: ../gramps/gui/editors/displaytabs/surnametab.py:73
-#: ../gramps/gui/glade/editperson.glade:471
-#: ../gramps/plugins/export/exportcsv.py:380
-#: ../gramps/plugins/importer/importcsv.py:156
+#: ../gramps/gui/glade/editperson.glade:470
+#: ../gramps/plugins/export/exportcsv.py:354
+#: ../gramps/plugins/importer/importcsv.py:165
 msgid "Prefix"
 msgstr "Präfix"
 
@@ -9845,21 +9907,21 @@ msgstr "%(east_longitude)s O"
 msgid "%(west_longitude)s W"
 msgstr "%(west_longitude)s W"
 
-#: ../gramps/gen/utils/string.py:46 ../gramps/gui/editors/editperson.py:351
+#: ../gramps/gen/utils/string.py:46 ../gramps/gui/editors/editperson.py:350
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:89
 #: ../gramps/gui/merge/mergeperson.py:61
 #: ../gramps/gui/views/treemodels/peoplemodel.py:97
 #: ../gramps/plugins/tool/dumpgenderstats.py:35
-#: ../gramps/plugins/webreport/narrativeweb.py:6263
+#: ../gramps/plugins/webreport/narrativeweb.py:6327
 msgid "male"
 msgstr "männlich"
 
-#: ../gramps/gen/utils/string.py:47 ../gramps/gui/editors/editperson.py:350
+#: ../gramps/gen/utils/string.py:47 ../gramps/gui/editors/editperson.py:349
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:89
 #: ../gramps/gui/merge/mergeperson.py:61
 #: ../gramps/gui/views/treemodels/peoplemodel.py:97
 #: ../gramps/plugins/tool/dumpgenderstats.py:35
-#: ../gramps/plugins/webreport/narrativeweb.py:6264
+#: ../gramps/plugins/webreport/narrativeweb.py:6328
 msgid "female"
 msgstr "weiblich"
 
@@ -9871,25 +9933,26 @@ msgstr "unbekannt"
 msgid "Invalid"
 msgstr "Ungültig"
 
-#: ../gramps/gen/utils/string.py:55 ../gramps/gui/editors/editcitation.py:216
+#: ../gramps/gen/utils/string.py:55 ../gramps/gui/editors/editcitation.py:214
 msgid "Very High"
 msgstr "Sehr hoch"
 
-#: ../gramps/gen/utils/string.py:56 ../gramps/gui/editors/editcitation.py:215
+#: ../gramps/gen/utils/string.py:56 ../gramps/gui/editors/editcitation.py:213
 #: ../gramps/plugins/tool/finddupes.py:62
 msgid "High"
 msgstr "Hoch"
 
-#: ../gramps/gen/utils/string.py:57 ../gramps/gui/editors/editcitation.py:214
+#: ../gramps/gen/utils/string.py:57 ../gramps/gui/editors/editcitation.py:212
+#: ../gramps/plugins/graph/gvfamilylines.py:242
 msgid "Normal"
 msgstr "Normal"
 
-#: ../gramps/gen/utils/string.py:58 ../gramps/gui/editors/editcitation.py:213
+#: ../gramps/gen/utils/string.py:58 ../gramps/gui/editors/editcitation.py:211
 #: ../gramps/plugins/tool/finddupes.py:60
 msgid "Low"
 msgstr "Niedrig"
 
-#: ../gramps/gen/utils/string.py:59 ../gramps/gui/editors/editcitation.py:212
+#: ../gramps/gen/utils/string.py:59 ../gramps/gui/editors/editcitation.py:210
 msgid "Very Low"
 msgstr "Sehr niedrig"
 
@@ -9942,7 +10005,7 @@ msgstr ""
 "Objekte, die mit dieser Notiz referenziert sind, fehlen in der am %s "
 "importierten Datei."
 
-#: ../gramps/grampsapp.py:154
+#: ../gramps/grampsapp.py:158
 #, python-format
 msgid ""
 "Your Python version does not meet the requirements. At least python %(v1)d."
@@ -9955,16 +10018,16 @@ msgstr ""
 "\n"
 "Gramps wird nun beendet."
 
-#: ../gramps/grampsapp.py:410 ../gramps/grampsapp.py:417
-#: ../gramps/grampsapp.py:461
+#: ../gramps/grampsapp.py:414 ../gramps/grampsapp.py:421
+#: ../gramps/grampsapp.py:465
 msgid "Configuration error:"
 msgstr "Konfigurationsfehler:"
 
-#: ../gramps/grampsapp.py:414
+#: ../gramps/grampsapp.py:418
 msgid "Error reading configuration"
 msgstr "Fehler beim Lesen der Konfiguration"
 
-#: ../gramps/grampsapp.py:418
+#: ../gramps/grampsapp.py:422
 #, python-format
 msgid ""
 "A definition for the MIME-type %s could not be found \n"
@@ -10009,19 +10072,19 @@ msgid "manual|Using_the_Clipboard"
 msgstr "Benutzen_der_Zwischenablage"
 
 #. We encounter a PLAC, having previously encountered an ADDR
-#: ../gramps/gui/clipboard.py:303 ../gramps/gui/configure.py:511
-#: ../gramps/gui/editors/editaddress.py:168
-#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:102
+#: ../gramps/gui/clipboard.py:303 ../gramps/gui/configure.py:516
+#: ../gramps/gui/editors/editaddress.py:167
+#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:106
 #: ../gramps/plugins/gramplet/repositorydetails.py:133
-#: ../gramps/plugins/lib/libgedcom.py:5418
-#: ../gramps/plugins/lib/libgedcom.py:5599
-#: ../gramps/plugins/textreport/familygroup.py:347
-#: ../gramps/plugins/webreport/narrativeweb.py:7855
+#: ../gramps/plugins/lib/libgedcom.py:5421
+#: ../gramps/plugins/lib/libgedcom.py:5587
+#: ../gramps/plugins/textreport/familygroup.py:348
+#: ../gramps/plugins/webreport/narrativeweb.py:7926
 msgid "Address"
 msgstr "Adresse"
 
 #. 0 this order range above
-#: ../gramps/gui/clipboard.py:340 ../gramps/gui/configure.py:541
+#: ../gramps/gui/clipboard.py:340 ../gramps/gui/configure.py:546
 #: ../gramps/gui/editors/editlink.py:90
 #: ../gramps/gui/editors/filtereditor.py:295
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:133
@@ -10030,26 +10093,26 @@ msgstr "Adresse"
 #: ../gramps/plugins/quickview/filterbyname.py:246
 #: ../gramps/plugins/quickview/quickview.gpr.py:201
 #: ../gramps/plugins/quickview/references.py:87
-#: ../gramps/plugins/textreport/placereport.py:439
-#: ../gramps/plugins/webreport/narrativeweb.py:373
-#: ../gramps/plugins/webreport/narrativeweb.py:1035
+#: ../gramps/plugins/textreport/placereport.py:461
+#: ../gramps/plugins/webreport/narrativeweb.py:989
 msgid "Event"
 msgstr "Ereignis"
 
 #. 5
-#: ../gramps/gui/clipboard.py:367 ../gramps/gui/configure.py:533
+#: ../gramps/gui/clipboard.py:367 ../gramps/gui/configure.py:538
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:81
 #: ../gramps/gui/editors/displaytabs/familyldsembedlist.py:55
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:65
 #: ../gramps/gui/editors/editlink.py:95
 #: ../gramps/gui/editors/filtereditor.py:296
-#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:105
+#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:108
 #: ../gramps/gui/glade/editevent.glade:270
-#: ../gramps/gui/plug/_guioptions.py:1342
-#: ../gramps/gui/selectors/selectevent.py:73
-#: ../gramps/gui/views/treemodels/placemodel.py:282
-#: ../gramps/plugins/export/exportcsv.py:499
-#: ../gramps/plugins/export/exportcsv.py:563
+#: ../gramps/gui/plug/_guioptions.py:1343
+#: ../gramps/gui/selectors/selectevent.py:72
+#: ../gramps/gui/views/treemodels/placemodel.py:283
+#: ../gramps/plugins/export/exportcsv.py:285
+#: ../gramps/plugins/export/exportcsv.py:473
+#: ../gramps/plugins/gramplet/coordinates.py:93
 #: ../gramps/plugins/gramplet/events.py:91
 #: ../gramps/plugins/gramplet/personresidence.py:61
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:112
@@ -10061,14 +10124,13 @@ msgstr "Ereignis"
 #: ../gramps/plugins/quickview/onthisday.py:82
 #: ../gramps/plugins/quickview/quickview.gpr.py:203
 #: ../gramps/plugins/quickview/references.py:92
-#: ../gramps/plugins/textreport/indivcomplete.py:461
-#: ../gramps/plugins/textreport/indivcomplete.py:656
+#: ../gramps/plugins/textreport/indivcomplete.py:496
+#: ../gramps/plugins/textreport/indivcomplete.py:694
 #: ../gramps/plugins/tool/sortevents.py:58
 #: ../gramps/plugins/view/eventview.py:86
-#: ../gramps/plugins/webreport/narrativeweb.py:382
-#: ../gramps/plugins/webreport/narrativeweb.py:1037
-#: ../gramps/plugins/webreport/narrativeweb.py:1323
-#: ../gramps/plugins/webreport/narrativeweb.py:1353
+#: ../gramps/plugins/webreport/narrativeweb.py:991
+#: ../gramps/plugins/webreport/narrativeweb.py:1279
+#: ../gramps/plugins/webreport/narrativeweb.py:1309
 msgid "Place"
 msgstr "Ort"
 
@@ -10081,7 +10143,7 @@ msgstr "Familiäres Ereignis"
 msgid "Url"
 msgstr "URL"
 
-#: ../gramps/gui/clipboard.py:459 ../gramps/gui/editors/editattribute.py:136
+#: ../gramps/gui/clipboard.py:459 ../gramps/gui/editors/editattribute.py:135
 msgid "Attribute"
 msgstr "Attribut"
 
@@ -10138,11 +10200,11 @@ msgstr "%(frel)s %(mrel)s"
 #.
 #. ------------------------------------------------------------------------
 #. functions for the actual quickreports
-#: ../gramps/gui/clipboard.py:743 ../gramps/gui/configure.py:529
+#: ../gramps/gui/clipboard.py:743 ../gramps/gui/configure.py:534
 #: ../gramps/gui/editors/editlink.py:94
 #: ../gramps/gui/editors/filtereditor.py:293
 #: ../gramps/gui/glade/editpersonref.glade:211
-#: ../gramps/plugins/export/exportcsv.py:379
+#: ../gramps/plugins/export/exportcsv.py:353
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:107
 #: ../gramps/plugins/importer/importcsv.py:207
 #: ../gramps/plugins/quickview/ageondate.py:54
@@ -10163,24 +10225,23 @@ msgstr "%(frel)s %(mrel)s"
 #: ../gramps/plugins/quickview/samesurnames.py:160
 #: ../gramps/plugins/textreport/placereport.py:221
 #: ../gramps/plugins/textreport/placereport.py:297
-#: ../gramps/plugins/textreport/placereport.py:439
+#: ../gramps/plugins/textreport/placereport.py:461
 #: ../gramps/plugins/tool/eventcmp.py:251
-#: ../gramps/plugins/webreport/narrativeweb.py:383
-#: ../gramps/plugins/webreport/narrativeweb.py:3504
-#: ../gramps/plugins/webreport/narrativeweb.py:4155
-#: ../gramps/plugins/webreport/narrativeweb.py:6985
+#: ../gramps/plugins/webreport/narrativeweb.py:3508
+#: ../gramps/plugins/webreport/narrativeweb.py:4198
+#: ../gramps/plugins/webreport/narrativeweb.py:7065
 msgid "Person"
 msgstr "Person"
 
 #. 7
-#: ../gramps/gui/clipboard.py:800 ../gramps/gui/configure.py:535
+#: ../gramps/gui/clipboard.py:800 ../gramps/gui/configure.py:540
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:78
 #: ../gramps/gui/editors/editlink.py:97 ../gramps/gui/editors/editsource.py:86
 #: ../gramps/gui/editors/filtereditor.py:297
 #: ../gramps/gui/views/treemodels/citationtreemodel.py:170
-#: ../gramps/plugins/export/exportcsv.py:499
+#: ../gramps/plugins/export/exportcsv.py:473
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:114
-#: ../gramps/plugins/importer/importcsv.py:159
+#: ../gramps/plugins/importer/importcsv.py:168
 #: ../gramps/plugins/quickview/filterbyname.py:195
 #: ../gramps/plugins/quickview/filterbyname.py:258
 #: ../gramps/plugins/quickview/quickview.gpr.py:202
@@ -10192,7 +10253,7 @@ msgid "Source"
 msgstr "Quelle"
 
 #. 6
-#: ../gramps/gui/clipboard.py:827 ../gramps/gui/configure.py:543
+#: ../gramps/gui/clipboard.py:827 ../gramps/gui/configure.py:548
 #: ../gramps/gui/editors/editlink.py:96
 #: ../gramps/gui/editors/editrepository.py:77
 #: ../gramps/gui/editors/editrepository.py:79
@@ -10203,36 +10264,37 @@ msgstr "Quelle"
 msgid "Repository"
 msgstr "Aufbewahrungsort"
 
-#: ../gramps/gui/clipboard.py:967 ../gramps/gui/dbman.py:125
+#: ../gramps/gui/clipboard.py:967 ../gramps/gui/dbman.py:126
 #: ../gramps/gui/editors/displaytabs/attrembedlist.py:63
 #: ../gramps/gui/editors/displaytabs/srcattrembedlist.py:64
 #: ../gramps/plugins/gramplet/attributes.py:57
-#: ../gramps/plugins/lib/libmetadata.py:171
-#: ../gramps/plugins/tool/patchnames.py:405
-#: ../gramps/plugins/webreport/narrativeweb.py:392
-#: ../gramps/plugins/webreport/narrativeweb.py:1414
-#: ../gramps/plugins/webreport/narrativeweb.py:1671
+#: ../gramps/plugins/lib/libmetadata.py:173
+#: ../gramps/plugins/tool/patchnames.py:406
+#: ../gramps/plugins/webreport/narrativeweb.py:1372
+#: ../gramps/plugins/webreport/narrativeweb.py:1633
 msgid "Value"
 msgstr "Wert"
 
-#: ../gramps/gui/clipboard.py:1390 ../gramps/gui/clipboard.py:1396
-#: ../gramps/gui/clipboard.py:1434 ../gramps/gui/clipboard.py:1478
+#: ../gramps/gui/clipboard.py:1387 ../gramps/gui/clipboard.py:1393
+#: ../gramps/gui/clipboard.py:1431 ../gramps/gui/clipboard.py:1475
 #: ../gramps/gui/glade/clipboard.glade:7
 msgid "Clipboard"
 msgstr "Zwischenablage"
 
-#: ../gramps/gui/clipboard.py:1522 ../gramps/gui/plug/quick/_quicktable.py:129
+#. Now add more items to popup menu, if available
+#. See details (edit, etc):
+#: ../gramps/gui/clipboard.py:1519 ../gramps/gui/plug/quick/_quicktable.py:141
 #, python-format
 msgid "the object|See %s details"
 msgstr "Siehe %s Details"
 
 #. ---------------------------
-#: ../gramps/gui/clipboard.py:1528 ../gramps/gui/plug/quick/_quicktable.py:139
+#: ../gramps/gui/clipboard.py:1525 ../gramps/gui/plug/quick/_quicktable.py:149
 #, python-format
 msgid "the object|Make %s active"
 msgstr "Aktiviere %s"
 
-#: ../gramps/gui/clipboard.py:1544
+#: ../gramps/gui/clipboard.py:1541
 #, python-format
 msgid "the object|Create Filter from %s selected..."
 msgstr "Erstelle Filter aus Auswahl %s..."
@@ -10246,18 +10308,18 @@ msgstr "Baumansicht: erste Spalte \"%s\" kann nicht geändert werden"
 msgid "Drag and drop the columns to change the order"
 msgstr "Für eine andere Reihenfolge ziehe die Spalte an eine neue Position."
 
-#: ../gramps/gui/columnorder.py:107 ../gramps/gui/configure.py:1487
-#: ../gramps/gui/configure.py:1510 ../gramps/gui/plug/_dialogs.py:123
-#: ../gramps/gui/viewmanager.py:1341
-#: ../gramps/plugins/lib/maps/geography.py:965
-#: ../gramps/plugins/lib/maps/geography.py:1218
+#: ../gramps/gui/columnorder.py:107 ../gramps/gui/configure.py:1542
+#: ../gramps/gui/configure.py:1565 ../gramps/gui/configure.py:1590
+#: ../gramps/gui/plug/_dialogs.py:130 ../gramps/gui/viewmanager.py:1453
+#: ../gramps/plugins/lib/maps/geography.py:1007
+#: ../gramps/plugins/lib/maps/geography.py:1261
 msgid "_Apply"
 msgstr "_Anwenden"
 
 #. #################
-#: ../gramps/gui/columnorder.py:128 ../gramps/gui/configure.py:1104
-#: ../gramps/plugins/drawreport/ancestortree.py:846
-#: ../gramps/plugins/drawreport/descendtree.py:1548
+#: ../gramps/gui/columnorder.py:128 ../gramps/gui/configure.py:1110
+#: ../gramps/plugins/drawreport/ancestortree.py:855
+#: ../gramps/plugins/drawreport/descendtree.py:1566
 msgid "Display"
 msgstr "Anzeige"
 
@@ -10265,42 +10327,42 @@ msgstr "Anzeige"
 msgid "Column Name"
 msgstr "Spaltenname"
 
-#: ../gramps/gui/configure.py:78
+#: ../gramps/gui/configure.py:80
 msgid "Father's surname"
 msgstr "Nachname des Vaters"
 
-#: ../gramps/gui/configure.py:80
+#: ../gramps/gui/configure.py:82
 msgid "Combination of mother's and father's surname"
 msgstr "Kombination aus den Nachnamen der Mutter und des Vaters"
 
-#: ../gramps/gui/configure.py:81
+#: ../gramps/gui/configure.py:83
 msgid "Icelandic style"
 msgstr "Isländischer Stil"
 
-#: ../gramps/gui/configure.py:103 ../gramps/gui/configure.py:105
+#: ../gramps/gui/configure.py:105 ../gramps/gui/configure.py:107
 msgid "Display Name Editor"
 msgstr "Namenseditor anzeigen"
 
 #. self.window.connect('response', self.close)
-#: ../gramps/gui/configure.py:104 ../gramps/gui/configure.py:178
-#: ../gramps/gui/glade/book.glade:469 ../gramps/gui/glade/book.glade:543
-#: ../gramps/gui/glade/clipboard.glade:73 ../gramps/gui/glade/dialog.glade:20
+#: ../gramps/gui/configure.py:106 ../gramps/gui/configure.py:180
+#: ../gramps/gui/glade/book.glade:466 ../gramps/gui/glade/book.glade:540
+#: ../gramps/gui/glade/clipboard.glade:71 ../gramps/gui/glade/dialog.glade:20
 #: ../gramps/gui/glade/dialog.glade:140
 #: ../gramps/gui/glade/displaystate.glade:25
-#: ../gramps/gui/glade/plugins.glade:24 ../gramps/gui/glade/rule.glade:26
-#: ../gramps/gui/glade/rule.glade:1029 ../gramps/gui/glade/tipofday.glade:117
-#: ../gramps/gui/glade/updateaddons.glade:26
-#: ../gramps/gui/plug/_windows.py:102 ../gramps/gui/plug/_windows.py:676
-#: ../gramps/gui/plug/_windows.py:732
-#: ../gramps/gui/plug/quick/_textbufdoc.py:62 ../gramps/gui/undohistory.py:90
-#: ../gramps/gui/viewmanager.py:1222 ../gramps/gui/views/bookmarks.py:236
-#: ../gramps/gui/views/tags.py:419 ../gramps/gui/widgets/grampletbar.py:633
+#: ../gramps/gui/glade/plugins.glade:22 ../gramps/gui/glade/rule.glade:24
+#: ../gramps/gui/glade/rule.glade:1024 ../gramps/gui/glade/tipofday.glade:117
+#: ../gramps/gui/glade/updateaddons.glade:26 ../gramps/gui/plug/_windows.py:102
+#: ../gramps/gui/plug/_windows.py:682 ../gramps/gui/plug/_windows.py:738
+#: ../gramps/gui/plug/quick/_textbufdoc.py:61 ../gramps/gui/undohistory.py:90
+#: ../gramps/gui/viewmanager.py:510 ../gramps/gui/viewmanager.py:1294
+#: ../gramps/gui/views/bookmarks.py:258 ../gramps/gui/views/tags.py:424
+#: ../gramps/gui/widgets/grampletbar.py:635
 #: ../gramps/gui/widgets/grampletpane.py:236
-#: ../gramps/plugins/lib/maps/placeselection.py:107
+#: ../gramps/plugins/lib/maps/placeselection.py:108
 msgid "_Close"
 msgstr "_Schließen"
 
-#: ../gramps/gui/configure.py:107
+#: ../gramps/gui/configure.py:110
 msgid ""
 "The following keywords are replaced with the appropriate name parts:<tt>\n"
 "  <b>Given</b>   - given name (first name)     <b>Surname</b>  - surnames "
@@ -10365,21 +10427,21 @@ msgstr ""
 "</i> Titel, <i>Sr</i> Suffix, <i>Ed</i> Spitzname, \n"
 "     <i>Underhills</i> Familienspitzname, <i>Jose</i> Rufname.\n"
 
-#: ../gramps/gui/configure.py:136
+#: ../gramps/gui/configure.py:138
 msgid " Name Editor"
 msgstr " Namenseditor"
 
-#: ../gramps/gui/configure.py:154 ../gramps/gui/configure.py:1565
-#: ../gramps/gui/views/pageview.py:607
+#: ../gramps/gui/configure.py:156 ../gramps/gui/configure.py:1645
+#: ../gramps/gui/views/pageview.py:590
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: ../gramps/gui/configure.py:229 ../gramps/gui/configure.py:234
-#: ../gramps/gui/configure.py:799
+#: ../gramps/gui/configure.py:232 ../gramps/gui/configure.py:238
+#: ../gramps/gui/configure.py:804
 msgid "Invalid or incomplete format definition."
 msgstr "Ungültige oder unvollständige Formatfestlegung."
 
-#: ../gramps/gui/configure.py:508
+#: ../gramps/gui/configure.py:513
 msgid ""
 "Enter your information so people can contact you when you distribute your "
 "Family Tree"
@@ -10387,73 +10449,76 @@ msgstr ""
 "Gib deine Daten an, so das dich Personen kontaktieren können, wenn du deinen "
 "Stammbaum weitergibst."
 
-#: ../gramps/gui/configure.py:514
+#: ../gramps/gui/configure.py:519
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:75
 #: ../gramps/plugins/view/repoview.py:92
 msgid "State/County"
 msgstr "Bundesland/Kreis"
 
-#: ../gramps/gui/configure.py:516 ../gramps/plugins/view/repoview.py:94
+#: ../gramps/gui/configure.py:521 ../gramps/plugins/view/repoview.py:94
 msgid "ZIP/Postal Code"
 msgstr "PLZ"
 
-#: ../gramps/gui/configure.py:517
+#: ../gramps/gui/configure.py:522 ../gramps/plugins/export/exportgedcom.py:784
+#: ../gramps/plugins/export/exportgedcom.py:1152
 #: ../gramps/plugins/gramplet/repositorydetails.py:121
-#: ../gramps/plugins/webreport/narrativeweb.py:384
+#: ../gramps/plugins/lib/libgedcom.py:3973
+#: ../gramps/plugins/lib/libgedcom.py:5684
+#: ../gramps/plugins/webreport/narrativeweb.py:1482
 msgid "Phone"
 msgstr "Telefon"
 
-#: ../gramps/gui/configure.py:518 ../gramps/gui/plug/_windows.py:610
+#: ../gramps/gui/configure.py:523 ../gramps/gui/plug/_windows.py:615
 #: ../gramps/plugins/view/repoview.py:95
 msgid "Email"
 msgstr "E-Mail"
 
-#: ../gramps/gui/configure.py:519
+#: ../gramps/gui/configure.py:524
 msgid "Researcher"
 msgstr "Informationen zum Forscher"
 
-#: ../gramps/gui/configure.py:539 ../gramps/gui/editors/editperson.py:647
+#: ../gramps/gui/configure.py:544 ../gramps/gui/editors/editperson.py:646
 #: ../gramps/gui/widgets/photo.py:86
 msgid "Media Object"
 msgstr "Medienobjekt"
 
-#: ../gramps/gui/configure.py:547
+#: ../gramps/gui/configure.py:552
 msgid "ID Formats"
 msgstr "ID-Formate"
 
-#: ../gramps/gui/configure.py:557
+#: ../gramps/gui/configure.py:562
 msgid "Set the colors used for boxes in the graphical views"
 msgstr "Setze die Farben für die Kästchen in den Grafikansichten."
 
-#: ../gramps/gui/configure.py:559
+#: ../gramps/gui/configure.py:564
 msgid "Gender Male Alive"
 msgstr "Geschlecht von 'männlich lebt'"
 
-#: ../gramps/gui/configure.py:561
+#: ../gramps/gui/configure.py:566
 msgid "Border Male Alive"
 msgstr "Rand von 'männlich lebt'"
 
-#: ../gramps/gui/configure.py:563
+#: ../gramps/gui/configure.py:568
 msgid "Gender Male Death"
 msgstr "Geschlecht von 'männlich tot'"
 
-#: ../gramps/gui/configure.py:565
+#: ../gramps/gui/configure.py:570
 msgid "Border Male Death"
 msgstr "Rand von 'männlich tot'"
 
-#: ../gramps/gui/configure.py:567
+#: ../gramps/gui/configure.py:572
 msgid "Gender Female Alive"
 msgstr "Geschlecht von 'weiblich lebt'"
 
-#: ../gramps/gui/configure.py:569
+#: ../gramps/gui/configure.py:574
 msgid "Border Female Alive"
 msgstr "Rand von 'weiblich lebt'"
 
-#: ../gramps/gui/configure.py:571
+#: ../gramps/gui/configure.py:576
 msgid "Gender Female Death"
 msgstr "Geschlecht von 'weiblich tot'"
 
-#: ../gramps/gui/configure.py:573
+#: ../gramps/gui/configure.py:578
 msgid "Border Female Death"
 msgstr "Rand von 'weiblich tot'"
 
@@ -10465,268 +10530,276 @@ msgstr "Rand von 'weiblich tot'"
 #. #                        'preferences.color-gender-other-death')
 #. #        self.add_color(grid, _('Border Other Death'), 8,
 #. #                        'preferences.bordercolor-gender-other-death')
-#: ../gramps/gui/configure.py:583
+#: ../gramps/gui/configure.py:588
 msgid "Gender Unknown Alive"
 msgstr "Geschlecht von 'unbekannt lebt'"
 
-#: ../gramps/gui/configure.py:585
+#: ../gramps/gui/configure.py:590
 msgid "Border Unknown Alive"
 msgstr "Rand von 'unbekannt lebt'"
 
-#: ../gramps/gui/configure.py:587
+#: ../gramps/gui/configure.py:592
 msgid "Gender Unknown Death"
 msgstr "Geschlecht von 'unbekannt tot'"
 
-#: ../gramps/gui/configure.py:589
+#: ../gramps/gui/configure.py:594
 msgid "Border Unknown Death"
 msgstr "Rand von 'unbekannt tot'"
 
-#: ../gramps/gui/configure.py:591
+#: ../gramps/gui/configure.py:596
 msgid "Colors"
 msgstr "Farben"
 
-#: ../gramps/gui/configure.py:599
+#: ../gramps/gui/configure.py:604
 msgid "Suppress warning when adding parents to a child."
 msgstr "Nicht warnen, wenn Eltern zu einem Kind hinzugefügt werden."
 
-#: ../gramps/gui/configure.py:603
+#: ../gramps/gui/configure.py:608
 msgid "Suppress warning when canceling with changed data."
 msgstr "Nicht warnen, wenn mit geänderten Daten abgebrochen wird."
 
-#: ../gramps/gui/configure.py:607
+#: ../gramps/gui/configure.py:612
 msgid "Suppress warning about missing researcher when exporting to GEDCOM."
 msgstr ""
 "Nicht warnen, wenn die Information zum Forscher beim Export zu GEDCOM fehlt."
 
-#: ../gramps/gui/configure.py:612
+#: ../gramps/gui/configure.py:617
 msgid "Show plugin status dialog on plugin load error."
 msgstr ""
 "Zeige den Zusatzmodulstatusdialog bei einem fehlerhaft geladenen Zusatzmodul."
 
-#: ../gramps/gui/configure.py:615
+#: ../gramps/gui/configure.py:620
 msgid "Warnings"
 msgstr "Warnungen"
 
-#: ../gramps/gui/configure.py:641 ../gramps/gui/configure.py:655
+#: ../gramps/gui/configure.py:646 ../gramps/gui/configure.py:660
 msgid "Common"
 msgstr "Üblich"
 
-#: ../gramps/gui/configure.py:648 ../gramps/plugins/export/exportcsv.py:380
-#: ../gramps/plugins/importer/importcsv.py:153
+#: ../gramps/gui/configure.py:653 ../gramps/plugins/export/exportcsv.py:354
+#: ../gramps/plugins/importer/importcsv.py:163
 msgid "Call"
 msgstr "Rufname"
 
-#: ../gramps/gui/configure.py:653
+#: ../gramps/gui/configure.py:658
 msgid "NotPatronymic"
 msgstr "Kein Patronymikon"
 
-#: ../gramps/gui/configure.py:730
+#: ../gramps/gui/configure.py:735
 msgid "Enter to save, Esc to cancel editing"
 msgstr "Drücke die Eingabetaste zum Speichern, ESC zum Abbrechen."
 
-#: ../gramps/gui/configure.py:777
+#: ../gramps/gui/configure.py:782
 msgid "This format exists already."
 msgstr "Dieses Format existiert bereits."
 
-#: ../gramps/gui/configure.py:816
+#: ../gramps/gui/configure.py:821
 msgid "Format"
 msgstr "Format"
 
-#: ../gramps/gui/configure.py:826
+#: ../gramps/gui/configure.py:831
 msgid "Example"
 msgstr "Beispiel"
 
 #. show an add button
-#: ../gramps/gui/configure.py:846
-#: ../gramps/gui/editors/displaytabs/embeddedlist.py:151
-#: ../gramps/gui/editors/displaytabs/embeddedlist.py:158
-#: ../gramps/gui/editors/displaytabs/eventembedlist.py:312
+#. we now construct an add menu
+#: ../gramps/gui/configure.py:851
+#: ../gramps/gui/editors/displaytabs/embeddedlist.py:146
+#: ../gramps/gui/editors/displaytabs/embeddedlist.py:153
+#: ../gramps/gui/editors/displaytabs/eventembedlist.py:314
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:127
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:122
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:129
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:115
-#: ../gramps/gui/editors/editfamily.py:149
-#: ../gramps/gui/plug/report/_bookdialog.py:694
-#: ../gramps/gui/views/tags.py:411 ../gramps/gui/widgets/fanchart.py:1777
-#: ../gramps/plugins/view/pedigreeview.py:1597
+#: ../gramps/gui/editors/editfamily.py:148
+#: ../gramps/gui/plug/report/_bookdialog.py:652 ../gramps/gui/views/tags.py:416
+#: ../gramps/gui/widgets/fanchart.py:1712
+#: ../gramps/gui/widgets/fanchart.py:1754
+#: ../gramps/plugins/view/pedigreeview.py:1627
 msgid "_Add"
 msgstr "_Hinzufügen"
 
-#: ../gramps/gui/configure.py:849
-#: ../gramps/gui/editors/displaytabs/embeddedlist.py:153
-#: ../gramps/gui/editors/displaytabs/embeddedlist.py:159
-#: ../gramps/gui/editors/displaytabs/eventembedlist.py:313
+#: ../gramps/gui/configure.py:854
+#: ../gramps/gui/editors/displaytabs/embeddedlist.py:148
+#: ../gramps/gui/editors/displaytabs/embeddedlist.py:154
+#: ../gramps/gui/editors/displaytabs/eventembedlist.py:315
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:129
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:123
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:130
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:116
-#: ../gramps/gui/glade/editlink.glade:223 ../gramps/gui/viewmanager.py:476
-#: ../gramps/gui/views/tags.py:412 ../gramps/gui/widgets/fanchart.py:1578
-#: ../gramps/plugins/view/pedigreeview.py:1638
-#: ../gramps/plugins/view/pedigreeview.py:1886
+#: ../gramps/gui/glade/editlink.glade:223
+#: ../gramps/gui/plug/report/_bookdialog.py:626
+#: ../gramps/gui/viewmanager.py:485 ../gramps/gui/views/tags.py:417
+#: ../gramps/gui/widgets/fanchart.py:1511
+#: ../gramps/plugins/view/pedigreeview.py:1662
+#: ../gramps/plugins/view/pedigreeview.py:1890
 msgid "_Edit"
 msgstr "_Bearbeiten"
 
-#: ../gramps/gui/configure.py:853
-#: ../gramps/gui/editors/displaytabs/embeddedlist.py:154
-#: ../gramps/gui/editors/displaytabs/embeddedlist.py:160
+#: ../gramps/gui/configure.py:858
+#: ../gramps/gui/editors/displaytabs/embeddedlist.py:149
+#: ../gramps/gui/editors/displaytabs/embeddedlist.py:155
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:130
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:124
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:117
-#: ../gramps/gui/editors/editfamily.py:153
-#: ../gramps/gui/plug/report/_bookdialog.py:661
-#: ../gramps/gui/views/bookmarks.py:232 ../gramps/gui/views/listview.py:211
-#: ../gramps/gui/views/tags.py:413 ../gramps/plugins/lib/libpersonview.py:382
+#: ../gramps/gui/editors/editfamily.py:151
+#: ../gramps/gui/plug/report/_bookdialog.py:621
+#: ../gramps/gui/views/bookmarks.py:254 ../gramps/gui/views/listview.py:212
+#: ../gramps/gui/views/tags.py:418 ../gramps/plugins/lib/libpersonview.py:388
 msgid "_Remove"
 msgstr "_Entfernen"
 
-#: ../gramps/gui/configure.py:978
+#: ../gramps/gui/configure.py:984
 #: ../gramps/gui/editors/displaytabs/buttontab.py:70
 #: ../gramps/gui/glade/editfamily.glade:286
 #: ../gramps/gui/glade/editfamily.glade:594
 #: ../gramps/gui/glade/editperson.glade:12
-#: ../gramps/gui/glade/editperson.glade:517 ../gramps/gui/glade/rule.glade:466
-#: ../gramps/gui/glade/styleeditor.glade:1869
+#: ../gramps/gui/glade/editperson.glade:516 ../gramps/gui/glade/rule.glade:463
+#: ../gramps/gui/glade/styleeditor.glade:1872
 #: ../gramps/gui/plug/_windows.py:148 ../gramps/gui/plug/_windows.py:203
-#: ../gramps/gui/plug/report/_bookdialog.py:666
+#: ../gramps/plugins/gramplet/coordinates.py:142
 #: ../gramps/plugins/gramplet/descendant.py:110
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: ../gramps/gui/configure.py:988
+#: ../gramps/gui/configure.py:994
 msgid "Consider single pa/matronymic as surname"
 msgstr "Einzelnes Pa/Matronymikon als Nachname betrachten"
 
-#: ../gramps/gui/configure.py:1002
+#: ../gramps/gui/configure.py:1008
 msgid "Date format"
 msgstr "Datumsformat"
 
-#: ../gramps/gui/configure.py:1010
+#: ../gramps/gui/configure.py:1016
 msgid "Years"
 msgstr "Jahre"
 
-#: ../gramps/gui/configure.py:1011
+#: ../gramps/gui/configure.py:1017
 msgid "Years, Months"
 msgstr "Jahre, Monate"
 
-#: ../gramps/gui/configure.py:1012
+#: ../gramps/gui/configure.py:1018
 msgid "Years, Months, Days"
 msgstr "Jahre, Monate, Tage"
 
-#: ../gramps/gui/configure.py:1024
+#: ../gramps/gui/configure.py:1030
 msgid "Age display precision (requires restart)"
 msgstr "Alter genau anzeigen (erfordert Neustart)"
 
-#: ../gramps/gui/configure.py:1037
+#: ../gramps/gui/configure.py:1043
 msgid "Calendar on reports"
 msgstr "Kalender für Berichte"
 
-#: ../gramps/gui/configure.py:1050
+#: ../gramps/gui/configure.py:1056
 msgid "Surname guessing"
 msgstr "Nachnamen-Schätzung"
 
-#: ../gramps/gui/configure.py:1063
+#: ../gramps/gui/configure.py:1069
 msgid "Default family relationship"
 msgstr "Standardfamilienbeziehung"
 
-#: ../gramps/gui/configure.py:1070
+#: ../gramps/gui/configure.py:1076
 msgid "Height multiple surname box (pixels)"
 msgstr "Höhe der Mehrfachnachnamenbox (Pixel)"
 
-#: ../gramps/gui/configure.py:1077
+#: ../gramps/gui/configure.py:1083
 msgid "Active person's name and ID"
 msgstr "Name und GRAMPS-ID der aktiven Person"
 
-#: ../gramps/gui/configure.py:1078
+#: ../gramps/gui/configure.py:1084
+#: ../gramps/plugins/textreport/indivcomplete.py:358
 msgid "Relationship to home person"
 msgstr "Verwandtschaftsverhältnis zur Hauptperson"
 
-#: ../gramps/gui/configure.py:1087
+#: ../gramps/gui/configure.py:1093
 msgid "Status bar"
 msgstr "Statusleiste"
 
-#: ../gramps/gui/configure.py:1094
+#: ../gramps/gui/configure.py:1100
 msgid "Show text label beside Navigator buttons (requires restart)"
 msgstr "Zeige Text neben Navigationsschaltflächen (benötigt Neustart)"
 
-#: ../gramps/gui/configure.py:1100
+#: ../gramps/gui/configure.py:1106
 msgid "Show close button in gramplet bar tabs"
 msgstr "Zeige die Schaltfläche 'Schließen' in den Gramplet Reitern."
 
-#: ../gramps/gui/configure.py:1113
+#: ../gramps/gui/configure.py:1119
 msgid "Enable automatic place title generation"
 msgstr "Automatische Ortstitelgeneration aktivieren"
 
-#: ../gramps/gui/configure.py:1125
+#: ../gramps/gui/configure.py:1131
 msgid "Suppress comma after house number"
 msgstr "Unterdrücke Komma nach Hausnummer"
 
-#: ../gramps/gui/configure.py:1130
+#: ../gramps/gui/configure.py:1136
 msgid "Reverse display order"
 msgstr "Kehre Anzeigereihenfolge um"
 
-#: ../gramps/gui/configure.py:1137
+#: ../gramps/gui/configure.py:1143
 msgid "Full place name"
 msgstr "Voller Ortsname"
 
-#: ../gramps/gui/configure.py:1138
+#: ../gramps/gui/configure.py:1144
 msgid "-> Hamlet/Village/Town/City"
 msgstr "-> Weiler/Dorf/Kleinstadt/Stadt"
 
-#: ../gramps/gui/configure.py:1139
+#: ../gramps/gui/configure.py:1145
 msgid "Hamlet/Village/Town/City ->"
 msgstr "Weiler/Dorf/Kleinstadt/Stadt ->"
 
-#: ../gramps/gui/configure.py:1144
+#: ../gramps/gui/configure.py:1150
 msgid "Restrict"
 msgstr "Begrenzen"
 
-#: ../gramps/gui/configure.py:1150
+#: ../gramps/gui/configure.py:1156
 #: ../gramps/gui/editors/displaytabs/placenameembedlist.py:65
 msgid "Language"
 msgstr "Sprache"
 
-#: ../gramps/gui/configure.py:1157
+#: ../gramps/gui/configure.py:1163
 #: ../gramps/plugins/quickview/filterbyname.py:100
 #: ../gramps/plugins/quickview/filterbyname.py:125
 #: ../gramps/plugins/textreport/tagreport.py:403
-#: ../gramps/plugins/view/view.gpr.py:204
-#: ../gramps/plugins/view/view.gpr.py:212
+#: ../gramps/plugins/view/view.gpr.py:219
 #: ../gramps/plugins/view/view.gpr.py:227
-#: ../gramps/plugins/webreport/narrativeweb.py:1901
-#: ../gramps/plugins/webreport/narrativeweb.py:1962
-#: ../gramps/plugins/webreport/narrativeweb.py:2020
-#: ../gramps/plugins/webreport/narrativeweb.py:3779
-#: ../gramps/plugins/webreport/narrativeweb.py:3928
+#: ../gramps/plugins/view/view.gpr.py:242
+#: ../gramps/plugins/webreport/narrativeweb.py:1877
+#: ../gramps/plugins/webreport/narrativeweb.py:1940
+#: ../gramps/plugins/webreport/narrativeweb.py:2006
+#: ../gramps/plugins/webreport/narrativeweb.py:3785
+#: ../gramps/plugins/webreport/narrativeweb.py:3938
 msgid "Places"
 msgstr "Orte"
 
-#: ../gramps/gui/configure.py:1173
+#: ../gramps/gui/configure.py:1179
 msgid "Missing surname"
 msgstr "Fehlender Nachname"
 
-#: ../gramps/gui/configure.py:1176
+#: ../gramps/gui/configure.py:1182
 msgid "Missing given name"
 msgstr "Fehlender Vorname"
 
-#: ../gramps/gui/configure.py:1179
+#: ../gramps/gui/configure.py:1185
 msgid "Missing record"
 msgstr "Fehlender Datensatz"
 
-#: ../gramps/gui/configure.py:1182
+#: ../gramps/gui/configure.py:1188
 msgid "Private surname"
 msgstr "Vertraulicher Nachname"
 
-#: ../gramps/gui/configure.py:1186
+#: ../gramps/gui/configure.py:1192
 msgid "Private given name"
 msgstr "Vertraulicher Vorname"
 
-#: ../gramps/gui/configure.py:1190
+#: ../gramps/gui/configure.py:1196
 msgid "Private record"
 msgstr "Vertraulicher Datensatz"
 
-#: ../gramps/gui/configure.py:1230
+#: ../gramps/gui/configure.py:1236
 msgid "Change is not immediate"
 msgstr "Änderung noch nicht wirksam"
 
-#: ../gramps/gui/configure.py:1231
+#: ../gramps/gui/configure.py:1237
 msgid ""
 "Changing the date format will not take effect until the next time Gramps is "
 "started."
@@ -10734,39 +10807,39 @@ msgstr ""
 "Das Ändern der Datumseinstellung wird erst mit einem Neustart von Gramps "
 "aktiv."
 
-#: ../gramps/gui/configure.py:1245
+#: ../gramps/gui/configure.py:1256
 msgid "Date about range"
 msgstr "Datum um Spanne"
 
-#: ../gramps/gui/configure.py:1248
+#: ../gramps/gui/configure.py:1259
 msgid "Date after range"
 msgstr "Datum nach Spanne"
 
-#: ../gramps/gui/configure.py:1251
+#: ../gramps/gui/configure.py:1262
 msgid "Date before range"
 msgstr "Datum vor Spanne"
 
-#: ../gramps/gui/configure.py:1254
+#: ../gramps/gui/configure.py:1265
 msgid "Maximum age probably alive"
 msgstr "Maximales Alter von 'wahrscheinlich am leben'"
 
-#: ../gramps/gui/configure.py:1257
+#: ../gramps/gui/configure.py:1268
 msgid "Maximum sibling age difference"
 msgstr "Maximaler Altersabstand von Geschwistern"
 
-#: ../gramps/gui/configure.py:1260
+#: ../gramps/gui/configure.py:1271
 msgid "Minimum years between generations"
 msgstr "Minimaler Abstand zwischen Generationen in Jahren"
 
-#: ../gramps/gui/configure.py:1263
+#: ../gramps/gui/configure.py:1274
 msgid "Average years between generations"
 msgstr "Durchschnittlicher Abstand zwischen Generationen in Jahren"
 
-#: ../gramps/gui/configure.py:1266
+#: ../gramps/gui/configure.py:1277
 msgid "Markup for invalid date format"
 msgstr "Markierung für ungültiges Datumsformat"
 
-#: ../gramps/gui/configure.py:1269
+#: ../gramps/gui/configure.py:1280
 #, python-format
 msgid ""
 "Convenience markups are:\n"
@@ -10797,23 +10870,29 @@ msgstr ""
 "Zum Beispiel: &lt;u&gt;&lt;b&gt;%s&lt;/b&gt;&lt;/u&gt;\n"
 "zeigt <u><b>Unterstrichenes fettes Datum</b></u>\n"
 
-#: ../gramps/gui/configure.py:1283
+#: ../gramps/gui/configure.py:1294
 msgid "Dates"
 msgstr "Daten"
 
-#: ../gramps/gui/configure.py:1293
+#: ../gramps/gui/configure.py:1305
+msgid "Use alternate Font handler for GUI and Reports (requires restart)"
+msgstr ""
+"Verwende alternativen Schrift handler für Oberfläche und Berichte (erfordert"
+" Neustart)"
+
+#: ../gramps/gui/configure.py:1311
 msgid "Add default source on GEDCOM import"
 msgstr "Füge Standardquelle beim GEDCOM Import hinzu"
 
-#: ../gramps/gui/configure.py:1297
+#: ../gramps/gui/configure.py:1315
 msgid "Add tag on import"
 msgstr "Markierung beim Import hinzufügen"
 
-#: ../gramps/gui/configure.py:1308
+#: ../gramps/gui/configure.py:1326
 msgid "Enable spelling checker"
 msgstr "Rechtschreibprüfung aktivieren"
 
-#: ../gramps/gui/configure.py:1317
+#: ../gramps/gui/configure.py:1335
 #, python-format
 msgid ""
 "GtkSpell not loaded. Spell checking will not be available.\n"
@@ -10823,100 +10902,100 @@ msgstr ""
 "stehen.\n"
 "Um es für Gramps zu erstellen siehe %(gramps_wiki_build_spell_url)s"
 
-#: ../gramps/gui/configure.py:1324
+#: ../gramps/gui/configure.py:1342
 msgid "Display Tip of the Day"
 msgstr "Tipp des Tages anzeigen"
 
-#: ../gramps/gui/configure.py:1329
+#: ../gramps/gui/configure.py:1347
 msgid "Remember last view displayed"
 msgstr "Letzte angezeigte Ansicht merken"
 
-#: ../gramps/gui/configure.py:1334
+#: ../gramps/gui/configure.py:1352
 msgid "Max generations for relationships"
 msgstr "Maximale Anzahl der Generationen für Beziehungen"
 
-#: ../gramps/gui/configure.py:1340
+#: ../gramps/gui/configure.py:1358
 msgid "Base path for relative media paths"
 msgstr "Basisverzeichnis für relative Medienpfade"
 
-#: ../gramps/gui/configure.py:1348
+#: ../gramps/gui/configure.py:1366
 msgid "Once a month"
 msgstr "Einmal im Monat"
 
-#: ../gramps/gui/configure.py:1349
+#: ../gramps/gui/configure.py:1367
 msgid "Once a week"
 msgstr "Einmal die Woche"
 
-#: ../gramps/gui/configure.py:1350
+#: ../gramps/gui/configure.py:1368
 msgid "Once a day"
 msgstr "Einmal am Tag"
 
-#: ../gramps/gui/configure.py:1351
+#: ../gramps/gui/configure.py:1369
 msgid "Always"
 msgstr "Immer"
 
-#: ../gramps/gui/configure.py:1356
+#: ../gramps/gui/configure.py:1374
 msgid "Check for updates"
 msgstr "Nach Aktualisierungen suchen"
 
-#: ../gramps/gui/configure.py:1362
+#: ../gramps/gui/configure.py:1380
 msgid "Updated addons only"
 msgstr "Nur aktualisierte Erweiterungen"
 
-#: ../gramps/gui/configure.py:1363
+#: ../gramps/gui/configure.py:1381
 msgid "New addons only"
 msgstr "Nur neue Erweiterungen"
 
-#: ../gramps/gui/configure.py:1364
+#: ../gramps/gui/configure.py:1382
 msgid "New and updated addons"
 msgstr "Neue und aktualisierte Erweiterungen"
 
-#: ../gramps/gui/configure.py:1374
+#: ../gramps/gui/configure.py:1392
 msgid "What to check"
 msgstr "Was prüfen"
 
-#: ../gramps/gui/configure.py:1379
+#: ../gramps/gui/configure.py:1397
 msgid "Where to check"
 msgstr "Wo prüfen"
 
-#: ../gramps/gui/configure.py:1383
+#: ../gramps/gui/configure.py:1401
 msgid "Do not ask about previously notified addons"
 msgstr "Bereits aktualisierte Erweiterungen nicht erneut abfragen"
 
-#: ../gramps/gui/configure.py:1388
+#: ../gramps/gui/configure.py:1406
 msgid "Check now"
 msgstr "Jetzt prüfen"
 
-#: ../gramps/gui/configure.py:1398
+#: ../gramps/gui/configure.py:1416
 msgid "Checking Addons Failed"
 msgstr "Überprüfen der Erweiterungen fehlgeschlagen"
 
-#: ../gramps/gui/configure.py:1399
+#: ../gramps/gui/configure.py:1417
 msgid "The addon repository appears to be unavailable. Please try again later."
 msgstr ""
 "Der Aufbewahrungsort im Internet für Zusatzmodule ist nicht erreichbar. "
 "Bitte versuche es später noch einmal."
 
-#: ../gramps/gui/configure.py:1408
+#: ../gramps/gui/configure.py:1427
 msgid "There are no available addons of this type"
 msgstr "Es sind keine Erweiterungen dieses Typs verfügbar"
 
-#: ../gramps/gui/configure.py:1409
+#: ../gramps/gui/configure.py:1428
 #, python-format
 msgid "Checked for '%s'"
 msgstr "Prüfe nach '%s'"
 
-#: ../gramps/gui/configure.py:1410
+#: ../gramps/gui/configure.py:1429
 msgid "' and '"
 msgstr "' und '"
 
 #. List of translated strings used here
 #. Dead code for l10n
-#: ../gramps/gui/configure.py:1415
+#: ../gramps/gui/configure.py:1434
 msgid "new"
 msgstr "neu"
 
-#: ../gramps/gui/configure.py:1415
+#: ../gramps/gui/configure.py:1434
 msgid "update"
 msgstr "Aktualisierung"
 
@@ -10924,87 +11003,114 @@ msgstr "Aktualisierung"
 msgid "Database backend"
 msgstr "Datenbank Backend"
 
-#: ../gramps/gui/configure.py:1460
+#: ../gramps/gui/configure.py:1461
 msgid "Family Tree Database path"
 msgstr "Stammbaumdatenbankpfad"
 
-#: ../gramps/gui/configure.py:1469
+#: ../gramps/gui/configure.py:1470
 msgid "Automatically load last Family Tree"
 msgstr "Letzten Stammbaum automatisch laden"
 
-#: ../gramps/gui/configure.py:1482
+#: ../gramps/gui/configure.py:1476
+msgid "Backup path"
+msgstr "Sicherungspfad"
+
+#: ../gramps/gui/configure.py:1483
+msgid "Backup on exit"
+msgstr "Beim beenden sichern"
+
+#: ../gramps/gui/configure.py:1490
+msgid "Every 15 minutes"
+msgstr "Alle 15 Minuten"
+
+#: ../gramps/gui/configure.py:1491
+msgid "Every 30 minutes"
+msgstr "Alle 30 Minuten"
+
+#: ../gramps/gui/configure.py:1492
+msgid "Every hour"
+msgstr "Jede Stunde"
+
+#: ../gramps/gui/configure.py:1497
+msgid "Autobackup"
+msgstr "Automatisches Backup"
+
+#: ../gramps/gui/configure.py:1537
 msgid "Select media directory"
 msgstr "Wähle ein Medienverzeichnis"
 
-#: ../gramps/gui/configure.py:1485 ../gramps/gui/configure.py:1508
-#: ../gramps/gui/dbloader.py:141 ../gramps/gui/editors/edittaglist.py:117
-#: ../gramps/gui/glade/addmedia.glade:24
+#: ../gramps/gui/configure.py:1540 ../gramps/gui/configure.py:1563
+#: ../gramps/gui/configure.py:1588 ../gramps/gui/dbloader.py:146
+#: ../gramps/gui/editors/edittaglist.py:117
+#: ../gramps/gui/glade/addmedia.glade:22
 #: ../gramps/gui/glade/baseselector.glade:24
 #: ../gramps/gui/glade/configure.glade:23 ../gramps/gui/glade/dialog.glade:416
 #: ../gramps/gui/glade/dialog.glade:700 ../gramps/gui/glade/dialog.glade:839
 #: ../gramps/gui/glade/editaddress.glade:21
 #: ../gramps/gui/glade/editattribute.glade:21
 #: ../gramps/gui/glade/editchildref.glade:22
-#: ../gramps/gui/glade/editcitation.glade:43
-#: ../gramps/gui/glade/editdate.glade:69
-#: ../gramps/gui/glade/editevent.glade:21
+#: ../gramps/gui/glade/editcitation.glade:42
+#: ../gramps/gui/glade/editdate.glade:69 ../gramps/gui/glade/editevent.glade:21
 #: ../gramps/gui/glade/editeventref.glade:38
 #: ../gramps/gui/glade/editfamily.glade:21
-#: ../gramps/gui/glade/editldsord.glade:41
+#: ../gramps/gui/glade/editldsord.glade:39
 #: ../gramps/gui/glade/editlink.glade:23
-#: ../gramps/gui/glade/editlocation.glade:22
+#: ../gramps/gui/glade/editlocation.glade:21
 #: ../gramps/gui/glade/editmedia.glade:22
 #: ../gramps/gui/glade/editmediaref.glade:44
-#: ../gramps/gui/glade/editname.glade:22 ../gramps/gui/glade/editnote.glade:23
-#: ../gramps/gui/glade/editperson.glade:46
+#: ../gramps/gui/glade/editname.glade:21 ../gramps/gui/glade/editnote.glade:21
+#: ../gramps/gui/glade/editperson.glade:45
 #: ../gramps/gui/glade/editpersonref.glade:21
 #: ../gramps/gui/glade/editplace.glade:21
 #: ../gramps/gui/glade/editplacename.glade:21
 #: ../gramps/gui/glade/editplaceref.glade:38
 #: ../gramps/gui/glade/editreporef.glade:22
 #: ../gramps/gui/glade/editrepository.glade:22
-#: ../gramps/gui/glade/editsource.glade:23
-#: ../gramps/gui/glade/editurl.glade:22
-#: ../gramps/gui/glade/mergecitation.glade:22
+#: ../gramps/gui/glade/editsource.glade:23 ../gramps/gui/glade/editurl.glade:21
+#: ../gramps/gui/glade/mergecitation.glade:21
 #: ../gramps/gui/glade/mergedata.glade:25
 #: ../gramps/gui/glade/mergedata.glade:246
 #: ../gramps/gui/glade/mergedata.glade:434
 #: ../gramps/gui/glade/mergedata.glade:666
-#: ../gramps/gui/glade/mergeevent.glade:22
-#: ../gramps/gui/glade/mergefamily.glade:22
-#: ../gramps/gui/glade/mergemedia.glade:22
-#: ../gramps/gui/glade/mergenote.glade:22
-#: ../gramps/gui/glade/mergeperson.glade:23
-#: ../gramps/gui/glade/mergeplace.glade:22
-#: ../gramps/gui/glade/mergerepository.glade:22
-#: ../gramps/gui/glade/mergesource.glade:22
-#: ../gramps/gui/glade/reorder.glade:24 ../gramps/gui/glade/rule.glade:319
-#: ../gramps/gui/glade/rule.glade:750 ../gramps/gui/glade/styleeditor.glade:86
-#: ../gramps/gui/glade/styleeditor.glade:1720
+#: ../gramps/gui/glade/mergeevent.glade:21
+#: ../gramps/gui/glade/mergefamily.glade:21
+#: ../gramps/gui/glade/mergemedia.glade:21
+#: ../gramps/gui/glade/mergenote.glade:21
+#: ../gramps/gui/glade/mergeperson.glade:21
+#: ../gramps/gui/glade/mergeplace.glade:21
+#: ../gramps/gui/glade/mergerepository.glade:21
+#: ../gramps/gui/glade/mergesource.glade:21
+#: ../gramps/gui/glade/reorder.glade:24 ../gramps/gui/glade/rule.glade:316
+#: ../gramps/gui/glade/rule.glade:747 ../gramps/gui/glade/styleeditor.glade:86
+#: ../gramps/gui/glade/styleeditor.glade:1723
 #: ../gramps/gui/logger/_errorview.py:140 ../gramps/gui/plug/_guioptions.py:78
-#: ../gramps/gui/plug/_guioptions.py:1727 ../gramps/gui/plug/_windows.py:427
-#: ../gramps/gui/plug/report/_fileentry.py:63
-#: ../gramps/gui/plug/report/_reportdialog.py:160 ../gramps/gui/utils.py:172
-#: ../gramps/gui/viewmanager.py:1339 ../gramps/gui/views/listview.py:1002
-#: ../gramps/gui/views/navigationview.py:360 ../gramps/gui/views/tags.py:629
+#: ../gramps/gui/plug/_guioptions.py:1728 ../gramps/gui/plug/_windows.py:432
+#: ../gramps/gui/plug/report/_fileentry.py:64
+#: ../gramps/gui/plug/report/_reportdialog.py:161 ../gramps/gui/utils.py:172
+#: ../gramps/gui/viewmanager.py:1451 ../gramps/gui/views/listview.py:1010
+#: ../gramps/gui/views/navigationview.py:362 ../gramps/gui/views/tags.py:635
 #: ../gramps/gui/widgets/progressdialog.py:437
-#: ../gramps/plugins/lib/maps/geography.py:964
-#: ../gramps/plugins/lib/maps/geography.py:1216
-#: ../gramps/plugins/tool/check.py:694 ../gramps/plugins/tool/eventcmp.py:396
-#: ../gramps/plugins/tool/populatesources.py:89
-#: ../gramps/plugins/tool/testcasegenerator.py:296
+#: ../gramps/plugins/lib/maps/geography.py:1006
+#: ../gramps/plugins/lib/maps/geography.py:1259
+#: ../gramps/plugins/tool/check.py:769 ../gramps/plugins/tool/eventcmp.py:396
+#: ../gramps/plugins/tool/populatesources.py:90
+#: ../gramps/plugins/tool/testcasegenerator.py:327
 msgid "_Cancel"
 msgstr "_Abbrechen"
 
-#: ../gramps/gui/configure.py:1505
+#: ../gramps/gui/configure.py:1560
 msgid "Select database directory"
 msgstr "Wähle ein Datenbankverzeichnis."
 
-#: ../gramps/gui/dbloader.py:125 ../gramps/gui/plug/tool.py:108
+#: ../gramps/gui/configure.py:1585 ../gramps/gui/viewmanager.py:1448
+msgid "Select backup directory"
+msgstr "Sicherungsverzeichnis wählen"
+
+#: ../gramps/gui/dbloader.py:130 ../gramps/gui/plug/tool.py:108
 msgid "Undo history warning"
 msgstr "Warnung: Bearbeitungschronik zurück setzen."
 
-#: ../gramps/gui/dbloader.py:126
+#: ../gramps/gui/dbloader.py:131
 msgid ""
 "Proceeding with import will erase the undo history for this session. In "
 "particular, you will not be able to revert the import or any changes made "
@@ -11020,23 +11126,23 @@ msgstr ""
 "Wenn du den Import möglicherweise doch rückgängig machen willst, sichere "
 "bitte deine Datenbank vorher."
 
-#: ../gramps/gui/dbloader.py:131
+#: ../gramps/gui/dbloader.py:136
 msgid "_Proceed with import"
 msgstr "_Import starten"
 
-#: ../gramps/gui/dbloader.py:131 ../gramps/gui/plug/tool.py:115
+#: ../gramps/gui/dbloader.py:136 ../gramps/gui/plug/tool.py:115
 msgid "_Stop"
 msgstr "_Stopp"
 
-#: ../gramps/gui/dbloader.py:138
+#: ../gramps/gui/dbloader.py:143
 msgid "Gramps: Import Family Tree"
 msgstr "Gramp: Stammbaum Import"
 
-#: ../gramps/gui/dbloader.py:143
+#: ../gramps/gui/dbloader.py:148
 msgid "Import"
 msgstr "Importieren"
 
-#: ../gramps/gui/dbloader.py:199
+#: ../gramps/gui/dbloader.py:204
 #, python-format
 msgid ""
 "File type \"%s\" is unknown to Gramps.\n"
@@ -11049,29 +11155,29 @@ msgstr ""
 "Gültige Typen sind: Gramps-Datenbank, Gramps-XML, Gramps-Paket, GEDCOM und "
 "andere."
 
-#: ../gramps/gui/dbloader.py:223 ../gramps/gui/dbloader.py:230
+#: ../gramps/gui/dbloader.py:228 ../gramps/gui/dbloader.py:235
 msgid "Cannot open file"
 msgstr "Die Datei kann nicht geöffnet werden."
 
-#: ../gramps/gui/dbloader.py:224
+#: ../gramps/gui/dbloader.py:229
 msgid "The selected file is a directory, not a file.\n"
 msgstr ""
 "Die ausgewählte Datei ist ein ganzes Verzeichnis und keine einzelne Datei.\n"
 
-#: ../gramps/gui/dbloader.py:231
+#: ../gramps/gui/dbloader.py:236
 msgid "You do not have read access to the selected file."
 msgstr "Du hast keinen Lesezugriff auf die ausgewählte Datei."
 
-#: ../gramps/gui/dbloader.py:241
+#: ../gramps/gui/dbloader.py:246
 msgid "Cannot create file"
 msgstr "Die Datei kann nicht erstellt werden."
 
-#: ../gramps/gui/dbloader.py:264
+#: ../gramps/gui/dbloader.py:269
 #, python-format
 msgid "Could not import file: %s"
 msgstr "Die Datei kann nicht importiert werden: %s."
 
-#: ../gramps/gui/dbloader.py:265
+#: ../gramps/gui/dbloader.py:270
 msgid ""
 "This file incorrectly identifies its character set, so it cannot be "
 "accurately imported. Please fix the encoding, and import again"
@@ -11079,13 +11185,13 @@ msgstr ""
 "Diese Datei gibt ihren Zeichensatz falsch an, daher kann sie nicht korrekt "
 "importiert werden. Bitte korrigiere den Zeichensatz und importiere sie erneut"
 
-#: ../gramps/gui/dbloader.py:343 ../gramps/gui/dbloader.py:357
-#: ../gramps/gui/dbloader.py:385
+#: ../gramps/gui/dbloader.py:348 ../gramps/gui/dbloader.py:363
+#: ../gramps/gui/dbloader.py:393
 msgid "Are you sure you want to upgrade this Family Tree?"
 msgstr "Willst du wirklich den Stammbaum aktualisieren?"
 
-#: ../gramps/gui/dbloader.py:346 ../gramps/gui/dbloader.py:360
-#: ../gramps/gui/dbloader.py:388
+#: ../gramps/gui/dbloader.py:351 ../gramps/gui/dbloader.py:366
+#: ../gramps/gui/dbloader.py:396
 msgid ""
 "I have made a backup,\n"
 "please upgrade my Family Tree"
@@ -11093,19 +11199,19 @@ msgstr ""
 "Ich habe eine Sicherung erstellt,\n"
 " bitte aktualisiere meinen Stammbaum"
 
-#: ../gramps/gui/dbloader.py:348 ../gramps/gui/dbloader.py:362
-#: ../gramps/gui/dbloader.py:376 ../gramps/gui/dbloader.py:390
-#: ../gramps/gui/plug/report/_bookdialog.py:293
-#: ../gramps/gui/plug/report/_bookdialog.py:746
-#: ../gramps/gui/viewmanager.py:762
+#: ../gramps/gui/dbloader.py:353 ../gramps/gui/dbloader.py:368
+#: ../gramps/gui/dbloader.py:383 ../gramps/gui/dbloader.py:398
+#: ../gramps/gui/plug/report/_bookdialog.py:242
+#: ../gramps/gui/plug/report/_bookdialog.py:738
+#: ../gramps/gui/viewmanager.py:790
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ../gramps/gui/dbloader.py:371
+#: ../gramps/gui/dbloader.py:378
 msgid "Are you sure you want to downgrade this Family Tree?"
 msgstr "Willst du wirklich den Stammbaum herunterstufen?"
 
-#: ../gramps/gui/dbloader.py:374
+#: ../gramps/gui/dbloader.py:381
 msgid ""
 "I have made a backup,\n"
 "please downgrade my Family Tree"
@@ -11113,127 +11219,121 @@ msgstr ""
 "Ich habe eine Sicherung erstellt,\n"
 "bitte stufe meinen Stammbaum herunter."
 
-#: ../gramps/gui/dbloader.py:458
+#: ../gramps/gui/dbloader.py:467
 msgid "All files"
 msgstr "Alle Dateien"
 
-#: ../gramps/gui/dbloader.py:499
+#: ../gramps/gui/dbloader.py:508
 msgid "Automatically detected"
 msgstr "Automatisch erkannt"
 
-#: ../gramps/gui/dbloader.py:508
+#: ../gramps/gui/dbloader.py:517
 msgid "Select file _type:"
 msgstr "Datei_typ auswählen:"
 
-#: ../gramps/gui/dbman.py:95
+#: ../gramps/gui/dbman.py:96
 #, python-format
 msgid "%s_-_Manage_Family_Trees"
 msgstr "%s_-_Stammbäume _verwalten"
 
-#: ../gramps/gui/dbman.py:96
+#: ../gramps/gui/dbman.py:97
 msgid "Family_Trees_manager_window"
 msgstr "Stammbäumeverwaltungfenster"
 
-#: ../gramps/gui/dbman.py:110 ../gramps/gui/glade/dbman.glade:352
+#: ../gramps/gui/dbman.py:111 ../gramps/gui/glade/dbman.glade:352
 msgid "_Archive"
 msgstr "_Archiv"
 
-#: ../gramps/gui/dbman.py:110
+#: ../gramps/gui/dbman.py:111
 msgid "_Extract"
 msgstr "_Extrahieren"
 
-#: ../gramps/gui/dbman.py:116 ../gramps/gui/dbman.py:141
+#: ../gramps/gui/dbman.py:118 ../gramps/gui/dbman.py:142
 msgid "Database Information"
 msgstr "Datumsinformation"
 
-#: ../gramps/gui/dbman.py:118 ../gramps/gui/editors/edittaglist.py:118
-#: ../gramps/gui/glade/addmedia.glade:40
-#: ../gramps/gui/glade/baseselector.glade:40
-#: ../gramps/gui/glade/book.glade:485 ../gramps/gui/glade/book.glade:559
-#: ../gramps/gui/glade/configure.glade:39 ../gramps/gui/glade/dbman.glade:24
-#: ../gramps/gui/glade/editaddress.glade:36
+#: ../gramps/gui/dbman.py:121 ../gramps/gui/editors/edittaglist.py:118
+#: ../gramps/gui/glade/addmedia.glade:38
+#: ../gramps/gui/glade/baseselector.glade:40 ../gramps/gui/glade/book.glade:482
+#: ../gramps/gui/glade/book.glade:556 ../gramps/gui/glade/configure.glade:39
+#: ../gramps/gui/glade/dbman.glade:24 ../gramps/gui/glade/editaddress.glade:36
 #: ../gramps/gui/glade/editattribute.glade:37
 #: ../gramps/gui/glade/editchildref.glade:38
-#: ../gramps/gui/glade/editcitation.glade:58
-#: ../gramps/gui/glade/editdate.glade:85
-#: ../gramps/gui/glade/editevent.glade:40
+#: ../gramps/gui/glade/editcitation.glade:57
+#: ../gramps/gui/glade/editdate.glade:85 ../gramps/gui/glade/editevent.glade:40
 #: ../gramps/gui/glade/editeventref.glade:54
 #: ../gramps/gui/glade/editfamily.glade:40
-#: ../gramps/gui/glade/editldsord.glade:57
+#: ../gramps/gui/glade/editldsord.glade:55
 #: ../gramps/gui/glade/editlink.glade:39
-#: ../gramps/gui/glade/editlocation.glade:38
+#: ../gramps/gui/glade/editlocation.glade:37
 #: ../gramps/gui/glade/editmedia.glade:38
 #: ../gramps/gui/glade/editmediaref.glade:59
-#: ../gramps/gui/glade/editname.glade:41 ../gramps/gui/glade/editnote.glade:39
-#: ../gramps/gui/glade/editperson.glade:65
+#: ../gramps/gui/glade/editname.glade:40 ../gramps/gui/glade/editnote.glade:37
+#: ../gramps/gui/glade/editperson.glade:64
 #: ../gramps/gui/glade/editpersonref.glade:37
 #: ../gramps/gui/glade/editplace.glade:36
 #: ../gramps/gui/glade/editplacename.glade:36
 #: ../gramps/gui/glade/editplaceref.glade:54
 #: ../gramps/gui/glade/editreporef.glade:41
 #: ../gramps/gui/glade/editrepository.glade:40
-#: ../gramps/gui/glade/editsource.glade:40
-#: ../gramps/gui/glade/editurl.glade:38
-#: ../gramps/gui/glade/mergecitation.glade:38
+#: ../gramps/gui/glade/editsource.glade:40 ../gramps/gui/glade/editurl.glade:37
+#: ../gramps/gui/glade/mergecitation.glade:37
 #: ../gramps/gui/glade/mergedata.glade:262
 #: ../gramps/gui/glade/mergedata.glade:451
 #: ../gramps/gui/glade/mergedata.glade:682
-#: ../gramps/gui/glade/mergeevent.glade:38
-#: ../gramps/gui/glade/mergefamily.glade:38
-#: ../gramps/gui/glade/mergemedia.glade:38
-#: ../gramps/gui/glade/mergenote.glade:38
-#: ../gramps/gui/glade/mergeperson.glade:39
-#: ../gramps/gui/glade/mergeplace.glade:37
-#: ../gramps/gui/glade/mergerepository.glade:38
-#: ../gramps/gui/glade/mergesource.glade:38
-#: ../gramps/gui/glade/reorder.glade:40 ../gramps/gui/glade/rule.glade:336
-#: ../gramps/gui/glade/rule.glade:767
-#: ../gramps/gui/glade/styleeditor.glade:103
-#: ../gramps/gui/glade/styleeditor.glade:1736
+#: ../gramps/gui/glade/mergeevent.glade:37
+#: ../gramps/gui/glade/mergefamily.glade:37
+#: ../gramps/gui/glade/mergemedia.glade:37
+#: ../gramps/gui/glade/mergenote.glade:37
+#: ../gramps/gui/glade/mergeperson.glade:37
+#: ../gramps/gui/glade/mergeplace.glade:36
+#: ../gramps/gui/glade/mergerepository.glade:37
+#: ../gramps/gui/glade/mergesource.glade:37
+#: ../gramps/gui/glade/reorder.glade:40 ../gramps/gui/glade/rule.glade:333
+#: ../gramps/gui/glade/rule.glade:764 ../gramps/gui/glade/styleeditor.glade:103
+#: ../gramps/gui/glade/styleeditor.glade:1739
 #: ../gramps/gui/plug/_guioptions.py:79
-#: ../gramps/gui/plug/report/_reportdialog.py:164 ../gramps/gui/utils.py:186
-#: ../gramps/gui/viewmanager.py:1220 ../gramps/gui/views/tags.py:628
-#: ../gramps/plugins/tool/check.py:695
-#: ../gramps/plugins/tool/patchnames.py:117
-#: ../gramps/plugins/tool/populatesources.py:90
-#: ../gramps/plugins/tool/testcasegenerator.py:297
+#: ../gramps/gui/plug/report/_reportdialog.py:165 ../gramps/gui/utils.py:186
+#: ../gramps/gui/viewmanager.py:1292 ../gramps/gui/views/tags.py:634
+#: ../gramps/plugins/tool/check.py:770 ../gramps/plugins/tool/patchnames.py:117
+#: ../gramps/plugins/tool/populatesources.py:91
+#: ../gramps/plugins/tool/testcasegenerator.py:328
 msgid "_OK"
 msgstr "_OK"
 
-#: ../gramps/gui/dbman.py:124
+#: ../gramps/gui/dbman.py:125
 msgid "Setting"
 msgstr "Einstellung"
 
-#: ../gramps/gui/dbman.py:360
+#: ../gramps/gui/dbman.py:366
 msgid "Family Tree name"
 msgstr "Stammbaumname:"
 
 #. icon_column = Gtk.TreeViewColumn(_('Status'), render,
 #. icon_name=ICON_COL)
-#: ../gramps/gui/dbman.py:373
+#: ../gramps/gui/dbman.py:379
 #: ../gramps/gui/editors/displaytabs/familyldsembedlist.py:53
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:63
 #: ../gramps/gui/plug/_windows.py:123 ../gramps/gui/plug/_windows.py:180
 #: ../gramps/plugins/importer/importgedcom.glade:515
 #: ../gramps/plugins/quickview/ageondate.py:54
-#: ../gramps/plugins/textreport/indivcomplete.py:459
-#: ../gramps/plugins/textreport/indivcomplete.py:654
+#: ../gramps/plugins/textreport/indivcomplete.py:494
+#: ../gramps/plugins/textreport/indivcomplete.py:692
 #: ../gramps/plugins/textreport/notelinkreport.py:95
-#: ../gramps/plugins/webreport/narrativeweb.py:387
-#: ../gramps/plugins/webreport/narrativeweb.py:1354
+#: ../gramps/plugins/webreport/narrativeweb.py:1310
 msgid "Status"
 msgstr "Status"
 
-#: ../gramps/gui/dbman.py:380
+#: ../gramps/gui/dbman.py:386
 msgid "Database Type"
 msgstr "Datenbankart"
 
-#: ../gramps/gui/dbman.py:485
+#: ../gramps/gui/dbman.py:492
 #, python-format
 msgid "Break the lock on the '%s' database?"
 msgstr "Sperre der Datenbank '%s' aufheben?"
 
-#: ../gramps/gui/dbman.py:486
+#: ../gramps/gui/dbman.py:493
 msgid ""
 "Gramps believes that someone else is actively editing this database. You "
 "cannot edit this database while it is locked. If no one is editing the "
@@ -11246,15 +11346,15 @@ msgstr ""
 "Jedoch wenn jemand anderes die Datenbank bearbeitet und du die Sperrung "
 "aufhebst, kannst du die Datenbank beschädigen."
 
-#: ../gramps/gui/dbman.py:492
+#: ../gramps/gui/dbman.py:499
 msgid "Break lock"
 msgstr "Sperre aufheben"
 
-#: ../gramps/gui/dbman.py:583
+#: ../gramps/gui/dbman.py:589
 msgid "Rename failed"
 msgstr "Umbenennung ist fehlgeschlagen"
 
-#: ../gramps/gui/dbman.py:584
+#: ../gramps/gui/dbman.py:590
 #, python-format
 msgid ""
 "An attempt to rename a version failed with the following message:\n"
@@ -11266,56 +11366,56 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dbman.py:603
+#: ../gramps/gui/dbman.py:608
 msgid "Could not rename the Family Tree."
 msgstr "Kann diesen Stammbaum nicht umbenennen."
 
-#: ../gramps/gui/dbman.py:604
+#: ../gramps/gui/dbman.py:609
 msgid "Family Tree already exists, choose a unique name."
 msgstr "Stammbaum besteht bereits, wähle einen einmaligen Namen."
 
-#: ../gramps/gui/dbman.py:647
+#: ../gramps/gui/dbman.py:653
 msgid "Extracting archive..."
 msgstr "Entpacke Archiv..."
 
-#: ../gramps/gui/dbman.py:652
+#: ../gramps/gui/dbman.py:658
 msgid "Importing archive..."
 msgstr "Importiere Archiv..."
 
-#: ../gramps/gui/dbman.py:668
+#: ../gramps/gui/dbman.py:674
 #, python-format
 msgid "Remove the '%s' Family Tree?"
 msgstr "Den '%s' Stammbaum entfernen?"
 
-#: ../gramps/gui/dbman.py:669
+#: ../gramps/gui/dbman.py:675
 msgid "Removing this Family Tree will permanently destroy the data."
 msgstr "Das Entfernen dieses Stammbaum zerstört die Daten dauerhaft."
 
-#: ../gramps/gui/dbman.py:671
+#: ../gramps/gui/dbman.py:677
 msgid "Remove Family Tree"
 msgstr "Stammbaum entfernen"
 
-#: ../gramps/gui/dbman.py:677
+#: ../gramps/gui/dbman.py:682
 #, python-format
 msgid "Remove the '%(revision)s' version of '%(database)s'"
 msgstr "Entfernt die '%(revision)s' Version von %(database)s'"
 
-#: ../gramps/gui/dbman.py:681
+#: ../gramps/gui/dbman.py:686
 msgid ""
 "Removing this version will prevent you from extracting it in the future."
 msgstr ""
 "Das Entfernen dieser Version verhindert, dass du sie zukünftig auswählen "
 "kannst."
 
-#: ../gramps/gui/dbman.py:683
+#: ../gramps/gui/dbman.py:688
 msgid "Remove version"
 msgstr "Die Version wird entfernt."
 
-#: ../gramps/gui/dbman.py:738
+#: ../gramps/gui/dbman.py:743
 msgid "Deletion failed"
 msgstr "Die Löschung ist fehlgeschlagen."
 
-#: ../gramps/gui/dbman.py:739
+#: ../gramps/gui/dbman.py:744
 #, python-format
 msgid ""
 "An attempt to delete a version failed with the following message:\n"
@@ -11327,57 +11427,57 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dbman.py:756
+#: ../gramps/gui/dbman.py:761
 #, python-format
 msgid "Convert the '%s' database?"
 msgstr "Die '%s' Datenbank konvertieren?"
 
-#: ../gramps/gui/dbman.py:757
+#: ../gramps/gui/dbman.py:762
 msgid "You wish to convert this database into the new DB-API format?"
 msgstr "Du willst diese Datenbank in das neue DB-API Format konvertieren?"
 
-#: ../gramps/gui/dbman.py:758
+#: ../gramps/gui/dbman.py:763
 msgid "Convert"
 msgstr "Konvertiere"
 
-#: ../gramps/gui/dbman.py:769
+#: ../gramps/gui/dbman.py:773
 #, python-format
 msgid "Opening the '%s' database"
 msgstr "Öffne die '%s' Datenbank"
 
-#: ../gramps/gui/dbman.py:770
+#: ../gramps/gui/dbman.py:774
 msgid "An attempt to convert the database failed. Perhaps it needs updating."
 msgstr ""
 "Der Versuch, die Datenbank zu konvertieren ist fehlgeschlagen. Vielleicht "
 "benötigt sie eine Aktualisierung. "
 
-#: ../gramps/gui/dbman.py:782 ../gramps/gui/dbman.py:807
+#: ../gramps/gui/dbman.py:785 ../gramps/gui/dbman.py:810
 #, python-format
 msgid "Converting the '%s' database"
 msgstr "Konvertiere die '%s' Datenbank"
 
-#: ../gramps/gui/dbman.py:783
+#: ../gramps/gui/dbman.py:786
 msgid "An attempt to export the database failed."
 msgstr "Ein Versuch die Datenbank zu exportieren ist fehlgeschlagen."
 
-#: ../gramps/gui/dbman.py:786
+#: ../gramps/gui/dbman.py:790
 msgid "Converting data..."
 msgstr "Konvertiere Daten..."
 
-#: ../gramps/gui/dbman.py:791 ../gramps/gui/dbman.py:794
+#: ../gramps/gui/dbman.py:795 ../gramps/gui/dbman.py:798
 #, python-format
 msgid "(Converted #%d)"
 msgstr "(Converted #%d)"
 
-#: ../gramps/gui/dbman.py:808
+#: ../gramps/gui/dbman.py:811
 msgid "An attempt to import into the database failed."
 msgstr "Ein Versuch in die Datenbank zu importieren ist fehlgeschlagen."
 
-#: ../gramps/gui/dbman.py:864
+#: ../gramps/gui/dbman.py:868
 msgid "Repair Family Tree?"
 msgstr "Stammbaum reparieren?"
 
-#: ../gramps/gui/dbman.py:865
+#: ../gramps/gui/dbman.py:869
 #, python-format
 msgid ""
 "If you click %(bold_start)sProceed%(bold_end)s, Gramps will attempt to "
@@ -11428,31 +11528,31 @@ msgstr ""
 "deaktivieren, indem du die Datei %(recover_file)s aus dem "
 "Stammbaumverzeichnis entfernst."
 
-#: ../gramps/gui/dbman.py:896
+#: ../gramps/gui/dbman.py:900
 msgid "Proceed, I have taken a backup"
 msgstr "Weiter, ich habe eine Sicherung"
 
-#: ../gramps/gui/dbman.py:897
+#: ../gramps/gui/dbman.py:901
 msgid "Stop"
 msgstr "Stopp"
 
-#: ../gramps/gui/dbman.py:919
+#: ../gramps/gui/dbman.py:924
 msgid "Rebuilding database from backup files"
 msgstr "Datenbank aus Sicherungsdateien wiederherstellen"
 
-#: ../gramps/gui/dbman.py:924
+#: ../gramps/gui/dbman.py:929
 msgid "Error restoring backup data"
 msgstr "Fehler beim wiederherstellen der Sicherungsdaten."
 
-#: ../gramps/gui/dbman.py:962
+#: ../gramps/gui/dbman.py:968
 msgid "Could not create Family Tree"
 msgstr "Der Stammbaum konnte nicht erstellt werden."
 
-#: ../gramps/gui/dbman.py:1089
+#: ../gramps/gui/dbman.py:1096
 msgid "Retrieve failed"
 msgstr "Die Abfrage ist fehlgeschlagen."
 
-#: ../gramps/gui/dbman.py:1090
+#: ../gramps/gui/dbman.py:1097
 #, python-format
 msgid ""
 "An attempt to retrieve the data failed with the following message:\n"
@@ -11463,11 +11563,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dbman.py:1129 ../gramps/gui/dbman.py:1156
+#: ../gramps/gui/dbman.py:1135 ../gramps/gui/dbman.py:1161
 msgid "Archiving failed"
 msgstr "Archivierung ist fehlgeschlagen"
 
-#: ../gramps/gui/dbman.py:1130
+#: ../gramps/gui/dbman.py:1136
 #, python-format
 msgid ""
 "An attempt to create the archive failed with the following message:\n"
@@ -11479,15 +11579,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dbman.py:1135
+#: ../gramps/gui/dbman.py:1141
 msgid "Creating data to be archived..."
 msgstr "Erstelle zu archivierende Daten..."
 
-#: ../gramps/gui/dbman.py:1144
+#: ../gramps/gui/dbman.py:1150
 msgid "Saving archive..."
 msgstr "Das Archiv wird gespeichert..."
 
-#: ../gramps/gui/dbman.py:1157
+#: ../gramps/gui/dbman.py:1162
 #, python-format
 msgid ""
 "An attempt to archive the data failed with the following message:\n"
@@ -11499,33 +11599,12 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dialog.py:202
-msgid "Error detected in database"
-msgstr "In der Datenbank wurde ein Fehler entdeckt"
-
-#: ../gramps/gui/dialog.py:203
-#, python-format
-msgid ""
-"Gramps has detected an error in the database. This can usually be resolved "
-"by running the \"Check and Repair Database\" tool.\n"
-"\n"
-"If this problem continues to exist after running this tool, please file a "
-"bug report at %(gramps_bugtracker_url)s\n"
-"\n"
-msgstr ""
-"Gramps hat einen Fehler in der Datenbank entdeckt. Dies kann meist durch "
-"Verwendung des Werkzeugs \"Datenbank prüfen und reparieren\" behoben "
-"werden.\n"
-"n\"Wenn der Fehler nach Einsatz dieses Werkzeugs nicht behoben wurde, so "
-"schreibe bitte einen Fehlerbericht auf %(gramps_bugtracker_url)s\n"
-"\n"
-
-#: ../gramps/gui/dialog.py:336 ../gramps/gui/dialog.py:409
+#: ../gramps/gui/dialog.py:339 ../gramps/gui/dialog.py:412
 #: ../gramps/gui/utils.py:301
 msgid "Attempt to force closing the dialog"
 msgstr "Versuch, das Schließen des Dialogs zu erzwingen"
 
-#: ../gramps/gui/dialog.py:337 ../gramps/gui/dialog.py:410
+#: ../gramps/gui/dialog.py:340 ../gramps/gui/dialog.py:413
 msgid ""
 "Please do not force closing this important dialog.\n"
 "Instead select one of the available options"
@@ -11533,44 +11612,44 @@ msgstr ""
 "Bitte versuche nicht, diesen wichtigen Dialog zu Umgehen.\n"
 "Wähle stattdessen eine der verfügbaren Optionen."
 
-#: ../gramps/gui/displaystate.py:378
+#: ../gramps/gui/displaystate.py:379
 #: ../gramps/plugins/gramplet/persondetails.py:169
 msgid "No active person"
 msgstr "Keine aktive Person"
 
-#: ../gramps/gui/displaystate.py:379
+#: ../gramps/gui/displaystate.py:380
 msgid "No active family"
 msgstr "Keine aktive Familie"
 
-#: ../gramps/gui/displaystate.py:380
+#: ../gramps/gui/displaystate.py:381
 msgid "No active event"
 msgstr "Kein aktives Ereignis"
 
-#: ../gramps/gui/displaystate.py:381
+#: ../gramps/gui/displaystate.py:382
 msgid "No active place"
 msgstr "Kein aktiver Ort"
 
-#: ../gramps/gui/displaystate.py:382
+#: ../gramps/gui/displaystate.py:383
 msgid "No active source"
 msgstr "Keine aktive Quelle"
 
-#: ../gramps/gui/displaystate.py:383
+#: ../gramps/gui/displaystate.py:384
 msgid "No active citation"
 msgstr "Keine aktive Fundstelle"
 
-#: ../gramps/gui/displaystate.py:384
+#: ../gramps/gui/displaystate.py:385
 msgid "No active repository"
 msgstr "Kein aktiver Aufbewahrungsort"
 
-#: ../gramps/gui/displaystate.py:385
+#: ../gramps/gui/displaystate.py:386
 msgid "No active media"
 msgstr "Keine aktiven Medien"
 
-#: ../gramps/gui/displaystate.py:386
+#: ../gramps/gui/displaystate.py:387
 msgid "No active note"
 msgstr "Keine aktive Notiz"
 
-#: ../gramps/gui/displaystate.py:579
+#: ../gramps/gui/displaystate.py:618
 msgid "No active object"
 msgstr "Kein aktives Objekt"
 
@@ -11582,24 +11661,24 @@ msgstr "Wähle_einen_Medienselektor"
 msgid "Select a media object"
 msgstr "Wähle ein Medienobjekt"
 
-#: ../gramps/gui/editors/addmedia.py:148
+#: ../gramps/gui/editors/addmedia.py:149
 msgid "Select media object"
 msgstr "Wähle ein Medienobjekt"
 
-#: ../gramps/gui/editors/addmedia.py:158
+#: ../gramps/gui/editors/addmedia.py:159
 msgid "Import failed"
 msgstr "Der Import ist fehlgeschlagen."
 
-#: ../gramps/gui/editors/addmedia.py:159
+#: ../gramps/gui/editors/addmedia.py:160
 msgid "The filename supplied could not be found."
 msgstr "Der eingegebene Dateiname konnte nicht gefunden werden."
 
-#: ../gramps/gui/editors/addmedia.py:169
+#: ../gramps/gui/editors/addmedia.py:170
 #, python-format
 msgid "Cannot import %s"
 msgstr "Kann %s nicht importieren"
 
-#: ../gramps/gui/editors/addmedia.py:170
+#: ../gramps/gui/editors/addmedia.py:171
 #, python-format
 msgid ""
 "Directory specified in preferences: Base path for relative media paths: %s "
@@ -11609,12 +11688,12 @@ msgstr ""
 "Medienpfade: %s existiert nicht. Ändere die Präferenzen oder verwende keine "
 "relativen Pfade beim Import"
 
-#: ../gramps/gui/editors/addmedia.py:233
+#: ../gramps/gui/editors/addmedia.py:238
 #, python-format
 msgid "Cannot display %s"
 msgstr "Kann %s nicht anzeigen"
 
-#: ../gramps/gui/editors/addmedia.py:234
+#: ../gramps/gui/editors/addmedia.py:239
 msgid ""
 "Gramps is not able to display the image file. This may be caused by a "
 "corrupt file."
@@ -11685,47 +11764,45 @@ msgstr "_Attribute"
 #: ../gramps/gui/editors/displaytabs/placerefembedlist.py:58
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:66
 #: ../gramps/gui/editors/editfamily.py:122
-#: ../gramps/gui/editors/filtereditor.py:977
+#: ../gramps/gui/editors/filtereditor.py:976
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:104
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:111
-#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:100
+#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:103
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:111
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:87
-#: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:96
+#: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:100
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:127
-#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:100
-#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:99
+#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:104
+#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:103
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:86
-#: ../gramps/gui/merge/mergeperson.py:178
-#: ../gramps/gui/plug/_guioptions.py:1165
-#: ../gramps/gui/plug/_guioptions.py:1343
-#: ../gramps/gui/selectors/selectcitation.py:76
-#: ../gramps/gui/selectors/selectevent.py:75
-#: ../gramps/gui/selectors/selectfamily.py:70
-#: ../gramps/gui/selectors/selectnote.py:76
+#: ../gramps/gui/merge/mergeperson.py:179
+#: ../gramps/gui/plug/_guioptions.py:1166
+#: ../gramps/gui/plug/_guioptions.py:1344
+#: ../gramps/gui/selectors/selectcitation.py:75
+#: ../gramps/gui/selectors/selectevent.py:74
+#: ../gramps/gui/selectors/selectfamily.py:69
+#: ../gramps/gui/selectors/selectnote.py:75
 #: ../gramps/gui/selectors/selectobject.py:81
-#: ../gramps/gui/selectors/selectperson.py:95
-#: ../gramps/gui/selectors/selectplace.py:72
-#: ../gramps/gui/selectors/selectrepository.py:71
-#: ../gramps/gui/selectors/selectsource.py:72
-#: ../gramps/gui/views/bookmarks.py:218
-#: ../gramps/gui/views/navigationview.py:355
-#: ../gramps/plugins/gramplet/locations.py:87
+#: ../gramps/gui/selectors/selectperson.py:94
+#: ../gramps/gui/selectors/selectplace.py:71
+#: ../gramps/gui/selectors/selectrepository.py:70
+#: ../gramps/gui/selectors/selectsource.py:71
+#: ../gramps/gui/views/bookmarks.py:240
+#: ../gramps/gui/views/navigationview.py:357
+#: ../gramps/plugins/gramplet/locations.py:88
 #: ../gramps/plugins/lib/libpersonview.py:99
 #: ../gramps/plugins/lib/libplaceview.py:85
 #: ../gramps/plugins/tool/eventcmp.py:251
 #: ../gramps/plugins/tool/notrelated.py:125
-#: ../gramps/plugins/tool/patchnames.py:399
-#: ../gramps/plugins/tool/removeunused.py:191
-#: ../gramps/plugins/tool/sortevents.py:56
-#: ../gramps/plugins/tool/verify.py:535
+#: ../gramps/plugins/tool/patchnames.py:400
+#: ../gramps/plugins/tool/removeunused.py:194
+#: ../gramps/plugins/tool/sortevents.py:56 ../gramps/plugins/tool/verify.py:570
 #: ../gramps/plugins/view/citationlistview.py:99
 #: ../gramps/plugins/view/citationtreeview.py:94
 #: ../gramps/plugins/view/eventview.py:83
 #: ../gramps/plugins/view/familyview.py:79
-#: ../gramps/plugins/view/mediaview.py:95
-#: ../gramps/plugins/view/noteview.py:80 ../gramps/plugins/view/relview.py:591
-#: ../gramps/plugins/view/repoview.py:86
+#: ../gramps/plugins/view/mediaview.py:95 ../gramps/plugins/view/noteview.py:80
+#: ../gramps/plugins/view/relview.py:602 ../gramps/plugins/view/repoview.py:86
 #: ../gramps/plugins/view/sourceview.py:83
 msgid "ID"
 msgstr "ID"
@@ -11743,19 +11820,17 @@ msgstr "eferenz bearbeiten"
 msgid "%(part1)s - %(part2)s"
 msgstr "%(part1)s - %(part2)s"
 
-#. we now construct an add menu
 #: ../gramps/gui/editors/displaytabs/buttontab.py:68
 #: ../gramps/gui/glade/editfamily.glade:217
 #: ../gramps/gui/glade/editfamily.glade:224
 #: ../gramps/gui/glade/editfamily.glade:494
 #: ../gramps/gui/glade/editfamily.glade:501
 #: ../gramps/gui/glade/editperson.glade:22
-#: ../gramps/gui/glade/editperson.glade:362 ../gramps/gui/glade/rule.glade:425
-#: ../gramps/gui/glade/rule.glade:432
-#: ../gramps/gui/glade/styleeditor.glade:1830
-#: ../gramps/gui/glade/styleeditor.glade:1837
-#: ../gramps/gui/widgets/fanchart.py:1823
-#: ../gramps/plugins/view/relview.py:408
+#: ../gramps/gui/glade/editperson.glade:361 ../gramps/gui/glade/rule.glade:422
+#: ../gramps/gui/glade/rule.glade:429
+#: ../gramps/gui/glade/styleeditor.glade:1833
+#: ../gramps/gui/glade/styleeditor.glade:1840
+#: ../gramps/plugins/view/relview.py:418
 msgid "Add"
 msgstr "Hinzufügen"
 
@@ -11766,16 +11841,16 @@ msgstr "Hinzufügen"
 #: ../gramps/gui/glade/editfamily.glade:563
 #: ../gramps/gui/glade/grampletpane.glade:104
 #: ../gramps/gui/glade/grampletpane.glade:111
-#: ../gramps/gui/glade/rule.glade:493 ../gramps/gui/glade/rule.glade:500
-#: ../gramps/gui/glade/styleeditor.glade:1894
-#: ../gramps/gui/glade/styleeditor.glade:1901
+#: ../gramps/gui/glade/rule.glade:490 ../gramps/gui/glade/rule.glade:497
+#: ../gramps/gui/glade/styleeditor.glade:1897
+#: ../gramps/gui/glade/styleeditor.glade:1904
 msgid "Remove"
 msgstr "Entfernen"
 
 #: ../gramps/gui/editors/displaytabs/buttontab.py:71
-#: ../gramps/gui/editors/displaytabs/embeddedlist.py:152
+#: ../gramps/gui/editors/displaytabs/embeddedlist.py:147
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:128
-#: ../gramps/plugins/view/relview.py:412
+#: ../gramps/plugins/view/relview.py:422
 msgid "Share"
 msgstr "Beteiligen"
 
@@ -11819,17 +11894,17 @@ msgstr "Gewählte Fundstelle nach unten verschieben"
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:81
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:106
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:88
-#: ../gramps/gui/selectors/selectsource.py:71
+#: ../gramps/gui/selectors/selectsource.py:70
 #: ../gramps/plugins/gramplet/citations.py:78
 #: ../gramps/plugins/textreport/tagreport.py:745
 #: ../gramps/plugins/view/sourceview.py:84
-#: ../gramps/plugins/webreport/narrativeweb.py:4809
-#: ../gramps/plugins/webreport/narrativeweb.py:4906
+#: ../gramps/plugins/webreport/narrativeweb.py:4860
+#: ../gramps/plugins/webreport/narrativeweb.py:4957
 msgid "Author"
 msgstr "Autor"
 
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:82
-#: ../gramps/plugins/webreport/narrativeweb.py:2603
+#: ../gramps/plugins/webreport/narrativeweb.py:2590
 msgid "Page"
 msgstr "Seite"
 
@@ -11838,18 +11913,18 @@ msgid "_Source Citations"
 msgstr "_Quelle Fundstellen"
 
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:171
-#: ../gramps/gui/editors/displaytabs/citationembedlist.py:181
-#: ../gramps/gui/editors/displaytabs/citationembedlist.py:254
-#: ../gramps/gui/editors/displaytabs/citationembedlist.py:274
+#: ../gramps/gui/editors/displaytabs/citationembedlist.py:182
+#: ../gramps/gui/editors/displaytabs/citationembedlist.py:256
+#: ../gramps/gui/editors/displaytabs/citationembedlist.py:277
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:267
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:337
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:332
 #: ../gramps/plugins/view/citationtreeview.py:430
-#: ../gramps/plugins/view/citationtreeview.py:481
+#: ../gramps/plugins/view/citationtreeview.py:473
 msgid "Cannot share this reference"
 msgstr "Kann diese Referenz nicht teilen"
 
-#: ../gramps/gui/editors/displaytabs/citationembedlist.py:190
-#: ../gramps/plugins/view/citationtreeview.py:489
+#: ../gramps/gui/editors/displaytabs/citationembedlist.py:192
+#: ../gramps/plugins/view/citationtreeview.py:481
 msgid ""
 "This citation cannot be created at this time. Either the associated Source "
 "object is already being edited, or another citation associated with the same "
@@ -11869,43 +11944,42 @@ msgstr ""
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:60
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:112
 #: ../gramps/gui/glade/editfamily.glade:192
-#: ../gramps/gui/merge/mergeperson.py:220
-#: ../gramps/gui/selectors/selectfamily.py:71
+#: ../gramps/gui/merge/mergeperson.py:221
+#: ../gramps/gui/selectors/selectfamily.py:70
 #: ../gramps/gui/widgets/reorderfam.py:83
 #: ../gramps/plugins/gramplet/persondetails.py:219
 #: ../gramps/plugins/importer/importcsv.py:215
 #: ../gramps/plugins/quickview/all_relations.py:300
-#: ../gramps/plugins/textreport/familygroup.py:227
-#: ../gramps/plugins/textreport/familygroup.py:238
-#: ../gramps/plugins/textreport/indivcomplete.py:308
-#: ../gramps/plugins/textreport/indivcomplete.py:310
-#: ../gramps/plugins/textreport/indivcomplete.py:862
+#: ../gramps/plugins/textreport/familygroup.py:228
+#: ../gramps/plugins/textreport/familygroup.py:239
+#: ../gramps/plugins/textreport/indivcomplete.py:317
+#: ../gramps/plugins/textreport/indivcomplete.py:319
+#: ../gramps/plugins/textreport/indivcomplete.py:902
 #: ../gramps/plugins/textreport/tagreport.py:248
 #: ../gramps/plugins/view/familyview.py:80
-#: ../gramps/plugins/view/relview.py:888
-#: ../gramps/plugins/webreport/narrativeweb.py:7353
+#: ../gramps/plugins/view/relview.py:899
+#: ../gramps/plugins/webreport/narrativeweb.py:7437
 msgid "Father"
 msgstr "Vater"
 
-#. ----------------------------------
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:61
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:113
 #: ../gramps/gui/glade/editfamily.glade:470
-#: ../gramps/gui/merge/mergeperson.py:222
-#: ../gramps/gui/selectors/selectfamily.py:72
+#: ../gramps/gui/merge/mergeperson.py:223
+#: ../gramps/gui/selectors/selectfamily.py:71
 #: ../gramps/gui/widgets/reorderfam.py:84
 #: ../gramps/plugins/gramplet/persondetails.py:220
 #: ../gramps/plugins/importer/importcsv.py:212
 #: ../gramps/plugins/quickview/all_relations.py:297
-#: ../gramps/plugins/textreport/familygroup.py:244
-#: ../gramps/plugins/textreport/familygroup.py:255
-#: ../gramps/plugins/textreport/indivcomplete.py:317
-#: ../gramps/plugins/textreport/indivcomplete.py:319
-#: ../gramps/plugins/textreport/indivcomplete.py:863
+#: ../gramps/plugins/textreport/familygroup.py:245
+#: ../gramps/plugins/textreport/familygroup.py:256
+#: ../gramps/plugins/textreport/indivcomplete.py:326
+#: ../gramps/plugins/textreport/indivcomplete.py:328
+#: ../gramps/plugins/textreport/indivcomplete.py:903
 #: ../gramps/plugins/textreport/tagreport.py:254
 #: ../gramps/plugins/view/familyview.py:81
-#: ../gramps/plugins/view/relview.py:889
-#: ../gramps/plugins/webreport/narrativeweb.py:7367
+#: ../gramps/plugins/view/relview.py:900
+#: ../gramps/plugins/webreport/narrativeweb.py:7451
 msgid "Mother"
 msgstr "Mutter"
 
@@ -11944,7 +12018,7 @@ msgid "_Events"
 msgstr "_Ereignisse"
 
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:247
-#: ../gramps/gui/editors/displaytabs/eventembedlist.py:346
+#: ../gramps/gui/editors/displaytabs/eventembedlist.py:348
 msgid ""
 "This event reference cannot be edited at this time. Either the associated "
 "event is already being edited or another event reference that is associated "
@@ -11958,18 +12032,18 @@ msgstr ""
 "\n"
 "Um die Ereignis-Referenz zu bearbeiten, muss die Quelle geschlossen werden."
 
-#: ../gramps/gui/editors/displaytabs/eventembedlist.py:280
-#: ../gramps/gui/editors/displaytabs/eventembedlist.py:345
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:357
+#: ../gramps/gui/editors/displaytabs/eventembedlist.py:281
+#: ../gramps/gui/editors/displaytabs/eventembedlist.py:347
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:353
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:168
 msgid "Cannot edit this reference"
 msgstr "Kann diese Referenz nicht bearbeiten"
 
-#: ../gramps/gui/editors/displaytabs/eventembedlist.py:322
+#: ../gramps/gui/editors/displaytabs/eventembedlist.py:324
 msgid "Cannot change Person"
 msgstr "Diese Person kann nicht geändert werden."
 
-#: ../gramps/gui/editors/displaytabs/eventembedlist.py:323
+#: ../gramps/gui/editors/displaytabs/eventembedlist.py:325
 msgid "You cannot change Person events in the Family Editor"
 msgstr "Du kannst persönliche Ereignisse nicht im Familieneditor ändern."
 
@@ -11981,10 +12055,9 @@ msgstr "%(groupname)s - %(groupnumber)d"
 
 #: ../gramps/gui/editors/displaytabs/familyldsembedlist.py:54
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:64
-#: ../gramps/plugins/textreport/indivcomplete.py:460
-#: ../gramps/plugins/textreport/indivcomplete.py:655
-#: ../gramps/plugins/webreport/narrativeweb.py:391
-#: ../gramps/plugins/webreport/narrativeweb.py:1352
+#: ../gramps/plugins/textreport/indivcomplete.py:495
+#: ../gramps/plugins/textreport/indivcomplete.py:693
+#: ../gramps/plugins/webreport/narrativeweb.py:1308
 msgid "Temple"
 msgstr "Tempel"
 
@@ -11992,29 +12065,28 @@ msgstr "Tempel"
 msgid "_Gallery"
 msgstr "_Galerie"
 
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:138
-#: ../gramps/gui/editors/editperson.py:650
-#: ../gramps/plugins/view/mediaview.py:210
-msgid "View"
-msgstr "Ansicht"
+#. Translators: _View means "to look at this"
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:140
+msgid "verb:look at this|_View"
+msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:146
-#: ../gramps/plugins/view/mediaview.py:214
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:145
+#: ../gramps/plugins/view/mediaview.py:215
 msgid "Open Containing _Folder"
 msgstr "Enthaltenen _Ordner öffnen"
 
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:154
-#: ../gramps/gui/widgets/photo.py:87
-msgid "Make Active Media"
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:153
+#, fuzzy
+msgid "_Make Active Media"
 msgstr "zum aktiven Medium machen"
 
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:263
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:257
 #: ../gramps/gui/editors/editperson.py:960
-#: ../gramps/plugins/textreport/indivcomplete.py:552
+#: ../gramps/plugins/textreport/indivcomplete.py:587
 msgid "Non existing media found in the Gallery"
 msgstr "Nicht existierendes Medium in der Galerie gefunden"
 
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:312
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:307
 msgid ""
 "This media reference cannot be edited at this time. Either the associated "
 "media object is already being edited or another media reference that is "
@@ -12030,8 +12102,8 @@ msgstr ""
 "Um die Medienreferenz zu bearbeiten, muss das Medienobjekt geschlossen "
 "werden."
 
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:530
-#: ../gramps/plugins/view/mediaview.py:196
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:527
+#: ../gramps/plugins/view/mediaview.py:197
 msgid "Drag Media Object"
 msgstr "Medienobjekt ziehen"
 
@@ -12106,13 +12178,13 @@ msgstr "Als Standardnamen setzen"
 #.
 #. -------------------------------------------------------------------------
 #: ../gramps/gui/editors/displaytabs/namemodel.py:56
-#: ../gramps/gui/plug/_guioptions.py:1246 ../gramps/gui/views/tags.py:488
+#: ../gramps/gui/plug/_guioptions.py:1247 ../gramps/gui/views/tags.py:493
 #: ../gramps/plugins/quickview/all_relations.py:306
 msgid "Yes"
 msgstr "Ja"
 
 #: ../gramps/gui/editors/displaytabs/namemodel.py:57
-#: ../gramps/gui/plug/_guioptions.py:1245 ../gramps/gui/views/tags.py:489
+#: ../gramps/gui/plug/_guioptions.py:1246 ../gramps/gui/views/tags.py:494
 #: ../gramps/plugins/quickview/all_relations.py:310
 msgid "No"
 msgstr "Nein"
@@ -12151,11 +12223,11 @@ msgid "Move the selected note downwards"
 msgstr "Gewählte Notiz nach unten verschieben"
 
 #: ../gramps/gui/editors/displaytabs/notetab.py:78
-#: ../gramps/gui/glade/addmedia.glade:138
+#: ../gramps/gui/glade/addmedia.glade:136
 #: ../gramps/gui/glade/editmedia.glade:188
 #: ../gramps/gui/glade/editmediaref.glade:190
 #: ../gramps/gui/glade/editmediaref.glade:503
-#: ../gramps/gui/selectors/selectnote.py:75
+#: ../gramps/gui/selectors/selectnote.py:74
 #: ../gramps/plugins/view/noteview.py:79
 msgid "Preview"
 msgstr "Vorschau"
@@ -12166,7 +12238,7 @@ msgstr "_Notizen"
 
 #. add personal column
 #: ../gramps/gui/editors/displaytabs/personeventembedlist.py:50
-#: ../gramps/plugins/webreport/narrativeweb.py:2065
+#: ../gramps/plugins/webreport/narrativeweb.py:2051
 msgid "Personal"
 msgstr "Persönlich"
 
@@ -12264,8 +12336,8 @@ msgid "Alternative Names"
 msgstr "Alternative Namen"
 
 #: ../gramps/gui/editors/displaytabs/placerefembedlist.py:69
-#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:104
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1276
+#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:108
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1299
 msgid "Enclosed By"
 msgstr "Teil von"
 
@@ -12347,6 +12419,7 @@ msgid "Move the selected surname downwards"
 msgstr "Gewählten Nachnamen nach unten verschieben"
 
 #: ../gramps/gui/editors/displaytabs/surnametab.py:77
+#: ../gramps/plugins/lib/libgedcom.py:618
 msgid "Origin"
 msgstr "Ursprung"
 
@@ -12387,8 +12460,8 @@ msgid "_Internet"
 msgstr "_Internet"
 
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:118
-#: ../gramps/gui/glade/editurl.glade:201
-#: ../gramps/gui/views/navigationview.py:361
+#: ../gramps/gui/glade/editurl.glade:200
+#: ../gramps/gui/views/navigationview.py:363
 msgid "_Jump to"
 msgstr "_Springe nach"
 
@@ -12396,8 +12469,8 @@ msgstr "_Springe nach"
 msgid "manual|Address_Editor_dialog"
 msgstr "Adresseditor_Dialog"
 
-#: ../gramps/gui/editors/editaddress.py:94
-#: ../gramps/gui/editors/editaddress.py:168
+#: ../gramps/gui/editors/editaddress.py:92
+#: ../gramps/gui/editors/editaddress.py:167
 msgid "Address Editor"
 msgstr "Adresseditor"
 
@@ -12405,34 +12478,34 @@ msgstr "Adresseditor"
 msgid "manual|Attribute_Editor_dialog"
 msgstr "Attributeditor_Dialog"
 
-#: ../gramps/gui/editors/editattribute.py:96
-#: ../gramps/gui/editors/editattribute.py:137
+#: ../gramps/gui/editors/editattribute.py:94
+#: ../gramps/gui/editors/editattribute.py:136
 msgid "Attribute Editor"
 msgstr "Attributeditor"
 
-#: ../gramps/gui/editors/editattribute.py:131
-#: ../gramps/gui/editors/editattribute.py:135
+#: ../gramps/gui/editors/editattribute.py:130
+#: ../gramps/gui/editors/editattribute.py:134
 msgid "New Attribute"
 msgstr "Neues Attribut"
 
-#: ../gramps/gui/editors/editattribute.py:149
+#: ../gramps/gui/editors/editattribute.py:148
 msgid "Cannot save attribute"
 msgstr "Das Attribut kann nicht gespeichert werden."
 
-#: ../gramps/gui/editors/editattribute.py:150
+#: ../gramps/gui/editors/editattribute.py:149
 msgid "The attribute type cannot be empty"
 msgstr "Attributart darf nicht leer sein"
 
-#: ../gramps/gui/editors/editchildref.py:67
+#: ../gramps/gui/editors/editchildref.py:66
 msgid "manual|Child_Reference_Editor"
 msgstr "Kindreferenzeditor"
 
-#: ../gramps/gui/editors/editchildref.py:102
-#: ../gramps/gui/editors/editchildref.py:197
+#: ../gramps/gui/editors/editchildref.py:99
+#: ../gramps/gui/editors/editchildref.py:195
 msgid "Child Reference Editor"
 msgstr "Kindreferenzeditor"
 
-#: ../gramps/gui/editors/editchildref.py:197
+#: ../gramps/gui/editors/editchildref.py:195
 msgid "Child Reference"
 msgstr "Kindreferenz"
 
@@ -12445,15 +12518,15 @@ msgstr "Neue_Fundstelle_Dialog"
 msgid "New Citation"
 msgstr "Neue Fundstelle"
 
-#: ../gramps/gui/editors/editcitation.py:279
+#: ../gramps/gui/editors/editcitation.py:277
 msgid "Edit Citation"
 msgstr "Fundstelle bearbeiten"
 
-#: ../gramps/gui/editors/editcitation.py:287
+#: ../gramps/gui/editors/editcitation.py:285
 msgid "No source selected"
 msgstr "Keine Quelle ausgewählt"
 
-#: ../gramps/gui/editors/editcitation.py:288
+#: ../gramps/gui/editors/editcitation.py:286
 msgid ""
 "A source is anything (personal testimony, video recording, photograph, "
 "newspaper column, gravestone...) from which information can be derived. To "
@@ -12467,17 +12540,17 @@ msgstr ""
 "Quelle und gib dann die Stelle ein, an der sich die Informationen in dieser "
 "Quelle befinden, im 'Band/Seite' Feld ein."
 
-#: ../gramps/gui/editors/editcitation.py:302
+#: ../gramps/gui/editors/editcitation.py:300
 msgid "Cannot save citation. ID already exists."
 msgstr "Die Fundstelle kann nicht gespeichert werden. ID existiert bereits."
 
-#: ../gramps/gui/editors/editcitation.py:303
-#: ../gramps/gui/editors/editevent.py:250
-#: ../gramps/gui/editors/editmedia.py:299
+#: ../gramps/gui/editors/editcitation.py:301
+#: ../gramps/gui/editors/editevent.py:249
+#: ../gramps/gui/editors/editmedia.py:298
 #: ../gramps/gui/editors/editperson.py:846
-#: ../gramps/gui/editors/editplace.py:297
+#: ../gramps/gui/editors/editplace.py:295
 #: ../gramps/gui/editors/editreference.py:287
-#: ../gramps/gui/editors/editrepository.py:190
+#: ../gramps/gui/editors/editrepository.py:189
 #: ../gramps/gui/editors/editsource.py:210
 #, python-format
 msgid ""
@@ -12490,17 +12563,17 @@ msgstr ""
 "eine andere ID ein oder lasse sie leer um den nächsten verfügbaren ID Wert "
 "zu erhalten."
 
-#: ../gramps/gui/editors/editcitation.py:315
+#: ../gramps/gui/editors/editcitation.py:313
 #, python-format
 msgid "Add Citation (%s)"
 msgstr "Fundstelle (%s) hinzufügen"
 
-#: ../gramps/gui/editors/editcitation.py:321
+#: ../gramps/gui/editors/editcitation.py:319
 #, python-format
 msgid "Edit Citation (%s)"
 msgstr "Fundstelle (%s) bearbeiten"
 
-#: ../gramps/gui/editors/editcitation.py:356
+#: ../gramps/gui/editors/editcitation.py:354
 #, python-format
 msgid "Delete Citation (%s)"
 msgstr "Fundstelle (%s) löschen"
@@ -12569,11 +12642,11 @@ msgstr "Ereignis: %s"
 msgid "New Event"
 msgstr "Neues Ereignis"
 
-#: ../gramps/gui/editors/editevent.py:230
+#: ../gramps/gui/editors/editevent.py:228
 #: ../gramps/plugins/view/geoclose.py:545
-#: ../gramps/plugins/view/geoevents.py:338
-#: ../gramps/plugins/view/geoevents.py:372
-#: ../gramps/plugins/view/geofamclose.py:736
+#: ../gramps/plugins/view/geoevents.py:340
+#: ../gramps/plugins/view/geoevents.py:374
+#: ../gramps/plugins/view/geofamclose.py:735
 #: ../gramps/plugins/view/geofamily.py:430
 #: ../gramps/plugins/view/geomoves.py:620
 #: ../gramps/plugins/view/geoperson.py:440
@@ -12582,23 +12655,23 @@ msgstr "Neues Ereignis"
 msgid "Edit Event"
 msgstr "Ereignis bearbeiten"
 
-#: ../gramps/gui/editors/editevent.py:239
-#: ../gramps/gui/editors/editevent.py:262
+#: ../gramps/gui/editors/editevent.py:237
+#: ../gramps/gui/editors/editevent.py:261
 msgid "Cannot save event"
 msgstr "Das Ereignis kann nicht gespeichert werden."
 
-#: ../gramps/gui/editors/editevent.py:240
+#: ../gramps/gui/editors/editevent.py:238
 msgid "No data exists for this event. Please enter data or cancel the edit."
 msgstr ""
 "Es existieren keine Daten für dieses Ereignis. Bitte gib Daten ein oder "
 "brich das Bearbeiten ab."
 
-#: ../gramps/gui/editors/editevent.py:249
+#: ../gramps/gui/editors/editevent.py:248
 #: ../gramps/gui/editors/editreference.py:276
 msgid "Cannot save event. ID already exists."
 msgstr "Das Ereignis kann gespeichert werden. ID besteht bereits."
 
-#: ../gramps/gui/editors/editevent.py:263
+#: ../gramps/gui/editors/editevent.py:262
 msgid "The event type cannot be empty"
 msgstr "Ereignisart darf nicht leer sein"
 
@@ -12621,16 +12694,16 @@ msgstr "Ereignis (%s) löschen"
 msgid "manual|Event_Reference_Editor_dialog"
 msgstr "Ereignisreferenzeditor_Dialog"
 
-#: ../gramps/gui/editors/editeventref.py:78
+#: ../gramps/gui/editors/editeventref.py:76
 #: ../gramps/gui/editors/editeventref.py:255
 msgid "Event Reference Editor"
 msgstr "Ereignisreferenzeditor"
 
 #: ../gramps/gui/editors/editeventref.py:95
 #: ../gramps/gui/editors/editmediaref.py:114
-#: ../gramps/gui/editors/editname.py:135
-#: ../gramps/gui/editors/editplaceref.py:76
-#: ../gramps/gui/editors/editreporef.py:78
+#: ../gramps/gui/editors/editname.py:134
+#: ../gramps/gui/editors/editplaceref.py:77
+#: ../gramps/gui/editors/editreporef.py:77
 msgid "_General"
 msgstr "_Allgemeines"
 
@@ -12683,7 +12756,7 @@ msgid "Maternal"
 msgstr "Mütterlicherseits"
 
 #: ../gramps/gui/editors/editfamily.py:127
-#: ../gramps/gui/selectors/selectperson.py:97
+#: ../gramps/gui/selectors/selectperson.py:96
 #: ../gramps/plugins/gramplet/children.py:94
 #: ../gramps/plugins/gramplet/children.py:193
 #: ../gramps/plugins/lib/libpersonview.py:101
@@ -12703,7 +12776,7 @@ msgid "Birth Date"
 msgstr "Geburtsdatum"
 
 #: ../gramps/gui/editors/editfamily.py:128
-#: ../gramps/gui/selectors/selectperson.py:99
+#: ../gramps/gui/selectors/selectperson.py:98
 #: ../gramps/plugins/gramplet/children.py:96
 #: ../gramps/plugins/gramplet/children.py:195
 #: ../gramps/plugins/lib/libpersonview.py:103
@@ -12713,13 +12786,13 @@ msgid "Death Date"
 msgstr "Sterbedatum"
 
 #: ../gramps/gui/editors/editfamily.py:129
-#: ../gramps/gui/selectors/selectperson.py:98
+#: ../gramps/gui/selectors/selectperson.py:97
 #: ../gramps/plugins/lib/libpersonview.py:102
 msgid "Birth Place"
 msgstr "Geburtsort"
 
 #: ../gramps/gui/editors/editfamily.py:130
-#: ../gramps/gui/selectors/selectperson.py:100
+#: ../gramps/gui/selectors/selectperson.py:99
 #: ../gramps/plugins/lib/libpersonview.py:104
 msgid "Death Place"
 msgstr "Sterbeort"
@@ -12733,25 +12806,25 @@ msgstr "_Kinder"
 msgid "Edit child"
 msgstr "Kind bearbeiten"
 
-#: ../gramps/gui/editors/editfamily.py:150
+#: ../gramps/gui/editors/editfamily.py:149
 msgid "Add an existing child"
 msgstr "Bestehendes Kind hinzufügen"
 
-#: ../gramps/gui/editors/editfamily.py:151
+#: ../gramps/gui/editors/editfamily.py:150
 msgid "Edit relationship"
 msgstr "Beziehung bearbeiten"
 
-#: ../gramps/gui/editors/editfamily.py:219
-#: ../gramps/gui/editors/editfamily.py:234
-#: ../gramps/plugins/view/relview.py:1569
+#: ../gramps/gui/editors/editfamily.py:217
+#: ../gramps/gui/editors/editfamily.py:232
+#: ../gramps/plugins/view/relview.py:1579
 msgid "Select Child"
 msgstr "Wähle ein Kind"
 
-#: ../gramps/gui/editors/editfamily.py:367
+#: ../gramps/gui/editors/editfamily.py:365
 msgid "Adding parents to a person"
 msgstr "Eltern zu einer Person hinzufügen"
 
-#: ../gramps/gui/editors/editfamily.py:368
+#: ../gramps/gui/editors/editfamily.py:366
 msgid ""
 "It is possible to accidentally create multiple families with the same "
 "parents. To help avoid this problem, only the buttons to select parents are "
@@ -12764,11 +12837,11 @@ msgstr ""
 "anzulegen. Die weiteren Felder stehen erst nach dem Wählen der Eltern zur "
 "Verfügung."
 
-#: ../gramps/gui/editors/editfamily.py:462
+#: ../gramps/gui/editors/editfamily.py:461
 msgid "Family has changed"
 msgstr "Familie wurde geändert"
 
-#: ../gramps/gui/editors/editfamily.py:463
+#: ../gramps/gui/editors/editfamily.py:462
 #, python-format
 msgid ""
 "The %(object)s you are editing has changed outside this editor. This can be "
@@ -12785,7 +12858,7 @@ msgstr ""
 "die angezeigten Daten aktualisiert. Einige ihrer Änderungen können verloren "
 "gegangen sein."
 
-#: ../gramps/gui/editors/editfamily.py:468
+#: ../gramps/gui/editors/editfamily.py:467
 #: ../gramps/plugins/importer/importcsv.py:210
 #: ../gramps/plugins/view/familyview.py:260
 msgid "family"
@@ -12797,48 +12870,48 @@ msgid "New Family"
 msgstr "Neue Familie"
 
 #: ../gramps/gui/editors/editfamily.py:505
-#: ../gramps/gui/editors/editfamily.py:1131
+#: ../gramps/gui/editors/editfamily.py:1132
 #: ../gramps/plugins/view/geofamily.py:422
 msgid "Edit Family"
 msgstr "Familie bearbeiten"
 
-#: ../gramps/gui/editors/editfamily.py:538
+#: ../gramps/gui/editors/editfamily.py:536
 msgid "Select a person as the mother"
 msgstr "Wähle eine Person als Mutter"
 
-#: ../gramps/gui/editors/editfamily.py:539
+#: ../gramps/gui/editors/editfamily.py:537
 msgid "Add a new person as the mother"
 msgstr "Neue Person als Mutter hinzufügen"
 
-#: ../gramps/gui/editors/editfamily.py:540
+#: ../gramps/gui/editors/editfamily.py:538
 msgid "Remove the person as the mother"
 msgstr "Die Person als Mutter entfernen"
 
-#: ../gramps/gui/editors/editfamily.py:553
+#: ../gramps/gui/editors/editfamily.py:551
 msgid "Select a person as the father"
 msgstr "Eine Person als Vater wählen"
 
-#: ../gramps/gui/editors/editfamily.py:554
+#: ../gramps/gui/editors/editfamily.py:552
 msgid "Add a new person as the father"
 msgstr "Neue Person als Vater hinzufügen"
 
-#: ../gramps/gui/editors/editfamily.py:555
+#: ../gramps/gui/editors/editfamily.py:553
 msgid "Remove the person as the father"
 msgstr "Die Person als Vater entfernen"
 
-#: ../gramps/gui/editors/editfamily.py:836
+#: ../gramps/gui/editors/editfamily.py:834
 msgid "Select Mother"
 msgstr "Mutter wählen"
 
-#: ../gramps/gui/editors/editfamily.py:881
+#: ../gramps/gui/editors/editfamily.py:879
 msgid "Select Father"
 msgstr "Vater wählen"
 
-#: ../gramps/gui/editors/editfamily.py:905
+#: ../gramps/gui/editors/editfamily.py:903
 msgid "Duplicate Family"
 msgstr "Doppelte Familie"
 
-#: ../gramps/gui/editors/editfamily.py:906
+#: ../gramps/gui/editors/editfamily.py:904
 msgid ""
 "A family with these parents already exists in the database. If you save, you "
 "will create a duplicate family. It is recommended that you cancel the "
@@ -12848,29 +12921,25 @@ msgstr ""
 "du speicherst, wird eine doppelte Familie erstellt. Es wird empfohlen "
 "abzubrechen und die bestehende Familie zu bearbeiten"
 
-#: ../gramps/gui/editors/editfamily.py:954
-#: ../gramps/plugins/view/relview.py:569 ../gramps/plugins/view/relview.py:991
-#: ../gramps/plugins/view/relview.py:1048
-#: ../gramps/plugins/view/relview.py:1172
-#: ../gramps/plugins/view/relview.py:1278
+#: ../gramps/gui/editors/editfamily.py:952
 #, python-format
 msgid "Edit %s"
 msgstr "Bearbeiten von %s"
 
-#: ../gramps/gui/editors/editfamily.py:1063
+#: ../gramps/gui/editors/editfamily.py:1061
 msgid "A father cannot be his own child"
 msgstr "Ein Vater kann nicht sein eigenes Kind sein"
 
-#: ../gramps/gui/editors/editfamily.py:1064
+#: ../gramps/gui/editors/editfamily.py:1062
 #, python-format
 msgid "%s is listed as both the father and child of the family."
 msgstr "%s wird als Vater und Kind dieser Familie geführt."
 
-#: ../gramps/gui/editors/editfamily.py:1073
+#: ../gramps/gui/editors/editfamily.py:1072
 msgid "A mother cannot be her own child"
 msgstr "Eine Mutter kann nicht ihr eigenes Kind sein"
 
-#: ../gramps/gui/editors/editfamily.py:1074
+#: ../gramps/gui/editors/editfamily.py:1073
 #, python-format
 msgid "%s is listed as both the mother and child of the family."
 msgstr "%s wird als Mutter und Kind dieser Familie geführt."
@@ -12885,12 +12954,12 @@ msgstr ""
 "Es existieren keine Daten für diese Familie. Bitte gib Daten ein oder brich "
 "die Bearbeitung ab."
 
-#: ../gramps/gui/editors/editfamily.py:1089
+#: ../gramps/gui/editors/editfamily.py:1090
 msgid "Cannot save family. ID already exists."
 msgstr "Die Familie kann nicht gespeichert werden. ID existiert bereits."
 
-#: ../gramps/gui/editors/editfamily.py:1090
-#: ../gramps/gui/editors/editnote.py:322
+#: ../gramps/gui/editors/editfamily.py:1091
+#: ../gramps/gui/editors/editnote.py:321
 #: ../gramps/gui/editors/editreference.py:294
 #, python-format
 msgid ""
@@ -12902,7 +12971,7 @@ msgstr ""
 "verwenden. Dieser Wert wird bereits benutzt. Bitte gib eine andere ID ein "
 "oder lasse sie leer, um den nächsten verfügbaren ID Wert zu erhalten."
 
-#: ../gramps/gui/editors/editfamily.py:1105
+#: ../gramps/gui/editors/editfamily.py:1106
 msgid "Add Family"
 msgstr "Familie hinzufügen"
 
@@ -12910,33 +12979,33 @@ msgstr "Familie hinzufügen"
 msgid "manual|LDS_Ordinance_Editor"
 msgstr "LDS_Ordinationseditor"
 
-#: ../gramps/gui/editors/editldsord.py:160
-#: ../gramps/gui/editors/editldsord.py:316
-#: ../gramps/gui/editors/editldsord.py:353
-#: ../gramps/gui/editors/editldsord.py:439
+#: ../gramps/gui/editors/editldsord.py:158
+#: ../gramps/gui/editors/editldsord.py:315
+#: ../gramps/gui/editors/editldsord.py:352
+#: ../gramps/gui/editors/editldsord.py:443
 msgid "LDS Ordinance Editor"
 msgstr "LDS Ordinationseditor"
 
-#: ../gramps/gui/editors/editldsord.py:289
+#: ../gramps/gui/editors/editldsord.py:288
 #, python-format
 msgid "%(father)s and %(mother)s [%(gramps_id)s]"
 msgstr "%(father)s und %(mother)s [%(gramps_id)s]"
 
-#: ../gramps/gui/editors/editldsord.py:295
+#: ../gramps/gui/editors/editldsord.py:294
 #, python-format
 msgid "%(father)s [%(gramps_id)s]"
 msgstr "%(father)s [%(gramps_id)s]"
 
-#: ../gramps/gui/editors/editldsord.py:300
+#: ../gramps/gui/editors/editldsord.py:299
 #, python-format
 msgid "%(mother)s [%(gramps_id)s]"
 msgstr "%(mother)s [%(gramps_id)s]"
 
-#: ../gramps/gui/editors/editldsord.py:315
-#: ../gramps/gui/editors/editldsord.py:438
-#: ../gramps/plugins/textreport/indivcomplete.py:450
-#: ../gramps/plugins/textreport/indivcomplete.py:651
-#: ../gramps/plugins/webreport/narrativeweb.py:832
+#: ../gramps/gui/editors/editldsord.py:314
+#: ../gramps/gui/editors/editldsord.py:442
+#: ../gramps/plugins/textreport/indivcomplete.py:485
+#: ../gramps/plugins/textreport/indivcomplete.py:689
+#: ../gramps/plugins/webreport/narrativeweb.py:786
 msgid "LDS Ordinance"
 msgstr "LDS Ordination"
 
@@ -12952,7 +13021,7 @@ msgstr "Verknüpfungeditor"
 msgid "Internet Address"
 msgstr "Internetadresse"
 
-#: ../gramps/gui/editors/editlocation.py:50
+#: ../gramps/gui/editors/editlocation.py:48
 msgid "Location Editor"
 msgstr "Ortseditor"
 
@@ -12971,31 +13040,31 @@ msgstr "Medium: %s"
 msgid "New Media"
 msgstr "Neues Medium"
 
-#: ../gramps/gui/editors/editmedia.py:243
+#: ../gramps/gui/editors/editmedia.py:241
 msgid "Edit Media Object"
 msgstr "Medienobjekt bearbeiten"
 
-#: ../gramps/gui/editors/editmedia.py:288
+#: ../gramps/gui/editors/editmedia.py:286
 msgid "Cannot save media object"
 msgstr "Das Medienobjekt kann nicht gespeichert werden."
 
-#: ../gramps/gui/editors/editmedia.py:289
+#: ../gramps/gui/editors/editmedia.py:287
 msgid ""
 "No data exists for this media object. Please enter data or cancel the edit."
 msgstr ""
 "Es existieren keine Daten für dieses Medienobjekt. Bitte gib Daten ein oder "
 "brich die Bearbeitung ab."
 
-#: ../gramps/gui/editors/editmedia.py:298
+#: ../gramps/gui/editors/editmedia.py:297
 #: ../gramps/gui/editors/editreference.py:279
 msgid "Cannot save media object. ID already exists."
 msgstr "Das Medienobjekt kann nicht gespeichert werden. ID existiert bereits."
 
-#: ../gramps/gui/editors/editmedia.py:313
+#: ../gramps/gui/editors/editmedia.py:312
 msgid "There is no media matching the current path value!"
 msgstr "Es gibt kein Medium, welches den aktuellem Pfadwerten entspricht!"
 
-#: ../gramps/gui/editors/editmedia.py:314
+#: ../gramps/gui/editors/editmedia.py:313
 #, python-format
 msgid ""
 "You have attempted to use the path with value '%(path)s'. This path does not "
@@ -13004,19 +13073,19 @@ msgstr ""
 "Du hast versucht, den Pfad mit dem Wert '%(path)s' zu verwenden. Dieser Pfad "
 "existiert nicht! Gib bitte einen anderen Pfad ein."
 
-#: ../gramps/gui/editors/editmedia.py:327
+#: ../gramps/gui/editors/editmedia.py:326
 #: ../gramps/gui/editors/editmediaref.py:523
 #, python-format
 msgid "Add Media Object (%s)"
 msgstr "Medienobjekt (%s) hinzufügen"
 
-#: ../gramps/gui/editors/editmedia.py:332
+#: ../gramps/gui/editors/editmedia.py:331
 #: ../gramps/gui/editors/editmediaref.py:517
 #, python-format
 msgid "Edit Media Object (%s)"
 msgstr "Medienobjekt (%s) bearbeiten"
 
-#: ../gramps/gui/editors/editmedia.py:369
+#: ../gramps/gui/editors/editmedia.py:368
 msgid "Remove Media Object"
 msgstr "Medienobjekt entfernen"
 
@@ -13024,7 +13093,7 @@ msgstr "Medienobjekt entfernen"
 msgid "manual|Media_Reference_Editor_dialog"
 msgstr "Medienreferenzeditor_Dialog"
 
-#: ../gramps/gui/editors/editmediaref.py:95
+#: ../gramps/gui/editors/editmediaref.py:93
 #: ../gramps/gui/editors/editmediaref.py:409
 msgid "Media Reference Editor"
 msgstr "Medienreferenzeditor"
@@ -13036,29 +13105,29 @@ msgstr "Medienreferenzeditor"
 msgid "Y coordinate|Y"
 msgstr "Y"
 
-#: ../gramps/gui/editors/editname.py:122 ../gramps/gui/editors/editname.py:314
+#: ../gramps/gui/editors/editname.py:120 ../gramps/gui/editors/editname.py:313
 msgid "Name Editor"
 msgstr "Namenseditor"
 
-#: ../gramps/gui/editors/editname.py:163
+#: ../gramps/gui/editors/editname.py:162
 msgid "manual|Name_Editor"
 msgstr "Namenseditor"
 
-#: ../gramps/gui/editors/editname.py:175
-#: ../gramps/gui/editors/editperson.py:328
+#: ../gramps/gui/editors/editname.py:174
+#: ../gramps/gui/editors/editperson.py:327
 msgid "Call name must be the given name that is normally used."
 msgstr ""
 "Der Rufname ist der Teil des Vornamen, der normalerweise verwendet wird."
 
-#: ../gramps/gui/editors/editname.py:313
+#: ../gramps/gui/editors/editname.py:312
 msgid "New Name"
 msgstr "Neuer Name"
 
-#: ../gramps/gui/editors/editname.py:380
+#: ../gramps/gui/editors/editname.py:379
 msgid "Break global name grouping?"
 msgstr "Globale Namensgruppierung aufheben?"
 
-#: ../gramps/gui/editors/editname.py:381
+#: ../gramps/gui/editors/editname.py:380
 #, python-format
 msgid ""
 "All people with the name of %(surname)s will no longer be grouped with the "
@@ -13067,11 +13136,11 @@ msgstr ""
 "Alle Personen mit dem Namen %(surname)s werden nicht länger mit dem Namen "
 "%(group_name)s gruppiert sein."
 
-#: ../gramps/gui/editors/editname.py:385
+#: ../gramps/gui/editors/editname.py:384
 msgid "Continue"
 msgstr "Fortsetzen"
 
-#: ../gramps/gui/editors/editname.py:386
+#: ../gramps/gui/editors/editname.py:385
 msgid "Return to Name Editor"
 msgstr "Zurück zum Namenseditor"
 
@@ -13119,34 +13188,34 @@ msgstr "Neue Notiz - %(context)s"
 msgid "New Note"
 msgstr "Neue Notiz"
 
-#: ../gramps/gui/editors/editnote.py:191
+#: ../gramps/gui/editors/editnote.py:189
 msgid "_Note"
 msgstr "_Notiz"
 
-#: ../gramps/gui/editors/editnote.py:294 ../gramps/gui/editors/editnote.py:339
+#: ../gramps/gui/editors/editnote.py:292 ../gramps/gui/editors/editnote.py:338
 #: ../gramps/gui/editors/objectentries.py:436
 msgid "Edit Note"
 msgstr "Notiz bearbeiten"
 
-#: ../gramps/gui/editors/editnote.py:313
+#: ../gramps/gui/editors/editnote.py:311
 msgid "Cannot save note"
 msgstr "Die Notiz kann nicht gespeichert werden."
 
-#: ../gramps/gui/editors/editnote.py:314
+#: ../gramps/gui/editors/editnote.py:312
 msgid "No data exists for this note. Please enter data or cancel the edit."
 msgstr ""
 "Es existieren keine Daten für diese Notiz. Bitte gib Daten ein oder brich "
 "die Bearbeitung ab."
 
-#: ../gramps/gui/editors/editnote.py:321
+#: ../gramps/gui/editors/editnote.py:320
 msgid "Cannot save note. ID already exists."
 msgstr "Die Notiz kann nicht gespeichert werden. ID existiert bereits."
 
-#: ../gramps/gui/editors/editnote.py:334
+#: ../gramps/gui/editors/editnote.py:333
 msgid "Add Note"
 msgstr "Notiz hinzufügen"
 
-#: ../gramps/gui/editors/editnote.py:354
+#: ../gramps/gui/editors/editnote.py:353
 #, python-format
 msgid "Delete Note (%s)"
 msgstr "Notiz (%s) löschen"
@@ -13165,32 +13234,37 @@ msgstr "Neue Person: %(name)s"
 msgid "New Person"
 msgstr "Neue Person"
 
-#: ../gramps/gui/editors/editperson.py:246
+#: ../gramps/gui/editors/editperson.py:245
 msgid "manual|Editing_information_about_people"
 msgstr "Informationen_über_Personen_bearbeiten"
 
-#: ../gramps/gui/editors/editperson.py:607
+#: ../gramps/gui/editors/editperson.py:606
 #: ../gramps/plugins/view/geofamily.py:426
 msgid "Edit Person"
 msgstr "Person bearbeiten"
 
-#: ../gramps/gui/editors/editperson.py:652
+#: ../gramps/gui/editors/editperson.py:649
+#: ../gramps/plugins/view/mediaview.py:211
+msgid "View"
+msgstr "Ansicht"
+
+#: ../gramps/gui/editors/editperson.py:651
 msgid "Edit Object Properties"
 msgstr "Objekteigenschaften bearbeiten"
 
-#: ../gramps/gui/editors/editperson.py:691
+#: ../gramps/gui/editors/editperson.py:690
 msgid "Make Active Person"
 msgstr "Als Aktive Person setzen"
 
-#: ../gramps/gui/editors/editperson.py:695
+#: ../gramps/gui/editors/editperson.py:694
 msgid "Make Home Person"
 msgstr "Als Hauptperson setzen"
 
-#: ../gramps/gui/editors/editperson.py:809
+#: ../gramps/gui/editors/editperson.py:808
 msgid "Problem changing the gender"
 msgstr "Problem beim Ändern des Geschlechts"
 
-#: ../gramps/gui/editors/editperson.py:810
+#: ../gramps/gui/editors/editperson.py:809
 msgid ""
 "Changing the gender caused problems with marriage information.\n"
 "Please check the person's marriages."
@@ -13198,11 +13272,11 @@ msgstr ""
 "Die Änderung des Geschlechts verursachte Probleme bei den Eheinformationen.\n"
 "Bitte überprüfe die Ehen der Person."
 
-#: ../gramps/gui/editors/editperson.py:821
+#: ../gramps/gui/editors/editperson.py:820
 msgid "Cannot save person"
 msgstr "Die Person kann nicht gespeichert werden."
 
-#: ../gramps/gui/editors/editperson.py:822
+#: ../gramps/gui/editors/editperson.py:821
 msgid "No data exists for this person. Please enter data or cancel the edit."
 msgstr ""
 "Es existieren keine Daten für diese Person. Gib bitte Daten ein oder brich "
@@ -13218,15 +13292,19 @@ msgid "Add Person (%s)"
 msgstr "Person (%s) hinzufügen"
 
 #: ../gramps/gui/editors/editperson.py:869
+#: ../gramps/plugins/view/relview.py:580 ../gramps/plugins/view/relview.py:1002
+#: ../gramps/plugins/view/relview.py:1059
+#: ../gramps/plugins/view/relview.py:1183
+#: ../gramps/plugins/view/relview.py:1288
 #, python-format
 msgid "Edit Person (%s)"
 msgstr "Person (%s) bearbeiten"
 
-#: ../gramps/gui/editors/editperson.py:1096
+#: ../gramps/gui/editors/editperson.py:1097
 msgid "Unknown gender specified"
 msgstr "Unbekanntes Geschlecht angegeben"
 
-#: ../gramps/gui/editors/editperson.py:1098
+#: ../gramps/gui/editors/editperson.py:1099
 msgid ""
 "The gender of the person is currently unknown. Usually, this is a mistake. "
 "Please specify the gender."
@@ -13234,36 +13312,36 @@ msgstr ""
 "Das Geschlecht der Person ist im Moment unbekannt. Gewöhnlich ist dies ein "
 "Fehler. Bitte wähle das Geschlecht aus."
 
-#: ../gramps/gui/editors/editperson.py:1101
+#: ../gramps/gui/editors/editperson.py:1102
 msgid "_Male"
 msgstr "_Männlich"
 
-#: ../gramps/gui/editors/editperson.py:1102
+#: ../gramps/gui/editors/editperson.py:1103
 msgid "_Female"
 msgstr "_Weiblich"
 
-#: ../gramps/gui/editors/editperson.py:1103
+#: ../gramps/gui/editors/editperson.py:1104
 msgid "_Unknown"
 msgstr "_Unbekannt"
 
-#: ../gramps/gui/editors/editpersonref.py:68
+#: ../gramps/gui/editors/editpersonref.py:67
 msgid "manual|Person_Reference_Editor"
 msgstr "Personenreferenzeditor"
 
-#: ../gramps/gui/editors/editpersonref.py:97
-#: ../gramps/gui/editors/editpersonref.py:224
+#: ../gramps/gui/editors/editpersonref.py:93
+#: ../gramps/gui/editors/editpersonref.py:222
 msgid "Person Reference Editor"
 msgstr "Personenreferenzeditor"
 
-#: ../gramps/gui/editors/editpersonref.py:224
+#: ../gramps/gui/editors/editpersonref.py:222
 msgid "Person Reference"
 msgstr "Personreferenz"
 
-#: ../gramps/gui/editors/editpersonref.py:241
+#: ../gramps/gui/editors/editpersonref.py:239
 msgid "No person selected"
 msgstr "Keine Person ausgewählt"
 
-#: ../gramps/gui/editors/editpersonref.py:242
+#: ../gramps/gui/editors/editpersonref.py:240
 msgid "You must either select a person or Cancel the edit"
 msgstr "Du musst entweder eine Person auswählen oder die Bearbeitung abbrechen"
 
@@ -13271,75 +13349,74 @@ msgstr "Du musst entweder eine Person auswählen oder die Bearbeitung abbrechen"
 msgid "manual|Place_Editor_dialog"
 msgstr "Ortsnamenseditor_Dialog"
 
-#: ../gramps/gui/editors/editplace.py:93
-#: ../gramps/gui/glade/editplace.glade:288
-#: ../gramps/gui/merge/mergeplace.py:55
+#: ../gramps/gui/editors/editplace.py:91
+#: ../gramps/gui/glade/editplace.glade:288 ../gramps/gui/merge/mergeplace.py:55
 msgid "place|Name:"
 msgstr "Ortsname:"
 
-#: ../gramps/gui/editors/editplace.py:98
-#: ../gramps/gui/editors/editplaceref.py:95
+#: ../gramps/gui/editors/editplace.py:96
+#: ../gramps/gui/editors/editplaceref.py:96
 #, python-format
 msgid "Place: %s"
 msgstr "Ort: %s"
 
-#: ../gramps/gui/editors/editplace.py:100
-#: ../gramps/gui/editors/editplaceref.py:97
+#: ../gramps/gui/editors/editplace.py:98
+#: ../gramps/gui/editors/editplaceref.py:98
 msgid "New Place"
 msgstr "Neuer Ort"
 
-#: ../gramps/gui/editors/editplace.py:181
-#: ../gramps/gui/editors/editplaceref.py:171
+#: ../gramps/gui/editors/editplace.py:179
+#: ../gramps/gui/editors/editplaceref.py:172
 msgid "Invalid latitude (syntax: 18\\u00b09'"
 msgstr "Ungültiger Breitengrad (Syntax: 18\\u00b09'"
 
-#: ../gramps/gui/editors/editplace.py:182
-#: ../gramps/gui/editors/editplaceref.py:172
+#: ../gramps/gui/editors/editplace.py:180
+#: ../gramps/gui/editors/editplaceref.py:173
 msgid "48.21\"S, -18.2412 or -18:9:48.21)"
 msgstr "48.21\"S, -18.2412 oder -18:9:48.21)"
 
-#: ../gramps/gui/editors/editplace.py:184
-#: ../gramps/gui/editors/editplaceref.py:174
+#: ../gramps/gui/editors/editplace.py:182
+#: ../gramps/gui/editors/editplaceref.py:175
 msgid "Invalid longitude (syntax: 18\\u00b09'"
 msgstr "Ungültiger Längengrad (Syntax: 18\\u00b09'"
 
-#: ../gramps/gui/editors/editplace.py:185
-#: ../gramps/gui/editors/editplaceref.py:175
+#: ../gramps/gui/editors/editplace.py:183
+#: ../gramps/gui/editors/editplaceref.py:176
 msgid "48.21\"E, -18.2412 or -18:9:48.21)"
 msgstr "48.21\"O, -18.2412 oder -18:9:48.21)"
 
-#: ../gramps/gui/editors/editplace.py:195
-#: ../gramps/plugins/lib/maps/geography.py:878
-#: ../gramps/plugins/view/geoplaces.py:345
-#: ../gramps/plugins/view/geoplaces.py:371
+#: ../gramps/gui/editors/editplace.py:193
+#: ../gramps/plugins/lib/maps/geography.py:920
+#: ../gramps/plugins/view/geoplaces.py:429
+#: ../gramps/plugins/view/geoplaces.py:455
 msgid "Edit Place"
 msgstr "Ort bearbeiten"
 
-#: ../gramps/gui/editors/editplace.py:286
-#: ../gramps/gui/editors/editplaceref.py:277
+#: ../gramps/gui/editors/editplace.py:284
+#: ../gramps/gui/editors/editplaceref.py:278
 msgid "Cannot save place. Name not entered."
 msgstr "Kann Ort nicht speichern. Name nicht eingegeben."
 
-#: ../gramps/gui/editors/editplace.py:287
-#: ../gramps/gui/editors/editplaceref.py:278
+#: ../gramps/gui/editors/editplace.py:285
+#: ../gramps/gui/editors/editplaceref.py:279
 msgid "You must enter a name before saving."
 msgstr "Du musst einen Namen eingeben bevor du speicherst."
 
-#: ../gramps/gui/editors/editplace.py:296
+#: ../gramps/gui/editors/editplace.py:294
 msgid "Cannot save place. ID already exists."
 msgstr "Der Ort kann nicht gespeichert werden. ID besteht bereits."
 
-#: ../gramps/gui/editors/editplace.py:310
+#: ../gramps/gui/editors/editplace.py:308
 #, python-format
 msgid "Add Place (%s)"
 msgstr "Ort (%s) hinzufügen"
 
-#: ../gramps/gui/editors/editplace.py:315
+#: ../gramps/gui/editors/editplace.py:313
 #, python-format
 msgid "Edit Place (%s)"
 msgstr "Ort (%s) bearbeiten"
 
-#: ../gramps/gui/editors/editplace.py:340
+#: ../gramps/gui/editors/editplace.py:338
 #, python-format
 msgid "Delete Place (%s)"
 msgstr "Ort (%s) löschen"
@@ -13365,16 +13442,16 @@ msgstr "Kann Ortsnamen nicht speichern"
 msgid "The place name cannot be empty"
 msgstr "Der Ortsname darf nicht leer sein"
 
-#: ../gramps/gui/editors/editplaceref.py:59
-#: ../gramps/gui/editors/editplaceref.py:98
+#: ../gramps/gui/editors/editplaceref.py:58
+#: ../gramps/gui/editors/editplaceref.py:99
 msgid "Place Reference Editor"
 msgstr "Ortsreferenzeditor"
 
-#: ../gramps/gui/editors/editplaceref.py:284
+#: ../gramps/gui/editors/editplaceref.py:285
 msgid "Modify Place"
 msgstr "Ort ändern"
 
-#: ../gramps/gui/editors/editplaceref.py:289
+#: ../gramps/gui/editors/editplaceref.py:290
 msgid "Add Place"
 msgstr "Ort hinzufügen"
 
@@ -13387,7 +13464,7 @@ msgid "If you close without saving, the changes you have made will be lost"
 msgstr "Wenn du ohne zu speichern schließt, gehen deine Änderungen verloren."
 
 #: ../gramps/gui/editors/editreference.py:282
-#: ../gramps/gui/editors/editrepository.py:189
+#: ../gramps/gui/editors/editrepository.py:188
 msgid "Cannot save repository. ID already exists."
 msgstr ""
 "Der Aufbewahrungsort kann nicht gespeichert werden. ID besteht bereits."
@@ -13396,29 +13473,29 @@ msgstr ""
 msgid "Cannot save item. ID already exists."
 msgstr "Kann Element nicht speichern. ID existiert bereits."
 
-#: ../gramps/gui/editors/editreporef.py:62
+#: ../gramps/gui/editors/editreporef.py:60
 msgid "Repository Reference Editor"
 msgstr "Referenzierungseditor für Aufbewahrungsort"
 
-#: ../gramps/gui/editors/editreporef.py:185
+#: ../gramps/gui/editors/editreporef.py:184
 #, python-format
 msgid "Repository: %s"
 msgstr "Aufbewahrungsort: %s"
 
-#: ../gramps/gui/editors/editreporef.py:187
+#: ../gramps/gui/editors/editreporef.py:186
 #: ../gramps/gui/editors/editrepository.py:81
 msgid "New Repository"
 msgstr "Neuer Aufbewahrungsort"
 
-#: ../gramps/gui/editors/editreporef.py:188
+#: ../gramps/gui/editors/editreporef.py:187
 msgid "Repo Reference Editor"
 msgstr "Referenzierungseditor für Aufbewahrungsort"
 
-#: ../gramps/gui/editors/editreporef.py:193
+#: ../gramps/gui/editors/editreporef.py:192
 msgid "Modify Repository"
 msgstr "Aufbewahrungsort ändern"
 
-#: ../gramps/gui/editors/editreporef.py:198
+#: ../gramps/gui/editors/editreporef.py:197
 msgid "Add Repository"
 msgstr "Aufbewahrungsort hinzufügen"
 
@@ -13426,32 +13503,32 @@ msgstr "Aufbewahrungsort hinzufügen"
 msgid "manual|New_Repositories_dialog"
 msgstr "Neue_Aufbewahrungsorte_Dialog"
 
-#: ../gramps/gui/editors/editrepository.py:94
+#: ../gramps/gui/editors/editrepository.py:92
 msgid "Edit Repository"
 msgstr "Aufbewahrungsort bearbeiten"
 
-#: ../gramps/gui/editors/editrepository.py:179
+#: ../gramps/gui/editors/editrepository.py:177
 msgid "Cannot save repository"
 msgstr "Der Aufbewahrungsort konnte nicht gespeichert werden."
 
-#: ../gramps/gui/editors/editrepository.py:180
+#: ../gramps/gui/editors/editrepository.py:178
 msgid ""
 "No data exists for this repository. Please enter data or cancel the edit."
 msgstr ""
 "Es existieren keine Daten für diesen Aufbewahrungsort. Bitte gib Daten ein "
 "oder brich die Bearbeitung ab."
 
-#: ../gramps/gui/editors/editrepository.py:202
+#: ../gramps/gui/editors/editrepository.py:201
 #, python-format
 msgid "Add Repository (%s)"
 msgstr "Aufbewahrungsort (%s) hinzufügen"
 
-#: ../gramps/gui/editors/editrepository.py:207
+#: ../gramps/gui/editors/editrepository.py:206
 #, python-format
 msgid "Edit Repository (%s)"
 msgstr "Aufbewahrungsort (%s) bearbeiten"
 
-#: ../gramps/gui/editors/editrepository.py:220
+#: ../gramps/gui/editors/editrepository.py:219
 #, python-format
 msgid "Delete Repository (%s)"
 msgstr "Aufbewahrungsort (%s) löschen"
@@ -13464,15 +13541,15 @@ msgstr "Neue_Quelle_Dialog"
 msgid "New Source"
 msgstr "Neue Quelle"
 
-#: ../gramps/gui/editors/editsource.py:194
+#: ../gramps/gui/editors/editsource.py:193
 msgid "Edit Source"
 msgstr "Quelle bearbeiten"
 
-#: ../gramps/gui/editors/editsource.py:199
+#: ../gramps/gui/editors/editsource.py:198
 msgid "Cannot save source"
 msgstr "Die Quelle kann nicht gespeichert werden."
 
-#: ../gramps/gui/editors/editsource.py:200
+#: ../gramps/gui/editors/editsource.py:199
 msgid "No data exists for this source. Please enter data or cancel the edit."
 msgstr ""
 "Es existieren keine Daten für diese Quelle. Gib Daten ein oder brich die "
@@ -13507,82 +13584,80 @@ msgid "Tag selection"
 msgstr "Markierungenauswahl"
 
 #. pylint: disable-msg=E1101
-#: ../gramps/gui/editors/edittaglist.py:99
-#: ../gramps/gui/views/bookmarks.py:205 ../gramps/gui/views/tags.py:382
-#: ../gramps/gui/views/tags.py:605 ../gramps/gui/views/tags.py:621
+#: ../gramps/gui/editors/edittaglist.py:100
+#: ../gramps/gui/views/bookmarks.py:227 ../gramps/gui/views/tags.py:387
+#: ../gramps/gui/views/tags.py:611 ../gramps/gui/views/tags.py:627
 #, python-format
 msgid "%(title)s - Gramps"
 msgstr "%(title)s - Gramps"
 
-#: ../gramps/gui/editors/edittaglist.py:99
+#: ../gramps/gui/editors/edittaglist.py:100
 msgid "Edit Tags"
 msgstr "Markierungen bearbeiten"
 
 #: ../gramps/gui/editors/edittaglist.py:107
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:116
-#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:107
+#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:110
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:118
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:93
-#: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:99
+#: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:103
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:135
-#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:106
-#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:105
+#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:110
+#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:109
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:92
-#: ../gramps/gui/views/tags.py:221 ../gramps/gui/views/tags.py:226
-#: ../gramps/plugins/textreport/tagreport.py:898
+#: ../gramps/gui/views/tags.py:225 ../gramps/gui/views/tags.py:230
 #: ../gramps/plugins/textreport/tagreport.py:902
+#: ../gramps/plugins/textreport/tagreport.py:906
 msgid "Tag"
 msgstr "Markierung"
 
 #: ../gramps/gui/editors/edittaglist.py:116
-#: ../gramps/gui/glade/addmedia.glade:57
+#: ../gramps/gui/glade/addmedia.glade:55
 #: ../gramps/gui/glade/baseselector.glade:56
-#: ../gramps/gui/glade/clipboard.glade:23 ../gramps/gui/glade/dbman.glade:157
+#: ../gramps/gui/glade/clipboard.glade:21 ../gramps/gui/glade/dbman.glade:157
 #: ../gramps/gui/glade/editaddress.glade:55
 #: ../gramps/gui/glade/editattribute.glade:54
 #: ../gramps/gui/glade/editchildref.glade:58
-#: ../gramps/gui/glade/editcitation.glade:28
-#: ../gramps/gui/glade/editdate.glade:53
-#: ../gramps/gui/glade/editevent.glade:58
+#: ../gramps/gui/glade/editcitation.glade:27
+#: ../gramps/gui/glade/editdate.glade:53 ../gramps/gui/glade/editevent.glade:58
 #: ../gramps/gui/glade/editeventref.glade:22
 #: ../gramps/gui/glade/editfamily.glade:60
-#: ../gramps/gui/glade/editldsord.glade:77
+#: ../gramps/gui/glade/editldsord.glade:75
 #: ../gramps/gui/glade/editlink.glade:59
-#: ../gramps/gui/glade/editlocation.glade:55
+#: ../gramps/gui/glade/editlocation.glade:54
 #: ../gramps/gui/glade/editmedia.glade:55
 #: ../gramps/gui/glade/editmediaref.glade:75
-#: ../gramps/gui/glade/editname.glade:60 ../gramps/gui/glade/editnote.glade:55
-#: ../gramps/gui/glade/editperson.glade:83
+#: ../gramps/gui/glade/editname.glade:59 ../gramps/gui/glade/editnote.glade:53
+#: ../gramps/gui/glade/editperson.glade:82
 #: ../gramps/gui/glade/editpersonref.glade:57
 #: ../gramps/gui/glade/editplace.glade:52
 #: ../gramps/gui/glade/editplacename.glade:55
 #: ../gramps/gui/glade/editplaceref.glade:22
 #: ../gramps/gui/glade/editreporef.glade:61
 #: ../gramps/gui/glade/editrepository.glade:59
-#: ../gramps/gui/glade/editsource.glade:58
-#: ../gramps/gui/glade/editurl.glade:58
-#: ../gramps/gui/glade/mergecitation.glade:54
+#: ../gramps/gui/glade/editsource.glade:58 ../gramps/gui/glade/editurl.glade:57
+#: ../gramps/gui/glade/mergecitation.glade:53
 #: ../gramps/gui/glade/mergedata.glade:77
 #: ../gramps/gui/glade/mergedata.glade:278
 #: ../gramps/gui/glade/mergedata.glade:468
 #: ../gramps/gui/glade/mergedata.glade:698
-#: ../gramps/gui/glade/mergeevent.glade:54
-#: ../gramps/gui/glade/mergefamily.glade:54
-#: ../gramps/gui/glade/mergemedia.glade:54
-#: ../gramps/gui/glade/mergenote.glade:54
-#: ../gramps/gui/glade/mergeperson.glade:55
-#: ../gramps/gui/glade/mergeplace.glade:52
-#: ../gramps/gui/glade/mergerepository.glade:54
-#: ../gramps/gui/glade/mergesource.glade:54
-#: ../gramps/gui/glade/reorder.glade:56 ../gramps/gui/glade/rule.glade:43
-#: ../gramps/gui/glade/rule.glade:354 ../gramps/gui/glade/rule.glade:784
+#: ../gramps/gui/glade/mergeevent.glade:53
+#: ../gramps/gui/glade/mergefamily.glade:53
+#: ../gramps/gui/glade/mergemedia.glade:53
+#: ../gramps/gui/glade/mergenote.glade:53
+#: ../gramps/gui/glade/mergeperson.glade:53
+#: ../gramps/gui/glade/mergeplace.glade:51
+#: ../gramps/gui/glade/mergerepository.glade:53
+#: ../gramps/gui/glade/mergesource.glade:53
+#: ../gramps/gui/glade/reorder.glade:56 ../gramps/gui/glade/rule.glade:41
+#: ../gramps/gui/glade/rule.glade:351 ../gramps/gui/glade/rule.glade:781
 #: ../gramps/gui/logger/_errorview.py:142
-#: ../gramps/gui/plug/report/_reportdialog.py:157
-#: ../gramps/gui/undohistory.py:82 ../gramps/gui/viewmanager.py:479
-#: ../gramps/gui/views/bookmarks.py:237 ../gramps/gui/views/tags.py:420
-#: ../gramps/gui/views/tags.py:627 ../gramps/gui/widgets/grampletbar.py:639
+#: ../gramps/gui/plug/report/_reportdialog.py:158
+#: ../gramps/gui/undohistory.py:82 ../gramps/gui/viewmanager.py:488
+#: ../gramps/gui/views/bookmarks.py:259 ../gramps/gui/views/tags.py:425
+#: ../gramps/gui/views/tags.py:633 ../gramps/gui/widgets/grampletbar.py:641
 #: ../gramps/gui/widgets/grampletpane.py:240
-#: ../gramps/plugins/tool/testcasegenerator.py:298
+#: ../gramps/plugins/tool/testcasegenerator.py:329
 msgid "_Help"
 msgstr "_Hilfe"
 
@@ -13590,7 +13665,7 @@ msgstr "_Hilfe"
 msgid "manual|Internet_Address_Editor"
 msgstr "Internetadresseneditor"
 
-#: ../gramps/gui/editors/editurl.py:70 ../gramps/gui/editors/editurl.py:104
+#: ../gramps/gui/editors/editurl.py:68 ../gramps/gui/editors/editurl.py:103
 msgid "Internet Address Editor"
 msgstr "Internetadresseneditor"
 
@@ -13669,44 +13744,44 @@ msgstr ""
 "Gib eine Quellen ID ein, wähle eine aus oder lasse sie leer um Objekte ohne "
 "Quelle zu finden."
 
-#: ../gramps/gui/editors/filtereditor.py:563
+#: ../gramps/gui/editors/filtereditor.py:562
 msgid "Include selected Gramps ID"
 msgstr "Ausgewählte Gramps ID aufnehmen"
 
-#: ../gramps/gui/editors/filtereditor.py:565
+#: ../gramps/gui/editors/filtereditor.py:564
 msgid "Use exact case of letters"
 msgstr "Beachte Groß/Kleinschreibung"
 
-#: ../gramps/gui/editors/filtereditor.py:566
+#: ../gramps/gui/editors/filtereditor.py:565
 msgid "Regular-Expression matching:"
 msgstr "Regulärer Ausdruck entsprechend:"
 
-#: ../gramps/gui/editors/filtereditor.py:567
+#: ../gramps/gui/editors/filtereditor.py:566
 msgid "Use regular expression"
 msgstr "Regulären Ausdruck benutzen"
 
-#: ../gramps/gui/editors/filtereditor.py:569
+#: ../gramps/gui/editors/filtereditor.py:568
 msgid "Also family events where person is wife/husband"
 msgstr "Auch Familienereignisse bei denen die Person Frau/Mann ist"
 
-#: ../gramps/gui/editors/filtereditor.py:572
+#: ../gramps/gui/editors/filtereditor.py:571
 msgid "Only include primary participants"
 msgstr "Nur Hauptbeteiligte aufnehmen"
 
-#: ../gramps/gui/editors/filtereditor.py:596
+#: ../gramps/gui/editors/filtereditor.py:595
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:76
-#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:77
+#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:80
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:87
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:66
-#: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:73
+#: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:77
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:92
-#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:80
-#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:76
+#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:84
+#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:80
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:65
 msgid "Use regular expressions"
 msgstr "Reguläre Ausdrücke benutzen"
 
-#: ../gramps/gui/editors/filtereditor.py:597
+#: ../gramps/gui/editors/filtereditor.py:596
 msgid ""
 "Interpret the contents of string fields as regular expressions.\n"
 "A decimal point will match any character. A question mark will match zero or "
@@ -13726,38 +13801,36 @@ msgstr ""
 "passt auf den Beginn einer Zeile, ein Dollarzeichen $ auf das Ende einer "
 "Zeile."
 
-#: ../gramps/gui/editors/filtereditor.py:626
+#: ../gramps/gui/editors/filtereditor.py:625
 msgid "Rule Name"
 msgstr "Regelname"
 
-#: ../gramps/gui/editors/filtereditor.py:757
-#: ../gramps/gui/editors/filtereditor.py:761
-#: ../gramps/gui/glade/rule.glade:917
+#: ../gramps/gui/editors/filtereditor.py:756
+#: ../gramps/gui/editors/filtereditor.py:760 ../gramps/gui/glade/rule.glade:914
 msgid "No rule selected"
 msgstr "Keine Regel ausgewählt"
 
-#: ../gramps/gui/editors/filtereditor.py:816
+#: ../gramps/gui/editors/filtereditor.py:813
 msgid "Define filter"
 msgstr "Filter definieren"
 
-#: ../gramps/gui/editors/filtereditor.py:820
-#: ../gramps/gui/glade/rule.glade:970
+#: ../gramps/gui/editors/filtereditor.py:818 ../gramps/gui/glade/rule.glade:967
 msgid "Values"
 msgstr "Werte"
 
-#: ../gramps/gui/editors/filtereditor.py:919
+#: ../gramps/gui/editors/filtereditor.py:917
 msgid "Add Rule"
 msgstr "Regel hinzufügen"
 
-#: ../gramps/gui/editors/filtereditor.py:931
+#: ../gramps/gui/editors/filtereditor.py:929
 msgid "Edit Rule"
 msgstr "Regel bearbeiten"
 
-#: ../gramps/gui/editors/filtereditor.py:966
+#: ../gramps/gui/editors/filtereditor.py:964
 msgid "Filter Test"
 msgstr "Filtertest"
 
-#: ../gramps/gui/editors/filtereditor.py:1105
+#: ../gramps/gui/editors/filtereditor.py:1103
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -13765,40 +13838,40 @@ msgstr "Kommentar"
 #. ###############################
 #. #########################
 #. ###############################
-#: ../gramps/gui/editors/filtereditor.py:1105
-#: ../gramps/plugins/drawreport/calendarreport.py:468
-#: ../gramps/plugins/drawreport/statisticschart.py:984
-#: ../gramps/plugins/drawreport/timeline.py:413
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:983
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:997
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1011
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1025
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1039
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1053
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1067
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1081
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1095
-#: ../gramps/plugins/graph/gvrelgraph.py:666
+#: ../gramps/gui/editors/filtereditor.py:1103
+#: ../gramps/plugins/drawreport/calendarreport.py:472
+#: ../gramps/plugins/drawreport/statisticschart.py:988
+#: ../gramps/plugins/drawreport/timeline.py:417
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1006
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1020
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1034
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1048
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1062
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1076
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1090
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1104
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1118
+#: ../gramps/plugins/graph/gvrelgraph.py:669
 #: ../gramps/plugins/quickview/quickview.gpr.py:127
-#: ../gramps/plugins/textreport/birthdayreport.py:418
-#: ../gramps/plugins/textreport/familygroup.py:704
-#: ../gramps/plugins/textreport/indivcomplete.py:989
-#: ../gramps/plugins/textreport/recordsreport.py:213
+#: ../gramps/plugins/textreport/birthdayreport.py:417
+#: ../gramps/plugins/textreport/familygroup.py:708
+#: ../gramps/plugins/textreport/indivcomplete.py:1035
+#: ../gramps/plugins/textreport/recordsreport.py:218
 #: ../gramps/plugins/tool/sortevents.py:166
-#: ../gramps/plugins/webreport/narrativeweb.py:9368
-#: ../gramps/plugins/webreport/webcal.py:1606
+#: ../gramps/plugins/webreport/narrativeweb.py:9647
+#: ../gramps/plugins/webreport/webcal.py:1624
 msgid "Filter"
 msgstr "Filter"
 
-#: ../gramps/gui/editors/filtereditor.py:1113
+#: ../gramps/gui/editors/filtereditor.py:1111
 msgid "Custom Filter Editor"
 msgstr "Benutzerfiltereditor"
 
-#: ../gramps/gui/editors/filtereditor.py:1180
+#: ../gramps/gui/editors/filtereditor.py:1183
 msgid "Delete Filter?"
 msgstr "Filter löschen?"
 
-#: ../gramps/gui/editors/filtereditor.py:1181
+#: ../gramps/gui/editors/filtereditor.py:1184
 msgid ""
 "This filter is currently being used as the base for other filters. "
 "Deletingthis filter will result in removing all other filters that depend on "
@@ -13808,7 +13881,7 @@ msgstr ""
 "Löschen dieses Filters hat zur Folge, das alle Filter die von ihm abhängen, "
 "auch gelöscht werden."
 
-#: ../gramps/gui/editors/filtereditor.py:1185
+#: ../gramps/gui/editors/filtereditor.py:1188
 msgid "Delete Filter"
 msgstr "Filter löschen"
 
@@ -13874,7 +13947,7 @@ msgstr ""
 "Schaltflächen."
 
 #: ../gramps/gui/editors/objectentries.py:389
-#: ../gramps/gui/plug/_guioptions.py:1104
+#: ../gramps/gui/plug/_guioptions.py:1105
 msgid "No image given, click button to select one"
 msgstr "Kein Bild angegeben, auf Schaltfläche klicken um eines zu wählen"
 
@@ -13883,7 +13956,7 @@ msgid "Edit media object"
 msgstr "Medienobjekt bearbeiten"
 
 #: ../gramps/gui/editors/objectentries.py:391
-#: ../gramps/gui/plug/_guioptions.py:1082
+#: ../gramps/gui/plug/_guioptions.py:1083
 msgid "Select an existing media object"
 msgstr "Ein bestehendes Medienobjekt auswählen"
 
@@ -13902,13 +13975,13 @@ msgstr ""
 "Um eine Notiz zu wählen, verwende ziehen und ablegen oder die Schaltflächen"
 
 #: ../gramps/gui/editors/objectentries.py:435
-#: ../gramps/gui/plug/_guioptions.py:1002
+#: ../gramps/gui/plug/_guioptions.py:1003
 msgid "No note given, click button to select one"
 msgstr ""
 "Die Notiz wurde nicht angegeben. Zum Auswählen klicke auf die Schaltfläche."
 
 #: ../gramps/gui/editors/objectentries.py:437
-#: ../gramps/gui/plug/_guioptions.py:977
+#: ../gramps/gui/plug/_guioptions.py:978
 msgid "Select an existing note"
 msgstr "Wähle eine existierende Notiz aus."
 
@@ -13927,9 +14000,7 @@ msgid "_Find"
 msgstr "_Suchen"
 
 #: ../gramps/gui/filters/_searchbar.py:57
-#: ../gramps/gui/glade/clipboard.glade:56
-#: ../gramps/gui/plug/report/_bookdialog.py:663
-#: ../gramps/gui/undohistory.py:88
+#: ../gramps/gui/glade/clipboard.glade:54 ../gramps/gui/undohistory.py:88
 msgid "_Clear"
 msgstr "_Leeren"
 
@@ -13953,20 +14024,20 @@ msgstr "%s ist nicht"
 msgid "%s does not contain"
 msgstr "%s enthält nicht"
 
-#: ../gramps/gui/filters/_searchbar.py:168
-#: ../gramps/gui/views/listview.py:1140 ../gramps/gui/views/listview.py:1160
+#: ../gramps/gui/filters/_searchbar.py:168 ../gramps/gui/views/listview.py:1141
+#: ../gramps/gui/views/listview.py:1161
 msgid "Updating display..."
 msgstr "Anzeige wird aktualisiert..."
 
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:103
-#: ../gramps/gui/glade/editcitation.glade:264
+#: ../gramps/gui/glade/editcitation.glade:263
 msgid "Source:"
 msgstr "Quelle:"
 
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:107
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:89
 #: ../gramps/plugins/view/sourceview.py:85
-#: ../gramps/plugins/webreport/narrativeweb.py:4907
+#: ../gramps/plugins/webreport/narrativeweb.py:4958
 msgid "Abbreviation"
 msgstr "Abkürzung"
 
@@ -13990,18 +14061,18 @@ msgid "Citation: Minimum Confidence|Min. Conf."
 msgstr "Min. Verl.:"
 
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:117
-#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:108
+#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:111
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:119
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:94
-#: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:100
+#: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:104
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:136
-#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:107
-#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:106
+#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:111
+#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:110
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:93
 msgid "Custom filter"
 msgstr "Eigener Filter"
 
-#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:103
+#: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:106
 #: ../gramps/plugins/textreport/tagreport.py:343
 msgid "Participants"
 msgstr "Beteiligte"
@@ -14010,7 +14081,7 @@ msgstr "Beteiligte"
 #: ../gramps/gui/widgets/reorderfam.py:90
 #: ../gramps/plugins/textreport/tagreport.py:260
 #: ../gramps/plugins/view/familyview.py:82
-#: ../gramps/plugins/webreport/narrativeweb.py:6986
+#: ../gramps/plugins/webreport/narrativeweb.py:7066
 msgid "Relationship"
 msgstr "Beziehung"
 
@@ -14019,8 +14090,7 @@ msgid "any"
 msgstr "alle"
 
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:129
-#: ../gramps/plugins/export/exportcsv.py:382
-#: ../gramps/plugins/importer/importcsv.py:166
+#: ../gramps/plugins/export/exportcsv.py:356
 msgid "Birth date"
 msgstr "Geburtsdatum"
 
@@ -14031,19 +14101,18 @@ msgid "example: \"%(msg1)s\" or \"%(msg2)s\""
 msgstr "Beispiel: \"%(msg1)s\" oder \"%(msg2)s\""
 
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:131
-#: ../gramps/plugins/export/exportcsv.py:384
-#: ../gramps/plugins/importer/importcsv.py:198
+#: ../gramps/plugins/export/exportcsv.py:358
 msgid "Death date"
 msgstr "Sterbedatum"
 
-#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:103
-#: ../gramps/plugins/export/exportcsv.py:565
+#: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:107
+#: ../gramps/plugins/export/exportcsv.py:287
 #: ../gramps/plugins/importer/importcsv.py:226
 #: ../gramps/plugins/lib/libplaceview.py:88
 msgid "Code"
 msgstr "Kennung"
 
-#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:103
+#: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:107
 msgid "URL"
 msgstr "URL"
 
@@ -14051,15 +14120,15 @@ msgstr "URL"
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: ../gramps/gui/glade/addmedia.glade:129
-#: ../gramps/gui/glade/editperson.glade:293
-#: ../gramps/gui/glade/editperson.glade:301
-#: ../gramps/plugins/lib/libmetadata.py:99
-#: ../gramps/plugins/textreport/simplebooktitle.py:148
+#: ../gramps/gui/glade/addmedia.glade:127
+#: ../gramps/gui/glade/editperson.glade:292
+#: ../gramps/gui/glade/editperson.glade:300
+#: ../gramps/plugins/lib/libmetadata.py:101
+#: ../gramps/plugins/textreport/simplebooktitle.py:152
 msgid "Image"
 msgstr "Bild"
 
-#: ../gramps/gui/glade/addmedia.glade:169
+#: ../gramps/gui/glade/addmedia.glade:167
 #: ../gramps/gui/glade/editmedia.glade:111
 #: ../gramps/gui/glade/editmediaref.glade:409
 #: ../gramps/gui/glade/editplace.glade:90
@@ -14067,7 +14136,7 @@ msgstr "Bild"
 msgid "_Title:"
 msgstr "_Titel:"
 
-#: ../gramps/gui/glade/addmedia.glade:193
+#: ../gramps/gui/glade/addmedia.glade:191
 msgid "Convert to a relative path"
 msgstr "Ändere in ein relatives Verzeichnis"
 
@@ -14075,51 +14144,52 @@ msgstr "Ändere in ein relatives Verzeichnis"
 msgid "Show all"
 msgstr "Alle anzeigen"
 
-#: ../gramps/gui/glade/book.glade:54
+#: ../gramps/gui/glade/book.glade:51
 msgid "Book _name:"
 msgstr "Buch_name:"
 
-#: ../gramps/gui/glade/book.glade:93
+#: ../gramps/gui/glade/book.glade:90
+#: ../gramps/gui/plug/report/_bookdialog.py:623
 msgid "Clear the book"
 msgstr "Das Buch leeren"
 
-#: ../gramps/gui/glade/book.glade:115
+#: ../gramps/gui/glade/book.glade:112
 msgid "Save current set of configured selections"
 msgstr "Aktuelle Auswahl speichern"
 
-#: ../gramps/gui/glade/book.glade:138
+#: ../gramps/gui/glade/book.glade:135
 msgid "Open previously created book"
 msgstr "Zuvor erstelltes Buch öffnen"
 
-#: ../gramps/gui/glade/book.glade:160
+#: ../gramps/gui/glade/book.glade:157
 msgid "Manage previously created books"
 msgstr "Zuvor erstellte Bücher verwalten"
 
-#: ../gramps/gui/glade/book.glade:330
+#: ../gramps/gui/glade/book.glade:327
 msgid "Add an item to the book"
 msgstr "Etwas zum Buch hinzufügen"
 
-#: ../gramps/gui/glade/book.glade:353
+#: ../gramps/gui/glade/book.glade:350
 msgid "Remove currently selected item from the book"
 msgstr "Den gewählten Artikel aus dem Buch entfernen"
 
-#: ../gramps/gui/glade/book.glade:375
+#: ../gramps/gui/glade/book.glade:372
 msgid "Move current selection one step up in the book"
 msgstr "Die aktuelle Auswahl im Buch einen Schritt nach oben schieben"
 
-#: ../gramps/gui/glade/book.glade:397
+#: ../gramps/gui/glade/book.glade:394
 msgid "Move current selection one step down in the book"
 msgstr "Die aktuelle Auswahl im Buch einen Schritt nach unten schieben"
 
-#: ../gramps/gui/glade/book.glade:419
+#: ../gramps/gui/glade/book.glade:416
 msgid "Configure currently selected item"
 msgstr "Den gewählten Artikel konfigurieren"
 
-#: ../gramps/gui/glade/book.glade:527 ../gramps/gui/glade/dbman.glade:272
+#: ../gramps/gui/glade/book.glade:524 ../gramps/gui/glade/dbman.glade:272
 msgid "_Delete"
 msgstr "_Löschen"
 
-#: ../gramps/gui/glade/clipboard.glade:40
+#: ../gramps/gui/glade/clipboard.glade:38
 msgid "Clear _All"
 msgstr "_Alle löschen"
 
@@ -14289,9 +14359,9 @@ msgstr "_Ohne speichern schließen"
 
 #. widget
 #: ../gramps/gui/glade/dialog.glade:856
-#: ../gramps/gui/plug/report/_bookdialog.py:664
-#: ../gramps/gui/views/listview.py:1003
-#: ../gramps/gui/widgets/grampletpane.py:573
+#: ../gramps/gui/plug/report/_bookdialog.py:624
+#: ../gramps/gui/views/listview.py:1011
+#: ../gramps/gui/widgets/grampletpane.py:578
 #: ../gramps/plugins/tool/eventcmp.py:398
 msgid "_Save"
 msgstr "_Speichern"
@@ -14300,27 +14370,30 @@ msgstr "_Speichern"
 msgid "Do not ask again"
 msgstr "Nicht wieder fragen"
 
+#: ../gramps/gui/glade/displaystate.glade:8
+msgid "Gramps Warnings"
+msgstr "Gramps Warnungen"
+
 #: ../gramps/gui/glade/editaddress.glade:44
 #: ../gramps/gui/glade/editchildref.glade:47
 #: ../gramps/gui/glade/editevent.glade:47
 #: ../gramps/gui/glade/editfamily.glade:49
-#: ../gramps/gui/glade/editldsord.glade:66
-#: ../gramps/gui/glade/editlink.glade:48 ../gramps/gui/glade/editname.glade:49
-#: ../gramps/gui/glade/editperson.glade:71
+#: ../gramps/gui/glade/editldsord.glade:64
+#: ../gramps/gui/glade/editlink.glade:48 ../gramps/gui/glade/editname.glade:48
+#: ../gramps/gui/glade/editperson.glade:70
 #: ../gramps/gui/glade/editpersonref.glade:46
 #: ../gramps/gui/glade/editplacename.glade:44
 #: ../gramps/gui/glade/editreporef.glade:50
 #: ../gramps/gui/glade/editrepository.glade:48
-#: ../gramps/gui/glade/editsource.glade:46
-#: ../gramps/gui/glade/editurl.glade:47
+#: ../gramps/gui/glade/editsource.glade:46 ../gramps/gui/glade/editurl.glade:46
 msgid "Accept changes and close window"
 msgstr "Änderungen akzeptieren und Fenster schließen"
 
 #: ../gramps/gui/glade/editaddress.glade:93
-#: ../gramps/gui/glade/editcitation.glade:91
+#: ../gramps/gui/glade/editcitation.glade:90
 #: ../gramps/gui/glade/editevent.glade:111
 #: ../gramps/gui/glade/editeventref.glade:238
-#: ../gramps/gui/glade/editldsord.glade:116
+#: ../gramps/gui/glade/editldsord.glade:114
 #: ../gramps/gui/glade/editmedia.glade:125
 #: ../gramps/gui/glade/editmediaref.glade:546
 #: ../gramps/gui/glade/editplacename.glade:93
@@ -14333,7 +14406,7 @@ msgid "St_reet:"
 msgstr "St_raße:"
 
 #: ../gramps/gui/glade/editaddress.glade:123
-#: ../gramps/gui/glade/editlocation.glade:94
+#: ../gramps/gui/glade/editlocation.glade:93
 msgid "C_ity:"
 msgstr "_Stadt:"
 
@@ -14347,7 +14420,7 @@ msgid "_State/County:"
 msgstr "Bundesland/Kre_is:"
 
 #: ../gramps/gui/glade/editaddress.glade:166
-#: ../gramps/gui/glade/editlocation.glade:249
+#: ../gramps/gui/glade/editlocation.glade:248
 msgid "_ZIP/Postal code:"
 msgstr "PLZ/Postleit_zahl:"
 
@@ -14356,12 +14429,12 @@ msgid "Postal code"
 msgstr "Postleitzahl"
 
 #: ../gramps/gui/glade/editaddress.glade:194
-#: ../gramps/gui/glade/editlocation.glade:221
+#: ../gramps/gui/glade/editlocation.glade:220
 msgid "Cou_ntry:"
 msgstr "La_nd:"
 
 #: ../gramps/gui/glade/editaddress.glade:209
-#: ../gramps/gui/glade/editlocation.glade:275
+#: ../gramps/gui/glade/editlocation.glade:274
 msgid "Phon_e:"
 msgstr "T_elefon:"
 
@@ -14393,7 +14466,7 @@ msgstr ""
 #: ../gramps/gui/glade/editaddress.glade:290
 #: ../gramps/gui/glade/editattribute.glade:146
 #: ../gramps/gui/glade/editchildref.glade:173
-#: ../gramps/gui/glade/editcitation.glade:339
+#: ../gramps/gui/glade/editcitation.glade:338
 #: ../gramps/gui/glade/editevent.glade:348
 #: ../gramps/gui/glade/editeventref.glade:142
 #: ../gramps/gui/glade/editeventref.glade:413
@@ -14402,9 +14475,9 @@ msgstr ""
 #: ../gramps/gui/glade/editmedia.glade:325
 #: ../gramps/gui/glade/editmediaref.glade:294
 #: ../gramps/gui/glade/editmediaref.glade:616
-#: ../gramps/gui/glade/editname.glade:149
-#: ../gramps/gui/glade/editnote.glade:228
-#: ../gramps/gui/glade/editperson.glade:411
+#: ../gramps/gui/glade/editname.glade:148
+#: ../gramps/gui/glade/editnote.glade:226
+#: ../gramps/gui/glade/editperson.glade:410
 #: ../gramps/gui/glade/editpersonref.glade:151
 #: ../gramps/gui/glade/editplace.glade:255
 #: ../gramps/gui/glade/editplaceref.glade:358
@@ -14412,19 +14485,19 @@ msgstr ""
 #: ../gramps/gui/glade/editreporef.glade:397
 #: ../gramps/gui/glade/editrepository.glade:205
 #: ../gramps/gui/glade/editsource.glade:288
-#: ../gramps/gui/glade/editurl.glade:150
-#: ../gramps/plugins/webreport/narrativeweb.py:9539
+#: ../gramps/gui/glade/editurl.glade:149
+#: ../gramps/plugins/webreport/narrativeweb.py:9833
 msgid "Privacy"
 msgstr "Privatsphäre"
 
 #: ../gramps/gui/glade/editaddress.glade:313
-#: ../gramps/gui/glade/editcitation.glade:107
+#: ../gramps/gui/glade/editcitation.glade:106
 #: ../gramps/gui/glade/editevent.glade:127
 #: ../gramps/gui/glade/editeventref.glade:369
-#: ../gramps/gui/glade/editldsord.glade:148
+#: ../gramps/gui/glade/editldsord.glade:146
 #: ../gramps/gui/glade/editmedia.glade:235
 #: ../gramps/gui/glade/editmediaref.glade:573
-#: ../gramps/gui/glade/editname.glade:563
+#: ../gramps/gui/glade/editname.glade:562
 #: ../gramps/gui/glade/editplacename.glade:123
 msgid "Invoke date editor"
 msgstr "Datumseditor aufrufen"
@@ -14434,7 +14507,7 @@ msgid "Date at which the address is valid."
 msgstr "Datum, an dem die Adresse gültig ist."
 
 #: ../gramps/gui/glade/editaddress.glade:361
-#: ../gramps/gui/glade/editlocation.glade:315
+#: ../gramps/gui/glade/editlocation.glade:314
 #: ../gramps/plugins/tool/ownereditor.glade:360
 msgid "_Locality:"
 msgstr "_Lokalität:"
@@ -14493,12 +14566,12 @@ msgstr "Öffne Personeneditor für dieses Kind"
 
 #: ../gramps/gui/glade/editchildref.glade:240
 #: ../gramps/gui/glade/editfamily.glade:279
-#: ../gramps/gui/glade/editfamily.glade:587 ../gramps/gui/glade/rule.glade:459
-#: ../gramps/gui/glade/styleeditor.glade:1862
+#: ../gramps/gui/glade/editfamily.glade:587 ../gramps/gui/glade/rule.glade:456
+#: ../gramps/gui/glade/styleeditor.glade:1865
 msgid "Edition"
 msgstr "Bearbeitung"
 
-#: ../gramps/gui/glade/editcitation.glade:137
+#: ../gramps/gui/glade/editcitation.glade:136
 msgid ""
 "Specific location within the information referenced. For a published work, "
 "this could include the volume of a multi-volume work and the page number(s). "
@@ -14517,15 +14590,15 @@ msgstr ""
 "könnte eine Zeilennummer, eine Wohnung und die Familiennummer nebst der "
 "Seitenzahl enthalten. "
 
-#: ../gramps/gui/glade/editcitation.glade:153
+#: ../gramps/gui/glade/editcitation.glade:152
 msgid "_Volume/Page:"
 msgstr "_Band/Film/Seite:"
 
-#: ../gramps/gui/glade/editcitation.glade:168
+#: ../gramps/gui/glade/editcitation.glade:167
 msgid "Con_fidence:"
 msgstr "Verlä_sslichkeit:"
 
-#: ../gramps/gui/glade/editcitation.glade:182
+#: ../gramps/gui/glade/editcitation.glade:181
 msgid ""
 "The date of the entry in the source you are referencing, e.g. the date a "
 "house was visited during a census, or the date an entry was made in a birth "
@@ -14535,7 +14608,7 @@ msgstr ""
 "an dem ein Haus während einer Volkszählung besucht wurde, oder das Datum, an "
 "dem ein Eintrag ins Geburtsregister erstellt wurde. "
 
-#: ../gramps/gui/glade/editcitation.glade:202
+#: ../gramps/gui/glade/editcitation.glade:201
 msgid ""
 "Conveys the submitter's quantitative evaluation of the credibility of a "
 "piece of information, based upon its supporting evidence. It is not intended "
@@ -14559,14 +14632,14 @@ msgstr ""
 "aufgezeichnet wurden.\n"
 "Sehr hoch    = Direkte, primäre Belege oder logische Ableitungen."
 
-#: ../gramps/gui/glade/editcitation.glade:227
+#: ../gramps/gui/glade/editcitation.glade:226
 #: ../gramps/gui/glade/editevent.glade:312
 #: ../gramps/gui/glade/editeventref.glade:285
 #: ../gramps/gui/glade/editfamily.glade:670
 #: ../gramps/gui/glade/editmedia.glade:96
 #: ../gramps/gui/glade/editmediaref.glade:394
-#: ../gramps/gui/glade/editnote.glade:168
-#: ../gramps/gui/glade/editperson.glade:618
+#: ../gramps/gui/glade/editnote.glade:166
+#: ../gramps/gui/glade/editperson.glade:617
 #: ../gramps/gui/glade/editplace.glade:149
 #: ../gramps/gui/glade/editreporef.glade:352
 #: ../gramps/gui/glade/editrepository.glade:165
@@ -14574,11 +14647,11 @@ msgstr ""
 msgid "_ID:"
 msgstr "_ID:"
 
-#: ../gramps/gui/glade/editcitation.glade:241
+#: ../gramps/gui/glade/editcitation.glade:240
 msgid "A unique ID to identify the citation"
 msgstr "Eine eindeutige ID zur Identifizierung der Fundstelle"
 
-#: ../gramps/gui/glade/editcitation.glade:361
+#: ../gramps/gui/glade/editcitation.glade:360
 #: ../gramps/gui/glade/editevent.glade:390
 #: ../gramps/gui/glade/editplace.glade:331
 #: ../gramps/gui/glade/editplaceref.glade:478
@@ -14676,7 +14749,7 @@ msgstr ""
 
 #: ../gramps/gui/glade/editevent.glade:194
 #: ../gramps/gui/glade/editeventref.glade:270
-#: ../gramps/gui/glade/editldsord.glade:131
+#: ../gramps/gui/glade/editldsord.glade:129
 msgid "_Place:"
 msgstr "_Ort:"
 
@@ -14710,7 +14783,7 @@ msgstr "Eine eindeutige ID zur Identifizierung des Ereignis"
 #: ../gramps/gui/glade/editplaceref.glade:85
 #: ../gramps/gui/glade/editreporef.glade:97
 msgid "Reference information"
-msgstr "Informationen zu Referenzen"
+msgstr "Informationen zur Referenz"
 
 #: ../gramps/gui/glade/editeventref.glade:117
 msgid "_Role:"
@@ -14732,8 +14805,8 @@ msgid "Shared information"
 msgstr "Gemeinsam genutzte Informationen"
 
 #: ../gramps/gui/glade/editfamily.glade:29
-#: ../gramps/gui/glade/editname.glade:30
-#: ../gramps/gui/glade/editperson.glade:52
+#: ../gramps/gui/glade/editname.glade:29
+#: ../gramps/gui/glade/editperson.glade:51
 #: ../gramps/gui/glade/editreporef.glade:30
 #: ../gramps/gui/glade/editrepository.glade:29
 #: ../gramps/gui/glade/editsource.glade:28
@@ -14776,12 +14849,12 @@ msgid "A unique ID for the family"
 msgstr "Eine eindeutige Kennzeichnung für die Familie"
 
 #: ../gramps/gui/glade/editfamily.glade:698
-#: ../gramps/gui/glade/editname.glade:103
-#: ../gramps/gui/glade/editnote.glade:135
-#: ../gramps/gui/glade/editperson.glade:728
+#: ../gramps/gui/glade/editname.glade:102
+#: ../gramps/gui/glade/editnote.glade:133
+#: ../gramps/gui/glade/editperson.glade:727
 #: ../gramps/gui/glade/editreporef.glade:279
 #: ../gramps/gui/glade/editrepository.glade:112
-#: ../gramps/gui/glade/editurl.glade:127
+#: ../gramps/gui/glade/editurl.glade:126
 msgid "_Type:"
 msgstr "_Typ:"
 
@@ -14796,8 +14869,8 @@ msgstr ""
 #: ../gramps/gui/glade/editfamily.glade:733
 #: ../gramps/gui/glade/editmedia.glade:360
 #: ../gramps/gui/glade/editmediaref.glade:696
-#: ../gramps/gui/glade/editnote.glade:250
-#: ../gramps/gui/glade/editperson.glade:651
+#: ../gramps/gui/glade/editnote.glade:248
+#: ../gramps/gui/glade/editperson.glade:650
 msgid "_Tags:"
 msgstr "_Markierung:"
 
@@ -14806,17 +14879,22 @@ msgstr "_Markierung:"
 msgid "Edit the tag list"
 msgstr "Die Markierungenliste bearbeiten"
 
-#: ../gramps/gui/glade/editldsord.glade:182
+#: ../gramps/gui/glade/editldsord.glade:180
 msgid "Ordinance:"
 msgstr "Ordination:"
 
-#: ../gramps/gui/glade/editldsord.glade:194
+#: ../gramps/gui/glade/editldsord.glade:192
 msgid "LDS _Temple:"
 msgstr "HLT-Tempel:"
 
-#: ../gramps/gui/glade/editldsord.glade:225
+#: ../gramps/gui/glade/editldsord.glade:223
 msgid "_Family:"
 msgstr "_Familie:"
+
+#: ../gramps/gui/glade/editldsord.glade:248
+#: ../gramps/gui/selectors/selectfamily.py:62
+msgid "Select Family"
+msgstr "Familie wählen"
 
 #: ../gramps/gui/glade/editldsord.glade:282
 msgid "_Status:"
@@ -14834,19 +14912,19 @@ msgstr "Internetadresse:"
 msgid "_Link Type:"
 msgstr "_Linkart:"
 
-#: ../gramps/gui/glade/editlocation.glade:108
+#: ../gramps/gui/glade/editlocation.glade:107
 msgid "The town or city where the place is."
 msgstr "Die Kleinstadt oder Stadt in der sich der Ort befindet."
 
-#: ../gramps/gui/glade/editlocation.glade:122
+#: ../gramps/gui/glade/editlocation.glade:121
 msgid "S_treet:"
 msgstr "S_traße:"
 
-#: ../gramps/gui/glade/editlocation.glade:137
+#: ../gramps/gui/glade/editlocation.glade:136
 msgid "Ch_urch parish:"
 msgstr "_Kirchengemeinde:"
 
-#: ../gramps/gui/glade/editlocation.glade:151
+#: ../gramps/gui/glade/editlocation.glade:150
 msgid ""
 "Lowest clergical division of this place. Typically used for church sources "
 "that only mention the parish."
@@ -14854,21 +14932,21 @@ msgstr ""
 "Niedrigste geistliche Abteilung für diese Lokation. Meistens für "
 "Kirchenquellen verwendet, die nur die Gemeinde angeben."
 
-#: ../gramps/gui/glade/editlocation.glade:165
+#: ../gramps/gui/glade/editlocation.glade:164
 msgid "Co_unty:"
 msgstr "_Kreis:"
 
-#: ../gramps/gui/glade/editlocation.glade:179
+#: ../gramps/gui/glade/editlocation.glade:178
 msgid "Third level of place division. Eg., in the USA a county."
 msgstr ""
 "Dritte Stufe einer Lokationsaufteilung: z.B. in Deutschland der Landkreis, "
 "in den USA das County."
 
-#: ../gramps/gui/glade/editlocation.glade:193
+#: ../gramps/gui/glade/editlocation.glade:192
 msgid "_State:"
 msgstr "_Bundesland:"
 
-#: ../gramps/gui/glade/editlocation.glade:207
+#: ../gramps/gui/glade/editlocation.glade:206
 msgid ""
 "Second level of place division, eg., in the USA a state, in Germany a "
 "Bundesland."
@@ -14876,15 +14954,15 @@ msgstr ""
 "Zweite Stufe einer Lokationsaufteilung: z.B. in Deutschland das Bundesland, "
 "in den USA der Staat."
 
-#: ../gramps/gui/glade/editlocation.glade:235
+#: ../gramps/gui/glade/editlocation.glade:234
 msgid "The country where the place is."
 msgstr "Das Land, in dem sich die Lokation befindet."
 
-#: ../gramps/gui/glade/editlocation.glade:300
+#: ../gramps/gui/glade/editlocation.glade:299
 msgid "Lowest level of a place division: eg the street name."
 msgstr "Niedrigste Stufe einer Lokationsaufteilung: z.B. der Straßenname."
 
-#: ../gramps/gui/glade/editlocation.glade:328
+#: ../gramps/gui/glade/editlocation.glade:327
 msgid "A district within, or a settlement near to, a town or city."
 msgstr ""
 "Ein Bereich in, oder eine Siedlung in der Nähe von einer Kleinstadt oder "
@@ -15018,43 +15096,43 @@ msgstr "Eine Datei wählen"
 msgid "Shared Information"
 msgstr "Gemeinsam benutzte Informationen"
 
-#: ../gramps/gui/glade/editname.glade:119
-#: ../gramps/gui/glade/editperson.glade:317
+#: ../gramps/gui/glade/editname.glade:118
+#: ../gramps/gui/glade/editperson.glade:316
 msgid ""
 "An identification of what type of Name this is, eg. Birth Name, Married Name."
 msgstr ""
 "Eine Bezeichnung, um was für eine Art von Namen es sich handelt z.B. "
 "Geburtsname, Name nach der Hochzeit."
 
-#: ../gramps/gui/glade/editname.glade:193
-#: ../gramps/gui/glade/editperson.glade:135
+#: ../gramps/gui/glade/editname.glade:192
+#: ../gramps/gui/glade/editperson.glade:134
 msgid "_Given:"
 msgstr "_Vorname:"
 
-#: ../gramps/gui/glade/editname.glade:208
-#: ../gramps/gui/glade/editperson.glade:198
+#: ../gramps/gui/glade/editname.glade:207
+#: ../gramps/gui/glade/editperson.glade:197
 msgid "T_itle:"
 msgstr "T_itel:"
 
-#: ../gramps/gui/glade/editname.glade:222
+#: ../gramps/gui/glade/editname.glade:221
 msgid "Suffi_x:"
 msgstr "Suffi_x:"
 
-#: ../gramps/gui/glade/editname.glade:236
+#: ../gramps/gui/glade/editname.glade:235
 msgid "C_all Name:"
 msgstr "R_ufname:"
 
-#: ../gramps/gui/glade/editname.glade:251
-#: ../gramps/gui/glade/editperson.glade:151
+#: ../gramps/gui/glade/editname.glade:250
+#: ../gramps/gui/glade/editperson.glade:150
 msgid "The person's given names"
 msgstr "Vorname der Person"
 
-#: ../gramps/gui/glade/editname.glade:266
+#: ../gramps/gui/glade/editname.glade:265
 msgid "_Nick Name:"
 msgstr "_Spitzname:"
 
-#: ../gramps/gui/glade/editname.glade:279
-#: ../gramps/gui/glade/editperson.glade:180
+#: ../gramps/gui/glade/editname.glade:278
+#: ../gramps/gui/glade/editperson.glade:179
 msgid ""
 "Part of the Given name that is the normally used name. If background is red, "
 "call name is not part of Given name and will not be printed underlined in "
@@ -15064,22 +15142,22 @@ msgstr ""
 "ist, ist der Rufname nicht Teil des Vornamen und wird in einigen Berichten "
 "nicht unterstrichen gedruckt."
 
-#: ../gramps/gui/glade/editname.glade:292
-#: ../gramps/gui/glade/editperson.glade:212
+#: ../gramps/gui/glade/editname.glade:291
+#: ../gramps/gui/glade/editperson.glade:211
 msgid "A title used to refer to the person, such as 'Dr.' or 'Rev.'"
 msgstr ""
 "Ein Titel, der verwendet wird um sich auf eine Person zu beziehen, wie z.B. "
 "'Dr.' oder 'Rev.'"
 
-#: ../gramps/gui/glade/editname.glade:305
-#: ../gramps/gui/glade/editperson.glade:226
+#: ../gramps/gui/glade/editname.glade:304
+#: ../gramps/gui/glade/editperson.glade:225
 msgid "An optional suffix to the name, such as \"Jr.\" or \"III\""
 msgstr ""
 "Suffix: Ein optionaler Anhang an den Namen wie \"Jun.\", \"d.Ä.\" oder \"III."
 "\""
 
-#: ../gramps/gui/glade/editname.glade:318
-#: ../gramps/gui/glade/editperson.glade:260
+#: ../gramps/gui/glade/editname.glade:317
+#: ../gramps/gui/glade/editperson.glade:259
 msgid ""
 "A descriptive name given in place of or in addition to the official given "
 "name."
@@ -15087,15 +15165,15 @@ msgstr ""
 "Ein beschreibender Name, der anstatt oder zusätzlich zum offiziellen "
 "Vornamen gegeben wurde."
 
-#: ../gramps/gui/glade/editname.glade:334
+#: ../gramps/gui/glade/editname.glade:333
 msgid "Given Name(s) "
 msgstr "Vorname(n) "
 
-#: ../gramps/gui/glade/editname.glade:385
+#: ../gramps/gui/glade/editname.glade:384
 msgid "_Family Nick Name:"
 msgstr "_Familienspitzname:"
 
-#: ../gramps/gui/glade/editname.glade:399
+#: ../gramps/gui/glade/editname.glade:398
 msgid ""
 "A non official name given to a family to distinguish them of people with the "
 "same family name. Often referred to as eg. Farm name."
@@ -15104,23 +15182,23 @@ msgstr ""
 "Personen mit dem selben Nachnamen abzugrenzen. Oft bezieht sich dies auf "
 "einen gesellschaftlichen Namen bei Hofe."
 
-#: ../gramps/gui/glade/editname.glade:425
+#: ../gramps/gui/glade/editname.glade:424
 msgid "Family Names "
 msgstr "Familiennamen "
 
-#: ../gramps/gui/glade/editname.glade:463
+#: ../gramps/gui/glade/editname.glade:462
 msgid "G_roup as:"
 msgstr "G_ruppieren als:"
 
-#: ../gramps/gui/glade/editname.glade:477
+#: ../gramps/gui/glade/editname.glade:476
 msgid "_Sort as:"
 msgstr "_Sortieren als:"
 
-#: ../gramps/gui/glade/editname.glade:491
+#: ../gramps/gui/glade/editname.glade:490
 msgid "_Display as:"
 msgstr "_Anzeigen als:"
 
-#: ../gramps/gui/glade/editname.glade:504
+#: ../gramps/gui/glade/editname.glade:503
 msgid ""
 "People are displayed according to the name format given in the Preferences "
 "(the default).\n"
@@ -15133,11 +15211,11 @@ msgstr ""
 "Benutzernamensformat angezeigt wird (zusätzliche Formate können in den "
 "Präferenzen definiert werden)."
 
-#: ../gramps/gui/glade/editname.glade:525
+#: ../gramps/gui/glade/editname.glade:524
 msgid "Dat_e:"
 msgstr "_Datum:"
 
-#: ../gramps/gui/glade/editname.glade:539
+#: ../gramps/gui/glade/editname.glade:538
 msgid ""
 "People are sorted according to the name format given in the Preferences (the "
 "default).\n"
@@ -15150,7 +15228,7 @@ msgstr ""
 "Benutzernamensformat sortiert wird (zusätzliche Formate können in den "
 "Präferenzen definiert werden)."
 
-#: ../gramps/gui/glade/editname.glade:602
+#: ../gramps/gui/glade/editname.glade:601
 msgid ""
 "The Person Tree view groups people under the primary surname. You can "
 "override this by setting here a group value. \n"
@@ -15162,11 +15240,11 @@ msgstr ""
 "Du wirst gefragt, ob du nur diese Person oder alle Personen mit dem "
 "spezifischen Nachnamen gruppieren willst."
 
-#: ../gramps/gui/glade/editname.glade:616
+#: ../gramps/gui/glade/editname.glade:615
 msgid "O_verride"
 msgstr "_Aufheben"
 
-#: ../gramps/gui/glade/editname.glade:642
+#: ../gramps/gui/glade/editname.glade:641
 msgid ""
 "A Date associated with this name. Eg. for a Married Name, date the name is "
 "first used or marriage date."
@@ -15174,23 +15252,23 @@ msgstr ""
 "Ein Datum, das mit dem Namen in Verbindung steht. Z.B. für Heiratsnamen, das "
 "Datum an dem der Name das erste mal verwendet wurde oder das Heiratsdatum."
 
-#: ../gramps/gui/glade/editnote.glade:103
+#: ../gramps/gui/glade/editnote.glade:101
 msgid "Styled Text Editor"
 msgstr "Gestylter Texteditor"
 
-#: ../gramps/gui/glade/editnote.glade:148
+#: ../gramps/gui/glade/editnote.glade:146
 msgid "A type to classify the note."
 msgstr "Ein Typ, um die Notiz zu klassifizieren."
 
-#: ../gramps/gui/glade/editnote.glade:181
+#: ../gramps/gui/glade/editnote.glade:179
 msgid "A unique ID to identify the note."
 msgstr "Eine eindeutige ID, um die Notiz zu identifizieren."
 
-#: ../gramps/gui/glade/editnote.glade:192
+#: ../gramps/gui/glade/editnote.glade:190
 msgid "_Preformatted"
 msgstr "_Vorformatiert"
 
-#: ../gramps/gui/glade/editnote.glade:200
+#: ../gramps/gui/glade/editnote.glade:198
 msgid ""
 "When active the whitespace in your note will be respected in reports. Use "
 "this to add formatting layout with spaces, eg a table. \n"
@@ -15204,19 +15282,19 @@ msgstr ""
 "das Berichtlayout verbessert.\n"
 "Verwende eine nichtproportionale Schrift, um die Vorformatierung zu erhalten."
 
-#: ../gramps/gui/glade/editperson.glade:166
+#: ../gramps/gui/glade/editperson.glade:165
 msgid "C_all:"
 msgstr "_Rufname:"
 
-#: ../gramps/gui/glade/editperson.glade:246
+#: ../gramps/gui/glade/editperson.glade:245
 msgid "_Nick:"
 msgstr "_Spitzname:"
 
-#: ../gramps/gui/glade/editperson.glade:336
+#: ../gramps/gui/glade/editperson.glade:335
 msgid "Click on a table cell to edit."
 msgstr "Zum Bearbeiten auf Tabellenzelle klicken."
 
-#: ../gramps/gui/glade/editperson.glade:356
+#: ../gramps/gui/glade/editperson.glade:355
 msgid ""
 "Use Multiple Surnames\n"
 "Indicate that the surname consists of different parts. Every surname has its "
@@ -15230,15 +15308,15 @@ msgstr ""
 "'Ramón', welcher vom Vater geerbt wurde, wohingegen die Verbindung 'y' und "
 "'Cajal' gespeichert wird, als von der Mutter geerbt."
 
-#: ../gramps/gui/glade/editperson.glade:400
+#: ../gramps/gui/glade/editperson.glade:399
 msgid "Set person as private data"
 msgstr "Setze Person als vertrauliche Daten"
 
-#: ../gramps/gui/glade/editperson.glade:451
+#: ../gramps/gui/glade/editperson.glade:450
 msgid "_Surname:"
 msgstr "_Nachname:"
 
-#: ../gramps/gui/glade/editperson.glade:467
+#: ../gramps/gui/glade/editperson.glade:466
 msgid ""
 "An optional prefix for the family that is not used in sorting, such as \"de"
 "\" or \"van\"."
@@ -15246,23 +15324,23 @@ msgstr ""
 "Eine optionale Voranstellung für die Familie, die nicht für die Sortierung "
 "verwendet wird, wie \"von\", \"de\" oder \"van\"."
 
-#: ../gramps/gui/glade/editperson.glade:486
+#: ../gramps/gui/glade/editperson.glade:485
 msgid ""
 "Part of a person's name indicating the family to which the person belongs"
 msgstr ""
 "Teil des Namens einer Person, der die Familie zeigt, zu der die Person "
 "gehört."
 
-#: ../gramps/gui/glade/editperson.glade:512
+#: ../gramps/gui/glade/editperson.glade:511
 msgid "Go to Name Editor to add more information about this name"
 msgstr ""
 "Gehe zum Namenseditor um mehr Informationen zu diesem Namen hinzuzufügen"
 
-#: ../gramps/gui/glade/editperson.glade:537
+#: ../gramps/gui/glade/editperson.glade:536
 msgid "O_rigin:"
 msgstr "A_nfang:"
 
-#: ../gramps/gui/glade/editperson.glade:552
+#: ../gramps/gui/glade/editperson.glade:551
 msgid ""
 "The origin of this family name for this family, eg 'Inherited' or "
 "'Patronymic'."
@@ -15270,15 +15348,15 @@ msgstr ""
 "Die Herkunft dieses Nachnamen für diese Familie z.B. 'Geerbt' oder "
 "'Patronymikon'."
 
-#: ../gramps/gui/glade/editperson.glade:586
+#: ../gramps/gui/glade/editperson.glade:585
 msgid "G_ender:"
 msgstr "G_eschlecht:"
 
-#: ../gramps/gui/glade/editperson.glade:634
+#: ../gramps/gui/glade/editperson.glade:633
 msgid "A unique ID for the person."
 msgstr "Ein eindeutiges Kennzeichen für die Person."
 
-#: ../gramps/gui/glade/editperson.glade:709
+#: ../gramps/gui/glade/editperson.glade:708
 msgid "Preferred Name"
 msgstr "Bevorzugter Name"
 
@@ -15438,7 +15516,7 @@ msgstr "Kennnummer der Quelle im Aufbewahrungsort."
 
 #: ../gramps/gui/glade/editreporef.glade:264
 #: ../gramps/gui/glade/editrepository.glade:97
-#: ../gramps/gui/glade/rule.glade:659
+#: ../gramps/gui/glade/rule.glade:656
 #: ../gramps/plugins/tool/ownereditor.glade:152
 msgid "_Name:"
 msgstr "_Name:"
@@ -15509,19 +15587,19 @@ msgstr "A_bkürzung:"
 msgid "A unique ID to identify the source"
 msgstr "Eine eindeutige Kennzeichnung für die Quelle"
 
-#: ../gramps/gui/glade/editurl.glade:97
+#: ../gramps/gui/glade/editurl.glade:96
 msgid "_Web address:"
 msgstr "_Web-Adresse:"
 
-#: ../gramps/gui/glade/editurl.glade:112
+#: ../gramps/gui/glade/editurl.glade:111
 msgid "_Description:"
 msgstr "_Beschreibung:"
 
-#: ../gramps/gui/glade/editurl.glade:171
+#: ../gramps/gui/glade/editurl.glade:170
 msgid "Type of internet address, eg. E-mail, Web Page, ..."
 msgstr "Art der Internetadresse z.B. e-Mail, Webseite,...."
 
-#: ../gramps/gui/glade/editurl.glade:190
+#: ../gramps/gui/glade/editurl.glade:189
 msgid ""
 "The internet address as needed to navigate to it, eg. http://gramps-project."
 "org"
@@ -15529,11 +15607,11 @@ msgstr ""
 "Die Internetadresse, die benötigt wird um dorthin zu navigieren z.B. http://"
 "gramps-project.org"
 
-#: ../gramps/gui/glade/editurl.glade:206
+#: ../gramps/gui/glade/editurl.glade:205
 msgid "Open the web address in the default browser."
 msgstr "Webadresse im Standardbrowser öffnen."
 
-#: ../gramps/gui/glade/editurl.glade:218
+#: ../gramps/gui/glade/editurl.glade:217
 msgid "A descriptive caption of the Internet location you are storing."
 msgstr "Ein beschreibender Titel für die zu speichernde Internet Adresse."
 
@@ -15561,7 +15639,7 @@ msgstr "Klicken, um das Gramplet aus der Ansicht zu löschen."
 msgid "Delete"
 msgstr "Löschen"
 
-#: ../gramps/gui/glade/mergecitation.glade:98
+#: ../gramps/gui/glade/mergecitation.glade:97
 msgid ""
 "Select the citation that will provide the\n"
 "primary data for the merged citation."
@@ -15569,56 +15647,56 @@ msgstr ""
 "Wähle die Fundstelle, die die Hauptdaten für\n"
 "die zusammengefasste Fundstelle enthält."
 
-#: ../gramps/gui/glade/mergecitation.glade:187
+#: ../gramps/gui/glade/mergecitation.glade:186
 #: ../gramps/gui/glade/mergedata.glade:732
-#: ../gramps/gui/glade/mergesource.glade:187
+#: ../gramps/gui/glade/mergesource.glade:186
 msgid "Source 1"
 msgstr "Quelle 1"
 
-#: ../gramps/gui/glade/mergecitation.glade:201
+#: ../gramps/gui/glade/mergecitation.glade:200
 #: ../gramps/gui/glade/mergedata.glade:747
-#: ../gramps/gui/glade/mergesource.glade:201
+#: ../gramps/gui/glade/mergesource.glade:200
 msgid "Source 2"
 msgstr "Quelle 2"
 
-#: ../gramps/gui/glade/mergecitation.glade:312
-#: ../gramps/gui/glade/mergecitation.glade:328
+#: ../gramps/gui/glade/mergecitation.glade:311
+#: ../gramps/gui/glade/mergecitation.glade:327
 #: ../gramps/gui/glade/mergedata.glade:891
 #: ../gramps/gui/glade/mergedata.glade:907
-#: ../gramps/gui/glade/mergeevent.glade:345
-#: ../gramps/gui/glade/mergeevent.glade:361
-#: ../gramps/gui/glade/mergefamily.glade:287
-#: ../gramps/gui/glade/mergefamily.glade:303
-#: ../gramps/gui/glade/mergemedia.glade:312
-#: ../gramps/gui/glade/mergemedia.glade:328
-#: ../gramps/gui/glade/mergenote.glade:312
-#: ../gramps/gui/glade/mergenote.glade:328
-#: ../gramps/gui/glade/mergeperson.glade:290
-#: ../gramps/gui/glade/mergeperson.glade:306
-#: ../gramps/gui/glade/mergeplace.glade:299
-#: ../gramps/gui/glade/mergeplace.glade:314
-#: ../gramps/gui/glade/mergerepository.glade:279
-#: ../gramps/gui/glade/mergerepository.glade:295
-#: ../gramps/gui/glade/mergesource.glade:345
-#: ../gramps/gui/glade/mergesource.glade:361
+#: ../gramps/gui/glade/mergeevent.glade:344
+#: ../gramps/gui/glade/mergeevent.glade:360
+#: ../gramps/gui/glade/mergefamily.glade:286
+#: ../gramps/gui/glade/mergefamily.glade:302
+#: ../gramps/gui/glade/mergemedia.glade:311
+#: ../gramps/gui/glade/mergemedia.glade:327
+#: ../gramps/gui/glade/mergenote.glade:311
+#: ../gramps/gui/glade/mergenote.glade:327
+#: ../gramps/gui/glade/mergeperson.glade:288
+#: ../gramps/gui/glade/mergeperson.glade:304
+#: ../gramps/gui/glade/mergeplace.glade:298
+#: ../gramps/gui/glade/mergeplace.glade:313
+#: ../gramps/gui/glade/mergerepository.glade:278
+#: ../gramps/gui/glade/mergerepository.glade:294
+#: ../gramps/gui/glade/mergesource.glade:344
+#: ../gramps/gui/glade/mergesource.glade:360
 msgid "Gramps ID:"
 msgstr "Gramps ID:"
 
-#: ../gramps/gui/glade/mergecitation.glade:456
+#: ../gramps/gui/glade/mergecitation.glade:455
 msgid "Notes, media objects and data-items of both citations will be combined."
 msgstr ""
 "Notizen, Medienobjekte und Datenelemente werden von beiden Fundstellen "
 "kombiniert."
 
-#: ../gramps/gui/glade/mergecitation.glade:472
-#: ../gramps/gui/glade/mergeevent.glade:529
-#: ../gramps/gui/glade/mergefamily.glade:475
-#: ../gramps/gui/glade/mergemedia.glade:472
-#: ../gramps/gui/glade/mergenote.glade:487
-#: ../gramps/gui/glade/mergeperson.glade:427
-#: ../gramps/gui/glade/mergeplace.glade:636
-#: ../gramps/gui/glade/mergerepository.glade:415
-#: ../gramps/gui/glade/mergesource.glade:529
+#: ../gramps/gui/glade/mergecitation.glade:471
+#: ../gramps/gui/glade/mergeevent.glade:528
+#: ../gramps/gui/glade/mergefamily.glade:474
+#: ../gramps/gui/glade/mergemedia.glade:471
+#: ../gramps/gui/glade/mergenote.glade:486
+#: ../gramps/gui/glade/mergeperson.glade:425
+#: ../gramps/gui/glade/mergeplace.glade:635
+#: ../gramps/gui/glade/mergerepository.glade:414
+#: ../gramps/gui/glade/mergesource.glade:528
 msgid "Detailed Selection"
 msgstr "Detailauswahl"
 
@@ -15632,9 +15710,9 @@ msgstr "Zusa_mmenführen und schließen"
 
 #. name, click?, width, toggle
 #: ../gramps/gui/glade/mergedata.glade:173
-#: ../gramps/gui/glade/mergedata.glade:189 ../gramps/gui/plug/_windows.py:1077
+#: ../gramps/gui/glade/mergedata.glade:189 ../gramps/gui/plug/_windows.py:1088
 #: ../gramps/plugins/tool/changenames.py:195
-#: ../gramps/plugins/tool/patchnames.py:396
+#: ../gramps/plugins/tool/patchnames.py:397
 msgid "Select"
 msgstr "Auswählen"
 
@@ -15648,16 +15726,16 @@ msgid "Title selection"
 msgstr "Auswahl des Titels"
 
 #: ../gramps/gui/glade/mergedata.glade:576
-#: ../gramps/gui/glade/mergeplace.glade:180
+#: ../gramps/gui/glade/mergeplace.glade:179
 msgid "Place 1"
 msgstr "Ort 1"
 
 #: ../gramps/gui/glade/mergedata.glade:593
-#: ../gramps/gui/glade/mergeplace.glade:194
+#: ../gramps/gui/glade/mergeplace.glade:193
 msgid "Place 2"
 msgstr "Ort 2"
 
-#: ../gramps/gui/glade/mergeevent.glade:98
+#: ../gramps/gui/glade/mergeevent.glade:97
 msgid ""
 "Select the event that will provide the\n"
 "primary data for the merged event."
@@ -15665,22 +15743,22 @@ msgstr ""
 "Wähle das Ereignis, das die Hauptdaten\n"
 "für das zusammengefasste Ereignis enthält."
 
-#: ../gramps/gui/glade/mergeevent.glade:187
+#: ../gramps/gui/glade/mergeevent.glade:186
 msgid "Event 1"
 msgstr "Ereignis 1"
 
-#: ../gramps/gui/glade/mergeevent.glade:201
+#: ../gramps/gui/glade/mergeevent.glade:200
 msgid "Event 2"
 msgstr "Ereignis 2"
 
-#: ../gramps/gui/glade/mergeevent.glade:513
+#: ../gramps/gui/glade/mergeevent.glade:512
 msgid ""
 "Attributes, notes, sources and media objects of both events will be combined."
 msgstr ""
 "Attribute, Notizen, Quellen und Medienobjekte werden von beiden Ereignissen "
 "vereint."
 
-#: ../gramps/gui/glade/mergefamily.glade:99
+#: ../gramps/gui/glade/mergefamily.glade:98
 msgid ""
 "Select the family that will provide the\n"
 "primary data for the merged family."
@@ -15688,30 +15766,30 @@ msgstr ""
 "Wähle die Familie, die die Hauptdaten\n"
 "für die zusammengefasste Familie enthält."
 
-#: ../gramps/gui/glade/mergefamily.glade:188
-#: ../gramps/gui/glade/mergefamily.glade:204
+#: ../gramps/gui/glade/mergefamily.glade:187
+#: ../gramps/gui/glade/mergefamily.glade:203
 msgid "Father:"
 msgstr "Vater:"
 
-#: ../gramps/gui/glade/mergefamily.glade:221
-#: ../gramps/gui/glade/mergefamily.glade:237
+#: ../gramps/gui/glade/mergefamily.glade:220
+#: ../gramps/gui/glade/mergefamily.glade:236
 msgid "Mother:"
 msgstr "Mutter:"
 
-#: ../gramps/gui/glade/mergefamily.glade:254
-#: ../gramps/gui/glade/mergefamily.glade:270
+#: ../gramps/gui/glade/mergefamily.glade:253
+#: ../gramps/gui/glade/mergefamily.glade:269
 msgid "Relationship:"
 msgstr "Beziehung:"
 
-#: ../gramps/gui/glade/mergefamily.glade:418
+#: ../gramps/gui/glade/mergefamily.glade:417
 msgid "Family 1"
 msgstr "Familie 1"
 
-#: ../gramps/gui/glade/mergefamily.glade:432
+#: ../gramps/gui/glade/mergefamily.glade:431
 msgid "Family 2"
 msgstr "Familie 2"
 
-#: ../gramps/gui/glade/mergefamily.glade:459
+#: ../gramps/gui/glade/mergefamily.glade:458
 msgid ""
 "Events, lds_ord, media objects, attributes, notes, sources and tags of both "
 "families will be combined."
@@ -15719,7 +15797,7 @@ msgstr ""
 "Ereignisse, HLT_Ord, Medienobjekte, Attribute, Notizen, Quellen und "
 "Markierungen beider Familien werden kombiniert."
 
-#: ../gramps/gui/glade/mergemedia.glade:98
+#: ../gramps/gui/glade/mergemedia.glade:97
 msgid ""
 "Select the object that will provide the\n"
 "primary data for the merged object."
@@ -15727,21 +15805,21 @@ msgstr ""
 "Wähle das Objekt, das die Hauptdaten\n"
 "für das zusammengefasste Objekt enthält."
 
-#: ../gramps/gui/glade/mergemedia.glade:187
+#: ../gramps/gui/glade/mergemedia.glade:186
 msgid "Object 1"
 msgstr "Objekt 1"
 
-#: ../gramps/gui/glade/mergemedia.glade:201
+#: ../gramps/gui/glade/mergemedia.glade:200
 msgid "Object 2"
 msgstr "Objekt 2"
 
-#: ../gramps/gui/glade/mergemedia.glade:456
+#: ../gramps/gui/glade/mergemedia.glade:455
 msgid "Attributes, sources, notes and tags of both objects will be combined."
 msgstr ""
 "Attribute, Quellen, Notizen und Markierungen werden von beiden Objekten "
 "kombiniert."
 
-#: ../gramps/gui/glade/mergenote.glade:98
+#: ../gramps/gui/glade/mergenote.glade:97
 msgid ""
 "Select the note that will provide the\n"
 "primary data for the merged note."
@@ -15749,21 +15827,20 @@ msgstr ""
 "Wähle die Notiz, die die Hauptdaten\n"
 "für die zusammengefasste Notiz enthält."
 
-#: ../gramps/gui/glade/mergenote.glade:187
+#: ../gramps/gui/glade/mergenote.glade:186
 msgid "Note 1"
 msgstr "Notiz 1"
 
-#: ../gramps/gui/glade/mergenote.glade:201
+#: ../gramps/gui/glade/mergenote.glade:200
 msgid "Note 2"
 msgstr "Notiz 2"
 
-#: ../gramps/gui/glade/mergenote.glade:279
-#: ../gramps/gui/glade/mergenote.glade:295
-#: ../gramps/gui/views/listview.py:1007
+#: ../gramps/gui/glade/mergenote.glade:278
+#: ../gramps/gui/glade/mergenote.glade:294 ../gramps/gui/views/listview.py:1015
 msgid "Format:"
 msgstr "Format:"
 
-#: ../gramps/gui/glade/mergeperson.glade:104
+#: ../gramps/gui/glade/mergeperson.glade:102
 msgid ""
 "Select the person that will provide the\n"
 "primary data for the merged person."
@@ -15771,20 +15848,20 @@ msgstr ""
 "Wähle die Person, die die Hauptdaten\n"
 "für die zusammengefasste Person enthält."
 
-#: ../gramps/gui/glade/mergeperson.glade:198
+#: ../gramps/gui/glade/mergeperson.glade:196
 msgid "Person 1"
 msgstr "Person 1"
 
-#: ../gramps/gui/glade/mergeperson.glade:212
+#: ../gramps/gui/glade/mergeperson.glade:210
 msgid "Person 2"
 msgstr "Person 2"
 
-#: ../gramps/gui/glade/mergeperson.glade:257
-#: ../gramps/gui/glade/mergeperson.glade:273
+#: ../gramps/gui/glade/mergeperson.glade:255
+#: ../gramps/gui/glade/mergeperson.glade:271
 msgid "Gender:"
 msgstr "Geschlecht:"
 
-#: ../gramps/gui/glade/mergeperson.glade:411
+#: ../gramps/gui/glade/mergeperson.glade:409
 msgid ""
 "Events, media objects, addresses, attributes, urls, notes, sources and tags "
 "of both persons will be combined."
@@ -15792,11 +15869,11 @@ msgstr ""
 "Ereignisse, Medienobjekte, Adressen, Attribute, URLs. Notizen, Quellen und "
 "Markierungen werden von beiden Personen kombiniert."
 
-#: ../gramps/gui/glade/mergeperson.glade:502
+#: ../gramps/gui/glade/mergeperson.glade:500
 msgid "Context Information"
 msgstr "Kontextinformation"
 
-#: ../gramps/gui/glade/mergeplace.glade:95
+#: ../gramps/gui/glade/mergeplace.glade:94
 msgid ""
 "Select the place that will provide the\n"
 "primary data for the merged place."
@@ -15804,7 +15881,7 @@ msgstr ""
 "Wähle den Ort, der die Hauptdaten\n"
 "für den zusammengefassten Ort enthält."
 
-#: ../gramps/gui/glade/mergeplace.glade:620
+#: ../gramps/gui/glade/mergeplace.glade:619
 msgid ""
 "Alternative names, sources, urls, media objects and notes of both places "
 "will be combined."
@@ -15812,7 +15889,7 @@ msgstr ""
 "Alternative Namen, Quellen, URLs, Medienobjekte und Notizen beider Orte "
 "werden kombiniert."
 
-#: ../gramps/gui/glade/mergerepository.glade:98
+#: ../gramps/gui/glade/mergerepository.glade:97
 msgid ""
 "Select the repository that will provide the\n"
 "primary data for the merged repository."
@@ -15820,19 +15897,19 @@ msgstr ""
 "Wähle den Aufbewahrungsort, der die Hauptdaten\n"
 "für den zusammengefassten Aufbewahrungsort enthält."
 
-#: ../gramps/gui/glade/mergerepository.glade:187
+#: ../gramps/gui/glade/mergerepository.glade:186
 msgid "Repository 1"
 msgstr "Aufbewahrungsort 1"
 
-#: ../gramps/gui/glade/mergerepository.glade:201
+#: ../gramps/gui/glade/mergerepository.glade:200
 msgid "Repository 2"
 msgstr "Aufbewahrungsort 2"
 
-#: ../gramps/gui/glade/mergerepository.glade:399
+#: ../gramps/gui/glade/mergerepository.glade:398
 msgid "Addresses, urls and notes of both repositories will be combined."
 msgstr "Adressen, URLs und Notizen beider Aufbewahrungsorte werden kombiniert."
 
-#: ../gramps/gui/glade/mergesource.glade:98
+#: ../gramps/gui/glade/mergesource.glade:97
 msgid ""
 "Select the source that will provide the\n"
 "primary data for the merged source."
@@ -15840,7 +15917,7 @@ msgstr ""
 "Wähle die Quelle, die die Hauptdaten\n"
 "für die zusammengefasste Quelle enthält."
 
-#: ../gramps/gui/glade/mergesource.glade:513
+#: ../gramps/gui/glade/mergesource.glade:512
 msgid ""
 "Notes, media objects, data-items and repository references of both sources "
 "will be combined."
@@ -15884,8 +15961,8 @@ msgstr "Ausrichtung:"
 #: ../gramps/gui/glade/styleeditor.glade:724
 #: ../gramps/gui/glade/styleeditor.glade:737
 #: ../gramps/gui/glade/styleeditor.glade:869
-#: ../gramps/gui/glade/styleeditor.glade:1295
-#: ../gramps/gui/glade/styleeditor.glade:1641
+#: ../gramps/gui/glade/styleeditor.glade:1298
+#: ../gramps/gui/glade/styleeditor.glade:1644
 #: ../gramps/gui/plug/report/_papermenu.py:208
 msgid "cm"
 msgstr "cm"
@@ -15914,24 +15991,24 @@ msgstr "_Unten:"
 msgid "Metric"
 msgstr "Metrisch"
 
-#: ../gramps/gui/glade/plugins.glade:46
+#: ../gramps/gui/glade/plugins.glade:44
 msgid "Perform selected action"
 msgstr "Gewählte Aktion durchführen"
 
-#: ../gramps/gui/glade/plugins.glade:51
+#: ../gramps/gui/glade/plugins.glade:49
 #: ../gramps/plugins/gramplet/ageondategramplet.py:68
 msgid "Run"
 msgstr "Starten"
 
-#: ../gramps/gui/glade/plugins.glade:141 ../gramps/gui/plug/_dialogs.py:284
+#: ../gramps/gui/glade/plugins.glade:139 ../gramps/gui/plug/_dialogs.py:291
 msgid "Select a report from those available on the left."
 msgstr "Einen der linksseitig aufgeführten Berichte auswählen."
 
-#: ../gramps/gui/glade/plugins.glade:162
+#: ../gramps/gui/glade/plugins.glade:160
 msgid "Status:"
 msgstr "Status:"
 
-#: ../gramps/gui/glade/plugins.glade:208
+#: ../gramps/gui/glade/plugins.glade:206
 msgid "Author's email:"
 msgstr "E-Mail-Adresse des Autors:"
 
@@ -15967,58 +16044,57 @@ msgstr "Familie nach oben verschieben"
 msgid "Move family down"
 msgstr "Familie nach unten verschieben"
 
-#: ../gramps/gui/glade/rule.glade:124
+#: ../gramps/gui/glade/rule.glade:122
 msgid "Add a new filter"
 msgstr "Filter hinzufügen"
 
-#: ../gramps/gui/glade/rule.glade:148
+#: ../gramps/gui/glade/rule.glade:146
 msgid "Edit the selected filter"
 msgstr "Gewählten Filter bearbeiten"
 
-#: ../gramps/gui/glade/rule.glade:172
+#: ../gramps/gui/glade/rule.glade:170
 msgid "Clone the selected filter"
 msgstr "Gewählten Filter duplizieren"
 
-#: ../gramps/gui/glade/rule.glade:194
+#: ../gramps/gui/glade/rule.glade:192
 msgid "Test the selected filter"
 msgstr "Den gewählten Filter testen"
 
-#: ../gramps/gui/glade/rule.glade:218
+#: ../gramps/gui/glade/rule.glade:216
 msgid "Delete the selected filter"
 msgstr "Gewählten Filter löschen"
 
-#: ../gramps/gui/glade/rule.glade:258
+#: ../gramps/gui/glade/rule.glade:256
 msgid "Note: changes take effect only after this window is closed"
 msgstr ""
 "Anmerkung: Änderungen werden erst wirksam, nachdem dieses Fenster "
 "geschlossen wurde"
 
-#: ../gramps/gui/glade/rule.glade:290 gtklist.h:6
+#: ../gramps/gui/glade/rule.glade:288 gtklist.h:6
 msgid "All rules must apply"
 msgstr "Alle Regeln müssen passen"
 
-#: ../gramps/gui/glade/rule.glade:293 gtklist.h:7
+#: ../gramps/gui/glade/rule.glade:291 gtklist.h:7
 msgid "At least one rule must apply"
 msgstr "Mindestens eine Regel muss passen"
 
-#: ../gramps/gui/glade/rule.glade:296 gtklist.h:8
+#: ../gramps/gui/glade/rule.glade:294 gtklist.h:8
 msgid "Exactly one rule must apply"
 msgstr "Genau eine Regel muss passen"
 
-#: ../gramps/gui/glade/rule.glade:416
+#: ../gramps/gui/glade/rule.glade:413
 msgid "Add another rule to the filter"
 msgstr "Dem Filter eine weitere Regel hinzufügen"
 
-#: ../gramps/gui/glade/rule.glade:450
+#: ../gramps/gui/glade/rule.glade:447
 msgid "Edit the selected rule"
 msgstr "Die gewählte Regel bearbeiten"
 
-#: ../gramps/gui/glade/rule.glade:484
+#: ../gramps/gui/glade/rule.glade:481
 msgid "Delete the selected rule"
 msgstr "Die gewählte Regel löschen"
 
-#: ../gramps/gui/glade/rule.glade:524
-#: ../gramps/gui/glade/styleeditor.glade:403
+#: ../gramps/gui/glade/rule.glade:521 ../gramps/gui/glade/styleeditor.glade:403
 #: ../gramps/plugins/export/exportcsv.glade:113
 #: ../gramps/plugins/export/exportftree.glade:120
 #: ../gramps/plugins/export/exportgeneweb.glade:121
@@ -16030,23 +16106,23 @@ msgstr "Die gewählte Regel löschen"
 msgid "Options"
 msgstr "Optionen"
 
-#: ../gramps/gui/glade/rule.glade:539
+#: ../gramps/gui/glade/rule.glade:536
 msgid "Rule list"
 msgstr "Regelliste"
 
-#: ../gramps/gui/glade/rule.glade:554
+#: ../gramps/gui/glade/rule.glade:551
 msgid "Definition"
 msgstr "Definition"
 
-#: ../gramps/gui/glade/rule.glade:571
+#: ../gramps/gui/glade/rule.glade:568
 msgid "Co_mment:"
 msgstr "Ko_mmentar:"
 
-#: ../gramps/gui/glade/rule.glade:606
+#: ../gramps/gui/glade/rule.glade:603
 msgid "Return values that do no_t match the filter rules"
 msgstr "Werte liefern, die nicht den Filterregeln entsprechen"
 
-#: ../gramps/gui/glade/rule.glade:898
+#: ../gramps/gui/glade/rule.glade:895
 msgid "Selected Rule"
 msgstr "Gewählte Regel"
 
@@ -16072,19 +16148,19 @@ msgstr "_Swiss (Arial, Helvetica, sans-serif)"
 
 #. #################
 #: ../gramps/gui/glade/styleeditor.glade:339
-#: ../gramps/plugins/drawreport/ancestortree.py:890
-#: ../gramps/plugins/drawreport/descendtree.py:1601
+#: ../gramps/plugins/drawreport/ancestortree.py:899
+#: ../gramps/plugins/drawreport/descendtree.py:1619
 msgid "Size"
 msgstr "Größe"
 
 #: ../gramps/gui/glade/styleeditor.glade:369
-#: ../gramps/gui/plug/report/_styleeditor.py:228
+#: ../gramps/gui/plug/report/_styleeditor.py:231
 msgid "point size|pt"
 msgstr "Pkt."
 
 #: ../gramps/gui/glade/styleeditor.glade:384
-#: ../gramps/gui/glade/styleeditor.glade:1430
-#: ../gramps/gui/plug/_guioptions.py:1493 ../gramps/gui/views/tags.py:398
+#: ../gramps/gui/glade/styleeditor.glade:1433
+#: ../gramps/gui/plug/_guioptions.py:1494 ../gramps/gui/views/tags.py:403
 msgid "Color"
 msgstr "Farbe"
 
@@ -16109,7 +16185,7 @@ msgid "Alignment"
 msgstr "Ausrichtung"
 
 #: ../gramps/gui/glade/styleeditor.glade:570
-#: ../gramps/plugins/drawreport/fanchart.py:701
+#: ../gramps/plugins/drawreport/fanchart.py:713
 msgid "Background color"
 msgstr "Hintergrundfarbe"
 
@@ -16138,8 +16214,8 @@ msgid "Belo_w:"
 msgstr "Unte_n:"
 
 #: ../gramps/gui/glade/styleeditor.glade:753
-#: ../gramps/gui/glade/styleeditor.glade:1253
-#: ../gramps/plugins/drawreport/calendarreport.py:645
+#: ../gramps/gui/glade/styleeditor.glade:1256
+#: ../gramps/plugins/drawreport/calendarreport.py:648
 msgid "Borders"
 msgstr "Ränder"
 
@@ -16159,115 +16235,115 @@ msgstr "_Links"
 msgid "_Right"
 msgstr "_Rechts"
 
-#: ../gramps/gui/glade/styleeditor.glade:959
+#: ../gramps/gui/glade/styleeditor.glade:960
 msgid "J_ustify"
 msgstr "_Blocksatz"
 
-#: ../gramps/gui/glade/styleeditor.glade:976
+#: ../gramps/gui/glade/styleeditor.glade:978
 msgid "Cen_ter"
 msgstr "Zen_triert"
 
-#: ../gramps/gui/glade/styleeditor.glade:1005
+#: ../gramps/gui/glade/styleeditor.glade:1008
 msgid "Le_ft"
 msgstr "Li_nks"
 
-#: ../gramps/gui/glade/styleeditor.glade:1023
+#: ../gramps/gui/glade/styleeditor.glade:1026
 msgid "Righ_t"
 msgstr "Re_chts"
 
-#: ../gramps/gui/glade/styleeditor.glade:1040
+#: ../gramps/gui/glade/styleeditor.glade:1043
 msgid "_Top"
 msgstr "_Oben"
 
-#: ../gramps/gui/glade/styleeditor.glade:1057
+#: ../gramps/gui/glade/styleeditor.glade:1060
 msgid "_Bottom"
 msgstr "_Unten"
 
-#: ../gramps/gui/glade/styleeditor.glade:1121
+#: ../gramps/gui/glade/styleeditor.glade:1124
 msgid "Paragraph options"
 msgstr "Absatzoptionen"
 
-#: ../gramps/gui/glade/styleeditor.glade:1143
+#: ../gramps/gui/glade/styleeditor.glade:1146
 msgid "Width"
 msgstr "Breite"
 
-#: ../gramps/gui/glade/styleeditor.glade:1158
+#: ../gramps/gui/glade/styleeditor.glade:1161
 msgid "Column widths"
 msgstr "Spaltenbreite"
 
-#: ../gramps/gui/glade/styleeditor.glade:1202
+#: ../gramps/gui/glade/styleeditor.glade:1205
 msgid "%"
 msgstr "%"
 
-#: ../gramps/gui/glade/styleeditor.glade:1228
+#: ../gramps/gui/glade/styleeditor.glade:1231
 msgid "Table options"
 msgstr "Tabellenoptionen"
 
-#: ../gramps/gui/glade/styleeditor.glade:1284
+#: ../gramps/gui/glade/styleeditor.glade:1287
 msgid "Padding:"
 msgstr "Füllung:"
 
-#: ../gramps/gui/glade/styleeditor.glade:1309
+#: ../gramps/gui/glade/styleeditor.glade:1312
 msgid "Left"
 msgstr "Links"
 
-#: ../gramps/gui/glade/styleeditor.glade:1325
+#: ../gramps/gui/glade/styleeditor.glade:1328
 msgid "Right"
 msgstr "Rechts"
 
-#: ../gramps/gui/glade/styleeditor.glade:1384
+#: ../gramps/gui/glade/styleeditor.glade:1387
 msgid "Cell options"
 msgstr "Zellenoptionen"
 
-#: ../gramps/gui/glade/styleeditor.glade:1409
+#: ../gramps/gui/glade/styleeditor.glade:1412
 msgid "Line"
 msgstr "Linie"
 
-#: ../gramps/gui/glade/styleeditor.glade:1449
+#: ../gramps/gui/glade/styleeditor.glade:1452
 msgid "Style:"
 msgstr "Stil:"
 
-#: ../gramps/gui/glade/styleeditor.glade:1462
+#: ../gramps/gui/glade/styleeditor.glade:1465
 msgid "Width:"
 msgstr "Breite:"
 
-#: ../gramps/gui/glade/styleeditor.glade:1475
+#: ../gramps/gui/glade/styleeditor.glade:1478
 msgid "Line:"
 msgstr "Linie:"
 
-#: ../gramps/gui/glade/styleeditor.glade:1488
+#: ../gramps/gui/glade/styleeditor.glade:1491
 msgid "Fill:"
 msgstr "Füllung:"
 
-#: ../gramps/gui/glade/styleeditor.glade:1503
+#: ../gramps/gui/glade/styleeditor.glade:1506
 msgid "Shadow"
 msgstr "Schatten"
 
-#: ../gramps/gui/glade/styleeditor.glade:1579
+#: ../gramps/gui/glade/styleeditor.glade:1582
 msgid "pt"
 msgstr "pt"
 
-#: ../gramps/gui/glade/styleeditor.glade:1602
+#: ../gramps/gui/glade/styleeditor.glade:1605
 msgid "Spacing:"
 msgstr "Abstand:"
 
-#: ../gramps/gui/glade/styleeditor.glade:1624
+#: ../gramps/gui/glade/styleeditor.glade:1627
 msgid "Draw shadow"
 msgstr "Schatten zeichnen"
 
-#: ../gramps/gui/glade/styleeditor.glade:1666
+#: ../gramps/gui/glade/styleeditor.glade:1669
 msgid "Draw options"
 msgstr "Zeichnen-Optionen"
 
-#: ../gramps/gui/glade/styleeditor.glade:1821
+#: ../gramps/gui/glade/styleeditor.glade:1824
 msgid "Add a new style"
 msgstr "Neue Stil hinzufügen"
 
-#: ../gramps/gui/glade/styleeditor.glade:1853
+#: ../gramps/gui/glade/styleeditor.glade:1856
 msgid "Edit the selected style"
 msgstr "Gewählte Stil bearbeiten"
 
-#: ../gramps/gui/glade/styleeditor.glade:1885
+#: ../gramps/gui/glade/styleeditor.glade:1888
 msgid "Delete the selected style"
 msgstr "Gewählte Stil löschen"
 
@@ -16276,7 +16352,7 @@ msgid "_Display on startup"
 msgstr "_Beim Starten anzeigen"
 
 #: ../gramps/gui/glade/tipofday.glade:102
-#: ../gramps/gui/views/navigationview.py:291
+#: ../gramps/gui/views/navigationview.py:293
 msgid "_Forward"
 msgstr "_Vor"
 
@@ -16285,7 +16361,7 @@ msgid "Install Selected _Addons"
 msgstr "Gewählte _Erweiterungen installieren"
 
 #: ../gramps/gui/glade/updateaddons.glade:73
-#: ../gramps/gui/plug/_windows.py:1058
+#: ../gramps/gui/plug/_windows.py:1069
 msgid "Available Gramps Updates for Addons"
 msgstr "Verfügbare Gramps Aktualisierungen für die Erweiterungen (Addons)"
 
@@ -16316,7 +16392,7 @@ msgstr "_Alles wählen"
 msgid "Select _None"
 msgstr "_Nichts wählen"
 
-#: ../gramps/gui/grampsgui.py:58
+#: ../gramps/gui/grampsgui.py:60
 msgid ""
 "Your version of gi (gnome-introspection) seems to be too old. You need a "
 "version which has the function 'require_version' to start Gramps"
@@ -16325,7 +16401,7 @@ msgstr ""
 "benötigst eine Version mit der Funktion 'require_version' um Gramps zu "
 "starten"
 
-#: ../gramps/gui/grampsgui.py:72
+#: ../gramps/gui/grampsgui.py:74
 #, python-format
 msgid ""
 "Your pygobject version does not meet the requirements.\n"
@@ -16340,7 +16416,7 @@ msgstr ""
 "\n"
 "Gramps wird nun beendet."
 
-#: ../gramps/gui/grampsgui.py:90
+#: ../gramps/gui/grampsgui.py:92
 msgid ""
 "Gdk, Gtk, Pango or PangoCairo typelib not installed.\n"
 "Install Gnome Introspection, and pygobject version 3.12 or later.\n"
@@ -16354,7 +16430,7 @@ msgstr ""
 "\n"
 "Gramps wird jetzt beendet."
 
-#: ../gramps/gui/grampsgui.py:101
+#: ../gramps/gui/grampsgui.py:103
 #, python-format
 msgid ""
 "Your Gtk version does not meet the requirements.\n"
@@ -16367,7 +16443,7 @@ msgstr ""
 "\n"
 "Gramps wird nun beendet."
 
-#: ../gramps/gui/grampsgui.py:112
+#: ../gramps/gui/grampsgui.py:114
 msgid ""
 "\n"
 "cairo python support not installed. Install cairo for your version of "
@@ -16381,15 +16457,19 @@ msgstr ""
 "\n"
 "Gramps wird jetzt beendet."
 
-#: ../gramps/gui/grampsgui.py:130
+#: ../gramps/gui/grampsgui.py:145
 msgid "Danger: This is unstable code!"
 msgstr "ACHTUNG: Dies ist instabiler Code!"
 
-#: ../gramps/gui/grampsgui.py:131
+#: ../gramps/gui/grampsgui.py:146
+#, python-format
+msgid "This Gramps ('%s') is a development release.\n"
+msgstr "Dieses Gramps ('%s') ist eine Entwicklerversion.\n"
+
+#: ../gramps/gui/grampsgui.py:148
 #, python-format
 msgid ""
-"This Gramps ('master') is a development release. This version is not meant "
-"for normal usage. Use at your own risk.\n"
+"This version is not meant for normal usage. Use at your own risk.\n"
 "\n"
 "This version may:\n"
 "1) Work differently than you expect.\n"
@@ -16402,7 +16482,7 @@ msgid ""
 "with this version, and make sure to export your data to XML every now and "
 "then."
 msgstr ""
-"Dies Gramps ('master') ist eine Entwicklerversion. Diese Version ist nicht "
+"Diese Version ist nicht "
 "für die tägliche Arbeit gedacht. Verwendung auf eigenes Risiko.\n"
 "\n"
 "Diese Version kann:\n"
@@ -16416,11 +16496,11 @@ msgstr ""
 "%(bold_start)sSICHERE%(bold_end)s deine bestehenden Daten bevor du sie mit "
 "dieser Version öffnest, und exportiere deine Daten öfter im XML-Format."
 
-#: ../gramps/gui/grampsgui.py:186
+#: ../gramps/gui/grampsgui.py:178
 msgid "Gramps detected an incomplete GTK installation"
 msgstr "Gramps hat eine unvollständige GTK installation entdeckt"
 
-#: ../gramps/gui/grampsgui.py:187
+#: ../gramps/gui/grampsgui.py:180
 #, python-format
 msgid ""
 "GTK translations for the current language (%(language)s) are missing.\n"
@@ -16439,11 +16519,11 @@ msgstr ""
 "Installationsvoraussetzungen,\n"
 "welche normalerweise unter /usr/share/doc/gramps abgelegt ist.\n"
 
-#: ../gramps/gui/grampsgui.py:230
+#: ../gramps/gui/grampsgui.py:297
 msgid "Error parsing arguments"
 msgstr "Fehler beim analysieren der Argumente."
 
-#: ../gramps/gui/grampsgui.py:279 ../gramps/gui/grampsgui.py:317
+#: ../gramps/gui/grampsgui.py:347 ../gramps/gui/grampsgui.py:386
 msgid ""
 "\n"
 "Gramps failed to start. Please report a bug about this.\n"
@@ -16462,6 +16542,10 @@ msgstr ""
 "Du kannst auch händisch die Startansicht in der gramps.ini Datei durch "
 "Ändern \n"
 "des last-view Parameter ändern.\n"
+
+#: ../gramps/gui/grampsgui.py:365
+msgid "Gramps terminated because of no DISPLAY"
+msgstr "Gramps wurde wegen kein DISPLAY beendet"
 
 #: ../gramps/gui/logger/_errorreportassistant.py:86
 msgid "Error Report Assistant"
@@ -16698,9 +16782,9 @@ msgstr "Familien_zusammenfassen"
 msgid "Merge Families"
 msgstr "Familien zusammenfassen"
 
-#: ../gramps/gui/merge/mergefamily.py:222
-#: ../gramps/gui/merge/mergeperson.py:328
-#: ../gramps/plugins/lib/libpersonview.py:418
+#: ../gramps/gui/merge/mergefamily.py:227
+#: ../gramps/gui/merge/mergeperson.py:329
+#: ../gramps/plugins/lib/libpersonview.py:424
 msgid "Cannot merge people"
 msgstr "Die Personen können nicht zusammengefasst werden."
 
@@ -16712,11 +16796,11 @@ msgstr "Medienobjekte_zusammenfassen"
 msgid "manual|Merge_Notes"
 msgstr "Notizen_zusammenfassen"
 
-#: ../gramps/gui/merge/mergenote.py:93
+#: ../gramps/gui/merge/mergenote.py:94
 msgid "flowed"
 msgstr "fließend"
 
-#: ../gramps/gui/merge/mergenote.py:93
+#: ../gramps/gui/merge/mergenote.py:94
 msgid "preformatted"
 msgstr "vorformatiert"
 
@@ -16728,73 +16812,72 @@ msgstr "Personen_zusammenfassen"
 msgid "Merge People"
 msgstr "Personen zusammenfassen"
 
-#: ../gramps/gui/merge/mergeperson.py:193
-#: ../gramps/plugins/textreport/indivcomplete.py:343
+#: ../gramps/gui/merge/mergeperson.py:194
+#: ../gramps/plugins/textreport/indivcomplete.py:378
 msgid "Alternate Names"
 msgstr "Alternative Namen"
 
-#: ../gramps/gui/merge/mergeperson.py:200
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:451
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:465
+#: ../gramps/gui/merge/mergeperson.py:201
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:474
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:488
 #: ../gramps/plugins/quickview/filterbyname.py:97
 #: ../gramps/plugins/quickview/filterbyname.py:122
 #: ../gramps/plugins/textreport/tagreport.py:320
 #: ../gramps/plugins/view/eventview.py:119
 #: ../gramps/plugins/view/view.gpr.py:35 ../gramps/plugins/view/view.gpr.py:43
-#: ../gramps/plugins/webreport/narrativeweb.py:1900
-#: ../gramps/plugins/webreport/narrativeweb.py:1965
-#: ../gramps/plugins/webreport/narrativeweb.py:2019
-#: ../gramps/plugins/webreport/narrativeweb.py:4118
-#: ../gramps/plugins/webreport/narrativeweb.py:4338
-#: ../gramps/plugins/webreport/narrativeweb.py:7269
+#: ../gramps/plugins/webreport/narrativeweb.py:1876
+#: ../gramps/plugins/webreport/narrativeweb.py:1943
+#: ../gramps/plugins/webreport/narrativeweb.py:2005
+#: ../gramps/plugins/webreport/narrativeweb.py:4161
+#: ../gramps/plugins/webreport/narrativeweb.py:4384
+#: ../gramps/plugins/webreport/narrativeweb.py:7353
 msgid "Events"
 msgstr "Ereignisse"
 
 #. Go over parents and build their menu
 #. don't show rest
-#: ../gramps/gui/merge/mergeperson.py:215
-#: ../gramps/gui/widgets/fanchart.py:1742
+#: ../gramps/gui/merge/mergeperson.py:216
+#: ../gramps/gui/widgets/fanchart.py:1679
 #: ../gramps/plugins/quickview/all_relations.py:305
 #: ../gramps/plugins/tool/notrelated.py:126
-#: ../gramps/plugins/view/pedigreeview.py:1781
-#: ../gramps/plugins/view/relview.py:527 ../gramps/plugins/view/relview.py:851
-#: ../gramps/plugins/view/relview.py:887
-#: ../gramps/plugins/webreport/narrativeweb.py:379
-#: ../gramps/plugins/webreport/narrativeweb.py:3270
-#: ../gramps/plugins/webreport/narrativeweb.py:6085
-#: ../gramps/plugins/webreport/narrativeweb.py:7476
+#: ../gramps/plugins/view/pedigreeview.py:1790
+#: ../gramps/plugins/view/relview.py:538 ../gramps/plugins/view/relview.py:862
+#: ../gramps/plugins/view/relview.py:898
+#: ../gramps/plugins/webreport/narrativeweb.py:3265
+#: ../gramps/plugins/webreport/narrativeweb.py:6143
+#: ../gramps/plugins/webreport/narrativeweb.py:7563
 msgid "Parents"
 msgstr "Eltern"
 
-#: ../gramps/gui/merge/mergeperson.py:218
-#: ../gramps/gui/merge/mergeperson.py:232
+#: ../gramps/gui/merge/mergeperson.py:219
+#: ../gramps/gui/merge/mergeperson.py:233
 #: ../gramps/plugins/tool/findloop.py:111
 msgid "Family ID"
 msgstr "Familie-ID"
 
-#: ../gramps/gui/merge/mergeperson.py:224
+#: ../gramps/gui/merge/mergeperson.py:225
 msgid "No parents found"
 msgstr "Keine Eltern gefunden"
 
 #. Go over spouses and build their menu
-#: ../gramps/gui/merge/mergeperson.py:226
-#: ../gramps/gui/widgets/fanchart.py:1626
-#: ../gramps/plugins/textreport/kinshipreport.py:131
-#: ../gramps/plugins/view/pedigreeview.py:1659
+#: ../gramps/gui/merge/mergeperson.py:227
+#: ../gramps/gui/widgets/fanchart.py:1551
+#: ../gramps/plugins/textreport/kinshipreport.py:132
+#: ../gramps/plugins/view/pedigreeview.py:1677
 msgid "Spouses"
 msgstr "(Ehe-)Partner"
 
-#: ../gramps/gui/merge/mergeperson.py:236
-#: ../gramps/gui/selectors/selectperson.py:101
+#: ../gramps/gui/merge/mergeperson.py:237
+#: ../gramps/gui/selectors/selectperson.py:100
 #: ../gramps/gui/widgets/reorderfam.py:89
 #: ../gramps/plugins/gramplet/children.py:98
 #: ../gramps/plugins/lib/libpersonview.py:105
-#: ../gramps/plugins/textreport/familygroup.py:565
-#: ../gramps/plugins/view/relview.py:1395
+#: ../gramps/plugins/textreport/familygroup.py:566
+#: ../gramps/plugins/view/relview.py:1405
 msgid "Spouse"
 msgstr "Partner(in)"
 
-#: ../gramps/gui/merge/mergeperson.py:250
+#: ../gramps/gui/merge/mergeperson.py:251
 msgid "No spouses or children found"
 msgstr "Keine (Ehe-)Partner oder Kinder gefunden"
 
@@ -16814,31 +16897,31 @@ msgstr "Quellen_zusammenfassen"
 msgid "Merge Sources"
 msgstr "Quellen zusammenfassen"
 
-#: ../gramps/gui/plug/_dialogs.py:283
+#: ../gramps/gui/plug/_dialogs.py:290
 msgid "Report Selection"
 msgstr "Auswahl eines Berichts"
 
-#: ../gramps/gui/plug/_dialogs.py:285
+#: ../gramps/gui/plug/_dialogs.py:292
 msgid "Generate selected report"
 msgstr "Ausgewählten Bericht erstellen"
 
-#: ../gramps/gui/plug/_dialogs.py:285
+#: ../gramps/gui/plug/_dialogs.py:292
 msgid "_Generate"
 msgstr "_Erstellen"
 
-#: ../gramps/gui/plug/_dialogs.py:314
+#: ../gramps/gui/plug/_dialogs.py:321
 msgid "Tool Selection"
 msgstr "Werkzeugauswahl"
 
-#: ../gramps/gui/plug/_dialogs.py:315
+#: ../gramps/gui/plug/_dialogs.py:322
 msgid "Select a tool from those available on the left."
 msgstr "Eines der linksseitig aufgeführten Werkzeuge auswählen."
 
-#: ../gramps/gui/plug/_dialogs.py:316 ../gramps/plugins/tool/verify.glade:144
+#: ../gramps/gui/plug/_dialogs.py:323 ../gramps/plugins/tool/verify.glade:144
 msgid "_Run"
 msgstr "Ausfüh_ren"
 
-#: ../gramps/gui/plug/_dialogs.py:317
+#: ../gramps/gui/plug/_dialogs.py:324
 msgid "Run selected tool"
 msgstr "Ausgewähltes Werkzeug ausführen"
 
@@ -16851,63 +16934,54 @@ msgstr "Nachnamen wählen"
 msgid "Count"
 msgstr "Zählung"
 
-#. we could use database.get_surname_list(), but if we do that
-#. all we get is a list of names without a count...therefore
-#. we'll traverse the entire database ourself and build up a
-#. list that we can use
-#. for name in database.get_surname_list():
-#. self.__model.append([name, 0])
-#. build up the list of surnames, keeping track of the count for each
-#. name (this can be a lengthy process, so by passing in the
-#. dictionary we can be certain we only do this once)
-#: ../gramps/gui/plug/_guioptions.py:117
+#: ../gramps/gui/plug/_guioptions.py:118
 msgid "Finding Surnames"
 msgstr "Finde Nachnamen"
 
-#: ../gramps/gui/plug/_guioptions.py:118
+#: ../gramps/gui/plug/_guioptions.py:119
 msgid "Finding surnames"
 msgstr "Finde Nachnamen"
 
-#: ../gramps/gui/plug/_guioptions.py:674
+#: ../gramps/gui/plug/_guioptions.py:675
 msgid "Select a different person"
 msgstr "Eine andere Person wählen"
 
-#: ../gramps/gui/plug/_guioptions.py:701
+#: ../gramps/gui/plug/_guioptions.py:702
 msgid "Select a person for the report"
 msgstr "Eine Person für den Bericht wählen"
 
-#: ../gramps/gui/plug/_guioptions.py:784
+#: ../gramps/gui/plug/_guioptions.py:785
 msgid "Select a different family"
 msgstr "Eine andere Familie wählen"
 
-#: ../gramps/gui/plug/_guioptions.py:1241
+#: ../gramps/gui/plug/_guioptions.py:1242
 #, python-format
 msgid "Also include %s?"
 msgstr "%s auch berücksichtigen?"
 
-#: ../gramps/gui/plug/_guioptions.py:1243
-#: ../gramps/gui/selectors/selectperson.py:87
+#: ../gramps/gui/plug/_guioptions.py:1244
+#: ../gramps/gui/selectors/selectperson.py:86
 msgid "Select Person"
 msgstr "Person wählen"
 
-#: ../gramps/gui/plug/_guioptions.py:1563
+#: ../gramps/gui/plug/_guioptions.py:1564
 #, python-format
 msgid "Select color for %s"
 msgstr "Wähle die Farbe für %s"
 
-#: ../gramps/gui/plug/_guioptions.py:1725
-#: ../gramps/gui/plug/report/_reportdialog.py:449
+#: ../gramps/gui/plug/_guioptions.py:1726
+#: ../gramps/gui/plug/report/_reportdialog.py:450
 msgid "Save As"
 msgstr "Speichern als"
 
-#: ../gramps/gui/plug/_guioptions.py:1729 ../gramps/gui/plug/_windows.py:429
-#: ../gramps/gui/plug/report/_bookdialog.py:665
-#: ../gramps/gui/plug/report/_fileentry.py:65
+#: ../gramps/gui/plug/_guioptions.py:1730 ../gramps/gui/plug/_windows.py:434
+#: ../gramps/gui/plug/report/_bookdialog.py:625
+#: ../gramps/gui/plug/report/_fileentry.py:66
 msgid "_Open"
 msgstr " _Öffnen"
 
-#: ../gramps/gui/plug/_guioptions.py:1806
-#: ../gramps/gui/plug/report/_reportdialog.py:327
+#: ../gramps/gui/plug/_guioptions.py:1807
+#: ../gramps/gui/plug/report/_reportdialog.py:328
 msgid "Style Editor"
 msgstr "Stileditor"
 
@@ -16988,155 +17062,155 @@ msgstr "Neu laden"
 msgid "Refreshing Addon List"
 msgstr "Erweiterungsliste wird aktualisiert"
 
-#: ../gramps/gui/plug/_windows.py:309 ../gramps/gui/plug/_windows.py:314
-#: ../gramps/gui/plug/_windows.py:405
+#: ../gramps/gui/plug/_windows.py:310 ../gramps/gui/plug/_windows.py:315
+#: ../gramps/gui/plug/_windows.py:410
 msgid "Reading gramps-project.org..."
 msgstr "Lese gramps-project.org..."
 
-#: ../gramps/gui/plug/_windows.py:332
+#: ../gramps/gui/plug/_windows.py:333
 msgid "Checking addon..."
 msgstr "Überprüfe Erweiterung..."
 
-#: ../gramps/gui/plug/_windows.py:340
+#: ../gramps/gui/plug/_windows.py:341
 msgid "Unknown Help URL"
 msgstr "Unbekannte Hilfe URL"
 
-#: ../gramps/gui/plug/_windows.py:351
+#: ../gramps/gui/plug/_windows.py:352
 msgid "Unknown URL"
 msgstr "Unbekannte URL"
 
-#: ../gramps/gui/plug/_windows.py:386
+#: ../gramps/gui/plug/_windows.py:388
 msgid "Install all Addons"
 msgstr "Alle Erweiterungen installieren"
 
-#: ../gramps/gui/plug/_windows.py:386
+#: ../gramps/gui/plug/_windows.py:388
 msgid "Installing..."
 msgstr "Installiere..."
 
-#: ../gramps/gui/plug/_windows.py:404
+#: ../gramps/gui/plug/_windows.py:408
 msgid "Installing Addon"
 msgstr "Installiere Erweiterung"
 
-#: ../gramps/gui/plug/_windows.py:425
+#: ../gramps/gui/plug/_windows.py:430
 msgid "Load Addon"
 msgstr "Erweiterung laden"
 
-#: ../gramps/gui/plug/_windows.py:487
+#: ../gramps/gui/plug/_windows.py:492
 #: ../gramps/plugins/tool/dateparserdisplaytest.py:188
 msgid "Fail"
 msgstr "Fehler"
 
-#: ../gramps/gui/plug/_windows.py:502 ../gramps/gui/widgets/grampletbar.py:547
+#: ../gramps/gui/plug/_windows.py:507 ../gramps/gui/widgets/grampletbar.py:548
 msgid "OK"
 msgstr "OK"
 
-#: ../gramps/gui/plug/_windows.py:606
+#: ../gramps/gui/plug/_windows.py:611
 msgid "Plugin name"
 msgstr "Zusatzmodulname"
 
-#: ../gramps/gui/plug/_windows.py:608
+#: ../gramps/gui/plug/_windows.py:613
 msgid "Version"
 msgstr "Version"
 
-#: ../gramps/gui/plug/_windows.py:609
+#: ../gramps/gui/plug/_windows.py:614
 msgid "Authors"
 msgstr "Autoren"
 
 #. Save Frame
-#: ../gramps/gui/plug/_windows.py:611
-#: ../gramps/gui/plug/report/_reportdialog.py:468
+#: ../gramps/gui/plug/_windows.py:616
+#: ../gramps/gui/plug/report/_reportdialog.py:470
 msgid "Filename"
 msgstr "Dateiname"
 
-#: ../gramps/gui/plug/_windows.py:614
+#: ../gramps/gui/plug/_windows.py:619
 msgid "Detailed Info"
 msgstr "Detaillierte Information"
 
-#: ../gramps/gui/plug/_windows.py:671
+#: ../gramps/gui/plug/_windows.py:677
 msgid "Plugin Error"
 msgstr "Zusatzmodul Fehler"
 
-#: ../gramps/gui/plug/_windows.py:736
+#: ../gramps/gui/plug/_windows.py:742
 msgid "_Execute"
 msgstr "_Ausführen"
 
-#: ../gramps/gui/plug/_windows.py:1027
+#: ../gramps/gui/plug/_windows.py:1038
 #: ../gramps/plugins/tool/ownereditor.py:162
 msgid "Main window"
 msgstr "Hauptfenster"
 
-#: ../gramps/gui/plug/_windows.py:1094
+#: ../gramps/gui/plug/_windows.py:1105
 #, python-format
 msgid "%(adjective)s: %(addon)s"
 msgstr "%(adjective)s: %(addon)s"
 
-#: ../gramps/gui/plug/_windows.py:1155
+#: ../gramps/gui/plug/_windows.py:1166
 msgid "Downloading and installing selected addons..."
 msgstr "Herunterladen und installieren der gewählten Erweiterungen..."
 
-#: ../gramps/gui/plug/_windows.py:1190
+#: ../gramps/gui/plug/_windows.py:1201
 msgid "Installation Errors"
 msgstr "Installationsfehler"
 
-#: ../gramps/gui/plug/_windows.py:1191
+#: ../gramps/gui/plug/_windows.py:1202
 msgid "The following addons had errors: "
 msgstr "Die folgenden Erweiterungen hatten Fehler: "
 
-#: ../gramps/gui/plug/_windows.py:1195 ../gramps/gui/plug/_windows.py:1203
+#: ../gramps/gui/plug/_windows.py:1206 ../gramps/gui/plug/_windows.py:1214
 msgid "Done downloading and installing addons"
 msgstr "Herunterladen und Installation der Erweiterungen abgeschlossen"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/gui/plug/_windows.py:1197
+#: ../gramps/gui/plug/_windows.py:1208
 #, python-brace-format
 msgid "{number_of} addon was installed."
 msgid_plural "{number_of} addons were installed."
 msgstr[0] "{number_of} Zusatzmodul wurde installiert."
 msgstr[1] "{number_of} Zusatzmodule wurden installiert."
 
-#: ../gramps/gui/plug/_windows.py:1200
+#: ../gramps/gui/plug/_windows.py:1211
 msgid "You need to restart Gramps to see new views."
 msgstr "Um neue Ansichten zu sehen, muss Gramps neu gestartet werden."
 
-#: ../gramps/gui/plug/_windows.py:1204
+#: ../gramps/gui/plug/_windows.py:1215
 msgid "No addons were installed."
 msgstr "Es wurden keine Erweiterungen installiert."
 
 #. set up ManagedWindow
-#: ../gramps/gui/plug/export/_exportassistant.py:116
+#: ../gramps/gui/plug/export/_exportassistant.py:119
 msgid "Export Assistant"
 msgstr "Exportassistent"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:180
+#: ../gramps/gui/plug/export/_exportassistant.py:182
 msgid "Saving your data"
 msgstr "Ihre Daten speichern"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:226
+#: ../gramps/gui/plug/export/_exportassistant.py:228
 msgid "Choose the output format"
 msgstr "Ausgabeformat wählen"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:240
+#: ../gramps/gui/plug/export/_exportassistant.py:242
 msgid "Export options"
 msgstr "Exportoptionen"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:310
+#: ../gramps/gui/plug/export/_exportassistant.py:313
 msgid "Select save file"
 msgstr "Wähle Speicherdatei"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:354
+#: ../gramps/gui/plug/export/_exportassistant.py:357
 #: ../gramps/plugins/tool/mediamanager.py:103
 msgid "Final confirmation"
 msgstr "Endgültige Bestätigung"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:370
+#: ../gramps/gui/plug/export/_exportassistant.py:373
 msgid "Please wait while your data is selected and exported"
 msgstr "Bitte warten während deine Daten ausgewählt und exportiert werden"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:382
+#: ../gramps/gui/plug/export/_exportassistant.py:385
 msgid "Summary"
 msgstr "Zusammenfassung"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:449
+#: ../gramps/gui/plug/export/_exportassistant.py:453
 #, python-format
 msgid ""
 "The data will be exported as follows:\n"
@@ -17152,7 +17226,7 @@ msgstr ""
 "Klicke zum starten auf Anwenden, auf Zurück um deine Einstellungen zu "
 "überprüfen oder auf Abbrechen"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:462
+#: ../gramps/gui/plug/export/_exportassistant.py:466
 #, python-format
 msgid ""
 "The data will be saved as follows:\n"
@@ -17172,7 +17246,7 @@ msgstr ""
 "Klicke zum starten auf Anwenden, auf Zurück um deine Einstellungen zu "
 "überprüfen oder auf Abbrechen"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:472
+#: ../gramps/gui/plug/export/_exportassistant.py:476
 msgid ""
 "The selected file and folder to save to cannot be created or found.\n"
 "\n"
@@ -17183,11 +17257,11 @@ msgstr ""
 "\n"
 "Gehe zurück und wähle einen gültigen Dateinamen."
 
-#: ../gramps/gui/plug/export/_exportassistant.py:498
+#: ../gramps/gui/plug/export/_exportassistant.py:502
 msgid "Your data has been saved"
 msgstr "Deine Daten wurden gespeichert"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:500
+#: ../gramps/gui/plug/export/_exportassistant.py:504
 msgid ""
 "The copy of your data has been successfully saved. You may press Close "
 "button now to continue.\n"
@@ -17204,16 +17278,16 @@ msgstr ""
 "werden die gerade erstellte Kopie nicht verändern. "
 
 #. add test, what is dir
-#: ../gramps/gui/plug/export/_exportassistant.py:508
+#: ../gramps/gui/plug/export/_exportassistant.py:512
 #, python-format
 msgid "Filename: %s"
 msgstr "Dateiname: %s"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:510
+#: ../gramps/gui/plug/export/_exportassistant.py:514
 msgid "Saving failed"
 msgstr "Das Speichern ist gescheitert"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:512
+#: ../gramps/gui/plug/export/_exportassistant.py:516
 msgid ""
 "There was an error while saving your data. You may try starting the export "
 "again.\n"
@@ -17227,7 +17301,7 @@ msgstr ""
 "Anmerkung: Deine momentan geöffnete Datenbank ist sicher. Nur die Kopie "
 "deiner Daten konnte nicht gespeichert werden."
 
-#: ../gramps/gui/plug/export/_exportassistant.py:533
+#: ../gramps/gui/plug/export/_exportassistant.py:541
 msgid ""
 "Under normal circumstances, Gramps does not require you to directly save "
 "your changes. All changes you make are immediately saved to the database.\n"
@@ -17254,7 +17328,7 @@ msgstr ""
 "gefahrlos auf die Abbrechen Schaltfläche klicken und deine aktuelle "
 "Datenbank wird weiterhin intakt bleiben."
 
-#: ../gramps/gui/plug/export/_exportassistant.py:602
+#: ../gramps/gui/plug/export/_exportassistant.py:610
 msgid "Error exporting your Family Tree"
 msgstr "Fehler beim Exportieren ihres Stammbaum"
 
@@ -17262,148 +17336,152 @@ msgstr "Fehler beim Exportieren ihres Stammbaum"
 msgid "Selecting Preview Data"
 msgstr "Vorschau Daten auswählen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:67
-#: ../gramps/gui/plug/export/_exportoptions.py:70
+#: ../gramps/gui/plug/export/_exportoptions.py:68
+#: ../gramps/gui/plug/export/_exportoptions.py:71
 msgid "Selecting..."
 msgstr "Auswählen..."
 
-#: ../gramps/gui/plug/export/_exportoptions.py:159
+#: ../gramps/gui/plug/export/_exportoptions.py:161
 msgid "Unfiltered Family Tree:"
 msgstr "Ungefilterter Stammbaum:"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/gui/plug/export/_exportoptions.py:163
-#: ../gramps/gui/plug/export/_exportoptions.py:269
-#: ../gramps/gui/plug/export/_exportoptions.py:564
+#: ../gramps/gui/plug/export/_exportoptions.py:165
+#: ../gramps/gui/plug/export/_exportoptions.py:272
+#: ../gramps/gui/plug/export/_exportoptions.py:573
 #, python-brace-format
 msgid "{number_of} Person"
 msgid_plural "{number_of} People"
 msgstr[0] "{number_of} Person"
 msgstr[1] "{number_of} Personen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:166
+#: ../gramps/gui/plug/export/_exportoptions.py:168
 msgid "Click to see preview of unfiltered data"
 msgstr "Klicken zeigt dir die Vorschau der ungefilterten Daten."
 
-#: ../gramps/gui/plug/export/_exportoptions.py:178
+#: ../gramps/gui/plug/export/_exportoptions.py:180
 msgid "_Do not include records marked private"
 msgstr "Als vertraulich markierte _Datensätze ignorieren"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:193
-#: ../gramps/gui/plug/export/_exportoptions.py:379
+#: ../gramps/gui/plug/export/_exportoptions.py:195
+#: ../gramps/gui/plug/export/_exportoptions.py:388
 msgid "Change order"
 msgstr "Reihenfolge ändern"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:198
+#: ../gramps/gui/plug/export/_exportoptions.py:200
 msgid "Calculate Previews"
 msgstr "Vorschauen berechnen"
 
 #: ../gramps/gui/plug/export/_exportoptions.py:278
+msgid ":"
+msgstr ":"
+
+#: ../gramps/gui/plug/export/_exportoptions.py:282
 msgid "_Person Filter"
 msgstr "_Personenfilter"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:290
+#: ../gramps/gui/plug/export/_exportoptions.py:295
 msgid "Click to see preview after person filter"
 msgstr "Klicken zeigt dir die Vorschau nach dem Personenfilter."
 
-#: ../gramps/gui/plug/export/_exportoptions.py:295
+#: ../gramps/gui/plug/export/_exportoptions.py:300
 msgid "_Note Filter"
 msgstr "_Notizfilter"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:307
+#: ../gramps/gui/plug/export/_exportoptions.py:313
 msgid "Click to see preview after note filter"
 msgstr "Klicken zeigt dir die Vorschau nach dem Notizfilter."
 
 #. Frame 3:
-#: ../gramps/gui/plug/export/_exportoptions.py:310
+#: ../gramps/gui/plug/export/_exportoptions.py:316
 msgid "Privacy Filter"
 msgstr "Vertraulichkeitsfilter"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:316
+#: ../gramps/gui/plug/export/_exportoptions.py:323
 msgid "Click to see preview after privacy filter"
 msgstr "Klicken zeigt dir die Vorschau nach dem Vertraulichkeitsfilter."
 
 #. Frame 4:
-#: ../gramps/gui/plug/export/_exportoptions.py:319
+#: ../gramps/gui/plug/export/_exportoptions.py:326
 msgid "Living Filter"
 msgstr "Lebendfilter"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:326
+#: ../gramps/gui/plug/export/_exportoptions.py:334
 msgid "Click to see preview after living filter"
 msgstr "Klicken zeigt dir die Vorschau nach dem Lebendfilter."
 
-#: ../gramps/gui/plug/export/_exportoptions.py:330
+#: ../gramps/gui/plug/export/_exportoptions.py:338
 msgid "Reference Filter"
 msgstr "Referenzfilter"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:336
+#: ../gramps/gui/plug/export/_exportoptions.py:345
 msgid "Click to see preview after reference filter"
 msgstr "Klicken zeigt dir die Vorschau nach dem Referenzfilter."
 
-#: ../gramps/gui/plug/export/_exportoptions.py:386
+#: ../gramps/gui/plug/export/_exportoptions.py:395
 msgid "Hide order"
 msgstr "Reihenfolge verbergen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:579
+#: ../gramps/gui/plug/export/_exportoptions.py:588
 msgid "Filtering private data"
 msgstr "Filtere vertrauliche Daten"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:588
+#: ../gramps/gui/plug/export/_exportoptions.py:597
 msgid "Filtering living persons"
 msgstr "Filtere lebende Personen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:605
+#: ../gramps/gui/plug/export/_exportoptions.py:614
 msgid "Applying selected person filter"
 msgstr "Gewählten Personenfilter anwenden"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:615
+#: ../gramps/gui/plug/export/_exportoptions.py:624
 msgid "Applying selected note filter"
 msgstr "Gewählten Notizfilter anwenden"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:624
+#: ../gramps/gui/plug/export/_exportoptions.py:633
 msgid "Filtering referenced records"
 msgstr "Filtere referenzierte Datensätze"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:665
+#: ../gramps/gui/plug/export/_exportoptions.py:674
 msgid "Cannot edit a system filter"
 msgstr "Kann einen Systemfilter nicht bearbeiten"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:666
+#: ../gramps/gui/plug/export/_exportoptions.py:675
 msgid "Please select a different filter to edit"
 msgstr "Bitte einen anderen Filter zum bearbeiten wählen."
 
-#: ../gramps/gui/plug/export/_exportoptions.py:695
-#: ../gramps/gui/plug/export/_exportoptions.py:719
+#: ../gramps/gui/plug/export/_exportoptions.py:705
+#: ../gramps/gui/plug/export/_exportoptions.py:729
 msgid "Include all selected people"
 msgstr "Alle ausgewählten Personen einbeziehen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:709
+#: ../gramps/gui/plug/export/_exportoptions.py:719
 msgid "Include all selected notes"
 msgstr "Alle ausgewählten Notizen einbeziehen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:720
+#: ../gramps/gui/plug/export/_exportoptions.py:730
 msgid "Replace given names of living people"
 msgstr "Ersetze Vornamen von lebenden Personen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:721
+#: ../gramps/gui/plug/export/_exportoptions.py:731
 msgid "Replace complete name of living people"
 msgstr "Ersetze den kompletten Namen von lebenden Personen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:722
+#: ../gramps/gui/plug/export/_exportoptions.py:732
 msgid "Do not include living people"
 msgstr "Lebende Personen nicht aufnehmen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:731
+#: ../gramps/gui/plug/export/_exportoptions.py:741
 msgid "Include all selected records"
 msgstr "Alle gewählten Datensätze aufnehmen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:732
+#: ../gramps/gui/plug/export/_exportoptions.py:742
 msgid "Do not include records not linked to a selected person"
 msgstr ""
 "Datensätze nicht aufnehmen, die mit der gewählten Person nicht verknüpft "
 "sind."
 
-#: ../gramps/gui/plug/export/_exportoptions.py:753
+#: ../gramps/gui/plug/export/_exportoptions.py:763
 msgid "Use Compression"
 msgstr "Verwende Komprimierung"
 
@@ -17412,93 +17490,88 @@ msgid "Web Connect"
 msgstr "Webverbindung"
 
 #: ../gramps/gui/plug/quick/_quickreports.py:139
-#: ../gramps/gui/plug/quick/_textbufdoc.py:75
-#: ../gramps/gui/plug/quick/_textbufdoc.py:155
-#: ../gramps/gui/plug/quick/_textbufdoc.py:157
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:196
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:203
-#: ../gramps/plugins/lib/libpersonview.py:373
+#: ../gramps/gui/plug/quick/_textbufdoc.py:76
+#: ../gramps/gui/plug/quick/_textbufdoc.py:156
+#: ../gramps/gui/plug/quick/_textbufdoc.py:158
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:213
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:220
+#: ../gramps/plugins/lib/libpersonview.py:379
 #: ../gramps/plugins/lib/libplaceview.py:152
 #: ../gramps/plugins/view/citationlistview.py:182
-#: ../gramps/plugins/view/citationtreeview.py:290
+#: ../gramps/plugins/view/citationtreeview.py:292
 #: ../gramps/plugins/view/eventview.py:214
 #: ../gramps/plugins/view/familyview.py:209
-#: ../gramps/plugins/view/mediaview.py:218
+#: ../gramps/plugins/view/mediaview.py:219
 #: ../gramps/plugins/view/noteview.py:201
 #: ../gramps/plugins/view/repoview.py:153
 #: ../gramps/plugins/view/sourceview.py:138
 msgid "Quick View"
 msgstr "Schnellansicht"
 
-#: ../gramps/gui/plug/quick/_quicktable.py:121
+#: ../gramps/gui/plug/quick/_quicktable.py:134
 #: ../gramps/plugins/gramplet/descendant.py:113
 msgid "Copy all"
 msgstr "Alles kopieren"
 
-#: ../gramps/gui/plug/quick/_quicktable.py:152
+#: ../gramps/gui/plug/quick/_quicktable.py:161
 msgid "See data not in Filter"
 msgstr "Daten nicht im Filter ansehen"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:184
-#, python-format
-msgid "%(father)s and %(mother)s (%(id)s)"
-msgstr "%(father)s und %(mother)s (%(id)s)"
-
-#: ../gramps/gui/plug/report/_bookdialog.py:220
+#: ../gramps/gui/plug/report/_bookdialog.py:166
 msgid "Available Books"
 msgstr "Verfügbare Bücher"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:290
+#: ../gramps/gui/plug/report/_bookdialog.py:239
 msgid "Discard Unsaved Changes"
 msgstr "Ungesicherte Änderungen verwerfen"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:291
+#: ../gramps/gui/plug/report/_bookdialog.py:240
 msgid "You have made changes which have not been saved."
 msgstr "Deine Änderungen wurden noch nicht gespeichert."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:292
-#: ../gramps/gui/plug/report/_bookdialog.py:745
+#: ../gramps/gui/plug/report/_bookdialog.py:241
+#: ../gramps/gui/plug/report/_bookdialog.py:737
 msgid "Proceed"
 msgstr "Fortsetzen"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:349
+#: ../gramps/gui/plug/report/_bookdialog.py:300
 msgid "Name of the book. MANDATORY"
 msgstr "Name des Buches. Pflichtfeld!"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:371
+#: ../gramps/gui/plug/report/_bookdialog.py:322
 msgid "Manage Books"
 msgstr "Bücher verwalten"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:409
+#: ../gramps/gui/plug/report/_bookdialog.py:361
 msgid "New Book"
 msgstr "Neues Buch"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:412
+#: ../gramps/gui/plug/report/_bookdialog.py:364
 msgid "_Available items"
 msgstr "Verfügbare _Artikel"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:416
+#: ../gramps/gui/plug/report/_bookdialog.py:368
 msgid "Current _book"
 msgstr "Aktuelles _Buch"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:424
+#: ../gramps/gui/plug/report/_bookdialog.py:376
 #: ../gramps/plugins/drawreport/statisticschart.py:307
 msgid "Item name"
 msgstr "Artikelname"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:427
+#: ../gramps/gui/plug/report/_bookdialog.py:379
 msgid "Subject"
 msgstr "Betreff"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:439
+#: ../gramps/gui/plug/report/_bookdialog.py:393
 msgid "Book selection list"
 msgstr "Liste zur Auswahl eines Buches"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:493
+#: ../gramps/gui/plug/report/_bookdialog.py:445
 msgid "Different database"
 msgstr "Andere Datenbank"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:494
+#: ../gramps/gui/plug/report/_bookdialog.py:446
 #, python-format
 msgid ""
 "This book was created with the references to database %s.\n"
@@ -17517,49 +17590,43 @@ msgstr ""
 "Deswegen wurde die Hauptperson für jeden Artikel auf die aktive Person "
 "dieser geöffneten Datenbank gesetzt."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:596
+#: ../gramps/gui/plug/report/_bookdialog.py:552
 msgid "No selected book item"
 msgstr "Kein gewähltes Buchelement"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:597
+#: ../gramps/gui/plug/report/_bookdialog.py:553
 msgid "Please select a book item to configure."
 msgstr "Bitte ein Buchelement zum konfigurieren wählen."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:658
-#: ../gramps/gui/views/bookmarks.py:230 ../gramps/gui/views/tags.py:409
+#: ../gramps/gui/plug/report/_bookdialog.py:618
+#: ../gramps/gui/views/bookmarks.py:252 ../gramps/gui/views/tags.py:414
 msgid "_Up"
 msgstr "_Hoch"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:659
-#: ../gramps/gui/views/bookmarks.py:231 ../gramps/gui/views/tags.py:410
+#: ../gramps/gui/plug/report/_bookdialog.py:619
+#: ../gramps/gui/views/bookmarks.py:253 ../gramps/gui/views/tags.py:415
 msgid "_Down"
 msgstr "_Runter"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:660
+#: ../gramps/gui/plug/report/_bookdialog.py:620
 msgid "Setup"
 msgstr "Einrichten"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:670
-msgid "Book Menu"
-msgstr "Buchmenü"
-
-#: ../gramps/gui/plug/report/_bookdialog.py:698
-msgid "Available Items Menu"
-msgstr "Verfügbare Artikel Menü"
-
-#: ../gramps/gui/plug/report/_bookdialog.py:721
+#: ../gramps/gui/plug/report/_bookdialog.py:709
+#: ../gramps/gui/plug/report/_bookdialog.py:720
 msgid "No items"
 msgstr "Keine Elemente"
 
+#: ../gramps/gui/plug/report/_bookdialog.py:710
 #: ../gramps/gui/plug/report/_bookdialog.py:721
 msgid "This book has no items."
 msgstr "Dieses Buch besitzt keine Elemente."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:733
+#: ../gramps/gui/plug/report/_bookdialog.py:727
 msgid "No book name"
 msgstr "Kein Buchname"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:734
+#: ../gramps/gui/plug/report/_bookdialog.py:728
 msgid ""
 "You are about to save away a book with no name.\n"
 "\n"
@@ -17569,20 +17636,20 @@ msgstr ""
 "\n"
 "Bitte gib ihm vor dem Speichern einen Namen."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:741
+#: ../gramps/gui/plug/report/_bookdialog.py:734
 msgid "Book name already exists"
 msgstr "Buchname existiert bereits"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:742
+#: ../gramps/gui/plug/report/_bookdialog.py:735
 msgid "You are about to save away a book with a name which already exists."
 msgstr ""
 "Du bist dabei ein Buch mit einem bereits bestehenden Namen zu speichern."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:918
+#: ../gramps/gui/plug/report/_bookdialog.py:925
 msgid "Generate Book"
 msgstr "Buch erstellen"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:955
+#: ../gramps/gui/plug/report/_bookdialog.py:968
 msgid "Gramps Book"
 msgstr "Gramps Buch"
 
@@ -17621,14 +17688,14 @@ msgstr "Querformat"
 msgid "inch|in."
 msgstr "in."
 
-#: ../gramps/gui/plug/report/_reportdialog.py:141
+#: ../gramps/gui/plug/report/_reportdialog.py:142
 msgid "Configuration"
 msgstr "Konfiguration"
 
 #. Styles Frame
-#: ../gramps/gui/plug/report/_reportdialog.py:322
-#: ../gramps/gui/plug/report/_styleeditor.py:101
-#: ../gramps/gui/plug/report/_styleeditor.py:230
+#: ../gramps/gui/plug/report/_reportdialog.py:323
+#: ../gramps/gui/plug/report/_styleeditor.py:103
+#: ../gramps/gui/plug/report/_styleeditor.py:233
 msgid "Style"
 msgstr "Stil"
 
@@ -17643,54 +17710,56 @@ msgstr "Stil"
 #. menu.add_option(category_name, "Spouse_disp", Spouse_disp)
 #. #################
 #. #########################
+#. #################
 #. ###############################
 #. ---------------------
 #. ###############################
 #. Report Options
 #. #########################
 #. ###############################
-#: ../gramps/gui/plug/report/_reportdialog.py:364
-#: ../gramps/plugins/drawreport/ancestortree.py:827
-#: ../gramps/plugins/drawreport/calendarreport.py:464
-#: ../gramps/plugins/drawreport/fanchart.py:678
-#: ../gramps/plugins/drawreport/statisticschart.py:980
-#: ../gramps/plugins/drawreport/timeline.py:411
-#: ../gramps/plugins/graph/gvfamilylines.py:108
+#: ../gramps/gui/plug/report/_reportdialog.py:365
+#: ../gramps/plugins/drawreport/ancestortree.py:836
+#: ../gramps/plugins/drawreport/calendarreport.py:468
+#: ../gramps/plugins/drawreport/descendtree.py:1520
+#: ../gramps/plugins/drawreport/fanchart.py:686
+#: ../gramps/plugins/drawreport/statisticschart.py:984
+#: ../gramps/plugins/drawreport/timeline.py:415
+#: ../gramps/plugins/graph/gvfamilylines.py:110
 #: ../gramps/plugins/graph/gvhourglass.py:306
-#: ../gramps/plugins/graph/gvrelgraph.py:662
-#: ../gramps/plugins/textreport/alphabeticalindex.py:88
-#: ../gramps/plugins/textreport/ancestorreport.py:272
-#: ../gramps/plugins/textreport/birthdayreport.py:411
-#: ../gramps/plugins/textreport/descendreport.py:418
-#: ../gramps/plugins/textreport/detancestralreport.py:770
-#: ../gramps/plugins/textreport/detdescendantreport.py:922
-#: ../gramps/plugins/textreport/endoflinereport.py:260
-#: ../gramps/plugins/textreport/familygroup.py:700
-#: ../gramps/plugins/textreport/indivcomplete.py:986
-#: ../gramps/plugins/textreport/kinshipreport.py:346
-#: ../gramps/plugins/textreport/numberofancestorsreport.py:194
-#: ../gramps/plugins/textreport/placereport.py:414
-#: ../gramps/plugins/textreport/recordsreport.py:211
-#: ../gramps/plugins/textreport/simplebooktitle.py:130
-#: ../gramps/plugins/textreport/summary.py:283
-#: ../gramps/plugins/textreport/tableofcontents.py:87
-#: ../gramps/plugins/textreport/tagreport.py:890
-#: ../gramps/plugins/webreport/narrativeweb.py:9342
-#: ../gramps/plugins/webreport/webcal.py:1591
+#: ../gramps/plugins/graph/gvrelgraph.py:665
+#: ../gramps/plugins/textreport/alphabeticalindex.py:93
+#: ../gramps/plugins/textreport/ancestorreport.py:281
+#: ../gramps/plugins/textreport/birthdayreport.py:415
+#: ../gramps/plugins/textreport/descendreport.py:504
+#: ../gramps/plugins/textreport/detancestralreport.py:779
+#: ../gramps/plugins/textreport/detdescendantreport.py:975
+#: ../gramps/plugins/textreport/endoflinereport.py:269
+#: ../gramps/plugins/textreport/familygroup.py:704
+#: ../gramps/plugins/textreport/indivcomplete.py:1032
+#: ../gramps/plugins/textreport/kinshipreport.py:355
+#: ../gramps/plugins/textreport/numberofancestorsreport.py:203
+#: ../gramps/plugins/textreport/placereport.py:432
+#: ../gramps/plugins/textreport/recordsreport.py:216
+#: ../gramps/plugins/textreport/simplebooktitle.py:134
+#: ../gramps/plugins/textreport/summary.py:287
+#: ../gramps/plugins/textreport/tableofcontents.py:92
+#: ../gramps/plugins/textreport/tagreport.py:894
+#: ../gramps/plugins/webreport/narrativeweb.py:9621
+#: ../gramps/plugins/webreport/webcal.py:1609
 msgid "Report Options"
 msgstr "Berichtsoptionen"
 
 #. need any labels at top:
-#: ../gramps/gui/plug/report/_reportdialog.py:453
+#: ../gramps/gui/plug/report/_reportdialog.py:455
 msgid "Document Options"
 msgstr "Dokumentoptionen"
 
-#: ../gramps/gui/plug/report/_reportdialog.py:499
-#: ../gramps/gui/plug/report/_reportdialog.py:526
+#: ../gramps/gui/plug/report/_reportdialog.py:501
+#: ../gramps/gui/plug/report/_reportdialog.py:528
 msgid "Permission problem"
 msgstr "Berechtigungsproblem"
 
-#: ../gramps/gui/plug/report/_reportdialog.py:500
+#: ../gramps/gui/plug/report/_reportdialog.py:502
 #, python-format
 msgid ""
 "You do not have permission to write under the directory %s\n"
@@ -17701,26 +17770,26 @@ msgstr ""
 "\n"
 "Bitte wähle ein anderes Verzeichnis oder korrigiere die Berechtigungen."
 
-#: ../gramps/gui/plug/report/_reportdialog.py:509
+#: ../gramps/gui/plug/report/_reportdialog.py:511
 msgid "File already exists"
 msgstr "Datei existiert bereits"
 
-#: ../gramps/gui/plug/report/_reportdialog.py:510
+#: ../gramps/gui/plug/report/_reportdialog.py:512
 msgid ""
 "You can choose to either overwrite the file, or change the selected filename."
 msgstr ""
 "Du kannst entscheiden, ob die Datei überschrieben wird oder den gewählten "
 "Dateinamen ändern."
 
-#: ../gramps/gui/plug/report/_reportdialog.py:512
+#: ../gramps/gui/plug/report/_reportdialog.py:514
 msgid "_Overwrite"
 msgstr "_Überschreiben"
 
-#: ../gramps/gui/plug/report/_reportdialog.py:513
+#: ../gramps/gui/plug/report/_reportdialog.py:515
 msgid "_Change filename"
 msgstr "_Dateinamen ändern"
 
-#: ../gramps/gui/plug/report/_reportdialog.py:527
+#: ../gramps/gui/plug/report/_reportdialog.py:529
 #, python-format
 msgid ""
 "You do not have permission to create %s\n"
@@ -17731,13 +17800,13 @@ msgstr ""
 "\n"
 "Bitte wähle ein anderes Verzeichnis oder korrigiere die Berechtigungen."
 
-#: ../gramps/gui/plug/report/_reportdialog.py:534
-#: ../gramps/plugins/export/exportxml.py:143
+#: ../gramps/gui/plug/report/_reportdialog.py:536
+#: ../gramps/plugins/export/exportxml.py:146
 msgid "No directory"
 msgstr "Kein Verzeichnis"
 
-#: ../gramps/gui/plug/report/_reportdialog.py:535
-#: ../gramps/plugins/export/exportxml.py:144
+#: ../gramps/gui/plug/report/_reportdialog.py:537
+#: ../gramps/plugins/export/exportxml.py:147
 #, python-format
 msgid ""
 "There is no directory %s.\n"
@@ -17748,53 +17817,53 @@ msgstr ""
 "\n"
 "Bitte wähle ein anderes Verzeichnis oder erstelle es."
 
-#: ../gramps/gui/plug/report/_reportdialog.py:661
-#: ../gramps/gui/plug/tool.py:136 ../gramps/plugins/tool/relcalc.py:149
+#: ../gramps/gui/plug/report/_reportdialog.py:663
+#: ../gramps/gui/plug/tool.py:135 ../gramps/plugins/tool/relcalc.py:150
 msgid "Active person has not been set"
 msgstr "Keine Person ausgewählt"
 
-#: ../gramps/gui/plug/report/_reportdialog.py:662
+#: ../gramps/gui/plug/report/_reportdialog.py:664
 msgid "You must select an active person for this report to work properly."
 msgstr "Du musst eine aktive Person wählen, um einen Bericht zu erstellen."
 
-#: ../gramps/gui/plug/report/_reportdialog.py:714
-#: ../gramps/gui/plug/report/_reportdialog.py:720
+#: ../gramps/gui/plug/report/_reportdialog.py:716
+#: ../gramps/gui/plug/report/_reportdialog.py:723
 msgid "Report could not be created"
 msgstr "Der Bericht konnte nicht erzeugt werden"
 
 #: ../gramps/gui/plug/report/_stylecombobox.py:66
 #: ../gramps/gui/plug/report/_stylecombobox.py:85
-#: ../gramps/gui/plug/report/_styleeditor.py:115
-#: ../gramps/gui/plug/report/_styleeditor.py:157
-#: ../gramps/gui/plug/report/_styleeditor.py:168
+#: ../gramps/gui/plug/report/_styleeditor.py:117
+#: ../gramps/gui/plug/report/_styleeditor.py:160
+#: ../gramps/gui/plug/report/_styleeditor.py:171
 #: ../gramps/plugins/importer/importgedcom.glade:11 gtklist.h:1
 msgid "default"
 msgstr "Standardwert"
 
-#: ../gramps/gui/plug/report/_styleeditor.py:88
+#: ../gramps/gui/plug/report/_styleeditor.py:90
 msgid "Document Styles"
 msgstr "Dokumentenstile"
 
-#: ../gramps/gui/plug/report/_styleeditor.py:128
+#: ../gramps/gui/plug/report/_styleeditor.py:130
 msgid "New Style"
 msgstr "Neuer Stil"
 
-#: ../gramps/gui/plug/report/_styleeditor.py:139
+#: ../gramps/gui/plug/report/_styleeditor.py:141
 msgid "Error saving stylesheet"
 msgstr "Fehler beim Speichern der Formatvorlage"
 
-#: ../gramps/gui/plug/report/_styleeditor.py:227
+#: ../gramps/gui/plug/report/_styleeditor.py:230
 msgid "Style editor"
 msgstr "Stileditor"
 
-#: ../gramps/gui/plug/report/_styleeditor.py:305
-#: ../gramps/gui/plug/report/_styleeditor.py:326
-#: ../gramps/gui/plug/report/_styleeditor.py:342
-#: ../gramps/gui/plug/report/_styleeditor.py:375
+#: ../gramps/gui/plug/report/_styleeditor.py:308
+#: ../gramps/gui/plug/report/_styleeditor.py:329
+#: ../gramps/gui/plug/report/_styleeditor.py:345
+#: ../gramps/gui/plug/report/_styleeditor.py:378
 msgid "No description available"
 msgstr "Keine Beschreibung verfügbar"
 
-#: ../gramps/gui/plug/report/_styleeditor.py:352
+#: ../gramps/gui/plug/report/_styleeditor.py:355
 #, python-format
 msgid "Column %d:"
 msgstr "Spalte %d:"
@@ -17843,7 +17912,7 @@ msgstr ""
 msgid "_Proceed with the tool"
 msgstr "_Mit dem Werkzeug fortfahren"
 
-#: ../gramps/gui/plug/tool.py:137 ../gramps/plugins/tool/relcalc.py:150
+#: ../gramps/gui/plug/tool.py:136 ../gramps/plugins/tool/relcalc.py:151
 msgid "You must select an active person for this tool to work properly."
 msgstr ""
 "Du musst eine aktive Person für dieses Werkzeug wählen, um weiter arbeiten "
@@ -17853,24 +17922,24 @@ msgstr ""
 msgid "manual|Select_Source_or_Citation_selector"
 msgstr "Quelle_oder_Fundstelle_wählen_Auswahl"
 
-#: ../gramps/gui/selectors/selectcitation.py:68
+#: ../gramps/gui/selectors/selectcitation.py:67
 msgid "Select Source or Citation"
 msgstr "Quelle oder Fundstelle wählen"
 
-#: ../gramps/gui/selectors/selectcitation.py:75
+#: ../gramps/gui/selectors/selectcitation.py:74
 #: ../gramps/plugins/view/citationtreeview.py:93
 msgid "Source: Title or Citation: Volume/Page"
 msgstr "Quelle: Titel  oder Fundstelle: Band/Seite"
 
-#: ../gramps/gui/selectors/selectcitation.py:77
-#: ../gramps/gui/selectors/selectevent.py:76
-#: ../gramps/gui/selectors/selectfamily.py:73
-#: ../gramps/gui/selectors/selectnote.py:79
+#: ../gramps/gui/selectors/selectcitation.py:76
+#: ../gramps/gui/selectors/selectevent.py:75
+#: ../gramps/gui/selectors/selectfamily.py:72
+#: ../gramps/gui/selectors/selectnote.py:78
 #: ../gramps/gui/selectors/selectobject.py:83
-#: ../gramps/gui/selectors/selectperson.py:102
-#: ../gramps/gui/selectors/selectplace.py:75
-#: ../gramps/gui/selectors/selectrepository.py:72
-#: ../gramps/gui/selectors/selectsource.py:73
+#: ../gramps/gui/selectors/selectperson.py:101
+#: ../gramps/gui/selectors/selectplace.py:74
+#: ../gramps/gui/selectors/selectrepository.py:71
+#: ../gramps/gui/selectors/selectsource.py:72
 msgid "Last Change"
 msgstr "Letzte Änderung"
 
@@ -17878,7 +17947,7 @@ msgstr "Letzte Änderung"
 msgid "manual|Select_Event_selector"
 msgstr "Ereignis_wählen_Auswahl"
 
-#: ../gramps/gui/selectors/selectevent.py:63
+#: ../gramps/gui/selectors/selectevent.py:62
 msgid "Select Event"
 msgstr "Ereignis wählen"
 
@@ -17886,15 +17955,11 @@ msgstr "Ereignis wählen"
 msgid "manual|Select_Family_selector"
 msgstr "Familie_wählen_Auswahl"
 
-#: ../gramps/gui/selectors/selectfamily.py:63
-msgid "Select Family"
-msgstr "Familie wählen"
-
 #: ../gramps/gui/selectors/selectnote.py:49
 msgid "manual|Select_Note_selector"
 msgstr "Notiz_wählen_Ausahl"
 
-#: ../gramps/gui/selectors/selectnote.py:68
+#: ../gramps/gui/selectors/selectnote.py:67
 msgid "Select Note"
 msgstr "Notiz wählen"
 
@@ -17922,7 +17987,7 @@ msgstr "Mutter_wählen_Auswahl"
 msgid "manual|Select_Place_selector"
 msgstr "Ort_wählen_Auswahl"
 
-#: ../gramps/gui/selectors/selectplace.py:64
+#: ../gramps/gui/selectors/selectplace.py:63
 msgid "Select Place"
 msgstr "Ort wählen"
 
@@ -17930,7 +17995,7 @@ msgstr "Ort wählen"
 msgid "manual|Repositories"
 msgstr "Aufbewahrungsorte"
 
-#: ../gramps/gui/selectors/selectrepository.py:63
+#: ../gramps/gui/selectors/selectrepository.py:62
 msgid "Select Repository"
 msgstr "Aufbewahrungsort wählen"
 
@@ -17944,7 +18009,7 @@ msgstr "Aufbewahrungsort wählen"
 msgid "manual|xxxx"
 msgstr "xxxx"
 
-#: ../gramps/gui/selectors/selectsource.py:63
+#: ../gramps/gui/selectors/selectsource.py:62
 msgid "Select Source"
 msgstr "Quelle wählen"
 
@@ -17964,21 +18029,21 @@ msgstr ""
 "Du hast keine Wörterbücher installiert. Entweder installiere eines oder "
 "deaktiviere die Rechtschreibprüfung."
 
-#: ../gramps/gui/spell.py:151
+#: ../gramps/gui/spell.py:153
 #, python-format
 msgid "Spelling checker initialization failed: %s"
 msgstr "Die Einrichtung der Rechtschreibprüfung ist fehlgeschlagen: %s"
 
 #: ../gramps/gui/tipofday.py:67 ../gramps/gui/tipofday.py:68
-#: ../gramps/gui/tipofday.py:119 ../gramps/gui/viewmanager.py:496
+#: ../gramps/gui/tipofday.py:121 ../gramps/gui/viewmanager.py:505
 msgid "Tip of the Day"
 msgstr "Tipp des Tages"
 
-#: ../gramps/gui/tipofday.py:86
+#: ../gramps/gui/tipofday.py:87
 msgid "Failed to display tip of the day"
 msgstr "Den Tipp des Tages anzuzeigen ist fehlgeschlagen."
 
-#: ../gramps/gui/tipofday.py:87
+#: ../gramps/gui/tipofday.py:88
 #, python-format
 msgid ""
 "Unable to read the tips from external file.\n"
@@ -17997,13 +18062,13 @@ msgstr "11"
 msgid "Undo History"
 msgstr "Bearbeitungschronik"
 
-#: ../gramps/gui/undohistory.py:84 ../gramps/gui/viewmanager.py:572
-#: ../gramps/gui/viewmanager.py:1165
+#: ../gramps/gui/undohistory.py:84 ../gramps/gui/viewmanager.py:593
+#: ../gramps/gui/viewmanager.py:1237
 msgid "_Undo"
 msgstr "_Rückgängig"
 
-#: ../gramps/gui/undohistory.py:86 ../gramps/gui/viewmanager.py:577
-#: ../gramps/gui/viewmanager.py:1182
+#: ../gramps/gui/undohistory.py:86 ../gramps/gui/viewmanager.py:598
+#: ../gramps/gui/viewmanager.py:1254
 msgid "_Redo"
 msgstr "_Wiederherstellen"
 
@@ -18058,7 +18123,13 @@ msgstr ""
 msgid "Error from external program"
 msgstr "Fehler aus externem Programm"
 
-#: ../gramps/gui/utils.py:576
+#: ../gramps/gui/utils.py:416
+#: ../gramps/plugins/textreport/simplebooktitle.py:107
+#, python-format
+msgid "File %s does not exist"
+msgstr "Datei %s existiert nicht"
+
+#: ../gramps/gui/utils.py:579
 msgid ""
 "Cannot open new citation editor at this time. Either the citation is already "
 "being edited, or the associated source is already being edited, and opening "
@@ -18076,190 +18147,193 @@ msgstr ""
 "Um die Fundstelle zu bearbeiten, schließe den Quelleneditor und öffne nur "
 "den Fundstelleneditor."
 
-#: ../gramps/gui/utils.py:589
+#: ../gramps/gui/utils.py:592
 msgid "Cannot open new citation editor"
 msgstr "Der neue Fundstelleneditor kann nicht geöffnet werden."
 
-#: ../gramps/gui/viewmanager.py:450
+#: ../gramps/gui/viewmanager.py:437 ../gramps/gui/viewmanager.py:1211
+msgid "No Family Tree"
+msgstr "Kein Stammbaum"
+
+#: ../gramps/gui/viewmanager.py:459
 msgid "Connect to a recent database"
 msgstr "Mit neuer Datenbank verbinden"
 
-#: ../gramps/gui/viewmanager.py:468
+#: ../gramps/gui/viewmanager.py:477
 msgid "_Family Trees"
 msgstr "_Stammbäume"
 
-#: ../gramps/gui/viewmanager.py:469
+#: ../gramps/gui/viewmanager.py:478
 msgid "_Manage Family Trees..."
 msgstr "Stammbäume _verwalten..."
 
-#: ../gramps/gui/viewmanager.py:470
+#: ../gramps/gui/viewmanager.py:479
 msgid "Manage databases"
 msgstr "Datenbanken verwalten"
 
-#: ../gramps/gui/viewmanager.py:471
+#: ../gramps/gui/viewmanager.py:480
 msgid "Open _Recent"
 msgstr "_Zuletzt geöffnet"
 
-#: ../gramps/gui/viewmanager.py:472
+#: ../gramps/gui/viewmanager.py:481
 msgid "Open an existing database"
 msgstr "Eine existierende Datenbank öffnen"
 
-#: ../gramps/gui/viewmanager.py:473
+#: ../gramps/gui/viewmanager.py:482
 msgid "_Quit"
 msgstr "_Beenden"
 
-#: ../gramps/gui/viewmanager.py:475
+#: ../gramps/gui/viewmanager.py:484
 msgid "_View"
 msgstr "_Ansicht"
 
-#: ../gramps/gui/viewmanager.py:477
+#: ../gramps/gui/viewmanager.py:486
 msgid "_Preferences..."
 msgstr "_Einstellungen..."
 
-#: ../gramps/gui/viewmanager.py:480
+#: ../gramps/gui/viewmanager.py:489
 msgid "Gramps _Home Page"
 msgstr "Gramps _Homepage"
 
-#: ../gramps/gui/viewmanager.py:482
+#: ../gramps/gui/viewmanager.py:491
 msgid "Gramps _Mailing Lists"
 msgstr "Gramps _Mailinglisten"
 
-#: ../gramps/gui/viewmanager.py:484
+#: ../gramps/gui/viewmanager.py:493
 msgid "_Report a Bug"
 msgstr "_Programmfehler melden"
 
-#: ../gramps/gui/viewmanager.py:486
+#: ../gramps/gui/viewmanager.py:495
 msgid "_Extra Reports/Tools"
 msgstr "_Weitere Berichte/Werkzeuge"
 
-#: ../gramps/gui/viewmanager.py:488
+#: ../gramps/gui/viewmanager.py:497
 msgid "_About"
 msgstr "_Info"
 
-#: ../gramps/gui/viewmanager.py:490
+#: ../gramps/gui/viewmanager.py:499
 msgid "_Plugin Manager"
 msgstr "_Zusatzmodulverwaltung"
 
-#: ../gramps/gui/viewmanager.py:492
+#: ../gramps/gui/viewmanager.py:501
 msgid "_FAQ"
 msgstr "Häufig gestellte _Fragen"
 
-#: ../gramps/gui/viewmanager.py:493
+#: ../gramps/gui/viewmanager.py:502
 msgid "_Key Bindings"
 msgstr "Tastatur_kürzel"
 
-#: ../gramps/gui/viewmanager.py:494
+#: ../gramps/gui/viewmanager.py:503
 msgid "_User Manual"
 msgstr "_Benutzerhandbuch"
 
-#: ../gramps/gui/viewmanager.py:501
+#: ../gramps/gui/viewmanager.py:511
+msgid "Close the current database"
+msgstr "Schließe die aktuelle Datenbank"
+
+#: ../gramps/gui/viewmanager.py:512
 msgid "_Export..."
 msgstr "_Export..."
 
-#: ../gramps/gui/viewmanager.py:503
+#: ../gramps/gui/viewmanager.py:514
 msgid "Make Backup..."
 msgstr "Erstelle Sicherung..."
 
-#: ../gramps/gui/viewmanager.py:504
+#: ../gramps/gui/viewmanager.py:515
 msgid "Make a Gramps XML backup of the database"
 msgstr "Gramps XML Sicherung der Datenbank erstellen"
 
-#: ../gramps/gui/viewmanager.py:506
+#: ../gramps/gui/viewmanager.py:517
 msgid "_Abandon Changes and Quit"
 msgstr "Änderungen _Verwerfen und Beenden"
 
-#: ../gramps/gui/viewmanager.py:507 ../gramps/gui/viewmanager.py:510
+#: ../gramps/gui/viewmanager.py:518 ../gramps/gui/viewmanager.py:521
 msgid "_Reports"
 msgstr "Be_richte"
 
-#: ../gramps/gui/viewmanager.py:508
+#: ../gramps/gui/viewmanager.py:519
 msgid "Open the reports dialog"
 msgstr "Öffnet den Berichtsdialog"
 
-#: ../gramps/gui/viewmanager.py:509
+#: ../gramps/gui/viewmanager.py:520
 msgid "_Go"
 msgstr "_Gehe zu"
 
-#: ../gramps/gui/viewmanager.py:511
+#: ../gramps/gui/viewmanager.py:522
 msgid "Books..."
 msgstr "Bücher..."
 
-#: ../gramps/gui/viewmanager.py:512
+#: ../gramps/gui/viewmanager.py:523
 msgid "_Windows"
 msgstr "_Fenster"
 
-#: ../gramps/gui/viewmanager.py:549
+#: ../gramps/gui/viewmanager.py:570
 msgid "Clip_board"
 msgstr "Zwischena_blage"
 
-#: ../gramps/gui/viewmanager.py:550
+#: ../gramps/gui/viewmanager.py:571
 msgid "Open the Clipboard dialog"
 msgstr "Öffnet den Zwischenablagedialog"
 
-#: ../gramps/gui/viewmanager.py:551
+#: ../gramps/gui/viewmanager.py:572
 msgid "_Import..."
 msgstr "_Import..."
 
-#: ../gramps/gui/viewmanager.py:553 ../gramps/gui/viewmanager.py:556
+#: ../gramps/gui/viewmanager.py:574 ../gramps/gui/viewmanager.py:577
 msgid "_Tools"
 msgstr "_Werkzeuge"
 
-#: ../gramps/gui/viewmanager.py:554
+#: ../gramps/gui/viewmanager.py:575
 msgid "Open the tools dialog"
 msgstr "Öffnet den Werkzeugdialog"
 
-#: ../gramps/gui/viewmanager.py:555
+#: ../gramps/gui/viewmanager.py:576
 msgid "_Bookmarks"
 msgstr "_Lesezeichen"
 
-#: ../gramps/gui/viewmanager.py:557
+#: ../gramps/gui/viewmanager.py:578
 msgid "_Configure..."
 msgstr "_Konfigurieren..."
 
-#: ../gramps/gui/viewmanager.py:558
+#: ../gramps/gui/viewmanager.py:579
 msgid "Configure the active view"
 msgstr "Die aktive Ansicht konfigurieren"
 
-#: ../gramps/gui/viewmanager.py:563
+#: ../gramps/gui/viewmanager.py:584
 msgid "_Navigator"
 msgstr "_Navigator"
 
-#: ../gramps/gui/viewmanager.py:565
+#: ../gramps/gui/viewmanager.py:586
 msgid "_Toolbar"
 msgstr "_Werkzeugleiste"
 
-#: ../gramps/gui/viewmanager.py:567
+#: ../gramps/gui/viewmanager.py:588
 msgid "F_ull Screen"
 msgstr "Vollbild"
 
-#: ../gramps/gui/viewmanager.py:583
+#: ../gramps/gui/viewmanager.py:604
 msgid "Undo History..."
 msgstr "Bearbeitungschronik..."
 
-#: ../gramps/gui/viewmanager.py:606
+#: ../gramps/gui/viewmanager.py:627
 #, python-format
 msgid "Key %s is not bound"
 msgstr "Schlüssel %s ist nicht eingebunden"
 
-#. load plugins
-#: ../gramps/gui/viewmanager.py:707
-msgid "Loading plugins..."
-msgstr "Lade Zusatzmodule..."
-
-#: ../gramps/gui/viewmanager.py:714 ../gramps/gui/viewmanager.py:729
-msgid "Ready"
-msgstr "Bereit"
-
 #. registering plugins
-#: ../gramps/gui/viewmanager.py:722
+#: ../gramps/gui/viewmanager.py:734
 msgid "Registering plugins..."
 msgstr "Zusatzmodule registrieren..."
 
-#: ../gramps/gui/viewmanager.py:758
+#: ../gramps/gui/viewmanager.py:741
+msgid "Ready"
+msgstr "Bereit"
+
+#: ../gramps/gui/viewmanager.py:786
 msgid "Abort changes?"
 msgstr "Änderungen verwerfen?"
 
-#: ../gramps/gui/viewmanager.py:759
+#: ../gramps/gui/viewmanager.py:787
 msgid ""
 "Aborting changes will return the database to the state it was before you "
 "started this editing session."
@@ -18267,15 +18341,15 @@ msgstr ""
 "Änderungen verwerfen bringt die Datenbank in den Stand vor Beginn dieser "
 "Bearbeitungssitzung zurück."
 
-#: ../gramps/gui/viewmanager.py:761
+#: ../gramps/gui/viewmanager.py:789
 msgid "Abort changes"
 msgstr "Änderungen verwerfen"
 
-#: ../gramps/gui/viewmanager.py:772
+#: ../gramps/gui/viewmanager.py:800
 msgid "Cannot abandon session's changes"
 msgstr "Die Sitzungsänderungen können nicht zurück genommen werden."
 
-#: ../gramps/gui/viewmanager.py:773
+#: ../gramps/gui/viewmanager.py:801
 msgid ""
 "Changes cannot be completely abandoned because the number of changes made in "
 "the session exceeded the limit."
@@ -18283,28 +18357,28 @@ msgstr ""
 "Die Änderungen können nicht vollständig zurück genommen werden, da die "
 "Anzahl der Änderungen das Limit der Sitzung überschritten hat."
 
-#: ../gramps/gui/viewmanager.py:929
+#: ../gramps/gui/viewmanager.py:962
 msgid "View failed to load. Check error output."
 msgstr "Ansicht konnte nicht geladen werden. Fehlerbericht kontrollieren."
 
-#: ../gramps/gui/viewmanager.py:1068
+#: ../gramps/gui/viewmanager.py:1114
 msgid "Import Statistics"
 msgstr "Importstatistiken"
 
-#: ../gramps/gui/viewmanager.py:1134
+#: ../gramps/gui/viewmanager.py:1181
 msgid "Read Only"
 msgstr "Nur lesen"
 
-#: ../gramps/gui/viewmanager.py:1216
+#: ../gramps/gui/viewmanager.py:1288
 msgid "Gramps XML Backup"
 msgstr "Gramps XML Sicherung"
 
-#: ../gramps/gui/viewmanager.py:1246
+#: ../gramps/gui/viewmanager.py:1319
 #: ../gramps/plugins/importer/importgedcom.glade:289
 msgid "File:"
 msgstr "Datei:"
 
-#: ../gramps/gui/viewmanager.py:1278
+#: ../gramps/gui/viewmanager.py:1351
 msgid "Media:"
 msgstr "Medium:"
 
@@ -18312,68 +18386,101 @@ msgstr "Medium:"
 #. --------------------
 #. ###############################
 #. What to include
-#. #########################
 #. ###############################
-#: ../gramps/gui/viewmanager.py:1284
-#: ../gramps/plugins/drawreport/ancestortree.py:953
-#: ../gramps/plugins/drawreport/descendtree.py:1653
-#: ../gramps/plugins/graph/gvfamilylines.py:187
-#: ../gramps/plugins/graph/gvrelgraph.py:689
-#: ../gramps/plugins/textreport/detancestralreport.py:843
-#: ../gramps/plugins/textreport/detdescendantreport.py:999
-#: ../gramps/plugins/textreport/familygroup.py:732
-#: ../gramps/plugins/textreport/indivcomplete.py:1021
+#: ../gramps/gui/viewmanager.py:1357
+#: ../gramps/plugins/drawreport/ancestortree.py:962
+#: ../gramps/plugins/drawreport/descendtree.py:1671
+#: ../gramps/plugins/graph/gvfamilylines.py:189
+#: ../gramps/plugins/graph/gvrelgraph.py:692
+#: ../gramps/plugins/textreport/detancestralreport.py:852
+#: ../gramps/plugins/textreport/detdescendantreport.py:1061
+#: ../gramps/plugins/textreport/detdescendantreport.py:1085
+#: ../gramps/plugins/textreport/indivcomplete.py:1067
 msgid "Include"
 msgstr "Einbeziehen"
 
-#: ../gramps/gui/viewmanager.py:1285
-#: ../gramps/plugins/gramplet/statsgramplet.py:137
+#: ../gramps/gui/viewmanager.py:1358
+#: ../gramps/plugins/gramplet/statsgramplet.py:139
+#: ../gramps/plugins/webreport/narrativeweb.py:8119
 msgid "Megabyte|MB"
 msgstr "MB"
 
-#: ../gramps/gui/viewmanager.py:1286
+#: ../gramps/gui/viewmanager.py:1360
 msgid "Exclude"
 msgstr "Ausschließen"
 
-#: ../gramps/gui/viewmanager.py:1301
+#: ../gramps/gui/viewmanager.py:1381
 msgid "Backup file already exists! Overwrite?"
 msgstr "Sicherungsdatei existiert bereits! Überschreiben?"
 
-#: ../gramps/gui/viewmanager.py:1302
+#: ../gramps/gui/viewmanager.py:1382
 #, python-format
 msgid "The file '%s' exists."
 msgstr "Die Datei '%s' existiert."
 
-#: ../gramps/gui/viewmanager.py:1303
+#: ../gramps/gui/viewmanager.py:1383
 msgid "Proceed and overwrite"
 msgstr "Fortsetzen und überschreiben"
 
-#: ../gramps/gui/viewmanager.py:1304
+#: ../gramps/gui/viewmanager.py:1384
 msgid "Cancel the backup"
 msgstr "Sicherung abbrechen"
 
-#: ../gramps/gui/viewmanager.py:1312
+#: ../gramps/gui/viewmanager.py:1392
 msgid "Making backup..."
 msgstr "Erstelle Sicherung..."
 
-#: ../gramps/gui/viewmanager.py:1324
+#: ../gramps/gui/viewmanager.py:1405
 #, python-format
 msgid "Backup saved to '%s'"
 msgstr "Sicherung gespeichert in '%s'"
 
-#: ../gramps/gui/viewmanager.py:1327
+#: ../gramps/gui/viewmanager.py:1408
 msgid "Backup aborted"
 msgstr "Sicherung abgebrochen"
 
-#: ../gramps/gui/viewmanager.py:1336
-msgid "Select backup directory"
-msgstr "Sicherungsverzeichnis wählen"
+#: ../gramps/gui/viewmanager.py:1418
+msgid "Autobackup..."
+msgstr "Automatisches Backup..."
 
-#: ../gramps/gui/viewmanager.py:1600
+#: ../gramps/gui/viewmanager.py:1423
+msgid "Error saving backup data"
+msgstr "Fehler beim speichern der Sicherungsdaten."
+
+#: ../gramps/gui/viewmanager.py:1673
+msgid "Failed Loading View"
+msgstr "Laden der Ansicht fehlgeschlagen"
+
+#: ../gramps/gui/viewmanager.py:1674
+#, python-format
+msgid ""
+"The view %(name)s did not load and reported an error.\n"
+"\n"
+"%(error_msg)s\n"
+"\n"
+"If you are unable to fix the fault yourself then you can submit a bug at "
+"%(gramps_bugtracker_url)s or contact the view author "
+"(%(firstauthoremail)s).\n"
+"\n"
+"If you do not want Gramps to try and load this view again, you can hide it "
+"by using the Plugin Manager on the Help menu."
+msgstr ""
+"Die Ansicht  %(name)s wurde nicht geladen und meldete einen Fehler.\n"
+"\n"
+"%(error_msg)s\n"
+"\n"
+"Wenn du den Fehler nicht alleine beheben kannst, erstelle einen "
+"Fehlerbericht über %(gramps_bugtracker_url)s oder kontaktiere den "
+"Ansichtsautor(%(firstauthoremail)s).\n"
+"\n"
+"Wenn du nicht willst, das Gramps weiter versucht diese Ansicht zu laden, "
+"kannst du sie in der Zusatzmodulverwaltung über das Hilfemenü verstecken."
+
+#: ../gramps/gui/viewmanager.py:1766
 msgid "Failed Loading Plugin"
 msgstr "Laden des Zusatzmodul fehlgeschlagen"
 
-#: ../gramps/gui/viewmanager.py:1601
+#: ../gramps/gui/viewmanager.py:1767
 #, python-format
 msgid ""
 "The plugin %(name)s did not load and reported an error.\n"
@@ -18399,89 +18506,60 @@ msgstr ""
 "laden, kannst du es in der Zusatzmodulverwaltung über das Hilfemenü "
 "verstecken."
 
-#: ../gramps/gui/viewmanager.py:1657
-msgid "Failed Loading View"
-msgstr "Laden der Ansicht fehlgeschlagen"
-
-#: ../gramps/gui/viewmanager.py:1658
-#, python-format
-msgid ""
-"The view %(name)s did not load and reported an error.\n"
-"\n"
-"%(error_msg)s\n"
-"\n"
-"If you are unable to fix the fault yourself then you can submit a bug at "
-"%(gramps_bugtracker_url)s or contact the view author "
-"(%(firstauthoremail)s).\n"
-"\n"
-"If you do not want Gramps to try and load this view again, you can hide it "
-"by using the Plugin Manager on the Help menu."
-msgstr ""
-"Die Ansicht  %(name)s wurde nicht geladen und meldete einen Fehler.\n"
-"\n"
-"%(error_msg)s\n"
-"\n"
-"Wenn du den Fehler nicht alleine beheben kannst, erstelle einen "
-"Fehlerbericht über %(gramps_bugtracker_url)s oder kontaktiere den "
-"Ansichtsautor(%(firstauthoremail)s).\n"
-"\n"
-"Wenn du nicht willst, das Gramps weiter versucht diese Ansicht zu laden, "
-"kannst du sie in der Zusatzmodulverwaltung über das Hilfemenü verstecken."
-
-#: ../gramps/gui/views/bookmarks.py:64
+#: ../gramps/gui/views/bookmarks.py:65
 msgid "manual|Bookmarks"
 msgstr "Lesezeichen"
 
-#: ../gramps/gui/views/bookmarks.py:205 ../gramps/gui/views/bookmarks.py:212
-#: ../gramps/gui/views/navigationview.py:274
+#: ../gramps/gui/views/bookmarks.py:227 ../gramps/gui/views/bookmarks.py:234
+#: ../gramps/gui/views/navigationview.py:276
 msgid "Organize Bookmarks"
 msgstr "Lesezeichen organisieren"
 
-#: ../gramps/gui/views/bookmarks.py:407
+#: ../gramps/gui/views/bookmarks.py:433
 msgid "Cannot bookmark this reference"
 msgstr "Kann kein Lesezeichen für diese Referenz erstellen"
 
-#: ../gramps/gui/views/listview.py:209
-#: ../gramps/plugins/lib/libpersonview.py:380
+#: ../gramps/gui/views/listview.py:210
+#: ../gramps/plugins/lib/libpersonview.py:386
 msgid "_Add..."
 msgstr "_Hinzufügen..."
 
-#: ../gramps/gui/views/listview.py:213
-#: ../gramps/plugins/lib/libpersonview.py:384
+#: ../gramps/gui/views/listview.py:214
+#: ../gramps/plugins/lib/libpersonview.py:390
 msgid "_Merge..."
 msgstr "_Zusammenfassen..."
 
-#: ../gramps/gui/views/listview.py:215
-#: ../gramps/plugins/lib/libpersonview.py:386
+#: ../gramps/gui/views/listview.py:216
+#: ../gramps/plugins/lib/libpersonview.py:392
 msgid "Export View..."
 msgstr "Ansicht exportieren..."
 
-#: ../gramps/gui/views/listview.py:221
-#: ../gramps/plugins/lib/libpersonview.py:371
+#: ../gramps/gui/views/listview.py:222
+#: ../gramps/plugins/lib/libpersonview.py:377
 msgid "action|_Edit..."
 msgstr "_Bearbeiten..."
 
-#: ../gramps/gui/views/listview.py:437
+#: ../gramps/gui/views/listview.py:443
 msgid "Active object not visible"
 msgstr "Aktives Objekt ist nicht sichtbar"
 
-#: ../gramps/gui/views/listview.py:448
-#: ../gramps/gui/views/navigationview.py:255
-#: ../gramps/plugins/lib/maps/geography.py:202
-#: ../gramps/plugins/lib/maps/geography.py:218
+#: ../gramps/gui/views/listview.py:453
+#: ../gramps/gui/views/navigationview.py:256
+#: ../gramps/plugins/lib/maps/geography.py:203
+#: ../gramps/plugins/lib/maps/geography.py:219
 #: ../gramps/plugins/view/familyview.py:220
 msgid "Could Not Set a Bookmark"
 msgstr "Das Lesezeichen konnte nicht gesetzt werden"
 
-#: ../gramps/gui/views/listview.py:449
+#: ../gramps/gui/views/listview.py:454
 msgid "A bookmark could not be set because nothing was selected."
 msgstr "Das Lesezeichen konnte nicht gesetzt werden, da nichts ausgewählt war."
 
-#: ../gramps/gui/views/listview.py:540
+#: ../gramps/gui/views/listview.py:546
 msgid "Multiple Selection Delete"
 msgstr "Mehrfache Auswahl löschen"
 
-#: ../gramps/gui/views/listview.py:541
+#: ../gramps/gui/views/listview.py:547
 msgid ""
 "More than one item has been selected for deletion. Select the option "
 "indicating how to delete the items:"
@@ -18489,15 +18567,15 @@ msgstr ""
 "Mehr als ein Element wurden zum Löschen gewählt. Wähle die Option wie die "
 "Elemente gelöscht werden sollen:"
 
-#: ../gramps/gui/views/listview.py:543
+#: ../gramps/gui/views/listview.py:549
 msgid "Delete All"
 msgstr "Alle Löschen"
 
-#: ../gramps/gui/views/listview.py:544
+#: ../gramps/gui/views/listview.py:550
 msgid "Confirm Each Delete"
 msgstr "Jedes Löschen Bestätigen"
 
-#: ../gramps/gui/views/listview.py:554
+#: ../gramps/gui/views/listview.py:561
 msgid ""
 "This item is currently being used. Deleting it will remove it from the "
 "database and from all other items that reference it."
@@ -18505,94 +18583,93 @@ msgstr ""
 "Dieses Element wird derzeit verwendet. Beim Löschen wird es aus der "
 "Datenbank und allen referenzierenden Objekten entfernt."
 
-#: ../gramps/gui/views/listview.py:558
-#: ../gramps/plugins/view/familyview.py:267
+#: ../gramps/gui/views/listview.py:565 ../gramps/plugins/view/familyview.py:267
 msgid "Deleting item will remove it from the database."
 msgstr "Das Löschen des Elementes wird es aus der Datenbank ganz entfernen."
 
-#: ../gramps/gui/views/listview.py:565
+#: ../gramps/gui/views/listview.py:572
 #: ../gramps/plugins/lib/libpersonview.py:312
 #: ../gramps/plugins/view/familyview.py:260
 #, python-format
 msgid "Delete %s?"
 msgstr "%s löschen?"
 
-#: ../gramps/gui/views/listview.py:566
+#: ../gramps/gui/views/listview.py:573
 msgid "_Delete Item"
 msgstr "Element _löschen"
 
-#: ../gramps/gui/views/listview.py:607
+#: ../gramps/gui/views/listview.py:615
 msgid "Column clicked, sorting..."
 msgstr "Spalte geklickt, sortiere..."
 
-#: ../gramps/gui/views/listview.py:999
+#: ../gramps/gui/views/listview.py:1007
 msgid "Export View as Spreadsheet"
 msgstr "Ansicht als Tabelle exportieren"
 
-#: ../gramps/gui/views/listview.py:1012
+#: ../gramps/gui/views/listview.py:1020
 msgid "CSV"
 msgstr "CSV"
 
-#: ../gramps/gui/views/listview.py:1013
+#: ../gramps/gui/views/listview.py:1021
 msgid "OpenDocument Spreadsheet"
 msgstr "OpenDocument Tabelle"
 
-#: ../gramps/gui/views/listview.py:1208
+#: ../gramps/gui/views/listview.py:1209
 msgid "Columns"
 msgstr "Spalten"
 
-#: ../gramps/gui/views/navigationview.py:251
+#: ../gramps/gui/views/navigationview.py:252
 #, python-format
 msgid "%s has been bookmarked"
 msgstr "Lesezeichen für %s gesetzt"
 
-#: ../gramps/gui/views/navigationview.py:256
-#: ../gramps/plugins/lib/maps/geography.py:203
-#: ../gramps/plugins/lib/maps/geography.py:219
+#: ../gramps/gui/views/navigationview.py:257
+#: ../gramps/plugins/lib/maps/geography.py:204
+#: ../gramps/plugins/lib/maps/geography.py:220
 #: ../gramps/plugins/view/familyview.py:221
 msgid "A bookmark could not be set because no one was selected."
 msgstr ""
 "Das Lesezeichen konnte nicht gesetzt werden, da niemand ausgewählt war."
 
-#: ../gramps/gui/views/navigationview.py:271
+#: ../gramps/gui/views/navigationview.py:273
 msgid "_Add Bookmark"
 msgstr "Lesezeichen _hinzufügen"
 
-#: ../gramps/gui/views/navigationview.py:274
+#: ../gramps/gui/views/navigationview.py:276
 #, python-format
 msgid "%(title)s..."
 msgstr "%(title)s..."
 
-#: ../gramps/gui/views/navigationview.py:292
+#: ../gramps/gui/views/navigationview.py:294
 msgid "Go to the next object in the history"
 msgstr "Gehe zum nächsten Objekt in der Chronik."
 
-#: ../gramps/gui/views/navigationview.py:299
+#: ../gramps/gui/views/navigationview.py:301
 msgid "_Back"
 msgstr "_Zurück"
 
-#: ../gramps/gui/views/navigationview.py:300
+#: ../gramps/gui/views/navigationview.py:302
 msgid "Go to the previous object in the history"
 msgstr "Gehe zum vorherigen Objekt in der Chronik."
 
-#: ../gramps/gui/views/navigationview.py:304
-#: ../gramps/plugins/view/pedigreeview.py:1541
+#: ../gramps/gui/views/navigationview.py:306
+#: ../gramps/plugins/view/pedigreeview.py:1577
 msgid "_Home"
 msgstr "_Anfang"
 
-#: ../gramps/gui/views/navigationview.py:306
+#: ../gramps/gui/views/navigationview.py:308
 msgid "Go to the default person"
 msgstr "Springe zur Hauptperson"
 
-#: ../gramps/gui/views/navigationview.py:310
+#: ../gramps/gui/views/navigationview.py:312
 msgid "Set _Home Person"
 msgstr "Hauptperson _setzen"
 
-#: ../gramps/gui/views/navigationview.py:335
+#: ../gramps/gui/views/navigationview.py:337
 msgid "No Home Person"
 msgstr "Keine Hauptperson"
 
-#: ../gramps/gui/views/navigationview.py:336
+#: ../gramps/gui/views/navigationview.py:338
 msgid ""
 "You need to set a 'default person' to go to. Select the People View, select "
 "the person you want as 'Home Person', then confirm your choice via the menu "
@@ -18602,41 +18679,41 @@ msgstr ""
 "Personenansicht, wähle die Person, die du als 'Hauptperson' setzen willst "
 "und bestätige deine Wahl über Menü Bearbeiten -> Hauptperson setzen."
 
-#: ../gramps/gui/views/navigationview.py:346
-#: ../gramps/gui/views/navigationview.py:349
+#: ../gramps/gui/views/navigationview.py:348
+#: ../gramps/gui/views/navigationview.py:351
 msgid "Jump to by Gramps ID"
 msgstr "Springe zur Gramps-ID"
 
-#: ../gramps/gui/views/navigationview.py:373
+#: ../gramps/gui/views/navigationview.py:375
 #, python-format
 msgid "Error: %s is not a valid Gramps ID"
 msgstr "Fehler: %s ist keine gültige Gramps ID"
 
-#: ../gramps/gui/views/pageview.py:405
+#: ../gramps/gui/views/pageview.py:422
 msgid "_Sidebar"
 msgstr "_Seitenleiste"
 
-#: ../gramps/gui/views/pageview.py:408
+#: ../gramps/gui/views/pageview.py:425
 msgid "_Bottombar"
 msgstr "_Fußleiste"
 
-#: ../gramps/gui/views/pageview.py:578
+#: ../gramps/gui/views/pageview.py:561
 #, python-format
 msgid "Configure %(cat)s - %(view)s"
 msgstr "Konfiguriere %(cat)s - %(view)s"
 
-#: ../gramps/gui/views/pageview.py:595
+#: ../gramps/gui/views/pageview.py:578
 #, python-format
 msgid "%(cat)s - %(view)s"
 msgstr "%(cat)s - %(view)s"
 
-#: ../gramps/gui/views/pageview.py:614
+#: ../gramps/gui/views/pageview.py:598
 #, python-format
 msgid "Configure %s View"
 msgstr "Ansicht %s konfigurieren"
 
 #. top widget at the top
-#: ../gramps/gui/views/pageview.py:628
+#: ../gramps/gui/views/pageview.py:612
 #, python-format
 msgid "View %(name)s: %(msg)s"
 msgstr "Ansicht %(name)s: %(msg)s"
@@ -18649,41 +18726,41 @@ msgstr "Markierungen_Organisieren_Fenster"
 msgid "manual|New_Tag_dialog"
 msgstr "Neue_Markierung_Dialog"
 
-#: ../gramps/gui/views/tags.py:222
+#: ../gramps/gui/views/tags.py:226
 msgid "New Tag..."
 msgstr "Neue Markierung..."
 
-#: ../gramps/gui/views/tags.py:224
+#: ../gramps/gui/views/tags.py:228
 msgid "Organize Tags..."
 msgstr "Markierungen organisieren...."
 
-#: ../gramps/gui/views/tags.py:227
+#: ../gramps/gui/views/tags.py:231
 msgid "Tag selected rows"
 msgstr "Ausgewählte Reihen markieren"
 
-#: ../gramps/gui/views/tags.py:269
+#: ../gramps/gui/views/tags.py:274
 msgid "Adding Tags"
 msgstr "Markierungen hinzufügen"
 
-#: ../gramps/gui/views/tags.py:274
+#: ../gramps/gui/views/tags.py:279
 #, python-format
 msgid "Tag Selection (%s)"
 msgstr "Markierungenauswahl (%s)"
 
-#: ../gramps/gui/views/tags.py:337
+#: ../gramps/gui/views/tags.py:342
 msgid "Change Tag Priority"
 msgstr "Ändere die Priorität der Markierung."
 
-#: ../gramps/gui/views/tags.py:382 ../gramps/gui/views/tags.py:389
+#: ../gramps/gui/views/tags.py:387 ../gramps/gui/views/tags.py:394
 msgid "Organize Tags"
 msgstr "Markierungen organisieren"
 
-#: ../gramps/gui/views/tags.py:485
+#: ../gramps/gui/views/tags.py:490
 #, python-format
 msgid "Remove tag '%s'?"
 msgstr "Die Markierung '%s' entfernen?"
 
-#: ../gramps/gui/views/tags.py:486
+#: ../gramps/gui/views/tags.py:491
 msgid ""
 "The tag definition will be removed.  The tag will be also removed from all "
 "objects in the database."
@@ -18691,54 +18768,54 @@ msgstr ""
 "Die Markierungsfestlegung wird entfernt. Die Markierung wird auch von allen "
 "Objekten in der Datenbank entfernt."
 
-#: ../gramps/gui/views/tags.py:517
+#: ../gramps/gui/views/tags.py:523
 msgid "Removing Tags"
 msgstr "Entferne Markierung"
 
-#: ../gramps/gui/views/tags.py:522
+#: ../gramps/gui/views/tags.py:528
 #, python-format
 msgid "Delete Tag (%s)"
 msgstr "Lösche Markierung (%s)"
 
-#: ../gramps/gui/views/tags.py:581
+#: ../gramps/gui/views/tags.py:586
 msgid "Cannot save tag"
 msgstr "Kann Markierung nicht speichern"
 
-#: ../gramps/gui/views/tags.py:582
+#: ../gramps/gui/views/tags.py:587
 msgid "The tag name cannot be empty"
 msgstr "Markierungsname darf nicht leer sein"
 
-#: ../gramps/gui/views/tags.py:586
+#: ../gramps/gui/views/tags.py:592
 #, python-format
 msgid "Add Tag (%s)"
 msgstr "Markierung (%s) hinzufügen"
 
-#: ../gramps/gui/views/tags.py:592
+#: ../gramps/gui/views/tags.py:598
 #, python-format
 msgid "Edit Tag (%s)"
 msgstr "Markierung (%s) bearbeiten"
 
-#: ../gramps/gui/views/tags.py:602
+#: ../gramps/gui/views/tags.py:608
 #, python-format
 msgid "Tag: %s"
 msgstr "Markierung: %s"
 
-#: ../gramps/gui/views/tags.py:604
+#: ../gramps/gui/views/tags.py:610
 msgid "New Tag"
 msgstr "Neue Markierung"
 
-#: ../gramps/gui/views/tags.py:614
+#: ../gramps/gui/views/tags.py:620
 msgid "Tag Name:"
 msgstr "Markierungsname:"
 
-#: ../gramps/gui/views/tags.py:621
+#: ../gramps/gui/views/tags.py:627
 msgid "Pick a Color"
 msgstr "Eine Farbe wählen"
 
-#: ../gramps/gui/views/treemodels/placemodel.py:136
-#: ../gramps/gui/views/treemodels/placemodel.py:144
-#: ../gramps/gui/views/treemodels/placemodel.py:152
-#: ../gramps/gui/views/treemodels/placemodel.py:160
+#: ../gramps/gui/views/treemodels/placemodel.py:137
+#: ../gramps/gui/views/treemodels/placemodel.py:145
+#: ../gramps/gui/views/treemodels/placemodel.py:153
+#: ../gramps/gui/views/treemodels/placemodel.py:161
 msgid "Error in format"
 msgstr "Fehler im Format"
 
@@ -18759,77 +18836,69 @@ msgstr "Datensatz ist vertraulich"
 msgid "Record is public"
 msgstr "Information ist öffentlich"
 
-#: ../gramps/gui/widgets/expandcollapsearrow.py:85
+#: ../gramps/gui/widgets/expandcollapsearrow.py:86
 msgid "Expand this section"
 msgstr "Diesen Abschnitt ausklappen"
 
-#: ../gramps/gui/widgets/expandcollapsearrow.py:89
+#: ../gramps/gui/widgets/expandcollapsearrow.py:90
 msgid "Collapse this section"
 msgstr "Diesen Abschnitt einklappen"
 
-#: ../gramps/gui/widgets/fanchart.py:1564
-#: ../gramps/plugins/view/pedigreeview.py:1595
-#: ../gramps/plugins/view/pedigreeview.py:1624
-msgid "People Menu"
-msgstr "Personenmenü"
-
-#: ../gramps/gui/widgets/fanchart.py:1589
-#: ../gramps/plugins/view/relview.py:800
+#: ../gramps/gui/widgets/fanchart.py:1519 ../gramps/plugins/view/relview.py:811
 msgid "Edit family"
 msgstr "Familie bearbeiten"
 
-#: ../gramps/gui/widgets/fanchart.py:1608
-#: ../gramps/plugins/view/relview.py:801
+#: ../gramps/gui/widgets/fanchart.py:1535 ../gramps/plugins/view/relview.py:812
 msgid "Reorder families"
 msgstr "Familien wieder ordnen"
 
-#: ../gramps/gui/widgets/fanchart.py:1614
-#: ../gramps/plugins/view/pedigreeview.py:1646
-#: ../gramps/plugins/view/pedigreeview.py:1894
+#: ../gramps/gui/widgets/fanchart.py:1541
+#: ../gramps/plugins/view/pedigreeview.py:1667
+#: ../gramps/plugins/view/pedigreeview.py:1895
 msgid "_Copy"
 msgstr "_Kopieren"
 
 #. Go over siblings and build their menu
-#: ../gramps/gui/widgets/fanchart.py:1662
+#: ../gramps/gui/widgets/fanchart.py:1585
 #: ../gramps/plugins/quickview/quickview.gpr.py:316
-#: ../gramps/plugins/view/pedigreeview.py:1696
-#: ../gramps/plugins/view/relview.py:903
+#: ../gramps/plugins/view/pedigreeview.py:1711
+#: ../gramps/plugins/view/relview.py:914
 msgid "Siblings"
 msgstr "Geschwister"
 
 #. Go over children and build their menu
-#: ../gramps/gui/widgets/fanchart.py:1705
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:829
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:843
-#: ../gramps/plugins/textreport/familygroup.py:638
-#: ../gramps/plugins/textreport/indivcomplete.py:625
-#: ../gramps/plugins/view/pedigreeview.py:1741
-#: ../gramps/plugins/view/relview.py:1410
-#: ../gramps/plugins/webreport/narrativeweb.py:800
+#: ../gramps/gui/widgets/fanchart.py:1644
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:852
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:866
+#: ../gramps/plugins/textreport/familygroup.py:639
+#: ../gramps/plugins/textreport/indivcomplete.py:663
+#: ../gramps/plugins/view/pedigreeview.py:1753
+#: ../gramps/plugins/view/relview.py:1420
+#: ../gramps/plugins/webreport/narrativeweb.py:753
 msgid "Children"
 msgstr "Kinder"
 
 #. Go over parents and build their menu
-#: ../gramps/gui/widgets/fanchart.py:1788
-#: ../gramps/plugins/view/pedigreeview.py:1831
+#: ../gramps/gui/widgets/fanchart.py:1721
+#: ../gramps/plugins/view/pedigreeview.py:1838
 msgid "Related"
 msgstr "Verknüpft"
 
-#: ../gramps/gui/widgets/fanchart.py:1841
+#: ../gramps/gui/widgets/fanchart.py:1769
 msgid "Add partner to person"
 msgstr "Partner zu einer Person hinzufügen"
 
-#: ../gramps/gui/widgets/fanchart.py:1850
+#: ../gramps/gui/widgets/fanchart.py:1776
 msgid "Add a person"
 msgstr "Eine Person hinzufügen"
 
-#: ../gramps/gui/widgets/fanchart.py:1925
-#: ../gramps/plugins/view/relview.py:1551
+#: ../gramps/gui/widgets/fanchart.py:1851
+#: ../gramps/plugins/view/relview.py:1561
 msgid "Add Child to Family"
 msgstr "Kind zur Familie hinzufügen"
 
 #: ../gramps/gui/widgets/grampletbar.py:206
-#: ../gramps/gui/widgets/grampletpane.py:1176
+#: ../gramps/gui/widgets/grampletpane.py:1181
 msgid "Unnamed Gramplet"
 msgstr "Unbenanntes Gramplet"
 
@@ -18846,7 +18915,7 @@ msgstr ""
 "Entfernen oder Wiederherstellen von Gramplets."
 
 #: ../gramps/gui/widgets/grampletbar.py:486
-#: ../gramps/plugins/view/dashboardview.py:94
+#: ../gramps/plugins/view/dashboardview.py:100
 msgid "Add a gramplet"
 msgstr "Ein Gramplet hinzufügen"
 
@@ -18858,11 +18927,11 @@ msgstr "Ein Gramplet entfernen"
 msgid "Restore default gramplets"
 msgstr "Standardgramplets wiederherstellen"
 
-#: ../gramps/gui/widgets/grampletbar.py:544
+#: ../gramps/gui/widgets/grampletbar.py:545
 msgid "Restore to defaults?"
 msgstr "Auf Standardwerte zurücksetzen?"
 
-#: ../gramps/gui/widgets/grampletbar.py:545
+#: ../gramps/gui/widgets/grampletbar.py:546
 msgid ""
 "The gramplet bar will be restored to contain its default gramplets.  This "
 "action cannot be undone."
@@ -18871,46 +18940,46 @@ msgstr ""
 "enthält. Dieser Vorgang kann nicht rückgängig gemacht werden."
 
 #. default tooltip
-#: ../gramps/gui/widgets/grampletpane.py:798
+#: ../gramps/gui/widgets/grampletpane.py:803
 msgid "Drag Properties Button to move and click it for setup"
 msgstr ""
 "Ziehe die Eigenschaftenschaltfläche, um sie zu verschieben. Zum Einrichten "
 "klicke darauf."
 
 #. build the GUI:
-#: ../gramps/gui/widgets/grampletpane.py:994
+#: ../gramps/gui/widgets/grampletpane.py:999
 msgid "Right click to add gramplets"
 msgstr "Rechts-klick zum hinzufügen von Gramplets."
 
-#: ../gramps/gui/widgets/grampletpane.py:1041
+#: ../gramps/gui/widgets/grampletpane.py:1046
 msgid "Untitled Gramplet"
 msgstr "Unbenanntes Gramplet"
 
-#: ../gramps/gui/widgets/grampletpane.py:1529
+#: ../gramps/gui/widgets/grampletpane.py:1534
 msgid "Number of Columns"
 msgstr "Spaltenanzahl"
 
-#: ../gramps/gui/widgets/grampletpane.py:1534
+#: ../gramps/gui/widgets/grampletpane.py:1539
 msgid "Gramplet Layout"
 msgstr "Gramplet Layout"
 
-#: ../gramps/gui/widgets/grampletpane.py:1564
+#: ../gramps/gui/widgets/grampletpane.py:1569
 msgid "Use maximum height available"
 msgstr "Verwende maximale verfügbare Höhe"
 
-#: ../gramps/gui/widgets/grampletpane.py:1570
+#: ../gramps/gui/widgets/grampletpane.py:1575
 msgid "Height if not maximized"
 msgstr "Höhe, wenn nicht maximiert"
 
-#: ../gramps/gui/widgets/grampletpane.py:1577
+#: ../gramps/gui/widgets/grampletpane.py:1582
 msgid "Detached width"
 msgstr "Freistehende Breite"
 
-#: ../gramps/gui/widgets/grampletpane.py:1584
+#: ../gramps/gui/widgets/grampletpane.py:1589
 msgid "Detached height"
 msgstr "Freistehende Höhe"
 
-#: ../gramps/gui/widgets/labels.py:120
+#: ../gramps/gui/widgets/labels.py:121
 msgid ""
 "Click to make this person active\n"
 "Right click to display the edit menu\n"
@@ -18937,6 +19006,10 @@ msgstr ""
 "Doppelklicke auf das Bild, damit es in der Standard "
 "Bildbetrachtungsanwendung angezeigt wird."
 
+#: ../gramps/gui/widgets/photo.py:87
+msgid "Make Active Media"
+msgstr "zum aktiven Medium machen"
+
 #: ../gramps/gui/widgets/progressdialog.py:298
 msgid "Progress Information"
 msgstr "Fortschritt Informationen"
@@ -18951,61 +19024,61 @@ msgid "Reorder Relationships: %s"
 msgstr "Beziehungen neu ordnen: %s"
 
 #. spell checker submenu
-#: ../gramps/gui/widgets/styledtexteditor.py:369
+#: ../gramps/gui/widgets/styledtexteditor.py:370
 msgid "Spellcheck"
 msgstr "Rechtschreibprüfung"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:374
+#: ../gramps/gui/widgets/styledtexteditor.py:375
 msgid "Search selection on web"
 msgstr "Suche Auswahl im Web"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:385
+#: ../gramps/gui/widgets/styledtexteditor.py:386
 msgid "_Send Mail To..."
 msgstr "E-Mail _senden an..."
 
-#: ../gramps/gui/widgets/styledtexteditor.py:387
+#: ../gramps/gui/widgets/styledtexteditor.py:388
 msgid "Copy _E-mail Address"
 msgstr "_E-Mail-Adresse kopieren"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:390
+#: ../gramps/gui/widgets/styledtexteditor.py:391
 msgid "_Open Link"
 msgstr "Link _öffnen"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:392
+#: ../gramps/gui/widgets/styledtexteditor.py:393
 msgid "Copy _Link Address"
 msgstr "_Linkadresse kopieren"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:396
+#: ../gramps/gui/widgets/styledtexteditor.py:397
 msgid "_Edit Link"
 msgstr "Verknüpfung _bearbeiten"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:468
+#: ../gramps/gui/widgets/styledtexteditor.py:469
 msgid "Font Color"
 msgstr "Schriftfarbe"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:470
+#: ../gramps/gui/widgets/styledtexteditor.py:471
 msgid "Background Color"
 msgstr "Hintergrundfarbe"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:474
+#: ../gramps/gui/widgets/styledtexteditor.py:475
 msgid "Clear Markup"
 msgstr "Markierungen löschen"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:514
 #: ../gramps/gui/widgets/styledtexteditor.py:515
+#: ../gramps/gui/widgets/styledtexteditor.py:516
 msgid "Undo"
 msgstr "Rückgängig"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:518
 #: ../gramps/gui/widgets/styledtexteditor.py:519
+#: ../gramps/gui/widgets/styledtexteditor.py:520
 msgid "Redo"
 msgstr "Wiederherstellen"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:642
+#: ../gramps/gui/widgets/styledtexteditor.py:643
 msgid "Select font color"
 msgstr "Wähle Schriftfarbe"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:644
+#: ../gramps/gui/widgets/styledtexteditor.py:645
 msgid "Select background color"
 msgstr "Wähle Hintergrundfarbe"
 
@@ -19024,54 +19097,54 @@ msgstr "Dies ist ein Pflichtfeld"
 msgid "'%s' is not a valid date value"
 msgstr "'%s' ist kein gültiger Datumswert"
 
-#: ../gramps/plugins/database/bsddb.gpr.py:23
+#: ../gramps/plugins/db/bsddb/bsddb.gpr.py:23
 msgid "BSDDB"
 msgstr "BSDDB"
 
-#: ../gramps/plugins/database/bsddb.gpr.py:24
+#: ../gramps/plugins/db/bsddb/bsddb.gpr.py:24
 msgid "_BSDDB Database"
 msgstr "_BSDDB Datenbank"
 
-#: ../gramps/plugins/database/bsddb.gpr.py:25
+#: ../gramps/plugins/db/bsddb/bsddb.gpr.py:25
 msgid "Berkeley Software Distribution Database Backend"
 msgstr "Berkeley Software Distribution Datenbank Backend"
 
-#: ../gramps/plugins/database/bsddb_support/upgrade.py:398
+#: ../gramps/plugins/db/bsddb/upgrade.py:398
 #, python-format
 msgid ""
 "%(n1)6d  People        upgraded with %(n2)6d citations in %(n3)6d secs\n"
 msgstr ""
 "%(n1)6d  Personen      aktualisiert mit %(n2)6d Fundstellen in %(n3)6d sek.\n"
 
-#: ../gramps/plugins/database/bsddb_support/upgrade.py:399
+#: ../gramps/plugins/db/bsddb/upgrade.py:399
 #, python-format
 msgid ""
 "%(n1)6d  Families      upgraded with %(n2)6d citations in %(n3)6d secs\n"
 msgstr ""
 "%(n1)6d  Familien      aktualisiert mit %(n2)6d Fundstellen in %(n3)6d sek.\n"
 
-#: ../gramps/plugins/database/bsddb_support/upgrade.py:400
+#: ../gramps/plugins/db/bsddb/upgrade.py:400
 #, python-format
 msgid ""
 "%(n1)6d  Events        upgraded with %(n2)6d citations in %(n3)6d secs\n"
 msgstr ""
 "%(n1)6d  Ereignisse    aktualisiert mit %(n2)6d Fundstellen in %(n3)6d sek.\n"
 
-#: ../gramps/plugins/database/bsddb_support/upgrade.py:401
+#: ../gramps/plugins/db/bsddb/upgrade.py:401
 #, python-format
 msgid ""
 "%(n1)6d  Media Objects upgraded with %(n2)6d citations in %(n3)6d secs\n"
 msgstr ""
 "%(n1)6d  Medienobjekte aktualisiert mit %(n2)6d Fundstellen in %(n3)6d Sek.\n"
 
-#: ../gramps/plugins/database/bsddb_support/upgrade.py:402
+#: ../gramps/plugins/db/bsddb/upgrade.py:402
 #, python-format
 msgid ""
 "%(n1)6d  Places        upgraded with %(n2)6d citations in %(n3)6d secs\n"
 msgstr ""
 "%(n1)6d  Orte          aktualisiert mit %(n2)6d Fundstellen in %(n3)6d sek.\n"
 
-#: ../gramps/plugins/database/bsddb_support/upgrade.py:403
+#: ../gramps/plugins/db/bsddb/upgrade.py:403
 #, python-format
 msgid ""
 "%(n1)6d  Repositories  upgraded with %(n2)6d citations in %(n3)6d secs\n"
@@ -19079,7 +19152,7 @@ msgstr ""
 "%(n1)6d  Aufbewahrungsorte aktualisiert mit %(n2)6d Fundstellen in %(n3)6d "
 "sek.\n"
 
-#: ../gramps/plugins/database/bsddb_support/upgrade.py:404
+#: ../gramps/plugins/db/bsddb/upgrade.py:404
 #, python-format
 msgid ""
 "%(n1)6d  Sources       upgraded with %(n2)6d citations in %(n3)6d secs\n"
@@ -19087,11 +19160,11 @@ msgstr ""
 "%(n1)6d  Quellen          aktualisiert mit %(n2)6d Fundstellen in %(n3)6d "
 "sek.\n"
 
-#: ../gramps/plugins/database/bsddb_support/upgrade.py:789
+#: ../gramps/plugins/db/bsddb/upgrade.py:789
 msgid "Number of new objects upgraded:\n"
 msgstr "Anzahl von neuen, aktualisierten Objekten:\n"
 
-#: ../gramps/plugins/database/bsddb_support/upgrade.py:798
+#: ../gramps/plugins/db/bsddb/upgrade.py:798
 msgid ""
 "\n"
 "\n"
@@ -19107,11 +19180,11 @@ msgstr ""
 "um Fundstellen zusammenzufassen, die identische\n"
 "Informationen enthalten."
 
-#: ../gramps/plugins/database/bsddb_support/upgrade.py:802
+#: ../gramps/plugins/db/bsddb/upgrade.py:802
 msgid "Upgrade Statistics"
 msgstr "Aktualisiere Statistiken"
 
-#: ../gramps/plugins/database/bsddb_support/write.py:1340
+#: ../gramps/plugins/db/bsddb/write.py:1330
 #, python-format
 msgid ""
 "An attempt is made to save a reference key which is partly bytecode, this is "
@@ -19124,11 +19197,11 @@ msgstr ""
 
 #. Make a tuple of the functions and classes that we need for
 #. each of the primary object tables.
-#: ../gramps/plugins/database/bsddb_support/write.py:1409
+#: ../gramps/plugins/db/bsddb/write.py:1399
 msgid "Rebuild reference map"
 msgstr "Interne Referenzen neu erstellen"
 
-#: ../gramps/plugins/database/bsddb_support/write.py:2209
+#: ../gramps/plugins/db/bsddb/write.py:2172
 #, python-format
 msgid ""
 "A second transaction is started while there is still a transaction, \"%s\", "
@@ -19137,44 +19210,52 @@ msgstr ""
 "Es wurde eine zweite Transaktion gestartet, während noch eine andere "
 "Transaktion \"%s\" in der Datenbank aktiv ist."
 
-#: ../gramps/plugins/database/bsddb_support/write.py:2558
+#: ../gramps/plugins/db/bsddb/write.py:2483
 msgid "DB-API version"
 msgstr "DB-API Version"
 
-#: ../gramps/plugins/database/bsddb_support/write.py:2570
+#: ../gramps/plugins/db/bsddb/write.py:2495
 msgid "Database db version"
 msgstr "Datenbank DB Version"
 
-#: ../gramps/plugins/database/dbapi.gpr.py:23
+#: ../gramps/plugins/db/dbapi/dbapi.gpr.py:23
 msgid "DB-API"
 msgstr "DB-API"
 
-#: ../gramps/plugins/database/dbapi.gpr.py:24
+#: ../gramps/plugins/db/dbapi/dbapi.gpr.py:24
 msgid "DB-_API Database"
 msgstr "DB-_API Datenbank"
 
-#: ../gramps/plugins/database/dbapi.gpr.py:25
+#: ../gramps/plugins/db/dbapi/dbapi.gpr.py:25
 msgid "DB-API Database"
 msgstr "DB-API Datenbank"
 
-#: ../gramps/plugins/database/inmemorydb.gpr.py:23
+#: ../gramps/plugins/db/dbapi/inmemorydb.gpr.py:23
 msgid "In-Memory"
 msgstr "Im-Speicher"
 
-#: ../gramps/plugins/database/inmemorydb.gpr.py:24
+#: ../gramps/plugins/db/dbapi/inmemorydb.gpr.py:24
 msgid "In-_Memory Database"
 msgstr "Im-_Speicher Datenbank"
 
-#: ../gramps/plugins/database/inmemorydb.gpr.py:25
+#: ../gramps/plugins/db/dbapi/inmemorydb.gpr.py:25
 msgid "In-Memory Database"
 msgstr "Im-Speicher Datenbank"
 
-#. internal name: don't translate
-#: ../gramps/plugins/docgen/asciidoc.py:462
+#: ../gramps/plugins/db/dummydb.gpr.py:23
+msgid "Dummy database"
+msgstr "Atrappendatenbank"
+
+#: ../gramps/plugins/db/dummydb.gpr.py:24
+#: ../gramps/plugins/db/dummydb.gpr.py:25
+msgid "Dummy Database"
+msgstr "Atrappendatenbank"
+
+#: ../gramps/plugins/docgen/asciidoc.py:463
 msgid "Characters per line"
 msgstr "Zeichen pro Zeile"
 
-#: ../gramps/plugins/docgen/asciidoc.py:463
+#: ../gramps/plugins/docgen/asciidoc.py:464
 msgid "The number of characters per line"
 msgstr "Die Anzahl der Zeichen pro Zeile"
 
@@ -19296,14 +19377,14 @@ msgid "of %d"
 msgstr "von %d"
 
 #: ../gramps/plugins/docgen/htmldoc.py:273
-#: ../gramps/plugins/webreport/narrativeweb.py:9258
-#: ../gramps/plugins/webreport/webcal.py:265
+#: ../gramps/plugins/webreport/narrativeweb.py:9532
+#: ../gramps/plugins/webreport/webcal.py:268
 msgid "Possible destination error"
 msgstr "Möglicher Fehler im Ziel."
 
 #: ../gramps/plugins/docgen/htmldoc.py:274
-#: ../gramps/plugins/webreport/narrativeweb.py:9259
-#: ../gramps/plugins/webreport/webcal.py:266
+#: ../gramps/plugins/webreport/narrativeweb.py:9533
+#: ../gramps/plugins/webreport/webcal.py:269
 msgid ""
 "You appear to have set your target directory to a directory used for data "
 "storage. This could create problems with file management. It is recommended "
@@ -19339,146 +19420,145 @@ msgstr ""
 msgid "Could not open %s"
 msgstr "Konnte %s nicht öffnen"
 
-#. internal name: don't translate
-#: ../gramps/plugins/docgen/svgdrawdoc.py:339
+#: ../gramps/plugins/docgen/svgdrawdoc.py:341
 msgid "SVG background color"
 msgstr "SVG Hintergrundfarbe"
 
-#: ../gramps/plugins/docgen/svgdrawdoc.py:341
+#: ../gramps/plugins/docgen/svgdrawdoc.py:343
 msgid "transparent background"
 msgstr "Transparenter Hintergrund"
 
-#: ../gramps/plugins/docgen/svgdrawdoc.py:342
-#: ../gramps/plugins/drawreport/fanchart.py:702
+#: ../gramps/plugins/docgen/svgdrawdoc.py:344
+#: ../gramps/plugins/drawreport/fanchart.py:714
 msgid "white"
 msgstr "Weiß"
 
-#: ../gramps/plugins/docgen/svgdrawdoc.py:343
+#: ../gramps/plugins/docgen/svgdrawdoc.py:345
 msgid "black"
 msgstr "schwarz"
 
-#: ../gramps/plugins/docgen/svgdrawdoc.py:344
+#: ../gramps/plugins/docgen/svgdrawdoc.py:346
 msgid "red"
 msgstr "rot"
 
-#: ../gramps/plugins/docgen/svgdrawdoc.py:345
+#: ../gramps/plugins/docgen/svgdrawdoc.py:347
 msgid "green"
 msgstr "grün"
 
-#: ../gramps/plugins/docgen/svgdrawdoc.py:346
+#: ../gramps/plugins/docgen/svgdrawdoc.py:348
 msgid "blue"
 msgstr "blau"
 
-#: ../gramps/plugins/docgen/svgdrawdoc.py:347
+#: ../gramps/plugins/docgen/svgdrawdoc.py:349
 msgid "cyan"
 msgstr "türkis"
 
-#: ../gramps/plugins/docgen/svgdrawdoc.py:348
+#: ../gramps/plugins/docgen/svgdrawdoc.py:350
 msgid "magenta"
 msgstr "magenta"
 
-#: ../gramps/plugins/docgen/svgdrawdoc.py:349
+#: ../gramps/plugins/docgen/svgdrawdoc.py:351
 msgid "yellow"
 msgstr "gelb"
 
-#: ../gramps/plugins/docgen/svgdrawdoc.py:350
+#: ../gramps/plugins/docgen/svgdrawdoc.py:352
 msgid "The color, if any, of the SVG background"
 msgstr "Die Farbe, wenn vorhanden des SVG Hintergrund"
 
 #. we want no text, but need a text for the TOC in a book!
-#: ../gramps/plugins/drawreport/ancestortree.py:113
+#: ../gramps/plugins/drawreport/ancestortree.py:114
 msgid "Ancestor Graph"
 msgstr "Ahnendiagramm"
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/drawreport/ancestortree.py:130
+#: ../gramps/plugins/drawreport/ancestortree.py:131
 #, python-format
 msgid "Ancestor Graph for %s"
 msgstr "Ahnendiagramm für %s"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:356
+#: ../gramps/plugins/drawreport/ancestortree.py:357
 #: ../gramps/plugins/drawreport/calendarreport.py:113
-#: ../gramps/plugins/drawreport/descendtree.py:687
-#: ../gramps/plugins/drawreport/fanchart.py:194
+#: ../gramps/plugins/drawreport/descendtree.py:689
+#: ../gramps/plugins/drawreport/fanchart.py:195
 #: ../gramps/plugins/graph/gvhourglass.py:100
-#: ../gramps/plugins/textreport/ancestorreport.py:111
+#: ../gramps/plugins/graph/gvrelgraph.py:179
+#: ../gramps/plugins/textreport/ancestorreport.py:112
 #: ../gramps/plugins/textreport/birthdayreport.py:113
-#: ../gramps/plugins/textreport/descendreport.py:368
-#: ../gramps/plugins/textreport/detancestralreport.py:159
-#: ../gramps/plugins/textreport/detdescendantreport.py:173
-#: ../gramps/plugins/textreport/endoflinereport.py:89
-#: ../gramps/plugins/textreport/kinshipreport.py:104
-#: ../gramps/plugins/textreport/numberofancestorsreport.py:83
+#: ../gramps/plugins/textreport/descendreport.py:440
+#: ../gramps/plugins/textreport/detancestralreport.py:160
+#: ../gramps/plugins/textreport/detdescendantreport.py:179
+#: ../gramps/plugins/textreport/endoflinereport.py:90
+#: ../gramps/plugins/textreport/kinshipreport.py:105
+#: ../gramps/plugins/textreport/numberofancestorsreport.py:84
 #, python-format
 msgid "Person %s is not in the Database"
 msgstr "Person %s ist nicht in der Datenbank"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:601
-#: ../gramps/plugins/drawreport/ancestortree.py:687
+#: ../gramps/plugins/drawreport/ancestortree.py:602
+#: ../gramps/plugins/drawreport/ancestortree.py:688
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:50
 msgid "Ancestor Tree"
 msgstr "Ahnenbaum"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:602
+#: ../gramps/plugins/drawreport/ancestortree.py:603
 msgid "Making the Tree..."
 msgstr "Erstelle den Baum..."
 
-#: ../gramps/plugins/drawreport/ancestortree.py:688
+#: ../gramps/plugins/drawreport/ancestortree.py:689
 msgid "Printing the Tree..."
 msgstr "Drucke den Baum..."
 
 #. #################
-#: ../gramps/plugins/drawreport/ancestortree.py:777
-#: ../gramps/plugins/drawreport/descendtree.py:1505
+#: ../gramps/plugins/drawreport/ancestortree.py:786
+#: ../gramps/plugins/drawreport/descendtree.py:1540
 msgid "Tree Options"
 msgstr "Baumoptionen"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:779
-#: ../gramps/plugins/drawreport/calendarreport.py:474
-#: ../gramps/plugins/drawreport/fanchart.py:680
+#: ../gramps/plugins/drawreport/ancestortree.py:788
+#: ../gramps/plugins/drawreport/calendarreport.py:478
+#: ../gramps/plugins/drawreport/fanchart.py:688
 #: ../gramps/plugins/graph/gvhourglass.py:308
-#: ../gramps/plugins/graph/gvrelgraph.py:672
-#: ../gramps/plugins/textreport/ancestorreport.py:274
-#: ../gramps/plugins/textreport/birthdayreport.py:423
-#: ../gramps/plugins/textreport/descendreport.py:420
-#: ../gramps/plugins/textreport/detancestralreport.py:773
-#: ../gramps/plugins/textreport/detdescendantreport.py:925
-#: ../gramps/plugins/textreport/endoflinereport.py:262
-#: ../gramps/plugins/textreport/kinshipreport.py:348
-#: ../gramps/plugins/textreport/numberofancestorsreport.py:196
+#: ../gramps/plugins/graph/gvrelgraph.py:675
+#: ../gramps/plugins/textreport/ancestorreport.py:283
+#: ../gramps/plugins/textreport/descendreport.py:506
+#: ../gramps/plugins/textreport/detancestralreport.py:782
+#: ../gramps/plugins/textreport/detdescendantreport.py:978
+#: ../gramps/plugins/textreport/endoflinereport.py:271
+#: ../gramps/plugins/textreport/kinshipreport.py:357
+#: ../gramps/plugins/textreport/numberofancestorsreport.py:205
 msgid "Center Person"
 msgstr "Hauptperson"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:780
+#: ../gramps/plugins/drawreport/ancestortree.py:789
 msgid "The center person for the tree"
 msgstr "Die Hauptperson für den Baum"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:790
+#: ../gramps/plugins/drawreport/ancestortree.py:799
 msgid "Include siblings of the center person"
 msgstr "Geschwister der Hauptperson aufnehmen"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:792
+#: ../gramps/plugins/drawreport/ancestortree.py:801
 msgid ""
 "Whether to only display the center person or all of his/her siblings too"
 msgstr ""
 "Ob nur die Hauptperson oder auch all ihre/seine Geschwister angezeigt werden"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:796
-#: ../gramps/plugins/drawreport/descendtree.py:1531
-#: ../gramps/plugins/drawreport/fanchart.py:688
-#: ../gramps/plugins/textreport/ancestorreport.py:284
-#: ../gramps/plugins/textreport/descendreport.py:438
-#: ../gramps/plugins/textreport/detancestralreport.py:788
-#: ../gramps/plugins/textreport/detdescendantreport.py:944
+#: ../gramps/plugins/drawreport/ancestortree.py:805
+#: ../gramps/plugins/drawreport/descendtree.py:1542
+#: ../gramps/plugins/drawreport/fanchart.py:700
+#: ../gramps/plugins/textreport/ancestorreport.py:293
+#: ../gramps/plugins/textreport/descendreport.py:531
+#: ../gramps/plugins/textreport/detancestralreport.py:797
+#: ../gramps/plugins/textreport/detdescendantreport.py:1006
 msgid "Generations"
 msgstr "Generationen"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:797
-#: ../gramps/plugins/drawreport/descendtree.py:1532
+#: ../gramps/plugins/drawreport/ancestortree.py:806
+#: ../gramps/plugins/drawreport/descendtree.py:1543
 msgid "The number of generations to include in the tree"
 msgstr "Anzahl der im Baum berücksichtigten Generationen"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:801
+#: ../gramps/plugins/drawreport/ancestortree.py:810
 msgid ""
 "Display unknown\n"
 "generations"
@@ -19486,16 +19566,16 @@ msgstr ""
 "Zeige unbekannte\n"
 "Generationen"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:803
+#: ../gramps/plugins/drawreport/ancestortree.py:812
 msgid "The number of generations of empty boxes that will be displayed"
 msgstr "Die Anzahl der Generationen mit leeren Boxen, die angezeigt werden."
 
-#: ../gramps/plugins/drawreport/ancestortree.py:810
-#: ../gramps/plugins/drawreport/descendtree.py:1540
+#: ../gramps/plugins/drawreport/ancestortree.py:819
+#: ../gramps/plugins/drawreport/descendtree.py:1560
 msgid "Compress tree"
 msgstr "Baum komprimieren"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:812
+#: ../gramps/plugins/drawreport/ancestortree.py:821
 msgid ""
 "Whether to remove any extra blank spaces set aside for people that are "
 "unknown"
@@ -19503,46 +19583,46 @@ msgstr ""
 "Legt fest, ob zusätzliche Leerzeichen, die für unbekannte Personen "
 "vorgesehen sind, entfernt werden oder nicht."
 
-#: ../gramps/plugins/drawreport/ancestortree.py:829
-#: ../gramps/plugins/drawreport/descendtree.py:1655
+#: ../gramps/plugins/drawreport/ancestortree.py:838
+#: ../gramps/plugins/drawreport/descendtree.py:1673
 msgid "Report Title"
 msgstr "Berichttitel"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:830
-#: ../gramps/plugins/drawreport/descendtree.py:1656
-#: ../gramps/plugins/drawreport/descendtree.py:1711
+#: ../gramps/plugins/drawreport/ancestortree.py:839
+#: ../gramps/plugins/drawreport/descendtree.py:1674
+#: ../gramps/plugins/drawreport/descendtree.py:1729
 msgid "Do not include a title"
 msgstr "Ohne Titel"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:831
+#: ../gramps/plugins/drawreport/ancestortree.py:840
 msgid "Include Report Title"
 msgstr "Berichttitel aufnehmen"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:832
-#: ../gramps/plugins/drawreport/descendtree.py:1664
+#: ../gramps/plugins/drawreport/ancestortree.py:841
+#: ../gramps/plugins/drawreport/descendtree.py:1682
 msgid "Choose a title for the report"
 msgstr "Wähle einen Titel für den Bericht"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:835
-#: ../gramps/plugins/drawreport/descendtree.py:1668
+#: ../gramps/plugins/drawreport/ancestortree.py:844
+#: ../gramps/plugins/drawreport/descendtree.py:1686
 msgid "Include a border"
 msgstr "Mit Rand"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:836
-#: ../gramps/plugins/drawreport/descendtree.py:1669
+#: ../gramps/plugins/drawreport/ancestortree.py:845
+#: ../gramps/plugins/drawreport/descendtree.py:1687
 msgid "Whether to make a border around the report."
 msgstr "Ob ein Rand um den Bericht gelegt wird."
 
-#: ../gramps/plugins/drawreport/ancestortree.py:839
-#: ../gramps/plugins/drawreport/descendtree.py:1672
+#: ../gramps/plugins/drawreport/ancestortree.py:848
+#: ../gramps/plugins/drawreport/descendtree.py:1690
 msgid "Include Page Numbers"
 msgstr "Mit Seitennummern"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:840
+#: ../gramps/plugins/drawreport/ancestortree.py:849
 msgid "Whether to print page numbers on each page."
 msgstr "Ob Seitennummern auf jeder Seite des Berichts gedruckt werden."
 
-#: ../gramps/plugins/drawreport/ancestortree.py:848
+#: ../gramps/plugins/drawreport/ancestortree.py:857
 msgid ""
 "Father\n"
 "Display Format"
@@ -19550,7 +19630,7 @@ msgstr ""
 "Vater\n"
 "Anzeigeformat"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:852
+#: ../gramps/plugins/drawreport/ancestortree.py:861
 msgid "Display format for the fathers box."
 msgstr "Anzeigeformat für die Vaterbox."
 
@@ -19561,7 +19641,7 @@ msgstr "Anzeigeformat für die Vaterbox."
 #. missing.set_help(_("What will print when information is not known"))
 #. menu.add_option(category_name, "miss_val", missing)
 #. category_name = _("Secondary")
-#: ../gramps/plugins/drawreport/ancestortree.py:865
+#: ../gramps/plugins/drawreport/ancestortree.py:874
 msgid ""
 "Mother\n"
 "Display Format"
@@ -19569,11 +19649,11 @@ msgstr ""
 "Mutter\n"
 "Anzeigeformat"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:870
+#: ../gramps/plugins/drawreport/ancestortree.py:879
 msgid "Display format for the mothers box."
 msgstr "Anzeigeformat für die Mutterbox."
 
-#: ../gramps/plugins/drawreport/ancestortree.py:873
+#: ../gramps/plugins/drawreport/ancestortree.py:882
 msgid ""
 "Center person uses\n"
 "which format"
@@ -19581,30 +19661,30 @@ msgstr ""
 "Zentrale Person verwendet\n"
 "welches Format"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:875
+#: ../gramps/plugins/drawreport/ancestortree.py:884
 msgid "Use Fathers Display format"
 msgstr "Verwende Anzeigeformat des Vaters"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:876
+#: ../gramps/plugins/drawreport/ancestortree.py:885
 msgid "Use Mothers display format"
 msgstr "Verwende Anzeigeformat der Mutter"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:877
+#: ../gramps/plugins/drawreport/ancestortree.py:886
 msgid "Which Display format to use the center person"
 msgstr "Welches Anzeigeformat für die zentrale Person verwendet wird"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:880
-#: ../gramps/plugins/drawreport/descendtree.py:1582
+#: ../gramps/plugins/drawreport/ancestortree.py:889
+#: ../gramps/plugins/drawreport/descendtree.py:1600
 msgid "Include Marriage box"
 msgstr "Heiratsboxen aufnehmen"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:882
-#: ../gramps/plugins/drawreport/descendtree.py:1584
+#: ../gramps/plugins/drawreport/ancestortree.py:891
+#: ../gramps/plugins/drawreport/descendtree.py:1602
 msgid "Whether to include a separate marital box in the report"
 msgstr "Ob eine extra Ehebox in dem Bericht enthalten ist"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:885
-#: ../gramps/plugins/drawreport/descendtree.py:1587
+#: ../gramps/plugins/drawreport/ancestortree.py:894
+#: ../gramps/plugins/drawreport/descendtree.py:1605
 msgid ""
 "Marriage\n"
 "Display Format"
@@ -19612,38 +19692,38 @@ msgstr ""
 "Heirat\n"
 "Anzeigeformat"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:886
-#: ../gramps/plugins/drawreport/descendtree.py:1588
+#: ../gramps/plugins/drawreport/ancestortree.py:895
+#: ../gramps/plugins/drawreport/descendtree.py:1606
 msgid "Display format for the marital box."
 msgstr "Anzeigeformat für die Ehebox."
 
-#: ../gramps/plugins/drawreport/ancestortree.py:892
-#: ../gramps/plugins/drawreport/descendtree.py:1603
+#: ../gramps/plugins/drawreport/ancestortree.py:901
+#: ../gramps/plugins/drawreport/descendtree.py:1621
 msgid "Scale tree to fit"
 msgstr "Baum passend skalieren"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:893
-#: ../gramps/plugins/drawreport/descendtree.py:1604
+#: ../gramps/plugins/drawreport/ancestortree.py:902
+#: ../gramps/plugins/drawreport/descendtree.py:1622
 msgid "Do not scale tree"
 msgstr "Baum nicht skalieren"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:894
-#: ../gramps/plugins/drawreport/descendtree.py:1605
+#: ../gramps/plugins/drawreport/ancestortree.py:903
+#: ../gramps/plugins/drawreport/descendtree.py:1623
 msgid "Scale tree to fit page width only"
 msgstr "Baum nur auf Seitenbreite skalieren"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:895
-#: ../gramps/plugins/drawreport/descendtree.py:1606
+#: ../gramps/plugins/drawreport/ancestortree.py:904
+#: ../gramps/plugins/drawreport/descendtree.py:1624
 msgid "Scale tree to fit the size of the page"
 msgstr "Baum auf Seitengröße skalieren"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:897
-#: ../gramps/plugins/drawreport/descendtree.py:1608
+#: ../gramps/plugins/drawreport/ancestortree.py:906
+#: ../gramps/plugins/drawreport/descendtree.py:1626
 msgid "Whether to scale the tree to fit a specific paper size"
 msgstr "Ob der Baum auf eine bestimmte Papiergröße skaliert wird"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:904
-#: ../gramps/plugins/drawreport/descendtree.py:1615
+#: ../gramps/plugins/drawreport/ancestortree.py:913
+#: ../gramps/plugins/drawreport/descendtree.py:1633
 msgid ""
 "Resize Page to Fit Tree size\n"
 "\n"
@@ -19653,8 +19733,8 @@ msgstr ""
 "\n"
 "Beachte: dies überschreibt die Optionen im Reiter 'Papieroptionen'."
 
-#: ../gramps/plugins/drawreport/ancestortree.py:910
-#: ../gramps/plugins/drawreport/descendtree.py:1621
+#: ../gramps/plugins/drawreport/ancestortree.py:919
+#: ../gramps/plugins/drawreport/descendtree.py:1639
 msgid ""
 "Whether to resize the page to fit the size \n"
 "of the tree.  Note:  the page will have a \n"
@@ -19685,33 +19765,33 @@ msgstr ""
 "'Baum auf Seitengröße skalieren' paßt die Seite so an,\n"
 " dass jeder Abstand/Zwischenraum in der Höhe und Breite entfernt wird."
 
-#: ../gramps/plugins/drawreport/ancestortree.py:930
+#: ../gramps/plugins/drawreport/ancestortree.py:939
 msgid "inter-box scale factor"
 msgstr "Faktor für den Kästchenabstand"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:933
+#: ../gramps/plugins/drawreport/ancestortree.py:942
 msgid "Make the inter-box spacing bigger or smaller"
 msgstr "Vergrößere oder verkleinere den Abstand zwischen Kästchen"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:936
-#: ../gramps/plugins/drawreport/descendtree.py:1646
+#: ../gramps/plugins/drawreport/ancestortree.py:945
+#: ../gramps/plugins/drawreport/descendtree.py:1664
 msgid "box shadow scale factor"
 msgstr "Skalierungsfaktor für die Kästchenschatten"
 
 #. down to 0
-#: ../gramps/plugins/drawreport/ancestortree.py:938
-#: ../gramps/plugins/drawreport/descendtree.py:1648
+#: ../gramps/plugins/drawreport/ancestortree.py:947
+#: ../gramps/plugins/drawreport/descendtree.py:1666
 msgid "Make the box shadow bigger or smaller"
 msgstr "Macht den Schatten der Kästchen größer oder kleiner"
 
 #. #################
-#: ../gramps/plugins/drawreport/ancestortree.py:943
-#: ../gramps/plugins/drawreport/descendtree.py:1592
+#: ../gramps/plugins/drawreport/ancestortree.py:952
+#: ../gramps/plugins/drawreport/descendtree.py:1610
 msgid "Replace"
 msgstr "Ersetze"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:946
-#: ../gramps/plugins/drawreport/descendtree.py:1595
+#: ../gramps/plugins/drawreport/ancestortree.py:955
+#: ../gramps/plugins/drawreport/descendtree.py:1613
 msgid ""
 "Replace Display Format:\n"
 "'Replace this'/' with this'"
@@ -19719,8 +19799,8 @@ msgstr ""
 "Anzeigeformat austauschen:\n"
 "'Ersetze dieses'/'Durch dieses'"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:948
-#: ../gramps/plugins/drawreport/descendtree.py:1597
+#: ../gramps/plugins/drawreport/ancestortree.py:957
+#: ../gramps/plugins/drawreport/descendtree.py:1615
 msgid ""
 "i.e.\n"
 "United States of America/U.S.A"
@@ -19728,13 +19808,13 @@ msgstr ""
 "z.B.\n"
 "Vereinigte Staaten von Amerika/U.S.A"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:955
-#: ../gramps/plugins/drawreport/descendtree.py:1676
+#: ../gramps/plugins/drawreport/ancestortree.py:964
+#: ../gramps/plugins/drawreport/descendtree.py:1694
 msgid "Include Blank Pages"
 msgstr "Enthält leere Seiten"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:956
-#: ../gramps/plugins/drawreport/descendtree.py:1677
+#: ../gramps/plugins/drawreport/ancestortree.py:965
+#: ../gramps/plugins/drawreport/descendtree.py:1695
 msgid "Whether to include pages that are blank."
 msgstr "Ob leere Seiten enthalten sind."
 
@@ -19745,18 +19825,18 @@ msgstr "Ob leere Seiten enthalten sind."
 #. _("Whether to include thumbnails of people."))
 #. menu.add_option(category_name, "includeImages", self.__include_images)
 #. category_name = _("Notes")
-#: ../gramps/plugins/drawreport/ancestortree.py:970
-#: ../gramps/plugins/drawreport/descendtree.py:1682
+#: ../gramps/plugins/drawreport/ancestortree.py:979
+#: ../gramps/plugins/drawreport/descendtree.py:1700
 msgid "Include a note"
 msgstr "Eine Notiz aufnehmen"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:971
-#: ../gramps/plugins/drawreport/descendtree.py:1684
+#: ../gramps/plugins/drawreport/ancestortree.py:980
+#: ../gramps/plugins/drawreport/descendtree.py:1702
 msgid "Whether to include a note on the report."
 msgstr "Ob eine Notiz auf dem Bericht enthalten ist."
 
-#: ../gramps/plugins/drawreport/ancestortree.py:976
-#: ../gramps/plugins/drawreport/descendtree.py:1689
+#: ../gramps/plugins/drawreport/ancestortree.py:985
+#: ../gramps/plugins/drawreport/descendtree.py:1707
 msgid ""
 "Add a note\n"
 "\n"
@@ -19766,55 +19846,55 @@ msgstr ""
 "\n"
 "$T heutiges Datum einfügen"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:981
-#: ../gramps/plugins/drawreport/descendtree.py:1694
+#: ../gramps/plugins/drawreport/ancestortree.py:990
+#: ../gramps/plugins/drawreport/descendtree.py:1712
 msgid "Note Location"
 msgstr "Position der Notiz"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:984
-#: ../gramps/plugins/drawreport/descendtree.py:1697
+#: ../gramps/plugins/drawreport/ancestortree.py:993
+#: ../gramps/plugins/drawreport/descendtree.py:1715
 msgid "Where to place the note."
 msgstr "Wo die Notiz platziert wird."
 
-#: ../gramps/plugins/drawreport/ancestortree.py:999
+#: ../gramps/plugins/drawreport/ancestortree.py:1008
 msgid "No generations of empty boxes for unknown ancestors"
 msgstr "Keine leeren Boxen für unbekannte Vorfahren erzeugen"
 
-#: ../gramps/plugins/drawreport/ancestortree.py:1002
+#: ../gramps/plugins/drawreport/ancestortree.py:1011
 msgid "One Generation of empty boxes for unknown ancestors"
 msgstr "Eine Generation leerer Boxen für unbekannte Vorfahren erzeugen."
 
-#: ../gramps/plugins/drawreport/ancestortree.py:1007
+#: ../gramps/plugins/drawreport/ancestortree.py:1016
 msgid " Generations of empty boxes for unknown ancestors"
 msgstr "Leere Boxen für unbekannte Vorfahren erzeugen."
 
-#: ../gramps/plugins/drawreport/ancestortree.py:1023
-#: ../gramps/plugins/drawreport/descendtree.py:1745
-#: ../gramps/plugins/textreport/ancestorreport.py:363
-#: ../gramps/plugins/textreport/detancestralreport.py:952
-#: ../gramps/plugins/textreport/detdescendantreport.py:1127
-#: ../gramps/plugins/textreport/endoflinereport.py:305
-#: ../gramps/plugins/textreport/endoflinereport.py:324
-#: ../gramps/plugins/textreport/familygroup.py:851
-#: ../gramps/plugins/textreport/indivcomplete.py:1152
-#: ../gramps/plugins/textreport/kinshipreport.py:410
-#: ../gramps/plugins/textreport/notelinkreport.py:193
-#: ../gramps/plugins/textreport/numberofancestorsreport.py:225
-#: ../gramps/plugins/textreport/recordsreport.py:320
-#: ../gramps/plugins/textreport/summary.py:326
-#: ../gramps/plugins/textreport/tagreport.py:960
+#: ../gramps/plugins/drawreport/ancestortree.py:1032
+#: ../gramps/plugins/drawreport/descendtree.py:1763
+#: ../gramps/plugins/textreport/ancestorreport.py:372
+#: ../gramps/plugins/textreport/detancestralreport.py:961
+#: ../gramps/plugins/textreport/detdescendantreport.py:1191
+#: ../gramps/plugins/textreport/endoflinereport.py:314
+#: ../gramps/plugins/textreport/endoflinereport.py:333
+#: ../gramps/plugins/textreport/familygroup.py:860
+#: ../gramps/plugins/textreport/indivcomplete.py:1203
+#: ../gramps/plugins/textreport/kinshipreport.py:421
+#: ../gramps/plugins/textreport/notelinkreport.py:198
+#: ../gramps/plugins/textreport/numberofancestorsreport.py:234
+#: ../gramps/plugins/textreport/recordsreport.py:336
+#: ../gramps/plugins/textreport/summary.py:330
+#: ../gramps/plugins/textreport/tagreport.py:964
 msgid "The basic style used for the text display."
 msgstr "Der Basisstil, der für die Textanzeige verwendet wird."
 
-#: ../gramps/plugins/drawreport/ancestortree.py:1033
-#: ../gramps/plugins/drawreport/descendtree.py:1767
-#: ../gramps/plugins/textreport/familygroup.py:863
-#: ../gramps/plugins/textreport/tagreport.py:978
+#: ../gramps/plugins/drawreport/ancestortree.py:1042
+#: ../gramps/plugins/drawreport/descendtree.py:1785
+#: ../gramps/plugins/textreport/familygroup.py:872
+#: ../gramps/plugins/textreport/tagreport.py:982
 msgid "The basic style used for the note display."
 msgstr "Der Basisstil, der für die Notizenanzeige verwendet wird."
 
-#: ../gramps/plugins/drawreport/ancestortree.py:1043
-#: ../gramps/plugins/drawreport/descendtree.py:1735
+#: ../gramps/plugins/drawreport/ancestortree.py:1052
+#: ../gramps/plugins/drawreport/descendtree.py:1753
 msgid "The basic style used for the title display."
 msgstr "Der Basisstil, der für die Titelanzeige verwendet wird."
 
@@ -19843,13 +19923,13 @@ msgstr "Formatiere Monate..."
 
 #: ../gramps/plugins/drawreport/calendarreport.py:315
 #: ../gramps/plugins/textreport/birthdayreport.py:259
-#: ../gramps/plugins/webreport/webcal.py:1257
+#: ../gramps/plugins/webreport/webcal.py:1269
 msgid "Applying Filter..."
 msgstr "Wende Filter an..."
 
 #: ../gramps/plugins/drawreport/calendarreport.py:322
 #: ../gramps/plugins/textreport/birthdayreport.py:269
-#: ../gramps/plugins/webreport/webcal.py:1262
+#: ../gramps/plugins/webreport/webcal.py:1274
 msgid "Reading database..."
 msgstr "Lese Datenbank..."
 
@@ -19893,288 +19973,287 @@ msgstr[1] ""
 "{spouse} und\n"
 " {person}, {nyears}"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:470
-#: ../gramps/plugins/webreport/webcal.py:1608
+#: ../gramps/plugins/drawreport/calendarreport.py:474
+#: ../gramps/plugins/webreport/webcal.py:1626
 msgid "Select filter to restrict people that appear on calendar"
 msgstr ""
 "Benutze den Filter, um Personen auszuschliessen, die im Kalender erscheinen."
 
-#: ../gramps/plugins/drawreport/calendarreport.py:475
-#: ../gramps/plugins/drawreport/fanchart.py:681
-#: ../gramps/plugins/graph/gvrelgraph.py:673
-#: ../gramps/plugins/textreport/ancestorreport.py:275
-#: ../gramps/plugins/textreport/birthdayreport.py:424
-#: ../gramps/plugins/textreport/descendreport.py:421
-#: ../gramps/plugins/textreport/detancestralreport.py:774
-#: ../gramps/plugins/textreport/detdescendantreport.py:926
-#: ../gramps/plugins/textreport/endoflinereport.py:263
-#: ../gramps/plugins/textreport/kinshipreport.py:349
-#: ../gramps/plugins/textreport/numberofancestorsreport.py:197
+#: ../gramps/plugins/drawreport/calendarreport.py:479
+#: ../gramps/plugins/drawreport/fanchart.py:689
+#: ../gramps/plugins/graph/gvrelgraph.py:676
+#: ../gramps/plugins/textreport/ancestorreport.py:284
+#: ../gramps/plugins/textreport/descendreport.py:507
+#: ../gramps/plugins/textreport/detancestralreport.py:783
+#: ../gramps/plugins/textreport/detdescendantreport.py:979
+#: ../gramps/plugins/textreport/endoflinereport.py:272
+#: ../gramps/plugins/textreport/kinshipreport.py:358
+#: ../gramps/plugins/textreport/numberofancestorsreport.py:206
 msgid "The center person for the report"
 msgstr "Die Hauptperson für den Bericht"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:486
-#: ../gramps/plugins/textreport/birthdayreport.py:435
-#: ../gramps/plugins/webreport/webcal.py:1637
+#: ../gramps/plugins/drawreport/calendarreport.py:490
+#: ../gramps/plugins/textreport/birthdayreport.py:433
+#: ../gramps/plugins/webreport/webcal.py:1655
 msgid "Include only living people"
 msgstr "Nur lebende Personen einbeziehen"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:487
-#: ../gramps/plugins/webreport/webcal.py:1638
+#: ../gramps/plugins/drawreport/calendarreport.py:491
+#: ../gramps/plugins/webreport/webcal.py:1656
 msgid "Include only living people in the calendar"
 msgstr "Kalender nur mit lebenden Personen"
 
 #. #########################
-#: ../gramps/plugins/drawreport/calendarreport.py:493
-#: ../gramps/plugins/webreport/webcal.py:1666
+#: ../gramps/plugins/drawreport/calendarreport.py:497
+#: ../gramps/plugins/webreport/webcal.py:1685
 msgid "Content Options"
 msgstr "Inhaltsoptionen"
 
 #. #########################
-#: ../gramps/plugins/drawreport/calendarreport.py:497
-#: ../gramps/plugins/drawreport/calendarreport.py:499
+#: ../gramps/plugins/drawreport/calendarreport.py:501
+#: ../gramps/plugins/drawreport/calendarreport.py:503
 msgid "Year of calendar"
 msgstr "Kalenderjahr"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:502
-#: ../gramps/plugins/textreport/birthdayreport.py:439
-#: ../gramps/plugins/webreport/webcal.py:1692
+#: ../gramps/plugins/drawreport/calendarreport.py:506
+#: ../gramps/plugins/textreport/birthdayreport.py:448
+#: ../gramps/plugins/webreport/webcal.py:1711
 msgid "Country for holidays"
 msgstr "Land für Feiertage"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:513
-#: ../gramps/plugins/textreport/birthdayreport.py:450
+#: ../gramps/plugins/drawreport/calendarreport.py:517
+#: ../gramps/plugins/textreport/birthdayreport.py:459
 msgid "Select the country to see associated holidays"
 msgstr "Wähle ein Land aus, um die dazugehörigen Feiertage zu sehen."
 
 #. Default selection ????
-#: ../gramps/plugins/drawreport/calendarreport.py:516
-#: ../gramps/plugins/textreport/birthdayreport.py:453
-#: ../gramps/plugins/webreport/webcal.py:1708
+#: ../gramps/plugins/drawreport/calendarreport.py:520
+#: ../gramps/plugins/textreport/birthdayreport.py:462
+#: ../gramps/plugins/webreport/webcal.py:1727
 msgid "First day of week"
 msgstr "Erster Tag der Woche"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:521
-#: ../gramps/plugins/webreport/webcal.py:1712
+#: ../gramps/plugins/drawreport/calendarreport.py:525
+#: ../gramps/plugins/webreport/webcal.py:1730
 msgid "Select the first day of the week for the calendar"
 msgstr "Wähle den ersten Tag der Kalenderwoche."
 
-#: ../gramps/plugins/drawreport/calendarreport.py:524
-#: ../gramps/plugins/textreport/birthdayreport.py:461
-#: ../gramps/plugins/webreport/webcal.py:1716
+#: ../gramps/plugins/drawreport/calendarreport.py:528
+#: ../gramps/plugins/textreport/birthdayreport.py:470
+#: ../gramps/plugins/webreport/webcal.py:1734
 msgid "Birthday surname"
 msgstr "Nachname bei Geburtstagen"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:525
-#: ../gramps/plugins/textreport/birthdayreport.py:462
-#: ../gramps/plugins/webreport/webcal.py:1717
+#: ../gramps/plugins/drawreport/calendarreport.py:529
+#: ../gramps/plugins/textreport/birthdayreport.py:471
+#: ../gramps/plugins/webreport/webcal.py:1735
 msgid "Wives use husband's surname (from first family listed)"
 msgstr ""
 "Frauen benutzen den Nachnamen vom Mann (von der ersten gelisteten Familie)"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:526
-#: ../gramps/plugins/textreport/birthdayreport.py:463
-#: ../gramps/plugins/webreport/webcal.py:1719
+#: ../gramps/plugins/drawreport/calendarreport.py:530
+#: ../gramps/plugins/textreport/birthdayreport.py:472
+#: ../gramps/plugins/webreport/webcal.py:1737
 msgid "Wives use husband's surname (from last family listed)"
 msgstr ""
 "Frauen benutzen den Nachnamen vom Mann (von der letzten gelisteten Familie)"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:527
-#: ../gramps/plugins/textreport/birthdayreport.py:464
-#: ../gramps/plugins/webreport/webcal.py:1721
+#: ../gramps/plugins/drawreport/calendarreport.py:531
+#: ../gramps/plugins/textreport/birthdayreport.py:473
+#: ../gramps/plugins/webreport/webcal.py:1739
 msgid "Wives use their own surname"
 msgstr "Frauen benutzen ihren Mädchennamen"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:528
-#: ../gramps/plugins/textreport/birthdayreport.py:465
-#: ../gramps/plugins/webreport/webcal.py:1722
+#: ../gramps/plugins/drawreport/calendarreport.py:532
+#: ../gramps/plugins/textreport/birthdayreport.py:474
+#: ../gramps/plugins/webreport/webcal.py:1740
 msgid "Select married women's displayed surname"
 msgstr "Wähle den anzuzeigenden Nachnamen für verheiratete Frauen."
 
-#: ../gramps/plugins/drawreport/calendarreport.py:531
-#: ../gramps/plugins/textreport/birthdayreport.py:468
-#: ../gramps/plugins/webreport/webcal.py:1732
+#: ../gramps/plugins/drawreport/calendarreport.py:535
+#: ../gramps/plugins/textreport/birthdayreport.py:477
+#: ../gramps/plugins/webreport/webcal.py:1750
 msgid "Include birthdays"
 msgstr "Geburtstage mit einbeziehen"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:532
-#: ../gramps/plugins/webreport/webcal.py:1733
+#: ../gramps/plugins/drawreport/calendarreport.py:536
+#: ../gramps/plugins/webreport/webcal.py:1751
 msgid "Include birthdays in the calendar"
 msgstr "Kalender mit Geburtstagen"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:535
-#: ../gramps/plugins/textreport/birthdayreport.py:472
-#: ../gramps/plugins/webreport/webcal.py:1736
+#: ../gramps/plugins/drawreport/calendarreport.py:539
+#: ../gramps/plugins/textreport/birthdayreport.py:481
+#: ../gramps/plugins/webreport/webcal.py:1754
 msgid "Include anniversaries"
 msgstr "Jubiläen mit einbeziehen"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:536
-#: ../gramps/plugins/webreport/webcal.py:1737
+#: ../gramps/plugins/drawreport/calendarreport.py:540
+#: ../gramps/plugins/webreport/webcal.py:1755
 msgid "Include anniversaries in the calendar"
 msgstr "Kalender mit Jubiläen"
 
 #. #########################
-#: ../gramps/plugins/drawreport/calendarreport.py:540
-#: ../gramps/plugins/drawreport/calendarreport.py:541
-#: ../gramps/plugins/textreport/birthdayreport.py:483
+#: ../gramps/plugins/drawreport/calendarreport.py:544
+#: ../gramps/plugins/drawreport/calendarreport.py:545
+#: ../gramps/plugins/textreport/birthdayreport.py:490
 msgid "Text Options"
 msgstr "Textoptionen"
 
 #. #########################
-#: ../gramps/plugins/drawreport/calendarreport.py:544
-#: ../gramps/plugins/textreport/birthdayreport.py:489
+#: ../gramps/plugins/drawreport/calendarreport.py:548
+#: ../gramps/plugins/textreport/birthdayreport.py:496
 msgid "Text Area 1"
 msgstr "Textbereich 1"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:545
+#: ../gramps/plugins/drawreport/calendarreport.py:549
 msgid "First line of text at bottom of calendar"
 msgstr "Erste Textzeile am Fuß des Kalenders."
 
-#: ../gramps/plugins/drawreport/calendarreport.py:548
-#: ../gramps/plugins/textreport/birthdayreport.py:493
+#: ../gramps/plugins/drawreport/calendarreport.py:552
+#: ../gramps/plugins/textreport/birthdayreport.py:500
 msgid "Text Area 2"
 msgstr "Textbereich 2"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:549
+#: ../gramps/plugins/drawreport/calendarreport.py:553
 msgid "Second line of text at bottom of calendar"
 msgstr "Zweite Textzeile am Fuß des Kalenders."
 
-#: ../gramps/plugins/drawreport/calendarreport.py:552
-#: ../gramps/plugins/textreport/birthdayreport.py:497
+#: ../gramps/plugins/drawreport/calendarreport.py:556
+#: ../gramps/plugins/textreport/birthdayreport.py:504
 msgid "Text Area 3"
 msgstr "Textbereich 3"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:553
+#: ../gramps/plugins/drawreport/calendarreport.py:557
 msgid "Third line of text at bottom of calendar"
 msgstr "Dritte Textzeile am Fuß des Kalenders."
 
-#: ../gramps/plugins/drawreport/calendarreport.py:623
+#: ../gramps/plugins/drawreport/calendarreport.py:626
 msgid "Title text and background color"
 msgstr "Titeltext und Hintergrundfarbe"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:627
+#: ../gramps/plugins/drawreport/calendarreport.py:630
 msgid "Calendar day numbers"
 msgstr "Kalendertag-Nummer"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:630
+#: ../gramps/plugins/drawreport/calendarreport.py:633
 msgid "Daily text display"
 msgstr "Tagestext Anzeige"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:632
+#: ../gramps/plugins/drawreport/calendarreport.py:635
 msgid "Holiday text display"
 msgstr "Feiertagstext Anzeige"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:635
+#: ../gramps/plugins/drawreport/calendarreport.py:638
 msgid "Days of the week text"
 msgstr "Text der Wochentage"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:639
-#: ../gramps/plugins/textreport/birthdayreport.py:565
+#: ../gramps/plugins/drawreport/calendarreport.py:642
+#: ../gramps/plugins/textreport/birthdayreport.py:584
 msgid "Text at bottom, line 1"
 msgstr "Text unten, Zeile 1"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:641
-#: ../gramps/plugins/textreport/birthdayreport.py:567
+#: ../gramps/plugins/drawreport/calendarreport.py:644
+#: ../gramps/plugins/textreport/birthdayreport.py:586
 msgid "Text at bottom, line 2"
 msgstr "Text unten, Zeile 2"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:643
-#: ../gramps/plugins/textreport/birthdayreport.py:569
+#: ../gramps/plugins/drawreport/calendarreport.py:646
+#: ../gramps/plugins/textreport/birthdayreport.py:588
 msgid "Text at bottom, line 3"
 msgstr "Text unten, Zeile 3"
 
-#: ../gramps/plugins/drawreport/descendtree.py:156
+#: ../gramps/plugins/drawreport/descendtree.py:158
 #, python-format
 msgid "Descendant Chart for %(person)s and %(father1)s, %(mother1)s"
 msgstr "Nachkommenschaubild für %(person)s und %(father1)s, %(mother1)s"
 
 #. Should be 2 items in names list
-#: ../gramps/plugins/drawreport/descendtree.py:163
+#: ../gramps/plugins/drawreport/descendtree.py:165
 #, python-format
 msgid "Descendant Chart for %(person)s, %(father1)s and %(mother1)s"
 msgstr "Nachkommenschaubild für %(person)s, %(father1)s und %(mother1)s"
 
 #. Should be 2 items in both names and names2 lists
-#: ../gramps/plugins/drawreport/descendtree.py:170
+#: ../gramps/plugins/drawreport/descendtree.py:172
 #, python-format
 msgid ""
 "Descendant Chart for %(father1)s, %(father2)s and %(mother1)s, %(mother2)s"
 msgstr ""
 "achkommenschaubild für %(father1)s, %(father2)s und %(mother1)s, %(mother2)s"
 
-#: ../gramps/plugins/drawreport/descendtree.py:180
+#: ../gramps/plugins/drawreport/descendtree.py:182
 #, python-format
 msgid "Descendant Chart for %(person)s"
 msgstr "Nachkommenschaubild für %(person)s"
 
 #. Should be two items in names list
-#: ../gramps/plugins/drawreport/descendtree.py:182
+#: ../gramps/plugins/drawreport/descendtree.py:184
 #, python-format
 msgid "Descendant Chart for %(father)s and %(mother)s"
 msgstr "Nachkommenschaubild von %(father)s und %(mother)s"
 
 #. we want no text, but need a text for the TOC in a book!
-#: ../gramps/plugins/drawreport/descendtree.py:211
+#: ../gramps/plugins/drawreport/descendtree.py:213
 msgid "Descendant Graph"
 msgstr "Nachkommen Grafik"
 
-#: ../gramps/plugins/drawreport/descendtree.py:324
+#: ../gramps/plugins/drawreport/descendtree.py:326
 #, python-format
 msgid "Family Chart for %(person)s"
 msgstr "Familienschaubild für %(person)s"
 
-#: ../gramps/plugins/drawreport/descendtree.py:327
+#: ../gramps/plugins/drawreport/descendtree.py:329
 #, python-format
 msgid "Family Chart for %(father1)s and %(mother1)s"
 msgstr "Familienschaubild für %(father1)s und %(mother1)s"
 
-#: ../gramps/plugins/drawreport/descendtree.py:353
+#: ../gramps/plugins/drawreport/descendtree.py:355
 #, python-format
 msgid "Cousin Chart for %(names)s"
 msgstr "Cousinenschaubild für %(names)s"
 
-#: ../gramps/plugins/drawreport/descendtree.py:755
+#: ../gramps/plugins/drawreport/descendtree.py:757
 #, python-format
 msgid "Family %s is not in the Database"
 msgstr "Familie %s ist nicht in der Datenbank"
 
 #. if self.name == "familial_descend_tree":
-#: ../gramps/plugins/drawreport/descendtree.py:1508
-#: ../gramps/plugins/drawreport/descendtree.py:1512
+#: ../gramps/plugins/drawreport/descendtree.py:1523
+#: ../gramps/plugins/drawreport/descendtree.py:1527
 msgid "Report for"
 msgstr "Bericht für"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1509
+#: ../gramps/plugins/drawreport/descendtree.py:1524
 msgid "The main person for the report"
 msgstr "Die Hauptperson für den Bericht"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1513
+#: ../gramps/plugins/drawreport/descendtree.py:1528
 msgid "The main family for the report"
 msgstr "Die zentrale Familie für den Bericht"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1523
-msgid "Start with the parent(s) of the selected first"
-msgstr "Starte mit den Eltern des zuerst gewählten"
-
-#: ../gramps/plugins/drawreport/descendtree.py:1526
-msgid "Will show the parents, brother and sisters of the selected person."
-msgstr "Zeigt die Eltern, Brüder und Schwestern der gewählten Person."
-
-#: ../gramps/plugins/drawreport/descendtree.py:1535
+#: ../gramps/plugins/drawreport/descendtree.py:1546
 msgid "Level of Spouses"
 msgstr "Ebene der Partner"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1536
+#: ../gramps/plugins/drawreport/descendtree.py:1547
 msgid "0=no Spouses, 1=include Spouses, 2=include Spouses of the spouse, etc"
 msgstr "0=keine Partner, 1=mit Partnern, 2=mit Partnern der Partner, usw"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1541
+#: ../gramps/plugins/drawreport/descendtree.py:1552
+msgid "Start with the parent(s) of the selected first"
+msgstr "Starte mit den Eltern des zuerst gewählten"
+
+#: ../gramps/plugins/drawreport/descendtree.py:1555
+msgid "Will show the parents, brother and sisters of the selected person."
+msgstr "Zeigt die Eltern, Brüder und Schwestern der gewählten Person."
+
+#: ../gramps/plugins/drawreport/descendtree.py:1561
 msgid "Whether to move people up, where possible, resulting in a smaller tree"
 msgstr ""
 "Legt fest, ob Personen, wo immer möglich nach oben verschoben werden können, "
 "um einen schmaleren Baum zu erhalten."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1550
+#: ../gramps/plugins/drawreport/descendtree.py:1568
 msgid ""
 "Descendant\n"
 "Display Format"
@@ -20182,15 +20261,15 @@ msgstr ""
 "Nachkommen\n"
 "Anzeigeformat"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1554
+#: ../gramps/plugins/drawreport/descendtree.py:1572
 msgid "Display format for a descendant."
 msgstr "Anzeigeformat für einen Nachkommen."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1557
+#: ../gramps/plugins/drawreport/descendtree.py:1575
 msgid "Bold direct descendants"
 msgstr "Direkte Nachkommen fett gedruckt"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1559
+#: ../gramps/plugins/drawreport/descendtree.py:1577
 msgid ""
 "Whether to bold those people that are direct (not step or half) descendants."
 msgstr ""
@@ -20203,15 +20282,15 @@ msgstr ""
 #. True)
 #. diffspouse.set_help(_("Whether spouses can have a different format."))
 #. menu.add_option(category_name, "diffspouse", diffspouse)
-#: ../gramps/plugins/drawreport/descendtree.py:1571
+#: ../gramps/plugins/drawreport/descendtree.py:1589
 msgid "Indent Spouses"
 msgstr "Partner einrücken"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1572
+#: ../gramps/plugins/drawreport/descendtree.py:1590
 msgid "Whether to indent the spouses in the tree."
 msgstr "Legt fest, ob Partner im Baum eingerückt werden."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1575
+#: ../gramps/plugins/drawreport/descendtree.py:1593
 msgid ""
 "Spousal\n"
 "Display Format"
@@ -20219,38 +20298,38 @@ msgstr ""
 "Ehegatten\n"
 "Anzeigeformat"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1579
+#: ../gramps/plugins/drawreport/descendtree.py:1597
 msgid "Display format for a spouse."
 msgstr "Anzeigeformat für eine(n) Partner(in)."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1641
+#: ../gramps/plugins/drawreport/descendtree.py:1659
 msgid "inter-box Y scale factor"
 msgstr "Faktor für den Y-Kästchenabstand"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1643
+#: ../gramps/plugins/drawreport/descendtree.py:1661
 msgid "Make the inter-box Y bigger or smaller"
 msgstr "Vergrößere oder verkleinere den Y-Abstand zwischen Kästchen"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1657
-#: ../gramps/plugins/drawreport/descendtree.py:1712
+#: ../gramps/plugins/drawreport/descendtree.py:1675
+#: ../gramps/plugins/drawreport/descendtree.py:1730
 msgid "Descendant Chart for [selected person(s)]"
 msgstr "Nachkommenschaubild für [gewählte Person(en)]"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1660
-#: ../gramps/plugins/drawreport/descendtree.py:1716
+#: ../gramps/plugins/drawreport/descendtree.py:1678
+#: ../gramps/plugins/drawreport/descendtree.py:1734
 msgid "Family Chart for [names of chosen family]"
 msgstr "Familienschaubild für [Namen der gewählten Familie]"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1663
-#: ../gramps/plugins/drawreport/descendtree.py:1720
+#: ../gramps/plugins/drawreport/descendtree.py:1681
+#: ../gramps/plugins/drawreport/descendtree.py:1738
 msgid "Cousin Chart for [names of children]"
 msgstr "Cousinenschaubild für [Namen der Kinder]"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1673
+#: ../gramps/plugins/drawreport/descendtree.py:1691
 msgid "Whether to include page numbers on each page."
 msgstr "Legt fest, ob Seitennummern auf jeder Seite enthalten sind."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1757
+#: ../gramps/plugins/drawreport/descendtree.py:1775
 msgid "The bold style used for the text display."
 msgstr "Der Fettdruckstil, der für die Textanzeige verwendet wird."
 
@@ -20311,7 +20390,7 @@ msgstr "Erstellt einen grafischen Nachkommenbaum um eine Familie herum."
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:172
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:118
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:127
-#: ../gramps/plugins/view/fanchartview.py:71
+#: ../gramps/plugins/view/fanchartview.py:73
 #: ../gramps/plugins/view/view.gpr.py:141
 msgid "Fan Chart"
 msgstr "Fächergrafik"
@@ -20345,12 +20424,12 @@ msgid "Produces a timeline chart."
 msgstr "Erzeugt eine Zeitliniengrafik."
 
 #. choose  one line or two lines translation according to the width
-#: ../gramps/plugins/drawreport/fanchart.py:256
+#: ../gramps/plugins/drawreport/fanchart.py:257
 #, python-format
 msgid "%(generations)d Generation Fan Chart for %(person)s"
 msgstr "%(generations)d Generationen-Fächergrafik für %(person)s"
 
-#: ../gramps/plugins/drawreport/fanchart.py:271
+#: ../gramps/plugins/drawreport/fanchart.py:272
 #, python-format
 msgid ""
 "%(generations)d Generation Fan Chart for\n"
@@ -20359,88 +20438,102 @@ msgstr ""
 "%(generations)d Generationen-Fächergrafik für\n"
 "%(person)s"
 
-#: ../gramps/plugins/drawreport/fanchart.py:689
-#: ../gramps/plugins/textreport/ancestorreport.py:285
-#: ../gramps/plugins/textreport/descendreport.py:439
-#: ../gramps/plugins/textreport/detancestralreport.py:789
-#: ../gramps/plugins/textreport/detdescendantreport.py:946
+#. Content options
+#. Content
+#: ../gramps/plugins/drawreport/fanchart.py:698
+#: ../gramps/plugins/textreport/birthdayreport.py:441
+#: ../gramps/plugins/textreport/descendreport.py:518
+#: ../gramps/plugins/textreport/detancestralreport.py:805
+#: ../gramps/plugins/textreport/detdescendantreport.py:1015
+#: ../gramps/plugins/textreport/kinshipreport.py:369
+#: ../gramps/plugins/textreport/placereport.py:442
+#: ../gramps/plugins/textreport/recordsreport.py:240
+#: ../gramps/plugins/view/relview.py:1726
+msgid "Content"
+msgstr "Inhalt"
+
+#: ../gramps/plugins/drawreport/fanchart.py:701
+#: ../gramps/plugins/textreport/ancestorreport.py:294
+#: ../gramps/plugins/textreport/descendreport.py:532
+#: ../gramps/plugins/textreport/detancestralreport.py:798
+#: ../gramps/plugins/textreport/detdescendantreport.py:1008
 msgid "The number of generations to include in the report"
 msgstr "Anzahl der im Bericht enthaltenen Generationen"
 
-#: ../gramps/plugins/drawreport/fanchart.py:693
+#: ../gramps/plugins/drawreport/fanchart.py:705
 msgid "Type of graph"
 msgstr "Diagrammart"
 
-#: ../gramps/plugins/drawreport/fanchart.py:694
+#: ../gramps/plugins/drawreport/fanchart.py:706
 msgid "full circle"
 msgstr "Vollkreis"
 
-#: ../gramps/plugins/drawreport/fanchart.py:695
+#: ../gramps/plugins/drawreport/fanchart.py:707
 msgid "half circle"
 msgstr "Halbkreis"
 
-#: ../gramps/plugins/drawreport/fanchart.py:696
+#: ../gramps/plugins/drawreport/fanchart.py:708
 msgid "quarter circle"
 msgstr "Viertelkreis"
 
-#: ../gramps/plugins/drawreport/fanchart.py:697
+#: ../gramps/plugins/drawreport/fanchart.py:709
 msgid "The form of the graph: full circle, half circle, or quarter circle."
 msgstr "Art des Diagrammes: Vollkreis, Halbkreis oder Viertelkreis."
 
-#: ../gramps/plugins/drawreport/fanchart.py:703
+#: ../gramps/plugins/drawreport/fanchart.py:715
 msgid "generation dependent"
 msgstr "von der Generation abhängig"
 
-#: ../gramps/plugins/drawreport/fanchart.py:704
+#: ../gramps/plugins/drawreport/fanchart.py:716
 msgid "Background color is either white or generation dependent"
 msgstr "Hintergrundfarbe ist entweder weiß oder von der Generation abhängig"
 
-#: ../gramps/plugins/drawreport/fanchart.py:708
+#: ../gramps/plugins/drawreport/fanchart.py:720
 msgid "Orientation of radial texts"
 msgstr "Ausrichtung von radialen Texten"
 
-#: ../gramps/plugins/drawreport/fanchart.py:710
+#: ../gramps/plugins/drawreport/fanchart.py:722
 msgid "upright"
 msgstr "Vertikal"
 
-#: ../gramps/plugins/drawreport/fanchart.py:711
+#: ../gramps/plugins/drawreport/fanchart.py:723
 msgid "roundabout"
 msgstr "ringsum"
 
-#: ../gramps/plugins/drawreport/fanchart.py:712
+#: ../gramps/plugins/drawreport/fanchart.py:724
 msgid "Print radial texts upright or roundabout"
 msgstr "Drucke strahlenförmigen Text aufrecht oder ringsum."
 
-#: ../gramps/plugins/drawreport/fanchart.py:714
+#: ../gramps/plugins/drawreport/fanchart.py:726
 msgid "Draw empty boxes"
 msgstr "Zeichne leere Kästchen"
 
-#: ../gramps/plugins/drawreport/fanchart.py:715
+#: ../gramps/plugins/drawreport/fanchart.py:727
 msgid "Draw the background although there is no information"
 msgstr "Hintergrund auch ohne Informationen zeichnen"
 
-#: ../gramps/plugins/drawreport/fanchart.py:719
+#: ../gramps/plugins/drawreport/fanchart.py:731
 msgid "Use one font style for all generations"
 msgstr "Verwende einen Schriftstil für alle Generationen"
 
-#: ../gramps/plugins/drawreport/fanchart.py:721
+#: ../gramps/plugins/drawreport/fanchart.py:733
 msgid ""
 "You can customize font and color for each generation in the style editor"
 msgstr ""
 "Du kannst die Schrift und Farbe für jede Generation im Stileditor einstellen"
 
-#: ../gramps/plugins/drawreport/fanchart.py:750
-#: ../gramps/plugins/textreport/alphabeticalindex.py:98
-#: ../gramps/plugins/textreport/recordsreport.py:293
-#: ../gramps/plugins/textreport/tableofcontents.py:97
+#: ../gramps/plugins/drawreport/fanchart.py:760
+#: ../gramps/plugins/textreport/alphabeticalindex.py:103
+#: ../gramps/plugins/textreport/recordsreport.py:309
+#: ../gramps/plugins/textreport/tableofcontents.py:102
 msgid "The style used for the title."
 msgstr "Der Stil, der für den Titel verwendet wird."
 
-#: ../gramps/plugins/drawreport/fanchart.py:760
+#: ../gramps/plugins/drawreport/fanchart.py:770
 msgid "The basic style used for the default text display."
 msgstr "Der Basisstil, der für die Standardtextanzeige verwendet wird."
 
-#: ../gramps/plugins/drawreport/fanchart.py:771
+#: ../gramps/plugins/drawreport/fanchart.py:781
 #, python-format
 msgid "The style used for the text display of generation \"%d\""
 msgstr ""
@@ -20493,14 +20586,13 @@ msgid "Death month"
 msgstr "Todesmonat"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:348
-#: ../gramps/plugins/export/exportcsv.py:382
-#: ../gramps/plugins/importer/importcsv.py:161
+#: ../gramps/plugins/export/exportcsv.py:356
+#: ../gramps/plugins/importer/importcsv.py:171
 msgid "Birth place"
 msgstr "Geburtsort"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:350
-#: ../gramps/plugins/export/exportcsv.py:384
-#: ../gramps/plugins/importer/importcsv.py:193
+#: ../gramps/plugins/export/exportcsv.py:358
 msgid "Death place"
 msgstr "Sterbeort"
 
@@ -20593,7 +20685,7 @@ msgstr "Persönliche Informationen fehlen"
 #: ../gramps/plugins/drawreport/statisticschart.py:771
 #: ../gramps/plugins/drawreport/timeline.py:118
 #: ../gramps/plugins/textreport/placereport.py:97
-#: ../gramps/plugins/textreport/recordsreport.py:91
+#: ../gramps/plugins/textreport/recordsreport.py:92
 #: ../gramps/plugins/textreport/tagreport.py:98
 #, python-format
 msgid "(Living people: %(option_name)s)"
@@ -20627,123 +20719,129 @@ msgstr "Diagramme sichern..."
 msgid "%s (persons):"
 msgstr "%s (Personen):"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:985
-#: ../gramps/plugins/textreport/recordsreport.py:215
+#: ../gramps/plugins/drawreport/statisticschart.py:989
+#: ../gramps/plugins/textreport/recordsreport.py:220
 msgid "Determines what people are included in the report."
 msgstr "Legt fest, welche Personen im Bericht enthalten sind."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:990
-#: ../gramps/plugins/drawreport/timeline.py:419
-#: ../gramps/plugins/textreport/indivcomplete.py:995
-#: ../gramps/plugins/textreport/recordsreport.py:219
+#: ../gramps/plugins/drawreport/statisticschart.py:994
+#: ../gramps/plugins/drawreport/timeline.py:423
+#: ../gramps/plugins/textreport/birthdayreport.py:423
+#: ../gramps/plugins/textreport/indivcomplete.py:1041
+#: ../gramps/plugins/textreport/recordsreport.py:224
 #: ../gramps/plugins/tool/sortevents.py:171
-#: ../gramps/plugins/webreport/narrativeweb.py:9374
-#: ../gramps/plugins/webreport/webcal.py:1612
+#: ../gramps/plugins/webreport/narrativeweb.py:9653
+#: ../gramps/plugins/webreport/webcal.py:1630
 msgid "Filter Person"
 msgstr "Personenfilter"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:991
-#: ../gramps/plugins/textreport/indivcomplete.py:996
+#: ../gramps/plugins/drawreport/statisticschart.py:995
+#: ../gramps/plugins/textreport/birthdayreport.py:424
+#: ../gramps/plugins/textreport/indivcomplete.py:1042
 msgid "The center person for the filter."
 msgstr "Die Hauptperson für den Filter."
 
 #. ###############################
-#: ../gramps/plugins/drawreport/statisticschart.py:1007
+#: ../gramps/plugins/drawreport/statisticschart.py:1011
 msgid "Report Details"
 msgstr "Berichtdetails"
 
 #. ###############################
-#: ../gramps/plugins/drawreport/statisticschart.py:1011
+#: ../gramps/plugins/drawreport/statisticschart.py:1015
 msgid "Sort chart items by"
 msgstr "Sortiere Diagrammeinträge nach"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1016
+#: ../gramps/plugins/drawreport/statisticschart.py:1020
 msgid "Select how the statistical data is sorted."
 msgstr "Wähle aus, wie die statistischen Daten sortiert werden sollen."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1019
+#: ../gramps/plugins/drawreport/statisticschart.py:1023
 msgid "Sort in reverse order"
 msgstr "In umgekehrter Reihenfolge sortieren"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1020
+#: ../gramps/plugins/drawreport/statisticschart.py:1024
 msgid "Check to reverse the sorting order."
 msgstr "Markieren, um die Sortierung umzukehren."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1024
+#: ../gramps/plugins/drawreport/statisticschart.py:1028
 msgid "People Born After"
 msgstr "Personen geboren nach"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1026
+#: ../gramps/plugins/drawreport/statisticschart.py:1030
 msgid "Birth year from which to include people."
 msgstr "Geburtsjahr, ab dem Personen enthalten sind."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1029
+#: ../gramps/plugins/drawreport/statisticschart.py:1033
 msgid "People Born Before"
 msgstr "Personen geboren vor"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1031
+#: ../gramps/plugins/drawreport/statisticschart.py:1035
 msgid "Birth year until which to include people"
 msgstr "Geburtsjahr, bis zu dem Personen enthalten sind."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1034
+#: ../gramps/plugins/drawreport/statisticschart.py:1038
 msgid "Include people without known birth years"
 msgstr "Personen ohne Geburtsjahr einbeziehen"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1036
+#: ../gramps/plugins/drawreport/statisticschart.py:1040
 msgid "Whether to include people without known birth years."
 msgstr "Legt fest, ob Personen ohne bekanntes Geburtsjahr aufgenommen werden."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1040
+#: ../gramps/plugins/drawreport/statisticschart.py:1044
 msgid "Genders included"
 msgstr "Geschlechter aufnehmen"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1045
+#: ../gramps/plugins/drawreport/statisticschart.py:1049
 msgid "Select which genders are included into statistics."
 msgstr ""
 "Wähle aus, welche Geschlechter in die Statistik aufgenommen werden sollen."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1049
+#: ../gramps/plugins/drawreport/statisticschart.py:1053
 msgid "Max. items for a pie"
 msgstr "Max. Stücke für ein Tortendiagramm"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1050
+#: ../gramps/plugins/drawreport/statisticschart.py:1054
 msgid ""
 "With fewer items pie chart and legend will be used instead of a bar chart."
 msgstr ""
 "Mit weniger Einträgen wird ein Tortendiagramm mit Legende verwendet anstatt "
 "eines Balkendiagramms."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1065
-msgid "Charts 1"
-msgstr "Grafiken 1"
+#: ../gramps/plugins/drawreport/statisticschart.py:1069
+msgid "Charts 3"
+msgstr "Grafiken 3"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1067
+#: ../gramps/plugins/drawreport/statisticschart.py:1071
 msgid "Charts 2"
 msgstr "Grafiken 2"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1069
+#: ../gramps/plugins/drawreport/statisticschart.py:1073
+msgid "Charts 1"
+msgstr "Grafiken 1"
+
+#: ../gramps/plugins/drawreport/statisticschart.py:1075
 msgid "Include charts with indicated data."
 msgstr "Grafiken mit angezeigten Datum aufnehmen."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1112
+#: ../gramps/plugins/drawreport/statisticschart.py:1117
 msgid "The style used for the items and values."
 msgstr "Der Stil, der für Artikel und Werte verwendet wird."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1121
-#: ../gramps/plugins/drawreport/timeline.py:494
-#: ../gramps/plugins/textreport/ancestorreport.py:340
-#: ../gramps/plugins/textreport/descendreport.py:471
-#: ../gramps/plugins/textreport/detancestralreport.py:906
-#: ../gramps/plugins/textreport/detdescendantreport.py:1081
-#: ../gramps/plugins/textreport/endoflinereport.py:287
-#: ../gramps/plugins/textreport/familygroup.py:842
-#: ../gramps/plugins/textreport/indivcomplete.py:1120
-#: ../gramps/plugins/textreport/kinshipreport.py:392
-#: ../gramps/plugins/textreport/notelinkreport.py:173
-#: ../gramps/plugins/textreport/numberofancestorsreport.py:218
-#: ../gramps/plugins/textreport/simplebooktitle.py:167
-#: ../gramps/plugins/textreport/summary.py:307
-#: ../gramps/plugins/textreport/tagreport.py:929
+#: ../gramps/plugins/drawreport/statisticschart.py:1126
+#: ../gramps/plugins/drawreport/timeline.py:497
+#: ../gramps/plugins/textreport/ancestorreport.py:349
+#: ../gramps/plugins/textreport/descendreport.py:562
+#: ../gramps/plugins/textreport/detancestralreport.py:915
+#: ../gramps/plugins/textreport/detdescendantreport.py:1145
+#: ../gramps/plugins/textreport/endoflinereport.py:296
+#: ../gramps/plugins/textreport/familygroup.py:851
+#: ../gramps/plugins/textreport/indivcomplete.py:1171
+#: ../gramps/plugins/textreport/kinshipreport.py:403
+#: ../gramps/plugins/textreport/notelinkreport.py:178
+#: ../gramps/plugins/textreport/numberofancestorsreport.py:227
+#: ../gramps/plugins/textreport/simplebooktitle.py:171
+#: ../gramps/plugins/textreport/summary.py:311
+#: ../gramps/plugins/textreport/tagreport.py:933
 msgid "The style used for the title of the page."
 msgstr "Der Stil, der für den Seitentitel verwendet wird."
 
@@ -20765,7 +20863,7 @@ msgid "Timeline"
 msgstr "Zeitleiste"
 
 #: ../gramps/plugins/drawreport/timeline.py:133
-#: ../gramps/plugins/textreport/familygroup.py:662
+#: ../gramps/plugins/textreport/familygroup.py:663
 msgid "Applying filter..."
 msgstr "Wende Filter an..."
 
@@ -20791,33 +20889,33 @@ msgstr "Keine Datumsinformation"
 msgid "Finding date range..."
 msgstr "Finde Zeitraum..."
 
-#: ../gramps/plugins/drawreport/timeline.py:415
+#: ../gramps/plugins/drawreport/timeline.py:419
 msgid "Determines what people are included in the report"
 msgstr "Legt fest, welche Personen im Bericht enthalten sind."
 
-#: ../gramps/plugins/drawreport/timeline.py:420
-#: ../gramps/plugins/textreport/recordsreport.py:220
+#: ../gramps/plugins/drawreport/timeline.py:424
+#: ../gramps/plugins/textreport/recordsreport.py:225
 #: ../gramps/plugins/tool/sortevents.py:172
-#: ../gramps/plugins/webreport/narrativeweb.py:9375
-#: ../gramps/plugins/webreport/webcal.py:1613
+#: ../gramps/plugins/webreport/narrativeweb.py:9654
+#: ../gramps/plugins/webreport/webcal.py:1631
 msgid "The center person for the filter"
 msgstr "Die Hauptperson für den Filter"
 
-#: ../gramps/plugins/drawreport/timeline.py:433
+#: ../gramps/plugins/drawreport/timeline.py:437
 #: ../gramps/plugins/tool/sortevents.py:178
 msgid "Sort by"
 msgstr "Sortieren nach"
 
-#: ../gramps/plugins/drawreport/timeline.py:438
+#: ../gramps/plugins/drawreport/timeline.py:442
 #: ../gramps/plugins/tool/sortevents.py:183
 msgid "Sorting method to use"
 msgstr "Zu verwendendes Sortierverfahren"
 
-#: ../gramps/plugins/drawreport/timeline.py:476
+#: ../gramps/plugins/drawreport/timeline.py:479
 msgid "The style used for the person's name."
 msgstr "Der Stil, der für den Namen der Person verwendet wird."
 
-#: ../gramps/plugins/drawreport/timeline.py:485
+#: ../gramps/plugins/drawreport/timeline.py:488
 msgid "The style used for the year labels."
 msgstr "Der Stil, der für die Beschriftung der Jahre verwendet wird."
 
@@ -20981,135 +21079,146 @@ msgstr "Überschriften ü_bersetzen"
 msgid "Export:"
 msgstr "Export:"
 
-#: ../gramps/plugins/export/exportcsv.py:200
+#: ../gramps/plugins/export/exportcsv.py:135
 msgid "Include people"
 msgstr "Personen aufnehmen"
 
-#: ../gramps/plugins/export/exportcsv.py:201
+#: ../gramps/plugins/export/exportcsv.py:136
 msgid "Include marriages"
 msgstr "Heiraten aufnehmen"
 
-#: ../gramps/plugins/export/exportcsv.py:202
+#: ../gramps/plugins/export/exportcsv.py:137
 msgid "Include children"
 msgstr "Kinder aufnehmen"
 
-#: ../gramps/plugins/export/exportcsv.py:203
-#: ../gramps/plugins/graph/gvfamilylines.py:212
+#: ../gramps/plugins/export/exportcsv.py:138
+#: ../gramps/plugins/graph/gvfamilylines.py:214
 msgid "Include places"
 msgstr "Orte aufnehmen"
 
-#: ../gramps/plugins/export/exportcsv.py:204
+#: ../gramps/plugins/export/exportcsv.py:139
 msgid "Translate headers"
 msgstr "Überschriften übersetzen"
 
-#: ../gramps/plugins/export/exportcsv.py:365
+#: ../gramps/plugins/export/exportcsv.py:286
+#: ../gramps/plugins/gramplet/coordinates.py:95
+#: ../gramps/plugins/gramplet/placedetails.py:131
+#: ../gramps/plugins/lib/libplaceview.py:89
+#: ../gramps/plugins/webreport/narrativeweb.py:2918
+#: ../gramps/plugins/webreport/narrativeweb.py:3826
+msgid "Latitude"
+msgstr "Breitengrad"
+
+#: ../gramps/plugins/export/exportcsv.py:286
+#: ../gramps/plugins/gramplet/coordinates.py:96
+#: ../gramps/plugins/gramplet/placedetails.py:133
+#: ../gramps/plugins/lib/libplaceview.py:90
+#: ../gramps/plugins/webreport/narrativeweb.py:2926
+#: ../gramps/plugins/webreport/narrativeweb.py:3827
+msgid "Longitude"
+msgstr "Längengrad"
+
+#: ../gramps/plugins/export/exportcsv.py:287
+msgid "Enclosed_by"
+msgstr "Teil_von"
+
+#: ../gramps/plugins/export/exportcsv.py:339
 #, python-brace-format
 msgid "CSV export doesn't support non-primary surnames, {count} dropped"
 msgstr "CSV Export unterstützt nur Hauptnachnamen, {count} ausgelassen."
 
-#: ../gramps/plugins/export/exportcsv.py:382
-#: ../gramps/plugins/importer/importcsv.py:168
+#: ../gramps/plugins/export/exportcsv.py:356
 msgid "Birth source"
 msgstr "Geburt Quellenangabe"
 
-#: ../gramps/plugins/export/exportcsv.py:383
-#: ../gramps/plugins/importer/importcsv.py:178
+#: ../gramps/plugins/export/exportcsv.py:357
 msgid "Baptism date"
 msgstr "Taufdatum"
 
-#: ../gramps/plugins/export/exportcsv.py:383
-#: ../gramps/plugins/importer/importcsv.py:172
+#: ../gramps/plugins/export/exportcsv.py:357
 msgid "Baptism place"
 msgstr "Taufort"
 
-#: ../gramps/plugins/export/exportcsv.py:383
-#: ../gramps/plugins/importer/importcsv.py:181
+#: ../gramps/plugins/export/exportcsv.py:357
 msgid "Baptism source"
 msgstr "Taufe Quellenangabe"
 
-#: ../gramps/plugins/export/exportcsv.py:384
-#: ../gramps/plugins/importer/importcsv.py:200
+#: ../gramps/plugins/export/exportcsv.py:358
 msgid "Death source"
 msgstr "Sterbequelle"
 
-#: ../gramps/plugins/export/exportcsv.py:385
-#: ../gramps/plugins/importer/importcsv.py:188
+#: ../gramps/plugins/export/exportcsv.py:359
 msgid "Burial date"
 msgstr "Beerdigungsdatum"
 
-#: ../gramps/plugins/export/exportcsv.py:385
-#: ../gramps/plugins/importer/importcsv.py:183
+#: ../gramps/plugins/export/exportcsv.py:359
 msgid "Burial place"
 msgstr "Beerdigungsort"
 
-#: ../gramps/plugins/export/exportcsv.py:385
-#: ../gramps/plugins/importer/importcsv.py:191
+#: ../gramps/plugins/export/exportcsv.py:359
 msgid "Burial source"
 msgstr "Beerdigungsquelle"
 
-#: ../gramps/plugins/export/exportcsv.py:498
-#: ../gramps/plugins/importer/importcsv.py:215
-#: ../gramps/plugins/textreport/familygroup.py:619
-#: ../gramps/plugins/webreport/narrativeweb.py:2736
+#: ../gramps/plugins/export/exportcsv.py:472
+#: ../gramps/plugins/importer/importcsv.py:216
+#: ../gramps/plugins/textreport/familygroup.py:620
+#: ../gramps/plugins/webreport/narrativeweb.py:2726
 msgid "Husband"
 msgstr "Ehemann"
 
-#: ../gramps/plugins/export/exportcsv.py:498
-#: ../gramps/plugins/importer/importcsv.py:212
-#: ../gramps/plugins/textreport/familygroup.py:628
-#: ../gramps/plugins/webreport/narrativeweb.py:2734
+#: ../gramps/plugins/export/exportcsv.py:472
+#: ../gramps/plugins/importer/importcsv.py:213
+#: ../gramps/plugins/textreport/familygroup.py:629
+#: ../gramps/plugins/webreport/narrativeweb.py:2724
 msgid "Wife"
 msgstr "Ehefrau"
-
-#: ../gramps/plugins/export/exportcsv.py:564
-#: ../gramps/plugins/gramplet/placedetails.py:131
-#: ../gramps/plugins/lib/libplaceview.py:89
-#: ../gramps/plugins/webreport/narrativeweb.py:375
-#: ../gramps/plugins/webreport/narrativeweb.py:3820
-msgid "Latitude"
-msgstr "Breitengrad"
-
-#: ../gramps/plugins/export/exportcsv.py:564
-#: ../gramps/plugins/gramplet/placedetails.py:133
-#: ../gramps/plugins/importer/importcsv.py:225
-#: ../gramps/plugins/lib/libplaceview.py:90
-#: ../gramps/plugins/webreport/narrativeweb.py:377
-#: ../gramps/plugins/webreport/narrativeweb.py:3821
-msgid "Longitude"
-msgstr "Längengrad"
-
-#: ../gramps/plugins/export/exportcsv.py:565
-#: ../gramps/plugins/importer/importcsv.py:228
-msgid "Enclosed_by"
-msgstr "Teil_von"
 
 #: ../gramps/plugins/export/exportftree.glade:150
 #: ../gramps/plugins/export/exportgeneweb.glade:151
 msgid "_Restrict data on living people"
 msgstr "Daten von lebenden Pe_rsonen beschränken"
 
-#: ../gramps/plugins/export/exportgedcom.py:388
+#: ../gramps/plugins/export/exportgedcom.py:394
 msgid "Writing individuals"
 msgstr "Schreibe Personen"
 
-#: ../gramps/plugins/export/exportgedcom.py:756
-#: ../gramps/plugins/textreport/familygroup.py:667
+#: ../gramps/plugins/export/exportgedcom.py:786
+#: ../gramps/plugins/export/exportgedcom.py:1062
+#: ../gramps/plugins/export/exportgedcom.py:1154
+#: ../gramps/plugins/lib/libgedcom.py:3988
+#: ../gramps/plugins/lib/libgedcom.py:5696
+#: ../gramps/plugins/lib/libgedcom.py:6829
+msgid "FAX"
+msgstr "FAX"
+
+#: ../gramps/plugins/export/exportgedcom.py:800
+#: ../gramps/plugins/textreport/familygroup.py:668
 msgid "Writing families"
 msgstr "Schreibe Familien"
 
-#: ../gramps/plugins/export/exportgedcom.py:922
+#: ../gramps/plugins/export/exportgedcom.py:966
 msgid "Writing sources"
 msgstr "Schreibe Quellen"
 
-#: ../gramps/plugins/export/exportgedcom.py:957
+#: ../gramps/plugins/export/exportgedcom.py:1001
 msgid "Writing notes"
 msgstr "Schreibe Notizen"
 
-#: ../gramps/plugins/export/exportgedcom.py:995
+#: ../gramps/plugins/export/exportgedcom.py:1039
 msgid "Writing repositories"
 msgstr "Schreibe Aufbewahrungsorte"
 
-#: ../gramps/plugins/export/exportgedcom.py:1497
+#: ../gramps/plugins/export/exportgedcom.py:1156
+#: ../gramps/plugins/lib/libgedcom.py:5708
+msgid "EMAIL"
+msgstr "E-MAIL"
+
+#: ../gramps/plugins/export/exportgedcom.py:1158
+#: ../gramps/plugins/lib/libgedcom.py:5720
+msgid "WWW"
+msgstr ""
+
+#: ../gramps/plugins/export/exportgedcom.py:1551
 msgid "GEDCOM Export failed"
 msgstr "GEDCOM Export fehlgeschlagen"
 
@@ -21135,9 +21244,9 @@ msgid "No families matched by selected filter"
 msgstr "Keine Familien entsprechen dem ausgewählten Filter"
 
 #: ../gramps/plugins/export/exportpkg.py:179
-#: ../gramps/plugins/export/exportxml.py:136
-#: ../gramps/plugins/export/exportxml.py:152
-#: ../gramps/plugins/export/exportxml.py:170
+#: ../gramps/plugins/export/exportxml.py:139
+#: ../gramps/plugins/export/exportxml.py:155
+#: ../gramps/plugins/export/exportxml.py:173
 #, python-format
 msgid "Failure writing %s"
 msgstr "Fehler beim Schreiben von %s"
@@ -21167,7 +21276,7 @@ msgstr "Tod von %s"
 msgid "Anniversary: %s"
 msgstr "Jahrestag: %s"
 
-#: ../gramps/plugins/export/exportxml.py:137
+#: ../gramps/plugins/export/exportxml.py:140
 msgid ""
 "The database cannot be saved because you do not have permission to write to "
 "the directory. Please make sure you have write access to the directory and "
@@ -21177,7 +21286,7 @@ msgstr ""
 "in dieses Verzeichnis zu schreiben. Bitte stelle sicher, dass du "
 "Schreibzugriff auf dieses Verzeichnis hast, und versuche es erneut."
 
-#: ../gramps/plugins/export/exportxml.py:153
+#: ../gramps/plugins/export/exportxml.py:156
 msgid ""
 "The database cannot be saved because you do not have permission to write to "
 "the file. Please make sure you have write access to the file and try again."
@@ -21244,8 +21353,10 @@ msgid "Mother - Child Age Diff Distribution"
 msgstr "Mutter - Kind Altersunterschied Verteilung"
 
 #: ../gramps/plugins/gramplet/agestats.py:238
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:242
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:249
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:259
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:266
+#: ../gramps/plugins/webreport/narrativeweb.py:1886
+#: ../gramps/plugins/webreport/narrativeweb.py:8061
 msgid "Statistics"
 msgstr "Statistik"
 
@@ -21276,8 +21387,8 @@ msgstr "Doppelt-klicken, um %d Personen zu sehen."
 
 #: ../gramps/plugins/gramplet/ancestor.py:141
 #: ../gramps/plugins/gramplet/ancestor.py:149
-#: ../gramps/plugins/gramplet/descendant.py:170
-#: ../gramps/plugins/gramplet/descendant.py:178
+#: ../gramps/plugins/gramplet/descendant.py:172
+#: ../gramps/plugins/gramplet/descendant.py:180
 #, python-format
 msgid "%(abbr)s %(date)s"
 msgstr "%(abbr)s %(date)s"
@@ -21296,8 +21407,8 @@ msgstr ""
 "dem gewählten Attribut zu sehen."
 
 #: ../gramps/plugins/gramplet/attributes.py:56
-#: ../gramps/plugins/lib/libmetadata.py:170
-#: ../gramps/plugins/webreport/narrativeweb.py:1413
+#: ../gramps/plugins/lib/libmetadata.py:172
+#: ../gramps/plugins/webreport/narrativeweb.py:1370
 msgid "Key"
 msgstr "Schlüssel"
 
@@ -21326,9 +21437,32 @@ msgstr "Herausgeber"
 msgid "<No Citation>"
 msgstr "<Keine Fundstelle>"
 
-#: ../gramps/plugins/gramplet/descendant.py:108
-msgid "Descendent Menu"
-msgstr "Nachfahremenü"
+#: ../gramps/plugins/gramplet/coordinates.py:83
+msgid "Right-click on a row to edit the selected event or the related place."
+msgstr ""
+"Rechtsklick auf eine Zeile um das gewählte Ereignis oder den dazugehörigen"
+" Ort zu bearbeiten."
+
+#: ../gramps/plugins/gramplet/coordinates.py:94
+#: ../gramps/plugins/textreport/tagreport.py:154
+#: ../gramps/plugins/textreport/tagreport.py:242
+#: ../gramps/plugins/textreport/tagreport.py:331
+#: ../gramps/plugins/textreport/tagreport.py:414
+#: ../gramps/plugins/textreport/tagreport.py:495
+#: ../gramps/plugins/textreport/tagreport.py:564
+#: ../gramps/plugins/textreport/tagreport.py:648
+#: ../gramps/plugins/textreport/tagreport.py:733
+#: ../gramps/plugins/textreport/tagreport.py:813
+msgid "Id"
+msgstr "ID"
+
+#: ../gramps/plugins/gramplet/coordinates.py:143
+msgid "Edit the event"
+msgstr "Das Ereignis bearbeiten"
+
+#: ../gramps/plugins/gramplet/coordinates.py:148
+msgid "Edit the place"
+msgstr "Den Ort bearbeiten"
 
 #: ../gramps/plugins/gramplet/eval.py:72
 msgid "Evaluation"
@@ -21351,8 +21485,9 @@ msgstr "Anwenden"
 msgid "Double-click on a row to edit the selected event."
 msgstr "Das gewählte Ereigniss bearbeiten: Doppelklick auf eine Zeile."
 
-#: ../gramps/plugins/gramplet/fanchartdescgramplet.py:62
-#: ../gramps/plugins/gramplet/fanchartgramplet.py:65
+#: ../gramps/plugins/gramplet/fanchart2waygramplet.py:87
+#: ../gramps/plugins/gramplet/fanchartdescgramplet.py:64
+#: ../gramps/plugins/gramplet/fanchartgramplet.py:67
 msgid ""
 "Click to expand/contract person\n"
 "Right-click for options\n"
@@ -21601,12 +21736,12 @@ msgstr "Gramplet zeigt die Nachkommen der aktiven Person"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:101
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:108
-#: ../gramps/plugins/webreport/narrativeweb.py:6904
+#: ../gramps/plugins/webreport/narrativeweb.py:6984
 msgid "Ancestors"
 msgstr "Vorfahren"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:102
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:180
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:197
 msgid "Gramplet showing active person's ancestors"
 msgstr "Gramplet zeigt die Vorfahren der aktiven Person"
 
@@ -21616,7 +21751,7 @@ msgstr ""
 "Gramplet zeigt die direkten Vorfahren der aktiven Person als Fächergrafik"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:135
-#: ../gramps/plugins/view/fanchartdescview.py:72
+#: ../gramps/plugins/view/fanchartdescview.py:75
 msgid "Descendant Fan Chart"
 msgstr "Nachkommenfächerdiagramm"
 
@@ -21631,169 +21766,187 @@ msgid "Descendant Fan"
 msgstr "Nachfahrefächer"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:152
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:158
+#: ../gramps/plugins/view/fanchart2wayview.py:78
+msgid "2-Way Fan Chart"
+msgstr "2-Wege Fächergrafik"
+
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:153
+msgid ""
+"Gramplet showing active person's direct ancestors and descendants as a "
+"fanchart"
+msgstr ""
+"Gramplet zeigt die direkten Vorfahren und Nachkommen der aktiven Person als"
+" Fächergrafik"
+
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:161
+#: ../gramps/plugins/view/view.gpr.py:171
+msgid "2-Way Fan"
+msgstr "2-Wege Fächer"
+
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:169
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:175
 msgid "FAQ"
 msgstr "FAQ"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:153
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:170
 msgid "Gramplet showing frequently asked questions"
 msgstr "Gramplet zeigt die am häufigsten gestellten Fragen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:165
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:172
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:182
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:189
 msgid "Given Name Cloud"
 msgstr "Vornamen Wolke"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:166
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:183
 msgid "Gramplet showing all given names as a text cloud"
 msgstr "Gramplet zeigt alle Vornamen als Textwolke"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:179
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:185
-#: ../gramps/plugins/view/pedigreeview.py:512
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:196
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:202
+#: ../gramps/plugins/view/pedigreeview.py:528
 #: ../gramps/plugins/view/view.gpr.py:125
-#: ../gramps/plugins/webreport/narrativeweb.py:7090
+#: ../gramps/plugins/webreport/narrativeweb.py:7170
 msgid "Pedigree"
 msgstr "Ahnentafel"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:197
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:214
 msgid "Gramplet showing an active item Quick View"
 msgstr "Gramplet zeigt eine Schnellansicht aktiver Objekte"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:212
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:218
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:229
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:235
 msgid "Relatives"
 msgstr "Angehörige"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:213
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:230
 msgid "Gramplet showing active person's relatives"
 msgstr "Gramplet zeigt Verwandte der aktiven Person"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:228
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:235
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:245
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:252
 msgid "Session Log"
 msgstr "Sitzungsaufzeichnungen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:229
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:246
 msgid "Gramplet showing all activity for this session"
 msgstr "Gramplet zeigt alle Aktivitäten dieser Sitzung"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:243
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:260
 msgid "Gramplet showing summary data of the Family Tree"
 msgstr "Gramplet zeigt eine Zusammenfassung der Daten dieses Stammbaums"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:256
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:263
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:273
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:280
 msgid "Surname Cloud"
 msgstr "Nachnamen Wolke"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:257
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:274
 msgid "Gramplet showing all surnames as a text cloud"
 msgstr "Gramplet zeigt alle Nachnamen als Textwolke"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:270
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:277
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1125
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1139
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1153
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1167
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1181
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1195
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1209
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1223
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:287
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:294
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1148
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1162
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1176
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1190
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1204
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1218
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1232
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1246
 msgid "gramplet|To Do"
 msgstr "Zu erledigen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:271
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:288
 msgid "Gramplet for displaying a To Do list"
 msgstr "Gramplet zeigt die Liste 'noch zu erledigen'."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:285
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:291
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:302
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:308
 msgid "Top Surnames"
 msgstr "Häufigste Nachnamen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:286
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:303
 msgid "Gramplet showing most frequent surnames in this tree"
 msgstr "Gramplet zeigt die häufigsten Nachnamen in diesem Stammbaum"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:298
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:315
 msgid "Welcome"
 msgstr "Willkommen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:299
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:316
 msgid "Gramplet showing a welcome message"
 msgstr "Gramplet zeigt eine Willkommensnachricht"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:305
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:322
 msgid "Welcome to Gramps!"
 msgstr "Willkommen bei Gramps!"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:312
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:329
 msgid "What's Next"
 msgstr "Was als nächstes"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:313
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:330
 msgid "Gramplet suggesting items to research"
 msgstr "Gramplet schlägt zu erforschende Punkte vor"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:319
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:336
 msgid "What's Next?"
 msgstr "Was nun?"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:329
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:346
 msgid "Person Details"
 msgstr "Persondetails"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:330
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:347
 msgid "Gramplet showing details of a person"
 msgstr "Gramplet zeigt Details einer Person"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:337
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:351
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:365
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:354
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:368
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:382
 msgid "Details"
 msgstr "Details"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:343
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:360
 msgid "Repository Details"
 msgstr "Aufbewahrungsortdetails"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:344
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:361
 msgid "Gramplet showing details of a repository"
 msgstr "Gramplet zeigt Details eines Aufbewahrungsortes."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:357
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:374
 msgid "Place Details"
 msgstr "Ortsdetails"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:358
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:375
 msgid "Gramplet showing details of a place"
 msgstr "Gramplet zeigt Details eines Ortes."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:371
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:379
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:388
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:396
 msgid "Media Preview"
 msgstr "Medienvorschau"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:372
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:389
 msgid "Gramplet showing a preview of a media object"
 msgstr "Gramplet zeigt eine Vorschau eines Medienobjektes."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:399
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:407
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:416
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:424
 msgid "Image Metadata"
 msgstr "Bildmetadaten"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:400
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:417
 msgid "Gramplet showing metadata for a media object"
 msgstr "Gramplet zeigt Metadaten eines Medienobjektes."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:421
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:438
 msgid "GExiv2 module not loaded."
 msgstr "GExiv2 Modul nicht geladen."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:422
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:439
 #, python-format
 msgid ""
 "Image metadata functionality will not be available.\n"
@@ -21802,522 +21955,541 @@ msgstr ""
 "Die Bildmetadaten Funktionalität wird nicht zur Verfügung stehen.\n"
 "Um es für Gramps zu erstellen siehe %(gramps_wiki_build_gexiv2_url)s"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:429
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:452
 msgid "Person Residence"
 msgstr "Wohnort der Person"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:430
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:453
 msgid "Gramplet showing residence events for a person"
 msgstr "Gramplet zeigt Wohnortsereignisse für eine Person"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:443
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:466
 msgid "Person Events"
 msgstr "Ereignisse zur Person"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:444
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:467
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1320
 msgid "Gramplet showing the events for a person"
 msgstr "Gramplet zeigt die Ereignisse einer Person"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:457
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:480
 msgid "Family Events"
 msgstr "Familiäre Ereignisse"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:458
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:481
 msgid "Gramplet showing the events for a family"
 msgstr "Gramplet zeigt die Ereignisse einer Familie"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:471
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:494
 msgid "Person Gallery"
 msgstr "Personengalerie"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:472
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:495
 msgid "Gramplet showing media objects for a person"
 msgstr "Gramplet zeigt Medienobjekte einer Person"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:479
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:493
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:507
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:521
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:535
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:549
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:502
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:516
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:530
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:544
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:558
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:572
 msgid "Gallery"
 msgstr "Galerie"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:485
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:508
 msgid "Family Gallery"
 msgstr "Familiengalerie"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:486
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:509
 msgid "Gramplet showing media objects for a family"
 msgstr "Gramplet zeigt Medienobjekte einer Familie"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:499
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:522
 msgid "Event Gallery"
 msgstr "Ereignisgalerie"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:500
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:523
 msgid "Gramplet showing media objects for an event"
 msgstr "Gramplet zeigt Medienobjekte eines Ereignisses"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:513
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:536
 msgid "Place Gallery"
 msgstr "Ortsgalerie"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:514
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:537
 msgid "Gramplet showing media objects for a place"
 msgstr "Gramplet zeigt Medienobjekte eines Ortes"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:527
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:550
 msgid "Source Gallery"
 msgstr "Quellengalerie"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:528
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:551
 msgid "Gramplet showing media objects for a source"
 msgstr "Gramplet zeigt Medienobjekte einer Quelle"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:541
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:564
 msgid "Citation Gallery"
 msgstr "Fundstellegalerie"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:542
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:565
 msgid "Gramplet showing media objects for a citation"
 msgstr "Gramplet zeigt Medienobjekte einer Fundstelle"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:555
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:578
 msgid "Person Attributes"
 msgstr "Person Attribute"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:556
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:579
 msgid "Gramplet showing the attributes of a person"
 msgstr "Gramplet zeigt die Attribute einer Person"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:569
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:592
 msgid "Event Attributes"
 msgstr "Ereignisattribute"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:570
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:593
 msgid "Gramplet showing the attributes of an event"
 msgstr "Gramplet zeigt die Attribute eines Ereignis"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:583
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:606
 msgid "Family Attributes"
 msgstr "Familienattribute"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:584
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:607
 msgid "Gramplet showing the attributes of a family"
 msgstr "Gramplet zeigt die Attribute einer Familie"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:597
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:620
 msgid "Media Attributes"
 msgstr "Medienattribute"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:598
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:621
 msgid "Gramplet showing the attributes of a media object"
 msgstr "Gramplet zeigt die Attribute eines Medienobjekts"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:611
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:634
 msgid "Source Attributes"
 msgstr "Quellenattribute"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:612
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:635
 msgid "Gramplet showing the attributes of a source object"
 msgstr "Gramplet zeigt die Attribute eines Quellenobjekts"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:625
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:648
 msgid "Citation Attributes"
 msgstr "Fundstellenattribute"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:626
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:649
 msgid "Gramplet showing the attributes of a citation object"
 msgstr "Gramplet zeigt die Attribute eines Fundstellenobjekts"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:639
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:662
 msgid "Person Notes"
 msgstr "Personennotizen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:640
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:663
 msgid "Gramplet showing the notes for a person"
 msgstr "Gramplet zeigt Notizen einer Person"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:653
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:676
 msgid "Event Notes"
 msgstr "Ereignisnotizen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:654
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:677
 msgid "Gramplet showing the notes for an event"
 msgstr "Gramplet zeigt die Notizen eines Ereignis"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:667
-#: ../gramps/plugins/textreport/familygroup.py:771
+#. #########################
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:690
+#: ../gramps/plugins/textreport/familygroup.py:773
 msgid "Family Notes"
 msgstr "Familiennotizen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:668
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:691
 msgid "Gramplet showing the notes for a family"
 msgstr "Gramplet zeigt Notizen einer Familie"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:681
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:704
 msgid "Place Notes"
 msgstr "Ortsnotizen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:682
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:705
 msgid "Gramplet showing the notes for a place"
 msgstr "Gramplet zeigt Notizen für einen Ort"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:695
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:718
 msgid "Source Notes"
 msgstr "Quellennotizen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:696
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:719
 msgid "Gramplet showing the notes for a source"
 msgstr "Gramplet zeigt Notizen für Quellen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:709
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:732
 msgid "Citation Notes"
 msgstr "Fundstelle Notizen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:710
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:733
 msgid "Gramplet showing the notes for a citation"
 msgstr "Gramplet zeigt Notizen einer Fundstelle"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:723
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:746
 msgid "Repository Notes"
 msgstr "Aufbewahrungsortnotizen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:724
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:747
 msgid "Gramplet showing the notes for a repository"
 msgstr "Gramplet zeigt Notizen eines Aufbewahrungsortes."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:737
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:760
 msgid "Media Notes"
 msgstr "Mediumnotizen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:738
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:761
 msgid "Gramplet showing the notes for a media object"
 msgstr "Gramplet zeigt Notizen eines Medienobjekt"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:751
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:774
 msgid "Person Citations"
 msgstr "Personfundstellen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:752
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:775
 msgid "Gramplet showing the citations for a person"
 msgstr "Gramplet zeigt Fundstellen einer Person"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:765
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:788
 msgid "Event Citations"
 msgstr "Ereignisfundstellen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:766
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:789
 msgid "Gramplet showing the citations for an event"
 msgstr "Gramplet zeigt die Fundstellen eines Ereignisses."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:779
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:802
 msgid "Family Citations"
 msgstr "Familienfundstellen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:780
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:803
 msgid "Gramplet showing the citations for a family"
 msgstr "Gramplet zeigt die Fundstellen einer Familie"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:793
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:816
 msgid "Place Citations"
 msgstr "Ortsfundstelle"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:794
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:817
 msgid "Gramplet showing the citations for a place"
 msgstr "Gramplet zeigt die Fundstelle für einen Ort"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:807
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:830
 msgid "Media Citations"
 msgstr "Medienfundstelle"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:808
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:831
 msgid "Gramplet showing the citations for a media object"
 msgstr "Gramplet zeigt die Fundstelle eines Medienobjektes."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:821
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:844
 msgid "Person Children"
 msgstr "Person Kinder"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:822
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:845
 msgid "Gramplet showing the children of a person"
 msgstr "Gramplet zeigt die Kinder einer Person"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:835
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:858
 msgid "Family Children"
 msgstr "Familie Kinder"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:836
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:859
 msgid "Gramplet showing the children of a family"
 msgstr "Gramplet zeigt die Kinder einer Familie"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:849
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:872
 msgid "Person References"
 msgstr "Personenreferenzen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:850
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:873
 msgid "Gramplet showing the backlink references for a person"
 msgstr "Gramplet zeigt die rückwärts Referenzen für eine Person"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:857
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:871
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:885
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:899
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:913
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:927
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:941
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:955
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:969
-#: ../gramps/plugins/webreport/narrativeweb.py:2683
-#: ../gramps/plugins/webreport/narrativeweb.py:3172
-#: ../gramps/plugins/webreport/narrativeweb.py:5675
-#: ../gramps/plugins/webreport/narrativeweb.py:6686
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:880
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:894
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:908
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:922
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:936
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:950
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:964
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:978
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:992
+#: ../gramps/plugins/webreport/narrativeweb.py:2670
+#: ../gramps/plugins/webreport/narrativeweb.py:3166
+#: ../gramps/plugins/webreport/narrativeweb.py:5732
+#: ../gramps/plugins/webreport/narrativeweb.py:6766
 msgid "References"
 msgstr "Referenzen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:863
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:886
 msgid "Event References"
 msgstr "Ereignisreferenzen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:864
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:887
 msgid "Gramplet showing the backlink references for an event"
 msgstr "Gramplet zeigt die rückwärts Referenzen für eine Ereignis"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:877
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:900
 msgid "Family References"
 msgstr "Familienreferenzen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:878
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:901
 msgid "Gramplet showing the backlink references for a family"
 msgstr "Gramplet zeigt die rückwärts Referenzen für eine Familie"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:891
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:914
 msgid "Place References"
 msgstr "Ortsreferenzen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:892
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:915
 msgid "Gramplet showing the backlink references for a place"
 msgstr "Gramplet zeigt die rückwärts Referenzen für einen Ort"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:905
-#: ../gramps/plugins/webreport/narrativeweb.py:2567
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:928
+#: ../gramps/plugins/webreport/narrativeweb.py:2553
 msgid "Source References"
 msgstr "Ereignisreferenzen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:906
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:929
 msgid "Gramplet showing the backlink references for a source"
 msgstr "Gramplet zeigt die rückwärts Referenzen für eine Quelle"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:919
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:942
 msgid "Citation References"
 msgstr "Fundstellenreferenzen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:920
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:943
 msgid "Gramplet showing the backlink references for a citation"
 msgstr "Gramplet zeigt die rückwärts Referenzen für eine Fundstelle"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:933
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:956
 #: ../gramps/plugins/quickview/quickview.gpr.py:248
 msgid "Repository References"
 msgstr "Aufbewahrungsortreferenz"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:934
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:957
 msgid "Gramplet showing the backlink references for a repository"
 msgstr "Gramplet zeigt die rückwärts Referenzen für einen Aufbewahrungsort"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:947
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:970
 msgid "Media References"
 msgstr "Medienreferenzen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:948
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:971
 msgid "Gramplet showing the backlink references for a media object"
 msgstr "Gramplet zeigt die rückwärts Referenzen für ein Medienobjekt."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:961
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:984
 msgid "Note References"
 msgstr "Notizreferenzen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:962
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:985
 msgid "Gramplet showing the backlink references for a note"
 msgstr "Gramplet zeigt die rückwärts Referenzen für eine Notiz"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:975
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:998
 msgid "Person Filter"
 msgstr "Personenfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:976
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:999
 msgid "Gramplet providing a person filter"
 msgstr "Gramplet bietet einen Personenfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:989
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1012
 msgid "Family Filter"
 msgstr "Familienfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:990
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1013
 msgid "Gramplet providing a family filter"
 msgstr "Gramplet bietet einen Familienfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1003
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1026
 msgid "Event Filter"
 msgstr "Ereignisfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1004
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1027
 msgid "Gramplet providing an event filter"
 msgstr "Gramplet bietet einen Ereignisfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1017
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1040
 msgid "Source Filter"
 msgstr "Quellenfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1018
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1041
 msgid "Gramplet providing a source filter"
 msgstr "Gramplet bietet einen Quellenfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1031
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1054
 msgid "Citation Filter"
 msgstr "Fundstellenfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1032
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1055
 msgid "Gramplet providing a citation filter"
 msgstr "Gramplet bietet einen Fundstellenfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1045
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1068
 msgid "Place Filter"
 msgstr "Ortsfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1046
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1069
 msgid "Gramplet providing a place filter"
 msgstr "Gramplet bietet einen Ortsfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1059
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1082
 msgid "Media Filter"
 msgstr "Medienfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1060
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1083
 msgid "Gramplet providing a media filter"
 msgstr "Gramplet bietet einen Medienfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1073
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1096
 msgid "Repository Filter"
 msgstr "Aufbewahrungsortfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1074
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1097
 msgid "Gramplet providing a repository filter"
 msgstr "Gramplet bietet einen Aufbewahrungsortsfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1087
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1110
 msgid "Note Filter"
 msgstr "Notizfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1088
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1111
 msgid "Gramplet providing a note filter"
 msgstr "Gramplet bietet einen Notizenfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1101
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1112
-#: ../gramps/plugins/textreport/recordsreport.py:118
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1124
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1135
+#: ../gramps/plugins/textreport/recordsreport.py:119
 msgid "Records"
 msgstr "Rekorde"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1102
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1125
 #: ../gramps/plugins/textreport/textplugins.gpr.py:413
 msgid "Shows some interesting records about people and families"
 msgstr "Zeigt einige interessante Rekorde von Personen und Familien"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1117
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1140
 msgid "Person To Do"
 msgstr "Personen 'noch zu erledigen'"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1118
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1141
 msgid "Gramplet showing the To Do notes for a person"
 msgstr "Gramplet zeigt die 'noch zu erledigen' Notizen für eine Person."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1131
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1154
 msgid "Event To Do"
 msgstr "Ereignis 'noch zu erledigen'"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1132
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1155
 msgid "Gramplet showing the To Do notes for an event"
 msgstr "Gramplet zeigt die 'noch zu erledigen' Notizen für ein Ereignis."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1145
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1168
 msgid "Family To Do"
 msgstr "Familie 'noch zu erledigen'"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1146
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1169
 msgid "Gramplet showing the To Do notes for a family"
 msgstr "Gramplet zeigt die 'noch zu erledigen' Notizen für eine Familie."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1159
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1182
 msgid "Place To Do"
 msgstr "Ort 'noch zu erledigen'"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1160
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1183
 msgid "Gramplet showing the To Do notes for a place"
 msgstr "Gramplet zeigt die 'noch zu erledigen' Notizen für einen Ort."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1173
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1196
 msgid "Source To Do"
 msgstr "Quelle 'noch zu erledigen'"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1174
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1197
 msgid "Gramplet showing the To Do notes for a source"
 msgstr "Gramplet zeigt die 'noch zu erledigen' Notizen für eine Quelle."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1187
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1210
 msgid "Citation To Do"
 msgstr "Fundstelle 'noch zu erledigen'"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1188
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1211
 msgid "Gramplet showing the To Do notes for a citation"
 msgstr "Gramplet zeigt die 'noch zu erledigen' Notizen für eine Fundstelle."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1201
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1224
 msgid "Repository To Do"
 msgstr "Aufbewahrungsort 'noch zu erledigen'"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1202
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1225
 msgid "Gramplet showing the To Do notes for a repository"
 msgstr ""
 "Gramplet zeigt die 'noch zu erledigen' Notizen für einen Aufbewahrungsort."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1215
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1238
 msgid "Media To Do"
 msgstr "Medien 'noch zu erledigen'"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1216
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1239
 msgid "Gramplet showing the To Do notes for a media object"
 msgstr "Gramplet zeigt die 'noch zu erledigen' Notizen für ein Medienobjekt."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1255
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1263
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1278
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1286
 msgid "SoundEx"
 msgstr "SoundEx:"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1256
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1279
 msgid "Gramplet to generate SoundEx codes"
 msgstr "Gramplet zum SoundEx-Codes Erstellen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1268
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1291
 msgid "Place Enclosed By"
 msgstr "Ort Teil von"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1269
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1292
 msgid "Gramplet showing the places enclosed by the active place"
 msgstr "Gramplet zeigt die  Orte die im aktuellen Ort enthalten sind"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1282
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1305
 msgid "Place Encloses"
 msgstr "Enthaltene Orte"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1283
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1306
 msgid "Gramplet showing the places that the active place encloses"
 msgstr "Gramplet zeigt die Orte die der aktive Ort enthält"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1290
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1313
 msgid "Encloses"
 msgstr "Enthalten"
+
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1319
+msgid "Geography coordinates for Person Events"
+msgstr "Geografiekoordinaten für Personen Ereignisse"
+
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1327
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1341
+msgid "Events Coordinates"
+msgstr "Ereigniskoordinaten"
+
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1333
+msgid "Geography coordinates for Family Events"
+msgstr "Geografiekoordinaten für Familien Ereignisse"
+
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1334
+msgid "Gramplet showing the events for all the family"
+msgstr "Gramplet zeigt die Ereignisse für die gesamte Familie"
 
 #: ../gramps/plugins/gramplet/leak.py:93
 msgid "Uncollected object"
@@ -22342,7 +22514,7 @@ msgstr "%d bezieht sich auf"
 msgid "Uncollected Objects: %s"
 msgstr "Nicht erfasste Objekte: %s"
 
-#: ../gramps/plugins/gramplet/locations.py:80
+#: ../gramps/plugins/gramplet/locations.py:81
 msgid "Double-click on a row to edit the selected place."
 msgstr "Doppelklick auf eine Zeile um den gewählten Ort zu bearbeiten."
 
@@ -22360,8 +22532,8 @@ msgstr "Maus für Optionen über Links bewegen"
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:58
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:67
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:78
-#: ../gramps/plugins/view/fanchartdescview.py:274
-#: ../gramps/plugins/view/fanchartview.py:272
+#: ../gramps/plugins/view/fanchartdescview.py:294
+#: ../gramps/plugins/view/fanchartview.py:290
 msgid "Max generations"
 msgstr "Max Generationen"
 
@@ -22427,10 +22599,10 @@ msgstr " enthält 1 von 1 Personen (%(percent)s komplett)\n"
 
 #. Create the Generation title, set an index marker
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:267
-#: ../gramps/plugins/textreport/ancestorreport.py:212
-#: ../gramps/plugins/textreport/detancestralreport.py:217
-#: ../gramps/plugins/textreport/detdescendantreport.py:312
-#: ../gramps/plugins/textreport/endoflinereport.py:184
+#: ../gramps/plugins/textreport/ancestorreport.py:213
+#: ../gramps/plugins/textreport/detancestralreport.py:218
+#: ../gramps/plugins/textreport/detdescendantreport.py:347
+#: ../gramps/plugins/textreport/endoflinereport.py:185
 #, python-format
 msgid "Generation %d"
 msgstr "Generation %d"
@@ -22582,56 +22754,71 @@ msgstr "Eintrag doppelt-klicken, um die Treffer zu sehen."
 
 #: ../gramps/plugins/gramplet/statsgramplet.py:87
 #: ../gramps/plugins/textreport/summary.py:241
+#: ../gramps/plugins/webreport/narrativeweb.py:8081
 msgid "less than 1"
 msgstr "weniger als 1"
 
 #. -------------------------
-#: ../gramps/plugins/gramplet/statsgramplet.py:98
-#: ../gramps/plugins/graph/gvfamilylines.py:248
+#: ../gramps/plugins/gramplet/statsgramplet.py:99
+#: ../gramps/plugins/graph/gvfamilylines.py:256
 #: ../gramps/plugins/textreport/summary.py:114
-#: ../gramps/plugins/webreport/narrativeweb.py:1897
-#: ../gramps/plugins/webreport/narrativeweb.py:1953
-#: ../gramps/plugins/webreport/narrativeweb.py:2010
-#: ../gramps/plugins/webreport/narrativeweb.py:6034
+#: ../gramps/plugins/webreport/narrativeweb.py:1873
+#: ../gramps/plugins/webreport/narrativeweb.py:1931
+#: ../gramps/plugins/webreport/narrativeweb.py:1996
+#: ../gramps/plugins/webreport/narrativeweb.py:6091
+#: ../gramps/plugins/webreport/narrativeweb.py:8092
+#: ../gramps/plugins/webreport/narrativeweb.py:8159
 msgid "Individuals"
 msgstr "Personen"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:100
+#: ../gramps/plugins/gramplet/statsgramplet.py:101
+#: ../gramps/plugins/webreport/narrativeweb.py:8095
+#: ../gramps/plugins/webreport/narrativeweb.py:8160
 msgid "Number of individuals"
 msgstr "Personenzahl"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:110
+#: ../gramps/plugins/gramplet/statsgramplet.py:111
+#: ../gramps/plugins/webreport/narrativeweb.py:8101
+#: ../gramps/plugins/webreport/narrativeweb.py:8167
 msgid "Individuals with unknown gender"
 msgstr "Personen mit unbekanntem Geschlecht"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:114
+#: ../gramps/plugins/gramplet/statsgramplet.py:115
 #: ../gramps/plugins/textreport/summary.py:212
+#: ../gramps/plugins/webreport/narrativeweb.py:8105
+#: ../gramps/plugins/webreport/narrativeweb.py:8171
 msgid "Family Information"
 msgstr "Familieninformation"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:120
+#: ../gramps/plugins/gramplet/statsgramplet.py:122
+#: ../gramps/plugins/webreport/narrativeweb.py:8108
 msgid "Unique surnames"
 msgstr "Eindeutige Nachnamen"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:124
+#: ../gramps/plugins/gramplet/statsgramplet.py:126
 #: ../gramps/plugins/textreport/summary.py:229
+#: ../gramps/plugins/webreport/narrativeweb.py:8112
 msgid "Media Objects"
 msgstr "Medienobjekte"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:126
+#: ../gramps/plugins/gramplet/statsgramplet.py:128
+#: ../gramps/plugins/webreport/narrativeweb.py:8114
 msgid "Total number of media object references"
 msgstr "Gesamtanzahl der Medienobjektreferenzen"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:130
+#: ../gramps/plugins/gramplet/statsgramplet.py:132
+#: ../gramps/plugins/webreport/narrativeweb.py:8116
 msgid "Number of unique media objects"
 msgstr "Anzahl von einzelnen Medienobjekten"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:135
+#: ../gramps/plugins/gramplet/statsgramplet.py:137
+#: ../gramps/plugins/webreport/narrativeweb.py:8118
 msgid "Total size of media objects"
 msgstr "Gesamtgröße der Medienobjekte"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:139
+#: ../gramps/plugins/gramplet/statsgramplet.py:141
 #: ../gramps/plugins/textreport/summary.py:259
+#: ../gramps/plugins/webreport/narrativeweb.py:8121
 msgid "Missing Media Objects"
 msgstr "Fehlende Medienobjekte"
 
@@ -22965,29 +23152,29 @@ msgstr "Erstellt eine Beziehungengrafik mit GraphViz."
 #. Constant options items
 #.
 #. ------------------------------------------------------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:71
+#: ../gramps/plugins/graph/gvfamilylines.py:73
 #: ../gramps/plugins/graph/gvhourglass.py:57
-#: ../gramps/plugins/graph/gvrelgraph.py:70
+#: ../gramps/plugins/graph/gvrelgraph.py:71
 msgid "B&W outline"
 msgstr "Schwarz-Weiß umrandet"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:72
+#: ../gramps/plugins/graph/gvfamilylines.py:74
 #: ../gramps/plugins/graph/gvhourglass.py:58
-#: ../gramps/plugins/graph/gvrelgraph.py:71
+#: ../gramps/plugins/graph/gvrelgraph.py:72
 msgid "Colored outline"
 msgstr "Farbig umrandet"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:73
+#: ../gramps/plugins/graph/gvfamilylines.py:75
 #: ../gramps/plugins/graph/gvhourglass.py:59
-#: ../gramps/plugins/graph/gvrelgraph.py:72
+#: ../gramps/plugins/graph/gvrelgraph.py:73
 msgid "Color fill"
 msgstr "Farbig gefüllt"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:116
+#: ../gramps/plugins/graph/gvfamilylines.py:118
 msgid "Follow parents to determine \"family lines\""
 msgstr "Folge den Eltern um \"Familienlinien\" fest zu stellen."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:118
+#: ../gramps/plugins/graph/gvfamilylines.py:120
 msgid ""
 "Parents and their ancestors will be considered when determining \"family "
 "lines\"."
@@ -22995,20 +23182,20 @@ msgstr ""
 "Eltern und deren Vorfahren werden in Betracht gezogen, wenn \"Familienlinien"
 "\" bestimmt werden."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:122
+#: ../gramps/plugins/graph/gvfamilylines.py:124
 msgid "Follow children to determine \"family lines\""
 msgstr "Den Kindern folgen, um \"Familienlinien\" fest zu stellen."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:124
+#: ../gramps/plugins/graph/gvfamilylines.py:126
 msgid "Children will be considered when determining \"family lines\"."
 msgstr ""
 "Kinder werden in Betracht gezogen, wenn \"Familienlinien\" bestimmt werden."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:128
+#: ../gramps/plugins/graph/gvfamilylines.py:130
 msgid "Try to remove extra people and families"
 msgstr "Versuche, zusätzliche Personen und Familien zu entfernen."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:130
+#: ../gramps/plugins/graph/gvfamilylines.py:132
 msgid ""
 "People and families not directly related to people of interest will be "
 "removed when determining \"family lines\"."
@@ -23017,27 +23204,27 @@ msgstr ""
 "verwandt sind, werden entfernt, wenn \"Familienlinien\" bestimmt werden."
 
 #. see bug report #2180
-#: ../gramps/plugins/graph/gvfamilylines.py:136
+#: ../gramps/plugins/graph/gvfamilylines.py:138
 #: ../gramps/plugins/graph/gvhourglass.py:349
-#: ../gramps/plugins/graph/gvrelgraph.py:805
+#: ../gramps/plugins/graph/gvrelgraph.py:808
 msgid "Use rounded corners"
 msgstr "Abgerundete Ecken verwenden"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:137
+#: ../gramps/plugins/graph/gvfamilylines.py:139
 #: ../gramps/plugins/graph/gvhourglass.py:351
-#: ../gramps/plugins/graph/gvrelgraph.py:806
+#: ../gramps/plugins/graph/gvrelgraph.py:809
 msgid "Use rounded corners to differentiate between women and men."
 msgstr ""
 "Benutze abgerundete Ecken, um zwischen Frauen und Männern zu unterscheiden."
 
 #. ###############################
-#: ../gramps/plugins/graph/gvfamilylines.py:141
+#: ../gramps/plugins/graph/gvfamilylines.py:143
 #: ../gramps/plugins/graph/gvhourglass.py:341
-#: ../gramps/plugins/graph/gvrelgraph.py:772
+#: ../gramps/plugins/graph/gvrelgraph.py:775
 msgid "Graph coloring"
 msgstr "Diagrammfärbung"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:144
+#: ../gramps/plugins/graph/gvfamilylines.py:146
 msgid ""
 "Males will be shown with blue, females with red, unless otherwise set above "
 "for filled. If the sex of an individual is unknown it will be shown with "
@@ -23047,16 +23234,16 @@ msgstr ""
 "oben anders gesetzt. Bei unbekanntem Geschlecht wird grau benutzt."
 
 #. --------------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:153
+#: ../gramps/plugins/graph/gvfamilylines.py:155
 msgid "People of Interest"
 msgstr "Personen von Interesse"
 
 #. --------------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:156
+#: ../gramps/plugins/graph/gvfamilylines.py:158
 msgid "People of interest"
 msgstr "Personen von Interesse"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:157
+#: ../gramps/plugins/graph/gvfamilylines.py:159
 msgid ""
 "People of interest are used as a starting point when determining \"family "
 "lines\"."
@@ -23064,74 +23251,74 @@ msgstr ""
 "Personen von Interesse werden als Startpunkt zum Bestimmen von "
 "\"Familienlinien\" benutzt."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:161
+#: ../gramps/plugins/graph/gvfamilylines.py:163
 msgid "Limit the number of ancestors"
 msgstr "Anzahl der Ahnen begrenzen"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:163
+#: ../gramps/plugins/graph/gvfamilylines.py:165
 msgid "Whether to limit the number of ancestors."
 msgstr "Legt fest, ob die Anzahl der Ahnen begrenzt wird."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:169
+#: ../gramps/plugins/graph/gvfamilylines.py:171
 msgid "The maximum number of ancestors to include."
 msgstr "Maximale Anzahl der enthaltenen Vorfahren."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:173
+#: ../gramps/plugins/graph/gvfamilylines.py:175
 msgid "Limit the number of descendants"
 msgstr "Anzahl der Nachkommen begrenzen"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:176
+#: ../gramps/plugins/graph/gvfamilylines.py:178
 msgid "Whether to limit the number of descendants."
 msgstr "Legt fest, ob die Anzahl der Nachkommen begrenzt wird."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:182
+#: ../gramps/plugins/graph/gvfamilylines.py:184
 msgid "The maximum number of descendants to include."
 msgstr "Maximale Anzahl der enthaltenen Nachkommen."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:193
+#: ../gramps/plugins/graph/gvfamilylines.py:195
 #: ../gramps/plugins/graph/gvhourglass.py:328
-#: ../gramps/plugins/graph/gvrelgraph.py:720
-#: ../gramps/plugins/textreport/indivcomplete.py:1049
+#: ../gramps/plugins/graph/gvrelgraph.py:723
+#: ../gramps/plugins/textreport/indivcomplete.py:1095
 msgid "Include Gramps ID"
 msgstr "Gramps ID aufnehmen"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:194
+#: ../gramps/plugins/graph/gvfamilylines.py:196
 #: ../gramps/plugins/graph/gvhourglass.py:329
-#: ../gramps/plugins/graph/gvrelgraph.py:721
+#: ../gramps/plugins/graph/gvrelgraph.py:724
 msgid "Do not include"
 msgstr "Nicht aufnehmen"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:195
+#: ../gramps/plugins/graph/gvfamilylines.py:197
 #: ../gramps/plugins/graph/gvhourglass.py:330
-#: ../gramps/plugins/graph/gvrelgraph.py:722
+#: ../gramps/plugins/graph/gvrelgraph.py:725
 msgid "Share an existing line"
 msgstr "An einem existierenden Linie teilnehmen"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:196
+#: ../gramps/plugins/graph/gvfamilylines.py:198
 #: ../gramps/plugins/graph/gvhourglass.py:331
-#: ../gramps/plugins/graph/gvrelgraph.py:723
+#: ../gramps/plugins/graph/gvrelgraph.py:726
 msgid "On a line of its own"
 msgstr "In einer eigenen Linie"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:197
+#: ../gramps/plugins/graph/gvfamilylines.py:199
 #: ../gramps/plugins/graph/gvhourglass.py:332
-#: ../gramps/plugins/graph/gvrelgraph.py:724
+#: ../gramps/plugins/graph/gvrelgraph.py:727
 msgid "Whether (and where) to include Gramps IDs"
 msgstr "Ob (und wo) Gramps IDs enthalten sind"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:200
+#: ../gramps/plugins/graph/gvfamilylines.py:202
 msgid "Include dates"
 msgstr "Daten aufnehmen"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:201
+#: ../gramps/plugins/graph/gvfamilylines.py:203
 msgid "Whether to include dates for people and families."
 msgstr "Legt fest, ob Daten für Personen und Familien enthalten sind."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:206
+#: ../gramps/plugins/graph/gvfamilylines.py:208
 msgid "Limit dates to years only"
 msgstr "Daten auf Jahre begrenzen"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:207
+#: ../gramps/plugins/graph/gvfamilylines.py:209
 msgid ""
 "Prints just dates' year, neither month or day nor date approximation or "
 "interval are shown."
@@ -23139,15 +23326,15 @@ msgstr ""
 "Druckt nur die Jahre, weder Monate, Tage, noch Schätzungen oder Intervalle "
 "werden gezeigt."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:213
+#: ../gramps/plugins/graph/gvfamilylines.py:215
 msgid "Whether to include placenames for people and families."
 msgstr "Legt fest, ob Ortsnamen für Personen und Familien enthalten sind."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:217
+#: ../gramps/plugins/graph/gvfamilylines.py:219
 msgid "Include the number of children"
 msgstr "Anzahl der Kinder aufnehmen"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:219
+#: ../gramps/plugins/graph/gvfamilylines.py:221
 msgid ""
 "Whether to include the number of children for families with more than 1 "
 "child."
@@ -23155,125 +23342,141 @@ msgstr ""
 "Legt fest, ob die Anzahl der Kinder für Familien mit mehr als einem Kind "
 "enthalten ist."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:224
-#: ../gramps/plugins/graph/gvrelgraph.py:736
+#: ../gramps/plugins/graph/gvfamilylines.py:226
+#: ../gramps/plugins/graph/gvrelgraph.py:739
 msgid "Include thumbnail images of people"
 msgstr "Mit Miniaturbildern der Personen"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:227
+#: ../gramps/plugins/graph/gvfamilylines.py:229
 msgid "Whether to include thumbnail images of people."
 msgstr "Legt fest, ob Miniaturbilder von Personen aufgenommen werden."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:232
+#: ../gramps/plugins/graph/gvfamilylines.py:234
 msgid "Thumbnail location"
 msgstr "Miniaturbild Position"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:233
-#: ../gramps/plugins/graph/gvrelgraph.py:743
+#: ../gramps/plugins/graph/gvfamilylines.py:235
+#: ../gramps/plugins/graph/gvrelgraph.py:746
 msgid "Above the name"
 msgstr "Über dem Namen"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:234
-#: ../gramps/plugins/graph/gvrelgraph.py:744
+#: ../gramps/plugins/graph/gvfamilylines.py:236
+#: ../gramps/plugins/graph/gvrelgraph.py:747
 msgid "Beside the name"
 msgstr "Neben dem Namen"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:235
-#: ../gramps/plugins/graph/gvrelgraph.py:746
+#: ../gramps/plugins/graph/gvfamilylines.py:237
+#: ../gramps/plugins/graph/gvrelgraph.py:749
 msgid "Where the thumbnail image should appear relative to the name"
 msgstr ""
 "Legt fest, wo das Miniaturbild im Verhältnis zum Namen erscheinen soll."
 
+#: ../gramps/plugins/graph/gvfamilylines.py:241
+msgid "Thumbnail size"
+msgstr "Miniaturbildgröße"
+
+#: ../gramps/plugins/graph/gvfamilylines.py:243
+msgid "Large"
+msgstr "Groß"
+
+#: ../gramps/plugins/graph/gvfamilylines.py:244
+#, fuzzy
+msgid "Size of the thumbnail image"
+msgstr "Erstelle und verwende nur Miniaturbilder"
+
 #. ----------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:240
+#: ../gramps/plugins/graph/gvfamilylines.py:248
 msgid "Family Colors"
 msgstr "Familienfarben"
 
 #. ----------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:243
+#: ../gramps/plugins/graph/gvfamilylines.py:251
 msgid "Family colors"
 msgstr "Familienfarben"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:244
+#: ../gramps/plugins/graph/gvfamilylines.py:252
 msgid "Colors to use for various family lines."
 msgstr "Farben, die für verschiedene Familienlinien verwendet werden."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:252
-#: ../gramps/plugins/graph/gvrelgraph.py:781
+#: ../gramps/plugins/graph/gvfamilylines.py:260
+#: ../gramps/plugins/graph/gvrelgraph.py:784
 msgid "The color to use to display men."
 msgstr "Die Farbe, die für die Anzeige von Männern verwendet wird."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:256
-#: ../gramps/plugins/graph/gvrelgraph.py:785
+#: ../gramps/plugins/graph/gvfamilylines.py:264
+#: ../gramps/plugins/graph/gvrelgraph.py:788
 msgid "The color to use to display women."
 msgstr "Die Farbe, die für die Anzeige von Frauen verwendet wird."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:260
-#: ../gramps/plugins/graph/gvrelgraph.py:790
+#: ../gramps/plugins/graph/gvfamilylines.py:268
+#: ../gramps/plugins/graph/gvrelgraph.py:793
 msgid "The color to use when the gender is unknown."
 msgstr "Die Farbe die verwendet wird, wenn das Geschlecht unbekannt ist."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:265
-#: ../gramps/plugins/graph/gvrelgraph.py:795
+#: ../gramps/plugins/graph/gvfamilylines.py:273
+#: ../gramps/plugins/graph/gvrelgraph.py:798
 msgid "The color to use to display families."
 msgstr "Die Farbe, die für die Anzeige von Familien verwendet wird."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:364
+#: ../gramps/plugins/graph/gvfamilylines.py:374
+#: ../gramps/plugins/textreport/familygroup.py:675
+#: ../gramps/plugins/textreport/indivcomplete.py:812
 msgid "Empty report"
 msgstr "Leerer Bericht"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:365
+#: ../gramps/plugins/graph/gvfamilylines.py:375
+#: ../gramps/plugins/textreport/familygroup.py:676
+#: ../gramps/plugins/textreport/indivcomplete.py:813
 msgid "You did not specify anybody"
 msgstr "Du hast niemanden angegeben"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:424
+#: ../gramps/plugins/graph/gvfamilylines.py:434
 msgid "Number of people in database:"
 msgstr "Personenanzahl in der Datenbank:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:427
+#: ../gramps/plugins/graph/gvfamilylines.py:437
 msgid "Number of people of interest:"
 msgstr "Personenanzahl von Interesse:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:430
+#: ../gramps/plugins/graph/gvfamilylines.py:440
 msgid "Number of families in database:"
 msgstr "Familienanzahl in der Datenbank:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:433
+#: ../gramps/plugins/graph/gvfamilylines.py:443
 msgid "Number of families of interest:"
 msgstr "Familienanzahl von Interesse:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:437
+#: ../gramps/plugins/graph/gvfamilylines.py:447
 msgid "Additional people removed:"
-msgstr ""
+msgstr "Weitere Personen entfernt:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:440
-#, fuzzy
+#: ../gramps/plugins/graph/gvfamilylines.py:450
 msgid "Additional families removed:"
-msgstr "alle Familien"
+msgstr "Weitere Familien entfernt:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:443
+#: ../gramps/plugins/graph/gvfamilylines.py:453
 msgid "Initial list of people of interest:"
 msgstr "Initiale Liste von Personen von Interesse:"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/graph/gvfamilylines.py:929
+#: ../gramps/plugins/graph/gvfamilylines.py:942
 #, python-brace-format
 msgid "{number_of} child"
 msgid_plural "{number_of} children"
 msgstr[0] "{number_of} Kind"
 msgstr[1] "{number_of} Kinder"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:1004
+#: ../gramps/plugins/graph/gvfamilylines.py:1017
 #, python-format
 msgid "father: %s"
 msgstr "Vater: %s"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:1013
+#: ../gramps/plugins/graph/gvfamilylines.py:1026
 #, python-format
 msgid "mother: %s"
 msgstr "Mutter: %s"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:1025
+#: ../gramps/plugins/graph/gvfamilylines.py:1038
 #, python-format
 msgid "child: %s"
 msgstr "Kind: %s"
@@ -23283,7 +23486,7 @@ msgid "The Center person for the graph"
 msgstr "Die zentrale Person für die Grafik"
 
 #: ../gramps/plugins/graph/gvhourglass.py:318
-#: ../gramps/plugins/textreport/kinshipreport.py:358
+#: ../gramps/plugins/textreport/kinshipreport.py:371
 msgid "Max Descendant Generations"
 msgstr "Max. Nachkommengenerationen"
 
@@ -23292,7 +23495,7 @@ msgid "The number of generations of descendants to include in the graph"
 msgstr "Die Anzahl der Generationen von Nachkommen für die Grafik"
 
 #: ../gramps/plugins/graph/gvhourglass.py:323
-#: ../gramps/plugins/textreport/kinshipreport.py:362
+#: ../gramps/plugins/textreport/kinshipreport.py:375
 msgid "Max Ancestor Generations"
 msgstr "Max. Vorfahrengenerationen"
 
@@ -23302,12 +23505,12 @@ msgstr "Die Anzahl der Vorfahrengenerationen in der Grafik"
 
 #. ###############################
 #: ../gramps/plugins/graph/gvhourglass.py:338
-#: ../gramps/plugins/graph/gvrelgraph.py:769
+#: ../gramps/plugins/graph/gvrelgraph.py:772
 msgid "Graph Style"
 msgstr "Diagrammstil"
 
 #: ../gramps/plugins/graph/gvhourglass.py:344
-#: ../gramps/plugins/graph/gvrelgraph.py:775
+#: ../gramps/plugins/graph/gvrelgraph.py:778
 msgid ""
 "Males will be shown with blue, females with red.  If the sex of an "
 "individual is unknown it will be shown with gray."
@@ -23315,75 +23518,75 @@ msgstr ""
 "Männer werden in blau gezeigt, Frauen in rot. Personen mit unbekanntem "
 "Geschlecht in grau."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:74
+#: ../gramps/plugins/graph/gvrelgraph.py:75
 msgid "Descendants <- Ancestors"
 msgstr "Nachkommen <- Vorfahren"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:75
+#: ../gramps/plugins/graph/gvrelgraph.py:76
 msgid "Descendants -> Ancestors"
 msgstr "Nachkommen -> Vorfahren"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:76
+#: ../gramps/plugins/graph/gvrelgraph.py:77
 msgid "Descendants <-> Ancestors"
 msgstr "Nachkommen <-> Vorfahren"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:77
+#: ../gramps/plugins/graph/gvrelgraph.py:78
 msgid "Descendants - Ancestors"
 msgstr "Nachkommen - Vorfahren"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:668
+#: ../gramps/plugins/graph/gvrelgraph.py:671
 msgid "Determines what people are included in the graph"
 msgstr "Legt fest, welche Personen in der Grafik enthalten sind."
 
 #. ###############################
-#: ../gramps/plugins/graph/gvrelgraph.py:692
+#: ../gramps/plugins/graph/gvrelgraph.py:695
 msgid "Dates and/or Places"
 msgstr "Daten und/oder Orte"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:693
+#: ../gramps/plugins/graph/gvrelgraph.py:696
 msgid "Do not include any dates or places"
 msgstr "Keine Daten oder Orte aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:694
+#: ../gramps/plugins/graph/gvrelgraph.py:697
 msgid "Include (birth, marriage, death) dates, but no places"
 msgstr "Geburts-, Hochzeits- und Sterbedaten aufnehmen, aber keine Orte"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:696
+#: ../gramps/plugins/graph/gvrelgraph.py:699
 msgid "Include (birth, marriage, death) dates, and places"
 msgstr "Geburts-, Hochzeits- und Sterbedaten und Orte aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:698
+#: ../gramps/plugins/graph/gvrelgraph.py:701
 msgid "Include (birth, marriage, death) dates, and places if no dates"
 msgstr ""
 "Geburts-, Hochzeits- und Sterbedaten aufnehmen und Orte wenn kein Datum "
 "vorhanden"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:700
+#: ../gramps/plugins/graph/gvrelgraph.py:703
 msgid "Include (birth, marriage, death) years, but no places"
 msgstr "Geburts-, Hochzeits- und Sterbejahre aber keine Orte aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:702
+#: ../gramps/plugins/graph/gvrelgraph.py:705
 msgid "Include (birth, marriage, death) years, and places"
 msgstr "Geburts-, Hochzeits- und Sterbejahre und Orte aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:704
+#: ../gramps/plugins/graph/gvrelgraph.py:707
 msgid "Include (birth, marriage, death) places, but no dates"
 msgstr "Geburts-, Hochzeits- und Sterbeorte aber keine Daten aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:706
+#: ../gramps/plugins/graph/gvrelgraph.py:709
 msgid "Include (birth, marriage, death) dates and places on same line"
 msgstr ""
 "(Geburts-, Hochzeits- und Sterbe)daten und Orte in der selben Zeile aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:709
+#: ../gramps/plugins/graph/gvrelgraph.py:712
 msgid "Whether to include dates and/or places"
 msgstr "Legt fest, ob Daten und oder Orte enthalten sind."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:712
+#: ../gramps/plugins/graph/gvrelgraph.py:715
 msgid "Include URLs"
 msgstr "URLs aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:713
+#: ../gramps/plugins/graph/gvrelgraph.py:716
 msgid ""
 "Include a URL in each graph node so that PDF and imagemap files can be "
 "generated that contain active links to the files generated by the 'Narrated "
@@ -23393,76 +23596,78 @@ msgstr ""
 "erzeugt werden können, die Links zu den mit \"Erzählende Website generieren"
 "\" erstellten Dateien enthalten."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:728
+#: ../gramps/plugins/graph/gvrelgraph.py:731
+#: ../gramps/plugins/textreport/indivcomplete.py:1108
 msgid "Include relationship to center person"
 msgstr "Mit Beziehungen zur Hauptperson"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:729
+#: ../gramps/plugins/graph/gvrelgraph.py:732
+#: ../gramps/plugins/textreport/indivcomplete.py:1109
 msgid "Whether to show every person's relationship to the center person"
 msgstr "Legt fest, ob die Beziehung jeder Person zur Hauptperson gezeigt wird."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:738
+#: ../gramps/plugins/graph/gvrelgraph.py:741
 msgid "Whether to include thumbnails of people."
 msgstr "Legt fest, ob Miniaturbildern von Personen enthalten sein werden."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:742
+#: ../gramps/plugins/graph/gvrelgraph.py:745
 msgid "Thumbnail Location"
 msgstr "Miniaturbilder Position"
 
 #. occupation = BooleanOption(_("Include occupation"), False)
-#: ../gramps/plugins/graph/gvrelgraph.py:750
+#: ../gramps/plugins/graph/gvrelgraph.py:753
 msgid "Include occupation"
 msgstr "Beruf aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:751
+#: ../gramps/plugins/graph/gvrelgraph.py:754
 msgid "Do not include any occupation"
 msgstr "Keinen Beruf aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:752
+#: ../gramps/plugins/graph/gvrelgraph.py:755
 msgid "Include description of most recent occupation"
 msgstr "Beschreibung des aktuellsten Berufs aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:754
+#: ../gramps/plugins/graph/gvrelgraph.py:757
 msgid "Include date, description and place of all occupations"
 msgstr "Datum, Beschreibung und Ort aller Berufe aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:756
+#: ../gramps/plugins/graph/gvrelgraph.py:759
 msgid "Whether to include the last occupation"
 msgstr "Ob der letzte Beruf aufgenommen wird"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:760
+#: ../gramps/plugins/graph/gvrelgraph.py:763
 msgid "Include relationship debugging numbers also"
 msgstr "Mit Beziehungen Fehlerprüfungnummern"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:763
+#: ../gramps/plugins/graph/gvrelgraph.py:766
 msgid ""
 "Whether to include 'Ga' and 'Gb' also, to debug the relationship calculator"
 msgstr ""
 "Legt fest, ob zur Fehlerbehebung beim Beziehungsrechner auch 'Ga' und 'Gb' "
 "berücksichtigt werden."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:798
+#: ../gramps/plugins/graph/gvrelgraph.py:801
 msgid "Arrowhead direction"
 msgstr "Pfeilrichtungen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:801
+#: ../gramps/plugins/graph/gvrelgraph.py:804
 msgid "Choose the direction that the arrows point."
 msgstr "Richtung der Pfeile auswählen."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:811
+#: ../gramps/plugins/graph/gvrelgraph.py:814
 msgid "Indicate non-birth relationships with dotted lines"
 msgstr "Nicht-leibliche Verwandtschaft durch gestrichelte Linie andeuten."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:812
+#: ../gramps/plugins/graph/gvrelgraph.py:815
 msgid "Non-birth relationships will show up as dotted lines in the graph."
 msgstr ""
 "Nicht-leibliche Verwandtschaft erscheint im Graph als gestrichelte Linie."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:816
+#: ../gramps/plugins/graph/gvrelgraph.py:819
 msgid "Show family nodes"
 msgstr "Familienknoten anzeigen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:817
+#: ../gramps/plugins/graph/gvrelgraph.py:820
 msgid "Families will show up as ellipses, linked to parents and children."
 msgstr ""
 "Familien werden als Ellipsen, verbunden mit den Eltern und Kindern, gezeigt."
@@ -23519,9 +23724,9 @@ msgstr "Daten aus Pro-Gen Dateien importieren"
 msgid "Import data from vCard files"
 msgstr "Daten aus vKarte-Dateien importieren"
 
-#: ../gramps/plugins/importer/importcsv.py:112
-#: ../gramps/plugins/importer/importgedcom.py:123
-#: ../gramps/plugins/importer/importgedcom.py:137
+#: ../gramps/plugins/importer/importcsv.py:122
+#: ../gramps/plugins/importer/importgedcom.py:129
+#: ../gramps/plugins/importer/importgedcom.py:143
 #: ../gramps/plugins/importer/importgeneweb.py:152
 #: ../gramps/plugins/importer/importgeneweb.py:158
 #: ../gramps/plugins/importer/importvcard.py:69
@@ -23530,115 +23735,99 @@ msgstr "Daten aus vKarte-Dateien importieren"
 msgid "%s could not be opened\n"
 msgstr "%s konnte nicht geöffnet werden\n"
 
-#: ../gramps/plugins/importer/importcsv.py:114
-#: ../gramps/plugins/importer/importgedcom.py:146
+#: ../gramps/plugins/importer/importcsv.py:124
+#: ../gramps/plugins/importer/importgedcom.py:152
 #: ../gramps/plugins/importer/importgeneweb.py:161
 #: ../gramps/plugins/importer/importprogen.py:85
 #: ../gramps/plugins/importer/importvcard.py:74
 msgid "Results"
 msgstr "Ergebnisse"
 
-#: ../gramps/plugins/importer/importcsv.py:114
-#: ../gramps/plugins/importer/importgedcom.py:146
+#: ../gramps/plugins/importer/importcsv.py:124
+#: ../gramps/plugins/importer/importgedcom.py:152
 #: ../gramps/plugins/importer/importgeneweb.py:161
 #: ../gramps/plugins/importer/importprogen.py:85
 #: ../gramps/plugins/importer/importvcard.py:74
 msgid "done"
 msgstr "fertig"
 
-#: ../gramps/plugins/importer/importcsv.py:151
+#: ../gramps/plugins/importer/importcsv.py:160
 msgid "given name"
 msgstr "Vorname"
 
-#: ../gramps/plugins/importer/importcsv.py:154
+#: ../gramps/plugins/importer/importcsv.py:163
 msgid "call"
 msgstr "Rufname"
 
-#: ../gramps/plugins/importer/importcsv.py:155
-msgid "Person or Place|Title"
-msgstr "Titel"
-
-#: ../gramps/plugins/importer/importcsv.py:155
+#: ../gramps/plugins/importer/importcsv.py:164
 msgid "Person or Place|title"
 msgstr "Titel"
 
-#: ../gramps/plugins/importer/importcsv.py:158
+#: ../gramps/plugins/importer/importcsv.py:164
+msgid "title"
+msgstr "Titel"
+
+#: ../gramps/plugins/importer/importcsv.py:167
 msgid "gender"
 msgstr "Geschlecht"
 
-#: ../gramps/plugins/importer/importcsv.py:159
+#: ../gramps/plugins/importer/importcsv.py:168
 msgid "source"
 msgstr "Quelle"
 
-#: ../gramps/plugins/importer/importcsv.py:160
+#: ../gramps/plugins/importer/importcsv.py:169
 msgid "note"
 msgstr "Notiz"
 
-#: ../gramps/plugins/importer/importcsv.py:162
+#: ../gramps/plugins/importer/importcsv.py:171
 msgid "birth place"
 msgstr "Geburtsort"
 
-#: ../gramps/plugins/importer/importcsv.py:163
-msgid "Birth place id"
-msgstr "Geburtsort ID"
-
-#: ../gramps/plugins/importer/importcsv.py:164
+#: ../gramps/plugins/importer/importcsv.py:173
 msgid "birth place id"
 msgstr "Geburtsort ID"
 
-#: ../gramps/plugins/importer/importcsv.py:170
+#: ../gramps/plugins/importer/importcsv.py:178
 msgid "birth source"
 msgstr "Geburtsquelle"
 
-#: ../gramps/plugins/importer/importcsv.py:173
+#: ../gramps/plugins/importer/importcsv.py:180
 msgid "baptism place"
 msgstr "Taufort"
 
-#: ../gramps/plugins/importer/importcsv.py:175
-msgid "Baptism place id"
-msgstr "Taufort ID"
-
-#: ../gramps/plugins/importer/importcsv.py:176
+#: ../gramps/plugins/importer/importcsv.py:182
 msgid "baptism place id"
 msgstr "Taufort ID"
 
-#: ../gramps/plugins/importer/importcsv.py:179
+#: ../gramps/plugins/importer/importcsv.py:184
 msgid "baptism date"
 msgstr "Taufdatum"
 
-#: ../gramps/plugins/importer/importcsv.py:182
+#: ../gramps/plugins/importer/importcsv.py:186
 msgid "baptism source"
 msgstr "Taufquelle"
 
-#: ../gramps/plugins/importer/importcsv.py:184
+#: ../gramps/plugins/importer/importcsv.py:187
 msgid "burial place"
 msgstr "Beerdigungsort"
 
-#: ../gramps/plugins/importer/importcsv.py:185
-msgid "Burial place id"
-msgstr "Beerdigungsort ID"
-
-#: ../gramps/plugins/importer/importcsv.py:186
+#: ../gramps/plugins/importer/importcsv.py:189
 msgid "burial place id"
 msgstr "Beerdigungsort ID"
 
-#: ../gramps/plugins/importer/importcsv.py:189
+#: ../gramps/plugins/importer/importcsv.py:191
 msgid "burial date"
 msgstr "Beerdigungsdatum"
 
-#: ../gramps/plugins/importer/importcsv.py:192
+#: ../gramps/plugins/importer/importcsv.py:193
 msgid "burial source"
 msgstr "Beerdigungsquelle"
 
-#: ../gramps/plugins/importer/importcsv.py:194
+#: ../gramps/plugins/importer/importcsv.py:195
 msgid "death place"
 msgstr "Sterbeort"
 
-#: ../gramps/plugins/importer/importcsv.py:195
-msgid "Death place id"
-msgstr "Sterbeort ID"
-
-#: ../gramps/plugins/importer/importcsv.py:196
+#: ../gramps/plugins/importer/importcsv.py:197
 msgid "death place id"
 msgstr "Sterbeort ID"
 
@@ -23646,31 +23835,21 @@ msgstr "Sterbeort ID"
 msgid "death source"
 msgstr "Sterbequelle"
 
-#: ../gramps/plugins/importer/importcsv.py:203
-msgid "Death cause"
-msgstr "Todesursache"
-
 #: ../gramps/plugins/importer/importcsv.py:204
 msgid "death cause"
 msgstr "Todesursache"
-
-#: ../gramps/plugins/importer/importcsv.py:206
-msgid "Gramps id"
-msgstr "Gramps id"
 
 #: ../gramps/plugins/importer/importcsv.py:207
 msgid "person"
 msgstr "Person"
 
+#. ----------------------------------
 #: ../gramps/plugins/importer/importcsv.py:209
 msgid "child"
 msgstr "Kind"
 
-#: ../gramps/plugins/importer/importcsv.py:213
-msgid "Parent2"
-msgstr "Elter2"
-
-#: ../gramps/plugins/importer/importcsv.py:213
+#. ----------------------------------
+#: ../gramps/plugins/importer/importcsv.py:212
 msgid "mother"
 msgstr "Mutter"
 
@@ -23678,11 +23857,7 @@ msgstr "Mutter"
 msgid "parent2"
 msgstr "Elter2"
 
-#: ../gramps/plugins/importer/importcsv.py:216
-msgid "Parent1"
-msgstr "Elter1"
-
-#: ../gramps/plugins/importer/importcsv.py:216
+#: ../gramps/plugins/importer/importcsv.py:215
 msgid "father"
 msgstr "Vater"
 
@@ -23701,6 +23876,10 @@ msgstr "Datum"
 #: ../gramps/plugins/importer/importcsv.py:220
 msgid "place"
 msgstr "Ort"
+
+#: ../gramps/plugins/importer/importcsv.py:221
+msgid "place id"
+msgstr "Ort ID"
 
 #: ../gramps/plugins/importer/importcsv.py:222
 msgid "name"
@@ -23723,10 +23902,6 @@ msgid "code"
 msgstr "Kennung"
 
 #: ../gramps/plugins/importer/importcsv.py:227
-msgid "Enclosed by"
-msgstr "Teil von"
-
-#: ../gramps/plugins/importer/importcsv.py:227
 msgid "enclosed by"
 msgstr "Teil von"
 
@@ -23734,27 +23909,27 @@ msgstr "Teil von"
 msgid "enclosed_by"
 msgstr "Teil_von"
 
-#: ../gramps/plugins/importer/importcsv.py:256
+#: ../gramps/plugins/importer/importcsv.py:255
 #, python-format
 msgid "format error: line %(line)d: %(zero)s"
 msgstr "Formatfehler: Zeile %(line)d: %(zero)s"
 
-#: ../gramps/plugins/importer/importcsv.py:331
+#: ../gramps/plugins/importer/importcsv.py:336
 msgid "CSV Import"
 msgstr "CSV Import"
 
-#: ../gramps/plugins/importer/importcsv.py:333
+#: ../gramps/plugins/importer/importcsv.py:338
 msgid "Reading data..."
 msgstr "Lese Daten..."
 
-#: ../gramps/plugins/importer/importcsv.py:340
+#: ../gramps/plugins/importer/importcsv.py:345
 msgid "CSV import"
 msgstr "CSV Import"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/importer/importcsv.py:348
+#: ../gramps/plugins/importer/importcsv.py:353
 #: ../gramps/plugins/importer/importgeneweb.py:273
-#: ../gramps/plugins/importer/importvcard.py:233
+#: ../gramps/plugins/importer/importvcard.py:247
 #, python-brace-format
 msgid "Import Complete: {number_of} second"
 msgid_plural "Import Complete: {number_of} seconds"
@@ -23826,16 +24001,16 @@ msgstr "Version:"
 msgid "Families:"
 msgstr "Familien:"
 
-#: ../gramps/plugins/importer/importgedcom.py:126
+#: ../gramps/plugins/importer/importgedcom.py:132
 msgid "Invalid GEDCOM file"
 msgstr "Ungültige GEDCOM-Datei"
 
-#: ../gramps/plugins/importer/importgedcom.py:127
+#: ../gramps/plugins/importer/importgedcom.py:133
 #, python-format
 msgid "%s could not be imported"
 msgstr "%s konnte nicht importiert werden"
 
-#: ../gramps/plugins/importer/importgedcom.py:144
+#: ../gramps/plugins/importer/importgedcom.py:150
 msgid "Error reading GEDCOM file"
 msgstr "Fehler beim Lesen der GEDCOM-Datei"
 
@@ -23861,6 +24036,7 @@ msgid "Change Name"
 msgstr "Namen Ändern"
 
 #: ../gramps/plugins/importer/importgeneweb.py:89
+#: ../gramps/plugins/lib/libgedcom.py:603
 msgid "Circumcision"
 msgstr "Beschneidung"
 
@@ -23873,6 +24049,7 @@ msgid "Dotation"
 msgstr "Dotation"
 
 #: ../gramps/plugins/importer/importgeneweb.py:100
+#: ../gramps/plugins/lib/libgedcom.py:609
 msgid "Excommunication"
 msgstr "Exkommunikation"
 
@@ -23881,6 +24058,7 @@ msgid "LDS Family Link"
 msgstr "LDS Familienverknüpfung"
 
 #: ../gramps/plugins/importer/importgeneweb.py:103
+#: ../gramps/plugins/lib/libgedcom.py:611
 msgid "Funeral"
 msgstr "Beerdigung"
 
@@ -24002,8 +24180,8 @@ msgstr ""
 #: ../gramps/plugins/importer/importgrdb.py:61
 #: ../gramps/plugins/importer/importprogen.py:74
 #: ../gramps/plugins/importer/importprogen.py:83
-#: ../gramps/plugins/importer/importxml.py:436
-#: ../gramps/plugins/importer/importxml.py:439
+#: ../gramps/plugins/importer/importxml.py:440
+#: ../gramps/plugins/importer/importxml.py:443
 #, python-format
 msgid "%s could not be opened"
 msgstr "%s konnte nicht geöffnet werden"
@@ -24045,62 +24223,103 @@ msgid "Cannot find DEF file: %(deffname)s"
 msgstr "Kann DEF Datei nicht finden: %(deffname)s"
 
 #. print self.def_.diag()
-#: ../gramps/plugins/importer/importprogen.py:514
+#. TODO no-parent
+#: ../gramps/plugins/importer/importprogen.py:515
 msgid "Import from Pro-Gen"
 msgstr "Aus Pro-Gen importieren"
 
-#: ../gramps/plugins/importer/importprogen.py:520
+#: ../gramps/plugins/importer/importprogen.py:521
 msgid "Pro-Gen import"
 msgstr "Pro-Gen importieren"
 
-#: ../gramps/plugins/importer/importprogen.py:749
+#: ../gramps/plugins/importer/importprogen.py:750
 #, python-format
 msgid "date did not match: '%(text)s' (%(msg)s)"
 msgstr "Datum passt nicht: '%(text)s' (%(msg)s)"
 
 #. The records are numbered 1..N
-#: ../gramps/plugins/importer/importprogen.py:829
+#: ../gramps/plugins/importer/importprogen.py:830
 msgid "Importing individuals"
 msgstr "Importiere Personen"
 
 #. The records are numbered 1..N
-#: ../gramps/plugins/importer/importprogen.py:1104
+#: ../gramps/plugins/importer/importprogen.py:1105
 msgid "Importing families"
 msgstr "Importiere Familien"
 
 #. The records are numbered 1..N
-#: ../gramps/plugins/importer/importprogen.py:1281
+#: ../gramps/plugins/importer/importprogen.py:1282
 msgid "Adding children"
 msgstr "Kinder hinzufügen"
 
-#: ../gramps/plugins/importer/importprogen.py:1292
+#: ../gramps/plugins/importer/importprogen.py:1293
 #, python-format
 msgid "cannot find father for I%(person)s (father=%(id)d)"
 msgstr "Der Vater für I%(person)s (father=%(id)d) kann nicht gefunden werden."
 
-#: ../gramps/plugins/importer/importprogen.py:1295
+#: ../gramps/plugins/importer/importprogen.py:1296
 #, python-format
 msgid "cannot find mother for I%(person)s (mother=%(mother)d)"
 msgstr ""
 "Die Mutter für I%(person)s (mother=%(mother)d) kann nicht gefunden werden."
 
-#: ../gramps/plugins/importer/importvcard.py:227
+#: ../gramps/plugins/importer/importvcard.py:226
+#, python-format
+msgid "Line %(line)5d: %(prob)s\n"
+msgstr "Linie %(line)5d: %(prob)s\n"
+
+#: ../gramps/plugins/importer/importvcard.py:241
 msgid "vCard import"
 msgstr "vKarte importieren"
 
-#: ../gramps/plugins/importer/importvcard.py:316
+#: ../gramps/plugins/importer/importvcard.py:252
+msgid "VCARD import report: No errors detected"
+msgstr "VCARD Importbericht: keine Fehler gefunden"
+
+#: ../gramps/plugins/importer/importvcard.py:254
+#, python-format
+msgid "VCARD import report: %s errors detected\n"
+msgstr "VCARD Importbericht: %s Fehler gefunden"
+
+#: ../gramps/plugins/importer/importvcard.py:319
+#, python-format
+msgid "Token >%(token)s< unknown. line skipped: %(line)s"
+msgstr ""
+
+#: ../gramps/plugins/importer/importvcard.py:333
+msgid ""
+"BEGIN property not properly closed by END property, Gramps can't cope with "
+"nested VCards."
+msgstr ""
+
+#: ../gramps/plugins/importer/importvcard.py:344
 #, python-format
 msgid "Import of VCards version %s is not supported by Gramps."
 msgstr "Der Import von VCards Version %s wird von Gramps nicht unterstützt."
 
-#: ../gramps/plugins/importer/importvcard.py:484
-#, python-brace-format
-msgid "Invalid date {date} in BDAY {vcard_snippet}, preserving date as text."
+#: ../gramps/plugins/importer/importvcard.py:364
+msgid ""
+"VCard is malformed missing the compulsory N property, so there is no name; "
+"skip it."
+msgstr ""
+
+#: ../gramps/plugins/importer/importvcard.py:369
+msgid ""
+"VCard is malformed missing the compulsory FN property, get name from N alone."
+msgstr ""
+
+#: ../gramps/plugins/importer/importvcard.py:373
+msgid "VCard is malformed wrong number of name components."
+msgstr ""
+
+#: ../gramps/plugins/importer/importvcard.py:515
+#, fuzzy, python-brace-format
+msgid "Invalid date in BDAY {vcard_snippet}, preserving date as text."
 msgstr ""
 "Ungültiges Datum {date} in BDAY {vcard_snippet}, Datum wird als Text "
 "gespeichert."
 
-#: ../gramps/plugins/importer/importvcard.py:492
+#: ../gramps/plugins/importer/importvcard.py:523
 #, python-brace-format
 msgid ""
 "Date {vcard_snippet} not in appropriate format yyyy-mm-dd, preserving date "
@@ -24282,26 +24501,26 @@ msgstr ""
 "Objekte, die Kandidaten für das Zusammenfassen sind:\n"
 
 #. there is no old style XML
-#: ../gramps/plugins/importer/importxml.py:804
-#: ../gramps/plugins/importer/importxml.py:1274
-#: ../gramps/plugins/importer/importxml.py:1547
-#: ../gramps/plugins/importer/importxml.py:1966
+#: ../gramps/plugins/importer/importxml.py:808
+#: ../gramps/plugins/importer/importxml.py:1278
+#: ../gramps/plugins/importer/importxml.py:1551
+#: ../gramps/plugins/importer/importxml.py:1970
 msgid "The Gramps Xml you are trying to import is malformed."
 msgstr "Die Gramps XML, die du versuchst zu importieren, ist missgebildet."
 
-#: ../gramps/plugins/importer/importxml.py:805
+#: ../gramps/plugins/importer/importxml.py:809
 msgid "Attributes that link the data together are missing."
 msgstr "Attribute, die die Daten verbinden, fehlen."
 
-#: ../gramps/plugins/importer/importxml.py:909
+#: ../gramps/plugins/importer/importxml.py:913
 msgid "Gramps XML import"
 msgstr "Gramps-XML importieren"
 
-#: ../gramps/plugins/importer/importxml.py:944
+#: ../gramps/plugins/importer/importxml.py:948
 msgid "Could not change media path"
 msgstr "Konnte Medienpfad nicht ändern"
 
-#: ../gramps/plugins/importer/importxml.py:945
+#: ../gramps/plugins/importer/importxml.py:949
 #, python-format
 msgid ""
 "The opened file has media path %s, which conflicts with the media path of "
@@ -24314,7 +24533,7 @@ msgstr ""
 "wurde beibehalten. Kopiere die Dateien in das korrekte Verzeichnis oder "
 "ändere den Medienpfad der Datenbank in den Einstellungen."
 
-#: ../gramps/plugins/importer/importxml.py:1004
+#: ../gramps/plugins/importer/importxml.py:1008
 msgid ""
 "The .gramps file you are importing does not contain information about the "
 "version of Gramps with, which it was produced.\n"
@@ -24326,11 +24545,11 @@ msgstr ""
 "\n"
 "Die Datei wird nicht importiert."
 
-#: ../gramps/plugins/importer/importxml.py:1007
+#: ../gramps/plugins/importer/importxml.py:1011
 msgid "Import file misses Gramps version"
 msgstr "Der Importdatei fehlt die Grampsversion."
 
-#: ../gramps/plugins/importer/importxml.py:1009
+#: ../gramps/plugins/importer/importxml.py:1013
 #, python-format
 msgid ""
 "The .gramps file you are importing was made by version %(newer)s of Gramps, "
@@ -24342,7 +24561,7 @@ msgstr ""
 "nicht importiert. Bitte wechsele auf die neuste Version von Gramps und "
 "versuche es erneut."
 
-#: ../gramps/plugins/importer/importxml.py:1017
+#: ../gramps/plugins/importer/importxml.py:1021
 #, python-format
 msgid ""
 "The .gramps file you are importing was made by version %(oldgramps)s of "
@@ -24363,11 +24582,11 @@ msgstr ""
 "  %(gramps_wiki_xml_url)s\n"
 "für mehr Informationen."
 
-#: ../gramps/plugins/importer/importxml.py:1028
+#: ../gramps/plugins/importer/importxml.py:1032
 msgid "The file will not be imported"
 msgstr "Die Datei wird nicht importiert"
 
-#: ../gramps/plugins/importer/importxml.py:1030
+#: ../gramps/plugins/importer/importxml.py:1034
 #, python-format
 msgid ""
 "The .gramps file you are importing was made by version %(oldgramps)s of "
@@ -24391,25 +24610,25 @@ msgstr ""
 "  %(gramps_wiki_xml_url)s\n"
 "für mehr Informationen."
 
-#: ../gramps/plugins/importer/importxml.py:1043
+#: ../gramps/plugins/importer/importxml.py:1047
 msgid "Old xml file"
 msgstr "Alte XML Datei"
 
-#: ../gramps/plugins/importer/importxml.py:1195
-#: ../gramps/plugins/importer/importxml.py:2677
+#: ../gramps/plugins/importer/importxml.py:1199
+#: ../gramps/plugins/importer/importxml.py:2681
 #, python-format
 msgid "Witness name: %s"
 msgstr "Namen des Zeugen: %s"
 
-#: ../gramps/plugins/importer/importxml.py:1275
+#: ../gramps/plugins/importer/importxml.py:1279
 msgid "Any event reference must have a 'hlink' attribute."
 msgstr "Alle Ereignisreferenzen müssen ein 'hlink' Attribut besitzen."
 
-#: ../gramps/plugins/importer/importxml.py:1548
+#: ../gramps/plugins/importer/importxml.py:1552
 msgid "Any person reference must have a 'hlink' attribute."
 msgstr "Alle Personenreferenzen müssen ein 'hlink' Attribut besitzen."
 
-#: ../gramps/plugins/importer/importxml.py:1736
+#: ../gramps/plugins/importer/importxml.py:1740
 #, python-format
 msgid ""
 "Your Family Tree groups name \"%(key)s\" together with \"%(parent)s\", did "
@@ -24418,31 +24637,31 @@ msgstr ""
 "Dein Stammbaum gruppiert Name \"%(key)s\" zusammen mit \"%(parent)s\", diese "
 "Gruppierung wurde nicht nach \"%(value)s\" geändert."
 
-#: ../gramps/plugins/importer/importxml.py:1739
+#: ../gramps/plugins/importer/importxml.py:1743
 msgid "Gramps ignored a name grouping"
 msgstr "Gramps hat die Namensgruppierung ignoriert."
 
-#: ../gramps/plugins/importer/importxml.py:1798
+#: ../gramps/plugins/importer/importxml.py:1802
 msgid "Unknown when imported"
 msgstr "Beim Import unbekannt"
 
-#: ../gramps/plugins/importer/importxml.py:1967
+#: ../gramps/plugins/importer/importxml.py:1971
 msgid "Any note reference must have a 'hlink' attribute."
 msgstr "Alle Notizreferenzen müssen ein 'hlink' Attribut besitzen."
 
 #. TRANSLATORS: leave the {date} and {xml} untranslated in the format string,
 #. but you may re-order them if needed.
-#: ../gramps/plugins/importer/importxml.py:2497
+#: ../gramps/plugins/importer/importxml.py:2501
 #, python-brace-format
 msgid "Invalid date {date} in XML {xml}, preserving XML as text"
 msgstr "Ungültiges Datum {date} in XML {xml}, Datum wird als Text gespeichert"
 
-#: ../gramps/plugins/importer/importxml.py:2547
+#: ../gramps/plugins/importer/importxml.py:2551
 #, python-format
 msgid "Witness comment: %s"
 msgstr "Kommentar für Zeugen: %s"
 
-#: ../gramps/plugins/importer/importxml.py:3200
+#: ../gramps/plugins/importer/importxml.py:3204
 #, python-format
 msgid ""
 "Error: family '%(family)s' father '%(father)s' does not refer back to the "
@@ -24451,7 +24670,7 @@ msgstr ""
 "FEHLER: Familie '%(family)s' Vater '%(father)s' verweist nicht zurück auf "
 "die Familie. Eine Referenz wurde hinzugefügt."
 
-#: ../gramps/plugins/importer/importxml.py:3216
+#: ../gramps/plugins/importer/importxml.py:3220
 #, python-format
 msgid ""
 "Error: family '%(family)s' mother '%(mother)s' does not refer back to the "
@@ -24460,7 +24679,7 @@ msgstr ""
 "FEHLER: Familie '%(family)s' Mutter '%(mother)s' verweist nicht zurück auf "
 "die Familie. Eine Referenz wurde hinzugefügt."
 
-#: ../gramps/plugins/importer/importxml.py:3238
+#: ../gramps/plugins/importer/importxml.py:3242
 #, python-format
 msgid ""
 "Error: family '%(family)s' child '%(child)s' does not refer back to the "
@@ -24479,57 +24698,119 @@ msgstr ""
 "Format.\n"
 " Schreibe nach %(filename)s im Format %(impliedext)s!"
 
-#: ../gramps/plugins/lib/libgedcom.py:765
+#: ../gramps/plugins/lib/libgedcom.py:604
+msgid "Common Law Marriage"
+msgstr "Eheähnliche Gemeinschaft "
+
+#: ../gramps/plugins/lib/libgedcom.py:605
+#: ../gramps/plugins/webreport/narrativeweb.py:9634
+#: ../gramps/plugins/webreport/webcal.py:1613
+msgid "Destination"
+msgstr "Ziel"
+
+#: ../gramps/plugins/lib/libgedcom.py:606
+msgid "DNA"
+msgstr "DNA"
+
+#: ../gramps/plugins/lib/libgedcom.py:607
+msgid "Cause of Death"
+msgstr "Todesursache"
+
+#: ../gramps/plugins/lib/libgedcom.py:608
+msgid "Employment"
+msgstr "Beschäftigung"
+
+#: ../gramps/plugins/lib/libgedcom.py:610
+msgid "Eye Color"
+msgstr "Augenfarbe"
+
+#: ../gramps/plugins/lib/libgedcom.py:612
+msgid "Height"
+msgstr "Höhe"
+
+#: ../gramps/plugins/lib/libgedcom.py:613
+msgid "Initiatory (LDS)"
+msgstr ""
+
+#: ../gramps/plugins/lib/libgedcom.py:614
+msgid "Military ID"
+msgstr "Militär ID"
+
+#: ../gramps/plugins/lib/libgedcom.py:615
+#, fuzzy
+msgid "Mission (LDS)"
+msgstr "Sitzungsaufzeichnungen"
+
+#: ../gramps/plugins/lib/libgedcom.py:616
+msgid "Namesake"
+msgstr "Namenspatron"
+
+#: ../gramps/plugins/lib/libgedcom.py:617
+msgid "Ordinance"
+msgstr "Ordination"
+
+#: ../gramps/plugins/lib/libgedcom.py:619
+msgid "Separation"
+msgstr "Trennung"
+
+#. Applies to Families
+#: ../gramps/plugins/lib/libgedcom.py:620
+msgid "Weight"
+msgstr "Gewicht"
+
+#: ../gramps/plugins/lib/libgedcom.py:825
 msgid "Line ignored "
 msgstr "Zeile ignoriert "
 
 #. e.g. Illegal character (oxAB) (0xCB)... 1 NOTE xyz?pqr?lmn
-#: ../gramps/plugins/lib/libgedcom.py:1560
+#: ../gramps/plugins/lib/libgedcom.py:1423
 #, python-format
 msgid "Illegal character%s"
 msgstr "ungültiges Zeichen %s"
 
-#: ../gramps/plugins/lib/libgedcom.py:1828
+#: ../gramps/plugins/lib/libgedcom.py:1696
 msgid "Your GEDCOM file is corrupted. It appears to have been truncated."
 msgstr ""
 "Deine GEDCOM-Datei ist beschädigt. Vermutlich ist die Datei unvollständig."
 
-#: ../gramps/plugins/lib/libgedcom.py:1911
+#: ../gramps/plugins/lib/libgedcom.py:1778
 #, python-format
 msgid "Import from GEDCOM (%s)"
 msgstr "Importieren von GEDCOM (%s)"
 
-#: ../gramps/plugins/lib/libgedcom.py:2711
-#: ../gramps/plugins/lib/libgedcom.py:3127
+#: ../gramps/plugins/lib/libgedcom.py:2614
+#: ../gramps/plugins/lib/libgedcom.py:3062
 msgid "GEDCOM import"
 msgstr "GEDCOM-Import"
 
-#: ../gramps/plugins/lib/libgedcom.py:2739
+#: ../gramps/plugins/lib/libgedcom.py:2642
 msgid "GEDCOM import report: No errors detected"
 msgstr "GEDCOM Importbericht: keine Fehler gefunden"
 
-#: ../gramps/plugins/lib/libgedcom.py:2741
+#: ../gramps/plugins/lib/libgedcom.py:2644
 #, python-format
 msgid "GEDCOM import report: %s errors detected"
 msgstr "GEDCOM Importbericht: %s Fehler gefunden"
 
-#: ../gramps/plugins/lib/libgedcom.py:3048
-msgid "Tag recognized but not supported"
-msgstr "Die Markierung wurde zwar erkannt, wird aber nicht unterstützt."
-
-#: ../gramps/plugins/lib/libgedcom.py:3059
+#: ../gramps/plugins/lib/libgedcom.py:2957
+#: ../gramps/plugins/lib/libgedcom.py:2981
+#: ../gramps/plugins/lib/libgedcom.py:2994
 msgid "Line ignored as not understood"
 msgstr "Die Zeile wurde ignoriert, da sie nicht verstanden wurde."
 
-#: ../gramps/plugins/lib/libgedcom.py:3084
+#: ../gramps/plugins/lib/libgedcom.py:2983
+msgid "Tag recognized but not supported"
+msgstr "Die Markierung wurde zwar erkannt, wird aber nicht unterstützt."
+
+#: ../gramps/plugins/lib/libgedcom.py:3019
 msgid "Skipped subordinate line"
 msgstr "Untergeordnete Zeile übersprungen"
 
-#: ../gramps/plugins/lib/libgedcom.py:3118
+#: ../gramps/plugins/lib/libgedcom.py:3053
 msgid "Records not imported into "
 msgstr "Datensätze nicht importiert nach "
 
-#: ../gramps/plugins/lib/libgedcom.py:3154
+#: ../gramps/plugins/lib/libgedcom.py:3089
 #, python-format
 msgid ""
 "Error: %(msg)s  '%(gramps_id)s' (input as @%(xref)s@) not in input GEDCOM. "
@@ -24538,7 +24819,7 @@ msgstr ""
 "FEHLER: %(msg)s  '%(gramps_id)s' (eingelesen als @%(xref)s@) ist nicht im "
 "eingelesenen GEDCOM. Der Datensatz wird synthetisiert."
 
-#: ../gramps/plugins/lib/libgedcom.py:3163
+#: ../gramps/plugins/lib/libgedcom.py:3098
 #, python-format
 msgid ""
 "Error: %(msg)s '%(gramps_id)s' (input as @%(xref)s@) not in input GEDCOM. "
@@ -24548,7 +24829,7 @@ msgstr ""
 "eingelesenen GEDCOM. Der Datensatz wird mit dem versinnbildlichenden "
 "Attribut 'Unbekannt' erstellt."
 
-#: ../gramps/plugins/lib/libgedcom.py:3202
+#: ../gramps/plugins/lib/libgedcom.py:3143
 #, python-format
 msgid ""
 "Error: family '%(family)s' (input as @%(orig_family)s@) person %(person)s "
@@ -24559,7 +24840,7 @@ msgstr ""
 "%(person)s (eingelesen als %(orig_person)s) ist kein referenziertes Mitglied "
 "der Familie. Die Familienreferenz wurde von der Person entfernt."
 
-#: ../gramps/plugins/lib/libgedcom.py:3280
+#: ../gramps/plugins/lib/libgedcom.py:3221
 #, python-format
 msgid ""
 "\n"
@@ -24579,196 +24860,177 @@ msgstr ""
 #. message means that the element %s was ignored, but
 #. expressed the wrong way round because the message is
 #. truncated for output
-#: ../gramps/plugins/lib/libgedcom.py:3352
+#: ../gramps/plugins/lib/libgedcom.py:3293
 #, python-format
 msgid "ADDR element ignored '%s'"
 msgstr "ADDR Element ignoriert '%s'"
 
-#: ../gramps/plugins/lib/libgedcom.py:3372
+#: ../gramps/plugins/lib/libgedcom.py:3313
 msgid "TRLR (trailer)"
 msgstr "TRLR (Anhang)"
 
-#: ../gramps/plugins/lib/libgedcom.py:3401
+#: ../gramps/plugins/lib/libgedcom.py:3342
 msgid "(Submitter):"
 msgstr "(Ersteller):"
 
-#: ../gramps/plugins/lib/libgedcom.py:3432
-#: ../gramps/plugins/lib/libgedcom.py:7024
+#: ../gramps/plugins/lib/libgedcom.py:3366
+#: ../gramps/plugins/lib/libgedcom.py:7085
 msgid "GEDCOM data"
 msgstr "GEDCOM Daten"
 
-#: ../gramps/plugins/lib/libgedcom.py:3478
+#: ../gramps/plugins/lib/libgedcom.py:3412
 msgid "Unknown tag"
 msgstr "Unbekannte Markierung"
 
-#: ../gramps/plugins/lib/libgedcom.py:3480
-#: ../gramps/plugins/lib/libgedcom.py:3494
-#: ../gramps/plugins/lib/libgedcom.py:3498
-#: ../gramps/plugins/lib/libgedcom.py:3519
+#: ../gramps/plugins/lib/libgedcom.py:3414
+#: ../gramps/plugins/lib/libgedcom.py:3428
+#: ../gramps/plugins/lib/libgedcom.py:3432
+#: ../gramps/plugins/lib/libgedcom.py:3453
 msgid "Top Level"
 msgstr "Oberste Ebene"
 
-#: ../gramps/plugins/lib/libgedcom.py:3591
+#: ../gramps/plugins/lib/libgedcom.py:3528
 #, python-format
 msgid "INDI (individual) Gramps ID %s"
 msgstr "INDI (Individium) Gramps ID %s"
 
-#: ../gramps/plugins/lib/libgedcom.py:3708
+#: ../gramps/plugins/lib/libgedcom.py:3647
 msgid "Empty Alias <NAME PERSONAL> ignored"
 msgstr "Leerer Alias <PERSÖNLICHER NAME> ignoriert"
 
-#: ../gramps/plugins/lib/libgedcom.py:3788
-#: ../gramps/plugins/lib/libgedcom.py:5121
-#: ../gramps/plugins/lib/libgedcom.py:5349
-#: ../gramps/plugins/lib/libgedcom.py:5482
-#: ../gramps/plugins/lib/libgedcom.py:6152
-#: ../gramps/plugins/lib/libgedcom.py:6305
-msgid "Filename omitted"
-msgstr "Dateiname ausgelassen"
-
-#: ../gramps/plugins/lib/libgedcom.py:3790
-#: ../gramps/plugins/lib/libgedcom.py:5123
-#: ../gramps/plugins/lib/libgedcom.py:5351
-#: ../gramps/plugins/lib/libgedcom.py:5484
-#: ../gramps/plugins/lib/libgedcom.py:6154
-#: ../gramps/plugins/lib/libgedcom.py:6307
-msgid "Form omitted"
-msgstr "Formular ausgelassen"
-
-#: ../gramps/plugins/lib/libgedcom.py:4879
+#: ../gramps/plugins/lib/libgedcom.py:4812
 #, python-format
 msgid "FAM (family) Gramps ID %s"
 msgstr "FAM (Familie) Gramps ID: %s"
 
-#: ../gramps/plugins/lib/libgedcom.py:5265
-#: ../gramps/plugins/lib/libgedcom.py:7327
-#: ../gramps/plugins/lib/libgedcom.py:7367
-msgid "Empty note ignored"
-msgstr "Leere Notiz ignoriert"
+#: ../gramps/plugins/lib/libgedcom.py:5164
+#: ../gramps/plugins/lib/libgedcom.py:6518
+msgid "Filename omitted"
+msgstr "Dateiname ausgelassen"
+
+#: ../gramps/plugins/lib/libgedcom.py:5187
+#: ../gramps/plugins/lib/libgedcom.py:6558
+#, python-format
+msgid "Could not import %s"
+msgstr "Kann Datei %s nicht importieren"
+
+#: ../gramps/plugins/lib/libgedcom.py:5244
+#: ../gramps/plugins/lib/libgedcom.py:6659
+msgid "Media-Type"
+msgstr "Medienart"
+
+#: ../gramps/plugins/lib/libgedcom.py:5268
+#: ../gramps/plugins/lib/libgedcom.py:6549
+msgid "Multiple FILE in a single OBJE ignored"
+msgstr "Mehrere FILE in einem einzelnen OBJ ignoriert"
 
 #. We have previously found a PLAC
-#: ../gramps/plugins/lib/libgedcom.py:5420
+#: ../gramps/plugins/lib/libgedcom.py:5423
 msgid "A second PLAC ignored"
 msgstr "Ein zweites PLAC ignoriert"
 
 #. For RootsMagic etc. Place Details e.g. address, hospital, cemetary
-#: ../gramps/plugins/lib/libgedcom.py:5573
+#: ../gramps/plugins/lib/libgedcom.py:5561
 msgid "Detail"
 msgstr "Detail"
 
 #. We have perviously found an ADDR, or have populated location
 #. from PLAC title
-#: ../gramps/plugins/lib/libgedcom.py:5586
+#: ../gramps/plugins/lib/libgedcom.py:5574
 msgid "Location already populated; ADDR ignored"
 msgstr "Örtlichkeit schon bekannt ADDR ignoriert"
 
-#. empty: discard, with warning and skip subs
-#. Note: level+2
-#: ../gramps/plugins/lib/libgedcom.py:5671
-msgid "Empty event note ignored"
-msgstr "Leere Ereignisnotiz ignoriert"
-
-#: ../gramps/plugins/lib/libgedcom.py:5989
-#: ../gramps/plugins/lib/libgedcom.py:6804
+#: ../gramps/plugins/lib/libgedcom.py:5979
+#: ../gramps/plugins/lib/libgedcom.py:6866
 msgid "Warn: ADDR overwritten"
 msgstr "Warn: ADDR überschrieben"
 
-#: ../gramps/plugins/lib/libgedcom.py:6166
-#: ../gramps/plugins/lib/libgedcom.py:6601
+#: ../gramps/plugins/lib/libgedcom.py:6144
+msgid "Citation Justification"
+msgstr "Fundstelle Begründung"
+
+#: ../gramps/plugins/lib/libgedcom.py:6171
 msgid "REFN ignored"
 msgstr "REFN ignoriert"
 
 #. SOURce with the given gramps_id had no title
-#: ../gramps/plugins/lib/libgedcom.py:6265
+#: ../gramps/plugins/lib/libgedcom.py:6270
 #, python-format
 msgid "No title - ID %s"
 msgstr "Kein Titel - ID %s"
 
-#: ../gramps/plugins/lib/libgedcom.py:6270
+#: ../gramps/plugins/lib/libgedcom.py:6275
 #, python-format
 msgid "SOUR (source) Gramps ID %s"
 msgstr "SOUR (Quelle) Gramps ID %s"
 
-#: ../gramps/plugins/lib/libgedcom.py:6526
+#: ../gramps/plugins/lib/libgedcom.py:6525
 #, python-format
 msgid "OBJE (multi-media object) Gramps ID %s"
 msgstr "OBJE (Multimediaobjekt) Gramps ID %s"
 
-#: ../gramps/plugins/lib/libgedcom.py:6554
-#: ../gramps/plugins/lib/libgedcom.py:7556
-#, python-format
-msgid "Could not import %s"
-msgstr "Kann Datei %s nicht importieren"
-
-#: ../gramps/plugins/lib/libgedcom.py:6591
-msgid "BLOB ignored"
-msgstr "BLOB ignoriert"
-
-#: ../gramps/plugins/lib/libgedcom.py:6611
-msgid "Multimedia REFN:TYPE ignored"
-msgstr "Multimedia REFN:TYPE ignoriert"
-
-#: ../gramps/plugins/lib/libgedcom.py:6621
-msgid "Mutimedia RIN ignored"
-msgstr "Mutimedia RIN ignoriert"
-
-#: ../gramps/plugins/lib/libgedcom.py:6708
+#: ../gramps/plugins/lib/libgedcom.py:6755
 #, python-format
 msgid "REPO (repository) Gramps ID %s"
 msgstr "REPO (Aufbewahrungsort) Gramps ID %s"
 
-#: ../gramps/plugins/lib/libgedcom.py:6939
+#: ../gramps/plugins/lib/libgedcom.py:6816
+#: ../gramps/plugins/lib/libgedcom.py:7792
+msgid "Only one phone number supported"
+msgstr "Es wird nur eine Telefonnummer unterstützt"
+
+#: ../gramps/plugins/lib/libgedcom.py:7001
 msgid "HEAD (header)"
 msgstr "Kopf (Dateikopf)"
 
-#: ../gramps/plugins/lib/libgedcom.py:6961
+#: ../gramps/plugins/lib/libgedcom.py:7022
 msgid "Approved system identification"
 msgstr "Anerkannte Systemidentifikation"
 
-#: ../gramps/plugins/lib/libgedcom.py:6973
+#: ../gramps/plugins/lib/libgedcom.py:7034
 msgid "Generated By"
 msgstr "Erstellt von"
 
-#: ../gramps/plugins/lib/libgedcom.py:6989
+#: ../gramps/plugins/lib/libgedcom.py:7050
 msgid "Name of software product"
 msgstr "Name der Software"
 
-#: ../gramps/plugins/lib/libgedcom.py:7003
+#: ../gramps/plugins/lib/libgedcom.py:7064
 msgid "Version number of software product"
 msgstr "Versionsnummer des Programms"
 
-#: ../gramps/plugins/lib/libgedcom.py:7021
+#: ../gramps/plugins/lib/libgedcom.py:7082
 #, python-format
 msgid "Business that produced the product: %s"
 msgstr "Firma die das Produkt herstellt: %s"
 
-#: ../gramps/plugins/lib/libgedcom.py:7043
+#: ../gramps/plugins/lib/libgedcom.py:7104
 msgid "Name of source data"
 msgstr "Name der Quelldaten"
 
-#: ../gramps/plugins/lib/libgedcom.py:7060
+#: ../gramps/plugins/lib/libgedcom.py:7121
 msgid "Copyright of source data"
 msgstr "Copyright der Quelldaten"
 
-#: ../gramps/plugins/lib/libgedcom.py:7077
+#: ../gramps/plugins/lib/libgedcom.py:7138
 msgid "Publication date of source data"
 msgstr "Publikationsdatum der Quelldaten"
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/lib/libgedcom.py:7091
+#: ../gramps/plugins/lib/libgedcom.py:7152
 #, python-format
 msgid "Import from %s"
 msgstr "Aus %s importieren"
 
-#: ../gramps/plugins/lib/libgedcom.py:7130
+#: ../gramps/plugins/lib/libgedcom.py:7191
 msgid "Submission record identifier"
 msgstr "Einreichung Datensatz Bezeichnung"
 
-#: ../gramps/plugins/lib/libgedcom.py:7143
+#: ../gramps/plugins/lib/libgedcom.py:7204
 msgid "Language of GEDCOM text"
 msgstr "Sprache des GEDCOM Text"
 
-#: ../gramps/plugins/lib/libgedcom.py:7169
+#: ../gramps/plugins/lib/libgedcom.py:7225
 #, python-format
 msgid ""
 "Import of GEDCOM file %(filename)s with DEST=%(by)s, could cause errors in "
@@ -24777,83 +25039,88 @@ msgstr ""
 "Import der GEDCOM Datei %(filename)s mit dem ZIEL=%(by)s kann Fehler in der "
 "resultierenden Datenbank verursachen!"
 
-#: ../gramps/plugins/lib/libgedcom.py:7172
+#: ../gramps/plugins/lib/libgedcom.py:7228
 msgid "Look for nameless events."
 msgstr "Suche nach namenlosen Ereignissen."
 
-#: ../gramps/plugins/lib/libgedcom.py:7196
+#: ../gramps/plugins/lib/libgedcom.py:7252
 msgid "Character set"
 msgstr "Zeichensatz"
 
-#: ../gramps/plugins/lib/libgedcom.py:7201
+#: ../gramps/plugins/lib/libgedcom.py:7257
 msgid "Character set and version"
 msgstr "Zeichensatz und Version"
 
-#: ../gramps/plugins/lib/libgedcom.py:7218
+#: ../gramps/plugins/lib/libgedcom.py:7274
 msgid "GEDCOM version not supported"
 msgstr "GEDCOM Version nicht unterstützt"
 
-#: ../gramps/plugins/lib/libgedcom.py:7222
+#: ../gramps/plugins/lib/libgedcom.py:7278
 msgid "GEDCOM version"
 msgstr "GEDCOM Version"
 
 #. Allow Lineage-Linked etc. though it should be in uppercase
-#: ../gramps/plugins/lib/libgedcom.py:7230
+#: ../gramps/plugins/lib/libgedcom.py:7286
 msgid "GEDCOM FORM should be in uppercase"
 msgstr "GEDCOM FORM sollte groß geschrieben sein"
 
-#: ../gramps/plugins/lib/libgedcom.py:7232
+#: ../gramps/plugins/lib/libgedcom.py:7288
 msgid "GEDCOM FORM not supported"
 msgstr "GEDCOM FORM nicht unterstützt"
 
-#: ../gramps/plugins/lib/libgedcom.py:7235
+#: ../gramps/plugins/lib/libgedcom.py:7291
 msgid "GEDCOM form"
 msgstr "GEDCOM Formular"
 
-#: ../gramps/plugins/lib/libgedcom.py:7284
+#: ../gramps/plugins/lib/libgedcom.py:7340
 msgid "Creation date of GEDCOM"
 msgstr "Erstellungsdatum von GEDCOM"
 
-#: ../gramps/plugins/lib/libgedcom.py:7289
+#: ../gramps/plugins/lib/libgedcom.py:7345
 msgid "Creation date and time of GEDCOM"
 msgstr "Erstellungsdatum und Zeit des GEDCOM"
 
-#: ../gramps/plugins/lib/libgedcom.py:7382
+#: ../gramps/plugins/lib/libgedcom.py:7386
+#: ../gramps/plugins/lib/libgedcom.py:7428
+msgid "Empty note ignored"
+msgstr "Leere Notiz ignoriert"
+
+#: ../gramps/plugins/lib/libgedcom.py:7444
 #, python-format
 msgid "NOTE Gramps ID %s"
 msgstr "Notiz Gramps ID: %s"
 
-#: ../gramps/plugins/lib/libgedcom.py:7432
+#: ../gramps/plugins/lib/libgedcom.py:7495
 msgid "Submission: Submitter"
 msgstr "Einreichung: Antragsteller"
 
-#: ../gramps/plugins/lib/libgedcom.py:7434
+#: ../gramps/plugins/lib/libgedcom.py:7497
 msgid "Submission: Family file"
 msgstr "Einreichung: Familiendatei"
 
-#: ../gramps/plugins/lib/libgedcom.py:7436
+#: ../gramps/plugins/lib/libgedcom.py:7499
 msgid "Submission: Temple code"
 msgstr "Einreichung: Tempelkode"
 
-#: ../gramps/plugins/lib/libgedcom.py:7438
+#: ../gramps/plugins/lib/libgedcom.py:7501
 msgid "Submission: Generations of ancestors"
 msgstr "Einreichung: Generationen der Vorfahren"
 
-#: ../gramps/plugins/lib/libgedcom.py:7440
+#: ../gramps/plugins/lib/libgedcom.py:7503
 msgid "Submission: Generations of descendants"
 msgstr "Einreichung: Generationen der Nachkommen"
 
-#: ../gramps/plugins/lib/libgedcom.py:7442
+#: ../gramps/plugins/lib/libgedcom.py:7505
 msgid "Submission: Ordinance process flag"
 msgstr "Einreichung: Ordinance process flag"
 
 #. # Okay we have no clue which temple this is.
 #. # We should tell the user and store it anyway.
-#: ../gramps/plugins/lib/libgedcom.py:7663
+#: ../gramps/plugins/lib/libgedcom.py:7731
 msgid "Invalid temple code"
 msgstr "Ungültiger Tempelkode"
 
-#: ../gramps/plugins/lib/libgedcom.py:7751
+#: ../gramps/plugins/lib/libgedcom.py:7825
 msgid ""
 "Your GEDCOM file is corrupted. The file appears to be encoded using the "
 "UTF16 character set, but is missing the BOM marker."
@@ -24861,7 +25128,7 @@ msgstr ""
 "Deine GEDCOM Datei ist beschädigt. Die Datei scheint UTF16 kodiert zu sein, "
 "aber die BOM Markierung fehlt."
 
-#: ../gramps/plugins/lib/libgedcom.py:7754
+#: ../gramps/plugins/lib/libgedcom.py:7828
 msgid "Your GEDCOM file is empty."
 msgstr "Deine GEDCOM-Datei ist leer."
 
@@ -24908,30 +25175,30 @@ msgstr ""
 msgid "No copyright notice"
 msgstr "Keine Copyright Notiz"
 
-#: ../gramps/plugins/lib/libmetadata.py:60
-#: ../gramps/plugins/lib/libmetadata.py:96
+#: ../gramps/plugins/lib/libmetadata.py:62
+#: ../gramps/plugins/lib/libmetadata.py:98
 msgid "Invalid format"
 msgstr "Ungültiges Format"
 
-#: ../gramps/plugins/lib/libmetadata.py:64
+#: ../gramps/plugins/lib/libmetadata.py:66
 #, python-format
 msgid "%(hr)02d:%(min)02d:%(sec)02d"
 msgstr "%(hr)02d:%(min)02d:%(sec)02d"
 
-#: ../gramps/plugins/lib/libmetadata.py:67
+#: ../gramps/plugins/lib/libmetadata.py:69
 #, python-format
 msgid "%(date)s %(time)s"
 msgstr "%(date)s %(time)s"
 
-#: ../gramps/plugins/lib/libmetadata.py:100
+#: ../gramps/plugins/lib/libmetadata.py:102
 msgid "Camera"
 msgstr "Kamera"
 
-#: ../gramps/plugins/lib/libmetadata.py:101
+#: ../gramps/plugins/lib/libmetadata.py:103
 msgid "GPS"
 msgstr "GPS"
 
-#: ../gramps/plugins/lib/libmetadata.py:102
+#: ../gramps/plugins/lib/libmetadata.py:104
 msgid "Advanced"
 msgstr "Erweitert"
 
@@ -25038,7 +25305,7 @@ msgid "She was born on %(birth_date)s."
 msgstr "Sie wurde am %(birth_date)s geboren."
 
 #: ../gramps/plugins/lib/libnarrate.py:125
-#: ../gramps/plugins/webreport/webcal.py:1991
+#: ../gramps/plugins/webreport/webcal.py:2013
 #, python-format
 msgid "Born %(birth_date)s."
 msgstr "Geboren %(birth_date)s."
@@ -25405,7 +25672,7 @@ msgstr "Sie starb am %(death_date)s im Alter von %(age)s."
 #. latin cross for html code
 #: ../gramps/plugins/lib/libnarrate.py:283
 #: ../gramps/plugins/lib/libnarrate.py:316
-#: ../gramps/plugins/webreport/webcal.py:1981
+#: ../gramps/plugins/webreport/webcal.py:2003
 #, python-format
 msgid "Died %(death_date)s."
 msgstr "Starb %(death_date)s."
@@ -28271,17 +28538,17 @@ msgstr "Das Löschen der Person entfernt die Person aus der Datenbank."
 msgid "Delete Person (%s)"
 msgstr "Person (%s) löschen"
 
-#: ../gramps/plugins/lib/libpersonview.py:369
-#: ../gramps/plugins/view/pedigreeview.py:662
-#: ../gramps/plugins/view/relview.py:421
+#: ../gramps/plugins/lib/libpersonview.py:375
+#: ../gramps/plugins/view/pedigreeview.py:694
+#: ../gramps/plugins/view/relview.py:431
 msgid "Person Filter Editor"
 msgstr "Filtereditor für Personen"
 
-#: ../gramps/plugins/lib/libpersonview.py:374
+#: ../gramps/plugins/lib/libpersonview.py:380
 msgid "Web Connection"
 msgstr "Webverbindung"
 
-#: ../gramps/plugins/lib/libpersonview.py:419
+#: ../gramps/plugins/lib/libpersonview.py:425
 msgid ""
 "Exactly two people must be selected to perform a merge. A second person can "
 "be selected by holding down the control key while clicking on the desired "
@@ -28553,86 +28820,100 @@ msgstr "Unten links"
 msgid "Bottom Right"
 msgstr "Unten rechts"
 
-#: ../gramps/plugins/lib/maps/geography.py:297
-#: ../gramps/plugins/view/fanchartdescview.py:166
-#: ../gramps/plugins/view/fanchartview.py:164
+#: ../gramps/plugins/lib/maps/geography.py:308
+#: ../gramps/plugins/view/fanchart2wayview.py:191
+#: ../gramps/plugins/view/fanchartdescview.py:186
+#: ../gramps/plugins/view/fanchartview.py:182
 msgid "_Print..."
 msgstr "_Drucken..."
 
-#: ../gramps/plugins/lib/maps/geography.py:299
+#: ../gramps/plugins/lib/maps/geography.py:310
 msgid "Print or save the Map"
 msgstr "Die Karte drucken oder speichern"
 
-#: ../gramps/plugins/lib/maps/geography.py:336
+#: ../gramps/plugins/lib/maps/geography.py:347
 msgid "Map Menu"
 msgstr "Kartenmenü"
 
-#: ../gramps/plugins/lib/maps/geography.py:339
+#: ../gramps/plugins/lib/maps/geography.py:350
 msgid "Remove cross hair"
 msgstr "Fadenkreuz entfernen"
 
-#: ../gramps/plugins/lib/maps/geography.py:341
+#: ../gramps/plugins/lib/maps/geography.py:352
 msgid "Add cross hair"
 msgstr "Fadenkreuz hinzufügen"
 
-#: ../gramps/plugins/lib/maps/geography.py:348
+#: ../gramps/plugins/lib/maps/geography.py:359
 msgid "Unlock zoom and position"
 msgstr "Zoom und Position entsperren"
 
-#: ../gramps/plugins/lib/maps/geography.py:350
+#: ../gramps/plugins/lib/maps/geography.py:361
 msgid "Lock zoom and position"
 msgstr "Zoom und Position sperren"
 
-#: ../gramps/plugins/lib/maps/geography.py:357
+#: ../gramps/plugins/lib/maps/geography.py:368
 msgid "Add place"
 msgstr "Ort hinzufügen"
 
-#: ../gramps/plugins/lib/maps/geography.py:362
+#: ../gramps/plugins/lib/maps/geography.py:373
 msgid "Link place"
 msgstr "Ort verknüpfen"
 
-#: ../gramps/plugins/lib/maps/geography.py:367
+#: ../gramps/plugins/lib/maps/geography.py:378
 msgid "Add place from kml"
 msgstr "Ort aus kml hinzufügen"
 
-#: ../gramps/plugins/lib/maps/geography.py:372
+#: ../gramps/plugins/lib/maps/geography.py:383
 msgid "Center here"
 msgstr "Hier zentrieren"
 
-#: ../gramps/plugins/lib/maps/geography.py:385
+#: ../gramps/plugins/lib/maps/geography.py:396
 #, python-format
 msgid "Replace '%(map)s' by =>"
 msgstr "Ersetze '%(map)s' durch =>"
 
-#: ../gramps/plugins/lib/maps/geography.py:404
+#: ../gramps/plugins/lib/maps/geography.py:415
+#, python-format
+msgid "Reload all visible tiles for '%(map)s'."
+msgstr ""
+
+#: ../gramps/plugins/lib/maps/geography.py:425
 #, python-format
 msgid "Clear the '%(map)s' tiles cache."
 msgstr "Leert den  '%(map)s' Kacheln Cache."
 
 #: ../gramps/plugins/lib/maps/geography.py:882
+msgid "You can't use the print functionality"
+msgstr "Du kannst die Druckfunktion nicht verwenden"
+
+#: ../gramps/plugins/lib/maps/geography.py:883
+msgid "Your Gtk version is too old."
+msgstr "Deine Gtk Version ist zu alt."
+
+#: ../gramps/plugins/lib/maps/geography.py:924
 #: ../gramps/plugins/view/geoclose.py:550
-#: ../gramps/plugins/view/geoevents.py:343
-#: ../gramps/plugins/view/geoevents.py:376
-#: ../gramps/plugins/view/geofamclose.py:741
+#: ../gramps/plugins/view/geoevents.py:345
+#: ../gramps/plugins/view/geoevents.py:378
+#: ../gramps/plugins/view/geofamclose.py:740
 #: ../gramps/plugins/view/geofamily.py:434
 #: ../gramps/plugins/view/geomoves.py:625
 #: ../gramps/plugins/view/geoperson.py:445
 #: ../gramps/plugins/view/geoperson.py:466
 #: ../gramps/plugins/view/geoperson.py:506
-#: ../gramps/plugins/view/geoplaces.py:350
-#: ../gramps/plugins/view/geoplaces.py:375
+#: ../gramps/plugins/view/geoplaces.py:434
+#: ../gramps/plugins/view/geoplaces.py:459
 msgid "Center on this place"
 msgstr "Auf diesen Ort zentrieren"
 
-#: ../gramps/plugins/lib/maps/geography.py:961
+#: ../gramps/plugins/lib/maps/geography.py:1003
 msgid "Select a kml file used to add places"
 msgstr "Wähle eine kml Datei um einen Ort hinzuzufügen"
 
-#: ../gramps/plugins/lib/maps/geography.py:1026
+#: ../gramps/plugins/lib/maps/geography.py:1068
 msgid "You have at least two places with the same title."
 msgstr "Du hast mindestens zwei Orte mit dem selben Titel."
 
-#: ../gramps/plugins/lib/maps/geography.py:1027
+#: ../gramps/plugins/lib/maps/geography.py:1069
 #, python-format
 msgid ""
 "The title of the places is:\n"
@@ -28649,19 +28930,19 @@ msgstr ""
 "\n"
 "%(bold_start)sIch kann deine Anfrage nicht durchführen%(bold_end)s.\n"
 
-#: ../gramps/plugins/lib/maps/geography.py:1155
+#: ../gramps/plugins/lib/maps/geography.py:1198
 msgid "Nothing for this view."
 msgstr "Nichts für diese Ansicht."
 
-#: ../gramps/plugins/lib/maps/geography.py:1156
+#: ../gramps/plugins/lib/maps/geography.py:1199
 msgid "Specific parameters"
 msgstr "Bestimmte Parameter"
 
-#: ../gramps/plugins/lib/maps/geography.py:1174
+#: ../gramps/plugins/lib/maps/geography.py:1217
 msgid "Where to save the tiles for offline mode."
 msgstr "Wo die Kacheln für den offline Modus gespeichert werden."
 
-#: ../gramps/plugins/lib/maps/geography.py:1178
+#: ../gramps/plugins/lib/maps/geography.py:1221
 msgid ""
 "If you have no more space in your file system. You can remove all tiles "
 "placed in the above path.\n"
@@ -28671,15 +28952,15 @@ msgstr ""
 "Kacheln die im obigen Pfad liegen entfernen.\n"
 "Sei vorsichtig! Wenn du kein Internet hast, erhältst du keine Karte."
 
-#: ../gramps/plugins/lib/maps/geography.py:1183
+#: ../gramps/plugins/lib/maps/geography.py:1226
 msgid "Zoom used when centering"
 msgstr "Zoom der beim Zentrieren verwendet wird"
 
-#: ../gramps/plugins/lib/maps/geography.py:1187
+#: ../gramps/plugins/lib/maps/geography.py:1230
 msgid "The maximum number of places to show"
 msgstr "Maximale Anzahl der angezeigten Orte"
 
-#: ../gramps/plugins/lib/maps/geography.py:1191
+#: ../gramps/plugins/lib/maps/geography.py:1234
 msgid ""
 "Use keypad for shortcuts :\n"
 "Either we choose the + and - from the keypad if we select this,\n"
@@ -28689,30 +28970,31 @@ msgstr ""
 "Entweder verwenden wir + und - vom Nummernblock wenn wir es wählen, \n"
 "oder wir verwenden die Zeichen von der Tastatur."
 
-#: ../gramps/plugins/lib/maps/geography.py:1197
+#: ../gramps/plugins/lib/maps/geography.py:1240
 msgid "The map"
 msgstr "Die Karte"
 
-#: ../gramps/plugins/lib/maps/geography.py:1213
+#: ../gramps/plugins/lib/maps/geography.py:1256
 msgid "Select tile cache directory for offline mode"
 msgstr "Wähle das Verzeichnis für die Kacheln für de offline Modus"
 
-#: ../gramps/plugins/lib/maps/osmgps.py:119
+#: ../gramps/plugins/lib/maps/osmgps.py:138
 #, python-format
 msgid "Can't create tiles cache directory %s"
 msgstr "Das Kachelzwischenspeicherverzeichnis kann nicht erstellt werden %s."
 
-#: ../gramps/plugins/lib/maps/osmgps.py:141
+#: ../gramps/plugins/lib/maps/osmgps.py:161
+#: ../gramps/plugins/lib/maps/osmgps.py:226
 #, python-format
 msgid "Can't create tiles cache directory for '%s'."
 msgstr "Kann Titelzwischenspeicherverzeichnis für '%s' nicht erstellen."
 
-#: ../gramps/plugins/lib/maps/placeselection.py:106
-#: ../gramps/plugins/lib/maps/placeselection.py:108
+#: ../gramps/plugins/lib/maps/placeselection.py:107
+#: ../gramps/plugins/lib/maps/placeselection.py:109
 msgid "Place Selection in a region"
 msgstr "Ortsauswahl in einem Bereich"
 
-#: ../gramps/plugins/lib/maps/placeselection.py:109
+#: ../gramps/plugins/lib/maps/placeselection.py:110
 msgid ""
 "Choose the radius of the selection.\n"
 "On the map you should see a circle or an oval depending on the latitude."
@@ -28721,14 +29003,14 @@ msgstr ""
 "Auf der Karte solltest du einen Kreis oder Oval abhängig vom Breitengrad "
 "sehen."
 
-#: ../gramps/plugins/lib/maps/placeselection.py:147
+#: ../gramps/plugins/lib/maps/placeselection.py:148
 msgid "The green values in the row correspond to the current place values."
 msgstr ""
 "Die grünen Werte in der Reihe decken sich mit den Werten des aktuellen Orts."
 
 #. here, we could add value from geography names services ...
 #. if we found no place, we must create a default place.
-#: ../gramps/plugins/lib/maps/placeselection.py:197
+#: ../gramps/plugins/lib/maps/placeselection.py:195
 msgid "New place with empty fields"
 msgstr "Neue Orte mit leeren Feldern"
 
@@ -28753,16 +29035,16 @@ msgid "Longitude not within '8.05' to '24.15'"
 msgstr "Länge nicht innerhalb von '8.05' bis '24.15'"
 
 #: ../gramps/plugins/mapservices/eniroswedenmap.py:147
-#: ../gramps/plugins/mapservices/eniroswedenmap.py:174
-#: ../gramps/plugins/mapservices/eniroswedenmap.py:179
+#: ../gramps/plugins/mapservices/eniroswedenmap.py:175
+#: ../gramps/plugins/mapservices/eniroswedenmap.py:181
 msgid "Eniro map not available"
 msgstr "Eniro Karte nicht verfügbar"
 
-#: ../gramps/plugins/mapservices/eniroswedenmap.py:175
+#: ../gramps/plugins/mapservices/eniroswedenmap.py:176
 msgid "Coordinates needed in Denmark"
 msgstr "Koordinaten innerhalb Dänemarks benötigt"
 
-#: ../gramps/plugins/mapservices/eniroswedenmap.py:180
+#: ../gramps/plugins/mapservices/eniroswedenmap.py:182
 msgid ""
 "Latitude and longitude,\n"
 "or street and city needed"
@@ -28787,7 +29069,7 @@ msgid "Open on maps.google.com"
 msgstr "Öffnen auf maps.google.com"
 
 #: ../gramps/plugins/mapservices/mapservice.gpr.py:69
-#: ../gramps/plugins/webreport/narrativeweb.py:9674
+#: ../gramps/plugins/webreport/narrativeweb.py:9974
 msgid "OpenStreetMap"
 msgstr "OpenStreetMap"
 
@@ -28848,7 +29130,7 @@ msgstr "Ereignisort"
 #: ../gramps/plugins/quickview/all_events.py:60
 #: ../gramps/plugins/quickview/all_events.py:105
 #: ../gramps/plugins/quickview/all_events.py:117
-#: ../gramps/plugins/webreport/narrativeweb.py:6702
+#: ../gramps/plugins/webreport/narrativeweb.py:6782
 msgid "Event Type"
 msgstr "Ereignisart"
 
@@ -28876,13 +29158,13 @@ msgid "Home person not set."
 msgstr "Hauptperson nicht gesetzt."
 
 #: ../gramps/plugins/quickview/all_relations.py:79
-#: ../gramps/plugins/tool/relcalc.py:192
+#: ../gramps/plugins/tool/relcalc.py:194
 #, python-format
 msgid "%(person)s and %(active_person)s are the same person."
 msgstr "%(person)s und %(active_person)s sind die selbe Person."
 
 #: ../gramps/plugins/quickview/all_relations.py:88
-#: ../gramps/plugins/tool/relcalc.py:205
+#: ../gramps/plugins/tool/relcalc.py:207
 #, python-format
 msgid "%(person)s is the %(relationship)s of %(active_person)s."
 msgstr "%(person)s ist der/die %(relationship)s von %(active_person)s."
@@ -28917,12 +29199,11 @@ msgid "Parent"
 msgstr "Elter"
 
 #: ../gramps/plugins/quickview/all_relations.py:286
-#: ../gramps/plugins/view/relview.py:404
-#: ../gramps/plugins/webreport/narrativeweb.py:381
-#: ../gramps/plugins/webreport/narrativeweb.py:2738
-#: ../gramps/plugins/webreport/narrativeweb.py:2740
-#: ../gramps/plugins/webreport/narrativeweb.py:3266
-#: ../gramps/plugins/webreport/narrativeweb.py:6081
+#: ../gramps/plugins/view/relview.py:414
+#: ../gramps/plugins/webreport/narrativeweb.py:2728
+#: ../gramps/plugins/webreport/narrativeweb.py:2730
+#: ../gramps/plugins/webreport/narrativeweb.py:3260
+#: ../gramps/plugins/webreport/narrativeweb.py:6138
 msgid "Partner"
 msgstr "Partner"
 
@@ -29094,27 +29375,28 @@ msgstr "Objekt"
 #: ../gramps/plugins/quickview/filterbyname.py:91
 #: ../gramps/plugins/quickview/filterbyname.py:116
 #: ../gramps/plugins/textreport/tagreport.py:143
-#: ../gramps/plugins/view/view.gpr.py:180
-#: ../gramps/plugins/view/view.gpr.py:188
-#: ../gramps/plugins/view/view.gpr.py:197
+#: ../gramps/plugins/view/view.gpr.py:195
+#: ../gramps/plugins/view/view.gpr.py:203
+#: ../gramps/plugins/view/view.gpr.py:212
 msgid "People"
 msgstr "Personen"
 
 #: ../gramps/plugins/quickview/filterbyname.py:103
 #: ../gramps/plugins/quickview/filterbyname.py:128
 #: ../gramps/plugins/view/sourceview.py:115
-#: ../gramps/plugins/view/view.gpr.py:250
-#: ../gramps/plugins/view/view.gpr.py:258
-#: ../gramps/plugins/view/view.gpr.py:289
-#: ../gramps/plugins/webreport/narrativeweb.py:386
-#: ../gramps/plugins/webreport/narrativeweb.py:1040
-#: ../gramps/plugins/webreport/narrativeweb.py:1355
-#: ../gramps/plugins/webreport/narrativeweb.py:1673
-#: ../gramps/plugins/webreport/narrativeweb.py:1902
-#: ../gramps/plugins/webreport/narrativeweb.py:1959
-#: ../gramps/plugins/webreport/narrativeweb.py:2021
-#: ../gramps/plugins/webreport/narrativeweb.py:4775
-#: ../gramps/plugins/webreport/narrativeweb.py:4872
+#: ../gramps/plugins/view/view.gpr.py:265
+#: ../gramps/plugins/view/view.gpr.py:273
+#: ../gramps/plugins/view/view.gpr.py:304
+#: ../gramps/plugins/webreport/narrativeweb.py:994
+#: ../gramps/plugins/webreport/narrativeweb.py:1311
+#: ../gramps/plugins/webreport/narrativeweb.py:1486
+#: ../gramps/plugins/webreport/narrativeweb.py:1635
+#: ../gramps/plugins/webreport/narrativeweb.py:1878
+#: ../gramps/plugins/webreport/narrativeweb.py:1937
+#: ../gramps/plugins/webreport/narrativeweb.py:2007
+#: ../gramps/plugins/webreport/narrativeweb.py:4826
+#: ../gramps/plugins/webreport/narrativeweb.py:4923
+#: ../gramps/plugins/webreport/narrativeweb.py:7068
 msgid "Sources"
 msgstr "Quellen"
 
@@ -29122,13 +29404,13 @@ msgstr "Quellen"
 #: ../gramps/plugins/quickview/filterbyname.py:131
 #: ../gramps/plugins/textreport/tagreport.py:637
 #: ../gramps/plugins/view/repoview.py:129
-#: ../gramps/plugins/view/view.gpr.py:235
-#: ../gramps/plugins/view/view.gpr.py:243
-#: ../gramps/plugins/webreport/narrativeweb.py:1903
-#: ../gramps/plugins/webreport/narrativeweb.py:2022
-#: ../gramps/plugins/webreport/narrativeweb.py:3034
-#: ../gramps/plugins/webreport/narrativeweb.py:7658
-#: ../gramps/plugins/webreport/narrativeweb.py:7742
+#: ../gramps/plugins/view/view.gpr.py:250
+#: ../gramps/plugins/view/view.gpr.py:258
+#: ../gramps/plugins/webreport/narrativeweb.py:1879
+#: ../gramps/plugins/webreport/narrativeweb.py:2008
+#: ../gramps/plugins/webreport/narrativeweb.py:3025
+#: ../gramps/plugins/webreport/narrativeweb.py:7726
+#: ../gramps/plugins/webreport/narrativeweb.py:7811
 msgid "Repositories"
 msgstr "Aufbewahrungsorte"
 
@@ -29255,7 +29537,7 @@ msgstr "Keine Geburtsbeziehung mit Kind"
 
 #: ../gramps/plugins/quickview/lineage.py:158
 #: ../gramps/plugins/quickview/lineage.py:178
-#: ../gramps/plugins/tool/verify.py:978
+#: ../gramps/plugins/tool/verify.py:1064
 msgid "Unknown gender"
 msgstr "Unbekanntes Geschlecht"
 
@@ -29449,7 +29731,7 @@ msgid "No references for this %s"
 msgstr "Keine Referenzen für diese %s"
 
 #: ../gramps/plugins/quickview/reporef.py:62
-#: ../gramps/plugins/webreport/narrativeweb.py:3047
+#: ../gramps/plugins/webreport/narrativeweb.py:3040
 msgid "Call number"
 msgstr "Standortnummer/Signatur:"
 
@@ -29632,7 +29914,7 @@ msgstr "Schwedischer Verwandtschaftsrechner"
 msgid "Ukrainian Relationship Calculator"
 msgstr "Ukrainischer Verwandtschaftsrechner"
 
-#: ../gramps/plugins/sidebar/dropdownsidebar.py:159
+#: ../gramps/plugins/sidebar/dropdownsidebar.py:164
 msgid "Click to select a view"
 msgstr "Klicken, um eine Ansicht zu wählen"
 
@@ -29673,42 +29955,47 @@ msgstr "Auswahl von Ansichten aus sich aufklappenden Listen"
 msgid "Expander"
 msgstr "Expander"
 
-#: ../gramps/plugins/textreport/alphabeticalindex.py:64
+#: ../gramps/plugins/textreport/alphabeticalindex.py:65
 #: ../gramps/plugins/textreport/textplugins.gpr.py:390
 msgid "Alphabetical Index"
 msgstr "Alphabetischer Index"
 
-#: ../gramps/plugins/textreport/alphabeticalindex.py:68
+#: ../gramps/plugins/textreport/alphabeticalindex.py:69
 msgid "Index"
 msgstr "Index"
 
-#: ../gramps/plugins/textreport/alphabeticalindex.py:115
+#: ../gramps/plugins/textreport/alphabeticalindex.py:89
+#: ../gramps/plugins/textreport/tableofcontents.py:88
+msgid "Entire Book"
+msgstr "Gesamte Buch"
+
+#: ../gramps/plugins/textreport/alphabeticalindex.py:120
 msgid "The style used for index entries."
 msgstr "Der Stil, der für Indexeinträge verwendet wird."
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/textreport/ancestorreport.py:191
+#: ../gramps/plugins/textreport/ancestorreport.py:192
 #, python-format
 msgid "Ahnentafel Report for %s"
 msgstr "Ahnentafel für %s"
 
-#: ../gramps/plugins/textreport/ancestorreport.py:288
-#: ../gramps/plugins/textreport/detancestralreport.py:792
-#: ../gramps/plugins/textreport/detdescendantreport.py:949
+#: ../gramps/plugins/textreport/ancestorreport.py:297
+#: ../gramps/plugins/textreport/detancestralreport.py:840
+#: ../gramps/plugins/textreport/detdescendantreport.py:1051
 msgid "Page break between generations"
 msgstr "Seitenumbruch zwischen Generationen"
 
-#: ../gramps/plugins/textreport/ancestorreport.py:290
-#: ../gramps/plugins/textreport/detancestralreport.py:794
-#: ../gramps/plugins/textreport/detdescendantreport.py:951
+#: ../gramps/plugins/textreport/ancestorreport.py:299
+#: ../gramps/plugins/textreport/detancestralreport.py:842
+#: ../gramps/plugins/textreport/detdescendantreport.py:1053
 msgid "Whether to start a new page after each generation."
 msgstr "Legt fest, ob nach jeder Generation eine neue Seite begonnen wird."
 
-#: ../gramps/plugins/textreport/ancestorreport.py:293
+#: ../gramps/plugins/textreport/ancestorreport.py:302
 msgid "Add linebreak after each name"
 msgstr "Zeilenumbruch nach jedem Namen"
 
-#: ../gramps/plugins/textreport/ancestorreport.py:294
+#: ../gramps/plugins/textreport/ancestorreport.py:303
 msgid "Indicates if a line break should follow the name."
 msgstr "Zeigt, ob nach dem Namen ein Zeilenumbruch folgt."
 
@@ -29743,72 +30030,74 @@ msgid_plural "{person}, {age}{relation}"
 msgstr[0] "{person}, {age}{relation}"
 msgstr[1] "{person}, {age}{relation}"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:413
-#: ../gramps/plugins/textreport/birthdayreport.py:415
-msgid "Year of report"
-msgstr "Jahr des Berichts"
+#: ../gramps/plugins/textreport/birthdayreport.py:419
+#: ../gramps/plugins/textreport/familygroup.py:710
+#: ../gramps/plugins/textreport/indivcomplete.py:1037
+msgid "Select the filter to be applied to the report."
+msgstr "Filter wählen, um ihn auf den Bericht anzuwenden."
 
-#: ../gramps/plugins/textreport/birthdayreport.py:420
-msgid "Select filter to restrict people that appear on report"
-msgstr "Filter wählen, um Personen einzugrenzen, die im Bericht erscheinen."
-
-#: ../gramps/plugins/textreport/birthdayreport.py:436
+#: ../gramps/plugins/textreport/birthdayreport.py:434
 msgid "Include only living people in the report"
 msgstr "Nur lebende Personen in den Bericht aufnehmen"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:458
+#: ../gramps/plugins/textreport/birthdayreport.py:443
+#: ../gramps/plugins/textreport/birthdayreport.py:445
+msgid "Year of report"
+msgstr "Jahr des Berichts"
+
+#: ../gramps/plugins/textreport/birthdayreport.py:467
 msgid "Select the first day of the week for the report"
 msgstr "Wähle den ersten Tag der Woche für den Bericht"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:469
+#: ../gramps/plugins/textreport/birthdayreport.py:478
 msgid "Include birthdays in the report"
 msgstr "Geburtstage in den Bericht aufnehmen"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:473
+#: ../gramps/plugins/textreport/birthdayreport.py:482
 msgid "Include anniversaries in the report"
 msgstr "Jubiläen in dem Bericht aufnehmen"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:476
+#: ../gramps/plugins/textreport/birthdayreport.py:485
 msgid "Include relationships to center person"
 msgstr "Mit Beziehungen zur Hauptperson"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:478
+#: ../gramps/plugins/textreport/birthdayreport.py:487
 msgid "Include relationships to center person (slower)"
 msgstr "Mit Beziehungen zur Hauptperson (langsamer)"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:485
+#: ../gramps/plugins/textreport/birthdayreport.py:492
 msgid "Title text"
 msgstr "Titeltext"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:486
+#: ../gramps/plugins/textreport/birthdayreport.py:493
 msgid "Title of report"
 msgstr "Titel des Berichts"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:490
+#: ../gramps/plugins/textreport/birthdayreport.py:497
 msgid "First line of text at bottom of report"
 msgstr "Erste Textzeile am Fuß des Berichts."
 
-#: ../gramps/plugins/textreport/birthdayreport.py:494
+#: ../gramps/plugins/textreport/birthdayreport.py:501
 msgid "Second line of text at bottom of report"
 msgstr "Zweite Textzeile am Fuß des Berichts."
 
-#: ../gramps/plugins/textreport/birthdayreport.py:498
+#: ../gramps/plugins/textreport/birthdayreport.py:505
 msgid "Third line of text at bottom of report"
 msgstr "Dritte Textzeile am Fuß des Berichts."
 
-#: ../gramps/plugins/textreport/birthdayreport.py:555
+#: ../gramps/plugins/textreport/birthdayreport.py:574
 msgid "Title text style"
 msgstr "Titeltext Stil"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:558
+#: ../gramps/plugins/textreport/birthdayreport.py:577
 msgid "Data text display"
 msgstr "Daten Textanzeige"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:560
+#: ../gramps/plugins/textreport/birthdayreport.py:579
 msgid "Day text style"
 msgstr "Tagestext Stil"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:563
+#: ../gramps/plugins/textreport/birthdayreport.py:582
 msgid "Month text style"
 msgstr "Monatstext Stil"
 
@@ -29820,167 +30109,183 @@ msgstr "Monatstext Stil"
 msgid "Custom Text"
 msgstr "Benutzer Text"
 
-#: ../gramps/plugins/textreport/custombooktext.py:131
+#: ../gramps/plugins/textreport/custombooktext.py:134
 msgid "Initial Text"
 msgstr "Eingangstext"
 
-#: ../gramps/plugins/textreport/custombooktext.py:132
+#: ../gramps/plugins/textreport/custombooktext.py:135
 msgid "Text to display at the top."
 msgstr "Text, der oben angezeigt werden soll."
 
-#: ../gramps/plugins/textreport/custombooktext.py:135
+#: ../gramps/plugins/textreport/custombooktext.py:138
 msgid "Middle Text"
 msgstr "Mitteltext"
 
-#: ../gramps/plugins/textreport/custombooktext.py:136
+#: ../gramps/plugins/textreport/custombooktext.py:139
 msgid "Text to display in the middle"
 msgstr "Text, der in der Mitte angezeigt werden soll."
 
-#: ../gramps/plugins/textreport/custombooktext.py:139
+#: ../gramps/plugins/textreport/custombooktext.py:142
 msgid "Final Text"
 msgstr "Schlusstext"
 
-#: ../gramps/plugins/textreport/custombooktext.py:140
+#: ../gramps/plugins/textreport/custombooktext.py:143
 msgid "Text to display last."
 msgstr "Text, der am Ende angezeigt werden soll."
 
-#: ../gramps/plugins/textreport/custombooktext.py:152
+#: ../gramps/plugins/textreport/custombooktext.py:165
 msgid "The style used for the first portion of the custom text."
 msgstr "Der Stil, der für den ersten Teil von gewöhnlichem Text benutzt wird."
 
-#: ../gramps/plugins/textreport/custombooktext.py:162
+#: ../gramps/plugins/textreport/custombooktext.py:175
 msgid "The style used for the middle portion of the custom text."
 msgstr "Der Stil, der für den Mittelteil von gewöhnlichem Text benutzt wird."
 
-#: ../gramps/plugins/textreport/custombooktext.py:172
+#: ../gramps/plugins/textreport/custombooktext.py:185
 msgid "The style used for the last portion of the custom text."
 msgstr "Der Stil, der für den letzten Teil von gewöhnlichem Text benutzt wird."
 
-#: ../gramps/plugins/textreport/descendreport.py:235
-#: ../gramps/plugins/textreport/descendreport.py:241
+#: ../gramps/plugins/textreport/descendreport.py:307
+#: ../gramps/plugins/textreport/descendreport.py:313
 #, python-format
 msgid "sp. %(spouse)s"
 msgstr "Partner %(spouse)s"
 
-#: ../gramps/plugins/textreport/descendreport.py:252
+#: ../gramps/plugins/textreport/descendreport.py:324
 #, python-format
 msgid "sp. see %(reference)s: %(spouse)s"
 msgstr "Part. siehe %(reference)s : %(spouse)s"
 
-#: ../gramps/plugins/textreport/descendreport.py:312
+#: ../gramps/plugins/textreport/descendreport.py:384
 #, python-format
 msgid "%s sp."
 msgstr "%s Part."
 
-#: ../gramps/plugins/textreport/descendreport.py:430
-#: ../gramps/plugins/textreport/detdescendantreport.py:935
+#: ../gramps/plugins/textreport/descendreport.py:520
+#: ../gramps/plugins/textreport/detdescendantreport.py:988
 msgid "Numbering system"
 msgstr "Nummerierungssystem"
 
-#: ../gramps/plugins/textreport/descendreport.py:432
+#: ../gramps/plugins/textreport/descendreport.py:522
 msgid "Simple numbering"
 msgstr "Einfache Nummerierung"
 
-#: ../gramps/plugins/textreport/descendreport.py:433
+#: ../gramps/plugins/textreport/descendreport.py:523
+#: ../gramps/plugins/textreport/detdescendantreport.py:992
+msgid "d'Aboville numbering"
+msgstr "d'Aboville Nummerierung"
+
+#: ../gramps/plugins/textreport/descendreport.py:524
+#: ../gramps/plugins/textreport/detdescendantreport.py:990
+msgid "Henry numbering"
+msgstr "Henry-Nummerierung"
+
+#: ../gramps/plugins/textreport/descendreport.py:525
+#: ../gramps/plugins/textreport/detdescendantreport.py:991
+#, fuzzy
+msgid "Modified Henry numbering"
+msgstr "Henry-Nummerierung"
+
+#: ../gramps/plugins/textreport/descendreport.py:526
 msgid "de Villiers/Pama numbering"
 msgstr "de Villiers/Pama Nummerierung"
 
-#: ../gramps/plugins/textreport/descendreport.py:434
+#: ../gramps/plugins/textreport/descendreport.py:527
 msgid "Meurgey de Tupigny numbering"
 msgstr "Meurgey de Tupigny Nummerierung"
 
-#: ../gramps/plugins/textreport/descendreport.py:435
-#: ../gramps/plugins/textreport/detdescendantreport.py:941
+#: ../gramps/plugins/textreport/descendreport.py:528
+#: ../gramps/plugins/textreport/detdescendantreport.py:995
 msgid "The numbering system to be used"
 msgstr "Das Nummerierungssystem, das verwendet wird"
 
-#: ../gramps/plugins/textreport/descendreport.py:442
+#: ../gramps/plugins/textreport/descendreport.py:535
 msgid "Show marriage info"
 msgstr "Heiratsdaten anzeigen"
 
-#: ../gramps/plugins/textreport/descendreport.py:444
+#: ../gramps/plugins/textreport/descendreport.py:537
 msgid "Whether to show marriage information in the report."
 msgstr "Legt fest, ob Heiratsinformationen in dem Bericht enthalten sind."
 
-#: ../gramps/plugins/textreport/descendreport.py:447
+#: ../gramps/plugins/textreport/descendreport.py:540
 msgid "Show divorce info"
 msgstr "Scheidungsinformationen zeigen"
 
-#: ../gramps/plugins/textreport/descendreport.py:448
+#: ../gramps/plugins/textreport/descendreport.py:541
 msgid "Whether to show divorce information in the report."
 msgstr "Legt fest, ob Scheidungsinformationen in dem Bericht enthalten sind."
 
-#: ../gramps/plugins/textreport/descendreport.py:451
+#: ../gramps/plugins/textreport/descendreport.py:544
 msgid "Show duplicate trees"
 msgstr "Doppelte Stammbäume zeigen"
 
-#: ../gramps/plugins/textreport/descendreport.py:453
+#: ../gramps/plugins/textreport/descendreport.py:546
 msgid "Whether to show duplicate Family Trees in the report."
 msgstr "Legt fest, ob doppelte Stammbäume in dem Bericht enthalten sind."
 
-#: ../gramps/plugins/textreport/descendreport.py:485
+#: ../gramps/plugins/textreport/descendreport.py:576
 #, python-format
 msgid "The style used for the level %d display."
 msgstr "Der Stil, der für Anzeigen der Stufe %d verwendet wird."
 
-#: ../gramps/plugins/textreport/descendreport.py:496
+#: ../gramps/plugins/textreport/descendreport.py:587
 #, python-format
 msgid "The style used for the spouse level %d display."
 msgstr ""
 "Der Stil, der für die Anzeige der Stufe des Ehepartners %d verwendet wird."
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/textreport/detancestralreport.py:205
+#: ../gramps/plugins/textreport/detancestralreport.py:206
 #, python-format
 msgid "Ancestral Report for %s"
 msgstr "Ahnenbericht für %s"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:268
-#: ../gramps/plugins/textreport/detdescendantreport.py:822
-#: ../gramps/plugins/textreport/detdescendantreport.py:840
-#: ../gramps/plugins/textreport/detdescendantreport.py:851
-#: ../gramps/plugins/textreport/detdescendantreport.py:877
+#: ../gramps/plugins/textreport/detancestralreport.py:269
+#: ../gramps/plugins/textreport/detdescendantreport.py:866
+#: ../gramps/plugins/textreport/detdescendantreport.py:884
+#: ../gramps/plugins/textreport/detdescendantreport.py:895
+#: ../gramps/plugins/textreport/detdescendantreport.py:921
 #, python-format
 msgid "More about %(person_name)s:"
 msgstr "Mehr über %(person_name)s:"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:304
-#: ../gramps/plugins/textreport/detdescendantreport.py:408
+#: ../gramps/plugins/textreport/detancestralreport.py:305
+#: ../gramps/plugins/textreport/detdescendantreport.py:448
 #, python-format
 msgid "%(name)s is the same person as [%(id_str)s]."
 msgstr "%(name)s ist die gleiche Person wie [%(id_str)s]."
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/textreport/detancestralreport.py:346
-#: ../gramps/plugins/textreport/detdescendantreport.py:809
+#: ../gramps/plugins/textreport/detancestralreport.py:347
+#: ../gramps/plugins/textreport/detdescendantreport.py:853
 #, python-format
 msgid "Notes for %s"
 msgstr "Notizen für %s"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:364
-#: ../gramps/plugins/textreport/detdescendantreport.py:830
+#: ../gramps/plugins/textreport/detancestralreport.py:365
+#: ../gramps/plugins/textreport/detdescendantreport.py:874
 #, python-format
 msgid "%(name_kind)s: %(name)s%(endnotes)s"
 msgstr "%(name_kind)s: %(name)s%(endnotes)s"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:393
-#: ../gramps/plugins/textreport/detdescendantreport.py:864
+#: ../gramps/plugins/textreport/detancestralreport.py:394
+#: ../gramps/plugins/textreport/detdescendantreport.py:908
 msgid "Address: "
 msgstr "Adresse: "
 
 #. translators: needed for Arabic, ignore otherwise
-#: ../gramps/plugins/textreport/detancestralreport.py:402
-#: ../gramps/plugins/textreport/detdescendantreport.py:867
+#: ../gramps/plugins/textreport/detancestralreport.py:403
+#: ../gramps/plugins/textreport/detdescendantreport.py:911
 #, python-format
 msgid "%s, "
 msgstr "%s, "
 
 #. translators: needed for French, ignore otherwise
-#: ../gramps/plugins/textreport/detancestralreport.py:415
-#: ../gramps/plugins/textreport/detancestralreport.py:483
-#: ../gramps/plugins/textreport/detdescendantreport.py:483
-#: ../gramps/plugins/textreport/detdescendantreport.py:746
-#: ../gramps/plugins/textreport/detdescendantreport.py:886
+#: ../gramps/plugins/textreport/detancestralreport.py:416
+#: ../gramps/plugins/textreport/detancestralreport.py:484
+#: ../gramps/plugins/textreport/detdescendantreport.py:524
+#: ../gramps/plugins/textreport/detdescendantreport.py:789
+#: ../gramps/plugins/textreport/detdescendantreport.py:930
 #, python-format
 msgid "%(type)s: %(value)s%(endnotes)s"
 msgstr "%(type)s: %(value)s%(endnotes)s"
@@ -29988,240 +30293,232 @@ msgstr "%(type)s: %(value)s%(endnotes)s"
 #. translators: needed for French, ignore otherwise
 #. translators: for French, else ignore
 #. translators: needed for French, ignore otherwise
-#: ../gramps/plugins/textreport/detancestralreport.py:460
-#: ../gramps/plugins/textreport/detdescendantreport.py:467
-#: ../gramps/plugins/textreport/familygroup.py:135
-#: ../gramps/plugins/textreport/familygroup.py:301
-#: ../gramps/plugins/textreport/indivcomplete.py:850
+#: ../gramps/plugins/textreport/detancestralreport.py:461
+#: ../gramps/plugins/textreport/detdescendantreport.py:508
+#: ../gramps/plugins/textreport/familygroup.py:136
+#: ../gramps/plugins/textreport/familygroup.py:302
 #: ../gramps/plugins/textreport/indivcomplete.py:890
-#: ../gramps/plugins/textreport/indivcomplete.py:960
+#: ../gramps/plugins/textreport/indivcomplete.py:930
+#: ../gramps/plugins/textreport/indivcomplete.py:1001
 #: ../gramps/plugins/textreport/placereport.py:180
 #, python-format
 msgid "%(str1)s: %(str2)s"
 msgstr "%(str1)s: %(str2)s"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:464
+#: ../gramps/plugins/textreport/detancestralreport.py:465
 #, python-format
 msgid "%(event_role)s at %(event_name)s of %(primary_person)s: %(event_text)s"
 msgstr ""
 "%(event_role)s bei %(event_name)s von %(primary_person)s: %(event_text)s"
 
 #. translators: needed for Arabic, ignore otherwise
-#: ../gramps/plugins/textreport/detancestralreport.py:480
-#: ../gramps/plugins/textreport/detdescendantreport.py:367
-#: ../gramps/plugins/textreport/detdescendantreport.py:480
-#: ../gramps/plugins/textreport/familygroup.py:132
+#: ../gramps/plugins/textreport/detancestralreport.py:481
+#: ../gramps/plugins/textreport/detdescendantreport.py:407
+#: ../gramps/plugins/textreport/detdescendantreport.py:521
+#: ../gramps/plugins/textreport/familygroup.py:133
 msgid "; "
 msgstr "; "
 
-#: ../gramps/plugins/textreport/detancestralreport.py:584
-#: ../gramps/plugins/textreport/detdescendantreport.py:633
+#: ../gramps/plugins/textreport/detancestralreport.py:585
+#: ../gramps/plugins/textreport/detdescendantreport.py:676
 #, python-format
 msgid "Children of %(mother_name)s and %(father_name)s"
 msgstr "Kinder von %(mother_name)s und %(father_name)s"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:647
-#: ../gramps/plugins/textreport/detdescendantreport.py:719
-#: ../gramps/plugins/textreport/detdescendantreport.py:738
+#: ../gramps/plugins/textreport/detancestralreport.py:648
+#: ../gramps/plugins/textreport/detdescendantreport.py:762
+#: ../gramps/plugins/textreport/detdescendantreport.py:781
 #, python-format
 msgid "More about %(mother_name)s and %(father_name)s:"
 msgstr "Mehr über %(mother_name)s und %(father_name)s:"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:702
-#: ../gramps/plugins/textreport/detdescendantreport.py:573
+#: ../gramps/plugins/textreport/detancestralreport.py:703
+#: ../gramps/plugins/textreport/detdescendantreport.py:615
 #, python-format
 msgid "Spouse: %s"
 msgstr "Partner(in): %s"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:706
-#: ../gramps/plugins/textreport/detdescendantreport.py:577
+#: ../gramps/plugins/textreport/detancestralreport.py:707
+#: ../gramps/plugins/textreport/detdescendantreport.py:619
 #, python-format
 msgid "Relationship with: %s"
 msgstr "Beziehung mit: %s"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:777
+#: ../gramps/plugins/textreport/detancestralreport.py:786
 msgid "Sosa-Stradonitz number"
 msgstr "Kekule-Nummer"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:779
+#: ../gramps/plugins/textreport/detancestralreport.py:788
 msgid "The Sosa-Stradonitz number of the central person."
 msgstr "Die Kekule-Nummer der zentralen Person."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:797
-#: ../gramps/plugins/textreport/detdescendantreport.py:954
-#: ../gramps/plugins/textreport/indivcomplete.py:1013
-msgid "Page break before end notes"
-msgstr "Seitenumbruch vor Endnotiz"
-
-#: ../gramps/plugins/textreport/detancestralreport.py:799
-#: ../gramps/plugins/textreport/detdescendantreport.py:956
-#: ../gramps/plugins/textreport/indivcomplete.py:1015
-msgid "Whether to start a new page before the end notes."
-msgstr "Legt fest, ob vor der Endnotiz eine neue Seite begonnen wird."
-
-#. Content options
-#. Content
-#: ../gramps/plugins/textreport/detancestralreport.py:806
-#: ../gramps/plugins/textreport/detdescendantreport.py:963
-#: ../gramps/plugins/view/relview.py:1716
-msgid "Content"
-msgstr "Inhalt"
-
-#: ../gramps/plugins/textreport/detancestralreport.py:808
-#: ../gramps/plugins/textreport/detdescendantreport.py:965
+#: ../gramps/plugins/textreport/detancestralreport.py:807
+#: ../gramps/plugins/textreport/detdescendantreport.py:1017
 msgid "Use callname for common name"
 msgstr "Benutze Rufnamen für Namen"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:809
-#: ../gramps/plugins/textreport/detdescendantreport.py:967
+#: ../gramps/plugins/textreport/detancestralreport.py:808
+#: ../gramps/plugins/textreport/detdescendantreport.py:1019
 msgid "Whether to use the call name as the first name."
 msgstr "Legt fest, ob der Rufname als Vorname benutzt wird."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:813
-#: ../gramps/plugins/textreport/detdescendantreport.py:971
+#: ../gramps/plugins/textreport/detancestralreport.py:812
+#: ../gramps/plugins/textreport/detdescendantreport.py:1023
 msgid "Use full dates instead of only the year"
 msgstr "Zeige vollständiges Datum, anstatt nur das Jahr zu verwenden."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:815
-#: ../gramps/plugins/textreport/detdescendantreport.py:973
+#: ../gramps/plugins/textreport/detancestralreport.py:814
+#: ../gramps/plugins/textreport/detdescendantreport.py:1025
 msgid "Whether to use full dates instead of just year."
 msgstr ""
 "Legt fest, ob ein vollständiges Datum anstelle der Jahreszahl benutzt wird."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:818
-#: ../gramps/plugins/textreport/detdescendantreport.py:976
+#: ../gramps/plugins/textreport/detancestralreport.py:817
+#: ../gramps/plugins/textreport/detdescendantreport.py:1028
 msgid "List children"
 msgstr "Kinder auflisten"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:819
-#: ../gramps/plugins/textreport/detdescendantreport.py:977
+#: ../gramps/plugins/textreport/detancestralreport.py:818
+#: ../gramps/plugins/textreport/detdescendantreport.py:1029
 msgid "Whether to list children."
 msgstr "Legt fest, ob Kinder aufgelistet werden."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:822
-#: ../gramps/plugins/textreport/detdescendantreport.py:980
+#: ../gramps/plugins/textreport/detancestralreport.py:821
+#: ../gramps/plugins/textreport/detdescendantreport.py:1032
 msgid "Compute death age"
 msgstr "Alter bei Tot berechnen"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:823
-#: ../gramps/plugins/textreport/detdescendantreport.py:981
+#: ../gramps/plugins/textreport/detancestralreport.py:822
+#: ../gramps/plugins/textreport/detdescendantreport.py:1033
 msgid "Whether to compute a person's age at death."
 msgstr "Legt fest, ob das Alter einer Person beim Tod berechnet wird."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:826
-#: ../gramps/plugins/textreport/detdescendantreport.py:984
+#: ../gramps/plugins/textreport/detancestralreport.py:825
+#: ../gramps/plugins/textreport/detdescendantreport.py:1036
 msgid "Omit duplicate ancestors"
 msgstr "Doppelte Vorfahren weglassen"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:827
-#: ../gramps/plugins/textreport/detdescendantreport.py:985
+#: ../gramps/plugins/textreport/detancestralreport.py:826
+#: ../gramps/plugins/textreport/detdescendantreport.py:1037
 msgid "Whether to omit duplicate ancestors."
 msgstr "Legt fest, ob doppelte Vorfahren weglassen werden."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:830
+#: ../gramps/plugins/textreport/detancestralreport.py:829
 msgid "Use Complete Sentences"
 msgstr "Benutze vollständige Sätze"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:832
-#: ../gramps/plugins/textreport/detdescendantreport.py:990
+#: ../gramps/plugins/textreport/detancestralreport.py:831
+#: ../gramps/plugins/textreport/detdescendantreport.py:1042
 msgid "Whether to use complete sentences or succinct language."
 msgstr "Legt fest, ob vollständige Sätze oder knappe Sprache benutzt wird."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:836
-#: ../gramps/plugins/textreport/detdescendantreport.py:993
+#: ../gramps/plugins/textreport/detancestralreport.py:835
+#: ../gramps/plugins/textreport/detdescendantreport.py:1045
 msgid "Add descendant reference in child list"
 msgstr "Verweis auf Nachfahren in die Liste der Kinder aufnehmen"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:838
-#: ../gramps/plugins/textreport/detdescendantreport.py:996
+#: ../gramps/plugins/textreport/detancestralreport.py:837
+#: ../gramps/plugins/textreport/detdescendantreport.py:1048
 msgid "Whether to add descendant references in child list."
 msgstr ""
 "Legt fest, ob Verweise auf Nachfahren in die Liste der Kinder aufgenommen "
 "wird."
 
 #: ../gramps/plugins/textreport/detancestralreport.py:845
-#: ../gramps/plugins/textreport/detdescendantreport.py:1001
+#: ../gramps/plugins/textreport/detdescendantreport.py:1056
+#: ../gramps/plugins/textreport/indivcomplete.py:1059
+msgid "Page break before end notes"
+msgstr "Seitenumbruch vor Endnotiz"
+
+#: ../gramps/plugins/textreport/detancestralreport.py:847
+#: ../gramps/plugins/textreport/detdescendantreport.py:1058
+#: ../gramps/plugins/textreport/indivcomplete.py:1061
+msgid "Whether to start a new page before the end notes."
+msgstr "Legt fest, ob vor der Endnotiz eine neue Seite begonnen wird."
+
+#: ../gramps/plugins/textreport/detancestralreport.py:854
+#: ../gramps/plugins/textreport/detdescendantreport.py:1072
 msgid "Include notes"
 msgstr "Notizen aufnehmen"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:846
-#: ../gramps/plugins/textreport/detdescendantreport.py:1002
+#: ../gramps/plugins/textreport/detancestralreport.py:855
+#: ../gramps/plugins/textreport/detdescendantreport.py:1073
 msgid "Whether to include notes."
 msgstr "Legt fest, ob Notizen aufgenommen werden."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:849
-#: ../gramps/plugins/textreport/detdescendantreport.py:1005
+#: ../gramps/plugins/textreport/detancestralreport.py:858
+#: ../gramps/plugins/textreport/detdescendantreport.py:1091
 msgid "Include attributes"
 msgstr "Attribute aufnehmen"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:850
-#: ../gramps/plugins/textreport/detdescendantreport.py:1006
-#: ../gramps/plugins/textreport/familygroup.py:758
-#: ../gramps/plugins/textreport/indivcomplete.py:1042
+#: ../gramps/plugins/textreport/detancestralreport.py:859
+#: ../gramps/plugins/textreport/detdescendantreport.py:1092
+#: ../gramps/plugins/textreport/familygroup.py:756
+#: ../gramps/plugins/textreport/indivcomplete.py:1088
 msgid "Whether to include attributes."
 msgstr "Legt fest, ob Attribute aufgenommen werden."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:853
-#: ../gramps/plugins/textreport/detdescendantreport.py:1010
-#: ../gramps/plugins/textreport/indivcomplete.py:1037
+#: ../gramps/plugins/textreport/detancestralreport.py:862
+#: ../gramps/plugins/textreport/detdescendantreport.py:1064
+#: ../gramps/plugins/textreport/indivcomplete.py:1083
 msgid "Include Photo/Images from Gallery"
 msgstr "Fotos/Bilder aus der Galerie aufnehmen"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:854
-#: ../gramps/plugins/textreport/detdescendantreport.py:1011
-#: ../gramps/plugins/textreport/indivcomplete.py:1038
+#: ../gramps/plugins/textreport/detancestralreport.py:863
+#: ../gramps/plugins/textreport/detdescendantreport.py:1065
+#: ../gramps/plugins/textreport/indivcomplete.py:1084
 msgid "Whether to include images."
 msgstr "Legt fest, ob Bilder aufgenommen werden."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:857
-#: ../gramps/plugins/textreport/detdescendantreport.py:1014
+#: ../gramps/plugins/textreport/detancestralreport.py:866
+#: ../gramps/plugins/textreport/detdescendantreport.py:1095
 msgid "Include alternative names"
 msgstr "Alternative Namen mit einbeziehen"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:858
-#: ../gramps/plugins/textreport/detdescendantreport.py:1015
+#: ../gramps/plugins/textreport/detancestralreport.py:867
+#: ../gramps/plugins/textreport/detdescendantreport.py:1096
 msgid "Whether to include other names."
 msgstr "Legt fest, ob andere Namen aufgenommen werden."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:861
-#: ../gramps/plugins/textreport/detdescendantreport.py:1018
+#: ../gramps/plugins/textreport/detancestralreport.py:870
+#: ../gramps/plugins/textreport/detdescendantreport.py:1068
 msgid "Include events"
 msgstr "Ereignisse aufnehmen"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:862
-#: ../gramps/plugins/textreport/detdescendantreport.py:1019
+#: ../gramps/plugins/textreport/detancestralreport.py:871
+#: ../gramps/plugins/textreport/detdescendantreport.py:1069
 msgid "Whether to include events."
 msgstr "Legt fest, ob Ereignisse aufgenommen werden."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:865
-#: ../gramps/plugins/textreport/detdescendantreport.py:1022
+#: ../gramps/plugins/textreport/detancestralreport.py:874
+#: ../gramps/plugins/textreport/detdescendantreport.py:1087
 msgid "Include addresses"
 msgstr "Adressen einbeziehen"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:866
-#: ../gramps/plugins/textreport/detdescendantreport.py:1023
+#: ../gramps/plugins/textreport/detancestralreport.py:875
+#: ../gramps/plugins/textreport/detdescendantreport.py:1088
 msgid "Whether to include addresses."
 msgstr "Legt fest, ob Adressen aufgenommen werden."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:869
-#: ../gramps/plugins/textreport/detdescendantreport.py:1026
+#: ../gramps/plugins/textreport/detancestralreport.py:878
+#: ../gramps/plugins/textreport/detdescendantreport.py:1099
 msgid "Include sources"
 msgstr "Quellen einbeziehen"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:870
-#: ../gramps/plugins/textreport/detdescendantreport.py:1027
+#: ../gramps/plugins/textreport/detancestralreport.py:879
+#: ../gramps/plugins/textreport/detdescendantreport.py:1100
 msgid "Whether to include source references."
 msgstr "Legt fest, ob Quellenangaben einbezogen werden."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:873
-#: ../gramps/plugins/textreport/detdescendantreport.py:1030
-#: ../gramps/plugins/textreport/indivcomplete.py:1029
+#: ../gramps/plugins/textreport/detancestralreport.py:882
+#: ../gramps/plugins/textreport/detdescendantreport.py:1103
+#: ../gramps/plugins/textreport/indivcomplete.py:1075
 msgid "Include sources notes"
 msgstr "Quellennotizen einbeziehen"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:874
-#: ../gramps/plugins/textreport/detdescendantreport.py:1032
-#: ../gramps/plugins/textreport/indivcomplete.py:1031
+#: ../gramps/plugins/textreport/detancestralreport.py:883
+#: ../gramps/plugins/textreport/detdescendantreport.py:1105
+#: ../gramps/plugins/textreport/indivcomplete.py:1077
 msgid ""
 "Whether to include source notes in the Endnotes section. Only works if "
 "Include sources is selected."
@@ -30229,121 +30526,132 @@ msgstr ""
 "Legt fest, ob Quellennotizen in die Schlussnotizen aufgenommen werden. "
 "Funktioniert nur, wenn 'Quellen aufnehmen' gewählt ist."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:879
+#: ../gramps/plugins/textreport/detancestralreport.py:888
 msgid "Include other events"
 msgstr "Andere Ereignisse aufnehmen"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:880
+#: ../gramps/plugins/textreport/detancestralreport.py:889
 msgid "Whether to include other events people participated in."
 msgstr ""
 "Ob andere Ereignisse an denen Personen beteiligt sind aufgenommen werden."
 
 #. How to handle missing information
 #. Missing information
-#: ../gramps/plugins/textreport/detancestralreport.py:886
-#: ../gramps/plugins/textreport/detdescendantreport.py:1059
+#: ../gramps/plugins/textreport/detancestralreport.py:895
+#: ../gramps/plugins/textreport/detdescendantreport.py:1123
 msgid "Missing information"
 msgstr "Fehlende Information"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:888
-#: ../gramps/plugins/textreport/detdescendantreport.py:1062
+#: ../gramps/plugins/textreport/detancestralreport.py:897
+#: ../gramps/plugins/textreport/detdescendantreport.py:1126
 msgid "Replace missing places with ______"
 msgstr "Ersetze fehlende Orte durch ______"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:889
-#: ../gramps/plugins/textreport/detdescendantreport.py:1064
+#: ../gramps/plugins/textreport/detancestralreport.py:898
+#: ../gramps/plugins/textreport/detdescendantreport.py:1128
 msgid "Whether to replace missing Places with blanks."
 msgstr "Legt fest, ob fehlende Orte durch Lücken ersetzt werden."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:892
-#: ../gramps/plugins/textreport/detdescendantreport.py:1067
+#: ../gramps/plugins/textreport/detancestralreport.py:901
+#: ../gramps/plugins/textreport/detdescendantreport.py:1131
 msgid "Replace missing dates with ______"
 msgstr "Ersetze fehlende Daten durch ______"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:893
-#: ../gramps/plugins/textreport/detdescendantreport.py:1068
+#: ../gramps/plugins/textreport/detancestralreport.py:902
+#: ../gramps/plugins/textreport/detdescendantreport.py:1132
 msgid "Whether to replace missing Dates with blanks."
 msgstr "Legt fest, ob fehlende Daten durch Lücken ersetzt werden."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:926
-#: ../gramps/plugins/textreport/detdescendantreport.py:1101
+#: ../gramps/plugins/textreport/detancestralreport.py:935
+#: ../gramps/plugins/textreport/detdescendantreport.py:1165
 msgid "The style used for the children list title."
 msgstr "Der Stil, der für den Titel der Kinderliste verwendet wird."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:936
-#: ../gramps/plugins/textreport/detdescendantreport.py:1111
+#: ../gramps/plugins/textreport/detancestralreport.py:945
+#: ../gramps/plugins/textreport/detdescendantreport.py:1175
 msgid "The style used for the children list."
 msgstr "Der Stil, der für die Kinderliste verwendet wird."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:959
-#: ../gramps/plugins/textreport/detdescendantreport.py:1134
+#: ../gramps/plugins/textreport/detancestralreport.py:968
+#: ../gramps/plugins/textreport/detdescendantreport.py:1198
 msgid "The style used for the first personal entry."
 msgstr "Der Stil, der für den ersten persönlichen Eintrag verwendet wird."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:969
+#: ../gramps/plugins/textreport/detancestralreport.py:978
 msgid "The style used for the More About header."
 msgstr "Der Stil, der für den \"Mehr über\" Kopfzeile verwendet wird."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:979
-#: ../gramps/plugins/textreport/detdescendantreport.py:1156
+#: ../gramps/plugins/textreport/detancestralreport.py:988
+#: ../gramps/plugins/textreport/detdescendantreport.py:1220
 msgid "The style used for additional detail data."
 msgstr "Der Stil, der für die sonstigen genauen Daten verwendet wird."
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/textreport/detdescendantreport.py:299
+#: ../gramps/plugins/textreport/detdescendantreport.py:334
 #, python-format
 msgid "Descendant Report for %(person_name)s"
 msgstr "Nachkommenbericht für %(person_name)s"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:593
+#: ../gramps/plugins/textreport/detdescendantreport.py:635
 #, python-format
 msgid "Ref: %(number)s. %(name)s"
 msgstr "Ref: %(number)s. %(name)s"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:696
+#: ../gramps/plugins/textreport/detdescendantreport.py:739
 #, python-format
 msgid "Notes for %(mother_name)s and %(father_name)s:"
 msgstr "Notizen für %(mother_name)s und %(father_name)s:"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:937
-msgid "Henry numbering"
-msgstr "Henry-Nummerierung"
-
-#: ../gramps/plugins/textreport/detdescendantreport.py:938
-msgid "d'Aboville numbering"
-msgstr "d'Aboville Nummerierung"
-
-#: ../gramps/plugins/textreport/detdescendantreport.py:940
+#: ../gramps/plugins/textreport/detdescendantreport.py:994
 msgid "Record (Modified Register) numbering"
 msgstr "Datensatz (Modifizierte Register) Nummerierung"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:988
+#: ../gramps/plugins/textreport/detdescendantreport.py:998
+#, fuzzy
+msgid "Report structure"
+msgstr "Berichtsdatum"
+
+#: ../gramps/plugins/textreport/detdescendantreport.py:1001
+#, fuzzy
+msgid "show people by generations"
+msgstr "Alle Generationen"
+
+#: ../gramps/plugins/textreport/detdescendantreport.py:1002
+msgid "show people by lineage"
+msgstr ""
+
+#: ../gramps/plugins/textreport/detdescendantreport.py:1003
+#, fuzzy
+msgid "How people are organized in the report"
+msgstr "Legt fest, welche Personen im Bericht enthalten sind."
+
+#: ../gramps/plugins/textreport/detdescendantreport.py:1040
 msgid "Use complete sentences"
 msgstr "Benutze vollständige Sätze"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1036
-#: ../gramps/plugins/textreport/kinshipreport.py:366
+#: ../gramps/plugins/textreport/detdescendantreport.py:1076
+#: ../gramps/plugins/textreport/kinshipreport.py:379
 msgid "Include spouses"
 msgstr "Partner einbeziehen"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1038
+#: ../gramps/plugins/textreport/detdescendantreport.py:1078
 msgid "Whether to include detailed spouse information."
 msgstr ""
 "Legt fest, ob detaillierte Informationen über den Partner enthalten sind."
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1041
+#: ../gramps/plugins/textreport/detdescendantreport.py:1081
 msgid "Include spouse reference"
 msgstr "Partner Referenzen einbeziehen"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1042
+#: ../gramps/plugins/textreport/detdescendantreport.py:1082
 msgid "Whether to include reference to spouse."
 msgstr "Legt fest, ob Referenzen zum Partner einbezogen werden."
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1046
+#: ../gramps/plugins/textreport/detdescendantreport.py:1110
 msgid "Include sign of succession ('+') in child-list"
 msgstr "Mit Nachkommenzeichen ('+') in Kinderliste"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1047
+#: ../gramps/plugins/textreport/detdescendantreport.py:1111
 msgid ""
 "Whether to include a sign ('+') before the descendant number in the child-"
 "list to indicate a child has succession."
@@ -30351,11 +30659,11 @@ msgstr ""
 "Legt fest, ob ein Zeichen ('+') vor der Nachkommennummer in der Kinderliste "
 "angezeigt wird, um anzuzeigen, dass ein Kind Nachkommen hat."
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1052
+#: ../gramps/plugins/textreport/detdescendantreport.py:1116
 msgid "Include path to start-person"
 msgstr "Mit Weg zur Start-Person"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1053
+#: ../gramps/plugins/textreport/detdescendantreport.py:1117
 msgid ""
 "Whether to include the path of descendancy from the start-person to each "
 "descendant."
@@ -30363,345 +30671,352 @@ msgstr ""
 "Legt fest, ob der Pfad der Nachkommenschaft von der Startperson zu jedem "
 "Nachkommen enthalten ist."
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1145
+#: ../gramps/plugins/textreport/detdescendantreport.py:1209
 msgid "The style used for the More About header and for headers of mates."
 msgstr ""
 "Der Stil, der für die \"Mehr über\" Kopfzeile und Kopfzeile von Partnern "
 "verwendet wird."
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/textreport/endoflinereport.py:157
+#: ../gramps/plugins/textreport/endoflinereport.py:158
 #, python-format
 msgid "End of Line Report for %s"
 msgstr "Sackgassen-Liste für %s"
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/textreport/endoflinereport.py:164
+#: ../gramps/plugins/textreport/endoflinereport.py:165
 #, python-format
 msgid "All the ancestors of %s who are missing a parent"
 msgstr "Alle Vorfahren von %s, bei denen ein Elternteil fehlt"
 
-#: ../gramps/plugins/textreport/endoflinereport.py:209
-#: ../gramps/plugins/textreport/kinshipreport.py:319
+#: ../gramps/plugins/textreport/endoflinereport.py:210
+#: ../gramps/plugins/textreport/kinshipreport.py:320
 #, python-format
 msgid " (%(birth_date)s - %(death_date)s)"
 msgstr " (%(birth_date)s - %(death_date)s)"
 
-#: ../gramps/plugins/textreport/endoflinereport.py:296
-#: ../gramps/plugins/textreport/indivcomplete.py:1162
-#: ../gramps/plugins/textreport/notelinkreport.py:183
-#: ../gramps/plugins/textreport/tagreport.py:950
+#: ../gramps/plugins/textreport/endoflinereport.py:305
+#: ../gramps/plugins/textreport/indivcomplete.py:1213
+#: ../gramps/plugins/textreport/notelinkreport.py:188
+#: ../gramps/plugins/textreport/tagreport.py:954
 msgid "The style used for the section headers."
 msgstr "Der Stil, der für die Abschnittsüberschriften verwendet wird."
 
-#: ../gramps/plugins/textreport/endoflinereport.py:315
+#: ../gramps/plugins/textreport/endoflinereport.py:324
 msgid "The basic style used for generation headings."
 msgstr "Der Stil, der für die Generationenüberschriften verwendet wird."
 
-#: ../gramps/plugins/textreport/familygroup.py:502
+#: ../gramps/plugins/textreport/familygroup.py:503
 msgid "acronym for male|M"
 msgstr "M"
 
-#: ../gramps/plugins/textreport/familygroup.py:504
+#: ../gramps/plugins/textreport/familygroup.py:505
 msgid "acronym for female|F"
 msgstr "F"
 
-#: ../gramps/plugins/textreport/familygroup.py:506
+#: ../gramps/plugins/textreport/familygroup.py:507
 #, python-format
 msgid "acronym for unknown|%dU"
 msgstr "%dU"
 
-#: ../gramps/plugins/textreport/familygroup.py:610
+#: ../gramps/plugins/textreport/familygroup.py:611
 #, python-format
 msgid "Family Group Report - Generation %d"
 msgstr "Familien-Blockbericht - Generation %d"
 
-#: ../gramps/plugins/textreport/familygroup.py:612
-#: ../gramps/plugins/textreport/familygroup.py:661
-#: ../gramps/plugins/textreport/familygroup.py:666
-#: ../gramps/plugins/textreport/familygroup.py:675
+#: ../gramps/plugins/textreport/familygroup.py:613
+#: ../gramps/plugins/textreport/familygroup.py:662
+#: ../gramps/plugins/textreport/familygroup.py:667
 #: ../gramps/plugins/textreport/textplugins.gpr.py:188
 msgid "Family Group Report"
 msgstr "Familien Blockbericht"
 
-#: ../gramps/plugins/textreport/familygroup.py:706
-#: ../gramps/plugins/textreport/indivcomplete.py:991
-msgid "Select the filter to be applied to the report."
-msgstr "Filter wählen, um ihn auf den Bericht anzuwenden."
-
-#: ../gramps/plugins/textreport/familygroup.py:710
+#: ../gramps/plugins/textreport/familygroup.py:714
 msgid "Center Family"
 msgstr "Zentrale Familie"
 
-#: ../gramps/plugins/textreport/familygroup.py:711
+#: ../gramps/plugins/textreport/familygroup.py:715
 msgid "The center family for the filter"
 msgstr "Die zentrale Familie für den Filter"
 
-#: ../gramps/plugins/textreport/familygroup.py:724
+#: ../gramps/plugins/textreport/familygroup.py:728
 msgid "Recursive (down)"
 msgstr "Rekursiv (abwärts)"
 
-#: ../gramps/plugins/textreport/familygroup.py:725
+#: ../gramps/plugins/textreport/familygroup.py:729
 msgid "Create reports for all descendants of this family."
 msgstr "Erstellt Berichte für alle Nachkommen dieser Familie."
 
+#. #########################
 #: ../gramps/plugins/textreport/familygroup.py:736
-#: ../gramps/plugins/textreport/indivcomplete.py:1050
+#, fuzzy
+msgid "Include 1"
+msgstr "Einbeziehen"
+
+#: ../gramps/plugins/textreport/familygroup.py:740
+#: ../gramps/plugins/textreport/indivcomplete.py:1096
 msgid "Whether to include Gramps ID next to names."
 msgstr "Legt fest, ob die Gramps ID neben den Namen aufgenommen werden."
 
-#: ../gramps/plugins/textreport/familygroup.py:739
-msgid "Generation numbers (recursive only)"
-msgstr "Generationen-Nummerierung (nur Rekursiv)"
-
-#: ../gramps/plugins/textreport/familygroup.py:741
-msgid "Whether to include the generation on each report (recursive only)."
-msgstr ""
-"Legt fest, ob die Generation auf jedem Bericht angegeben wird (nur rekursiv)."
-
-#: ../gramps/plugins/textreport/familygroup.py:745
+#: ../gramps/plugins/textreport/familygroup.py:743
 msgid "Parent Events"
 msgstr "Ereignisse der Eltern"
 
-#: ../gramps/plugins/textreport/familygroup.py:746
+#: ../gramps/plugins/textreport/familygroup.py:744
 msgid "Whether to include events for parents."
 msgstr "Legt fest, ob Ereignisse für Eltern enthalten sind."
 
-#: ../gramps/plugins/textreport/familygroup.py:749
+#: ../gramps/plugins/textreport/familygroup.py:747
 msgid "Parent Addresses"
 msgstr "Adressen der Eltern"
 
-#: ../gramps/plugins/textreport/familygroup.py:750
+#: ../gramps/plugins/textreport/familygroup.py:748
 msgid "Whether to include addresses for parents."
 msgstr "Legt fest, ob Adressen der Eltern enthalten sind."
 
-#: ../gramps/plugins/textreport/familygroup.py:753
+#: ../gramps/plugins/textreport/familygroup.py:751
 msgid "Parent Notes"
 msgstr "Notizen der Eltern"
 
-#: ../gramps/plugins/textreport/familygroup.py:754
+#: ../gramps/plugins/textreport/familygroup.py:752
 msgid "Whether to include notes for parents."
 msgstr "Legt fest, ob Notizen für Eltern enthalten sind."
 
-#: ../gramps/plugins/textreport/familygroup.py:757
+#: ../gramps/plugins/textreport/familygroup.py:755
 msgid "Parent Attributes"
 msgstr "Attribute der Eltern"
 
-#: ../gramps/plugins/textreport/familygroup.py:761
+#: ../gramps/plugins/textreport/familygroup.py:759
 msgid "Alternate Parent Names"
 msgstr "Alternative Namen der Eltern"
 
-#: ../gramps/plugins/textreport/familygroup.py:763
+#: ../gramps/plugins/textreport/familygroup.py:761
 msgid "Whether to include alternate names for parents."
 msgstr "Legt fest, ob alternative Namen der Eltern enthalten sind."
 
-#: ../gramps/plugins/textreport/familygroup.py:766
+#: ../gramps/plugins/textreport/familygroup.py:764
 msgid "Parent Marriage"
 msgstr "Hochzeit der Eltern"
 
-#: ../gramps/plugins/textreport/familygroup.py:768
+#: ../gramps/plugins/textreport/familygroup.py:766
 msgid "Whether to include marriage information for parents."
 msgstr "Legt fest, ob Heiratsinformationen der Eltern enthalten sind."
 
-#: ../gramps/plugins/textreport/familygroup.py:772
+#. #########################
+#: ../gramps/plugins/textreport/familygroup.py:770
+#, fuzzy
+msgid "Include 2"
+msgstr "Einbeziehen"
+
+#: ../gramps/plugins/textreport/familygroup.py:774
 msgid "Whether to include notes for families."
 msgstr "Ob Notizen für Familien enthalten sind."
 
-#: ../gramps/plugins/textreport/familygroup.py:775
+#: ../gramps/plugins/textreport/familygroup.py:777
 msgid "Dates of Relatives"
 msgstr "Daten der Angehörigen"
 
-#: ../gramps/plugins/textreport/familygroup.py:776
+#: ../gramps/plugins/textreport/familygroup.py:778
 msgid "Whether to include dates for relatives (father, mother, spouse)."
 msgstr ""
 "Legt fest, ob Daten von Verwandten (Vater, Mutter, Partner) enthalten sind."
 
-#: ../gramps/plugins/textreport/familygroup.py:780
+#: ../gramps/plugins/textreport/familygroup.py:782
 msgid "Children Marriages"
 msgstr "Hochzeiten der Kinder"
 
-#: ../gramps/plugins/textreport/familygroup.py:782
+#: ../gramps/plugins/textreport/familygroup.py:784
 msgid "Whether to include marriage information for children."
 msgstr "Legt fest, ob Heiratsinformationen der Kinder enthalten sind."
 
+#: ../gramps/plugins/textreport/familygroup.py:787
+msgid "Generation numbers (recursive only)"
+msgstr "Generationen-Nummerierung (nur Rekursiv)"
+
+#: ../gramps/plugins/textreport/familygroup.py:789
+msgid "Whether to include the generation on each report (recursive only)."
+msgstr ""
+"Legt fest, ob die Generation auf jedem Bericht angegeben wird (nur rekursiv)."
+
+#. TODO make insensitive if ...
 #. #########################
-#: ../gramps/plugins/textreport/familygroup.py:786
+#: ../gramps/plugins/textreport/familygroup.py:794
 msgid "Missing Information"
 msgstr "Fehlende Informationen"
 
 #. #########################
-#: ../gramps/plugins/textreport/familygroup.py:789
+#: ../gramps/plugins/textreport/familygroup.py:797
 msgid "Print fields for missing information"
 msgstr "Drucke Felder für fehlende Informationen"
 
-#: ../gramps/plugins/textreport/familygroup.py:791
+#: ../gramps/plugins/textreport/familygroup.py:799
 msgid "Whether to include fields for missing information."
 msgstr "Legt fest, ob Felder für fehlende Informationen enthalten sind."
 
-#: ../gramps/plugins/textreport/familygroup.py:873
+#: ../gramps/plugins/textreport/familygroup.py:882
 msgid "The style used for the text related to the children."
 msgstr "Der Stil, der für den Text zu den Kindern verwendet wird."
 
-#: ../gramps/plugins/textreport/familygroup.py:883
+#: ../gramps/plugins/textreport/familygroup.py:892
 msgid "The style used for the parent's name"
 msgstr "Der Stil, der für den Namen der Eltern verwendet wird"
 
 #. make sure it's translated, so it can be used below, in "combine"
-#: ../gramps/plugins/textreport/indivcomplete.py:178
+#: ../gramps/plugins/textreport/indivcomplete.py:187
 #, python-format
 msgid "%(str1)s in %(str2)s. "
 msgstr "%(str1)s in %(str2)s. "
 
 #. for example (a stepfather): John Smith, relationship: Step
-#: ../gramps/plugins/textreport/indivcomplete.py:234
+#: ../gramps/plugins/textreport/indivcomplete.py:243
 #, python-format
 msgid "%(parent-name)s, relationship: %(rel-type)s"
 msgstr "%(parent-name)s, Beziehung: %(rel-type)s"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:282
+#: ../gramps/plugins/textreport/indivcomplete.py:291
 msgid "Alternate Parents"
 msgstr "Alternative Eltern"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:396
-#: ../gramps/plugins/webreport/narrativeweb.py:6973
+#: ../gramps/plugins/textreport/indivcomplete.py:431
+#: ../gramps/plugins/webreport/narrativeweb.py:7053
 msgid "Associations"
 msgstr "Verknüpfungen"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:541
+#: ../gramps/plugins/textreport/indivcomplete.py:576
 msgid "Images"
 msgstr "Bilder"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:789
+#: ../gramps/plugins/textreport/indivcomplete.py:829
 #: ../gramps/plugins/textreport/textplugins.gpr.py:211
 msgid "Complete Individual Report"
 msgstr "Alle Daten einer Person"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:869
+#: ../gramps/plugins/textreport/indivcomplete.py:909
 #: ../gramps/plugins/tool/dumpgenderstats.py:63
 msgid "Male"
 msgstr "Männlich"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:871
+#: ../gramps/plugins/textreport/indivcomplete.py:911
 #: ../gramps/plugins/tool/dumpgenderstats.py:64
 msgid "Female"
 msgstr "Weiblich"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:885
+#: ../gramps/plugins/textreport/indivcomplete.py:925
 msgid "(image)"
 msgstr "(Bild)"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1009
+#: ../gramps/plugins/textreport/indivcomplete.py:1055
 msgid "List events chronologically"
 msgstr "Listet Ereignisse chronologisch"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1010
+#: ../gramps/plugins/textreport/indivcomplete.py:1056
 msgid "Whether to sort events into chronological order."
 msgstr ""
 "Legt fest, ob Ereignisse in chronologischer Reihenfolge sortiert werden."
 
 #. ###############################
-#: ../gramps/plugins/textreport/indivcomplete.py:1024
+#: ../gramps/plugins/textreport/indivcomplete.py:1070
 msgid "Include Source Information"
 msgstr "Quellinformationen aufnehmen"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1025
+#: ../gramps/plugins/textreport/indivcomplete.py:1071
 msgid "Whether to cite sources."
 msgstr "Legt fest, ob Quellen zitiert werden."
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1041
+#: ../gramps/plugins/textreport/indivcomplete.py:1087
 msgid "Include Attributes"
 msgstr "Attribute aufnehmen"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1045
+#: ../gramps/plugins/textreport/indivcomplete.py:1091
 msgid "Include Census Events"
 msgstr "Volkszählungsereignisse aufnehmen"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1046
+#: ../gramps/plugins/textreport/indivcomplete.py:1092
 msgid "Whether to include Census Events."
 msgstr "Ob Volkszählungsereignisse aufgenommen werden."
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1053
+#: ../gramps/plugins/textreport/indivcomplete.py:1099
 msgid "Include Notes"
 msgstr "Notizen aufnehmen"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1054
+#: ../gramps/plugins/textreport/indivcomplete.py:1100
 msgid "Whether to include Person and Family Notes."
 msgstr "Ob Personen- und Familiennotizen aufgenommen werden."
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1057
+#: ../gramps/plugins/textreport/indivcomplete.py:1103
 msgid "Include Tags"
 msgstr "Markierungen aufnehmen"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1058
+#: ../gramps/plugins/textreport/indivcomplete.py:1104
 msgid "Whether to include tags."
 msgstr "Ob Markierungen aufgenommen werden."
 
 #. ###############################
-#: ../gramps/plugins/textreport/indivcomplete.py:1062
+#: ../gramps/plugins/textreport/indivcomplete.py:1114
 msgid "Sections"
 msgstr "Abschnitte"
 
 #. ###############################
-#: ../gramps/plugins/textreport/indivcomplete.py:1065
+#: ../gramps/plugins/textreport/indivcomplete.py:1117
 msgid "Event groups"
 msgstr "Ereignisgruppen"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1066
+#: ../gramps/plugins/textreport/indivcomplete.py:1118
 msgid "Check if a separate section is required."
 msgstr "Prüfen, ob ein separater Abschnitt benötigt wird."
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1132
+#: ../gramps/plugins/textreport/indivcomplete.py:1183
 msgid "The style used for category labels."
 msgstr "Der Stil, der für Kategoriebeschriftungen verwendet wird."
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1143
+#: ../gramps/plugins/textreport/indivcomplete.py:1194
 msgid "The style used for the spouse's name."
 msgstr "Der Stil, der für den Namen des Partners verwendet wird."
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1172
+#: ../gramps/plugins/textreport/indivcomplete.py:1223
 msgid "A style used for image facts."
 msgstr "Der Stil, der für  Bilder Fakten verwendet wird."
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1182
+#: ../gramps/plugins/textreport/indivcomplete.py:1233
 msgid "A style used for image captions."
 msgstr "Der Stil, der für  Bildunterschriften verwendet wird."
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/textreport/kinshipreport.py:123
+#: ../gramps/plugins/textreport/kinshipreport.py:124
 #, python-format
 msgid "Kinship Report for %s"
 msgstr "Verwandtschaftsliste für %s"
 
-#: ../gramps/plugins/textreport/kinshipreport.py:359
+#: ../gramps/plugins/textreport/kinshipreport.py:372
 msgid "The maximum number of descendant generations"
 msgstr "Maximale Anzahl der Nachkommengenerationen"
 
-#: ../gramps/plugins/textreport/kinshipreport.py:363
+#: ../gramps/plugins/textreport/kinshipreport.py:376
 msgid "The maximum number of ancestor generations"
 msgstr "Maximale Anzahl der Vorfahrengenerationen"
 
-#: ../gramps/plugins/textreport/kinshipreport.py:367
+#: ../gramps/plugins/textreport/kinshipreport.py:380
 msgid "Whether to include spouses"
 msgstr "Legt fest, ob Partner aufgenommen werden."
 
-#: ../gramps/plugins/textreport/kinshipreport.py:370
+#: ../gramps/plugins/textreport/kinshipreport.py:383
 msgid "Include cousins"
 msgstr "Cousins aufnehmen"
 
-#: ../gramps/plugins/textreport/kinshipreport.py:371
+#: ../gramps/plugins/textreport/kinshipreport.py:384
 msgid "Whether to include cousins"
 msgstr "Legt fest, ob Cousins aufgenommen werden."
 
-#: ../gramps/plugins/textreport/kinshipreport.py:374
+#: ../gramps/plugins/textreport/kinshipreport.py:387
 msgid "Include aunts/uncles/nephews/nieces"
 msgstr "Tanten/Onkel/Neffen/Nichten aufnehmen"
 
-#: ../gramps/plugins/textreport/kinshipreport.py:375
+#: ../gramps/plugins/textreport/kinshipreport.py:388
 msgid "Whether to include aunts/uncles/nephews/nieces"
 msgstr "Legt fest, ob Tanten/Onkel/Neffen/Nichten aufgenommen werden."
 
-#: ../gramps/plugins/textreport/kinshipreport.py:402
-#: ../gramps/plugins/textreport/summary.py:316
+#: ../gramps/plugins/textreport/kinshipreport.py:413
+#: ../gramps/plugins/textreport/summary.py:320
 msgid "The basic style used for sub-headings."
 msgstr "Der Standardstil für Untertitel."
 
@@ -30725,18 +31040,18 @@ msgstr "Verknüpfungen Zu"
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
-#: ../gramps/plugins/textreport/notelinkreport.py:204
-#: ../gramps/plugins/textreport/tagreport.py:971
+#: ../gramps/plugins/textreport/notelinkreport.py:209
+#: ../gramps/plugins/textreport/tagreport.py:975
 msgid "The basic style used for table headings."
 msgstr "Der Basisstil, der für Tabellenüberschriften verwendet wird."
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/textreport/numberofancestorsreport.py:104
+#: ../gramps/plugins/textreport/numberofancestorsreport.py:105
 #, python-format
 msgid "Number of Ancestors for %s"
 msgstr "Anzahl der Vorfahren von %s"
 
-#: ../gramps/plugins/textreport/numberofancestorsreport.py:125
+#: ../gramps/plugins/textreport/numberofancestorsreport.py:126
 #, python-brace-format
 msgid "Generation {number} has {count} individual. {percent}"
 msgid_plural "Generation {number} has {count} individuals. {percent}"
@@ -30745,7 +31060,7 @@ msgstr[1] "Generation {number} enthält {count} Personen. {percent}"
 
 #. TC # English return something like:
 #. Total ancestors in generations 2 to 3 is 4. (66.67%)
-#: ../gramps/plugins/textreport/numberofancestorsreport.py:167
+#: ../gramps/plugins/textreport/numberofancestorsreport.py:168
 #, python-format
 msgid ""
 "Total ancestors in generations %(second_generation)d to %(last_generation)d "
@@ -30804,158 +31119,159 @@ msgstr "Personen, die mit diesem Ort verbunden sind."
 msgid "%(father)s (%(father_id)s) and %(mother)s (%(mother_id)s)"
 msgstr "%(father)s (%(father_id)s) und %(mother)s (%(mother_id)s)"
 
-#: ../gramps/plugins/textreport/placereport.py:420
+#: ../gramps/plugins/textreport/placereport.py:448
 msgid "Select using filter"
 msgstr "Unter Verwendung vom Filter wählen"
 
-#: ../gramps/plugins/textreport/placereport.py:421
+#: ../gramps/plugins/textreport/placereport.py:449
 msgid "Select places using a filter"
 msgstr "Ort unter Verwendung vom Filter wählen"
 
-#: ../gramps/plugins/textreport/placereport.py:428
+#: ../gramps/plugins/textreport/placereport.py:456
 msgid "Select places individually"
 msgstr "Orte einzeln wählen"
 
-#: ../gramps/plugins/textreport/placereport.py:429
+#: ../gramps/plugins/textreport/placereport.py:457
 msgid "List of places to report on"
 msgstr "Liste der Orte für den Bericht"
 
-#: ../gramps/plugins/textreport/placereport.py:438
+#: ../gramps/plugins/textreport/placereport.py:460
 msgid "Center on"
 msgstr "Zentrieren an"
 
-#: ../gramps/plugins/textreport/placereport.py:440
+#: ../gramps/plugins/textreport/placereport.py:462
 msgid "If report is event or person centered"
 msgstr "Legt fest, ob der Bericht am Ereignis oder an Personen zentriert ist."
 
-#: ../gramps/plugins/textreport/placereport.py:473
+#: ../gramps/plugins/textreport/placereport.py:493
 msgid "The style used for the title of the report."
 msgstr "Der Stil, der für den Titel des Berichts verwendet wird."
 
-#: ../gramps/plugins/textreport/placereport.py:488
-#: ../gramps/plugins/textreport/recordsreport.py:303
-#: ../gramps/plugins/textreport/simplebooktitle.py:177
-#: ../gramps/plugins/textreport/tagreport.py:940
+#: ../gramps/plugins/textreport/placereport.py:508
+#: ../gramps/plugins/textreport/recordsreport.py:319
+#: ../gramps/plugins/textreport/simplebooktitle.py:181
+#: ../gramps/plugins/textreport/tagreport.py:944
 msgid "The style used for the subtitle."
 msgstr "Der Stil, der für Untertitel verwendet wird."
 
-#: ../gramps/plugins/textreport/placereport.py:502
+#: ../gramps/plugins/textreport/placereport.py:522
 msgid "The style used for place title."
 msgstr "Der Stil, der für den Ortstitel verwendet wird."
 
-#: ../gramps/plugins/textreport/placereport.py:514
+#: ../gramps/plugins/textreport/placereport.py:534
 msgid "The style used for place details."
 msgstr "Der Stil, der für die Ortsdetails verwendet wird."
 
-#: ../gramps/plugins/textreport/placereport.py:526
+#: ../gramps/plugins/textreport/placereport.py:546
 msgid "The style used for a column title."
 msgstr "Der Stil, der für den Spaltentitel verwendet wird."
 
-#: ../gramps/plugins/textreport/placereport.py:540
+#: ../gramps/plugins/textreport/placereport.py:560
 msgid "The style used for each section."
 msgstr "Der Stil, der für jeden Absatz verwendet wird."
 
-#: ../gramps/plugins/textreport/placereport.py:571
+#: ../gramps/plugins/textreport/placereport.py:591
 msgid "The style used for event and person details."
 msgstr "Der Stil, der für Ereignis- und Persondetails verwendet wird."
 
-#: ../gramps/plugins/textreport/recordsreport.py:173
+#: ../gramps/plugins/textreport/recordsreport.py:174
 #, python-format
 msgid "%(number)s. "
 msgstr "%(number)s. "
 
-#: ../gramps/plugins/textreport/recordsreport.py:233
+#: ../gramps/plugins/textreport/recordsreport.py:242
 msgid "Number of ranks to display"
 msgstr "Anzahl der darzustellenden Ebenen"
 
-#: ../gramps/plugins/textreport/recordsreport.py:236
+#: ../gramps/plugins/textreport/recordsreport.py:245
 msgid "Use call name"
 msgstr "Rufname"
 
-#: ../gramps/plugins/textreport/recordsreport.py:238
+#: ../gramps/plugins/textreport/recordsreport.py:247
 msgid "Don't use call name"
 msgstr "Rufname nicht verwenden"
 
-#: ../gramps/plugins/textreport/recordsreport.py:239
+#: ../gramps/plugins/textreport/recordsreport.py:248
 msgid "Replace first names with call name"
 msgstr "Vornamen durch Rufnamen ersetzen"
 
-#: ../gramps/plugins/textreport/recordsreport.py:241
+#: ../gramps/plugins/textreport/recordsreport.py:250
 msgid "Underline call name in first names / add call name to first name"
 msgstr "Rufnamen in Vornamen unterstreichen / Rufnamen zum Vornamen hinzufügen"
 
-#: ../gramps/plugins/textreport/recordsreport.py:245
+#: ../gramps/plugins/textreport/recordsreport.py:254
 msgid "Footer text"
 msgstr "Fußzeilentext"
 
-#: ../gramps/plugins/textreport/recordsreport.py:253
-msgid "Person Records"
+#: ../gramps/plugins/textreport/recordsreport.py:267
+#, fuzzy
+msgid "Person Records 2"
 msgstr "Rekorde von Personen"
 
-#: ../gramps/plugins/textreport/recordsreport.py:255
+#: ../gramps/plugins/textreport/recordsreport.py:269
+#, fuzzy
+msgid "Person Records 1"
+msgstr "Rekorde von Personen"
+
+#: ../gramps/plugins/textreport/recordsreport.py:272
 msgid "Family Records"
 msgstr "Rekorde von Familien"
 
-#: ../gramps/plugins/textreport/recordsreport.py:312
+#: ../gramps/plugins/textreport/recordsreport.py:328
 msgid "The style used for headings."
 msgstr "Der Stil für Überschriften."
 
-#: ../gramps/plugins/textreport/recordsreport.py:330
-#: ../gramps/plugins/textreport/simplebooktitle.py:187
+#: ../gramps/plugins/textreport/recordsreport.py:346
+#: ../gramps/plugins/textreport/simplebooktitle.py:191
 msgid "The style used for the footer."
 msgstr "Der Stil, der für Fußzeilen verwendet wird."
 
-#: ../gramps/plugins/textreport/simplebooktitle.py:107
-#, python-format
-msgid "File %s does not exist"
-msgstr "Datei %s existiert nicht"
-
-#: ../gramps/plugins/textreport/simplebooktitle.py:132
+#: ../gramps/plugins/textreport/simplebooktitle.py:136
 msgid "Title of the Book"
 msgstr "Titel des Buches"
 
-#: ../gramps/plugins/textreport/simplebooktitle.py:132
+#: ../gramps/plugins/textreport/simplebooktitle.py:136
 msgid "book|Title"
 msgstr "Titel"
 
-#: ../gramps/plugins/textreport/simplebooktitle.py:133
+#: ../gramps/plugins/textreport/simplebooktitle.py:137
 msgid "Title string for the book."
 msgstr "Titeltext des Buches."
 
-#: ../gramps/plugins/textreport/simplebooktitle.py:136
+#: ../gramps/plugins/textreport/simplebooktitle.py:140
 msgid "Subtitle"
 msgstr "Untertitel"
 
-#: ../gramps/plugins/textreport/simplebooktitle.py:136
+#: ../gramps/plugins/textreport/simplebooktitle.py:140
 msgid "Subtitle of the Book"
 msgstr "Untertitel des Buches"
 
-#: ../gramps/plugins/textreport/simplebooktitle.py:137
+#: ../gramps/plugins/textreport/simplebooktitle.py:141
 msgid "Subtitle string for the book."
 msgstr "Untertiteltext des Buches."
 
-#: ../gramps/plugins/textreport/simplebooktitle.py:142
+#: ../gramps/plugins/textreport/simplebooktitle.py:146
 #, python-format
 msgid "Copyright %(year)d %(name)s"
 msgstr "Copyright %(year)d %(name)s"
 
-#: ../gramps/plugins/textreport/simplebooktitle.py:144
+#: ../gramps/plugins/textreport/simplebooktitle.py:148
 msgid "Footer"
 msgstr "Fußzeile"
 
-#: ../gramps/plugins/textreport/simplebooktitle.py:145
+#: ../gramps/plugins/textreport/simplebooktitle.py:149
 msgid "Footer string for the page."
 msgstr "Text für die Fußzeile."
 
-#: ../gramps/plugins/textreport/simplebooktitle.py:150
+#: ../gramps/plugins/textreport/simplebooktitle.py:154
 msgid "Gramps ID of the media object to use as an image."
 msgstr "Gramps ID des Medienobjekts, das als Bild verwendet wird."
 
-#: ../gramps/plugins/textreport/simplebooktitle.py:153
+#: ../gramps/plugins/textreport/simplebooktitle.py:157
 msgid "Image Size"
 msgstr "Bildgröße"
 
-#: ../gramps/plugins/textreport/simplebooktitle.py:154
+#: ../gramps/plugins/textreport/simplebooktitle.py:158
 msgid ""
 "Size of the image in cm. A value of 0 indicates that the image should be fit "
 "to the page."
@@ -31028,28 +31344,28 @@ msgstr "Anzahl von eindeutigen Medienobjekten: %d"
 msgid "Total size of media objects: %s MB"
 msgstr "Gesamtgröße der Medienobjekte: %s MB"
 
-#: ../gramps/plugins/textreport/summary.py:287
+#: ../gramps/plugins/textreport/summary.py:291
 msgid "Whether to count private data"
 msgstr "Ob vertrauliche Daten gezählt werden"
 
-#: ../gramps/plugins/textreport/tableofcontents.py:63
+#: ../gramps/plugins/textreport/tableofcontents.py:64
 #: ../gramps/plugins/textreport/textplugins.gpr.py:368
 msgid "Table Of Contents"
 msgstr "Inhaltsverzeichnis"
 
-#: ../gramps/plugins/textreport/tableofcontents.py:67
+#: ../gramps/plugins/textreport/tableofcontents.py:68
 msgid "Contents"
 msgstr "Inhalt"
 
-#: ../gramps/plugins/textreport/tableofcontents.py:112
+#: ../gramps/plugins/textreport/tableofcontents.py:117
 msgid "The style used for first level headings."
 msgstr "Der Stil für Ebene eins Überschriften."
 
-#: ../gramps/plugins/textreport/tableofcontents.py:118
+#: ../gramps/plugins/textreport/tableofcontents.py:123
 msgid "The style used for second level headings."
 msgstr "Der Stil für Ebene zwei Überschriften."
 
-#: ../gramps/plugins/textreport/tableofcontents.py:124
+#: ../gramps/plugins/textreport/tableofcontents.py:129
 msgid "The style used for third level headings."
 msgstr "Der Stil für Ebene drei Überschriften."
 
@@ -31070,18 +31386,6 @@ msgstr ""
 msgid "Tag Report for %s Items"
 msgstr "Markierungenbericht für %s Objekte"
 
-#: ../gramps/plugins/textreport/tagreport.py:154
-#: ../gramps/plugins/textreport/tagreport.py:242
-#: ../gramps/plugins/textreport/tagreport.py:331
-#: ../gramps/plugins/textreport/tagreport.py:414
-#: ../gramps/plugins/textreport/tagreport.py:495
-#: ../gramps/plugins/textreport/tagreport.py:564
-#: ../gramps/plugins/textreport/tagreport.py:648
-#: ../gramps/plugins/textreport/tagreport.py:733
-#: ../gramps/plugins/textreport/tagreport.py:813
-msgid "Id"
-msgstr "ID"
-
 #: ../gramps/plugins/textreport/tagreport.py:666
 msgid "Email Address"
 msgstr "E-Mail-Adresse"
@@ -31091,7 +31395,7 @@ msgstr "E-Mail-Adresse"
 msgid "Publication Information"
 msgstr "Publikationsinformation"
 
-#: ../gramps/plugins/textreport/tagreport.py:905
+#: ../gramps/plugins/textreport/tagreport.py:909
 msgid "The tag to use for the report"
 msgstr "Die Markierung zur Verwendung für den Bericht"
 
@@ -31234,7 +31538,7 @@ msgstr "Großschreibung_von_Nachnamen_korrigieren"
 msgid "Capitalization changes"
 msgstr "Änderungen der Großschreibung"
 
-#: ../gramps/plugins/tool/changenames.py:85
+#: ../gramps/plugins/tool/changenames.py:86
 msgid "Checking Family Names"
 msgstr "Nachnamen überprüfen"
 
@@ -31244,7 +31548,7 @@ msgstr "Nachnamen suchen"
 
 #: ../gramps/plugins/tool/changenames.py:144
 #: ../gramps/plugins/tool/eventnames.py:126
-#: ../gramps/plugins/tool/patchnames.py:363
+#: ../gramps/plugins/tool/patchnames.py:364
 msgid "No modifications made"
 msgstr "Keine Veränderungen gemacht"
 
@@ -31262,7 +31566,7 @@ msgstr "Änderungen der Großschreibung"
 
 #: ../gramps/plugins/tool/changenames.py:209
 #: ../gramps/plugins/tool/eventcmp.py:302
-#: ../gramps/plugins/tool/patchnames.py:418
+#: ../gramps/plugins/tool/patchnames.py:419
 msgid "Building display"
 msgstr "Anzeige wird erstellt"
 
@@ -31308,15 +31612,15 @@ msgid_plural "{number_of} event records were modified."
 msgstr[0] "{number_of} Ereigniseintrag wurde geändert."
 msgstr[1] "{number_of} Ereigniseinträge wurden geändert."
 
-#: ../gramps/plugins/tool/check.py:106 ../gramps/plugins/tool/check.py:249
+#: ../gramps/plugins/tool/check.py:119 ../gramps/plugins/tool/check.py:278
 msgid "Checking Database"
 msgstr "Datenbank überprüfen"
 
-#: ../gramps/plugins/tool/check.py:107
+#: ../gramps/plugins/tool/check.py:120
 msgid "Looking for cross table duplicates"
 msgstr "Suche nach tabellenübergreifenden Duplikaten"
 
-#: ../gramps/plugins/tool/check.py:157
+#: ../gramps/plugins/tool/check.py:177
 msgid ""
 "Your Family Tree contains cross table duplicate handles.\n"
 " This is bad and can be fixed by making a backup of your\n"
@@ -31331,11 +31635,11 @@ msgstr ""
 "abgebrochen, das überprüfen und reparieren Werkzeug sollte auf\n"
 "dem neuen Stammbaum erneut ausgeführt werden."
 
-#: ../gramps/plugins/tool/check.py:164
+#: ../gramps/plugins/tool/check.py:187
 msgid "Check Integrity"
 msgstr "Integrität überprüfen"
 
-#: ../gramps/plugins/tool/check.py:251
+#: ../gramps/plugins/tool/check.py:281
 #, python-format
 msgid ""
 "Objects referenced by this note were referenced but missing so that is why "
@@ -31345,39 +31649,44 @@ msgstr ""
 "fehlen aber praktisch. Als du 'prüfen und reparieren' auf %s ausgeführt "
 "hast, wurde die Notiz erzeugt, damit du sie finden und überarbeiten kannst."
 
-#: ../gramps/plugins/tool/check.py:273
+#: ../gramps/plugins/tool/check.py:303
 msgid "Looking for invalid name format references"
 msgstr "Suche nach Referenzen mit falschen Namensformat"
 
-#: ../gramps/plugins/tool/check.py:325
+#: ../gramps/plugins/tool/check.py:355
 msgid "Looking for duplicate spouses"
 msgstr "Suche nach doppelt vorkommenden Partnern"
 
-#: ../gramps/plugins/tool/check.py:349
+#: ../gramps/plugins/tool/check.py:378
 msgid "Looking for character encoding errors"
 msgstr "Suche nach Zeichenkodierungsfehlern"
 
-#: ../gramps/plugins/tool/check.py:390
+#: ../gramps/plugins/tool/check.py:419
 msgid "Looking for ctrl characters in notes"
 msgstr "Suche nach Strg Zeichen in den Notizen"
 
-#: ../gramps/plugins/tool/check.py:416
+#: ../gramps/plugins/tool/check.py:447
+#, fuzzy
+msgid "Looking for bad alternate place names"
+msgstr "Suche nach leeren Ortsdatensätzen"
+
+#: ../gramps/plugins/tool/check.py:477
 msgid "Looking for broken family links"
 msgstr "Suche nach ungültige Familienverknüpfungen"
 
-#: ../gramps/plugins/tool/check.py:618
+#: ../gramps/plugins/tool/check.py:689
 msgid "Looking for unused objects"
 msgstr "Suche nach unbenutzten Objekten"
 
-#: ../gramps/plugins/tool/check.py:692
+#: ../gramps/plugins/tool/check.py:767
 msgid "Select file"
 msgstr "Datei wählen"
 
-#: ../gramps/plugins/tool/check.py:726
+#: ../gramps/plugins/tool/check.py:800
 msgid "Media object could not be found"
 msgstr "Medienobjekt konnte nicht gefunden werden"
 
-#: ../gramps/plugins/tool/check.py:727
+#: ../gramps/plugins/tool/check.py:801
 #, python-format
 msgid ""
 "The file:\n"
@@ -31394,131 +31703,136 @@ msgstr ""
 "Du kannst entweder die Verknüpfung aus der Datenbank entfernen,\n"
 "die Verknüpfung zur fehlenden Datei behalten, oder eine neue Datei auswählen."
 
-#: ../gramps/plugins/tool/check.py:809
+#: ../gramps/plugins/tool/check.py:884
 msgid "Looking for empty people records"
 msgstr "Suche nach leeren Personendatensätzen"
 
-#: ../gramps/plugins/tool/check.py:817
+#: ../gramps/plugins/tool/check.py:891
 msgid "Looking for empty family records"
 msgstr "Suche nach leeren Familiendatensätzen"
 
-#: ../gramps/plugins/tool/check.py:825
+#: ../gramps/plugins/tool/check.py:898
 msgid "Looking for empty event records"
 msgstr "Suche nach leeren Ereignisdatensätzen"
 
-#: ../gramps/plugins/tool/check.py:833
+#: ../gramps/plugins/tool/check.py:905
 msgid "Looking for empty source records"
 msgstr "Suche nach leeren Quellendatensätzen"
 
-#: ../gramps/plugins/tool/check.py:841
+#: ../gramps/plugins/tool/check.py:912
 msgid "Looking for empty citation records"
 msgstr "Suche nach leeren Fundstellendatensätzen"
 
-#: ../gramps/plugins/tool/check.py:849
+#: ../gramps/plugins/tool/check.py:919
 msgid "Looking for empty place records"
 msgstr "Suche nach leeren Ortsdatensätzen"
 
-#: ../gramps/plugins/tool/check.py:857
+#: ../gramps/plugins/tool/check.py:926
 msgid "Looking for empty media records"
 msgstr "Suche nach leeren Mediendatensätzen"
 
-#: ../gramps/plugins/tool/check.py:865
+#: ../gramps/plugins/tool/check.py:933
 msgid "Looking for empty repository records"
 msgstr "Suche nach leeren Aufbewahrungsortedatensätzen"
 
-#: ../gramps/plugins/tool/check.py:873
+#: ../gramps/plugins/tool/check.py:940
 msgid "Looking for empty note records"
 msgstr "Suche nach leeren Notizdatensätzen"
 
-#: ../gramps/plugins/tool/check.py:919
+#: ../gramps/plugins/tool/check.py:984
 msgid "Looking for empty families"
 msgstr "Suche nach leeren Familien"
 
-#: ../gramps/plugins/tool/check.py:955
+#: ../gramps/plugins/tool/check.py:1020
 msgid "Looking for broken parent relationships"
 msgstr "Suche nach kaputten Beziehungen von Elternteilen"
 
-#: ../gramps/plugins/tool/check.py:993
+#: ../gramps/plugins/tool/check.py:1060
 msgid "Looking for event problems"
 msgstr "Suche nach Problemen mit Ereignissen"
 
-#: ../gramps/plugins/tool/check.py:1159
+#: ../gramps/plugins/tool/check.py:1233
 msgid "Looking for person reference problems"
 msgstr "Suche nach Problemen mit Referenzen von Personen"
 
-#: ../gramps/plugins/tool/check.py:1190
+#: ../gramps/plugins/tool/check.py:1267
 msgid "Looking for family reference problems"
 msgstr "Suche nach Problemen mit Referenzen von Familien"
 
-#: ../gramps/plugins/tool/check.py:1215
+#: ../gramps/plugins/tool/check.py:1294
 msgid "Looking for repository reference problems"
 msgstr "Suche nach Problemen mit Referenzen von Aufbewahrungsorten"
 
-#: ../gramps/plugins/tool/check.py:1248
+#: ../gramps/plugins/tool/check.py:1330
 msgid "Looking for place reference problems"
 msgstr "Suche nach Problemen mit Referenzen von Orten"
 
-#: ../gramps/plugins/tool/check.py:1359
+#: ../gramps/plugins/tool/check.py:1446
 msgid "Looking for citation reference problems"
 msgstr "Suche nach Problemen mit Fundstellenreferenzen"
 
-#: ../gramps/plugins/tool/check.py:1495
+#: ../gramps/plugins/tool/check.py:1564
 msgid "Looking for source reference problems"
 msgstr "Suche nach Problemen mit Referenzen von Quellen"
 
-#: ../gramps/plugins/tool/check.py:1536
+#: ../gramps/plugins/tool/check.py:1608
 msgid "Looking for media object reference problems"
 msgstr "Suche nach Problemen mit Referenzen von Medienobjekten"
 
-#: ../gramps/plugins/tool/check.py:1679
+#: ../gramps/plugins/tool/check.py:1731
 msgid "Looking for note reference problems"
 msgstr "Suche nach Problemen mit Referenzen von Notizen"
 
-#: ../gramps/plugins/tool/check.py:1830
+#: ../gramps/plugins/tool/check.py:1859
 msgid "Updating checksums on media"
 msgstr "Aktualisiere Prüfsummen der Medien"
 
-#: ../gramps/plugins/tool/check.py:1854
+#: ../gramps/plugins/tool/check.py:1887
 msgid "Looking for tag reference problems"
 msgstr "Suche nach Problemen mit Markierungsreferenzen"
 
-#: ../gramps/plugins/tool/check.py:1943
+#: ../gramps/plugins/tool/check.py:2032
 msgid "Looking for media source reference problems"
 msgstr "Suche nach Problemen mit Referenzen von Medienquellen"
 
-#: ../gramps/plugins/tool/check.py:2110
+#: ../gramps/plugins/tool/check.py:2100
+#, fuzzy
+msgid "Looking for Duplicated Gramps ID problems"
+msgstr "Suche nach doppelt vorkommenden Partnern"
+
+#: ../gramps/plugins/tool/check.py:2331
 msgid "No errors were found"
 msgstr "Keine Fehler gefunden"
 
-#: ../gramps/plugins/tool/check.py:2111
+#: ../gramps/plugins/tool/check.py:2332
 msgid "The database has passed internal checks"
 msgstr "Die internen Prüfungen der Datenbank wurden erfolgreich durchgeführt"
 
-#: ../gramps/plugins/tool/check.py:2114
+#: ../gramps/plugins/tool/check.py:2335
 msgid "No errors were found: the database has passed internal checks."
 msgstr ""
 "Keine Fehler gefunden: Die internen Prüfungen der Datenbank wurden "
 "erfolgreich durchgeführt."
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2121
+#: ../gramps/plugins/tool/check.py:2342
 #, python-brace-format
 msgid "{quantity} broken child/family link was fixed\n"
 msgid_plural "{quantity} broken child/family links were fixed\n"
 msgstr[0] "{quantity} beschädigte Kind/Familie Beziehung wurde repariert\n"
 msgstr[1] "{quantity} beschädigte Kind/Familie Beziehungen wurden repariert\n"
 
-#: ../gramps/plugins/tool/check.py:2130
+#: ../gramps/plugins/tool/check.py:2350
 msgid "Non existing child"
 msgstr "Kein existierendes Kind"
 
-#: ../gramps/plugins/tool/check.py:2138
+#: ../gramps/plugins/tool/check.py:2361
 #, python-format
 msgid "%(person)s was removed from the family of %(family)s\n"
 msgstr "%(person)s wurde von der Familie von %(family)s entfernt\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2145
+#: ../gramps/plugins/tool/check.py:2368
 #, python-brace-format
 msgid "{quantity} broken spouse/family link was fixed\n"
 msgid_plural "{quantity} broken spouse/family links were fixed\n"
@@ -31526,17 +31840,17 @@ msgstr[0] "{quantity} beschädigte Partner/Familie Beziehung wurde repariert\n"
 msgstr[1] ""
 "{quantity} beschädigte Partner/Familie Beziehungen wurden repariert\n"
 
-#: ../gramps/plugins/tool/check.py:2154 ../gramps/plugins/tool/check.py:2180
+#: ../gramps/plugins/tool/check.py:2376 ../gramps/plugins/tool/check.py:2404
 msgid "Non existing person"
 msgstr "Nicht-existierende Person"
 
-#: ../gramps/plugins/tool/check.py:2162 ../gramps/plugins/tool/check.py:2188
+#: ../gramps/plugins/tool/check.py:2387 ../gramps/plugins/tool/check.py:2415
 #, python-format
 msgid "%(person)s was restored to the family of %(family)s\n"
 msgstr "%(person)s wurde in der Familie von %(family)s wiederhergestellt\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2169
+#: ../gramps/plugins/tool/check.py:2394
 #, python-brace-format
 msgid "{quantity} duplicate spouse/family link was found\n"
 msgid_plural "{quantity} duplicate spouse/family links were found\n"
@@ -31544,7 +31858,7 @@ msgstr[0] "{quantity} doppelte Partner/Familienverbindung wurde gefunden\n"
 msgstr[1] "{quantity} doppelte Partner/Familienverbindungen wurde gefunden\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2195
+#: ../gramps/plugins/tool/check.py:2422
 #, python-brace-format
 msgid "{quantity} family with no parents or children found, removed.\n"
 msgid_plural ""
@@ -31553,14 +31867,22 @@ msgstr[0] "{quantity} Familie ohne Kinder und Eltern gefunden, entfernt.\n"
 msgstr[1] "{quantity} Familien ohne Kinder und Eltern gefunden, entfernt.\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2207
+#: ../gramps/plugins/tool/check.py:2434
 #, python-brace-format
 msgid "{quantity} corrupted family relationship fixed\n"
 msgid_plural "{quantity} corrupted family relationships fixed\n"
 msgstr[0] "{quantity} beschädigte Familienbeziehung repariert\n"
 msgstr[1] "{quantity} beschädigte Familienbeziehungen repariert\n"
 
-#: ../gramps/plugins/tool/check.py:2216
+#. translators: leave all/any {...} untranslated
+#: ../gramps/plugins/tool/check.py:2442
+#, fuzzy, python-brace-format
+msgid "{quantity} place alternate name fixed\n"
+msgid_plural "{quantity} place alternate names fixed\n"
+msgstr[0] "{quantity} ungültiger Todesereignisname wurde korrigiert\n"
+msgstr[1] "{quantity} ungültige Todesereignisnamen wurden korrigiert\n"
+
+#: ../gramps/plugins/tool/check.py:2451
 #, python-brace-format
 msgid "{quantity} person was referenced but not found\n"
 msgid_plural "{quantity} persons were referenced, but not found\n"
@@ -31568,7 +31890,7 @@ msgstr[0] "{quantity} Ereignis wurde referenziert, aber nicht gefunden\n"
 msgstr[1] "{quantity} Ereignisse wurden referenziert, aber nicht gefunden\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2224
+#: ../gramps/plugins/tool/check.py:2459
 #, python-brace-format
 msgid "{quantity} family was referenced but not found\n"
 msgid_plural "{quantity} families were referenced, but not found\n"
@@ -31576,14 +31898,14 @@ msgstr[0] "{quantity} Familie wurde referenziert, aber nicht gefunden\n"
 msgstr[1] "{quantity} Familien wurden referenziert, aber nicht gefunden\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2234
+#: ../gramps/plugins/tool/check.py:2469
 #, python-brace-format
 msgid "{quantity} date was corrected\n"
 msgid_plural "{quantity} dates were corrected\n"
 msgstr[0] "{quantity} Datum wurde korrigiert\n"
 msgstr[1] "{quantity} Daten wurden korrigiert\n"
 
-#: ../gramps/plugins/tool/check.py:2243
+#: ../gramps/plugins/tool/check.py:2478
 #, python-brace-format
 msgid "{quantity} repository was referenced but not found\n"
 msgid_plural "{quantity} repositories were referenced, but not found\n"
@@ -31593,14 +31915,14 @@ msgstr[1] ""
 "{quantity} Aufbewahrungsorte wurden referenziert, aber nicht gefunden\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2253 ../gramps/plugins/tool/check.py:2341
+#: ../gramps/plugins/tool/check.py:2488 ../gramps/plugins/tool/check.py:2575
 #, python-brace-format
 msgid "{quantity} media object was referenced but not found\n"
 msgid_plural "{quantity} media objects were referenced, but not found\n"
 msgstr[0] "{quantity} Medienobjekt wurde referenziert, aber nicht gefunden\n"
 msgstr[1] "{quantity} Medienobjekte wurden referenziert, aber nicht gefunden\n"
 
-#: ../gramps/plugins/tool/check.py:2264
+#: ../gramps/plugins/tool/check.py:2499
 #, python-brace-format
 msgid "Reference to {quantity} missing media object was kept\n"
 msgid_plural "References to {quantity} media objects were kept\n"
@@ -31608,7 +31930,7 @@ msgstr[0] "Referenz zu {quantity} fehlenden Medienobjekt wurde behalten\n"
 msgstr[1] "Referenz zu {quantity} fehlenden Medienobjekten wurde behalten\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2272
+#: ../gramps/plugins/tool/check.py:2507
 #, python-brace-format
 msgid "{quantity} missing media object was replaced\n"
 msgid_plural "{quantity} missing media objects were replaced\n"
@@ -31616,7 +31938,7 @@ msgstr[0] "{quantity} fehlendes Medienobjekt wurde ersetzt\n"
 msgstr[1] "{quantity} fehlende Medienobjekte wurden ersetzt\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2280
+#: ../gramps/plugins/tool/check.py:2515
 #, python-brace-format
 msgid "{quantity} missing media object was removed\n"
 msgid_plural "{quantity} missing media objects were removed\n"
@@ -31624,7 +31946,7 @@ msgstr[0] "{quantity} fehlendes Medienobjekt wurde entfernt\n"
 msgstr[1] "{quantity} fehlende Medienobjekte wurden entfernt\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2288
+#: ../gramps/plugins/tool/check.py:2523
 #, python-brace-format
 msgid "{quantity} event was referenced but not found\n"
 msgid_plural "{quantity} events were referenced, but not found\n"
@@ -31632,7 +31954,7 @@ msgstr[0] "{quantity} Ereignis wurde referenziert, aber nicht gefunden\n"
 msgstr[1] "{quantity} Ereignisse wurden referenziert, aber nicht gefunden\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2296
+#: ../gramps/plugins/tool/check.py:2531
 #, python-brace-format
 msgid "{quantity} invalid birth event name was fixed\n"
 msgid_plural "{quantity} invalid birth event names were fixed\n"
@@ -31640,7 +31962,7 @@ msgstr[0] "{quantity} ungültiger Geburtsereignisname wurde korrigiert\n"
 msgstr[1] "{quantity} ungültige Geburtsereignisnamen wurden korrigiert\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2304
+#: ../gramps/plugins/tool/check.py:2539
 #, python-brace-format
 msgid "{quantity} invalid death event name was fixed\n"
 msgid_plural "{quantity} invalid death event names were fixed\n"
@@ -31648,23 +31970,21 @@ msgstr[0] "{quantity} ungültiger Todesereignisname wurde korrigiert\n"
 msgstr[1] "{quantity} ungültige Todesereignisnamen wurden korrigiert\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2312
+#: ../gramps/plugins/tool/check.py:2547
 #, python-brace-format
 msgid "{quantity} place was referenced but not found\n"
 msgid_plural "{quantity} places were referenced, but not found\n"
 msgstr[0] "{quantity} Ort wurde referenziert, aber nicht gefunden\n"
 msgstr[1] "{quantity} Orte wurden referenziert, aber nicht gefunden\n"
 
-#. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2320
+#: ../gramps/plugins/tool/check.py:2556
 #, python-brace-format
 msgid "{quantity} citation was referenced but not found\n"
 msgid_plural "{quantity} citations were referenced, but not found\n"
 msgstr[0] "{quantity} Fundstelle wurde referenziert, aber nicht gefunden\n"
 msgstr[1] "{quantity} Fundstellen wurden referenziert, aber nicht gefunden\n"
 
-#. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2331
+#: ../gramps/plugins/tool/check.py:2566
 #, python-brace-format
 msgid "{quantity} source was referenced but not found\n"
 msgid_plural "{quantity} sources were referenced, but not found\n"
@@ -31672,7 +31992,7 @@ msgstr[0] "{quantity} Quelle wurde referenziert, aber nicht gefunden\n"
 msgstr[1] "{quantity} Quellen wurden referenziert, aber nicht gefunden\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2351
+#: ../gramps/plugins/tool/check.py:2584
 #, python-brace-format
 msgid "{quantity} note object was referenced but not found\n"
 msgid_plural "{quantity} note objects were referenced, but not found\n"
@@ -31680,7 +32000,7 @@ msgstr[0] "{quantity} Notizobjekt wurde referenziert, aber nicht gefunden\n"
 msgstr[1] "{quantity} Notizobjekte wurden referenziert, aber nicht gefunden\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2361 ../gramps/plugins/tool/check.py:2371
+#: ../gramps/plugins/tool/check.py:2594 ../gramps/plugins/tool/check.py:2604
 #, python-brace-format
 msgid "{quantity} tag object was referenced but not found\n"
 msgid_plural "{quantity} tag objects were referenced, but not found\n"
@@ -31690,22 +32010,29 @@ msgstr[1] ""
 "{quantity} Markierungsobjekte wurden referenziert, aber nicht gefunden\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2381
+#: ../gramps/plugins/tool/check.py:2614
 #, python-brace-format
 msgid "{quantity} invalid name format reference was removed\n"
 msgid_plural "{quantity} invalid name format references were removed\n"
 msgstr[0] "{quantity} ungültige Namensformatreferenz wurde entfernt\n"
 msgstr[1] "{quantity} ungültige Namensformatreferenzen wurden entfernt\n"
 
-#. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2391
+#: ../gramps/plugins/tool/check.py:2625
 #, python-brace-format
 msgid "{quantity} invalid source citation was fixed\n"
 msgid_plural "{quantity} invalid source citations were fixed\n"
 msgstr[0] "{quantity} ungültiger Quellenfundstelle wurde korrigiert\n"
 msgstr[1] "{quantity} ungültige Quellenfundstellen wurden korrigiert\n"
 
-#: ../gramps/plugins/tool/check.py:2398
+#. translators: leave all/any {...} untranslated
+#: ../gramps/plugins/tool/check.py:2634
+#, fuzzy, python-brace-format
+msgid "{quantity} Duplicated Gramps ID fixed\n"
+msgid_plural "{quantity} Duplicated Gramps IDs fixed\n"
+msgstr[0] "{quantity} ungültiger Todesereignisname wurde korrigiert\n"
+msgstr[1] "{quantity} ungültige Todesereignisnamen wurden korrigiert\n"
+
+#: ../gramps/plugins/tool/check.py:2641
 #, python-format
 msgid ""
 "%(empty_obj)d empty objects removed:\n"
@@ -31728,11 +32055,11 @@ msgstr ""
 "   %(repo)d Aufbewahrungsorteobjekte\n"
 "   %(note)d Notizobjekte\n"
 
-#: ../gramps/plugins/tool/check.py:2444
+#: ../gramps/plugins/tool/check.py:2688
 msgid "Integrity Check Results"
 msgstr "Resultate der Integritätsprüfung"
 
-#: ../gramps/plugins/tool/check.py:2449
+#: ../gramps/plugins/tool/check.py:2694
 msgid "Check and Repair"
 msgstr "Prüfen und reparieren"
 
@@ -31860,11 +32187,11 @@ msgstr "Filterauswahl"
 msgid "Comparing events"
 msgstr "Ereignisse vergleichen"
 
-#: ../gramps/plugins/tool/eventcmp.py:182
+#: ../gramps/plugins/tool/eventcmp.py:181
 msgid "Selecting people"
 msgstr "Wählen von Personen"
 
-#: ../gramps/plugins/tool/eventcmp.py:194
+#: ../gramps/plugins/tool/eventcmp.py:193
 msgid "No matches were found"
 msgstr "Keine Treffer gefunden"
 
@@ -31884,7 +32211,7 @@ msgstr "%(event_name)s Datum"
 msgid "%(event_name)s Place"
 msgstr "%(event_name)s Ort"
 
-#: ../gramps/plugins/tool/eventcmp.py:309
+#: ../gramps/plugins/tool/eventcmp.py:310
 msgid "Comparing Events"
 msgstr "Ereignisse vergleichen"
 
@@ -31958,7 +32285,7 @@ msgstr "Werkzeug zum Finden von Dubletten"
 
 #: ../gramps/plugins/tool/finddupes.py:142
 #: ../gramps/plugins/tool/mergecitations.py:163
-#: ../gramps/plugins/tool/verify.py:322
+#: ../gramps/plugins/tool/verify.py:347
 msgid "Tool settings"
 msgstr "Werkzeugeinstellungen"
 
@@ -32043,9 +32370,9 @@ msgid "Gramps Media Manager"
 msgstr "Gramps Medienverwaltung"
 
 #: ../gramps/plugins/tool/mediamanager.py:95
-#: ../gramps/plugins/webreport/narrativeweb.py:1896
-#: ../gramps/plugins/webreport/narrativeweb.py:2009
-#: ../gramps/plugins/webreport/narrativeweb.py:4616
+#: ../gramps/plugins/webreport/narrativeweb.py:1871
+#: ../gramps/plugins/webreport/narrativeweb.py:1994
+#: ../gramps/plugins/webreport/narrativeweb.py:4667
 msgid "Introduction"
 msgstr "Einleitung"
 
@@ -32449,27 +32776,27 @@ msgstr "Verbinder, die Nachnamen nicht aufteilen:"
 msgid "Extracting Information from Names"
 msgstr "Information aus Namen extrahieren"
 
-#: ../gramps/plugins/tool/patchnames.py:172
+#: ../gramps/plugins/tool/patchnames.py:173
 msgid "Analyzing names"
 msgstr "Namen analysieren"
 
-#: ../gramps/plugins/tool/patchnames.py:364
+#: ../gramps/plugins/tool/patchnames.py:365
 msgid "No titles, nicknames or prefixes were found"
 msgstr "Keine Titel, Spitznamen oder Präfixe gefunden"
 
-#: ../gramps/plugins/tool/patchnames.py:408
+#: ../gramps/plugins/tool/patchnames.py:409
 msgid "Current Name"
 msgstr "Aktueller Name"
 
-#: ../gramps/plugins/tool/patchnames.py:449
+#: ../gramps/plugins/tool/patchnames.py:450
 msgid "Prefix in given name"
 msgstr "Präfix im Vornamen"
 
-#: ../gramps/plugins/tool/patchnames.py:459
+#: ../gramps/plugins/tool/patchnames.py:460
 msgid "Compound surname"
 msgstr "Zusammengesetzter Nachname"
 
-#: ../gramps/plugins/tool/patchnames.py:485
+#: ../gramps/plugins/tool/patchnames.py:486
 msgid "Extract information from names"
 msgstr "Information aus Namen extrahieren"
 
@@ -32512,7 +32839,7 @@ msgstr "Interne Referenzen neu erstellt"
 msgid "All reference maps have been rebuilt."
 msgstr "Alle internen Referenzen wurden neu erstellt."
 
-#: ../gramps/plugins/tool/relcalc.glade:78
+#: ../gramps/plugins/tool/relcalc.glade:76
 msgid "Select a person to determine the relationship"
 msgstr "Wähle eine Person, um die Beziehung zu ermitteln"
 
@@ -32526,26 +32853,26 @@ msgstr "Verwandtschaftsrechner: %(person_name)s"
 msgid "Relationship to %(person_name)s"
 msgstr "Verwandtschaft zu %(person_name)s"
 
-#: ../gramps/plugins/tool/relcalc.py:166
+#: ../gramps/plugins/tool/relcalc.py:168
 msgid "Relationship Calculator tool"
 msgstr "Verwandtschaftsrechnerwerkzeug"
 
-#: ../gramps/plugins/tool/relcalc.py:198
+#: ../gramps/plugins/tool/relcalc.py:200
 #, python-format
 msgid "%(person)s and %(active_person)s are not related."
 msgstr "%(person)s und %(active_person)s sind nicht verwandt."
 
-#: ../gramps/plugins/tool/relcalc.py:217
+#: ../gramps/plugins/tool/relcalc.py:219
 #, python-format
 msgid "Their common ancestor is %s."
 msgstr "Der gemeinsame Vorfahre ist %s."
 
-#: ../gramps/plugins/tool/relcalc.py:223
+#: ../gramps/plugins/tool/relcalc.py:225
 #, python-format
 msgid "Their common ancestors are %(ancestor1)s and %(ancestor2)s."
 msgstr "Ihre gemeinsamen Vorfahren sind %(ancestor1)s und %(ancestor2)s."
 
-#: ../gramps/plugins/tool/relcalc.py:229
+#: ../gramps/plugins/tool/relcalc.py:231
 msgid "Their common ancestors are: "
 msgstr "Ihre gemeinsamen Vorfahren sind: "
 
@@ -32578,94 +32905,94 @@ msgid "Search for notes"
 msgstr "Suche nach Notizen"
 
 #: ../gramps/plugins/tool/removeunused.glade:289
-#: ../gramps/plugins/tool/verify.glade:932
+#: ../gramps/plugins/tool/verify.glade:930
 msgid "_Mark all"
 msgstr "_alles markieren"
 
 #: ../gramps/plugins/tool/removeunused.glade:305
-#: ../gramps/plugins/tool/verify.glade:948
+#: ../gramps/plugins/tool/verify.glade:946
 msgid "_Unmark all"
 msgstr "_Markierung komplett aufheben"
 
 #: ../gramps/plugins/tool/removeunused.glade:321
-#: ../gramps/plugins/tool/verify.glade:964
+#: ../gramps/plugins/tool/verify.glade:962
 msgid "In_vert marks"
 msgstr "Markierungen in_vertieren"
 
 #: ../gramps/plugins/tool/removeunused.glade:346
-#: ../gramps/plugins/tool/verify.glade:907
+#: ../gramps/plugins/tool/verify.glade:905
 msgid "Double-click on a row to view/edit data"
 msgstr "Doppelklick auf eine Zeile um die Daten zu betrachten/bearbeiten"
 
-#: ../gramps/plugins/tool/removeunused.py:66
+#: ../gramps/plugins/tool/removeunused.py:69
 msgid "Unused Objects"
 msgstr "Unbenutzte Objekte"
 
 #. Add mark column
 #. Add ignore column
-#: ../gramps/plugins/tool/removeunused.py:180
-#: ../gramps/plugins/tool/verify.py:517
+#: ../gramps/plugins/tool/removeunused.py:183
+#: ../gramps/plugins/tool/verify.py:552
 msgid "Mark"
 msgstr "Markieren"
 
-#: ../gramps/plugins/tool/removeunused.py:293
+#: ../gramps/plugins/tool/removeunused.py:299
 msgid "Remove unused objects"
 msgstr "Unbenutzte Objekte entfernen"
 
-#: ../gramps/plugins/tool/reorderids.py:68
+#: ../gramps/plugins/tool/reorderids.py:69
 msgid "Reordering Gramps IDs"
 msgstr "Gramps-IDs neu ordnen"
 
-#: ../gramps/plugins/tool/reorderids.py:70
+#: ../gramps/plugins/tool/reorderids.py:71
 msgid "Reordering Gramps IDs..."
 msgstr "Gramps-IDs neu ordnen..."
 
-#: ../gramps/plugins/tool/reorderids.py:72
+#: ../gramps/plugins/tool/reorderids.py:73
 #: ../gramps/plugins/tool/tools.gpr.py:372
 msgid "Reorder Gramps IDs"
 msgstr "Ordne Gramps-IDs neu"
 
-#: ../gramps/plugins/tool/reorderids.py:76
+#: ../gramps/plugins/tool/reorderids.py:77
 msgid "Reordering People IDs"
 msgstr "Personen-IDs neu ordnen"
 
-#: ../gramps/plugins/tool/reorderids.py:87
+#: ../gramps/plugins/tool/reorderids.py:88
 msgid "Reordering Family IDs"
 msgstr "Familien-IDs neu ordnen"
 
-#: ../gramps/plugins/tool/reorderids.py:97
+#: ../gramps/plugins/tool/reorderids.py:98
 msgid "Reordering Event IDs"
 msgstr "Ereignis-IDs neu ordnen"
 
-#: ../gramps/plugins/tool/reorderids.py:107
+#: ../gramps/plugins/tool/reorderids.py:108
 msgid "Reordering Media Object IDs"
 msgstr "Medienobjekt-IDs neu ordnen"
 
-#: ../gramps/plugins/tool/reorderids.py:117
+#: ../gramps/plugins/tool/reorderids.py:118
 msgid "Reordering Source IDs"
 msgstr "Quellen-IDs neu ordnen"
 
-#: ../gramps/plugins/tool/reorderids.py:127
+#: ../gramps/plugins/tool/reorderids.py:128
 msgid "Reordering Citation IDs"
 msgstr "Fundstellen-IDs neu ordnen"
 
-#: ../gramps/plugins/tool/reorderids.py:137
+#: ../gramps/plugins/tool/reorderids.py:138
 msgid "Reordering Place IDs"
 msgstr "Orte-IDs neu ordnen"
 
-#: ../gramps/plugins/tool/reorderids.py:147
+#: ../gramps/plugins/tool/reorderids.py:148
 msgid "Reordering Repository IDs"
 msgstr "Aufbewahrungsort-IDs neu ordnen"
 
-#: ../gramps/plugins/tool/reorderids.py:158
+#: ../gramps/plugins/tool/reorderids.py:159
 msgid "Reordering Note IDs"
 msgstr "Notiz-IDs neu ordnen"
 
-#: ../gramps/plugins/tool/reorderids.py:170
+#: ../gramps/plugins/tool/reorderids.py:171
 msgid "Done."
 msgstr "Fertig."
 
-#: ../gramps/plugins/tool/reorderids.py:232
+#: ../gramps/plugins/tool/reorderids.py:231
 msgid "Finding and assigning unused IDs"
 msgstr "Finden und zuweisen von unbenutzten IDs"
 
@@ -32709,46 +33036,46 @@ msgstr "Familienereignisse aufnehmen"
 msgid "Sort family events of the person"
 msgstr "Familienereignisse der Person sortieren"
 
-#: ../gramps/plugins/tool/testcasegenerator.py:87
+#: ../gramps/plugins/tool/testcasegenerator.py:91
 msgid "Generate_Testcases_for_Persons_and_Families"
 msgstr "Erstelle_Testfälle_für_Personen_und_Familien"
 
-#: ../gramps/plugins/tool/testcasegenerator.py:246
-#: ../gramps/plugins/tool/testcasegenerator.py:251
+#: ../gramps/plugins/tool/testcasegenerator.py:274
+#: ../gramps/plugins/tool/testcasegenerator.py:280
 msgid "Generate testcases"
 msgstr "Testfälle erstellen"
 
-#: ../gramps/plugins/tool/testcasegenerator.py:255
+#: ../gramps/plugins/tool/testcasegenerator.py:285
 msgid ""
 "Generate low level database errors\n"
 "Correction needs database reload"
 msgstr ""
 
-#: ../gramps/plugins/tool/testcasegenerator.py:260
+#: ../gramps/plugins/tool/testcasegenerator.py:290
 msgid "Generate database errors"
 msgstr "Datenbankfehler erstellen"
 
-#: ../gramps/plugins/tool/testcasegenerator.py:264
+#: ../gramps/plugins/tool/testcasegenerator.py:294
 msgid "Generate dummy data"
 msgstr "Scheindaten erstellen"
 
-#: ../gramps/plugins/tool/testcasegenerator.py:269
+#: ../gramps/plugins/tool/testcasegenerator.py:299
 msgid "Generate long names"
 msgstr "Lange Namen erstellen"
 
-#: ../gramps/plugins/tool/testcasegenerator.py:273
+#: ../gramps/plugins/tool/testcasegenerator.py:304
 msgid "Add special characters"
 msgstr "Sonderzeichen hinzufügen"
 
-#: ../gramps/plugins/tool/testcasegenerator.py:277
+#: ../gramps/plugins/tool/testcasegenerator.py:308
 msgid "Add serial number"
 msgstr "Seriennummer hinzufügen"
 
-#: ../gramps/plugins/tool/testcasegenerator.py:281
+#: ../gramps/plugins/tool/testcasegenerator.py:312
 msgid "Add line break"
 msgstr "Zeilenumbruch hinzufügen"
 
-#: ../gramps/plugins/tool/testcasegenerator.py:285
+#: ../gramps/plugins/tool/testcasegenerator.py:317
 msgid ""
 "Number of people to generate\n"
 "(Number is approximate because families are generated)"
@@ -32756,27 +33083,24 @@ msgstr ""
 "Anzahl der zu erstellenden Personen\n"
 "(Anzahl ist angenähert weil Familien erstellt werden)"
 
-#: ../gramps/plugins/tool/testcasegenerator.py:341
+#: ../gramps/plugins/tool/testcasegenerator.py:375
+#: ../gramps/plugins/tool/testcasegenerator.py:385
+#: ../gramps/plugins/tool/testcasegenerator.py:391
 msgid "Generating testcases"
 msgstr "Erstelle Testfälle"
 
-#: ../gramps/plugins/tool/testcasegenerator.py:346
+#: ../gramps/plugins/tool/testcasegenerator.py:376
 msgid "Generating low level database errors"
 msgstr "Erstelle Datenbankfehler auf niedriger Ebene"
 
-#: ../gramps/plugins/tool/testcasegenerator.py:358
-msgid "Generating families"
-msgstr "Erstelle Familien"
-
-#: ../gramps/plugins/tool/testcasegenerator.py:389
+#: ../gramps/plugins/tool/testcasegenerator.py:386
 msgid "Generating database errors"
 msgstr "Erstelle Datenbankfehler"
 
-#. Creates a media object with character encoding errors. This tests
-#. Check.fix_encoding() and also cleanup_missing_photos
-#. Creates a note with control characters. This tests
-#. Check.fix_ctrlchars_in_notes()
-#. Generate empty objects to test their deletion
+#: ../gramps/plugins/tool/testcasegenerator.py:392
+msgid "Generating families"
+msgstr "Erstelle Familien"
+
 #. Create a family, that links to father and mother, but father does not
 #. link back
 #. Create a family, that misses the link to the father
@@ -32785,19 +33109,20 @@ msgstr "Erstelle Datenbankfehler"
 #. link back
 #. person2 = self.db.get_person_from_handle(person2_h)
 #. person2.add_family_handle(fam_h)
-#. self.db.commit_person(person2,self.trans)
+#. self.db.commit_person(person2, self.trans)
 #. Create two married people of same sex.
 #. This is NOT detected as an error by plugins/tool/Check.py
 #. Create a family, that contains an invalid handle to for the father
 #. Create a family, that contains an invalid handle to for the mother
 #. person2 = self.db.get_person_from_handle(person2_h)
 #. person2.add_family_handle(fam_h)
-#. self.db.commit_person(person2,self.trans)
+#. self.db.commit_person(person2, self.trans)
 #. Creates a family where the child does not link back to the family
 #. child = self.db.get_person_from_handle(child_h)
 #. person2.add_parent_family_handle(fam_h)
-#. self.db.commit_person(child,self.trans)
-#. Creates a family where the child is not linked, but the child links to the family
+#. self.db.commit_person(child, self.trans)
+#. Creates a family where the child is not linked, but the child links
+#. to the family
 #. Creates a family where the child is one of the parents
 #. Creates a couple that refer to a family that does not exist in the
 #. database.
@@ -32810,35 +33135,36 @@ msgstr "Erstelle Datenbankfehler"
 #. This is NOT detected as an error by plugins/tool/Check.py
 #. Creates a person with a birth event pointing to nonexisting place
 #. Creates a person with an event pointing to nonexisting place
-#. Generate objects that refer to non-existant citations
-#: ../gramps/plugins/tool/testcasegenerator.py:418
-#: ../gramps/plugins/tool/testcasegenerator.py:453
-#: ../gramps/plugins/tool/testcasegenerator.py:499
-#: ../gramps/plugins/tool/testcasegenerator.py:517
-#: ../gramps/plugins/tool/testcasegenerator.py:551
-#: ../gramps/plugins/tool/testcasegenerator.py:569
-#: ../gramps/plugins/tool/testcasegenerator.py:587
-#: ../gramps/plugins/tool/testcasegenerator.py:606
-#: ../gramps/plugins/tool/testcasegenerator.py:625
-#: ../gramps/plugins/tool/testcasegenerator.py:643
-#: ../gramps/plugins/tool/testcasegenerator.py:661
-#: ../gramps/plugins/tool/testcasegenerator.py:679
-#: ../gramps/plugins/tool/testcasegenerator.py:705
-#: ../gramps/plugins/tool/testcasegenerator.py:731
+#: ../gramps/plugins/tool/testcasegenerator.py:468
+#: ../gramps/plugins/tool/testcasegenerator.py:504
+#: ../gramps/plugins/tool/testcasegenerator.py:553
+#: ../gramps/plugins/tool/testcasegenerator.py:570
+#: ../gramps/plugins/tool/testcasegenerator.py:596
+#: ../gramps/plugins/tool/testcasegenerator.py:666
+#: ../gramps/plugins/tool/testcasegenerator.py:701
+#: ../gramps/plugins/tool/testcasegenerator.py:721
+#: ../gramps/plugins/tool/testcasegenerator.py:739
 #: ../gramps/plugins/tool/testcasegenerator.py:758
-#: ../gramps/plugins/tool/testcasegenerator.py:793
-#: ../gramps/plugins/tool/testcasegenerator.py:804
+#: ../gramps/plugins/tool/testcasegenerator.py:779
+#: ../gramps/plugins/tool/testcasegenerator.py:797
 #: ../gramps/plugins/tool/testcasegenerator.py:815
-#: ../gramps/plugins/tool/testcasegenerator.py:826
-#: ../gramps/plugins/tool/testcasegenerator.py:842
-#: ../gramps/plugins/tool/testcasegenerator.py:859
-#: ../gramps/plugins/tool/testcasegenerator.py:882
-#: ../gramps/plugins/tool/testcasegenerator.py:898
-#: ../gramps/plugins/tool/testcasegenerator.py:915
-#: ../gramps/plugins/tool/testcasegenerator.py:948
-#: ../gramps/plugins/tool/testcasegenerator.py:1381
-#: ../gramps/plugins/tool/testcasegenerator.py:1482
-#: ../gramps/plugins/tool/testcasegenerator.py:1506
+#: ../gramps/plugins/tool/testcasegenerator.py:833
+#: ../gramps/plugins/tool/testcasegenerator.py:860
+#: ../gramps/plugins/tool/testcasegenerator.py:886
+#: ../gramps/plugins/tool/testcasegenerator.py:913
+#: ../gramps/plugins/tool/testcasegenerator.py:949
+#: ../gramps/plugins/tool/testcasegenerator.py:960
+#: ../gramps/plugins/tool/testcasegenerator.py:971
+#: ../gramps/plugins/tool/testcasegenerator.py:982
+#: ../gramps/plugins/tool/testcasegenerator.py:998
+#: ../gramps/plugins/tool/testcasegenerator.py:1015
+#: ../gramps/plugins/tool/testcasegenerator.py:1039
+#: ../gramps/plugins/tool/testcasegenerator.py:1055
+#: ../gramps/plugins/tool/testcasegenerator.py:1072
+#: ../gramps/plugins/tool/testcasegenerator.py:1105
+#: ../gramps/plugins/tool/testcasegenerator.py:1552
+#: ../gramps/plugins/tool/testcasegenerator.py:1658
+#: ../gramps/plugins/tool/testcasegenerator.py:1683
 #, python-format
 msgid "Testcase generator step %d"
 msgstr "Testfälle erstellen Schritt %d"
@@ -33068,182 +33394,180 @@ msgstr "Maximaler Altersa_bstand zwischen zwei Kindern"
 msgid "Maximum _span of years for all children"
 msgstr "Maximaler Zeitra_um für die Geburt aller Kinder"
 
-#: ../gramps/plugins/tool/verify.glade:987
-#: ../gramps/plugins/tool/verify.py:632
+#: ../gramps/plugins/tool/verify.glade:985 ../gramps/plugins/tool/verify.py:676
 msgid "_Hide marked"
 msgstr "_als versteckt markiert"
 
-#: ../gramps/plugins/tool/verify.py:74
+#: ../gramps/plugins/tool/verify.py:83
 msgid "manual|Verify_the_Data"
 msgstr "Die_Daten_Vergleichen"
 
-#: ../gramps/plugins/tool/verify.py:263
+#: ../gramps/plugins/tool/verify.py:295
 msgid "Data Verify tool"
 msgstr "Datenüberprüfungswerkzeug"
 
 #. translators: needed for French+Arabic, ignore otherwise
-#: ../gramps/plugins/tool/verify.py:282 ../gramps/plugins/tool/verify.py:287
-#: ../gramps/plugins/tool/verify.py:292
+#: ../gramps/plugins/tool/verify.py:318
 #, python-format
 msgid "%(severity)s: %(msg)s, %(type)s: %(gid)s, %(name)s"
 msgstr "%(severity)s: %(msg)s, %(type)s: %(gid)s, %(name)s"
 
-#: ../gramps/plugins/tool/verify.py:465
+#: ../gramps/plugins/tool/verify.py:498
 msgid "Data Verification Results"
 msgstr "Ergebnisse der Datenüberprüfung"
 
 #. Add column with the warning text
-#: ../gramps/plugins/tool/verify.py:528
+#: ../gramps/plugins/tool/verify.py:563
 msgid "Warning"
 msgstr "Warnung"
 
-#: ../gramps/plugins/tool/verify.py:622
+#: ../gramps/plugins/tool/verify.py:666
 msgid "_Show all"
 msgstr "_Alle anzeigen"
 
-#: ../gramps/plugins/tool/verify.py:884
+#: ../gramps/plugins/tool/verify.py:947
 msgid "Baptism before birth"
 msgstr "Taufe vor Geburt"
 
-#: ../gramps/plugins/tool/verify.py:897
+#: ../gramps/plugins/tool/verify.py:963
 msgid "Death before baptism"
 msgstr "Tod vor Taufe"
 
-#: ../gramps/plugins/tool/verify.py:910
+#: ../gramps/plugins/tool/verify.py:979
 msgid "Burial before birth"
 msgstr "Beerdigung vor Geburt"
 
-#: ../gramps/plugins/tool/verify.py:923
+#: ../gramps/plugins/tool/verify.py:995
 msgid "Burial before death"
 msgstr "Beerdigung vor Tod"
 
-#: ../gramps/plugins/tool/verify.py:936
+#: ../gramps/plugins/tool/verify.py:1011
 msgid "Death before birth"
 msgstr "Vor der Geburt verstorben"
 
-#: ../gramps/plugins/tool/verify.py:949
+#: ../gramps/plugins/tool/verify.py:1027
 msgid "Burial before baptism"
 msgstr "Beerdigung vor Taufe"
 
-#: ../gramps/plugins/tool/verify.py:967
+#: ../gramps/plugins/tool/verify.py:1050
 msgid "Old age at death"
 msgstr "Sehr alt verstorben"
 
-#: ../gramps/plugins/tool/verify.py:988
+#: ../gramps/plugins/tool/verify.py:1077
 msgid "Multiple parents"
 msgstr "Mehrere Eltern"
 
-#: ../gramps/plugins/tool/verify.py:1005
+#: ../gramps/plugins/tool/verify.py:1099
 msgid "Married often"
 msgstr "Häufig verheiratet"
 
-#: ../gramps/plugins/tool/verify.py:1024
+#: ../gramps/plugins/tool/verify.py:1123
 msgid "Old and unmarried"
 msgstr "Alt und Unverheiratet"
 
-#: ../gramps/plugins/tool/verify.py:1051
+#: ../gramps/plugins/tool/verify.py:1155
 msgid "Too many children"
 msgstr "Zu viele Kinder"
 
-#: ../gramps/plugins/tool/verify.py:1066
+#: ../gramps/plugins/tool/verify.py:1173
 msgid "Same sex marriage"
 msgstr "Gleichgeschlechtliche Hochzeit"
 
-#: ../gramps/plugins/tool/verify.py:1076
+#: ../gramps/plugins/tool/verify.py:1186
 msgid "Female husband"
 msgstr "Weiblicher Ehemann"
 
-#: ../gramps/plugins/tool/verify.py:1086
+#: ../gramps/plugins/tool/verify.py:1199
 msgid "Male wife"
 msgstr "Männliche Ehefrau"
 
-#: ../gramps/plugins/tool/verify.py:1113
+#: ../gramps/plugins/tool/verify.py:1229
 msgid "Husband and wife with the same surname"
 msgstr "Ehemann und Ehefrau mit dem gleichen Nachnamen"
 
-#: ../gramps/plugins/tool/verify.py:1138
+#: ../gramps/plugins/tool/verify.py:1259
 msgid "Large age difference between spouses"
 msgstr "Großer Altersunterschied zwischen den Ehepartnern"
 
-#: ../gramps/plugins/tool/verify.py:1169
+#: ../gramps/plugins/tool/verify.py:1295
 msgid "Marriage before birth"
 msgstr "Heirat vor der Geburt"
 
-#: ../gramps/plugins/tool/verify.py:1200
+#: ../gramps/plugins/tool/verify.py:1331
 msgid "Marriage after death"
 msgstr "Heirat nach dem Tod"
 
-#: ../gramps/plugins/tool/verify.py:1234
+#: ../gramps/plugins/tool/verify.py:1372
 msgid "Early marriage"
 msgstr "Jung verheiratet"
 
-#: ../gramps/plugins/tool/verify.py:1266
+#: ../gramps/plugins/tool/verify.py:1411
 msgid "Late marriage"
 msgstr "Hohes Alter bei Heirat"
 
-#: ../gramps/plugins/tool/verify.py:1327
+#: ../gramps/plugins/tool/verify.py:1460
 msgid "Old father"
 msgstr "Alter Vater"
 
-#: ../gramps/plugins/tool/verify.py:1330
+#: ../gramps/plugins/tool/verify.py:1464
 msgid "Old mother"
 msgstr "Alte Mutter"
 
-#: ../gramps/plugins/tool/verify.py:1372
+#: ../gramps/plugins/tool/verify.py:1513
 msgid "Young father"
 msgstr "Junger Vater"
 
-#: ../gramps/plugins/tool/verify.py:1375
+#: ../gramps/plugins/tool/verify.py:1517
 msgid "Young mother"
 msgstr "Junge Mutter"
 
-#: ../gramps/plugins/tool/verify.py:1414
+#: ../gramps/plugins/tool/verify.py:1561
 msgid "Unborn father"
 msgstr "Ungeborener Vater"
 
-#: ../gramps/plugins/tool/verify.py:1417
+#: ../gramps/plugins/tool/verify.py:1565
 msgid "Unborn mother"
 msgstr "Ungeborene Mutter"
 
-#: ../gramps/plugins/tool/verify.py:1462
+#: ../gramps/plugins/tool/verify.py:1616
 msgid "Dead father"
 msgstr "Toter Vater"
 
-#: ../gramps/plugins/tool/verify.py:1465
+#: ../gramps/plugins/tool/verify.py:1620
 msgid "Dead mother"
 msgstr "Tote Mutter"
 
-#: ../gramps/plugins/tool/verify.py:1487
+#: ../gramps/plugins/tool/verify.py:1646
 msgid "Large year span for all children"
 msgstr "Große Zeitspanne für alle Kinder"
 
-#: ../gramps/plugins/tool/verify.py:1509
+#: ../gramps/plugins/tool/verify.py:1673
 msgid "Large age differences between children"
 msgstr "Große Altersunterschiede zwischen den Kindern"
 
-#: ../gramps/plugins/tool/verify.py:1519
+#: ../gramps/plugins/tool/verify.py:1686
 msgid "Disconnected individual"
 msgstr "Einzeln stehende Person"
 
-#: ../gramps/plugins/tool/verify.py:1541
+#: ../gramps/plugins/tool/verify.py:1713
 msgid "Invalid birth date"
 msgstr "Ungültiges Geburtsdatum"
 
-#: ../gramps/plugins/tool/verify.py:1563
+#: ../gramps/plugins/tool/verify.py:1740
 msgid "Invalid death date"
 msgstr "Ungültiges Sterbedatum"
 
-#: ../gramps/plugins/tool/verify.py:1579
+#: ../gramps/plugins/tool/verify.py:1760
 msgid "Marriage date but not married"
 msgstr "Heiratsdatum, aber nicht verheiratet"
 
-#: ../gramps/plugins/tool/verify.py:1602
+#: ../gramps/plugins/tool/verify.py:1788
 msgid "Old age but no death"
 msgstr "Alt, aber nicht tot"
 
 #: ../gramps/plugins/view/citationlistview.py:101
 #: ../gramps/plugins/view/citationtreeview.py:96
-#: ../gramps/plugins/webreport/narrativeweb.py:2604
+#: ../gramps/plugins/webreport/narrativeweb.py:2591
 msgid "Confidence"
 msgstr "Verlässlichkeit"
 
@@ -33301,7 +33625,7 @@ msgid "Citation View"
 msgstr "Fundstellenansicht"
 
 #: ../gramps/plugins/view/citationlistview.py:180
-#: ../gramps/plugins/view/citationtreeview.py:288
+#: ../gramps/plugins/view/citationtreeview.py:290
 msgid "Citation Filter Editor"
 msgstr "Filtereditor für Fundstellen"
 
@@ -33321,13 +33645,13 @@ msgstr ""
 
 #: ../gramps/plugins/view/citationlistview.py:311
 #: ../gramps/plugins/view/citationlistview.py:322
-#: ../gramps/plugins/view/citationtreeview.py:512
-#: ../gramps/plugins/view/citationtreeview.py:532
+#: ../gramps/plugins/view/citationtreeview.py:504
+#: ../gramps/plugins/view/citationtreeview.py:517
 msgid "Cannot merge citations."
 msgstr "Kann Fundstellen nicht zusammenfassen."
 
 #: ../gramps/plugins/view/citationlistview.py:312
-#: ../gramps/plugins/view/citationtreeview.py:513
+#: ../gramps/plugins/view/citationtreeview.py:505
 msgid ""
 "Exactly two citations must be selected to perform a merge. A second citation "
 "can be selected by holding down the control key while clicking on the "
@@ -33338,7 +33662,7 @@ msgstr ""
 "Fundstelle bei gehaltener Strg-Taste gewählt werden."
 
 #: ../gramps/plugins/view/citationlistview.py:323
-#: ../gramps/plugins/view/citationtreeview.py:533
+#: ../gramps/plugins/view/citationtreeview.py:518
 msgid ""
 "The two selected citations must have the same source to perform a merge. If "
 "you want to merge these two citations, then you must merge the sources first."
@@ -33363,27 +33687,27 @@ msgstr "Die gewählten Fundstellen oder Quellen zusammenfassen"
 msgid "Citation Tree View"
 msgstr "Fundstellenbaumansicht"
 
-#: ../gramps/plugins/view/citationtreeview.py:275
+#: ../gramps/plugins/view/citationtreeview.py:277
 msgid "Add source..."
 msgstr "Quelle hinzufügen..."
 
-#: ../gramps/plugins/view/citationtreeview.py:280
+#: ../gramps/plugins/view/citationtreeview.py:282
 msgid "Add citation..."
 msgstr "Fundstelle hinzufügen..."
 
-#: ../gramps/plugins/view/citationtreeview.py:296
+#: ../gramps/plugins/view/citationtreeview.py:298
 #: ../gramps/plugins/view/persontreeview.py:82
 #: ../gramps/plugins/view/placetreeview.py:74
 msgid "Expand all Nodes"
 msgstr "Alle Knoten aufklappen"
 
-#: ../gramps/plugins/view/citationtreeview.py:298
+#: ../gramps/plugins/view/citationtreeview.py:300
 #: ../gramps/plugins/view/persontreeview.py:84
 #: ../gramps/plugins/view/placetreeview.py:76
 msgid "Collapse all Nodes"
 msgstr "Alle Knoten schließen"
 
-#: ../gramps/plugins/view/citationtreeview.py:499
+#: ../gramps/plugins/view/citationtreeview.py:491
 msgid ""
 "This source cannot be edited at this time. Either the associated Source "
 "object is already being edited, or another citation associated with the same "
@@ -33397,11 +33721,11 @@ msgstr ""
 "\n"
 "Um diese Quelle zu bearbeiten, muss das Objekt geschlossen werden."
 
-#: ../gramps/plugins/view/citationtreeview.py:544
+#: ../gramps/plugins/view/citationtreeview.py:530
 msgid "Cannot perform merge."
 msgstr "Kann das Zusammenfassen nicht durchführen."
 
-#: ../gramps/plugins/view/citationtreeview.py:545
+#: ../gramps/plugins/view/citationtreeview.py:531
 msgid ""
 "Both objects must be of the same type, either both must be sources, or both "
 "must be citations."
@@ -33414,7 +33738,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr "Gramplet Werkzeugbank"
 
-#: ../gramps/plugins/view/dashboardview.py:95
+#: ../gramps/plugins/view/dashboardview.py:101
 msgid "Restore a gramplet"
 msgstr "Gramplet wiederherstellen"
 
@@ -33493,11 +33817,11 @@ msgstr "Familie _löschen"
 msgid "Family [%s]"
 msgstr "Familie [%s]"
 
-#: ../gramps/plugins/view/familyview.py:299
+#: ../gramps/plugins/view/familyview.py:305
 msgid "Cannot merge families."
 msgstr "Kann Familien nicht zusammenfassen."
 
-#: ../gramps/plugins/view/familyview.py:300
+#: ../gramps/plugins/view/familyview.py:306
 msgid ""
 "Exactly two families must be selected to perform a merge. A second family "
 "can be selected by holding down the control key while clicking on the "
@@ -33507,132 +33831,178 @@ msgstr ""
 "durchzuführen. Eine zweite Familie kann durch Anklicken bei gehaltener Strg-"
 "Taste gewählt werden."
 
-#: ../gramps/plugins/view/fanchartdescview.py:168
-#: ../gramps/plugins/view/fanchartview.py:166
+#: ../gramps/plugins/view/fanchart2wayview.py:193
+#: ../gramps/plugins/view/fanchartdescview.py:188
+#: ../gramps/plugins/view/fanchartview.py:184
 msgid "Print or save the Fan Chart View"
 msgstr "Drucke oder speichere die Fächergrafikansicht"
 
-#: ../gramps/plugins/view/fanchartdescview.py:278
-#: ../gramps/plugins/view/fanchartview.py:276
+#: ../gramps/plugins/view/fanchart2wayview.py:294
+#, fuzzy
+msgid "Max ancestor generations"
+msgstr "Max. Vorfahrengenerationen"
+
+#: ../gramps/plugins/view/fanchart2wayview.py:297
+#, fuzzy
+msgid "Max descendant generations"
+msgstr "Max. Nachkommengenerationen"
+
+#: ../gramps/plugins/view/fanchart2wayview.py:301
+#: ../gramps/plugins/view/fanchartdescview.py:298
+#: ../gramps/plugins/view/fanchartview.py:294
 msgid "Text Font"
 msgstr "Text Schrift"
 
-#: ../gramps/plugins/view/fanchartdescview.py:282
-#: ../gramps/plugins/view/fanchartview.py:280
+#: ../gramps/plugins/view/fanchart2wayview.py:305
+#: ../gramps/plugins/view/fanchartdescview.py:302
+#: ../gramps/plugins/view/fanchartview.py:298
 msgid "Gender colors"
 msgstr "Geschlechtsfarben"
 
-#: ../gramps/plugins/view/fanchartdescview.py:283
-#: ../gramps/plugins/view/fanchartview.py:281
+#: ../gramps/plugins/view/fanchart2wayview.py:306
+#: ../gramps/plugins/view/fanchartdescview.py:303
+#: ../gramps/plugins/view/fanchartview.py:299
 msgid "Generation based gradient"
 msgstr "Auf Generationen basierender Farbverlauf"
 
-#: ../gramps/plugins/view/fanchartdescview.py:284
-#: ../gramps/plugins/view/fanchartview.py:282
+#: ../gramps/plugins/view/fanchart2wayview.py:307
+#: ../gramps/plugins/view/fanchartdescview.py:304
+#: ../gramps/plugins/view/fanchartview.py:300
 msgid "Age (0-100) based gradient"
 msgstr "Auf Alter (0-100) basierender Farbverlauf"
 
-#: ../gramps/plugins/view/fanchartdescview.py:286
-#: ../gramps/plugins/view/fanchartview.py:284
+#: ../gramps/plugins/view/fanchart2wayview.py:309
+#: ../gramps/plugins/view/fanchartdescview.py:306
+#: ../gramps/plugins/view/fanchartview.py:302
 msgid "Single main (filter) color"
 msgstr "Einzelne Haupt(filter)farbe"
 
-#: ../gramps/plugins/view/fanchartdescview.py:287
-#: ../gramps/plugins/view/fanchartview.py:285
+#: ../gramps/plugins/view/fanchart2wayview.py:310
+#: ../gramps/plugins/view/fanchartdescview.py:307
+#: ../gramps/plugins/view/fanchartview.py:303
 msgid "Time period based gradient"
 msgstr "Auf Zeitraum basierender Farbverlauf"
 
-#: ../gramps/plugins/view/fanchartdescview.py:288
-#: ../gramps/plugins/view/fanchartview.py:286
+#: ../gramps/plugins/view/fanchart2wayview.py:311
+#: ../gramps/plugins/view/fanchartdescview.py:308
+#: ../gramps/plugins/view/fanchartview.py:304
 msgid "White"
 msgstr "Weiß"
 
-#: ../gramps/plugins/view/fanchartdescview.py:289
-#: ../gramps/plugins/view/fanchartview.py:287
+#: ../gramps/plugins/view/fanchart2wayview.py:312
+#: ../gramps/plugins/view/fanchartdescview.py:309
+#: ../gramps/plugins/view/fanchartview.py:305
 msgid "Color scheme classic report"
 msgstr "Farbschema klassischer Bericht"
 
-#: ../gramps/plugins/view/fanchartdescview.py:290
-#: ../gramps/plugins/view/fanchartview.py:288
+#: ../gramps/plugins/view/fanchart2wayview.py:313
+#: ../gramps/plugins/view/fanchartdescview.py:310
+#: ../gramps/plugins/view/fanchartview.py:306
 msgid "Color scheme classic view"
 msgstr "Farbschema klassische Ansicht"
 
-#: ../gramps/plugins/view/fanchartdescview.py:299
-#: ../gramps/plugins/view/fanchartview.py:297
+#: ../gramps/plugins/view/fanchart2wayview.py:322
+#: ../gramps/plugins/view/fanchartdescview.py:319
+#: ../gramps/plugins/view/fanchartview.py:315
 msgid "Background"
 msgstr "Hintergrund"
 
+#: ../gramps/plugins/view/fanchart2wayview.py:331
+msgid "Add global background colored gradient"
+msgstr ""
+
 #. colors, stored as hex values
-#: ../gramps/plugins/view/fanchartdescview.py:306
-#: ../gramps/plugins/view/fanchartview.py:303
+#: ../gramps/plugins/view/fanchart2wayview.py:335
+#: ../gramps/plugins/view/fanchartdescview.py:326
+#: ../gramps/plugins/view/fanchartview.py:321
 msgid "Start gradient/Main color"
 msgstr "Start Farbverlauf/Hauptfarbe"
 
-#: ../gramps/plugins/view/fanchartdescview.py:308
-#: ../gramps/plugins/view/fanchartview.py:305
+#: ../gramps/plugins/view/fanchart2wayview.py:337
+#: ../gramps/plugins/view/fanchartdescview.py:328
+#: ../gramps/plugins/view/fanchartview.py:323
 msgid "End gradient/2nd color"
 msgstr "Ende Farbverlauf/2. Farbe"
 
-#: ../gramps/plugins/view/fanchartdescview.py:310
+#: ../gramps/plugins/view/fanchart2wayview.py:339
+#: ../gramps/plugins/view/fanchartdescview.py:330
 msgid "Color for duplicates"
 msgstr "Farbe für Duplikate"
 
-#. form of the fan
-#: ../gramps/plugins/view/fanchartdescview.py:313
-#: ../gramps/plugins/view/fanchartview.py:308
-msgid "Fan chart type"
-msgstr "Fächergrafikart"
-
-#: ../gramps/plugins/view/fanchartdescview.py:315
-#: ../gramps/plugins/view/fanchartview.py:310
-msgid "Full Circle"
-msgstr "Vollkreis"
-
-#: ../gramps/plugins/view/fanchartdescview.py:316
-#: ../gramps/plugins/view/fanchartview.py:310
-msgid "Half Circle"
-msgstr "Halbkreis"
-
-#: ../gramps/plugins/view/fanchartdescview.py:317
-#: ../gramps/plugins/view/fanchartview.py:311
-msgid "Quadrant"
-msgstr "Viertelkreis"
-
 #. algo for the fan angle distribution
-#: ../gramps/plugins/view/fanchartdescview.py:320
+#: ../gramps/plugins/view/fanchart2wayview.py:342
+#: ../gramps/plugins/view/fanchartdescview.py:340
 msgid "Fan chart distribution"
 msgstr "Fächergrafik Verteilung"
 
-#: ../gramps/plugins/view/fanchartdescview.py:323
+#: ../gramps/plugins/view/fanchart2wayview.py:345
+#: ../gramps/plugins/view/fanchartdescview.py:343
 msgid "Homogeneous children distribution"
 msgstr "Einheitliche Kinderaufteilung"
 
-#: ../gramps/plugins/view/fanchartdescview.py:325
+#: ../gramps/plugins/view/fanchart2wayview.py:347
+#: ../gramps/plugins/view/fanchartdescview.py:345
 msgid "Size  proportional to number of descendants"
 msgstr "Größe proportional zur Anzahl der Nachkommen"
+
+#: ../gramps/plugins/view/fanchart2wayview.py:353
+#: ../gramps/plugins/view/fanchartdescview.py:351
+#: ../gramps/plugins/view/fanchartview.py:334
+#, fuzzy
+msgid "Show names on two lines"
+msgstr "Familienknoten anzeigen"
+
+#: ../gramps/plugins/view/fanchart2wayview.py:358
+#: ../gramps/plugins/view/fanchartdescview.py:356
+#: ../gramps/plugins/view/fanchartview.py:339
+msgid "Flip name on the left of the fan"
+msgstr ""
 
 #. options we don't show on the dialog
 #. #configdialog.add_checkbox(table,
 #. #        _('Allow radial text'),
 #. #        ??, 'interface.fanview-radialtext')
-#: ../gramps/plugins/view/fanchartdescview.py:329
-#: ../gramps/plugins/view/fanchartview.py:323
-#: ../gramps/plugins/view/pedigreeview.py:2039
-#: ../gramps/plugins/view/relview.py:1699
+#: ../gramps/plugins/view/fanchart2wayview.py:361
+#: ../gramps/plugins/view/fanchartdescview.py:359
+#: ../gramps/plugins/view/fanchartview.py:351
+#: ../gramps/plugins/view/pedigreeview.py:2052
+#: ../gramps/plugins/view/relview.py:1709
 msgid "Layout"
 msgstr "Layout"
 
-#: ../gramps/plugins/view/fanchartdescview.py:502
-#: ../gramps/plugins/view/fanchartview.py:511
+#: ../gramps/plugins/view/fanchart2wayview.py:562
+#: ../gramps/plugins/view/fanchartdescview.py:550
+#: ../gramps/plugins/view/fanchartview.py:557
 msgid "No preview available"
 msgstr "Keine Vorschau verfügbar."
 
-#: ../gramps/plugins/view/fanchartview.py:316
+#. form of the fan
+#: ../gramps/plugins/view/fanchartdescview.py:333
+#: ../gramps/plugins/view/fanchartview.py:326
+msgid "Fan chart type"
+msgstr "Fächergrafikart"
+
+#: ../gramps/plugins/view/fanchartdescview.py:335
+#: ../gramps/plugins/view/fanchartview.py:328
+msgid "Full Circle"
+msgstr "Vollkreis"
+
+#: ../gramps/plugins/view/fanchartdescview.py:336
+#: ../gramps/plugins/view/fanchartview.py:328
+msgid "Half Circle"
+msgstr "Halbkreis"
+
+#: ../gramps/plugins/view/fanchartdescview.py:337
+#: ../gramps/plugins/view/fanchartview.py:329
+msgid "Quadrant"
+msgstr "Viertelkreis"
+
+#: ../gramps/plugins/view/fanchartview.py:344
 msgid "Show children ring"
 msgstr "Kinderring zeigen"
 
 #: ../gramps/plugins/view/geoclose.py:143
-#: ../gramps/plugins/view/geography.gpr.py:153
+#: ../gramps/plugins/view/geography.gpr.py:159
 msgid "Have they been able to meet?"
 msgstr "War es ihnen möglich, sich zu treffen?"
 
@@ -33679,7 +34049,7 @@ msgid "Select the person which will be our reference."
 msgstr "Wähle die Person, welche unsere Referenz wird."
 
 #: ../gramps/plugins/view/geoclose.py:412
-#: ../gramps/plugins/view/geofamclose.py:497
+#: ../gramps/plugins/view/geofamclose.py:496
 #: ../gramps/plugins/view/geofamily.py:207
 #: ../gramps/plugins/view/geomoves.py:292
 #: ../gramps/plugins/view/geoperson.py:339
@@ -33708,7 +34078,7 @@ msgstr ""
 "Die Werteaufteilung ist in Gradzehntel."
 
 #: ../gramps/plugins/view/geoclose.py:602
-#: ../gramps/plugins/view/geofamclose.py:793
+#: ../gramps/plugins/view/geofamclose.py:792
 msgid "The selection parameters"
 msgstr "Die Auswahlparameter"
 
@@ -33724,29 +34094,29 @@ msgstr "GeoEreignisse"
 msgid "incomplete or unreferenced event ?"
 msgstr "Unvollständiges oder nicht referenziertes Ereignis?"
 
-#: ../gramps/plugins/view/geoevents.py:294
-#: ../gramps/plugins/view/geoevents.py:305
+#: ../gramps/plugins/view/geoevents.py:295
+#: ../gramps/plugins/view/geoevents.py:307
 msgid "Selecting all events"
 msgstr "Alle Ereignisse wählen"
 
-#: ../gramps/plugins/view/geoevents.py:350
-#: ../gramps/plugins/view/geoevents.py:382
+#: ../gramps/plugins/view/geoevents.py:352
+#: ../gramps/plugins/view/geoevents.py:384
 msgid "Bookmark this event"
 msgstr "Ein Lesezeichen für dieses Ereignis erstellen"
 
-#: ../gramps/plugins/view/geoevents.py:397
+#: ../gramps/plugins/view/geoevents.py:399
 msgid "Show all events"
 msgstr "Zeigt alle Ereignisse"
 
-#: ../gramps/plugins/view/geoevents.py:401
-#: ../gramps/plugins/view/geoevents.py:406
-#: ../gramps/plugins/view/geoplaces.py:400
-#: ../gramps/plugins/view/geoplaces.py:405
+#: ../gramps/plugins/view/geoevents.py:403
+#: ../gramps/plugins/view/geoevents.py:408
+#: ../gramps/plugins/view/geoplaces.py:484
+#: ../gramps/plugins/view/geoplaces.py:489
 msgid "Centering on Place"
 msgstr "Auf Ort zentrieren"
 
 #: ../gramps/plugins/view/geofamclose.py:143
-#: ../gramps/plugins/view/geography.gpr.py:135
+#: ../gramps/plugins/view/geography.gpr.py:141
 msgid "Have these two families been able to meet?"
 msgstr "War es diesen zwei Familien möglich sich zu treffen?"
 
@@ -33760,22 +34130,22 @@ msgstr "GeoFamNah"
 msgid "%(gramps_id)s : %(father)s and %(mother)s"
 msgstr "%(gramps_id)s : %(father)s und %(mother)s"
 
-#: ../gramps/plugins/view/geofamclose.py:265
+#: ../gramps/plugins/view/geofamclose.py:264
 #, python-format
 msgid "Family reference : %s"
 msgstr "Familienreferenz: %s"
 
-#: ../gramps/plugins/view/geofamclose.py:268
-#: ../gramps/plugins/view/geofamclose.py:272
+#: ../gramps/plugins/view/geofamclose.py:267
+#: ../gramps/plugins/view/geofamclose.py:270
 #, python-format
 msgid "The other family : %s"
 msgstr "die andere Familie: %s"
 
-#: ../gramps/plugins/view/geofamclose.py:278
+#: ../gramps/plugins/view/geofamclose.py:277
 msgid "You must choose one reference family."
 msgstr "Du musst eine Referenzfamilie wählen."
 
-#: ../gramps/plugins/view/geofamclose.py:280
+#: ../gramps/plugins/view/geofamclose.py:279
 msgid ""
 "Go to the family view and select the families you want to compare. Return to "
 "this view and use the history."
@@ -33783,43 +34153,43 @@ msgstr ""
 "Gehe in die Familienansicht und wähle die Familien, die du vergleichen "
 "möchtest. Kehre dann in diese Ansicht zurück und verwende die Chronik."
 
-#: ../gramps/plugins/view/geofamclose.py:296
+#: ../gramps/plugins/view/geofamclose.py:295
 msgid "reference _Family"
 msgstr "Referenz_familie"
 
-#: ../gramps/plugins/view/geofamclose.py:297
+#: ../gramps/plugins/view/geofamclose.py:296
 msgid "Select the family which is the reference for life ways"
 msgstr "Wähle die Familie für die Referenz für Lebenswege"
 
-#: ../gramps/plugins/view/geofamclose.py:609
+#: ../gramps/plugins/view/geofamclose.py:608
 #: ../gramps/plugins/view/geofamily.py:345
 #, python-format
 msgid "Father : %(id)s : %(name)s"
 msgstr "Vater : %(id)s : %(name)s"
 
-#: ../gramps/plugins/view/geofamclose.py:618
+#: ../gramps/plugins/view/geofamclose.py:617
 #: ../gramps/plugins/view/geofamily.py:354
 #, python-format
 msgid "Mother : %(id)s : %(name)s"
 msgstr "Mutter : %(id)s : %(name)s"
 
-#: ../gramps/plugins/view/geofamclose.py:630
+#: ../gramps/plugins/view/geofamclose.py:629
 #: ../gramps/plugins/view/geofamily.py:366
 #, python-format
 msgid "Child : %(id)s - %(index)d : %(name)s"
 msgstr "Kind : %(id)s - %(index)d : %(name)s"
 
-#: ../gramps/plugins/view/geofamclose.py:640
+#: ../gramps/plugins/view/geofamclose.py:639
 #: ../gramps/plugins/view/geofamily.py:375
 #, python-format
 msgid "Person : %(id)s %(name)s has no family."
 msgstr "Person : %(id)s %(name)s hat keine Familie."
 
-#: ../gramps/plugins/view/geofamclose.py:759
+#: ../gramps/plugins/view/geofamclose.py:758
 msgid "Choose and bookmark the new reference family"
 msgstr "Wähle die neue Referenzfamilie und füge sie als Lesezeichen hinzu."
 
-#: ../gramps/plugins/view/geofamclose.py:782
+#: ../gramps/plugins/view/geofamclose.py:781
 msgid ""
 "The meeting zone probability radius.\n"
 "The colored zone is approximative.\n"
@@ -33861,41 +34231,41 @@ msgstr ""
 "Geografie Funktionalität wird nicht zur Verfügung stehen.\n"
 "Um es für Gramps zu erstellen siehe %(gramps_wiki_build_osmgps_url)s"
 
-#: ../gramps/plugins/view/geography.gpr.py:80
+#: ../gramps/plugins/view/geography.gpr.py:86
 msgid "All known places for one Person"
 msgstr "Alle bekannten Orte für eine Person"
 
-#: ../gramps/plugins/view/geography.gpr.py:81
+#: ../gramps/plugins/view/geography.gpr.py:87
 msgid "A view showing the places visited by one person during his life."
 msgstr ""
 "Eine Ansicht die alle Orte zeigt, die von einer Person während ihres "
 "gesamten Lebens besucht wurden."
 
-#: ../gramps/plugins/view/geography.gpr.py:89
-#: ../gramps/plugins/view/geography.gpr.py:106
-#: ../gramps/plugins/view/geography.gpr.py:127
-#: ../gramps/plugins/view/geography.gpr.py:145
-#: ../gramps/plugins/view/geography.gpr.py:163
-#: ../gramps/plugins/view/geography.gpr.py:179
-#: ../gramps/plugins/view/geography.gpr.py:196
+#: ../gramps/plugins/view/geography.gpr.py:95
+#: ../gramps/plugins/view/geography.gpr.py:112
+#: ../gramps/plugins/view/geography.gpr.py:133
+#: ../gramps/plugins/view/geography.gpr.py:151
+#: ../gramps/plugins/view/geography.gpr.py:169
+#: ../gramps/plugins/view/geography.gpr.py:185
+#: ../gramps/plugins/view/geography.gpr.py:202
 msgid "Geography"
 msgstr "Geografie"
 
-#: ../gramps/plugins/view/geography.gpr.py:97
+#: ../gramps/plugins/view/geography.gpr.py:103
 msgid "All known places for one Family"
 msgstr "Alle bekannten Orte für eine Familie"
 
-#: ../gramps/plugins/view/geography.gpr.py:98
+#: ../gramps/plugins/view/geography.gpr.py:104
 msgid "A view showing the places visited by one family during all their life."
 msgstr ""
 "Eine Ansicht die alle Orte zeigt, die von einer Familie während ihres "
 "gesamten Lebens besucht wurden."
 
-#: ../gramps/plugins/view/geography.gpr.py:114
+#: ../gramps/plugins/view/geography.gpr.py:120
 msgid "Every residence or move for a person and any descendants"
 msgstr "Jeder Wohnort oder Umzug einer Person und ihrer Nachkommen"
 
-#: ../gramps/plugins/view/geography.gpr.py:116
+#: ../gramps/plugins/view/geography.gpr.py:122
 msgid ""
 "A view showing all the places visited by all persons during their life.\n"
 "This is for a person and any descendant.\n"
@@ -33906,7 +34276,7 @@ msgstr ""
 "Dies ist für eine Person und ihre Nachkommen.\n"
 "Du kannst die Daten zu dem entsprechenden Zeitraum sehen."
 
-#: ../gramps/plugins/view/geography.gpr.py:136
+#: ../gramps/plugins/view/geography.gpr.py:142
 msgid ""
 "A view showing the places visited by all family's members during their life: "
 "have these two people been able to meet?"
@@ -33915,7 +34285,7 @@ msgstr ""
 "ihres jeweiligen Lebens besucht wurden: war es diesen zwei Personen möglich, "
 "sich zu treffen?"
 
-#: ../gramps/plugins/view/geography.gpr.py:154
+#: ../gramps/plugins/view/geography.gpr.py:160
 msgid ""
 "A view showing the places visited by two persons during their life: have "
 "these two people been able to meet?"
@@ -33924,19 +34294,19 @@ msgstr ""
 "jeweiligen Lebens besucht wurden: war es diesen zwei Personen möglich, sich "
 "zu treffen?"
 
-#: ../gramps/plugins/view/geography.gpr.py:171
+#: ../gramps/plugins/view/geography.gpr.py:177
 msgid "All known Places"
 msgstr "Alle bekannten Orte"
 
-#: ../gramps/plugins/view/geography.gpr.py:172
+#: ../gramps/plugins/view/geography.gpr.py:178
 msgid "A view showing all places of the database."
 msgstr "Eine Ansicht, die alle Orte einer Datenbank zeigt."
 
-#: ../gramps/plugins/view/geography.gpr.py:187
+#: ../gramps/plugins/view/geography.gpr.py:193
 msgid "All places related to Events"
 msgstr "Alle Orte, die mit Ereignissen verbunden sind."
 
-#: ../gramps/plugins/view/geography.gpr.py:188
+#: ../gramps/plugins/view/geography.gpr.py:194
 msgid "A view showing all the event places of the database."
 msgstr "Eine Ansicht, die alle Ereignisorte einer Datenbank zeigt."
 
@@ -34010,52 +34380,71 @@ msgstr ""
 msgid "The animation parameters"
 msgstr "Die Animationsparameter"
 
-#: ../gramps/plugins/view/geoplaces.py:116
+#: ../gramps/plugins/view/geoplaces.py:157
 msgid "Places map"
 msgstr "Ortekarte"
 
-#: ../gramps/plugins/view/geoplaces.py:143
+#: ../gramps/plugins/view/geoplaces.py:185
 msgid "GeoPlaces"
 msgstr "GeoOrte"
 
-#: ../gramps/plugins/view/geoplaces.py:274
-#: ../gramps/plugins/view/geoplaces.py:285
+#: ../gramps/plugins/view/geoplaces.py:345
+#: ../gramps/plugins/view/geoplaces.py:357
 msgid "Selecting all places"
 msgstr "Alle Orte wählen"
 
-#: ../gramps/plugins/view/geoplaces.py:311
+#: ../gramps/plugins/view/geoplaces.py:367
+msgid ""
+"Right click on the map and select 'show all places' to show all known places "
+"with coordinates. You can change the markers color depending on place type. "
+"You can use filtering."
+msgstr ""
+
+#: ../gramps/plugins/view/geoplaces.py:380
+msgid ""
+"Right click on the map and select 'show all places' to show all known places "
+"with coordinates. You can use the history to navigate on the map. You can "
+"change the markers color depending on place type. You can use filtering."
+msgstr ""
+
+#: ../gramps/plugins/view/geoplaces.py:395
 msgid "The place name in the status bar is disabled."
 msgstr "Der Ortename in der Statusleiste ist deaktiviert."
 
-#: ../gramps/plugins/view/geoplaces.py:316
+#: ../gramps/plugins/view/geoplaces.py:400
 #, python-format
 msgid "The maximum number of places is reached (%d)."
 msgstr "Maximale Anzahl der Orte (%d) ist erreicht."
 
-#: ../gramps/plugins/view/geoplaces.py:319
+#: ../gramps/plugins/view/geoplaces.py:403
 msgid "Some information are missing."
 msgstr "Einige Informationen fehlen."
 
-#: ../gramps/plugins/view/geoplaces.py:321
+#: ../gramps/plugins/view/geoplaces.py:405
 msgid "Please, use filtering to reduce this number."
 msgstr "Bitte verwende Filter, um die Anzahl zu reduzieren."
 
-#: ../gramps/plugins/view/geoplaces.py:323
+#: ../gramps/plugins/view/geoplaces.py:407
 msgid "You can modify this value in the geography option."
 msgstr "Du kannst diesen Wert in den Geografieoptionen ändern."
 
-#: ../gramps/plugins/view/geoplaces.py:325
+#: ../gramps/plugins/view/geoplaces.py:409
 msgid "In this case, it may take time to show all markers."
 msgstr "In diesem Fall kann es etwas dauern, alle Markierungen anzuzeigen."
 
-#: ../gramps/plugins/view/geoplaces.py:357
-#: ../gramps/plugins/view/geoplaces.py:381
+#: ../gramps/plugins/view/geoplaces.py:441
+#: ../gramps/plugins/view/geoplaces.py:465
 msgid "Bookmark this place"
 msgstr "Ein Lesezeichen für diesen Ort erstellen"
 
-#: ../gramps/plugins/view/geoplaces.py:396
+#: ../gramps/plugins/view/geoplaces.py:480
 msgid "Show all places"
 msgstr "Alle Orte zeigen"
+
+#: ../gramps/plugins/view/geoplaces.py:590
+#, fuzzy
+msgid "The places marker color"
+msgstr "Hat Marker"
 
 #: ../gramps/plugins/view/mediaview.py:113
 msgid "Edit the selected media object"
@@ -34069,23 +34458,23 @@ msgstr "Das ausgewählte Medienobjekt löschen"
 msgid "Merge the selected media objects"
 msgstr "Die ausgewählten Medienobjekte zusammenfassen"
 
-#: ../gramps/plugins/view/mediaview.py:208
+#: ../gramps/plugins/view/mediaview.py:209
 msgid "Media Filter Editor"
 msgstr "Filtereditor für Medienobjekte"
 
-#: ../gramps/plugins/view/mediaview.py:211
+#: ../gramps/plugins/view/mediaview.py:212
 msgid "View in the default viewer"
 msgstr "In voreingestellten Programm anzeigen"
 
-#: ../gramps/plugins/view/mediaview.py:215
+#: ../gramps/plugins/view/mediaview.py:216
 msgid "Open the folder containing the media file"
 msgstr "Öffne den Ordner der die Mediendateien enthält"
 
-#: ../gramps/plugins/view/mediaview.py:349
+#: ../gramps/plugins/view/mediaview.py:350
 msgid "Cannot merge media objects."
 msgstr "Kann Medienobjekt nicht zusammenfassen."
 
-#: ../gramps/plugins/view/mediaview.py:350
+#: ../gramps/plugins/view/mediaview.py:351
 msgid ""
 "Exactly two media objects must be selected to perform a merge. A second "
 "object can be selected by holding down the control key while clicking on the "
@@ -34144,85 +34533,86 @@ msgstr "▭"
 msgid "short for cremated|crem."
 msgstr "⚱"
 
-#: ../gramps/plugins/view/pedigreeview.py:1110
+#: ../gramps/plugins/view/pedigreeview.py:1145
 msgid "Jump to child..."
 msgstr "Springe zu Kind..."
 
-#: ../gramps/plugins/view/pedigreeview.py:1123
+#: ../gramps/plugins/view/pedigreeview.py:1159
 msgid "Jump to father"
 msgstr "Springe zum Vater"
 
-#: ../gramps/plugins/view/pedigreeview.py:1136
+#: ../gramps/plugins/view/pedigreeview.py:1173
 msgid "Jump to mother"
 msgstr "Springe zur Mutter"
 
-#: ../gramps/plugins/view/pedigreeview.py:1496
+#: ../gramps/plugins/view/pedigreeview.py:1531
 msgid "A person was found to be his/her own ancestor."
 msgstr "Es wurde eine Person gefunden, die ihr eigener Vorfahre ist."
 
-#: ../gramps/plugins/view/pedigreeview.py:1539
+#: ../gramps/plugins/view/pedigreeview.py:1575
 msgid "Pre_vious"
 msgstr "_Vorherige"
 
-#: ../gramps/plugins/view/pedigreeview.py:1540
+#: ../gramps/plugins/view/pedigreeview.py:1576
 msgid "_Next"
 msgstr "_Nächste"
 
 #. Mouse scroll direction setting.
-#: ../gramps/plugins/view/pedigreeview.py:1567
+#: ../gramps/plugins/view/pedigreeview.py:1599
 msgid "Mouse scroll direction"
 msgstr "Maus Rollradrichtung"
 
-#: ../gramps/plugins/view/pedigreeview.py:1571
+#: ../gramps/plugins/view/pedigreeview.py:1603
 msgid "Top <-> Bottom"
 msgstr "Oben <-> Unten"
 
-#: ../gramps/plugins/view/pedigreeview.py:1579
+#: ../gramps/plugins/view/pedigreeview.py:1610
 msgid "Left <-> Right"
 msgstr "Links <-> Rechts"
 
-#: ../gramps/plugins/view/pedigreeview.py:1820
-#: ../gramps/plugins/view/relview.py:410
+#: ../gramps/plugins/view/pedigreeview.py:1827
+#: ../gramps/plugins/view/relview.py:420
 msgid "Add New Parents..."
 msgstr "Neue Eltern hinzufügen..."
 
-#: ../gramps/plugins/view/pedigreeview.py:1880
-msgid "Family Menu"
-msgstr "Familienmenü"
-
-#: ../gramps/plugins/view/pedigreeview.py:2012
+#: ../gramps/plugins/view/pedigreeview.py:2022
 msgid "Show images"
 msgstr "Bilder anzeigen"
 
-#: ../gramps/plugins/view/pedigreeview.py:2015
+#: ../gramps/plugins/view/pedigreeview.py:2025
 msgid "Show marriage data"
 msgstr "Heiratsdaten anzeigen"
 
-#: ../gramps/plugins/view/pedigreeview.py:2018
+#: ../gramps/plugins/view/pedigreeview.py:2028
 msgid "Show unknown people"
 msgstr "Zeige unbekannte Personen"
 
-#: ../gramps/plugins/view/pedigreeview.py:2021
+#: ../gramps/plugins/view/pedigreeview.py:2031
+#, fuzzy
+msgid "Show tags"
+msgstr "Bilder anzeigen"
+
+#: ../gramps/plugins/view/pedigreeview.py:2034
 msgid "Tree style"
 msgstr "Baumstil"
 
-#: ../gramps/plugins/view/pedigreeview.py:2023
+#: ../gramps/plugins/view/pedigreeview.py:2036
 msgid "Standard"
 msgstr "Standard"
 
-#: ../gramps/plugins/view/pedigreeview.py:2024
+#: ../gramps/plugins/view/pedigreeview.py:2037
 msgid "Compact"
 msgstr "Kompakt"
 
-#: ../gramps/plugins/view/pedigreeview.py:2025
+#: ../gramps/plugins/view/pedigreeview.py:2038
 msgid "Expanded"
 msgstr "Erweitert"
 
-#: ../gramps/plugins/view/pedigreeview.py:2028
+#: ../gramps/plugins/view/pedigreeview.py:2041
 msgid "Tree direction"
 msgstr "Baumausrichtung"
 
-#: ../gramps/plugins/view/pedigreeview.py:2035
+#: ../gramps/plugins/view/pedigreeview.py:2048
 msgid "Tree size"
 msgstr "Baumgröße"
 
@@ -34250,174 +34640,172 @@ msgstr "Diese komplette Gruppe ausklappen"
 msgid "Collapse this Entire Group"
 msgstr "Diese komplette Gruppe einklappen"
 
-#: ../gramps/plugins/view/relview.py:396
+#: ../gramps/plugins/view/relview.py:406
 msgid "_Reorder"
 msgstr "Neu _ordnen"
 
-#: ../gramps/plugins/view/relview.py:397
+#: ../gramps/plugins/view/relview.py:407
 msgid "Change order of parents and families"
 msgstr "Reihenfolge von Eltern und Familien ändern"
 
-#: ../gramps/plugins/view/relview.py:402
+#: ../gramps/plugins/view/relview.py:412
 msgid "Edit..."
 msgstr "Bearbeiten..."
 
-#: ../gramps/plugins/view/relview.py:403
+#: ../gramps/plugins/view/relview.py:413
 msgid "Edit the active person"
 msgstr "Bearbeitet die aktive Person"
 
-#: ../gramps/plugins/view/relview.py:405 ../gramps/plugins/view/relview.py:407
-#: ../gramps/plugins/view/relview.py:798
+#: ../gramps/plugins/view/relview.py:415 ../gramps/plugins/view/relview.py:417
+#: ../gramps/plugins/view/relview.py:809
 msgid "Add a new family with person as parent"
 msgstr "Eine neue Familie mit aktiver Person als Elternteil hinzufügen"
 
-#: ../gramps/plugins/view/relview.py:406
+#: ../gramps/plugins/view/relview.py:416
 msgid "Add Partner..."
 msgstr "Partner hinzufügen..."
 
-#: ../gramps/plugins/view/relview.py:409 ../gramps/plugins/view/relview.py:411
-#: ../gramps/plugins/view/relview.py:792
+#: ../gramps/plugins/view/relview.py:419 ../gramps/plugins/view/relview.py:421
+#: ../gramps/plugins/view/relview.py:803
 msgid "Add a new set of parents"
 msgstr "Neues Elternpaar hinzufügen"
 
-#: ../gramps/plugins/view/relview.py:413 ../gramps/plugins/view/relview.py:417
-#: ../gramps/plugins/view/relview.py:793
+#: ../gramps/plugins/view/relview.py:423 ../gramps/plugins/view/relview.py:427
+#: ../gramps/plugins/view/relview.py:804
 msgid "Add person as child to an existing family"
 msgstr "Person als Kind zu bestehender Familie hinzufügen"
 
-#: ../gramps/plugins/view/relview.py:416
+#: ../gramps/plugins/view/relview.py:426
 msgid "Add Existing Parents..."
 msgstr "Existierende Eltern hinzufügen..."
 
-#: ../gramps/plugins/view/relview.py:630
+#: ../gramps/plugins/view/relview.py:641
 msgid "Alive"
 msgstr "Lebt"
 
-#: ../gramps/plugins/view/relview.py:697 ../gramps/plugins/view/relview.py:724
+#: ../gramps/plugins/view/relview.py:708 ../gramps/plugins/view/relview.py:735
 #, python-format
 msgid "%(date)s in %(place)s"
 msgstr "%(date)s in %(place)s"
 
-#: ../gramps/plugins/view/relview.py:794
+#: ../gramps/plugins/view/relview.py:805
 msgid "Edit parents"
 msgstr "Eltern bearbeiten"
 
-#: ../gramps/plugins/view/relview.py:795
+#: ../gramps/plugins/view/relview.py:806
 msgid "Reorder parents"
 msgstr "Eltern neu ordnen"
 
-#: ../gramps/plugins/view/relview.py:796
+#: ../gramps/plugins/view/relview.py:807
 msgid "Remove person as child of these parents"
 msgstr "Entferne Person als Kind dieser Eltern"
 
-#: ../gramps/plugins/view/relview.py:802
+#: ../gramps/plugins/view/relview.py:813
 msgid "Remove person as parent in this family"
 msgstr "Entferne Person als Elternteil dieser Familie."
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/view/relview.py:862 ../gramps/plugins/view/relview.py:918
+#: ../gramps/plugins/view/relview.py:873 ../gramps/plugins/view/relview.py:929
 #, python-brace-format
 msgid " ({number_of} sibling)"
 msgid_plural " ({number_of} siblings)"
 msgstr[0] "({number_of} Geschwister)"
 msgstr[1] "({number_of} Geschwister)"
 
-#: ../gramps/plugins/view/relview.py:869 ../gramps/plugins/view/relview.py:925
+#: ../gramps/plugins/view/relview.py:880 ../gramps/plugins/view/relview.py:936
 msgid " (1 brother)"
 msgstr "(1 Bruder)"
 
-#: ../gramps/plugins/view/relview.py:871 ../gramps/plugins/view/relview.py:927
+#: ../gramps/plugins/view/relview.py:882 ../gramps/plugins/view/relview.py:938
 msgid " (1 sister)"
 msgstr "(1 Schwester)"
 
-#: ../gramps/plugins/view/relview.py:873 ../gramps/plugins/view/relview.py:929
+#: ../gramps/plugins/view/relview.py:884 ../gramps/plugins/view/relview.py:940
 msgid " (1 sibling)"
 msgstr "(1 Geschwister)"
 
-#: ../gramps/plugins/view/relview.py:875 ../gramps/plugins/view/relview.py:931
+#: ../gramps/plugins/view/relview.py:886 ../gramps/plugins/view/relview.py:942
 msgid " (only child)"
 msgstr "(Einzelkind)"
 
-#: ../gramps/plugins/view/relview.py:945
-#: ../gramps/plugins/view/relview.py:1442
+#: ../gramps/plugins/view/relview.py:956 ../gramps/plugins/view/relview.py:1452
 msgid "Add new child to family"
 msgstr "Neues Kind zur Familie hinzufügen"
 
-#: ../gramps/plugins/view/relview.py:949
-#: ../gramps/plugins/view/relview.py:1446
+#: ../gramps/plugins/view/relview.py:960 ../gramps/plugins/view/relview.py:1456
 msgid "Add existing child to family"
 msgstr "Bestehendes Kind zur Familie hinzufügen"
 
-#: ../gramps/plugins/view/relview.py:1227
+#: ../gramps/plugins/view/relview.py:1238
 #, python-format
 msgid "%(birthabbrev)s %(birthdate)s, %(deathabbrev)s %(deathdate)s"
 msgstr "%(birthabbrev)s %(birthdate)s, %(deathabbrev)s %(deathdate)s"
 
-#: ../gramps/plugins/view/relview.py:1234
-#: ../gramps/plugins/view/relview.py:1236
+#: ../gramps/plugins/view/relview.py:1245
+#: ../gramps/plugins/view/relview.py:1247
 #, python-format
 msgid "%(event)s %(date)s"
 msgstr "%(event)s %(date)s"
 
-#: ../gramps/plugins/view/relview.py:1297
+#: ../gramps/plugins/view/relview.py:1306
 #, python-format
 msgid "Relationship type: %s"
 msgstr "Beziehungsart: %s"
 
-#: ../gramps/plugins/view/relview.py:1335
+#: ../gramps/plugins/view/relview.py:1344
 #, python-format
 msgid "%(event_type)s: %(date)s in %(place)s"
 msgstr "%(event_type)s: %(date)s, in %(place)s"
 
-#: ../gramps/plugins/view/relview.py:1339
+#: ../gramps/plugins/view/relview.py:1348
 #, python-format
 msgid "%(event_type)s: %(date)s"
 msgstr "%(event_type)s: %(date)s"
 
-#: ../gramps/plugins/view/relview.py:1343
+#: ../gramps/plugins/view/relview.py:1352
 #, python-format
 msgid "%(event_type)s: %(place)s"
 msgstr "%(event_type)s: %(place)s"
 
-#: ../gramps/plugins/view/relview.py:1354
+#: ../gramps/plugins/view/relview.py:1363
 msgid "Broken family detected"
 msgstr "Fehler in Familie entdeckt"
 
-#: ../gramps/plugins/view/relview.py:1355
+#: ../gramps/plugins/view/relview.py:1364
 msgid "Please run the Check and Repair Database tool"
 msgstr "Bitte benutze das Werkzeug \"Datenbank prüfen und reparieren\""
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/view/relview.py:1377
-#: ../gramps/plugins/view/relview.py:1424
+#: ../gramps/plugins/view/relview.py:1387
+#: ../gramps/plugins/view/relview.py:1434
 #, python-brace-format
 msgid " ({number_of} child)"
 msgid_plural " ({number_of} children)"
 msgstr[0] "({number_of} Kind)"
 msgstr[1] "({number_of} Kinder)"
 
-#: ../gramps/plugins/view/relview.py:1381
-#: ../gramps/plugins/view/relview.py:1428
+#: ../gramps/plugins/view/relview.py:1391
+#: ../gramps/plugins/view/relview.py:1438
 msgid " (no children)"
 msgstr " (keine Kinder)"
 
-#: ../gramps/plugins/view/relview.py:1688
+#: ../gramps/plugins/view/relview.py:1698
 msgid "Use shading"
 msgstr "Verwende Schattierung"
 
-#: ../gramps/plugins/view/relview.py:1691
+#: ../gramps/plugins/view/relview.py:1701
 msgid "Display edit buttons"
 msgstr "Bearbeitenschaltflächen anzeigen"
 
-#: ../gramps/plugins/view/relview.py:1693
+#: ../gramps/plugins/view/relview.py:1703
 msgid "View links as website links"
 msgstr "Zeige Verknüpfungen als Weblinks"
 
-#: ../gramps/plugins/view/relview.py:1710
+#: ../gramps/plugins/view/relview.py:1720
 msgid "Show Details"
 msgstr "Details zeigen"
 
-#: ../gramps/plugins/view/relview.py:1713
+#: ../gramps/plugins/view/relview.py:1723
 msgid "Show Siblings"
 msgstr "Geschwister zeigen"
 
@@ -34520,6 +34908,7 @@ msgstr "Die Ansicht zeigt eine Ahnentafel der gewählten Person"
 #: ../gramps/plugins/view/view.gpr.py:133
 #: ../gramps/plugins/view/view.gpr.py:142
 #: ../gramps/plugins/view/view.gpr.py:157
+#: ../gramps/plugins/view/view.gpr.py:172
 msgid "Charts"
 msgstr "Schaubilder"
 
@@ -34531,105 +34920,96 @@ msgstr "Die Ansicht zeigt die Eltern in einer Fächergrafik"
 msgid "Showing descendants through a fanchart"
 msgstr "Zeigt Nachkommen in einer Fächergrafik"
 
-#: ../gramps/plugins/view/view.gpr.py:171
+#: ../gramps/plugins/view/view.gpr.py:173
+#, fuzzy
+msgid "Showing ascendants and descendants through a fanchart"
+msgstr "Zeigt Nachkommen in einer Fächergrafik"
+
+#: ../gramps/plugins/view/view.gpr.py:186
 msgid "Grouped People"
 msgstr "Gruppierte Personen "
 
-#: ../gramps/plugins/view/view.gpr.py:172
+#: ../gramps/plugins/view/view.gpr.py:187
 msgid "The view showing all people in the Family Tree grouped per family name"
 msgstr "Die Ansicht zeigt alle Personen im Stammbaum nach Nachnamen gruppiert"
 
-#: ../gramps/plugins/view/view.gpr.py:189
+#: ../gramps/plugins/view/view.gpr.py:204
 msgid "The view showing all people in the Family Tree in a flat list"
 msgstr "Die Ansicht zeigt alle Personen im Stammbaum in einer flachen Liste"
 
-#: ../gramps/plugins/view/view.gpr.py:205
+#: ../gramps/plugins/view/view.gpr.py:220
 msgid "The view showing all the places of the Family Tree"
 msgstr "Die Ansicht zeigt alle Orte des Stammbaums"
 
-#: ../gramps/plugins/view/view.gpr.py:219
+#: ../gramps/plugins/view/view.gpr.py:234
 msgid "Place Tree"
 msgstr "Ortsbaum"
 
-#: ../gramps/plugins/view/view.gpr.py:220
+#: ../gramps/plugins/view/view.gpr.py:235
 msgid "A view displaying places in a tree format."
 msgstr "Eine Ansicht, die Orte in einem Baumformat anzeigt."
 
-#: ../gramps/plugins/view/view.gpr.py:236
+#: ../gramps/plugins/view/view.gpr.py:251
 msgid "The view showing all the repositories"
 msgstr "Die Ansicht zeigt alle Aufbewahrungsorte"
 
-#: ../gramps/plugins/view/view.gpr.py:251
+#: ../gramps/plugins/view/view.gpr.py:266
 msgid "The view showing all the sources"
 msgstr "Die Ansicht zeigt alle Quellen"
 
-#: ../gramps/plugins/view/view.gpr.py:267
+#: ../gramps/plugins/view/view.gpr.py:282
 msgid "The view showing all the citations"
 msgstr "Die Ansicht zeigt alle Fundstellen"
 
-#: ../gramps/plugins/view/view.gpr.py:281
+#: ../gramps/plugins/view/view.gpr.py:296
 msgid "Citation Tree"
 msgstr "Fundstellenbaum"
 
-#: ../gramps/plugins/view/view.gpr.py:282
+#: ../gramps/plugins/view/view.gpr.py:297
 msgid "A view displaying citations and sources in a tree format."
 msgstr "Eine Ansicht, die Fundstellen und Quellen in einem Baumformat anzeigt."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:374
-msgid "Gramps&nbsp;ID"
-msgstr "Gramps&nbsp;ID"
-
-#: ../gramps/plugins/webreport/narrativeweb.py:380
-msgid "Church Parish"
-msgstr "Kirchengemeinde"
-
-#: ../gramps/plugins/webreport/narrativeweb.py:385
-msgid "Postal Code"
-msgstr "Postleitzahl"
-
-#: ../gramps/plugins/webreport/narrativeweb.py:388
-msgid "State/ Province"
-msgstr "Bundesland/ Provinz"
-
-#: ../gramps/plugins/webreport/narrativeweb.py:393
-msgid "Alternate Locations"
-msgstr "Alternative Ortsangaben"
-
-#: ../gramps/plugins/webreport/narrativeweb.py:394
-msgid "Locations"
-msgstr "Lagen"
-
-#: ../gramps/plugins/webreport/narrativeweb.py:396
-msgid "<absent>"
-msgstr "<fehlt>"
-
 #. add section title
-#: ../gramps/plugins/webreport/narrativeweb.py:789
-#: ../gramps/plugins/webreport/narrativeweb.py:2439
+#: ../gramps/plugins/webreport/narrativeweb.py:741
+#: ../gramps/plugins/webreport/narrativeweb.py:2425
 msgid "Narrative"
 msgstr "Erzählend"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1102
+#: ../gramps/plugins/webreport/narrativeweb.py:1056
 #, python-format
 msgid "%(type)s: %(value)s"
 msgstr "%(type)s: %(value)s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1713
+#: ../gramps/plugins/webreport/narrativeweb.py:1478
+#: ../gramps/plugins/webreport/narrativeweb.py:2939
+#: ../gramps/plugins/webreport/narrativeweb.py:2965
+#: ../gramps/plugins/webreport/narrativeweb.py:3824
+msgid "State/ Province"
+msgstr "Bundesland/ Provinz"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1480
+#: ../gramps/plugins/webreport/narrativeweb.py:2940
+#: ../gramps/plugins/webreport/narrativeweb.py:2966
+msgid "Postal Code"
+msgstr "Postleitzahl"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1675
 #, python-format
 msgid "Generated by %(gramps_home_html_start)sGramps%(html_end)s %(version)s"
 msgstr "Erstellt mit %(gramps_home_html_start)sGramps%(html_end)s %(version)s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1723
+#: ../gramps/plugins/webreport/narrativeweb.py:1685
 #, python-format
 msgid "Last change was the %(date)s"
 msgstr "Letzte Änderung war %(date)s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1725
+#: ../gramps/plugins/webreport/narrativeweb.py:1688
 #, python-format
 msgid " on %(date)s"
 msgstr " am %(date)s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1740
+#: ../gramps/plugins/webreport/narrativeweb.py:1709
+#: ../gramps/plugins/webreport/narrativeweb.py:1714
 #, python-format
 msgid "%(http_break)sCreated for %(subject_url)s"
 msgstr "%(http_break)sErstellt für %(subject_url)s"
@@ -34638,79 +35018,108 @@ msgstr "%(http_break)sErstellt für %(subject_url)s"
 #. is the style sheet either Basic-Blue or Visually Impaired,
 #. and menu layout is Drop Down?
 #. Basic Blue style sheet with navigation menus
-#: ../gramps/plugins/webreport/narrativeweb.py:1855
-#: ../gramps/plugins/webstuff/webstuff.py:63
+#: ../gramps/plugins/webreport/narrativeweb.py:1829
+#: ../gramps/plugins/webstuff/webstuff.py:64
 msgid "Basic-Blue"
 msgstr "Einfach - Blau"
 
 #. Visually Impaired style sheet with its navigation menus
-#: ../gramps/plugins/webreport/narrativeweb.py:1856
-#: ../gramps/plugins/webstuff/webstuff.py:95
+#: ../gramps/plugins/webreport/narrativeweb.py:1830
+#: ../gramps/plugins/webstuff/webstuff.py:96
 msgid "Visually Impaired"
 msgstr "Sehbehindert"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1895
-#: ../gramps/plugins/webreport/narrativeweb.py:2061
+#: ../gramps/plugins/webreport/narrativeweb.py:1869
+#: ../gramps/plugins/webreport/narrativeweb.py:2047
 msgid "Html|Home"
 msgstr "Startseite"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1905
-#: ../gramps/plugins/webreport/narrativeweb.py:2030
-#: ../gramps/plugins/webreport/narrativeweb.py:5576
+#: ../gramps/plugins/webreport/narrativeweb.py:1881
+#: ../gramps/plugins/webreport/narrativeweb.py:2016
+#: ../gramps/plugins/webreport/narrativeweb.py:5633
 msgid "Thumbnails"
 msgstr "Miniaturbilder"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1906
-#: ../gramps/plugins/webreport/narrativeweb.py:2037
-#: ../gramps/plugins/webreport/narrativeweb.py:5773
-#: ../gramps/plugins/webreport/narrativeweb.py:9550
+#: ../gramps/plugins/webreport/narrativeweb.py:1882
+#: ../gramps/plugins/webreport/narrativeweb.py:2023
+#: ../gramps/plugins/webreport/narrativeweb.py:5830
+#: ../gramps/plugins/webreport/narrativeweb.py:9844
 msgid "Download"
 msgstr "Download"
 
 #. Add xml, doctype, meta and stylesheets
-#: ../gramps/plugins/webreport/narrativeweb.py:1907
-#: ../gramps/plugins/webreport/narrativeweb.py:1971
-#: ../gramps/plugins/webreport/narrativeweb.py:2038
-#: ../gramps/plugins/webreport/narrativeweb.py:7824
-#: ../gramps/plugins/webreport/narrativeweb.py:7938
+#: ../gramps/plugins/webreport/narrativeweb.py:1883
+#: ../gramps/plugins/webreport/narrativeweb.py:1949
+#: ../gramps/plugins/webreport/narrativeweb.py:2024
+#: ../gramps/plugins/webreport/narrativeweb.py:7895
+#: ../gramps/plugins/webreport/narrativeweb.py:8009
 msgid "Address Book"
 msgstr "Adressbuch"
 
 #. add contact column
-#: ../gramps/plugins/webreport/narrativeweb.py:1908
-#: ../gramps/plugins/webreport/narrativeweb.py:2045
-#: ../gramps/plugins/webreport/narrativeweb.py:2082
-#: ../gramps/plugins/webreport/narrativeweb.py:5890
+#: ../gramps/plugins/webreport/narrativeweb.py:1885
+#: ../gramps/plugins/webreport/narrativeweb.py:2031
+#: ../gramps/plugins/webreport/narrativeweb.py:2068
+#: ../gramps/plugins/webreport/narrativeweb.py:5946
 msgid "Contact"
 msgstr "Kontakt"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1909
+#: ../gramps/plugins/webreport/narrativeweb.py:1887
 #: ../gramps/plugins/webreport/webplugins.gpr.py:55
 msgid "Web Calendar"
 msgstr "Webkalender"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2458
-#: ../gramps/plugins/webreport/narrativeweb.py:7857
+#: ../gramps/plugins/webreport/narrativeweb.py:1967
+#: ../gramps/plugins/webreport/narrativeweb.py:5301
+msgid "Previous"
+msgstr "Zurück"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1969
+#: ../gramps/plugins/webreport/narrativeweb.py:5313
+msgid "Next"
+msgstr "Vor"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:2444
+#: ../gramps/plugins/webreport/narrativeweb.py:7928
 msgid "Web Links"
 msgstr "Weblinks"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2507
+#: ../gramps/plugins/webreport/narrativeweb.py:2493
 msgid " [Click to Go]"
 msgstr " [Zum Gehen klicken]"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2531
+#: ../gramps/plugins/webreport/narrativeweb.py:2517
 msgid "Latter-Day Saints/ LDS Ordinance"
 msgstr "Heilige der letzten Tage/ HLT Ordination"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2716
-#: ../gramps/plugins/webreport/narrativeweb.py:2717
-#: ../gramps/plugins/webreport/narrativeweb.py:6461
-#: ../gramps/plugins/webreport/narrativeweb.py:6749
+#: ../gramps/plugins/webreport/narrativeweb.py:2704
+#: ../gramps/plugins/webreport/narrativeweb.py:2705
+#: ../gramps/plugins/webreport/narrativeweb.py:6526
+#: ../gramps/plugins/webreport/narrativeweb.py:6829
 msgid "Family Map"
 msgstr "Familienkarte"
 
+#: ../gramps/plugins/webreport/narrativeweb.py:2937
+#: ../gramps/plugins/webreport/narrativeweb.py:2963
+msgid "Church Parish"
+msgstr "Kirchengemeinde"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:2953
+msgid "Alternate Locations"
+msgstr "Alternative Ortsangaben"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:2984
+msgid "Locations"
+msgstr "Lagen"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:3215
+#: ../gramps/plugins/webreport/narrativeweb.py:4592
+#: ../gramps/plugins/webreport/narrativeweb.py:6160
+msgid "<absent>"
+msgstr "<fehlt>"
+
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/webreport/narrativeweb.py:3237
+#: ../gramps/plugins/webreport/narrativeweb.py:3231
 #, python-format
 msgid ""
 "This page contains an index of all the individuals in the database with the "
@@ -34722,34 +35131,35 @@ msgstr ""
 "gelangst du zur Seite der Person."
 
 #. Name Column
-#: ../gramps/plugins/webreport/narrativeweb.py:3254
-#: ../gramps/plugins/webreport/narrativeweb.py:6069
+#: ../gramps/plugins/webreport/narrativeweb.py:3248
+#: ../gramps/plugins/webreport/narrativeweb.py:6126
 msgid "Given Name"
 msgstr "Vorname"
 
 #. set progress bar pass for Repositories
-#: ../gramps/plugins/webreport/narrativeweb.py:3425
-#: ../gramps/plugins/webreport/narrativeweb.py:3755
-#: ../gramps/plugins/webreport/narrativeweb.py:4091
-#: ../gramps/plugins/webreport/narrativeweb.py:4748
-#: ../gramps/plugins/webreport/narrativeweb.py:4990
-#: ../gramps/plugins/webreport/narrativeweb.py:5998
-#: ../gramps/plugins/webreport/narrativeweb.py:7622
-#: ../gramps/plugins/webreport/narrativeweb.py:8316
-#: ../gramps/plugins/webreport/narrativeweb.py:8321
-#: ../gramps/plugins/webreport/narrativeweb.py:8845
-#: ../gramps/plugins/webreport/narrativeweb.py:8898
-#: ../gramps/plugins/webreport/narrativeweb.py:8918
-#: ../gramps/plugins/webreport/narrativeweb.py:8960
+#: ../gramps/plugins/webreport/narrativeweb.py:3429
+#: ../gramps/plugins/webreport/narrativeweb.py:3761
+#: ../gramps/plugins/webreport/narrativeweb.py:4134
+#: ../gramps/plugins/webreport/narrativeweb.py:4799
+#: ../gramps/plugins/webreport/narrativeweb.py:5040
+#: ../gramps/plugins/webreport/narrativeweb.py:6055
+#: ../gramps/plugins/webreport/narrativeweb.py:7690
+#: ../gramps/plugins/webreport/narrativeweb.py:8574
+#: ../gramps/plugins/webreport/narrativeweb.py:8579
+#: ../gramps/plugins/webreport/narrativeweb.py:9110
+#: ../gramps/plugins/webreport/narrativeweb.py:9163
+#: ../gramps/plugins/webreport/narrativeweb.py:9183
+#: ../gramps/plugins/webreport/narrativeweb.py:9192
+#: ../gramps/plugins/webreport/narrativeweb.py:9234
 msgid "Narrated Web Site Report"
 msgstr "Erzählende Website"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:3426
+#: ../gramps/plugins/webreport/narrativeweb.py:3430
 msgid "Creating family pages..."
 msgstr "Erstelle Familienseiten..."
 
 #. Families list page message
-#: ../gramps/plugins/webreport/narrativeweb.py:3457
+#: ../gramps/plugins/webreport/narrativeweb.py:3461
 msgid ""
 "This page contains an index of all the families/ relationships in the "
 "database, sorted by their family name/ surname. Clicking on a person&#8217;s "
@@ -34759,23 +35169,23 @@ msgstr ""
 "sortiert nach dem Familien/Nachnamen. Klicken auf den Namen einer Person "
 "bringt dich zu der Familien/Beziehungsseite."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:3503
-#: ../gramps/plugins/webreport/narrativeweb.py:3816
-#: ../gramps/plugins/webreport/narrativeweb.py:4151
-#: ../gramps/plugins/webreport/narrativeweb.py:4496
+#: ../gramps/plugins/webreport/narrativeweb.py:3507
+#: ../gramps/plugins/webreport/narrativeweb.py:3822
+#: ../gramps/plugins/webreport/narrativeweb.py:4194
+#: ../gramps/plugins/webreport/narrativeweb.py:4542
 msgid "Letter"
 msgstr "Letter"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:3546
+#: ../gramps/plugins/webreport/narrativeweb.py:3551
 msgid "Families beginning with letter "
 msgstr "Familien beginnend mit Buchstaben "
 
-#: ../gramps/plugins/webreport/narrativeweb.py:3756
+#: ../gramps/plugins/webreport/narrativeweb.py:3762
 msgid "Creating place pages"
 msgstr "Erstelle Ortsseiten"
 
 #. place list page message
-#: ../gramps/plugins/webreport/narrativeweb.py:3788
+#: ../gramps/plugins/webreport/narrativeweb.py:3794
 msgid ""
 "This page contains an index of all the places in the database, sorted by "
 "their title. Clicking on a place&#8217;s title will take you to that "
@@ -34785,25 +35195,25 @@ msgstr ""
 "ihrem Titel sortiert sind. Wenn du auf den Ortstitel klickst, gelangst du "
 "zur Seite des Ortes."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:3817
+#: ../gramps/plugins/webreport/narrativeweb.py:3823
 msgid "Place Name | Name"
 msgstr "Ortsname"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:3861
+#: ../gramps/plugins/webreport/narrativeweb.py:3871
 #, python-format
 msgid "Places beginning with letter %s"
 msgstr "Orte mit dem Buchstaben %s"
 
 #. section title
-#: ../gramps/plugins/webreport/narrativeweb.py:4000
+#: ../gramps/plugins/webreport/narrativeweb.py:4030
 msgid "Place Map"
 msgstr "Ortskarte"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:4092
+#: ../gramps/plugins/webreport/narrativeweb.py:4135
 msgid "Creating event pages"
 msgstr "Erstelle Ereignisseiten"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:4124
+#: ../gramps/plugins/webreport/narrativeweb.py:4167
 msgid ""
 "This page contains an index of all the events in the database, sorted by "
 "their type and date (if one is present). Clicking on an event&#8217;s Gramps "
@@ -34813,17 +35223,17 @@ msgstr ""
 "nach ihrem Typ, Datum (wenn vorhanden) sortiert sind. Klicken auf eine "
 "Grampsereignis ID öffnet eine Seite für dieses Ereignis."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:4219
+#: ../gramps/plugins/webreport/narrativeweb.py:4264
 #, python-format
 msgid "Event types beginning with letter %s"
 msgstr "Ereignisarten beginnend mit Buchstaben %s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:4458
+#: ../gramps/plugins/webreport/narrativeweb.py:4504
 msgid "Surnames by person count"
 msgstr "Nachnamen nach Anzahl der Personen"
 
 #. page message
-#: ../gramps/plugins/webreport/narrativeweb.py:4465
+#: ../gramps/plugins/webreport/narrativeweb.py:4511
 msgid ""
 "This page contains an index of all the surnames in the database. Selecting a "
 "link will lead to a list of individuals in the database with this same "
@@ -34832,25 +35242,25 @@ msgstr ""
 "Diese Seite enthält alle Nachnamen in der Datenbank. Die Links führen zu "
 "einer Liste der Personen in der Datenbank mit diesem Nachnamen."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:4510
+#: ../gramps/plugins/webreport/narrativeweb.py:4557
 msgid "Number of People"
 msgstr "Personenzahl"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:4555
+#: ../gramps/plugins/webreport/narrativeweb.py:4605
 #, python-format
 msgid "Surnames beginning with letter %s"
 msgstr "Nachnamen beginnend mit Buchstaben %s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:4660
-#: ../gramps/plugins/webreport/webcal.py:561
+#: ../gramps/plugins/webreport/narrativeweb.py:4711
+#: ../gramps/plugins/webreport/webcal.py:568
 msgid "Home"
 msgstr "Anfang"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:4749
+#: ../gramps/plugins/webreport/narrativeweb.py:4800
 msgid "Creating source pages"
 msgstr "Erstelle Ereignisseiten"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:4791
+#: ../gramps/plugins/webreport/narrativeweb.py:4842
 msgid ""
 "This page contains an index of all the sources in the database, sorted by "
 "their title. Clicking on a source&#8217;s title will take you to that "
@@ -34860,19 +35270,19 @@ msgstr ""
 "Titel sortiert sind. Durch Klicken auf den Titel der Quelle gelangst du zur "
 "Seite der Quelle."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:4810
+#: ../gramps/plugins/webreport/narrativeweb.py:4861
 msgid "Source Name|Name"
 msgstr "Name"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:4908
+#: ../gramps/plugins/webreport/narrativeweb.py:4959
 msgid "Publication information"
 msgstr "Informationen zur Veröffentlichung"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:4991
+#: ../gramps/plugins/webreport/narrativeweb.py:5041
 msgid "Creating media pages"
 msgstr "Erstelle Medienseiten"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:5039
+#: ../gramps/plugins/webreport/narrativeweb.py:5089
 msgid ""
 "This page contains an index of all the media objects in the database, sorted "
 "by their title. Clicking on the title will take you to that media "
@@ -34884,23 +35294,19 @@ msgstr ""
 "Seite des Medienobjektes. Wenn Mediengrößen über einem Bild siehst, klick "
 "auf das Bild um es in Originalgröße zu sehen.  "
 
-#: ../gramps/plugins/webreport/narrativeweb.py:5064
+#: ../gramps/plugins/webreport/narrativeweb.py:5114
 msgid "Media | Name"
 msgstr "Name"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:5066
+#: ../gramps/plugins/webreport/narrativeweb.py:5116
 msgid "Mime Type"
 msgstr "Mimetyp"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:5130
+#: ../gramps/plugins/webreport/narrativeweb.py:5180
 msgid "Below unused media objects"
 msgstr "Unten unbenutzte Medienobjekte"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:5247
-msgid "Previous"
-msgstr "Zurück"
-
-#: ../gramps/plugins/webreport/narrativeweb.py:5248
+#: ../gramps/plugins/webreport/narrativeweb.py:5302
 #, python-format
 msgid ""
 "%(strong1_start)s%(page_number)d%(strong_end)s of %(strong2_start)s"
@@ -34909,24 +35315,20 @@ msgstr ""
 "%(strong1_start)s%(page_number)d%(strong_end)s von %(strong2_start)s"
 "%(total_pages)d%(strong_end)s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:5259
-msgid "Next"
-msgstr "Vor"
-
 #. missing media error message
-#: ../gramps/plugins/webreport/narrativeweb.py:5262
+#: ../gramps/plugins/webreport/narrativeweb.py:5316
 msgid "The file has been moved or deleted."
 msgstr "Die Datei wurde verschoben oder gelöscht."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:5417
+#: ../gramps/plugins/webreport/narrativeweb.py:5472
 msgid "File Type"
 msgstr "Dateityp"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:5518
+#: ../gramps/plugins/webreport/narrativeweb.py:5575
 msgid "Missing media object:"
 msgstr "Fehlendes Medienobjekt"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:5581
+#: ../gramps/plugins/webreport/narrativeweb.py:5638
 msgid ""
 "This page displays a indexed list of all the media objects in this "
 "database.  It is sorted by media title.  There is an index of all the media "
@@ -34937,11 +35339,11 @@ msgstr ""
 "Datenbank. Sie ist nach dem Medientitel sortiert. Klicken auf ein "
 "Vorschaubild bringt dich auf die Seite des Bildes."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:5600
+#: ../gramps/plugins/webreport/narrativeweb.py:5657
 msgid "Thumbnail Preview"
 msgstr "Miniaturbild Vorschau"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:5779
+#: ../gramps/plugins/webreport/narrativeweb.py:5836
 msgid ""
 "This page is for the user/ creator of this Family Tree/ Narrative website to "
 "share a couple of files with you regarding their family.  If there are any "
@@ -34955,20 +35357,20 @@ msgstr ""
 "anklicken herunterladen. Die Downloadseite und Dateien unterliegen dem "
 "selben Copyright, wie der Rest der Webseite."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:5805
+#: ../gramps/plugins/webreport/narrativeweb.py:5862
 msgid "File Name"
 msgstr "Dateiname"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:5807
+#: ../gramps/plugins/webreport/narrativeweb.py:5864
 msgid "Last Modified"
 msgstr "Zuletzt geändert"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:5999
+#: ../gramps/plugins/webreport/narrativeweb.py:6056
 msgid "Creating individual pages"
 msgstr "Erstelle Personenseiten"
 
 #. Individual List page message
-#: ../gramps/plugins/webreport/narrativeweb.py:6042
+#: ../gramps/plugins/webreport/narrativeweb.py:6099
 msgid ""
 "This page contains an index of all the individuals in the database, sorted "
 "by their last names. Selecting the person&#8217;s name will take you to that "
@@ -34978,18 +35380,18 @@ msgstr ""
 "Nachnamen sortiert sind . Das Auswählen des Personennamens wird dich zur "
 "eigenen Seite der Person bringen."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:6122
+#: ../gramps/plugins/webreport/narrativeweb.py:6184
 #, python-format
 msgid "Surnames %(surname)s beginning with letter %(letter)s"
 msgstr "Nachnamen %(surname)s beginnend mit Buchstaben %(letter)s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:6600
+#: ../gramps/plugins/webreport/narrativeweb.py:6681
 #, python-format
 msgid "Tracking %s"
 msgstr "Verfolge %s"
 
 #. page description
-#: ../gramps/plugins/webreport/narrativeweb.py:6604
+#: ../gramps/plugins/webreport/narrativeweb.py:6685
 msgid ""
 "This map page represents that person and any descendants with all of their "
 "event/ places. If you place your mouse over the marker it will display the "
@@ -35003,23 +35405,23 @@ msgstr ""
 "nach Datum sortiert (wenn vorhanden). Klicken auf einen Ort im "
 "Referenzbereich bringt dich auf die Ortsseite."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:6680
+#: ../gramps/plugins/webreport/narrativeweb.py:6756
 msgid "Drop Markers"
 msgstr "Markierungen auslassen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:6701
+#: ../gramps/plugins/webreport/narrativeweb.py:6781
 msgid "Place Title"
 msgstr "Ortstitel"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:7183
+#: ../gramps/plugins/webreport/narrativeweb.py:7264
 msgid "Call Name"
 msgstr "Rufname"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:7201
+#: ../gramps/plugins/webreport/narrativeweb.py:7282
 msgid "Nick Name"
 msgstr "Spitzname"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:7244
+#: ../gramps/plugins/webreport/narrativeweb.py:7328
 msgid "Age at Death"
 msgstr "Alter beim Tod"
 
@@ -35027,35 +35429,35 @@ msgstr "Alter beim Tod"
 #. actually be StepFather-in-law), but it is too expensive to
 #. calculate out the correct relationship using the Relationship
 #. Calculator
-#: ../gramps/plugins/webreport/narrativeweb.py:7359
+#: ../gramps/plugins/webreport/narrativeweb.py:7443
 msgid "Stepfather"
 msgstr "Stiefvater"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:7369
+#: ../gramps/plugins/webreport/narrativeweb.py:7453
 msgid "Stepmother"
 msgstr "Stiefmutter"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:7392
+#: ../gramps/plugins/webreport/narrativeweb.py:7479
 msgid "Not siblings"
 msgstr "Keine Geschwister"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:7454
+#: ../gramps/plugins/webreport/narrativeweb.py:7541
 msgid "Relation to the center person"
 msgstr "Beziehung zur Hauptperson"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:7491
+#: ../gramps/plugins/webreport/narrativeweb.py:7578
 msgid "Relation to main person"
 msgstr "Beziehung zur Hauptperson"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:7493
+#: ../gramps/plugins/webreport/narrativeweb.py:7580
 msgid "Relation within this family (if not by birth)"
 msgstr "Beziehung innerhalb dieser Familie (wenn nicht durch Geburt)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:7623
+#: ../gramps/plugins/webreport/narrativeweb.py:7691
 msgid "Creating repository pages"
 msgstr "Erstelle Aufbewahrungsorteseiten"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:7666
+#: ../gramps/plugins/webreport/narrativeweb.py:7734
 msgid ""
 "This page contains an index of all the repositories in the database, sorted "
 "by their title. Clicking on a repositories&#8217;s title will take you to "
@@ -35065,12 +35467,12 @@ msgstr ""
 "die nach Titel sortiert sind. Durch Klicken auf den Titel des "
 "Aufbewahrungsort gelangst du zur Seite des Aufbewahrungsort."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:7683
+#: ../gramps/plugins/webreport/narrativeweb.py:7752
 msgid "Repository |Name"
 msgstr "Name"
 
 #. Address Book Page message
-#: ../gramps/plugins/webreport/narrativeweb.py:7832
+#: ../gramps/plugins/webreport/narrativeweb.py:7903
 msgid ""
 "This page contains an index of all the individuals in the database, sorted "
 "by their surname, with one of the following: Address, Residence, or Web "
@@ -35082,239 +35484,261 @@ msgstr ""
 "oder Weblink . Das Auswählen des Personennamens wird dich zu der "
 "Adressbuchseite der Person bringen."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:7854
+#: ../gramps/plugins/webreport/narrativeweb.py:7925
 msgid "Full Name"
 msgstr "Kompletter Name"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:8111
+#: ../gramps/plugins/webreport/narrativeweb.py:8089
+#, fuzzy
+msgid "Database overview"
+msgstr "Datenbank geöffnet"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:8155
+#, fuzzy
+msgid "Narrative web content report for"
+msgstr "Erzählende Website"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:8365
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
 msgstr "Weder %(current)s noch %(parent)s ist ein Verzeichnis"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:8120
-#: ../gramps/plugins/webreport/narrativeweb.py:8125
-#: ../gramps/plugins/webreport/narrativeweb.py:8138
-#: ../gramps/plugins/webreport/narrativeweb.py:8143
+#: ../gramps/plugins/webreport/narrativeweb.py:8374
+#: ../gramps/plugins/webreport/narrativeweb.py:8379
+#: ../gramps/plugins/webreport/narrativeweb.py:8392
+#: ../gramps/plugins/webreport/narrativeweb.py:8397
 #, python-format
 msgid "Could not create the directory: %s"
 msgstr "Kann Verzeichnis nicht erstellen: %s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:8150
+#: ../gramps/plugins/webreport/narrativeweb.py:8404
 msgid "Invalid file name"
 msgstr "Ungültiger Dateiname"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:8151
+#: ../gramps/plugins/webreport/narrativeweb.py:8405
 msgid "The archive file must be a file, not a directory"
 msgstr "Das Archiv muss eine Datei sein, kein Verzeichnis"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:8282
+#: ../gramps/plugins/webreport/narrativeweb.py:8540
 #, python-format
 msgid "ID=%(grampsid)s, path=%(dir)s"
 msgstr "ID=%(grampsid)s, Pfad=%(dir)s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:8287
+#: ../gramps/plugins/webreport/narrativeweb.py:8545
 msgid "Missing media objects:"
 msgstr "Fehlende Medienobjekte:"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:8317
+#: ../gramps/plugins/webreport/narrativeweb.py:8575
 msgid "Applying Person Filter..."
 msgstr "Wende Personenfilter an..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:8322
+#: ../gramps/plugins/webreport/narrativeweb.py:8580
 msgid "Constructing list of other objects..."
 msgstr "Erstelle Liste der anderen Objekte..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:8561
+#: ../gramps/plugins/webreport/narrativeweb.py:8819
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr "Familie von %(husband)s und %(spouse)s"
 
 #. Only the name of the husband is known
 #. Only the name of the wife is known
-#: ../gramps/plugins/webreport/narrativeweb.py:8567
-#: ../gramps/plugins/webreport/narrativeweb.py:8571
+#: ../gramps/plugins/webreport/narrativeweb.py:8825
+#: ../gramps/plugins/webreport/narrativeweb.py:8829
 #, python-format
 msgid "Family of %s"
 msgstr "Familie von %s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:8846
+#: ../gramps/plugins/webreport/narrativeweb.py:9111
 msgid "Creating GENDEX file"
 msgstr "Erstelle GENDEX-Datei"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:8899
+#: ../gramps/plugins/webreport/narrativeweb.py:9164
 msgid "Creating surname pages"
 msgstr "Erstelle Nachnamensseiten"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:8919
+#: ../gramps/plugins/webreport/narrativeweb.py:9184
 msgid "Creating thumbnail preview page..."
 msgstr "Erstelle Miniaturbild Vorschauseite..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:8961
+#: ../gramps/plugins/webreport/narrativeweb.py:9193
+#, fuzzy
+msgid "Creating statistics page..."
+msgstr "Erstelle Familienseiten..."
+
+#: ../gramps/plugins/webreport/narrativeweb.py:9235
 msgid "Creating address book pages ..."
 msgstr "Erstelle Adressbuchseiten ..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9345
+#: ../gramps/plugins/webreport/narrativeweb.py:9624
 msgid "Store web pages in .tar.gz archive"
 msgstr "Webseiten in ein .tar.gz Archiv abspeichern"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9347
+#: ../gramps/plugins/webreport/narrativeweb.py:9626
 msgid "Whether to store the web pages in an archive file"
 msgstr "Legt fest, ob die Webseiten in einer Archivdatei gespeichert werden."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9355
-#: ../gramps/plugins/webreport/webcal.py:1595
-msgid "Destination"
-msgstr "Ziel"
-
-#: ../gramps/plugins/webreport/narrativeweb.py:9358
-#: ../gramps/plugins/webreport/webcal.py:1598
+#: ../gramps/plugins/webreport/narrativeweb.py:9637
+#: ../gramps/plugins/webreport/webcal.py:1616
 msgid "The destination directory for the web files"
 msgstr "Das Zielverzeichnis für die Webdateien"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9364
+#: ../gramps/plugins/webreport/narrativeweb.py:9643
 msgid "My Family Tree"
 msgstr "Mein Stammbaum"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9364
+#: ../gramps/plugins/webreport/narrativeweb.py:9643
 msgid "Web site title"
 msgstr "Webseitentitel"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9365
+#: ../gramps/plugins/webreport/narrativeweb.py:9644
 msgid "The title of the web site"
 msgstr "Der Titel der Website"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9370
+#: ../gramps/plugins/webreport/narrativeweb.py:9649
 msgid "Select filter to restrict people that appear on web site"
 msgstr ""
 "Filter wählen, um Personen zu begrenzen, die auf der Website erscheinen."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9383
-#: ../gramps/plugins/webreport/webcal.py:1641
+#: ../gramps/plugins/webreport/narrativeweb.py:9668
+msgid "Report Options (2)"
+msgstr "Berichtsoptionen (2)"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:9671
+#: ../gramps/plugins/webreport/webcal.py:1659
 msgid "File extension"
 msgstr "Dateierweiterung"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9386
-#: ../gramps/plugins/webreport/webcal.py:1644
+#: ../gramps/plugins/webreport/narrativeweb.py:9674
+#: ../gramps/plugins/webreport/webcal.py:1662
 msgid "The extension to be used for the web files"
 msgstr "Die Erweiterung, die für die Webdateien verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9389
-#: ../gramps/plugins/webreport/webcal.py:1647
+#: ../gramps/plugins/webreport/narrativeweb.py:9677
+#: ../gramps/plugins/webreport/webcal.py:1665
 msgid "Copyright"
 msgstr "Copyright"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9392
-#: ../gramps/plugins/webreport/webcal.py:1650
+#: ../gramps/plugins/webreport/narrativeweb.py:9680
+#: ../gramps/plugins/webreport/webcal.py:1668
 msgid "The copyright to be used for the web files"
 msgstr "Das Copyright, das für die Webdateien verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9395
-#: ../gramps/plugins/webreport/webcal.py:1656
+#: ../gramps/plugins/webreport/narrativeweb.py:9683
+#: ../gramps/plugins/webreport/webcal.py:1674
 msgid "StyleSheet"
 msgstr "Layoutvorlage"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9400
-#: ../gramps/plugins/webreport/webcal.py:1659
+#: ../gramps/plugins/webreport/narrativeweb.py:9688
+#: ../gramps/plugins/webreport/webcal.py:1677
 msgid "The stylesheet to be used for the web pages"
 msgstr "Die Layoutvorlage, für die Webseiten verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9405
+#: ../gramps/plugins/webreport/narrativeweb.py:9693
 msgid "Horizontal -- Default"
 msgstr "Horizontal -- Standard"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9406
+#: ../gramps/plugins/webreport/narrativeweb.py:9694
 msgid "Vertical   -- Left Side"
 msgstr "Vertikal -- Linke Seite"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9407
+#: ../gramps/plugins/webreport/narrativeweb.py:9695
 msgid "Fade       -- WebKit Browsers Only"
 msgstr "Überblenden  -- Nur WebKit Browser"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9408
-#: ../gramps/plugins/webreport/narrativeweb.py:9422
+#: ../gramps/plugins/webreport/narrativeweb.py:9696
+#: ../gramps/plugins/webreport/narrativeweb.py:9710
 msgid "Drop-Down  -- WebKit Browsers Only"
 msgstr "Drop-Down  -- Nur WebKit Browser"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9410
+#: ../gramps/plugins/webreport/narrativeweb.py:9698
 msgid "Navigation Menu Layout"
 msgstr "Navigationsmenülayout"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9414
+#: ../gramps/plugins/webreport/narrativeweb.py:9702
 msgid "Choose which layout for the Navigation Menus."
 msgstr "Wähle das Layout für die Navigationsmenüs."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9421
+#: ../gramps/plugins/webreport/narrativeweb.py:9709
 msgid "Normal Outline Style"
 msgstr "Normaler Umrandungsstil"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9425
+#: ../gramps/plugins/webreport/narrativeweb.py:9713
 msgid "Citation Referents Layout"
 msgstr "Fundstelle Referenzen Layout"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9429
+#: ../gramps/plugins/webreport/narrativeweb.py:9717
 msgid ""
 "Determine the default layout for the Source Page's Citation Referents section"
 msgstr ""
 "Bestimmt das Standardlayout für den Fundstellenreferenzabschnitt der "
 "Quellenseite"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9433
+#: ../gramps/plugins/webreport/narrativeweb.py:9721
 msgid "Include ancestor's tree"
 msgstr "Mit Ahnentafel"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9434
+#: ../gramps/plugins/webreport/narrativeweb.py:9722
 msgid "Whether to include an ancestor graph on each individual page"
 msgstr "Legt fest, ob jede Personenseite eine Ahnentafel enthält."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9439
+#: ../gramps/plugins/webreport/narrativeweb.py:9727
 msgid "Graph generations"
 msgstr "Generationengrafik"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9440
+#: ../gramps/plugins/webreport/narrativeweb.py:9728
 msgid "The number of generations to include in the ancestor graph"
 msgstr "Anzahl der in der Ahnengrafik berücksichtigten Generationen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9450
+#: ../gramps/plugins/webreport/narrativeweb.py:9733
+msgid "Suppress Gramps ID"
+msgstr "Gramps-IDs ausblenden"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:9734
+msgid "Whether to include the Gramps ID of objects"
+msgstr "Legt fest, ob die GRAMPS IDs von Objekten aufgenommen werden."
+
+#: ../gramps/plugins/webreport/narrativeweb.py:9741
 msgid "Page Generation"
 msgstr "Seiten Generation"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9453
+#: ../gramps/plugins/webreport/narrativeweb.py:9744
 msgid "Home page note"
 msgstr "Homepagenotiz"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9454
+#: ../gramps/plugins/webreport/narrativeweb.py:9745
 msgid "A note to be used on the home page"
 msgstr "Eine Notiz, die auf der Homepage verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9457
+#: ../gramps/plugins/webreport/narrativeweb.py:9748
 msgid "Home page image"
 msgstr "Homepagebild"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9458
+#: ../gramps/plugins/webreport/narrativeweb.py:9749
 msgid "An image to be used on the home page"
 msgstr "Ein Bild, das auf der Homepage verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9461
+#: ../gramps/plugins/webreport/narrativeweb.py:9752
 msgid "Introduction note"
 msgstr "Einleitungsnotiz"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9462
+#: ../gramps/plugins/webreport/narrativeweb.py:9753
 msgid "A note to be used as the introduction"
 msgstr "Eine Notiz, die als Einleitung verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9465
+#: ../gramps/plugins/webreport/narrativeweb.py:9756
 msgid "Introduction image"
 msgstr "Einleitungsbild"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9466
+#: ../gramps/plugins/webreport/narrativeweb.py:9757
 msgid "An image to be used as the introduction"
 msgstr "Ein Bild, das als Einleitung verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9469
+#: ../gramps/plugins/webreport/narrativeweb.py:9760
 msgid "Publisher contact note"
 msgstr "Kontakt-Notiz des Herausgebers"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9470
+#: ../gramps/plugins/webreport/narrativeweb.py:9761
 msgid ""
 "A note to be used as the publisher contact.\n"
 "If no publisher information is given,\n"
@@ -35324,11 +35748,11 @@ msgstr ""
 "Wenn keine Herausgeber Informationen angegeben sind,\n"
 "wird keine Kontaktseite erstellt"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9476
+#: ../gramps/plugins/webreport/narrativeweb.py:9767
 msgid "Publisher contact image"
 msgstr "Bild für Kontakt mit dem Herausgeber"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9477
+#: ../gramps/plugins/webreport/narrativeweb.py:9768
 msgid ""
 "An image to be used as the publisher contact.\n"
 "If no publisher information is given,\n"
@@ -35338,43 +35762,48 @@ msgstr ""
 "Wenn keine Herausgeber Informationen angegeben sind,\n"
 "wird keine Kontaktseite erstellt"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9483
+#: ../gramps/plugins/webreport/narrativeweb.py:9774
 msgid "HTML user header"
 msgstr "HTML Kopfzeile"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9484
+#: ../gramps/plugins/webreport/narrativeweb.py:9775
 msgid "A note to be used as the page header"
 msgstr "Eine Notiz, die als Kopfzeile benutzt wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9487
+#: ../gramps/plugins/webreport/narrativeweb.py:9778
 msgid "HTML user footer"
 msgstr "HTML Fußzeile"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9488
+#: ../gramps/plugins/webreport/narrativeweb.py:9779
 msgid "A note to be used as the page footer"
 msgstr "Eine Notiz, die als Fußzeile benutzt wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9491
+#: ../gramps/plugins/webreport/narrativeweb.py:9786
+#, fuzzy
+msgid "Images Generation"
+msgstr "Seiten Generation"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:9789
 msgid "Include images and media objects"
 msgstr "Bilder und Medienobjekte aufnehmen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9493
+#: ../gramps/plugins/webreport/narrativeweb.py:9791
 msgid "Whether to include a gallery of media objects"
 msgstr "Legt fest, ob eine Galerie mit Medienobjekten aufgenommen wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9499
+#: ../gramps/plugins/webreport/narrativeweb.py:9797
 msgid "Include unused images and media objects"
 msgstr "Unbenutzte Bilder und Medienobjekte aufnehmen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9500
+#: ../gramps/plugins/webreport/narrativeweb.py:9798
 msgid "Whether to include unused or unreferenced media objects"
 msgstr "Ob unbenutzte nicht referenzierte Medienobjekte aufgenommen werden"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9505
+#: ../gramps/plugins/webreport/narrativeweb.py:9803
 msgid "Create and only use thumbnail- sized images"
 msgstr "Erstelle und verwende nur Miniaturbilder"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9507
+#: ../gramps/plugins/webreport/narrativeweb.py:9805
 msgid ""
 "This option allows you to create only thumbnail images instead of the full-"
 "sized images on the Media Page. This will allow you to have a much smaller "
@@ -35385,11 +35814,11 @@ msgstr ""
 "ist die Datenmenge, die du zu deinen Website Anbieter hoch laden musst "
 "erheblich kleiner."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9516
+#: ../gramps/plugins/webreport/narrativeweb.py:9814
 msgid "Max width of initial image"
 msgstr "Max. Breite für Anfangsbild"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9518
+#: ../gramps/plugins/webreport/narrativeweb.py:9816
 msgid ""
 "This allows you to set the maximum width of the image shown on the media "
 "page. Set to 0 for no limit."
@@ -35397,11 +35826,11 @@ msgstr ""
 "Dies erlaubt dir, die maximale Breite des Bildes zu bestimmen, das auf der "
 "Medienseite gezeigt wird. Setze 0 für unbegrenzt."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9523
+#: ../gramps/plugins/webreport/narrativeweb.py:9821
 msgid "Max height of initial image"
 msgstr "Max. Höhe für Anfangsbild"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9525
+#: ../gramps/plugins/webreport/narrativeweb.py:9823
 msgid ""
 "This allows you to set the maximum height of the image shown on the media "
 "page. Set to 0 for no limit."
@@ -35409,162 +35838,158 @@ msgstr ""
 "Dies erlaubt dir, die maximale Höhe des Bildes zu bestimmen, das auf der "
 "Medienseite gezeigt wird. Setze 0 für unbegrenzt."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9531
-msgid "Suppress Gramps ID"
-msgstr "Gramps-IDs ausblenden"
-
-#: ../gramps/plugins/webreport/narrativeweb.py:9532
-msgid "Whether to include the Gramps ID of objects"
-msgstr "Legt fest, ob die GRAMPS IDs von Objekten aufgenommen werden."
-
-#: ../gramps/plugins/webreport/narrativeweb.py:9553
+#: ../gramps/plugins/webreport/narrativeweb.py:9847
 msgid "Include download page"
 msgstr "Enthält eine Downloadseite"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9555
+#: ../gramps/plugins/webreport/narrativeweb.py:9849
 msgid "Whether to include a database download option"
 msgstr "Legt fest, ob in die Datenbank eine download Option aufgenommen wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9560
-#: ../gramps/plugins/webreport/narrativeweb.py:9572
+#: ../gramps/plugins/webreport/narrativeweb.py:9854
+#: ../gramps/plugins/webreport/narrativeweb.py:9866
 msgid "Download Filename"
 msgstr "Download Dateiname"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9563
-#: ../gramps/plugins/webreport/narrativeweb.py:9575
+#: ../gramps/plugins/webreport/narrativeweb.py:9857
+#: ../gramps/plugins/webreport/narrativeweb.py:9869
 msgid "File to be used for downloading of database"
 msgstr "Datei, die für das Herunterladen der Datenbank verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9566
-#: ../gramps/plugins/webreport/narrativeweb.py:9578
+#: ../gramps/plugins/webreport/narrativeweb.py:9860
+#: ../gramps/plugins/webreport/narrativeweb.py:9872
 msgid "Description for download"
 msgstr "Beschreibung für Download"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9567
+#: ../gramps/plugins/webreport/narrativeweb.py:9861
 msgid "Smith Family Tree"
 msgstr "Smith Stammbaum"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9568
-#: ../gramps/plugins/webreport/narrativeweb.py:9580
+#: ../gramps/plugins/webreport/narrativeweb.py:9862
+#: ../gramps/plugins/webreport/narrativeweb.py:9874
 msgid "Give a description for this file."
 msgstr "Gib eine Beschreibung für die Datei."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9579
+#: ../gramps/plugins/webreport/narrativeweb.py:9873
 msgid "Johnson Family Tree"
 msgstr "Johnson Stammbaum"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9589
-#: ../gramps/plugins/webreport/webcal.py:1801
+#: ../gramps/plugins/webreport/narrativeweb.py:9883
+#: ../gramps/plugins/webreport/webcal.py:1819
 msgid "Advanced Options"
 msgstr "Erweiterte Optionen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9592
-#: ../gramps/plugins/webreport/webcal.py:1803
+#: ../gramps/plugins/webreport/narrativeweb.py:9886
+#: ../gramps/plugins/webreport/webcal.py:1821
 msgid "Character set encoding"
 msgstr "Codierung der Zeichensetzung"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9596
-#: ../gramps/plugins/webreport/webcal.py:1807
+#: ../gramps/plugins/webreport/narrativeweb.py:9890
+#: ../gramps/plugins/webreport/webcal.py:1825
 msgid "The encoding to be used for the web files"
 msgstr "Die Kodierung, die für die Webdateien verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9600
+#: ../gramps/plugins/webreport/narrativeweb.py:9894
 msgid "Include link to active person on every page"
 msgstr "Link zur aktiven Person auf jeder Seite"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9602
+#: ../gramps/plugins/webreport/narrativeweb.py:9896
 msgid "Include a link to the active person (if they have a webpage)"
 msgstr "Link zur aktiven Person auf jeder Seite (wenn sie eine Website hat)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9606
+#: ../gramps/plugins/webreport/narrativeweb.py:9900
 msgid "Include a column for birth dates on the index pages"
 msgstr "Spalte für Geburtsdaten auf den Indexseiten"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9607
+#: ../gramps/plugins/webreport/narrativeweb.py:9901
 msgid "Whether to include a birth column"
 msgstr "Ob eine Spalte für Geburt aufgenommen wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9611
+#: ../gramps/plugins/webreport/narrativeweb.py:9905
 msgid "Include a column for death dates on the index pages"
 msgstr "Spalte für Todesdaten auf den Indexseiten"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9612
+#: ../gramps/plugins/webreport/narrativeweb.py:9906
 msgid "Whether to include a death column"
 msgstr "Ob eine Spalte für Tod aufgenommen wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9615
+#: ../gramps/plugins/webreport/narrativeweb.py:9909
 msgid "Include a column for partners on the index pages"
 msgstr "Spalte für Partner auf den Indexseiten"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9617
+#: ../gramps/plugins/webreport/narrativeweb.py:9911
 msgid "Whether to include a partners column"
 msgstr "Ob eine Spalte für Partner aufgenommen wird"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9620
+#: ../gramps/plugins/webreport/narrativeweb.py:9914
 msgid "Include a column for parents on the index pages"
 msgstr "Spalte für Eltern auf den Indexseiten"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9622
+#: ../gramps/plugins/webreport/narrativeweb.py:9916
 msgid "Whether to include a parents column"
 msgstr "Ob eine Spalte für Eltern aufgenommen wird"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9626
+#: ../gramps/plugins/webreport/narrativeweb.py:9920
 msgid "Include half and/ or step-siblings on the individual pages"
 msgstr "Halb- und/oder Stiefgeschwister auf den Personenseiten aufnehmen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9629
+#: ../gramps/plugins/webreport/narrativeweb.py:9923
 msgid ""
 "Whether to include half and/ or step-siblings with the parents and siblings"
 msgstr ""
 "Legt fest, ob Halb- und/oder Stiefgeschwister mit den Eltern und "
 "Geschwistern aufgenommen werden."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9634
+#: ../gramps/plugins/webreport/narrativeweb.py:9931
+msgid "Advanced Options (2)"
+msgstr "Erweiterte Optionen (2)"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:9935
 msgid "Sort all children in birth order"
 msgstr "Alle Kinder in Reihenfolge der Geburt sortieren"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9636
+#: ../gramps/plugins/webreport/narrativeweb.py:9937
 msgid "Whether to display children in birth order or in entry order?"
 msgstr "Kinder in der Reihenfolge der Geburt oder Eingabe anzeigen?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9639
+#: ../gramps/plugins/webreport/narrativeweb.py:9940
 msgid "Include family pages"
 msgstr "Familienseiten aufnehmen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9640
+#: ../gramps/plugins/webreport/narrativeweb.py:9941
 msgid "Whether or not to include family pages."
 msgstr "Legt fest, ob Familienseiten enthalten sind."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9643
+#: ../gramps/plugins/webreport/narrativeweb.py:9944
 msgid "Include event pages"
 msgstr "Ereignisseiten aufnehmen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9645
+#: ../gramps/plugins/webreport/narrativeweb.py:9946
 msgid "Add a complete events list and relevant pages or not"
 msgstr ""
 "Eine komplette Ereignisliste und entsprechende Seiten aufnehmen oder nicht"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9648
+#: ../gramps/plugins/webreport/narrativeweb.py:9949
 msgid "Include repository pages"
 msgstr "Aufbewahrungsorteseiten aufnehmen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9650
+#: ../gramps/plugins/webreport/narrativeweb.py:9951
 msgid "Whether or not to include the Repository Pages."
 msgstr "Legt fest, ob Aufbewahrungsorteseiten enthalten sind."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9654
+#: ../gramps/plugins/webreport/narrativeweb.py:9955
 msgid "Include GENDEX file (/gendex.txt)"
 msgstr "GENDEX-Datei (/gendex.txt) aufnehmen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9655
+#: ../gramps/plugins/webreport/narrativeweb.py:9956
 msgid "Whether to include a GENDEX file or not"
 msgstr "Legt fest, ob eine GENDEX-Datei aufgenommen wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9658
+#: ../gramps/plugins/webreport/narrativeweb.py:9959
 msgid "Include address book pages"
 msgstr "Adressbuchseiten einbeziehen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9659
+#: ../gramps/plugins/webreport/narrativeweb.py:9960
 msgid ""
 "Whether or not to add Address Book pages,which can include e-mail and "
 "website addresses and personal address/ residence events."
@@ -35572,27 +35997,27 @@ msgstr ""
 "Legt fest, ob Adressbuchseiten enthalten sind, die E-mail-, Webseiten-, und "
 "persönliche Adressen und Wohnortsereignisse enthalten können."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9669
+#: ../gramps/plugins/webreport/narrativeweb.py:9970
 msgid "Place Map Options"
 msgstr "Ortekarteoptionen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9673
+#: ../gramps/plugins/webreport/narrativeweb.py:9975
 msgid "Google"
 msgstr "Google"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9675
+#: ../gramps/plugins/webreport/narrativeweb.py:9976
 msgid "Map Service"
 msgstr "Kartenservice"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9679
+#: ../gramps/plugins/webreport/narrativeweb.py:9980
 msgid "Choose your choice of map service for creating the Place Map Pages."
 msgstr "Wähle den Kartenservice zum Erstellen der Ortskartenseiten."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9685
+#: ../gramps/plugins/webreport/narrativeweb.py:9986
 msgid "Include Place map on Place Pages"
 msgstr "Mit Orte Karte auf den Ortsseiten"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9687
+#: ../gramps/plugins/webreport/narrativeweb.py:9988
 msgid ""
 "Whether to include a place map on the Place Pages, where Latitude/ Longitude "
 "are available."
@@ -35600,11 +36025,11 @@ msgstr ""
 "Legt fest, ob eine Ortskarte auf der Ortsseite aufgenommen wird, wo Längen-/"
 "Breitenangaben vorhanden sind."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9692
+#: ../gramps/plugins/webreport/narrativeweb.py:9993
 msgid "Include Family Map Pages with all places shown on the map"
 msgstr "Mit Familien Kartenseite mit allen Orten angezeigt auf der Karte"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9696
+#: ../gramps/plugins/webreport/narrativeweb.py:9997
 msgid ""
 "Whether or not to add an individual page map showing all the places on this "
 "page. This will allow you to see how your family traveled around the country."
@@ -35613,23 +36038,23 @@ msgstr ""
 "wird. Dies ermöglicht es dir zu sehen, wie deine Familie im Land gewandert "
 "ist."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9704
+#: ../gramps/plugins/webreport/narrativeweb.py:10005
 msgid "Family Links"
 msgstr "Familienverknüpfungen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9705
+#: ../gramps/plugins/webreport/narrativeweb.py:10006
 msgid "Drop"
 msgstr "Abbrechen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9706
+#: ../gramps/plugins/webreport/narrativeweb.py:10007
 msgid "Markers"
 msgstr "Markierungen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9707
+#: ../gramps/plugins/webreport/narrativeweb.py:10008
 msgid "Google/ FamilyMap Option"
 msgstr "Google/ FamilienKarte Option"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9712
+#: ../gramps/plugins/webreport/narrativeweb.py:10013
 msgid ""
 "Select which option that you would like to have for the Google Maps Family "
 "Map pages..."
@@ -35637,35 +36062,44 @@ msgstr ""
 "Wähle welche Option du für die Google Maps Familienkartenseiten haben "
 "möchtest..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9722
+#: ../gramps/plugins/webreport/narrativeweb.py:10017
+msgid "Google maps API key"
+msgstr "GoogleMaps API Schlüssel"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:10018
+#, fuzzy
+msgid "The API key used for the Google maps"
+msgstr "Der Stil, der für Fußzeilen verwendet wird."
+
+#: ../gramps/plugins/webreport/narrativeweb.py:10027
 msgid "Other inclusion (CMS, Web Calendar, Php)"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9726
+#: ../gramps/plugins/webreport/narrativeweb.py:10031
 msgid "Do we include these pages in a cms web ?"
 msgstr "Integrieren wir diese Seiten in ein CMS Web?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9730
-#: ../gramps/plugins/webreport/narrativeweb.py:9747
+#: ../gramps/plugins/webreport/narrativeweb.py:10035
+#: ../gramps/plugins/webreport/narrativeweb.py:10052
 msgid "URI"
 msgstr "URI"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9736
+#: ../gramps/plugins/webreport/narrativeweb.py:10041
 msgid "Where do you place your web site ? default = /NAVWEB"
 msgstr "Wo speicherst du deine Website ? Standard = /NAVWEB"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9743
+#: ../gramps/plugins/webreport/narrativeweb.py:10048
 #, fuzzy
 msgid "Do we include the web calendar ?"
 msgstr "Integrieren wir diese Seiten in ein CMS Web?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:9753
+#: ../gramps/plugins/webreport/narrativeweb.py:10058
 msgid "Where do you place your web site ? default = /WEBCAL"
 msgstr "Wo speicherst du deine Website ? Standard = /WEBCAL"
 
 #. adding title to hyperlink menu for screen readers and
 #. braille writers
-#: ../gramps/plugins/webreport/narrativeweb.py:10233
+#: ../gramps/plugins/webreport/narrativeweb.py:10547
 #, python-format
 msgid "Alphabet Menu: %s"
 msgstr "Alphabet Menü: %s"
@@ -35674,20 +36108,20 @@ msgstr "Alphabet Menü: %s"
 #. Number of directory levels up to get to self.html_dir / root
 #. Number of directory levels up to get to root
 #. generate progress pass for "Year At A Glance"
-#: ../gramps/plugins/webreport/webcal.py:324
-#: ../gramps/plugins/webreport/webcal.py:955
-#: ../gramps/plugins/webreport/webcal.py:1040
-#: ../gramps/plugins/webreport/webcal.py:1256
-#: ../gramps/plugins/webreport/webcal.py:1261
+#: ../gramps/plugins/webreport/webcal.py:327
+#: ../gramps/plugins/webreport/webcal.py:964
+#: ../gramps/plugins/webreport/webcal.py:1049
+#: ../gramps/plugins/webreport/webcal.py:1268
+#: ../gramps/plugins/webreport/webcal.py:1273
 msgid "Web Calendar Report"
 msgstr "Webkalender"
 
-#: ../gramps/plugins/webreport/webcal.py:325
+#: ../gramps/plugins/webreport/webcal.py:328
 #, python-format
 msgid "Calculating Holidays for year %04d"
 msgstr "Berechne Feiertage für das Jahr %04d"
 
-#: ../gramps/plugins/webreport/webcal.py:481
+#: ../gramps/plugins/webreport/webcal.py:485
 #, python-format
 msgid ""
 "the \"WebCal\" will be the potential-email Subject|Created for "
@@ -35695,39 +36129,39 @@ msgid ""
 msgstr ""
 "Erstellt für %(html_email_author_start)sWebCal%(html_email_author_end)s"
 
-#: ../gramps/plugins/webreport/webcal.py:489
+#: ../gramps/plugins/webreport/webcal.py:493
 #, python-format
 msgid "Created for %(author)s"
 msgstr "Erstellt für %(author)s"
 
 #. Add a link for year_glance() if requested
-#: ../gramps/plugins/webreport/webcal.py:567
+#: ../gramps/plugins/webreport/webcal.py:574
 msgid "Year Glance"
 msgstr "Jahresüberblick"
 
-#: ../gramps/plugins/webreport/webcal.py:605
+#: ../gramps/plugins/webreport/webcal.py:612
 msgid "NarrativeWeb Home"
 msgstr "Erzählende Website Anfang"
 
-#: ../gramps/plugins/webreport/webcal.py:607
+#: ../gramps/plugins/webreport/webcal.py:614
 msgid "Full year at a Glance"
 msgstr "Jahresüberblick"
 
-#: ../gramps/plugins/webreport/webcal.py:956
+#: ../gramps/plugins/webreport/webcal.py:965
 msgid "Formatting months ..."
 msgstr "Formatiere Monate ..."
 
-#: ../gramps/plugins/webreport/webcal.py:1041
+#: ../gramps/plugins/webreport/webcal.py:1050
 msgid "Creating Year At A Glance calendar"
 msgstr "Erstelle Jahresüberblick Kalender"
 
 #. page title
-#: ../gramps/plugins/webreport/webcal.py:1046
+#: ../gramps/plugins/webreport/webcal.py:1055
 #, python-format
 msgid "%(year)d, At A Glance"
 msgstr "Jahresüberblick %(year)d"
 
-#: ../gramps/plugins/webreport/webcal.py:1061
+#: ../gramps/plugins/webreport/webcal.py:1070
 msgid ""
 "This calendar is meant to give you access to all your data at a glance "
 "compressed into one page. Clicking on a date will take you to a page that "
@@ -35738,219 +36172,218 @@ msgstr ""
 "wenn welche vorhanden sind.\n"
 
 #. page title
-#: ../gramps/plugins/webreport/webcal.py:1114
+#: ../gramps/plugins/webreport/webcal.py:1123
 msgid "One Day Within A Year"
 msgstr "Ein Tag innerhalb eines Jahres"
 
-#: ../gramps/plugins/webreport/webcal.py:1412
+#: ../gramps/plugins/webreport/webcal.py:1430
 #, python-format
 msgid "%(spouse)s and %(person)s"
 msgstr "%(spouse)s und %(person)s"
 
 #. Display date as user set in preferences
-#: ../gramps/plugins/webreport/webcal.py:1432
+#: ../gramps/plugins/webreport/webcal.py:1450
 #, python-format
 msgid "Generated by %(gramps_home_html_start)sGramps%(html_end)s on %(date)s"
 msgstr "Erstellt mit %(gramps_home_html_start)sGramps%(html_end)s am %(date)s"
 
 #. page title
-#: ../gramps/plugins/webreport/webcal.py:1538
-#: ../gramps/plugins/webreport/webcal.py:1602
+#: ../gramps/plugins/webreport/webcal.py:1556
+#: ../gramps/plugins/webreport/webcal.py:1620
 msgid "My Family Calendar"
 msgstr "Mein Familienkalender"
 
-#: ../gramps/plugins/webreport/webcal.py:1602
+#: ../gramps/plugins/webreport/webcal.py:1620
 msgid "Calendar Title"
 msgstr "Kalendertitel"
 
-#: ../gramps/plugins/webreport/webcal.py:1603
+#: ../gramps/plugins/webreport/webcal.py:1621
 msgid "The title of the calendar"
 msgstr "Der Titel des Kalenders"
 
-#: ../gramps/plugins/webreport/webcal.py:1671
+#: ../gramps/plugins/webreport/webcal.py:1690
 msgid "Create multiple year calendars"
 msgstr "Kalender für mehrere Jahre erstellen"
 
-#: ../gramps/plugins/webreport/webcal.py:1673
+#: ../gramps/plugins/webreport/webcal.py:1692
 msgid "Whether to create Multiple year calendars or not."
 msgstr "Legt fest, ob der Kalender für mehrere Jahre erstellt wird oder nicht."
 
-#: ../gramps/plugins/webreport/webcal.py:1678
+#: ../gramps/plugins/webreport/webcal.py:1697
 msgid "Start Year for the Calendar(s)"
 msgstr "Startjahr de(s/r) Kalender"
 
-#: ../gramps/plugins/webreport/webcal.py:1680
+#: ../gramps/plugins/webreport/webcal.py:1699
 msgid "Enter the starting year for the calendars between 1900 - 3000"
 msgstr "Gib ein Startjahr der Kalender zwischen 1900 und 3000 ein"
 
-#: ../gramps/plugins/webreport/webcal.py:1684
+#: ../gramps/plugins/webreport/webcal.py:1703
 msgid "End Year for the Calendar(s)"
 msgstr "Endjahr de(s/r) Kalender"
 
-#: ../gramps/plugins/webreport/webcal.py:1686
+#: ../gramps/plugins/webreport/webcal.py:1705
 msgid "Enter the ending year for the calendars between 1900 - 3000."
 msgstr "Gib ein Endjahr der Kalender zwischen 1900 und 3000 ein."
 
-#: ../gramps/plugins/webreport/webcal.py:1703
+#: ../gramps/plugins/webreport/webcal.py:1722
 msgid "Holidays will be included for the selected country"
 msgstr "Feiertage werden für das gewählte Land aufgenommen"
 
-#: ../gramps/plugins/webreport/webcal.py:1727
+#: ../gramps/plugins/webreport/webcal.py:1745
 msgid "Home link"
 msgstr "Heimat Link"
 
-#: ../gramps/plugins/webreport/webcal.py:1728
+#: ../gramps/plugins/webreport/webcal.py:1746
 msgid ""
 "The link to be included to direct the user to the main page of the web site"
 msgstr ""
 "Der aufgenommene Link, der den Benutzer zur Hauptseite des Webauftritt "
 "leitet."
 
-#: ../gramps/plugins/webreport/webcal.py:1744
+#: ../gramps/plugins/webreport/webcal.py:1762
 msgid "Jan - Jun Notes"
 msgstr "Jan - Jun Notizen"
 
-#: ../gramps/plugins/webreport/webcal.py:1746
+#: ../gramps/plugins/webreport/webcal.py:1764
 msgid "January Note"
 msgstr "Januarnotiz"
 
-#: ../gramps/plugins/webreport/webcal.py:1747
+#: ../gramps/plugins/webreport/webcal.py:1765
 msgid "The note for the month of January"
 msgstr "Die Notiz für den Monat Januar"
 
-#: ../gramps/plugins/webreport/webcal.py:1750
+#: ../gramps/plugins/webreport/webcal.py:1768
 msgid "February Note"
 msgstr "Februarnotiz"
 
-#: ../gramps/plugins/webreport/webcal.py:1751
+#: ../gramps/plugins/webreport/webcal.py:1769
 msgid "The note for the month of February"
 msgstr "Die Notiz für den Monat Februar"
 
-#: ../gramps/plugins/webreport/webcal.py:1754
+#: ../gramps/plugins/webreport/webcal.py:1772
 msgid "March Note"
 msgstr "Märznotiz"
 
-#: ../gramps/plugins/webreport/webcal.py:1755
+#: ../gramps/plugins/webreport/webcal.py:1773
 msgid "The note for the month of March"
 msgstr "Die Notiz für den Monat März"
 
-#: ../gramps/plugins/webreport/webcal.py:1758
+#: ../gramps/plugins/webreport/webcal.py:1776
 msgid "April Note"
 msgstr "Aprilnotiz"
 
-#: ../gramps/plugins/webreport/webcal.py:1759
+#: ../gramps/plugins/webreport/webcal.py:1777
 msgid "The note for the month of April"
 msgstr "Die Notiz für den Monat April"
 
-#: ../gramps/plugins/webreport/webcal.py:1762
+#: ../gramps/plugins/webreport/webcal.py:1780
 msgid "May Note"
 msgstr "Mainotiz"
 
-#: ../gramps/plugins/webreport/webcal.py:1763
+#: ../gramps/plugins/webreport/webcal.py:1781
 msgid "The note for the month of May"
 msgstr "Die Notiz für den Monat Mai"
 
-#: ../gramps/plugins/webreport/webcal.py:1766
+#: ../gramps/plugins/webreport/webcal.py:1784
 msgid "June Note"
 msgstr "Juninotiz"
 
-#: ../gramps/plugins/webreport/webcal.py:1767
+#: ../gramps/plugins/webreport/webcal.py:1785
 msgid "The note for the month of June"
 msgstr "Die Notiz für den Monat Juni"
 
-#: ../gramps/plugins/webreport/webcal.py:1770
+#: ../gramps/plugins/webreport/webcal.py:1788
 msgid "Jul - Dec Notes"
 msgstr "Jul. - Dez. Notizen"
 
-#: ../gramps/plugins/webreport/webcal.py:1772
+#: ../gramps/plugins/webreport/webcal.py:1790
 msgid "July Note"
 msgstr "Julinotiz"
 
-#: ../gramps/plugins/webreport/webcal.py:1773
+#: ../gramps/plugins/webreport/webcal.py:1791
 msgid "The note for the month of July"
 msgstr "Die Notiz für den Monat Juli"
 
-#: ../gramps/plugins/webreport/webcal.py:1776
+#: ../gramps/plugins/webreport/webcal.py:1794
 msgid "August Note"
 msgstr "Augustnotiz"
 
-#: ../gramps/plugins/webreport/webcal.py:1777
+#: ../gramps/plugins/webreport/webcal.py:1795
 msgid "The note for the month of August"
 msgstr "Die Notiz für den Monat August"
 
-#: ../gramps/plugins/webreport/webcal.py:1780
+#: ../gramps/plugins/webreport/webcal.py:1798
 msgid "September Note"
 msgstr "Septembernotiz"
 
-#: ../gramps/plugins/webreport/webcal.py:1781
+#: ../gramps/plugins/webreport/webcal.py:1799
 msgid "The note for the month of September"
 msgstr "Die Notiz für den Monat September"
 
-#: ../gramps/plugins/webreport/webcal.py:1784
+#: ../gramps/plugins/webreport/webcal.py:1802
 msgid "October Note"
 msgstr "Oktobernotiz"
 
-#: ../gramps/plugins/webreport/webcal.py:1785
+#: ../gramps/plugins/webreport/webcal.py:1803
 msgid "The note for the month of October"
 msgstr "Die Notiz für den Monat Oktober"
 
-#: ../gramps/plugins/webreport/webcal.py:1788
+#: ../gramps/plugins/webreport/webcal.py:1806
 msgid "November Note"
 msgstr "Novembernotiz"
 
-#: ../gramps/plugins/webreport/webcal.py:1789
+#: ../gramps/plugins/webreport/webcal.py:1807
 msgid "The note for the month of November"
 msgstr "Die Notiz für den Monat November"
 
-#: ../gramps/plugins/webreport/webcal.py:1792
+#: ../gramps/plugins/webreport/webcal.py:1810
 msgid "December Note"
 msgstr "Dezembernotiz"
 
-#: ../gramps/plugins/webreport/webcal.py:1793
+#: ../gramps/plugins/webreport/webcal.py:1811
 msgid "The note for the month of December"
 msgstr "Die Notiz für den Monat Dezember"
 
-#: ../gramps/plugins/webreport/webcal.py:1810
+#: ../gramps/plugins/webreport/webcal.py:1828
 msgid "Create one day event pages for Year At A Glance calendar"
 msgstr "Erstelle Eintagesereignissseiten für Jahresüberblick Kalender"
 
-#: ../gramps/plugins/webreport/webcal.py:1812
+#: ../gramps/plugins/webreport/webcal.py:1830
 msgid "Whether to create one day pages or not"
 msgstr "Legt fest, ob Eintages Seiten erstellt werden oder nicht."
 
-#: ../gramps/plugins/webreport/webcal.py:1815
+#: ../gramps/plugins/webreport/webcal.py:1833
 msgid "Link to Narrated Web Report"
 msgstr "Link zu erzählender Website"
 
-#: ../gramps/plugins/webreport/webcal.py:1816
+#: ../gramps/plugins/webreport/webcal.py:1834
 msgid "Whether to link data to web report or not"
 msgstr "Legt fest, ob Daten mit einem Webbericht verknüpft werden oder nicht."
 
-#: ../gramps/plugins/webreport/webcal.py:1822
+#: ../gramps/plugins/webreport/webcal.py:1840
 msgid "Link prefix"
 msgstr "Verknüpfungspräfix"
 
-#: ../gramps/plugins/webreport/webcal.py:1823
+#: ../gramps/plugins/webreport/webcal.py:1841
 msgid "A Prefix on the links to take you to Narrated Web Report"
 msgstr ""
 "Ein Präfix an den Links, um dich zum erzählenden Webbericht zu bringen."
 
-#: ../gramps/plugins/webreport/webcal.py:1990
+#: ../gramps/plugins/webreport/webcal.py:2012
 #, python-format
 msgid "%s old"
 msgstr "%s alt"
 
-#: ../gramps/plugins/webreport/webcal.py:1999
+#: ../gramps/plugins/webreport/webcal.py:2021
 #, python-format
 msgid "%(couple)s, <em>wedding</em>"
 msgstr "%(couple)s, <em>Hochzeit</em>"
 
-#: ../gramps/plugins/webreport/webcal.py:2007
+#: ../gramps/plugins/webreport/webcal.py:2029
 msgid "Until"
 msgstr "Bis"
 
-#. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/webreport/webcal.py:2015
+#: ../gramps/plugins/webreport/webcal.py:2038
 #, python-brace-format
 msgid "{couple}, {years} year anniversary"
 msgid_plural "{couple}, {years} year anniversary"
@@ -35982,44 +36415,116 @@ msgstr "Liefert eine Sammlung von Hilfsmitteln für das Web"
 #. "default" is used as default
 #. default style sheet in the options
 #. Basic Ash style sheet
-#: ../gramps/plugins/webstuff/webstuff.py:59
+#: ../gramps/plugins/webstuff/webstuff.py:60
 msgid "Basic-Ash"
 msgstr "Einfach - Asche"
 
 #. Basic Cypress style sheet
-#: ../gramps/plugins/webstuff/webstuff.py:67
+#: ../gramps/plugins/webstuff/webstuff.py:68
 msgid "Basic-Cypress"
 msgstr "Einfach - Zypresse"
 
 #. basic Lilac style sheet
-#: ../gramps/plugins/webstuff/webstuff.py:71
+#: ../gramps/plugins/webstuff/webstuff.py:72
 msgid "Basic-Lilac"
 msgstr "Einfach - Lila"
 
 #. basic Peach style sheet
-#: ../gramps/plugins/webstuff/webstuff.py:75
+#: ../gramps/plugins/webstuff/webstuff.py:76
 msgid "Basic-Peach"
 msgstr "Einfach - Pfirsich"
 
 #. basic Spruce style sheet
-#: ../gramps/plugins/webstuff/webstuff.py:79
+#: ../gramps/plugins/webstuff/webstuff.py:80
 msgid "Basic-Spruce"
 msgstr "Einfach - Tannengrün"
 
 #. Mainz style sheet with its images
-#: ../gramps/plugins/webstuff/webstuff.py:83
+#: ../gramps/plugins/webstuff/webstuff.py:84
 msgid "Mainz"
 msgstr "Mainz"
 
 #. Nebraska style sheet
-#: ../gramps/plugins/webstuff/webstuff.py:91
+#: ../gramps/plugins/webstuff/webstuff.py:92
 msgid "Nebraska"
 msgstr "Nebraska"
 
 #. no style sheet option
-#: ../gramps/plugins/webstuff/webstuff.py:152
+#: ../gramps/plugins/webstuff/webstuff.py:153
 msgid "No style sheet"
 msgstr "Kein Stylesheet"
+
+#~ msgid "%(father)s and %(mother)s (%(id)s)"
+#~ msgstr "%(father)s und %(mother)s (%(id)s)"
+
+#~ msgid "Book Menu"
+#~ msgstr "Buchmenü"
+
+#~ msgid "Available Items Menu"
+#~ msgstr "Verfügbare Artikel Menü"
+
+#~ msgid "Loading plugins..."
+#~ msgstr "Lade Zusatzmodule..."
+
+#~ msgid "People Menu"
+#~ msgstr "Personenmenü"
+
+#~ msgid "Descendent Menu"
+#~ msgstr "Nachfahremenü"
+
+#~ msgid "Person or Place|Title"
+#~ msgstr "Titel"
+
+#~ msgid "Birth place id"
+#~ msgstr "Geburtsort ID"
+
+#~ msgid "Baptism place id"
+#~ msgstr "Taufort ID"
+
+#~ msgid "Burial place id"
+#~ msgstr "Beerdigungsort ID"
+
+#~ msgid "Death place id"
+#~ msgstr "Sterbeort ID"
+
+#~ msgid "Death cause"
+#~ msgstr "Todesursache"
+
+#~ msgid "Gramps id"
+#~ msgstr "Gramps id"
+
+#~ msgid "Parent2"
+#~ msgstr "Elter2"
+
+#~ msgid "Parent1"
+#~ msgstr "Elter1"
+
+#~ msgid "Enclosed by"
+#~ msgstr "Teil von"
+
+#~ msgid "Form omitted"
+#~ msgstr "Formular ausgelassen"
+
+#~ msgid "Empty event note ignored"
+#~ msgstr "Leere Ereignisnotiz ignoriert"
+
+#~ msgid "BLOB ignored"
+#~ msgstr "BLOB ignoriert"
+
+#~ msgid "Multimedia REFN:TYPE ignored"
+#~ msgstr "Multimedia REFN:TYPE ignoriert"
+
+#~ msgid "Mutimedia RIN ignored"
+#~ msgstr "Mutimedia RIN ignoriert"
+
+#~ msgid "Select filter to restrict people that appear on report"
+#~ msgstr "Filter wählen, um Personen einzugrenzen, die im Bericht erscheinen."
+
+#~ msgid "Family Menu"
+#~ msgstr "Familienmenü"
+
+#~ msgid "Gramps&nbsp;ID"
+#~ msgstr "Gramps&nbsp;ID"
 
 #~ msgid "%(date)s, %(place)s"
 #~ msgstr "%(date)s, %(place)s"
@@ -36065,9 +36570,6 @@ msgstr "Kein Stylesheet"
 
 #~ msgid "BIC"
 #~ msgstr "IBG"
-
-#~ msgid "DNS"
-#~ msgstr "kSieg"
 
 #~ msgid "DNS/CAN"
 #~ msgstr "kSieg/Annul"
@@ -36278,9 +36780,6 @@ msgstr "Kein Stylesheet"
 
 #~ msgid "Familes"
 #~ msgstr "Familien"
-
-#~ msgid "Names"
-#~ msgstr "Namen"
 
 #~ msgid "Requested %s does not exist."
 #~ msgstr "Gewünschte %s existiert nicht."
@@ -36955,9 +37454,6 @@ msgstr "Kein Stylesheet"
 #~ msgid "Recipient"
 #~ msgstr "Empfänger"
 
-#~ msgid "Report date"
-#~ msgstr "Berichtsdatum"
-
 #, fuzzy
 #~ msgid "Report date (Short)"
 #~ msgstr "Bericht für"
@@ -36987,10 +37483,6 @@ msgstr "Kein Stylesheet"
 
 #~ msgid "Session"
 #~ msgstr "Sitzung"
-
-#, fuzzy
-#~ msgid "Session (Short)"
-#~ msgstr "Sitzungsaufzeichnungen"
 
 #~ msgid "Sheet no."
 #~ msgstr "Blatt Nr."
@@ -37333,9 +37825,6 @@ msgstr "Kein Stylesheet"
 
 #~ msgid "Spelling checker could not be attached to TextView"
 #~ msgstr "Rechtschreibprüfung kann nicht zur Textansicht hinzugefügt werden."
-
-#~ msgid "Citation information"
-#~ msgstr "Informationen zur Fundstelle"
 
 #~ msgid ""
 #~ "<b>Note:</b> Any changes in the shared citation information will be "
@@ -37846,9 +38335,6 @@ msgstr "Kein Stylesheet"
 #~ msgid "Need to upgrade Bsddb database!"
 #~ msgstr "Bsddb Datenbank muss aktualisiert werden!"
 
-#~ msgid "How the title will be shown."
-#~ msgstr "Wie der Titel angezeigt wird."
-
 #~ msgid " (%(value)s)"
 #~ msgstr " (%(value)s)"
 
@@ -38221,9 +38707,6 @@ msgstr "Kein Stylesheet"
 #~ msgid "Invalid longitude (syntax: 18°9'"
 #~ msgstr "Ungültiger Längengrad (Syntax: 18°9'"
 
-#~ msgid "Gramps Bar"
-#~ msgstr "Grampsleiste"
-
 #~ msgid ""
 #~ "The Grampsbar will be restored to contain its default gramplets.  This "
 #~ "action cannot be undone."
@@ -38495,10 +38978,6 @@ msgstr "Kein Stylesheet"
 #~ msgid_plural "%(quantity)d invalid event references were removed\n"
 #~ msgstr[0] "%(quantity)d ungültige Ereignisreferenz wurde entfernt\n"
 #~ msgstr[1] "%(quantity)d ungültige Ereignisreferenzen wurden entfernt\n"
-
-#, fuzzy
-#~ msgid "Entire Book"
-#~ msgstr "Neues Buch"
 
 #~ msgid "Install Addons"
 #~ msgstr "Addons installieren"
@@ -40297,9 +40776,6 @@ msgstr "Kein Stylesheet"
 
 #~ msgid "Objects with <Id>"
 #~ msgstr "Objekte mit <ID>"
-
-#~ msgid "Has marker of"
-#~ msgstr "Hat Marker"
 
 #~ msgid "Matches markers of a particular type"
 #~ msgstr "Liefert Marker eines bestimmten Typs"

--- a/po/nl.po
+++ b/po/nl.po
@@ -43,8 +43,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gramps\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-17 09:59+0100\n"
-"PO-Revision-Date: 2016-12-06 10:08+0100\n"
+"POT-Creation-Date: 2016-12-05 09:47+0100\n"
+"PO-Revision-Date: 2016-12-11 22:35+0100\n"
 "Last-Translator: Frederik De Richter <frederik.de.richter@gmail.com>\n"
 "Language-Team: nederlands <frederik.de.richter@gmail.com>\n"
 "Language: nl\n"
@@ -1183,12 +1183,12 @@ msgstr ""
 msgid "OK to overwrite?"
 msgstr "OK om te overschrijven?"
 
-#: ../gramps/cli/arghandler.py:294 ../gramps/cli/clidbman.py:433
+#: ../gramps/cli/arghandler.py:294 ../gramps/cli/clidbman.py:434
 msgid "no"
 msgstr "nee"
 
 #: ../gramps/cli/arghandler.py:294 ../gramps/cli/arghandler.py:295
-#: ../gramps/cli/clidbman.py:433
+#: ../gramps/cli/clidbman.py:434
 msgid "yes"
 msgstr "ja"
 
@@ -1211,7 +1211,7 @@ msgstr "Lijst van bestaande stambomen in uw opslaglocatie\n"
 msgid "%(full_DB_path)s with name \"%(f_t_name)s\""
 msgstr "%(full_DB_path)s met naam \"%(f_t_name)s\""
 
-#: ../gramps/cli/arghandler.py:428 ../gramps/cli/clidbman.py:183
+#: ../gramps/cli/arghandler.py:428 ../gramps/cli/clidbman.py:184
 msgid "Gramps Family Trees:"
 msgstr "Gramps-stambomen:"
 
@@ -1224,8 +1224,8 @@ msgstr "Gramps-stambomen:"
 #. -------------------------------------------------------------------------
 #: ../gramps/cli/arghandler.py:434 ../gramps/cli/arghandler.py:436
 #: ../gramps/cli/arghandler.py:441 ../gramps/cli/arghandler.py:442
-#: ../gramps/cli/arghandler.py:444 ../gramps/cli/clidbman.py:68
-#: ../gramps/cli/clidbman.py:171 ../gramps/cli/clidbman.py:192
+#: ../gramps/cli/arghandler.py:444 ../gramps/cli/clidbman.py:69
+#: ../gramps/cli/clidbman.py:172 ../gramps/cli/clidbman.py:193
 #: ../gramps/gui/clipboard.py:970 ../gramps/gui/configure.py:1466
 msgid "Family Tree"
 msgstr "Stamboom"
@@ -1610,7 +1610,7 @@ msgstr ""
 "Om de opdrachtregel juist te gebruiken dient u minstens één bestand op te "
 "geven om te starten."
 
-#: ../gramps/cli/clidbman.py:81
+#: ../gramps/cli/clidbman.py:82
 #, python-format
 msgid ""
 "ERROR: %(title)s \n"
@@ -1619,14 +1619,14 @@ msgstr ""
 "FOUT: %(title)s \n"
 "       %(message)s"
 
-#: ../gramps/cli/clidbman.py:168 ../gramps/cli/clidbman.py:170
+#: ../gramps/cli/clidbman.py:169 ../gramps/cli/clidbman.py:171
 #: ../gramps/gui/clipboard.py:186 ../gramps/gui/clipboard.py:187
 #: ../gramps/gui/plug/_windows.py:488
 msgid "Unavailable"
 msgstr "Niet beschikbaar"
 
 # Locatie
-#: ../gramps/cli/clidbman.py:172 ../gramps/gen/lib/media.py:195
+#: ../gramps/cli/clidbman.py:173 ../gramps/gen/lib/media.py:195
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:66
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:90
 #: ../gramps/gui/glade/editmedia.glade:289
@@ -1635,48 +1635,48 @@ msgstr "Niet beschikbaar"
 msgid "Path"
 msgstr "Pad"
 
-#: ../gramps/cli/clidbman.py:173 ../gramps/gen/plug/_pluginreg.py:88
+#: ../gramps/cli/clidbman.py:174 ../gramps/gen/plug/_pluginreg.py:88
 msgid "Database"
 msgstr "Gegevensbestand"
 
-#: ../gramps/cli/clidbman.py:174 ../gramps/gui/dbman.py:395
+#: ../gramps/cli/clidbman.py:175 ../gramps/gui/dbman.py:396
 msgid "Last accessed"
 msgstr "Laatste toegang"
 
-#: ../gramps/cli/clidbman.py:175
+#: ../gramps/cli/clidbman.py:176
 msgid "Locked?"
 msgstr "Vergrendeld?"
 
-#: ../gramps/cli/clidbman.py:192
+#: ../gramps/cli/clidbman.py:193
 #, python-format
 msgid "Family Tree \"%s\":"
 msgstr "Stamboom \"%s\":"
 
 #. translators: needed for French, ignore otherwise
-#: ../gramps/cli/clidbman.py:196
+#: ../gramps/cli/clidbman.py:197
 #, python-format
 msgid "   %(item)s: %(summary)s"
 msgstr "   %(item)s: %(summary)s"
 
-#: ../gramps/cli/clidbman.py:282
+#: ../gramps/cli/clidbman.py:283
 #, python-format
 msgid "Starting Import, %s"
 msgstr "Importeren gestart, %s"
 
-#: ../gramps/cli/clidbman.py:288
+#: ../gramps/cli/clidbman.py:289
 msgid "Import finished..."
 msgstr "Importeren beëindigd..."
 
 #. Create a new database
-#: ../gramps/cli/clidbman.py:375 ../gramps/plugins/importer/importcsv.py:342
+#: ../gramps/cli/clidbman.py:376 ../gramps/plugins/importer/importcsv.py:342
 msgid "Importing data..."
 msgstr "Importeren van gegevens..."
 
-#: ../gramps/cli/clidbman.py:429
+#: ../gramps/cli/clidbman.py:430
 msgid "Remove family tree warning"
 msgstr "Waarschuwing vanb stamboom verwijderen"
 
-#: ../gramps/cli/clidbman.py:430
+#: ../gramps/cli/clidbman.py:431
 #, python-format
 msgid ""
 "Are you sure you want to remove the family tree named\n"
@@ -1685,15 +1685,15 @@ msgstr ""
 "Weet u zeker dat u de stamboom wilt verwijderen\n"
 "\"%s\"?"
 
-#: ../gramps/cli/clidbman.py:440 ../gramps/gui/dbman.py:717
+#: ../gramps/cli/clidbman.py:441 ../gramps/gui/dbman.py:718
 msgid "Could not delete Family Tree"
 msgstr "Kon de stamboom niet verwijderen"
 
-#: ../gramps/cli/clidbman.py:454
+#: ../gramps/cli/clidbman.py:455
 msgid "Could not rename Family Tree"
 msgstr "De stamboom kon niet hernoemd worden"
 
-#: ../gramps/cli/clidbman.py:487
+#: ../gramps/cli/clidbman.py:488
 #, python-format
 msgid ""
 "\n"
@@ -1712,18 +1712,18 @@ msgstr ""
 "    %s\n"
 "\n"
 
-#: ../gramps/cli/clidbman.py:539 ../gramps/gui/configure.py:1357
+#: ../gramps/cli/clidbman.py:540 ../gramps/gui/configure.py:1357
 msgid "Never"
 msgstr "Nooit"
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/cli/clidbman.py:555
+#: ../gramps/cli/clidbman.py:556
 #, python-format
 msgid "Locked by %s"
 msgstr "Vergrendeld door %s"
 
 #. allow deferred translation of attribute UI strings
-#: ../gramps/cli/clidbman.py:557 ../gramps/gen/lib/attrtype.py:62
+#: ../gramps/cli/clidbman.py:558 ../gramps/gen/lib/attrtype.py:62
 #: ../gramps/gen/lib/childreftype.py:73 ../gramps/gen/lib/eventroletype.py:52
 #: ../gramps/gen/lib/eventtype.py:162 ../gramps/gen/lib/familyreltype.py:47
 #: ../gramps/gen/lib/grampstype.py:33 ../gramps/gen/lib/nameorigintype.py:73
@@ -1734,7 +1734,7 @@ msgstr "Vergrendeld door %s"
 #: ../gramps/gen/utils/lds.py:86 ../gramps/gen/utils/unknown.py:119
 #: ../gramps/gen/utils/unknown.py:121 ../gramps/gen/utils/unknown.py:125
 #: ../gramps/gen/utils/unknown.py:131 ../gramps/gen/utils/unknown.py:136
-#: ../gramps/gui/clipboard.py:183 ../gramps/gui/dbman.py:978
+#: ../gramps/gui/clipboard.py:183 ../gramps/gui/dbman.py:979
 #: ../gramps/gui/editors/displaytabs/personrefembedlist.py:125
 #: ../gramps/gui/editors/displaytabs/personrefembedlist.py:143
 #: ../gramps/gui/editors/editmedia.py:180
@@ -1777,7 +1777,7 @@ msgstr "Vergrendeld door %s"
 #: ../gramps/plugins/textreport/detdescendantreport.py:811
 #: ../gramps/plugins/textreport/indivcomplete.py:86
 #: ../gramps/plugins/textreport/indivcomplete.py:913
-#: ../gramps/plugins/tool/check.py:2278 ../gramps/plugins/tool/check.py:2304
+#: ../gramps/plugins/tool/check.py:2356 ../gramps/plugins/tool/check.py:2382
 #: ../gramps/plugins/tool/dumpgenderstats.py:65
 #: ../gramps/plugins/view/geoclose.py:521
 #: ../gramps/plugins/view/geofamclose.py:271
@@ -1797,22 +1797,22 @@ msgstr "Vergrendeld door %s"
 msgid "Unknown"
 msgstr "Onbekend"
 
-#: ../gramps/cli/grampscli.py:83
+#: ../gramps/cli/grampscli.py:84
 #, python-format
 msgid "WARNING: %s"
 msgstr "WAARSCHUWING: %s"
 
-#: ../gramps/cli/grampscli.py:90 ../gramps/cli/grampscli.py:249
+#: ../gramps/cli/grampscli.py:91 ../gramps/cli/grampscli.py:250
 #, python-format
 msgid "ERROR: %s"
 msgstr "FOUT: %s"
 
-#: ../gramps/cli/grampscli.py:104 ../gramps/cli/user.py:199
+#: ../gramps/cli/grampscli.py:105 ../gramps/cli/user.py:199
 #: ../gramps/gui/dialog.py:217
 msgid "Low level database corruption detected"
 msgstr "Gegevensbestandsbeschadiging gedetecteerd"
 
-#: ../gramps/cli/grampscli.py:106 ../gramps/cli/user.py:200
+#: ../gramps/cli/grampscli.py:107 ../gramps/cli/user.py:200
 #: ../gramps/gui/dialog.py:218
 msgid ""
 "Gramps has detected a problem in the underlying Berkeley database. This can "
@@ -1823,44 +1823,44 @@ msgstr ""
 "gegevensbestand. Dit kan hersteld worden door middel van de "
 "stamboombeheerder. Kies het gegevensbestand en klik op de herstelknop"
 
-#: ../gramps/cli/grampscli.py:151 ../gramps/gui/dbloader.py:305
+#: ../gramps/cli/grampscli.py:152 ../gramps/gui/dbloader.py:306
 msgid "Read only database"
 msgstr "Alleen-lezen gegevensbestand"
 
-#: ../gramps/cli/grampscli.py:152 ../gramps/gui/dbloader.py:246
-#: ../gramps/gui/dbloader.py:306
+#: ../gramps/cli/grampscli.py:153 ../gramps/gui/dbloader.py:247
+#: ../gramps/gui/dbloader.py:307
 msgid "You do not have write access to the selected file."
 msgstr "U heeft geen schrijftoegangsrechten tot het geselecteerde bestand."
 
-#: ../gramps/cli/grampscli.py:178 ../gramps/cli/grampscli.py:181
-#: ../gramps/cli/grampscli.py:184 ../gramps/cli/grampscli.py:187
-#: ../gramps/cli/grampscli.py:190 ../gramps/cli/grampscli.py:193
-#: ../gramps/cli/grampscli.py:196 ../gramps/cli/grampscli.py:199
-#: ../gramps/cli/grampscli.py:202 ../gramps/gui/dbloader.py:409
-#: ../gramps/gui/dbloader.py:412 ../gramps/gui/dbloader.py:415
-#: ../gramps/gui/dbloader.py:418 ../gramps/gui/dbloader.py:421
+#: ../gramps/cli/grampscli.py:179 ../gramps/cli/grampscli.py:182
+#: ../gramps/cli/grampscli.py:185 ../gramps/cli/grampscli.py:188
+#: ../gramps/cli/grampscli.py:191 ../gramps/cli/grampscli.py:194
+#: ../gramps/cli/grampscli.py:197 ../gramps/cli/grampscli.py:200
+#: ../gramps/cli/grampscli.py:203 ../gramps/gui/dbloader.py:410
+#: ../gramps/gui/dbloader.py:413 ../gramps/gui/dbloader.py:416
+#: ../gramps/gui/dbloader.py:419 ../gramps/gui/dbloader.py:422
 msgid "Cannot open database"
 msgstr "Kan gegevensbestand niet openen"
 
-#: ../gramps/cli/grampscli.py:206 ../gramps/gui/dbloader.py:202
-#: ../gramps/gui/dbloader.py:425
+#: ../gramps/cli/grampscli.py:207 ../gramps/gui/dbloader.py:203
+#: ../gramps/gui/dbloader.py:426
 #, python-format
 msgid "Could not open file: %s"
 msgstr "Bestand: %s kon niet geopend worden"
 
-#: ../gramps/cli/grampscli.py:262
+#: ../gramps/cli/grampscli.py:263
 msgid "Could not load a recent Family Tree."
 msgstr "Stamboom kon niet geladen worden."
 
-#: ../gramps/cli/grampscli.py:263
+#: ../gramps/cli/grampscli.py:264
 msgid "Family Tree does not exist, as it has been deleted."
 msgstr "Deze stamboom bestaat niet meer omdat dit bestand werd verwijderd."
 
-#: ../gramps/cli/grampscli.py:268
+#: ../gramps/cli/grampscli.py:269
 msgid "The database is locked."
 msgstr "Het gegevensbestand is vergrendeld."
 
-#: ../gramps/cli/grampscli.py:269
+#: ../gramps/cli/grampscli.py:270
 msgid ""
 "Use the --force-unlock option if you are sure that the database is not in use."
 msgstr ""
@@ -1868,17 +1868,17 @@ msgstr ""
 "niet in gebruik is."
 
 #. already errors encountered. Show first one on terminal and exit
-#: ../gramps/cli/grampscli.py:349
+#: ../gramps/cli/grampscli.py:350
 #, python-format
 msgid "Error encountered: %s"
 msgstr "Fout: %s"
 
-#: ../gramps/cli/grampscli.py:351 ../gramps/cli/grampscli.py:359
+#: ../gramps/cli/grampscli.py:352 ../gramps/cli/grampscli.py:360
 #, python-format
 msgid "  Details: %s"
 msgstr "  Details: %s"
 
-#: ../gramps/cli/grampscli.py:356
+#: ../gramps/cli/grampscli.py:357
 #, python-format
 msgid "Error encountered in argument parsing: %s"
 msgstr "Fout tijdens verwerken argumenten: %s"
@@ -2023,7 +2023,7 @@ msgstr "Verslag werd niet aangemaakt. "
 #: ../gramps/cli/plug/__init__.py:793
 #, python-format
 msgid "Failed to make '%s' report."
-msgstr "Verslag '%s' werd niet aangemaakt. "
+msgstr "Verslag '%s' werd niet aangemaakt."
 
 #: ../gramps/cli/user.py:216 ../gramps/gui/dialog.py:203
 msgid "Error detected in database"
@@ -2047,28 +2047,28 @@ msgstr ""
 "stuur dan een foutrapport naar %(gramps_bugtracker_url)s\n"
 "\n"
 
-#: ../gramps/gen/config.py:326
+#: ../gramps/gen/config.py:325
 msgid "Imported %Y/%m/%d %H:%M:%S"
 msgstr "Geïmporteerd op %Y/%m/%d %H:%M:%S"
 
-#: ../gramps/gen/config.py:340
+#: ../gramps/gen/config.py:339
 msgid "Missing Given Name"
 msgstr "Ontbrekende voornaam"
 
 # complete/volledige/volledig ingevulde  kaarten/archieven
-#: ../gramps/gen/config.py:341
+#: ../gramps/gen/config.py:340
 msgid "Missing Record"
 msgstr "Ontbrekend gegeven"
 
-#: ../gramps/gen/config.py:342
+#: ../gramps/gen/config.py:341
 msgid "Missing Surname"
 msgstr "Ontbrekende achternaam"
 
-#: ../gramps/gen/config.py:349 ../gramps/gen/config.py:351
+#: ../gramps/gen/config.py:348 ../gramps/gen/config.py:350
 msgid "[Living]"
 msgstr "[Nog in leven]"
 
-#: ../gramps/gen/config.py:350
+#: ../gramps/gen/config.py:349
 msgid "Private Record"
 msgstr "Gegevens privé"
 
@@ -2882,31 +2882,31 @@ msgstr "Vrijdag"
 msgid "Saturday"
 msgstr "Zaterdag"
 
-#: ../gramps/gen/db/base.py:1760 ../gramps/gui/widgets/fanchart.py:1806
+#: ../gramps/gen/db/base.py:1789 ../gramps/gui/widgets/fanchart.py:1761
 msgid "Add child to family"
 msgstr "Kind aan gezin toevoegen"
 
-#: ../gramps/gen/db/base.py:1774 ../gramps/gen/db/base.py:1780
+#: ../gramps/gen/db/base.py:1803 ../gramps/gen/db/base.py:1809
 msgid "Remove child from family"
 msgstr "Kind uit gezin verwijderen"
 
-#: ../gramps/gen/db/base.py:1856 ../gramps/gen/db/base.py:1860
+#: ../gramps/gen/db/base.py:1885 ../gramps/gen/db/base.py:1889
 msgid "Remove Family"
 msgstr "Gezin verwijderen"
 
-#: ../gramps/gen/db/base.py:1902
+#: ../gramps/gen/db/base.py:1931
 msgid "Remove father from family"
 msgstr "Vader uit gezin verwijderen"
 
-#: ../gramps/gen/db/base.py:1904
+#: ../gramps/gen/db/base.py:1933
 msgid "Remove mother from family"
 msgstr "Moeder uit gezin verwijderen"
 
-#: ../gramps/gen/db/base.py:1979
+#: ../gramps/gen/db/base.py:2008
 msgid "Autobackup..."
 msgstr "Automatisch reservekopie maken..."
 
-#: ../gramps/gen/db/base.py:1983
+#: ../gramps/gen/db/base.py:2012
 msgid "Error saving backup data"
 msgstr "Fout bij het maken van een reservekopie"
 
@@ -2931,7 +2931,7 @@ msgstr ""
 "gegevens te migreren tussen verschillende versies van gegevensbestanden."
 
 #: ../gramps/gen/db/exceptions.py:114
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "The Python version is not supported by this version of Gramps.\n"
 "\n"
@@ -2941,14 +2941,13 @@ msgid ""
 "Please upgrade to the corresponding version or use XML for porting data "
 "between different Python versions."
 msgstr ""
-"De versie van het gegevensbestand wordt niet door deze versie van Gramps "
-"ondersteund.\n"
+"De Pythonversie wordt niet door deze versie van Gramps ondersteund.\n"
 "\n"
-"Deze stamboom maakt gebruik van versie %(tree_vers)s, en deze versie van "
+"Deze stamboom maakt gebruik van Pythonversie %(tree_vers)s en deze versie van "
 "Gramps ondersteunt de versies %(min_vers)s tot %(max_vers)s.\n"
 "\n"
 "Gelieve op te waarderen naar een ondersteunde versie of gebruik XML om "
-"gegevens te migreren tussen verschillende versies van gegevensbestanden."
+"gegevens te migreren tussen verschillende Pythonversies."
 
 #: ../gramps/gen/db/exceptions.py:136
 #, python-format
@@ -3146,27 +3145,27 @@ msgstr ""
 "%(bold_start)soude%(bold_end)s versie van Gramps op te starten en "
 "%(wiki_backup_html_start)sreservekopie%(html_end)s te maken."
 
-#: ../gramps/gen/db/generic.py:160 ../gramps/gen/db/generic.py:199
-#: ../gramps/gen/db/generic.py:824 ../gramps/plugins/db/bsddb/undoredo.py:245
+#: ../gramps/gen/db/generic.py:155 ../gramps/gen/db/generic.py:200
+#: ../gramps/gen/db/generic.py:2184 ../gramps/plugins/db/bsddb/undoredo.py:245
 #: ../gramps/plugins/db/bsddb/undoredo.py:282
 #: ../gramps/plugins/db/bsddb/write.py:2326
 #, python-format
 msgid "_Undo %s"
 msgstr "Ongedaan maken %s"
 
-#: ../gramps/gen/db/generic.py:166 ../gramps/gen/db/generic.py:205
+#: ../gramps/gen/db/generic.py:160 ../gramps/gen/db/generic.py:206
 #: ../gramps/plugins/db/bsddb/undoredo.py:251
 #: ../gramps/plugins/db/bsddb/undoredo.py:288
 #, python-format
 msgid "_Redo %s"
 msgstr "%s opnieuw doen"
 
-#: ../gramps/gen/db/generic.py:1892 ../gramps/plugins/db/bsddb/read.py:2114
+#: ../gramps/gen/db/generic.py:2630 ../gramps/plugins/db/bsddb/read.py:2081
 #: ../gramps/plugins/db/bsddb/write.py:2517
 msgid "Number of people"
 msgstr "Aantal personen"
 
-#: ../gramps/gen/db/generic.py:1893 ../gramps/plugins/db/bsddb/read.py:2115
+#: ../gramps/gen/db/generic.py:2631 ../gramps/plugins/db/bsddb/read.py:2082
 #: ../gramps/plugins/db/bsddb/write.py:2518
 #: ../gramps/plugins/gramplet/statsgramplet.py:117
 #: ../gramps/plugins/webreport/narrativeweb.py:8108
@@ -3174,70 +3173,74 @@ msgstr "Aantal personen"
 msgid "Number of families"
 msgstr "Aantal gezinnen"
 
-#: ../gramps/gen/db/generic.py:1894 ../gramps/plugins/db/bsddb/read.py:2116
+#: ../gramps/gen/db/generic.py:2632 ../gramps/plugins/db/bsddb/read.py:2083
 #: ../gramps/plugins/db/bsddb/write.py:2519
 #: ../gramps/plugins/webreport/narrativeweb.py:8135
 #: ../gramps/plugins/webreport/narrativeweb.py:8186
 msgid "Number of sources"
 msgstr "Aantal bronnen"
 
-#: ../gramps/gen/db/generic.py:1895 ../gramps/plugins/db/bsddb/read.py:2117
+#: ../gramps/gen/db/generic.py:2633 ../gramps/plugins/db/bsddb/read.py:2084
 #: ../gramps/plugins/db/bsddb/write.py:2520
 #: ../gramps/plugins/webreport/narrativeweb.py:8139
 #: ../gramps/plugins/webreport/narrativeweb.py:8189
 msgid "Number of citations"
 msgstr "Aantal citaten"
 
-#: ../gramps/gen/db/generic.py:1896 ../gramps/plugins/db/bsddb/read.py:2118
+#: ../gramps/gen/db/generic.py:2634 ../gramps/plugins/db/bsddb/read.py:2085
 #: ../gramps/plugins/db/bsddb/write.py:2521
 #: ../gramps/plugins/webreport/narrativeweb.py:8128
 #: ../gramps/plugins/webreport/narrativeweb.py:8180
 msgid "Number of events"
 msgstr "Aantal gebeurtenissen"
 
-#: ../gramps/gen/db/generic.py:1897 ../gramps/plugins/db/bsddb/read.py:2119
+#: ../gramps/gen/db/generic.py:2635 ../gramps/plugins/db/bsddb/read.py:2086
 #: ../gramps/plugins/db/bsddb/write.py:2522
 msgid "Number of media"
 msgstr "Aantal media-objecten"
 
-#: ../gramps/gen/db/generic.py:1898 ../gramps/plugins/db/bsddb/read.py:2120
+#: ../gramps/gen/db/generic.py:2636 ../gramps/plugins/db/bsddb/read.py:2087
 #: ../gramps/plugins/db/bsddb/write.py:2523
 #: ../gramps/plugins/webreport/narrativeweb.py:8131
 #: ../gramps/plugins/webreport/narrativeweb.py:8183
 msgid "Number of places"
 msgstr "Aantal locaties"
 
-#: ../gramps/gen/db/generic.py:1899 ../gramps/plugins/db/bsddb/read.py:2121
+#: ../gramps/gen/db/generic.py:2637 ../gramps/plugins/db/bsddb/read.py:2088
 #: ../gramps/plugins/db/bsddb/write.py:2524
 #: ../gramps/plugins/webreport/narrativeweb.py:8143
 #: ../gramps/plugins/webreport/narrativeweb.py:8192
 msgid "Number of repositories"
 msgstr "Aantal bibliotheken"
 
-#: ../gramps/gen/db/generic.py:1900 ../gramps/plugins/db/bsddb/read.py:2122
+#: ../gramps/gen/db/generic.py:2638 ../gramps/plugins/db/bsddb/read.py:2089
 #: ../gramps/plugins/db/bsddb/write.py:2525
 msgid "Number of notes"
 msgstr "Aantal opmerkingen"
 
-#: ../gramps/gen/db/generic.py:1901 ../gramps/plugins/db/bsddb/read.py:2123
+#: ../gramps/gen/db/generic.py:2639 ../gramps/plugins/db/bsddb/read.py:2090
 #: ../gramps/plugins/db/bsddb/write.py:2526
 msgid "Number of tags"
 msgstr "Aantal tags"
 
-#: ../gramps/gen/db/generic.py:1902 ../gramps/plugins/db/bsddb/write.py:2527
+#: ../gramps/gen/db/generic.py:2640 ../gramps/plugins/db/bsddb/write.py:2527
 msgid "Data version"
 msgstr "Gegevensversie"
 
-#: ../gramps/gen/db/generic.py:1903
+#: ../gramps/gen/db/generic.py:2641
 msgid "Backups, count"
 msgstr "Reservekopie, aantal"
 
-#: ../gramps/gen/db/generic.py:1904
+#: ../gramps/gen/db/generic.py:2642
 msgid "Backups, last"
-msgstr "Reservekopie, laatste "
+msgstr "Reservekopie, laatste"
 
 #. translators: needed for Arabic, ignore otherwise
-#: ../gramps/gen/display/name.py:349 ../gramps/plugins/lib/libtreebase.py:707
+#. need for spacing on the french translation
+#. translators: needed for Arabic, ignore otherwise
+#: ../gramps/gen/display/name.py:349
+#: ../gramps/gui/views/treemodels/placemodel.py:130
+#: ../gramps/plugins/lib/libtreebase.py:707
 msgid ","
 msgstr ","
 
@@ -3373,12 +3376,12 @@ msgstr "bijnaam"
 msgid "familynick"
 msgstr "familiebijnaam"
 
-#: ../gramps/gen/display/name.py:1099
+#: ../gramps/gen/display/name.py:1117
 #, python-format
 msgid "Wrong name format string %s"
 msgstr "Verkeerd naamformaat %s"
 
-#: ../gramps/gen/display/name.py:1103
+#: ../gramps/gen/display/name.py:1121
 msgid "ERROR, Edit Name format in Preferences"
 msgstr "FOUT, u dient in voorkeuren het naamformaat aan te passen"
 
@@ -4519,15 +4522,13 @@ msgid "Inclusive:"
 msgstr "Inclusief:"
 
 #: ../gramps/gen/filters/rules/family/_isancestorof.py:45
-#, fuzzy
 msgid "Ancestor families of <family>"
-msgstr "Is een voorouder van resultaat van filter"
+msgstr "Voorouderfamilies van <familie>"
 
 # opgegeven ipv gespecificeerde?
 #: ../gramps/gen/filters/rules/family/_isancestorof.py:47
-#, fuzzy
 msgid "Matches ancestor families of the specified family"
-msgstr "Vindt gezinnen met een opgegeven filter"
+msgstr "Voorouderfamilies van de opgegeven familie zoeken"
 
 #: ../gramps/gen/filters/rules/family/_isbookmarked.py:44
 msgid "Bookmarked families"
@@ -4538,9 +4539,8 @@ msgid "Matches the families on the bookmark list"
 msgstr "Vindt de gezinnen op de lijst met bladwijzers"
 
 #: ../gramps/gen/filters/rules/family/_isdescendantof.py:45
-#, fuzzy
 msgid "Descendant families of <family>"
-msgstr "Familie-afstammelingen van %s"
+msgstr "Afstammelingenfamilies van <familie>"
 
 #: ../gramps/gen/filters/rules/family/_isdescendantof.py:47
 msgid "Matches descendant families of the specified family"
@@ -6427,6 +6427,7 @@ msgstr "Kaste"
 #: ../gramps/gui/plug/_windows.py:130 ../gramps/gui/plug/_windows.py:239
 #: ../gramps/gui/plug/_windows.py:612 ../gramps/gui/plug/_windows.py:1095
 #: ../gramps/gui/selectors/selectevent.py:74
+#: ../gramps/plugins/gramplet/coordinates.py:90
 #: ../gramps/plugins/gramplet/events.py:86
 #: ../gramps/plugins/lib/libmetadata.py:98
 #: ../gramps/plugins/textreport/placereport.py:221
@@ -6509,7 +6510,7 @@ msgstr "Tijd"
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:176
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:171
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:154
-#: ../gramps/plugins/tool/check.py:2332
+#: ../gramps/plugins/tool/check.py:2410
 msgid "None"
 msgstr "Geen"
 
@@ -6659,9 +6660,8 @@ msgid "0 days"
 msgstr "0 dagen"
 
 #: ../gramps/gen/lib/date.py:1873
-#, fuzzy
 msgid "date-quality|none"
-msgstr "geschat "
+msgstr "geen"
 
 #: ../gramps/gen/lib/date.py:1874
 msgid "calculated"
@@ -6673,7 +6673,7 @@ msgstr "geschat"
 
 #: ../gramps/gen/lib/date.py:1888
 msgid "date-modifier|none"
-msgstr "geen "
+msgstr "geen"
 
 #: ../gramps/gen/lib/date.py:1889 ../gramps/plugins/lib/libsubstkeyword.py:315
 msgid "about"
@@ -6749,7 +6749,7 @@ msgstr "Levensgebeurtenissen"
 #: ../gramps/gui/configure.py:534
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:59
 #: ../gramps/gui/editors/displaytabs/personeventembedlist.py:52
-#: ../gramps/gui/editors/editfamily.py:501 ../gramps/gui/editors/editlink.py:91
+#: ../gramps/gui/editors/editfamily.py:499 ../gramps/gui/editors/editlink.py:91
 #: ../gramps/gui/editors/filtereditor.py:294
 #: ../gramps/gui/glade/editldsord.glade:269
 #: ../gramps/plugins/export/exportcsv.py:515
@@ -6787,7 +6787,7 @@ msgid "Legal"
 msgstr "Wettelijk"
 
 #: ../gramps/gen/lib/eventtype.py:153 ../gramps/gen/lib/eventtype.py:195
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:443
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:460
 #: ../gramps/plugins/webreport/narrativeweb.py:3081
 #: ../gramps/plugins/webreport/narrativeweb.py:7929
 msgid "Residence"
@@ -7209,9 +7209,8 @@ msgstr "Getrouwd"
 
 #: ../gramps/gen/lib/grampstype.py:213 ../gramps/gen/lib/grampstype.py:214
 #: ../gramps/gen/lib/grampstype.py:215
-#, fuzzy
 msgid "Family Relationship"
-msgstr "Gezinsrelaties"
+msgstr "Gezinsrelatie"
 
 #: ../gramps/gen/lib/ldsord.py:95
 msgid "Endowment"
@@ -7231,7 +7230,7 @@ msgstr "<Geen status>"
 
 #: ../gramps/gen/lib/ldsord.py:103
 msgid "Born in Covenant"
-msgstr ""
+msgstr "Geboren in Covenant"
 
 #: ../gramps/gen/lib/ldsord.py:104
 msgid "Canceled"
@@ -7370,15 +7369,15 @@ msgstr "MIME"
 
 #: ../gramps/gen/lib/media.py:198
 msgid "Checksum"
-msgstr ""
+msgstr "Controlesom"
 
 #: ../gramps/gen/lib/media.py:199 ../gramps/gen/lib/person.py:225
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:569
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:583
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:597
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:611
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:625
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:639
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:586
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:600
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:614
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:628
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:642
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:656
 #: ../gramps/plugins/textreport/indivcomplete.py:458
 #: ../gramps/plugins/textreport/indivcomplete.py:677
 #: ../gramps/plugins/webreport/narrativeweb.py:798
@@ -7389,26 +7388,26 @@ msgstr "Kenmerken"
 
 #: ../gramps/gen/lib/media.py:200 ../gramps/gen/lib/name.py:201
 #: ../gramps/gen/lib/person.py:228
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:765
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:779
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:793
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:807
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:821
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:782
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:796
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:810
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:824
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:838
 #: ../gramps/plugins/textreport/tagreport.py:802
-#: ../gramps/plugins/view/view.gpr.py:266 ../gramps/plugins/view/view.gpr.py:274
+#: ../gramps/plugins/view/view.gpr.py:281 ../gramps/plugins/view/view.gpr.py:289
 msgid "Citations"
 msgstr "Citaten"
 
 #: ../gramps/gen/lib/media.py:201 ../gramps/gen/lib/name.py:202
 #: ../gramps/gen/lib/person.py:229
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:653
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:667
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:681
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:695
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:709
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:723
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:737
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:751
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:670
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:684
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:698
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:712
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:726
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:740
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:754
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:768
 #: ../gramps/plugins/quickview/filterbyname.py:112
 #: ../gramps/plugins/quickview/filterbyname.py:137
 #: ../gramps/plugins/textreport/indivcomplete.py:260
@@ -7460,8 +7459,9 @@ msgstr "Laatste wijziging"
 #: ../gramps/plugins/export/exportcsv.py:287
 #: ../gramps/plugins/export/exportcsv.py:473
 #: ../gramps/plugins/gramplet/ageondategramplet.py:66
+#: ../gramps/plugins/gramplet/coordinates.py:91
 #: ../gramps/plugins/gramplet/events.py:87
-#: ../gramps/plugins/gramplet/locations.py:86
+#: ../gramps/plugins/gramplet/locations.py:87
 #: ../gramps/plugins/gramplet/personresidence.py:60
 #: ../gramps/plugins/importer/importcsv.py:219
 #: ../gramps/plugins/quickview/onthisday.py:80
@@ -7577,7 +7577,7 @@ msgstr "Persoonlijk"
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:104
 #: ../gramps/gui/plug/_guioptions.py:1165 ../gramps/gui/plug/_windows.py:126
 #: ../gramps/gui/plug/_windows.py:1094
-#: ../gramps/gui/plug/report/_bookdialog.py:371
+#: ../gramps/gui/plug/report/_bookdialog.py:372
 #: ../gramps/gui/selectors/selectperson.py:94
 #: ../gramps/gui/selectors/selectplace.py:71
 #: ../gramps/gui/views/bookmarks.py:240 ../gramps/gui/views/tags.py:402
@@ -7586,7 +7586,7 @@ msgstr "Persoonlijk"
 #: ../gramps/plugins/gramplet/ancestor.py:63
 #: ../gramps/plugins/gramplet/backlinks.py:56
 #: ../gramps/plugins/gramplet/descendant.py:62
-#: ../gramps/plugins/gramplet/locations.py:84
+#: ../gramps/plugins/gramplet/locations.py:85
 #: ../gramps/plugins/gramplet/placedetails.py:122
 #: ../gramps/plugins/importer/importcsv.py:222
 #: ../gramps/plugins/lib/libpersonview.py:98
@@ -7673,16 +7673,17 @@ msgstr "Titel"
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:105
 #: ../gramps/gui/merge/mergeperson.py:242 ../gramps/gui/plug/_windows.py:119
 #: ../gramps/gui/plug/_windows.py:235 ../gramps/gui/plug/_windows.py:1093
-#: ../gramps/gui/plug/report/_bookdialog.py:372
-#: ../gramps/gui/plug/report/_bookdialog.py:376
+#: ../gramps/gui/plug/report/_bookdialog.py:373
+#: ../gramps/gui/plug/report/_bookdialog.py:377
 #: ../gramps/gui/selectors/selectevent.py:70
 #: ../gramps/gui/selectors/selectnote.py:77
 #: ../gramps/gui/selectors/selectobject.py:82
 #: ../gramps/gui/selectors/selectplace.py:73
 #: ../gramps/plugins/export/exportcsv.py:286
 #: ../gramps/plugins/gramplet/backlinks.py:55
+#: ../gramps/plugins/gramplet/coordinates.py:89
 #: ../gramps/plugins/gramplet/events.py:85
-#: ../gramps/plugins/gramplet/locations.py:85
+#: ../gramps/plugins/gramplet/locations.py:86
 #: ../gramps/plugins/gramplet/placedetails.py:123
 #: ../gramps/plugins/importer/importcsv.py:223
 #: ../gramps/plugins/lib/libplaceview.py:87
@@ -7887,9 +7888,8 @@ msgid "notetype|To Do"
 msgstr "Taak"
 
 #: ../gramps/gen/lib/notetype.py:83
-#, fuzzy
 msgid "notetype|Link"
-msgstr "Taak"
+msgstr "Link"
 
 #: ../gramps/gen/lib/notetype.py:87
 msgid "Person Note"
@@ -7964,7 +7964,7 @@ msgstr "Opmerking over een verwijzing naar een kind"
 
 #: ../gramps/gen/lib/person.py:213
 msgid "Handle"
-msgstr ""
+msgstr "Handle"
 
 #: ../gramps/gen/lib/person.py:215 ../gramps/gui/editors/editfamily.py:124
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:128
@@ -7981,9 +7981,8 @@ msgid "Gender"
 msgstr "Geslacht"
 
 #: ../gramps/gen/lib/person.py:216
-#, fuzzy
 msgid "Primary name"
-msgstr "Primaire rol:"
+msgstr "Primaire naam"
 
 #: ../gramps/gen/lib/person.py:217
 msgid "Alternate names"
@@ -8023,9 +8022,8 @@ msgid "Families"
 msgstr "Gezinnen"
 
 #: ../gramps/gen/lib/person.py:222
-#, fuzzy
 msgid "Parent families"
-msgstr "Gezinnen herschikken"
+msgstr "Oudergezinnen"
 
 #: ../gramps/gen/lib/person.py:224 ../gramps/gui/merge/mergeperson.py:257
 #: ../gramps/plugins/textreport/indivcomplete.py:406
@@ -8038,7 +8036,6 @@ msgid "Urls"
 msgstr "Urls"
 
 #: ../gramps/gen/lib/person.py:227
-#, fuzzy
 msgid "LDS ordinances"
 msgstr "JDS Wijding"
 
@@ -8057,7 +8054,7 @@ msgstr "Gramps IDs samengevoegd"
 #: ../gramps/gen/lib/placetype.py:65 ../gramps/gui/configure.py:518
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:76
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:59
-#: ../gramps/gui/views/treemodels/placemodel.py:282
+#: ../gramps/gui/views/treemodels/placemodel.py:283
 #: ../gramps/plugins/lib/maps/placeselection.py:132
 #: ../gramps/plugins/view/geoplaces.py:558 ../gramps/plugins/view/repoview.py:93
 #: ../gramps/plugins/webreport/narrativeweb.py:1481
@@ -8069,7 +8066,7 @@ msgstr "Land"
 
 #: ../gramps/gen/lib/placetype.py:66
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:58
-#: ../gramps/gui/views/treemodels/placemodel.py:282
+#: ../gramps/gui/views/treemodels/placemodel.py:283
 #: ../gramps/plugins/lib/maps/placeselection.py:133
 #: ../gramps/plugins/view/geoplaces.py:561
 msgid "State"
@@ -8077,7 +8074,7 @@ msgstr "Deelstaat"
 
 #: ../gramps/gen/lib/placetype.py:67
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:57
-#: ../gramps/gui/views/treemodels/placemodel.py:282
+#: ../gramps/gui/views/treemodels/placemodel.py:283
 #: ../gramps/plugins/lib/maps/placeselection.py:134
 #: ../gramps/plugins/view/geoplaces.py:564
 #: ../gramps/plugins/webreport/narrativeweb.py:1479
@@ -8220,7 +8217,7 @@ msgstr "Kluis"
 msgid "Audio"
 msgstr "Geluid"
 
-#: ../gramps/gen/lib/srcmediatype.py:59 ../gramps/gui/glade/book.glade:9
+#: ../gramps/gen/lib/srcmediatype.py:59 ../gramps/gui/glade/book.glade:7
 msgid "Book"
 msgstr "Boek"
 
@@ -8335,11 +8332,11 @@ msgstr "Zoeken op het web"
 msgid "FTP"
 msgstr "FTP"
 
-#: ../gramps/gen/merge/diff.py:188
+#: ../gramps/gen/merge/diff.py:100
 msgid "Family Tree Differences"
 msgstr "Stamboomverschillen"
 
-#: ../gramps/gen/merge/diff.py:189
+#: ../gramps/gen/merge/diff.py:101
 msgid "Searching..."
 msgstr "Zoeken..."
 
@@ -8701,9 +8698,8 @@ msgid "Bottom"
 msgstr "Onder"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:90
-#, fuzzy
 msgid "Straight"
-msgstr "rechtop"
+msgstr "Rechtop"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:91
 msgid "Curved"
@@ -8791,13 +8787,12 @@ msgstr ""
 "1 is."
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:182
-#, fuzzy
 msgid "Connecting lines"
-msgstr "Gezinnen aanmaken"
+msgstr "Lijnen verbinden"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:185
 msgid "How the lines between objects will be drawn."
-msgstr ""
+msgstr "Hoe de lijnen tussen de objecten worden getekend."
 
 #. ###############################
 #: ../gramps/gen/plug/docgen/graphdoc.py:201
@@ -9009,7 +9004,7 @@ msgstr "Waarde '%(val)s' niet gevonden voor optie '%(opt)s'"
 
 #: ../gramps/gen/plug/menu/_enumeratedlist.py:144
 msgid "Valid values: "
-msgstr "Geldige waarden:"
+msgstr "Geldige waarden: "
 
 #. ------------------------------------------------------------------------
 #.
@@ -9017,7 +9012,7 @@ msgstr "Geldige waarden:"
 #.
 #. ------------------------------------------------------------------------
 #: ../gramps/gen/plug/report/_book.py:71 ../gramps/gui/plug/_dialogs.py:59
-#: ../gramps/gui/plug/report/_bookdialog.py:86 ../gramps/gui/viewmanager.py:110
+#: ../gramps/gui/plug/report/_bookdialog.py:84 ../gramps/gui/viewmanager.py:110
 msgid "Unsupported"
 msgstr "Niet ondersteund"
 
@@ -9117,23 +9112,23 @@ msgstr "Nog in leven zijnde personen"
 
 #: ../gramps/gen/plug/report/stdoptions.py:169
 msgid "'living people'|Included, and all data"
-msgstr ""
+msgstr "Alle gegevens bijvoegen"
 
 #: ../gramps/gen/plug/report/stdoptions.py:173
 msgid "'living people'|Full names, but data removed"
-msgstr ""
+msgstr "Volledige namen maar gegevens verwijderd"
 
 #: ../gramps/gen/plug/report/stdoptions.py:175
 msgid "'living people'|Given names replaced, and data removed"
-msgstr ""
+msgstr "Voornamen vervangen en alle gegevens verwijderd"
 
 #: ../gramps/gen/plug/report/stdoptions.py:177
 msgid "'living people'|Complete names replaced, and data removed"
-msgstr ""
+msgstr "Volledige namen vervangen en alle gegevens verwijderd"
 
 #: ../gramps/gen/plug/report/stdoptions.py:179
 msgid "'living people'|Not included"
-msgstr ""
+msgstr "Niet toevoegen"
 
 #. for deferred translation
 #: ../gramps/gen/plug/report/stdoptions.py:181
@@ -9180,7 +9175,7 @@ msgstr "Volledig gegevensbestand"
 
 #. feature request 2356: avoid genitive form
 #: ../gramps/gen/plug/report/utils.py:299
-#: ../gramps/gui/plug/export/_exportoptions.py:443
+#: ../gramps/gui/plug/export/_exportoptions.py:445
 #: ../gramps/plugins/textreport/descendreport.py:472
 #, python-format
 msgid "Descendants of %s"
@@ -9188,20 +9183,20 @@ msgstr "Afstammelingen van %s"
 
 #. feature request 2356: avoid genitive form
 #: ../gramps/gen/plug/report/utils.py:303 ../gramps/gen/plug/report/utils.py:380
-#: ../gramps/gui/plug/export/_exportoptions.py:448
+#: ../gramps/gui/plug/export/_exportoptions.py:450
 #, python-format
 msgid "Descendant Families of %s"
 msgstr "Familie-afstammelingen van %s"
 
 #. feature request 2356: avoid genitive form
 #: ../gramps/gen/plug/report/utils.py:307
-#: ../gramps/gui/plug/export/_exportoptions.py:453
+#: ../gramps/gui/plug/export/_exportoptions.py:455
 #, python-format
 msgid "Ancestors of %s"
 msgstr "Voorouders van %s"
 
 #: ../gramps/gen/plug/report/utils.py:310
-#: ../gramps/gui/plug/export/_exportoptions.py:457
+#: ../gramps/gui/plug/export/_exportoptions.py:459
 #, python-format
 msgid "People with common ancestor with %s"
 msgstr "Personen met dezelfde voorouder als %s"
@@ -9299,7 +9294,7 @@ msgid "Registered '%s'"
 msgstr "Geregistreerde '%s'"
 
 #: ../gramps/gen/recentfiles.py:204
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "Unable to save list of recent DBs file {fname}: {error}"
 msgstr "Lijst met recente DB-bestand kon niet worden geopend {fname}: {error}"
 
@@ -10183,9 +10178,10 @@ msgstr "Gebeurtenis"
 #: ../gramps/gui/glade/editevent.glade:270
 #: ../gramps/gui/plug/_guioptions.py:1343
 #: ../gramps/gui/selectors/selectevent.py:73
-#: ../gramps/gui/views/treemodels/placemodel.py:282
+#: ../gramps/gui/views/treemodels/placemodel.py:283
 #: ../gramps/plugins/export/exportcsv.py:285
 #: ../gramps/plugins/export/exportcsv.py:473
+#: ../gramps/plugins/gramplet/coordinates.py:93
 #: ../gramps/plugins/gramplet/events.py:91
 #: ../gramps/plugins/gramplet/personresidence.py:61
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:112
@@ -10340,7 +10336,7 @@ msgstr "Bron"
 msgid "Repository"
 msgstr "Bibliotheek"
 
-#: ../gramps/gui/clipboard.py:967 ../gramps/gui/dbman.py:126
+#: ../gramps/gui/clipboard.py:967 ../gramps/gui/dbman.py:127
 #: ../gramps/gui/editors/displaytabs/attrembedlist.py:63
 #: ../gramps/gui/editors/displaytabs/srcattrembedlist.py:64
 #: ../gramps/plugins/gramplet/attributes.py:57
@@ -10353,24 +10349,26 @@ msgstr "Waarde"
 
 # zie ook uncleared.
 # is dit goed?
-#: ../gramps/gui/clipboard.py:1390 ../gramps/gui/clipboard.py:1396
-#: ../gramps/gui/clipboard.py:1434 ../gramps/gui/clipboard.py:1478
+#: ../gramps/gui/clipboard.py:1387 ../gramps/gui/clipboard.py:1393
+#: ../gramps/gui/clipboard.py:1431 ../gramps/gui/clipboard.py:1475
 #: ../gramps/gui/glade/clipboard.glade:7
 msgid "Clipboard"
 msgstr "Klembord"
 
-#: ../gramps/gui/clipboard.py:1522 ../gramps/gui/plug/quick/_quicktable.py:129
+#. Now add more items to popup menu, if available
+#. See details (edit, etc):
+#: ../gramps/gui/clipboard.py:1519 ../gramps/gui/plug/quick/_quicktable.py:141
 #, python-format
 msgid "the object|See %s details"
 msgstr "Zie %s details"
 
 #. ---------------------------
-#: ../gramps/gui/clipboard.py:1528 ../gramps/gui/plug/quick/_quicktable.py:139
+#: ../gramps/gui/clipboard.py:1525 ../gramps/gui/plug/quick/_quicktable.py:149
 #, python-format
 msgid "the object|Make %s active"
 msgstr "%s activeren"
 
-#: ../gramps/gui/clipboard.py:1544
+#: ../gramps/gui/clipboard.py:1541
 #, python-format
 msgid "the object|Create Filter from %s selected..."
 msgstr "Filter van geselecteerde %s aanmaken..."
@@ -10386,7 +10384,7 @@ msgstr "Versleep de kolommen om de volgorde te veranderen"
 
 #: ../gramps/gui/columnorder.py:107 ../gramps/gui/configure.py:1507
 #: ../gramps/gui/configure.py:1530 ../gramps/gui/plug/_dialogs.py:124
-#: ../gramps/gui/viewmanager.py:1409
+#: ../gramps/gui/viewmanager.py:1414
 #: ../gramps/plugins/lib/maps/geography.py:1007
 #: ../gramps/plugins/lib/maps/geography.py:1261
 msgid "_Apply"
@@ -10422,15 +10420,15 @@ msgstr "Het naambewerkingsscherm tonen"
 
 #. self.window.connect('response', self.close)
 #: ../gramps/gui/configure.py:105 ../gramps/gui/configure.py:179
-#: ../gramps/gui/glade/book.glade:469 ../gramps/gui/glade/book.glade:543
-#: ../gramps/gui/glade/clipboard.glade:73 ../gramps/gui/glade/dialog.glade:20
+#: ../gramps/gui/glade/book.glade:466 ../gramps/gui/glade/book.glade:540
+#: ../gramps/gui/glade/clipboard.glade:71 ../gramps/gui/glade/dialog.glade:20
 #: ../gramps/gui/glade/dialog.glade:140
 #: ../gramps/gui/glade/displaystate.glade:25
 #: ../gramps/gui/glade/plugins.glade:24 ../gramps/gui/glade/rule.glade:26
 #: ../gramps/gui/glade/rule.glade:1029 ../gramps/gui/glade/tipofday.glade:117
 #: ../gramps/gui/glade/updateaddons.glade:26 ../gramps/gui/plug/_windows.py:102
 #: ../gramps/gui/plug/_windows.py:682 ../gramps/gui/plug/_windows.py:738
-#: ../gramps/gui/plug/quick/_textbufdoc.py:62 ../gramps/gui/undohistory.py:90
+#: ../gramps/gui/plug/quick/_textbufdoc.py:61 ../gramps/gui/undohistory.py:90
 #: ../gramps/gui/viewmanager.py:506 ../gramps/gui/viewmanager.py:1286
 #: ../gramps/gui/views/bookmarks.py:258 ../gramps/gui/views/tags.py:424
 #: ../gramps/gui/widgets/grampletbar.py:635
@@ -10440,7 +10438,6 @@ msgid "_Close"
 msgstr "Sluiten"
 
 #: ../gramps/gui/configure.py:108
-#, fuzzy
 msgid ""
 "The following keywords are replaced with the appropriate name parts:<tt>\n"
 "  <b>Given</b>   - given name (first name)     <b>Surname</b>  - surnames "
@@ -10497,11 +10494,11 @@ msgstr ""
 "\n"
 "<b>Vooorbeeld</b>: 'Dr. Edwin Jose von der Smith and Weston Wilson Sr (\"Ed"
 "\") - Underhills'\n"
-"     <i>Edwin Jose</i> zijn de voornamen, <i>von der</i> is de prefix, "
-"<i>Smith</i> and <i>Weston</i> achternamen, \n"
-"     <i>and</i> is een verbinding, <i>Wilson</i> patronieme achternaam, <i>Dr."
-"</i> titel, <i>Sr</i> suffix, <i>Ed</i> bijnaam, \n"
-"     <i>Underhills</i> familiebijnaam, <i>Jose</i> roepnaam.\n"
+"     <i>Edwin Jose</i>: voornamen, <i>von der</i>: prefix, <i>Smith</i> en "
+"<i>Weston</i>: achternamen, \n"
+"     <i>and</i>: verbinding, <i>Wilson</i>: patronieme achternaam, <i>Dr.</"
+"i>: titel, <i>Sr</i>: suffix, <i>Ed</i>: bijnaam, \n"
+"     <i>Underhills</i>: familiebijnaam, <i>Jose</i>: roepnaam.\n"
 
 #: ../gramps/gui/configure.py:137
 msgid " Name Editor"
@@ -10693,9 +10690,9 @@ msgstr "Voorbeeld"
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:122
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:129
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:115
-#: ../gramps/gui/editors/editfamily.py:149
-#: ../gramps/gui/plug/report/_bookdialog.py:650 ../gramps/gui/views/tags.py:416
-#: ../gramps/gui/widgets/fanchart.py:1757 ../gramps/gui/widgets/fanchart.py:1799
+#: ../gramps/gui/editors/editfamily.py:148
+#: ../gramps/gui/plug/report/_bookdialog.py:652 ../gramps/gui/views/tags.py:416
+#: ../gramps/gui/widgets/fanchart.py:1712 ../gramps/gui/widgets/fanchart.py:1754
 #: ../gramps/plugins/view/pedigreeview.py:1613
 msgid "_Add"
 msgstr "Toevoegen"
@@ -10709,8 +10706,8 @@ msgstr "Toevoegen"
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:130
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:116
 #: ../gramps/gui/glade/editlink.glade:223
-#: ../gramps/gui/plug/report/_bookdialog.py:624 ../gramps/gui/viewmanager.py:481
-#: ../gramps/gui/views/tags.py:417 ../gramps/gui/widgets/fanchart.py:1575
+#: ../gramps/gui/plug/report/_bookdialog.py:626 ../gramps/gui/viewmanager.py:481
+#: ../gramps/gui/views/tags.py:417 ../gramps/gui/widgets/fanchart.py:1511
 #: ../gramps/plugins/view/pedigreeview.py:1648
 #: ../gramps/plugins/view/pedigreeview.py:1876
 msgid "_Edit"
@@ -10722,8 +10719,8 @@ msgstr "Be_werken"
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:130
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:124
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:117
-#: ../gramps/gui/editors/editfamily.py:153
-#: ../gramps/gui/plug/report/_bookdialog.py:619
+#: ../gramps/gui/editors/editfamily.py:151
+#: ../gramps/gui/plug/report/_bookdialog.py:621
 #: ../gramps/gui/views/bookmarks.py:254 ../gramps/gui/views/listview.py:212
 #: ../gramps/gui/views/tags.py:418 ../gramps/plugins/lib/libpersonview.py:388
 msgid "_Remove"
@@ -10737,6 +10734,7 @@ msgstr "_Verwijderen"
 #: ../gramps/gui/glade/editperson.glade:517 ../gramps/gui/glade/rule.glade:466
 #: ../gramps/gui/glade/styleeditor.glade:1872 ../gramps/gui/plug/_windows.py:148
 #: ../gramps/gui/plug/_windows.py:203
+#: ../gramps/plugins/gramplet/coordinates.py:142
 #: ../gramps/plugins/gramplet/descendant.py:110
 msgid "Edit"
 msgstr "Bewerken"
@@ -10819,7 +10817,6 @@ msgid "Full place name"
 msgstr "Volledige plaatsnaam"
 
 #: ../gramps/gui/configure.py:1141
-#, fuzzy
 msgid "-> Hamlet/Village/Town/City"
 msgstr "-> Dorpje/Gemeente/Stad"
 
@@ -10841,8 +10838,8 @@ msgstr "Taal"
 #: ../gramps/plugins/quickview/filterbyname.py:100
 #: ../gramps/plugins/quickview/filterbyname.py:125
 #: ../gramps/plugins/textreport/tagreport.py:403
-#: ../gramps/plugins/view/view.gpr.py:204 ../gramps/plugins/view/view.gpr.py:212
-#: ../gramps/plugins/view/view.gpr.py:227
+#: ../gramps/plugins/view/view.gpr.py:219 ../gramps/plugins/view/view.gpr.py:227
+#: ../gramps/plugins/view/view.gpr.py:242
 #: ../gramps/plugins/webreport/narrativeweb.py:1877
 #: ../gramps/plugins/webreport/narrativeweb.py:1940
 #: ../gramps/plugins/webreport/narrativeweb.py:2006
@@ -11096,7 +11093,7 @@ msgid "Select media directory"
 msgstr "Selecteer mediamap"
 
 #: ../gramps/gui/configure.py:1505 ../gramps/gui/configure.py:1528
-#: ../gramps/gui/dbloader.py:145 ../gramps/gui/editors/edittaglist.py:117
+#: ../gramps/gui/dbloader.py:146 ../gramps/gui/editors/edittaglist.py:117
 #: ../gramps/gui/glade/addmedia.glade:22
 #: ../gramps/gui/glade/baseselector.glade:24
 #: ../gramps/gui/glade/configure.glade:23 ../gramps/gui/glade/dialog.glade:416
@@ -11141,7 +11138,7 @@ msgstr "Selecteer mediamap"
 #: ../gramps/gui/plug/_guioptions.py:1728 ../gramps/gui/plug/_windows.py:432
 #: ../gramps/gui/plug/report/_fileentry.py:64
 #: ../gramps/gui/plug/report/_reportdialog.py:161 ../gramps/gui/utils.py:172
-#: ../gramps/gui/viewmanager.py:1407 ../gramps/gui/views/listview.py:1010
+#: ../gramps/gui/viewmanager.py:1412 ../gramps/gui/views/listview.py:1010
 #: ../gramps/gui/views/navigationview.py:362 ../gramps/gui/views/tags.py:635
 #: ../gramps/gui/widgets/progressdialog.py:437
 #: ../gramps/plugins/lib/maps/geography.py:1006
@@ -11157,11 +11154,11 @@ msgstr "Annuleren"
 msgid "Select database directory"
 msgstr "Gegevensbestandsmap selecteren"
 
-#: ../gramps/gui/dbloader.py:129 ../gramps/gui/plug/tool.py:108
+#: ../gramps/gui/dbloader.py:130 ../gramps/gui/plug/tool.py:108
 msgid "Undo history warning"
 msgstr "Waarschuwing bewerkingsgeschiedenis"
 
-#: ../gramps/gui/dbloader.py:130
+#: ../gramps/gui/dbloader.py:131
 msgid ""
 "Proceeding with import will erase the undo history for this session. In "
 "particular, you will not be able to revert the import or any changes made "
@@ -11177,23 +11174,23 @@ msgstr ""
 "Indien u de import wil terugdraaien moet u hier stoppen en eerst een "
 "reservekopie maken van uw gegevensbestand."
 
-#: ../gramps/gui/dbloader.py:135
+#: ../gramps/gui/dbloader.py:136
 msgid "_Proceed with import"
 msgstr "Doorgaan met importeren"
 
-#: ../gramps/gui/dbloader.py:135 ../gramps/gui/plug/tool.py:115
+#: ../gramps/gui/dbloader.py:136 ../gramps/gui/plug/tool.py:115
 msgid "_Stop"
 msgstr "_Stop"
 
-#: ../gramps/gui/dbloader.py:142
+#: ../gramps/gui/dbloader.py:143
 msgid "Gramps: Import Family Tree"
 msgstr "Gramps: Stamboom importeren"
 
-#: ../gramps/gui/dbloader.py:147
+#: ../gramps/gui/dbloader.py:148
 msgid "Import"
 msgstr "Importeren"
 
-#: ../gramps/gui/dbloader.py:203
+#: ../gramps/gui/dbloader.py:204
 #, python-format
 msgid ""
 "File type \"%s\" is unknown to Gramps.\n"
@@ -11206,28 +11203,28 @@ msgstr ""
 "Geldige typen zijn: Gramps-gegevensbestand, Gramps-XML, Gramps-pakket, GEDCOM "
 "en andere."
 
-#: ../gramps/gui/dbloader.py:227 ../gramps/gui/dbloader.py:234
+#: ../gramps/gui/dbloader.py:228 ../gramps/gui/dbloader.py:235
 msgid "Cannot open file"
 msgstr "Kan bestand niet openen"
 
-#: ../gramps/gui/dbloader.py:228
+#: ../gramps/gui/dbloader.py:229
 msgid "The selected file is a directory, not a file.\n"
 msgstr "Het geselecteerde bestand is een map, geen bestand.\n"
 
-#: ../gramps/gui/dbloader.py:235
+#: ../gramps/gui/dbloader.py:236
 msgid "You do not have read access to the selected file."
 msgstr "U heeft geen leestoegangsrechten tot het geselecteerde bestand."
 
-#: ../gramps/gui/dbloader.py:245
+#: ../gramps/gui/dbloader.py:246
 msgid "Cannot create file"
 msgstr "Kan gegevensbestand niet aanmaken"
 
-#: ../gramps/gui/dbloader.py:268
+#: ../gramps/gui/dbloader.py:269
 #, python-format
 msgid "Could not import file: %s"
 msgstr "Kon bestand %s niet importeren"
 
-#: ../gramps/gui/dbloader.py:269
+#: ../gramps/gui/dbloader.py:270
 msgid ""
 "This file incorrectly identifies its character set, so it cannot be "
 "accurately imported. Please fix the encoding, and import again"
@@ -11236,73 +11233,72 @@ msgstr ""
 "geïmporteerd worden. Tracht dus eerst de tekenset te corrigeren en importeer "
 "dan opnieuw"
 
-#: ../gramps/gui/dbloader.py:347 ../gramps/gui/dbloader.py:362
-#: ../gramps/gui/dbloader.py:392
+#: ../gramps/gui/dbloader.py:348 ../gramps/gui/dbloader.py:363
+#: ../gramps/gui/dbloader.py:393
 msgid "Are you sure you want to upgrade this Family Tree?"
 msgstr "Weet u zeker dat u de stamboom wilt opwaarderen?"
 
-#: ../gramps/gui/dbloader.py:350 ../gramps/gui/dbloader.py:365
-#: ../gramps/gui/dbloader.py:395
+#: ../gramps/gui/dbloader.py:351 ../gramps/gui/dbloader.py:366
+#: ../gramps/gui/dbloader.py:396
 msgid ""
 "I have made a backup,\n"
 "please upgrade my Family Tree"
 msgstr "Ik heb een reservekopie gemaakt, werk de stamboom bij"
 
-#: ../gramps/gui/dbloader.py:352 ../gramps/gui/dbloader.py:367
-#: ../gramps/gui/dbloader.py:382 ../gramps/gui/dbloader.py:397
-#: ../gramps/gui/plug/report/_bookdialog.py:244
-#: ../gramps/gui/plug/report/_bookdialog.py:731 ../gramps/gui/viewmanager.py:782
+#: ../gramps/gui/dbloader.py:353 ../gramps/gui/dbloader.py:368
+#: ../gramps/gui/dbloader.py:383 ../gramps/gui/dbloader.py:398
+#: ../gramps/gui/plug/report/_bookdialog.py:242
+#: ../gramps/gui/plug/report/_bookdialog.py:738 ../gramps/gui/viewmanager.py:782
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: ../gramps/gui/dbloader.py:377
+#: ../gramps/gui/dbloader.py:378
 msgid "Are you sure you want to downgrade this Family Tree?"
 msgstr "Weet u zeker dat u de stamboom wilt degraderen?"
 
-#: ../gramps/gui/dbloader.py:380
+#: ../gramps/gui/dbloader.py:381
 msgid ""
 "I have made a backup,\n"
 "please downgrade my Family Tree"
 msgstr "Ik heb een reservekopie gemaakt, degradeer mijn stamboom"
 
-#: ../gramps/gui/dbloader.py:466
+#: ../gramps/gui/dbloader.py:467
 msgid "All files"
 msgstr "Alle bestanden"
 
-#: ../gramps/gui/dbloader.py:507
+#: ../gramps/gui/dbloader.py:508
 msgid "Automatically detected"
 msgstr "Automatisch gedetecteerd"
 
-#: ../gramps/gui/dbloader.py:516
+#: ../gramps/gui/dbloader.py:517
 msgid "Select file _type:"
 msgstr "Bestands_type selecteren:"
 
-#: ../gramps/gui/dbman.py:95
-#, fuzzy, python-format
-msgid "%s_-_Manage_Family_Trees"
-msgstr "Stambomen beheren..."
-
 #: ../gramps/gui/dbman.py:96
-#, fuzzy
-msgid "Family_Trees_manager_window"
-msgstr "Stamboomnaam"
+#, python-format
+msgid "%s_-_Manage_Family_Trees"
+msgstr "%s_-_Stambomen beheren"
 
-#: ../gramps/gui/dbman.py:110 ../gramps/gui/glade/dbman.glade:352
+#: ../gramps/gui/dbman.py:97
+msgid "Family_Trees_manager_window"
+msgstr "Family_Trees_manager_window"
+
+#: ../gramps/gui/dbman.py:111 ../gramps/gui/glade/dbman.glade:352
 msgid "_Archive"
 msgstr "_Archiveer"
 
-#: ../gramps/gui/dbman.py:110
+#: ../gramps/gui/dbman.py:111
 msgid "_Extract"
 msgstr "Ophalen"
 
-#: ../gramps/gui/dbman.py:117 ../gramps/gui/dbman.py:142
+#: ../gramps/gui/dbman.py:118 ../gramps/gui/dbman.py:143
 msgid "Database Information"
 msgstr "Gegevensbestandsinformatie"
 
-#: ../gramps/gui/dbman.py:119 ../gramps/gui/editors/edittaglist.py:118
+#: ../gramps/gui/dbman.py:120 ../gramps/gui/editors/edittaglist.py:118
 #: ../gramps/gui/glade/addmedia.glade:38
-#: ../gramps/gui/glade/baseselector.glade:40 ../gramps/gui/glade/book.glade:485
-#: ../gramps/gui/glade/book.glade:559 ../gramps/gui/glade/configure.glade:39
+#: ../gramps/gui/glade/baseselector.glade:40 ../gramps/gui/glade/book.glade:482
+#: ../gramps/gui/glade/book.glade:556 ../gramps/gui/glade/configure.glade:39
 #: ../gramps/gui/glade/dbman.glade:24 ../gramps/gui/glade/editaddress.glade:36
 #: ../gramps/gui/glade/editattribute.glade:37
 #: ../gramps/gui/glade/editchildref.glade:38
@@ -11348,17 +11344,17 @@ msgid "_OK"
 msgstr "OK"
 
 # Classificatie, taxering
-#: ../gramps/gui/dbman.py:125
+#: ../gramps/gui/dbman.py:126
 msgid "Setting"
 msgstr "Instellingen"
 
-#: ../gramps/gui/dbman.py:366
+#: ../gramps/gui/dbman.py:367
 msgid "Family Tree name"
 msgstr "Stamboomnaam"
 
 #. icon_column = Gtk.TreeViewColumn(_('Status'), render,
 #. icon_name=ICON_COL)
-#: ../gramps/gui/dbman.py:379
+#: ../gramps/gui/dbman.py:380
 #: ../gramps/gui/editors/displaytabs/familyldsembedlist.py:53
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:63
 #: ../gramps/gui/plug/_windows.py:123 ../gramps/gui/plug/_windows.py:180
@@ -11371,17 +11367,16 @@ msgstr "Stamboomnaam"
 msgid "Status"
 msgstr "Status"
 
-#: ../gramps/gui/dbman.py:386
-#, fuzzy
+#: ../gramps/gui/dbman.py:387
 msgid "Database Type"
-msgstr "Gegevensbestand geopend"
+msgstr "Type gegevensbestand"
 
-#: ../gramps/gui/dbman.py:492
+#: ../gramps/gui/dbman.py:493
 #, python-format
 msgid "Break the lock on the '%s' database?"
 msgstr "Vergrendeling van het gegevensbestand %s opheffen?"
 
-#: ../gramps/gui/dbman.py:493
+#: ../gramps/gui/dbman.py:494
 msgid ""
 "Gramps believes that someone else is actively editing this database. You "
 "cannot edit this database while it is locked. If no one is editing the "
@@ -11395,15 +11390,15 @@ msgstr ""
 "vergrendeling opheft terwijl er wel iemand het bestand gebruikt, kan het "
 "bestand worden beschadigd."
 
-#: ../gramps/gui/dbman.py:499
+#: ../gramps/gui/dbman.py:500
 msgid "Break lock"
 msgstr "Vergrendeling opheffen"
 
-#: ../gramps/gui/dbman.py:589
+#: ../gramps/gui/dbman.py:590
 msgid "Rename failed"
 msgstr "Hernoemen is mislukt"
 
-#: ../gramps/gui/dbman.py:590
+#: ../gramps/gui/dbman.py:591
 #, python-format
 msgid ""
 "An attempt to rename a version failed with the following message:\n"
@@ -11414,55 +11409,55 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dbman.py:608
+#: ../gramps/gui/dbman.py:609
 msgid "Could not rename the Family Tree."
 msgstr "Kon de stamboom niet hernoemen."
 
-#: ../gramps/gui/dbman.py:609
+#: ../gramps/gui/dbman.py:610
 msgid "Family Tree already exists, choose a unique name."
 msgstr "Deze stamboom bestaat reeds, kies een unieke naam."
 
-#: ../gramps/gui/dbman.py:653
+#: ../gramps/gui/dbman.py:654
 msgid "Extracting archive..."
 msgstr "Archief ophalen..."
 
-#: ../gramps/gui/dbman.py:658
+#: ../gramps/gui/dbman.py:659
 msgid "Importing archive..."
 msgstr "Importeren van archief..."
 
-#: ../gramps/gui/dbman.py:674
+#: ../gramps/gui/dbman.py:675
 #, python-format
 msgid "Remove the '%s' Family Tree?"
 msgstr "Het gegevensbestand '%s' verwijderen?"
 
-#: ../gramps/gui/dbman.py:675
+#: ../gramps/gui/dbman.py:676
 msgid "Removing this Family Tree will permanently destroy the data."
 msgstr ""
 "Het verwijderen van deze stamboom zal de gegevens onherstelbaar verwijderen."
 
-#: ../gramps/gui/dbman.py:677
+#: ../gramps/gui/dbman.py:678
 msgid "Remove Family Tree"
 msgstr "Stamboom verwijderen"
 
-#: ../gramps/gui/dbman.py:682
+#: ../gramps/gui/dbman.py:683
 #, python-format
 msgid "Remove the '%(revision)s' version of '%(database)s'"
 msgstr "Verwijder de '%(revision)s' versie van '%(database)s'"
 
-#: ../gramps/gui/dbman.py:686
+#: ../gramps/gui/dbman.py:687
 msgid "Removing this version will prevent you from extracting it in the future."
 msgstr ""
 "Door deze versie te verwijderen, kunt u het in de toekomst niet meer ophalen."
 
-#: ../gramps/gui/dbman.py:688
+#: ../gramps/gui/dbman.py:689
 msgid "Remove version"
 msgstr "Versie verwijderen"
 
-#: ../gramps/gui/dbman.py:743
+#: ../gramps/gui/dbman.py:744
 msgid "Deletion failed"
 msgstr "Verwijderen mislukt"
 
-#: ../gramps/gui/dbman.py:744
+#: ../gramps/gui/dbman.py:745
 #, python-format
 msgid ""
 "An attempt to delete a version failed with the following message:\n"
@@ -11473,59 +11468,58 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dbman.py:761
+#: ../gramps/gui/dbman.py:762
 #, python-format
 msgid "Convert the '%s' database?"
 msgstr "Het gegevensbestand '%s' omzetten?"
 
-#: ../gramps/gui/dbman.py:762
+#: ../gramps/gui/dbman.py:763
 msgid "You wish to convert this database into the new DB-API format?"
 msgstr ""
+"U wenst het gegevensbestand naar het nieuwe 'DB-API'-formaat om te zetten?"
 
-#: ../gramps/gui/dbman.py:763
+#: ../gramps/gui/dbman.py:764
 msgid "Convert"
 msgstr "Omzetten"
 
-#: ../gramps/gui/dbman.py:773
+#: ../gramps/gui/dbman.py:774
 #, python-format
 msgid "Opening the '%s' database"
 msgstr "Gegevensbestand '%s' openen"
 
-#: ../gramps/gui/dbman.py:774
-#, fuzzy
+#: ../gramps/gui/dbman.py:775
 msgid "An attempt to convert the database failed. Perhaps it needs updating."
 msgstr ""
-"Een poging om de gegevens te archiveren mislukte met de volgende boodschap:\n"
-"\n"
-"%s"
+"Een poging om het gegevensbestand om te zetten mislukte. Mogelijk moet het "
+"bestand vernieuwd worden."
 
-#: ../gramps/gui/dbman.py:785 ../gramps/gui/dbman.py:810
+#: ../gramps/gui/dbman.py:786 ../gramps/gui/dbman.py:811
 #, python-format
 msgid "Converting the '%s' database"
 msgstr "Gegevensbestand '%s' wordt omgezet"
 
-#: ../gramps/gui/dbman.py:786
+#: ../gramps/gui/dbman.py:787
 msgid "An attempt to export the database failed."
-msgstr ""
+msgstr "Poging om het gegevensbestand te exporteren mislukte."
 
-#: ../gramps/gui/dbman.py:790
+#: ../gramps/gui/dbman.py:791
 msgid "Converting data..."
 msgstr "Gegevens omzetten..."
 
-#: ../gramps/gui/dbman.py:795 ../gramps/gui/dbman.py:798
+#: ../gramps/gui/dbman.py:796 ../gramps/gui/dbman.py:799
 #, python-format
 msgid "(Converted #%d)"
 msgstr "(Omgezet #%d)"
 
-#: ../gramps/gui/dbman.py:811
+#: ../gramps/gui/dbman.py:812
 msgid "An attempt to import into the database failed."
-msgstr ""
+msgstr "Poging om te importeren naar het gegevensbestand mislukte."
 
-#: ../gramps/gui/dbman.py:868
+#: ../gramps/gui/dbman.py:869
 msgid "Repair Family Tree?"
 msgstr "Stamboom herstellen?"
 
-#: ../gramps/gui/dbman.py:869
+#: ../gramps/gui/dbman.py:870
 #, python-format
 msgid ""
 "If you click %(bold_start)sProceed%(bold_end)s, Gramps will attempt to "
@@ -11575,31 +11569,31 @@ msgstr ""
 "hersteld worden. Wanneer dit het geval is, kunt u de herstelknop uitschakelen "
 "door het bestand %(recover_file)s  uit de stamboommap te verwijderen."
 
-#: ../gramps/gui/dbman.py:900
+#: ../gramps/gui/dbman.py:901
 msgid "Proceed, I have taken a backup"
 msgstr "U kunt verder gaan, er is een reservekopie genomen"
 
-#: ../gramps/gui/dbman.py:901
+#: ../gramps/gui/dbman.py:902
 msgid "Stop"
 msgstr "Stop"
 
-#: ../gramps/gui/dbman.py:924
+#: ../gramps/gui/dbman.py:925
 msgid "Rebuilding database from backup files"
 msgstr "Het gegevensbestand wordt vanuit de reservekopie opnieuw opgebouwd"
 
-#: ../gramps/gui/dbman.py:929
+#: ../gramps/gui/dbman.py:930
 msgid "Error restoring backup data"
 msgstr "Fout bij het terugzetten van de reservekopie"
 
-#: ../gramps/gui/dbman.py:968
+#: ../gramps/gui/dbman.py:969
 msgid "Could not create Family Tree"
 msgstr "Kon geen stamboom aanmaken"
 
-#: ../gramps/gui/dbman.py:1096
+#: ../gramps/gui/dbman.py:1097
 msgid "Retrieve failed"
 msgstr "Ophalen mislukte"
 
-#: ../gramps/gui/dbman.py:1097
+#: ../gramps/gui/dbman.py:1098
 #, python-format
 msgid ""
 "An attempt to retrieve the data failed with the following message:\n"
@@ -11610,11 +11604,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dbman.py:1135 ../gramps/gui/dbman.py:1161
+#: ../gramps/gui/dbman.py:1136 ../gramps/gui/dbman.py:1162
 msgid "Archiving failed"
 msgstr "Archieveren is mislukt"
 
-#: ../gramps/gui/dbman.py:1136
+#: ../gramps/gui/dbman.py:1137
 #, python-format
 msgid ""
 "An attempt to create the archive failed with the following message:\n"
@@ -11625,15 +11619,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dbman.py:1141
+#: ../gramps/gui/dbman.py:1142
 msgid "Creating data to be archived..."
 msgstr "Gegevens worden aangemaakt om te archiveren..."
 
-#: ../gramps/gui/dbman.py:1150
+#: ../gramps/gui/dbman.py:1151
 msgid "Saving archive..."
 msgstr "Archief wordt opgeslagen..."
 
-#: ../gramps/gui/dbman.py:1162
+#: ../gramps/gui/dbman.py:1163
 #, python-format
 msgid ""
 "An attempt to archive the data failed with the following message:\n"
@@ -11694,7 +11688,7 @@ msgstr "Geen actief media-object"
 msgid "No active note"
 msgstr "Geen actieve opmerking"
 
-#: ../gramps/gui/displaystate.py:580
+#: ../gramps/gui/displaystate.py:591
 msgid "No active object"
 msgstr "Geen actief voorwerp"
 
@@ -11837,7 +11831,7 @@ msgstr "_Kenmerken"
 #: ../gramps/gui/selectors/selectsource.py:72
 #: ../gramps/gui/views/bookmarks.py:240
 #: ../gramps/gui/views/navigationview.py:357
-#: ../gramps/plugins/gramplet/locations.py:87
+#: ../gramps/plugins/gramplet/locations.py:88
 #: ../gramps/plugins/lib/libpersonview.py:99
 #: ../gramps/plugins/lib/libplaceview.py:85
 #: ../gramps/plugins/tool/eventcmp.py:251
@@ -12116,7 +12110,7 @@ msgstr "Ga_lerij"
 #. Translators: _View means "to look at this"
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:140
 msgid "verb:look at this|_View"
-msgstr ""
+msgstr "Kijken naar"
 
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:145
 #: ../gramps/plugins/view/mediaview.py:215
@@ -12384,7 +12378,7 @@ msgstr "Alternatieve namen"
 
 #: ../gramps/gui/editors/displaytabs/placerefembedlist.py:69
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:108
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1282
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1299
 msgid "Enclosed By"
 msgstr "Besloten in"
 
@@ -12607,17 +12601,17 @@ msgstr ""
 #: ../gramps/gui/editors/editcitation.py:315
 #, python-format
 msgid "Add Citation (%s)"
-msgstr "Citaat (%s) toevoegen"
+msgstr "Citaat toevoegen (%s)"
 
 #: ../gramps/gui/editors/editcitation.py:321
 #, python-format
 msgid "Edit Citation (%s)"
-msgstr "Citaat (%s) bewerken"
+msgstr "Citaat bewerken (%s)"
 
 #: ../gramps/gui/editors/editcitation.py:356
 #, python-format
 msgid "Delete Citation (%s)"
-msgstr "Citaat (%s) verwijderen"
+msgstr "Citaat verwijderen (%s)"
 
 #: ../gramps/gui/editors/editdate.py:76 ../gramps/gui/editors/editdate.py:85
 msgid "Regular"
@@ -12671,7 +12665,7 @@ msgstr "Datumselectie"
 #: ../gramps/gui/editors/editdate.py:268
 #, python-brace-format
 msgid "Correct the date or switch from `{cur_mode}' to `{text_mode}'"
-msgstr "Datum van `{cur_mode}' naar `{text_mode}' verbeteren "
+msgstr "Datum verbeteren van `{cur_mode}' naar `{text_mode}'"
 
 #: ../gramps/gui/editors/editevent.py:64
 #, fuzzy
@@ -12859,25 +12853,25 @@ msgstr "Kinderen"
 msgid "Edit child"
 msgstr "Kind bewerken"
 
-#: ../gramps/gui/editors/editfamily.py:150
+#: ../gramps/gui/editors/editfamily.py:149
 msgid "Add an existing child"
 msgstr "Een bestaand kind toevoegen"
 
-#: ../gramps/gui/editors/editfamily.py:151
+#: ../gramps/gui/editors/editfamily.py:150
 msgid "Edit relationship"
 msgstr "Verwantschap bewerken"
 
-#: ../gramps/gui/editors/editfamily.py:219
-#: ../gramps/gui/editors/editfamily.py:234
+#: ../gramps/gui/editors/editfamily.py:217
+#: ../gramps/gui/editors/editfamily.py:232
 #: ../gramps/plugins/view/relview.py:1569
 msgid "Select Child"
 msgstr "Kind selecteren"
 
-#: ../gramps/gui/editors/editfamily.py:367
+#: ../gramps/gui/editors/editfamily.py:365
 msgid "Adding parents to a person"
 msgstr "Ouders aan een persoon toevoegen"
 
-#: ../gramps/gui/editors/editfamily.py:368
+#: ../gramps/gui/editors/editfamily.py:366
 msgid ""
 "It is possible to accidentally create multiple families with the same "
 "parents. To help avoid this problem, only the buttons to select parents are "
@@ -12889,11 +12883,11 @@ msgstr ""
 "selecteren beschikbaar wanneer een nieuw gezin wordt aangemaakt. De andere "
 "invulvelden zullen beschikbaar zijn wanneer u probeert een ouder te kiezen."
 
-#: ../gramps/gui/editors/editfamily.py:463
+#: ../gramps/gui/editors/editfamily.py:461
 msgid "Family has changed"
 msgstr "Gezin werd gewijzigd"
 
-#: ../gramps/gui/editors/editfamily.py:464
+#: ../gramps/gui/editors/editfamily.py:462
 #, python-format
 msgid ""
 "The %(object)s you are editing has changed outside this editor. This can be "
@@ -12910,60 +12904,60 @@ msgstr ""
 "gegevens nu vernieuwd. Sommige gemaakte aanpassingen kunnen verloren zijn "
 "gegaan."
 
-#: ../gramps/gui/editors/editfamily.py:469
+#: ../gramps/gui/editors/editfamily.py:467
 #: ../gramps/plugins/importer/importcsv.py:210
 #: ../gramps/plugins/view/familyview.py:260
 msgid "family"
 msgstr "gezin"
 
-#: ../gramps/gui/editors/editfamily.py:500
-#: ../gramps/gui/editors/editfamily.py:503
+#: ../gramps/gui/editors/editfamily.py:498
+#: ../gramps/gui/editors/editfamily.py:501
 msgid "New Family"
 msgstr "Nieuw gezin"
 
-#: ../gramps/gui/editors/editfamily.py:507
-#: ../gramps/gui/editors/editfamily.py:1136
+#: ../gramps/gui/editors/editfamily.py:505
+#: ../gramps/gui/editors/editfamily.py:1134
 #: ../gramps/plugins/view/geofamily.py:422
 msgid "Edit Family"
 msgstr "Gezin bewerken"
 
-#: ../gramps/gui/editors/editfamily.py:540
+#: ../gramps/gui/editors/editfamily.py:538
 msgid "Select a person as the mother"
 msgstr "Een persoon als moeder selecteren"
 
-#: ../gramps/gui/editors/editfamily.py:541
+#: ../gramps/gui/editors/editfamily.py:539
 msgid "Add a new person as the mother"
 msgstr "Een nieuwe persoon als moeder toevoegen"
 
-#: ../gramps/gui/editors/editfamily.py:542
+#: ../gramps/gui/editors/editfamily.py:540
 msgid "Remove the person as the mother"
 msgstr "De persoon als moeder verwijderen"
 
-#: ../gramps/gui/editors/editfamily.py:555
+#: ../gramps/gui/editors/editfamily.py:553
 msgid "Select a person as the father"
 msgstr "Een persoon als vader selecteren"
 
-#: ../gramps/gui/editors/editfamily.py:556
+#: ../gramps/gui/editors/editfamily.py:554
 msgid "Add a new person as the father"
 msgstr "Een nieuwe persoon als vader toevoegen"
 
-#: ../gramps/gui/editors/editfamily.py:557
+#: ../gramps/gui/editors/editfamily.py:555
 msgid "Remove the person as the father"
 msgstr "Persoon als vader verwijderen"
 
-#: ../gramps/gui/editors/editfamily.py:838
+#: ../gramps/gui/editors/editfamily.py:836
 msgid "Select Mother"
 msgstr "Moeder selecteren"
 
-#: ../gramps/gui/editors/editfamily.py:883
+#: ../gramps/gui/editors/editfamily.py:881
 msgid "Select Father"
 msgstr "Vader selecteren"
 
-#: ../gramps/gui/editors/editfamily.py:907
+#: ../gramps/gui/editors/editfamily.py:905
 msgid "Duplicate Family"
 msgstr "Dubbel gezin"
 
-#: ../gramps/gui/editors/editfamily.py:908
+#: ../gramps/gui/editors/editfamily.py:906
 msgid ""
 "A family with these parents already exists in the database. If you save, you "
 "will create a duplicate family. It is recommended that you cancel the editing "
@@ -12973,44 +12967,44 @@ msgstr ""
 "gegevens opslaat zal een duplicaatgezin worden aangemaakt. Het is aangeraden "
 "dat u deze aanpassing stopt in dit venster en een bestaand gezin kiest"
 
-#: ../gramps/gui/editors/editfamily.py:956
+#: ../gramps/gui/editors/editfamily.py:954
 #, python-format
 msgid "Edit %s"
 msgstr "Bewerken van %s"
 
-#: ../gramps/gui/editors/editfamily.py:1065
+#: ../gramps/gui/editors/editfamily.py:1063
 msgid "A father cannot be his own child"
 msgstr "Een vader kan niet zijn eigen kind zijn"
 
-#: ../gramps/gui/editors/editfamily.py:1066
+#: ../gramps/gui/editors/editfamily.py:1064
 #, python-format
 msgid "%s is listed as both the father and child of the family."
 msgstr "%s is zowel vader als kind van dit gezin."
 
-#: ../gramps/gui/editors/editfamily.py:1076
+#: ../gramps/gui/editors/editfamily.py:1074
 msgid "A mother cannot be her own child"
 msgstr "Een moeder kan niet haar eigen kind zijn"
 
-#: ../gramps/gui/editors/editfamily.py:1077
+#: ../gramps/gui/editors/editfamily.py:1075
 #, python-format
 msgid "%s is listed as both the mother and child of the family."
 msgstr "%s is zowel moeder als kind van dit gezin."
 
-#: ../gramps/gui/editors/editfamily.py:1085
+#: ../gramps/gui/editors/editfamily.py:1083
 msgid "Cannot save family"
 msgstr "Kan gezin niet opslaan"
 
-#: ../gramps/gui/editors/editfamily.py:1086
+#: ../gramps/gui/editors/editfamily.py:1084
 msgid "No data exists for this family. Please enter data or cancel the edit."
 msgstr ""
 "Er bestaan geen gegevens voor dit gezin. Voer gegevens in of verwerp de "
 "aanpassingen."
 
-#: ../gramps/gui/editors/editfamily.py:1094
+#: ../gramps/gui/editors/editfamily.py:1092
 msgid "Cannot save family. ID already exists."
 msgstr "Kan gezin niet opslaan. ID bestaat reeds."
 
-#: ../gramps/gui/editors/editfamily.py:1095
+#: ../gramps/gui/editors/editfamily.py:1093
 #: ../gramps/gui/editors/editnote.py:323
 #: ../gramps/gui/editors/editreference.py:294
 #, python-format
@@ -13023,7 +13017,7 @@ msgstr ""
 "gebruiken. Deze waarde is al in gebruik. Geef een andere ID op of laat het "
 "invoerveld leeg zodat de volgende bruikbare ID kan gebruikt worden."
 
-#: ../gramps/gui/editors/editfamily.py:1110
+#: ../gramps/gui/editors/editfamily.py:1108
 msgid "Add Family"
 msgstr "Gezin toevoegen"
 
@@ -13117,7 +13111,7 @@ msgstr "Kan media-object niet opslaan. ID bestaat al."
 #: ../gramps/gui/editors/editmedia.py:314
 msgid "There is no media matching the current path value!"
 msgstr ""
-"Er werden geen media gevonden die overeen komen met de actuele padwaarde."
+"Er werden geen media gevonden die overeen komen met de actuele padwaarde!"
 
 #: ../gramps/gui/editors/editmedia.py:315
 #, python-format
@@ -13132,13 +13126,13 @@ msgstr ""
 #: ../gramps/gui/editors/editmediaref.py:523
 #, python-format
 msgid "Add Media Object (%s)"
-msgstr "Media-object (%s) toevoegen"
+msgstr "Media-object toevoegen (%s)"
 
 #: ../gramps/gui/editors/editmedia.py:333
 #: ../gramps/gui/editors/editmediaref.py:517
 #, python-format
 msgid "Edit Media Object (%s)"
-msgstr "Media-object (%s) bewerken"
+msgstr "Media-object bewerken (%s)"
 
 #: ../gramps/gui/editors/editmedia.py:370
 msgid "Remove Media Object"
@@ -13275,7 +13269,7 @@ msgstr "Opmerking toevoegen"
 #: ../gramps/gui/editors/editnote.py:355
 #, python-format
 msgid "Delete Note (%s)"
-msgstr "Opmerking (%s) verwijderen"
+msgstr "Opmerking verwijderen (%s)"
 
 # naam filteren of filternaam
 #: ../gramps/gui/editors/editperson.py:157
@@ -13350,14 +13344,14 @@ msgstr "Kan persoon niet opslaan. ID bestaat reeds."
 #: ../gramps/gui/editors/editperson.py:864
 #, python-format
 msgid "Add Person (%s)"
-msgstr "Persoon (%s) toevoegen"
+msgstr "Persoon toevoegen (%s)"
 
 #: ../gramps/gui/editors/editperson.py:870 ../gramps/plugins/view/relview.py:570
 #: ../gramps/plugins/view/relview.py:992 ../gramps/plugins/view/relview.py:1049
 #: ../gramps/plugins/view/relview.py:1173 ../gramps/plugins/view/relview.py:1278
 #, python-format
 msgid "Edit Person (%s)"
-msgstr "Persoon (%s) bewerken"
+msgstr "Persoon bewerken (%s)"
 
 #: ../gramps/gui/editors/editperson.py:1098
 msgid "Unknown gender specified"
@@ -13473,17 +13467,17 @@ msgstr "Kan locatie niet opslaan. ID bestaat reeds."
 #: ../gramps/gui/editors/editplace.py:310
 #, python-format
 msgid "Add Place (%s)"
-msgstr "Locatie (%s) toevoegen"
+msgstr "Locatie toevoegen (%s)"
 
 #: ../gramps/gui/editors/editplace.py:315
 #, python-format
 msgid "Edit Place (%s)"
-msgstr "Locatie (%s) bewerken"
+msgstr "Locatie bewerken (%s)"
 
 #: ../gramps/gui/editors/editplace.py:340
 #, python-format
 msgid "Delete Place (%s)"
-msgstr "Locatie (%s) verwijderen"
+msgstr "Locatie verwijderen (%s)"
 
 #: ../gramps/gui/editors/editplacename.py:49
 #, fuzzy
@@ -13591,17 +13585,17 @@ msgstr ""
 #: ../gramps/gui/editors/editrepository.py:203
 #, python-format
 msgid "Add Repository (%s)"
-msgstr "Bibliotheek (%s) toevoegen"
+msgstr "Bibliotheek toevoegen (%s)"
 
 #: ../gramps/gui/editors/editrepository.py:208
 #, python-format
 msgid "Edit Repository (%s)"
-msgstr "Bibliotheek (%s) bewerken"
+msgstr "Bibliotheek bewerken (%s)"
 
 #: ../gramps/gui/editors/editrepository.py:221
 #, python-format
 msgid "Delete Repository (%s)"
-msgstr "Bibliotheek (%s) verwijderen"
+msgstr "Bibliotheek verwijderen (%s)"
 
 #: ../gramps/gui/editors/editsource.py:64
 #, fuzzy
@@ -13635,18 +13629,18 @@ msgstr "Kan bron niet opslaan. ID bestaat reeds."
 #: ../gramps/gui/editors/editsource.py:223
 #, python-format
 msgid "Add Source (%s)"
-msgstr "Bron (%s) toevoegen"
+msgstr "Bron toevoegen (%s)"
 
 # Bronnen vermelden/citeren
 #: ../gramps/gui/editors/editsource.py:228
 #, python-format
 msgid "Edit Source (%s)"
-msgstr "Bron (%s) bewerken"
+msgstr "Bron bewerken (%s)"
 
 #: ../gramps/gui/editors/editsource.py:243
 #, python-format
 msgid "Delete Source (%s)"
-msgstr "Bron (%s) verwijderen"
+msgstr "Bron verwijderen (%s)"
 
 #: ../gramps/gui/editors/edittaglist.py:48
 #, fuzzy
@@ -13659,14 +13653,14 @@ msgid "Tag selection"
 msgstr "Tagselectie"
 
 #. pylint: disable-msg=E1101
-#: ../gramps/gui/editors/edittaglist.py:99 ../gramps/gui/views/bookmarks.py:227
+#: ../gramps/gui/editors/edittaglist.py:100 ../gramps/gui/views/bookmarks.py:227
 #: ../gramps/gui/views/tags.py:387 ../gramps/gui/views/tags.py:611
 #: ../gramps/gui/views/tags.py:627
 #, python-format
 msgid "%(title)s - Gramps"
 msgstr "%(title)s - Gramps"
 
-#: ../gramps/gui/editors/edittaglist.py:99
+#: ../gramps/gui/editors/edittaglist.py:100
 msgid "Edit Tags"
 msgstr "Tags bewerken"
 
@@ -13689,7 +13683,7 @@ msgstr "Tag"
 #: ../gramps/gui/editors/edittaglist.py:116
 #: ../gramps/gui/glade/addmedia.glade:55
 #: ../gramps/gui/glade/baseselector.glade:56
-#: ../gramps/gui/glade/clipboard.glade:23 ../gramps/gui/glade/dbman.glade:157
+#: ../gramps/gui/glade/clipboard.glade:21 ../gramps/gui/glade/dbman.glade:157
 #: ../gramps/gui/glade/editaddress.glade:55
 #: ../gramps/gui/glade/editattribute.glade:54
 #: ../gramps/gui/glade/editchildref.glade:58
@@ -13918,15 +13912,15 @@ msgstr "Opmerking"
 #: ../gramps/plugins/drawreport/calendarreport.py:472
 #: ../gramps/plugins/drawreport/statisticschart.py:988
 #: ../gramps/plugins/drawreport/timeline.py:417
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:989
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1003
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1017
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1031
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1045
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1059
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1073
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1087
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1101
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1006
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1020
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1034
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1048
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1062
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1076
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1090
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1104
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1118
 #: ../gramps/plugins/graph/gvrelgraph.py:669
 #: ../gramps/plugins/quickview/quickview.gpr.py:127
 #: ../gramps/plugins/textreport/birthdayreport.py:422
@@ -14077,7 +14071,7 @@ msgstr "Zoek"
 
 # zie ook uncleared.
 # is dit goed?
-#: ../gramps/gui/filters/_searchbar.py:57 ../gramps/gui/glade/clipboard.glade:56
+#: ../gramps/gui/filters/_searchbar.py:57 ../gramps/gui/glade/clipboard.glade:54
 #: ../gramps/gui/undohistory.py:88
 msgid "_Clear"
 msgstr "Gewist"
@@ -14223,52 +14217,52 @@ msgstr "Omzetten naar relatief pad"
 msgid "Show all"
 msgstr "Alles tonen"
 
-#: ../gramps/gui/glade/book.glade:54
+#: ../gramps/gui/glade/book.glade:51
 msgid "Book _name:"
 msgstr "Boek_naam:"
 
-#: ../gramps/gui/glade/book.glade:93
-#: ../gramps/gui/plug/report/_bookdialog.py:621
+#: ../gramps/gui/glade/book.glade:90
+#: ../gramps/gui/plug/report/_bookdialog.py:623
 msgid "Clear the book"
 msgstr "Het boek wissen"
 
-#: ../gramps/gui/glade/book.glade:115
+#: ../gramps/gui/glade/book.glade:112
 msgid "Save current set of configured selections"
 msgstr "De huidige verzameling geconfigureerde selecties opslaan"
 
-#: ../gramps/gui/glade/book.glade:138
+#: ../gramps/gui/glade/book.glade:135
 msgid "Open previously created book"
 msgstr "Eerder aangemaakte boeken openen"
 
-#: ../gramps/gui/glade/book.glade:160
+#: ../gramps/gui/glade/book.glade:157
 msgid "Manage previously created books"
 msgstr "Eerder aangemaakte boeken beheren"
 
-#: ../gramps/gui/glade/book.glade:330
+#: ../gramps/gui/glade/book.glade:327
 msgid "Add an item to the book"
 msgstr "Een item aan het boek toevoegen"
 
-#: ../gramps/gui/glade/book.glade:353
+#: ../gramps/gui/glade/book.glade:350
 msgid "Remove currently selected item from the book"
 msgstr "Het geselecteerde item uit het boek verwijderen"
 
-#: ../gramps/gui/glade/book.glade:375
+#: ../gramps/gui/glade/book.glade:372
 msgid "Move current selection one step up in the book"
 msgstr "Huidige selectie naar boven verplaatsen in de lijst"
 
-#: ../gramps/gui/glade/book.glade:397
+#: ../gramps/gui/glade/book.glade:394
 msgid "Move current selection one step down in the book"
 msgstr "Huidige selectie naar beneden verplaatsen in de lijst"
 
-#: ../gramps/gui/glade/book.glade:419
+#: ../gramps/gui/glade/book.glade:416
 msgid "Configure currently selected item"
 msgstr "Het geselecteerde item configureren"
 
-#: ../gramps/gui/glade/book.glade:527 ../gramps/gui/glade/dbman.glade:272
+#: ../gramps/gui/glade/book.glade:524 ../gramps/gui/glade/dbman.glade:272
 msgid "_Delete"
 msgstr "Verwijderen"
 
-#: ../gramps/gui/glade/clipboard.glade:40
+#: ../gramps/gui/glade/clipboard.glade:38
 msgid "Clear _All"
 msgstr "_Alles wissen"
 
@@ -14442,7 +14436,7 @@ msgstr "Sluiten _zonder opslaan"
 
 #. widget
 #: ../gramps/gui/glade/dialog.glade:856
-#: ../gramps/gui/plug/report/_bookdialog.py:622
+#: ../gramps/gui/plug/report/_bookdialog.py:624
 #: ../gramps/gui/views/listview.py:1011
 #: ../gramps/gui/widgets/grampletpane.py:578
 #: ../gramps/plugins/tool/eventcmp.py:398
@@ -16492,7 +16486,7 @@ msgid ""
 msgstr ""
 "Uw versie van gi (gnome-introspection) is mogelijk verouderd. Om Gramps op te "
 "kunnen starten dient u een versie te gebruiken die over de functie "
-"'require_version' beschikt."
+"'require_version' beschikt"
 
 #: ../gramps/gui/grampsgui.py:74
 #, python-format
@@ -16559,10 +16553,10 @@ msgstr "Let op dit is nog onstabiele code!"
 #: ../gramps/gui/grampsgui.py:146
 #, python-format
 msgid "This Gramps ('%s') is a development release.\n"
-msgstr ""
+msgstr "Deze grampsversie ('%s') is een ontwikkelingsuitgave.\n"
 
 #: ../gramps/gui/grampsgui.py:148
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "This version is not meant for normal usage. Use at your own risk.\n"
 "\n"
@@ -16577,8 +16571,8 @@ msgid ""
 "with this version, and make sure to export your data to XML every now and "
 "then."
 msgstr ""
-"Deze Gramps-versie ('master') is een ontwikkelingsversie. Deze versie is niet "
-"bedoeld voor normaal gebruik. Gebruik deze versie dus op eigen risico.\n"
+"Deze versie is niet bedoeld voor normaal gebruik. Gebruik deze versie dus op "
+"eigen risico.\n"
 "\n"
 "Deze versie kan:\n"
 "1) anders werken dan u misschien zou verwachten.\n"
@@ -16588,8 +16582,8 @@ msgstr ""
 "5) uw gegevens opslaan in een bestandsformaat dat niet werkt in de officiële "
 "versie.\n"
 "\n"
-"%(bold_start)sBACKUP%(bold_end)s uw gegevensbestand voor u deze versie "
-"gebruikt en maak af en toe een XML-export van uw gegevens."
+"%(bold_start)sMAAK EEN RESERVEKOPIE%(bold_end)s uw gegevensbestand voor u "
+"deze versie gebruikt en maak af en toe een XML-export van uw gegevens."
 
 #: ../gramps/gui/grampsgui.py:178
 msgid "Gramps detected an incomplete GTK installation"
@@ -16638,7 +16632,7 @@ msgstr ""
 
 #: ../gramps/gui/grampsgui.py:365
 msgid "Gramps terminated because of no DISPLAY"
-msgstr ""
+msgstr "Gramps is gestopt omdat er geen SCHERM is"
 
 #: ../gramps/gui/logger/_errorreportassistant.py:86
 msgid "Error Report Assistant"
@@ -16649,7 +16643,6 @@ msgid "Report a bug"
 msgstr "Een fout rapporteren"
 
 #: ../gramps/gui/logger/_errorreportassistant.py:259
-#, fuzzy
 msgid ""
 "This is the Bug Reporting Assistant. It will help you to make a bug report to "
 "the Gramps developers that will be as detailed as possible.\n"
@@ -16716,7 +16709,6 @@ msgstr ""
 "Deze informatie over uw systeem helpt de ontwikkelaars de fout te corrigeren."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:433
-#, fuzzy
 msgid ""
 "Please provide as much information as you can about what you were doing when "
 "the error occurred."
@@ -16729,13 +16721,12 @@ msgid "Further Information"
 msgstr "Verdere informatie"
 
 #: ../gramps/gui/logger/_errorreportassistant.py:477
-#, fuzzy
 msgid ""
 "This is your opportunity to describe what you were doing when the error "
 "occurred."
 msgstr ""
-"U heeft nu de mogelijkheid om te omschrijven wat u juist deed wanneer de "
-"foutzich voordeed."
+"U heeft nu de mogelijkheid om te omschrijven wat u juist deed wanneer de fout "
+"zich voordeed."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:504
 msgid ""
@@ -16913,8 +16904,8 @@ msgstr "Alternatieve namen"
 
 # Gebeuren (korter)
 #: ../gramps/gui/merge/mergeperson.py:203
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:457
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:471
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:474
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:488
 #: ../gramps/plugins/quickview/filterbyname.py:97
 #: ../gramps/plugins/quickview/filterbyname.py:122
 #: ../gramps/plugins/textreport/tagreport.py:320
@@ -16931,7 +16922,7 @@ msgstr "Gebeurtenissen"
 
 #. Go over parents and build their menu
 #. don't show rest
-#: ../gramps/gui/merge/mergeperson.py:218 ../gramps/gui/widgets/fanchart.py:1724
+#: ../gramps/gui/merge/mergeperson.py:218 ../gramps/gui/widgets/fanchart.py:1679
 #: ../gramps/plugins/quickview/all_relations.py:305
 #: ../gramps/plugins/tool/notrelated.py:126
 #: ../gramps/plugins/view/pedigreeview.py:1776
@@ -16953,7 +16944,7 @@ msgid "No parents found"
 msgstr "Geen ouders gevonden"
 
 #. Go over spouses and build their menu
-#: ../gramps/gui/merge/mergeperson.py:229 ../gramps/gui/widgets/fanchart.py:1614
+#: ../gramps/gui/merge/mergeperson.py:229 ../gramps/gui/widgets/fanchart.py:1551
 #: ../gramps/plugins/textreport/kinshipreport.py:132
 #: ../gramps/plugins/view/pedigreeview.py:1663
 msgid "Spouses"
@@ -17068,7 +17059,7 @@ msgid "Save As"
 msgstr "Opslaan als"
 
 #: ../gramps/gui/plug/_guioptions.py:1730 ../gramps/gui/plug/_windows.py:434
-#: ../gramps/gui/plug/report/_bookdialog.py:623
+#: ../gramps/gui/plug/report/_bookdialog.py:625
 #: ../gramps/gui/plug/report/_fileentry.py:66
 msgid "_Open"
 msgstr "Openen"
@@ -17270,40 +17261,40 @@ msgid "No addons were installed."
 msgstr "Er werden geen uitbreidingen geïnstalleerd."
 
 #. set up ManagedWindow
-#: ../gramps/gui/plug/export/_exportassistant.py:116
+#: ../gramps/gui/plug/export/_exportassistant.py:119
 msgid "Export Assistant"
 msgstr "Export Assistent"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:180
+#: ../gramps/gui/plug/export/_exportassistant.py:183
 msgid "Saving your data"
 msgstr "Uw gegevens opslaan"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:226
+#: ../gramps/gui/plug/export/_exportassistant.py:229
 msgid "Choose the output format"
 msgstr "Kies het opslagformaat"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:240
+#: ../gramps/gui/plug/export/_exportassistant.py:243
 msgid "Export options"
 msgstr "Exportopties"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:310
+#: ../gramps/gui/plug/export/_exportassistant.py:314
 msgid "Select save file"
 msgstr "Opslagbestand selecteren"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:354
+#: ../gramps/gui/plug/export/_exportassistant.py:358
 #: ../gramps/plugins/tool/mediamanager.py:103
 msgid "Final confirmation"
 msgstr "Een laatste bevestiging"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:370
+#: ../gramps/gui/plug/export/_exportassistant.py:374
 msgid "Please wait while your data is selected and exported"
 msgstr "Wacht tot uw geselecteerde gegevens zijn geëxporteerd"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:382
+#: ../gramps/gui/plug/export/_exportassistant.py:386
 msgid "Summary"
 msgstr "Samenvatting"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:449
+#: ../gramps/gui/plug/export/_exportassistant.py:454
 #, python-format
 msgid ""
 "The data will be exported as follows:\n"
@@ -17319,7 +17310,7 @@ msgstr ""
 "Klik op Volgende om door te gaan, Annuleren om te af te breken, of Terug om "
 "uw instellingen te wijzigen"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:462
+#: ../gramps/gui/plug/export/_exportassistant.py:467
 #, python-format
 msgid ""
 "The data will be saved as follows:\n"
@@ -17339,7 +17330,7 @@ msgstr ""
 "Klik op Volgende om door te gaan, Annuleren om af te breken, of Terug om uw "
 "instellingen te wijzigen"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:472
+#: ../gramps/gui/plug/export/_exportassistant.py:477
 msgid ""
 "The selected file and folder to save to cannot be created or found.\n"
 "\n"
@@ -17350,11 +17341,11 @@ msgstr ""
 "\n"
 "Druk Terug en kies een geldige bestandsnaam."
 
-#: ../gramps/gui/plug/export/_exportassistant.py:498
+#: ../gramps/gui/plug/export/_exportassistant.py:503
 msgid "Your data has been saved"
 msgstr "Uw gegevens zijn opgeslagen"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:500
+#: ../gramps/gui/plug/export/_exportassistant.py:505
 msgid ""
 "The copy of your data has been successfully saved. You may press Close button "
 "now to continue.\n"
@@ -17372,16 +17363,16 @@ msgstr ""
 "in de kopie die u zojuist heeft opgeslagen. "
 
 #. add test, what is dir
-#: ../gramps/gui/plug/export/_exportassistant.py:508
+#: ../gramps/gui/plug/export/_exportassistant.py:513
 #, python-format
 msgid "Filename: %s"
 msgstr "Bestandsnaam: %s"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:510
+#: ../gramps/gui/plug/export/_exportassistant.py:515
 msgid "Saving failed"
 msgstr "Het opslaan is mislukt"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:512
+#: ../gramps/gui/plug/export/_exportassistant.py:517
 msgid ""
 "There was an error while saving your data. You may try starting the export "
 "again.\n"
@@ -17395,7 +17386,7 @@ msgstr ""
 "Merk op: uw huidige geopend gegevensbestand is veilig. Het was slechts een "
 "kopie van uw gegevens die niet kon worden opgeslagen."
 
-#: ../gramps/gui/plug/export/_exportassistant.py:533
+#: ../gramps/gui/plug/export/_exportassistant.py:538
 msgid ""
 "Under normal circumstances, Gramps does not require you to directly save your "
 "changes. All changes you make are immediately saved to the database.\n"
@@ -17420,7 +17411,7 @@ msgstr ""
 "Indien u tijdens dit proces op uw beslissing wilt terugkomen kunt u altijd op "
 "de knop Annuleren drukken. Uw huidig gegevensbestand zal intact blijven."
 
-#: ../gramps/gui/plug/export/_exportassistant.py:602
+#: ../gramps/gui/plug/export/_exportassistant.py:607
 msgid "Error exporting your Family Tree"
 msgstr "Fout bij het exporteren van uw stamboom"
 
@@ -17433,144 +17424,143 @@ msgstr "Gegevens voor voorbeeld selecteren"
 msgid "Selecting..."
 msgstr "Selecteren..."
 
-#: ../gramps/gui/plug/export/_exportoptions.py:160
+#: ../gramps/gui/plug/export/_exportoptions.py:161
 msgid "Unfiltered Family Tree:"
 msgstr "Ongefilterde stamboom:"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/gui/plug/export/_exportoptions.py:164
-#: ../gramps/gui/plug/export/_exportoptions.py:270
-#: ../gramps/gui/plug/export/_exportoptions.py:565
+#: ../gramps/gui/plug/export/_exportoptions.py:165
+#: ../gramps/gui/plug/export/_exportoptions.py:272
+#: ../gramps/gui/plug/export/_exportoptions.py:567
 #, python-brace-format
 msgid "{number_of} Person"
 msgid_plural "{number_of} People"
 msgstr[0] "{number_of} Persoon"
 msgstr[1] "{number_of} Personen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:167
+#: ../gramps/gui/plug/export/_exportoptions.py:168
 msgid "Click to see preview of unfiltered data"
 msgstr "De ongefilterde gegeven tonen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:179
+#: ../gramps/gui/plug/export/_exportoptions.py:180
 msgid "_Do not include records marked private"
 msgstr "Gegevens met de aanduiding privé niet bijvoegen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:194
-#: ../gramps/gui/plug/export/_exportoptions.py:380
+#: ../gramps/gui/plug/export/_exportoptions.py:195
+#: ../gramps/gui/plug/export/_exportoptions.py:382
 msgid "Change order"
 msgstr "Volgorde wijzigen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:199
+#: ../gramps/gui/plug/export/_exportoptions.py:200
 msgid "Calculate Previews"
 msgstr "Voorbeelden berekenen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:279
+#: ../gramps/gui/plug/export/_exportoptions.py:281
 msgid "_Person Filter"
 msgstr "Personenfilter"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:291
+#: ../gramps/gui/plug/export/_exportoptions.py:293
 msgid "Click to see preview after person filter"
 msgstr "Om het resultaat na de personenfilter te zien, klikken"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:296
+#: ../gramps/gui/plug/export/_exportoptions.py:298
 msgid "_Note Filter"
 msgstr "Opmerkingenfilter"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:308
+#: ../gramps/gui/plug/export/_exportoptions.py:310
 msgid "Click to see preview after note filter"
 msgstr "Resultaat na van de opmerkingenfilter tonen"
 
 #. Frame 3:
-#: ../gramps/gui/plug/export/_exportoptions.py:311
+#: ../gramps/gui/plug/export/_exportoptions.py:313
 msgid "Privacy Filter"
 msgstr "Privacy-filter"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:317
+#: ../gramps/gui/plug/export/_exportoptions.py:319
 msgid "Click to see preview after privacy filter"
 msgstr "Resultaat na de privé-filter tonen"
 
 #. Frame 4:
-#: ../gramps/gui/plug/export/_exportoptions.py:320
+#: ../gramps/gui/plug/export/_exportoptions.py:322
 msgid "Living Filter"
 msgstr "'Nog-in-leven'-filter"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:327
+#: ../gramps/gui/plug/export/_exportoptions.py:329
 msgid "Click to see preview after living filter"
 msgstr "Resultaat na de 'nog-in-leven'-filter tonen"
 
 # Bronnen, verwijzingen, literatuurverwijzingen
-#: ../gramps/gui/plug/export/_exportoptions.py:331
+#: ../gramps/gui/plug/export/_exportoptions.py:333
 msgid "Reference Filter"
 msgstr "Verwijzingsfilter"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:337
+#: ../gramps/gui/plug/export/_exportoptions.py:339
 msgid "Click to see preview after reference filter"
 msgstr "Resultaat na de verwijzingenfilter tonen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:387
+#: ../gramps/gui/plug/export/_exportoptions.py:389
 msgid "Hide order"
 msgstr "Volorde verbergen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:580
+#: ../gramps/gui/plug/export/_exportoptions.py:582
 msgid "Filtering private data"
 msgstr "Filteren van privé-gegevens"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:589
+#: ../gramps/gui/plug/export/_exportoptions.py:591
 msgid "Filtering living persons"
 msgstr "Filteren van nog in leven zijnde personen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:606
+#: ../gramps/gui/plug/export/_exportoptions.py:608
 msgid "Applying selected person filter"
 msgstr "De geselecteerde personenfilter toepassen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:616
+#: ../gramps/gui/plug/export/_exportoptions.py:618
 msgid "Applying selected note filter"
 msgstr "De geselecteerde opmerkingenfilter toepassen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:625
+#: ../gramps/gui/plug/export/_exportoptions.py:627
 msgid "Filtering referenced records"
 msgstr "Gegevens waarnaar verwezen wordt filteren"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:666
+#: ../gramps/gui/plug/export/_exportoptions.py:668
 msgid "Cannot edit a system filter"
 msgstr "Een systeemfilter kan niet gewijzigd worden"
 
 # dit is een soort titel in een file-selector
-#: ../gramps/gui/plug/export/_exportoptions.py:667
+#: ../gramps/gui/plug/export/_exportoptions.py:669
 msgid "Please select a different filter to edit"
 msgstr "Een andere filter selecteren om aan te passen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:697
-#: ../gramps/gui/plug/export/_exportoptions.py:721
+#: ../gramps/gui/plug/export/_exportoptions.py:699
+#: ../gramps/gui/plug/export/_exportoptions.py:723
 msgid "Include all selected people"
 msgstr "Alle geselecteerde personen bijvoegen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:711
+#: ../gramps/gui/plug/export/_exportoptions.py:713
 msgid "Include all selected notes"
 msgstr "Alle geselecteerde opmerkingen bijvoegen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:722
+#: ../gramps/gui/plug/export/_exportoptions.py:724
 msgid "Replace given names of living people"
 msgstr "De achternamen van nog in levend zijnde personen vervangen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:723
-#, fuzzy
+#: ../gramps/gui/plug/export/_exportoptions.py:725
 msgid "Replace complete name of living people"
-msgstr "De achternamen van nog in levend zijnde personen vervangen"
+msgstr "De volledige naam van nog in levend zijnde personen vervangen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:724
+#: ../gramps/gui/plug/export/_exportoptions.py:726
 msgid "Do not include living people"
 msgstr "Nog levende personen niet bijvoegen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:733
+#: ../gramps/gui/plug/export/_exportoptions.py:735
 msgid "Include all selected records"
 msgstr "Alle geselecteerde gegevens bijvoegen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:734
+#: ../gramps/gui/plug/export/_exportoptions.py:736
 msgid "Do not include records not linked to a selected person"
 msgstr "Gegevens die geen verband houden met de persoon niet bijvoegen"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:755
+#: ../gramps/gui/plug/export/_exportoptions.py:757
 msgid "Use Compression"
 msgstr "Compressie gebruiken"
 
@@ -17583,8 +17573,8 @@ msgstr "Web Connect"
 #: ../gramps/gui/plug/quick/_textbufdoc.py:75
 #: ../gramps/gui/plug/quick/_textbufdoc.py:155
 #: ../gramps/gui/plug/quick/_textbufdoc.py:157
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:196
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:203
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:213
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:220
 #: ../gramps/plugins/lib/libpersonview.py:379
 #: ../gramps/plugins/lib/libplaceview.py:152
 #: ../gramps/plugins/view/citationlistview.py:182
@@ -17597,29 +17587,29 @@ msgstr "Web Connect"
 msgid "Quick View"
 msgstr "Snelscherm"
 
-#: ../gramps/gui/plug/quick/_quicktable.py:121
+#: ../gramps/gui/plug/quick/_quicktable.py:134
 #: ../gramps/plugins/gramplet/descendant.py:113
 msgid "Copy all"
 msgstr "Alles kopiëren"
 
-#: ../gramps/gui/plug/quick/_quicktable.py:152
+#: ../gramps/gui/plug/quick/_quicktable.py:161
 msgid "See data not in Filter"
 msgstr "Gegevens die niet tot filter behoren tonen"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:168
+#: ../gramps/gui/plug/report/_bookdialog.py:166
 msgid "Available Books"
 msgstr "Beschikbare boeken"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:241
+#: ../gramps/gui/plug/report/_bookdialog.py:239
 msgid "Discard Unsaved Changes"
 msgstr "Wijzigingen niet opslaan"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:242
+#: ../gramps/gui/plug/report/_bookdialog.py:240
 msgid "You have made changes which have not been saved."
 msgstr "U hebt wijzigingen aangebracht die nog niet opgeslagen zijn."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:243
-#: ../gramps/gui/plug/report/_bookdialog.py:730
+#: ../gramps/gui/plug/report/_bookdialog.py:241
+#: ../gramps/gui/plug/report/_bookdialog.py:737
 msgid "Proceed"
 msgstr "Verder gaan"
 
@@ -17631,36 +17621,36 @@ msgstr "Naam voor het boek. VERPLICHT"
 msgid "Manage Books"
 msgstr "Boeken beheren"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:360
+#: ../gramps/gui/plug/report/_bookdialog.py:361
 msgid "New Book"
 msgstr "Nieuw boek"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:363
+#: ../gramps/gui/plug/report/_bookdialog.py:364
 msgid "_Available items"
 msgstr "Beschikbare items"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:367
+#: ../gramps/gui/plug/report/_bookdialog.py:368
 msgid "Current _book"
 msgstr "Huidig _boek"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:375
+#: ../gramps/gui/plug/report/_bookdialog.py:376
 #: ../gramps/plugins/drawreport/statisticschart.py:307
 msgid "Item name"
 msgstr "Itemnaam"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:378
+#: ../gramps/gui/plug/report/_bookdialog.py:379
 msgid "Subject"
 msgstr "Onderwerp"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:392
+#: ../gramps/gui/plug/report/_bookdialog.py:393
 msgid "Book selection list"
 msgstr "Boek selectielijst"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:444
+#: ../gramps/gui/plug/report/_bookdialog.py:445
 msgid "Different database"
 msgstr "Ander gegevensbestand"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:445
+#: ../gramps/gui/plug/report/_bookdialog.py:446
 #, python-format
 msgid ""
 "This book was created with the references to database %s.\n"
@@ -17678,42 +17668,44 @@ msgstr ""
 "Daarom wordt de centrale persoon voor elk item gezet op de actieve persoon "
 "van het gegevensbestand dat nu geopend is."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:550
+#: ../gramps/gui/plug/report/_bookdialog.py:552
 msgid "No selected book item"
 msgstr "Geen boekitem geselecteerd"
 
 # dit is een soort titel in een file-selector
-#: ../gramps/gui/plug/report/_bookdialog.py:551
+#: ../gramps/gui/plug/report/_bookdialog.py:553
 msgid "Please select a book item to configure."
 msgstr "Een boekitem selecteren om aan te passen."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:616
+#: ../gramps/gui/plug/report/_bookdialog.py:618
 #: ../gramps/gui/views/bookmarks.py:252 ../gramps/gui/views/tags.py:414
 msgid "_Up"
 msgstr "Naar boven"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:617
+#: ../gramps/gui/plug/report/_bookdialog.py:619
 #: ../gramps/gui/views/bookmarks.py:253 ../gramps/gui/views/tags.py:415
 msgid "_Down"
 msgstr "Naar beneden"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:618
+#: ../gramps/gui/plug/report/_bookdialog.py:620
 msgid "Setup"
 msgstr "Instellingen"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:707
+#: ../gramps/gui/plug/report/_bookdialog.py:709
+#: ../gramps/gui/plug/report/_bookdialog.py:720
 msgid "No items"
 msgstr "Geen items"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:708
+#: ../gramps/gui/plug/report/_bookdialog.py:710
+#: ../gramps/gui/plug/report/_bookdialog.py:721
 msgid "This book has no items."
 msgstr "Er zijn items in dit boek."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:720
+#: ../gramps/gui/plug/report/_bookdialog.py:727
 msgid "No book name"
 msgstr "Geen boeknaam"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:721
+#: ../gramps/gui/plug/report/_bookdialog.py:728
 msgid ""
 "You are about to save away a book with no name.\n"
 "\n"
@@ -17723,20 +17715,20 @@ msgstr ""
 "\n"
 "Geef een naam op voor het boek op te slaan."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:727
+#: ../gramps/gui/plug/report/_bookdialog.py:734
 msgid "Book name already exists"
 msgstr "Boeknaam bestaat reeds"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:728
+#: ../gramps/gui/plug/report/_bookdialog.py:735
 msgid "You are about to save away a book with a name which already exists."
 msgstr ""
 "U staat op het punt om een boek met een naam die al bestaat, op te slaan."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:919
+#: ../gramps/gui/plug/report/_bookdialog.py:925
 msgid "Generate Book"
 msgstr "Boek aanmaken"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:962
+#: ../gramps/gui/plug/report/_bookdialog.py:968
 msgid "Gramps Book"
 msgstr "Gramps-boek"
 
@@ -18517,46 +18509,46 @@ msgstr "Megabyte|MB"
 msgid "Exclude"
 msgstr "Niet toevoegen"
 
-#: ../gramps/gui/viewmanager.py:1368
+#: ../gramps/gui/viewmanager.py:1373
 msgid "Backup file already exists! Overwrite?"
 msgstr "Bestand bestaat reeds! Overschrijven?"
 
-#: ../gramps/gui/viewmanager.py:1369
+#: ../gramps/gui/viewmanager.py:1374
 #, python-format
 msgid "The file '%s' exists."
 msgstr "Het bestand '%s' bestaat."
 
-#: ../gramps/gui/viewmanager.py:1370
+#: ../gramps/gui/viewmanager.py:1375
 msgid "Proceed and overwrite"
 msgstr "Verder gaan en overschrijven"
 
-#: ../gramps/gui/viewmanager.py:1371
+#: ../gramps/gui/viewmanager.py:1376
 msgid "Cancel the backup"
 msgstr "Reservekopie annuleren"
 
-#: ../gramps/gui/viewmanager.py:1379
+#: ../gramps/gui/viewmanager.py:1384
 msgid "Making backup..."
 msgstr "Reservekopie wordt aangemaakt..."
 
-#: ../gramps/gui/viewmanager.py:1392
+#: ../gramps/gui/viewmanager.py:1397
 #, python-format
 msgid "Backup saved to '%s'"
 msgstr "Reservekopie naar '%s' opgeslagen"
 
-#: ../gramps/gui/viewmanager.py:1395
+#: ../gramps/gui/viewmanager.py:1400
 msgid "Backup aborted"
 msgstr "Reservekopie aanmaken werd afgebroken"
 
 # dit is een soort titel in een file-selector
-#: ../gramps/gui/viewmanager.py:1404
+#: ../gramps/gui/viewmanager.py:1409
 msgid "Select backup directory"
 msgstr "Een map voor de reservekopie selecteren"
 
-#: ../gramps/gui/viewmanager.py:1628
+#: ../gramps/gui/viewmanager.py:1634
 msgid "Failed Loading View"
 msgstr "Scherm kon niet geladen worden"
 
-#: ../gramps/gui/viewmanager.py:1629
+#: ../gramps/gui/viewmanager.py:1635
 #, python-format
 msgid ""
 "The view %(name)s did not load and reported an error.\n"
@@ -18580,11 +18572,11 @@ msgstr ""
 "Wenst u echter dat deze uitbreiding niet meer door Gramps wordt geladen, kunt "
 "u de uitbreiding verbergen via het uitbreidingsmenu in het hulpmenu."
 
-#: ../gramps/gui/viewmanager.py:1721
+#: ../gramps/gui/viewmanager.py:1727
 msgid "Failed Loading Plugin"
 msgstr "Laden van de uitbreiding mislukte"
 
-#: ../gramps/gui/viewmanager.py:1722
+#: ../gramps/gui/viewmanager.py:1728
 #, python-format
 msgid ""
 "The plugin %(name)s did not load and reported an error.\n"
@@ -18882,7 +18874,7 @@ msgstr "Tags verwijderd"
 #: ../gramps/gui/views/tags.py:528
 #, python-format
 msgid "Delete Tag (%s)"
-msgstr "Tag (%s) verwijderen"
+msgstr "Tag verwijderen (%s)"
 
 #: ../gramps/gui/views/tags.py:586
 msgid "Cannot save tag"
@@ -18895,12 +18887,12 @@ msgstr "Een tagnaam kan niet leeg zijn"
 #: ../gramps/gui/views/tags.py:592
 #, python-format
 msgid "Add Tag (%s)"
-msgstr "Tag (%s) toevoegen"
+msgstr "Tag toevoegen (%s)"
 
 #: ../gramps/gui/views/tags.py:598
 #, python-format
 msgid "Edit Tag (%s)"
-msgstr "Tag (%s) bewerken"
+msgstr "Tag bewerken (%s)"
 
 #: ../gramps/gui/views/tags.py:608
 #, python-format
@@ -18919,10 +18911,10 @@ msgstr "Tagnaam:"
 msgid "Pick a Color"
 msgstr "Kleur kiezen"
 
-#: ../gramps/gui/views/treemodels/placemodel.py:136
-#: ../gramps/gui/views/treemodels/placemodel.py:144
-#: ../gramps/gui/views/treemodels/placemodel.py:152
-#: ../gramps/gui/views/treemodels/placemodel.py:160
+#: ../gramps/gui/views/treemodels/placemodel.py:137
+#: ../gramps/gui/views/treemodels/placemodel.py:145
+#: ../gramps/gui/views/treemodels/placemodel.py:153
+#: ../gramps/gui/views/treemodels/placemodel.py:161
 msgid "Error in format"
 msgstr "Formaatfout"
 
@@ -18951,22 +18943,22 @@ msgstr "Deze sectie expanderen"
 msgid "Collapse this section"
 msgstr "Deze sectie samenvoegen"
 
-#: ../gramps/gui/widgets/fanchart.py:1582 ../gramps/plugins/view/relview.py:801
+#: ../gramps/gui/widgets/fanchart.py:1519 ../gramps/plugins/view/relview.py:801
 msgid "Edit family"
 msgstr "Gezin bewerken"
 
-#: ../gramps/gui/widgets/fanchart.py:1598 ../gramps/plugins/view/relview.py:802
+#: ../gramps/gui/widgets/fanchart.py:1535 ../gramps/plugins/view/relview.py:802
 msgid "Reorder families"
 msgstr "Gezinnen herschikken"
 
-#: ../gramps/gui/widgets/fanchart.py:1604
+#: ../gramps/gui/widgets/fanchart.py:1541
 #: ../gramps/plugins/view/pedigreeview.py:1653
 #: ../gramps/plugins/view/pedigreeview.py:1881
 msgid "_Copy"
 msgstr "Kopieer"
 
 #. Go over siblings and build their menu
-#: ../gramps/gui/widgets/fanchart.py:1648
+#: ../gramps/gui/widgets/fanchart.py:1585
 #: ../gramps/plugins/quickview/quickview.gpr.py:316
 #: ../gramps/plugins/view/pedigreeview.py:1697
 #: ../gramps/plugins/view/relview.py:904
@@ -18974,9 +18966,9 @@ msgid "Siblings"
 msgstr "Broers en zussen"
 
 #. Go over children and build their menu
-#: ../gramps/gui/widgets/fanchart.py:1689
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:835
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:849
+#: ../gramps/gui/widgets/fanchart.py:1644
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:852
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:866
 #: ../gramps/plugins/textreport/familygroup.py:639
 #: ../gramps/plugins/textreport/indivcomplete.py:663
 #: ../gramps/plugins/view/pedigreeview.py:1739
@@ -18986,20 +18978,20 @@ msgid "Children"
 msgstr "Kinderen"
 
 #. Go over parents and build their menu
-#: ../gramps/gui/widgets/fanchart.py:1766
+#: ../gramps/gui/widgets/fanchart.py:1721
 #: ../gramps/plugins/view/pedigreeview.py:1824
 msgid "Related"
 msgstr "Verwant aan"
 
-#: ../gramps/gui/widgets/fanchart.py:1814
+#: ../gramps/gui/widgets/fanchart.py:1769
 msgid "Add partner to person"
 msgstr "Partner aan een persoon toevoegen"
 
-#: ../gramps/gui/widgets/fanchart.py:1821
+#: ../gramps/gui/widgets/fanchart.py:1776
 msgid "Add a person"
 msgstr "Een persoon toevoegen"
 
-#: ../gramps/gui/widgets/fanchart.py:1896 ../gramps/plugins/view/relview.py:1551
+#: ../gramps/gui/widgets/fanchart.py:1851 ../gramps/plugins/view/relview.py:1551
 msgid "Add Child to Family"
 msgstr "Kind aan gezin toevoegen"
 
@@ -19314,22 +19306,20 @@ msgstr ""
 "actief is in het gegevensbestand."
 
 #: ../gramps/plugins/db/bsddb/write.py:2516
-#, fuzzy
 msgid "DB-API version"
-msgstr "Bsddbversie"
+msgstr "DB-API versie"
 
 #: ../gramps/plugins/db/bsddb/write.py:2528
-#, fuzzy
 msgid "Database db version"
-msgstr "Bsddbversie"
+msgstr "Database db versie"
 
 #: ../gramps/plugins/db/dbapi/dbapi.gpr.py:23
 msgid "DB-API"
-msgstr ""
+msgstr "DB-API"
 
 #: ../gramps/plugins/db/dbapi/dbapi.gpr.py:24
 msgid "DB-_API Database"
-msgstr ""
+msgstr "DB-_API gegevensbestand"
 
 #: ../gramps/plugins/db/dbapi/dbapi.gpr.py:25
 msgid "DB-API Database"
@@ -19337,17 +19327,23 @@ msgstr "DB-API gegevensbestand"
 
 #: ../gramps/plugins/db/dbapi/inmemorydb.gpr.py:23
 msgid "In-Memory"
-msgstr ""
+msgstr "In-Memory"
 
 #: ../gramps/plugins/db/dbapi/inmemorydb.gpr.py:24
-#, fuzzy
 msgid "In-_Memory Database"
-msgstr "Gramps-gegevensbestand importeren"
+msgstr "In-_Memory gegevensbestand"
 
 #: ../gramps/plugins/db/dbapi/inmemorydb.gpr.py:25
-#, fuzzy
 msgid "In-Memory Database"
-msgstr "Gramps-gegevensbestand importeren"
+msgstr "In-Memory gegevensbestand"
+
+#: ../gramps/plugins/db/dummydb.gpr.py:23
+msgid "Dummy database"
+msgstr "Dummy gegevensbestand"
+
+#: ../gramps/plugins/db/dummydb.gpr.py:24 ../gramps/plugins/db/dummydb.gpr.py:25
+msgid "Dummy Database"
+msgstr "Dummy gegevensbestand"
 
 #: ../gramps/plugins/docgen/asciidoc.py:463
 msgid "Characters per line"
@@ -19510,7 +19506,7 @@ msgid ""
 msgstr ""
 "Het aanmaken van jpg afbeeldingen vanuit niet-jpg afbeeldingen in 'LaTeX' "
 "documenten zal niet beschikbaar zijn. Gebruik uw pakketbeheerder om 'python-"
-"imaging' of 'python-pillow' te installeren."
+"imaging' of 'python-pillow' te installeren"
 
 #: ../gramps/plugins/docgen/odfdoc.py:1164
 #, python-format
@@ -20495,7 +20491,7 @@ msgstr "Een grafische afstammelingenboom rond een gezin aanmaken"
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:172
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:118
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:127
-#: ../gramps/plugins/view/fanchartview.py:71
+#: ../gramps/plugins/view/fanchartview.py:73
 #: ../gramps/plugins/view/view.gpr.py:141
 msgid "Fan Chart"
 msgstr "Waaier"
@@ -20781,7 +20777,7 @@ msgstr "Persoonlijke informatie ontbreekt"
 #: ../gramps/plugins/textreport/tagreport.py:98
 #, python-format
 msgid "(Living people: %(option_name)s)"
-msgstr ""
+msgstr "(Nog in leven zijnde personen: %(option_name)s)"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:790
 #, python-format
@@ -20833,9 +20829,8 @@ msgstr "De centrale persoon voor de filter."
 
 #. ###############################
 #: ../gramps/plugins/drawreport/statisticschart.py:1011
-#, fuzzy
 msgid "Report Details"
-msgstr "Bibliotheekdetails"
+msgstr "Verslagdetails"
 
 #. ###############################
 #: ../gramps/plugins/drawreport/statisticschart.py:1015
@@ -21195,6 +21190,7 @@ msgid "Translate headers"
 msgstr "Hoofdingen vertalen"
 
 #: ../gramps/plugins/export/exportcsv.py:286
+#: ../gramps/plugins/gramplet/coordinates.py:95
 #: ../gramps/plugins/gramplet/placedetails.py:131
 #: ../gramps/plugins/lib/libplaceview.py:89
 #: ../gramps/plugins/webreport/narrativeweb.py:2918
@@ -21203,6 +21199,7 @@ msgid "Latitude"
 msgstr "Breedtegraad"
 
 #: ../gramps/plugins/export/exportcsv.py:286
+#: ../gramps/plugins/gramplet/coordinates.py:96
 #: ../gramps/plugins/gramplet/placedetails.py:133
 #: ../gramps/plugins/lib/libplaceview.py:90
 #: ../gramps/plugins/webreport/narrativeweb.py:2926
@@ -21329,7 +21326,7 @@ msgstr "_Levende als eerste naam gebruiken"
 
 #: ../gramps/plugins/export/exportgeneweb.glade:260
 msgid "Reference i_mages from path:  "
-msgstr "Beeldverwijzingen van pad:"
+msgstr "Beeldverwijzingen van pad:   "
 
 #: ../gramps/plugins/export/exportgeneweb.glade:280
 #: ../gramps/plugins/quickview/filterbyname.py:377
@@ -21450,8 +21447,8 @@ msgid "Mother - Child Age Diff Distribution"
 msgstr "Moeder - kind leeftijdsverschilverdeling"
 
 #: ../gramps/plugins/gramplet/agestats.py:238
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:242
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:249
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:259
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:266
 #: ../gramps/plugins/webreport/narrativeweb.py:1886
 #: ../gramps/plugins/webreport/narrativeweb.py:8063
 msgid "Statistics"
@@ -21534,6 +21531,33 @@ msgstr "Publicist"
 msgid "<No Citation>"
 msgstr "<Geen citaat>"
 
+#: ../gramps/plugins/gramplet/coordinates.py:83
+msgid "Right-click on a row to edit the selected event or the related place."
+msgstr ""
+"Rechtsklikken op een rij om de geselecteerde locatie of gebeurtenis te "
+"bewerken."
+
+#: ../gramps/plugins/gramplet/coordinates.py:94
+#: ../gramps/plugins/textreport/tagreport.py:154
+#: ../gramps/plugins/textreport/tagreport.py:242
+#: ../gramps/plugins/textreport/tagreport.py:331
+#: ../gramps/plugins/textreport/tagreport.py:414
+#: ../gramps/plugins/textreport/tagreport.py:495
+#: ../gramps/plugins/textreport/tagreport.py:564
+#: ../gramps/plugins/textreport/tagreport.py:648
+#: ../gramps/plugins/textreport/tagreport.py:733
+#: ../gramps/plugins/textreport/tagreport.py:813
+msgid "Id"
+msgstr "Id"
+
+#: ../gramps/plugins/gramplet/coordinates.py:143
+msgid "Edit the event"
+msgstr "De gebeurtenis bewerken"
+
+#: ../gramps/plugins/gramplet/coordinates.py:148
+msgid "Edit the place"
+msgstr "Locatie bewerken"
+
 #: ../gramps/plugins/gramplet/eval.py:72
 msgid "Evaluation"
 msgstr "Evaluatie"
@@ -21555,8 +21579,9 @@ msgstr "Toepassen"
 msgid "Double-click on a row to edit the selected event."
 msgstr "Dubbelklik op een rij om de geselecteerde gebeurtenis te bewerken."
 
-#: ../gramps/plugins/gramplet/fanchartdescgramplet.py:62
-#: ../gramps/plugins/gramplet/fanchartgramplet.py:65
+#: ../gramps/plugins/gramplet/fanchart2waygramplet.py:87
+#: ../gramps/plugins/gramplet/fanchartdescgramplet.py:64
+#: ../gramps/plugins/gramplet/fanchartgramplet.py:67
 msgid ""
 "Click to expand/contract person\n"
 "Right-click for options\n"
@@ -21813,7 +21838,7 @@ msgid "Ancestors"
 msgstr "Voorouders"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:102
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:180
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:197
 msgid "Gramplet showing active person's ancestors"
 msgstr "Gramplet die de voorouders van de actieve persoon toont"
 
@@ -21824,7 +21849,7 @@ msgstr ""
 "waaier toont"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:135
-#: ../gramps/plugins/view/fanchartdescview.py:72
+#: ../gramps/plugins/view/fanchartdescview.py:75
 msgid "Descendant Fan Chart"
 msgstr "Afstammelingenwaaier"
 
@@ -21840,171 +21865,189 @@ msgid "Descendant Fan"
 msgstr "Afstammelingenwaaier"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:152
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:158
+#: ../gramps/plugins/view/fanchart2wayview.py:78
+msgid "2-Way Fan Chart"
+msgstr "Waaiergrafiek in twee richtingen"
+
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:153
+msgid ""
+"Gramplet showing active person's direct ancestors and descendants as a "
+"fanchart"
+msgstr ""
+"Gramplet die de rechtstreekse voorouders en afstammelingen van de actieve "
+"persoon in een waaier toont"
+
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:161
+#: ../gramps/plugins/view/view.gpr.py:171
+msgid "2-Way Fan"
+msgstr "Waaier in twee richtingen"
+
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:169
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:175
 msgid "FAQ"
 msgstr "FAQ"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:153
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:170
 msgid "Gramplet showing frequently asked questions"
 msgstr "Gramplet toont vaak gestelde vragen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:165
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:172
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:182
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:189
 msgid "Given Name Cloud"
 msgstr "Voornamenwolk"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:166
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:183
 msgid "Gramplet showing all given names as a text cloud"
 msgstr "Gramplet toont alle achternamen in een tekstwolk"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:179
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:185
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:196
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:202
 #: ../gramps/plugins/view/pedigreeview.py:528
 #: ../gramps/plugins/view/view.gpr.py:125
 #: ../gramps/plugins/webreport/narrativeweb.py:7172
 msgid "Pedigree"
 msgstr "Kwartierstaat"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:197
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:214
 msgid "Gramplet showing an active item Quick View"
 msgstr "Gramplet toont een snelscherm voor het actieve item"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:212
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:218
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:229
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:235
 msgid "Relatives"
 msgstr "Verwanten"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:213
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:230
 msgid "Gramplet showing active person's relatives"
 msgstr "Gramplet toont de verwanten van de actieve persoon"
 
 # Huwelijkszegen?
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:228
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:235
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:245
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:252
 msgid "Session Log"
 msgstr "Sessielog"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:229
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:246
 msgid "Gramplet showing all activity for this session"
 msgstr "Gramplet toont alle activiteiten van deze sessie"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:243
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:260
 msgid "Gramplet showing summary data of the Family Tree"
 msgstr "Gramplet die een samenvatting van de stamboom toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:256
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:263
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:273
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:280
 msgid "Surname Cloud"
 msgstr "Achternamenwolk"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:257
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:274
 msgid "Gramplet showing all surnames as a text cloud"
 msgstr "Gramplet toont alle voornamen in een tekstwolk"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:270
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:277
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1131
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1145
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1159
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1173
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1187
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1201
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1215
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1229
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:287
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:294
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1148
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1162
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1176
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1190
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1204
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1218
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1232
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1246
 msgid "gramplet|To Do"
 msgstr "Taken"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:271
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:288
 msgid "Gramplet for displaying a To Do list"
 msgstr "Gramplet die een takenlijst toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:285
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:291
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:302
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:308
 msgid "Top Surnames"
 msgstr "Top achternamen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:286
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:303
 msgid "Gramplet showing most frequent surnames in this tree"
 msgstr "Gramplet die de meest voorkomende voornamen in deze stamboom toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:298
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:315
 msgid "Welcome"
 msgstr "Welkom"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:299
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:316
 msgid "Gramplet showing a welcome message"
 msgstr "Gramplet toont een welkomstboodschap"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:305
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:322
 msgid "Welcome to Gramps!"
 msgstr "Welkom bij Gramps!"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:312
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:329
 msgid "What's Next"
 msgstr "Wat volgt er"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:313
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:330
 msgid "Gramplet suggesting items to research"
 msgstr "Gramplet stelt items voor voor verder onderzoek"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:319
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:336
 msgid "What's Next?"
 msgstr "Wat volgt er?"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:329
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:346
 msgid "Person Details"
 msgstr "Personendetails"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:330
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:347
 msgid "Gramplet showing details of a person"
 msgstr "Gramplet toont details van een persoon"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:337
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:351
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:365
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:354
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:368
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:382
 msgid "Details"
 msgstr "Details"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:343
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:360
 msgid "Repository Details"
 msgstr "Bibliotheekdetails"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:344
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:361
 msgid "Gramplet showing details of a repository"
 msgstr "Gramplet die de bibliotheekdetails toont"
 
 # Plaatsnaam
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:357
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:374
 msgid "Place Details"
 msgstr "Locatiedetails"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:358
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:375
 msgid "Gramplet showing details of a place"
 msgstr "Gramplet die de locatiedetails toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:371
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:379
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:388
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:396
 msgid "Media Preview"
 msgstr "Mediavoorvertoning"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:372
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:389
 msgid "Gramplet showing a preview of a media object"
 msgstr "Gramplet die een voorvertning van een media-object toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:399
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:407
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:416
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:424
 msgid "Image Metadata"
 msgstr "Beeldmetagegevens"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:400
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:417
 msgid "Gramplet showing metadata for a media object"
 msgstr "Gramplet die de metagegevens van een media-object toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:421
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:438
 msgid "GExiv2 module not loaded."
 msgstr "Module GExiv2 niet geladen."
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:422
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:439
 #, python-format
 msgid ""
 "Image metadata functionality will not be available.\n"
@@ -22014,276 +22057,276 @@ msgstr ""
 "Om deze functie voor Gramps te kunnen bouwen zie "
 "%(gramps_wiki_build_gexiv2_url)s"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:435
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:452
 msgid "Person Residence"
 msgstr "Persoonsresidentie"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:436
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:453
 msgid "Gramplet showing residence events for a person"
 msgstr "Gramplet die de residentiegebeurtenissen van een persoon toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:449
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:466
 msgid "Person Events"
 msgstr "Persoonlijke gebeurtenissen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:450
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1303
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:467
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1320
 msgid "Gramplet showing the events for a person"
 msgstr "Gramplet die de gebeurtenissen van een persoon toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:463
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:480
 msgid "Family Events"
 msgstr "Gezinsgebeurtenissen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:464
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:481
 msgid "Gramplet showing the events for a family"
 msgstr "Gramplet die de gebeurtenissen van een gezin toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:477
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:494
 msgid "Person Gallery"
 msgstr "Personengalerij"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:478
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:495
 msgid "Gramplet showing media objects for a person"
 msgstr "Gramplet die de media-objecten van een persoon toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:485
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:499
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:513
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:527
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:541
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:555
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:502
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:516
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:530
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:544
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:558
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:572
 msgid "Gallery"
 msgstr "Galerij"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:491
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:508
 msgid "Family Gallery"
 msgstr "Familiegalerij"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:492
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:509
 msgid "Gramplet showing media objects for a family"
 msgstr "Gramplet die de media-objecten van een gezin toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:505
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:522
 msgid "Event Gallery"
 msgstr "Gebeurtenissengalerij"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:506
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:523
 msgid "Gramplet showing media objects for an event"
 msgstr "Gramplet die de media-objecten van een gebeurtenis toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:519
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:536
 msgid "Place Gallery"
 msgstr "Locatiegalerij"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:520
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:537
 msgid "Gramplet showing media objects for a place"
 msgstr "Gramplet die de media-objecten van een locatie toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:533
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:550
 msgid "Source Gallery"
 msgstr "Bronnengalerij"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:534
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:551
 msgid "Gramplet showing media objects for a source"
 msgstr "Gramplet die de media-objecten van een bron toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:547
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:564
 msgid "Citation Gallery"
 msgstr "Citatengalerij"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:548
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:565
 msgid "Gramplet showing media objects for a citation"
 msgstr "Gramplet die de media-objecten van een citaat toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:561
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:578
 msgid "Person Attributes"
 msgstr "Persoonlijke kenmerken"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:562
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:579
 msgid "Gramplet showing the attributes of a person"
 msgstr "Gramplet die de kenmerken van een persoon toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:575
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:592
 msgid "Event Attributes"
 msgstr "Gebeurteniskenmerken"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:576
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:593
 msgid "Gramplet showing the attributes of an event"
 msgstr "Gramplet die de kenmerken van een gebeurtenis toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:589
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:606
 msgid "Family Attributes"
 msgstr "Gezinskenmerken"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:590
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:607
 msgid "Gramplet showing the attributes of a family"
 msgstr "Gramplet die de kenmerken van een gezin toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:603
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:620
 msgid "Media Attributes"
 msgstr "Mediakenmerken"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:604
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:621
 msgid "Gramplet showing the attributes of a media object"
 msgstr "Gramplet die de kenmerken van een media-object toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:617
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:634
 msgid "Source Attributes"
 msgstr "Bronkenmerken"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:618
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:635
 msgid "Gramplet showing the attributes of a source object"
 msgstr "Gramplet die de kenmerken van een bron toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:631
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:648
 msgid "Citation Attributes"
 msgstr "Citaatkenmerken"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:632
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:649
 msgid "Gramplet showing the attributes of a citation object"
 msgstr "Gramplet die de kenmerken van een citaat toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:645
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:662
 msgid "Person Notes"
 msgstr "Persoonsopmerkingen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:646
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:663
 msgid "Gramplet showing the notes for a person"
 msgstr "Gramplet die de opmerkingen van een persoon toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:659
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:676
 msgid "Event Notes"
 msgstr "Gebeurtenisopmerkingen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:660
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:677
 msgid "Gramplet showing the notes for an event"
 msgstr "Gramplet die de opmerkingen van een gebeurtenis toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:673
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:690
 #: ../gramps/plugins/textreport/familygroup.py:775
 msgid "Family Notes"
 msgstr "Gezinsopmerkingen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:674
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:691
 msgid "Gramplet showing the notes for a family"
 msgstr "Gramplet die de opmerkingen van een gezin toont"
 
 # Plaatsnaam
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:687
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:704
 msgid "Place Notes"
 msgstr "Locatie-opmerkingen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:688
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:705
 msgid "Gramplet showing the notes for a place"
 msgstr "Gramplet die de opmerkingen van een locatie toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:701
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:718
 msgid "Source Notes"
 msgstr "Bronopmerkingen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:702
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:719
 msgid "Gramplet showing the notes for a source"
 msgstr "Gramplet die de opmerkingen van een bron toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:715
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:732
 msgid "Citation Notes"
 msgstr "Citaatopmerkingen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:716
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:733
 msgid "Gramplet showing the notes for a citation"
 msgstr "Gramplet die de opmerkingen van een citaat toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:729
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:746
 msgid "Repository Notes"
 msgstr "Bibliotheekopmerkingen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:730
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:747
 msgid "Gramplet showing the notes for a repository"
 msgstr "Gramplet die de opmerkingen van een bibliotheek toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:743
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:760
 msgid "Media Notes"
 msgstr "Media-opmerkingen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:744
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:761
 msgid "Gramplet showing the notes for a media object"
 msgstr "Gramplet die de opmerkingen van een  media-object toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:757
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:774
 msgid "Person Citations"
 msgstr "Persoonscitaten"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:758
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:775
 msgid "Gramplet showing the citations for a person"
 msgstr "Gramplet die de citaten van een persoon toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:771
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:788
 msgid "Event Citations"
 msgstr "Gebeurteniscitaten"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:772
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:789
 msgid "Gramplet showing the citations for an event"
 msgstr "Gramplet die de citaten van een gebeurtenis toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:785
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:802
 msgid "Family Citations"
 msgstr "Gezinscitaten"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:786
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:803
 msgid "Gramplet showing the citations for a family"
 msgstr "Gramplet die de citaten van een gezin toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:799
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:816
 msgid "Place Citations"
 msgstr "Locatiecitaten"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:800
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:817
 msgid "Gramplet showing the citations for a place"
 msgstr "Gramplet die de citaten van een locatie toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:813
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:830
 msgid "Media Citations"
 msgstr "Citaten van de media-objecten"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:814
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:831
 msgid "Gramplet showing the citations for a media object"
 msgstr "Gramplet die de citaten van een  media-object toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:827
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:844
 msgid "Person Children"
 msgstr "Kinderen van de persoon"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:828
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:845
 msgid "Gramplet showing the children of a person"
 msgstr "Gramplet die de kinderen van een persoon toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:841
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:858
 msgid "Family Children"
 msgstr "Kinderen van dit gezin"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:842
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:859
 msgid "Gramplet showing the children of a family"
 msgstr "Gramplet die de kinderen in een gezin toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:855
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:872
 msgid "Person References"
 msgstr "Persoonsverwijzingen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:856
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:873
 msgid "Gramplet showing the backlink references for a person"
 msgstr "Gramplet die de verwijzingen naar een persoon toont"
 
 # Bronnen, verwijzingen, literatuurverwijzingen
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:863
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:877
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:891
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:905
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:919
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:933
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:947
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:961
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:975
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:880
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:894
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:908
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:922
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:936
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:950
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:964
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:978
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:992
 #: ../gramps/plugins/webreport/narrativeweb.py:2670
 #: ../gramps/plugins/webreport/narrativeweb.py:3166
 #: ../gramps/plugins/webreport/narrativeweb.py:5734
@@ -22292,275 +22335,269 @@ msgid "References"
 msgstr "Referenties"
 
 # Bronnen, verwijzingen, literatuurverwijzingen
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:869
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:886
 msgid "Event References"
 msgstr "Gebeurtenissenverwijzingen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:870
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:887
 msgid "Gramplet showing the backlink references for an event"
 msgstr "Gramplet die de verwijzingen naar een gebeurtenis toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:883
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:900
 msgid "Family References"
 msgstr "Familieverwijzingen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:884
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:901
 msgid "Gramplet showing the backlink references for a family"
 msgstr "Gramplet die de verwijzingen naar een gezin toont"
 
 # Bronnen, verwijzingen, literatuurverwijzingen
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:897
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:914
 msgid "Place References"
 msgstr "Plaatsverwijzingen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:898
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:915
 msgid "Gramplet showing the backlink references for a place"
 msgstr "Gramplet die de verwijzingen naar een locatie toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:911
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:928
 #: ../gramps/plugins/webreport/narrativeweb.py:2553
 msgid "Source References"
 msgstr "Bronverwijzing"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:912
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:929
 msgid "Gramplet showing the backlink references for a source"
 msgstr "Gramplet die de verwijzingen naar een bron toont"
 
 # Bronnen, verwijzingen, literatuurverwijzingen
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:925
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:942
 msgid "Citation References"
 msgstr "Citaatverwijzingen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:926
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:943
 msgid "Gramplet showing the backlink references for a citation"
 msgstr "Gramplet die de verwijzingen naar een citaat toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:939
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:956
 #: ../gramps/plugins/quickview/quickview.gpr.py:248
 msgid "Repository References"
 msgstr "Bibliothekenverwijzingen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:940
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:957
 msgid "Gramplet showing the backlink references for a repository"
 msgstr "Gramplet die de verwijzingen naar een bibliotheek toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:953
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:970
 msgid "Media References"
 msgstr "Mediaverwijzingen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:954
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:971
 msgid "Gramplet showing the backlink references for a media object"
 msgstr "Gramplet die de verwijzingen naar een media-object toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:967
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:984
 msgid "Note References"
 msgstr "Notitieverwijzing"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:968
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:985
 msgid "Gramplet showing the backlink references for a note"
 msgstr "Gramplet die de verwijzingen naar een opmerking toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:981
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:998
 msgid "Person Filter"
 msgstr "Personenfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:982
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:999
 msgid "Gramplet providing a person filter"
 msgstr "Gramplet die een personenfilter toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:995
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1012
 msgid "Family Filter"
 msgstr "Gezinsfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:996
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1013
 msgid "Gramplet providing a family filter"
 msgstr "Gramplet die een gezinsfilter toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1009
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1026
 msgid "Event Filter"
 msgstr "Gebeurtenissenfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1010
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1027
 msgid "Gramplet providing an event filter"
 msgstr "Gramplet die een gebeurtenissenfilter toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1023
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1040
 msgid "Source Filter"
 msgstr "Bronnenfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1024
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1041
 msgid "Gramplet providing a source filter"
 msgstr "Gramplet die een bronnenfilter toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1037
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1054
 msgid "Citation Filter"
 msgstr "Citatenfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1038
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1055
 msgid "Gramplet providing a citation filter"
 msgstr "Gramplet die een citatenfilter toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1051
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1068
 msgid "Place Filter"
 msgstr "Locatiefilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1052
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1069
 msgid "Gramplet providing a place filter"
 msgstr "Gramplet die een locatiefilter toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1065
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1082
 msgid "Media Filter"
 msgstr "Mediafilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1066
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1083
 msgid "Gramplet providing a media filter"
 msgstr "Gramplet die een media-objectenfilter toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1079
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1096
 msgid "Repository Filter"
 msgstr "Bibliotheekfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1080
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1097
 msgid "Gramplet providing a repository filter"
 msgstr "Gramplet die een bibliothekenfilter toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1093
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1110
 msgid "Note Filter"
 msgstr "Opmerkingenfilter"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1094
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1111
 msgid "Gramplet providing a note filter"
 msgstr "Gramplet die een opmerkingenfilter toont"
 
 # rapportages
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1107
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1118
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1124
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1135
 #: ../gramps/plugins/textreport/recordsreport.py:119
 msgid "Records"
 msgstr "Records"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1108
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1125
 #: ../gramps/plugins/textreport/textplugins.gpr.py:413
 msgid "Shows some interesting records about people and families"
 msgstr "Interessante records van personen en gezinnen tonen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1123
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1140
 msgid "Person To Do"
 msgstr "Persoonstaken"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1124
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1141
 msgid "Gramplet showing the To Do notes for a person"
 msgstr "Gramplet die de takenlijst van een persoon toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1137
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1154
 msgid "Event To Do"
 msgstr "Gebeurtenistaken"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1138
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1155
 msgid "Gramplet showing the To Do notes for an event"
 msgstr "Gramplet die de takenlijst van een gebeurtenis toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1151
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1168
 msgid "Family To Do"
 msgstr "Gezinstaken"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1152
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1169
 msgid "Gramplet showing the To Do notes for a family"
 msgstr "Gramplet die de takenlijst van een gezin toont"
 
 # Plaatsnaam
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1165
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1182
 msgid "Place To Do"
 msgstr "Locatietaken"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1166
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1183
 msgid "Gramplet showing the To Do notes for a place"
 msgstr "Gramplet die de takenlijst van een locatie toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1179
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1196
 msgid "Source To Do"
 msgstr "Brontaken"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1180
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1197
 msgid "Gramplet showing the To Do notes for a source"
 msgstr "Gramplet die de takenlijst van een bron toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1193
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1210
 msgid "Citation To Do"
 msgstr "Citaattaken"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1194
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1211
 msgid "Gramplet showing the To Do notes for a citation"
 msgstr "Gramplet die de takenlijst van een citaat toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1207
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1224
 msgid "Repository To Do"
 msgstr "Bibliotheektaken"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1208
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1225
 msgid "Gramplet showing the To Do notes for a repository"
 msgstr "Gramplet die de takenlijst van een bibliotheek toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1221
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1238
 msgid "Media To Do"
 msgstr "Mediataken"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1222
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1239
 msgid "Gramplet showing the To Do notes for a media object"
 msgstr "Gramplet die de takenlijst van een  media-object toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1261
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1269
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1278
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1286
 msgid "SoundEx"
 msgstr "SoundEx"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1262
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1279
 msgid "Gramplet to generate SoundEx codes"
 msgstr "Gramplet om 'SoundEx'-codes aan te maken"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1274
-#, fuzzy
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1291
 msgid "Place Enclosed By"
-msgstr "Besloten in"
+msgstr "Locatie besloten in"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1275
-#, fuzzy
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1292
 msgid "Gramplet showing the places enclosed by the active place"
-msgstr "Gramplet die de opmerkingen van een locatie toont"
+msgstr "Gramplet die de locaties toont die besloten zijn in de actieve locatie"
 
 # Plaatsnaam
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1288
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1305
 msgid "Place Encloses"
 msgstr "Locatie bevat"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1289
-#, fuzzy
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1306
 msgid "Gramplet showing the places that the active place encloses"
-msgstr "Gramplet die de citaten van een locatie toont"
+msgstr "Gramplet die de locaties die de actieve locatie omsluit, toont"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1296
-#, fuzzy
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1313
 msgid "Encloses"
-msgstr "Besloten in"
+msgstr "Omsluit"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1302
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1319
 msgid "Geography coordinates for Person Events"
-msgstr ""
+msgstr "Geografische coordinaten van de persoonsgebeurtenissen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1310
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1324
-#, fuzzy
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1327
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1341
 msgid "Events Coordinates"
-msgstr "Gebeurtenissen van %(date)s"
+msgstr "Gebeurtenissencoördinaten"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1316
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1333
 msgid "Geography coordinates for Family Events"
-msgstr ""
+msgstr "Geografische coordinaten van de familiegebeurtenissen"
 
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:1317
-#, fuzzy
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:1334
 msgid "Gramplet showing the events for all the family"
-msgstr "Gramplet die de gebeurtenissen van een gezin toont"
+msgstr "Gramplet die de gebeurtenissen van alle familieleden toont"
 
 #: ../gramps/plugins/gramplet/leak.py:93
 msgid "Uncollected object"
@@ -22586,7 +22623,7 @@ msgstr "%d verwijst naar"
 msgid "Uncollected Objects: %s"
 msgstr "Niet-verzamelde objecten: %s"
 
-#: ../gramps/plugins/gramplet/locations.py:80
+#: ../gramps/plugins/gramplet/locations.py:81
 msgid "Double-click on a row to edit the selected place."
 msgstr "Dubbelklik op een rij om de geselecteerde locatie te bewerken."
 
@@ -22604,8 +22641,8 @@ msgstr "Beweeg met de muis over de koppelingen voor opties"
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:58
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:67
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:78
-#: ../gramps/plugins/view/fanchartdescview.py:274
-#: ../gramps/plugins/view/fanchartview.py:272
+#: ../gramps/plugins/view/fanchartdescview.py:280
+#: ../gramps/plugins/view/fanchartview.py:276
 msgid "Max generations"
 msgstr "Max aantal generaties"
 
@@ -23036,7 +23073,6 @@ msgid "Dashboard View"
 msgstr "Dashboard-scherm"
 
 #: ../gramps/plugins/gramplet/welcomegramplet.py:131
-#, fuzzy
 msgid ""
 "You are currently reading from the \"Dashboard\" view, where you can add your "
 "own gramplets. You can also add gramplets to any view by adding a sidebar and/"
@@ -23049,8 +23085,8 @@ msgid ""
 msgstr ""
 "U leest momenteel de tekst van de \"Dashboard\"-pagina waar u uw eigen "
 "'gramplets' kunt toevoegen. Bovendien kunt u 'gramplets' toevoegen aan alle "
-"schermen door een onderbalk of de zijbalk te voegen en rechts te klikken op "
-"de tab.\n"
+"schermen door een onderbalk of de zijbalk toe te voegen en rechts te klikken "
+"op de tab.\n"
 "\n"
 "U kunt op de het configuratie-icoontje klikken in de werkbalk om bijkomende "
 "kolommen toe te voegen. Door op de achtergrond rechts te klikken kunt u "
@@ -23451,9 +23487,8 @@ msgid "Large"
 msgstr "Groot"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:244
-#, fuzzy
 msgid "Size of the thumbnail image"
-msgstr "Enkel miniaturen aanmaken en gebruiken"
+msgstr "Grootte van het miniatuurbeeld"
 
 #. ----------------------------
 #: ../gramps/plugins/graph/gvfamilylines.py:248
@@ -23703,7 +23738,7 @@ msgstr "Broers en zussen van de centrale persoon toevoegen"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:757
 msgid "Include date, description and place of all occupations"
-msgstr ""
+msgstr "Datum, beschrijving en locaties van alle beroepen bijvoegen"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:759
 msgid "Whether to include the last occupation"
@@ -24369,13 +24404,15 @@ msgstr "GEDCOM importverslag: %s fouten gevonden"
 #: ../gramps/plugins/importer/importvcard.py:319
 #, python-format
 msgid "Token >%(token)s< unknown. line skipped: %(line)s"
-msgstr ""
+msgstr "'Token' >%(token)s< onbekend. lijn overgeslagen: %(line)s"
 
 #: ../gramps/plugins/importer/importvcard.py:333
 msgid ""
 "BEGIN property not properly closed by END property, Gramps can't cope with "
 "nested VCards."
 msgstr ""
+"BEGIN eigenschap is niet juist afgesloten door een END eigenschap, Gramps kan "
+"deze geneste 'VCards' niet verwerken."
 
 #: ../gramps/plugins/importer/importvcard.py:344
 #, python-format
@@ -24388,16 +24425,19 @@ msgid ""
 "VCard is malformed missing the compulsory N property, so there is no name; "
 "skip it."
 msgstr ""
+"VCard-formaat is niet just want vereiste N-eigenschap ontbreekt en er is dus "
+"geen naam; wordt overgeslagen."
 
 #: ../gramps/plugins/importer/importvcard.py:369
 msgid ""
 "VCard is malformed missing the compulsory FN property, get name from N alone."
 msgstr ""
+"VCard-formaat is niet juist want de vereiste FN-eigenschap ontbreekt, naam "
+"wordt enkel door N bepaald."
 
 #: ../gramps/plugins/importer/importvcard.py:373
 msgid "VCard is malformed wrong number of name components."
-msgstr ""
-"VCard formaat is niet correct omdat het aantal naamcomponenten fout is  "
+msgstr "VCard formaat is niet correct omdat het aantal naamcomponenten fout is."
 
 #: ../gramps/plugins/importer/importvcard.py:515
 #, python-brace-format
@@ -24825,16 +24865,15 @@ msgstr "Hoogte"
 
 #: ../gramps/plugins/lib/libgedcom.py:613
 msgid "Initiatory (LDS)"
-msgstr ""
+msgstr "Initiatory (LDS)"
 
 #: ../gramps/plugins/lib/libgedcom.py:614
-#, fuzzy
 msgid "Military ID"
-msgstr "Militaire dienst"
+msgstr "Militaire ID"
 
 #: ../gramps/plugins/lib/libgedcom.py:615
 msgid "Mission (LDS)"
-msgstr ""
+msgstr "Mission (LDS)"
 
 #: ../gramps/plugins/lib/libgedcom.py:616
 #, fuzzy
@@ -24852,13 +24891,12 @@ msgstr "Afgezonderd"
 
 #. Applies to Families
 #: ../gramps/plugins/lib/libgedcom.py:620
-#, fuzzy
 msgid "Weight"
-msgstr "Rechts"
+msgstr "Gewicht"
 
 #: ../gramps/plugins/lib/libgedcom.py:825
 msgid "Line ignored "
-msgstr "Lijn genegeerd"
+msgstr "Lijn genegeerd "
 
 #. e.g. Illegal character (oxAB) (0xCB)... 1 NOTE xyz?pqr?lmn
 #: ../gramps/plugins/lib/libgedcom.py:1423
@@ -25021,7 +25059,7 @@ msgstr "Mediatype"
 #: ../gramps/plugins/lib/libgedcom.py:5268
 #: ../gramps/plugins/lib/libgedcom.py:6549
 msgid "Multiple FILE in a single OBJE ignored"
-msgstr ""
+msgstr "Meerdere 'FILE' in een enkel 'OBJE' genegeerd"
 
 #. We have previously found a PLAC
 #: ../gramps/plugins/lib/libgedcom.py:5423
@@ -26269,7 +26307,7 @@ msgstr "Zij werd begraven in %(month_year)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:517
 #, python-format
 msgid "%(unknown_gender_name)s was buried in %(month_year)s%(endnotes)s."
-msgstr "%(unknown_gender_name)s werd begraven in %(month_year)s%(endnotes)s"
+msgstr "%(unknown_gender_name)s werd begraven in %(month_year)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:518
 #, python-format
@@ -26300,7 +26338,7 @@ msgid ""
 "%(female_name)s was buried %(modified_date)s in %(burial_place)s%(endnotes)s."
 msgstr ""
 "%(female_name)s werd begraven %(modified_date)s te %(burial_place)s."
-"%(endnotes)s"
+"%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:530
 #, python-format
@@ -26314,7 +26352,7 @@ msgid ""
 "%(endnotes)s."
 msgstr ""
 "%(unknown_gender_name)s werd begraven %(modified_date)s te %(burial_place)s."
-"%(endnotes)s"
+"%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:534
 #, python-format
@@ -26376,7 +26414,7 @@ msgstr "Hij werd begraven te %(burial_place)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:561
 #, python-format
 msgid "%(female_name)s was buried in %(burial_place)s%(endnotes)s."
-msgstr "%(female_name)s werd begraven te %(burial_place)s%(endnotes)s"
+msgstr "%(female_name)s werd begraven te %(burial_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:562
 #, python-format
@@ -26401,7 +26439,7 @@ msgstr "Begraven te %(burial_place)s.%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:573
 #, python-format
 msgid "%(male_name)s was buried%(endnotes)s."
-msgstr "%(male_name)s werd begraven.%(endnotes)s"
+msgstr "%(male_name)s werd begraven.%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:574
 #, python-format
@@ -26468,7 +26506,7 @@ msgid ""
 "%(endnotes)s."
 msgstr ""
 "%(unknown_gender_name)s werd gedoopt op %(baptism_date)s te %(baptism_place)s."
-"%(endnotes)s"
+"%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:603
 #, python-format
@@ -26486,7 +26524,7 @@ msgstr "Gedoopt %(baptism_date)s te %(baptism_place)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:610
 #, python-format
 msgid "%(male_name)s was baptized on %(baptism_date)s%(endnotes)s."
-msgstr "%(male_name)s werd gedoopt op %(baptism_date)s%(endnotes)s"
+msgstr "%(male_name)s werd gedoopt op %(baptism_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:611
 #, python-format
@@ -26496,7 +26534,7 @@ msgstr "Hij werd gedoopt  op %(baptism_date)s.%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:614
 #, python-format
 msgid "%(female_name)s was baptized on %(baptism_date)s%(endnotes)s."
-msgstr "%(female_name)s werd gedoopt op %(baptism_date)s.%(endnotes)s"
+msgstr "%(female_name)s werd gedoopt op %(baptism_date)s.%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:615
 #, python-format
@@ -26523,12 +26561,13 @@ msgstr "Gedoopt %(baptism_date)s%(endnotes)s."
 msgid ""
 "%(male_name)s was baptized in %(month_year)s in %(baptism_place)s%(endnotes)s."
 msgstr ""
-"%(male_name)s werd gedoopt in %(month_year)s te %(baptism_place)s.%(endnotes)s"
+"%(male_name)s werd gedoopt in %(month_year)s te %(baptism_place)s."
+"%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:627
 #, python-format
 msgid "He was baptized in %(month_year)s in %(baptism_place)s%(endnotes)s."
-msgstr "Hij werd gedoopt in %(month_year)s te %(baptism_place)s.%(endnotes)s"
+msgstr "Hij werd gedoopt in %(month_year)s te %(baptism_place)s.%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:630
 #, python-format
@@ -26537,7 +26576,7 @@ msgid ""
 "%(endnotes)s."
 msgstr ""
 "%(female_name)s werd gedoopt in %(month_year)s te %(baptism_place)s."
-"%(endnotes)s"
+"%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:631
 #, python-format
@@ -26551,7 +26590,7 @@ msgid ""
 "%(endnotes)s."
 msgstr ""
 "%(unknown_gender_name)s werd gedoopt in %(month_year)s te %(baptism_place)s."
-"%(endnotes)s"
+"%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:635
 #, python-format
@@ -26563,12 +26602,12 @@ msgstr ""
 #: ../gramps/plugins/lib/libnarrate.py:637
 #, python-format
 msgid "Baptized %(month_year)s in %(baptism_place)s%(endnotes)s."
-msgstr "Gedoopt %(month_year)s te %(baptism_place)s.%(endnotes)s"
+msgstr "Gedoopt %(month_year)s te %(baptism_place)s.%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:642
 #, python-format
 msgid "%(male_name)s was baptized in %(month_year)s%(endnotes)s."
-msgstr "%(male_name)s werd gedoopt in %(month_year)s%(endnotes)s"
+msgstr "%(male_name)s werd gedoopt in %(month_year)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:643
 #, python-format
@@ -26588,7 +26627,7 @@ msgstr "Zij werd gedoopt in %(month_year)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:650
 #, python-format
 msgid "%(unknown_gender_name)s was baptized in %(month_year)s%(endnotes)s."
-msgstr "%(unknown_gender_name)s werd gedoopt in %(month_year)s.%(endnotes)s"
+msgstr "%(unknown_gender_name)s werd gedoopt in %(month_year)s.%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:651
 #, python-format
@@ -26605,12 +26644,13 @@ msgstr "Gedoopt %(month_year)s%(endnotes)s."
 msgid ""
 "%(male_name)s was baptized %(modified_date)s in %(baptism_place)s%(endnotes)s."
 msgstr ""
-"%(male_name)s werd gedoopt %(modified_date)s te %(baptism_place)s.%(endnotes)s"
+"%(male_name)s werd gedoopt %(modified_date)s te %(baptism_place)s."
+"%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:659
 #, python-format
 msgid "He was baptized %(modified_date)s in %(baptism_place)s%(endnotes)s."
-msgstr "Hij werd gedoopt %(modified_date)s te %(baptism_place)s.%(endnotes)s"
+msgstr "Hij werd gedoopt %(modified_date)s te %(baptism_place)s.%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:662
 #, python-format
@@ -26619,7 +26659,7 @@ msgid ""
 "%(endnotes)s."
 msgstr ""
 "%(female_name)s werd gedoopt %(modified_date)s te %(baptism_place)s."
-"%(endnotes)s"
+"%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:663
 #, python-format
@@ -26650,17 +26690,17 @@ msgstr "Gedoopt %(modified_date)s te %(baptism_place)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:674
 #, python-format
 msgid "%(male_name)s was baptized %(modified_date)s%(endnotes)s."
-msgstr "%(male_name)s werd gedoopt %(modified_date)s%(endnotes)s"
+msgstr "%(male_name)s werd gedoopt %(modified_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:675
 #, python-format
 msgid "He was baptized %(modified_date)s%(endnotes)s."
-msgstr "Hij werd gedoopt %(modified_date)s.%(endnotes)s"
+msgstr "Hij werd gedoopt %(modified_date)s.%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:678
 #, python-format
 msgid "%(female_name)s was baptized %(modified_date)s%(endnotes)s."
-msgstr "%(female_name)s werd gedoopt %(modified_date)s.%(endnotes)s"
+msgstr "%(female_name)s werd gedoopt %(modified_date)s.%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:679
 #, python-format
@@ -26670,7 +26710,7 @@ msgstr "Zij werd gedoopt %(modified_date)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:682
 #, python-format
 msgid "%(unknown_gender_name)s was baptized %(modified_date)s%(endnotes)s."
-msgstr "%(unknown_gender_name)s werd gedoopt %(modified_date)s.%(endnotes)s"
+msgstr "%(unknown_gender_name)s werd gedoopt %(modified_date)s.%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:683
 #, python-format
@@ -26695,7 +26735,7 @@ msgstr "Hij werd gedoopt te %(baptism_place)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:694
 #, python-format
 msgid "%(female_name)s was baptized in %(baptism_place)s%(endnotes)s."
-msgstr "%(female_name)s werd gedoopt te %(baptism_place)s.%(endnotes)s"
+msgstr "%(female_name)s werd gedoopt te %(baptism_place)s.%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:695
 #, python-format
@@ -26705,7 +26745,7 @@ msgstr "Zij werd gedoopt te %(baptism_place)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:698
 #, python-format
 msgid "%(unknown_gender_name)s was baptized in %(baptism_place)s%(endnotes)s."
-msgstr "%(unknown_gender_name)s werd gedoopt te %(baptism_place)s.%(endnotes)s"
+msgstr "%(unknown_gender_name)s werd gedoopt te %(baptism_place)s.%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:699
 #, python-format
@@ -26715,17 +26755,17 @@ msgstr "Deze persoon werd bedoopt te %(baptism_place)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:701
 #, python-format
 msgid "Baptized in %(baptism_place)s%(endnotes)s."
-msgstr "Gedoopt te %(baptism_place)s%(endnotes)s"
+msgstr "Gedoopt te %(baptism_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:706
 #, python-format
 msgid "%(male_name)s was baptized%(endnotes)s."
-msgstr "%(male_name)s werd gedoopt%(endnotes)s"
+msgstr "%(male_name)s werd gedoopt%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:707
 #, python-format
 msgid "He was baptized%(endnotes)s."
-msgstr "Hij werd gedoopt.%(endnotes)s"
+msgstr "Hij werd gedoopt.%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:710
 #, python-format
@@ -26750,7 +26790,7 @@ msgstr "Deze persoon werd gedoopt %(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:717
 #, python-format
 msgid "Baptized%(endnotes)s."
-msgstr "Gedoopt%(endnotes)s"
+msgstr "Gedoopt%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:727
 #, python-format
@@ -26794,7 +26834,7 @@ msgid ""
 "%(christening_place)s%(endnotes)s."
 msgstr ""
 "%(unknown_gender_name)s werd gedoopt op %(christening_date)s te "
-"%(christening_place)s.%(endnotes)s"
+"%(christening_place)s.%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:736
 #, python-format
@@ -26808,7 +26848,7 @@ msgstr ""
 #: ../gramps/plugins/lib/libnarrate.py:738
 #, python-format
 msgid "Christened %(christening_date)s in %(christening_place)s%(endnotes)s."
-msgstr "Gedoopt %(christening_date)s te %(christening_place)s.%(endnotes)s"
+msgstr "Gedoopt %(christening_date)s te %(christening_place)s.%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:743
 #, python-format
@@ -26818,12 +26858,12 @@ msgstr "%(male_name)s werd gedoopt op %(christening_date)s.%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:744
 #, python-format
 msgid "He was christened on %(christening_date)s%(endnotes)s."
-msgstr "Hij werd gedoopt op %(christening_date)s.%(endnotes)s"
+msgstr "Hij werd gedoopt op %(christening_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:747
 #, python-format
 msgid "%(female_name)s was christened on %(christening_date)s%(endnotes)s."
-msgstr "%(female_name)s werd gedoopt op %(christening_date)s.%(endnotes)s"
+msgstr "%(female_name)s werd gedoopt op %(christening_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:748
 #, python-format
@@ -26835,7 +26875,7 @@ msgstr "Zij werd gedoopt op %(christening_date)s%(endnotes)s."
 msgid ""
 "%(unknown_gender_name)s was christened on %(christening_date)s%(endnotes)s."
 msgstr ""
-"%(unknown_gender_name)s werd gedoopt op %(christening_date)s.%(endnotes)s"
+"%(unknown_gender_name)s werd gedoopt op %(christening_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:752
 #, python-format
@@ -26845,7 +26885,7 @@ msgstr "Deze persoon werd gedoopt op %(christening_date)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:754
 #, python-format
 msgid "Christened %(christening_date)s%(endnotes)s."
-msgstr "Gedoopt %(christening_date)s.%(endnotes)s"
+msgstr "Gedoopt %(christening_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:759
 #, python-format
@@ -26853,15 +26893,15 @@ msgid ""
 "%(male_name)s was christened in %(month_year)s in %(christening_place)s"
 "%(endnotes)s."
 msgstr ""
-"%(male_name)s werd gedoopt in %(month_year)s te %(christening_place)s."
-"%(endnotes)s"
+"%(male_name)s werd gedoopt in %(month_year)s te %(christening_place)s"
+"%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:760
 #, python-format
 msgid ""
 "He was christened in %(month_year)s in %(christening_place)s%(endnotes)s."
 msgstr ""
-"Hij werd gedoopt in %(month_year)s te %(christening_place)s.%(endnotes)s"
+"Hij werd gedoopt in %(month_year)s te %(christening_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:763
 #, python-format
@@ -26869,8 +26909,8 @@ msgid ""
 "%(female_name)s was christened in %(month_year)s in %(christening_place)s"
 "%(endnotes)s."
 msgstr ""
-"%(female_name)s werd gedoopt in %(month_year)s te %(christening_place)s."
-"%(endnotes)s"
+"%(female_name)s werd gedoopt in %(month_year)s te %(christening_place)s"
+"%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:764
 #, python-format
@@ -26886,7 +26926,7 @@ msgid ""
 "%(christening_place)s%(endnotes)s."
 msgstr ""
 "%(unknown_gender_name)s werd gedoopt in %(month_year)s te "
-"%(christening_place)s.%(endnotes)s"
+"%(christening_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:768
 #, python-format
@@ -26910,7 +26950,7 @@ msgstr "%(male_name)s werd gedoopt in %(month_year)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:776
 #, python-format
 msgid "He was christened in %(month_year)s%(endnotes)s."
-msgstr "Hij werd gedoopt in %(month_year)s.%(endnotes)s"
+msgstr "Hij werd gedoopt in %(month_year)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:779
 #, python-format
@@ -26925,7 +26965,7 @@ msgstr "Zij werd gedoopt in %(month_year)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:783
 #, python-format
 msgid "%(unknown_gender_name)s was christened in %(month_year)s%(endnotes)s."
-msgstr "%(unknown_gender_name)s werd gedoopt in %(month_year)s.%(endnotes)s"
+msgstr "%(unknown_gender_name)s werd gedoopt in %(month_year)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:784
 #, python-format
@@ -26935,7 +26975,7 @@ msgstr "Deze persoon werd gedoopt in %(month_year)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:786
 #, python-format
 msgid "Christened %(month_year)s%(endnotes)s."
-msgstr "Gedoopt %(month_year)s.%(endnotes)s"
+msgstr "Gedoopt %(month_year)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:791
 #, python-format
@@ -26943,15 +26983,15 @@ msgid ""
 "%(male_name)s was christened %(modified_date)s in %(christening_place)s"
 "%(endnotes)s."
 msgstr ""
-"%(male_name)s werd gedoopt %(modified_date)s te %(christening_place)s."
-"%(endnotes)s"
+"%(male_name)s werd gedoopt %(modified_date)s te %(christening_place)s"
+"%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:792
 #, python-format
 msgid ""
 "He was christened %(modified_date)s in %(christening_place)s%(endnotes)s."
 msgstr ""
-"Hij werd gedoopt %(modified_date)s te %(christening_place)s.%(endnotes)s"
+"Hij werd gedoopt %(modified_date)s te %(christening_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:795
 #, python-format
@@ -26959,8 +26999,8 @@ msgid ""
 "%(female_name)s was christened %(modified_date)s in %(christening_place)s"
 "%(endnotes)s."
 msgstr ""
-"%(female_name)s werd gedoopt %(modified_date)s te %(christening_place)s."
-"%(endnotes)s"
+"%(female_name)s werd gedoopt %(modified_date)s te %(christening_place)s"
+"%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:796
 #, python-format
@@ -26990,12 +27030,12 @@ msgstr ""
 #: ../gramps/plugins/lib/libnarrate.py:802
 #, python-format
 msgid "Christened %(modified_date)s in %(christening_place)s%(endnotes)s."
-msgstr "Gedoopt %(modified_date)s te %(christening_place)s.%(endnotes)s"
+msgstr "Gedoopt %(modified_date)s te %(christening_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:807
 #, python-format
 msgid "%(male_name)s was christened %(modified_date)s%(endnotes)s."
-msgstr "%(male_name)s werd gedoopt %(modified_date)s.%(endnotes)s"
+msgstr "%(male_name)s werd gedoopt %(modified_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:808
 #, python-format
@@ -27030,17 +27070,17 @@ msgstr "Gedoopt %(modified_date)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:823
 #, python-format
 msgid "%(male_name)s was christened in %(christening_place)s%(endnotes)s."
-msgstr "%(male_name)s werd gedoopt in %(christening_place)s.%(endnotes)s"
+msgstr "%(male_name)s werd gedoopt in %(christening_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:824
 #, python-format
 msgid "He was christened in %(christening_place)s%(endnotes)s."
-msgstr "Hij werd gedoopt te %(christening_place)s.%(endnotes)s"
+msgstr "Hij werd gedoopt te %(christening_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:827
 #, python-format
 msgid "%(female_name)s was christened in %(christening_place)s%(endnotes)s."
-msgstr "%(female_name)s werd gedoopt te %(christening_place)s.%(endnotes)s"
+msgstr "%(female_name)s werd gedoopt te %(christening_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:828
 #, python-format
@@ -27087,7 +27127,7 @@ msgstr "Zij werd gedoopt%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:847
 #, python-format
 msgid "%(unknown_gender_name)s was christened%(endnotes)s."
-msgstr "%(unknown_gender_name)s werd gedoopt.%(endnotes)s"
+msgstr "%(unknown_gender_name)s werd gedoopt%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:848
 #, python-format
@@ -27097,7 +27137,7 @@ msgstr "Deze persoon werd gedoopt %(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:850
 #, python-format
 msgid "Christened%(endnotes)s."
-msgstr "Gedoopt.%(endnotes)s"
+msgstr "Gedoopt%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:861
 #, python-format
@@ -27811,7 +27851,7 @@ msgid ""
 "%(place)s%(endnotes)s."
 msgstr ""
 "Hij had tevens een relatie (geen huwelijk) met %(spouse)s in %(partial_date)s "
-"te %(place)s.%(endnotes)s"
+"te %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1127
 #, python-format
@@ -28917,8 +28957,9 @@ msgid "Bottom Right"
 msgstr "Rechtsonder"
 
 #: ../gramps/plugins/lib/maps/geography.py:308
-#: ../gramps/plugins/view/fanchartdescview.py:166
-#: ../gramps/plugins/view/fanchartview.py:164
+#: ../gramps/plugins/view/fanchart2wayview.py:177
+#: ../gramps/plugins/view/fanchartdescview.py:172
+#: ../gramps/plugins/view/fanchartview.py:168
 msgid "_Print..."
 msgstr "Afdrukken..."
 
@@ -28973,7 +29014,7 @@ msgstr "'%(map)s' vervangen door =>"
 #: ../gramps/plugins/lib/maps/geography.py:415
 #, python-format
 msgid "Reload all visible tiles for '%(map)s'."
-msgstr ""
+msgstr "Alle zichtbare tegels van '%(map)s' herladen."
 
 #: ../gramps/plugins/lib/maps/geography.py:425
 #, python-format
@@ -28982,7 +29023,7 @@ msgstr "De '%(map)s' tegels cache wissen."
 
 #: ../gramps/plugins/lib/maps/geography.py:882
 msgid "You can't use the print functionality"
-msgstr ""
+msgstr "De printfunctie is niet beschikbaar"
 
 #: ../gramps/plugins/lib/maps/geography.py:883
 msgid "Your Gtk version is too old."
@@ -29484,16 +29525,16 @@ msgstr "Onderwerp"
 #: ../gramps/plugins/quickview/filterbyname.py:91
 #: ../gramps/plugins/quickview/filterbyname.py:116
 #: ../gramps/plugins/textreport/tagreport.py:143
-#: ../gramps/plugins/view/view.gpr.py:180 ../gramps/plugins/view/view.gpr.py:188
-#: ../gramps/plugins/view/view.gpr.py:197
+#: ../gramps/plugins/view/view.gpr.py:195 ../gramps/plugins/view/view.gpr.py:203
+#: ../gramps/plugins/view/view.gpr.py:212
 msgid "People"
 msgstr "Personen"
 
 #: ../gramps/plugins/quickview/filterbyname.py:103
 #: ../gramps/plugins/quickview/filterbyname.py:128
 #: ../gramps/plugins/view/sourceview.py:115
-#: ../gramps/plugins/view/view.gpr.py:250 ../gramps/plugins/view/view.gpr.py:258
-#: ../gramps/plugins/view/view.gpr.py:289
+#: ../gramps/plugins/view/view.gpr.py:265 ../gramps/plugins/view/view.gpr.py:273
+#: ../gramps/plugins/view/view.gpr.py:304
 #: ../gramps/plugins/webreport/narrativeweb.py:994
 #: ../gramps/plugins/webreport/narrativeweb.py:1311
 #: ../gramps/plugins/webreport/narrativeweb.py:1486
@@ -29510,8 +29551,8 @@ msgstr "Bronnen"
 #: ../gramps/plugins/quickview/filterbyname.py:106
 #: ../gramps/plugins/quickview/filterbyname.py:131
 #: ../gramps/plugins/textreport/tagreport.py:637
-#: ../gramps/plugins/view/repoview.py:129 ../gramps/plugins/view/view.gpr.py:235
-#: ../gramps/plugins/view/view.gpr.py:243
+#: ../gramps/plugins/view/repoview.py:129 ../gramps/plugins/view/view.gpr.py:250
+#: ../gramps/plugins/view/view.gpr.py:258
 #: ../gramps/plugins/webreport/narrativeweb.py:1879
 #: ../gramps/plugins/webreport/narrativeweb.py:2008
 #: ../gramps/plugins/webreport/narrativeweb.py:3025
@@ -30736,7 +30777,7 @@ msgstr "Personen per generaties tonen"
 
 #: ../gramps/plugins/textreport/detdescendantreport.py:1002
 msgid "show people by lineage"
-msgstr ""
+msgstr "personen volgens afstamming tonen"
 
 #: ../gramps/plugins/textreport/detdescendantreport.py:1003
 msgid "How people are organized in the report"
@@ -30861,9 +30902,8 @@ msgid "The center family for the filter"
 msgstr "Het centrale gezin voor de filter"
 
 #: ../gramps/plugins/textreport/familygroup.py:728
-#, fuzzy
 msgid "Recursive (down)"
-msgstr "Recursief"
+msgstr "Recursief (naar onder)"
 
 #: ../gramps/plugins/textreport/familygroup.py:729
 msgid "Create reports for all descendants of this family."
@@ -31051,14 +31091,12 @@ msgid "Include Notes"
 msgstr "Opmerkingen bijvoegen"
 
 #: ../gramps/plugins/textreport/indivcomplete.py:1100
-#, fuzzy
 msgid "Whether to include Person and Family Notes."
-msgstr "Al of niet andere namen toevoegen."
+msgstr "Al of niet opmerkingen van personen en families toevoegen."
 
 #: ../gramps/plugins/textreport/indivcomplete.py:1103
-#, fuzzy
 msgid "Include Tags"
-msgstr "Datums bijvoegen"
+msgstr "Tags bijvoegen"
 
 #: ../gramps/plugins/textreport/indivcomplete.py:1104
 msgid "Whether to include tags."
@@ -31500,18 +31538,6 @@ msgstr ""
 msgid "Tag Report for %s Items"
 msgstr "Tagverslag voor %s elementen"
 
-#: ../gramps/plugins/textreport/tagreport.py:154
-#: ../gramps/plugins/textreport/tagreport.py:242
-#: ../gramps/plugins/textreport/tagreport.py:331
-#: ../gramps/plugins/textreport/tagreport.py:414
-#: ../gramps/plugins/textreport/tagreport.py:495
-#: ../gramps/plugins/textreport/tagreport.py:564
-#: ../gramps/plugins/textreport/tagreport.py:648
-#: ../gramps/plugins/textreport/tagreport.py:733
-#: ../gramps/plugins/textreport/tagreport.py:813
-msgid "Id"
-msgstr "Id"
-
 #: ../gramps/plugins/textreport/tagreport.py:666
 msgid "Email Address"
 msgstr "E-mailadres"
@@ -31917,29 +31943,28 @@ msgstr "Naar problemen met opmerkingenverwijzingen zoeken"
 msgid "Updating checksums on media"
 msgstr "Controlesommen op media bijwerken"
 
-#: ../gramps/plugins/tool/check.py:1882
+#: ../gramps/plugins/tool/check.py:1887
 msgid "Looking for tag reference problems"
 msgstr "Naar problemen met tagverwijzingen zoeken"
 
-#: ../gramps/plugins/tool/check.py:1957
+#: ../gramps/plugins/tool/check.py:2032
 msgid "Looking for media source reference problems"
 msgstr "Naar problemen met mediabronverwijzingen zoeken"
 
 # Duplicaat
-#: ../gramps/plugins/tool/check.py:2022
-#, fuzzy
+#: ../gramps/plugins/tool/check.py:2100
 msgid "Looking for Duplicated Gramps ID problems"
-msgstr "Mogelijke dubbele echtgenoten zoeken"
+msgstr "Mogelijke dubbele Gramps ID zoeken"
 
-#: ../gramps/plugins/tool/check.py:2253
+#: ../gramps/plugins/tool/check.py:2331
 msgid "No errors were found"
 msgstr "Er zijn geen fouten gevonden"
 
-#: ../gramps/plugins/tool/check.py:2254
+#: ../gramps/plugins/tool/check.py:2332
 msgid "The database has passed internal checks"
 msgstr "Het gegevensbestand is goed door de interne controle gekomen"
 
-#: ../gramps/plugins/tool/check.py:2257
+#: ../gramps/plugins/tool/check.py:2335
 msgid "No errors were found: the database has passed internal checks."
 msgstr ""
 "Geen fouten gevonden: het gegevensbestand is goed door de interne controle "
@@ -31947,24 +31972,24 @@ msgstr ""
 
 # gebroken link, klinkt zo stom, verkeerd is duidelijker, komt op hetzelfde neer.
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2264
+#: ../gramps/plugins/tool/check.py:2342
 #, python-brace-format
 msgid "{quantity} broken child/family link was fixed\n"
 msgid_plural "{quantity} broken child/family links were fixed\n"
 msgstr[0] "Er is {quantity} gebroken kind-gezin verwijzing hersteld\n"
 msgstr[1] "Er zijn {quantity} gebroken kind-gezin verwijzingen hersteld\n"
 
-#: ../gramps/plugins/tool/check.py:2272
+#: ../gramps/plugins/tool/check.py:2350
 msgid "Non existing child"
 msgstr "Niet bestaand kind"
 
-#: ../gramps/plugins/tool/check.py:2283
+#: ../gramps/plugins/tool/check.py:2361
 #, python-format
 msgid "%(person)s was removed from the family of %(family)s\n"
 msgstr "%(person)s is verwijderd uit het gezin %(family)s\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2290
+#: ../gramps/plugins/tool/check.py:2368
 #, python-brace-format
 msgid "{quantity} broken spouse/family link was fixed\n"
 msgid_plural "{quantity} broken spouse/family links were fixed\n"
@@ -31973,17 +31998,17 @@ msgstr[0] ""
 msgstr[1] ""
 "Er werden {quantity} gebroken echtgeno(o)t(e)-gezinsverwijzingen hersteld\n"
 
-#: ../gramps/plugins/tool/check.py:2298 ../gramps/plugins/tool/check.py:2326
+#: ../gramps/plugins/tool/check.py:2376 ../gramps/plugins/tool/check.py:2404
 msgid "Non existing person"
 msgstr "Niet bestaand persoon"
 
-#: ../gramps/plugins/tool/check.py:2309 ../gramps/plugins/tool/check.py:2337
+#: ../gramps/plugins/tool/check.py:2387 ../gramps/plugins/tool/check.py:2415
 #, python-format
 msgid "%(person)s was restored to the family of %(family)s\n"
 msgstr "%(person)s werd terug geplaatst in het gezin %(family)s\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2316
+#: ../gramps/plugins/tool/check.py:2394
 #, python-brace-format
 msgid "{quantity} duplicate spouse/family link was found\n"
 msgid_plural "{quantity} duplicate spouse/family links were found\n"
@@ -31991,7 +32016,7 @@ msgstr[0] "{quantity} dubbele echtgenoot/gezinsverwijzing werd gevonden\n"
 msgstr[1] "{quantity} dubbele echtgenoten/gezinsverwijzgingen werden gevonden\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2344
+#: ../gramps/plugins/tool/check.py:2422
 #, python-brace-format
 msgid "{quantity} family with no parents or children found, removed.\n"
 msgid_plural "{quantity} families with no parents or children found, removed.\n"
@@ -32001,7 +32026,7 @@ msgstr[1] ""
 "{quantity} gezinnen met ouders noch kinderen werd gevonden en verwijderd.\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2356
+#: ../gramps/plugins/tool/check.py:2434
 #, python-brace-format
 msgid "{quantity} corrupted family relationship fixed\n"
 msgid_plural "{quantity} corrupted family relationships fixed\n"
@@ -32009,14 +32034,14 @@ msgstr[0] "{quantity}  gecorrumpeerde gezinsrelatie hersteld\n"
 msgstr[1] "{quantity} gecorrumpeerde gezinsrelaties herstekd\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2364
+#: ../gramps/plugins/tool/check.py:2442
 #, fuzzy, python-brace-format
 msgid "{quantity} place alternate name fixed\n"
 msgid_plural "{quantity} place alternate names fixed\n"
 msgstr[0] "{quantity}  ongeldige sterfgeval werd verbeterd\n"
 msgstr[1] "{quantity}  ongeldige sterfgevallen werden verbeterd\n"
 
-#: ../gramps/plugins/tool/check.py:2373
+#: ../gramps/plugins/tool/check.py:2451
 #, python-brace-format
 msgid "{quantity} person was referenced but not found\n"
 msgid_plural "{quantity} persons were referenced, but not found\n"
@@ -32026,7 +32051,7 @@ msgstr[1] ""
 "naar {quantity} gebeurtenissen werd verwezen maar die werden niet gevonden\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2381
+#: ../gramps/plugins/tool/check.py:2459
 #, python-brace-format
 msgid "{quantity} family was referenced but not found\n"
 msgid_plural "{quantity} families were referenced, but not found\n"
@@ -32036,14 +32061,14 @@ msgstr[1] ""
 "Er werd naar {quantity} gezinnen verwezen, die niet konden worden gevonden\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2391
+#: ../gramps/plugins/tool/check.py:2469
 #, python-brace-format
 msgid "{quantity} date was corrected\n"
 msgid_plural "{quantity} dates were corrected\n"
 msgstr[0] "{quantity} datum werd verbeterd\n"
 msgstr[1] "{quantity} datums werden verbeterd\n"
 
-#: ../gramps/plugins/tool/check.py:2400
+#: ../gramps/plugins/tool/check.py:2478
 #, python-brace-format
 msgid "{quantity} repository was referenced but not found\n"
 msgid_plural "{quantity} repositories were referenced, but not found\n"
@@ -32053,7 +32078,7 @@ msgstr[1] ""
 "Er waren verwijzingen naar {quantity} bibliotheken, die niet werden gevonden\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2410 ../gramps/plugins/tool/check.py:2497
+#: ../gramps/plugins/tool/check.py:2488 ../gramps/plugins/tool/check.py:2575
 #, python-brace-format
 msgid "{quantity} media object was referenced but not found\n"
 msgid_plural "{quantity} media objects were referenced, but not found\n"
@@ -32063,7 +32088,7 @@ msgstr[1] ""
 "Er waren verwijzingen naar {quantity} media-objecten welke niet werden "
 "gevonden\n"
 
-#: ../gramps/plugins/tool/check.py:2421
+#: ../gramps/plugins/tool/check.py:2499
 #, python-brace-format
 msgid "Reference to {quantity} missing media object was kept\n"
 msgid_plural "References to {quantity} media objects were kept\n"
@@ -32072,7 +32097,7 @@ msgstr[1] ""
 "Verwijzingen naar {quantity} ontbrekende media-objecten werden behouden\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2429
+#: ../gramps/plugins/tool/check.py:2507
 #, python-brace-format
 msgid "{quantity} missing media object was replaced\n"
 msgid_plural "{quantity} missing media objects were replaced\n"
@@ -32080,7 +32105,7 @@ msgstr[0] "{quantity} ontbrekend media-object werd vervangen\n"
 msgstr[1] "{quantity}  ontbrekende media-objecten werden vervangen\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2437
+#: ../gramps/plugins/tool/check.py:2515
 #, python-brace-format
 msgid "{quantity} missing media object was removed\n"
 msgid_plural "{quantity} missing media objects were removed\n"
@@ -32088,7 +32113,7 @@ msgstr[0] "{quantity}  ontbrekend media-object werd verwijderd\n"
 msgstr[1] "{quantity}  ontbrekende media-objecten werden verwijderd\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2445
+#: ../gramps/plugins/tool/check.py:2523
 #, python-brace-format
 msgid "{quantity} event was referenced but not found\n"
 msgid_plural "{quantity} events were referenced, but not found\n"
@@ -32098,7 +32123,7 @@ msgstr[1] ""
 "naar {quantity} gebeurtenissen werd verwezen maar die werden niet gevonden\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2453
+#: ../gramps/plugins/tool/check.py:2531
 #, python-brace-format
 msgid "{quantity} invalid birth event name was fixed\n"
 msgid_plural "{quantity} invalid birth event names were fixed\n"
@@ -32106,7 +32131,7 @@ msgstr[0] "{quantity} ongeldige geboorte verbeterd\n"
 msgstr[1] "{quantity} ongeldige geboortes werden verbeterd\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2461
+#: ../gramps/plugins/tool/check.py:2539
 #, python-brace-format
 msgid "{quantity} invalid death event name was fixed\n"
 msgid_plural "{quantity} invalid death event names were fixed\n"
@@ -32114,14 +32139,14 @@ msgstr[0] "{quantity}  ongeldige sterfgeval werd verbeterd\n"
 msgstr[1] "{quantity}  ongeldige sterfgevallen werden verbeterd\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2469
+#: ../gramps/plugins/tool/check.py:2547
 #, python-brace-format
 msgid "{quantity} place was referenced but not found\n"
 msgid_plural "{quantity} places were referenced, but not found\n"
 msgstr[0] "{quantity}  verwijzing naar een locatie, die niet werd gevonden\n"
 msgstr[1] "{quantity}  verwijzingen naar locaties, die niet werden gevonden\n"
 
-#: ../gramps/plugins/tool/check.py:2478
+#: ../gramps/plugins/tool/check.py:2556
 #, python-brace-format
 msgid "{quantity} citation was referenced but not found\n"
 msgid_plural "{quantity} citations were referenced, but not found\n"
@@ -32129,7 +32154,7 @@ msgstr[0] "naar {quantity} citaat werd verwezen maar die werd niet gevonden\n"
 msgstr[1] ""
 "naar {quantity} citaten werd verwezen maar die werden niet gevonden\n"
 
-#: ../gramps/plugins/tool/check.py:2488
+#: ../gramps/plugins/tool/check.py:2566
 #, python-brace-format
 msgid "{quantity} source was referenced but not found\n"
 msgid_plural "{quantity} sources were referenced, but not found\n"
@@ -32138,7 +32163,7 @@ msgstr[1] ""
 "Er wordt verwezen naar {quantity} bronnen, maar niet werden niet gevonden\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2506
+#: ../gramps/plugins/tool/check.py:2584
 #, python-brace-format
 msgid "{quantity} note object was referenced but not found\n"
 msgid_plural "{quantity} note objects were referenced, but not found\n"
@@ -32147,7 +32172,7 @@ msgstr[1] ""
 "{quantity}  verwijzingen naar opmerkingen welke niet werden gevonden\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2516 ../gramps/plugins/tool/check.py:2526
+#: ../gramps/plugins/tool/check.py:2594 ../gramps/plugins/tool/check.py:2604
 #, python-brace-format
 msgid "{quantity} tag object was referenced but not found\n"
 msgid_plural "{quantity} tag objects were referenced, but not found\n"
@@ -32155,7 +32180,7 @@ msgstr[0] "naar {quantity} tag werd verwezen maar die werd niet gevonden\n"
 msgstr[1] "naar {quantity} tags werd verwezen maar die werden niet gevonden\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2536
+#: ../gramps/plugins/tool/check.py:2614
 #, python-brace-format
 msgid "{quantity} invalid name format reference was removed\n"
 msgid_plural "{quantity} invalid name format references were removed\n"
@@ -32164,7 +32189,7 @@ msgstr[0] ""
 msgstr[1] ""
 "{quantity}  ongeldige verwijzingen naar een naamformaat werden verwijderd\n"
 
-#: ../gramps/plugins/tool/check.py:2547
+#: ../gramps/plugins/tool/check.py:2625
 #, python-brace-format
 msgid "{quantity} invalid source citation was fixed\n"
 msgid_plural "{quantity} invalid source citations were fixed\n"
@@ -32172,14 +32197,14 @@ msgstr[0] "{quantity}  ongeldige geboorte verbeterd\n"
 msgstr[1] "{quantity}  ongeldige geboortes werden verbeterd\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2556
+#: ../gramps/plugins/tool/check.py:2634
 #, fuzzy, python-brace-format
 msgid "{quantity} Duplicated Gramps ID fixed\n"
 msgid_plural "{quantity} Duplicated Gramps IDs fixed\n"
 msgstr[0] "{quantity}  ongeldige sterfgeval werd verbeterd\n"
 msgstr[1] "{quantity}  ongeldige sterfgevallen werden verbeterd\n"
 
-#: ../gramps/plugins/tool/check.py:2563
+#: ../gramps/plugins/tool/check.py:2641
 #, python-format
 msgid ""
 "%(empty_obj)d empty objects removed:\n"
@@ -32202,11 +32227,11 @@ msgstr ""
 "   %(repo)d bibliotheekobjecten\n"
 "   %(note)d opmerkingobjecten\n"
 
-#: ../gramps/plugins/tool/check.py:2610
+#: ../gramps/plugins/tool/check.py:2688
 msgid "Integrity Check Results"
 msgstr "Integriteitscontrole resultaten"
 
-#: ../gramps/plugins/tool/check.py:2615
+#: ../gramps/plugins/tool/check.py:2693
 msgid "Check and Repair"
 msgstr "Controleren en herstellen"
 
@@ -32832,11 +32857,11 @@ msgstr[1] "De naam opzoeken van {number_of} personen"
 
 #: ../gramps/plugins/tool/ownereditor.glade:10
 msgid "Copy from DB to Preferences"
-msgstr ""
+msgstr "Van DB naar Voorkeuren kopieren"
 
 #: ../gramps/plugins/tool/ownereditor.glade:23
 msgid "Copy from Preferences to DB"
-msgstr ""
+msgstr "Van Voorkeuren naar DB kopieren"
 
 #: ../gramps/plugins/tool/ownereditor.glade:166
 msgid "_Street:"
@@ -32865,7 +32890,7 @@ msgstr "E-mail:"
 
 #: ../gramps/plugins/tool/ownereditor.glade:385
 msgid "Right-click to copy from/to Researcher Preferences"
-msgstr ""
+msgstr "Rechtsklikken om naar/van Onderzoekersvoorkeuren te kopieren"
 
 #: ../gramps/plugins/tool/ownereditor.py:56
 #, fuzzy
@@ -33053,9 +33078,8 @@ msgid "Search for sources"
 msgstr "Naar bronnen zoeken"
 
 #: ../gramps/plugins/tool/removeunused.glade:130
-#, fuzzy
 msgid "Search for citations"
-msgstr "Bron of citaat"
+msgstr "Naar citaten zoeken"
 
 #: ../gramps/plugins/tool/removeunused.glade:145
 msgid "Search for places"
@@ -34020,128 +34044,171 @@ msgstr ""
 "toetsenbord de 'control-toets' in te drukken en dan het gewenste gezin aan te "
 "klikken."
 
-#: ../gramps/plugins/view/fanchartdescview.py:168
-#: ../gramps/plugins/view/fanchartview.py:166
+#: ../gramps/plugins/view/fanchart2wayview.py:179
+#: ../gramps/plugins/view/fanchartdescview.py:174
+#: ../gramps/plugins/view/fanchartview.py:170
 msgid "Print or save the Fan Chart View"
 msgstr "De waaier afdrukken of opslaan"
 
-#: ../gramps/plugins/view/fanchartdescview.py:278
-#: ../gramps/plugins/view/fanchartview.py:276
+#: ../gramps/plugins/view/fanchart2wayview.py:280
+msgid "Max ancestor generations"
+msgstr "Max vooroudergeneraties"
+
+#: ../gramps/plugins/view/fanchart2wayview.py:283
+msgid "Max descendant generations"
+msgstr "Max aantal afstammelingengeneraties"
+
+#: ../gramps/plugins/view/fanchart2wayview.py:287
+#: ../gramps/plugins/view/fanchartdescview.py:284
+#: ../gramps/plugins/view/fanchartview.py:280
 msgid "Text Font"
 msgstr "Lettertype"
 
-#: ../gramps/plugins/view/fanchartdescview.py:282
-#: ../gramps/plugins/view/fanchartview.py:280
+#: ../gramps/plugins/view/fanchart2wayview.py:291
+#: ../gramps/plugins/view/fanchartdescview.py:288
+#: ../gramps/plugins/view/fanchartview.py:284
 msgid "Gender colors"
 msgstr "Kleuren voor de geslachten"
 
-#: ../gramps/plugins/view/fanchartdescview.py:283
-#: ../gramps/plugins/view/fanchartview.py:281
+#: ../gramps/plugins/view/fanchart2wayview.py:292
+#: ../gramps/plugins/view/fanchartdescview.py:289
+#: ../gramps/plugins/view/fanchartview.py:285
 msgid "Generation based gradient"
 msgstr "Kleurverloop gebaseerd op de generaties"
 
-#: ../gramps/plugins/view/fanchartdescview.py:284
-#: ../gramps/plugins/view/fanchartview.py:282
+#: ../gramps/plugins/view/fanchart2wayview.py:293
+#: ../gramps/plugins/view/fanchartdescview.py:290
+#: ../gramps/plugins/view/fanchartview.py:286
 msgid "Age (0-100) based gradient"
 msgstr "Kleurverloop op basis van leeftijd"
 
-#: ../gramps/plugins/view/fanchartdescview.py:286
-#: ../gramps/plugins/view/fanchartview.py:284
+#: ../gramps/plugins/view/fanchart2wayview.py:295
+#: ../gramps/plugins/view/fanchartdescview.py:292
+#: ../gramps/plugins/view/fanchartview.py:288
 msgid "Single main (filter) color"
 msgstr "Een enkele hoofdkleur"
 
-#: ../gramps/plugins/view/fanchartdescview.py:287
-#: ../gramps/plugins/view/fanchartview.py:285
+#: ../gramps/plugins/view/fanchart2wayview.py:296
+#: ../gramps/plugins/view/fanchartdescview.py:293
+#: ../gramps/plugins/view/fanchartview.py:289
 msgid "Time period based gradient"
 msgstr "Kleurverloop gebaseerd op tijdsperiode"
 
-#: ../gramps/plugins/view/fanchartdescview.py:288
-#: ../gramps/plugins/view/fanchartview.py:286
+#: ../gramps/plugins/view/fanchart2wayview.py:297
+#: ../gramps/plugins/view/fanchartdescview.py:294
+#: ../gramps/plugins/view/fanchartview.py:290
 msgid "White"
 msgstr "Wit"
 
-#: ../gramps/plugins/view/fanchartdescview.py:289
-#: ../gramps/plugins/view/fanchartview.py:287
+#: ../gramps/plugins/view/fanchart2wayview.py:298
+#: ../gramps/plugins/view/fanchartdescview.py:295
+#: ../gramps/plugins/view/fanchartview.py:291
 msgid "Color scheme classic report"
 msgstr "Kleurschema voor standaard verslag"
 
-#: ../gramps/plugins/view/fanchartdescview.py:290
-#: ../gramps/plugins/view/fanchartview.py:288
+#: ../gramps/plugins/view/fanchart2wayview.py:299
+#: ../gramps/plugins/view/fanchartdescview.py:296
+#: ../gramps/plugins/view/fanchartview.py:292
 msgid "Color scheme classic view"
 msgstr "Kleurschema voor standaard scherm"
 
-#: ../gramps/plugins/view/fanchartdescview.py:299
-#: ../gramps/plugins/view/fanchartview.py:297
+#: ../gramps/plugins/view/fanchart2wayview.py:308
+#: ../gramps/plugins/view/fanchartdescview.py:305
+#: ../gramps/plugins/view/fanchartview.py:301
 msgid "Background"
 msgstr "Achtergrond"
 
+#: ../gramps/plugins/view/fanchart2wayview.py:317
+msgid "Add global background colored gradient"
+msgstr "Een globale achtergrond met kleurverloop"
+
 #. colors, stored as hex values
-#: ../gramps/plugins/view/fanchartdescview.py:306
-#: ../gramps/plugins/view/fanchartview.py:303
+#: ../gramps/plugins/view/fanchart2wayview.py:321
+#: ../gramps/plugins/view/fanchartdescview.py:312
+#: ../gramps/plugins/view/fanchartview.py:307
 msgid "Start gradient/Main color"
 msgstr "Begin kleurverloop/hoofdkleur"
 
-#: ../gramps/plugins/view/fanchartdescview.py:308
-#: ../gramps/plugins/view/fanchartview.py:305
+#: ../gramps/plugins/view/fanchart2wayview.py:323
+#: ../gramps/plugins/view/fanchartdescview.py:314
+#: ../gramps/plugins/view/fanchartview.py:309
 msgid "End gradient/2nd color"
 msgstr "Einde kleurverloop/2de kleur"
 
 # Duplicaat
-#: ../gramps/plugins/view/fanchartdescview.py:310
+#: ../gramps/plugins/view/fanchart2wayview.py:325
+#: ../gramps/plugins/view/fanchartdescview.py:316
 msgid "Color for duplicates"
 msgstr "Kleur voor duplicaten"
 
-#. form of the fan
-#: ../gramps/plugins/view/fanchartdescview.py:313
-#: ../gramps/plugins/view/fanchartview.py:308
-msgid "Fan chart type"
-msgstr "Type waaier"
-
-#: ../gramps/plugins/view/fanchartdescview.py:315
-#: ../gramps/plugins/view/fanchartview.py:310
-msgid "Full Circle"
-msgstr "Volle cirkel"
-
-#: ../gramps/plugins/view/fanchartdescview.py:316
-#: ../gramps/plugins/view/fanchartview.py:310
-msgid "Half Circle"
-msgstr "Halve cirkel"
-
-#: ../gramps/plugins/view/fanchartdescview.py:317
-#: ../gramps/plugins/view/fanchartview.py:311
-msgid "Quadrant"
-msgstr "Kwadrant"
-
 #. algo for the fan angle distribution
-#: ../gramps/plugins/view/fanchartdescview.py:320
+#: ../gramps/plugins/view/fanchart2wayview.py:328
+#: ../gramps/plugins/view/fanchartdescview.py:326
 msgid "Fan chart distribution"
 msgstr "Verdeling voor de waaier"
 
-#: ../gramps/plugins/view/fanchartdescview.py:323
+#: ../gramps/plugins/view/fanchart2wayview.py:331
+#: ../gramps/plugins/view/fanchartdescview.py:329
 msgid "Homogeneous children distribution"
 msgstr "Gelijke verdeling voor de kinderen"
 
-#: ../gramps/plugins/view/fanchartdescview.py:325
+#: ../gramps/plugins/view/fanchart2wayview.py:333
+#: ../gramps/plugins/view/fanchartdescview.py:331
 msgid "Size  proportional to number of descendants"
 msgstr "Grootte proportioneel met aantal afstammelingen"
+
+#: ../gramps/plugins/view/fanchart2wayview.py:339
+#: ../gramps/plugins/view/fanchartdescview.py:337
+#: ../gramps/plugins/view/fanchartview.py:320
+msgid "Show names on two lines"
+msgstr "Namen op twee lijnen tonen"
+
+#: ../gramps/plugins/view/fanchart2wayview.py:344
+#: ../gramps/plugins/view/fanchartdescview.py:342
+#: ../gramps/plugins/view/fanchartview.py:325
+msgid "Flip name on the left of the fan"
+msgstr "Naam omdraaien links van de waaier"
 
 #. options we don't show on the dialog
 #. #configdialog.add_checkbox(table,
 #. #        _('Allow radial text'),
 #. #        ??, 'interface.fanview-radialtext')
-#: ../gramps/plugins/view/fanchartdescview.py:329
-#: ../gramps/plugins/view/fanchartview.py:323
+#: ../gramps/plugins/view/fanchart2wayview.py:347
+#: ../gramps/plugins/view/fanchartdescview.py:345
+#: ../gramps/plugins/view/fanchartview.py:337
 #: ../gramps/plugins/view/pedigreeview.py:2038
 #: ../gramps/plugins/view/relview.py:1699
 msgid "Layout"
 msgstr "Layout"
 
-#: ../gramps/plugins/view/fanchartdescview.py:502
-#: ../gramps/plugins/view/fanchartview.py:511
+#: ../gramps/plugins/view/fanchart2wayview.py:548
+#: ../gramps/plugins/view/fanchartdescview.py:536
+#: ../gramps/plugins/view/fanchartview.py:543
 msgid "No preview available"
 msgstr "Geen voorvertoning beschikbaar"
 
-#: ../gramps/plugins/view/fanchartview.py:316
+#. form of the fan
+#: ../gramps/plugins/view/fanchartdescview.py:319
+#: ../gramps/plugins/view/fanchartview.py:312
+msgid "Fan chart type"
+msgstr "Type waaier"
+
+#: ../gramps/plugins/view/fanchartdescview.py:321
+#: ../gramps/plugins/view/fanchartview.py:314
+msgid "Full Circle"
+msgstr "Volle cirkel"
+
+#: ../gramps/plugins/view/fanchartdescview.py:322
+#: ../gramps/plugins/view/fanchartview.py:314
+msgid "Half Circle"
+msgstr "Halve cirkel"
+
+#: ../gramps/plugins/view/fanchartdescview.py:323
+#: ../gramps/plugins/view/fanchartview.py:315
+msgid "Quadrant"
+msgstr "Kwadrant"
+
+#: ../gramps/plugins/view/fanchartview.py:330
 msgid "Show children ring"
 msgstr "Ring met kinderen tonen"
 
@@ -34376,8 +34443,7 @@ msgid ""
 "To build it for Gramps see %(gramps_wiki_build_osmgps_url)s"
 msgstr ""
 "Geografische functionaliteit is niet beschikbaar.\n"
-"Kijk op %(gramps_wiki_build_osmgps_url)s om deze functionaliteit voor Gramps "
-"in te bouwen."
+"Om deze functionaliteit in te bouwen, kijk op %(gramps_wiki_build_osmgps_url)s"
 
 #: ../gramps/plugins/view/geography.gpr.py:86
 msgid "All known places for one Person"
@@ -34546,6 +34612,9 @@ msgid ""
 "with coordinates. You can change the markers color depending on place type. "
 "You can use filtering."
 msgstr ""
+"Door op de kaart rechts te klikken en 'alle locaties tonen' te selecteren "
+"worden alle locaties met coördinaten getoond. De kleur van de merkers kunnen "
+"veranderd worden volgens het locatietype. Filtering is mogelijk."
 
 #: ../gramps/plugins/view/geoplaces.py:380
 msgid ""
@@ -35059,7 +35128,7 @@ msgid "The view showing an ancestor pedigree of the selected person"
 msgstr "Het scherm toont een voorouderstamboom van de geselecteerde persoon"
 
 #: ../gramps/plugins/view/view.gpr.py:133 ../gramps/plugins/view/view.gpr.py:142
-#: ../gramps/plugins/view/view.gpr.py:157
+#: ../gramps/plugins/view/view.gpr.py:157 ../gramps/plugins/view/view.gpr.py:172
 msgid "Charts"
 msgstr "Grafieken"
 
@@ -35071,49 +35140,53 @@ msgstr "Een scherm dat de ouders toont in waaier"
 msgid "Showing descendants through a fanchart"
 msgstr "Afstammelingen in een waaier tonen"
 
-#: ../gramps/plugins/view/view.gpr.py:171
+#: ../gramps/plugins/view/view.gpr.py:173
+msgid "Showing ascendants and descendants through a fanchart"
+msgstr "Voorouders en afstammelingen in een waaier tonen"
+
+#: ../gramps/plugins/view/view.gpr.py:186
 msgid "Grouped People"
 msgstr "Gegroepeerde personen"
 
-#: ../gramps/plugins/view/view.gpr.py:172
+#: ../gramps/plugins/view/view.gpr.py:187
 msgid "The view showing all people in the Family Tree grouped per family name"
 msgstr ""
 "Het scherm dat alle personen in de stamboom gegroepeerd per familienaam toont"
 
-#: ../gramps/plugins/view/view.gpr.py:189
+#: ../gramps/plugins/view/view.gpr.py:204
 msgid "The view showing all people in the Family Tree in a flat list"
 msgstr "Het scherm dat alle personen in de stamboom in een lijst toont"
 
-#: ../gramps/plugins/view/view.gpr.py:205
+#: ../gramps/plugins/view/view.gpr.py:220
 msgid "The view showing all the places of the Family Tree"
 msgstr "Het scherm dat alle locaties van de stamboom toont"
 
 # Plaatsnaam
-#: ../gramps/plugins/view/view.gpr.py:219
+#: ../gramps/plugins/view/view.gpr.py:234
 msgid "Place Tree"
 msgstr "Locatieboomstruktuur"
 
-#: ../gramps/plugins/view/view.gpr.py:220
+#: ../gramps/plugins/view/view.gpr.py:235
 msgid "A view displaying places in a tree format."
 msgstr "Een scherm waar de locaties in een boomstruktuur getoond worden."
 
-#: ../gramps/plugins/view/view.gpr.py:236
+#: ../gramps/plugins/view/view.gpr.py:251
 msgid "The view showing all the repositories"
 msgstr "Scherm toont alle bibliotheken"
 
-#: ../gramps/plugins/view/view.gpr.py:251
+#: ../gramps/plugins/view/view.gpr.py:266
 msgid "The view showing all the sources"
 msgstr "Scherm toont alle bronnen"
 
-#: ../gramps/plugins/view/view.gpr.py:267
+#: ../gramps/plugins/view/view.gpr.py:282
 msgid "The view showing all the citations"
 msgstr "Het scherm toont alle citaten"
 
-#: ../gramps/plugins/view/view.gpr.py:281
+#: ../gramps/plugins/view/view.gpr.py:296
 msgid "Citation Tree"
 msgstr "Citatenscherm met boomstruktuur"
 
-#: ../gramps/plugins/view/view.gpr.py:282
+#: ../gramps/plugins/view/view.gpr.py:297
 msgid "A view displaying citations and sources in a tree format."
 msgstr ""
 "Een scherm waar de citaten en bronnen in een boomstruktuur getoond worden."
@@ -35143,11 +35216,10 @@ msgid "Postal Code"
 msgstr "Postcode"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1675
-#, fuzzy, python-format
+#, python-format
 msgid "Generated by %(gramps_home_html_start)sGramps%(html_end)s %(version)s"
 msgstr ""
-"Gegenereerd met %(gramps_home_html_start)sGramps%(html_end)s %(version)s op "
-"%(date)s"
+"Gegenereerd met %(gramps_home_html_start)sGramps%(html_end)s %(version)s"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1685
 #, python-format
@@ -35651,15 +35723,13 @@ msgid "Full Name"
 msgstr "Volledige naam"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:8091
-#, fuzzy
 msgid "Database overview"
-msgstr "Gegevensbestand geopend"
+msgstr "Overzicht gegevensbestand"
 
 # webstek
 #: ../gramps/plugins/webreport/narrativeweb.py:8157
-#, fuzzy
 msgid "Narrative web content report for"
-msgstr "Websiteverslag"
+msgstr "Verslag inhoud webstek voor"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:8367
 #, python-format
@@ -35725,9 +35795,8 @@ msgid "Creating thumbnail preview page..."
 msgstr "Pagina's voor de voorvertoning van de miniaturen aanmaken..."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:9195
-#, fuzzy
 msgid "Creating statistics page..."
-msgstr "Gezinspagina's aanmaken..."
+msgstr "Statistiekpagina aanmaken..."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:9237
 msgid "Creating address book pages ..."
@@ -35945,9 +36014,8 @@ msgid "Include unused images and media objects"
 msgstr "Ongebruikte plaatjes en media-objecten bijvoegen"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:9779
-#, fuzzy
 msgid "Whether to include unused or unreferenced media objects"
-msgstr "Al of niet een galerij van de media-objecten toevoegen"
+msgstr "Al of niet niet gebruikte of ongerefereerde media-objecten toevoegen"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:9784
 msgid "Create and only use thumbnail- sized images"
@@ -36224,22 +36292,20 @@ msgstr ""
 "familiekaarten..."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:9995
-#, fuzzy
 msgid "Google maps API key"
-msgstr "GoogleMaps"
+msgstr "GoogleMaps API sleutel"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:9996
-#, fuzzy
 msgid "The API key used for the Google maps"
-msgstr "De gebruikte opmaak voor de voettekst."
+msgstr "De gebruikte API sleutel voor de GoogleMaps"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:10005
 msgid "Other inclusion (CMS, Web Calendar, Php)"
-msgstr ""
+msgstr "Andere toevoegingen ( CMS, Web Calendar, Php)"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:10009
 msgid "Do we include these pages in a cms web ?"
-msgstr ""
+msgstr "Deze pagina's in een 'cms web' toeveogen?"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:10013
 #: ../gramps/plugins/webreport/narrativeweb.py:10030
@@ -36248,16 +36314,15 @@ msgstr "URI"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:10019
 msgid "Where do you place your web site ? default = /NAVWEB"
-msgstr ""
+msgstr "Waar uw webstek plaatsen? standaard = /NAVWEB"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:10026
-#, fuzzy
 msgid "Do we include the web calendar ?"
-msgstr "Kalendertitel"
+msgstr "Webkalender toevoegen?"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:10036
 msgid "Where do you place your web site ? default = /WEBCAL"
-msgstr ""
+msgstr "Waar uw webstek plaatsen? standaard = /WEBCAL"
 
 #. adding title to hyperlink menu for screen readers and
 #. braille writers

--- a/po/nl.po
+++ b/po/nl.po
@@ -43,8 +43,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gramps\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-05 09:47+0100\n"
-"PO-Revision-Date: 2016-12-11 22:35+0100\n"
+"POT-Creation-Date: 2016-12-10 10:01-0800\n"
+"PO-Revision-Date: 2016-12-14 10:39+0100\n"
 "Last-Translator: Frederik De Richter <frederik.de.richter@gmail.com>\n"
 "Language-Team: nederlands <frederik.de.richter@gmail.com>\n"
 "Language: nl\n"
@@ -80,7 +80,7 @@ msgstr ""
 "Al uw onderzoek wordt geordend en doorzoekbaar gemaakt, precies zoals u dat "
 "wilt."
 
-#: ../data/gramps.desktop.in.h:1 ../gramps/gui/glade/displaystate.glade:8
+#: ../data/gramps.desktop.in.h:1
 msgid "Gramps"
 msgstr "Gramps"
 
@@ -1226,7 +1226,7 @@ msgstr "Gramps-stambomen:"
 #: ../gramps/cli/arghandler.py:441 ../gramps/cli/arghandler.py:442
 #: ../gramps/cli/arghandler.py:444 ../gramps/cli/clidbman.py:69
 #: ../gramps/cli/clidbman.py:172 ../gramps/cli/clidbman.py:193
-#: ../gramps/gui/clipboard.py:970 ../gramps/gui/configure.py:1466
+#: ../gramps/gui/clipboard.py:970 ../gramps/gui/configure.py:1501
 msgid "Family Tree"
 msgstr "Stamboom"
 
@@ -1639,7 +1639,7 @@ msgstr "Pad"
 msgid "Database"
 msgstr "Gegevensbestand"
 
-#: ../gramps/cli/clidbman.py:175 ../gramps/gui/dbman.py:396
+#: ../gramps/cli/clidbman.py:175 ../gramps/gui/dbman.py:395
 msgid "Last accessed"
 msgstr "Laatste toegang"
 
@@ -1685,7 +1685,7 @@ msgstr ""
 "Weet u zeker dat u de stamboom wilt verwijderen\n"
 "\"%s\"?"
 
-#: ../gramps/cli/clidbman.py:441 ../gramps/gui/dbman.py:718
+#: ../gramps/cli/clidbman.py:441 ../gramps/gui/dbman.py:717
 msgid "Could not delete Family Tree"
 msgstr "Kon de stamboom niet verwijderen"
 
@@ -1712,7 +1712,8 @@ msgstr ""
 "    %s\n"
 "\n"
 
-#: ../gramps/cli/clidbman.py:540 ../gramps/gui/configure.py:1357
+#: ../gramps/cli/clidbman.py:540 ../gramps/gui/configure.py:1365
+#: ../gramps/gui/configure.py:1489
 msgid "Never"
 msgstr "Nooit"
 
@@ -1734,12 +1735,12 @@ msgstr "Vergrendeld door %s"
 #: ../gramps/gen/utils/lds.py:86 ../gramps/gen/utils/unknown.py:119
 #: ../gramps/gen/utils/unknown.py:121 ../gramps/gen/utils/unknown.py:125
 #: ../gramps/gen/utils/unknown.py:131 ../gramps/gen/utils/unknown.py:136
-#: ../gramps/gui/clipboard.py:183 ../gramps/gui/dbman.py:979
+#: ../gramps/gui/clipboard.py:183 ../gramps/gui/dbman.py:978
 #: ../gramps/gui/editors/displaytabs/personrefembedlist.py:125
 #: ../gramps/gui/editors/displaytabs/personrefembedlist.py:143
-#: ../gramps/gui/editors/editmedia.py:180
+#: ../gramps/gui/editors/editmedia.py:178
 #: ../gramps/gui/editors/editmediaref.py:142
-#: ../gramps/plugins/db/bsddb/write.py:2514
+#: ../gramps/plugins/db/bsddb/write.py:2481
 #: ../gramps/plugins/gramplet/persondetails.py:208
 #: ../gramps/plugins/gramplet/persondetails.py:214
 #: ../gramps/plugins/gramplet/persondetails.py:216
@@ -1785,8 +1786,8 @@ msgstr "Vergrendeld door %s"
 #: ../gramps/plugins/view/geofamily.py:465
 #: ../gramps/plugins/view/geomoves.py:596
 #: ../gramps/plugins/view/geoperson.py:480
-#: ../gramps/plugins/view/geoplaces.py:525 ../gramps/plugins/view/relview.py:458
-#: ../gramps/plugins/view/relview.py:998 ../gramps/plugins/view/relview.py:1055
+#: ../gramps/plugins/view/geoplaces.py:525 ../gramps/plugins/view/relview.py:468
+#: ../gramps/plugins/view/relview.py:1008 ../gramps/plugins/view/relview.py:1065
 #: ../gramps/plugins/webreport/narrativeweb.py:2147
 #: ../gramps/plugins/webreport/narrativeweb.py:2176
 #: ../gramps/plugins/webreport/narrativeweb.py:2181
@@ -2047,28 +2048,28 @@ msgstr ""
 "stuur dan een foutrapport naar %(gramps_bugtracker_url)s\n"
 "\n"
 
-#: ../gramps/gen/config.py:325
+#: ../gramps/gen/config.py:256
 msgid "Imported %Y/%m/%d %H:%M:%S"
 msgstr "Geïmporteerd op %Y/%m/%d %H:%M:%S"
 
-#: ../gramps/gen/config.py:339
+#: ../gramps/gen/config.py:270
 msgid "Missing Given Name"
 msgstr "Ontbrekende voornaam"
 
 # complete/volledige/volledig ingevulde  kaarten/archieven
-#: ../gramps/gen/config.py:340
+#: ../gramps/gen/config.py:271
 msgid "Missing Record"
 msgstr "Ontbrekend gegeven"
 
-#: ../gramps/gen/config.py:341
+#: ../gramps/gen/config.py:272
 msgid "Missing Surname"
 msgstr "Ontbrekende achternaam"
 
-#: ../gramps/gen/config.py:348 ../gramps/gen/config.py:350
+#: ../gramps/gen/config.py:279 ../gramps/gen/config.py:281
 msgid "[Living]"
 msgstr "[Nog in leven]"
 
-#: ../gramps/gen/config.py:349
+#: ../gramps/gen/config.py:280
 msgid "Private Record"
 msgstr "Gegevens privé"
 
@@ -2161,7 +2162,7 @@ msgstr "{long_month} {year}"
 #: ../gramps/gen/datehandler/_datedisplay.py:176
 #, python-brace-format
 msgid "to|{long_month} {year}"
-msgstr ""
+msgstr "{long_month} {year}"
 
 #. first date in a range
 #. If "between <Month>" needs a special inflection in your
@@ -2171,7 +2172,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:184
 #, python-brace-format
 msgid "between|{long_month} {year}"
-msgstr ""
+msgstr "{long_month} {year}"
 
 #. second date in a range
 #. If "and <Month>" needs a special inflection in your
@@ -2181,7 +2182,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:192
 #, python-brace-format
 msgid "and|{long_month} {year}"
-msgstr ""
+msgstr "{long_month} {year}"
 
 #. If "before <Month>" needs a special inflection in your
 #. language, translate this to "{long_month.f[X]} {year}"
@@ -2190,7 +2191,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:199
 #, python-brace-format
 msgid "before|{long_month} {year}"
-msgstr ""
+msgstr "{long_month} {year}"
 
 #. If "after <Month>" needs a special inflection in your
 #. language, translate this to "{long_month.f[X]} {year}"
@@ -2199,7 +2200,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:206
 #, python-brace-format
 msgid "after|{long_month} {year}"
-msgstr ""
+msgstr "{long_month} {year}"
 
 #. If "about <Month>" needs a special inflection in your
 #. language, translate this to "{long_month.f[X]} {year}"
@@ -2208,7 +2209,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:213
 #, python-brace-format
 msgid "about|{long_month} {year}"
-msgstr ""
+msgstr "{long_month} {year}"
 
 #. If "estimated <Month>" needs a special inflection in your
 #. language, translate this to "{long_month.f[X]} {year}"
@@ -2231,7 +2232,7 @@ msgstr "{long_month} {year}"
 #: ../gramps/gen/datehandler/_datedisplay.py:232
 #, python-brace-format
 msgid "{short_month} {year}"
-msgstr ""
+msgstr "{short_month} {year}"
 
 #. first date in a span
 #. If "from <Month>" needs a special inflection in your
@@ -2241,7 +2242,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:240
 #, python-brace-format
 msgid "from|{short_month} {year}"
-msgstr ""
+msgstr "{short_month} {year}"
 
 #. second date in a span
 #. If "to <Month>" needs a special inflection in your
@@ -2251,7 +2252,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:248
 #, python-brace-format
 msgid "to|{short_month} {year}"
-msgstr ""
+msgstr "{short_month} {year}"
 
 #. first date in a range
 #. If "between <Month>" needs a special inflection in your
@@ -2280,7 +2281,7 @@ msgstr "and|{short_month} {year}"
 #: ../gramps/gen/datehandler/_datedisplay.py:271
 #, python-brace-format
 msgid "before|{short_month} {year}"
-msgstr ""
+msgstr "{short_month} {year}"
 
 #. If "after <Month>" needs a special inflection in your
 #. language, translate this to "{short_month.f[X]} {year}"
@@ -2289,7 +2290,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:278
 #, python-brace-format
 msgid "after|{short_month} {year}"
-msgstr ""
+msgstr "{short_month} {year}"
 
 #. If "about <Month>" needs a special inflection in your
 #. language, translate this to "{short_month.f[X]} {year}"
@@ -2298,7 +2299,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:285
 #, python-brace-format
 msgid "about|{short_month} {year}"
-msgstr ""
+msgstr "{short_month} {year}"
 
 #. If "estimated <Month>" needs a special inflection in your
 #. language, translate this to "{short_month.f[X]} {year}"
@@ -2626,47 +2627,47 @@ msgstr "Heshvan"
 
 #: ../gramps/gen/datehandler/_datestrings.py:148
 msgid "Hebrew month lexeme|Kislev"
-msgstr ""
+msgstr "Kislev"
 
 #: ../gramps/gen/datehandler/_datestrings.py:149
 msgid "Hebrew month lexeme|Tevet"
-msgstr ""
+msgstr "Tevet"
 
 #: ../gramps/gen/datehandler/_datestrings.py:150
 msgid "Hebrew month lexeme|Shevat"
-msgstr ""
+msgstr "Shevat"
 
 #: ../gramps/gen/datehandler/_datestrings.py:151
 msgid "Hebrew month lexeme|AdarI"
-msgstr ""
+msgstr "AdarI"
 
 #: ../gramps/gen/datehandler/_datestrings.py:152
 msgid "Hebrew month lexeme|AdarII"
-msgstr ""
+msgstr "AdarII"
 
 #: ../gramps/gen/datehandler/_datestrings.py:153
 msgid "Hebrew month lexeme|Nisan"
-msgstr ""
+msgstr "Nisan"
 
 #: ../gramps/gen/datehandler/_datestrings.py:154
 msgid "Hebrew month lexeme|Iyyar"
-msgstr ""
+msgstr "Iyyar"
 
 #: ../gramps/gen/datehandler/_datestrings.py:155
 msgid "Hebrew month lexeme|Sivan"
-msgstr ""
+msgstr "Sivan"
 
 #: ../gramps/gen/datehandler/_datestrings.py:156
 msgid "Hebrew month lexeme|Tammuz"
-msgstr ""
+msgstr "Tammuz"
 
 #: ../gramps/gen/datehandler/_datestrings.py:157
 msgid "Hebrew month lexeme|Av"
-msgstr ""
+msgstr "Av"
 
 #: ../gramps/gen/datehandler/_datestrings.py:158
 msgid "Hebrew month lexeme|Elul"
-msgstr ""
+msgstr "Elul"
 
 #. TRANSLATORS: see
 #. http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
@@ -2798,7 +2799,7 @@ msgstr ""
 
 #: ../gramps/gen/datehandler/_datestrings.py:212
 msgid "Persian month lexeme|Mordad"
-msgstr ""
+msgstr "Mordad"
 
 #: ../gramps/gen/datehandler/_datestrings.py:213
 msgid "Persian month lexeme|Shahrivar"
@@ -2806,27 +2807,27 @@ msgstr ""
 
 #: ../gramps/gen/datehandler/_datestrings.py:214
 msgid "Persian month lexeme|Mehr"
-msgstr ""
+msgstr "Mehr"
 
 #: ../gramps/gen/datehandler/_datestrings.py:215
 msgid "Persian month lexeme|Aban"
-msgstr ""
+msgstr "Aban"
 
 #: ../gramps/gen/datehandler/_datestrings.py:216
 msgid "Persian month lexeme|Azar"
-msgstr ""
+msgstr "Azar"
 
 #: ../gramps/gen/datehandler/_datestrings.py:217
 msgid "Persian month lexeme|Dey"
-msgstr ""
+msgstr "Dey"
 
 #: ../gramps/gen/datehandler/_datestrings.py:218
 msgid "Persian month lexeme|Bahman"
-msgstr ""
+msgstr "Bahman"
 
 #: ../gramps/gen/datehandler/_datestrings.py:219
 msgid "Persian month lexeme|Esfand"
-msgstr ""
+msgstr "Esfand"
 
 #. TRANSLATORS: if the modifier is after the date
 #. put the space ahead of the word instead of after it
@@ -2901,14 +2902,6 @@ msgstr "Vader uit gezin verwijderen"
 #: ../gramps/gen/db/base.py:1933
 msgid "Remove mother from family"
 msgstr "Moeder uit gezin verwijderen"
-
-#: ../gramps/gen/db/base.py:2008
-msgid "Autobackup..."
-msgstr "Automatisch reservekopie maken..."
-
-#: ../gramps/gen/db/base.py:2012
-msgid "Error saving backup data"
-msgstr "Fout bij het maken van een reservekopie"
 
 #: ../gramps/gen/db/exceptions.py:91
 #, python-format
@@ -3146,9 +3139,9 @@ msgstr ""
 "%(wiki_backup_html_start)sreservekopie%(html_end)s te maken."
 
 #: ../gramps/gen/db/generic.py:155 ../gramps/gen/db/generic.py:200
-#: ../gramps/gen/db/generic.py:2184 ../gramps/plugins/db/bsddb/undoredo.py:245
+#: ../gramps/gen/db/generic.py:2137 ../gramps/plugins/db/bsddb/undoredo.py:245
 #: ../gramps/plugins/db/bsddb/undoredo.py:282
-#: ../gramps/plugins/db/bsddb/write.py:2326
+#: ../gramps/plugins/db/bsddb/write.py:2325
 #, python-format
 msgid "_Undo %s"
 msgstr "Ongedaan maken %s"
@@ -3160,78 +3153,78 @@ msgstr "Ongedaan maken %s"
 msgid "_Redo %s"
 msgstr "%s opnieuw doen"
 
-#: ../gramps/gen/db/generic.py:2630 ../gramps/plugins/db/bsddb/read.py:2081
-#: ../gramps/plugins/db/bsddb/write.py:2517
+#: ../gramps/gen/db/generic.py:2569 ../gramps/plugins/db/bsddb/read.py:2071
+#: ../gramps/plugins/db/bsddb/write.py:2484
 msgid "Number of people"
 msgstr "Aantal personen"
 
-#: ../gramps/gen/db/generic.py:2631 ../gramps/plugins/db/bsddb/read.py:2082
-#: ../gramps/plugins/db/bsddb/write.py:2518
+#: ../gramps/gen/db/generic.py:2570 ../gramps/plugins/db/bsddb/read.py:2072
+#: ../gramps/plugins/db/bsddb/write.py:2485
 #: ../gramps/plugins/gramplet/statsgramplet.py:117
 #: ../gramps/plugins/webreport/narrativeweb.py:8108
 #: ../gramps/plugins/webreport/narrativeweb.py:8174
 msgid "Number of families"
 msgstr "Aantal gezinnen"
 
-#: ../gramps/gen/db/generic.py:2632 ../gramps/plugins/db/bsddb/read.py:2083
-#: ../gramps/plugins/db/bsddb/write.py:2519
+#: ../gramps/gen/db/generic.py:2571 ../gramps/plugins/db/bsddb/read.py:2073
+#: ../gramps/plugins/db/bsddb/write.py:2486
 #: ../gramps/plugins/webreport/narrativeweb.py:8135
 #: ../gramps/plugins/webreport/narrativeweb.py:8186
 msgid "Number of sources"
 msgstr "Aantal bronnen"
 
-#: ../gramps/gen/db/generic.py:2633 ../gramps/plugins/db/bsddb/read.py:2084
-#: ../gramps/plugins/db/bsddb/write.py:2520
+#: ../gramps/gen/db/generic.py:2572 ../gramps/plugins/db/bsddb/read.py:2074
+#: ../gramps/plugins/db/bsddb/write.py:2487
 #: ../gramps/plugins/webreport/narrativeweb.py:8139
 #: ../gramps/plugins/webreport/narrativeweb.py:8189
 msgid "Number of citations"
 msgstr "Aantal citaten"
 
-#: ../gramps/gen/db/generic.py:2634 ../gramps/plugins/db/bsddb/read.py:2085
-#: ../gramps/plugins/db/bsddb/write.py:2521
+#: ../gramps/gen/db/generic.py:2573 ../gramps/plugins/db/bsddb/read.py:2075
+#: ../gramps/plugins/db/bsddb/write.py:2488
 #: ../gramps/plugins/webreport/narrativeweb.py:8128
 #: ../gramps/plugins/webreport/narrativeweb.py:8180
 msgid "Number of events"
 msgstr "Aantal gebeurtenissen"
 
-#: ../gramps/gen/db/generic.py:2635 ../gramps/plugins/db/bsddb/read.py:2086
-#: ../gramps/plugins/db/bsddb/write.py:2522
+#: ../gramps/gen/db/generic.py:2574 ../gramps/plugins/db/bsddb/read.py:2076
+#: ../gramps/plugins/db/bsddb/write.py:2489
 msgid "Number of media"
 msgstr "Aantal media-objecten"
 
-#: ../gramps/gen/db/generic.py:2636 ../gramps/plugins/db/bsddb/read.py:2087
-#: ../gramps/plugins/db/bsddb/write.py:2523
+#: ../gramps/gen/db/generic.py:2575 ../gramps/plugins/db/bsddb/read.py:2077
+#: ../gramps/plugins/db/bsddb/write.py:2490
 #: ../gramps/plugins/webreport/narrativeweb.py:8131
 #: ../gramps/plugins/webreport/narrativeweb.py:8183
 msgid "Number of places"
 msgstr "Aantal locaties"
 
-#: ../gramps/gen/db/generic.py:2637 ../gramps/plugins/db/bsddb/read.py:2088
-#: ../gramps/plugins/db/bsddb/write.py:2524
+#: ../gramps/gen/db/generic.py:2576 ../gramps/plugins/db/bsddb/read.py:2078
+#: ../gramps/plugins/db/bsddb/write.py:2491
 #: ../gramps/plugins/webreport/narrativeweb.py:8143
 #: ../gramps/plugins/webreport/narrativeweb.py:8192
 msgid "Number of repositories"
 msgstr "Aantal bibliotheken"
 
-#: ../gramps/gen/db/generic.py:2638 ../gramps/plugins/db/bsddb/read.py:2089
-#: ../gramps/plugins/db/bsddb/write.py:2525
+#: ../gramps/gen/db/generic.py:2577 ../gramps/plugins/db/bsddb/read.py:2079
+#: ../gramps/plugins/db/bsddb/write.py:2492
 msgid "Number of notes"
 msgstr "Aantal opmerkingen"
 
-#: ../gramps/gen/db/generic.py:2639 ../gramps/plugins/db/bsddb/read.py:2090
-#: ../gramps/plugins/db/bsddb/write.py:2526
+#: ../gramps/gen/db/generic.py:2578 ../gramps/plugins/db/bsddb/read.py:2080
+#: ../gramps/plugins/db/bsddb/write.py:2493
 msgid "Number of tags"
 msgstr "Aantal tags"
 
-#: ../gramps/gen/db/generic.py:2640 ../gramps/plugins/db/bsddb/write.py:2527
+#: ../gramps/gen/db/generic.py:2579 ../gramps/plugins/db/bsddb/write.py:2494
 msgid "Data version"
 msgstr "Gegevensversie"
 
-#: ../gramps/gen/db/generic.py:2641
+#: ../gramps/gen/db/generic.py:2580
 msgid "Backups, count"
 msgstr "Reservekopie, aantal"
 
-#: ../gramps/gen/db/generic.py:2642
+#: ../gramps/gen/db/generic.py:2581
 msgid "Backups, last"
 msgstr "Reservekopie, laatste"
 
@@ -3253,13 +3246,13 @@ msgid "Surname, Given Suffix"
 msgstr "Achternaam, voornaam suffix"
 
 #: ../gramps/gen/display/name.py:356 ../gramps/gen/utils/keyword.py:55
-#: ../gramps/gui/configure.py:643 ../gramps/gui/configure.py:645
-#: ../gramps/gui/configure.py:650 ../gramps/gui/configure.py:652
-#: ../gramps/gui/configure.py:654 ../gramps/gui/configure.py:655
+#: ../gramps/gui/configure.py:645 ../gramps/gui/configure.py:647
+#: ../gramps/gui/configure.py:652 ../gramps/gui/configure.py:654
 #: ../gramps/gui/configure.py:656 ../gramps/gui/configure.py:657
-#: ../gramps/gui/configure.py:659 ../gramps/gui/configure.py:660
+#: ../gramps/gui/configure.py:658 ../gramps/gui/configure.py:659
 #: ../gramps/gui/configure.py:661 ../gramps/gui/configure.py:662
 #: ../gramps/gui/configure.py:663 ../gramps/gui/configure.py:664
+#: ../gramps/gui/configure.py:665 ../gramps/gui/configure.py:666
 #: ../gramps/plugins/export/exportcsv.py:353
 #: ../gramps/plugins/importer/importcsv.py:161
 msgid "Given"
@@ -3295,7 +3288,7 @@ msgid "surname"
 msgstr "achternaam"
 
 #: ../gramps/gen/display/name.py:603 ../gramps/gen/display/name.py:703
-#: ../gramps/gui/editors/editperson.py:389
+#: ../gramps/gui/editors/editperson.py:388
 #: ../gramps/plugins/importer/importcsv.py:166
 msgid "suffix"
 msgstr "suffix"
@@ -3359,7 +3352,7 @@ msgid "Remaining names|rest"
 msgstr "overige"
 
 #: ../gramps/gen/display/name.py:640 ../gramps/gen/display/name.py:732
-#: ../gramps/gui/editors/editperson.py:410
+#: ../gramps/gui/editors/editperson.py:409
 #: ../gramps/plugins/importer/importcsv.py:165
 msgid "prefix"
 msgstr "prefix"
@@ -3526,7 +3519,7 @@ msgstr "Volume/Pagina:"
 #: ../gramps/gen/filters/rules/person/_hasevent.py:49
 #: ../gramps/gen/filters/rules/person/_hasfamilyevent.py:49
 #: ../gramps/gen/filters/rules/place/_hascitation.py:49
-#: ../gramps/gui/editors/filtereditor.py:580
+#: ../gramps/gui/editors/filtereditor.py:579
 #: ../gramps/gui/glade/mergecitation.glade:245
 #: ../gramps/gui/glade/mergecitation.glade:261
 #: ../gramps/gui/glade/mergeevent.glade:245
@@ -3583,7 +3576,7 @@ msgstr "Gebeurtenissenfilters"
 #: ../gramps/gen/filters/rules/person/_hasaddress.py:48
 #: ../gramps/gen/filters/rules/person/_hasassociation.py:48
 #: ../gramps/gen/filters/rules/source/_hasrepository.py:46
-#: ../gramps/gui/editors/filtereditor.py:514
+#: ../gramps/gui/editors/filtereditor.py:513
 msgid "Number must be:"
 msgstr "Getal moet zijn:"
 
@@ -3594,7 +3587,7 @@ msgstr "Getal moet zijn:"
 #: ../gramps/gen/filters/rules/person/_hasaddress.py:48
 #: ../gramps/gen/filters/rules/person/_hasassociation.py:48
 #: ../gramps/gen/filters/rules/source/_hasrepository.py:46
-#: ../gramps/gui/editors/filtereditor.py:509
+#: ../gramps/gui/editors/filtereditor.py:508
 msgid "Number of instances:"
 msgstr "Aantal gevallen:"
 
@@ -3615,7 +3608,7 @@ msgstr "Aantal gevallen:"
 #: ../gramps/gen/filters/rules/person/_matchidof.py:44
 #: ../gramps/gen/filters/rules/person/_relationshippathbetween.py:45
 #: ../gramps/gen/filters/rules/place/_isenclosedby.py:48
-#: ../gramps/gui/editors/filtereditor.py:518
+#: ../gramps/gui/editors/filtereditor.py:517
 #: ../gramps/gui/glade/editplaceref.glade:230
 msgid "ID:"
 msgstr "ID:"
@@ -3646,12 +3639,12 @@ msgstr "Deeltekenreeks:"
 
 # Bronnen, verwijzingen, literatuurverwijzingen
 #: ../gramps/gen/filters/rules/_hasreferencecountbase.py:42
-#: ../gramps/gui/editors/filtereditor.py:512
+#: ../gramps/gui/editors/filtereditor.py:511
 msgid "Reference count must be:"
 msgstr "Aantal maal waarnaar verwezen wordt moet zijn:"
 
 #: ../gramps/gen/filters/rules/_hasreferencecountbase.py:42
-#: ../gramps/gui/editors/filtereditor.py:508
+#: ../gramps/gui/editors/filtereditor.py:507
 msgid "Reference count:"
 msgstr "Aantal verwijzingen:"
 
@@ -3660,7 +3653,7 @@ msgstr "Aantal verwijzingen:"
 #: ../gramps/gen/filters/rules/media/_hassourceof.py:45
 #: ../gramps/gen/filters/rules/person/_hassourceof.py:45
 #: ../gramps/gen/filters/rules/place/_hassourceof.py:45
-#: ../gramps/gui/editors/filtereditor.py:521
+#: ../gramps/gui/editors/filtereditor.py:520
 msgid "Source ID:"
 msgstr "Bron-ID:"
 
@@ -3675,7 +3668,7 @@ msgstr "Bron-ID:"
 #: ../gramps/gen/filters/rules/person/_isparentoffiltermatch.py:46
 #: ../gramps/gen/filters/rules/person/_issiblingoffiltermatch.py:45
 #: ../gramps/gen/filters/rules/person/_isspouseoffiltermatch.py:46
-#: ../gramps/gui/editors/filtereditor.py:523
+#: ../gramps/gui/editors/filtereditor.py:522
 msgid "Filter name:"
 msgstr "Filternaam:"
 
@@ -3689,7 +3682,7 @@ msgstr "Filter %s werd niet gevonden in de eigen aangemaakte filters"
 #: ../gramps/gen/filters/rules/_matchessourcefilterbase.py:47
 #: ../gramps/gen/filters/rules/citation/_matchessourcefilter.py:48
 #: ../gramps/gen/filters/rules/event/_matchessourcefilter.py:48
-#: ../gramps/gui/editors/filtereditor.py:531
+#: ../gramps/gui/editors/filtereditor.py:530
 msgid "Source filter name:"
 msgstr "Bronnenfilternaam:"
 
@@ -3697,7 +3690,7 @@ msgstr "Bronnenfilternaam:"
 msgid "Miscellaneous filters"
 msgstr "Overige filters"
 
-#: ../gramps/gen/filters/rules/_rule.py:54 ../gramps/gui/glade/rule.glade:953
+#: ../gramps/gen/filters/rules/_rule.py:54 ../gramps/gui/glade/rule.glade:950
 #: ../gramps/plugins/view/geoclose.py:533
 #: ../gramps/plugins/view/geofamclose.py:724
 #: ../gramps/plugins/view/geofamily.py:478
@@ -3771,7 +3764,7 @@ msgstr "Citaten die als privé zijn aangeduid"
 #: ../gramps/gen/filters/rules/person/_matchessourceconfidence.py:43
 #: ../gramps/gen/filters/rules/place/_hascitation.py:50
 #: ../gramps/gen/filters/rules/place/_matchessourceconfidence.py:43
-#: ../gramps/gui/editors/filtereditor.py:577
+#: ../gramps/gui/editors/filtereditor.py:576
 msgid "Confidence level:"
 msgstr "Zekerheid:"
 
@@ -3845,12 +3838,12 @@ msgid "Title:"
 msgstr "Titel:"
 
 #: ../gramps/gen/filters/rules/citation/_hassource.py:49
-#: ../gramps/gui/glade/editcitation.glade:396
+#: ../gramps/gui/glade/editcitation.glade:395
 #: ../gramps/gui/glade/mergedata.glade:792
 #: ../gramps/gui/glade/mergedata.glade:808
 #: ../gramps/gui/glade/mergesource.glade:245
 #: ../gramps/gui/glade/mergesource.glade:261
-#: ../gramps/gui/glade/plugins.glade:192
+#: ../gramps/gui/glade/plugins.glade:190
 msgid "Author:"
 msgstr "Auteur:"
 
@@ -3915,7 +3908,7 @@ msgstr ""
 #: ../gramps/gen/filters/rules/place/_hastag.py:48
 #: ../gramps/gen/filters/rules/repository/_hastag.py:48
 #: ../gramps/gen/filters/rules/source/_hastag.py:48
-#: ../gramps/gui/editors/filtereditor.py:573
+#: ../gramps/gui/editors/filtereditor.py:572
 msgid "Tag:"
 msgstr "Tag:"
 
@@ -3946,7 +3939,7 @@ msgstr "Citaten waarvan volume/agina een bepaalde deeltekenreeks bevat"
 
 #: ../gramps/gen/filters/rules/citation/_matchesrepositoryfilter.py:45
 #: ../gramps/gen/filters/rules/source/_matchesrepositoryfilter.py:43
-#: ../gramps/gui/editors/filtereditor.py:533
+#: ../gramps/gui/editors/filtereditor.py:532
 msgid "Repository filter name:"
 msgstr "Bibliotheekfilternaam:"
 
@@ -4028,7 +4021,7 @@ msgstr "Vindt gebeurtenissen die aangegeven zijn als privé"
 
 #: ../gramps/gen/filters/rules/event/_hasattribute.py:44
 #: ../gramps/gui/editors/filtereditor.py:106
-#: ../gramps/gui/editors/filtereditor.py:546
+#: ../gramps/gui/editors/filtereditor.py:545
 msgid "Event attribute:"
 msgstr "Gebeurteniskenmerk:"
 
@@ -4060,7 +4053,7 @@ msgstr "Gebeurtenissen met citaten die een bepaald waarde hebben"
 #: ../gramps/gen/filters/rules/event/_hastype.py:45
 #: ../gramps/gen/filters/rules/person/_iswitness.py:44
 #: ../gramps/gui/editors/filtereditor.py:103
-#: ../gramps/gui/editors/filtereditor.py:539
+#: ../gramps/gui/editors/filtereditor.py:538
 msgid "Event type:"
 msgstr "Gebeurtenistype:"
 
@@ -4070,7 +4063,7 @@ msgstr "Gebeurtenistype:"
 #: ../gramps/gen/filters/rules/person/_hasdeath.py:48
 #: ../gramps/gen/filters/rules/person/_hasevent.py:50
 #: ../gramps/gen/filters/rules/person/_hasfamilyevent.py:50
-#: ../gramps/gui/editors/filtereditor.py:506
+#: ../gramps/gui/editors/filtereditor.py:505
 #: ../gramps/gui/glade/mergeevent.glade:278
 #: ../gramps/gui/glade/mergeevent.glade:294
 msgid "Place:"
@@ -4096,7 +4089,7 @@ msgid "Matches events with data of a particular value"
 msgstr "Vindt gebeurtenissen met gegevens die een bepaald waarde hebben"
 
 #: ../gramps/gen/filters/rules/event/_hasdayofweek.py:44
-#: ../gramps/gui/editors/filtereditor.py:582
+#: ../gramps/gui/editors/filtereditor.py:581
 msgid "Day of Week:"
 msgstr "Weekdag:"
 
@@ -4197,14 +4190,14 @@ msgid "Matches events matched by the specified filter name"
 msgstr "Vindt gebeurtenissen met een opgegeven filter"
 
 #: ../gramps/gen/filters/rules/event/_matchespersonfilter.py:50
-#: ../gramps/gui/editors/filtereditor.py:568
+#: ../gramps/gui/editors/filtereditor.py:567
 msgid "Include Family events:"
 msgstr "Gezinsgebeurtenissen bijvoegen:"
 
 # naam filteren of filternaam
 #. filters of another namespace, name may be same as caller!
 #: ../gramps/gen/filters/rules/event/_matchespersonfilter.py:50
-#: ../gramps/gui/editors/filtereditor.py:527
+#: ../gramps/gui/editors/filtereditor.py:526
 msgid "Person filter name:"
 msgstr "Personenfilternaam:"
 
@@ -4219,7 +4212,7 @@ msgstr "Vindt persoonsgebeurtenissen met een opgegeven personennaamfilter"
 
 # naam filteren of filternaam
 #: ../gramps/gen/filters/rules/event/_matchesplacefilter.py:49
-#: ../gramps/gui/editors/filtereditor.py:535
+#: ../gramps/gui/editors/filtereditor.py:534
 msgid "Place filter name:"
 msgstr "Locatiefilternaam:"
 
@@ -4359,7 +4352,7 @@ msgstr "Vindt gezinnen waarvan vader (een deel van) een bepaalde naam heeft"
 #: ../gramps/gen/filters/rules/family/_hasattribute.py:44
 #: ../gramps/gen/filters/rules/person/_hasfamilyattribute.py:44
 #: ../gramps/gui/editors/filtereditor.py:105
-#: ../gramps/gui/editors/filtereditor.py:544
+#: ../gramps/gui/editors/filtereditor.py:543
 msgid "Family attribute:"
 msgstr "Gezinskenmerk:"
 
@@ -4382,13 +4375,13 @@ msgstr "Vindt gezinnen met een citaat van een bepaald type"
 #: ../gramps/gen/filters/rules/family/_hasevent.py:47
 #: ../gramps/gen/filters/rules/person/_hasfamilyevent.py:48
 #: ../gramps/gui/editors/filtereditor.py:102
-#: ../gramps/gui/editors/filtereditor.py:540
+#: ../gramps/gui/editors/filtereditor.py:539
 msgid "Family event:"
 msgstr "Gezinsgebeurtenis:"
 
 #: ../gramps/gen/filters/rules/family/_hasevent.py:51
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:83
-#: ../gramps/gui/selectors/selectevent.py:71
+#: ../gramps/gui/selectors/selectevent.py:70
 #: ../gramps/plugins/gramplet/events.py:92
 #: ../gramps/plugins/view/eventview.py:90
 msgid "Main Participants"
@@ -4467,7 +4460,7 @@ msgstr "Vindt gezinnen waarnaar een bepaald aantal maal naar verwezen wordt"
 #: ../gramps/gen/filters/rules/family/_hasreltype.py:45
 #: ../gramps/gen/filters/rules/person/_hasrelationship.py:46
 #: ../gramps/gui/editors/filtereditor.py:108
-#: ../gramps/gui/editors/filtereditor.py:550
+#: ../gramps/gui/editors/filtereditor.py:549
 msgid "Relationship type:"
 msgstr "Verwantschapstype:"
 
@@ -4517,7 +4510,7 @@ msgstr "Vindt gezinnen met tweelingen"
 #: ../gramps/gen/filters/rules/person/_isdescendantfamilyof.py:49
 #: ../gramps/gen/filters/rules/person/_isdescendantof.py:45
 #: ../gramps/gen/filters/rules/place/_isenclosedby.py:48
-#: ../gramps/gui/editors/filtereditor.py:562
+#: ../gramps/gui/editors/filtereditor.py:561
 msgid "Inclusive:"
 msgstr "Inclusief:"
 
@@ -4676,7 +4669,7 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/media/_hasattribute.py:44
 #: ../gramps/gui/editors/filtereditor.py:107
-#: ../gramps/gui/editors/filtereditor.py:548
+#: ../gramps/gui/editors/filtereditor.py:547
 msgid "Media attribute:"
 msgstr "Mediakenmerk:"
 
@@ -4724,7 +4717,7 @@ msgstr "Type:"
 # pad
 #: ../gramps/gen/filters/rules/media/_hasmedia.py:48
 #: ../gramps/gui/glade/mergemedia.glade:245
-#: ../gramps/gui/glade/mergemedia.glade:261 ../gramps/gui/viewmanager.py:1290
+#: ../gramps/gui/glade/mergemedia.glade:261 ../gramps/gui/viewmanager.py:1298
 msgid "Path:"
 msgstr "Pad:"
 
@@ -4856,7 +4849,7 @@ msgstr "Vindt een opmerking met een opgegeven Gramps ID"
 #: ../gramps/gen/filters/rules/note/_hasnote.py:47
 #: ../gramps/gen/filters/rules/note/_hastype.py:45
 #: ../gramps/gui/editors/filtereditor.py:109
-#: ../gramps/gui/editors/filtereditor.py:552
+#: ../gramps/gui/editors/filtereditor.py:551
 msgid "Note type:"
 msgstr "Opmerkingstype:"
 
@@ -5049,7 +5042,7 @@ msgstr "Vindt personen met een bepaald aantal associaties"
 
 #: ../gramps/gen/filters/rules/person/_hasattribute.py:44
 #: ../gramps/gui/editors/filtereditor.py:104
-#: ../gramps/gui/editors/filtereditor.py:542
+#: ../gramps/gui/editors/filtereditor.py:541
 msgid "Personal attribute:"
 msgstr "Persoonlijk kenmerk:"
 
@@ -5125,7 +5118,7 @@ msgstr "Vindt personen met een bepaalde sterfdatum"
 
 #: ../gramps/gen/filters/rules/person/_hasevent.py:48
 #: ../gramps/gui/editors/filtereditor.py:101
-#: ../gramps/gui/editors/filtereditor.py:539
+#: ../gramps/gui/editors/filtereditor.py:538
 msgid "Personal event:"
 msgstr "Persoonlijke gebeurtenis:"
 
@@ -5134,7 +5127,7 @@ msgid "Main Participants:"
 msgstr "Belangrijkste deelnemers:"
 
 #: ../gramps/gen/filters/rules/person/_hasevent.py:53
-#: ../gramps/gui/editors/filtereditor.py:571
+#: ../gramps/gui/editors/filtereditor.py:570
 msgid "Primary Role:"
 msgstr "Primaire rol:"
 
@@ -5248,7 +5241,7 @@ msgstr "Vindt personen met een bepaalde (deel van) naam"
 
 #: ../gramps/gen/filters/rules/person/_hasnameorigintype.py:46
 #: ../gramps/gui/editors/filtereditor.py:111
-#: ../gramps/gui/editors/filtereditor.py:556
+#: ../gramps/gui/editors/filtereditor.py:555
 msgid "Surname origin type:"
 msgstr "Oorsprongstype achternaam:"
 
@@ -5262,7 +5255,7 @@ msgstr "Personen met dezelfde naamoorsprong vinden"
 
 #: ../gramps/gen/filters/rules/person/_hasnametype.py:46
 #: ../gramps/gui/editors/filtereditor.py:110
-#: ../gramps/gui/editors/filtereditor.py:554
+#: ../gramps/gui/editors/filtereditor.py:553
 msgid "Name type:"
 msgstr "Naamtype:"
 
@@ -5364,7 +5357,7 @@ msgid "Matches people with the particular tag"
 msgstr "Personen met een bepaalde tag zoeken"
 
 #: ../gramps/gen/filters/rules/person/_hastextmatchingsubstringof.py:47
-#: ../gramps/gui/editors/filtereditor.py:564
+#: ../gramps/gui/editors/filtereditor.py:563
 msgid "Case sensitive:"
 msgstr "Hoofdlettergevoelig:"
 
@@ -5536,7 +5529,7 @@ msgstr "Vindt alle vrouwen"
 #: ../gramps/gen/filters/rules/person/_islessthannthgenerationdescendantof.py:45
 #: ../gramps/gen/filters/rules/person/_ismorethannthgenerationancestorof.py:45
 #: ../gramps/gen/filters/rules/person/_ismorethannthgenerationdescendantof.py:45
-#: ../gramps/gui/editors/filtereditor.py:516
+#: ../gramps/gui/editors/filtereditor.py:515
 msgid "Number of generations:"
 msgstr "Aantal generaties:"
 
@@ -5668,7 +5661,7 @@ msgstr "Vindt personen die getuigen zijn bij een gebeurtenis"
 
 #: ../gramps/gen/filters/rules/person/_matcheseventfilter.py:51
 #: ../gramps/gen/filters/rules/place/_matcheseventfilter.py:49
-#: ../gramps/gui/editors/filtereditor.py:529
+#: ../gramps/gui/editors/filtereditor.py:528
 msgid "Event filter name:"
 msgstr "Gebeurtenissenfilternaam:"
 
@@ -5882,7 +5875,7 @@ msgstr "Naam:"
 
 #: ../gramps/gen/filters/rules/place/_hasdata.py:49
 #: ../gramps/gui/editors/filtereditor.py:112
-#: ../gramps/gui/editors/filtereditor.py:558
+#: ../gramps/gui/editors/filtereditor.py:557
 msgid "Place type:"
 msgstr "Locatieype:"
 
@@ -6423,10 +6416,10 @@ msgstr "Kaste"
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:75
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:67
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:104
-#: ../gramps/gui/glade/rule.glade:934 ../gramps/gui/glade/styleeditor.glade:262
+#: ../gramps/gui/glade/rule.glade:931 ../gramps/gui/glade/styleeditor.glade:262
 #: ../gramps/gui/plug/_windows.py:130 ../gramps/gui/plug/_windows.py:239
 #: ../gramps/gui/plug/_windows.py:612 ../gramps/gui/plug/_windows.py:1095
-#: ../gramps/gui/selectors/selectevent.py:74
+#: ../gramps/gui/selectors/selectevent.py:73
 #: ../gramps/plugins/gramplet/coordinates.py:90
 #: ../gramps/plugins/gramplet/events.py:86
 #: ../gramps/plugins/lib/libmetadata.py:98
@@ -6459,8 +6452,8 @@ msgid "Social Security Number"
 msgstr "Sofinummer"
 
 #: ../gramps/gen/lib/attrtype.py:70 ../gramps/gen/utils/keyword.py:72
-#: ../gramps/gui/configure.py:646 ../gramps/gui/configure.py:648
-#: ../gramps/gui/configure.py:653 ../gramps/gui/configure.py:660
+#: ../gramps/gui/configure.py:648 ../gramps/gui/configure.py:650
+#: ../gramps/gui/configure.py:655 ../gramps/gui/configure.py:662
 #: ../gramps/plugins/tool/patchnames.py:430
 msgid "Nickname"
 msgstr "Bijnaam"
@@ -6500,7 +6493,7 @@ msgid "Time"
 msgstr "Tijd"
 
 # niet/geen
-#: ../gramps/gen/lib/childreftype.py:67 ../gramps/gui/configure.py:80
+#: ../gramps/gen/lib/childreftype.py:67 ../gramps/gui/configure.py:81
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:209
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:175
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:199
@@ -6515,7 +6508,7 @@ msgid "None"
 msgstr "Geen"
 
 #: ../gramps/gen/lib/childreftype.py:68 ../gramps/gen/lib/eventtype.py:165
-#: ../gramps/gui/merge/mergeperson.py:187
+#: ../gramps/gui/merge/mergeperson.py:185
 #: ../gramps/plugins/gramplet/ancestor.py:64
 #: ../gramps/plugins/gramplet/descendant.py:63
 #: ../gramps/plugins/quickview/all_relations.py:270
@@ -6524,7 +6517,7 @@ msgstr "Geen"
 #: ../gramps/plugins/textreport/familygroup.py:524
 #: ../gramps/plugins/textreport/familygroup.py:526
 #: ../gramps/plugins/textreport/tagreport.py:166
-#: ../gramps/plugins/view/relview.py:602
+#: ../gramps/plugins/view/relview.py:612
 #: ../gramps/plugins/webreport/narrativeweb.py:3252
 #: ../gramps/plugins/webreport/narrativeweb.py:6132
 msgid "Birth"
@@ -6555,13 +6548,13 @@ msgstr "Pleegouder"
 #: ../gramps/gen/lib/date.py:273 ../gramps/gen/lib/date.py:421
 #: ../gramps/gen/mime/_pythonmime.py:48 ../gramps/gen/mime/_pythonmime.py:56
 #: ../gramps/gen/mime/_winmime.py:57 ../gramps/gen/utils/db.py:523
-#: ../gramps/gui/editors/editperson.py:352
+#: ../gramps/gui/editors/editperson.py:351
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:89
 #: ../gramps/gui/merge/mergeperson.py:61
 #: ../gramps/gui/views/treemodels/peoplemodel.py:97
 #: ../gramps/plugins/textreport/indivcomplete.py:648
 #: ../gramps/plugins/tool/dumpgenderstats.py:35
-#: ../gramps/plugins/view/relview.py:638
+#: ../gramps/plugins/view/relview.py:648
 #: ../gramps/plugins/webreport/narrativeweb.py:6331
 msgid "unknown"
 msgstr "onbekend"
@@ -6595,9 +6588,9 @@ msgid "between"
 msgstr "tussen"
 
 #: ../gramps/gen/lib/date.py:297 ../gramps/gen/lib/date.py:341
-#: ../gramps/gen/lib/date.py:359 ../gramps/gui/merge/mergefamily.py:153
+#: ../gramps/gen/lib/date.py:359 ../gramps/gui/merge/mergefamily.py:155
 #: ../gramps/plugins/quickview/all_relations.py:282
-#: ../gramps/plugins/view/relview.py:978
+#: ../gramps/plugins/view/relview.py:988
 #: ../gramps/plugins/webreport/narrativeweb.py:1195
 msgid "and"
 msgstr "en"
@@ -6746,7 +6739,7 @@ msgstr "Levensgebeurtenissen"
 #. show "> Family: ..." and nothing else
 #. show "V Family: ..." and the rest
 #: ../gramps/gen/lib/eventtype.py:139 ../gramps/gui/clipboard.py:771
-#: ../gramps/gui/configure.py:534
+#: ../gramps/gui/configure.py:536
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:59
 #: ../gramps/gui/editors/displaytabs/personeventembedlist.py:52
 #: ../gramps/gui/editors/editfamily.py:499 ../gramps/gui/editors/editlink.py:91
@@ -6761,7 +6754,7 @@ msgstr "Levensgebeurtenissen"
 #: ../gramps/plugins/quickview/filterbyname.py:240
 #: ../gramps/plugins/quickview/quickview.gpr.py:200
 #: ../gramps/plugins/quickview/references.py:86
-#: ../gramps/plugins/view/relview.py:1368 ../gramps/plugins/view/relview.py:1392
+#: ../gramps/plugins/view/relview.py:1378 ../gramps/plugins/view/relview.py:1402
 #: ../gramps/plugins/webreport/narrativeweb.py:3509
 msgid "Family"
 msgstr "Gezin"
@@ -6802,12 +6795,12 @@ msgid "Other"
 msgstr "Overige"
 
 # Gebeurtenistype: overlijden/sterven/sterfgeval/doodgaan
-#: ../gramps/gen/lib/eventtype.py:166 ../gramps/gui/merge/mergeperson.py:191
+#: ../gramps/gen/lib/eventtype.py:166 ../gramps/gui/merge/mergeperson.py:189
 #: ../gramps/plugins/textreport/familygroup.py:324
 #: ../gramps/plugins/textreport/familygroup.py:530
 #: ../gramps/plugins/textreport/familygroup.py:532
 #: ../gramps/plugins/textreport/tagreport.py:172
-#: ../gramps/plugins/view/relview.py:611 ../gramps/plugins/view/relview.py:636
+#: ../gramps/plugins/view/relview.py:621 ../gramps/plugins/view/relview.py:646
 #: ../gramps/plugins/webreport/narrativeweb.py:3256
 #: ../gramps/plugins/webreport/narrativeweb.py:6136
 msgid "Death"
@@ -6944,7 +6937,7 @@ msgstr "Pensioen"
 msgid "Will"
 msgstr "Testament"
 
-#: ../gramps/gen/lib/eventtype.py:198 ../gramps/gui/merge/mergeperson.py:246
+#: ../gramps/gen/lib/eventtype.py:198 ../gramps/gui/merge/mergeperson.py:244
 #: ../gramps/plugins/export/exportcsv.py:472
 #: ../gramps/plugins/importer/importcsv.py:218
 #: ../gramps/plugins/textreport/familygroup.py:402
@@ -7239,7 +7232,7 @@ msgstr "Geannuleerd"
 #: ../gramps/gen/lib/ldsord.py:105
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:114
 #: ../gramps/gui/glade/editchildref.glade:250
-#: ../gramps/gui/merge/mergeperson.py:250
+#: ../gramps/gui/merge/mergeperson.py:248
 #: ../gramps/plugins/export/exportcsv.py:515
 #: ../gramps/plugins/gramplet/children.py:93
 #: ../gramps/plugins/gramplet/children.py:192
@@ -7439,8 +7432,8 @@ msgstr "Laatste wijziging"
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:91
 #: ../gramps/gui/glade/editaddress.glade:322
 #: ../gramps/gui/glade/editaddress.glade:332
-#: ../gramps/gui/glade/editcitation.glade:116
-#: ../gramps/gui/glade/editcitation.glade:123
+#: ../gramps/gui/glade/editcitation.glade:115
+#: ../gramps/gui/glade/editcitation.glade:122
 #: ../gramps/gui/glade/editdate.glade:324
 #: ../gramps/gui/glade/editevent.glade:138
 #: ../gramps/gui/glade/editevent.glade:148
@@ -7455,7 +7448,7 @@ msgstr "Laatste wijziging"
 #: ../gramps/gui/glade/editname.glade:572 ../gramps/gui/glade/editname.glade:582
 #: ../gramps/gui/glade/editplacename.glade:132
 #: ../gramps/gui/glade/editplacename.glade:142
-#: ../gramps/gui/selectors/selectevent.py:72
+#: ../gramps/gui/selectors/selectevent.py:71
 #: ../gramps/plugins/export/exportcsv.py:287
 #: ../gramps/plugins/export/exportcsv.py:473
 #: ../gramps/plugins/gramplet/ageondategramplet.py:66
@@ -7494,9 +7487,9 @@ msgstr "Datum"
 #: ../gramps/gui/glade/editfamily.glade:773
 #: ../gramps/gui/glade/editmedia.glade:396
 #: ../gramps/gui/glade/editmediaref.glade:726
-#: ../gramps/gui/glade/editnote.glade:286
-#: ../gramps/gui/glade/editperson.glade:684
-#: ../gramps/gui/selectors/selectnote.py:78
+#: ../gramps/gui/glade/editnote.glade:284
+#: ../gramps/gui/glade/editperson.glade:683
+#: ../gramps/gui/selectors/selectnote.py:77
 #: ../gramps/plugins/lib/libpersonview.py:111
 #: ../gramps/plugins/lib/libplaceview.py:92
 #: ../gramps/plugins/textreport/indivcomplete.py:534
@@ -7529,7 +7522,7 @@ msgstr "Tags"
 #: ../gramps/gui/glade/editaddress.glade:297
 #: ../gramps/gui/glade/editattribute.glade:153
 #: ../gramps/gui/glade/editchildref.glade:180
-#: ../gramps/gui/glade/editcitation.glade:346
+#: ../gramps/gui/glade/editcitation.glade:345
 #: ../gramps/gui/glade/editevent.glade:355
 #: ../gramps/gui/glade/editeventref.glade:149
 #: ../gramps/gui/glade/editeventref.glade:420
@@ -7537,8 +7530,8 @@ msgstr "Tags"
 #: ../gramps/gui/glade/editmedia.glade:332
 #: ../gramps/gui/glade/editmediaref.glade:301
 #: ../gramps/gui/glade/editmediaref.glade:623
-#: ../gramps/gui/glade/editname.glade:156 ../gramps/gui/glade/editnote.glade:235
-#: ../gramps/gui/glade/editperson.glade:418
+#: ../gramps/gui/glade/editname.glade:156 ../gramps/gui/glade/editnote.glade:233
+#: ../gramps/gui/glade/editperson.glade:417
 #: ../gramps/gui/glade/editpersonref.glade:158
 #: ../gramps/gui/glade/editplace.glade:262
 #: ../gramps/gui/glade/editplaceref.glade:365
@@ -7563,23 +7556,23 @@ msgstr "Persoonlijk"
 #. Handle
 #. Add column with object name
 #: ../gramps/gen/lib/name.py:199 ../gramps/gui/clipboard.py:589
-#: ../gramps/gui/configure.py:513
+#: ../gramps/gui/configure.py:515
 #: ../gramps/gui/editors/displaytabs/backreflist.py:61
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:73
 #: ../gramps/gui/editors/displaytabs/personrefembedlist.py:64
 #: ../gramps/gui/editors/displaytabs/placenameembedlist.py:63
 #: ../gramps/gui/editors/displaytabs/placerefembedlist.py:59
 #: ../gramps/gui/editors/editfamily.py:123 ../gramps/gui/editors/editname.py:311
-#: ../gramps/gui/editors/filtereditor.py:820
-#: ../gramps/gui/editors/filtereditor.py:974
+#: ../gramps/gui/editors/filtereditor.py:818
+#: ../gramps/gui/editors/filtereditor.py:973
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:126
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:105
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:104
 #: ../gramps/gui/plug/_guioptions.py:1165 ../gramps/gui/plug/_windows.py:126
 #: ../gramps/gui/plug/_windows.py:1094
 #: ../gramps/gui/plug/report/_bookdialog.py:372
-#: ../gramps/gui/selectors/selectperson.py:94
-#: ../gramps/gui/selectors/selectplace.py:71
+#: ../gramps/gui/selectors/selectperson.py:93
+#: ../gramps/gui/selectors/selectplace.py:70
 #: ../gramps/gui/views/bookmarks.py:240 ../gramps/gui/views/tags.py:402
 #: ../gramps/gui/views/treemodels/peoplemodel.py:616
 #: ../gramps/plugins/export/exportcsv.py:285
@@ -7619,11 +7612,11 @@ msgid "Surnames"
 msgstr "Achternamen"
 
 #: ../gramps/gen/lib/name.py:206 ../gramps/gen/utils/keyword.py:60
-#: ../gramps/gui/configure.py:643 ../gramps/gui/configure.py:645
-#: ../gramps/gui/configure.py:647 ../gramps/gui/configure.py:649
-#: ../gramps/gui/configure.py:650 ../gramps/gui/configure.py:655
-#: ../gramps/gui/configure.py:657 ../gramps/gui/configure.py:662
-#: ../gramps/gui/configure.py:664 ../gramps/gui/glade/editperson.glade:230
+#: ../gramps/gui/configure.py:645 ../gramps/gui/configure.py:647
+#: ../gramps/gui/configure.py:649 ../gramps/gui/configure.py:651
+#: ../gramps/gui/configure.py:652 ../gramps/gui/configure.py:657
+#: ../gramps/gui/configure.py:659 ../gramps/gui/configure.py:664
+#: ../gramps/gui/configure.py:666 ../gramps/gui/glade/editperson.glade:229
 #: ../gramps/plugins/export/exportcsv.py:354
 #: ../gramps/plugins/importer/importcsv.py:166
 msgid "Suffix"
@@ -7636,9 +7629,9 @@ msgstr "Achtervoegsel"
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:88
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:87
 #: ../gramps/gui/selectors/selectobject.py:80
-#: ../gramps/gui/selectors/selectplace.py:74
-#: ../gramps/gui/selectors/selectrepository.py:70
-#: ../gramps/gui/selectors/selectsource.py:70
+#: ../gramps/gui/selectors/selectplace.py:73
+#: ../gramps/gui/selectors/selectrepository.py:69
+#: ../gramps/gui/selectors/selectsource.py:69
 #: ../gramps/gui/widgets/grampletpane.py:1562
 #: ../gramps/plugins/export/exportcsv.py:285
 #: ../gramps/plugins/gramplet/persondetails.py:160
@@ -7671,14 +7664,14 @@ msgstr "Titel"
 #: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:102
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:106
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:105
-#: ../gramps/gui/merge/mergeperson.py:242 ../gramps/gui/plug/_windows.py:119
+#: ../gramps/gui/merge/mergeperson.py:240 ../gramps/gui/plug/_windows.py:119
 #: ../gramps/gui/plug/_windows.py:235 ../gramps/gui/plug/_windows.py:1093
 #: ../gramps/gui/plug/report/_bookdialog.py:373
 #: ../gramps/gui/plug/report/_bookdialog.py:377
-#: ../gramps/gui/selectors/selectevent.py:70
-#: ../gramps/gui/selectors/selectnote.py:77
+#: ../gramps/gui/selectors/selectevent.py:69
+#: ../gramps/gui/selectors/selectnote.py:76
 #: ../gramps/gui/selectors/selectobject.py:82
-#: ../gramps/gui/selectors/selectplace.py:73
+#: ../gramps/gui/selectors/selectplace.py:72
 #: ../gramps/plugins/export/exportcsv.py:286
 #: ../gramps/plugins/gramplet/backlinks.py:55
 #: ../gramps/plugins/gramplet/coordinates.py:89
@@ -7784,7 +7777,7 @@ msgstr "Overgenomen"
 
 # patronymisch/patroniemen
 #: ../gramps/gen/lib/nameorigintype.py:79 ../gramps/gen/utils/keyword.py:65
-#: ../gramps/gui/configure.py:656
+#: ../gramps/gui/configure.py:658
 msgid "Patronymic"
 msgstr "Patroniem"
 
@@ -7829,17 +7822,17 @@ msgstr "Geboortenaam"
 msgid "Married Name"
 msgstr "Getrouwde naam"
 
-#: ../gramps/gen/lib/notetype.py:75 ../gramps/gui/configure.py:1402
+#: ../gramps/gen/lib/notetype.py:75 ../gramps/gui/configure.py:1410
 #: ../gramps/gui/editors/editeventref.py:89
 #: ../gramps/gui/editors/editmediaref.py:106
-#: ../gramps/gui/editors/editplaceref.py:70
-#: ../gramps/gui/editors/editreporef.py:72
+#: ../gramps/gui/editors/editplaceref.py:71
+#: ../gramps/gui/editors/editreporef.py:71
 #: ../gramps/gui/glade/editeventref.glade:183
 #: ../gramps/gui/glade/editeventref.glade:563
 #: ../gramps/gui/glade/editmediaref.glade:342
 #: ../gramps/gui/glade/editmediaref.glade:756
 #: ../gramps/gui/glade/editname.glade:672
-#: ../gramps/gui/glade/editperson.glade:383
+#: ../gramps/gui/glade/editperson.glade:382
 #: ../gramps/gui/glade/editplaceref.glade:160
 #: ../gramps/gui/glade/editplaceref.glade:598
 #: ../gramps/gui/glade/editreporef.glade:225
@@ -7862,7 +7855,7 @@ msgstr "Brontekst"
 
 #. 8
 #: ../gramps/gen/lib/notetype.py:79 ../gramps/gui/clipboard.py:490
-#: ../gramps/gui/configure.py:540 ../gramps/gui/editors/editcitation.py:119
+#: ../gramps/gui/configure.py:542 ../gramps/gui/editors/editcitation.py:119
 #: ../gramps/gui/editors/editcitation.py:125
 #: ../gramps/gui/editors/editlink.py:98
 #: ../gramps/gui/editors/filtereditor.py:301
@@ -7968,8 +7961,8 @@ msgstr "Handle"
 
 #: ../gramps/gen/lib/person.py:215 ../gramps/gui/editors/editfamily.py:124
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:128
-#: ../gramps/gui/merge/mergeperson.py:183
-#: ../gramps/gui/selectors/selectperson.py:96
+#: ../gramps/gui/merge/mergeperson.py:181
+#: ../gramps/gui/selectors/selectperson.py:95
 #: ../gramps/plugins/drawreport/statisticschart.py:338
 #: ../gramps/plugins/export/exportcsv.py:355
 #: ../gramps/plugins/importer/importcsv.py:167
@@ -7990,9 +7983,8 @@ msgstr "Alterneer namen"
 
 # Bronnen, verwijzingen, literatuurverwijzingen
 #: ../gramps/gen/lib/person.py:218
-#, fuzzy
 msgid "Death reference index"
-msgstr "Opmerking over gebeurtenissenverwijzingen"
+msgstr "Index overlijdensverwijzingen"
 
 #: ../gramps/gen/lib/person.py:219
 msgid "Birth reference index"
@@ -8025,7 +8017,7 @@ msgstr "Gezinnen"
 msgid "Parent families"
 msgstr "Oudergezinnen"
 
-#: ../gramps/gen/lib/person.py:224 ../gramps/gui/merge/mergeperson.py:257
+#: ../gramps/gen/lib/person.py:224 ../gramps/gui/merge/mergeperson.py:255
 #: ../gramps/plugins/textreport/indivcomplete.py:406
 #: ../gramps/plugins/webreport/narrativeweb.py:1430
 msgid "Addresses"
@@ -8051,7 +8043,7 @@ msgstr "Waarschijnlijk in leven"
 msgid "Merged Gramps ID"
 msgstr "Gramps IDs samengevoegd"
 
-#: ../gramps/gen/lib/placetype.py:65 ../gramps/gui/configure.py:518
+#: ../gramps/gen/lib/placetype.py:65 ../gramps/gui/configure.py:520
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:76
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:59
 #: ../gramps/gui/views/treemodels/placemodel.py:283
@@ -8084,7 +8076,7 @@ msgid "County"
 msgstr "Provincie"
 
 # stad
-#: ../gramps/gen/lib/placetype.py:68 ../gramps/gui/configure.py:516
+#: ../gramps/gen/lib/placetype.py:68 ../gramps/gui/configure.py:518
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:74
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:56
 #: ../gramps/plugins/view/geoplaces.py:582 ../gramps/plugins/view/repoview.py:91
@@ -8102,7 +8094,7 @@ msgstr "Dorp of stad"
 msgid "Parish"
 msgstr "Parochie"
 
-#: ../gramps/gen/lib/placetype.py:70 ../gramps/gui/configure.py:515
+#: ../gramps/gen/lib/placetype.py:70 ../gramps/gui/configure.py:517
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:73
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:55
 #: ../gramps/plugins/view/geoplaces.py:531 ../gramps/plugins/view/repoview.py:90
@@ -8355,9 +8347,9 @@ msgstr "Een ouder dient een vader of een moeder te zijn."
 #: ../gramps/gen/merge/mergefamilyquery.py:103
 #: ../gramps/gen/merge/mergefamilyquery.py:114
 #: ../gramps/gen/merge/mergepersonquery.py:54
-#: ../gramps/gen/merge/test/merge_ref_test.py:1895
-#: ../gramps/gen/merge/test/merge_ref_test.py:1917
-#: ../gramps/gen/merge/test/merge_ref_test.py:1940
+#: ../gramps/gen/merge/test/merge_ref_test.py:1874
+#: ../gramps/gen/merge/test/merge_ref_test.py:1898
+#: ../gramps/gen/merge/test/merge_ref_test.py:1922
 msgid ""
 "A parent and child cannot be merged. To merge these people, you must first "
 "break the relationship between them."
@@ -8386,12 +8378,11 @@ msgstr ""
 "Echtgenoten kunnen niet samengevoegd worden. Om deze personen toch samen te "
 "voegen moet u eerst de relatie tussen hen verbreken."
 
-#: ../gramps/gen/merge/mergepersonquery.py:117
+#: ../gramps/gen/merge/mergepersonquery.py:118
 msgid "Merge Person"
 msgstr "Personen samenvoegen"
 
-#: ../gramps/gen/merge/mergepersonquery.py:156
-#: ../gramps/gen/merge/test/merge_ref_test.py:1503
+#: ../gramps/gen/merge/mergepersonquery.py:157
 msgid ""
 "A person with multiple relations with the same spouse is about to be merged. "
 "This is beyond the capabilities of the merge routine. The merge is aborted."
@@ -8400,7 +8391,7 @@ msgstr ""
 "Dit overstijgt de mogelijkheden van de samenvoegingsroutine. Het samenvoegen "
 "wordt afgebroken."
 
-#: ../gramps/gen/merge/mergepersonquery.py:167
+#: ../gramps/gen/merge/mergepersonquery.py:168
 msgid "Multiple families get merged. This is unusual, the merge is aborted."
 msgstr ""
 "Meerdere gezinnen worden samengevoegd. Dit is ongebruikelijk. De samenvoeging "
@@ -8624,22 +8615,22 @@ msgid "TrueType / FreeSans"
 msgstr "TrueType / FreeSans"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:69
-#: ../gramps/plugins/view/pedigreeview.py:2029
+#: ../gramps/plugins/view/pedigreeview.py:2043
 msgid "Vertical (↓)"
 msgstr "Verticaal (↓)"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:70
-#: ../gramps/plugins/view/pedigreeview.py:2030
+#: ../gramps/plugins/view/pedigreeview.py:2044
 msgid "Vertical (↑)"
 msgstr "Verticaal (↑)"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:71
-#: ../gramps/plugins/view/pedigreeview.py:2031
+#: ../gramps/plugins/view/pedigreeview.py:2045
 msgid "Horizontal (→)"
 msgstr "Horizontaal (→)"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:72
-#: ../gramps/plugins/view/pedigreeview.py:2032
+#: ../gramps/plugins/view/pedigreeview.py:2046
 msgid "Horizontal (←)"
 msgstr "Horizontaal (←)"
 
@@ -8893,8 +8884,8 @@ msgstr ""
 #. ###############################
 #. 3
 #: ../gramps/gen/plug/docgen/graphdoc.py:255 ../gramps/gui/clipboard.py:394
-#: ../gramps/gui/configure.py:548 ../gramps/gui/editors/editlink.py:93
-#: ../gramps/gui/editors/editmedia.py:98 ../gramps/gui/editors/editmedia.py:183
+#: ../gramps/gui/configure.py:550 ../gramps/gui/editors/editlink.py:93
+#: ../gramps/gui/editors/editmedia.py:98 ../gramps/gui/editors/editmedia.py:181
 #: ../gramps/gui/editors/editmediaref.py:145
 #: ../gramps/gui/editors/filtereditor.py:300
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:109
@@ -8905,10 +8896,10 @@ msgstr ""
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:109
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:108
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:91
-#: ../gramps/gui/glade/editnote.glade:328
+#: ../gramps/gui/glade/editnote.glade:326
 #: ../gramps/gui/views/treemodels/mediamodel.py:117
 #: ../gramps/plugins/drawreport/ancestortree.py:984
-#: ../gramps/plugins/drawreport/descendtree.py:1703
+#: ../gramps/plugins/drawreport/descendtree.py:1706
 #: ../gramps/plugins/export/exportcsv.py:360
 #: ../gramps/plugins/export/exportcsv.py:473
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:111
@@ -9012,7 +9003,7 @@ msgstr "Geldige waarden: "
 #.
 #. ------------------------------------------------------------------------
 #: ../gramps/gen/plug/report/_book.py:71 ../gramps/gui/plug/_dialogs.py:59
-#: ../gramps/gui/plug/report/_bookdialog.py:84 ../gramps/gui/viewmanager.py:110
+#: ../gramps/gui/plug/report/_bookdialog.py:84 ../gramps/gui/viewmanager.py:111
 msgid "Unsupported"
 msgstr "Niet ondersteund"
 
@@ -9041,7 +9032,7 @@ msgid "Graphs"
 msgstr "Grafieken"
 
 #: ../gramps/gen/plug/report/_constants.py:53 ../gramps/gui/clipboard.py:637
-#: ../gramps/gui/clipboard.py:645 ../gramps/gui/configure.py:1196
+#: ../gramps/gui/clipboard.py:645 ../gramps/gui/configure.py:1199
 #: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:101
 #: ../gramps/plugins/textreport/custombooktext.py:132
 #: ../gramps/plugins/textreport/tagreport.py:507
@@ -9088,7 +9079,7 @@ msgid "The translation to be used for the report."
 msgstr "De gebruikte taal voor het verslag."
 
 #. label for the combo
-#: ../gramps/gen/plug/report/stdoptions.py:68 ../gramps/gui/configure.py:977
+#: ../gramps/gen/plug/report/stdoptions.py:68 ../gramps/gui/configure.py:980
 #: ../gramps/plugins/webreport/webcal.py:1646
 msgid "Name format"
 msgstr "Naamweergave"
@@ -9316,7 +9307,7 @@ msgstr ""
 "Bent u zeker dat er geen problemen zijn bij andere bestanden, verwijder het "
 "en herstart Gramps."
 
-#: ../gramps/gen/relationship.py:860 ../gramps/plugins/view/pedigreeview.py:1516
+#: ../gramps/gen/relationship.py:860 ../gramps/plugins/view/pedigreeview.py:1530
 msgid "Relationship loop detected"
 msgstr "Verwantschapskringloop ontdekt"
 
@@ -9795,19 +9786,19 @@ msgstr "Titel"
 msgid "GIVEN"
 msgstr "VOORNAAM"
 
-#: ../gramps/gen/utils/keyword.py:56 ../gramps/gui/configure.py:650
-#: ../gramps/gui/configure.py:657 ../gramps/gui/configure.py:659
-#: ../gramps/gui/configure.py:660 ../gramps/gui/configure.py:661
+#: ../gramps/gen/utils/keyword.py:56 ../gramps/gui/configure.py:652
+#: ../gramps/gui/configure.py:659 ../gramps/gui/configure.py:661
 #: ../gramps/gui/configure.py:662 ../gramps/gui/configure.py:663
+#: ../gramps/gui/configure.py:664 ../gramps/gui/configure.py:665
 msgid "SURNAME"
 msgstr "ACHTERNAAM"
 
 #. show surname and first name
 #: ../gramps/gen/utils/keyword.py:56 ../gramps/gui/clipboard.py:621
-#: ../gramps/gui/configure.py:643 ../gramps/gui/configure.py:645
-#: ../gramps/gui/configure.py:647 ../gramps/gui/configure.py:649
-#: ../gramps/gui/configure.py:652 ../gramps/gui/configure.py:653
+#: ../gramps/gui/configure.py:645 ../gramps/gui/configure.py:647
+#: ../gramps/gui/configure.py:649 ../gramps/gui/configure.py:651
 #: ../gramps/gui/configure.py:654 ../gramps/gui/configure.py:655
+#: ../gramps/gui/configure.py:656 ../gramps/gui/configure.py:657
 #: ../gramps/gui/editors/displaytabs/surnametab.py:74
 #: ../gramps/gui/plug/_guioptions.py:88 ../gramps/gui/plug/_guioptions.py:1493
 #: ../gramps/plugins/drawreport/statisticschart.py:334
@@ -9832,9 +9823,9 @@ msgstr "Roepnaam"
 msgid "Name|COMMON"
 msgstr "GEWONE"
 
-#: ../gramps/gen/utils/keyword.py:58 ../gramps/gui/configure.py:647
-#: ../gramps/gui/configure.py:649 ../gramps/gui/configure.py:652
-#: ../gramps/gui/configure.py:653 ../gramps/gui/configure.py:659
+#: ../gramps/gen/utils/keyword.py:58 ../gramps/gui/configure.py:649
+#: ../gramps/gui/configure.py:651 ../gramps/gui/configure.py:654
+#: ../gramps/gui/configure.py:655 ../gramps/gui/configure.py:661
 msgid "Name|Common"
 msgstr "Gewone"
 
@@ -9920,7 +9911,7 @@ msgstr "Patroniem[con]"
 msgid "RAWSURNAMES"
 msgstr "RUWACHTERNAAM"
 
-#: ../gramps/gen/utils/keyword.py:69 ../gramps/gui/configure.py:664
+#: ../gramps/gen/utils/keyword.py:69 ../gramps/gui/configure.py:666
 msgid "Rawsurnames"
 msgstr "Ruwachternaam"
 
@@ -9939,7 +9930,7 @@ msgstr "PREFIX"
 
 #: ../gramps/gen/utils/keyword.py:71
 #: ../gramps/gui/editors/displaytabs/surnametab.py:73
-#: ../gramps/gui/glade/editperson.glade:471
+#: ../gramps/gui/glade/editperson.glade:470
 #: ../gramps/plugins/export/exportcsv.py:354
 #: ../gramps/plugins/importer/importcsv.py:165
 msgid "Prefix"
@@ -9977,7 +9968,7 @@ msgstr "%(east_longitude)s O"
 msgid "%(west_longitude)s W"
 msgstr "%(west_longitude)s W"
 
-#: ../gramps/gen/utils/string.py:46 ../gramps/gui/editors/editperson.py:351
+#: ../gramps/gen/utils/string.py:46 ../gramps/gui/editors/editperson.py:350
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:89
 #: ../gramps/gui/merge/mergeperson.py:61
 #: ../gramps/gui/views/treemodels/peoplemodel.py:97
@@ -9986,7 +9977,7 @@ msgstr "%(west_longitude)s W"
 msgid "male"
 msgstr "mannelijk"
 
-#: ../gramps/gen/utils/string.py:47 ../gramps/gui/editors/editperson.py:350
+#: ../gramps/gen/utils/string.py:47 ../gramps/gui/editors/editperson.py:349
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:89
 #: ../gramps/gui/merge/mergeperson.py:61
 #: ../gramps/gui/views/treemodels/peoplemodel.py:97
@@ -10003,26 +9994,26 @@ msgstr "onbekend"
 msgid "Invalid"
 msgstr "Ongeldig"
 
-#: ../gramps/gen/utils/string.py:55 ../gramps/gui/editors/editcitation.py:216
+#: ../gramps/gen/utils/string.py:55 ../gramps/gui/editors/editcitation.py:214
 msgid "Very High"
 msgstr "Zeer hoog"
 
-#: ../gramps/gen/utils/string.py:56 ../gramps/gui/editors/editcitation.py:215
+#: ../gramps/gen/utils/string.py:56 ../gramps/gui/editors/editcitation.py:213
 #: ../gramps/plugins/tool/finddupes.py:62
 msgid "High"
 msgstr "Hoog"
 
-#: ../gramps/gen/utils/string.py:57 ../gramps/gui/editors/editcitation.py:214
+#: ../gramps/gen/utils/string.py:57 ../gramps/gui/editors/editcitation.py:212
 #: ../gramps/plugins/graph/gvfamilylines.py:242
 msgid "Normal"
 msgstr "Normaal"
 
-#: ../gramps/gen/utils/string.py:58 ../gramps/gui/editors/editcitation.py:213
+#: ../gramps/gen/utils/string.py:58 ../gramps/gui/editors/editcitation.py:211
 #: ../gramps/plugins/tool/finddupes.py:60
 msgid "Low"
 msgstr "Laag"
 
-#: ../gramps/gen/utils/string.py:59 ../gramps/gui/editors/editcitation.py:212
+#: ../gramps/gen/utils/string.py:59 ../gramps/gui/editors/editcitation.py:210
 msgid "Very Low"
 msgstr "Zeer laag"
 
@@ -10140,7 +10131,7 @@ msgid "manual|Using_the_Clipboard"
 msgstr "Gebruik_van_het_klembord"
 
 #. We encounter a PLAC, having previously encountered an ADDR
-#: ../gramps/gui/clipboard.py:303 ../gramps/gui/configure.py:514
+#: ../gramps/gui/clipboard.py:303 ../gramps/gui/configure.py:516
 #: ../gramps/gui/editors/editaddress.py:168
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:106
 #: ../gramps/plugins/gramplet/repositorydetails.py:133
@@ -10153,7 +10144,7 @@ msgstr "Adres"
 
 # Gebeuren (korter)
 #. 0 this order range above
-#: ../gramps/gui/clipboard.py:340 ../gramps/gui/configure.py:544
+#: ../gramps/gui/clipboard.py:340 ../gramps/gui/configure.py:546
 #: ../gramps/gui/editors/editlink.py:90
 #: ../gramps/gui/editors/filtereditor.py:295
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:133
@@ -10162,13 +10153,13 @@ msgstr "Adres"
 #: ../gramps/plugins/quickview/filterbyname.py:246
 #: ../gramps/plugins/quickview/quickview.gpr.py:201
 #: ../gramps/plugins/quickview/references.py:87
-#: ../gramps/plugins/textreport/placereport.py:457
+#: ../gramps/plugins/textreport/placereport.py:461
 #: ../gramps/plugins/webreport/narrativeweb.py:989
 msgid "Event"
 msgstr "Gebeurtenis"
 
 #. 5
-#: ../gramps/gui/clipboard.py:367 ../gramps/gui/configure.py:536
+#: ../gramps/gui/clipboard.py:367 ../gramps/gui/configure.py:538
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:81
 #: ../gramps/gui/editors/displaytabs/familyldsembedlist.py:55
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:65
@@ -10177,7 +10168,7 @@ msgstr "Gebeurtenis"
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:108
 #: ../gramps/gui/glade/editevent.glade:270
 #: ../gramps/gui/plug/_guioptions.py:1343
-#: ../gramps/gui/selectors/selectevent.py:73
+#: ../gramps/gui/selectors/selectevent.py:72
 #: ../gramps/gui/views/treemodels/placemodel.py:283
 #: ../gramps/plugins/export/exportcsv.py:285
 #: ../gramps/plugins/export/exportcsv.py:473
@@ -10272,7 +10263,7 @@ msgstr "%(frel)s %(mrel)s"
 #.
 #. ------------------------------------------------------------------------
 #. functions for the actual quickreports
-#: ../gramps/gui/clipboard.py:743 ../gramps/gui/configure.py:532
+#: ../gramps/gui/clipboard.py:743 ../gramps/gui/configure.py:534
 #: ../gramps/gui/editors/editlink.py:94
 #: ../gramps/gui/editors/filtereditor.py:293
 #: ../gramps/gui/glade/editpersonref.glade:211
@@ -10297,7 +10288,7 @@ msgstr "%(frel)s %(mrel)s"
 #: ../gramps/plugins/quickview/samesurnames.py:160
 #: ../gramps/plugins/textreport/placereport.py:221
 #: ../gramps/plugins/textreport/placereport.py:297
-#: ../gramps/plugins/textreport/placereport.py:457
+#: ../gramps/plugins/textreport/placereport.py:461
 #: ../gramps/plugins/tool/eventcmp.py:251
 #: ../gramps/plugins/webreport/narrativeweb.py:3508
 #: ../gramps/plugins/webreport/narrativeweb.py:4200
@@ -10306,7 +10297,7 @@ msgid "Person"
 msgstr "Persoon"
 
 #. 7
-#: ../gramps/gui/clipboard.py:800 ../gramps/gui/configure.py:538
+#: ../gramps/gui/clipboard.py:800 ../gramps/gui/configure.py:540
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:78
 #: ../gramps/gui/editors/editlink.py:97 ../gramps/gui/editors/editsource.py:86
 #: ../gramps/gui/editors/filtereditor.py:297
@@ -10325,7 +10316,7 @@ msgid "Source"
 msgstr "Bron"
 
 #. 6
-#: ../gramps/gui/clipboard.py:827 ../gramps/gui/configure.py:546
+#: ../gramps/gui/clipboard.py:827 ../gramps/gui/configure.py:548
 #: ../gramps/gui/editors/editlink.py:96
 #: ../gramps/gui/editors/editrepository.py:77
 #: ../gramps/gui/editors/editrepository.py:79
@@ -10336,7 +10327,7 @@ msgstr "Bron"
 msgid "Repository"
 msgstr "Bibliotheek"
 
-#: ../gramps/gui/clipboard.py:967 ../gramps/gui/dbman.py:127
+#: ../gramps/gui/clipboard.py:967 ../gramps/gui/dbman.py:126
 #: ../gramps/gui/editors/displaytabs/attrembedlist.py:63
 #: ../gramps/gui/editors/displaytabs/srcattrembedlist.py:64
 #: ../gramps/plugins/gramplet/attributes.py:57
@@ -10382,9 +10373,9 @@ msgstr "Boomweergave: de eerste kolom \"%s\" kan niet veranderd worden"
 msgid "Drag and drop the columns to change the order"
 msgstr "Versleep de kolommen om de volgorde te veranderen"
 
-#: ../gramps/gui/columnorder.py:107 ../gramps/gui/configure.py:1507
-#: ../gramps/gui/configure.py:1530 ../gramps/gui/plug/_dialogs.py:124
-#: ../gramps/gui/viewmanager.py:1414
+#: ../gramps/gui/columnorder.py:107 ../gramps/gui/configure.py:1542
+#: ../gramps/gui/configure.py:1565 ../gramps/gui/configure.py:1590
+#: ../gramps/gui/plug/_dialogs.py:130 ../gramps/gui/viewmanager.py:1453
 #: ../gramps/plugins/lib/maps/geography.py:1007
 #: ../gramps/plugins/lib/maps/geography.py:1261
 msgid "_Apply"
@@ -10392,9 +10383,9 @@ msgstr "Toepassen"
 
 # De weergave van Datums en kalenders, werkbalk en statusbalk.
 #. #################
-#: ../gramps/gui/columnorder.py:128 ../gramps/gui/configure.py:1107
+#: ../gramps/gui/columnorder.py:128 ../gramps/gui/configure.py:1110
 #: ../gramps/plugins/drawreport/ancestortree.py:855
-#: ../gramps/plugins/drawreport/descendtree.py:1563
+#: ../gramps/plugins/drawreport/descendtree.py:1566
 msgid "Display"
 msgstr "Weergave"
 
@@ -10402,34 +10393,34 @@ msgstr "Weergave"
 msgid "Column Name"
 msgstr "Kolomnaam"
 
-#: ../gramps/gui/configure.py:79
+#: ../gramps/gui/configure.py:80
 msgid "Father's surname"
 msgstr "Achternaam vader"
 
-#: ../gramps/gui/configure.py:81
+#: ../gramps/gui/configure.py:82
 msgid "Combination of mother's and father's surname"
 msgstr "Combinatie van achternamen vader en moeder"
 
-#: ../gramps/gui/configure.py:82
+#: ../gramps/gui/configure.py:83
 msgid "Icelandic style"
 msgstr "IJsland-stijl"
 
-#: ../gramps/gui/configure.py:104 ../gramps/gui/configure.py:106
+#: ../gramps/gui/configure.py:105 ../gramps/gui/configure.py:107
 msgid "Display Name Editor"
 msgstr "Het naambewerkingsscherm tonen"
 
 #. self.window.connect('response', self.close)
-#: ../gramps/gui/configure.py:105 ../gramps/gui/configure.py:179
+#: ../gramps/gui/configure.py:106 ../gramps/gui/configure.py:180
 #: ../gramps/gui/glade/book.glade:466 ../gramps/gui/glade/book.glade:540
 #: ../gramps/gui/glade/clipboard.glade:71 ../gramps/gui/glade/dialog.glade:20
 #: ../gramps/gui/glade/dialog.glade:140
 #: ../gramps/gui/glade/displaystate.glade:25
-#: ../gramps/gui/glade/plugins.glade:24 ../gramps/gui/glade/rule.glade:26
-#: ../gramps/gui/glade/rule.glade:1029 ../gramps/gui/glade/tipofday.glade:117
+#: ../gramps/gui/glade/plugins.glade:22 ../gramps/gui/glade/rule.glade:24
+#: ../gramps/gui/glade/rule.glade:1024 ../gramps/gui/glade/tipofday.glade:117
 #: ../gramps/gui/glade/updateaddons.glade:26 ../gramps/gui/plug/_windows.py:102
 #: ../gramps/gui/plug/_windows.py:682 ../gramps/gui/plug/_windows.py:738
 #: ../gramps/gui/plug/quick/_textbufdoc.py:61 ../gramps/gui/undohistory.py:90
-#: ../gramps/gui/viewmanager.py:506 ../gramps/gui/viewmanager.py:1286
+#: ../gramps/gui/viewmanager.py:510 ../gramps/gui/viewmanager.py:1294
 #: ../gramps/gui/views/bookmarks.py:258 ../gramps/gui/views/tags.py:424
 #: ../gramps/gui/widgets/grampletbar.py:635
 #: ../gramps/gui/widgets/grampletpane.py:236
@@ -10437,7 +10428,7 @@ msgstr "Het naambewerkingsscherm tonen"
 msgid "_Close"
 msgstr "Sluiten"
 
-#: ../gramps/gui/configure.py:108
+#: ../gramps/gui/configure.py:110
 msgid ""
 "The following keywords are replaced with the appropriate name parts:<tt>\n"
 "  <b>Given</b>   - given name (first name)     <b>Surname</b>  - surnames "
@@ -10500,22 +10491,22 @@ msgstr ""
 "i>: titel, <i>Sr</i>: suffix, <i>Ed</i>: bijnaam, \n"
 "     <i>Underhills</i>: familiebijnaam, <i>Jose</i>: roepnaam.\n"
 
-#: ../gramps/gui/configure.py:137
+#: ../gramps/gui/configure.py:138
 msgid " Name Editor"
 msgstr "Naamaanpassingscherm"
 
 # Bronnen, verwijzingen, literatuurverwijzingen
-#: ../gramps/gui/configure.py:155 ../gramps/gui/configure.py:1585
+#: ../gramps/gui/configure.py:156 ../gramps/gui/configure.py:1645
 #: ../gramps/gui/views/pageview.py:590
 msgid "Preferences"
 msgstr "Voorkeuren"
 
-#: ../gramps/gui/configure.py:231 ../gramps/gui/configure.py:237
-#: ../gramps/gui/configure.py:802
+#: ../gramps/gui/configure.py:232 ../gramps/gui/configure.py:238
+#: ../gramps/gui/configure.py:804
 msgid "Invalid or incomplete format definition."
 msgstr "Ongeldige of onvolledige formaatdefinitie."
 
-#: ../gramps/gui/configure.py:511
+#: ../gramps/gui/configure.py:513
 msgid ""
 "Enter your information so people can contact you when you distribute your "
 "Family Tree"
@@ -10523,17 +10514,17 @@ msgstr ""
 "U kunt uw informatie hier invullen zodat mensen u kunnen contacteren wanneer "
 "u uw stamboom deelt met anderen"
 
-#: ../gramps/gui/configure.py:517
+#: ../gramps/gui/configure.py:519
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:75
 #: ../gramps/plugins/view/repoview.py:92
 msgid "State/County"
 msgstr "Provincie"
 
-#: ../gramps/gui/configure.py:519 ../gramps/plugins/view/repoview.py:94
+#: ../gramps/gui/configure.py:521 ../gramps/plugins/view/repoview.py:94
 msgid "ZIP/Postal Code"
 msgstr "Postcode"
 
-#: ../gramps/gui/configure.py:520 ../gramps/plugins/export/exportgedcom.py:784
+#: ../gramps/gui/configure.py:522 ../gramps/plugins/export/exportgedcom.py:784
 #: ../gramps/plugins/export/exportgedcom.py:1152
 #: ../gramps/plugins/gramplet/repositorydetails.py:121
 #: ../gramps/plugins/lib/libgedcom.py:3973
@@ -10542,57 +10533,57 @@ msgstr "Postcode"
 msgid "Phone"
 msgstr "Telefoon"
 
-#: ../gramps/gui/configure.py:521 ../gramps/gui/plug/_windows.py:615
+#: ../gramps/gui/configure.py:523 ../gramps/gui/plug/_windows.py:615
 #: ../gramps/plugins/view/repoview.py:95
 msgid "Email"
 msgstr "E-mail"
 
-#: ../gramps/gui/configure.py:522
+#: ../gramps/gui/configure.py:524
 msgid "Researcher"
 msgstr "Onderzoeker"
 
-#: ../gramps/gui/configure.py:542 ../gramps/gui/editors/editperson.py:647
+#: ../gramps/gui/configure.py:544 ../gramps/gui/editors/editperson.py:646
 #: ../gramps/gui/widgets/photo.py:86
 msgid "Media Object"
 msgstr "Media-object"
 
-#: ../gramps/gui/configure.py:550
+#: ../gramps/gui/configure.py:552
 msgid "ID Formats"
 msgstr "ID Formaten"
 
-#: ../gramps/gui/configure.py:560
+#: ../gramps/gui/configure.py:562
 msgid "Set the colors used for boxes in the graphical views"
 msgstr "De kleuren die gebruikt worden voor de grafische schermen vastleggen"
 
-#: ../gramps/gui/configure.py:562
+#: ../gramps/gui/configure.py:564
 msgid "Gender Male Alive"
 msgstr "Achtergrond mannen nog in leven"
 
-#: ../gramps/gui/configure.py:564
+#: ../gramps/gui/configure.py:566
 msgid "Border Male Alive"
 msgstr "Rand voor mannen nog in leven"
 
-#: ../gramps/gui/configure.py:566
+#: ../gramps/gui/configure.py:568
 msgid "Gender Male Death"
 msgstr "Achtergrond overleden mannen"
 
-#: ../gramps/gui/configure.py:568
+#: ../gramps/gui/configure.py:570
 msgid "Border Male Death"
 msgstr "Rand overleden mannen"
 
-#: ../gramps/gui/configure.py:570
+#: ../gramps/gui/configure.py:572
 msgid "Gender Female Alive"
 msgstr "Achtergrond vrouwen nog in leven"
 
-#: ../gramps/gui/configure.py:572
+#: ../gramps/gui/configure.py:574
 msgid "Border Female Alive"
 msgstr "Rand voor vrouwen nog in leven"
 
-#: ../gramps/gui/configure.py:574
+#: ../gramps/gui/configure.py:576
 msgid "Gender Female Death"
 msgstr "Achtergrond overleden vrouwen"
 
-#: ../gramps/gui/configure.py:576
+#: ../gramps/gui/configure.py:578
 msgid "Border Female Death"
 msgstr "Rand overleden vrouwen"
 
@@ -10604,85 +10595,85 @@ msgstr "Rand overleden vrouwen"
 #. #                        'preferences.color-gender-other-death')
 #. #        self.add_color(grid, _('Border Other Death'), 8,
 #. #                        'preferences.bordercolor-gender-other-death')
-#: ../gramps/gui/configure.py:586
+#: ../gramps/gui/configure.py:588
 msgid "Gender Unknown Alive"
 msgstr "Achtergrond onbekend geslacht nog in leven"
 
-#: ../gramps/gui/configure.py:588
+#: ../gramps/gui/configure.py:590
 msgid "Border Unknown Alive"
 msgstr "Rand voor onbekend geslacht nog in leven"
 
-#: ../gramps/gui/configure.py:590
+#: ../gramps/gui/configure.py:592
 msgid "Gender Unknown Death"
 msgstr "Achtergrond onbekend geslacht"
 
-#: ../gramps/gui/configure.py:592
+#: ../gramps/gui/configure.py:594
 msgid "Border Unknown Death"
 msgstr "Rand onbekend geslacht overleden"
 
-#: ../gramps/gui/configure.py:594
+#: ../gramps/gui/configure.py:596
 msgid "Colors"
 msgstr "Kleuren"
 
-#: ../gramps/gui/configure.py:602
+#: ../gramps/gui/configure.py:604
 msgid "Suppress warning when adding parents to a child."
 msgstr "Onderdruk waarschuwing als ouders aan een kind worden toegevoegd."
 
-#: ../gramps/gui/configure.py:606
+#: ../gramps/gui/configure.py:608
 msgid "Suppress warning when canceling with changed data."
 msgstr ""
 "Onderdruk waarschuwing wanneer verwijderopdracht wordt gegeven met veranderde "
 "gegevens."
 
-#: ../gramps/gui/configure.py:610
+#: ../gramps/gui/configure.py:612
 msgid "Suppress warning about missing researcher when exporting to GEDCOM."
 msgstr ""
 "Onderdruk waarschuwing over een ontbrekende onderzoeker wanneer naar GEDCOM "
 "wordt geëxporteerd."
 
-#: ../gramps/gui/configure.py:615
+#: ../gramps/gui/configure.py:617
 msgid "Show plugin status dialog on plugin load error."
 msgstr ""
 "Wanneer er zich een fout tijdens het laden van de uitbreiding voordoet, de "
 "status van de uitbreidingen tonen."
 
-#: ../gramps/gui/configure.py:618
+#: ../gramps/gui/configure.py:620
 msgid "Warnings"
 msgstr "Waarschuwingen"
 
-#: ../gramps/gui/configure.py:644 ../gramps/gui/configure.py:658
+#: ../gramps/gui/configure.py:646 ../gramps/gui/configure.py:660
 msgid "Common"
 msgstr "Algemeen"
 
-#: ../gramps/gui/configure.py:651 ../gramps/plugins/export/exportcsv.py:354
+#: ../gramps/gui/configure.py:653 ../gramps/plugins/export/exportcsv.py:354
 #: ../gramps/plugins/importer/importcsv.py:163
 msgid "Call"
 msgstr "Roep"
 
 # patronymisch/patroniemen
-#: ../gramps/gui/configure.py:656
+#: ../gramps/gui/configure.py:658
 msgid "NotPatronymic"
 msgstr "NietPatroniem"
 
-#: ../gramps/gui/configure.py:733
+#: ../gramps/gui/configure.py:735
 msgid "Enter to save, Esc to cancel editing"
 msgstr "Enter om op te slaan, Esc om te annuleren"
 
-#: ../gramps/gui/configure.py:780
+#: ../gramps/gui/configure.py:782
 msgid "This format exists already."
 msgstr "Dit formaat bestaat al."
 
-#: ../gramps/gui/configure.py:819
+#: ../gramps/gui/configure.py:821
 msgid "Format"
 msgstr "Formaat"
 
-#: ../gramps/gui/configure.py:829
+#: ../gramps/gui/configure.py:831
 msgid "Example"
 msgstr "Voorbeeld"
 
 #. show an add button
 #. we now construct an add menu
-#: ../gramps/gui/configure.py:849
+#: ../gramps/gui/configure.py:851
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:146
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:153
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:314
@@ -10693,11 +10684,11 @@ msgstr "Voorbeeld"
 #: ../gramps/gui/editors/editfamily.py:148
 #: ../gramps/gui/plug/report/_bookdialog.py:652 ../gramps/gui/views/tags.py:416
 #: ../gramps/gui/widgets/fanchart.py:1712 ../gramps/gui/widgets/fanchart.py:1754
-#: ../gramps/plugins/view/pedigreeview.py:1613
+#: ../gramps/plugins/view/pedigreeview.py:1627
 msgid "_Add"
 msgstr "Toevoegen"
 
-#: ../gramps/gui/configure.py:852
+#: ../gramps/gui/configure.py:854
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:148
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:154
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:315
@@ -10706,14 +10697,14 @@ msgstr "Toevoegen"
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:130
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:116
 #: ../gramps/gui/glade/editlink.glade:223
-#: ../gramps/gui/plug/report/_bookdialog.py:626 ../gramps/gui/viewmanager.py:481
+#: ../gramps/gui/plug/report/_bookdialog.py:626 ../gramps/gui/viewmanager.py:485
 #: ../gramps/gui/views/tags.py:417 ../gramps/gui/widgets/fanchart.py:1511
-#: ../gramps/plugins/view/pedigreeview.py:1648
-#: ../gramps/plugins/view/pedigreeview.py:1876
+#: ../gramps/plugins/view/pedigreeview.py:1662
+#: ../gramps/plugins/view/pedigreeview.py:1890
 msgid "_Edit"
 msgstr "Be_werken"
 
-#: ../gramps/gui/configure.py:856
+#: ../gramps/gui/configure.py:858
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:149
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:155
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:130
@@ -10726,12 +10717,12 @@ msgstr "Be_werken"
 msgid "_Remove"
 msgstr "_Verwijderen"
 
-#: ../gramps/gui/configure.py:981
+#: ../gramps/gui/configure.py:984
 #: ../gramps/gui/editors/displaytabs/buttontab.py:70
 #: ../gramps/gui/glade/editfamily.glade:286
 #: ../gramps/gui/glade/editfamily.glade:594
 #: ../gramps/gui/glade/editperson.glade:12
-#: ../gramps/gui/glade/editperson.glade:517 ../gramps/gui/glade/rule.glade:466
+#: ../gramps/gui/glade/editperson.glade:516 ../gramps/gui/glade/rule.glade:463
 #: ../gramps/gui/glade/styleeditor.glade:1872 ../gramps/gui/plug/_windows.py:148
 #: ../gramps/gui/plug/_windows.py:203
 #: ../gramps/plugins/gramplet/coordinates.py:142
@@ -10739,102 +10730,102 @@ msgstr "_Verwijderen"
 msgid "Edit"
 msgstr "Bewerken"
 
-#: ../gramps/gui/configure.py:991
+#: ../gramps/gui/configure.py:994
 msgid "Consider single pa/matronymic as surname"
 msgstr "Overweeg een enkel pa/matroniem als achternaam"
 
-#: ../gramps/gui/configure.py:1005
+#: ../gramps/gui/configure.py:1008
 msgid "Date format"
 msgstr "Datumnotatie"
 
-#: ../gramps/gui/configure.py:1013
+#: ../gramps/gui/configure.py:1016
 msgid "Years"
 msgstr "Jaren"
 
-#: ../gramps/gui/configure.py:1014
+#: ../gramps/gui/configure.py:1017
 msgid "Years, Months"
 msgstr "Jaren, maanden"
 
-#: ../gramps/gui/configure.py:1015
+#: ../gramps/gui/configure.py:1018
 msgid "Years, Months, Days"
 msgstr "Jaren, maanden en dagen"
 
-#: ../gramps/gui/configure.py:1027
+#: ../gramps/gui/configure.py:1030
 msgid "Age display precision (requires restart)"
 msgstr "Nauwkeurigheid van de leeftijd (vereist herstart)"
 
-#: ../gramps/gui/configure.py:1040
+#: ../gramps/gui/configure.py:1043
 msgid "Calendar on reports"
 msgstr "Kalender in verslagen"
 
-#: ../gramps/gui/configure.py:1053
+#: ../gramps/gui/configure.py:1056
 msgid "Surname guessing"
 msgstr "Achternaam raden"
 
-#: ../gramps/gui/configure.py:1066
+#: ../gramps/gui/configure.py:1069
 msgid "Default family relationship"
 msgstr "Standaard gezinsverwantschap"
 
-#: ../gramps/gui/configure.py:1073
+#: ../gramps/gui/configure.py:1076
 msgid "Height multiple surname box (pixels)"
 msgstr "Hoogte rechthoek voor meerdere achternamen (pixels)"
 
-#: ../gramps/gui/configure.py:1080
+#: ../gramps/gui/configure.py:1083
 msgid "Active person's name and ID"
 msgstr "Naam en Gramps-ID van actieve persoon"
 
-#: ../gramps/gui/configure.py:1081
+#: ../gramps/gui/configure.py:1084
 #: ../gramps/plugins/textreport/indivcomplete.py:358
 msgid "Relationship to home person"
 msgstr "Verwantschap met de beginpersoon"
 
-#: ../gramps/gui/configure.py:1090
+#: ../gramps/gui/configure.py:1093
 msgid "Status bar"
 msgstr "Statusbalk"
 
-#: ../gramps/gui/configure.py:1097
+#: ../gramps/gui/configure.py:1100
 msgid "Show text label beside Navigator buttons (requires restart)"
 msgstr "Toon tekst in de knoppen van de zijbalk (vereist herstart)"
 
-#: ../gramps/gui/configure.py:1103
+#: ../gramps/gui/configure.py:1106
 msgid "Show close button in gramplet bar tabs"
 msgstr "Knop 'Sluiten' in de gramplet-balk tonen"
 
-#: ../gramps/gui/configure.py:1116
+#: ../gramps/gui/configure.py:1119
 msgid "Enable automatic place title generation"
 msgstr "Het automatisch aanmaken van plaatstitel toelaten"
 
-#: ../gramps/gui/configure.py:1128
+#: ../gramps/gui/configure.py:1131
 msgid "Suppress comma after house number"
 msgstr "De komma na het huisnummer weglaten"
 
-#: ../gramps/gui/configure.py:1133
+#: ../gramps/gui/configure.py:1136
 msgid "Reverse display order"
 msgstr "Weergavevolgorde omkeren"
 
-#: ../gramps/gui/configure.py:1140
+#: ../gramps/gui/configure.py:1143
 msgid "Full place name"
 msgstr "Volledige plaatsnaam"
 
-#: ../gramps/gui/configure.py:1141
+#: ../gramps/gui/configure.py:1144
 msgid "-> Hamlet/Village/Town/City"
 msgstr "-> Dorpje/Gemeente/Stad"
 
-#: ../gramps/gui/configure.py:1142
+#: ../gramps/gui/configure.py:1145
 msgid "Hamlet/Village/Town/City ->"
 msgstr "Dorp/Gemeente/Stad ->"
 
-#: ../gramps/gui/configure.py:1147
+#: ../gramps/gui/configure.py:1150
 msgid "Restrict"
 msgstr "Beperken"
 
-#: ../gramps/gui/configure.py:1153
+#: ../gramps/gui/configure.py:1156
 #: ../gramps/gui/editors/displaytabs/placenameembedlist.py:65
 msgid "Language"
 msgstr "Taal"
 
 # Plaatsen
-#: ../gramps/gui/configure.py:1160
+#: ../gramps/gui/configure.py:1163
 #: ../gramps/plugins/quickview/filterbyname.py:100
 #: ../gramps/plugins/quickview/filterbyname.py:125
 #: ../gramps/plugins/textreport/tagreport.py:403
@@ -10848,36 +10839,36 @@ msgstr "Taal"
 msgid "Places"
 msgstr "Locaties"
 
-#: ../gramps/gui/configure.py:1176
+#: ../gramps/gui/configure.py:1179
 msgid "Missing surname"
 msgstr "Ontbrekende achternaam"
 
-#: ../gramps/gui/configure.py:1179
+#: ../gramps/gui/configure.py:1182
 msgid "Missing given name"
 msgstr "Ontbrekende voornaam"
 
 # complete/volledige/volledig ingevulde  kaarten/archieven
-#: ../gramps/gui/configure.py:1182
+#: ../gramps/gui/configure.py:1185
 msgid "Missing record"
 msgstr "Ontbrekend gegeven"
 
-#: ../gramps/gui/configure.py:1185
+#: ../gramps/gui/configure.py:1188
 msgid "Private surname"
 msgstr "Achternaam privé"
 
-#: ../gramps/gui/configure.py:1189
+#: ../gramps/gui/configure.py:1192
 msgid "Private given name"
 msgstr "Voornaam privé"
 
-#: ../gramps/gui/configure.py:1193
+#: ../gramps/gui/configure.py:1196
 msgid "Private record"
 msgstr "Gegevens privé"
 
-#: ../gramps/gui/configure.py:1233
+#: ../gramps/gui/configure.py:1236
 msgid "Change is not immediate"
 msgstr "Verandering is niet onmiddellijk"
 
-#: ../gramps/gui/configure.py:1234
+#: ../gramps/gui/configure.py:1237
 msgid ""
 "Changing the date format will not take effect until the next time Gramps is "
 "started."
@@ -10885,39 +10876,39 @@ msgstr ""
 "Het veranderen van het datumformaat is enkel van toepassing bij de volgende "
 "start van Gramps."
 
-#: ../gramps/gui/configure.py:1248
+#: ../gramps/gui/configure.py:1256
 msgid "Date about range"
 msgstr "Datum ongeveer bereik"
 
-#: ../gramps/gui/configure.py:1251
+#: ../gramps/gui/configure.py:1259
 msgid "Date after range"
 msgstr "Datum na bereik"
 
-#: ../gramps/gui/configure.py:1254
+#: ../gramps/gui/configure.py:1262
 msgid "Date before range"
 msgstr "Datum voor bereik"
 
-#: ../gramps/gui/configure.py:1257
+#: ../gramps/gui/configure.py:1265
 msgid "Maximum age probably alive"
 msgstr "Maximum leeftijd van personen die waarschijnlijk in leven zijn"
 
-#: ../gramps/gui/configure.py:1260
+#: ../gramps/gui/configure.py:1268
 msgid "Maximum sibling age difference"
 msgstr "Maximum leeftijdsverschil tussen broers en zussen"
 
-#: ../gramps/gui/configure.py:1263
+#: ../gramps/gui/configure.py:1271
 msgid "Minimum years between generations"
 msgstr "Minimum leeftijdsverschil tussen generaties"
 
-#: ../gramps/gui/configure.py:1266
+#: ../gramps/gui/configure.py:1274
 msgid "Average years between generations"
 msgstr "Gemiddeld leeftijdsverschil tussen generaties"
 
-#: ../gramps/gui/configure.py:1269
+#: ../gramps/gui/configure.py:1277
 msgid "Markup for invalid date format"
 msgstr "Aanduiding voor ongeldig datumformaat"
 
-#: ../gramps/gui/configure.py:1272
+#: ../gramps/gui/configure.py:1280
 #, python-format
 msgid ""
 "Convenience markups are:\n"
@@ -10948,28 +10939,28 @@ msgstr ""
 "Bijvoorbeeld: &lt;u&gt;&lt;b&gt;%s&lt;/b&gt;&lt;/u&gt;\n"
 "toont <u><b>Onderstreepte vette datum</b></u>.\n"
 
-#: ../gramps/gui/configure.py:1286
+#: ../gramps/gui/configure.py:1294
 msgid "Dates"
 msgstr "Datums"
 
-#: ../gramps/gui/configure.py:1297
+#: ../gramps/gui/configure.py:1305
 msgid "Use alternate Font handler for GUI and Reports (requires restart)"
 msgstr ""
 "Andere lettertypesysteem voor 'GUI' en verslagen gebruiken (herstart is nodig)"
 
-#: ../gramps/gui/configure.py:1303
+#: ../gramps/gui/configure.py:1311
 msgid "Add default source on GEDCOM import"
 msgstr "Standaardbron bij het importeren van een GEDCOM-bestand toevoegen"
 
-#: ../gramps/gui/configure.py:1307
+#: ../gramps/gui/configure.py:1315
 msgid "Add tag on import"
 msgstr "Tag bij het importeren toevoegen"
 
-#: ../gramps/gui/configure.py:1318
+#: ../gramps/gui/configure.py:1326
 msgid "Enable spelling checker"
 msgstr "Spellingcontrole aanzetten"
 
-#: ../gramps/gui/configure.py:1327
+#: ../gramps/gui/configure.py:1335
 #, python-format
 msgid ""
 "GtkSpell not loaded. Spell checking will not be available.\n"
@@ -10978,122 +10969,147 @@ msgstr ""
 "GtkSpell niet geladen. Spellingcontrole zal niet beschikbaar zijn.\n"
 "Zie %(gramps_wiki_build_spell_url)s"
 
-#: ../gramps/gui/configure.py:1334
+#: ../gramps/gui/configure.py:1342
 msgid "Display Tip of the Day"
 msgstr "Tip van de dag weergeven"
 
-#: ../gramps/gui/configure.py:1339
+#: ../gramps/gui/configure.py:1347
 msgid "Remember last view displayed"
 msgstr "Laatst getoonde scherm onthouden"
 
-#: ../gramps/gui/configure.py:1344
+#: ../gramps/gui/configure.py:1352
 msgid "Max generations for relationships"
 msgstr "Maximum aantal generaties waarvoor de verwantschap wordt bepaald"
 
-#: ../gramps/gui/configure.py:1350
+#: ../gramps/gui/configure.py:1358
 msgid "Base path for relative media paths"
 msgstr "Standaardpad voor relatieve mediamappen"
 
-#: ../gramps/gui/configure.py:1358
+#: ../gramps/gui/configure.py:1366
 msgid "Once a month"
 msgstr "Eens per maand"
 
-#: ../gramps/gui/configure.py:1359
+#: ../gramps/gui/configure.py:1367
 msgid "Once a week"
 msgstr "Eens per week"
 
-#: ../gramps/gui/configure.py:1360
+#: ../gramps/gui/configure.py:1368
 msgid "Once a day"
 msgstr "Eens per dag"
 
-#: ../gramps/gui/configure.py:1361
+#: ../gramps/gui/configure.py:1369
 msgid "Always"
 msgstr "Altijd"
 
-#: ../gramps/gui/configure.py:1366
+#: ../gramps/gui/configure.py:1374
 msgid "Check for updates"
 msgstr "Naar actualisaties zoeken"
 
-#: ../gramps/gui/configure.py:1372
+#: ../gramps/gui/configure.py:1380
 msgid "Updated addons only"
 msgstr "Enkel geactualiseerde uitbreidingen"
 
-#: ../gramps/gui/configure.py:1373
+#: ../gramps/gui/configure.py:1381
 msgid "New addons only"
 msgstr "Alleen nieuwe uitbreidingen"
 
-#: ../gramps/gui/configure.py:1374
+#: ../gramps/gui/configure.py:1382
 msgid "New and updated addons"
 msgstr "Nieuwe en geactualiseerde uitbreidingen"
 
-#: ../gramps/gui/configure.py:1384
+#: ../gramps/gui/configure.py:1392
 msgid "What to check"
 msgstr "Wat controleren"
 
-#: ../gramps/gui/configure.py:1389
+#: ../gramps/gui/configure.py:1397
 msgid "Where to check"
 msgstr "Waar controleren"
 
-#: ../gramps/gui/configure.py:1393
+#: ../gramps/gui/configure.py:1401
 msgid "Do not ask about previously notified addons"
 msgstr "Niet naar eerder aangekondigde uitbreidingen vragen"
 
-#: ../gramps/gui/configure.py:1398
+#: ../gramps/gui/configure.py:1406
 msgid "Check now"
 msgstr "Nu controleren"
 
-#: ../gramps/gui/configure.py:1408
+#: ../gramps/gui/configure.py:1416
 msgid "Checking Addons Failed"
 msgstr "Controle op uitbreidingen mislukt"
 
-#: ../gramps/gui/configure.py:1409
+#: ../gramps/gui/configure.py:1417
 msgid "The addon repository appears to be unavailable. Please try again later."
 msgstr ""
 "De uitbreidingsbibliotheek lijkt niet bereikbaar te zijn. Gelieve het later "
 "nog eens te proberen."
 
-#: ../gramps/gui/configure.py:1419
+#: ../gramps/gui/configure.py:1427
 msgid "There are no available addons of this type"
 msgstr "Er zijn geen beschikbare uitbreidingen van dit type"
 
-#: ../gramps/gui/configure.py:1420
+#: ../gramps/gui/configure.py:1428
 #, python-format
 msgid "Checked for '%s'"
 msgstr "Op '%s' gecontroleerd"
 
-#: ../gramps/gui/configure.py:1421
+#: ../gramps/gui/configure.py:1429
 msgid "' and '"
 msgstr "' en '"
 
 #. List of translated strings used here
 #. Dead code for l10n
-#: ../gramps/gui/configure.py:1426
+#: ../gramps/gui/configure.py:1434
 msgid "new"
 msgstr "nieuw"
 
-#: ../gramps/gui/configure.py:1426
+#: ../gramps/gui/configure.py:1434
 msgid "update"
 msgstr "opwaarderen"
 
-#: ../gramps/gui/configure.py:1445
+#: ../gramps/gui/configure.py:1453
 msgid "Database backend"
 msgstr "Gegevensbestand 'backend'"
 
-#: ../gramps/gui/configure.py:1453
+#: ../gramps/gui/configure.py:1461
 msgid "Family Tree Database path"
 msgstr "Stamboomgegevensbestandspad"
 
-#: ../gramps/gui/configure.py:1462
+#: ../gramps/gui/configure.py:1470
 msgid "Automatically load last Family Tree"
 msgstr "Laatste stamboom automatisch laden"
 
+#: ../gramps/gui/configure.py:1476
+msgid "Backup path"
+msgstr "Pad reservekopie"
+
+#: ../gramps/gui/configure.py:1483
+msgid "Backup on exit"
+msgstr "Reservekopie bij afsluiten"
+
+#: ../gramps/gui/configure.py:1490
+msgid "Every 15 minutes"
+msgstr "Alle 15 minuten"
+
+#: ../gramps/gui/configure.py:1491
+msgid "Every 30 minutes"
+msgstr "Alle 30 minuten"
+
+#: ../gramps/gui/configure.py:1492
+msgid "Every hour"
+msgstr "Elk uur"
+
+#: ../gramps/gui/configure.py:1497
+msgid "Autobackup"
+msgstr "Automatisch reservekopie"
+
 # dit is een soort titel in een file-selector
-#: ../gramps/gui/configure.py:1502
+#: ../gramps/gui/configure.py:1537
 msgid "Select media directory"
 msgstr "Selecteer mediamap"
 
-#: ../gramps/gui/configure.py:1505 ../gramps/gui/configure.py:1528
-#: ../gramps/gui/dbloader.py:146 ../gramps/gui/editors/edittaglist.py:117
+#: ../gramps/gui/configure.py:1540 ../gramps/gui/configure.py:1563
+#: ../gramps/gui/configure.py:1588 ../gramps/gui/dbloader.py:146
+#: ../gramps/gui/editors/edittaglist.py:117
 #: ../gramps/gui/glade/addmedia.glade:22
 #: ../gramps/gui/glade/baseselector.glade:24
 #: ../gramps/gui/glade/configure.glade:23 ../gramps/gui/glade/dialog.glade:416
@@ -11101,7 +11117,7 @@ msgstr "Selecteer mediamap"
 #: ../gramps/gui/glade/editaddress.glade:21
 #: ../gramps/gui/glade/editattribute.glade:21
 #: ../gramps/gui/glade/editchildref.glade:22
-#: ../gramps/gui/glade/editcitation.glade:43
+#: ../gramps/gui/glade/editcitation.glade:42
 #: ../gramps/gui/glade/editdate.glade:69 ../gramps/gui/glade/editevent.glade:21
 #: ../gramps/gui/glade/editeventref.glade:38
 #: ../gramps/gui/glade/editfamily.glade:21
@@ -11109,8 +11125,8 @@ msgstr "Selecteer mediamap"
 #: ../gramps/gui/glade/editlocation.glade:22
 #: ../gramps/gui/glade/editmedia.glade:22
 #: ../gramps/gui/glade/editmediaref.glade:44
-#: ../gramps/gui/glade/editname.glade:22 ../gramps/gui/glade/editnote.glade:23
-#: ../gramps/gui/glade/editperson.glade:46
+#: ../gramps/gui/glade/editname.glade:22 ../gramps/gui/glade/editnote.glade:21
+#: ../gramps/gui/glade/editperson.glade:45
 #: ../gramps/gui/glade/editpersonref.glade:21
 #: ../gramps/gui/glade/editplace.glade:21
 #: ../gramps/gui/glade/editplacename.glade:21
@@ -11131,14 +11147,14 @@ msgstr "Selecteer mediamap"
 #: ../gramps/gui/glade/mergeplace.glade:21
 #: ../gramps/gui/glade/mergerepository.glade:21
 #: ../gramps/gui/glade/mergesource.glade:21 ../gramps/gui/glade/reorder.glade:24
-#: ../gramps/gui/glade/rule.glade:319 ../gramps/gui/glade/rule.glade:750
+#: ../gramps/gui/glade/rule.glade:316 ../gramps/gui/glade/rule.glade:747
 #: ../gramps/gui/glade/styleeditor.glade:86
 #: ../gramps/gui/glade/styleeditor.glade:1723
 #: ../gramps/gui/logger/_errorview.py:140 ../gramps/gui/plug/_guioptions.py:78
 #: ../gramps/gui/plug/_guioptions.py:1728 ../gramps/gui/plug/_windows.py:432
 #: ../gramps/gui/plug/report/_fileentry.py:64
 #: ../gramps/gui/plug/report/_reportdialog.py:161 ../gramps/gui/utils.py:172
-#: ../gramps/gui/viewmanager.py:1412 ../gramps/gui/views/listview.py:1010
+#: ../gramps/gui/viewmanager.py:1451 ../gramps/gui/views/listview.py:1010
 #: ../gramps/gui/views/navigationview.py:362 ../gramps/gui/views/tags.py:635
 #: ../gramps/gui/widgets/progressdialog.py:437
 #: ../gramps/plugins/lib/maps/geography.py:1006
@@ -11150,9 +11166,14 @@ msgid "_Cancel"
 msgstr "Annuleren"
 
 # dit is een soort titel in een file-selector
-#: ../gramps/gui/configure.py:1525
+#: ../gramps/gui/configure.py:1560
 msgid "Select database directory"
 msgstr "Gegevensbestandsmap selecteren"
+
+# dit is een soort titel in een file-selector
+#: ../gramps/gui/configure.py:1585 ../gramps/gui/viewmanager.py:1448
+msgid "Select backup directory"
+msgstr "Een map voor de reservekopie selecteren"
 
 #: ../gramps/gui/dbloader.py:130 ../gramps/gui/plug/tool.py:108
 msgid "Undo history warning"
@@ -11248,7 +11269,7 @@ msgstr "Ik heb een reservekopie gemaakt, werk de stamboom bij"
 #: ../gramps/gui/dbloader.py:353 ../gramps/gui/dbloader.py:368
 #: ../gramps/gui/dbloader.py:383 ../gramps/gui/dbloader.py:398
 #: ../gramps/gui/plug/report/_bookdialog.py:242
-#: ../gramps/gui/plug/report/_bookdialog.py:738 ../gramps/gui/viewmanager.py:782
+#: ../gramps/gui/plug/report/_bookdialog.py:738 ../gramps/gui/viewmanager.py:790
 msgid "Cancel"
 msgstr "Annuleren"
 
@@ -11291,18 +11312,18 @@ msgstr "_Archiveer"
 msgid "_Extract"
 msgstr "Ophalen"
 
-#: ../gramps/gui/dbman.py:118 ../gramps/gui/dbman.py:143
+#: ../gramps/gui/dbman.py:118 ../gramps/gui/dbman.py:142
 msgid "Database Information"
 msgstr "Gegevensbestandsinformatie"
 
-#: ../gramps/gui/dbman.py:120 ../gramps/gui/editors/edittaglist.py:118
+#: ../gramps/gui/dbman.py:121 ../gramps/gui/editors/edittaglist.py:118
 #: ../gramps/gui/glade/addmedia.glade:38
 #: ../gramps/gui/glade/baseselector.glade:40 ../gramps/gui/glade/book.glade:482
 #: ../gramps/gui/glade/book.glade:556 ../gramps/gui/glade/configure.glade:39
 #: ../gramps/gui/glade/dbman.glade:24 ../gramps/gui/glade/editaddress.glade:36
 #: ../gramps/gui/glade/editattribute.glade:37
 #: ../gramps/gui/glade/editchildref.glade:38
-#: ../gramps/gui/glade/editcitation.glade:58
+#: ../gramps/gui/glade/editcitation.glade:57
 #: ../gramps/gui/glade/editdate.glade:85 ../gramps/gui/glade/editevent.glade:40
 #: ../gramps/gui/glade/editeventref.glade:54
 #: ../gramps/gui/glade/editfamily.glade:40
@@ -11310,8 +11331,8 @@ msgstr "Gegevensbestandsinformatie"
 #: ../gramps/gui/glade/editlocation.glade:38
 #: ../gramps/gui/glade/editmedia.glade:38
 #: ../gramps/gui/glade/editmediaref.glade:59
-#: ../gramps/gui/glade/editname.glade:41 ../gramps/gui/glade/editnote.glade:39
-#: ../gramps/gui/glade/editperson.glade:65
+#: ../gramps/gui/glade/editname.glade:41 ../gramps/gui/glade/editnote.glade:37
+#: ../gramps/gui/glade/editperson.glade:64
 #: ../gramps/gui/glade/editpersonref.glade:37
 #: ../gramps/gui/glade/editplace.glade:36
 #: ../gramps/gui/glade/editplacename.glade:36
@@ -11331,12 +11352,12 @@ msgstr "Gegevensbestandsinformatie"
 #: ../gramps/gui/glade/mergeplace.glade:36
 #: ../gramps/gui/glade/mergerepository.glade:37
 #: ../gramps/gui/glade/mergesource.glade:37 ../gramps/gui/glade/reorder.glade:40
-#: ../gramps/gui/glade/rule.glade:336 ../gramps/gui/glade/rule.glade:767
+#: ../gramps/gui/glade/rule.glade:333 ../gramps/gui/glade/rule.glade:764
 #: ../gramps/gui/glade/styleeditor.glade:103
 #: ../gramps/gui/glade/styleeditor.glade:1739
 #: ../gramps/gui/plug/_guioptions.py:79
 #: ../gramps/gui/plug/report/_reportdialog.py:165 ../gramps/gui/utils.py:186
-#: ../gramps/gui/viewmanager.py:1284 ../gramps/gui/views/tags.py:634
+#: ../gramps/gui/viewmanager.py:1292 ../gramps/gui/views/tags.py:634
 #: ../gramps/plugins/tool/check.py:770 ../gramps/plugins/tool/patchnames.py:117
 #: ../gramps/plugins/tool/populatesources.py:91
 #: ../gramps/plugins/tool/testcasegenerator.py:328
@@ -11344,17 +11365,17 @@ msgid "_OK"
 msgstr "OK"
 
 # Classificatie, taxering
-#: ../gramps/gui/dbman.py:126
+#: ../gramps/gui/dbman.py:125
 msgid "Setting"
 msgstr "Instellingen"
 
-#: ../gramps/gui/dbman.py:367
+#: ../gramps/gui/dbman.py:366
 msgid "Family Tree name"
 msgstr "Stamboomnaam"
 
 #. icon_column = Gtk.TreeViewColumn(_('Status'), render,
 #. icon_name=ICON_COL)
-#: ../gramps/gui/dbman.py:380
+#: ../gramps/gui/dbman.py:379
 #: ../gramps/gui/editors/displaytabs/familyldsembedlist.py:53
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:63
 #: ../gramps/gui/plug/_windows.py:123 ../gramps/gui/plug/_windows.py:180
@@ -11367,16 +11388,16 @@ msgstr "Stamboomnaam"
 msgid "Status"
 msgstr "Status"
 
-#: ../gramps/gui/dbman.py:387
+#: ../gramps/gui/dbman.py:386
 msgid "Database Type"
 msgstr "Type gegevensbestand"
 
-#: ../gramps/gui/dbman.py:493
+#: ../gramps/gui/dbman.py:492
 #, python-format
 msgid "Break the lock on the '%s' database?"
 msgstr "Vergrendeling van het gegevensbestand %s opheffen?"
 
-#: ../gramps/gui/dbman.py:494
+#: ../gramps/gui/dbman.py:493
 msgid ""
 "Gramps believes that someone else is actively editing this database. You "
 "cannot edit this database while it is locked. If no one is editing the "
@@ -11390,15 +11411,15 @@ msgstr ""
 "vergrendeling opheft terwijl er wel iemand het bestand gebruikt, kan het "
 "bestand worden beschadigd."
 
-#: ../gramps/gui/dbman.py:500
+#: ../gramps/gui/dbman.py:499
 msgid "Break lock"
 msgstr "Vergrendeling opheffen"
 
-#: ../gramps/gui/dbman.py:590
+#: ../gramps/gui/dbman.py:589
 msgid "Rename failed"
 msgstr "Hernoemen is mislukt"
 
-#: ../gramps/gui/dbman.py:591
+#: ../gramps/gui/dbman.py:590
 #, python-format
 msgid ""
 "An attempt to rename a version failed with the following message:\n"
@@ -11409,55 +11430,55 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dbman.py:609
+#: ../gramps/gui/dbman.py:608
 msgid "Could not rename the Family Tree."
 msgstr "Kon de stamboom niet hernoemen."
 
-#: ../gramps/gui/dbman.py:610
+#: ../gramps/gui/dbman.py:609
 msgid "Family Tree already exists, choose a unique name."
 msgstr "Deze stamboom bestaat reeds, kies een unieke naam."
 
-#: ../gramps/gui/dbman.py:654
+#: ../gramps/gui/dbman.py:653
 msgid "Extracting archive..."
 msgstr "Archief ophalen..."
 
-#: ../gramps/gui/dbman.py:659
+#: ../gramps/gui/dbman.py:658
 msgid "Importing archive..."
 msgstr "Importeren van archief..."
 
-#: ../gramps/gui/dbman.py:675
+#: ../gramps/gui/dbman.py:674
 #, python-format
 msgid "Remove the '%s' Family Tree?"
 msgstr "Het gegevensbestand '%s' verwijderen?"
 
-#: ../gramps/gui/dbman.py:676
+#: ../gramps/gui/dbman.py:675
 msgid "Removing this Family Tree will permanently destroy the data."
 msgstr ""
 "Het verwijderen van deze stamboom zal de gegevens onherstelbaar verwijderen."
 
-#: ../gramps/gui/dbman.py:678
+#: ../gramps/gui/dbman.py:677
 msgid "Remove Family Tree"
 msgstr "Stamboom verwijderen"
 
-#: ../gramps/gui/dbman.py:683
+#: ../gramps/gui/dbman.py:682
 #, python-format
 msgid "Remove the '%(revision)s' version of '%(database)s'"
 msgstr "Verwijder de '%(revision)s' versie van '%(database)s'"
 
-#: ../gramps/gui/dbman.py:687
+#: ../gramps/gui/dbman.py:686
 msgid "Removing this version will prevent you from extracting it in the future."
 msgstr ""
 "Door deze versie te verwijderen, kunt u het in de toekomst niet meer ophalen."
 
-#: ../gramps/gui/dbman.py:689
+#: ../gramps/gui/dbman.py:688
 msgid "Remove version"
 msgstr "Versie verwijderen"
 
-#: ../gramps/gui/dbman.py:744
+#: ../gramps/gui/dbman.py:743
 msgid "Deletion failed"
 msgstr "Verwijderen mislukt"
 
-#: ../gramps/gui/dbman.py:745
+#: ../gramps/gui/dbman.py:744
 #, python-format
 msgid ""
 "An attempt to delete a version failed with the following message:\n"
@@ -11468,58 +11489,58 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dbman.py:762
+#: ../gramps/gui/dbman.py:761
 #, python-format
 msgid "Convert the '%s' database?"
 msgstr "Het gegevensbestand '%s' omzetten?"
 
-#: ../gramps/gui/dbman.py:763
+#: ../gramps/gui/dbman.py:762
 msgid "You wish to convert this database into the new DB-API format?"
 msgstr ""
 "U wenst het gegevensbestand naar het nieuwe 'DB-API'-formaat om te zetten?"
 
-#: ../gramps/gui/dbman.py:764
+#: ../gramps/gui/dbman.py:763
 msgid "Convert"
 msgstr "Omzetten"
 
-#: ../gramps/gui/dbman.py:774
+#: ../gramps/gui/dbman.py:773
 #, python-format
 msgid "Opening the '%s' database"
 msgstr "Gegevensbestand '%s' openen"
 
-#: ../gramps/gui/dbman.py:775
+#: ../gramps/gui/dbman.py:774
 msgid "An attempt to convert the database failed. Perhaps it needs updating."
 msgstr ""
 "Een poging om het gegevensbestand om te zetten mislukte. Mogelijk moet het "
 "bestand vernieuwd worden."
 
-#: ../gramps/gui/dbman.py:786 ../gramps/gui/dbman.py:811
+#: ../gramps/gui/dbman.py:785 ../gramps/gui/dbman.py:810
 #, python-format
 msgid "Converting the '%s' database"
 msgstr "Gegevensbestand '%s' wordt omgezet"
 
-#: ../gramps/gui/dbman.py:787
+#: ../gramps/gui/dbman.py:786
 msgid "An attempt to export the database failed."
 msgstr "Poging om het gegevensbestand te exporteren mislukte."
 
-#: ../gramps/gui/dbman.py:791
+#: ../gramps/gui/dbman.py:790
 msgid "Converting data..."
 msgstr "Gegevens omzetten..."
 
-#: ../gramps/gui/dbman.py:796 ../gramps/gui/dbman.py:799
+#: ../gramps/gui/dbman.py:795 ../gramps/gui/dbman.py:798
 #, python-format
 msgid "(Converted #%d)"
 msgstr "(Omgezet #%d)"
 
-#: ../gramps/gui/dbman.py:812
+#: ../gramps/gui/dbman.py:811
 msgid "An attempt to import into the database failed."
 msgstr "Poging om te importeren naar het gegevensbestand mislukte."
 
-#: ../gramps/gui/dbman.py:869
+#: ../gramps/gui/dbman.py:868
 msgid "Repair Family Tree?"
 msgstr "Stamboom herstellen?"
 
-#: ../gramps/gui/dbman.py:870
+#: ../gramps/gui/dbman.py:869
 #, python-format
 msgid ""
 "If you click %(bold_start)sProceed%(bold_end)s, Gramps will attempt to "
@@ -11569,31 +11590,31 @@ msgstr ""
 "hersteld worden. Wanneer dit het geval is, kunt u de herstelknop uitschakelen "
 "door het bestand %(recover_file)s  uit de stamboommap te verwijderen."
 
-#: ../gramps/gui/dbman.py:901
+#: ../gramps/gui/dbman.py:900
 msgid "Proceed, I have taken a backup"
 msgstr "U kunt verder gaan, er is een reservekopie genomen"
 
-#: ../gramps/gui/dbman.py:902
+#: ../gramps/gui/dbman.py:901
 msgid "Stop"
 msgstr "Stop"
 
-#: ../gramps/gui/dbman.py:925
+#: ../gramps/gui/dbman.py:924
 msgid "Rebuilding database from backup files"
 msgstr "Het gegevensbestand wordt vanuit de reservekopie opnieuw opgebouwd"
 
-#: ../gramps/gui/dbman.py:930
+#: ../gramps/gui/dbman.py:929
 msgid "Error restoring backup data"
 msgstr "Fout bij het terugzetten van de reservekopie"
 
-#: ../gramps/gui/dbman.py:969
+#: ../gramps/gui/dbman.py:968
 msgid "Could not create Family Tree"
 msgstr "Kon geen stamboom aanmaken"
 
-#: ../gramps/gui/dbman.py:1097
+#: ../gramps/gui/dbman.py:1096
 msgid "Retrieve failed"
 msgstr "Ophalen mislukte"
 
-#: ../gramps/gui/dbman.py:1098
+#: ../gramps/gui/dbman.py:1097
 #, python-format
 msgid ""
 "An attempt to retrieve the data failed with the following message:\n"
@@ -11604,11 +11625,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dbman.py:1136 ../gramps/gui/dbman.py:1162
+#: ../gramps/gui/dbman.py:1135 ../gramps/gui/dbman.py:1161
 msgid "Archiving failed"
 msgstr "Archieveren is mislukt"
 
-#: ../gramps/gui/dbman.py:1137
+#: ../gramps/gui/dbman.py:1136
 #, python-format
 msgid ""
 "An attempt to create the archive failed with the following message:\n"
@@ -11619,15 +11640,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dbman.py:1142
+#: ../gramps/gui/dbman.py:1141
 msgid "Creating data to be archived..."
 msgstr "Gegevens worden aangemaakt om te archiveren..."
 
-#: ../gramps/gui/dbman.py:1151
+#: ../gramps/gui/dbman.py:1150
 msgid "Saving archive..."
 msgstr "Archief wordt opgeslagen..."
 
-#: ../gramps/gui/dbman.py:1163
+#: ../gramps/gui/dbman.py:1162
 #, python-format
 msgid ""
 "An attempt to archive the data failed with the following message:\n"
@@ -11651,44 +11672,44 @@ msgstr ""
 "Sluit deze belangrijke dialoog niet geforceerd af.\n"
 "Gebruik één van de aanwezige keuzes"
 
-#: ../gramps/gui/displaystate.py:378
+#: ../gramps/gui/displaystate.py:379
 #: ../gramps/plugins/gramplet/persondetails.py:169
 msgid "No active person"
 msgstr "Geen actieve persoon"
 
-#: ../gramps/gui/displaystate.py:379
+#: ../gramps/gui/displaystate.py:380
 msgid "No active family"
 msgstr "Geen actief gezin"
 
-#: ../gramps/gui/displaystate.py:380
+#: ../gramps/gui/displaystate.py:381
 msgid "No active event"
 msgstr "Geen actieve gebeurtenis"
 
-#: ../gramps/gui/displaystate.py:381
+#: ../gramps/gui/displaystate.py:382
 msgid "No active place"
 msgstr "Geen actieve locatie"
 
-#: ../gramps/gui/displaystate.py:382
+#: ../gramps/gui/displaystate.py:383
 msgid "No active source"
 msgstr "Geen actieve bron"
 
-#: ../gramps/gui/displaystate.py:383
+#: ../gramps/gui/displaystate.py:384
 msgid "No active citation"
 msgstr "Geen actief citaat"
 
-#: ../gramps/gui/displaystate.py:384
+#: ../gramps/gui/displaystate.py:385
 msgid "No active repository"
 msgstr "Geen actieve bibliotheek"
 
-#: ../gramps/gui/displaystate.py:385
+#: ../gramps/gui/displaystate.py:386
 msgid "No active media"
 msgstr "Geen actief media-object"
 
-#: ../gramps/gui/displaystate.py:386
+#: ../gramps/gui/displaystate.py:387
 msgid "No active note"
 msgstr "Geen actieve opmerking"
 
-#: ../gramps/gui/displaystate.py:591
+#: ../gramps/gui/displaystate.py:618
 msgid "No active object"
 msgstr "Geen actief voorwerp"
 
@@ -11807,7 +11828,7 @@ msgstr "_Kenmerken"
 #: ../gramps/gui/editors/displaytabs/placerefembedlist.py:58
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:66
 #: ../gramps/gui/editors/editfamily.py:122
-#: ../gramps/gui/editors/filtereditor.py:977
+#: ../gramps/gui/editors/filtereditor.py:976
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:104
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:111
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:103
@@ -11818,17 +11839,17 @@ msgstr "_Kenmerken"
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:104
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:103
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:86
-#: ../gramps/gui/merge/mergeperson.py:181 ../gramps/gui/plug/_guioptions.py:1166
+#: ../gramps/gui/merge/mergeperson.py:179 ../gramps/gui/plug/_guioptions.py:1166
 #: ../gramps/gui/plug/_guioptions.py:1344
-#: ../gramps/gui/selectors/selectcitation.py:76
-#: ../gramps/gui/selectors/selectevent.py:75
-#: ../gramps/gui/selectors/selectfamily.py:70
-#: ../gramps/gui/selectors/selectnote.py:76
+#: ../gramps/gui/selectors/selectcitation.py:75
+#: ../gramps/gui/selectors/selectevent.py:74
+#: ../gramps/gui/selectors/selectfamily.py:69
+#: ../gramps/gui/selectors/selectnote.py:75
 #: ../gramps/gui/selectors/selectobject.py:81
-#: ../gramps/gui/selectors/selectperson.py:95
-#: ../gramps/gui/selectors/selectplace.py:72
-#: ../gramps/gui/selectors/selectrepository.py:71
-#: ../gramps/gui/selectors/selectsource.py:72
+#: ../gramps/gui/selectors/selectperson.py:94
+#: ../gramps/gui/selectors/selectplace.py:71
+#: ../gramps/gui/selectors/selectrepository.py:70
+#: ../gramps/gui/selectors/selectsource.py:71
 #: ../gramps/gui/views/bookmarks.py:240
 #: ../gramps/gui/views/navigationview.py:357
 #: ../gramps/plugins/gramplet/locations.py:88
@@ -11844,7 +11865,7 @@ msgstr "_Kenmerken"
 #: ../gramps/plugins/view/eventview.py:83
 #: ../gramps/plugins/view/familyview.py:79
 #: ../gramps/plugins/view/mediaview.py:95 ../gramps/plugins/view/noteview.py:80
-#: ../gramps/plugins/view/relview.py:592 ../gramps/plugins/view/repoview.py:86
+#: ../gramps/plugins/view/relview.py:602 ../gramps/plugins/view/repoview.py:86
 #: ../gramps/plugins/view/sourceview.py:83
 msgid "ID"
 msgstr "ID"
@@ -11869,10 +11890,10 @@ msgstr "%(part1)s - %(part2)s"
 #: ../gramps/gui/glade/editfamily.glade:494
 #: ../gramps/gui/glade/editfamily.glade:501
 #: ../gramps/gui/glade/editperson.glade:22
-#: ../gramps/gui/glade/editperson.glade:362 ../gramps/gui/glade/rule.glade:425
-#: ../gramps/gui/glade/rule.glade:432 ../gramps/gui/glade/styleeditor.glade:1833
+#: ../gramps/gui/glade/editperson.glade:361 ../gramps/gui/glade/rule.glade:422
+#: ../gramps/gui/glade/rule.glade:429 ../gramps/gui/glade/styleeditor.glade:1833
 #: ../gramps/gui/glade/styleeditor.glade:1840
-#: ../gramps/plugins/view/relview.py:408
+#: ../gramps/plugins/view/relview.py:418
 msgid "Add"
 msgstr "Toevoegen"
 
@@ -11882,8 +11903,8 @@ msgstr "Toevoegen"
 #: ../gramps/gui/glade/editfamily.glade:556
 #: ../gramps/gui/glade/editfamily.glade:563
 #: ../gramps/gui/glade/grampletpane.glade:104
-#: ../gramps/gui/glade/grampletpane.glade:111 ../gramps/gui/glade/rule.glade:493
-#: ../gramps/gui/glade/rule.glade:500 ../gramps/gui/glade/styleeditor.glade:1897
+#: ../gramps/gui/glade/grampletpane.glade:111 ../gramps/gui/glade/rule.glade:490
+#: ../gramps/gui/glade/rule.glade:497 ../gramps/gui/glade/styleeditor.glade:1897
 #: ../gramps/gui/glade/styleeditor.glade:1904
 msgid "Remove"
 msgstr "Verwijderen"
@@ -11891,7 +11912,7 @@ msgstr "Verwijderen"
 #: ../gramps/gui/editors/displaytabs/buttontab.py:71
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:147
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:128
-#: ../gramps/plugins/view/relview.py:412
+#: ../gramps/plugins/view/relview.py:422
 msgid "Share"
 msgstr "Delen"
 
@@ -11935,7 +11956,7 @@ msgstr "Het geselecteerde citaat naar beneden verschuiven"
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:81
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:106
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:88
-#: ../gramps/gui/selectors/selectsource.py:71
+#: ../gramps/gui/selectors/selectsource.py:70
 #: ../gramps/plugins/gramplet/citations.py:78
 #: ../gramps/plugins/textreport/tagreport.py:745
 #: ../gramps/plugins/view/sourceview.py:84
@@ -11985,8 +12006,8 @@ msgstr ""
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:60
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:112
 #: ../gramps/gui/glade/editfamily.glade:192
-#: ../gramps/gui/merge/mergeperson.py:223
-#: ../gramps/gui/selectors/selectfamily.py:71
+#: ../gramps/gui/merge/mergeperson.py:221
+#: ../gramps/gui/selectors/selectfamily.py:70
 #: ../gramps/gui/widgets/reorderfam.py:83
 #: ../gramps/plugins/gramplet/persondetails.py:219
 #: ../gramps/plugins/importer/importcsv.py:215
@@ -11997,7 +12018,7 @@ msgstr ""
 #: ../gramps/plugins/textreport/indivcomplete.py:319
 #: ../gramps/plugins/textreport/indivcomplete.py:902
 #: ../gramps/plugins/textreport/tagreport.py:248
-#: ../gramps/plugins/view/familyview.py:80 ../gramps/plugins/view/relview.py:889
+#: ../gramps/plugins/view/familyview.py:80 ../gramps/plugins/view/relview.py:899
 #: ../gramps/plugins/webreport/narrativeweb.py:7439
 msgid "Father"
 msgstr "Vader"
@@ -12005,8 +12026,8 @@ msgstr "Vader"
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:61
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:113
 #: ../gramps/gui/glade/editfamily.glade:470
-#: ../gramps/gui/merge/mergeperson.py:225
-#: ../gramps/gui/selectors/selectfamily.py:72
+#: ../gramps/gui/merge/mergeperson.py:223
+#: ../gramps/gui/selectors/selectfamily.py:71
 #: ../gramps/gui/widgets/reorderfam.py:84
 #: ../gramps/plugins/gramplet/persondetails.py:220
 #: ../gramps/plugins/importer/importcsv.py:212
@@ -12017,7 +12038,7 @@ msgstr "Vader"
 #: ../gramps/plugins/textreport/indivcomplete.py:328
 #: ../gramps/plugins/textreport/indivcomplete.py:903
 #: ../gramps/plugins/textreport/tagreport.py:254
-#: ../gramps/plugins/view/familyview.py:81 ../gramps/plugins/view/relview.py:890
+#: ../gramps/plugins/view/familyview.py:81 ../gramps/plugins/view/relview.py:900
 #: ../gramps/plugins/webreport/narrativeweb.py:7453
 msgid "Mother"
 msgstr "Moeder"
@@ -12122,7 +12143,7 @@ msgid "_Make Active Media"
 msgstr "Maak actieve media"
 
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:257
-#: ../gramps/gui/editors/editperson.py:961
+#: ../gramps/gui/editors/editperson.py:960
 #: ../gramps/plugins/textreport/indivcomplete.py:587
 msgid "Non existing media found in the Gallery"
 msgstr "Onbestaande media gevonden in de galerij"
@@ -12267,7 +12288,7 @@ msgstr "De geselecteerde opmerkingen naar beneden verschuiven"
 #: ../gramps/gui/glade/editmedia.glade:188
 #: ../gramps/gui/glade/editmediaref.glade:190
 #: ../gramps/gui/glade/editmediaref.glade:503
-#: ../gramps/gui/selectors/selectnote.py:75
+#: ../gramps/gui/selectors/selectnote.py:74
 #: ../gramps/plugins/view/noteview.py:79
 msgid "Preview"
 msgstr "Voorbeeld"
@@ -12533,16 +12554,16 @@ msgstr "Kan kenmerk niet opslaan"
 msgid "The attribute type cannot be empty"
 msgstr "Het kenmerktype kan niet leeg zijn"
 
-#: ../gramps/gui/editors/editchildref.py:67
+#: ../gramps/gui/editors/editchildref.py:66
 msgid "manual|Child_Reference_Editor"
 msgstr "Verwijzing naar kind bewerken"
 
-#: ../gramps/gui/editors/editchildref.py:102
-#: ../gramps/gui/editors/editchildref.py:197
+#: ../gramps/gui/editors/editchildref.py:99
+#: ../gramps/gui/editors/editchildref.py:195
 msgid "Child Reference Editor"
 msgstr "Verwijzing naar kind bewerken"
 
-#: ../gramps/gui/editors/editchildref.py:197
+#: ../gramps/gui/editors/editchildref.py:195
 msgid "Child Reference"
 msgstr "Verwijzing naar kind"
 
@@ -12555,15 +12576,15 @@ msgstr "Nieuw citaat"
 msgid "New Citation"
 msgstr "Nieuw citaat"
 
-#: ../gramps/gui/editors/editcitation.py:279
+#: ../gramps/gui/editors/editcitation.py:277
 msgid "Edit Citation"
 msgstr "Citaat bewerken"
 
-#: ../gramps/gui/editors/editcitation.py:287
+#: ../gramps/gui/editors/editcitation.py:285
 msgid "No source selected"
 msgstr "Geen bron geselecteerd"
 
-#: ../gramps/gui/editors/editcitation.py:288
+#: ../gramps/gui/editors/editcitation.py:286
 msgid ""
 "A source is anything (personal testimony, video recording, photograph, "
 "newspaper column, gravestone...) from which information can be derived. To "
@@ -12577,17 +12598,17 @@ msgstr ""
 "selecteren. Dan kunt u de gegevens invullen over de plaats van de informatie "
 "waarnaar de bron verwijst in het veld \"Volume/pagina\"."
 
-#: ../gramps/gui/editors/editcitation.py:302
+#: ../gramps/gui/editors/editcitation.py:300
 msgid "Cannot save citation. ID already exists."
 msgstr "Kan citaat niet opslaan. ID bestaat reeds."
 
-#: ../gramps/gui/editors/editcitation.py:303
-#: ../gramps/gui/editors/editevent.py:251 ../gramps/gui/editors/editmedia.py:300
-#: ../gramps/gui/editors/editperson.py:847
-#: ../gramps/gui/editors/editplace.py:297
+#: ../gramps/gui/editors/editcitation.py:301
+#: ../gramps/gui/editors/editevent.py:249 ../gramps/gui/editors/editmedia.py:298
+#: ../gramps/gui/editors/editperson.py:846
+#: ../gramps/gui/editors/editplace.py:295
 #: ../gramps/gui/editors/editreference.py:287
-#: ../gramps/gui/editors/editrepository.py:191
-#: ../gramps/gui/editors/editsource.py:211
+#: ../gramps/gui/editors/editrepository.py:189
+#: ../gramps/gui/editors/editsource.py:210
 #, python-format
 msgid ""
 "You have attempted to use the existing Gramps ID with value %(id)s. This "
@@ -12598,17 +12619,17 @@ msgstr ""
 "waarde wordt reeds gebruikt door '%(prim_object)s'. Voer een andere ID in of "
 "laat het invoerveld leeg zodat de volgende beschikbare ID kan gebruikt worden."
 
-#: ../gramps/gui/editors/editcitation.py:315
+#: ../gramps/gui/editors/editcitation.py:313
 #, python-format
 msgid "Add Citation (%s)"
 msgstr "Citaat toevoegen (%s)"
 
-#: ../gramps/gui/editors/editcitation.py:321
+#: ../gramps/gui/editors/editcitation.py:319
 #, python-format
 msgid "Edit Citation (%s)"
 msgstr "Citaat bewerken (%s)"
 
-#: ../gramps/gui/editors/editcitation.py:356
+#: ../gramps/gui/editors/editcitation.py:354
 #, python-format
 msgid "Delete Citation (%s)"
 msgstr "Citaat verwijderen (%s)"
@@ -12686,7 +12707,7 @@ msgid "New Event"
 msgstr "Nieuwe gebeurtenis"
 
 # Gebeuren (korter)
-#: ../gramps/gui/editors/editevent.py:230 ../gramps/plugins/view/geoclose.py:545
+#: ../gramps/gui/editors/editevent.py:228 ../gramps/plugins/view/geoclose.py:545
 #: ../gramps/plugins/view/geoevents.py:340
 #: ../gramps/plugins/view/geoevents.py:374
 #: ../gramps/plugins/view/geofamclose.py:735
@@ -12698,37 +12719,37 @@ msgstr "Nieuwe gebeurtenis"
 msgid "Edit Event"
 msgstr "Gebeurtenis bewerken"
 
-#: ../gramps/gui/editors/editevent.py:239 ../gramps/gui/editors/editevent.py:263
+#: ../gramps/gui/editors/editevent.py:237 ../gramps/gui/editors/editevent.py:261
 msgid "Cannot save event"
 msgstr "Kan gebeurtenis niet opslaan"
 
-#: ../gramps/gui/editors/editevent.py:240
+#: ../gramps/gui/editors/editevent.py:238
 msgid "No data exists for this event. Please enter data or cancel the edit."
 msgstr ""
 "Er bestaan geen gegevens voor deze gebeurtenis. Gelieve gegevens in te voeren "
 "of de gebeurtenis te verwijderen."
 
-#: ../gramps/gui/editors/editevent.py:250
+#: ../gramps/gui/editors/editevent.py:248
 #: ../gramps/gui/editors/editreference.py:276
 msgid "Cannot save event. ID already exists."
 msgstr "Kan gebeurtenis niet opslaan. ID bestaat reeds."
 
-#: ../gramps/gui/editors/editevent.py:264
+#: ../gramps/gui/editors/editevent.py:262
 msgid "The event type cannot be empty"
 msgstr "Een gebeurtenis type kan niet leeg zijn"
 
-#: ../gramps/gui/editors/editevent.py:270
+#: ../gramps/gui/editors/editevent.py:268
 #, python-format
 msgid "Add Event (%s)"
 msgstr "Gebeurtenis toevoegen (%s)"
 
 # Gebeuren (korter)
-#: ../gramps/gui/editors/editevent.py:276
+#: ../gramps/gui/editors/editevent.py:274
 #, python-format
 msgid "Edit Event (%s)"
 msgstr "Gebeurtenis bewerken (%s)"
 
-#: ../gramps/gui/editors/editevent.py:321
+#: ../gramps/gui/editors/editevent.py:319
 #, python-format
 msgid "Delete Event (%s)"
 msgstr "Gebeurtenis verwijderen (%s)"
@@ -12740,7 +12761,7 @@ msgid "manual|Event_Reference_Editor_dialog"
 msgstr "Gebeurtenissenverwijzingen bewerken"
 
 # Bronnen, verwijzingen, literatuurverwijzingen
-#: ../gramps/gui/editors/editeventref.py:78
+#: ../gramps/gui/editors/editeventref.py:76
 #: ../gramps/gui/editors/editeventref.py:255
 msgid "Event Reference Editor"
 msgstr "Gebeurtenissenverwijzingen bewerken"
@@ -12748,8 +12769,8 @@ msgstr "Gebeurtenissenverwijzingen bewerken"
 #: ../gramps/gui/editors/editeventref.py:95
 #: ../gramps/gui/editors/editmediaref.py:114
 #: ../gramps/gui/editors/editname.py:135
-#: ../gramps/gui/editors/editplaceref.py:76
-#: ../gramps/gui/editors/editreporef.py:78
+#: ../gramps/gui/editors/editplaceref.py:77
+#: ../gramps/gui/editors/editreporef.py:77
 msgid "_General"
 msgstr "Alge_meen"
 
@@ -12803,7 +12824,7 @@ msgid "Maternal"
 msgstr "Maternaal"
 
 #: ../gramps/gui/editors/editfamily.py:127
-#: ../gramps/gui/selectors/selectperson.py:97
+#: ../gramps/gui/selectors/selectperson.py:96
 #: ../gramps/plugins/gramplet/children.py:94
 #: ../gramps/plugins/gramplet/children.py:193
 #: ../gramps/plugins/lib/libpersonview.py:101
@@ -12823,7 +12844,7 @@ msgid "Birth Date"
 msgstr "Geboortedatum"
 
 #: ../gramps/gui/editors/editfamily.py:128
-#: ../gramps/gui/selectors/selectperson.py:99
+#: ../gramps/gui/selectors/selectperson.py:98
 #: ../gramps/plugins/gramplet/children.py:96
 #: ../gramps/plugins/gramplet/children.py:195
 #: ../gramps/plugins/lib/libpersonview.py:103
@@ -12833,13 +12854,13 @@ msgid "Death Date"
 msgstr "Sterfdatum"
 
 #: ../gramps/gui/editors/editfamily.py:129
-#: ../gramps/gui/selectors/selectperson.py:98
+#: ../gramps/gui/selectors/selectperson.py:97
 #: ../gramps/plugins/lib/libpersonview.py:102
 msgid "Birth Place"
 msgstr "Geboorteplaats"
 
 #: ../gramps/gui/editors/editfamily.py:130
-#: ../gramps/gui/selectors/selectperson.py:100
+#: ../gramps/gui/selectors/selectperson.py:99
 #: ../gramps/plugins/lib/libpersonview.py:104
 msgid "Death Place"
 msgstr "Sterfplaats"
@@ -12863,7 +12884,7 @@ msgstr "Verwantschap bewerken"
 
 #: ../gramps/gui/editors/editfamily.py:217
 #: ../gramps/gui/editors/editfamily.py:232
-#: ../gramps/plugins/view/relview.py:1569
+#: ../gramps/plugins/view/relview.py:1579
 msgid "Select Child"
 msgstr "Kind selecteren"
 
@@ -12916,48 +12937,48 @@ msgid "New Family"
 msgstr "Nieuw gezin"
 
 #: ../gramps/gui/editors/editfamily.py:505
-#: ../gramps/gui/editors/editfamily.py:1134
+#: ../gramps/gui/editors/editfamily.py:1132
 #: ../gramps/plugins/view/geofamily.py:422
 msgid "Edit Family"
 msgstr "Gezin bewerken"
 
-#: ../gramps/gui/editors/editfamily.py:538
+#: ../gramps/gui/editors/editfamily.py:536
 msgid "Select a person as the mother"
 msgstr "Een persoon als moeder selecteren"
 
-#: ../gramps/gui/editors/editfamily.py:539
+#: ../gramps/gui/editors/editfamily.py:537
 msgid "Add a new person as the mother"
 msgstr "Een nieuwe persoon als moeder toevoegen"
 
-#: ../gramps/gui/editors/editfamily.py:540
+#: ../gramps/gui/editors/editfamily.py:538
 msgid "Remove the person as the mother"
 msgstr "De persoon als moeder verwijderen"
 
-#: ../gramps/gui/editors/editfamily.py:553
+#: ../gramps/gui/editors/editfamily.py:551
 msgid "Select a person as the father"
 msgstr "Een persoon als vader selecteren"
 
-#: ../gramps/gui/editors/editfamily.py:554
+#: ../gramps/gui/editors/editfamily.py:552
 msgid "Add a new person as the father"
 msgstr "Een nieuwe persoon als vader toevoegen"
 
-#: ../gramps/gui/editors/editfamily.py:555
+#: ../gramps/gui/editors/editfamily.py:553
 msgid "Remove the person as the father"
 msgstr "Persoon als vader verwijderen"
 
-#: ../gramps/gui/editors/editfamily.py:836
+#: ../gramps/gui/editors/editfamily.py:834
 msgid "Select Mother"
 msgstr "Moeder selecteren"
 
-#: ../gramps/gui/editors/editfamily.py:881
+#: ../gramps/gui/editors/editfamily.py:879
 msgid "Select Father"
 msgstr "Vader selecteren"
 
-#: ../gramps/gui/editors/editfamily.py:905
+#: ../gramps/gui/editors/editfamily.py:903
 msgid "Duplicate Family"
 msgstr "Dubbel gezin"
 
-#: ../gramps/gui/editors/editfamily.py:906
+#: ../gramps/gui/editors/editfamily.py:904
 msgid ""
 "A family with these parents already exists in the database. If you save, you "
 "will create a duplicate family. It is recommended that you cancel the editing "
@@ -12967,45 +12988,45 @@ msgstr ""
 "gegevens opslaat zal een duplicaatgezin worden aangemaakt. Het is aangeraden "
 "dat u deze aanpassing stopt in dit venster en een bestaand gezin kiest"
 
-#: ../gramps/gui/editors/editfamily.py:954
+#: ../gramps/gui/editors/editfamily.py:952
 #, python-format
 msgid "Edit %s"
 msgstr "Bewerken van %s"
 
-#: ../gramps/gui/editors/editfamily.py:1063
+#: ../gramps/gui/editors/editfamily.py:1061
 msgid "A father cannot be his own child"
 msgstr "Een vader kan niet zijn eigen kind zijn"
 
-#: ../gramps/gui/editors/editfamily.py:1064
+#: ../gramps/gui/editors/editfamily.py:1062
 #, python-format
 msgid "%s is listed as both the father and child of the family."
 msgstr "%s is zowel vader als kind van dit gezin."
 
-#: ../gramps/gui/editors/editfamily.py:1074
+#: ../gramps/gui/editors/editfamily.py:1072
 msgid "A mother cannot be her own child"
 msgstr "Een moeder kan niet haar eigen kind zijn"
 
-#: ../gramps/gui/editors/editfamily.py:1075
+#: ../gramps/gui/editors/editfamily.py:1073
 #, python-format
 msgid "%s is listed as both the mother and child of the family."
 msgstr "%s is zowel moeder als kind van dit gezin."
 
-#: ../gramps/gui/editors/editfamily.py:1083
+#: ../gramps/gui/editors/editfamily.py:1081
 msgid "Cannot save family"
 msgstr "Kan gezin niet opslaan"
 
-#: ../gramps/gui/editors/editfamily.py:1084
+#: ../gramps/gui/editors/editfamily.py:1082
 msgid "No data exists for this family. Please enter data or cancel the edit."
 msgstr ""
 "Er bestaan geen gegevens voor dit gezin. Voer gegevens in of verwerp de "
 "aanpassingen."
 
-#: ../gramps/gui/editors/editfamily.py:1092
+#: ../gramps/gui/editors/editfamily.py:1090
 msgid "Cannot save family. ID already exists."
 msgstr "Kan gezin niet opslaan. ID bestaat reeds."
 
-#: ../gramps/gui/editors/editfamily.py:1093
-#: ../gramps/gui/editors/editnote.py:323
+#: ../gramps/gui/editors/editfamily.py:1091
+#: ../gramps/gui/editors/editnote.py:321
 #: ../gramps/gui/editors/editreference.py:294
 #, python-format
 msgid ""
@@ -13017,7 +13038,7 @@ msgstr ""
 "gebruiken. Deze waarde is al in gebruik. Geef een andere ID op of laat het "
 "invoerveld leeg zodat de volgende bruikbare ID kan gebruikt worden."
 
-#: ../gramps/gui/editors/editfamily.py:1108
+#: ../gramps/gui/editors/editfamily.py:1106
 msgid "Add Family"
 msgstr "Gezin toevoegen"
 
@@ -13088,32 +13109,32 @@ msgstr "Media: %s"
 msgid "New Media"
 msgstr "Nieuwe media"
 
-#: ../gramps/gui/editors/editmedia.py:243
+#: ../gramps/gui/editors/editmedia.py:241
 msgid "Edit Media Object"
 msgstr "Media-object bewerken"
 
-#: ../gramps/gui/editors/editmedia.py:288
+#: ../gramps/gui/editors/editmedia.py:286
 msgid "Cannot save media object"
 msgstr "Kan media-object niet opslaan"
 
-#: ../gramps/gui/editors/editmedia.py:289
+#: ../gramps/gui/editors/editmedia.py:287
 msgid ""
 "No data exists for this media object. Please enter data or cancel the edit."
 msgstr ""
 "Er bestaan geen gegevens voor dit media-object. Gelieve gegevens in te voeren "
 "of de aanpassingen te verwijderen."
 
-#: ../gramps/gui/editors/editmedia.py:299
+#: ../gramps/gui/editors/editmedia.py:297
 #: ../gramps/gui/editors/editreference.py:279
 msgid "Cannot save media object. ID already exists."
 msgstr "Kan media-object niet opslaan. ID bestaat al."
 
-#: ../gramps/gui/editors/editmedia.py:314
+#: ../gramps/gui/editors/editmedia.py:312
 msgid "There is no media matching the current path value!"
 msgstr ""
 "Er werden geen media gevonden die overeen komen met de actuele padwaarde!"
 
-#: ../gramps/gui/editors/editmedia.py:315
+#: ../gramps/gui/editors/editmedia.py:313
 #, python-format
 msgid ""
 "You have attempted to use the path with value '%(path)s'. This path does not "
@@ -13122,19 +13143,19 @@ msgstr ""
 "U probeerde het pad met de waarde '%(path)s' te gebruiken. Dit pad bestaat "
 "niet! Geef een andere pad op"
 
-#: ../gramps/gui/editors/editmedia.py:328
+#: ../gramps/gui/editors/editmedia.py:326
 #: ../gramps/gui/editors/editmediaref.py:523
 #, python-format
 msgid "Add Media Object (%s)"
 msgstr "Media-object toevoegen (%s)"
 
-#: ../gramps/gui/editors/editmedia.py:333
+#: ../gramps/gui/editors/editmedia.py:331
 #: ../gramps/gui/editors/editmediaref.py:517
 #, python-format
 msgid "Edit Media Object (%s)"
 msgstr "Media-object bewerken (%s)"
 
-#: ../gramps/gui/editors/editmedia.py:370
+#: ../gramps/gui/editors/editmedia.py:368
 msgid "Remove Media Object"
 msgstr "Media-object verwijderen"
 
@@ -13143,7 +13164,7 @@ msgstr "Media-object verwijderen"
 msgid "manual|Media_Reference_Editor_dialog"
 msgstr "Mediaverwijzingen bewerken"
 
-#: ../gramps/gui/editors/editmediaref.py:95
+#: ../gramps/gui/editors/editmediaref.py:93
 #: ../gramps/gui/editors/editmediaref.py:409
 msgid "Media Reference Editor"
 msgstr "Mediaverwijzingen bewerken"
@@ -13164,7 +13185,7 @@ msgstr "Naam bewerken"
 msgid "manual|Name_Editor"
 msgstr "Naam bewerken"
 
-#: ../gramps/gui/editors/editname.py:175 ../gramps/gui/editors/editperson.py:328
+#: ../gramps/gui/editors/editname.py:175 ../gramps/gui/editors/editperson.py:327
 msgid "Call name must be the given name that is normally used."
 msgstr "Roepnaam is dat deel van de voornaam dat gewoonlijk wordt gebruikt."
 
@@ -13238,35 +13259,35 @@ msgstr "Nieuwe opmerking - %(context)s"
 msgid "New Note"
 msgstr "Nieuwe opmerking"
 
-#: ../gramps/gui/editors/editnote.py:191
+#: ../gramps/gui/editors/editnote.py:189
 msgid "_Note"
 msgstr "_Opmerking"
 
 # Bronnen vermelden/citeren
-#: ../gramps/gui/editors/editnote.py:294 ../gramps/gui/editors/editnote.py:340
+#: ../gramps/gui/editors/editnote.py:292 ../gramps/gui/editors/editnote.py:338
 #: ../gramps/gui/editors/objectentries.py:436
 msgid "Edit Note"
 msgstr "Opmerking bewerken"
 
-#: ../gramps/gui/editors/editnote.py:313
+#: ../gramps/gui/editors/editnote.py:311
 msgid "Cannot save note"
 msgstr "Kan opmerking niet opslaan"
 
-#: ../gramps/gui/editors/editnote.py:314
+#: ../gramps/gui/editors/editnote.py:312
 msgid "No data exists for this note. Please enter data or cancel the edit."
 msgstr ""
 "Er bestaan geen gegevens voor deze opmerking. Gelieve gegevens in te voeren "
 "of de aanpassingen te verwijderen."
 
-#: ../gramps/gui/editors/editnote.py:322
+#: ../gramps/gui/editors/editnote.py:320
 msgid "Cannot save note. ID already exists."
 msgstr "Kan opmerking niet opslaan. ID bestaat reeds."
 
-#: ../gramps/gui/editors/editnote.py:335
+#: ../gramps/gui/editors/editnote.py:333
 msgid "Add Note"
 msgstr "Opmerking toevoegen"
 
-#: ../gramps/gui/editors/editnote.py:355
+#: ../gramps/gui/editors/editnote.py:353
 #, python-format
 msgid "Delete Note (%s)"
 msgstr "Opmerking verwijderen (%s)"
@@ -13286,39 +13307,39 @@ msgstr "Nieuwe persoon:%(name)s"
 msgid "New Person"
 msgstr "Nieuw persoon"
 
-#: ../gramps/gui/editors/editperson.py:246
+#: ../gramps/gui/editors/editperson.py:245
 #, fuzzy
 msgid "manual|Editing_information_about_people"
 msgstr "Informatie_aanpassen_van_personen"
 
-#: ../gramps/gui/editors/editperson.py:607
+#: ../gramps/gui/editors/editperson.py:606
 #: ../gramps/plugins/view/geofamily.py:426
 msgid "Edit Person"
 msgstr "Persoon bewerken"
 
 # het gaat om het weergeven van de voorouders of een samenvatting van de db.
-#: ../gramps/gui/editors/editperson.py:650
+#: ../gramps/gui/editors/editperson.py:649
 #: ../gramps/plugins/view/mediaview.py:211
 msgid "View"
 msgstr "Weergeven"
 
-#: ../gramps/gui/editors/editperson.py:652
+#: ../gramps/gui/editors/editperson.py:651
 msgid "Edit Object Properties"
 msgstr "Object-eigenschappen bewerken"
 
-#: ../gramps/gui/editors/editperson.py:691
+#: ../gramps/gui/editors/editperson.py:690
 msgid "Make Active Person"
 msgstr "Maak actieve persoon"
 
-#: ../gramps/gui/editors/editperson.py:695
+#: ../gramps/gui/editors/editperson.py:694
 msgid "Make Home Person"
 msgstr "Beginpersoon instellen"
 
-#: ../gramps/gui/editors/editperson.py:809
+#: ../gramps/gui/editors/editperson.py:808
 msgid "Problem changing the gender"
 msgstr "Probleem met wijzigen van het geslacht"
 
-#: ../gramps/gui/editors/editperson.py:810
+#: ../gramps/gui/editors/editperson.py:809
 msgid ""
 "Changing the gender caused problems with marriage information.\n"
 "Please check the person's marriages."
@@ -13327,37 +13348,37 @@ msgstr ""
 "huwelijksinformatie.\n"
 "Controleer de huwelijken van de persoon."
 
-#: ../gramps/gui/editors/editperson.py:821
+#: ../gramps/gui/editors/editperson.py:820
 msgid "Cannot save person"
 msgstr "Kan persoon niet opslaan"
 
-#: ../gramps/gui/editors/editperson.py:822
+#: ../gramps/gui/editors/editperson.py:821
 msgid "No data exists for this person. Please enter data or cancel the edit."
 msgstr ""
 "Er bestaan geen gegevens voor deze persoon. Gelieve gegevens in te voeren of "
 "de gebeurtenis te verwijderen."
 
-#: ../gramps/gui/editors/editperson.py:846
+#: ../gramps/gui/editors/editperson.py:845
 msgid "Cannot save person. ID already exists."
 msgstr "Kan persoon niet opslaan. ID bestaat reeds."
 
-#: ../gramps/gui/editors/editperson.py:864
+#: ../gramps/gui/editors/editperson.py:863
 #, python-format
 msgid "Add Person (%s)"
 msgstr "Persoon toevoegen (%s)"
 
-#: ../gramps/gui/editors/editperson.py:870 ../gramps/plugins/view/relview.py:570
-#: ../gramps/plugins/view/relview.py:992 ../gramps/plugins/view/relview.py:1049
-#: ../gramps/plugins/view/relview.py:1173 ../gramps/plugins/view/relview.py:1278
+#: ../gramps/gui/editors/editperson.py:869 ../gramps/plugins/view/relview.py:580
+#: ../gramps/plugins/view/relview.py:1002 ../gramps/plugins/view/relview.py:1059
+#: ../gramps/plugins/view/relview.py:1183 ../gramps/plugins/view/relview.py:1288
 #, python-format
 msgid "Edit Person (%s)"
 msgstr "Persoon bewerken (%s)"
 
-#: ../gramps/gui/editors/editperson.py:1098
+#: ../gramps/gui/editors/editperson.py:1097
 msgid "Unknown gender specified"
 msgstr "Onbekend geslacht opgegeven"
 
-#: ../gramps/gui/editors/editperson.py:1100
+#: ../gramps/gui/editors/editperson.py:1099
 msgid ""
 "The gender of the person is currently unknown. Usually, this is a mistake. "
 "Please specify the gender."
@@ -13365,39 +13386,39 @@ msgstr ""
 "Het geslacht van de persoon is momenteel onbekend. Dit is meestal een "
 "vergissing. Geef geslacht op."
 
-#: ../gramps/gui/editors/editperson.py:1103
+#: ../gramps/gui/editors/editperson.py:1102
 msgid "_Male"
 msgstr "Man"
 
-#: ../gramps/gui/editors/editperson.py:1104
+#: ../gramps/gui/editors/editperson.py:1103
 msgid "_Female"
 msgstr "Vrouw"
 
-#: ../gramps/gui/editors/editperson.py:1105
+#: ../gramps/gui/editors/editperson.py:1104
 msgid "_Unknown"
 msgstr "Onbekend"
 
 # Bronnen, verwijzingen, literatuurverwijzingen
-#: ../gramps/gui/editors/editpersonref.py:68
+#: ../gramps/gui/editors/editpersonref.py:67
 #, fuzzy
 msgid "manual|Person_Reference_Editor"
 msgstr "Personenverwijzingen bewerken"
 
 # Bronnen, verwijzingen, literatuurverwijzingen
-#: ../gramps/gui/editors/editpersonref.py:97
-#: ../gramps/gui/editors/editpersonref.py:224
+#: ../gramps/gui/editors/editpersonref.py:93
+#: ../gramps/gui/editors/editpersonref.py:222
 msgid "Person Reference Editor"
 msgstr "Personenverwijzingen bewerken"
 
-#: ../gramps/gui/editors/editpersonref.py:224
+#: ../gramps/gui/editors/editpersonref.py:222
 msgid "Person Reference"
 msgstr "Persoonsreferentie"
 
-#: ../gramps/gui/editors/editpersonref.py:241
+#: ../gramps/gui/editors/editpersonref.py:239
 msgid "No person selected"
 msgstr "Geen persoon geselecteerd"
 
-#: ../gramps/gui/editors/editpersonref.py:242
+#: ../gramps/gui/editors/editpersonref.py:240
 msgid "You must either select a person or Cancel the edit"
 msgstr "U moet ofwel een persoon selecteren ofwel de aanpassing teniet doen"
 
@@ -13407,74 +13428,74 @@ msgid "manual|Place_Editor_dialog"
 msgstr "Locatie-aanpassingscherm"
 
 # Plaatsnaam
-#: ../gramps/gui/editors/editplace.py:93 ../gramps/gui/glade/editplace.glade:288
+#: ../gramps/gui/editors/editplace.py:91 ../gramps/gui/glade/editplace.glade:288
 #: ../gramps/gui/merge/mergeplace.py:55
 msgid "place|Name:"
 msgstr "Naam:"
 
-#: ../gramps/gui/editors/editplace.py:98
-#: ../gramps/gui/editors/editplaceref.py:95
+#: ../gramps/gui/editors/editplace.py:96
+#: ../gramps/gui/editors/editplaceref.py:96
 #, python-format
 msgid "Place: %s"
 msgstr "Locatie: %s"
 
-#: ../gramps/gui/editors/editplace.py:100
-#: ../gramps/gui/editors/editplaceref.py:97
+#: ../gramps/gui/editors/editplace.py:98
+#: ../gramps/gui/editors/editplaceref.py:98
 msgid "New Place"
 msgstr "Nieuwe locatie"
 
-#: ../gramps/gui/editors/editplace.py:181
-#: ../gramps/gui/editors/editplaceref.py:171
+#: ../gramps/gui/editors/editplace.py:179
+#: ../gramps/gui/editors/editplaceref.py:172
 msgid "Invalid latitude (syntax: 18\\u00b09'"
 msgstr "Ongeldige breedtegraad (syntax: 18\\u00b09'"
 
-#: ../gramps/gui/editors/editplace.py:182
-#: ../gramps/gui/editors/editplaceref.py:172
+#: ../gramps/gui/editors/editplace.py:180
+#: ../gramps/gui/editors/editplaceref.py:173
 msgid "48.21\"S, -18.2412 or -18:9:48.21)"
 msgstr "48.21\"Z, -18.2412 of -18:9:48.21)"
 
-#: ../gramps/gui/editors/editplace.py:184
-#: ../gramps/gui/editors/editplaceref.py:174
+#: ../gramps/gui/editors/editplace.py:182
+#: ../gramps/gui/editors/editplaceref.py:175
 msgid "Invalid longitude (syntax: 18\\u00b09'"
 msgstr "Ongeldige lengtegraad (syntax: 18\\u00b09'"
 
-#: ../gramps/gui/editors/editplace.py:185
-#: ../gramps/gui/editors/editplaceref.py:175
+#: ../gramps/gui/editors/editplace.py:183
+#: ../gramps/gui/editors/editplaceref.py:176
 msgid "48.21\"E, -18.2412 or -18:9:48.21)"
 msgstr "48.21\"O, -18.2412 of -18:9:48.21)"
 
-#: ../gramps/gui/editors/editplace.py:195
+#: ../gramps/gui/editors/editplace.py:193
 #: ../gramps/plugins/lib/maps/geography.py:920
 #: ../gramps/plugins/view/geoplaces.py:429
 #: ../gramps/plugins/view/geoplaces.py:455
 msgid "Edit Place"
 msgstr "Locatie bewerken"
 
-#: ../gramps/gui/editors/editplace.py:286
-#: ../gramps/gui/editors/editplaceref.py:277
+#: ../gramps/gui/editors/editplace.py:284
+#: ../gramps/gui/editors/editplaceref.py:278
 msgid "Cannot save place. Name not entered."
 msgstr "Kan locatie niet opslaan. Naam ontbreekt."
 
-#: ../gramps/gui/editors/editplace.py:287
-#: ../gramps/gui/editors/editplaceref.py:278
+#: ../gramps/gui/editors/editplace.py:285
+#: ../gramps/gui/editors/editplaceref.py:279
 msgid "You must enter a name before saving."
 msgstr "U dient eerst een naam in te geven voor het opslaan."
 
-#: ../gramps/gui/editors/editplace.py:296
+#: ../gramps/gui/editors/editplace.py:294
 msgid "Cannot save place. ID already exists."
 msgstr "Kan locatie niet opslaan. ID bestaat reeds."
 
-#: ../gramps/gui/editors/editplace.py:310
+#: ../gramps/gui/editors/editplace.py:308
 #, python-format
 msgid "Add Place (%s)"
 msgstr "Locatie toevoegen (%s)"
 
-#: ../gramps/gui/editors/editplace.py:315
+#: ../gramps/gui/editors/editplace.py:313
 #, python-format
 msgid "Edit Place (%s)"
 msgstr "Locatie bewerken (%s)"
 
-#: ../gramps/gui/editors/editplace.py:340
+#: ../gramps/gui/editors/editplace.py:338
 #, python-format
 msgid "Delete Place (%s)"
 msgstr "Locatie verwijderen (%s)"
@@ -13502,17 +13523,17 @@ msgid "The place name cannot be empty"
 msgstr "De locatinaam kan niet leeg zijn"
 
 # Bronnen, verwijzingen, literatuurverwijzingen
-#: ../gramps/gui/editors/editplaceref.py:59
-#: ../gramps/gui/editors/editplaceref.py:98
+#: ../gramps/gui/editors/editplaceref.py:58
+#: ../gramps/gui/editors/editplaceref.py:99
 msgid "Place Reference Editor"
 msgstr "Locatieverwijzingen bewerken"
 
-#: ../gramps/gui/editors/editplaceref.py:284
+#: ../gramps/gui/editors/editplaceref.py:285
 msgid "Modify Place"
 msgstr "Locatie wijzigen"
 
 # Plaatsen
-#: ../gramps/gui/editors/editplaceref.py:289
+#: ../gramps/gui/editors/editplaceref.py:290
 msgid "Add Place"
 msgstr "Locatie toevoegen"
 
@@ -13527,7 +13548,7 @@ msgstr ""
 "verloren gaan"
 
 #: ../gramps/gui/editors/editreference.py:282
-#: ../gramps/gui/editors/editrepository.py:190
+#: ../gramps/gui/editors/editrepository.py:188
 msgid "Cannot save repository. ID already exists."
 msgstr "Kan bibliotheek niet opslaan. ID bestaat reeds."
 
@@ -13535,30 +13556,30 @@ msgstr "Kan bibliotheek niet opslaan. ID bestaat reeds."
 msgid "Cannot save item. ID already exists."
 msgstr "Kan item niet opslaan. ID bestaat reeds."
 
-#: ../gramps/gui/editors/editreporef.py:62
+#: ../gramps/gui/editors/editreporef.py:60
 msgid "Repository Reference Editor"
 msgstr "Verwijzing naar bibliotheek bewerken"
 
-#: ../gramps/gui/editors/editreporef.py:185
+#: ../gramps/gui/editors/editreporef.py:184
 #, python-format
 msgid "Repository: %s"
 msgstr "Bibliotheek: %s"
 
-#: ../gramps/gui/editors/editreporef.py:187
+#: ../gramps/gui/editors/editreporef.py:186
 #: ../gramps/gui/editors/editrepository.py:81
 msgid "New Repository"
 msgstr "Nieuwe bibliotheek"
 
 # Bronnen, verwijzingen, literatuurverwijzingen
-#: ../gramps/gui/editors/editreporef.py:188
+#: ../gramps/gui/editors/editreporef.py:187
 msgid "Repo Reference Editor"
 msgstr "Bib verwijzing aanpassen"
 
-#: ../gramps/gui/editors/editreporef.py:193
+#: ../gramps/gui/editors/editreporef.py:192
 msgid "Modify Repository"
 msgstr "Verander bibliotheek"
 
-#: ../gramps/gui/editors/editreporef.py:198
+#: ../gramps/gui/editors/editreporef.py:197
 msgid "Add Repository"
 msgstr "Bibliotheek toevoegen"
 
@@ -13567,32 +13588,32 @@ msgstr "Bibliotheek toevoegen"
 msgid "manual|New_Repositories_dialog"
 msgstr "_Bibliotheken"
 
-#: ../gramps/gui/editors/editrepository.py:94
+#: ../gramps/gui/editors/editrepository.py:92
 msgid "Edit Repository"
 msgstr "Bibliotheek bewerken"
 
-#: ../gramps/gui/editors/editrepository.py:179
+#: ../gramps/gui/editors/editrepository.py:177
 msgid "Cannot save repository"
 msgstr "Kan bibliotheek niet opslaan"
 
-#: ../gramps/gui/editors/editrepository.py:180
+#: ../gramps/gui/editors/editrepository.py:178
 msgid ""
 "No data exists for this repository. Please enter data or cancel the edit."
 msgstr ""
 "Er bestaan geen gegevens voor deze bibliotheek. Voer gegevens in of stop het "
 "bewerken."
 
-#: ../gramps/gui/editors/editrepository.py:203
+#: ../gramps/gui/editors/editrepository.py:201
 #, python-format
 msgid "Add Repository (%s)"
 msgstr "Bibliotheek toevoegen (%s)"
 
-#: ../gramps/gui/editors/editrepository.py:208
+#: ../gramps/gui/editors/editrepository.py:206
 #, python-format
 msgid "Edit Repository (%s)"
 msgstr "Bibliotheek bewerken (%s)"
 
-#: ../gramps/gui/editors/editrepository.py:221
+#: ../gramps/gui/editors/editrepository.py:219
 #, python-format
 msgid "Delete Repository (%s)"
 msgstr "Bibliotheek verwijderen (%s)"
@@ -13607,37 +13628,37 @@ msgid "New Source"
 msgstr "Nieuwe bron"
 
 # Bronnen vermelden/citeren
-#: ../gramps/gui/editors/editsource.py:194
+#: ../gramps/gui/editors/editsource.py:193
 msgid "Edit Source"
 msgstr "Bron bewerken"
 
-#: ../gramps/gui/editors/editsource.py:199
+#: ../gramps/gui/editors/editsource.py:198
 msgid "Cannot save source"
 msgstr "Kan bronnen niet opslaan"
 
-#: ../gramps/gui/editors/editsource.py:200
+#: ../gramps/gui/editors/editsource.py:199
 msgid "No data exists for this source. Please enter data or cancel the edit."
 msgstr ""
 "Er bestaan geen gegevens voor deze bron. Gelieve gegevens in te voeren of de "
 "aanpassing teniet te doen."
 
-#: ../gramps/gui/editors/editsource.py:210
+#: ../gramps/gui/editors/editsource.py:209
 msgid "Cannot save source. ID already exists."
 msgstr "Kan bron niet opslaan. ID bestaat reeds."
 
 # Bronnen vermelden/citeren
-#: ../gramps/gui/editors/editsource.py:223
+#: ../gramps/gui/editors/editsource.py:222
 #, python-format
 msgid "Add Source (%s)"
 msgstr "Bron toevoegen (%s)"
 
 # Bronnen vermelden/citeren
-#: ../gramps/gui/editors/editsource.py:228
+#: ../gramps/gui/editors/editsource.py:227
 #, python-format
 msgid "Edit Source (%s)"
 msgstr "Bron bewerken (%s)"
 
-#: ../gramps/gui/editors/editsource.py:243
+#: ../gramps/gui/editors/editsource.py:242
 #, python-format
 msgid "Delete Source (%s)"
 msgstr "Bron verwijderen (%s)"
@@ -13687,7 +13708,7 @@ msgstr "Tag"
 #: ../gramps/gui/glade/editaddress.glade:55
 #: ../gramps/gui/glade/editattribute.glade:54
 #: ../gramps/gui/glade/editchildref.glade:58
-#: ../gramps/gui/glade/editcitation.glade:28
+#: ../gramps/gui/glade/editcitation.glade:27
 #: ../gramps/gui/glade/editdate.glade:53 ../gramps/gui/glade/editevent.glade:58
 #: ../gramps/gui/glade/editeventref.glade:22
 #: ../gramps/gui/glade/editfamily.glade:60
@@ -13695,8 +13716,8 @@ msgstr "Tag"
 #: ../gramps/gui/glade/editlocation.glade:55
 #: ../gramps/gui/glade/editmedia.glade:55
 #: ../gramps/gui/glade/editmediaref.glade:75
-#: ../gramps/gui/glade/editname.glade:60 ../gramps/gui/glade/editnote.glade:55
-#: ../gramps/gui/glade/editperson.glade:83
+#: ../gramps/gui/glade/editname.glade:60 ../gramps/gui/glade/editnote.glade:53
+#: ../gramps/gui/glade/editperson.glade:82
 #: ../gramps/gui/glade/editpersonref.glade:57
 #: ../gramps/gui/glade/editplace.glade:52
 #: ../gramps/gui/glade/editplacename.glade:55
@@ -13717,10 +13738,10 @@ msgstr "Tag"
 #: ../gramps/gui/glade/mergeplace.glade:51
 #: ../gramps/gui/glade/mergerepository.glade:53
 #: ../gramps/gui/glade/mergesource.glade:53 ../gramps/gui/glade/reorder.glade:56
-#: ../gramps/gui/glade/rule.glade:43 ../gramps/gui/glade/rule.glade:354
-#: ../gramps/gui/glade/rule.glade:784 ../gramps/gui/logger/_errorview.py:142
+#: ../gramps/gui/glade/rule.glade:41 ../gramps/gui/glade/rule.glade:351
+#: ../gramps/gui/glade/rule.glade:781 ../gramps/gui/logger/_errorview.py:142
 #: ../gramps/gui/plug/report/_reportdialog.py:158
-#: ../gramps/gui/undohistory.py:82 ../gramps/gui/viewmanager.py:484
+#: ../gramps/gui/undohistory.py:82 ../gramps/gui/viewmanager.py:488
 #: ../gramps/gui/views/bookmarks.py:259 ../gramps/gui/views/tags.py:425
 #: ../gramps/gui/views/tags.py:633 ../gramps/gui/widgets/grampletbar.py:641
 #: ../gramps/gui/widgets/grampletpane.py:240
@@ -13813,31 +13834,31 @@ msgstr ""
 "Geef een bron-ID of selecteer een bron-ID. Laat leeg om alle objecten zonder "
 "bron te vinden."
 
-#: ../gramps/gui/editors/filtereditor.py:563
+#: ../gramps/gui/editors/filtereditor.py:562
 msgid "Include selected Gramps ID"
 msgstr "Geselecteerde gramp-IDs bijvoegen"
 
-#: ../gramps/gui/editors/filtereditor.py:565
+#: ../gramps/gui/editors/filtereditor.py:564
 msgid "Use exact case of letters"
 msgstr "Exacte schrijfwijze toepassen"
 
-#: ../gramps/gui/editors/filtereditor.py:566
+#: ../gramps/gui/editors/filtereditor.py:565
 msgid "Regular-Expression matching:"
 msgstr "Reguliere uitdrukking overeenkomst:"
 
-#: ../gramps/gui/editors/filtereditor.py:567
+#: ../gramps/gui/editors/filtereditor.py:566
 msgid "Use regular expression"
 msgstr "Reguliere uitdrukking toepassen"
 
-#: ../gramps/gui/editors/filtereditor.py:569
+#: ../gramps/gui/editors/filtereditor.py:568
 msgid "Also family events where person is wife/husband"
 msgstr "Ook die gezinsgebeurtenissen waarin de persoon echtgenoot/echtgenote is"
 
-#: ../gramps/gui/editors/filtereditor.py:572
+#: ../gramps/gui/editors/filtereditor.py:571
 msgid "Only include primary participants"
 msgstr "Enkel de belangrijkste deelnemers toevoegen"
 
-#: ../gramps/gui/editors/filtereditor.py:596
+#: ../gramps/gui/editors/filtereditor.py:595
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:76
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:80
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:87
@@ -13850,7 +13871,7 @@ msgstr "Enkel de belangrijkste deelnemers toevoegen"
 msgid "Use regular expressions"
 msgstr "Reguliere uitdrukkingen toepassen"
 
-#: ../gramps/gui/editors/filtereditor.py:597
+#: ../gramps/gui/editors/filtereditor.py:596
 msgid ""
 "Interpret the contents of string fields as regular expressions.\n"
 "A decimal point will match any character. A question mark will match zero or "
@@ -13870,36 +13891,36 @@ msgstr ""
 "begin van een nieuwe regel. Een dollarteken komt overeen met het eind van een "
 "regel."
 
-#: ../gramps/gui/editors/filtereditor.py:626
+#: ../gramps/gui/editors/filtereditor.py:625
 msgid "Rule Name"
 msgstr "Regelnaam"
 
-#: ../gramps/gui/editors/filtereditor.py:757
-#: ../gramps/gui/editors/filtereditor.py:761 ../gramps/gui/glade/rule.glade:917
+#: ../gramps/gui/editors/filtereditor.py:756
+#: ../gramps/gui/editors/filtereditor.py:760 ../gramps/gui/glade/rule.glade:914
 msgid "No rule selected"
 msgstr "Geen regel geselecteerd"
 
-#: ../gramps/gui/editors/filtereditor.py:816
+#: ../gramps/gui/editors/filtereditor.py:813
 msgid "Define filter"
 msgstr "Filter bepalen"
 
-#: ../gramps/gui/editors/filtereditor.py:820 ../gramps/gui/glade/rule.glade:970
+#: ../gramps/gui/editors/filtereditor.py:818 ../gramps/gui/glade/rule.glade:967
 msgid "Values"
 msgstr "Waarden"
 
-#: ../gramps/gui/editors/filtereditor.py:919
+#: ../gramps/gui/editors/filtereditor.py:917
 msgid "Add Rule"
 msgstr "Regel toevoegen"
 
-#: ../gramps/gui/editors/filtereditor.py:931
+#: ../gramps/gui/editors/filtereditor.py:929
 msgid "Edit Rule"
 msgstr "Regel bewerken"
 
-#: ../gramps/gui/editors/filtereditor.py:966
+#: ../gramps/gui/editors/filtereditor.py:964
 msgid "Filter Test"
 msgstr "Filtertest"
 
-#: ../gramps/gui/editors/filtereditor.py:1105
+#: ../gramps/gui/editors/filtereditor.py:1103
 msgid "Comment"
 msgstr "Opmerking"
 
@@ -13908,7 +13929,7 @@ msgstr "Opmerking"
 #. ###############################
 #. #########################
 #. ###############################
-#: ../gramps/gui/editors/filtereditor.py:1105
+#: ../gramps/gui/editors/filtereditor.py:1103
 #: ../gramps/plugins/drawreport/calendarreport.py:472
 #: ../gramps/plugins/drawreport/statisticschart.py:988
 #: ../gramps/plugins/drawreport/timeline.py:417
@@ -13923,7 +13944,7 @@ msgstr "Opmerking"
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1118
 #: ../gramps/plugins/graph/gvrelgraph.py:669
 #: ../gramps/plugins/quickview/quickview.gpr.py:127
-#: ../gramps/plugins/textreport/birthdayreport.py:422
+#: ../gramps/plugins/textreport/birthdayreport.py:417
 #: ../gramps/plugins/textreport/familygroup.py:708
 #: ../gramps/plugins/textreport/indivcomplete.py:1035
 #: ../gramps/plugins/textreport/recordsreport.py:218
@@ -13933,15 +13954,15 @@ msgstr "Opmerking"
 msgid "Filter"
 msgstr "Filter"
 
-#: ../gramps/gui/editors/filtereditor.py:1113
+#: ../gramps/gui/editors/filtereditor.py:1111
 msgid "Custom Filter Editor"
 msgstr "Eigengemaakte filters"
 
-#: ../gramps/gui/editors/filtereditor.py:1180
+#: ../gramps/gui/editors/filtereditor.py:1183
 msgid "Delete Filter?"
 msgstr "Filter verwijderen?"
 
-#: ../gramps/gui/editors/filtereditor.py:1181
+#: ../gramps/gui/editors/filtereditor.py:1184
 msgid ""
 "This filter is currently being used as the base for other filters. "
 "Deletingthis filter will result in removing all other filters that depend on "
@@ -13951,7 +13972,7 @@ msgstr ""
 "deze filter verwijderd wordt, zullen alle onderliggende filters ook "
 "verwijderd worden."
 
-#: ../gramps/gui/editors/filtereditor.py:1185
+#: ../gramps/gui/editors/filtereditor.py:1188
 msgid "Delete Filter"
 msgstr "Filter verwijderen"
 
@@ -14103,7 +14124,7 @@ msgid "Updating display..."
 msgstr "Weergave bijwerken..."
 
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:103
-#: ../gramps/gui/glade/editcitation.glade:264
+#: ../gramps/gui/glade/editcitation.glade:263
 msgid "Source:"
 msgstr "Bron:"
 
@@ -14194,8 +14215,8 @@ msgid "Reset"
 msgstr "Herzetten"
 
 #: ../gramps/gui/glade/addmedia.glade:127
-#: ../gramps/gui/glade/editperson.glade:293
-#: ../gramps/gui/glade/editperson.glade:301
+#: ../gramps/gui/glade/editperson.glade:292
+#: ../gramps/gui/glade/editperson.glade:300
 #: ../gramps/plugins/lib/libmetadata.py:99
 #: ../gramps/plugins/textreport/simplebooktitle.py:152
 msgid "Image"
@@ -14447,12 +14468,16 @@ msgstr "Opslaan"
 msgid "Do not ask again"
 msgstr "Niet opnieuw vragen"
 
+#: ../gramps/gui/glade/displaystate.glade:8
+msgid "Gramps Warnings"
+msgstr "Grampswaarschuwingen"
+
 #: ../gramps/gui/glade/editaddress.glade:44
 #: ../gramps/gui/glade/editchildref.glade:47
 #: ../gramps/gui/glade/editevent.glade:47
 #: ../gramps/gui/glade/editfamily.glade:49
 #: ../gramps/gui/glade/editldsord.glade:66 ../gramps/gui/glade/editlink.glade:48
-#: ../gramps/gui/glade/editname.glade:49 ../gramps/gui/glade/editperson.glade:71
+#: ../gramps/gui/glade/editname.glade:49 ../gramps/gui/glade/editperson.glade:70
 #: ../gramps/gui/glade/editpersonref.glade:46
 #: ../gramps/gui/glade/editplacename.glade:44
 #: ../gramps/gui/glade/editreporef.glade:50
@@ -14462,7 +14487,7 @@ msgid "Accept changes and close window"
 msgstr "Wijzigingen accepteren en venster sluiten"
 
 #: ../gramps/gui/glade/editaddress.glade:93
-#: ../gramps/gui/glade/editcitation.glade:91
+#: ../gramps/gui/glade/editcitation.glade:90
 #: ../gramps/gui/glade/editevent.glade:111
 #: ../gramps/gui/glade/editeventref.glade:238
 #: ../gramps/gui/glade/editldsord.glade:116
@@ -14540,7 +14565,7 @@ msgstr ""
 #: ../gramps/gui/glade/editaddress.glade:290
 #: ../gramps/gui/glade/editattribute.glade:146
 #: ../gramps/gui/glade/editchildref.glade:173
-#: ../gramps/gui/glade/editcitation.glade:339
+#: ../gramps/gui/glade/editcitation.glade:338
 #: ../gramps/gui/glade/editevent.glade:348
 #: ../gramps/gui/glade/editeventref.glade:142
 #: ../gramps/gui/glade/editeventref.glade:413
@@ -14549,8 +14574,8 @@ msgstr ""
 #: ../gramps/gui/glade/editmedia.glade:325
 #: ../gramps/gui/glade/editmediaref.glade:294
 #: ../gramps/gui/glade/editmediaref.glade:616
-#: ../gramps/gui/glade/editname.glade:149 ../gramps/gui/glade/editnote.glade:228
-#: ../gramps/gui/glade/editperson.glade:411
+#: ../gramps/gui/glade/editname.glade:149 ../gramps/gui/glade/editnote.glade:226
+#: ../gramps/gui/glade/editperson.glade:410
 #: ../gramps/gui/glade/editpersonref.glade:151
 #: ../gramps/gui/glade/editplace.glade:255
 #: ../gramps/gui/glade/editplaceref.glade:358
@@ -14564,7 +14589,7 @@ msgid "Privacy"
 msgstr "Privacy"
 
 #: ../gramps/gui/glade/editaddress.glade:313
-#: ../gramps/gui/glade/editcitation.glade:107
+#: ../gramps/gui/glade/editcitation.glade:106
 #: ../gramps/gui/glade/editevent.glade:127
 #: ../gramps/gui/glade/editeventref.glade:369
 #: ../gramps/gui/glade/editldsord.glade:148
@@ -14639,12 +14664,12 @@ msgstr "Open aanpasvenster voor dit kind"
 
 #: ../gramps/gui/glade/editchildref.glade:240
 #: ../gramps/gui/glade/editfamily.glade:279
-#: ../gramps/gui/glade/editfamily.glade:587 ../gramps/gui/glade/rule.glade:459
+#: ../gramps/gui/glade/editfamily.glade:587 ../gramps/gui/glade/rule.glade:456
 #: ../gramps/gui/glade/styleeditor.glade:1865
 msgid "Edition"
 msgstr "Editie"
 
-#: ../gramps/gui/glade/editcitation.glade:137
+#: ../gramps/gui/glade/editcitation.glade:136
 msgid ""
 "Specific location within the information referenced. For a published work, "
 "this could include the volume of a multi-volume work and the page number(s). "
@@ -14663,16 +14688,16 @@ msgstr ""
 "volkstelling kan een lijnnummer bevatten of de gezinsnummers en ook een "
 "paginanummer. "
 
-#: ../gramps/gui/glade/editcitation.glade:153
+#: ../gramps/gui/glade/editcitation.glade:152
 msgid "_Volume/Page:"
 msgstr "_Volume/Pagina:"
 
 # Vertrouwen
-#: ../gramps/gui/glade/editcitation.glade:168
+#: ../gramps/gui/glade/editcitation.glade:167
 msgid "Con_fidence:"
 msgstr "_Zekerheid:"
 
-#: ../gramps/gui/glade/editcitation.glade:182
+#: ../gramps/gui/glade/editcitation.glade:181
 msgid ""
 "The date of the entry in the source you are referencing, e.g. the date a "
 "house was visited during a census, or the date an entry was made in a birth "
@@ -14683,7 +14708,7 @@ msgstr ""
 "volkstelling of de datum dat er iets werd opgetekend in een geboorte register "
 "of logboek. "
 
-#: ../gramps/gui/glade/editcitation.glade:202
+#: ../gramps/gui/glade/editcitation.glade:201
 msgid ""
 "Conveys the submitter's quantitative evaluation of the credibility of a piece "
 "of information, based upon its supporting evidence. It is not intended to "
@@ -14705,14 +14730,14 @@ msgstr ""
 "gebeurtenis\n"
 "Zeer hoog =Direct en primair bewijs of overtuigende bewijzen "
 
-#: ../gramps/gui/glade/editcitation.glade:227
+#: ../gramps/gui/glade/editcitation.glade:226
 #: ../gramps/gui/glade/editevent.glade:312
 #: ../gramps/gui/glade/editeventref.glade:285
 #: ../gramps/gui/glade/editfamily.glade:670
 #: ../gramps/gui/glade/editmedia.glade:96
 #: ../gramps/gui/glade/editmediaref.glade:394
-#: ../gramps/gui/glade/editnote.glade:168
-#: ../gramps/gui/glade/editperson.glade:618
+#: ../gramps/gui/glade/editnote.glade:166
+#: ../gramps/gui/glade/editperson.glade:617
 #: ../gramps/gui/glade/editplace.glade:149
 #: ../gramps/gui/glade/editreporef.glade:352
 #: ../gramps/gui/glade/editrepository.glade:165
@@ -14720,11 +14745,11 @@ msgstr ""
 msgid "_ID:"
 msgstr "_ID:"
 
-#: ../gramps/gui/glade/editcitation.glade:241
+#: ../gramps/gui/glade/editcitation.glade:240
 msgid "A unique ID to identify the citation"
 msgstr "Een unieke ID voor het citaat"
 
-#: ../gramps/gui/glade/editcitation.glade:361
+#: ../gramps/gui/glade/editcitation.glade:360
 #: ../gramps/gui/glade/editevent.glade:390
 #: ../gramps/gui/glade/editplace.glade:331
 #: ../gramps/gui/glade/editplaceref.glade:478
@@ -14879,7 +14904,7 @@ msgid "Shared information"
 msgstr "Gedeelde informatie"
 
 #: ../gramps/gui/glade/editfamily.glade:29 ../gramps/gui/glade/editname.glade:30
-#: ../gramps/gui/glade/editperson.glade:52
+#: ../gramps/gui/glade/editperson.glade:51
 #: ../gramps/gui/glade/editreporef.glade:30
 #: ../gramps/gui/glade/editrepository.glade:29
 #: ../gramps/gui/glade/editsource.glade:28
@@ -14923,8 +14948,8 @@ msgid "A unique ID for the family"
 msgstr "Een unieke ID voor het gezin"
 
 #: ../gramps/gui/glade/editfamily.glade:698
-#: ../gramps/gui/glade/editname.glade:103 ../gramps/gui/glade/editnote.glade:135
-#: ../gramps/gui/glade/editperson.glade:728
+#: ../gramps/gui/glade/editname.glade:103 ../gramps/gui/glade/editnote.glade:133
+#: ../gramps/gui/glade/editperson.glade:727
 #: ../gramps/gui/glade/editreporef.glade:279
 #: ../gramps/gui/glade/editrepository.glade:112
 #: ../gramps/gui/glade/editurl.glade:127
@@ -14942,8 +14967,8 @@ msgstr ""
 #: ../gramps/gui/glade/editfamily.glade:733
 #: ../gramps/gui/glade/editmedia.glade:360
 #: ../gramps/gui/glade/editmediaref.glade:696
-#: ../gramps/gui/glade/editnote.glade:250
-#: ../gramps/gui/glade/editperson.glade:651
+#: ../gramps/gui/glade/editnote.glade:248
+#: ../gramps/gui/glade/editperson.glade:650
 msgid "_Tags:"
 msgstr "Tags:"
 
@@ -14965,7 +14990,7 @@ msgid "_Family:"
 msgstr "Gezin:"
 
 #: ../gramps/gui/glade/editldsord.glade:250
-#: ../gramps/gui/selectors/selectfamily.py:63
+#: ../gramps/gui/selectors/selectfamily.py:62
 msgid "Select Family"
 msgstr "Gezin selecteren"
 
@@ -15174,19 +15199,19 @@ msgid "Shared Information"
 msgstr "Gedeelde informatie"
 
 #: ../gramps/gui/glade/editname.glade:119
-#: ../gramps/gui/glade/editperson.glade:317
+#: ../gramps/gui/glade/editperson.glade:316
 msgid ""
 "An identification of what type of Name this is, eg. Birth Name, Married Name."
 msgstr ""
 "Een aanduiding van het soort naam, bijvoorbeeld geboortenaam of huwelijksnaam."
 
 #: ../gramps/gui/glade/editname.glade:193
-#: ../gramps/gui/glade/editperson.glade:135
+#: ../gramps/gui/glade/editperson.glade:134
 msgid "_Given:"
 msgstr "Voornaam:"
 
 #: ../gramps/gui/glade/editname.glade:208
-#: ../gramps/gui/glade/editperson.glade:198
+#: ../gramps/gui/glade/editperson.glade:197
 msgid "T_itle:"
 msgstr "Titel:"
 
@@ -15200,7 +15225,7 @@ msgid "C_all Name:"
 msgstr "Roepnaam:"
 
 #: ../gramps/gui/glade/editname.glade:251
-#: ../gramps/gui/glade/editperson.glade:151
+#: ../gramps/gui/glade/editperson.glade:150
 msgid "The person's given names"
 msgstr "De voornamen van de persoon"
 
@@ -15209,7 +15234,7 @@ msgid "_Nick Name:"
 msgstr "Bijnaam:"
 
 #: ../gramps/gui/glade/editname.glade:279
-#: ../gramps/gui/glade/editperson.glade:180
+#: ../gramps/gui/glade/editperson.glade:179
 msgid ""
 "Part of the Given name that is the normally used name. If background is red, "
 "call name is not part of Given name and will not be printed underlined in "
@@ -15220,17 +15245,17 @@ msgstr ""
 "niet onderstreept worden in sommige verslagen."
 
 #: ../gramps/gui/glade/editname.glade:292
-#: ../gramps/gui/glade/editperson.glade:212
+#: ../gramps/gui/glade/editperson.glade:211
 msgid "A title used to refer to the person, such as 'Dr.' or 'Rev.'"
 msgstr "Een titel die betrekking heeft op de persoon zoals 'Dr.' of 'Eerw.'"
 
 #: ../gramps/gui/glade/editname.glade:305
-#: ../gramps/gui/glade/editperson.glade:226
+#: ../gramps/gui/glade/editperson.glade:225
 msgid "An optional suffix to the name, such as \"Jr.\" or \"III\""
 msgstr "Een optioneel naamachtervoegsel zoals \"Jr.\" of \"III\""
 
 #: ../gramps/gui/glade/editname.glade:318
-#: ../gramps/gui/glade/editperson.glade:260
+#: ../gramps/gui/glade/editperson.glade:259
 msgid ""
 "A descriptive name given in place of or in addition to the official given "
 "name."
@@ -15325,23 +15350,23 @@ msgstr ""
 "het huwelijk, de datum dat deze naam voor het eerst werd gebruikt of de "
 "huwelijksdatum."
 
-#: ../gramps/gui/glade/editnote.glade:103
+#: ../gramps/gui/glade/editnote.glade:101
 msgid "Styled Text Editor"
 msgstr "Tekststijl bewerken"
 
-#: ../gramps/gui/glade/editnote.glade:148
+#: ../gramps/gui/glade/editnote.glade:146
 msgid "A type to classify the note."
 msgstr "Een type om de opmerking te classificeren."
 
-#: ../gramps/gui/glade/editnote.glade:181
+#: ../gramps/gui/glade/editnote.glade:179
 msgid "A unique ID to identify the note."
 msgstr "Een unieke ID voor de opmerking."
 
-#: ../gramps/gui/glade/editnote.glade:192
+#: ../gramps/gui/glade/editnote.glade:190
 msgid "_Preformatted"
 msgstr "Opmaak"
 
-#: ../gramps/gui/glade/editnote.glade:200
+#: ../gramps/gui/glade/editnote.glade:198
 msgid ""
 "When active the whitespace in your note will be respected in reports. Use "
 "this to add formatting layout with spaces, eg a table. \n"
@@ -15356,19 +15381,19 @@ msgstr ""
 "de  verslagen, zodat de lay-out van het verslag wordt verbeterd.\n"
 "Gebruik een 'monospace'-lettertype om het formaat te behouden."
 
-#: ../gramps/gui/glade/editperson.glade:166
+#: ../gramps/gui/glade/editperson.glade:165
 msgid "C_all:"
 msgstr "Roep:"
 
-#: ../gramps/gui/glade/editperson.glade:246
+#: ../gramps/gui/glade/editperson.glade:245
 msgid "_Nick:"
 msgstr "Bijnaam:"
 
-#: ../gramps/gui/glade/editperson.glade:336
+#: ../gramps/gui/glade/editperson.glade:335
 msgid "Click on a table cell to edit."
 msgstr "Om een cel van de tabel aan te passen, op de cel klikken."
 
-#: ../gramps/gui/glade/editperson.glade:356
+#: ../gramps/gui/glade/editperson.glade:355
 msgid ""
 "Use Multiple Surnames\n"
 "Indicate that the surname consists of different parts. Every surname has its "
@@ -15383,15 +15408,15 @@ msgstr ""
 "als Ramón, die van de vader geërfd is, met de verbinding y en Cajal, een "
 "naamsdeel geërfd van de moeder."
 
-#: ../gramps/gui/glade/editperson.glade:400
+#: ../gramps/gui/glade/editperson.glade:399
 msgid "Set person as private data"
 msgstr "De persoonsgegeven als privé markeren"
 
-#: ../gramps/gui/glade/editperson.glade:451
+#: ../gramps/gui/glade/editperson.glade:450
 msgid "_Surname:"
 msgstr "Achternaam:"
 
-#: ../gramps/gui/glade/editperson.glade:467
+#: ../gramps/gui/glade/editperson.glade:466
 msgid ""
 "An optional prefix for the family that is not used in sorting, such as \"de\" "
 "or \"van\"."
@@ -15399,36 +15424,36 @@ msgstr ""
 "Een optioneel voorvoegsel voor de achternaam dat niet wordt gebruikt bij het "
 "sorteren zoals \"de\" of  \"van\"."
 
-#: ../gramps/gui/glade/editperson.glade:486
+#: ../gramps/gui/glade/editperson.glade:485
 msgid ""
 "Part of a person's name indicating the family to which the person belongs"
 msgstr "Naamgedeelte dat naar de familie verwijst waartoe de persoon behoort"
 
-#: ../gramps/gui/glade/editperson.glade:512
+#: ../gramps/gui/glade/editperson.glade:511
 msgid "Go to Name Editor to add more information about this name"
 msgstr ""
 "Om bijkomende naaminformatie in te geven dient u naar het naamaanpasscherm te "
 "gaan"
 
-#: ../gramps/gui/glade/editperson.glade:537
+#: ../gramps/gui/glade/editperson.glade:536
 msgid "O_rigin:"
 msgstr "O_orsprong:"
 
-#: ../gramps/gui/glade/editperson.glade:552
+#: ../gramps/gui/glade/editperson.glade:551
 msgid ""
 "The origin of this family name for this family, eg 'Inherited' or "
 "'Patronymic'."
 msgstr "De oorsprong van deze familienaam, 'geërfd' of 'patroniem'."
 
-#: ../gramps/gui/glade/editperson.glade:586
+#: ../gramps/gui/glade/editperson.glade:585
 msgid "G_ender:"
 msgstr "Geslacht:"
 
-#: ../gramps/gui/glade/editperson.glade:634
+#: ../gramps/gui/glade/editperson.glade:633
 msgid "A unique ID for the person."
 msgstr "Een unieke ID voor de persoon."
 
-#: ../gramps/gui/glade/editperson.glade:709
+#: ../gramps/gui/glade/editperson.glade:708
 msgid "Preferred Name"
 msgstr "Voorkeursnaam"
 
@@ -15587,7 +15612,7 @@ msgstr "Id van de bron in de bibliotheek."
 
 #: ../gramps/gui/glade/editreporef.glade:264
 #: ../gramps/gui/glade/editrepository.glade:97
-#: ../gramps/gui/glade/rule.glade:659
+#: ../gramps/gui/glade/rule.glade:656
 #: ../gramps/plugins/tool/ownereditor.glade:152
 msgid "_Name:"
 msgstr "_Naam:"
@@ -16078,24 +16103,24 @@ msgstr "_Onder:"
 msgid "Metric"
 msgstr "Metrisch"
 
-#: ../gramps/gui/glade/plugins.glade:46
+#: ../gramps/gui/glade/plugins.glade:44
 msgid "Perform selected action"
 msgstr "Geselecteerde actie uitvoeren"
 
-#: ../gramps/gui/glade/plugins.glade:51
+#: ../gramps/gui/glade/plugins.glade:49
 #: ../gramps/plugins/gramplet/ageondategramplet.py:68
 msgid "Run"
 msgstr "Uitvoeren"
 
-#: ../gramps/gui/glade/plugins.glade:141 ../gramps/gui/plug/_dialogs.py:285
+#: ../gramps/gui/glade/plugins.glade:139 ../gramps/gui/plug/_dialogs.py:291
 msgid "Select a report from those available on the left."
 msgstr "Kies een verslag uit de lijst aan de linkerkant."
 
-#: ../gramps/gui/glade/plugins.glade:162
+#: ../gramps/gui/glade/plugins.glade:160
 msgid "Status:"
 msgstr "Status:"
 
-#: ../gramps/gui/glade/plugins.glade:208
+#: ../gramps/gui/glade/plugins.glade:206
 msgid "Author's email:"
 msgstr "E-mail van auteur:"
 
@@ -16131,55 +16156,55 @@ msgstr "Gezin naar boven verplaatsen"
 msgid "Move family down"
 msgstr "Gezin naar beneden verplaatsen"
 
-#: ../gramps/gui/glade/rule.glade:124
+#: ../gramps/gui/glade/rule.glade:122
 msgid "Add a new filter"
 msgstr "Een nieuw filter toevoegen"
 
-#: ../gramps/gui/glade/rule.glade:148
+#: ../gramps/gui/glade/rule.glade:146
 msgid "Edit the selected filter"
 msgstr "Het geselecteerde filter bewerken"
 
-#: ../gramps/gui/glade/rule.glade:172
+#: ../gramps/gui/glade/rule.glade:170
 msgid "Clone the selected filter"
 msgstr "Maak een kloon van de geselecteerde filter"
 
-#: ../gramps/gui/glade/rule.glade:194
+#: ../gramps/gui/glade/rule.glade:192
 msgid "Test the selected filter"
 msgstr "Het geselecteerde filter testen"
 
-#: ../gramps/gui/glade/rule.glade:218
+#: ../gramps/gui/glade/rule.glade:216
 msgid "Delete the selected filter"
 msgstr "Het geselecteerde filter verwijderen"
 
-#: ../gramps/gui/glade/rule.glade:258
+#: ../gramps/gui/glade/rule.glade:256
 msgid "Note: changes take effect only after this window is closed"
 msgstr "Merk op: wijzigingen hebben pas effect nadat dit venster is gesloten"
 
-#: ../gramps/gui/glade/rule.glade:290 gtklist.h:6
+#: ../gramps/gui/glade/rule.glade:288 gtklist.h:6
 msgid "All rules must apply"
 msgstr "Alle regels moeten gelden"
 
-#: ../gramps/gui/glade/rule.glade:293 gtklist.h:7
+#: ../gramps/gui/glade/rule.glade:291 gtklist.h:7
 msgid "At least one rule must apply"
 msgstr "Minstens één regel moet gelden"
 
-#: ../gramps/gui/glade/rule.glade:296 gtklist.h:8
+#: ../gramps/gui/glade/rule.glade:294 gtklist.h:8
 msgid "Exactly one rule must apply"
 msgstr "Exact een regel moet gelden"
 
-#: ../gramps/gui/glade/rule.glade:416
+#: ../gramps/gui/glade/rule.glade:413
 msgid "Add another rule to the filter"
 msgstr "Voeg een regel aan het filter toe"
 
-#: ../gramps/gui/glade/rule.glade:450
+#: ../gramps/gui/glade/rule.glade:447
 msgid "Edit the selected rule"
 msgstr "De geselecteerde regel bewerken"
 
-#: ../gramps/gui/glade/rule.glade:484
+#: ../gramps/gui/glade/rule.glade:481
 msgid "Delete the selected rule"
 msgstr "Geselecteerde filter verwijderen"
 
-#: ../gramps/gui/glade/rule.glade:524 ../gramps/gui/glade/styleeditor.glade:403
+#: ../gramps/gui/glade/rule.glade:521 ../gramps/gui/glade/styleeditor.glade:403
 #: ../gramps/plugins/export/exportcsv.glade:113
 #: ../gramps/plugins/export/exportftree.glade:120
 #: ../gramps/plugins/export/exportgeneweb.glade:121
@@ -16191,24 +16216,24 @@ msgstr "Geselecteerde filter verwijderen"
 msgid "Options"
 msgstr "Opties"
 
-#: ../gramps/gui/glade/rule.glade:539
+#: ../gramps/gui/glade/rule.glade:536
 msgid "Rule list"
 msgstr "Regellijst"
 
-#: ../gramps/gui/glade/rule.glade:554
+#: ../gramps/gui/glade/rule.glade:551
 msgid "Definition"
 msgstr "Definitie"
 
-#: ../gramps/gui/glade/rule.glade:571
+#: ../gramps/gui/glade/rule.glade:568
 msgid "Co_mment:"
 msgstr "Op_merkingen:"
 
 # enigszins vrij vertaald, maar wel duidelijk
-#: ../gramps/gui/glade/rule.glade:606
+#: ../gramps/gui/glade/rule.glade:603
 msgid "Return values that do no_t match the filter rules"
 msgstr "_Resultaten die niet door het filter komen"
 
-#: ../gramps/gui/glade/rule.glade:898
+#: ../gramps/gui/glade/rule.glade:895
 msgid "Selected Rule"
 msgstr "Geselecteerde regel"
 
@@ -16236,7 +16261,7 @@ msgstr "_Zwitsers (Arial, Helvetica, sans-serif)"
 #. #################
 #: ../gramps/gui/glade/styleeditor.glade:339
 #: ../gramps/plugins/drawreport/ancestortree.py:899
-#: ../gramps/plugins/drawreport/descendtree.py:1616
+#: ../gramps/plugins/drawreport/descendtree.py:1619
 msgid "Size"
 msgstr "Grootte"
 
@@ -16272,7 +16297,7 @@ msgid "Alignment"
 msgstr "Uitlijning"
 
 #: ../gramps/gui/glade/styleeditor.glade:570
-#: ../gramps/plugins/drawreport/fanchart.py:709
+#: ../gramps/plugins/drawreport/fanchart.py:713
 msgid "Background color"
 msgstr "Achtergrondkleur"
 
@@ -16868,7 +16893,7 @@ msgstr "Gezinnen_samenvoegen"
 msgid "Merge Families"
 msgstr "Gezinnen samenvoegen"
 
-#: ../gramps/gui/merge/mergefamily.py:225 ../gramps/gui/merge/mergeperson.py:331
+#: ../gramps/gui/merge/mergefamily.py:227 ../gramps/gui/merge/mergeperson.py:329
 #: ../gramps/plugins/lib/libpersonview.py:424
 msgid "Cannot merge people"
 msgstr "Kan personen niet samenvoegen"
@@ -16881,11 +16906,11 @@ msgstr "Media-objecten_samenvoegen"
 msgid "manual|Merge_Notes"
 msgstr "Opmerkingen_samenvoegen"
 
-#: ../gramps/gui/merge/mergenote.py:96
+#: ../gramps/gui/merge/mergenote.py:94
 msgid "flowed"
 msgstr "doorlopend"
 
-#: ../gramps/gui/merge/mergenote.py:96
+#: ../gramps/gui/merge/mergenote.py:94
 msgid "preformatted"
 msgstr "opmaak"
 
@@ -16897,13 +16922,13 @@ msgstr "Personen_samenvoegen"
 msgid "Merge People"
 msgstr "Personen samenvoegen"
 
-#: ../gramps/gui/merge/mergeperson.py:196
+#: ../gramps/gui/merge/mergeperson.py:194
 #: ../gramps/plugins/textreport/indivcomplete.py:378
 msgid "Alternate Names"
 msgstr "Alternatieve namen"
 
 # Gebeuren (korter)
-#: ../gramps/gui/merge/mergeperson.py:203
+#: ../gramps/gui/merge/mergeperson.py:201
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:474
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:488
 #: ../gramps/plugins/quickview/filterbyname.py:97
@@ -16922,45 +16947,45 @@ msgstr "Gebeurtenissen"
 
 #. Go over parents and build their menu
 #. don't show rest
-#: ../gramps/gui/merge/mergeperson.py:218 ../gramps/gui/widgets/fanchart.py:1679
+#: ../gramps/gui/merge/mergeperson.py:216 ../gramps/gui/widgets/fanchart.py:1679
 #: ../gramps/plugins/quickview/all_relations.py:305
 #: ../gramps/plugins/tool/notrelated.py:126
-#: ../gramps/plugins/view/pedigreeview.py:1776
-#: ../gramps/plugins/view/relview.py:528 ../gramps/plugins/view/relview.py:852
-#: ../gramps/plugins/view/relview.py:888
+#: ../gramps/plugins/view/pedigreeview.py:1790
+#: ../gramps/plugins/view/relview.py:538 ../gramps/plugins/view/relview.py:862
+#: ../gramps/plugins/view/relview.py:898
 #: ../gramps/plugins/webreport/narrativeweb.py:3265
 #: ../gramps/plugins/webreport/narrativeweb.py:6145
 #: ../gramps/plugins/webreport/narrativeweb.py:7565
 msgid "Parents"
 msgstr "Ouders"
 
-#: ../gramps/gui/merge/mergeperson.py:221 ../gramps/gui/merge/mergeperson.py:235
+#: ../gramps/gui/merge/mergeperson.py:219 ../gramps/gui/merge/mergeperson.py:233
 #: ../gramps/plugins/tool/findloop.py:111
 msgid "Family ID"
 msgstr "Gezins-ID"
 
-#: ../gramps/gui/merge/mergeperson.py:227
+#: ../gramps/gui/merge/mergeperson.py:225
 msgid "No parents found"
 msgstr "Geen ouders gevonden"
 
 #. Go over spouses and build their menu
-#: ../gramps/gui/merge/mergeperson.py:229 ../gramps/gui/widgets/fanchart.py:1551
+#: ../gramps/gui/merge/mergeperson.py:227 ../gramps/gui/widgets/fanchart.py:1551
 #: ../gramps/plugins/textreport/kinshipreport.py:132
-#: ../gramps/plugins/view/pedigreeview.py:1663
+#: ../gramps/plugins/view/pedigreeview.py:1677
 msgid "Spouses"
 msgstr "Echtgenoten"
 
-#: ../gramps/gui/merge/mergeperson.py:239
-#: ../gramps/gui/selectors/selectperson.py:101
+#: ../gramps/gui/merge/mergeperson.py:237
+#: ../gramps/gui/selectors/selectperson.py:100
 #: ../gramps/gui/widgets/reorderfam.py:89
 #: ../gramps/plugins/gramplet/children.py:98
 #: ../gramps/plugins/lib/libpersonview.py:105
 #: ../gramps/plugins/textreport/familygroup.py:566
-#: ../gramps/plugins/view/relview.py:1395
+#: ../gramps/plugins/view/relview.py:1405
 msgid "Spouse"
 msgstr "Echtgenoot"
 
-#: ../gramps/gui/merge/mergeperson.py:253
+#: ../gramps/gui/merge/mergeperson.py:251
 msgid "No spouses or children found"
 msgstr "Geen echtgenoten of kinderen gevonden"
 
@@ -16980,31 +17005,31 @@ msgstr "Bronnen_samenvoegen"
 msgid "Merge Sources"
 msgstr "Bronnen samenvoegen"
 
-#: ../gramps/gui/plug/_dialogs.py:284
+#: ../gramps/gui/plug/_dialogs.py:290
 msgid "Report Selection"
 msgstr "Verslagskeuze"
 
-#: ../gramps/gui/plug/_dialogs.py:286
+#: ../gramps/gui/plug/_dialogs.py:292
 msgid "Generate selected report"
 msgstr "Gekozen verslag aanmaken"
 
-#: ../gramps/gui/plug/_dialogs.py:286
+#: ../gramps/gui/plug/_dialogs.py:292
 msgid "_Generate"
 msgstr "Aanmaken"
 
-#: ../gramps/gui/plug/_dialogs.py:315
+#: ../gramps/gui/plug/_dialogs.py:321
 msgid "Tool Selection"
 msgstr "Keuze hulpmiddel"
 
-#: ../gramps/gui/plug/_dialogs.py:316
+#: ../gramps/gui/plug/_dialogs.py:322
 msgid "Select a tool from those available on the left."
 msgstr "Kies een hulpmiddel uit de lijst aan de linkerkant."
 
-#: ../gramps/gui/plug/_dialogs.py:317 ../gramps/plugins/tool/verify.glade:144
+#: ../gramps/gui/plug/_dialogs.py:323 ../gramps/plugins/tool/verify.glade:144
 msgid "_Run"
 msgstr "_Uitvoeren"
 
-#: ../gramps/gui/plug/_dialogs.py:318
+#: ../gramps/gui/plug/_dialogs.py:324
 msgid "Run selected tool"
 msgstr "Het gekozen hulpmiddel gebruiken"
 
@@ -17044,7 +17069,7 @@ msgid "Also include %s?"
 msgstr "Ook %s?"
 
 #: ../gramps/gui/plug/_guioptions.py:1244
-#: ../gramps/gui/selectors/selectperson.py:87
+#: ../gramps/gui/selectors/selectperson.py:86
 msgid "Select Person"
 msgstr "Persoon selecteren"
 
@@ -17793,6 +17818,7 @@ msgstr "Stijl"
 #. menu.add_option(category_name, "Spouse_disp", Spouse_disp)
 #. #################
 #. #########################
+#. #################
 #. ###############################
 #. ---------------------
 #. ###############################
@@ -17802,6 +17828,7 @@ msgstr "Stijl"
 #: ../gramps/gui/plug/report/_reportdialog.py:365
 #: ../gramps/plugins/drawreport/ancestortree.py:836
 #: ../gramps/plugins/drawreport/calendarreport.py:468
+#: ../gramps/plugins/drawreport/descendtree.py:1520
 #: ../gramps/plugins/drawreport/fanchart.py:686
 #: ../gramps/plugins/drawreport/statisticschart.py:984
 #: ../gramps/plugins/drawreport/timeline.py:415
@@ -17882,12 +17909,12 @@ msgstr ""
 "Kies een ander pad of verander de machtigingen."
 
 #: ../gramps/gui/plug/report/_reportdialog.py:536
-#: ../gramps/plugins/export/exportxml.py:143
+#: ../gramps/plugins/export/exportxml.py:146
 msgid "No directory"
 msgstr "Geen map"
 
 #: ../gramps/gui/plug/report/_reportdialog.py:537
-#: ../gramps/plugins/export/exportxml.py:144
+#: ../gramps/plugins/export/exportxml.py:147
 #, python-format
 msgid ""
 "There is no directory %s.\n"
@@ -18005,24 +18032,24 @@ msgstr ""
 msgid "manual|Select_Source_or_Citation_selector"
 msgstr "Bron of citaat selecteren"
 
-#: ../gramps/gui/selectors/selectcitation.py:68
+#: ../gramps/gui/selectors/selectcitation.py:67
 msgid "Select Source or Citation"
 msgstr "Bron of citaat selecteren"
 
-#: ../gramps/gui/selectors/selectcitation.py:75
+#: ../gramps/gui/selectors/selectcitation.py:74
 #: ../gramps/plugins/view/citationtreeview.py:93
 msgid "Source: Title or Citation: Volume/Page"
 msgstr "Bron: titel of citaat: volume/pagina"
 
-#: ../gramps/gui/selectors/selectcitation.py:77
-#: ../gramps/gui/selectors/selectevent.py:76
-#: ../gramps/gui/selectors/selectfamily.py:73
-#: ../gramps/gui/selectors/selectnote.py:79
+#: ../gramps/gui/selectors/selectcitation.py:76
+#: ../gramps/gui/selectors/selectevent.py:75
+#: ../gramps/gui/selectors/selectfamily.py:72
+#: ../gramps/gui/selectors/selectnote.py:78
 #: ../gramps/gui/selectors/selectobject.py:83
-#: ../gramps/gui/selectors/selectperson.py:102
-#: ../gramps/gui/selectors/selectplace.py:75
-#: ../gramps/gui/selectors/selectrepository.py:72
-#: ../gramps/gui/selectors/selectsource.py:73
+#: ../gramps/gui/selectors/selectperson.py:101
+#: ../gramps/gui/selectors/selectplace.py:74
+#: ../gramps/gui/selectors/selectrepository.py:71
+#: ../gramps/gui/selectors/selectsource.py:72
 msgid "Last Change"
 msgstr "Laatste wijziging"
 
@@ -18031,7 +18058,7 @@ msgstr "Laatste wijziging"
 msgid "manual|Select_Event_selector"
 msgstr "Gebeurtenissen_samenvoegen"
 
-#: ../gramps/gui/selectors/selectevent.py:63
+#: ../gramps/gui/selectors/selectevent.py:62
 msgid "Select Event"
 msgstr "Gebeurtenis selecteren"
 
@@ -18045,7 +18072,7 @@ msgstr ""
 msgid "manual|Select_Note_selector"
 msgstr "Opmerkingen_samenvoegen"
 
-#: ../gramps/gui/selectors/selectnote.py:68
+#: ../gramps/gui/selectors/selectnote.py:67
 msgid "Select Note"
 msgstr "Selecteer opmerking"
 
@@ -18077,7 +18104,7 @@ msgstr ""
 msgid "manual|Select_Place_selector"
 msgstr "Locaties_samenvoegen"
 
-#: ../gramps/gui/selectors/selectplace.py:64
+#: ../gramps/gui/selectors/selectplace.py:63
 msgid "Select Place"
 msgstr "Locatie selecteren"
 
@@ -18086,7 +18113,7 @@ msgstr "Locatie selecteren"
 msgid "manual|Repositories"
 msgstr "Bibliotheken_samenvoegen"
 
-#: ../gramps/gui/selectors/selectrepository.py:63
+#: ../gramps/gui/selectors/selectrepository.py:62
 msgid "Select Repository"
 msgstr "Bibliotheek kiezen"
 
@@ -18101,7 +18128,7 @@ msgstr "Bibliotheek kiezen"
 msgid "manual|xxxx"
 msgstr "Tags"
 
-#: ../gramps/gui/selectors/selectsource.py:63
+#: ../gramps/gui/selectors/selectsource.py:62
 msgid "Select Source"
 msgstr "Bron selecteren"
 
@@ -18127,15 +18154,15 @@ msgid "Spelling checker initialization failed: %s"
 msgstr "Initialisatie van de spellingscontrole faalde: %s"
 
 #: ../gramps/gui/tipofday.py:67 ../gramps/gui/tipofday.py:68
-#: ../gramps/gui/tipofday.py:120 ../gramps/gui/viewmanager.py:501
+#: ../gramps/gui/tipofday.py:121 ../gramps/gui/viewmanager.py:505
 msgid "Tip of the Day"
 msgstr "Tip van de dag"
 
-#: ../gramps/gui/tipofday.py:86
+#: ../gramps/gui/tipofday.py:87
 msgid "Failed to display tip of the day"
 msgstr "Kan de dagtip niet weergeven"
 
-#: ../gramps/gui/tipofday.py:87
+#: ../gramps/gui/tipofday.py:88
 #, python-format
 msgid ""
 "Unable to read the tips from external file.\n"
@@ -18154,13 +18181,13 @@ msgstr "11"
 msgid "Undo History"
 msgstr "Bewerkingsgeschiedenis"
 
-#: ../gramps/gui/undohistory.py:84 ../gramps/gui/viewmanager.py:589
-#: ../gramps/gui/viewmanager.py:1229
+#: ../gramps/gui/undohistory.py:84 ../gramps/gui/viewmanager.py:593
+#: ../gramps/gui/viewmanager.py:1237
 msgid "_Undo"
 msgstr "Ongedaan maken"
 
-#: ../gramps/gui/undohistory.py:86 ../gramps/gui/viewmanager.py:594
-#: ../gramps/gui/viewmanager.py:1246
+#: ../gramps/gui/undohistory.py:86 ../gramps/gui/viewmanager.py:598
+#: ../gramps/gui/viewmanager.py:1254
 msgid "_Redo"
 msgstr "Opnieuw"
 
@@ -18243,195 +18270,195 @@ msgstr ""
 msgid "Cannot open new citation editor"
 msgstr "Het scherm om de citaten aan te passen kon niet geopend worden"
 
-#: ../gramps/gui/viewmanager.py:433 ../gramps/gui/viewmanager.py:1203
+#: ../gramps/gui/viewmanager.py:437 ../gramps/gui/viewmanager.py:1211
 msgid "No Family Tree"
 msgstr "Geen stamboom"
 
-#: ../gramps/gui/viewmanager.py:455
+#: ../gramps/gui/viewmanager.py:459
 msgid "Connect to a recent database"
 msgstr "Verbinden met een recent gegevensbestand"
 
-#: ../gramps/gui/viewmanager.py:473
+#: ../gramps/gui/viewmanager.py:477
 msgid "_Family Trees"
 msgstr "Stambomen"
 
-#: ../gramps/gui/viewmanager.py:474
+#: ../gramps/gui/viewmanager.py:478
 msgid "_Manage Family Trees..."
 msgstr "Stambomen beheren..."
 
-#: ../gramps/gui/viewmanager.py:475
+#: ../gramps/gui/viewmanager.py:479
 msgid "Manage databases"
 msgstr "Gegevensbestanden beheren"
 
-#: ../gramps/gui/viewmanager.py:476
+#: ../gramps/gui/viewmanager.py:480
 msgid "Open _Recent"
 msgstr "_Recent openen"
 
-#: ../gramps/gui/viewmanager.py:477
+#: ../gramps/gui/viewmanager.py:481
 msgid "Open an existing database"
 msgstr "Een bestaand gegevensbestand openen"
 
-#: ../gramps/gui/viewmanager.py:478
+#: ../gramps/gui/viewmanager.py:482
 msgid "_Quit"
 msgstr "Afsluiten"
 
-#: ../gramps/gui/viewmanager.py:480
+#: ../gramps/gui/viewmanager.py:484
 msgid "_View"
 msgstr "Scherm"
 
 # Bronnen, verwijzingen, literatuurverwijzingen
-#: ../gramps/gui/viewmanager.py:482
+#: ../gramps/gui/viewmanager.py:486
 msgid "_Preferences..."
 msgstr "_Voorkeuren..."
 
-#: ../gramps/gui/viewmanager.py:485
+#: ../gramps/gui/viewmanager.py:489
 msgid "Gramps _Home Page"
 msgstr "Gramps _homepagina"
 
-#: ../gramps/gui/viewmanager.py:487
+#: ../gramps/gui/viewmanager.py:491
 msgid "Gramps _Mailing Lists"
 msgstr "Gramps-postlijsten"
 
-#: ../gramps/gui/viewmanager.py:489
+#: ../gramps/gui/viewmanager.py:493
 msgid "_Report a Bug"
 msgstr "Een fout _rapporteren"
 
-#: ../gramps/gui/viewmanager.py:491
+#: ../gramps/gui/viewmanager.py:495
 msgid "_Extra Reports/Tools"
 msgstr "Bijkomende Verslagen/Hulpmiddelen"
 
-#: ../gramps/gui/viewmanager.py:493
+#: ../gramps/gui/viewmanager.py:497
 msgid "_About"
 msgstr "_Info"
 
-#: ../gramps/gui/viewmanager.py:495
+#: ../gramps/gui/viewmanager.py:499
 msgid "_Plugin Manager"
 msgstr "Uitbreidingenbeheerder"
 
-#: ../gramps/gui/viewmanager.py:497
+#: ../gramps/gui/viewmanager.py:501
 msgid "_FAQ"
 msgstr "_FAQ"
 
-#: ../gramps/gui/viewmanager.py:498
+#: ../gramps/gui/viewmanager.py:502
 msgid "_Key Bindings"
 msgstr "Sneltoetsen"
 
-#: ../gramps/gui/viewmanager.py:499
+#: ../gramps/gui/viewmanager.py:503
 msgid "_User Manual"
 msgstr "Gebr_uikshandleiding"
 
-#: ../gramps/gui/viewmanager.py:507
+#: ../gramps/gui/viewmanager.py:511
 msgid "Close the current database"
 msgstr "Huidig gegevensbestand sluiten"
 
-#: ../gramps/gui/viewmanager.py:508
+#: ../gramps/gui/viewmanager.py:512
 msgid "_Export..."
 msgstr "_Exporteren..."
 
-#: ../gramps/gui/viewmanager.py:510
+#: ../gramps/gui/viewmanager.py:514
 msgid "Make Backup..."
 msgstr "Reservekopie maken..."
 
-#: ../gramps/gui/viewmanager.py:511
+#: ../gramps/gui/viewmanager.py:515
 msgid "Make a Gramps XML backup of the database"
 msgstr "Een Gramps XML reservekopie van het gegevensbestand aanmaken"
 
 # annuleren hier beter dan negeren/verlaten
-#: ../gramps/gui/viewmanager.py:513
+#: ../gramps/gui/viewmanager.py:517
 msgid "_Abandon Changes and Quit"
 msgstr "_Wijzigingen annuleren en sluiten"
 
 # rapportages
-#: ../gramps/gui/viewmanager.py:514 ../gramps/gui/viewmanager.py:517
+#: ../gramps/gui/viewmanager.py:518 ../gramps/gui/viewmanager.py:521
 msgid "_Reports"
 msgstr "Verslagen"
 
-#: ../gramps/gui/viewmanager.py:515
+#: ../gramps/gui/viewmanager.py:519
 msgid "Open the reports dialog"
 msgstr "Het dialoogvenster voor verslagen openen"
 
 # ga naar
-#: ../gramps/gui/viewmanager.py:516
+#: ../gramps/gui/viewmanager.py:520
 msgid "_Go"
 msgstr "_Ga naar"
 
-#: ../gramps/gui/viewmanager.py:518
+#: ../gramps/gui/viewmanager.py:522
 msgid "Books..."
 msgstr "Boeken..."
 
-#: ../gramps/gui/viewmanager.py:519
+#: ../gramps/gui/viewmanager.py:523
 msgid "_Windows"
 msgstr "Vensters"
 
 # zie ook uncleared.
 # is dit goed?
-#: ../gramps/gui/viewmanager.py:566
+#: ../gramps/gui/viewmanager.py:570
 msgid "Clip_board"
 msgstr "Klembord"
 
-#: ../gramps/gui/viewmanager.py:567
+#: ../gramps/gui/viewmanager.py:571
 msgid "Open the Clipboard dialog"
 msgstr "Het klemborddialoogvenster openen"
 
-#: ../gramps/gui/viewmanager.py:568
+#: ../gramps/gui/viewmanager.py:572
 msgid "_Import..."
 msgstr "_Importeren..."
 
-#: ../gramps/gui/viewmanager.py:570 ../gramps/gui/viewmanager.py:573
+#: ../gramps/gui/viewmanager.py:574 ../gramps/gui/viewmanager.py:577
 msgid "_Tools"
 msgstr "Hulpmiddelen"
 
-#: ../gramps/gui/viewmanager.py:571
+#: ../gramps/gui/viewmanager.py:575
 msgid "Open the tools dialog"
 msgstr "De hulpmiddelendialoog openen"
 
-#: ../gramps/gui/viewmanager.py:572
+#: ../gramps/gui/viewmanager.py:576
 msgid "_Bookmarks"
 msgstr "Bladwijzers"
 
-#: ../gramps/gui/viewmanager.py:574
+#: ../gramps/gui/viewmanager.py:578
 msgid "_Configure..."
 msgstr "Scherminstellingen..."
 
-#: ../gramps/gui/viewmanager.py:575
+#: ../gramps/gui/viewmanager.py:579
 msgid "Configure the active view"
 msgstr "Het actieve scherm configureren"
 
-#: ../gramps/gui/viewmanager.py:580
+#: ../gramps/gui/viewmanager.py:584
 msgid "_Navigator"
 msgstr "_Navigator"
 
-#: ../gramps/gui/viewmanager.py:582
+#: ../gramps/gui/viewmanager.py:586
 msgid "_Toolbar"
 msgstr "Werkbalk"
 
-#: ../gramps/gui/viewmanager.py:584
+#: ../gramps/gui/viewmanager.py:588
 msgid "F_ull Screen"
 msgstr "Volledig beeld"
 
-#: ../gramps/gui/viewmanager.py:600
+#: ../gramps/gui/viewmanager.py:604
 msgid "Undo History..."
 msgstr "Geschiedenis wissen..."
 
-#: ../gramps/gui/viewmanager.py:623
+#: ../gramps/gui/viewmanager.py:627
 #, python-format
 msgid "Key %s is not bound"
 msgstr "Toets %s is niet gebonden"
 
 #. registering plugins
-#: ../gramps/gui/viewmanager.py:730
+#: ../gramps/gui/viewmanager.py:734
 msgid "Registering plugins..."
 msgstr "Geregistreerde uitbreidingen..."
 
-#: ../gramps/gui/viewmanager.py:737
+#: ../gramps/gui/viewmanager.py:741
 msgid "Ready"
 msgstr "Klaar"
 
-#: ../gramps/gui/viewmanager.py:778
+#: ../gramps/gui/viewmanager.py:786
 msgid "Abort changes?"
 msgstr "Wijzigingen annuleren?"
 
-#: ../gramps/gui/viewmanager.py:779
+#: ../gramps/gui/viewmanager.py:787
 msgid ""
 "Aborting changes will return the database to the state it was before you "
 "started this editing session."
@@ -18439,15 +18466,15 @@ msgstr ""
 "Het annuleren van wijzigingen zorgt ervoor wijzigingen in het gegevensbestand "
 "worden teruggedraaid naar de toestand voordat u de wijzigingen doorvoerde."
 
-#: ../gramps/gui/viewmanager.py:781
+#: ../gramps/gui/viewmanager.py:789
 msgid "Abort changes"
 msgstr "Wijzigingen annuleren"
 
-#: ../gramps/gui/viewmanager.py:792
+#: ../gramps/gui/viewmanager.py:800
 msgid "Cannot abandon session's changes"
 msgstr "Kan deze veranderingen aan deze sessie niet ongedaan maken"
 
-#: ../gramps/gui/viewmanager.py:793
+#: ../gramps/gui/viewmanager.py:801
 msgid ""
 "Changes cannot be completely abandoned because the number of changes made in "
 "the session exceeded the limit."
@@ -18455,28 +18482,28 @@ msgstr ""
 "Veranderingen kunnen niet volledig ongedaan gemaakt worden omdat het aantal "
 "veranderingen van de sessie het maximum overschrijdt."
 
-#: ../gramps/gui/viewmanager.py:954
+#: ../gramps/gui/viewmanager.py:962
 msgid "View failed to load. Check error output."
 msgstr "Scherm kon niet geladen worden. Best foutboodschap controleren."
 
-#: ../gramps/gui/viewmanager.py:1106
+#: ../gramps/gui/viewmanager.py:1114
 msgid "Import Statistics"
 msgstr "Statistieken importeren"
 
-#: ../gramps/gui/viewmanager.py:1173
+#: ../gramps/gui/viewmanager.py:1181
 msgid "Read Only"
 msgstr "Alleen lezen"
 
-#: ../gramps/gui/viewmanager.py:1280
+#: ../gramps/gui/viewmanager.py:1288
 msgid "Gramps XML Backup"
 msgstr "Gramps XML reservekopie"
 
-#: ../gramps/gui/viewmanager.py:1311
+#: ../gramps/gui/viewmanager.py:1319
 #: ../gramps/plugins/importer/importgedcom.glade:289
 msgid "File:"
 msgstr "Bestand:"
 
-#: ../gramps/gui/viewmanager.py:1343
+#: ../gramps/gui/viewmanager.py:1351
 msgid "Media:"
 msgstr "Media:"
 
@@ -18484,71 +18511,72 @@ msgstr "Media:"
 #. --------------------
 #. ###############################
 #. What to include
-#. #########################
 #. ###############################
-#: ../gramps/gui/viewmanager.py:1349
+#: ../gramps/gui/viewmanager.py:1357
 #: ../gramps/plugins/drawreport/ancestortree.py:962
-#: ../gramps/plugins/drawreport/descendtree.py:1668
+#: ../gramps/plugins/drawreport/descendtree.py:1671
 #: ../gramps/plugins/graph/gvfamilylines.py:189
 #: ../gramps/plugins/graph/gvrelgraph.py:692
 #: ../gramps/plugins/textreport/detancestralreport.py:852
 #: ../gramps/plugins/textreport/detdescendantreport.py:1061
 #: ../gramps/plugins/textreport/detdescendantreport.py:1085
-#: ../gramps/plugins/textreport/familygroup.py:736
 #: ../gramps/plugins/textreport/indivcomplete.py:1067
 msgid "Include"
 msgstr "Bijvoegen"
 
-#: ../gramps/gui/viewmanager.py:1350
+#: ../gramps/gui/viewmanager.py:1358
 #: ../gramps/plugins/gramplet/statsgramplet.py:139
 #: ../gramps/plugins/webreport/narrativeweb.py:8121
 msgid "Megabyte|MB"
 msgstr "Megabyte|MB"
 
-#: ../gramps/gui/viewmanager.py:1352
+#: ../gramps/gui/viewmanager.py:1360
 msgid "Exclude"
 msgstr "Niet toevoegen"
 
-#: ../gramps/gui/viewmanager.py:1373
+#: ../gramps/gui/viewmanager.py:1381
 msgid "Backup file already exists! Overwrite?"
 msgstr "Bestand bestaat reeds! Overschrijven?"
 
-#: ../gramps/gui/viewmanager.py:1374
+#: ../gramps/gui/viewmanager.py:1382
 #, python-format
 msgid "The file '%s' exists."
 msgstr "Het bestand '%s' bestaat."
 
-#: ../gramps/gui/viewmanager.py:1375
+#: ../gramps/gui/viewmanager.py:1383
 msgid "Proceed and overwrite"
 msgstr "Verder gaan en overschrijven"
 
-#: ../gramps/gui/viewmanager.py:1376
+#: ../gramps/gui/viewmanager.py:1384
 msgid "Cancel the backup"
 msgstr "Reservekopie annuleren"
 
-#: ../gramps/gui/viewmanager.py:1384
+#: ../gramps/gui/viewmanager.py:1392
 msgid "Making backup..."
 msgstr "Reservekopie wordt aangemaakt..."
 
-#: ../gramps/gui/viewmanager.py:1397
+#: ../gramps/gui/viewmanager.py:1405
 #, python-format
 msgid "Backup saved to '%s'"
 msgstr "Reservekopie naar '%s' opgeslagen"
 
-#: ../gramps/gui/viewmanager.py:1400
+#: ../gramps/gui/viewmanager.py:1408
 msgid "Backup aborted"
 msgstr "Reservekopie aanmaken werd afgebroken"
 
-# dit is een soort titel in een file-selector
-#: ../gramps/gui/viewmanager.py:1409
-msgid "Select backup directory"
-msgstr "Een map voor de reservekopie selecteren"
+#: ../gramps/gui/viewmanager.py:1418
+msgid "Autobackup..."
+msgstr "Automatisch reservekopie maken..."
 
-#: ../gramps/gui/viewmanager.py:1634
+#: ../gramps/gui/viewmanager.py:1423
+msgid "Error saving backup data"
+msgstr "Fout bij het maken van een reservekopie"
+
+#: ../gramps/gui/viewmanager.py:1673
 msgid "Failed Loading View"
 msgstr "Scherm kon niet geladen worden"
 
-#: ../gramps/gui/viewmanager.py:1635
+#: ../gramps/gui/viewmanager.py:1674
 #, python-format
 msgid ""
 "The view %(name)s did not load and reported an error.\n"
@@ -18572,11 +18600,11 @@ msgstr ""
 "Wenst u echter dat deze uitbreiding niet meer door Gramps wordt geladen, kunt "
 "u de uitbreiding verbergen via het uitbreidingsmenu in het hulpmenu."
 
-#: ../gramps/gui/viewmanager.py:1727
+#: ../gramps/gui/viewmanager.py:1766
 msgid "Failed Loading Plugin"
 msgstr "Laden van de uitbreiding mislukte"
 
-#: ../gramps/gui/viewmanager.py:1728
+#: ../gramps/gui/viewmanager.py:1767
 #, python-format
 msgid ""
 "The plugin %(name)s did not load and reported an error.\n"
@@ -18748,7 +18776,7 @@ msgstr "Naar het vorige object in de geschiedenis gaan"
 
 # Nog geen definieve vertaling gevonden
 #: ../gramps/gui/views/navigationview.py:306
-#: ../gramps/plugins/view/pedigreeview.py:1563
+#: ../gramps/plugins/view/pedigreeview.py:1577
 msgid "_Home"
 msgstr "Begin"
 
@@ -18804,13 +18832,13 @@ msgstr "%(cat)s - %(view)s configureren"
 msgid "%(cat)s - %(view)s"
 msgstr "%(cat)s - %(view)s"
 
-#: ../gramps/gui/views/pageview.py:597
+#: ../gramps/gui/views/pageview.py:598
 #, python-format
 msgid "Configure %s View"
 msgstr "Scherm %s configureren"
 
 #. top widget at the top
-#: ../gramps/gui/views/pageview.py:611
+#: ../gramps/gui/views/pageview.py:612
 #, python-format
 msgid "View %(name)s: %(msg)s"
 msgstr "%(name)s: %(msg)s tonen"
@@ -18943,25 +18971,25 @@ msgstr "Deze sectie expanderen"
 msgid "Collapse this section"
 msgstr "Deze sectie samenvoegen"
 
-#: ../gramps/gui/widgets/fanchart.py:1519 ../gramps/plugins/view/relview.py:801
+#: ../gramps/gui/widgets/fanchart.py:1519 ../gramps/plugins/view/relview.py:811
 msgid "Edit family"
 msgstr "Gezin bewerken"
 
-#: ../gramps/gui/widgets/fanchart.py:1535 ../gramps/plugins/view/relview.py:802
+#: ../gramps/gui/widgets/fanchart.py:1535 ../gramps/plugins/view/relview.py:812
 msgid "Reorder families"
 msgstr "Gezinnen herschikken"
 
 #: ../gramps/gui/widgets/fanchart.py:1541
-#: ../gramps/plugins/view/pedigreeview.py:1653
-#: ../gramps/plugins/view/pedigreeview.py:1881
+#: ../gramps/plugins/view/pedigreeview.py:1667
+#: ../gramps/plugins/view/pedigreeview.py:1895
 msgid "_Copy"
 msgstr "Kopieer"
 
 #. Go over siblings and build their menu
 #: ../gramps/gui/widgets/fanchart.py:1585
 #: ../gramps/plugins/quickview/quickview.gpr.py:316
-#: ../gramps/plugins/view/pedigreeview.py:1697
-#: ../gramps/plugins/view/relview.py:904
+#: ../gramps/plugins/view/pedigreeview.py:1711
+#: ../gramps/plugins/view/relview.py:914
 msgid "Siblings"
 msgstr "Broers en zussen"
 
@@ -18971,15 +18999,15 @@ msgstr "Broers en zussen"
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:866
 #: ../gramps/plugins/textreport/familygroup.py:639
 #: ../gramps/plugins/textreport/indivcomplete.py:663
-#: ../gramps/plugins/view/pedigreeview.py:1739
-#: ../gramps/plugins/view/relview.py:1410
+#: ../gramps/plugins/view/pedigreeview.py:1753
+#: ../gramps/plugins/view/relview.py:1420
 #: ../gramps/plugins/webreport/narrativeweb.py:753
 msgid "Children"
 msgstr "Kinderen"
 
 #. Go over parents and build their menu
 #: ../gramps/gui/widgets/fanchart.py:1721
-#: ../gramps/plugins/view/pedigreeview.py:1824
+#: ../gramps/plugins/view/pedigreeview.py:1838
 msgid "Related"
 msgstr "Verwant aan"
 
@@ -18991,7 +19019,7 @@ msgstr "Partner aan een persoon toevoegen"
 msgid "Add a person"
 msgstr "Een persoon toevoegen"
 
-#: ../gramps/gui/widgets/fanchart.py:1851 ../gramps/plugins/view/relview.py:1551
+#: ../gramps/gui/widgets/fanchart.py:1851 ../gramps/plugins/view/relview.py:1561
 msgid "Add Child to Family"
 msgstr "Kind aan gezin toevoegen"
 
@@ -19296,7 +19324,7 @@ msgstr ""
 msgid "Rebuild reference map"
 msgstr "Opnieuw opbouwen van referentiestructuur"
 
-#: ../gramps/plugins/db/bsddb/write.py:2173
+#: ../gramps/plugins/db/bsddb/write.py:2172
 #, python-format
 msgid ""
 "A second transaction is started while there is still a transaction, \"%s\", "
@@ -19305,11 +19333,11 @@ msgstr ""
 "Een tweede transactie wordt gestart terwijl er nog een transactie \"%s\" "
 "actief is in het gegevensbestand."
 
-#: ../gramps/plugins/db/bsddb/write.py:2516
+#: ../gramps/plugins/db/bsddb/write.py:2483
 msgid "DB-API version"
 msgstr "DB-API versie"
 
-#: ../gramps/plugins/db/bsddb/write.py:2528
+#: ../gramps/plugins/db/bsddb/write.py:2495
 msgid "Database db version"
 msgstr "Database db versie"
 
@@ -19522,7 +19550,7 @@ msgid "transparent background"
 msgstr "doorschijnende achtergrond"
 
 #: ../gramps/plugins/docgen/svgdrawdoc.py:344
-#: ../gramps/plugins/drawreport/fanchart.py:710
+#: ../gramps/plugins/drawreport/fanchart.py:714
 msgid "white"
 msgstr "wit"
 
@@ -19603,7 +19631,7 @@ msgstr "Stamboom afdrukken..."
 
 #. #################
 #: ../gramps/plugins/drawreport/ancestortree.py:786
-#: ../gramps/plugins/drawreport/descendtree.py:1520
+#: ../gramps/plugins/drawreport/descendtree.py:1540
 msgid "Tree Options"
 msgstr "Stamboomopties"
 
@@ -19613,7 +19641,6 @@ msgstr "Stamboomopties"
 #: ../gramps/plugins/graph/gvhourglass.py:308
 #: ../gramps/plugins/graph/gvrelgraph.py:675
 #: ../gramps/plugins/textreport/ancestorreport.py:283
-#: ../gramps/plugins/textreport/birthdayreport.py:427
 #: ../gramps/plugins/textreport/descendreport.py:506
 #: ../gramps/plugins/textreport/detancestralreport.py:782
 #: ../gramps/plugins/textreport/detdescendantreport.py:978
@@ -19637,17 +19664,17 @@ msgstr ""
 "Al of niet de centrale persoon of al zijn / haar broers en zussen weergeven"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:805
-#: ../gramps/plugins/drawreport/descendtree.py:1546
-#: ../gramps/plugins/drawreport/fanchart.py:696
+#: ../gramps/plugins/drawreport/descendtree.py:1542
+#: ../gramps/plugins/drawreport/fanchart.py:700
 #: ../gramps/plugins/textreport/ancestorreport.py:293
-#: ../gramps/plugins/textreport/descendreport.py:527
+#: ../gramps/plugins/textreport/descendreport.py:531
 #: ../gramps/plugins/textreport/detancestralreport.py:797
 #: ../gramps/plugins/textreport/detdescendantreport.py:1006
 msgid "Generations"
 msgstr "Generaties"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:806
-#: ../gramps/plugins/drawreport/descendtree.py:1547
+#: ../gramps/plugins/drawreport/descendtree.py:1543
 msgid "The number of generations to include in the tree"
 msgstr "Het aantal generaties dat in de stamboom wordt voorzien"
 
@@ -19664,7 +19691,7 @@ msgid "The number of generations of empty boxes that will be displayed"
 msgstr "Het aantal generaties met lege rechthoeken dat getoond wordt"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:819
-#: ../gramps/plugins/drawreport/descendtree.py:1555
+#: ../gramps/plugins/drawreport/descendtree.py:1560
 msgid "Compress tree"
 msgstr "Stamboom comprimeren"
 
@@ -19676,13 +19703,13 @@ msgstr ""
 "verwijderen"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:838
-#: ../gramps/plugins/drawreport/descendtree.py:1670
+#: ../gramps/plugins/drawreport/descendtree.py:1673
 msgid "Report Title"
 msgstr "Verslagtitel"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:839
-#: ../gramps/plugins/drawreport/descendtree.py:1671
-#: ../gramps/plugins/drawreport/descendtree.py:1726
+#: ../gramps/plugins/drawreport/descendtree.py:1674
+#: ../gramps/plugins/drawreport/descendtree.py:1729
 msgid "Do not include a title"
 msgstr "Geen titel toevoegen"
 
@@ -19691,22 +19718,22 @@ msgid "Include Report Title"
 msgstr "Verslagstitel toevoegen"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:841
-#: ../gramps/plugins/drawreport/descendtree.py:1679
+#: ../gramps/plugins/drawreport/descendtree.py:1682
 msgid "Choose a title for the report"
 msgstr "Een titel voor het verslag kiezen"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:844
-#: ../gramps/plugins/drawreport/descendtree.py:1683
+#: ../gramps/plugins/drawreport/descendtree.py:1686
 msgid "Include a border"
 msgstr "Rand toevoegen"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:845
-#: ../gramps/plugins/drawreport/descendtree.py:1684
+#: ../gramps/plugins/drawreport/descendtree.py:1687
 msgid "Whether to make a border around the report."
 msgstr "Al of niet een rand rond het verslag toevoegen."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:848
-#: ../gramps/plugins/drawreport/descendtree.py:1687
+#: ../gramps/plugins/drawreport/descendtree.py:1690
 msgid "Include Page Numbers"
 msgstr "Paginanummers toeveogen"
 
@@ -19766,17 +19793,17 @@ msgid "Which Display format to use the center person"
 msgstr "Weergaveformaat voor de centrale persoon"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:889
-#: ../gramps/plugins/drawreport/descendtree.py:1597
+#: ../gramps/plugins/drawreport/descendtree.py:1600
 msgid "Include Marriage box"
 msgstr "Huwelijkrechthoek bijvoegen"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:891
-#: ../gramps/plugins/drawreport/descendtree.py:1599
+#: ../gramps/plugins/drawreport/descendtree.py:1602
 msgid "Whether to include a separate marital box in the report"
 msgstr "Al of niet een aparte huwelijkrechthoek in het verslag voorzien"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:894
-#: ../gramps/plugins/drawreport/descendtree.py:1602
+#: ../gramps/plugins/drawreport/descendtree.py:1605
 msgid ""
 "Marriage\n"
 "Display Format"
@@ -19785,37 +19812,37 @@ msgstr ""
 "Weergaveformaat"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:895
-#: ../gramps/plugins/drawreport/descendtree.py:1603
+#: ../gramps/plugins/drawreport/descendtree.py:1606
 msgid "Display format for the marital box."
 msgstr "Weergave van de huwelijksrechthoek."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:901
-#: ../gramps/plugins/drawreport/descendtree.py:1618
+#: ../gramps/plugins/drawreport/descendtree.py:1621
 msgid "Scale tree to fit"
 msgstr "Boom passend schalen"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:902
-#: ../gramps/plugins/drawreport/descendtree.py:1619
+#: ../gramps/plugins/drawreport/descendtree.py:1622
 msgid "Do not scale tree"
 msgstr "Boom niet schalen"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:903
-#: ../gramps/plugins/drawreport/descendtree.py:1620
+#: ../gramps/plugins/drawreport/descendtree.py:1623
 msgid "Scale tree to fit page width only"
 msgstr "Boom aan paginabreedte aanpassen"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:904
-#: ../gramps/plugins/drawreport/descendtree.py:1621
+#: ../gramps/plugins/drawreport/descendtree.py:1624
 msgid "Scale tree to fit the size of the page"
 msgstr "Stamboom schalen zodat hij op één pagina past"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:906
-#: ../gramps/plugins/drawreport/descendtree.py:1623
+#: ../gramps/plugins/drawreport/descendtree.py:1626
 msgid "Whether to scale the tree to fit a specific paper size"
 msgstr "Boom al dan niet naar een specifieke pagina-afmeting schalen"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:913
-#: ../gramps/plugins/drawreport/descendtree.py:1630
+#: ../gramps/plugins/drawreport/descendtree.py:1633
 msgid ""
 "Resize Page to Fit Tree size\n"
 "\n"
@@ -19827,7 +19854,7 @@ msgstr ""
 "gehouden met de instellingen in de tab 'papieropties'"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:919
-#: ../gramps/plugins/drawreport/descendtree.py:1636
+#: ../gramps/plugins/drawreport/descendtree.py:1639
 msgid ""
 "Whether to resize the page to fit the size \n"
 "of the tree.  Note:  the page will have a \n"
@@ -19871,24 +19898,24 @@ msgid "Make the inter-box spacing bigger or smaller"
 msgstr "De schaalfactor tussen de rechthoeken groter of kleiner maken"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:945
-#: ../gramps/plugins/drawreport/descendtree.py:1661
+#: ../gramps/plugins/drawreport/descendtree.py:1664
 msgid "box shadow scale factor"
 msgstr "schaalfactor voor de schaduw voor de rechthoek"
 
 #. down to 0
 #: ../gramps/plugins/drawreport/ancestortree.py:947
-#: ../gramps/plugins/drawreport/descendtree.py:1663
+#: ../gramps/plugins/drawreport/descendtree.py:1666
 msgid "Make the box shadow bigger or smaller"
 msgstr "De schaduw rond de rechthoeken groter of kleiner maken"
 
 #. #################
 #: ../gramps/plugins/drawreport/ancestortree.py:952
-#: ../gramps/plugins/drawreport/descendtree.py:1607
+#: ../gramps/plugins/drawreport/descendtree.py:1610
 msgid "Replace"
 msgstr "Vervang"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:955
-#: ../gramps/plugins/drawreport/descendtree.py:1610
+#: ../gramps/plugins/drawreport/descendtree.py:1613
 msgid ""
 "Replace Display Format:\n"
 "'Replace this'/' with this'"
@@ -19897,7 +19924,7 @@ msgstr ""
 "'Vervang dit'/'door dit'"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:957
-#: ../gramps/plugins/drawreport/descendtree.py:1612
+#: ../gramps/plugins/drawreport/descendtree.py:1615
 msgid ""
 "i.e.\n"
 "United States of America/U.S.A"
@@ -19906,12 +19933,12 @@ msgstr ""
 "Verenigde Staten van Amerika/V.S"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:964
-#: ../gramps/plugins/drawreport/descendtree.py:1691
+#: ../gramps/plugins/drawreport/descendtree.py:1694
 msgid "Include Blank Pages"
 msgstr "Lege pagina's bijvoegen"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:965
-#: ../gramps/plugins/drawreport/descendtree.py:1692
+#: ../gramps/plugins/drawreport/descendtree.py:1695
 msgid "Whether to include pages that are blank."
 msgstr "Met/zonder blanco pagina's."
 
@@ -19923,17 +19950,17 @@ msgstr "Met/zonder blanco pagina's."
 #. menu.add_option(category_name, "includeImages", self.__include_images)
 #. category_name = _("Notes")
 #: ../gramps/plugins/drawreport/ancestortree.py:979
-#: ../gramps/plugins/drawreport/descendtree.py:1697
+#: ../gramps/plugins/drawreport/descendtree.py:1700
 msgid "Include a note"
 msgstr "Opmerking bijvoegen"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:980
-#: ../gramps/plugins/drawreport/descendtree.py:1699
+#: ../gramps/plugins/drawreport/descendtree.py:1702
 msgid "Whether to include a note on the report."
 msgstr "Al of niet een opmerking toevoegen aan het verslag."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:985
-#: ../gramps/plugins/drawreport/descendtree.py:1704
+#: ../gramps/plugins/drawreport/descendtree.py:1707
 msgid ""
 "Add a note\n"
 "\n"
@@ -19944,12 +19971,12 @@ msgstr ""
 "$T voegt de datum van vandaag toe"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:990
-#: ../gramps/plugins/drawreport/descendtree.py:1709
+#: ../gramps/plugins/drawreport/descendtree.py:1712
 msgid "Note Location"
 msgstr "Opmerking locatie"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:993
-#: ../gramps/plugins/drawreport/descendtree.py:1712
+#: ../gramps/plugins/drawreport/descendtree.py:1715
 msgid "Where to place the note."
 msgstr "Waar de opmerking moet geplaatst worden."
 
@@ -19966,32 +19993,32 @@ msgid " Generations of empty boxes for unknown ancestors"
 msgstr " Aantal generaties met lege rechthoeken voor onbekende voorouders"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:1032
-#: ../gramps/plugins/drawreport/descendtree.py:1760
+#: ../gramps/plugins/drawreport/descendtree.py:1763
 #: ../gramps/plugins/textreport/ancestorreport.py:372
 #: ../gramps/plugins/textreport/detancestralreport.py:961
 #: ../gramps/plugins/textreport/detdescendantreport.py:1191
 #: ../gramps/plugins/textreport/endoflinereport.py:314
 #: ../gramps/plugins/textreport/endoflinereport.py:333
-#: ../gramps/plugins/textreport/familygroup.py:855
+#: ../gramps/plugins/textreport/familygroup.py:860
 #: ../gramps/plugins/textreport/indivcomplete.py:1204
-#: ../gramps/plugins/textreport/kinshipreport.py:419
+#: ../gramps/plugins/textreport/kinshipreport.py:421
 #: ../gramps/plugins/textreport/notelinkreport.py:198
 #: ../gramps/plugins/textreport/numberofancestorsreport.py:234
-#: ../gramps/plugins/textreport/recordsreport.py:325
+#: ../gramps/plugins/textreport/recordsreport.py:336
 #: ../gramps/plugins/textreport/summary.py:330
 #: ../gramps/plugins/textreport/tagreport.py:964
 msgid "The basic style used for the text display."
 msgstr "De gebruikte standaardopmaak voor de tekstweergave."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:1042
-#: ../gramps/plugins/drawreport/descendtree.py:1782
-#: ../gramps/plugins/textreport/familygroup.py:867
+#: ../gramps/plugins/drawreport/descendtree.py:1785
+#: ../gramps/plugins/textreport/familygroup.py:872
 #: ../gramps/plugins/textreport/tagreport.py:982
 msgid "The basic style used for the note display."
 msgstr "De gebruikte standaardopmaak voor de weergave van opmerkingen."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:1052
-#: ../gramps/plugins/drawreport/descendtree.py:1750
+#: ../gramps/plugins/drawreport/descendtree.py:1753
 msgid "The basic style used for the title display."
 msgstr "De gebruikte standaardopmaak voor de titelweergave."
 
@@ -20081,7 +20108,6 @@ msgstr ""
 #: ../gramps/plugins/drawreport/fanchart.py:689
 #: ../gramps/plugins/graph/gvrelgraph.py:676
 #: ../gramps/plugins/textreport/ancestorreport.py:284
-#: ../gramps/plugins/textreport/birthdayreport.py:428
 #: ../gramps/plugins/textreport/descendreport.py:507
 #: ../gramps/plugins/textreport/detancestralreport.py:783
 #: ../gramps/plugins/textreport/detdescendantreport.py:979
@@ -20092,7 +20118,7 @@ msgid "The center person for the report"
 msgstr "De centrale persoon voor dit verslag"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:490
-#: ../gramps/plugins/textreport/birthdayreport.py:439
+#: ../gramps/plugins/textreport/birthdayreport.py:433
 #: ../gramps/plugins/webreport/webcal.py:1655
 msgid "Include only living people"
 msgstr "Enkel nog levende personen bijvoegen"
@@ -20115,19 +20141,19 @@ msgid "Year of calendar"
 msgstr "Kalenderjaar"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:506
-#: ../gramps/plugins/textreport/birthdayreport.py:443
+#: ../gramps/plugins/textreport/birthdayreport.py:448
 #: ../gramps/plugins/webreport/webcal.py:1711
 msgid "Country for holidays"
 msgstr "Land voor feestdagen"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:517
-#: ../gramps/plugins/textreport/birthdayreport.py:454
+#: ../gramps/plugins/textreport/birthdayreport.py:459
 msgid "Select the country to see associated holidays"
 msgstr "Kies een land om de overeenkomstige feestdagen te zien"
 
 #. Default selection ????
 #: ../gramps/plugins/drawreport/calendarreport.py:520
-#: ../gramps/plugins/textreport/birthdayreport.py:457
+#: ../gramps/plugins/textreport/birthdayreport.py:462
 #: ../gramps/plugins/webreport/webcal.py:1727
 msgid "First day of week"
 msgstr "Eerste weekdag"
@@ -20138,38 +20164,38 @@ msgid "Select the first day of the week for the calendar"
 msgstr "Kies de eerste weekdag voor de kalender"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:528
-#: ../gramps/plugins/textreport/birthdayreport.py:465
+#: ../gramps/plugins/textreport/birthdayreport.py:470
 #: ../gramps/plugins/webreport/webcal.py:1734
 msgid "Birthday surname"
 msgstr "Verjaardag achternaam"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:529
-#: ../gramps/plugins/textreport/birthdayreport.py:466
+#: ../gramps/plugins/textreport/birthdayreport.py:471
 #: ../gramps/plugins/webreport/webcal.py:1735
 msgid "Wives use husband's surname (from first family listed)"
 msgstr "Vrouwen gebruiken achternaam echtgenoot (van het eerste gezin in lijst)"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:530
-#: ../gramps/plugins/textreport/birthdayreport.py:467
+#: ../gramps/plugins/textreport/birthdayreport.py:472
 #: ../gramps/plugins/webreport/webcal.py:1737
 msgid "Wives use husband's surname (from last family listed)"
 msgstr ""
 "Vrouwen gebruiken achternaam echtgenoot (van het laatste gezin in de lijst)"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:531
-#: ../gramps/plugins/textreport/birthdayreport.py:468
+#: ../gramps/plugins/textreport/birthdayreport.py:473
 #: ../gramps/plugins/webreport/webcal.py:1739
 msgid "Wives use their own surname"
 msgstr "Vrouwen eigen achternaam"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:532
-#: ../gramps/plugins/textreport/birthdayreport.py:469
+#: ../gramps/plugins/textreport/birthdayreport.py:474
 #: ../gramps/plugins/webreport/webcal.py:1740
 msgid "Select married women's displayed surname"
 msgstr "Kies getoonde achternaam van de echtgenote"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:535
-#: ../gramps/plugins/textreport/birthdayreport.py:472
+#: ../gramps/plugins/textreport/birthdayreport.py:477
 #: ../gramps/plugins/webreport/webcal.py:1750
 msgid "Include birthdays"
 msgstr "Verjaardagen toevoegen"
@@ -20181,7 +20207,7 @@ msgstr "Verjaardagen toevoegen in de kalender"
 
 # Het gaat hier niet om verjaardagen
 #: ../gramps/plugins/drawreport/calendarreport.py:539
-#: ../gramps/plugins/textreport/birthdayreport.py:476
+#: ../gramps/plugins/textreport/birthdayreport.py:481
 #: ../gramps/plugins/webreport/webcal.py:1754
 msgid "Include anniversaries"
 msgstr "Jubilea toevoegen"
@@ -20195,13 +20221,13 @@ msgstr "Jubilea toevoegen in de kalender"
 #. #########################
 #: ../gramps/plugins/drawreport/calendarreport.py:544
 #: ../gramps/plugins/drawreport/calendarreport.py:545
-#: ../gramps/plugins/textreport/birthdayreport.py:487
+#: ../gramps/plugins/textreport/birthdayreport.py:490
 msgid "Text Options"
 msgstr "Tekstopties"
 
 #. #########################
 #: ../gramps/plugins/drawreport/calendarreport.py:548
-#: ../gramps/plugins/textreport/birthdayreport.py:493
+#: ../gramps/plugins/textreport/birthdayreport.py:496
 msgid "Text Area 1"
 msgstr "Tekstgebied 1"
 
@@ -20210,7 +20236,7 @@ msgid "First line of text at bottom of calendar"
 msgstr "Eerste tekstlijn onderaan de kalender"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:552
-#: ../gramps/plugins/textreport/birthdayreport.py:497
+#: ../gramps/plugins/textreport/birthdayreport.py:500
 msgid "Text Area 2"
 msgstr "Tekstgebied 2"
 
@@ -20219,7 +20245,7 @@ msgid "Second line of text at bottom of calendar"
 msgstr "Tweede tekstlijn onderaan de kalender"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:556
-#: ../gramps/plugins/textreport/birthdayreport.py:501
+#: ../gramps/plugins/textreport/birthdayreport.py:504
 msgid "Text Area 3"
 msgstr "Tekstgebied 3"
 
@@ -20248,17 +20274,17 @@ msgid "Days of the week text"
 msgstr "Tekst weekdagen"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:643
-#: ../gramps/plugins/textreport/birthdayreport.py:569
+#: ../gramps/plugins/textreport/birthdayreport.py:584
 msgid "Text at bottom, line 1"
 msgstr "Tekst onderaan, regel 1"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:645
-#: ../gramps/plugins/textreport/birthdayreport.py:571
+#: ../gramps/plugins/textreport/birthdayreport.py:586
 msgid "Text at bottom, line 2"
 msgstr "Tekst onderaan, regel 2"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:647
-#: ../gramps/plugins/textreport/birthdayreport.py:573
+#: ../gramps/plugins/textreport/birthdayreport.py:588
 msgid "Text at bottom, line 3"
 msgstr "Tekst onderaan, regel 3"
 
@@ -20330,31 +20356,31 @@ msgstr "De hoofdpersoon voor dit verslag"
 msgid "The main family for the report"
 msgstr "Het centrale gezin voor het verslag"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1538
-msgid "Start with the parent(s) of the selected first"
-msgstr "Met de ouder(s) van de geselecteerde persoon beginnen"
-
-#: ../gramps/plugins/drawreport/descendtree.py:1541
-msgid "Will show the parents, brother and sisters of the selected person."
-msgstr ""
-"De ouders, broers en zusters van de geselecteerde persoon worden getoond."
-
-#: ../gramps/plugins/drawreport/descendtree.py:1550
+#: ../gramps/plugins/drawreport/descendtree.py:1546
 msgid "Level of Spouses"
 msgstr "Niveau voor de echtgenoten"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1551
+#: ../gramps/plugins/drawreport/descendtree.py:1547
 msgid "0=no Spouses, 1=include Spouses, 2=include Spouses of the spouse, etc"
 msgstr ""
 "0=geen echtgenoten, 1=echtgenoten toevoegen, 2=partners van de echtgenoten, "
 "enz"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1556
+#: ../gramps/plugins/drawreport/descendtree.py:1552
+msgid "Start with the parent(s) of the selected first"
+msgstr "Met de ouder(s) van de geselecteerde persoon beginnen"
+
+#: ../gramps/plugins/drawreport/descendtree.py:1555
+msgid "Will show the parents, brother and sisters of the selected person."
+msgstr ""
+"De ouders, broers en zusters van de geselecteerde persoon worden getoond."
+
+#: ../gramps/plugins/drawreport/descendtree.py:1561
 msgid "Whether to move people up, where possible, resulting in a smaller tree"
 msgstr ""
 "Al of niet personen naar boven verschuiven om een kleinere boom te verkrijgen"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1565
+#: ../gramps/plugins/drawreport/descendtree.py:1568
 msgid ""
 "Descendant\n"
 "Display Format"
@@ -20362,15 +20388,15 @@ msgstr ""
 "Afstammeling\n"
 "Weergaveformaat"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1569
+#: ../gramps/plugins/drawreport/descendtree.py:1572
 msgid "Display format for a descendant."
 msgstr "Weergave van een afstammeling."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1572
+#: ../gramps/plugins/drawreport/descendtree.py:1575
 msgid "Bold direct descendants"
 msgstr "Rechtstreekse afstammelingen: vet"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1574
+#: ../gramps/plugins/drawreport/descendtree.py:1577
 msgid ""
 "Whether to bold those people that are direct (not step or half) descendants."
 msgstr ""
@@ -20383,15 +20409,15 @@ msgstr ""
 #. True)
 #. diffspouse.set_help(_("Whether spouses can have a different format."))
 #. menu.add_option(category_name, "diffspouse", diffspouse)
-#: ../gramps/plugins/drawreport/descendtree.py:1586
+#: ../gramps/plugins/drawreport/descendtree.py:1589
 msgid "Indent Spouses"
 msgstr "Echtgenoten laten inspringen"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1587
+#: ../gramps/plugins/drawreport/descendtree.py:1590
 msgid "Whether to indent the spouses in the tree."
 msgstr "De echtgenoten al of niet laten inspringen in de stamboom."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1590
+#: ../gramps/plugins/drawreport/descendtree.py:1593
 msgid ""
 "Spousal\n"
 "Display Format"
@@ -20399,38 +20425,38 @@ msgstr ""
 "Weergaveformaat\n"
 "partner"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1594
+#: ../gramps/plugins/drawreport/descendtree.py:1597
 msgid "Display format for a spouse."
 msgstr "Weergave van een echtgenoot."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1656
+#: ../gramps/plugins/drawreport/descendtree.py:1659
 msgid "inter-box Y scale factor"
 msgstr "Schaalfactor Y tussen de rechthoeken"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1658
+#: ../gramps/plugins/drawreport/descendtree.py:1661
 msgid "Make the inter-box Y bigger or smaller"
 msgstr "De Y tussen de rechthoeken groter of kleiner maken"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1672
-#: ../gramps/plugins/drawreport/descendtree.py:1727
+#: ../gramps/plugins/drawreport/descendtree.py:1675
+#: ../gramps/plugins/drawreport/descendtree.py:1730
 msgid "Descendant Chart for [selected person(s)]"
 msgstr "Afstammelingen van [geselecteerde perso(o)n(en)]"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1675
-#: ../gramps/plugins/drawreport/descendtree.py:1731
+#: ../gramps/plugins/drawreport/descendtree.py:1678
+#: ../gramps/plugins/drawreport/descendtree.py:1734
 msgid "Family Chart for [names of chosen family]"
 msgstr "Gezinskaart voor [namen van de gekozen gezinnen]"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1678
-#: ../gramps/plugins/drawreport/descendtree.py:1735
+#: ../gramps/plugins/drawreport/descendtree.py:1681
+#: ../gramps/plugins/drawreport/descendtree.py:1738
 msgid "Cousin Chart for [names of children]"
 msgstr "Neven en nichten grafiek voor [namen van de kinderen]"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1688
+#: ../gramps/plugins/drawreport/descendtree.py:1691
 msgid "Whether to include page numbers on each page."
 msgstr "Al of niet de paginanummers op elke pagina toevoegen."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1772
+#: ../gramps/plugins/drawreport/descendtree.py:1775
 msgid "The bold style used for the text display."
 msgstr "De gebruikte opmaak voor de tekstweergave van vetgedrukte tekst."
 
@@ -20539,89 +20565,103 @@ msgstr ""
 "%(generations)d generatiewaaier voor\n"
 "%(person)s"
 
-#: ../gramps/plugins/drawreport/fanchart.py:697
+#. Content options
+#. Content
+#: ../gramps/plugins/drawreport/fanchart.py:698
+#: ../gramps/plugins/textreport/birthdayreport.py:441
+#: ../gramps/plugins/textreport/descendreport.py:518
+#: ../gramps/plugins/textreport/detancestralreport.py:805
+#: ../gramps/plugins/textreport/detdescendantreport.py:1015
+#: ../gramps/plugins/textreport/kinshipreport.py:369
+#: ../gramps/plugins/textreport/placereport.py:442
+#: ../gramps/plugins/textreport/recordsreport.py:240
+#: ../gramps/plugins/view/relview.py:1726
+msgid "Content"
+msgstr "Inhoud"
+
+#: ../gramps/plugins/drawreport/fanchart.py:701
 #: ../gramps/plugins/textreport/ancestorreport.py:294
-#: ../gramps/plugins/textreport/descendreport.py:528
+#: ../gramps/plugins/textreport/descendreport.py:532
 #: ../gramps/plugins/textreport/detancestralreport.py:798
 #: ../gramps/plugins/textreport/detdescendantreport.py:1008
 msgid "The number of generations to include in the report"
 msgstr "Het aantal generaties dat in het verslag getoond wordt"
 
-#: ../gramps/plugins/drawreport/fanchart.py:701
+#: ../gramps/plugins/drawreport/fanchart.py:705
 msgid "Type of graph"
 msgstr "Soort grafiek"
 
-#: ../gramps/plugins/drawreport/fanchart.py:702
+#: ../gramps/plugins/drawreport/fanchart.py:706
 msgid "full circle"
 msgstr "volle cirkel"
 
-#: ../gramps/plugins/drawreport/fanchart.py:703
+#: ../gramps/plugins/drawreport/fanchart.py:707
 msgid "half circle"
 msgstr "halve cirkel"
 
-#: ../gramps/plugins/drawreport/fanchart.py:704
+#: ../gramps/plugins/drawreport/fanchart.py:708
 msgid "quarter circle"
 msgstr "kwart cirkel"
 
-#: ../gramps/plugins/drawreport/fanchart.py:705
+#: ../gramps/plugins/drawreport/fanchart.py:709
 msgid "The form of the graph: full circle, half circle, or quarter circle."
 msgstr "De grafiekvorm: hele cirkel, halve cirkel of kwart cirkel."
 
-#: ../gramps/plugins/drawreport/fanchart.py:711
+#: ../gramps/plugins/drawreport/fanchart.py:715
 msgid "generation dependent"
 msgstr "Generatie afhankelijk"
 
-#: ../gramps/plugins/drawreport/fanchart.py:712
+#: ../gramps/plugins/drawreport/fanchart.py:716
 msgid "Background color is either white or generation dependent"
 msgstr "De achtergrondkleur is ofwel wit, ofwel generatie-afhankelijk"
 
-#: ../gramps/plugins/drawreport/fanchart.py:716
+#: ../gramps/plugins/drawreport/fanchart.py:720
 msgid "Orientation of radial texts"
 msgstr "Richting van de radiaalteksten"
 
-#: ../gramps/plugins/drawreport/fanchart.py:718
+#: ../gramps/plugins/drawreport/fanchart.py:722
 msgid "upright"
 msgstr "rechtop"
 
-#: ../gramps/plugins/drawreport/fanchart.py:719
+#: ../gramps/plugins/drawreport/fanchart.py:723
 msgid "roundabout"
 msgstr "omstreeks"
 
-#: ../gramps/plugins/drawreport/fanchart.py:720
+#: ../gramps/plugins/drawreport/fanchart.py:724
 msgid "Print radial texts upright or roundabout"
 msgstr "Druk radiale teksten rechtop af, of in een ronde vorm"
 
-#: ../gramps/plugins/drawreport/fanchart.py:722
+#: ../gramps/plugins/drawreport/fanchart.py:726
 msgid "Draw empty boxes"
 msgstr "Lege rechthoeken tekenen"
 
-#: ../gramps/plugins/drawreport/fanchart.py:723
+#: ../gramps/plugins/drawreport/fanchart.py:727
 msgid "Draw the background although there is no information"
 msgstr "De achtergrong toch tekene ook zonder informatie"
 
-#: ../gramps/plugins/drawreport/fanchart.py:727
+#: ../gramps/plugins/drawreport/fanchart.py:731
 msgid "Use one font style for all generations"
 msgstr "Voor alle generaties hetzelfde lettertype gebruiken"
 
-#: ../gramps/plugins/drawreport/fanchart.py:729
+#: ../gramps/plugins/drawreport/fanchart.py:733
 msgid "You can customize font and color for each generation in the style editor"
 msgstr ""
 "U kunt de kleur en het lettertype voor elke generatie wijzigen in het scherm "
 "aanpassen stijlen"
 
-#: ../gramps/plugins/drawreport/fanchart.py:758
+#: ../gramps/plugins/drawreport/fanchart.py:760
 #: ../gramps/plugins/textreport/alphabeticalindex.py:103
-#: ../gramps/plugins/textreport/recordsreport.py:298
+#: ../gramps/plugins/textreport/recordsreport.py:309
 #: ../gramps/plugins/textreport/tableofcontents.py:102
 msgid "The style used for the title."
 msgstr "De gebruikte opmaak voor de titel."
 
-#: ../gramps/plugins/drawreport/fanchart.py:768
+#: ../gramps/plugins/drawreport/fanchart.py:770
 msgid "The basic style used for the default text display."
 msgstr "De gebruikte standaardopmaak voor de standaard tekstweergave."
 
 # Niet in de te vertalen tekst opgenomen, maar er komt nog een getal achter de tekst.
-#: ../gramps/plugins/drawreport/fanchart.py:779
+#: ../gramps/plugins/drawreport/fanchart.py:781
 #, python-format
 msgid "The style used for the text display of generation \"%d\""
 msgstr "De gebruikte opmaak voor de tekstweergave van generatie  \"%d\""
@@ -20814,6 +20854,7 @@ msgstr "Bepaalt welke personen toegevoegd worden aan het verslag."
 
 #: ../gramps/plugins/drawreport/statisticschart.py:994
 #: ../gramps/plugins/drawreport/timeline.py:423
+#: ../gramps/plugins/textreport/birthdayreport.py:423
 #: ../gramps/plugins/textreport/indivcomplete.py:1041
 #: ../gramps/plugins/textreport/recordsreport.py:224
 #: ../gramps/plugins/tool/sortevents.py:171
@@ -20823,6 +20864,7 @@ msgid "Filter Person"
 msgstr "Personenfilter"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:995
+#: ../gramps/plugins/textreport/birthdayreport.py:424
 #: ../gramps/plugins/textreport/indivcomplete.py:1042
 msgid "The center person for the filter."
 msgstr "De centrale persoon voor de filter."
@@ -20897,31 +20939,35 @@ msgstr ""
 "balkgrafiek."
 
 #: ../gramps/plugins/drawreport/statisticschart.py:1069
-msgid "Charts 1"
-msgstr "Eerste grafiek"
+msgid "Charts 3"
+msgstr "Grafiek 3"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:1071
 msgid "Charts 2"
 msgstr "Tweede grafiek"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:1073
+msgid "Charts 1"
+msgstr "Eerste grafiek"
+
+#: ../gramps/plugins/drawreport/statisticschart.py:1075
 msgid "Include charts with indicated data."
 msgstr "Grafieken toevoegen met de opgegeven datum."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1116
+#: ../gramps/plugins/drawreport/statisticschart.py:1117
 msgid "The style used for the items and values."
 msgstr "De gebruikte opmaak voor de items en waardes."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1125
+#: ../gramps/plugins/drawreport/statisticschart.py:1126
 #: ../gramps/plugins/drawreport/timeline.py:498
 #: ../gramps/plugins/textreport/ancestorreport.py:349
-#: ../gramps/plugins/textreport/descendreport.py:560
+#: ../gramps/plugins/textreport/descendreport.py:562
 #: ../gramps/plugins/textreport/detancestralreport.py:915
 #: ../gramps/plugins/textreport/detdescendantreport.py:1145
 #: ../gramps/plugins/textreport/endoflinereport.py:296
-#: ../gramps/plugins/textreport/familygroup.py:846
+#: ../gramps/plugins/textreport/familygroup.py:851
 #: ../gramps/plugins/textreport/indivcomplete.py:1172
-#: ../gramps/plugins/textreport/kinshipreport.py:401
+#: ../gramps/plugins/textreport/kinshipreport.py:403
 #: ../gramps/plugins/textreport/notelinkreport.py:178
 #: ../gramps/plugins/textreport/numberofancestorsreport.py:227
 #: ../gramps/plugins/textreport/simplebooktitle.py:171
@@ -21338,9 +21384,9 @@ msgid "No families matched by selected filter"
 msgstr "Geen gezinnen gevonden door het geselecteerde filter"
 
 #: ../gramps/plugins/export/exportpkg.py:179
-#: ../gramps/plugins/export/exportxml.py:136
-#: ../gramps/plugins/export/exportxml.py:152
-#: ../gramps/plugins/export/exportxml.py:170
+#: ../gramps/plugins/export/exportxml.py:139
+#: ../gramps/plugins/export/exportxml.py:155
+#: ../gramps/plugins/export/exportxml.py:173
 #, python-format
 msgid "Failure writing %s"
 msgstr "Schrijven van %s mislukt"
@@ -21370,7 +21416,7 @@ msgstr "Overlijden van %s"
 msgid "Anniversary: %s"
 msgstr "Verjaardag: %s"
 
-#: ../gramps/plugins/export/exportxml.py:137
+#: ../gramps/plugins/export/exportxml.py:140
 msgid ""
 "The database cannot be saved because you do not have permission to write to "
 "the directory. Please make sure you have write access to the directory and "
@@ -21380,7 +21426,7 @@ msgstr ""
 "naar de map te schrijven. Zorg dat u schrijftoegang krijgt tot de map en "
 "probeer dan opnieuw."
 
-#: ../gramps/plugins/export/exportxml.py:153
+#: ../gramps/plugins/export/exportxml.py:156
 msgid ""
 "The database cannot be saved because you do not have permission to write to "
 "the file. Please make sure you have write access to the file and try again."
@@ -22203,8 +22249,9 @@ msgstr "Gebeurtenisopmerkingen"
 msgid "Gramplet showing the notes for an event"
 msgstr "Gramplet die de opmerkingen van een gebeurtenis toont"
 
+#. #########################
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:690
-#: ../gramps/plugins/textreport/familygroup.py:775
+#: ../gramps/plugins/textreport/familygroup.py:773
 msgid "Family Notes"
 msgstr "Gezinsopmerkingen"
 
@@ -22641,8 +22688,8 @@ msgstr "Beweeg met de muis over de koppelingen voor opties"
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:58
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:67
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:78
-#: ../gramps/plugins/view/fanchartdescview.py:280
-#: ../gramps/plugins/view/fanchartview.py:276
+#: ../gramps/plugins/view/fanchartdescview.py:294
+#: ../gramps/plugins/view/fanchartview.py:290
 msgid "Max generations"
 msgstr "Max aantal generaties"
 
@@ -23592,7 +23639,7 @@ msgid "The Center person for the graph"
 msgstr "De centrale persoon voor deze grafiek"
 
 #: ../gramps/plugins/graph/gvhourglass.py:318
-#: ../gramps/plugins/textreport/kinshipreport.py:367
+#: ../gramps/plugins/textreport/kinshipreport.py:371
 msgid "Max Descendant Generations"
 msgstr "Maximum aantal afstammelingengeneraties"
 
@@ -23601,7 +23648,7 @@ msgid "The number of generations of descendants to include in the graph"
 msgstr "Het aantal nakomelingengeneraties dat opgenomen wordt in het verslag"
 
 #: ../gramps/plugins/graph/gvhourglass.py:323
-#: ../gramps/plugins/textreport/kinshipreport.py:371
+#: ../gramps/plugins/textreport/kinshipreport.py:375
 msgid "Max Ancestor Generations"
 msgstr "Max vooroudergeneraties"
 
@@ -23681,9 +23728,10 @@ msgid "Include (birth, marriage, death) places, but no dates"
 msgstr "Locaties (geboorte, trouw, overlijden) bijvoegen maar geen datums"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:709
-#, fuzzy
 msgid "Include (birth, marriage, death) dates and places on same line"
-msgstr "Datums van (geboorte, trouw en overlijden) bijvoegen en ook locaties"
+msgstr ""
+"Datums en locaties van (geboorte, trouw en overlijden) op dezelfde lijn "
+"toevoegen"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:712
 msgid "Whether to include dates and/or places"
@@ -23727,14 +23775,12 @@ msgid "Include occupation"
 msgstr "Beroep al dan niet bijvoegen"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:754
-#, fuzzy
 msgid "Do not include any occupation"
-msgstr "Geen titel toevoegen"
+msgstr "Geen beroep toevoegen"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:755
-#, fuzzy
 msgid "Include description of most recent occupation"
-msgstr "Broers en zussen van de centrale persoon toevoegen"
+msgstr "Beschrijving van het recentste beroep toevoegen"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:757
 msgid "Include date, description and place of all occupations"
@@ -24298,8 +24344,8 @@ msgstr ""
 #: ../gramps/plugins/importer/importgrdb.py:61
 #: ../gramps/plugins/importer/importprogen.py:74
 #: ../gramps/plugins/importer/importprogen.py:83
-#: ../gramps/plugins/importer/importxml.py:437
 #: ../gramps/plugins/importer/importxml.py:440
+#: ../gramps/plugins/importer/importxml.py:443
 #, python-format
 msgid "%s could not be opened"
 msgstr "%s kon niet worden geopend"
@@ -24392,14 +24438,13 @@ msgid "vCard import"
 msgstr "vCard import"
 
 #: ../gramps/plugins/importer/importvcard.py:252
-#, fuzzy
 msgid "VCARD import report: No errors detected"
-msgstr "GEDCOM importverslag: Geen fouten gevonden"
+msgstr "VCARD importverslag: Geen fouten gevonden"
 
 #: ../gramps/plugins/importer/importvcard.py:254
-#, fuzzy, python-format
+#, python-format
 msgid "VCARD import report: %s errors detected\n"
-msgstr "GEDCOM importverslag: %s fouten gevonden"
+msgstr "VCARD importverslag: %s fouten gevonden\n"
 
 #: ../gramps/plugins/importer/importvcard.py:319
 #, python-format
@@ -24635,26 +24680,26 @@ msgstr ""
 "Objecten die mogelijk samengevoegd kunnen worden:\n"
 
 #. there is no old style XML
-#: ../gramps/plugins/importer/importxml.py:805
-#: ../gramps/plugins/importer/importxml.py:1275
-#: ../gramps/plugins/importer/importxml.py:1548
-#: ../gramps/plugins/importer/importxml.py:1967
+#: ../gramps/plugins/importer/importxml.py:808
+#: ../gramps/plugins/importer/importxml.py:1278
+#: ../gramps/plugins/importer/importxml.py:1551
+#: ../gramps/plugins/importer/importxml.py:1970
 msgid "The Gramps Xml you are trying to import is malformed."
 msgstr "De Gramps-xml die u tracht te importeren heeft niet het juiste formaat."
 
-#: ../gramps/plugins/importer/importxml.py:806
+#: ../gramps/plugins/importer/importxml.py:809
 msgid "Attributes that link the data together are missing."
 msgstr "Kenmerken die de gegevens verbinden, ontbreken."
 
-#: ../gramps/plugins/importer/importxml.py:910
+#: ../gramps/plugins/importer/importxml.py:913
 msgid "Gramps XML import"
 msgstr "Gramps XML import"
 
-#: ../gramps/plugins/importer/importxml.py:945
+#: ../gramps/plugins/importer/importxml.py:948
 msgid "Could not change media path"
 msgstr "Kon mediapad niet veranderen"
 
-#: ../gramps/plugins/importer/importxml.py:946
+#: ../gramps/plugins/importer/importxml.py:949
 #, python-format
 msgid ""
 "The opened file has media path %s, which conflicts with the media path of the "
@@ -24666,7 +24711,7 @@ msgstr ""
 "behouden. Kopieer de bestanden naar een correcte map of verander het mediapad "
 "in het menu 'voorkeuren'."
 
-#: ../gramps/plugins/importer/importxml.py:1005
+#: ../gramps/plugins/importer/importxml.py:1008
 msgid ""
 "The .gramps file you are importing does not contain information about the "
 "version of Gramps with, which it was produced.\n"
@@ -24678,11 +24723,11 @@ msgstr ""
 "\n"
 "Het bestand wordt niet geïmporteerd."
 
-#: ../gramps/plugins/importer/importxml.py:1008
+#: ../gramps/plugins/importer/importxml.py:1011
 msgid "Import file misses Gramps version"
 msgstr "Importbestand mist een Gramps versie"
 
-#: ../gramps/plugins/importer/importxml.py:1010
+#: ../gramps/plugins/importer/importxml.py:1013
 #, python-format
 msgid ""
 "The .gramps file you are importing was made by version %(newer)s of Gramps, "
@@ -24694,7 +24739,7 @@ msgstr ""
 "niet worden geïmporteerd. U kunt best naar de meest recente Gramps-versie "
 "opwaarderen en dan opnieuw proberen."
 
-#: ../gramps/plugins/importer/importxml.py:1018
+#: ../gramps/plugins/importer/importxml.py:1021
 #, python-format
 msgid ""
 "The .gramps file you are importing was made by version %(oldgramps)s of "
@@ -24715,11 +24760,11 @@ msgstr ""
 "%(gramps_wiki_xml_url)s\n"
 "voor meer informatie."
 
-#: ../gramps/plugins/importer/importxml.py:1029
+#: ../gramps/plugins/importer/importxml.py:1032
 msgid "The file will not be imported"
 msgstr "Het bestand kon niet worden geïmporteerd"
 
-#: ../gramps/plugins/importer/importxml.py:1031
+#: ../gramps/plugins/importer/importxml.py:1034
 #, python-format
 msgid ""
 "The .gramps file you are importing was made by version %(oldgramps)s of "
@@ -24743,25 +24788,25 @@ msgstr ""
 "  %(gramps_wiki_xml_url)s\n"
 "voor meer informatie."
 
-#: ../gramps/plugins/importer/importxml.py:1044
+#: ../gramps/plugins/importer/importxml.py:1047
 msgid "Old xml file"
 msgstr "Een oud xml-bestand"
 
-#: ../gramps/plugins/importer/importxml.py:1196
-#: ../gramps/plugins/importer/importxml.py:2678
+#: ../gramps/plugins/importer/importxml.py:1199
+#: ../gramps/plugins/importer/importxml.py:2681
 #, python-format
 msgid "Witness name: %s"
 msgstr "Getuige naam: %s"
 
-#: ../gramps/plugins/importer/importxml.py:1276
+#: ../gramps/plugins/importer/importxml.py:1279
 msgid "Any event reference must have a 'hlink' attribute."
 msgstr "Alle gebeurtenisverwijzingen moeten een 'hlink' kenmerk hebben."
 
-#: ../gramps/plugins/importer/importxml.py:1549
+#: ../gramps/plugins/importer/importxml.py:1552
 msgid "Any person reference must have a 'hlink' attribute."
 msgstr "Alle persoonsverwijzingen moeten een 'hlink' kenmerk hebben."
 
-#: ../gramps/plugins/importer/importxml.py:1737
+#: ../gramps/plugins/importer/importxml.py:1740
 #, python-format
 msgid ""
 "Your Family Tree groups name \"%(key)s\" together with \"%(parent)s\", did "
@@ -24770,31 +24815,31 @@ msgstr ""
 "Uw stamboomgroepsnaam \"%(key)s\" samen met \"%(parent)s\" werd niet "
 "veranderd naar \"%(value)s\"."
 
-#: ../gramps/plugins/importer/importxml.py:1740
+#: ../gramps/plugins/importer/importxml.py:1743
 msgid "Gramps ignored a name grouping"
 msgstr "Gramps negeerde de \"namemap\" waarde"
 
-#: ../gramps/plugins/importer/importxml.py:1799
+#: ../gramps/plugins/importer/importxml.py:1802
 msgid "Unknown when imported"
 msgstr "Onbekend na importeren"
 
-#: ../gramps/plugins/importer/importxml.py:1968
+#: ../gramps/plugins/importer/importxml.py:1971
 msgid "Any note reference must have a 'hlink' attribute."
 msgstr "Alle opmerkingenverwijzingen moeten een 'hlink' kenmerk hebben."
 
 #. TRANSLATORS: leave the {date} and {xml} untranslated in the format string,
 #. but you may re-order them if needed.
-#: ../gramps/plugins/importer/importxml.py:2498
+#: ../gramps/plugins/importer/importxml.py:2501
 #, python-brace-format
 msgid "Invalid date {date} in XML {xml}, preserving XML as text"
 msgstr "Ongeldige datum {date} in XML {xml}, behoud van XML als tekst"
 
-#: ../gramps/plugins/importer/importxml.py:2548
+#: ../gramps/plugins/importer/importxml.py:2551
 #, python-format
 msgid "Witness comment: %s"
 msgstr "Getuige commentaar: %s"
 
-#: ../gramps/plugins/importer/importxml.py:3201
+#: ../gramps/plugins/importer/importxml.py:3204
 #, python-format
 msgid ""
 "Error: family '%(family)s' father '%(father)s' does not refer back to the "
@@ -24803,7 +24848,7 @@ msgstr ""
 "Fout: gezin '%(family)s' vader '%(father)s' verwijst niet naar het gezin "
 "terug. Verwijzing toegevoegd."
 
-#: ../gramps/plugins/importer/importxml.py:3217
+#: ../gramps/plugins/importer/importxml.py:3220
 #, python-format
 msgid ""
 "Error: family '%(family)s' mother '%(mother)s' does not refer back to the "
@@ -24812,7 +24857,7 @@ msgstr ""
 "Fout: gezin '%(family)s' moeder '%(mother)s' verwijst niet naar het gezin "
 "terug. Verwijzing toegevoegd."
 
-#: ../gramps/plugins/importer/importxml.py:3239
+#: ../gramps/plugins/importer/importxml.py:3242
 #, python-format
 msgid ""
 "Error: family '%(family)s' child '%(child)s' does not refer back to the "
@@ -24851,9 +24896,8 @@ msgid "Cause of Death"
 msgstr "Doodsoorzaak"
 
 #: ../gramps/plugins/lib/libgedcom.py:608
-#, fuzzy
 msgid "Employment"
-msgstr "Schenking"
+msgstr "Werk"
 
 #: ../gramps/plugins/lib/libgedcom.py:610
 msgid "Eye Color"
@@ -24885,9 +24929,8 @@ msgid "Ordinance"
 msgstr "Wijding"
 
 #: ../gramps/plugins/lib/libgedcom.py:619
-#, fuzzy
 msgid "Separation"
-msgstr "Afgezonderd"
+msgstr "Scheiding"
 
 #. Applies to Families
 #: ../gramps/plugins/lib/libgedcom.py:620
@@ -28672,8 +28715,8 @@ msgid "Delete Person (%s)"
 msgstr "Persoon verwijderen (%s)"
 
 #: ../gramps/plugins/lib/libpersonview.py:375
-#: ../gramps/plugins/view/pedigreeview.py:680
-#: ../gramps/plugins/view/relview.py:421
+#: ../gramps/plugins/view/pedigreeview.py:694
+#: ../gramps/plugins/view/relview.py:431
 msgid "Person Filter Editor"
 msgstr "Aanpassen personenfilter"
 
@@ -28957,9 +29000,9 @@ msgid "Bottom Right"
 msgstr "Rechtsonder"
 
 #: ../gramps/plugins/lib/maps/geography.py:308
-#: ../gramps/plugins/view/fanchart2wayview.py:177
-#: ../gramps/plugins/view/fanchartdescview.py:172
-#: ../gramps/plugins/view/fanchartview.py:168
+#: ../gramps/plugins/view/fanchart2wayview.py:191
+#: ../gramps/plugins/view/fanchartdescview.py:186
+#: ../gramps/plugins/view/fanchartview.py:182
 msgid "_Print..."
 msgstr "Afdrukken..."
 
@@ -29345,7 +29388,7 @@ msgid "Parent"
 msgstr "Ouder"
 
 #: ../gramps/plugins/quickview/all_relations.py:286
-#: ../gramps/plugins/view/relview.py:404
+#: ../gramps/plugins/view/relview.py:414
 #: ../gramps/plugins/webreport/narrativeweb.py:2728
 #: ../gramps/plugins/webreport/narrativeweb.py:2730
 #: ../gramps/plugins/webreport/narrativeweb.py:3260
@@ -30133,13 +30176,13 @@ msgid "Ahnentafel Report for %s"
 msgstr "Kwartierstaat voor %s"
 
 #: ../gramps/plugins/textreport/ancestorreport.py:297
-#: ../gramps/plugins/textreport/detancestralreport.py:801
+#: ../gramps/plugins/textreport/detancestralreport.py:840
 #: ../gramps/plugins/textreport/detdescendantreport.py:1051
 msgid "Page break between generations"
 msgstr "Nieuwe pagina bij volgende generatie"
 
 #: ../gramps/plugins/textreport/ancestorreport.py:299
-#: ../gramps/plugins/textreport/detancestralreport.py:803
+#: ../gramps/plugins/textreport/detancestralreport.py:842
 #: ../gramps/plugins/textreport/detdescendantreport.py:1053
 msgid "Whether to start a new page after each generation."
 msgstr "Al of niet een nieuwe pagina starten na iedere generatie."
@@ -30183,74 +30226,74 @@ msgid_plural "{person}, {age}{relation}"
 msgstr[0] "{person}, {age}{relation}"
 msgstr[1] "{person}, {age}{relation}"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:417
 #: ../gramps/plugins/textreport/birthdayreport.py:419
-msgid "Year of report"
-msgstr "Jaar voor verslag"
+#: ../gramps/plugins/textreport/familygroup.py:710
+#: ../gramps/plugins/textreport/indivcomplete.py:1037
+msgid "Select the filter to be applied to the report."
+msgstr "Kies een filter die gebruikt moet worden voor het verslag."
 
-#: ../gramps/plugins/textreport/birthdayreport.py:424
-msgid "Select filter to restrict people that appear on report"
-msgstr ""
-"Kies een filter om het aantal personen te beperken dat getoond wordt in het "
-"verslag"
-
-#: ../gramps/plugins/textreport/birthdayreport.py:440
+#: ../gramps/plugins/textreport/birthdayreport.py:434
 msgid "Include only living people in the report"
 msgstr "Enkel nog levende personen aan het verslag toevoegen"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:462
+#: ../gramps/plugins/textreport/birthdayreport.py:443
+#: ../gramps/plugins/textreport/birthdayreport.py:445
+msgid "Year of report"
+msgstr "Jaar voor verslag"
+
+#: ../gramps/plugins/textreport/birthdayreport.py:467
 msgid "Select the first day of the week for the report"
 msgstr "De eerste weekdag voor het verslag kiezen"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:473
+#: ../gramps/plugins/textreport/birthdayreport.py:478
 msgid "Include birthdays in the report"
 msgstr "Verjaardagen aan het verslag toevoegen"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:477
+#: ../gramps/plugins/textreport/birthdayreport.py:482
 msgid "Include anniversaries in the report"
 msgstr "Verjaardagen aan het verslag toevoegen"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:480
+#: ../gramps/plugins/textreport/birthdayreport.py:485
 msgid "Include relationships to center person"
 msgstr "Verwantschappen van de centrale persoon toevoegen"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:482
+#: ../gramps/plugins/textreport/birthdayreport.py:487
 msgid "Include relationships to center person (slower)"
 msgstr "Verwantschappen toevoegen van de centrale persoon (trager)"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:489
+#: ../gramps/plugins/textreport/birthdayreport.py:492
 msgid "Title text"
 msgstr "Titel tekst"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:490
+#: ../gramps/plugins/textreport/birthdayreport.py:493
 msgid "Title of report"
 msgstr "Titel van het verslag"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:494
+#: ../gramps/plugins/textreport/birthdayreport.py:497
 msgid "First line of text at bottom of report"
 msgstr "Eerste tekstlijn onderaan het verslag"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:498
+#: ../gramps/plugins/textreport/birthdayreport.py:501
 msgid "Second line of text at bottom of report"
 msgstr "Tweede tekstlijn onderaan het verslag"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:502
+#: ../gramps/plugins/textreport/birthdayreport.py:505
 msgid "Third line of text at bottom of report"
 msgstr "Derde tekstlijn onderaan het verslag"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:559
+#: ../gramps/plugins/textreport/birthdayreport.py:574
 msgid "Title text style"
 msgstr "Opmaak titel"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:562
+#: ../gramps/plugins/textreport/birthdayreport.py:577
 msgid "Data text display"
 msgstr "Gegevens tekstweergave"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:564
+#: ../gramps/plugins/textreport/birthdayreport.py:579
 msgid "Day text style"
 msgstr "Opmaak dag"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:567
+#: ../gramps/plugins/textreport/birthdayreport.py:582
 msgid "Month text style"
 msgstr "Opmaak maand"
 
@@ -30314,73 +30357,73 @@ msgstr "echtgt. zie  %(reference)s: %(spouse)s"
 msgid "%s sp."
 msgstr "%s echtgt."
 
-#: ../gramps/plugins/textreport/descendreport.py:516
+#: ../gramps/plugins/textreport/descendreport.py:520
 #: ../gramps/plugins/textreport/detdescendantreport.py:988
 msgid "Numbering system"
 msgstr "Nummersysteem"
 
-#: ../gramps/plugins/textreport/descendreport.py:518
+#: ../gramps/plugins/textreport/descendreport.py:522
 msgid "Simple numbering"
 msgstr "Eenvoudige nummering"
 
-#: ../gramps/plugins/textreport/descendreport.py:519
+#: ../gramps/plugins/textreport/descendreport.py:523
 #: ../gramps/plugins/textreport/detdescendantreport.py:992
 msgid "d'Aboville numbering"
 msgstr "d'Aboville nummering"
 
-#: ../gramps/plugins/textreport/descendreport.py:520
+#: ../gramps/plugins/textreport/descendreport.py:524
 #: ../gramps/plugins/textreport/detdescendantreport.py:990
 msgid "Henry numbering"
 msgstr "Henry-nummering"
 
-#: ../gramps/plugins/textreport/descendreport.py:521
+#: ../gramps/plugins/textreport/descendreport.py:525
 #: ../gramps/plugins/textreport/detdescendantreport.py:991
 msgid "Modified Henry numbering"
 msgstr "Aangepaste Henry-nummering"
 
-#: ../gramps/plugins/textreport/descendreport.py:522
+#: ../gramps/plugins/textreport/descendreport.py:526
 msgid "de Villiers/Pama numbering"
 msgstr "de Villiers/Pama nummering"
 
-#: ../gramps/plugins/textreport/descendreport.py:523
+#: ../gramps/plugins/textreport/descendreport.py:527
 msgid "Meurgey de Tupigny numbering"
 msgstr "Meurgey de Tupigny nummering"
 
-#: ../gramps/plugins/textreport/descendreport.py:524
+#: ../gramps/plugins/textreport/descendreport.py:528
 #: ../gramps/plugins/textreport/detdescendantreport.py:995
 msgid "The numbering system to be used"
 msgstr "Welk nummersysteem gebruikt wordt"
 
-#: ../gramps/plugins/textreport/descendreport.py:531
+#: ../gramps/plugins/textreport/descendreport.py:535
 msgid "Show marriage info"
 msgstr "Gegevens huwelijk tonen"
 
-#: ../gramps/plugins/textreport/descendreport.py:533
+#: ../gramps/plugins/textreport/descendreport.py:537
 msgid "Whether to show marriage information in the report."
 msgstr "Al of niet de huwelijksinformatie in het verslag toevoegen."
 
-#: ../gramps/plugins/textreport/descendreport.py:536
+#: ../gramps/plugins/textreport/descendreport.py:540
 msgid "Show divorce info"
 msgstr "Gegevens scheiding tonen"
 
-#: ../gramps/plugins/textreport/descendreport.py:537
+#: ../gramps/plugins/textreport/descendreport.py:541
 msgid "Whether to show divorce information in the report."
 msgstr "Al of niet de scheidingsinformatie in het verslag toevoegen."
 
-#: ../gramps/plugins/textreport/descendreport.py:540
+#: ../gramps/plugins/textreport/descendreport.py:544
 msgid "Show duplicate trees"
 msgstr "Dubbele stambomen tonen"
 
-#: ../gramps/plugins/textreport/descendreport.py:542
+#: ../gramps/plugins/textreport/descendreport.py:546
 msgid "Whether to show duplicate Family Trees in the report."
 msgstr "Al of niet dubbele stambomen in het verslag tonen."
 
-#: ../gramps/plugins/textreport/descendreport.py:574
+#: ../gramps/plugins/textreport/descendreport.py:576
 #, python-format
 msgid "The style used for the level %d display."
 msgstr "De gebruikte opmaak voor de weergave van niveau %d."
 
-#: ../gramps/plugins/textreport/descendreport.py:585
+#: ../gramps/plugins/textreport/descendreport.py:587
 #, python-format
 msgid "The style used for the spouse level %d display."
 msgstr "De gebruikte opmaak voor de weergave van echtgenoot niveau %d."
@@ -30502,98 +30545,90 @@ msgstr "Sosa-Stradonitz nummer"
 msgid "The Sosa-Stradonitz number of the central person."
 msgstr "Het Sosa-Stradonitz nummer van de centrale persoon."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:806
-#: ../gramps/plugins/textreport/detdescendantreport.py:1056
-#: ../gramps/plugins/textreport/indivcomplete.py:1059
-msgid "Page break before end notes"
-msgstr "Nieuwe pagina voor de eindopmerkingen"
-
-#: ../gramps/plugins/textreport/detancestralreport.py:808
-#: ../gramps/plugins/textreport/detdescendantreport.py:1058
-#: ../gramps/plugins/textreport/indivcomplete.py:1061
-msgid "Whether to start a new page before the end notes."
-msgstr "Al of niet een nieuwe pagina starten voor de eindopmerkingen."
-
-#. Content options
-#. Content
-#: ../gramps/plugins/textreport/detancestralreport.py:815
-#: ../gramps/plugins/textreport/detdescendantreport.py:1015
-#: ../gramps/plugins/view/relview.py:1716
-msgid "Content"
-msgstr "Inhoud"
-
-#: ../gramps/plugins/textreport/detancestralreport.py:817
+#: ../gramps/plugins/textreport/detancestralreport.py:807
 #: ../gramps/plugins/textreport/detdescendantreport.py:1017
 msgid "Use callname for common name"
 msgstr "Gebruik roepnaam voor gewone naam"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:818
+#: ../gramps/plugins/textreport/detancestralreport.py:808
 #: ../gramps/plugins/textreport/detdescendantreport.py:1019
 msgid "Whether to use the call name as the first name."
 msgstr "De roepnaam al of niet gebruiken als voornaam."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:822
+#: ../gramps/plugins/textreport/detancestralreport.py:812
 #: ../gramps/plugins/textreport/detdescendantreport.py:1023
 msgid "Use full dates instead of only the year"
 msgstr "Volledige datums gebruiken in plaats van alleen het jaar"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:824
+#: ../gramps/plugins/textreport/detancestralreport.py:814
 #: ../gramps/plugins/textreport/detdescendantreport.py:1025
 msgid "Whether to use full dates instead of just year."
 msgstr "Volledige datums gebruiken in plaats van alleen het jaar."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:827
+#: ../gramps/plugins/textreport/detancestralreport.py:817
 #: ../gramps/plugins/textreport/detdescendantreport.py:1028
 msgid "List children"
 msgstr "Kinderen opsommen"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:828
+#: ../gramps/plugins/textreport/detancestralreport.py:818
 #: ../gramps/plugins/textreport/detdescendantreport.py:1029
 msgid "Whether to list children."
 msgstr "Kinderen al of niet oplijsten."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:831
+#: ../gramps/plugins/textreport/detancestralreport.py:821
 #: ../gramps/plugins/textreport/detdescendantreport.py:1032
 msgid "Compute death age"
 msgstr "Leeftijd bij overlijden berekenen"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:832
+#: ../gramps/plugins/textreport/detancestralreport.py:822
 #: ../gramps/plugins/textreport/detdescendantreport.py:1033
 msgid "Whether to compute a person's age at death."
 msgstr "Al dan niet de leeftijd bij overlijden berekenen."
 
 # Duplicaat-voorouders
-#: ../gramps/plugins/textreport/detancestralreport.py:835
+#: ../gramps/plugins/textreport/detancestralreport.py:825
 #: ../gramps/plugins/textreport/detdescendantreport.py:1036
 msgid "Omit duplicate ancestors"
 msgstr "Voorouder-duplicaten weglaten"
 
 # Duplicaat-voorouders
-#: ../gramps/plugins/textreport/detancestralreport.py:836
+#: ../gramps/plugins/textreport/detancestralreport.py:826
 #: ../gramps/plugins/textreport/detdescendantreport.py:1037
 msgid "Whether to omit duplicate ancestors."
 msgstr "Al of niet voorouderduplicaten weglaten."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:839
+#: ../gramps/plugins/textreport/detancestralreport.py:829
 msgid "Use Complete Sentences"
 msgstr "Gebruik volledige zinnen"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:841
+#: ../gramps/plugins/textreport/detancestralreport.py:831
 #: ../gramps/plugins/textreport/detdescendantreport.py:1042
 msgid "Whether to use complete sentences or succinct language."
 msgstr "Beknopte vorm gebruiken of volledige zinnen."
 
 # Opnemen ipv toevoegen
-#: ../gramps/plugins/textreport/detancestralreport.py:845
+#: ../gramps/plugins/textreport/detancestralreport.py:835
 #: ../gramps/plugins/textreport/detdescendantreport.py:1045
 msgid "Add descendant reference in child list"
 msgstr "Afstammeling-verwijzingen in kinderenlijst toevoegen"
 
 # Opnemen ipv toevoegen
-#: ../gramps/plugins/textreport/detancestralreport.py:847
+#: ../gramps/plugins/textreport/detancestralreport.py:837
 #: ../gramps/plugins/textreport/detdescendantreport.py:1048
 msgid "Whether to add descendant references in child list."
 msgstr "Al of niet afstammelingverwijzingen in kinderenlijst toevoegen."
+
+#: ../gramps/plugins/textreport/detancestralreport.py:845
+#: ../gramps/plugins/textreport/detdescendantreport.py:1056
+#: ../gramps/plugins/textreport/indivcomplete.py:1059
+msgid "Page break before end notes"
+msgstr "Nieuwe pagina voor de eindopmerkingen"
+
+#: ../gramps/plugins/textreport/detancestralreport.py:847
+#: ../gramps/plugins/textreport/detdescendantreport.py:1058
+#: ../gramps/plugins/textreport/indivcomplete.py:1061
+msgid "Whether to start a new page before the end notes."
+msgstr "Al of niet een nieuwe pagina starten voor de eindopmerkingen."
 
 #: ../gramps/plugins/textreport/detancestralreport.py:854
 #: ../gramps/plugins/textreport/detdescendantreport.py:1072
@@ -30612,7 +30647,7 @@ msgstr "Kenmerken bijvoegen"
 
 #: ../gramps/plugins/textreport/detancestralreport.py:859
 #: ../gramps/plugins/textreport/detdescendantreport.py:1092
-#: ../gramps/plugins/textreport/familygroup.py:762
+#: ../gramps/plugins/textreport/familygroup.py:756
 #: ../gramps/plugins/textreport/indivcomplete.py:1088
 msgid "Whether to include attributes."
 msgstr "Al of niet kenmerken toevoegen."
@@ -30788,7 +30823,7 @@ msgid "Use complete sentences"
 msgstr "Gebruik volledige zinnen"
 
 #: ../gramps/plugins/textreport/detdescendantreport.py:1076
-#: ../gramps/plugins/textreport/kinshipreport.py:375
+#: ../gramps/plugins/textreport/kinshipreport.py:379
 msgid "Include spouses"
 msgstr "Echtgenoten bijvoegen"
 
@@ -30888,11 +30923,6 @@ msgstr "Familie groepsverslag - Generatie %d"
 msgid "Family Group Report"
 msgstr "Familie groepsverslag"
 
-#: ../gramps/plugins/textreport/familygroup.py:710
-#: ../gramps/plugins/textreport/indivcomplete.py:1037
-msgid "Select the filter to be applied to the report."
-msgstr "Kies een filter die gebruikt moet worden voor het verslag."
-
 #: ../gramps/plugins/textreport/familygroup.py:714
 msgid "Center Family"
 msgstr "Centraal gezin"
@@ -30909,106 +30939,117 @@ msgstr "Recursief (naar onder)"
 msgid "Create reports for all descendants of this family."
 msgstr "Verslagen aanmaken voor alle afstammelingen van dit gezin."
 
+#. #########################
+#: ../gramps/plugins/textreport/familygroup.py:736
+msgid "Include 1"
+msgstr "Bijvoegen 1"
+
 #: ../gramps/plugins/textreport/familygroup.py:740
 #: ../gramps/plugins/textreport/indivcomplete.py:1096
 msgid "Whether to include Gramps ID next to names."
 msgstr "Al of niet de Gramps-ID naast de namen toevoegen."
 
 #: ../gramps/plugins/textreport/familygroup.py:743
+msgid "Parent Events"
+msgstr "Gebeurtenissen ouders"
+
+#: ../gramps/plugins/textreport/familygroup.py:744
+msgid "Whether to include events for parents."
+msgstr "Al of niet gebeurtenissen van de ouders toevoegen."
+
+#: ../gramps/plugins/textreport/familygroup.py:747
+msgid "Parent Addresses"
+msgstr "Adressen ouders"
+
+#: ../gramps/plugins/textreport/familygroup.py:748
+msgid "Whether to include addresses for parents."
+msgstr "Al of niet adressen van de ouders toevoegen."
+
+#: ../gramps/plugins/textreport/familygroup.py:751
+msgid "Parent Notes"
+msgstr "Opmerkingen ouders"
+
+#: ../gramps/plugins/textreport/familygroup.py:752
+msgid "Whether to include notes for parents."
+msgstr "Al of niet opmerkingen i.v.m. de ouders toevoegen."
+
+#: ../gramps/plugins/textreport/familygroup.py:755
+msgid "Parent Attributes"
+msgstr "Ouderkenmerken"
+
+#: ../gramps/plugins/textreport/familygroup.py:759
+msgid "Alternate Parent Names"
+msgstr "Alternatieve oudernamen"
+
+#: ../gramps/plugins/textreport/familygroup.py:761
+msgid "Whether to include alternate names for parents."
+msgstr "Al of niet alterantieve namen van de ouders toevoegen."
+
+#: ../gramps/plugins/textreport/familygroup.py:764
+msgid "Parent Marriage"
+msgstr "Huwelijk ouder"
+
+#: ../gramps/plugins/textreport/familygroup.py:766
+msgid "Whether to include marriage information for parents."
+msgstr "Al of niet de huwelijksinformatie van de ouders toevoegen."
+
+#. #########################
+#: ../gramps/plugins/textreport/familygroup.py:770
+msgid "Include 2"
+msgstr "Bijvoegen 2"
+
+#: ../gramps/plugins/textreport/familygroup.py:774
+msgid "Whether to include notes for families."
+msgstr "Al of niet opmerkingen ivan de families toevoegen."
+
+#: ../gramps/plugins/textreport/familygroup.py:777
+msgid "Dates of Relatives"
+msgstr "Datums van de verwanten"
+
+#: ../gramps/plugins/textreport/familygroup.py:778
+msgid "Whether to include dates for relatives (father, mother, spouse)."
+msgstr ""
+"Al of niet de datums van verwanten [vader, moeder, echtgeno(o)t(e)] toevoegen."
+
+#: ../gramps/plugins/textreport/familygroup.py:782
+msgid "Children Marriages"
+msgstr "Huwelijken van de kinderen"
+
+#: ../gramps/plugins/textreport/familygroup.py:784
+msgid "Whether to include marriage information for children."
+msgstr "Al of niet de huwelijksinformatie van de kinderen toevoegen."
+
+#: ../gramps/plugins/textreport/familygroup.py:787
 msgid "Generation numbers (recursive only)"
 msgstr "Generatie nummering (enkel recursief)"
 
-#: ../gramps/plugins/textreport/familygroup.py:745
+#: ../gramps/plugins/textreport/familygroup.py:789
 msgid "Whether to include the generation on each report (recursive only)."
 msgstr ""
 "Al of niet de generatie toevoegen aan ieder verslag (enkel bij optie "
 "recursief)."
 
-#: ../gramps/plugins/textreport/familygroup.py:749
-msgid "Parent Events"
-msgstr "Gebeurtenissen ouders"
-
-#: ../gramps/plugins/textreport/familygroup.py:750
-msgid "Whether to include events for parents."
-msgstr "Al of niet gebeurtenissen van de ouders toevoegen."
-
-#: ../gramps/plugins/textreport/familygroup.py:753
-msgid "Parent Addresses"
-msgstr "Adressen ouders"
-
-#: ../gramps/plugins/textreport/familygroup.py:754
-msgid "Whether to include addresses for parents."
-msgstr "Al of niet adressen van de ouders toevoegen."
-
-#: ../gramps/plugins/textreport/familygroup.py:757
-msgid "Parent Notes"
-msgstr "Opmerkingen ouders"
-
-#: ../gramps/plugins/textreport/familygroup.py:758
-msgid "Whether to include notes for parents."
-msgstr "Al of niet opmerkingen i.v.m. de ouders toevoegen."
-
-#: ../gramps/plugins/textreport/familygroup.py:761
-msgid "Parent Attributes"
-msgstr "Ouderkenmerken"
-
-#: ../gramps/plugins/textreport/familygroup.py:765
-msgid "Alternate Parent Names"
-msgstr "Alternatieve oudernamen"
-
-#: ../gramps/plugins/textreport/familygroup.py:767
-msgid "Whether to include alternate names for parents."
-msgstr "Al of niet alterantieve namen van de ouders toevoegen."
-
-#: ../gramps/plugins/textreport/familygroup.py:770
-msgid "Parent Marriage"
-msgstr "Huwelijk ouder"
-
-#: ../gramps/plugins/textreport/familygroup.py:772
-msgid "Whether to include marriage information for parents."
-msgstr "Al of niet de huwelijksinformatie van de ouders toevoegen."
-
-#: ../gramps/plugins/textreport/familygroup.py:776
-msgid "Whether to include notes for families."
-msgstr "Al of niet opmerkingen ivan de families toevoegen."
-
-#: ../gramps/plugins/textreport/familygroup.py:779
-msgid "Dates of Relatives"
-msgstr "Datums van de verwanten"
-
-#: ../gramps/plugins/textreport/familygroup.py:780
-msgid "Whether to include dates for relatives (father, mother, spouse)."
-msgstr ""
-"Al of niet de datums van verwanten [vader, moeder, echtgeno(o)t(e)] toevoegen."
-
-#: ../gramps/plugins/textreport/familygroup.py:784
-msgid "Children Marriages"
-msgstr "Huwelijken van de kinderen"
-
-#: ../gramps/plugins/textreport/familygroup.py:786
-msgid "Whether to include marriage information for children."
-msgstr "Al of niet de huwelijksinformatie van de kinderen toevoegen."
-
+#. TODO make insensitive if ...
 #. #########################
-#: ../gramps/plugins/textreport/familygroup.py:790
+#: ../gramps/plugins/textreport/familygroup.py:794
 msgid "Missing Information"
 msgstr "Ontbrekende informatie"
 
 #. #########################
-#: ../gramps/plugins/textreport/familygroup.py:793
+#: ../gramps/plugins/textreport/familygroup.py:797
 msgid "Print fields for missing information"
 msgstr "Druk velden af voor ontbrekende informatie"
 
-#: ../gramps/plugins/textreport/familygroup.py:795
+#: ../gramps/plugins/textreport/familygroup.py:799
 msgid "Whether to include fields for missing information."
 msgstr "Al of niet velden voorzien voor ontbrekende informatie."
 
 # related to?
-#: ../gramps/plugins/textreport/familygroup.py:877
+#: ../gramps/plugins/textreport/familygroup.py:882
 msgid "The style used for the text related to the children."
 msgstr "De gebruikte opmaak voor de tekst verbonden met de kinderen."
 
-#: ../gramps/plugins/textreport/familygroup.py:887
+#: ../gramps/plugins/textreport/familygroup.py:892
 msgid "The style used for the parent's name"
 msgstr "De gebruikte opmaak voor de naam van de ouders"
 
@@ -31078,9 +31119,8 @@ msgid "Include Attributes"
 msgstr "Kenmerken bijvoegen"
 
 #: ../gramps/plugins/textreport/indivcomplete.py:1091
-#, fuzzy
 msgid "Include Census Events"
-msgstr "Gebeurtenissen bijvoegen"
+msgstr "Census-gebeurtenissen bijvoegen"
 
 #: ../gramps/plugins/textreport/indivcomplete.py:1092
 msgid "Whether to include Census Events."
@@ -31139,36 +31179,36 @@ msgstr "Een gebruikte opmaak voor beelden."
 msgid "Kinship Report for %s"
 msgstr "Verwantschapsverslag voor %s"
 
-#: ../gramps/plugins/textreport/kinshipreport.py:368
+#: ../gramps/plugins/textreport/kinshipreport.py:372
 msgid "The maximum number of descendant generations"
 msgstr "Het maximum aantal afstammelingengeneraties"
 
-#: ../gramps/plugins/textreport/kinshipreport.py:372
+#: ../gramps/plugins/textreport/kinshipreport.py:376
 msgid "The maximum number of ancestor generations"
 msgstr "Het maximum aantal vooroudergeneraties"
 
-#: ../gramps/plugins/textreport/kinshipreport.py:376
+#: ../gramps/plugins/textreport/kinshipreport.py:380
 msgid "Whether to include spouses"
 msgstr "Al of niet echtgenoten toevoegen"
 
-#: ../gramps/plugins/textreport/kinshipreport.py:379
+#: ../gramps/plugins/textreport/kinshipreport.py:383
 msgid "Include cousins"
 msgstr "Neven bijvoegen"
 
-#: ../gramps/plugins/textreport/kinshipreport.py:380
+#: ../gramps/plugins/textreport/kinshipreport.py:384
 msgid "Whether to include cousins"
 msgstr "Neven bijvoegen"
 
 # nonkel is spreektaal in België, http://www.vrt.be/taal/taalmail-326-350
-#: ../gramps/plugins/textreport/kinshipreport.py:383
+#: ../gramps/plugins/textreport/kinshipreport.py:387
 msgid "Include aunts/uncles/nephews/nieces"
 msgstr "Meenemen van tantes/ooms/neven/nichten"
 
-#: ../gramps/plugins/textreport/kinshipreport.py:384
+#: ../gramps/plugins/textreport/kinshipreport.py:388
 msgid "Whether to include aunts/uncles/nephews/nieces"
 msgstr "Al of niet tantes/ooms/neven/nichten toevoegen"
 
-#: ../gramps/plugins/textreport/kinshipreport.py:411
+#: ../gramps/plugins/textreport/kinshipreport.py:413
 #: ../gramps/plugins/textreport/summary.py:320
 msgid "The basic style used for sub-headings."
 msgstr "De gebruikte standaardopmaak voor de ondertitels."
@@ -31277,58 +31317,58 @@ msgstr "Personen verbonden met deze locatie"
 msgid "%(father)s (%(father_id)s) and %(mother)s (%(mother_id)s)"
 msgstr "%(father)s (%(father_id)s) en %(mother)s (%(mother_id)s)"
 
-#: ../gramps/plugins/textreport/placereport.py:438
+#: ../gramps/plugins/textreport/placereport.py:448
 msgid "Select using filter"
 msgstr "Filter gebruiken selecteren"
 
-#: ../gramps/plugins/textreport/placereport.py:439
+#: ../gramps/plugins/textreport/placereport.py:449
 msgid "Select places using a filter"
 msgstr "Locaties selecteren door middel van een filter"
 
-#: ../gramps/plugins/textreport/placereport.py:446
+#: ../gramps/plugins/textreport/placereport.py:456
 msgid "Select places individually"
 msgstr "Locaties afzonderlijk selecteren"
 
-#: ../gramps/plugins/textreport/placereport.py:447
+#: ../gramps/plugins/textreport/placereport.py:457
 msgid "List of places to report on"
 msgstr "Lijst van de locaties waarvoor een verslag wordt aangemaakt"
 
-#: ../gramps/plugins/textreport/placereport.py:456
+#: ../gramps/plugins/textreport/placereport.py:460
 msgid "Center on"
 msgstr "Centreren op"
 
-#: ../gramps/plugins/textreport/placereport.py:458
+#: ../gramps/plugins/textreport/placereport.py:462
 msgid "If report is event or person centered"
 msgstr "Verslag is ofwel gebeurtenis gebaseerd op op een persoon gebaseerd"
 
-#: ../gramps/plugins/textreport/placereport.py:491
+#: ../gramps/plugins/textreport/placereport.py:493
 msgid "The style used for the title of the report."
 msgstr "De gebruikte opmaak voor de titel van het verslag."
 
-#: ../gramps/plugins/textreport/placereport.py:506
-#: ../gramps/plugins/textreport/recordsreport.py:308
+#: ../gramps/plugins/textreport/placereport.py:508
+#: ../gramps/plugins/textreport/recordsreport.py:319
 #: ../gramps/plugins/textreport/simplebooktitle.py:181
 #: ../gramps/plugins/textreport/tagreport.py:944
 msgid "The style used for the subtitle."
 msgstr "De gebruikte opmaak voor de ondertitel."
 
-#: ../gramps/plugins/textreport/placereport.py:520
+#: ../gramps/plugins/textreport/placereport.py:522
 msgid "The style used for place title."
 msgstr "De gebruikte opmaak voor locatietitel."
 
-#: ../gramps/plugins/textreport/placereport.py:532
+#: ../gramps/plugins/textreport/placereport.py:534
 msgid "The style used for place details."
 msgstr "De gebruikte opmaak voor de locatiedetails."
 
-#: ../gramps/plugins/textreport/placereport.py:544
+#: ../gramps/plugins/textreport/placereport.py:546
 msgid "The style used for a column title."
 msgstr "De gebruikte opmaak voor de kolomhoofding."
 
-#: ../gramps/plugins/textreport/placereport.py:558
+#: ../gramps/plugins/textreport/placereport.py:560
 msgid "The style used for each section."
 msgstr "De gebruikte opmaak voor iedere sectie."
 
-#: ../gramps/plugins/textreport/placereport.py:589
+#: ../gramps/plugins/textreport/placereport.py:591
 msgid "The style used for event and person details."
 msgstr "De gebruikte opmaak voor de gebeurtenissen- en personendetails."
 
@@ -31337,43 +31377,47 @@ msgstr "De gebruikte opmaak voor de gebeurtenissen- en personendetails."
 msgid "%(number)s. "
 msgstr "%(number)s. "
 
-#: ../gramps/plugins/textreport/recordsreport.py:238
+#: ../gramps/plugins/textreport/recordsreport.py:242
 msgid "Number of ranks to display"
 msgstr "Aantal rijen dat getoond wordt"
 
-#: ../gramps/plugins/textreport/recordsreport.py:241
+#: ../gramps/plugins/textreport/recordsreport.py:245
 msgid "Use call name"
 msgstr "Gebruik roepnaam"
 
-#: ../gramps/plugins/textreport/recordsreport.py:243
+#: ../gramps/plugins/textreport/recordsreport.py:247
 msgid "Don't use call name"
 msgstr "Gebruik de roepnaam niet"
 
-#: ../gramps/plugins/textreport/recordsreport.py:244
+#: ../gramps/plugins/textreport/recordsreport.py:248
 msgid "Replace first names with call name"
 msgstr "De voornaam door de roepnaam vervangen"
 
-#: ../gramps/plugins/textreport/recordsreport.py:246
+#: ../gramps/plugins/textreport/recordsreport.py:250
 msgid "Underline call name in first names / add call name to first name"
 msgstr "Onderstreep roepnaam in de voornaam / voeg roepnaam aan voornaam toe"
 
-#: ../gramps/plugins/textreport/recordsreport.py:250
+#: ../gramps/plugins/textreport/recordsreport.py:254
 msgid "Footer text"
 msgstr "Voetnoot"
 
-#: ../gramps/plugins/textreport/recordsreport.py:258
-msgid "Person Records"
-msgstr "Persoonsgegevens"
+#: ../gramps/plugins/textreport/recordsreport.py:267
+msgid "Person Records 2"
+msgstr "Persoonsgegevens 2"
 
-#: ../gramps/plugins/textreport/recordsreport.py:260
+#: ../gramps/plugins/textreport/recordsreport.py:269
+msgid "Person Records 1"
+msgstr "Persoonsgegevens 1"
+
+#: ../gramps/plugins/textreport/recordsreport.py:272
 msgid "Family Records"
 msgstr "Gezinsgegevens"
 
-#: ../gramps/plugins/textreport/recordsreport.py:317
+#: ../gramps/plugins/textreport/recordsreport.py:328
 msgid "The style used for headings."
 msgstr "De gebruikte opmaak voor de hoofding."
 
-#: ../gramps/plugins/textreport/recordsreport.py:335
+#: ../gramps/plugins/textreport/recordsreport.py:346
 #: ../gramps/plugins/textreport/simplebooktitle.py:191
 msgid "The style used for the footer."
 msgstr "De gebruikte opmaak voor de voettekst."
@@ -32035,11 +32079,11 @@ msgstr[1] "{quantity} gecorrumpeerde gezinsrelaties herstekd\n"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2442
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "{quantity} place alternate name fixed\n"
 msgid_plural "{quantity} place alternate names fixed\n"
-msgstr[0] "{quantity}  ongeldige sterfgeval werd verbeterd\n"
-msgstr[1] "{quantity}  ongeldige sterfgevallen werden verbeterd\n"
+msgstr[0] "{quantity}  alternatieve locatienaam verbeterd\n"
+msgstr[1] "{quantity}  alternatieve locatienamen verbeterd\n"
 
 #: ../gramps/plugins/tool/check.py:2451
 #, python-brace-format
@@ -32198,11 +32242,11 @@ msgstr[1] "{quantity}  ongeldige geboortes werden verbeterd\n"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2634
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "{quantity} Duplicated Gramps ID fixed\n"
 msgid_plural "{quantity} Duplicated Gramps IDs fixed\n"
-msgstr[0] "{quantity}  ongeldige sterfgeval werd verbeterd\n"
-msgstr[1] "{quantity}  ongeldige sterfgevallen werden verbeterd\n"
+msgstr[0] "{quantity}  dubbele Gramps ID verbeterd\n"
+msgstr[1] "{quantity}  Gramps IDs verbeterd\n"
 
 #: ../gramps/plugins/tool/check.py:2641
 #, python-format
@@ -34044,128 +34088,128 @@ msgstr ""
 "toetsenbord de 'control-toets' in te drukken en dan het gewenste gezin aan te "
 "klikken."
 
-#: ../gramps/plugins/view/fanchart2wayview.py:179
-#: ../gramps/plugins/view/fanchartdescview.py:174
-#: ../gramps/plugins/view/fanchartview.py:170
+#: ../gramps/plugins/view/fanchart2wayview.py:193
+#: ../gramps/plugins/view/fanchartdescview.py:188
+#: ../gramps/plugins/view/fanchartview.py:184
 msgid "Print or save the Fan Chart View"
 msgstr "De waaier afdrukken of opslaan"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:280
+#: ../gramps/plugins/view/fanchart2wayview.py:294
 msgid "Max ancestor generations"
 msgstr "Max vooroudergeneraties"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:283
+#: ../gramps/plugins/view/fanchart2wayview.py:297
 msgid "Max descendant generations"
 msgstr "Max aantal afstammelingengeneraties"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:287
-#: ../gramps/plugins/view/fanchartdescview.py:284
-#: ../gramps/plugins/view/fanchartview.py:280
+#: ../gramps/plugins/view/fanchart2wayview.py:301
+#: ../gramps/plugins/view/fanchartdescview.py:298
+#: ../gramps/plugins/view/fanchartview.py:294
 msgid "Text Font"
 msgstr "Lettertype"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:291
-#: ../gramps/plugins/view/fanchartdescview.py:288
-#: ../gramps/plugins/view/fanchartview.py:284
+#: ../gramps/plugins/view/fanchart2wayview.py:305
+#: ../gramps/plugins/view/fanchartdescview.py:302
+#: ../gramps/plugins/view/fanchartview.py:298
 msgid "Gender colors"
 msgstr "Kleuren voor de geslachten"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:292
-#: ../gramps/plugins/view/fanchartdescview.py:289
-#: ../gramps/plugins/view/fanchartview.py:285
+#: ../gramps/plugins/view/fanchart2wayview.py:306
+#: ../gramps/plugins/view/fanchartdescview.py:303
+#: ../gramps/plugins/view/fanchartview.py:299
 msgid "Generation based gradient"
 msgstr "Kleurverloop gebaseerd op de generaties"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:293
-#: ../gramps/plugins/view/fanchartdescview.py:290
-#: ../gramps/plugins/view/fanchartview.py:286
+#: ../gramps/plugins/view/fanchart2wayview.py:307
+#: ../gramps/plugins/view/fanchartdescview.py:304
+#: ../gramps/plugins/view/fanchartview.py:300
 msgid "Age (0-100) based gradient"
 msgstr "Kleurverloop op basis van leeftijd"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:295
-#: ../gramps/plugins/view/fanchartdescview.py:292
-#: ../gramps/plugins/view/fanchartview.py:288
+#: ../gramps/plugins/view/fanchart2wayview.py:309
+#: ../gramps/plugins/view/fanchartdescview.py:306
+#: ../gramps/plugins/view/fanchartview.py:302
 msgid "Single main (filter) color"
 msgstr "Een enkele hoofdkleur"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:296
-#: ../gramps/plugins/view/fanchartdescview.py:293
-#: ../gramps/plugins/view/fanchartview.py:289
+#: ../gramps/plugins/view/fanchart2wayview.py:310
+#: ../gramps/plugins/view/fanchartdescview.py:307
+#: ../gramps/plugins/view/fanchartview.py:303
 msgid "Time period based gradient"
 msgstr "Kleurverloop gebaseerd op tijdsperiode"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:297
-#: ../gramps/plugins/view/fanchartdescview.py:294
-#: ../gramps/plugins/view/fanchartview.py:290
+#: ../gramps/plugins/view/fanchart2wayview.py:311
+#: ../gramps/plugins/view/fanchartdescview.py:308
+#: ../gramps/plugins/view/fanchartview.py:304
 msgid "White"
 msgstr "Wit"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:298
-#: ../gramps/plugins/view/fanchartdescview.py:295
-#: ../gramps/plugins/view/fanchartview.py:291
+#: ../gramps/plugins/view/fanchart2wayview.py:312
+#: ../gramps/plugins/view/fanchartdescview.py:309
+#: ../gramps/plugins/view/fanchartview.py:305
 msgid "Color scheme classic report"
 msgstr "Kleurschema voor standaard verslag"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:299
-#: ../gramps/plugins/view/fanchartdescview.py:296
-#: ../gramps/plugins/view/fanchartview.py:292
+#: ../gramps/plugins/view/fanchart2wayview.py:313
+#: ../gramps/plugins/view/fanchartdescview.py:310
+#: ../gramps/plugins/view/fanchartview.py:306
 msgid "Color scheme classic view"
 msgstr "Kleurschema voor standaard scherm"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:308
-#: ../gramps/plugins/view/fanchartdescview.py:305
-#: ../gramps/plugins/view/fanchartview.py:301
+#: ../gramps/plugins/view/fanchart2wayview.py:322
+#: ../gramps/plugins/view/fanchartdescview.py:319
+#: ../gramps/plugins/view/fanchartview.py:315
 msgid "Background"
 msgstr "Achtergrond"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:317
+#: ../gramps/plugins/view/fanchart2wayview.py:331
 msgid "Add global background colored gradient"
 msgstr "Een globale achtergrond met kleurverloop"
 
 #. colors, stored as hex values
-#: ../gramps/plugins/view/fanchart2wayview.py:321
-#: ../gramps/plugins/view/fanchartdescview.py:312
-#: ../gramps/plugins/view/fanchartview.py:307
+#: ../gramps/plugins/view/fanchart2wayview.py:335
+#: ../gramps/plugins/view/fanchartdescview.py:326
+#: ../gramps/plugins/view/fanchartview.py:321
 msgid "Start gradient/Main color"
 msgstr "Begin kleurverloop/hoofdkleur"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:323
-#: ../gramps/plugins/view/fanchartdescview.py:314
-#: ../gramps/plugins/view/fanchartview.py:309
+#: ../gramps/plugins/view/fanchart2wayview.py:337
+#: ../gramps/plugins/view/fanchartdescview.py:328
+#: ../gramps/plugins/view/fanchartview.py:323
 msgid "End gradient/2nd color"
 msgstr "Einde kleurverloop/2de kleur"
 
 # Duplicaat
-#: ../gramps/plugins/view/fanchart2wayview.py:325
-#: ../gramps/plugins/view/fanchartdescview.py:316
+#: ../gramps/plugins/view/fanchart2wayview.py:339
+#: ../gramps/plugins/view/fanchartdescview.py:330
 msgid "Color for duplicates"
 msgstr "Kleur voor duplicaten"
 
 #. algo for the fan angle distribution
-#: ../gramps/plugins/view/fanchart2wayview.py:328
-#: ../gramps/plugins/view/fanchartdescview.py:326
+#: ../gramps/plugins/view/fanchart2wayview.py:342
+#: ../gramps/plugins/view/fanchartdescview.py:340
 msgid "Fan chart distribution"
 msgstr "Verdeling voor de waaier"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:331
-#: ../gramps/plugins/view/fanchartdescview.py:329
+#: ../gramps/plugins/view/fanchart2wayview.py:345
+#: ../gramps/plugins/view/fanchartdescview.py:343
 msgid "Homogeneous children distribution"
 msgstr "Gelijke verdeling voor de kinderen"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:333
-#: ../gramps/plugins/view/fanchartdescview.py:331
+#: ../gramps/plugins/view/fanchart2wayview.py:347
+#: ../gramps/plugins/view/fanchartdescview.py:345
 msgid "Size  proportional to number of descendants"
 msgstr "Grootte proportioneel met aantal afstammelingen"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:339
-#: ../gramps/plugins/view/fanchartdescview.py:337
-#: ../gramps/plugins/view/fanchartview.py:320
+#: ../gramps/plugins/view/fanchart2wayview.py:353
+#: ../gramps/plugins/view/fanchartdescview.py:351
+#: ../gramps/plugins/view/fanchartview.py:334
 msgid "Show names on two lines"
 msgstr "Namen op twee lijnen tonen"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:344
-#: ../gramps/plugins/view/fanchartdescview.py:342
-#: ../gramps/plugins/view/fanchartview.py:325
+#: ../gramps/plugins/view/fanchart2wayview.py:358
+#: ../gramps/plugins/view/fanchartdescview.py:356
+#: ../gramps/plugins/view/fanchartview.py:339
 msgid "Flip name on the left of the fan"
 msgstr "Naam omdraaien links van de waaier"
 
@@ -34173,42 +34217,42 @@ msgstr "Naam omdraaien links van de waaier"
 #. #configdialog.add_checkbox(table,
 #. #        _('Allow radial text'),
 #. #        ??, 'interface.fanview-radialtext')
-#: ../gramps/plugins/view/fanchart2wayview.py:347
-#: ../gramps/plugins/view/fanchartdescview.py:345
-#: ../gramps/plugins/view/fanchartview.py:337
-#: ../gramps/plugins/view/pedigreeview.py:2038
-#: ../gramps/plugins/view/relview.py:1699
+#: ../gramps/plugins/view/fanchart2wayview.py:361
+#: ../gramps/plugins/view/fanchartdescview.py:359
+#: ../gramps/plugins/view/fanchartview.py:351
+#: ../gramps/plugins/view/pedigreeview.py:2052
+#: ../gramps/plugins/view/relview.py:1709
 msgid "Layout"
 msgstr "Layout"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:548
-#: ../gramps/plugins/view/fanchartdescview.py:536
-#: ../gramps/plugins/view/fanchartview.py:543
+#: ../gramps/plugins/view/fanchart2wayview.py:562
+#: ../gramps/plugins/view/fanchartdescview.py:550
+#: ../gramps/plugins/view/fanchartview.py:557
 msgid "No preview available"
 msgstr "Geen voorvertoning beschikbaar"
 
 #. form of the fan
-#: ../gramps/plugins/view/fanchartdescview.py:319
-#: ../gramps/plugins/view/fanchartview.py:312
+#: ../gramps/plugins/view/fanchartdescview.py:333
+#: ../gramps/plugins/view/fanchartview.py:326
 msgid "Fan chart type"
 msgstr "Type waaier"
 
-#: ../gramps/plugins/view/fanchartdescview.py:321
-#: ../gramps/plugins/view/fanchartview.py:314
+#: ../gramps/plugins/view/fanchartdescview.py:335
+#: ../gramps/plugins/view/fanchartview.py:328
 msgid "Full Circle"
 msgstr "Volle cirkel"
 
-#: ../gramps/plugins/view/fanchartdescview.py:322
-#: ../gramps/plugins/view/fanchartview.py:314
+#: ../gramps/plugins/view/fanchartdescview.py:336
+#: ../gramps/plugins/view/fanchartview.py:328
 msgid "Half Circle"
 msgstr "Halve cirkel"
 
-#: ../gramps/plugins/view/fanchartdescview.py:323
-#: ../gramps/plugins/view/fanchartview.py:315
+#: ../gramps/plugins/view/fanchartdescview.py:337
+#: ../gramps/plugins/view/fanchartview.py:329
 msgid "Quadrant"
 msgstr "Kwadrant"
 
-#: ../gramps/plugins/view/fanchartview.py:330
+#: ../gramps/plugins/view/fanchartview.py:344
 msgid "Show children ring"
 msgstr "Ring met kinderen tonen"
 
@@ -34622,6 +34666,10 @@ msgid ""
 "with coordinates. You can use the history to navigate on the map. You can "
 "change the markers color depending on place type. You can use filtering."
 msgstr ""
+"Rechtklikken op de kaart en selecteer 'toon alle locaties' om alle gekende "
+"locaties met coordinaten te tonen. U kunt de geschiedenis gebruiken om te "
+"bewegen op de kaart en u kunt de kleur van de merker veranderen volgens het "
+"type locatie en u kunt filters gebruiken."
 
 #: ../gramps/plugins/view/geoplaces.py:395
 msgid "The place name in the status bar is disabled."
@@ -34752,85 +34800,85 @@ msgstr "bgr."
 msgid "short for cremated|crem."
 msgstr "crem."
 
-#: ../gramps/plugins/view/pedigreeview.py:1131
+#: ../gramps/plugins/view/pedigreeview.py:1145
 msgid "Jump to child..."
 msgstr "Spring naar kind..."
 
-#: ../gramps/plugins/view/pedigreeview.py:1145
+#: ../gramps/plugins/view/pedigreeview.py:1159
 msgid "Jump to father"
 msgstr "Spring naar vader"
 
-#: ../gramps/plugins/view/pedigreeview.py:1159
+#: ../gramps/plugins/view/pedigreeview.py:1173
 msgid "Jump to mother"
 msgstr "Spring naar moeder"
 
-#: ../gramps/plugins/view/pedigreeview.py:1517
+#: ../gramps/plugins/view/pedigreeview.py:1531
 msgid "A person was found to be his/her own ancestor."
 msgstr "Er werd een persoon gevonden die zijn/haar eigen voorouder is."
 
-#: ../gramps/plugins/view/pedigreeview.py:1561
+#: ../gramps/plugins/view/pedigreeview.py:1575
 msgid "Pre_vious"
 msgstr "Vorige"
 
-#: ../gramps/plugins/view/pedigreeview.py:1562
+#: ../gramps/plugins/view/pedigreeview.py:1576
 msgid "_Next"
 msgstr "Volgende"
 
 #. Mouse scroll direction setting.
-#: ../gramps/plugins/view/pedigreeview.py:1585
+#: ../gramps/plugins/view/pedigreeview.py:1599
 msgid "Mouse scroll direction"
 msgstr "Richting waarin muis scrollt"
 
-#: ../gramps/plugins/view/pedigreeview.py:1589
+#: ../gramps/plugins/view/pedigreeview.py:1603
 msgid "Top <-> Bottom"
 msgstr "Boven <-> Beneden"
 
-#: ../gramps/plugins/view/pedigreeview.py:1596
+#: ../gramps/plugins/view/pedigreeview.py:1610
 msgid "Left <-> Right"
 msgstr "Links <-> Rechts"
 
-#: ../gramps/plugins/view/pedigreeview.py:1813
-#: ../gramps/plugins/view/relview.py:410
+#: ../gramps/plugins/view/pedigreeview.py:1827
+#: ../gramps/plugins/view/relview.py:420
 msgid "Add New Parents..."
 msgstr "Nieuwe ouders toevoegen..."
 
-#: ../gramps/plugins/view/pedigreeview.py:2008
+#: ../gramps/plugins/view/pedigreeview.py:2022
 msgid "Show images"
 msgstr "Afbeeldingen tonen"
 
-#: ../gramps/plugins/view/pedigreeview.py:2011
+#: ../gramps/plugins/view/pedigreeview.py:2025
 msgid "Show marriage data"
 msgstr "Huwelijksgegevens tonen"
 
-#: ../gramps/plugins/view/pedigreeview.py:2014
+#: ../gramps/plugins/view/pedigreeview.py:2028
 msgid "Show unknown people"
 msgstr "Onbekende personen tonen"
 
-#: ../gramps/plugins/view/pedigreeview.py:2017
+#: ../gramps/plugins/view/pedigreeview.py:2031
 msgid "Show tags"
 msgstr "Tags tonen"
 
-#: ../gramps/plugins/view/pedigreeview.py:2020
+#: ../gramps/plugins/view/pedigreeview.py:2034
 msgid "Tree style"
 msgstr "Boomstijl"
 
-#: ../gramps/plugins/view/pedigreeview.py:2022
+#: ../gramps/plugins/view/pedigreeview.py:2036
 msgid "Standard"
 msgstr "Standaard"
 
-#: ../gramps/plugins/view/pedigreeview.py:2023
+#: ../gramps/plugins/view/pedigreeview.py:2037
 msgid "Compact"
 msgstr "Compact"
 
-#: ../gramps/plugins/view/pedigreeview.py:2024
+#: ../gramps/plugins/view/pedigreeview.py:2038
 msgid "Expanded"
 msgstr "Uitgevouwd"
 
-#: ../gramps/plugins/view/pedigreeview.py:2027
+#: ../gramps/plugins/view/pedigreeview.py:2041
 msgid "Tree direction"
 msgstr "Boomrichting"
 
-#: ../gramps/plugins/view/pedigreeview.py:2034
+#: ../gramps/plugins/view/pedigreeview.py:2048
 msgid "Tree size"
 msgstr "Grootte stamboom"
 
@@ -34861,170 +34909,170 @@ msgstr "Deze volledige groep uitklappen"
 msgid "Collapse this Entire Group"
 msgstr "Deze volledige groep inklappen"
 
-#: ../gramps/plugins/view/relview.py:396
+#: ../gramps/plugins/view/relview.py:406
 msgid "_Reorder"
 msgstr "_Herschikken"
 
-#: ../gramps/plugins/view/relview.py:397
+#: ../gramps/plugins/view/relview.py:407
 msgid "Change order of parents and families"
 msgstr "De volgorde van de ouders en gezinnen veranderen"
 
-#: ../gramps/plugins/view/relview.py:402
+#: ../gramps/plugins/view/relview.py:412
 msgid "Edit..."
 msgstr "Bewerken..."
 
-#: ../gramps/plugins/view/relview.py:403
+#: ../gramps/plugins/view/relview.py:413
 msgid "Edit the active person"
 msgstr "De actieve persoon bewerken"
 
-#: ../gramps/plugins/view/relview.py:405 ../gramps/plugins/view/relview.py:407
-#: ../gramps/plugins/view/relview.py:799
+#: ../gramps/plugins/view/relview.py:415 ../gramps/plugins/view/relview.py:417
+#: ../gramps/plugins/view/relview.py:809
 msgid "Add a new family with person as parent"
 msgstr "Een nieuw gezin met de persoon als ouder toevoegen"
 
-#: ../gramps/plugins/view/relview.py:406
+#: ../gramps/plugins/view/relview.py:416
 msgid "Add Partner..."
 msgstr "Partner toevoegen..."
 
-#: ../gramps/plugins/view/relview.py:409 ../gramps/plugins/view/relview.py:411
-#: ../gramps/plugins/view/relview.py:793
+#: ../gramps/plugins/view/relview.py:419 ../gramps/plugins/view/relview.py:421
+#: ../gramps/plugins/view/relview.py:803
 msgid "Add a new set of parents"
 msgstr "Een nieuw stel ouders toevoegen"
 
-#: ../gramps/plugins/view/relview.py:413 ../gramps/plugins/view/relview.py:417
-#: ../gramps/plugins/view/relview.py:794
+#: ../gramps/plugins/view/relview.py:423 ../gramps/plugins/view/relview.py:427
+#: ../gramps/plugins/view/relview.py:804
 msgid "Add person as child to an existing family"
 msgstr "De persoon als kind aan een bestaand gezin toevoegen"
 
-#: ../gramps/plugins/view/relview.py:416
+#: ../gramps/plugins/view/relview.py:426
 msgid "Add Existing Parents..."
 msgstr "Bestaande ouders toevoegen..."
 
-#: ../gramps/plugins/view/relview.py:631
+#: ../gramps/plugins/view/relview.py:641
 msgid "Alive"
 msgstr "In leven"
 
-#: ../gramps/plugins/view/relview.py:698 ../gramps/plugins/view/relview.py:725
+#: ../gramps/plugins/view/relview.py:708 ../gramps/plugins/view/relview.py:735
 #, python-format
 msgid "%(date)s in %(place)s"
 msgstr "%(date)s in %(place)s"
 
 # Gebeuren (korter)
-#: ../gramps/plugins/view/relview.py:795
+#: ../gramps/plugins/view/relview.py:805
 msgid "Edit parents"
 msgstr "Ouders bewerken"
 
-#: ../gramps/plugins/view/relview.py:796
+#: ../gramps/plugins/view/relview.py:806
 msgid "Reorder parents"
 msgstr "Ouders herschikken"
 
-#: ../gramps/plugins/view/relview.py:797
+#: ../gramps/plugins/view/relview.py:807
 msgid "Remove person as child of these parents"
 msgstr "De persoon als kind van deze ouders verwijderen"
 
-#: ../gramps/plugins/view/relview.py:803
+#: ../gramps/plugins/view/relview.py:813
 msgid "Remove person as parent in this family"
 msgstr "De persoon als ouder in dit gezin verwijderen"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/view/relview.py:863 ../gramps/plugins/view/relview.py:919
+#: ../gramps/plugins/view/relview.py:873 ../gramps/plugins/view/relview.py:929
 #, python-brace-format
 msgid " ({number_of} sibling)"
 msgid_plural " ({number_of} siblings)"
 msgstr[0] " ({number_of} broer of zus)"
 msgstr[1] " ({number_of} broers of zussen)"
 
-#: ../gramps/plugins/view/relview.py:870 ../gramps/plugins/view/relview.py:926
+#: ../gramps/plugins/view/relview.py:880 ../gramps/plugins/view/relview.py:936
 msgid " (1 brother)"
 msgstr " (1 broer)"
 
-#: ../gramps/plugins/view/relview.py:872 ../gramps/plugins/view/relview.py:928
+#: ../gramps/plugins/view/relview.py:882 ../gramps/plugins/view/relview.py:938
 msgid " (1 sister)"
 msgstr " (1 zus)"
 
-#: ../gramps/plugins/view/relview.py:874 ../gramps/plugins/view/relview.py:930
+#: ../gramps/plugins/view/relview.py:884 ../gramps/plugins/view/relview.py:940
 msgid " (1 sibling)"
 msgstr " (1 broer of zus)"
 
-#: ../gramps/plugins/view/relview.py:876 ../gramps/plugins/view/relview.py:932
+#: ../gramps/plugins/view/relview.py:886 ../gramps/plugins/view/relview.py:942
 msgid " (only child)"
 msgstr " (enig kind)"
 
-#: ../gramps/plugins/view/relview.py:946 ../gramps/plugins/view/relview.py:1442
+#: ../gramps/plugins/view/relview.py:956 ../gramps/plugins/view/relview.py:1452
 msgid "Add new child to family"
 msgstr "Nieuw kind aan gezin toevoegen"
 
-#: ../gramps/plugins/view/relview.py:950 ../gramps/plugins/view/relview.py:1446
+#: ../gramps/plugins/view/relview.py:960 ../gramps/plugins/view/relview.py:1456
 msgid "Add existing child to family"
 msgstr "Bestaand kind aan gezin toevoegen"
 
-#: ../gramps/plugins/view/relview.py:1228
+#: ../gramps/plugins/view/relview.py:1238
 #, python-format
 msgid "%(birthabbrev)s %(birthdate)s, %(deathabbrev)s %(deathdate)s"
 msgstr "%(birthabbrev)s %(birthdate)s, %(deathabbrev)s %(deathdate)s"
 
-#: ../gramps/plugins/view/relview.py:1235 ../gramps/plugins/view/relview.py:1237
+#: ../gramps/plugins/view/relview.py:1245 ../gramps/plugins/view/relview.py:1247
 #, python-format
 msgid "%(event)s %(date)s"
 msgstr "%(event)s %(date)s"
 
-#: ../gramps/plugins/view/relview.py:1296
+#: ../gramps/plugins/view/relview.py:1306
 #, python-format
 msgid "Relationship type: %s"
 msgstr "Type verwantschap: %s"
 
-#: ../gramps/plugins/view/relview.py:1334
+#: ../gramps/plugins/view/relview.py:1344
 #, python-format
 msgid "%(event_type)s: %(date)s in %(place)s"
 msgstr "%(event_type)s:·%(date)s·in·%(place)s"
 
-#: ../gramps/plugins/view/relview.py:1338
+#: ../gramps/plugins/view/relview.py:1348
 #, python-format
 msgid "%(event_type)s: %(date)s"
 msgstr "%(event_type)s: %(date)s"
 
-#: ../gramps/plugins/view/relview.py:1342
+#: ../gramps/plugins/view/relview.py:1352
 #, python-format
 msgid "%(event_type)s: %(place)s"
 msgstr "%(event_type)s: %(place)s"
 
-#: ../gramps/plugins/view/relview.py:1353
+#: ../gramps/plugins/view/relview.py:1363
 msgid "Broken family detected"
 msgstr "Gebroken gezin gedetecteerd"
 
-#: ../gramps/plugins/view/relview.py:1354
+#: ../gramps/plugins/view/relview.py:1364
 msgid "Please run the Check and Repair Database tool"
 msgstr "Gelieve het gegevensbestand te controleren en repareren"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/view/relview.py:1377 ../gramps/plugins/view/relview.py:1424
+#: ../gramps/plugins/view/relview.py:1387 ../gramps/plugins/view/relview.py:1434
 #, python-brace-format
 msgid " ({number_of} child)"
 msgid_plural " ({number_of} children)"
 msgstr[0] " ({number_of} kind)"
 msgstr[1] " ({number_of} kinderen)"
 
-#: ../gramps/plugins/view/relview.py:1381 ../gramps/plugins/view/relview.py:1428
+#: ../gramps/plugins/view/relview.py:1391 ../gramps/plugins/view/relview.py:1438
 msgid " (no children)"
 msgstr " (geen kinderen)"
 
-#: ../gramps/plugins/view/relview.py:1688
+#: ../gramps/plugins/view/relview.py:1698
 msgid "Use shading"
 msgstr "Schaduwen gebruiken"
 
-#: ../gramps/plugins/view/relview.py:1691
+#: ../gramps/plugins/view/relview.py:1701
 msgid "Display edit buttons"
 msgstr "Aanpasknoppen tonen"
 
-#: ../gramps/plugins/view/relview.py:1693
+#: ../gramps/plugins/view/relview.py:1703
 msgid "View links as website links"
 msgstr "Verwijzingen worden als 'website-links' getoond"
 
-#: ../gramps/plugins/view/relview.py:1710
+#: ../gramps/plugins/view/relview.py:1720
 msgid "Show Details"
 msgstr "Details tonen"
 
-#: ../gramps/plugins/view/relview.py:1713
+#: ../gramps/plugins/view/relview.py:1723
 msgid "Show Siblings"
 msgstr "Broers en zussen tonen"
 
@@ -36685,6 +36733,11 @@ msgstr "Nebraska"
 #: ../gramps/plugins/webstuff/webstuff.py:153
 msgid "No style sheet"
 msgstr "Geen stijlblad"
+
+#~ msgid "Select filter to restrict people that appear on report"
+#~ msgstr ""
+#~ "Kies een filter om het aantal personen te beperken dat getoond wordt in "
+#~ "het verslag"
 
 #~ msgid "%(father)s and %(mother)s (%(id)s)"
 #~ msgstr "%(father)s en %(mother)s %(id)s"


### PR DESCRIPTION
bug 9235:  Original 'Break Lock' dialog was greater than 1280 wide, since the text was long and had no line breaks.  Rather than add line breaks (and require new translations) I decided to set default dialog size to 760; looked at other dialogs and this seems to work OK.