### PR TITLE
Fix Session Log for exception on closed db reference click

### DIFF
--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -638,6 +638,8 @@ class GuiGramplet:
         for (tag, link_type, handle, tooltip) in self._tags:
             if iter.has_tag(tag):
                 if link_type == 'Person':
+                    if not self.dbstate.db.has_person_handle(handle):
+                        return True
                     person = self.dbstate.db.get_person_from_handle(handle)
                     if person is not None:
                         if event.button == 1: # left mouse
@@ -699,6 +701,8 @@ class GuiGramplet:
                             display_help(handle)
                     return True
                 elif link_type == 'Family':
+                    if not self.dbstate.db.has_family_handle(handle):
+                        return True
                     family = self.dbstate.db.get_family_from_handle(handle)
                     if family is not None:
                         if event.button == 1: # left mouse

--- a/gramps/plugins/gramplet/sessionloggramplet.py
+++ b/gramps/plugins/gramplet/sessionloggramplet.py
@@ -69,10 +69,16 @@ class LogGramplet(Gramplet):
                      lambda handles: self.log('Family', 'Deleted', handles))
         self.connect(self.dbstate.db, 'family-update',
                      lambda handles: self.log('Family', 'Edited', handles))
+        self.connect_signal('Person', self.active_changed)
+        self.connect_signal('Family', self.active_changed_family)
 
     def active_changed(self, handle):
         if handle:
             self.log('Person', 'Selected', [handle])
+
+    def active_changed_family(self, handle):
+        if handle:
+            self.log('Family', 'Selected', [handle])
 
     def log(self, ltype, action, handles):
         for handle in set(handles):
@@ -90,6 +96,8 @@ class LogGramplet(Gramplet):
                         for i in transaction.get_recnos(reverse=True):
                             (obj_type, trans_type, hndl, old_data, dummy) = \
                                     transaction.get_record(i)
+                            if isinstance(hndl, bytes):
+                                hndl = str(hndl, "utf-8")
                             if (obj_type == PERSON_KEY and trans_type == TXNDEL
                                     and hndl == handle):
                                 person = Person()
@@ -102,6 +110,8 @@ class LogGramplet(Gramplet):
                         for i in transaction.get_recnos(reverse=True):
                             (obj_type, trans_type, hndl, old_data, dummy) = \
                                     transaction.get_record(i)
+                            if isinstance(hndl, bytes):
+                                hndl = str(hndl, "utf-8")
                             if (obj_type == FAMILY_KEY and trans_type == TXNDEL
                                     and hndl == handle):
                                 family = Family()


### PR DESCRIPTION
The Session Log Gramplet keeps a running record of changes made.  The original version kept this even across db close/open operations.  However, if the user mouse clicked one of the links to a closed db, an exception would occur.

I patched the HandleError in the grampletpane code so clicks on bad links would not get the exception.

During testing I noticed that deleted persons or families were not being identified; turns out that for bsddb the 'interesting' method of looking into the transaction log was getting a 'bytes' handle and trying to compare with str handle.  So put back in code to convert to str if bytes was found.

I then noticed that the Person select code was not getting executed; this was due to an earlier fix that stopped generating active-change for persons for everything.  Added the proper connect for that.  And added a similar connect for Family active-change  while I was at it.

These bugs found while trying to recreate a bug from the bug tracker (not successfully).