### PR TITLE
Fix HandleErrors related to LDS

### DIFF
--- a/gramps/gen/proxy/referencedbyselection.py
+++ b/gramps/gen/proxy/referencedbyselection.py
@@ -427,9 +427,10 @@ class ReferencedBySelectionProxyDb(ProxyDbBase):
     def process_lds_ord(self, lds_ord):
         """ Find all of the primary objects referred to """
         fam_handle = lds_ord.get_family_handle()
-        fam = self.db.get_family_from_handle(fam_handle)
-        if fam:
-            self.queue_object("Family", fam_handle)
+        if fam_handle:
+            fam = self.db.get_family_from_handle(fam_handle)
+            if fam:
+                self.queue_object("Family", fam_handle)
 
         place_handle = lds_ord.get_place_handle()
         if place_handle:

--- a/gramps/plugins/gramplet/citations.py
+++ b/gramps/plugins/gramplet/citations.py
@@ -249,9 +249,10 @@ class Citations(Gramplet, DbGUIElement):
             if self.check_citations(lds):
                 return True
             place_handle = lds.get_place_handle()
-            place = self.dbstate.db.get_place_from_handle(place_handle)
-            if place and self.check_place_citations(place):
-                return True
+            if place_handle:
+                place = self.dbstate.db.get_place_from_handle(place_handle)
+                if place and self.check_place_citations(place):
+                    return True
         return False
 
     def check_association_citations(self, obj):


### PR DESCRIPTION
Two commits;
If LDS has no Family handle the ReferencedBySelection proxy failed
Fixes [#10865](https://gramps-project.org/bugs/view.php?id=10865)

Second commit
And while debugging that, I found another HandleError if the LDS did not have a place.
Fix HandleError in Citations Gramplet for lds place missing 