### PR TITLE
fix bug 10061 people tree view doesn't update when selection changes

### DIFF
--- a/gramps/gui/views/treemodels/treebasemodel.py
+++ b/gramps/gui/views/treemodels/treebasemodel.py
@@ -597,6 +597,8 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
             with gen_cursor() as cursor:
                 for handle, data in cursor:
                     status_ppl.heartbeat()
+                    if not isinstance(handle, str):
+                        handle = handle.decode('utf-8')
                     add_func(handle, data)
                     self.__displayed += 1
 


### PR DESCRIPTION
from people flat or relationship views

The handle2iter dict structure which is responsible for converting a person handle to the tree view row was failing because a recent change had caused the dict to be keyed by 'bytes' handles.  The 'selection-changed' code was using 'str' handles.  So no handle was ever found.

Mini-rant; as I've said before , I wish we would only use one type of handle (preferably 'str') instead of mixing them up everywhere.  If the db needs them different internally, make conversions in the db code only.  I guess this was a non-ideal choice in the Python2 to 3 conversion...