### PR TITLE
bug 9954; fix Gedcom import for empty FAMC line

### DIFF
--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -4555,6 +4555,9 @@ class GedcomParser(UpdateCallback):
         @type state: CurrentState
         """
 
+        if not line.data:  # handles empty FAMC line
+            self.__not_recognized(line, state)
+            return
         sub_state = CurrentState()
         sub_state.person = state.person
         sub_state.level = state.level + 1

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -3058,6 +3058,8 @@ class GedcomParser(UpdateCallback):
         text = StyledText(message, [tag])
         new_note.set_styledtext(text)
         new_note.set_handle(create_id())
+        gramps_id = self.nid_map[""]
+        new_note.set_gramps_id(gramps_id)
         note_type = NoteType()
         note_type.set((NoteType.CUSTOM, _("GEDCOM import")))
         new_note.set_type(note_type)


### PR DESCRIPTION
An empty FAMC xref is a violation of the Gedcom standard.  One of many created by various source software...
That said, we can deal with it a bit better.  I added a patch to detect the empty xref and add the error to the error list and error notes.

Assuming that there was no valid FAMC with an XREF on the same person, Gramps will generate correct family and person references; this is detected in a post processing step of the Gedcom importer. 

Gramps also puts a message to this effect in the Error list shown at the end of import, although this particular error type is NOT added as a note.

During debugging and validation of this I found an additional issue; the second commit deals with this.
Gedcom import has improper creation of error message notes.  The GIDs were not being checked against others created by the Gedcom importer (the importer assigns GIDs when a note reference is first found, but  delays actual note creation until note text is found in the Gedcom file).

The improper note could overwrite another note, due to overlapping GIDs; an eventual result being that we ended up with a corrupt db with a handle reference error.