### PR TITLE
Fix exception when closing early editor in tree of editors

### DIFF
--- a/gramps/gui/managedwindow.py
+++ b/gramps/gui/managedwindow.py
@@ -576,8 +576,8 @@ class ManagedWindow:
         self.opened = False
         self._save_position(save_config=False)  # the next line will save it
         self._save_size()
-        self.clean_up()
         self.uistate.gwm.close_track(self.track)
+        self.clean_up()
         # put a previously modal window back to modal, now that we are closing
         if self.other_modal_window:
             self.other_modal_window.set_modal(True)


### PR DESCRIPTION
Fixes [#10876](https://gramps-project.org/bugs/view.php?id=10876)

If you add a primary object and then use its notetab to add a note, but don't save the note, and then save the primary object, the window manager closes the note editor (which in turn asks if you want to save).  If you use the popup dialog to save the note, it attempts to call back and update the original primary object's notetab.

In the original bug, it turned out that saving the original primary object, was 'cleaning up' its notetab.  So when the callback occurred, it failed.

I changed the order of the cleanup and closing of subsidiary windows.  I've tested in as many cases as I can think of and this appears to stop the exceptions.  

The user might still be a bit confused if he does this, because saving the note doesn't let it get attached to the original primary object, as it was already saved before the note was completed.  It does seem to be a corner case that does not happen if the user does the natural thing and closes each subsidiary editor window as he finishes it.