### PR TITLE
Geography: KML media objects not shown on map.

### DIFF
--- a/gramps/plugins/lib/maps/geography.py
+++ b/gramps/plugins/lib/maps/geography.py
@@ -54,6 +54,7 @@ from gramps.gen.const import HOME_DIR
 from gramps.gen.config import config
 from gramps.gui.editors import EditPlace, EditEvent, EditFamily, EditPerson
 from gramps.gui.selectors.selectplace import SelectPlace
+from gramps.gen.utils.file import media_path_full
 
 import gi
 gi.require_version('OsmGpsMap', '1.0')
@@ -866,6 +867,7 @@ class GeoGraphyView(OsmGps, NavigationView):
                 path = media_obj.get_path()
                 name, extension = os.path.splitext(path)
                 if extension == ".kml":
+                    path = media_path_full(self.dbstate.db, path)
                     if os.path.isfile(path):
                         self.kml_layer.add_kml(path)
 

--- a/gramps/plugins/view/geoplaces.py
+++ b/gramps/plugins/view/geoplaces.py
@@ -252,6 +252,7 @@ class GeoPlaces(GeoGraphyView):
         longitude = place.get_longitude()
         latitude = place.get_latitude()
         latitude, longitude = conv_lat_lon(latitude, longitude, "D.D8")
+        self.load_kml_files(place)
         # place.get_longitude and place.get_latitude return
         # one string. We have coordinates when the two values
         # contains non null string.
@@ -266,7 +267,6 @@ class GeoPlaces(GeoGraphyView):
                                         None, # family.gramps_id
                                         color=self.plc_color[int(place.get_type())+1]
                                        )
-            self.load_kml_files(place)
 
     def _createmap(self, place_x):
         """


### PR DESCRIPTION
Geography doesn't conform to the relative paths
If a place has no coordinates, KML files are not displayed.

Fixes [#10487](https://gramps-project.org/bugs/view.php?id=10487)