### PR TITLE
bug 6130; fix export filtering

### DIFF
--- a/gramps/gen/proxy/filter.py
+++ b/gramps/gen/proxy/filter.py
@@ -78,6 +78,8 @@ class FilterProxyDb(ProxyDbBase):
         Finds a Person in the database from the passed Gramps ID.
         If no such Person exists, None is returned.
         """
+        if isinstance(handle, bytes):
+            handle = str(handle, 'utf-8')
         if handle in self.plist:
             person = self.db.get_person_from_handle(handle)
             if person is None:
@@ -115,15 +117,23 @@ class FilterProxyDb(ProxyDbBase):
             return None
 
     def include_person(self, handle):
+        if isinstance(handle, bytes):
+            handle = str(handle, 'utf-8')
         return handle in self.plist
 
     def include_family(self, handle):
+        if isinstance(handle, bytes):
+            handle = str(handle, 'utf-8')
         return handle in self.flist
 
     def include_event(self, handle):
+        if isinstance(handle, bytes):
+            handle = str(handle, 'utf-8')
         return handle in self.elist
 
     def include_note(self, handle):
+        if isinstance(handle, bytes):
+            handle = str(handle, 'utf-8')
         return handle in self.nlist
 
     def get_source_from_handle(self, handle):
@@ -202,6 +212,8 @@ class FilterProxyDb(ProxyDbBase):
         Finds a Event in the database from the passed Gramps ID.
         If no such Event exists, None is returned.
         """
+        if isinstance(handle, bytes):
+            handle = str(handle, 'utf-8')
         if handle in self.elist:
             event = self.db.get_event_from_handle(handle)
             # Filter all notes out
@@ -215,6 +227,8 @@ class FilterProxyDb(ProxyDbBase):
         Finds a Family in the database from the passed Gramps ID.
         If no such Family exists, None is returned.
         """
+        if isinstance(handle, bytes):
+            handle = str(handle, 'utf-8')
         if handle in self.flist:
             family = self.db.get_family_from_handle(handle)
             if family is None:
@@ -281,6 +295,8 @@ class FilterProxyDb(ProxyDbBase):
         Finds a Note in the database from the passed Gramps ID.
         If no such Note exists, None is returned.
         """
+        if isinstance(handle, bytes):
+            handle = str(handle, 'utf-8')
         if handle in self.nlist:
             return self.db.get_note_from_handle(handle)
         else:


### PR DESCRIPTION
Under some conditions, the handle passed in for comparison to the various filter lists (plist, nlist etc.) is a 'bytes', whereas the lists always seem to be 'str' type.  The "if handle in self.plist" fails; that is, handles that are present in the list are not found because they are the wrong type.

There has been a lot of history since the 6130 bug was filed on Gramps version 3.4.1.  I tested the current 4.2 branch and everything seems to work correctly with no patches; the original 6130 bug does not seem to be present.  But I found this bug when testing master branch.

I'm not sure if this is the -best- way to fix this, but it does seem to work.  As I ranted before, it would be nice if we could somehow make all handle related APIs the same type, not sometimes 'bytes' and sometimes 'str'.  But things seem to have been this way since the transition to Python3.