### PR TITLE
upgrade Update Addons to ManagedWindow

### DIFF
--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -1421,7 +1421,7 @@ class GrampsPreferences(ConfigureDialog):
             return
 
         if len(addon_update_list) > 0:
-            PluginWindows.UpdateAddons(addon_update_list, self.window)
+            PluginWindows.UpdateAddons(self.uistate, self.track, addon_update_list)
         else:
             check_types = config.get('behavior.check-for-addon-update-types')
             OkDialog(

--- a/gramps/gui/glade/updateaddons.glade
+++ b/gramps/gui/glade/updateaddons.glade
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkDialog" id="dialog1">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
-    <property name="window_position">center</property>
     <property name="default_width">700</property>
     <property name="default_height">500</property>
     <property name="destroy_with_parent">True</property>

--- a/gramps/gui/plug/_windows.py
+++ b/gramps/gui/plug/_windows.py
@@ -1072,16 +1072,16 @@ class ToolManagedWindow(tool.Tool, ToolManagedWindowBase):
 # UpdateAddons
 #
 #-------------------------------------------------------------------------
-class UpdateAddons:
+class UpdateAddons(ManagedWindow):
 
-    def __init__(self, addon_update_list, parent_window):
+    def __init__(self, uistate, track, addon_update_list):
         self.title = _('Available Gramps Updates for Addons')
 
+        ManagedWindow.__init__(self, uistate, track, self, modal=True)
         glade = Glade("updateaddons.glade")
-        self.window = glade.toplevel
+        self.set_window(glade.toplevel, None, None)
         self.window.set_title(self.title)
-        self.window.set_size_request(750, 400)
-        self.window.set_transient_for(parent_window)
+        self.setup_configs("interface.updateaddons", 750, 400)
 
         apply_button = glade.get_object('apply')
         cancel_button = glade.get_object('cancel')
@@ -1135,13 +1135,11 @@ class UpdateAddons:
                 pos = iter
         if pos:
             self.list.selection.select_iter(pos)
-        self.window.run()
 
-    def close(self, widget):
-        """
-        Close the dialog.
-        """
-        self.window.destroy()
+        self.show()
+
+    def build_menu_names(self, obj):
+        return (self.title, " ")
 
     def select_all_clicked(self, widget):
         """
@@ -1176,7 +1174,7 @@ class UpdateAddons:
             length, 1, # total, increment-by
             can_cancel=True)
         pm = ProgressMonitor(GtkProgressDialog,
-                             ("Title", self.window, Gtk.DialogFlags.MODAL))
+                             ("Title", self.parent_window, Gtk.DialogFlags.MODAL))
         pm.add_op(longop)
         count = 0
         if not config.get('behavior.do-not-show-previously-seen-addon-updates'):
@@ -1210,7 +1208,7 @@ class UpdateAddons:
             OkDialog(_("Installation Errors"),
                      _("The following addons had errors: ") +
                      ", ".join(errors),
-                     parent=self.window)
+                     parent=self.parent_window)
         if count:
             OkDialog(_("Done downloading and installing addons"),
                      # translators: leave all/any {...} untranslated
@@ -1218,12 +1216,12 @@ class UpdateAddons:
                                          "{number_of} addons were installed.",
                                          count).format(number_of=count),
                         _("If you have installed a 'Gramps View', you will need to restart Gramps.")),
-                     parent=self.window)
+                     parent=self.parent_window)
         else:
             OkDialog(_("Done downloading and installing addons"),
                      _("No addons were installed."),
-                     parent=self.window)
-        self.window.destroy()
+                     parent=self.parent_window)
+        self.close()
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -344,7 +344,7 @@ class ViewManager(CLIManager):
         """
         Called when add-on updates are available.
         """
-        PluginWindows.UpdateAddons(addon_update_list, self.window)
+        PluginWindows.UpdateAddons(self.uistate, [], addon_update_list)
         self.do_reg_plugins(self.dbstate, self.uistate)
 
     def _errordialog(self, title, errormessage):


### PR DESCRIPTION
This change was initiated to correct status bar and popup dialogs that were coming up in the wrong place under Windows.
Upgrade to Managedwindow allows for size/position config, correct popup of subordinate dialogs, and better window management in relation to other dialogs.
The Glade change allows the transient parent function to work.
Note that UpdateAddons remains a modal dialog.

During Gramps startup, it is possible to start two modal dialogs;
the 'Family Trees' and the 'Update Addons' (when preferences is set to check on startup).  Both are modal. This presented some issues on Windows, at least.

So the second commit upgrades the Window manager and ManagedWindow to support this case.  If this occurs, then the most recent modal window is left that way, a previous modal window is temporarily downgraded to non-modal, and the newest window is set 'transient' for the previous modal window, even if it was not the parent.
This means that there can be only one modal window, and it is always on top and active.
During testing for this change, I ran into a conflict with the Gtk.Window.present and the ManagedWindow.present methods, so I renamed the ManagedWindow version.

I've put both commits in the same PR as they can be best tested together.