### PR TITLE
Allow filters/rules via plugin without fail on restart

### DIFF
--- a/gramps/gen/filters/__init__.py
+++ b/gramps/gen/filters/__init__.py
@@ -22,7 +22,6 @@
 Package providing filtering framework for Gramps.
 """
 
-#SystemFilters = None
 CustomFilters = None
 
 from ..const import CUSTOM_FILTERS
@@ -32,18 +31,10 @@ from ._genericfilter import (GenericFilter, GenericFilterFactory,
 from ._paramfilter import ParamFilter
 from ._searchfilter import SearchFilter, ExactSearchFilter
 
-#def reload_system_filters():
-    #global SystemFilters
-    #SystemFilters = FilterList(SYSTEM_FILTERS)
-    #SystemFilters.load()
-
 def reload_custom_filters():
     global CustomFilters
     CustomFilters = FilterList(CUSTOM_FILTERS)
     CustomFilters.load()
 
-#if not SystemFilters:
-    #reload_system_filters()
-
-if not CustomFilters:
-    reload_custom_filters()
+# if not CustomFilters:  # moved to viewmanager
+    # reload_custom_filters()

--- a/gramps/gen/filters/rules/_rule.py
+++ b/gramps/gen/filters/rules/_rule.py
@@ -141,8 +141,10 @@ class Rule:
 
     def display_values(self):
         """Return the labels and values of this rule."""
-        l_v = ( '%s="%s"' % (_(self.labels[ix]), self.list[ix])
-                for ix in range(len(self.list)) if self.list[ix] )
+        l_v = ('%s="%s"' % (_(self.labels[ix][0] if
+                              isinstance(self.labels[ix], tuple) else
+                              self.labels[ix]), self.list[ix])
+               for ix in range(len(self.list)) if self.list[ix])
 
         return ';'.join(l_v)
 

--- a/gramps/gen/filters/rules/test/person_rules_test.py
+++ b/gramps/gen/filters/rules/test/person_rules_test.py
@@ -17,7 +17,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-from ....filters.rules.person._matchidof import MatchIdOf
 
 """
 Unittest that tests person-specific filter rules
@@ -27,6 +26,8 @@ import os
 from time import perf_counter
 import inspect
 
+from ....filters import reload_custom_filters
+reload_custom_filters()
 from ....db.utils import import_as_dict
 from ....filters import GenericFilter, CustomFilters
 from ....const import DATA_DIR

--- a/gramps/gen/plug/_manager.py
+++ b/gramps/gen/plug/_manager.py
@@ -39,6 +39,7 @@ import os
 import sys
 import re
 import logging
+import importlib
 LOG = logging.getLogger('._manager')
 LOG.progagate = True
 from ..const import GRAMPS_LOCALE as glocale
@@ -197,6 +198,18 @@ class BasePluginManager:
                         plugin.data += results
                     except:
                         plugin.data = results
+        # Get the addon rules and import them and make them findable
+        for plugin in self.__pgr.rule_plugins():
+            mod = self.load_plugin(plugin)  # load the addon rule
+            # get place in rule heirarchy to put the new rule
+            obj_rules = importlib.import_module(
+                'gramps.gen.filters.rules.' + plugin.namespace.lower())
+            # get the new rule class object
+            r_class = getattr(mod, plugin.ruleclass)
+            # make the new rule findable via import statements
+            setattr(obj_rules, plugin.ruleclass, r_class)
+            # and add it to the correct fiter editor list
+            obj_rules.editor_rule_list.append(r_class)
 
     def is_loaded(self, pdata_id):
         """

--- a/gramps/gen/plug/_pluginreg.py
+++ b/gramps/gen/plug/_pluginreg.py
@@ -72,8 +72,9 @@ RELCALC = 9
 GRAMPLET = 10
 SIDEBAR = 11
 DATABASE = 12
-PTYPE = [REPORT , QUICKREPORT, TOOL, IMPORT, EXPORT, DOCGEN, GENERAL,
-               MAPSERVICE, VIEW, RELCALC, GRAMPLET, SIDEBAR, DATABASE]
+RULE = 13
+PTYPE = [REPORT, QUICKREPORT, TOOL, IMPORT, EXPORT, DOCGEN, GENERAL,
+         MAPSERVICE, VIEW, RELCALC, GRAMPLET, SIDEBAR, DATABASE, RULE]
 PTYPE_STR = {
         REPORT: _('Report') ,
         QUICKREPORT: _('Quickreport'),
@@ -88,6 +89,7 @@ PTYPE_STR = {
         GRAMPLET: _('Gramplet'),
         SIDEBAR: _('Sidebar'),
         DATABASE: _('Database'),
+        RULE: _('Rule')
         }
 
 #possible report categories
@@ -211,7 +213,7 @@ class PluginData:
        The python path where the plugin implementation can be found
     .. attribute:: ptype
        The plugin type. One of REPORT , QUICKREPORT, TOOL, IMPORT,
-        EXPORT, DOCGEN, GENERAL, MAPSERVICE, VIEW, GRAMPLET, DATABASE
+        EXPORT, DOCGEN, GENERAL, MAPSERVICE, VIEW, GRAMPLET, DATABASE, RULE
     .. attribute:: authors
        List of authors of the plugin, default=[]
     .. attribute:: authors_email
@@ -362,6 +364,13 @@ class PluginData:
     .. attribute:: reset_system
        Boolean to indicate that the system (sys.modules) should
        be reset.
+
+    Attributes for RULE plugins
+
+    .. attribute:: namespace
+       The class (Person, Event, Media, etc.) the rule applies to.
+    .. attribute:: ruleclass
+       The exact class name of the rule; ex: HasSourceParameter
     """
 
     def __init__(self):
