### PR TITLE
Fix exception when changing a family with Add person editor open

### DIFF
--- a/gramps/gui/editors/editperson.py
+++ b/gramps/gui/editors/editperson.py
@@ -300,7 +300,7 @@ class EditPerson(EditPrimary):
 
     def _update_families(self):
         phandle = self.obj.get_handle()
-        if phandle:
+        if self.dbstate.db.has_person_handle(phandle):
             #new person has no handle yet and cannot be in a family.
             person = self.dbstate.db.get_person_from_handle(phandle)
             self.obj.set_family_handle_list(person.get_family_handle_list())


### PR DESCRIPTION
fixes #10187

To create the bug, Add a new person, but don't finish up with the person editor, leave it open.  Move editor out of way if necessary, go to family view and edit a family.  Make any change (add a note, for example) and click OK.

The editperson has registered for a callback on the 'family-change' signal, where it updates its view of the person in case anything has changed.  It tries to read the person object again to find out what might have changed underneath.  However, since the person was never committed, it is not in the db, and self.dbstate.db.get_person_from_handle(phandle) fails.

It turns out that the person being edited was assigned a handle on an Add, so testing for that is not useful.  So tested for presence in the db instead.
If the person is indeed being added (as opposed to edit), there is no need to update the family handles, they cannot have been set yet.