### PR TITLE
Fix make_unknown to create valid Place

### DIFF
--- a/gramps/gen/utils/unknown.py
+++ b/gramps/gen/utils/unknown.py
@@ -117,6 +117,7 @@ def make_unknown(class_arg, explanation, class_func, commit_func, transaction,
             obj.set_type(EventType.UNKNOWN)
     elif isinstance(obj, Place):
         obj.set_title(_('Unknown'))
+        obj.name.set_value(_('Unknown'))
     elif isinstance(obj, Source):
         obj.set_title(_('Unknown'))
     elif isinstance(obj, Citation):


### PR DESCRIPTION
Fixes #10202
The gen.utils.unknown make_unknown function creates objects for Check and Repair or bad Gedcoms (at least) when one is referenced but doesn't exist.

When making an unknown Place, the function makes a place with a title but no name. This may not be strictly invalid, but does create issues with some other code.