### PR TITLE
Prevent a hidden Webstuff plugin from crashing all reports

### DIFF
--- a/gramps/gui/plug/report/_docreportdialog.py
+++ b/gramps/gui/plug/report/_docreportdialog.py
@@ -255,7 +255,11 @@ class DocReportDialog(ReportDialog):
         displayed on the screen.  The subclass will know whether this
         entry was enabled.  This is for simplicity of programming."""
 
-        self.css_filename = self.CSS[self.css_combo.get_active()]["filename"]
+        indx = self.css_combo.get_active()
+        if indx >= 0:
+            self.css_filename = self.CSS[indx]["filename"]
+        else:
+            self.css_filename = ''
         self.options.handler.set_css_filename(self.css_filename)
 
     def on_ok_clicked(self, obj):


### PR DESCRIPTION
Fixes [#10604](https://gramps-project.org/bugs/view.php?id=10604), [#8189](https://gramps-project.org/bugs/view.php?id=8189), [#9461](https://gramps-project.org/bugs/view.php?id=9461), [#9299](https://gramps-project.org/bugs/view.php?id=9299)

The user has used the 'Help/Plugin Manager' to 'Hide' the 'Webstuff' plugin. Since this plugin provides the CSS style sheets for HTML documents and Narrative Web reports, it should NEVER be hidden. We should probably rename the plugin and change the description to make this more clear.  Or something...

With the Webstuff plugin hidden, there are no style sheets, and the HTML tab in the report dialog (always existing, although only shown for HTML reports) has no entries for the 'CSS file' drop-down. Thus when the code tries to get the active entry for the 'CSS file' combobox, it gets a -1 for a result, even though the code earlier set the active entry to 0 (invalid for no entries).   This generates an IndexError when trying to find the stylesheet filename.

This patch will prevent the immediate error from the bug reports, although without style sheets, I note that HTML reports don't seem to work (blank report).

@Nick-Hall I'm not sure how to fix the larger issue; I don't think we should allow the Webstuff plugin to be hidden at all.  Any thoughts on how this might be done?

When this is resolved, we should cherry-pick to gramps50 and master branches.