### PR TITLE
 Fix Addon manager to recognize newly installed addons immediately

### DIFF
--- a/gramps/cli/grampscli.py
+++ b/gramps/cli/grampscli.py
@@ -337,6 +337,8 @@ class CLIManager:
         """
         self._pmgr.reg_plugins(PLUGINS_DIR, dbstate, uistate, rescan=rescan)
         self._pmgr.reg_plugins(USER_PLUGINS, dbstate, uistate, load_on_reg=True)
+        if rescan:  # supports updated plugin installs
+            self._pmgr.reload_plugins()
 
 def startcli(errors, argparser):
     """

--- a/gramps/cli/grampscli.py
+++ b/gramps/cli/grampscli.py
@@ -331,11 +331,11 @@ class CLIManager:
         recent_files(filename, name)
         self.file_loaded = True
 
-    def do_reg_plugins(self, dbstate, uistate):
+    def do_reg_plugins(self, dbstate, uistate, rescan=False):
         """
         Register the plugins at initialization time.
         """
-        self._pmgr.reg_plugins(PLUGINS_DIR, dbstate, uistate)
+        self._pmgr.reg_plugins(PLUGINS_DIR, dbstate, uistate, rescan=rescan)
         self._pmgr.reg_plugins(USER_PLUGINS, dbstate, uistate, load_on_reg=True)
 
 def startcli(errors, argparser):

--- a/gramps/gen/plug/_manager.py
+++ b/gramps/gen/plug/_manager.py
@@ -104,7 +104,7 @@ class BasePluginManager:
         self.__scanned_dirs = []
 
     def reg_plugins(self, direct, dbstate=None, uistate=None,
-                    load_on_reg=False):
+                    load_on_reg=False, rescan=False):
         """
         Searches the specified directory, and registers python plugin that
         are being defined in gpr.py files.
@@ -112,6 +112,14 @@ class BasePluginManager:
         If a relationship calculator for env var LANG is present, it is
         immediately loaded so it is available for all.
         """
+        if rescan:
+            self.__import_plugins    = []
+            self.__export_plugins    = []
+            self.__docgen_plugins    = []
+            self.__docgen_names      = []
+            self.__scanned_dirs = []
+            self.__pgr._PluginRegister__plugindata = []
+            self.__pgr._PluginRegister__id_to_pdata = {}
         # if we've already scanned this directory or if the directory does not
         # exist, we are done.  Should only happen in tests.
 
@@ -300,6 +308,8 @@ class BasePluginManager:
         self.__import_plugins = []
         self.__export_plugins = []
         self.__docgen_plugins = []
+        self.__docgen_names = []
+
 
     def reload_plugins(self):
         """ Reload previously loaded plugins """

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -1421,7 +1421,10 @@ class GrampsPreferences(ConfigureDialog):
             return
 
         if len(addon_update_list) > 0:
-            PluginWindows.UpdateAddons(self.uistate, self.track, addon_update_list)
+            rescan = PluginWindows.UpdateAddons(self.uistate, self.track,
+                                                addon_update_list).rescan
+            self.uistate.viewmanager.do_reg_plugins(self.dbstate, self.uistate,
+                                                    rescan=rescan)
         else:
             check_types = config.get('behavior.check-for-addon-update-types')
             OkDialog(
@@ -1434,7 +1437,6 @@ class GrampsPreferences(ConfigureDialog):
         # Dead code for l10n
         _('new'), _('update')
 
-        self.uistate.viewmanager.do_reg_plugins(self.dbstate, self.uistate)
 
     def database_backend_changed(self, obj):
         the_list = obj.get_model()

--- a/gramps/gui/plug/_windows.py
+++ b/gramps/gui/plug/_windows.py
@@ -1082,6 +1082,7 @@ class UpdateAddons(ManagedWindow):
         self.set_window(glade.toplevel, None, None)
         self.window.set_title(self.title)
         self.setup_configs("interface.updateaddons", 750, 400)
+        self.rescan = False
 
         apply_button = glade.get_object('apply')
         cancel_button = glade.get_object('cancel')
@@ -1137,6 +1138,7 @@ class UpdateAddons(ManagedWindow):
             self.list.selection.select_iter(pos)
 
         self.show()
+        self.window.run()
 
     def build_menu_names(self, obj):
         return (self.title, " ")
@@ -1210,6 +1212,7 @@ class UpdateAddons(ManagedWindow):
                      ", ".join(errors),
                      parent=self.parent_window)
         if count:
+            self.rescan = True
             OkDialog(_("Done downloading and installing addons"),
                      # translators: leave all/any {...} untranslated
                      "%s %s" % (ngettext("{number_of} addon was installed.",

--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -344,8 +344,9 @@ class ViewManager(CLIManager):
         """
         Called when add-on updates are available.
         """
-        PluginWindows.UpdateAddons(self.uistate, [], addon_update_list)
-        self.do_reg_plugins(self.dbstate, self.uistate)
+        rescan = PluginWindows.UpdateAddons(self.uistate, [],
+                                            addon_update_list).rescan
+        self.do_reg_plugins(self.dbstate, self.uistate, rescan=rescan)
 
     def _errordialog(self, title, errormessage):
         """
@@ -727,14 +728,15 @@ class ViewManager(CLIManager):
         if not self.dbstate.is_open() and show_manager:
             self.__open_activate(None)
 
-    def do_reg_plugins(self, dbstate, uistate):
+    def do_reg_plugins(self, dbstate, uistate, rescan=False):
         """
         Register the plugins at initialization time. The plugin status window
         is opened on an error if the user has requested.
         """
         # registering plugins
         self.uistate.status_text(_('Registering plugins...'))
-        error = CLIManager.do_reg_plugins(self, dbstate, uistate)
+        error = CLIManager.do_reg_plugins(self, dbstate, uistate,
+                                          rescan=rescan)
 
         #  get to see if we need to open the plugin status window
         if error and config.get('behavior.pop-plugin-status'):


### PR DESCRIPTION
During testing of an improved Addon manager, I discovered that the original manager had been changed such that it would no longer recognize any newly installed addons immediately.  They were properly recognized on restart.

The issue was caused by myself, through two inadvertent changes.  A change in the UpdateAddons class to make it a ManagedWindow (which prevented a re-scan of plugins), and the performance improvements for the plugin manager (which by design stopped multiple scans of plugins).

Rather than give up the performance improvements to plugin operations, I decided to make the re-scan explicit.

I discovered that even after re-enabling a rescan, newly installed import, export and docgen plugins were not getting recognized.  This appears to be an old bug.

Then I discovered that updated addons were not recognized.  This appears to be an old bug.

The changes here get all this functionality working.

I do note that updated Views and Gramplets (those that are actively running) are still not being recognized.  I think that is because the original code, while in use, is not getting removed/replaced by Python, even after asking for a reload.  Probably reasonable in that I can imagine all sorts of issues that could occur...