### PR TITLE
Speed up Check and Repair, backlinks check stage.

### DIFF
--- a/gramps/plugins/tool/check.py
+++ b/gramps/plugins/tool/check.py
@@ -1271,6 +1271,13 @@ class CheckIntegrity:
         for key, blinks in my_blinks.items():
             for item in blinks:
                 self.progress.step()
+                if key not in db_blinks:
+                    # object has reference to something not in db;
+                    # should have been found in previous checks
+                    logging.warning('    Fail: reference to an object %(obj)s'
+                                    ' not in the db by %(ref)s!',
+                                    {'obj': key, 'ref': item})
+                    continue
                 if item not in db_blinks[key]:
                     # Object has reference with no cooresponding backlink
                     self.bad_backlinks += 1


### PR DESCRIPTION
There are complaints that the 'backlinks' check portion of Check and repair tool takes too long for large databases.  So I've marked this as a bug...  ( [10618](https://gramps-project.org/bugs/view.php?id=10618) )

This PR optimizes this process by scanning the db once to build backlink tables, and doing the checks against the in memory tables, rather than the database.

I have a db with 15900 generated individuals, 156000 total objects.  The current code backlink scan took 9.5 hours.  An actual (forced) backlink rebuild took 18 min.  With this optimization, the backlink scan drops to 3.2 minutes for the same db.  No changes to backlink rebuild, as that is in the db itself.
The current code working set on my Win64 machine was 249,860k.
The optimized code working set was 528,228k.

I've based this on Gramps50 branch, even though it might be considered an enhancement, as it seems to me to be worthwhile to get to users faster, to reduce the complaints about execution time.  It uses no new translation strings.