### PR TITLE
Fix Family Lines Graph when 'unknown' places are present

### DIFF
--- a/gramps/plugins/graph/gvfamilylines.py
+++ b/gramps/plugins/graph/gvfamilylines.py
@@ -1072,7 +1072,7 @@ class FamilyLinesReport(Report):
 
     def get_event_place(self, event):
         """ get the place of the event """
-        place_text = None
+        place_text = ''
         place_handle = event.get_place_handle()
         if place_handle:
             place = self._db.get_place_from_handle(place_handle)


### PR DESCRIPTION
Fixes #10402

Current code initializes 'place_text' to None; then later on (after potentially setting value to a string) tries to do a string replace on it.  When the place type is 'Unknown' the 'place_text' never is set.  Looking over the code it appears initialization to empty string works just as well; there are several test of the (potential) str value for any value, they should fail with empty str as well as None.

Works with Example db and bug reporter's source Gedcom file.,