### PR TITLE
Fix strings containing deprecated illegal escape sequences

### DIFF
--- a/gramps/gen/config.py
+++ b/gramps/gen/config.py
@@ -325,7 +325,7 @@ if not os.path.exists(CONFIGMAN.filename):
     # check previous version of gramps:
     fullpath, filename = os.path.split(CONFIGMAN.filename)
     fullpath, previous = os.path.split(fullpath)
-    match = re.match('gramps(\d*)', previous)
+    match = re.match(r'gramps(\d*)', previous)
     if match:
         # cycle back looking for previous versions of gramps
         for i in range(1, 20): # check back 2 gramps versions

--- a/gramps/gen/datehandler/_date_ar.py
+++ b/gramps/gen/datehandler/_date_ar.py
@@ -124,12 +124,12 @@ class DateParserAR(DateParser):
         _span_2 = ['إلى']
         _range_1 = ['بين']
         _range_2 = ['و']
-        self._span =  re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_span_1), '|'.join(_span_2)),
-                                 re.IGNORECASE)
-        self._range = re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2)),
-                                 re.IGNORECASE)
+        self._span = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
+            ('|'.join(_span_1), '|'.join(_span_2)), re.IGNORECASE)
+        self._range = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
+            ('|'.join(_range_1), '|'.join(_range_2)), re.IGNORECASE)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_bg.py
+++ b/gramps/gen/datehandler/_date_bg.py
@@ -166,12 +166,12 @@ class DateParserBG(DateParser):
         _span_2 = ['до']
         _range_1 = ['между']
         _range_2 = ['и']
-        self._span =  re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_span_1), '|'.join(_span_2)),
-                                 re.IGNORECASE)
-        self._range = re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2)),
-                                 re.IGNORECASE)
+        self._span = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
+            ('|'.join(_span_1), '|'.join(_span_2)), re.IGNORECASE)
+        self._range = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
+            ('|'.join(_range_1), '|'.join(_range_2)), re.IGNORECASE)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_ca.py
+++ b/gramps/gen/datehandler/_date_ca.py
@@ -98,14 +98,14 @@ class DateParserCA(DateParser):
         DateParser.init_strings(self)
         _span_1 = ['des de']
         _span_2 = ['fins a']
-        _range_1 = ['entre', 'ent\.', 'ent']
+        _range_1 = ['entre', r'ent\.', 'ent']
         _range_2 = ['i']
-        self._span =  re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_span_1), '|'.join(_span_2)),
-                                 re.IGNORECASE)
-        self._range = re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2)),
-                                 re.IGNORECASE)
+        self._span = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
+            ('|'.join(_span_1), '|'.join(_span_2)), re.IGNORECASE)
+        self._range = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
+            ('|'.join(_range_1), '|'.join(_range_2)), re.IGNORECASE)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_da.py
+++ b/gramps/gen/datehandler/_date_da.py
@@ -89,10 +89,11 @@ class DateParserDa(DateParser):
 
     def init_strings(self):
         DateParser.init_strings(self)
-        self._span     = re.compile("(fra)?\s*(?P<start>.+)\s*(til|--|–)\s*(?P<stop>.+)",
-                                    re.IGNORECASE)
-        self._range    = re.compile("(mellem)\s+(?P<start>.+)\s+og\s+(?P<stop>.+)",
-                                    re.IGNORECASE)
+        self._span = re.compile(
+            r"(fra)?\s*(?P<start>.+)\s*(til|--|–)\s*(?P<stop>.+)",
+            re.IGNORECASE)
+        self._range = re.compile(
+            r"(mellem)\s+(?P<start>.+)\s+og\s+(?P<stop>.+)", re.IGNORECASE)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_de.py
+++ b/gramps/gen/datehandler/_date_de.py
@@ -248,14 +248,16 @@ class DateParserDE(DateParser):
 
     def init_strings(self):
         DateParser.init_strings(self)
-        self._span   = re.compile("(von|vom)\s+(?P<start>.+)\s+(bis)\s+(?P<stop>.+)",
-                                  re.IGNORECASE)
-        self._range  = re.compile("zwischen\s+(?P<start>.+)\s+und\s+(?P<stop>.+)",
-                                  re.IGNORECASE)
-        self._text2  = re.compile('(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?' % self._mon_str,
-                                  re.IGNORECASE)
-        self._jtext2 = re.compile('(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?' % self._jmon_str,
-                                  re.IGNORECASE)
+        self._span = re.compile(
+            r"(von|vom)\s+(?P<start>.+)\s+(bis)\s+(?P<stop>.+)", re.IGNORECASE)
+        self._range = re.compile(
+            r"zwischen\s+(?P<start>.+)\s+und\s+(?P<stop>.+)", re.IGNORECASE)
+        self._text2 = re.compile(
+            r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?' % self._mon_str,
+            re.IGNORECASE)
+        self._jtext2 = re.compile(
+            r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?' % self._jmon_str,
+            re.IGNORECASE)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_el.py
+++ b/gramps/gen/datehandler/_date_el.py
@@ -116,14 +116,14 @@ class DateParserEL(DateParser):
         DateParser.init_strings(self)
         _span_1 = ['από']
         _span_2 = ['έως']
-        _range_1 = ['μετ', 'μετ\.', 'μεταξύ']
+        _range_1 = ['μετ', r'μετ\.', 'μεταξύ']
         _range_2 = ['και']
-        self._span =  re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_span_1), '|'.join(_span_2)),
-                                 re.IGNORECASE)
-        self._range = re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2)),
-                                 re.IGNORECASE)
+        self._span = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
+            ('|'.join(_span_1), '|'.join(_span_2)), re.IGNORECASE)
+        self._range = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
+            ('|'.join(_range_1), '|'.join(_range_2)), re.IGNORECASE)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_es.py
+++ b/gramps/gen/datehandler/_date_es.py
@@ -97,14 +97,14 @@ class DateParserES(DateParser):
         DateParser.init_strings(self)
         _span_1 = ['de']
         _span_2 = ['a']
-        _range_1 = ['entre', 'ent\.', 'ent']
+        _range_1 = ['entre', r'ent\.', 'ent']
         _range_2 = ['y']
-        self._span =  re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_span_1), '|'.join(_span_2)),
-                                 re.IGNORECASE)
-        self._range = re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2)),
-                                 re.IGNORECASE)
+        self._span = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
+            ('|'.join(_span_1), '|'.join(_span_2)), re.IGNORECASE)
+        self._range = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
+            ('|'.join(_range_1), '|'.join(_range_2)), re.IGNORECASE)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_fi.py
+++ b/gramps/gen/datehandler/_date_fi.py
@@ -98,12 +98,12 @@ class DateParserFI(DateParser):
 
     def init_strings(self):
         DateParser.init_strings(self)
-        self._text2 = re.compile('(\d+)?\.?\s+?%s\.?\s*((\d+)(/\d+)?)?\s*$'
-                                         % self._mon_str, re.IGNORECASE)
-        self._span = re.compile("(?P<start>.+)\s+(-)\s+(?P<stop>.+)",
-                           re.IGNORECASE)
+        self._text2 = re.compile(r'(\d+)?\.?\s+?%s\.?\s*((\d+)(/\d+)?)?\s*$'
+                                 % self._mon_str, re.IGNORECASE)
+        self._span = re.compile(r"(?P<start>.+)\s+(-)\s+(?P<stop>.+)",
+                                re.IGNORECASE)
         self._range = re.compile(
-            "(vuosien\s*)?(?P<start>.+)\s+ja\s+(?P<stop>.+)\s+välillä",
+            r"(vuosien\s*)?(?P<start>.+)\s+ja\s+(?P<stop>.+)\s+välillä",
             re.IGNORECASE)
 
 #-------------------------------------------------------------------------

