### PR TITLE
Fix Custom filter update when created via sidebar

### DIFF
--- a/gramps/gui/filters/sidebar/_sidebarfilter.py
+++ b/gramps/gui/filters/sidebar/_sidebarfilter.py
@@ -267,7 +267,7 @@ class SidebarFilter(DbGUIElement):
         from gramps.gen.filters import reload_custom_filters
         filterdb.save()
         reload_custom_filters()
-        self.on_filters_changed(self.namespace)
+        self.uistate.emit('filters-changed', (self.namespace,))
         self.set_filters_to_name(filter_name)
 
     def set_filters_to_name(self, filter_name):


### PR DESCRIPTION
Fixes [#10620](https://gramps-project.org/bugs/view.php?id=10620)

Adding a filter via the sidebar editor originally only updated the current view, other associated views did not see the new filter.  First noticed in People views.  This causes the 'filters-changed' to be emitted which updates all associated view.