### PR TITLE
Accels

### DIFF
--- a/gramps/gui/dialog.py
+++ b/gramps/gui/dialog.py
@@ -35,6 +35,7 @@ _LOG = logging.getLogger(".dialog")
 #-------------------------------------------------------------------------
 from gi.repository import GObject
 from gi.repository import Gtk
+from gi.repository import Gdk
 from gi.repository import GdkPixbuf
 
 #-------------------------------------------------------------------------
@@ -46,6 +47,7 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 from gramps.gen.const import ICON, URL_BUGHOME
 from gramps.gen.config import config
+from gramps.gen.constfunc import is_quartz
 from .glade import Glade
 from .display import display_url
 
@@ -506,6 +508,12 @@ def main(args):
     win = Gtk.Window()
     win.set_title('Dialog test window')
     win.set_position(Gtk.WindowPosition.CENTER)
+    #Set the mnemonic modifier on Macs to alt-ctrl so that it
+    #doesn't interfere with the extended keyboard, see
+    #https://gramps-project.org/bugs/view.php?id=6943
+    if is_quartz():
+        win.set_mnemonic_modifier(
+            Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.MOD1_MASK)
     def cb(window, event):
         Gtk.main_quit()
     win.connect('delete-event', cb)

--- a/gramps/gui/glade.py
+++ b/gramps/gui/glade.py
@@ -46,6 +46,7 @@ from gi.repository import Gtk
 #
 #------------------------------------------------------------------------
 from gramps.gen.const import GLADE_DIR, GRAMPS_LOCALE as glocale
+from gramps.gen.constfunc import is_quartz
 
 #------------------------------------------------------------------------
 #
@@ -142,11 +143,19 @@ class Glade(Gtk.Builder):
         # toplevel is given
         if toplevel:
             loadlist = [toplevel] + also_load
-            self.add_objects_from_file(path, loadlist)
+            with open(path, 'r', encoding='utf-8') as builder_file:
+                data = builder_file.read().replace('\n', '')
+                if is_quartz():
+                    data = data.replace('GDK_CONTROL_MASK', 'GDK_META_MASK')
+                self.add_objects_from_string(data, loadlist)
             self.__toplevel = self.get_object(toplevel)
         # toplevel not given
         else:
-            self.add_from_file(path)
+            with open(path, 'r', encoding='utf-8') as builder_file:
+                data = builder_file.read().replace('\n', '')
+                if is_quartz():
+                    data = data.replace('GDK_CONTROL_MASK', 'GDK_META_MASK')
+                self.add_from_string(data)
             # first, use filename as possible toplevel widget name
             self.__toplevel = self.get_object(filename.rpartition('.')[0])
 

--- a/gramps/gui/managedwindow.py
+++ b/gramps/gui/managedwindow.py
@@ -38,6 +38,7 @@ from io import StringIO
 #
 #-------------------------------------------------------------------------
 from gi.repository import Gtk
+from gi.repository import Gdk
 
 #-------------------------------------------------------------------------
 #
@@ -47,6 +48,7 @@ from gi.repository import Gtk
 from gramps.gen.const import GLADE_FILE, ICON
 from gramps.gen.errors import WindowActiveError
 from gramps.gen.config import config
+from gramps.gen.constfunc import is_quartz
 from .glade import Glade
 
 #-------------------------------------------------------------------------
@@ -488,6 +490,13 @@ class ManagedWindow:
             #closing the Gtk.Window must also close ManagedWindow
             self.window = window
             self.window.connect('delete-event', self.close)
+        #Set the mnemonic modifier on Macs to alt-ctrl so that it
+        #doesn't interfere with the extended keyboard, see
+        #https://gramps-project.org/bugs/view.php?id=6943
+        if is_quartz():
+            self.window.set_mnemonic_modifier(
+                Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.MOD1_MASK)
+
         if self.modal:
             self.window.set_modal(True)
         # The following makes sure that we only have one modal window open;

--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -55,6 +55,7 @@ LOG = logging.getLogger(".")
 #
 #-------------------------------------------------------------------------
 from gi.repository import Gtk
+from gi.repository import Gdk
 
 #-------------------------------------------------------------------------
 #
@@ -394,7 +395,12 @@ class ViewManager(CLIManager):
         self.window.set_icon_from_file(ICON)
         self.window.set_default_size(width, height)
         self.window.move(horiz_position, vert_position)
-
+        #Set the mnemonic modifier on Macs to alt-ctrl so that it
+        #doesn't interfere with the extended keyboard, see
+        #https://gramps-project.org/bugs/view.php?id=6943
+        if is_quartz():
+            self.window.set_mnemonic_modifier(
+                Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.MOD1_MASK)
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.window.add(vbox)
         hpane = Gtk.Paned()

--- a/gramps/gui/widgets/validatedmaskedentry.py
+++ b/gramps/gui/widgets/validatedmaskedentry.py
@@ -52,7 +52,7 @@ from gi.repository import Pango
 #-------------------------------------------------------------------------
 from gramps.gen.errors import MaskError, ValidationError, WindowActiveError
 from .undoableentry import UndoableEntry
-
+from gramps.gen.constfunc import is_quartz
 #============================================================================
 #
 # MaskedEntry and ValidatableMaskedEntry copied and merged from the Kiwi
@@ -1248,6 +1248,12 @@ def main(args):
     win = Gtk.Window()
     win.set_title('ValidatableMaskedEntry test window')
     win.set_position(Gtk.WindowPosition.CENTER)
+    #Set the mnemonic modifier on Macs to alt-ctrl so that it
+    #doesn't interfere with the extended keyboard, see
+    #https://gramps-project.org/bugs/view.php?id=6943
+    if is_quartz():
+        win.set_mnemonic_modifier(
+            Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.MOD1_MASK)
     def cb(window, event):
         Gtk.main_quit()
     win.connect('delete-event', cb)


### PR DESCRIPTION
This is a two-fer: It fixes both [bug 6943](https://gramps-project.org/bugs/view.php?id=6943) and the part of the fix to [10231](https://gramps-project.org/bugs/view.php?id=10231) that had to be reverted.

With the first commit mnemonics are operated with ctrl-alt instead of just alt so that they don't interfere with typing non-ascii characters. The second changes all instances of GDK_CONTROL_MASK to GDK_META_MASK (which is what Gdk maps the command key to in the Quartz backend).  That works on all versions of Gtk3, unlike GDK_MODIFIER_INTENT_PRIMARY_MASK.. and saves a little indirection in the Gtk code in the process. (Part of the motivation is that I've had it shoved home yet again that Gtk+ > 3.14 doesn't seem to get along well with PyGobject on MacOS, see [bug 10185](https://gramps-project.org/bugs/view.php?id=10185) and friends.)