### PR TITLE
Fix Russian date handler crash when Russian .po (actually .mo) isn't present

### DIFF
--- a/gramps/gen/datehandler/_date_ru.py
+++ b/gramps/gen/datehandler/_date_ru.py
@@ -132,6 +132,11 @@ class DateDisplayRU(DateDisplay):
                                                    inflect, long_months)
         elif date_val[1] == 0: # month is zero but day is not (see 8477)
             return self.display_iso(date_val)
+        elif not hasattr(long_months[date_val[1]], 'f'): # not a Lexeme
+            return "{day:d} {long_month} {year}".format(
+                     day = date_val[0],
+                     long_month = long_months[date_val[1]],
+                     year = year)
         else:
             return "{day:d} {long_month.f[Р]} {year}".format(
                      day = date_val[0],
@@ -151,6 +156,11 @@ class DateDisplayRU(DateDisplay):
                                                     inflect, short_months)
         elif date_val[1] == 0: # month is zero but day is not (see 8477)
             return self.display_iso(date_val)
+        elif not hasattr(short_months[date_val[1]], 'f'): # not a Lexeme
+            return "{day:d} {short_month} {year}".format(
+                     day = date_val[0],
+                     short_month = short_months[date_val[1]],
+                     year = year)
         else:
             return "{day:d} {short_month.f[Р]} {year}".format(
                      day = date_val[0],


### PR DESCRIPTION
Fixes [#10855](https://gramps-project.org/bugs/view.php?id=10855)

Original code assumed that the Lexeme format of the translated months is available, not true when the language translation is not installed (Window AIO is not installing languages by default anymore).