### PR TITLE
[Experiment] Relationships Category view the default instead of Dashboard.

### DIFF
--- a/gramps/gen/config.py
+++ b/gramps/gen/config.py
@@ -187,10 +187,21 @@ register('geography.use-keypad', True)
 # needed), for instance to four 'interface.clipboard' variables --
 # so do a recursive grep for "setup_configs" to see all the (base) names
 register('interface.dont-ask', False)
+#Default Navigator views (sets order shown)
+#register('interface.view-categories',
+#         ["Dashboard", "People", "Relationships", "Families",
+#          "Ancestry", "Events", "Places", "Geography", "Sources",
+#          "Citations", "Repositories", "Media", "Notes"])
+# New order 1
+#register('interface.view-categories',
+#         ["Dashboard", "Relationships", "Ancestry","Geography",
+#          "People", "Families", "Events", "Places", "Notes",
+#          "Media", "Citations", "Sources", "Repositories",])
+# New order 2
 register('interface.view-categories',
-         ["Dashboard", "People", "Relationships", "Families",
-          "Ancestry", "Events", "Places", "Geography", "Sources",
-          "Citations", "Repositories", "Media", "Notes"])
+         ["Relationships", "Dashboard", "Ancestry","Geography",
+          "People", "Families", "Events", "Places", "Notes",
+          "Media", "Citations", "Sources", "Repositories",])
 register('interface.filter', False)
 register('interface.fullscreen', False)
 register('interface.grampletbar-close', False)

--- a/gramps/gen/config.py
+++ b/gramps/gen/config.py
@@ -197,9 +197,12 @@ register('interface.dont-ask', False)
 #         ["Dashboard", "Relationships", "Ancestry","Geography",
 #          "People", "Families", "Events", "Places", "Notes",
 #          "Media", "Citations", "Sources", "Repositories",])
