### PR TITLE
bug 9920; fix for multiline Titles in Source view

### DIFF
--- a/gramps/gui/views/treemodels/sourcemodel.py
+++ b/gramps/gui/views/treemodels/sourcemodel.py
@@ -99,7 +99,7 @@ class SourceModel(FlatBaseModel):
         return len(self.fmap)+1
 
     def column_title(self,data):
-        return data[2]
+        return data[2].replace('\n', ' ')
 
     def column_author(self,data):
         return data[3]


### PR DESCRIPTION
Source view is set up for single line rows, multi-line Titles cause problems for Gtk (sometimes many unrelated rows get doubled in height).

Some dbs, originating in Gedcom, have Source titles with one or more line breaks.  This patch fixes the Source view ONLY, so reports, exports etc. still get the original data format.
Despite suggestions to get sophisticated with replacing '\n', I decided to keep it simple and go with ' ' (single space).  This is the same as Gtk itself does for our Source Editor Title.