### PR TITLE
Fix Geography view 'Find' when db is closed.

### DIFF
--- a/gramps/plugins/view/geoclose.py
+++ b/gramps/plugins/view/geoclose.py
@@ -323,10 +323,12 @@ class GeoClose(GeoGraphyView):
         all handling of visibility is now in rebuild_trees, see that for more
         information.
         """
+        self.lifeway_layer.clear_ways()
+        if not self.dbstate.is_open():
+            return
         active = self.get_active()
         if active:
             person = self.dbstate.db.get_person_from_handle(active)
-            self.lifeway_layer.clear_ways()
             if person is None:
                 self.goto_handle(None)
             else:

--- a/gramps/plugins/view/geoevents.py
+++ b/gramps/plugins/view/geoevents.py
@@ -187,6 +187,8 @@ class GeoEvents(GeoGraphyView):
         all handling of visibility is now in rebuild_trees, see that for more
         information.
         """
+        if not self.dbstate.is_open():
+            return
         active = self.uistate.get_active('Event')
         if active:
             self._createmap(active)

--- a/gramps/plugins/view/geofamclose.py
+++ b/gramps/plugins/view/geofamclose.py
@@ -317,6 +317,9 @@ class GeoFamClose(GeoGraphyView):
         all handling of visibility is now in rebuild_trees, see that for more
         information.
         """
+        self.lifeway_layer.clear_ways()
+        if not self.dbstate.is_open():
+            return
         active = self.get_active()
         if active:
             family = self.dbstate.db.get_family_from_handle(active)

--- a/gramps/plugins/view/geofamily.py
+++ b/gramps/plugins/view/geofamily.py
@@ -175,6 +175,8 @@ class GeoFamily(GeoGraphyView):
         all handling of visibility is now in rebuild_trees, see that for more
         information.
         """
+        if not self.dbstate.is_open():
+            return
         if self.uistate.get_active('Family'):
             self._createmap(self.uistate.get_active('Family'))
         else:

--- a/gramps/plugins/view/geoperson.py
+++ b/gramps/plugins/view/geoperson.py
@@ -210,6 +210,8 @@ class GeoPerson(GeoGraphyView):
         all handling of visibility is now in rebuild_trees, see that for more
         information.
         """
+        if not self.dbstate.is_open():
+            return
         active = self.get_active()
         self._createmap(None)
         self.uistate.modify_statusbar(self.dbstate)

--- a/gramps/plugins/view/geoplaces.py
+++ b/gramps/plugins/view/geoplaces.py
@@ -1,4 +1,4 @@
-								# -*- python -*-
+# -*- python -*-
 # -*- coding: utf-8 -*-
 #
 # Gramps - a GTK+/GNOME based genealogy program
@@ -232,6 +232,8 @@ class GeoPlaces(GeoGraphyView):
         all handling of visibility is now in rebuild_trees, see that for more
         information.
         """
+        if not self.dbstate.is_open():
+            return
         active = self.uistate.get_active('Place')
         if active:
             self._createmap(active)


### PR DESCRIPTION
Fixes #10229

Crash when clicking 'Find' in Geography view when db is closed.

View attempts to recreate the map with the filter, and the filters don't deal well with closed db.
PR just skips the attempt to put places on the map when db is closed.