### PR TITLE
Fix Fan charts for scrolling/resizing of window; bad rendering

### DIFF
--- a/gramps/gui/widgets/fanchart.py
+++ b/gramps/gui/widgets/fanchart.py
@@ -120,6 +120,7 @@ class FanChartBaseWidget(Gtk.DrawingArea):
         self.dbstate = dbstate
         self.uistate = uistate
         self.translating = False
+        self.surface = None
         self.goto = None
         self.on_popup = callback_popup
         self.last_x, self.last_y = None, None
@@ -248,7 +249,15 @@ class FanChartBaseWidget(Gtk.DrawingArea):
         """
         callback to draw the fanchart
         """
-        raise NotImplementedError
+        if self.surface:
+            cr.set_source_surface(self.surface, 0, 0)
+            cr.paint()
+
+    def prt_draw(self, widget, cr, scale=1.0):
+        """
+        method to allow direct drawing to cairo context for printing
+        """
+        self.draw(cr=cr, scale=scale)
 
     def people_generator(self):
         """
@@ -749,7 +758,7 @@ class FanChartBaseWidget(Gtk.DrawingArea):
         return lambda x, y: \
             (rho(y) * math.cos(phi(x)), rho(y) * math.sin(phi(x)))
 
-    def draw_gradient_legend(self, cr, widget, halfdist):
+    def draw_gradient_legend(self, cr, halfdist):
         gradwidth = 10
         gradheight = 10
         starth = 15
@@ -924,6 +933,7 @@ class FanChartBaseWidget(Gtk.DrawingArea):
             diff_angle = (end_angle - start_angle) % (math.pi * 2.0)
             self.rotate_value -= math.degrees(diff_angle)
             self.last_x, self.last_y = event.x, event.y
+        self.draw()
         self.queue_draw()
         return True
 
@@ -954,8 +964,12 @@ class FanChartBaseWidget(Gtk.DrawingArea):
             return True
         if self.translating:
             self.translating = False
+        else:
+            self.center_delta_xy = -1, 0
+            self.center_xy = self.center_xy_from_delta()
 
         self.last_x, self.last_y = None, None
+        self.draw()
         self.queue_draw()
         return True
 
@@ -1207,27 +1221,39 @@ class FanChartWidget(FanChartBaseWidget):
             (person, parents, child, userdata) = childdata
             yield (person, userdata)
 
-    def on_draw(self, widget, cr, scale=1.):
+    def draw(self, cr=None, scale=1.0):
         """
         The main method to do the drawing.
