### PR TITLE
Fix dbapi dbs for closeing read-only db crash

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -671,7 +671,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         if update is False, don't change access times, etc.
         """
         if self._directory != ":memory:":
-            if update:
+            if update and not self.readonly:
                 # This is just a dummy file to indicate last modified time of
                 # the database for gramps.cli.clidbman:
                 filename = os.path.join(self._directory, "meta_data.db")


### PR DESCRIPTION
Fixes [#10613](https://gramps-project.org/bugs/view.php?id=10613)

The sqlite (and other dbapi dbs) tried to save their metadata on a close operation, which doesn't work for read-only dbs.