### PR TITLE
FR10850 V2: freeze/unfreeze button per gramplet

### DIFF
--- a/gramps/gen/config.py
+++ b/gramps/gen/config.py
@@ -196,6 +196,7 @@ register('interface.view-categories',
 register('interface.filter', False)
 register('interface.fullscreen', False)
 register('interface.grampletbar-close', False)
+register('interface.grampletbar-freeze', False)
 register('interface.ignore-gexiv2', False)
 register('interface.ignore-pil', False)
 register('interface.ignore-osmgpsmap', False)

--- a/gramps/gen/plug/_gramplet.py
+++ b/gramps/gen/plug/_gramplet.py
@@ -291,17 +291,46 @@ class Gramplet:
         """
         The main interface for running the :meth:`main` method.
         """
-        from gi.repository import GLib
         if ((not self.active) and
             not self.gui.force_update):
             self.dirty = True
             if self.dbstate.is_open():
-                #print "  %s is not active" % self.gui.gname
+                #print("  %s is not active" % self.gui.gname)
                 self.update_has_data()
             else:
                 self.set_has_data(False)
             return
-        #print "     %s is UPDATING" % self.gui.gname
+        #print("     %s is UPDATING" % self.gui.gname)
+        uva = self.uistate.viewmanager.active_page
+        # The dashboard has no sidebar or bottombar
+        if uva.bottombar:
+            for gramplets in [uva.bottombar.get_children()]:
+                for gramplet in gramplets:
+                    for i in range(gramplet.pui.gui.pane.get_n_pages()):
+                        child = gramplet.pui.gui.pane.get_nth_page(i)
+                        label = gramplet.pui.gui.pane.get_tab_label(child)
+                        act_grplet = (i == gramplet.pui.gui.pane.get_current_page())
+                        if (gramplet.title == child.get_title() and
+                            gramplet.title == self.gui.title and
+                            not label.get_freeze().get_active() and
+                            act_grplet):
+                            self._really_update()
+            for gramplets in [uva.sidebar.get_children()]:
+                for gramplet in gramplets:
+                    for i in range(gramplet.pui.gui.pane.get_n_pages()):
+                        child = gramplet.pui.gui.pane.get_nth_page(i)
+                        label = gramplet.pui.gui.pane.get_tab_label(child)
+                        act_grplet = (i == gramplet.pui.gui.pane.get_current_page())
+                        if (gramplet.title == child.get_title() and
+                            gramplet.title == self.gui.title and
+                            not label.get_freeze().get_active() and
+                            act_grplet):
+                            self._really_update()
+        else:
+            self._really_update()
+
+    def _really_update(self):
+        from gi.repository import GLib
         self.dirty = False
         LOG.debug("gramplet updater: %s: running" % self.gui.title)
         if self._idle_id != 0:

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -984,6 +984,12 @@ class GrampsPreferences(ConfigureDialog):
         """
         self.uistate.emit('grampletbar-close-changed')
 
+    def cb_grampletbar_freeze(self, obj):
+        """
+        Gramplet bar freeze/unfreeze button preference callback
+        """
+        self.uistate.emit('grampletbar-freeze-changed')
+
     def add_formats_panel(self, configdialog):
         row = 0
         grid = Gtk.Grid()
@@ -1184,6 +1190,13 @@ class GrampsPreferences(ConfigureDialog):
                           _("Show close button in gramplet bar tabs"),
                           row, 'interface.grampletbar-close', stop=3,
                           extra_callback=self.cb_grampletbar_close)
+        row += 1
+
+        # Gramplet bar freeze button:
+        self.add_checkbox(grid,
+                          _("Enable freeze/unfreeze for the active gramplet"),
+                          row, 'interface.grampletbar-freeze', stop=3,
+                          extra_callback=self.cb_grampletbar_freeze)
         row += 1
         return _('Display'), grid
 

--- a/gramps/gui/displaystate.py
+++ b/gramps/gui/displaystate.py
@@ -398,6 +398,7 @@ class DisplayState(Callback):
         'nameformat-changed' : None,
         'placeformat-changed' : None,
         'grampletbar-close-changed' : None,
+        'grampletbar-freeze-changed' : None,
         'update-available' : (list, ),
         'autobackup' : None,
         }


### PR DESCRIPTION
Fixes #10850

This is the second method to avoid reloading gramplet automaticaly.

We need to choose between this PR and the PR698