### PR TITLE
Fix Tag editor for multiple tag removes

### DIFF
--- a/gramps/gui/views/tags.py
+++ b/gramps/gui/views/tags.py
@@ -370,6 +370,7 @@ class OrganizeTagsDialog(ManagedWindow):
         """
         for new_priority, row in enumerate(self.namemodel.model):
             if row[0] != new_priority:
+                row[0] = new_priority
                 tag = self.db.get_tag_from_handle(row[1])
                 if tag:
                     tag.set_priority(new_priority)
@@ -530,6 +531,7 @@ class OrganizeTagsDialog(ManagedWindow):
             pmon.add_op(status)
 
             msg = _('Delete Tag (%s)') % tag_name
+            self.namemodel.remove(iter_)
             with DbTxn(msg, self.db) as trans:
                 for classname, handle in links:
                     status.heartbeat()
@@ -539,7 +541,6 @@ class OrganizeTagsDialog(ManagedWindow):
 
                 self.db.remove_tag(tag_handle, trans)
                 self.__change_tag_priority(trans)
-            self.namemodel.remove(iter_)
             status.end()
 
 #-------------------------------------------------------------------------


### PR DESCRIPTION
Fixes [#10552](https://gramps-project.org/bugs/view.php?id=10552)
User attempted to remove multiple tags without closing dialog.  Seems that original code did not update the model correctly during delete.

Should back port to gramps42...