### PR TITLE
Fix Citation Tree view for crash after plugin reload

### DIFF
--- a/gramps/plugins/view/citationtreeview.py
+++ b/gramps/plugins/view/citationtreeview.py
@@ -159,7 +159,7 @@ class CitationTreeView(ListView):
     def change_active(self, handle):
         try:
             self.dbstate.db.get_citation_from_handle(handle)
-            super(CitationTreeView, self).change_active(handle)
+            super().change_active(handle)
         except HandleError:
             # FIXME: See http://www.gramps-project.org/bugs/view.php?id=6352 a
             # more comprehensive solution is needed in the long term. See also


### PR DESCRIPTION
Fixes [#10541](https://gramps-project.org/bugs/view.php?id=10541)

The original 'super' call included the 'CitationTreeview' and 'self' parameters.  Apparently a plugin reload (CitationTreeview is a plugin) changes one of these so the original references are not correct anymore.  Removing the reference allows Python to dynamically find the correct value.