### PR TITLE
Fix FilterParser for much older 3.x custom_filters.xml files

### DIFF
--- a/gramps/gen/filters/_filterparser.py
+++ b/gramps/gen/filters/_filterparser.py
@@ -62,6 +62,9 @@ class FilterParser(handler.ContentHandler):
                 self.namespace = attrs['type']
             else:
                 self.namespace = "generic"
+            if self.namespace == 'MediaObject':
+                # deals with older custom filters
+                self.namespace = 'Media'
         elif tag == "filter":
             self.f = GenericFilterFactory(self.namespace)()
             self.f.set_name(attrs['name'])


### PR DESCRIPTION
Fixes [#8075](https://gramps-project.org/bugs/view.php?id=8075), [#10669](https://gramps-project.org/bugs/view.php?id=10669), [#10516](https://gramps-project.org/bugs/view.php?id=10516)

This difficult to debug issue was caused by old custom_filters.xml files, probably from back in 3.x timeframe.  They contained data starting with:
```
<?xml version="1.0" encoding="utf-8"?>
<filters>
<object type="MediaObject">
```
which is no longer valid.  The correct value for object type is 'Media'.  Due to less than ideal error handling, the failure prevented Gramps startup.