### PR TITLE
Remove hidden character from front of shebang line

### DIFF
--- a/gramps/plugins/test/test_imports.py
+++ b/gramps/plugins/test/test_imports.py
@@ -1,4 +1,4 @@
-﻿#! /usr/bin/env python3
+#! /usr/bin/env python3
 """ Test program for import modules
 """
 #


### PR DESCRIPTION
Found by [pycycle --verbose --source gramps]

Once corrected pycycle reports:

Project successfully transformed to AST, checking imports for cycles..

No worries, no cycles here!

https://github.com/bndr/pycycle