### PR TITLE
Fix Find Database Loop Tool (bad import of _collections)

### DIFF
--- a/gramps/plugins/tool/findloop.py
+++ b/gramps/plugins/tool/findloop.py
@@ -18,7 +18,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-from _collections import OrderedDict
+from collections import OrderedDict
 
 "Find possible loop in a people descendance"
 


### PR DESCRIPTION
Fixes [#10722](https://gramps-project.org/bugs/view.php?id=10722)

Inappropriate cut/paste from web error; apparently in some configurations there IS an '_collections' Python module, but not in all configurations.  Which is why I did not spot this the first time, sigh...