### PR TITLE
FR10850 V1: Refresh button in the gramplet bar.

### DIFF
--- a/gramps/gen/config.py
+++ b/gramps/gen/config.py
@@ -196,6 +196,7 @@ register('interface.view-categories',
 register('interface.filter', False)
 register('interface.fullscreen', False)
 register('interface.grampletbar-close', False)
+register('interface.grampletbar-refresh', False)
 register('interface.ignore-gexiv2', False)
 register('interface.ignore-pil', False)
 register('interface.ignore-osmgpsmap', False)

--- a/gramps/gen/plug/_gramplet.py
+++ b/gramps/gen/plug/_gramplet.py
@@ -34,6 +34,7 @@ LOG = logging.getLogger(".Gramplets")
 #
 #------------------------------------------------------------------------
 from ..const import GRAMPS_LOCALE as glocale
+from gramps.gen.config import config
 _ = glocale.translation.gettext
 
 class Gramplet:
@@ -296,12 +297,15 @@ class Gramplet:
             not self.gui.force_update):
             self.dirty = True
             if self.dbstate.is_open():
-                #print "  %s is not active" % self.gui.gname
+                #print("  %s is not active" % self.gui.gname)
                 self.update_has_data()
             else:
                 self.set_has_data(False)
             return
-        #print "     %s is UPDATING" % self.gui.gname
+        #print("     %s is UPDATING" % self.gui.gname)
+        if (config.get('interface.grampletbar-refresh') and
+            self.gui.view.navigation_type() != None): # dashboard has no navtype
+            return # Don't update the gramplet if we are in manual refresh
         self.dirty = False
         LOG.debug("gramplet updater: %s: running" % self.gui.title)
         if self._idle_id != 0:

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -984,6 +984,12 @@ class GrampsPreferences(ConfigureDialog):
         """
         self.uistate.emit('grampletbar-close-changed')
 
+    def cb_grampletbar_refresh(self, obj):
+        """
+        Gramplet bar refresh button preference callback
+        """
+        self.uistate.emit('grampletbar-refresh-changed')
+
     def add_formats_panel(self, configdialog):
         row = 0
         grid = Gtk.Grid()
@@ -1184,6 +1190,13 @@ class GrampsPreferences(ConfigureDialog):
                           _("Show close button in gramplet bar tabs"),
                           row, 'interface.grampletbar-close', stop=3,
                           extra_callback=self.cb_grampletbar_close)
+        row += 1
+
+        # Gramplet bar refresh button:
+        self.add_checkbox(grid,
+                          _("Enable manual refresh for the active gramplet"),
+                          row, 'interface.grampletbar-refresh', stop=3,
+                          extra_callback=self.cb_grampletbar_refresh)
         row += 1
         return _('Display'), grid
 

--- a/gramps/gui/displaystate.py
+++ b/gramps/gui/displaystate.py
@@ -398,6 +398,7 @@ class DisplayState(Callback):
         'nameformat-changed' : None,
         'placeformat-changed' : None,
         'grampletbar-close-changed' : None,
+        'grampletbar-refresh-changed' : None,
         'update-available' : (list, ),
         'autobackup' : None,
         }

--- a/gramps/gui/widgets/grampletbar.py
+++ b/gramps/gui/widgets/grampletbar.py
@@ -104,6 +104,16 @@ class GrampletBar(Gtk.Notebook):
         self.set_show_border(False)
         self.set_scrollable(True)
 
+        image = Gtk.Image(stock=Gtk.STOCK_REFRESH)
+        refresh_button = Gtk.Button(image=image)
+        refresh_button.set_relief(Gtk.ReliefStyle.NONE)
+        refresh_button.connect('clicked', self.__refresh_clicked)
+        self.set_action_widget(refresh_button, Gtk.PackType.START)
+        if config.get('interface.grampletbar-refresh'):
+            refresh_button.show()
+        else:
+            refresh_button.hide()
+
         book_button = Gtk.Button()
         # Arrow is too small unless in a box
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
@@ -142,6 +152,7 @@ class GrampletBar(Gtk.Notebook):
         self.set_current_page(config_settings[1])
 
         uistate.connect('grampletbar-close-changed', self.cb_close_changed)
+        uistate.connect('grampletbar-refresh-changed', self.cb_refresh_changed)
 
         # Connect after gramplets added to prevent making them active
         self.connect('switch-page', self.__switch_page)
@@ -404,6 +415,16 @@ class GrampletBar(Gtk.Notebook):
             tablabel = self.get_tab_label(gramplet)
             tablabel.use_close(config.get('interface.grampletbar-close'))
 
+    def cb_refresh_changed(self):
+        """
+        Refresh button preference changed.
+        """
+        button = self.get_action_widget(Gtk.PackType.START)
+        if config.get('interface.grampletbar-refresh'):
+            button.show()
+        else:
+            button.hide()
+
     def __delete_clicked(self, button, gramplet):
         """
         Called when the delete button is clicked.
@@ -475,6 +496,15 @@ class GrampletBar(Gtk.Notebook):
         """
         gramplet.detached_window.close()
         gramplet.detached_window = None
+
+    def __refresh_clicked(self, button):
+        """
+        Called when the drop-down button is clicked.
+        """
+        for gramplet in self.get_children():
+            if gramplet and gramplet.pui:
+                if gramplet.pui.active:
+                    gramplet.pui.main()
 
     def __button_clicked(self, button):
         """
@@ -743,7 +773,7 @@ class TabLabel(Gtk.Box):
 
     def use_close(self, use_close):
         """
-        Display the cose button according to user preference.
+        Display the close button according to user preference.
         """
         if use_close:
             self.closebtn.show()

--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -34,6 +34,7 @@ from gi.repository import Pango
 import time
 import os
 import configparser
+from gramps.gen.config import config
 
 import logging
 
@@ -242,6 +243,8 @@ class GrampletWindow(ManagedWindow):
         self.setup_configs('interface.' + cfg_name,
                            gramplet.detached_width, gramplet.detached_height)
         self.window.add_button(_('_Help'), Gtk.ResponseType.HELP)
+        if config.get('interface.grampletbar-refresh'):
+            self.window.add_button(_('Refresh'), Gtk.ResponseType.APPLY)
         # add gramplet:
         if self.gramplet.pui:
             self.gramplet.pui.active = True
@@ -274,12 +277,20 @@ class GrampletWindow(ManagedWindow):
             else:
                 display_help(WIKI_HELP_PAGE,
                                    self.gramplet.tname.replace(" ", "_"))
+        elif response == Gtk.ResponseType.APPLY:
+            self.refresh()
 
     def build_menu_names(self, obj):
         """
         Part of the Gramps window interface.
         """
         return (self.title, 'Gramplet')
+
+    def refresh(self):
+        """
+        Refresh the detached gramplet
+        """
+        self.gramplet.pui.main() # refresh
 
     def get_title(self):
         """


### PR DESCRIPTION
Fixes #10850

This is the first method to avoid reloading gramplet automaticaly.

We need to choose between this PR and the next PR.