### PR TITLE
Fix Person views to update on changes in birth/death event/place

### DIFF
--- a/gramps/plugins/lib/libpersonview.py
+++ b/gramps/plugins/lib/libpersonview.py
@@ -142,6 +142,8 @@ class BasePersonView(ListView):
             'family-update'  : self.object_build,
             'family-add'     : self.object_build,
             'family-delete'  : self.object_build,
+            'event-update'   : self.object_build,
+            'place-update'   : self.object_build,
             }
 
         ListView.__init__(

--- a/gramps/plugins/view/familyview.py
+++ b/gramps/plugins/view/familyview.py
@@ -108,6 +108,7 @@ class FamilyView(ListView):
             'family-update'  : self.row_update,
             'family-delete'  : self.row_delete,
             'family-rebuild' : self.object_build,
+            'event-update'   : self.object_build,
             }
 
         ListView.__init__(


### PR DESCRIPTION
Fixes [#10532](https://gramps-project.org/bugs/view.php?id=10532)

User noticed that changes to person birth/death event did not get updated on people list/tree view screen.