### PR TITLE
10076: Filtering in the sidebar doesn't work in the citation view. Fixes #10076

### DIFF
--- a/gramps/gen/filters/rules/_rule.py
+++ b/gramps/gen/filters/rules/_rule.py
@@ -82,7 +82,7 @@ class Rule:
                 for i in range(len(self.labels)):
                     if self.list[i]:
                         try:
-                            self.regex[i] = re.compile(self.list[i], re.I)
+                            self.regex[i] = re.compile(str(self.list[i]), re.I)
                         except re.error:
                             self.regex[i] = re.compile('')
                 self.match_substring = self.match_regex


### PR DESCRIPTION
This occurs if you use the regular expressions.