### PR TITLE
Change person name sidebar search so multiple substrings match name

### DIFF
--- a/gramps/gui/filters/sidebar/_personsidebarfilter.py
+++ b/gramps/gui/filters/sidebar/_personsidebarfilter.py
@@ -186,8 +186,10 @@ class PersonSidebarFilter(SidebarFilter):
             # if the name is not empty, choose either the regular expression
             # version or the normal text match
             if name:
-                rule = RegExpName([name], use_regex=regex)
-                generic_filter.add_rule(rule)
+                name_parts = name.split(sep=" ")
+                for name_part in name_parts:
+                    rule = RegExpName([name_part], use_regex=regex)
+                    generic_filter.add_rule(rule)
 
             # if the id is not empty, choose either the regular expression
             # version or the normal text match


### PR DESCRIPTION
This allows for several words to be used in search and match each
independently with effective AND.  So searching "lewis garner" in
example.gramps will find someone.
Fixes #7950, #7952

It's probably more of an enhancement than a bug, but depends on point of view...