### PR TITLE
Fix ImportError & update API docs year 2018

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Gramps'
-copyright = '2017, The Gramps Project'
+copyright = '2001-2018, The Gramps Project'
 author = 'Donald N. Allingham'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/gen/gen_db.rst
+++ b/docs/gen/gen_db.rst
@@ -46,7 +46,7 @@ Generic
 
 DummyDb
 ====================================
-.. automodule:: gramps.plugins.db.dummydb
+.. automodule:: gramps.gen.db.dummydb
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
- Fixes ImportError: No module named 'gramps.plugins.db.dummydb'
- Update Copyright to 2018