### PR TITLE
Fix startup messages with bad filename

### DIFF
--- a/gramps/cli/arghandler.py
+++ b/gramps/cli/arghandler.py
@@ -382,7 +382,7 @@ class ArgHandler:
                 self.open = db_path
                 self.__open_action()
             else:
-                sys.exit(1)
+                sys.exit(_("Error: cannot open '%s'") % self.open_gui)
             return db_path
 
         # if not open_gui, parse any command line args. We can only have one

--- a/gramps/gui/grampsgui.py
+++ b/gramps/gui/grampsgui.py
@@ -369,8 +369,11 @@ def __startgramps(errors, argparser):
         quit_now = True
         if err.code:
             exit_code = err.code
-            LOG.error("Gramps terminated with exit code: %d.", err.code,
-                      exc_info=True)
+            if isinstance(err.code, str):
+                LOG.error(err.code, exc_info=False)
+            else:
+                LOG.error("Gramps terminated with exit code: %d.", err.code,
+                          exc_info=False)
     except OSError as err:
         quit_now = True
         exit_code = err.errno or 1


### PR DESCRIPTION
Fixes [#10885](https://gramps-project.org/bugs/view.php?id=10885)

User added a bad file name to command line for GUI start and got a pretty poor crash message.

I reused an already present error message (no new translation) to support a better startup error.

Pretty minor, but tries to make it a bit more friendly.