### PR TITLE
Add Garbage collection after tools/reports

### DIFF
--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -39,6 +39,7 @@ import time
 import datetime
 from io import StringIO
 import posixpath
+import gc
 
 #-------------------------------------------------------------------------
 #
@@ -1766,6 +1767,7 @@ def run_plugin(pdata, dbstate, uistate):
                       name=pdata.id,
                       category=pdata.category,
                       callback=dbstate.db.request_rebuild)
+    gc.collect(2)
 
 def make_plugin_callback(pdata, dbstate, uistate):
     """


### PR DESCRIPTION
Fixes [#10287](https://gramps-project.org/bugs/view.php?id=10287)

User noted that Gramps was using a lot of memory after running Narrative Web, and that running multiple times made it worse.  Doing a forced gc after all reports/tools appears to reduce the issue.