### PR TITLE
Correct issue with exception on database change in Gramplets

### DIFF
--- a/gramps/gen/plug/_gramplet.py
+++ b/gramps/gen/plug/_gramplet.py
@@ -399,8 +399,7 @@ class Gramplet:
         self.update()
 
     def _no_db(self):
-        if self.dbstate.db.is_open():
-            self.disconnect_all()  # clear the old signals
+        self.disconnect_all()  # clear the old signals
 
     def get_option_widget(self, label):
         """

--- a/gramps/gen/utils/callback.py
+++ b/gramps/gen/utils/callback.py
@@ -311,8 +311,7 @@ class Callback:
             for key in keymap:
                 self.__callback_map[signal_name].remove(key)
             self.__callback_map[signal_name] = None
-        self.__callback_map = None
-        del self.__callback_map
+        self.__callback_map = {}
 
     def emit(self, signal_name, args=tuple()):
         """


### PR DESCRIPTION
Fixes #10147 and #10154
Exception was occurring on  'no-database'  and 'database-changed' signals under some conditions.
An earlier fix attempted to disconnect signals from old db during a db change to prevent multiple Gramplet updates after multiple db changes.  Problem was occurring in the disconnect when the db had already wiped out all its signals.

The fix is not very elegant, since the problem is that Gramps is not very consistent in the state at the time the signals arrive.  Sometimes when _gramplet gets the 'no-database' signal, the prior db is open, sometimes closed  The current db as can also be opened or closed.  When the prior one is closed the exception will occur.