### PR TITLE
Fix wording for addon restart

### DIFF
--- a/gramps/gui/plug/_windows.py
+++ b/gramps/gui/plug/_windows.py
@@ -1217,7 +1217,7 @@ class UpdateAddons:
                      "%s %s" % (ngettext("{number_of} addon was installed.",
                                          "{number_of} addons were installed.",
                                          count).format(number_of=count),
-                        _("You need to restart Gramps to use the new addons.")),
+                        _("If you have installed a 'Gramps View', you will need to restart Gramps.")),
                      parent=self.window)
         else:
             OkDialog(_("Done downloading and installing addons"),


### PR DESCRIPTION
to mention [Gramps Views] as the special case why you need to restart

It is not necessary to restart Gramps after installing most addons. Gramps Views are a special case

![updated-restart-message](https://cloud.githubusercontent.com/assets/8924713/21959258/972397ca-db15-11e6-98b5-5dc7b84cf0e8.png)
