### PR TITLE
Improve progress indicator for deep relationship filter

### DIFF
--- a/gramps/gui/utils.py
+++ b/gramps/gui/utils.py
@@ -139,7 +139,18 @@ class ProgressMeter:
         else:
             self.__cancel_callback = self.handle_cancel
 
-        if has_display():
+        # if we don't have an explicit parent, try to find one
+        if has_display() and not parent:
+            gramps_main = None
+            for win in Gtk.Window.list_toplevels():
+                if win.is_active():
+                    parent = win
+                    break
+                if hasattr(win, 'gramps_main'):
+                    gramps_main = win
+        parent = parent if parent else gramps_main
+        # if we still don't have a parent (cli), give up
+        if has_display() and parent:
             self.__dialog = Gtk.Dialog()
         else:
             self.__dialog = CLIDialog()
@@ -152,12 +163,6 @@ class ProgressMeter:
         self.__dialog.vbox.set_spacing(10)
         self.__dialog.vbox.set_border_width(24)
         self.__dialog.set_size_request(400, 125)
-        if not parent:  # if we don't have an explicit parent, try to find one
-            for win in Gtk.Window.list_toplevels():
-                if win.is_active():
-                    parent = win
-                    break
-        # if we still don't have a parent, give up
         if parent:
             self.__dialog.set_transient_for(parent)
             self.__dialog.set_modal(True)

--- a/gramps/gui/utils.py
+++ b/gramps/gui/utils.py
@@ -44,6 +44,9 @@ import gi
 gi.require_version('PangoCairo', '1.0')
 from gi.repository import PangoCairo
 from gi.repository import GLib
+from gi.repository import Gtk
+from gi.repository import Gdk
+
 
 #-------------------------------------------------------------------------
 #
@@ -127,7 +130,6 @@ class ProgressMeter:
         """
         Specify the title and the current pass header.
         """
-        from gi.repository import Gtk
         self.__mode = ProgressMeter.MODE_FRACTION
         self.__pbar_max = 100.0
         self.__pbar_index = 0.0
@@ -246,7 +248,6 @@ class ProgressMeter:
         of steps to be used.
         """
 
-        from gi.repository import Gtk
         self.__mode = mode
         self.__pbar_max = total
         self.__pbar_index = 0.0
@@ -273,7 +274,6 @@ class ProgressMeter:
         and insure that it doesn't go over 100%.
         """
 
-        from gi.repository import Gtk
         if self.__mode is ProgressMeter.MODE_FRACTION:
             self.__pbar_index = self.__pbar_index + 1.0
 
@@ -298,7 +298,6 @@ class ProgressMeter:
         return self.__cancelled
 
     def set_header(self, text):
-        from gi.repository import Gtk
         self.__lbl.set_text(text)
         while Gtk.events_pending():
             Gtk.main_iteration()
@@ -448,7 +447,6 @@ def open_file_with_default_application(path, uistate):
 
     proc = subprocess.Popen([utility, norm_path], stderr=subprocess.STDOUT)
 
-    from gi.repository import GLib
     GLib.timeout_add_seconds(1, poll_external, (proc, errstrings, uistate))
     return
 
@@ -456,7 +454,6 @@ def process_pending_events(max_count=10):
     """
     Process pending events, but don't get into an infinite loop.
     """
-    from gi.repository import Gtk
     count = 0
     while Gtk.events_pending():
         Gtk.main_iteration()
@@ -473,7 +470,6 @@ def is_right_click(event):
     """
     Returns True if the event is a button-3 or equivalent
     """
-    from gi.repository import Gdk
 
     if event.type == Gdk.EventType.BUTTON_PRESS:
         if is_quartz():
@@ -685,8 +681,6 @@ def text_to_clipboard(text):
     """
     Put any text into the clipboard
     """
-    from gi.repository import Gdk
-    from gi.repository import Gtk
     clipboard = Gtk.Clipboard.get_for_display(Gdk.Display.get_default(),
                                               Gdk.SELECTION_CLIPBOARD)
     clipboard.set_text(text, -1)

--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -366,6 +366,7 @@ class ViewManager(CLIManager):
         vert_position = config.get('interface.main-window-vert-position')
 
         self.window = Gtk.Window()
+        self.window.gramps_main = True
         self.window.set_icon_from_file(ICON)
         self.window.set_default_size(width, height)
         self.window.move(horiz_position, vert_position)


### PR DESCRIPTION
and improve gui.utils.ProgressMeter to help it find a parent window.

The deep relationship filter now actually shows progress, not just an activity indicator.

I've spent way too much time trying to figure out a way to fix up the plumbing for this one rarely used filter.  So here is a fix that at least makes it work for the person tree view, exports, and reports in both GUI and CLI modes.

The fix is not ideal in that it does NOT use the User class or similar.  That would take extensive architectural reworking in filters, proxy db, db, reports, export, and views.  After spending almost a week unsuccessfully trying to figure out limited changes to most of these, I am retreating, at least for now.

This work was an offshoot of the [8128](https://gramps-project.org/bugs/view.php?id=8128#c49001) transient parent bug.

In the research for this I did find a couple more bugs which I CAN deal with...