### PR TITLE
Fixed issues in the Dutch relationship calculator

### DIFF
--- a/gramps/plugins/rel/rel_nl.py
+++ b/gramps/plugins/rel/rel_nl.py
@@ -4,6 +4,7 @@
 #
 # Copyright (C) 2003-2005  Donald N. Allingham
 # Copyright (C) 2008       Brian G. Matherly
+# Copyright (C) 2018       Robin van der Vliet
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -38,388 +39,240 @@ import gramps.gen.relationship
 #
 #-------------------------------------------------------------------------
 
-_removed_level = [ " ",
-                " eerste",
-                " tweede",
-                " derde",
-                " vierde",
-                " vijfde",
-                " zesde",
-                " zevende",
-                " achtste",
-                " negende",
-                " tiende",
-                " elfde",
-                " twaalfde",
-                " dertiende",
-                " veertiende",
-                " vijftiende",
-                " zestiende",
-                " zeventiende",
-                " achttiende",
-                " negentiende",
-                " twintigste",
-                " eenentwintigste",
-                " tweeëntwintigste",
-                " drieëntwingste",
-                " vierentwingste",
-                " vijfentwintigste",
-                " zesentwintigste",
-                " zevenentwintigste",
-                " achtentwintigste",
-                " negenentwintigste",
-                " dertigste" ]
+_ordinal_level = [ "",
+    "eerste", "tweede", "derde", "vierde", "vijfde",
+    "zesde", "zevende", "achtste", "negende", "tiende",
+    "elfde", "twaalfde", "dertiende", "veertiende", "vijftiende",
+    "zestiende", "zeventiende", "achttiende", "negentiende", "twintigste",
+    "eenentwintigste", "tweeëntwintigste", "drieëntwintigste", "vierentwintigste", "vijfentwintigste",
+    "zesentwintigste", "zevenentwintigste", "achtentwintigste", "negenentwintigste", "dertigste",
+    "eenendertigste", "tweeëndertigste", "drieëndertigste", "vierendertigste", "vijfendertigste",
+    "zesendertigste", "zevenendertigste", "achtendertigste", "negenendertigste", "veertigste",
+    "eenenveertigste", "tweeënveertigste", "drieënveertigste", "vierenveertigste", "vijfenveertigste",
+    "zesenveertigste", "zevenenveertigste", "achtenveertigste", "negenenveertigste", "vijftigste" ]
 
-_parents_level = [ "",
-                   "ouders",
-                   "grootouders",
-                   "overgrootouders",
-                   "betovergrootouders",
-                   "oudouders",
-                   "oudgrootouders",
-                   "oudovergrootouders",
-                   "oudbetovergrootouders",
-                   "stamouders",
-                   "stamgrootouders",        # gen 10
-                   "stamovergrootouders",
-                   "stambetovergrootouders",
-                   "stamoudouders",
-                   "stamoudgrootouders",
-                   "stamoudovergrootouders",
-                   "stamoudbetovergrootouders",
-                   "edelouders",
-                   "edelgrootoders",
-                   "edelovergrootoudouders",
-                   "edelbetovergrootouders", # gen 20
-                   "edeloudouders",
-                   "edeloudgrootouders",
-                   "edeloudvergrootouders",
-                   "edeloudbetovergrootouders",
-                   "edelstamouders",
-                   "edelstamgrootouders",
-                   "edelstamovergrootouders",
-                   "edelstambetovergrootouders",
-                   "edelstamoudouders" ]
+_removed_level = [ "", "",
+    "groot", "overgroot", "betovergroot", "oud", "oudgroot",
+    "oudovergroot", "oudbetovergroot", "stam", "stamgroot", "stamovergroot",
+    "stambetovergroot", "stamoud", "stamoudgroot", "stamoudovergroot", "stamoudbetovergroot",
+    "edel", "edelgroot", "edelovergroot", "edelbetovergroot", "edeloud",
+    "edeloudgroot", "edeloudovergroot", "edeloudbetovergroot", "edelstam", "edelstamgroot",
+    "edelstamovergroot", "edelstambetovergroot", "edelstamoud", "edelstamoudgroot", "edelstamoudovergroot",
+    "edelstamoudbetovergroot", "voor", "voorgroot", "voorovergroot", "voorbetovergroot",
+    "vooroud", "vooroudgroot", "vooroudovergroot", "vooroudbetovergroot", "voorstam",
+    "voorstamgroot", "voorstamovergroot", "voorstambetovergroot", "voorstamoud", "voorstamoudgroot",
+    "voorstamoudovergroot", "voorstamoudbetovergroot", "vooredel" ]
 
