### PR TITLE
Fix 'References' Gramplet for issue when activated during an import

### DIFF
--- a/gramps/gui/dbloader.py
+++ b/gramps/gui/dbloader.py
@@ -506,10 +506,9 @@ class GrampsImportFileDialog(ManagedWindow):
 
                 for plugin in pmgr.get_import_plugins():
                     if extension == plugin.get_extension():
-                        self.do_import(import_dialog,
-                                       plugin.get_import_function(),
-                                       filename)
                         self.close()
+                        self.do_import(plugin.get_import_function(),
+                                       filename)
                         if callback is not None:
                             callback(self.import_info)
                         return
@@ -565,12 +564,10 @@ class GrampsImportFileDialog(ManagedWindow):
 
         return False
 
-    def do_import(self, dialog, importer, filename):
+    def do_import(self, importer, filename):
         self.import_info = None
-        position = self.window.get_position() # crock
-        dialog.hide()
-        self.window.move(position[0], position[1])
         self._begin_progress()
+        self.uistate.window.set_sensitive(False)
 
         try:
             #an importer can return an object with info, object.info_text()
@@ -590,6 +587,7 @@ class GrampsImportFileDialog(ManagedWindow):
                 parent=self.uistate.window)
         except Exception:
             _LOG.error("Failed to import database.", exc_info=True)
+        self.uistate.window.set_sensitive(True)
         self._end_progress()
 
     def build_menu_names(self, obj): # this is meaningless since it's modal

--- a/gramps/gui/dbloader.py
+++ b/gramps/gui/dbloader.py
@@ -567,7 +567,8 @@ class GrampsImportFileDialog(ManagedWindow):
     def do_import(self, importer, filename):
         self.import_info = None
         self._begin_progress()
-        self.uistate.window.set_sensitive(False)
+        self.uistate.set_sensitive(False)
+        self.uistate.viewmanager.enable_menu(False)
 
         try:
             #an importer can return an object with info, object.info_text()
@@ -587,7 +588,8 @@ class GrampsImportFileDialog(ManagedWindow):
                 parent=self.uistate.window)
         except Exception:
             _LOG.error("Failed to import database.", exc_info=True)
-        self.uistate.window.set_sensitive(True)
+        self.uistate.set_sensitive(True)
+        self.uistate.viewmanager.enable_menu(True)
         self._end_progress()
 
     def build_menu_names(self, obj): # this is meaningless since it's modal

--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -1279,6 +1279,44 @@ class ViewManager(CLIManager):
         config.set('paths.recent-file', '')
         config.save()
 
+    def enable_menu(self, enable):
+        """ Enable/disable the menues.  Used by the dbloader for import to
+        prevent other operations during import.  Needed because simpler methods
+        don't work under Gnome with application menus at top of screen (instead
+        of Gramps window).
+        Note: enable must be set to False on first call.
+        """
+        if not enable:
+            self.action_st = (
+                self.actiongroup.get_sensitive(),
+                self.readonlygroup.get_sensitive(),
+                self.undoactions.get_sensitive(),
+                self.redoactions.get_sensitive(),
+                self.undohistoryactions.get_sensitive(),
+                self.fileactions.get_sensitive(),
+                self.toolactions.get_sensitive(),
+                self.reportactions.get_sensitive(),
+                self.recent_manager.action_group.get_sensitive())
+            self.actiongroup.set_sensitive(enable)
+            self.readonlygroup.set_sensitive(enable)
+            self.undoactions.set_sensitive(enable)
+            self.redoactions.set_sensitive(enable)
+            self.undohistoryactions.set_sensitive(enable)
+            self.fileactions.set_sensitive(enable)
+            self.toolactions.set_sensitive(enable)
+            self.reportactions.set_sensitive(enable)
+            self.recent_manager.action_group.set_sensitive(enable)
+        else:
+            self.actiongroup.set_sensitive(self.action_st[0])
+            self.readonlygroup.set_sensitive(self.action_st[1])
+            self.undoactions.set_sensitive(self.action_st[2])
+            self.redoactions.set_sensitive(self.action_st[3])
+            self.undohistoryactions.set_sensitive(self.action_st[4])
+            self.fileactions.set_sensitive(self.action_st[5])
+            self.toolactions.set_sensitive(self.action_st[6])
+            self.reportactions.set_sensitive(self.action_st[7])
+            self.recent_manager.action_group.set_sensitive(self.action_st[8])
+
     def __change_undo_label(self, label):
         """
         Change the UNDO label

--- a/gramps/plugins/gramplet/backlinks.py
+++ b/gramps/plugins/gramplet/backlinks.py
@@ -64,7 +64,7 @@ class Backlinks(Gramplet):
         Display the back references for an object.
         """
         for classname, handle in \
-                        self.dbstate.db.find_backlink_handles(active_handle):
+                self.dbstate.db.find_backlink_handles(active_handle):
             name = navigation_label(self.dbstate.db, classname, handle)[0]
             self.model.add((_(classname), name, handle, classname))
         self.set_has_data(self.model.count > 0)
@@ -73,7 +73,7 @@ class Backlinks(Gramplet):
         """
         Return True if the gramplet has data, else return False.
         """
-        if active_handle is None:
+        if not active_handle:
             return False
         for handle in self.dbstate.db.find_backlink_handles(active_handle):
             return True


### PR DESCRIPTION
Fixes [#10507](https://gramps-project.org/bugs/view.php?id=10507) ... Maybe

I noticed that the active_handle was being returned as empty string, not None so changed test for that.
Based on Nick's observation that you cannot do a backlinks lookup and other things during an import, I disabled input to the main window during the import.

The popup from Gedcom import for Ansel character sets still works.  Other main window input seems to be locked out.  The progress bar still updates.
