### PR TITLE
Bug9876; fix two progress bars occupy the same space

### DIFF
--- a/gramps/gui/selectors/baseselector.py
+++ b/gramps/gui/selectors/baseselector.py
@@ -268,11 +268,10 @@ class BaseSelector(ManagedWindow):
 
         #reset the model with correct sorting
         self.clear_model()
-        self.model = self.get_model_class()(self.db, self.sort_col,
-                                            self.sortorder,
-                                            sort_map=self.column_order(),
-                                            skip=self.skip_list,
-                                            search=filter_info)
+        self.model = self.get_model_class()(
+            self.db, self.uistate, self.sort_col, self.sortorder,
+            sort_map=self.column_order(), skip=self.skip_list,
+            search=filter_info)
 
         self.tree.set_model(self.model)
 
@@ -317,11 +316,10 @@ class BaseSelector(ManagedWindow):
     def show_toggle(self, obj):
         filter_info = None if obj.get_active() else self.filter
         self.clear_model()
-        self.model = self.get_model_class()(self.db, self.sort_col,
-                                            self.sortorder,
-                                            sort_map=self.column_order(),
-                                            skip=self.skip_list,
-                                            search=filter_info)
+        self.model = self.get_model_class()(
+            self.db, self.uistate, self.sort_col, self.sortorder,
+            sort_map=self.column_order(), skip=self.skip_list,
+            search=filter_info)
         self.tree.set_model(self.model)
         self.tree.grab_focus()
 

--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -320,9 +320,9 @@ class ListView(NavigationView):
                 if self.model:
                     self.list.set_model(None)
                     self.model.destroy()
-                self.model = self.make_model(self.dbstate.db, self.sort_col,
-                                             search=filter_info,
-                                             sort_map=self.column_order())
+                self.model = self.make_model(
+                    self.dbstate.db, self.uistate, self.sort_col,
+                    search=filter_info, sort_map=self.column_order())
             else:
                 #the entire data to show is already in memory.
                 #run only the part that determines what to show
@@ -647,10 +647,9 @@ class ListView(NavigationView):
                 self.model.reverse_order()
                 self.list.set_model(self.model)
         else:
-            self.model = self.make_model(self.dbstate.db, self.sort_col,
-                                         self.sort_order,
-                                         search=filter_info,
-                                         sort_map=self.column_order())
+            self.model = self.make_model(
+                self.dbstate.db, self.uistate, self.sort_col, self.sort_order,
+                search=filter_info, sort_map=self.column_order())
 
             self.list.set_model(self.model)
 

--- a/gramps/gui/views/treemodels/citationlistmodel.py
+++ b/gramps/gui/views/treemodels/citationlistmodel.py
@@ -56,8 +56,8 @@ class CitationListModel(CitationBaseModel, FlatBaseModel):
     """
     Flat citation model.  (Original code in CitationBaseModel).
     """
-    def __init__(self, db, scol=0, order=Gtk.SortType.ASCENDING, search=None,
-                 skip=set(), sort_map=None):
+    def __init__(self, db, uistate, scol=0, order=Gtk.SortType.ASCENDING,
+                 search=None, skip=set(), sort_map=None):
         self.map = db.get_raw_citation_data
         self.gen_cursor = db.get_citation_cursor
         self.fmap = [
@@ -94,8 +94,8 @@ class CitationListModel(CitationBaseModel, FlatBaseModel):
             self.citation_src_chan,
             self.citation_tag_color
             ]
