### PR TITLE
Fix CSV importer for place event name using gramps_id

### DIFF
--- a/gramps/plugins/importer/importcsv.py
+++ b/gramps/plugins/importer/importcsv.py
@@ -920,6 +920,9 @@ class CSVParser:
 
     def get_or_create_place(self, place_name):
         "Return the requested place object tuple-packed with a new indicator."
+        if place_name.startswith("[") and place_name.endswith("]"):
+            place = self.lookup("place", place_name)
+            return (0, place)
         LOG.debug("get_or_create_place: looking for: %s", place_name)
         for place_handle in self.db.iter_place_handles():
             place = self.db.get_place_from_handle(place_handle)


### PR DESCRIPTION
Fixes #10239

Exporting a CSV file and importing it back into the database (with or without edits) creates new places with names such as [P0852] referencing events, and the actual place names (which are still there) lose their reference to the events.