### PR TITLE
Fix Gedcom import for illegal Gedcom Family Attributes

### DIFF
--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -5226,12 +5226,20 @@ class GedcomParser(UpdateCallback):
 
     def __family_attr(self, line, state):
         """
+        Parses an TOKEN that Gramps recognizes as an Attribute
         @param line: The current line in GedLine format
         @type line: GedLine
         @param state: The current state
         @type state: CurrentState
         """
+        sub_state = CurrentState()
+        sub_state.person = state.person
+        sub_state.attr = line.data
+        sub_state.level = state.level + 1
         state.family.add_attribute(line.data)
+        self.__parse_level(sub_state, self.person_attr_parse_tbl,
+                           self.__ignore)
+        state.msg += sub_state.msg
 
     def __family_cust_attr(self, line, state):
         """


### PR DESCRIPTION
Issue #10262
TMG Gedcom exports an illegal NCHI with sub-data for FAM.  Gramps
could not handle this and attached the sub-data to the FAM creating
some corrupted Event records.
The corrupted records ended up with the Event description field containing Date type data, rather than str, which had a number of bad effects.

This fixes the Gedcom importer to avoid this in the future.