-        FlatBaseModel.__init__(self, db, scol, order, search=search, skip=skip,
-                               sort_map=sort_map)
+        FlatBaseModel.__init__(self, db, uistate, scol, order, search=search,
+                               skip=skip, sort_map=sort_map)
 
     def destroy(self):
         """

--- a/gramps/gui/views/treemodels/citationtreemodel.py
+++ b/gramps/gui/views/treemodels/citationtreemodel.py
@@ -65,8 +65,8 @@ class CitationTreeModel(CitationBaseModel, TreeBaseModel):
     """
     Hierarchical citation model.
     """
-    def __init__(self, db, scol=0, order=Gtk.SortType.ASCENDING, search=None,
-                 skip=set(), sort_map=None):
+    def __init__(self, db, uistate, scol=0, order=Gtk.SortType.ASCENDING,
+                 search=None, skip=set(), sort_map=None):
         self.db = db
         self.number_items = self.db.get_number_of_sources
         self.map = self.db.get_raw_source_data
@@ -100,7 +100,7 @@ class CitationTreeModel(CitationBaseModel, TreeBaseModel):
             self.source_src_tag_color
             ]
 
-        TreeBaseModel.__init__(self, self.db, scol=scol, order=order,
+        TreeBaseModel.__init__(self, self.db, uistate, scol=scol, order=order,
                                search=search, skip=skip, sort_map=sort_map,
                                nrgroups=1,
                                group_can_have_handle=True,

--- a/gramps/gui/views/treemodels/eventmodel.py
+++ b/gramps/gui/views/treemodels/eventmodel.py
@@ -71,8 +71,8 @@ INVALID_DATE_FORMAT = config.get('preferences.invalid-date-format')
 #-------------------------------------------------------------------------
 class EventModel(FlatBaseModel):
 
-    def __init__(self, db, scol=0, order=Gtk.SortType.ASCENDING, search=None,
-                 skip=set(), sort_map=None):
+    def __init__(self, db, uistate, scol=0, order=Gtk.SortType.ASCENDING,
+                 search=None, skip=set(), sort_map=None):
         self.gen_cursor = db.get_event_cursor
         self.map = db.get_raw_event_data
 
@@ -100,8 +100,8 @@ class EventModel(FlatBaseModel):
             self.column_participant,
             self.column_tag_color
            ]
-        FlatBaseModel.__init__(self, db, scol, order, search=search, skip=skip,
-                               sort_map=sort_map)
+        FlatBaseModel.__init__(self, db, uistate, scol, order, search=search,
+                               skip=skip, sort_map=sort_map)
 
     def destroy(self):
         """

--- a/gramps/gui/views/treemodels/familymodel.py
+++ b/gramps/gui/views/treemodels/familymodel.py
@@ -56,8 +56,8 @@ invalid_date_format = config.get('preferences.invalid-date-format')
 #-------------------------------------------------------------------------
 class FamilyModel(FlatBaseModel):
 
-    def __init__(self, db, scol=0, order=Gtk.SortType.ASCENDING, search=None,
-                 skip=set(), sort_map=None):
+    def __init__(self, db, uistate, scol=0, order=Gtk.SortType.ASCENDING,
+                 search=None, skip=set(), sort_map=None):
         self.gen_cursor = db.get_family_cursor
         self.map = db.get_raw_family_data
         self.fmap = [
@@ -82,8 +82,8 @@ class FamilyModel(FlatBaseModel):
             self.sort_change,
             self.column_tag_color,
             ]
-        FlatBaseModel.__init__(self, db, scol, order, search=search, skip=skip,
-                               sort_map=sort_map)
+        FlatBaseModel.__init__(self, db, uistate, scol, order, search=search,
+                               skip=skip, sort_map=sort_map)
 
     def destroy(self):
         """

--- a/gramps/gui/views/treemodels/flatbasemodel.py
+++ b/gramps/gui/views/treemodels/flatbasemodel.py
@@ -450,7 +450,7 @@ class FlatBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
             so as to have localized sort
     """
 
-    def __init__(self, db, scol=0, order=Gtk.SortType.ASCENDING,
+    def __init__(self, db, uistate, scol=0, order=Gtk.SortType.ASCENDING,
                  search=None, skip=set(),
                  sort_map=None):
         cput = time.clock()

--- a/gramps/gui/views/treemodels/mediamodel.py
+++ b/gramps/gui/views/treemodels/mediamodel.py
@@ -52,8 +52,8 @@ from .flatbasemodel import FlatBaseModel
 #-------------------------------------------------------------------------
 class MediaModel(FlatBaseModel):
 
-    def __init__(self, db, scol=0, order=Gtk.SortType.ASCENDING, search=None,
-                 skip=set(), sort_map=None):
+    def __init__(self, db, uistate, scol=0, order=Gtk.SortType.ASCENDING,
+                 search=None, skip=set(), sort_map=None):
         self.gen_cursor = db.get_media_cursor
         self.map = db.get_raw_media_data
 
@@ -80,8 +80,8 @@ class MediaModel(FlatBaseModel):
             self.sort_change,
             self.column_tag_color,
             ]
