### PR TITLE
Fixes for errors opening family tree when a backend is unavailable

### DIFF
--- a/gramps/cli/arghandler.py
+++ b/gramps/cli/arghandler.py
@@ -554,6 +554,9 @@ class ArgHandler:
         if self.dbman.needs_recovery(dbpath):
             self.__error(_("Database needs recovery, cannot open it!"))
             return False
+        if self.dbman.backend_unavailable(dbpath):
+            self.__error(_("Database backend unavailable, cannot open it!"))
+            return False
         return True
 
     #-------------------------------------------------------------------------

--- a/gramps/cli/clidbman.py
+++ b/gramps/cli/clidbman.py
@@ -70,6 +70,7 @@ DEFAULT_TITLE = _("Family Tree")
 NAME_FILE = "name.txt"
 BACKEND_FILE = "database.txt"
 META_NAME = "meta_data.db"
+UNAVAILABLE = _('Unavailable')
 
 #-------------------------------------------------------------------------
 #
@@ -183,7 +184,7 @@ class CLIDbManager:
         for plugin in pmgr.get_reg_databases():
             if plugin.id == dbid:
                 return plugin._name
-        return _("Unknown")
+        return UNAVAILABLE
 
     def print_family_tree_summaries(self, database_names=None):
         """

--- a/gramps/gen/db/utils.py
+++ b/gramps/gen/db/utils.py
@@ -41,7 +41,7 @@ from ..plug import BasePluginManager
 from ..const import PLUGINS_DIR, USER_PLUGINS
 from ..constfunc import win, get_env_var
 from ..config import config
-from .dbconst import DBLOGNAME, DBLOCKFN
+from .dbconst import DBLOGNAME, DBLOCKFN, DBBACKEND
 
 #-------------------------------------------------------------------------
 #
@@ -109,13 +109,7 @@ def lookup_family_tree(dbname):
             if dbname == name:
                 locked = False
                 locked_by = None
-                backend = None
-                fname = os.path.join(dirpath, "database.txt")
-                if os.path.isfile(fname):
-                    with open(fname, 'r', encoding='utf8') as ifile:
-                        backend = ifile.read().strip()
-                else:
-                    backend = "bsddb"
+                backend = get_dbid_from_path(dirpath)
                 try:
                     fname = os.path.join(dirpath, "lock")
                     with open(fname, 'r', encoding='utf8') as ifile:
@@ -125,6 +119,17 @@ def lookup_family_tree(dbname):
                     pass
                 return (dirpath, locked, locked_by, backend)
     return None
+
+def get_dbid_from_path(dirpath):
+    """
+    Return a database backend from a directory path.
+    """
+    dbid = "bsddb"
+    dbid_path = os.path.join(dirpath, DBBACKEND)
+    if os.path.isfile(dbid_path):
+        with open(dbid_path) as file:
+            dbid = file.read().strip()
+    return dbid
 
 def import_as_dict(filename, user, skp_imp_adds=True):
     """

--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -57,7 +57,7 @@ from gramps.gen.const import URL_WIKISTRING, URL_MANUAL_PAGE
 from .user import User
 from .dialog import ErrorDialog, QuestionDialog, QuestionDialog2, ICON
 from .pluginmanager import GuiPluginManager
-from gramps.cli.clidbman import CLIDbManager, NAME_FILE, time_val
+from gramps.cli.clidbman import CLIDbManager, NAME_FILE, time_val, UNAVAILABLE
 from .managedwindow import ManagedWindow
 from .ddtargets import DdTargets
 from gramps.gen.recentfiles import rename_filename, remove_filename
@@ -313,6 +313,12 @@ class DbManager(CLIDbManager, ManagedWindow):
             self.connect_btn.set_sensitive(False)
             if _RCS_FOUND:
                 self.rcs_btn.set_sensitive(True)
+        elif store.get_value(node, BACKEND_COL) == UNAVAILABLE:
+            self.close_btn.set_sensitive(False)
+            self.convert_btn.set_sensitive(False)
+            self.connect_btn.set_sensitive(False)
+            self.rcs_btn.set_sensitive(False)
+            self.repair_btn.set_sensitive(False)
         else:
             self.close_btn.set_sensitive(False)
             dbid = config.get('database.backend')
@@ -361,6 +367,10 @@ class DbManager(CLIDbManager, ManagedWindow):
         # Put some help on the buttons:
         dbid = config.get('database.backend')
         backend_type = self.get_backend_name_from_dbid(dbid)
+        if backend_type == UNAVAILABLE:
+            dbid = 'bsddb'
+            config.set('database.backend', dbid)
+            backend_type = self.get_backend_name_from_dbid(dbid)
         self.new_btn.set_tooltip_text(backend_type)
 
         # build the database name column

--- a/gramps/gui/displaystate.py
+++ b/gramps/gui/displaystate.py
@@ -64,6 +64,7 @@ from gramps.gen.relationship import get_relationship_calculator
 from .glade import Glade
 from gramps.gen.utils.db import navigation_label
 from .widgets.progressdialog import ProgressMonitor, GtkProgressDialog
+from .dialog import ErrorDialog
 
 DISABLED = -1
 
@@ -261,7 +262,11 @@ class RecentDocsMenu:
 
     def load(self, item):
         filename = item.get_path()
-        self.fileopen(filename)
+        try:
+            self.fileopen(filename)
+        except Exception as err:
+            ErrorDialog(_('Cannot load database'), str(err),
+                        parent=self.uistate.window)
 
     def build(self):
         buf = StringIO()


### PR DESCRIPTION
When the default backend is unavailable disable the new and
convert buttons.

When the selected tree backend is unavailable disable the connect
and convert buttons.