### PR TITLE
add CONTRIBUTING file, enable packacking this file

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -1,0 +1,4 @@
+See documentation at
+https://gramps-project.org/wiki/index.php?title=Portal:Developers
+https://gramps-project.org/wiki/index.php?title=Brief_introduction_to_Git#Making_a_patchfile
+https://gramps-project.org/wiki/index.php?title=Brief_introduction_to_Git#Making_a_PR

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include MANIFEST.in
 include NEWS
 include RELEASE_NOTES
 include TODO
+include CONTRIBUTING
 include TestPlan.txt
 recursive-include data *
 recursive-include debian *


### PR DESCRIPTION
CONTRIBUTING file is standard place for documentation how one may send patches
such documentation exists for this project so that file will be redirection to existing resources

Ref: https://gramps-project.org/bugs/view.php?id=10019

-----

Note to myself: see https://gramps-project.org/bugs/my_view_page.php for next issues to process