### PR TITLE
Relationships view new toolbar icon to [Add a new Person]

### DIFF
--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -410,6 +410,10 @@ class RelationshipView(NavigationView):
         """
       <placeholder id='otheredit'>
         <item>
+          <attribute name="action">win.AddNewPerson</attribute>
+          <attribute name="label" translatable="yes">Add new Person...</attribute>
+        </item>
+        <item>
           <attribute name="action">win.Edit</attribute>
           <attribute name="label" translatable="yes">Edit...</attribute>
         </item>
@@ -498,6 +502,18 @@ class RelationshipView(NavigationView):
     <placeholder id='BarCommonEdit'>
     <child groups='RW'>
       <object class="GtkToolButton">
+        <property name="icon-name">gramps-person</property>
+        <property name="action-name">win.AddNewPerson</property>
+        <property name="tooltip_text" translatable="yes">'''
+        '''Add a new Person</property>
+        <property name="label" translatable="yes">Add new Person...</property>
+      </object>
+      <packing>
+        <property name="homogeneous">False</property>
+      </packing>
+    </child>
+    <child groups='RW'>
+      <object class="GtkToolButton">
         <property name="icon-name">gtk-edit</property>
         <property name="action-name">win.Edit</property>
         <property name="tooltip_text" translatable="yes">"""
@@ -570,6 +586,7 @@ class RelationshipView(NavigationView):
         self.family_action = ActionGroup(name=self.title + "/Family")
         self.family_action.add_actions(
             [
+                ("AddNewPerson", self.add_new_person),
                 ("Edit", self.edit_active, "<PRIMARY>Return"),
                 ("AddSpouse", self.add_spouse),
                 ("AddParents", self.add_parents),
@@ -1743,6 +1760,20 @@ class RelationshipView(NavigationView):
                 EditFamily(self.dbstate, self.uistate, [], family)
             except WindowActiveError:
                 pass
+
+    def add_new_person(self, obj, event):
+        """
+        Add a new person to the database.
+        """
+        person = Person()
+        #the editor requires a surname
+        person.primary_name.add_surname(Surname())
+        person.primary_name.set_primary_surname(0)
+
+        try:
+            EditPerson(self.dbstate, self.uistate, [], person)
+        except WindowActiveError:
+            pass
 
     def add_family(self, obj, event, handle):
         if button_activated(event, _LEFT_BUTTON):


### PR DESCRIPTION
_Made this WIP as it may be confusing when you add a person the displayed active person does not change to the just newly added person._

The idea of this is that the user does not have to change to the people list view to create a new person and they can start creating a new family tree from this view.  Current behavior is on an empty family tree all the icon's are inactive with no hint as to what to do.

* "Add a new Person" Icon on Tool bar .

![37b3cb7e-374b-11e7-8f62-8d47d5c0d83b](https://cloud.githubusercontent.com/assets/8924713/26088820/6d7a00ae-3a3c-11e7-8787-0f90f56ad272.png)

> Current behavior is on an empty family tree all the icon's are inactive with no hint as to what to do.

![currentbehavior](https://user-images.githubusercontent.com/8924713/37248161-19694f10-251e-11e8-8c35-ca6e1fb012ed.png)

 - [ ] Update [wiki](https://gramps-project.org/wiki/index.php?title=Gramps_5.0_Wiki_Manual_-_Categories#Relationships_Category)