### PR TITLE
Fix ManagedWindow/GrampsWindowManager for subsidiary window close

### DIFF
--- a/gramps/gui/managedwindow.py
+++ b/gramps/gui/managedwindow.py
@@ -196,10 +196,14 @@ class GrampsWindowManager:
 
     def close_item(self, item, *args):
         # Given an item, close its window and remove it's ID from the dict
+        if item.opened:
+            item.close()
         if item.window_id:
             del self.id2item[item.window_id]
+            item.window_id = None
         if item.get_window():
             item.get_window().destroy()
+            item.window = None
 
     def remove_item(self, track):
         # We need the whole gymnastics below because our item
@@ -560,11 +564,11 @@ class ManagedWindow:
 
         Takes care of closing children and removing itself from menu.
         """
-        self._save_position(save_config=False) # the next line will save it
+        self.opened = False
+        self._save_position(save_config=False)  # the next line will save it
         self._save_size()
         self.clean_up()
         self.uistate.gwm.close_track(self.track)
-        self.opened = False
         # put a previously modal window back to modal, now that we are closing
         if self.other_modal_window:
             self.other_modal_window.set_modal(True)


### PR DESCRIPTION
fixes #10194
The 10194 bug has Check&Repair being run with a bunch of Gramps editor windows open, particularly opened each from the previous.
What is happening is that the Check&Repair eventually gets to do *-rebuild signals from the db.  These in turn tell the various open editor windows to close.

Issues occur when the editor windows attempt to close in a different order than they were opened.  In this case the GrampsWindowManager is designed to close subsidiary windows first, on its own.  But the code to do so was very simple and did not actually 'close' the entire editor object, but rather just destroyed the Gtk Window and part of the GrampsWindowManager state.

A bit later during the rebuild, another signal arrives to the (partially closed) editor which then attempts to really close the Gtk window.  This created an error in the GrampsWindowManager which appears on the console ("Missing item from window manager").  A further issue is that the ManagedWindow code attempts to 'present' (make visible) the parent window during the close operation.  Since in several cases the parent window had already been (partially) closed (actually destroyed), the 'present' creates a long list of Gtk-CRITICAL errors and then puts back up an empty window for the user to see.

Note that the improper closing of subsidiary Windows (which can be done by the GUI) also creates Memory leaks as the objects are still present in memory, and since the Window Manager has destroyed is record of them, opening them again creates new copies.  A 'rebuild' signal occurring anytime after that will cause issues.

This patch for the GrampsWindowManager and ManagedWindow code makes the automatic closing of subsidiary windows actually run the object 'close' routine.  It seems to work OK in all the windows I've tested, but there are a LOT of dialogs and windows in all the Gramps code.  So this will require watching to see if it works properly with everything.