### PR TITLE
bug 9856; fix popup ProgressMonitor to find a parent for set_transient_for

### DIFF
--- a/gramps/gui/widgets/progressdialog.py
+++ b/gramps/gui/widgets/progressdialog.py
@@ -496,6 +496,11 @@ class GtkProgressDialog(Gtk.Dialog):
         Gtk.Dialog.__init__(self)
         if len(window_params) >= 2:
             self.set_transient_for(window_params[1])
+        else:
+            for win in Gtk.Window.list_toplevels():
+                if win.is_active():
+                    self.set_transient_for(win)
+                    break
         if len(window_params) >= 3:
             flags = window_params[2]
             if Gtk.DialogFlags.MODAL & flags:


### PR DESCRIPTION
In Person Tree view (and other tree views), when long running tree rebuilds are happening, a popup progress dialog appears.
The rebuild must take longer than two seconds for this to occur, so you may need a large db with a filter applied to make it happen.

This fix enables the popup to find the parent window, so it can be located front and center on top of the action.

The fix is a bit of a hack in that the original progress meter was called deep inside the TreeBaseModel class where there is no information on the current window or uistate.  Rather than refactor TreeBaseModel to fix this, I took an end around in the GtkProgressDialog class to ask Gtk to locate the current window and use it as the parent.