### PR TITLE
bug 9886; fix citation tree view quick report right click

### DIFF
--- a/gramps/gui/plug/quick/_quickreports.py
+++ b/gramps/gui/plug/quick/_quickreports.py
@@ -257,14 +257,12 @@ def run_report(dbstate, uistate, category, handle, pdata, container=None,
                 elif category == CATEGORY_QR_CITATION :
                     obj = dbstate.db.get_citation_from_handle(handle)
                 elif category == CATEGORY_QR_SOURCE_OR_CITATION :
-                    source = dbstate.db.get_source_from_handle(handle)
-                    citation = dbstate.db.get_citation_from_handle(handle)
-                    if (not source and not citation) or (source and citation):
-                        raise ValueError("selection must be either source or citation")
-                    if citation:
-                        obj = citation
+                    if dbstate.db.has_source_handle(handle):
+                        obj = dbstate.db.get_source_from_handle(handle)
+                    elif dbstate.db.has_citation_handle(handle):
+                        obj = dbstate.db.get_citation_from_handle(handle)
                     else:
-                        obj = source
+                        raise ValueError("selection must be either source or citation")
                 elif category == CATEGORY_QR_PLACE :
                     obj = dbstate.db.get_place_from_handle(handle)
                 elif category == CATEGORY_QR_MEDIA :

--- a/gramps/plugins/quickview/quickview.gpr.py
+++ b/gramps/plugins/quickview/quickview.gpr.py
@@ -207,7 +207,7 @@ refitems = [(CATEGORY_QR_PERSON, 'person', _("Person")),
             (CATEGORY_QR_MEDIA, 'media', _("Media")),
             (CATEGORY_QR_NOTE, 'note', _("Note")),
             (CATEGORY_QR_CITATION, 'citation', _("Citation")),
-            (CATEGORY_QR_SOURCE_OR_CITATION, 'source or citation',
+            (CATEGORY_QR_SOURCE_OR_CITATION, 'source_or_citation',
                     _("Source or Citation"))
             ]
 


### PR DESCRIPTION
Another HandleError issue;  Also, the Quick report that started was
actually the wrong one, due to a typo in the quickview.gpr.py.

I also rediscovered the bug 6352; and its relationship to quickreports.
It seems that you cannot run a quick report on a source from citation tree view.  Even if it looks like you can, it really ran on the last citation you looked at, not the source.  If you never look at a citation in this view since startup, the quick report menu item doesn't even appear.