### PR TITLE
fix bug 7593; Gedcom import with OBJE/FORM URL on event

### DIFF
--- a/data/tests/imp_MediaTest.ged
+++ b/data/tests/imp_MediaTest.ged
@@ -43,6 +43,15 @@
 2 NOTE @N0018@
 1 OBJE @M7@
 1 OBJE @M8@
+1 OBJE
+2 FORM URL
+2 FILE http:\\obje.form.on_person.org
+1 BIRT
+2 TYPE Birth of the Tester
+2 DATE 2 OCT 1864
+2 OBJE
+3 FORM URL
+3 FILE http:\\obje.form.on_event.org
 0 @M1@ OBJE
 1 FORM jpeg
 1 TITL Multimedia link to linked form v5.5 blob

--- a/data/tests/imp_MediaTest.gramps
+++ b/data/tests/imp_MediaTest.gramps
@@ -3,17 +3,26 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-08-29" version="5.0.0-alpha1"/>
+    <created date="2017-05-30" version="5.0.0-alpha1"/>
     <researcher>
     </researcher>
   </header>
+  <events>
+    <event handle="_0000000f0000000f" change="1" id="E0000">
+      <type>Birth</type>
+      <dateval val="1864-10-02"/>
+      <description>Birth of the Tester</description>
+      <noteref hlink="_0000001000000010"/>
+    </event>
+  </events>
   <people>
-    <person handle="_0000000100000001" change="1472500307" id="I0001">
+    <person handle="_0000000100000001" change="1" id="I0001">
       <gender>U</gender>
       <name type="Birth Name">
         <first>The</first>
         <surname>Tester</surname>
       </name>
+      <eventref hlink="_0000000f0000000f" role="Primary"/>
       <objref hlink="_0000000300000003"/>
       <objref hlink="_0000000400000004"/>
       <objref hlink="_0000000500000005"/>
@@ -25,106 +34,107 @@
       <objref hlink="_0000000c0000000c"/>
       <objref hlink="_0000000d0000000d"/>
       <objref hlink="_0000000e0000000e"/>
-      <noteref hlink="_0000000f0000000f"/>
+      <url  href="http:\\obje.form.on_person.org" type="Web Home"/>
+      <noteref hlink="_0000001100000011"/>
     </person>
   </people>
   <citations>
-    <citation handle="_0000001b0000001b" change="1472500307" id="C0000">
+    <citation handle="_0000001d0000001d" change="1" id="C0000">
       <confidence>0</confidence>
-      <noteref hlink="_0000001a0000001a"/>
-      <sourceref hlink="_0000001900000019"/>
+      <noteref hlink="_0000001c0000001c"/>
+      <sourceref hlink="_0000001b0000001b"/>
     </citation>
-    <citation handle="_0000002500000025" change="1472500307" id="C0001">
+    <citation handle="_0000002700000027" change="1" id="C0001">
       <dateval val="2014-06-07"/>
       <page>77, 78 discussion of multimedia link with two files</page>
       <confidence>4</confidence>
-      <noteref hlink="_0000002400000024"/>
-      <sourceref hlink="_0000002300000023"/>
+      <noteref hlink="_0000002600000026"/>
+      <sourceref hlink="_0000002500000025"/>
     </citation>
   </citations>
   <sources>
-    <source handle="_0000001900000019" change="1472500307" id="S0002">
+    <source handle="_0000001b0000001b" change="1" id="S0002">
       <stitle>A Great Photographer</stitle>
     </source>
-    <source handle="_0000002300000023" change="1472500307" id="S0001">
+    <source handle="_0000002500000025" change="1" id="S0001">
       <stitle>The Testers personal files</stitle>
       <sauthor>The Tester</sauthor>
       <spubinfo>Name: Tester Publishing Operations, Inc.; Location: OSF world</spubinfo>
     </source>
   </sources>
   <objects>
