### PR TITLE
Fix Place Tree view for proper display after filter cleared.

### DIFF
--- a/gramps/gui/filters/sidebar/_placesidebarfilter.py
+++ b/gramps/gui/filters/sidebar/_placesidebarfilter.py
@@ -121,7 +121,7 @@ class PlaceSidebarFilter(SidebarFilter):
         self.filter_code.set_text('')
         self.filter_enclosed.set_text('')
         self.filter_note.set_text('')
-        self.filter_within.set_value(0, 0)
+        self.filter_within.set_value('', 0)
         self.ptype.get_child().set_text('')
         self.tag.set_active(0)
         self.generic.set_active(0)
@@ -133,7 +133,7 @@ class PlaceSidebarFilter(SidebarFilter):
         code = str(self.filter_code.get_text()).strip()
         enclosed = str(self.filter_enclosed.get_text()).strip()
         note = str(self.filter_note.get_text()).strip()
-        within = self.filter_within.get_value()
+        within = self.filter_within.get_value()[0]
         regex = self.filter_regex.get_active()
         tag = self.tag.get_active() > 0
         gen = self.generic.get_active() > 0


### PR DESCRIPTION
Fixes #10416
The recent addition of the 'Within' filter for Places caused the get_filter method to not recognize when a filter had been reset.  As a result, once a filter was used, it continued to be used even though all the parameters were cleared.  During tree build, the presence of the filter changes the algorithm so that the tree doesn't get constructed right.  (Which may be a different bug).

This fixes the sidebar filter so that when reset, no filter is used at all.

I also cleared the 'Within' back to an empty string, rather than '0' as the '0' was inconsistent with the default, never used setting, which was an empty string.