### PR TITLE
bug 9934; fix error when 'Manage Family Tree' is closed via ESC key

### DIFF
--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -484,7 +484,8 @@ class DbManager(CLIDbManager, ManagedWindow):
             else:
                 del self.selection
                 del self.name_renderer
-                self.close()
+                if value != Gtk.ResponseType.DELETE_EVENT:
+                    self.close()
                 return None
 
     def __ask_to_break_lock(self, store, node):


### PR DESCRIPTION
or the dialog close 'x' in top left.

These methods of closing the dialog took a direct path to 'self.close' from the Gtk 'delete-event' signal via a 'connect' in the ManagedWindow class 'set_window' method.
And then when the dialog finished closing in the dbman 'run', the dbman original code called 'self.close' again.  The Window manager could not find the already closed window in the list, thus the error.

I did not catch this originally myself, because I tend to use the keyboard rarely, and have always clicked the 'Close Window' button, which does NOT emit the 'delete-event' signal.