### PR TITLE
In personsidebarfilter, search on each part of name

### DIFF
--- a/gramps/gui/filters/sidebar/_personsidebarfilter.py
+++ b/gramps/gui/filters/sidebar/_personsidebarfilter.py
@@ -186,8 +186,10 @@ class PersonSidebarFilter(SidebarFilter):
             # if the name is not empty, choose either the regular expression
             # version or the normal text match
             if name:
-                rule = RegExpName([name], use_regex=regex)
-                generic_filter.add_rule(rule)
+                name_parts = name.split(sep=" ")
+                for name_part in name_parts:
+                    rule = RegExpName([name_part], use_regex=regex)
+                    generic_filter.add_rule(rule)
 
             # if the id is not empty, choose either the regular expression
             # version or the normal text match


### PR DESCRIPTION
Fixes mantis bug [#7950](https://gramps-project.org/bugs/view.php?id=7950)
Fixes mantis bug [#7952](https://gramps-project.org/bugs/view.php?id=7952)
Instead of requiring that the entire search string matches a single one of the Person's names, the function now requires that each word in the search string matches any of the Person's name fields.