### PR TITLE
Fix Gramplet configure (View/Configure) for large options

### DIFF
--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -566,19 +566,17 @@ class GuiGramplet:
         if len(self.pui.option_order) == 0: return
         frame = Gtk.Frame()
         topbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        hbox = Gtk.Box(spacing=5)
-        labels = Gtk.Box(orientation=Gtk.Orientation.VERTICAL,
-                         homogeneous=True)
-        options = Gtk.Box(orientation=Gtk.Orientation.VERTICAL,
-                          homogeneous=True)
-        hbox.pack_start(labels, False, True, 0)
-        hbox.pack_start(options, True, True, 0)
+        hbox = Gtk.Grid()
+        hbox.set_column_spacing(5)
         topbox.pack_start(hbox, False, False, 0)
+        row = 0
         for item in self.pui.option_order:
             label = Gtk.Label(label=item + COLON)
             label.set_halign(Gtk.Align.END)
-            labels.pack_start(label, True, True, 0)
-            options.pack_start(self.pui.option_dict[item][0], True, True, 0) # widget
+            hbox.attach(label, 0, row, 1, 1)
+            # put Widget next to label
+            hbox.attach(self.pui.option_dict[item][0], 1, row, 1, 1)
+            row += 1
         save_button = Gtk.Button.new_with_mnemonic(_('_Save'))
         topbox.pack_end(save_button, False, False, 0)
         save_button.connect('clicked', self.pui.save_update_options)


### PR DESCRIPTION
When a Gramplet uses a BooleanListOption with a lot of entries, along with other options, all the options take on the size of the large BooleanListOption, which doesn't work well at all.
![viewconfigbefore](https://user-images.githubusercontent.com/18122203/41240022-21d946da-6d5f-11e8-9d3c-455131e8b3e1.jpg)
This PR corrects this.
![viewconfigafter](https://user-images.githubusercontent.com/18122203/41240041-2f7bb9b2-6d5f-11e8-9a1d-42aaa723e151.jpg)
I've looked over the various Gramplets that use config options, and the PR doesn't seem to affect any others.
