### PR TITLE
Fix Citation Editor to Tab out of Confidence ComboBox

### DIFF
--- a/gramps/gui/glade/editcitation.glade
+++ b/gramps/gui/glade/editcitation.glade
@@ -197,7 +197,7 @@
                 <child>
                   <object class="GtkComboBox" id="confidence">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can_focus">False</property>
                     <property name="tooltip_text" translatable="yes">Conveys the submitter's quantitative evaluation of the credibility of a piece of information, based upon its supporting evidence. It is not intended to eliminate the receiver's need to evaluate the evidence for themselves.
 Very Low =Unreliable evidence or estimated data
 Low =Questionable reliability of evidence (interviews, census, oral genealogies, or potential for bias for example, an autobiography)


### PR DESCRIPTION
Fixes [#10351](https://gramps-project.org/bugs/view.php?id=10351)