### PR TITLE
Fix FanChartDesc for typo (copy/paste error).

### DIFF
--- a/gramps/gui/widgets/fanchartdesc.py
+++ b/gramps/gui/widgets/fanchartdesc.py
@@ -546,8 +546,7 @@ class FanChartDescWidget(FanChartBaseWidget):
         elif nrparent <= 4:
             angleinc = math.pi/2
         else:
-            # FIXME: nrchild not set
-            angleinc = 2 * math.pi / nrchild
+            angleinc = 2 * math.pi / nrparent
         for data in self.innerring:
             self.draw_innerring(cr, data[0], data[1], startangle, angleinc)
             startangle += angleinc


### PR DESCRIPTION
Fixes #10565

Bug occurs when selected person has more than 4 parents.
Same as PR610, but for Gramps50