### PR TITLE
Citations Gramplet doesn't update in many cases, fixes #10069

### DIFF
--- a/gramps/plugins/gramplet/citations.py
+++ b/gramps/plugins/gramplet/citations.py
@@ -57,8 +57,14 @@ class Citations(Gramplet, DbGUIElement):
         """
         called on init of DbGUIElement, connect to db as required.
         """
-        self.callman.register_callbacks({'citation-update': self.changed})
-        self.callman.connect_all(keys=['citation'])
+        self.callman.register_callbacks({'citation-update': self.changed,
+                                         'person-update': self.changed,
+                                         'family-update': self.changed,
+                                         'event-update': self.changed,
+                                         'media-update': self.changed,
+                                         'place-update': self.changed})
+        self.callman.connect_all(keys=['citation', 'family', 'person', 'event',
+                                       'media', 'place'])
 
     def changed(self, handle):
         """
@@ -102,6 +108,7 @@ class Citations(Gramplet, DbGUIElement):
             self.add_media_citations(media)
 
     def add_media_citations(self, media):
+        self.callman.register_handles({'media': [media.handle]})
         self.add_citations(media)
         self.add_attribute_citations(media)
 
@@ -112,6 +119,7 @@ class Citations(Gramplet, DbGUIElement):
             self.add_event_citations(event)
 
     def add_event_citations(self, event):
+        self.callman.register_handles({'event': [event.handle]})
         self.add_citations(event)
         self.add_attribute_citations(event)
         self.add_mediaref_citations(event)
@@ -122,6 +130,7 @@ class Citations(Gramplet, DbGUIElement):
                 self.add_place_citations(place)
 
     def add_place_citations(self, place):
+        self.callman.register_handles({'place': [place.handle]})
         self.add_citations(place)
         self.add_mediaref_citations(place)
 
@@ -311,7 +320,6 @@ class PersonCitations(Citations):
         if active_handle:
             active = self.dbstate.db.get_person_from_handle(active_handle)
             if active:
-                self.callman.register_obj(active)
                 self.display_citations(active)
             else:
                 self.set_has_data(False)
@@ -323,6 +331,7 @@ class PersonCitations(Citations):
         Display the citations for the active person.
         """
         self.source_nodes = {}
+        self.callman.register_handles({'person': [person.handle]})
         self.add_citations(person)
         self.add_eventref_citations(person)
         for handle in person.get_family_handle_list():
@@ -388,7 +397,6 @@ class EventCitations(Citations):
         if active_handle:
             active = self.dbstate.db.get_event_from_handle(active_handle)
             if active:
-                self.callman.register_obj(active)
                 self.display_citations(active)
             else:
                 self.set_has_data(False)
@@ -436,7 +444,6 @@ class FamilyCitations(Citations):
         if active_handle:
             active = self.dbstate.db.get_family_from_handle(active_handle)
             if active:
-                self.callman.register_obj(active)
                 self.display_citations(active)
             else:
                 self.set_has_data(False)
@@ -448,6 +455,7 @@ class FamilyCitations(Citations):
         Display the citations for the active family.
         """
         self.source_nodes = {}
+        self.callman.register_handles({'family': [family.handle]})
         self.add_citations(family)
         self.add_eventref_citations(family)
         self.add_attribute_citations(family)
@@ -497,7 +505,6 @@ class PlaceCitations(Citations):
         if active_handle:
             active = self.dbstate.db.get_place_from_handle(active_handle)
             if active:
-                self.callman.register_obj(active)
                 self.display_citations(active)
             else:
                 self.set_has_data(False)
@@ -545,7 +552,6 @@ class MediaCitations(Citations):
         if active_handle:
             active = self.dbstate.db.get_media_from_handle(active_handle)
             if active:
-                self.callman.register_obj(active)
                 self.display_citations(active)
             else:
                 self.set_has_data(False)


### PR DESCRIPTION
To avoid issues in testing this, https://github.com/gramps-project/gramps/pull/399 should be merged first.  The bugs were a bit different so different PRs and commits.

I went through every type of data that the citations Gramplet(s) can show, and tested that the Gramplet updated when 1) the Citation data was changed, and 2) the Citation was deleted, and 3) the citation was removed from the object it was attached to, and 4) the citation was restored to a monitored object.

Since the Citations Gramplet 'goes deep' for many types of data, this meant on a Persons citations for example; checking citations on Persons Events, checking Citations on Person Events Places, Person Media citations etc.

The original code used a callman method register_obj, which did not do a very good job of finding all the handles that the citations Gramplet needed to monitor for its signals.  So I found a slightly different way to accomplish the job.  I also had to add additional monitoring of the objects that citations are attached to in order to catch cases where citations were deleted, and added to the objects.

This started as an observation during debug of another issue, and turned into an educational debug process or our callback signalling system in its own right.