### PR TITLE
Change Default Navigator views order

### DIFF
--- a/gramps/gen/config.py
+++ b/gramps/gen/config.py
@@ -191,10 +191,11 @@ register('geography.use-keypad', True)
 # needed), for instance to four 'interface.clipboard' variables --
 # so do a recursive grep for "setup_configs" to see all the (base) names
 register('interface.dont-ask', False)
+#Default Navigator views (sets order shown)
 register('interface.view-categories',
-         ["Dashboard", "People", "Relationships", "Families",
-          "Ancestry", "Events", "Places", "Geography", "Sources",
-          "Citations", "Repositories", "Media", "Notes"])
+         ["Relationships", "Dashboard", "Ancestry","Geography",
+          "People", "Families", "Events", "Places", "Notes",
+          "Media", "Citations", "Sources", "Repositories",])
 register('interface.filter', False)
 register('interface.fullscreen', False)
 register('interface.grampletbar-close', False)


### PR DESCRIPTION
Reordered the categories in the Navigator so that List are grouped below and non list are at the top. This makes it easier for people to understand at a glance the difference between the top 4 categories [Dashboard] & [Programmed Views/Extensions] and those below eg. List.

* Ideally I would like a separator or the label "List" to appear in-between "Geography" and "People"

Old order on left / New order on right
![old left - right-new](https://cloud.githubusercontent.com/assets/8924713/25991697/85e6ba08-3747-11e7-9f63-42e281bac1e7.png)
