### PR TITLE
DescendantTree report; fix crashes and Title spacing

### DIFF
--- a/gramps/plugins/drawreport/descendtree.py
+++ b/gramps/plugins/drawreport/descendtree.py
@@ -468,8 +468,9 @@ class RecurseDown:
         #calculate the text.
         myself.calc_text(self.database, indi_handle, fams_handle)
 
-        myself.add_mark(self.database,
-                        self.database.get_person_from_handle(indi_handle))
+        if indi_handle:
+            myself.add_mark(self.database,
+                            self.database.get_person_from_handle(indi_handle))
 
         self.add_to_col(myself)
 
@@ -692,7 +693,8 @@ class MakePersonTree(RecurseDown):
         family2 = family2_h = None
         if self.do_parents:
             family2_h = center1.get_main_parents_family_handle()
-            family2 = self.database.get_family_from_handle(family2_h)
+            if family2_h:
+                family2 = self.database.get_family_from_handle(family2_h)
 
         mother2_h = father2_h = None
         if family2:

--- a/gramps/plugins/lib/libtreebase.py
+++ b/gramps/plugins/lib/libtreebase.py
@@ -669,7 +669,7 @@ class TitleBox(BoxBase):
             return
         #fix me. width should be the printable area
         self.width = PT2CM(self.doc.string_width(self.font, self.text))
-        self.height = PT2CM(self.font.get_size() * 1.2)
+        self.height = PT2CM(self.font.get_size() * 2)
 
     def _get_names(self, persons, name_displayer):
         """  A helper function that receives a list of persons and


### PR DESCRIPTION
Bug10377 had two issues, crashes, and Title spacing.  Separate commits.