-    <object handle="_0000000300000003" change="1472500307" id="O0000">
+    <object handle="_0000000300000003" change="1" id="O0000">
       <file src="test_emb_55.jpg" mime="image/jpeg" description="Multimedia link embedded form v5.5"/>
       <noteref hlink="_0000000200000002"/>
     </object>
     <object handle="_0000000400000004" change="548708291" id="M1">
       <file src="" mime="" description="Multimedia link to linked form v5.5 blob"/>
       <attribute type="REFN" value="Ref12345M1">
-        <noteref hlink="_0000001000000010"/>
+        <noteref hlink="_0000001200000012"/>
       </attribute>
       <attribute type="RIN" value="ID09876M1"/>
-      <noteref hlink="_0000001100000011"/>
-      <noteref hlink="_0000001200000012"/>
+      <noteref hlink="_0000001300000013"/>
+      <noteref hlink="_0000001400000014"/>
     </object>
     <object handle="_0000000500000005" change="548797681" id="M3">
       <file src="test.jpg" mime="image/jpeg" description="Multimedia link to linked form Gramps style v5.5ish file"/>
-      <noteref hlink="_0000001500000015"/>
-      <noteref hlink="_0000001600000016"/>
+      <noteref hlink="_0000001700000017"/>
+      <noteref hlink="_0000001800000018"/>
     </object>
     <object handle="_0000000600000006" change="548883481" id="M4">
       <file src="test.jpg" mime="image/jpeg" description="Multimedia link to linked form v5.5.1 file"/>
       <attribute type="Media-Type" value="Photo"/>
       <attribute type="REFN" value="Ref1234567M4">
-        <noteref hlink="_0000001700000017"/>
+        <noteref hlink="_0000001900000019"/>
       </attribute>
       <attribute type="RIN" value="ID098765M4"/>
-      <noteref hlink="_0000001800000018"/>
-      <noteref hlink="_0000001c0000001c"/>
-      <citationref hlink="_0000001b0000001b"/>
+      <noteref hlink="_0000001a0000001a"/>
+      <noteref hlink="_0000001e0000001e"/>
+      <citationref hlink="_0000001d0000001d"/>
     </object>
-    <object handle="_0000000800000008" change="1472500307" id="O0001">
+    <object handle="_0000000800000008" change="1" id="O0001">
       <file src="test_emb_551.jpg" mime="image/jpeg" description="Multimedia link embedded form v5.5.1"/>
       <attribute type="Media-Type" value="Photo"/>
       <noteref hlink="_0000000700000007"/>
     </object>
-    <object handle="_0000000900000009" change="1472500307" id="M5">
+    <object handle="_0000000900000009" change="1" id="M5">
       <file src="test.jpg" mime="image/jpeg" description="Multimedia link to linked form FTM style file"/>
-      <datestr val="6/4/2016 9:33:57 AM"/>
-      <noteref hlink="_0000001d0000001d"/>
-      <noteref hlink="_0000001e0000001e"/>
       <noteref hlink="_0000001f0000001f"/>
       <noteref hlink="_0000002000000020"/>
+      <noteref hlink="_0000002100000021"/>
+      <noteref hlink="_0000002200000022"/>
+      <datestr val="6/4/2016 9:33:57 AM"/>
     </object>
     <object handle="_0000000a0000000a" change="549056401" id="M6">
       <file src="test.jpg" mime="image/jpeg" description="Multimedia link to linked form v5.5.1 with two files(1)"/>
       <attribute type="Media-Type" value="Photo"/>
       <attribute type="REFN" value="Ref1234567M6">
-        <noteref hlink="_0000002100000021"/>
+        <noteref hlink="_0000002300000023"/>
       </attribute>
       <attribute type="RIN" value="ID098765M6"/>
-      <noteref hlink="_0000002200000022"/>
-      <noteref hlink="_0000002600000026"/>
-      <citationref hlink="_0000002500000025"/>
+      <noteref hlink="_0000002400000024"/>
+      <noteref hlink="_0000002800000028"/>
+      <citationref hlink="_0000002700000027"/>
     </object>
