### PR TITLE
Fix ToDo Gramplet for multiple attempts to edit a note

### DIFF
--- a/gramps/plugins/gramplet/todo.py
+++ b/gramps/plugins/gramplet/todo.py
@@ -34,6 +34,7 @@ from gramps.gui.widgets.styledtexteditor import StyledTextEditor
 from gramps.gui.widgets import SimpleButton
 from gramps.gen.lib import StyledText, Note, NoteType
 from gramps.gen.db import DbTxn
+from gramps.gen.errors import WindowActiveError
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 
@@ -177,7 +178,7 @@ class ToDo(Gramplet):
         note = self.dbstate.db.get_note_from_handle(note_handle)
         try:
             EditNote(self.gui.dbstate, self.gui.uistate, [], note)
-        except AttributeError:
+        except WindowActiveError:
             pass
 
     def new_clicked(self, obj):
@@ -189,7 +190,7 @@ class ToDo(Gramplet):
         note.set_type(NoteType.TODO)
         try:
             EditNote(self.gui.dbstate, self.gui.uistate, [], note, self.created)
-        except AttributeError:
+        except WindowActiveError:
             pass
 
 class PersonToDo(ToDo):


### PR DESCRIPTION
Fixes [#10645](https://gramps-project.org/bugs/view.php?id=10645)

ToDo Gramplet used wrong exception type for starting the EditNote.