### PR TITLE
bug 9872: fix Windows issue; Book dialogs don't stay on top

### DIFF
--- a/gramps/gui/glade/book.glade
+++ b/gramps/gui/glade/book.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkWindow" id="top">
@@ -507,8 +507,6 @@
     <property name="height_request">300</property>
     <property name="can_focus">False</property>
     <property name="type_hint">normal</property>
-    <property name="transient_for">top</property>
-    <property name="window_position">center</property>>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>

--- a/gramps/gui/plug/report/_bookdialog.py
+++ b/gramps/gui/plug/report/_bookdialog.py
@@ -147,7 +147,7 @@ class BookListDisplay:
     Allows the user to select and/or delete a book from the list.
     """
 
-    def __init__(self, booklist, nodelete=False, dosave=False):
+    def __init__(self, booklist, nodelete=False, dosave=False, parent=None):
         """
         Create a BookListDisplay object that displays the books in BookList.
 
@@ -191,6 +191,7 @@ class BookListDisplay:
 
         self.redraw()
         self.selection = None
+        self.top.set_transient_for(parent)
         self.top.run()
 
     def redraw(self):
@@ -330,7 +331,7 @@ class BookSelector(ManagedWindow):
         title_label = self.xml.get_object('title')
         self.set_window(window, title_label, self.title)
         self.setup_configs('interface.bookselector', 700, 600)
-        window.show()
+        self.show()
         self.xml.connect_signals({
             "on_add_clicked"        : self.on_add_clicked,
             "on_remove_clicked"     : self.on_remove_clicked,
@@ -764,8 +765,8 @@ class BookSelector(ManagedWindow):
         """
         Run the BookListDisplay dialog to present the choice of books to open.
         """
-        booklistdisplay = BookListDisplay(self.book_list,
-                                          nodelete=True, dosave=False)
+        booklistdisplay = BookListDisplay(self.book_list, nodelete=True,
+                                          dosave=False, parent=self.window)
         booklistdisplay.top.destroy()
         book = booklistdisplay.selection
         if book:
@@ -777,8 +778,8 @@ class BookSelector(ManagedWindow):
         """
         Run the BookListDisplay dialog to present the choice of books to delete.
         """
-        booklistdisplay = BookListDisplay(self.book_list,
-                                          nodelete=False, dosave=True)
+        booklistdisplay = BookListDisplay(self.book_list, nodelete=False,
+                                          dosave=True, parent=self.window)
         booklistdisplay.top.destroy()
         book = booklistdisplay.selection
         if book:


### PR DESCRIPTION
They are pushed to background if background window tooltip appears.
Also, The book list display was not popping up above the dialog
(no transient parent).

Turns out that the dialog, although a ManagedWindow, was not calling the ManagedWindow.show(); only the Gtk.Window.show().
This meant that the ManagedWindow transient parent code was not being executed.

The book list display transient parent was theoretically being set in the Glade file; however this functionality appears to be broken, it sets the parent to _some_ window, but I have no idea which one, certainly not the correct parent. Also the Glade file had set the book list display to 'Centered' which seems to somewhat override the transient parent location and instead centers on the screen (the center of dual screens in my case), rather than centered above the dialog. 