### PR TITLE
Fix StyledTextEditor EditLink for root text changed to zero length

### DIFF
--- a/gramps/gui/editors/editlink.py
+++ b/gramps/gui/editors/editlink.py
@@ -74,7 +74,7 @@ class EditLink(ManagedWindow):
         self.simple_access = SimpleAccess(self.dbstate.db)
         self.callback = callback
 
-        ManagedWindow.__init__(self, uistate, track, url)
+        ManagedWindow.__init__(self, uistate, track, url, modal=True)
 
         self._local_init()
         self._connect_signals()


### PR DESCRIPTION
Fixes #9750

If you start an EditLink from within the StyledTextEditor (Edit note) you have to have some text selected to have the Edit link dialog pop up.  Prior to this fix, if you had the EditLink dialog open, you could change the selected text within the StyledTextEditor window itself.  If it was changed to zero length (no text selected), you would get an exception on 'Ok' from the EditLink dialog, as there was no place to apply the link.

This PR changes the EditLink to modal, so nothing can be changed in the StyledTextEditor window.