### PR TITLE
bug 8510 fix for special characters in Family Tree names

### DIFF
--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -36,6 +36,7 @@ import copy
 import subprocess
 from urllib.parse import urlparse
 import logging
+import re
 
 #-------------------------------------------------------------------------
 #
@@ -543,6 +544,8 @@ class DbManager(CLIDbManager):
         If the new string is empty, do nothing. Otherwise, renaming the
         database is simply changing the contents of the name file.
         """
+        # kill special characters so can use as file name in backup.
+        new_text = re.sub(r"[':<>|,;=\"\[\]\.\+\*\/\?\\]", "_", new_text)
         #path is a string, convert to TreePath first
         path = Gtk.TreePath(path=path)
         if len(new_text) > 0:


### PR DESCRIPTION
If special characters are present in Family Tree names, then the automatic backup fails, since the Family Tree name is part of the filename for the automatic backup.  

Default file names for reports are also effected.

The fix is not totally robust, since there are a number of other special cases regarding filenames (Try using 'con' or 'prn' on Windows, for instance), but should avoid most usual cases of trouble.
By placing the name substitution where I did, the user has an opportunity to see the change immediately and edit it himself.  It affects both 'New' and 'Rename' are corrected.