### PR TITLE
Fix Gedcom import for "1 MARR Y" issue

### DIFF
--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -5018,6 +5018,8 @@ class GedcomParser(UpdateCallback):
                 event.set_description('')
             else:
                 state.family.type.set(FamilyRelType.MARRIED)
+            if descr == "Y":
+                event.set_description('')
 
         self.dbase.commit_event(event, self.trans)
         event_ref.ref = event.handle


### PR DESCRIPTION
Fixes #10188

In Gedcom the MARR line must contain a 'Y' (if there are no subordinate levels) or nothing.
But if Gramps finds text in this field it puts it into the marriage event description field.  I guess this covers some not quite legal Gedcom files.  Originally Gramps also copied the 'Y' to description.

On export, Gramps puts description values in the MARR.TYPE field, if present; also allowed.
Gramps also correctly outputs the MARR 'Y' for no subordinate levels.

But in the case of the MARR 'Y', Gramps was outputting a subordinate level (TYPE 'Y').  So the import to export was not transparent.

There is no need for a 'Y' in our description field, so I removed it.  The import to export via Gedcom for this MARR record is  now transparent.