### PR TITLE
Fix test_exports to ignore changes in Gedcom Copyright year

### DIFF
--- a/gramps/plugins/test/test_exports.py
+++ b/gramps/plugins/test/test_exports.py
@@ -127,6 +127,9 @@ def gedfilt(line):
         elif token == "FILE" and "tests" in line:
             # probably have a media with file name
             retval = False
+        elif token == "COPR" and "Copyright (c) " in line:
+            # probably have a copyright line with year
+            retval = False
     else:   # this is an addition
         if token == "VERS" and gedfilt.prev[gedfilt.indx-1][0] == "VERS":
             # we must have a header with Gramps version
@@ -144,6 +147,9 @@ def gedfilt(line):
             retval = False
         elif token == "FILE" and "tests" in line:
             # probably have a media with file name
+            retval = False
+        elif token == "COPR" and "Copyright (c) " in line:
+            # probably have a copyright line with year
             retval = False
     return retval
 


### PR DESCRIPTION
Happy new year!

fix an bug where I did not realize that the Gramps Gedcom export inserted a programmatic copyright year in the Gedcom file.  This caused the export tests to mis-compare and fail on the changing of the years.