### PR TITLE
Fix FamilyRelationshpType _DATAMAP order to correspond with values

### DIFF
--- a/gramps/gen/lib/familyreltype.py
+++ b/gramps/gen/lib/familyreltype.py
@@ -44,11 +44,11 @@ class FamilyRelType(GrampsType):
     _DEFAULT = MARRIED
 
     _DATAMAP = [
+        (MARRIED, _("Married"), "Married"),
+        (UNMARRIED, _("Unmarried"), "Unmarried"),
+        (CIVIL_UNION, _("Civil Union"), "Civil Union"),
         (UNKNOWN, _("Unknown"), "Unknown"),
         (CUSTOM, _("Custom"), "Custom"),
-        (CIVIL_UNION, _("Civil Union"), "Civil Union"),
-        (UNMARRIED, _("Unmarried"), "Unmarried"),
-        (MARRIED, _("Married"), "Married"),
         ]
 
     def __init__(self, value=None):


### PR DESCRIPTION
Fixes #10275

The bug report says that the Preferences/Display/Default Family Relationship value was not consistent with the shown value in the Add/Edit Family dialog for new Families.  Turns out that the gramps.gui.configure code was expecting that the GrampsType value to be a match for the position in the returned GrampsType.get_standard_names() method list.

This was probably not a good assumption (the general use of GrampsTypes _DATAMAP tables does not usually have such a correspondence), and definitely not for the FamilyRelationshipType.

I judged it easier to shift the order of the _DATAMAP table for FamilyRelationshipType than to re-code the configure code to be agnostic to the order.  The table is now in the same order as the returned list from GrampsType.get_standard_names() so that the index matches the GrampsType values.

The other way would be to change the configure code to utilize a ComboBoxText, instead of a ComboBox, and operate on strings instead of position indexes.  With some slight complications in that the config (save preferences) code expects GrampsType Values.

A side effect is that users that had already set the Preferences/Display/Default Family Relationship value will find it looking different the next time they look in Preferences, it will actually say what it really does.

If accepted this should be back-ported to Gramps4.2...