--- a/gramps/gen/datehandler/_date_hr.py
+++ b/gramps/gen/datehandler/_date_hr.py
@@ -83,11 +83,11 @@ class DateParserHR(DateParser):
         _span_2 = ['do']
         _range_1 = ['između']
         _range_2 = ['i']
-        self._span =  re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_span_1), '|'.join(_span_2)),
-                                 re.IGNORECASE)
-        self._range = re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2)),
+        self._span = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+                                % ('|'.join(_span_1), '|'.join(_span_2)),
+                                re.IGNORECASE)
+        self._range = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+                                 % ('|'.join(_range_1), '|'.join(_range_2)),
                                  re.IGNORECASE)
 
 #-------------------------------------------------------------------------

--- a/gramps/gen/datehandler/_date_hu.py
+++ b/gramps/gen/datehandler/_date_hu.py
@@ -228,19 +228,19 @@ class DateParserHU(DateParser):
         DateParser.init_strings(self)
 
         self._numeric = re.compile(
-                            "((\d+)[/\.])?\s*((\d+)[/\.])?\s*(\d+)[/\. ]?$")
+            r"((\d+)[/\.])?\s*((\d+)[/\.])?\s*(\d+)[/\. ]?$")
         # this next RE has the (possibly-slashed) year at the string's start
-        self._text2 = re.compile('((\d+)(/\d+)?\.)?\s+?%s\.?\s*(\d+\.)?\s*$'
-                                       % self._mon_str, re.IGNORECASE)
-        _span_1 = ['-tó\(ő\)l', '-tól', '-től']
+        self._text2 = re.compile(r'((\d+)(/\d+)?\.)?\s+?%s\.?\s*(\d+\.)?\s*$'
+                                 % self._mon_str, re.IGNORECASE)
+        _span_1 = [r'-tó\(ő\)l', '-tól', '-től']
         _span_2 = ['-ig']
         _range_1 = ['és']
         _range_2 = ['között']
-        self._span  = re.compile("(?P<start>.+)(%s)\s+(?P<stop>.+)(%s)" %
-                                     ('|'.join(_span_1), '|'.join(_span_2)),
-                                 re.IGNORECASE)
-        self._range = re.compile("(?P<start>.+)\s+(%s)\s+(?P<stop>.+)\s+(%s)" %
-                                     ('|'.join(_range_1), '|'.join(_range_2)),
+        self._span = re.compile(r"(?P<start>.+)(%s)\s+(?P<stop>.+)(%s)" %
+                                ('|'.join(_span_1), '|'.join(_span_2)),
+                                re.IGNORECASE)
+        self._range = re.compile(r"(?P<start>.+)\s+(%s)\s+(?P<stop>.+)\s+(%s)"
+                                 % ('|'.join(_range_1), '|'.join(_range_2)),
                                  re.IGNORECASE)
 
 

--- a/gramps/gen/datehandler/_date_is.py
+++ b/gramps/gen/datehandler/_date_is.py
@@ -90,22 +90,23 @@ class DateParserIs(DateParser):
         }
 
     def dhformat_changed(self):
-        self._dhformat_parse = re.compile(".*%(\S).*%(\S).*%(\S).*%(\S).*")
+        self._dhformat_parse = re.compile(r".*%(\S).*%(\S).*%(\S).*%(\S).*")
 
     def init_strings(self):
         DateParser.init_strings(self)
 
         # match 'day. month year' format
-        self._text2 = re.compile('(\d+)?\.?\s*?%s\.?\s*((\d+)(/\d+)?)?\s*$'
+        self._text2 = re.compile(r'(\d+)?\.?\s*?%s\.?\s*((\d+)(/\d+)?)?\s*$'
                                  % self._mon_str, re.IGNORECASE)
         # match 'short-day day.month year' format
         short_day_str = '(' + '|'.join(self._ds.short_days[1:]) + ')'
-        self._numeric = re.compile("%s\s*((\d+)[\.]\s*)?((\d+)\s*)?(\d+)\s*$"
+        self._numeric = re.compile(r"%s\s*((\d+)[\.]\s*)?((\d+)\s*)?(\d+)\s*$"
                                    % short_day_str, re.IGNORECASE)
-        self._span     = re.compile("(frá)?\s*(?P<start>.+)\s*(til|--|–)\s*(?P<stop>.+)",
-                                    re.IGNORECASE)
-        self._range    = re.compile("(milli)\s+(?P<start>.+)\s+og\s+(?P<stop>.+)",
-                                    re.IGNORECASE)
+        self._span = re.compile(
+            r"(frá)?\s*(?P<start>.+)\s*(til|--|–)\s*(?P<stop>.+)",
+            re.IGNORECASE)
+        self._range = re.compile(
+            r"(milli)\s+(?P<start>.+)\s+og\s+(?P<stop>.+)", re.IGNORECASE)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_it.py
+++ b/gramps/gen/datehandler/_date_it.py
@@ -96,12 +96,12 @@ class DateParserIT(DateParser):
         _span_2 = ['al', 'a']
         _range_1 = ['tra', 'fra']
         _range_2 = ['e']
-        self._span =  re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_span_1), '|'.join(_span_2)),
+        self._span = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
+                                ('|'.join(_span_1), '|'.join(_span_2)),
                                  re.IGNORECASE)
-        self._range = re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2)),
-                                 re.IGNORECASE)
+        self._range = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
+            ('|'.join(_range_1), '|'.join(_range_2)), re.IGNORECASE)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_ja.py
+++ b/gramps/gen/datehandler/_date_ja.py
@@ -166,13 +166,13 @@ class DateParserJA(DateParser):
         _span_2 = ['まで', '']
         _range_1 = ['から', 'と', '~', '〜']
         _range_2 = ['までの間', 'の間']
-        self._span =  re.compile("(?P<start>.+)(%s)(?P<stop>\d+)(%s)" %
-                                 ('|'.join(_span_1), '|'.join(_span_2)),
-                                 re.IGNORECASE)
-        self._range = re.compile("(?P<start>.+)(%s)(?P<stop>.+)(%s)" %
+        self._span = re.compile(r"(?P<start>.+)(%s)(?P<stop>\d+)(%s)" %
+                                ('|'.join(_span_1), '|'.join(_span_2)),
+                                re.IGNORECASE)
+        self._range = re.compile(r"(?P<start>.+)(%s)(?P<stop>.+)(%s)" %
                                  ('|'.join(_range_1), '|'.join(_range_2)),
                                  re.IGNORECASE)
-        self._numeric = re.compile("((\d+)年\s*)?((\d+)月\s*)?(\d+)?日?\s*$")
+        self._numeric = re.compile(r"((\d+)年\s*)?((\d+)月\s*)?(\d+)?日?\s*$")
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_lt.py
+++ b/gramps/gen/datehandler/_date_lt.py
@@ -131,18 +131,19 @@ class DateParserLT(DateParser):
     def init_strings(self):
         DateParser.init_strings(self)
         # this next RE has the (possibly-slashed) year at the string's start
-        self._text2 = re.compile('((\d+)(/\d+)?)?\s+?m\.\s+%s\s*(\d+)?\s*d?\.?$'
-                                 % self._mon_str, re.IGNORECASE)
+        self._text2 = re.compile(
+            r'((\d+)(/\d+)?)?\s+?m\.\s+%s\s*(\d+)?\s*d?\.?$'
+            % self._mon_str, re.IGNORECASE)
         _span_1 = ['nuo']
         _span_2 = ['iki']
         _range_1 = ['tarp']
         _range_2 = ['ir']
-        self._span =  re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_span_1), '|'.join(_span_2)),
-                                 re.IGNORECASE)
-        self._range = re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2)),
-                                 re.IGNORECASE)
+        self._span = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
+                                ('|'.join(_span_1), '|'.join(_span_2)),
+                                re.IGNORECASE)
+        self._range = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
+            ('|'.join(_range_1), '|'.join(_range_2)), re.IGNORECASE)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_nb.py
+++ b/gramps/gen/datehandler/_date_nb.py
@@ -90,11 +90,12 @@ class DateParserNb(DateParser):
     def init_strings(self):
         DateParser.init_strings(self)
         # match day. month year
