### PR TITLE
Fix reports for shared event attribute and note errors

### DIFF
--- a/gramps/plugins/textreport/detancestralreport.py
+++ b/gramps/plugins/textreport/detancestralreport.py
@@ -484,7 +484,7 @@ class DetAncestorReport(Report):
 
         if self.inc_attrs:
             text = ""
-            attr_list = event.get_attribute_list()
+            attr_list = event.get_attribute_list()[:]  # we don't want to modify cached original
             attr_list.extend(event_ref.get_attribute_list())
             for attr in attr_list:
                 if text:
@@ -504,7 +504,7 @@ class DetAncestorReport(Report):
         if self.includenotes:
             # if the event or event reference has a note attached to it,
             # get the text and format it correctly
-            notelist = event.get_note_list()
+            notelist = event.get_note_list()[:]  # we don't want to modify cached original
             notelist.extend(event_ref.get_note_list())
             for notehandle in notelist:
                 note = self._db.get_note_from_handle(notehandle)

--- a/gramps/plugins/textreport/detdescendantreport.py
+++ b/gramps/plugins/textreport/detdescendantreport.py
@@ -509,7 +509,7 @@ class DetDescendantReport(Report):
 
         if self.inc_attrs:
             text = ""
-            attr_list = event.get_attribute_list()
+            attr_list = event.get_attribute_list()[:]  # we don't want to modify cached original
             attr_list.extend(event_ref.get_attribute_list())
             for attr in attr_list:
                 if text:
@@ -529,7 +529,7 @@ class DetDescendantReport(Report):
         if self.inc_notes:
             # if the event or event reference has a note attached to it,
             # get the text and format it correctly
-            notelist = event.get_note_list()
+            notelist = event.get_note_list()[:]  # we don't want to modify cached original
             notelist.extend(event_ref.get_note_list())
             for notehandle in notelist:
                 note = self._db.get_note_from_handle(notehandle)

--- a/gramps/plugins/textreport/indivcomplete.py
+++ b/gramps/plugins/textreport/indivcomplete.py
@@ -256,7 +256,7 @@ class IndivCompleteReport(Report):
 
     def write_note(self):
         """ write a note """
-        notelist = self.person.get_note_list()
+        notelist = self.person.get_note_list()[:]  # we don't want to modify cached original
         notelist += self.family_notes_list
         if self.names_notes_list:
             for note_handle in self.names_notes_list:

--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -679,13 +679,13 @@ class BasePage: # pylint: disable=C1001
         trow += Html("td", srcrefs, class_="ColumnSources")
 
         # get event notes
-        notelist = event.get_note_list()
+        notelist = event.get_note_list()[:]  # we don't want to modify cached original
         notelist.extend(event_ref.get_note_list())
         htmllist = self.dump_notes(notelist)
 
         # if the event or event reference has an attribute attached to it,
         # get the text and format it correctly?
-        attrlist = event.get_attribute_list()
+        attrlist = event.get_attribute_list()[:]  # we don't want to modify cached original
         attrlist.extend(event_ref.get_attribute_list())
         for attr in attrlist:
             htmllist.extend(Html("p",


### PR DESCRIPTION
Fixes #10720
Since we added caching to the reports, we picked up some errors where the report writer was extending attribute and note lists from cached primary objects.  This mostly did not matter, but when a primary object was referenced more than once in a report (like shared events), the extended lists would accumulate all the changes.

I looked in all the reports that used the CacheProxyDb, searching for ".extend(" or "+=" and inspected to see if it was potentially modifying the cached primary object.  If so, I made a copy of the list before using it.

There is another PR for the reports in AddonsSource for same bug.

I hope I got them all...