### PR TITLE
Fix webstuff when user css does not exist

### DIFF
--- a/gramps/plugins/webstuff/webstuff.py
+++ b/gramps/plugins/webstuff/webstuff.py
@@ -178,14 +178,14 @@ def load_on_reg(dbstate, uistate, plugin):
          path_img_48x48("gramps-geo-mainmap.png"), None, [], [] ],
         ]
     # If we add css user files, we must restart gramps to use them.
-    try:
+    if os.path.exists(USER_CSS):
         list_files = os.listdir(USER_CSS)
         for cssfile in list_files:
             CSS_FILES.append([cssfile, 1, cssfile.replace('.css', ''),
                               os.path.join(USER_CSS,cssfile),
                               None, [], [] ])
         return CSS_FILES
-    except FileNotFoundError:
+    else:
         return CSS_FILES
 
 def process_list(data):

--- a/gramps/plugins/webstuff/webstuff.py
+++ b/gramps/plugins/webstuff/webstuff.py
@@ -185,7 +185,7 @@ def load_on_reg(dbstate, uistate, plugin):
                               os.path.join(USER_CSS,cssfile),
                               None, [], [] ])
         return CSS_FILES
-    except:
+    except FileNotFoundError:
         return CSS_FILES
 
 def process_list(data):

--- a/gramps/plugins/webstuff/webstuff.py
+++ b/gramps/plugins/webstuff/webstuff.py
@@ -178,12 +178,15 @@ def load_on_reg(dbstate, uistate, plugin):
          path_img_48x48("gramps-geo-mainmap.png"), None, [], [] ],
         ]
     # If we add css user files, we must restart gramps to use them.
-    list_files = os.listdir(USER_CSS)
-    for cssfile in list_files:
-        CSS_FILES.append([cssfile, 1, cssfile.replace('.css', ''),
-                          os.path.join(USER_CSS,cssfile),
-                          None, [], [] ])
-    return CSS_FILES
+    try:
+        list_files = os.listdir(USER_CSS)
+        for cssfile in list_files:
+            CSS_FILES.append([cssfile, 1, cssfile.replace('.css', ''),
+                              os.path.join(USER_CSS,cssfile),
+                              None, [], [] ])
+        return CSS_FILES
+    except:
+        return CSS_FILES
 
 def process_list(data):
     """


### PR DESCRIPTION
As mentioned in https://github.com/gramps-project/gramps/commit/74ffc76af0d3be2463a8ef918a82a8e1df4d6126#commitcomment-21026601
```

Traceback (most recent call last):
  File "/home/travis/build/gramps-project/gramps/gramps/gen/plug/_manager.py", line 181, in reg_plugins
    results = mod.load_on_reg(dbstate, uistate, plugin)
  File "/home/travis/build/gramps-project/gramps/gramps/plugins/webstuff/webstuff.py", line 181, in load_on_reg
    list_files = os.listdir(USER_CSS)
FileNotFoundError: [Errno 2] No such file or directory: '/home/travis/.gramps/css'
```