### PR TITLE
Fix Person/Family/Event view updates on various associated changes

### DIFF
--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -817,6 +817,19 @@ class ListView(NavigationView):
                 self.change_active(handle)
                 break
 
+    def related_update(self, hndl_list):
+        """ Find handles pointing to the view from a related object update;
+        for example if an event update occurs, find person handles referenced
+        by that event. Use this list to perfom row_updates.
+        """
+        nav_type = self.navigation_type()
+        for hndl in hndl_list:
+            hndls = [handl for cl_name, handl in
+                     self.dbstate.db.find_backlink_handles(
+                         hndl, include_classes=[nav_type])]
+        if hndls:
+            self.row_update(hndls)
+
     def _button_press(self, obj, event):
         """
         Called when a mouse is clicked.

--- a/gramps/plugins/lib/libpersonview.py
+++ b/gramps/plugins/lib/libpersonview.py
@@ -139,11 +139,10 @@ class BasePersonView(ListView):
             'person-rebuild' : self.object_build,
             'person-groupname-rebuild' : self.object_build,
             'no-database': self.no_database,
-            'family-update'  : self.object_build,
-            'family-add'     : self.object_build,
-            'family-delete'  : self.object_build,
-            'event-update'   : self.object_build,
-            'place-update'   : self.object_build,
+            'family-update'  : self.related_update,
+            'family-add'     : self.related_update,
+            'event-update'   : self.related_update,
+            'place-update'   : self.related_update,
             }
 
         ListView.__init__(

--- a/gramps/plugins/view/eventview.py
+++ b/gramps/plugins/view/eventview.py
@@ -113,6 +113,12 @@ class EventView(ListView):
             'event-update'  : self.row_update,
             'event-delete'  : self.row_delete,
             'event-rebuild' : self.object_build,
+            'person-update' : self.person_update,
+            'person-add'    : self.person_update,
+            'person-delete' : self.object_build,  # TODO slow way to do this
+            'family-update' : self.family_update,
+            'family-add'    : self.family_update,
+            'family-delete' : self.object_build,  # TODO slow way to do this
             'place-update'  : self.related_update,
             }
 
@@ -133,6 +139,31 @@ class EventView(ListView):
         uistate.connect('placeformat-changed', self.build_tree)
 
         self.additional_uis.append(self.additional_ui())
+
+    def person_update(self, hndl_list):
+        """ Deal with person updates thay may effect the Main Participants
+        column.  These cannot use the more generic mechanism because Person
+        objects use EventRef to point to events, rather than Events pointing
+        to persons. Example: A person's name change or add event to person"""
+        update_list = []
+        for hndl in hndl_list:
+            person = self.dbstate.db.get_person_from_handle(hndl)
+            for eventref in person.get_event_ref_list():
+                update_list.append(eventref.ref)
+        self.row_update(update_list)
+
+    def family_update(self, hndl_list):
+        """ Deal with family updates thay may effect the Main Participants
+        column.  These cannot use the more generic mechanism because Family
+        objects use EventRef to point to events, rather than Events pointing
+        to Families. Example: Change/add/removal of parent, or add family to
+        event"""
+        update_list = []
+        for hndl in hndl_list:
+            family = self.dbstate.db.get_family_from_handle(hndl)
+            for eventref in family.get_event_ref_list():
+                update_list.append(eventref.ref)
+        self.row_update(update_list)
 
     def navigation_type(self):
         return 'Event'

--- a/gramps/plugins/view/eventview.py
+++ b/gramps/plugins/view/eventview.py
@@ -113,6 +113,7 @@ class EventView(ListView):
             'event-update'  : self.row_update,
             'event-delete'  : self.row_delete,
             'event-rebuild' : self.object_build,
+            'place-update'  : self.related_update,
             }
 
         ListView.__init__(

--- a/gramps/plugins/view/familyview.py
+++ b/gramps/plugins/view/familyview.py
@@ -108,7 +108,8 @@ class FamilyView(ListView):
             'family-update'  : self.row_update,
             'family-delete'  : self.row_delete,
             'family-rebuild' : self.object_build,
-            'event-update'   : self.object_build,
+            'event-update'   : self.related_update,
+            'person-update'  : self.related_update,
             }
 
         ListView.__init__(


### PR DESCRIPTION
Fixes [#10532](https://gramps-project.org/bugs/view.php?id=10532)

This attempts to correct some of the views for updates that effect the 'other' columns in the view.  For example the original bug report noted that the Person view birth/death event date/place were not updated when updating those events.

The 'fix' was to find backlinks to affected objects and do the row updates on those objects.

During testing I noticed that Event view Main Participants also needed work; but it needed a different method to find/update.  I added a second commit to deal with add/update of a person or family, however I could not figure out an elegant (fast) method of dealing with person/family delete.  At the moment, I just have it redoing the whole view on a person/family delete (slow).  The problem is I don't have a good way to figure out what rows to update, based on the person-delete signal.  It includes person handles, but the person objects are already gone from the db, and the event model doesn't contain Main Participant handles to compare against.  Maybe something from the undo db????

Another category that was not covered well was Place updates.  If the update is to an enclosing object (example, change country name, most places in views will not be updated).  Also for Person view, if the birth/death place changed it was not getting updated.  The third commit deals with these issues.