-# New order 2
+# New order 2 (Make relationships the default view #Todo work out how to keep
+#              dashboard 1st | Group list views below non list views eg
+#              Geography etc # Todo add separator or label btwn list & non list
+#              views
 register('interface.view-categories',
-         ["Relationships", "Dashboard", "Ancestry","Geography",
+         ["Dashboard", "Relationships", "Ancestry","Geography",
           "People", "Families", "Events", "Places", "Notes",
           "Media", "Citations", "Sources", "Repositories",])
 register('interface.filter', False)
@@ -276,8 +279,8 @@ register('preferences.private-record-text', "[%s]" % _("Private Record"))
 register('preferences.private-surname-text', "%s" % _T_("[Living]"))
 register('preferences.rprefix', 'R%04d')
 register('preferences.sprefix', 'S%04d')
-register('preferences.use-last-view', False)
-register('preferences.last-view', '')
+register('preferences.use-last-view', True)
+register('preferences.last-view', 'relview')
 register('preferences.last-views', [])
 register('preferences.family-relation-type', 3) # UNKNOWN
 register('preferences.age-display-precision', 1)

--- a/gramps/plugins/gramplet/gramplet.gpr.py
+++ b/gramps/plugins/gramplet/gramplet.gpr.py
@@ -328,6 +328,20 @@ register(GRAMPLET,
          )
 
 register(GRAMPLET,
+         id="WelStartRelview",
+         name=_("StartRelview"),
+         description = _("Gramplet showing a welcome message"),
+         status = STABLE,
+         fname="welcomerelview.py",
+         height=300,
+         expand=True,
+         gramplet = 'WelcomeRelview',
+         gramplet_title=_("Start here - Welcome to Gramps!"),
+         version="1.0.0",
+         gramps_target_version=MODULE_VERSION,
+         )
+
+register(GRAMPLET,
          id = "What's Next",
          name =_("What's Next"),
          description = _("Gramplet suggesting items to research"),

--- a/gramps/plugins/gramplet/welcomerelview.py
+++ b/gramps/plugins/gramplet/welcomerelview.py
@@ -1,0 +1,139 @@
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2007-2009  Douglas S. Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#------------------------------------------------------------------------
+#
+# Gtk modules
+#
+#------------------------------------------------------------------------
+from gi.repository import Gtk
+
+#------------------------------------------------------------------------
+#
+# Gramps modules
+#
+#------------------------------------------------------------------------
+from gramps.gen.const import URL_WIKISTRING, URL_MANUAL_PAGE, URL_HOMEPAGE
+from gramps.gen.plug import Gramplet
+from gramps.gui.widgets.styledtexteditor import StyledTextEditor
+from gramps.gen.lib import StyledText, StyledTextTag, StyledTextTagType
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+_ = glocale.translation.sgettext
+
+#-------------------------------------------------------------------------
+#
+# constants
+#
+#-------------------------------------------------------------------------
+WIKI_HELP_PAGE = _('%s_-_Categories') % URL_MANUAL_PAGE
+WIKI_HELP_SEC = _('Relationships_Category')
+
+#------------------------------------------------------------------------
+#
+# Functions
+#
+#------------------------------------------------------------------------
+def st(text):
+    """ Return text as styled text
+    """
+    return StyledText(text)
+
+def boldst(text):
+    """ Return text as bold styled text
+    """
+    tags = [StyledTextTag(StyledTextTagType.BOLD, True, [(0, len(text))])]
+    return StyledText(text, tags)
+
+def linkst(text, url):
+    """ Return text as link styled text
+    """
+    tags = [StyledTextTag(StyledTextTagType.LINK, url, [(0, len(text))])]
+    return StyledText(text, tags)
+
+#------------------------------------------------------------------------
+#
+# Gramplet class
+#
+#------------------------------------------------------------------------
+
+class WelcomeRelview(Gramplet):
+    """
+    Displays a welcome note on relview to the user.
+    """
+    def init(self):
+        self.gui.WIDGET = self.build_gui()
+        self.gui.get_container_widget().remove(self.gui.textview)
+        self.gui.get_container_widget().add(self.gui.WIDGET)
+        self.gui.WIDGET.show()
+
+    def build_gui(self):
+        """
+        Build the GUI interface.
+        """
+        top = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+
+        scrolledwindow = Gtk.ScrolledWindow()
+        scrolledwindow.set_policy(Gtk.PolicyType.AUTOMATIC,
+                                  Gtk.PolicyType.AUTOMATIC)
+        self.texteditor = StyledTextEditor()
+        self.texteditor.set_editable(False)
+        self.texteditor.set_wrap_mode(Gtk.WrapMode.WORD)
+        scrolledwindow.add(self.texteditor)
+
+        self.display_text()
+
+        top.pack_start(scrolledwindow, True, True, 0)
+        top.show_all()
+        return top
+
+    def display_text(self):
+        """
+        Display the welcome text.
+        """
+        welcome = boldst(_('Getting Started')) + '\n\n' + _(
+            'The first thing you must do is to create a new Family Tree. To '
+            'create a new Family Tree (sometimes called \'database\') select '
+            '"Family Trees" from the menu, pick "Manage Family Trees", press '
+            '"New" and name your Family Tree. For more details, please read '
+            'the information available from the Gramps user manual link.\n\n')
+        welcome += boldst(_('Relationships Category view')) + '\n\n' + _(
+            'You are currently reading from the "Relationships" view, which'
+            ' displays all the relationships of the Active Person'
+            ' (the selected person). Specifically, it shows the parents,'
+            ' siblings, spouses, and children of that person.\n\n'
+            'You can click the configuration icon in the toolbar to configure'
+            ' additional options.'
+        )
+        welcome += boldst(_('Online help Link')) + '\n\n'
+        welcome += linkst(_('Relationships Category view'),
+                          URL_WIKISTRING + WIKI_HELP_PAGE + WIKI_HELP_SEC +
+                          _('locale_suffix|')) + '\n'
+
+        welcome += boldst(_('What is Gramps?')) + '\n\n'
+        welcome += _(
+            'Gramps is a software package designed for genealogical research.'
+            'Visit the Dashboard for additional information.\n\n')
+
+        self.texteditor.set_text(welcome)
+
+    def get_has_data(self, obj):
+        """
+        Return True if the gramplet has data, else return False.
+        """
+        return True
+

--- a/gramps/plugins/gramplet/welcomerelview.py
+++ b/gramps/plugins/gramplet/welcomerelview.py
@@ -117,12 +117,12 @@ class WelcomeRelview(Gramplet):
             ' (the selected person). Specifically, it shows the parents,'
             ' siblings, spouses, and children of that person.\n\n'
             'You can click the configuration icon in the toolbar to configure'
-            ' additional options.'
+            ' additional options.\n\n'
         )
-        welcome += boldst(_('Online help Link')) + '\n\n'
+        welcome += boldst(_('Online help Link')) + '\n'
         welcome += linkst(_('Relationships Category view'),
                           URL_WIKISTRING + WIKI_HELP_PAGE + WIKI_HELP_SEC +
-                          _('locale_suffix|')) + '\n'
+                          _('locale_suffix|')) + '\n\n'
 
         welcome += boldst(_('What is Gramps?')) + '\n\n'
         welcome += _(

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -1747,6 +1747,13 @@ class RelationshipView(NavigationView):
         """
         return [self.content_panel, self.config_panel]
 
+    def get_default_gramplets(self):
+        """
+        Define the default gramplets for the sidebar and bottombar.
+        """
+        return (("Welcome",),
+                ())
+
 #-------------------------------------------------------------------------
 #
 # Function to return if person has children

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -411,7 +411,7 @@ class RelationshipView(NavigationView):
 
         self.family_action = ActionGroup(name=self.title + '/Family')
         self.family_action.add_actions([
-            ('AddNewPerson', 'gramps-spouse', _('Add Person'), None ,
+            ('AddNewPerson', 'gramps-person', _('Add new Person'), None ,
                 _("Add a new person"), self.add_new_person),
             ('Edit', 'gtk-edit', _('Edit...'), "<PRIMARY>Return",
                 _("Edit the active person"), self.edit_active),

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -1769,7 +1769,7 @@ class RelationshipView(NavigationView):
         """
         Define the default gramplets for the sidebar and bottombar.
         """
-        return (("Welcome",),
+        return (("WelStartRelview",),
                 ())
 
 #-------------------------------------------------------------------------

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -518,6 +518,7 @@ class RelationshipView(NavigationView):
         if not person:
             self.family_action.set_sensitive(False)
             self.order_action.set_sensitive(False)
+            #self.write_no_family_tree_message()
             self.redrawing = False
             return
         self.family_action.set_sensitive(True)
@@ -564,6 +565,25 @@ class RelationshipView(NavigationView):
         self.dirty = False
 
         return True
+
+    def write_no_family_tree_message(self):
+        """No Family Tree open - mention how to create one"""
+        #TODO not working
+        grid = Gtk.Grid()
+        grid.set_column_spacing(12)
+        grid.set_row_spacing(0)
+
+        # name and edit button
+        name = "xxxxxxxxxxxxxxxxxxx"
+        fmt = '<span size="larger" weight="bold">%s</span>'
+        text = fmt % escape(name)
+        label = widgets.BasicLabel(text)
+        eventbox = Gtk.EventBox()
+        eventbox.set_visible_window(False)
+        hbox = widgets.LinkBox(label)
+        eventbox.add(hbox)
+
+        grid.attach(eventbox, 0, 0, 2, 1)
 
     def write_title(self, person):
 

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -814,8 +814,8 @@ class RelationshipView(NavigationView):
                 call_fcn = self.add_family
                 del_fcn = self.delete_family
 
-            if not self.toolbar_visible and not self.dbstate.db.readonly:
-                # Show edit-Buttons if toolbar is not visible
+            if not self.dbstate.db.readonly:
+                # Show edit-Buttons only if db is not readonly
                 if self.reorder_sensitive:
                     add = widgets.IconButton(self.reorder_button_press, None,
                                              'view-sort-ascending')

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -360,6 +360,7 @@ class RelationshipView(NavigationView):
               </placeholder>
             </menu>
             <menu action="EditMenu">
+              <menuitem action="AddNewPerson"/>
               <menuitem action="Edit"/>
               <menuitem action="AddParentsMenu"/>
               <menuitem action="ShareFamilyMenu"/>
@@ -383,6 +384,7 @@ class RelationshipView(NavigationView):
               <toolitem action="HomePerson"/>
             </placeholder>
             <placeholder name="CommonEdit">
+              <toolitem action="AddNewPerson"/>
               <toolitem action="Edit"/>
               <toolitem action="AddParents"/>
               <toolitem action="ShareFamily"/>
@@ -409,6 +411,8 @@ class RelationshipView(NavigationView):
 
         self.family_action = ActionGroup(name=self.title + '/Family')
         self.family_action.add_actions([
+            ('AddNewPerson', 'gramps-spouse', _('Add Person'), None ,
+                _("Add a new person"), self.add_new_person),
             ('Edit', 'gtk-edit', _('Edit...'), "<PRIMARY>Return",
                 _("Edit the active person"), self.edit_active),
             ('AddSpouse', 'gramps-spouse', _('Partner'), None ,
@@ -1493,6 +1497,20 @@ class RelationshipView(NavigationView):
                 EditFamily(self.dbstate, self.uistate, [], family)
             except WindowActiveError:
                 pass
+
+    def add_new_person(self, obj):
+        """
+        Add a new person to the database.
+        """
+        person = Person()
+        #the editor requires a surname
+        person.primary_name.add_surname(Surname())
+        person.primary_name.set_primary_surname(0)
+
+        try:
+            EditPerson(self.dbstate, self.uistate, [], person)
+        except WindowActiveError:
+            pass
 
     def add_family(self, obj, event, handle):
         if button_activated(event, _LEFT_BUTTON):

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -610,6 +610,7 @@ gramps/plugins/gramplet/todo.py
 gramps/plugins/gramplet/todogramplet.py
 gramps/plugins/gramplet/topsurnamesgramplet.py
 gramps/plugins/gramplet/welcomegramplet.py
+gramps/plugins/gramplet/welcomerelview.py
 gramps/plugins/gramplet/whatsnext.py
 gramps/plugins/graph/graphplugins.gpr.py
 gramps/plugins/graph/gvfamilylines.py


### PR DESCRIPTION
Found another older experimental patch to improve Gramps usability and rebased it on gramps master.

Would ideally work with [PR281's](https://github.com/gramps-project/gramps/pull/281) new global Add menu.


**Made** Relationships Category view the default instead of Dashboard.

 * Includes a new "Start here - Welcome to Gramps!" gramplet in the relview sidebar with brief instructions.

 * Changed the default for showing the edit buttons in relview to always show independent of toolbar.
 
 * Added a new menu and toolbar icon to "Add a new Person" 

**TODO**[ ] (Currently only adds a new person and does not switch relview to the newly created person?)


  * Reordered the categories in the Navigator so that List are grouped below and non list are at the top. (ideally would like a separator or label "List" to appear in-between "Geography" and "People") This makes it easier for people to understand the at a glance the difference between the top 4 categories and those below.

Also changed default for  "preferences.use-last-view" so that relview would be the first view shown on startup.


TODO:
Instead a of blank view in relview when:
 - [  ]  No Family Tree (database) is open, show a message to "Create a new family tree or open an existing one"
 - [  ]  Empty Family Tree is open, show a message or icon to "Add a new Person"
        
Feed back appreciated.

Merry Xmas to all.