### PR TITLE
Fix interface problems with dark themes

### DIFF
--- a/gramps/gui/utils.py
+++ b/gramps/gui/utils.py
@@ -538,6 +538,21 @@ def rgb_to_hex(rgb):
         rgbint = (int(rgb[0] * 255), int(rgb[1] * 255), int(rgb[2] * 255))
         return '#%02x%02x%02x' % rgbint
 
+def get_link_color(context):
+    """
+    Find the link color for the current theme.
+    """
+    from gi.repository import Gtk
+
+    if Gtk.get_minor_version() > 11:
+        col = context.get_color(Gtk.StateFlags.LINK)
+    else:
+        found, col = context.lookup_color('link_color')
+        if not found:
+            col.parse('blue')
+
+    return rgb_to_hex((col.red, col.green, col.blue))
+
 def edit_object(dbstate, uistate, reftype, ref):
     """
     Invokes the appropriate editor for an object type and given handle.

--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -67,7 +67,7 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
 from ..ddtargets import DdTargets
 from ..plug.quick import create_quickreport_menu, create_web_connect_menu
-from ..utils import is_right_click
+from ..utils import is_right_click, rgb_to_hex
 from ..widgets.interactivesearchbox import InteractiveSearchBox
 
 #----------------------------------------------------------------
@@ -281,11 +281,12 @@ class ListView(NavigationView):
         function because we don't want to set the color of untagged rows.
         '''
         fg_color = model.get_value(iter_, model.color_column())
-        #for color errors, typically color column is badly set
-        if fg_color:
-            renderer.set_property('foreground', fg_color)
-        else:
-            LOG.debug('Bad color set: ' + str(fg_color))
+        if not fg_color:
+            context = self.list.get_style_context()
+            color = context.get_color(Gtk.StateFlags.ACTIVE)
+            fg_color = rgb_to_hex((color.red, color.green, color.blue))
+
+        renderer.set_property('foreground', fg_color)
 
     def set_active(self):
         """

--- a/gramps/gui/views/treemodels/citationbasemodel.py
+++ b/gramps/gui/views/treemodels/citationbasemodel.py
@@ -138,7 +138,7 @@ class CitationBaseModel(object):
         tag_handle = data[0]
         cached, tag_color = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
-            tag_color = "#000000000000"
+            tag_color = ""
             tag_priority = None
             for handle in data[COLUMN_TAGS]:
                 tag = self.db.get_tag_from_handle(handle)
@@ -297,7 +297,7 @@ class CitationBaseModel(object):
         tag_handle = data[0]
         cached, tag_color = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
-            tag_color = "#000000000000"
+            tag_color = ""
             tag_priority = None
             for handle in data[COLUMN2_TAGS]:
                 tag = self.db.get_tag_from_handle(handle)

--- a/gramps/gui/views/treemodels/eventmodel.py
+++ b/gramps/gui/views/treemodels/eventmodel.py
@@ -208,7 +208,7 @@ class EventModel(FlatBaseModel):
         tag_handle = data[0]
         cached, tag_color = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
-            tag_color = "#000000000000"
+            tag_color = ""
             tag_priority = None
             for handle in data[COLUMN_TAGS]:
                 tag = self.db.get_tag_from_handle(handle)

--- a/gramps/gui/views/treemodels/familymodel.py
+++ b/gramps/gui/views/treemodels/familymodel.py
@@ -220,7 +220,7 @@ class FamilyModel(FlatBaseModel):
         tag_handle = data[0]
         cached, tag_color = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
-            tag_color = "#000000000000"
+            tag_color = ""
             tag_priority = None
             for handle in data[13]:
                 tag = self.db.get_tag_from_handle(handle)

--- a/gramps/gui/views/treemodels/mediamodel.py
+++ b/gramps/gui/views/treemodels/mediamodel.py
@@ -187,7 +187,7 @@ class MediaModel(FlatBaseModel):
         tag_handle = data[0]
         cached, tag_color = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
-            tag_color = "#000000000000"
+            tag_color = ""
             tag_priority = None
             for handle in data[11]:
                 tag = self.db.get_tag_from_handle(handle)

--- a/gramps/gui/views/treemodels/notemodel.py
+++ b/gramps/gui/views/treemodels/notemodel.py
@@ -150,7 +150,7 @@ class NoteModel(FlatBaseModel):
         tag_handle = data[0]
         cached, value = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
-            tag_color = "#000000000000"
+            tag_color = ""
             tag_priority = None
             for handle in data[Note.POS_TAGS]:
                 tag = self.db.get_tag_from_handle(handle)

--- a/gramps/gui/views/treemodels/peoplemodel.py
+++ b/gramps/gui/views/treemodels/peoplemodel.py
@@ -545,7 +545,7 @@ class PeopleBaseModel(BaseModel):
         tag_handle = data[0]
         cached, value = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
