### PR TITLE
Fix Statusbar update to avoid intermittent exception on closed db

### DIFF
--- a/gramps/gui/displaystate.py
+++ b/gramps/gui/displaystate.py
@@ -621,18 +621,16 @@ class DisplayState(Callback):
 
         self.status.pop(self.status_id)
 
-        if active_handle:
+        if active_handle and dbstate.is_open():
             name, obj = navigation_label(dbstate.db, nav_type, active_handle)
+            # Append relationship to default person if funtionality is enabled.
+            if nav_type == 'Person' and config.get('interface.statusbar') > 1:
+                if active_handle != dbstate.db.get_default_handle():
+                    msg = self.display_relationship(dbstate, active_handle)
+                    if msg:
+                        name = '%s (%s)' % (name, msg.strip())
         else:
             name = _('No active object')
-
-        # Append relationship to default person if funtionality is enabled.
-        if nav_type == 'Person' and active_handle \
-                                and config.get('interface.statusbar') > 1:
-            if active_handle != dbstate.db.get_default_handle():
-                msg = self.display_relationship(dbstate, active_handle)
-                if msg:
-                    name = '%s (%s)' % (name, msg.strip())
 
         if not name:
             name = self.NAV2MES[nav_type]


### PR DESCRIPTION
Fixes [#10882](https://gramps-project.org/bugs/view.php?id=10882)

The bug report shows that the statusbar update is getting an exception on a closed db (inferred from
`  File "/usr/lib/python3.7/site-packages/gramps/plugins/db/bsddb/read.py", line 688, in get_person_from_handle
    return self._get_from_handle(handle, Person, self.person_map)
  File "/usr/lib/python3.7/site-packages/gramps/plugins/db/bsddb/read.py", line 675, in _get_from_handle
    data = data_map.get(handle.encode('utf-8'))
AttributeError: 'NoneType' object has no attribute 'get'
`
I have not been able to replicate this but I suspect that it is caused by some sequence of events caused by the 'push_message' routine which causes a statusbar update after 5 seconds from a previous message.  I suspect that if the timeout occurs at just the right point in a program shutdown, you might get the exception.

In any event, I hardened the code to Not exception out if a db is closed; previously it depended on the active_handle being None or empty string during the close (which it usually is).