### PR TITLE
Fix bsddb for person sort with empty Surname list

### DIFF
--- a/gramps/plugins/db/bsddb/read.py
+++ b/gramps/plugins/db/bsddb/read.py
@@ -129,9 +129,12 @@ def find_fullname(key, data):
     #   surname primary,
     #   surname origin type,
     #   surname connector)]
-    fullname_data = [(data[3][5][0][0] + ' ' + data[3][4], # surname givenname
-                      data[3][5][0][1], data[3][5][0][2],
-                      data[3][5][0][3], data[3][5][0][4])]
+    if data[3][5]:  # if Surname available
+        fullname_data = [(data[3][5][0][0] + ' ' + data[3][4],  # combined
+                          data[3][5][0][1], data[3][5][0][2],
+                          data[3][5][0][3], data[3][5][0][4])]
+    else:  # Some importers don't add any Surname at all
+        fullname_data = [(' ' + data[3][4], '', True, (1, ''), '')]
     # ignore if origin type is PATRONYMIC or MATRONYMIC
     return __index_surname(fullname_data)
 


### PR DESCRIPTION
Fixes [#10078](https://gramps-project.org/bugs/view.php?id=10078), [#10577](https://gramps-project.org/bugs/view.php?id=10577)

First found with an attempted export of a tree with persons having no Surnames at all (not just a list with an Empty Surname).  Some importers have been creating dbs this way for a long time, so the case is present in a lot of user trees.

Issue also occurs with some reports.

A gramps50 change added the ability to sort returned lists of people; this was not present in gramps42, the assembly of a fullname from a name that did not take into account the possibility of no surname was the issue.