### PR TITLE
Surname Editor fixes Take 2!

### DIFF
--- a/gramps/gui/editors/displaytabs/embeddedlist.py
+++ b/gramps/gui/editors/displaytabs/embeddedlist.py
@@ -42,6 +42,7 @@ from gi.repository import Pango
 # Gramps classes
 #
 #-------------------------------------------------------------------------
+from ...widgets.cellrenderertextedit import CellRendererTextEdit
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 from ...utils import is_right_click
@@ -482,7 +483,10 @@ class EmbeddedList(ButtonTab):
             type_col = self._column_names[pair[1]][3]
 
             if (type_col in [TEXT_COL, MARKUP_COL, TEXT_EDIT_COL]):
-                renderer = Gtk.CellRendererText()
+                if type_col == TEXT_EDIT_COL:
+                    renderer = CellRendererTextEdit()
+                else:
+                    renderer = Gtk.CellRendererText()
                 renderer.set_property('ellipsize', Pango.EllipsizeMode.END)
                 if type_col == TEXT_COL or type_col == TEXT_EDIT_COL:
                     column = Gtk.TreeViewColumn(name, renderer, text=pair[1])

--- a/gramps/gui/editors/displaytabs/embeddedlist.py
+++ b/gramps/gui/editors/displaytabs/embeddedlist.py
@@ -523,9 +523,12 @@ class EmbeddedList(ButtonTab):
                 # insert the colum into the tree
                 column.set_resizable(True)
             column.set_clickable(True)
-            column.set_sizing(Gtk.TreeViewColumnSizing.FIXED)
-            #column.set_min_width(self._column_names[pair[1]][2])
-            column.set_fixed_width(self._column_names[pair[1]][2])
+            if self._column_names[pair[1]][2] != -1:
+                column.set_sizing(Gtk.TreeViewColumnSizing.FIXED)
+                #column.set_min_width(self._column_names[pair[1]][2])
+                column.set_fixed_width(self._column_names[pair[1]][2])
+            else:
+                column.set_expand(True)
 
             column.set_sort_column_id(self._column_names[pair[1]][1])
             self.columns.append(column)

--- a/gramps/gui/editors/displaytabs/surnametab.py
+++ b/gramps/gui/editors/displaytabs/surnametab.py
@@ -45,7 +45,7 @@ _ENTER = Gdk.keyval_from_name("Enter")
 #
 #-------------------------------------------------------------------------
 from .surnamemodel import SurnameModel
-from .embeddedlist import EmbeddedList, TEXT_COL, MARKUP_COL, ICON_COL
+from .embeddedlist import EmbeddedList, TEXT_EDIT_COL
 from ...ddtargets import DdTargets
 from gramps.gen.lib import Surname, NameOriginType
 from ...utils import get_primary_mask
@@ -71,9 +71,9 @@ class SurnameTab(EmbeddedList):
     #index = column in model. Value =
     #  (name, sortcol in model, width, markup/text
     _column_names = [
-        (_('Prefix'), -1, 150, TEXT_COL, -1, None),
-        (_('Surname'), -1, 250, TEXT_COL, -1, None),
-        (_('Connector'), -1, 100, TEXT_COL, -1, None),
+        (_('Prefix'), 0, 150, TEXT_EDIT_COL, -1, None),
+        (_('Surname'), 1, -1, TEXT_EDIT_COL, -1, None),
+        (_('Connector'), 2, 100, TEXT_EDIT_COL, -1, None),
         ]
     _column_combo = (_('Origin'), -1, 150, 3)  # name, sort, width, modelcol
     _column_toggle = (_('Name|Primary'), -1, 80, 4)
@@ -93,14 +93,6 @@ class SurnameTab(EmbeddedList):
     def build_columns(self):
         #first the standard text columns with normal method
         EmbeddedList.build_columns(self)
-
-        # Need to add attributes to renderers
-        # and connect renderers to the 'edited' signal
-        for colno in range(len(self.columns)):
-            for renderer in self.columns[colno].get_cells():
-                renderer.set_property('editable', not self.dbstate.db.readonly)
-                renderer.connect('editing_started', self.on_edit_start, colno)
-                renderer.connect('edited', self.on_edit_inline, self.column_order()[colno][1])
 
         # now we add the two special columns
         # combobox for type
