### PR TITLE
Fix merge persons when removed person was the Home (default) person

### DIFF
--- a/gramps/gen/merge/mergepersonquery.py
+++ b/gramps/gen/merge/mergepersonquery.py
@@ -182,5 +182,7 @@ class MergePersonQuery:
                 self.database.commit_family(family, trans)
             parent_list.append(parents)
 
+        if self.database.get_default_handle() == old_handle:
+            self.database.set_default_person_handle(None)
         self.database.remove_person(old_handle, trans)
         return family_merge_ok


### PR DESCRIPTION
Fixes [#10597](https://gramps-project.org/bugs/view.php?id=10597)

If a person merge removes the default (Home) person, the previous code started having HandleError crashes.  This checks for and corrects this issue.  Did not see the issue with 4.2.x because there were no HandleErrors.