-_father_level = [ "",
-                  "%s%svader",
-                  "%s%sgrootvader",
-                  "%s%sovergrootvader",
-                  "%s%sbetovergrootvader",
-                  "%s%soudvader (generatie 5)",
-                  "%s%soudgrootvader (generatie 6)",
-                  "%s%soudovergrootvader (generatie 7)",
-                  "%s%soudbetovergrootvader (generatie 8)",
-                  "%s%sstamvader (generatie 9)",
-                  "%s%sstamgrootvader (generatie 10)",
-                  "%s%sstamovergrootvader (generatie 11)",
-                  "%s%sstambetovergrootvader (generatie 12)",
-                  "%s%sstamoudvader (generatie 13)",
-                  "%s%sstamoudgrootvader (generatie 14)",
-                  "%s%sstamoudovergrootvader (generatie 15)",
-                  "%s%sstamoudbetovergrootvader (generatie 16)",
-                  "%s%sedelvader (generatie 17)",
-                  "%s%sedelgrootvader (generatie 18)",
-                  "%s%sedelovergrootoudvader (generatie 19)",
-                  "%s%sedelbetovergrootvader (generatie 20)",
-                  "%s%sedeloudvader (generatie 21)",
-                  "%s%sedeloudgrootvader (generatie 22)",
-                  "%s%sedeloudvergrootvader (generatie 23)",
-                  "%s%sedeloudbetovergrootvader (generatie 24)",
-                  "%s%sedelstamvader (generatie 25)",
-                  "%s%sedelstamgrootvader (generatie 26)",
-                  "%s%sedelstamovergrootvader (generatie 27)",
-                  "%s%sedelstambetovergrootvader (generatie 28)",
-                  "%s%sedelstamoudvader (generatie 29)" ]
+_child_level = [ "", "",
+    "klein", "achterklein", "achterachterklein" ]
 
-_mother_level = [ "",
-                  "%s%smoeder",
-                  "%s%sgrootmoeder",
-                  "%s%sovergrootmoeder",
-                  "%s%sbetovergrootmoeder",
-                  "%s%soudmoeder (generatie 5)",
-                  "%s%soudgrootmoeder (generatie 6)",
-                  "%s%soudovergrootmoeder (generatie 7)",
-                  "%s%soudbetovergrootmoeder (generatie 8)",
-                  "%s%sstammoeder (generatie 9)",
-                  "%s%sstamgrootmoeder (generatie 10)",
-                  "%s%sstamovergrootmoeder (generatie 11)",
-                  "%s%sstambetovergrootmoeder (generatie 12)",
-                  "%s%sstamoudmoeder (generatie 13)",
-                  "%s%sstamoudgrootmoeder (generatie 14)",
-                  "%s%sstamoudovergrootmoeder (generatie 15)",
-                  "%s%sstamoudbetovergrootmoeder (generatie 16)",
-                  "%s%sedelmoeder (generatie 17)",
-                  "%s%sedelgrootmoeder (generatie 18)",
-                  "%s%sedelovergrootoudmoeder (generatie 19)",
-                  "%s%sedelbetovergrootmoeder (generatie 20)",
-                  "%s%sedeloudmoeder (generatie 21)",
-                  "%s%sedeloudgrootmoeder (generatie 22)",
-                  "%s%sedeloudvergrootmoeder (generatie 23)",
-                  "%s%sedeloudbetovergrootmoeder (generatie 24)",
-                  "%s%sedelstammoeder (generatie 25)",
-                  "%s%sedelstamgrootmoeder (generatie 26)",
-                  "%s%sedelstamovergrootmoeder (generatie 27)",
-                  "%s%sedelstambetovergrootmoeder (generatie 28)",
-                  "%s%sedelstamoudmoeder (generatie 29)" ]
+_nibling_level = [ "", "",
+    "achter", "achterachter", "achterachterachter" ]
 
