### PR TITLE
Fix view buttons order keeps changing on different startups

### DIFF
--- a/gramps/gen/plug/_pluginreg.py
+++ b/gramps/gen/plug/_pluginreg.py
@@ -1245,8 +1245,7 @@ class PluginRegister:
         """
         Return a list of :class:`PluginData` that are of type ptype
         """
-        return [self.get_plugin(id) for id in
-                set([x.id for x in self.__plugindata if x.ptype == ptype])]
+        return [x for x in self.__plugindata if x.ptype == ptype]
 
     def report_plugins(self, gui=True):
         """
@@ -1355,6 +1354,4 @@ class PluginRegister:
         """
         Return a list of :class:`PluginData` that have load_on_reg == True
         """
-        return [self.get_plugin(id) for id in
-                set([x.id for x in self.__plugindata
-                     if x.load_on_reg == True])]
+        return [x for x in self.__plugindata if x.load_on_reg == True]


### PR DESCRIPTION
Fixes #10391

Root cause, the creation of the plugins view (and other) lists had an intermediate 'set' to store the data.  This was a vestige of an old (no longer allowed) capability to have multiple plugins with the same ID, apparently different versions.  See https://github.com/gramps-project/gramps/commit/12918718f9fe702f41e997cdad983613c87ab386 for the original capability addition.

Currently several places in the code prohibit this, so the 'set' is no longer needed, and it does mess up the repeatability of the plugin order.