### PR TITLE
Filters optimization; Use cache proxy with filters in views

### DIFF
--- a/gramps/gui/views/treemodels/flatbasemodel.py
+++ b/gramps/gui/views/treemodels/flatbasemodel.py
@@ -74,6 +74,7 @@ from gramps.gen.filters import SearchFilter, ExactSearchFilter
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from .basemodel import BaseModel
 from ...user import User
+from gramps.gen.proxy.cache import CacheProxyDb
 
 #-------------------------------------------------------------------------
 #
@@ -608,18 +609,19 @@ class FlatBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
         self.clear_cache()
         self._in_build = True
         if (self.db is not None) and self.db.is_open():
+            cdb = CacheProxyDb(self.db)
             allkeys = self.node_map.full_srtkey_hndl_map()
             if not allkeys:
                 allkeys = self.sort_keys()
             if self.search:
                 ident = False
                 if ignore is None:
-                    dlist = self.search.apply(self.db, allkeys, tupleind=1,
+                    dlist = self.search.apply(cdb, allkeys, tupleind=1,
                                               user=self.user)
                 else:
-                    dlist = self.search.apply(self.db,
-                                [ k for k in allkeys if k[1] != ignore],
-                                tupleind=1)
+                    dlist = self.search.apply(
+                        cdb, [k for k in allkeys if k[1] != ignore],
+                        tupleind=1)
             elif ignore is None :
                 ident = True
                 dlist = allkeys

--- a/gramps/gui/views/treemodels/treebasemodel.py
+++ b/gramps/gui/views/treemodels/treebasemodel.py
@@ -57,6 +57,7 @@ from ...user import User
 from bisect import bisect_right
 from gramps.gen.filters import SearchFilter, ExactSearchFilter
 from .basemodel import BaseModel
+from gramps.gen.proxy.cache import CacheProxyDb
 
 #-------------------------------------------------------------------------
 #
@@ -584,7 +585,8 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
         self.__total += items
         assert not skip
         if dfilter:
-            for handle in dfilter.apply(self.db,
+            cdb = CacheProxyDb(self.db)
+            for handle in dfilter.apply(cdb,
                                         user=User(parent=self.uistate.window)):
                 status_ppl.heartbeat()
                 data = data_map(handle)


### PR DESCRIPTION
One more improvement in use of filters.  This one uses the CacheProxyDb to provide some speedup in the use of filters in views.  This is applied only when a filter is being executed in the view.

Provides a good speedup with complex filters, and larger trees less so with simpler ones.  I expect good improvements until the tree size approaches the size of the cache, (currently 100,000 objects) after which a smaller effect.

The improvement is less noticeable if the other filter optimizations (PR https://github.com/gramps-project/gramps/pull/496 , https://github.com/gramps-project/gramps/pull/497) are also put into effect.