-_ouder_level = [ "",
-                  "%s%souder ",
-                  "%s%sgrootouder",
-                  "%s%sovergrootouder",
-                  "%s%sbetovergrootouder",
-                  "%s%soudouder (generatie 5)",
-                  "%s%soudgrootouder (generatie 6)",
-                  "%s%soudovergrootouder (generatie 7)",
-                  "%s%soudbetovergrootouder (generatie 8)",
-                  "%s%sstamouder (generatie 9)",
-                  "%s%sstamgrootouder (generatie 10)",
-                  "%s%sstamovergrootouder (generatie 11)",
-                  "%s%sstambetovergrootouder (generatie 12)",
-                  "%s%sstamoudouder (generatie 13)",
-                  "%s%sstamoudgrootouder (generatie 14)",
-                  "%s%sstamoudovergrootouder (generatie 15)",
-                  "%s%sstamoudbetovergrootouder (generatie 16)",
-                  "%s%sedelouder (generatie 17)",
-                  "%s%sedelgrootouder (generatie 18)",
-                  "%s%sedelovergrootoudouder (generatie 19)",
-                  "%s%sedelbetovergrootouder (generatie 20)",
-                  "%s%sedeloudouder (generatie 21)",
-                  "%s%sedeloudgrootouder (generatie 22)",
-                  "%s%sedeloudvergrootouder (generatie 23)",
-                  "%s%sedeloudbetovergrootouder (generatie 24)",
-                  "%s%sedelstamouder (generatie 25)",
-                  "%s%sedelstamgrootouder (generatie 26)",
-                  "%s%sedelstamovergrootouder (generatie 27)",
-                  "%s%sedelstambetovergrootouder (generatie 28)",
-                  "%s%sedelstamoudouder (generatie 29)" ]
-
-_son_level = [ "",
-               "%s%szoon",
-               "%s%skleinzoon",
-               "%s%sachterkleinzoon",
-               "%s%sachterachterkleinzoon",
-               "%s%sachterachterachterkleinzoon"]
-
-_daughter_level = [ "",
-                    "%s%sdochter",
-                    "%s%skleindochter",
-                    "%s%sachterkleindochter",
-                    "%s%sachterachterkleindochter",
-                    "%s%sachterachterachterkleindochter"]
-
-_kind_level = [ "",
-                "%s%skind",
-                "%s%skleinkind",
-                "%s%sachterkleinkind",
-                "%s%sachterachterkleinkind",
-                "%s%sachterachterachterkleinkind"]
-
-_nephew_level = [ "",
-                  "%s%sneef",
-                  "%s%sachterneef",
-                  "%s%sachterachterneef" ]
-
-_niece_level = [ "",
-                 "%s%snicht",
-                 "%s%sachternicht",
-                 "%s%sachterachternicht"]
-_aunt_level = [ "",
-                "%s%stante",
-                "%s%sgroottante",
-                "%s%sovergroottante",
-                "%s%sbetovergroottante",
-                "%s%soudtante"]
-
-_uncle_level = [ "",
-                 "%s%soom",
-                 "%s%sgrootoom",
-                 "%s%sovergrootoom",
-                 "%s%sbetovergrootoom",
-                 "%s%soudoom"]
 #-------------------------------------------------------------------------
 #
 #
 #
 #-------------------------------------------------------------------------
+
 class RelationshipCalculator(gramps.gen.relationship.RelationshipCalculator):
     """
     RelationshipCalculator Class
     """
 
     #sibling strings
-    STEP = 'stief'
-    HALF = 'half'
+    STEP = "stief"
+    HALF = "half"
 
