### PR TITLE
bug 9478; fix quick search exception when nothing in searched list

### DIFF
--- a/gramps/gui/widgets/interactivesearchbox.py
+++ b/gramps/gui/widgets/interactivesearchbox.py
@@ -440,6 +440,8 @@ class InteractiveSearchBox():
         search_column = self._treeview.get_search_column()
         is_tree = not (model.get_flags() & Gtk.TreeModelFlags.LIST_ONLY)
         while True:
+            if not cur_iter:    # can happen on empty list
+                return False
             if (self.search_equal_func(model, search_column,
                                        text, cur_iter)):
                 count += 1


### PR DESCRIPTION
Same as PR288 except for Gramps42

Our quick search (start typing a name when a list is active) can fail if the list is empty. Not usual for someone to try to search an empty list, but can happen by mistake.
Added check for None on node to fix.