### PR TITLE
Fixes for some Gtk deprecations

### DIFF
--- a/gramps/gui/dialog.py
+++ b/gramps/gui/dialog.py
@@ -183,9 +183,9 @@ class OptionDialog:
 class ErrorDialog(Gtk.MessageDialog):
     def __init__(self, msg1, msg2="", parent=None):
 
-        Gtk.MessageDialog.__init__(self, parent,
-                                   flags=Gtk.DialogFlags.MODAL,
-                                   type=Gtk.MessageType.ERROR,
+        Gtk.MessageDialog.__init__(self, transient_for=parent,
+                                   modal=True,
+                                   message_type=Gtk.MessageType.ERROR,
                                    buttons=Gtk.ButtonsType.CLOSE)
         self.set_markup('<span weight="bold" size="larger">%s</span>' % str(msg1))
         self.format_secondary_text(msg2)
@@ -223,9 +223,9 @@ class DBErrorDialog(ErrorDialog):
 class WarningDialog(Gtk.MessageDialog):
     def __init__(self, msg1, msg2="", parent=None):
 
-        Gtk.MessageDialog.__init__(self, parent,
-                                   flags=Gtk.DialogFlags.MODAL,
-                                   type=Gtk.MessageType.WARNING,
+        Gtk.MessageDialog.__init__(self, transient_for=parent,
+                                   modal=True,
+                                   message_type=Gtk.MessageType.WARNING,
                                    buttons=Gtk.ButtonsType.CLOSE)
         self.set_markup('<span weight="bold" size="larger">%s</span>' % msg1)
         self.format_secondary_markup(msg2)
@@ -243,9 +243,9 @@ class WarningDialog(Gtk.MessageDialog):
 class OkDialog(Gtk.MessageDialog):
     def __init__(self, msg1, msg2="", parent=None):
 
-        Gtk.MessageDialog.__init__(self, parent,
-                                   flags=Gtk.DialogFlags.MODAL,
-                                   type=Gtk.MessageType.INFO,
+        Gtk.MessageDialog.__init__(self, transient_for=parent,
+                                   modal=True,
+                                   message_type=Gtk.MessageType.INFO,
                                    buttons=Gtk.ButtonsType.CLOSE)
         self.set_markup('<span weight="bold" size="larger">%s</span>' % msg1)
         self.format_secondary_text(msg2)

--- a/gramps/gui/plug/quick/_textbufdoc.py
+++ b/gramps/gui/plug/quick/_textbufdoc.py
@@ -56,11 +56,9 @@ class DisplayBuf(ManagedWindow):
     def __init__(self, title, document, track=[]):
         self.title = title
         ManagedWindow.__init__(self, document.uistate, track, document)
-        self.set_window(Gtk.Dialog(title="",
-                                   flags=Gtk.DialogFlags.DESTROY_WITH_PARENT,
-                                   buttons=(_('_Close'),
-                                             Gtk.ResponseType.CLOSE)),
-                        None, title, True)
+        dialog = Gtk.Dialog(title="", destroy_with_parent=True)
+        dialog.add_button(_('_Close'), Gtk.ResponseType.CLOSE)
+        self.set_window(dialog, None, title, True)
         self.setup_configs('interface.' + title.lower().replace(' ', ''),
                            600, 400)
         scrolled_window = Gtk.ScrolledWindow()

--- a/gramps/gui/widgets/interactivesearchbox.py
+++ b/gramps/gui/widgets/interactivesearchbox.py
@@ -36,7 +36,7 @@ _LOG = logging.getLogger(".widgets.interactivesearch")
 # GTK modules
 #
 #-------------------------------------------------------------------------
-from gi.repository import GObject, Gtk, Gdk
+from gi.repository import Gtk, Gdk, GLib
 
 #-------------------------------------------------------------------------
 #
@@ -124,8 +124,8 @@ class InteractiveSearchBox:
     def _preedit_changed(self, im_context, tree_view):
         self.__imcontext_changed = 1
         if(self._entry_flush_timeout):
-            GObject.source_remove(self._entry_flush_timeout)
-            self._entry_flush_timeout = GObject.timeout_add(
+            GLib.source_remove(self._entry_flush_timeout)
+            self._entry_flush_timeout = GLib.timeout_add(
                 self._SEARCH_DIALOG_TIMEOUT, self.cb_entry_flush_timeout)
 
     def ensure_interactive_directory(self):
@@ -140,7 +140,7 @@ class InteractiveSearchBox:
             self._search_window.set_screen(screen)
             return
 
-        self._search_window = Gtk.Window(Gtk.WindowType.POPUP)
+        self._search_window = Gtk.Window(type=Gtk.WindowType.POPUP)
         self._search_window.set_screen(screen)
         if toplevel.has_group():
             toplevel.get_group().add_window(self._search_window)
@@ -222,8 +222,8 @@ class InteractiveSearchBox:
         self._renew_flush_timeout()
         # renew search timeout
         if self._entry_launchsearch_timeout:
-            GObject.source_remove(self._entry_launchsearch_timeout)
-        self._entry_launchsearch_timeout = GObject.timeout_add(
+            GLib.source_remove(self._entry_launchsearch_timeout)
+        self._entry_launchsearch_timeout = GLib.timeout_add(
             self._SEARCH_DIALOG_LAUNCH_TIMEOUT, self.search_init)
 
     def search_init(self):
@@ -239,7 +239,7 @@ class InteractiveSearchBox:
         selection = self._treeview.get_selection()
         # disable flush timeout while searching
         if self._entry_flush_timeout:
-            GObject.source_remove(self._entry_flush_timeout)
+            GLib.source_remove(self._entry_flush_timeout)
             self._entry_flush_timeout = 0
         # search
         # cursor_path = self._treeview.get_cursor()[0]
@@ -252,8 +252,8 @@ class InteractiveSearchBox:
 
     def _renew_flush_timeout(self):
         if self._entry_flush_timeout:
-            GObject.source_remove(self._entry_flush_timeout)
-        self._entry_flush_timeout = GObject.timeout_add(
+            GLib.source_remove(self._entry_flush_timeout)
+        self._entry_flush_timeout = GLib.timeout_add(
             self._SEARCH_DIALOG_TIMEOUT, self.cb_entry_flush_timeout)
 
     def _move(self, up=False):
@@ -268,7 +268,7 @@ class InteractiveSearchBox:
         selection = self._treeview.get_selection()
         # disable flush timeout while searching
         if self._entry_flush_timeout:
-            GObject.source_remove(self._entry_flush_timeout)
+            GLib.source_remove(self._entry_flush_timeout)
             self._entry_flush_timeout = 0
         # search
         start_count = self.__selected_search_result + (-1 if up else 1)
@@ -314,7 +314,7 @@ class InteractiveSearchBox:
         menu.connect("hide", self._enable_popdown)
 
     def _enable_popdown(self, obj):
-        self._timeout_enable_popdown = GObject.timeout_add(
+        self._timeout_enable_popdown = GLib.timeout_add(
             self._SEARCH_DIALOG_TIMEOUT, self._real_search_enable_popdown)
 
     def _real_search_enable_popdown(self):
@@ -351,7 +351,7 @@ class InteractiveSearchBox:
         # Launch search
         if (event.keyval in [Gdk.KEY_Return, Gdk.KEY_KP_Enter]):
             if self._entry_launchsearch_timeout:
-                GObject.source_remove(self._entry_launchsearch_timeout)
+                GLib.source_remove(self._entry_launchsearch_timeout)
                 self._entry_launchsearch_timeout = 0
             self.search_init()
             retval = True
@@ -388,10 +388,10 @@ class InteractiveSearchBox:
             self._search_entry.disconnect(self._search_entry_changed_id)
             self._search_entry_changed_id = 0
         if self._entry_flush_timeout:
-            GObject.source_remove(self._entry_flush_timeout)
+            GLib.source_remove(self._entry_flush_timeout)
             self._entry_flush_timeout = 0
         if self._entry_launchsearch_timeout:
-            GObject.source_remove(self._entry_launchsearch_timeout)
+            GLib.source_remove(self._entry_launchsearch_timeout)
             self._entry_launchsearch_timeout = 0
         if self._search_window.get_visible():
             # send focus-in event


### PR DESCRIPTION
_textbufdoc (used for QuickReports etc.): 
* flags= and buttons= parameters are deprecated for Gtk.Dialog; used as initializers

interactivesearchbox 
* Had GObject items that have been moved to GLib (Gtk 3.10 requires GLib 2.37.5 )

_windows (Plugin manager) 
* flags= and buttons= parameters are deprecated for Gtk.Dialog; used as initializers
* positional arguments are deprecated in initializers
* Using the action_area directly is deprecated; use add_button instead (required a check for Gtk.ResponseType to get to the right routine).

dialog (Gramps dialogs)
* positional arguments are deprecated in initializers (parent -> transient_for=parent)
* flags= parameters are deprecated for Gtk.Dialog; used as initializers
* type= parameters are deprecated for Gtk.Dialog; used as initializers