### PR TITLE
Fix QuestionDialog display for html like characters in title

### DIFF
--- a/gramps/gui/dialog.py
+++ b/gramps/gui/dialog.py
@@ -24,6 +24,7 @@
 #
 #-------------------------------------------------------------------------
 import sys
+import html
 import logging
 _LOG = logging.getLogger(".dialog")
 
@@ -98,7 +99,8 @@ class QuestionDialog:
         self.top.set_title("%s - Gramps" % msg1)
 
         label1 = self.xml.get_object('qd_label1')
-        label1.set_text('<span weight="bold" size="larger">%s</span>' % msg1)
+        label1.set_text('<span weight="bold" size="larger">%s</span>' %
+                         html.escape(msg1))
         label1.set_use_markup(True)
 
         label2 = self.xml.get_object('qd_label2')
@@ -134,7 +136,8 @@ class QuestionDialog2:
         self.top.set_title("%s - Gramps" % msg1)
 
         label1 = self.xml.get_object('qd_label1')
-        label1.set_text('<span weight="bold" size="larger">%s</span>' % msg1)
+        label1.set_text('<span weight="bold" size="larger">%s</span>' %
+                        html.escape(msg1))
         label1.set_use_markup(True)
 
         label2 = self.xml.get_object('qd_label2')


### PR DESCRIPTION
Fixes #10298

QuestionDialog was used to display Family Tree names, which may have characters interpreted as html, ('&') even though they are not.

I scanned all Gramps source and Addons Source, and no-one was putting html in title (msg1), so used the html.escape() call to protect the title, as suggested by user DougReider