-            tag_color = "#000000000000"
+            tag_color = ""
             tag_priority = None
             for handle in data[COLUMN_TAGS]:
                 tag = self.db.get_tag_from_handle(handle)

--- a/gramps/gui/views/treemodels/placemodel.py
+++ b/gramps/gui/views/treemodels/placemodel.py
@@ -200,7 +200,7 @@ class PlaceBaseModel(object):
         tag_handle = data[0]
         cached, value = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
-            tag_color = "#000000000000"
+            tag_color = ""
             tag_priority = None
             for handle in data[16]:
                 tag = self.db.get_tag_from_handle(handle)

--- a/gramps/gui/views/treemodels/repomodel.py
+++ b/gramps/gui/views/treemodels/repomodel.py
@@ -253,7 +253,7 @@ class RepositoryModel(FlatBaseModel):
         tag_handle = data[0]
         cached, tag_color = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
-            tag_color = "#000000000000"
+            tag_color = ""
             tag_priority = None
             for handle in data[8]:
                 tag = self.db.get_tag_from_handle(handle)

--- a/gramps/gui/views/treemodels/sourcemodel.py
+++ b/gramps/gui/views/treemodels/sourcemodel.py
@@ -143,7 +143,7 @@ class SourceModel(FlatBaseModel):
         tag_handle = data[0]
         cached, value = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
-            tag_color = "#000000000000"
+            tag_color = ""
             tag_priority = None
             for handle in data[11]:
                 tag = self.db.get_tag_from_handle(handle)

--- a/gramps/gui/views/treemodels/treebasemodel.py
+++ b/gramps/gui/views/treemodels/treebasemodel.py
@@ -897,7 +897,7 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
             # Header rows dont get the foreground color set
             if col == self.color_column():
                 #color must not be utf-8
-                return "#000000000000"
+                return ""
 
             # Return the node name for the first column
             if col == 0:

--- a/gramps/gui/widgets/__init__.py
+++ b/gramps/gui/widgets/__init__.py
@@ -31,6 +31,7 @@ from .photo import *
 from .placeentry import *
 from .monitoredwidgets import *
 from .selectionwidget import SelectionWidget, Region
+from .shadebox import *
 from .shortlistcomboentry import *
 from .springseparator import *
 from .statusbar import Statusbar

--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -50,7 +50,7 @@ from gramps.gen.errors import WindowActiveError
 from gramps.gen.const import URL_MANUAL_PAGE, VERSION_DIR
 from ..editors import EditPerson, EditFamily
 from ..managedwindow import ManagedWindow
-from ..utils import is_right_click, rgb_to_hex
+from ..utils import is_right_click, get_link_color
 from .menuitem import add_menuitem
 from ..plug.quick import run_quick_report_by_name
 from ..display import display_help, display_url
@@ -197,12 +197,7 @@ class LinkTag(Gtk.TextTag):
     lid = 0
     #obtaining the theme link color once. Restart needed on theme change!
     linkcolor = Gtk.Label(label='test') #needed to avoid label destroyed to early
-    linkcolor = linkcolor.get_style_context().lookup_color('link_color')
-    if linkcolor[0]:
-        linkcolor = rgb_to_hex((linkcolor[1].red, linkcolor[1].green,
-                                linkcolor[1].blue))
-    else:
-        linkcolor = 'blue'
+    linkcolor = get_link_color(linkcolor.get_style_context())
     
     def __init__(self, buffer):
         LinkTag.lid += 1

--- a/gramps/gui/widgets/labels.py
+++ b/gramps/gui/widgets/labels.py
@@ -49,7 +49,7 @@ from gi.repository import Pango
 #
 #-------------------------------------------------------------------------
 from gramps.gen.constfunc import has_display, win
-from ..utils import rgb_to_hex
+from ..utils import get_link_color
 
 #-------------------------------------------------------------------------
 #
@@ -85,11 +85,7 @@ class LinkLabel(Gtk.EventBox):
         GObject.GObject.__init__(self)
         
         st_cont = self.get_style_context()
-        col = st_cont.lookup_color('link_color')
-        if col[0]:
-            self.color = rgb_to_hex((col[1].red, col[1].green, col[1].blue))
-        else:
-            self.color = 'blue'
+        self.color = get_link_color(st_cont)
 
         if emph:
             #emphasize a link

