### PR TITLE
Filter Rule editor, save pane position

### DIFF
--- a/gramps/gui/editors/filtereditor.py
+++ b/gramps/gui/editors/filtereditor.py
@@ -73,6 +73,7 @@ from gramps.gen.utils.db import family_name
 from gramps.gen.utils.string import conf_strings
 from ..widgets import DateEntry
 from gramps.gen.datehandler import displayer
+from gramps.gen.config import config
 
 #-------------------------------------------------------------------------
 #
@@ -684,6 +685,9 @@ class EditRule(ManagedWindow):
         self.rname_filter.connect('changed', self.on_rname_filter_changed)
 
         self._set_size()
+        config.register('interface.edit-rule-pane', 205)
+        panepos = config.get('interface.edit-rule-pane')
+        self.get_widget('hpaned1').set_position(panepos)
         self.show()
 
     def select_iter(self, data):
@@ -728,6 +732,8 @@ class EditRule(ManagedWindow):
                                    section=WIKI_HELP_SEC)
 
     def close_window(self, obj):
+        panepos = self.get_widget('hpaned1').get_position()
+        config.set('interface.edit-rule-pane', panepos)
         self.close()
 
     def on_node_selected(self, obj):


### PR DESCRIPTION
This fix saves the Edit/Filter edit rule dialog 'pane' position between the rule tree and the remainder of the dialog.

A long standing annoyance of mine is that the default position doesn't let me see much of the rule tree lines without scrolling or repositioning of the pane edge.  But the pane position doesn't get saved, so I have to do it every time I use the editor.

While it might be considered an enhancement, it doesn't have any compatibility issues or new translatable strings that would require delaying to 5.1.