### PR TITLE
Fix Media Preview Gramplet for closed db

### DIFF
--- a/gramps/plugins/gramplet/mediapreview.py
+++ b/gramps/plugins/gramplet/mediapreview.py
@@ -77,6 +77,7 @@ class MediaPreview(Gramplet):
                 self.set_has_data(False)
             self.top.show()
         else:
+            self.photo.set_image(None)
             self.set_has_data(False)
 
     def load_image(self, media):


### PR DESCRIPTION
Fixes #10332

Media Preview was not being cleared when a db closed or changed.