-    <object handle="_0000000c0000000c" change="1472500307" id="O0002">
+    <object handle="_0000000c0000000c" change="1" id="O0002">
       <file src="http://www.geni.com/photo/view?photo_id=6000000001341319061" mime="unknown" description="Multimedia link embedded form v5.5 URL"/>
       <noteref hlink="_0000000b0000000b"/>
     </object>
-    <object handle="_0000000d0000000d" change="1472500307" id="M7">
+    <object handle="_0000000d0000000d" change="1" id="M7">
       <file src="http://s6.postimg.org/8i2erq27l/Preserve_Record_Numbers_Option.png" mime="image/png" description="Multimedia link to linked form v5.5.1 with URL"/>
       <attribute type="Media-Type" value="Photo"/>
     </object>
-    <object handle="_0000000e0000000e" change="1472500307" id="M8">
+    <object handle="_0000000e0000000e" change="1" id="M8">
       <file src="No_path_No_Title_NoForm.jpg" mime="image/jpeg" description="No_path_No_Title_NoForm.jpg"/>
-      <noteref hlink="_0000002700000027"/>
+      <noteref hlink="_0000002900000029"/>
     </object>
-    <object handle="_0000001300000013" change="1472500307" id="M2">
+    <object handle="_0000001500000015" change="1" id="M2">
       <file src="" mime="" description="2nd blob Multimedia link to linked form v5.5 blob"/>
-      <noteref hlink="_0000001400000014"/>
+      <noteref hlink="_0000001600000016"/>
     </object>
   </objects>
   <notes>
-    <note handle="_0000000200000002" change="1472500307" id="N0010" type="Media Note">
+    <note handle="_0000000200000002" change="1" id="N0010" type="Media Note">
       <text>Media note test: Multimedia link embedded form v5.5
 n OBJE {1:1} p.55
 +1 FORM &lt;MULTIMEDIA_FORMAT&gt; {1:1} p.48
@@ -132,7 +142,7 @@ n OBJE {1:1} p.55
 +1 FILE &lt;MULTIMEDIA_FILE_REFERENCE&gt; {1:1} p.47
 +1 &lt;&lt;NOTE_STRUCTURE&gt;&gt; {0:M} p.33</text>
     </note>
-    <note handle="_0000000700000007" change="1472500307" id="N0014" type="Media Note">
+    <note handle="_0000000700000007" change="1" id="N0014" type="Media Note">
       <text>Media note test: Multimedia link embedded form v5.5.1
 This note is not in the 5.5.1 spec, but is an obvious extrapolation from 5.5.
 n OBJE
@@ -141,23 +151,27 @@ n OBJE
 +3 MEDI &lt;SOURCE_MEDIA_TYPE&gt; {0:1} p.62
 +1 TITL &lt;DESCRIPTIVE_TITLE&gt; {0:1} p.48</text>
     </note>
-    <note handle="_0000000b0000000b" change="1472500307" id="N0018" type="Media Note">
+    <note handle="_0000000b0000000b" change="1" id="N0018" type="Media Note">
       <text>Multimedia embedded 2nd copy v5.5</text>
     </note>
-    <note handle="_0000000f0000000f" change="1472500307" id="N0000" type="GEDCOM import">
+    <note handle="_0000001000000010" change="1" id="N0000" type="Event Note">
+      <text>http:\\obje.form.on_event.org</text>
+    </note>
+    <note handle="_0000001100000011" change="1" id="N0001" type="GEDCOM import">
       <text>Records not imported into INDI (individual) Gramps ID I0001:
 
 Could not import test_emb_55.jpg                                    Line    18: 1 OBJE 
 Could not import test_emb_551.jpg                                   Line    26: 1 OBJE 
-Could not import test_emb_55.jpg                                    Line    34: 1 OBJE</text>
+Could not import test_emb_55.jpg                                    Line    34: 1 OBJE 
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="326"/>
       </style>
     </note>
-    <note handle="_0000001000000010" change="1472500307" id="N0001" type="REFN-TYPE">
+    <note handle="_0000001200000012" change="1" id="N0002" type="REFN-TYPE">
       <text>SOMETEXT</text>
     </note>
