### PR TITLE
Fix 'Tip of the day' dialog to stay on top of main window

### DIFF
--- a/gramps/gui/tipofday.py
+++ b/gramps/gui/tipofday.py
@@ -96,7 +96,7 @@ class TipOfDay(ManagedWindow):
         self.index = 0
         self.next_tip_cb()
 
-        window.show_all()
+        self.show()
 
     def escape(self,text):
         text = text.replace('&','&amp;');       # Must be first


### PR DESCRIPTION
Previously never had a transient parent because it failed to call
ManagedWindow.show()