### PR TITLE
bug 9854; fix Merge Family; Error dialog hidden behind Merge Dialog

### DIFF
--- a/gramps/gui/merge/mergefamily.py
+++ b/gramps/gui/merge/mergefamily.py
@@ -225,6 +225,6 @@ class MergeFamily(ManagedWindow):
             query.execute()
         except MergeError as err:
             ErrorDialog(_("Cannot merge people"), str(err),
-                        parent=self.uistate.window)
+                        parent=self.window)
         self.uistate.set_busy_cursor(False)
         self.close()


### PR DESCRIPTION
While performing a Merge Family that results in an error, the Error
dialog appears as normally initially.

However, if the user switches to another application and back, the
Error dialog can disappear (it is under the Merge dialog in the UI).
The mouse cannot clear this up (although the keyboard 'enter' or
'Esc' keys will be directed to the Error dialog and close everything.

This occurs because we set the wrong parent in the set_transient_for in the call. The parent was incorrectly set to self.uistate.window (Gramps main window) when it should have been set to self.window since the Merge persons dialog is the real parent.