### PR TITLE
Add Progress indicators to filters and reports

### DIFF
--- a/gramps/gen/filters/rules/person/_deeprelationshippathbetween.py
+++ b/gramps/gen/filters/rules/person/_deeprelationshippathbetween.py
@@ -106,6 +106,8 @@ def find_deep_relations(db, user, person, path, seen, target_people):
     if handle in seen:
         return []
     seen.append(handle)
+    if user:
+        user.step_progress()
 
     return_paths = []
     person_path = path + [handle]
@@ -118,8 +120,6 @@ def find_deep_relations(db, user, person, path, seen, target_people):
     for family_person in family_people:
         pers = db.get_person_from_handle(family_person)
         return_paths += find_deep_relations(db, user, pers, person_path, seen, target_people)
-        if user:
-            user.step_progress()
 
     return return_paths
 

--- a/gramps/gen/filters/rules/person/_hascommonancestorwithfiltermatch.py
+++ b/gramps/gen/filters/rules/person/_hascommonancestorwithfiltermatch.py
@@ -64,12 +64,20 @@ class HasCommonAncestorWithFilterMatch(HasCommonAncestorWith):
         self.with_people = []
         filt = MatchesFilter(self.list)
         filt.requestprepare(db, user)
+        if user:
+            user.begin_progress(self.category,
+                                _('Retrieving all sub-filter matches'),
+                                db.get_number_of_people())
         for handle in db.iter_person_handles():
             person = db.get_person_from_handle(handle)
+            if user:
+                user.step_progress()
             if person and filt.apply(db, person):
                 #store all people in the filter so as to compare later
                 self.with_people.append(person.handle)
                 #fill list of ancestor of person if not present yet
                 if handle not in self.ancestor_cache:
                     self.add_ancs(db, person)
+        if user:
+            user.end_progress()
         filt.requestreset()

--- a/gramps/gen/filters/rules/person/_isancestoroffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isancestoroffiltermatch.py
@@ -62,9 +62,17 @@ class IsAncestorOfFilterMatch(IsAncestorOf):
 
         filt = MatchesFilter(self.list[0:1])
         filt.requestprepare(db, user)
+        if user:
+            user.begin_progress(self.category,
+                                _('Retrieving all sub-filter matches'),
+                                db.get_number_of_people())
         for person in db.iter_people():
+            if user:
+                user.step_progress()
             if filt.apply(db, person):
                 self.init_ancestor_list(db, person, first)
+        if user:
+            user.end_progress()
         filt.requestreset()
 
     def reset(self):

--- a/gramps/gen/filters/rules/person/_ischildoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_ischildoffiltermatch.py
@@ -53,9 +53,17 @@ class IsChildOfFilterMatch(Rule):
         self.map = set()
         filt = MatchesFilter(self.list)
         filt.requestprepare(db, user)
+        if user:
+            user.begin_progress(self.category,
+                                _('Retrieving all sub-filter matches'),
+                                db.get_number_of_people())
         for person in db.iter_people():
+            if user:
+                user.step_progress()
             if filt.apply(db, person):
                 self.init_list(person)
+        if user:
+            user.end_progress()
         filt.requestreset()
 
     def reset(self):

--- a/gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py
@@ -55,8 +55,16 @@ class IsDescendantFamilyOfFilterMatch(IsDescendantFamilyOf):
 
         filt = MatchesFilter(self.list[0:1])
         filt.requestprepare(db, user)
+        if user:
+            user.begin_progress(self.category,
+                                _('Retrieving all sub-filter matches'),
+                                db.get_number_of_people())
         for person in db.iter_people():
+            if user:
+                user.step_progress()
             if filt.apply(db, person):
                 self.add_matches(person)
+        if user:
+            user.end_progress()
         filt.requestreset()
 

--- a/gramps/gen/filters/rules/person/_isdescendantoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isdescendantoffiltermatch.py
@@ -62,9 +62,17 @@ class IsDescendantOfFilterMatch(IsDescendantOf):
 
         filt = MatchesFilter(self.list[0:1])
         filt.requestprepare(db, user)
+        if user:
+            user.begin_progress(self.category,
+                                _('Retrieving all sub-filter matches'),
+                                db.get_number_of_people())
         for person in db.iter_people():
+            if user:
+                user.step_progress()
             if filt.apply(db, person):
                 self.init_list(person, first)
+        if user:
+            user.end_progress()
         filt.requestreset()
 
     def reset(self):

--- a/gramps/gen/filters/rules/person/_isparentoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isparentoffiltermatch.py
@@ -53,9 +53,17 @@ class IsParentOfFilterMatch(Rule):
         self.map = set()
         filt = MatchesFilter(self.list)
         filt.requestprepare(db, user)
+        if user:
+            user.begin_progress(self.category,
+                                _('Retrieving all sub-filter matches'),
+                                db.get_number_of_people())
         for person in db.iter_people():
+            if user:
+                user.step_progress()
             if filt.apply(db, person):
                 self.init_list(person)
+        if user:
+            user.end_progress()
         filt.requestreset()
 
     def reset(self):

--- a/gramps/gen/filters/rules/person/_issiblingoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_issiblingoffiltermatch.py
@@ -52,9 +52,17 @@ class IsSiblingOfFilterMatch(Rule):
         self.map = set()
         filt = MatchesFilter(self.list)
         filt.requestprepare(db, user)
