### PR TITLE
9130: Quick search with Czech characters -> Crash

### DIFF
--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -907,7 +907,7 @@ class ListView(NavigationView):
             self.edit(obj)
             return True
         # Custom interactive search
-        if event.string:
+        if Gdk.keyval_to_unicode(event.keyval):
             return self.searchbox.treeview_keypress(obj, event)
         return False
 
@@ -935,7 +935,7 @@ class ListView(NavigationView):
                     else:
                         self.edit(obj)
                         return True
-        elif event.string:
+        elif Gdk.keyval_to_unicode(event.keyval):
             # Custom interactive search
             return self.searchbox.treeview_keypress(obj, event)
         return False

--- a/gramps/gui/widgets/interactivesearchbox.py
+++ b/gramps/gui/widgets/interactivesearchbox.py
@@ -70,7 +70,7 @@ class InteractiveSearchBox:
         function handling keypresses from the treeview
         for the typeahead find capabilities
         """
-        if not event.string:
+        if not Gdk.keyval_to_unicode(event.keyval):
             return False
         if self._key_cancels_search(event.keyval):
             return False


### PR DESCRIPTION
Crash happen when checking for "event.string" in "treeview_keypress"
function in "gramps/gui/widgets/interactivesearchbox.py"
Note that

https://lazka.github.io/pgi-docs/Gdk-3.0/classes/EventKey.html#Gdk.EventKey
says it is deprecated and should never be used.

Gdk.keyval_to_unicode return the corresponding unicode character, or 0
if there is no corresponding character.