### PR TITLE
Fix Quickview for missing table data on some Gtk Versions

### DIFF
--- a/gramps/gui/plug/quick/_quicktable.py
+++ b/gramps/gui/plug/quick/_quicktable.py
@@ -344,6 +344,7 @@ class QuickTable(SimpleTable):
         self.simpledoc = document
         buffer = self.simpledoc.doc.buffer
         text_view = self.simpledoc.doc.text_view
+        text_view.set_sensitive(False)
         model_index = 1 # start after index
         if self._sort_col:
             sort_index = self._columns.index(self._sort_col)
@@ -428,3 +429,6 @@ class QuickTable(SimpleTable):
         text_view.show_all()
         self.simpledoc.paragraph("")
         self.simpledoc.paragraph("")
+        while Gtk.events_pending():
+            Gtk.main_iteration()
+        text_view.set_sensitive(True)


### PR DESCRIPTION
Issue [#10448](https://gramps-project.org/bugs/view.php?id=10448)  Where Quickview table data is sometimes missing on older Gtk versions.
I was shown a GrampsAIO with an older Gtk 3.14 version which exhibited this error.  I tried a lot of 'fixes' and determined that many events which cause the table to be redrawn will make the missing table show up.  So I settled on a change of 'sensitivity' after the table was loaded and the TextView was supposed to be complete as a way to trigger a redraw.  It turned out that I also had to get prior Gtk events to be processed to make this work.

The following was my first comment, kept for the history...

> I was looking at our code for this Quickview and I noticed that we are inserting the TreeView into the TextView before we have  finished creating the entire model for the tree.  In fact before we have added any rows.  I also note that in the failing cases, the TreeView Column titles are present, so at least part of the TreeView is being displayed.
> 
> It seems to me that it is possible in some versions of Gtk that updates to the TreeView are getting lost.  Since I cannot test this (I only have a recent version of a MAC VM available with a good Gtk), I've created a PR for someone to test to see if getting the view finished BEFORE putting it into the TextView makes any difference.