-        self._numeric  = re.compile("((\d+)[\.])?\s*((\d+))?\s*(\d+)$")
-        self._span     = re.compile("(fra)?\s*(?P<start>.+)\s*(til|--|–)\s*(?P<stop>.+)",
-                                    re.IGNORECASE)
-        self._range    = re.compile("(mellom)\s+(?P<start>.+)\s+og\s+(?P<stop>.+)",
-                                    re.IGNORECASE)
+        self._numeric = re.compile(r"((\d+)[\.])?\s*((\d+))?\s*(\d+)$")
+        self._span = re.compile(
+            r"(fra)?\s*(?P<start>.+)\s*(til|--|–)\s*(?P<stop>.+)",
+            re.IGNORECASE)
+        self._range = re.compile(
+            r"(mellom)\s+(?P<start>.+)\s+og\s+(?P<stop>.+)", re.IGNORECASE)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_nl.py
+++ b/gramps/gen/datehandler/_date_nl.py
@@ -119,16 +119,14 @@ class DateParserNL(DateParser):
 
     def init_strings(self):
         DateParser.init_strings(self)
-        self._span  = re.compile("(van)\s+(?P<start>.+)\s+(tot)\s+(?P<stop>.+)",
+        self._span = re.compile(
+            r"(van)\s+(?P<start>.+)\s+(tot)\s+(?P<stop>.+)", re.IGNORECASE)
+        self._range = re.compile(r"tussen\s+(?P<start>.+)\s+en\s+(?P<stop>.+)",
                                  re.IGNORECASE)
-        self._range  = re.compile("tussen\s+(?P<start>.+)\s+en\s+(?P<stop>.+)",
-                                  re.IGNORECASE)
-        self._text2  = re.compile('(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?'
-                                  % self._mon_str,
-                                  re.IGNORECASE)
-        self._jtext2 = re.compile('(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?'
-                                  % self._jmon_str,
-                                  re.IGNORECASE)
+        self._text2 = re.compile(r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?'
+                                 % self._mon_str, re.IGNORECASE)
+        self._jtext2 = re.compile(r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?'
+                                  % self._jmon_str, re.IGNORECASE)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_pl.py
+++ b/gramps/gen/datehandler/_date_pl.py
@@ -156,13 +156,16 @@ class DateParserPL(DateParser):
 
     def init_strings(self):
         DateParser.init_strings(self)
-        self._span  = re.compile("(od)\s+(?P<start>.+)\s+(do)\s+(?P<stop>.+)", re.IGNORECASE)
+        self._span = re.compile(
+            r"(od)\s+(?P<start>.+)\s+(do)\s+(?P<stop>.+)", re.IGNORECASE)
         # Also handle a common mistakes
-        self._range = re.compile("((?:po)?mi(?:ę|e)dzy)\s+(?P<start>.+)\s+(a)\s+(?P<stop>.+)", re.IGNORECASE)
-        self._text2 = re.compile('(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?' % self._mon_str,
-                                 re.IGNORECASE)
-        self._jtext2 = re.compile('(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?' % self._jmon_str,
-                                 re.IGNORECASE)
+        self._range = re.compile(
+            r"((?:po)?mi(?:ę|e)dzy)\s+(?P<start>.+)\s+(a)\s+(?P<stop>.+)",
+            re.IGNORECASE)
+        self._text2 = re.compile(r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?'
+                                 % self._mon_str, re.IGNORECASE)
+        self._jtext2 = re.compile(r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?'
+                                  % self._jmon_str, re.IGNORECASE)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_pt.py
+++ b/gramps/gen/datehandler/_date_pt.py
@@ -102,13 +102,13 @@ class DateParserPT(DateParser):
         DateParser.init_strings(self)
         _span_1 = ['de']
         _span_2 = ['a']
-        _range_1 = ['entre','ent\.','ent']
+        _range_1 = ['entre', r'ent\.', 'ent']
         _range_2 = ['e']
-        self._span =  re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_span_1), '|'.join(_span_2)),
-                                 re.IGNORECASE)
-        self._range = re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2)),
+        self._span = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+                                % ('|'.join(_span_1), '|'.join(_span_2)),
+                                re.IGNORECASE)
+        self._range = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+                                 % ('|'.join(_range_1), '|'.join(_range_2)),
                                  re.IGNORECASE)
 
 #-------------------------------------------------------------------------

--- a/gramps/gen/datehandler/_date_ru.py
+++ b/gramps/gen/datehandler/_date_ru.py
@@ -94,13 +94,13 @@ class DateParserRU(DateParser):
         _span_1 = ['с', 'от']
         #_span_2 = ['по', 'до'] # <-- clashes with bce parsing :-(
         _span_2 = ['по']
-        _range_1 = ['между', 'меж\.', 'меж']
+        _range_1 = ['между', r'меж\.', 'меж']
         _range_2 = ['и']
-        self._span =  re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_span_1), '|'.join(_span_2)),
-                                 re.IGNORECASE)
-        self._range = re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2)),
+        self._span = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+                                % ('|'.join(_span_1), '|'.join(_span_2)),
+                                re.IGNORECASE)
+        self._range = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+                                 % ('|'.join(_range_1), '|'.join(_range_2)),
                                  re.IGNORECASE)
 
 #-------------------------------------------------------------------------

--- a/gramps/gen/datehandler/_date_sk.py
+++ b/gramps/gen/datehandler/_date_sk.py
@@ -86,11 +86,11 @@ class DateParserSK(DateParser):
         _span_2 = ['do']
         _range_1 = ['medzi']
         _range_2 = ['a']
-        self._span =  re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_span_1), '|'.join(_span_2)),
-                                 re.IGNORECASE)
-        self._range = re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2)),
+        self._span = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+                                % ('|'.join(_span_1), '|'.join(_span_2)),
+                                re.IGNORECASE)
+        self._range = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+                                 % ('|'.join(_range_1), '|'.join(_range_2)),
                                  re.IGNORECASE)
 
 #-------------------------------------------------------------------------

--- a/gramps/gen/datehandler/_date_sl.py
+++ b/gramps/gen/datehandler/_date_sl.py
@@ -88,18 +88,18 @@ class DateParserSL(DateParser):
 
         DateParser.init_strings(self)
         # match 'Day. MONTH year.' format with or without dots
