### PR TITLE
Fix multi-page Graph output to pdf with filenames containg spaces

### DIFF
--- a/gramps/gen/plug/docgen/graphdoc.py
+++ b/gramps/gen/plug/docgen/graphdoc.py
@@ -988,7 +988,7 @@ class GVPdfGsDoc(GVDocBase):
             os.system(command)
         # Merge pieces to single multipage PDF ;
         command = '%s -q -dBATCH -dNOPAUSE '\
-            '-sOUTPUTFILE=%s -r72 -sDEVICE=pdfwrite %s '\
+            '-sOUTPUTFILE="%s" -r72 -sDEVICE=pdfwrite %s '\
             % (_GS_CMD, self._filename, ' '.join(list_of_pieces))
         os.system(command)
 


### PR DESCRIPTION
Fixes [#10470](https://gramps-project.org/bugs/view.php?id=10470)

Should be backported to gramps42 when accepted.