### PR TITLE
Not a pull request - Comment only about hardcoded bsddb not my defaul…

### DIFF
--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -665,7 +665,7 @@ class DbManager(CLIDbManager, ManagedWindow):
 
         self.__start_cursor(_("Extracting archive..."))
 
-        dbase = make_database("bsddb")
+        dbase = make_database("bsddb")  # < Unexpected behavior when I've selected SQLite as my default, then archive my family tree 
         dbase.load(new_path)
 
         self.__start_cursor(_("Importing archive..."))


### PR DESCRIPTION
…t database format

Hello, could not find a way to raise an issue here on github, hence the pull reqest 

Unexpected behavior when I've selected SQLite as my default. 
 * Create a new family tree
 * Use the gui manager to "archive" my family tree
 * select the archived tree from the gui and the button changes to "Extract" so press that
 * In the "Database type" column "BSDDB" is listed instead of my default of sqlite


Keep up the great work.

Tested on Arch Linux