### PR TITLE
Fix export gpkg when media files have fractional timestamps.

### DIFF
--- a/gramps/plugins/export/exportpkg.py
+++ b/gramps/plugins/export/exportpkg.py
@@ -86,6 +86,12 @@ def writeData(database, filename, user, option_box=None):
     writer = PackageWriter(database, filename, user)
     return writer.export()
 
+
+def fix_mtime(tarinfo):
+    """ this fixes a bug in the python tarfile GNU_FORMAT where if mtime has
+    a fractional component, it fails."""
+    tarinfo.mtime = int(tarinfo.mtime)
+    return tarinfo
 #-------------------------------------------------------------------------
 #
 # PackageWriter
@@ -186,7 +192,7 @@ class PackageWriter:
             filename = media_path_full(self.db, mobject.get_path())
             archname = str(mobject.get_path())
             if os.path.isfile(filename) and os.access(filename, os.R_OK):
-                archive.add(filename, archname)
+                archive.add(filename, archname, filter=fix_mtime)
 
         # Write XML now
         g = BytesIO()


### PR DESCRIPTION
Fixes [#10424](https://gramps-project.org/bugs/view.php?id=10424)
I'm pretty sure this is a Python tarfile error.  Found by analyzing the code. If the media file has one or more timestamps with fractional seconds, it will fail. Seems that the default GNU_FORMAT code doesn't convert the time values to int.

Changed fix from using PAX_FORMAT back to GNU_FORMAT, and adding filter per @Nick-Hall suggestion.

May want to backport to 4.2.x if we are going to have another version.