-        FlatBaseModel.__init__(self, db, scol, order, search=search, skip=skip,
-                               sort_map=sort_map)
+        FlatBaseModel.__init__(self, db, uistate, scol, order, search=search,
+                               skip=skip, sort_map=sort_map)
 
     def destroy(self):
         """

--- a/gramps/gui/views/treemodels/notemodel.py
+++ b/gramps/gui/views/treemodels/notemodel.py
@@ -52,8 +52,8 @@ from gramps.gen.lib import (Note, NoteType, StyledText)
 class NoteModel(FlatBaseModel):
     """
     """
-    def __init__(self, db, scol=0, order=Gtk.SortType.ASCENDING, search=None,
-                 skip=set(), sort_map=None):
+    def __init__(self, db, uistate, scol=0, order=Gtk.SortType.ASCENDING,
+                 search=None, skip=set(), sort_map=None):
         """Setup initial values for instance variables."""
         self.gen_cursor = db.get_note_cursor
         self.map = db.get_raw_note_data
@@ -75,8 +75,8 @@ class NoteModel(FlatBaseModel):
             self.sort_change,
             self.column_tag_color
         ]
-        FlatBaseModel.__init__(self, db, scol, order, search=search, skip=skip,
-                               sort_map=sort_map)
+        FlatBaseModel.__init__(self, db, uistate, scol, order, search=search,
+                               skip=skip, sort_map=sort_map)
 
     def destroy(self):
         """

--- a/gramps/gui/views/treemodels/peoplemodel.py
+++ b/gramps/gui/views/treemodels/peoplemodel.py
@@ -573,11 +573,11 @@ class PersonListModel(PeopleBaseModel, FlatBaseModel):
     """
     Listed people model.
     """
-    def __init__(self, db, scol=0, order=Gtk.SortType.ASCENDING, search=None,
-                 skip=set(), sort_map=None):
+    def __init__(self, db, uistate, scol=0, order=Gtk.SortType.ASCENDING,
+                 search=None, skip=set(), sort_map=None):
         PeopleBaseModel.__init__(self, db)
-        FlatBaseModel.__init__(self, db, search=search, skip=skip, scol=scol,
-                               order=order, sort_map=sort_map)
+        FlatBaseModel.__init__(self, db, uistate, search=search, skip=skip,
+                               scol=scol, order=order, sort_map=sort_map)
 
     def destroy(self):
         """
@@ -590,11 +590,11 @@ class PersonTreeModel(PeopleBaseModel, TreeBaseModel):
     """
     Hierarchical people model.
     """
-    def __init__(self, db, scol=0, order=Gtk.SortType.ASCENDING, search=None,
-                 skip=set(), sort_map=None):
+    def __init__(self, db, uistate, scol=0, order=Gtk.SortType.ASCENDING,
+                 search=None, skip=set(), sort_map=None):
         PeopleBaseModel.__init__(self, db)
-        TreeBaseModel.__init__(self, db, search=search, skip=skip, scol=scol,
-                               order=order, sort_map=sort_map)
+        TreeBaseModel.__init__(self, db, uistate, search=search, skip=skip,
+                               scol=scol, order=order, sort_map=sort_map)
 
     def destroy(self):
         """

--- a/gramps/gui/views/treemodels/placemodel.py
+++ b/gramps/gui/views/treemodels/placemodel.py
@@ -230,12 +230,12 @@ class PlaceListModel(PlaceBaseModel, FlatBaseModel):
     """
     Flat place model.  (Original code in PlaceBaseModel).
     """