--- a/gramps/gui/widgets/shadebox.py
+++ b/gramps/gui/widgets/shadebox.py
@@ -1,0 +1,58 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2018        Nick Hall
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, 
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+__all__ = ["ShadeBox"]
+
+#-------------------------------------------------------------------------
+#
+# Standard python modules
+#
+#-------------------------------------------------------------------------
+import logging
+_LOG = logging.getLogger(".widgets.shadebox")
+
+#-------------------------------------------------------------------------
+#
+# GTK/Gnome modules
+#
+#-------------------------------------------------------------------------
+from gi.repository import Gtk
+
+#-------------------------------------------------------------------------
+#
+# ShadeBox class
+#
+#-------------------------------------------------------------------------
+class ShadeBox(Gtk.EventBox):
+    """
+    An EventBox with a shaded background.
+    """
+    def __init__(self, use_shade):
+        Gtk.EventBox.__init__(self)
+        self.use_shade = use_shade
+
+    def do_draw(self, cr):
+        if self.use_shade:
+            tv = Gtk.TextView()
+            tv_context = tv.get_style_context()
+            width = self.get_allocated_width()
+            height = self.get_allocated_height()
+            Gtk.render_background(tv_context, cr, 0, 0, width, height)
+        self.get_child().draw(cr)

--- a/gramps/gui/widgets/styledtexteditor.py
+++ b/gramps/gui/widgets/styledtexteditor.py
@@ -60,7 +60,7 @@ from .toolcomboentry import ToolComboEntry
 from .springseparator import SpringSeparatorAction
 from ..spell import Spell
 from ..display import display_url
-from ..utils import SystemFonts, rgb_to_hex
+from ..utils import SystemFonts, get_link_color
 from gramps.gen.config import config
 from gramps.gen.constfunc import has_display
 from ..actiongroup import ActionGroup
@@ -184,11 +184,7 @@ class StyledTextEditor(Gtk.TextView):
         self.set_buffer(self.textbuffer)
 
         st_cont = self.get_style_context()
-        col = st_cont.lookup_color('link_color')
-        if col[0]:
-            self.linkcolor = rgb_to_hex((col[1].red, col[1].green, col[1].blue))
-        else:
-            self.linkcolor = 'blue'
+        self.linkcolor = get_link_color(st_cont)
         self.textbuffer.linkcolor = self.linkcolor
 
         self.match = None

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -306,15 +306,6 @@ class RelationshipView(NavigationView):
         self.child = None
 
         self.scroll = Gtk.ScrolledWindow()
-
-        st_cont = self.scroll.get_style_context()
-        col = st_cont.lookup_color('base_color')
-        if col[0]:
-            self.color = col[1]
-        else:
-            self.color = Gdk.RGBA()
-            self.color.parse("White")
-
         self.scroll.set_policy(Gtk.PolicyType.AUTOMATIC,
                                Gtk.PolicyType.AUTOMATIC)
         self.scroll.show()
@@ -575,9 +566,7 @@ class RelationshipView(NavigationView):
 
         grid.attach(eventbox, 0, 0, 2, 1)
 
-        eventbox = Gtk.EventBox()
-        if self.use_shade:
-            eventbox.override_background_color(Gtk.StateType.NORMAL, self.color)
+        eventbox = widgets.ShadeBox(self.use_shade)
         grid.attach(eventbox, 1, 1, 1, 1)
         subgrid = Gtk.Grid()
         subgrid.set_column_spacing(12)
@@ -874,9 +863,7 @@ class RelationshipView(NavigationView):
             box = self.get_people_box(family.get_father_handle(),
                                       family.get_mother_handle(),
                                       post_msg=childmsg)
-            eventbox = Gtk.EventBox()
-            if self.use_shade:
-                eventbox.override_background_color(Gtk.StateType.NORMAL, self.color)
+            eventbox = widgets.ShadeBox(self.use_shade)
             eventbox.add(box)
             self.child.attach(eventbox, _PDATA_START, self.row,
                                _PDATA_STOP-_PDATA_START, 1)
@@ -928,9 +915,7 @@ class RelationshipView(NavigationView):
                     else :
                         childmsg = _(" (only child)")
                     box = self.get_people_box(post_msg=childmsg)
-                    eventbox = Gtk.EventBox()
-                    if self.use_shade:
-                        eventbox.override_background_color(Gtk.StateType.NORMAL, self.color)
+                    eventbox = widgets.ShadeBox(self.use_shade)
                     eventbox.add(box)
                     self.child.attach(eventbox, _PDATA_START, self.row,
                                       _PDATA_STOP-_PDATA_START, 1)
@@ -958,9 +943,7 @@ class RelationshipView(NavigationView):
                         child_should_be_linked = (child_handle != active)
                         self.write_child(vbox, child_handle, i, child_should_be_linked)
                         i += 1
-                    eventbox = Gtk.EventBox()
-                    if self.use_shade:
-                        eventbox.override_background_color(Gtk.StateType.NORMAL, self.color)
+                    eventbox = widgets.ShadeBox(self.use_shade)
                     eventbox.add(vbox)
                     self.child.attach(eventbox, _CDATA_START-1, self.row,
                                       _CDATA_STOP-_CDATA_START+1, 1)
