### PR TITLE
Fix interactive search for exception on click then down arrow

### DIFF
--- a/gramps/gui/widgets/interactivesearchbox.py
+++ b/gramps/gui/widgets/interactivesearchbox.py
@@ -402,7 +402,7 @@ class InteractiveSearchBox:
             self._search_window.hide()
             self._search_entry.set_text("")
             self._treeview.emit('focus-in-event', event)
-        self.__selected_search_result = None
+        self.__selected_search_result = 0
 
     def _position_func(self, userdata=None):
         tree_window = self._treeview.get_window()


### PR DESCRIPTION
Fixes #10226

> In the "People" view, user was trying to locate a person by typing. He got the surname typed in, it went to the surname and expanded it.
> 
> He pressed the down cursor button a few times - which didn't move the selected person down, so he clicked on the fourth person down in the expanded surname list.
> 

This is a timing issue combined with a minor bug.  I was able to reproduce it several times.  After the fix I was unable to reproduce this at all.

The __selected_search_result should never have been set to None; it is always used as an int.  But until the timing issue was triggered, no one noticed, because it got reset to a valid int.
