### PR TITLE
Filter fixes to prevent MatchesFilter types from running multiple times

### DIFF
--- a/gramps/gen/filters/rules/person/_hascommonancestorwithfiltermatch.py
+++ b/gramps/gen/filters/rules/person/_hascommonancestorwithfiltermatch.py
@@ -62,8 +62,8 @@ class HasCommonAncestorWithFilterMatch(HasCommonAncestorWith):
         # Start with filling the cache for root person (gramps_id in self.list[0])
         self.ancestor_cache = {}
         self.with_people = []
-        filt = MatchesFilter(self.list)
-        filt.requestprepare(db, user)
+        self.filt = MatchesFilter(self.list)
+        self.filt.requestprepare(db, user)
         if user:
             user.begin_progress(self.category,
                                 _('Retrieving all sub-filter matches'),
@@ -72,7 +72,7 @@ class HasCommonAncestorWithFilterMatch(HasCommonAncestorWith):
             person = db.get_person_from_handle(handle)
             if user:
                 user.step_progress()
-            if person and filt.apply(db, person):
+            if person and self.filt.apply(db, person):
                 #store all people in the filter so as to compare later
                 self.with_people.append(person.handle)
                 #fill list of ancestor of person if not present yet
@@ -80,4 +80,7 @@ class HasCommonAncestorWithFilterMatch(HasCommonAncestorWith):
                     self.add_ancs(db, person)
         if user:
             user.end_progress()
-        filt.requestreset()
+
+    def reset(self):
+        self.filt.requestreset()
+        self.ancestor_cache = {}

--- a/gramps/gen/filters/rules/person/_isancestoroffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isancestoroffiltermatch.py
@@ -60,8 +60,8 @@ class IsAncestorOfFilterMatch(IsAncestorOf):
         except IndexError:
             first = 1
 
-        filt = MatchesFilter(self.list[0:1])
-        filt.requestprepare(db, user)
+        self.filt = MatchesFilter(self.list[0:1])
+        self.filt.requestprepare(db, user)
         if user:
             user.begin_progress(self.category,
                                 _('Retrieving all sub-filter matches'),
@@ -69,13 +69,13 @@ class IsAncestorOfFilterMatch(IsAncestorOf):
         for person in db.iter_people():
             if user:
                 user.step_progress()
-            if filt.apply(db, person):
+            if self.filt.apply(db, person):
                 self.init_ancestor_list(db, person, first)
         if user:
             user.end_progress()
-        filt.requestreset()
 
     def reset(self):
+        self.filt.requestreset()
         self.map.clear()
 
     def apply(self,db,person):

--- a/gramps/gen/filters/rules/person/_ischildoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_ischildoffiltermatch.py
@@ -51,8 +51,8 @@ class IsChildOfFilterMatch(Rule):
     def prepare(self, db, user):
         self.db = db
         self.map = set()
-        filt = MatchesFilter(self.list)
-        filt.requestprepare(db, user)
+        self.filt = MatchesFilter(self.list)
+        self.filt.requestprepare(db, user)
         if user:
             user.begin_progress(self.category,
                                 _('Retrieving all sub-filter matches'),
@@ -60,13 +60,13 @@ class IsChildOfFilterMatch(Rule):
         for person in db.iter_people():
             if user:
                 user.step_progress()
-            if filt.apply(db, person):
+            if self.filt.apply(db, person):
                 self.init_list(person)
         if user:
             user.end_progress()
-        filt.requestreset()
 
     def reset(self):
+        self.filt.requestreset()
         self.map.clear()
 
     def apply(self,db,person):

--- a/gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py
@@ -43,7 +43,7 @@ class IsDescendantFamilyOfFilterMatch(IsDescendantFamilyOf):
     """Rule that checks for a person that is a descendant
     of someone matched by a filter"""
 
-    labels      = [ _('Filter name:') ]
+    labels      = [ _('Filter name:')]
     name        = _('Descendant family members of <filter> match')
     category    = _('Descendant filters')
     description = _("Matches people that are descendants or the spouse "
@@ -53,8 +53,8 @@ class IsDescendantFamilyOfFilterMatch(IsDescendantFamilyOf):
         self.db = db
         self.matches = set()
 
-        filt = MatchesFilter(self.list[0:1])
-        filt.requestprepare(db, user)
+        self.matchfilt = MatchesFilter(self.list[0:1])
+        self.matchfilt.requestprepare(db, user)
         if user:
             user.begin_progress(self.category,
                                 _('Retrieving all sub-filter matches'),
@@ -62,9 +62,11 @@ class IsDescendantFamilyOfFilterMatch(IsDescendantFamilyOf):
         for person in db.iter_people():
             if user:
                 user.step_progress()
-            if filt.apply(db, person):
+            if self.matchfilt.apply(db, person):
                 self.add_matches(person)
         if user:
             user.end_progress()
-        filt.requestreset()
 
+    def reset(self):
+        self.matchfilt.requestreset()
+        self.matches = set()

--- a/gramps/gen/filters/rules/person/_isdescendantoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isdescendantoffiltermatch.py
@@ -60,8 +60,8 @@ class IsDescendantOfFilterMatch(IsDescendantOf):
         except IndexError:
             first = 1
 
-        filt = MatchesFilter(self.list[0:1])
-        filt.requestprepare(db, user)
+        self.filt = MatchesFilter(self.list[0:1])
+        self.filt.requestprepare(db, user)
         if user:
             user.begin_progress(self.category,
                                 _('Retrieving all sub-filter matches'),
@@ -69,13 +69,13 @@ class IsDescendantOfFilterMatch(IsDescendantOf):
         for person in db.iter_people():
             if user:
                 user.step_progress()
-            if filt.apply(db, person):
+            if self.filt.apply(db, person):
                 self.init_list(person, first)
         if user:
             user.end_progress()
-        filt.requestreset()
 
     def reset(self):
+        self.filt.requestreset()
         self.map.clear()
 
     def apply(self,db,person):

--- a/gramps/gen/filters/rules/person/_isparentoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isparentoffiltermatch.py
@@ -51,8 +51,8 @@ class IsParentOfFilterMatch(Rule):
     def prepare(self, db, user):
         self.db = db
         self.map = set()
-        filt = MatchesFilter(self.list)
-        filt.requestprepare(db, user)
+        self.filt = MatchesFilter(self.list)
+        self.filt.requestprepare(db, user)
         if user:
             user.begin_progress(self.category,
                                 _('Retrieving all sub-filter matches'),
@@ -60,13 +60,13 @@ class IsParentOfFilterMatch(Rule):
         for person in db.iter_people():
             if user:
                 user.step_progress()
-            if filt.apply(db, person):
+            if self.filt.apply(db, person):
                 self.init_list(person)
         if user:
             user.end_progress()
-        filt.requestreset()
 
     def reset(self):
+        self.filt.requestreset()
         self.map.clear()
 
     def apply(self,db,person):

--- a/gramps/gen/filters/rules/person/_issiblingoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_issiblingoffiltermatch.py
@@ -50,8 +50,8 @@ class IsSiblingOfFilterMatch(Rule):
     def prepare(self, db, user):
         self.db = db
         self.map = set()
-        filt = MatchesFilter(self.list)
-        filt.requestprepare(db, user)
+        self.matchfilt = MatchesFilter(self.list)
+        self.matchfilt.requestprepare(db, user)
         if user:
             user.begin_progress(self.category,
                                 _('Retrieving all sub-filter matches'),
@@ -59,13 +59,13 @@ class IsSiblingOfFilterMatch(Rule):
         for person in db.iter_people():
             if user:
                 user.step_progress()
-            if filt.apply (db, person):
-                self.init_list (person)
+            if self.matchfilt.apply(db, person):
+                self.init_list(person)
         if user:
             user.end_progress()
-        filt.requestreset()
 
     def reset(self):
+        self.matchfilt.requestreset()
         self.map.clear()
 
     def apply(self,db,person):


### PR DESCRIPTION
The filters that include 'OfFilterMatch' in their name run 'on top' of other filters; they execute the other filters first and then use the results as their starting point.
If there are multiple filter rules that include 'OfFilterMatch' and they are executing the same base filter, then the current code runs the same base filter multiple times.  The base filter gives the same result each time, so this represents extra work.

The current code attempted to correct this in the gen.filters.rules._rule.py in the 'requestprepare' method by tracking if a filter had been already run.  The already run indication was cleared by the 'requestreset' method.  

Unfortunately, the filters that include 'OfFilterMatch' were executing the 'requestreset' as soon as they were individually done with the base filter result during their 'prepare' step.  This meant that the base filter 'already run indication' was also cleared.  A subsequent attempt to use the same base filter would have to execute it again.

To avoid the multiple runs of base filters, I've moved the base filter 'requestreset' call from 'OfFilterMatch' filters from the 'prepare step' to their 'requestreset' step, so that all the filters are reset together at the end of operations.  Thus the state of the base filters is retained for use multiple times, if needed.

This PR will increase memory usage when 'OfFilterMatch' rules are used, during the execution of the overall filters.  The time saved will depend greatly on the number of times the base filters are reused, and the time spent in their 'prepare' step.

I recommend that this PR be accepted after PR https://github.com/gramps-project/gramps/pull/494, which includes additional tests to demonstrate the correct execution of the filters.