### PR TITLE
remove gramps.gen.simple.by_date

### DIFF
--- a/gramps/gen/simple/_simpleaccess.py
+++ b/gramps/gen/simple/_simpleaccess.py
@@ -1066,24 +1066,3 @@ class SimpleAccess:
         if object_class in self.dbase.get_table_names():
             return self.dbase.get_table_metadata(object_class) \
                 [prop + "_func"](value)
-
-def by_date(event1, event2):
-    """
-    Sort function that will compare two events by their dates.
-
-    :param event1: first event
-    :type event1: :py:class:`.Event`
-    :param event2: second event
-    :type event2: :py:class:`.Event`
-    :return: Returns -1 if event1 < event2, 0 if they are equal, and
-       1 if they are the same.
-    :rtype: int
-    """
-    if event1 and event2:
-        return cmp(event1.get_date_object() , event2.get_date_object())
-    elif event1:
-        return -1
-    elif event2:
-        return 1
-    else:
-        return 0

--- a/gramps/plugins/quickview/all_events.py
+++ b/gramps/plugins/quickview/all_events.py
@@ -24,7 +24,7 @@
 Display a person's events, both personal and family
 """
 
-from gramps.gen.simple import SimpleAccess, by_date, SimpleDoc
+from gramps.gen.simple import SimpleAccess, SimpleDoc
 from gramps.gui.plug.quick import QuickTable
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext


### PR DESCRIPTION
The function was deprecated in 8b39b80 (2012-11-15) but the deprecated
comment was somehow removed in 3ef1c02 (2013-11-12). The function won't
work anymore due to cmp not existing in python 3.