@@ -160,6 +152,24 @@ class SurnameTab(EmbeddedList):
 ##        fvalue = self.cmborigmap[first]
 ##        svalue = self.cmborigmap[second]
 ##        return glocale.strcoll(fvalue, svalue)
+
+    def setup_editable_col(self):
+        """
+        inherit this and set the variables needed for editable columns
+        Variable edit_col_funcs needs to be a dictionary from model col_nr to
+        function to call for
+        Example:
+        self.edit_col_funcs ={1: {'edit_start': self.on_edit_start,
+                                  'edited': self.on_edited
+                              }}
+        """
+        self.edit_col_funcs = {
+            0: {'edit_start': self.on_edit_start,
+                'edited': self.on_edit_inline},
+            1: {'edit_start': self.on_edit_start,
+                'edited': self.on_edit_inline},
+            2: {'edit_start': self.on_edit_start,
+                'edited': self.on_edit_inline}}
 
     def get_data(self):
         return self.obj.get_surname_list()

--- a/gramps/gui/editors/displaytabs/surnametab.py
+++ b/gramps/gui/editors/displaytabs/surnametab.py
@@ -204,6 +204,16 @@ class SurnameTab(EmbeddedList):
         if self.on_change:
             self.on_change()
 
+    def post_rebuild(self, prebuildpath):
+        """
+        Called when data model has changed, in particular necessary when row
+        order is updated.
+        @param prebuildpath: path selected before rebuild, None if none
+        @type prebuildpath: tree path
+        """
+        if self.on_change:
+            self.on_change()
+
     def column_order(self):
         # order of columns for EmbeddedList. Only the text columns here
         return ((1, 0), (1, 1), (1, 2))

--- a/gramps/gui/editors/displaytabs/surnametab.py
+++ b/gramps/gui/editors/displaytabs/surnametab.py
@@ -125,7 +125,7 @@ class SurnameTab(EmbeddedList):
         column.set_resizable(True)
         column.set_sort_column_id(self._column_combo[1])
         column.set_min_width(self._column_combo[2])
-        column.set_expand(True)
+        column.set_expand(False)
         self.columns.append(column)
         self.tree.append_column(column)
         # toggle box for primary
@@ -141,7 +141,7 @@ class SurnameTab(EmbeddedList):
         column.set_sizing(Gtk.TreeViewColumnSizing.FIXED)
         column.set_alignment(0.5)
         column.set_sort_column_id(self._column_toggle[1])
-        column.set_min_width(self._column_toggle[2])
+        column.set_max_width(self._column_toggle[2])
         self.columns.append(column)
         self.tree.append_column(column)
 
@@ -249,11 +249,13 @@ class SurnameTab(EmbeddedList):
         """
         self.on_edit_start(cellr, celle, path, colnr)
         #set up autocomplete
+        entry = celle.get_child()
+        entry.set_width_chars(10)
         completion = Gtk.EntryCompletion()
         completion.set_model(self.cmborig)
         completion.set_minimum_key_length(1)
         completion.set_text_column(1)
-        celle.get_child().set_completion(completion)
+        entry.set_completion(completion)
         #
         celle.connect('changed', self.on_origcmb_change, path, colnr)
 

--- a/gramps/gui/editors/editperson.py
+++ b/gramps/gui/editors/editperson.py
@@ -197,9 +197,6 @@ class EditPerson(EditPrimary):
         self.singsurnfr = SingSurn(self.top)
         self.multsurnfr = self.top.get_object("hboxmultsurnames")
         self.singlesurn_active = True
-        self.surntab = SurnameTab(self.dbstate, self.uistate, self.track,
-                                  self.obj.get_primary_name(),
-                                  on_change=self._changed_name)
 
         self.set_contexteventbox(self.top.get_object("eventboxtop"))
 
@@ -445,6 +442,9 @@ class EditPerson(EditPrimary):
 
         self.preview_name = self.top.get_object("full_name")
         self.preview_name.override_font(Pango.FontDescription('sans bold 12'))
+        self.surntab = SurnameTab(self.dbstate, self.uistate, self.track,
+                                  self.obj.get_primary_name(),
+                                  on_change=self._changed_name)
 
     def get_start_date(self):
         """
@@ -936,7 +936,8 @@ class EditPerson(EditPrimary):
         msurhbox = self.top.get_object("hboxmultsurnames")
         msurhbox.remove(self.surntab)
         self.surntab = SurnameTab(self.dbstate, self.uistate, self.track,
-                       self.obj.get_primary_name())
+                                  self.obj.get_primary_name(),
+                                  on_change=self._changed_name)
         self.multsurnfr.set_size_request(-1,
                                 int(config.get('interface.surname-box-height')))
         msurhbox.pack_start(self.surntab, True, True, 0)

