### PR TITLE
Fix AddMedia to use updated ManagedWindow modal parameter

### DIFF
--- a/gramps/gui/editors/addmedia.py
+++ b/gramps/gui/editors/addmedia.py
@@ -88,7 +88,7 @@ class AddMedia(ManagedWindow):
         The media is updated with the information, and on save, the
         callback function is called
         """
-        ManagedWindow.__init__(self, uistate, track, self)
+        ManagedWindow.__init__(self, uistate, track, self, modal=True)
 
         self.dbase = dbstate.db
         self.obj = media
@@ -140,7 +140,6 @@ class AddMedia(ManagedWindow):
                                              section=WIKI_HELP_SEC))
         self.cancel_button.connect('clicked', self.close)
         self.show()
-        self.modal_call()
 
     def build_menu_names(self, obj):
         """
@@ -192,6 +191,7 @@ class AddMedia(ManagedWindow):
         self._cleanup_on_exit()
         if self.callback:
             self.callback(self.obj)
+        self.close()
 
     def on_name_changed(self, *obj):
         """

--- a/gramps/gui/managedwindow.py
+++ b/gramps/gui/managedwindow.py
@@ -533,39 +533,6 @@ class ManagedWindow:
             self.opened = True
             self.window.show_all()
 
-    def  modal_call(self, after_ok_func=None):
-        """
-        This is deprecated; use the 'modal=True' on the ManagedWindow
-        initialization for new work.
-
-            Method to do modal run of the ManagedWindow.
-            Connect the OK button to a method that checks if all is ok,
-                Do not call close, close is called here.
-                (if not ok, do self.window.run() to obtain new response )
-                TODO: remove close here and do close in ReportDialog,
-                      this can only be done, once all methods use modal_call()
-                      instead of their own implementation
-            Connect Cancel to do close, delete event is connected to close
-                here in ManagedWindow.
-            Do not generete RESPONSE_OK/CANCEL/DELETE_EVENT on button clicks
-            of other buttons
-            after_ok_func is called on ok click in this method
-        """
-        #self.show()
-        while True:
-            response = self.window.run()
-            if response == Gtk.ResponseType.OK:
-                # dialog will be closed by connect, now continue work while
-                # rest of dialog is unresponsive, release when finished
-                self.close()
-                if after_ok_func is not None:
-                    after_ok_func()
-                break
-            elif (response == Gtk.ResponseType.DELETE_EVENT or
-              response == Gtk.ResponseType.CANCEL):
-                # connect buttons generating this to a close call
-                break
-
     def close(self, *obj):
         """
         Close itself.


### PR DESCRIPTION
and Remove now unused ManagedWindow modal_call method.

This eliminates one of the ways that ManagedWindow classes can implement a modal window.  The use of an initialization parameter (modal=) on the ManagedWindow is preferred.