### PR TITLE
Use assertRaises to check for the NameError

### DIFF
--- a/gramps/gen/utils/test/callback_test.py
+++ b/gramps/gen/utils/test/callback_test.py
@@ -65,11 +65,10 @@ class TestCallback(unittest.TestCase):
 
         def borked(i):
             """
-            this intentionally raises a NameError exception
-            FIXME: could use an explanation
-              or perhaps some explicit Try/Except code
+            This intentionally raises a NameError exception
             """
-            rubish.append(i)
+            with self.assertRaises(NameError):
+                rubish.append(i)
 
         t = TestSignals()
 
@@ -87,7 +86,7 @@ class TestCallback(unittest.TestCase):
         log = _log
 
         self.assertEqual(len(rl), 1, "No signal emitted")
-        self.assertEqual(rl[0], 1, "Wrong argument recieved")
+        self.assertEqual(rl[0], 1, "Wrong argument received")
 
     def test_disconnect(self):
 


### PR DESCRIPTION
Use [assertRaises](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertRaises) to check for the NameError and only output a test passed dot during unitest. eg removes the following output:
```

Warning: TestSignals: Exception occurred in callback function.
Traceback (most recent call last):
  File "/home/enlite93/gramps/gramps/gen/utils/callback.py", line 406, in emit
    fn(*args)
  File "/home/enlite93/gramps/gramps/gen/utils/test/callback_test.py", line 72, in borked
    rubish.append(i)
NameError: name 'rubish' is not defined

```

Also corrected spelling of a word.