### PR TITLE
bug 9235: Shrink size of Break Lock (and other QuestionDialogs) by setting default width to 760.

### DIFF
--- a/gramps/gui/glade/dialog.glade
+++ b/gramps/gui/glade/dialog.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkDialog" id="hidedialog">
@@ -97,6 +97,7 @@
                 <property name="margin_bottom">12</property>
                 <property name="hexpand">True</property>
                 <property name="wrap">True</property>
+                <property name="max_width_chars">80</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
@@ -760,6 +761,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">label</property>
+                    <property name="max_width_chars">80</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -778,6 +780,7 @@
                     <property name="label" translatable="yes">label</property>
                     <property name="use_markup">True</property>
                     <property name="wrap">True</property>
+                    <property name="max_width_chars">80</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>


### PR DESCRIPTION
bug 9235: Original 'Break Lock' dialog was greater than 1280 wide, since the text was long and had no line breaks. Rather than add line breaks (and require new translations) I decided to set default dialog size to 760; looked at other dialogs and this seems to work OK.
 uxcq says:
`Believe I found another too large dialog, uncheck the "Suppress warning when adding parents to a child" in Edit/preferences/warnings to see what I mean.`

So I also set default MessageHideDialog size to 760.