### PR TITLE
Fix Quickview Gramplet so updates work when changing active

### DIFF
--- a/gramps/plugins/gramplet/quickviewgramplet.py
+++ b/gramps/plugins/gramplet/quickviewgramplet.py
@@ -49,7 +49,8 @@ class QuickViewGramplet(Gramplet):
     def active_changed(self, handle):
         self.update()
 
-    def post_init(self):
+    def db_changed(self):
+        self.connect_signal('Person', self._active_changed)
         self.connect_signal('Family', self._active_changed)
         self.connect_signal('Event', self._active_changed)
         self.connect_signal('Place', self._active_changed)


### PR DESCRIPTION
Fixes #10713
Another change to Gramps50 caused signals to be disconnected on a db change, so making Gramplet connections on init no longer works.  Connections have to be made when db is changed.