### PR TITLE
Fix place reference editor for bad cut/paste on set_latlongitude

### DIFF
--- a/gramps/gui/editors/editplaceref.py
+++ b/gramps/gui/editors/editplaceref.py
@@ -179,8 +179,8 @@ class EditPlaceRef(EditReference):
             self.latitude.set_text(value[:coma])
             self.top.get_object("lat_entry").validate(force=True)
             self.top.get_object("lon_entry").validate(force=True)
-            self.obj.set_latitude(self.latitude.get_value())
-            self.obj.set_longitude(self.longitude.get_value())
+            self.source.set_latitude(self.latitude.get_value())
+            self.source.set_longitude(self.longitude.get_value())
         except:
             pass
 


### PR DESCRIPTION
Fixes [#10719](https://gramps-project.org/bugs/view.php?id=10719)

Bad cut/paste masked by raw except...