### PR TITLE
NarrativeWeb: space between place, description and

### DIFF
--- a/data/css/Web_Basic-Ash.css
+++ b/data/css/Web_Basic-Ash.css
@@ -330,6 +330,10 @@ table.IndividualList td.ColumnSurname {
     content: "";
 }
 
+table.eventlist tbody tr td.ColumnSources {
+    width: 5%;
+}
+
 /* Gallery
 ----------------------------------------------------- */
 #GalleryNav {

--- a/data/css/Web_Basic-Blue.css
+++ b/data/css/Web_Basic-Blue.css
@@ -489,7 +489,7 @@ table.eventlist tbody tr td.ColumnNotes {
     width: 20%;
 }
 table.eventlist tbody tr td.ColumnSources {
-    width: 17%;
+    width: 5%;
 }
 table.eventlist tbody tr td.ColumnPerson {
     width: 35%;

--- a/data/css/Web_Basic-Cypress.css
+++ b/data/css/Web_Basic-Cypress.css
@@ -373,6 +373,10 @@ table.IndividualList td.ColumnSurname {
     content: "";
 }
 
+table.eventlist tbody tr td.ColumnSources {
+    width: 5%;
+}
+
 /* Gallery
 ----------------------------------------------------- */
 #GalleryNav {

--- a/data/css/Web_Basic-Lilac.css
+++ b/data/css/Web_Basic-Lilac.css
@@ -366,6 +366,10 @@ table.IndividualList td.ColumnSurname {
     content: "";
 }
 
+table.eventlist tbody tr td.ColumnSources {
+    width: 5%;
+}
+
 /* Gallery
 ----------------------------------------------------- */
 #GalleryNav {

--- a/data/css/Web_Basic-Peach.css
+++ b/data/css/Web_Basic-Peach.css
@@ -366,6 +366,10 @@ table.IndividualList td.ColumnSurname {
     content: "";
 }
 
+table.eventlist tbody tr td.ColumnSources {
+    width: 5%;
+}
+
 /* Gallery
 ----------------------------------------------------- */
 #GalleryNav {

--- a/data/css/Web_Basic-Spruce.css
+++ b/data/css/Web_Basic-Spruce.css
@@ -366,6 +366,10 @@ table.IndividualList td.ColumnSurname {
     content: "";
 }
 
+table.eventlist tbody tr td.ColumnSources {
+    width: 5%;
+}
+
 /* Gallery
 ----------------------------------------------------- */
 #GalleryNav {

--- a/data/css/Web_Horizontal-Menus.css
+++ b/data/css/Web_Horizontal-Menus.css
@@ -32,7 +32,6 @@ body {
     background-color: #00029D;
     color: #00029D;
     width: 100%;
-    padding: 0px 14px;
 }
 
 /*   Navigation Menus

--- a/data/css/Web_Mainz.css
+++ b/data/css/Web_Mainz.css
@@ -312,6 +312,10 @@ table#SortByCount thead th.ColumnQuantity a:after {
     content: "";
 }
 
+table.eventlist tbody tr td.ColumnSources {
+    width: 5%;
+}
+
 /* Gallery
 -----------------------------------------------------------------*/
 #GalleryNav {

--- a/data/css/Web_Nebraska.css
+++ b/data/css/Web_Nebraska.css
@@ -576,6 +576,10 @@ table.relationships tbody tr td.ColumnPartner a:hover {
     content: "";
 }
 
+table.eventlist tbody tr td.ColumnSources {
+    width: 5%;
+}
+
 /* Gallery
 ----------------------------------------------------- */
 #Gallery {  }

--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -676,7 +676,7 @@ class BasePage: # pylint: disable=C1001
         trow2 += Html("td", "", class_="ColumnEvent")
         # get event source references
         srcrefs = self.get_citation_links(event.get_citation_list()) or "&nbsp;"
-        trow += Html("td", srcrefs, class_="ColumnSources")
+        trow += Html("td", srcrefs, class_="ColumnSources", rowspan=2)
 
         # get event notes
         notelist = event.get_note_list()
@@ -1391,10 +1391,10 @@ class BasePage: # pylint: disable=C1001
         # create stylesheet and favicon links
         links = Html("link", type="image/x-icon",
                      href=url4, rel="shortcut icon") + (
+                         Html("link", type="text/css", href=url3,
+                              media='print', rel="stylesheet", indent=False),
                          Html("link", type="text/css", href=url2,
                               media="screen", rel="stylesheet", indent=False),
-                         Html("link", type="text/css", href=url3,
-                              media='print', rel="stylesheet", indent=False)
                          )
 
         # Link to Navigation Menus stylesheet


### PR DESCRIPTION
              the event note when there is many sources.
              Change the css order between print and screen.
              The chosen theme can erase prior values.
              Add a width for the source column in all themes

Fixes #10810