### PR TITLE
sqlite import try to make a transaction within a transaction

### DIFF
--- a/gramps/plugins/db/dbapi/sqlite.py
+++ b/gramps/plugins/db/dbapi/sqlite.py
@@ -130,7 +130,7 @@ class Sqlite:
         the next COMMIT or ROLLBACK command.
         """
         self.log.debug("BEGIN TRANSACTION;")
-        self.execute("BEGIN TRANSACTION;")
+        #self.execute("BEGIN TRANSACTION;")
 
     def commit(self):
         """


### PR DESCRIPTION
An error occure when importing a gramps backup (from 4.2.6)
* disable the "BEGIN TRANSACTION" in the begin method of Sqlite class

Traceback (most recent call last):
  File "./Gramps.py", line 29, in <module>
    app.main()
  File "/home/user/develop/gramps/gramps/grampsapp.py", line 484, in main
    errors = run()
  File "/home/user/develop/gramps/gramps/grampsapp.py", line 474, in run
    startcli(error, argpars)
  File "/home/user/develop/gramps/gramps/cli/grampscli.py", line 381, in startcli
    handler.handle_args_cli()
  File "/home/user/develop/gramps/gramps/cli/arghandler.py", line 451, in handle_args_cli
    self.__import_action()
  File "/home/user/develop/gramps/gramps/cli/arghandler.py", line 521, in __import_action
    self.cl_import(imp[0], imp[1])
  File "/home/user/develop/gramps/gramps/cli/arghandler.py", line 572, in cl_import
    import_function(self.dbstate.db, filename, self.user)
  File "/home/user/develop/gramps/gramps/plugins/importer/importxml.py", line 149, in importData
    info = parser.parse(xml_file, line_cnt, person_cnt)
  File "/home/user/develop/gramps/gramps/plugins/importer/importxml.py", line 940, in parse
    self.db.set_default_person_handle(person.handle)
  File "/home/user/develop/gramps/gramps/gen/db/generic.py", line 2326, in set_default_person_handle
    self._set_metadata("default-person-handle", handle)
  File "/home/user/develop/gramps/gramps/plugins/db/dbapi/dbapi.py", line 371, in _set_metadata
    self._txn_begin()
  File "/home/user/develop/gramps/gramps/plugins/db/dbapi/dbapi.py", line 265, in _txn_begin
    self.dbapi.begin()
  File "/home/user/develop/gramps/gramps/plugins/db/dbapi/sqlite.py", line 133, in begin
    self.execute("BEGIN TRANSACTION;")
  File "/home/user/develop/gramps/gramps/plugins/db/dbapi/sqlite.py", line 111, in execute
    self.__cursor.execute(*args, **kwargs)
sqlite3.OperationalError: cannot start a transaction within a transaction