### PR TITLE
Fix and restore Statistics Gramplet to 4.2.x status

### DIFF
--- a/gramps/plugins/gramplet/statsgramplet.py
+++ b/gramps/plugins/gramplet/statsgramplet.py
@@ -48,13 +48,15 @@ _YIELD_INTERVAL = 200
 # StatsGramplet class
 #
 #------------------------------------------------------------------------
+
+
 class StatsGramplet(Gramplet):
+    """ Display some statistics about the tree, with links to filtered quick
+    reports
+    """
     def init(self):
         self.set_text(_("No Family Tree loaded."))
         self.set_tooltip(_("Double-click item to see matches"))
-
-    def active_changed(self, handle):
-        self.update()
 
     def db_changed(self):
         self.connect(self.dbstate.db, 'person-add', self.update)
@@ -68,12 +70,17 @@ class StatsGramplet(Gramplet):
     def main(self):
         self.set_text(_("Processing..."))
         database = self.dbstate.db
+        personList = database.iter_people()
 
+        with_media = 0
         total_media = 0
+        incomp_names = 0
+        disconnected = 0
+        missing_bday = 0
         males = 0
         females = 0
         unknowns = 0
-        bytes = 0
+        bytes_cnt = 0
         notfound = []
 
         mobjects = database.get_number_of_media()
@@ -81,20 +88,54 @@ class StatsGramplet(Gramplet):
         for media in database.iter_media():
             fullname = media_path_full(database, media.get_path())
             try:
-                bytes += os.path.getsize(fullname)
-                length = len(str(bytes))
-                if bytes <= 999999:
+                bytes_cnt += os.path.getsize(fullname)
+                length = len(str(bytes_cnt))
+                if bytes_cnt <= 999999:
                     mbytes = _("less than 1")
                 else:
-                    mbytes = str(bytes)[:(length-6)]
+                    mbytes = str(bytes_cnt)[:(length - 6)]
             except OSError:
                 notfound.append(media.get_path())
 
-        if hasattr(database, 'genderStats'):
-            males = sum([v[0] for v in database.genderStats.stats.values()])
-            females = sum([v[1] for v in database.genderStats.stats.values()])
-            unknowns = sum([v[2] for v in database.genderStats.stats.values()])
+        for cnt, person in enumerate(personList):
+            length = len(person.get_media_list())
+            if length > 0:
+                with_media += 1
+                total_media += length
 
+            for name in ([person.get_primary_name()] +
+                         person.get_alternate_names()):
+
+                if name.get_first_name().strip() == "":
+                    incomp_names += 1
+                else:
+                    if name.get_surname_list():
+                        for surname in name.get_surname_list():
+                            if surname.get_surname().strip() == "":
+                                incomp_names += 1
+                    else:
+                        incomp_names += 1
+
+            if (not person.get_main_parents_family_handle() and
+                    not person.get_family_handle_list()):
+                disconnected += 1
+
+            birth_ref = person.get_birth_ref()
+            if birth_ref:
+                birth = database.get_event_from_handle(birth_ref.ref)
+                if not get_date(birth):
+                    missing_bday += 1
+            else:
+                missing_bday += 1
+
+            if person.get_gender() == Person.FEMALE:
+                females += 1
+            elif person.get_gender() == Person.MALE:
+                males += 1
+            else:
+                unknowns += 1
+            if not cnt % _YIELD_INTERVAL:
+                yield True
         self.clear_text()
         self.append_text(_("Individuals") + "\n")
         self.append_text("----------------------------\n")
@@ -112,6 +153,18 @@ class StatsGramplet(Gramplet):
                   'Filter', 'people with unknown gender')
         self.append_text(" %s" % unknowns)
         self.append_text("\n")
+        self.link(_("%s:") % _("Incomplete names"),
+                  'Filter', 'incomplete names')
+        self.append_text(" %s" % incomp_names)
+        self.append_text("\n")
+        self.link(_("%s:") % _("Individuals missing birth dates"),
+                  'Filter', 'people with missing birth dates')
+        self.append_text(" %s" % missing_bday)
+        self.append_text("\n")
+        self.link(_("%s:") % _("Disconnected individuals"),
+                  'Filter', 'disconnected people')
+        self.append_text(" %s" % disconnected)
+        self.append_text("\n")
         self.append_text("\n%s\n" % _("Family Information"))
         self.append_text("----------------------------\n")
         self.link(_("%s:") % _("Number of families"),
@@ -125,6 +178,10 @@ class StatsGramplet(Gramplet):
             self.append_text("\n")
         self.append_text("\n%s\n" % _("Media Objects"))
         self.append_text("----------------------------\n")
+        self.link(_("%s:") % _("Individuals with media objects"),
+                  'Filter', 'people with media')
+        self.append_text(" %s" % with_media)
+        self.append_text("\n")
         self.link(_("%s:") % _("Total number of media object references"),
                   'Filter', 'media references')
         self.append_text(" %s" % total_media)


### PR DESCRIPTION
Fixes [#10756](https://gramps-project.org/bugs/view.php?id=10756)

A bit of history.  bug [2060](https://gramps-project.org/bugs/view.php?id=2060) was filed a long time ago (2008), and a patch was added to close it in 2016.  I believe that the bug had already been patched by then, although I cannot be sure.  The patch caused the Gramplet to update anytime the active-changed signal occurred on a person view.  I suspect that this caused a fair amount of overhead on very large dbs as the entire person list was rescanned.

In any event, Doug Blank recently removed the original scan code, as well as some useful functionality.  And left behind a bug where a value was always zero.  The users email list had some complaints about the lost functionality, and I also saw some recent complaints that the gender statistics were incorrect.  Turns out that the db's genderstats data was incorrect, probably due to crashes after db updates.  The Genderstats don't get saved until db closes normally.  In addition, running the Genderstats rebuild tool, did not immediately appear to correct the situation, Gramps had to be restarted to show the updated results.

I added the original statistics code back into the Gramplet, suitably updated for 5.0.x.  So the Gramplet no longer depends on dbs genderstats, it scans for it now on its own.

I removed the update on active-changed function, so overhead is only present on actual db updates (which have their own signals).  I tested that the add, edit, and delete person changes do properly cause the statistics to update now.  So the active-changed signal is not necessary.
