### PR TITLE
fix view so column widths are preserved when using filters

### DIFF
--- a/gramps/gui/columnorder.py
+++ b/gramps/gui/columnorder.py
@@ -143,8 +143,10 @@ class ColumnOrder(Gtk.Box):
         index = 0
         for val, size in zip(self.oldorder, self.oldsize):
             if val in self.oldvis:
-                size = widths[index]
-                index += 1
+                if val != self.oldvis[-1]:
+                    # don't use last col width, its wrong
+                    size = widths[index]
+                    index += 1
                 colord.append((1, val, size))
             else:
                 colord.append((0, val, size))

--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -1041,7 +1041,7 @@ class ListView(NavigationView):
         newsize = []
         index = 0
         for val, size in zip(order, size):
-            if val in vis:
+            if val in vis[:-1]:  # don't use last column size, it's wrong
                 if widths[index]:
                     size = widths[index]
                 index += 1


### PR DESCRIPTION
Fixes [#10725](https://gramps-project.org/bugs/view.php?id=10725)

Current code saves column widths when exiting or configuring the columns.  But when using a sidebar filter it loads the last configured column widths, which loses the users changes unless he has configured the columns with the View/configure.

This PR preserves the current column widths anytime the view is rebuilt.  Note that when actually configuring the column layout the columnorder widget already saves the widths, so we don't do the preserve in the build_columns method. 

Fixes [#10800](https://gramps-project.org/bugs/view.php?id=10800)

Current Gtk design causes the last column in a view to expand to fill in any remaining space, regardless of previous column size settings.  This only matters when a user configures the view to add another column after the last column.  In that case, the new column is not immediately visible, because the last column fills remaining screen space; the user has to scroll horizontally to see the next column (and readjust the previous last column to a more reasonable size).

The second commit changes to code so that the settings for the last column size is not modified when other settings are saved.  This allows the previously set column value for the last column to be maintained.  If the user configures other columns after the current last column, it reverts to the original or last stored size (when it was not a last column).  This may allow the new column configuration to be partially or wholly visible, without scrolling.
I think this provides a minor, but useful improvement to usability.