### PR TITLE
Change PlaceView drag from whole row to just icon during drag

### DIFF
--- a/gramps/plugins/lib/libplaceview.py
+++ b/gramps/plugins/lib/libplaceview.py
@@ -206,16 +206,6 @@ class PlaceBaseView(ListView):
         self.mapslistlabel.append(lbl)
         widget.set_label_widget(self.mapslistlabel[-1])
         widget.set_icon_name('go-jump')
-        if self.drag_info():
-            self.list.enable_model_drag_source(Gdk.ModifierType.BUTTON1_MASK,
-              [],
-              Gdk.DragAction.COPY)
-            tglist = Gtk.TargetList.new([])
-            tglist.add(self.drag_info().atom_drag_type,
-                       self.drag_info().target_flags,
-                       self.drag_info().app_id)
-            tglist.add_text_targets (0)
-            self.list.drag_source_set_target_list(tglist)
 
     def __create_maps_menu_actions(self):
         """


### PR DESCRIPTION
Fixes #10863

Both the Listview and libplaceview code had drag setups for the source.  It appears that doing both caused the listviews drag_begin widget.drag_source_set_icon_name(self.get_stock()) to be ignored.

I remove the drag source setup in libplaceview; drags of places still works (it was set up in listview) and now the drag-icon is correctly set.