### PR TITLE
Fix Book TOC and Index numbering and placement

### DIFF
--- a/gramps/plugins/docgen/cairodoc.py
+++ b/gramps/plugins/docgen/cairodoc.py
@@ -146,6 +146,8 @@ class CairoDocgen(libcairodoc.CairoDoc):
                     if offset > 0:
                         self.__increment_pages(toc, index, toc_page, offset)
                         rebuild_required = True
+                    if index_page and toc_page < index_page:
+                        index_page += offset
                 else:
                     toc_pages = []
 
@@ -157,6 +159,8 @@ class CairoDocgen(libcairodoc.CairoDoc):
                     if offset > 0:
                         self.__increment_pages(toc, index, index_page, offset)
                         rebuild_required = True
+                    if toc_page and toc_page > index_page:
+                        toc_page += offset
                 else:
                     index_pages = []
 
@@ -200,6 +204,7 @@ class CairoDocgen(libcairodoc.CairoDoc):
         """
         Increment the page numbers in the table of contents and index.
         """
+        start_page += 1  # toc/index numbers start at 1
         for n, value in enumerate(toc):
             page_nr = toc[n][1]
             toc[n][1] = page_nr + (offset if page_nr > start_page else 0)


### PR DESCRIPTION
Fixes [#10452](https://gramps-project.org/bugs/view.php?id=10452)

Initial bug states that the TOC page number for the TOC itself was wrong if the TOC had more than one page.  Was a comparison problem with one based page numbers and internal zero based page index.

During testing I noted that the Index, when used, overwrote part of the report.  This was because the Index's page index was not being adjusted for multi-page TOC (and vise versa).

Both of these worked fine with TOC/Index smaller than one page, it was only when the first encountered was larger than a single page that the bug showed up.