### PR TITLE
Fix crash when a filter with loop in definition is defined

### DIFF
--- a/gramps/gen/filters/rules/_rule.py
+++ b/gramps/gen/filters/rules/_rule.py
@@ -28,9 +28,11 @@ Base class for filter rules.
 # Standard Python modules
 #
 #-------------------------------------------------------------------------
+import re
+
+from ...errors import FilterError
 from ...const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
-import re
 
 #-------------------------------------------------------------------------
 #
@@ -88,6 +90,10 @@ class Rule:
                 self.match_substring = self.match_regex
             self.prepare(db, user)
         self.nrprepare += 1
+        if self.nrprepare > 20:  # more references to a filter than expected
+            raise FilterError(_("The filter definition contains a loop."),
+                              _("One rule references another which eventually"
+                                " references the first."))
 
     def prepare(self, db, user):
         """prepare so the rule can be executed efficiently"""


### PR DESCRIPTION
Fixes [#10621](https://gramps-project.org/bugs/view.php?id=10621)

A user created a custom filter that had a set of rules that eventually referenced each other in a loop.  When trying to 'Find' with that filter, Gramps crashes hard with a
RecursionError: maximum recursion depth exceeded while calling a Python object.

I added a test to watch for too many calls to the filter; this catches the issue.  I also added a new error message.