-    <note handle="_0000001100000011" change="1472500307" id="N0011" type="Media Note">
+    <note handle="_0000001300000013" change="1" id="N0011" type="Media Note">
       <text>Media note test: Multimedia link to linked form v5.5 blob
 n @XREF:OBJE@ OBJE {1:1}
 +1 FORM &lt;MULTIMEDIA_FORMAT&gt; {1:1} p.48  
@@ -171,10 +185,10 @@ n @XREF:OBJE@ OBJE {1:1}
 +1 RIN &lt;AUTOMATED_RECORD_ID&gt; {0:1} p.38
 +1 &lt;&lt;CHANGE_DATE&gt;&gt; {0:1} p.29</text>
     </note>
-    <note handle="_0000001200000012" change="1472500307" id="N0002" type="GEDCOM import">
+    <note handle="_0000001400000014" change="1" id="N0003" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M1:
 
-Tag recognized but not supported                                    Line    49: 1 BLOB 
+Tag recognized but not supported                                    Line    58: 1 BLOB 
                                                                                        .HM.......k.1..F.jwA.Dzzzzw............A....1.........0U.66..E.8
                                                                                        .......A..k.a6.A.......A..k.........../6....G.......0../..U.....
                                                                                        .w1/m........HC0..../...zzzzzzzz..5zzk..AnA..U..W6U....2rRrRrRrR
@@ -182,23 +196,25 @@ Tag recognized but not supported                                    Line    49: 
                                                                                        /Dw/.Tvz.E5zzUE9/kHz.Tw2/DzzzEEA.kE2zk5yzk2/zzs21.U2/Dw/.Tw/.Tzy
                                                                                        /.fy/.HzzkHzzzo21Ds00.E2.UE2.U62/.k./Ds0.UE0/Do0..E8/UE2.U62.U9w
                                                                                        /.Tx/.20.jg2/jo2..9u/.0U.6A.zk
-Line ignored as not understood                                      Line    57: 1 OBJE @M2@
-Filename omitted                                                    Line    46: 0 M1 OBJE</text>
+Line ignored as not understood                                      Line    66: 1 OBJE @M2@
+Filename omitted                                                    Line    55: 0 M1 OBJE
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="1367"/>
       </style>
     </note>
-    <note handle="_0000001400000014" change="1472500307" id="N0003" type="GEDCOM import">
+    <note handle="_0000001600000016" change="1" id="N0004" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M2:
 
-Tag recognized but not supported                                    Line    68: 1 BLOB 
+Tag recognized but not supported                                    Line    77: 1 BLOB 
                                                                                        67890gramps doesn't do this anyway, so don't bother doing it right.
-Filename omitted                                                    Line    65: 0 M2 OBJE</text>
+Filename omitted                                                    Line    74: 0 M2 OBJE
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="400"/>
       </style>
     </note>
-    <note handle="_0000001500000015" change="1472500307" id="N0012" type="Media Note">
+    <note handle="_0000001700000017" change="1" id="N0012" type="Media Note">
       <text>Media note test: Multimedia link to linked form Gramps style v5.5ish file
 n @XREF:OBJE@ OBJE {1:1}
 +1 FORM &lt;MULTIMEDIA_FORMAT&gt; {1:1} p.48  
@@ -206,18 +222,19 @@ n @XREF:OBJE@ OBJE {1:1}
 +1 FILE &lt;MULTIMEDIA_FILE_REFERENCE&gt; {1:1} p.47
 +1 &lt;&lt;NOTE_STRUCTURE&gt;&gt; {0:M} p.33</text>
     </note>
-    <note handle="_0000001600000016" change="1472500307" id="N0004" type="GEDCOM import">
+    <note handle="_0000001800000018" change="1" id="N0005" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M3:
 
-Could not import test.jpg                                           Line    73: 1 FILE test.jpg</text>
+Could not import test.jpg                                           Line    82: 1 FILE test.jpg
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="163"/>
       </style>
     </note>
