### PR TITLE
bug 8128; Fix 'print...' dialogs for missing transient parent

### DIFF
--- a/gramps/gen/plug/docgen/basedoc.py
+++ b/gramps/gen/plug/docgen/basedoc.py
@@ -60,7 +60,7 @@ class BaseDoc(metaclass=ABCMeta):
     such as OpenOffice, AbiWord, and LaTeX are derived from this base
     class, providing a common interface to all document generators.
     """
-    def __init__(self, styles, paper_style, track=[]):
+    def __init__(self, styles, paper_style, track=[], uistate=None):
         """
         Create a BaseDoc instance, which provides a document generation
         interface. This class should never be instantiated directly, but
@@ -77,6 +77,7 @@ class BaseDoc(metaclass=ABCMeta):
         self.track = track
         self._creator = ""
         self.init_called = False
+        self.uistate = uistate
 
     def init(self):
         self.init_called = True

--- a/gramps/gen/plug/docgen/graphdoc.py
+++ b/gramps/gen/plug/docgen/graphdoc.py
@@ -385,8 +385,8 @@ class GVDocBase(BaseDoc, GVDoc):
     inherit from this class will only need to implement the close function.
     The close function will generate the actual file of the appropriate type.
     """
-    def __init__(self, options, paper_style):
-        BaseDoc.__init__(self, None, paper_style)
+    def __init__(self, options, paper_style, uistate=None):
+        BaseDoc.__init__(self, None, paper_style, uistate=uistate)
 
         self._filename      = None
         self._dot = BytesIO()

--- a/gramps/gui/plug/report/_docreportdialog.py
+++ b/gramps/gui/plug/report/_docreportdialog.py
@@ -108,9 +108,11 @@ class DocReportDialog(ReportDialog):
 
         if self.doc_options:
             self.doc = self.format(self.selected_style, pstyle,
-                                   self.doc_options)
+                                   self.doc_options,
+                                   uistate=self.uistate)
         else:
-            self.doc = self.format(self.selected_style, pstyle)
+            self.doc = self.format(self.selected_style, pstyle,
+                                   uistate=self.uistate)
         if not self.format_menu.get_active_plugin().get_paper_used():
             #set css filename
             self.doc.set_css_filename(self.css_filename)

--- a/gramps/plugins/docgen/asciidoc.py
+++ b/gramps/plugins/docgen/asciidoc.py
@@ -134,8 +134,8 @@ class AsciiDoc(BaseDoc, TextDoc):
     """
     ASCII document generator.
     """
-    def __init__(self, styles, paper_style, options=None):
-        BaseDoc.__init__(self, styles, paper_style)
+    def __init__(self, styles, paper_style, options=None, uistate=None):
+        BaseDoc.__init__(self, styles, paper_style, uistate=uistate)
         self.__note_format = False
 
         self._cpl = 72 # characters per line, in case the options are ignored

--- a/gramps/plugins/docgen/gtkprint.py
+++ b/gramps/plugins/docgen/gtkprint.py
@@ -184,6 +184,7 @@ class PrintPreview:
         self._operation = operation
         self._preview = preview
         self._context = context
+        self._parent = parent
 
         self.__build_window()
         self._current_page = None
@@ -196,7 +197,7 @@ class PrintPreview:
         from gramps.gui.glade import Glade
         glade_xml = Glade()
         self._window = glade_xml.toplevel
-        #self._window.set_transient_for(parent)
+        self._window.set_transient_for(self._parent)
 
         # remember active widgets for future use
         self._swin = glade_xml.get_object('swin')
@@ -521,7 +522,8 @@ class GtkPrint(libcairodoc.CairoDoc):
         # run print dialog
         while True:
             self.preview = None
-            res = operation.run(Gtk.PrintOperationAction.PRINT_DIALOG, None)
+            res = operation.run(Gtk.PrintOperationAction.PRINT_DIALOG,
+                                self.uistate.window)
             if self.preview is None: # cancel or print
                 break
             # set up printing again; can't reuse PrintOperation?

--- a/gramps/plugins/docgen/htmldoc.py
+++ b/gramps/plugins/docgen/htmldoc.py
@@ -93,8 +93,8 @@ class HtmlDoc(BaseDoc, TextDoc):
     Fontface is removed. Size, italic, bold, margins, borders are retained
     """
 
-    def __init__(self, styles, paper_style):
-        BaseDoc.__init__(self, styles, None)
+    def __init__(self, styles, paper_style, uistate=None):
+        BaseDoc.__init__(self, styles, None, uistate=uistate)
         self.style_declaration = ''
         self.htmllist = []
         self._backend = None

--- a/gramps/plugins/docgen/odfdoc.py
+++ b/gramps/plugins/docgen/odfdoc.py
@@ -403,11 +403,11 @@ class ODFDoc(BaseDoc, TextDoc, DrawDoc):
     The ODF document class
     """
 
-    def __init__(self, styles, ftype):
+    def __init__(self, styles, ftype, uistate=None):
         """
         Class init
         """
-        BaseDoc.__init__(self, styles, ftype)
+        BaseDoc.__init__(self, styles, ftype, uistate=uistate)
         self.media_list = []
         self.init_called = False
         self.index_title = None

--- a/gramps/plugins/docgen/svgdrawdoc.py
+++ b/gramps/plugins/docgen/svgdrawdoc.py
@@ -52,8 +52,8 @@ _ = glocale.translation.gettext
 #-------------------------------------------------------------------------
 class SvgDrawDoc(BaseDoc, DrawDoc):
 
-    def __init__(self, styles, type, options=None):
-        BaseDoc.__init__(self, styles, type)
+    def __init__(self, styles, type, options=None, uistate=None):
+        BaseDoc.__init__(self, styles, type, uistate=uistate)
         self.file = None
         self.filename = None
         self.level = 0


### PR DESCRIPTION
Requires adding uistate to the docgen basedoc and all files that
override the __init__