### PR TITLE
Fix Book XML handler to deal with unusual characters in Book name

### DIFF
--- a/gramps/gen/plug/report/_book.py
+++ b/gramps/gen/plug/report/_book.py
@@ -495,14 +495,14 @@ class BookList:
         """
         Saves the current BookList to the associated file.
         """
-        with open(self.file, "w") as b_f:
+        with open(self.file, "w", encoding="utf-8") as b_f:
             b_f.write("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n")
             b_f.write('<booklist>\n')
             for name in sorted(self.bookmap): # enable a diff of archived copies
                 book = self.get_book(name)
-                dbname = book.get_dbname()
+                dbname = escape(book.get_dbname())
                 b_f.write('  <book name="%s" database="%s">'
-                          '\n' % (name, dbname))
+                          '\n' % (escape(name), dbname))
                 for item in book.get_item_list():
                     b_f.write('    <item name="%s" '
                               'trans_name="%s">\n' % (
@@ -578,8 +578,15 @@ class BookList:
         try:
             parser = make_parser()
             parser.setContentHandler(BookParser(self, self.dbase))
-            with open(self.file) as the_file:
-                parser.parse(the_file)
+            # bug 10387; XML should be utf8, but was not previously saved
+            # that way.  So try to read utf8, if fails, try with system
+            # encoding.  Only an issue on non-utf8 systems.
+            try:
+                with open(self.file, encoding="utf-8") as the_file:
+                    parser.parse(the_file)
+            except UnicodeDecodeError:
+                with open(self.file) as the_file:
+                    parser.parse(the_file)
         except (IOError, OSError, ValueError, SAXParseException, KeyError,
                 AttributeError):
             LOG.debug("Failed to parse book list", exc_info=True)

--- a/gramps/gen/plug/report/_book.py
+++ b/gramps/gen/plug/report/_book.py
@@ -566,7 +566,7 @@ class BookList:
                               '\n' % book.get_format_name())
                 if book.get_output():
                     b_f.write('    <output name="%s"/>'
-                              '\n' % book.get_output())
+                              '\n' % escape(book.get_output()))
                 b_f.write('  </book>\n')
 
             b_f.write('</booklist>\n')

--- a/gramps/gui/plug/report/_bookdialog.py
+++ b/gramps/gui/plug/report/_bookdialog.py
@@ -684,7 +684,7 @@ class BookSelector(ManagedWindow):
             old_margins = self.book.get_margins()
             old_format_name = self.book.get_format_name()
             old_output = self.book.get_output()
-            BookDialog(self.dbstate, self.uistate, self.book, BookOptions)
+            BookDialog(self.dbstate, self.uistate, self.book, BookOptions, track=self.track)
             new_paper_name = self.book.get_paper_name()
             new_orientation = self.book.get_orientation()
             new_paper_metric = self.book.get_paper_metric()
@@ -918,7 +918,7 @@ class BookDialog(DocReportDialog):
     Create a dialog selecting target, format, and paper/HTML options.
     """
 
-    def __init__(self, dbstate, uistate, book, options):
+    def __init__(self, dbstate, uistate, book, options, track=[]):
         self.format_menu = None
         self.options = options
         self.page_html_added = False
@@ -926,7 +926,7 @@ class BookDialog(DocReportDialog):
         self.title = _('Generate Book')
         self.database = dbstate.db
         DocReportDialog.__init__(self, dbstate, uistate, options,
-                                 'book', self.title)
+                                 'book', self.title, track=track)
         self.options.options_dict['bookname'] = self.book.get_name()
 
         response = self.window.run()

--- a/gramps/gui/plug/report/_docreportdialog.py
+++ b/gramps/gui/plug/report/_docreportdialog.py
@@ -63,7 +63,7 @@ class DocReportDialog(ReportDialog):
     dialogs for docgen derived reports.
     """
 
-    def __init__(self, dbstate, uistate, option_class, name, trans_name):
+    def __init__(self, dbstate, uistate, option_class, name, trans_name, track=[]):
         """Initialize a dialog to request that the user select options
         for a basic *stand-alone* report."""
 
@@ -72,7 +72,7 @@ class DocReportDialog(ReportDialog):
         self.css = PLUGMAN.process_plugin_data('WEBSTUFF')
         self.dbname = dbstate.db.get_dbname()
         ReportDialog.__init__(self, dbstate, uistate, option_class,
-                              name, trans_name)
+                              name, trans_name, track=track)
 
         self.basedocname = None # keep pylint happy
         self.css_filename = None


### PR DESCRIPTION
Fixes #10387
Three issues;
1) Book name could have legal characters that messed up the html ('&')
2) Book could have characters that could not be stored in the system default encoding.  The latter issue is more likely in Windows with its 'code page' default encoding.
3) 'Generate Book' dialog had a bad transient parent so it sometimes ended up under the main book dialog.
4) Book report name could have legal characters that messed up the html ('&')

First commit deals with first two issues.  Changed book.xml file to be stored utf8, and added necessary 'escape'.  To deal with older previously stored non-utf8 book.xml, added a check for UnicodeDecodeError, with a retry using system default encoding.

Second commit deals with bad transient parent.

Third commit fixes bad report name.