-    INLAW = 'aangetrouwde '
+    INLAW = "aangetrouwde "
 
     def __init__(self):
         gramps.gen.relationship.RelationshipCalculator.__init__(self)
 
     def get_parents(self, level):
-        if level > len(_parents_level)-1:
+        if level > len(_removed_level)-1:
             return "verre voorouders (%d generaties)" % level
+        elif level > 4:
+            return "%souders (%d generaties)" % (_removed_level[level], level)
         else:
-            return _parents_level[level]
+            return "%souders" % _removed_level[level]
 
-    def _get_father(self, level, step='', inlaw=''):
+    def _get_father(self, level, step="", inlaw=""):
         """Internal Dutch method to create relation string
         """
-        if level > len(_father_level)-1:
+        if level > len(_removed_level)-1:
             return "verre %s%svoorvader (%d generaties)" % (inlaw, step, level)
+        elif level > 4:
+            return "%s%s%svader (%d generaties)" % (inlaw, step, _removed_level[level], level)
         else:
-            return _father_level[level] % (inlaw, step)
+            return "%s%s%svader" % (inlaw, step, _removed_level[level])
 
-    def _get_son(self, level, step='', inlaw=''):
+    def _get_son(self, level, step="", inlaw=""):
         """Internal Dutch method to create relation string
         """
-        if level < len(_son_level):
-            return _son_level[level]  % (inlaw, step)
+        if level > len(_child_level)-1:
+            return "verre %s%sachterkleinzoon (%d generaties)" % (inlaw, step, level)
         else:
-            return "verre %s%sachterkleinzoon (%d generaties)" % (inlaw,
-                                                                  step, level)
+            return "%s%s%szoon" % (inlaw, step, _child_level[level])
 
-    def _get_mother(self, level, step='', inlaw=''):
+    def _get_mother(self, level, step="", inlaw=""):
         """Internal Dutch method to create relation string
         """
-        if level > len(_mother_level)-1:
-            return "verre %s%svoormoeder (%d generaties)"  % (inlaw, step, level)
+        if level > len(_removed_level)-1:
+            return "verre %s%svoormoeder (%d generaties)" % (inlaw, step, level)
+        elif level > 4:
+            return "%s%s%smoeder (%d generaties)" % (inlaw, step, _removed_level[level], level)
         else:
-            return _mother_level[level] % (inlaw, step)
+            return "%s%s%smoeder" % (inlaw, step, _removed_level[level])
 
-    def _get_daughter(self, level, step='', inlaw=''):
+    def _get_daughter(self, level, step="", inlaw=""):
         """Internal Dutch method to create relation string
         """
-        if level > len(_daughter_level)-1:
-            return "verre %s%sachterkleindochter (%d generaties)" % (inlaw,
-                                                                   step, level)
+        if level > len(_child_level)-1:
+            return "verre %s%sachterkleindochter (%d generaties)" % (inlaw, step, level)
         else:
-            return _daughter_level[level]  % (inlaw, step)
+            return "%s%s%sdochter" % (inlaw, step, _child_level[level])
 
-    def _get_parent_unknown(self, level, step='', inlaw=''):
+    def _get_parent_unknown(self, level, step="", inlaw=""):
         """Internal Dutch method to create relation string
         """
-        if level > len(_ouder_level)-1:
-            return "verre %s%svoorouder (%d generaties)"  % (inlaw, step, level)
-        elif level == 1:
-            return _mother_level[level] % (inlaw, step) + ' of ' + \
-                    _father_level[level] % (inlaw, step)
+        if level > len(_removed_level)-1:
+            return "verre %s%svoorouder (%d generaties)" % (inlaw, step, level)
+        elif level > 4:
+            return "%s%s%souder (%d generaties)" % (inlaw, step, _removed_level[level], level)
         else:
-            return _ouder_level[level] % (inlaw, step)
+            return "%s%s%souder" % (inlaw, step, _removed_level[level])
 
-    def _get_child_unknown(self, level, step='', inlaw=''):
+    def _get_child_unknown(self, level, step="", inlaw=""):
         """Internal Dutch method to create relation string
         """