@@ -440,6 +449,9 @@ class PluginData:
         #GENERAL attr
         self._data = []
         self._process = None
+        #RULE attr
+        self._ruleclass = None
+        self._namespace = None
 
     def _set_id(self, id):
        self._id = id
@@ -987,6 +999,26 @@ class PluginData:
     data = property(_get_data, _set_data)
     process = property(_get_process, _set_process)
 
+    #RULE attr
+    def _set_ruleclass(self, data):
+        if self._ptype != RULE:
+            raise ValueError('ruleclass may only be set for RULE plugins')
+        self._ruleclass = data
+
+    def _get_ruleclass(self):
+        return self._ruleclass
+
+    def _set_namespace(self, data):
+        if self._ptype != RULE:
+            raise ValueError('namespace may only be set for RULE plugins')
+        self._namespace = data
+
+    def _get_namespace(self):
+        return self._namespace
+
+    ruleclass = property(_get_ruleclass, _set_ruleclass)
+    namespace = property(_get_namespace, _set_namespace)
+
 def newplugin():
     """
     Function to create a new plugindata object, add it to list of
@@ -1034,6 +1066,7 @@ def make_environment(**kwargs):
         'EXPORT': EXPORT,
         'DOCGEN': DOCGEN,
         'GENERAL': GENERAL,
+        'RULE': RULE,
         'MAPSERVICE': MAPSERVICE,
         'VIEW': VIEW,
         'RELCALC': RELCALC,
@@ -1349,6 +1382,12 @@ class PluginRegister:
         Return a list of :class:`PluginData` that are of type DATABASE
         """
         return self.type_plugins(DATABASE)
+
+    def rule_plugins(self):
+        """
+        Return a list of :class:`PluginData` that are of type RULE
+        """
+        return self.type_plugins(RULE)
 
     def filter_load_on_reg(self):
         """

--- a/gramps/gui/editors/filtereditor.py
+++ b/gramps/gui/editors/filtereditor.py
@@ -501,7 +501,11 @@ class EditRule(ManagedWindow):
             grid.set_row_spacing(6)
             grid.show()
             for v in arglist:
-                l = Gtk.Label(label=v, halign=Gtk.Align.END)
+                if isinstance(v, tuple):
+                    # allows filter to create its own GUI element
+                    l = Gtk.Label(label=v[0], halign=Gtk.Align.END)
+                else:
+                    l = Gtk.Label(label=v, halign=Gtk.Align.END)
                 l.show()
                 if v == _('Place:'):
                     t = MyPlaces([])
@@ -585,6 +589,9 @@ class EditRule(ManagedWindow):
                 elif v == _('Units:'):
                     t = MyList([0, 1, 2],
                                [_('kilometers'), _('miles'), _('degrees')])
+                elif isinstance(v, tuple):
+                    # allow filter to create its own GUI element
+                    t = v[1](self.db)
                 else:
                     t = MyEntry()
                 t.set_hexpand(True)

--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -100,6 +100,7 @@ from gramps.gui.editors import (EditPerson, EditFamily, EditMedia, EditNote,
                                 EditPlace, EditSource, EditRepository,
                                 EditCitation, EditEvent)
 from gramps.gen.db.exceptions import DbWriteFailure
+from gramps.gen.filters import reload_custom_filters
 from .managedwindow import ManagedWindow
 
 #-------------------------------------------------------------------------
@@ -195,6 +196,7 @@ class ViewManager(CLIManager):
         self.__connect_signals()
 
         self.do_reg_plugins(self.dbstate, self.uistate)
+        reload_custom_filters()
         #plugins loaded now set relationship class
         self.rel_class = get_relationship_calculator()
         self.uistate.set_relationship_class()

--- a/gramps/test/test_util.py
+++ b/gramps/test/test_util.py
@@ -37,6 +37,8 @@ from gramps.cli.grampscli import CLIManager
 from gramps.cli.argparser import ArgParser
 from gramps.cli.arghandler import ArgHandler
 from gramps.gen.const import USER_DIRLIST
+from gramps.gen.filters import reload_custom_filters
+reload_custom_filters()  # so reports with filter options don't fail
 
 # _caller_context is primarily here to support and document the process
 # of determining the test-module's directory.


### PR DESCRIPTION
In attempting to add a new filter or rule via an addon, I discovered that the added filter/rule would not work after the first restart after its first use.  In addition I would get a console error:
ERROR: Filter rule 'HasSourceParameter' in filter 'testit' not found!
In this case I had added the new rule 'HasSourceParameter' in the addon, and tried to use it in a custom source filter called 'testit'.

It turned out that the 'custom_filters.xml' file was being processed on startup before the plugins/addons were scanned, so the addon filter was not found.

- First commit deals with this issue.
- Second commit allows a new addon category 'Rule'.
- Third commit allows an addon to provide its own rule GUI elements, for when the already defined rule parameters in filtereditor are not right for the addon.