### PR TITLE
Bug 7928; Make merging people with complex families more friendly

### DIFF
--- a/gramps/gui/merge/mergeperson.py
+++ b/gramps/gui/merge/mergeperson.py
@@ -45,7 +45,7 @@ from gramps.gen.const import URL_MANUAL_SECT3
 from ..display import display_help
 from gramps.gen.datehandler import get_date
 from gramps.gen.errors import MergeError
-from ..dialog import ErrorDialog
+from ..dialog import ErrorDialog, WarningDialog
 from ..managedwindow import ManagedWindow
 from gramps.gen.merge import MergePersonQuery
 
@@ -337,7 +337,15 @@ class MergePerson(ManagedWindow):
 
         try:
             query = MergePersonQuery(self.database, phoenix, titanic)
-            query.execute()
+            family_merge_ok = query.execute()
+            if not family_merge_ok:
+                WarningDialog(
+                    _("Warning"),
+                    _("The persons have been merged.\nHowever, the families "
+                      "for this merge were too complex to automatically "
+                      "handle.  We recommend that you go to Relationships "
+                      "view and see if additional manual merging of families "
+                      "is necessary."), parent=self.uistate.window)
         except MergeError as err:
             ErrorDialog(_("Cannot merge people"), str(err),
                         parent=self.uistate.window)

--- a/gramps/gui/merge/mergeperson.py
+++ b/gramps/gui/merge/mergeperson.py
@@ -345,10 +345,10 @@ class MergePerson(ManagedWindow):
                       "for this merge were too complex to automatically "
                       "handle.  We recommend that you go to Relationships "
                       "view and see if additional manual merging of families "
-                      "is necessary."), parent=self.uistate.window)
+                      "is necessary."), parent=self.window)
         except MergeError as err:
             ErrorDialog(_("Cannot merge people"), str(err),
-                        parent=self.uistate.window)
+                        parent=self.window)
         self.uistate.set_busy_cursor(False)
         self.close()
         if self.update:


### PR DESCRIPTION
If families are complex, skip the family merge portion of the person merge with a warning message rather than abort the persons merge.
Users will be able to merge people successfully even when they have complex families, there may be some extra families attached to them which could perhaps be merged, but would be unsafe for Gramps to do on its own.  The warning message lets them know and suggests how to fix.