### PR TITLE
Bugfix: use same box margin for SVG and PDF

### DIFF
--- a/gramps/plugins/docgen/svgdrawdoc.py
+++ b/gramps/plugins/docgen/svgdrawdoc.py
@@ -243,7 +243,14 @@ class SvgDrawDoc(BaseDoc, DrawDoc):
             font = para.get_font()
             font_size = font.get_size()
             lines = text.split('\n')
-            mar = 10/28.35
+
+            # horizontal position of the text is not included in the style,
+            # we assume that it is the size of the shadow, or 0.2mm
+            if box_style.get_shadow():
+                mar = box_style.get_shadow_space()
+            else:
+                mar = 0.2
+
             fsize = (font_size/28.35) * 1.2
             center = y + (h + fsize)/2.0 + (fsize*0.2)
             ystart = center - (fsize/2.0) * len(lines)


### PR DESCRIPTION
When drawing text boxes in SVG, the text is often placed too far to the right and touches the right frame. For an example, generate a »Descendent tree« in SVG format. In the PDF version, the text does not touch the frame of any boxes.

This PR fixes the problem by using the same text displacement (margin) inside the box as the PDF driver. The code is taken from gramps/plugins/lib/libcairodoc.py.