### PR TITLE
Some filter optimizations to avoid repeated parts of tree scan

### DIFF
--- a/gramps/gen/filters/rules/person/_isdescendantfamilyof.py
+++ b/gramps/gen/filters/rules/person/_isdescendantfamilyof.py
@@ -82,7 +82,8 @@ class IsDescendantFamilyOf(Rule):
 
         while expand:
             person = expand.pop(0)
-            if person is None:
+            if person is None or person.handle in self.matches:
+                # if we have been here before, skip
                 continue
             self.matches.add(person.handle)
             for family_handle in person.get_family_handle_list():

--- a/gramps/gen/filters/rules/person/_isdescendantof.py
+++ b/gramps/gen/filters/rules/person/_isdescendantof.py
@@ -67,7 +67,8 @@ class IsDescendantOf(Rule):
         return person.handle in self.map
 
     def init_list(self, person, first):
-        if not person:
+        if not person or person.handle in self.map:
+            # if we have been here before, skip
             return
         if not first:
             self.map.add(person.handle)

--- a/gramps/gen/filters/rules/person/_islessthannthgenerationancestorof.py
+++ b/gramps/gen/filters/rules/person/_islessthannthgenerationancestorof.py
@@ -61,6 +61,9 @@ class IsLessThanNthGenerationAncestorOf(Rule):
         queue = [(root_handle, 1)] # generation 1 is root
         while queue:
             handle, gen = queue.pop(0) # pop off front of queue
+            if handle in self.map:
+                # if we have been here before, skip
+                continue
             self.map.add(handle)
             gen += 1
             if gen <= int(self.list[1]):

--- a/gramps/gen/filters/rules/person/_islessthannthgenerationancestorofbookmarked.py
+++ b/gramps/gen/filters/rules/person/_islessthannthgenerationancestorofbookmarked.py
@@ -71,7 +71,8 @@ class IsLessThanNthGenerationAncestorOfBookmarked(Rule):
     def init_ancestor_list(self, handle, gen):
 #        if p.get_handle() in self.map:
 #            loop_error(self.orig,p)
-        if not handle:
+        if not handle or handle in self.map:
+            # if been here already, skip
             return
         if gen:
             self.map.add(handle)

--- a/gramps/gen/filters/rules/person/_islessthannthgenerationancestorofdefaultperson.py
+++ b/gramps/gen/filters/rules/person/_islessthannthgenerationancestorofdefaultperson.py
@@ -64,7 +64,8 @@ class IsLessThanNthGenerationAncestorOfDefaultPerson(Rule):
     def init_ancestor_list(self, handle, gen):
 #        if p.get_handle() in self.map:
 #            loop_error(self.orig,p)
-        if not handle:
+        if not handle or handle in self.map:
+            # if we have been here before, skip
             return
         if gen:
             self.map.add(handle)

--- a/gramps/gen/filters/rules/person/_islessthannthgenerationdescendantof.py
+++ b/gramps/gen/filters/rules/person/_islessthannthgenerationdescendantof.py
@@ -65,7 +65,8 @@ class IsLessThanNthGenerationDescendantOf(Rule):
         return person.handle in self.map
 
     def init_list(self,person,gen):
-        if not person:
+        if not person or person.handle in self.map:
+            # if we have been here before, skip
             return
         if gen:
             self.map.add(person.handle)


### PR DESCRIPTION
While looking into bug [#10200](https://gramps-project.org/bugs/view.php?id=10200) which was complaining about long filter times I spotted a class of optimizations to some filters that would speed them up.

The speedup depends largely on the size of the tree, and to some extent on the amount of 'inbreeding'.

What sometimes occurs is that while performing an ancestor or descendant scan, the path scanned can 'overlap' paths already scanned.  This can happen on any tree if there is inbreeding, cousins or closer marrying each other.

It also happens a lot more in the IsDescendantOfFilterMatch and its equivalent 'OfFilterMatch' filters.  In this case the 'OfFilterMatch' filter may have multiple starting points that create overlaps in the descendant trees.

The optimization is to simply skip the extension of the scan when a person is encountered that is already in the filter map (thus indicating that the person has already been part of the scan).

Many of the filters already had this optimization in place, the ones in this PR did not.

I suggest accepting this PR after PR https://github.com/gramps-project/gramps/pull/494, which included a couple of fixes and an enhanced test suite; that way you can see that this doesn't break in a really obvious way.