### PR TITLE
Error on 'cancel' for db upgrade.  Fixes #10065

### DIFF
--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -1178,7 +1178,8 @@ class ViewManager(CLIManager):
                 self.dbstate.db.close(user=self.user)
             (filename, title) = value
             self.db_loader.read_file(filename)
-            self._post_load_newdb(filename, 'x-directory/normal', title)
+            if self.dbstate.db.is_open():
+                self._post_load_newdb(filename, 'x-directory/normal', title)
         else:
             if dialog.after_change != "":
                 # We change the title of the main window.


### PR DESCRIPTION
Try to load an older db that needs some sort of upgrade; you get the "Are you sure you want to upgrade this Family Tree?".
Hit cancel, rather than accept the upgrade.
We tried to do db processing even though there was no db.