### PR TITLE
Fix FTM: rename a locked db, don't open, but title bar changes

### DIFF
--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -557,7 +557,7 @@ class DbManager(CLIDbManager, ManagedWindow):
         if len(new_text) > 0:
             node = self.model.get_iter(path)
             old_text = self.model.get_value(node, NAME_COL)
-            if self.model.get_value(node, ICON_COL) not in [None, ""]:
+            if self.model.get_value(node, ICON_COL) == 'document-open':
                 # this database is loaded. We must change the title
                 # in case we change the name several times before quitting,
                 # we save the first old name.


### PR DESCRIPTION
Fixes #10303

When renaming a Family Tree, current code examines the 'status' column to see if the tree is open and updates the Gramps title bar with an indication of the changed name.

But if the tree is NOT open, but the status column contains an icon, (like 'lock' icon) then the title bar is also (incorrectly) updated.