### PR TITLE
Fix Fan Chart(s) so they don't crash when opened as last view

### DIFF
--- a/gramps/gui/widgets/fanchart.py
+++ b/gramps/gui/widgets/fanchart.py
@@ -93,6 +93,11 @@ from gramps.gen.const import (
 _ = glocale.translation.gettext
 from ..utilscairo import warpPath
 
+# following are used in name_displayer format def
+# (must not conflict with standard defs)
+TWO_LINE_FORMAT_1 = 100
+TWO_LINE_FORMAT_2 = 101
+
 #-------------------------------------------------------------------------
 #
 # FanChartBaseWidget
@@ -120,8 +125,12 @@ class FanChartBaseWidget(Gtk.DrawingArea):
         self.last_x, self.last_y = None, None
         self.fontdescr = "Sans"
         self.fontsize = 8
-        self.twolineformat_nums=(name_displayer.add_name_format('fanchart_name_line1', '%l'),
-                                 name_displayer.add_name_format('fanchart_name_line2', '%f %s'))
+        # add parts of a two line name format to the displayer.  We add them
+        # as standard names, but set them inactive so they don't show up in
+        # name editor or selector.
+        name_displayer.set_name_format(
+            [(TWO_LINE_FORMAT_1, 'fanchart_name_line1', '%l', False),
+             (TWO_LINE_FORMAT_2, 'fanchart_name_line2', '%f %s', False)])
         self.connect("button_release_event", self.on_mouse_up)
         self.connect("motion_notify_event", self.on_mouse_move)
         self.connect("button-press-event", self.on_mouse_down)
@@ -170,10 +179,6 @@ class FanChartBaseWidget(Gtk.DrawingArea):
         #(re)compute everything
         self.reset()
         self.set_size_request(120, 120)
-
-    def __del__(self):
-        for num in self.twolineformat_nums:
-            name_displayer.del_name_format(num)
 
     def reset(self):
         """
@@ -578,8 +583,8 @@ class FanChartBaseWidget(Gtk.DrawingArea):
                        fontcolor, bold)
         else:
             text=name_displayer.display(person)
-            text_line1=name_displayer.display_format(person,self.twolineformat_nums[0])
-            text_line2=name_displayer.display_format(person,self.twolineformat_nums[1])
+            text_line1=name_displayer.display_format(person, TWO_LINE_FORMAT_1)
+            text_line2=name_displayer.display_format(person, TWO_LINE_FORMAT_2)
             if draw_radial:
                 split_frac_line1=0.5
                 flipped = can_flip and ((math.degrees((start+stop)/2.0) + self.rotate_value - 90) % 360 < 179 and self.flipupsidedownname)


### PR DESCRIPTION
Fixes [#10440](https://gramps-project.org/bugs/view.php?id=10440)
The 10440 problem seems to arise because when a fan chart "view" is remembered as the last view, and restarted, the code calls FanChartBaseWidget's `__init__` and that adds two **custom** formats to the name displayer.

And then, CLIManager's open_activate is called, which calls CLIManager's _read_recent_file, which calls CLIManager's _post_load_newdb_nongui, which calls name_displayer.clear_custom_formats() and that clears the two name formats which were just added.

So they aren't there when FanChartBaseWidget's draw_person_text calls name_displayer.display_format
with the custom formats.

I decided to add the two formats as standard formats instead, but marked them as 'inactive' so they would not appear in the name editor or name formats lists.  That way they are not cleared by the CLIManager before they are used.

Hopefully, users are not expecting to be able to edit these formats...