### PR TITLE
Bug8723: Missing [edit buttons] in relationship view

### DIFF
--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -814,8 +814,8 @@ class RelationshipView(NavigationView):
                 call_fcn = self.add_family
                 del_fcn = self.delete_family
 
-            if not self.toolbar_visible and not self.dbstate.db.readonly:
-                # Show edit-Buttons if toolbar is not visible
+            if not self.dbstate.db.readonly:
+                # Show edit-Buttons only if db is not readonly
                 if self.reorder_sensitive:
                     add = widgets.IconButton(self.reorder_button_press, None,
                                              'view-sort-ascending')


### PR DESCRIPTION
Shows edit-Buttons by default only if familytree is not readonly

Missing buttons highlighted

![2911d20c-c94e-11e6-95c9-e99687c5f34c](https://cloud.githubusercontent.com/assets/8924713/25993089/39a7580a-374c-11e7-9797-58138d92ec4d.png)
