### PR TITLE
bug 9470; Don't allow selecton of Active or Home person until actually commited

### DIFF
--- a/gramps/gui/editors/editperson.py
+++ b/gramps/gui/editors/editperson.py
@@ -695,8 +695,8 @@ class EditPerson(EditPrimary):
                     None, None, self._make_home_person),
                 ])
 
-        self.all_action.set_visible(True)
-        self.home_action.set_visible(True)
+        self.all_action.set_visible(not self.added)
+        self.home_action.set_visible(not self.added)
 
         ui_top_cm = '''
             <menuitem action="ActivePerson"/>


### PR DESCRIPTION
"Make Active Person" or "Make Home Person" gives error from Edit Person Dialog on a new person.

What is happening is that until you hit 'OK' the person is not really in the database (not committed). So when you attempt to "Make Active Person" you are setting up other portions of the UI to try to use something not in the database. Thus handle not found errors. 