### PR TITLE
fix invalid export (and import) of Gedcom EMAIL records

### DIFF
--- a/data/tests/exp_sample_ged.ged
+++ b/data/tests/exp_sample_ged.ged
@@ -1,12 +1,12 @@
 0 HEAD
 1 SOUR Gramps
-2 VERS 5.0.0-alpha1
+2 VERS 5.0.0-alpha2
 2 NAME Gramps
-1 DATE 29 OCT 2016
-2 TIME 15:10:31
+1 DATE 1 SEP 2017
+2 TIME 12:10:38
 1 SUBM @SUBM@
 1 FILE C:\Users\prc\AppData\Roaming\gramps\temp\exp_sample_ged.ged
-1 COPR Copyright (c) 2016 Alex Roitman,,,.
+1 COPR Copyright (c) 2017 Alex Roitman,,,.
 1 GEDC
 2 VERS 5.5.1
 2 FORM LINEAGE-LINKED
@@ -17,7 +17,7 @@
 1 ADDR Not Provided
 2 ADR1 Not Provided
 1 PHON 666-555-4444
-1 EMAIL an_email@gmail.com
+1 EMAIL an_email@@gmail.com
 0 @I0000@ INDI
 1 NAME Anna /Hansdotter/
 2 GIVN Anna
@@ -789,7 +789,7 @@
 1 OBJE
 2 FORM jpeg
 2 TITL Michael O'Toole 2015-11
-2 FILE c:\grampsaio64-4.9.9\share\gramps\tests\O0.jpg
+2 FILE c:\grampsaio64-5.0.0\share\gramps\tests\O0.jpg
 2 NOTE @N0019@
 1 NOTE @N0007@
 1 CHAN
@@ -820,7 +820,7 @@
 3 CTRY USA
 2 PHON 440-871-3400
 2 PHON 800-871-3400
-2 EMAIL thetester@gmail.com
+2 EMAIL thetester@@gmail.com
 2 FAX 440-123-4567
 2 WWW http://thetester.com
 1 EVEN A very bad day
@@ -862,7 +862,7 @@
 2 DATE 30 DEC 1954
 2 PLAC 123 Main St., Winslow, PA, 12345
 2 PHON 440-871-3401
-2 EMAIL mrstester@gmail.com
+2 EMAIL mrstester@@gmail.com
 2 FAX 440-321-4568
 2 WWW http://mrstester.com
 2 NOTE @N0011@
@@ -879,7 +879,7 @@
 3 POST 12345
 1 PHON 440-871-3401
 1 PHON 800-871-3401
-1 EMAIL mrstester@gmail.com
+1 EMAIL mrstester@@gmail.com
 1 FAX 440-321-4568
 1 WWW http://mrstester.com
 1 NOTE @N0010@
@@ -904,7 +904,7 @@
 3 STAE Colorado
 3 CTRY USA
 2 PHON 440-871-3402
-2 EMAIL tomtester@gmail.com
+2 EMAIL tomtester@@gmail.com
 2 FAX 440-321-4569
 2 WWW http://tomtester.com
 1 RESI
@@ -1316,10 +1316,10 @@
 2 ADR1 360 W 4800 N, Provo, UT 84604
 1 PHON (801) 705-7000
 1 FAX (801) 705-7001
-1 EMAIL help@ancestry.com
+1 EMAIL help@@ancestry.com
 1 WWW http://www.ancestry.com
 0 @R0001@ REPO
-1 NAME SUBM (Submitter): (@SUBM@) The Subm /Tester/
+1 NAME SUBM (Submitter): (@@SUBM@@) The Subm /Tester/
 1 ADDR 123 Main St.
 2 CONT Winslow
 2 CONT PA
@@ -1329,7 +1329,7 @@
 2 STAE PA
 2 POST 12345
 1 PHON 440-871-3401
-1 EMAIL mrstester@gmail.com
+1 EMAIL mrstester@@gmail.com
 1 FAX 440-321-4568
 1 WWW http://mrstester.com
 1 NOTE @N0009@
@@ -1362,7 +1362,7 @@
 1 ADDR 123 High St., OSF village, CA, USA
 2 ADR1 123 High St., OSF village, CA, USA
 1 PHON 988-765-4321
-1 EMAIL tester_repo@osf.com
+1 EMAIL tester_repo@@osf.com
 1 FAX 987-654-3210
 1 WWW http://www.tester_repo.com
 1 NOTE @N0012@
@@ -1401,8 +1401,8 @@
 1 CONT 
 1 CONT Only one phone number supported                                     Lin
 1 CONC e     9: 3 PHON (800) 705-7000
-0 @N0009@ NOTE Records not imported into SUBM (Submitter): (@SUBM@) The Subm /Test
-1 CONC er/:
+0 @N0009@ NOTE Records not imported into SUBM (Submitter): (@@SUBM@@) The Subm /Te
+1 CONC ster/:
 1 CONT 
 1 CONT Only one phone number supported                                     Lin
 1 CONC e    29: 1 PHON 800-871-3401

--- a/data/tests/imp_PhonFax_dfs.ged
+++ b/data/tests/imp_PhonFax_dfs.ged
@@ -44,7 +44,7 @@
 3 FORM Street, City, County, State, Country, Zip code
 2 PHON 440-871-3400
 2 PHON 800-871-3400
-2 EMAIL thetester@gmail.com
+2 EMAIL thetester@@gmail.com
 2 FAX 440-123-4567
 2 WWW http://thetester.com
 0 @I1@ INDI

--- a/gramps/plugins/export/exportgedcom.py
+++ b/gramps/plugins/export/exportgedcom.py
@@ -278,6 +278,9 @@ class GedcomWriter(UpdateCallback):
             # break the line into multiple lines if a newline is found
             textlines = textlines.replace('\n\r', '\n')
             textlines = textlines.replace('\r', '\n')
+            # Need to double '@' See Gedcom 5.5 spec 'any_char'
+            if not textlines.startswith('@'):  # avoid xrefs
+                textlines = textlines.replace('@', '@@')
             textlist = textlines.split('\n')
             token_level = level
             for text in textlist:

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -839,6 +839,8 @@ class Lexer:
                 self.__add_msg(message)
                 continue
 
+            # Need to un-double '@' See Gedcom 5.5 spec 'any_char'
+            line_value = line_value.replace('@@', '@')
             token = TOKENS.get(tag, TOKEN_UNKNOWN)
             data = (level, token, line_value, tag, self.index)
 


### PR DESCRIPTION
Gedcom spec 5.5 requires '@' in general text to be doubled '@@'
fixes #10167