### PR TITLE
Fix Gedcom export for bad Hebrew Months

### DIFF
--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -752,7 +752,7 @@ for __val, __key in PERSONALCONSTANTATTRIBUTES.items():
 #
 #-------------------------------------------------------------------------
 HMONTH = [
-    "", "ELUL", "TSH", "CSH", "KSL", "TVT", "SHV", "ADR",
+    "", "TSH", "CSH", "KSL", "TVT", "SHV", "ADR",
     "ADS", "NSN", "IYR", "SVN", "TMZ", "AAV", "ELL"]
 
 FMONTH = [


### PR DESCRIPTION
Fixes #10245

I have no idea how long this has been broken; I can only assume that some other change in Hebrew date handling did not take Gedcom export into account.
The export month table did not line up with the gen.datehandler._dateparser hebrew_to_int table.
And the "ELUL" has never been in the legal Gedcom Hebrew Month values!