### PR TITLE
_errorview dialog mapped without transient parent, Fixes #8128

### DIFF
--- a/gramps/gui/logger/_errorreportassistant.py
+++ b/gramps/gui/logger/_errorreportassistant.py
@@ -119,7 +119,7 @@ class ErrorReportAssistant(ManagedWindow, Gtk.Assistant):
         if self.parent_window is not None:
             self._save_position(save_config=False) # the next line saves it
             self._save_size()
-        self.hide()
+        self.destroy()
         if self.ownthread:
             Gtk.main_quit()
 

--- a/gramps/gui/logger/_errorview.py
+++ b/gramps/gui/logger/_errorview.py
@@ -106,8 +106,13 @@ class ErrorView(ManagedWindow):
     def draw_window(self):
         title = "%s - Gramps" % _("Error Report")
         self.top = Gtk.Dialog(title)
+        # look over the top level windows, it seems the oldest come first, so
+        # the most recent still visible window appears to be a good choice for
+        # a transient parent
         for win in self.top.list_toplevels():
-            if win.is_active():
+            if win == self.top:  # not interested if this is us...
+                continue
+            if win.is_toplevel() and win.is_visible():
                 self.parent_window = win # for ManagedWindow
         if self.parent_window is None: # but it is on some screen
             self.parent_window = self.top.get_screen()


### PR DESCRIPTION
@SNoiraud noticed that the errorview dialog had no transient parent on another bug and added another note to #8128.  I looked over the code and determined that there are some cases where the parent window search we did was not catching a parent, yet there was one available.  It seems that sometimes the gtk.is_active() on a window object is not set.  However the gtk.is_visible() seems to be true in every case I could test for.

@Paul-Franklin since you tested a variety of case the last time you worked on this, I'd appreciate if you tested this.  It seems to work ok for the cases I tried on my Windows and Linux systems.

I also noticed that the error report assistant was not getting destroyed; after several tries with it there were several extra copies of it in memory.

During debug I found it necessary to disable the save of window position for errorview, I was confused at first that it wasn't popping up over the failed window ;-)