### PR TITLE
bug 8128; Fix transient parent for popup 'Gramps Warnings'

### DIFF
--- a/gramps/gui/displaystate.py
+++ b/gramps/gui/displaystate.py
@@ -317,13 +317,14 @@ from .logger import RotateHandler
 
 class WarnHandler(RotateHandler):
 
-    def __init__(self, capacity, button):
+    def __init__(self, capacity, button, parent=None):
         RotateHandler.__init__(self, capacity)
         self.setLevel(logging.WARN)
         self.button = button
         button.on_clicked(self.display)
         self.timer = None
         self.last_line = '-1'
+        self.parent = parent
 
     def emit(self, record):
         if self.timer is None:
@@ -354,12 +355,14 @@ class WarnHandler(RotateHandler):
 
     def display(self, obj):
         obj.hide()
-        self.glade = Glade()
+        self.glade = Glade(toplevel='displaystate')
         top = self.glade.toplevel
         msg = self.glade.get_object('msg')
         buf = msg.get_buffer()
         for i in self.get_formatted_log():
             buf.insert_at_cursor(i + '\n')
+        if self.parent:
+            top.set_transient_for(self.parent)
         top.run()
         top.destroy()
 
@@ -414,7 +417,7 @@ class DisplayState(Callback):
 
         formatter = logging.Formatter('%(levelname)s %(name)s: %(message)s')
         warnbtn = status.get_warning_button()
-        self.rhandler = WarnHandler(capacity=400, button=warnbtn)
+        self.rhandler = WarnHandler(capacity=400, button=warnbtn, parent=window)
         self.rhandler.setFormatter(formatter)
         self.rhandler.setLevel(logging.WARNING)
         self.log = logging.getLogger()

--- a/gramps/gui/glade/displaystate.glade
+++ b/gramps/gui/glade/displaystate.glade
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
-  <requires lib="gtk+" version="3.0"/>
+  <requires lib="gtk+" version="3.10"/>
   <object class="GtkDialog" id="displaystate">
-    <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Gramps Warnings</property>
-    <property name="window_position">center-always</property>
     <property name="default_width">650</property>
     <property name="default_height">500</property>
     <property name="type_hint">dialog</property>
@@ -23,7 +21,6 @@
             <child>
               <object class="GtkButton" id="close">
                 <property name="label" translatable="yes">_Close</property>
-                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
@@ -59,7 +56,7 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
An obscure feature is the ability to popup a display of recent warnings (normally in debug log) whenever the little icon in the left of the Gramps status bar appears.  This was popping up in the wrong place, so needed to fix for 'transient parent'.
To test, you need to generate loggable warnings.  I generated a new tree, used the 'tools/debug/Generate testcases' with the 'Generate database errors' check set, and then used 'tools/Family Tree Repair/Check & Repair' to have something logged.
The icon in the status bar then shows up and can be clicked.

The Glade file was causing the external transient parent setting to be ignored at first, so I did some editing and updated it; not sure exactly which setting caused the issue, but it works now.