### PR TITLE
Fix Gedcom export for incorrect escaping with @#DFRENCH R@

### DIFF
--- a/gramps/plugins/export/exportgedcom.py
+++ b/gramps/plugins/export/exportgedcom.py
@@ -281,7 +281,8 @@ class GedcomWriter(UpdateCallback):
             textlines = textlines.replace('\n\r', '\n')
             textlines = textlines.replace('\r', '\n')
             # Need to double '@' See Gedcom 5.5 spec 'any_char'
-            if not textlines.startswith('@'):  # avoid xrefs
+            # but avoid xrefs and escapes
+            if not textlines.startswith('@') and '@#' not in textlines:
                 textlines = textlines.replace('@', '@@')
             textlist = textlines.split('\n')
             token_level = level


### PR DESCRIPTION
Fixes #10833

An earlier fix that doubled the '@' symbol (per Gedcom spec missed the fact that the special calendar dates like @#DFRENCH R@ should not have the '@' doubled.

I accepted, and if there will be more gramps42 versions, this should be cherry-picked to that branch as well.