+        if user:
+            user.begin_progress(self.category,
+                                _('Retrieving all sub-filter matches'),
+                                db.get_number_of_people())
         for person in db.iter_people():
+            if user:
+                user.step_progress()
             if filt.apply (db, person):
                 self.init_list (person)
+        if user:
+            user.end_progress()
         filt.requestreset()
 
     def reset(self):
@@ -67,8 +75,9 @@ class IsSiblingOfFilterMatch(Rule):
         if not person:
             return
         fam_id = person.get_main_parents_family_handle()
-        fam = self.db.get_family_from_handle(fam_id)
-        if fam:
-            self.map.update(child_ref.ref
-                for child_ref in fam.get_child_ref_list()
+        if fam_id:
+            fam = self.db.get_family_from_handle(fam_id)
+            if fam:
+                self.map.update(
+                    child_ref.ref for child_ref in fam.get_child_ref_list()
                     if child_ref and child_ref.ref != person.handle)

--- a/gramps/gen/plug/report/_reportbase.py
+++ b/gramps/gen/plug/report/_reportbase.py
@@ -45,6 +45,7 @@ class Report:
     def __init__(self, database, options_class, user):
         self.database = database
         self.options_class = options_class
+        self._user = user
 
         self.doc = options_class.get_document()
 

--- a/gramps/gui/views/treemodels/treebasemodel.py
+++ b/gramps/gui/views/treemodels/treebasemodel.py
@@ -587,7 +587,8 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
         self.__total += items
         assert not skip
         if dfilter:
-            for handle in dfilter.apply(self.db, user=User()):
+            for handle in dfilter.apply(self.db,
+                                        user=User(parent=self.uistate.window)):
                 status_ppl.heartbeat()
                 data = data_map(handle)
                 add_func(handle, data)

--- a/gramps/plugins/graph/gvrelgraph.py
+++ b/gramps/plugins/graph/gvrelgraph.py
@@ -193,8 +193,14 @@ class RelGraphReport(Report):
                                             self._db.iter_person_handles())
 
         if len(person_handles) > 1:
+            if self._user:
+                self._user.begin_progress(_("Relationship Graph"),
+                                          _("Generating report"),
+                                          len(person_handles) * 2)
             self.add_persons_and_families(person_handles)
             self.add_child_links_to_families(person_handles)
+            if self._user:
+                self._user.end_progress()
 
     def add_child_links_to_families(self, person_handles):
         """
@@ -205,6 +211,8 @@ class RelGraphReport(Report):
         person_dict = dict([handle, 1] for handle in person_handles)
 
         for person_handle in person_handles:
+            if self._user:
+                self._user.step_progress()
             person = self._db.get_person_from_handle(person_handle)
             p_id = person.get_gramps_id()
             for fam_handle in person.get_parent_family_handle_list():
@@ -261,6 +269,8 @@ class RelGraphReport(Report):
         # so we don't do it twice
         families_done = {}
         for person_handle in person_handles:
+            if self._user:
+                self._user.step_progress()
             # determine per person if we use HTML style label
             if self.includeimg:
                 self.use_html_output = True

--- a/gramps/plugins/textreport/indivcomplete.py
+++ b/gramps/plugins/textreport/indivcomplete.py
@@ -812,12 +812,21 @@ class IndivCompleteReport(Report):
             raise ReportError(_('Empty report'),
                               _('You did not specify anybody'))
 
+        if self._user:
+            self._user.begin_progress(_("Complete Individual Report"),
+                                      _("Generating report"),
+                                      len(ind_list))
         for count, person_handle in enumerate(ind_list):
+            if self._user:
+                self._user.step_progress()
             self.person = self._db.get_person_from_handle(person_handle)
             if self.person is None:
                 continue
             self.family_notes_list = []
             self.write_person(count)
+        if self._user:
+            self._user.end_progress()
+
 
     def write_person(self, count):
         """ write a person """

--- a/gramps/plugins/textreport/notelinkreport.py
+++ b/gramps/plugins/textreport/notelinkreport.py
@@ -98,7 +98,13 @@ class NoteLinkReport(Report):
 
         self.doc.end_row()
 
+        if self._user:
+            self._user.begin_progress(_("Note Link Check Report"),
+                                      _("Generating report"),
+                                      self.database.get_number_of_notes())
         for note in self.database.iter_notes():
+            if self._user:
+                self._user.step_progress()
             for (ldomain, ltype, lprop, lvalue) in note.get_links():
                     if ldomain == "gramps":
                         tagtype = _(ltype)
@@ -141,6 +147,8 @@ class NoteLinkReport(Report):
                     self.doc.end_cell()
 
                     self.doc.end_row()
+        if self._user:
+            self._user.end_progress()
 
         self.doc.end_table()
 


### PR DESCRIPTION
It started with testing the user progress indicator...

Add progress indication for filters with long 'prepare' times (these had scans of the entire db for persons in the 'prepare' stage).

And fix DeepRelationshipPathBetween for more accurate progress; the original code called step many more times than the 'total' progress count, which made for an apparent freeze.  The fix makes indication more accurate, can still be off a bit if the family tree has a lot of non-relatives (filter ends before progress get to 100%), and can be off the other way if the family tree has cycles.

And fix IsSiblingOfFilterMatch for HandleError, just found this during testing of progress, too lazy to make a separate commit.

Fix TreeBaseModel so that filters have correct transient parent.

Add progress indication to long running reports.