### PR TITLE
Fix creating new PostgreSQL database

### DIFF
--- a/gramps/gen/utils/grampslocale.py
+++ b/gramps/gen/utils/grampslocale.py
@@ -935,6 +935,12 @@ class GrampsLocale:
                 return string
             return key
 
+    def get_collation(self):
+        """
+        Return the collation without any character encoding.
+        """
+        return self.collation.split('.')[0]
+
     def strcoll(self, string1, string2):
         """
         Given two localized strings, compare them and return -1 if

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -418,8 +418,9 @@ class DBAPI(DbGeneric):
         If sort_handles is True, the list is sorted by surnames.
         """
         if sort_handles:
-            self.dbapi.execute("SELECT handle FROM person "
-                               "ORDER BY surname COLLATE glocale")
+            self.dbapi.execute('SELECT handle FROM person '
+                               'ORDER BY surname '
+                               'COLLATE "%s"' % glocale.get_collation())
         else:
             self.dbapi.execute("SELECT handle FROM person")
         rows = self.dbapi.fetchall()
@@ -433,21 +434,21 @@ class DBAPI(DbGeneric):
         If sort_handles is True, the list is sorted by surnames.
         """
         if sort_handles:
-            sql = ("SELECT family.handle " +
-                   "FROM family " +
-                   "LEFT JOIN person AS father " +
-                   "ON family.father_handle = father.handle " +
-                   "LEFT JOIN person AS mother " +
-                   "ON family.mother_handle = mother.handle " +
-                   "ORDER BY (CASE WHEN father.handle IS NULL " +
-                   "THEN mother.surname " +
-                   "ELSE father.surname " +
-                   "END), " +
-                   "(CASE WHEN family.handle IS NULL " +
-                   "THEN mother.given_name " +
-                   "ELSE father.given_name " +
-                   "END) " +
-                   "COLLATE glocale")
+            sql = ('SELECT family.handle ' +
+                   'FROM family ' +
+                   'LEFT JOIN person AS father ' +
+                   'ON family.father_handle = father.handle ' +
+                   'LEFT JOIN person AS mother ' +
+                   'ON family.mother_handle = mother.handle ' +
+                   'ORDER BY (CASE WHEN father.handle IS NULL ' +
+                   'THEN mother.surname ' +
+                   'ELSE father.surname ' +
+                   'END), ' +
+                   '(CASE WHEN family.handle IS NULL ' +
+                   'THEN mother.given_name ' +
+                   'ELSE father.given_name ' +
+                   'END) ' +
+                   'COLLATE "%s"' % glocale.get_collation())
             self.dbapi.execute(sql)
         else:
             self.dbapi.execute("SELECT handle FROM family")
@@ -471,8 +472,9 @@ class DBAPI(DbGeneric):
         If sort_handles is True, the list is sorted by Citation title.
         """
         if sort_handles:
-            self.dbapi.execute("SELECT handle FROM citation "
-                               "ORDER BY page COLLATE glocale")
+            self.dbapi.execute('SELECT handle FROM citation '
+                               'ORDER BY page '
+                               'COLLATE "%s"' % glocale.get_collation())
         else:
             self.dbapi.execute("SELECT handle FROM citation")
         rows = self.dbapi.fetchall()
@@ -486,8 +488,9 @@ class DBAPI(DbGeneric):
         If sort_handles is True, the list is sorted by Source title.
         """
         if sort_handles:
-            self.dbapi.execute("SELECT handle FROM source "
-                               "ORDER BY title COLLATE glocale")
+            self.dbapi.execute('SELECT handle FROM source '
+                               'ORDER BY title '
+                               'COLLATE "%s"' % glocale.get_collation())
         else:
             self.dbapi.execute("SELECT handle from source")
         rows = self.dbapi.fetchall()
@@ -501,8 +504,9 @@ class DBAPI(DbGeneric):
         If sort_handles is True, the list is sorted by Place title.
         """
         if sort_handles:
