### PR TITLE
Media Verify tool generates names with '..\..' unnecessarily (Windows)

### DIFF
--- a/gramps/gen/utils/file.py
+++ b/gramps/gen/utils/file.py
@@ -140,9 +140,12 @@ def relative_path(original, base):
     # base path is normcase (lower case on Windows) so compare target in lower
     # on Windows as well
     for i in range(min(len(base_list), len(target_list))):
-        if base_list[i] != (target_list[i].lower() if win()
-                            else target_list[i]):
-            break
+        if win():
+            if base_list[i].lower() != target_list[i].lower():
+                break
+        else:
+            if base_list[i] != target_list[i]:
+                break
     else:
         #if break did not happen we are here at end, and add 1.
         i += 1


### PR DESCRIPTION
fixes #10087

On Windows, file path case is ignored.
When comparing proposed base path file path, the original routine assumed that the base path was already in lowercase, when it checked against file_path.lower().  This is not always true, the base path could have uppercase names.
I think other users of this routine probably did the base_path.lower() conversion of base path before calling...  Which is why it works for normal media add.