### PR TITLE
Fix memory leak in ProgressMeter

### DIFF
--- a/gramps/gui/utils.py
+++ b/gramps/gui/utils.py
@@ -314,6 +314,7 @@ class ProgressMeter:
         """
         Close the progress meter
         """
+        del self.__cancel_callback
         self.__dialog.destroy()
 
 #-------------------------------------------------------------------------


### PR DESCRIPTION
Experiments in leak detection, started out with an easy one.  ProgressMeter left a leak in memory each time it runs.  Turns out it had a stored reference to one of its methods; apparently that counts as a circular reference.

I thought gc was able to break these, but I never saw it happen.