### PR TITLE
fixes for Media Reference Editor (bug 8429)

### DIFF
--- a/gramps/gui/editors/editmediaref.py
+++ b/gramps/gui/editors/editmediaref.py
@@ -100,6 +100,7 @@ class EditMediaRef(EditReference):
         tblref =  self.top.get_object('table50')
         self.notebook_ref = self.top.get_object('notebook_ref')
         self.track_ref_for_deletion("notebook_ref")
+        self.expander = self.top.get_object('expander1')
         #recreate start page as GrampsTab
         self.notebook_ref.remove_page(0)
         self.reftab = RefTab(self.dbstate, self.uistate, self.track,
@@ -187,6 +188,7 @@ class EditMediaRef(EditReference):
         self.selection.set_multiple_selection(False)
         self.selection.connect("region-modified", self.region_modified)
         self.selection.connect("region-created", self.region_modified)
+        self.expander.connect("activate", self.selection.expander)
         frame = self.top.get_object("frame9")
         frame.add(self.selection)
         self.track_ref_for_deletion("selection")

--- a/gramps/gui/editors/editmediaref.py
+++ b/gramps/gui/editors/editmediaref.py
@@ -386,6 +386,7 @@ class EditMediaRef(EditReference):
         real = self.selection.proportional_to_real_rect(self.rectangle)
         region = Region(real[0], real[1], real[2], real[3])
         self.selection.set_regions([region])
+        self.selection.select(region)  # update the selection box shown
         self.selection.refresh()
 
     def region_modified(self, widget):

--- a/gramps/gui/widgets/selectionwidget.py
+++ b/gramps/gui/widgets/selectionwidget.py
@@ -197,6 +197,7 @@ class SelectionWidget(Gtk.ScrolledWindow):
         self.pixbuf = None
         self.scaled_pixbuf = None
         self.scale = 1.0
+        self.old_viewport_size = None
 
         Gtk.ScrolledWindow.__init__(self)
         self.add(self._build_gui())
@@ -227,6 +228,7 @@ class SelectionWidget(Gtk.ScrolledWindow):
         self.event_box.add(self.image)
 
         self.viewport = Gtk.Viewport()
+        self.connect("size-allocate", self._resize)
         self.viewport.add(self.event_box)
         return self.viewport
 
@@ -296,6 +298,7 @@ class SelectionWidget(Gtk.ScrolledWindow):
                                         self.pixbuf.get_height())
 
             viewport_size = self.viewport.get_allocation()
+            self.old_viewport_size = viewport_size
             self.scale = scale_to_fit(self.pixbuf.get_width(),
                                       self.pixbuf.get_height(),
                                       viewport_size.width,
@@ -312,6 +315,32 @@ class SelectionWidget(Gtk.ScrolledWindow):
         self.pixbuf = None
         self.image.set_from_icon_name('image-missing', Gtk.IconSize.DIALOG)
         self.image.queue_draw()
+
+    def _resize(self, *dummy):
+        """
+        Handles size-allocate' events from Gtk.
+        """
+        if self.pixbuf:
+            viewport_size = self.viewport.get_allocation()
+            if viewport_size.height != self.old_viewport_size.height or \
+                    viewport_size.width != self.old_viewport_size.width or \
+                    not self.image.get_pixbuf():
+                self.scale = scale_to_fit(self.pixbuf.get_width(),
+                                          self.pixbuf.get_height(),
+                                          viewport_size.width,
+                                          viewport_size.height)
+                self._rescale()
+                self.old_viewport_size = viewport_size
+                return False
+
+    def expander(self, *dummy):
+        """ Handler for expander in caller; needed because Gtk doesn't handle
+        verticle expansion right
+        """
+        self.image.clear()
+        self.image.set_size_request(2, 2)
+        self.event_box.set_size_request(2, 2)
+        return False
 
     # ======================================================
     # coordinate transformations (public methods)
@@ -531,14 +560,14 @@ class SelectionWidget(Gtk.ScrolledWindow):
     # drawing and scaling the image
     # ======================================================
 
-    def _expose_handler(self, widget, event):
+    def _expose_handler(self, widget, cr):
         """
         Handles the expose-event signal of the underlying widget.
         """
         if self.pixbuf:
-            self._draw_selection()
+            self._draw_selection(widget, cr)
 
-    def _draw_selection(self):
+    def _draw_selection(self, widget, cr):
         """
         Draws the image, the selection boxes and does the necessary
         shading.
@@ -550,8 +579,6 @@ class SelectionWidget(Gtk.ScrolledWindow):
         offset_x, offset_y = self._image_to_screen((0, 0))
         offset_x -= 1
         offset_y -= 1
-
-        cr = self.image.get_window().cairo_create()
 
         if self.selection:
             x1, y1, x2, y2 = self._rect_image_to_screen(self.selection)


### PR DESCRIPTION
bug 8429; fix for selection frame outside/behind image

This was two different bugs; 
1)the various objects were not responding to the resize events, 
2)the cairo objects were under some conditions hidden behind the image (worse on the Windows platform).  Even on Linux, a zoom in would hide the cairo objects.

Added signal handler to deal with the resize event.  Unfortunately, it appears that Gtk still is doing something odd when the 'Shared Information' expander is clicked and the 'Preview' window shrinks.  The basic resize handler did not correctly deal with this case.  I found it necessary to add another handler for the expander; in that I had to kill the image and allocate a small size, before letting the resize handler bring it back to the new correct size.  Surprisingly, the same trick did NOT work if put into the resize handler.  There is a lot I don't understand about Gtk...

Fixed the cairo object to use the already defined (by Gtk) object rather than making a new one each time.  I suspect that on Windows, the new cairo object was under some conditions getting drawn behind the image.  The Gtk object, when reused seems to always work correctly.

During debugging I found that the spin buttons did not update the selection frame etc. if the image had already been selected via mouse click (frame showing and background greyed out).  Added a signal emit to deal with this.

During debugging I found that the popup instructions did not work; the user could not just drag to draw the selection.  I added code to detect and do this.

Tested on Windows and Linux (Umbuntu).

Also Tested with the Photo Tagging Gramplet, looks like everything still works (better), although I found a Photo Tagging Gramplet specific bug.