### PR TITLE
Records Report: call name not underlined in HTML

### DIFF
--- a/gramps/plugins/docgen/htmldoc.py
+++ b/gramps/plugins/docgen/htmldoc.py
@@ -337,6 +337,20 @@ class HtmlDoc(BaseDoc, TextDoc):
             self._empty = 0
         self.__write_text(text, mark, links=links)
 
+    def write_markup(self, text, s_tags, mark=None):
+        """
+        Overwrite base method
+        Writes the text in the current paragraph.  Should only be used after a
+        start_paragraph and before an end_paragraph.
+
+        @param text: text to write. The text is assumed to be _not_ escaped
+        @param s_tags:  assumed to be list of styledtexttags to apply to the
+                        text
+        @param mark:  IndexMark to use for indexing
+        """
+        markuptext = self._backend.add_markup_from_styled(text, s_tags)
+        self.__write_text(markuptext, mark=mark, markup=True)
+
     def write_title(self):
         """
         Add title field to header


### PR DESCRIPTION
Fixes #10816