### PR TITLE
Fix InteractiveSearch for find before model is populated

### DIFF
--- a/gramps/gui/widgets/interactivesearchbox.py
+++ b/gramps/gui/widgets/interactivesearchbox.py
@@ -239,6 +239,8 @@ class InteractiveSearchBox:
             return
 
         model = self._treeview.get_model()
+        if not model:
+            return
         selection = self._treeview.get_selection()
         # disable flush timeout while searching
         if self._entry_flush_timeout:


### PR DESCRIPTION
Fixes #10844

If it takes a while to load the Selector view, but user tries to search before it is complete, he got an exception.  Cab happen with large trees (or fast user typing).  This prevents that.