### PR TITLE
Replace use of CONTROL_MASK with PRIMARY_INTENT.

### DIFF
--- a/gramps/gui/clipboard.py
+++ b/gramps/gui/clipboard.py
@@ -60,7 +60,7 @@ from gramps.gen.constfunc import mac
 from .glade import Glade
 from .ddtargets import DdTargets
 from .makefilter import make_filter
-from .utils import is_right_click
+from .utils import is_right_click, get_primary_mask
 
 #-------------------------------------------------------------------------
 #
@@ -1598,7 +1598,7 @@ class MultiTreeView(Gtk.TreeView):
         # otherwise:
         if (target
             and event.type == Gdk.EventType.BUTTON_PRESS
-            and not (event.get_state() & (Gdk.ModifierType.CONTROL_MASK|Gdk.ModifierType.SHIFT_MASK))
+            and not (event.get_state() & get_primary_mask(Gdk.ModifierType.SHIFT_MASK))
             and self.get_selection().path_is_selected(target[0])):
             # disable selection
             self.get_selection().set_select_function(lambda *ignore: False, None)

--- a/gramps/gui/editors/displaytabs/buttontab.py
+++ b/gramps/gui/editors/displaytabs/buttontab.py
@@ -43,6 +43,7 @@ _ = glocale.translation.gettext
 from ...widgets import SimpleButton
 from .grampstab import GrampsTab
 from gramps.gen.errors import WindowActiveError
+from ...utils import get_primary_mask
 
 _KP_ENTER = Gdk.keyval_from_name("KP_Enter")
 _RETURN = Gdk.keyval_from_name("Return")
@@ -219,7 +220,7 @@ class ButtonTab(GrampsTab):
                     return
                 self.add_button_clicked(obj)
             elif event.keyval in (_OPEN,) and self.share_btn and \
-                    (event.get_state() & Gdk.ModifierType.CONTROL_MASK):
+                    (event.get_state() & get_primary_mask()):
                 self.share_button_clicked(obj)
             elif event.keyval in (_LEFT,) and \
                     (event.get_state() & Gdk.ModifierType.MOD1_MASK):

--- a/gramps/gui/editors/displaytabs/surnametab.py
+++ b/gramps/gui/editors/displaytabs/surnametab.py
@@ -48,6 +48,7 @@ from .surnamemodel import SurnameModel
 from .embeddedlist import EmbeddedList, TEXT_COL, MARKUP_COL, ICON_COL
 from ...ddtargets import DdTargets
 from gramps.gen.lib import Surname, NameOriginType
+from ...utils import get_primary_mask
 
 #-------------------------------------------------------------------------
 #
