### PR TITLE
Fix: 0010333: PyGIWarning when creating a report from the command line.

### DIFF
--- a/gramps/plugins/docgen/cairodoc.py
+++ b/gramps/plugins/docgen/cairodoc.py
@@ -35,6 +35,9 @@ import logging
 # GTK modules
 #
 #-------------------------------------------------------------------------
+import gi
+gi.require_version('Pango', '1.0')
+gi.require_version('PangoCairo', '1.0')
 from gi.repository import Pango, PangoCairo
 import cairo
 


### PR DESCRIPTION
Added a requirement for pango and pangocairo versions to eliminate a warning that was present when calling a report from the command line.  Reference bug tracker [0010333](https://gramps-project.org/bugs/view.php?id=10333).