### PR TITLE
Gramplets HandleErrors with Family Merge and issues on close/open

### DIFF
--- a/gramps/gen/plug/_gramplet.py
+++ b/gramps/gen/plug/_gramplet.py
@@ -64,12 +64,12 @@ class Gramplet:
         self.init()
         self.on_load()
         self.build_options()
-        self.connect(self.dbstate, "database-changed", self._db_changed)
-        self.connect(self.gui.textview, "button-press-event",
-                     self.gui.on_button_press)
-        self.connect(self.gui.textview, "motion-notify-event",
-                     self.gui.on_motion)
-        self.connect_signal('Person', self._active_changed)
+        self.dbstate.connect("database-changed", self._db_changed)
+        self.dbstate.connect("no-database", self._no_db)
+        self.gui.textview.connect("button-press-event",
+                                  self.gui.on_button_press)
+        self.gui.textview.connect("motion-notify-event",
+                                  self.gui.on_motion)
         self._db_changed(self.dbstate.db)
         active_person = self.get_active('Person')
         if active_person: # already changed
@@ -83,6 +83,7 @@ class Gramplet:
         """
         self.uistate.register(self.dbstate, nav_type, self.nav_group)
         history = self.uistate.get_history(nav_type, self.nav_group)
+        # print('History: nave-type = %s' % nav_type)
         self.connect(history, "active-changed", method)
 
     def init(self): # once, constructor
@@ -383,10 +384,23 @@ class Gramplet:
         Internal method for handling items that should happen when the
         database changes. This will push a message to the GUI status bar.
         """
+        if self.dbstate.db.is_open():
+            self.disconnect_all()  # clear the old signals from old db
         self.dbstate.db = db
         self.gui.dbstate.db = db
-        self.db_changed()
+        if db.is_open():
+            # the following prevents connecting to every Gramplet, and still
+            # allows Person Gramplets to be informed of active-changed
+            # Some Gramplets .gpr files don't have navtypes set, thus the
+            # hasattr
+            if hasattr(self.gui, 'navtypes') and 'Person' in self.gui.navtypes:
+                self.connect_signal('Person', self._active_changed)
+            self.db_changed()
         self.update()
+
+    def _no_db(self):
+        if self.dbstate.db.is_open():
+            self.disconnect_all()  # clear the old signals
 
     def get_option_widget(self, label):
         """
@@ -428,8 +442,18 @@ class Gramplet:
         if signal in self._signal:
             for (id, signal_obj) in self._signal[signal]:
                 signal_obj.disconnect(id)
+            self._signal[signal] = []
         else:
             raise AttributeError("unknown signal: '%s'" % signal)
+
+    def disconnect_all(self):
+        """
+        Used to disconnect all the signals for this specific gramplet
+        """
+        for signal in self._signal:
+            for (sig_id, signal_obj) in self._signal[signal]:
+                signal_obj.disconnect(sig_id)
+            self._signal[signal] = []
 
     def hidden_widgets(self):
         """

--- a/gramps/plugins/gramplet/ageondategramplet.py
+++ b/gramps/plugins/gramplet/ageondategramplet.py
@@ -77,9 +77,6 @@ class AgeOnDateGramplet(Gramplet):
         self.gui.get_container_widget().add(vbox)
         vbox.show_all()
 
-    def post_init(self):
-        self.disconnect("active-changed")
-
     def run(self, obj):
         """
         Method that is run when you click the Run button.

--- a/gramps/plugins/gramplet/agestats.py
+++ b/gramps/plugins/gramplet/agestats.py
@@ -48,9 +48,6 @@ class AgeStatsGramplet(Gramplet):
         self.max_father_diff = 60
         self.chart_width = 60
 
-    def post_init(self):
-        self.disconnect("active-changed")
-
     def build_options(self):
         from gramps.gen.plug.menu import NumberOption
         self.add_option(NumberOption(_("Max age"),

--- a/gramps/plugins/gramplet/attributes.py
+++ b/gramps/plugins/gramplet/attributes.py
@@ -93,7 +93,7 @@ class PersonAttributes(Attributes):
     Displays the attributes of a person.
     """
     def db_changed(self):