@@ -980,9 +963,6 @@ class RelationshipView(NavigationView):
                 name = self.get_name(handle, True)
                 link_label = widgets.LinkLabel(name, self._button_press, 
                                                handle, theme=self.theme)
-                if self.use_shade:
-                    link_label.override_background_color(Gtk.StateType.NORMAL,
-                                                         self.color)
                 if self._config.get('preferences.releditbtn'):
                     button = widgets.IconButton(self.edit_button_press, 
                                                 handle)
@@ -1025,7 +1005,7 @@ class RelationshipView(NavigationView):
                           _PLABEL_STOP-_PLABEL_START, 1)
 
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        eventbox = Gtk.EventBox()
+        eventbox = widgets.ShadeBox(self.use_shade)
         if handle:
             name = self.get_name(handle, True)
             person = self.dbstate.db.get_person_from_handle(handle)
@@ -1039,8 +1019,6 @@ class RelationshipView(NavigationView):
                 emph = False
             link_label = widgets.LinkLabel(name, self._button_press, 
                                            handle, emph, theme=self.theme)
-            if self.use_shade:
-                link_label.override_background_color(Gtk.StateType.NORMAL, self.color)
             if self._config.get('preferences.releditbtn'):
                 button = widgets.IconButton(self.edit_button_press, handle)
                 button.set_tooltip_text(_('Edit %s') % name[0])
@@ -1059,8 +1037,6 @@ class RelationshipView(NavigationView):
             if value:
                 vbox.pack_start(widgets.MarkupLabel(value), True, True, 0)
 
-        if self.use_shade:
-            eventbox.override_background_color(Gtk.StateType.NORMAL, self.color)
         eventbox.add(vbox)
         
         self.child.attach(eventbox, _PDATA_START, self.row,
@@ -1160,9 +1136,6 @@ class RelationshipView(NavigationView):
         name = self.get_name(handle, True)
         link_label = widgets.LinkLabel(name, link_func, handle, emph,
                                        theme=self.theme)
-
-        if self.use_shade:
-            link_label.override_background_color(Gtk.StateType.NORMAL, self.color)
         link_label.set_padding(3, 0)
         if child_should_be_linked and self._config.get(
             'preferences.releditbtn'):
@@ -1379,9 +1352,7 @@ class RelationshipView(NavigationView):
             else :
                 childmsg = _(" (no children)")
             box = self.get_people_box(handle, post_msg=childmsg)
-            eventbox = Gtk.EventBox()
-            if self.use_shade:
-                eventbox.override_background_color(Gtk.StateType.NORMAL, self.color)
+            eventbox = widgets.ShadeBox(self.use_shade)
             eventbox.add(box)
             self.child.attach(eventbox, _PDATA_START, self.row,
                               _PDATA_STOP-_PDATA_START, 1)
@@ -1426,9 +1397,7 @@ class RelationshipView(NavigationView):
                 else :
                     childmsg = _(" (no children)")
                 box = self.get_people_box(post_msg=childmsg)
-                eventbox = Gtk.EventBox()
-                if self.use_shade:
-                    eventbox.override_background_color(Gtk.StateType.NORMAL, self.color)
+                eventbox = widgets.ShadeBox(self.use_shade)
                 eventbox.add(box)
                 self.child.attach(eventbox, _PDATA_START, self.row,
                                   _PDATA_STOP-_PDATA_START, 1)
@@ -1456,9 +1425,7 @@ class RelationshipView(NavigationView):
                     i += 1
 
                 self.row += 1
-                eventbox = Gtk.EventBox()
-                if self.use_shade:
-                    eventbox.override_background_color(Gtk.StateType.NORMAL, self.color)
+                eventbox = widgets.ShadeBox(self.use_shade)
                 eventbox.add(vbox)
                 self.child.attach(eventbox, _CDATA_START-1, self.row,
                                   _CDATA_STOP-_CDATA_START+1, 1)

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -366,6 +366,7 @@ gramps/gui/widgets/linkbox.py
 gramps/gui/widgets/menuitem.py
 gramps/gui/widgets/multitreeview.py
 gramps/gui/widgets/placeentry.py
+gramps/gui/widgets/shadebox.py
 gramps/gui/widgets/shortlistcomboentry.py
 gramps/gui/widgets/springseparator.py
 gramps/gui/widgets/statusbar.py


### PR DESCRIPTION
* List views now use the default foreground colour from the theme rather than using black.
* Find the link colour from the theme.  Changing the theme will still require a restart.
* Change the shading in the relationship view to use black for dark themes and white for light themes.  I use the amount of red to distinguish a light theme from a dark theme.  There may be a better way to do this.