### PR TITLE
Allow Copying of text fields for Details tabs

### DIFF
--- a/gramps/plugins/gramplet/persondetails.py
+++ b/gramps/plugins/gramplet/persondetails.py
@@ -62,6 +62,7 @@ class PersonDetails(Gramplet):
         self.photo.show()
         self.name = Gtk.Label(halign=Gtk.Align.START)
         self.name.override_font(Pango.FontDescription('sans bold 12'))
+        self.name.set_selectable(True)
         vbox.pack_start(self.name, fill=True, expand=False, padding=7)
         self.grid = Gtk.Grid(orientation=Gtk.Orientation.VERTICAL)
         self.grid.set_column_spacing(10)
@@ -77,8 +78,10 @@ class PersonDetails(Gramplet):
         """
         label = Gtk.Label(label=title + COLON, halign=Gtk.Align.END,
                           valign=Gtk.Align.START)
+        label.set_selectable(True)
         label.show()
         value = Gtk.Label(label=value, halign=Gtk.Align.START)
+        value.set_selectable(True)
         value.show()
         self.grid.add(label)
         self.grid.attach_next_to(value, label, Gtk.PositionType.RIGHT, 1, 1)
@@ -176,6 +179,7 @@ class PersonDetails(Gramplet):
         """
         label = Gtk.Label(label='')
         label.override_font(Pango.FontDescription('sans 4'))
+        label.set_selectable(True)
         label.show()
         self.grid.add(label)
 

--- a/gramps/plugins/gramplet/placedetails.py
+++ b/gramps/plugins/gramplet/placedetails.py
@@ -56,6 +56,7 @@ class PlaceDetails(Gramplet):
         self.photo = Photo(self.uistate.screen_height() < 1000)
         self.title = Gtk.Label(halign=Gtk.Align.START)
         self.title.override_font(Pango.FontDescription('sans bold 12'))
+        self.title.set_selectable(True)
         vbox.pack_start(self.title, False, True, 7)
         self.grid = Gtk.Grid(orientation=Gtk.Orientation.VERTICAL)
         self.grid.set_column_spacing(10)
@@ -71,8 +72,10 @@ class PlaceDetails(Gramplet):
         """
         label = Gtk.Label(label=title + COLON, halign=Gtk.Align.END,
                           valign=Gtk.Align.START)
+        label.set_selectable(True)
         label.show()
         value = Gtk.Label(label=value, halign=Gtk.Align.START)
+        value.set_selectable(True)
         value.show()
         self.grid.add(label)
         self.grid.attach_next_to(value, label, Gtk.PositionType.RIGHT, 1, 1)
@@ -157,6 +160,7 @@ class PlaceDetails(Gramplet):
         """
         label = Gtk.Label(label='')
         label.override_font(Pango.FontDescription('sans 4'))
+        label.set_selectable(True)
         label.show()
         self.grid.add(label)
 

--- a/gramps/plugins/gramplet/repositorydetails.py
+++ b/gramps/plugins/gramplet/repositorydetails.py
@@ -52,6 +52,7 @@ class RepositoryDetails(Gramplet):
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.name = Gtk.Label(halign=Gtk.Align.START)
         self.name.override_font(Pango.FontDescription('sans bold 12'))
+        self.name.set_selectable(True)
         vbox.pack_start(self.name, fill=True, expand=False, padding=7)
         self.grid = Gtk.Grid(orientation=Gtk.Orientation.VERTICAL)
         self.grid.set_column_spacing(10)
@@ -66,8 +67,10 @@ class RepositoryDetails(Gramplet):
         """
         label = Gtk.Label(label=title + COLON, halign=Gtk.Align.END,
                           valign=Gtk.Align.START)
+        label.set_selectable(True)
         label.show()
         value = Gtk.Label(label=value, halign=Gtk.Align.START)
+        value.set_selectable(True)
         value.show()
         self.grid.add(label)
         self.grid.attach_next_to(value, label, Gtk.PositionType.RIGHT, 1, 1)
@@ -153,5 +156,6 @@ class RepositoryDetails(Gramplet):
         """
         label = Gtk.Label(label='')
         label.override_font(Pango.FontDescription('sans 4'))
+        label.set_selectable(True)
         label.show()
         self.grid.add(label)


### PR DESCRIPTION
Allow selection of text fields from details tab in selected views with "Details" gramplets.
* Person Details
* Place Details
* Repository Details

Resolves [#7874](https://gramps-project.org/bugs/view.php?id=7874)