### PR TITLE
Fix generate_checksum routine to avoid MemoryError crash

### DIFF
--- a/gramps/gen/utils/file.py
+++ b/gramps/gen/utils/file.py
@@ -251,11 +251,17 @@ def create_checksum(full_path):
     Create a md5 hash for the given file.
     """
     full_path = os.path.normpath(full_path)
+    md5 = hashlib.md5()
     try:
         with open(full_path, 'rb') as media_file:
-            md5sum = hashlib.md5(media_file.read()).hexdigest()
+            while True:
+                buf = media_file.read(65536)
+                if not buf:
+                    break
+                md5.update(buf)
+        md5sum = md5.hexdigest()
     except IOError:
-            md5sum = ''
+        md5sum = ''
     except UnicodeEncodeError:
-            md5sum = ''
+        md5sum = ''
     return md5sum


### PR DESCRIPTION
with very large files and 32-bit OS

Issue [#10690](https://gramps-project.org/bugs/view.php?id=10690)

Original method tried to load entire file into memory for processing at once; crashed on 32-bit systems.  This processes file in 64k chunks.

Note that I also am fixing the MediaVerify Addon to use the now fixed gen/utils/file generate_checksum routine instead of rolling its own.  So it will also start working when this PR is accepted.