### PR TITLE
Fix some Gtk deprecations

### DIFF
--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -102,9 +102,9 @@ class DisplayNameEditor(ManagedWindow):
         self.dialog = dialog
         self.dbstate = dbstate
         self.set_window(
-            Gtk.Dialog(_('Display Name Editor'),
-                       buttons=(_('_Close'), Gtk.ResponseType.CLOSE)),
+            Gtk.Dialog(title=_('Display Name Editor')),
             None, _('Display Name Editor'), None)
+        self.window.add_button(_('_Close'), Gtk.ResponseType.CLOSE)
         self.setup_configs('interface.displaynameeditor', 820, 550)
         grid = self.dialog._build_custom_name_ui()
         label = Gtk.Label(label=_("""The following keywords are replaced with the appropriate name parts:<tt>
@@ -176,9 +176,9 @@ class ConfigureDialog(ManagedWindow):
         self.__config = configmanager
         ManagedWindow.__init__(self, uistate, [], configobj)
         self.set_window(
-            Gtk.Dialog(dialogtitle,
-                       buttons=(_('_Close'), Gtk.ResponseType.CLOSE)),
+            Gtk.Dialog(title=dialogtitle),
                        None, dialogtitle, None)
+        self.window.add_button(_('_Close'), Gtk.ResponseType.CLOSE)
         self.panel = Gtk.Notebook()
         self.panel.set_scrollable(True)
         self.window.vbox.pack_start(self.panel, True, True, 0)
@@ -817,7 +817,7 @@ class GrampsPreferences(ConfigureDialog):
         grid.set_row_spacing(6)
 
         # make a treeview for listing all the name formats
-        format_tree = Gtk.TreeView(self.fmt_model)
+        format_tree = Gtk.TreeView(model=self.fmt_model)
         name_renderer = Gtk.CellRendererText()
         name_column = Gtk.TreeViewColumn(_('Format'),
                                          name_renderer,
@@ -982,7 +982,7 @@ class GrampsPreferences(ConfigureDialog):
         lwidget.set_use_underline(True)
         lwidget.set_mnemonic_widget(self.fmt_obox)
         hbox = Gtk.Box()
-        btn = Gtk.Button("%s..." % _('Edit') )
+        btn = Gtk.Button(label=("%s..." % _('Edit')))
         btn.connect('clicked', self.cb_name_dialog)
         hbox.pack_start(self.fmt_obox, True, True, 0)
         hbox.pack_start(btn, False, False, 0)
@@ -1559,13 +1559,10 @@ class GrampsPreferences(ConfigureDialog):
 
     def select_dbpath(self, *obj):
         f = Gtk.FileChooserDialog(title=_("Select database directory"),
-                                    parent=self.window,
-                                    action=Gtk.FileChooserAction.SELECT_FOLDER,
-                                    buttons=(_('_Cancel'),
-                                                Gtk.ResponseType.CANCEL,
-                                                _('_Apply'),
-                                                Gtk.ResponseType.OK)
-                                    )
+                                  transient_for=self.window,
+                                  action=Gtk.FileChooserAction.SELECT_FOLDER)
+        f.add_buttons(_('_Cancel'), Gtk.ResponseType.CANCEL,
+                      _('_Apply'), Gtk.ResponseType.OK)
         dbpath = config.get('database.path')
         if not dbpath:
             dbpath = os.path.join(HOME_DIR,'grampsdb')

--- a/gramps/gui/plug/_guioptions.py
+++ b/gramps/gui/plug/_guioptions.py
@@ -1161,7 +1161,7 @@ class GuiPersonListOption(Gtk.Box):
         self.set_size_request(150, 150)
 
         self.__model = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_STRING)
-        self.__tree_view = Gtk.TreeView(self.__model)
+        self.__tree_view = Gtk.TreeView(model=self.__model)
         col1 = Gtk.TreeViewColumn(_('Name'), Gtk.CellRendererText(), text=0)
         col2 = Gtk.TreeViewColumn(_('ID'), Gtk.CellRendererText(), text=1)
         col1.set_resizable(True)
@@ -1488,7 +1488,7 @@ class GuiSurnameColorOption(Gtk.Box):
         self.__surnames = {}  # list of surnames and count
 
         self.__model = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_STRING)
-        self.__tree_view = Gtk.TreeView(self.__model)
+        self.__tree_view = Gtk.TreeView(model=self.__model)
         self.__tree_view.connect('row-activated', self.__row_clicked)
         col1 = Gtk.TreeViewColumn(_('Surname'), Gtk.CellRendererText(), text=0)
         col2 = Gtk.TreeViewColumn(_('Color'), Gtk.CellRendererText(), text=1)

--- a/gramps/gui/plug/report/_graphvizreportdialog.py
+++ b/gramps/gui/plug/report/_graphvizreportdialog.py
@@ -154,7 +154,8 @@ class GraphvizReportDialog(ReportDialog):
         self.grid.attach(self.format_menu, 2, self.row, 2, 1)
         self.row += 1
 
-        self.open_with_app = Gtk.CheckButton(_("Open with default viewer"))
+        self.open_with_app = Gtk.CheckButton(
+            label=_("Open with default viewer"))
         self.open_with_app.set_active(
             config.get('interface.open-with-default-viewer'))
         self.grid.attach(self.open_with_app, 2, self.row, 2, 1)

--- a/gramps/gui/plug/report/_reportdialog.py
+++ b/gramps/gui/plug/report/_reportdialog.py
@@ -151,7 +151,7 @@ class ReportDialog(ManagedWindow):
 
         self.style_name = self.options.handler.get_default_stylesheet_name()
 
-        window = Gtk.Dialog('Gramps')
+        window = Gtk.Dialog(title='Gramps')
         self.set_window(window, None, self.get_title())
         self.window.set_modal(True)
 
@@ -325,7 +325,7 @@ class ReportDialog(ManagedWindow):
 
         self.style_menu = StyleComboBox()
         self.style_menu.set_hexpand(True)
-        self.style_button = Gtk.Button("%s..." % _("Style Editor"))
+        self.style_button = Gtk.Button(label="%s..." % _("Style Editor"))
         self.style_button.connect('clicked', self.on_style_edit_clicked)
 
         self.grid.attach(label, 1, self.row, 1, 1)
@@ -616,7 +616,7 @@ class ReportDialog(ManagedWindow):
             widget, has_label = make_gui_option(option, self.dbstate,
                                                 self.uistate, self.track)
             if has_label:
-                widget_text = Gtk.Label(_('%s:') % option.get_label())
+                widget_text = Gtk.Label(label=(_('%s:') % option.get_label()))
                 widget_text.set_halign(Gtk.Align.START)
                 self.grid.attach(widget_text, 1, self.row, 1, 1)
                 self.doc_widgets.append(widget_text)

--- a/gramps/gui/undohistory.py
+++ b/gramps/gui/undohistory.py
@@ -76,8 +76,8 @@ class UndoHistory(ManagedWindow):
         self.undodb = self.db.undodb
         self.dbstate = dbstate
 
-        window = Gtk.Dialog("", uistate.window,
-                            Gtk.DialogFlags.DESTROY_WITH_PARENT, None)
+        window = Gtk.Dialog(title="", transient_for=uistate.window,
+                            destroy_with_parent=True)
 
         self.help_button = window.add_button(_('_Help'),
                                              Gtk.ResponseType.HELP)

--- a/gramps/gui/widgets/toolcomboentry.py
+++ b/gramps/gui/widgets/toolcomboentry.py
@@ -61,7 +61,7 @@ class ToolComboEntry(ValueToolItem):
         self.set_expand(False)
 
         combo = ShortlistComboEntry(items, shortlist, validator)
-        combo.set_focus_on_click(False)
+        Gtk.Widget.set_focus_on_click(combo, False)
         combo.set_entry_editable(editable)
         combo.show()
         self.add(combo)


### PR DESCRIPTION
This makes minor changes to our Gtk code to avoid some of the common deprecation warnings.

- gramps\gui\configure.py:106: PyGTKDeprecationWarning: The "buttons" argument must be a Gtk.ButtonsType enum value. Please use the "add_buttons" method for adding buttons.
- PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "title" or use a class specific constructor.
- gramps\gui\configure.py:180: PyGTKDeprecationWarning: The "buttons" argument must be a Gtk.ButtonsType enum value. Please use the "add_buttons" method for adding buttons. 
- PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "title" or use a class specific constructor.
- gramps\gui\configure.py:820: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "model" or use a class specific constructor.
- gramps\gui\configure.py:985: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. 
- gramps\gui\configure.py:1544: PyGTKDeprecationWarning: The "buttons" argument must be a Gtk.ButtonsType enum value. Please use the "add_buttons" method for adding buttons.
- PyGTKDeprecationWarning: The keyword(s) "parent" have been deprecated in favor of "transient_for" respectively.

- gramps\gui\plug\report\_graphvizreportdialog.py:157: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor.

- gramps\gui\plug\report\_reportdialog.py:328: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor.
- gramps\gui\plug\report\_reportdialog.py:619: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. 
- gramps\gui\plug\report\_reportdialog.py:154: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "title" or use a class specific constructor.

- gramps\gui\undohistory.py:80: PyGTKDeprecationWarning: The "flags" argument for dialog construction is deprecated. Please use initializer keywords: modal=True and/or destroy_with_parent=True.
- PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "title, transient_for, flags, add_buttons" or use a class specific constructor. 

- gramps\gui\widgets\toolcomboentry.py:64: DeprecationWarning: Gtk.ComboBox.set_focus_on_click is deprecated

