### PR TITLE
fix bug 10052, relationship calculator fails (missing uistate param)

### DIFF
--- a/gramps/plugins/tool/relcalc.py
+++ b/gramps/plugins/tool/relcalc.py
@@ -118,7 +118,7 @@ class RelCalc(tool.Tool, ManagedWindow):
         self.textbuffer = Gtk.TextBuffer()
         self.text.set_buffer(self.textbuffer)
 
-        self.model = PersonTreeModel(self.db)
+        self.model = PersonTreeModel(self.db, uistate)
         self.tree.set_model(self.model)
 
         self.tree.connect('key-press-event', self._key_press)


### PR DESCRIPTION
bug was a missed edit during a general fixup of treemodels to add uistate...