### PR TITLE
New CLI commands; Safe mode and Defaults

### DIFF
--- a/gramps/gen/const.py
+++ b/gramps/gen/const.py
@@ -104,6 +104,13 @@ elif 'USERPROFILE' in os.environ:
 else:
     USER_HOME = get_env_var('HOME')
     HOME_DIR = os.path.join(USER_HOME, '.gramps')
+ORIG_HOME_DIR = HOME_DIR
+if 'SAFEMODE' in os.environ:
+    if 'USERPROFILE' in os.environ:
+        USER_HOME = get_env_var('USERPROFILE')
+    else:
+        USER_HOME = get_env_var('HOME')
+    HOME_DIR = get_env_var('SAFEMODE')
 
 
 VERSION_DIR = os.path.join(
@@ -267,6 +274,7 @@ LONGOPTS = [
     "class=",
     "config=",
     "debug=",
+    "default=",
     "display=",
     "disable-sound",
     "disable-crash-dialog",
@@ -294,6 +302,7 @@ LONGOPTS = [
     "password=",
     "create=",
     "options=",
+    "safe",
     "screen=",
     "show",
     "sm-client-id=",
@@ -307,7 +316,7 @@ LONGOPTS = [
     "quiet",
 ]
 
-SHORTOPTS = "O:U:P:C:i:e:f:a:p:d:c:r:lLthuv?syq"
+SHORTOPTS = "O:U:P:C:i:e:f:a:p:d:c:r:lLthuv?syqSD:"
 
 GRAMPS_UUID = uuid.UUID('516cd010-5a41-470f-99f8-eb22f1098ad6')
 

--- a/gramps/gen/utils/configmanager.py
+++ b/gramps/gen/utils/configmanager.py
@@ -299,7 +299,12 @@ class ConfigManager:
                             continue # with next setting
                     ####################### End upgrade code
                     else:
-                        value = safe_eval(raw_value)
+                        try:
+                            value = safe_eval(raw_value)
+                        except:
+                            # most likely exception is SyntaxError but
+                            # others are possible  ex: '0L' from Python2 days
+                            value = None
                     ####################### Now, let's test and set:
                     if (name in self.default and
                         setting in self.default[name]):

--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -38,15 +38,22 @@ LOG = logging.getLogger(".")
 from subprocess import Popen, PIPE
 
 #-------------------------------------------------------------------------
+# process 'safe mode'; set up for a temp directory for user data
+# actual directory paths set up in const module
+if "-S" in sys.argv or "--safe" in sys.argv:
+    from tempfile import TemporaryDirectory
+    tempdir = TemporaryDirectory(prefix='gramps_')
+    os.environ['SAFEMODE'] = tempdir.name
+
+#-------------------------------------------------------------------------
 #
 # Gramps modules
 #
 #-------------------------------------------------------------------------
-from .gen.const import APP_GRAMPS, USER_DIRLIST, HOME_DIR
+from .gen.const import APP_GRAMPS, USER_DIRLIST, HOME_DIR, ORIG_HOME_DIR
 from .gen.constfunc import mac
 from .version import VERSION_TUPLE
 from .gen.constfunc import win, get_env_var
-from .gen.config import config
 
 #-------------------------------------------------------------------------
 #
@@ -436,6 +443,18 @@ def run():
     argv_copy = sys.argv[:]
     argpars = ArgParser(argv_copy)
 
+    # if in safe mode we should point the db dir back to the original dir.
+    # It is ok to import config here, 'Defaults' command had its chance...
+    from .gen.config import config
+    if 'SAFEMODE' in os.environ:
+        config.set('database.path', os.path.join(ORIG_HOME_DIR, 'grampsdb'))
+
+    # On windows the fontconfig handler may be a better choice; ask user to
+    # choose for now.
+    if(win() and ('PANGOCAIRO_BACKEND' not in os.environ) and
+       config.get('preferences.alternate-fonthandler')):
+        os.environ['PANGOCAIRO_BACKEND'] = "fontconfig"
+
     # Calls to LOG must be after setup_logging() and ArgParser()
     LOG = logging.getLogger(".locale")
     LOG.debug("Encoding: %s", glocale.encoding)
@@ -477,9 +496,6 @@ def main():
         resource_path, filename = os.path.split(os.path.abspath(__file__))
         resource_path, dirname = os.path.split(resource_path)
         os.environ['GRAMPS_RESOURCES'] = resource_path
-    if win() and ('PANGOCAIRO_BACKEND' not in os.environ) and \
-            config.get('preferences.alternate-fonthandler'):
-        os.environ['PANGOCAIRO_BACKEND'] = "fontconfig"
     errors = run()
     if errors and isinstance(errors, list):
         for error in errors:


### PR DESCRIPTION
Also a second commit that improves safety in loading an older or corrupted config file.

'**Safe mode**'  ("gramps -S" or "gramps --safe").  This CLI command starts Gramps as if it had never been installed before.  In this mode, any previous family trees can still be loaded, as long as they were stored in the default folder.  All other settings, filters, books, addons etc. are either cleared or returned to their default values.  Other CLI commands can be used, or, if none, Gramps will start the GUI.  Nothing except the actual family tree data is saved.

This actually works by setting the folder that Gramps uses to store its user data (except for family trees) to a temporary directory, which is deleted when Gramps closes.

'**Defaults**' ("gramps -D E" or "gramps --default=E").  This CLI command causes Gramps to clear out or return to defaults the desired settings.  The family tree databases are NOT cleared out or removed.  The sub-commands (replace the 'E' from the example command line above) are:

- 'A' Addons are cleared.  Any installed addons are removed, along with their settings.
- 'F' Filters are cleared.  Any custom filters are removed.
- 'P' Preferences are returned to their default values.
- 'X' Books are cleared, Reports and Tools settings are returned to their default values.
- 'Z' Old '.zip' files from family tree version upgrades are deleted.
- 'E' Everything except the actual family tree data is returned to default settings.  This does all of the above as well as a few more items; deletes thumbnails, maps and the user CSS (used in web reports).

If this PR is accepted, I will create and reference a wiki entry containing the previous information.

Note: I had to shift the code for 'import config'  and its usage a bit to prevent it from getting done before the new commands had a chance to take effect.