-            self.dbapi.execute("SELECT handle FROM place "
-                               "ORDER BY title COLLATE glocale")
+            self.dbapi.execute('SELECT handle FROM place '
+                               'ORDER BY title '
+                               'COLLATE "%s"' % glocale.get_collation())
         else:
             self.dbapi.execute("SELECT handle FROM place")
         rows = self.dbapi.fetchall()
@@ -525,8 +529,9 @@ class DBAPI(DbGeneric):
         If sort_handles is True, the list is sorted by title.
         """
         if sort_handles:
-            self.dbapi.execute("SELECT handle FROM media "
-                               "ORDER BY desc COLLATE glocale")
+            self.dbapi.execute('SELECT handle FROM media '
+                               'ORDER BY desc '
+                               'COLLATE "%s"' % glocale.get_collation())
         else:
             self.dbapi.execute("SELECT handle FROM media")
         rows = self.dbapi.fetchall()
@@ -549,8 +554,9 @@ class DBAPI(DbGeneric):
         If sort_handles is True, the list is sorted by Tag name.
         """
         if sort_handles:
-            self.dbapi.execute("SELECT handle FROM tag "
-                               "ORDER BY name COLLATE glocale")
+            self.dbapi.execute('SELECT handle FROM tag '
+                               'ORDER BY name '
+                               'COLLATE "%s"' % glocale.get_collation())
         else:
             self.dbapi.execute("SELECT handle FROM tag")
         rows = self.dbapi.fetchall()

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -919,6 +919,8 @@ class DBAPI(DbGeneric):
             table_name = cls.__name__.lower()
             for field, schema_type, max_length in cls.get_secondary_fields():
                 sql_type = self._sql_type(schema_type, max_length)
+                # PostgreSQL may rollback on error; commit everything now
+                self.dbapi.commit()
                 try:
                     # test to see if it exists:
                     self.dbapi.execute("SELECT %s FROM %s LIMIT 1"

--- a/gramps/plugins/db/dbapi/settings.py
+++ b/gramps/plugins/db/dbapi/settings.py
@@ -38,15 +38,15 @@ if dbtype == "sqlite":
     dbapi = Sqlite(path_to_db)
 else:
     # NOTE: you can override these settings here or in settings.ini:
-    dbname = config.get('database.dbname')
-    host = config.get('database.host')
-    user = config.get('database.user')
-    password = config.get('database.password')
-    port = config.get('database.port')
+    dbkwargs = {}
+    for key in config.get_section_settings('database'):
+        # Use all parameters except dbtype as keyword arguments
+        if key == 'dbtype':
+            continue
+        dbkwargs[key] = config.get('database.' + key)
     if dbtype == "postgresql":
         from gramps.plugins.db.dbapi.postgresql import Postgresql
-        dbapi = Postgresql(dbname=dbname, user=user,
-                           host=host, password=password)
+        dbapi = Postgresql(**dbkwargs)
     else:
         raise AttributeError(("invalid DB-API dbtype: '%s'. " +
                               "Should be 'sqlite' or 'postgresql'") % dbtype)

--- a/gramps/plugins/db/dbapi/sqlite.py
+++ b/gramps/plugins/db/dbapi/sqlite.py
@@ -83,7 +83,8 @@ class Sqlite:
         self.log = logging.getLogger(".sqlite")
         self.__connection = sqlite3.connect(*args, **kwargs)
         self.__cursor = self.__connection.cursor()
-        self.__connection.create_collation("glocale", glocale.strcoll)
+        self.__connection.create_collation(glocale.get_collation(),
+                                           glocale.strcoll)
         self.__connection.create_function("regexp", 2, regexp)
 
     def execute(self, *args, **kwargs):


### PR DESCRIPTION
1. Use all parameters from settings.ini as keyword arguments for PostgreSQL (port was missing, and other can be useful such as `sslmode='verify-full'`)
2. Fix Collation on PostgreSQL (Name each collation to prevent users form clobbering each other's collation)