### PR TITLE
Fix syntax error postgresql

### DIFF
--- a/gramps/plugins/db/dbapi/postgresql.py
+++ b/gramps/plugins/db/dbapi/postgresql.py
@@ -58,7 +58,7 @@ class Postgresql:
         self.__connection.autocommit = True
         self.__cursor = self.__connection.cursor()
         locale = os.environ.get('LANG', 'en_US.utf8')
-        self.execute("DROP COLLTAION IF EXISTS glocale")
+        self.execute("DROP COLLATION IF EXISTS glocale")
         self.execute("CREATE COLLATION glocale (LOCALE = '%s')" % locale)
 
     def _hack_query(self, query):


### PR DESCRIPTION
Gets past the following:

> 2017-05-04 14:16:01.436: ERROR: dbloader.py: line 110: syntax error at or near "COLLTAION"
> LINE 1: DROP COLLTAION IF EXISTS glocale
>              ^

and

> psycopg2.ProgrammingError: syntax error at or near "COLLTAION"
> LINE 1: DROP COLLTAION IF EXISTS glocale
>                       ^

Found while attempting to set up Gramps with postgresql.