### PR TITLE
9914: Add [Arrowhead direction] option to Familylines graph

### DIFF
--- a/gramps/plugins/graph/gvfamilylines.py
+++ b/gramps/plugins/graph/gvfamilylines.py
@@ -74,6 +74,11 @@ _COLORS = [{'name' : _("B&W outline"), 'value' : "outline"},
            {'name' : _("Colored outline"), 'value' : "colored"},
            {'name' : _("Color fill"), 'value' : "filled"}]
 
+_ARROWS = [ { 'name' : _("Descendants <- Ancestors"),  'value' : 'd' },
+            { 'name' : _("Descendants -> Ancestors"),  'value' : 'a' },
+            { 'name' : _("Descendants <-> Ancestors"), 'value' : 'da' },
+            { 'name' : _("Descendants - Ancestors"),   'value' : '' }]
+
 #------------------------------------------------------------------------
 #
 # A quick overview of the classes we'll be using:
@@ -148,6 +153,12 @@ class FamilyLinesOptions(MenuReportOptions):
                          "If the sex of an individual "
                          "is unknown it will be shown with gray."))
         add_option("color", color)
+
+        arrow = EnumeratedListOption(_("Arrowhead direction"), 'd')
+        for i in range( 0, len(_ARROWS) ):
+            arrow.add_item(_ARROWS[i]["value"], _ARROWS[i]["name"])
+        arrow.set_help(_("Choose the direction that the arrows point."))
+        add_option("arrow", arrow)
 
         stdoptions.add_localization_option(menu, category_name)
 
@@ -365,6 +376,16 @@ class FamilyLinesReport(Report):
         self._incplaces = get_value('incplaces')
         self._incchildcount = get_value('incchildcnt')
         self.includeid = get_value('incid')
+
+        arrow_str = get_value('arrow')
+        if 'd' in arrow_str:
+            self._arrowheadstyle = 'normal'
+        else:
+            self._arrowheadstyle = 'none'
+        if 'a' in arrow_str:
+            self._arrowtailstyle = 'normal'
+        else:
+            self._arrowtailstyle = 'none'
 
         # the gidlist is annoying for us to use since we always have to convert
         # the GIDs to either Person or to handles, so we may as well convert the
@@ -1015,8 +1036,9 @@ class FamilyLinesReport(Report):
                     father = self._db.get_person_from_handle(father_handle)
                     father_rn = father.get_primary_name().get_regular_name()
                     comment = self._("father: %s") % father_rn
-                    self.doc.add_link(father.get_gramps_id(),
-                                      fgid, comment=comment)
+                    self.doc.add_link(father.get_gramps_id(), fgid, "",
+                                      self._arrowheadstyle, self._arrowtailstyle,
+                                      comment=comment)
 
             # see if we have a mother to link to this family
             if mother_handle:
@@ -1024,8 +1046,9 @@ class FamilyLinesReport(Report):
                     mother = self._db.get_person_from_handle(mother_handle)
                     mother_rn = mother.get_primary_name().get_regular_name()
                     comment = self._("mother: %s") % mother_rn
-                    self.doc.add_link(mother.get_gramps_id(),
-                                      fgid, comment=comment)
+                    self.doc.add_link(mother.get_gramps_id(), fgid, "",
+                                      self._arrowheadstyle, self._arrowtailstyle,
+                                      comment=comment)
 
             if self._usesubgraphs and father_handle and mother_handle:
                 self.doc.end_subgraph()
@@ -1036,7 +1059,8 @@ class FamilyLinesReport(Report):
                     child = self._db.get_person_from_handle(childref.ref)
                     child_rn = child.get_primary_name().get_regular_name()
                     comment = self._("child: %s") % child_rn
-                    self.doc.add_link(fgid, child.get_gramps_id(),
+                    self.doc.add_link(fgid, child.get_gramps_id(), "",
+                                      self._arrowheadstyle, self._arrowtailstyle,
                                       comment=comment)
 
     def get_event_place(self, event):


### PR DESCRIPTION
Bring a bit more consistency to the three graph reports.  Adds the [Arrowhead direction] option to Familylines graph.

![familylines-arrowheaddirection-option-default](https://cloud.githubusercontent.com/assets/8924713/22359164/e2e001bc-e498-11e6-80aa-89419ac94623.png)

Example output with no arrowheads:
![familylines-arrowheaddirection-no-arrows-example-output](https://cloud.githubusercontent.com/assets/8924713/22359167/e6f383dc-e498-11e6-8694-e5cc4353984d.png)
