### PR TITLE
Fix Dashboard for multiple copies of a Gramplet

### DIFF
--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -1152,7 +1152,7 @@ class GrampletPane(Gtk.ScrolledWindow):
         retval = []
         filename = self.configfile
         if filename and os.path.exists(filename):
-            cp = configparser.ConfigParser()
+            cp = configparser.ConfigParser(strict=False)
             try:
                 cp.read(filename, encoding='utf-8')
             except Exception as err:
@@ -1216,12 +1216,9 @@ class GrampletPane(Gtk.ScrolledWindow):
                             for key in base_opts:
                                 if key in gramplet.__dict__:
                                     base_opts[key] = gramplet.__dict__[key]
-                            fp.write("[%s]\n" % gramplet.gname)
+                            fp.write("[%s]\n" % gramplet.title)  # section
                             for key in base_opts:
                                 if key == "content": continue
-                                elif key == "title":
-                                    if gramplet.title_override:
-                                        fp.write("title=%s\n" % base_opts[key])
                                 elif key == "tname": continue
                                 elif key == "column": continue
                                 elif key == "row": continue
@@ -1266,7 +1263,7 @@ class GrampletPane(Gtk.ScrolledWindow):
                                         fp.write("data[%d]=%s\n" % (cnt, item))
                                         cnt += 1
                             else:
-                                fp.write("%s=%s\n\n" % (key, base_opts[key]))
+                                fp.write("%s=%s\n" % (key, base_opts[key]))
 
         except IOError as err:
             LOG.warning("Failed to open %s because $s; gramplets not saved",

--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -1216,6 +1216,7 @@ class GrampletPane(Gtk.ScrolledWindow):
                             for key in base_opts:
                                 if key in gramplet.__dict__:
                                     base_opts[key] = gramplet.__dict__[key]
+                            base_opts['state'] = gramplet.gstate
                             fp.write("[%s]\n" % gramplet.title)  # section
                             for key in base_opts:
                                 if key == "content": continue
@@ -1244,6 +1245,7 @@ class GrampletPane(Gtk.ScrolledWindow):
                         for key in base_opts:
                             if key in gramplet.__dict__:
                                 base_opts[key] = gramplet.__dict__[key]
+                        base_opts['state'] = gramplet.gstate
                         fp.write("[%s]\n" % gramplet.title)
                         for key in base_opts:
                             if key == "content": continue


### PR DESCRIPTION
Fixes [#10650](https://gramps-project.org/bugs/view.php?id=10650)

If two or more copies of a Gramplet are installed in the Dashboard (don't know why this was supported, but it was, in part), the current code produces a warning similar to the following:
 WARNING: grampletpane.py: line 1163: Failed to load gramplets from /home/dave/.gramps/gramps50/Gramplets_dashboardview_gramplets.ini because While reading from '/home/dave/.gramps/gramps50/Gramplets_dashboardview_gramplets.ini' [line 65]: section 'To Do' already exists 

And then the dashboard is blank.  This does not fix itself on restart.

This PR corrects the situation by properly setting the .ini file section heading with a unique name for each copy of a gramplet.  It also sets the .ini parser to non-strict mode, so if a user already had this issue, the dashboard will at least load (although with only a single copy of the Gramplet).