### PR TITLE
Top surnames Gramplet doesn't update when db is closed, fixes #10073

### DIFF
--- a/gramps/plugins/gramplet/topsurnamesgramplet.py
+++ b/gramps/plugins/gramplet/topsurnamesgramplet.py
@@ -57,6 +57,7 @@ class TopSurnamesGramplet(Gramplet):
         self.dbstate.db.connect('person-update', self.update)
         self.dbstate.db.connect('person-rebuild', self.update)
         self.dbstate.db.connect('family-rebuild', self.update)
+        self.set_text(_("No Family Tree loaded."))
 
     def on_load(self):
         if len(self.gui.data) > 0:


### PR DESCRIPTION
If user is looking at another view, if the db is closed, and then you go back to dashboard, Top surnames Gramplet still shows the closed db data.