### PR TITLE
Fix dialogs for crash when canceling via 'x'

### DIFF
--- a/gramps/gui/dbloader.py
+++ b/gramps/gui/dbloader.py
@@ -485,9 +485,10 @@ class GrampsImportFileDialog(ManagedWindow):
             # the import_dialog.run() makes it modal, so any change to that
             # line would require the ManagedWindow.__init__ to be changed also
             response = import_dialog.run()
-            if response in (Gtk.ResponseType.CANCEL,
-                            Gtk.ResponseType.DELETE_EVENT):
+            if response == Gtk.ResponseType.CANCEL:
                 break
+            elif response == Gtk.ResponseType.DELETE_EVENT:
+                return
             elif response == Gtk.ResponseType.OK:
                 filename = import_dialog.get_filename()
                 if self.check_errors(filename):

--- a/gramps/gui/plug/_guioptions.py
+++ b/gramps/gui/plug/_guioptions.py
@@ -156,7 +156,9 @@ class LastNameDialog(ManagedWindow):
                 tree_iter = self.__model.get_iter(path)
                 surname = self.__model.get_value(tree_iter, 0)
                 surname_set.add(surname)
-        self.close() # ManagedWindow: set the parent dialog to be modal again
+        if response != Gtk.ResponseType.DELETE_EVENT:
+            # ManagedWindow: set the parent dialog to be modal again
+            self.close()
         return surname_set
 
     def build_menu_names(self, obj):

--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -1986,7 +1986,8 @@ class QuickBackup(ManagedWindow): # TODO move this class into its own module
             config.set('paths.quick-backup-directory', path_entry.get_text())
         else:
             self.uistate.push_message(self.dbstate, _("Backup aborted"))
-        self.close()
+        if dbackup != Gtk.ResponseType.DELETE_EVENT:
+            self.close()
 
     def select_backup_path(self, widget, path_entry):
         """


### PR DESCRIPTION
Fixes #10607
crash on cancelling import dialog with 'x'
crash on cancelling backup dialog with 'x'
crash on cancelling Reports/Graphs/Family Lines/Family Colors/add: select surname dialog with 'x'