-    def __init__(self, db, scol=0, order=Gtk.SortType.ASCENDING, search=None,
-                 skip=set(), sort_map=None):
+    def __init__(self, db, uistate, scol=0, order=Gtk.SortType.ASCENDING,
+                 search=None, skip=set(), sort_map=None):
 
         PlaceBaseModel.__init__(self, db)
-        FlatBaseModel.__init__(self, db, scol, order, search=search, skip=skip,
-                               sort_map=sort_map)
+        FlatBaseModel.__init__(self, db, uistate, scol, order, search=search,
+                               skip=skip, sort_map=sort_map)
 
     def destroy(self):
         """
@@ -253,11 +253,11 @@ class PlaceTreeModel(PlaceBaseModel, TreeBaseModel):
     """
     Hierarchical place model.
     """
-    def __init__(self, db, scol=0, order=Gtk.SortType.ASCENDING, search=None,
-                 skip=set(), sort_map=None):
+    def __init__(self, db, uistate, scol=0, order=Gtk.SortType.ASCENDING,
+                 search=None, skip=set(), sort_map=None):
 
         PlaceBaseModel.__init__(self, db)
-        TreeBaseModel.__init__(self, db, scol=scol, order=order,
+        TreeBaseModel.__init__(self, db, uistate, scol=scol, order=order,
                                search=search, skip=skip, sort_map=sort_map,
                                nrgroups=3,
                                group_can_have_handle=True)

--- a/gramps/gui/views/treemodels/repomodel.py
+++ b/gramps/gui/views/treemodels/repomodel.py
@@ -49,8 +49,8 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 #-------------------------------------------------------------------------
 class RepositoryModel(FlatBaseModel):
 
-    def __init__(self, db, scol=0, order=Gtk.SortType.ASCENDING, search=None,
-                 skip=set(), sort_map=None):
+    def __init__(self, db, uistate, scol=0, order=Gtk.SortType.ASCENDING,
+                 search=None, skip=set(), sort_map=None):
         self.gen_cursor = db.get_repository_cursor
         self.get_handles = db.get_repository_handles
         self.map = db.get_raw_repository_data
@@ -92,8 +92,8 @@ class RepositoryModel(FlatBaseModel):
             self.column_tag_color
             ]
 
-        FlatBaseModel.__init__(self, db, scol, order, search=search, skip=skip,
-                               sort_map=sort_map)
+        FlatBaseModel.__init__(self, db, uistate, scol, order, search=search,
+                               skip=skip, sort_map=sort_map)
 
     def destroy(self):
         """

--- a/gramps/gui/views/treemodels/sourcemodel.py
+++ b/gramps/gui/views/treemodels/sourcemodel.py
@@ -49,8 +49,8 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 #-------------------------------------------------------------------------
 class SourceModel(FlatBaseModel):
 
-    def __init__(self, db, scol=0, order=Gtk.SortType.ASCENDING, search=None,
-                 skip=set(), sort_map=None):
+    def __init__(self, db, uistate, scol=0, order=Gtk.SortType.ASCENDING,
+                 search=None, skip=set(), sort_map=None):
         self.map = db.get_raw_source_data
         self.gen_cursor = db.get_source_cursor
         self.fmap = [
@@ -75,8 +75,8 @@ class SourceModel(FlatBaseModel):
             self.sort_change,
             self.column_tag_color
             ]
-        FlatBaseModel.__init__(self, db, scol, order, search=search, skip=skip,
-                               sort_map=sort_map)
+        FlatBaseModel.__init__(self, db, uistate, scol, order, search=search,
+                               skip=skip, sort_map=sort_map)
 
     def destroy(self):
         """

--- a/gramps/gui/views/treemodels/treebasemodel.py
+++ b/gramps/gui/views/treemodels/treebasemodel.py
@@ -528,11 +528,11 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
         Rebuild the data map for a single Gramps object type, where a search
         condition is applied.
         """