-        self._text2 = re.compile('(\d+)?\.?\s*?%s\.?\s*((\d+)(/\d+)?)?\s*\.?$'
-                                % self._mon_str, re.IGNORECASE)
+        self._text2 = re.compile(r'(\d+)?\.?\s*?%s\.?\s*((\d+)(/\d+)?)?\s*\.?$'
+                                 % self._mon_str, re.IGNORECASE)
         # match Day.Month.Year.
-        self._numeric  = re.compile("((\d+)[/\.-])?\s*((\d+)[/\.-])?\s*(\d+)\.?$")
+        self._numeric = re.compile(
+            r"((\d+)[/\.-])?\s*((\d+)[/\.-])?\s*(\d+)\.?$")
 
-        self._span  = re.compile("od\s+(?P<start>.+)\s+do\s+(?P<stop>.+)",
+        self._span = re.compile(r"od\s+(?P<start>.+)\s+do\s+(?P<stop>.+)",
                                 re.IGNORECASE)
         self._range = re.compile(
-                            "med\s+(?P<start>.+)\s+in\s+(?P<stop>.+)",
-                            re.IGNORECASE)
-        self._jtext2 = re.compile('(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?'\
-                                % self._jmon_str, re.IGNORECASE)
+            r"med\s+(?P<start>.+)\s+in\s+(?P<stop>.+)", re.IGNORECASE)
+        self._jtext2 = re.compile(r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?'
+                                  % self._jmon_str, re.IGNORECASE)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_sr.py
+++ b/gramps/gen/datehandler/_date_sr.py
@@ -208,21 +208,22 @@ class DateParserSR(DateParser):
         """
         DateParser.init_strings(self)
         # match 'Day. MONTH year.' format with or without dots
-        self._text2 = re.compile('(\d+)?\.?\s*?%s\s*((\d+)(/\d+)?)?\.?\s*$'
-                                % self._mon_str, re.IGNORECASE)
+        self._text2 = re.compile(r'(\d+)?\.?\s*?%s\s*((\d+)(/\d+)?)?\.?\s*$'
+                                 % self._mon_str, re.IGNORECASE)
 
         # match Day.Month.Year.
-        self._numeric  = re.compile("((\d+)[/\. ])?\s*((\d+)[/\.])?\s*(\d+)\.?$")
+        self._numeric = re.compile(
+            r"((\d+)[/\. ])?\s*((\d+)[/\.])?\s*(\d+)\.?$")
 
         _span_1 = ['od', 'од']
         _span_2 = ['do', 'до']
         _range_1 = ['između', 'између']
         _range_2 = ['i', 'и']
-        self._span =  re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_span_1), '|'.join(_span_2)),
-                                 re.IGNORECASE)
-        self._range = re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2)),
+        self._span = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+                                % ('|'.join(_span_1), '|'.join(_span_2)),
+                                re.IGNORECASE)
+        self._range = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+                                 % ('|'.join(_range_1), '|'.join(_range_2)),
                                  re.IGNORECASE)
 
 #-------------------------------------------------------------------------

--- a/gramps/gen/datehandler/_date_sv.py
+++ b/gramps/gen/datehandler/_date_sv.py
@@ -95,14 +95,16 @@ class DateParserSv(DateParser):
     def init_strings(self):
         """ Define, in Swedish, span and range regular expressions"""
         DateParser.init_strings(self)
-        self._numeric = re.compile("((\d+)/)?\s*((\d+)/)?\s*(\d+)[/ ]?$")
+        self._numeric = re.compile(r"((\d+)/)?\s*((\d+)/)?\s*(\d+)[/ ]?$")
         # this next RE has the (possibly-slashed) year at the string's start
-        self._text2 = re.compile('((\d+)(/\d+)?)?\s+?%s\s*(\d+)?\s*$'
-                                     % self._mon_str, re.IGNORECASE)
-        self._span     = re.compile("(från)?\s*(?P<start>.+)\s*(till|--|–)\s*(?P<stop>.+)",
-                                    re.IGNORECASE)
-        self._range    = re.compile("(mellan)\s+(?P<start>.+)\s+och\s+(?P<stop>.+)",
-                                    re.IGNORECASE)
+        self._text2 = re.compile(r'((\d+)(/\d+)?)?\s+?%s\s*(\d+)?\s*$'
+                                 % self._mon_str, re.IGNORECASE)
+        self._span = re.compile(
+            r"(från)?\s*(?P<start>.+)\s*(till|--|–)\s*(?P<stop>.+)",
+            re.IGNORECASE)
+        self._range = re.compile(
+            r"(mellan)\s+(?P<start>.+)\s+och\s+(?P<stop>.+)",
+            re.IGNORECASE)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_uk.py
+++ b/gramps/gen/datehandler/_date_uk.py
@@ -108,14 +108,14 @@ class DateParserUK(DateParser):
 
         _span_1 = ['з', 'від']
         # b.c.e. pattern also have "до" so skip "до н."
-        _span_2 = ['по', 'до(?!\s+н)']
+        _span_2 = ['по', r'до(?!\s+н)']
         _range_1 = ['між']
         _range_2 = ['і', 'та']
-        self._span  = re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_span_1), '|'.join(_span_2)),
-                                 re.IGNORECASE)
-        self._range = re.compile("(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2)),
+        self._span = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
+                                ('|'.join(_span_1), '|'.join(_span_2)),
+                                re.IGNORECASE)
+        self._range = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+                                 % ('|'.join(_range_1), '|'.join(_range_2)),
                                  re.IGNORECASE)
 
 #-------------------------------------------------------------------------

--- a/gramps/gen/datehandler/_date_zh_CN.py
+++ b/gramps/gen/datehandler/_date_zh_CN.py
@@ -124,13 +124,13 @@ class DateParserZH_CN(DateParser):
         _span_2 = ['至']
         _range_1 = ['介于']
         _range_2 = ['与']
-        self._span =  re.compile("(%s)(?P<start>.+)(%s)(?P<stop>\d+)" %
-                                 ('|'.join(_span_1), '|'.join(_span_2)),
-                                 re.IGNORECASE)
-        self._range = re.compile("(%s)(?P<start>.+)(%s)(?P<stop>\d+)" %
+        self._span = re.compile(r"(%s)(?P<start>.+)(%s)(?P<stop>\d+)" %
+                                ('|'.join(_span_1), '|'.join(_span_2)),
+                                re.IGNORECASE)
+        self._range = re.compile(r"(%s)(?P<start>.+)(%s)(?P<stop>\d+)" %
                                  ('|'.join(_range_1), '|'.join(_range_2)),
                                  re.IGNORECASE)
-        self._numeric = re.compile("((\d+)年\s*)?((\d+)月\s*)?(\d+)?日?\s*$")
+        self._numeric = re.compile(r"((\d+)年\s*)?((\d+)月\s*)?(\d+)?日?\s*$")
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_zh_TW.py
+++ b/gramps/gen/datehandler/_date_zh_TW.py
@@ -124,13 +124,13 @@ class DateParserZH_TW(DateParser):
         _span_2 = ['至']
         _range_1 = ['介於']
         _range_2 = ['與']
-        self._span =  re.compile("(%s)(?P<start>.+)(%s)(?P<stop>\d+)" %
-                                 ('|'.join(_span_1), '|'.join(_span_2)),
-                                 re.IGNORECASE)
-        self._range = re.compile("(%s)(?P<start>.+)(%s)(?P<stop>\d+)" %
+        self._span = re.compile(r"(%s)(?P<start>.+)(%s)(?P<stop>\d+)" %
+                                ('|'.join(_span_1), '|'.join(_span_2)),
+                                re.IGNORECASE)
+        self._range = re.compile(r"(%s)(?P<start>.+)(%s)(?P<stop>\d+)" %
                                  ('|'.join(_range_1), '|'.join(_range_2)),
                                  re.IGNORECASE)
-        self._numeric = re.compile("((\d+)年\s*)?((\d+)月\s*)?(\d+)?日?\s*$")
+        self._numeric = re.compile(r"((\d+)年\s*)?((\d+)月\s*)?(\d+)?日?\s*$")
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_dateparser.py
+++ b/gramps/gen/datehandler/_dateparser.py
@@ -193,7 +193,7 @@ class DateParser:
     converted, the text string is assigned.
     """
 
