### PR TITLE
Fix Clipboard for right-click on empty clipboard

### DIFF
--- a/gramps/gui/clipboard.py
+++ b/gramps/gui/clipboard.py
@@ -1540,6 +1540,8 @@ class MultiTreeView(Gtk.TreeView):
         if is_right_click(event):
             selection = widget.get_selection()
             store, paths = selection.get_selected_rows()
+            if not paths:
+                return
             tpath = paths[0] if len(paths) > 0 else None
             node = store.get_iter(tpath) if tpath else None
             o = None


### PR DESCRIPTION
Issues #10473

Bug 10473 contains two problems, this fixes the right-click on an empty clipboard (which popped up a blank menu).

The other bug was for the **addon** Clipboard **Gramplet** and is addressed in a PR https://github.com/gramps-project/addons-source/pull/119 for that addons-source.