### PR TITLE
Fix Delete dialogs to all canceling multiple deletes more easily

### DIFF
--- a/gramps/gui/dialog.py
+++ b/gramps/gui/dialog.py
@@ -168,6 +168,52 @@ class QuestionDialog2:
             self.parent.set_modal(True)
         return (response == Gtk.ResponseType.ACCEPT)
 
+class QuestionDialog3:
+    """ Like QuestionDialog2, but includes cancel button,
+    returns: 1  (okbutton, label_msg1)
+             0  (no button label_msg2)
+             -1 (cancel button)
+    """
+    def __init__(self, msg1, msg2, label_msg1, label_msg2, parent=None):
+        self.xml = Glade(toplevel='questiondialog')
+
+        self.top = self.xml.toplevel
+        self.top.set_icon(ICON)
+        self.top.set_title("%s - Gramps" % msg1)
+
+        label1 = self.xml.get_object('qd_label1')
+        label1.set_text('<span weight="bold" size="larger">%s</span>' %
+                        html.escape(msg1))
+        label1.set_use_markup(True)
+
+        label2 = self.xml.get_object('qd_label2')
+        # see https://github.com/emesene/emesene/issues/723
+        label2.connect('activate-link', on_activate_link)
+        label2.set_text(msg2)
+        label2.set_use_markup(True)
+
+        self.xml.get_object('okbutton').set_label(label_msg1)
+        self.xml.get_object('okbutton').set_use_underline(True)
+        self.xml.get_object('no').set_label(label_msg2)
+        self.xml.get_object('no').set_use_underline(True)
+        self.xml.get_object('cancelbutton').show()
+
+        self.parent = parent
+        if parent:
+            self.top.set_transient_for(parent)
+            self.parent_modal = parent.get_modal()
+            if self.parent_modal:
+                parent.set_modal(False)
+        self.top.show()
+
+    def run(self):
+        response = self.top.run()
+        self.top.destroy()
+        if self.parent and self.parent_modal:
+            self.parent.set_modal(True)
+        return (-1 if response == Gtk.ResponseType.DELETE_EVENT
+                else response == Gtk.ResponseType.ACCEPT)
+
 class OptionDialog:
     def __init__(self, msg1, msg2, btnmsg1, task1, btnmsg2, task2, parent=None):
         self.xml = Glade(toplevel='optiondialog')

--- a/gramps/gui/glade/dialog.glade
+++ b/gramps/gui/glade/dialog.glade
@@ -697,6 +697,19 @@
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
+              <object class="GtkButton" id="cancelbutton">
+                <property name="label" translatable="yes">Cancel</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkButton" id="no">
                 <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
@@ -708,7 +721,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="position">0</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
@@ -722,7 +735,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>
@@ -805,6 +818,7 @@
       </object>
     </child>
     <action-widgets>
+      <action-widget response="-4">cancelbutton</action-widget>
       <action-widget response="-6">no</action-widget>
       <action-widget response="-3">okbutton</action-widget>
     </action-widgets>

--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -66,7 +66,7 @@ from gramps.gen.const import CUSTOM_FILTERS
 from gramps.gen.utils.debug import profile
 from gramps.gen.utils.string import data_recover_msg
 from gramps.gen.plug import CATEGORY_QR_PERSON
-from ..dialog import QuestionDialog, QuestionDialog2, ErrorDialog
+from ..dialog import QuestionDialog, QuestionDialog3, ErrorDialog
 from ..editors import FilterEditor
 from ..ddtargets import DdTargets
 from ..plug.quick import create_quickreport_menu, create_web_connect_menu
@@ -543,14 +543,18 @@ class ListView(NavigationView):
         """
         prompt = True
         if len(self.selected_handles()) > 1:
-            q = QuestionDialog2(
+            ques = QuestionDialog3(
                 _("Multiple Selection Delete"),
                 _("More than one item has been selected for deletion. "
                   "Select the option indicating how to delete the items:"),
                 _("Delete All"),
                 _("Confirm Each Delete"),
                 parent=self.uistate.window)
-            prompt = not q.run()
+            res = ques.run()
+            if res == -1:  # Cancel
+                return
+            else:
+                prompt = not res  # we prompt on 'Confirm Each Delete'
 
         if not prompt:
             self.uistate.set_busy_cursor(True)
@@ -569,11 +573,16 @@ class ListView(NavigationView):
                 #descr = object.get_description()
                 #if descr == "":
                 descr = object.get_gramps_id()
-                self.uistate.set_busy_cursor(True)
-                QuestionDialog(_('Delete %s?') % descr, msg,
-                               _('_Delete Item'), query.query_response,
-                               parent=self.uistate.window)
-                self.uistate.set_busy_cursor(False)
+                ques = QuestionDialog3(_('Delete %s?') % descr, msg,
+                                       _('_Yes'), _('_No'),
+                                       parent=self.uistate.window)
+                res = ques.run()
+                if res == -1:  # Cancel
+                    return
+                elif res:  # If true, perfom the delete
+                    self.uistate.set_busy_cursor(True)
+                    query.query_response()
+                    self.uistate.set_busy_cursor(False)
             else:
                 query.query_response()
 


### PR DESCRIPTION
Fixes [#10796](https://gramps-project.org/bugs/view.php?id=10796)
This PR allows for easier cancellation of a multiple delete for most of the views (Person and Family views had their own delete, that is a bit different).  For the two dialogs involved in the delete process, I have added a 'Cancel' button, which aborts the process entirely.  Also in each case, closing the dialog with the 'x' in the corner does the same thing as cancel.
![multdel](https://user-images.githubusercontent.com/18122203/46549349-48b15c00-c897-11e8-90e4-235553253606.PNG)
![multdel_1](https://user-images.githubusercontent.com/18122203/46549350-4cdd7980-c897-11e8-964b-91d876c148c4.PNG)
