### PR TITLE
fix bug 10062 text-only dates are sometimes not exported in XML

### DIFF
--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -1765,9 +1765,9 @@ class Date:
         """
         Return True if the date contains no information (empty text).
         """
-        return (self.modifier == Date.MOD_TEXTONLY and not self.text) or \
-               (self.get_start_date() == Date.EMPTY
-                and self.get_stop_date() == Date.EMPTY)
+        return not((self.modifier == Date.MOD_TEXTONLY and self.text)
+               or self.get_start_date() != Date.EMPTY
+                or self.get_stop_date() != Date.EMPTY)
 
     def is_compound(self):
         """

--- a/gramps/gen/lib/test/date_test.py
+++ b/gramps/gen/lib/test/date_test.py
@@ -536,5 +536,42 @@ class Test_set_newyear(BaseDateTest):
             except DateError:
                 self.assertTrue(should_raise, message)
 
+#-------------------------------------------------------------------------
+#
+# EmptyDateTest
+#
+#-------------------------------------------------------------------------
+class EmptyDateTest(BaseDateTest):
+    """
+    Tests for empty dates.
+    """
+    def test_empty(self):
+        d = Date()
+        self.assertTrue(d.is_empty())
+
+    def test_text_only_empty(self):
+        d = Date()
+        d.set(text='First of Jan',
+              modifier=Date.MOD_TEXTONLY)
+        self.assertFalse(d.is_empty())
+
+    def test_single_empty(self):
+        d = Date()
+        d.set(value=(1, 1, 1900, False),
+              modifier=Date.MOD_NONE)
+        self.assertFalse(d.is_empty())
+
+    def test_range_empty(self):
+        d = Date()
+        d.set(value=(1, 1, 1900, False, 1, 1, 1910, False),
+              modifier=Date.MOD_RANGE)
+        self.assertFalse(d.is_empty())
+
+    def test_span_empty(self):
+        d = Date()
+        d.set(value=(1, 1, 1900, False, 1, 1, 1910, False),
+              modifier=Date.MOD_SPAN)
+        self.assertFalse(d.is_empty())
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In some cases, a date that is entered and results in 'text only' doesn't get exported to XML. The date may be missing in other situations as well.
For XML export, this type of date attached to at least media, lds_ord, and parts of places is missing.

I believe the issue is on the date.py is_empty method; seems to me it is not returning a valid 'empty' condition.

Could not find any obvious recent changes, so this could have been here for a while...