--- a/gramps/gui/widgets/cellrenderertextedit.py
+++ b/gramps/gui/widgets/cellrenderertextedit.py
@@ -1,0 +1,70 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2017      Paul Culley
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+#------------------------------------------------------------------------
+#
+# Python Modules
+#
+#------------------------------------------------------------------------
+from gi.repository import Gdk
+from gi.repository import Gtk
+
+
+#------------------------------------------------------------------------
+#
+# Gramps Modules
+#
+#------------------------------------------------------------------------
+class CellRendererTextEdit(Gtk.CellRendererText):
+    """ To be used where you normally use Gtk.CellRendererText and you want to
+    avoid losing the text if the user clicks outside the cell (Like an 'OK'
+    button. """
+
+    __gtype_name__ = 'CellRendererTextEdit'
+
+    def __init__(self):
+        Gtk.CellRendererText.__init__(self)
+
+    def do_start_editing(
+            self, event, treeview, path, background_area, cell_area, flags):
+        if not self.get_property('editable'):
+            return
+        entry = Gtk.Entry()
+        entry.set_has_frame(False)
+        xalign, yalign = self.get_alignment()
+        entry.set_alignment(xalign)
+        entry.set_width_chars(5)
+        entry.set_text(self.get_property("text"))  # get original cell text
+        entry.add_events(Gdk.EventMask.FOCUS_CHANGE_MASK)
+        entry.connect('focus-out-event', self.focus_out, path)
+        entry.connect('key-press-event', self._key_press)
+        entry.show()
+        return entry
+
+    def focus_out(self, entry, event, path):
+        self.emit('edited', path, entry.get_text())
+        return False
+
+    def _key_press(self, entry, event):
+        if event.type == Gdk.EventType.KEY_PRESS:
+            if event.keyval == Gdk.KEY_Escape:
+                # get original cell text
+                entry.set_text(self.get_property("text"))
+        return False

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -431,6 +431,7 @@ gramps/gui/views/treemodels/test/node_test.py
 #
 gramps/gui/widgets/__init__.py
 gramps/gui/widgets/basicentry.py
+gramps/gui/widgets/cellrenderertextedit.py
 gramps/gui/widgets/dateentry.py
 gramps/gui/widgets/fanchart2way.py
 gramps/gui/widgets/fanchartdesc.py


### PR DESCRIPTION
While looking at another problem I ran into a technique that allowed me to fix an annoyance I tried to fix previously, without requiring another dialog, which was considered the wrong way to fix this.  So here is another take at getting this corrected.

Issues fixed:
* Typing a surname 'Multiple Surnames' box, followed by mouse click anywhere but in the 'Multiple Surnames' box (like the 'OK' button) lost the typed surname.  Annoying to mouse users.  Fixes [#9868](https://gramps-project.org/bugs/view.php?id=9868), [#6828](https://gramps-project.org/bugs/view.php?id=6828), [#6257](https://gramps-project.org/bugs/view.php?id=6257)  This was done by creating my own CellRendererTextEdit class, which was the same as the original Gtk class except that it saved the data on focus-out instead of tossing it out.

* Changes made in the person editor 'Multiple Surnames' box did not appear in the 'Preferred name', unlike other changes. Two cases, name changes, and order of names, needed different fixes.  Fixes [#10254](https://gramps-project.org/bugs/view.php?id=10254), 

* If shrunk to the minimum size, the 'Primary' field of the Person Editor 'Multiple Surnames' box was partly cut off.  If shrunk to the minimum size, the 'Primary' field of the Name Editor 'Family Names' box was almost completely cut off.
For that one I adjusted the 'Multiple Surnames' box for better fitting when the windows are resized. This was done by making the 'Surname' field in the box the one that changes with overall window size. The user can still change the other field sizes by adjusting the column breaks in the header.

* While editing a cell, the edit box would expand beyond the cell size, sometimes even going outside of the dialog visible area (Try editing a prefix with a minimum size Person or Surname editor dialog).  Some changes to the underlying Gtk.Entry size (set_width_chars) made the editing stay confined to the cells.

Three separate commits, the first two in their own commit, the sizing changes in a single commit, dependent on the first one.