-    _dhformat_parse = re.compile(".*%(\S).*%(\S).*%(\S).*")
+    _dhformat_parse = re.compile(r".*%(\S).*%(\S).*%(\S).*")
 
     # RFC-2822 only uses capitalized English abbreviated names, no locales.
     _rfc_days = ('Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat')
@@ -423,63 +423,69 @@ class DateParser:
         # bce, calendar type and quality may be either at the end or at
         # the beginning of the given date string, therefore they will
         # be parsed from the middle and will be in match.group(2).
-        self._bce_re    = re.compile("(.*)\s+%s( ?.*)" % self._bce_str)
+        self._bce_re = re.compile(r"(.*)\s+%s( ?.*)" % self._bce_str)
 
-        self._cal       = re.compile("(.*)\s+\(%s\)( ?.*)" % self._cal_str,
-                                     re.IGNORECASE)
-        self._calny     = re.compile("(.*)\s+\(%s,\s*%s\)( ?.*)" % (self._cal_str,
-                                                                    self._ny_str),
-                                     re.IGNORECASE)
-        self._calny_iso = re.compile("(.*)\s+\(%s,\s*(\d{1,2}-\d{1,2})\)( ?.*)" % self._cal_str,
-                                     re.IGNORECASE)
+        self._cal = re.compile(r"(.*)\s+\(%s\)( ?.*)" % self._cal_str,
+                               re.IGNORECASE)
+        self._calny = re.compile(r"(.*)\s+\(%s,\s*%s\)( ?.*)" %
+                                 (self._cal_str, self._ny_str), re.IGNORECASE)
+        self._calny_iso = re.compile(
+            r"(.*)\s+\(%s,\s*(\d{1,2}-\d{1,2})\)( ?.*)" % self._cal_str,
+            re.IGNORECASE)
 
-        self._ny        = re.compile("(.*)\s+\(%s\)( ?.*)" % self._ny_str,
-                                     re.IGNORECASE)
-        self._ny_iso    = re.compile("(.*)\s+\((\d{1,2}-\d{1,2})\)( ?.*)")
+        self._ny = re.compile(r"(.*)\s+\(%s\)( ?.*)" % self._ny_str,
+                              re.IGNORECASE)
+        self._ny_iso = re.compile(r"(.*)\s+\((\d{1,2}-\d{1,2})\)( ?.*)")
 
-        self._qual     = re.compile("(.* ?)%s\s+(.+)" % self._qual_str,
-                                    re.IGNORECASE)
+        self._qual = re.compile(r"(.* ?)%s\s+(.+)" % self._qual_str,
+                                re.IGNORECASE)
 