@@ -322,11 +323,11 @@ class SurnameTab(EmbeddedList):
         """
         if not EmbeddedList.key_pressed(self, obj, event):
             if event.type == Gdk.EventType.KEY_PRESS and event.keyval in (_TAB,):
-                if not (event.get_state() & (Gdk.ModifierType.SHIFT_MASK |
-                                       Gdk.ModifierType.CONTROL_MASK)):
+                if not (event.get_state() &
+                        get_primary_mask(Gdk.ModifierType.SHIFT_MASK)):
                     return self.next_cell()
-                elif (event.get_state() & (Gdk.ModifierType.SHIFT_MASK |
-                                     Gdk.ModifierType.CONTROL_MASK)):
+                elif (event.get_state() &
+                      get_primary_mask(Gdk.ModifierType.SHIFT_MASK)):
                     return self.prev_cell()
                 else:
                     return

--- a/gramps/gui/filters/_searchbar.py
+++ b/gramps/gui/filters/_searchbar.py
@@ -32,7 +32,7 @@ from gi.repository import Gdk
 from gi.repository import Gtk
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
-
+from ..utils import get_primary_mask
 _RETURN = Gdk.keyval_from_name("Return")
 _KP_ENTER = Gdk.keyval_from_name("KP_Enter")
 
@@ -139,7 +139,7 @@ class SearchBar:
             self.clear_button.set_sensitive(True)
 
     def key_press(self, obj, event):
-        if not (event.get_state() & Gdk.ModifierType.CONTROL_MASK):
+        if not (event.get_state() & get_primary_mask()):
             if event.keyval in (_RETURN, _KP_ENTER):
                 self.filter_button.set_sensitive(False)
                 self.clear_button.set_sensitive(True)

--- a/gramps/gui/filters/sidebar/_sidebarfilter.py
+++ b/gramps/gui/filters/sidebar/_sidebarfilter.py
@@ -29,6 +29,7 @@ from gi.repository import Pango
 from ... import widgets
 from ...dbguielement import DbGUIElement
 from gramps.gen.config import config
+from ...utils import get_primary_mask
 
 _RETURN = Gdk.keyval_from_name("Return")
 _KP_ENTER = Gdk.keyval_from_name("KP_Enter")
@@ -129,7 +130,7 @@ class SidebarFilter(DbGUIElement):
             widget.set_tooltip_text(tooltip)
 
     def key_press(self, obj, event):
-        if not (event.get_state() & Gdk.ModifierType.CONTROL_MASK):
+        if not (event.get_state() & get_primary_mask()):
             if event.keyval in (_RETURN, _KP_ENTER):
                 self.clicked(obj)
         return False

--- a/gramps/gui/glade/book.glade
+++ b/gramps/gui/glade/book.glade
@@ -118,7 +118,7 @@
                                 <property name="icon_name">document-save</property>
                               </object>
                             </child>
-                            <accelerator key="r" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                            <accelerator key="r" signal="activate" modifiers="primary"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -163,7 +163,7 @@
                                 <property name="icon_name">gtk-index</property>
                               </object>
                             </child>
-                            <accelerator key="s" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                            <accelerator key="s" signal="activate" modifiers="primary"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -333,7 +333,7 @@
                             <property name="icon_name">list-add</property>
                           </object>
                         </child>
-                        <accelerator key="a" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <accelerator key="a" signal="activate" modifiers="primary"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/gramps/gui/glade/editaddress.glade
+++ b/gramps/gui/glade/editaddress.glade
@@ -297,7 +297,7 @@ Note: Use Residence Event for genealogical address data.</property>
                         <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                       </object>
                     </child>
-                    <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="p" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">5</property>
@@ -332,7 +332,7 @@ Note: Use Residence Event for genealogical address data.</property>
                         <property name="AtkObject::accessible-name" translatable="yes">Date</property>
                       </object>
                     </child>
-                    <accelerator key="d" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="d" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">5</property>

--- a/gramps/gui/glade/editattribute.glade
+++ b/gramps/gui/glade/editattribute.glade
@@ -153,7 +153,7 @@
                         <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                       </object>
                     </child>
-                    <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="p" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">2</property>

--- a/gramps/gui/glade/editchildref.glade
+++ b/gramps/gui/glade/editchildref.glade
@@ -180,7 +180,7 @@
                         <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                       </object>
                     </child>
-                    <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="p" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">2</property>
@@ -250,7 +250,7 @@
                         <property name="AtkObject::accessible-name" translatable="yes">Child</property>
                       </object>
                     </child>
-                    <accelerator key="e" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="e" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">2</property>

--- a/gramps/gui/glade/editcitation.glade
+++ b/gramps/gui/glade/editcitation.glade
@@ -122,7 +122,7 @@
                     <property name="AtkObject::accessible-name" translatable="yes">Date</property>
                   </object>
                 </child>
-                <accelerator key="d" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                <accelerator key="d" signal="activate" modifiers="primary"/>
               </object>
               <packing>
                 <property name="left_attach">2</property>
@@ -345,7 +345,7 @@ Very High =Direct and primary evidence used, or by dominance of the evidence </p
                     <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                   </object>
                 </child>
-                <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                <accelerator key="p" signal="activate" modifiers="primary"/>
               </object>
               <packing>
                 <property name="left_attach">2</property>

--- a/gramps/gui/glade/editevent.glade
+++ b/gramps/gui/glade/editevent.glade
@@ -148,7 +148,7 @@
                         <property name="AtkObject::accessible-name" translatable="yes">Date</property>
                       </object>
                     </child>
-                    <accelerator key="d" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="d" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">4</property>
@@ -213,7 +213,7 @@
                         <property name="can_focus">False</property>
                       </object>
                     </child>
-                    <accelerator key="a" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="a" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">4</property>
@@ -270,7 +270,7 @@
                             <property name="AtkObject::accessible-name" translatable="yes">Place</property>
                           </object>
                         </child>
-                        <accelerator key="s" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <accelerator key="s" signal="activate" modifiers="primary"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -355,7 +355,7 @@
                         <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                       </object>
                     </child>
-                    <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="p" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">4</property>

--- a/gramps/gui/glade/editeventref.glade
+++ b/gramps/gui/glade/editeventref.glade
@@ -149,7 +149,7 @@
                         <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                       </object>
                     </child>
-                    <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="p" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">2</property>
@@ -388,7 +388,7 @@
                             <property name="AtkObject::accessible-name" translatable="yes">Date</property>
                           </object>
                         </child>
-                        <accelerator key="d" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <accelerator key="d" signal="activate" modifiers="primary"/>
                       </object>
                       <packing>
                         <property name="left_attach">2</property>

--- a/gramps/gui/glade/editfamily.glade
+++ b/gramps/gui/glade/editfamily.glade
@@ -286,7 +286,7 @@
                                         <property name="AtkObject::accessible-name" translatable="yes">Edit</property>
                                       </object>
                                     </child>
-                                    <accelerator key="f" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                                    <accelerator key="f" signal="activate" modifiers="primary"/>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -530,7 +530,7 @@
                                         </child>
                                       </object>
                                     </child>
-                                    <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                                    <accelerator key="p" signal="activate" modifiers="primary"/>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -594,7 +594,7 @@
                                         <property name="AtkObject::accessible-name" translatable="yes">Edit</property>
                                       </object>
                                     </child>
-                                    <accelerator key="m" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                                    <accelerator key="m" signal="activate" modifiers="primary"/>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>

--- a/gramps/gui/glade/editldsord.glade
+++ b/gramps/gui/glade/editldsord.glade
@@ -165,7 +165,7 @@
                         <property name="AtkObject::accessible-name" translatable="yes">Date</property>
                       </object>
                     </child>
-                    <accelerator key="d" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="d" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">2</property>
@@ -267,7 +267,7 @@
                         <property name="AtkObject::accessible-name" translatable="yes">Family</property>
                       </object>
                     </child>
-                    <accelerator key="s" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="s" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">2</property>
@@ -381,7 +381,7 @@
                         <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                       </object>
                     </child>
-                    <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="p" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">2</property>

--- a/gramps/gui/glade/editlink.glade
+++ b/gramps/gui/glade/editlink.glade
@@ -171,7 +171,7 @@
                         <property name="AtkObject::accessible-name" translatable="yes">Link</property>
                       </object>
                     </child>
-                    <accelerator key="s" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="s" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">2</property>

--- a/gramps/gui/glade/editmedia.glade
+++ b/gramps/gui/glade/editmedia.glade
@@ -254,7 +254,7 @@ Gramps does not store the media internally, it only stores the path! Set the 'Re
                         <property name="AtkObject::accessible-name" translatable="yes">Date</property>
                       </object>
                     </child>
-                    <accelerator key="d" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="d" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">3</property>
@@ -332,7 +332,7 @@ Gramps does not store the media internally, it only stores the path! Set the 'Re
                         <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                       </object>
                     </child>
-                    <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="p" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">3</property>

--- a/gramps/gui/glade/editmediaref.glade
+++ b/gramps/gui/glade/editmediaref.glade
@@ -301,7 +301,7 @@ You can use the mouse on the picture to select a region, or use these spinbutton
                                 <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                               </object>
                             </child>
-                            <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                            <accelerator key="p" signal="activate" modifiers="primary"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -592,7 +592,7 @@ You can use the mouse on the picture to select a region, or use these spinbutton
                                 <property name="AtkObject::accessible-name" translatable="yes">Date</property>
                               </object>
                             </child>
-                            <accelerator key="d" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                            <accelerator key="d" signal="activate" modifiers="primary"/>
                           </object>
                           <packing>
                             <property name="left_attach">3</property>

--- a/gramps/gui/glade/editname.glade
+++ b/gramps/gui/glade/editname.glade
@@ -155,7 +155,7 @@
                             <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                           </object>
                         </child>
-                        <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <accelerator key="p" signal="activate" modifiers="primary"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -581,7 +581,7 @@ Here you can make sure this person is sorted according to a custom name format (
                             <property name="AtkObject::accessible-name" translatable="yes">Date</property>
                           </object>
                         </child>
-                        <accelerator key="d" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <accelerator key="d" signal="activate" modifiers="primary"/>
                       </object>
                       <packing>
                         <property name="left_attach">2</property>

--- a/gramps/gui/glade/editnote.glade
+++ b/gramps/gui/glade/editnote.glade
@@ -233,7 +233,7 @@ Use monospace font to keep preformatting.</property>
                             <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                           </object>
                         </child>
-                        <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <accelerator key="p" signal="activate" modifiers="primary"/>
                       </object>
                       <packing>
                         <property name="left_attach">4</property>

--- a/gramps/gui/glade/editperson.glade
+++ b/gramps/gui/glade/editperson.glade
@@ -361,7 +361,7 @@ Indicate that the surname consists of different parts. Every surname has its own
                             <property name="AtkObject::accessible-name" translatable="yes">Add</property>
                           </object>
                         </child>
-                        <accelerator key="a" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <accelerator key="a" signal="activate" modifiers="primary"/>
                       </object>
                       <packing>
                         <property name="left_attach">8</property>
@@ -417,7 +417,7 @@ Indicate that the surname consists of different parts. Every surname has its own
                                 <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                               </object>
                             </child>
-                            <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                            <accelerator key="p" signal="activate" modifiers="primary"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -516,7 +516,7 @@ Indicate that the surname consists of different parts. Every surname has its own
                             <property name="AtkObject::accessible-name" translatable="yes">Edit</property>
                           </object>
                         </child>
-                        <accelerator key="e" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <accelerator key="e" signal="activate" modifiers="primary"/>
                       </object>
                       <packing>
                         <property name="left_attach">8</property>

--- a/gramps/gui/glade/editpersonref.glade
+++ b/gramps/gui/glade/editpersonref.glade
@@ -158,7 +158,7 @@ Note: Use Events instead for relations connected to specific time frames or occa
                         <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                       </object>
                     </child>
-                    <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="p" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">2</property>
@@ -211,7 +211,7 @@ Note: Use Events instead for relations connected to specific time frames or occa
                         <property name="AtkObject::accessible-name" translatable="yes">Person</property>
                       </object>
                     </child>
-                    <accelerator key="s" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="s" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">2</property>

--- a/gramps/gui/glade/editplace.glade
+++ b/gramps/gui/glade/editplace.glade
@@ -328,7 +328,7 @@ You can set these values via the Geography View by searching the place, or via a
                         <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                       </object>
                     </child>
-                    <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="p" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">4</property>

--- a/gramps/gui/glade/editplacename.glade
+++ b/gramps/gui/glade/editplacename.glade
@@ -142,7 +142,7 @@
                         <property name="AtkObject::accessible-name" translatable="yes">Date</property>
                       </object>
                     </child>
-                    <accelerator key="d" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="d" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">2</property>

--- a/gramps/gui/glade/editplaceref.glade
+++ b/gramps/gui/glade/editplaceref.glade
@@ -431,7 +431,7 @@
                             <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                           </object>
                         </child>
-                        <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <accelerator key="p" signal="activate" modifiers="primary"/>
                       </object>
                       <packing>
                         <property name="left_attach">4</property>

--- a/gramps/gui/glade/editreporef.glade
+++ b/gramps/gui/glade/editreporef.glade
@@ -195,7 +195,7 @@
                             <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                           </object>
                         </child>
-                        <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <accelerator key="p" signal="activate" modifiers="primary"/>
                       </object>
                       <packing>
                         <property name="left_attach">2</property>

--- a/gramps/gui/glade/editrepository.glade
+++ b/gramps/gui/glade/editrepository.glade
@@ -212,7 +212,7 @@
                             <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                           </object>
                         </child>
-                        <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <accelerator key="p" signal="activate" modifiers="primary"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/gramps/gui/glade/editsource.glade
+++ b/gramps/gui/glade/editsource.glade
@@ -295,7 +295,7 @@
                         <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                       </object>
                     </child>
-                    <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="p" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">2</property>

--- a/gramps/gui/glade/editurl.glade
+++ b/gramps/gui/glade/editurl.glade
@@ -156,7 +156,7 @@
                         <property name="AtkObject::accessible-name" translatable="yes">Private</property>
                       </object>
                     </child>
-                    <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                    <accelerator key="p" signal="activate" modifiers="primary"/>
                   </object>
                   <packing>
                     <property name="left_attach">2</property>

--- a/gramps/gui/utils.py
+++ b/gramps/gui/utils.py
@@ -44,6 +44,7 @@ import gi
 gi.require_version('PangoCairo', '1.0')
 from gi.repository import PangoCairo
 from gi.repository import GLib
+from gi.repository import Gdk
 
 #-------------------------------------------------------------------------
 #
@@ -472,6 +473,9 @@ def is_right_click(event):
 
     if event.type == Gdk.EventType.BUTTON_PRESS:
         if is_quartz():
+            # Catch quartz emulation of right-click for single-button
+            # mouse.  Note that in this case we want CONTROL_MASK not
+            # PRIMARY_ACCELERATOR!
             if (event.button == 3
                 or (event.button == 1 and event.get_state() & Gdk.ModifierType.CONTROL_MASK)):
                 return True
@@ -685,3 +689,12 @@ def text_to_clipboard(text):
     clipboard = Gtk.Clipboard.get_for_display(Gdk.Display.get_default(),
                                               Gdk.SELECTION_CLIPBOARD)
     clipboard.set_text(text, -1)
+
+def get_primary_mask(addl_mask=0):
+    """
+    Obtain the IntentPrimary mask for the platform bitwise-ored with a
+    passed-in additional mask.
+    """
+    keymap = Gdk.Keymap.get_default()
+    primary = keymap.get_modifier_mask(Gdk.ModifierIntent.PRIMARY_ACCELERATOR)
+    return primary | addl_mask

--- a/gramps/gui/utils.py
+++ b/gramps/gui/utils.py
@@ -467,21 +467,11 @@ def process_pending_events(max_count=10):
 
 def is_right_click(event):
     """
