### PR TITLE
bug 9286; fix styledtext editing of LINK with URL as Visible element

### DIFF
--- a/gramps/gui/widgets/styledtexteditor.py
+++ b/gramps/gui/widgets/styledtexteditor.py
@@ -291,20 +291,18 @@ class StyledTextEditor(Gtk.TextView):
             iter_at_location = iter_at_location[1]
         self.match = self.textbuffer.match_check(iter_at_location.get_offset())
         tooltip = None
-        if not self.match:
-            for tag in (tag for tag in iter_at_location.get_tags()
-                        if tag.get_property('name').startswith("link")):
-                self.match = (x, y, LINK, tag.data, tag)
-                tooltip = self.make_tooltip_from_link(tag)
-                break
+        for tag in (tag for tag in iter_at_location.get_tags()
+                    if tag.get_property('name').startswith("link")):
+            self.match = (x, y, LINK, tag.data, tag)
+            tooltip = self.make_tooltip_from_link(tag)
+            break
 
         if self.match != self.last_match:
             self.emit('match-changed', self.match)
 
         self.last_match = self.match
-        self.get_root_window().get_pointer()
-        if tooltip:
-            self.set_tooltip_text(tooltip)
+        # self.get_root_window().get_pointer()  # Doesn't seem to do anythhing!
+        self.set_tooltip_text(tooltip)
         return False
 
     def make_tooltip_from_link(self, link_tag):


### PR DESCRIPTION
If Gramps note contains text like 'www.google.com' and the user selects that text and uses the Link edit to make a styled LINK, then right-click on that doesn't allow editing of the underlying LINK.  Also the right-click 'Open Link' or 'Copy Link Address' only works with the visible text, not the underlying link.

I changed the priority of the 'cursor hover' automatic link detection so that if it is a styled LINK, it is detected over the visible text that matches the link detection regex.

During testing I also noticed that the tooltip did not go away after leaving the LINK, it would reappear if the cursor stopped anywhere in the text area of the note editor box.  
So I fixed that as well.

When testing the code I got some GTK deprecation warnings on the line:
`self.get_root_window().get_pointer()`
Since the value returned by that line was never assigned (and did not have side-effects I could find in the GTK docs), it appeared to be non-functional code, so I deleted it. 