-        If widget is given, we assume we draw in GTK3 and use the allocation.
-        To draw raw on the cairo context cr, set widget=None.
+        If cr is given, we assume we draw draw raw on the cairo context cr
+        To draw in GTK3 and use the allocation, set cr=None.
+        Note: when drawing for display, to counter a Gtk issue with scrolling
+        or resizing the drawing window, we draw on a surface, then copy to the
+        drawing context when the Gtk 'draw' signal arrives.
         """
         # first do size request of what we will need
         halfdist = self.halfdist()
-        if widget:
+        if not cr:  # Display
             if self.form == FORM_CIRCLE:
-                self.set_size_request(2 * halfdist, 2 * halfdist)
+                size_w = size_h = 2 * halfdist
             elif self.form == FORM_HALFCIRCLE:
-                self.set_size_request(2 * halfdist, halfdist + self.CENTER + PAD_PX)
+                size_w = 2 * halfdist
+                size_h = halfdist + self.CENTER + PAD_PX
             elif self.form == FORM_QUADRANT:
-                self.set_size_request(halfdist + self.CENTER + PAD_PX, halfdist + self.CENTER + PAD_PX)
+                size_w = size_h = halfdist + self.CENTER + PAD_PX
 
-        cr.scale(scale, scale)
-        if widget:
+            size_w_a = self.get_allocated_width()
+            size_h_a = self.get_allocated_height()
+            self.set_size_request(max(size_w, size_w_a), max(size_h, size_h_a))
+            size_w = self.get_allocated_width()
+            size_h = self.get_allocated_height()
+            self.surface = cairo.ImageSurface(cairo.FORMAT_ARGB32,
+                                              size_w, size_h)
+            cr = cairo.Context(self.surface)
             self.center_xy = self.center_xy_from_delta()
             cr.translate(*self.center_xy)
-        else:
+        else:  # printing
+            self.center_xy = halfdist, halfdist
+            cr.scale(scale, scale)
             cr.translate(halfdist, halfdist)
 
         cr.save()
@@ -1262,7 +1288,7 @@ class FanChartWidget(FanChartBaseWidget):
             if child and self.childring:
                 self.draw_childring(cr)
         if self.background in [BACKGROUND_GRAD_AGE, BACKGROUND_GRAD_PERIOD]:
-            self.draw_gradient_legend(cr, widget, halfdist)
+            self.draw_gradient_legend(cr, halfdist)
 
     def draw_childring(self, cr):
         cr.move_to(TRANSLATE_PX + CHILDRING_WIDTH, 0)
@@ -1460,6 +1486,7 @@ class FanChartWidget(FanChartBaseWidget):
         # no drag occured, expand or collapse the section
         self.toggle_cell_state(self._mouse_click_cell_address)
         self._mouse_click = False
+        self.draw()
         self.queue_draw()
 
 class FanChartGrampsGUI:
@@ -1494,6 +1521,7 @@ class FanChartGrampsGUI:
                         self.grad_start, self.grad_end,
                         self.generic_filter, self.alpha_filter, self.form)
         self.fan.reset()
+        self.fan.draw()
         self.fan.queue_draw()
 
     def on_popup(self, obj, event, person_handle, family_handle=None):

--- a/gramps/plugins/view/fanchart2wayview.py
+++ b/gramps/plugins/view/fanchart2wayview.py
@@ -256,7 +256,8 @@ class FanChart2WayView(fanchart2way.FanChart2WayGrampsGUI, NavigationView):
         widthpx = 2 * self.fan.halfdist()
         heightpx = widthpx
 
-        prt = CairoPrintSave(widthpx, heightpx, self.fan.on_draw, self.uistate.window)
+        prt = CairoPrintSave(widthpx, heightpx, self.fan.prt_draw,
+                             self.uistate.window)
         prt.run()
 
     def on_childmenu_changed(self, obj, person_handle):

--- a/gramps/plugins/view/fanchartdescview.py
+++ b/gramps/plugins/view/fanchartdescview.py
@@ -256,7 +256,8 @@ class FanChartDescView(fanchartdesc.FanChartDescGrampsGUI, NavigationView):
             heightpx = heightpx / 2 + self.fan.CENTER + fanchart.PAD_PX
             widthpx = heightpx
 
-        prt = CairoPrintSave(widthpx, heightpx, self.fan.on_draw, self.uistate.window)
+        prt = CairoPrintSave(widthpx, heightpx, self.fan.prt_draw,
+                             self.uistate.window)
         prt.run()
 
     def on_childmenu_changed(self, obj, person_handle):

--- a/gramps/plugins/view/fanchartview.py
+++ b/gramps/plugins/view/fanchartview.py
@@ -252,7 +252,8 @@ class FanChartView(fanchart.FanChartGrampsGUI, NavigationView):
             heightpx = heightpx / 2 + self.fan.CENTER + fanchart.PAD_PX
             widthpx = heightpx
 
-        prt = CairoPrintSave(widthpx, heightpx, self.fan.on_draw, self.uistate.window)
+        prt = CairoPrintSave(widthpx, heightpx, self.fan.prt_draw,
+                             self.uistate.window)
         prt.run()
 
     def on_childmenu_changed(self, obj, person_handle):


### PR DESCRIPTION
Fixes [#10381](https://gramps-project.org/bugs/view.php?id=10381)
During fan chart scrolling/resizing when less than 1/2 of the figure was visible, Gtk was having a lot of trouble getting the whole chart rendered.  Mostly text was missing, although sometimes stripes of the chart were slightly offset from each other.  Did not seem to be related to Gtk version (Issue on v3.18.9 and 3.22.28).  It really seemed to be a Gtk bug though.  This following figure shows up the problem pretty well.

![peek 202018-01-21 2014-28](https://user-images.githubusercontent.com/18122203/37007632-e871c334-20a3-11e8-8ff5-c2d9f9a04d5e.gif)


I think what is happening is that the charts take too long to draw, and somehow get interrupted by Gtk, or perhaps there is a problem with their caching or double-buffering algorithms.

I spent a day trying various fixes but ended up by changing our drawing method.  Instead of drawing in detail when the 'draw' signal arrives, I performed the draw to an ImageSurface when something changed on the Gramps side.  When the 'draw' signal arrived (as it does when scrolling etc.), I copied the surface to the cairo context.  This seems to have stopped the issue, with the added benefit that scrolling or resizing the window is much smoother now.

During testing I found another minor issue; the legend was not getting located properly when the chart was printed if the chart had been re-centered by the user, because the centering data was not getting reset during printing. 