### PR TITLE
Fix duplicated method and memory leak in ProxyCache

### DIFF
--- a/gramps/gen/proxy/cache.py
+++ b/gramps/gen/proxy/cache.py
@@ -57,7 +57,10 @@ class CacheProxyDb:
         if handle:
             del self.cache_handle[handle]
         else:
-            self.cache_handle = LRU(100000)
+            # Memory allocation is power of 2 where slots has to fit.
+            # LRU uses one extra slot in its work, so set max to 2^17-1
+            # otherwise we are just wasting memory
+            self.cache_handle = LRU(131071)
 
     def get_person_from_handle(self, handle):
         """
@@ -93,15 +96,6 @@ class CacheProxyDb:
         """
         if handle not in self.cache_handle:
             self.cache_handle[handle] = self.db.get_repository_from_handle(handle)
-        return self.cache_handle[handle]
-
-    def get_place_from_handle(self, handle):
-        """
-        Gets item from cache if it exists. Converts
-        handles to string, for uniformity.
-        """
-        if handle not in self.cache_handle:
-            self.cache_handle[handle] = self.db.get_place_from_handle(handle)
         return self.cache_handle[handle]
 
     def get_place_from_handle(self, handle):

--- a/gramps/gen/proxy/cache.py
+++ b/gramps/gen/proxy/cache.py
@@ -40,7 +40,13 @@ class CacheProxyDb:
         proxies.
         """
         self.db = database
-        self.clear_cache()
+        # Memory allocation is power of 2 where slots has to fit.
+        # LRU uses one extra slot in its work, so set max to 2^17-1
+        # otherwise we are just wasting memory
+        self.cache_handle = LRU(131071)
+
+    def __del__(self):
+        self.cache_handle.clear()
 
     def __getattr__(self, attr):
         """
@@ -57,10 +63,7 @@ class CacheProxyDb:
         if handle:
             del self.cache_handle[handle]
         else:
-            # Memory allocation is power of 2 where slots has to fit.
-            # LRU uses one extra slot in its work, so set max to 2^17-1
-            # otherwise we are just wasting memory
-            self.cache_handle = LRU(131071)
+            self.cache_handle.clear()
 
     def get_person_from_handle(self, handle):
         """


### PR DESCRIPTION
Fixes #10291
Also changed size request to better utilize actual memory

I have also added an `__del__` method to the class, so that when the ProxyCacheDb is deleted or no longer needed, it will call the `clear()` method of the underlying LRU class to stop memory leaks.  The LRU uses a doubly linked list that seems to give the Python gc module difficulty in cleaning up, the `clear()` breaks up the links and deletes the cache slots for much faster garbage collection.