### PR TITLE
Fix several intl date displayers for missing parameter.

### DIFF
--- a/gramps/gen/datehandler/_date_de.py
+++ b/gramps/gen/datehandler/_date_de.py
@@ -221,7 +221,7 @@ class DateDisplayDE(DateDisplay):
         )
         # this definition must agree with its "_display_gregorian" method
 
-    def _display_gregorian(self, date_val):
+    def _display_gregorian(self, date_val, **kwargs):
         """
         display gregorian calendar date in different format
         """

--- a/gramps/gen/datehandler/_date_el.py
+++ b/gramps/gen/datehandler/_date_el.py
@@ -155,7 +155,7 @@ class DateDisplayEL(DateDisplay):
         )
         # this definition must agree with its "_display_gregorian" method
 
-    def _display_gregorian(self, date_val):
+    def _display_gregorian(self, date_val, **kwargs):
         """
         display gregorian calendar date in different format
         """

--- a/gramps/gen/datehandler/_date_lt.py
+++ b/gramps/gen/datehandler/_date_lt.py
@@ -185,7 +185,7 @@ class DateDisplayLT(DateDisplay):
         "mmmm-MM-DD (ISO)", "mmmm m. mėnesio diena d.", "Mėn diena, metai")
         # this definition must agree with its "_display_gregorian" method
 
-    def _display_gregorian(self, date_val):
+    def _display_gregorian(self, date_val, **kwargs):
         """
         display gregorian calendar date in different format
         """

--- a/gramps/gen/datehandler/_date_nl.py
+++ b/gramps/gen/datehandler/_date_nl.py
@@ -164,7 +164,7 @@ class DateDisplayNL(DateDisplay):
         )
         # this definition must agree with its "_display_gregorian" method
 
-    def _display_gregorian(self, date_val):
+    def _display_gregorian(self, date_val, **kwargs):
         """
         display gregorian calendar date in different format
         """

--- a/gramps/gen/datehandler/_date_pl.py
+++ b/gramps/gen/datehandler/_date_pl.py
@@ -215,7 +215,7 @@ class DateDisplayPL(DateDisplay):
         "XII"
         )
 
-    def _display_gregorian(self, date_val):
+    def _display_gregorian(self, date_val, **kwargs):
         """
         display gregorian calendar date in different format
         """

--- a/gramps/gen/datehandler/_date_sr.py
+++ b/gramps/gen/datehandler/_date_sr.py
@@ -240,7 +240,7 @@ class DateDisplaySR_Base(DateDisplay):
         "VII", "VIII", "IX", "X", "XI", "XII"
         )
 
-    def _display_gregorian(self, date_val):
+    def _display_gregorian(self, date_val, **kwargs):
         """
         display gregorian calendar date in different format
         """


### PR DESCRIPTION
Fixes #10196

It appears that when the 'inflect' parameter and capability was added to the date displayer, Paul F. did not realize that changes would also have to be made to any _display_gregorian methods as well. I'm not familiar with the purpose of the 'inflect' parameter, but I think we can simply ignore it for those languages that have not already been modified. It appears that we should do like was done for the french version in _date_fr;
change
def _display_gregorian(self, date_val):
to
def _display_gregorian(self, date_val, **kwargs):

This should be forward ported to gramps50 when accepted.