-        if level > len(_kind_level)-1:
-            return "ver %s%sachterkleinkind (%d generaties)" % (inlaw, step,
-                                                                level)
-        else:
-            return _kind_level[level]  % (inlaw, step)
+        if inlaw == "aangetrouwde ":
+            #The word "kind" is grammatically neuter, so it has a different adjective.
+            inlaw = "aangetrouwd "
 
-    def _get_aunt(self, level, removed, step='', inlaw=''):
+        if level > len(_child_level)-1:
+            return "ver %s%sachterkleinkind (%d generaties)" % (inlaw, step, level)
+        else:
+            return "%s%s%skind" % (inlaw, step, _child_level[level])
+
+    def _get_aunt(self, level, removed, step="", inlaw=""):
         """Internal Dutch method to create relation string
         """
-        if removed == 1 and level < len(_aunt_level):
-            return _aunt_level[level] % (inlaw, step)
+        if removed == 1 and level < len(_removed_level):
+            if level > 4:
+                return "%s%s%stante (%d generaties)" % (inlaw, step, _removed_level[level], level)
+            else:
+                return "%s%s%stante" % (inlaw, step, _removed_level[level])
         elif removed == 1:
             return "verre %s%stante (%d generaties)" % (inlaw, step, level)
-        elif level > len(_aunt_level)-1 and removed > len(_removed_level) -1:
+        elif level > len(_removed_level)-1 and removed > len(_ordinal_level)-1:
             return "verre %s%stante (%d generaties, %d graden)" % (inlaw, step,
                                                             level, removed)
-        elif level > len(_aunt_level)-1:
-            return "verre %s%stante van de%s graad (%d generaties)" % (inlaw,
-                                        step, _removed_level[removed], level)
+        elif level > len(_removed_level)-1:
+            return "verre %s%stante van de %s graad (%d generaties)" % (inlaw,
+                                        step, _ordinal_level[removed], level)
         else:
-            return _aunt_level[level] % (inlaw, step) \
-                        + _removed_level[removed] + " graad"
+            if level > 4:
+                return "%s%s%stante (%d generaties)" % (inlaw, step, _removed_level[level], level) \
+                        + " " + _ordinal_level[removed] + " graad"
+            else:
+                return "%s%s%stante" % (inlaw, step, _removed_level[level]) \
+                        + " " + _ordinal_level[removed] + " graad"
 
-    def _get_uncle(self, level, removed, step='', inlaw=''):
+    def _get_uncle(self, level, removed, step="", inlaw=""):
         """Internal Dutch method to create relation string
         """
-        if removed == 1 and level < len(_uncle_level):
-            return _uncle_level[level] % (inlaw, step)
+        if removed == 1 and level < len(_removed_level):
+            if level > 4:
+                return "%s%s%soom (%d generaties)" % (inlaw, step, _removed_level[level], level)
+            else:
+                return "%s%s%soom" % (inlaw, step, _removed_level[level])
         elif removed == 1:
             return "verre %s%soom (%d generaties)" % (inlaw, step, level)
-        elif level > len(_uncle_level)-1 and removed > len(_removed_level) -1:
+        elif level > len(_removed_level)-1 and removed > len(_ordinal_level)-1:
             return "verre %s%soom (%d generaties, %d graden)" % (inlaw, step,
                                                             level, removed)
-        elif level > len(_uncle_level)-1:
-            return "verre %s%soom van de%s graad (%d generaties)" % (inlaw,
-                                        step, _removed_level[removed], level)
+        elif level > len(_removed_level)-1:
+            return "verre %s%soom van de %s graad (%d generaties)" % (inlaw,
+                                        step, _ordinal_level[removed], level)
         else:
-            return _uncle_level[level] % (inlaw, step) \
-                        + _removed_level[removed] + " graad"
+            if level > 4:
+                return "%s%s%soom (%d generaties)" % (inlaw, step, _removed_level[level], level) \
+                        + " " + _ordinal_level[removed] + " graad"
+            else:
+                return "%s%s%soom" % (inlaw, step, _removed_level[level]) \
+                        + " " + _ordinal_level[removed] + " graad"
 
