### PR TITLE
Fix Person Sidebarfilter when using 'Event' and Reg expressions

### DIFF
--- a/gramps/gui/filters/sidebar/_personsidebarfilter.py
+++ b/gramps/gui/filters/sidebar/_personsidebarfilter.py
@@ -206,7 +206,7 @@ class PersonSidebarFilter(SidebarFilter):
 
             # Build an event filter if needed
             if etype:
-                rule = HasEvent([etype, '', '', '', '', True], use_regex=regex)
+                rule = HasEvent([etype, '', '', '', '', '1'], use_regex=regex)
                 generic_filter.add_rule(rule)
 
             # Build birth event filter if needed


### PR DESCRIPTION
Fixes [#10659](https://gramps-project.org/bugs/view.php?id=10659)

When using the 'Event' type in the Person Sidebar Filter, and checking 'Use regular expressions' the person HasEvent rule includes the following parameters:
'Personal event:', 'Date:', 'Place:', 'Description:', 'Main Participants:', 'Primary Role:'
All of these except for 'Primary Role' are strings, and can be used as the source string for re.compile.
The latter causes the exception.
When using the same rule created by the Filter Editor, the last parameter is a string '1' or '0'.  Either works correctly, since the 'apply' converts the parameter to an int for testing, so I changed the Person Sidebar Filter to also start this rule with a string parameter.