### PR TITLE
Fix BaseSelector to avoid long delay before display on large trees

### DIFF
--- a/gramps/gui/glade/baseselector.glade
+++ b/gramps/gui/glade/baseselector.glade
@@ -121,6 +121,7 @@
                 <property name="use_action_appearance">False</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
+                <property name="no_show_all">True</property>
                 <property name="halign">center</property>
                 <property name="use_underline">True</property>
                 <property name="xalign">0.5</property>
@@ -130,6 +131,22 @@
                 <property name="expand">False</property>
                 <property name="fill">False</property>
                 <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="loading">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Loading items...</property>
+                <property name="width_chars">10</property>
+                <attributes>
+                  <attribute name="font-desc" value="&lt;Enter Value&gt; 20"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
               </packing>
             </child>
           </object>

--- a/gramps/gui/selectors/baseselector.py
+++ b/gramps/gui/selectors/baseselector.py
@@ -107,7 +107,6 @@ class BaseSelector(ManagedWindow):
         self.sortorder = Gtk.SortType.ASCENDING
 
         self.skip_list=skip
-        self.build_tree()
         self.selection = self.tree.get_selection()
         self.track_ref_for_deletion("selection")
 
@@ -123,6 +122,12 @@ class BaseSelector(ManagedWindow):
             self.showall.show()
         else:
             self.showall.hide()
+        while Gtk.events_pending():
+            Gtk.main_iteration()
+        self.build_tree()
+        loading = self.glade.get_object('loading')
+        loading.hide()
+
         if default:
             self.goto_handle(default)
 


### PR DESCRIPTION
Fixes [#10634](https://gramps-project.org/bugs/view.php?id=10634)

The bug report indicates it is possible for the user to create two (or more) modal windows if he started by utilizing a Selector (PersonSelector was demonstrated) that took a long time to appear.  The problem was also caused by the 'loading items' progress indicator which allowed additional Gtk events to be executed during the wait.  The user started a second modal window (a Person Editor) during the wait.  The multiple modal windows confuses Gtk and can result in apparent Gramps freezes.  In this case, under Windows, the Selector dialog was hidden behind the Edit dialog, even though it was active and focused.  If the user shifted the dialog windows to access the Selector dialog, and closed it, both dialogs disappeared and Gramps appeared unresponsive to mouse (a keyboard 'ESC' would still close the hidden Person Editor).

I fixed this by causing the Selector Dialog to show before building the model it is showing.  For large models the Dialog can now appear empty until the model completes.  Previously the dialog did not appear at all until it was fully built.  The fix prevents the user from starting a second dialog.

It may be we should add a 'Loading Items..." into the Selector Dialog during the delay before showing the model; this would be a bit more user friendly, this PR doesn't do that.