-    Returns True if the event is a button-3 or equivalent
+    Returns True if the event is to open the context menu.
     """
     from gi.repository import Gdk
-
-    if event.type == Gdk.EventType.BUTTON_PRESS:
-        if is_quartz():
-            # Catch quartz emulation of right-click for single-button
-            # mouse.  Note that in this case we want CONTROL_MASK not
-            # PRIMARY_ACCELERATOR!
-            if (event.button == 3
-                or (event.button == 1 and event.get_state() & Gdk.ModifierType.CONTROL_MASK)):
-                return True
-
-        if event.button == 3:
-            return True
+    if Gdk.Event.triggers_context_menu(event):
+        return True
 
 def color_graph_box(alive=False, gender=Person.MALE):
     """

--- a/gramps/gui/views/navigationview.py
+++ b/gramps/gui/views/navigationview.py
@@ -52,6 +52,7 @@ from .pageview import PageView
 from ..actiongroup import ActionGroup
 from gramps.gen.utils.db import navigation_label
 from gramps.gen.constfunc import mod_key
+from ..utils import get_primary_mask
 
 DISABLED = -1
 MRU_SIZE = 10
@@ -480,7 +481,7 @@ class NavigationView(PageView):
         if self.active:
             if event.type == Gdk.EventType.KEY_PRESS:
                 if (event.keyval == Gdk.KEY_c and
-                    (event.get_state() & Gdk.ModifierType.CONTROL_MASK)):
+                    (event.get_state() & get_primary_mask())):
                     self.call_copy()
                     return True
         return super(NavigationView, self).key_press_handler(widget, event)

