### PR TITLE
bug 9285; fix detection of URLs in Styled text editor

### DIFF
--- a/gramps/gui/widgets/styledtexteditor.py
+++ b/gramps/gui/widgets/styledtexteditor.py
@@ -105,14 +105,15 @@ FORMAT_TOOLBAR = '''
 FONT_SIZES = [8, 9, 10, 11, 12, 13, 14, 16, 18, 20, 22,
               24, 26, 28, 32, 36, 40, 48, 56, 64, 72]
 
-USERCHARS = "-A-Za-z0-9"
-PASSCHARS = "-A-Za-z0-9,?;.:/!%$^*&~\"#'"
-HOSTCHARS = "-A-Za-z0-9"
-PATHCHARS = "-A-Za-z0-9_$.+!*(),;:@&=?/~#%"
+USERCHARS = r"-\w"
+PASSCHARS = r"-\w,?;.:/!%$^*&~\"#'"
+HOSTCHARS = r"-\w"
+PATHCHARS = r"-\w$.+!*(),;:@&=?/~#%"
 #SCHEME = "(news:|telnet:|nntp:|file:/|https?:|ftps?:|webcal:)"
 SCHEME = "(file:/|https?:|ftps?:|webcal:)"
 USER = "[" + USERCHARS + "]+(:[" + PASSCHARS + "]+)?"
-URLPATH = "/[" + PATHCHARS + "]*[^]'.}>) \t\r\n,\\\"]"
+HOST = r"([-\w.]+|\[[0-9A-F:]+\])?"
+URLPATH = "(/[" + PATHCHARS + "]*)?[^]'.:}> \t\r\n,\\\"]"
 
 (GENURL, HTTP, MAIL, LINK) = list(range(4))
 
@@ -546,14 +547,14 @@ class StyledTextEditor(Gtk.TextView):
         self.textbuffer.create_tag('hyperlink',
                                    underline=Pango.Underline.SINGLE,
                                    foreground=self.linkcolor)
-        self.textbuffer.match_add(SCHEME + "//(" + USER + "@)?[" +
-                                  HOSTCHARS + ".]+" + "(:[0-9]+)?(" +
-                                  URLPATH + ")?/?", GENURL)
-        self.textbuffer.match_add("(www|ftp)[" + HOSTCHARS + "]*\\.[" +
-                                  HOSTCHARS + ".]+" + "(:[0-9]+)?(" +
-                                  URLPATH + ")?/?", HTTP)
-        self.textbuffer.match_add("(mailto:)?[a-z0-9][a-z0-9.-]*@[a-z0-9]"
-                                  "[a-z0-9-]*(\\.[a-z0-9][a-z0-9-]*)+", MAIL)
+        self.textbuffer.match_add(SCHEME + "//(" + USER + "@)?" +
+                                  HOST + "(:[0-9]+)?" +
+                                  URLPATH, GENURL)
+        self.textbuffer.match_add(r"(www\.|ftp\.)[" + HOSTCHARS + r"]*\.[" +
+                                  HOSTCHARS + ".]+" + "(:[0-9]+)?" +
+                                  URLPATH, HTTP)
+        self.textbuffer.match_add(r"(mailto:)?[\w][-.\w]*@[\w]"
+                                  r"[-\w]*(\.[\w][-.\w]*)+", MAIL)
 
     def _create_spell_menu(self):
         """


### PR DESCRIPTION
A trailing '.' or ':' as used in sentences like "Go to http://google.com." or The site http://findagrave.com: is good for finding grave sites.  Prior regex would include the '.' or ':' at the end of the URL, rendering it unusable in opening the site.

While testing for this I also found the following issues and fixed them.
When detecting "www.google.com" or "ftp.whoknows.what" type URLs, it also incorrectly would flag "Wwwilly coyote" or "softphone".
International (unicode) characters in URLs would not be correctly detected. example:
    https://zh.wikipedia.org/wiki/Wikipedia:关于中文维基百科/en
IPV6 addresses as URLs would not work 
    http://[1080::8:800:200C:417A]/foo
URLs containing a trailing ')' would fail. 
    https://en.wikipedia.org/wiki/URL_(disambiguation) 
Note: while my patch corrects the trailing ')', it will now fail if the user places the entire URL in parenthesis.  I don't know how to test for and discard a leading '(' and to use the result of that test to remove the leading '(' and trailing ')' with the regex language.  Most other likely enclosures ("...", <...>, [...], '...' {...}) work correctly.

If you are interested, some of the URLs used for testing are included below; just paste them into Gramps note and hover over them with mouse.

(http://google.com/bla/) <-- Error, should be no closing parenthesis
http://google.com/bla/
[http://google.com/bla/]   <-- no brackets
https://en.wikipedia.org/wiki/URL_(disambiguation)   <-- Must be closing parenthesis
(https://en.wikipedia.org/wiki/URL_(disambiguation)) <-- Error again, only one closing parenthesis allowed
http://www.exam_ple.com/wpstyle/?p=364/   <-- check for '_' in hostname
https://www.example.com/foo/?bar=baz&inga=42&quux  
http://h关df.ws/123   <-- Unicode in hostname
http://userid:password@example.com:8080/wpstyle/?p=364/  <-- lots of options
http://userid@example.com/   <-- just userid
http://142.42.1.1:8080   
 http://192.168.1.1:8080/mysite.html
http://foo.com/blah_(wikipedia)#cite-1  <--parenthesis in URL
http://foo.com/unicode_(关)_in_parens   <-- Unicode in URL
http://foo.com/(something)?after=parens 
http://w关.damowmow.com/ 
http://code.google.com/events/#&product=browser sfd
http://j.mp
ftp://foo.bar/baz
http://foo.bar/?q=Test%20URL-encoded%20stuff
http://مثال.إختبار  <-- Unicode
http://例子.测试  <-- Unicode
http://1337.net
http://a.b-c.de
http://223.255.255.254
http://google.com/bla/: <-- no colon 
ftp://foo.bar/baz.  <-- no period
https://zh.wikipedia.org/wiki/Wikipedia:关于中文维基百科/en  <-- Unicode
http://[1080::8:800:200C:417A]/foo  <-- IPV6
www.google.com/blah
ftp.my.site.org/blah
'Helllloooo' says Wwwiiillleyyy Coyote on his softphone.  <-- no Wwwiiillleyy or softphone
"mailto:paulr2787@gmail.com"
"mailto:ジョン_スミス@gmail.com" <-- Unicode
 mailto:존스미스@삼성.com <-- Unicode