### PR TITLE
bug 6664; fix Detailed Descendent Report, multi paths to descendant

### DIFF
--- a/gramps/plugins/textreport/detdescendantreport.py
+++ b/gramps/plugins/textreport/detdescendantreport.py
@@ -105,8 +105,6 @@ class DetDescendantReport(Report):
         repplace      - Whether to replace missing Places with ___________.
         repdate       - Whether to replace missing Dates with ___________.
         computeage    - Whether to compute age.
-        omitda        - Whether to omit duplicate ancestors
-                            (e.g. when distant cousins marry).
         verbose       - Whether to use complete sentences.
         numbering     - The descendancy numbering system to be utilized.
         desref        - Whether to add descendant references in child list.
@@ -161,7 +159,6 @@ class DetDescendantReport(Report):
         blankplace = get_value('repplace')
         blankdate = get_value('repdate')
         self.calcageflag = get_value('computeage')
-        self.dubperson = get_value('omitda')
         self.verbose = get_value('verbose')
         self.numbering = get_value('numbering')
         self.childref = get_value('desref')
@@ -442,19 +439,6 @@ class DetDescendantReport(Report):
 
         if self.inc_paths:
             self.write_path(person)
-
-        if self.dubperson:
-            # Check for duplicate record (result of distant cousins marrying)
-            for dkey in sorted(self.map):
-                if dkey >= key:
-                    break
-                if self.map[key] == self.map[dkey]:
-                    self.doc.write_text(
-                        self._("%(name)s is the same person as [%(id_str)s]."
-                              ) % {'name'   : '',
-                                   'id_str' : self.dnumber[self.map[dkey]]})
-                    self.doc.end_paragraph()
-                    return
 
         self.doc.end_paragraph()
 
@@ -1005,6 +989,7 @@ class DetDescendantOptions(MenuReportOptions):
         self.__pid.set_help(_("The center person for the report"))
         add_option("pid", self.__pid)
 
+
         numbering = EnumeratedListOption(_("Numbering system"), "Henry")
         numbering.set_items([
             ("Henry", _("Henry numbering")),
@@ -1068,10 +1053,6 @@ class DetDescendantOptions(MenuReportOptions):
         computeage = BooleanOption(_("Compute death age"), True)
         computeage.set_help(_("Whether to compute a person's age at death."))
         add_option("computeage", computeage)
-
-        omitda = BooleanOption(_("Omit duplicate ancestors"), True)
-        omitda.set_help(_("Whether to omit duplicate ancestors."))
-        add_option("omitda", omitda)
 
         usecall = BooleanOption(_("Use callname for common name"), False)
         usecall.set_help(_("Whether to use the call name as the first name."))


### PR DESCRIPTION
where the descendant ends up in different generations at the same time.

An earlier patch for bug https://gramps-project.org/bugs/view.php?id=5259 seems to have eliminated multiple reports for different paths so people who are members of different generations via different paths only get reported in the lowest generation number. I expect that this is reasonable in that if we tried to report people in each generation that they are members of, the report would rapidly get unwieldy for convoluted trees.

The current code that creates the text 'is the same person as' is trying to indicate that a descendant is an already reported member of an earlier generation (which we don't do now) and so ends up redundant the way things are now; it is just preventing the normal report result.

I've completely eliminated the code which makes that check, and the associated edit/preferences option.  So the code now completes the report as expected by the bug submitter.