-    <note handle="_0000001700000017" change="1472500307" id="N0005" type="REFN-TYPE">
+    <note handle="_0000001900000019" change="1" id="N0006" type="REFN-TYPE">
       <text>SOMETEXT</text>
     </note>
-    <note handle="_0000001800000018" change="1472500307" id="N0013" type="Media Note">
+    <note handle="_0000001a0000001a" change="1" id="N0013" type="Media Note">
       <text>Media note test: Multimedia link to linked form v5.5.1 file
 n @XREF:OBJE@ OBJE {1:1}
 +1 FILE &lt;MULTIMEDIA_FILE_REFN&gt; {1:M} p.54
@@ -231,25 +248,26 @@ n @XREF:OBJE@ OBJE {1:1}
 +1 &lt;&lt;SOURCE_CITATION&gt;&gt; {0:M} p.39
 +1 &lt;&lt;CHANGE_DATE&gt;&gt; {0:1} p.31</text>
     </note>
-    <note handle="_0000001a0000001a" change="1472500307" id="N0006" type="Source text">
+    <note handle="_0000001c0000001c" change="1" id="N0007" type="Source text">
       <text>who shall remain un-named</text>
     </note>
-    <note handle="_0000001c0000001c" change="1472500307" id="N0007" type="GEDCOM import">
+    <note handle="_0000001e0000001e" change="1" id="N0008" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M4:
 
-Could not import test.jpg                                           Line    79: 1 FILE test.jpg</text>
+Could not import test.jpg                                           Line    88: 1 FILE test.jpg
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="163"/>
       </style>
     </note>
-    <note handle="_0000001d0000001d" change="1472500307" id="N0008" type="Media Note">
+    <note handle="_0000001f0000001f" change="1" id="N0009" type="Media Note">
       <text>A fine gentelman was he, upstanding in his community and a great believer in the testing of open source software.</text>
     </note>
-    <note handle="_0000001e0000001e" change="1472500307" id="N0015" type="Media Note">
+    <note handle="_0000002000000020" change="1" id="N0015" type="Media Note">
       <text>A note on the FTM media, to see how this integrates...  The DATE line is bad; it doesnt follow Gedcom standard at all, and includes the time.
 The TEXT line comes from the FTM media description.  This is the media Note.</text>
     </note>
-    <note handle="_0000001f0000001f" change="1472500307" id="N0016" type="Media Note">
+    <note handle="_0000002100000021" change="1" id="N0016" type="Media Note">
       <text>Multimedia link to linked form FTM style
 n @XREF:OBJE@ OBJE {1:1}
 +1 FILE &lt;MULTIMEDIA_FILE_REFN&gt; {1:M} p.54
@@ -258,39 +276,42 @@ n @XREF:OBJE@ OBJE {1:1}
 +2 TEXT text string from FTM media description sometimes populated from exif comments
 +1 &lt;&lt;NOTE_STRUCTURE&gt;&gt; {0:M} p.33</text>
     </note>
-    <note handle="_0000002000000020" change="1472500307" id="N0009" type="GEDCOM import">
+    <note handle="_0000002200000022" change="1" id="N0017" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M5:
 
-Could not import test.jpg                                           Line    94: 1 FILE test.jpg</text>
+Could not import test.jpg                                           Line   103: 1 FILE test.jpg
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="163"/>
       </style>
     </note>
-    <note handle="_0000002100000021" change="1472500307" id="N0017" type="REFN-TYPE">
+    <note handle="_0000002300000023" change="1" id="N0019" type="REFN-TYPE">
       <text>SOMETEXT</text>
     </note>
-    <note handle="_0000002200000022" change="1472500307" id="N0019" type="Media Note">
+    <note handle="_0000002400000024" change="1" id="N0020" type="Media Note">
       <text>Multimedia link to linked form v5.5.1 with two files</text>
     </note>
-    <note handle="_0000002400000024" change="1472500307" id="N0020" type="Source text">
+    <note handle="_0000002600000026" change="1" id="N0021" type="Source text">
       <text>A source who shall remain un-named</text>
     </note>
