### PR TITLE
Fix PlaceModel to avoid exception following merge

### DIFF
--- a/gramps/gui/views/treemodels/placemodel.py
+++ b/gramps/gui/views/treemodels/placemodel.py
@@ -222,6 +222,26 @@ class PlaceBaseModel:
         # TODO for Arabic, should the next line's comma be translated?
         return ', '.join(sorted(tag_list, key=glocale.sort_key))
 
+    def clear_cache(self, handle=None):
+        """
+        Clear the LRU cache. Always clear lru_path, because paths may have
+        changed.
+        Need special version of this because Places include Placerefs, and a
+        change in the place the Placeref points to can make the cache stale.
+        So just clearing the effected (deleted/changed) handle is not enough.
+        Note that this is only a (very) short term issue, during processing of
+        signals from a merge event.  The update of the place containing a
+        Placeref will occur.
+        See bug 10184.
+
+        Note that this method overrides the one from 'BaseModel', through
+        FlatBaseModel and TreeBaseModel.  By locating this in PlaceBaseModel,
+        the MRU rules mean this method takes precedence.
+        """
+        self.lru_data.clear()
+        # Invalidates all paths
+        self.lru_path.clear()
+
 #-------------------------------------------------------------------------
 #
 # PlaceListModel


### PR DESCRIPTION
Fixes #10184
Bug #8377
So this is a bit tricky.  It was hard to reproduce because several conditions had to be met to induce the error.  So again thank @leonhaeuser for his excellent bug report.

The underlying problem is that we have a small cache on the Gtk ListModel (and TreeModel) to improve performance.  As with all caches it must be kept up to date when things change.  In this case it is done by clearing part (based on object handle) or all of the cache.
When a signal from the db arrives indicating a delete or update of an object the original code clears the cache for that particular object.  The signal also performs other actions, among them is to move the select off of the affected row.
Normally, for most objects, this is enough.  But for places, we have the situation that they can refer to other places.  With this scenario when the merge occurs, the signals are sent in the order (place-delete, place-update) after the actual merge is complete in the db.   When the place-delete signal was processed, the select was moved to a row that contained a reference to the place that was removed in the merge.  When the select moved, the row was displayed again, using a cached copy of the underlying place data.  Even though when the signal arrived, the underlying data had been updated, the cached data was stale.

Ironically the cache for the newly selected object would also be cleared, but too late, when the place-update signals arrive.  We have already had an exception by then.

I decided to just completely clear the cache on a place delete/update signals.  I judge that this will only impart a performance penalty for the short time following a place change.