-        self.dbstate.db.connect('person-update', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
 
     def active_changed(self, handle):
         self.update()
@@ -123,7 +123,7 @@ class EventAttributes(Attributes):
     Displays the attributes of an event.
     """
     def db_changed(self):
-        self.dbstate.db.connect('event-update', self.update)
+        self.connect(self.dbstate.db, 'event-update', self.update)
         self.connect_signal('Event', self.update)
 
     def update_has_data(self):
@@ -151,7 +151,7 @@ class FamilyAttributes(Attributes):
     Displays the attributes of an event.
     """
     def db_changed(self):
-        self.dbstate.db.connect('family-update', self.update)
+        self.connect(self.dbstate.db, 'family-update', self.update)
         self.connect_signal('Family', self.update)
 
     def update_has_data(self):
@@ -179,7 +179,7 @@ class MediaAttributes(Attributes):
     Displays the attributes of a media object.
     """
     def db_changed(self):
-        self.dbstate.db.connect('media-update', self.update)
+        self.connect(self.dbstate.db, 'media-update', self.update)
         self.connect_signal('Media', self.update)
 
     def update_has_data(self):
@@ -207,7 +207,7 @@ class SourceAttributes(Attributes):
     Displays the attributes of a source object.
     """
     def db_changed(self):
-        self.dbstate.db.connect('source-update', self.update)
+        self.connect(self.dbstate.db, 'source-update', self.update)
         self.connect_signal('Source', self.update)
 
     def update_has_data(self):
@@ -235,7 +235,7 @@ class CitationAttributes(Attributes):
     Displays the attributes of a citation object.
     """
     def db_changed(self):
-        self.dbstate.db.connect('citation-update', self.update)
+        self.connect(self.dbstate.db, 'citation-update', self.update)
         self.connect_signal('Citation', self.update)
 
     def update_has_data(self):

--- a/gramps/plugins/gramplet/backlinks.py
+++ b/gramps/plugins/gramplet/backlinks.py
@@ -97,7 +97,7 @@ class PersonBacklinks(Backlinks):
     Displays the back references for a person.
     """
     def db_changed(self):
-        self.dbstate.db.connect('person-update', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
 
     def active_changed(self, handle):
         self.update()
@@ -119,7 +119,7 @@ class EventBacklinks(Backlinks):
     Displays the back references for an event.
     """
     def db_changed(self):
-        self.dbstate.db.connect('event-update', self.update)
+        self.connect(self.dbstate.db, 'event-update', self.update)
         self.connect_signal('Event', self.update)
 
     def update_has_data(self):
@@ -139,7 +139,7 @@ class FamilyBacklinks(Backlinks):
     Displays the back references for a family.
     """
     def db_changed(self):
-        self.dbstate.db.connect('family-update', self.update)
+        self.connect(self.dbstate.db, 'family-update', self.update)
         self.connect_signal('Family', self.update)
 
     def update_has_data(self):
@@ -159,7 +159,7 @@ class PlaceBacklinks(Backlinks):
     Displays the back references for a place.
     """
     def db_changed(self):
-        self.dbstate.db.connect('place-update', self.update)
+        self.connect(self.dbstate.db, 'place-update', self.update)
         self.connect_signal('Place', self.update)
 
     def update_has_data(self):
@@ -179,7 +179,7 @@ class SourceBacklinks(Backlinks):
     Displays the back references for a source,.
     """
     def db_changed(self):
-        self.dbstate.db.connect('source-update', self.update)
+        self.connect(self.dbstate.db, 'source-update', self.update)
         self.connect_signal('Source', self.update)
 
     def update_has_data(self):
@@ -199,7 +199,7 @@ class CitationBacklinks(Backlinks):
     Displays the back references for a Citation,.
     """
     def db_changed(self):
-        self.dbstate.db.connect('citation-update', self.update)
+        self.connect(self.dbstate.db, 'citation-update', self.update)
         self.connect_signal('Citation', self.update)
 
     def update_has_data(self):
@@ -219,7 +219,7 @@ class RepositoryBacklinks(Backlinks):
     Displays the back references for a repository.
     """
     def db_changed(self):
-        self.dbstate.db.connect('repository-update', self.update)
+        self.connect(self.dbstate.db, 'repository-update', self.update)
         self.connect_signal('Repository', self.update)
 
     def update_has_data(self):
@@ -239,7 +239,7 @@ class MediaBacklinks(Backlinks):
     Displays the back references for a media object.
     """
     def db_changed(self):
-        self.dbstate.db.connect('media-update', self.update)
+        self.connect(self.dbstate.db, 'media-update', self.update)
         self.connect_signal('Media', self.update)
 
     def update_has_data(self):
@@ -259,7 +259,7 @@ class NoteBacklinks(Backlinks):
     Displays the back references for a note.
     """
     def db_changed(self):
-        self.dbstate.db.connect('note-update', self.update)
+        self.connect(self.dbstate.db, 'note-update', self.update)
         self.connect_signal('Note', self.update)
 
     def update_has_data(self):

--- a/gramps/plugins/gramplet/calendargramplet.py
+++ b/gramps/plugins/gramplet/calendargramplet.py
@@ -57,9 +57,6 @@ class CalendarGramplet(Gramplet):
         self.gui.get_container_widget().add(vbox)
         vbox.show_all()
 
-    def post_init(self):
-        self.disconnect("active-changed")
-
     def double_click(self, obj):
         """
         Bring up events on this day.

--- a/gramps/plugins/gramplet/children.py
+++ b/gramps/plugins/gramplet/children.py
@@ -100,7 +100,7 @@ class PersonChildren(Children):
         return top
 
     def db_changed(self):
-        self.dbstate.db.connect('person-update', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
 
     def active_changed(self, handle):
         self.update()
@@ -198,10 +198,9 @@ class FamilyChildren(Children):
         return top
 
     def db_changed(self):
-        self.dbstate.db.connect('family-update', self.update)
-        self.connect_signal('Family', self.update)
-        self.dbstate.db.connect('person-update', self.update)
-        self.connect_signal('Person', self.update)
+        self.connect(self.dbstate.db, 'family-update', self.update)
+        self.connect_signal('Family', self.update)  # familiy active-changed
+        self.connect(self.dbstate.db, 'person-update', self.update)
 
     def main(self):
         active_handle = self.get_active('Family')

--- a/gramps/plugins/gramplet/coordinates.py
+++ b/gramps/plugins/gramplet/coordinates.py
@@ -188,7 +188,7 @@ class GeoPersonEvents(GeoEvents):
     Displays the events for a person.
     """
     def db_changed(self):
-        self.dbstate.db.connect('person-update', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
 
     def active_changed(self, handle):
         self.update()
@@ -256,7 +256,7 @@ class GeoFamilyEvents(GeoEvents):
     Displays the events for a family.
     """
     def db_changed(self):
-        self.dbstate.db.connect('family-update', self.update)
+        self.connect(self.dbstate.db, 'family-update', self.update)
         self.connect_signal('Family', self.update)
 
     def update_has_data(self):

--- a/gramps/plugins/gramplet/events.py
+++ b/gramps/plugins/gramplet/events.py
@@ -162,7 +162,7 @@ class PersonEvents(Events):
     Displays the events for a person.
     """
     def db_changed(self):
-        self.dbstate.db.connect('person-update', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
 
     def active_changed(self, handle):
         self.update()
@@ -242,7 +242,7 @@ class FamilyEvents(Events):
     Displays the events for a family.
     """
     def db_changed(self):
-        self.dbstate.db.connect('family-update', self.update)
+        self.connect(self.dbstate.db, 'family-update', self.update)
         self.connect_signal('Family', self.update)
 
     def update_has_data(self):

--- a/gramps/plugins/gramplet/faqgramplet.py
+++ b/gramps/plugins/gramplet/faqgramplet.py
@@ -175,6 +175,3 @@ class FAQGramplet(Gramplet):
               "How can I help with Gramps?"
               "%(html_end)s\n") % faq_dict)
         self.append_text("", scroll_to='begin')
-
-    def post_init(self):
-        self.disconnect("active-changed")

--- a/gramps/plugins/gramplet/gallery.py
+++ b/gramps/plugins/gramplet/gallery.py
@@ -108,7 +108,7 @@ class PersonGallery(Gallery):
     Displays a gallery of media objects for a person.
     """
     def db_changed(self):
-        self.dbstate.db.connect('person-update', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
 
     def active_changed(self, handle):
         self.update()
@@ -138,7 +138,7 @@ class FamilyGallery(Gallery):
     Displays a gallery of media objects for a family.
     """
     def db_changed(self):
-        self.dbstate.db.connect('family-update', self.update)
+        self.connect(self.dbstate.db, 'family-update', self.update)
         self.connect_signal('Family', self.update)
 
     def update_has_data(self):
@@ -166,7 +166,7 @@ class EventGallery(Gallery):
     Displays a gallery of media objects for an event.
     """
     def db_changed(self):
-        self.dbstate.db.connect('event-update', self.update)
+        self.connect(self.dbstate.db, 'event-update', self.update)
         self.connect_signal('Event', self.update)
 
     def update_has_data(self):
@@ -194,7 +194,7 @@ class PlaceGallery(Gallery):
     Displays a gallery of media objects for a place.
     """
     def db_changed(self):
-        self.dbstate.db.connect('place-update', self.update)
+        self.connect(self.dbstate.db, 'place-update', self.update)
         self.connect_signal('Place', self.update)
 
     def update_has_data(self):
@@ -222,7 +222,7 @@ class SourceGallery(Gallery):
     Displays a gallery of media objects for a source.
     """
     def db_changed(self):
-        self.dbstate.db.connect('event-update', self.update)
+        self.connect(self.dbstate.db, 'event-update', self.update)
         self.connect_signal('Source', self.update)
 
     def update_has_data(self):
@@ -250,7 +250,7 @@ class CitationGallery(Gallery):
     Displays a gallery of media objects for a Citation.
     """
     def db_changed(self):
-        self.dbstate.db.connect('event-update', self.update)
+        self.connect(self.dbstate.db, 'event-update', self.update)
         self.connect_signal('Citation', self.update)
 
     def update_has_data(self):

--- a/gramps/plugins/gramplet/givennamegramplet.py
+++ b/gramps/plugins/gramplet/givennamegramplet.py
@@ -55,9 +55,9 @@ class GivenNameCloudGramplet(Gramplet):
         self.set_text(_("No Family Tree loaded."))
 
     def db_changed(self):
-        self.dbstate.db.connect('person-add', self.update)
-        self.dbstate.db.connect('person-delete', self.update)
-        self.dbstate.db.connect('person-update', self.update)
+        self.connect(self.dbstate.db, 'person-add', self.update)
+        self.connect(self.dbstate.db, 'person-delete', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
 
     def on_load(self):
         if len(self.gui.data) > 0:

--- a/gramps/plugins/gramplet/mediapreview.py
+++ b/gramps/plugins/gramplet/mediapreview.py
@@ -53,7 +53,7 @@ class MediaPreview(Gramplet):
         return self.top
 
     def db_changed(self):
-        self.dbstate.db.connect('media-update', self.update)
+        self.connect(self.dbstate.db, 'media-update', self.update)
         self.connect_signal('Media', self.update)
 
     def update_has_data(self):

--- a/gramps/plugins/gramplet/notes.py
+++ b/gramps/plugins/gramplet/notes.py
@@ -149,7 +149,7 @@ class PersonNotes(Notes):
     Displays the notes for a person.
     """
     def db_changed(self):
-        self.dbstate.db.connect('person-update', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
 
     def active_changed(self, handle):
         self.update()
@@ -179,7 +179,7 @@ class EventNotes(Notes):
     Displays the notes for an event.
     """
     def db_changed(self):
-        self.dbstate.db.connect('event-update', self.update)
+        self.connect(self.dbstate.db, 'event-update', self.update)
         self.connect_signal('Event', self.update)
 
     def update_has_data(self):
@@ -207,7 +207,7 @@ class FamilyNotes(Notes):
     Displays the notes for a family.
     """
     def db_changed(self):
-        self.dbstate.db.connect('family-update', self.update)
+        self.connect(self.dbstate.db, 'family-update', self.update)
         self.connect_signal('Family', self.update)
 
     def update_has_data(self):
@@ -235,7 +235,7 @@ class PlaceNotes(Notes):
     Displays the notes for a place.
     """
     def db_changed(self):
-        self.dbstate.db.connect('place-update', self.update)
+        self.connect(self.dbstate.db, 'place-update', self.update)
         self.connect_signal('Place', self.update)
 
     def update_has_data(self):
@@ -263,7 +263,7 @@ class SourceNotes(Notes):
     Displays the notes for a source.
     """
     def db_changed(self):
-        self.dbstate.db.connect('source-update', self.update)
+        self.connect(self.dbstate.db, 'source-update', self.update)
         self.connect_signal('Source', self.update)
 
     def update_has_data(self):
@@ -291,7 +291,7 @@ class CitationNotes(Notes):
     Displays the notes for a Citation.
     """
     def db_changed(self):
-        self.dbstate.db.connect('citation-update', self.update)
+        self.connect(self.dbstate.db, 'citation-update', self.update)
         self.connect_signal('Citation', self.update)
 
     def update_has_data(self):
@@ -319,7 +319,7 @@ class RepositoryNotes(Notes):
     Displays the notes for a repository.
     """
     def db_changed(self):
-        self.dbstate.db.connect('repository-update', self.update)
+        self.connect(self.dbstate.db, 'repository-update', self.update)
         self.connect_signal('Repository', self.update)
 
     def update_has_data(self):
@@ -347,7 +347,7 @@ class MediaNotes(Notes):
     Displays the notes for a media object.
     """
     def db_changed(self):
-        self.dbstate.db.connect('media-update', self.update)
+        self.connect(self.dbstate.db, 'media-update', self.update)
         self.connect_signal('Media', self.update)
 
     def update_has_data(self):

--- a/gramps/plugins/gramplet/pedigreegramplet.py
+++ b/gramps/plugins/gramplet/pedigreegramplet.py
@@ -86,12 +86,12 @@ class PedigreeGramplet(Gramplet):
         If a person or family changes, the ancestors of active person might have
         changed.
         """
-        self.dbstate.db.connect('person-add', self.update)
-        self.dbstate.db.connect('person-delete', self.update)
-        self.dbstate.db.connect('family-add', self.update)
-        self.dbstate.db.connect('family-delete', self.update)
-        self.dbstate.db.connect('person-rebuild', self.update)
-        self.dbstate.db.connect('family-rebuild', self.update)
+        self.connect(self.dbstate.db, 'person-add', self.update)
+        self.connect(self.dbstate.db, 'person-delete', self.update)
+        self.connect(self.dbstate.db, 'family-add', self.update)
+        self.connect(self.dbstate.db, 'family-delete', self.update)
+        self.connect(self.dbstate.db, 'person-rebuild', self.update)
+        self.connect(self.dbstate.db, 'family-rebuild', self.update)
 
     def active_changed(self, handle):
         self.update()

--- a/gramps/plugins/gramplet/persondetails.py
+++ b/gramps/plugins/gramplet/persondetails.py
@@ -89,7 +89,7 @@ class PersonDetails(Gramplet):
         list(map(self.grid.remove, self.grid.get_children()))
 
     def db_changed(self):
-        self.dbstate.db.connect('person-update', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
 
     def active_changed(self, handle):
         self.update()

--- a/gramps/plugins/gramplet/personresidence.py
+++ b/gramps/plugins/gramplet/personresidence.py
@@ -63,7 +63,7 @@ class PersonResidence(Gramplet):
         return top
 
     def db_changed(self):
-        self.dbstate.db.connect('person-update', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
 
     def active_changed(self, handle):
         self.update()

--- a/gramps/plugins/gramplet/placedetails.py
+++ b/gramps/plugins/gramplet/placedetails.py
@@ -84,7 +84,7 @@ class PlaceDetails(Gramplet):
         list(map(self.grid.remove, self.grid.get_children()))
 
     def db_changed(self):
-        self.dbstate.db.connect('place-update', self.update)
+        self.connect(self.dbstate.db, 'place-update', self.update)
         self.connect_signal('Place', self.update)
 
     def update_has_data(self):

--- a/gramps/plugins/gramplet/recordsgramplet.py
+++ b/gramps/plugins/gramplet/recordsgramplet.py
@@ -43,8 +43,8 @@ class RecordsGramplet(Gramplet):
         self.set_text(_("No Family Tree loaded."))
 
     def db_changed(self):
-        self.dbstate.db.connect('person-rebuild', self.update)
-        self.dbstate.db.connect('family-rebuild', self.update)
+        self.connect(self.dbstate.db, 'person-rebuild', self.update)
+        self.connect(self.dbstate.db, 'family-rebuild', self.update)
 
     def main(self):
         self.set_text(_("Processing...") + "\n")

--- a/gramps/plugins/gramplet/relativegramplet.py
+++ b/gramps/plugins/gramplet/relativegramplet.py
@@ -46,12 +46,12 @@ class RelativesGramplet(Gramplet):
         If person or family changes, the relatives of active person might have
         changed
         """
-        self.dbstate.db.connect('person-add', self.update)
-        self.dbstate.db.connect('person-delete', self.update)
-        self.dbstate.db.connect('family-add', self.update)
-        self.dbstate.db.connect('family-delete', self.update)
-        self.dbstate.db.connect('person-rebuild', self.update)
-        self.dbstate.db.connect('family-rebuild', self.update)
+        self.connect(self.dbstate.db, 'person-add', self.update)
+        self.connect(self.dbstate.db, 'person-delete', self.update)
+        self.connect(self.dbstate.db, 'family-add', self.update)
+        self.connect(self.dbstate.db, 'family-delete', self.update)
+        self.connect(self.dbstate.db, 'person-rebuild', self.update)
+        self.connect(self.dbstate.db, 'family-rebuild', self.update)
 
     def active_changed(self, handle):
         self.update()

--- a/gramps/plugins/gramplet/repositorydetails.py
+++ b/gramps/plugins/gramplet/repositorydetails.py
@@ -79,7 +79,7 @@ class RepositoryDetails(Gramplet):
         list(map(self.grid.remove, self.grid.get_children()))
 
     def db_changed(self):
-        self.dbstate.db.connect('repository-update', self.update)
+        self.connect(self.dbstate.db, 'repository-update', self.update)
         self.connect_signal('Repository', self.update)
 
     def update_has_data(self):

--- a/gramps/plugins/gramplet/sessionloggramplet.py
+++ b/gramps/plugins/gramplet/sessionloggramplet.py
@@ -57,18 +57,18 @@ class LogGramplet(Gramplet):
         self.append_text(_("Opened data base -----------\n"))
         # List of translated strings used here (translated in self.log ).
         _('Added'), _('Deleted'), _('Edited'), _('Selected') # Dead code for l10n
-        self.dbstate.db.connect('person-add',
-                                lambda handles: self.log('Person', 'Added', handles))
-        self.dbstate.db.connect('person-delete',
-                                lambda handles: self.log('Person', 'Deleted', handles))
-        self.dbstate.db.connect('person-update',
-                                lambda handles: self.log('Person', 'Edited', handles))
-        self.dbstate.db.connect('family-add',
-                                lambda handles: self.log('Family', 'Added', handles))
-        self.dbstate.db.connect('family-delete',
-                                lambda handles: self.log('Family', 'Deleted', handles))
-        self.dbstate.db.connect('family-update',
-                                lambda handles: self.log('Family', 'Edited', handles))
+        self.connect(self.dbstate.db, 'person-add',
+                     lambda handles: self.log('Person', 'Added', handles))
+        self.connect(self.dbstate.db, 'person-delete',
+                     lambda handles: self.log('Person', 'Deleted', handles))
+        self.connect(self.dbstate.db, 'person-update',
+                     lambda handles: self.log('Person', 'Edited', handles))
+        self.connect(self.dbstate.db, 'family-add',
+                     lambda handles: self.log('Family', 'Added', handles))
+        self.connect(self.dbstate.db, 'family-delete',
+                     lambda handles: self.log('Family', 'Deleted', handles))
+        self.connect(self.dbstate.db, 'family-update',
+                     lambda handles: self.log('Family', 'Edited', handles))
 
     def active_changed(self, handle):
         if handle:

--- a/gramps/plugins/gramplet/statsgramplet.py
+++ b/gramps/plugins/gramplet/statsgramplet.py
@@ -57,13 +57,13 @@ class StatsGramplet(Gramplet):
         self.update()
 
     def db_changed(self):
-        self.dbstate.db.connect('person-add', self.update)
-        self.dbstate.db.connect('person-edit', self.update)
-        self.dbstate.db.connect('person-delete', self.update)
-        self.dbstate.db.connect('family-add', self.update)
-        self.dbstate.db.connect('family-delete', self.update)
-        self.dbstate.db.connect('person-rebuild', self.update)
-        self.dbstate.db.connect('family-rebuild', self.update)
+        self.connect(self.dbstate.db, 'person-add', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
+        self.connect(self.dbstate.db, 'person-delete', self.update)
+        self.connect(self.dbstate.db, 'family-add', self.update)
+        self.connect(self.dbstate.db, 'family-delete', self.update)
+        self.connect(self.dbstate.db, 'person-rebuild', self.update)
+        self.connect(self.dbstate.db, 'family-rebuild', self.update)
 
     def main(self):
         self.set_text(_("Processing..."))

--- a/gramps/plugins/gramplet/surnamecloudgramplet.py
+++ b/gramps/plugins/gramplet/surnamecloudgramplet.py
@@ -70,11 +70,11 @@ class SurnameCloudGramplet(Gramplet):
         self.set_text(_("No Family Tree loaded."))
 
     def db_changed(self):
-        self.dbstate.db.connect('person-add', self.update)
-        self.dbstate.db.connect('person-delete', self.update)
-        self.dbstate.db.connect('person-update', self.update)
-        self.dbstate.db.connect('person-rebuild', self.update)
-        self.dbstate.db.connect('family-rebuild', self.update)
+        self.connect(self.dbstate.db, 'person-add', self.update)
+        self.connect(self.dbstate.db, 'person-delete', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
+        self.connect(self.dbstate.db, 'person-rebuild', self.update)
+        self.connect(self.dbstate.db, 'family-rebuild', self.update)
 
     def on_load(self):
         if len(self.gui.data) == 3:

--- a/gramps/plugins/gramplet/todo.py
+++ b/gramps/plugins/gramplet/todo.py
@@ -197,7 +197,7 @@ class PersonToDo(ToDo):
     Displays the To Do notes for a person.
     """
     def db_changed(self):
-        self.dbstate.db.connect('person-update', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
 
     def active_changed(self, handle):
         self.update()
@@ -232,7 +232,7 @@ class EventToDo(ToDo):
     Displays the To Do notes for an event.
     """
     def db_changed(self):
-        self.dbstate.db.connect('event-update', self.update)
+        self.connect(self.dbstate.db, 'event-update', self.update)
         self.connect_signal('Event', self.update)
 
     def update_has_data(self):
@@ -265,7 +265,7 @@ class FamilyToDo(ToDo):
     Displays the To Do notes for a family.
     """
     def db_changed(self):
-        self.dbstate.db.connect('family-update', self.update)
+        self.connect(self.dbstate.db, 'family-update', self.update)
         self.connect_signal('Family', self.update)
 
     def update_has_data(self):
@@ -298,7 +298,7 @@ class PlaceToDo(ToDo):
     Displays the To Do notes for a place.
     """
     def db_changed(self):
-        self.dbstate.db.connect('place-update', self.update)
+        self.connect(self.dbstate.db, 'place-update', self.update)
         self.connect_signal('Place', self.update)
 
     def update_has_data(self):
@@ -331,7 +331,7 @@ class SourceToDo(ToDo):
     Displays the To Do notes for a source.
     """
     def db_changed(self):
-        self.dbstate.db.connect('source-update', self.update)
+        self.connect(self.dbstate.db, 'source-update', self.update)
         self.connect_signal('Source', self.update)
 
     def update_has_data(self):
@@ -364,7 +364,7 @@ class CitationToDo(ToDo):
     Displays the To Do notes for a Citation.
     """
     def db_changed(self):
-        self.dbstate.db.connect('citation-update', self.update)
+        self.connect(self.dbstate.db, 'citation-update', self.update)
         self.connect_signal('Citation', self.update)
 
     def update_has_data(self):
@@ -397,7 +397,7 @@ class RepositoryToDo(ToDo):
     Displays the To Do notes for a repository.
     """
     def db_changed(self):
-        self.dbstate.db.connect('repository-update', self.update)
+        self.connect(self.dbstate.db, 'repository-update', self.update)
         self.connect_signal('Repository', self.update)
 
     def update_has_data(self):
@@ -430,7 +430,7 @@ class MediaToDo(ToDo):
     Displays the To Do notes for a media object.
     """
     def db_changed(self):
-        self.dbstate.db.connect('media-update', self.update)
+        self.connect(self.dbstate.db, 'media-update', self.update)
         self.connect_signal('Media', self.update)
 
     def update_has_data(self):

--- a/gramps/plugins/gramplet/todogramplet.py
+++ b/gramps/plugins/gramplet/todogramplet.py
@@ -210,6 +210,6 @@ class ToDoGramplet(Gramplet):
         self.set_has_data(self.get_has_data())
 
     def db_changed(self):
-        self.dbstate.db.connect('note-add', self.update)
-        self.dbstate.db.connect('note-delete', self.update)
-        self.dbstate.db.connect('note-update', self.update)
+        self.connect(self.dbstate.db, 'note-add', self.update)
+        self.connect(self.dbstate.db, 'note-delete', self.update)
+        self.connect(self.dbstate.db, 'note-update', self.update)

--- a/gramps/plugins/gramplet/topsurnamesgramplet.py
+++ b/gramps/plugins/gramplet/topsurnamesgramplet.py
@@ -52,11 +52,11 @@ class TopSurnamesGramplet(Gramplet):
         self.set_text(_("No Family Tree loaded."))
 
     def db_changed(self):
-        self.dbstate.db.connect('person-add', self.update)
-        self.dbstate.db.connect('person-delete', self.update)
-        self.dbstate.db.connect('person-update', self.update)
-        self.dbstate.db.connect('person-rebuild', self.update)
-        self.dbstate.db.connect('family-rebuild', self.update)
+        self.connect(self.dbstate.db, 'person-add', self.update)
+        self.connect(self.dbstate.db, 'person-delete', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
+        self.connect(self.dbstate.db, 'person-rebuild', self.update)
+        self.connect(self.dbstate.db, 'family-rebuild', self.update)
         self.set_text(_("No Family Tree loaded."))
 
     def on_load(self):

--- a/gramps/plugins/gramplet/whatsnext.py
+++ b/gramps/plugins/gramplet/whatsnext.py
@@ -147,13 +147,13 @@ class WhatNextGramplet(Gramplet):
 
     def db_changed(self):
 
-        self.dbstate.db.connect('home-person-changed', self.update)
-        self.dbstate.db.connect('person-add', self.update)
-        self.dbstate.db.connect('person-delete', self.update)
-        self.dbstate.db.connect('person-update', self.update)
-        self.dbstate.db.connect('family-add', self.update)
-        self.dbstate.db.connect('family-delete', self.update)
-        self.dbstate.db.connect('family-update', self.update)
+        self.connect(self.dbstate.db, 'home-person-changed', self.update)
+        self.connect(self.dbstate.db, 'person-add', self.update)
+        self.connect(self.dbstate.db, 'person-delete', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
+        self.connect(self.dbstate.db, 'family-add', self.update)
+        self.connect(self.dbstate.db, 'family-delete', self.update)
+        self.connect(self.dbstate.db, 'family-update', self.update)
 
 
     def main(self):


### PR DESCRIPTION
This PR was tested on top of https://github.com/gramps-project/gramps/pull/423 to deal with as many HandleErrors as I could.  If you intend to test this, you should accept PR 423 first, I cannot guarantee everything works unless both are present.

This should finish #10068, #10081, #10082, #10089, #10090 and possibly some others.

After PR 423, I discovered that doing a Family merge that also merged at least one parent, would still get HandleErrors.  Root cause, a lot of Gramplets were getting connected to Person history active-changed signal, and thus were doing unnecessary updates.  In this case, the Person update occured before the Family Gramplets got shifted off of the family deleted by the merge, so the Gramplets tried to show the (now deleted) family again.  And got HandleErrors.

I changed the base Gramplet class to only make default connections to the Person History active-change signal when the Gramplet had a navtype of 'Person' from the .gpr file.  So unless a Gramplet has navtype=['Person'] in .gpr it will not get an automatic connection to Person active-changed.

It turns out a few Gramplets knew they were getting the 'extra' Person connection, and had a 'disconnect' which now failed with the prior change.  So these extra disconnects are removed.

I also noticed that on db close/open, a lot of signals were getting connected when they already were connected.  This because the connection was made in a db_changed method, but never disconnected.

To prevent multiple connections after db close/open, I decided to make all connections through Gramplet class 'connect', rather than directly to db, and to implement a disconnect on db_close and on db_changed, prior to making the connections again.

In the sweep though all our Gramplets I spotted a few other smaller issues #10082 had a wrong signal connect ('person-edit', rather than 'person-update').  And a few signals were missing from some of the Gramplets.

I apologize for not separating these issues into separate commits, but I discovered after all the testing that many of the changes were too close together for 'git add -p' to break them up.  And I'm too lazy to do it manually.

I have a PR for the addons-source repo that does the same thing for those addons as well.