### PR TITLE
List sort by number for citation confidence level

### DIFF
--- a/gramps/gui/glade/editcitation.glade
+++ b/gramps/gui/glade/editcitation.glade
@@ -199,10 +199,10 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="tooltip_text" translatable="yes">Conveys the submitter's quantitative evaluation of the credibility of a piece of information, based upon its supporting evidence. It is not intended to eliminate the receiver's need to evaluate the evidence for themselves.
-Very Low =Unreliable evidence or estimated data
-Low =Questionable reliability of evidence (interviews, census, oral genealogies, or potential for bias for example, an autobiography)
-High =Secondary evidence, data officially recorded sometime after event
-Very High =Direct and primary evidence used, or by dominance of the evidence </property>
+/Very Low =Unreliable evidence or estimated data.
+/Low =Questionable reliability of evidence (interviews, census, oral genealogies, or potential for bias for example, an autobiography).
+/High =Secondary evidence, data officially recorded sometime after event.
+/Very High =Direct and primary evidence used, or by dominance of the evidence.</property>
                     <property name="hexpand">True</property>
                     <property name="model">confidence_model</property>
                     <child>

--- a/gramps/gui/views/treemodels/citationbasemodel.py
+++ b/gramps/gui/views/treemodels/citationbasemodel.py
@@ -114,6 +114,11 @@ class CitationBaseModel:
     def citation_page(self, data):
         return data[COLUMN_PAGE]
 
+    def citation_sort_confidence(self, data):
+        if data[COLUMN_CONFIDENCE]:
+            return str(data[COLUMN_CONFIDENCE])
+        return ''
+
     def citation_confidence(self, data):
         return _(conf_strings[data[COLUMN_CONFIDENCE]])
 

--- a/gramps/gui/views/treemodels/citationlistmodel.py
+++ b/gramps/gui/views/treemodels/citationlistmodel.py
@@ -81,7 +81,7 @@ class CitationListModel(CitationBaseModel, FlatBaseModel):
             self.citation_page,
             self.citation_id,
             self.citation_sort_date,
-            self.citation_confidence,
+            self.citation_sort_confidence,
             self.citation_private,
             self.citation_tags,
             self.citation_sort_change,

--- a/gramps/gui/views/treemodels/citationtreemodel.py
+++ b/gramps/gui/views/treemodels/citationtreemodel.py
@@ -147,7 +147,7 @@ class CitationTreeModel(CitationBaseModel, TreeBaseModel):
             self.citation_page,
             self.citation_id,
             self.citation_sort_date,
-            self.citation_confidence,
+            self.citation_sort_confidence,
             self.citation_private,
             self.citation_tags,
             self.citation_sort_change,


### PR DESCRIPTION
Fixes [#10506](https://gramps-project.org/bugs/view.php?id=10506)

Citation confidence levels are now sorted numerically and not alphabetically.

Fix tooltip on Confidence level entry for the Citation Editor, so text does not run on to each other.