-        pmon = progressdlg.ProgressMonitor(progressdlg.GtkProgressDialog,
-                                            popup_time=2)
-        status = progressdlg.LongOpStatus(msg=_("Building View"),
-                            total_steps=items, interval=items//20,
-                            can_cancel=True)
+        pmon = progressdlg.ProgressMonitor(
+            progressdlg.StatusProgress, (self.uistate,), popup_time=2,
+            title=_("Loading items..."))
+        status = progressdlg.LongOpStatus(total_steps=items,
+                                          interval=items // 20)
         pmon.add_op(status)
         with gen_cursor() as cursor:
             for handle, data in cursor:
@@ -540,16 +540,13 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
                 if not isinstance(handle, str):
                     handle = handle.decode('utf-8')
                 status.heartbeat()
-                if status.should_cancel():
-                    break
                 self.__total += 1
                 if not (handle in skip or (dfilter and not
                                         dfilter.match(handle, self.db))):
                     _LOG.debug("    add %s %s" % (handle, data))
                     self.__displayed += 1
                     add_func(handle, data)
-        if not status.was_cancelled():
-            status.end()
+        status.end()
 
     def _rebuild_filter(self, dfilter, dfilter2, skip):
         """

--- a/gramps/gui/views/treemodels/treebasemodel.py
+++ b/gramps/gui/views/treemodels/treebasemodel.py
@@ -274,12 +274,9 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
                       secondary object type.
     """
 
-    def __init__(self, db,
-                    search=None, skip=set(),
-                    scol=0, order=Gtk.SortType.ASCENDING, sort_map=None,
-                    nrgroups = 1,
-                    group_can_have_handle = False,
-                    has_secondary=False):
+    def __init__(self, db, uistate, search=None, skip=set(), scol=0,
+                 order=Gtk.SortType.ASCENDING, sort_map=None, nrgroups = 1,
+                 group_can_have_handle = False, has_secondary=False):
         cput = time.clock()
         GObject.GObject.__init__(self)
         BaseModel.__init__(self)

--- a/gramps/gui/views/treemodels/treebasemodel.py
+++ b/gramps/gui/views/treemodels/treebasemodel.py
@@ -295,6 +295,7 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
         self.prev_handle = None
         self.prev_data = None
 
+        self.uistate = uistate
         self.__reverse = (order == Gtk.SortType.DESCENDING)
         self.scol = scol
         self.nrgroups = nrgroups
@@ -581,13 +582,11 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
         Rebuild the data map for a single Gramps object type, where a filter
         is applied.
         """
-        pmon = progressdlg.ProgressMonitor(progressdlg.GtkProgressDialog,
-                                            popup_time=2)
-        status = progressdlg.LongOpStatus(msg=_("Building View"),
-                              total_steps=3, interval=1)
-        pmon.add_op(status)
-        status_ppl = progressdlg.LongOpStatus(msg=_("Loading items..."),
-                        total_steps=items, interval=items//10)
+        pmon = progressdlg.ProgressMonitor(
+            progressdlg.StatusProgress, (self.uistate,), popup_time=2,
+            title=_("Loading items..."))
+        status_ppl = progressdlg.LongOpStatus(total_steps=items,
+                                              interval=items // 20)
         pmon.add_op(status_ppl)
 
         self.__total += items
@@ -606,7 +605,6 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
                     self.__displayed += 1
 
         status_ppl.end()
-        status.end()
 
     def add_node(self, parent, child, sortkey, handle, add_parent=True,
                  secondary=False):


### PR DESCRIPTION
The person tree view pops up a progress bar (GtkProgressDialog) on slow updates, with a useful indication of progress.

When the 'Relationship path between <person> and people matching <filter>' filter is used, a second progress bar (ProgressMeter) pops up which overlays the first. The 2nd bar conveys no useful information, it just flashes.

This fix moves the person tree view progress down to the Gramps Status bar (where the progress bar was already present for other operations).

Currently the other progress (ProgressMeter) pops up in the center of the screen, so both are visible.

In order to do this cleanly, I needed uistate in the TreeBaseModel; this rippled through all the dependent classes as well as the FlatBaseModel and its dependent classes for compatibility.

If (or when) this and PR316 are accepted, I will also finalize a fix for the deeprelationshippath filter and its progress bar, to get rid of its dependency on gramps.gui.utils ProgressMeter