### PR TITLE
bug 8128; fix progress meters for transient parent

### DIFF
--- a/gramps/gui/utils.py
+++ b/gramps/gui/utils.py
@@ -152,6 +152,12 @@ class ProgressMeter:
         self.__dialog.vbox.set_spacing(10)
         self.__dialog.vbox.set_border_width(24)
         self.__dialog.set_size_request(400, 125)
+        if not parent:  # if we don't have an explicit parent, try to find one
+            for win in Gtk.Window.list_toplevels():
+                if win.is_active():
+                    parent = win
+                    break
+        # if we still don't have a parent, give up
         if parent:
             self.__dialog.set_transient_for(parent)
             self.__dialog.set_modal(True)

--- a/gramps/gui/widgets/progressdialog.py
+++ b/gramps/gui/widgets/progressdialog.py
@@ -494,13 +494,17 @@ class GtkProgressDialog(Gtk.Dialog):
         :type title: string
         """
         Gtk.Dialog.__init__(self)
+        parent = None
         if len(window_params) >= 2:
-            self.set_transient_for(window_params[1])
-        else:
+            parent = window_params[1]   # we got an explicit parent
+        else:                           # try to find an active window
             for win in Gtk.Window.list_toplevels():
                 if win.is_active():
-                    self.set_transient_for(win)
+                    parent = win
                     break
+        # if we still don't have a parent, give up
+        if parent:
+            self.set_transient_for(parent)
         if len(window_params) >= 3:
             flags = window_params[2]
             if Gtk.DialogFlags.MODAL & flags:


### PR DESCRIPTION
Update:
This is a partial fix for the current progress meters; it adds an attempt to find the current Gtk Window to the meters if the parent is not set.  It doesn't always work, in that if the user activates another application before the progress meter gets put up, the code cannot find a parent.  This occurs during debugging (when the debugger is the other parent).

I've abandoned the earlier attempt to do an end run around and find the Gramps main window via a stored global variable.  So some comments below are no longer relevant.

This started as a fix for the deeprelationship filter using a progress meter.  Another PR will address that more effectively.
