### PR TITLE
[Narrative webreport]Events difficult to read (screen and mobile)

### DIFF
--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -619,18 +619,10 @@ class BasePage: # pylint: disable=C1001
                 (self._("Event"), "ColumnEvent"),
                 (self._("Date"), "ColumnDate"),
                 (self._("Place"), "ColumnPlace"),
-                (self._("Description"), "ColumnDescription")]
+                (self._("Description"), "ColumnDescription"),
+                (self._("Sources"), "ColumnSources")]
         )
         trow += Html("/tr", close=None)
-        trow2 = Html("tr", indent=False)
-        trow2.extend(
-            Html("th", trans, class_=colclass, colspan=opt, inline=True)
-            for trans, colclass, opt in  [
-                ("", "ColumnEvent", 1),
-                (self._("Sources"), "ColumnSources", 1),
-                (self._("Notes"), "ColumnNotes", 2)]
-        )
-        trow.extend(trow2)
         return trow
 
     def display_event_row(self, event, event_ref, place_lat_long,
@@ -681,10 +673,10 @@ class BasePage: # pylint: disable=C1001
         )
 
         trow2 = Html("tr")
-        trow2 += Html("td", "", class_="ColumnSources")
+        trow2 += Html("td", "", class_="ColumnEvent")
         # get event source references
         srcrefs = self.get_citation_links(event.get_citation_list()) or "&nbsp;"
-        trow2 += Html("td", srcrefs, class_="ColumnSources")
+        trow += Html("td", srcrefs, class_="ColumnSources")
 
         # get event notes
         notelist = event.get_note_list()
@@ -707,7 +699,7 @@ class BasePage: # pylint: disable=C1001
             if notelist:
                 htmllist.extend(self.dump_notes(notelist))
 
-        trow2 += Html("td", htmllist, class_="ColumnNotes", colspan=2)
+        trow2 += Html("td", htmllist, class_="ColumnNotes", colspan=3)
 
         trow += trow2
         # return events table row to its callers


### PR DESCRIPTION
On the Narrative webreport the event is difficult to read depending the device we use.

Fixes #[10697](https://gramps-project.org/bugs/view.php?id=10697), #[10781](https://gramps-project.org/bugs/view.php?id=10781)