-    <note handle="_0000002600000026" change="1472500307" id="N0021" type="GEDCOM import">
+    <note handle="_0000002800000028" change="1" id="N0022" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M6:
 
-Could not import test.jpg                                           Line   102: 1 FILE test.jpg
-Multiple FILE in a single OBJE ignored                              Line   106: 1 FILE test1.jpg
-Skipped subordinate line                                            Line   107: 2 FORM jpeg
-Skipped subordinate line                                            Line   108: 3 TYPE photo
-Skipped subordinate line                                            Line   109: 2 TITL Multimedia link to linked form v5.5.1 with two files(2)</text>
+Could not import test.jpg                                           Line   111: 1 FILE test.jpg
+Multiple FILE in a single OBJE ignored                              Line   115: 1 FILE test1.jpg
+Skipped subordinate line                                            Line   116: 2 FORM jpeg
+Skipped subordinate line                                            Line   117: 3 TYPE photo
+Skipped subordinate line                                            Line   118: 2 TITL Multimedia link to linked form v5.5.1 with two files(2)
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="588"/>
       </style>
     </note>
-    <note handle="_0000002700000027" change="1472500307" id="N0022" type="GEDCOM import">
+    <note handle="_0000002900000029" change="1" id="N0023" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M8:
 
-Could not import No_path_No_Title_NoForm.jpg                        Line   129: 1 FILE No_path_No_Title_NoForm.jpg</text>
+Could not import No_path_No_Title_NoForm.jpg                        Line   138: 1 FILE No_path_No_Title_NoForm.jpg
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="182"/>
       </style>

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -133,6 +133,7 @@ from gramps.gen.db.dbconst import EVENT_KEY
 from gramps.gui.dialog import WarningDialog
 from gramps.gen.lib.const import IDENTICAL, DIFFERENT
 from gramps.gen.lib import (StyledText, StyledTextTag, StyledTextTagType)
+from gramps.gen.lib.urlbase import UrlBase
 from gramps.plugins.lib.libplaceimport import PlaceImport
 from gramps.gen.display.place import displayer as _pd
 from gramps.gen.utils.grampslocale import GrampsLocale
@@ -5181,11 +5182,21 @@ class GedcomParser(UpdateCallback):
         # The following code that detects URL is an older v5.5 usage; the
         # modern option is to use the EMAIL tag.
         if isinstance(sub_state.form, str) and sub_state.form == "url":
-            url = Url()
-            url.set_path(sub_state.filename)
-            url.set_description(sub_state.title)
-            url.set_type(UrlType.WEB_HOME)
-            pri_obj.add_url(url)
+            if isinstance(pri_obj, UrlBase):
+                url = Url()
+                url.set_path(sub_state.filename)
+                url.set_description(sub_state.title)
+                url.set_type(UrlType.WEB_HOME)
+                pri_obj.add_url(url)
+            else:  # some primary objects (Event) son't have spot for URL
+                new_note = Note(sub_state.filename)
+                new_note.set_gramps_id(self.nid_map[""])
+                new_note.set_handle(create_id())
+                new_note.set_type(OBJ_NOTETYPE.get(type(pri_obj).__name__,
+                                                   NoteType.GENERAL))
+                self.dbase.commit_note(new_note, self.trans, new_note.change)
+                pri_obj.add_note(new_note.get_handle())
+
         else:
             # to allow import of references to URLs (especially for import from
             # geni.com), do not try to find the file if it is blatently a URL


### PR DESCRIPTION
Certain Gedcom files have media objects of the form
1 OBJE
2 FORM URL
2 FILE http:\\obje.form.on_person.org

This has been accepted on people, places, repos and anything else where we have a UrlBase as part of the primary object inheritance (an 'internet' tab on the object).  Unfortunately someone came up with a Gedcom file that had this attached to an Event, so our import code crashed.

This PR accepts these media formats on all primary objects, those without the UrlBase, get the data stored as Notes, rather than 'Internet' objects.

It seems a bit like an enhancement, but since it prevents a crash on import (so the Gedcom cannot be imported), I feel it deserves to be a bug.