-    def _get_sibling(self, level, step='', inlaw=''):
+    def _get_sibling(self, level, step="", inlaw=""):
         """overwrite of English method to return unknown gender sibling
         """
         assert(level == 1)
-        return self._get_male_cousin(0, step=step, inlaw=inlaw) + ' of ' \
+        return self._get_male_cousin(0, step=step, inlaw=inlaw) + " of " \
                 + self._get_female_cousin(0, step=step, inlaw=inlaw)
 
-    def _get_nephew(self, level, removed=1, step='', inlaw=''):
+    def _get_nephew(self, level, removed=1, step="", inlaw=""):
         """Internal Dutch method to create relation string
         """
-        if removed == 1 and level < len(_nephew_level):
-            return _nephew_level[level] % (inlaw, step)
+        if removed == 1 and level < len(_nibling_level):
+            return "%s%s%sneef" % (inlaw, step, _nibling_level[level])
         elif removed == 1:
             return "verre %s%sneef (%d generaties)" % (inlaw, step, level)
-        elif level > len(_nephew_level)-1 and removed > len(_removed_level) -1:
+        elif level > len(_nibling_level)-1 and removed > len(_ordinal_level) -1:
             return "verre %s%sneef (%d generaties, %d graden)" % (inlaw, step,
                                                                 level, removed)
-        elif level > len(_nephew_level)-1:
-            return "verre %s%sneef van de%s graad (%d generaties)" % (inlaw, step,
-                                                _removed_level[removed], level)
+        elif level > len(_nibling_level)-1:
+            return "verre %s%sneef van de %s graad (%d generaties)" % (inlaw, step,
+                                                _ordinal_level[removed], level)
         else:
-            return _nephew_level[level] % (inlaw, step) \
-                        + _removed_level[removed] + " graad"
+            return "%s%s%sneef" % (inlaw, step, _nibling_level[level]) \
+                        + " " + _ordinal_level[removed] + " graad"
 
-    def _get_niece(self, level, removed=1, step='', inlaw=''):
+    def _get_niece(self, level, removed=1, step="", inlaw=""):
         """Internal Dutch method to create relation string
         """
-        if removed == 1 and level < len(_niece_level):
-            return _niece_level[level] % (inlaw, step)
+        if removed == 1 and level < len(_nibling_level):
+            return "%s%s%snicht" % (inlaw, step, _nibling_level[level])
         elif removed == 1:
             return "verre %s%snicht (%d generaties)" % (inlaw, step, level)
-        elif level > len(_niece_level)-1 and removed > len(_removed_level) -1:
+        elif level > len(_nibling_level)-1 and removed > len(_ordinal_level) -1:
             return "verre %s%snicht (%d generaties, %d graden)" % (inlaw, step,
                                                                 level, removed)
-        elif level > len(_niece_level)-1:
-            return "verre %s%snicht van de%s graad (%d generaties)"% (inlaw,
-                                        step, _removed_level[removed], level)
+        elif level > len(_nibling_level)-1:
+            return "verre %s%snicht van de %s graad (%d generaties)" % (inlaw, step,
+                                                _ordinal_level[removed], level)
         else:
-            return _niece_level[level] % (inlaw, step) \
-                        + _removed_level[removed] + " graad"
+            return "%s%s%snicht" % (inlaw, step, _nibling_level[level]) \
+                        + " " + _ordinal_level[removed] + " graad"
 
-    def _get_male_cousin(self, removed, step='', inlaw=''):
+    def _get_male_cousin(self, removed, step="", inlaw=""):
         """Specific Dutch thing, the nieces/nephews on same level are called
             going sideways in a branch as the nieces/newphews going downward
             from your brother/sisters. This used to be called "kozijn"
         """
         removed -= 1
-        if removed > len(_removed_level)-1:
+        if removed > len(_ordinal_level)-1:
             return "verre %s%sneef (kozijn, %d graden)" % (inlaw, step,
                                                            removed)
         elif removed == 0:
             return "%s%sbroer" % (inlaw, step)
         else:
