### PR TITLE
Fix Fan Chart Print centering and scaling on Windows

### DIFF
--- a/gramps/gui/widgets/fanchart.py
+++ b/gramps/gui/widgets/fanchart.py
@@ -1221,7 +1221,9 @@ class FanChartWidget(FanChartBaseWidget):
         cr.scale(scale, scale)
         if widget:
             self.center_xy = self.center_xy_from_delta()
-        cr.translate(*self.center_xy)
+            cr.translate(*self.center_xy)
+        else:
+            cr.translate(halfdist, halfdist)
 
         cr.save()
         cr.rotate(math.radians(self.rotate_value))

--- a/gramps/gui/widgets/fanchart2way.py
+++ b/gramps/gui/widgets/fanchart2way.py
@@ -374,7 +374,9 @@ class FanChart2WayWidget(FanChartWidget, FanChartDescWidget):
         cr.scale(scale, scale)
         if widget:
             self.center_xy = self.center_xy_from_delta()
-        cr.translate(*self.center_xy)
+            cr.translate(*self.center_xy)
+        else:
+            cr.translate(halfdist, halfdist)
 
         cr.save()
         # Draw background

--- a/gramps/plugins/view/fanchart2wayview.py
+++ b/gramps/plugins/view/fanchart2wayview.py
@@ -528,8 +528,6 @@ class CairoPrintSave():
         pxwidth = round(context.get_width())
         pxheight = round(context.get_height())
         scale = min(pxwidth/self.widthpx, pxheight/self.heightpx)
-        if scale > 1:
-            scale = 1
         self.drawfunc(None, cr, scale=scale)
 
     def on_paginate(self, operation, context):

--- a/gramps/plugins/view/fanchartdescview.py
+++ b/gramps/plugins/view/fanchartdescview.py
@@ -516,8 +516,6 @@ class CairoPrintSave:
         pxwidth = round(context.get_width())
         pxheight = round(context.get_height())
         scale = min(pxwidth/self.widthpx, pxheight/self.heightpx)
-        if scale > 1:
-            scale = 1
         self.drawfunc(None, cr, scale=scale)
 
     def on_paginate(self, operation, context):

--- a/gramps/plugins/view/fanchartview.py
+++ b/gramps/plugins/view/fanchartview.py
@@ -523,8 +523,6 @@ class CairoPrintSave:
         pxwidth = round(context.get_width())
         pxheight = round(context.get_height())
         scale = min(pxwidth/self.widthpx, pxheight/self.heightpx)
-        if scale > 1:
-            scale = 1
         self.drawfunc(None, cr, scale=scale)
 
     def on_paginate(self, operation, context):


### PR DESCRIPTION
Fixes #8460
Most of the work for this was already done by Josip and Sam back in Aug 2015.  Sam reminded me that it needed testing.
I also discovered that the centering of the printed chart was wrong.  The original centering depended on the shape of the Gramps charts pane; if it was wider than it was tall, the printed chart was incorrect.  Due to the centering code using the wrong values for printing.
Tested on Windows with actual printer, and pdf, and on Linux with 'Print to file' both SVG and PDF.

Centering is perfect on Windows, but slightly off on Linux.  I suspect that there is some margin adjustment on Ubuntu Linux not being accounted for.  The Linux chart never exceeded the margins in my testing.

I note that the CairoPrintSave class code is duplicated in three places (plugins/view/fannchart*view.py), and similar in plugins/lib/maps/cairoprint.py.  It was suggested to move this class to a common area, possibly gramps/gen or gramps/gui but I did not address that with this PR as I don't know what the best choice might be.