### PR TITLE
fix Quickreport start from Editor when object not yet committed

### DIFF
--- a/gramps/gui/editors/editprimary.py
+++ b/gramps/gui/editors/editprimary.py
@@ -309,7 +309,7 @@ class EditPrimary(ManagedWindow, DbGUIElement, metaclass=abc.ABCMeta):
         if self.QR_CATEGORY > -1 :
             (ui_qr, reportactions) = create_quickreport_menu(self.QR_CATEGORY,
                                     self.dbstate, self.uistate,
-                                    self.obj.get_handle())
+                                    self.obj, track=self.track)
             self.report_action = Gtk.ActionGroup(name="/PersonReport")
             self.report_action.add_actions(reportactions)
             self.report_action.set_visible(True)

--- a/gramps/gui/plug/quick/_quickreports.py
+++ b/gramps/gui/plug/quick/_quickreports.py
@@ -117,7 +117,8 @@ def create_web_connect_menu(dbstate, uistate, nav_group, handle):
     retval.extend(actions)
     return retval
 
-def create_quickreport_menu(category,dbstate,uistate, handle) :
+
+def create_quickreport_menu(category, dbstate, uistate, handle, track=[]):
     """ This functions querries the registered quick reports with
             quick_report_list of _PluginMgr.py
         It collects the reports of the requested category, which must be one of
@@ -154,14 +155,16 @@ def create_quickreport_menu(category,dbstate,uistate, handle) :
         new_key = pdata.id.replace(' ', '-')
         ofile.write('<menuitem action="%s"/>' % new_key)
         actions.append((new_key, None, pdata.name, None, None,
-                make_quick_report_callback(pdata, category,
-                                           dbstate, uistate, handle)))
+                make_quick_report_callback(pdata, category, dbstate,
+                                           uistate, handle, track=track)))
     ofile.write('</menu>')
 
     return (ofile.getvalue(), actions)
 
-def make_quick_report_callback(pdata, category, dbstate, uistate, handle):
-    return lambda x: run_report(dbstate, uistate, category, handle, pdata)
+def make_quick_report_callback(pdata, category, dbstate, uistate, handle,
+                               track=[]):
+    return lambda x: run_report(dbstate, uistate, category, handle, pdata,
+                                track=track)
 
 def get_quick_report_list(qv_category=None):
     """


### PR DESCRIPTION
Fixes #10048

I decided not to use Paul Franklins patch attached to the bug report, when I discovered that his pop up Error message had a bad transient parent (when started from an editor) and it would be painful to fix that.
The _quickreports.run_report code allows to pass in the object as well as the object handle, so I decided to use that when started from the editor.  That way, even if the object had not been committed yet, the QR could operate on it.

I then discovered that the QR was not getting a proper transient parent either, when started that way.  So I added the 'track' parameter to allow the Window manager etc. to get this set up correctly.