### PR TITLE
Fix bug 10054 HandleErrors in Gramplets

### DIFF
--- a/gramps/plugins/gramplet/citations.py
+++ b/gramps/plugins/gramplet/citations.py
@@ -133,9 +133,10 @@ class Citations(Gramplet, DbGUIElement):
         for lds in obj.get_lds_ord_list():
             self.add_citations(lds)
             place_handle = lds.get_place_handle()
-            place = self.dbstate.db.get_place_from_handle(place_handle)
-            if place:
-                self.add_place_citations(place)
+            if place_handle:
+                place = self.dbstate.db.get_place_from_handle(place_handle)
+                if place:
+                    self.add_place_citations(place)
 
     def add_association_citations(self, obj):
         for assoc in obj.get_person_ref_list():


### PR DESCRIPTION
Error occurred when deleting a Family in Family view.
Don't know why the error occurred in one Gramplet, but not all of them, when they generally use the same code methods for looking at the active handle; sigh...

Checked for similar errors in other Family elements/Gramplets.

The citations Gramplet error was a bit different, it appeared when I added a Citation to the Family and selected the family in the Family view.