### PR TITLE
add the date-format option to narrativeweb and webcal.

### DIFF
--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -8267,8 +8267,9 @@ class NavWebReport(Report):
             menuopt = menu.get_option_by_name(optname)
             self.options[optname] = menuopt.get_value()
 
-        lang = self.options['trans']
-        self.rlocale = self.set_locale(lang)
+        self.set_locale(options.menu.get_option_by_name('trans').get_value())
+        stdoptions.run_date_format_option(self, menu)
+        self.rlocale = self._locale
 
         stdoptions.run_private_data_option(self, menu)
         stdoptions.run_living_people_option(self, menu)
@@ -9687,7 +9688,8 @@ class NavWebOptions(MenuReportOptions):
 
         stdoptions.add_name_format_option(menu, category_name)
 
-        stdoptions.add_localization_option(menu, category_name)
+        locale_opt = stdoptions.add_localization_option(menu, category_name)
+        stdoptions.add_date_format_option(menu, category_name, locale_opt)
 
         self.__securesite = BooleanOption(_("This is a secure site (https)"),
                                           False)

--- a/gramps/plugins/webreport/webcal.py
+++ b/gramps/plugins/webreport/webcal.py
@@ -126,8 +126,9 @@ class WebCalReport(Report):
 
         mgobn = lambda name: options.menu.get_option_by_name(name).get_value()
 
-        lang = mgobn('trans')
-        self.rlocale = self.set_locale(lang)
+        self.set_locale(options.menu.get_option_by_name('trans').get_value())
+        stdoptions.run_date_format_option(self, options.menu)
+        self.rlocale = self._locale
         self._ = self.rlocale.translation.sgettext
 
         self.html_dir = mgobn('target')
@@ -1681,7 +1682,8 @@ class WebCalOptions(MenuReportOptions):
         alive.set_help(_("Include only living people in the calendar"))
         menu.add_option(category_name, "alive", alive)
 
-        stdoptions.add_localization_option(menu, category_name)
+        locale_opt = stdoptions.add_localization_option(menu, category_name)
+        stdoptions.add_date_format_option(menu, category_name, locale_opt)
 
     def __add_content_options(self, menu):
         """


### PR DESCRIPTION
This pull request cover the feature request 3452.

mail received from paul : 
...
I didn't add it to either webcal or the narrative web,
partly because I don't know if that option makes sense
for those reports, but mainly because I think of you as
the expert on those reports.
...
