### PR TITLE
Fix two help links 50

### DIFF
--- a/gramps/gui/editors/editrepository.py
+++ b/gramps/gui/editors/editrepository.py
@@ -57,7 +57,7 @@ from gramps.gen.const import URL_MANUAL_SECT2
 #-------------------------------------------------------------------------
 
 WIKI_HELP_PAGE = URL_MANUAL_SECT2
-WIKI_HELP_SEC = _('manual|New_Repositories_dialog')
+WIKI_HELP_SEC = _('manual|New_Repository_dialog')
 
 class EditRepository(EditPrimary):
 

--- a/gramps/plugins/tool/reorderids.py
+++ b/gramps/plugins/tool/reorderids.py
@@ -42,7 +42,7 @@ from gi.repository import Gtk, Gdk
 #------------------------------------------------------------------------
 from gramps.gen.const import URL_MANUAL_PAGE
 from gramps.gen.const import GRAMPS_LOCALE as glocale
-_ = glocale.translation.gettext
+_ = glocale.translation.sgettext
 
 from gramps.gen.config import config
 from gramps.gen.db import DbTxn


### PR DESCRIPTION
- [x]  (Bug# )Tool "Reorder_Gramps_ID"  URL for help was broken went to
   https://gramps-project.org/wiki/index.php?title=Gramps_5.0_Wiki_Manual_-_Tools#manual|Reorder_Gramps_ID
    issue with pipe for translation using sgettext instead fixes link
   https://gramps-project.org/wiki/index.php?title=Gramps_5.0_Wiki_Manual_-_Tools#Reorder_Gramps_ID 

- [x]  (Bug# )Rename the wiki section to match interface and and updated gramps code to be "New Repository dialog" instead of "New_Repositor>ies< dialog"
was:
https://gramps-project.org/wiki/index.php?title=Gramps_5.0_Wiki_Manual_-_Entering_and_editing_data:_detailed_-_part_2#New_Repositories_dialog
now:
https://gramps-project.org/wiki/index.php?title=Gramps_5.0_Wiki_Manual_-_Entering_and_editing_data:_detailed_-_part_2#New_Repository_dialog