### PR TITLE
Fix Export View to CSV when Unicode characters are present

### DIFF
--- a/gramps/gen/utils/docgen/csvtab.py
+++ b/gramps/gen/utils/docgen/csvtab.py
@@ -31,6 +31,7 @@ import csv
 #
 #-------------------------------------------------------------------------
 from .tabbeddoc import *
+from ...constfunc import win
 
 class CSVTab(TabbedDoc):
 
@@ -48,7 +49,8 @@ class CSVTab(TabbedDoc):
         else:
             self.filename = filename
 
-        self.f = open(self.filename, "w")
+        self.f = open(self.filename, "w",
+                      encoding='utf_8_sig' if win() else 'utf_8')
         self.writer = csv.writer(self.f)
 
     def close(self):


### PR DESCRIPTION
Fixes #10404

Current code opens CSV for write in system code page, which doesn't always cover all Unicode characters.  Changed to utf8, using same strategy as our CSV Exporter, which uses the utf8-BOM for Windows systems (as Microsoft products don't always recognize utf8 without the BOM) and no BOM for Linux systems.

May want to back port to gramps42...