### PR TITLE
Fix testsuite failure when build happens out of the source tree.

### DIFF
--- a/gramps/gen/filters/rules/test/person_rules_test.py
+++ b/gramps/gen/filters/rules/test/person_rules_test.py
@@ -17,7 +17,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-from build.lib.gramps.gen.filters.rules.person._matchidof import MatchIdOf
+from ....filters.rules.person._matchidof import MatchIdOf
 
 """
 Unittest that tests person-specific filter rules


### PR DESCRIPTION
Build path was hardcoded in an import in:
gramps/gen/filters/rules/test/person_rules_test.py

Fixes #10450.