-        self._span     = re.compile("(from)\s+(?P<start>.+)\s+to\s+(?P<stop>.+)",
+        self._span = re.compile(r"(from)\s+(?P<start>.+)\s+to\s+(?P<stop>.+)",
+                                re.IGNORECASE)
+        self._range = re.compile(
+            r"(bet|bet.|between)\s+(?P<start>.+)\s+and\s+(?P<stop>.+)",
+            re.IGNORECASE)
+        self._modifier = re.compile(r'%s\s+(.*)' % self._mod_str,
                                     re.IGNORECASE)
-        self._range    = re.compile("(bet|bet.|between)\s+(?P<start>.+)\s+and\s+(?P<stop>.+)",
-                                    re.IGNORECASE)
-        self._modifier = re.compile('%s\s+(.*)' % self._mod_str,
-                                    re.IGNORECASE)
-        self._modifier_after = re.compile('(.*)\s+%s' % self._mod_after_str,
+        self._modifier_after = re.compile(r'(.*)\s+%s' % self._mod_after_str,
                                           re.IGNORECASE)
-        self._abt2     = re.compile('<(.*)>', re.IGNORECASE)
-        self._text     = re.compile('%s\.?(\s+\d+)?\s*,?\s+((\d+)(/\d+)?)?\s*$'
-                                        % self._mon_str, re.IGNORECASE)
+        self._abt2 = re.compile('<(.*)>', re.IGNORECASE)
+        self._text = re.compile(r'%s\.?(\s+\d+)?\s*,?\s+((\d+)(/\d+)?)?\s*$'
+                                % self._mon_str, re.IGNORECASE)
         # this next RE has the (possibly-slashed) year at the string's end
-        self._text2    = re.compile('(\d+)?\s+?%s\.?\s*((\d+)(/\d+)?)?\s*$' % self._mon_str,
-                                    re.IGNORECASE)
-        self._jtext    = re.compile('%s\s+(\d+)?\s*,?\s*((\d+)(/\d+)?)?\s*$' % self._jmon_str,
-                                    re.IGNORECASE)
-        self._jtext2   = re.compile('(\d+)?\s+?%s\s*((\d+)(/\d+)?)?\s*$' % self._jmon_str,
-                                    re.IGNORECASE)
-        self._ftext    = re.compile('%s\s+(\d+)?\s*,?\s*((\d+)(/\d+)?)?\s*$' % self._fmon_str,
-                                    re.IGNORECASE)
-        self._ftext2   = re.compile('(\d+)?\s+?%s\s*((\d+)(/\d+)?)?\s*$' % self._fmon_str,
-                                    re.IGNORECASE)
-        self._ptext    = re.compile('%s\s+(\d+)?\s*,?\s*((\d+)(/\d+)?)?\s*$' % self._pmon_str,
-                                    re.IGNORECASE)
-        self._ptext2   = re.compile('(\d+)?\s+?%s\s*((\d+)(/\d+)?)?\s*$' % self._pmon_str,
-                                    re.IGNORECASE)
-        self._itext    = re.compile('%s\s+(\d+)?\s*,?\s*((\d+)(/\d+)?)?\s*$' % self._imon_str,
-                                    re.IGNORECASE)
-        self._itext2   = re.compile('(\d+)?\s+?%s\s*((\d+)(/\d+)?)?\s*$' % self._imon_str,
-                                    re.IGNORECASE)
-        self._stext     = re.compile('%s\.?\s+(\d+)?\s*,?\s*((\d+)(/\d+)?)?\s*$' % self._smon_str,
-                                    re.IGNORECASE)
-        self._stext2    = re.compile('(\d+)?\s+?%s\.?\s*((\d+)(/\d+)?)?\s*$' % self._smon_str,
-                                    re.IGNORECASE)
-        self._numeric  = re.compile("((\d+)[/\.]\s*)?((\d+)[/\.]\s*)?(\d+)\s*$")
-        self._iso      = re.compile("(\d+)(/(\d+))?-(\d+)-(\d+)\s*$")
-        self._isotimestamp = re.compile("^\s*?(\d{4})([01]\d)([0123]\d)(?:(?:[012]\d[0-5]\d[0-5]\d)|(?:\s+[012]\d:[0-5]\d(?::[0-5]\d)?))?\s*?$")
-        self._rfc      = re.compile("(%s,)?\s+(\d|\d\d)\s+%s\s+(\d+)\s+\d\d:\d\d(:\d\d)?\s+(\+|-)\d\d\d\d"
-                                    % (self._rfc_day_str, self._rfc_mon_str))
-        self._today = re.compile("^\s*%s\s*$" % self._today_str, re.IGNORECASE)
+        self._text2 = re.compile(r'(\d+)?\s+?%s\.?\s*((\d+)(/\d+)?)?\s*$'
+                                 % self._mon_str, re.IGNORECASE)
+        self._jtext = re.compile(r'%s\s+(\d+)?\s*,?\s*((\d+)(/\d+)?)?\s*$'
+                                 % self._jmon_str, re.IGNORECASE)
+        self._jtext2 = re.compile(r'(\d+)?\s+?%s\s*((\d+)(/\d+)?)?\s*$'
+                                  % self._jmon_str, re.IGNORECASE)
+        self._ftext = re.compile(r'%s\s+(\d+)?\s*,?\s*((\d+)(/\d+)?)?\s*$'
+                                 % self._fmon_str, re.IGNORECASE)
+        self._ftext2 = re.compile(r'(\d+)?\s+?%s\s*((\d+)(/\d+)?)?\s*$'
+                                  % self._fmon_str, re.IGNORECASE)
+        self._ptext = re.compile(r'%s\s+(\d+)?\s*,?\s*((\d+)(/\d+)?)?\s*$'
+                                 % self._pmon_str, re.IGNORECASE)
+        self._ptext2 = re.compile(r'(\d+)?\s+?%s\s*((\d+)(/\d+)?)?\s*$'
+                                  % self._pmon_str, re.IGNORECASE)
+        self._itext = re.compile(r'%s\s+(\d+)?\s*,?\s*((\d+)(/\d+)?)?\s*$'
+                                 % self._imon_str, re.IGNORECASE)
+        self._itext2 = re.compile(r'(\d+)?\s+?%s\s*((\d+)(/\d+)?)?\s*$'
+                                  % self._imon_str, re.IGNORECASE)
+        self._stext = re.compile(r'%s\.?\s+(\d+)?\s*,?\s*((\d+)(/\d+)?)?\s*$'
+                                 % self._smon_str, re.IGNORECASE)
+        self._stext2 = re.compile(r'(\d+)?\s+?%s\.?\s*((\d+)(/\d+)?)?\s*$'
+                                  % self._smon_str, re.IGNORECASE)
+        self._numeric = re.compile(
+            r"((\d+)[/\.]\s*)?((\d+)[/\.]\s*)?(\d+)\s*$")
+        self._iso = re.compile(r"(\d+)(/(\d+))?-(\d+)-(\d+)\s*$")
+        self._isotimestamp = re.compile(
+            r"^\s*?(\d{4})([01]\d)([0123]\d)(?:(?:[012]\d[0-5]\d[0-5]\d)|"
+            r"(?:\s+[012]\d:[0-5]\d(?::[0-5]\d)?))?\s*?$")
+        self._rfc = re.compile(
+            r"(%s,)?\s+(\d|\d\d)\s+%s\s+(\d+)\s+\d\d:\d\d(:\d\d)?\s+"
+            r"(\+|-)\d\d\d\d" % (self._rfc_day_str, self._rfc_mon_str))
+        self._today = re.compile(r"^\s*%s\s*$" % self._today_str,
+                                 re.IGNORECASE)
 
     def _get_int(self, val):
         """

--- a/gramps/gen/display/name.py
+++ b/gramps/gen/display/name.py
@@ -1059,13 +1059,13 @@ class NameDisplay:
             format_str = format_str[1:]
         else:
             patterns = [
-                ",\W*\"%(" + ("|".join(codes)) + ")\"",  # ,\W*"%s"
-                ",\W*\(%(" + ("|".join(codes)) + ")\)",  # ,\W*(%s)
-                ",\W*%(" + ("|".join(codes)) + ")",      # ,\W*%s
-                "\"%(" + ("|".join(codes)) + ")\"",      # "%s"
-                "_%(" + ("|".join(codes)) + ")_",        # _%s_
-                "\(%(" + ("|".join(codes)) + ")\)",      # (%s)
-                "%(" + ("|".join(codes)) + ")",          # %s
+                ",\\W*\"%(" + ("|".join(codes)) + ")\"",    # ,\W*"%s"
+                ",\\W*\\(%(" + ("|".join(codes)) + ")\\)",  # ,\W*(%s)
+                ",\\W*%(" + ("|".join(codes)) + ")",        # ,\W*%s
+                "\"%(" + ("|".join(codes)) + ")\"",         # "%s"
+                "_%(" + ("|".join(codes)) + ")_",           # _%s_
+                "\\(%(" + ("|".join(codes)) + ")\\)",       # (%s)
+                "%(" + ("|".join(codes)) + ")",             # %s
                 ]
         new_fmt = format_str
 

--- a/gramps/gen/filters/rules/_changedsincebase.py
+++ b/gramps/gen/filters/rules/_changedsincebase.py
@@ -56,17 +56,17 @@ class ChangedSinceBase(Rule):
     category    = _('General filters')
 
     def add_time(self, date):
-        if re.search("\d.*\s+\d{1,2}:\d{2}:\d{2}", date):
+        if re.search(r"\d.*\s+\d{1,2}:\d{2}:\d{2}", date):
             return date
-        elif re.search("\d.*\s+\d{1,2}:\d{2}", date):
+        elif re.search(r"\d.*\s+\d{1,2}:\d{2}", date):
             return date + ":00"
-        elif re.search("\d.*\s+\d{1,2}", date):
+        elif re.search(r"\d.*\s+\d{1,2}", date):
             return date + ":00:00"
-        elif re.search("\d{4}-\d{1,2}-\d{1,2}", date):
+        elif re.search(r"\d{4}-\d{1,2}-\d{1,2}", date):
             return date + " 00:00:00"
-        elif re.search("\d{4}-\d{1,2}", date):
+        elif re.search(r"\d{4}-\d{1,2}", date):
             return date + "-01 00:00:00"
-        elif re.search("\d{4}", date):
+        elif re.search(r"\d{4}", date):
             return date + "-01-01 00:00:00"
         else:
             return date

--- a/gramps/gen/lib/place.py
+++ b/gramps/gen/lib/place.py
@@ -520,11 +520,11 @@ class Place(CitationBase, NoteBase, MediaBase, UrlBase, PrimaryObject):
         Return a list of alternate :class:`~.location.Location` objects the
         present alternate information about the current Place.
 
-        A Place can have more than one :class:`~.location.Location`, since names
-        and jurisdictions can change over time for the same place.
+        A Place can have more than one :class:`~.location.Location`, since
+        names and jurisdictions can change over time for the same place.
 
-        :returns: Returns the alternate :class:`~.location.Location`\ s for the
-                  Place
+        :returns: Returns the alternate :class:`~.location.Location` objects
+                  for the Place
         :rtype: list of :class:`~.location.Location` objects
         """
         return self.alt_loc

--- a/gramps/gen/mime/_winmime.py
+++ b/gramps/gen/mime/_winmime.py
@@ -85,7 +85,7 @@ def _get_extension(mime_type):
     extension = None
     try:
         hcr = ConnectRegistry(None, HKEY_CLASSES_ROOT)
-        subkey = OpenKey(hcr, "MIME\DataBase\Content Type")
+        subkey = OpenKey(hcr, r"MIME\DataBase\Content Type")
         mimekey = OpenKey(subkey, mime_type)
         extension, value_type = QueryValueEx(mimekey, "Extension")
         CloseKey(mimekey)

--- a/gramps/gen/soundex.py
+++ b/gramps/gen/soundex.py
@@ -34,7 +34,7 @@ import unicodedata
 # constants
 #
 #-------------------------------------------------------------------------
-IGNORE = "HW~!@#$%^&*()_+=-`[]\|;:'/?.,<>\" \t\f\v"
+IGNORE = "HW~!@#$%^&*()_+=-`[]\\|;:'/?.,<>\" \t\f\v"
 TABLE = bytes.maketrans(b'ABCDEFGIJKLMNOPQRSTUVXYZ',
                         b'012301202245501262301202')
 

--- a/gramps/gen/utils/db.py
+++ b/gramps/gen/utils/db.py
@@ -256,7 +256,7 @@ def get_participant_from_event(db, event_handle, all_=False):
     Obtain the first primary or family participant to an event we find in the
     database. Note that an event can have more than one primary or
     family participant, only one is returned, adding ellipses if there are
-    more. If the all\_ parameter is true a comma-space separated string with
+    more. If the all_ parameter is true a comma-space separated string with
     the names of all primary participants is returned and no ellipses is used.
     """
     participant = ""

--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -1048,8 +1048,8 @@ def find_revisions(name):
     """
     import re
 
-    rev = re.compile("\s*revision\s+([\d\.]+)")
-    date = re.compile("date:\s+(\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d)[-+]\d\d;")
+    rev = re.compile(r"\s*revision\s+([\d\.]+)")
+    date = re.compile(r"date:\s+(\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d)[-+]\d\d;")
 
     if not os.path.isfile(name) or not _RCS_FOUND:
         return []

--- a/gramps/gui/editors/editlink.py
+++ b/gramps/gui/editors/editlink.py
@@ -142,7 +142,7 @@ class EditLink(ManagedWindow):
     def update_ui(self, widget):
         url = self.url_link.get_text()
         # text needs to have 3 or more chars://and at least one char
-        match = re.match("\w{3,}://\w+", url)
+        match = re.match(r"\w{3,}://\w+", url)
         if match:
             self.ok_button.set_sensitive(True)
         else:

--- a/gramps/plugins/docgen/latexdoc.py
+++ b/gramps/plugins/docgen/latexdoc.py
@@ -579,7 +579,7 @@ class LaTeXBackend(DocBackend):
             LaTeXBackend.ESCAPE_FUNC = lambda x: latexescapeverbatim
 
     def _create_xmltag(self, type, value):
-        """
+        r"""
         overwrites the method in DocBackend.
         creates the latex tags needed for non bool style types we support:
             FONTSIZE : use different \large denomination based
@@ -1267,7 +1267,8 @@ class LaTeXDoc(BaseDoc, TextDoc):
             text = re.sub(URL_PATTERN, _CLICKABLE, text)
 
         #hard coded replace of the underline used for missing names/data
-        text = text.replace('\\_'*13, '\\underline{\hspace{3\\grbaseindent}}')
+        text = text.replace('\\_' * 13,
+                            '\\underline{\\hspace{3\\grbaseindent}}')
         self.emit(text + ' ')
 
 

--- a/gramps/plugins/docgen/rtfdoc.py
+++ b/gramps/plugins/docgen/rtfdoc.py
@@ -102,7 +102,7 @@ class RTFDoc(BaseDoc, TextDoc):
             '{\\fonttbl\n'
             '{\\f0\\froman\\fcharset0\\fprq0 Times New Roman;}\n'
             '{\\f1\\fswiss\\fcharset0\\fprq0 Arial;}}\n'
-            '{\colortbl\n'
+            '{\\colortbl\n'
             )
 
         self.color_map = {}
@@ -442,7 +442,7 @@ class RTFDoc(BaseDoc, TextDoc):
         act_height = size[1]
 
         if self.in_table:
-            self.text += '{\*\shppict{\\pict\\jpegblip'
+            self.text += '{\\*\\shppict{\\pict\\jpegblip'
             self.text += '\\picwgoal%d\\pichgoal%d\n' % (act_width, act_height)
             index = 1
             for i in buf:
@@ -452,7 +452,7 @@ class RTFDoc(BaseDoc, TextDoc):
                 index = index+1
             self.text += '}}\\par\n'
         else:
-            self.file.write('{\*\shppict{\\pict\\jpegblip')
+            self.file.write('{\\*\\shppict{\\pict\\jpegblip')
             self.file.write('\\picwgoal%d\\pichgoal%d\n' % (act_width, act_height))
             index = 1
             for i in buf:

--- a/gramps/plugins/export/test/exportvcard_test.py
+++ b/gramps/plugins/export/test/exportvcard_test.py
@@ -170,7 +170,7 @@ class VCardCheck(unittest.TestCase):
 
     def test_write_name_honsuffix(self):
         ET.SubElement(self.name, "suffix").text = "Jr."
-        self.expect[3] = "FN:Lastname\, Jr."
+        self.expect[3] = "FN:Lastname\\, Jr."
         self.expect[4] = "N:Lastname;;;;Jr."
         self.expect[5] = "SORT-STRING:" + "Lastname".ljust(55)+ "Jr."
         self.do_case(self.database, self.expect)

--- a/gramps/plugins/importer/importgeneweb.py
+++ b/gramps/plugins/importer/importgeneweb.py
@@ -55,8 +55,9 @@ from gramps.gen.lib import (Attribute, AttributeType, ChildRef, Citation,
 from gramps.gen.db import DbTxn
 from html.entities import name2codepoint
 
-_date_parse = re.compile('([kmes~?<>]+)?([0-9/]+)([J|H|F])?(\.\.)?([0-9/]+)?([J|H|F])?')
-_text_parse = re.compile('0\((.*)\)')
+_date_parse = re.compile(
+    r'([kmes~?<>]+)?([0-9/]+)([J|H|F])?(\.\.)?([0-9/]+)?([J|H|F])?')
+_text_parse = re.compile(r'0\((.*)\)')
 
 _mod_map = {
     '>' : Date.MOD_AFTER,
@@ -312,7 +313,7 @@ class GeneWebParser:
         return None
 
     def read_relationship_person(self,line,fields):
-        LOG.debug("\Relationships:")
+        LOG.debug(r"\Relationships:")
         (idx,person) = self.parse_person(fields,1,Person.UNKNOWN,None)
         if person:
             self.current_relationship_person_handle = person.get_handle()
@@ -607,7 +608,7 @@ class GeneWebParser:
             firstname = self.decode(fields[idx])
         idx += 1
         if idx < len(fields) and father_surname:
-            noSurnameRe = re.compile("^[({\[~><?0-9#].*$")
+            noSurnameRe = re.compile(r"^[({\[~><?0-9#].*$")
             if not noSurnameRe.match(fields[idx]):
                 surname = self.decode(fields[idx])
                 idx += 1
@@ -623,7 +624,7 @@ class GeneWebParser:
         if person.get_gender() == Person.UNKNOWN and gender is not None:
             person.set_gender(gender)
         self.db.commit_person(person,self.trans)
-        personDataRe = re.compile("^[kmes0-9<>~#\[({!].*$")
+        personDataRe = re.compile(r"^[kmes0-9<>~#\[({!].*$")
         dateRe = re.compile("^[kmes0-9~<>?]+.*$")
 
         source = None

--- a/gramps/plugins/importer/importxml.py
+++ b/gramps/plugins/importer/importxml.py
@@ -708,7 +708,7 @@ class GrampsParser(UpdateCallback):
             "rname": (None, self.stop_rname),
         }
         self.grampsuri = re.compile(r"^gramps://(?P<object_class>[A-Z][a-z]+)/"
-            "handle/(?P<handle>\w+)$")
+                                    r"handle/(?P<handle>\w+)$")
 
     def inaugurate(self, handle, target, prim_obj):
         """

--- a/gramps/plugins/importer/test/importvcard_test.py
+++ b/gramps/plugins/importer/test/importvcard_test.py
@@ -144,11 +144,12 @@ class VCardCheck(unittest.TestCase):
                          "TEL:012\\345,67;89")
 
     def test_unesc_list(self):
-        self.assertEqual(VCardParser.unesc(["Last\,name", "First\;name"]),
+        self.assertEqual(VCardParser.unesc([r"Last\,name", r"First\;name"]),
                          ["Last,name", "First;name"])
 
     def test_unesc_tuple(self):
-        self.assertRaises(TypeError, VCardParser.unesc, ("Last\,name", "First\;name"))
+        self.assertRaises(TypeError, VCardParser.unesc,
+                          (r"Last\,name", r"First\;name"))
 
     def test_count_escapes_null(self):
         self.assertEqual(VCardParser.count_escapes("Lastname"), 0)
@@ -371,7 +372,7 @@ class VCardCheck(unittest.TestCase):
         self.do_case("\r\n".join(self.vcard), self.gramps)
 
     def test_add_nicknames_multiple(self):
-        self.vcard.insert(4, "NICKNAME:A,B\,C")
+        self.vcard.insert(4, r"NICKNAME:A,B\,C")
         attribs = {"alt": "1", "type": "Birth Name"}
         name = ET.SubElement(self.person, 'name', attribs)
         ET.SubElement(name, 'nick').text = "A"
@@ -391,7 +392,7 @@ class VCardCheck(unittest.TestCase):
         self.do_case("\r\n".join(self.vcard), self.gramps)
 
     def test_add_address_too_many(self):
-        self.vcard.insert(4, "ADR:;;Broadway 11; New\,York; ;; USA; Earth")
+        self.vcard.insert(4, r"ADR:;;Broadway 11; New\,York; ;; USA; Earth")
         address = ET.SubElement(self.person, 'address')
         ET.SubElement(address, 'street').text = 'Broadway 11'
         ET.SubElement(address, 'city').text = 'New,York'

--- a/gramps/plugins/tool/reorderids.py
+++ b/gramps/plugins/tool/reorderids.py
@@ -561,10 +561,10 @@ class ReorderIds(tool.BatchTool, ManagedWindow, UpdateCallback):
             print('\nDone.')
 
     # finds integer portion in a GrampsID
-    _findint = re.compile('^[^\d]*(\d+)[^\d]*$')
+    _findint = re.compile(r'^[^\d]*(\d+)[^\d]*$')
     # finds prefix, number, suffix of a Gramps ID ignoring a leading or
     # trailing space.  The number must be at least three digits.
-    _prob_id = re.compile('^ *([^\d]*)(\d{3,9})([^\d]*) *$')
+    _prob_id = re.compile(r'^ *([^\d]*)(\d{3,9})([^\d]*) *$')
 
     def _reorder(self, prim_obj):
         """ reorders all selected objects with a (new) style, start & step """

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,8 @@ def intltool_version():
     Return the version of intltool as a tuple.
     '''
     if sys.platform == 'win32':
-        cmd = ["perl", "-e print qx(intltool-update --version) =~ m/(\d+.\d+.\d+)/;"]
+        cmd = ["perl",
+               r"-e print qx(intltool-update --version) =~ m/(\d+.\d+.\d+)/;"]
         try:
             ver, ret = subprocess.Popen(cmd ,stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE, shell=True).communicate()

--- a/windows/nonAIO/builder/build_GrampsWin32.py
+++ b/windows/nonAIO/builder/build_GrampsWin32.py
@@ -222,7 +222,7 @@ class buildbase(GObject.GObject):
             os.makedirs(mo_dir)
         #TODO: find a better way to handle  different platforms
         if sys.platform == 'win32':
-            po_files = glob.glob(po_dir + "\*.po")
+            po_files = glob.glob(po_dir + r"\*.po")
             # no longer using python msgfmt as it doesn't handle plurals (april 2010)
             # msgfmtCmd = path.normpath(path.join(sys.prefix, "Tools/i18n/msgfmt.py") )
 

--- a/windows/nonAIO/builder/check_gtk_install.py
+++ b/windows/nonAIO/builder/check_gtk_install.py
@@ -138,7 +138,8 @@ def ScanDependencyFileForErrors(fname):
             parts = line[pthend_idx:].split()
             OK = False
             if dirname.startswith(os.path.join(sysroot, 'winsxs').lower()) \
-            or dirname.startswith(os.path.join(sys.prefix, 'lib\site-packages\gtk-2.0').lower()):
+                or dirname.startswith(os.path.join(
+                    sys.prefix, r'lib\site-packages\gtk-2.0').lower()):
                 OK = True
 
             for pth in acceptablePaths:

--- a/windows/nonAIO/builder/make_launcher.py
+++ b/windows/nonAIO/builder/make_launcher.py
@@ -139,7 +139,7 @@ def writeLauncher(language, langcode, runtimepath, grampspath):
 @rem During the boot process of GRAMPS there is a check for an environment variable
 @rem called GRAMPSHOME. Without this environment variable GRAMPS uses the default
 @rem windows path as the location to save all configuration files:
-@rem <system drive>\<userpath>\<application data>\gramps
+@rem <system drive>\\<userpath>\\<application data>\\gramps
 @rem If required, uncomment GRAMPSHOME line and edit to suit your use.
  ''')
     lines.append('\n@rem set the path for GRAMPS configuration files')

--- a/windows/nonAIO/check_gtk_install.py
+++ b/windows/nonAIO/check_gtk_install.py
@@ -133,7 +133,8 @@ def ScanDependencyFileForErrors(fname):
             parts = line[pthend_idx:].split()
             OK = False
             if dirname.startswith(os.path.join(sysroot, 'winsxs').lower()) \
-            or dirname.startswith(os.path.join(sys.prefix, 'lib\site-packages\gtk-2.0').lower()):
+                or dirname.startswith(os.path.join(
+                    sys.prefix, r'lib\site-packages\gtk-2.0').lower()):
                 OK = True
 
             for pth in acceptablePaths:


### PR DESCRIPTION
Python 3.6 and above has deprecated illegal string escape sequences.  Escape sequences are preceded by a `'\'` and valid ones are "\n\t\r" etc.  Illegal ones are not in the list https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals.

Previous to Python 3.6 these illegal sequences were ignored and the `'\'` was left in place.  Pylint has been noting these for a while now.

This PR corrects these sequences in Gramps.  I used
`find . -name "*.py" | xargs -t -n 1 python3 -Wd -m py_compile 2>&1 | grep Depre`
to locate the failing strings.

I've done this work in gramps50 branch, as I expect it to live for a while.