### PR TITLE
Fix usage of posixpath; should be os.path for os independence

### DIFF
--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -38,7 +38,6 @@ import os
 import time
 import datetime
 from io import StringIO
-import posixpath
 import gc
 
 #-------------------------------------------------------------------------
@@ -1912,7 +1911,7 @@ class QuickBackup(ManagedWindow): # TODO move this class into its own module
         for media in self.dbstate.db.iter_media():
             fullname = media_path_full(self.dbstate.db, media.get_path())
             try:
-                fbytes += posixpath.getsize(fullname)
+                fbytes += os.path.getsize(fullname)
                 length = len(str(fbytes))
                 if fbytes <= 999999:
                     mbytes = "< 1"

--- a/gramps/plugins/gramplet/statsgramplet.py
+++ b/gramps/plugins/gramplet/statsgramplet.py
@@ -21,7 +21,7 @@
 # Python modules
 #
 #------------------------------------------------------------------------
-import posixpath
+import os
 
 #------------------------------------------------------------------------
 #
@@ -81,7 +81,7 @@ class StatsGramplet(Gramplet):
         for media in database.iter_media():
             fullname = media_path_full(database, media.get_path())
             try:
-                bytes += posixpath.getsize(fullname)
+                bytes += os.path.getsize(fullname)
                 length = len(str(bytes))
                 if bytes <= 999999:
                     mbytes = _("less than 1")

--- a/gramps/plugins/quickview/filterbyname.py
+++ b/gramps/plugins/quickview/filterbyname.py
@@ -32,7 +32,7 @@ from gramps.gui.plug.quick import run_quick_report_by_name_direct
 from gramps.gen.lib import Person
 from gramps.gen.datehandler import get_date
 
-import posixpath
+import os
 from collections import defaultdict
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
@@ -389,7 +389,7 @@ def run(database, document, filter_name, *args, **kwargs):
         for photo in database.iter_media():
             fullname = media_path_full(database, photo.get_path())
             try:
-                posixpath.getsize(fullname)
+                os.path.getsize(fullname)
             except:
                 stab.row(fullname)
                 matches += 1
@@ -399,7 +399,7 @@ def run(database, document, filter_name, *args, **kwargs):
         for photo in database.iter_media():
             fullname = media_path_full(database, photo.get_path())
             try:
-                bytes = posixpath.getsize(fullname)
+                bytes = os.path.getsize(fullname)
                 stab.row(fullname, str(bytes))
                 matches += 1
             except:

--- a/gramps/plugins/textreport/summary.py
+++ b/gramps/plugins/textreport/summary.py
@@ -30,7 +30,7 @@ Reports/Text Reports/Database Summary Report.
 # standard python modules
 #
 #------------------------------------------------------------------------
-import posixpath
+import os
 
 #------------------------------------------------------------------------
 #
@@ -233,7 +233,7 @@ class SummaryReport(Report):
         for media_id in self.__db.get_media_handles():
             media = self.__db.get_media_from_handle(media_id)
             try:
-                size_in_bytes += posixpath.getsize(
+                size_in_bytes += os.path.getsize(
                     media_path_full(self.__db, media.get_path()))
                 length = len(str(size_in_bytes))
                 if size_in_bytes <= 999999:

--- a/gramps/plugins/webreport/statistics.py
+++ b/gramps/plugins/webreport/statistics.py
@@ -74,7 +74,7 @@ class StatisticsPage(BasePage):
                                  for this report
         @param: title         -- Is the title of the web page
         """
-        import posixpath
+        import os
         BasePage.__init__(self, report, title)
         self.bibli = Bibliography()
         self.uplink = False
@@ -99,7 +99,7 @@ class StatisticsPage(BasePage):
             total_media += 1
             fullname = media_path_full(report.database, media.get_path())
             try:
-                chars += posixpath.getsize(fullname)
+                chars += os.path.getsize(fullname)
                 length = len(str(chars))
                 if chars <= 999999:
                     mbytes = _("less than 1")


### PR DESCRIPTION
Fixes #10740

Using posixpath routines causes UnicodeEncodeError on Windows machines if the path/filename contains non-ASCII characters.

According to https://docs.python.org/3/library/os.path.html?highlight=posixpath we should be using the os.path routines, which in turn call the appropriate routines for each OS.