### PR TITLE
bug 9445; fix XML export of notes so lead/trail spaces are preserved

### DIFF
--- a/gramps/plugins/export/exportxml.py
+++ b/gramps/plugins/export/exportxml.py
@@ -511,7 +511,7 @@ class GrampsXmlWriter(UpdateCallback):
             self.g.write('  ' * indent)
 
         self.g.write('<%s>' % val)
-        self.g.write(self.fix(text.rstrip()))
+        self.g.write(escxml(str(text).translate(strip_dict)))
         self.g.write("</%s>\n" % val)
 
     def write_person(self,person,index=1):


### PR DESCRIPTION
XML export does not currently preserve leading or trailing spaces in notes.  XML import does.  This patch corrects this situation.