### PR TITLE
bug 9844; fix QuickReports for Cairo crash when no objects found

### DIFF
--- a/gramps/plugins/quickview/ageondate.py
+++ b/gramps/plugins/quickview/ageondate.py
@@ -81,7 +81,8 @@ def run(database, document, date):
     sdoc.paragraph(_("\nLiving matches: %(alive)d, "
                      "Deceased matches: %(dead)d\n") %
                          {'alive' : alive_matches, 'dead' : dead_matches})
-    stab.write(sdoc)
+    if document.has_data:
+        stab.write(sdoc)
     sdoc.paragraph("")
 
 def get_event_date_from_ref(database, ref):

--- a/gramps/plugins/quickview/all_events.py
+++ b/gramps/plugins/quickview/all_events.py
@@ -64,7 +64,10 @@ def run(database, document, person):
                  sdb.event_date_obj(event),
                  sdb.event_place(event))
         document.has_data = True
-    stab.write(sdoc)
+    if document.has_data:
+        stab.write(sdoc)
+    else:
+        sdoc.header1(_("Not found"))
 
 def run_fam(database, document, family):
     """
@@ -98,7 +101,8 @@ def run_fam(database, document, family):
     # display the results
 
     sdoc.title(_("Sorted events of family\n %(father)s - %(mother)s") % {
-        'father' : sdb.name(sdb.father(family)), 'mother' : sdb.name(sdb.mother(family)) })
+        'father': sdb.name(sdb.father(family)),
+        'mother': sdb.name(sdb.mother(family))})
     sdoc.paragraph("")
 
     document.has_data = False
@@ -110,7 +114,10 @@ def run_fam(database, document, family):
                  sdb.event_date_obj(event),
                  sdb.event_place(event))
         document.has_data = True
-    stab.write(sdoc)
+    if document.has_data:
+        stab.write(sdoc)
+    else:
+        sdoc.header1(_("Not found\n"))
 
     stab = QuickTable(sdb)
     sdoc.header1(_("Personal events of the children"))
@@ -121,4 +128,7 @@ def run_fam(database, document, family):
                  sdb.event_date_obj(event),
                  sdb.event_place(event))
         document.has_data = True
-    stab.write(sdoc)
+    if document.has_data:
+        stab.write(sdoc)
+    else:
+        sdoc.header1(_("Not found\n"))

--- a/gramps/plugins/quickview/attributematch.py
+++ b/gramps/plugins/quickview/attributematch.py
@@ -44,4 +44,7 @@ def run(database, document, attribute, value=None):
             matches += 1
     document.has_data = matches > 0
     sdoc.paragraph(_("There are %d people with a matching attribute name.\n") % matches)
-    stab.write(sdoc)
+    if document.has_data:
+        stab.write(sdoc)
+    else:
+        sdoc.header1(_("Not found"))

--- a/gramps/plugins/quickview/reporef.py
+++ b/gramps/plugins/quickview/reporef.py
@@ -77,4 +77,7 @@ def run(database, document, repo):
 
                 stab.row(src.get_title(), media, call)
                 document.has_data = True
-    stab.write(sdoc)
+    if document.has_data:
+        stab.write(sdoc)
+    else:
+        sdoc.header1(_("Not found"))

--- a/gramps/plugins/quickview/siblings.py
+++ b/gramps/plugins/quickview/siblings.py
@@ -66,4 +66,7 @@ def run(database, document, person):
                      sdb.birth_or_fallback(child),
                      rel_str)
             document.has_data = True
-    stab.write(sdoc)
+    if document.has_data:
+        stab.write(sdoc)
+    else:
+        sdoc.header1(_("Not found\n"))


### PR DESCRIPTION
There is a recent Cairo bug that only appears to effect the Windows distribution.  It results in a full Gramps crash with a message:
`A s s e r t i o n f a i l e d !

 P r o g r a m : c : \ G r a m p s A I O 6 4 - 5 . 0 . 0 \ b i n \ g r a m p s . e x e
 F i l e : . . / . . / c a i r o - 1 . 1 5 . 2 / s r c / c a i r o - s u r f a c e . c , L i n e 5 4 5

 E x p r e s s i o n : s u r f a c e - > i s _ c l e a r`
I have no idea why there are illegal characters between each real character of the message, but that is another issue...

Bug first found when doing the 'all events' QuickReport on a family from family view.  There were no events in that family.
During testing I found that the same bug occurred in QuickReports for:
* 'all events' on persons in person view (no events on person)
* 'siblings' on persons in person view ( no siblings of person)
* 'Repository References' in repository view (no references)

I was unable to figure out how to activate the 'attributematch' QuickReport, but code inspection caused me to think the bug might hit there, so I patched it.  Untested.
I was unable to figure out how to activate the 'ageondate' QuickReport, but code inspection caused me to think the bug might hit there, so I patched it.  Untested.
I tested and inspected the code on the remaining QuickReports, and either was unable to get them to crash or am convinced that they won't crash (because they don't try to display empty lines).