-            return "%s%sneef (kozijn)" % (inlaw, step)  \
-                        +_removed_level[removed] + " graad"
+            return "%s%sneef (kozijn)" % (inlaw, step) \
+                        + " " + _ordinal_level[removed] + " graad"
 
-    def _get_female_cousin(self, removed, step='', inlaw=''):
+    def _get_female_cousin(self, removed, step="", inlaw=""):
         """Specific Dutch thing, the nieces/nephews on same level are called
             going sideways in a branch as the nieces/newphews going downward
-            from your brother/sisters.  This used to be called "kozijn"
+            from your brother/sisters. This used to be called "kozijn"
         """
         removed -= 1
-        if removed > len(_removed_level)-1:
+        if removed > len(_ordinal_level)-1:
             return "verre %s%snicht (kozijn, %d graden)" % (inlaw, step,
                                                            removed)
         elif removed == 0:
-            return "%s%szus"  % (inlaw, step)
+            return "%s%szus" % (inlaw, step)
         else:
-            return "%s%snicht (kozijn)"  % (inlaw, step) \
-                        + _removed_level[removed] + " graad"
+            return "%s%snicht (kozijn)" % (inlaw, step) \
+                        + " " + _ordinal_level[removed] + " graad"
 
     def get_single_relationship_string(self, Ga, Gb, gender_a, gender_b,
                                        reltocommon_a, reltocommon_b,
@@ -430,28 +283,28 @@ class RelationshipCalculator(gramps.gen.relationship.RelationshipCalculator):
         see english method, eg b is father of a
         """
         if only_birth:
-            step = ''
+            step = ""
         else:
             step = self.STEP
 
         if in_law_a or in_law_b :
             inlaw = self.INLAW
         else:
-            inlaw = ''
+            inlaw = ""
 
         rel_str = "verre %s%sfamilie" % (inlaw, step)
 
         if Gb == 0:
             #b is ancestor
             if Ga == 0:
-                rel_str = 'zelfde persoon'
+                rel_str = "zelfde persoon"
             elif Ga == 1 and inlaw and not step:
                 if gender_b == Person.MALE:
-                    rel_str = 'schoonvader'
+                    rel_str = "schoonvader"
                 elif gender_b == Person.FEMALE:
-                    rel_str = 'schoonmoeder'
+                    rel_str = "schoonmoeder"
                 else:
-                    rel_str = 'schoonouder'
+                    rel_str = "schoonouder"
             elif gender_b == Person.MALE:
                 rel_str = self._get_father(Ga, step, inlaw)
             elif gender_b == Person.FEMALE:
@@ -462,19 +315,19 @@ class RelationshipCalculator(gramps.gen.relationship.RelationshipCalculator):
             #a is descendant
             if Gb == 1 and inlaw and not step:
                 if gender_b == Person.MALE:
-                    rel_str = 'schoonzoon'
+                    rel_str = "schoonzoon"
                 elif gender_b == Person.FEMALE:
-                    rel_str = 'schoondochter'
+                    rel_str = "schoondochter"
                 else:
-                    rel_str = 'schoonzoon of -dochter'
+                    rel_str = "schoonkind"
             elif Gb == 1 and inlaw and step:
                 #inlaw stepchild
                 if gender_b == Person.MALE:
-                    rel_str = 'aangetrouwde stiefzoon'
+                    rel_str = "aangetrouwde stiefzoon"
                 elif gender_b == Person.FEMALE:
-                    rel_str = 'aangetrouwde stiefdochter'
+                    rel_str = "aangetrouwde stiefdochter"
                 else:
-                    rel_str = 'aangetrouwde stiefzoon of dochter'
+                    rel_str = "aangetrouwd stiefkind"
             elif gender_b == Person.MALE:
                 rel_str = self._get_son(Gb, step, inlaw)
             elif gender_b == Person.FEMALE:
@@ -483,24 +336,33 @@ class RelationshipCalculator(gramps.gen.relationship.RelationshipCalculator):
                 rel_str = self._get_child_unknown(Gb, step, inlaw)
         elif Ga > Gb:
             #b is higher in the branch, in english uncle/aunt or
-            #cousin up, in dutch always 'oom/tante'
+            #cousin up, in Dutch always 'oom/tante'
             if gender_b == Person.MALE:
                 rel_str = self._get_uncle(Ga - Gb, Gb, step, inlaw)
-            else:
+            elif gender_b == Person.FEMALE:
                 rel_str = self._get_aunt(Ga - Gb, Gb, step, inlaw)
+            else:
+                rel_str = self._get_uncle(Ga - Gb, Gb, step, inlaw) + " of " \
+                        + self._get_aunt(Ga - Gb, Gb, step, inlaw)
         elif Ga < Gb:
             #b is lower in the branch, in english niece/nephew or
-            #cousin down, in dutch always 'neef/nicht'
+            #cousin down, in Dutch always 'neef/nicht'
             if gender_b == Person.MALE:
                 rel_str = self._get_nephew(Gb - Ga, Ga, step, inlaw)
-            else:
+            elif gender_b == Person.FEMALE:
                 rel_str = self._get_niece(Gb - Ga, Ga, step, inlaw)
+            else:
+                rel_str = self._get_nephew(Gb - Ga, Ga, step, inlaw) + " of " \
+                        + self._get_niece(Gb - Ga, Ga, step, inlaw)
         else:
             # people on the same level Ga == Gb
             if gender_b == Person.MALE:
                 rel_str = self._get_male_cousin(Ga, step, inlaw)
-            else:
+            elif gender_b == Person.FEMALE:
                 rel_str = self._get_female_cousin(Ga, step, inlaw)
+            else:
+                rel_str = self._get_male_cousin(Ga, step, inlaw) + " of " \
+                        + self._get_female_cousin(Ga, step, inlaw)
 
         return rel_str
 
@@ -519,7 +381,7 @@ class RelationshipCalculator(gramps.gen.relationship.RelationshipCalculator):
                      get_sibling)
         """
         if sib_type == self.NORM_SIB or sib_type == self.UNKNOWN_SIB:
-            typestr = ''
+            typestr = ""
         elif sib_type == self.HALF_SIB_FATHER \
                 or sib_type == self.HALF_SIB_MOTHER:
             typestr = self.HALF
@@ -529,20 +391,23 @@ class RelationshipCalculator(gramps.gen.relationship.RelationshipCalculator):
         if in_law_a or in_law_b :
             inlaw = self.INLAW
         else:
-            inlaw = ''
+            inlaw = ""
 
         if inlaw and not typestr:
             if gender_b == Person.MALE:
-                rel_str = 'schoonbroer'
+                rel_str = "schoonbroer"
             elif gender_b == Person.FEMALE:
-                rel_str = 'schoonzus'
+                rel_str = "schoonzus"
             else:
-                rel_str = 'schoonzus/broer'
+                rel_str = "schoonbroer of -zus"
         else:
             if gender_b == Person.MALE:
                 rel_str = self._get_male_cousin(1, typestr, inlaw)
-            else:
+            elif gender_b == Person.FEMALE:
                 rel_str = self._get_female_cousin(1, typestr, inlaw)
+            else:
+                rel_str = self._get_male_cousin(1, typestr, inlaw) + " of " \
+                        + self._get_female_cousin(1, typestr, inlaw)
         return rel_str
 
 


### PR DESCRIPTION
In this pull request I fixed some issues in the Dutch relationship calculator and I also extended the ordinal and removed lists till 50, just like the English lists.

- Replaced huge lists by reusable lists.
- Fixed bug in which uncles/aunts, nephews/nieces (niblings), siblings and cousins with an unknown gender show up as female.
- Fixed some misspellings:
drieëntwingste > drieëntwinTIgste
vierentwingste > vierentwinTIgste
edelovergrootOUD > edelovergroot
edeloudvergroot > edeloudOvergroot