### PR TITLE
Fix 'Welcome' Gramplet and StyledTextEditor for Link handling

### DIFF
--- a/gramps/gui/widgets/styledtexteditor.py
+++ b/gramps/gui/widgets/styledtexteditor.py
@@ -50,6 +50,7 @@ from gi.repository import Pango
 #
 #-------------------------------------------------------------------------
 from gramps.gen.lib import StyledTextTagType
+from gramps.gen.constfunc import mac
 from .styledtextbuffer import (ALLOWED_STYLES,
                                           MATCH_START, MATCH_END,
                                           MATCH_FLAVOR, MATCH_STRING,
@@ -319,8 +320,9 @@ class StyledTextEditor(Gtk.TextView):
             if url.startswith("gramps://"):
                 obj_class, prop, value = url[9:].split("/")
                 display = simple_access.display(obj_class, prop, value) or url
-        return display + \
-            ("\nCtrl-Click to follow link" if self.get_editable() else '')
+        return display + ((_("\nCommand-Click to follow link") if mac() else
+                           _("\nCtrl-Click to follow link"))
+                          if self.get_editable() else '')
 
     def on_button_release_event(self, widget, event):
         """

--- a/gramps/gui/widgets/styledtexteditor.py
+++ b/gramps/gui/widgets/styledtexteditor.py
@@ -319,7 +319,8 @@ class StyledTextEditor(Gtk.TextView):
             if url.startswith("gramps://"):
                 obj_class, prop, value = url[9:].split("/")
                 display = simple_access.display(obj_class, prop, value) or url
-        return display
+        return display + \
+            ("\nCtrl-Click to follow link" if self.get_editable() else '')
 
     def on_button_release_event(self, widget, event):
         """
@@ -343,9 +344,9 @@ class StyledTextEditor(Gtk.TextView):
         """
         self.selclick=False
         if ((event.type == Gdk.EventType.BUTTON_PRESS) and
-            (event.button == 1) and
-            (event.get_state() and get_primary_mask()) and
-            (self.url_match)):
+            (event.button == 1) and (self.url_match) and
+            (event.get_state() & get_primary_mask()) or
+             not self.get_editable())):
 
             flavor = self.url_match[MATCH_FLAVOR]
             url = self.url_match[MATCH_STRING]


### PR DESCRIPTION
Issue [#10179](https://gramps-project.org/bugs/view.php?id=10179)

This fixes the StyledTextEditor so that it actually responds only to ctrl-click on a Link to open it.  Before, it would also respond to shift-click, caps-lock-click etc.

To resolve part of #10179 "Welcome Gramplet doesn't respond to links", the styled text editor was also changed to respond to a left-click on a link immediately, if the editor was not editable.

I also added to the tool-tip for the link, when it was editable "Ctrl-Click to follow link" as that is not the usual way to open links.  This is similar to Microsoft Office apps or LibreOffice Writer.

Note, there is a pending discussion on MAC usage of the CONTROL key for this and lots of other places in Gramps; this PR does not address this as I think it should be a separate commit.