### PR TITLE
bug 9875; fix up export dialog to show progress bar

### DIFF
--- a/gramps/gui/plug/export/_exportassistant.py
+++ b/gramps/gui/plug/export/_exportassistant.py
@@ -350,6 +350,8 @@ class ExportAssistant(ManagedWindow, Gtk.Assistant):
         box.set_spacing(6)
         box.pack_start(image, False, False, 5)
         box.pack_start(self.confirm, False, False, 5)
+        self.progressbar = Gtk.ProgressBar()
+        box.pack_start(self.progressbar, False, False, 0)
 
         page = box
         self.append_page(page)
@@ -369,13 +371,10 @@ class ExportAssistant(ManagedWindow, Gtk.Assistant):
         image.set_from_file(SPLASH)
         vbox.pack_start(image, False, False, 5)
 
-        self.labelsum = Gtk.Label(label=_("Please wait while your data is selected and exported"))
+        self.labelsum = Gtk.Label()
         self.labelsum.set_line_wrap(True)
         self.labelsum.set_use_markup(True)
         vbox.pack_start(self.labelsum, False, False, 0)
-
-        self.progressbar = Gtk.ProgressBar()
-        vbox.pack_start(self.progressbar, True, True, 0)
 
         page = vbox
         page.show_all()
@@ -486,6 +485,7 @@ class ExportAssistant(ManagedWindow, Gtk.Assistant):
                 # Override message
                 confirm_text = self.option_box_instance.confirm_text
             self.confirm.set_label(confirm_text)
+            self.progressbar.hide()
 
         elif self.get_page_type(page) ==  Gtk.AssistantPageType.SUMMARY :
             # The summary page
@@ -601,11 +601,14 @@ class ExportAssistant(ManagedWindow, Gtk.Assistant):
             log.error(_("Error exporting your Family Tree"), exc_info=True)
         return success
 
-    def pre_save(self,page):
-        #as all is locked, show the page, which assistant normally only does
-        # after prepare signal!
+    def pre_save(self, page):
+        ''' Since we are in 'prepare', the next page is not yet shown, so
+        modify the 'confirm' page text and show the progress bar
+        '''
+        self.confirm.set_label(
+            _("Please wait while your data is selected and exported"))
         self.writestarted = True
-        page.set_child_visible(True)
+        self.progressbar.show()
         self.show_all()
 
         self.set_busy_cursor(1)


### PR DESCRIPTION
Originally the progress bar and associated text was shown on the
summary page, but it was never seen since it was shown during the
Gtk assistant 'prepare' stage, before the page was shown.