--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -48,7 +48,7 @@ from gramps.gen.errors import WindowActiveError
 from gramps.gen.const import URL_MANUAL_PAGE, VERSION_DIR, COLON
 from ..editors import EditPerson, EditFamily
 from ..managedwindow import ManagedWindow
-from ..utils import is_right_click, rgb_to_hex
+from ..utils import is_right_click, rgb_to_hex, get_primary_mask
 from .menuitem import add_menuitem
 from ..plug import make_gui_option
 from ..plug.quick import run_quick_report_by_name
@@ -405,12 +405,12 @@ class GuiGramplet:
 
         """
         if ((Gdk.keyval_name(event.keyval) == 'Z') and
-            (event.get_state() & Gdk.ModifierType.CONTROL_MASK) and
-            (event.get_state() & Gdk.ModifierType.SHIFT_MASK)):
+            (event.get_state() &
+             get_primary_mask(Gdk.ModifierType.SHIFT_MASK))):
             self.redo()
             return True
         elif ((Gdk.keyval_name(event.keyval) == 'z') and
-              (event.get_state() & Gdk.ModifierType.CONTROL_MASK)):
+              (event.get_state() & get_primary_mask())):
             self.undo()
             return True
 

--- a/gramps/gui/widgets/interactivesearchbox.py
+++ b/gramps/gui/widgets/interactivesearchbox.py
@@ -40,6 +40,12 @@ from gi.repository import Gtk, Gdk, GLib
 
 #-------------------------------------------------------------------------
 #
+# Gramps modules
+#
+#-------------------------------------------------------------------------
+from ..utils import get_primary_mask
+#-------------------------------------------------------------------------
+#
 # InteractiveSearchBox class
 #
 #-------------------------------------------------------------------------
@@ -100,10 +106,7 @@ class InteractiveSearchBox:
         self._search_entry.disconnect(popup_menu_id)
 
         # Intercept CTRL+F keybinding because Gtk do not allow to _replace_ it.
-        default_accel = obj.get_modifier_mask(
-            Gdk.ModifierIntent.PRIMARY_ACCELERATOR)
-        if ((event.state & (default_accel | Gdk.ModifierType.CONTROL_MASK))
-                == (default_accel | Gdk.ModifierType.CONTROL_MASK)
+        if ((event.state & get_primary_mask())
                 and event.keyval in [Gdk.KEY_f, Gdk.KEY_F]):
             self.__imcontext_changed = True
             # self.real_start_interactive_search(event.get_device(), True)

--- a/gramps/gui/widgets/multitreeview.py
+++ b/gramps/gui/widgets/multitreeview.py
@@ -24,6 +24,7 @@ An override to allow easy multiselections.
 
 from gi.repository import Gdk
 from gi.repository import Gtk
+from ..utils import get_primary_mask
 
 #-------------------------------------------------------------------------
 #
@@ -65,7 +66,8 @@ class MultiTreeView(Gtk.TreeView):
         target = self.get_path_at_pos(int(event.x), int(event.y))
         if (target
             and event.type == Gdk.EventType.BUTTON_PRESS
-            and not (event.get_state() & (Gdk.ModifierType.CONTROL_MASK|Gdk.ModifierType.SHIFT_MASK))
+            and not (event.get_state() &
+                     get_primary_mask(Gdk.ModifierType.SHIFT_MASK))
             and self.get_selection().path_is_selected(target[0])):
             # disable selection
             self.get_selection().set_select_function(lambda *ignore: False, None)

--- a/gramps/gui/widgets/styledtexteditor.py
+++ b/gramps/gui/widgets/styledtexteditor.py
@@ -60,7 +60,7 @@ from .toolcomboentry import ToolComboEntry
 from .springseparator import SpringSeparatorAction
 from ..spell import Spell
 from ..display import display_url
-from ..utils import SystemFonts, rgb_to_hex
+from ..utils import SystemFonts, rgb_to_hex, get_primary_mask
 from gramps.gen.config import config
 from gramps.gen.constfunc import has_display
 from ..actiongroup import ActionGroup
@@ -247,12 +247,12 @@ class StyledTextEditor(Gtk.TextView):
 
         """
         if ((Gdk.keyval_name(event.keyval) == 'Z') and
-            (event.get_state() & Gdk.ModifierType.CONTROL_MASK) and
-            (event.get_state() & Gdk.ModifierType.SHIFT_MASK)):
+            (event.get_state() &
+             get_primary_mask(Gdk.ModifierType.SHIFT_MASK))):
             self.redo()
             return True
         elif ((Gdk.keyval_name(event.keyval) == 'z') and
-              (event.get_state() & Gdk.ModifierType.CONTROL_MASK)):
+              (event.get_state() & get_primary_mask())):
             self.undo()
             return True
         else:
