### PR TITLE
Fix dbapi set_name_group_mapping to properly close transaction

### DIFF
--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -572,6 +572,7 @@ class DBAPI(DbGeneric):
         """
         Set the default grouping name for a surname.
         """
+        self._txn_begin()
         self.dbapi.execute("SELECT 1 FROM name_group WHERE name = ?",
                            [name])
         row = self.dbapi.fetchone()
@@ -582,6 +583,7 @@ class DBAPI(DbGeneric):
             self.dbapi.execute(
                 "INSERT INTO name_group (name, grouping) VALUES (?, ?)",
                 [name, grouping])
+        self._txn_commit()
 
     def _commit_base(self, obj, obj_key, trans, change_time):
         """


### PR DESCRIPTION
Fixes [#10730](https://gramps-project.org/bugs/view.php?id=10730)

It seems that you have to properly end a transaction (at least) when updating or inserting data into your db.  If you don't, then attempting another transaction gives an error (the bug report [#10730](https://gramps-project.org/bugs/view.php?id=10730) ).