### PR TITLE
Fix AgeOnDate and some reports using SimpleAccess for missing surname

### DIFF
--- a/gramps/gen/simple/_simpleaccess.py
+++ b/gramps/gen/simple/_simpleaccess.py
@@ -787,7 +787,8 @@ class SimpleAccess:
 
         with self.dbase.get_person_cursor() as cursor:
             # data[3] is primary_name; data[3][5][0][0] is surname
-            slist = sorted((data[3][5][0][0], key) for key, data in cursor)
+            slist = sorted((data[3][5][0][0] if data[3][5] else '', key)
+                           for key, data in cursor)
 
         for info in slist:
             obj = self.dbase.get_person_from_handle(info[1])


### PR DESCRIPTION
Fixes [#9958](https://gramps-project.org/bugs/view.php?id=9958)

Another issue with completely missing surname  similar to https://github.com/gramps-project/gramps/pull/613.

This was found with the Age on date Gramplet, but would effect any report using SimpleAccess.