@@ -344,7 +344,7 @@ class StyledTextEditor(Gtk.TextView):
         self.selclick=False
         if ((event.type == Gdk.EventType.BUTTON_PRESS) and
             (event.button == 1) and
-            (event.get_state() and Gdk.ModifierType.CONTROL_MASK) and
+            (event.get_state() and get_primary_mask()) and
             (self.url_match)):
 
             flavor = self.url_match[MATCH_FLAVOR]

--- a/gramps/plugins/lib/maps/osmgps.py
+++ b/gramps/plugins/lib/maps/osmgps.py
@@ -504,7 +504,7 @@ class OsmGps:
         elif event.button == 2 and event.type == Gdk.EventType.BUTTON_RELEASE:
             self.end_selection = current
             self.zone_selection = False
-        elif event.button == 3 and event.type == Gdk.EventType.BUTTON_PRESS:
+        elif Gdk.Event.triggers_context_menu():
             self.build_nav_menu(osm, event, lat, lon)
         else:
             self.save_center(lat, lon)


### PR DESCRIPTION
For better UX on Macs. Mac users expect to use the "command" modifier key pretty much everywhere that users of other systems use the "control" key. Gtk provides for this preference with the  Gdk.ModifierIntent.PRIMARY_ACCELERATOR, which should always be used instead of GDK_CONTROL_MASK. Gtk.Widget uses a private GtkBuilder function to implement the alias "primary" in Builder XML (a.k.a. glade) files.