### PR TITLE
fix Sidebar to resize better

### DIFF
--- a/gramps/gui/widgets/grampletbar.py
+++ b/gramps/gui/widgets/grampletbar.py
@@ -370,7 +370,7 @@ class GrampletBar(Gtk.Notebook):
         """
         Add a tab to the notebook for the given gramplet.
         """
-        width = min(int(self.uistate.screen_width() * 0.25), 400)
+        width = -1  # Allow tab width to adjust (smaller) to sidebar
         height = min(int(self.uistate.screen_height() * 0.20), 400)
         gramplet.set_size_request(width, height)
 


### PR DESCRIPTION
Fixes [#10334](https://gramps-project.org/bugs/view.php?id=10334)  (or at least helps) Filter sidebar loses RH controls when adjusting sidebar width down.
Issue [#10161](https://gramps-project.org/bugs/view.php?id=10161)  Difficult to expand Sidebar on Windows after it is shrunk to nothing.

The sidebar is currently set to be the smaller of 25% of SCREEN width or 400 pix, whatever is smaller.  For large screens (particularly multi-monitor), you end up with a 400 pix wide sidebar, no matter what size the Gramps window is.

As the bug reporter noted, if you try to shrink the sidebar, you lose the right hand portion of it.
The undersized sidebar also did not have a bottom scroll bar to allow the user to scroll to see all of it.

I think it would be better to allow the sidebar contents to shrink with the sidebar to their 'natural' minimum.  It should help a lot with the reporter's issue since the natural minimum is a lot smaller than 400pix.

Further, if you shrink the sidebar to nothing, it becomes very hard to expand it again #10161.  So I further suggest limiting the sidebar minimum size to its overall natural minimum.  That way it cannot be eliminated completely, but the remaining amount is pretty obviously too small and less likely to just hide the sidebar right hand side contents.  I note that the results are a bit different on Windows and Ubuntu Linux, probably due to different CSS.  The user can always eliminate the sidebar via the 'View' menu.

With these changes, an undersized sidebar will also have a scroll bar at the bottom of the sidebar.

I also set up the default sidebar size to be dependent on the window size.  This only applies for first run until user adjusts manually.  Tested and looks OK for Gramps windows at 800, 1280, and 1920 wide (delete ".gramps/gramps50/People_personview.ini" etc. to test).