### PR TITLE
Updated swedish translation

### DIFF
--- a/po/sv.po
+++ b/po/sv.po
@@ -20,20 +20,21 @@
 # Jens Arvidsson <jya@sverige.nu>, 2002-2005.
 # Stefan Björk <betula@users.sourceforge.net>, 2005-2006.
 # Peter Landgren <peter.talken@telia.com>, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017.
+# Pär Ekholm <par.ekholm@pekholm.se>, 2018.
 msgid ""
 msgstr ""
 "Project-Id-Version: sv\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-20 09:31-0500\n"
-"PO-Revision-Date: 2017-01-21 14:20+0100\n"
-"Last-Translator: Peter Landgren <peter.talken@telia.com>\n"
-"Language-Team: Swedish <kde-i18n-doc@kde.org>\n"
-"Language: sv\n"
+"POT-Creation-Date: 2018-07-24 14:13+0100\n"
+"PO-Revision-Date: 2018-11-15 18:11+0100\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Lokalize 1.5\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
+"Last-Translator: Pär Ekholm <par.ekholm@pekholm.se>\n"
+"Language: sv\n"
 
 #: ../data/gramps.appdata.xml.in.h:1
 msgid ""
@@ -58,8 +59,7 @@ msgid ""
 "All of your research is kept organized, searchable and as precise as you "
 "need it to be."
 msgstr ""
-" All din forskning hålls organiserad, sökbar och precis så detaljerad du "
-"vill."
+"All din forskning hålls organiserad, sökbar och precis så detaljerad du vill."
 
 #: ../data/gramps.desktop.in.h:1
 msgid "Gramps"
@@ -177,31 +177,31 @@ msgstr "Purim"
 
 #: ../data/holidays.xml.in.h:17
 msgid "Passover"
-msgstr "Passover"
+msgstr "Pesach"
 
 #: ../data/holidays.xml.in.h:18
 msgid "2 of Passover"
-msgstr "2 i Passover"
+msgstr "2 i Pesach"
 
 #: ../data/holidays.xml.in.h:19
 msgid "3 of Passover"
-msgstr "3 i Passover"
+msgstr "3 i Pesach"
 
 #: ../data/holidays.xml.in.h:20
 msgid "4 of Passover"
-msgstr "4 i Passover"
+msgstr "4 i Pesach"
 
 #: ../data/holidays.xml.in.h:21
 msgid "5 of Passover"
-msgstr "5 i Passover"
+msgstr "5 i Pesach"
 
 #: ../data/holidays.xml.in.h:22
 msgid "6 of Passover"
-msgstr "6 i Passover"
+msgstr "6 i Pesach"
 
 #: ../data/holidays.xml.in.h:23
 msgid "7 of Passover"
-msgstr "7 i Passover"
+msgstr "7 i Pesach"
 
 #: ../data/holidays.xml.in.h:24
 msgid "Shavuot"
@@ -217,71 +217,71 @@ msgstr "Rosh Ha'Shana 2"
 
 #: ../data/holidays.xml.in.h:27
 msgid "Yom Kippur"
-msgstr "Yom Kippur"
+msgstr "Jom Kippur"
 
 #: ../data/holidays.xml.in.h:28
 msgid "Sukot"
-msgstr "Sukot"
+msgstr "Sukkot"
 
 #: ../data/holidays.xml.in.h:29
 msgid "2 of Sukot"
-msgstr "2 i Sukot"
+msgstr "2 i Sukkot"
 
 #: ../data/holidays.xml.in.h:30
 msgid "3 of Sukot"
-msgstr "3 i Sukot"
+msgstr "3 i Sukkot"
 
 #: ../data/holidays.xml.in.h:31
 msgid "4 of Sukot"
-msgstr "4 i Sukot"
+msgstr "4 i Sukkot"
 
 #: ../data/holidays.xml.in.h:32
 msgid "5 of Sukot"
-msgstr "5 i Sukot"
+msgstr "5 i Sukkot"
 
 #: ../data/holidays.xml.in.h:33
 msgid "6 of Sukot"
-msgstr "6 i Sukot"
+msgstr "6 i Sukkot"
 
 #: ../data/holidays.xml.in.h:34
 msgid "7 of Sukot"
-msgstr "7 i Sukot"
+msgstr "7 i Sukkot"
 
 #: ../data/holidays.xml.in.h:35
 msgid "Simhat Tora"
-msgstr "Simhat Tora"
+msgstr "Simchat Torah"
 
 #: ../data/holidays.xml.in.h:36
 msgid "Hanuka"
-msgstr "Hanuka"
+msgstr "Chanukka"
 
 #: ../data/holidays.xml.in.h:37
 msgid "2 of Hanuka"
-msgstr "2 i Hanuka"
+msgstr "2 i Chanukka"
 
 #: ../data/holidays.xml.in.h:38
 msgid "3 of Hanuka"
-msgstr "3 i Hanuka"
+msgstr "3 i Chanukka"
 
 #: ../data/holidays.xml.in.h:39
 msgid "4 of Hanuka"
-msgstr "4 i Hanuka"
+msgstr "4 i Chanukka"
 
 #: ../data/holidays.xml.in.h:40
 msgid "5 of Hanuka"
-msgstr "5 i Hanuka"
+msgstr "5 i Chanukka"
 
 #: ../data/holidays.xml.in.h:41
 msgid "6 of Hanuka"
-msgstr "6 i Hanuka"
+msgstr "6 i Chanukka"
 
 #: ../data/holidays.xml.in.h:42
 msgid "7 of Hanuka"
-msgstr "7 i Hanuka"
+msgstr "7 i Chanukka"
 
 #: ../data/holidays.xml.in.h:43
 msgid "8 of Hanuka"
-msgstr "8 i Hanuka"
+msgstr "8 i Chanukka"
 
 #: ../data/holidays.xml.in.h:44
 msgid "New Zealand"
@@ -289,7 +289,7 @@ msgstr "Nya Zealand"
 
 #: ../data/holidays.xml.in.h:45
 msgid "Ukraine"
-msgstr "Ukrainska"
+msgstr "Ukraina"
 
 #: ../data/holidays.xml.in.h:46
 msgid "Serbia"
@@ -309,7 +309,7 @@ msgid ""
 msgstr ""
 "<b>Arbeta med datum</b><br/>Ett datumintervall kan ges genom att använda "
 "formatet &quot;mellan 4 januari 2000 och 20 mars 2003&quot;. Du kan även "
-"indikera konfidensintervall på ett datum samt även välja mellan flera olika "
+"indikera konfidensintervall på ett datum samt även välja mellan sju olika "
 "kalendrar. Prova knappen bredvid datumfältet i händelseredigeraren."
 
 #: ../data/tips.xml.in.h:2
@@ -550,9 +550,8 @@ msgstr ""
 "inträffade (till exempel födelse eller död), så kan du i Gramps lägga in ett "
 "brett urval av datumformat baserade på en gissning eller en uppskattning. "
 "Exempelvis är &quot;omkring 1908&quot; ett giltigt format för ett "
-"födelsedatum i Gramps. Se Grampshandboken för mer information.    ???Se wiki-"
-"handboken för en komplett beskrivning av alternativen för inskrivning av "
-"datum."
+"födelsedatum i Gramps. Se Grampshandboken för en komplett beskrivning av "
+"alternativen för inskrivning av datum."
 
 #: ../data/tips.xml.in.h:20
 msgid ""
@@ -575,6 +574,7 @@ msgid ""
 msgstr ""
 "<b>Slå samman data</b><br/>Funktionen &quot;Redigera &quot; Jämför och slå "
 "samman...&quot; låter dig kombinera separat listade personer till en enda. "
+"Välj den andra posten genom att hålla ner CTRL tangenten medan du väljer. "
 "Detta är mycket användbart för att kombinera två databaser med överlappande "
 "personer eller för att kombinera felaktigt inskrivna olika namn för en enda "
 "person. Motsvarande gäller även för platser, källor och arkivplatser."
@@ -589,7 +589,7 @@ msgstr ""
 "<b>Organisering av vyer</b><br/>Många vyer kan visa dina data antingen i ett "
 "hierarkiskt träd eller i en enkel lista. Varje vy kan också ställas in på "
 "det sätt du vill ha det. Titta längst upp till höger på verktygsraden under "
-"&quot;Vy&quot;-menyn. "
+"&quot;Visa&quot;-menyn."
 
 #: ../data/tips.xml.in.h:23
 msgid ""
@@ -677,7 +677,8 @@ msgstr ""
 "förbättringar i Gramps. En förfrågan kan göras antingen via e-postlistorna "
 "gramps-users eller gramps-devel eller genom att skapa en förfrågan om "
 "förbättring (Feature Request) på http://bugs.gramps-project.org. Den "
-"sistnämnda metoden är att föredra."
+"sistnämnda metoden är att föredra men det kan vara bra att diskutera idéerna "
+"på e-postlistorna."
 
 #: ../data/tips.xml.in.h:30
 msgid ""
@@ -690,8 +691,8 @@ msgstr ""
 "<b>Gramps e-postlistor</b><br/>Vill du få svar på dina frågor om Gramps? Ta "
 "en titt på listan gramps-users. Många användare finns på listan, så du har "
 "stor chans att få ett snabbt svar. Om du behöver ställa frågor angående "
-"utvecklingen av Gramps, så försök med gramps-devel. Information om båda e-"
-"postlistorna finns på lists.sf.net."
+"utvecklingen av Gramps, så försök med gramps-devel. Du kan få information om "
+"båda e-postlistorna genom att välja &quot;Hjälp &gt; Gramps sändlistor&quot;."
 
 #: ../data/tips.xml.in.h:31
 msgid ""
@@ -709,7 +710,7 @@ msgstr ""
 "skriva dokumentation till att testa utvecklingsversioner till att hjälpa "
 "till med webbplatsen. Börja med att anmäla dig till grampsutvecklarnas e-"
 "postlista gramps-devel och presentera dig. Anmälningsinformation finns på "
-"&quot; Help &gt; Gramps Mailing Lists&quot;"
+"&quot; Hjälp &gt; Gramps sändlistor&quot;"
 
 #: ../data/tips.xml.in.h:32
 msgid ""
@@ -722,11 +723,10 @@ msgid ""
 msgstr ""
 "<b>Så vad betyder ett namn?</b><br/>Namnet Gramps föreslogs av den "
 "ursprunglige utvecklare, Don Allinghams far. Gramps kan uttolkas som "
-"<i>Genealogical Research and Analysis Management Program System</i>. Med "
-"andra ord, det är ett personligt släktforskningsprogram där du kan lagra, "
-"redigera och utforska genealogiska uppgifter. Gramps databasmotor är så "
-"robust att en del användare hanterar genealogier innehållande "
-"hundratusentals personer."
+"<i>Genealogical Research and Analysis Management Program System</i>. Det är "
+"ett fullfjädrat släktforskningsprogram där du kan lagra, redigera och "
+"utforska genealogiska uppgifter. Gramps databashanterare är så robust att en "
+"del användare hanterar genealogier innehållande hundratusentals personer."
 
 #: ../data/tips.xml.in.h:33
 msgid ""
@@ -741,7 +741,6 @@ msgstr ""
 "aktiveras denna. För att skapa ett bokmärke för en person, så aktivera denne "
 "först, gå sedan till &quot;Bokmärke &gt; Lägg till bokmärke&quot; eller "
 "tryck Ctrl+D. Du kan även utnyttja bokmärken för de flesta övriga objekt."
-"bookmark brukar få heta bookmark på svenska också"
 
 #: ../data/tips.xml.in.h:34
 msgid ""
@@ -753,10 +752,10 @@ msgid ""
 "Preferences &gt; Display&quot;."
 msgstr ""
 "<b>Felaktiga datum</b><br/>: Alla skriver någon gång in datum med ogiltigt "
-"format. Felaktiga datumformat kommer att visas med en rödaktig bakgrund "
-"eller en röd punkt vid fältets kant. Rätta till med hjälp av dialogrutan för "
-"datumval. Datumformatet ställs in under &quot;Redigera &gt; Inställningar "
-"&gt; Visa&quot;."
+"format. Felaktiga datumformat kommer att visas i Gramps med en rödaktig "
+"bakgrund eller en röd punkt vid fältets högra kant. Rätta till med hjälp av "
+"dialogrutan för datumval genom att klicka på datumknappen. Datumformatet "
+"ställs in under &quot;Redigera &gt; Inställningar &gt; Visa&quot;."
 
 #: ../data/tips.xml.in.h:35
 msgid ""
@@ -769,8 +768,8 @@ msgstr ""
 "redigeraren öppnad med&quot;Person &gt; Redigera person &gt; "
 "Händelser&quot;. Det finns en lång lista med förbestämda typer. Du kan lägga "
 "till egna händelsetyper genom att skriva in texten i fältet. De kommer att "
-"läggas till tillgängliga händelser, men blir ej översatta.(Men observera de "
-"kan f.n. inte tas bort på ett enkelt sätt/ö.s. anm.). "
+"läggas till tillgängliga händelser, men blir ej översatta. (Men observera de "
+"kan f.n. inte tas bort på ett enkelt sätt/ö.s. anm.)."
 
 #: ../data/tips.xml.in.h:36
 msgid ""
@@ -837,7 +836,7 @@ msgstr ""
 "<b>Filter</b><br/>Med ett filter kan du begränsa antalet av de personer du "
 "vill se i Personvyn. Förutom de många förinställda filtren kan du definiera "
 "egna, anpassade filter. Anpassade filter skapas från &quot;Redigera &gt; "
-"Personfilter&quot;."
+"Redigera personfilter&quot;."
 
 #: ../data/tips.xml.in.h:42
 msgid ""
@@ -850,7 +849,7 @@ msgstr ""
 "<b>Filformatet GEDCOM</b><br/>I Gramps kan du importera från och exportera "
 "till GEDCOM-format. Gramps stödjer industristandarden GEDCOM 5.5, vilket "
 "möjliggör utbyte med många andra släktforskningsprogram. Filter finns för "
-"att göra exportering i GEDCOM enkelt. "
+"att göra import och export i GEDCOM enkelt."
 
 #: ../data/tips.xml.in.h:43
 msgid ""
@@ -861,12 +860,12 @@ msgid ""
 "other Gramps users. This format has the key advantage over GEDCOM that no "
 "information is ever lost when exporting and importing."
 msgstr ""
-"<b>Gramps XML filsystem</b><br/>Du kan konvertera dina släktdata till en XML "
-"fil, vilket är en komplett fil i komprimerad form som innehåller din databas "
+"<b>Gramps XML-paket</b><br/>Du kan exportera dina släktdata till en XML fil, "
+"vilket är en komplett fil i komprimerad form som innehåller din databas "
 "inklusive alla media filer som används av databasen, exempelvis bilder. "
 "Denna fil är helt portabel så den är användbar för säkerhetskopiering eller "
 "för att dela med andra Gramps-användare. XML formatet har fördelar gentemot "
-"GEDCOM. T.ex. kan ingen information gå förlorad vid export eller import.hit"
+"GEDCOM. T.ex. kan ingen information gå förlorad vid export eller import."
 
 #: ../data/tips.xml.in.h:44
 msgid ""
@@ -943,7 +942,7 @@ msgid ""
 msgstr ""
 "<b>Ytterligare rapporter och verktyg</b><br/>Nya typer av rapporter och "
 "verktyg kan läggas till Gramps med &quot;Tilläggs&quot;-system. Se under "
-"&quot;Hjälp &gt; Nya rapporttyper och verktyg&quot;. Detta är bästa sättet "
+"&quot;Hjälp &gt; Extra rapporttyper och verktyg&quot;. Detta är bästa sättet "
 "för avancerade användare att experimentera och skapa ny funktioner."
 
 #: ../data/tips.xml.in.h:51
@@ -955,7 +954,8 @@ msgid ""
 msgstr ""
 "<b>Bokrapporter</b><br/> Bokrapporten under &quot;Reports &gt; Böcker &gt; "
 "Bokrapport...&quot;, låter användare samla ett antal olika rapporter till "
-"ett enda dokument. En enda rapport är fördelaktig ur många synpunkter."
+"ett enda dokument. En enda rapport är enklare att distribuera än flera "
+"rapporter, speciellt om de är utskrivna."
 
 #: ../data/tips.xml.in.h:52
 msgid ""
@@ -965,7 +965,7 @@ msgid ""
 msgstr ""
 "<b>Gramps tillkännagivanden </b><br/>Intresserad av att få ett meddelande "
 "när en ny Gramps-version släpps? Anmäl dig till e-postlistan Gramps-announce "
-"på http://lists.sourceforge.net/lists/listinfo/gramps-announce"
+"på &quot;Hjälp &gt; Gramps sändlistor&quot;"
 
 #: ../data/tips.xml.in.h:53
 msgid ""
@@ -1012,9 +1012,9 @@ msgid ""
 "displayed, set the default language in your operating system and restart "
 "Gramps."
 msgstr ""
-"<b>Talar ej engelska?</b><br/>Gramps har översatts till 20 språk. Om Gramps "
-"stödjer ditt språk och det inte visas, så ställ in standardspråket på din "
-"dator och starta om Gramps."
+"<b>Talar ej engelska?</b><br/>Frivilliga har översatt Gramps till mer än 40 "
+"språk. Om Gramps stödjer ditt språk och det inte visas, så ställ in "
+"standardspråket på din dator och starta om Gramps."
 
 #: ../data/tips.xml.in.h:57
 msgid ""
@@ -1080,9 +1080,10 @@ msgid ""
 "License, see http://www.gnu.org/licenses/licenses.html#GPL to read about the "
 "rights and restrictions of this license."
 msgstr ""
-"<b>Gramps programvarulicens</b><br/>Gramps är fritt distribuerbar under GNU "
-"General Public License, se http://www.gnu.org/licenses/licenses.html#GPL för "
-"att läsa mer om rättigheter och begränsningar."
+"<b>Gramps programvarulicens</b><br/>Du är fri att använda och dela Gramps "
+"med andra. Gramps är fritt distribuerbar under GNU General Public License, "
+"se http://www.gnu.org/licenses/licenses.html#GPL för att läsa mer om "
+"rättigheter och begränsningar."
 
 #: ../data/tips.xml.in.h:63
 msgid ""
@@ -1091,8 +1092,8 @@ msgid ""
 "libraries are installed it will run fine."
 msgstr ""
 "<b>Gramps för Gnome eller KDE?</b><br/>För Linux-användare fungerar Gramps "
-"med vilken skrivbordsmiljö som helst, så länge som de behövda GTK-"
-"biblioteken är installerade."
+"med vilken skrivbordsmiljö du önskar så länge som de behövda GTK-biblioteken "
+"är installerade."
 
 #: ../gramps/cli/arghandler.py:228
 #, python-format
@@ -1112,7 +1113,7 @@ msgid ""
 msgstr ""
 "Fel: Indatasläktträd \"%s\" saknas.\n"
 "Om GEDCOM, Gramps-xml eller grdb, använd -i alternativet för att importera "
-"till ett släktträd i stället. "
+"till ett släktträd i stället."
 
 #: ../gramps/cli/arghandler.py:254
 #, python-format
@@ -1191,7 +1192,7 @@ msgstr "Släktträd"
 #: ../gramps/gen/plug/report/endnotes.py:199
 #, python-format
 msgid "\"%s\""
-msgstr ""
+msgstr "\"%s\""
 
 #: ../gramps/cli/arghandler.py:456
 #, python-format
@@ -1247,14 +1248,13 @@ msgid "Database needs recovery, cannot open it!"
 msgstr "Databasen behöver återhämtas, kan ej öppna den!"
 
 #: ../gramps/cli/arghandler.py:558
-#, fuzzy
 msgid "Database backend unavailable, cannot open it!"
-msgstr "Databasen är låst, kan inte öppna den!"
+msgstr "Databas-bakända ej tillgänglig, kan ej öppna den!"
 
 #: ../gramps/cli/arghandler.py:609 ../gramps/cli/arghandler.py:658
 #: ../gramps/cli/arghandler.py:705
 msgid "Ignoring invalid options string."
-msgstr "Struntar ogiltig alternativsträng."
+msgstr "Ignorera ogiltig alternativsträng."
 
 #. name exists, but is not in the list of valid report names
 #: ../gramps/cli/arghandler.py:633
@@ -1298,10 +1298,9 @@ msgstr "Namn på bok ej angivet. Använd ett av %(donottranslate)s=boknamn."
 #: ../gramps/cli/arghandler.py:726
 #, python-format
 msgid "Unknown action: %s."
-msgstr "Okänd åtgärd: %s"
+msgstr "Okänd åtgärd: %s."
 
 #: ../gramps/cli/argparser.py:55
-#, fuzzy
 msgid ""
 "\n"
 "Usage: gramps.py [OPTION...]\n"
@@ -1338,40 +1337,41 @@ msgid ""
 "  -v, --version                          Show versions\n"
 msgstr ""
 "\n"
-"Användning: gramps.py [ALTERNATIV...]\n"
-"  --load-modules=MODULE1,MODULE2,...     Dynamiska moduler att ladda\n"
+"Usage: gramps.py [ALTERNATIV...]\n"
+"  --load-modules=MODULE1,MODULE2,...     Dynamiska moduler som ska läsas in\n"
 "\n"
-"Hjälpalternativ\n"
-"  -?, --help                             Visa detta meddelande\n"
-"  --usage                                Kortfattade anvisningar\n"
+"Hjälp-alternativ\n"
+"  -?, --help                             Visa detta hjälpmeddelande\n"
+"  --usage                                Visa kort anvisning för användning\n"
 "\n"
-"Tillämpningsalternativ\n"
-"  -O, --open=FAMILY_TREE                 Öppna släktträd\n"
-"  -C, --create=FAMILY_TREE               Skapa vid öppning ett nytt "
-"släktträd\n"
-"  -i, --import=FILENAME                  Importera fil\n"
-"  -e, --export=FILENAME                  Exportera fil\n"
-"  -f, --format=FORMAT                    Specificera släkträdsformat\n"
-"  -a, --action=ACTION                    Specificera åtgärd\n"
-"  -p, --options=OPTIONS_STRING           Specificera alternativ\n"
-"  -d, --debug=LOGGER_NAME                Tillåt avlusningsloggar\n"
-"  -l                                     Lista släktträd\n"
-"  -L                                     Lista släktträd med detaljer\n"
-"  -t                                     Lista släktträd i tabellform (med "
-"tab)\n"
-"  -u, --force-unlock                     Tvinga frisläppning av låst "
-"släktträd\n"
-"  -s, --show                             Visar alla "
-"konfigurationsparametrar\n"
-"  -c, --config=[config.setting[:value]]  Visar/ställer in specificerad "
-"konfigurationsparameter och startar Gramps\n"
-"  -y, --yes                              Fråga ej för att bekräfta, farligt "
-"åtgärd (endast icke-GUI- mode)   -q, --quiet                            "
-"Undertryck indikator om hur det går  -v, --version                          "
-"Visar versioner\n"
+"Programalternativ\n"
+"  -O, --open=SLÄKTTRÄD                 Öppna släktträd\n"
+"  -U, --username=ANVÄNDARNAMN                Användarnamn för databasen\n"
+"  -P, --password=LÖSENORD                Lösenord för databasen\n"
+"  -C, --create=SLÄKTTRÄD               Skapa vid start nytt släktträd om ej "
+"finnes\n"
+"  -i, --import=FILNAMN                  Importera fil\n"
+"  -e, --export=FILNAMN                  Exportera fil\n"
+"  -r, --remove=SLÄKTTRÄDS_MÖNSTER       Ta bort matchande släktträd (använd "
+"reguljära uttryck)\n"
+"  -f, --format=FORMAT                    Ange format för släktträdet\n"
+"  -a, --action=HANDLING                    Ange handling\n"
+"  -p, --options=ALTERNATIV           Ange alternativ\n"
+"  -d, --debug=LOGGFILS_NAMN                Aktivera avlusningsfil\n"
+"  -l [SLÄKTTRÄDS_MÖNSTER...]            Lists släktträd\n"
+"  -L [SLÄKTTRÄDS_MÖNSTER...]            Lista släktträd i detalj\n"
+"  -t [SLÄKTTRÄDS_MÖNSTER...]            Lista släktträd, avgränsad flik\n"
+"  -u, --force-unlock                     Tvinga upplåsning av släktträd\n"
+"  -s, --show                             Visa inställningar\n"
+"  -c, --config=[config.setting[:value]]  Ange inställning(ar) och starta "
+"Gramps\n"
+"  -y, --yes                              Be inte om bekräftelse vid farliga "
+"handlingar (endast icke-GUI-läge)\n"
+"  -q, --quiet                            Undertryck framgångsutdata (endast "
+"icke-GUI-läge)\n"
+"  -v, --version                          Visa versioner\n"
 
 #: ../gramps/cli/argparser.py:86
-#, fuzzy
 msgid ""
 "\n"
 "Example of usage of Gramps command line interface\n"
@@ -1430,24 +1430,25 @@ msgid ""
 "Syntax may be different for other shells and for Windows.\n"
 msgstr ""
 "\n"
-"Exempel på Gramps kommandoradssnitt\n"
+"Exempel på Gramps kommandoradsgränssnitt\n"
 "\n"
 "1. För att importera fyra databaser (vars format kan bestämmas från deras "
 "namn)\n"
 "och sedan kontrollera den resulterande databasen efter fel, kan man skriva:\n"
-"gramps -i file1.ged -i file2.gpkg -i ~/db3.gramps -i file4.wft -a check\n"
+"gramps -i file1.ged -i file2.gpkg -i ~/db3.gramps -i file4.wft -a tool -p "
+"name=check.\n"
 "\n"
 "2. För att uttryckligen specificera formaten i ovanstående  exempel, lägg "
 "till filnamn med lämpliga -f options:\n"
 "gramps -i file1.ged -f gedcom -i file2.gpkg -f gramps-pkg -i ~/db3.gramps -f "
-"gramps-xml -i file4.wft -f wft -a check\n"
+"gramps-xml -i file4.wft -f wft -a tool -p name=check.\n"
 "\n"
 "3. För att exportera den databasen, som erhållits från all import, lägg till "
 "-e flagga\n"
 "(använd -f om filnamnet inte tillåter Gramps att gissa dess format):\n"
 "gramps -i file1.ged -i file2.gpkg -e ~/new-package -f gramps-pkg\n"
 "\n"
-"4. För att spara några felmedelanden i ovanstående exempel till utfiloch "
+"4. För att spara alla felmedelanden i ovanstående exempel till utfil och "
 "felfil, kör:\n"
 "gramps -i file1.ged -i file2.dpkg -e ~/new-package -f gramps-pkg >utfil "
 "2>felfil\n"
@@ -1466,7 +1467,7 @@ msgstr ""
 "gramps -O 'Family Tree 1' -a report -p name=summary\n"
 "\n"
 "8. Skriva ut rapportval\n"
-"Använd name=timeline,show=all till att reda på alla tillgängliga val för "
+"Använd name=timeline,show=all till att finna alla tillgängliga val för "
 "tidslinjerapporten.\n"
 "För att få reda detaljer om ett speciellt val, använd show=option_name , t. "
 "ex. name=timeline,show=off string.\n"
@@ -1510,11 +1511,13 @@ msgid ""
 "WARNING: %(strerr)s (errno=%(errno)s):\n"
 "WARNING: %(name)s\n"
 msgstr ""
+"VARNING: %(strerr)s (felnr=%(errno)s):\n"
+"VARNING: %(name)s\n"
 
 #: ../gramps/cli/argparser.py:324
 #, python-format
 msgid "Unknown action: %s. Ignoring."
-msgstr "Okänd åtgärd: %s. Ignorerar"
+msgstr "Okänd åtgärd: %s. Ignorerar."
 
 #: ../gramps/cli/argparser.py:334
 msgid "setup debugging"
@@ -1582,9 +1585,8 @@ msgid "Path"
 msgstr "Sökväg"
 
 #: ../gramps/cli/clidbman.py:171 ../gramps/gen/plug/_pluginreg.py:90
-#, fuzzy
 msgid "Database"
-msgstr "Databassökväg"
+msgstr "Databas"
 
 #: ../gramps/cli/clidbman.py:172 ../gramps/gui/dbman.py:411
 msgid "Last accessed"
@@ -1637,16 +1639,17 @@ msgid "Importing data..."
 msgstr "Importerar data..."
 
 #: ../gramps/cli/clidbman.py:425
-#, fuzzy
 msgid "Remove family tree warning"
-msgstr "Ta bort släktträd"
+msgstr "Ta bort släktträdsvarningen"
 
 #: ../gramps/cli/clidbman.py:426
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "Are you sure you want to remove the family tree named\n"
 "\"%s\"?"
-msgstr "Är du säker på att du vill uppgradera detta släktträd?"
+msgstr ""
+"Är du säker att du vill ta bort släktträdet med namnet\n"
+"\"%s\"?"
 
 #: ../gramps/cli/clidbman.py:436 ../gramps/gui/dbman.py:739
 msgid "Could not delete Family Tree"
@@ -1714,7 +1717,7 @@ msgstr "Låst av %s"
 #: ../gramps/gui/editors/displaytabs/personrefembedlist.py:143
 #: ../gramps/gui/editors/editmedia.py:178
 #: ../gramps/gui/editors/editmediaref.py:143
-#: ../gramps/plugins/db/bsddb/write.py:2292
+#: ../gramps/plugins/db/bsddb/write.py:2294
 #: ../gramps/plugins/gramplet/persondetails.py:213
 #: ../gramps/plugins/gramplet/persondetails.py:219
 #: ../gramps/plugins/gramplet/persondetails.py:221
@@ -1801,14 +1804,14 @@ msgid ""
 msgstr ""
 "Gramps har upptäckt ett problem i den underliggande Berkeley-databasen. "
 "Detta kan repareras från Släktträdshanteraren. Välj databasen och klicka på "
-"Reparera-knappen."
+"Reparera-knappen"
 
 #: ../gramps/cli/grampscli.py:153 ../gramps/gui/dbloader.py:165
 msgid "Read only database"
 msgstr "Skrivskyddad databas"
 
 #: ../gramps/cli/grampscli.py:154 ../gramps/gui/dbloader.py:166
-#: ../gramps/gui/dbloader.py:561
+#: ../gramps/gui/dbloader.py:562
 msgid "You do not have write access to the selected file."
 msgstr "Du har inte skrivåtkomst till den valda filen."
 
@@ -1824,7 +1827,7 @@ msgid "Cannot open database"
 msgstr "Kan inte öppna databas"
 
 #: ../gramps/cli/grampscli.py:211 ../gramps/gui/dbloader.py:296
-#: ../gramps/gui/dbloader.py:518
+#: ../gramps/gui/dbloader.py:519
 #, python-format
 msgid "Could not open file: %s"
 msgstr "Kunde inte öppna fil: %s"
@@ -1839,14 +1842,14 @@ msgstr "Släktträdet saknas, då det har raderats."
 
 #: ../gramps/cli/grampscli.py:273
 msgid "The database is locked."
-msgstr "Databasen är låst"
+msgstr "Databasen är låst."
 
 #: ../gramps/cli/grampscli.py:274
 msgid ""
 "Use the --force-unlock option if you are sure that the database is not in "
 "use."
 msgstr ""
-"Använd valet -force-unlocking om du är säker på att databasen inte används."
+"Använd valet --force-unlock om du är säker på att databasen inte används."
 
 #. already errors encountered. Show first one on terminal and exit
 #: ../gramps/cli/grampscli.py:352
@@ -1886,7 +1889,7 @@ msgstr "=format"
 
 #: ../gramps/cli/plug/__init__.py:295
 msgid "Output file format."
-msgstr "Format för utdata"
+msgstr "Format för utdata."
 
 #: ../gramps/cli/plug/__init__.py:296 ../gramps/cli/plug/__init__.py:297
 msgid "=name"
@@ -1894,11 +1897,11 @@ msgstr "=namn"
 
 #: ../gramps/cli/plug/__init__.py:296
 msgid "Style name."
-msgstr "Mallnamn"
+msgstr "Mallnamn."
 
 #: ../gramps/cli/plug/__init__.py:297
 msgid "Paper size name."
-msgstr "Pappersstorleksnamn"
+msgstr "Pappersstorleksnamn."
 
 #: ../gramps/cli/plug/__init__.py:298 ../gramps/cli/plug/__init__.py:299
 #: ../gramps/cli/plug/__init__.py:301 ../gramps/cli/plug/__init__.py:303
@@ -1941,9 +1944,9 @@ msgstr "CSS-filnamn att använda, endast html format"
 
 #. translators: needed for French, Hebrew and Arabic
 #: ../gramps/cli/plug/__init__.py:416
-#, fuzzy, python-format
+#, python-format
 msgid "%(id)s:\t%(father)s, %(mother)s"
-msgstr "%(gramps_id)s : %(father)s och %(mother)s"
+msgstr "%(id)s:\t%(father)s, %(mother)s"
 
 #: ../gramps/cli/plug/__init__.py:461
 #, python-format
@@ -1993,8 +1996,8 @@ msgid ""
 "Ignoring '%(notranslate1)s=%(notranslate2)s' and using '%(notranslate1)s="
 "%(notranslate3)s'."
 msgstr ""
-"Struntar i '%(notranslate1)s=%(notranslate2)s' och använder "
-"'%(notranslate1)s=%(notranslate3)s'."
+"Ignorerar '%(notranslate1)s=%(notranslate2)s' och använder '%(notranslate1)s="
+"%(notranslate3)s'."
 
 #: ../gramps/cli/plug/__init__.py:533
 #, python-format
@@ -2005,7 +2008,7 @@ msgstr "Använd '%(notranslate)s' för att få se giltiga värden."
 #: ../gramps/gen/plug/report/stdoptions.py:282
 #, python-format
 msgid "Ignoring unknown option: %s"
-msgstr "Struntar i okänt val: %s"
+msgstr "Ignorerar okänt val: %s"
 
 #: ../gramps/cli/plug/__init__.py:624
 msgid "   Available options:"
@@ -2013,7 +2016,7 @@ msgstr "   Tillängliga alternativ:"
 
 #: ../gramps/cli/plug/__init__.py:633
 msgid "(no help available)"
-msgstr "(ingen hjälp är tillgänglig )"
+msgstr "(ingen hjälp är tillgänglig)"
 
 #: ../gramps/cli/plug/__init__.py:641
 msgid "   Available values are:"
@@ -2034,9 +2037,9 @@ msgid "Failed to write report. "
 msgstr "Misslyckades med att skriva rapport. "
 
 #: ../gramps/cli/plug/__init__.py:818
-#, fuzzy, python-format
+#, python-format
 msgid "Failed to make '%s' report."
-msgstr "Misslyckades med att skriva rapport. "
+msgstr "Misslyckades med att skapa '%s' rapport."
 
 #: ../gramps/cli/user.py:217 ../gramps/gui/dialog.py:235
 msgid "Error detected in database"
@@ -2055,8 +2058,8 @@ msgstr ""
 "Gramps har hittat ett fel i databasen. Detta kan oftast lösas genom att köra "
 "verktyget \"Kontrollera och reparera\".\n"
 "\n"
-"Om detta problem fortsätter efter reparationen ovan, fyll i en felrapport "
-"vid %(gramps_bugtracker_url)s\n"
+"Om detta problem fortsätter efter att ha kört detta verktyg, fyll i en "
+"felrapport vid %(gramps_bugtracker_url)s\n"
 "\n"
 
 #: ../gramps/gen/config.py:242
@@ -2076,9 +2079,8 @@ msgid "Missing Surname"
 msgstr "Saknat efternamn"
 
 #: ../gramps/gen/config.py:262 ../gramps/gen/config.py:264
-#, fuzzy
 msgid "[Living]"
-msgstr "Levande"
+msgstr "[Levande]"
 
 #: ../gramps/gen/config.py:263
 msgid "Private Record"
@@ -2100,22 +2102,20 @@ msgid ""
 "is a personal genealogy program."
 msgstr ""
 "Gramps\n"
-" (Genealogical Research and Analysis Management Programming System) är ett "
-"släktforskningsprogram för privatpersoner."
+" (Genealogical Research and Analysis Management Programming System) \n"
+"är ett släktforskningsprogram för privatpersoner."
 
 #: ../gramps/gen/const.py:251
-#, fuzzy
 msgid "surname|none"
-msgstr "efternamn okänt"
+msgstr "okänt"
 
 #: ../gramps/gen/const.py:252
-#, fuzzy
 msgid "given-name|none"
-msgstr "förnamn"
+msgstr "okänt"
 
 #: ../gramps/gen/const.py:256 ../gramps/plugins/webreport/basepage.py:140
 msgid ":"
-msgstr ""
+msgstr ":"
 
 #: ../gramps/gen/datehandler/__init__.py:83
 #, python-format
@@ -2144,12 +2144,12 @@ msgstr "Numeriskt"
 #. Full month name, day, year
 #: ../gramps/gen/datehandler/_datedisplay.py:80
 msgid "Month Day, Year"
-msgstr "Mån dag år"
+msgstr "Mån dag, år"
 
 #. Abbreviated month name, day, year
 #: ../gramps/gen/datehandler/_datedisplay.py:83
 msgid "MON DAY, YEAR"
-msgstr "MÅN DAG ÅR"
+msgstr "MÅN DAG, ÅR"
 
 #. Day, full month name, year
 #: ../gramps/gen/datehandler/_datedisplay.py:86
@@ -2168,7 +2168,7 @@ msgstr "DAG MÅN ÅR"
 #: ../gramps/plugins/drawreport/calendarreport.py:233
 #, python-brace-format
 msgid "{long_month} {year}"
-msgstr ""
+msgstr "{long_month} {year}"
 
 #. first date in a span
 #. If "from <Month>" needs a special inflection in your
@@ -2178,7 +2178,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:189
 #, python-brace-format
 msgid "from|{long_month} {year}"
-msgstr ""
+msgstr "from|{long_month} {year}"
 
 #. second date in a span
 #. If "to <Month>" needs a special inflection in your
@@ -2188,7 +2188,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:197
 #, python-brace-format
 msgid "to|{long_month} {year}"
-msgstr ""
+msgstr "to|{long_month} {year}"
 
 #. first date in a range
 #. If "between <Month>" needs a special inflection in your
@@ -2198,7 +2198,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:205
 #, python-brace-format
 msgid "between|{long_month} {year}"
-msgstr ""
+msgstr "between|{long_month} {year}"
 
 #. second date in a range
 #. If "and <Month>" needs a special inflection in your
@@ -2208,7 +2208,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:213
 #, python-brace-format
 msgid "and|{long_month} {year}"
-msgstr ""
+msgstr "and|{long_month} {year}"
 
 #. If "before <Month>" needs a special inflection in your
 #. language, translate this to "{long_month.f[X]} {year}"
@@ -2217,7 +2217,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:220
 #, python-brace-format
 msgid "before|{long_month} {year}"
-msgstr ""
+msgstr "before|{long_month} {year}"
 
 #. If "after <Month>" needs a special inflection in your
 #. language, translate this to "{long_month.f[X]} {year}"
@@ -2226,7 +2226,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:227
 #, python-brace-format
 msgid "after|{long_month} {year}"
-msgstr ""
+msgstr "after|{long_month} {year}"
 
 #. If "about <Month>" needs a special inflection in your
 #. language, translate this to "{long_month.f[X]} {year}"
@@ -2235,7 +2235,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:234
 #, python-brace-format
 msgid "about|{long_month} {year}"
-msgstr ""
+msgstr "about|{long_month} {year}"
 
 #. If "estimated <Month>" needs a special inflection in your
 #. language, translate this to "{long_month.f[X]} {year}"
@@ -2244,7 +2244,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:241
 #, python-brace-format
 msgid "estimated|{long_month} {year}"
-msgstr ""
+msgstr "estimated|{long_month} {year}"
 
 #. If "calculated <Month>" needs a special inflection in your
 #. language, translate this to "{long_month.f[X]} {year}"
@@ -2253,12 +2253,12 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:248
 #, python-brace-format
 msgid "calculated|{long_month} {year}"
-msgstr ""
+msgstr "calculated|{long_month} {year}"
 
 #: ../gramps/gen/datehandler/_datedisplay.py:253
 #, python-brace-format
 msgid "{short_month} {year}"
-msgstr ""
+msgstr "{short_month} {year}"
 
 #. first date in a span
 #. If "from <Month>" needs a special inflection in your
@@ -2268,7 +2268,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:261
 #, python-brace-format
 msgid "from|{short_month} {year}"
-msgstr ""
+msgstr "from|{short_month} {year}"
 
 #. second date in a span
 #. If "to <Month>" needs a special inflection in your
@@ -2278,7 +2278,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:269
 #, python-brace-format
 msgid "to|{short_month} {year}"
-msgstr ""
+msgstr "to|{short_month} {year}"
 
 #. first date in a range
 #. If "between <Month>" needs a special inflection in your
@@ -2288,7 +2288,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:277
 #, python-brace-format
 msgid "between|{short_month} {year}"
-msgstr ""
+msgstr "between|{short_month} {year}"
 
 #. second date in a range
 #. If "and <Month>" needs a special inflection in your
@@ -2298,7 +2298,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:285
 #, python-brace-format
 msgid "and|{short_month} {year}"
-msgstr ""
+msgstr "and|{short_month} {year}"
 
 #. If "before <Month>" needs a special inflection in your
 #. language, translate this to "{short_month.f[X]} {year}"
@@ -2307,7 +2307,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:292
 #, python-brace-format
 msgid "before|{short_month} {year}"
-msgstr ""
+msgstr "before|{short_month} {year}"
 
 #. If "after <Month>" needs a special inflection in your
 #. language, translate this to "{short_month.f[X]} {year}"
@@ -2316,7 +2316,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:299
 #, python-brace-format
 msgid "after|{short_month} {year}"
-msgstr ""
+msgstr "after|{short_month} {year}"
 
 #. If "about <Month>" needs a special inflection in your
 #. language, translate this to "{short_month.f[X]} {year}"
@@ -2325,7 +2325,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:306
 #, python-brace-format
 msgid "about|{short_month} {year}"
-msgstr ""
+msgstr "about|{short_month} {year}"
 
 #. If "estimated <Month>" needs a special inflection in your
 #. language, translate this to "{short_month.f[X]} {year}"
@@ -2334,7 +2334,7 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:313
 #, python-brace-format
 msgid "estimated|{short_month} {year}"
-msgstr ""
+msgstr "estimated|{short_month} {year}"
 
 #. If "calculated <Month>" needs a special inflection in your
 #. language, translate this to "{short_month.f[X]} {year}"
@@ -2343,21 +2343,21 @@ msgstr ""
 #: ../gramps/gen/datehandler/_datedisplay.py:320
 #, python-brace-format
 msgid "calculated|{short_month} {year}"
-msgstr ""
+msgstr "calculated|{short_month} {year}"
 
 #. If there is no special inflection for "from <Month>"
 #. in your language, DON'T translate this string.  Otherwise,
 #. "translate" this to "from" in ENGLISH!!! ENGLISH!!!
 #: ../gramps/gen/datehandler/_datedisplay.py:427
 msgid "from-date|"
-msgstr ""
+msgstr "from"
 
 #. If there is no special inflection for "to <Month>"
 #. in your language, DON'T translate this string.  Otherwise,
 #. "translate" this to "to" in ENGLISH!!! ENGLISH!!!
 #: ../gramps/gen/datehandler/_datedisplay.py:432
 msgid "to-date|"
-msgstr ""
+msgstr "to"
 
 #: ../gramps/gen/datehandler/_datedisplay.py:433
 #, python-brace-format
@@ -2370,14 +2370,14 @@ msgstr ""
 #. "translate" this to "between" in ENGLISH!!! ENGLISH!!!
 #: ../gramps/gen/datehandler/_datedisplay.py:452
 msgid "between-date|"
-msgstr ""
+msgstr "between-date|"
 
 #. If there is no special inflection for "and <Month>"
 #. in your language, DON'T translate this string.  Otherwise,
 #. "translate" this to "and" in ENGLISH!!! ENGLISH!!!
 #: ../gramps/gen/datehandler/_datedisplay.py:457
 msgid "and-date|"
-msgstr ""
+msgstr "and-date|"
 
 #: ../gramps/gen/datehandler/_datedisplay.py:458
 #, python-brace-format
@@ -2391,64 +2391,64 @@ msgstr ""
 #. "translate" this to "before" in ENGLISH!!! ENGLISH!!!
 #: ../gramps/gen/datehandler/_datedisplay.py:491
 msgid "before-date|"
-msgstr ""
+msgstr "before-date|"
 
 #. If there is no special inflection for "after <Month>"
 #. in your language, DON'T translate this string.  Otherwise,
 #. "translate" this to "after" in ENGLISH!!! ENGLISH!!!
 #: ../gramps/gen/datehandler/_datedisplay.py:496
 msgid "after-date|"
-msgstr ""
+msgstr "after-date|"
 
 #. If there is no special inflection for "about <Month>"
 #. in your language, DON'T translate this string.  Otherwise,
 #. "translate" this to "about" in ENGLISH!!! ENGLISH!!!
 #: ../gramps/gen/datehandler/_datedisplay.py:501
 msgid "about-date|"
-msgstr ""
+msgstr "about"
 
 #. If there is no special inflection for "estimated <Month>"
 #. in your language, DON'T translate this string.  Otherwise,
 #. "translate" this to "estimated" in ENGLISH!!! ENGLISH!!!
 #: ../gramps/gen/datehandler/_datedisplay.py:506
 msgid "estimated-date|"
-msgstr ""
+msgstr "estimated-date"
 
 #. If there is no special inflection for "calculated <Month>"
 #. in your language, DON'T translate this string.  Otherwise,
 #. "translate" this to "calculated" in ENGLISH!!! ENGLISH!!!
 #: ../gramps/gen/datehandler/_datedisplay.py:511
 msgid "calculated-date|"
-msgstr ""
+msgstr "calculated-date"
 
 #: ../gramps/gen/datehandler/_datedisplay.py:530
 #, python-brace-format
 msgid "{date_quality}{noncompound_modifier}{date}{nonstd_calendar_and_ny}"
-msgstr ""
+msgstr "{date_quality}{noncompound_modifier}{date}{nonstd_calendar_and_ny}"
 
 #. TRANSLATORS: this month is ALREADY inflected: ignore it
 #: ../gramps/gen/datehandler/_datedisplay.py:639
 #, python-brace-format
 msgid "{long_month} {day:d}, {year}"
-msgstr ""
+msgstr "{long_month} {day:d}, {year}"
 
 #. TRANSLATORS: this month is ALREADY inflected: ignore it
 #: ../gramps/gen/datehandler/_datedisplay.py:665
 #, python-brace-format
 msgid "{short_month} {day:d}, {year}"
-msgstr ""
+msgstr "{short_month} {day:d}, {year}"
 
 #. TRANSLATORS: this month is ALREADY inflected: ignore it
 #: ../gramps/gen/datehandler/_datedisplay.py:691
 #, python-brace-format
 msgid "{day:d} {long_month} {year}"
-msgstr ""
+msgstr "{day:d} {long_month} {year}"
 
 #. TRANSLATORS: this month is ALREADY inflected: ignore it
 #: ../gramps/gen/datehandler/_datedisplay.py:717
 #, python-brace-format
 msgid "{day:d} {short_month} {year}"
-msgstr ""
+msgstr "{day:d} {short_month} {year}"
 
 #: ../gramps/gen/datehandler/_dateparser.py:421
 msgid "today"
@@ -2556,51 +2556,51 @@ msgstr "dec"
 #. DateParser code!
 #: ../gramps/gen/datehandler/_datestrings.py:116
 msgid "alternative month names for January||"
-msgstr ""
+msgstr "alternative month names for January||"
 
 #: ../gramps/gen/datehandler/_datestrings.py:117
 msgid "alternative month names for February||"
-msgstr ""
+msgstr "alternative month names for February||"
 
 #: ../gramps/gen/datehandler/_datestrings.py:118
 msgid "alternative month names for March||"
-msgstr ""
+msgstr "alternative month names for March||"
 
 #: ../gramps/gen/datehandler/_datestrings.py:119
 msgid "alternative month names for April||"
-msgstr ""
+msgstr "alternative month names for April||"
 
 #: ../gramps/gen/datehandler/_datestrings.py:120
 msgid "alternative month names for May||"
-msgstr ""
+msgstr "alternative month names for May||"
 
 #: ../gramps/gen/datehandler/_datestrings.py:121
 msgid "alternative month names for June||"
-msgstr ""
+msgstr "alternative month names for June||"
 
 #: ../gramps/gen/datehandler/_datestrings.py:122
 msgid "alternative month names for July||"
-msgstr ""
+msgstr "alternative month names for July||"
 
 #: ../gramps/gen/datehandler/_datestrings.py:123
 msgid "alternative month names for August||"
-msgstr ""
+msgstr "alternative month names for August||"
 
 #: ../gramps/gen/datehandler/_datestrings.py:124
 msgid "alternative month names for September||"
-msgstr ""
+msgstr "alternative month names for September||"
 
 #: ../gramps/gen/datehandler/_datestrings.py:125
 msgid "alternative month names for October||"
-msgstr ""
+msgstr "alternative month names for October||"
 
 #: ../gramps/gen/datehandler/_datestrings.py:126
 msgid "alternative month names for November||"
-msgstr ""
+msgstr "alternative month names for November||"
 
 #: ../gramps/gen/datehandler/_datestrings.py:127
 msgid "alternative month names for December||"
-msgstr ""
+msgstr "alternative month names for December||"
 
 #. Must appear in the order indexed by Date.CAL_... numeric constants
 #: ../gramps/gen/datehandler/_datestrings.py:131 ../gramps/gen/lib/date.py:609
@@ -2637,55 +2637,55 @@ msgstr "Svensk"
 #. DateDisplayer code!
 #: ../gramps/gen/datehandler/_datestrings.py:146
 msgid "Hebrew month lexeme|Tishri"
-msgstr ""
+msgstr "Hebrew month lexeme|Tishri"
 
 #: ../gramps/gen/datehandler/_datestrings.py:147
 msgid "Hebrew month lexeme|Heshvan"
-msgstr ""
+msgstr "Hebrew month lexeme|Heshvan"
 
 #: ../gramps/gen/datehandler/_datestrings.py:148
 msgid "Hebrew month lexeme|Kislev"
-msgstr ""
+msgstr "Hebrew month lexeme|Kislev"
 
 #: ../gramps/gen/datehandler/_datestrings.py:149
 msgid "Hebrew month lexeme|Tevet"
-msgstr ""
+msgstr "Hebrew month lexeme|Tevet"
 
 #: ../gramps/gen/datehandler/_datestrings.py:150
 msgid "Hebrew month lexeme|Shevat"
-msgstr ""
+msgstr "Hebrew month lexeme|Shevat"
 
 #: ../gramps/gen/datehandler/_datestrings.py:151
 msgid "Hebrew month lexeme|AdarI"
-msgstr ""
+msgstr "Hebrew month lexeme|AdarI"
 
 #: ../gramps/gen/datehandler/_datestrings.py:152
 msgid "Hebrew month lexeme|AdarII"
-msgstr ""
+msgstr "Hebrew month lexeme|AdarII"
 
 #: ../gramps/gen/datehandler/_datestrings.py:153
 msgid "Hebrew month lexeme|Nisan"
-msgstr ""
+msgstr "Hebrew month lexeme|Nisan"
 
 #: ../gramps/gen/datehandler/_datestrings.py:154
 msgid "Hebrew month lexeme|Iyyar"
-msgstr ""
+msgstr "Hebrew month lexeme|Iyyar"
 
 #: ../gramps/gen/datehandler/_datestrings.py:155
 msgid "Hebrew month lexeme|Sivan"
-msgstr ""
+msgstr "Hebrew month lexeme|Sivan"
 
 #: ../gramps/gen/datehandler/_datestrings.py:156
 msgid "Hebrew month lexeme|Tammuz"
-msgstr ""
+msgstr "Hebrew month lexeme|Tammuz"
 
 #: ../gramps/gen/datehandler/_datestrings.py:157
 msgid "Hebrew month lexeme|Av"
-msgstr ""
+msgstr "Hebrew month lexeme|Av"
 
 #: ../gramps/gen/datehandler/_datestrings.py:158
 msgid "Hebrew month lexeme|Elul"
-msgstr ""
+msgstr "Hebrew month lexeme|Elul"
 
 #. TRANSLATORS: see
 #. http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
@@ -2693,55 +2693,55 @@ msgstr ""
 #. DateDisplayer code!
 #: ../gramps/gen/datehandler/_datestrings.py:167
 msgid "French month lexeme|Vendémiaire"
-msgstr ""
+msgstr "French month lexeme|Vendémiaire"
 
 #: ../gramps/gen/datehandler/_datestrings.py:168
 msgid "French month lexeme|Brumaire"
-msgstr ""
+msgstr "French month lexeme|Brumaire"
 
 #: ../gramps/gen/datehandler/_datestrings.py:169
 msgid "French month lexeme|Frimaire"
-msgstr ""
+msgstr "French month lexeme|Frimaire"
 
 #: ../gramps/gen/datehandler/_datestrings.py:170
 msgid "French month lexeme|Nivôse"
-msgstr ""
+msgstr "French month lexeme|Nivôse"
 
 #: ../gramps/gen/datehandler/_datestrings.py:171
 msgid "French month lexeme|Pluviôse"
-msgstr ""
+msgstr "French month lexeme|Pluviôse"
 
 #: ../gramps/gen/datehandler/_datestrings.py:172
 msgid "French month lexeme|Ventôse"
-msgstr ""
+msgstr "French month lexeme|Ventôse"
 
 #: ../gramps/gen/datehandler/_datestrings.py:173
 msgid "French month lexeme|Germinal"
-msgstr ""
+msgstr "French month lexeme|Germinal"
 
 #: ../gramps/gen/datehandler/_datestrings.py:174
 msgid "French month lexeme|Floréal"
-msgstr ""
+msgstr "French month lexeme|Floréal"
 
 #: ../gramps/gen/datehandler/_datestrings.py:175
 msgid "French month lexeme|Prairial"
-msgstr ""
+msgstr "French month lexeme|Prairial"
 
 #: ../gramps/gen/datehandler/_datestrings.py:176
 msgid "French month lexeme|Messidor"
-msgstr ""
+msgstr "French month lexeme|Messidor"
 
 #: ../gramps/gen/datehandler/_datestrings.py:177
 msgid "French month lexeme|Thermidor"
-msgstr ""
+msgstr "French month lexeme|Thermidor"
 
 #: ../gramps/gen/datehandler/_datestrings.py:178
 msgid "French month lexeme|Fructidor"
-msgstr ""
+msgstr "French month lexeme|Fructidor"
 
 #: ../gramps/gen/datehandler/_datestrings.py:179
 msgid "French month lexeme|Extra"
-msgstr ""
+msgstr "French month lexeme|Extra"
 
 #. TRANSLATORS: see
 #. http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
@@ -2749,51 +2749,51 @@ msgstr ""
 #. DateDisplayer code!
 #: ../gramps/gen/datehandler/_datestrings.py:188
 msgid "Islamic month lexeme|Muharram"
-msgstr ""
+msgstr "Islamic month lexeme|Muharram"
 
 #: ../gramps/gen/datehandler/_datestrings.py:189
 msgid "Islamic month lexeme|Safar"
-msgstr ""
+msgstr "Islamic month lexeme|Safar"
 
 #: ../gramps/gen/datehandler/_datestrings.py:190
 msgid "Islamic month lexeme|Rabi`al-Awwal"
-msgstr ""
+msgstr "Islamic month lexeme|Rabi`al-Awwal"
 
 #: ../gramps/gen/datehandler/_datestrings.py:191
 msgid "Islamic month lexeme|Rabi`ath-Thani"
-msgstr ""
+msgstr "Islamic month lexeme|Rabi`ath-Thani"
 
 #: ../gramps/gen/datehandler/_datestrings.py:192
 msgid "Islamic month lexeme|Jumada l-Ula"
-msgstr ""
+msgstr "Islamic month lexeme|Jumada l-Ula"
 
 #: ../gramps/gen/datehandler/_datestrings.py:193
 msgid "Islamic month lexeme|Jumada t-Tania"
-msgstr ""
+msgstr "Islamic month lexeme|Jumada t-Tania"
 
 #: ../gramps/gen/datehandler/_datestrings.py:194
 msgid "Islamic month lexeme|Rajab"
-msgstr ""
+msgstr "Islamic month lexeme|Rajab"
 
 #: ../gramps/gen/datehandler/_datestrings.py:195
 msgid "Islamic month lexeme|Sha`ban"
-msgstr ""
+msgstr "Islamic month lexeme|Sha`ban"
 
 #: ../gramps/gen/datehandler/_datestrings.py:196
 msgid "Islamic month lexeme|Ramadan"
-msgstr ""
+msgstr "Islamic month lexeme|Ramadan"
 
 #: ../gramps/gen/datehandler/_datestrings.py:197
 msgid "Islamic month lexeme|Shawwal"
-msgstr ""
+msgstr "Islamic month lexeme|Shawwal"
 
 #: ../gramps/gen/datehandler/_datestrings.py:198
 msgid "Islamic month lexeme|Dhu l-Qa`da"
-msgstr ""
+msgstr "Islamic month lexeme|Dhu l-Qa`da"
 
 #: ../gramps/gen/datehandler/_datestrings.py:199
 msgid "Islamic month lexeme|Dhu l-Hijja"
-msgstr ""
+msgstr "Islamic month lexeme|Dhu l-Hijja"
 
 #. TRANSLATORS: see
 #. http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
@@ -2801,51 +2801,51 @@ msgstr ""
 #. DateDisplayer code!
 #: ../gramps/gen/datehandler/_datestrings.py:208
 msgid "Persian month lexeme|Farvardin"
-msgstr ""
+msgstr "Persian month lexeme|Farvardin"
 
 #: ../gramps/gen/datehandler/_datestrings.py:209
 msgid "Persian month lexeme|Ordibehesht"
-msgstr ""
+msgstr "Persian month lexeme|Ordibehesht"
 
 #: ../gramps/gen/datehandler/_datestrings.py:210
 msgid "Persian month lexeme|Khordad"
-msgstr ""
+msgstr "Persian month lexeme|Khordad"
 
 #: ../gramps/gen/datehandler/_datestrings.py:211
 msgid "Persian month lexeme|Tir"
-msgstr ""
+msgstr "Persian month lexeme|Tir"
 
 #: ../gramps/gen/datehandler/_datestrings.py:212
 msgid "Persian month lexeme|Mordad"
-msgstr ""
+msgstr "Persian month lexeme|Mordad"
 
 #: ../gramps/gen/datehandler/_datestrings.py:213
 msgid "Persian month lexeme|Shahrivar"
-msgstr ""
+msgstr "Persian month lexeme|Shahrivar"
 
 #: ../gramps/gen/datehandler/_datestrings.py:214
 msgid "Persian month lexeme|Mehr"
-msgstr ""
+msgstr "Persian month lexeme|Mehr"
 
 #: ../gramps/gen/datehandler/_datestrings.py:215
 msgid "Persian month lexeme|Aban"
-msgstr ""
+msgstr "Persian month lexeme|Aban"
 
 #: ../gramps/gen/datehandler/_datestrings.py:216
 msgid "Persian month lexeme|Azar"
-msgstr ""
+msgstr "Persian month lexeme|Azar"
 
 #: ../gramps/gen/datehandler/_datestrings.py:217
 msgid "Persian month lexeme|Dey"
-msgstr ""
+msgstr "Persian month lexeme|Dey"
 
 #: ../gramps/gen/datehandler/_datestrings.py:218
 msgid "Persian month lexeme|Bahman"
-msgstr ""
+msgstr "Persian month lexeme|Bahman"
 
 #: ../gramps/gen/datehandler/_datestrings.py:219
 msgid "Persian month lexeme|Esfand"
-msgstr ""
+msgstr "Persian month lexeme|Esfand"
 
 #. TRANSLATORS: if the modifier is after the date
 #. put the space ahead of the word instead of after it
@@ -2903,38 +2903,32 @@ msgstr "Lördag"
 
 #. Icelandic needs them
 #: ../gramps/gen/datehandler/_datestrings.py:252
-#, fuzzy
 msgid "Sun"
-msgstr "Kör"
+msgstr "Sön"
 
 #: ../gramps/gen/datehandler/_datestrings.py:253
-#, fuzzy
 msgid "Mon"
-msgstr "Män"
+msgstr "Mån"
 
 #: ../gramps/gen/datehandler/_datestrings.py:254
-#, fuzzy
 msgid "Tue"
-msgstr "Sant"
+msgstr "Tis"
 
 #: ../gramps/gen/datehandler/_datestrings.py:255
-#, fuzzy
 msgid "Wed"
-msgstr "röd"
+msgstr "Ons"
 
 #: ../gramps/gen/datehandler/_datestrings.py:256
 msgid "Thu"
-msgstr ""
+msgstr "Tor"
 
 #: ../gramps/gen/datehandler/_datestrings.py:257
-#, fuzzy
 msgid "Fri"
-msgstr "Fredag"
+msgstr "Fre"
 
 #: ../gramps/gen/datehandler/_datestrings.py:258
-#, fuzzy
 msgid "Sat"
-msgstr "Län/delstat"
+msgstr "Lör"
 
 #: ../gramps/gen/db/base.py:1816 ../gramps/gui/widgets/fanchart.py:1798
 msgid "Add child to family"
@@ -2967,7 +2961,7 @@ msgid ""
 "Please upgrade to the corresponding version or use XML for porting data "
 "between different schema versions."
 msgstr ""
-"Schema-version stöds ej av denna version of Gramps.\n"
+"Schema-version stöds ej av denna version av Gramps.\n"
 "\n"
 "Detta släktträd har schema version %(tree_vers)s och denna version av Gramps "
 "stöder versionerna %(min_vers)s till %(max_vers)s\n"
@@ -2976,7 +2970,7 @@ msgstr ""
 "mellan skilda databasversioner."
 
 #: ../gramps/gen/db/exceptions.py:114
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "The Python version is not supported by this version of Gramps.\n"
 "\n"
@@ -2986,13 +2980,13 @@ msgid ""
 "Please upgrade to the corresponding version or use XML for porting data "
 "between different Python versions."
 msgstr ""
-"Schema-version stöds ej av denna version of Gramps.\n"
+"Pythonversionen stöds ej av denna version av Gramps.\n"
 "\n"
-"Detta släktträd har schema version %(tree_vers)s och denna version av Gramps "
-"stöder versionerna %(min_vers)s till %(max_vers)s\n"
+"Detta släktträd har Python-version %(tree_vers)s, och denna version av "
+"Gramps stödjer versionerna %(min_vers)s till %(max_vers)s\n"
 "\n"
 "Uppgradera till motsvarande version eller använd XML för att flytta data "
-"mellan skilda databasversioner."
+"mellan skilda Pythonversioner."
 
 #: ../gramps/gen/db/exceptions.py:136
 #, python-format
@@ -3006,15 +3000,15 @@ msgid ""
 "%(wiki_backup_html_start)smake a backup%(html_end)s of your Family Tree. You "
 "can then import this backup into this version of Gramps."
 msgstr ""
-"Det släktträd du försöker ladda är av Bsddb-versionen  %(env_version)s "
+"Det släktträd du försöker ladda är av Bsddb-versionen %(env_version)s "
 "format. Denna version av Gramps använder Bsddb-versionen %(bdb_version)s. Så "
 "du försöker ladda data skapade i ett nyare format in till ett äldre program. "
 "Detta leder till ett misslyckande.\n"
 "\n"
 "Du bör starta din %(bold_start)snyare%(bold_end)s version av Gramps och "
-"%(wiki_backup_html_start)sHow_to_make_a_backup%(html_end)s göra en "
-"%(wiki_backup_html_start)ssäkerhetskopia%(html_end)s av ditt släktträd. Du "
-"kan sedan importera denna säkerhetskopia till denna version av Gramps."
+"%(wiki_backup_html_start)sskapa en säkerhetskopia%(html_end)s av ditt "
+"släktträd. Du kan sedan importera denna säkerhetskopia till denna version av "
+"Gramps."
 
 #: ../gramps/gen/db/exceptions.py:166
 #, python-format
@@ -3029,15 +3023,15 @@ msgid ""
 "start your %(bold_start)snewer%(bold_end)s version of Gramps and "
 "%(wiki_backup_html_start)smake a backup%(html_end)s of your Family Tree."
 msgstr ""
-"Det släktträd du försöker ladda är av Bsddb-versionen  %(env_version)s "
+"Det släktträd du försöker ladda är av Bsddb-versionen %(env_version)s "
 "format. Denna version av Gramps använder Bsddb-versionen %(bdb_version)s. Så "
 "du försöker ladda data skapade i ett nyare format in till ett äldre program. "
 "I detta speciella fall är skillnaderna  mycket små, så det kan fungera.\n"
 "\n"
 "Om du inte redan har gjort säkerhetskopia av ditt släktträd, bör du starta "
 "din %(bold_start)snyare%(bold_end)s version av Gramps och "
-"%(wiki_backup_html_start)sHow_to_make_a_backup%(html_end)s göra en "
-"säkerhetskopia</a> av ditt släktträd."
+"%(wiki_backup_html_start)sskapa en säkerhetsskopia%(html_end)s av ditt "
+"släktträd."
 
 #: ../gramps/gen/db/exceptions.py:195
 #, python-format
@@ -3066,7 +3060,8 @@ msgstr ""
 "\n"
 "Om du inte redan gjort en säkerhetskopia av ditt släktträd, bör du starta "
 "din %(bold_start)sgamla%(bold_end)s version av Gramps och "
-"%(wiki_backup_html_start)sHow_to_make_a_backup%(html_end)s av ditt släktträd."
+"%(wiki_backup_html_start)sskapa en säkerhetskopia%(html_end)s av ditt "
+"släktträd."
 
 #: ../gramps/gen/db/exceptions.py:225
 msgid ""
@@ -3118,16 +3113,16 @@ msgstr ""
 "schema-versionen av släktträdet.\n"
 "\n"
 "Om du uppgraderar, kan du inte använda föregående version av Gramps, även om "
-"du följaktligen  %(wiki_manual_backup_html_start)sbackup%(html_end)s or "
-"%(wiki_manual_export_html_start)sexport%(html_end)s ditt uppgraderade "
-"släktträd.\n"
+"du följaktligen %(wiki_manual_backup_html_start)ssäkerhetskopierar"
+"%(html_end)s eller %(wiki_manual_export_html_start)sexporterar%(html_end)s "
+"ditt uppgraderade släktträd.\n"
 "\n"
-"Uppgradering är en svår uppgift, som kan oåterkalleligen förstöra ditt "
-"släktträd, om den avbryts all misslyckas.\n"
+"Uppgradering är en svår uppgift, som oåterkalleligen kan förstöra ditt "
+"släktträd, om den avbryts eller misslyckas.\n"
 "\n"
 "Om du inte redan gjort en säkerhetskopia av ditt släktträd, bör du starta "
-"din %(bold_start)sold%(bold_end)s version av Gramps och "
-"%(wiki_backup_html_start)smake en säkerhetskopia%(html_end)s av ditt "
+"din %(bold_start)sgamla%(bold_end)s version av Gramps och "
+"%(wiki_backup_html_start)sskapa en säkerhetskopia%(html_end)s av ditt "
 "släktträd."
 
 #: ../gramps/gen/db/exceptions.py:290
@@ -3148,7 +3143,7 @@ msgstr ""
 "format in till ett äldre program. Detta leder till ett misslyckande.\n"
 "\n"
 "Du bör starta din %(bold_start)snyare%(bold_end)s version av Gramps och "
-"%(wiki_backup_html_start)sgör en %(html_end)sgöra en säkerhetskopia av ditt "
+"%(wiki_backup_html_start)sgöra en säkerhetskopia%(html_end)s av ditt "
 "släktträd. Du kan sedan importera denna säkerhetskopia till denna version av "
 "Gramps."
 
@@ -3178,16 +3173,16 @@ msgstr ""
 "först uppgradera schema-versionen av släktträdet.\n"
 "\n"
 "Om du uppgraderar, kan du inte använda föregående version av Gramps, även om "
-"du följaktligen %(wiki_manual_backup_html_start)sbackup%(html_end)s eller "
-"%(wiki_manual_export_html_start)sexport%(html_end)s ditt uppgraderade "
-"släktträd.\n"
+"du följaktligen %(wiki_manual_backup_html_start)ssäkerhetskopierar"
+"%(html_end)s eller %(wiki_manual_export_html_start)sexporterar%(html_end)s "
+"ditt uppgraderade släktträd.\n"
 "\n"
 "Uppgradering är en svår uppgift, som kan oåterkalleligen förstöra ditt "
 "släktträd, om den avbryts all misslyckas.\n"
 "\n"
 "Om du inte redan gjort en säkerhetskopia av ditt släktträd, bör du starta din"
-"%(bold_start)sold%(bold_end)s version av Gramps and "
-"%(wiki_backup_html_start)sgöra en säkerhetskopia%(html_end)s av ditt "
+"%(bold_start)sgamla%(bold_end)s version av Gramps och "
+"%(wiki_backup_html_start)sskapa en säkerhetskopia%(html_end)s av ditt "
 "släktträd."
 
 #: ../gramps/gen/db/exceptions.py:356
@@ -3199,11 +3194,16 @@ msgid ""
 "Please check your connection settings file:\n"
 "%(settings_file)s"
 msgstr ""
+"Anslutning till databasen misslyckades.\n"
+"\n"
+"%(message)s\n"
+"Kontrollera din anslutning till databasen:\n"
+"%(settings_file)s"
 
 #: ../gramps/gen/db/generic.py:161 ../gramps/gen/db/generic.py:211
 #: ../gramps/gen/db/generic.py:2018 ../gramps/plugins/db/bsddb/undoredo.py:251
 #: ../gramps/plugins/db/bsddb/undoredo.py:293
-#: ../gramps/plugins/db/bsddb/write.py:2139
+#: ../gramps/plugins/db/bsddb/write.py:2141
 #, python-format
 msgid "_Undo %s"
 msgstr "_Ångra %s"
@@ -3216,12 +3216,12 @@ msgid "_Redo %s"
 msgstr "Åte_rställ %s"
 
 #: ../gramps/gen/db/generic.py:2410 ../gramps/plugins/db/bsddb/read.py:1935
-#: ../gramps/plugins/db/bsddb/write.py:2294
+#: ../gramps/plugins/db/bsddb/write.py:2296
 msgid "Number of people"
 msgstr "Antal personer"
 
 #: ../gramps/gen/db/generic.py:2411 ../gramps/plugins/db/bsddb/read.py:1936
-#: ../gramps/plugins/db/bsddb/write.py:2295
+#: ../gramps/plugins/db/bsddb/write.py:2297
 #: ../gramps/plugins/gramplet/statsgramplet.py:117
 #: ../gramps/plugins/webreport/statistics.py:130
 #: ../gramps/plugins/webreport/statistics.py:195
@@ -3229,67 +3229,58 @@ msgid "Number of families"
 msgstr "Antal familjer"
 
 #: ../gramps/gen/db/generic.py:2412 ../gramps/plugins/db/bsddb/read.py:1937
-#: ../gramps/plugins/db/bsddb/write.py:2296
+#: ../gramps/plugins/db/bsddb/write.py:2298
 #: ../gramps/plugins/webreport/statistics.py:158
 #: ../gramps/plugins/webreport/statistics.py:207
-#, fuzzy
 msgid "Number of sources"
-msgstr "Antal efternamn"
+msgstr "Antal källor"
 
 #: ../gramps/gen/db/generic.py:2413 ../gramps/plugins/db/bsddb/read.py:1938
-#: ../gramps/plugins/db/bsddb/write.py:2297
+#: ../gramps/plugins/db/bsddb/write.py:2299
 #: ../gramps/plugins/webreport/statistics.py:162
 #: ../gramps/plugins/webreport/statistics.py:210
-#, fuzzy
 msgid "Number of citations"
-msgstr "Antal generationer:"
+msgstr "Antal källhänvisningar"
 
 #: ../gramps/gen/db/generic.py:2414 ../gramps/plugins/db/bsddb/read.py:1939
-#: ../gramps/plugins/db/bsddb/write.py:2298
+#: ../gramps/plugins/db/bsddb/write.py:2300
 #: ../gramps/plugins/webreport/statistics.py:151
 #: ../gramps/plugins/webreport/statistics.py:201
-#, fuzzy
 msgid "Number of events"
-msgstr "Antal föräldrar"
+msgstr "Antal händelser"
 
 #: ../gramps/gen/db/generic.py:2415 ../gramps/plugins/db/bsddb/read.py:1940
-#: ../gramps/plugins/db/bsddb/write.py:2299
-#, fuzzy
+#: ../gramps/plugins/db/bsddb/write.py:2301
 msgid "Number of media"
-msgstr "Antal familjer"
+msgstr "Antal mediaobjekt"
 
 #: ../gramps/gen/db/generic.py:2416 ../gramps/plugins/db/bsddb/read.py:1941
-#: ../gramps/plugins/db/bsddb/write.py:2300
+#: ../gramps/plugins/db/bsddb/write.py:2302
 #: ../gramps/plugins/webreport/statistics.py:154
 #: ../gramps/plugins/webreport/statistics.py:204
-#, fuzzy
 msgid "Number of places"
-msgstr "Antal personer"
+msgstr "Antal platser"
 
 #: ../gramps/gen/db/generic.py:2417 ../gramps/plugins/db/bsddb/read.py:1942
-#: ../gramps/plugins/db/bsddb/write.py:2301
+#: ../gramps/plugins/db/bsddb/write.py:2303
 #: ../gramps/plugins/webreport/statistics.py:166
 #: ../gramps/plugins/webreport/statistics.py:213
-#, fuzzy
 msgid "Number of repositories"
-msgstr "Leta efter arkivplatser"
+msgstr "Antal arkivplatser"
 
 #: ../gramps/gen/db/generic.py:2418 ../gramps/plugins/db/bsddb/read.py:1943
-#: ../gramps/plugins/db/bsddb/write.py:2302
-#, fuzzy
+#: ../gramps/plugins/db/bsddb/write.py:2304
 msgid "Number of notes"
-msgstr "Antal föräldrar"
+msgstr "Antal notiser"
 
 #: ../gramps/gen/db/generic.py:2419 ../gramps/plugins/db/bsddb/read.py:1944
-#: ../gramps/plugins/db/bsddb/write.py:2303
-#, fuzzy
+#: ../gramps/plugins/db/bsddb/write.py:2305
 msgid "Number of tags"
-msgstr "Antal äktenskap"
+msgstr "Antal taggar"
 
-#: ../gramps/gen/db/generic.py:2420 ../gramps/plugins/db/bsddb/write.py:2304
-#, fuzzy
+#: ../gramps/gen/db/generic.py:2420 ../gramps/plugins/db/bsddb/write.py:2306
 msgid "Schema version"
-msgstr "Tag bort version"
+msgstr "Schema-version"
 
 #. translators: needed for Arabic, ignore otherwise
 #. need for spacing on the french translation
@@ -3298,7 +3289,7 @@ msgstr "Tag bort version"
 #: ../gramps/gui/views/treemodels/placemodel.py:131
 #: ../gramps/plugins/lib/libtreebase.py:707
 msgid ","
-msgstr ", "
+msgstr ","
 
 #: ../gramps/gen/display/name.py:352
 msgid "Default format (defined by Gramps preferences)"
@@ -3460,9 +3451,8 @@ msgstr "FEL: filter %s kunde inte laddas korrekt. Redigera filtret!"
 
 #: ../gramps/gen/filters/_genericfilter.py:139
 #: ../gramps/gen/filters/_genericfilter.py:169
-#, fuzzy
 msgid "Applying ..."
-msgstr "Tillämpar filter..."
+msgstr "Tillämpar..."
 
 #. #########################
 #. ###############################
@@ -3472,7 +3462,7 @@ msgstr "Tillämpar filter..."
 #: ../gramps/gen/filters/_genericfilter.py:169
 #: ../gramps/gui/editors/filtereditor.py:1105
 #: ../gramps/plugins/drawreport/calendarreport.py:470
-#: ../gramps/plugins/drawreport/statisticschart.py:990
+#: ../gramps/plugins/drawreport/statisticschart.py:1001
 #: ../gramps/plugins/drawreport/timeline.py:415
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1009
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1023
@@ -3598,7 +3588,7 @@ msgstr ""
 #: ../gramps/gui/glade/mergecitation.glade:212
 #: ../gramps/gui/glade/mergecitation.glade:228
 msgid "Volume/Page:"
-msgstr "Volym/sida"
+msgstr "Volym/sida:"
 
 #: ../gramps/gen/filters/rules/_hascitationbase.py:50
 #: ../gramps/gen/filters/rules/citation/_hascitation.py:49
@@ -3705,7 +3695,7 @@ msgstr "Antal fall:"
 #: ../gramps/gen/filters/rules/place/_isenclosedby.py:48
 #: ../gramps/gen/filters/rules/place/_withinarea.py:50
 #: ../gramps/gui/editors/filtereditor.py:517
-#: ../gramps/gui/glade/editplaceref.glade:244
+#: ../gramps/gui/glade/editplaceref.glade:245
 msgid "ID:"
 msgstr "ID:"
 
@@ -3884,11 +3874,12 @@ msgstr "Matchar citeringar, som har ett visst antal notiser"
 
 #: ../gramps/gen/filters/rules/citation/_hasnotematchingsubstringof.py:43
 msgid "Citations having notes containing <substring>"
-msgstr "Citeringar med <delsträng> i notiser"
+msgstr "Citeringar med notiser innehållande <delsträng>"
 
 #: ../gramps/gen/filters/rules/citation/_hasnotematchingsubstringof.py:44
 msgid "Matches citations whose notes contain text matching a substring"
-msgstr "Matchar citeringar vars notiser matchar en delsträng"
+msgstr ""
+"Matchar citeringar vars notiser innehåller text som matchar en delsträng"
 
 #: ../gramps/gen/filters/rules/citation/_hasnoteregexp.py:42
 msgid "Citations having notes containing <text>"
@@ -3913,7 +3904,7 @@ msgstr "Matchar citeringar med en viss referensräknare"
 #: ../gramps/gen/filters/rules/media/_hasmedia.py:46
 #: ../gramps/gen/filters/rules/place/_hasplace.py:48
 #: ../gramps/gen/filters/rules/place/_hastitle.py:48
-#: ../gramps/gui/glade/editplaceref.glade:200
+#: ../gramps/gui/glade/editplaceref.glade:201
 #: ../gramps/gui/glade/mergedata.glade:759
 #: ../gramps/gui/glade/mergedata.glade:775
 #: ../gramps/gui/glade/mergemedia.glade:212
@@ -3976,15 +3967,15 @@ msgstr "Matchar en citering med en källa med ett angivet Gramps-ID"
 
 #: ../gramps/gen/filters/rules/citation/_hassourcenoteregexp.py:52
 msgid "Citations having source notes containing <text>"
-msgstr "Citeringar med notiser innehållande <text>"
+msgstr "Citeringar med källnotiser innehållande <text>"
 
 #: ../gramps/gen/filters/rules/citation/_hassourcenoteregexp.py:53
 msgid ""
 "Matches citations whose source notes contain a substring or match a regular "
 "expression"
 msgstr ""
-"Matchar citeringar vars notiser innehåller en text eller som matchar ett "
-"reguljärt uttryck"
+"Matchar citeringar vars källnotiser innehåller en delsträng eller som "
+"matchar ett reguljärt uttryck"
 
 #: ../gramps/gen/filters/rules/citation/_hastag.py:48
 #: ../gramps/gen/filters/rules/event/_hastag.py:48
@@ -4017,7 +4008,7 @@ msgstr "Matchar den citering, som matchas av det angivna filtret"
 
 #: ../gramps/gen/filters/rules/citation/_matchespagesubstringof.py:43
 msgid "Citations with Volume/Page containing <text>"
-msgstr "Citering med Volume/sida innehållande <text>"
+msgstr "Citeringar med Volume/sida innehållande <text>"
 
 #: ../gramps/gen/filters/rules/citation/_matchespagesubstringof.py:44
 msgid "Matches citations whose Volume/Page contains a certain substring"
@@ -4042,8 +4033,8 @@ msgid ""
 "Matches citations with sources with a repository reference that match a "
 "certain repository filter"
 msgstr ""
-"Matchar citeringar, som har en arkivplatsreferens, som matchar ett givet "
-"arkivplatsfilter"
+"Matchar citeringar med källor, som har en arkivplatsreferens, som matchar "
+"ett givet arkivplatsfilter"
 
 #: ../gramps/gen/filters/rules/citation/_matchessourcefilter.py:49
 msgid "Citations with source matching the <source filter>"
@@ -4052,9 +4043,7 @@ msgstr "Citeringar med källa matchande <källfilter>"
 #: ../gramps/gen/filters/rules/citation/_matchessourcefilter.py:50
 msgid ""
 "Matches citations with sources that match the specified source filter name"
-msgstr ""
-"Matchar citeringar med källor,\n"
-"som matchar det angivna källfilternamnet"
+msgstr "Matchar citeringar med källor som matchar det angivna källfilternamnet"
 
 #: ../gramps/gen/filters/rules/citation/_regexpidof.py:48
 msgid "Citations with Id containing <text>"
@@ -4072,7 +4061,9 @@ msgstr "Citeringar med käll-Id innehållande <text>"
 msgid ""
 "Matches citations whose source has a Gramps ID that matches the regular "
 "expression"
-msgstr "Matchar citeringar vars Gramps-ID matchar det reguljära uttrycket"
+msgstr ""
+"Matchar citeringar vars källa har ett Gramps-ID som matchar det reguljära "
+"uttrycket"
 
 #: ../gramps/gen/filters/rules/event/_allevents.py:44
 msgid "Every event"
@@ -4199,7 +4190,7 @@ msgstr "Händelser med <Id>"
 
 #: ../gramps/gen/filters/rules/event/_hasidof.py:45
 msgid "Matches an event with a specified Gramps ID"
-msgstr "Matchar händelser med ett angivet Gramps-ID"
+msgstr "Matchar en händelse med ett angivet Gramps-ID"
 
 #: ../gramps/gen/filters/rules/event/_hasnote.py:45
 msgid "Events having <count> notes"
@@ -4211,19 +4202,22 @@ msgstr "Matchar händelser, som har ett visst antal notiser"
 
 #: ../gramps/gen/filters/rules/event/_hasnotematchingsubstringof.py:42
 msgid "Events having notes containing <substring>"
-msgstr "Händelser med <delsträng> i notiser"
+msgstr "Händelser med notiser innehållande <delsträng>"
 
 #: ../gramps/gen/filters/rules/event/_hasnotematchingsubstringof.py:43
 msgid "Matches events whose notes contain text matching a substring"
-msgstr "Matchar personer vars notiser innehåller angiven delsträng"
+msgstr ""
+"Matchar händelser vars notiser innehåller text som matchar en delsträng"
 
 #: ../gramps/gen/filters/rules/event/_hasnoteregexp.py:41
 msgid "Events having notes containing <text>"
-msgstr "Händelser med <text> i notiser"
+msgstr "Händelser med notiser innehållande <text>"
 
 #: ../gramps/gen/filters/rules/event/_hasnoteregexp.py:42
 msgid "Matches events whose notes contain text matching a regular expression"
-msgstr "Matchar händelser vars notiser innehåller angivet reguljärt uttryck"
+msgstr ""
+"Matchar händelser vars notiser innehåller text som matchar ett reguljärt "
+"uttryck"
 
 #: ../gramps/gen/filters/rules/event/_hasreferencecountof.py:42
 msgid "Events with a reference count of <count>"
@@ -4247,7 +4241,7 @@ msgstr "Notiser med <flagga>"
 
 #: ../gramps/gen/filters/rules/event/_hastag.py:50
 msgid "Matches events with the particular tag"
-msgstr "Matchar notiser av den särskilda flaggan"
+msgstr "Matchar notiser med den särskilda flaggan"
 
 #: ../gramps/gen/filters/rules/event/_hastype.py:46
 msgid "Events with the particular type"
@@ -4278,7 +4272,7 @@ msgstr "Personfilternamn:"
 
 #: ../gramps/gen/filters/rules/event/_matchespersonfilter.py:51
 msgid "Events of persons matching the <person filter>"
-msgstr "Händelser för en person matchande <personfilter>"
+msgstr "Händelser för personer matchande <personfilter>"
 
 #: ../gramps/gen/filters/rules/event/_matchespersonfilter.py:52
 msgid "Matches events of persons matched by the specified person filter name"
@@ -4303,7 +4297,7 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/event/_matchessourceconfidence.py:45
 msgid "Events with at least one direct source >= <confidence level>"
-msgstr "Händelser med minst en direkt källa >=<konfidensnivå>"
+msgstr "Händelser med minst en direkt källa >= <konfidensnivå>"
 
 #: ../gramps/gen/filters/rules/event/_matchessourceconfidence.py:46
 msgid "Matches events with at least one direct source with confidence level(s)"
@@ -4315,9 +4309,7 @@ msgstr "Händelser med källa matchande <källfilter>"
 
 #: ../gramps/gen/filters/rules/event/_matchessourcefilter.py:50
 msgid "Matches events with sources that match the specified source filter name"
-msgstr ""
-"Matchar händelser med källor,\n"
-"som matchar det angivna källfilternamnet"
+msgstr "Matchar händelser med källor som matchar det angivna källfilternamnet"
 
 #: ../gramps/gen/filters/rules/event/_regexpidof.py:47
 msgid "Events with Id containing <text>"
@@ -4419,7 +4411,7 @@ msgstr "Familjeattribut:"
 
 #: ../gramps/gen/filters/rules/family/_hasattribute.py:45
 msgid "Families with the family <attribute>"
-msgstr "Familjer med familjen<attribut>"
+msgstr "Familjer med familje<attribut>"
 
 #: ../gramps/gen/filters/rules/family/_hasattribute.py:46
 msgid "Matches families with the family attribute of a particular value"
@@ -4462,15 +4454,15 @@ msgstr "Familjer med <antal> media"
 
 #: ../gramps/gen/filters/rules/family/_hasgallery.py:46
 msgid "Matches families with a certain number of items in the gallery"
-msgstr "Matchar personer som har ett visst antal mediaobjekt i galleriet"
+msgstr "Matchar familjer som har ett visst antal mediaobjekt i galleriet"
 
 #: ../gramps/gen/filters/rules/family/_hasidof.py:44
 msgid "Family with <Id>"
-msgstr "Familjer med <Id>"
+msgstr "Familj med <Id>"
 
 #: ../gramps/gen/filters/rules/family/_hasidof.py:45
 msgid "Matches a family with a specified Gramps ID"
-msgstr "Matchar familjer med ett angivet Gramps-ID"
+msgstr "Matchar en familj med ett angivet Gramps-ID"
 
 #: ../gramps/gen/filters/rules/family/_haslds.py:48
 msgid "Families with <count> LDS events"
@@ -4490,11 +4482,11 @@ msgstr "Matchar familjer som har ett visst antal notiser"
 
 #: ../gramps/gen/filters/rules/family/_hasnotematchingsubstringof.py:42
 msgid "Families having notes containing <substring>"
-msgstr "Familjer med <delsträng> i notiser"
+msgstr "Familjer med notiser innehållande <delsträng>"
 
 #: ../gramps/gen/filters/rules/family/_hasnotematchingsubstringof.py:43
 msgid "Matches families whose notes contain text matching a substring"
-msgstr "Matchar familjer vars notiser innehåller angiven delsträng"
+msgstr "Matchar familjer vars notiser innehåller text som matchar delsträng"
 
 #: ../gramps/gen/filters/rules/family/_hasnoteregexp.py:41
 msgid "Families having notes containing <text>"
@@ -4502,7 +4494,9 @@ msgstr "Familjer med notiser innehållande <text>"
 
 #: ../gramps/gen/filters/rules/family/_hasnoteregexp.py:42
 msgid "Matches families whose notes contain text matching a regular expression"
-msgstr "Matchar familjer vars notiser innehåller angivet reguljärt uttryck"
+msgstr ""
+"Matchar familjer vars notiser innehåller text som matchar ett reguljärt "
+"uttryck"
 
 #: ../gramps/gen/filters/rules/family/_hasreferencecountof.py:42
 msgid "Families with a reference count of <count>"
@@ -4533,8 +4527,7 @@ msgstr "Familjer med <antal> källor"
 
 #: ../gramps/gen/filters/rules/family/_hassourcecount.py:46
 msgid "Matches families with a certain number of sources connected to it"
-msgstr ""
-"Matchar familjer med en viss antal objekt bland källor kopplade till sig"
+msgstr "Matchar familjer med ett visst antal källor kopplade till sig"
 
 #: ../gramps/gen/filters/rules/family/_hassourceof.py:46
 msgid "Families with the <source>"
@@ -4571,14 +4564,12 @@ msgid "Inclusive:"
 msgstr "Inkluderande:"
 
 #: ../gramps/gen/filters/rules/family/_isancestorof.py:45
-#, fuzzy
 msgid "Ancestor families of <family>"
-msgstr "Anor till <filter> träff"
+msgstr "Anor för <familj>"
 
 #: ../gramps/gen/filters/rules/family/_isancestorof.py:47
-#, fuzzy
 msgid "Matches ancestor families of the specified family"
-msgstr "Matchar familjer, som matchas av det angivna filtret"
+msgstr "Matchar förfaderfamiljer för den angivna familjen"
 
 #: ../gramps/gen/filters/rules/family/_isbookmarked.py:44
 msgid "Bookmarked families"
@@ -4589,18 +4580,16 @@ msgid "Matches the families on the bookmark list"
 msgstr "Matchar familjerna i bokmärkeslistan"
 
 #: ../gramps/gen/filters/rules/family/_isdescendantof.py:45
-#, fuzzy
 msgid "Descendant families of <family>"
-msgstr "Ättlingafamiljer till %s"
+msgstr "Ättlingafamiljer för <familj>"
 
 #: ../gramps/gen/filters/rules/family/_isdescendantof.py:47
-#, fuzzy
 msgid "Matches descendant families of the specified family"
-msgstr "Matchar alla ättlingar för den angivna personen"
+msgstr "Matchar ättlingafamiljer för den angivna familjen"
 
 #: ../gramps/gen/filters/rules/family/_matchesfilter.py:44
 msgid "Families matching the <filter>"
-msgstr "Släkter som matchar <filter>"
+msgstr "Familjer som matchar <filter>"
 
 #: ../gramps/gen/filters/rules/family/_matchesfilter.py:45
 msgid "Matches families matched by the specified filter name"
@@ -4608,7 +4597,7 @@ msgstr "Matchar familjer, som matchas av det angivna filtret"
 
 #: ../gramps/gen/filters/rules/family/_matchessourceconfidence.py:44
 msgid "Families with at least one direct source >= <confidence level>"
-msgstr "Familjer med minst en direkt källa >=<konfidensnivån>"
+msgstr "Familjer med minst en direkt källa >= <konfidensnivå>"
 
 #: ../gramps/gen/filters/rules/family/_matchessourceconfidence.py:45
 msgid ""
@@ -4648,8 +4637,8 @@ msgid ""
 "Matches families where some child has a name that matches a specified "
 "regular expression"
 msgstr ""
-"Matchar familjer vars barn har ett namn,\n"
-"som matchar ett angivet reguljärt uttryck"
+"Matchar familjer med något barn som har ett namn som matchar ett angivet "
+"reguljärt uttryck"
 
 #: ../gramps/gen/filters/rules/family/_regexpfathername.py:45
 msgid "Families with father matching the <regex_name>"
@@ -4660,8 +4649,8 @@ msgid ""
 "Matches families whose father has a name matching a specified regular "
 "expression"
 msgstr ""
-"Matchar familjer vars far har ett namn\n"
-"som matchar ett visst angivet reguljärt uttryck"
+"Matchar familjer vars far har ett namn som matchar ett angivet reguljärt "
+"uttryck"
 
 #: ../gramps/gen/filters/rules/family/_regexpidof.py:47
 msgid "Families with Id containing <text>"
@@ -4680,8 +4669,8 @@ msgid ""
 "Matches families whose mother has a name matching a specified regular "
 "expression"
 msgstr ""
-"Matchar familjer vars mor har ett namn\n"
-"som matchar ett visst angivet reguljärt uttryck"
+"Matchar familjer vars mor har ett namn som matchar ett angivet reguljärt "
+"uttryck"
 
 #: ../gramps/gen/filters/rules/family/_searchchildname.py:45
 msgid "Families with any child matching the <name>"
@@ -4752,8 +4741,8 @@ msgstr "Matchar mediaobjekt med ett angivet Gramps-ID"
 #: ../gramps/gen/filters/rules/media/_hasmedia.py:47
 #: ../gramps/gen/filters/rules/repository/_hasrepo.py:47
 #: ../gramps/gui/glade/editmediaref.glade:521
-#: ../gramps/gui/glade/editplace.glade:366
-#: ../gramps/gui/glade/editplaceref.glade:317
+#: ../gramps/gui/glade/editplace.glade:367
+#: ../gramps/gui/glade/editplaceref.glade:318
 #: ../gramps/gui/glade/mergeevent.glade:212
 #: ../gramps/gui/glade/mergeevent.glade:228
 #: ../gramps/gui/glade/mergenote.glade:245
@@ -4767,7 +4756,7 @@ msgstr "Typ:"
 
 #: ../gramps/gen/filters/rules/media/_hasmedia.py:48
 #: ../gramps/gui/glade/mergemedia.glade:245
-#: ../gramps/gui/glade/mergemedia.glade:261 ../gramps/gui/viewmanager.py:1872
+#: ../gramps/gui/glade/mergemedia.glade:261 ../gramps/gui/viewmanager.py:1870
 msgid "Path:"
 msgstr "Sökväg:"
 
@@ -4781,11 +4770,12 @@ msgstr "Matchar mediaobjekt med vissa parametrar"
 
 #: ../gramps/gen/filters/rules/media/_hasnotematchingsubstringof.py:42
 msgid "Media objects having notes containing <substring>"
-msgstr "Mediaobjekt med <delsträng> i notiser"
+msgstr "Mediaobjekt med notiser innehållande <delsträng>"
 
 #: ../gramps/gen/filters/rules/media/_hasnotematchingsubstringof.py:43
 msgid "Matches media objects whose notes contain text matching a substring"
-msgstr "Matchar mediaobjekt vars notiser innehåller angiven delsträng"
+msgstr ""
+"Matchar mediaobjekt vars notiser innehåller text som matchar en delsträng"
 
 #: ../gramps/gen/filters/rules/media/_hasnoteregexp.py:41
 msgid "Media objects having notes containing <text>"
@@ -4794,7 +4784,9 @@ msgstr "Mediaobjekt med notiser innehållande <text>"
 #: ../gramps/gen/filters/rules/media/_hasnoteregexp.py:42
 msgid ""
 "Matches media objects whose notes contain text matching a regular expression"
-msgstr "Matchar mediaobjekt vars notiser matchar ett reguljärt uttryck"
+msgstr ""
+"Matchar mediaobjekt vars notiser innehåller text som matchar ett reguljärt "
+"uttryck"
 
 #: ../gramps/gen/filters/rules/media/_hasreferencecountof.py:42
 msgid "Media objects with a reference count of <count>"
@@ -4810,7 +4802,7 @@ msgstr "Media med <antal> källor"
 
 #: ../gramps/gen/filters/rules/media/_hassourcecount.py:46
 msgid "Matches media with a certain number of sources connected to it"
-msgstr "Matchar media med en viss antal objekt bland källor kopplade till sig"
+msgstr "Matchar media med ett visst antal källor kopplade till sig"
 
 #: ../gramps/gen/filters/rules/media/_hassourceof.py:46
 msgid "Media with the <source>"
@@ -4838,7 +4830,7 @@ msgstr "Matchar mediaobjekt som matchar det angivna filtret"
 
 #: ../gramps/gen/filters/rules/media/_matchessourceconfidence.py:44
 msgid "Media with a direct source >= <confidence level>"
-msgstr "Media med minst en direkt källa >=<konfidensnivå>"
+msgstr "Media med minst en direkt källa >= <konfidensnivå>"
 
 #: ../gramps/gen/filters/rules/media/_matchessourceconfidence.py:45
 msgid "Matches media with at least one direct source with confidence level(s)"
@@ -4854,7 +4846,7 @@ msgstr "Matchar mediaobjekt som indikerats som privata"
 
 #: ../gramps/gen/filters/rules/media/_regexpidof.py:47
 msgid "Media objects with Id containing <text>"
-msgstr "Mediaobjekt  med Id innehållande <text>"
+msgstr "Mediaobjekt med Id innehållande <text>"
 
 #: ../gramps/gen/filters/rules/media/_regexpidof.py:48
 msgid "Matches media objects whose Gramps ID matches the regular expression"
@@ -4897,7 +4889,7 @@ msgstr "Notistyp:"
 
 #: ../gramps/gen/filters/rules/note/_hasnote.py:49
 msgid "Notes matching parameters"
-msgstr "Notiser, som matchar parametrar"
+msgstr "Notiser som matchar parametrar"
 
 #: ../gramps/gen/filters/rules/note/_hasnote.py:50
 msgid "Matches Notes with particular parameters"
@@ -4933,7 +4925,7 @@ msgstr "Notiser som matchar <filter>"
 
 #: ../gramps/gen/filters/rules/note/_matchesfilter.py:45
 msgid "Matches notes matched by the specified filter name"
-msgstr "Matchar notiser, som matchas av det angivna filternamnet"
+msgstr "Matchar notiser som matchas av det angivna filtret"
 
 #: ../gramps/gen/filters/rules/note/_matchesregexpof.py:44
 msgid "Notes containing <text>"
@@ -4942,16 +4934,15 @@ msgstr "Notiser innehållande <text>"
 #: ../gramps/gen/filters/rules/note/_matchesregexpof.py:45
 msgid "Matches notes that contain a substring or match a regular expression"
 msgstr ""
-"Matchar notiser, som innehåller en deltext eller matchar ett reguljärt "
-"uttryck"
+"Matchar notiser som innehåller en deltext eller matchar ett reguljärt uttryck"
 
 #: ../gramps/gen/filters/rules/note/_matchessubstringof.py:44
 msgid "Notes containing <substring>"
-msgstr "Notiser med <delsträng>"
+msgstr "Notiser innehållande <delsträng>"
 
 #: ../gramps/gen/filters/rules/note/_matchessubstringof.py:45
 msgid "Matches notes that contain text which matches a substring"
-msgstr "Matchar notiser, som innehåller text matchande en delsträng"
+msgstr "Matchar notiser som innehåller text som matchar en delsträng"
 
 #: ../gramps/gen/filters/rules/note/_noteprivate.py:42
 msgid "Notes marked private"
@@ -5019,7 +5010,8 @@ msgstr ""
 "Letar igenom hela databasen med början från en bestämd person och visar alla "
 "mellan den personen och en uppsättning målpersoner, beskrivna av ett filter. "
 "Detta åstadkommer en mängd av släktskapsvägar (inklusive giften) mellan den "
-"valda personen och målen. Varje väg är nödvändigtvis inte den kortaste vägen."
+"valda personen och målpersonerna. Varje väg är nödvändigtvis inte den "
+"kortaste vägen."
 
 #: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:177
 msgid "Evaluating people"
@@ -5034,8 +5026,8 @@ msgid ""
 "Matches people that have no family relationships to any other person in the "
 "database"
 msgstr ""
-"Matchar personer som inte har någon släktrelation\n"
-"med någon annan person i databasen"
+"Matchar personer som inte har någon släktrelation med någon annan person i "
+"databasen"
 
 #: ../gramps/gen/filters/rules/person/_everyone.py:44
 msgid "Everyone"
@@ -5051,9 +5043,7 @@ msgstr "Familjer med ofullständiga händelser"
 
 #: ../gramps/gen/filters/rules/person/_familywithincompleteevent.py:43
 msgid "Matches people with missing date or place in an event of the family"
-msgstr ""
-"Matchar personer med saknat datum\n"
-"eller plats i en händelse i familjen"
+msgstr "Matchar personer med saknat datum eller plats i en händelse i familjen"
 
 #: ../gramps/gen/filters/rules/person/_hasaddress.py:49
 msgid "People with <count> addresses"
@@ -5061,7 +5051,7 @@ msgstr "Personer med <antal> adresser"
 
 #: ../gramps/gen/filters/rules/person/_hasaddress.py:50
 msgid "Matches people with a certain number of personal addresses"
-msgstr "Matchar personer med visst antal egna adresser"
+msgstr "Matchar personer med ett visst antal egna adresser"
 
 #: ../gramps/gen/filters/rules/person/_hasalternatename.py:45
 msgid "People with an alternate name"
@@ -5069,7 +5059,7 @@ msgstr "Personer med ett alternativt namn"
 
 #: ../gramps/gen/filters/rules/person/_hasalternatename.py:46
 msgid "Matches people with an alternate name"
-msgstr "Matchar personer ett alternativt namn"
+msgstr "Matchar personer med ett alternativt namn"
 
 #: ../gramps/gen/filters/rules/person/_hasassociation.py:49
 msgid "People with <count> associations"
@@ -5091,9 +5081,7 @@ msgstr "Personer med personligt <attribut>"
 
 #: ../gramps/gen/filters/rules/person/_hasattribute.py:46
 msgid "Matches people with the personal attribute of a particular value"
-msgstr ""
-"Matchar personer som har ett personligt attribut\n"
-"med ett visst värde"
+msgstr "Matchar personer som har ett personligt attribut med ett visst värde"
 
 #: ../gramps/gen/filters/rules/person/_hasbirth.py:49
 msgid "People with the <birth data>"
@@ -5101,9 +5089,7 @@ msgstr "Personer med <födelsedatum>"
 
 #: ../gramps/gen/filters/rules/person/_hasbirth.py:50
 msgid "Matches people with birth data of a particular value"
-msgstr ""
-"Matchar personer som har födelsedata\n"
-"med ett visst värde"
+msgstr "Matchar personer som har födelsedata med ett visst värde"
 
 #: ../gramps/gen/filters/rules/person/_hascitation.py:50
 msgid "People with the <citation>"
@@ -5131,9 +5117,7 @@ msgstr "Anfilter"
 
 #: ../gramps/gen/filters/rules/person/_hascommonancestorwith.py:48
 msgid "Matches people that have a common ancestor with a specified person"
-msgstr ""
-"Matchar personer som har en ana gemensam\n"
-"med en angiven person"
+msgstr "Matchar personer som har en ana gemensam med en angiven person"
 
 #: ../gramps/gen/filters/rules/person/_hascommonancestorwithfiltermatch.py:48
 msgid "People with a common ancestor with <filter> match"
@@ -5143,8 +5127,7 @@ msgstr "Personer med en ana gemensam med <filter>träff"
 msgid ""
 "Matches people that have a common ancestor with anybody matched by a filter"
 msgstr ""
-"Matchar personer, som har en ana gemensam\n"
-"med någon som matchas av ett filter "
+"Matchar personer som har en ana gemensam med någon som matchas av ett filter"
 
 #: ../gramps/gen/filters/rules/person/_hasdeath.py:49
 msgid "People with the <death data>"
@@ -5152,9 +5135,7 @@ msgstr "Personer med <dödsdatum>"
 
 #: ../gramps/gen/filters/rules/person/_hasdeath.py:50
 msgid "Matches people with death data of a particular value"
-msgstr ""
-"Matchar personer, som har dödsdata\n"
-"med ett visst värde"
+msgstr "Matchar personer som har dödsdata med ett visst värde"
 
 #: ../gramps/gen/filters/rules/person/_hasevent.py:48
 #: ../gramps/gui/editors/filtereditor.py:101
@@ -5177,9 +5158,7 @@ msgstr "Personer med den personliga <händelsen>"
 
 #: ../gramps/gen/filters/rules/person/_hasevent.py:55
 msgid "Matches people with a personal event of a particular value"
-msgstr ""
-"Matchar personer som har en personlig händelse\n"
-"med ett visst värde"
+msgstr "Matchar personer som har en personlig händelse med ett visst värde"
 
 #: ../gramps/gen/filters/rules/person/_hasfamilyattribute.py:45
 msgid "People with the family <attribute>"
@@ -5187,9 +5166,7 @@ msgstr "Personer med familje<attribut>"
 
 #: ../gramps/gen/filters/rules/person/_hasfamilyattribute.py:46
 msgid "Matches people with the family attribute of a particular value"
-msgstr ""
-"Matchar personer som har familjeattribut\n"
-"med ett visst värde"
+msgstr "Matchar personer som har familjeattribut med ett visst värde"
 
 #: ../gramps/gen/filters/rules/person/_hasfamilyevent.py:52
 msgid "People with the family <event>"
@@ -5197,9 +5174,7 @@ msgstr "Personer med familje<händelsen>"
 
 #: ../gramps/gen/filters/rules/person/_hasfamilyevent.py:53
 msgid "Matches people with a family event of a particular value"
-msgstr ""
-"Matchar personer med en familjehändelse\n"
-"med ett visst värde"
+msgstr "Matchar personer med en familjehändelse med ett visst värde"
 
 #: ../gramps/gen/filters/rules/person/_hasgallery.py:42
 msgid "People with <count> media"
@@ -5207,9 +5182,7 @@ msgstr "Personer med <antal> media"
 
 #: ../gramps/gen/filters/rules/person/_hasgallery.py:43
 msgid "Matches people with a certain number of items in the gallery"
-msgstr ""
-"Matchar personer som har ett visst\n"
-"antal mediaobjekt i galleriet"
+msgstr "Matchar personer som har ett visst antal mediaobjekt i galleriet"
 
 #: ../gramps/gen/filters/rules/person/_hasidof.py:44
 #: ../gramps/gen/filters/rules/person/_matchidof.py:45
@@ -5296,7 +5269,7 @@ msgstr "Personer med <Efternamnsursprung>"
 
 #: ../gramps/gen/filters/rules/person/_hasnameorigintype.py:48
 msgid "Matches people with a surname origin"
-msgstr "Matchar personer med att efternamnursprung"
+msgstr "Matchar personer med ett efternamnursprung"
 
 #: ../gramps/gen/filters/rules/person/_hasnametype.py:46
 #: ../gramps/gui/editors/filtereditor.py:110
@@ -5330,13 +5303,11 @@ msgstr "Matchar personer som har ett visst antal notiser"
 
 #: ../gramps/gen/filters/rules/person/_hasnotematchingsubstringof.py:42
 msgid "People having notes containing <substring>"
-msgstr "Personer med <delsträng> i notiser"
+msgstr "Personer med notiser innehållande <delsträng>"
 
 #: ../gramps/gen/filters/rules/person/_hasnotematchingsubstringof.py:43
 msgid "Matches people whose notes contain text matching a substring"
-msgstr ""
-"Matchar personer vars notiser\n"
-"innehåller angiven text"
+msgstr "Matchar personer vars notiser innehåller angiven text"
 
 #: ../gramps/gen/filters/rules/person/_hasnoteregexp.py:41
 msgid "People having notes containing <text>"
@@ -5344,9 +5315,7 @@ msgstr "Personer med notiser innehållande <text>"
 
 #: ../gramps/gen/filters/rules/person/_hasnoteregexp.py:42
 msgid "Matches people whose notes contain text matching a regular expression"
-msgstr ""
-"Matchar personer vars notiser\n"
-"innehåller angivet reguljärt uttryck"
+msgstr "Matchar personer vars notiser innehåller angivet reguljärt uttryck"
 
 #: ../gramps/gen/filters/rules/person/_hasrelationship.py:45
 msgid "Number of relationships:"
@@ -5383,7 +5352,7 @@ msgstr "Släktfilter"
 #: ../gramps/gui/glade/editfamily.glade:372
 #: ../gramps/gui/glade/editplaceformat.glade:200
 #: ../gramps/gui/glade/editplacename.glade:183
-#: ../gramps/gui/glade/editplaceref.glade:214
+#: ../gramps/gui/glade/editplaceref.glade:215
 #: ../gramps/gui/glade/mergeperson.glade:222
 #: ../gramps/gui/glade/mergeperson.glade:238
 #: ../gramps/gui/glade/mergeplace.glade:425
@@ -5393,15 +5362,16 @@ msgid "Name:"
 msgstr "Namn:"
 
 #: ../gramps/gen/filters/rules/person/_hassoundexname.py:42
-#, fuzzy
 msgid "Soundex match of People with the <name>"
-msgstr "Personer med <namn>"
+msgstr "Soundex-sökning som matchar personer med <namn>"
 
 #: ../gramps/gen/filters/rules/person/_hassoundexname.py:43
 msgid ""
 "Soundex Match of people with a specified name. First name, Surname, Call "
 "name, and Nickname are searched in primary and alternate names."
 msgstr ""
+"Soundex-sökning av personer med ett angivet namn. Förnamn, efternamn, "
+"tilltalsnamn, och smeknamn söks igenom som huvudnamn och alternativa namn."
 
 #: ../gramps/gen/filters/rules/person/_hassourcecount.py:45
 msgid "People with <count> sources"
@@ -5438,9 +5408,7 @@ msgstr "Matchar personer vars poster innehåller <delsträng>"
 
 #: ../gramps/gen/filters/rules/person/_hastextmatchingsubstringof.py:49
 msgid "Matches people whose records contain text matching a substring"
-msgstr ""
-"Matchar personer vars poster innehåller text\n"
-"som matchar en delsträng"
+msgstr "Matchar personer vars poster innehåller text som matchar en delsträng"
 
 #: ../gramps/gen/filters/rules/person/_hasunknowngender.py:45
 msgid "People with unknown gender"
@@ -5488,9 +5456,7 @@ msgstr "Anor till <filter> träff"
 
 #: ../gramps/gen/filters/rules/person/_isancestoroffiltermatch.py:49
 msgid "Matches people that are ancestors of anybody matched by a filter"
-msgstr ""
-"Matchar personer, som är anor till någon,\n"
-"som matchas av ett filter"
+msgstr "Matchar personer som är anor till någon som matchas av ett filter"
 
 #: ../gramps/gen/filters/rules/person/_isbookmarked.py:45
 msgid "Bookmarked people"
@@ -5506,7 +5472,7 @@ msgstr "Barn till <filter>träff"
 
 #: ../gramps/gen/filters/rules/person/_ischildoffiltermatch.py:49
 msgid "Matches children of anybody matched by a filter"
-msgstr "Matchar barn till någon, som matchas av ett filter"
+msgstr "Matchar barn till någon som matchas av ett filter"
 
 #: ../gramps/gen/filters/rules/person/_isdefaultperson.py:44
 msgid "Default person"
@@ -5534,8 +5500,8 @@ msgid ""
 "Matches people that are descendants or the spouse of a descendant of a "
 "specified person"
 msgstr ""
-"Matchar personer som är ättlingar eller maka/make\n"
-"till en ättling till en angiven person"
+"Matchar personer som är ättlingar eller maka/make till en ättling till en "
+"angiven person"
 
 #: ../gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py:47
 msgid "Descendant family members of <filter> match"
@@ -5546,8 +5512,8 @@ msgid ""
 "Matches people that are descendants or the spouse of anybody matched by a "
 "filter"
 msgstr ""
-"Matchar personer, som är ättlingar eller maka/make till någon, som matchas "
-"av ett filter."
+"Matchar personer som är ättlingar eller maka/make till någon som matchas av "
+"ett filter"
 
 #: ../gramps/gen/filters/rules/person/_isdescendantof.py:46
 msgid "Descendants of <person>"
@@ -5563,9 +5529,7 @@ msgstr "Ättlingar till <filter>-träff"
 
 #: ../gramps/gen/filters/rules/person/_isdescendantoffiltermatch.py:49
 msgid "Matches people that are descendants of anybody matched by a filter"
-msgstr ""
-"Matchar personer, som är ättlingar till någon,\n"
-"som matchas av ett filter"
+msgstr "Matchar personer som är ättlingar till någon som matchas av ett filter"
 
 #: ../gramps/gen/filters/rules/person/_isduplicatedancestorof.py:47
 msgid "Duplicated ancestors of <person>"
@@ -5573,7 +5537,8 @@ msgstr "Dubbla förfäder till <person>"
 
 #: ../gramps/gen/filters/rules/person/_isduplicatedancestorof.py:49
 msgid "Matches people that are ancestors twice or more of a specified person"
-msgstr "Matchar personer, som är dubbla förfäder, till en angiven person"
+msgstr ""
+"Matchar personer som är dubbla förfäder eller mer till en angiven person"
 
 #: ../gramps/gen/filters/rules/person/_isfemale.py:45
 #: ../gramps/plugins/gramplet/statsgramplet.py:108
@@ -5608,8 +5573,7 @@ msgid ""
 "Matches people that are ancestors of a specified person not more than N "
 "generations away"
 msgstr ""
-"Matchar personer som är anor till en angiven person\n"
-"mindre än N generationer bort"
+"Matchar personer som är anor till en angiven person högst N generationer bort"
 
 #: ../gramps/gen/filters/rules/person/_islessthannthgenerationancestorofbookmarked.py:52
 msgid "Ancestors of bookmarked people not more than <N> generations away"
@@ -5619,9 +5583,7 @@ msgstr "Anor till personer med bokmärken inte mer än <N> generationer bort"
 msgid ""
 "Matches ancestors of the people on the bookmark list not more than N "
 "generations away"
-msgstr ""
-"Matchar anor till personer med\n"
-"bokmärken högst N generationer bort"
+msgstr "Matchar anor till personer i bokmärkeslistan högst N generationer bort"
 
 #: ../gramps/gen/filters/rules/person/_islessthannthgenerationancestorofdefaultperson.py:47
 msgid "Ancestors of the default person not more than <N> generations away"
@@ -5630,9 +5592,7 @@ msgstr "Anor till förvald person inte mer än <N> generationer bort"
 #: ../gramps/gen/filters/rules/person/_islessthannthgenerationancestorofdefaultperson.py:50
 msgid ""
 "Matches ancestors of the default person not more than N generations away"
-msgstr ""
-"Matchar anor till förvald person\n"
-"mindre än N generationer bort"
+msgstr "Matchar anor till förvald person högst N generationer bort"
 
 #: ../gramps/gen/filters/rules/person/_islessthannthgenerationdescendantof.py:46
 msgid "Descendants of <person> not more than <N> generations away"
@@ -5643,8 +5603,8 @@ msgid ""
 "Matches people that are descendants of a specified person not more than N "
 "generations away"
 msgstr ""
-"Matchar personer som är ättlingar till en angiven person\n"
-"mindre än N generationer bort"
+"Matchar personer som är ättlingar till en angiven person högst N "
+"generationer bort"
 
 #. -------------------------
 #. ###############################
@@ -5671,8 +5631,7 @@ msgid ""
 "Matches people that are ancestors of a specified person at least N "
 "generations away"
 msgstr ""
-"Matchar personer som är anor till en angiven person\n"
-"minst N generationer bort"
+"Matchar personer som är anor till en angiven person minst N generationer bort"
 
 #: ../gramps/gen/filters/rules/person/_ismorethannthgenerationdescendantof.py:46
 msgid "Descendants of <person> at least <N> generations away"
@@ -5683,8 +5642,8 @@ msgid ""
 "Matches people that are descendants of a specified person at least N "
 "generations away"
 msgstr ""
-"Matchar personer som är ättlingar till en angiven person\n"
-"minst N generationer bort"
+"Matchar personer som är ättlingar till en angiven person minst N "
+"generationer bort"
 
 #: ../gramps/gen/filters/rules/person/_isparentoffiltermatch.py:47
 msgid "Parents of <filter> match"
@@ -5692,9 +5651,7 @@ msgstr "Föräldrar till <filter>träff"
 
 #: ../gramps/gen/filters/rules/person/_isparentoffiltermatch.py:49
 msgid "Matches parents of anybody matched by a filter"
-msgstr ""
-"Matchar föräldrarna till någon,\n"
-"som matchas av ett filter"
+msgstr "Matchar föräldrarna till någon som matchas av ett filter"
 
 #: ../gramps/gen/filters/rules/person/_isrelatedwith.py:45
 msgid "People related to <Person>"
@@ -5702,7 +5659,7 @@ msgstr "Personer besläktad med <Person>"
 
 #: ../gramps/gen/filters/rules/person/_isrelatedwith.py:47
 msgid "Matches people related to a specified person"
-msgstr "Matchar personer som är besläktad med en angiven person"
+msgstr "Matchar personer som är besläktade med en angiven person"
 
 #: ../gramps/gen/filters/rules/person/_issiblingoffiltermatch.py:46
 msgid "Siblings of <filter> match"
@@ -5710,7 +5667,7 @@ msgstr "Syskon till <filter>träff"
 
 #: ../gramps/gen/filters/rules/person/_issiblingoffiltermatch.py:48
 msgid "Matches siblings of anybody matched by a filter"
-msgstr "Matchar syskon till någon, som matchas av ett filter"
+msgstr "Matchar syskon till någon som matchas av ett filter"
 
 #: ../gramps/gen/filters/rules/person/_isspouseoffiltermatch.py:47
 msgid "Spouses of <filter> match"
@@ -5741,8 +5698,7 @@ msgstr "Personer med händelser matchande <händelsefilter>"
 #: ../gramps/gen/filters/rules/person/_matcheseventfilter.py:53
 msgid "Matches persons who have events that match a certain event filter"
 msgstr ""
-"Matchar personer, som har händelser,\n"
-"som matchar ett givet händelsefilter"
+"Matchar personer som har händelser som matchar ett givet händelsefilter"
 
 #: ../gramps/gen/filters/rules/person/_matchesfilter.py:44
 msgid "People matching the <filter>"
@@ -5750,11 +5706,11 @@ msgstr "Personer som matchar <filter>"
 
 #: ../gramps/gen/filters/rules/person/_matchesfilter.py:45
 msgid "Matches people matched by the specified filter name"
-msgstr "Matchar personer, som matchas av det angivna filtret"
+msgstr "Matchar personer som matchas av det angivna filtret"
 
 #: ../gramps/gen/filters/rules/person/_matchessourceconfidence.py:44
 msgid "Persons with at least one direct source >= <confidence level>"
-msgstr "Personer med minst en direkt källa >=<konfidensnivå>"
+msgstr "Personer med minst en direkt källa >= <konfidensnivå>"
 
 #: ../gramps/gen/filters/rules/person/_matchessourceconfidence.py:45
 msgid ""
@@ -5763,16 +5719,15 @@ msgstr "Matchar personer med minst en direkt källa med konfidensnivå(er)"
 
 #: ../gramps/gen/filters/rules/person/_missingparent.py:43
 msgid "People missing parents"
-msgstr "Personer, som saknar föräldrar"
+msgstr "Personer som saknar föräldrar"
 
 #: ../gramps/gen/filters/rules/person/_missingparent.py:44
 msgid ""
 "Matches people that are children in a family with less than two parents or "
 "are not children in any family."
 msgstr ""
-"Matchar personer, som är barn i en familj,\n"
-"med mindre än två föräldrar\n"
-"eller som inte är barn i någon familj."
+"Matchar personer som är barn i en familj med mindre än två föräldrar eller "
+"som inte är barn i någon familj."
 
 #: ../gramps/gen/filters/rules/person/_multiplemarriages.py:42
 msgid "People with multiple marriage records"
@@ -5828,9 +5783,7 @@ msgstr "Personer med ofullständiga händelser"
 
 #: ../gramps/gen/filters/rules/person/_personwithincompleteevent.py:43
 msgid "Matches people with missing date or place in an event"
-msgstr ""
-"Matchar personer med saknat datum\n"
-"eller plats i en händelse"
+msgstr "Matchar personer med saknat datum eller plats i en händelse"
 
 #: ../gramps/gen/filters/rules/person/_probablyalive.py:44
 msgid "On date:"
@@ -5873,9 +5826,8 @@ msgid ""
 "Matches the ancestors of two persons back to a common ancestor, producing "
 "the relationship path between two persons."
 msgstr ""
-"Matchar anorna för två personer tillbaka till en\n"
-"gemensam ana och redovisar på så vis\n"
-"släktskapsvägen mellan två personer."
+"Matchar anorna för två personer tillbaka till en gemensam ana och redovisar "
+"på så vis släktskapsvägen mellan två personer."
 
 #: ../gramps/gen/filters/rules/person/_relationshippathbetweenbookmarks.py:51
 msgid "Relationship path between bookmarked persons"
@@ -5886,8 +5838,8 @@ msgid ""
 "Matches the ancestors of bookmarked individuals back to common ancestors, "
 "producing the relationship path(s) between bookmarked persons."
 msgstr ""
-"Matchar anorna för personer med bokmärken tillbaka till en gemensam ana\n"
-"och redovisar på så vis släktskapsvägen mellan två personer."
+"Matchar anorna för personer med bokmärken tillbaka till gemensamma anor och "
+"redovisar på så vis släktskapsvägen(arna) mellan bokmärkta personer."
 
 #: ../gramps/gen/filters/rules/person/_searchname.py:46
 msgid "People matching the <name>"
@@ -5928,17 +5880,17 @@ msgid "Place type:"
 msgstr "Platstyp:"
 
 #: ../gramps/gen/filters/rules/place/_hasdata.py:50
-#: ../gramps/gui/glade/editplace.glade:279
-#: ../gramps/gui/glade/editplaceref.glade:510
+#: ../gramps/gui/glade/editplace.glade:280
+#: ../gramps/gui/glade/editplaceref.glade:511
 #: ../gramps/gui/glade/mergeplace.glade:545
 #: ../gramps/gui/glade/mergeplace.glade:562
 msgid "Code:"
-msgstr "Kod"
+msgstr "Kod:"
 
 #: ../gramps/gen/filters/rules/place/_hasdata.py:52
 #: ../gramps/gen/filters/rules/place/_hasplace.py:58
 msgid "Places matching parameters"
-msgstr "Platser med parametrar"
+msgstr "Platser matchande parametrar"
 
 #: ../gramps/gen/filters/rules/place/_hasdata.py:53
 #: ../gramps/gen/filters/rules/place/_hasplace.py:59
@@ -5967,7 +5919,7 @@ msgstr "Platser utan latitud eller longitud angivet"
 
 #: ../gramps/gen/filters/rules/place/_hasnolatorlon.py:49
 msgid "Matches places with empty latitude or longitude"
-msgstr "Matchar platser med tomt latitud eller longitud"
+msgstr "Matchar platser där latitud eller longitud har ett tomt värde"
 
 #: ../gramps/gen/filters/rules/place/_hasnolatorlon.py:50
 #: ../gramps/gen/filters/rules/place/_inlatlonneighborhood.py:56
@@ -5981,11 +5933,11 @@ msgstr "Platser med <antal> notiser"
 
 #: ../gramps/gen/filters/rules/place/_hasnote.py:46
 msgid "Matches places having a certain number of notes"
-msgstr "Matchar platser, som har ett visst antal notiser"
+msgstr "Matchar platser som har ett visst antal notiser"
 
 #: ../gramps/gen/filters/rules/place/_hasnotematchingsubstringof.py:42
 msgid "Places having notes containing <substring>"
-msgstr "Platser med <delsträng> i notiser"
+msgstr "Platser med notiser innehållande <delsträng>"
 
 #: ../gramps/gen/filters/rules/place/_hasnotematchingsubstringof.py:43
 msgid "Matches places whose notes contain text matching a substring"
@@ -6057,11 +6009,11 @@ msgstr "Matchar platser som har en viss källa"
 
 #: ../gramps/gen/filters/rules/place/_hastag.py:49
 msgid "Places with the <tag>"
-msgstr "Personer med <flaggan>"
+msgstr "Platser med <flaggan>"
 
 #: ../gramps/gen/filters/rules/place/_hastag.py:50
 msgid "Matches places with the particular tag"
-msgstr "Matchar platser den särskilda flaggan"
+msgstr "Matchar platser med den särskilda flaggan"
 
 #: ../gramps/gen/filters/rules/place/_hastitle.py:49
 msgid "Places matching a title"
@@ -6069,17 +6021,17 @@ msgstr "Platser som matchar en titel"
 
 #: ../gramps/gen/filters/rules/place/_hastitle.py:50
 msgid "Matches places with a particular title"
-msgstr "Matchar platser en särskild titel"
+msgstr "Matchar platser med en särskild titel"
 
 #: ../gramps/gen/filters/rules/place/_inlatlonneighborhood.py:49
-#: ../gramps/gui/glade/editplaceref.glade:258
+#: ../gramps/gui/glade/editplaceref.glade:259
 #: ../gramps/gui/glade/mergeplace.glade:236
 #: ../gramps/gui/glade/mergeplace.glade:251
 msgid "Latitude:"
 msgstr "Latitud:"
 
 #: ../gramps/gen/filters/rules/place/_inlatlonneighborhood.py:49
-#: ../gramps/gui/glade/editplaceref.glade:331
+#: ../gramps/gui/glade/editplaceref.glade:332
 #: ../gramps/gui/glade/mergeplace.glade:267
 #: ../gramps/gui/glade/mergeplace.glade:282
 msgid "Longitude:"
@@ -6103,9 +6055,9 @@ msgid ""
 "height and width (in degrees), and with middlepoint the given latitude and "
 "longitude."
 msgstr ""
-"Matchar platser med latitud- eller longitudposition i en rektangel\n"
-"med given höjd och bredd (i grader) och med mittpunkt\n"
-"enligt den angivna latitud och longitud."
+"Matchar platser med latitud- eller longitudposition i en rektangel med given "
+"höjd och bredd (i grader) och med mittpunkt enligt den angivna latituden och "
+"longituden."
 
 #: ../gramps/gen/filters/rules/place/_isenclosedby.py:49
 msgid "Places enclosed by another place"
@@ -6113,7 +6065,7 @@ msgstr "Platser omgivna av annan plats"
 
 #: ../gramps/gen/filters/rules/place/_isenclosedby.py:50
 msgid "Matches a place enclosed by a particular place"
-msgstr "Matchar en plats, omgiven av en särskild plats"
+msgstr "Matchar en plats omgiven av en särskild plats"
 
 #: ../gramps/gen/filters/rules/place/_matcheseventfilter.py:50
 msgid "Places of events matching the <event filter>"
@@ -6124,8 +6076,8 @@ msgid ""
 "Matches places where events happened that match the specified event filter "
 "name"
 msgstr ""
-"Matchar platser, där händelser inträffade,\n"
-"som matchas av det angivna händelsefilternamnet"
+"Matchar platser där händelser inträffade som matchas av det angivna "
+"händelsefilternamnet"
 
 #: ../gramps/gen/filters/rules/place/_matchesfilter.py:44
 msgid "Places matching the <filter>"
@@ -6133,11 +6085,11 @@ msgstr "Platser som matchar <filter>"
 
 #: ../gramps/gen/filters/rules/place/_matchesfilter.py:45
 msgid "Matches places matched by the specified filter name"
-msgstr "Matchar platser, som matchas av det angivna filtret"
+msgstr "Matchar platser som matchas av det angivna filtret"
 
 #: ../gramps/gen/filters/rules/place/_matchessourceconfidence.py:44
 msgid "Place with a direct source >= <confidence level>"
-msgstr "Plats med minst en direkt källa >=<konfidensnivå>"
+msgstr "Plats med en direkt källa >= <konfidensnivå>"
 
 #: ../gramps/gen/filters/rules/place/_matchessourceconfidence.py:45
 msgid "Matches places with at least one direct source with confidence level(s)"
@@ -6162,17 +6114,15 @@ msgstr "Matchar platser vars Gramps-ID matchar det reguljära uttrycket"
 #: ../gramps/gen/filters/rules/place/_withinarea.py:50
 #: ../gramps/gui/editors/filtereditor.py:584
 msgid "Units:"
-msgstr ""
+msgstr "Enheter:"
 
 #: ../gramps/gen/filters/rules/place/_withinarea.py:51
-#, fuzzy
 msgid "Places within an area"
-msgstr "Platser med <antal> media"
+msgstr "Platser inom ett område"
 
 #: ../gramps/gen/filters/rules/place/_withinarea.py:52
-#, fuzzy
 msgid "Matches places within a given distance of another place"
-msgstr "Matchar platser med en citering av visst värde"
+msgstr "Matchar platser inom ett givet avstånd från en annan plats"
 
 #: ../gramps/gen/filters/rules/repository/_allrepos.py:44
 msgid "Every repository"
@@ -6200,11 +6150,11 @@ msgstr "Arkivplats med <id>"
 
 #: ../gramps/gen/filters/rules/repository/_hasidof.py:45
 msgid "Matches a repository with a specified Gramps ID"
-msgstr "Matchar arkivplatser med ett angivet Gramps-ID"
+msgstr "Matchar en arkivplats med ett angivet Gramps-ID"
 
 #: ../gramps/gen/filters/rules/repository/_hasnotematchingsubstringof.py:42
 msgid "Repositories having notes containing <substring>"
-msgstr "Arkivplatser med <delsträng> i notiser"
+msgstr "Arkivplatser med notiser innehållande <delsträng>"
 
 #: ../gramps/gen/filters/rules/repository/_hasnotematchingsubstringof.py:43
 msgid "Matches repositories whose notes contain text matching a substring"
@@ -6212,7 +6162,7 @@ msgstr "Matchar arkivplatser vars notiser innehåller angiven delsträng"
 
 #: ../gramps/gen/filters/rules/repository/_hasnoteregexp.py:41
 msgid "Repositories having notes containing <text>"
-msgstr "Arkivplatser med <text> i notiser"
+msgstr "Arkivplatser med notiser innehållande <text>"
 
 #: ../gramps/gen/filters/rules/repository/_hasnoteregexp.py:42
 msgid ""
@@ -6225,7 +6175,7 @@ msgstr "Arkivplatser med en referensräknare på <antal>"
 
 #: ../gramps/gen/filters/rules/repository/_hasreferencecountof.py:43
 msgid "Matches repositories with a certain reference count"
-msgstr "Matcher arkivplatser med en viss referensräknare"
+msgstr "Matchar arkivplatser med en viss referensräknare"
 
 #: ../gramps/gen/filters/rules/repository/_hasrepo.py:46
 #: ../gramps/gui/glade/mergerepository.glade:212
@@ -6252,7 +6202,7 @@ msgstr "Matchar arkivplatser med vissa parametrar"
 
 #: ../gramps/gen/filters/rules/repository/_hastag.py:49
 msgid "Repositories with the <tag>"
-msgstr "Arkivplats med <flagga>"
+msgstr "Arkivplatser med <flagga>"
 
 #: ../gramps/gen/filters/rules/repository/_hastag.py:50
 msgid "Matches repositories with the particular tag"
@@ -6268,7 +6218,7 @@ msgstr "Matchar arkivplatser som matchar det angivna filtret"
 
 #: ../gramps/gen/filters/rules/repository/_matchesnamesubstringof.py:43
 msgid "Repositories with name containing <text>"
-msgstr "Arkivplatser med en namn innehållande <text>"
+msgstr "Arkivplatser med namn innehållande <text>"
 
 #: ../gramps/gen/filters/rules/repository/_matchesnamesubstringof.py:44
 msgid "Matches repositories whose name contains a certain substring"
@@ -6324,7 +6274,7 @@ msgstr "Källor med <Id>"
 
 #: ../gramps/gen/filters/rules/source/_hasidof.py:45
 msgid "Matches a source with a specified Gramps ID"
-msgstr "Matchar källor med ett angivet Gramps-ID"
+msgstr "Matchar en källa med ett angivet Gramps-ID"
 
 #: ../gramps/gen/filters/rules/source/_hasnote.py:45
 msgid "Sources having <count> notes"
@@ -6332,11 +6282,11 @@ msgstr "Källor med <antal> notiser"
 
 #: ../gramps/gen/filters/rules/source/_hasnote.py:46
 msgid "Matches sources having a certain number of notes"
-msgstr "Matchar källor, som har ett visst antal notiser"
+msgstr "Matchar källor som har ett visst antal notiser"
 
 #: ../gramps/gen/filters/rules/source/_hasnotematchingsubstringof.py:42
 msgid "Sources having notes containing <substring>"
-msgstr "Källor med <delsträng> i notiser"
+msgstr "Källor med notiser innehållande <delsträng>"
 
 #: ../gramps/gen/filters/rules/source/_hasnotematchingsubstringof.py:43
 msgid "Matches sources whose notes contain text matching a substring"
@@ -6356,7 +6306,7 @@ msgstr "Källor med en referensräknare på <antal>"
 
 #: ../gramps/gen/filters/rules/source/_hasreferencecountof.py:43
 msgid "Matches sources with a certain reference count"
-msgstr "Matchar källor ned en viss referensräknare"
+msgstr "Matchar källor med en viss referensräknare"
 
 #: ../gramps/gen/filters/rules/source/_hasrepository.py:47
 msgid "Sources with <count> Repository references"
@@ -6364,12 +6314,11 @@ msgstr "Källor med <antal> arkivplatsreferenser"
 
 #: ../gramps/gen/filters/rules/source/_hasrepository.py:48
 msgid "Matches sources with a certain number of repository references"
-msgstr "Matchar källor med ett viss antal arkivplatsreferenser"
+msgstr "Matchar källor med ett visst antal arkivplatsreferenser"
 
 #: ../gramps/gen/filters/rules/source/_hasrepositorycallnumberref.py:44
 msgid "Sources with repository reference containing <text> in \"Call Number\""
-msgstr ""
-"Källor med arkivplatsreferens innehållande <delsträng> i \"Call Number\""
+msgstr "Källor med arkivplatsreferens innehållande <text> i \"Referensnummer\""
 
 #: ../gramps/gen/filters/rules/source/_hasrepositorycallnumberref.py:45
 msgid ""
@@ -6377,11 +6326,11 @@ msgid ""
 "containing a substring in \"Call Number\""
 msgstr ""
 "Matchar källor vars arkivplatsreferens\n"
-"innehåller en delsträng i \"Call Number\""
+"innehåller en delsträng i \"Referensnummer\""
 
 #: ../gramps/gen/filters/rules/source/_hastag.py:49
 msgid "Sources with the <tag>"
-msgstr "Notiser med <flagga>"
+msgstr "Källor med <flagga>"
 
 #: ../gramps/gen/filters/rules/source/_hastag.py:50
 msgid "Matches sources with the particular tag"
@@ -6404,12 +6353,12 @@ msgid ""
 "Matches sources with a repository reference that match a certain\n"
 "repository filter"
 msgstr ""
-"Matchar källor, som har en arkivplatsreferens,\n"
-"som matchar ett givet arkivplatsfilter"
+"Matchar källor med en arkivplatsreferens som matchar ett givet\n"
+" arkivplatsfilter"
 
 #: ../gramps/gen/filters/rules/source/_matchestitlesubstringof.py:43
 msgid "Sources with title containing <text>"
-msgstr "Källor med <delsträng> i titel"
+msgstr "Källor med titel innehållande <delsträng>"
 
 #: ../gramps/gen/filters/rules/source/_matchestitlesubstringof.py:44
 msgid "Matches sources whose title contains a certain substring"
@@ -6417,7 +6366,7 @@ msgstr "Matchar källor vars titel innehåller angiven delsträng"
 
 #: ../gramps/gen/filters/rules/source/_regexpidof.py:47
 msgid "Sources with Id containing <text>"
-msgstr "Källor  med Id innehållande <text>"
+msgstr "Källor med Id innehållande <text>"
 
 #: ../gramps/gen/filters/rules/source/_regexpidof.py:48
 msgid "Matches sources whose Gramps ID matches the regular expression"
@@ -6482,8 +6431,8 @@ msgstr "Adress"
 #: ../gramps/gui/glade/editnote.glade:233
 #: ../gramps/gui/glade/editperson.glade:417
 #: ../gramps/gui/glade/editpersonref.glade:158
-#: ../gramps/gui/glade/editplace.glade:328
-#: ../gramps/gui/glade/editplaceref.glade:431
+#: ../gramps/gui/glade/editplace.glade:329
+#: ../gramps/gui/glade/editplaceref.glade:432
 #: ../gramps/gui/glade/editreporef.glade:195
 #: ../gramps/gui/glade/editreporef.glade:404
 #: ../gramps/gui/glade/editrepository.glade:212
@@ -6836,7 +6785,7 @@ msgstr "Barnreferens"
 #: ../gramps/gen/lib/reporef.py:104 ../gramps/gen/lib/src.py:102
 #: ../gramps/gen/lib/tag.py:120
 msgid "Handle"
-msgstr ""
+msgstr "Hantera"
 
 #: ../gramps/gen/lib/childreftype.py:67 ../gramps/gen/plug/docgen/treedoc.py:72
 #: ../gramps/gui/configure.py:83
@@ -7010,7 +6959,6 @@ msgstr "Källattribut"
 #: ../gramps/gen/lib/note.py:122 ../gramps/gen/lib/person.py:228
 #: ../gramps/gen/lib/place.py:176 ../gramps/gen/lib/repo.py:108
 #: ../gramps/gen/lib/src.py:121 ../gramps/gen/lib/tag.py:130
-#, fuzzy
 msgid "Last changed"
 msgstr "Senast ändrad"
 
@@ -7140,14 +7088,12 @@ msgid "Calendar"
 msgstr "Kalender"
 
 #: ../gramps/gen/lib/date.py:712
-#, fuzzy
 msgid "Modifier"
-msgstr "Ändrat: "
+msgstr "Ändrat av"
 
 #: ../gramps/gen/lib/date.py:714
-#, fuzzy
 msgid "Quality"
-msgstr "K_valitet"
+msgstr "Kvalitet"
 
 #: ../gramps/gen/lib/date.py:716 ../gramps/gui/editors/filtereditor.py:820
 #: ../gramps/gui/glade/rule.glade:967
@@ -7165,19 +7111,16 @@ msgid "Text"
 msgstr "Text"
 
 #: ../gramps/gen/lib/date.py:721
-#, fuzzy
 msgid "Sort value"
-msgstr "_Sortera som:"
+msgstr "Sorteringsvärde"
 
 #: ../gramps/gen/lib/date.py:723
-#, fuzzy
 msgid "New year begins"
-msgstr "N_ytt år börjar:  "
+msgstr "Nytt år börjar"
 
 #: ../gramps/gen/lib/date.py:1856
-#, fuzzy
 msgid "date-quality|none"
-msgstr "uppskattat "
+msgstr "Ingen"
 
 #: ../gramps/gen/lib/date.py:1857
 msgid "calculated"
@@ -7188,9 +7131,8 @@ msgid "estimated"
 msgstr "uppskattad"
 
 #: ../gramps/gen/lib/date.py:1871
-#, fuzzy
 msgid "date-modifier|none"
-msgstr "före "
+msgstr "Ingen"
 
 #: ../gramps/gen/lib/date.py:1872 ../gramps/plugins/lib/libsubstkeyword.py:314
 msgid "about"
@@ -7247,7 +7189,7 @@ msgstr "Händelse"
 #: ../gramps/gui/editors/filtereditor.py:296
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:108
 #: ../gramps/gui/glade/editevent.glade:270
-#: ../gramps/gui/plug/_guioptions.py:1352
+#: ../gramps/gui/plug/_guioptions.py:1354
 #: ../gramps/gui/selectors/selectevent.py:72 ../gramps/gui/viewmanager.py:613
 #: ../gramps/gui/views/treemodels/placemodel.py:305
 #: ../gramps/plugins/export/exportcsv.py:286
@@ -7276,7 +7218,6 @@ msgid "Place"
 msgstr "Plats"
 
 #: ../gramps/gen/lib/eventref.py:95
-#, fuzzy
 msgid "Event reference"
 msgstr "Händelsereferens"
 
@@ -7702,7 +7643,7 @@ msgstr "adel"
 
 #: ../gramps/gen/lib/eventtype.py:239
 msgid "Number of Marriages abbreviation|n.o.mar."
-msgstr "a. giftenl"
+msgstr "a. giften"
 
 #: ../gramps/gen/lib/eventtype.py:240
 msgid "Occupation abbreviation|occ."
@@ -7849,7 +7790,6 @@ msgid "Events"
 msgstr "Händelser"
 
 #: ../gramps/gen/lib/family.py:174 ../gramps/gen/lib/person.py:218
-#, fuzzy
 msgid "LDS ordinances"
 msgstr "SDH-ceremoni"
 
@@ -7949,7 +7889,7 @@ msgstr "<Ingen status>"
 
 #: ../gramps/gen/lib/ldsord.py:104
 msgid "Born in Covenant"
-msgstr ""
+msgstr "Born in Covenant"
 
 #: ../gramps/gen/lib/ldsord.py:105
 msgid "Canceled"
@@ -7976,9 +7916,8 @@ msgid "Completed"
 msgstr "Färdigt"
 
 #: ../gramps/gen/lib/ldsord.py:109
-#, fuzzy
 msgid "Do not seal"
-msgstr "Skala inte om trädet"
+msgstr "Försegla inte"
 
 #: ../gramps/gen/lib/ldsord.py:110
 msgid "Infant"
@@ -7993,9 +7932,8 @@ msgid "Qualified"
 msgstr "Kvalificerad"
 
 #: ../gramps/gen/lib/ldsord.py:113
-#, fuzzy
 msgid "Do not seal/Cancel"
-msgstr "Fråga inte igen"
+msgstr "Försegla inte/Avbryt"
 
 #: ../gramps/gen/lib/ldsord.py:114
 msgid "Stillborn"
@@ -8061,11 +7999,11 @@ msgstr "Att göra"
 
 #: ../gramps/gen/lib/media.py:145
 msgid "MIME"
-msgstr ""
+msgstr "Mimetyp"
 
 #: ../gramps/gen/lib/media.py:149
 msgid "Checksum"
-msgstr ""
+msgstr "Checksum"
 
 #: ../gramps/gen/lib/mediaref.py:86 ../gramps/gui/clipboard.py:656
 msgid "Media ref"
@@ -8095,7 +8033,7 @@ msgstr "Region"
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:131
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:108
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:104
-#: ../gramps/gui/plug/_guioptions.py:1174 ../gramps/gui/plug/_windows.py:130
+#: ../gramps/gui/plug/_guioptions.py:1176 ../gramps/gui/plug/_windows.py:130
 #: ../gramps/gui/plug/_windows.py:1104
 #: ../gramps/gui/plug/report/_bookdialog.py:373
 #: ../gramps/gui/selectors/selectperson.py:93
@@ -8165,7 +8103,7 @@ msgstr "Suffix"
 #: ../gramps/gui/selectors/selectplace.py:73
 #: ../gramps/gui/selectors/selectrepository.py:69
 #: ../gramps/gui/selectors/selectsource.py:69
-#: ../gramps/gui/widgets/grampletpane.py:1570
+#: ../gramps/gui/widgets/grampletpane.py:1567
 #: ../gramps/plugins/export/exportcsv.py:286
 #: ../gramps/plugins/gramplet/persondetails.py:164
 #: ../gramps/plugins/lib/libplaceview.py:86
@@ -8179,39 +8117,34 @@ msgid "Title"
 msgstr "Titel"
 
 #: ../gramps/gen/lib/name.py:169
-#, fuzzy
 msgid "Group as"
-msgstr "G_ruppera som:"
+msgstr "Gruppera som"
 
 #: ../gramps/gen/lib/name.py:171
-#, fuzzy
 msgid "Sort as"
-msgstr "_Sortera som:"
+msgstr "Sortera efter"
 
 #: ../gramps/gen/lib/name.py:173
-#, fuzzy
 msgid "Display as"
-msgstr "_Visa som:"
+msgstr "Visa som"
 
 #: ../gramps/gen/lib/name.py:175 ../gramps/plugins/importer/importcsv.py:163
 msgid "Call name"
 msgstr "Tilltalsnamn"
 
 #: ../gramps/gen/lib/name.py:177
-#, fuzzy
 msgid "Nick name"
 msgstr "Smeknamn"
 
 #: ../gramps/gen/lib/name.py:179
-#, fuzzy
 msgid "Family nick name"
-msgstr "Familjesmeknamn:"
+msgstr "Familjesmeknamn"
 
 #. translators: needed for Arabic, ignore otherwise
 #: ../gramps/gen/lib/name.py:461 ../gramps/gen/lib/name.py:476
 #, python-format
 msgid "%(surname)s, %(first)s %(suffix)s"
-msgstr ""
+msgstr "%(surname)s, %(first)s %(suffix)s"
 
 #. translators: needed for Arabic, ignore otherwise
 #. translators: needed for Arabic, ignore othewise
@@ -8229,7 +8162,7 @@ msgstr ""
 #: ../gramps/plugins/textreport/indivcomplete.py:1017
 #, python-format
 msgid "%(str1)s, %(str2)s"
-msgstr ""
+msgstr "%(str1)s, %(str2)s"
 
 #. translators: needed for Arabic, ignore otherwise
 #: ../gramps/gen/lib/name.py:493
@@ -8337,8 +8270,8 @@ msgstr "Format"
 #: ../gramps/gui/glade/editmediaref.glade:756
 #: ../gramps/gui/glade/editname.glade:671
 #: ../gramps/gui/glade/editperson.glade:382
-#: ../gramps/gui/glade/editplaceref.glade:160
-#: ../gramps/gui/glade/editplaceref.glade:664
+#: ../gramps/gui/glade/editplaceref.glade:161
+#: ../gramps/gui/glade/editplaceref.glade:665
 #: ../gramps/gui/glade/editreporef.glade:225
 #: ../gramps/gui/glade/editreporef.glade:445
 #: ../gramps/plugins/tool/verify.glade:406
@@ -8351,7 +8284,7 @@ msgstr "Forskning"
 
 #: ../gramps/gen/lib/notetype.py:77
 msgid "Transcript"
-msgstr "Utskrift"
+msgstr "Avskrift"
 
 #: ../gramps/gen/lib/notetype.py:78
 msgid "Source text"
@@ -8371,9 +8304,8 @@ msgid "notetype|To Do"
 msgstr "Att-göra notis"
 
 #: ../gramps/gen/lib/notetype.py:83
-#, fuzzy
 msgid "notetype|Link"
-msgstr "Att-göra notis"
+msgstr "Länk"
 
 #: ../gramps/gen/lib/notetype.py:87
 msgid "Person Note"
@@ -8501,24 +8433,20 @@ msgid "Gender"
 msgstr "Kön"
 
 #: ../gramps/gen/lib/person.py:188
-#, fuzzy
 msgid "Alternate names"
 msgstr "Alternativa namn"
 
 #: ../gramps/gen/lib/person.py:190
-#, fuzzy
 msgid "Death reference index"
-msgstr "Händelsereferensnotis"
+msgstr "Dödsreferensindex"
 
 #: ../gramps/gen/lib/person.py:192
-#, fuzzy
 msgid "Birth reference index"
-msgstr "Redigera referens"
+msgstr "Födelsereferensindex"
 
 #: ../gramps/gen/lib/person.py:195
-#, fuzzy
 msgid "Event references"
-msgstr "Händelsereferens"
+msgstr "Händelsereferenser"
 
 #: ../gramps/gen/lib/person.py:199 ../gramps/plugins/graph/gvfamilylines.py:285
 #: ../gramps/plugins/graph/gvhourglass.py:381
@@ -8540,9 +8468,8 @@ msgid "Families"
 msgstr "Familjer"
 
 #: ../gramps/gen/lib/person.py:203
-#, fuzzy
 msgid "Parent families"
-msgstr "Sorterar om familjer"
+msgstr "Föräldrafamiljer"
 
 #: ../gramps/gen/lib/person.py:209 ../gramps/gen/lib/repo.py:103
 #: ../gramps/gui/merge/mergeperson.py:268
@@ -8553,10 +8480,9 @@ msgstr "Adresser"
 
 #: ../gramps/gen/lib/person.py:215
 msgid "Urls"
-msgstr ""
+msgstr "Urls"
 
 #: ../gramps/gen/lib/person.py:237
-#, fuzzy
 msgid "Person references"
 msgstr "Personreferenser"
 
@@ -8626,7 +8552,7 @@ msgstr "Alternativa platser"
 
 #: ../gramps/gen/lib/place.py:163 ../gramps/gen/lib/repo.py:106
 msgid "URLs"
-msgstr ""
+msgstr "URLs"
 
 #: ../gramps/gen/lib/placename.py:95 ../gramps/gui/clipboard.py:579
 #: ../gramps/gui/editors/editplacename.py:134
@@ -8692,7 +8618,7 @@ msgstr "Byggnad"
 #: ../gramps/plugins/webreport/basepage.py:2671
 #: ../gramps/plugins/webreport/source.py:163
 msgid "Number"
-msgstr "Nummer"
+msgstr "Antal"
 
 #. 6
 #: ../gramps/gen/lib/repo.py:86 ../gramps/gui/clipboard.py:781
@@ -8714,7 +8640,7 @@ msgstr "Arkivplatsreferens"
 #: ../gramps/gen/lib/reporef.py:107
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:68
 msgid "Call Number"
-msgstr "Klassifikationssignum"
+msgstr "Referensnummer"
 
 #: ../gramps/gen/lib/repotype.py:54
 msgid "Library"
@@ -8766,7 +8692,6 @@ msgid "Author"
 msgstr "Författare"
 
 #: ../gramps/gen/lib/src.py:110
-#, fuzzy
 msgid "Publication info"
 msgstr "Publiceringsinformation"
 
@@ -8845,14 +8770,12 @@ msgid "Video"
 msgstr "Video"
 
 #: ../gramps/gen/lib/styledtext.py:317
-#, fuzzy
 msgid "Styled Text"
-msgstr "Mallredigerare"
+msgstr "Formaterad text"
 
 #: ../gramps/gen/lib/styledtext.py:324
-#, fuzzy
 msgid "Styled Text Tags"
-msgstr "Mallredigerare"
+msgstr "Formaterade textflaggor"
 
 #: ../gramps/gen/lib/styledtexttag.py:101 ../gramps/gen/lib/tag.py:115
 #: ../gramps/gui/editors/edittaglist.py:109
@@ -8872,22 +8795,21 @@ msgid "Tag"
 msgstr "Flagga"
 
 #: ../gramps/gen/lib/styledtexttag.py:112
-#, fuzzy
 msgid "Ranges"
 msgstr "Intervall"
 
 #: ../gramps/gen/lib/styledtexttagtype.py:61
-#: ../gramps/gui/widgets/styledtexteditor.py:456
+#: ../gramps/gui/widgets/styledtexteditor.py:455
 msgid "Bold"
 msgstr "Fetstil"
 
 #: ../gramps/gen/lib/styledtexttagtype.py:62
-#: ../gramps/gui/widgets/styledtexteditor.py:454
+#: ../gramps/gui/widgets/styledtexteditor.py:453
 msgid "Italic"
 msgstr "Kursiv"
 
 #: ../gramps/gen/lib/styledtexttagtype.py:63
-#: ../gramps/gui/widgets/styledtexteditor.py:458
+#: ../gramps/gui/widgets/styledtexteditor.py:457
 msgid "Underline"
 msgstr "Understruken"
 
@@ -8915,8 +8837,8 @@ msgstr "Superskrift"
 #: ../gramps/gui/glade/editlink.glade:171
 #: ../gramps/gui/widgets/styledtextbuffer.py:565
 #: ../gramps/gui/widgets/styledtextbuffer.py:605
+#: ../gramps/gui/widgets/styledtexteditor.py:469
 #: ../gramps/gui/widgets/styledtexteditor.py:470
-#: ../gramps/gui/widgets/styledtexteditor.py:471
 msgid "Link"
 msgstr "Länk"
 
@@ -8928,7 +8850,7 @@ msgstr "Länk"
 #: ../gramps/gui/configure.py:697 ../gramps/gui/configure.py:698
 #: ../gramps/gui/configure.py:699 ../gramps/gui/configure.py:700
 #: ../gramps/gui/editors/displaytabs/surnametab.py:75
-#: ../gramps/gui/plug/_guioptions.py:88 ../gramps/gui/plug/_guioptions.py:1506
+#: ../gramps/gui/plug/_guioptions.py:88 ../gramps/gui/plug/_guioptions.py:1508
 #: ../gramps/plugins/drawreport/statisticschart.py:334
 #: ../gramps/plugins/export/exportcsv.py:354
 #: ../gramps/plugins/importer/importcsv.py:159
@@ -8948,7 +8870,6 @@ msgid "Prefix"
 msgstr "Prefix"
 
 #: ../gramps/gen/lib/surname.py:95
-#, fuzzy
 msgid "Primary"
 msgstr "Primär"
 
@@ -8961,13 +8882,13 @@ msgstr "%(first)s %(second)s"
 #: ../gramps/gen/lib/tag.py:125 ../gramps/gen/plug/docgen/treedoc.py:168
 #: ../gramps/gui/glade/styleeditor.glade:384
 #: ../gramps/gui/glade/styleeditor.glade:1433
-#: ../gramps/gui/plug/_guioptions.py:1507 ../gramps/gui/views/tags.py:411
+#: ../gramps/gui/plug/_guioptions.py:1509 ../gramps/gui/views/tags.py:411
 msgid "Color"
 msgstr "Färg"
 
 #: ../gramps/gen/lib/tag.py:128
 msgid "Priority"
-msgstr ""
+msgstr "Prioritet"
 
 #: ../gramps/gen/lib/url.py:88 ../gramps/gui/clipboard.py:418
 msgid "Url"
@@ -9135,7 +9056,7 @@ msgstr "Släktskap"
 #: ../gramps/gui/glade/grampletpane.glade:156
 #: ../gramps/gui/widgets/grampletbar.py:627
 #: ../gramps/gui/widgets/grampletpane.py:220
-#: ../gramps/gui/widgets/grampletpane.py:979
+#: ../gramps/gui/widgets/grampletpane.py:976
 msgid "Gramplet"
 msgstr "Gramplet"
 
@@ -9344,26 +9265,25 @@ msgid "Bottom"
 msgstr "Nederkant"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:91
-#, fuzzy
 msgid "Straight"
-msgstr "rak"
+msgstr "Rakt"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:92
 msgid "Curved"
-msgstr ""
+msgstr "Krökt"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:93
 msgid "Orthogonal"
-msgstr ""
+msgstr "Vinkelrät"
 
 #. ###############################
 #: ../gramps/gen/plug/docgen/graphdoc.py:134
 msgid "Graphviz Layout"
-msgstr "Graphviz Layout"
+msgstr "Graphviz-layout"
 
 #. ###############################
 #: ../gramps/gen/plug/docgen/graphdoc.py:136
-#: ../gramps/gui/widgets/styledtexteditor.py:480
+#: ../gramps/gui/widgets/styledtexteditor.py:479
 msgid "Font family"
 msgstr "Teckensnittsfamilj"
 
@@ -9377,7 +9297,7 @@ msgstr ""
 "freefont/"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:145
-#: ../gramps/gui/widgets/styledtexteditor.py:492
+#: ../gramps/gui/widgets/styledtexteditor.py:491
 msgid "Font size"
 msgstr "Typsnittsstorlek"
 
@@ -9431,18 +9351,16 @@ msgid ""
 "The order in which the graph pages are output. This option only applies if "
 "the horizontal pages or vertical pages are greater than 1."
 msgstr ""
-"Den ordning i vilket diagramsidor mats ut. Detta val är tillämpligt om antal "
-"horisontella eller vertikala sidor är större än 1."
+"Den ordning i vilket diagramsidor matas ut. Detta val är tillämpligt om "
+"antal horisontella eller vertikala sidor är större än 1."
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:180
-#, fuzzy
 msgid "Connecting lines"
-msgstr "Skapa familjer"
+msgstr "Förbinder linjer"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:183
-#, fuzzy
 msgid "How the lines between objects will be drawn."
-msgstr "Hur titeln kommer att visas."
+msgstr "Hur linjerna mellan objekt kommer att ritas."
 
 #. ###############################
 #: ../gramps/gen/plug/docgen/graphdoc.py:199
@@ -9479,7 +9397,7 @@ msgstr ""
 "aspektförhållandet.\n"
 "Om diagrammet är större än utskriftsytan:\n"
 "  Packning kommer att krympa diagrammet för att åstadkomma en tätare "
-"packaning på bekostnad av symmetri.\n"
+"packning på bekostnad av symmetri.\n"
 "  Ifyllning kommer att krympa diagrammet för att passa utskriftsytan genom "
 "att först öka nodavståndet.\n"
 "  Expandera kommer att krympa diagrammet likformigt för att passa "
@@ -9497,7 +9415,7 @@ msgid ""
 msgstr ""
 "Punkter per tum. När bilder, som .gif- eller .png-filer skapas för Internet, "
 "försök med tal som 100 eller 300 DPI. För PostScript- eller PDF-filer använd "
-"72 DPI."
+"alltid 72 DPI."
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:230
 msgid "Node spacing"
@@ -9511,7 +9429,7 @@ msgid ""
 msgstr ""
 "Det minsta fria utrymme, i tum, mellan individuella noder. För vertikala "
 "diagram motsvarar detta avståndet mellan kolumner. För horisontella diagram "
-"motsvara detta avståndet mellan rader."
+"motsvarar detta avståndet mellan rader."
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:238
 msgid "Rank spacing"
@@ -9524,20 +9442,20 @@ msgid ""
 "this corresponds to spacing between columns."
 msgstr ""
 "Det minsta fria utrymmet, i tum, mellan mellan nivåer. För vertikala diagram "
-"motsvarar detta avståndet mellan kolumner. För horisontella diagram motsvara "
-"detta avståndet mellan rader."
+"motsvarar detta avståndet mellan rader. För horisontella diagram motsvarar "
+"detta avståndet mellan kolumner."
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:246
 msgid "Use subgraphs"
-msgstr "Använd underordnade stycken"
+msgstr "Använd delgrafer"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:247
 msgid ""
 "Subgraphs can help Graphviz position spouses together, but with non-trivial "
 "graphs will result in longer lines and larger graphs."
 msgstr ""
-"Underordnade stycken kan hjälpa Graphviz att placera makar ihop, men kan "
-"även orsaka längre linjer och större diagram vid komplicerade sådana."
+"Delgrafer kan hjälpa Graphviz att placera makar ihop, men kan även orsaka "
+"längre linjer och större diagram vid komplicerade sådana."
 
 #. ###############################
 #: ../gramps/gen/plug/docgen/graphdoc.py:257
@@ -9606,11 +9524,11 @@ msgstr "Graphviz-fil"
 
 #: ../gramps/gen/plug/docgen/paperstyle.py:78
 msgid "paper size|Letter"
-msgstr "paper size|Letter"
+msgstr "Letter"
 
 #: ../gramps/gen/plug/docgen/paperstyle.py:80
 msgid "paper size|Legal"
-msgstr "paper size|Legal"
+msgstr "Legal"
 
 #: ../gramps/gen/plug/docgen/paperstyle.py:82
 msgid "Custom Size"
@@ -9622,9 +9540,8 @@ msgstr "Anpassad storlek"
 #.
 #. -------------------------------------------------------------------------
 #: ../gramps/gen/plug/docgen/treedoc.py:63
-#, fuzzy
 msgid "Full"
-msgstr "Komplett namn"
+msgstr "Full"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:64
 #: ../gramps/plugins/tool/finddupes.py:61
@@ -9633,21 +9550,19 @@ msgstr "Medel"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:65
 msgid "Short"
-msgstr ""
+msgstr "Kort"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:68
 msgid "Above"
-msgstr ""
+msgstr "Över"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:69
-#, fuzzy
 msgid "Below"
-msgstr "U_nder:"
+msgstr "Under"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:70
-#, fuzzy
 msgid "Not shown"
-msgstr "Inga föräldrar hittades"
+msgstr "Visas inte"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:74 ../gramps/gui/configure.py:158
 #: ../gramps/gui/configure.py:1715 ../gramps/gui/views/pageview.py:606
@@ -9656,55 +9571,51 @@ msgstr "Inställningar"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:76
 msgid "Down (↓)"
-msgstr ""
+msgstr "Ned (↓)"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:77
 msgid "Up (↑)"
-msgstr ""
+msgstr "Upp (↑)"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:78
-#, fuzzy
 msgid "Right (→)"
-msgstr "Höger"
+msgstr "Höger (→)"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:79
 msgid "Left (←)"
-msgstr ""
+msgstr "Vänster (←)"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:81
 msgid "Perpendicular"
-msgstr ""
+msgstr "Vinkelrätt"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:82
-#, fuzzy
 msgid "Rounded"
-msgstr "odefinierad"
+msgstr "Avrundad"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:83
 msgid "Swing"
-msgstr ""
+msgstr "Swing"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:84
 msgid "Mesh"
-msgstr ""
+msgstr "Mesh"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:89
 msgid "Tiny"
-msgstr ""
+msgstr "Mycket liten"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:90
-#, fuzzy
 msgid "Script"
-msgstr "PostScript"
+msgstr "Script"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:91
-#, fuzzy
 msgid "Footnote"
-msgstr "Sidfot"
+msgstr "Fotnot"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:92
 msgid "Small"
-msgstr ""
+msgstr "Liten"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:93 ../gramps/gen/utils/string.py:57
 #: ../gramps/gui/editors/editcitation.py:212
@@ -9715,73 +9626,69 @@ msgstr "Normal"
 #: ../gramps/gen/plug/docgen/treedoc.py:94
 #: ../gramps/plugins/graph/gvfamilylines.py:256
 msgid "Large"
-msgstr ""
+msgstr "Stor"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:95
-#, fuzzy
 msgid "Very large"
-msgstr "Alla platser"
+msgstr "Mycket stor"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:96
-#, fuzzy
 msgid "Extra large"
-msgstr "Extrahera platsdata"
+msgstr "Extra stor"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:97
 msgid "Huge"
-msgstr ""
+msgstr "Enorm"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:98
 msgid "Extra huge"
-msgstr ""
+msgstr "Extra stor"
 
 #. ###############################
 #: ../gramps/gen/plug/docgen/treedoc.py:141
-#, fuzzy
 msgid "Node Options"
-msgstr "Trädalternativ"
+msgstr "Nodalternativ"
 
 #. ###############################
 #: ../gramps/gen/plug/docgen/treedoc.py:144
-#, fuzzy
 msgid "Node detail"
-msgstr "Se detaljer"
+msgstr "Noddetaljer"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:147
 msgid "Detail of information to be shown in a node."
-msgstr ""
+msgstr "Detaljerad information som ska visas i en nod."
 
 #: ../gramps/gen/plug/docgen/treedoc.py:153
-#, fuzzy
 msgid "Position of marriage information."
-msgstr "Ta med giftermålsinformation"
+msgstr "Positionen för vigselinformationen."
 
 #: ../gramps/gen/plug/docgen/treedoc.py:156
-#, fuzzy
 msgid "Node size"
-msgstr "Notisstorlek"
+msgstr "Nodstorlek"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:157
 msgid ""
 "One dimension of a node, in mm. If the timeflow is up or down then this is "
 "the width, otherwise it is the height."
 msgstr ""
+"En storlek av en nod, i mm. Om tidsflödet är upp eller ned är detta bredden, "
+"annars är det höjden."
 
 #: ../gramps/gen/plug/docgen/treedoc.py:162
-#, fuzzy
 msgid "Level size"
-msgstr "Trädstorlek"
+msgstr "Nivåstorlek"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:163
 msgid ""
 "One dimension of a node, in mm. If the timeflow is up or down then this is "
 "the height, otherwise it is the width."
 msgstr ""
+"En storlek av en nod, i mm. Om tidsflödet är upp eller ned är detta höjden, "
+"annars är det bredden."
 
 #: ../gramps/gen/plug/docgen/treedoc.py:171
-#, fuzzy
 msgid "Node color."
-msgstr "Färg för kön"
+msgstr "Nodfärg."
 
 #. ###############################
 #. #################
@@ -9793,62 +9700,55 @@ msgstr "Trädalternativ"
 
 #. ###############################
 #: ../gramps/gen/plug/docgen/treedoc.py:178
-#, fuzzy
 msgid "Timeflow"
-msgstr "Tidpunkt"
+msgstr "Tidsflöde"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:181
 msgid "Direction that the graph will grow over time."
-msgstr ""
+msgstr "Riktningen som ett diagram kommer växa med tiden."
 
 #: ../gramps/gen/plug/docgen/treedoc.py:184
-#, fuzzy
 msgid "Edge style"
-msgstr "Trädmall"
+msgstr "Kantstil"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:187
 msgid "Style of the edges between nodes."
-msgstr ""
+msgstr "Stilen på kanterna mellan noder."
 
 #: ../gramps/gen/plug/docgen/treedoc.py:190
 msgid "Level distance"
-msgstr ""
+msgstr "Nivåavstånd"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:191
-#, fuzzy
 msgid ""
 "The minimum amount of free space, in mm, between levels.  For vertical "
 "graphs, this corresponds to spacing between rows.  For horizontal graphs, "
 "this corresponds to spacing between columns."
 msgstr ""
-"Det minsta fria utrymmet, i tum, mellan mellan nivåer. För vertikala diagram "
-"motsvarar detta avståndet mellan kolumner. För horisontella diagram motsvara "
-"detta avståndet mellan rader."
+"Det minsta fria utrymmet, i mm, mellan mellan nivåer. För vertikala diagram "
+"motsvarar detta avståndet mellan rader. För horisontella diagram motsvarar "
+"detta avståndet mellan kolumner."
 
 #. ###############################
 #: ../gramps/gen/plug/docgen/treedoc.py:202
-#, fuzzy
 msgid "Note to add to the tree"
-msgstr "Notis att lägga till grafen"
+msgstr "Notis att lägga till trädet"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:203
-#, fuzzy
 msgid "This text will be added to the tree."
-msgstr "Den här texten läggs till grafen."
+msgstr "Den här texten läggs till trädet."
 
 #: ../gramps/gen/plug/docgen/treedoc.py:216
-#, fuzzy
 msgid "The size of note text."
-msgstr "Storlek på notis, i punkter."
+msgstr "Storleken på notistexten."
 
 #: ../gramps/gen/plug/docgen/treedoc.py:653
 msgid "PDF"
-msgstr ""
+msgstr "PDF"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:659
-#, fuzzy
 msgid "LaTeX File"
-msgstr "LaTeX-dokument"
+msgstr "LaTeX-fil"
 
 #: ../gramps/gen/plug/menu/_enumeratedlist.py:142
 #, python-format
@@ -9857,9 +9757,8 @@ msgstr "Värde '%(val)s' ej hittat för valet '%(opt)s'"
 
 #: ../gramps/gen/plug/menu/_enumeratedlist.py:144
 #: ../gramps/gen/plug/report/stdoptions.py:283
-#, fuzzy
 msgid "Valid values: "
-msgstr "Värden"
+msgstr "Giltiga värden: "
 
 #. ------------------------------------------------------------------------
 #.
@@ -9896,9 +9795,8 @@ msgid "Graphs"
 msgstr "Diagram"
 
 #: ../gramps/gen/plug/report/_constants.py:51
-#, fuzzy
 msgid "Trees"
-msgstr "Trädstorlek"
+msgstr "Träd"
 
 #: ../gramps/gen/plug/report/_constants.py:55
 msgid "Graphics"
@@ -9915,24 +9813,23 @@ msgstr "Mall som används för generationsrubriken."
 #: ../gramps/gen/plug/report/endnotes.py:68
 msgid "The basic style used for the endnotes source display."
 msgstr ""
-"Den grundläggande mall, som används vid visning av notförteckningen över "
-"källor."
+"Den grundläggande mall, som används vid visning av slutnoterna för källor."
 
 #: ../gramps/gen/plug/report/endnotes.py:76
 msgid "The basic style used for the endnotes notes display."
 msgstr ""
-"Den grundläggande mall, som används vid visning av notförteckningens notiser."
+"Den grundläggande mall, som används vid visning av slutnoternas notiser."
 
 #: ../gramps/gen/plug/report/endnotes.py:84
 msgid "The basic style used for the endnotes reference display."
 msgstr ""
-"Den grundläggande mall, som används vid visning av notförteckningen över "
+"Den grundläggande mall, som används vid visning av slutnoterna för "
 "referenser."
 
 #: ../gramps/gen/plug/report/endnotes.py:92
 msgid "The basic style used for the endnotes reference notes display."
 msgstr ""
-"Den grundläggande mall, som används vid visning av notförteckningen över "
+"Den grundläggande mall, som används vid visning av slutnoterna för "
 "referensnotiser."
 
 #: ../gramps/gen/plug/report/endnotes.py:156
@@ -10016,23 +9913,23 @@ msgstr "Levande personer"
 
 #: ../gramps/gen/plug/report/stdoptions.py:174
 msgid "'living people'|Included, and all data"
-msgstr ""
+msgstr "Medtagna, och all data"
 
 #: ../gramps/gen/plug/report/stdoptions.py:178
 msgid "'living people'|Full names, but data removed"
-msgstr ""
+msgstr "Hela namn, men data borttaget"
 
 #: ../gramps/gen/plug/report/stdoptions.py:180
 msgid "'living people'|Given names replaced, and data removed"
-msgstr ""
+msgstr "Förnamn utbytta, och data borttaget"
 
 #: ../gramps/gen/plug/report/stdoptions.py:182
 msgid "'living people'|Complete names replaced, and data removed"
-msgstr ""
+msgstr "Hela namn utbytta, och data borttaget"
 
 #: ../gramps/gen/plug/report/stdoptions.py:184
 msgid "'living people'|Not included"
-msgstr ""
+msgstr "Ej medtagna"
 
 #. for deferred translation
 #: ../gramps/gen/plug/report/stdoptions.py:186
@@ -10044,9 +9941,8 @@ msgid "Years from death to consider living"
 msgstr "År från död att ses som levande"
 
 #: ../gramps/gen/plug/report/stdoptions.py:192
-#, fuzzy
 msgid "Whether to restrict data on recently-dead people"
-msgstr "Begränsa information om nu le_vande personer"
+msgstr "Huruvida begränsa data för nyligen döda personer"
 
 #: ../gramps/gen/plug/report/stdoptions.py:257 ../gramps/gui/configure.py:1058
 msgid "Date format"
@@ -10054,7 +9950,7 @@ msgstr "Datumformat"
 
 #: ../gramps/gen/plug/report/stdoptions.py:260
 msgid "The format and language for dates, with examples"
-msgstr ""
+msgstr "Formatet och språket för datum, med exempel"
 
 #: ../gramps/gen/plug/report/stdoptions.py:322
 msgid "Do not include"
@@ -10078,7 +9974,7 @@ msgstr "Huruvida och var ta med Gramps ID"
 #. #########################
 #. ###############################
 #: ../gramps/gen/plug/report/stdoptions.py:328
-#: ../gramps/gui/viewmanager.py:1931
+#: ../gramps/gui/viewmanager.py:1929
 #: ../gramps/plugins/graph/gvfamilylines.py:211
 #: ../gramps/plugins/graph/gvrelgraph.py:819
 #: ../gramps/plugins/textreport/detancestralreport.py:892
@@ -10090,19 +9986,16 @@ msgid "Include"
 msgstr "Ta med"
 
 #: ../gramps/gen/plug/report/stdoptions.py:329
-#, fuzzy
 msgid "Whether to include Gramps IDs"
-msgstr "Huruvida och var ta med Gramps ID"
+msgstr "Huruvida ta med Gramps ID"
 
 #: ../gramps/gen/plug/report/stdoptions.py:337 ../gramps/gui/configure.py:1072
-#, fuzzy
 msgid "Place format"
-msgstr "Pappersformat"
+msgstr "Platsformat"
 
 #: ../gramps/gen/plug/report/stdoptions.py:341
-#, fuzzy
 msgid "Select the format to display places"
-msgstr "Välj format vid namnvisning"
+msgstr "Välj format för platsvisning"
 
 #: ../gramps/gen/plug/report/utils.py:158
 #: ../gramps/plugins/textreport/indivcomplete.py:918
@@ -10133,7 +10026,7 @@ msgstr "Hela databasen"
 
 #. feature request 2356: avoid genitive form
 #: ../gramps/gen/plug/report/utils.py:301
-#: ../gramps/gui/plug/export/_exportoptions.py:452
+#: ../gramps/gui/plug/export/_exportoptions.py:455
 #: ../gramps/plugins/textreport/descendreport.py:488
 #, python-format
 msgid "Descendants of %s"
@@ -10142,48 +10035,47 @@ msgstr "Ättlingar till %s"
 #. feature request 2356: avoid genitive form
 #: ../gramps/gen/plug/report/utils.py:305
 #: ../gramps/gen/plug/report/utils.py:382
-#: ../gramps/gui/plug/export/_exportoptions.py:457
+#: ../gramps/gui/plug/export/_exportoptions.py:460
 #, python-format
 msgid "Descendant Families of %s"
 msgstr "Ättlingafamiljer till %s"
 
 #. feature request 2356: avoid genitive form
 #: ../gramps/gen/plug/report/utils.py:309
-#: ../gramps/gui/plug/export/_exportoptions.py:462
+#: ../gramps/gui/plug/export/_exportoptions.py:465
 #, python-format
 msgid "Ancestors of %s"
 msgstr "Anor till %s"
 
 #: ../gramps/gen/plug/report/utils.py:312
-#: ../gramps/gui/plug/export/_exportoptions.py:466
+#: ../gramps/gui/plug/export/_exportoptions.py:469
 #, python-format
 msgid "People with common ancestor with %s"
 msgstr "Personer med ana gemensam med %s"
 
-#: ../gramps/gen/plug/report/utils.py:354 ../gramps/gui/plug/_guioptions.py:895
+#: ../gramps/gen/plug/report/utils.py:354 ../gramps/gui/plug/_guioptions.py:897
 msgid "unknown father"
 msgstr "okänd far"
 
-#: ../gramps/gen/plug/report/utils.py:360 ../gramps/gui/plug/_guioptions.py:901
+#: ../gramps/gen/plug/report/utils.py:360 ../gramps/gui/plug/_guioptions.py:903
 msgid "unknown mother"
 msgstr "okänd mor"
 
-#: ../gramps/gen/plug/report/utils.py:362 ../gramps/gui/plug/_guioptions.py:903
+#: ../gramps/gen/plug/report/utils.py:362 ../gramps/gui/plug/_guioptions.py:905
 #, python-format
 msgid "%(father_name)s and %(mother_name)s (%(family_id)s)"
 msgstr "%(father_name)s och %(mother_name)s (%(family_id)s)"
 
 #. Do this in case of command line options query (show=filter)
 #: ../gramps/gen/plug/report/utils.py:369
-#, fuzzy
 msgid "FAMILY"
-msgstr "FAMILJESMEKNAMN"
+msgstr "FAMILJ"
 
 #. feature request 2356: avoid genitive form
 #: ../gramps/gen/plug/report/utils.py:386
-#, fuzzy, python-format
+#, python-format
 msgid "Ancestor Families of %s"
-msgstr "Anor till %s"
+msgstr "Anfamiljer för %s"
 
 #: ../gramps/gen/plug/utils.py:250
 msgid "Updated"
@@ -10191,7 +10083,7 @@ msgstr "Uppdaterade"
 
 #: ../gramps/gen/plug/utils.py:262
 msgid "updates|New"
-msgstr "Nya"
+msgstr "Ny"
 
 #: ../gramps/gen/plug/utils.py:291 ../gramps/gen/plug/utils.py:298
 #, python-format
@@ -10241,7 +10133,7 @@ msgstr "Den är för version %(v1)d.%(v2)d"
 #: ../gramps/gen/plug/utils.py:368
 #, python-format
 msgid "Error: missing gramps_target_version in '%s'..."
-msgstr "Fel: saknar gramps_target_version  i '%s'..."
+msgstr "Fel: saknar gramps_target_version i '%s'..."
 
 #: ../gramps/gen/plug/utils.py:380
 #, python-format
@@ -10254,9 +10146,9 @@ msgid "Registered '%s'"
 msgstr "Registrerade '%s'"
 
 #: ../gramps/gen/recentfiles.py:204
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "Unable to save list of recent DBs file {fname}: {error}"
-msgstr "Kan ej öppna lista med nyligen använd DBs-fil {fname}: {error}"
+msgstr "Kan ej spara lista med nyligen använd DBs-fil {fname}: {error}"
 
 #: ../gramps/gen/recentfiles.py:265
 #, python-brace-format
@@ -10271,10 +10163,10 @@ msgid ""
 "If you're sure there is no problem with other files, delete it, and restart "
 "Gramps."
 msgstr ""
-"Fel vid parsing lista med nyligen använd DBs från fil {fname}: {error}.\n"
+"Fel vid tolkning av lista med nyligen använd DBs från fil {fname}: {error}.\n"
 "Detta kan indikera en skada på dina filer.\n"
-"Om dun är säker på på att det inte är några problem med andra filer, tag "
-"bort den och strta om Gramps."
+"Om du är säker på att det inte är några problem med andra filer, tag bort "
+"den och starta om Gramps."
 
 #: ../gramps/gen/relationship.py:1273
 #: ../gramps/plugins/view/pedigreeview.py:1531
@@ -10289,7 +10181,7 @@ msgid ""
 msgstr ""
 "Släktträd når bakåt längre än det maximalt antal av %d generationer, som "
 "genomsökts.\n"
-"Det är möjligt att släktskap har missats."
+"Det är möjligt att släktskap har missats"
 
 #: ../gramps/gen/relationship.py:1406
 msgid "Relationship loop detected:"
@@ -10298,7 +10190,7 @@ msgstr "Släktskapsslinga upptäckt:"
 #: ../gramps/gen/relationship.py:1407
 #, python-format
 msgid "Person %(person)s connects to himself via %(relation)s"
-msgstr "Person %(person)s länkar till själv via %(relation)s"
+msgstr "Person %(person)s länkar till sig själv via %(relation)s"
 
 #: ../gramps/gen/relationship.py:1685
 msgid "undefined"
@@ -10435,11 +10327,11 @@ msgstr "syskons dödsrelaterat datum"
 
 #: ../gramps/gen/utils/alive.py:235 ../gramps/gen/utils/alive.py:246
 msgid "a spouse's birth-related date, "
-msgstr "en make/makas födelserelaterat datum"
+msgstr "en make/makas födelserelaterat datum "
 
 #: ../gramps/gen/utils/alive.py:239 ../gramps/gen/utils/alive.py:250
 msgid "a spouse's death-related date, "
-msgstr "en make/makas dödsrelaterat datum"
+msgstr "en make/makas dödsrelaterat datum, "
 
 #: ../gramps/gen/utils/alive.py:268
 msgid "event with spouse"
@@ -10507,6 +10399,9 @@ msgid ""
 "%(file)s\n"
 "because %(error)s -- recreating it\n"
 msgstr ""
+"VARNING: kunde inte tolka filen:\n"
+"%(file)s\n"
+"på grund av %(error)s -- återskapar den\n"
 
 #: ../gramps/gen/utils/db.py:294 ../gramps/gen/utils/db.py:313
 #, python-format
@@ -10689,7 +10584,7 @@ msgstr "Förenklad kinesiska"
 
 #: ../gramps/gen/utils/grampslocale.py:112
 msgid "Chinese (Hong Kong)"
-msgstr "Hong Kong-kinesiska "
+msgstr "Hong Kong-kinesiska"
 
 #: ../gramps/gen/utils/grampslocale.py:113
 msgid "Chinese (Traditional)"
@@ -10733,7 +10628,7 @@ msgstr "filtret"
 
 #: ../gramps/gen/utils/grampslocale.py:914
 msgid "the citation"
-msgstr "Varje citering"
+msgstr "citeringen"
 
 #: ../gramps/gen/utils/grampslocale.py:916
 msgid "See details"
@@ -10744,8 +10639,8 @@ msgid ""
 "WARNING: PIL module not loaded.  Image cropping in report files will be "
 "impaired."
 msgstr ""
-"VARNING: PIL modul ej laddad.  Bildhantering i rapportfiler kommer ej vara "
-"tillgänglig."
+"VARNING: PIL modul ej laddad.  Bildbeskärning i rapportfiler kommer inte att "
+"fungera."
 
 #: ../gramps/gen/utils/keyword.py:54
 msgid "Person|TITLE"
@@ -10981,8 +10876,8 @@ msgid ""
 "The data can only be recovered by Undo operation or by quitting with "
 "abandoning changes."
 msgstr ""
-"Data kan endast återhämtas genom operationen \n"
-"'Redigera->Ångra' eller genom att avsluta med 'Avbryt'."
+"Data kan endast återhämtas genom operationen 'Redigera->Ångra' eller genom "
+"att avsluta med 'Avbryt'."
 
 #: ../gramps/gen/utils/unknown.py:140
 msgid "Unknown, created to replace a missing note object."
@@ -11012,7 +10907,7 @@ msgstr ""
 "Din Python-version möter inte kraven. Åtminstone python %(v1)d.%(v2)d.%(v3)d "
 "behövs för att starta Gramps.\n"
 "\n"
-"Gramps kommer att avslutas nu.."
+"Gramps kommer att avslutas nu."
 
 #: ../gramps/grampsapp.py:414 ../gramps/grampsapp.py:421
 #: ../gramps/grampsapp.py:465
@@ -11061,17 +10956,17 @@ msgstr "Bidrag av"
 #. TRANSLATORS: Translate this to your name in your native language
 #: ../gramps/gui/aboutdialog.py:120
 msgid "translator-credits"
-msgstr "Översättarförtjänst"
+msgstr "Peter Landgren, Pär Ekholm"
 
 #: ../gramps/gui/aboutdialog.py:131
-#, fuzzy, python-format
+#, python-format
 msgid "Distribution: %s"
-msgstr "Beskrivning: "
+msgstr "Distribution: %s"
 
 #: ../gramps/gui/aboutdialog.py:142
-#, fuzzy, python-format
+#, python-format
 msgid "OS: %s"
-msgstr ": %s\n"
+msgstr "OS: %s"
 
 #: ../gramps/gui/clipboard.py:70
 msgid "manual|Using_the_Clipboard"
@@ -11129,7 +11024,7 @@ msgstr "Gör %s aktiv"
 #: ../gramps/gui/clipboard.py:1551
 #, python-format
 msgid "the object|Create Filter from %s selected..."
-msgstr "Skapa filter från valda %s..."
+msgstr "Skapa filter från %s valda..."
 
 #: ../gramps/gui/columnorder.py:89
 #, python-format
@@ -11142,7 +11037,7 @@ msgstr "Drag och släpp kolumner för att ändra ordning"
 
 #: ../gramps/gui/columnorder.py:107 ../gramps/gui/configure.py:1615
 #: ../gramps/gui/configure.py:1637 ../gramps/gui/configure.py:1660
-#: ../gramps/gui/plug/_dialogs.py:130 ../gramps/gui/viewmanager.py:2002
+#: ../gramps/gui/plug/_dialogs.py:130 ../gramps/gui/viewmanager.py:2001
 #: ../gramps/plugins/lib/maps/geography.py:1011
 #: ../gramps/plugins/lib/maps/geography.py:1266
 msgid "_Apply"
@@ -11189,7 +11084,7 @@ msgstr "Redigerare för namnvisning"
 #: ../gramps/gui/glade/updateaddons.glade:25 ../gramps/gui/plug/_windows.py:105
 #: ../gramps/gui/plug/_windows.py:691 ../gramps/gui/plug/_windows.py:747
 #: ../gramps/gui/plug/quick/_textbufdoc.py:60 ../gramps/gui/undohistory.py:90
-#: ../gramps/gui/viewmanager.py:543 ../gramps/gui/viewmanager.py:1866
+#: ../gramps/gui/viewmanager.py:543 ../gramps/gui/viewmanager.py:1864
 #: ../gramps/gui/views/bookmarks.py:286 ../gramps/gui/views/tags.py:432
 #: ../gramps/gui/widgets/grampletbar.py:635
 #: ../gramps/gui/widgets/grampletpane.py:232
@@ -11199,7 +11094,6 @@ msgid "_Close"
 msgstr "_Stäng"
 
 #: ../gramps/gui/configure.py:112
-#, fuzzy
 msgid ""
 "The following keywords are replaced with the appropriate name parts:<tt>\n"
 "  <b>Given</b>   - given name (first name)     <b>Surname</b>  - surnames "
@@ -11230,36 +11124,36 @@ msgid ""
 "     <i>Dr.</i>: Title, <i>Sr</i>: Suffix, <i>Ed</i>: Nickname, "
 "<i>Underhills</i>: Familynick, <i>Jose</i>: Call.\n"
 msgstr ""
-"Följande nyckelord kommer att ersättas av passande namndelar:\n"
-"<tt>  \n"
-"  <b>Förnamn</b>           - namn vid dop (första namn)\n"
-"  <b>Efternamn</b>         - efternamn (med prefix och bindeord)\n"
-"  <b>Titel</b>             - titel (Dr., Fru)\n"
-"  <b>Suffix</b>            - suffix (Jr., Sr.)\n"
-"  <b>Tilltalsnamn</b>      - tilltalsnamn\n"
-"  <b>Smeknamn</b>          - smeknamn\n"
-"  <b>Initialer</b>         - första bokstäver i dopnamn\n"
-"  <b>Vanligt</b>           - smeknamn, annars första i dopnamn\n"
-"  <b>Huvudnamn, Huvud namn[pre] eller [eft] eller [bnd]</b>       - komplett "
-"efternamn, prefix, endast efternamn, bindord\n"
-"  <b>Patronymikon, Patronymikon[pre] eller [eft] eller [bnd]</b>  - pa/ma-"
-"tronymiskt efternamn, prefix, endast efternamn, bindord\n"
-"  <b>Familjesmeknamn</b>   - familjesmeknamn\n"
-"  <b>Rest</b>              - resterande delar av efternamn\n"
-"  <b>Totalefternamn</b>    - efternamn (inga prefix eller bindeord)\n"
-"\n"
+"Följande nyckelord kommer att ersättas av passande namndelar:<tt>\n"
+"  <b>Förnamn</b>   - förnamn     <b>Efternamn</b>  - efternamn (med prefix "
+"och bindeord)\n"
+"  <b>Titel</b>   - titel (Dr., Fru)           <b>Suffix</b>   - suffix (Jr., "
+"Sr.)\n"
+"  <b>Tilltalsnamn</b>    - tilltalsnamn                   <b>Smeknamn</b> - "
+"smeknamn\n"
+"  <b>Initialer</b>- första bokstäver i förnamn      <b>Vanligt</b>   - "
+"smeknamn, annars första i dopnamn\n"
+"  <b>Prefix</b>  - alla prefix (von, de)\n"
+"Efternamn:\n"
+"  <b>Resten</b>      - inga huvudnamn    <b>Inga patronymikon</b>- alla "
+"efternamn, utom pa/matronymikon &amp; huvudnamn\n"
+"  <b>Familjesmeknamn</b>- familjesmeknamn        <b>Totalefternamn</b>  - "
+"efternamn (inga prefix eller bindeord)\n"
+"  <b>Huvudnamn, Huvudnamn[pre] eller [eft] eller [bnd]</b>- hela huvudnamn, "
+"prefix, endast efternamn, bindeord\n"
+"  <b>Patronymikon, eller [pre] eller [eft] eller [bnd]</b> - hela pa/"
+"matronymikon, prefix, endast efternamn, bindeord\n"
 "</tt>\n"
-"Använd samma nyckelord med STORA BOKSTÄVER för att få stora bokstäver. "
-"Parenteser och komman\n"
-"tas bort runt tomma fält. Annan text visas som den är.\n"
+"Använd samma nyckelord med STORA BOKSTÄVER för att få stora bokstäver, "
+"Parenteser och komman tas bort. Annan text visas som den är.\n"
 "\n"
-"<b>Example</b>: 'Dr. Edwin Jose von der Smith and Weston Wilson Sr (\"Ed\") "
-"- Underhills'\n"
-"     <i>Edwin Jose</i> är dopnamn, <i>von der</i> är prefixet, <i>Smith</i> "
-"och <i>Weston</i> efternamn, \n"
-"     <i>and</i> ett bindeord, <i>Wilson</i> patronymiskt efterman, <i>Dr.</"
-"i> titel, <i>Sr</i> suffix, <i>Ed</i> smeknamn, \n"
-"     <i>Underhills</i> familjesmeknamn, <i>Jose</i> tilltalsnamn.\n"
+"<b>Exempel</b>: Dr. Edwin Jose von der Smith and Weston Wilson Sr (\"Ed\") - "
+"Underhills\n"
+"     <i>Edwin Jose</i>:är dopnamn, <i>von der</i>: är prefixet, <i>Smith</i> "
+"och <i>Weston</i>: huvudefternamn, <i>och</i>: ett bindeord, <i>Wilson</i>: "
+"är ett patronymiskt efternamn,\n"
+"     <i>Dr.</i>: är titel, <i>Sr</i>: är suffix, <i>Ed</i>: smeknamn, "
+"<i>Underhills</i>: är familjesmeknamn, <i>Jose</i>: är tilltalsnamn.\n"
 
 #: ../gramps/gui/configure.py:140
 msgid " Name Editor"
@@ -11284,9 +11178,9 @@ msgstr "Ogiltig eller ofullständig formatdefinition."
 #: ../gramps/gui/configure.py:1515 ../gramps/gui/configure.py:1570
 #: ../gramps/gui/views/navigationview.py:358
 #: ../gramps/plugins/gramplet/sessionloggramplet.py:90
-#, fuzzy, python-format
+#, python-format
 msgid "%s: "
-msgstr "   %s: %s"
+msgstr "%s: "
 
 #: ../gramps/gui/configure.py:533
 msgid ""
@@ -11294,7 +11188,7 @@ msgid ""
 "Family Tree"
 msgstr ""
 "Skriv in information om dig, så personer kan ta kontakt med dig, när du "
-"slickar ut ditt släktträd"
+"skickar ut ditt släktträd"
 
 #: ../gramps/gui/configure.py:540
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:75
@@ -11329,76 +11223,62 @@ msgid "Set the colors used for boxes in the graphical views"
 msgstr "Bestäm färg att användas till rutor i de grafiska vyerna"
 
 #: ../gramps/gui/configure.py:588
-#, fuzzy
 msgid "Light colors"
-msgstr "Släktfärger"
+msgstr "Ljusa färger"
 
 #: ../gramps/gui/configure.py:589
-#, fuzzy
 msgid "Dark colors"
-msgstr "Markeringsfärger"
+msgstr "Mörka färger"
 
 #: ../gramps/gui/configure.py:594
-#, fuzzy
 msgid "Color scheme"
-msgstr "Färg"
+msgstr "Färgschema"
 
 #: ../gramps/gui/configure.py:598
-#, fuzzy
 msgid "Restore to defaults"
-msgstr "Återställ till standard?"
+msgstr "Återställ till standard"
 
 #: ../gramps/gui/configure.py:604
-#, fuzzy
 msgid "Male Alive"
 msgstr "Levande mansperson"
 
 #: ../gramps/gui/configure.py:605
-#, fuzzy
 msgid "Male Dead"
-msgstr "Manlig hustru"
+msgstr "Död mansperson"
 
 #: ../gramps/gui/configure.py:606
-#, fuzzy
 msgid "Female Alive"
 msgstr "Levande kvinnoperson"
 
 #: ../gramps/gui/configure.py:607
-#, fuzzy
 msgid "Female Dead"
-msgstr "Kvinnor: %d"
+msgstr "Död kvinnoperson"
 
 #: ../gramps/gui/configure.py:608
-#, fuzzy
 msgid "Unknown Alive"
 msgstr "Levande av okänt kön"
 
 #: ../gramps/gui/configure.py:609
-#, fuzzy
 msgid "Unknown Dead"
-msgstr "Okänd flagga"
+msgstr "Död av okänt kön"
 
 #: ../gramps/gui/configure.py:610
-#, fuzzy
 msgid "Family Node"
-msgstr "Familjenotis"
+msgstr "Familjenod"
 
 #: ../gramps/gui/configure.py:611
-#, fuzzy
 msgid "Family Divorced"
-msgstr "Familjekällor"
+msgstr "Skild familj"
 
 #: ../gramps/gui/configure.py:612
-#, fuzzy
 msgid "Home Person"
-msgstr "Hemperson är inte bestämd."
+msgstr "Hemperson"
 
 #: ../gramps/gui/configure.py:613
 msgid "Border Male Alive"
 msgstr "Kant för levande mansperson"
 
 #: ../gramps/gui/configure.py:614
-#, fuzzy
 msgid "Border Male Dead"
 msgstr "Kant för död mansperson"
 
@@ -11407,7 +11287,6 @@ msgid "Border Female Alive"
 msgstr "Kant för levande kvinnoperson"
 
 #: ../gramps/gui/configure.py:616
-#, fuzzy
 msgid "Border Female Dead"
 msgstr "Kant för död kvinnoperson"
 
@@ -11416,23 +11295,20 @@ msgid "Border Unknown Alive"
 msgstr "Kant för levande av okänt kön"
 
 #: ../gramps/gui/configure.py:618
-#, fuzzy
 msgid "Border Unknown Dead"
-msgstr "Kant för person av okänt kön"
+msgstr "Kant för död av okänt kön"
 
 #: ../gramps/gui/configure.py:619
-#, fuzzy
 msgid "Border Family"
-msgstr "Slå samman familj"
+msgstr "Kant för familj"
 
 #: ../gramps/gui/configure.py:620
-#, fuzzy
 msgid "Border Family Divorced"
-msgstr "Kant för levande kvinnoperson"
+msgstr "Kant för skild familj"
 
 #: ../gramps/gui/configure.py:628
 msgid "Colors"
-msgstr "Färg"
+msgstr "Färger"
 
 #: ../gramps/gui/configure.py:647
 msgid "Suppress warning when adding parents to a child."
@@ -11469,7 +11345,7 @@ msgstr "IckePatronymikon"
 
 #: ../gramps/gui/configure.py:778
 msgid "Enter to save, Esc to cancel editing"
-msgstr "Vagnretur för att spara, Esc för att avbryta redigering"
+msgstr "Retur för att spara, Esc för att avbryta redigering"
 
 #: ../gramps/gui/configure.py:825
 msgid "This format exists already."
@@ -11496,7 +11372,7 @@ msgstr "Exempel"
 #: ../gramps/gui/widgets/fanchart.py:1791
 #: ../gramps/plugins/view/pedigreeview.py:1628
 msgid "_Add"
-msgstr "_Lägg till..."
+msgstr "_Lägg till"
 
 #: ../gramps/gui/configure.py:897
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:149
@@ -11546,7 +11422,7 @@ msgstr "Överväg enkelt patro/matronymikon som efternamn"
 
 #: ../gramps/gui/configure.py:1085
 msgid "Enable automatic place title generation"
-msgstr "Tillåt automatisk skapande av platstitel."
+msgstr "Tillåt automatisk skapande av platstitel"
 
 #: ../gramps/gui/configure.py:1094
 msgid "Years"
@@ -11599,7 +11475,7 @@ msgstr "Visa textetiketter bredvid navigeringsknappar  (aktiveras vid omstart)"
 
 #: ../gramps/gui/configure.py:1184
 msgid "Show close button in gramplet bar tabs"
-msgstr "Visa stängningsknapp i flikar hos gramplets"
+msgstr "Visa stängningsknapp i gramplet-flikar"
 
 #: ../gramps/gui/configure.py:1204
 msgid "Missing surname"
@@ -11684,18 +11560,18 @@ msgid ""
 "For example: &lt;u&gt;&lt;b&gt;%s&lt;/b&gt;&lt;/u&gt;\n"
 "will display <u><b>Underlined bold date</b></u>.\n"
 msgstr ""
-"Vanliga markups är:\n"
+"Passande markeringar är:\n"
 "<b>&lt;b&gt;Fetstil&lt;/b&gt;</b>\n"
-"<big>&lt;big&gt;Gör font relativt större&lt;/big&gt;</big>\n"
+"<big>&lt;big&gt;Gör typsnitt relativt större&lt;/big&gt;</big>\n"
 "<i>&lt;i&gt;kursivt&lt;/i&gt;</i>\n"
 "<s>&lt;s&gt;Genomstreck&lt;/s&gt;</s>\n"
 "<sub>&lt;sub&gt;Subskrift&lt;/sub&gt;</sub>\n"
 "<sup>&lt;sup&gt;Superskrift&lt;/sup&gt;</sup>\n"
-"<small>&lt;small&gt;Gör font relativt mindre&lt;/small&gt;</small>\n"
-"<tt>&lt;tt&gt;Fast font&lt;/tt&gt;</tt>\n"
+"<small>&lt;small&gt;Gör typsnitt relativt mindre&lt;/small&gt;</small>\n"
+"<tt>&lt;tt&gt;Monospace font&lt;/tt&gt;</tt>\n"
 "<u>&lt;u&gt;Understrykning&lt;/u&gt;</u>\n"
 "\n"
-"Till example: &lt;u&gt;&lt;b&gt;%s&lt;/b&gt;&lt;/u&gt;\n"
+"Exempel: &lt;u&gt;&lt;b&gt;%s&lt;/b&gt;&lt;/u&gt;\n"
 "kommer att visa <u><b>Datum i fetstil, understruken</b></u>.\n"
 
 #: ../gramps/gui/configure.py:1344
@@ -11705,7 +11581,7 @@ msgstr "Datum"
 #: ../gramps/gui/configure.py:1355
 msgid "Use alternate Font handler for GUI and Reports (requires restart)"
 msgstr ""
-"Använd alternativ fonthanterare till GUI och rapporter (kräver omstart)"
+"Använd alternativ typsnittshanterare till GUI och rapporter (kräver omstart)"
 
 #: ../gramps/gui/configure.py:1361
 msgid "Add default source on GEDCOM import"
@@ -11761,17 +11637,16 @@ msgid "Always"
 msgstr "Alltid"
 
 #: ../gramps/gui/configure.py:1424
-#, fuzzy
 msgid "Check for addon updates"
-msgstr "Kontrollera om det finns uppdateringar"
+msgstr "Kontrollera om det finns uppdateringar för tillägg"
 
 #: ../gramps/gui/configure.py:1430
 msgid "Updated addons only"
-msgstr "Uppdatera endast tillägg"
+msgstr "Endast uppdaterade tillägg"
 
 #: ../gramps/gui/configure.py:1431
 msgid "New addons only"
-msgstr "Endast ny tillägg"
+msgstr "Endast nya tillägg"
 
 #: ../gramps/gui/configure.py:1432
 msgid "New and updated addons"
@@ -11787,12 +11662,11 @@ msgstr "Var kontroll skall göras"
 
 #: ../gramps/gui/configure.py:1451
 msgid "Do not ask about previously notified addons"
-msgstr "Fråga ej om tidigare  noterade tillägg"
+msgstr "Fråga ej om tidigare notifierade tillägg"
 
 #: ../gramps/gui/configure.py:1456
-#, fuzzy
 msgid "Check for updated addons now"
-msgstr "Kontrollera om det finns uppdateringar"
+msgstr "Kontrollera uppdaterade tillägg nu"
 
 #: ../gramps/gui/configure.py:1466
 msgid "Checking Addons Failed"
@@ -11800,7 +11674,7 @@ msgstr "Kontroll av tillägg misslyckades"
 
 #: ../gramps/gui/configure.py:1467
 msgid "The addon repository appears to be unavailable. Please try again later."
-msgstr "Arkivplatsen med tillägg verkar vara otillgängligt. Försök senare."
+msgstr "Arkivplatsen med tillägg verkar vara otillgänglig. Försök senare."
 
 #: ../gramps/gui/configure.py:1480
 msgid "There are no available addons of this type"
@@ -11813,7 +11687,7 @@ msgstr "Kontrollerade om '%s'"
 
 #: ../gramps/gui/configure.py:1482
 msgid "' and '"
-msgstr "' och '"
+msgstr "'och'"
 
 #. List of translated strings used here
 #. Dead code for l10n
@@ -11823,21 +11697,19 @@ msgstr "ny"
 
 #: ../gramps/gui/configure.py:1487
 msgid "update"
-msgstr "uppdaterade"
+msgstr "uppdatera"
 
 #: ../gramps/gui/configure.py:1515
-#, fuzzy
 msgid "Database backend"
-msgstr "Databas öppnad"
+msgstr "Databashanterare"
 
 #: ../gramps/gui/configure.py:1522
 msgid "Host"
-msgstr ""
+msgstr "Värd"
 
 #: ../gramps/gui/configure.py:1526
-#, fuzzy
 msgid "Port"
-msgstr "Stående"
+msgstr "Port"
 
 #: ../gramps/gui/configure.py:1534
 msgid "Family Tree Database path"
@@ -11848,34 +11720,28 @@ msgid "Automatically load last Family Tree"
 msgstr "Läs in senaste Släktträd automatiskt"
 
 #: ../gramps/gui/configure.py:1549
-#, fuzzy
 msgid "Backup path"
-msgstr "Säkerhetskopiering avbruten"
+msgstr "Sökväg till säkerhetskopia"
 
 #: ../gramps/gui/configure.py:1556
-#, fuzzy
 msgid "Backup on exit"
-msgstr "Säkerhetskopiering avbruten"
+msgstr "Gör säkerhetskopiering vid avslut"
 
 #: ../gramps/gui/configure.py:1563
-#, fuzzy
 msgid "Every 15 minutes"
-msgstr "Varje notis"
+msgstr "Var 15:e minut"
 
 #: ../gramps/gui/configure.py:1564
-#, fuzzy
 msgid "Every 30 minutes"
-msgstr "Varje notis"
+msgstr "Varje halvtimme"
 
 #: ../gramps/gui/configure.py:1565
-#, fuzzy
 msgid "Every hour"
-msgstr "Alla källor"
+msgstr "Varje timme"
 
 #: ../gramps/gui/configure.py:1570
-#, fuzzy
 msgid "Autobackup"
-msgstr "Automatisk säkerhetskopiering..."
+msgstr "Automatisk säkerhetskopiering"
 
 #: ../gramps/gui/configure.py:1610
 msgid "Select media directory"
@@ -11905,7 +11771,7 @@ msgstr "Välj en mediamapp"
 #: ../gramps/gui/glade/editpersonref.glade:21
 #: ../gramps/gui/glade/editplace.glade:21
 #: ../gramps/gui/glade/editplacename.glade:21
-#: ../gramps/gui/glade/editplaceref.glade:38
+#: ../gramps/gui/glade/editplaceref.glade:39
 #: ../gramps/gui/glade/editreporef.glade:22
 #: ../gramps/gui/glade/editrepository.glade:22
 #: ../gramps/gui/glade/editsource.glade:23 ../gramps/gui/glade/editurl.glade:21
@@ -11926,10 +11792,10 @@ msgstr "Välj en mediamapp"
 #: ../gramps/gui/glade/rule.glade:747 ../gramps/gui/glade/styleeditor.glade:86
 #: ../gramps/gui/glade/styleeditor.glade:1721
 #: ../gramps/gui/logger/_errorview.py:173 ../gramps/gui/plug/_guioptions.py:79
-#: ../gramps/gui/plug/_guioptions.py:1742 ../gramps/gui/plug/_windows.py:440
+#: ../gramps/gui/plug/_guioptions.py:1744 ../gramps/gui/plug/_windows.py:440
 #: ../gramps/gui/plug/report/_fileentry.py:64
 #: ../gramps/gui/plug/report/_reportdialog.py:162 ../gramps/gui/utils.py:180
-#: ../gramps/gui/viewmanager.py:2000 ../gramps/gui/views/listview.py:1046
+#: ../gramps/gui/viewmanager.py:1999 ../gramps/gui/views/listview.py:1046
 #: ../gramps/gui/views/navigationview.py:363 ../gramps/gui/views/tags.py:648
 #: ../gramps/gui/widgets/progressdialog.py:437
 #: ../gramps/plugins/lib/maps/geography.py:1010
@@ -11944,13 +11810,13 @@ msgstr "_Avbryt"
 msgid "Select database directory"
 msgstr "Välj en databasmapp"
 
-#: ../gramps/gui/configure.py:1655 ../gramps/gui/viewmanager.py:1997
+#: ../gramps/gui/configure.py:1655 ../gramps/gui/viewmanager.py:1996
 msgid "Select backup directory"
 msgstr "Välj mapp för säkerhetskopia"
 
 #: ../gramps/gui/dbloader.py:120 ../gramps/gui/plug/tool.py:109
 msgid "Undo history warning"
-msgstr "Redigeringshistorik - varning"
+msgstr "Varning vid ångrahistorik"
 
 #: ../gramps/gui/dbloader.py:121
 msgid ""
@@ -11961,8 +11827,8 @@ msgid ""
 "If you think you may want to revert the import, please stop here and backup "
 "your database."
 msgstr ""
-"Att importera en databas kommer att radera nuvarande redigeringshistorik. "
-"Det går inte att ångra importen eller tidigare ändringar.\n"
+"Att importera en databas kommer att radera nuvarande ångrahistorik. Det går "
+"inte att ångra importen eller tidigare ändringar.\n"
 "\n"
 "Om du vill ha möjlighet att ångra importen, måste du avbryta nu och "
 "säkerhetskopiera databasen."
@@ -12023,28 +11889,25 @@ msgstr "Välj fil_typ:"
 
 #: ../gramps/gui/dbloader.py:401 ../gramps/gui/dbloader.py:423
 msgid "Login"
-msgstr ""
+msgstr "Logga in"
 
 #: ../gramps/gui/dbloader.py:409
-#, fuzzy
 msgid "Username: "
-msgstr "efternamn"
+msgstr "Användarnamn: "
 
 #: ../gramps/gui/dbloader.py:414
-#, fuzzy
 msgid "Password: "
-msgstr "Lösenord:"
+msgstr "Lösenord: "
 
 #: ../gramps/gui/dbloader.py:446
-#, fuzzy
 msgid "Import Family Tree"
-msgstr "Gramps: Importera släktträd"
+msgstr "Importera släktträd"
 
 #: ../gramps/gui/dbloader.py:457
 msgid "Import"
 msgstr "Importera"
 
-#: ../gramps/gui/dbloader.py:519
+#: ../gramps/gui/dbloader.py:520
 #, python-format
 msgid ""
 "File type \"%s\" is unknown to Gramps.\n"
@@ -12057,44 +11920,43 @@ msgstr ""
 "Giltiga typer är: Gramps-databas, Gramps-XML, Gramps-paket och GEDCOM samt "
 "andra."
 
-#: ../gramps/gui/dbloader.py:542 ../gramps/gui/dbloader.py:549
+#: ../gramps/gui/dbloader.py:543 ../gramps/gui/dbloader.py:550
 msgid "Cannot open file"
 msgstr "Kan inte öppna fil"
 
-#: ../gramps/gui/dbloader.py:543
+#: ../gramps/gui/dbloader.py:544
 msgid "The selected file is a directory, not a file.\n"
 msgstr "Den valda filen är en katalog, inte en fil.\n"
 
-#: ../gramps/gui/dbloader.py:550
+#: ../gramps/gui/dbloader.py:551
 msgid "You do not have read access to the selected file."
 msgstr "Du har inte läsåtkomst till den valda filen."
 
-#: ../gramps/gui/dbloader.py:560
+#: ../gramps/gui/dbloader.py:561
 msgid "Cannot create file"
 msgstr "Kan inte skapa fil"
 
-#: ../gramps/gui/dbloader.py:584
+#: ../gramps/gui/dbloader.py:585
 #, python-format
 msgid "Could not import file: %s"
 msgstr "Kunde inte importera fil: %s"
 
-#: ../gramps/gui/dbloader.py:585
+#: ../gramps/gui/dbloader.py:586
 msgid ""
 "This file incorrectly identifies its character set, so it cannot be "
 "accurately imported. Please fix the encoding, and import again"
 msgstr ""
 "Denna fil identifierar sin teckenuppsättning felaktigt, så den kan ej "
-"importeras korrekt. Justera teckenkodningen och importera igen."
+"importeras korrekt. Justera teckenkodningen och importera igen"
 
 #: ../gramps/gui/dbman.py:97
-#, fuzzy, python-format
+#, python-format
 msgid "%s_-_Manage_Family_Trees"
-msgstr "_Hantera släktträd..."
+msgstr "%s_-_Hantera_släktträd"
 
 #: ../gramps/gui/dbman.py:98
-#, fuzzy
 msgid "Family_Trees_manager_window"
-msgstr "Släktträdsnamn"
+msgstr "Släktträd_hanterings_fönster"
 
 #: ../gramps/gui/dbman.py:112 ../gramps/gui/glade/dbman.glade:345
 msgid "_Archive"
@@ -12105,9 +11967,8 @@ msgid "_Extract"
 msgstr "_Extrahera"
 
 #: ../gramps/gui/dbman.py:119 ../gramps/gui/dbman.py:140
-#, fuzzy
 msgid "Database Information"
-msgstr "Ingen datuminformation"
+msgstr "Databasinformation"
 
 #: ../gramps/gui/dbman.py:121 ../gramps/gui/editors/edittaglist.py:120
 #: ../gramps/gui/glade/addmedia.glade:38
@@ -12130,7 +11991,7 @@ msgstr "Ingen datuminformation"
 #: ../gramps/gui/glade/editpersonref.glade:37
 #: ../gramps/gui/glade/editplace.glade:36
 #: ../gramps/gui/glade/editplacename.glade:36
-#: ../gramps/gui/glade/editplaceref.glade:54
+#: ../gramps/gui/glade/editplaceref.glade:55
 #: ../gramps/gui/glade/editreporef.glade:41
 #: ../gramps/gui/glade/editrepository.glade:40
 #: ../gramps/gui/glade/editsource.glade:40 ../gramps/gui/glade/editurl.glade:37
@@ -12151,7 +12012,7 @@ msgstr "Ingen datuminformation"
 #: ../gramps/gui/glade/styleeditor.glade:1738
 #: ../gramps/gui/plug/_guioptions.py:80
 #: ../gramps/gui/plug/report/_reportdialog.py:166 ../gramps/gui/utils.py:194
-#: ../gramps/gui/viewmanager.py:1868 ../gramps/gui/views/tags.py:649
+#: ../gramps/gui/viewmanager.py:1866 ../gramps/gui/views/tags.py:649
 #: ../gramps/plugins/tool/check.py:781 ../gramps/plugins/tool/patchnames.py:118
 #: ../gramps/plugins/tool/populatesources.py:91
 #: ../gramps/plugins/tool/testcasegenerator.py:328
@@ -12159,9 +12020,8 @@ msgid "_OK"
 msgstr "_OK"
 
 #: ../gramps/gui/dbman.py:125
-#, fuzzy
 msgid "Setting"
-msgstr "Börjar"
+msgstr "Inställning"
 
 #: ../gramps/gui/dbman.py:200
 msgid "Family Trees"
@@ -12172,9 +12032,8 @@ msgid "Family Tree name"
 msgstr "Släktträdsnamn"
 
 #: ../gramps/gui/dbman.py:402
-#, fuzzy
 msgid "Database Type"
-msgstr "Databas öppnad"
+msgstr "Databastyp"
 
 #: ../gramps/gui/dbman.py:509
 #, python-format
@@ -12188,7 +12047,7 @@ msgid ""
 "database you may safely break the lock. However, if someone else is editing "
 "the database and you break the lock, you may corrupt the database."
 msgstr ""
-"Gramps upplever att någon annan aktivt redigerar denna databas. Du kan inte "
+"Det verkar som om någon annan aktivt redigerar denna databas. Du kan inte "
 "redigera denna databas, medan den är låst. Om ingen annan håller på att "
 "redigera databasen kan du utan risk bryta låset. Men om någon annan "
 "redigerar databasen och du bryter låset kan databasen förstöras."
@@ -12218,7 +12077,7 @@ msgstr "Kunde inte döpa om släktträdet."
 
 #: ../gramps/gui/dbman.py:628
 msgid "Family Tree already exists, choose a unique name."
-msgstr "Släktträdet finns reda, välj ett unikt namn."
+msgstr "Släktträdet finns redan, välj ett unikt namn."
 
 #: ../gramps/gui/dbman.py:675
 msgid "Extracting archive..."
@@ -12271,56 +12130,52 @@ msgstr ""
 "%s"
 
 #: ../gramps/gui/dbman.py:784
-#, fuzzy, python-format
+#, python-format
 msgid "Convert the '%s' database?"
-msgstr "Bryta låset på '%s'-databasen?"
+msgstr "Konvertera databasen '%s'?"
 
 #: ../gramps/gui/dbman.py:785
 #, python-format
 msgid ""
 "Do you wish to convert this family tree into a %(database_type)s database?"
-msgstr ""
+msgstr "Vill du konvertera detta släktträd till en %(database_type)s databas?"
 
 #: ../gramps/gui/dbman.py:787
 msgid "Convert"
-msgstr "Omvandla"
+msgstr "Konvertera"
 
 #: ../gramps/gui/dbman.py:797
-#, fuzzy, python-format
+#, python-format
 msgid "Opening the '%s' database"
-msgstr "Öppna en befintlig databas"
+msgstr "Öppnar '%s'-databasen"
 
 #: ../gramps/gui/dbman.py:798
-#, fuzzy
 msgid "An attempt to convert the database failed. Perhaps it needs updating."
 msgstr ""
-"Ett försök att arkivera informationen misslyckades med följande "
-"felmeddelande:\n"
-"\n"
-"%s"
+"Ett försök att konvertera databasen misslyckades. Kanske den behöver "
+"uppdateras."
 
 #: ../gramps/gui/dbman.py:809 ../gramps/gui/dbman.py:835
-#, fuzzy, python-format
+#, python-format
 msgid "Converting the '%s' database"
-msgstr "Bryta låset på '%s'-databasen?"
+msgstr "Konverterar '%s'-databasen"
 
 #: ../gramps/gui/dbman.py:810
 msgid "An attempt to export the database failed."
-msgstr ""
+msgstr "Ett försök att exportera databasen misslyckades."
 
 #: ../gramps/gui/dbman.py:814
-#, fuzzy
 msgid "Converting data..."
-msgstr "Sorterar data..."
+msgstr "Konverterar data..."
 
 #: ../gramps/gui/dbman.py:819 ../gramps/gui/dbman.py:822
-#, fuzzy, python-format
+#, python-format
 msgid "(Converted #%d)"
-msgstr "Omvandla"
+msgstr "(Konverterad #%d)"
 
 #: ../gramps/gui/dbman.py:836
 msgid "An attempt to import into the database failed."
-msgstr ""
+msgstr "Ett försök att importera till databasen misslyckades."
 
 #: ../gramps/gui/dbman.py:893
 msgid "Repair Family Tree?"
@@ -12352,18 +12207,19 @@ msgid ""
 "this is the case, you can disable the repair button by removing the file "
 "%(recover_file)s in the Family Tree directory."
 msgstr ""
-"Om du klickar på %(bold_start)sFortsättt%(bold_end)s, Kommer Gramps att "
-"försöka  återskapa ditt släktträd från senaste godkända backup. Det finns "
+"Om du klickar på %(bold_start)sFortsätt%(bold_end)s, Kommer Gramps att "
+"försöka återskapa ditt släktträd från senaste godkända backup. Det finns "
 "flera möjligheter, att detta kan skapa oönskade effekter, så "
 "%(bold_start)ssäkerhetskopiera%(bold_end)s släktträdet först.\n"
 "Det släktträd du har valt är sparat i %(dirname)s.\n"
+"\n"
 "Innan reparationen utförs, kontrollera att släktträdet verkligen inte kan "
 "öppnas längre, då databashanteraren kan återställa vissa fel automatiskt.\n"
 "\n"
 "%(bold_start)sDetaljer:%(bold_end)s Vid reparation av ett släktträd "
-"utnyttjas den senaste säkerhetskopieringen  av släktträdet, vilken Gramps "
+"utnyttjas den senaste säkerhetskopieringen av släktträdet, vilken Gramps "
 "sparade vid senaste användningen. Om du arbetat flera timmar/dagar utan att "
-"stänga Gramps, kommer all denna information  att förloras! Om reparationen "
+"stänga Gramps, kommer all denna information att förloras! Om reparationen "
 "misslyckas, är det ursprungliga släktträdet förlorat för alltid, därför är "
 "en säkerhetskopiering nödvändig. Om reparationen misslyckas eller alltför "
 "mycket data förlorats, kan du ordna till det ursprungliga släktträdet "
@@ -12420,7 +12276,7 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
-"Ett försök att skapa arkivet misslyckades med följande meddelande:\n"
+"Ett försök att skapa arkivet misslyckades med följande felmeddelande:\n"
 "\n"
 "%s"
 
@@ -12447,20 +12303,19 @@ msgstr ""
 #: ../gramps/gui/dialog.py:388 ../gramps/gui/dialog.py:466
 #: ../gramps/gui/utils.py:309
 msgid "Attempt to force closing the dialog"
-msgstr "Försök att stänga dialogen med våld"
+msgstr "Försök att tvinga att stänga dialogen"
 
 #: ../gramps/gui/dialog.py:389 ../gramps/gui/dialog.py:467
 msgid ""
 "Please do not force closing this important dialog.\n"
 "Instead select one of the available options"
 msgstr ""
-"Försök inte stänga den här viktiga dialogrutan med våld.\n"
+"Försök inte att tvinga stänga den här viktiga dialogrutan.\n"
 "Välj i stället någon av de tillgängliga alternativen"
 
 #: ../gramps/gui/displaystate.py:268
-#, fuzzy
 msgid "Cannot load database"
-msgstr "Kan inte öppna databas"
+msgstr "Kan inte ladda in databasen"
 
 #: ../gramps/gui/displaystate.py:388
 #: ../gramps/plugins/gramplet/persondetails.py:173
@@ -12500,14 +12355,12 @@ msgid "No active note"
 msgstr "Ingen aktiv notis"
 
 #: ../gramps/gui/displaystate.py:627
-#, fuzzy
 msgid "No active object"
-msgstr "Ingen aktiv notis"
+msgstr "Inget aktivt objekt"
 
 #: ../gramps/gui/editors/addmedia.py:70
-#, fuzzy
 msgid "manual|Select_a_media_selector"
-msgstr "Välj en mediaobjektselektor"
+msgstr "manual|Select_a_media_selector"
 
 #: ../gramps/gui/editors/addmedia.py:104
 msgid "Select a media object"
@@ -12515,7 +12368,7 @@ msgstr "Välj ett mediaobjekt"
 
 #: ../gramps/gui/editors/addmedia.py:148
 msgid "Select media object"
-msgstr "Välj ett mediaobjekt"
+msgstr "Välj mediaobjekt"
 
 #: ../gramps/gui/editors/addmedia.py:158
 msgid "Import failed"
@@ -12536,8 +12389,8 @@ msgid ""
 "Directory specified in preferences: Base path for relative media paths: %s "
 "does not exist. Change preferences or do not use relative path when importing"
 msgstr ""
-"Mapp specificerad i inställningar: Bassökväg för relativa mediasökvägar: %s "
-"saknas Ändra inställningar eller använd inte relativ sökväg vid import"
+"Katalog specificerad i inställningar: Bassökväg för relativa mediasökvägar: "
+"%s saknas. Ändra inställningar eller använd inte relativ sökväg vid import"
 
 #: ../gramps/gui/editors/addmedia.py:238
 #, python-format
@@ -12625,8 +12478,8 @@ msgstr "Attrib_ut"
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:103
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:86
 #: ../gramps/gui/merge/mergeperson.py:182
-#: ../gramps/gui/plug/_guioptions.py:1175
-#: ../gramps/gui/plug/_guioptions.py:1353
+#: ../gramps/gui/plug/_guioptions.py:1177
+#: ../gramps/gui/plug/_guioptions.py:1355
 #: ../gramps/gui/selectors/selectcitation.py:75
 #: ../gramps/gui/selectors/selectevent.py:74
 #: ../gramps/gui/selectors/selectfamily.py:69
@@ -12769,7 +12622,7 @@ msgstr ""
 "Den här citeringen kan inte skapas just nu. Antingen redigeras den "
 "associerade källan eller en annan citering associerad med samma källa.\n"
 "\n"
-"För att redigera den här citering, måste du stänga det objektet."
+"För att redigera den här citeringen, måste du stänga det objektet."
 
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:64
 msgid "Add a new family event"
@@ -12850,7 +12703,7 @@ msgstr "_Galleri"
 #. Translators: _View means "to look at this"
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:140
 msgid "verb:look at this|_View"
-msgstr ""
+msgstr "verb:look at this|_View"
 
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:145
 #: ../gramps/plugins/view/mediaview.py:215
@@ -12858,9 +12711,8 @@ msgid "Open Containing _Folder"
 msgstr "Öppnar innehålls_mapp"
 
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:153
-#, fuzzy
 msgid "_Make Active Media"
-msgstr "Gör aktivt media"
+msgstr "_Gör aktivt media"
 
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:257
 #: ../gramps/gui/editors/editperson.py:961
@@ -12957,13 +12809,13 @@ msgstr "Ange som standardnamn"
 #.
 #. -------------------------------------------------------------------------
 #: ../gramps/gui/editors/displaytabs/namemodel.py:56
-#: ../gramps/gui/plug/_guioptions.py:1256 ../gramps/gui/views/tags.py:498
+#: ../gramps/gui/plug/_guioptions.py:1258 ../gramps/gui/views/tags.py:498
 #: ../gramps/plugins/quickview/all_relations.py:306
 msgid "Yes"
 msgstr "Ja"
 
 #: ../gramps/gui/editors/displaytabs/namemodel.py:57
-#: ../gramps/gui/plug/_guioptions.py:1255 ../gramps/gui/views/tags.py:499
+#: ../gramps/gui/plug/_guioptions.py:1257 ../gramps/gui/views/tags.py:499
 #: ../gramps/plugins/quickview/all_relations.py:310
 msgid "No"
 msgstr "Nej"
@@ -13119,7 +12971,7 @@ msgstr "Platser i ring upptäckt"
 
 #: ../gramps/gui/editors/displaytabs/placerefembedlist.py:142
 msgid "The place you are adding is already enclosed by this place"
-msgstr "Den plats du lägger till, är redan omgiven av denna plats"
+msgstr "Den plats du lägger till är redan omgiven av denna plats"
 
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:55
 msgid "Create and add a new repository"
@@ -13127,7 +12979,7 @@ msgstr "Skapa och lägg till en ny arkivplats"
 
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:56
 msgid "Remove the existing repository"
-msgstr "Ta bort den existerande arkivplats"
+msgstr "Ta bort den existerande arkivplatsen"
 
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:57
 #: ../gramps/plugins/view/repoview.py:113
@@ -13195,7 +13047,7 @@ msgstr "Flera efternamn"
 
 #: ../gramps/gui/editors/displaytabs/surnametab.py:89
 msgid "Family Surnames"
-msgstr "Familjeefternamn:"
+msgstr "Familjeefternamn"
 
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:54
 msgid "Create and add a new web address"
@@ -13504,7 +13356,7 @@ msgstr "Flytta barnet neråt i barnlistan"
 
 #: ../gramps/gui/editors/editfamily.py:121
 msgid "#"
-msgstr "Nr."
+msgstr "#"
 
 #: ../gramps/gui/editors/editfamily.py:125
 msgid "Paternal"
@@ -13610,7 +13462,7 @@ msgid ""
 "updated. Some edits you have made may have been lost."
 msgstr ""
 "Det %(object)s du redigerar har ändrats utanför denna redigerare. Detta kan "
-"bero på ändringar in en av huvudvyerna. T. ex. en källa, som använd här har, "
+"bero på ändringar in en av huvudvyerna. T. ex. en källa som använd här har "
 "tagits bort i källvyn.\n"
 "För att säkerställa att informationen fortfarande är rätt har visade data "
 "uppdaterats. Några redigeringar du gjort kan ha gått förlorade."
@@ -13676,7 +13528,7 @@ msgid ""
 msgstr ""
 "En familj med dessa föräldrar finns redan i databasen. Om du sparar kommer "
 "du att skapa en dubblett av familjen. Rekommendationen är att avbryta "
-"redigeringen  idet här fönstret och välja den existerande familjen"
+"redigeringen i det här fönstret och väljer den existerande familjen"
 
 #: ../gramps/gui/editors/editfamily.py:954
 #, python-format
@@ -13725,7 +13577,7 @@ msgid ""
 "next available ID value."
 msgstr ""
 "Du har försökt använda ett befintligt Gramps-ID med värdet %(id)s. Det här "
-"värdet används redan av. Skriv in ett annat ID eller lämna tomt så fås nästa "
+"värdet används redan. Skriv in ett annat ID eller lämna tomt så fås nästa "
 "tillgängliga ID-värde."
 
 #: ../gramps/gui/editors/editfamily.py:1108
@@ -13811,7 +13663,7 @@ msgstr "Kan ej spara mediaobjekt. ID finns redan."
 
 #: ../gramps/gui/editors/editmedia.py:312
 msgid "There is no media matching the current path value!"
-msgstr "Det finns inget media, som matchar värdet på den aktuella sökvägen!"
+msgstr "Det finns inget media som matchar värdet på den aktuella sökvägen!"
 
 #: ../gramps/gui/editors/editmedia.py:313
 #, python-format
@@ -14097,7 +13949,7 @@ msgid "manual|Place_Editor_dialog"
 msgstr "Platsredigerardialog"
 
 #: ../gramps/gui/editors/editplace.py:91
-#: ../gramps/gui/glade/editplace.glade:354 ../gramps/gui/merge/mergeplace.py:55
+#: ../gramps/gui/glade/editplace.glade:355 ../gramps/gui/merge/mergeplace.py:55
 msgid "place|Name:"
 msgstr "Platsnamn:"
 
@@ -14115,20 +13967,22 @@ msgstr "Ny plats"
 #. translators: translate the "S" too (and the "or" of course)
 #: ../gramps/gui/editors/editplace.py:201
 #: ../gramps/gui/editors/editplaceref.py:194
-#, fuzzy
 msgid ""
 "Invalid latitude\n"
 "(syntax: 18\\u00b09'48.21\"S, -18.2412 or -18:9:48.21)"
-msgstr "Ogiltig latitud (syntax: 18\\u00b09'"
+msgstr ""
+"Ogiltig latitud\n"
+"(syntax: 18\\u00b09'48.21\"S, -18.2412 eller -18:9:48.21)"
 
 #. translators: translate the "E" too (and the "or" of course)
 #: ../gramps/gui/editors/editplace.py:206
 #: ../gramps/gui/editors/editplaceref.py:199
-#, fuzzy
 msgid ""
 "Invalid longitude\n"
 "(syntax: 18\\u00b09'48.21\"E, -18.2412 or -18:9:48.21)"
-msgstr "Ogiltig longitud (syntax: 18\\u00b09'"
+msgstr ""
+"Ogiltig longitud\n"
+"(syntax: 18\\u00b09'48.21\"S, -18.2412 eller -18:9:48.21)"
 
 #: ../gramps/gui/editors/editplace.py:217
 #: ../gramps/plugins/lib/maps/geography.py:924
@@ -14167,9 +14021,8 @@ msgid "Delete Place (%s)"
 msgstr "Radera plats (%s)"
 
 #: ../gramps/gui/editors/editplaceformat.py:49
-#, fuzzy
 msgid "Place Format Editor"
-msgstr "Namnformatsredigerare"
+msgstr "Platsformatsredigerare"
 
 #: ../gramps/gui/editors/editplaceformat.py:137
 msgid "New"
@@ -14182,7 +14035,7 @@ msgstr "Platsnamnsredigerardialog"
 #: ../gramps/gui/editors/editplacename.py:101
 #: ../gramps/gui/editors/editplacename.py:134
 msgid "Place Name Editor"
-msgstr " Redigerare för platsnamn"
+msgstr "Redigerare för platsnamn"
 
 #: ../gramps/gui/editors/editplacename.py:125
 msgid "Invalid ISO code"
@@ -14254,7 +14107,6 @@ msgid "Add Repository"
 msgstr "Lägg till arkivplats"
 
 #: ../gramps/gui/editors/editrepository.py:60
-#, fuzzy
 msgid "manual|New_Repository_dialog"
 msgstr "manual|Dialog för ny arkivplats"
 
@@ -14472,7 +14324,7 @@ msgstr ""
 
 #: ../gramps/gui/editors/filtereditor.py:562
 msgid "Include selected Gramps ID"
-msgstr "Ta med  valda Gramps ID"
+msgstr "Ta med valda Gramps ID"
 
 #: ../gramps/gui/editors/filtereditor.py:564
 msgid "Use exact case of letters"
@@ -14487,9 +14339,8 @@ msgid "Use regular expression"
 msgstr "Använd reguljärt uttryck"
 
 #: ../gramps/gui/editors/filtereditor.py:568
-#, fuzzy
 msgid "Also family events where person is spouse"
-msgstr "Även familjehändelser, där person är maka/make"
+msgstr "Även familjehändelser där person är maka/make"
 
 #: ../gramps/gui/editors/filtereditor.py:570
 msgid "Only include primary participants"
@@ -14497,20 +14348,18 @@ msgstr "Tag bara med primära deltagare"
 
 #: ../gramps/gui/editors/filtereditor.py:586
 #: ../gramps/gui/widgets/placewithin.py:73
-#, fuzzy
 msgid "degrees"
-msgstr "Examen - utbildningsnivå"
+msgstr "grader"
 
 #: ../gramps/gui/editors/filtereditor.py:586
 #: ../gramps/gui/widgets/placewithin.py:73
 msgid "kilometers"
-msgstr ""
+msgstr "kilometer"
 
 #: ../gramps/gui/editors/filtereditor.py:586
 #: ../gramps/gui/widgets/placewithin.py:73
-#, fuzzy
 msgid "miles"
-msgstr "Familjer"
+msgstr "mil"
 
 #: ../gramps/gui/editors/filtereditor.py:597
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:76
@@ -14575,20 +14424,19 @@ msgstr "Kommentar"
 
 #: ../gramps/gui/editors/filtereditor.py:1113
 msgid "Custom Filter Editor"
-msgstr "Anpassade filter"
+msgstr "Redigerare för anpassade filter"
 
 #: ../gramps/gui/editors/filtereditor.py:1185
 msgid "Delete Filter?"
 msgstr "Radera filter?"
 
 #: ../gramps/gui/editors/filtereditor.py:1186
-#, fuzzy
 msgid ""
 "This filter is currently being used as the base for other filters. Deleting "
 "this filter will result in removing all other filters that depend on it."
 msgstr ""
 "Detta filter används nu som bas för andra filter. Genom att ta bort detta "
-"filter kommer alla filter, som beror på detta att tas bort."
+"filter kommer alla filter som beror på detta att tas bort."
 
 #: ../gramps/gui/editors/filtereditor.py:1190
 msgid "Delete Filter"
@@ -14617,7 +14465,7 @@ msgstr "Lägg till en ny plats"
 
 #: ../gramps/gui/editors/objectentries.py:300
 msgid "Remove place"
-msgstr "Ta bort plats"
+msgstr "Tag bort plats"
 
 #: ../gramps/gui/editors/objectentries.py:341
 msgid "To select a source, use drag-and-drop or use the buttons"
@@ -14651,7 +14499,7 @@ msgid "To select a media object, use drag-and-drop or use the buttons"
 msgstr "Använd dra-och-släpp eller knapparna för att välja ett mediaobjekt"
 
 #: ../gramps/gui/editors/objectentries.py:389
-#: ../gramps/gui/plug/_guioptions.py:1114
+#: ../gramps/gui/plug/_guioptions.py:1116
 msgid "No image given, click button to select one"
 msgstr "Ingen bild angiven, klicka på knappen för att välja en"
 
@@ -14660,7 +14508,7 @@ msgid "Edit media object"
 msgstr "Redigera mediaobjekt"
 
 #: ../gramps/gui/editors/objectentries.py:391
-#: ../gramps/gui/plug/_guioptions.py:1092
+#: ../gramps/gui/plug/_guioptions.py:1094
 msgid "Select an existing media object"
 msgstr "Välj ett befintligt mediaobjekt"
 
@@ -14671,19 +14519,19 @@ msgstr "Lägg till nytt mediaobjekt"
 
 #: ../gramps/gui/editors/objectentries.py:393
 msgid "Remove media object"
-msgstr "Ta bort mediaobjekt"
+msgstr "Tag bort mediaobjekt"
 
 #: ../gramps/gui/editors/objectentries.py:433
 msgid "To select a note, use drag-and-drop or use the buttons"
 msgstr "Använd dra-och-släpp eller knapparna för att välja en notis"
 
 #: ../gramps/gui/editors/objectentries.py:435
-#: ../gramps/gui/plug/_guioptions.py:1012
+#: ../gramps/gui/plug/_guioptions.py:1014
 msgid "No note given, click button to select one"
 msgstr "Ingen notis angiven, klicka på knappen för att välja en"
 
 #: ../gramps/gui/editors/objectentries.py:437
-#: ../gramps/gui/plug/_guioptions.py:987
+#: ../gramps/gui/plug/_guioptions.py:989
 msgid "Select an existing note"
 msgstr "Välj en befintlig notis"
 
@@ -14719,7 +14567,7 @@ msgstr "%s innehåller"
 #: ../gramps/gui/filters/_searchbar.py:113
 #, python-format
 msgid "%s is not"
-msgstr " %s är inte"
+msgstr "%s är inte"
 
 #: ../gramps/gui/filters/_searchbar.py:115
 #, python-format
@@ -14743,7 +14591,7 @@ msgstr "Publikation"
 
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:110
 msgid "Citation:"
-msgstr "Citat:"
+msgstr "Citering:"
 
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:112
 #: ../gramps/plugins/textreport/tagreport.py:826
@@ -14803,9 +14651,8 @@ msgid "Death date"
 msgstr "Dödsdatum"
 
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:112
-#, fuzzy
 msgid "Within"
-msgstr "_Med:"
+msgstr "Inom"
 
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:107
 msgid "URL"
@@ -14826,7 +14673,7 @@ msgstr "Bild"
 #: ../gramps/gui/glade/addmedia.glade:167
 #: ../gramps/gui/glade/editmedia.glade:111
 #: ../gramps/gui/glade/editmediaref.glade:409
-#: ../gramps/gui/glade/editplace.glade:90
+#: ../gramps/gui/glade/editplace.glade:91
 #: ../gramps/gui/glade/editsource.glade:97
 msgid "_Title:"
 msgstr "_Titel:"
@@ -14838,6 +14685,12 @@ msgstr "Konvertera till relativ sökväg"
 #: ../gramps/gui/glade/baseselector.glade:120
 msgid "Show all"
 msgstr "Visa alla"
+
+#: ../gramps/gui/glade/baseselector.glade:140
+#: ../gramps/gui/views/treemodels/treebasemodel.py:534
+#: ../gramps/gui/views/treemodels/treebasemodel.py:579
+msgid "Loading items..."
+msgstr "Laddar detaljer..."
 
 #: ../gramps/gui/glade/book.glade:51
 msgid "Book _name:"
@@ -14951,9 +14804,8 @@ msgid "_New"
 msgstr "_Ny"
 
 #: ../gramps/gui/glade/dbman.glade:250
-#, fuzzy
 msgid "_Info"
-msgstr "Info"
+msgstr "_Info"
 
 #: ../gramps/gui/glade/dbman.glade:281
 msgid "_Rename"
@@ -14965,9 +14817,8 @@ msgid "Close"
 msgstr "Stäng"
 
 #: ../gramps/gui/glade/dbman.glade:313
-#, fuzzy
 msgid "Con_vert"
-msgstr "Omvandla"
+msgstr "Kon_vertera"
 
 #: ../gramps/gui/glade/dbman.glade:329
 msgid "Re_pair"
@@ -15003,7 +14854,7 @@ msgstr "Välj ersättning för den saknade filen"
 
 #: ../gramps/gui/glade/dialog.glade:366
 msgid "_Use this selection for all missing media files"
-msgstr "An_vänd denna flagga för alla saknade mediafiler"
+msgstr "_Använd detta val för alla saknade mediafiler"
 
 #: ../gramps/gui/glade/dialog.glade:370
 msgid ""
@@ -15012,7 +14863,7 @@ msgid ""
 "be presented for any missing media files."
 msgstr ""
 "Om du markerar denna knapp, så kommer alla saknade mediafiler att "
-"automatiskt behandlas enligt den för tillfället valda alternativet. Inga "
+"automatiskt behandlas enligt det för tillfället valda alternativet. Inga "
 "ytterligare dialoger kommer att presenteras för saknade mediafiler."
 
 #: ../gramps/gui/glade/dialog.glade:422
@@ -15062,11 +14913,10 @@ msgstr "etikett"
 msgid "Close _without saving"
 msgstr "Stäng _utan att spara"
 
-#. widget
 #: ../gramps/gui/glade/dialog.glade:859
 #: ../gramps/gui/plug/report/_bookdialog.py:625
 #: ../gramps/gui/views/listview.py:1047
-#: ../gramps/gui/widgets/grampletpane.py:582
+#: ../gramps/gui/widgets/grampletpane.py:579
 #: ../gramps/plugins/tool/eventcmp.py:400
 msgid "_Save"
 msgstr "_Spara"
@@ -15076,9 +14926,8 @@ msgid "Do not ask again"
 msgstr "Fråga inte igen"
 
 #: ../gramps/gui/glade/displaystate.glade:7
-#, fuzzy
 msgid "Gramps Warnings"
-msgstr "Varningar"
+msgstr "Gramps-varningar"
 
 #: ../gramps/gui/glade/editaddress.glade:44
 #: ../gramps/gui/glade/editchildref.glade:47
@@ -15103,7 +14952,7 @@ msgstr "Spara ändringar och stäng fönster"
 #: ../gramps/gui/glade/editmedia.glade:125
 #: ../gramps/gui/glade/editmediaref.glade:546
 #: ../gramps/gui/glade/editplacename.glade:93
-#: ../gramps/gui/glade/editplaceref.glade:117
+#: ../gramps/gui/glade/editplaceref.glade:118
 msgid "_Date:"
 msgstr "_Datum:"
 
@@ -15128,7 +14977,7 @@ msgstr "_Stat/Län:"
 #: ../gramps/gui/glade/editaddress.glade:166
 #: ../gramps/gui/glade/editlocation.glade:248
 msgid "_ZIP/Postal code:"
-msgstr "Postnu_mmer:"
+msgstr "_Postnummer:"
 
 #: ../gramps/gui/glade/editaddress.glade:180
 msgid "Postal code"
@@ -15157,7 +15006,7 @@ msgstr ""
 
 #: ../gramps/gui/glade/editaddress.glade:250
 msgid "Country of the address"
-msgstr "Land för adresserna"
+msgstr "Land för adressen"
 
 #: ../gramps/gui/glade/editaddress.glade:264
 msgid ""
@@ -15185,8 +15034,8 @@ msgstr ""
 #: ../gramps/gui/glade/editnote.glade:226
 #: ../gramps/gui/glade/editperson.glade:410
 #: ../gramps/gui/glade/editpersonref.glade:151
-#: ../gramps/gui/glade/editplace.glade:321
-#: ../gramps/gui/glade/editplaceref.glade:424
+#: ../gramps/gui/glade/editplace.glade:322
+#: ../gramps/gui/glade/editplaceref.glade:425
 #: ../gramps/gui/glade/editreporef.glade:188
 #: ../gramps/gui/glade/editreporef.glade:397
 #: ../gramps/gui/glade/editrepository.glade:205
@@ -15209,7 +15058,7 @@ msgstr "Starta datumredigerare"
 
 #: ../gramps/gui/glade/editaddress.glade:346
 msgid "Date at which the address is valid."
-msgstr "Det datum, vid vilket adressen är giltig."
+msgstr "Det datum vid vilket adressen är giltig."
 
 #: ../gramps/gui/glade/editaddress.glade:361
 #: ../gramps/gui/glade/editlocation.glade:314
@@ -15231,7 +15080,7 @@ msgstr "_Värde:"
 
 #: ../gramps/gui/glade/editattribute.glade:122
 msgid "The value of the attribute. Eg. 1.8, Sunny, or Blue eyes."
-msgstr "Värdet på ett attribut. T. ex. 1,8, Soligt eller blå ögon."
+msgstr "Värdet på ett attribut. T. ex. 1.8, Soligt eller blå ögon."
 
 #: ../gramps/gui/glade/editattribute.glade:167
 msgid ""
@@ -15286,12 +15135,12 @@ msgid ""
 "etc. A census record might have a line number or dwelling and family numbers "
 "in addition to the page number. "
 msgstr ""
-"Särskild plats inom den refererade information. För publicerade verk kan "
+"Särskild plats inom den refererade informationen. För publicerade verk kan "
 "detta innehålla volymen i ett flervolyms verk samt sidnummer. För "
 "tidskrifter kan det innehålla volym, utgåva och sidnummer. För en tidning "
 "kan det innehålla kolumnnummer och sidonummer. För en opublicerad källa kan "
 "det vara bladnummer, sidnummer etc. En folkräkning kan ha radnummer eller "
-"boplats och familjenummer utöver sidnummer."
+"boplats och familjenummer utöver sidnummer. "
 
 #: ../gramps/gui/glade/editcitation.glade:152
 msgid "_Volume/Page:"
@@ -15308,11 +15157,10 @@ msgid ""
 "log/registry. "
 msgstr ""
 "Datumet för inmatningen i källan du refererar till, t. ex. datumet då ett "
-"hus besöktes under en folkräkning eller datumet för en inmatning gjorts i "
-"ett föddebok eller liknande. "
+"hus besöktes under en folkräkning eller datumet en inmatning gjorts i en "
+"födelsebok eller liknande. "
 
 #: ../gramps/gui/glade/editcitation.glade:201
-#, fuzzy
 msgid ""
 "Conveys the submitter's quantitative evaluation of the credibility of a "
 "piece of information, based upon its supporting evidence. It is not intended "
@@ -15324,13 +15172,17 @@ msgid ""
 "-Very High =Direct and primary evidence used, or by dominance of the "
 "evidence."
 msgstr ""
-"Överför uppgiftlämnares kvantitativa utvärdering  av tillförlitligheten hos "
+"Överför uppgiftlämnares kvantitativa utvärdering av tillförlitligheten hos "
 "ett stycke information, grundat på stödjande källor. Det är ej avsett för "
 "att eliminera mottagarens behov att utvärdera källorna själva.\n"
-"Mycket låg = Otillförlitliga källor eller uppskattade data\n"
-"Låg = Ifrågasatt tillförlitlighet hos källor (intervjuer, folkräkning, "
+"Mycket låg =Otillförlitliga källor eller uppskattade data\n"
+"Låg =Ifrågasatt tillförlitlighet hos källor (intervjuer, folkräkning, "
 "muntliga uppgifter eller möjlighet till påverkan från t. ex en "
-"självbiografiMycket hög = Direkt eller primär källa använd"
+"självbiografi).\n"
+"Hög =Sekundär källa, informationen är officiellt upprättad förhållandevis "
+"kort tid efter händelsen.\n"
+"Mycket hög =Direkt eller primär källa använd, eller som följer av händelsens "
+"själva natur."
 
 #: ../gramps/gui/glade/editcitation.glade:226
 #: ../gramps/gui/glade/editevent.glade:312
@@ -15340,7 +15192,7 @@ msgstr ""
 #: ../gramps/gui/glade/editmediaref.glade:394
 #: ../gramps/gui/glade/editnote.glade:166
 #: ../gramps/gui/glade/editperson.glade:617
-#: ../gramps/gui/glade/editplace.glade:163
+#: ../gramps/gui/glade/editplace.glade:164
 #: ../gramps/gui/glade/editreporef.glade:352
 #: ../gramps/gui/glade/editrepository.glade:165
 #: ../gramps/gui/glade/editsource.glade:263
@@ -15349,13 +15201,13 @@ msgstr "_ID:"
 
 #: ../gramps/gui/glade/editcitation.glade:240
 msgid "A unique ID to identify the citation"
-msgstr "Ett unikt ID för att identifiera citeringen."
+msgstr "Ett unikt ID för att identifiera citeringen"
 
 #: ../gramps/gui/glade/editcitation.glade:360
 #: ../gramps/gui/glade/editevent.glade:390
 #: ../gramps/gui/glade/editeventref.glade:465
-#: ../gramps/gui/glade/editplace.glade:397
-#: ../gramps/gui/glade/editplaceref.glade:544
+#: ../gramps/gui/glade/editplace.glade:398
+#: ../gramps/gui/glade/editplaceref.glade:545
 #: ../gramps/gui/glade/editrepository.glade:234
 #: ../gramps/gui/glade/editsource.glade:229
 msgid "Tags:"
@@ -15379,7 +15231,7 @@ msgstr "N_ytt år börjar:  "
 
 #: ../gramps/gui/glade/editdate.glade:231
 msgid "Month-Day of first day of new year (e.g., \"1-1\", \"3-1\", \"3-25\")"
-msgstr "Månad-dag för årets första dag (t. ex.  \"1-1\", \"3-1\", \"3-25\")"
+msgstr "Månad-dag för årets första dag (t. ex. \"1-1\", \"3-1\", \"3-25\")"
 
 #: ../gramps/gui/glade/editdate.glade:261
 msgid "Q_uality"
@@ -15445,7 +15297,7 @@ msgid ""
 "the tool 'Extract Event Description'."
 msgstr ""
 "Beskrivning av händelsen. Lämnas tomt om du vill automatiskt skapa detta med "
-"verktyget ' Ta fram händelsbeskrivningar'."
+"verktyget 'Ta fram händelsebeskrivning'."
 
 #: ../gramps/gui/glade/editevent.glade:194
 #: ../gramps/gui/glade/editeventref.glade:270
@@ -15464,7 +15316,7 @@ msgstr "Väljare"
 
 #: ../gramps/gui/glade/editevent.glade:292
 msgid "What type of event this is. Eg 'Burial', 'Graduation', ... ."
-msgstr "Typ av händelse. T. ex. 'Begravning', 'Examen', ..."
+msgstr "Typ av händelse. T. ex. 'Begravning', 'Examen', ... ."
 
 #: ../gramps/gui/glade/editevent.glade:326
 msgid ""
@@ -15477,10 +15329,10 @@ msgstr ""
 #: ../gramps/gui/glade/editevent.glade:375
 #: ../gramps/gui/glade/editeventref.glade:451
 msgid "A unique ID to identify the event"
-msgstr "Ett unikt ID för identifikation av händelsen."
+msgstr "Ett unikt ID för identifikation av händelsen"
 
 #: ../gramps/gui/glade/editeventref.glade:85
-#: ../gramps/gui/glade/editplaceref.glade:85
+#: ../gramps/gui/glade/editplaceref.glade:86
 #: ../gramps/gui/glade/editreporef.glade:97
 msgid "Reference information"
 msgstr "Referensinformation"
@@ -15498,7 +15350,7 @@ msgstr ""
 "återspeglas i händelsen själv och därmed händelsens alla deltagare."
 
 #: ../gramps/gui/glade/editeventref.glade:624
-#: ../gramps/gui/glade/editplaceref.glade:693
+#: ../gramps/gui/glade/editplaceref.glade:694
 #: ../gramps/gui/glade/editreporef.glade:460
 msgid "Shared information"
 msgstr "Delad information"
@@ -15545,7 +15397,7 @@ msgstr "Släktskapsinformation"
 
 #: ../gramps/gui/glade/editfamily.glade:683
 msgid "A unique ID for the family"
-msgstr "Ett unikt IF för familjen"
+msgstr "Ett unikt ID för familjen"
 
 #: ../gramps/gui/glade/editfamily.glade:698
 #: ../gramps/gui/glade/editname.glade:102
@@ -15580,7 +15432,7 @@ msgstr "Redigera flagglistan"
 
 #: ../gramps/gui/glade/editldsord.glade:180
 msgid "Ordinance:"
-msgstr "Prästvigsel:"
+msgstr "Ceremoni:"
 
 #: ../gramps/gui/glade/editldsord.glade:192
 msgid "LDS _Temple:"
@@ -15588,7 +15440,7 @@ msgstr "SDH-_tempel:"
 
 #: ../gramps/gui/glade/editldsord.glade:223
 msgid "_Family:"
-msgstr "_Efternamn:"
+msgstr "_Familj:"
 
 #: ../gramps/gui/glade/editldsord.glade:248
 #: ../gramps/gui/selectors/selectfamily.py:62
@@ -15613,7 +15465,7 @@ msgstr "_Länktyp:"
 
 #: ../gramps/gui/glade/editlocation.glade:107
 msgid "The town or city where the place is."
-msgstr "Den kommun eller stad, där platsen ligger."
+msgstr "Den kommun eller stad där platsen ligger."
 
 #: ../gramps/gui/glade/editlocation.glade:121
 msgid "S_treet:"
@@ -15638,8 +15490,8 @@ msgstr "Lan_dskap:"
 #: ../gramps/gui/glade/editlocation.glade:178
 msgid "Third level of place division. Eg., in the USA a county."
 msgstr ""
-"Tredje platsindelningsnivån. T. ex. i USA är det 'county', i Sverige är det "
-"landskap."
+"Tredje indelningsnivån för platser. T. ex. i USA är det 'county', i Sverige "
+"är det landskap."
 
 #: ../gramps/gui/glade/editlocation.glade:192
 msgid "_State:"
@@ -15650,12 +15502,12 @@ msgid ""
 "Second level of place division, eg., in the USA a state, in Germany a "
 "Bundesland."
 msgstr ""
-"Andra indelningsnivån för platser. t. ex. i USA en delstat, i Sverige ett "
+"Andra indelningsnivån för platser. T. ex. i USA en delstat, i Sverige ett "
 "Län."
 
 #: ../gramps/gui/glade/editlocation.glade:234
 msgid "The country where the place is."
-msgstr "Det land, där platsen ligger."
+msgstr "Det land där platsen ligger."
 
 #: ../gramps/gui/glade/editlocation.glade:299
 msgid "Lowest level of a place division: eg the street name."
@@ -15684,9 +15536,9 @@ msgid ""
 msgstr ""
 "Sökväg för mediaobjekt på din dator.\n"
 "Gramps sparar inte media internt utan bara sökvägar! Sätt 'Relativ sökväg' i "
-"Inställningar så undviker du att skriva om den gemensamma mappen, där alla "
+"Inställningar så undviker du att skriva om den gemensamma mappen där alla "
 "dina media är lagrade. Verktyget 'Mediahanteraren' kan hjälpa dig att "
-"justera sökvägar för an samling mediaobjekt."
+"justera sökvägar för en samling mediaobjekt. "
 
 #: ../gramps/gui/glade/editmedia.glade:219
 #: ../gramps/gui/glade/editmediaref.glade:423
@@ -15709,7 +15561,7 @@ msgstr "Ett unikt ID för att identifiera mediaobjektet."
 #: ../gramps/gui/glade/editmedia.glade:346
 msgid ""
 "A date associated with the media, eg., for a picture the date it is taken."
-msgstr "Ett datum, kopplat till media, t. ex. datum då en bild är tagen."
+msgstr "Ett datum kopplat till media, t. ex. datum då en bild är tagen."
 
 #: ../gramps/gui/glade/editmediaref.glade:119
 msgid "_Corner 2:  X"
@@ -15726,10 +15578,10 @@ msgid ""
 "region. Point (0,0) is the top left corner of the picture, and (100,100) the "
 "bottom right corner."
 msgstr ""
-"Om media är en bild, välj den bilddel du vill referera till.\\ Du kan "
-"använda musen i bilden för att välja ett område eller använda  rullknapparna "
-"för att ställa in översta vänstar hörnet och nedersta högra  i "
-"referensområdet. Punkte (0,0) är bildens övre vänstra hörn och (100,100)  "
+"Om media är en bild, välj den bilddel du vill referera till.\n"
+"Du kan använda musen i bilden för att välja ett område eller använda  "
+"rullknapparna för att ställa in översta vänstra hörnet och nedersta högra i "
+"referensområdet. Punkten (0,0) är bildens övre vänstra hörn och (100,100) "
 "det nedre högra."
 
 #: ../gramps/gui/glade/editmediaref.glade:178
@@ -15741,8 +15593,8 @@ msgid ""
 msgstr ""
 "Refererat område i ett bildmediaobjekt.\n"
 "Välj ett område genom att klicka och hålla ner musknappen på det övre "
-"vänstra hörnet i det område du vill drag sedan musen till nedre högra hörnet "
-"i området och släpp musknappen."
+"vänstra hörnet i det område du önskar drag sedan musen till nedre högra "
+"hörnet i området och släpp musknappen."
 
 #: ../gramps/gui/glade/editmediaref.glade:208
 msgid "_Corner 1:  X"
@@ -15757,10 +15609,10 @@ msgid ""
 "region. Point (0,0) is the top left corner of the picture, and (100,100) the "
 "bottom right corner.\n"
 msgstr ""
-"Om media är en bild, välj den bilddel du vill referera till.\\ Du kan "
-"använda musen i bilden för att välja ett område eller använda  rullknapparna "
-"för att ställa in översta vänstar hörnet och nedersta högra  i "
-"referensområdet. Punkte (0,0) är bildens övre vänstra hörn och (100,100)  "
+"Om media är en bild, välj den bilddel du vill referera till.\n"
+"Du kan använda musen i bilden för att välja ett område eller använda "
+"rullknapparna för att ställa in översta vänstra hörnet och nedersta högra i "
+"referensområdet. Punkten (0,0) är bildens övre vänstra hörn och (100,100) "
 "det nedre högra.\n"
 
 #: ../gramps/gui/glade/editmediaref.glade:459
@@ -15829,14 +15681,14 @@ msgid ""
 "call name is not part of Given name and will not be printed underlined in "
 "some reports."
 msgstr ""
-"Del av förnamn, som är det normalt använda. Om bakgrunden är röd visar detta "
+"Del av förnamn som är det normalt använda. Om bakgrunden är röd visar detta "
 "att tilltalsnamnet inte är del av förnamnet och kommer ej att skrivas "
 "understruket i vissa rapporter."
 
 #: ../gramps/gui/glade/editname.glade:291
 #: ../gramps/gui/glade/editperson.glade:211
 msgid "A title used to refer to the person, such as 'Dr.' or 'Rev.'"
-msgstr "En titel för personen i fråga, såsom Doktor. Sömmerska,"
+msgstr "En titel för personen i fråga, såsom 'Doktor', 'Sömmerska'"
 
 #: ../gramps/gui/glade/editname.glade:304
 #: ../gramps/gui/glade/editperson.glade:225
@@ -15849,8 +15701,8 @@ msgid ""
 "A descriptive name given in place of or in addition to the official given "
 "name."
 msgstr ""
-"Ett beskrivande namn satt i stället för eller som tillägg till den "
-"officiella namnet."
+"Ett beskrivande namn satt i stället för eller som tillägg till det "
+"officiella förnamnet."
 
 #: ../gramps/gui/glade/editname.glade:333
 msgid "Given Name(s) "
@@ -15933,7 +15785,7 @@ msgid ""
 "A Date associated with this name. Eg. for a Married Name, date the name is "
 "first used or marriage date."
 msgstr ""
-"Ett datum kopplat till detta namn. T. ex. för att namn som gift, datum för "
+"Ett datum kopplat till detta namn. T. ex. för ett namn som gift, datum för "
 "första användning eller giftermåls datum."
 
 #: ../gramps/gui/glade/editnote.glade:101
@@ -15976,7 +15828,7 @@ msgstr "_Smeknamn:"
 
 #: ../gramps/gui/glade/editperson.glade:335
 msgid "Click on a table cell to edit."
-msgstr "Klicka på en tabellcell för att redigera"
+msgstr "Klicka på en tabellcell för att redigera."
 
 #: ../gramps/gui/glade/editperson.glade:355
 msgid ""
@@ -16005,13 +15857,13 @@ msgid ""
 "An optional prefix for the family that is not used in sorting, such as \"de"
 "\" or \"van\"."
 msgstr ""
-"Ett valbart prefix till familjenamnet, som ej används för sortering, som \"af"
-"\" eller \"von\""
+"Ett valbart prefix till familjenamnet som ej används för sortering, som \"af"
+"\" eller \"von\"."
 
 #: ../gramps/gui/glade/editperson.glade:485
 msgid ""
 "Part of a person's name indicating the family to which the person belongs"
-msgstr "Del av en persons namn, som visar till vilken familj personen hör"
+msgstr "Del av en persons namn som visar till vilken familj personen hör"
 
 #: ../gramps/gui/glade/editperson.glade:511
 msgid "Go to Name Editor to add more information about this name"
@@ -16057,9 +15909,9 @@ msgid ""
 "occasions. Events can be shared between people, each indicating their role "
 "in the event."
 msgstr ""
-"Beskrivning på koppling, t- ex. gudfader, vän, ...\n"
+"Beskrivning på koppling, t.ex. gudfader, vän, ...\n"
 "\n"
-"OBS: Använd i stället händelser för släktskap till en särskilda tidsepoker "
+"OBS: Använd i stället händelser för släktskap till särskilda tidsepoker "
 "eller tillfällen. Händelser kan delas mellan personer, var och en visande "
 "deras roll i händelsen."
 
@@ -16068,35 +15920,37 @@ msgid ""
 "Use the select button to choose a person that has an association to the "
 "edited person."
 msgstr ""
-"Använd valknappen till att välja en person, som har en koppling till den "
+"Använd valknappen till att välja en person som har en koppling till den "
 "redigerade personen."
 
 #: ../gramps/gui/glade/editpersonref.glade:193
 msgid "Select a person that has an association to the edited person."
-msgstr "Välj den person som har en koppling till den redigerade personen."
+msgstr "Välj en person som har en koppling till den redigerade personen."
 
-#: ../gramps/gui/glade/editplace.glade:105
-#: ../gramps/gui/glade/editplaceref.glade:228
+#: ../gramps/gui/glade/editplace.glade:106
+#: ../gramps/gui/glade/editplaceref.glade:229
 msgid ""
 "Either use the two fields below to enter coordinates (latitude and "
 "longitude),"
 msgstr ""
+"Antingen använd de två fälten nedan för att ange koordinater (latitud och "
+"longitud),"
 
-#: ../gramps/gui/glade/editplace.glade:119
+#: ../gramps/gui/glade/editplace.glade:120
 msgid "L_atitude:"
 msgstr "_Latitud:"
 
-#: ../gramps/gui/glade/editplace.glade:134
+#: ../gramps/gui/glade/editplace.glade:135
 msgid "_Longitude:"
 msgstr "Longit_ud:"
 
-#: ../gramps/gui/glade/editplace.glade:148
-#: ../gramps/gui/glade/editplaceref.glade:445
+#: ../gramps/gui/glade/editplace.glade:149
+#: ../gramps/gui/glade/editplaceref.glade:446
 msgid "Full title of this place."
 msgstr "Komplett namn på denna plats."
 
-#: ../gramps/gui/glade/editplace.glade:176
-#: ../gramps/gui/glade/editplaceref.glade:459
+#: ../gramps/gui/glade/editplace.glade:177
+#: ../gramps/gui/glade/editplaceref.glade:460
 msgid ""
 "Latitude (position above the Equator) of the place in decimal or degree "
 "notation. \n"
@@ -16111,8 +15965,8 @@ msgstr ""
 "Du kan bestämma dessa värden via Geografivyn genom att söka efter platsen "
 "eller via en karttjänst i platsvyn."
 
-#: ../gramps/gui/glade/editplace.glade:191
-#: ../gramps/gui/glade/editplaceref.glade:474
+#: ../gramps/gui/glade/editplace.glade:192
+#: ../gramps/gui/glade/editplaceref.glade:475
 msgid ""
 "Longitude (position relative to the Prime, or Greenwich, Meridian) of the "
 "place in decimal or degree notation. \n"
@@ -16123,58 +15977,60 @@ msgid ""
 msgstr ""
 "Longitud (position relativt Greenwichmeridianen) för platsen som decimal- "
 "eller i gradnotation.\n"
-"Giltiga värden är  t. ex. -124.3647, 124°52′21.92″E, E124°52′21.92″ eller "
+"Giltiga värden är t. ex. -124.3647, 124°52′21.92″E, E124°52′21.92″ eller "
 "124:52:21.92\n"
 "Du kan bestämma dessa värden via Geografivyn genom att söka efter platsen "
 "eller via en karttjänst i platsvyn."
 
-#: ../gramps/gui/glade/editplace.glade:212
-#: ../gramps/gui/glade/editplaceref.glade:350
+#: ../gramps/gui/glade/editplace.glade:213
+#: ../gramps/gui/glade/editplaceref.glade:351
 msgid ""
 "or use copy/paste from your favorite map provider (format : latitude,"
 "longitude) in the following field:"
 msgstr ""
+"eller använd kopiera/klistra in från din favoritkarttjänst (format : latitud,"
+"longitud) i följande fält:"
 
-#: ../gramps/gui/glade/editplace.glade:237
-#: ../gramps/gui/glade/editplaceref.glade:375
+#: ../gramps/gui/glade/editplace.glade:238
+#: ../gramps/gui/glade/editplaceref.glade:376
 msgid ""
 "Field used to paste info from a web page like google, openstreetmap, ... "
 msgstr ""
+"Fält som används för att klistra in information från en webbsida som google, "
+"openstreetmap, ... "
 
-#: ../gramps/gui/glade/editplace.glade:264
-#: ../gramps/gui/glade/editplaceref.glade:495
+#: ../gramps/gui/glade/editplace.glade:265
+#: ../gramps/gui/glade/editplaceref.glade:496
 msgid "A unique ID to identify the place"
-msgstr "Ett unikt ID, som identifierar platsen."
+msgstr "Ett unikt ID, som identifierar platsen"
 
-#: ../gramps/gui/glade/editplace.glade:292
-#: ../gramps/gui/glade/editplaceref.glade:523
+#: ../gramps/gui/glade/editplace.glade:293
+#: ../gramps/gui/glade/editplaceref.glade:524
 msgid "Code associated with this place. Eg Country Code or Postal Code."
 msgstr "Kod kopplad till denna plats. T. ex. landskod eller postnummer."
 
-#: ../gramps/gui/glade/editplace.glade:377
-#: ../gramps/gui/glade/editplaceref.glade:396
+#: ../gramps/gui/glade/editplace.glade:378
+#: ../gramps/gui/glade/editplaceref.glade:397
 msgid "What type of place this is. Eg 'Country', 'City', ... ."
-msgstr "Platsens typ, t. ex. land, stad, ... ,"
+msgstr "Platsens typ, t. ex. land, stad, ... ."
 
-#: ../gramps/gui/glade/editplace.glade:440
-#: ../gramps/gui/glade/editplaceref.glade:598
+#: ../gramps/gui/glade/editplace.glade:441
+#: ../gramps/gui/glade/editplaceref.glade:599
 msgid "The name of this place."
 msgstr "Namnet på denna plats."
 
-#: ../gramps/gui/glade/editplace.glade:455
-#: ../gramps/gui/glade/editplaceref.glade:617
+#: ../gramps/gui/glade/editplace.glade:456
+#: ../gramps/gui/glade/editplaceref.glade:618
 msgid "Invoke place name editor."
-msgstr "Starta platsnamnsredigerare"
+msgstr "Starta platsnamnsredigerare."
 
 #: ../gramps/gui/glade/editplaceformat.glade:124
-#, fuzzy
 msgid "Levels:"
-msgstr "Översta nivå"
+msgstr "Nivåer:"
 
 #: ../gramps/gui/glade/editplaceformat.glade:136
-#, fuzzy
 msgid "Street format:"
-msgstr "Datumformat"
+msgstr "Gatuadressformat:"
 
 #: ../gramps/gui/glade/editplaceformat.glade:148
 #: ../gramps/gui/glade/editplacename.glade:108
@@ -16183,22 +16039,20 @@ msgstr "Språk:"
 
 #: ../gramps/gui/glade/editplaceformat.glade:168
 msgid "Reverse display order"
-msgstr "Omvänt  visningsordning"
+msgstr "Omvänd visningsordning"
 
 #: ../gramps/gui/glade/editplaceformat.glade:186
-#, fuzzy
 msgid "Number Street"
-msgstr "Antal föräldrar"
+msgstr "Gatunummer"
 
 #: ../gramps/gui/glade/editplaceformat.glade:187
-#, fuzzy
 msgid "Street Number"
-msgstr "Gatuadress"
+msgstr "Gatunummer"
 
 #: ../gramps/gui/glade/editplacename.glade:156
 #: ../gramps/plugins/webreport/basepage.py:2585
 msgid "Date range in which the name is valid."
-msgstr "Det datumspan, vid vilket namnet är giltigt."
+msgstr "Det datumintervall i vilket namnet är giltigt."
 
 #: ../gramps/gui/glade/editplacename.glade:169
 msgid "The name of the place."
@@ -16212,7 +16066,7 @@ msgstr ""
 "Det språk namnet är skrivet. Godkända värden är två tecken ISO-koder. T. ex. "
 "sv, en, fr, de ..."
 
-#: ../gramps/gui/glade/editplaceref.glade:294
+#: ../gramps/gui/glade/editplaceref.glade:295
 msgid ""
 "<b>Note:</b> Any changes in the enclosing place information will be "
 "reflected in the place itself, for places that it encloses."
@@ -16231,7 +16085,7 @@ msgstr "_Referensnummer:"
 
 #: ../gramps/gui/glade/editreporef.glade:156
 msgid "On what type of media this source is available in the repository."
-msgstr "På vilket slags media är denna källa tillgänglig på arkivplatsen."
+msgstr "På vilket slags media denna källa är tillgänglig på arkivplatsen."
 
 #: ../gramps/gui/glade/editreporef.glade:209
 msgid "Id number of the source in the repository."
@@ -16298,7 +16152,7 @@ msgid ""
 "Provide a short title used for sorting, filing, and retrieving source "
 "records."
 msgstr ""
-"Lämna en kort titel, som används vid sortering, lagring och återhämtning av "
+"Lämna en kort titel som används vid sortering, lagring och återhämtning av "
 "källposter."
 
 #: ../gramps/gui/glade/editsource.glade:194
@@ -16307,7 +16161,7 @@ msgstr "För_kortning:"
 
 #: ../gramps/gui/glade/editsource.glade:214
 msgid "A unique ID to identify the source"
-msgstr "Ett unikt ID, som identifierar källan."
+msgstr "Ett unikt ID som identifierar källan"
 
 #: ../gramps/gui/glade/editurl.glade:96
 msgid "_Web address:"
@@ -16331,7 +16185,7 @@ msgstr ""
 
 #: ../gramps/gui/glade/editurl.glade:205
 msgid "Open the web address in the default browser."
-msgstr "Öppna webbadressen med standardbläddraren"
+msgstr "Öppna webbadressen med standardwebbläsaren."
 
 #: ../gramps/gui/glade/editurl.glade:217
 msgid "A descriptive caption of the Internet location you are storing."
@@ -16339,7 +16193,7 @@ msgstr "En beskrivning av den internetplats du vill spara."
 
 #: ../gramps/gui/glade/grampletpane.glade:63
 msgid "Drag to move; click to detach"
-msgstr "Drag för att flytta; klicka för att koppla loss."
+msgstr "Dra för att flytta; klicka för att koppla loss"
 
 #: ../gramps/gui/glade/grampletpane.glade:71
 msgid "Config"
@@ -16355,7 +16209,7 @@ msgstr "Klicka för att expandera/implodera"
 
 #: ../gramps/gui/glade/grampletpane.glade:129
 msgid "Click to delete gramplet from view"
-msgstr "Klicka för att radera ett Gramplet"
+msgstr "Klicka för att radera Gramplet"
 
 #: ../gramps/gui/glade/grampletpane.glade:144
 msgid "Delete"
@@ -16518,8 +16372,8 @@ msgid ""
 "Events, lds_ord, media objects, attributes, notes, sources and tags of both "
 "families will be combined."
 msgstr ""
-"Händelser, lds_ord, media objekt, attribut, notiser och källor samt flaggor "
-"för bägge familjer kommer att kombineras."
+"Händelser, sdh_ord, mediaobjekt, attribut, notiser, källor samt flaggor för "
+"bägge familjer kommer att kombineras."
 
 #: ../gramps/gui/glade/mergemedia.glade:97
 msgid ""
@@ -16540,7 +16394,7 @@ msgstr "Objekt 2"
 #: ../gramps/gui/glade/mergemedia.glade:455
 msgid "Attributes, sources, notes and tags of both objects will be combined."
 msgstr ""
-"Attribut, källor och notiser samt flaggor för bägge objekten kommer att "
+"Attribut, källor, notiser samt flaggor för bägge objekten kommer att "
 "kombineras."
 
 #: ../gramps/gui/glade/mergenote.glade:97
@@ -16592,7 +16446,7 @@ msgid ""
 "Events, media objects, addresses, attributes, urls, notes, sources and tags "
 "of both persons will be combined."
 msgstr ""
-"Händelser, mediaobjekt, adresser, attribut, url, notiser och källor samt "
+"Händelser, mediaobjekt, adresser, attribut, url:er, notiser, källor samt "
 "flaggor för bägge personerna kommer att kombineras."
 
 #: ../gramps/gui/glade/mergeperson.glade:500
@@ -16612,7 +16466,7 @@ msgid ""
 "Alternative names, sources, urls, media objects and notes of both places "
 "will be combined."
 msgstr ""
-"Alternativa namn, källor, url-er, mediaobjekt och notiser för bägge "
+"Alternativa namn, källor, url:er, mediaobjekt och notiser för bägge "
 "platserna kommer att kombineras."
 
 #: ../gramps/gui/glade/mergerepository.glade:97
@@ -16634,7 +16488,7 @@ msgstr "Arkivplats 2"
 #: ../gramps/gui/glade/mergerepository.glade:398
 msgid "Addresses, urls and notes of both repositories will be combined."
 msgstr ""
-"Adresser, url och notiser för bägge arkivplatserna kommer att kombineras."
+"Adresser, url:er och notiser för bägge arkivplatserna kommer att kombineras."
 
 #: ../gramps/gui/glade/mergesource.glade:97
 msgid ""
@@ -16708,11 +16562,11 @@ msgstr "H_öger:"
 
 #: ../gramps/gui/glade/papermenu.glade:230
 msgid "_Top:"
-msgstr "_Överkant"
+msgstr "_Överkant:"
 
 #: ../gramps/gui/glade/papermenu.glade:244
 msgid "_Bottom:"
-msgstr "_Nederkant"
+msgstr "_Nederkant:"
 
 #: ../gramps/gui/glade/papermenu.glade:377
 msgid "Metric"
@@ -16749,7 +16603,7 @@ msgstr "Piltopp"
 
 #: ../gramps/gui/glade/reorder.glade:124
 msgid "Move parent up"
-msgstr "Flyttar föräldrar upp"
+msgstr "Flytta förälder upp"
 
 #: ../gramps/gui/glade/reorder.glade:147 ../gramps/gui/glade/reorder.glade:290
 msgid "Arrow bottom"
@@ -16757,19 +16611,19 @@ msgstr "Pilbotten"
 
 #: ../gramps/gui/glade/reorder.glade:154
 msgid "Move parent down"
-msgstr "Flyttar föräldrar ner"
+msgstr "Flytta förälder ner"
 
 #: ../gramps/gui/glade/reorder.glade:205
 msgid "Family relationships"
-msgstr "Familjsläktskap"
+msgstr "Familjesläktskap"
 
 #: ../gramps/gui/glade/reorder.glade:267
 msgid "Move family up"
-msgstr "Flyttar familj upp"
+msgstr "Flytta familj upp"
 
 #: ../gramps/gui/glade/reorder.glade:297
 msgid "Move family down"
-msgstr "Flyttar familj ner"
+msgstr "Flytta familj ner"
 
 #: ../gramps/gui/glade/rule.glade:122
 msgid "Add a new filter"
@@ -16860,11 +16714,11 @@ msgstr "Typsnitt"
 
 #: ../gramps/gui/glade/styleeditor.glade:299
 msgid "_Roman (Times, serif)"
-msgstr "Antikva (Times, se_rif)"
+msgstr "_Roman (Times, serif)"
 
 #: ../gramps/gui/glade/styleeditor.glade:316
 msgid "_Swiss (Arial, Helvetica, sans-serif)"
-msgstr "_Schweizisk (Arial, Helvetica, grotesk)"
+msgstr "_Swiss (Arial, Helvetica, sans-serif)"
 
 #: ../gramps/gui/glade/styleeditor.glade:339
 msgid "Size"
@@ -16873,7 +16727,7 @@ msgstr "Storlek"
 #: ../gramps/gui/glade/styleeditor.glade:369
 #: ../gramps/gui/plug/report/_styleeditor.py:257
 msgid "point size|pt"
-msgstr "Typsnittsstorlek"
+msgstr "pt"
 
 #: ../gramps/gui/glade/styleeditor.glade:416
 msgid "_Bold"
@@ -17020,11 +16874,11 @@ msgstr "Bredd:"
 
 #: ../gramps/gui/glade/styleeditor.glade:1478
 msgid "Line:"
-msgstr "Linje"
+msgstr "Linje:"
 
 #: ../gramps/gui/glade/styleeditor.glade:1491
 msgid "Fill:"
-msgstr "Ifyllnad"
+msgstr "Ifyllnad:"
 
 #: ../gramps/gui/glade/styleeditor.glade:1506
 msgid "Shadow"
@@ -17036,7 +16890,7 @@ msgstr "pt"
 
 #: ../gramps/gui/glade/styleeditor.glade:1605
 msgid "Spacing:"
-msgstr "Mellanrum"
+msgstr "Mellanrum:"
 
 #: ../gramps/gui/glade/styleeditor.glade:1627
 msgid "Draw shadow"
@@ -17069,7 +16923,7 @@ msgstr "_Framåt"
 
 #: ../gramps/gui/glade/updateaddons.glade:41
 msgid "Install Selected _Addons"
-msgstr "Installera valda tillägg"
+msgstr "Installera valda _tillägg"
 
 #: ../gramps/gui/glade/updateaddons.glade:72
 #: ../gramps/gui/plug/_windows.py:1078
@@ -17086,7 +16940,7 @@ msgid ""
 "If you close this dialog now, you can install addons later from the menu "
 "under Edit -> Preferences."
 msgstr ""
-"Gramps kommer med grundläggande uppsättning tillägg, vilka erbjuder alla "
+"Gramps kommer med en grundläggande uppsättning tillägg, vilka erbjuder alla "
 "nödvändiga funktioner. Men du kan utöka denna funktionalitet med extra "
 "tillägg. Dessa tillägg ger dig rapporter, listor, vyer, gramplets m. m. Här "
 "kan du välja bland de tillgängliga tilläggen. De kommer att hämtas via "
@@ -17108,7 +16962,7 @@ msgid ""
 "version which has the function 'require_version' to start Gramps"
 msgstr ""
 "Din version av gi (gnome-introspection) verkar vara för gammal. Du behöver "
-"en version, som har funktionen 'require_version' för att kunna starta Gramps"
+"en version som har funktionen 'require_version' för att kunna starta Gramps"
 
 #: ../gramps/gui/grampsgui.py:74
 #, python-format
@@ -17120,7 +16974,7 @@ msgid ""
 "Gramps will terminate now."
 msgstr ""
 "Din version av pygobject klarar ej kraven.\n"
-"Åtminstone pygobject %(major)d.%(feature)d.%(minor)d  behövs för att starta "
+"Åtminstone pygobject %(major)d.%(feature)d.%(minor)d behövs för att starta "
 "Gramps med ett GUI.\n"
 "\n"
 "Gramps kommer att avslutas nu."
@@ -17135,7 +16989,7 @@ msgid ""
 msgstr ""
 "Gdk, Gtk Pango eller PangoCairo typelib ej installerade.\n"
 "Installera Gnome Introspection, och pygobject version 3.12 eller senare.\n"
-"Installera sedan instrospection data för Gdk, Gtk, Pango  och PangoCairo\n"
+"Installera sedan instrospection data för Gdk, Gtk, Pango och PangoCairo\n"
 "\n"
 "Gramps kommer att avslutas nu."
 
@@ -17147,8 +17001,8 @@ msgid ""
 "\n"
 "Gramps will terminate now."
 msgstr ""
-"Din version av Gtk klarar ej kraven. Åtminstone pygobject %(major)d."
-"%(minor)d behövs för att starta Gramps med ett GUI.\n"
+"Din version av Gtk klarar ej kraven.\n"
+"Åtminstone %(major)d.%(minor)d behövs för att starta Gramps med ett GUI.\n"
 "\n"
 "Gramps kommer att avslutas nu."
 
@@ -17161,7 +17015,7 @@ msgid ""
 "Gramps will terminate now."
 msgstr ""
 "\n"
-"Stöd för cairo python är ej installerat. Installera cairo för din version v "
+"Stöd för cairo python är ej installerat. Installera cairo för din version av "
 "python\n"
 "\n"
 "Gramps kommer att avslutas nu."
@@ -17173,10 +17027,10 @@ msgstr "Varning: Detta är instabil kod!"
 #: ../gramps/gui/grampsgui.py:146
 #, python-format
 msgid "This Gramps ('%s') is a development release.\n"
-msgstr ""
+msgstr "Denna Gramps ('%s') är en utvecklingsversion.\n"
 
 #: ../gramps/gui/grampsgui.py:148
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "This version is not meant for normal usage. Use at your own risk.\n"
 "\n"
@@ -17191,19 +17045,18 @@ msgid ""
 "with this version, and make sure to export your data to XML every now and "
 "then."
 msgstr ""
-"Denna Gramps ('master') är en utvecklingsutgåva. Denna version är ej avsedd "
-"för normalt arbete. Används på egen risk.\n"
+"Denna version är ej avsedd för normal användning. Används på egen risk.\n"
 "\n"
-"This version may:\n"
-"1) Arbetar på annat sätt än förväntat.\n"
+"Denna version kan:\n"
+"1) Arbeta på annat sätt än förväntat.\n"
 "2) Går inte alls att köra.\n"
 "3) Kraschar ofta.\n"
 "4) Förstör dina data.\n"
 "5) Spara data i ett inkompatibelt format jämfört med officiell utgåva.\n"
 "\n"
-"%(bold_start)sBACKUP%(bold_end)s dina befintliga databaser innan du öppnar "
-"dem med denna version och säkerställ att du exporterar dina data till XML "
-"lite då och då."
+"%(bold_start)sSÄKERHETSKOPIERA%(bold_end)s dina befintliga databaser innan "
+"du öppnar dem med denna version och säkerställ att du exporterar dina data "
+"till XML lite då och då."
 
 #: ../gramps/gui/grampsgui.py:178
 msgid "Gramps detected an incomplete GTK installation"
@@ -17241,16 +17094,16 @@ msgid ""
 "by changing the last-view parameter.\n"
 msgstr ""
 "\n"
-"Gramps misslyckades med att starta. Rapportera detta som ena bug.\n"
-"detta skulle kunna bero på en (third party) vy vid uppstart.\n"
+"Gramps misslyckades med att starta. Rapportera detta som en bug.\n"
+"Detta skulle kunna bero på ett annat program, se vid uppstart.\n"
 "För att använda en annan vy, ladda inget släktträd, ändra vy och ladda sedan "
 "ditt släktträd.\n"
-"Du kan även ändra detta manuellt uppstartvyn filen gramps.ini \n"
+"Du kan även ändra detta manuellt i uppstartsfilen gramps.ini \n"
 "genom att ändra parametern \"last-view\".\n"
 
 #: ../gramps/gui/grampsgui.py:365
 msgid "Gramps terminated because of no DISPLAY"
-msgstr ""
+msgstr "Gramps avslutades på grund av ingen DISPLAY"
 
 #: ../gramps/gui/logger/_errorreportassistant.py:97
 msgid "Error Report Assistant"
@@ -17261,7 +17114,6 @@ msgid "Report a bug"
 msgstr "Rapportera ett programfel"
 
 #: ../gramps/gui/logger/_errorreportassistant.py:266
-#, fuzzy
 msgid ""
 "This is the Bug Reporting Assistant. It will help you to make a bug report "
 "to the Gramps developers that will be as detailed as possible.\n"
@@ -17289,7 +17141,7 @@ msgid ""
 "If you can see that there is any personal information included in the error "
 "please remove it."
 msgstr ""
-"Om du ser att det finns någon personlig information i felet, så ta bort den."
+"Om du ser att det finns någon personlig information i felet så ta bort den."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:327
 #: ../gramps/gui/logger/_errorreportassistant.py:355
@@ -17312,7 +17164,7 @@ msgid ""
 "wrong or remove anything that you would rather not have included in the bug "
 "report."
 msgstr ""
-"Kontrollera att informationen nedan och korrigera allt som du vet är fel och "
+"Kontrollera informationen nedan och korrigera allt som du vet är fel eller "
 "ta bort allt som du inte vill ha med i felrapporten."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:407
@@ -17326,14 +17178,13 @@ msgid ""
 "fix the bug."
 msgstr ""
 "Det här är informationen om ditt system som kommer att hjälpa utvecklarna "
-"att fixa felet."
+"att åtgärda felet."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:440
-#, fuzzy
 msgid ""
 "Please provide as much information as you can about what you were doing when "
 "the error occurred."
-msgstr "Beskriv så detaljerat som möjligt vad du gjorde, när felet uppstod."
+msgstr "Beskriv så detaljerat som möjligt vad du gjorde när felet uppstod."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:479
 #: ../gramps/gui/logger/_errorreportassistant.py:504
@@ -17341,7 +17192,6 @@ msgid "Further Information"
 msgstr "Ytterligare information"
 
 #: ../gramps/gui/logger/_errorreportassistant.py:484
-#, fuzzy
 msgid ""
 "This is your opportunity to describe what you were doing when the error "
 "occurred."
@@ -17368,7 +17218,7 @@ msgid ""
 "you to file a bug on the Gramps bug tracking system website."
 msgstr ""
 "Det här är den avslutade felrapporten. Den följande sidan kommer att hjälpa "
-"dig att registrera ett fel i Gramps feluppföljningssystem."
+"dig att registrera en felrapport i Gramps feluppföljningssystem."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:579
 msgid ""
@@ -17394,7 +17244,7 @@ msgid ""
 msgstr ""
 "Använda den här knappen för att kopiera felrapporten till urklipp. Gå sedan "
 "till felspårningssystemets hemsida genom att använda knappen nedan, klistra "
-"in rapporten och klicka skicka rapport."
+"in rapporten och klicka skicka rapport"
 
 #: ../gramps/gui/logger/_errorreportassistant.py:642
 #: ../gramps/gui/logger/_errorreportassistant.py:669
@@ -17437,7 +17287,7 @@ msgid ""
 "please click Report and the Error Reporting Wizard will help you to make a "
 "bug report."
 msgstr ""
-"Dina data är är säkra, men du bör starta om Gramps omedelbart. Om du vill "
+"Dina data är säkra, men du bör starta om Gramps omedelbart. Om du vill "
 "rapportera felet till Gramps utvecklarteam kan du klicka på Rapportera och "
 "du kommer att få hjälp att fylla i en felrapport."
 
@@ -17454,7 +17304,7 @@ msgstr "Filter %s från urklipp"
 #: ../gramps/gui/makefilter.py:46
 #, python-format
 msgid "Created on %(year)4d/%(month)02d/%(day)02d"
-msgstr "Skapade %(year)4d/%(month)02d/%(day)02d"
+msgstr "Skapat %(year)4d/%(month)02d/%(day)02d"
 
 #: ../gramps/gui/merge/mergecitation.py:46
 msgid "manual|Merge_Citations"
@@ -17475,7 +17325,7 @@ msgstr "Slå samman händelser"
 
 #: ../gramps/gui/merge/mergefamily.py:46
 msgid "manual|Merge_Families"
-msgstr "an inte slå samman familjer."
+msgstr "Slå samman familjer."
 
 #: ../gramps/gui/merge/mergefamily.py:68
 msgid "Merge Families"
@@ -17509,9 +17359,9 @@ msgstr "Slå samman personer"
 
 #. translators: needed for French, ignore otherwise
 #: ../gramps/gui/merge/mergeperson.py:62
-#, fuzzy, python-format
+#, python-format
 msgid "%(key)s:\t%(value)s"
-msgstr "%(type)s: %(value)s"
+msgstr "%(key)s:\t%(value)s"
 
 #: ../gramps/gui/merge/mergeperson.py:92
 msgid "Merge People"
@@ -17575,6 +17425,10 @@ msgid ""
 "handle.  We recommend that you go to Relationships view and see if "
 "additional manual merging of families is necessary."
 msgstr ""
+"Personerna har slagits samman.\n"
+"Men familjerna för denna sammanslagning var för komplexa för att hantera "
+"automatiskt. Vi rekommenderar att du går till släktskapsvyn för att se om "
+"ytterligare manuell sammanslagning av familjerna är nödvändig."
 
 #: ../gramps/gui/merge/mergeplace.py:53
 msgid "manual|Merge_Places"
@@ -17582,7 +17436,7 @@ msgstr "Slå samman platser"
 
 #: ../gramps/gui/merge/mergerepository.py:44
 msgid "manual|Merge_Repositories"
-msgstr "manual|Merge_Repositories"
+msgstr "Slå samman arkivplatser"
 
 #: ../gramps/gui/merge/mergesource.py:45
 msgid "manual|Merge_Sources"
@@ -17620,7 +17474,7 @@ msgstr "_Kör"
 msgid "Run selected tool"
 msgstr "Kör valt verktyg"
 
-#: ../gramps/gui/plug/_guioptions.py:82 ../gramps/gui/plug/_guioptions.py:163
+#: ../gramps/gui/plug/_guioptions.py:82 ../gramps/gui/plug/_guioptions.py:165
 msgid "Select surname"
 msgstr "Välj efternamn"
 
@@ -17637,45 +17491,45 @@ msgstr "Letar efternamn"
 msgid "Finding surnames"
 msgstr "Letar efternamn"
 
-#: ../gramps/gui/plug/_guioptions.py:684
+#: ../gramps/gui/plug/_guioptions.py:686
 msgid "Select a different person"
 msgstr "Välj en annan person"
 
-#: ../gramps/gui/plug/_guioptions.py:711
+#: ../gramps/gui/plug/_guioptions.py:713
 msgid "Select a person for the report"
-msgstr "Välj en personen för rapporten"
+msgstr "Välj en person för rapporten"
 
-#: ../gramps/gui/plug/_guioptions.py:794
+#: ../gramps/gui/plug/_guioptions.py:796
 msgid "Select a different family"
 msgstr "Välj en annan familj"
 
-#: ../gramps/gui/plug/_guioptions.py:1251
+#: ../gramps/gui/plug/_guioptions.py:1253
 #, python-format
 msgid "Also include %s?"
 msgstr "Skall även %s tas med?"
 
-#: ../gramps/gui/plug/_guioptions.py:1253
+#: ../gramps/gui/plug/_guioptions.py:1255
 #: ../gramps/gui/selectors/selectperson.py:86
 msgid "Select Person"
 msgstr "Välj person"
 
-#: ../gramps/gui/plug/_guioptions.py:1577
+#: ../gramps/gui/plug/_guioptions.py:1579
 #, python-format
 msgid "Select color for %s"
 msgstr "Välj färg på %s"
 
-#: ../gramps/gui/plug/_guioptions.py:1740
+#: ../gramps/gui/plug/_guioptions.py:1742
 #: ../gramps/gui/plug/report/_reportdialog.py:452
 msgid "Save As"
 msgstr "Spara som"
 
-#: ../gramps/gui/plug/_guioptions.py:1744 ../gramps/gui/plug/_windows.py:442
+#: ../gramps/gui/plug/_guioptions.py:1746 ../gramps/gui/plug/_windows.py:442
 #: ../gramps/gui/plug/report/_bookdialog.py:626
 #: ../gramps/gui/plug/report/_fileentry.py:66
 msgid "_Open"
 msgstr "_Öppna"
 
-#: ../gramps/gui/plug/_guioptions.py:1821
+#: ../gramps/gui/plug/_guioptions.py:1823
 #: ../gramps/gui/plug/report/_reportdialog.py:329
 msgid "Style Editor"
 msgstr "Mallredigerare"
@@ -17859,11 +17713,8 @@ msgstr[0] "{number_of} tillägg installerades."
 msgstr[1] "{number_of} tillägg installerades."
 
 #: ../gramps/gui/plug/_windows.py:1222
-#, fuzzy
 msgid "If you have installed a 'Gramps View', you will need to restart Gramps."
-msgstr ""
-"När vald, använd webkit, annars används mozilla.\n"
-"Gramps måste startas om."
+msgstr "Om du har installerat en 'Grampsvy' behöver du starta om Gramps."
 
 #: ../gramps/gui/plug/_windows.py:1226
 msgid "No addons were installed."
@@ -17912,8 +17763,8 @@ msgstr ""
 "\n"
 "Format:\t%s\n"
 "\n"
-"Tryck Verkställ för att fortsätta, Avbryt för att avbryta eller Bakåt för "
-"att återse alternativ."
+"Tryck Verkställ för att fortsätta, Bakåt för att återse alternativ eller "
+"Avbryt för att avbryta"
 
 #: ../gramps/gui/plug/export/_exportassistant.py:465
 #, python-format
@@ -17929,11 +17780,11 @@ msgstr ""
 "Data kommer att sparas enligt följande:\n"
 "\n"
 "Format:\t%(format)s\n"
-"Name:\t%(name)s\n"
-"Folder:\t%(folder)s\n"
+"Namn:\t%(name)s\n"
+"Mapp:\t%(folder)s\n"
 "\n"
-"Tryck Verkställ för att fortsätta, Avbryt för att avbryta eller Bakåt för "
-"att återse alternativ."
+"Tryck Verkställ för att fortsätta, Bakåt för att återse alternativ eller "
+"Avbryt för att avbryta"
 
 #: ../gramps/gui/plug/export/_exportassistant.py:475
 msgid ""
@@ -17941,10 +17792,10 @@ msgid ""
 "\n"
 "Press Back to return and select a valid filename."
 msgstr ""
-"Den valda filen och katalogen, som skall sparas till, kan ej skapas eller "
-"bli funnen.\n"
+"Den valda filen och katalogen som skall sparas till kan ej skapas eller bli "
+"funnen.\n"
 "\n"
-"Tryck Back för att återvända och välj ett giltigt filnamn."
+"Tryck Bakåt för att återvända och välj ett giltigt filnamn."
 
 #: ../gramps/gui/plug/export/_exportassistant.py:502
 msgid "Your data has been saved"
@@ -18038,16 +17889,16 @@ msgstr "Ofiltrerat släktträd:"
 #. translators: leave all/any {...} untranslated
 #: ../gramps/gui/plug/export/_exportoptions.py:167
 #: ../gramps/gui/plug/export/_exportoptions.py:274
-#: ../gramps/gui/plug/export/_exportoptions.py:574
+#: ../gramps/gui/plug/export/_exportoptions.py:577
 #, python-brace-format
 msgid "{number_of} Person"
 msgid_plural "{number_of} People"
-msgstr[0] "{number_of} Person"
-msgstr[1] "{number_of} Personer"
+msgstr[0] "{number_of} person"
+msgstr[1] "{number_of} personer"
 
 #: ../gramps/gui/plug/export/_exportoptions.py:170
 msgid "Click to see preview of unfiltered data"
-msgstr "Klicka för granska ofiltrerade data"
+msgstr "Klicka för att granska ofiltrerade data"
 
 #: ../gramps/gui/plug/export/_exportoptions.py:182
 msgid "_Do not include records marked private"
@@ -18085,7 +17936,7 @@ msgstr "Privatfilter"
 
 #: ../gramps/gui/plug/export/_exportoptions.py:324
 msgid "Click to see preview after privacy filter"
-msgstr "Klicka för granska efter privatfilter"
+msgstr "Klicka för att granska efter privatfilter"
 
 #. Frame 4:
 #: ../gramps/gui/plug/export/_exportoptions.py:327
@@ -18108,68 +17959,66 @@ msgstr "Klicka för att granska efter referensfilter"
 msgid "Hide order"
 msgstr "Dölj ordning"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:589
+#: ../gramps/gui/plug/export/_exportoptions.py:592
 msgid "Filtering private data"
 msgstr "Filtrerar privata data"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:598
+#: ../gramps/gui/plug/export/_exportoptions.py:601
 msgid "Filtering living persons"
 msgstr "Filtrerar levande personer"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:615
+#: ../gramps/gui/plug/export/_exportoptions.py:618
 msgid "Applying selected person filter"
 msgstr "Tillämpar valt personfilter"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:625
+#: ../gramps/gui/plug/export/_exportoptions.py:628
 msgid "Applying selected note filter"
 msgstr "Tillämpar valt notisfilter"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:634
+#: ../gramps/gui/plug/export/_exportoptions.py:637
 msgid "Filtering referenced records"
 msgstr "Filtrerar refererade poster"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:675
+#: ../gramps/gui/plug/export/_exportoptions.py:678
 msgid "Cannot edit a system filter"
 msgstr "Kan inte redigera systemfilter"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:676
+#: ../gramps/gui/plug/export/_exportoptions.py:679
 msgid "Please select a different filter to edit"
-msgstr "Välj ett annan filter att redigera"
+msgstr "Välj ett annat filter att redigera"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:706
-#: ../gramps/gui/plug/export/_exportoptions.py:730
+#: ../gramps/gui/plug/export/_exportoptions.py:709
+#: ../gramps/gui/plug/export/_exportoptions.py:733
 msgid "Include all selected people"
-msgstr "Ta bara med alla valda personer"
+msgstr "Ta med alla valda personer"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:720
+#: ../gramps/gui/plug/export/_exportoptions.py:723
 msgid "Include all selected notes"
 msgstr "Ta med alla valda notiser"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:731
+#: ../gramps/gui/plug/export/_exportoptions.py:734
 msgid "Replace given names of living people"
 msgstr "Byt ut förnamn på levande personer"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:732
-#, fuzzy
+#: ../gramps/gui/plug/export/_exportoptions.py:735
 msgid "Replace complete name of living people"
-msgstr "Byt ut förnamn på levande personer"
+msgstr "Byt ut fullständigt namn på levande personer"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:733
+#: ../gramps/gui/plug/export/_exportoptions.py:736
 msgid "Do not include living people"
 msgstr "Tag ej med levande personer"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:742
+#: ../gramps/gui/plug/export/_exportoptions.py:745
 msgid "Include all selected records"
 msgstr "Ta med valda poster"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:743
+#: ../gramps/gui/plug/export/_exportoptions.py:746
 msgid "Do not include records not linked to a selected person"
 msgstr "Ta inte med poster ej länkade till en vald person"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:764
-#, fuzzy
+#: ../gramps/gui/plug/export/_exportoptions.py:767
 msgid "Use Compression"
-msgstr "Använd reguljärt uttryck"
+msgstr "Använd komprimering"
 
 #: ../gramps/gui/plug/quick/_quickreports.py:94
 msgid "Web Connect"
@@ -18209,11 +18058,11 @@ msgstr "Tillgängliga böcker"
 
 #: ../gramps/gui/plug/report/_bookdialog.py:240
 msgid "Discard Unsaved Changes"
-msgstr "Kasta osparade ändringar?"
+msgstr "Kasta osparade ändringar"
 
 #: ../gramps/gui/plug/report/_bookdialog.py:241
 msgid "You have made changes which have not been saved."
-msgstr "Du har gjort ändringar, som inte har sparats."
+msgstr "Du har gjort ändringar som inte har sparats."
 
 #: ../gramps/gui/plug/report/_bookdialog.py:242
 #: ../gramps/gui/plug/report/_bookdialog.py:738
@@ -18225,9 +18074,8 @@ msgid "Name of the book. MANDATORY"
 msgstr "Namn på bok. OBLIGATORISKT"
 
 #: ../gramps/gui/plug/report/_bookdialog.py:323
-#, fuzzy
 msgid "Manage Books"
-msgstr "Tillgängliga böcker"
+msgstr "Hantera böcker"
 
 #: ../gramps/gui/plug/report/_bookdialog.py:362
 msgid "New Book"
@@ -18319,7 +18167,7 @@ msgid ""
 msgstr ""
 "Du är på väg att spara en bok utan namn.\n"
 "\n"
-"Ange ett namn innan du sparar det."
+"Ange ett namn innan du sparar den."
 
 #: ../gramps/gui/plug/report/_bookdialog.py:735
 msgid "Book name already exists"
@@ -18327,12 +18175,11 @@ msgstr "Boknamnet finns redan"
 
 #: ../gramps/gui/plug/report/_bookdialog.py:736
 msgid "You are about to save away a book with a name which already exists."
-msgstr "Du är på väg att spara en bok med ett namn, som redan finns."
+msgstr "Du är på väg att spara en bok med ett namn som redan finns."
 
 #: ../gramps/gui/plug/report/_bookdialog.py:926
-#, fuzzy
 msgid "Generate Book"
-msgstr "Skapad av"
+msgstr "Skapa bok"
 
 #: ../gramps/gui/plug/report/_bookdialog.py:969
 msgid "Gramps Book"
@@ -18406,7 +18253,7 @@ msgstr "Mall"
 #: ../gramps/plugins/drawreport/calendarreport.py:466
 #: ../gramps/plugins/drawreport/descendtree.py:1568
 #: ../gramps/plugins/drawreport/fanchart.py:685
-#: ../gramps/plugins/drawreport/statisticschart.py:986
+#: ../gramps/plugins/drawreport/statisticschart.py:997
 #: ../gramps/plugins/drawreport/timeline.py:413
 #: ../gramps/plugins/graph/gvfamilylines.py:115
 #: ../gramps/plugins/graph/gvhourglass.py:315
@@ -18462,8 +18309,8 @@ msgstr "Filen finns redan"
 msgid ""
 "You can choose to either overwrite the file, or change the selected filename."
 msgstr ""
-"Du kan välja att antingen skriva över filen eller att ändra det\n"
-"filnamn som valts."
+"Du kan välja att antingen skriva över filen eller att ändra det valda "
+"filnamnet."
 
 #: ../gramps/gui/plug/report/_reportdialog.py:516
 msgid "_Overwrite"
@@ -18549,9 +18396,8 @@ msgstr "Saknad information"
 
 #: ../gramps/gui/plug/report/_styleeditor.py:166
 #: ../gramps/gui/plug/report/_styleeditor.py:180
-#, fuzzy
 msgid "Select a style"
-msgstr "Välj fil"
+msgstr "Välj en mall"
 
 #: ../gramps/gui/plug/report/_styleeditor.py:226
 #: ../gramps/gui/plug/report/_styleeditor.py:298
@@ -18568,7 +18414,7 @@ msgstr "Beskrivning saknas"
 #: ../gramps/gui/plug/report/_styleeditor.py:344
 #, python-format
 msgid "(Embedded style '%s' must be edited separately)"
-msgstr ""
+msgstr "(Inbäddat format '%s' måste redigeras separat)"
 
 #: ../gramps/gui/plug/report/_styleeditor.py:397
 #, python-format
@@ -18627,7 +18473,7 @@ msgstr ""
 
 #: ../gramps/gui/selectors/selectcitation.py:51
 msgid "manual|Select_Source_or_Citation_selector"
-msgstr "Välj selektor för  källa eller citering"
+msgstr "Välj selektor för källa eller citering"
 
 #: ../gramps/gui/selectors/selectcitation.py:67
 msgid "Select Source or Citation"
@@ -18636,7 +18482,7 @@ msgstr "Välj källa eller citering"
 #: ../gramps/gui/selectors/selectcitation.py:74
 #: ../gramps/plugins/view/citationtreeview.py:93
 msgid "Source: Title or Citation: Volume/Page"
-msgstr "Källa; Titel eller citering: Volym/Sida"
+msgstr "Källa: Titel eller citering: Volym/Sida"
 
 #: ../gramps/gui/selectors/selectcitation.py:76
 #: ../gramps/gui/selectors/selectevent.py:75
@@ -18660,7 +18506,7 @@ msgstr "Välj händelse"
 
 #: ../gramps/gui/selectors/selectfamily.py:46
 msgid "manual|Select_Family_selector"
-msgstr "Välj familje selektor"
+msgstr "Välj familjeselektor"
 
 #: ../gramps/gui/selectors/selectnote.py:49
 msgid "manual|Select_Note_selector"
@@ -18723,13 +18569,13 @@ msgid ""
 "You have no installed dictionaries. Either install one or disable spell "
 "checking"
 msgstr ""
-"Du har inga installerade ordböcker. Antingen installera någon eller tag bort "
-"rättstavning"
+"Du har inga installerade ordböcker. Antingen installera någon eller "
+"avaktivera rättstavning"
 
 #: ../gramps/gui/spell.py:153
 #, python-format
 msgid "Spelling checker initialization failed: %s"
-msgstr "Installation av stavningskontroll misslyckades: %s"
+msgstr "Start av stavningskontroll misslyckades: %s"
 
 #: ../gramps/gui/tipofday.py:67 ../gramps/gui/tipofday.py:68
 #: ../gramps/gui/tipofday.py:121 ../gramps/gui/viewmanager.py:538
@@ -18747,7 +18593,7 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
-"Kan ej läsa tipsfilen från extern fil.\n"
+"Kan ej läsa tipsen från extern fil.\n"
 "\n"
 "%s"
 
@@ -18756,12 +18602,12 @@ msgid "Undo History"
 msgstr "Redigeringshistorik"
 
 #: ../gramps/gui/undohistory.py:84 ../gramps/gui/viewmanager.py:647
-#: ../gramps/gui/viewmanager.py:1331
+#: ../gramps/gui/viewmanager.py:1329
 msgid "_Undo"
 msgstr "_Ångra"
 
 #: ../gramps/gui/undohistory.py:86 ../gramps/gui/viewmanager.py:652
-#: ../gramps/gui/viewmanager.py:1348
+#: ../gramps/gui/viewmanager.py:1346
 msgid "_Redo"
 msgstr "Åte_rställ"
 
@@ -18805,12 +18651,12 @@ msgstr "Avbryter..."
 
 #: ../gramps/gui/utils.py:310
 msgid "Please do not force closing this important dialog."
-msgstr "Försök inte stänga den här viktiga dialogrutan med våld."
+msgstr "Försök inte tvinga nedstängning av den här viktiga dialogrutan."
 
 #: ../gramps/gui/utils.py:374
 msgid "The external program failed to launch or experienced an error"
 msgstr ""
-"Det gick ej att starta det externa programmet eller det signalerade ett fel"
+"Det gick ej att starta det externa programmet eller avbröts med ett fel"
 
 #: ../gramps/gui/utils.py:384
 msgid "Error from external program"
@@ -18834,9 +18680,9 @@ msgid ""
 msgstr ""
 "Kan ej öppna en citeringsredigerare just nu. Antingen redigeras citeringen "
 "redan eller redigeras den kopplade källan. Att öppna citeringsredigerare "
-"( som även tillåter att källan redigeras) skulle skapa tvetydigheter med två "
+"(som även tillåter att källan redigeras) skulle skapa tvetydigheter med två "
 "redigerare med samma källa. \n"
-"ns\n"
+"\n"
 "För att redigera en citering, så stäng källredigeraren och öppna en "
 "redigerare enbart för citeringen"
 
@@ -18844,10 +18690,9 @@ msgstr ""
 msgid "Cannot open new citation editor"
 msgstr "Kan inte öppna ny citeringsredigerare"
 
-#: ../gramps/gui/viewmanager.py:470 ../gramps/gui/viewmanager.py:1267
-#, fuzzy
+#: ../gramps/gui/viewmanager.py:470 ../gramps/gui/viewmanager.py:1265
 msgid "No Family Tree"
-msgstr "Släktträd"
+msgstr "Inget släktträd"
 
 #: ../gramps/gui/viewmanager.py:492
 msgid "Connect to a recent database"
@@ -18907,7 +18752,7 @@ msgstr "_Om"
 
 #: ../gramps/gui/viewmanager.py:532
 msgid "_Plugin Manager"
-msgstr "_Instickshanterare"
+msgstr "_Insticksmodulshanterare"
 
 #: ../gramps/gui/viewmanager.py:534
 msgid "_FAQ"
@@ -18922,9 +18767,8 @@ msgid "_User Manual"
 msgstr "Användarhand_bok"
 
 #: ../gramps/gui/viewmanager.py:544
-#, fuzzy
 msgid "Close the current database"
-msgstr "Anslut till en tidigare databas"
+msgstr "Stäng den nuvarande databasen"
 
 #: ../gramps/gui/viewmanager.py:545
 msgid "_Export..."
@@ -19005,7 +18849,7 @@ msgstr "_Verktygsrad"
 
 #: ../gramps/gui/viewmanager.py:642
 msgid "F_ull Screen"
-msgstr "F_ull skärm"
+msgstr "F_ullskärm"
 
 #: ../gramps/gui/viewmanager.py:658
 msgid "Undo History..."
@@ -19034,7 +18878,7 @@ msgid ""
 "Aborting changes will return the database to the state it was before you "
 "started this editing session."
 msgstr ""
-"Att överge ändringar innebär att databasen återställs till utseendet före "
+"Att överge ändringar innebär att databasen återställs till tillståndet före "
 "den här redigeringssessionen."
 
 #: ../gramps/gui/viewmanager.py:844
@@ -19055,29 +18899,29 @@ msgstr ""
 
 #: ../gramps/gui/viewmanager.py:1017
 msgid "View failed to load. Check error output."
-msgstr "Vy gick aj att ladda. Kontrollera felutskrift."
+msgstr "Vy gick ej att ladda. Kontrollera felutskrift."
 
 #: ../gramps/gui/viewmanager.py:1169
 msgid "Import Statistics"
 msgstr "Importstatistik"
 
-#: ../gramps/gui/viewmanager.py:1237
+#: ../gramps/gui/viewmanager.py:1240
 msgid "Read Only"
 msgstr "Skrivskyddad"
 
-#: ../gramps/gui/viewmanager.py:1394
+#: ../gramps/gui/viewmanager.py:1392
 msgid "Autobackup..."
 msgstr "Automatisk säkerhetskopiering..."
 
-#: ../gramps/gui/viewmanager.py:1399
+#: ../gramps/gui/viewmanager.py:1397
 msgid "Error saving backup data"
 msgstr "Fel vid sparande av säkerhetskopiedata"
 
-#: ../gramps/gui/viewmanager.py:1690
+#: ../gramps/gui/viewmanager.py:1688
 msgid "Failed Loading View"
 msgstr "Misslyckades med att ladda vy"
 
-#: ../gramps/gui/viewmanager.py:1691
+#: ../gramps/gui/viewmanager.py:1689
 #, python-format
 msgid ""
 "The view %(name)s did not load and reported an error.\n"
@@ -19095,18 +18939,18 @@ msgstr ""
 "\n"
 "%(error_msg)s\n"
 "\n"
-"Om du inte kan rätta till felet själv, så kan du skicka in en felrapport via "
+"Om du inte kan rätta till felet själv så kan du skicka in en felrapport via "
 "%(gramps_bugtracker_url)s eller kontakta författaren "
 "(%(firstauthoremail)s).\n"
 "\n"
 "Om du inte vill att Gramps skall försöka ladda denna vy igen, kan du gömma "
-"den genom att använda Insticksmodulshanterareen under Hjälp-meny."
+"den genom att använda Insticksmodulshanteraren under Hjälp-menyn."
 
-#: ../gramps/gui/viewmanager.py:1783
+#: ../gramps/gui/viewmanager.py:1781
 msgid "Failed Loading Plugin"
 msgstr "Misslyckades med att ladda insticksmodul"
 
-#: ../gramps/gui/viewmanager.py:1784
+#: ../gramps/gui/viewmanager.py:1782
 #, python-format
 msgid ""
 "The plugin %(name)s did not load and reported an error.\n"
@@ -19124,62 +18968,62 @@ msgstr ""
 "\n"
 "%(error_msg)s\n"
 "\n"
-"Om du inte kan rätta till felet själv, så kan du skicka in en felrapport via "
+"Om du inte kan rätta till felet själv så kan du skicka in en felrapport via "
 "%(gramps_bugtracker_url)s eller kontakta författaren "
 "(%(firstauthoremail)s).\n"
 "\n"
 "Om du inte vill att Gramps skall försöka ladda denna modul igen, kan du "
-"gömma den genom att använda Insticksmodulshanteraren under Hjälp-meny."
+"gömma den genom att använda Insticksmodulshanteraren under Hjälp-menyn."
 
-#: ../gramps/gui/viewmanager.py:1864
+#: ../gramps/gui/viewmanager.py:1862
 msgid "Gramps XML Backup"
 msgstr "Gramps XML-säkerhetskopia"
 
-#: ../gramps/gui/viewmanager.py:1893
+#: ../gramps/gui/viewmanager.py:1891
 msgid "File:"
 msgstr "Fil:"
 
-#: ../gramps/gui/viewmanager.py:1925
+#: ../gramps/gui/viewmanager.py:1923
 msgid "Media:"
 msgstr "Media:"
 
-#: ../gramps/gui/viewmanager.py:1932
+#: ../gramps/gui/viewmanager.py:1930
 #: ../gramps/plugins/gramplet/statsgramplet.py:139
 #: ../gramps/plugins/webreport/statistics.py:144
 msgid "Megabyte|MB"
 msgstr "MB"
 
-#: ../gramps/gui/viewmanager.py:1934
+#: ../gramps/gui/viewmanager.py:1932
 msgid "Exclude"
 msgstr "Uteslut"
 
-#: ../gramps/gui/viewmanager.py:1954
+#: ../gramps/gui/viewmanager.py:1952
 msgid "Backup file already exists! Overwrite?"
 msgstr "Säkerhetskopia finns redan! Skriva över?"
 
-#: ../gramps/gui/viewmanager.py:1955
+#: ../gramps/gui/viewmanager.py:1953
 #, python-format
 msgid "The file '%s' exists."
 msgstr "Filen '%s' finns."
 
-#: ../gramps/gui/viewmanager.py:1956
+#: ../gramps/gui/viewmanager.py:1954
 msgid "Proceed and overwrite"
 msgstr "Fortsätt och skriv över"
 
-#: ../gramps/gui/viewmanager.py:1957
+#: ../gramps/gui/viewmanager.py:1955
 msgid "Cancel the backup"
 msgstr "Avbryt säkerhetskopieringen"
 
-#: ../gramps/gui/viewmanager.py:1972
+#: ../gramps/gui/viewmanager.py:1970
 msgid "Making backup..."
 msgstr "Tar säkerhetskopia..."
 
-#: ../gramps/gui/viewmanager.py:1985
+#: ../gramps/gui/viewmanager.py:1983
 #, python-format
 msgid "Backup saved to '%s'"
 msgstr "Säkerhetskopia sparad till ' %s'"
 
-#: ../gramps/gui/viewmanager.py:1988
+#: ../gramps/gui/viewmanager.py:1986
 msgid "Backup aborted"
 msgstr "Säkerhetskopiering avbruten"
 
@@ -19220,7 +19064,7 @@ msgstr "R_edigera..."
 
 #: ../gramps/gui/views/listview.py:442
 msgid "Active object not visible"
-msgstr "Aktivt objekt är inte synlig"
+msgstr "Aktivt objekt är inte synligt"
 
 #: ../gramps/gui/views/listview.py:452
 #: ../gramps/gui/views/navigationview.py:257
@@ -19228,11 +19072,11 @@ msgstr "Aktivt objekt är inte synlig"
 #: ../gramps/plugins/lib/maps/geography.py:220
 #: ../gramps/plugins/view/familyview.py:222
 msgid "Could Not Set a Bookmark"
-msgstr "Kunde inte infoga ett bokmärke"
+msgstr "Kunde inte lägga till ett bokmärke"
 
 #: ../gramps/gui/views/listview.py:453
 msgid "A bookmark could not be set because nothing was selected."
-msgstr "Inget bokmärke kunde läggas till eftersom inget valts."
+msgstr "Bokmärke kunde ej läggas till eftersom inget valts."
 
 #: ../gramps/gui/views/listview.py:545
 msgid "Multiple Selection Delete"
@@ -19259,7 +19103,7 @@ msgid ""
 "This item is currently being used. Deleting it will remove it from the "
 "database and from all other items that reference it."
 msgstr ""
-"Den här posten används för närvarande. Om du raderar den, så kommer den att "
+"Den här posten används för närvarande. Om du raderar den så kommer den att "
 "tas bort från databasen och från alla poster som refererar till den."
 
 #: ../gramps/gui/views/listview.py:564 ../gramps/plugins/view/familyview.py:269
@@ -19307,7 +19151,7 @@ msgstr "%s har lagts till i bokmärkena"
 #: ../gramps/plugins/lib/maps/geography.py:221
 #: ../gramps/plugins/view/familyview.py:223
 msgid "A bookmark could not be set because no one was selected."
-msgstr "Inget bokmärke kunde infogas eftersom ingen hade valts."
+msgstr "Bokmärke kunde ej läggas till eftersom inget hade valts."
 
 #: ../gramps/gui/views/navigationview.py:274
 msgid "_Add Bookmark"
@@ -19345,7 +19189,7 @@ msgstr "Välj _hemperson"
 
 #: ../gramps/gui/views/navigationview.py:338
 msgid "No Home Person"
-msgstr "Hemperson är inte bestämd."
+msgstr "Hemperson är inte bestämd"
 
 #: ../gramps/gui/views/navigationview.py:339
 msgid ""
@@ -19360,7 +19204,7 @@ msgstr ""
 #: ../gramps/gui/views/navigationview.py:349
 #: ../gramps/gui/views/navigationview.py:352
 msgid "Jump to by Gramps ID"
-msgstr "Hoppa till Gramps-ID"
+msgstr "Hoppa till efter Gramps-ID"
 
 #: ../gramps/gui/views/navigationview.py:376
 #, python-format
@@ -19444,7 +19288,7 @@ msgid ""
 "The tag definition will be removed.  The tag will be also removed from all "
 "objects in the database."
 msgstr ""
-"Flagdefinitionen kommer att tas bort. Flaggan kommer även att tas bort från "
+"Flaggdefinitionen kommer att tas bort. Flaggan kommer även att tas bort från "
 "alla objekt i databasen."
 
 #: ../gramps/gui/views/tags.py:528
@@ -19503,14 +19347,9 @@ msgstr "Välj en färg"
 msgid "Error in format"
 msgstr "Formatfel"
 
-#: ../gramps/gui/views/treemodels/treebasemodel.py:534
-#: ../gramps/gui/views/treemodels/treebasemodel.py:579
-msgid "Loading items..."
-msgstr "Laddar detaljer"
-
 #: ../gramps/gui/widgets/buttons.py:159
 msgid "Record is private"
-msgstr "Posten när privat"
+msgstr "Posten är privat"
 
 #: ../gramps/gui/widgets/buttons.py:163
 msgid "Record is public"
@@ -19554,7 +19393,7 @@ msgstr "Släkt"
 
 #: ../gramps/gui/widgets/fanchart.py:1806
 msgid "Add partner to person"
-msgstr "Lägger partner till en person"
+msgstr "Lägg partner till en person"
 
 #: ../gramps/gui/widgets/fanchart.py:1813
 msgid "Add a person"
@@ -19566,7 +19405,7 @@ msgid "Add Child to Family"
 msgstr "Lägg till barn till familjen"
 
 #: ../gramps/gui/widgets/grampletbar.py:206
-#: ../gramps/gui/widgets/grampletpane.py:1189
+#: ../gramps/gui/widgets/grampletpane.py:1186
 msgid "Unnamed Gramplet"
 msgstr "Gramplet utan namn"
 
@@ -19580,7 +19419,7 @@ msgid ""
 "gramplets."
 msgstr ""
 "Välj pil neråt till höger för att lägga till, ta bort eller återställa "
-"gramplets"
+"gramplets."
 
 #: ../gramps/gui/widgets/grampletbar.py:486
 #: ../gramps/plugins/view/dashboardview.py:100
@@ -19604,36 +19443,36 @@ msgid ""
 "The gramplet bar will be restored to contain its default gramplets.  This "
 "action cannot be undone."
 msgstr ""
-"Grampletpanelen kommer att återställas med sina standar gramplets. Denna "
+"Grampletpanelen kommer att återställas med sina standard gramplets. Denna "
 "åtgärd kan ej ångras."
 
 #. default tooltip
-#: ../gramps/gui/widgets/grampletpane.py:811
+#: ../gramps/gui/widgets/grampletpane.py:808
 msgid "Drag Properties Button to move and click it for setup"
 msgstr "Drag egenskapsknappen för att flytta och klicka på den för inställning"
 
 #. build the GUI:
-#: ../gramps/gui/widgets/grampletpane.py:1007
+#: ../gramps/gui/widgets/grampletpane.py:1004
 msgid "Right click to add gramplets"
-msgstr "Högerklicka för att få fler Gramplets"
+msgstr "Högerklicka för att lägga till Gramplets"
 
-#: ../gramps/gui/widgets/grampletpane.py:1054
+#: ../gramps/gui/widgets/grampletpane.py:1051
 msgid "Untitled Gramplet"
 msgstr "Gramplet utan namn"
 
-#: ../gramps/gui/widgets/grampletpane.py:1542
+#: ../gramps/gui/widgets/grampletpane.py:1539
 msgid "Number of Columns"
 msgstr "Antal kolumner"
 
-#: ../gramps/gui/widgets/grampletpane.py:1547
+#: ../gramps/gui/widgets/grampletpane.py:1544
 msgid "Gramplet Layout"
 msgstr "Gramplet layout"
 
-#: ../gramps/gui/widgets/grampletpane.py:1577
+#: ../gramps/gui/widgets/grampletpane.py:1574
 msgid "Use maximum height available"
 msgstr "Använd maximalt tillgänglig höjd"
 
-#: ../gramps/gui/widgets/grampletpane.py:1583
+#: ../gramps/gui/widgets/grampletpane.py:1580
 msgid "Height if not maximized"
 msgstr "Höjd om ej maximerad"
 
@@ -19660,7 +19499,7 @@ msgstr "Datum senare än ett år i framtiden"
 msgid ""
 "Double-click on the picture to view it in the default image viewer "
 "application."
-msgstr "Dubbelklicka på bilden så syns den i standardbildvisaren."
+msgstr "Dubbelklicka på bilden så visas den i standardbildvisaren."
 
 #: ../gramps/gui/widgets/photo.py:87
 msgid "Make Active Media"
@@ -19672,6 +19511,8 @@ msgid ""
 "Matches places within a given distance of the active place. You have no "
 "active place."
 msgstr ""
+"Matchar platser inom ett givet avstånd från den aktiva platsen. Du har ingen "
+"aktiv plats."
 
 #: ../gramps/gui/widgets/progressdialog.py:298
 msgid "Progress Information"
@@ -19686,82 +19527,86 @@ msgstr "Ordna om släktskap"
 msgid "Reorder Relationships: %s"
 msgstr "Ordna om släktskap: %s"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:318
+#: ../gramps/gui/widgets/styledtexteditor.py:317
 msgid ""
 "\n"
 "Command-Click to follow link"
 msgstr ""
+"\n"
+"Kommando-klick för att följa länk"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:319
+#: ../gramps/gui/widgets/styledtexteditor.py:318
 msgid ""
 "\n"
 "Ctrl-Click to follow link"
 msgstr ""
+"\n"
+"Ctrl-klick för att följa länk"
 
 #. spell checker submenu
-#: ../gramps/gui/widgets/styledtexteditor.py:367
+#: ../gramps/gui/widgets/styledtexteditor.py:366
 msgid "Spellcheck"
 msgstr "Stavning"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:372
+#: ../gramps/gui/widgets/styledtexteditor.py:371
 msgid "Search selection on web"
 msgstr "Sök val på nätet"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:383
+#: ../gramps/gui/widgets/styledtexteditor.py:382
 msgid "_Send Mail To..."
 msgstr "_Skicka e-post till..."
 
-#: ../gramps/gui/widgets/styledtexteditor.py:385
+#: ../gramps/gui/widgets/styledtexteditor.py:384
 msgid "Copy _E-mail Address"
 msgstr "Kopiera _e-postadress"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:388
+#: ../gramps/gui/widgets/styledtexteditor.py:387
 msgid "_Open Link"
 msgstr "_Öppna länk"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:390
+#: ../gramps/gui/widgets/styledtexteditor.py:389
 msgid "Copy _Link Address"
 msgstr "Kopiera _länkadress"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:394
+#: ../gramps/gui/widgets/styledtexteditor.py:393
 msgid "_Edit Link"
 msgstr "_Redigera länk"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:466
+#: ../gramps/gui/widgets/styledtexteditor.py:465
 msgid "Font Color"
 msgstr "Typsnittsfärg"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:468
+#: ../gramps/gui/widgets/styledtexteditor.py:467
 msgid "Background Color"
 msgstr "Bakgrundsfärg"
 
+#: ../gramps/gui/widgets/styledtexteditor.py:471
 #: ../gramps/gui/widgets/styledtexteditor.py:472
-#: ../gramps/gui/widgets/styledtexteditor.py:473
 msgid "Clear Markup"
 msgstr "Rensa markering"
 
+#: ../gramps/gui/widgets/styledtexteditor.py:512
 #: ../gramps/gui/widgets/styledtexteditor.py:513
-#: ../gramps/gui/widgets/styledtexteditor.py:514
 msgid "Undo"
 msgstr "Ångra"
 
+#: ../gramps/gui/widgets/styledtexteditor.py:516
 #: ../gramps/gui/widgets/styledtexteditor.py:517
-#: ../gramps/gui/widgets/styledtexteditor.py:518
 msgid "Redo"
 msgstr "Återställ"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:645
+#: ../gramps/gui/widgets/styledtexteditor.py:644
 msgid "Select font color"
 msgstr "Välj färg på teckensnitt"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:649
+#: ../gramps/gui/widgets/styledtexteditor.py:648
 msgid "Select background color"
 msgstr "Välj bakgrundsfärg"
 
 #: ../gramps/gui/widgets/validatedmaskedentry.py:1154
 #, python-format
 msgid "'%s' is not a valid value for this field"
-msgstr "'%s' är ej ett giltigt värde för detta fält"
+msgstr "'%s' är inte ett giltigt värde för detta fält"
 
 #: ../gramps/gui/widgets/validatedmaskedentry.py:1197
 msgid "This field is mandatory"
@@ -19771,27 +19616,26 @@ msgstr "Detta fält är obligatoriskt"
 #: ../gramps/gui/widgets/validatedmaskedentry.py:1246
 #, python-format
 msgid "'%s' is not a valid date value"
-msgstr "'%s' är ej ett giltigt datumvärde"
+msgstr "'%s' är inte ett giltigt datumvärde"
 
 #: ../gramps/plugins/db/bsddb/bsddb.gpr.py:26
 msgid "BSDDB"
-msgstr ""
+msgstr "BSDDB"
 
 #: ../gramps/plugins/db/bsddb/bsddb.gpr.py:27
-#, fuzzy
 msgid "_BSDDB Database"
-msgstr "Hela databasen"
+msgstr "_BSDDB-databas"
 
 #: ../gramps/plugins/db/bsddb/bsddb.gpr.py:28
 msgid "Berkeley Software Distribution Database Backend"
-msgstr ""
+msgstr "Berkeley Software Distribution Database Backend"
 
 #: ../gramps/plugins/db/bsddb/upgrade.py:410
 #, python-format
 msgid ""
 "%(n1)6d  People        upgraded with %(n2)6d citations in %(n3)6d secs\n"
 msgstr ""
-"%(n1)6d  personer        uppgraderade med %(n2)6d citeringar i  %(n3)6d "
+"%(n1)6d  personer        uppgraderade med %(n2)6d citeringar i %(n3)6d "
 "sekunder\n"
 
 #: ../gramps/plugins/db/bsddb/upgrade.py:411
@@ -19799,7 +19643,7 @@ msgstr ""
 msgid ""
 "%(n1)6d  Families      upgraded with %(n2)6d citations in %(n3)6d secs\n"
 msgstr ""
-"%(n1)6d  familjer        uppgraderade med %(n2)6d citeringar i  %(n3)6d "
+"%(n1)6d  familjer      uppgraderade med %(n2)6d citeringar i %(n3)6d "
 "sekunder\n"
 
 #: ../gramps/plugins/db/bsddb/upgrade.py:412
@@ -19807,7 +19651,7 @@ msgstr ""
 msgid ""
 "%(n1)6d  Events        upgraded with %(n2)6d citations in %(n3)6d secs\n"
 msgstr ""
-"%(n1)6d  händelser        uppgraderade med %(n2)6d citeringar i  %(n3)6d  "
+"%(n1)6d  händelser        uppgraderade med %(n2)6d citeringar i %(n3)6d "
 "sekunder\n"
 
 #: ../gramps/plugins/db/bsddb/upgrade.py:413
@@ -19815,15 +19659,14 @@ msgstr ""
 msgid ""
 "%(n1)6d  Media Objects upgraded with %(n2)6d citations in %(n3)6d secs\n"
 msgstr ""
-"%(n1)6d  mediaobjekt        uppgraderade med %(n2)6d citeringar i  %(n3)6d  "
-"sekunder\n"
+"%(n1)6d  mediaobjekt uppgraderade med %(n2)6d citeringar i %(n3)6d sekunder\n"
 
 #: ../gramps/plugins/db/bsddb/upgrade.py:414
 #, python-format
 msgid ""
 "%(n1)6d  Places        upgraded with %(n2)6d citations in %(n3)6d secs\n"
 msgstr ""
-"%(n1)6d  platser        uppgraderade med %(n2)6d citeringar i  %(n3)6d "
+"%(n1)6d  platser        uppgraderade med %(n2)6d citeringar i %(n3)6d "
 "sekunder\n"
 
 #: ../gramps/plugins/db/bsddb/upgrade.py:415
@@ -19831,7 +19674,7 @@ msgstr ""
 msgid ""
 "%(n1)6d  Repositories  upgraded with %(n2)6d citations in %(n3)6d secs\n"
 msgstr ""
-"%(n1)6d  arkivplatser        uppgraderade med %(n2)6d citeringar i %(n3)6d "
+"%(n1)6d  arkivplatser  uppgraderade med %(n2)6d citeringar i %(n3)6d "
 "sekunder\n"
 
 #: ../gramps/plugins/db/bsddb/upgrade.py:416
@@ -19839,7 +19682,7 @@ msgstr ""
 msgid ""
 "%(n1)6d  Sources       upgraded with %(n2)6d citations in %(n3)6d secs\n"
 msgstr ""
-"%(n1)6d  platser        uppgraderade med %(n2)6d citeringar i %(n3)6d "
+"%(n1)6d  källor       uppgraderade med %(n2)6d citeringar i %(n3)6d "
 "sekunder\n"
 
 #: ../gramps/plugins/db/bsddb/upgrade.py:801
@@ -19860,30 +19703,30 @@ msgstr ""
 "Du kanske vill köra\n"
 "Verktyg -> Bearbetning av släktträd -> Slå samman\n"
 "för att slå samman citeringar som innehåller liknande\n"
-"that contain similar information"
+"information"
 
 #: ../gramps/plugins/db/bsddb/upgrade.py:814
 msgid "Upgrade Statistics"
-msgstr "Uppgadera statistik"
+msgstr "Uppgradera statistik"
 
-#: ../gramps/plugins/db/bsddb/write.py:1153
+#: ../gramps/plugins/db/bsddb/write.py:1154
 #, python-format
 msgid ""
 "An attempt is made to save a reference key which is partly bytecode, this is "
 "not allowed.\n"
 "Key is %s"
 msgstr ""
-"Ett försök att spara en referensnyckel, som delvis är bytecode, detta är ej "
-"tillåtet.\n"
+"Ett försök gjordes att spara en referensnyckel som delvis är bytecode, detta "
+"är ej tillåtet.\n"
 "Nyckel är %s"
 
 #. Make a tuple of the functions and classes that we need for
 #. each of the primary object tables.
-#: ../gramps/plugins/db/bsddb/write.py:1220
+#: ../gramps/plugins/db/bsddb/write.py:1221
 msgid "Rebuild reference map"
 msgstr "Bygg om referenskarta"
 
-#: ../gramps/plugins/db/bsddb/write.py:1984
+#: ../gramps/plugins/db/bsddb/write.py:1986
 #, python-format
 msgid ""
 "A second transaction is started while there is still a transaction, \"%s\", "
@@ -19892,35 +19735,30 @@ msgstr ""
 "En andra transaktion har påbörjats medan det fortfarande finns en "
 "transaktion, \"%s\", aktiv i databasen."
 
-#: ../gramps/plugins/db/bsddb/write.py:2305
+#: ../gramps/plugins/db/bsddb/write.py:2307
 #: ../gramps/plugins/db/dbapi/sqlite.py:61
-#, fuzzy
 msgid "Database version"
-msgstr "Bsddb-version"
+msgstr "Databasversion"
 
 #: ../gramps/plugins/db/dbapi/sqlite.gpr.py:26
 msgid "SQLite"
-msgstr ""
+msgstr "SQLite"
 
 #: ../gramps/plugins/db/dbapi/sqlite.gpr.py:27
-#, fuzzy
 msgid "_SQLite Database"
-msgstr "Hela databasen"
+msgstr "_SQLite-databas"
 
 #: ../gramps/plugins/db/dbapi/sqlite.gpr.py:28
-#, fuzzy
 msgid "SQLite Database"
-msgstr "Hela databasen"
+msgstr "SQLite-databas"
 
 #: ../gramps/plugins/db/dbapi/sqlite.py:62
-#, fuzzy
 msgid "Database module version"
-msgstr "Bsddb-version"
+msgstr "Databasmodulversion"
 
 #: ../gramps/plugins/db/dbapi/sqlite.py:63
-#, fuzzy
 msgid "Database module location"
-msgstr "Ingen datuminformation"
+msgstr "Databasmodulplats"
 
 #: ../gramps/plugins/docgen/asciidoc.py:469
 msgid "Characters per line"
@@ -19996,7 +19834,7 @@ msgstr "SVG-dokument"
 
 #: ../gramps/plugins/docgen/docgen.gpr.py:204
 msgid "Generates documents in Scalable Vector Graphics format (.svg)."
-msgstr "Skapar ett dokument i formatet Scalable Vector Graphics (.svg)."
+msgstr "Skapar dokument i formatet Scalable Vector Graphics (.svg)."
 
 #: ../gramps/plugins/docgen/gtkprint.glade:6
 msgid "Print Preview"
@@ -20004,7 +19842,7 @@ msgstr "Förhandsgranskning av utskrift"
 
 #: ../gramps/plugins/docgen/gtkprint.glade:26
 msgid "Closes print preview window"
-msgstr "Stänger utskriftsförhandsgranskningsfönstret"
+msgstr "Stänger förhandsgranskningsfönstret för utskrift"
 
 #: ../gramps/plugins/docgen/gtkprint.glade:41
 msgid "Prints the current file"
@@ -20062,9 +19900,9 @@ msgid ""
 "that you consider using a different directory to store your generated web "
 "pages."
 msgstr ""
-"Du verkar ha satt din målmapp till en mapp, som används för datalagring. "
+"Du verkar ha satt din målmapp till en mapp som används för datalagring. "
 "Detta skulle kunna skapa problem med filhantering. Det rekommenderas att du "
-"bör välja en annan mapp till att lagra webbsidor."
+"bör välja en annan mapp till att lagra dina webbsidor."
 
 #: ../gramps/plugins/docgen/htmldoc.py:553
 #, python-format
@@ -20073,19 +19911,17 @@ msgstr "Kunde inte skapa jpeg-version av bild %(name)s"
 
 #: ../gramps/plugins/docgen/latexdoc.py:1240
 msgid "PIL (Python Imaging Library) not loaded."
-msgstr ""
+msgstr "PIL (Python Imaging Library) inte laddat."
 
 #: ../gramps/plugins/docgen/latexdoc.py:1241
-#, fuzzy
 msgid ""
 "Production of jpg images from non-jpg images in LaTeX documents will not be "
 "available. Use your package manager to install python-imaging or python-"
 "pillow or python3-pillow"
 msgstr ""
-"PIL (Python Imaging Library) ej laddat. Skapande av jpg-bilder från icke-jpg "
-"bilder i LaTeX dokument kommer inte att vara tillgängligt. Använd din "
-"pakethanterare till att installera python3-imaging eller python3-pillow "
-"eller python3-pillow"
+"Konvertering av jpg-bilder från icke-jpg-bilder i LaTeX-dokument är inte "
+"möjligt. Använd din pakethanterare att installera python-imaging eller "
+"python-pillow eller python3-pillow"
 
 #: ../gramps/plugins/docgen/odfdoc.py:1182
 #, python-format
@@ -20201,12 +20037,12 @@ msgstr "Huvudpersonen för trädet"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:798
 msgid "Include siblings of the center person"
-msgstr "Ta med syskon till centralpersonen"
+msgstr "Ta med syskon till huvudpersonen"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:800
 msgid ""
 "Whether to only display the center person or all of his/her siblings too"
-msgstr "Huruvida enbart visa centerpersonen eller alla syskonen också"
+msgstr "Huruvida enbart visa huvudpersonen eller alla hans/hennes syskon också"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:804
 #: ../gramps/plugins/drawreport/descendtree.py:1533
@@ -20221,7 +20057,7 @@ msgstr "Generationer"
 #: ../gramps/plugins/drawreport/ancestortree.py:805
 #: ../gramps/plugins/drawreport/descendtree.py:1534
 msgid "The number of generations to include in the tree"
-msgstr "Antal generationer, som skall tas med i trädet"
+msgstr "Antal generationer som skall tas med i trädet"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:809
 msgid ""
@@ -20233,7 +20069,7 @@ msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:811
 msgid "The number of generations of empty boxes that will be displayed"
-msgstr "Det antal generationer med tomma rutor, som kommer att visas"
+msgstr "Det antal generationer med tomma rutor som kommer att visas"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:818
 #: ../gramps/plugins/drawreport/descendtree.py:1551
@@ -20245,7 +20081,7 @@ msgid ""
 "Whether to remove any extra blank spaces set aside for people that are "
 "unknown"
 msgstr ""
-"Huruvida ta bort några extra tomma utrymmen, reserverade för okända personer"
+"Huruvida ta bort några extra tomma utrymmen reserverade för okända personer"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:837
 #: ../gramps/plugins/drawreport/descendtree.py:1570
@@ -20275,7 +20111,7 @@ msgstr "Ta med en kant"
 #: ../gramps/plugins/drawreport/ancestortree.py:844
 #: ../gramps/plugins/drawreport/descendtree.py:1584
 msgid "Whether to make a border around the report."
-msgstr "Huruvida göra en ram runt rapporten .."
+msgstr "Huruvida göra en ram runt rapporten."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:847
 #: ../gramps/plugins/drawreport/descendtree.py:1587
@@ -20289,7 +20125,7 @@ msgstr "Huruvida skriva ut sidnummer på varje sida."
 #: ../gramps/plugins/drawreport/ancestortree.py:851
 #: ../gramps/plugins/drawreport/descendtree.py:1591
 msgid "Scale tree to fit"
-msgstr "Anpassa träd genom skalning"
+msgstr "Skala om träd så det passar"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:852
 #: ../gramps/plugins/drawreport/descendtree.py:1592
@@ -20299,17 +20135,17 @@ msgstr "Skala inte om trädet"
 #: ../gramps/plugins/drawreport/ancestortree.py:853
 #: ../gramps/plugins/drawreport/descendtree.py:1593
 msgid "Scale tree to fit page width only"
-msgstr "Skala om trädet för att anpassa till enbart till sidobredd"
+msgstr "Skala om trädet för att anpassa enbart till sidobredd"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:854
 #: ../gramps/plugins/drawreport/descendtree.py:1594
 msgid "Scale tree to fit the size of the page"
-msgstr "Skala om träd för att passa på en enda sida"
+msgstr "Skala om trädet för att anpassa till sidstorleken"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:856
 #: ../gramps/plugins/drawreport/descendtree.py:1596
 msgid "Whether to scale the tree to fit a specific paper size"
-msgstr "Huruvida skala om att passa för en särskild storlek"
+msgstr "Huruvida skala om trädet för att passa till en särskild storlek"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:863
 #: ../gramps/plugins/drawreport/descendtree.py:1603
@@ -20318,7 +20154,8 @@ msgid ""
 "\n"
 "Note: Overrides options in the 'Paper Option' tab"
 msgstr ""
-"Skala om sida att passa trädstorlek.\n"
+"Skala om sida att passa trädstorlek\n"
+"\n"
 "Notera: Tar över val i fliken för pappersval"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:869
@@ -20339,21 +20176,21 @@ msgid ""
 "With 'Scale tree to fit the size of the page' the page\n"
 "  is resized to remove any gap in either height or width"
 msgstr ""
-"Huruvida skala om sidan att passa trädstorleken\n"
-"\n"
-"Notera: sidan kommer att få en avvikande storlek.\n"
+"Huruvida skala om sidan att passa \n"
+"trädstorleken.  Notera:  sidan kommer att få en \n"
+"avvikande storlek.\n"
 "\n"
 "Med detta alternativ valt kommer följande att ske:\n"
 "\n"
 "Med alternativet 'Skala inte om träd' kommer sidan att\n"
-"anpassas till höjd/bredd på trädet\n"
+"  anpassas till höjd/bredd på trädet\n"
 "\n"
 "Med alternativet 'Skala om träd att passa endast bredd'\n"
-"kommer höjden på sidan att skalas om till höjden på trädet.\n"
+"  kommer höjden på sidan att skalas om till höjden på trädet.\n"
 "\n"
 " Med alternativet 'Skala om träd att passa sidstorlek'\n"
-"kommer sidan att skalas om så att allt tomrum i \n"
-"antingen sida eller höjd försvinner."
+"  kommer sidan att skalas om så att allt tomrum i antingen höjd eller bredd "
+"tas bort"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:889
 #: ../gramps/plugins/drawreport/descendtree.py:1629
@@ -20363,7 +20200,7 @@ msgstr "Ta med blanka sidor"
 #: ../gramps/plugins/drawreport/ancestortree.py:890
 #: ../gramps/plugins/drawreport/descendtree.py:1630
 msgid "Whether to include pages that are blank."
-msgstr "Huruvida ta med sidor, som är blanka."
+msgstr "Huruvida ta med sidor som är blanka."
 
 #. #################
 #. #########################
@@ -20377,7 +20214,7 @@ msgstr "Huruvida ta med sidor, som är blanka."
 #: ../gramps/plugins/drawreport/calendarreport.py:494
 #: ../gramps/plugins/drawreport/descendtree.py:1634
 #: ../gramps/plugins/drawreport/fanchart.py:728
-#: ../gramps/plugins/drawreport/statisticschart.py:1045
+#: ../gramps/plugins/drawreport/statisticschart.py:1056
 #: ../gramps/plugins/drawreport/timeline.py:434
 #: ../gramps/plugins/graph/gvfamilylines.py:162
 #: ../gramps/plugins/graph/gvhourglass.py:352
@@ -20393,9 +20230,8 @@ msgstr "Huruvida ta med sidor, som är blanka."
 #: ../gramps/plugins/textreport/placereport.py:461
 #: ../gramps/plugins/textreport/recordsreport.py:243
 #: ../gramps/plugins/webreport/webcal.py:1664
-#, fuzzy
 msgid "Report Options (2)"
-msgstr "Rapportalternativ"
+msgstr "Rapportalternativ (2)"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:911
 msgid ""
@@ -20444,9 +20280,8 @@ msgid "Use Mothers display format"
 msgstr "Använd moders visningsformat"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:938
-#, fuzzy
 msgid "The display format for the center person"
-msgstr "Vilket visningsformat, som skall användas för huvudpersonen"
+msgstr "Visningsformatet för huvudpersonen"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:941
 #: ../gramps/plugins/drawreport/descendtree.py:1670
@@ -20456,7 +20291,7 @@ msgstr "Ta med giftermålsruta"
 #: ../gramps/plugins/drawreport/ancestortree.py:943
 #: ../gramps/plugins/drawreport/descendtree.py:1672
 msgid "Whether to include a separate marital box in the report"
-msgstr "Huruvida ta med separat giftermålsruta i rapporten."
+msgstr "Huruvida ta med separat giftermålsruta i rapporten"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:947
 #: ../gramps/plugins/drawreport/descendtree.py:1676
@@ -20506,12 +20341,12 @@ msgstr ""
 #: ../gramps/plugins/drawreport/ancestortree.py:969
 #: ../gramps/plugins/drawreport/descendtree.py:1691
 msgid "Include a note"
-msgstr "Ta en notis"
+msgstr "Ta med en notis"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:970
 #: ../gramps/plugins/drawreport/descendtree.py:1692
 msgid "Whether to include a note on the report."
-msgstr ".Huruvida ta med en notis i rapporten."
+msgstr "Huruvida ta med en notis i rapporten."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:975
 #: ../gramps/plugins/drawreport/descendtree.py:1697
@@ -20520,8 +20355,7 @@ msgid ""
 "\n"
 "$T inserts today's date"
 msgstr ""
-"Notis att lägga till\n"
-"till trädet\n"
+"Lägg till en notis\n"
 "\n"
 "$T inflikar dagens datum"
 
@@ -20537,7 +20371,7 @@ msgstr "Var notisen skall placeras."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:987
 msgid "inter-box scale factor"
-msgstr "Skalfaktor mellan rutor"
+msgstr "skalfaktor mellan rutor"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:990
 msgid "Make the inter-box spacing bigger or smaller"
@@ -20564,7 +20398,7 @@ msgstr "En uppsättning tomma rutor för okända förfäder"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:1032
 msgid " Generations of empty boxes for unknown ancestors"
-msgstr "Flera uppsättningar tomma rutor för okända förfäder"
+msgstr " Flera uppsättningar tomma rutor för okända förfäder"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:1049
 #: ../gramps/plugins/drawreport/descendtree.py:1776
@@ -20597,7 +20431,7 @@ msgstr "Grundläggande mall som används för visning av notiser."
 #: ../gramps/plugins/drawreport/ancestortree.py:1068
 #: ../gramps/plugins/drawreport/descendtree.py:1767
 #: ../gramps/plugins/drawreport/fanchart.py:759
-#: ../gramps/plugins/drawreport/statisticschart.py:1130
+#: ../gramps/plugins/drawreport/statisticschart.py:1141
 #: ../gramps/plugins/drawreport/timeline.py:497
 #: ../gramps/plugins/textreport/alphabeticalindex.py:103
 #: ../gramps/plugins/textreport/ancestorreport.py:363
@@ -20657,8 +20491,8 @@ msgstr "%(person)s, födelse"
 #, python-brace-format
 msgid "{person}, {age}"
 msgid_plural "{person}, {age}"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "{person}, {age}"
+msgstr[1] "{person}, {age}"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:425
 #: ../gramps/plugins/textreport/birthdayreport.py:373
@@ -20690,7 +20524,7 @@ msgstr[1] ""
 #: ../gramps/plugins/drawreport/calendarreport.py:472
 #: ../gramps/plugins/webreport/webcal.py:1628
 msgid "Select filter to restrict people that appear on calendar"
-msgstr "Välj ett filter, som begränsar vilka personer, som tas med på kalender"
+msgstr "Välj ett filter som begränsar vilka personer som tas med på kalender"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:477
 #: ../gramps/plugins/drawreport/fanchart.py:688
@@ -20786,7 +20620,7 @@ msgstr "Välj veckans första dag för kalendern"
 #: ../gramps/plugins/textreport/birthdayreport.py:474
 #: ../gramps/plugins/webreport/webcal.py:1744
 msgid "Birthday surname"
-msgstr "Namn vid födseln"
+msgstr "Efternamn vid födseln"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:549
 #: ../gramps/plugins/textreport/birthdayreport.py:477
@@ -20820,9 +20654,8 @@ msgstr "Ta med födelsedagar"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:558
 #: ../gramps/plugins/textreport/birthdayreport.py:486
-#, fuzzy
 msgid "Whether to include birthdays"
-msgstr "Huruvida ta med bilder."
+msgstr "Huruvida ta med födelsedagar"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:561
 #: ../gramps/plugins/textreport/birthdayreport.py:489
@@ -20832,13 +20665,12 @@ msgstr "Ta med årsdagar"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:562
 #: ../gramps/plugins/textreport/birthdayreport.py:490
-#, fuzzy
 msgid "Whether to include anniversaries"
-msgstr "Huruvida ta med bilder."
+msgstr "Huruvida ta med årsdagar"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:631
 msgid "Title text and background color"
-msgstr "Rubriktext och bakgrundsfärg"
+msgstr "Titeltext och bakgrundsfärg"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:635
 msgid "Calendar day numbers"
@@ -20846,7 +20678,7 @@ msgstr "Dagnummer i kalender"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:638
 msgid "Daily text display"
-msgstr "Daglig text"
+msgstr "Visning av daglig text"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:640
 msgid "Holiday text display"
@@ -20874,20 +20706,20 @@ msgstr "Text vid nederkant, rad 3"
 #: ../gramps/plugins/drawreport/descendtree.py:158
 #, python-format
 msgid "Descendant Chart for %(person)s and %(father1)s, %(mother1)s"
-msgstr "Stamtavla för  %(person)s och %(father1)s, %(mother1)s"
+msgstr "Stamtavla för %(person)s och %(father1)s, %(mother1)s"
 
 #. Should be 2 items in names list
 #: ../gramps/plugins/drawreport/descendtree.py:165
 #, python-format
 msgid "Descendant Chart for %(person)s, %(father1)s and %(mother1)s"
-msgstr "Stamtavla för  %(person)s, %(father1)s och %(mother1)s"
+msgstr "Stamtavla för %(person)s, %(father1)s och %(mother1)s"
 
 #. Should be 2 items in both names and names2 lists
 #: ../gramps/plugins/drawreport/descendtree.py:172
 #, python-format
 msgid ""
 "Descendant Chart for %(father1)s, %(father2)s and %(mother1)s, %(mother2)s"
-msgstr "Stamtavla för  %(father1)s, %(father2)s samt %(mother1)s, %(mother2)s"
+msgstr "Stamtavla för %(father1)s, %(father2)s samt %(mother1)s, %(mother2)s"
 
 #: ../gramps/plugins/drawreport/descendtree.py:182
 #, python-format
@@ -20923,7 +20755,7 @@ msgstr "Kusintavla för %(names)s"
 #: ../gramps/plugins/drawreport/descendtree.py:759
 #, python-format
 msgid "Family %s is not in the Database"
-msgstr "Famil %s saknas i databasen"
+msgstr "Familj %s saknas i databasen"
 
 #. if self.name == "familial_descend_tree":
 #: ../gramps/plugins/drawreport/descendtree.py:1525
@@ -21007,7 +20839,7 @@ msgstr ""
 
 #: ../gramps/plugins/drawreport/descendtree.py:1653
 msgid "Display format for a descendant."
-msgstr "Visningsformat för ättlingar."
+msgstr "Visningsformat för en ättling."
 
 #. bug 4767
 #. diffspouse = BooleanOption(
@@ -21025,7 +20857,7 @@ msgstr ""
 
 #: ../gramps/plugins/drawreport/descendtree.py:1667
 msgid "Display format for a spouse."
-msgstr "Visningsformat för make/make."
+msgstr "Visningsformat för make/maka."
 
 #: ../gramps/plugins/drawreport/descendtree.py:1709
 msgid "inter-box Y scale factor"
@@ -21033,11 +20865,11 @@ msgstr "Y-skalfaktor innerruta"
 
 #: ../gramps/plugins/drawreport/descendtree.py:1711
 msgid "Make the inter-box Y bigger or smaller"
-msgstr "Gör innerrutans Y större eller mindre"
+msgstr "Gör innerrutan Y större eller mindre"
 
 #: ../gramps/plugins/drawreport/descendtree.py:1787
 msgid "The bold style used for the text display."
-msgstr "Fetstilsmall mall som används för textvisning."
+msgstr "Fetstilsmall som används för textvisning."
 
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:37
 msgid "Ancestor Chart"
@@ -21053,7 +20885,7 @@ msgstr "Skapar en grafisk antavla"
 
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:76
 msgid "Produces a graphical calendar"
-msgstr "Skapar en grafisk kalender."
+msgstr "Skapar en grafisk kalender"
 
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:97
 msgid "Descendant Chart"
@@ -21061,7 +20893,7 @@ msgstr "Stamtavla"
 
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:98
 msgid "Produces a graphical descendant chart"
-msgstr "Skapar en grafisk stamtavla."
+msgstr "Skapar en grafisk stamtavla"
 
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:113
 msgid "Descendant Tree"
@@ -21069,7 +20901,7 @@ msgstr "Stamtavla"
 
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:114
 msgid "Produces a graphical descendant tree"
-msgstr "Skapar ett grafisk stamträd."
+msgstr "Skapar ett grafisk stamträd"
 
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:135
 msgid "Family Descendant Chart"
@@ -21077,7 +20909,7 @@ msgstr "Familjestamtavla"
 
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:136
 msgid "Produces a graphical descendant chart around a family"
-msgstr "Skapar ett grafisk stamtavla utgående från en familj"
+msgstr "Skapar en grafisk stamtavla utgående från en familj"
 
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:152
 msgid "Family Descendant Tree"
@@ -21097,25 +20929,26 @@ msgstr "Antavla i cirkelformat"
 
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:176
 msgid "Produces fan charts"
-msgstr "Skapar en grafisk antavla i cirkelformat."
+msgstr "Skapar grafiska antavlor i cirkelformat"
 
 #. extract requested items from the database and count them
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:197
-#: ../gramps/plugins/drawreport/statisticschart.py:801
-#: ../gramps/plugins/drawreport/statisticschart.py:811
-#: ../gramps/plugins/drawreport/statisticschart.py:845
-#: ../gramps/plugins/drawreport/statisticschart.py:846
+#: ../gramps/plugins/drawreport/statisticschart.py:812
+#: ../gramps/plugins/drawreport/statisticschart.py:822
+#: ../gramps/plugins/drawreport/statisticschart.py:856
+#: ../gramps/plugins/drawreport/statisticschart.py:857
 msgid "Statistics Charts"
-msgstr "Statistik"
+msgstr "Statistikdiagram"
 
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:198
 msgid "Produces statistical bar and pie charts of the people in the database"
-msgstr "Skapar stapel- och cirkeldiagram över personerna i databasen."
+msgstr ""
+"Skapar statistiska stapel- och cirkeldiagram över personerna i databasen"
 
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:221
 #: ../gramps/plugins/drawreport/timeline.py:274
 msgid "Timeline Chart"
-msgstr "Livslängdslinjer"
+msgstr "Tidslinjediagram"
 
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:222
 msgid "Produces a timeline chart."
@@ -21142,7 +20975,7 @@ msgstr ""
 #: ../gramps/plugins/textreport/detancestralreport.py:833
 #: ../gramps/plugins/textreport/detdescendantreport.py:1024
 msgid "The number of generations to include in the report"
-msgstr "Antal generationer, som skall tas med i rapporten"
+msgstr "Antal generationer som skall tas med i rapporten"
 
 #: ../gramps/plugins/drawreport/fanchart.py:696
 msgid "Type of graph"
@@ -21194,7 +21027,7 @@ msgstr "Rita tomma rutor"
 
 #: ../gramps/plugins/drawreport/fanchart.py:718
 msgid "Draw the background although there is no information"
-msgstr "Fyll med bakgrundsfärg när informations saknas"
+msgstr "Fyll med bakgrundsfärg även när information saknas"
 
 #: ../gramps/plugins/drawreport/fanchart.py:722
 msgid "Use one font style for all generations"
@@ -21209,7 +21042,7 @@ msgstr ""
 #: ../gramps/plugins/drawreport/fanchart.py:780
 #, python-format
 msgid "The style used for the text display of generation \"%d\""
-msgstr "Mall som används för textvisning av generation  \"%d\""
+msgstr "Mall som används för textvisning av generation \"%d\""
 
 #: ../gramps/plugins/drawreport/statisticschart.py:306
 msgid "Item count"
@@ -21221,14 +21054,14 @@ msgstr "Både och"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:311
 #: ../gramps/plugins/drawreport/statisticschart.py:413
-#: ../gramps/plugins/drawreport/statisticschart.py:774
+#: ../gramps/plugins/drawreport/statisticschart.py:785
 #: ../gramps/plugins/tool/verify.glade:645
 msgid "Men"
 msgstr "Män"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:312
 #: ../gramps/plugins/drawreport/statisticschart.py:415
-#: ../gramps/plugins/drawreport/statisticschart.py:776
+#: ../gramps/plugins/drawreport/statisticschart.py:787
 #: ../gramps/plugins/tool/verify.glade:525
 msgid "Women"
 msgstr "Kvinnor"
@@ -21306,7 +21139,7 @@ msgstr "(Föredragen) titel saknas"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:396
 msgid "(Preferred) forename missing"
-msgstr "(Föredraget)förnamn saknas"
+msgstr "(Föredraget) förnamn saknas"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:406
 msgid "(Preferred) surname missing"
@@ -21314,89 +21147,89 @@ msgstr "(Föredraget) efternamn saknas"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:416
 msgid "Gender unknown"
-msgstr "Kön obekant"
+msgstr "Kön okänt"
 
 #. inadequate information
 #: ../gramps/plugins/drawreport/statisticschart.py:425
-#: ../gramps/plugins/drawreport/statisticschart.py:434
-#: ../gramps/plugins/drawreport/statisticschart.py:541
+#: ../gramps/plugins/drawreport/statisticschart.py:445
+#: ../gramps/plugins/drawreport/statisticschart.py:552
 msgid "Date(s) missing"
 msgstr "Datum saknas"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:443
-#: ../gramps/plugins/drawreport/statisticschart.py:457
+#: ../gramps/plugins/drawreport/statisticschart.py:454
+#: ../gramps/plugins/drawreport/statisticschart.py:468
 msgid "Place missing"
 msgstr "Plats saknas"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:465
+#: ../gramps/plugins/drawreport/statisticschart.py:476
 msgid "Already dead"
 msgstr "Redan död"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:472
+#: ../gramps/plugins/drawreport/statisticschart.py:483
 msgid "Still alive"
 msgstr "Lever fortfarande"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:480
-#: ../gramps/plugins/drawreport/statisticschart.py:492
+#: ../gramps/plugins/drawreport/statisticschart.py:491
+#: ../gramps/plugins/drawreport/statisticschart.py:503
 msgid "Events missing"
 msgstr "Händelser saknas"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:500
-#: ../gramps/plugins/drawreport/statisticschart.py:508
+#: ../gramps/plugins/drawreport/statisticschart.py:511
+#: ../gramps/plugins/drawreport/statisticschart.py:519
 msgid "Children missing"
 msgstr "Barn saknas"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:530
+#: ../gramps/plugins/drawreport/statisticschart.py:541
 msgid "Birth missing"
 msgstr "Födelse saknas"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:631
+#: ../gramps/plugins/drawreport/statisticschart.py:642
 msgid "Personal information missing"
 msgstr "Personinformation saknas"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:769
+#: ../gramps/plugins/drawreport/statisticschart.py:780
 #: ../gramps/plugins/drawreport/timeline.py:118
 #: ../gramps/plugins/textreport/placereport.py:99
 #: ../gramps/plugins/textreport/recordsreport.py:91
 #: ../gramps/plugins/textreport/tagreport.py:100
 #, python-format
 msgid "(Living people: %(option_name)s)"
-msgstr ""
+msgstr "(Levande personer: %(option_name)s)"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:788
+#: ../gramps/plugins/drawreport/statisticschart.py:799
 #, python-format
 msgid "%(genders)s born %(year_from)04d-%(year_to)04d"
 msgstr "%(genders)s födda %(year_from)04d-%(year_to)04d"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:792
+#: ../gramps/plugins/drawreport/statisticschart.py:803
 #, python-format
 msgid "Persons born %(year_from)04d-%(year_to)04d"
 msgstr "Personer födda %(year_from)04d-%(year_to)04d"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:802
+#: ../gramps/plugins/drawreport/statisticschart.py:813
 msgid "Collecting data..."
 msgstr "Samlar data..."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:812
+#: ../gramps/plugins/drawreport/statisticschart.py:823
 msgid "Sorting data..."
 msgstr "Sorterar data..."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:847
+#: ../gramps/plugins/drawreport/statisticschart.py:858
 msgid "Saving charts..."
 msgstr "Sparar diagram..."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:901
-#: ../gramps/plugins/drawreport/statisticschart.py:939
+#: ../gramps/plugins/drawreport/statisticschart.py:912
+#: ../gramps/plugins/drawreport/statisticschart.py:950
 #, python-format
 msgid "%s (persons):"
 msgstr "%s (personer):"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:991
+#: ../gramps/plugins/drawreport/statisticschart.py:1002
 #: ../gramps/plugins/textreport/recordsreport.py:219
 msgid "Determines what people are included in the report."
-msgstr "Avgör vilka personer, som tas med i rapporten."
+msgstr "Avgör vilka personer som tas med i rapporten."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:996
+#: ../gramps/plugins/drawreport/statisticschart.py:1007
 #: ../gramps/plugins/drawreport/timeline.py:421
 #: ../gramps/plugins/textreport/birthdayreport.py:417
 #: ../gramps/plugins/textreport/indivcomplete.py:1067
@@ -21407,89 +21240,88 @@ msgstr "Avgör vilka personer, som tas med i rapporten."
 msgid "Filter Person"
 msgstr "Filtrera person"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:997
+#: ../gramps/plugins/drawreport/statisticschart.py:1008
 #: ../gramps/plugins/textreport/birthdayreport.py:418
 #: ../gramps/plugins/textreport/indivcomplete.py:1068
 msgid "The center person for the filter."
 msgstr "Huvudpersonen för filtret."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1001
+#: ../gramps/plugins/drawreport/statisticschart.py:1012
 msgid "Sort chart items by"
 msgstr "Sortera tabellposter via"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1006
+#: ../gramps/plugins/drawreport/statisticschart.py:1017
 msgid "Select how the statistical data is sorted."
 msgstr "Välj hur de statistiska uppgifterna ska sorteras."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1009
+#: ../gramps/plugins/drawreport/statisticschart.py:1020
 msgid "Sort in reverse order"
 msgstr "Sortera i omvänd ordning"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1010
+#: ../gramps/plugins/drawreport/statisticschart.py:1021
 msgid "Check to reverse the sorting order."
 msgstr "Välj för att få omvänd sorteringsordning."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1014
+#: ../gramps/plugins/drawreport/statisticschart.py:1025
 msgid "People Born After"
 msgstr "Personer födda efter"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1016
+#: ../gramps/plugins/drawreport/statisticschart.py:1027
 msgid "Birth year from which to include people."
 msgstr "Det födelseår från vilket personer skall tas med."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1019
+#: ../gramps/plugins/drawreport/statisticschart.py:1030
 msgid "People Born Before"
 msgstr "Personer födda före"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1021
+#: ../gramps/plugins/drawreport/statisticschart.py:1032
 msgid "Birth year until which to include people"
 msgstr "Det födelseår t o m vilket personer skall tas med"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1024
+#: ../gramps/plugins/drawreport/statisticschart.py:1035
 msgid "Include people without known birth years"
 msgstr "Ta med personer utan känt födelseår"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1026
+#: ../gramps/plugins/drawreport/statisticschart.py:1037
 msgid "Whether to include people without known birth years."
-msgstr ".Huruvida ta med personer utan känt födelseår."
+msgstr "Huruvida ta med personer utan känt födelseår."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1030
+#: ../gramps/plugins/drawreport/statisticschart.py:1041
 msgid "Genders included"
 msgstr "Kön medtagna"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1035
+#: ../gramps/plugins/drawreport/statisticschart.py:1046
 msgid "Select which genders are included into statistics."
-msgstr "Välj vilka kön, som ska tas med i statistik."
+msgstr "Välj vilka kön som ska tas med i statistik."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1039
+#: ../gramps/plugins/drawreport/statisticschart.py:1050
 msgid "Max. items for a pie"
 msgstr "Max antal objekt för en cirkel"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1040
+#: ../gramps/plugins/drawreport/statisticschart.py:1051
 msgid ""
 "With fewer items pie chart and legend will be used instead of a bar chart."
 msgstr ""
 "Med färre poster kommer cirkeldiagram med teckenförklaring att användas i "
 "stället för stapeldiagram."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1073
-#, fuzzy
+#: ../gramps/plugins/drawreport/statisticschart.py:1084
 msgid "Charts 3"
-msgstr "Diagram 1"
+msgstr "Diagram 3"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1075
+#: ../gramps/plugins/drawreport/statisticschart.py:1086
 msgid "Charts 2"
 msgstr "Diagram 2"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1077
+#: ../gramps/plugins/drawreport/statisticschart.py:1088
 msgid "Charts 1"
 msgstr "Diagram 1"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1079
+#: ../gramps/plugins/drawreport/statisticschart.py:1090
 msgid "Include charts with indicated data."
 msgstr "Ta med diagram med markerade data."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1121
+#: ../gramps/plugins/drawreport/statisticschart.py:1132
 #: ../gramps/plugins/textreport/placereport.py:601
 msgid "The style used for the items and values."
 msgstr "Mall som används för objekt och värden."
@@ -21507,7 +21339,7 @@ msgstr "Namn"
 #: ../gramps/plugins/drawreport/timeline.py:168
 #: ../gramps/plugins/drawreport/timeline.py:337
 msgid "Timeline"
-msgstr "Livslängdslinje"
+msgstr "Tidslinje"
 
 #: ../gramps/plugins/drawreport/timeline.py:157
 msgid "Sorting dates..."
@@ -21529,11 +21361,11 @@ msgstr "Ingen datuminformation"
 
 #: ../gramps/plugins/drawreport/timeline.py:338
 msgid "Finding date range..."
-msgstr "Letar efter område..."
+msgstr "Finner datumintervall..."
 
 #: ../gramps/plugins/drawreport/timeline.py:417
 msgid "Determines what people are included in the report"
-msgstr "Avgör vilka personer, som tas med i rapporten"
+msgstr "Avgör vilka personer som tas med i rapporten"
 
 #: ../gramps/plugins/drawreport/timeline.py:422
 #: ../gramps/plugins/textreport/recordsreport.py:224
@@ -21560,16 +21392,16 @@ msgstr "Använd sorteringsmetod"
 #: ../gramps/plugins/textreport/recordsreport.py:327
 #: ../gramps/plugins/textreport/tagreport.py:965
 msgid "The style used for the section headers."
-msgstr "Mall som används för sektionsrubriken."
+msgstr "Mall som används för sektionsrubrikerna."
 
 #: ../gramps/plugins/export/export.gpr.py:34
 #: ../gramps/plugins/importer/import.gpr.py:36
 msgid "Comma Separated Values Spreadsheet (CSV)"
-msgstr "Kalkylblad med kommasSeparerade värden (CSV)"
+msgstr "Kalkylblad med kommaseparerade värden (CSV)"
 
 #: ../gramps/plugins/export/export.gpr.py:35
 msgid "Comma _Separated Values Spreadsheet (CSV)"
-msgstr "Kalkylblad med Komma-_Separerade-Värden (CSV)"
+msgstr "Kalkylblad med komma_separerade värden (CSV)"
 
 #: ../gramps/plugins/export/export.gpr.py:36
 msgid "CSV is a common spreadsheet format."
@@ -21589,7 +21421,7 @@ msgstr "_Web Family Tree"
 
 #: ../gramps/plugins/export/export.gpr.py:57
 msgid "Web Family Tree format"
-msgstr "Web Family Tree-format."
+msgstr "Web Family Tree-format"
 
 #: ../gramps/plugins/export/export.gpr.py:65
 msgid "Web Family Tree export options"
@@ -21637,7 +21469,8 @@ msgid ""
 "Gramps package is an archived XML family tree together with the media object "
 "files."
 msgstr ""
-"Gramps-paket är en arkiverad XML-databas tillsammans med mediaobjektfiler."
+"Gramps-paket är en arkiverad XML-databas av släktträdet tillsammans med "
+"mediaobjektfiler."
 
 #: ../gramps/plugins/export/export.gpr.py:130
 msgid "Gramps package export options"
@@ -21645,19 +21478,19 @@ msgstr "Gramps-paket exportalternativ"
 
 #: ../gramps/plugins/export/export.gpr.py:141
 msgid "Gramps XML (family tree)"
-msgstr "Gramps-XML (Släktträd)"
+msgstr "Gramps-XML (släktträd)"
 
 #: ../gramps/plugins/export/export.gpr.py:142
 msgid "Gramps _XML (family tree)"
-msgstr "Gramps-_XML (Släktträd)"
+msgstr "Gramps-_XML (släktträd)"
 
 #: ../gramps/plugins/export/export.gpr.py:143
 msgid ""
 "Gramps XML export is a complete archived XML backup of a Gramps family tree "
 "without the media object files. Suitable for backup purposes."
 msgstr ""
-"Gramps XML-export är en komplett arkiverad XML-databas utan "
-"mediaobjektfiler. Den är lämplig som säkerhetskopia."
+"Gramps XML-export är en komplett arkiverad XML-databas av ett Gramps-"
+"släktträd utan mediaobjektfiler. Den är lämplig som säkerhetskopia."
 
 #: ../gramps/plugins/export/export.gpr.py:153
 msgid "Gramps XML export options"
@@ -21669,7 +21502,7 @@ msgstr "vCalendar"
 
 #: ../gramps/plugins/export/export.gpr.py:165
 msgid "vC_alendar"
-msgstr "vCa_lender"
+msgstr "vC_alendar"
 
 #: ../gramps/plugins/export/export.gpr.py:166
 msgid "vCalendar is used in many calendaring and PIM applications."
@@ -21690,7 +21523,7 @@ msgstr "_vCard"
 
 #: ../gramps/plugins/export/export.gpr.py:187
 msgid "vCard is used in many addressbook and pim applications."
-msgstr "vCard används av många adressboks- och pimprogram."
+msgstr "vCard används av många adressboks- och pim-program."
 
 #: ../gramps/plugins/export/export.gpr.py:195
 msgid "vCard export options"
@@ -21721,20 +21554,20 @@ msgstr "Översätt rubriker"
 
 #: ../gramps/plugins/export/exportcsv.py:288
 msgid "Enclosed_by"
-msgstr "Omgivet av"
+msgstr "Omgivet_av"
 
 #: ../gramps/plugins/export/exportcsv.py:340
 #, python-brace-format
 msgid "CSV export doesn't support non-primary surnames, {count} dropped"
-msgstr "CSV-export stöder ej  ickeprimära efternamn, {count} tappade"
+msgstr "CSV-export stöder ej ickeprimära efternamn, {count} tappade"
 
 #: ../gramps/plugins/export/exportcsv.py:357
 msgid "Birth source"
-msgstr "Föddekälla"
+msgstr "Födelsekälla"
 
 #: ../gramps/plugins/export/exportcsv.py:358
 msgid "Baptism date"
-msgstr "Dopdag"
+msgstr "Dopdatum"
 
 #: ../gramps/plugins/export/exportcsv.py:358
 msgid "Baptism place"
@@ -21807,7 +21640,7 @@ msgstr "Skriver arkivplatser"
 #: ../gramps/plugins/export/exportgedcom.py:1172
 #: ../gramps/plugins/lib/libgedcom.py:5895
 msgid "EMAIL"
-msgstr "e-post"
+msgstr "E-POST"
 
 #: ../gramps/plugins/export/exportgedcom.py:1174
 #: ../gramps/plugins/lib/libgedcom.py:5907
@@ -21828,7 +21661,7 @@ msgstr "Inga familjer matchades av det valda filtret"
 #: ../gramps/plugins/export/exportxml.py:173
 #, python-format
 msgid "Failure writing %s"
-msgstr "Misslyckades med att skriva till %s"
+msgstr "Fel vid skrivning av %s"
 
 #. feature requests 2356, 1657: avoid genitive form
 #: ../gramps/plugins/export/exportvcalendar.py:135
@@ -21841,14 +21674,14 @@ msgstr "Giftermålet för %s"
 #: ../gramps/plugins/export/exportvcalendar.py:159
 #, python-format
 msgid "Birth of %s"
-msgstr "Födelsen av %s"
+msgstr "Födelse av %s"
 
 #. feature requests 2356, 1657: avoid genitive form
 #: ../gramps/plugins/export/exportvcalendar.py:172
 #: ../gramps/plugins/export/exportvcalendar.py:178
 #, python-format
 msgid "Death of %s"
-msgstr "Döden av %s"
+msgstr "Död av %s"
 
 #: ../gramps/plugins/export/exportvcalendar.py:237
 #, python-format
@@ -21861,7 +21694,7 @@ msgid ""
 "the directory. Please make sure you have write access to the directory and "
 "try again."
 msgstr ""
-"Databasen kan inte sparas eftersom du inte har tillåtelse att skriva till "
+"Databasen kan inte sparas eftersom du inte har rättighet att skriva till "
 "katalogen. Kontrollera att du har skrivåtkomst till katalogen och försök "
 "igen."
 
@@ -21870,13 +21703,13 @@ msgid ""
 "The database cannot be saved because you do not have permission to write to "
 "the file. Please make sure you have write access to the file and try again."
 msgstr ""
-"Databasen kan inte sparas eftersom du inte har tillåtelse att skriva till "
-"filen. Kontrollera att du har skrivåtkomst till katalogen och försök igen."
+"Databasen kan inte sparas eftersom du inte har rättighet att skriva till "
+"filen. Kontrollera att du har skrivåtkomst till filen och försök igen."
 
 #. GUI setup:
 #: ../gramps/plugins/gramplet/ageondategramplet.py:52
 msgid "Enter a date, click Run"
-msgstr "Mata i ett datum, klicka på Kör"
+msgstr "Mata in ett datum, klicka på Kör"
 
 #: ../gramps/plugins/gramplet/ageondategramplet.py:60
 msgid ""
@@ -21884,10 +21717,10 @@ msgid ""
 "will compute the ages for everyone in your Family Tree on that date. You can "
 "then sort by the age column, and double-click the row to view or edit."
 msgstr ""
-"Skriv in ett datum (som ÅÅÅÅ-MM-DD) i fältet nedan och klicka sedan på Kör. "
-"Detta kommer att beräkna ålder för all i ditt släktträd på detta datum. Du "
-"kan sedan sortera på ålderskolumnen och dubbelklicka på raden för att titta "
-"eller redigera."
+"Skriv in ett giltigt datum (som ÅÅÅÅ-MM-DD) i fältet nedan och klicka sedan "
+"på Kör. Detta kommer att beräkna ålder för alla i ditt släktträd på detta "
+"datum. Du kan sedan sortera med ålderskolumnen och dubbelklicka på raden för "
+"att visa eller redigera."
 
 #: ../gramps/plugins/gramplet/agestats.py:53
 #: ../gramps/plugins/gramplet/agestats.py:63
@@ -21924,11 +21757,11 @@ msgstr "Skillnad"
 
 #: ../gramps/plugins/gramplet/agestats.py:177
 msgid "Father - Child Age Diff Distribution"
-msgstr "Fördelning av far - barn åldersskillnad"
+msgstr "Fördelning av åldersskillnad mellan fader och barn"
 
 #: ../gramps/plugins/gramplet/agestats.py:178
 msgid "Mother - Child Age Diff Distribution"
-msgstr "Fördelning av mor - barn åldersskillnad"
+msgstr "Fördelning av åldersskillnad mellan moder och barn"
 
 #: ../gramps/plugins/gramplet/agestats.py:235
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:262
@@ -21940,7 +21773,7 @@ msgstr "Statistik"
 
 #: ../gramps/plugins/gramplet/agestats.py:236
 msgid "Total"
-msgstr "Totalt "
+msgstr "Totalt"
 
 #: ../gramps/plugins/gramplet/agestats.py:237
 msgid "Minimum"
@@ -21948,11 +21781,11 @@ msgstr "Minimum"
 
 #: ../gramps/plugins/gramplet/agestats.py:238
 msgid "Average"
-msgstr "Medel  "
+msgstr "Medel"
 
 #: ../gramps/plugins/gramplet/agestats.py:239
 msgid "Median"
-msgstr "Median "
+msgstr "Median"
 
 #: ../gramps/plugins/gramplet/agestats.py:240
 msgid "Maximum"
@@ -21981,7 +21814,8 @@ msgid ""
 "Double-click on a row to view a quick report showing all people with the "
 "selected attribute."
 msgstr ""
-"Dubbelklicka på en rad för att visa en snabbrapport med valda attribut."
+"Dubbelklicka på en rad för att visa en snabbrapport som visar alla personer "
+"med valt attribut."
 
 #: ../gramps/plugins/gramplet/attributes.py:56
 #: ../gramps/plugins/lib/libmetadata.py:172
@@ -22015,9 +21849,10 @@ msgid "<No Citation>"
 msgstr "<Ingen citering>"
 
 #: ../gramps/plugins/gramplet/coordinates.py:83
-#, fuzzy
 msgid "Right-click on a row to edit the selected event or the related place."
-msgstr "Dubbelklicka på en rad för att redigera den valda platsen."
+msgstr ""
+"Högerklicka på en rad för att redigera den valda händelsen eller den "
+"relaterade platsen."
 
 #: ../gramps/plugins/gramplet/coordinates.py:94
 #: ../gramps/plugins/textreport/tagreport.py:158
@@ -22033,14 +21868,12 @@ msgid "Id"
 msgstr "Id"
 
 #: ../gramps/plugins/gramplet/coordinates.py:143
-#, fuzzy
 msgid "Edit the event"
-msgstr "händelsen"
+msgstr "Redigera händelsen"
 
 #: ../gramps/plugins/gramplet/coordinates.py:148
-#, fuzzy
 msgid "Edit the place"
-msgstr "Redigera plats"
+msgstr "Redigera platsen"
 
 #: ../gramps/plugins/gramplet/eval.py:72
 msgid "Evaluation"
@@ -22072,7 +21905,7 @@ msgid ""
 "Click and drag in open area to rotate"
 msgstr ""
 "Klicka för att expandera/krympa person\n"
-"Högerklicka för val\n"
+"Högerklicka för alternativ\n"
 "Klicka och dra på öppen yta för att rotera"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:61
@@ -22084,7 +21917,7 @@ msgid ""
 msgstr ""
 "%(bold_start)s%(gramps_FAQ_html_start)s%(html_middle)sOfta Ställda Frågor"
 "%(html_end)s%(bold_end)s\n"
-"(needs a connection to the internet)\n"
+"(internetförbindelse är nödvändig)\n"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:66
 msgid "Editing Spouses"
@@ -22097,7 +21930,7 @@ msgid ""
 "spouses?%(html_end)s\n"
 msgstr ""
 "  1. %(gramps_FAQ_html_start)s%(faq_section)sHur ändrar jag ordningen på "
-"makar%(html_end)s\n"
+"makar?%(html_end)s\n"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:77
 #, python-format
@@ -22106,7 +21939,7 @@ msgid ""
 "spouse?%(html_end)s\n"
 msgstr ""
 "  2. %(gramps_FAQ_html_start)s%(faq_section)sHur lägger jag till en extra "
-"make/maka%(html_end)s\n"
+"make/maka?%(html_end)s\n"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:83
 #, python-format
@@ -22119,7 +21952,7 @@ msgstr ""
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:87
 msgid "Backups and Updates"
-msgstr "Säkerhetskopia och uppdateringar"
+msgstr "Säkerhetskopior och uppdateringar"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:92
 #, python-format
@@ -22158,8 +21991,8 @@ msgid ""
 "  7. %(gramps_FAQ_html_start)s%(faq_section)sWhat's the difference between a "
 "residence and an address?%(html_end)s\n"
 msgstr ""
-"  7. %(gramps_FAQ_html_start)s%(faq_section)sVad är skillnaden mellan ? "
-"boende och adress%(html_end)s\n"
+"  7. %(gramps_FAQ_html_start)s%(faq_section)sVad är skillnaden mellan en "
+"boende och en adress?%(html_end)s\n"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:120
 msgid "Media Files"
@@ -22172,7 +22005,7 @@ msgid ""
 "person/source/event?%(html_end)s\n"
 msgstr ""
 "  8. %(gramps_FAQ_html_start)s%(faq_section)sHur lägger jag till ett "
-"fotografi på person/källa/händelse%(html_end)s\n"
+"fotografi på en person/källa/händelse?%(html_end)s\n"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:131
 #, python-format
@@ -22180,7 +22013,7 @@ msgid ""
 "  9. %(gramps_FAQ_html_start)s%(faq_section)sHow do you find unused media "
 "objects?%(html_end)s\n"
 msgstr ""
-"  9. %(gramps_FAQ_html_start)s%(faq_section)sHur hittar du oanvända "
+"  9. %(gramps_FAQ_html_start)s%(faq_section)sHur hittar jag oanvända "
 "mediaobjekt?%(html_end)s\n"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:141
@@ -22285,7 +22118,7 @@ msgstr "Ålder vid datum"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:46
 msgid "Gramplet showing ages of living people on a specific date"
-msgstr "Gramplet med ålder på levande personer på en särskild dag"
+msgstr "Gramplet som visar ålder på levande personer på en särskild dag"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:58
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:65
@@ -22294,11 +22127,12 @@ msgstr "Åldersstatistik"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:59
 msgid "Gramplet showing graphs of various ages"
-msgstr "Gramplet visande diagram över olika åldrar"
+msgstr "Gramplet som visar diagram över olika åldrar"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:75
 msgid "Gramplet showing calendar and events on specific dates in history"
-msgstr "Grampet med almanacka och händelser på en särskild dag i historien"
+msgstr ""
+"Gramplet som visar almanacka och händelser på en särskild dag i historien"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:87
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:94
@@ -22307,7 +22141,7 @@ msgstr "Ättlingar"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:88
 msgid "Gramplet showing active person's descendants"
-msgstr "Gramplet med aktiv persons ättlingar"
+msgstr "Gramplet som visar aktiv persons ättlingar"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:104
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:111
@@ -22318,11 +22152,11 @@ msgstr "Anor"
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:105
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:200
 msgid "Gramplet showing active person's ancestors"
-msgstr "Gramplet med aktiv persons förfäder"
+msgstr "Gramplet som visar aktiv persons förfäder"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:122
 msgid "Gramplet showing active person's direct ancestors as a fanchart"
-msgstr "Gramplet med aktiv persons nära förfäder som ett cirkeldiagram"
+msgstr "Gramplet som visar aktiv persons nära förfäder som ett cirkeldiagram"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:138
 #: ../gramps/plugins/view/fanchartdescview.py:75
@@ -22331,7 +22165,7 @@ msgstr "Cirkeldiagram med ättlingar (stamtavla)"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:139
 msgid "Gramplet showing active person's direct descendants as a fanchart"
-msgstr "Gramplet med aktiv persons nära förfäder, som ett cirkeldiagram"
+msgstr "Gramplet som visar aktiv persons nära ättlingar som ett cirkeldiagram"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:147
 #: ../gramps/plugins/view/view.gpr.py:158
@@ -22340,21 +22174,21 @@ msgstr "Cirkeldiagram med ättlingar"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:155
 #: ../gramps/plugins/view/fanchart2wayview.py:78
-#, fuzzy
 msgid "2-Way Fan Chart"
-msgstr "Antavla i cirkelformat"
+msgstr "2-vägs cirkeldiagram"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:156
-#, fuzzy
 msgid ""
 "Gramplet showing active person's direct ancestors and descendants as a "
 "fanchart"
-msgstr "Gramplet med aktiv persons nära förfäder, som ett cirkeldiagram"
+msgstr ""
+"Gramplet som visar aktiv persons nära förfäder och ättlingar som ett "
+"cirkeldiagram"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:164
 #: ../gramps/plugins/view/view.gpr.py:173
 msgid "2-Way Fan"
-msgstr ""
+msgstr "2-vägscirkel"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:172
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:178
@@ -22363,7 +22197,7 @@ msgstr "FAQ"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:173
 msgid "Gramplet showing frequently asked questions"
-msgstr "Gramplet med ofta ställad frågor (FAQ)"
+msgstr "Gramplet som visar ofta ställda frågor (FAQ)"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:185
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:192
@@ -22372,7 +22206,7 @@ msgstr "Förnamnsstatistik"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:186
 msgid "Gramplet showing all given names as a text cloud"
-msgstr "Gramplet med alla förnamn som ett textmoln"
+msgstr "Gramplet som visar alla förnamn som ett textmoln"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:199
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:205
@@ -22384,7 +22218,7 @@ msgstr "Antavla"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:217
 msgid "Gramplet showing an active item Quick View"
-msgstr "Gramplet med en aktiv Snabb-titt"
+msgstr "Gramplet som visar ett aktivt objekt i snabbrapportvyn"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:232
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:238
@@ -22393,7 +22227,7 @@ msgstr "Släktingar"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:233
 msgid "Gramplet showing active person's relatives"
-msgstr "Gramplet med aktiv persons släktingar"
+msgstr "Gramplet som visar aktiv persons släktingar"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:248
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:255
@@ -22402,11 +22236,11 @@ msgstr "Körningslogg"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:249
 msgid "Gramplet showing all activity for this session"
-msgstr "Gramplet med alla aktiviteter under denna körning"
+msgstr "Gramplet som visar alla aktiviteter under denna session"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:263
 msgid "Gramplet showing summary data of the Family Tree"
-msgstr "Gramplet med en sammanfattning av data för släktträdet"
+msgstr "Gramplet som visar en sammanfattning av data för släktträdet"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:276
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:283
@@ -22415,7 +22249,7 @@ msgstr "Efternamnsstatistik"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:277
 msgid "Gramplet showing all surnames as a text cloud"
-msgstr "Gramplet med alla efternamn som ett textmoln"
+msgstr "Gramplet som visar alla efternamn som ett textmoln"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:290
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:297
@@ -22428,11 +22262,11 @@ msgstr "Gramplet med alla efternamn som ett textmoln"
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1235
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1249
 msgid "gramplet|To Do"
-msgstr "Att-göra-grampet"
+msgstr "Att Göra"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:291
 msgid "Gramplet for displaying a To Do list"
-msgstr "Gramplet erbjuder visa en Att Göra-lista"
+msgstr "Gramplet för att visa en Att Göra-lista"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:305
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:311
@@ -22441,7 +22275,7 @@ msgstr "Vanligaste efternamnen"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:306
 msgid "Gramplet showing most frequent surnames in this tree"
-msgstr "Gramplet med de vanligaste efternamn i detta släktträd"
+msgstr "Gramplet som visar de vanligaste efternamnen i detta släktträd"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:318
 msgid "Welcome"
@@ -22449,7 +22283,7 @@ msgstr "Välkommen"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:319
 msgid "Gramplet showing a welcome message"
-msgstr "Gramplet med välkomstmeddelande"
+msgstr "Gramplet som visar välkomstmeddelande"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:325
 msgid "Welcome to Gramps!"
@@ -22461,11 +22295,11 @@ msgstr "Nästa uppgift"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:333
 msgid "Gramplet suggesting items to research"
-msgstr "Gramplet med förslag på kommande forskningsuppgifter"
+msgstr "Gramplet som ger förslag på kommande forskningsuppgifter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:339
 msgid "What's Next?"
-msgstr "Nästa uppgift"
+msgstr "Nästa uppgift?"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:349
 msgid "Person Details"
@@ -22473,7 +22307,7 @@ msgstr "Persondetaljer"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:350
 msgid "Gramplet showing details of a person"
-msgstr "Gramplet visande detaljer för en person"
+msgstr "Gramplet som visar detaljer för en person"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:357
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:371
@@ -22487,7 +22321,7 @@ msgstr "Arkivplatsdetaljer"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:364
 msgid "Gramplet showing details of a repository"
-msgstr "Gramplet visande detaljer för en arkivplats"
+msgstr "Gramplet som visar detaljer för en arkivplats"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:377
 msgid "Place Details"
@@ -22495,7 +22329,7 @@ msgstr "Platsdetaljer"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:378
 msgid "Gramplet showing details of a place"
-msgstr "Gramplet visande detaljer för en plats"
+msgstr "Gramplet som visar detaljer för en plats"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:391
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:399
@@ -22504,7 +22338,7 @@ msgstr "Mediagranskning"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:392
 msgid "Gramplet showing a preview of a media object"
-msgstr "Gramplet med förhandsgranskning av ett mediaobjekt"
+msgstr "Gramplet som visar en förhandsgranskning av ett mediaobjekt"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:419
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:427
@@ -22513,11 +22347,11 @@ msgstr "Bildmetadata"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:420
 msgid "Gramplet showing metadata for a media object"
-msgstr "Gramplet visande metadata av mediaobjekt"
+msgstr "Gramplet som visar metadata av mediaobjekt"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:441
 msgid "GExiv2 module not loaded."
-msgstr "GExiv2-modul ej laddad"
+msgstr "GExiv2-modul ej laddad."
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:442
 #, python-format
@@ -22526,7 +22360,7 @@ msgid ""
 "To build it for Gramps see %(gramps_wiki_build_gexiv2_url)s"
 msgstr ""
 "Bildmetadatafunktionalitet kommer ej att vara tillgängligt.\n"
-"För att åstadkomma det för  Gramps se %(gramps_wiki_build_gexiv2_url)s"
+"För att åstadkomma det för Gramps se %(gramps_wiki_build_gexiv2_url)s"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:455
 msgid "Person Residence"
@@ -22534,16 +22368,16 @@ msgstr "Personboende"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:456
 msgid "Gramplet showing residence events for a person"
-msgstr "Gramplet visande bostadshändelser för en person"
+msgstr "Gramplet som visar bostadshändelser för en person"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:469
 msgid "Person Events"
-msgstr "Personliga händelser"
+msgstr "Personhändelser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:470
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1323
 msgid "Gramplet showing the events for a person"
-msgstr "Gramplet visande händelser för en person"
+msgstr "Gramplet som visar händelser för en person"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:483
 msgid "Family Events"
@@ -22551,7 +22385,7 @@ msgstr "Familjehändelser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:484
 msgid "Gramplet showing the events for a family"
-msgstr "Gramplet visande händelser för en familj"
+msgstr "Gramplet som visar händelser för en familj"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:497
 msgid "Person Gallery"
@@ -22559,7 +22393,7 @@ msgstr "Persongalleri"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:498
 msgid "Gramplet showing media objects for a person"
-msgstr "Gramplet visande mediaobjekt för en person"
+msgstr "Gramplet som visar mediaobjekt för en person"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:505
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:519
@@ -22572,11 +22406,11 @@ msgstr "Galleri"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:511
 msgid "Family Gallery"
-msgstr "Familjgalleri"
+msgstr "Familjegalleri"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:512
 msgid "Gramplet showing media objects for a family"
-msgstr "Gramplet visande mediaobjekt för en familj"
+msgstr "Gramplet som visar mediaobjekt för en familj"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:525
 msgid "Event Gallery"
@@ -22584,7 +22418,7 @@ msgstr "Händelsegalleri"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:526
 msgid "Gramplet showing media objects for an event"
-msgstr "Gramplet visande mediaobjekt för en händelse"
+msgstr "Gramplet som visar mediaobjekt för en händelse"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:539
 msgid "Place Gallery"
@@ -22592,7 +22426,7 @@ msgstr "Platsgalleri"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:540
 msgid "Gramplet showing media objects for a place"
-msgstr "Gramplet visande mediaobjekt för en plats"
+msgstr "Gramplet som visar mediaobjekt för en plats"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:553
 msgid "Source Gallery"
@@ -22600,7 +22434,7 @@ msgstr "Källgalleri"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:554
 msgid "Gramplet showing media objects for a source"
-msgstr "Gramplet visande mediaobjekt för en källa"
+msgstr "Gramplet som visar mediaobjekt för en källa"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:567
 msgid "Citation Gallery"
@@ -22608,7 +22442,7 @@ msgstr "Citeringsgalleri"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:568
 msgid "Gramplet showing media objects for a citation"
-msgstr "Gramplet visande mediaobjekt för en citering"
+msgstr "Gramplet som visar mediaobjekt för en citering"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:581
 msgid "Person Attributes"
@@ -22616,7 +22450,7 @@ msgstr "Personattribut"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:582
 msgid "Gramplet showing the attributes of a person"
-msgstr "Gramplet visande en persons attribut"
+msgstr "Gramplet som visar en persons attribut"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:595
 msgid "Event Attributes"
@@ -22624,7 +22458,7 @@ msgstr "Händelseattribut"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:596
 msgid "Gramplet showing the attributes of an event"
-msgstr "Gramplet visande en händelses attribut"
+msgstr "Gramplet som visar en händelses attribut"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:609
 msgid "Family Attributes"
@@ -22632,7 +22466,7 @@ msgstr "Familjeattribut"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:610
 msgid "Gramplet showing the attributes of a family"
-msgstr "Gramplet visande en familjs attribut"
+msgstr "Gramplet som visar en familjs attribut"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:623
 msgid "Media Attributes"
@@ -22640,11 +22474,11 @@ msgstr "Mediaattribut"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:624
 msgid "Gramplet showing the attributes of a media object"
-msgstr "Gramplet visande ett mediaobjekts attribut"
+msgstr "Gramplet som visar ett mediaobjekts attribut"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:638
 msgid "Gramplet showing the attributes of a source object"
-msgstr "Gramplet visande attribut för ett källobjekt"
+msgstr "Gramplet som visar attribut för ett källobjekt"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:651
 msgid "Citation Attributes"
@@ -22652,7 +22486,7 @@ msgstr "Citeringsattribut"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:652
 msgid "Gramplet showing the attributes of a citation object"
-msgstr "Gramplet visande attributen för ett citeringsobjekt"
+msgstr "Gramplet som visar attributen för ett citeringsobjekt"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:665
 msgid "Person Notes"
@@ -22660,7 +22494,7 @@ msgstr "Personnotiser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:666
 msgid "Gramplet showing the notes for a person"
-msgstr "Gramplet visande notiserna för en person"
+msgstr "Gramplet som visar notiserna för en person"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:679
 msgid "Event Notes"
@@ -22668,7 +22502,7 @@ msgstr "Händelsenotiser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:680
 msgid "Gramplet showing the notes for an event"
-msgstr "Gramplet visande notiserna för en händelse"
+msgstr "Gramplet som visar notiserna för en händelse"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:693
 #: ../gramps/plugins/textreport/familygroup.py:788
@@ -22677,7 +22511,7 @@ msgstr "Familjenotiser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:694
 msgid "Gramplet showing the notes for a family"
-msgstr "Gramplet visande notiserna för en familj"
+msgstr "Gramplet som visar notiserna för en familj"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:707
 msgid "Place Notes"
@@ -22685,7 +22519,7 @@ msgstr "Platsnotiser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:708
 msgid "Gramplet showing the notes for a place"
-msgstr "Gramplet visande notiserna för en plats"
+msgstr "Gramplet som visar notiserna för en plats"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:721
 msgid "Source Notes"
@@ -22693,7 +22527,7 @@ msgstr "Källnotiser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:722
 msgid "Gramplet showing the notes for a source"
-msgstr "Gramplet visande notiserna för en källa"
+msgstr "Gramplet som visar notiserna för en källa"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:735
 msgid "Citation Notes"
@@ -22701,7 +22535,7 @@ msgstr "Citeringsnotiser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:736
 msgid "Gramplet showing the notes for a citation"
-msgstr "Gramplet visande notiserna för en citering"
+msgstr "Gramplet som visar notiserna för en citering"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:749
 msgid "Repository Notes"
@@ -22709,7 +22543,7 @@ msgstr "Arkivplatsnotiser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:750
 msgid "Gramplet showing the notes for a repository"
-msgstr "Gramplet visande notiserna för en arkivplats"
+msgstr "Gramplet som visar notiserna för en arkivplats"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:763
 msgid "Media Notes"
@@ -22717,7 +22551,7 @@ msgstr "Medianotiser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:764
 msgid "Gramplet showing the notes for a media object"
-msgstr "Gramplet visande notiserna för ett mediaobjekt"
+msgstr "Gramplet som visar notiserna för ett mediaobjekt"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:777
 msgid "Person Citations"
@@ -22725,7 +22559,7 @@ msgstr "Personciteringar"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:778
 msgid "Gramplet showing the citations for a person"
-msgstr "Gramplet visande citeringar för en person"
+msgstr "Gramplet som visar citeringarna för en person"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:791
 msgid "Event Citations"
@@ -22733,7 +22567,7 @@ msgstr "Händelseciteringar"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:792
 msgid "Gramplet showing the citations for an event"
-msgstr "Gramplet visande citeringarna för en händelse"
+msgstr "Gramplet som visar citeringarna för en händelse"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:805
 msgid "Family Citations"
@@ -22741,7 +22575,7 @@ msgstr "Familjeciteringar"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:806
 msgid "Gramplet showing the citations for a family"
-msgstr "Gramplet visande citeringar för en familj"
+msgstr "Gramplet som visar citeringarna för en familj"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:819
 msgid "Place Citations"
@@ -22749,7 +22583,7 @@ msgstr "Platsciteringar"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:820
 msgid "Gramplet showing the citations for a place"
-msgstr "Gramplet visande citeringana för en plats"
+msgstr "Gramplet som visar citeringarna för en plats"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:833
 msgid "Media Citations"
@@ -22757,23 +22591,23 @@ msgstr "Mediciteringar"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:834
 msgid "Gramplet showing the citations for a media object"
-msgstr "Gramplet visande citeringarna för ett mediaobjekt"
+msgstr "Gramplet som visar citeringarna för ett mediaobjekt"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:847
 msgid "Person Children"
-msgstr "Barn"
+msgstr "Persons barn"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:848
 msgid "Gramplet showing the children of a person"
-msgstr "Gramplet visande en persons barn"
+msgstr "Gramplet som visar en persons barn"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:861
 msgid "Family Children"
-msgstr "Familjebarn"
+msgstr "Familjs barn"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:862
 msgid "Gramplet showing the children of a family"
-msgstr "Gramplet visande barnen i en familj"
+msgstr "Gramplet som visar barnen i en familj"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:875
 msgid "Person References"
@@ -22781,7 +22615,7 @@ msgstr "Personreferenser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:876
 msgid "Gramplet showing the backlink references for a person"
-msgstr "Gramplet visande referenser för en person"
+msgstr "Gramplet som visar referenserna för en person"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:883
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:897
@@ -22801,11 +22635,11 @@ msgstr "Referenser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:889
 msgid "Event References"
-msgstr "Händelsereferens"
+msgstr "Händelsereferenser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:890
 msgid "Gramplet showing the backlink references for an event"
-msgstr "Gramplet visande referenserna för en händelse"
+msgstr "Gramplet som visar referenserna för en händelse"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:903
 msgid "Family References"
@@ -22813,7 +22647,7 @@ msgstr "Familjereferenser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:904
 msgid "Gramplet showing the backlink references for a family"
-msgstr "Gramplet visande referenserna för an familj"
+msgstr "Gramplet som visar referenserna för en familj"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:917
 msgid "Place References"
@@ -22821,7 +22655,7 @@ msgstr "Platsreferenser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:918
 msgid "Gramplet showing the backlink references for a place"
-msgstr "Gramplet visande referenserna för en plats"
+msgstr "Gramplet som visar referenserna för en plats"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:931
 #: ../gramps/plugins/webreport/basepage.py:2153
@@ -22830,7 +22664,7 @@ msgstr "Källhänvisningar"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:932
 msgid "Gramplet showing the backlink references for a source"
-msgstr "Gramplet visande referenserna för en källa"
+msgstr "Gramplet som visar referenserna för en källa"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:945
 msgid "Citation References"
@@ -22838,7 +22672,7 @@ msgstr "Citeringsreferenser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:946
 msgid "Gramplet showing the backlink references for a citation"
-msgstr "Gramplet visande bakåtlänkat för en citering"
+msgstr "Gramplet som visar referenserna för en citering"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:959
 #: ../gramps/plugins/quickview/quickview.gpr.py:251
@@ -22847,7 +22681,7 @@ msgstr "Arkivplatsreferenser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:960
 msgid "Gramplet showing the backlink references for a repository"
-msgstr "Gramplet visande referenserna för en arkivplats"
+msgstr "Gramplet som visar referenserna för en arkivplats"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:973
 msgid "Media References"
@@ -22855,7 +22689,7 @@ msgstr "Mediareferenser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:974
 msgid "Gramplet showing the backlink references for a media object"
-msgstr "Gramplet visande referenserna för ett mediaobjekt"
+msgstr "Gramplet som visar referenserna för ett mediaobjekt"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:987
 msgid "Note References"
@@ -22863,7 +22697,7 @@ msgstr "Notisreferenser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:988
 msgid "Gramplet showing the backlink references for a note"
-msgstr "Gramplet visande referenser för en notis"
+msgstr "Gramplet som visar referenserna för en notis"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1001
 msgid "Person Filter"
@@ -22871,7 +22705,7 @@ msgstr "Personfilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1002
 msgid "Gramplet providing a person filter"
-msgstr "Gramplet erbjuder ett personfilter"
+msgstr "Gramplet som erbjuder ett personfilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1015
 msgid "Family Filter"
@@ -22879,7 +22713,7 @@ msgstr "Familjefilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1016
 msgid "Gramplet providing a family filter"
-msgstr "Gramplet erbjuder ett familjefilter"
+msgstr "Gramplet som erbjuder ett familjefilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1029
 msgid "Event Filter"
@@ -22887,7 +22721,7 @@ msgstr "Händelsefilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1030
 msgid "Gramplet providing an event filter"
-msgstr "Gramplet erbjuder ett händelsefilter"
+msgstr "Gramplet som erbjuder ett händelsefilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1043
 msgid "Source Filter"
@@ -22895,7 +22729,7 @@ msgstr "Källfilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1044
 msgid "Gramplet providing a source filter"
-msgstr "Gramplet erbjuder ett källfilter"
+msgstr "Gramplet som erbjuder ett källfilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1057
 msgid "Citation Filter"
@@ -22903,7 +22737,7 @@ msgstr "Citeringsfilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1058
 msgid "Gramplet providing a citation filter"
-msgstr "Gramplet erbjuder ett citeringsfilter"
+msgstr "Gramplet som erbjuder ett citeringsfilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1071
 msgid "Place Filter"
@@ -22911,7 +22745,7 @@ msgstr "Platsfilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1072
 msgid "Gramplet providing a place filter"
-msgstr "Gramplet erbjuder ett platsfilter"
+msgstr "Gramplet som erbjuder ett platsfilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1085
 msgid "Media Filter"
@@ -22919,7 +22753,7 @@ msgstr "Mediafilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1086
 msgid "Gramplet providing a media filter"
-msgstr "Gramplet erbjuder ett mediafilter"
+msgstr "Gramplet som erbjuder ett mediafilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1099
 msgid "Repository Filter"
@@ -22927,7 +22761,7 @@ msgstr "Arkivplatsfilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1100
 msgid "Gramplet providing a repository filter"
-msgstr "Gramplet erbjuder ett arkivplatsfilter"
+msgstr "Gramplet som erbjuder ett arkivplatsfilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1113
 msgid "Note Filter"
@@ -22935,18 +22769,18 @@ msgstr "Notisfilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1114
 msgid "Gramplet providing a note filter"
-msgstr "Gramplet erbjuder ett notisfilter"
+msgstr "Gramplet som erbjuder ett notisfilter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1127
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1138
 #: ../gramps/plugins/textreport/recordsreport.py:118
 msgid "Records"
-msgstr "Rekord"
+msgstr "Poster"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1128
 #: ../gramps/plugins/textreport/textplugins.gpr.py:416
 msgid "Shows some interesting records about people and families"
-msgstr "Visar några intressanta rekord om personer och familjer"
+msgstr "Visar några intressanta poster om personer och familjer"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1143
 msgid "Person To Do"
@@ -22954,7 +22788,7 @@ msgstr "Person Att Göra"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1144
 msgid "Gramplet showing the To Do notes for a person"
-msgstr "Gramplet visande Att Göra notiser för en person"
+msgstr "Gramplet som visar Att Göra notiser för en person"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1157
 msgid "Event To Do"
@@ -22962,7 +22796,7 @@ msgstr "Händelse Att Göra"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1158
 msgid "Gramplet showing the To Do notes for an event"
-msgstr "Gramplet visande Att Göra notiser för en händelse"
+msgstr "Gramplet som visar Att Göra notiser för en händelse"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1171
 msgid "Family To Do"
@@ -22970,7 +22804,7 @@ msgstr "Familj Att Göra"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1172
 msgid "Gramplet showing the To Do notes for a family"
-msgstr "Gramplet visande Att Göra notiser för en familj"
+msgstr "Gramplet som visar Att Göra notiser för en familj"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1185
 msgid "Place To Do"
@@ -22978,15 +22812,15 @@ msgstr "Plats Att Göra"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1186
 msgid "Gramplet showing the To Do notes for a place"
-msgstr "Gramplet visande Att Göra notiser för en plats"
+msgstr "Gramplet som visar Att Göra notiser för en plats"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1199
 msgid "Source To Do"
-msgstr "Käll Att Göra"
+msgstr "Källa Att Göra"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1200
 msgid "Gramplet showing the To Do notes for a source"
-msgstr "Gramplet visande Att Göra notiser för en källa"
+msgstr "Gramplet som visar Att Göra notiser för en källa"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1213
 msgid "Citation To Do"
@@ -22994,7 +22828,7 @@ msgstr "Citering Att Göra"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1214
 msgid "Gramplet showing the To Do notes for a citation"
-msgstr "Gramplet visande Att Göra notiser för en citering"
+msgstr "Gramplet som visar Att Göra notiser för en citering"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1227
 msgid "Repository To Do"
@@ -23002,33 +22836,32 @@ msgstr "Arkivplats Att Göra"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1228
 msgid "Gramplet showing the To Do notes for a repository"
-msgstr "Gramplet visande Att Göra notiser för en arkivplats"
+msgstr "Gramplet som visar Att Göra notiser för en arkivplats"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1241
 msgid "Media To Do"
-msgstr "Media  Att Göra"
+msgstr "Media Att Göra"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1242
 msgid "Gramplet showing the To Do notes for a media object"
-msgstr "Gramplet visande Att Göra notiser för ett mediaobjekt"
+msgstr "Gramplet som visar Att Göra notiser för ett mediaobjekt"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1281
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1289
 msgid "SoundEx"
-msgstr "SoundEx-kod:"
+msgstr "SoundEx-kod"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1282
 msgid "Gramplet to generate SoundEx codes"
 msgstr "Gramplet för att skapa SoundEx-koder"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1294
-#, fuzzy
 msgid "Place Enclosed By"
-msgstr "Plats innesluter"
+msgstr "Plats omgiven av"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1295
 msgid "Gramplet showing the places enclosed by the active place"
-msgstr "Gramplet visande de platser som omges av den aktiva platsen"
+msgstr "Gramplet som visar de platser som omges av den aktiva platsen"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1308
 msgid "Place Encloses"
@@ -23036,7 +22869,7 @@ msgstr "Plats innesluter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1309
 msgid "Gramplet showing the places that the active place encloses"
-msgstr "Gramplet visande de platser som den aktiva platsen innesluter"
+msgstr "Gramplet som visar de platser som den aktiva platsen innesluter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1316
 msgid "Encloses"
@@ -23044,22 +22877,20 @@ msgstr "Innesluter"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1322
 msgid "Geography coordinates for Person Events"
-msgstr ""
+msgstr "Geografiska koordinater för personhändelser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1330
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1344
-#, fuzzy
 msgid "Events Coordinates"
-msgstr "Händelser %(date)s"
+msgstr "Händelsekoordinater"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1336
 msgid "Geography coordinates for Family Events"
-msgstr ""
+msgstr "Geografiska koordinater för familjehändelser"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1337
-#, fuzzy
 msgid "Gramplet showing the events for all the family"
-msgstr "Gramplet visande händelser för en familj"
+msgstr "Gramplet som visar händelser för hela familjen"
 
 #: ../gramps/plugins/gramplet/leak.py:93
 msgid "Uncollected object"
@@ -23121,7 +22952,7 @@ msgstr "Linjetyp"
 
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:163
 msgid "Click to make active\n"
-msgstr "Klicka för göra aktiv\n"
+msgstr "Klicka för att göra aktiv\n"
 
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:164
 msgid "Right-click to edit"
@@ -23148,7 +22979,7 @@ msgid ""
 "Breakdown by generation:\n"
 msgstr ""
 "\n"
-"Summering generationsvis:\n"
+"Uppdelning efter generation:\n"
 
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:254
 msgid "percent sign or text string|%"
@@ -23160,12 +22991,12 @@ msgstr "Generation 1"
 
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:262
 msgid "Double-click to see people in generation"
-msgstr "Dubbelklicka för att få se personen i generationen"
+msgstr "Dubbelklicka för att se personer i generationen"
 
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:264
 #, python-format
 msgid " has 1 of 1 individual (%(percent)s complete)\n"
-msgstr " utgörs av en individ (%(percent)s komplett)\n"
+msgstr " har 1 av 1 individ (%(percent)s komplett)\n"
 
 #. Create the Generation title, set an index marker
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:267
@@ -23180,7 +23011,7 @@ msgstr "Generation %d"
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:268
 #, python-format
 msgid "Double-click to see people in generation %d"
-msgstr "Dubbelklicka för att få se personerna i generation %d"
+msgstr "Dubbelklicka för att se personer i generation %d"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:272
@@ -23190,7 +23021,7 @@ msgid ""
 msgid_plural ""
 " has {count_person} of {max_count_person} individuals ({percent} complete)\n"
 msgstr[0] ""
-" består av {count_person} av {max_count_person} individ ({percent} "
+" består av {count_person} av {max_count_person} individer ({percent} "
 "komplett)\n"
 msgstr[1] ""
 " består av {count_person} av {max_count_person} individer ({percent} "
@@ -23235,7 +23066,7 @@ msgstr "Vytyp"
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:122
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:144
 msgid "Quick Views"
-msgstr "Snabbrapportvy"
+msgstr "Snabbrapportvyer"
 
 #: ../gramps/plugins/gramplet/recordsgramplet.py:42
 #: ../gramps/plugins/gramplet/whatsnext.py:44
@@ -23244,11 +23075,11 @@ msgstr "Dubbelklicka på namn för detaljer"
 
 #: ../gramps/plugins/gramplet/relativegramplet.py:41
 msgid "Click name to make person active\n"
-msgstr "Klicka på namnet för göra personen aktiv\n"
+msgstr "Klicka på namnet för att göra personen aktiv\n"
 
 #: ../gramps/plugins/gramplet/relativegramplet.py:42
 msgid "Right-click name to edit person"
-msgstr "Högerklicka på namnet för redigera personen"
+msgstr "Högerklicka på namnet för att redigera personen"
 
 #: ../gramps/plugins/gramplet/relativegramplet.py:72
 #, python-format
@@ -23291,7 +23122,7 @@ msgstr ""
 
 #: ../gramps/plugins/gramplet/sessionloggramplet.py:48
 msgid "Log for this Session"
-msgstr "Logg för denna körning"
+msgstr "Logg för denna session"
 
 #: ../gramps/plugins/gramplet/sessionloggramplet.py:57
 msgid "Opened data base -----------\n"
@@ -23459,9 +23290,9 @@ msgid ""
 "powerful features.\n"
 "\n"
 msgstr ""
-"Gramps är ett programpaket framtaget för släktforskning. Fast likheter med "
-"andra släktforskningsprogram, erbjuder Gramps några unika och kraftfulla "
-"egenskaper.\n"
+"Gramps är ett programpaket framtaget för släktforskning. Fastän likheter med "
+"andra släktforskningsprogram finns, erbjuder Gramps några unika och "
+"kraftfulla egenskaper.\n"
 "\n"
 
 #: ../gramps/plugins/gramplet/welcomegramplet.py:105
@@ -23478,11 +23309,11 @@ msgstr "Börja med släktforskning och Gramps"
 
 #: ../gramps/plugins/gramplet/welcomegramplet.py:110
 msgid "Gramps online manual"
-msgstr "Gramps hanbok via Internet"
+msgstr "Gramps online-handbok"
 
 #: ../gramps/plugins/gramplet/welcomegramplet.py:112
 msgid "locale_suffix|"
-msgstr ""
+msgstr "locale_suffix|"
 
 #: ../gramps/plugins/gramplet/welcomegramplet.py:113
 msgid "Ask questions on gramps-users mailing list"
@@ -23504,7 +23335,7 @@ msgstr ""
 "Gramps är skapat av släktforskare för släktforskare, ordnade inom Gramps "
 "Project. Gramps är ett programpaket med öppen källkod, vilket innebär att du "
 "är fri att göra kopior och distribuera till vem du vill. Det utvecklas och "
-"underhålls av en världsomspännande samling frivilliga, vars mål är att göra "
+"underhålls av en världsomspännande samling frivilliga vars mål är att göra "
 "Gramps kraftfullt, men ändå lättanvänt.\n"
 "\n"
 
@@ -23522,8 +23353,8 @@ msgid ""
 msgstr ""
 "Det första du måste göra är att skapa ett Släktträd. För att skapa ett nytt "
 "Släktträd (ibland kallat databas), välj \"Släktträd\" från menyn, klicka på "
-"\"\"Hantera släkträd\" och Ny samt namnge trädet. För ytterligare detaljer "
-"hänvisas till information via länkarna ovan.\n"
+"\"Hantera släktträd\" och \"Ny\" samt namnge trädet. För ytterligare "
+"detaljer hänvisas till information via länkarna ovan.\n"
 "\n"
 
 #: ../gramps/plugins/gramplet/welcomegramplet.py:130
@@ -23531,7 +23362,6 @@ msgid "Dashboard View"
 msgstr "Anslagstavlevy"
 
 #: ../gramps/plugins/gramplet/welcomegramplet.py:131
-#, fuzzy
 msgid ""
 "You are currently reading from the \"Dashboard\" view, where you can add "
 "your own gramplets. You can also add gramplets to any view by adding a "
@@ -23542,9 +23372,9 @@ msgid ""
 "can also drag the Properties button to reposition the gramplet on this page, "
 "and detach the gramplet to float above Gramps."
 msgstr ""
-"Du läser just nu från en \"Gramplet\"-sida, där du kan lägga till din egna "
-"Gramplets. Du kan även lägga till Gramplets till all vyer antingen genom att "
-"lägga till en sido- eller bottenpanel. Detta sker genom att högerklicka till "
+"Du läser just nu från en \"Anslagstavlevy\", där du kan lägga till dina egna "
+"Gramplets. Du kan även lägga till Gramplets till alla vyer genom att lägga "
+"till en sido- och/eller bottenpanel, för att göra det, högerklicka till "
 "höger om panelens flik.\n"
 "\n"
 "Du kan klicka på inställningsikonen i verktygsraden för att ändra antal "
@@ -23583,13 +23413,13 @@ msgstr "Flagga för att visa att en persons uppgifter är fullständiga"
 #. children of this family are processed.
 #: ../gramps/plugins/gramplet/whatsnext.py:83
 msgid "Tag to indicate that a family is complete"
-msgstr "Flagga för att visa att en famils uppgifter är fullständiga"
+msgstr "Flagga för att visa att en familjs uppgifter är fullständiga"
 
 #. Tag to use to specify people and families to ignore. In his way,
 #. hopeless cases can be marked separately and don't clutter up the list.
 #: ../gramps/plugins/gramplet/whatsnext.py:89
 msgid "Tag to indicate that a person or family should be ignored"
-msgstr "Flagga visande att en person eller familj borde ignoreras"
+msgstr "Flagga för att visa att en person eller familj borde ignoreras"
 
 #: ../gramps/plugins/gramplet/whatsnext.py:163
 msgid "No Home Person set."
@@ -23692,7 +23522,7 @@ msgstr "Släktlinjediagram"
 
 #: ../gramps/plugins/graph/graphplugins.gpr.py:37
 msgid "Produces family line graphs using Graphviz."
-msgstr "Skapar ett diagram för en släktlinje med Graphviz."
+msgstr "Skapar släktlinjediagram med Graphviz."
 
 #: ../gramps/plugins/graph/graphplugins.gpr.py:59
 msgid "Hourglass Graph"
@@ -23709,7 +23539,7 @@ msgstr "Släktskapsdiagram"
 
 #: ../gramps/plugins/graph/graphplugins.gpr.py:82
 msgid "Produces relationship graphs using Graphviz."
-msgstr "Skapar en släktskapsdiagram genom att använda Graphviz."
+msgstr "Skapar släktskapsdiagram med Graphviz."
 
 #. ------------------------------------------------------------------------
 #.
@@ -23757,7 +23587,7 @@ msgstr "Ättlingar - Anor"
 #. ---------------------
 #: ../gramps/plugins/graph/gvfamilylines.py:119
 msgid "Follow parents to determine \"family lines\""
-msgstr "Följ föräldrar för att bestämma släktlinjer"
+msgstr "Följ föräldrar för att bestämma \"släktlinjer\""
 
 #: ../gramps/plugins/graph/gvfamilylines.py:121
 msgid ""
@@ -23783,8 +23613,8 @@ msgid ""
 "People and families not directly related to people of interest will be "
 "removed when determining \"family lines\"."
 msgstr ""
-"Personer och familjer ej direkt släkt med intressanta personer, kommer att "
-"tas bort vid bestämning av\"släktlinjer\"."
+"Personer och familjer ej direkt släkt med personer av intresse kommer att "
+"tas bort vid bestämning av \"släktlinjer\"."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:139
 #: ../gramps/plugins/graph/gvhourglass.py:331
@@ -23796,7 +23626,7 @@ msgstr "Riktning för pilspets"
 #: ../gramps/plugins/graph/gvhourglass.py:334
 #: ../gramps/plugins/graph/gvrelgraph.py:781
 msgid "Choose the direction that the arrows point."
-msgstr "Välj den riktning som pilarna ska peka åt."
+msgstr "Välj den riktning som pilarna pekar åt."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:145
 #: ../gramps/plugins/graph/gvhourglass.py:337
@@ -23811,7 +23641,7 @@ msgid ""
 "gray."
 msgstr ""
 "Män kommer att visas i blått, kvinnor i rött såvida inte annat angivits ovan "
-"för fyllning. Om könet för en person är okänt, visas den i grått."
+"för fyllning. Om könet för en person är okänt visas den i grått."
 
 #. see bug report #2180
 #: ../gramps/plugins/graph/gvfamilylines.py:154
@@ -23829,19 +23659,19 @@ msgstr "Använd avrundade hörn för att skilja mellan kvinnor och män."
 #. --------------------------------
 #: ../gramps/plugins/graph/gvfamilylines.py:177
 msgid "People of Interest"
-msgstr "Intressanta personer"
+msgstr "Personer av intresse"
 
 #. --------------------------------
 #: ../gramps/plugins/graph/gvfamilylines.py:180
 msgid "People of interest"
-msgstr "Intressanta personer"
+msgstr "Personer av intresse"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:181
 msgid ""
 "People of interest are used as a starting point when determining \"family "
 "lines\"."
 msgstr ""
-"Intressanta personer används som utgångspunkt i samband med bestämning av "
+"Personer av intresse används som utgångspunkt i samband med bestämning av "
 "\"släktlinjer\"."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:185
@@ -23854,7 +23684,7 @@ msgstr "Huruvida begränsa antal förfäder."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:193
 msgid "The maximum number of ancestors to include."
-msgstr "Maximalt antal förfäder, som skall tas med."
+msgstr "Maximalt antal förfäder som skall tas med."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:197
 msgid "Limit the number of descendants"
@@ -23862,11 +23692,11 @@ msgstr "Begränsa antalet ättlingar"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:200
 msgid "Whether to limit the number of descendants."
-msgstr "Huruvida begränsa antalet ättlingar."
+msgstr "Huruvida begränsa antal ättlingar."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:206
 msgid "The maximum number of descendants to include."
-msgstr "Maximalt antal ättlingar, som skall tas med."
+msgstr "Maximalt antal ättlingar som skall tas med."
 
 #. --------------------
 #: ../gramps/plugins/graph/gvfamilylines.py:215
@@ -23879,7 +23709,7 @@ msgstr "Huruvida ta med datum för personer och familjer."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:221
 msgid "Limit dates to years only"
-msgstr "Begränsa datum till år enbart"
+msgstr "Begränsa datum enbart till år"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:222
 msgid ""
@@ -23932,14 +23762,12 @@ msgid "Where the thumbnail image should appear relative to the name"
 msgstr "Var miniatyrbilden skall synas relativt till namnet"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:254
-#, fuzzy
 msgid "Thumbnail size"
-msgstr "Minatyrbild"
+msgstr "Miniatyrbild"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:257
-#, fuzzy
 msgid "Size of the thumbnail image"
-msgstr "Skapa och använd bara av mediaminiatyrbilder"
+msgstr "Storlek på miniatyrbilden"
 
 #. ----------------------------
 #: ../gramps/plugins/graph/gvfamilylines.py:261
@@ -23953,7 +23781,7 @@ msgstr "Släktfärger"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:265
 msgid "Colors to use for various family lines."
-msgstr "Färger, som används för olika släktlinjer."
+msgstr "Färger som används för olika släktlinjer."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:273
 #: ../gramps/plugins/graph/gvhourglass.py:369
@@ -23977,7 +23805,7 @@ msgstr "Färgen som används för att visa okänt kön."
 #: ../gramps/plugins/graph/gvhourglass.py:382
 #: ../gramps/plugins/graph/gvrelgraph.py:910
 msgid "The color to use to display families."
-msgstr "Färgen, som används vid visning av familjer."
+msgstr "Färgen som används vid visning av familjer."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:398
 #: ../gramps/plugins/textreport/familygroup.py:680
@@ -23989,41 +23817,35 @@ msgstr "Tom rapport"
 #: ../gramps/plugins/textreport/familygroup.py:681
 #: ../gramps/plugins/textreport/indivcomplete.py:830
 msgid "You did not specify anybody"
-msgstr "Du specificerad ingen"
+msgstr "Du specificerade inte någon"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:458
-#, fuzzy
 msgid "Number of people in database:"
-msgstr "Antal personer"
+msgstr "Antal personer i databasen:"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:461
-#, fuzzy
 msgid "Number of people of interest:"
-msgstr "Intressanta personer"
+msgstr "Antal personer av intresse:"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:464
-#, fuzzy
 msgid "Number of families in database:"
-msgstr "Antal familjer: %d"
+msgstr "Antal familjer i databasen:"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:467
-#, fuzzy
 msgid "Number of families of interest:"
-msgstr "Antal familjer"
+msgstr "Antal familjer av intresse:"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:471
 msgid "Additional people removed:"
-msgstr ""
+msgstr "Ytterligare personer som togs bort:"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:474
-#, fuzzy
 msgid "Additional families removed:"
-msgstr "samtliga familjer"
+msgstr "Ytterligare familjer som togs bort:"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:477
-#, fuzzy
 msgid "Initial list of people of interest:"
-msgstr "Intressanta personer"
+msgstr "Lista på personer av intresse:"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/graph/gvfamilylines.py:970
@@ -24034,43 +23856,39 @@ msgstr[0] "{number_of} barn"
 msgstr[1] "{number_of} barn"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:1045
-#, fuzzy, python-format
+#, python-format
 msgid "father: %s"
-msgstr "far"
+msgstr "far: %s"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:1055
-#, fuzzy, python-format
+#, python-format
 msgid "mother: %s"
-msgstr "Notis: %s"
+msgstr "mor: %s"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:1068
-#, fuzzy, python-format
+#, python-format
 msgid "child: %s"
-msgstr "barn"
+msgstr "barn: %s"
 
 #: ../gramps/plugins/graph/gvhourglass.py:61
-#, fuzzy
 msgid "Center -> Others"
-msgstr "Centrera hit"
+msgstr "Centrera -> Andra"
 
 #: ../gramps/plugins/graph/gvhourglass.py:62
-#, fuzzy
 msgid "Center <- Others"
-msgstr "Centrera hit"
+msgstr "Centrera <- Andra"
 
 #: ../gramps/plugins/graph/gvhourglass.py:63
-#, fuzzy
 msgid "Center <-> Other"
-msgstr "Centrera hit"
+msgstr "Centrera <-> Andra"
 
 #: ../gramps/plugins/graph/gvhourglass.py:64
-#, fuzzy
 msgid "Center - Other"
-msgstr "Centrera hit"
+msgstr "Centrera - Andra"
 
 #: ../gramps/plugins/graph/gvhourglass.py:318
 msgid "The Center person for the graph"
-msgstr "Huvudpersonen för rapporten"
+msgstr "Huvudpersonen för diagrammet"
 
 #: ../gramps/plugins/graph/gvhourglass.py:321
 #: ../gramps/plugins/textreport/kinshipreport.py:362
@@ -24079,7 +23897,7 @@ msgstr "Maximalt antal ättlingsgenerationer"
 
 #: ../gramps/plugins/graph/gvhourglass.py:322
 msgid "The number of generations of descendants to include in the graph"
-msgstr "Antal ättlingsgenerationer, som skall ingå i rapporten"
+msgstr "Antal ättlingsgenerationer som skall ingå i diagrammet"
 
 #: ../gramps/plugins/graph/gvhourglass.py:326
 #: ../gramps/plugins/textreport/kinshipreport.py:366
@@ -24088,7 +23906,7 @@ msgstr "Maximalt antal förfadersgenerationer"
 
 #: ../gramps/plugins/graph/gvhourglass.py:327
 msgid "The number of generations of ancestors to include in the graph"
-msgstr "Antal förfadersgenerationer, som skall ingå i rapporten"
+msgstr "Antal förfadersgenerationer som skall ingå i diagrammet"
 
 #: ../gramps/plugins/graph/gvhourglass.py:340
 #: ../gramps/plugins/graph/gvrelgraph.py:787
@@ -24096,14 +23914,14 @@ msgid ""
 "Males will be shown with blue, females with red.  If the sex of an "
 "individual is unknown it will be shown with gray."
 msgstr ""
-"Män kommer att visas i blått, kvinnor i rött. Om könet för en person är "
-"okänt, visas den i grått."
+"Män kommer att visas i blått, kvinnor i rött.  Om könet för en person är "
+"okänt visas den i grått."
 
 #. ###############################
 #: ../gramps/plugins/graph/gvhourglass.py:365
 #: ../gramps/plugins/graph/gvrelgraph.py:892
 msgid "Graph Style"
-msgstr "Diagrammall"
+msgstr "Diagram-mall"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:205
 #: ../gramps/plugins/textreport/indivcomplete.py:834
@@ -24114,7 +23932,7 @@ msgstr "Skapar rapport"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:769
 msgid "Determines what people are included in the graph"
-msgstr "Avgör vilka personer, som tas med i rapporten"
+msgstr "Avgör vilka personer som tas med i diagrammet"
 
 #. ###############################
 #: ../gramps/plugins/graph/gvrelgraph.py:822
@@ -24135,7 +23953,7 @@ msgstr "Ta med födelse-, giftermåls- och dödsdatum samt platser"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:828
 msgid "Include (birth, marriage, death) dates, and places if no dates"
-msgstr "Ta med födelse-, giftermåls- och dödsdatum om inga datum"
+msgstr "Ta med födelse-, giftermåls- och dödsdatum, och platser om inga datum"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:830
 msgid "Include (birth, marriage, death) years, but no places"
@@ -24150,9 +23968,8 @@ msgid "Include (birth, marriage, death) places, but no dates"
 msgstr "Ta med födelse-, giftermåls- och dödsplatser, men inga datum"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:836
-#, fuzzy
 msgid "Include (birth, marriage, death) dates and places on same line"
-msgstr "Ta med födelse-, giftermåls- och dödsdatum samt platser"
+msgstr "Ta med födelse-, giftermåls- och dödsdatum och platser på samma rad"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:839
 msgid "Whether to include dates and/or places"
@@ -24168,7 +23985,7 @@ msgid ""
 "generated that contain active links to the files generated by the 'Narrated "
 "Web Site' report."
 msgstr ""
-"Ta med en URL i varje diagramnod, så att det går att skapa PDF- och "
+"Ta med en URL i varje diagramnod så att det går att skapa PDF- och "
 "imagemapfiler med aktiva länkar till de filer som skapats med rapporten "
 "'Rapport som webbplats'."
 
@@ -24180,7 +23997,7 @@ msgstr "Ta med släktskap till centralperson"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:852
 msgid "Whether to show every person's relationship to the center person"
-msgstr "Huruvida visa varje persons släktskap för den centralpersonen"
+msgstr "Huruvida visa varje persons släktskap till den valda personen"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:861
 msgid "Whether to include thumbnails of people."
@@ -24192,28 +24009,24 @@ msgstr "Miniatyrbildsplats"
 
 #. occupation = BooleanOption(_("Include occupation"), False)
 #: ../gramps/plugins/graph/gvrelgraph.py:873
-#, fuzzy
 msgid "Include occupation"
-msgstr "Ta med kusiner"
+msgstr "Ta med yrke"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:874
-#, fuzzy
 msgid "Do not include any occupation"
-msgstr "Tag ej med titel"
+msgstr "Ta ej med något yrke"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:875
-#, fuzzy
 msgid "Include description of most recent occupation"
-msgstr "Ta med syskon till centralpersonen"
+msgstr "Ta med beskrivning av det senaste yrket"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:877
 msgid "Include date, description and place of all occupations"
-msgstr ""
+msgstr "Ta med datum, beskrivning och plats för alla yrken"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:879
-#, fuzzy
 msgid "Whether to include the last occupation"
-msgstr "Huruvida ta med alternativ för databasnedladdning"
+msgstr "Huruvida ta med det sista yrket"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:883
 msgid "Include relationship debugging numbers also"
@@ -24232,7 +24045,7 @@ msgstr "Indikera icke-födelserelationer med punkterade linjer"
 #: ../gramps/plugins/graph/gvrelgraph.py:915
 msgid "Non-birth relationships will show up as dotted lines in the graph."
 msgstr ""
-"Icke-födelserelationer kommer att visas med punkterade linjer i grafen."
+"Icke-födelserelationer kommer att visas med punkterade linjer i diagrammet."
 
 #: ../gramps/plugins/graph/gvrelgraph.py:919
 msgid "Show family nodes"
@@ -24261,7 +24074,7 @@ msgid ""
 "the media object files.)"
 msgstr ""
 "Importera data från ett Gramps-paket (en arkiverad XML-databas tillsammans "
-"med mediaobjektfiler)."
+"med mediaobjektfiler.)"
 
 #: ../gramps/plugins/importer/import.gpr.py:110
 msgid "Gramps XML Family Tree"
@@ -24272,7 +24085,7 @@ msgid ""
 "The Gramps XML format is a text version of a Family Tree. It is read-write "
 "compatible with the present Gramps database format."
 msgstr ""
-"Gramps XML-databas är en textversion av släktträd. Det är läs- och "
+"Gramps XML-databas är en textversion av ett släktträd. Det är läs- och "
 "skrivkompatibelt med Gramps nuvarande databasformat."
 
 #: ../gramps/plugins/importer/import.gpr.py:131
@@ -24293,7 +24106,7 @@ msgstr "Importera data från Pro-Gen-filer"
 
 #: ../gramps/plugins/importer/import.gpr.py:168
 msgid "Import data from vCard files"
-msgstr "Import data från vCard-filer"
+msgstr "Importera data från vCard-filer"
 
 #: ../gramps/plugins/importer/importcsv.py:123
 #: ../gramps/plugins/importer/importgedcom.py:129
@@ -24340,7 +24153,7 @@ msgstr "titel"
 
 #: ../gramps/plugins/importer/importcsv.py:165
 msgid "title"
-msgstr "Titel"
+msgstr "titel"
 
 #: ../gramps/plugins/importer/importcsv.py:168
 msgid "gender"
@@ -24364,7 +24177,7 @@ msgstr "födelseort id"
 
 #: ../gramps/plugins/importer/importcsv.py:179
 msgid "birth source"
-msgstr "föddekälla"
+msgstr "födelsekälla"
 
 #: ../gramps/plugins/importer/importcsv.py:181
 msgid "baptism place"
@@ -24376,7 +24189,7 @@ msgstr "dopplats id"
 
 #: ../gramps/plugins/importer/importcsv.py:185
 msgid "baptism date"
-msgstr "dopdag"
+msgstr "dopdatum"
 
 #: ../gramps/plugins/importer/importcsv.py:187
 msgid "baptism source"
@@ -24454,7 +24267,7 @@ msgstr "plats"
 
 #: ../gramps/plugins/importer/importcsv.py:222
 msgid "place id"
-msgstr "plats ID"
+msgstr "plats id"
 
 #: ../gramps/plugins/importer/importcsv.py:223
 msgid "name"
@@ -24487,7 +24300,7 @@ msgstr "omgivet_av"
 #: ../gramps/plugins/importer/importcsv.py:256
 #, python-format
 msgid "format error: line %(line)d: %(zero)s"
-msgstr "formatfelr: rad %(line)d: %(zero)s"
+msgstr "formatfel: rad %(line)d: %(zero)s"
 
 #: ../gramps/plugins/importer/importcsv.py:337
 msgid "CSV Import"
@@ -24595,16 +24408,16 @@ msgstr "Militär avmobilisering"
 
 #: ../gramps/plugins/importer/importgeneweb.py:99
 msgid "Dotation"
-msgstr "Donation"
+msgstr "Hemgift"
 
 #: ../gramps/plugins/importer/importgeneweb.py:100
 #: ../gramps/plugins/lib/libgedcom.py:711
 msgid "Excommunication"
-msgstr "Bannlysa"
+msgstr "Bannlysning"
 
 #: ../gramps/plugins/importer/importgeneweb.py:102
 msgid "LDS Family Link"
-msgstr "LDS släktlänkar"
+msgstr "SDH släktlänk"
 
 #: ../gramps/plugins/importer/importgeneweb.py:103
 #: ../gramps/plugins/lib/libgedcom.py:713
@@ -24613,7 +24426,7 @@ msgstr "Begravning"
 
 #: ../gramps/plugins/importer/importgeneweb.py:105
 msgid "Hospitalisation"
-msgstr "Hospitalisering"
+msgstr "Sjukhusvård"
 
 #: ../gramps/plugins/importer/importgeneweb.py:106
 msgid "Illness"
@@ -24625,7 +24438,7 @@ msgstr "Lista passagerare"
 
 #: ../gramps/plugins/importer/importgeneweb.py:109
 msgid "Military Distinction"
-msgstr "Militärtjänst"
+msgstr "Militärgrad"
 
 #: ../gramps/plugins/importer/importgeneweb.py:110
 msgid "Militaty Mobilisation"
@@ -24637,7 +24450,7 @@ msgstr "Militärbefordran"
 
 #: ../gramps/plugins/importer/importgeneweb.py:119
 msgid "LDS Seal to child"
-msgstr "LDS Seal to child"
+msgstr "SDH besegla till barn"
 
 #: ../gramps/plugins/importer/importgeneweb.py:122
 msgid "Sold property"
@@ -24658,7 +24471,7 @@ msgstr "GeneWeb-import"
 #: ../gramps/plugins/importer/importgeneweb.py:911
 #, python-brace-format
 msgid "Invalid date {date} in {gw_snippet}, preserving date as text."
-msgstr "Ogiltigt datum {date} i {gw_snippet}, behåller datum som text"
+msgstr "Ogiltigt datum {date} i {gw_snippet}, behåller datum som text."
 
 #: ../gramps/plugins/importer/importgpkg.py:72
 #, python-format
@@ -24676,7 +24489,7 @@ msgstr "Mediamappen %s är inte skrivbar"
 #, python-format
 msgid ""
 "Media directory %s exists. Delete it first, then restart the import process"
-msgstr "Mediamappen %s finns. Radera den först och starta sedan om importen."
+msgstr "Mediamappen %s finns. Radera den först och starta sedan om importen"
 
 #: ../gramps/plugins/importer/importgpkg.py:90
 #, python-format
@@ -24685,7 +24498,7 @@ msgstr "Fel vid extrahering till %s"
 
 #: ../gramps/plugins/importer/importgpkg.py:107
 msgid "Base path for relative media set"
-msgstr "Grundsökväg för relativ mediamängd"
+msgstr "Relativ grundsökväg för media är angiven"
 
 #: ../gramps/plugins/importer/importgpkg.py:108
 #, python-format
@@ -24698,7 +24511,7 @@ msgstr ""
 "Den grundläggande mediasökvägen för detta släktträd har satts till %s. "
 "Fundera på en enklare sökväg. Du kan ändra denna i Inställningar under det "
 "att du flyttar dina mediafiler till den nya platsen och använder "
-"mediahanteringshjälpmedlet, alternativ 'Byt ut delsträng i sökvägen för att "
+"mediahanteringshjälpmedlets alternativ 'Byt ut delsträng i sökvägen' för att "
 "ställa in riktiga sökvägar för dina mediaobjekt."
 
 #: ../gramps/plugins/importer/importgpkg.py:117
@@ -24716,12 +24529,12 @@ msgid ""
 "tool, option 'Replace substring in the path' to set correct paths in your "
 "media objects."
 msgstr ""
-"Det släktträd, som du importerat till, har redan en grundsökväg för media: "
+"Det släktträd som du importerat till har redan en grundsökväg för media: "
 "%(orig_path)s. De importerade mediaobjekten är emellertid relativa från "
-"%(path)s. Du kan ändra mediasökvägen i 'Inställningar eller också så kan du "
+"%(path)s. Du kan ändra mediasökvägen i 'Inställningar' eller också så kan du "
 "omvandla de importerade filerna till den befintliga grundsökvägen för media. "
 "Du kan göra detta genom att flytta dina mediafiler till den nya platsen och "
-"använda mediahanteringshjälpmedlet, alternativ 'Byt ut delsträng i sökväg' "
+"använda mediahanteringshjälpmedlets, alternativ 'Byt ut delsträng i sökväg' "
 "för att ställa in riktiga sökvägar för dina mediaobjekt."
 
 #: ../gramps/plugins/importer/importgrdb.py:61
@@ -24743,12 +24556,12 @@ msgid ""
 "example this version), create a new empty database and import the Gramps XML "
 "into that version. Please refer to:%(gramps_wiki_migrate_two_to_three_url)s"
 msgstr ""
-"Databasversionen stöds ej av denna version nav Gramps. Du borde använda en "
+"Databasversionen stöds ej av denna version av Gramps. Du borde använda en "
 "gammal version av Gramps av version 3.0.x och importera din databas till den "
 "versionen. Du bör sedan exportera en kopia av av dina data till Gramps XML "
 "(släktträd). Sedan bör du uppgradera till Gramps av senaste version (till "
 "exempel denna), skapa en ny tom databas och importera Gramps XML in till "
-"denna version. Se: :%(gramps_wiki_migrate_two_to_three_url)s"
+"denna version. Se:%(gramps_wiki_migrate_two_to_three_url)s"
 
 #: ../gramps/plugins/importer/importprogen.py:87
 #: ../gramps/plugins/importer/importprogen.py:517
@@ -24765,14 +24578,14 @@ msgid "Field '%(fldname)s' not found"
 msgstr "Fält '%(fldname)s' hittades ej"
 
 #: ../gramps/plugins/importer/importprogen.py:460
-#, fuzzy, python-format
+#, python-format
 msgid "Cannot find DEF file: %(dname)s"
-msgstr "Kan ej hitta DEF-fil: %(deffname)s"
+msgstr "Kan ej hitta DEF-fil: %(dname)s"
 
 #. Raise a error message
 #: ../gramps/plugins/importer/importprogen.py:516
 msgid "Not a supported Pro-Gen import file language"
-msgstr ""
+msgstr "Inte ett understött Pro-Gen import-filspråk"
 
 #. self.reset(_("Import from Pro-Gen"))  # non-functional for now
 #: ../gramps/plugins/importer/importprogen.py:527
@@ -24780,55 +24593,56 @@ msgid "Pro-Gen import"
 msgstr "Pro-Gen-import"
 
 #: ../gramps/plugins/importer/importprogen.py:586
-#, fuzzy, python-format
+#, python-format
 msgid "Import from Pro-Gen (%s)"
-msgstr "Importera från Pro-Gen"
+msgstr "Importera från Pro-Gen (%s)"
 
 #. Hmmm. Just use the plain text.
 #: ../gramps/plugins/importer/importprogen.py:1066
-#, fuzzy, python-format
+#, python-format
 msgid "Date did not match: '%(text)s' (%(msg)s)"
-msgstr "datum matchade inte: '%(text)s' (%(msg)s)"
+msgstr "Datum matchade inte: '%(text)s' (%(msg)s)"
 
 #: ../gramps/plugins/importer/importprogen.py:1790
-#, fuzzy, python-format
+#, python-format
 msgid "Cannot find father for I%(person)s (Father=%(id)d)"
-msgstr "kan inte hitta far till I%(person)s (far=%(id)d)"
+msgstr "Kan inte hitta far till I%(person)s (far=%(id)d)"
 
 #: ../gramps/plugins/importer/importprogen.py:1793
-#, fuzzy, python-format
+#, python-format
 msgid "Cannot find mother for I%(person)s (Mother=%(mother)d)"
-msgstr "kan inte hitta mor till I%(person)s (mor=%(mother)d)"
+msgstr "Kan inte hitta mor till I%(person)s (mor=%(mother)d)"
 
 #: ../gramps/plugins/importer/importvcard.py:228
-#, fuzzy, python-format
+#, python-format
 msgid "Line %(line)5d: %(prob)s\n"
-msgstr "formatfelr: rad %(line)d: %(zero)s"
+msgstr "Rad %(line)5d: %(prob)s\n"
 
 #: ../gramps/plugins/importer/importvcard.py:243
 msgid "vCard import"
 msgstr "vCard-import"
 
 #: ../gramps/plugins/importer/importvcard.py:254
-#, fuzzy
 msgid "VCARD import report: No errors detected"
-msgstr "GEDCOM importrappport: Inga fel hittade"
+msgstr "VCARD importrapport: Inga fel hittade"
 
 #: ../gramps/plugins/importer/importvcard.py:256
-#, fuzzy, python-format
+#, python-format
 msgid "VCARD import report: %s errors detected\n"
-msgstr "GEDCOM importrappport: %s fel hittades"
+msgstr "VCARD importrapport: %s fel hittades\n"
 
 #: ../gramps/plugins/importer/importvcard.py:321
 #, python-format
 msgid "Token >%(token)s< unknown. line skipped: %(line)s"
-msgstr ""
+msgstr "Token >%(token)s< okänd. rad hoppas över: %(line)s"
 
 #: ../gramps/plugins/importer/importvcard.py:335
 msgid ""
 "BEGIN property not properly closed by END property, Gramps can't cope with "
 "nested VCards."
 msgstr ""
+"BEGIN egenskap inte korrekt avslutad av END egenskap, Gramps kan inte "
+"hantera inbäddade VCards."
 
 #: ../gramps/plugins/importer/importvcard.py:346
 #, python-format
@@ -24840,21 +24654,24 @@ msgid ""
 "VCard is malformed missing the compulsory N property, so there is no name; "
 "skip it."
 msgstr ""
+"VCard är felformaterat saknar den obligatoriska N egenskapen, så det finns "
+"inget namn; hoppar över det."
 
 #: ../gramps/plugins/importer/importvcard.py:371
 msgid ""
 "VCard is malformed missing the compulsory FN property, get name from N alone."
 msgstr ""
+"VCard är felformaterat saknar den obligatoriska FN egenskapen, tar namn "
+"uteslutande från N."
 
 #: ../gramps/plugins/importer/importvcard.py:375
 msgid "VCard is malformed wrong number of name components."
-msgstr ""
+msgstr "VCard är felformaterat, felaktigt antal namnkomponenter."
 
 #: ../gramps/plugins/importer/importvcard.py:517
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "Invalid date in BDAY {vcard_snippet}, preserving date as text."
-msgstr ""
-"Ogiltigt datum i {date} i BDAY {vcard_snippet}, behåller datum som text."
+msgstr "Ogiltigt datum i BDAY {vcard_snippet}, behåller datum som text."
 
 #: ../gramps/plugins/importer/importvcard.py:525
 #, python-brace-format
@@ -24876,14 +24693,14 @@ msgstr ""
 #: ../gramps/plugins/tool/eventnames.py:137
 #, python-format
 msgid "%(event_name)s of %(family)s"
-msgstr "%(event_name)s mellan %(family)s"
+msgstr "%(event_name)s för %(family)s"
 
 #. feature requests 2356, 1658: avoid genitive form
 #: ../gramps/plugins/importer/importxml.py:105
 #: ../gramps/plugins/tool/eventnames.py:139
 #, python-format
 msgid "%(event_name)s of %(person)s"
-msgstr "%(person)s: %(event_name)s"
+msgstr "%(event_name)s för %(person)s"
 
 #: ../gramps/plugins/importer/importxml.py:154
 #: ../gramps/plugins/importer/importxml.py:159
@@ -24944,7 +24761,7 @@ msgstr "  Citering %(id)s med %(id2)s\n"
 #: ../gramps/plugins/importer/importxml.py:282
 #, python-format
 msgid "  People: %d\n"
-msgstr "  Person: %d\n"
+msgstr "  Personer: %d\n"
 
 #: ../gramps/plugins/importer/importxml.py:283
 #, python-format
@@ -25009,7 +24826,7 @@ msgstr ""
 "\n"
 " Den importerade filen var inte fullständig.\n"
 "För att rätta till detta skapades %(new)d objekt och\n"
-"deras typattribut satt till 'Okänd'.\n"
+"deras typattribut sattes till 'Okänd'.\n"
 "Uppdelningen per kategori är avbildad genom\n"
 "antal inom parentes. Där så är möjligt är\n"
 "dessa 'Okända' objekt refererade av notis %(unknown)s.\n"
@@ -25025,8 +24842,8 @@ msgstr ""
 "\n"
 "Mediaobjekt med relativa mediasökvägar har\n"
 "importerats. Dessa sökvägar ses som relativa till\n"
-"den mediamapp du kan ge i inställningar\n"
-"eller om ej given relativ till användarmappen.\n"
+"den mediamapp du kan ange i inställningar\n"
+"eller om ej given, relativ till användarmappen.\n"
 
 #: ../gramps/plugins/importer/importxml.py:321
 msgid ""
@@ -25044,11 +24861,11 @@ msgstr ""
 #: ../gramps/plugins/importer/importxml.py:1563
 #: ../gramps/plugins/importer/importxml.py:1984
 msgid "The Gramps Xml you are trying to import is malformed."
-msgstr "Den Gramps XML du försöker importera är felaktigt utformad."
+msgstr "Den Gramps XML-databas du försöker importera är felformaterad."
 
 #: ../gramps/plugins/importer/importxml.py:809
 msgid "Attributes that link the data together are missing."
-msgstr "Attribut, som länkar data tillsammans, saknas."
+msgstr "Attribut som länkar data tillsammans saknas."
 
 #: ../gramps/plugins/importer/importxml.py:922
 msgid "Gramps XML import"
@@ -25137,14 +24954,14 @@ msgid ""
 "for more info."
 msgstr ""
 "Den gramps-fil du importerar gjordes med Gramps version %(oldgramps)s, medan "
-"du kör en en senare version av Gramps, %(newgramps)s.\n"
+"du kör en senare version av Gramps, %(newgramps)s.\n"
 "\n"
 "Försäkra dig om att allt är korrekt efter importen. Om du stöter på problem, "
 "så gör en felanmälan och använd under tiden en äldre version av Gramps till "
 "att importera denna fil, som är xml version %(xmlversion)s.\n"
 "Se\n"
 "  %(gramps_wiki_xml_url)s\n"
-" för mer info."
+"för mer info."
 
 #: ../gramps/plugins/importer/importxml.py:1056
 msgid "Old xml file"
@@ -25162,7 +24979,7 @@ msgstr "Alla händelsereferenser måste ha ett 'hlink'-attribut."
 
 #: ../gramps/plugins/importer/importxml.py:1564
 msgid "Any person reference must have a 'hlink' attribute."
-msgstr "Alls personreferenser måste ha ett 'hlink'-attribut."
+msgstr "Alla personreferenser måste ha ett 'hlink'-attribut."
 
 #: ../gramps/plugins/importer/importxml.py:1753
 #, python-format
@@ -25203,7 +25020,7 @@ msgid ""
 "Error: family '%(family)s' father '%(father)s' does not refer back to the "
 "family. Reference added."
 msgstr ""
-"FEL: familj '%(family)s' far '%(father)s' refererar ej  tillbaka till "
+"FEL: familj '%(family)s' far '%(father)s' refererar ej tillbaka till "
 "familjen. Referens tillagd."
 
 #: ../gramps/plugins/importer/importxml.py:3240
@@ -25212,7 +25029,7 @@ msgid ""
 "Error: family '%(family)s' mother '%(mother)s' does not refer back to the "
 "family. Reference added."
 msgstr ""
-"FEL: familj '%(family)s' mor '%(mother)s' refererar ej  tillbaka till "
+"FEL: familj '%(family)s' mor '%(mother)s' refererar ej tillbaka till "
 "familjen. Referens tillagd."
 
 #: ../gramps/plugins/importer/importxml.py:3262
@@ -25221,7 +25038,7 @@ msgid ""
 "Error: family '%(family)s' child '%(child)s' does not refer back to the "
 "family. Reference added."
 msgstr ""
-"FEL: familj '%(family)s' barn '%(child)s' refererar ej  tillbaka till "
+"FEL: familj '%(family)s' barn '%(child)s' refererar ej tillbaka till "
 "familjen. Referens tillagd."
 
 #: ../gramps/plugins/lib/libcairodoc.py:1398
@@ -25230,7 +25047,7 @@ msgid ""
 "Mismatch between selected extension %(ext)s and actual format.\n"
 " Writing to %(filename)s in format %(impliedext)s."
 msgstr ""
-"Mismatch mellan vald extension %(ext)s och aktuellt format.\n"
+"Mismatch mellan vald filändelse %(ext)s och aktuellt format.\n"
 " Skriver till %(filename)s i format %(impliedext)s."
 
 #: ../gramps/plugins/lib/libgedcom.py:706
@@ -25265,7 +25082,7 @@ msgstr "Längd"
 
 #: ../gramps/plugins/lib/libgedcom.py:715
 msgid "Initiatory (LDS)"
-msgstr ""
+msgstr "Initiation (SDH)"
 
 #: ../gramps/plugins/lib/libgedcom.py:716
 msgid "Military ID"
@@ -25273,7 +25090,7 @@ msgstr "Militär ID"
 
 #: ../gramps/plugins/lib/libgedcom.py:717
 msgid "Mission (LDS)"
-msgstr ""
+msgstr "Mission (SDH)"
 
 #: ../gramps/plugins/lib/libgedcom.py:718
 msgid "Namesake"
@@ -25294,7 +25111,7 @@ msgstr "Vikt"
 
 #: ../gramps/plugins/lib/libgedcom.py:934
 msgid "Line ignored "
-msgstr "Rad ignorerad"
+msgstr "Rad ignorerad "
 
 #. e.g. Illegal character (oxAB) (0xCB)... 1 NOTE xyz?pqr?lmn
 #: ../gramps/plugins/lib/libgedcom.py:1547
@@ -25318,22 +25135,22 @@ msgstr "GEDCOM-import"
 
 #: ../gramps/plugins/lib/libgedcom.py:2773
 msgid "GEDCOM import report: No errors detected"
-msgstr "GEDCOM importrappport: Inga fel hittade"
+msgstr "GEDCOM importrapport: Inga fel hittade"
 
 #: ../gramps/plugins/lib/libgedcom.py:2775
 #, python-format
 msgid "GEDCOM import report: %s errors detected"
-msgstr "GEDCOM importrappport: %s fel hittades"
+msgstr "GEDCOM importrapport: %s fel hittades"
 
 #: ../gramps/plugins/lib/libgedcom.py:3092
 #: ../gramps/plugins/lib/libgedcom.py:3117
 #: ../gramps/plugins/lib/libgedcom.py:3130
 msgid "Line ignored as not understood"
-msgstr "Rad gick inte att förstå, så den ignorerades."
+msgstr "Rad gick inte att förstå, så den ignorerades"
 
 #: ../gramps/plugins/lib/libgedcom.py:3119
 msgid "Tag recognized but not supported"
-msgstr "Flagga upptäck, men stöds ej"
+msgstr "Flagga upptäckt men stöds ej"
 
 #: ../gramps/plugins/lib/libgedcom.py:3155
 msgid "Skipped subordinate line"
@@ -25341,7 +25158,7 @@ msgstr "Hoppade över underordnad rad"
 
 #: ../gramps/plugins/lib/libgedcom.py:3188
 msgid "Records not imported into "
-msgstr "Poster, som ej importerats till "
+msgstr "Poster som ej importerats till "
 
 #: ../gramps/plugins/lib/libgedcom.py:3226
 #, python-format
@@ -25359,7 +25176,7 @@ msgid ""
 "Record with typifying attribute 'Unknown' created"
 msgstr ""
 "FEL: %(msg)s '%(gramps_id)s' (indata som @%(xref)s@) ej i GEDCOM-indata. "
-"Post med typiskt attribut \"Okänd\" skapats"
+"Post med typattribut 'Okänd' skapad"
 
 #: ../gramps/plugins/lib/libgedcom.py:3279
 #, python-format
@@ -25369,7 +25186,7 @@ msgid ""
 "reference removed from person"
 msgstr ""
 "FEL: familj '%(family)s' (indata som @%(orig_family)s@) person %(person)s "
-"(indata som %(orig_person)s) är ej en medlem i refererade familj. "
+"(indata som %(orig_person)s) är inte en medlem i den refererade familjen. "
 "Familjereferens borttagen från person"
 
 #: ../gramps/plugins/lib/libgedcom.py:3357
@@ -25383,9 +25200,9 @@ msgid ""
 "referenced by note %(unknown)s.\n"
 msgstr ""
 "\n"
-" Den importerade filen var inte fullständig.\n"
+"Den importerade filen var inte fullständig.\n"
 "För att rätta till detta skapades %(new)d objekt och\n"
-"deras typattribut satt till 'Okänd'.\n"
+"deras typattribut sattes till 'Okänd'.\n"
 "Där så är möjligt är dessa 'Okända' objekt\n"
 "refererade av notis %(unknown)s.\n"
 
@@ -25424,7 +25241,7 @@ msgstr "Översta nivå"
 #: ../gramps/plugins/lib/libgedcom.py:3666
 #, python-format
 msgid "INDI (individual) Gramps ID %s"
-msgstr "INDI (individual) Gramps ID %s"
+msgstr "INDI (individ) Gramps ID %s"
 
 #: ../gramps/plugins/lib/libgedcom.py:3785
 msgid "Empty Alias <NAME PERSONAL> ignored"
@@ -25433,12 +25250,12 @@ msgstr "Tomt alias <personnamn> ignorerat"
 #: ../gramps/plugins/lib/libgedcom.py:4979
 #, python-format
 msgid "FAM (family) Gramps ID %s"
-msgstr "FAM (family) Gramps ID %s"
+msgstr "FAM (familj) Gramps ID %s"
 
 #: ../gramps/plugins/lib/libgedcom.py:5341
 #: ../gramps/plugins/lib/libgedcom.py:6705
 msgid "Filename omitted"
-msgstr "Filnamn saknas"
+msgstr "Filnamn utelämnat"
 
 #: ../gramps/plugins/lib/libgedcom.py:5374
 #: ../gramps/plugins/lib/libgedcom.py:6746
@@ -25454,7 +25271,7 @@ msgstr "Mediatyp"
 #: ../gramps/plugins/lib/libgedcom.py:5455
 #: ../gramps/plugins/lib/libgedcom.py:6736
 msgid "Multiple FILE in a single OBJE ignored"
-msgstr "Flera FILER filer i ett enda OBJE ignoreras"
+msgstr "Flera FILER i ett enda OBJE ignoreras"
 
 #. We have previously found a PLAC
 #: ../gramps/plugins/lib/libgedcom.py:5609
@@ -25494,7 +25311,7 @@ msgstr "Ingen titel - ID %s"
 #: ../gramps/plugins/lib/libgedcom.py:6462
 #, python-format
 msgid "SOUR (source) Gramps ID %s"
-msgstr "SOUR (source) Gramps ID %s"
+msgstr "SOUR (källa) Gramps ID %s"
 
 #: ../gramps/plugins/lib/libgedcom.py:6712
 #, python-format
@@ -25504,7 +25321,7 @@ msgstr "OBJE (multi-media objekt) Gramps ID %s"
 #: ../gramps/plugins/lib/libgedcom.py:6942
 #, python-format
 msgid "REPO (repository) Gramps ID %s"
-msgstr "REPO (repository) Gramps ID %s"
+msgstr "REPO (arkivplats) Gramps ID %s"
 
 #: ../gramps/plugins/lib/libgedcom.py:7003
 #: ../gramps/plugins/lib/libgedcom.py:7988
@@ -25513,7 +25330,7 @@ msgstr "Endast ett telefonnummer stöds"
 
 #: ../gramps/plugins/lib/libgedcom.py:7189
 msgid "HEAD (header)"
-msgstr "HEAD (header)"
+msgstr "HEAD (huvud)"
 
 #: ../gramps/plugins/lib/libgedcom.py:7210
 msgid "Approved system identification"
@@ -25552,11 +25369,11 @@ msgstr "Publiceringsdatum för källdata"
 #: ../gramps/plugins/lib/libgedcom.py:7340
 #, python-format
 msgid "Import from %s"
-msgstr "Import från %s"
+msgstr "Importera från %s"
 
 #: ../gramps/plugins/lib/libgedcom.py:7379
 msgid "Submission record identifier"
-msgstr ""
+msgstr "Inlämningsregisteridentifierare"
 
 #: ../gramps/plugins/lib/libgedcom.py:7392
 msgid "Language of GEDCOM text"
@@ -25568,7 +25385,7 @@ msgid ""
 "Import of GEDCOM file %(filename)s with DEST=%(by)s, could cause errors in "
 "the resulting database!"
 msgstr ""
-"Import av GEDCOM fil %(filename)s med DEST=%(by)s, kan orsaka del i den "
+"Import av GEDCOM fil %(filename)s med DEST=%(by)s, kan orsaka fel i den "
 "skapade databasen!"
 
 #: ../gramps/plugins/lib/libgedcom.py:7417
@@ -25599,7 +25416,7 @@ msgstr "GEDCOM FORM bör vara med versaler"
 
 #: ../gramps/plugins/lib/libgedcom.py:7478
 msgid "GEDCOM FORM not supported"
-msgstr "GEDCOM-form ej stödd"
+msgstr "GEDCOM-form stöds ej"
 
 #: ../gramps/plugins/lib/libgedcom.py:7481
 msgid "GEDCOM form"
@@ -25625,27 +25442,28 @@ msgstr "NOTE Gramps ID %s"
 
 #: ../gramps/plugins/lib/libgedcom.py:7688
 msgid "Submission: Submitter"
-msgstr ""
+msgstr "Inlämning: Inlämnare"
 
 #: ../gramps/plugins/lib/libgedcom.py:7690
 msgid "Submission: Family file"
-msgstr ""
+msgstr "Inlämning: Familjefil"
 
 #: ../gramps/plugins/lib/libgedcom.py:7692
 msgid "Submission: Temple code"
-msgstr ""
+msgstr "Inlämning: Tempelkod"
 
 #: ../gramps/plugins/lib/libgedcom.py:7694
 msgid "Submission: Generations of ancestors"
-msgstr ""
+msgstr "Inlämning: Generationer av förfäder"
 
 #: ../gramps/plugins/lib/libgedcom.py:7696
 msgid "Submission: Generations of descendants"
-msgstr ""
+msgstr "Inlämning: Generationer av ättlingar"
 
+# NOTE: Know nothing about LDS (The Church of Jesus Christ of Latter-day Saints). So I don't know if this is correct.
 #: ../gramps/plugins/lib/libgedcom.py:7698
 msgid "Submission: Ordinance process flag"
-msgstr ""
+msgstr "Inlämning: Processflagga för ceremoni"
 
 #. Okay we have no clue which temple this is.
 #. We should tell the user and store it anyway.
@@ -25658,7 +25476,7 @@ msgid ""
 "Your GEDCOM file is corrupted. The file appears to be encoded using the "
 "UTF16 character set, but is missing the BOM marker."
 msgstr ""
-"Din GEDCOM-fil är förstörd. Filen verkar varar kodad med UTF16-"
+"Din GEDCOM-fil är förstörd. Filen verkar vara kodad med UTF16-"
 "teckenuppsättning, men saknar BOM-markering."
 
 #: ../gramps/plugins/lib/libgedcom.py:8025
@@ -25894,7 +25712,7 @@ msgstr "Personen föddes %(month_year)s i %(birth_place)s."
 #: ../gramps/plugins/lib/libnarrate.py:150
 #, python-format
 msgid "He was born in %(month_year)s in %(birth_place)s."
-msgstr "Han föddes föddes %(month_year)s i %(birth_place)s."
+msgstr "Han föddes %(month_year)s i %(birth_place)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:151
 #, python-format
@@ -25987,8 +25805,8 @@ msgid ""
 "%(unknown_gender_name)s died on %(death_date)s in %(death_place)s at the age "
 "of %(age)s."
 msgstr ""
-"%(unknown_gender_name)s dog %(death_date)s i %(death_place)s, vid en ålder "
-"av %(age)s."
+"%(unknown_gender_name)s dog %(death_date)s i %(death_place)s vid en ålder av "
+"%(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:195
 #, python-format
@@ -26001,7 +25819,7 @@ msgid ""
 "%(male_name)s died on %(death_date)s in %(death_place)s at the age of "
 "%(age)s."
 msgstr ""
-"%(male_name)s dog %(death_date)s i %(death_place)s, vid en ålder av %(age)s."
+"%(male_name)s dog %(death_date)s i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:199
 #, python-format
@@ -26014,8 +25832,7 @@ msgid ""
 "%(female_name)s died on %(death_date)s in %(death_place)s at the age of "
 "%(age)s."
 msgstr ""
-"%(female_name)s dog %(death_date)s i %(death_place)s, vid en ålder av "
-"%(age)s."
+"%(female_name)s dog %(death_date)s i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:204
 #, python-format
@@ -26026,8 +25843,7 @@ msgstr "Personen dog %(death_date)s i %(death_place)s."
 #, python-format
 msgid ""
 "This person died on %(death_date)s in %(death_place)s at the age of %(age)s."
-msgstr ""
-"Personen dog %(death_date)s i %(death_place)s, vid en ålder av %(age)s."
+msgstr "Personen dog %(death_date)s i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:208
 #, python-format
@@ -26037,7 +25853,7 @@ msgstr "Han dog %(death_date)s i %(death_place)s."
 #: ../gramps/plugins/lib/libnarrate.py:209
 #, python-format
 msgid "He died on %(death_date)s in %(death_place)s at the age of %(age)s."
-msgstr "Han dog %(death_date)s i %(death_place)s, vid en ålder av %(age)s."
+msgstr "Han dog %(death_date)s i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:212
 #, python-format
@@ -26047,7 +25863,7 @@ msgstr "Hon dog %(death_date)s i %(death_place)s."
 #: ../gramps/plugins/lib/libnarrate.py:213
 #, python-format
 msgid "She died on %(death_date)s in %(death_place)s at the age of %(age)s."
-msgstr "Hon dog %(death_date)s i %(death_place)s, vid en ålder av %(age)s."
+msgstr "Hon dog %(death_date)s i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:217
 #: ../gramps/plugins/lib/libnarrate.py:250
@@ -26072,8 +25888,8 @@ msgid ""
 "%(unknown_gender_name)s died %(death_date)s in %(death_place)s at the age of "
 "%(age)s."
 msgstr ""
-"%(unknown_gender_name)s dog %(death_date)s i %(death_place)s, vid en ålder "
-"av %(age)s."
+"%(unknown_gender_name)s dog %(death_date)s i %(death_place)s vid en ålder av "
+"%(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:228
 #, python-format
@@ -26085,7 +25901,7 @@ msgstr "%(male_name)s dog %(death_date)s i %(death_place)s."
 msgid ""
 "%(male_name)s died %(death_date)s in %(death_place)s at the age of %(age)s."
 msgstr ""
-"%(male_name)s dog %(death_date)s i %(death_place)s, vid en ålder av %(age)s."
+"%(male_name)s dog %(death_date)s i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:232
 #, python-format
@@ -26097,8 +25913,7 @@ msgstr "%(female_name)s dog %(death_date)s i %(death_place)s."
 msgid ""
 "%(female_name)s died %(death_date)s in %(death_place)s at the age of %(age)s."
 msgstr ""
-"%(female_name)s dog %(death_date)s i %(death_place)s, vid en ålder av "
-"%(age)s."
+"%(female_name)s dog %(death_date)s i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:237
 #, python-format
@@ -26109,8 +25924,7 @@ msgstr "Personen dog %(death_date)s i %(death_place)s."
 #, python-format
 msgid ""
 "This person died %(death_date)s in %(death_place)s at the age of %(age)s."
-msgstr ""
-"Personen dog %(death_date)s i %(death_place)s, vid en ålder av %(age)s."
+msgstr "Personen dog %(death_date)s i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:241
 #, python-format
@@ -26120,7 +25934,7 @@ msgstr "Han dog %(death_date)s i %(death_place)s."
 #: ../gramps/plugins/lib/libnarrate.py:242
 #, python-format
 msgid "He died %(death_date)s in %(death_place)s at the age of %(age)s."
-msgstr "Han dog %(death_date)s i %(death_place)s, vid en ålder av %(age)s."
+msgstr "Han dog %(death_date)s i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:245
 #, python-format
@@ -26130,7 +25944,7 @@ msgstr "Hon dog %(death_date)s i %(death_place)s."
 #: ../gramps/plugins/lib/libnarrate.py:246
 #, python-format
 msgid "She died %(death_date)s in %(death_place)s at the age of %(age)s."
-msgstr "Hon dog %(death_date)s i %(death_place)s, vid en ålder av %(age)s."
+msgstr "Hon dog %(death_date)s i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:257
 #, python-format
@@ -26140,7 +25954,7 @@ msgstr "%(unknown_gender_name)s dog %(death_date)s."
 #: ../gramps/plugins/lib/libnarrate.py:258
 #, python-format
 msgid "%(unknown_gender_name)s died on %(death_date)s at the age of %(age)s."
-msgstr "%(unknown_gender_name)s dog %(death_date)s, vid en ålder av %(age)s."
+msgstr "%(unknown_gender_name)s dog %(death_date)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:261
 #, python-format
@@ -26150,7 +25964,7 @@ msgstr "%(male_name)s dog %(death_date)s."
 #: ../gramps/plugins/lib/libnarrate.py:262
 #, python-format
 msgid "%(male_name)s died on %(death_date)s at the age of %(age)s."
-msgstr "%(male_name)s dog %(death_date)s, vid en ålder av %(age)s."
+msgstr "%(male_name)s dog %(death_date)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:265
 #, python-format
@@ -26160,7 +25974,7 @@ msgstr "%(female_name)s dog %(death_date)s."
 #: ../gramps/plugins/lib/libnarrate.py:266
 #, python-format
 msgid "%(female_name)s died on %(death_date)s at the age of %(age)s."
-msgstr "%(female_name)s dog %(death_date)s, vid en ålder av %(age)s."
+msgstr "%(female_name)s dog %(death_date)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:270
 #, python-format
@@ -26170,7 +25984,7 @@ msgstr "Personen dog %(death_date)s."
 #: ../gramps/plugins/lib/libnarrate.py:271
 #, python-format
 msgid "This person died on %(death_date)s at the age of %(age)s."
-msgstr "Personen dog %(death_date)s, vid en ålder av %(age)s."
+msgstr "Personen dog %(death_date)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:274
 #, python-format
@@ -26180,7 +25994,7 @@ msgstr "Han dog %(death_date)s."
 #: ../gramps/plugins/lib/libnarrate.py:275
 #, python-format
 msgid "He died on %(death_date)s at the age of %(age)s."
-msgstr "Han dog %(death_date)s, vid en ålder av %(age)s."
+msgstr "Han dog %(death_date)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:278
 #, python-format
@@ -26190,7 +26004,7 @@ msgstr "Hon dog %(death_date)s."
 #: ../gramps/plugins/lib/libnarrate.py:279
 #, python-format
 msgid "She died on %(death_date)s at the age of %(age)s."
-msgstr "Hon dog %(death_date)s, vid en ålder av %(age)s."
+msgstr "Hon dog %(death_date)s vid en ålder av %(age)s."
 
 #. latin cross for html code
 #: ../gramps/plugins/lib/libnarrate.py:283
@@ -26214,7 +26028,7 @@ msgstr "%(unknown_gender_name)s dog %(death_date)s."
 #: ../gramps/plugins/lib/libnarrate.py:291
 #, python-format
 msgid "%(unknown_gender_name)s died %(death_date)s at the age of %(age)s."
-msgstr "%(unknown_gender_name)s dog %(death_date)s, vid en ålder av %(age)s."
+msgstr "%(unknown_gender_name)s dog %(death_date)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:294
 #, python-format
@@ -26224,7 +26038,7 @@ msgstr "%(male_name)s dog %(death_date)s."
 #: ../gramps/plugins/lib/libnarrate.py:295
 #, python-format
 msgid "%(male_name)s died %(death_date)s at the age of %(age)s."
-msgstr "%(male_name)s dog %(death_date)s, vid en ålder av %(age)s."
+msgstr "%(male_name)s dog %(death_date)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:298
 #, python-format
@@ -26234,7 +26048,7 @@ msgstr "%(female_name)s dog %(death_date)s."
 #: ../gramps/plugins/lib/libnarrate.py:299
 #, python-format
 msgid "%(female_name)s died %(death_date)s at the age of %(age)s."
-msgstr "%(female_name)s dog %(death_date)s, vid en ålder av %(age)s."
+msgstr "%(female_name)s dog %(death_date)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:303
 #, python-format
@@ -26244,7 +26058,7 @@ msgstr "Personen dog %(death_date)s."
 #: ../gramps/plugins/lib/libnarrate.py:304
 #, python-format
 msgid "This person died %(death_date)s at the age of %(age)s."
-msgstr "Personen dog %(death_date)s, vid en ålder av %(age)s."
+msgstr "Personen dog %(death_date)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:307
 #, python-format
@@ -26254,7 +26068,7 @@ msgstr "Han dog %(death_date)s."
 #: ../gramps/plugins/lib/libnarrate.py:308
 #, python-format
 msgid "He died %(death_date)s at the age of %(age)s."
-msgstr "Han dog %(death_date)s, vid en ålder av %(age)s."
+msgstr "Han dog %(death_date)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:311
 #, python-format
@@ -26264,7 +26078,7 @@ msgstr "Hon dog %(death_date)s."
 #: ../gramps/plugins/lib/libnarrate.py:312
 #, python-format
 msgid "She died %(death_date)s at the age of %(age)s."
-msgstr "Hon dog %(death_date)s, vid en ålder av %(age)s."
+msgstr "Hon dog %(death_date)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:323
 #, python-format
@@ -26277,8 +26091,8 @@ msgid ""
 "%(unknown_gender_name)s died in %(month_year)s in %(death_place)s at the age "
 "of %(age)s."
 msgstr ""
-"%(unknown_gender_name)s dog %(month_year)s i %(death_place)s, vid en ålder "
-"av %(age)s."
+"%(unknown_gender_name)s dog %(month_year)s i %(death_place)s vid en ålder av "
+"%(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:327
 #, python-format
@@ -26291,7 +26105,7 @@ msgid ""
 "%(male_name)s died in %(month_year)s in %(death_place)s at the age of "
 "%(age)s."
 msgstr ""
-"%(male_name)s dog %(month_year)s i %(death_place)s, vid en ålder av %(age)s."
+"%(male_name)s dog %(month_year)s i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:331
 #, python-format
@@ -26304,8 +26118,7 @@ msgid ""
 "%(female_name)s died in %(month_year)s in %(death_place)s at the age of "
 "%(age)s."
 msgstr ""
-"%(female_name)s dog %(month_year)s i %(death_place)s, vid en ålder av "
-"%(age)s."
+"%(female_name)s dog %(month_year)s i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:336
 #, python-format
@@ -26316,8 +26129,7 @@ msgstr "Personen dog %(month_year)s i %(death_place)s."
 #, python-format
 msgid ""
 "This person died in %(month_year)s in %(death_place)s at the age of %(age)s."
-msgstr ""
-"Personen dog %(month_year)s i %(death_place)s, vid en ålder av %(age)s."
+msgstr "Personen dog %(month_year)s i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:340
 #, python-format
@@ -26327,7 +26139,7 @@ msgstr "Han dog %(month_year)s i %(death_place)s."
 #: ../gramps/plugins/lib/libnarrate.py:341
 #, python-format
 msgid "He died in %(month_year)s in %(death_place)s at the age of %(age)s."
-msgstr "Han dog %(month_year)s i %(death_place)s, vid en ålder av %(age)s."
+msgstr "Han dog %(month_year)s i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:344
 #, python-format
@@ -26337,7 +26149,7 @@ msgstr "Hon dog %(month_year)s i %(death_place)s."
 #: ../gramps/plugins/lib/libnarrate.py:345
 #, python-format
 msgid "She died in %(month_year)s in %(death_place)s at the age of %(age)s."
-msgstr "Hon dog %(month_year)s i %(death_place)s, vid en ålder av %(age)s."
+msgstr "Hon dog %(month_year)s i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:349
 #, python-format
@@ -26357,7 +26169,7 @@ msgstr "%(unknown_gender_name)s dog %(month_year)s."
 #: ../gramps/plugins/lib/libnarrate.py:357
 #, python-format
 msgid "%(unknown_gender_name)s died in %(month_year)s at the age of %(age)s."
-msgstr "%(unknown_gender_name)s dog %(month_year)s, vid en ålder av %(age)s."
+msgstr "%(unknown_gender_name)s dog %(month_year)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:360
 #, python-format
@@ -26367,7 +26179,7 @@ msgstr "%(male_name)s dog %(month_year)s."
 #: ../gramps/plugins/lib/libnarrate.py:361
 #, python-format
 msgid "%(male_name)s died in %(month_year)s at the age of %(age)s."
-msgstr "%(male_name)s dog %(month_year)s, vid en ålder av %(age)s."
+msgstr "%(male_name)s dog %(month_year)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:364
 #, python-format
@@ -26377,7 +26189,7 @@ msgstr "%(female_name)s dog %(month_year)s."
 #: ../gramps/plugins/lib/libnarrate.py:365
 #, python-format
 msgid "%(female_name)s died in %(month_year)s at the age of %(age)s."
-msgstr "%(female_name)s dog %(month_year)s, vid en ålder av %(age)s."
+msgstr "%(female_name)s dog %(month_year)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:369
 #, python-format
@@ -26387,7 +26199,7 @@ msgstr "Personen dog %(month_year)s."
 #: ../gramps/plugins/lib/libnarrate.py:370
 #, python-format
 msgid "This person died in %(month_year)s at the age of %(age)s."
-msgstr "Personen dog %(month_year)s, vid en ålder av %(age)s."
+msgstr "Personen dog %(month_year)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:373
 #, python-format
@@ -26397,7 +26209,7 @@ msgstr "Han dog %(month_year)s."
 #: ../gramps/plugins/lib/libnarrate.py:374
 #, python-format
 msgid "He died in %(month_year)s at the age of %(age)s."
-msgstr "Han dog %(month_year)s, vid en ålder av %(age)s."
+msgstr "Han dog %(month_year)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:377
 #, python-format
@@ -26407,7 +26219,7 @@ msgstr "Hon dog %(month_year)s."
 #: ../gramps/plugins/lib/libnarrate.py:378
 #, python-format
 msgid "She died in %(month_year)s at the age of %(age)s."
-msgstr "Hon dog %(month_year)s, vid en ålder av %(age)s."
+msgstr "Hon dog %(month_year)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:382
 #, python-format
@@ -26427,8 +26239,7 @@ msgstr "%(unknown_gender_name)s dog i %(death_place)s."
 #: ../gramps/plugins/lib/libnarrate.py:390
 #, python-format
 msgid "%(unknown_gender_name)s died in %(death_place)s at the age of %(age)s."
-msgstr ""
-"%(unknown_gender_name)s dog i %(death_place)s, vid en ålder av %(age)s."
+msgstr "%(unknown_gender_name)s dog i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:393
 #, python-format
@@ -26438,7 +26249,7 @@ msgstr "%(male_name)s dog i %(death_place)s."
 #: ../gramps/plugins/lib/libnarrate.py:394
 #, python-format
 msgid "%(male_name)s died in %(death_place)s at the age of %(age)s."
-msgstr "%(male_name)s dog i %(death_place)s, vid en ålder av %(age)s."
+msgstr "%(male_name)s dog i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:397
 #, python-format
@@ -26448,7 +26259,7 @@ msgstr "%(female_name)s dog i %(death_place)s."
 #: ../gramps/plugins/lib/libnarrate.py:398
 #, python-format
 msgid "%(female_name)s died in %(death_place)s at the age of %(age)s."
-msgstr "%(female_name)s dog i %(death_place)s, vid en ålder av %(age)s."
+msgstr "%(female_name)s dog i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:403
 #, python-format
@@ -26458,7 +26269,7 @@ msgstr "Personen dog i %(death_place)s."
 #: ../gramps/plugins/lib/libnarrate.py:404
 #, python-format
 msgid "This person died in %(death_place)s at the age of %(age)s."
-msgstr "Personen dog i %(death_place)s, vid en ålder av %(age)s."
+msgstr "Personen dog i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:407
 #, python-format
@@ -26468,7 +26279,7 @@ msgstr "Han dog i %(death_place)s."
 #: ../gramps/plugins/lib/libnarrate.py:408
 #, python-format
 msgid "He died in %(death_place)s at the age of %(age)s."
-msgstr "Han dog i %(death_place)s, vid en ålder av %(age)s."
+msgstr "Han dog i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:411
 #, python-format
@@ -26478,7 +26289,7 @@ msgstr "Hon dog i %(death_place)s."
 #: ../gramps/plugins/lib/libnarrate.py:412
 #, python-format
 msgid "She died in %(death_place)s at the age of %(age)s."
-msgstr "Hon dog i %(death_place)s, vid en ålder av %(age)s."
+msgstr "Hon dog i %(death_place)s vid en ålder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:416
 #, python-format
@@ -26563,7 +26374,7 @@ msgstr ""
 #, python-format
 msgid ""
 "This person was buried on %(burial_date)s in %(burial_place)s%(endnotes)s."
-msgstr "Denna person begravdes %(burial_date)s i %(burial_place)s%(endnotes)s."
+msgstr "Personen begravdes %(burial_date)s i %(burial_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:472
 #, python-format
@@ -26598,7 +26409,7 @@ msgstr "%(unknown_gender_name)s begravdes %(burial_date)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:486
 #, python-format
 msgid "This person was buried on %(burial_date)s%(endnotes)s."
-msgstr "Denna person begravdes %(burial_date)s%(endnotes)s."
+msgstr "Personen begravdes %(burial_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:488
 #, python-format
@@ -26642,8 +26453,7 @@ msgstr ""
 #, python-format
 msgid ""
 "This person was buried in %(month_year)s in %(burial_place)s%(endnotes)s."
-msgstr ""
-"Denna person begravdes i %(month_year)s i %(burial_place)s%(endnotes)s."
+msgstr "Personen begravdes i %(month_year)s i %(burial_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:504
 #, python-format
@@ -26678,7 +26488,7 @@ msgstr "%(unknown_gender_name)s begravdes i %(month_year)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:518
 #, python-format
 msgid "This person was buried in %(month_year)s%(endnotes)s."
-msgstr "Denna person begravdes i %(month_year)s%(endnotes)s."
+msgstr "Personen begravdes i %(month_year)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:520
 #, python-format
@@ -26722,8 +26532,7 @@ msgstr ""
 #, python-format
 msgid ""
 "This person was buried %(modified_date)s in %(burial_place)s%(endnotes)s."
-msgstr ""
-"Denna person begravdes %(modified_date)s i %(burial_place)s%(endnotes)s."
+msgstr "Personen begravdes %(modified_date)s i %(burial_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:536
 #, python-format
@@ -26758,7 +26567,7 @@ msgstr "%(unknown_gender_name)s begravdes %(modified_date)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:550
 #, python-format
 msgid "This person was buried %(modified_date)s%(endnotes)s."
-msgstr "Denna person begravdes %(modified_date)s%(endnotes)s."
+msgstr "Personen begravdes %(modified_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:552
 #, python-format
@@ -26793,7 +26602,7 @@ msgstr "%(unknown_gender_name)s begravdes i %(burial_place)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:566
 #, python-format
 msgid "This person was buried in %(burial_place)s%(endnotes)s."
-msgstr "Denna person begravdes i %(burial_place)s%(endnotes)s."
+msgstr "Personen begravdes i %(burial_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:568
 #, python-format
@@ -26828,12 +26637,12 @@ msgstr "%(unknown_gender_name)s begravdes%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:582
 #, python-format
 msgid "This person was buried%(endnotes)s."
-msgstr "Denna person begravdes%(endnotes)s."
+msgstr "Personen begravdes%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:584
 #, python-format
 msgid "Buried%(endnotes)s."
-msgstr "Gegravd%(endnotes)s."
+msgstr "Begravd%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:594
 #, python-format
@@ -26874,7 +26683,7 @@ msgstr ""
 msgid ""
 "This person was baptized on %(baptism_date)s in %(baptism_place)s"
 "%(endnotes)s."
-msgstr "Denna person döptes %(baptism_date)s i %(baptism_place)s%(endnotes)s."
+msgstr "Personen döptes %(baptism_date)s i %(baptism_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:605
 #, python-format
@@ -26909,7 +26718,7 @@ msgstr "%(unknown_gender_name)s döptes %(baptism_date)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:619
 #, python-format
 msgid "This person was baptized on %(baptism_date)s%(endnotes)s."
-msgstr "Denna person döptes %(baptism_date)s%(endnotes)s."
+msgstr "Personen döptes %(baptism_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:621
 #, python-format
@@ -26954,7 +26763,7 @@ msgstr ""
 #, python-format
 msgid ""
 "This person was baptized in %(month_year)s in %(baptism_place)s%(endnotes)s."
-msgstr "Denna person döptes i %(month_year)s i %(baptism_place)s%(endnotes)s."
+msgstr "Personen döptes i %(month_year)s i %(baptism_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:637
 #, python-format
@@ -26989,7 +26798,7 @@ msgstr "%(unknown_gender_name)s döptes i %(month_year)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:651
 #, python-format
 msgid "This person was baptized in %(month_year)s%(endnotes)s."
-msgstr "Denna person döptes i %(month_year)s%(endnotes)s."
+msgstr "Personen döptes i %(month_year)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:653
 #, python-format
@@ -27035,7 +26844,7 @@ msgstr ""
 #, python-format
 msgid ""
 "This person was baptized %(modified_date)s in %(baptism_place)s%(endnotes)s."
-msgstr "Denna person döptes %(modified_date)s i %(baptism_place)s%(endnotes)s."
+msgstr "Personen döptes %(modified_date)s i %(baptism_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:669
 #, python-format
@@ -27070,7 +26879,7 @@ msgstr "%(unknown_gender_name)s döptes %(modified_date)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:683
 #, python-format
 msgid "This person was baptized %(modified_date)s%(endnotes)s."
-msgstr "Denna person döptes %(modified_date)s%(endnotes)s."
+msgstr "Personen döptes %(modified_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:685
 #, python-format
@@ -27105,7 +26914,7 @@ msgstr "%(unknown_gender_name)s döptes i %(baptism_place)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:699
 #, python-format
 msgid "This person was baptized in %(baptism_place)s%(endnotes)s."
-msgstr "Denna person döptes i %(baptism_place)s%(endnotes)s."
+msgstr "Personen döptes i %(baptism_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:701
 #, python-format
@@ -27140,7 +26949,7 @@ msgstr "%(unknown_gender_name)s döptes%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:715
 #, python-format
 msgid "This person was baptized%(endnotes)s."
-msgstr "Denna person döptes%(endnotes)s."
+msgstr "Personen döptes%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:717
 #, python-format
@@ -27194,7 +27003,7 @@ msgid ""
 "This person was christened on %(christening_date)s in %(christening_place)s"
 "%(endnotes)s."
 msgstr ""
-"Denna person döptes %(christening_date)s i %(christening_place)s%(endnotes)s."
+"Personen döptes %(christening_date)s i %(christening_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:738
 #, python-format
@@ -27230,7 +27039,7 @@ msgstr "%(unknown_gender_name)s döptes %(christening_date)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:752
 #, python-format
 msgid "This person was christened on %(christening_date)s%(endnotes)s."
-msgstr "Denna person döptes %(christening_date)s%(endnotes)s."
+msgstr "Personen döptes %(christening_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:754
 #, python-format
@@ -27279,8 +27088,7 @@ msgstr ""
 msgid ""
 "This person was christened in %(month_year)s in %(christening_place)s"
 "%(endnotes)s."
-msgstr ""
-"Denna person döptes %(month_year)s i %(christening_place)s%(endnotes)s."
+msgstr "Personen döptes %(month_year)s i %(christening_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:770
 #, python-format
@@ -27315,7 +27123,7 @@ msgstr "%(unknown_gender_name)s döptes %(month_year)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:784
 #, python-format
 msgid "This person was christened in %(month_year)s%(endnotes)s."
-msgstr "Denna person döptes %(month_year)s%(endnotes)s."
+msgstr "Personen döptes %(month_year)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:786
 #, python-format
@@ -27364,8 +27172,7 @@ msgstr ""
 msgid ""
 "This person was christened %(modified_date)s in %(christening_place)s"
 "%(endnotes)s."
-msgstr ""
-"Denna person döptes %(modified_date)s i %(christening_place)s%(endnotes)s."
+msgstr "Personen döptes %(modified_date)s i %(christening_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:802
 #, python-format
@@ -27400,7 +27207,7 @@ msgstr "%(unknown_gender_name)s döptes %(modified_date)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:816
 #, python-format
 msgid "This person was christened %(modified_date)s%(endnotes)s."
-msgstr "Denna person döptes %(modified_date)s%(endnotes)s."
+msgstr "Personen döptes %(modified_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:818
 #, python-format
@@ -27436,7 +27243,7 @@ msgstr "%(unknown_gender_name)s döptes i %(christening_place)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:832
 #, python-format
 msgid "This person was christened in %(christening_place)s%(endnotes)s."
-msgstr "Denna person döptes i %(christening_place)s%(endnotes)s."
+msgstr "Personen döptes i %(christening_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:834
 #, python-format
@@ -27471,7 +27278,7 @@ msgstr "%(unknown_gender_name)s döptes%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:848
 #, python-format
 msgid "This person was christened%(endnotes)s."
-msgstr "Denna person döptes%(endnotes)s."
+msgstr "Personen döptes%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:850
 #, python-format
@@ -27546,7 +27353,7 @@ msgstr "Hon är dotter till %(father)s och %(mother)s."
 #: ../gramps/plugins/lib/libnarrate.py:888
 #, python-format
 msgid "She was the daughter of %(father)s and %(mother)s."
-msgstr "Hon är dotter till %(father)s och %(mother)s."
+msgstr "Hon var dotter till %(father)s och %(mother)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:890
 #, python-format
@@ -27556,7 +27363,7 @@ msgstr "Dotter till %(father)s och %(mother)s."
 #: ../gramps/plugins/lib/libnarrate.py:897
 #, python-format
 msgid "%(male_name)s is the child of %(father)s."
-msgstr "%(male_name)s är barn till  %(father)s."
+msgstr "%(male_name)s är barn till %(father)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:898
 #, python-format
@@ -27566,7 +27373,7 @@ msgstr "%(male_name)s var barn till %(father)s."
 #: ../gramps/plugins/lib/libnarrate.py:901
 #, python-format
 msgid "This person is the child of %(father)s."
-msgstr "Personen är barn till  %(father)s."
+msgstr "Personen är barn till %(father)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:902
 #, python-format
@@ -27631,7 +27438,7 @@ msgstr "Dotter till %(father)s."
 #: ../gramps/plugins/lib/libnarrate.py:933
 #, python-format
 msgid "%(male_name)s is the child of %(mother)s."
-msgstr "%(male_name)s är barn är barn till %(mother)s."
+msgstr "%(male_name)s är barn till %(mother)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:934
 #, python-format
@@ -27896,17 +27703,17 @@ msgstr "Hon gifte sig med %(spouse)s %(modified_date)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:1034
 #, python-format
 msgid "Married %(spouse)s %(partial_date)s%(endnotes)s."
-msgstr "Gift %(spouse)s %(partial_date)s%(endnotes)s."
+msgstr "Gifte sig med %(spouse)s %(partial_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1035
 #, python-format
 msgid "Married %(spouse)s %(full_date)s%(endnotes)s."
-msgstr "Gift %(spouse)s %(full_date)s%(endnotes)s."
+msgstr "Gifte sig med %(spouse)s %(full_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1036
 #, python-format
 msgid "Married %(spouse)s %(modified_date)s%(endnotes)s."
-msgstr "Gift %(spouse)s %(modified_date)s%(endnotes)s."
+msgstr "Gifte sig med %(spouse)s %(modified_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1042
 #, python-format
@@ -27986,7 +27793,7 @@ msgstr "Hon gifte sig med %(spouse)s i %(place)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:1067
 #, python-format
 msgid "Married %(spouse)s in %(place)s%(endnotes)s."
-msgstr "Gift %(spouse)s i %(place)s%(endnotes)s."
+msgstr "Gifte sig med %(spouse)s i %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1071
 #, python-format
@@ -28026,7 +27833,7 @@ msgstr "Hon gifte sig med %(spouse)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:1081
 #, python-format
 msgid "Married %(spouse)s%(endnotes)s."
-msgstr "Gift %(spouse)s%(endnotes)s."
+msgstr "Gifte sig med %(spouse)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1085
 #, python-format
@@ -28054,7 +27861,7 @@ msgid ""
 "This person had an unmarried relationship with %(spouse)s in "
 "%(partial_date)s in %(place)s%(endnotes)s."
 msgstr ""
-"Denna person hade ett ogift förhållande med %(spouse)s i %(partial_date)s i "
+"Personen hade ett ogift förhållande med %(spouse)s %(partial_date)s i "
 "%(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1099
@@ -28063,8 +27870,8 @@ msgid ""
 "This person had an unmarried relationship with %(spouse)s on %(full_date)s "
 "in %(place)s%(endnotes)s."
 msgstr ""
-"Denna person hade ett ogift förhållande med %(spouse)s  %(full_date)s i "
-"%(place)s%(endnotes)s."
+"Personen hade ett ogift förhållande med %(spouse)s %(full_date)s i %(place)s"
+"%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1100
 #, python-format
@@ -28072,7 +27879,7 @@ msgid ""
 "This person had an unmarried relationship with %(spouse)s %(modified_date)s "
 "in %(place)s%(endnotes)s."
 msgstr ""
-"Denna person hade ett ogift förhållande med %(spouse)s %(modified_date)s i "
+"Personen hade ett ogift förhållande med %(spouse)s %(modified_date)s i "
 "%(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1103
@@ -28081,7 +27888,7 @@ msgid ""
 "He had an unmarried relationship with %(spouse)s in %(partial_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"Han hade ett ogift förhållande med %(spouse)s i %(partial_date)s i %(place)s"
+"Han hade ett ogift förhållande med %(spouse)s %(partial_date)s i %(place)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1104
@@ -28099,7 +27906,7 @@ msgid ""
 "He had an unmarried relationship with %(spouse)s %(modified_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"Han hade ett ogift förhållande med  %(spouse)s %(modified_date)s i %(place)s"
+"Han hade ett ogift förhållande med %(spouse)s %(modified_date)s i %(place)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1108
@@ -28108,7 +27915,7 @@ msgid ""
 "She had an unmarried relationship with %(spouse)s in %(partial_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"Hon hade ett ogift förhållande med %(spouse)s i %(partial_date)s i %(place)s"
+"Hon hade ett ogift förhållande med %(spouse)s %(partial_date)s i %(place)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1109
@@ -28162,7 +27969,7 @@ msgid ""
 "This person also had an unmarried relationship with %(spouse)s in "
 "%(partial_date)s in %(place)s%(endnotes)s."
 msgstr ""
-"Denna person hade ett ogift förhållande med %(spouse)s i %(partial_date)s i "
+"Personen hade även ett ogift förhållande med %(spouse)s %(partial_date)s i "
 "%(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1122
@@ -28171,7 +27978,7 @@ msgid ""
 "This person also had an unmarried relationship with %(spouse)s on "
 "%(full_date)s in %(place)s%(endnotes)s."
 msgstr ""
-"Denna person hade ett ogift förhållande med %(spouse)s %(full_date)s i "
+"Personen hade även ett ogift förhållande med %(spouse)s %(full_date)s i "
 "%(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1123
@@ -28180,7 +27987,7 @@ msgid ""
 "This person also had an unmarried relationship with %(spouse)s "
 "%(modified_date)s in %(place)s%(endnotes)s."
 msgstr ""
-"Denna person hade ett ogift förhållande med %(spouse)s %(modified_date)s i "
+"Personen hade även ett ogift förhållande med %(spouse)s %(modified_date)s i "
 "%(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1126
@@ -28189,7 +27996,7 @@ msgid ""
 "He also had an unmarried relationship with %(spouse)s in %(partial_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"Han hade också ett ogift förhållande med %(spouse)s i %(partial_date)s i "
+"Han hade även ett ogift förhållande med %(spouse)s %(partial_date)s i "
 "%(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1127
@@ -28198,7 +28005,7 @@ msgid ""
 "He also had an unmarried relationship with %(spouse)s on %(full_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"Han hade också ett ogift förhållande med %(spouse)s %(full_date)s i %(place)s"
+"Han hade även ett ogift förhållande med %(spouse)s %(full_date)s i %(place)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1128
@@ -28207,7 +28014,7 @@ msgid ""
 "He also had an unmarried relationship with %(spouse)s %(modified_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"Han hade också ett ogift förhållande med %(spouse)s %(modified_date)s i "
+"Han hade även ett ogift förhållande med %(spouse)s %(modified_date)s i "
 "%(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1131
@@ -28216,7 +28023,7 @@ msgid ""
 "She also had an unmarried relationship with %(spouse)s in %(partial_date)s "
 "in %(place)s%(endnotes)s."
 msgstr ""
-"Hon hade också ett ogift förhållande med %(spouse)s i %(partial_date)s i "
+"Hon hade även ett ogift förhållande med %(spouse)s %(partial_date)s i "
 "%(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1132
@@ -28225,7 +28032,7 @@ msgid ""
 "She also had an unmarried relationship with %(spouse)s on %(full_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"Hon hade också ett ogift förhållande med %(spouse)s %(full_date)s i %(place)s"
+"Hon hade även ett ogift förhållande med %(spouse)s %(full_date)s i %(place)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1133
@@ -28234,7 +28041,7 @@ msgid ""
 "She also had an unmarried relationship with %(spouse)s %(modified_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"Hon hade också ett ogift förhållande med %(spouse)s %(modified_date)s i "
+"Hon hade även ett ogift förhållande med %(spouse)s %(modified_date)s i "
 "%(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1144
@@ -28243,7 +28050,7 @@ msgid ""
 "This person had an unmarried relationship with %(spouse)s in %(partial_date)s"
 "%(endnotes)s."
 msgstr ""
-"Denna person hade ett ogift förhållande med %(spouse)s i %(partial_date)s"
+"Personen hade ett ogift förhållande med %(spouse)s %(partial_date)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1145
@@ -28252,8 +28059,7 @@ msgid ""
 "This person had an unmarried relationship with %(spouse)s on %(full_date)s"
 "%(endnotes)s."
 msgstr ""
-"Denna person hade ett ogift förhållande med %(spouse)s %(full_date)s"
-"%(endnotes)s."
+"Personen hade ett ogift förhållande med %(spouse)s %(full_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1146
 #, python-format
@@ -28261,7 +28067,7 @@ msgid ""
 "This person had an unmarried relationship with %(spouse)s %(modified_date)s"
 "%(endnotes)s."
 msgstr ""
-"Denna person hade ett ogift förhållande med %(spouse)s %(modified_date)s"
+"Personen hade ett ogift förhållande med %(spouse)s %(modified_date)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1149
@@ -28270,7 +28076,7 @@ msgid ""
 "He had an unmarried relationship with %(spouse)s in %(partial_date)s"
 "%(endnotes)s."
 msgstr ""
-"Han hade ett ogift förhållande med %(spouse)s i %(partial_date)s%(endnotes)s."
+"Han hade ett ogift förhållande med %(spouse)s %(partial_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1150
 #, python-format
@@ -28294,7 +28100,7 @@ msgid ""
 "She had an unmarried relationship with %(spouse)s in %(partial_date)s"
 "%(endnotes)s."
 msgstr ""
-"Hon hade ett ogift förhållande med %(spouse)s i %(partial_date)s%(endnotes)s."
+"Hon hade ett ogift förhållande med %(spouse)s %(partial_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1155
 #, python-format
@@ -28333,7 +28139,7 @@ msgid ""
 "This person also had an unmarried relationship with %(spouse)s in "
 "%(partial_date)s%(endnotes)s."
 msgstr ""
-"Denna person hade ett ogift förhållande med %(spouse)s i %(partial_date)s"
+"Personen hade ett ogift förhållande med %(spouse)s %(partial_date)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1168
@@ -28342,8 +28148,7 @@ msgid ""
 "This person also had an unmarried relationship with %(spouse)s on "
 "%(full_date)s%(endnotes)s."
 msgstr ""
-"Denna person hade ett ogift förhållande med %(spouse)s %(full_date)s"
-"%(endnotes)s."
+"Personen hade ett ogift förhållande med %(spouse)s %(full_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1169
 #, python-format
@@ -28351,7 +28156,7 @@ msgid ""
 "This person also had an unmarried relationship with %(spouse)s "
 "%(modified_date)s%(endnotes)s."
 msgstr ""
-"Denna person hade ett ogift förhållande med %(spouse)s %(modified_date)s"
+"Personen hade ett ogift förhållande med %(spouse)s %(modified_date)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1172
@@ -28360,7 +28165,7 @@ msgid ""
 "He also had an unmarried relationship with %(spouse)s in %(partial_date)s"
 "%(endnotes)s."
 msgstr ""
-"Han hade också ett ogift förhållande med %(spouse)s i %(partial_date)s"
+"Han hade även ett ogift förhållande med %(spouse)s %(partial_date)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1173
@@ -28369,8 +28174,7 @@ msgid ""
 "He also had an unmarried relationship with %(spouse)s on %(full_date)s"
 "%(endnotes)s."
 msgstr ""
-"Han hade också ett ogift förhållande med %(spouse)s %(full_date)s"
-"%(endnotes)s."
+"Han hade även ett ogift förhållande med %(spouse)s %(full_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1174
 #, python-format
@@ -28378,7 +28182,7 @@ msgid ""
 "He also had an unmarried relationship with %(spouse)s %(modified_date)s"
 "%(endnotes)s."
 msgstr ""
-"Han hade också ett ogift förhållande med %(spouse)s %(modified_date)s"
+"Han hade även ett ogift förhållande med %(spouse)s %(modified_date)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1177
@@ -28387,7 +28191,7 @@ msgid ""
 "She also had an unmarried relationship with %(spouse)s in %(partial_date)s"
 "%(endnotes)s."
 msgstr ""
-"Hon hade också ett ogift förhållande med %(spouse)s i %(partial_date)s"
+"Hon hade även ett ogift förhållande med %(spouse)s %(partial_date)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1178
@@ -28396,8 +28200,7 @@ msgid ""
 "She also had an unmarried relationship with %(spouse)s on %(full_date)s"
 "%(endnotes)s."
 msgstr ""
-"Hon hade också ett ogift förhållande med %(spouse)s %(full_date)s"
-"%(endnotes)s."
+"Hon hade även ett ogift förhållande med %(spouse)s %(full_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1179
 #, python-format
@@ -28405,7 +28208,7 @@ msgid ""
 "She also had an unmarried relationship with %(spouse)s %(modified_date)s"
 "%(endnotes)s."
 msgstr ""
-"Hon hade också ett ogift förhållande med %(spouse)s %(modified_date)s"
+"Hon hade även ett ogift förhållande med %(spouse)s %(modified_date)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1182
@@ -28433,8 +28236,7 @@ msgid ""
 "This person had an unmarried relationship with %(spouse)s in %(place)s"
 "%(endnotes)s."
 msgstr ""
-"Denna person hade ett ogift förhållande med %(spouse)s i %(place)s"
-"%(endnotes)s."
+"Personen hade ett ogift förhållande med %(spouse)s i %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1190
 #, python-format
@@ -28452,7 +28254,7 @@ msgstr "Hon hade ett ogift förhållande med %(spouse)s i %(place)s%(endnotes)s.
 #: ../gramps/plugins/lib/libnarrate.py:1199
 #, python-format
 msgid "Unmarried relationship with %(spouse)s in %(place)s%(endnotes)s."
-msgstr "Även ett ogift förhållande med %(spouse)s i %(place)s%(endnotes)s."
+msgstr "Ogift förhållande med %(spouse)s i %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1196
 #, python-format
@@ -28460,7 +28262,7 @@ msgid ""
 "This person also had an unmarried relationship with %(spouse)s in %(place)s"
 "%(endnotes)s."
 msgstr ""
-"Denna person hade ett ogift förhållande med %(spouse)s i %(place)s"
+"Personen hade även ett ogift förhållande med %(spouse)s i %(place)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1197
@@ -28469,7 +28271,7 @@ msgid ""
 "He also had an unmarried relationship with %(spouse)s in %(place)s"
 "%(endnotes)s."
 msgstr ""
-"Han hade också ett ogift förhållande med %(spouse)s i %(place)s%(endnotes)s."
+"Han hade även ett ogift förhållande med %(spouse)s i %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1198
 #, python-format
@@ -28477,12 +28279,12 @@ msgid ""
 "She also had an unmarried relationship with %(spouse)s in %(place)s"
 "%(endnotes)s."
 msgstr ""
-"Hon hade också ett ogift förhållande med %(spouse)s i %(place)s%(endnotes)s."
+"Hon hade även ett ogift förhållande med %(spouse)s i %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1203
 #, python-format
 msgid "This person had an unmarried relationship with %(spouse)s%(endnotes)s."
-msgstr "Denna person hade ett ogift förhållande med %(spouse)s%(endnotes)s."
+msgstr "Personen hade ett ogift förhållande med %(spouse)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1204
 #, python-format
@@ -28504,17 +28306,17 @@ msgstr "Ogift förhållande med %(spouse)s%(endnotes)s."
 #, python-format
 msgid ""
 "This person also had an unmarried relationship with %(spouse)s%(endnotes)s."
-msgstr "Denna person hade ett ogift förhållande med %(spouse)s%(endnotes)s."
+msgstr "Personen hade även ett ogift förhållande med %(spouse)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1211
 #, python-format
 msgid "He also had an unmarried relationship with %(spouse)s%(endnotes)s."
-msgstr "Han hade ett ogift förhållande med %(spouse)s%(endnotes)s."
+msgstr "Han hade även ett ogift förhållande med %(spouse)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1212
 #, python-format
 msgid "She also had an unmarried relationship with %(spouse)s%(endnotes)s."
-msgstr "Hon hade ett ogift förhållande med %(spouse)s%(endnotes)s."
+msgstr "Hon hade även ett ogift förhållande med %(spouse)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1224
 #, python-format
@@ -28522,8 +28324,8 @@ msgid ""
 "This person had a relationship with %(spouse)s in %(partial_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"Denna person hade ett ogift förhållande med %(spouse)s i %(partial_date)s i "
-"%(place)s%(endnotes)s."
+"Personen hade ett förhållande med %(spouse)s %(partial_date)s i %(place)s"
+"%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1225
 #, python-format
@@ -28531,8 +28333,8 @@ msgid ""
 "This person had a relationship with %(spouse)s on %(full_date)s in %(place)s"
 "%(endnotes)s."
 msgstr ""
-"Denna person hade ett ogift förhållande med %(spouse)s %(full_date)s i "
-"%(place)s%(endnotes)s."
+"Personen hade ett förhållande med %(spouse)s %(full_date)s i %(place)s"
+"%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1226
 #, python-format
@@ -28540,8 +28342,8 @@ msgid ""
 "This person had a relationship with %(spouse)s %(modified_date)s in %(place)s"
 "%(endnotes)s."
 msgstr ""
-"Denna person hade ett ogift förhållande med %(spouse)s %(modified_date)s in"
-"%(place)s%(endnotes)s."
+"Personen hade ett förhållande med %(spouse)s %(modified_date)s i %(place)s"
+"%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1229
 #, python-format
@@ -28549,7 +28351,7 @@ msgid ""
 "He had a relationship with %(spouse)s in %(partial_date)s in %(place)s"
 "%(endnotes)s."
 msgstr ""
-"Han hade ett förhållande med %(spouse)s under %(partial_date)s i %(place)s"
+"Han hade ett förhållande med %(spouse)s %(partial_date)s i %(place)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1230
@@ -28576,7 +28378,7 @@ msgid ""
 "She had a relationship with %(spouse)s in %(partial_date)s in %(place)s"
 "%(endnotes)s."
 msgstr ""
-"Hon hade ett förhållande med %(spouse)s i %(partial_date)s i %(place)s"
+"Hon hade ett förhållande med %(spouse)s %(partial_date)s i %(place)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1235
@@ -28619,7 +28421,7 @@ msgid ""
 "This person also had a relationship with %(spouse)s in %(partial_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"Denna person hade ett förhållande med %(spouse)s i %(partial_date)s i "
+"Personen hade även ett förhållande med %(spouse)s %(partial_date)s i "
 "%(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1248
@@ -28628,7 +28430,7 @@ msgid ""
 "This person also had a relationship with %(spouse)s on %(full_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"Denna person hade ett förhållande med %(spouse)s %(full_date)s i %(place)s"
+"Personen hade även ett förhållande med %(spouse)s %(full_date)s i %(place)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1249
@@ -28637,7 +28439,7 @@ msgid ""
 "This person also had a relationship with %(spouse)s %(modified_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"Denna person hade ett förhållande med %(spouse)s %(modified_date)s i "
+"Personen hade även ett förhållande med %(spouse)s %(modified_date)s i "
 "%(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1252
@@ -28646,7 +28448,7 @@ msgid ""
 "He also had a relationship with %(spouse)s in %(partial_date)s in %(place)s"
 "%(endnotes)s."
 msgstr ""
-"Han hade också ett förhållande med %(spouse)s i %(partial_date)s i %(place)s"
+"Han hade även ett förhållande med %(spouse)s %(partial_date)s i %(place)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1253
@@ -28655,7 +28457,7 @@ msgid ""
 "He also had a relationship with %(spouse)s on %(full_date)s in %(place)s"
 "%(endnotes)s."
 msgstr ""
-"Han hade också ett förhållande med %(spouse)s %(full_date)s i %(place)s"
+"Han hade även ett förhållande med %(spouse)s %(full_date)s i %(place)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1254
@@ -28664,7 +28466,7 @@ msgid ""
 "He also had a relationship with %(spouse)s %(modified_date)s in %(place)s"
 "%(endnotes)s."
 msgstr ""
-"Han hade också ett förhållande med %(spouse)s %(modified_date)s i %(place)s"
+"Han hade även ett förhållande med %(spouse)s %(modified_date)s i %(place)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1257
@@ -28673,7 +28475,7 @@ msgid ""
 "She also had a relationship with %(spouse)s in %(partial_date)s in %(place)s"
 "%(endnotes)s."
 msgstr ""
-"Hon hade också ett förhållande med %(spouse)s %(partial_date)s i %(place)s"
+"Hon hade även ett förhållande med %(spouse)s %(partial_date)s i %(place)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1258
@@ -28682,7 +28484,7 @@ msgid ""
 "She also had a relationship with %(spouse)s on %(full_date)s in %(place)s"
 "%(endnotes)s."
 msgstr ""
-"Hon hade också ett förhållande med %(spouse)s %(full_date)s i %(place)s"
+"Hon hade även ett förhållande med %(spouse)s %(full_date)s i %(place)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1259
@@ -28691,7 +28493,7 @@ msgid ""
 "She also had a relationship with %(spouse)s %(modified_date)s in %(place)s"
 "%(endnotes)s."
 msgstr ""
-"Hon hade också ett förhållande med %(spouse)s %(modified_date)s i %(place)s"
+"Hon hade även ett förhållande med %(spouse)s %(modified_date)s i %(place)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1262
@@ -28722,29 +28524,26 @@ msgid ""
 "This person had a relationship with %(spouse)s in %(partial_date)s"
 "%(endnotes)s."
 msgstr ""
-"Denna person hade ett förhållande med %(spouse)s i %(partial_date)s"
-"%(endnotes)s."
+"Personen hade ett förhållande med %(spouse)s %(partial_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1271
 #, python-format
 msgid ""
 "This person had a relationship with %(spouse)s on %(full_date)s%(endnotes)s."
 msgstr ""
-"Denna person hade ett förhållande med %(spouse)s %(full_date)s%(endnotes)s."
+"Personen hade ett förhållande med %(spouse)s %(full_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1272
 #, python-format
 msgid ""
 "This person had a relationship with %(spouse)s %(modified_date)s%(endnotes)s."
 msgstr ""
-"Denna person hade ett förhållande med %(spouse)s %(modified_date)s"
-"%(endnotes)s."
+"Personen hade ett förhållande med %(spouse)s %(modified_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1275
 #, python-format
 msgid "He had a relationship with %(spouse)s in %(partial_date)s%(endnotes)s."
-msgstr ""
-"Han hade ett förhållande med %(spouse)s i %(partial_date)s%(endnotes)s."
+msgstr "Han hade ett förhållande med %(spouse)s %(partial_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1276
 #, python-format
@@ -28759,13 +28558,12 @@ msgstr "Han hade ett förhållande med %(spouse)s %(modified_date)s%(endnotes)s.
 #: ../gramps/plugins/lib/libnarrate.py:1280
 #, python-format
 msgid "She had a relationship with %(spouse)s in %(partial_date)s%(endnotes)s."
-msgstr ""
-"Hon hade ett förhållande med %(spouse)s i %(partial_date)s%(endnotes)s."
+msgstr "Hon hade ett förhållande med %(spouse)s %(partial_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1281
 #, python-format
 msgid "She had a relationship with %(spouse)s on %(full_date)s%(endnotes)s."
-msgstr "Hon hade ett förhållande med  %(spouse)s %(full_date)s%(endnotes)s."
+msgstr "Hon hade ett förhållande med %(spouse)s %(full_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1282
 #, python-format
@@ -28793,7 +28591,7 @@ msgid ""
 "This person also had a relationship with %(spouse)s in %(partial_date)s"
 "%(endnotes)s."
 msgstr ""
-"Denna person hade också ett förhållande med %(spouse)s i %(partial_date)s"
+"Personen hade även ett förhållande med %(spouse)s %(partial_date)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1294
@@ -28802,8 +28600,7 @@ msgid ""
 "This person also had a relationship with %(spouse)s on %(full_date)s"
 "%(endnotes)s."
 msgstr ""
-"Denna person hade också ett förhållande med %(spouse)s %(full_date)s"
-"%(endnotes)s."
+"Personen hade även ett förhållande med %(spouse)s %(full_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1295
 #, python-format
@@ -28811,7 +28608,7 @@ msgid ""
 "This person also had a relationship with %(spouse)s %(modified_date)s"
 "%(endnotes)s."
 msgstr ""
-"Denna person hade också ett förhållande med %(spouse)s %(modified_date)s"
+"Personen hade även ett förhållande med %(spouse)s %(modified_date)s"
 "%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1298
@@ -28819,42 +28616,42 @@ msgstr ""
 msgid ""
 "He also had a relationship with %(spouse)s in %(partial_date)s%(endnotes)s."
 msgstr ""
-"Han hade också ett förhållande med %(spouse)s i %(partial_date)s%(endnotes)s."
+"Han hade även ett förhållande med %(spouse)s %(partial_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1299
 #, python-format
 msgid ""
 "He also had a relationship with %(spouse)s on %(full_date)s%(endnotes)s."
 msgstr ""
-"Han hade också ett förhållande med %(spouse)s %(full_date)s%(endnotes)s."
+"Han hade även ett förhållande med %(spouse)s %(full_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1300
 #, python-format
 msgid ""
 "He also had a relationship with %(spouse)s %(modified_date)s%(endnotes)s."
 msgstr ""
-"Han hade också ett förhållande med %(spouse)s %(modified_date)s%(endnotes)s."
+"Han hade även ett förhållande med %(spouse)s %(modified_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1303
 #, python-format
 msgid ""
 "She also had a relationship with %(spouse)s in %(partial_date)s%(endnotes)s."
 msgstr ""
-"Hon hade också ett förhållande med %(spouse)s i %(partial_date)s%(endnotes)s."
+"Hon hade även ett förhållande med %(spouse)s %(partial_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1304
 #, python-format
 msgid ""
 "She also had a relationship with %(spouse)s on %(full_date)s%(endnotes)s."
 msgstr ""
-"Hon hade också ett förhållande med  %(spouse)s %(full_date)s%(endnotes)s."
+"Hon hade även ett förhållande med %(spouse)s %(full_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1305
 #, python-format
 msgid ""
 "She also had a relationship with %(spouse)s %(modified_date)s%(endnotes)s."
 msgstr ""
-"Hon hade också ett förhållande med %(spouse)s %(modified_date)s%(endnotes)s."
+"Hon hade även ett förhållande med %(spouse)s %(modified_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1308
 #, python-format
@@ -28875,8 +28672,7 @@ msgstr "Även ett förhållande med %(spouse)s %(modified_date)s%(endnotes)s."
 #, python-format
 msgid ""
 "This person had a relationship with %(spouse)s in %(place)s%(endnotes)s."
-msgstr ""
-"Denna person hade ett förhållande med %(spouse)s i %(place)s%(endnotes)s."
+msgstr "Personen hade ett förhållande med %(spouse)s i %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1316
 #, python-format
@@ -28898,18 +28694,17 @@ msgstr "Förhållande med %(spouse)s i %(place)s%(endnotes)s."
 msgid ""
 "This person also had a relationship with %(spouse)s in %(place)s%(endnotes)s."
 msgstr ""
-"Denna person hade också ett förhållande med %(spouse)s i %(place)s"
-"%(endnotes)s."
+"Personen hade även ett förhållande med %(spouse)s i %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1323
 #, python-format
 msgid "He also had a relationship with %(spouse)s in %(place)s%(endnotes)s."
-msgstr "Han hade också ett förhållande med %(spouse)s i %(place)s%(endnotes)s."
+msgstr "Han hade även ett förhållande med %(spouse)s i %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1324
 #, python-format
 msgid "She also had a relationship with %(spouse)s in %(place)s%(endnotes)s."
-msgstr "Hon hade också ett förhållande med %(spouse)s i %(place)s%(endnotes)s."
+msgstr "Hon hade även ett förhållande med %(spouse)s i %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1325
 #, python-format
@@ -28919,7 +28714,7 @@ msgstr "Även ett förhållande med %(spouse)s i %(place)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:1329
 #, python-format
 msgid "This person had a relationship with %(spouse)s%(endnotes)s."
-msgstr "Denna person hade ett förhållande med %(spouse)s%(endnotes)s."
+msgstr "Personen hade ett förhållande med %(spouse)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1330
 #, python-format
@@ -28939,17 +28734,17 @@ msgstr "Förhållande med %(spouse)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:1336
 #, python-format
 msgid "This person also had a relationship with %(spouse)s%(endnotes)s."
-msgstr "Denna person hade också ett förhållande med %(spouse)s%(endnotes)s."
+msgstr "Personen hade även ett förhållande med %(spouse)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1337
 #, python-format
 msgid "He also had a relationship with %(spouse)s%(endnotes)s."
-msgstr "Han hade också ett förhållande med  %(spouse)s%(endnotes)s."
+msgstr "Han hade även ett förhållande med %(spouse)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1338
 #, python-format
 msgid "She also had a relationship with %(spouse)s%(endnotes)s."
-msgstr "Hon hade också ett förhållande med %(spouse)s%(endnotes)s."
+msgstr "Hon hade även ett förhållande med %(spouse)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1339
 #, python-format
@@ -28985,13 +28780,12 @@ msgid "Edit the selected person"
 msgstr "Redigera den valda personen"
 
 #: ../gramps/plugins/lib/libpersonview.py:126
-#, fuzzy
 msgid "Delete the selected person"
-msgstr "Tag bort den valda platsen"
+msgstr "Ta bort den valda personen"
 
 #: ../gramps/plugins/lib/libpersonview.py:127
 msgid "Merge the selected persons"
-msgstr "Slå ihop del valda personerna"
+msgstr "Slå ihop de valda personerna"
 
 #: ../gramps/plugins/lib/libpersonview.py:303
 msgid "_Delete Person"
@@ -29032,7 +28826,7 @@ msgstr "Redigera den valda platsen"
 
 #: ../gramps/plugins/lib/libplaceview.py:104
 msgid "Delete the selected place"
-msgstr "Tag bort den valda platsen"
+msgstr "Ta bort den valda platsen"
 
 #: ../gramps/plugins/lib/libplaceview.py:105
 msgid "Merge the selected places"
@@ -29048,7 +28842,7 @@ msgid ""
 "Attempt to see selected locations with a Map Service (OpenstreetMap, Google "
 "Maps, ...)"
 msgstr ""
-"Försök att se platser med en karttjänst (OpenstreetMap, Google MAps, eniros "
+"Försök att se platser med en karttjänst (OpenstreetMap, Google Maps, eniros "
 "kartor, ...)"
 
 #: ../gramps/plugins/lib/libplaceview.py:147
@@ -29065,7 +28859,7 @@ msgid ""
 "Attempt to see this location with a Map Service (OpenstreetMap, Google "
 "Maps, ...)"
 msgstr ""
-"Försök att se denna plats med en karttjänst (OpenstreetMap, Google MAps, "
+"Försök att se denna plats med en karttjänst (OpenstreetMap, Google Maps, "
 "eniros kartor, ...)"
 
 #: ../gramps/plugins/lib/libplaceview.py:153
@@ -29101,8 +28895,8 @@ msgid ""
 "This place is currently referenced by another place. First remove the places "
 "it contains."
 msgstr ""
-"Denna plats är just nu refererad av en annan plats. Tag först bort de "
-"platser den innehåller."
+"Denna plats är just nu refererad av en annan plats. Ta först bort de platser "
+"den innehåller."
 
 #: ../gramps/plugins/lib/libplaceview.py:408
 #: ../gramps/plugins/lib/libplaceview.py:416
@@ -29115,23 +28909,23 @@ msgid ""
 "be selected by holding down the control key while clicking on the desired "
 "place."
 msgstr ""
-"Exakt två personer måste vara valda för att kunna slås ihop. En andra person "
+"Exakt två platser måste vara valda för att kunna slås ihop. En andra plats "
 "kan väljas genom att hålla ned ctrl-tangenten medan man klickar på den "
-"önskade personen."
+"önskade platsen."
 
 #: ../gramps/plugins/lib/libplaceview.py:417
 msgid "Merging these places would create a cycle in the place hierarchy."
-msgstr "Att slå ihop dessa platser skulle skapa en en slinga i platsstrukturen"
+msgstr ""
+"Att slå ihop dessa platser skulle skapa en en slinga i platsstrukturen."
 
 #: ../gramps/plugins/lib/libplugins.gpr.py:35
 msgid "Provides a library for using Cairo to generate documents."
 msgstr ""
-"Tillhandahåller ett bibliotek genom att använda Cairo till att skapa "
-"dokument."
+"Tillhandahåller ett bibliotek genom att använda Cairo för att skapa dokument."
 
 #: ../gramps/plugins/lib/libplugins.gpr.py:54
 msgid "Provides GEDCOM processing functionality"
-msgstr "Tillhandahåller bearbetning av GEDCOM"
+msgstr "Tillhandahåller funktioner för bearbetning av GEDCOM"
 
 #: ../gramps/plugins/lib/libplugins.gpr.py:71
 msgid "Provides recursive routines for reports"
@@ -29147,7 +28941,7 @@ msgstr "Tillhandahåller information om helgdagar för olika länder."
 
 #: ../gramps/plugins/lib/libplugins.gpr.py:124
 msgid "Manages a HTML file implementing DocBackend."
-msgstr "Hanterar an HTML-fil genom DocBackend."
+msgstr "Hanterar en HTML-fil genom DocBackend."
 
 #: ../gramps/plugins/lib/libplugins.gpr.py:142
 msgid "Common constants for html files."
@@ -29155,7 +28949,7 @@ msgstr "Gemensamma konstanter för html-filer."
 
 #: ../gramps/plugins/lib/libplugins.gpr.py:160
 msgid "Manages an HTML DOM tree."
-msgstr "Hanterar att HTML-DOM-träd."
+msgstr "Hanterar ett HTML-DOM-träd."
 
 #: ../gramps/plugins/lib/libplugins.gpr.py:178
 msgid "Provides base functionality for map services."
@@ -29237,24 +29031,20 @@ msgid "Oldest mother"
 msgstr "Äldsta mor"
 
 #: ../gramps/plugins/lib/librecords.py:67
-#, fuzzy
 msgid "Father with most children"
-msgstr "Par med flest barn"
+msgstr "Far med flest barn"
 
 #: ../gramps/plugins/lib/librecords.py:68
-#, fuzzy
 msgid "Mother with most children"
-msgstr "Par med flest barn"
+msgstr "Mor med flest barn"
 
 #: ../gramps/plugins/lib/librecords.py:69
-#, fuzzy
 msgid "Father with most grandchildren"
-msgstr "Par med flest barn"
+msgstr "Far med flest barnbarn"
 
 #: ../gramps/plugins/lib/librecords.py:70
-#, fuzzy
 msgid "Mother with most grandchildren"
-msgstr "Par med flest barn"
+msgstr "Mor med flest barnbarn"
 
 #: ../gramps/plugins/lib/librecords.py:71
 msgid "Couple with most children"
@@ -29262,7 +29052,7 @@ msgstr "Par med flest barn"
 
 #: ../gramps/plugins/lib/librecords.py:72
 msgid "Living couple married most recently"
-msgstr "Senaste gifta levande par"
+msgstr "Senast gifta levande par"
 
 #: ../gramps/plugins/lib/librecords.py:73
 msgid "Living couple married most long ago"
@@ -29277,21 +29067,19 @@ msgid "Longest past marriage"
 msgstr "Längst varande giftermål"
 
 #: ../gramps/plugins/lib/librecords.py:76
-#, fuzzy
 msgid "Couple with smallest age difference"
-msgstr "Par med flest barn"
+msgstr "Par med minsta åldersskillnad"
 
 #: ../gramps/plugins/lib/librecords.py:77
-#, fuzzy
 msgid "Couple with biggest age difference"
-msgstr "Maximal åldersskillnad mellan syskon"
+msgstr "Par med största åldersskillnad"
 
 #. Add call name to first name.
 #. translators: used in French+Russian, ignore otherwise
 #: ../gramps/plugins/lib/librecords.py:517
-#, fuzzy, python-format
+#, python-format
 msgid "\"%(callname)s\" (%(firstname)s)"
-msgstr "%(name1)s och %(name2)s"
+msgstr "\"%(callname)s\" (%(firstname)s)"
 
 #: ../gramps/plugins/lib/libtreebase.py:756
 msgid "Top Left"
@@ -29314,7 +29102,7 @@ msgstr "Nederkant, höger"
 #: ../gramps/plugins/view/fanchartdescview.py:186
 #: ../gramps/plugins/view/fanchartview.py:182
 msgid "_Print..."
-msgstr "Skriv ut..."
+msgstr "_Skriv ut..."
 
 #: ../gramps/plugins/lib/maps/geography.py:311
 msgid "Print or save the Map"
@@ -29326,7 +29114,7 @@ msgstr "Kartmeny"
 
 #: ../gramps/plugins/lib/maps/geography.py:351
 msgid "Remove cross hair"
-msgstr "Tag bort hårkors"
+msgstr "Ta bort hårkors"
 
 #: ../gramps/plugins/lib/maps/geography.py:353
 msgid "Add cross hair"
@@ -29346,7 +29134,7 @@ msgstr "Lägg till plats"
 
 #: ../gramps/plugins/lib/maps/geography.py:374
 msgid "Link place"
-msgstr "Länka Plats"
+msgstr "Länka plats"
 
 #: ../gramps/plugins/lib/maps/geography.py:379
 msgid "Add place from kml"
@@ -29364,7 +29152,7 @@ msgstr "Ersätt '%(map)s' med =>"
 #: ../gramps/plugins/lib/maps/geography.py:416
 #, python-format
 msgid "Reload all visible tiles for '%(map)s'."
-msgstr ""
+msgstr "Ladda om alla synliga delrutor för '%(map)s'."
 
 #: ../gramps/plugins/lib/maps/geography.py:426
 #, python-format
@@ -29377,7 +29165,7 @@ msgstr "Du kan inte använda utskriftsfunktionen"
 
 #: ../gramps/plugins/lib/maps/geography.py:887
 msgid "Your Gtk version is too old."
-msgstr "Din version av Gtk är för gammal"
+msgstr "Din version av Gtk är för gammal."
 
 #: ../gramps/plugins/lib/maps/geography.py:928
 #: ../gramps/plugins/view/geoclose.py:552
@@ -29414,10 +29202,10 @@ msgid ""
 msgstr ""
 "Platsernas titel är :\n"
 "%(title)s\n"
-"Följande platser är liknande : %(gid)s\n"
+"Följande platser är liknande: %(gid)s\n"
 "Antingen döper du om platserna eller slår ihop dem.\n"
 "\n"
-"%(bold_start)sI kan ej fullfölja din begäran%(bold_end)s.\n"
+"%(bold_start)sJag kan ej fullfölja din begäran%(bold_end)s.\n"
 
 #: ../gramps/plugins/lib/maps/geography.py:1203
 msgid "Nothing for this view."
@@ -29425,11 +29213,11 @@ msgstr "Inget för denna vy."
 
 #: ../gramps/plugins/lib/maps/geography.py:1204
 msgid "Specific parameters"
-msgstr "Särskilda parametrar"
+msgstr "Specifika parametrar"
 
 #: ../gramps/plugins/lib/maps/geography.py:1222
 msgid "Where to save the tiles for offline mode."
-msgstr "Var spara delrutor i ej ansluten mod."
+msgstr "Var spara delrutor för offline-bruk."
 
 #: ../gramps/plugins/lib/maps/geography.py:1226
 msgid ""
@@ -29437,9 +29225,9 @@ msgid ""
 "placed in the above path.\n"
 "Be careful! If you have no internet, you'll get no map."
 msgstr ""
-"Om du inte har mer utrymme i ditt filsystem,\n"
-"så kan du ta bort alla alla delrutor placerade i ovan sökväg.\n"
-"Se upp! Om du inte har Internet, kommer du inte at få någon karta."
+"Om du inte har mer utrymme i ditt filsystem, så kan du ta bort alla delrutor "
+"placerade i ovan sökväg.\n"
+"Se upp! Om du inte har Internet, kommer du inte att få någon karta."
 
 #: ../gramps/plugins/lib/maps/geography.py:1231
 msgid "Zoom used when centering"
@@ -29455,9 +29243,9 @@ msgid ""
 "Either we choose the + and - from the keypad if we select this,\n"
 "or we use the characters from the keyboard."
 msgstr ""
-"Använd tangentbord till genvägar:\n"
-"Antingen väljer vi + och - från tangentbordet om vi väljer detta, eller så "
-"använder vi tecken från tangentbordet."
+"Använd knappsatsen för genvägar:\n"
+"Antingen väljer vi + och - från knappsatsen om vi väljer detta,\n"
+"eller så använder vi tecken från tangentbordet."
 
 #: ../gramps/plugins/lib/maps/geography.py:1245
 msgid "The map"
@@ -29465,18 +29253,18 @@ msgstr "Kartan"
 
 #: ../gramps/plugins/lib/maps/geography.py:1261
 msgid "Select tile cache directory for offline mode"
-msgstr "Välj buffertmapp för att arbeta utan internet."
+msgstr "Välj cache-katalog för delrutor vid arbete utan internet"
 
 #: ../gramps/plugins/lib/maps/osmgps.py:138
 #, python-format
 msgid "Can't create tiles cache directory %s"
-msgstr "Kunde inte mapp %s för delrutor"
+msgstr "Kan inte skapa cache-katalog %s för delrutor"
 
 #: ../gramps/plugins/lib/maps/osmgps.py:161
 #: ../gramps/plugins/lib/maps/osmgps.py:226
 #, python-format
 msgid "Can't create tiles cache directory for '%s'."
-msgstr "Kunde inte skapa mapp för delrutor för '%s"
+msgstr "Kan inte skapa cache-katalog för delrutor för '%s'."
 
 #: ../gramps/plugins/lib/maps/placeselection.py:110
 #: ../gramps/plugins/lib/maps/placeselection.py:112
@@ -29489,11 +29277,11 @@ msgid ""
 "On the map you should see a circle or an oval depending on the latitude."
 msgstr ""
 "Välj radie på valet.\n"
-"På kartan bör du nu se en cirkel eller oval, beroende på latitud."
+"På kartan bör du nu se en cirkel eller oval beroende på latitud."
 
 #: ../gramps/plugins/lib/maps/placeselection.py:151
 msgid "The green values in the row correspond to the current place values."
-msgstr "Det gröna värdet på en rad motsvarar den aktuella platsen värde."
+msgstr "De gröna värdena på en rad motsvarar den aktuella platsens värde."
 
 #. here, we could add value from geography names services ...
 #. if we found no place, we must create a default place.
@@ -29503,16 +29291,16 @@ msgstr "Ny plats med tomma fält"
 
 #: ../gramps/plugins/lib/maps/placeselection.py:273
 msgid "you have a wrong latitude for:"
-msgstr ""
+msgstr "du har en felaktig latitud för:"
 
 #: ../gramps/plugins/lib/maps/placeselection.py:275
 #: ../gramps/plugins/lib/maps/placeselection.py:285
 msgid "Please, correct this before linking"
-msgstr ""
+msgstr "Korrigera detta före länkning"
 
 #: ../gramps/plugins/lib/maps/placeselection.py:283
 msgid "you have a wrong longitude for:"
-msgstr ""
+msgstr "du har en felaktig longitud för:"
 
 #: ../gramps/plugins/mapservices/eniroswedenmap.py:53
 msgid "Denmark"
@@ -29530,11 +29318,11 @@ msgstr " län"
 
 #: ../gramps/plugins/mapservices/eniroswedenmap.py:150
 msgid "Latitude not within '54.55' to '69.05'\n"
-msgstr "Latitud ej inom '54.55' to '69.05'\n"
+msgstr "Latitud ej inom '54.55' till '69.05'\n"
 
 #: ../gramps/plugins/mapservices/eniroswedenmap.py:151
 msgid "Longitude not within '8.05' to '24.15'"
-msgstr "Longitud ej inom '8.05' to '24.15'"
+msgstr "Longitud ej inom '8.05' till '24.15'"
 
 #: ../gramps/plugins/mapservices/eniroswedenmap.py:152
 #: ../gramps/plugins/mapservices/eniroswedenmap.py:180
@@ -29556,11 +29344,11 @@ msgstr ""
 
 #: ../gramps/plugins/mapservices/mapservice.gpr.py:33
 msgid "EniroMaps"
-msgstr "Eniros karta"
+msgstr "Eniros kartor"
 
 #: ../gramps/plugins/mapservices/mapservice.gpr.py:34
 msgid "Opens on kartor.eniro.se"
-msgstr "Öppnar karta hos kartor.eniro.se"
+msgstr "Öppnar på kartor.eniro.se"
 
 #: ../gramps/plugins/mapservices/mapservice.gpr.py:52
 msgid "GoogleMaps"
@@ -29587,7 +29375,7 @@ msgstr "Personer och deras ålder den %s"
 #: ../gramps/plugins/quickview/ageondate.py:52
 #, python-format
 msgid "People and their ages on %s"
-msgstr "Personer och deras ålder av %s"
+msgstr "Personer och deras ålder på %s"
 
 #: ../gramps/plugins/quickview/ageondate.py:64
 #: ../gramps/plugins/quickview/ageondate.py:67
@@ -29642,9 +29430,8 @@ msgstr "Händelsetyp"
 #: ../gramps/plugins/quickview/attributematch.py:50
 #: ../gramps/plugins/quickview/reporef.py:83
 #: ../gramps/plugins/quickview/siblings.py:72
-#, fuzzy
 msgid "Not found"
-msgstr "Inga föräldrar hittades"
+msgstr "Inte funnen"
 
 #. display the results
 #: ../gramps/plugins/quickview/all_events.py:103
@@ -29703,12 +29490,12 @@ msgstr "Detaljerad väg från %(person)s till gemensam förfader"
 
 #: ../gramps/plugins/quickview/all_relations.py:269
 msgid "Name Common ancestor"
-msgstr "Namn på gemensam förfader"
+msgstr "Ange gemensam förfader"
 
 #: ../gramps/plugins/quickview/all_relations.py:270
 #: ../gramps/plugins/tool/findloop.py:114
 msgid "Parent"
-msgstr "Föräldrar"
+msgstr "Förälder"
 
 #: ../gramps/plugins/quickview/all_relations.py:286
 #: ../gramps/plugins/view/relview.py:406
@@ -29721,15 +29508,15 @@ msgstr "Partner"
 
 #: ../gramps/plugins/quickview/all_relations.py:313
 msgid "Partial"
-msgstr "Fäderne"
+msgstr "Delvis"
 
 #: ../gramps/plugins/quickview/all_relations.py:333
 msgid "Remarks with inlaw family"
-msgstr "Kommentar för ingift släkt"
+msgstr "Kommentarer för ingift släkt"
 
 #: ../gramps/plugins/quickview/all_relations.py:335
 msgid "Remarks"
-msgstr "Anmärkning"
+msgstr "Anmärkningar"
 
 #: ../gramps/plugins/quickview/all_relations.py:337
 msgid "The following problems were encountered:"
@@ -29738,12 +29525,12 @@ msgstr "Följande problem uppstod:"
 #: ../gramps/plugins/quickview/attributematch.py:32
 #, python-format
 msgid "People who have the '%s' Attribute"
-msgstr "Personer som har attributet '%s'"
+msgstr "Personer som har '%s' attributet"
 
 #: ../gramps/plugins/quickview/attributematch.py:46
 #, python-format
 msgid "There are %d people with a matching attribute name.\n"
-msgstr "Det finns %d människor med ett passande attributnamn.\n"
+msgstr "Det finns %d personer med ett matchande attributnamn.\n"
 
 #. else "nearby" comments are ignored
 #: ../gramps/plugins/quickview/filterbyname.py:41
@@ -29775,9 +29562,8 @@ msgid "Filtering_on|Inverse Repository"
 msgstr "ej utvald(a) arkivplats(er)"
 
 #: ../gramps/plugins/quickview/filterbyname.py:48
-#, fuzzy
 msgid "Filtering_on|Inverse Media"
-msgstr "ej utvald(a) mediaobjekt"
+msgstr "ej utvalt/utvalda mediaobjekt"
 
 #: ../gramps/plugins/quickview/filterbyname.py:49
 msgid "Filtering_on|Inverse Note"
@@ -29829,7 +29615,7 @@ msgstr "personer med okänt kön"
 
 #: ../gramps/plugins/quickview/filterbyname.py:63
 msgid "Filtering_on|incomplete names"
-msgstr "ej komplette namn"
+msgstr "ej kompletta namn"
 
 #: ../gramps/plugins/quickview/filterbyname.py:65
 msgid "Filtering_on|people with missing birth dates"
@@ -29837,7 +29623,7 @@ msgstr "personer utan känt födelsedatum"
 
 #: ../gramps/plugins/quickview/filterbyname.py:66
 msgid "Filtering_on|disconnected people"
-msgstr "isolerade personer"
+msgstr "släktlösa personer"
 
 #: ../gramps/plugins/quickview/filterbyname.py:67
 msgid "Filtering_on|unique surnames"
@@ -29849,7 +29635,7 @@ msgstr "personer med bilder/media"
 
 #: ../gramps/plugins/quickview/filterbyname.py:69
 msgid "Filtering_on|media references"
-msgstr "mediareferens"
+msgstr "mediareferenser"
 
 #: ../gramps/plugins/quickview/filterbyname.py:70
 msgid "Filtering_on|unique media"
@@ -29971,23 +29757,24 @@ msgstr "Storlek i byte"
 #, python-brace-format
 msgid "Filter matched {number_of} record."
 msgid_plural "Filter matched {number_of} records."
-msgstr[0] "Filter matchande {number_of} post."
-msgstr[1] "Filter matchande {number_of} poster."
+msgstr[0] "Filter matchande  {number_of} post."
+msgstr[1] "Filter matchande  {number_of} poster."
 
 #. display the results
 #. feature request 2356: avoid genitive form
 #: ../gramps/plugins/quickview/lineage.py:52
 #, python-format
 msgid "Father lineage for %s"
-msgstr "Fadersätt för %s"
+msgstr "Faders släktlinje för %s"
 
 #: ../gramps/plugins/quickview/lineage.py:54
 msgid ""
 "This report shows the father lineage, also called patronymic lineage or Y-"
 "line. People in this lineage all share the same Y-chromosome."
 msgstr ""
-"Denna rapport visar fadersätten, även kallad patronymikonätt eller Y-linje. "
-"Människor i denna ätt delar alla samma Y-kromosom."
+"Denna rapport visar släktlinjen för fader, även kallad den patronymiska "
+"härkomsten eller Y-linjen. Personer i denna släktlinje delar alla samma Y-"
+"kromosom."
 
 #: ../gramps/plugins/quickview/lineage.py:61
 msgid "Name Father"
@@ -30008,15 +29795,16 @@ msgstr "Direkta manliga ättlingar"
 #: ../gramps/plugins/quickview/lineage.py:83
 #, python-format
 msgid "Mother lineage for %s"
-msgstr "Modersätt för %s"
+msgstr "Moders släktlinje för %s"
 
 #: ../gramps/plugins/quickview/lineage.py:85
 msgid ""
 "This report shows the mother lineage, also called matronymic lineage mtDNA "
 "lineage. People in this lineage all share the same Mitochondrial DNA (mtDNA)."
 msgstr ""
-"Denna rapport visar modersätten, även kallad matronymikonätt eller mtDNA-"
-"linje. Människor i denna ätt delar alla samma mitokondrie-DNA (mtDNA)."
+"Denna rapport visar släktlinjen för moder, även kallad den matronymiska "
+"härkomsten eller mtDNA-linjen. Personer i denna släktlinje delar alla samma "
+"mitokondrie-DNA (mtDNA)."
 
 #: ../gramps/plugins/quickview/lineage.py:93
 msgid "Name Mother"
@@ -30076,7 +29864,7 @@ msgstr "Händelser %(date)s"
 
 #: ../gramps/plugins/quickview/onthisday.py:115
 msgid "Events on this exact date"
-msgstr "Händelser på exakt detta datum"
+msgstr "Händelser på denna dag"
 
 #: ../gramps/plugins/quickview/onthisday.py:118
 msgid "No events on this exact date"
@@ -30110,7 +29898,7 @@ msgstr "Attributmatchning"
 
 #: ../gramps/plugins/quickview/quickview.gpr.py:56
 msgid "Display people with same attribute."
-msgstr "Visa personer med lika attribut."
+msgstr "Visa personer med samma attribut."
 
 #: ../gramps/plugins/quickview/quickview.gpr.py:75
 msgid "All Events"
@@ -30142,19 +29930,19 @@ msgstr "Visa filtrerade data"
 
 #: ../gramps/plugins/quickview/quickview.gpr.py:150
 msgid "Father lineage"
-msgstr "Faderns ätt"
+msgstr "Faders släktlinje"
 
 #: ../gramps/plugins/quickview/quickview.gpr.py:151
 msgid "Display father lineage"
-msgstr "Visa fadersätten"
+msgstr "Visa faders släktlinje"
 
 #: ../gramps/plugins/quickview/quickview.gpr.py:164
 msgid "Mother lineage"
-msgstr "Moderns ätt"
+msgstr "Moders släktlinje"
 
 #: ../gramps/plugins/quickview/quickview.gpr.py:165
 msgid "Display mother lineage"
-msgstr "Visa modersätt"
+msgstr "Visa moders släktlinje"
 
 #: ../gramps/plugins/quickview/quickview.gpr.py:184
 msgid "On This Day"
@@ -30172,7 +29960,7 @@ msgstr "Källa eller citering"
 #: ../gramps/plugins/quickview/quickview.gpr.py:217
 #, python-format
 msgid "%s References"
-msgstr "%sreferenser"
+msgstr "%s referenser"
 
 #: ../gramps/plugins/quickview/quickview.gpr.py:218
 #, python-format
@@ -30203,16 +29991,16 @@ msgstr "Visa personer med samma efternamn som en person."
 
 #: ../gramps/plugins/quickview/quickview.gpr.py:286
 msgid "Same Given Names"
-msgstr "Lika förnamn"
+msgstr "Samma förnamn"
 
 #: ../gramps/plugins/quickview/quickview.gpr.py:287
 #: ../gramps/plugins/quickview/quickview.gpr.py:301
 msgid "Display people with the same given name as a person."
-msgstr "Visa personer med lika förnamn som en person."
+msgstr "Visa personer med samma förnamn som en person."
 
 #: ../gramps/plugins/quickview/quickview.gpr.py:300
 msgid "Same Given Names - stand-alone"
-msgstr "Lika förnamn - fristående"
+msgstr "Samma förnamn - fristående"
 
 #: ../gramps/plugins/quickview/quickview.gpr.py:320
 msgid "Display a person's siblings."
@@ -30222,7 +30010,7 @@ msgstr "Visa en persons syskon."
 #: ../gramps/plugins/quickview/references.py:68
 #, python-format
 msgid "References for this %s"
-msgstr "Referenser till denna %s"
+msgstr "Referenser för denna %s"
 
 #: ../gramps/plugins/quickview/references.py:80
 #, python-format
@@ -30252,7 +30040,7 @@ msgstr "Personer som matchar <efternamn>"
 
 #: ../gramps/plugins/quickview/samesurnames.py:52
 msgid "Matches people with same lastname"
-msgstr "Matchar personer samma efternamn"
+msgstr "Matchar personer med samma efternamn"
 
 #: ../gramps/plugins/quickview/samesurnames.py:64
 msgid "People matching the <given>"
@@ -30260,7 +30048,7 @@ msgstr "Personer matchande <förnamn>"
 
 #: ../gramps/plugins/quickview/samesurnames.py:65
 msgid "Matches people with same given name"
-msgstr "Matchar personer lika förnamn"
+msgstr "Matchar personer med samma förnamn"
 
 #: ../gramps/plugins/quickview/samesurnames.py:88
 msgid "People with incomplete given names"
@@ -30274,7 +30062,7 @@ msgstr "Matchar personer utan förnamn"
 #: ../gramps/plugins/quickview/samesurnames.py:113
 #, python-format
 msgid "People sharing the surname '%s'"
-msgstr "Personer, som delar på efternamnet '%s'"
+msgstr "Personer som delar på efternamnet '%s'"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/quickview/samesurnames.py:135
@@ -30420,11 +30208,11 @@ msgstr "Klicka för att välja en vy"
 
 #: ../gramps/plugins/sidebar/sidebar.gpr.py:33
 msgid "Category Sidebar"
-msgstr "Kategori sidopanel"
+msgstr "Kategori-sidopanel"
 
 #: ../gramps/plugins/sidebar/sidebar.gpr.py:34
 msgid "A sidebar to allow the selection of view categories"
-msgstr "En sidopanel, som tillåter att välja vykategorier"
+msgstr "En sidopanel som tillåter att välja vykategorier"
 
 #: ../gramps/plugins/sidebar/sidebar.gpr.py:42
 msgid "Category"
@@ -30448,7 +30236,7 @@ msgstr "Expandersidopanel"
 
 #: ../gramps/plugins/sidebar/sidebar.gpr.py:64
 msgid "Selection of views from lists with expanders"
-msgstr "Val av vyer från lista med expandering"
+msgstr "Val av vyer från listor med expandering"
 
 #: ../gramps/plugins/sidebar/sidebar.gpr.py:72
 msgid "Expander"
@@ -30457,7 +30245,7 @@ msgstr "Expander"
 #: ../gramps/plugins/textreport/alphabeticalindex.py:65
 #: ../gramps/plugins/textreport/textplugins.gpr.py:393
 msgid "Alphabetical Index"
-msgstr "Alfabetisk index"
+msgstr "Alfabetiskt index"
 
 #: ../gramps/plugins/textreport/alphabeticalindex.py:69
 msgid "Index"
@@ -30465,15 +30253,14 @@ msgstr "Index"
 
 #: ../gramps/plugins/textreport/alphabeticalindex.py:89
 #: ../gramps/plugins/textreport/tableofcontents.py:88
-#, fuzzy
 msgid "Entire Book"
-msgstr "Ny bok"
+msgstr "Hel bok"
 
 #. feature request 2356: avoid genitive form
 #: ../gramps/plugins/textreport/ancestorreport.py:197
 #, python-format
 msgid "Ahnentafel Report for %s"
-msgstr "Antavla för %s"
+msgstr "Ahnentafel-rapport för %s"
 
 #: ../gramps/plugins/textreport/ancestorreport.py:301
 #: ../gramps/plugins/textreport/detancestralreport.py:838
@@ -30492,9 +30279,8 @@ msgid "Add linebreak after each name"
 msgstr "Lägg till radbrytning efter varje namn"
 
 #: ../gramps/plugins/textreport/ancestorreport.py:307
-#, fuzzy
 msgid "Whether a line break should follow the name."
-msgstr "Visar om ny rad borde komma efter namnet."
+msgstr "Huruvida en radbrytning ska komma efter namnet."
 
 #: ../gramps/plugins/textreport/birthdayreport.py:65
 #: ../gramps/plugins/textreport/birthdayreport.py:217
@@ -30516,15 +30302,15 @@ msgstr "Visade släktskap är till %s"
 #: ../gramps/plugins/textreport/birthdayreport.py:320
 #, python-format
 msgid "%(person)s, birth%(relation)s"
-msgstr "%(person)s, birth%(relation)s"
+msgstr "%(person)s, födelse%(relation)s"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/textreport/birthdayreport.py:325
 #, python-brace-format
 msgid "{person}, {age}{relation}"
 msgid_plural "{person}, {age}{relation}"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "{person}, {age}{relation}"
+msgstr[1] "{person}, {age}{relation}"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:413
 #: ../gramps/plugins/textreport/familygroup.py:716
@@ -30559,13 +30345,12 @@ msgstr "Ta bara med nu levande personer i rapporten"
 #: ../gramps/plugins/textreport/birthdayreport.py:455
 #: ../gramps/plugins/textreport/birthdayreport.py:457
 msgid "Year of report"
-msgstr "År för rapporter"
+msgstr "År för rapporten"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:496
 #: ../gramps/plugins/textreport/indivcomplete.py:1146
-#, fuzzy
 msgid "Whether to include relationships to the center person"
-msgstr "Ta med släktskap till centralperson"
+msgstr "Huruvida ta med släktskap till centralpersonen"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:565
 msgid "Title text style"
@@ -30597,9 +30382,8 @@ msgstr "Inledande text"
 
 #: ../gramps/plugins/textreport/custombooktext.py:135
 #: ../gramps/plugins/textreport/custombooktext.py:164
-#, fuzzy
 msgid "Text to display at the top"
-msgstr "Text, som skall visas upptill."
+msgstr "Text som skall visas upptill"
 
 #: ../gramps/plugins/textreport/custombooktext.py:138
 msgid "Middle Text"
@@ -30608,7 +30392,7 @@ msgstr "Mittentext"
 #: ../gramps/plugins/textreport/custombooktext.py:139
 #: ../gramps/plugins/textreport/custombooktext.py:173
 msgid "Text to display in the middle"
-msgstr "Text, som skall visas i mitten"
+msgstr "Text som skall visas i mitten"
 
 #: ../gramps/plugins/textreport/custombooktext.py:142
 msgid "Final Text"
@@ -30616,9 +30400,8 @@ msgstr "Avslutande text"
 
 #: ../gramps/plugins/textreport/custombooktext.py:143
 #: ../gramps/plugins/textreport/custombooktext.py:182
-#, fuzzy
 msgid "Text to display at the bottom"
-msgstr "Text, som skall visas upptill."
+msgstr "Text som skall visas nedtill"
 
 #: ../gramps/plugins/textreport/descendreport.py:314
 #: ../gramps/plugins/textreport/descendreport.py:322
@@ -30627,14 +30410,14 @@ msgid "sp. %(spouse)s"
 msgstr "m. %(spouse)s"
 
 #: ../gramps/plugins/textreport/descendreport.py:333
-#, fuzzy, python-format
+#, python-format
 msgid "sp. see %(reference)s: %(spouse)s"
-msgstr "sp. se  %(reference)s : %(spouse)s"
+msgstr "m. se  %(reference)s : %(spouse)s"
 
 #: ../gramps/plugins/textreport/descendreport.py:393
 #, python-format
 msgid "%s sp."
-msgstr "%s sp."
+msgstr "%s m."
 
 #: ../gramps/plugins/textreport/descendreport.py:526
 #: ../gramps/plugins/textreport/detdescendantreport.py:1005
@@ -30657,9 +30440,8 @@ msgstr "Henry-numrering"
 
 #: ../gramps/plugins/textreport/descendreport.py:531
 #: ../gramps/plugins/textreport/detdescendantreport.py:1008
-#, fuzzy
 msgid "Modified Henry numbering"
-msgstr "Henry-numrering"
+msgstr "Modifierad Henry-numrering"
 
 #: ../gramps/plugins/textreport/descendreport.py:532
 msgid "de Villiers/Pama numbering"
@@ -30680,11 +30462,11 @@ msgstr "Visa giftermålsdata"
 
 #: ../gramps/plugins/textreport/descendreport.py:545
 msgid "Whether to show marriage information in the report."
-msgstr "Huruvida ta med giftermålssinformation i rapporten"
+msgstr "Huruvida ta med giftermålsinformation i rapporten."
 
 #: ../gramps/plugins/textreport/descendreport.py:548
 msgid "Show divorce info"
-msgstr "Visa skillsmässoinformation"
+msgstr "Visa skilsmässoinformation"
 
 #: ../gramps/plugins/textreport/descendreport.py:549
 msgid "Whether to show divorce information in the report."
@@ -30692,7 +30474,7 @@ msgstr "Huruvida ta med skilsmässoinformation i rapporten."
 
 #: ../gramps/plugins/textreport/descendreport.py:552
 msgid "Show duplicate trees"
-msgstr "Visa dubblerat träd"
+msgstr "Visa dubblerade träd"
 
 #: ../gramps/plugins/textreport/descendreport.py:554
 msgid "Whether to show duplicate Family Trees in the report."
@@ -30712,7 +30494,7 @@ msgstr "Mall som används för visning av makar på nivå %d."
 #: ../gramps/plugins/textreport/detancestralreport.py:214
 #, python-format
 msgid "Ancestral Report for %s"
-msgstr "Antavla för %s"
+msgstr "Antavle-rapport för %s"
 
 #: ../gramps/plugins/textreport/detancestralreport.py:277
 #: ../gramps/plugins/textreport/detdescendantreport.py:888
@@ -30760,9 +30542,10 @@ msgid "%s, "
 msgstr "%s, "
 
 #: ../gramps/plugins/textreport/detancestralreport.py:475
-#, fuzzy, python-format
+#, python-format
 msgid "%(event_role)s at %(event_name)s of %(primary_person)s: %(event_text)s"
-msgstr "%(event_name)s: %(event_text)s"
+msgstr ""
+"%(event_role)s vid %(event_name)s för %(primary_person)s: %(event_text)s"
 
 #. translators: needed for Arabic, ignore otherwise
 #: ../gramps/plugins/textreport/detancestralreport.py:491
@@ -30845,7 +30628,7 @@ msgstr "Beräkna ålder vid död"
 #: ../gramps/plugins/textreport/detancestralreport.py:879
 #: ../gramps/plugins/textreport/detdescendantreport.py:1070
 msgid "Whether to compute a person's age at death."
-msgstr "Huruvida beräkna ålder vid död."
+msgstr "Huruvida beräkna persons ålder vid död."
 
 #: ../gramps/plugins/textreport/detancestralreport.py:882
 msgid "Omit duplicate ancestors"
@@ -30863,7 +30646,7 @@ msgstr "Använd tilltalsnamn"
 #: ../gramps/plugins/textreport/detancestralreport.py:887
 #: ../gramps/plugins/textreport/detdescendantreport.py:1074
 msgid "Whether to use the call name as the first name."
-msgstr "Huruvida använda tilltalsnamn, som första namn."
+msgstr "Huruvida använda tilltalsnamn som första namn."
 
 #: ../gramps/plugins/textreport/detancestralreport.py:895
 #: ../gramps/plugins/textreport/detdescendantreport.py:1082
@@ -30872,15 +30655,13 @@ msgstr "Huruvida lista barn."
 
 #: ../gramps/plugins/textreport/detancestralreport.py:898
 #: ../gramps/plugins/textreport/detdescendantreport.py:1085
-#, fuzzy
 msgid "Include spouses of children"
-msgstr "Ta med antal barn"
+msgstr "Ta med makar till barn"
 
 #: ../gramps/plugins/textreport/detancestralreport.py:900
 #: ../gramps/plugins/textreport/detdescendantreport.py:1087
-#, fuzzy
 msgid "Whether to list the spouses of the children."
-msgstr "Huruvida dra in makar i trädet."
+msgstr "Huruvida lista makarna till barnen."
 
 #: ../gramps/plugins/textreport/detancestralreport.py:903
 #: ../gramps/plugins/textreport/detdescendantreport.py:1099
@@ -30893,25 +30674,22 @@ msgid "Whether to include events."
 msgstr "Huruvida ta med händelser."
 
 #: ../gramps/plugins/textreport/detancestralreport.py:907
-#, fuzzy
 msgid "Include other events"
-msgstr "Ta med händelser"
+msgstr "Ta med andra händelser"
 
 #: ../gramps/plugins/textreport/detancestralreport.py:908
-#, fuzzy
 msgid "Whether to include other events people participated in."
-msgstr "Huruvida ta med händelser för föräldrar."
+msgstr "Huruvida ta med andra händelser personer deltog i."
 
 #: ../gramps/plugins/textreport/detancestralreport.py:913
 #: ../gramps/plugins/textreport/detdescendantreport.py:1104
-#, fuzzy
 msgid "Include descendant reference in child list"
 msgstr "Lägg till ättlingareferens i barnlista"
 
 #: ../gramps/plugins/textreport/detancestralreport.py:915
 #: ../gramps/plugins/textreport/detdescendantreport.py:1106
 msgid "Whether to add descendant references in child list."
-msgstr "Huruvida lägg till ättlingareferens i barnlista."
+msgstr "Huruvida lägga till ättlingareferenser i barnlista."
 
 #: ../gramps/plugins/textreport/detancestralreport.py:919
 #: ../gramps/plugins/textreport/detdescendantreport.py:1110
@@ -30931,9 +30709,8 @@ msgstr "Huruvida ta med bilder."
 #: ../gramps/plugins/textreport/detdescendantreport.py:1114
 #: ../gramps/plugins/textreport/familygroup.py:782
 #: ../gramps/plugins/textreport/indivcomplete.py:1126
-#, fuzzy
 msgid "Include (2)"
-msgstr "Ta med"
+msgstr "Ta med (2)"
 
 #: ../gramps/plugins/textreport/detancestralreport.py:925
 #: ../gramps/plugins/textreport/detdescendantreport.py:1116
@@ -30968,7 +30745,7 @@ msgid ""
 "Whether to include source notes in the Endnotes section. Only works if "
 "Include sources is selected."
 msgstr ""
-"Huruvida ta ned källnotiser i notförteckningen. Fungerar bara om källor "
+"Huruvida ta med källnotiser i notförteckningen. Fungerar bara om källor "
 "medtages."
 
 #: ../gramps/plugins/textreport/detancestralreport.py:939
@@ -31036,15 +30813,14 @@ msgstr "Mall som används för text angående barnen."
 
 #: ../gramps/plugins/textreport/detancestralreport.py:1013
 #: ../gramps/plugins/textreport/detdescendantreport.py:1218
-#, fuzzy
 msgid "The style used for the note header."
-msgstr "Mall som används för generationsrubriken."
+msgstr "Mall som används för notisrubriken."
 
 #: ../gramps/plugins/textreport/detancestralreport.py:1027
 #: ../gramps/plugins/textreport/detdescendantreport.py:1232
 #: ../gramps/plugins/textreport/tableofcontents.py:117
 msgid "The style used for first level headings."
-msgstr "Mall som används för översta nivån av rubriker."
+msgstr "Mall som används för första nivån på rubriker."
 
 #: ../gramps/plugins/textreport/detancestralreport.py:1037
 #: ../gramps/plugins/textreport/detdescendantreport.py:1242
@@ -31058,15 +30834,14 @@ msgstr "Mall som används för andra nivån på rubriker."
 #: ../gramps/plugins/textreport/detdescendantreport.py:1252
 #: ../gramps/plugins/textreport/endoflinereport.py:335
 #: ../gramps/plugins/textreport/placereport.py:544
-#, fuzzy
 msgid "The style used for details."
-msgstr "Den mall, som används för detaljer om platser."
+msgstr "Mall som används för detaljer."
 
 #. feature request 2356: avoid genitive form
 #: ../gramps/plugins/textreport/detdescendantreport.py:340
 #, python-format
 msgid "Descendant Report for %(person_name)s"
-msgstr "Stamtavla för %(person_name)s"
+msgstr "Stamtavle-rapport för %(person_name)s"
 
 #: ../gramps/plugins/textreport/detdescendantreport.py:634
 #, python-format
@@ -31083,28 +30858,25 @@ msgid "Record (Modified Register) numbering"
 msgstr "Post(modifierat register)-numrering"
 
 #: ../gramps/plugins/textreport/detdescendantreport.py:1015
-#, fuzzy
 msgid "Report structure"
-msgstr "Rapporttitel"
+msgstr "Rapportstruktur"
 
 #: ../gramps/plugins/textreport/detdescendantreport.py:1018
-#, fuzzy
 msgid "show people by generations"
-msgstr "Samtliga generationer"
+msgstr "visa personer efter generationer"
 
 #: ../gramps/plugins/textreport/detdescendantreport.py:1019
 msgid "show people by lineage"
-msgstr ""
+msgstr "visa personer efter släktlinjer"
 
 #: ../gramps/plugins/textreport/detdescendantreport.py:1020
-#, fuzzy
 msgid "How people are organized in the report"
-msgstr "Avgör vilka personer, som tas med i rapporten"
+msgstr "Hur personer är organiserade i rapporten"
 
 #: ../gramps/plugins/textreport/detdescendantreport.py:1090
 #: ../gramps/plugins/textreport/kinshipreport.py:370
 msgid "Include spouses"
-msgstr "Ta med make/maka"
+msgstr "Ta med makar"
 
 #: ../gramps/plugins/textreport/detdescendantreport.py:1092
 msgid "Whether to include detailed spouse information."
@@ -31138,21 +30910,19 @@ msgstr "Ta med släktskapsförhållande till startperson"
 msgid ""
 "Whether to include the path of descendancy from the start-person to each "
 "descendant."
-msgstr ""
-"Huruvida ta med släktskapsförhållandet från startpersonen till varje "
-"släkting."
+msgstr "Huruvida ta med ättlingalinjen från startpersonen till varje ättling."
 
 #. feature request 2356: avoid genitive form
 #: ../gramps/plugins/textreport/endoflinereport.py:159
 #, python-format
 msgid "End of Line Report for %s"
-msgstr "Rapport över oavslutade släktband för %s"
+msgstr "Rapport för oavslutade släktband för %s"
 
 #. feature request 2356: avoid genitive form
 #: ../gramps/plugins/textreport/endoflinereport.py:166
 #, python-format
 msgid "All the ancestors of %s who are missing a parent"
-msgstr "Alla de förfäder till %s, vilka saknar en förälder"
+msgstr "Alla förfäder till %s, vilka saknar en förälder"
 
 #: ../gramps/plugins/textreport/endoflinereport.py:308
 #: ../gramps/plugins/textreport/placereport.py:518
@@ -31178,27 +30948,25 @@ msgstr "%dO"
 #: ../gramps/plugins/textreport/familygroup.py:618
 #, python-format
 msgid "Family Group Report - Generation %d"
-msgstr "Familjegruppsrapport - generation %d"
+msgstr "Familjerapport - generation %d"
 
 #: ../gramps/plugins/textreport/familygroup.py:620
 #: ../gramps/plugins/textreport/familygroup.py:672
 #: ../gramps/plugins/textreport/textplugins.gpr.py:191
 msgid "Family Group Report"
-msgstr "Familjegrupp"
+msgstr "Familjerapport"
 
 #: ../gramps/plugins/textreport/familygroup.py:720
 msgid "Center Family"
 msgstr "Huvudfamilj"
 
 #: ../gramps/plugins/textreport/familygroup.py:721
-#, fuzzy
 msgid "The center family for the filter"
-msgstr "Huvudfamiljen för rapporten"
+msgstr "Huvudfamiljen för filtret"
 
 #: ../gramps/plugins/textreport/familygroup.py:725
-#, fuzzy
 msgid "Recursive (down)"
-msgstr "Rekursiv"
+msgstr "Rekursiv (ned)"
 
 #: ../gramps/plugins/textreport/familygroup.py:726
 msgid "Create reports for all descendants of this family."
@@ -31211,7 +30979,7 @@ msgstr "Föräldrarnas giftermål"
 
 #: ../gramps/plugins/textreport/familygroup.py:757
 msgid "Whether to include marriage information for parents."
-msgstr "Huruvida ta med giftermålssinformation för föräldrar."
+msgstr "Huruvida ta med giftermålsinformation för föräldrar."
 
 #: ../gramps/plugins/textreport/familygroup.py:760
 msgid "Parent Events"
@@ -31247,12 +31015,11 @@ msgstr "Föräldrarnas alternativa namn"
 
 #: ../gramps/plugins/textreport/familygroup.py:778
 msgid "Whether to include alternate names for parents."
-msgstr "Huruvida ta med alternativt namn på föräldrar."
+msgstr "Huruvida ta med alternativa namn på föräldrar."
 
 #: ../gramps/plugins/textreport/familygroup.py:789
-#, fuzzy
 msgid "Whether to include notes for families."
-msgstr "Huruvida ta med notiser för föräldrar."
+msgstr "Huruvida ta med notiser för familjer."
 
 #: ../gramps/plugins/textreport/familygroup.py:792
 msgid "Dates of Relatives"
@@ -31268,7 +31035,7 @@ msgstr "Barns giftermål"
 
 #: ../gramps/plugins/textreport/familygroup.py:799
 msgid "Whether to include marriage information for children."
-msgstr "Huruvida ta med giftermålsformation för barn."
+msgstr "Huruvida ta med giftermålsinformation för barn."
 
 #: ../gramps/plugins/textreport/familygroup.py:802
 msgid "Generation numbers (recursive only)"
@@ -31280,7 +31047,7 @@ msgstr "Huruvida ta med generationen på varje rapport (endast rekursivt)."
 
 #: ../gramps/plugins/textreport/familygroup.py:808
 msgid "Print fields for missing information"
-msgstr "Skriv fält för saknad information"
+msgstr "Utskriftsfält för saknad information"
 
 #: ../gramps/plugins/textreport/familygroup.py:810
 msgid "Whether to include fields for missing information."
@@ -31319,7 +31086,7 @@ msgstr "Bilder"
 #: ../gramps/plugins/textreport/indivcomplete.py:855
 #: ../gramps/plugins/textreport/textplugins.gpr.py:214
 msgid "Complete Individual Report"
-msgstr "Ansedel"
+msgstr "Fullständig individuell rapport"
 
 #: ../gramps/plugins/textreport/indivcomplete.py:935
 #: ../gramps/plugins/tool/dumpgenderstats.py:72
@@ -31349,14 +31116,12 @@ msgstr "Huruvida sortera händelser kronologiskt."
 
 #. ###############################
 #: ../gramps/plugins/textreport/indivcomplete.py:1104
-#, fuzzy
 msgid "Include Notes"
 msgstr "Ta med notiser"
 
 #: ../gramps/plugins/textreport/indivcomplete.py:1105
-#, fuzzy
 msgid "Whether to include Person and Family Notes."
-msgstr "Huruvida ta med andra namn."
+msgstr "Huruvida ta med person- och familjenotiser."
 
 #: ../gramps/plugins/textreport/indivcomplete.py:1108
 msgid "Include Source Information"
@@ -31367,29 +31132,24 @@ msgid "Whether to cite sources."
 msgstr "Huruvida citera källor."
 
 #: ../gramps/plugins/textreport/indivcomplete.py:1131
-#, fuzzy
 msgid "Include Tags"
-msgstr "Ta med datum"
+msgstr "Ta med flaggor"
 
 #: ../gramps/plugins/textreport/indivcomplete.py:1132
-#, fuzzy
 msgid "Whether to include tags."
-msgstr "Huruvida ta med bilder."
+msgstr "Huruvida ta med flaggor."
 
 #: ../gramps/plugins/textreport/indivcomplete.py:1135
-#, fuzzy
 msgid "Include Attributes"
 msgstr "Ta med attribut"
 
 #: ../gramps/plugins/textreport/indivcomplete.py:1139
-#, fuzzy
 msgid "Include Census Events"
-msgstr "Ta med händelser"
+msgstr "Ta med folkräkningshändelser"
 
 #: ../gramps/plugins/textreport/indivcomplete.py:1140
-#, fuzzy
 msgid "Whether to include Census Events."
-msgstr "Huruvida ta med händelser."
+msgstr "Huruvida ta med folkräkningshändelser."
 
 #. ###############################
 #: ../gramps/plugins/textreport/indivcomplete.py:1150
@@ -31417,14 +31177,12 @@ msgid "The basic style used for table headings."
 msgstr "Grundläggande mall som används för tabellrubriker."
 
 #: ../gramps/plugins/textreport/indivcomplete.py:1256
-#, fuzzy
 msgid "The style used for image notes."
-msgstr "Mall som används för indexrader."
+msgstr "Mall som används för bildnotiser."
 
 #: ../gramps/plugins/textreport/indivcomplete.py:1266
-#, fuzzy
 msgid "The style used for image descriptions."
-msgstr "Den mall, som används för bildbeskrivning."
+msgstr "Mall som används för bildbeskrivningar."
 
 #. feature request 2356: avoid genitive form
 #: ../gramps/plugins/textreport/kinshipreport.py:125
@@ -31467,7 +31225,7 @@ msgstr ""
 #: ../gramps/plugins/textreport/notelinkreport.py:67
 #: ../gramps/plugins/textreport/notelinkreport.py:102
 msgid "Note Link Check Report"
-msgstr "Rapport med kontroll av notislänkar"
+msgstr "Kontrollrapport för notislänkar"
 
 #: ../gramps/plugins/textreport/notelinkreport.py:77
 msgid "Note ID"
@@ -31495,8 +31253,8 @@ msgstr "Antal anor för %s"
 #, python-brace-format
 msgid "Generation {number} has {count} individual. {percent}"
 msgid_plural "Generation {number} has {count} individuals. {percent}"
-msgstr[0] "Generation {number} has {count} individ. {percent}"
-msgstr[1] "Generation {number} has {count} individers. {percent}"
+msgstr[0] "Generation {number} har {count} individ. {percent}"
+msgstr[1] "Generation {number} har {count} individer. {percent}"
 
 #. TC # English return something like:
 #. Total ancestors in generations 2 to 3 is 4. (66.67%)
@@ -31520,7 +31278,7 @@ msgstr "Rapport över platser"
 
 #: ../gramps/plugins/textreport/placereport.py:129
 msgid "Please select at least one place before running this."
-msgstr "Var snäll och välj minst en plats innan detta körs"
+msgstr "Välj minst en plats innan detta körs."
 
 #: ../gramps/plugins/textreport/placereport.py:182
 #, python-format
@@ -31528,13 +31286,13 @@ msgid "Gramps ID: %s "
 msgstr "Gramps-ID: %s "
 
 #: ../gramps/plugins/textreport/placereport.py:199
-#, fuzzy, python-format
+#, python-format
 msgid "places|All Names: %s"
-msgstr "Platsnamn:"
+msgstr "Samtliga namn: %s"
 
 #: ../gramps/plugins/textreport/placereport.py:221
 msgid "Events that happened at this place"
-msgstr "Händelser, som inträffat på denna plats"
+msgstr "Händelser som inträffat på denna plats"
 
 #: ../gramps/plugins/textreport/placereport.py:225
 #: ../gramps/plugins/textreport/placereport.py:302
@@ -31561,7 +31319,7 @@ msgstr "Välj filteranvändning"
 
 #: ../gramps/plugins/textreport/placereport.py:445
 msgid "Select places using a filter"
-msgstr "Välj ut platser med hjälp av filter"
+msgstr "Välj ut platser med hjälp av ett filter"
 
 #: ../gramps/plugins/textreport/placereport.py:452
 msgid "Select places individually"
@@ -31573,11 +31331,11 @@ msgstr "Lista på platser att rapportera om"
 
 #: ../gramps/plugins/textreport/placereport.py:456
 msgid "Center on"
-msgstr "Huvudperson"
+msgstr "Centrera på"
 
 #: ../gramps/plugins/textreport/placereport.py:458
 msgid "If report is event or person centered"
-msgstr "Huruvida rapporten är händelse- eller person-centrerad"
+msgstr "Om rapporten är händelse- eller person-centrerad"
 
 #: ../gramps/plugins/textreport/recordsreport.py:173
 #, python-format
@@ -31607,7 +31365,7 @@ msgstr ""
 
 #: ../gramps/plugins/textreport/recordsreport.py:240
 msgid "Footer text"
-msgstr "Fottext"
+msgstr "Sidfotstext"
 
 #: ../gramps/plugins/textreport/recordsreport.py:345
 #: ../gramps/plugins/textreport/simplebooktitle.py:191
@@ -31653,7 +31411,7 @@ msgstr "Sidans fottext."
 
 #: ../gramps/plugins/textreport/simplebooktitle.py:154
 msgid "Gramps ID of the media object to use as an image."
-msgstr "Gramps-ID för det mediaobjekt, som skall användas som bild."
+msgstr "Gramps-ID för det mediaobjekt som skall användas som bild."
 
 #: ../gramps/plugins/textreport/simplebooktitle.py:157
 msgid "Image Size"
@@ -31705,7 +31463,7 @@ msgstr "Personer som saknar födelsedatum: %d"
 #: ../gramps/plugins/textreport/summary.py:193
 #, python-format
 msgid "Disconnected individuals: %d"
-msgstr "Isolerade personer: %d"
+msgstr "Släktlösa personer: %d"
 
 #: ../gramps/plugins/textreport/summary.py:198
 #, python-format
@@ -31734,12 +31492,12 @@ msgstr "Sammanlagd storlek på mediaobjekt: %s MB"
 
 #: ../gramps/plugins/textreport/summary.py:290
 msgid "Whether to count private data"
-msgstr "Huruvida räkna privata data"
+msgstr "Huruvida räkna med privata data"
 
 #: ../gramps/plugins/textreport/tableofcontents.py:64
 #: ../gramps/plugins/textreport/textplugins.gpr.py:371
 msgid "Table Of Contents"
-msgstr "Innehållstabell"
+msgstr "Innehållsförteckning"
 
 #: ../gramps/plugins/textreport/tableofcontents.py:68
 msgid "Contents"
@@ -31762,11 +31520,11 @@ msgstr "Du måste skapa en flagga innan du kör denna rapport."
 #: ../gramps/plugins/textreport/tagreport.py:116
 #, python-format
 msgid "Tag Report for %s Items"
-msgstr "Flaggrapport: %s-poster"
+msgstr "Flaggrapport för %s poster"
 
 #: ../gramps/plugins/textreport/tagreport.py:671
 msgid "Email Address"
-msgstr "e-postadress"
+msgstr "E-postadress"
 
 #: ../gramps/plugins/textreport/tagreport.py:757
 #: ../gramps/plugins/view/sourceview.py:86
@@ -31775,19 +31533,19 @@ msgstr "Publiceringsinformation"
 
 #: ../gramps/plugins/textreport/tagreport.py:916
 msgid "The tag to use for the report"
-msgstr "Den flagga, som skall användas för rapporten"
+msgstr "Flagga som skall användas för rapporten"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:37
 msgid "Ahnentafel Report"
-msgstr "Antavla, kortfattad"
+msgstr "Ahnentafel-rapport"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:38
 msgid "Produces a textual ancestral report"
-msgstr "Skapar en antavla med minsta tänkbar information."
+msgstr "Skapar en textrapport för anor"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:60
 msgid "Produces a report of birthdays and anniversaries"
-msgstr "Skapar en rapport med födelsedagar och årsdagar."
+msgstr "Skapar en rapport med födelsedagar och årsdagar"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:82
 msgid "Add custom text to the book report"
@@ -31795,27 +31553,27 @@ msgstr "Lägg till användartext till bokrapporten"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:103
 msgid "Descendant Report"
-msgstr "Stamtavla, kortfattad"
+msgstr "Rapport för ättlingar"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:104
 msgid "Produces a list of descendants of the active person"
-msgstr "Skapar en kortfattad lista över den aktiva personens ättlingar."
+msgstr "Skapar en lista över den aktiva personens ättlingar"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:125
 msgid "Detailed Ancestral Report"
-msgstr "Antavla, detaljerad"
+msgstr "Detaljerad rapport för förfäder"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:126
 msgid "Produces a detailed ancestral report"
-msgstr "Skapar en antavla med mycket information."
+msgstr "Skapar en detaljerad rapport för förfäder"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:147
 msgid "Detailed Descendant Report"
-msgstr "Stamtavla, detaljerad"
+msgstr "Detaljerad rapport för ättlingar"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:148
 msgid "Produces a detailed descendant report"
-msgstr "Skapar en detaljerad stamtavla."
+msgstr "Skapar en detaljerad rapport för ättlingar"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:169
 msgid "End of Line Report"
@@ -31823,27 +31581,27 @@ msgstr "Rapport för oavslutade släktband"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:170
 msgid "Produces a textual end of line report"
-msgstr "Skapar en textrapport för oavslutade släktband."
+msgstr "Skapar en textrapport för oavslutade släktband"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:192
 msgid ""
 "Produces a family group report showing information on a set of parents and "
 "their children."
 msgstr ""
-"Skapar en rapport för familjegrupp, som visar information om ett föräldrapar "
+"Skapar en rapport för familjegrupp som visar information om ett föräldrapar "
 "och dess barn."
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:215
 msgid "Produces a complete report on the selected people"
-msgstr "Skapar en fullständig ansedel om den valda personen."
+msgstr "Skapar en fullständig rapport om den valda personen"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:236
 msgid "Kinship Report"
-msgstr "Lista med släktingar"
+msgstr "Släktskapsrapport"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:237
 msgid "Produces a textual report of kinship for a given person"
-msgstr "Skapar en lista med släktingar till en given person."
+msgstr "Skapar en textrapport över släktskap för en given person"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:259
 msgid "Produces a list of people with a specified tag"
@@ -31859,7 +31617,7 @@ msgstr "Beräknar antalet anor för vald person"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:304
 msgid "Produces a textual place report"
-msgstr "Skapar en textinriktad rapport över platser"
+msgstr "Skapar en textrapport över platser"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:326
 msgid "Title Page"
@@ -31871,7 +31629,7 @@ msgstr "Skapar en titelsida för bokrapporter."
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:349
 msgid "Provides a summary of the current database"
-msgstr "Visar en sammanfattning av den aktuella databasen."
+msgstr "Visar en sammanfattning av den aktuella databasen"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:372
 msgid "Produces a table of contents for book reports."
@@ -31883,11 +31641,11 @@ msgstr "Skapar ett alfabetiskt index för bokrapporter."
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:415
 msgid "Records Report"
-msgstr "Rekordrapport"
+msgstr "Rapport av poster"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:437
 msgid "Note Link Report"
-msgstr "Rapport med notislänkar"
+msgstr "Rapport över notislänkar"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:438
 msgid "Shows status of links in notes"
@@ -31899,8 +31657,8 @@ msgid ""
 "Gramps can convert to correct capitalization. \n"
 "Select the names you wish Gramps to convert. "
 msgstr ""
-"Nedanför är en lista med de efternamn som Gramps\n"
-"kan konvertera till korrekt skiftlägesinformation.\n"
+"Nedanför är en lista med de efternamn som \n"
+"Gramps kan konvertera till korrekt skiftläge. \n"
 "Välj de namn som du vill att Gramps ska konvertera. "
 
 #: ../gramps/plugins/tool/changenames.glade:107
@@ -31953,8 +31711,8 @@ msgid ""
 "This tool will rename all events of one type to a different type. Once "
 "completed, this cannot be undone by the regular Undo function."
 msgstr ""
-"Detta verktyg kommer att namna om alla händelser av en typ till en annan "
-"typ. Denna åtgärd går inte att ångra."
+"Detta verktyg kommer att namnändra alla händelser av en typ till en annan "
+"typ. Denna åtgärd går inte att ångra med den vanliga ångrafunktionen."
 
 #: ../gramps/plugins/tool/changetypes.glade:112
 msgid "Original event type:"
@@ -31979,15 +31737,15 @@ msgstr "Analyserar händelser"
 
 #: ../gramps/plugins/tool/changetypes.py:134
 msgid "No event record was modified."
-msgstr "Ingen händelse ändrades."
+msgstr "Ingen händelsepost var modifierad."
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/changetypes.py:137
 #, python-brace-format
 msgid "{number_of} event record was modified."
 msgid_plural "{number_of} event records were modified."
-msgstr[0] "{number_of} händelsepost modifierades "
-msgstr[1] "{number_of} händelseposter modifierades "
+msgstr[0] "{number_of} händelsepost modifierades."
+msgstr[1] "{number_of} händelseposter modifierades."
 
 #: ../gramps/plugins/tool/check.py:119 ../gramps/plugins/tool/check.py:295
 msgid "Checking Database"
@@ -31995,7 +31753,7 @@ msgstr "Kontrollerar databas"
 
 #: ../gramps/plugins/tool/check.py:120
 msgid "Looking for cross table duplicates"
-msgstr "Letar efter dubbletter i tabeller korsvis "
+msgstr "Letar efter dubbletter i tabeller korsvis"
 
 #: ../gramps/plugins/tool/check.py:177
 msgid ""
@@ -32006,10 +31764,10 @@ msgid ""
 "Repair tool should be run anew on this new Family Tree."
 msgstr ""
 "Ditt släktträd innehåller korsvisa duplicerade referenser.\n"
-"Detta är inte bra men kan åtgärdas genom att ta en\n"
-"säkerhetskopia och importera den till ett tomt släktträd.\n"
-"Resterande kontroll hoppas över verktyget \"Kontrollera och reparera\"\n"
-"bör köras ånyo på det nya släktträdet."
+" Detta är inte bra men kan åtgärdas genom att ta en\n"
+"säkerhetskopia av släktträdet och importera den till ett tomt\n"
+" släktträd. Resterande kontroll hoppas över. Verktyget \"Kontrollera och "
+"reparera\" bör ånyo köras på det nya släktträdet."
 
 #: ../gramps/plugins/tool/check.py:187
 msgid "Check Integrity"
@@ -32018,9 +31776,8 @@ msgstr "Kontrollera integritet"
 #. for bsddb the check_backlinks doesn't work in 'batch' mode because
 #. the table used for backlinks is closed.
 #: ../gramps/plugins/tool/check.py:230
-#, fuzzy
 msgid "Check Backlink Integrity"
-msgstr "Kontrollera integritet"
+msgstr "Kontrollera länkintegritet"
 
 #: ../gramps/plugins/tool/check.py:237
 #: ../gramps/plugins/tool/rebuildrefmap.py:78
@@ -32034,8 +31791,8 @@ msgid ""
 "Objects referenced by this note were referenced but missing so that is why "
 "they have been created when you ran Check and Repair on %s."
 msgstr ""
-"Objekt, som refererats av denna notis, saknas, så det anledningen till att "
-"de har skapats när du körde Kontrollera och reparera på %s."
+"Objekt som refererats av denna notis, saknas, så det är anledningen till att "
+"de har skapats när du körde \"Kontrollera och reparera\" på %s."
 
 #: ../gramps/plugins/tool/check.py:320
 msgid "Looking for invalid name format references"
@@ -32054,9 +31811,8 @@ msgid "Looking for ctrl characters in notes"
 msgstr "Söker efter ctrl-tecken i notiser"
 
 #: ../gramps/plugins/tool/check.py:461
-#, fuzzy
 msgid "Looking for bad alternate place names"
-msgstr "Söker efter tomma ortsposter"
+msgstr "Söker efter felaktiga alternativa platsnamn"
 
 #: ../gramps/plugins/tool/check.py:490
 msgid "Looking for broken family links"
@@ -32085,11 +31841,12 @@ msgid ""
 "keep the reference to the missing file, or select a new file."
 msgstr ""
 "Filen:\n"
-" %(file_name)s \n"
-"refereras till i databasen, men finns inte längre. Filen kan ha blivit "
-"raderad eller flyttats till en annan plats. Du kan välja endera av att ta "
-"bort referensen från databasen, behålla referensen till den saknade filen, "
-"eller välja en ny fil."
+"%(file_name)s \n"
+"refereras till i databasen, men finns inte längre.\n"
+"Filen kan ha blivit raderad eller flyttats till en annan plats.\n"
+"Du kan välja antingen att ta bort referensen från databasen,\n"
+"\n"
+"behålla referensen till den saknade filen, eller välja en ny fil."
 
 #: ../gramps/plugins/tool/check.py:894
 msgid "Looking for empty people records"
@@ -32113,7 +31870,7 @@ msgstr "Söker efter tomma citeringsposter"
 
 #: ../gramps/plugins/tool/check.py:929
 msgid "Looking for empty place records"
-msgstr "Söker efter tomma ortsposter"
+msgstr "Söker efter tomma platsposter"
 
 #: ../gramps/plugins/tool/check.py:936
 msgid "Looking for empty media records"
@@ -32140,9 +31897,8 @@ msgid "Looking for event problems"
 msgstr "Söker efter problem med händelser"
 
 #: ../gramps/plugins/tool/check.py:1240
-#, fuzzy
 msgid "Looking for backlink reference problems"
-msgstr "Söker efter problem med referenser till platser"
+msgstr "Söker efter problem med länkreferenser"
 
 #: ../gramps/plugins/tool/check.py:1294
 msgid "Looking for person reference problems"
@@ -32154,44 +31910,43 @@ msgstr "Söker efter problem med familjereferenser"
 
 #: ../gramps/plugins/tool/check.py:1353
 msgid "Looking for repository reference problems"
-msgstr "Söker efter problem med arkivplatsreferens"
+msgstr "Söker efter problem med arkivplatsreferenser"
 
 #: ../gramps/plugins/tool/check.py:1388
 msgid "Looking for place reference problems"
-msgstr "Söker efter problem med referenser till platser"
+msgstr "Söker efter problem med platsreferenser"
 
 #: ../gramps/plugins/tool/check.py:1499
 msgid "Looking for citation reference problems"
-msgstr "Söker efter problem citeringshänvisningar"
+msgstr "Söker efter problem med citeringsreferenser"
 
 #: ../gramps/plugins/tool/check.py:1617
 msgid "Looking for source reference problems"
-msgstr "Söker efter problem med hänvisningar i källor"
+msgstr "Söker efter problem med källreferenser"
 
 #: ../gramps/plugins/tool/check.py:1659
 msgid "Looking for media object reference problems"
-msgstr "Söker efter problem med referenser till mediaobjekt"
+msgstr "Söker efter problem med mediaobjektsreferenser"
 
 #: ../gramps/plugins/tool/check.py:1781
 msgid "Looking for note reference problems"
-msgstr "Söker efter problem med hänvisningar i notiser"
+msgstr "Söker efter problem med notisreferenser"
 
 #: ../gramps/plugins/tool/check.py:1909
 msgid "Updating checksums on media"
-msgstr "Uppdaterar kontrollsumma för media"
+msgstr "Uppdaterar kontrollsummor för media"
 
 #: ../gramps/plugins/tool/check.py:1935
 msgid "Looking for tag reference problems"
-msgstr "Söker efter problem med hänvisningar i flaggor"
+msgstr "Söker efter problem med flaggreferenser"
 
 #: ../gramps/plugins/tool/check.py:2080
 msgid "Looking for media source reference problems"
-msgstr "Söker efter problem med hänvisningar i mediakällor"
+msgstr "Söker efter problem med referenser i mediakällor"
 
 #: ../gramps/plugins/tool/check.py:2148
-#, fuzzy
 msgid "Looking for Duplicated Gramps ID problems"
-msgstr "Söker efter dubblerade makar"
+msgstr "Söker efter problem med dubblerade Gramps-ID"
 
 #: ../gramps/plugins/tool/check.py:2380
 msgid "No errors were found"
@@ -32211,7 +31966,7 @@ msgstr "Inga fel hittades: databasen har klarat interna kontroller."
 msgid "{quantity} broken child/family link was fixed\n"
 msgid_plural "{quantity} broken child/family links were fixed\n"
 msgstr[0] "{quantity} trasig barn/familjelänk lagades\n"
-msgstr[1] "{quantity} trasig barn/familjelänkar lagades\n"
+msgstr[1] "{quantity} trasiga barn/familjelänkar lagades\n"
 
 #: ../gramps/plugins/tool/check.py:2399
 msgid "Non existing child"
@@ -32228,7 +31983,7 @@ msgstr "%(person)s togs bort från familjen %(family)s\n"
 msgid "{quantity} broken spouse/family link was fixed\n"
 msgid_plural "{quantity} broken spouse/family links were fixed\n"
 msgstr[0] "{quantity} trasig maka-/make-/familjelänk lagades\n"
-msgstr[1] "{quantity} trasig maka-/make-/familjelänkar lagades\n"
+msgstr[1] "{quantity} trasiga maka-/make-/familjelänkar lagades\n"
 
 #: ../gramps/plugins/tool/check.py:2425 ../gramps/plugins/tool/check.py:2453
 msgid "Non existing person"
@@ -32244,48 +31999,49 @@ msgstr "%(person)s återställdes till familjen %(family)s\n"
 #, python-brace-format
 msgid "{quantity} duplicate spouse/family link was found\n"
 msgid_plural "{quantity} duplicate spouse/family links were found\n"
-msgstr[0] "{quantity}duplicerad make-maka- eller familjelänk hittades\n"
-msgstr[1] "{quantity}duplicerad make-maka- eller familjelänkar hittades\n"
+msgstr[0] "{quantity} duplicerad maka-/make-/familjelänk hittades\n"
+msgstr[1] "{quantity} duplicerade maka-/make-/familjelänkar hittades\n"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2471
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "{quantity} family with no parents or children found, removed.\n"
 msgid_plural ""
 "{quantity} families with no parents or children found, removed.\n"
-msgstr[0] "1 familj utan föräldrar eller barn funnen, borttagen.\n"
-msgstr[1] "1 familj utan föräldrar eller barn funnen, borttagen.\n"
+msgstr[0] "{quantity} familj utan föräldrar eller barn funnen, tog bort den.\n"
+msgstr[1] ""
+"{quantity} familjer utan föräldrar eller barn funna, tog bort dem.\n"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2483
 #, python-brace-format
 msgid "{quantity} corrupted family relationship fixed\n"
 msgid_plural "{quantity} corrupted family relationships fixed\n"
-msgstr[0] "{quantity} förstört familjesläktskap rättat\n"
-msgstr[1] "{quantity} förstörda familjesläktskap rättade\n"
+msgstr[0] "{quantity} förstört familjesläktskap lagat\n"
+msgstr[1] "{quantity} förstörda familjesläktskap lagade\n"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2491
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "{quantity} place alternate name fixed\n"
 msgid_plural "{quantity} place alternate names fixed\n"
-msgstr[0] "{quantity} ogiltigt dödshändelsenamn lagades\n"
-msgstr[1] "{quantity} ogiltiga dödshändelsenamn lagades\n"
+msgstr[0] "{quantity} ogiltigt platsnamn rättat\n"
+msgstr[1] "{quantity} ogiltiga platsnamn rättade\n"
 
 #: ../gramps/plugins/tool/check.py:2500
 #, python-brace-format
 msgid "{quantity} person was referenced but not found\n"
 msgid_plural "{quantity} persons were referenced, but not found\n"
-msgstr[0] "{quantity} person, som refererats till, kunde inte hittas\n"
-msgstr[1] "{quantity} personer, som refererats till, kunde inte hittas\n"
+msgstr[0] "{quantity} person som refererats till kunde inte hittas\n"
+msgstr[1] "{quantity} personer som refererats till kunde inte hittas\n"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2508
 #, python-brace-format
 msgid "{quantity} family was referenced but not found\n"
 msgid_plural "{quantity} families were referenced, but not found\n"
-msgstr[0] "{quantity} familj, som refererats till, kunde inte hittas\n"
-msgstr[1] "{quantity} familjer, som refererats till, kunde inte hittas\n"
+msgstr[0] "{quantity} familj som refererats till kunde inte hittas\n"
+msgstr[1] "{quantity} familjer som refererats till kunde inte hittas\n"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2518
@@ -32299,23 +32055,23 @@ msgstr[1] "{quantity} datum rättades\n"
 #, python-brace-format
 msgid "{quantity} repository was referenced but not found\n"
 msgid_plural "{quantity} repositories were referenced, but not found\n"
-msgstr[0] "{quantity} arkivplats, som refererats till, kunde inte hittas\n"
-msgstr[1] "{quantity} arkivplatser, som refererats till, kunde inte hittas\n"
+msgstr[0] "{quantity} arkivplats som refererats till kunde inte hittas\n"
+msgstr[1] "{quantity} arkivplatser som refererats till kunde inte hittas\n"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2537 ../gramps/plugins/tool/check.py:2624
 #, python-brace-format
 msgid "{quantity} media object was referenced but not found\n"
 msgid_plural "{quantity} media objects were referenced, but not found\n"
-msgstr[0] "{quantity} mediaobjekt, som refererats till, kunde inte hittas\n"
-msgstr[1] "{quantity} mediaobjekt, som refererats till, kunde inte hittas\n"
+msgstr[0] "{quantity} mediaobjekt som refererats till kunde inte hittas\n"
+msgstr[1] "{quantity} mediaobjekt som refererats till kunde inte hittas\n"
 
 #: ../gramps/plugins/tool/check.py:2548
 #, python-brace-format
 msgid "Reference to {quantity} missing media object was kept\n"
 msgid_plural "References to {quantity} media objects were kept\n"
 msgstr[0] "Referens till {quantity} saknat mediaobjekt behölls\n"
-msgstr[1] "Referens till{quantity} saknade mediaobjekt behölls\n"
+msgstr[1] "Referens till {quantity} saknade mediaobjekt behölls\n"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2556
@@ -32338,8 +32094,8 @@ msgstr[1] "{quantity} saknade mediaobjekt togs bort\n"
 #, python-brace-format
 msgid "{quantity} event was referenced but not found\n"
 msgid_plural "{quantity} events were referenced, but not found\n"
-msgstr[0] "{quantity} händelse, som refererats till, kunde inte hittas\n"
-msgstr[1] "{quantity} händelser, som refererats till, kunde inte hittas\n"
+msgstr[0] "{quantity} händelse som refererats till kunde inte hittas\n"
+msgstr[1] "{quantity} händelser som refererats till kunde inte hittas\n"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2580
@@ -32362,38 +32118,38 @@ msgstr[1] "{quantity} ogiltiga dödshändelsenamn lagades\n"
 #, python-brace-format
 msgid "{quantity} place was referenced but not found\n"
 msgid_plural "{quantity} places were referenced, but not found\n"
-msgstr[0] "{quantity} plats, som refererats till, kunde inte hittas\n"
-msgstr[1] "{quantity} platser, som refererats till, kunde inte hittas\n"
+msgstr[0] "{quantity} plats som refererats till kunde inte hittas\n"
+msgstr[1] "{quantity} platser som refererats till kunde inte hittas\n"
 
 #: ../gramps/plugins/tool/check.py:2605
 #, python-brace-format
 msgid "{quantity} citation was referenced but not found\n"
 msgid_plural "{quantity} citations were referenced, but not found\n"
-msgstr[0] "{quantity} citering, som refererats till, kunde inte hittas\n"
-msgstr[1] "{quantity} citeringar, som refererats till, kunde inte hittas\n"
+msgstr[0] "{quantity} citering som refererats till kunde inte hittas\n"
+msgstr[1] "{quantity} citeringar som refererats till kunde inte hittas\n"
 
 #: ../gramps/plugins/tool/check.py:2615
 #, python-brace-format
 msgid "{quantity} source was referenced but not found\n"
 msgid_plural "{quantity} sources were referenced, but not found\n"
-msgstr[0] "{quantity} källa, som refererats till, kunde inte hittas\n"
-msgstr[1] "{quantity} källor, som refererats till, kunde inte hittas\n"
+msgstr[0] "{quantity} källa som refererats till kunde inte hittas\n"
+msgstr[1] "{quantity} källor som refererats till kunde inte hittas\n"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2633
 #, python-brace-format
 msgid "{quantity} note object was referenced but not found\n"
 msgid_plural "{quantity} note objects were referenced, but not found\n"
-msgstr[0] "{quantity} notisobjekt, som refererats till, kunde inte hittas\n"
-msgstr[1] "{quantity} notisobjekt, som refererats till, kunde inte hittas\n"
+msgstr[0] "{quantity} notisobjekt som refererats till kunde inte hittas\n"
+msgstr[1] "{quantity} notisobjekt som refererats till kunde inte hittas\n"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2643 ../gramps/plugins/tool/check.py:2653
 #, python-brace-format
 msgid "{quantity} tag object was referenced but not found\n"
 msgid_plural "{quantity} tag objects were referenced, but not found\n"
-msgstr[0] "{quantity} flagga, som refererats till, kunde inte hittas\n"
-msgstr[1] "{quantity} flaggor, som refererats till, kunde inte hittas\n"
+msgstr[0] "{quantity} flagga som refererats till kunde inte hittas\n"
+msgstr[1] "{quantity} flaggor som refererats till kunde inte hittas\n"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2663
@@ -32407,16 +32163,16 @@ msgstr[1] "{quantity} ogiltiga namnformatsreferenser togs bort\n"
 #, python-brace-format
 msgid "{quantity} invalid source citation was fixed\n"
 msgid_plural "{quantity} invalid source citations were fixed\n"
-msgstr[0] "{quantity} ogiltigt födelsehändelsenamn lagades\n"
-msgstr[1] "{quantity} ogiltiga födelsehändelsenamn lagades\n"
+msgstr[0] "{quantity} ogiltig källcitering lagades\n"
+msgstr[1] "{quantity} ogiltiga källciteringar lagades\n"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2683
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "{quantity} Duplicated Gramps ID fixed\n"
 msgid_plural "{quantity} Duplicated Gramps IDs fixed\n"
-msgstr[0] "{quantity} ogiltigt dödshändelsenamn lagades\n"
-msgstr[1] "{quantity} ogiltiga dödshändelsenamn lagades\n"
+msgstr[0] "{quantity} Dubblerat Gramps-ID lagades\n"
+msgstr[1] "{quantity} Dubblerade Gramps-ID lagades\n"
 
 #: ../gramps/plugins/tool/check.py:2690
 #, python-format
@@ -32431,7 +32187,7 @@ msgid ""
 "   %(repo)d repository objects\n"
 "   %(note)d note objects\n"
 msgstr ""
-"%(empty_obj)d tomma borttagna objekt:\n"
+"%(empty_obj)d tomma objekt borttagna:\n"
 "   %(person)d personobjekt\n"
 "   %(family)d familjeobjekt\n"
 "   %(event)d händelseobjekt\n"
@@ -32444,7 +32200,7 @@ msgstr ""
 #: ../gramps/plugins/tool/check.py:2712
 #, python-format
 msgid "%d bad backlinks were fixed;\n"
-msgstr ""
+msgstr "%d felaktiga länkar lagades;\n"
 
 #: ../gramps/plugins/tool/check.py:2714
 #: ../gramps/plugins/tool/rebuildrefmap.py:92
@@ -32469,8 +32225,8 @@ msgid ""
 "This test will create many persons and events in the current database. Do "
 "you really want to run this test?"
 msgstr ""
-"Denna test kommer att skapa många personer och händelser i den aktuella "
-"databasen. Vill du verkligen starta denna test?"
+"Detta test kommer att skapa många personer och händelser i den aktuella "
+"databasen. Vill du verkligen starta detta test?"
 
 #: ../gramps/plugins/tool/dateparserdisplaytest.py:71
 msgid "Run test"
@@ -32602,13 +32358,13 @@ msgstr "Resultat av händelsejämförelse"
 #: ../gramps/plugins/tool/eventcmp.py:255
 #, python-format
 msgid "%(event_name)s Date"
-msgstr "%(event_name)s: datum"
+msgstr "%(event_name)s Datum"
 
 #. This won't be shown in a tree
 #: ../gramps/plugins/tool/eventcmp.py:259
 #, python-format
 msgid "%(event_name)s Place"
-msgstr "%(event_name)s: plats"
+msgstr "%(event_name)s Plats"
 
 #: ../gramps/plugins/tool/eventcmp.py:312
 msgid "Comparing Events"
@@ -32624,12 +32380,12 @@ msgstr "Välj fil"
 
 #: ../gramps/plugins/tool/eventnames.py:79
 msgid "Event name changes"
-msgstr "Händelsenamnsändring"
+msgstr "Händelsenamnsändringar"
 
 #: ../gramps/plugins/tool/eventnames.py:85
 #: ../gramps/plugins/tool/tools.gpr.py:131
 msgid "Extract Event Description"
-msgstr "Ta fram händelsebeskrivningar"
+msgstr "Ta fram händelsebeskrivning"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/eventnames.py:120
@@ -32645,7 +32401,7 @@ msgstr "Gjorda ändringar"
 
 #: ../gramps/plugins/tool/eventnames.py:127
 msgid "No event description has been added."
-msgstr "Inga händelsebeskrivningar har lagts till"
+msgstr "Ingen händelsebeskrivning har lagts till."
 
 #: ../gramps/plugins/tool/finddupes.glade:117
 #: ../gramps/plugins/tool/mergecitations.glade:117
@@ -32709,7 +32465,7 @@ msgstr "Möjliga sammanslagningar"
 
 #: ../gramps/plugins/tool/finddupes.py:571
 msgid "Rating"
-msgstr "Grad"
+msgstr "Gradering"
 
 #: ../gramps/plugins/tool/finddupes.py:572
 msgid "First Person"
@@ -32721,23 +32477,20 @@ msgstr "Andra personen"
 
 #: ../gramps/plugins/tool/finddupes.py:583
 msgid "Merge candidates"
-msgstr "Slå samman misstänkta dubbletter"
+msgstr "Kandidater för sammanslagning"
 
 #: ../gramps/plugins/tool/finddupes.py:583
-#, fuzzy
 msgid "Merge persons"
-msgstr "Slå samman person"
+msgstr "Slå ihop personer"
 
 #: ../gramps/plugins/tool/findloop.py:58
-#, fuzzy
 msgid "manual|Find_database_loop"
-msgstr "Datumredigerare"
+msgstr "Hitta databasslinga"
 
 #: ../gramps/plugins/tool/findloop.py:73
 #: ../gramps/plugins/tool/tools.gpr.py:465
-#, fuzzy
 msgid "Find database loop"
-msgstr "Annan databas"
+msgstr "Hitta databasslinga"
 
 #. start the progress indicator
 #: ../gramps/plugins/tool/findloop.py:93
@@ -32747,13 +32500,12 @@ msgid "Starting"
 msgstr "Börjar"
 
 #: ../gramps/plugins/tool/findloop.py:95
-#, fuzzy
 msgid "Looking for possible loop for each person"
-msgstr "Letar efter {number_of} person"
+msgstr "Söker efter möjliga slingor för alla personer"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
 msgid "manual|Media_Manager..."
-msgstr "Mediahanterare"
+msgstr "Media_hanterare..."
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114
@@ -32770,7 +32522,7 @@ msgstr "Introduktion"
 
 #: ../gramps/plugins/tool/mediamanager.py:100
 msgid "Selection"
-msgstr "Utvalt"
+msgstr "Val"
 
 #: ../gramps/plugins/tool/mediamanager.py:229
 #, python-format
@@ -32797,7 +32549,7 @@ msgstr ""
 "\n"
 "Ett mediaobjekt är en samling information om ett mediaobjekts datafil: namn, "
 "sökväg, beskrivning, ID, notiser, källreferenser etc. Dessa data "
-"%(bold_start)sinnehåller inte datafilen självf%(bold_end)s..\n"
+"%(bold_start)sinnehåller inte datafilen självf%(bold_end)s.\n"
 "\n"
 "De datafiler som innehåller bilder, ljud, video etc, lagras separat på "
 "hårddisken. Dessa filer ligger utanför Gramps kontroll och tas inte med i "
@@ -32806,7 +32558,7 @@ msgstr ""
 "Det här verktyget låter dig ändra posterna i Gramps-databasen. Om du vill "
 "flytta eller byta namn på datafilerna måste du göra det på egen hand, "
 "utanför Gramps. Därefter kan du justera sökvägarna med detta verktyg så att "
-"mediaobjekten innehåller rätt sökvägar."
+"mediaobjekten innehåller rätt filplatser."
 
 #: ../gramps/plugins/tool/mediamanager.py:340
 msgid "Affected path"
@@ -32821,13 +32573,15 @@ msgstr ""
 
 #: ../gramps/plugins/tool/mediamanager.py:385
 msgid "Operation successfully finished"
-msgstr "Åtgärden avslutades framgångsrikt."
+msgstr "Åtgärden avslutades med lyckat resultat"
 
 #: ../gramps/plugins/tool/mediamanager.py:387
 msgid ""
 "The operation you requested has finished successfully. You may press Close "
 "now to continue."
-msgstr "Åtgärden du begärde har utförts. Tryck på OK för att fortsätta."
+msgstr ""
+"Åtgärden du begärde har utförts med lyckat resultat. Tryck på OK för att "
+"fortsätta."
 
 #: ../gramps/plugins/tool/mediamanager.py:390
 msgid "Operation failed"
@@ -32841,7 +32595,6 @@ msgstr ""
 "Det uppstod ett fel när den önskade åtgärden utfördes. Du kan eventuellt "
 "försöka starta verktyget på nytt."
 
-#
 #: ../gramps/plugins/tool/mediamanager.py:427
 #, python-format
 msgid ""
@@ -32851,7 +32604,7 @@ msgid ""
 msgstr ""
 "Följande åtgärder kommer att utföras:\n"
 "\n"
-"Åtgärd: %s"
+"Åtgärd:\t%s"
 
 #: ../gramps/plugins/tool/mediamanager.py:484
 msgid "Replace _substrings in the path"
@@ -32864,8 +32617,8 @@ msgid ""
 "from one directory to another"
 msgstr ""
 "Detta verktyg ändrar den angivna delsträngen i mediaobjektens sökväg till en "
-"ny delsträng. Detta kan vara användbart när du flyttar dina mediafiler från "
-"en katalog till en annan"
+"annan delsträng. Detta kan vara användbart när du flyttar dina mediafiler "
+"från en katalog till en annan"
 
 #: ../gramps/plugins/tool/mediamanager.py:491
 msgid "Replace substring settings"
@@ -32904,9 +32657,9 @@ msgid ""
 "does this by prepending the base path as given in the Preferences, or if "
 "that is not set, it prepends user's directory."
 msgstr ""
-"Det här verktyget omvandlar relativa sökvägar till absoluta sådana. Detta "
-"sker genom att komplettera den grundläggande sökvägen från Inställningar "
-"eller om denna inte är bestämd, kompletteras hemmappen."
+"Det här verktyget omvandlar relativa mediasökvägar till absoluta sådana. "
+"Detta sker genom att komplettera den grundläggande sökvägen som anges i "
+"'Inställningar' eller om denna inte är bestämd, kompletteras hemmappen."
 
 #: ../gramps/plugins/tool/mediamanager.py:603
 msgid "Convert paths from absolute to r_elative"
@@ -32919,31 +32672,31 @@ msgid ""
 "Preferences, or if that is not set, user's directory. A relative path allows "
 "to tie the file location to a base path that can change to your needs."
 msgstr ""
-"Det här verktyget tillåter omvandling av absoluta mediasökvägar till "
-"relativa. Den relativ sökvägen är relativ visavi den grundläggande sökvägen "
-"från Inställningar eller om den inte är bestämd, din hemmapp.. En relativa "
-"sökväg tillåter att knyta filplatsen till den grunläggande sökvägen, som kan "
-"anpassas för dina behov."
+"Det här verktyget omvandlar absoluta mediasökvägar till relativa. Den "
+"relativa sökvägen är relativ visavi den grundläggande sökvägen som anges i "
+"'Inställningar' eller om den inte är bestämd, din hemmapp. En relativ sökväg "
+"tillåter att knyta filplatsen till en grundläggande sökväg, som kan anpassas "
+"för dina behov."
 
 #: ../gramps/plugins/tool/mediamanager.py:640
 msgid "Add images not included in database"
-msgstr "Lägg till bilder, som ej ingår i databasen"
+msgstr "Lägg till bilder som ej ingår i databasen"
 
 #: ../gramps/plugins/tool/mediamanager.py:641
 msgid "Check directories for images not included in database"
-msgstr "Kontrollera mappar efter bilder, som ej ingår i databasen"
+msgstr "Kontrollera mappar efter bilder som ej ingår i databasen"
 
 #: ../gramps/plugins/tool/mediamanager.py:642
 msgid ""
 "This tool adds images in directories that are referenced by existing images "
 "in the database."
 msgstr ""
-"Detta verktyg lägger till bilder i mappar, som är refererade av befintliga "
+"Detta verktyg lägger till bilder i mappar som är refererade av befintliga "
 "bilder i databasen."
 
 #: ../gramps/plugins/tool/mergecitations.glade:144
 msgid "Don't merge if citation has notes"
-msgstr "Slå ej samman citeringar, som har notiser"
+msgstr "Slå ej samman citeringar som har notiser"
 
 #: ../gramps/plugins/tool/mergecitations.py:76
 msgid "Match on Page/Volume, Date and Confidence"
@@ -32969,7 +32722,7 @@ msgstr "Slå samman citeringar"
 msgid ""
 "Notes, media objects and data-items of matching citations will be combined."
 msgstr ""
-"Notiser, mediaobjekt och dataposter för matchande citeringarna kommer att "
+"Notiser, mediaobjekt och dataposter för matchande citeringar kommer att "
 "kombineras."
 
 #: ../gramps/plugins/tool/mergecitations.py:164
@@ -33025,8 +32778,8 @@ msgstr "Samtliga i databasen är släkt med %s"
 #, python-brace-format
 msgid "Setting tag for {number_of} person"
 msgid_plural "Setting tag for {number_of} people"
-msgstr[0] "Sätter flagga för {number_of} person"
-msgstr[1] "Sätter flaggor för {number_of} personer"
+msgstr[0] "Anger flagga för {number_of} person"
+msgstr[1] "Anger flaggor för {number_of} personer"
 
 #. translators: leave all/any {...} untranslated
 #. TRANS: No singular form is needed.
@@ -33042,8 +32795,8 @@ msgstr[1] "Letar släktskap mellan {number_of} personer"
 #, python-brace-format
 msgid "Looking for {number_of} person"
 msgid_plural "Looking for {number_of} people"
-msgstr[0] "Letar efter {number_of} person"
-msgstr[1] "Letar efter {number_of} personer"
+msgstr[0] "Söker efter {number_of} person"
+msgstr[1] "Söker efter {number_of} personer"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/notrelated.py:413
@@ -33051,15 +32804,15 @@ msgstr[1] "Letar efter {number_of} personer"
 msgid "Looking up the name of {number_of} person"
 msgid_plural "Looking up the names of {number_of} people"
 msgstr[0] "Slår upp namnet för {number_of} person"
-msgstr[1] "Slår upp namnen för{number_of} personer"
+msgstr[1] "Slår upp namnen för {number_of} personer"
 
 #: ../gramps/plugins/tool/ownereditor.glade:10
 msgid "Copy from DB to Preferences"
-msgstr ""
+msgstr "Kopiera från DB till inställningar"
 
 #: ../gramps/plugins/tool/ownereditor.glade:23
 msgid "Copy from Preferences to DB"
-msgstr ""
+msgstr "Kopiera från inställningar till DB"
 
 #: ../gramps/plugins/tool/ownereditor.glade:164
 msgid "_Street:"
@@ -33087,7 +32840,7 @@ msgstr "_E-post:"
 
 #: ../gramps/plugins/tool/ownereditor.glade:383
 msgid "Right-click to copy from/to Researcher Preferences"
-msgstr ""
+msgstr "Högerklicka för att kopiera från/till forskarinställningar"
 
 #: ../gramps/plugins/tool/ownereditor.py:56
 msgid "manual|Edit_Database_Owner_Information"
@@ -33121,18 +32874,20 @@ msgid ""
 "that can be extracted."
 msgstr ""
 "Nedan finner du en lista på de smeknamn, titlar, prefix och sammansatta "
-"efternamn som Gramps kan plocka ut från familjeträdet.\n"
-"Om du accepterar ändringarna kommer Gramps att ändra de termer, som valts.\n"
+"efternamn som Gramps kan extrahera från familjeträdet.\n"
+"Om du accepterar ändringarna kommer Gramps att ändra de poster som valts.\n"
 "\n"
-"Lencastre\" visas som:\n"
+"Sammansatta efternamn visas som listor av [prefix, efternamn, bindeord].\n"
+"Exempelvis med standardinställningarna kommer namnet \"de Mascarenhas da "
+"Silva e Lencastre\" visas som:\n"
 "       [de, Mascarenhas]-[da, Silva, e]-[,Lencastre]\n"
 "\n"
-"Kör detta verktyg flera gånger för att korrigera namn, som har flera "
-"informationsbitar, som kan plockas ut."
+"Kör detta verktyg flera gånger för att korrigera namn som har flera "
+"informationsbitar som kan extraheras."
 
 #: ../gramps/plugins/tool/patchnames.py:63
 msgid "manual|Extract_Information_from_Names"
-msgstr "Extrahera information från namn "
+msgstr "Extrahera information från namn"
 
 #: ../gramps/plugins/tool/patchnames.py:105
 msgid "Name and title extraction tool"
@@ -33140,7 +32895,7 @@ msgstr "Verktyg för namn- och titelextrahering"
 
 #: ../gramps/plugins/tool/patchnames.py:115
 msgid "Default prefix and connector settings"
-msgstr "Inställningar av standardprefix och ihopkopplingar"
+msgstr "Standardinställningar för prefix och bindeord"
 
 #: ../gramps/plugins/tool/patchnames.py:121
 msgid "Prefixes to search for:"
@@ -33148,11 +32903,11 @@ msgstr "Prefix att leta efter:"
 
 #: ../gramps/plugins/tool/patchnames.py:128
 msgid "Connectors splitting surnames:"
-msgstr "Bindeord, som delar efternamn:"
+msgstr "Bindeord som delar efternamn:"
 
 #: ../gramps/plugins/tool/patchnames.py:135
 msgid "Connectors not splitting surnames:"
-msgstr "Bindeord, som inte delar efternamn:"
+msgstr "Bindeord som inte delar efternamn:"
 
 #: ../gramps/plugins/tool/patchnames.py:173
 msgid "Extracting Information from Names"
@@ -33172,7 +32927,7 @@ msgstr "Aktuellt namn"
 
 #: ../gramps/plugins/tool/patchnames.py:457
 msgid "Prefix in given name"
-msgstr "Prefix till dopnamn"
+msgstr "Prefix i förnamn"
 
 #: ../gramps/plugins/tool/patchnames.py:469
 msgid "Compound surname"
@@ -33196,7 +32951,7 @@ msgstr "Alla sekundärindex har rekonstruerats."
 
 #: ../gramps/plugins/tool/rebuildgenderstat.py:82
 msgid "Rebuilding gender statistics for name gender guessing..."
-msgstr "Återskapande av könsstatistik för namn för att kunna gissa kön..."
+msgstr "Återskapande av könsstatistik för att gissa kön utifrån namnet..."
 
 #: ../gramps/plugins/tool/rebuildgenderstat.py:95
 msgid "Gender statistics rebuilt"
@@ -33204,7 +32959,7 @@ msgstr "Könsstatistik skapad"
 
 #: ../gramps/plugins/tool/rebuildgenderstat.py:96
 msgid "Gender statistics for name gender guessing have been rebuilt."
-msgstr "Könsstatistik för namngissning avseende kön har skapats."
+msgstr "Könsstatistik för att gissa kön utifrån namnet har skapats."
 
 #: ../gramps/plugins/tool/rebuildrefmap.py:91
 msgid "Reference maps rebuilt"
@@ -33256,9 +33011,8 @@ msgid "Search for sources"
 msgstr "Leta efter källor"
 
 #: ../gramps/plugins/tool/removeunused.glade:128
-#, fuzzy
 msgid "Search for citations"
-msgstr "Källa eller citering"
+msgstr "Leta efter citeringar"
 
 #: ../gramps/plugins/tool/removeunused.glade:143
 msgid "Search for places"
@@ -33305,7 +33059,7 @@ msgstr "Oanvända objekt"
 #: ../gramps/plugins/tool/removeunused.py:184
 #: ../gramps/plugins/tool/verify.py:551
 msgid "Mark"
-msgstr "Markerad"
+msgstr "Markera"
 
 #: ../gramps/plugins/tool/removeunused.py:299
 msgid "Remove unused objects"
@@ -33313,72 +33067,73 @@ msgstr "Ta bort oanvända objekt"
 
 #: ../gramps/plugins/tool/reorderids.glade:1406
 msgid "Enable ID reordering."
-msgstr ""
+msgstr "Aktivera omsortering av ID:n."
 
 #: ../gramps/plugins/tool/reorderids.glade:1420
 msgid ""
 "List next ID available\n"
 "(maynot be continuous)."
 msgstr ""
+"Visa nästa tillgängliga ID\n"
+"(behöver inte vara i ordning)."
 
 #: ../gramps/plugins/tool/reorderids.glade:1424
 msgid "  Actual"
-msgstr ""
+msgstr "  Faktisk"
 
 #: ../gramps/plugins/tool/reorderids.glade:1436
 msgid "Amount of ID in use."
-msgstr ""
+msgstr "Antal ID som används."
 
 #: ../gramps/plugins/tool/reorderids.glade:1438
 msgid " Quantity"
-msgstr ""
+msgstr " Antal"
 
 #: ../gramps/plugins/tool/reorderids.glade:1452
 msgid "Actual / Upcoming ID format."
-msgstr ""
+msgstr "Faktiskt / Kommande ID-format."
 
 #: ../gramps/plugins/tool/reorderids.glade:1465
-#, fuzzy
 msgid "Change"
-msgstr "intervall"
+msgstr "Ändra"
 
 #: ../gramps/plugins/tool/reorderids.glade:1470
 msgid ""
 "Enable ID reordering\n"
 "with Start / Step sequence."
 msgstr ""
+"Aktivera omsortering av ID:n\n"
+"med start / stegvis sekvens."
 
 #: ../gramps/plugins/tool/reorderids.glade:1483
-#, fuzzy
 msgid "Start"
-msgstr "Börjar"
+msgstr "Starta"
 
 #: ../gramps/plugins/tool/reorderids.glade:1488
-#, fuzzy
 msgid "Reorder ID start number."
-msgstr "Pappersorienteringsnummer."
+msgstr "Sortera om startnummer för ID:n."
 
 #: ../gramps/plugins/tool/reorderids.glade:1501
-#, fuzzy
 msgid "Step"
-msgstr "Styvbarn"
+msgstr "Steg"
 
 #: ../gramps/plugins/tool/reorderids.glade:1506
 msgid "Reorder ID step width."
-msgstr ""
+msgstr "Sortera om ID-stegvidd."
 
 #: ../gramps/plugins/tool/reorderids.glade:1518
 msgid "Keep"
-msgstr ""
+msgstr "Behåll"
 
 #: ../gramps/plugins/tool/reorderids.glade:1523
 msgid ""
 "Keep IDs with alternate\n"
 "prefixes untouched."
 msgstr ""
+"Behåll ID:n med alternativa\n"
+"prefix orörda."
 
 #: ../gramps/plugins/tool/reorderids.py:64
-#, fuzzy
 msgid "manual|Reorder_Gramps_ID"
 msgstr "Sortera om Gramps-ID:n"
 
@@ -33394,19 +33149,18 @@ msgstr "Sortera om Gramps-ID:n"
 
 #: ../gramps/plugins/tool/reorderids.py:544
 #: ../gramps/plugins/tool/reorderids.py:549
-#, fuzzy, python-format
+#, python-format
 msgid "Reorder %s IDs ..."
-msgstr "Sorterar om Gramps-ID:n"
+msgstr "Sortera om %s ID:n ..."
 
 #: ../gramps/plugins/tool/reorderids.py:625
-#, fuzzy, python-format
+#, python-format
 msgid "Do you want to replace %s?"
-msgstr "Tag ej med några datum eller platser"
+msgstr "Vill du byta ut %s?"
 
 #: ../gramps/plugins/tool/reorderids.py:684
-#, fuzzy
 msgid "Finding and assigning unused IDs."
-msgstr "Söker och tilldelar oanvända ID:n"
+msgstr "Söker och tilldelar oanvända ID:n."
 
 #: ../gramps/plugins/tool/sortevents.py:76
 msgid "Sort Events"
@@ -33450,7 +33204,7 @@ msgstr "Sortera familjehändelser för personen"
 
 #: ../gramps/plugins/tool/testcasegenerator.py:91
 msgid "Generate_Testcases_for_Persons_and_Families"
-msgstr "Skapa för personer och familjer"
+msgstr "Skapa testfall för personer och familjer"
 
 #: ../gramps/plugins/tool/testcasegenerator.py:274
 #: ../gramps/plugins/tool/testcasegenerator.py:280
@@ -33467,11 +33221,11 @@ msgstr ""
 
 #: ../gramps/plugins/tool/testcasegenerator.py:290
 msgid "Generate database errors"
-msgstr "Skapa datafel"
+msgstr "Skapa databasfel"
 
 #: ../gramps/plugins/tool/testcasegenerator.py:294
 msgid "Generate dummy data"
-msgstr "Skapad konstgjorda data"
+msgstr "Skapa nonsensdata"
 
 #: ../gramps/plugins/tool/testcasegenerator.py:299
 msgid "Generate long names"
@@ -33495,7 +33249,7 @@ msgid ""
 "(Number is approximate because families are generated)"
 msgstr ""
 "Antal personer att skapa\n"
-"(Antal är ungefärligt, ty familjer skapas)"
+"(Antal är ungefärligt på grund av att familjer skapas)"
 
 #: ../gramps/plugins/tool/testcasegenerator.py:375
 #: ../gramps/plugins/tool/testcasegenerator.py:385
@@ -33513,7 +33267,7 @@ msgstr "Skapar databasfel"
 
 #: ../gramps/plugins/tool/testcasegenerator.py:392
 msgid "Generating families"
-msgstr "Skapa familjer"
+msgstr "Skapar familjer"
 
 #. Create a family, that links to father and mother, but father does not
 #. link back
@@ -33590,7 +33344,7 @@ msgstr "Normera stor bokstav för efternamn"
 #: ../gramps/plugins/tool/tools.gpr.py:39
 msgid ""
 "Searches the entire database and attempts to fix capitalization of the names."
-msgstr "Söker i hela databasen och försöker rätta stor bokstav för efternamn."
+msgstr "Söker i hela databasen och försöker rätta stor bokstav för namnen."
 
 #: ../gramps/plugins/tool/tools.gpr.py:61
 msgid "Rename Event Types"
@@ -33598,28 +33352,28 @@ msgstr "Ändra namn på händelsetyper"
 
 #: ../gramps/plugins/tool/tools.gpr.py:62
 msgid "Allows all the events of a certain name to be renamed to a new name."
-msgstr "Ge alla händelser med ett speciellt namn ett nytt namn."
+msgstr "Tillåter alla händelser med ett speciellt namn att få ett nytt namn."
 
 #: ../gramps/plugins/tool/tools.gpr.py:84
 msgid "Check and Repair Database"
-msgstr "Kontrollera och reparera"
+msgstr "Kontrollera och reparera databasen"
 
 #: ../gramps/plugins/tool/tools.gpr.py:85
 msgid ""
 "Checks the database for integrity problems, fixing the problems that it can"
-msgstr "Kontrollerar databasen för interna fel och lagar dessa om möjligt."
+msgstr "Kontrollerar databasen för integritetsfel och lagar dessa om möjligt"
 
 #: ../gramps/plugins/tool/tools.gpr.py:107
 msgid "Compare Individual Events"
-msgstr "Jämför personliga händelser"
+msgstr "Jämför individuella händelser"
 
 #: ../gramps/plugins/tool/tools.gpr.py:108
 msgid ""
 "Aids in the analysis of data by allowing the development of custom filters "
 "that can be applied to the database to find similar events"
 msgstr ""
-"Hjälper vid analys av data genom att man kan tillåta utveckling av anpassade "
-"filter, som kan användas mot databasen, för att hitta liknande händelser."
+"Hjälper vid analys av data genom att tillåta utveckling av anpassade filter, "
+"som kan användas mot databasen för att hitta liknande händelser"
 
 #: ../gramps/plugins/tool/tools.gpr.py:132
 msgid "Extracts event descriptions from the event data"
@@ -33629,11 +33383,11 @@ msgstr "Hämtar händelsebeskrivningar från händelsedata"
 msgid ""
 "Searches the entire database, looking for individual entries that may "
 "represent the same person."
-msgstr "Söker hela databasen efter individer som kan vara samma person."
+msgstr "Söker i hela databasen efter individer som kan vara samma person."
 
 #: ../gramps/plugins/tool/tools.gpr.py:177
 msgid "Manages batch operations on media files"
-msgstr "Hanterar omgångsvisa åtgärder på mediafiler."
+msgstr "Hanterar batch-operationer på mediafiler"
 
 #: ../gramps/plugins/tool/tools.gpr.py:198
 msgid "Not Related"
@@ -33641,7 +33395,7 @@ msgstr "Ej släkt"
 
 #: ../gramps/plugins/tool/tools.gpr.py:199
 msgid "Find people who are not in any way related to the selected person"
-msgstr "Hitta personer, som inte på något sätt är släkt med den valda personen"
+msgstr "Hitta personer som inte på något sätt är släkt med den valda personen"
 
 #: ../gramps/plugins/tool/tools.gpr.py:221
 msgid "Edit Database Owner Information"
@@ -33660,8 +33414,8 @@ msgid ""
 "Extract titles, prefixes and compound surnames from given name or family "
 "name."
 msgstr ""
-"Plockar ut titlar, prefix och sammansatta efternamn från dopnamn och "
-"släktnamn:"
+"Extraherar titlar, prefix och sammansatta efternamn från förnamn eller "
+"släktnamn."
 
 #: ../gramps/plugins/tool/tools.gpr.py:265
 msgid "Rebuild Secondary Indexes"
@@ -33669,23 +33423,23 @@ msgstr "Rekonstruera sekundärindex"
 
 #: ../gramps/plugins/tool/tools.gpr.py:266
 msgid "Rebuilds secondary indexes"
-msgstr "Rekonstruerar sekundärindex."
+msgstr "Rekonstruerar sekundärindex"
 
 #: ../gramps/plugins/tool/tools.gpr.py:287
 msgid "Rebuild Reference Maps"
-msgstr "Bygg om referenskartor"
+msgstr "Rekonstruera referenskartor"
 
 #: ../gramps/plugins/tool/tools.gpr.py:288
 msgid "Rebuilds reference maps"
-msgstr "Bygger om referenskartor."
+msgstr "Rekonstruerar referenskartor"
 
 #: ../gramps/plugins/tool/tools.gpr.py:309
 msgid "Rebuild Gender Statistics"
-msgstr "Återskapa könsstatistik"
+msgstr "Rekonstruera könsstatistik"
 
 #: ../gramps/plugins/tool/tools.gpr.py:310
 msgid "Rebuilds gender statistics for name gender guessing..."
-msgstr "Återskapa könsstatistik för namn för gissning på kön..."
+msgstr "Rekonstruerar könsstatistik för att gissa kön utifrån namnet..."
 
 #: ../gramps/plugins/tool/tools.gpr.py:331
 msgid "Relationship Calculator"
@@ -33693,7 +33447,7 @@ msgstr "Släktskapsberäknare"
 
 #: ../gramps/plugins/tool/tools.gpr.py:332
 msgid "Calculates the relationship between two people"
-msgstr "Beräknar släktskap mellan två personer."
+msgstr "Beräknar släktskap mellan två personer"
 
 #: ../gramps/plugins/tool/tools.gpr.py:353
 msgid "Remove Unused Objects"
@@ -33701,11 +33455,11 @@ msgstr "Ta bort oanvända objekt"
 
 #: ../gramps/plugins/tool/tools.gpr.py:354
 msgid "Removes unused objects from the database"
-msgstr "Tar bort oanvända objekt från databasen."
+msgstr "Tar bort oanvända objekt från databasen"
 
 #: ../gramps/plugins/tool/tools.gpr.py:376
 msgid "Reorders the Gramps IDs according to Gramps' default rules."
-msgstr "Sorterar Gramps-ID efter Gramps standardregler."
+msgstr "Sorterar om Gramps-ID:n efter Gramps standardregler."
 
 #: ../gramps/plugins/tool/tools.gpr.py:398
 #: ../gramps/plugins/tool/tools.gpr.py:399
@@ -33718,29 +33472,27 @@ msgstr "Verifiera data"
 
 #: ../gramps/plugins/tool/tools.gpr.py:421
 msgid "Verifies the data against user-defined tests"
-msgstr "Verifiera data gentemot användardefinierade tester."
+msgstr "Verifiera data gentemot användardefinierade tester"
 
 #: ../gramps/plugins/tool/tools.gpr.py:443
 msgid ""
 "Searches the entire database, looking for citations that have the same "
 "Volume/Page, Date and Confidence."
 msgstr ""
-"Söker hela databasen efter citeringar som har samma Volym/sida, datum och "
+"Söker i hela databasen efter citeringar som har samma Volym/sida, datum och "
 "tillförlitlighet."
 
 #: ../gramps/plugins/tool/tools.gpr.py:466
-#, fuzzy
 msgid "Searches the entire database, looking for a possible loop."
-msgstr "Söker hela databasen efter individer som kan vara samma person."
+msgstr "Söker i hela databasen efter möjliga slingor."
 
 #: ../gramps/plugins/tool/toolsdebug.gpr.py:64
-#, fuzzy
 msgid "Dump Gender Statistics"
-msgstr "Återskapa könsstatistik"
+msgstr "Framställer könsstatistik"
 
 #: ../gramps/plugins/tool/toolsdebug.gpr.py:65
 msgid "Will dump the statistics for guessing the gender from the first name."
-msgstr ""
+msgstr "Kommer att framställa statistik för att gissa könet från förnamnet."
 
 #: ../gramps/plugins/tool/verify.glade:215
 msgid "Maximum _age"
@@ -33760,7 +33512,7 @@ msgstr "Maximalt antal _makar för en person"
 
 #: ../gramps/plugins/tool/verify.glade:323
 msgid "Maximum number of consecutive years of _widowhood before next marriage"
-msgstr "Maximalt antal år av _änkestånd innan nästa giftermål"
+msgstr "Maximalt antal sammanhängande år av _änkestånd innan nästa giftermål"
 
 #: ../gramps/plugins/tool/verify.glade:338
 msgid "Maximum age for an _unmarried person"
@@ -33768,7 +33520,7 @@ msgstr "Maximiålder för en ogi_ft person"
 
 #: ../gramps/plugins/tool/verify.glade:361
 msgid "_Estimate missing or inexact dates"
-msgstr "_Gör uppskattning för saknade eller oprecica datum"
+msgstr "_Gör uppskattning för saknade eller oprecisa datum"
 
 #: ../gramps/plugins/tool/verify.glade:378
 msgid "_Identify invalid dates"
@@ -33817,17 +33569,17 @@ msgstr "Verifiera data"
 
 #: ../gramps/plugins/tool/verify.py:295
 msgid "Data Verify tool"
-msgstr "Verktyg för databasverifiering"
+msgstr "Verktyg för dataverifiering"
 
 #. translators: needed for French+Arabic, ignore otherwise
 #: ../gramps/plugins/tool/verify.py:318
 #, python-format
 msgid "%(severity)s: %(msg)s, %(type)s: %(gid)s, %(name)s"
-msgstr ""
+msgstr "%(severity)s: %(msg)s, %(type)s: %(gid)s, %(name)s"
 
 #: ../gramps/plugins/tool/verify.py:499
 msgid "Data Verification Results"
-msgstr "Resultat av databasverifiering"
+msgstr "Resultat av dataverifiering"
 
 #: ../gramps/plugins/tool/verify.py:660
 msgid "_Show all"
@@ -33839,7 +33591,7 @@ msgstr "Dop före födelse"
 
 #: ../gramps/plugins/tool/verify.py:957
 msgid "Death before baptism"
-msgstr "Död före födelse"
+msgstr "Död före dop"
 
 #: ../gramps/plugins/tool/verify.py:973
 msgid "Burial before birth"
@@ -33955,7 +33707,7 @@ msgstr "Stora åldersskillnader mellan barn"
 
 #: ../gramps/plugins/tool/verify.py:1680
 msgid "Disconnected individual"
-msgstr "Isolerad person"
+msgstr "Släktlös person"
 
 #: ../gramps/plugins/tool/verify.py:1707
 msgid "Invalid birth date"
@@ -33989,7 +33741,7 @@ msgstr "Källa: Författare"
 #: ../gramps/plugins/view/citationlistview.py:108
 #: ../gramps/plugins/view/citationtreeview.py:101
 msgid "Source: Abbreviation"
-msgstr "Källa:Förkortning"
+msgstr "Källa: Förkortning"
 
 #: ../gramps/plugins/view/citationlistview.py:109
 #: ../gramps/plugins/view/citationtreeview.py:102
@@ -34020,7 +33772,7 @@ msgstr "Radera den valda citeringen"
 
 #: ../gramps/plugins/view/citationlistview.py:129
 msgid "Merge the selected citations"
-msgstr "Slå ihop del valda citeringarna"
+msgstr "Slå ihop de valda citeringarna"
 
 #: ../gramps/plugins/view/citationlistview.py:143
 msgid "Citation View"
@@ -34040,9 +33792,10 @@ msgid ""
 "To edit this citation, you need to close the object."
 msgstr ""
 "Den här citeringen kan inte redigeras just nu. Antingen redigeras den "
-"associerade citeringen eller en annan referens till samma citering.\n"
+"associerade citeringen eller ett annat objekt som är associerat till samma "
+"citering.\n"
 "\n"
-"För att redigera den här citering, måste du stänga objektet."
+"För att redigera den här citeringen, måste du stänga objektet."
 
 #: ../gramps/plugins/view/citationlistview.py:311
 #: ../gramps/plugins/view/citationlistview.py:322
@@ -34069,12 +33822,12 @@ msgid ""
 "you want to merge these two citations, then you must merge the sources first."
 msgstr ""
 "De två valda citeringarna måste ha samma källa för att kunna göra en "
-"sammanslagning. Om du vill slå samman dessa två citeringar, så måstre du slå "
-"samma källorna först."
+"sammanslagning. Om du vill slå samman dessa två citeringar, så måste du slå "
+"samman källorna först."
 
 #: ../gramps/plugins/view/citationtreeview.py:124
 msgid "Edit the selected citation or source"
-msgstr "Redigera den valda citeringen alle källan"
+msgstr "Redigera den valda citeringen eller källan"
 
 #: ../gramps/plugins/view/citationtreeview.py:125
 msgid "Delete the selected citation or source"
@@ -34116,10 +33869,10 @@ msgid ""
 "\n"
 "To edit this source, you need to close the object."
 msgstr ""
-"Den här källa kan inte redigeras just nu. Antingen redigeras den associerade "
-"källan eller en annan citering associerad med samma källa.\n"
+"Den här källan kan inte redigeras just nu. Antingen redigeras den "
+"associerade källan eller en annan citering associerad med samma källa.\n"
 "\n"
-"För att redigera den här källa, måste du objektet."
+"För att redigera den här källan, måste du stänga objektet."
 
 #: ../gramps/plugins/view/citationtreeview.py:554
 msgid "Cannot perform merge."
@@ -34238,12 +33991,10 @@ msgid "Print or save the Fan Chart View"
 msgstr "Skriv ut eller spara cirkeldiagram"
 
 #: ../gramps/plugins/view/fanchart2wayview.py:295
-#, fuzzy
 msgid "Max ancestor generations"
 msgstr "Maximalt antal förfadersgenerationer"
 
 #: ../gramps/plugins/view/fanchart2wayview.py:298
-#, fuzzy
 msgid "Max descendant generations"
 msgstr "Maximalt antal ättlingsgenerationer"
 
@@ -34275,7 +34026,7 @@ msgstr "Åldersrelaterad (0-100) gradient"
 #: ../gramps/plugins/view/fanchartdescview.py:307
 #: ../gramps/plugins/view/fanchartview.py:303
 msgid "Single main (filter) color"
-msgstr "En huvudfilter färg"
+msgstr "Enhetlig huvud (filter) färg"
 
 #: ../gramps/plugins/view/fanchart2wayview.py:311
 #: ../gramps/plugins/view/fanchartdescview.py:308
@@ -34287,7 +34038,7 @@ msgstr "Tidsperiodsrelaterad gradient"
 #: ../gramps/plugins/view/fanchartdescview.py:309
 #: ../gramps/plugins/view/fanchartview.py:305
 msgid "White"
-msgstr "Vitt"
+msgstr "Vit"
 
 #: ../gramps/plugins/view/fanchart2wayview.py:313
 #: ../gramps/plugins/view/fanchartdescview.py:310
@@ -34305,11 +34056,11 @@ msgstr "Färgschema enligt klassisk vy"
 #: ../gramps/plugins/view/fanchartdescview.py:320
 #: ../gramps/plugins/view/fanchartview.py:316
 msgid "Background"
-msgstr "Bakgrundsfärg"
+msgstr "Bakgrund"
 
 #: ../gramps/plugins/view/fanchart2wayview.py:332
 msgid "Add global background colored gradient"
-msgstr ""
+msgstr "Lägg till global bakgrund som färgad gradient"
 
 #. colors, stored as hex values
 #: ../gramps/plugins/view/fanchart2wayview.py:336
@@ -34343,20 +34094,19 @@ msgstr "Jämn fördelning av barn"
 #: ../gramps/plugins/view/fanchart2wayview.py:348
 #: ../gramps/plugins/view/fanchartdescview.py:346
 msgid "Size  proportional to number of descendants"
-msgstr "Storlek proportionell mot antal ättlingar"
+msgstr "Storleken proportionell till antalet ättlingar"
 
 #: ../gramps/plugins/view/fanchart2wayview.py:354
 #: ../gramps/plugins/view/fanchartdescview.py:352
 #: ../gramps/plugins/view/fanchartview.py:335
-#, fuzzy
 msgid "Show names on two lines"
-msgstr "Visa familjenoder"
+msgstr "Visa namn på två rader"
 
 #: ../gramps/plugins/view/fanchart2wayview.py:359
 #: ../gramps/plugins/view/fanchartdescview.py:357
 #: ../gramps/plugins/view/fanchartview.py:340
 msgid "Flip name on the left of the fan"
-msgstr ""
+msgstr "Vänd namnet på vänster sida om cirkeldiagrammet"
 
 #. options we don't show on the dialog
 #. #configdialog.add_checkbox(table,
@@ -34374,7 +34124,7 @@ msgstr "Layout"
 #: ../gramps/plugins/view/fanchartdescview.py:549
 #: ../gramps/plugins/view/fanchartview.py:556
 msgid "No preview available"
-msgstr "Ingen förhandsgranskning är tillgänglig."
+msgstr "Ingen förhandsgranskning är tillgänglig"
 
 #. form of the fan
 #: ../gramps/plugins/view/fanchartdescview.py:334
@@ -34385,7 +34135,7 @@ msgstr "Typ av cirkeldiagram"
 #: ../gramps/plugins/view/fanchartdescview.py:336
 #: ../gramps/plugins/view/fanchartview.py:329
 msgid "Full Circle"
-msgstr "Hel cirkel"
+msgstr "Helcirkel"
 
 #: ../gramps/plugins/view/fanchartdescview.py:337
 #: ../gramps/plugins/view/fanchartview.py:329
@@ -34433,8 +34183,8 @@ msgid ""
 "Go to the person view and select the people you want to compare. Return to "
 "this view and use the history."
 msgstr ""
-"Gå till person vyn och välj de personer du vill jämföra. Återvänd till denna "
-"vy och använd historien."
+"Gå till personvyn och välj de personer du vill jämföra. Återvänd till denna "
+"vy och använd historiken."
 
 #: ../gramps/plugins/view/geoclose.py:299
 msgid "reference _Person"
@@ -34442,7 +34192,7 @@ msgstr "referens_person"
 
 #: ../gramps/plugins/view/geoclose.py:300
 msgid "Select the person which is the reference for life ways"
-msgstr "Välj den person, vilken blir referensen för levnadsvägar"
+msgstr "Välj den person som är referens för levnadsvägar"
 
 #: ../gramps/plugins/view/geoclose.py:315
 msgid "Select the person which will be our reference."
@@ -34470,9 +34220,9 @@ msgid ""
 "The value 1 means about 4.6 miles or 7.5 kms.\n"
 "The value is in tenth of degree."
 msgstr ""
-"Sannolikheten för möteszonsradien.\n"
+"Sannolikheten för mötesområdesradien.\n"
 "Den färgade sonen är ungefärlig.\n"
-"Mötsezonen visas bara för referenspersonen.\n"
+"Mötsesområdet visas bara för referenspersonen.\n"
 "Värdet 9 innebär ca 42 miles eller 67 km.\n"
 "Värdet 1 innebär ca 4.6 miles eller 7.5 km.\n"
 "Värdet är i tiondels grad."
@@ -34496,9 +34246,8 @@ msgstr "ofullständig eller orefererad händelse?"
 
 #: ../gramps/plugins/view/geoevents.py:297
 #: ../gramps/plugins/view/geoevents.py:310
-#, fuzzy
 msgid "Selecting all events"
-msgstr "Välj föräldrar"
+msgstr "Välj alla händelser"
 
 #: ../gramps/plugins/view/geoevents.py:355
 #: ../gramps/plugins/view/geoevents.py:387
@@ -34519,7 +34268,7 @@ msgstr "Centrera på plats"
 #: ../gramps/plugins/view/geofamclose.py:143
 #: ../gramps/plugins/view/geography.gpr.py:141
 msgid "Have these two families been able to meet?"
-msgstr "Har dessa två familjer kunnat mötas?"
+msgstr "Har dessa två familjer haft möjlighet att mötas?"
 
 #: ../gramps/plugins/view/geofamclose.py:174
 msgid "GeoFamClose"
@@ -34552,7 +34301,7 @@ msgid ""
 "this view and use the history."
 msgstr ""
 "Gå till familjevyn och välj de familjer du vill jämföra. Återvänd till denna "
-"vy och använd historien."
+"vy och använd historiken."
 
 #: ../gramps/plugins/view/geofamclose.py:295
 msgid "reference _Family"
@@ -34560,7 +34309,7 @@ msgstr "referens _Familj"
 
 #: ../gramps/plugins/view/geofamclose.py:296
 msgid "Select the family which is the reference for life ways"
-msgstr "Välj den familj, som är referens för levnadsvägar"
+msgstr "Välj den familj som är referens för levnadsvägar"
 
 #: ../gramps/plugins/view/geofamclose.py:611
 #: ../gramps/plugins/view/geofamily.py:347
@@ -34584,7 +34333,7 @@ msgstr "Barn : %(id)s - %(index)d : %(name)s"
 #: ../gramps/plugins/view/geofamily.py:377
 #, python-format
 msgid "Person : %(id)s %(name)s has no family."
-msgstr "Person : %(id)s %(name)s har ingen familj"
+msgstr "Person : %(id)s %(name)s har ingen familj."
 
 #: ../gramps/plugins/view/geofamclose.py:761
 msgid "Choose and bookmark the new reference family"
@@ -34599,9 +34348,9 @@ msgid ""
 "The value 1 means about 4.6 miles or 7.5 kms.\n"
 "The value is in tenth of degree."
 msgstr ""
-"Sannolikheten för möteszonsradien.\n"
+"Sannolikheten för mötesområdesradien.\n"
 "Den färgade sonen är ungefärlig.\n"
-"Mötsezonen visas bara för referensfamiljen.\n"
+"Mötsesområdet visas bara för referensfamiljen.\n"
 "Värdet 9 innebär ca 42 miles eller 67 km.\n"
 "Värdet 1 innebär ca 4.6 miles eller 7.5 km.\n"
 "Värdet är i tiondels grad."
@@ -34621,7 +34370,7 @@ msgstr "Familjeplatser för %s"
 
 #: ../gramps/plugins/view/geography.gpr.py:71
 msgid "OsmGpsMap module not loaded."
-msgstr "OsmGpsMap-modul ej laddad"
+msgstr "OsmGpsMap-modul ej laddad."
 
 #: ../gramps/plugins/view/geography.gpr.py:72
 #, python-format
@@ -34629,17 +34378,16 @@ msgid ""
 "Geography functionality will not be available.\n"
 "To build it for Gramps see %(gramps_wiki_build_osmgps_url)s"
 msgstr ""
-"Geografi-funktionalitet kommer aj att vara tillgängligt.\n"
+"Geografi-funktionalitet kommer ej att vara tillgänglig.\n"
 "För att åstadkomma det för Gramps se %(gramps_wiki_build_osmgps_url)s"
 
 #: ../gramps/plugins/view/geography.gpr.py:86
 msgid "All known places for one Person"
-msgstr "Samtliga platser med för en person"
+msgstr "Alla kända platser för en person"
 
 #: ../gramps/plugins/view/geography.gpr.py:87
 msgid "A view showing the places visited by one person during his life."
-msgstr ""
-"En vy, som tillåter dig att se platser, besökta av en person under dess liv."
+msgstr "En vy som visar platser besökta av en person under dess liv."
 
 #: ../gramps/plugins/view/geography.gpr.py:95
 #: ../gramps/plugins/view/geography.gpr.py:112
@@ -34653,17 +34401,15 @@ msgstr "Geografi"
 
 #: ../gramps/plugins/view/geography.gpr.py:103
 msgid "All known places for one Family"
-msgstr "Samtliga platser för en familj"
+msgstr "Alla kända platser för en familj"
 
 #: ../gramps/plugins/view/geography.gpr.py:104
 msgid "A view showing the places visited by one family during all their life."
-msgstr ""
-"En vy, som tillåter dig att se alla platser besökta av en familj under dess "
-"levnad."
+msgstr "En vy som visar platser besökta av en familj under dess levnad."
 
 #: ../gramps/plugins/view/geography.gpr.py:120
 msgid "Every residence or move for a person and any descendants"
-msgstr "Alla förflyttningar för en person och dess ättlingar"
+msgstr "Alla boenden eller förflyttningar för en person och dess ättlingar"
 
 #: ../gramps/plugins/view/geography.gpr.py:122
 msgid ""
@@ -34671,7 +34417,7 @@ msgid ""
 "This is for a person and any descendant.\n"
 "You can see the dates corresponding to the period."
 msgstr ""
-"En vy, som visar alla de platser besökta av alla personer under livet.\n"
+"En vy som visar alla platser besökta av alla personer under livet.\n"
 "Detta är för en person och dess ättlingar.\n"
 "Du kan se datum motsvarande för perioden."
 
@@ -34680,16 +34426,16 @@ msgid ""
 "A view showing the places visited by all family's members during their life: "
 "have these two people been able to meet?"
 msgstr ""
-"En vy, som tillåter dig att se alla platser besökta av alla familjemedlemmar "
-"under dess levnad: har de haft chansen att mötas?"
+"En vy som visar platser besökta av alla familjemedlemmar under deras levnad: "
+"har dessa två personer haft möjlighet att mötas?"
 
 #: ../gramps/plugins/view/geography.gpr.py:160
 msgid ""
 "A view showing the places visited by two persons during their life: have "
 "these two people been able to meet?"
 msgstr ""
-"En vy, som tillåter dig att se platser, besökta av två personer under dess "
-"liv: har dessa två personer haft chansen att mötas?"
+"En vy som visar platser besökta av två personer under deras liv: har dessa "
+"två personer haft möjlighet att mötas?"
 
 #: ../gramps/plugins/view/geography.gpr.py:177
 msgid "All known Places"
@@ -34697,7 +34443,7 @@ msgstr "Alla kända platser"
 
 #: ../gramps/plugins/view/geography.gpr.py:178
 msgid "A view showing all places of the database."
-msgstr "En vy, som tillåter dig att se alla platser i databasen."
+msgstr "En vy som visar alla platser i databasen."
 
 #: ../gramps/plugins/view/geography.gpr.py:193
 msgid "All places related to Events"
@@ -34705,7 +34451,7 @@ msgstr "Samtliga platser kopplade till händelser"
 
 #: ../gramps/plugins/view/geography.gpr.py:194
 msgid "A view showing all the event places of the database."
-msgstr "En vy, som tillåter dig att se alla händelser i databasen."
+msgstr "En vy som visar alla platser för händelser i databasen."
 
 #: ../gramps/plugins/view/geomoves.py:142
 msgid "Descendance of the active person."
@@ -34759,14 +34505,14 @@ msgstr "Animeringshastighet i millisekunder (stort värde innebär långsammare)
 
 #: ../gramps/plugins/view/geoperson.py:550
 msgid "How many steps between two markers when we are on large move ?"
-msgstr "Antal steg mellan två markering, när det gäller långa förflyttningar?"
+msgstr "Antal steg mellan två markeringar när det gäller långa förflyttningar?"
 
 #: ../gramps/plugins/view/geoperson.py:557
 msgid ""
 "The minimum latitude/longitude to select large move.\n"
 "The value is in tenth of degree."
 msgstr ""
-"Det minsta latitud/longitud för att välja lång förflyttning.\n"
+"Den minsta latitud/longitud för att välja lång förflyttning.\n"
 "Värdet är i tiondels grad."
 
 #: ../gramps/plugins/view/geoperson.py:564
@@ -34783,9 +34529,8 @@ msgstr "GeoPlatser"
 
 #: ../gramps/plugins/view/geoplaces.py:348
 #: ../gramps/plugins/view/geoplaces.py:361
-#, fuzzy
 msgid "Selecting all places"
-msgstr "Väljer personer"
+msgstr "Väljer alla platser"
 
 #: ../gramps/plugins/view/geoplaces.py:373
 msgid ""
@@ -34793,6 +34538,9 @@ msgid ""
 "with coordinates. You can change the markers color depending on place type. "
 "You can use filtering."
 msgstr ""
+"Högerklicka på kartan och välj 'visa alla platser' för att visa alla kända "
+"platser med koordinater. Du kan ändra markeringarnas färg beroende på "
+"platstyp. Du kan använda filtrering."
 
 #: ../gramps/plugins/view/geoplaces.py:386
 msgid ""
@@ -34800,6 +34548,10 @@ msgid ""
 "with coordinates. You can use the history to navigate on the map. You can "
 "change the markers color depending on place type. You can use filtering."
 msgstr ""
+"Högerklicka på kartan och välj 'visa alla platser' för att visa alla kända "
+"platser med koordinater. Du kan använda historiken för att navigera på "
+"kartan. Du kan ändra markeringarnas färg beroende på platstyp. Du kan "
+"använda filtrering."
 
 #: ../gramps/plugins/view/geoplaces.py:401
 msgid "The place name in the status bar is disabled."
@@ -34812,7 +34564,7 @@ msgstr "Maximalt antal platser är uppnått (%d)."
 
 #: ../gramps/plugins/view/geoplaces.py:409
 msgid "Some information are missing."
-msgstr "Viss in formation saknas."
+msgstr "Viss information saknas."
 
 #: ../gramps/plugins/view/geoplaces.py:411
 msgid "Please, use filtering to reduce this number."
@@ -34820,7 +34572,7 @@ msgstr "Använd filter för att minska antalet."
 
 #: ../gramps/plugins/view/geoplaces.py:413
 msgid "You can modify this value in the geography option."
-msgstr "Du kan ändra detta värde i geografivalmöjligheter"
+msgstr "Du kan ändra detta värde i geografialternativen."
 
 #: ../gramps/plugins/view/geoplaces.py:415
 msgid "In this case, it may take time to show all markers."
@@ -34836,9 +34588,8 @@ msgid "Show all places"
 msgstr "Visa alla platser"
 
 #: ../gramps/plugins/view/geoplaces.py:596
-#, fuzzy
 msgid "The places marker color"
-msgstr "Har markering som"
+msgstr "Markeringsfärg för platser"
 
 #: ../gramps/plugins/view/mediaview.py:113
 msgid "Edit the selected media object"
@@ -34850,7 +34601,7 @@ msgstr "Radera det valda mediaobjektet"
 
 #: ../gramps/plugins/view/mediaview.py:115
 msgid "Merge the selected media objects"
-msgstr "Slå ihop de valda mediaobjekteten"
+msgstr "Slå ihop de valda mediaobjekten"
 
 #: ../gramps/plugins/view/mediaview.py:209
 msgid "Media Filter Editor"
@@ -34862,7 +34613,7 @@ msgstr "Visa i standardvisaren"
 
 #: ../gramps/plugins/view/mediaview.py:216
 msgid "Open the folder containing the media file"
-msgstr "Öppnar den mapp, som innehåller mediafil"
+msgstr "Öppnar den mapp som innehåller mediafilen"
 
 #: ../gramps/plugins/view/mediaview.py:350
 msgid "Cannot merge media objects."
@@ -34876,7 +34627,7 @@ msgid ""
 msgstr ""
 "Exakt två mediaobjekt måste vara valda för att kunna slås ihop. Ett andra "
 "objekt kan väljas genom att hålla ned ctrl-tangenten medan man klickar på "
-"den önskade objektet."
+"det önskade objektet."
 
 #: ../gramps/plugins/view/noteview.py:95
 msgid "Delete the selected note"
@@ -34905,11 +34656,11 @@ msgstr ""
 
 #: ../gramps/plugins/view/pedigreeview.py:80
 msgid "short for born|b."
-msgstr "född"
+msgstr "f."
 
 #: ../gramps/plugins/view/pedigreeview.py:81
 msgid "short for died|d."
-msgstr "död"
+msgstr "d."
 
 #: ../gramps/plugins/view/pedigreeview.py:82
 msgid "short for baptized|bap."
@@ -34982,9 +34733,8 @@ msgid "Show unknown people"
 msgstr "Visa okända personer"
 
 #: ../gramps/plugins/view/pedigreeview.py:2032
-#, fuzzy
 msgid "Show tags"
-msgstr "Visa bilder"
+msgstr "Visa flaggor"
 
 #: ../gramps/plugins/view/pedigreeview.py:2035
 msgid "Tree style"
@@ -35028,11 +34778,11 @@ msgstr "Hierarkisk platsvy"
 
 #: ../gramps/plugins/view/placetreeview.py:70
 msgid "Expand this Entire Group"
-msgstr "Expandera denna totala grupp"
+msgstr "Expandera hela denna grupp"
 
 #: ../gramps/plugins/view/placetreeview.py:72
 msgid "Collapse this Entire Group"
-msgstr "Komprimera denna totala"
+msgstr "Komprimera hela denna grupp"
 
 #: ../gramps/plugins/view/relview.py:398
 msgid "_Reorder"
@@ -35048,7 +34798,7 @@ msgstr "Redigera..."
 
 #: ../gramps/plugins/view/relview.py:405
 msgid "Edit the active person"
-msgstr "Redigerar den aktiva personen"
+msgstr "Redigera den aktiva personen"
 
 #: ../gramps/plugins/view/relview.py:407 ../gramps/plugins/view/relview.py:409
 #: ../gramps/plugins/view/relview.py:805
@@ -35062,12 +34812,12 @@ msgstr "Lägg till partner..."
 #: ../gramps/plugins/view/relview.py:411 ../gramps/plugins/view/relview.py:413
 #: ../gramps/plugins/view/relview.py:799
 msgid "Add a new set of parents"
-msgstr "Lägger till ett nytt föräldrapar"
+msgstr "Lägg till ett nytt föräldrapar"
 
 #: ../gramps/plugins/view/relview.py:415 ../gramps/plugins/view/relview.py:419
 #: ../gramps/plugins/view/relview.py:800
 msgid "Add person as child to an existing family"
-msgstr "Lägg till personen som barn i en befintlig familjen"
+msgstr "Lägg till personen som barn i en befintlig familj"
 
 #: ../gramps/plugins/view/relview.py:418
 msgid "Add Existing Parents..."
@@ -35096,7 +34846,7 @@ msgstr "Ta bort personen som barn till dessa föräldrar"
 
 #: ../gramps/plugins/view/relview.py:809
 msgid "Remove person as parent in this family"
-msgstr "Ta bort personen som föräldrar i denna familj"
+msgstr "Ta bort personen som förälder i denna familj"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/view/relview.py:869 ../gramps/plugins/view/relview.py:923
@@ -35120,7 +34870,7 @@ msgstr " (ett syskon)"
 
 #: ../gramps/plugins/view/relview.py:882 ../gramps/plugins/view/relview.py:936
 msgid " (only child)"
-msgstr " (ett barn)"
+msgstr " (enda barn)"
 
 #: ../gramps/plugins/view/relview.py:948 ../gramps/plugins/view/relview.py:1430
 msgid "Add new child to family"
@@ -35167,7 +34917,7 @@ msgstr "Trasigt familjeband upptäckt"
 
 #: ../gramps/plugins/view/relview.py:1346
 msgid "Please run the Check and Repair Database tool"
-msgstr "Kör verktyget \"kontrollera och reparera\""
+msgstr "Kör verktyget Kontrollera och reparera databasen"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/view/relview.py:1369
@@ -35175,7 +34925,7 @@ msgstr "Kör verktyget \"kontrollera och reparera\""
 #, python-brace-format
 msgid " ({number_of} child)"
 msgid_plural " ({number_of} children)"
-msgstr[0] " ({number_of} barn"
+msgstr[0] " ({number_of} barn)"
 msgstr[1] " ({number_of} barn)"
 
 #: ../gramps/plugins/view/relview.py:1373
@@ -35193,7 +34943,7 @@ msgstr "Visa redigeringsknappar"
 
 #: ../gramps/plugins/view/relview.py:1680
 msgid "View links as website links"
-msgstr "Visa länkar som på en webb-sida"
+msgstr "Visa länkar som webbside-länkar"
 
 #: ../gramps/plugins/view/relview.py:1697
 msgid "Show Details"
@@ -35205,11 +34955,11 @@ msgstr "Visa syskon"
 
 #: ../gramps/plugins/view/repoview.py:88
 msgid "Home URL"
-msgstr "Hemsida URL"
+msgstr "Hemsida"
 
 #: ../gramps/plugins/view/repoview.py:96
 msgid "Search URL"
-msgstr "Söksida URL"
+msgstr "Webbadress för sökning"
 
 #: ../gramps/plugins/view/repoview.py:112
 msgid "Add a new repository"
@@ -35281,7 +35031,7 @@ msgstr "Vyn visar samtliga familjer"
 
 #: ../gramps/plugins/view/view.gpr.py:68
 msgid "The view showing Gramplets"
-msgstr "Vyn visaande Gramplet"
+msgstr "Översikt över Gramplets"
 
 #: ../gramps/plugins/view/view.gpr.py:83
 msgid "The view showing all the media objects"
@@ -35308,16 +35058,15 @@ msgstr "Diagram"
 
 #: ../gramps/plugins/view/view.gpr.py:145
 msgid "A view showing parents through a fanchart"
-msgstr "Vyn visar anor i form av ett cirkeldiagram"
+msgstr "En vy som visar föräldrar i form av ett cirkeldiagram"
 
 #: ../gramps/plugins/view/view.gpr.py:160
 msgid "Showing descendants through a fanchart"
-msgstr "Vyn visar ättlingar i form av ett cirkeldiagram"
+msgstr "Visar ättlingar i form av ett cirkeldiagram"
 
 #: ../gramps/plugins/view/view.gpr.py:175
-#, fuzzy
 msgid "Showing ascendants and descendants through a fanchart"
-msgstr "Vyn visar ättlingar i form av ett cirkeldiagram"
+msgstr "Visar anor och ättlingar i form av ett cirkeldiagram"
 
 #: ../gramps/plugins/view/view.gpr.py:188
 msgid "Grouped People"
@@ -35325,11 +35074,11 @@ msgstr "Grupperade personer"
 
 #: ../gramps/plugins/view/view.gpr.py:189
 msgid "The view showing all people in the Family Tree grouped per family name"
-msgstr "Vyn visar alla personer i släktträdet grupperat på efternamn"
+msgstr "Vyn visar alla personer i släktträdet grupperade på efternamn"
 
 #: ../gramps/plugins/view/view.gpr.py:206
 msgid "The view showing all people in the Family Tree in a flat list"
-msgstr "Vyn visar samtliga personer i släktträdet i en rak lista"
+msgstr "Vyn visar alla personer i släktträdet i en rak lista"
 
 #: ../gramps/plugins/view/view.gpr.py:222
 msgid "The view showing all the places of the Family Tree"
@@ -35341,11 +35090,11 @@ msgstr "Hierarkisk platsvy"
 
 #: ../gramps/plugins/view/view.gpr.py:237
 msgid "A view displaying places in a tree format."
-msgstr "En vy, som visar platser i en trädformad struktur."
+msgstr "En vy som visar platser i en trädformad struktur."
 
 #: ../gramps/plugins/view/view.gpr.py:253
 msgid "The view showing all the repositories"
-msgstr "Vyn visar all arkivplatser"
+msgstr "Vyn visar alla arkivplatser"
 
 #: ../gramps/plugins/view/view.gpr.py:268
 msgid "The view showing all the sources"
@@ -35353,7 +35102,7 @@ msgstr "Vyn visar alla källor"
 
 #: ../gramps/plugins/view/view.gpr.py:284
 msgid "The view showing all the citations"
-msgstr "Vyn visar samtliga citeringar"
+msgstr "Vyn visar alla citeringar"
 
 #: ../gramps/plugins/view/view.gpr.py:298
 msgid "Citation Tree"
@@ -35361,7 +35110,7 @@ msgstr "Hierarkisk citeringsvy"
 
 #: ../gramps/plugins/view/view.gpr.py:299
 msgid "A view displaying citations and sources in a tree format."
-msgstr "En vy, som visar citeringar och källor i en trädformad struktur."
+msgstr "En vy som visar citeringar och källor i en trädformad struktur."
 
 #. Add xml, doctype, meta and stylesheets
 #: ../gramps/plugins/webreport/addressbook.py:87
@@ -35381,7 +35130,7 @@ msgid ""
 "Address Book page."
 msgstr ""
 "Denna sida är en förteckning över alla personer i databasen, sorterade på "
-"efternamn med länkar till en av följande: adress, bostad eller hemsida.  Val "
+"efternamn med länkar till en av följande: adress, bostad eller hemsida. Val "
 "av personens namn tar dig till den personens adressboks individuella sida."
 
 #: ../gramps/plugins/webreport/addressbooklist.py:111
@@ -35419,7 +35168,7 @@ msgstr "Senast ändrat %(date)s"
 #: ../gramps/plugins/webreport/basepage.py:1299
 #, python-format
 msgid " on %(date)s"
-msgstr " vid %(date)s"
+msgstr " den %(date)s"
 
 #: ../gramps/plugins/webreport/basepage.py:1320
 #: ../gramps/plugins/webreport/basepage.py:1325
@@ -35451,7 +35200,7 @@ msgstr "Hem"
 #: ../gramps/plugins/webreport/basepage.py:1628
 #: ../gramps/plugins/webreport/thumbnail.py:111
 msgid "Thumbnails"
-msgstr "Minatyrbild"
+msgstr "Minatyrbilder"
 
 #: ../gramps/plugins/webreport/basepage.py:1494
 #: ../gramps/plugins/webreport/basepage.py:1635
@@ -35505,12 +35254,12 @@ msgstr "Församling"
 
 #: ../gramps/plugins/webreport/basepage.py:2570
 msgid "Locations"
-msgstr "Lokaliseringar"
+msgstr "Platser"
 
 #: ../gramps/plugins/webreport/basepage.py:2781
 #, python-format
 msgid " (%s) "
-msgstr ""
+msgstr " (%s) "
 
 #: ../gramps/plugins/webreport/download.py:100
 msgid ""
@@ -35520,10 +35269,10 @@ msgid ""
 "download page and files have the same copyright as the remainder of these "
 "web pages."
 msgstr ""
-"Denna sida är till för användare/skapare av detta Släktträd/Hemsida till att "
+"Denna sida är till för användare/skapare av detta Släktträd/Hemsida för att "
 "dela några filer med dig angående sin familj. Om det finns några filer "
 "listade nedan, klicka på dem kommer att ge dig möjlighet att ladda ner dem. "
-"Nerladdningssidan och filer har samma copyright som resten av sidan."
+"Nerladdningssidan och filer har samma copyright som resten av webbsidan."
 
 #: ../gramps/plugins/webreport/download.py:126
 msgid "File Name"
@@ -35560,9 +35309,9 @@ msgid ""
 "their type and date (if one is present). Clicking on an event&#8217;s Gramps "
 "ID will open a page for that event."
 msgstr ""
-"Denna sida är en förteckning över alla händelser i databasen, sorterad efter "
-"typ, datum (om givet) samt Gramps-ID. Klickar du på en händelse Gramps-ID "
-"kommer en sida att laddas med denna typ av händelser."
+"Denna sida är en förteckning över alla händelser i databasen, sorterade "
+"efter typ, datum (om givet). Klickar du på en händelses Gramps-ID kommer en "
+"sida att laddas med denna händelse."
 
 #: ../gramps/plugins/webreport/event.py:173
 #: ../gramps/plugins/webreport/family.py:185
@@ -35574,7 +35323,7 @@ msgstr "Bokstav"
 #: ../gramps/plugins/webreport/event.py:245
 #, python-format
 msgid "Event types beginning with letter %s"
-msgstr "Händelsetyper börjande med bokstaven %s"
+msgstr "Händelsetyper som börjar med bokstaven %s"
 
 #: ../gramps/plugins/webreport/family.py:106
 msgid "Creating family pages..."
@@ -35588,8 +35337,8 @@ msgid ""
 "name will take you to their family/ relationship&#8217;s page."
 msgstr ""
 "Denna sida är en förteckning över alla familjer/släktskap i databasen, "
-"sorterad efter efternamn/förnamn. Klickar du på en person tar du dig till "
-"den familjen eller släktskapets sida."
+"sorterade efter släktnamn/efternamn. Klickar du på en person kommer sidan "
+"för personens familjer/släktskap att öppnas."
 
 #: ../gramps/plugins/webreport/family.py:231
 msgid "Families beginning with letter "
@@ -35611,36 +35360,34 @@ msgid ""
 "object&#8217;s page.  If you see media size dimensions above an image, click "
 "on the image to see the full sized version.  "
 msgstr ""
-"Denna sida är en förteckning över alla mediaobjekt i databasen, sorterad "
-"efter deras rubrik. Klickar du på en titel tar du dig till det "
-"mediaobjektets sida. Om du ser mediets storlek ovanför en bild, klicka på "
-"bilden så ser du den i full storlek."
+"Denna sida är en förteckning över alla mediaobjekt i databasen, sorterade "
+"efter deras titel. Klickar du på en titel kommer sidan med mediaobjektet att "
+"öppnas. Om du ser mediets storlek anges ovanför en bild, klicka på bilden så "
+"ser du den i full storlek.  "
 
 #: ../gramps/plugins/webreport/media.py:227
 msgid "Media | Name"
-msgstr " Namn"
+msgstr "Namn"
 
 #: ../gramps/plugins/webreport/media.py:230
 msgid "Mime Type"
 msgstr "Mimetyp"
 
 #: ../gramps/plugins/webreport/media.py:242
-#, fuzzy
 msgid "Creating list of media pages"
 msgstr "Skapar mediasidor"
 
 #: ../gramps/plugins/webreport/media.py:286
-#, fuzzy
 msgid "Below unused media objects"
-msgstr "Antal unika mediaobjekt"
+msgstr "Nedanför oanvända mediaobjekt"
 
 #: ../gramps/plugins/webreport/media.py:411
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "%(strong1_strt)s%(page_number)d%(strong_end)s of %(strong2_strt)s"
 "%(total_pages)d%(strong_end)s"
 msgstr ""
-"%(strong1_start)s%(page_number)d%(strong_end)s of %(strong2_start)s"
+"%(strong1_strt)s%(page_number)d%(strong_end)s av %(strong2_strt)s"
 "%(total_pages)d%(strong_end)s"
 
 #. missing media error message
@@ -35659,7 +35406,7 @@ msgstr "Mediaobjekt saknas:"
 #: ../gramps/plugins/webreport/narrativeweb.py:270
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
-msgstr "Varken %(current)s eller %(parent)s är mappar"
+msgstr "Varken %(current)s eller %(parent)s är kataloger"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:279
 #: ../gramps/plugins/webreport/narrativeweb.py:284
@@ -35693,7 +35440,7 @@ msgstr "Bygger lista med andra objekt..."
 #: ../gramps/plugins/webreport/narrativeweb.py:728
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
-msgstr "Familjy om %(husband)s och %(spouse)s"
+msgstr "Familj för %(husband)s och %(spouse)s"
 
 #. Only the name of the husband is known
 #. Only the name of the wife is known
@@ -35717,9 +35464,8 @@ msgid "Creating thumbnail preview page..."
 msgstr "Skapar förhandsgranskningssida med miniatyrbilder..."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1144
-#, fuzzy
 msgid "Creating statistics page..."
-msgstr "Skapar familjesidor..."
+msgstr "Skapar statistiksida..."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1185
 msgid "Creating address book pages ..."
@@ -35748,17 +35494,15 @@ msgstr "Webbplatstitel"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1599
 msgid "The title of the web site"
-msgstr "Webbplatsens titel"
+msgstr "Webbsidans titel"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1604
 msgid "Select filter to restrict people that appear on web site"
-msgstr ""
-"Välj ett filter, som begränsar vilka personer, som visas på en hemsida."
+msgstr "Välj ett filter som begränsar vilka personer som visas på en webbsida"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1624
-#, fuzzy
 msgid "Html options"
-msgstr "Cellalternativ"
+msgstr "HTML-alternativ"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1627
 #: ../gramps/plugins/webreport/webcal.py:1639
@@ -35768,7 +35512,7 @@ msgstr "Filändelse"
 #: ../gramps/plugins/webreport/narrativeweb.py:1630
 #: ../gramps/plugins/webreport/webcal.py:1642
 msgid "The extension to be used for the web files"
-msgstr "Filändelse, som skall används för webbfiler"
+msgstr "Filändelse som skall användas för webbfiler"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1633
 #: ../gramps/plugins/webreport/webcal.py:1645
@@ -35778,7 +35522,7 @@ msgstr "Copyright"
 #: ../gramps/plugins/webreport/narrativeweb.py:1636
 #: ../gramps/plugins/webreport/webcal.py:1648
 msgid "The copyright to be used for the web files"
-msgstr "Den copyright, som skall användas för webbfiler"
+msgstr "Den copyright som skall användas för webbfiler"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1639
 #: ../gramps/plugins/webreport/webcal.py:1654
@@ -35788,24 +35532,24 @@ msgstr "Mallblad"
 #: ../gramps/plugins/webreport/narrativeweb.py:1644
 #: ../gramps/plugins/webreport/webcal.py:1657
 msgid "The stylesheet to be used for the web pages"
-msgstr "Det mallblad, som skall användas för webbsidan"
+msgstr "Det mallblad som skall användas för webbsidan"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1649
 msgid "Horizontal -- Default"
-msgstr "Horisontellt -- Ingen ändring"
+msgstr "Horisontell -- Förvalt"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1650
 msgid "Vertical   -- Left Side"
-msgstr "Vertikal  -- vänster sida"
+msgstr "Vertikal   -- vänster sida"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1651
 msgid "Fade       -- WebKit Browsers Only"
-msgstr "Avklinga   -- Endast WebKitbläddrare"
+msgstr "Avklinga       -- Endast WebKit-webbläsare"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1652
 #: ../gramps/plugins/webreport/narrativeweb.py:1666
 msgid "Drop-Down  -- WebKit Browsers Only"
-msgstr "Rullgardin  --- Endast WebKitbläddrare"
+msgstr "Rullgardin  --- Endast WebKit-webbläsare"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1654
 msgid "Navigation Menu Layout"
@@ -35821,7 +35565,7 @@ msgstr "Normal skissmall"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1669
 msgid "Citation Referents Layout"
-msgstr "Citeringsreferentermall"
+msgstr "Citeringsreferensmall"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1673
 msgid ""
@@ -35842,15 +35586,15 @@ msgstr "Generationer i diagram"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1684
 msgid "The number of generations to include in the ancestor graph"
-msgstr "Antal generationer, som skall tas med i förfädersdiagrammet"
+msgstr "Antal generationer som skall tas med i förfädersdiagrammet"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1689
 msgid "This is a secure site (https)"
-msgstr ""
+msgstr "Detta är en säker sida (https)"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1691
 msgid "Whether to use http:// or https://"
-msgstr ""
+msgstr "Huruvida använda http:// eller https://"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1707
 msgid "Suppress Gramps ID"
@@ -35878,7 +35622,7 @@ msgstr "Hemsidenotis"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1726
 msgid "A note to be used on the home page"
-msgstr "En notis, som skall användas på hemsidan"
+msgstr "En notis för användning på hemsidan"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1729
 msgid "Home page image"
@@ -35886,7 +35630,7 @@ msgstr "Hemsidebild"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1730
 msgid "An image to be used on the home page"
-msgstr "En bild för användning på hemsidan."
+msgstr "En bild för användning på hemsidan"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1733
 msgid "Introduction note"
@@ -35894,7 +35638,7 @@ msgstr "Introduktionsnotis"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1734
 msgid "A note to be used as the introduction"
-msgstr "En notis, som skall användas som inledning."
+msgstr "En notis som skall användas som introduktion"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1737
 msgid "Introduction image"
@@ -35902,11 +35646,11 @@ msgstr "Introduktionsbild"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1738
 msgid "An image to be used as the introduction"
-msgstr "En bild, som skall användas som inledning."
+msgstr "En bild som skall användas som introduktion"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1741
 msgid "Publisher contact note"
-msgstr "Kontaktnotis hos utgivare"
+msgstr "Utgivarens kontaktnotis"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1742
 msgid ""
@@ -35914,13 +35658,13 @@ msgid ""
 "If no publisher information is given,\n"
 "no contact page will be created"
 msgstr ""
-"En notis, som används som kontakt med utgivaren.\n"
+"En notis som används till utgivarens kontaktinformation.\n"
 "Om ingen utgivarinformation ges,\n"
-"blir ingen kontaktsida skapad."
+"blir ingen kontaktsida skapad"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1748
 msgid "Publisher contact image"
-msgstr "Kontaktbild hos utgivare"
+msgstr "Utgivarens kontaktbild"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1749
 msgid ""
@@ -35928,9 +35672,9 @@ msgid ""
 "If no publisher information is given,\n"
 "no contact page will be created"
 msgstr ""
-"En bild, som används som kontakt med utgivaren.\n"
+"En bild som används till utgivarens kontaktinformation.\n"
 "Om ingen utgivarinformation ges,\n"
-"blir ingen kontaktsida skapad."
+"blir ingen kontaktsida skapad"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1755
 msgid "HTML user header"
@@ -35938,7 +35682,7 @@ msgstr "HTML sidhuvud"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1756
 msgid "A note to be used as the page header"
-msgstr "En notis, som skall användas som sidhuvud"
+msgstr "En notis som skall användas som sidhuvud"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1759
 msgid "HTML user footer"
@@ -35946,12 +35690,11 @@ msgstr "HTML sidfot"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1760
 msgid "A note to be used as the page footer"
-msgstr "En notis, som skall används som sidfot"
+msgstr "En notis som skall användas som sidfot"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1767
-#, fuzzy
 msgid "Images Generation"
-msgstr "Sidgenerering"
+msgstr "Bildgenerering"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1770
 msgid "Include images and media objects"
@@ -35959,21 +35702,19 @@ msgstr "Ta med bilder och mediaobjekt"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1772
 msgid "Whether to include a gallery of media objects"
-msgstr "Huruvida ta med galleri med mediaobjekt."
+msgstr "Huruvida ta med galleri med mediaobjekt"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1778
-#, fuzzy
 msgid "Include unused images and media objects"
-msgstr "Ta med bilder och mediaobjekt"
+msgstr "Ta med oanvända bilder och mediaobjekt"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1779
-#, fuzzy
 msgid "Whether to include unused or unreferenced media objects"
-msgstr "Huruvida ta med galleri med mediaobjekt."
+msgstr "Huruvida ta med oanvända eller orefererade mediaobjekt"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1784
 msgid "Create and only use thumbnail- sized images"
-msgstr "Skapa och använd bara av mediaminiatyrbilder"
+msgstr "Skapa och använd bara miniatyrbilder"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1786
 msgid ""
@@ -35982,32 +35723,32 @@ msgid ""
 "total upload size to your web hosting site."
 msgstr ""
 "Detta alternativ tillåter dig att välja att inte skapa bilder i full storlek "
-"som på mediasidan utan endast småbilder. Detta gör att du får en mycket "
+"som på mediasidan utan endast miniatyrbilder. Detta gör att du får en mycket "
 "mindre total storlek när du laddar upp till din hemsideleverantör."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1795
 msgid "Max width of initial image"
-msgstr "Största bredd hos första bild"
+msgstr "Största bredd på första bild"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1797
 msgid ""
 "This allows you to set the maximum width of the image shown on the media "
 "page. Set to 0 for no limit."
 msgstr ""
-"Detta tillåter dig att ställa in den största bredden för bilder, som visas "
-"på mediasidan. Satt till 0 fås ingen gräns."
+"Detta tillåter dig att ställa in den största bredden för bilden som visas på "
+"mediasidan. Sätt till 0 för obegränsad bredd."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1802
 msgid "Max height of initial image"
-msgstr "Största höjd hos första bild"
+msgstr "Största höjd på första bild"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1804
 msgid ""
 "This allows you to set the maximum height of the image shown on the media "
 "page. Set to 0 for no limit."
 msgstr ""
-"Detta tillåter dig att ställa in den största höjd för bilder, som visas på "
-"mediasidan. Satt till 0 fås ingen gräns."
+"Detta tillåter dig att ställa in den största höjden för bilden som visas på "
+"mediasidan. Sätt till 0 för obegränsad höjd."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1817
 msgid "Include download page"
@@ -36025,7 +35766,7 @@ msgstr "Nedladdningsfilnamn"
 #: ../gramps/plugins/webreport/narrativeweb.py:1827
 #: ../gramps/plugins/webreport/narrativeweb.py:1839
 msgid "File to be used for downloading of database"
-msgstr "Fil, som skall användas vid nedladdning av databas"
+msgstr "Fil som skall användas vid nedladdning av databas"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1830
 #: ../gramps/plugins/webreport/narrativeweb.py:1842
@@ -36058,11 +35799,11 @@ msgstr "Teckentabell"
 #: ../gramps/plugins/webreport/narrativeweb.py:1860
 #: ../gramps/plugins/webreport/webcal.py:1835
 msgid "The encoding to be used for the web files"
-msgstr "Den kodning, som skall användas för webbfiler"
+msgstr "Den kodning som skall användas för webbfiler"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1864
 msgid "Include link to active person on every page"
-msgstr "Ta med länk till aktiva personen på varje sida"
+msgstr "Ta med länk till den aktiva personen på varje sida"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1866
 msgid "Include a link to the active person (if they have a webpage)"
@@ -36102,13 +35843,13 @@ msgstr "Huruvida ta med en föräldrakolumn"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1890
 msgid "Include half and/ or step-siblings on the individual pages"
-msgstr "Ta med halv och/eller styvsyskon på de individuella sidorna"
+msgstr "Ta med halv- och/eller styvsyskon på de individuella sidorna"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1893
 msgid ""
 "Whether to include half and/ or step-siblings with the parents and siblings"
 msgstr ""
-"Huruvida ta med en halv- och/eller styvsyskon med föräldrarna och syskonen"
+"Huruvida ta med halv- och/eller styvsyskon med föräldrarna och syskonen"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1904
 msgid "Include family pages"
@@ -36120,25 +35861,24 @@ msgstr "Huruvida ta med familjesidor eller inte."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1908
 msgid "Include event pages"
-msgstr "Ta med händelser"
+msgstr "Ta med händelsesidor"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1910
 msgid "Add a complete events list and relevant pages or not"
 msgstr ""
-"Huruvida lägga till en fullständig lista med händelser och relevanta sidor "
-"eller inte"
+"Lägga till en fullständig lista med händelser och relevanta sidor eller inte"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1913
 msgid "Include repository pages"
-msgstr "Ta med arkivplatsförteckning"
+msgstr "Ta med arkivplatssidor"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1915
 msgid "Whether or not to include the Repository Pages."
-msgstr "Huruvida ta med arkivplatsförteckning eller inte."
+msgstr "Huruvida ta med arkivplatssidor eller inte."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1919
 msgid "Include GENDEX file (/gendex.txt)"
-msgstr "Inkludera GENDEX-fil (/gendex.txt)"
+msgstr "Ta med GENDEX-fil (/gendex.txt)"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1920
 msgid "Whether to include a GENDEX file or not"
@@ -36154,17 +35894,15 @@ msgid ""
 "website addresses and personal address/ residence events."
 msgstr ""
 "Huruvida ta med adressbokssidor eller inte, vilket kan inkludera e-post och "
-"internetadresser samt personlig uppgifter om adress/boende?"
+"internetadresser samt personliga uppgifter om adress/boende."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1930
-#, fuzzy
 msgid "Include the statistics page"
-msgstr "Skapar familjesidor..."
+msgstr "Ta med statistiksidan"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1931
-#, fuzzy
 msgid "Whether or not to add statistics page"
-msgstr "Huruvida ta med familjesidor eller inte."
+msgstr "Huruvida ta med statistiksida eller inte"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1938
 msgid "Place Map Options"
@@ -36191,24 +35929,24 @@ msgid ""
 "Whether to include a place map on the Place Pages, where Latitude/ Longitude "
 "are available."
 msgstr ""
-"Huruvida ta med en platskarta på platssidorna, där latitud/longitud syns."
+"Huruvida ta med en platskarta i platssidorna, där Latitud/Longitud finns "
+"tillgängliga."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1961
 msgid "Include Family Map Pages with all places shown on the map"
-msgstr "Tag med familjekartsidor med all platser visade på kartan"
+msgstr "Ta med familjekartsidor med alla platser visade på kartan"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1965
 msgid ""
 "Whether or not to add an individual page map showing all the places on this "
 "page. This will allow you to see how your family traveled around the country."
 msgstr ""
-"Huruvida lägga till en individuell sidobeskrivning med alla platser skall "
-"visas eller ej? Detta gör det möjligt för dig att se hur din familj "
-"förflyttat sig."
+"Huruvida ta med en individuell platskarta som visar alla platser på den "
+"sidan eller inte. Det gör att du kan se hur din familj reste runt i landet."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1973
 msgid "Family Links"
-msgstr "Familjerelänkar"
+msgstr "Familjelänkar"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1974
 msgid "Drop"
@@ -36226,48 +35964,44 @@ msgstr "Google/ Familjekartval"
 msgid ""
 "Select which option that you would like to have for the Google Maps Family "
 "Map pages..."
-msgstr "Välj vilket val du vill ha för Googlekartors familjekartsidor..."
+msgstr "Välj vilket val du vill ha för Googlekartornas familjekartsidor..."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1985
-#, fuzzy
 msgid "Google maps API key"
-msgstr "Google-kartor"
+msgstr "Google maps API key"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1986
-#, fuzzy
 msgid "The API key used for the Google maps"
-msgstr "Mall som används för sidfoten."
+msgstr "API-nyckeln som används för Google-maps"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1995
 msgid "Other inclusion (CMS, Web Calendar, Php)"
-msgstr ""
+msgstr "Andra som ingår (CMS, webbkalender, Php)"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1999
 msgid "Do we include these pages in a cms web ?"
-msgstr ""
+msgstr "Ska dessa sidor tas med i CMS-webbsidor ?"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:2003
 #: ../gramps/plugins/webreport/narrativeweb.py:2020
-#, fuzzy
 msgid "URI"
-msgstr "URL"
+msgstr "URI"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:2009
 msgid "Where do you place your web site ? default = /NAVWEB"
-msgstr ""
+msgstr "Var vill du spara din webbsida ? standard = /NAVWEB"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:2016
-#, fuzzy
 msgid "Do we include the web calendar ?"
-msgstr "Titel på kalender"
+msgstr "Ska webbkalendern tas med ?"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:2026
 msgid "Where do you place your web site ? default = /WEBCAL"
-msgstr ""
+msgstr "Var vill du spara din webbsida ? standard = /WEBCAL"
 
 #: ../gramps/plugins/webreport/person.py:135
 msgid "Creating individual pages"
-msgstr "Skapar personliga sidor"
+msgstr "Skapar individuella sidor"
 
 #. Individual List page message
 #: ../gramps/plugins/webreport/person.py:182
@@ -36277,7 +36011,7 @@ msgid ""
 "person&#8217;s individual page."
 msgstr ""
 "Denna sida är en förteckning över alla personer i databasen, sorterade på "
-"efternamn. Val av personens namn tar dig till den personens egen sida."
+"efternamn. Val av personens namn öppnar den personens egen sida."
 
 #. Name Column
 #: ../gramps/plugins/webreport/person.py:209
@@ -36289,12 +36023,12 @@ msgstr "Förnamn"
 #: ../gramps/plugins/webreport/surname.py:93
 #: ../gramps/plugins/webreport/surnamelist.py:190
 msgid "<absent>"
-msgstr "<frånvarande>"
+msgstr "<saknas>"
 
 #: ../gramps/plugins/webreport/person.py:264
 #, python-format
 msgid "Surnames %(surname)s beginning with letter %(letter)s"
-msgstr "Efternamn %(surname)s börjande på bokstaven %(letter)s"
+msgstr "Efternamn %(surname)s som börjar på bokstaven %(letter)s"
 
 #: ../gramps/plugins/webreport/person.py:772
 #, python-format
@@ -36313,12 +36047,12 @@ msgstr ""
 "Denna kartsida representerar endast personen och dess ättlingar med alla "
 "sina händelser/platser. Om du för musen över markören, kommer den att visa "
 "platsens namn. Markörerna och hänvisninglistan är sorterad i kronologisk "
-"ordning. Genom att klicka på en plats namn i hänvisningsdelen, kommer du "
-"till  den sidan."
+"ordning (om datum finns). Genom att klicka på en plats namn i "
+"hänvisningsdelen, kommer sidan för den platsen att öppnas."
 
 #: ../gramps/plugins/webreport/person.py:848
 msgid "Drop Markers"
-msgstr "Dropmarkörer"
+msgstr "Uteslut markörer"
 
 #: ../gramps/plugins/webreport/person.py:873
 msgid "Place Title"
@@ -36349,7 +36083,6 @@ msgid "Not siblings"
 msgstr "Ej syskon"
 
 #: ../gramps/plugins/webreport/person.py:1737
-#, fuzzy
 msgid "Relation to the center person"
 msgstr "Släktskap till huvudperson"
 
@@ -36372,17 +36105,17 @@ msgid ""
 "their title. Clicking on a place&#8217;s title will take you to that "
 "place&#8217;s page."
 msgstr ""
-"Denna sida är en förteckning över alla platser i databasen, sorterad efter "
-"rubrik. Klickar du på en plats titel tar du dig till den platsens egen sida."
+"Denna sida är en förteckning över alla platser i databasen, sorterade efter "
+"rubrik. Klickar du på en plats titel kommer platsens egen sida att öppnas."
 
 #: ../gramps/plugins/webreport/place.py:176
 msgid "Place Name | Name"
-msgstr "Ortsnamn"
+msgstr "Platsnamn"
 
 #: ../gramps/plugins/webreport/place.py:224
 #, python-format
 msgid "Places beginning with letter %s"
-msgstr "Platser börjande på bokstaven %s"
+msgstr "Platser som börjar på bokstaven %s"
 
 #. section title
 #: ../gramps/plugins/webreport/place.py:392
@@ -36392,7 +36125,7 @@ msgstr "Platskarta"
 #. set progress bar pass for Repositories
 #: ../gramps/plugins/webreport/repository.py:101
 msgid "Creating repository pages"
-msgstr "Skapar arkivplatsförteckning"
+msgstr "Skapar arkivplatssidor"
 
 #: ../gramps/plugins/webreport/repository.py:146
 msgid ""
@@ -36401,8 +36134,8 @@ msgid ""
 "that repositories&#8217;s page."
 msgstr ""
 "Denna sida är en förteckning över alla arkivplatser i databasen, sorterade "
-"på titel. Genom att klicka på en arkivplats titel kommer du till den "
-"arkivplatsens sida."
+"på titel. Genom att klicka på en arkivplats titel kommer den arkivplatsens "
+"sida att öppnas."
 
 #: ../gramps/plugins/webreport/repository.py:164
 msgid "Repository |Name"
@@ -36410,7 +36143,7 @@ msgstr "Namn"
 
 #: ../gramps/plugins/webreport/source.py:102
 msgid "Creating source pages"
-msgstr "Skapar källförteckning"
+msgstr "Skapar källsidor"
 
 #: ../gramps/plugins/webreport/source.py:146
 msgid ""
@@ -36419,7 +36152,8 @@ msgid ""
 "source&#8217;s page."
 msgstr ""
 "Denna sida är en förteckning över alla källor i databasen, sorterade på "
-"titel. Genom att klicka på en källas titel kommer du till den källans sida."
+"titel. Genom att klicka på en källas titel kommer den källans sida att "
+"öppnas."
 
 #: ../gramps/plugins/webreport/source.py:165
 msgid "Source Name|Name"
@@ -36427,17 +36161,15 @@ msgstr "Namn"
 
 #: ../gramps/plugins/webreport/source.py:263
 msgid "Publication information"
-msgstr "Publiceringsinformation"
+msgstr "Publiceringsinformation "
 
 #: ../gramps/plugins/webreport/statistics.py:113
-#, fuzzy
 msgid "Database overview"
-msgstr "Databas öppnad"
+msgstr "Databasöversikt"
 
 #: ../gramps/plugins/webreport/statistics.py:178
-#, fuzzy
 msgid "Narrative web content report for"
-msgstr "Rapport som webbplats"
+msgstr "Rapport som webbplats för"
 
 #. feature request 2356: avoid genitive form
 #: ../gramps/plugins/webreport/surname.py:109
@@ -36448,7 +36180,7 @@ msgid ""
 "person&#8217;s individual page."
 msgstr ""
 "Denna sida är en förteckning över alla individer i databasen med efternamnet "
-"%s. Val av personens namn tar dig till den personens egen sida."
+"%s. Val av personens namn öppnar den personens egen sida."
 
 #: ../gramps/plugins/webreport/surnamelist.py:101
 msgid "Surnames by person count"
@@ -36462,8 +36194,8 @@ msgid ""
 "surname."
 msgstr ""
 "Denna sida är en förteckning över alla efternamn i databasen. Genom att "
-"klicka på ett efternamn kommer du vidare till alla individer med det "
-"efternamnet."
+"klicka på ett efternamn kommer en lista med individer med det efternamnet "
+"att öppnas."
 
 #: ../gramps/plugins/webreport/surnamelist.py:154
 msgid "Number of People"
@@ -36472,7 +36204,7 @@ msgstr "Antal personer"
 #: ../gramps/plugins/webreport/surnamelist.py:203
 #, python-format
 msgid "Surnames beginning with letter %s"
-msgstr "Efternamn börjande med bokstaven %s"
+msgstr "Efternamn som börjar med bokstaven %s"
 
 #: ../gramps/plugins/webreport/thumbnail.py:116
 msgid ""
@@ -36482,8 +36214,8 @@ msgid ""
 "image&#8217;s page."
 msgstr ""
 "Denna sida är en förteckning över alla mediaobjekt i databasen, sorterad "
-"efter mediatitel. Klickar du på en miniatyrbild tar du dig till den bildens "
-"egen sida."
+"efter mediatitel. Klickar du på en miniatyrbild kommer den bildens sida att "
+"öppnas."
 
 #: ../gramps/plugins/webreport/thumbnail.py:135
 msgid "Thumbnail Preview"
@@ -36498,7 +36230,7 @@ msgstr "Förhandsgranskning av minatyrbild"
 #: ../gramps/plugins/webreport/webcal.py:1053
 #: ../gramps/plugins/webreport/webcal.py:1274
 msgid "Web Calendar Report"
-msgstr "Rapport i form av kalender"
+msgstr "Webb-kalender-rapport"
 
 #: ../gramps/plugins/webreport/webcal.py:329
 #, python-format
@@ -36510,14 +36242,12 @@ msgstr "Beräknar helgdagar för år %04d"
 msgid ""
 "the \"WebCal\" will be the potential-email Subject|Created for "
 "%(html_email_author_start)sWebCal%(html_email_author_end)s"
-msgstr ""
-"\"WebCal\" kommer att vara den viktigaste e-postsubjektet|Skapat för "
-"%(html_email_author_start)sWebCal%(html_email_author_end)s"
+msgstr "Skapat för %(html_email_author_start)sWebCal%(html_email_author_end)s"
 
 #: ../gramps/plugins/webreport/webcal.py:494
 #, python-format
 msgid "Created for %(author)s"
-msgstr "Skapad åt %(author)s"
+msgstr "Skapad för %(author)s"
 
 #. Add a link for year_glance() if requested
 #: ../gramps/plugins/webreport/webcal.py:576
@@ -36530,11 +36260,11 @@ msgstr "NarrativeWeb Hem"
 
 #: ../gramps/plugins/webreport/webcal.py:617
 msgid "Full year at a Glance"
-msgstr "Översikt av år"
+msgstr "Översikt av helt år"
 
 #: ../gramps/plugins/webreport/webcal.py:968
 msgid "Formatting months ..."
-msgstr "Formaterar månader..."
+msgstr "Formaterar månader ..."
 
 #: ../gramps/plugins/webreport/webcal.py:1054
 msgid "Creating Year At A Glance calendar"
@@ -36553,8 +36283,8 @@ msgid ""
 "shows all the events for that date, if there are any.\n"
 msgstr ""
 "Denna kalender avser att ge dig snabb tillgång till alla dina data "
-"komprimerat till en sida. Genom att klicka på ett datum, kommer du till en "
-"sida, som visar alla händelser på detta datum, om det finns några!\n"
+"komprimerat till en sida. Genom att klicka på ett datum kommer en sida att "
+"öppnas som visar alla händelser på detta datum, om det finns några.\n"
 
 #. page title
 #: ../gramps/plugins/webreport/webcal.py:1127
@@ -36570,7 +36300,7 @@ msgstr "%(spouse)s och %(person)s"
 #: ../gramps/plugins/webreport/webcal.py:1451
 #, python-format
 msgid "Generated by %(gramps_home_html_start)sGramps%(html_end)s on %(date)s"
-msgstr "Skapad av %(gramps_home_html_start)sGramps%(html_end)s på %(date)s"
+msgstr "Skapad av %(gramps_home_html_start)sGramps%(html_end)s den %(date)s"
 
 #. page title
 #: ../gramps/plugins/webreport/webcal.py:1557
@@ -36596,7 +36326,7 @@ msgstr "Skapa kalendrar för flera år"
 
 #: ../gramps/plugins/webreport/webcal.py:1702
 msgid "Whether to create Multiple year calendars or not."
-msgstr "Huruvida skapa en flerårskalender eller inte."
+msgstr "Huruvida skapa flerårskalendrar eller inte."
 
 #: ../gramps/plugins/webreport/webcal.py:1707
 msgid "Start Year for the Calendar(s)"
@@ -36612,7 +36342,7 @@ msgstr "Slutår för kalendrar"
 
 #: ../gramps/plugins/webreport/webcal.py:1715
 msgid "Enter the ending year for the calendars between 1900 - 3000."
-msgstr "Skriv in sluteår för kalendrar mellan 1900 och 3000"
+msgstr "Skriv in slutår för kalendrar mellan 1900 och 3000."
 
 #: ../gramps/plugins/webreport/webcal.py:1732
 msgid "Holidays will be included for the selected country"
@@ -36626,7 +36356,7 @@ msgstr "Hemlänk"
 msgid ""
 "The link to be included to direct the user to the main page of the web site"
 msgstr ""
-"Den länk, som skall tas med, för att hänvisa användaren till webbplatsens "
+"Den länk som skall tas med för att hänvisa användaren till webbplatsens "
 "huvudsida"
 
 #: ../gramps/plugins/webreport/webcal.py:1761
@@ -36647,7 +36377,7 @@ msgstr "Januarinotis"
 
 #: ../gramps/plugins/webreport/webcal.py:1775
 msgid "The note for the month of January"
-msgstr "Notisen för januari månad."
+msgstr "Notisen för januari månad"
 
 #: ../gramps/plugins/webreport/webcal.py:1778
 msgid "February Note"
@@ -36655,7 +36385,7 @@ msgstr "Februarinotis"
 
 #: ../gramps/plugins/webreport/webcal.py:1779
 msgid "The note for the month of February"
-msgstr "Notisen för februari månad."
+msgstr "Notisen för februari månad"
 
 #: ../gramps/plugins/webreport/webcal.py:1782
 msgid "March Note"
@@ -36663,7 +36393,7 @@ msgstr "Marsnotis"
 
 #: ../gramps/plugins/webreport/webcal.py:1783
 msgid "The note for the month of March"
-msgstr "Notisen för mars månad."
+msgstr "Notisen för mars månad"
 
 #: ../gramps/plugins/webreport/webcal.py:1786
 msgid "April Note"
@@ -36707,7 +36437,7 @@ msgstr "Augustinotis"
 
 #: ../gramps/plugins/webreport/webcal.py:1805
 msgid "The note for the month of August"
-msgstr "Notisen för augusti månad."
+msgstr "Notisen för augusti månad"
 
 #: ../gramps/plugins/webreport/webcal.py:1808
 msgid "September Note"
@@ -36731,7 +36461,7 @@ msgstr "Novembernotis"
 
 #: ../gramps/plugins/webreport/webcal.py:1817
 msgid "The note for the month of November"
-msgstr "Notisen för november månad."
+msgstr "Notisen för november månad"
 
 #: ../gramps/plugins/webreport/webcal.py:1820
 msgid "December Note"
@@ -36739,15 +36469,15 @@ msgstr "Decembernotis"
 
 #: ../gramps/plugins/webreport/webcal.py:1821
 msgid "The note for the month of December"
-msgstr "Notisen för december månad."
+msgstr "Notisen för december månad"
 
 #: ../gramps/plugins/webreport/webcal.py:1838
 msgid "Create one day event pages for Year At A Glance calendar"
-msgstr "Skapar en endags sida för årsöversiktskalender"
+msgstr "Skapar endags händelsesidor för årsöversiktskalender"
 
 #: ../gramps/plugins/webreport/webcal.py:1840
 msgid "Whether to create one day pages or not"
-msgstr "Huruvida skapa endagssidor eller inte."
+msgstr "Huruvida skapa endagssidor eller inte"
 
 #: ../gramps/plugins/webreport/webcal.py:1843
 msgid "Link to Narrated Web Report"
@@ -36755,7 +36485,7 @@ msgstr "Länk till rapport som webbplats"
 
 #: ../gramps/plugins/webreport/webcal.py:1844
 msgid "Whether to link data to web report or not"
-msgstr "Huruvida länka till webb-rapport eller inte?"
+msgstr "Huruvida data ska länkas till webb-rapport eller inte"
 
 #: ../gramps/plugins/webreport/webcal.py:1850
 msgid "Link prefix"
@@ -36763,7 +36493,8 @@ msgstr "Länkprefix"
 
 #: ../gramps/plugins/webreport/webcal.py:1851
 msgid "A Prefix on the links to take you to Narrated Web Report"
-msgstr "Ett prefix på länkarna som tar dig till webb-rapporten."
+msgstr ""
+"Ett prefix till länkarna som tar dig till den berättande webb-rapporten"
 
 #: ../gramps/plugins/webreport/webcal.py:2029
 #, python-format
@@ -36777,7 +36508,7 @@ msgstr "%(couple)s, <em>bröllop</em>"
 
 #: ../gramps/plugins/webreport/webcal.py:2048
 msgid "Until"
-msgstr ""
+msgstr "Tills"
 
 #: ../gramps/plugins/webreport/webcal.py:2057
 #, python-brace-format
@@ -36792,7 +36523,7 @@ msgstr "Berättad webbplats"
 
 #: ../gramps/plugins/webreport/webplugins.gpr.py:35
 msgid "Produces web (HTML) pages for individuals, or a set of individuals"
-msgstr "Skapar webbsidor (HTML) för personer eller en grupp av personer."
+msgstr "Skapar webbsidor (HTML) för personer eller en grupp av personer"
 
 #: ../gramps/plugins/webreport/webplugins.gpr.py:59
 msgid "Produces web (HTML) calendars."
@@ -36849,4425 +36580,3 @@ msgstr "Nebraska"
 #: ../gramps/plugins/webstuff/webstuff.py:143
 msgid "No style sheet"
 msgstr "Inget mallblad"
-
-#, fuzzy
-#~ msgid "Data version"
-#~ msgstr "Schema-version"
-
-#~ msgid "Gender Male Death"
-#~ msgstr "Död mansperson"
-
-#~ msgid "Gender Female Death"
-#~ msgstr "Död kvinnoperson"
-
-#~ msgid "Gender Unknown Death"
-#~ msgstr "Död person av okänt kön"
-
-#~ msgid "Suppress comma after house number"
-#~ msgstr "Undertryck komma efter husnummer"
-
-#~ msgid "Full place name"
-#~ msgstr "Komplett platsnamn:"
-
-#~ msgid "-> Hamlet/Village/Town/City"
-#~ msgstr "-> Hussamling/By Kommun/Stad"
-
-#~ msgid "Hamlet/Village/Town/City ->"
-#~ msgstr "Hussamling/By Kommun/Stad ->"
-
-#~ msgid "Restrict"
-#~ msgstr "Begränsa "
-
-#~ msgid "48.21\"S, -18.2412 or -18:9:48.21)"
-#~ msgstr "48.21\"S, -18.2412 eller -18:9:48.21)"
-
-#~ msgid "48.21\"E, -18.2412 or -18:9:48.21)"
-#~ msgstr "48.21\"E, -18.2412 eller -18:9:48.21)"
-
-#~ msgid "11"
-#~ msgstr "11"
-
-#, fuzzy
-#~ msgid "DB-API version"
-#~ msgstr "Bsddb-version"
-
-#, fuzzy
-#~ msgid "DB-API Database"
-#~ msgstr "Hela databasen"
-
-#, fuzzy
-#~ msgid "In-_Memory Database"
-#~ msgstr "Importera databas"
-
-#, fuzzy
-#~ msgid "In-Memory Database"
-#~ msgstr "Importera databas"
-
-#~ msgid "Ancestor"
-#~ msgstr "Anor"
-
-#~ msgid "Descendant"
-#~ msgstr "Ättlingar"
-
-#~ msgid "Alphabet Menu: %s"
-#~ msgstr "Alfabetisk meny: %s"
-
-#~ msgid "   %(item)s: %(summary)s"
-#~ msgstr "   %(item)s: %(summary)s"
-
-#~ msgid "Preparing sub-filter"
-#~ msgstr "Förbereder underordnat filter"
-
-#, fuzzy
-#~ msgid "Family Relationship"
-#~ msgstr "Familjsläktskap"
-
-#, fuzzy
-#~ msgid "Primary name"
-#~ msgstr "Huvudnamn"
-
-#, fuzzy
-#~ msgid "Probably alive"
-#~ msgstr "Personer som troligen lever"
-
-#~ msgid ""
-#~ "This allows you to restrict information on people who have not been dead "
-#~ "for very long"
-#~ msgstr ""
-#~ "Detta tillåter dig att begränsa uppgifter om personer, som inte har varit "
-#~ "döda tillräckligt länge."
-
-#~ msgid "%(adjective)s: %(addon)s"
-#~ msgstr "%(adjective)s: %(addon)s"
-
-#~ msgid "Detached width"
-#~ msgstr "Bredd, frikopplad"
-
-#~ msgid "Detached height"
-#~ msgstr "Höjd, frikopplad"
-
-#, fuzzy
-#~ msgid "Dummy database"
-#~ msgstr "Gramps databas"
-
-#, fuzzy
-#~ msgid "Dummy Database"
-#~ msgstr "Hela databasen"
-
-#~ msgid "Replace"
-#~ msgstr "Ersätt"
-
-#~ msgid "The basic style used for the title display."
-#~ msgstr "Grundläggande mall som används för visning av titel."
-
-#~ msgid "Text Options"
-#~ msgstr "Textalternativ"
-
-#~ msgid "The basic style used for the default text display."
-#~ msgstr "Grundläggande mall som används för textvisning."
-
-#, fuzzy
-#~ msgid "Report Details"
-#~ msgstr "Arkivplatsdetaljer"
-
-#~ msgid "The style used for the title of the page."
-#~ msgstr "Mall som används för sidans titel."
-
-#~ msgid "Applying filter..."
-#~ msgstr "Tillämpar filter..."
-
-#~ msgid "The style used for the person's name."
-#~ msgstr "Mall som används för personens namn."
-
-#~ msgid "The style used for the year labels."
-#~ msgstr "Mall som används för årsetiketter."
-
-#~ msgid "Filt_er:"
-#~ msgstr "Filt_er:"
-
-#~ msgid "_Marriages"
-#~ msgstr "_Giftermål"
-
-#~ msgid "I_ndividuals"
-#~ msgstr "I_ndivider"
-
-#~ msgid "Translate _Headers"
-#~ msgstr "Översätt _rubriker"
-
-#~ msgid "Export:"
-#~ msgstr "Export:"
-
-#~ msgid "Exclude _notes"
-#~ msgstr "Ta ej med _notiser"
-
-#~ msgid "Use _Living as first name"
-#~ msgstr "Använd _Levande som förnamn"
-
-#~ msgid "Reference i_mages from path:  "
-#~ msgstr "Referensbilder från _sökväg:  "
-
-#~ msgid "%(type)s: %(list)s"
-#~ msgstr "%(type)s: %(list)s"
-
-#~ msgid "Include Gramps ID"
-#~ msgstr "Ta med Gramps ID"
-
-#~ msgid "Warning messages"
-#~ msgstr "Varningsmeddelanden"
-
-#~ msgid "Created by:"
-#~ msgstr "Skapad av:"
-
-#~ msgid "People:"
-#~ msgstr "Personer:"
-
-#~ msgid "Encoding:"
-#~ msgstr "Kodning:"
-
-#~ msgid "Version:"
-#~ msgstr "Version:"
-
-#~ msgid "Families:"
-#~ msgstr "Familjer:"
-
-#~ msgid "Import from Pro-Gen"
-#~ msgstr "Importera från Pro-Gen"
-
-#, fuzzy
-#~ msgid "Initializing"
-#~ msgstr "Initialer"
-
-#~ msgid "Importing individuals"
-#~ msgstr "Importerar personer"
-
-#~ msgid "Importing families"
-#~ msgstr "Importerar familjer"
-
-#~ msgid "Adding children"
-#~ msgstr "Lägger till barn"
-
-#~ msgid "Remove the selected person"
-#~ msgstr "Ta bort den valda personen"
-
-#~ msgid "Select the first day of the week for the report"
-#~ msgstr "Välj veckans första dag för rapporten"
-
-#~ msgid "Include birthdays in the report"
-#~ msgstr "Ta med födelsedagar i rapporten"
-
-#~ msgid "Include anniversaries in the report"
-#~ msgstr "Ta med årsdagar i rapporten"
-
-#~ msgid "Include relationships to center person (slower)"
-#~ msgstr "Ta med släktskap till centralperson (långsammare)"
-
-#~ msgid "Text to display last."
-#~ msgstr "Text, som skall visas sist."
-
-#~ msgid "The style used for the first portion of the custom text."
-#~ msgstr "Mall som används för den första delen av den anpassade texten."
-
-#~ msgid "The style used for the middle portion of the custom text."
-#~ msgstr "Mall som används för mittendelen av den anpassade texten."
-
-#~ msgid "The style used for the last portion of the custom text."
-#~ msgstr "Mall som används för den sista delen av den anpassade texten."
-
-#~ msgid "%(name_kind)s: %(name)s%(endnotes)s"
-#~ msgstr "%(name_kind)s: %(name)s%(endnotes)s"
-
-#~ msgid "List children"
-#~ msgstr "Lista barn"
-
-#~ msgid "Use Complete Sentences"
-#~ msgstr "Använd fullständiga meningar"
-
-#~ msgid "The style used for the children list."
-#~ msgstr "Mall som används för barnlistan."
-
-#~ msgid "The style used for the first personal entry."
-#~ msgstr "Mall som används för den första personinformationen."
-
-#~ msgid "The style used for the More About header."
-#~ msgstr "Mall som används för notisdelens rubrik."
-
-#~ msgid "The style used for additional detail data."
-#~ msgstr "Mall som används för allmänna data."
-
-#~ msgid "The style used for the More About header and for headers of mates."
-#~ msgstr "Mall som används för Mer Om-rubriken samt för rubriker för makar."
-
-#~ msgid " (%(birth_date)s - %(death_date)s)"
-#~ msgstr " (%(birth_date)s - %(death_date)s)"
-
-#~ msgid "The basic style used for generation headings."
-#~ msgstr "Grundläggande mall använd för generationsrubriker."
-
-#, fuzzy
-#~ msgid "Include 1"
-#~ msgstr "Ta med"
-
-#~ msgid "Whether to include Gramps ID next to names."
-#~ msgstr "Huruvida ta med Gramps ID bredvid namnen"
-
-#~ msgid "Missing Information"
-#~ msgstr "Saknad information"
-
-#~ msgid "The style used for category labels."
-#~ msgstr "Mall som används för kategorietiketter."
-
-#~ msgid "A style used for image facts."
-#~ msgstr "Mall som används för bildfakta."
-
-#~ msgid "The basic style used for sub-headings."
-#~ msgstr "Grundläggande mall som används för underrubriker."
-
-#~ msgid "The style used for the title of the report."
-#~ msgstr "Den mall, som används för rapportens titel."
-
-#~ msgid "The style used for place title."
-#~ msgstr "Den mall, som används för platstiteln."
-
-#~ msgid "The style used for a column title."
-#~ msgstr "Den mall, som används för en kolumntitel."
-
-#~ msgid "The style used for each section."
-#~ msgstr "Den mall, som används för varje sektion."
-
-#~ msgid "The style used for event and person details."
-#~ msgstr "Den mall, som används för händelse- och persondetaljer."
-
-#, fuzzy
-#~ msgid "Person Records 2"
-#~ msgstr "Personposter"
-
-#, fuzzy
-#~ msgid "Person Records 1"
-#~ msgstr "Personposter"
-
-#~ msgid "Family Records"
-#~ msgstr "Familjeposter"
-
-#~ msgid "The style used for headings."
-#~ msgstr "Mall som används för rubriker."
-
-#~ msgid "Please be patient. This may take a while."
-#~ msgstr "Var tålmodig. Det här kan ta en stund."
-
-#~ msgid "Reordering Gramps IDs"
-#~ msgstr "Sorterar om Gramps-ID:n"
-
-#~ msgid "Reordering People IDs"
-#~ msgstr "Sorterar om person-ID:n"
-
-#~ msgid "Reordering Family IDs"
-#~ msgstr "Sorterar om familje-ID:n"
-
-#~ msgid "Reordering Event IDs"
-#~ msgstr "Sorterar om händelse-ID:n"
-
-#~ msgid "Reordering Media Object IDs"
-#~ msgstr "Sorterar om mediaobjekt-ID:n"
-
-#~ msgid "Reordering Source IDs"
-#~ msgstr "Sorterar om käll-ID:n"
-
-#~ msgid "Reordering Citation IDs"
-#~ msgstr "Sorterar om citerings-ID:n"
-
-#~ msgid "Reordering Place IDs"
-#~ msgstr "Sorterar om plats-ID:n"
-
-#~ msgid "Reordering Repository IDs"
-#~ msgstr "Sorterar om arkivplats-ID:n"
-
-#~ msgid "Reordering Note IDs"
-#~ msgstr "Sorterar om notis-ID:n"
-
-#~ msgid "Done."
-#~ msgstr "Klart."
-
-#~ msgid "%(type)s: %(value)s"
-#~ msgstr "%(type)s: %(value)s"
-
-#~ msgid "Applying Person Filter..."
-#~ msgstr "Tillämpar personfilter..."
-
-#, fuzzy
-#~ msgid "Advanced Options (2)"
-#~ msgstr "Avancerade alternativ"
-
-#~ msgid "Exiting."
-#~ msgstr "Avslutar."
-
-#~ msgid "none"
-#~ msgstr "inget"
-
-#~ msgid "BIC"
-#~ msgstr "BIC"
-
-#~ msgid "DNS"
-#~ msgstr "DNS"
-
-#~ msgid "DNS/CAN"
-#~ msgstr "DNS/CAN"
-
-#~ msgid ""
-#~ "A person with multiple relations with the same spouse is about to be "
-#~ "merged. This is beyond the capabilities of the merge routine. The merge "
-#~ "is aborted."
-#~ msgstr ""
-#~ "En person med flera förhållanden med samma maka/make skall till att slås "
-#~ "ihop. Detta är inte möjlighet med sammanslagningsrutinen. Avbryts."
-
-#~ msgid "Multiple families get merged. This is unusual, the merge is aborted."
-#~ msgstr "Flera familjer slås ihop. Detta är unikt, avbryts."
-
-#~ msgid ""
-#~ "\n"
-#~ "You don't have the python3 bsddb3 package installed. This package is "
-#~ "needed to start Gramps.\n"
-#~ "\n"
-#~ "Gramps will terminate now."
-#~ msgstr ""
-#~ "\n"
-#~ "Du har inte paketet med python3 bsddb3 installerat. Detta paket behövs "
-#~ "för at starta Gramps.\n"
-#~ "\n"
-#~ "Gramps kommer att avslutas nu."
-
-#~ msgid "Check now"
-#~ msgstr "Kontrollera nu"
-
-#~ msgid "Edit Tags"
-#~ msgstr "Redigera flaggor"
-
-#~ msgid "You need to restart Gramps to see new views."
-#~ msgstr "Du måste starta om Gramps för att se nya vyer."
-
-#~ msgid "%(father)s and %(mother)s (%(id)s)"
-#~ msgstr "%(father)s och %(mother)s (%(id)s)"
-
-#~ msgid "Your database is empty."
-#~ msgstr "Din databas är tom."
-
-#~ msgid "Book Menu"
-#~ msgstr "Bokmeny"
-
-#~ msgid "Available Items Menu"
-#~ msgstr "Tillgängliga objektmeny"
-
-#~ msgid "Loading plugins..."
-#~ msgstr "Läser in insticksmoduler..."
-
-#~ msgid "Building View"
-#~ msgstr "Bygger upp vy"
-
-#~ msgid "People Menu"
-#~ msgstr "Personmeny"
-
-#~ msgid "Add a Family Tree"
-#~ msgstr "Lägg till ett släktträd"
-
-#~ msgid "Descendent Menu"
-#~ msgstr "Ättlingameny"
-
-#~ msgid "Place Locations"
-#~ msgstr "Platslokalisering"
-
-#~ msgid "Incomplete names"
-#~ msgstr "Ofullständigt namn"
-
-#~ msgid "Individuals missing birth dates"
-#~ msgstr "Personer som saknar födelsedatum"
-
-#~ msgid "Disconnected individuals"
-#~ msgstr "Isolerade personer"
-
-#~ msgid "Individuals with media objects"
-#~ msgstr "Personer med mediaobjekt"
-
-#~ msgid "Empty event note ignored"
-#~ msgstr "Tom händelsenotis ignorerades"
-
-#~ msgid "Select filter to restrict people that appear on report"
-#~ msgstr ""
-#~ "Välj ett filter, som begränsar vilka personer, som tas med på rapport"
-
-#~ msgid "%(date)s, %(place)s"
-#~ msgstr "%(date)s, %(place)s"
-
-#~ msgid "%(date)s"
-#~ msgstr "%(date)s"
-
-#~ msgid "%(place)s"
-#~ msgstr "%(place)s"
-
-#~ msgid "Marriages/Children"
-#~ msgstr "Giftermål/Barn"
-
-#~ msgid "Summary of %s"
-#~ msgstr "Sammanfattning av %s"
-
-#~ msgid "The style used for the report title."
-#~ msgstr "Mall som används för rapporttiteln."
-
-#~ msgid "The style used for the report subtitle."
-#~ msgstr "Mall som används för rapportundertitel."
-
-#~ msgid "%(quantity)d families with no parents or children, removed.\n"
-#~ msgstr "%(quantity)d familjer utan föräldrar eller barn funna, borttagna.\n"
-
-#~ msgid "Place title"
-#~ msgstr "Platsbenämning"
-
-#~ msgid "Checking Place Titles"
-#~ msgstr "Kontrollerar platstitlar"
-
-#~ msgid "Looking for place fields"
-#~ msgstr "Söker efter platsfält"
-
-#~ msgid "No place information could be extracted."
-#~ msgstr "Ingen platsinformation kunde hämtas."
-
-#~ msgid ""
-#~ "Below is a list of Places with the possible data that can be extracted "
-#~ "from the place title. Select the places you wish Gramps to convert."
-#~ msgstr ""
-#~ "Nedanför är en lista med de platser med tänkbara data, som kan hämtas "
-#~ "från platsens benämning. Välj de platser som du vill att Gramps ska "
-#~ "konvertera."
-
-#~ msgid "Gramps Media Manager"
-#~ msgstr "Gramps mediahanterare"
-
-#~ msgid "Extract Place Data from a Place Title"
-#~ msgstr "Hämta uppgifter om platser från deras benämning"
-
-#~ msgid "Attempts to extract city and state/province from a place title"
-#~ msgstr ""
-#~ "Försök att hämta namn på stad/kommun och län från platsers benämning."
-
-#~ msgid "Cannot add citation."
-#~ msgstr "Kan inte lägga till citering."
-
-#~ msgid ""
-#~ "In order to add a citation to an existing source,  you must select a "
-#~ "source."
-#~ msgstr ""
-#~ "För att kunna lägga till en citering till en befintlig källa, måste du "
-#~ "välja en källa"
-
-#~ msgid "OsmGpsMap module not loaded. OsmGpsMap must be >= 0.8. yours is %s"
-#~ msgstr "OsmGpsMap-modulen el laddad. OsmGpsMap måste vara >=0.8. Din är %s"
-
-#~ msgid "Family Menu"
-#~ msgstr "Familjemeny"
-
-#~ msgid "Gramps&nbsp;ID"
-#~ msgstr "Gramps-ID"
-
-#~ msgid "Include Last Name Only"
-#~ msgstr "Ta bara med efternamnet"
-
-#~ msgid "Include Full Name Only"
-#~ msgstr "Ta bara med kompletta namnet"
-
-#~ msgid "Create \"Year At A Glance\" Calendar"
-#~ msgstr "Skapa översiktskalendrar"
-
-#~ msgid "Whether to create A one-page mini calendar with dates highlighted"
-#~ msgstr "Huruvida skapa en ensides minikalender med datum markerade"
-
-#~ msgid "birth"
-#~ msgstr "födelse"
-
-#~ msgid "Include original person"
-#~ msgstr "Ta med ursprunglig person"
-
-#~ msgid "Gramplet showing the locations of a place over time"
-#~ msgstr "Gramplet visande placering för en plats över tid "
-
-#~ msgid "Person or Place|Title"
-#~ msgstr "Titel"
-
-#~ msgid "Birth place id"
-#~ msgstr "Födelseort-id"
-
-#~ msgid "Baptism place id"
-#~ msgstr "Dopplats id"
-
-#~ msgid "Burial place id"
-#~ msgstr "Begravningsplats id"
-
-#~ msgid "Death place id"
-#~ msgstr "Dödsort id"
-
-#~ msgid "Death cause"
-#~ msgstr "Dödsorsak"
-
-#~ msgid "Gramps id"
-#~ msgstr "Gramps ID"
-
-#~ msgid "Parent2"
-#~ msgstr "Förälder2"
-
-#~ msgid "Parent1"
-#~ msgstr "Förälder1"
-
-#~ msgid "Enclosed by"
-#~ msgstr "Omgivet av"
-
-#~ msgid "Form omitted"
-#~ msgstr "Form utelämnad"
-
-#~ msgid "BLOB ignored"
-#~ msgstr "BLOB ignorerad"
-
-#~ msgid "Multimedia REFN:TYPE ignored"
-#~ msgstr "Multimedia REFN:TYPE ignorerad"
-
-#~ msgid "Mutimedia RIN ignored"
-#~ msgstr "Mutimedia RIN ignorerad"
-
-#~ msgid "Street: %s "
-#~ msgstr "Gatuadress: %s "
-
-#~ msgid "Parish: %s "
-#~ msgstr "Församling: %s "
-
-#~ msgid "Locality: %s "
-#~ msgstr "Trakt/ort: %s "
-
-#~ msgid "City: %s "
-#~ msgstr "Stad/Kommun: %s "
-
-#~ msgid "County: %s "
-#~ msgstr "Landskap: %s "
-
-#~ msgid "State: %s"
-#~ msgstr "Län/delstat: %s "
-
-#~ msgid "Country: %s "
-#~ msgstr "Land: %s "
-
-#~ msgid ""
-#~ "I have made a backup,\n"
-#~ "please upgrade my tree"
-#~ msgstr ""
-#~ "Jag har gjort en säkerhetskopia\n"
-#~ "uppgradera mitt släktträd"
-
-#~ msgid "%(new_DB_name)s (copied %(date_string)s)"
-#~ msgstr "%(new_DB_name)s (kopierad %(date_string)s)"
-
-#~ msgid "Language in which the name is written."
-#~ msgstr "Det språk, på vilket namnet är skrivet."
-
-#~ msgid "Obtaining all rows"
-#~ msgstr "Inhämtar alla rader"
-
-#~ msgid "Applying filter"
-#~ msgstr "Tillämpar filter"
-
-#~ msgid "Constructing column data"
-#~ msgstr "Konstruerar kolumndata"
-
-#~ msgid "Metadata Viewer"
-#~ msgstr "Visning av metadata"
-
-#~ msgid "Person Backlinks"
-#~ msgstr "Personreferenser"
-
-#~ msgid "Event Backlinks"
-#~ msgstr "Händelsereferenser"
-
-#~ msgid "Family Backlinks"
-#~ msgstr "Familjereferenser"
-
-#~ msgid "Place Backlinks"
-#~ msgstr "Platsreferenser"
-
-#~ msgid "Source Backlinks"
-#~ msgstr "Källreferenser"
-
-#~ msgid "Citation Backlinks"
-#~ msgstr "Bakåtlänkar för citering"
-
-#~ msgid "Repository Backlinks"
-#~ msgstr "Arkivplatsreferenser"
-
-#~ msgid "Media Backlinks"
-#~ msgstr "Mediareferenser"
-
-#~ msgid "Note Backlinks"
-#~ msgstr "Notisreferenser"
-
-#~ msgid "Records Gramplet"
-#~ msgstr "Gramplet med rekord"
-
-#~ msgid "SoundEx Generator"
-#~ msgstr "Generator för SoundEx-kod"
-
-#~ msgid "Marriage:"
-#~ msgstr "Giftermål:"
-
-#~ msgid "TRANSLATORS: Translate this to your name in your native language"
-#~ msgstr "Peter Landgren"
-
-#~ msgid "==== Authors ====\n"
-#~ msgstr "=== Författare ===\n"
-
-#~ msgid ""
-#~ "\n"
-#~ "==== Contributors ====\n"
-#~ msgstr ""
-#~ "\n"
-#~ "==== Medarbetare ====\n"
-
-#~ msgid "%s (copy, %s)"
-#~ msgstr "%s (kopiera, %s)"
-
-#~ msgid "<b>Multiple Surnames</b>"
-#~ msgstr "<b>Flera efternamn</b>"
-
-#~ msgid "Cannot save place"
-#~ msgstr "Kan inte spara plats"
-
-#~ msgid "No data exists for this place. Please enter data or cancel the edit."
-#~ msgstr ""
-#~ "Inga uppgifter finns för den här platsen. Ange sådana eller avbryt "
-#~ "redigeringen."
-
-#~ msgid "Cannot save location. Title not entered."
-#~ msgstr "Kan inte spara plats. Titel saknas."
-
-#~ msgid "You must enter a title before saving."
-#~ msgstr "Du måste skriva in en titel innan du sparar."
-
-#~ msgid "Place Name:"
-#~ msgstr "Platsnamn:"
-
-#~ msgid "Cannot save place reference"
-#~ msgstr "Kan inte spara platsreferens"
-
-#~ msgid "No place selected. Please select a place  or cancel the edit."
-#~ msgstr "Ingen plats vald. Välj en plats eller avbryt redigeringen."
-
-#~ msgid "First add a source using the buttons"
-#~ msgstr "Först lägg till en källa genom att använda knapparna"
-
-#~ msgid "ZIP/Postal code"
-#~ msgstr "Postnummer:"
-
-#~ msgid "Church parish"
-#~ msgstr "Församling"
-
-#~ msgid "_Add bookmark"
-#~ msgstr "_Lägg till bokmärke"
-
-#~ msgid "Configure"
-#~ msgstr "Ställ in"
-
-#~ msgid "Edit Date"
-#~ msgstr "Redigera datum"
-
-#~ msgid "Font"
-#~ msgstr "Typsnitt"
-
-#~ msgid "Font Background Color"
-#~ msgstr "Typsnittsbakgrundsfärg"
-
-#~ msgid "Gramplets"
-#~ msgstr "Gramplet"
-
-#~ msgid "Public"
-#~ msgstr "Allmän"
-
-#~ msgid "Merge"
-#~ msgstr "Slå samman"
-
-#~ msgid "Add Parents"
-#~ msgstr "Lägg till föräldrar"
-
-#~ msgid "Reports"
-#~ msgstr "Rapporter"
-
-#~ msgid "Add Spouse"
-#~ msgstr "Lägg till maka/make"
-
-#~ msgid "Tools"
-#~ msgstr "Verktyg"
-
-#~ msgid "Grouped List"
-#~ msgstr "Grupperad lista"
-
-#~ msgid "List"
-#~ msgstr "Lista"
-
-#~ msgid "Zoom In"
-#~ msgstr "Zooma in"
-
-#~ msgid "Zoom Out"
-#~ msgstr "Zooma ut"
-
-#~ msgid "Fit Width"
-#~ msgstr "Anpassa bredd"
-
-#~ msgid "Export"
-#~ msgstr "Exportera"
-
-#~ msgid "Paragraph"
-#~ msgstr "Stycke"
-
-#~ msgid "Confirm every deletion?"
-#~ msgstr "Bekräfta varje borttagande?"
-
-#~ msgid ""
-#~ "  1. <a wiki='%s_-_FAQ#How_do_I_change_the_order_of_spouses.3F'>How do I "
-#~ "change the order of spouses?</a>\n"
-#~ msgstr ""
-#~ "  1. <a wiki='%s_-_FAQ#How_do_I_change_the_order_of_spouses.3F'>Hur "
-#~ "ändrar jag ordingen på makar?</a>\n"
-
-#~ msgid ""
-#~ "  2. <a wiki='%s_-_FAQ#How_do_I_add_an_additional_spouse.3F'>How do I add "
-#~ "an additional spouse?</a>\n"
-#~ msgstr ""
-#~ "  2. <a wiki='%s_-_FAQ#How_do_I_add_an_additional_spouse.3F'>Hur lägger "
-#~ "jag till ytterligare makar?</a>\n"
-
-#~ msgid ""
-#~ "  3. <a wiki='%s_-_FAQ#How_do_I_remove_a_spouse.3F'>How do I remove a "
-#~ "spouse?</a>\n"
-#~ msgstr ""
-#~ "  3. <a wiki='%s_-_FAQ#How_do_I_remove_a_spouse.3F'>Hur tar jag bort en "
-#~ "make/maka?</a>\n"
-
-#~ msgid ""
-#~ "  4. <a wiki='%s_-_FAQ#How_do_I_keep_backups.3F'>How do I make backups "
-#~ "safely?</a>\n"
-#~ msgstr ""
-#~ "  4. <a wiki='%s_-_FAQ#How_do_I_keep_backups.3F'>Hur gör jag "
-#~ "säkerhetskopiering säkrast?</a>\n"
-
-#~ msgid ""
-#~ "  6. <a wiki='%s_-_Entering_and_Editing_Data:_Detailed_-"
-#~ "_part_1#Editing_Information_About_Relationships'>How should information "
-#~ "about marriages be entered?</a>\n"
-#~ msgstr ""
-#~ "  6. <a wiki='%s_-_Entering_and_Editing_Data:_Detailed_-"
-#~ "_part_1#Editing_Information_About_Relationships'>Hur bör information om "
-#~ "giftermål matas in?</a>\n"
-
-#~ msgid ""
-#~ "  9. <a wiki='%s_-_FAQ#How_do_you_find_unused_media_objects.3F'>How do "
-#~ "you find unused media objects?</a>\n"
-#~ msgstr ""
-#~ "  9. <a wiki='%s_-_FAQ#How_do_you_find_unused_media_objects.3F'>Hur "
-#~ "hittar du oanvända mediaobjekt?</a>\n"
-
-#~ msgid ""
-#~ " 10. <a wiki='%s_-"
-#~ "_FAQ#How_can_I_publish_web_sites_generated_by_GRAMPS.3F'>How can I make a "
-#~ "website with Gramps and my tree?</a>\n"
-#~ msgstr ""
-#~ " 10. <a wiki='%s_-"
-#~ "_FAQ#How_can_I_publish_web_sites_generated_by_GRAMPS.3F'>Hur kan jag göra "
-#~ "en hemsida med Gramps av mitt Släkträd?</a>\n"
-
-#~ msgid ""
-#~ " 11. <a href='http://sourceforge.net/mailarchive/message.php?"
-#~ "msg_id=21487967'>How do I record one's occupation?</a>\n"
-#~ msgstr ""
-#~ " 11. <a href='http://sourceforge.net/mailarchive/message.php?"
-#~ "msg_id=21487967'>Hur noterar jag yrke?</a>\n"
-
-#~ msgid ""
-#~ " 12. <a wiki='%s_-_FAQ#What_do_I_do_if_I_have_found_a_bug.3F'>What do I "
-#~ "do if I have found a bug?</a>\n"
-#~ msgstr ""
-#~ " 12. <a wiki='%s_-_FAQ#What_do_I_do_if_I_have_found_a_bug.3F'>Vad gör jag "
-#~ "om jag hittat en bug?</a>\n"
-
-#~ msgid ""
-#~ " 13. <a wiki='Portal:Using_GRAMPS'>Is there a manual for Gramps?</a>\n"
-#~ msgstr ""
-#~ " 13. <a wiki='Portal:Using_GRAMPS'>Finns det en handbok för Gramps?</a>\n"
-
-#~ msgid " 15. <a wiki='Category:How_do_I...'>How do I ...?</a>\n"
-#~ msgstr " 15. <a wiki='Category:How_do_I...'>Hur gör jag ...?</a>\n"
-
-#~ msgid " 16. <a wiki='How_you_can_help'>How can I help with Gramps?</a>\n"
-#~ msgstr " 16. <a wiki='How_you_can_help'>Hur kan jag stötta Gramps?</a>\n"
-
-#~ msgid "http://gramps-project.org/"
-#~ msgstr "http://gramps-project.org/"
-
-#~ msgid ""
-#~ "http://www.gramps-project.org/wiki/index.php?title=Start_with_Genealogy"
-#~ msgstr ""
-#~ "http://www.gramps-project.org/wiki/index.php?title=Start_with_Genealogy"
-
-#~ msgid ""
-#~ "http://www.gramps-project.org/wiki/index.php?title=Gramps_4.0_Wiki_Manual"
-#~ msgstr ""
-#~ "http://www.gramps-project.org/wiki/index.php?title=Gramps_4.0_Wiki_Manual"
-
-#~ msgid "http://gramps-project.org/contact/"
-#~ msgstr "http://gramps-project.org/contact/"
-
-#~ msgid "Include private records"
-#~ msgstr "Ta med privata poster"
-
-#~ msgid ""
-#~ "Whether to include names, dates, and families that are marked as private."
-#~ msgstr ""
-#~ "Huruvida ta med namn, datum och familjer, vilka är att betrakta som "
-#~ "privata."
-
-#~ msgid ""
-#~ "Include the dates that the individual was born, got married and/or died "
-#~ "in the graph labels."
-#~ msgstr ""
-#~ "Ta med de datum när personen föddes, gifte sig och/eller dog i "
-#~ "diagrametiketterna."
-
-#~ msgid "Use place when no date"
-#~ msgstr "Använd plats när datum saknas"
-
-#~ msgid ""
-#~ "When no birth, marriage, or death date is available, the correspondent "
-#~ "place field will be used."
-#~ msgstr ""
-#~ "När inget födelse-, giftermåls- eller dödsdatum finns tillgängligt, "
-#~ "kommer motsvarande platsfält att användas."
-
-#~ msgid "Include IDs"
-#~ msgstr "Ta med ID:n"
-
-#~ msgid "Include individual and family IDs."
-#~ msgstr "Ta med individ- och familje-ID."
-
-#~ msgid "SUBM (Submitter): @%s@"
-#~ msgstr "SUBM (Submitter): @%s@"
-
-#~ msgid "Invalid line %d in GEDCOM file."
-#~ msgstr "Ogiltig rad %d i GEDCOM-fil."
-
-#~ msgid "%(name)s [%(gid)s]"
-#~ msgstr "%(name)s [%(gid)s]"
-
-#~ msgid "Include private data"
-#~ msgstr "Ta med privata poster"
-
-#~ msgid "Webkit module not loaded."
-#~ msgstr "Webkit-modul ej laddad"
-
-#~ msgid ""
-#~ "Webkit module not loaded. Embedded web page viewing will not be "
-#~ "available. Use your package manager to install gir1.2-webkit-3.0"
-#~ msgstr ""
-#~ "Webkit-modul ej laddad. Inbäddad web-sideläsning kommer inte att vara "
-#~ "tillgängligt. Använd din pakethanterare till att installera girl1.2-"
-#~ "webkit-3.0"
-
-#~ msgid "Html View"
-#~ msgstr "Html-vy"
-
-#~ msgid "A view showing html pages embedded in Gramps"
-#~ msgstr "En vy, som tillåter dig att se html-sidor inbäddade i Gramps"
-
-#~ msgid "Web"
-#~ msgstr "Webb"
-
-#~ msgid "HtmlView"
-#~ msgstr "Html-vy"
-
-#~ msgid "Go to the previous page in the history"
-#~ msgstr "Gå till föregående sida i historiken"
-
-#~ msgid "Go to the next page in the history"
-#~ msgstr "Gå till nästa sida i historiken"
-
-#~ msgid "_Refresh"
-#~ msgstr "_Friska upp"
-
-#~ msgid "Stop and reload the page."
-#~ msgstr "Stanna och ladda om sidan."
-
-#~ msgid "Start page for the Html View"
-#~ msgstr "Begynnelsesida för Html-vyn"
-
-#~ msgid ""
-#~ "Type a webpage address at the top, and hit the execute button to load a "
-#~ "webpage in this page\n"
-#~ "<br>\n"
-#~ "For example: <b>http://gramps-project.org</p>"
-#~ msgstr ""
-#~ "Skriv in en webb-adress upptill och tryck på utförknappen för att ladda "
-#~ "en webb-sida till denna sida\n"
-#~ "<br>\n"
-#~ "Till exempel: <b>http://gramps-project.org</p>"
-
-#~ msgid "<br />Created for <a href = \"%(url)s\">%(name)s</a>"
-#~ msgstr "<br />Skapad åt <a href = \"%(url)s\">%(name)s</a>"
-
-#~ msgid "Whether to include private objects"
-#~ msgstr "Huruvida ta med privata objekt"
-
-#~ msgid ""
-#~ "Created for <a href=\"mailto:%(email)s?subject=WebCal\">%(author)s</a>"
-#~ msgstr ""
-#~ "Skapad åt <a href=\"mailto:%(email)s?subject=WebCal\">%(author)s</a>"
-
-#~ msgid ""
-#~ "Generated by <a href=\"http://gramps-project.org\">Gramps</a> on %(date)s"
-#~ msgstr "Skapad av <a href=\"http://gramps-project.org\">Gramps</a> %(date)s"
-
-#~ msgid ""
-#~ "You have attempted to use the existing Gramps ID with value "
-#~ "%(gramps_id)s. This value is already used by '%(prim_object)s'. Please "
-#~ "enter a different ID or leave blank to get the next available ID value."
-#~ msgstr ""
-#~ "Du har försökt att använda ett befintligt Gramps-ID med värdet "
-#~ "%(gramps_id)s. Detta värde används redan av '%(prim_object)s'. Skriv in "
-#~ "ett annat ID eller lämna tomt för att få nästa tillgängliga ID-värde."
-
-#~ msgid "Top level place"
-#~ msgstr "Toppnivå"
-
-#~ msgid "Source: Publication"
-#~ msgstr "Källa: Publikation"
-
-#~ msgid "Source: Note"
-#~ msgstr "Käll: Notis"
-
-#~ msgid "Citation: ID"
-#~ msgstr "Citering: ID"
-
-#~ msgid "Citation: Volume/Page"
-#~ msgstr "Citering: Volym/sida"
-
-#~ msgid "Citation: Date"
-#~ msgstr "Citering: datum"
-
-#~ msgid "Citation: Note"
-#~ msgstr "Citering: Notiser"
-
-#~ msgid "..."
-#~ msgstr "..."
-
-#~ msgid "Sweden - Holidays"
-#~ msgstr "Sverige - Helgdagar"
-
-#~ msgid "YES"
-#~ msgstr "Ja"
-
-#~ msgid ""
-#~ "Gramps stores its data in a Berkeley Database. The family Tree you try to "
-#~ "load was created with version %(env_version)s of the Berkeley DB. "
-#~ "However, the Gramps version in use right now employs version "
-#~ "%(bdb_version)s of the Berkeley DB. So you are trying to load data "
-#~ "created in a newer format into an older program; this is bound to fail. "
-#~ "The right approach in this case is to use XML export and import. So try "
-#~ "to open the family Tree on that computer with that software that created "
-#~ "the Family Tree, export it to XML and load that XML into the version of "
-#~ "Gramps you intend to use."
-#~ msgstr ""
-#~ "Gramps lagrar sina data i en Berkeley databas. Det släktträd, du försökte "
-#~ "ladda, var skapat med version %(env_version)s av Berkeley DB. Den "
-#~ "version, som Gramps nu använder är  %(bdb_version)s. Det du försöker "
-#~ "göra, är att ladda data, skapat i ett nyare format, till ett gammalt "
-#~ "program, vilket kommer att misslyckas. Rätt tillvägagångssätt är att "
-#~ "använda XML export och import. Så försök att öppna släktträdet på en "
-#~ "dator med den programvara, som trädet skapades med, exportera till XML "
-#~ "och ladda denna XML till den version av Gramps du tänker använda."
-
-#~ msgid ""
-#~ "The Family Tree structure has changed since the version of Gramps you "
-#~ "used to create this tree.\n"
-#~ "\n"
-#~ "Therefore, you cannot open this Family Tree without upgrading the "
-#~ "definition of the structure.\n"
-#~ "If you upgrade then you won't be able to use previous versions of Gramps, "
-#~ "also not with the .gramps xml export!\n"
-#~ "\n"
-#~ "Upgrading is a difficult task that may not be interrupted, or Gramps will "
-#~ "irretrievably corrupt your tree. Therefore, create a backup copy first. "
-#~ "See: \n"
-#~ "http://www.gramps-project.org/wiki/index.php?title=How_to_make_a_backup"
-#~ msgstr ""
-#~ "Strukturen på ditt släktträd har ändrats sedan den version av Gramps du "
-#~ "använde för att skapa detta träd.\n"
-#~ "Därför kan du inte öppna detta släktträd utan att uppgradera strukturens "
-#~ "definition.\n"
-#~ "Om du uppgraderar kan du inte sedan använda tidigare versioner av Gramps "
-#~ "även med .gramps xml export!\n"
-#~ "\n"
-#~ "Uppgradering är ett svårt jobb, som ej får avbrytas för då har Gramps "
-#~ "förstört ditt släkt träd. Därför är det bästa att först ta en "
-#~ "säkerhetskopia. Se: \n"
-#~ "http://www.gramps-project.org/wiki/index.php?title=How_to_make_a_backup"
-
-#~ msgid "Regular expression:"
-#~ msgstr "Reguljärt uttryck:"
-
-#~ msgid "Citations having notes containing <regular expression>"
-#~ msgstr "Citeringar med notiser innehållande <reguljärt uttryck>"
-
-#~ msgid "Citations with <Id> matching regular expression"
-#~ msgstr "Citeringar med <id> som matchar reguljärt uttryck"
-
-#~ msgid "Events having notes containing <regular expression>"
-#~ msgstr "Händelser med <reguljärt uttryck> i notiser"
-
-#~ msgid "Events with <Id> matching regular expression"
-#~ msgstr "Händelser med <id> som matchar reguljärt uttryck"
-
-#~ msgid "Families with child with the <Id>"
-#~ msgstr "Familjer med barn med <id>"
-
-#~ msgid "Families with father with the <Id>"
-#~ msgstr "Familjer med fader med id <id>"
-
-#~ msgid "Families having notes containing <regular expression>"
-#~ msgstr "Familjer med <reguljärt uttryck> i notiser"
-
-#~ msgid "Families with mother with the <Id>"
-#~ msgstr "Familjer med mor med <id>"
-
-#~ msgid "Families with <Id> matching regular expression"
-#~ msgstr "Familjer vars <id> matchar reguljärt uttryck"
-
-#~ msgid "Media objects having notes containing <regular expression>"
-#~ msgstr "Mediaobjekt med <reguljärt uttryck> i notiser"
-
-#~ msgid "Media Objects with <Id> matching regular expression"
-#~ msgstr "Mediaobjekt med <id> som matchar reguljärt uttryck"
-
-#~ msgid "Notes containing <regular expression>"
-#~ msgstr "Notiser innehållande <reguljärt uttryck>"
-
-#~ msgid "Notes with <Id> matching regular expression"
-#~ msgstr "Notiser med <id> som matchar reguljärt uttryck"
-
-#~ msgid "People having notes containing <regular expression>"
-#~ msgstr "Personer med <reguljärt uttryck> i notiser"
-
-#~ msgid "People with <Id> matching regular expression"
-#~ msgstr "Personer med <id> som matchar reguljärt uttryck"
-
-#~ msgid "Expression:"
-#~ msgstr "Utryck:"
-
-#~ msgid "People matching the <regex_name>"
-#~ msgstr "Personer som matchar <reguljärt uttryck för namn>"
-
-#~ msgid "Matches people's names with a specified regular expression"
-#~ msgstr "Matchar personers namn med angivet reguljärt uttryck"
-
-#~ msgid "Places having notes containing <regular expression>"
-#~ msgstr "Platser med <reguljärt uttryck> i notiser"
-
-#~ msgid "Places with <Id> matching regular expression"
-#~ msgstr "Platser med <id> som matchar reguljärt uttryck"
-
-#~ msgid "Repositories having notes containing <regular expression>"
-#~ msgstr "Arkivplatser med <reguljärt uttryck> i notiser"
-
-#~ msgid "Repository name containing <substring>"
-#~ msgstr "Arkivplatser med <delsträng> i namn"
-
-#~ msgid "Repositories with <Id> matching regular expression"
-#~ msgstr "Arkivplatser med <id> som matchar reguljärt uttryck"
-
-#~ msgid "Sources having notes containing <regular expression>"
-#~ msgstr "Källor med <reguljärt uttryck> i notiser"
-
-#~ msgid "Sources with <Id> matching regular expression"
-#~ msgstr "Källor med <id> som matchar reguljärt uttryck"
-
-#~ msgid "%d year"
-#~ msgid_plural "%d years"
-#~ msgstr[0] "%d år"
-#~ msgstr[1] "%d år"
-
-#~ msgid "%d month"
-#~ msgid_plural "%d months"
-#~ msgstr[0] "%d månad"
-#~ msgstr[1] "%d månader"
-
-#~ msgid "%d day"
-#~ msgid_plural "%d days"
-#~ msgstr[0] "%d dag"
-#~ msgstr[1] "%d dagar"
-
-#~ msgid "death event without date"
-#~ msgstr "dödshändelser utan datum"
-
-#~ msgid "death-related evidence"
-#~ msgstr "dödsrelaterat bevis"
-
-#~ msgid "death-related evidence without date"
-#~ msgstr "dödsrelaterat bevis utan datum"
-
-#~ msgid "birth-related evidence"
-#~ msgstr "födelserelaterat bevis"
-
-#~ msgid "Chinese"
-#~ msgstr "Kinesiska"
-
-#~ msgid "Brazil"
-#~ msgstr "Brasilianska"
-
-#~ msgid "Portugal"
-#~ msgstr "Portugal"
-
-#~ msgid "Need to upgrade database!"
-#~ msgstr "Databasen behöver uppgraderas!"
-
-#~ msgid "Upgrade now"
-#~ msgstr "Uppgadera nu"
-
-#~ msgid "Need to upgrade BSDDB database!"
-#~ msgstr "BSDDB-databasen behöver uppgraderas!"
-
-#~ msgid "Create and add a new data entry"
-#~ msgstr "Skapa och lägg till ett nytt inmatningsfält"
-
-#~ msgid "Remove the existing data entry"
-#~ msgstr "Ta bort det befintliga inmatningsfältet"
-
-#~ msgid "Edit the selected data entry"
-#~ msgstr "Redigera det valda inmatningsfältet"
-
-#~ msgid "Move the selected data entry upwards"
-#~ msgstr "Flytta det valda inmatningsfältet uppåt"
-
-#~ msgid "Move the selected data entry downwards"
-#~ msgstr "Flytta det valda inmatningsfältet neråt"
-
-#~ msgid "_Data"
-#~ msgstr "_Data"
-
-#~ msgid "Events father"
-#~ msgstr "Fars händelser"
-
-#~ msgid "Events mother"
-#~ msgstr "Mors händelser"
-
-#~ msgid "Personal Events"
-#~ msgstr "Personliga händelser"
-
-#~ msgid "With %(namepartner)s (%(famid)s)"
-#~ msgstr "Med %(namepartner)s (%(famid)s)"
-
-#~ msgid "_Location"
-#~ msgstr "P_lats"
-
-#~ msgid "%d Person"
-#~ msgid_plural "%d People"
-#~ msgstr[0] "%d person"
-#~ msgstr[1] "%d personer"
-
-#~ msgid "Spelling checker could not be attached to TextView"
-#~ msgstr "Stavningskontroll kunde ej kopplas till TextView"
-
-#~ msgid "Error Opening File"
-#~ msgstr "Fel vid filöppning"
-
-#~ msgid "Remove selected items?"
-#~ msgstr "Ta bort valda poster?"
-
-#~ msgid "<Countries>"
-#~ msgstr "<Countries>"
-
-#~ msgid "<States>"
-#~ msgstr "<States>"
-
-#~ msgid "<Counties>"
-#~ msgstr "<Counties>"
-
-#~ msgid "<Places>"
-#~ msgstr "<Places>"
-
-#~ msgid "<no name>"
-#~ msgstr "<no name>"
-
-#~ msgid "short for married|m."
-#~ msgstr "g."
-
-#~ msgid "Timeline Graph for %s"
-#~ msgstr "Tidslinje för %s"
-
-#~ msgid "Active person: <b>%s</b>"
-#~ msgstr "Aktiv person: <b>%s</b>"
-
-#~ msgid "No Active Person selected."
-#~ msgstr "Ingen aktiv person vald."
-
-#~ msgid "   sp. "
-#~ msgstr "   m. "
-
-#~ msgid "Gramplet showing active person's attributes"
-#~ msgstr "Gramplet med aktiv persons attribut"
-
-#~ msgid "%d children"
-#~ msgstr "%d barn"
-
-#~ msgid "Patronymic name skipped: '%(patronym)s' (%(msg)s)"
-#~ msgstr "Patronymiskt namn överhoppades: '%(patronym)s' (%(msg)s)"
-
-#~ msgid ""
-#~ "The .gramps file you are importing does not contain a valid xml-namespace "
-#~ "number.\n"
-#~ "\n"
-#~ "The file will not be imported."
-#~ msgstr ""
-#~ "Den .gramps-fil du importerar innehåller ej ett giltig XML-namspace-tal.\n"
-#~ "\n"
-#~ "Filen kommer ej att importeras."
-
-#~ msgid "Import file contains unacceptable XML namespace version"
-#~ msgstr "Importfilen innehååler en oacceptabel XML-namespace-version"
-
-#~ msgid ""
-#~ "\n"
-#~ "%d matches.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "%d matchningar.\n"
-
-#~ msgid "Title format"
-#~ msgstr "Titelformat"
-
-#~ msgid "Individual Facts"
-#~ msgstr "Individuella fakta"
-
-#~ msgid "%s in %s. "
-#~ msgstr "%s i %s. "
-
-#~ msgid "%d event record was modified."
-#~ msgid_plural "%d event records were modified."
-#~ msgstr[0] "%d händelse ändrades.d."
-#~ msgstr[1] "%d händelser ändrades."
-
-#~ msgid "%d person was referenced but not found\n"
-#~ msgid_plural "%d persons were referenced, but not found\n"
-#~ msgstr[0] "%d person, som refererats till, kunde inte hittas\n"
-#~ msgstr[1] "%d personer, som refererats till, kunde inte hittas\n"
-
-#~ msgid "%(quantity)d media object was referenced, but not found\n"
-#~ msgid_plural "%(quantity)d media objects were referenced, but not found\n"
-#~ msgstr[0] ""
-#~ "%(quantity)d mediaobjekt, som refererats till, kunde inte hittas\n"
-#~ msgstr[1] ""
-#~ "%(quantity)d mediaobjekt, som refererats till, kunde inte hittas\n"
-
-#~ msgid "Descendant Browser tool"
-#~ msgstr "Bläddrare för ättlingar"
-
-#~ msgid "Python evaluation window"
-#~ msgstr "Fönster för Python"
-
-#~ msgid "Uncollected Objects Tool"
-#~ msgstr "Verktyg för ej skräpsamlade objekt"
-
-#~ msgid "Interactive Descendant Browser"
-#~ msgstr "Bläddra bland ättlingar interaktivt"
-
-#~ msgid "Provides a browsable hierarchy based on the active person"
-#~ msgstr "Skapar en bläddringsbar lista baserad på den aktiva personen."
-
-#~ msgid "Generates SoundEx codes for names"
-#~ msgstr "Skapar SoundEx-koder för namn."
-
-#~ msgid "Title or Page"
-#~ msgstr "Titel eller sida"
-
-#~ msgid "Places places map"
-#~ msgstr "Karta för platser"
-
-#~ msgid " (%d sibling)"
-#~ msgid_plural " (%d siblings)"
-#~ msgstr[0] " (%d syskon)"
-#~ msgstr[1] " (%d syskon)"
-
-#~ msgid " (%d child)"
-#~ msgid_plural " (%d children)"
-#~ msgstr[0] " (%d barn)"
-#~ msgstr[1] " (%d barn)"
-
-#~ msgid "Data Map"
-#~ msgstr "Datakarta"
-
-#~ msgid "Telephone"
-#~ msgstr "Telefon"
-
-#~ msgid ""
-#~ "<b>Note:</b> Any changes in the shared citation information will be "
-#~ "reflected in the citation itself, for all items that reference the "
-#~ "citation."
-#~ msgstr ""
-#~ "<b>Observera:</b> Alla ändringar i en delad citeringinformation kommer "
-#~ "att återspeglas i citeringen själv och därmed alla poster som refererar "
-#~ "till den."
-
-#~ msgid "_Pub. Info.:"
-#~ msgstr "_Pub. Info.:"
-
-#~ msgid "Shared source information"
-#~ msgstr "Delad källinformation"
-
-#~ msgid "Referenced Region"
-#~ msgstr "Refererat område"
-
-#~ msgid ""
-#~ "Lowest level of a place division: eg the street name. \n"
-#~ "Use Alternate Locations tab to store the current name."
-#~ msgstr ""
-#~ "Understa nivån för en platsindelning: t. ex. gatunamn.\n"
-#~ "Använd alternativt plats till att lagra aktuellt namn."
-
-#~ msgid ""
-#~ "The town or city where the place is. \n"
-#~ "Use Alternate Locations tab to store the current name."
-#~ msgstr ""
-#~ "Den kommun eller stad, där platsen ligger.\n"
-#~ "Använd alternativ plats för att spara aktuellt namn."
-
-#~ msgid "Count_ry:"
-#~ msgstr "La_nd:"
-
-#~ msgid "The country where the place is. \n"
-#~ msgstr "Det land, där platsen ligger.\n"
-
-#~ msgid ""
-#~ "A district within, or a settlement near to, a town or city.\n"
-#~ "Use Alternate Locations tab to store the current name."
-#~ msgstr ""
-#~ "Ett område inom eller bebyggelse nära till en kommun eller stad.\n"
-#~ "Använd alternativ plats för att spara aktuellt namn."
-
-#~ msgid "window2"
-#~ msgstr "window2"
-
-#~ msgid "Location:"
-#~ msgstr "Plats:"
-
-#~ msgid "window1"
-#~ msgstr "window1"
-
-#~ msgid "Double-click on the row to edit personal information"
-#~ msgstr "Dubbelklicka på raden för att redigera personlig information"
-
-#~ msgid "Output Window"
-#~ msgstr "Utmatningsfönster"
-
-#~ msgid "Error Window"
-#~ msgstr "Felfönster"
-
-#~ msgid "Uncollected Objects"
-#~ msgstr "Ej samlade objekt"
-
-#~ msgid "Close Window"
-#~ msgstr "Stäng fönster"
-
-#~ msgid " (%(value)s)"
-#~ msgstr " (%(value)s)"
-
-#~ msgid "Requested %s does not exist."
-#~ msgstr "Begärd %s finns inte"
-
-#~ msgid "Browse"
-#~ msgstr "Bläddra"
-
-#~ msgid "User"
-#~ msgstr "Användare"
-
-#~ msgid "Requested user not found."
-#~ msgstr "Önskad användare saknas."
-
-#~ msgid "Requested page is not accessible."
-#~ msgstr "Önskad sida är ej åtkomlig."
-
-#~ msgid "Requested page type not known"
-#~ msgstr "Önskad sidotyp är okänd"
-
-#~ msgid "To Do"
-#~ msgstr "Att göra"
-
-#~ msgid "Provides Textual Translation."
-#~ msgstr "Tillhandahåller en textöversättning."
-
-#~ msgid "Father Age"
-#~ msgstr "Faders ålder"
-
-#~ msgid "Mother Age"
-#~ msgstr "Moders ålder"
-
-#~ msgid "Family tree"
-#~ msgstr "Släktträd"
-
-#~ msgid ""
-#~ "You cannot open this database without upgrading it.\n"
-#~ "If you upgrade then you won't be able to use previous versions of "
-#~ "Gramps.\n"
-#~ "You might want to make a backup copy first."
-#~ msgstr ""
-#~ "Du kan inte öppna denna databas utan att uppgradera den.\n"
-#~ "Om du uppgraderar kan du sen inte använda tidigare versioner av Gramps.\n"
-#~ "Du vill kanske göra en säkerhetskopia först."
-
-#~ msgid "<-- Image Types -->"
-#~ msgstr "<-- Bildtyper -->"
-
-#~ msgid ""
-#~ "Warning:  Changing this entry will update the Media object title field in "
-#~ "Gramps not Exiv2 metadata."
-#~ msgstr ""
-#~ "Varning: Ändring av detta fält kommer att uppdatera mediaobjektets "
-#~ "titelfält i Gramps ej i Exiv2 metadata."
-
-#~ msgid "Provide a short description for this image."
-#~ msgstr "Ge en kort beskrivning på denna bild."
-
-#~ msgid ""
-#~ "Enter the Artist/ Author of this image.  The person's name or the company "
-#~ "who is responsible for the creation of this image."
-#~ msgstr ""
-#~ "Skriv in bildens skapare. Personens namn eller det företag, som är "
-#~ "ansvarig för skapande av denna bild."
-
-#~ msgid "Enter the copyright information for this image. \n"
-#~ msgstr "Skriv in upphovsrättsinformation för denna bild. \n"
-
-#~ msgid ""
-#~ "The original date/ time when the image was first created/ taken as in a "
-#~ "photograph.\n"
-#~ "Example: 1830-01-1 09:30:59"
-#~ msgstr ""
-#~ "Det ursprungliga datum/klockslag som gällde då bilden första skapades "
-#~ "eller togs.\n"
-#~ "Exempel: 1830-01-1 09:30:59"
-
-#~ msgid ""
-#~ "This is the date/ time that the image was last changed/ modified.\n"
-#~ "Example: 2011-05-24 14:30:00"
-#~ msgstr ""
-#~ "Detta är det datum/klockslag som bilden senast ändrades.\n"
-#~ "Exemple: 2011-05-24 14:30:00"
-
-#~ msgid ""
-#~ "Enter the Latitude GPS coordinates for this image,\n"
-#~ "Example: 43.722965, 43 43 22 N, 38° 38′ 03″ N, 38 38 3"
-#~ msgstr ""
-#~ "Skriv in GPS-latitudkoordinat för din bild,\n"
-#~ "Exempel: 43.722965, 43 43 22 N, 38° 38′ 03″ N, 38 38 3"
-
-#~ msgid ""
-#~ "Enter the Longitude GPS coordinates for this image,\n"
-#~ "Example: 10.396378, 10 23 46 E, 105° 6′ 6″ W, -105 6 6"
-#~ msgstr ""
-#~ "Skriv in GPS-longitudkoordinat för din bild,\n"
-#~ "Exempel: 10.396378, 10 23 46 E, 105° 6′ 6″ W, -105 6 6"
-
-#~ msgid ""
-#~ "This is the measurement of Above or Below Sea Level.  It is measured in "
-#~ "meters.Example: 200.558, -200.558"
-#~ msgstr "Detta är höjden över havet mätt i meter."
-
-#~ msgid ""
-#~ "Displays the Gramps Wiki Help page for 'Edit Image Exif Metadata' in your "
-#~ "web browser."
-#~ msgstr ""
-#~ "Visar Gramps Wiki hjälpsida för 'Redigera Exif-metadata' på din "
-#~ "nätbläddrare"
-
-#~ msgid ""
-#~ "This will open up a new window to allow you to edit/ modify this image's "
-#~ "Exif metadata.\n"
-#~ "  It will also allow you to be able to Save the modified metadata."
-#~ msgstr ""
-#~ "Detta kommer att öppna ett nytt fönster, som tillåter dig att redigera "
-#~ "denna bilds Exif-metadat.\n"
-#~ "  Den kommer också att ge dig möjlighet att spara de ändrade metadata."
-
-#~ msgid "Will produce a Popup window showing a Thumbnail Viewing Area"
-#~ msgstr ""
-#~ "Kommer att skapa ett pop-upp-fönster visande en yta med miniatyrbilder"
-
-#~ msgid ""
-#~ "Select from a drop- down box the image file type that you would like to "
-#~ "convert your non- Exiv2 compatible media object to."
-#~ msgstr ""
-#~ "Välj från en rullgardinsmeny den filtyp du vill omvandla  din ej- Exiv2 "
-#~ "kompatible mediaobjekt till."
-
-#~ msgid ""
-#~ "If your image is not of an image type that can have Exif metadata read/ "
-#~ "written to/from, convert it to a type that can?"
-#~ msgstr ""
-#~ "Om din bild är av sådan typ, som ej kan ha Exif metadata, läs/skriv till/"
-#~ "från, omvandla till en bildtyp, som kan?"
-
-#~ msgid ""
-#~ "WARNING:  This will completely erase all Exif metadata from this image!  "
-#~ "Are you sure that you want to do this?"
-#~ msgstr ""
-#~ "Varning: Detta kommer att helt radera alla Exif-metadata från denna bild! "
-#~ "Är du säker på att du vill göra det?"
-
-#~ msgid "Thumbnail"
-#~ msgstr "Minatyrbild"
-
-#~ msgid "Select an image to begin..."
-#~ msgstr "Klicka på en bild för att börja..."
-
-#~ msgid ""
-#~ "Image is NOT readable,\n"
-#~ "Please choose a different image..."
-#~ msgstr ""
-#~ "Bilden omöjlig att läsa.\n"
-#~ "Välj en annan bild..."
-
-#~ msgid ""
-#~ "Image is NOT writable,\n"
-#~ "You will NOT be able to save Exif metadata...."
-#~ msgstr ""
-#~ "Bilden är ej skrivbar.\n"
-#~ "Du kommer ej att kunna spara Exif-metadata..."
-
-#~ msgid "Please convert this image to an Exiv2- compatible image type..."
-#~ msgstr "Omvandla denna bild till en Exiv2-kompatibel bildtyp..."
-
-#~ msgid "Image Size : %04(width)d x %04(height)d pixels"
-#~ msgstr "Bildstorlek : %04(width)d x %04(height)d pixels"
-
-#~ msgid "Displaying Exif metadata..."
-#~ msgstr "Visar Exif-metadata..."
-
-#~ msgid "Click Close to close this Thumbnail View Area."
-#~ msgstr "Klicka på Stäng för att stänga denna miniatyrbildsplats."
-
-#~ msgid "Thumbnail View Area"
-#~ msgstr "Minatyrbildsplats"
-
-#~ msgid "Edit Image Exif Metadata"
-#~ msgstr "Redigera bilds Exif-metadata"
-
-#~ msgid ""
-#~ "WARNING: You are about to convert this image into a .jpeg image.  Are you "
-#~ "sure that you want to do this?"
-#~ msgstr ""
-#~ "Varning: Du är på väg att omvandla denna bild till en .jpeg-bild! Är du "
-#~ "säker på att du vill göra det?"
-
-#~ msgid ""
-#~ "Your image has been converted and the original file has been deleted, and "
-#~ "the full path has been updated!"
-#~ msgstr ""
-#~ "Din bild har blivit omvandlad och orginalbilden har tagits bort samt "
-#~ "komplett sökväg har uppdaterats!"
-
-#~ msgid ""
-#~ "There has been an error, Please check your source and destination file "
-#~ "paths..."
-#~ msgstr "Det har inträffat et fel. Kontrollera din käll- och målsökvägar..."
-
-#~ msgid ""
-#~ "There was an error in deleting the original file.  You will need to "
-#~ "delete it yourself!"
-#~ msgstr ""
-#~ "Det blev fel vid bortagning av orginalfilen. Du måste ta bort den själv."
-
-#~ msgid "There was an error in converting your image file."
-#~ msgstr "Det inträffade ett fel vid omvandling av din bildfil."
-
-#~ msgid "Media Path Update"
-#~ msgstr "Uppdatering av mediasökväg"
-
-#~ msgid "There has been an error in updating the image file's path!"
-#~ msgstr "Det har inträffat ett fel vid uppdatering av bildens sökväg!"
-
-#~ msgid ""
-#~ "Click the close button when you are finished modifying this image's Exif "
-#~ "metadata."
-#~ msgstr ""
-#~ "Klicka på stängningsknappen när du är färdig med ändringar i denna bilds "
-#~ "metadata."
-
-#~ msgid "Saves a copy of the data fields into the image's Exif metadata."
-#~ msgstr "Sparar en kopia av datafälten i bilens Exiv metadata."
-
-#~ msgid "Re -display the data fields that were cleared from the Edit Area."
-#~ msgstr "Vosa igen de datafält, som rensades från redigeringsytan."
-
-#~ msgid "This button will clear all of the data fields shown here."
-#~ msgstr "Denna knapp kommer att rensa visade datafält."
-
-#~ msgid ""
-#~ "Closes this popup Edit window.\n"
-#~ "WARNING: This action will NOT Save any changes/ modification made to this "
-#~ "image's Exif metadata."
-#~ msgstr ""
-#~ "Stänger detta redigeringsfönster.\n"
-#~ "VARNING: Denna åtgärd kommer EJ att spara några ändringar till bildens "
-#~ "Exif metadata."
-
-#~ msgid "Media Object Title"
-#~ msgstr "Mediaobjekttitel"
-
-#~ msgid "media Title: "
-#~ msgstr "Mediatitel: "
-
-#~ msgid "General Data"
-#~ msgstr "Allmänt"
-
-#~ msgid "Artist: "
-#~ msgstr "Artist: "
-
-#~ msgid "Copyright: "
-#~ msgstr "Copyright: "
-
-#~ msgid "Date/ Time"
-#~ msgstr "Datum/tid"
-
-#~ msgid "Original: "
-#~ msgstr "Original: "
-
-#~ msgid "Latitude/ Longitude/ Altitude GPS coordinates"
-#~ msgstr "Latitud/ longitud/ höjd GPS koordinater"
-
-#~ msgid "Latitude :"
-#~ msgstr "Latitud:"
-
-#~ msgid "Longitude :"
-#~ msgstr "Longitud:"
-
-#~ msgid "Altitude :"
-#~ msgstr "Höjd:"
-
-#~ msgid "Bad Date/Time"
-#~ msgstr "Felaktig datum/tid"
-
-#~ msgid ""
-#~ "WARNING!  You are about to completely delete the Exif metadata from this "
-#~ "image?"
-#~ msgstr ""
-#~ "Varning: Du är på väg att helt ta bort Exif-metadata från denna bild?"
-
-#~ msgid "Media Title Update"
-#~ msgstr "Uppdatering av mediatitel"
-
-#~ msgid "Media Object Date Created"
-#~ msgstr "Mediaobjektdatum skapat"
-
-#~ msgid "Saving Exif metadata to this image..."
-#~ msgstr "Sparar Exif-metadata till bild..."
-
-#~ msgid "All Exif metadata has been deleted from this image..."
-#~ msgstr "All Exif-metadata har raderats från denna bild..."
-
-#~ msgid "There was an error in stripping the Exif metadata from this image..."
-#~ msgstr ""
-#~ "Det inträffade ett fel vid utplockning av Exif metadata från denna bild..."
-
-#~ msgid "Gramplet to view, edit, and save image Exif metadata"
-#~ msgstr "Gramplet för att se, redigera och spara bilds Exif-metadata"
-
-#~ msgid "Edit Exif Metadata"
-#~ msgstr "Redigera Exif-metadata"
-
-#~ msgid "Base class for ImportGrdb"
-#~ msgstr "Basklass för ImportGrdb"
-
-#~ msgid ""
-#~ "WARNING: osmgpsmap module not loaded. Geography functionality will not be "
-#~ "available."
-#~ msgstr ""
-#~ "Varning:  osmgpsmap-modulen el laddad. Geografifunktionalitet kommer att "
-#~ "saknas."
-
-#~ msgid "Unknown father"
-#~ msgstr "Okänd far"
-
-#~ msgid "Unknown mother"
-#~ msgstr "Okänd mor"
-
-#~ msgid ""
-#~ "WARNING: Setting locale failed. Please fix the LC_* and/or the LANG "
-#~ "environment variables to prevent this error"
-#~ msgstr ""
-#~ "VARNING: Inställning av locale misslyckades. Fixa miljövariablerna LC _* "
-#~ "och/eller LANG för att undvika detta fel."
-
-#~ msgid "ERROR: Setting the 'C' locale didn't work either"
-#~ msgstr "FEL: Inställningen av 'C' locale fingerade inte heller"
-
-#~ msgid "Right-click to the right of the tab to add a gramplet."
-#~ msgstr "Högerklicka till höger om fliken för att lägga till Gramplet."
-
-#~ msgid "%(language)s (%(country)s)"
-#~ msgstr "%(language)s (%(country)s)"
-
-#~ msgid "<b>Preview</b>"
-#~ msgstr "<b>Förhandsgranskning</b>"
-
-#~ msgid "<b>General</b>"
-#~ msgstr "<b>Allmänt</b>"
-
-#~ msgid "<b>_Type</b>"
-#~ msgstr "<b>_Typ</b>"
-
-#~ msgid "<b>Date</b>"
-#~ msgstr "<b>Datum</b>"
-
-#~ msgid "<b>Father</b>"
-#~ msgstr "<b>Far</b>"
-
-#~ msgid "<b>Mother</b>"
-#~ msgstr "<b>Mor</b>"
-
-#~ msgid "<i>Given Name(s)    </i>"
-#~ msgstr "<i>Dopnamn    </i>"
-
-#~ msgid "<i>Family Names     </i>"
-#~ msgstr "<i>Släktnamn     </i>"
-
-#~ msgid "<b>Note</b>"
-#~ msgstr "<b>Notis</b>"
-
-#~ msgid "<b>Image</b>"
-#~ msgstr "<b>Bild</b>"
-
-#~ msgid "<b>Preferred Name </b>"
-#~ msgstr "<b>Förstahandsnamn </b>"
-
-#~ msgid "<b>Location</b>"
-#~ msgstr "<b>Lokalisering</b>"
-
-#~ msgid "<b>Source 1</b>"
-#~ msgstr "<b>Källa 1</b>"
-
-#~ msgid "<b>Source 2</b>"
-#~ msgstr "<b>Källa 2</b>"
-
-#~ msgid "<b>Title selection</b>"
-#~ msgstr "<b>Val av titel</b>"
-
-#~ msgid "<b>Event 1</b>"
-#~ msgstr "<b>Händelse 1</b>"
-
-#~ msgid "<b>Event 2</b>"
-#~ msgstr "<b>Händelse 2</b>"
-
-#~ msgid "<b>Family 1</b>"
-#~ msgstr "<b>Familj 1</b>"
-
-#~ msgid "<b>Family 2</b>"
-#~ msgstr "<b>Familj 2</b>"
-
-#~ msgid "<b>Object 1</b>"
-#~ msgstr "<b>Objekt 1</b>"
-
-#~ msgid "<b>Object 2</b>"
-#~ msgstr "<b>Objekt 2</b>"
-
-#~ msgid "<b>Note 1</b>"
-#~ msgstr "<b>Notis 1</b>"
-
-#~ msgid "<b>Note 2</b>"
-#~ msgstr "<b>Notis 2</b>"
-
-#~ msgid "<b>Person 1</b>"
-#~ msgstr "<b>Person 1</b>"
-
-#~ msgid "<b>Person 2</b>"
-#~ msgstr "<b>Person 2</b>"
-
-#~ msgid "<b>Place 1</b>"
-#~ msgstr "<b>Plats 1</b>"
-
-#~ msgid "<b>Place 2</b>"
-#~ msgstr "<b>Plats 2</b>"
-
-#~ msgid "<b>Repository 1</b>"
-#~ msgstr "<b>Arkivplats 1</b>"
-
-#~ msgid "<b>Repository 2</b>"
-#~ msgstr "<b>Arkivplats 2</b>"
-
-#~ msgid "<b>Family relationships</b>"
-#~ msgstr "<b>Familjerelationer</b>"
-
-#~ msgid "<b>Options</b>"
-#~ msgstr "<b>Alternativ</b>"
-
-#~ msgid "<b>Definition</b>"
-#~ msgstr "<b>Definition</b>"
-
-#~ msgid "<b>Description</b>"
-#~ msgstr "<b>Beskrivning</b>"
-
-#~ msgid "<b>Values</b>"
-#~ msgstr "<b>Värden</b>"
-
-#~ msgid "<b>Size</b>"
-#~ msgstr "<b>Storlek</b>"
-
-#~ msgid "<b>Color</b>"
-#~ msgstr "<b>Färg</b>"
-
-#~ msgid "<b>Background color</b>"
-#~ msgstr "<b>Bakgrundsfärg</b>"
-
-#~ msgid "<b>Borders</b>"
-#~ msgstr "<b>Kanter</b>"
-
-#~ msgid "<b>Available Gramps Updates for Addons</b>"
-#~ msgstr "<b>Tillgängliga uppdateringar av Grampstillägg</b>"
-
-#~ msgid "<span size=\"larger\" weight=\"bold\">GEDCOM Encoding</span>"
-#~ msgstr "<span size=\"larger\" weight=\"bold\">GEDCOM-kodning</span>"
-
-#~ msgid "<b>Status</b>"
-#~ msgstr "<b>Status</b>"
-
-#~ msgid "<b>Uncollected Objects</b>"
-#~ msgstr "<b>Ej skräpsamlade objekt</b>"
-
-#~ msgid "<b>Women</b>"
-#~ msgstr "<b>Kvinnor</b>"
-
-#~ msgid "<b>Men</b>"
-#~ msgstr "<b>Män</b>"
-
-#~ msgid "<b>Families</b>"
-#~ msgstr "<b>Familjer</b>"
-
-#~ msgid "a spouse, "
-#~ msgstr "en maka/make, "
-
-#~ msgid "Add default source on import"
-#~ msgstr "Lägg till standardkälla vid import"
-
-#~ msgid "Gramps: Import database"
-#~ msgstr "Gramps: Importera databas"
-
-#~ msgid "Invalid latitude (syntax: 18°9'"
-#~ msgstr "Ogiltig latitud (syntax: 18°9'"
-
-#~ msgid "Invalid longitude (syntax: 18°9'"
-#~ msgstr "Ogiltig longitud (syntax: 18°9'"
-
-#~ msgid "You need to set a 'default person' to go to."
-#~ msgstr "Du måste bestämma en 'standardperson' att hoppa till."
-
-#~ msgid "TODO"
-#~ msgstr "Att-Göra-lista"
-
-#~ msgid "Gramplet for generic notes"
-#~ msgstr "Gramplet med allmänna notiser"
-
-#~ msgid "TODO List"
-#~ msgstr "Att-Göra-lista"
-
-#~ msgid "Enter text"
-#~ msgstr "Skriv in text"
-
-#~ msgid "Enter your TODO list here."
-#~ msgstr "Skriv din Att Göra-lista här."
-
-#~ msgid ""
-#~ "http://www.gramps-project.org/wiki/index.php?title=Gramps_3.3_Wiki_Manual"
-#~ msgstr ""
-#~ "http://www.gramps-project.org/wiki/index.php?title=Gramps_3.3_Wiki_Manual"
-
-#~ msgid "Gramplet View"
-#~ msgstr "Gramplet-vy"
-
-#~ msgid "Partner 1"
-#~ msgstr "Partner 1"
-
-#~ msgid "Partner 2"
-#~ msgstr "Partner 2"
-
-#~ msgid "Person(s)"
-#~ msgstr "Person(er)"
-
-#~ msgid "Half Siblings"
-#~ msgstr "Halvsyskon"
-
-#~ msgid "Step Siblings"
-#~ msgstr "Styvsyskon"
-
-#~ msgid "Referenced Sources"
-#~ msgstr "Referenserkällor"
-
-#~ msgid "Could not make database directory: "
-#~ msgstr "Kunde inte skapa databasmappen: "
-
-#~ msgid "Use optimal number of pages"
-#~ msgstr "Använd optimalt antal sidor"
-
-#~ msgid "Affects greatly how the graph is laid out on the page."
-#~ msgstr "Avgör väsentligt hur grafen placeras på papperet."
-
-#~ msgid "Report a bug: Step 1 of 5"
-#~ msgstr "Rapportera ett programfel: Steg 1 av 5"
-
-#~ msgid "Report a bug: Step 2 of 5"
-#~ msgstr "Rapportera ett programfel: Steg 2 av 5"
-
-#~ msgid "Report a bug: Step 3 of 5"
-#~ msgstr "Rapportera ett programfel: Steg 3 av 5"
-
-#~ msgid "Report a bug: Step 4 of 5"
-#~ msgstr "Rapportera ett programfel: Steg 4 av 5"
-
-#~ msgid "Report a bug: Step 5 of 5"
-#~ msgstr "Rapportera ett programfel: Steg 5 av 5"
-
-#~ msgid "Select Save File"
-#~ msgstr "Välj fil att spara"
-
-#~ msgid "Book Report"
-#~ msgstr "Bokrapport"
-
-#~ msgid "Please specify a book name"
-#~ msgstr "Specificera ett namn på boken"
-
-#~ msgid "No such book '%s'"
-#~ msgstr "Ingen sådan bok '%s'"
-
-#~ msgid "Produces a book containing several reports."
-#~ msgstr "Skapar en bok som innehåller flera rapporter."
-
-#~ msgid "PyGtk 2.10 or later is required"
-#~ msgstr "PyGtk 2.10 eller senare krävs"
-
-#~ msgid "Gramplet showing available third-party plugins (addons)"
-#~ msgstr "Gramplet med tillgängliga tredjepart insticksmoduler (addons)"
-
-#~ msgid "%d of %d"
-#~ msgstr "%d av %d"
-
-#~ msgid "Provides a FormattingHelper class for common strings"
-#~ msgstr "Erbjuder en formateringshjälpklass för vanliga strängar"
-
-#~ msgid "Ref: %s. %s"
-#~ msgstr "Ref: %s. %s"
-
-#~ msgid "%s and %s (%s)"
-#~ msgstr "%s och %s (%s)"
-
-#~ msgid "Reference : %s"
-#~ msgstr "Referenser: %s"
-
-#~ msgid "The other : %s"
-#~ msgstr "Den andra : %s"
-
-#~ msgid "%s %s"
-#~ msgstr "%s %s"
-
-#~ msgid "Event View"
-#~ msgstr "Händelsevy"
-
-#~ msgid "Family View"
-#~ msgstr "Familjevy"
-
-#~ msgid "Media View"
-#~ msgstr "Mediavy"
-
-#~ msgid "Note View"
-#~ msgstr "Notisvy"
-
-#~ msgid "Relationship View"
-#~ msgstr "Släktskapsvy"
-
-#~ msgid "Pedigree View"
-#~ msgstr "Antavelvy"
-
-#~ msgid "Ancestry"
-#~ msgstr "Anor"
-
-#~ msgid "Person Tree View"
-#~ msgstr "Hierarkisk personvy"
-
-#~ msgid "The view showing all people in the family tree"
-#~ msgstr "Vyn visar samtliga personer i släktträdet"
-
-#~ msgid "Repository View"
-#~ msgstr "Arkivplatsvy"
-
-#~ msgid "Source View"
-#~ msgstr "Källvy"
-
-#~ msgid "- default -"
-#~ msgstr "- standard -"
-
-#~ msgid "<b>phpGedView import</b>"
-#~ msgstr "<b>phpGedView import</b>"
-
-#~ msgid "http://"
-#~ msgstr "http://"
-
-#~ msgid "phpGedView import"
-#~ msgstr "phpGedView import"
-
-#~ msgid "State/Province:"
-#~ msgstr "Län/delstat:"
-
-#~ msgid "ZIP/Postal code:"
-#~ msgstr "Postnummer:"
-
-#~ msgid "Phone:"
-#~ msgstr "Telefon:"
-
-#~ msgid "Email:"
-#~ msgstr "E-post:"
-
-#~ msgid "Sources in repository"
-#~ msgstr "Källor på arkivplats"
-
-#~ msgid "Media Object Filters"
-#~ msgstr "Mediaobjektfilter"
-
-#~ msgid "Book List"
-#~ msgstr "Boklista"
-
-#~ msgid "Selecting operation"
-#~ msgstr "Välj åtgärd"
-
-#~ msgid "Colour"
-#~ msgstr "Färg"
-
-#~ msgid "Coloured outline"
-#~ msgstr "Färglagd kontur"
-
-#~ msgid "Colour fill"
-#~ msgstr "Färgfyllning"
-
-#~ msgid "_RefPerson"
-#~ msgstr "_RefPerson"
-
-#~ msgid "Vertical (top to bottom)"
-#~ msgstr "Vertikalt (uppifrån och ner)"
-
-#~ msgid "Vertical (bottom to top)"
-#~ msgstr "Vertikalt (nerifrån och upp)"
-
-#~ msgid "Horizontal (right to left)"
-#~ msgstr "Horisontellt (höger till vänster)"
-
-#~ msgid ""
-#~ "The plugin did not load. See Help Menu, Plugin Manager for more info.\n"
-#~ "Use http://bugs.gramps-project.org to submit bugs of official plugins, "
-#~ "contact the plugin author otherwise. "
-#~ msgstr ""
-#~ "Insticksmodulen gick inte att ladda. Se Hjälpmeny, Instickshanterare för "
-#~ "ytterligare info.\n"
-#~ "Använd http://bugs.gramps-project.org till att skicka in felrapporter på "
-#~ "officiella insticksmodluler, kontakta insticksmodulens författare i andra "
-#~ "fall."
-
-#~ msgid ""
-#~ "The view %(name)s did not load. See Help Menu, Plugin Manager for more "
-#~ "info.\n"
-#~ "Use http://bugs.gramps-project.org to submit bugs of official views, "
-#~ "contact the view author (%(firstauthoremail)s) otherwise. "
-#~ msgstr ""
-#~ "Vyn med namnet %(name)s gick inte att ladda. Se Hjälpmeny, "
-#~ "Instickshanterare för ytterligare info.\n"
-#~ "Använd http://bugs.gramps-project.org till att skicka in felrapporter på "
-#~ "officiella vyer, kontakta vyförfattaren (%(firstauthoremail)s) i andra "
-#~ "fall."
-
-#~ msgid "Install Addons"
-#~ msgstr "Installera tillägg"
-
-#~ msgid "Individuals with incomplete names"
-#~ msgstr "Personer med ofullständiga namn"
-
-#~ msgid "The Database version is not supported by this version of Gramps."
-#~ msgstr "Databasversionen stöds inte av denna version av Gramps."
-
-#~ msgid ""
-#~ "Your family tree groups name %(key)s together with %(present)s, did not "
-#~ "change this grouping to %(value)s"
-#~ msgstr ""
-#~ "Ditt släktträd grupperar namn %(key)s tillsammans med %(present)s, "
-#~ "ändrade inte detta till gruppering till %(value)s"
-
-#~ msgid "%(quantity)d invalid event reference was removed\n"
-#~ msgid_plural "%(quantity)d invalid event references were removed\n"
-#~ msgstr[0] "%(quantity)d ogiltig händelsereferens togs bort\n"
-#~ msgstr[1] "%(quantity)d ogiltiga händelsereferenser togs bort\n"
-
-#~ msgid "Source Reference: %s"
-#~ msgstr "Källreferens: %s"
-
-#~ msgid "Every object"
-#~ msgstr "Alla objekt"
-
-#~ msgid "Matches every object in the database"
-#~ msgstr "Matchar alla objekt i databasen"
-
-#~ msgid "Object with <Id>"
-#~ msgstr "Objekt med <Id>"
-
-#~ msgid "Matches objects with a specified Gramps ID"
-#~ msgstr "Matchar objekt med angivet Gramps-ID"
-
-#~ msgid "Matches objects whose records contain text matching a substring"
-#~ msgstr ""
-#~ "Matchar objekt vars poster innehåller text\n"
-#~ "som matchar en delsträng"
-
-#~ msgid "Objects marked private"
-#~ msgstr "Objekt markerade som privata"
-
-#~ msgid "Matches objects that are indicated as private"
-#~ msgstr "Matchar objekt som indikerats som privata"
-
-#~ msgid "Source: %s"
-#~ msgstr "Källa: %s"
-
-#~ msgid "Modify Source"
-#~ msgstr "Ändra källa"
-
-#~ msgid "Remove the existing source"
-#~ msgstr "Ta bort den existerande källan"
-
-#~ msgid "Move the selected source upwards"
-#~ msgstr "Flytta den valda källan uppåt"
-
-#~ msgid "Move the selected source downwards"
-#~ msgstr "Flytta den valda källan neråt"
-
-#~ msgid "_Sources"
-#~ msgstr "_Källor"
-
-#~ msgid "Building People View"
-#~ msgstr "Bygger personvy"
-
-#~ msgid "Produces a graphical ancestral tree (Book report)"
-#~ msgstr "Skapar en traditionell grafisk antavla (Bokrapport)"
-
-#~ msgid "Produces a graphical descendant tree (Book report)"
-#~ msgstr "Skapar ett grafisk stamträd (Bokrapport)"
-
-#~ msgid "Produces a graphical descendant tree around a family (Book report)"
-#~ msgstr "Skapar ett grafisk stamträd utgående från en familj (Bokrapport)"
-
-#~ msgid "Person Sources"
-#~ msgstr "Personkällor"
-
-#~ msgid "Gramplet showing the sources for a person"
-#~ msgstr "Gramplet visande källorna för en person"
-
-#~ msgid "Event Sources"
-#~ msgstr "Händelsekällor"
-
-#~ msgid "Gramplet showing the sources for an event"
-#~ msgstr "Gramplet visande källorna för en händelse"
-
-#~ msgid "Gramplet showing the sources for a family"
-#~ msgstr "Gramplet visande källorna för en familj"
-
-#~ msgid "Place Sources"
-#~ msgstr "Platskällor"
-
-#~ msgid "Media Sources"
-#~ msgstr "Mediakällor"
-
-#~ msgid "Gramplet showing the sources for a media object"
-#~ msgstr "Gramplet visande källorna för ett mediaobjekt"
-
-#~ msgid "Limit the number of children"
-#~ msgstr "Begränsa antal barn"
-
-#~ msgid "The maximum number of children to include."
-#~ msgstr "Maximalt antal barn, som skall tas med."
-
-#~ msgid "Pkace"
-#~ msgstr "Plats"
-
-#~ msgid "Family Hyperlink"
-#~ msgstr "Familjehyperlänk"
-
-#~ msgid ""
-#~ "Whether to create a thumbnail's preview page?  This will be hyper- linked "
-#~ "to the Media List Page only!"
-#~ msgstr ""
-#~ "Huruvida skapa förhandsgranskning av med mediaminiatyrer? Dessa kommer "
-#~ "att hyperlänkas till medialistsidan enbart!"
-
-#~ msgid "Matches sources with particular parameters"
-#~ msgstr "Matchar källor med vissa parametrar"
-
-#~ msgid "Baptism:"
-#~ msgstr "Dop:"
-
-#~ msgid "Burial:"
-#~ msgstr "Begravning:"
-
-#~ msgid "Processing File"
-#~ msgstr "Bearbetar fil"
-
-#~ msgid "The range of dates chosen was not valid"
-#~ msgstr "Datumintervallet som valdes var inte giltigt"
-
-#~ msgid "Description :"
-#~ msgstr "Beskrivning:"
-
-#~ msgid "Original Date/ Time :"
-#~ msgstr "Ursprunglig datum/tid:"
-
-#~ msgid "Last Changed :"
-#~ msgstr "Senast ändrad :"
-
-#~ msgid ""
-#~ "%(unknown_gender_name)s died on %(death_date)s in %(death_place)s at the "
-#~ "age of %(age)d years."
-#~ msgstr ""
-#~ "%(unknown_gender_name)s dog %(death_date)s i %(death_place)s, %(age)d år "
-#~ "gammal."
-
-#~ msgid ""
-#~ "%(unknown_gender_name)s died on %(death_date)s in %(death_place)s at the "
-#~ "age of %(age)d months."
-#~ msgstr ""
-#~ "%(unknown_gender_name)s dog %(death_date)s i %(death_place)s, %(age)d "
-#~ "månader gammal."
-
-#~ msgid ""
-#~ "%(male_name)s died on %(death_date)s in %(death_place)s at the age of "
-#~ "%(age)d years."
-#~ msgstr ""
-#~ "%(male_name)s dog %(death_date)s i %(death_place)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "%(male_name)s died on %(death_date)s in %(death_place)s at the age of "
-#~ "%(age)d months."
-#~ msgstr ""
-#~ "%(male_name)s dog %(death_date)s i %(death_place)s, %(age)d månader "
-#~ "gammal."
-
-#~ msgid ""
-#~ "%(female_name)s died on %(death_date)s in %(death_place)s at the age of "
-#~ "%(age)d years."
-#~ msgstr ""
-#~ "%(female_name)s dog %(death_date)s i %(death_place)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "%(female_name)s died on %(death_date)s in %(death_place)s at the age of "
-#~ "%(age)d months."
-#~ msgstr ""
-#~ "%(female_name)s dog %(death_date)s i %(death_place)s, %(age)d månader "
-#~ "gammal."
-
-#~ msgid ""
-#~ "This person died on %(death_date)s in %(death_place)s at the age of "
-#~ "%(age)d years."
-#~ msgstr "Personen dog %(death_date)s i %(death_place)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "This person died on %(death_date)s in %(death_place)s at the age of "
-#~ "%(age)d months."
-#~ msgstr ""
-#~ "Personen dog %(death_date)s i %(death_place)s, %(age)d månader gammal."
-
-#~ msgid ""
-#~ "He died on %(death_date)s in %(death_place)s at the age of %(age)d years."
-#~ msgstr "Han dog %(death_date)s i %(death_place)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "He died on %(death_date)s in %(death_place)s at the age of %(age)d months."
-#~ msgstr "Han dog %(death_date)s i %(death_place)s, %(age)d månader gammal."
-
-#~ msgid ""
-#~ "She died on %(death_date)s in %(death_place)s at the age of %(age)d years."
-#~ msgstr "Hon dog %(death_date)s i %(death_place)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "She died on %(death_date)s in %(death_place)s at the age of %(age)d "
-#~ "months."
-#~ msgstr "Hon dog %(death_date)s i %(death_place)s, %(age)d månader gammal."
-
-#~ msgid "Died %(death_date)s in %(death_place)s (age %(age)d years)."
-#~ msgstr "Dog %(death_date)s i %(death_place)s (vid %(age)d års ålder)."
-
-#~ msgid "Died %(death_date)s in %(death_place)s (age %(age)d months)."
-#~ msgstr "Dog %(death_date)s i %(death_place)s (vid %(age)d månaders ålder)."
-
-#~ msgid ""
-#~ "%(unknown_gender_name)s died %(death_date)s in %(death_place)s at the age "
-#~ "of %(age)d years."
-#~ msgstr ""
-#~ "%(unknown_gender_name)s dog %(death_date)s i %(death_place)s, %(age)d år "
-#~ "gammal."
-
-#~ msgid ""
-#~ "%(unknown_gender_name)s died %(death_date)s in %(death_place)s at the age "
-#~ "of %(age)d months."
-#~ msgstr ""
-#~ "%(unknown_gender_name)s dog %(death_date)s i %(death_place)s, %(age)d "
-#~ "månader gammal."
-
-#~ msgid ""
-#~ "%(male_name)s died %(death_date)s in %(death_place)s at the age of "
-#~ "%(age)d years."
-#~ msgstr ""
-#~ "%(male_name)s dog %(death_date)s i %(death_place)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "%(male_name)s died %(death_date)s in %(death_place)s at the age of "
-#~ "%(age)d months."
-#~ msgstr ""
-#~ "%(male_name)s dog %(death_date)s i %(death_place)s, %(age)d månader "
-#~ "gammal."
-
-#~ msgid ""
-#~ "%(female_name)s died %(death_date)s in %(death_place)s at the age of "
-#~ "%(age)d years."
-#~ msgstr ""
-#~ "%(female_name)s dog %(death_date)s i %(death_place)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "%(female_name)s died %(death_date)s in %(death_place)s at the age of "
-#~ "%(age)d months."
-#~ msgstr ""
-#~ "%(female_name)s dog %(death_date)s i %(death_place)s, %(age)d månader "
-#~ "gammal."
-
-#~ msgid ""
-#~ "This person died %(death_date)s in %(death_place)s at the age of %(age)d "
-#~ "years."
-#~ msgstr "Personen dog %(death_date)s i %(death_place)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "This person died %(death_date)s in %(death_place)s at the age of %(age)d "
-#~ "months."
-#~ msgstr ""
-#~ "Personen dog %(death_date)s i %(death_place)s, %(age)d månader gammal."
-
-#~ msgid ""
-#~ "He died %(death_date)s in %(death_place)s at the age of %(age)d years."
-#~ msgstr "Han dog %(death_date)s i %(death_place)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "He died %(death_date)s in %(death_place)s at the age of %(age)d months."
-#~ msgstr "Han dog %(death_date)s i %(death_place)s, %(age)d månader gammal."
-
-#~ msgid ""
-#~ "She died %(death_date)s in %(death_place)s at the age of %(age)d years."
-#~ msgstr "Hon dog %(death_date)s i %(death_place)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "She died %(death_date)s in %(death_place)s at the age of %(age)d months."
-#~ msgstr "Hon dog %(death_date)s i %(death_place)s, %(age)d månader gammal."
-
-#~ msgid ""
-#~ "%(unknown_gender_name)s died on %(death_date)s at the age of %(age)d "
-#~ "years."
-#~ msgstr "%(unknown_gender_name)s dog %(death_date)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "%(unknown_gender_name)s died on %(death_date)s at the age of %(age)d "
-#~ "months."
-#~ msgstr "%(unknown_gender_name)s dog %(death_date)s, %(age)d månader gammal."
-
-#~ msgid "%(male_name)s died on %(death_date)s at the age of %(age)d years."
-#~ msgstr "%(male_name)s dog %(death_date)s, %(age)d år gammal."
-
-#~ msgid "%(male_name)s died on %(death_date)s at the age of %(age)d months."
-#~ msgstr "%(male_name)s dog %(death_date)s, %(age)d månader gammal."
-
-#~ msgid "%(female_name)s died on %(death_date)s at the age of %(age)d years."
-#~ msgstr "%(female_name)s dog %(death_date)s, %(age)d år gammal."
-
-#~ msgid "%(female_name)s died on %(death_date)s at the age of %(age)d months."
-#~ msgstr "%(female_name)s dog %(death_date)s, %(age)d månader gammal."
-
-#~ msgid "This person died on %(death_date)s at the age of %(age)d years."
-#~ msgstr "Personen dog %(death_date)s, %(age)d år gammal."
-
-#~ msgid "This person died on %(death_date)s at the age of %(age)d months."
-#~ msgstr "Personen dog %(death_date)s, %(age)d månader gammal."
-
-#~ msgid "He died on %(death_date)s at the age of %(age)d years."
-#~ msgstr "Han dog %(death_date)s, %(age)d år gammal."
-
-#~ msgid "He died on %(death_date)s at the age of %(age)d months."
-#~ msgstr "Han dog %(death_date)s, %(age)d månader gammal."
-
-#~ msgid "She died on %(death_date)s at the age of %(age)d years."
-#~ msgstr "Hon dog %(death_date)s, %(age)d år gammal."
-
-#~ msgid "She died on %(death_date)s at the age of %(age)d months."
-#~ msgstr "Hon dog %(death_date)s, %(age)d månader gammal."
-
-#~ msgid "Died %(death_date)s (age %(age)d years)."
-#~ msgstr "Dog %(death_date)s (vid %(age)d års ålder)."
-
-#~ msgid "Died %(death_date)s (age %(age)d months)."
-#~ msgstr "Dog %(death_date)s (vid %(age)d månaders ålder)."
-
-#~ msgid ""
-#~ "%(unknown_gender_name)s died %(death_date)s at the age of %(age)d years."
-#~ msgstr "%(unknown_gender_name)s dog %(death_date)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "%(unknown_gender_name)s died %(death_date)s at the age of %(age)d months."
-#~ msgstr "%(unknown_gender_name)s dog %(death_date)s, %(age)d månader gammal."
-
-#~ msgid "%(male_name)s died %(death_date)s at the age of %(age)d years."
-#~ msgstr "%(male_name)s dog %(death_date)s, %(age)d år gammal."
-
-#~ msgid "%(male_name)s died %(death_date)s at the age of %(age)d months."
-#~ msgstr "%(male_name)s dog %(death_date)s, %(age)d månader gammal."
-
-#~ msgid "%(female_name)s died %(death_date)s at the age of %(age)d years."
-#~ msgstr "%(female_name)s dog %(death_date)s, %(age)d år gammal."
-
-#~ msgid "%(female_name)s died %(death_date)s at the age of %(age)d months."
-#~ msgstr "%(female_name)s dog %(death_date)s, %(age)d månader gammal."
-
-#~ msgid "This person died %(death_date)s at the age of %(age)d years."
-#~ msgstr "Personen dog %(death_date)s, %(age)d år gammal."
-
-#~ msgid "This person died %(death_date)s at the age of %(age)d months."
-#~ msgstr "Personen dog %(death_date)s, %(age)d månader gammal."
-
-#~ msgid "He died %(death_date)s at the age of %(age)d years."
-#~ msgstr "Han dog %(death_date)s, %(age)d år gammal."
-
-#~ msgid "He died %(death_date)s at the age of %(age)d months."
-#~ msgstr "Han dog %(death_date)s, %(age)d månader gammal."
-
-#~ msgid "She died %(death_date)s at the age of %(age)d years."
-#~ msgstr "Hon dog %(death_date)s, %(age)d år gammal."
-
-#~ msgid "She died %(death_date)s at the age of %(age)d months."
-#~ msgstr "Hon dog %(death_date)s, %(age)d månader gammal."
-
-#~ msgid ""
-#~ "%(unknown_gender_name)s died in %(month_year)s in %(death_place)s at the "
-#~ "age of %(age)d years."
-#~ msgstr ""
-#~ "%(unknown_gender_name)s dog %(month_year)s i %(death_place)s, %(age)d år "
-#~ "gammal."
-
-#~ msgid ""
-#~ "%(unknown_gender_name)s died in %(month_year)s in %(death_place)s at the "
-#~ "age of %(age)d months."
-#~ msgstr ""
-#~ "%(unknown_gender_name)s dog %(month_year)s i %(death_place)s vid %(age)d "
-#~ "månaders ålder."
-
-#~ msgid ""
-#~ "%(male_name)s died in %(month_year)s in %(death_place)s at the age of "
-#~ "%(age)d years."
-#~ msgstr ""
-#~ "%(male_name)s dog %(month_year)s i %(death_place)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "%(male_name)s died in %(month_year)s in %(death_place)s at the age of "
-#~ "%(age)d months."
-#~ msgstr ""
-#~ "%(male_name)s dog %(month_year)s i %(death_place)s, %(age)d månader "
-#~ "gammal."
-
-#~ msgid ""
-#~ "%(female_name)s died in %(month_year)s in %(death_place)s at the age of "
-#~ "%(age)d years."
-#~ msgstr ""
-#~ "%(female_name)s dog %(month_year)s i %(death_place)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "%(female_name)s died in %(month_year)s in %(death_place)s at the age of "
-#~ "%(age)d months."
-#~ msgstr ""
-#~ "%(female_name)s dog %(month_year)s i %(death_place)s, %(age)d månader "
-#~ "gammal."
-
-#~ msgid ""
-#~ "This person died in %(month_year)s in %(death_place)s at the age of "
-#~ "%(age)d years."
-#~ msgstr "Personen dog %(month_year)s i %(death_place)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "This person died in %(month_year)s in %(death_place)s at the age of "
-#~ "%(age)d months."
-#~ msgstr ""
-#~ "Personen dog %(month_year)s i %(death_place)s, %(age)d månader gammal."
-
-#~ msgid ""
-#~ "He died in %(month_year)s in %(death_place)s at the age of %(age)d years."
-#~ msgstr "Han dog %(month_year)s i %(death_place)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "He died in %(month_year)s in %(death_place)s at the age of %(age)d months."
-#~ msgstr "Han dog %(month_year)s i %(death_place)s, %(age)d månader gammal."
-
-#~ msgid ""
-#~ "She died in %(month_year)s in %(death_place)s at the age of %(age)d years."
-#~ msgstr "Hon dog %(month_year)s i %(death_place)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "She died in %(month_year)s in %(death_place)s at the age of %(age)d "
-#~ "months."
-#~ msgstr "Hon dog %(month_year)s i %(death_place)s, %(age)d månader gammal."
-
-#~ msgid "Died %(month_year)s in %(death_place)s (age %(age)d years)."
-#~ msgstr "Dog %(month_year)s i %(death_place)s (vid %(age)d års ålder)."
-
-#~ msgid "Died %(month_year)s in %(death_place)s (age %(age)d months)."
-#~ msgstr "Dog %(month_year)s i %(death_place)s (vid %(age)d månaders ålder)."
-
-#~ msgid ""
-#~ "%(unknown_gender_name)s died in %(month_year)s at the age of %(age)d "
-#~ "years."
-#~ msgstr "%(unknown_gender_name)s dog %(month_year)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "%(unknown_gender_name)s died in %(month_year)s at the age of %(age)d "
-#~ "months."
-#~ msgstr "%(unknown_gender_name)s dog %(month_year)s, %(age)d månader gammal."
-
-#~ msgid "%(male_name)s died in %(month_year)s at the age of %(age)d years."
-#~ msgstr "%(male_name)s dog %(month_year)s, %(age)d år gammal."
-
-#~ msgid "%(male_name)s died in %(month_year)s at the age of %(age)d months."
-#~ msgstr "%(male_name)s dog %(month_year)s, %(age)d månader gammal."
-
-#~ msgid "%(female_name)s died in %(month_year)s at the age of %(age)d years."
-#~ msgstr "%(female_name)s dog %(month_year)s, %(age)d år gammal."
-
-#~ msgid "%(female_name)s died in %(month_year)s at the age of %(age)d months."
-#~ msgstr "%(female_name)s dog %(month_year)s, %(age)d månader gammal."
-
-#~ msgid "This person died in %(month_year)s at the age of %(age)d years."
-#~ msgstr "Personen dog %(month_year)s, %(age)d år gammal."
-
-#~ msgid "This person died in %(month_year)s at the age of %(age)d months."
-#~ msgstr "Personen dog %(month_year)s, %(age)d månader gammal."
-
-#~ msgid "He died in %(month_year)s at the age of %(age)d years."
-#~ msgstr "Han dog %(month_year)s, %(age)d år gammal."
-
-#~ msgid "He died in %(month_year)s at the age of %(age)d months."
-#~ msgstr "Han dog %(month_year)s, %(age)d månader gammal."
-
-#~ msgid "She died in %(month_year)s at the age of %(age)d years."
-#~ msgstr "Hon dog %(month_year)s, %(age)d år gammal."
-
-#~ msgid "She died in %(month_year)s at the age of %(age)d months."
-#~ msgstr "Hon dog %(month_year)s, %(age)d månader gammal."
-
-#~ msgid "Died %(month_year)s (age %(age)d years)."
-#~ msgstr "Dog %(month_year)s (vid %(age)d års ålder)."
-
-#~ msgid "Died %(month_year)s (age %(age)d months)."
-#~ msgstr "Dog %(month_year)s (vid %(age)d månaders ålder)."
-
-#~ msgid ""
-#~ "%(unknown_gender_name)s died in %(death_place)s at the age of %(age)d "
-#~ "years."
-#~ msgstr "%(unknown_gender_name)s dog i %(death_place)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "%(unknown_gender_name)s died in %(death_place)s at the age of %(age)d "
-#~ "months."
-#~ msgstr ""
-#~ "%(unknown_gender_name)s dog i %(death_place)s, %(age)d månader gammal."
-
-#~ msgid "%(male_name)s died in %(death_place)s at the age of %(age)d years."
-#~ msgstr "%(male_name)s dog i %(death_place)s, %(age)d år gammal."
-
-#~ msgid "%(male_name)s died in %(death_place)s at the age of %(age)d months."
-#~ msgstr "%(male_name)s dog i %(death_place)s, %(age)d månader gammal."
-
-#~ msgid "%(female_name)s died in %(death_place)s at the age of %(age)d years."
-#~ msgstr "%(female_name)s dog i %(death_place)s, %(age)d år gammal."
-
-#~ msgid ""
-#~ "%(female_name)s died in %(death_place)s at the age of %(age)d months."
-#~ msgstr "%(female_name)s dog i %(death_place)s, %(age)d månader gammal."
-
-#~ msgid "This person died in %(death_place)s at the age of %(age)d years."
-#~ msgstr "Personen dog i %(death_place)s, %(age)d år gammal."
-
-#~ msgid "This person died in %(death_place)s at the age of %(age)d months."
-#~ msgstr "Personen dog i %(death_place)s, %(age)d månader gammal."
-
-#~ msgid "He died in %(death_place)s at the age of %(age)d years."
-#~ msgstr "Han dog i %(death_place)s, %(age)d år gammal."
-
-#~ msgid "He died in %(death_place)s at the age of %(age)d months."
-#~ msgstr "Han dog i %(death_place)s, %(age)d månader gammal."
-
-#~ msgid "She died in %(death_place)s at the age of %(age)d years."
-#~ msgstr "Hon dog i %(death_place)s, %(age)d år gammal."
-
-#~ msgid "She died in %(death_place)s at the age of %(age)d months."
-#~ msgstr "Hon dog i %(death_place)s, %(age)d månader gammal."
-
-#~ msgid "Died in %(death_place)s (age %(age)d years)."
-#~ msgstr "Dog i %(death_place)s (vid %(age)d års ålder)."
-
-#~ msgid "Died in %(death_place)s (age %(age)d months)."
-#~ msgstr "Dog i %(death_place)s (vid %(age)d månaders ålder)."
-
-#~ msgid "%(unknown_gender_name)s died at the age of %(age)d years."
-#~ msgstr "%(unknown_gender_name)s dog %(age)d år gammal."
-
-#~ msgid "%(unknown_gender_name)s died at the age of %(age)d months."
-#~ msgstr "%(unknown_gender_name)s dog %(age)d månader gammal."
-
-#~ msgid "%(male_name)s died at the age of %(age)d years."
-#~ msgstr "%(male_name)s dog %(age)d år gammal."
-
-#~ msgid "%(male_name)s died at the age of %(age)d months."
-#~ msgstr "%(male_name)s dog %(age)d månader gammal."
-
-#~ msgid "%(female_name)s died at the age of %(age)d years."
-#~ msgstr "%(female_name)s dog %(age)d år gammal."
-
-#~ msgid "%(female_name)s died at the age of %(age)d months."
-#~ msgstr "%(female_name)s dog %(age)d gammal."
-
-#~ msgid "This person died at the age of %(age)d years."
-#~ msgstr "Personen dog %(age)d år gammal."
-
-#~ msgid "This person died at the age of %(age)d months."
-#~ msgstr "Personen dog %(age)d månader gammal."
-
-#~ msgid "He died at the age of %(age)d years."
-#~ msgstr "Han dog %(age)d år gammal."
-
-#~ msgid "He died at the age of %(age)d months."
-#~ msgstr "Han dog %(age)d månader gammal."
-
-#~ msgid "She died at the age of %(age)d years."
-#~ msgstr "Hon dog %(age)d år gammal."
-
-#~ msgid "She died at the age of %(age)d months."
-#~ msgstr "Hon dog %(age)d månader gammal."
-
-#~ msgid "Died (age %(age)d years)."
-#~ msgstr "Dog (vid %(age)d års ålder)."
-
-#~ msgid "Died (age %(age)d months)."
-#~ msgstr "Dog (vid %(age)d månaders ålder)."
-
-#~ msgid "The view allowing to see Gramplets"
-#~ msgstr "Vyn visar Gramplet"
-
-#~ msgid "LDS"
-#~ msgstr "SDH (Mormonkyrkan)"
-
-#~ msgid ""
-#~ "The place markers on this page represent different locations based upon "
-#~ "spouse, children (if any), and personal events and their places of the "
-#~ "main person. The list is sorted in chronological order."
-#~ msgstr ""
-#~ "Platsmarkörerna på denna sida representerar en annan plats grundad på din "
-#~ "make/maka, dina barn (om några) och dina personliga händelser och dess "
-#~ "platser. Listan har sorterats i kronologisk ordning."
-
-#~ msgid "Family:"
-#~ msgstr "Familj:"
-
-#~ msgid "Bottom:"
-#~ msgstr "Nederkant:"
-
-#~ msgid "Left:"
-#~ msgstr "Vänster:"
-
-#~ msgid "Right:"
-#~ msgstr "Höger:"
-
-#~ msgid "Top:"
-#~ msgstr "Överkant:"
-
-#~ msgid "State/County:"
-#~ msgstr "Stat/Län:"
-
-#, fuzzy
-#~ msgid "Creating Familiy Relationship pages..."
-#~ msgstr "Skapar mediasidor"
-
-#~ msgid "Selection Options"
-#~ msgstr "Välj alternativ"
-
-#~ msgid ""
-#~ "You need to install, %s or greater, for this addon to work...\n"
-#~ "I would recommend installing, %s, and it may be downloaded from here: \n"
-#~ "%s"
-#~ msgstr ""
-#~ "Du måste installera %s eller högre version, för att detta tillägg skall "
-#~ "fungera...\n"
-#~ "Rekommenderas installation av, %s, och den kan laddas ned från: \n"
-#~ "%s"
-
-#~ msgid "Failed to load 'Edit Image Exif Metadata'..."
-#~ msgstr "Misslyckades med att ladda 'Redigera bild Exif-metadata'..."
-
-#~ msgid ""
-#~ "The minimum required version for pyexiv2 must be %s \n"
-#~ "or greater.  Or you do not have the python library installed yet.  You "
-#~ "may download it from here: %s\n"
-#~ "\n"
-#~ "  I recommend getting, %s"
-#~ msgstr ""
-#~ "Minimum krävd version för pyexiv2 måste vara %s eller högre.\n"
-#~ "Eller du har inte python-biblioteket installerat ännu.\n"
-#~ "Du kan ladda ner det från: %s\n"
-#~ "\n"
-#~ " Rekommenderar %s."
-
-#~ msgid "This is equivalent to the Title field in the media object editor."
-#~ msgstr "Detta är ekvivalent med titel-fältet i mediaobjektredigeraren."
-
-#~ msgid "No Exif metadata for this image..."
-#~ msgstr "Ännu inga Exif-metadata för denna bild..."
-
-#~ msgid "Please choose a different image..."
-#~ msgstr "Välj en annan bild..."
-
-#~ msgid "No Exif metadata to display..."
-#~ msgstr "Inga Exif-metadata att visa..."
-
-#~ msgid "Number of Key/ Value pairs : %04d"
-#~ msgstr "Antal nyckel/värde-par : %04d"
-
-#~ msgid "Error: %s does not contain an EXIF thumbnail."
-#~ msgstr "Fel: %s innehåller ej en Exif-miniatyrbild."
-
-#~ msgid "Entering data..."
-#~ msgstr "Skriver in data..."
-
-#~ msgid ""
-#~ "Convert GPS Latitude/ Longitude Coordinates to Decimal representation."
-#~ msgstr ""
-#~ "Omvandlar GPS-koordinater grader, minuter, sekunder till decimal "
-#~ "representation."
-
-#~ msgid ""
-#~ "Convert GPS Latitude/ Longitude Coordinates to (Degrees, Minutes, "
-#~ "Seconds) Representation."
-#~ msgstr "Omvandlar decimala GPS-koordinater till grader, minuter, sekunder."
-
-#~ msgid "Exif Label :"
-#~ msgstr "Exif-etikett :"
-
-#~ msgid "Convert GPS :"
-#~ msgstr "Omvandla GPS:"
-
-#~ msgid "Decimal"
-#~ msgstr "Decimal"
-
-#~ msgid "There is NO Exif metadata for this image."
-#~ msgstr "Det finns inga Exif-metadata för denna bild."
-
-#~ msgid "All Exif metadata has been cleared..."
-#~ msgstr "Bilds Exif-metadata har rensats..."
-
-#~ msgid "Finding ancestors and children"
-#~ msgstr "Hittar förfäder och barn"
-
-#~ msgid "Writing family lines"
-#~ msgstr "Skriver släktlinjer"
-
-#~ msgid "Main Navigation Item %s"
-#~ msgstr "Huvudnavigationspost %s"
-
-#~ msgid "Place Maps"
-#~ msgstr "Platskarta"
-
-#~ msgid "Alphabet Navigation Menu Item "
-#~ msgstr "Alfabetisk navigationsmenyrad "
-
-#~ msgid ""
-#~ "ImageMagick's convert program was not found on this computer.\n"
-#~ "You may download it from here: %s..."
-#~ msgstr ""
-#~ "ImageMagicks omvandlingsprogram hittades inte i denna dator.\n"
-#~ " Du kan ladda ner från: %s..."
-
-#~ msgid ""
-#~ "Jhead program was not found on this computer.\n"
-#~ "You may download it from: %s..."
-#~ msgstr ""
-#~ "Jhead-programmet hittades inte i denna dator.\n"
-#~ "Du kan ladda ner det från: %s..."
-
-#~ msgid "If your image is not a .jpg image, convert it to a .jpg image?"
-#~ msgstr "Om din bild inte är en jpeg-bild, omvandla till jpeg?"
-
-#~ msgid "Select an image to view it's Exif metadata..."
-#~ msgstr "Välj en bild att visa dess Exif-metadata..."
-
-#~ msgid ""
-#~ "Image is either missing or deleted,\n"
-#~ "Please choose a different image..."
-#~ msgstr ""
-#~ "Bilden saknas eller är bortagen.\n"
-#~ " Välj en annan bild..."
-
-#~ msgid ""
-#~ "Converting image,\n"
-#~ "You will need to delete the original image file..."
-#~ msgstr ""
-#~ "Omvandlar bild.\n"
-#~ "Du måste ta bort originalbildfilen..."
-
-#~ msgid "S"
-#~ msgstr "S"
-
-#~ msgid "Deleting all Exif metadata..."
-#~ msgstr "Raderar all Exif-metadata..."
-
-#~ msgid "pyenchant must be installed"
-#~ msgstr "pyenchant måste vara installerat"
-
-#~ msgid ""
-#~ "Original Date/ Time of this image.\n"
-#~ "Example: 1826-Apr-12 14:30:00, 1826-April-12, 1998-01-31 13:30:00"
-#~ msgstr ""
-#~ "Original datum/ tid for denna bild.\n"
-#~ "Example: 1826-Apr-12 14:30:00, 1826-April-12, 1998-01-31 13:30:00"
-
-#~ msgid "Copies information from the Display area to the Edit area."
-#~ msgstr "Kopierar information från visningsområdet till redigeringsområdet."
-
-#~ msgid "Clears the Exif metadata from the Edit area."
-#~ msgstr "Rensar Exif-metadata från redigeringsområdet."
-
-#~ msgid ""
-#~ "Saves/ writes the Exif metadata to this image.\n"
-#~ "WARNING: Exif metadata will be erased if you save a blank entry field..."
-#~ msgstr ""
-#~ "Sparar/skriver Exif-metadata till denna bild.\n"
-#~ "varning: Exif-metadata kommer att raderas om du sparar med ett tomt "
-#~ "fält..."
-
-#~ msgid "Select Date"
-#~ msgstr "Välj datum"
-
-#~ msgid "Copying Exif metadata to the Edit Area..."
-#~ msgstr "Kopierar Exif-metadata till redigeringsområdet..."
-
-#~ msgid "Edit area has been cleared..."
-#~ msgstr "Redigeringsområdet har rensats..."
-
-#~ msgid "Image Exif metadata has been cleared from this image..."
-#~ msgstr "Bildens Exif-metadata har raderats..."
-
-#~ msgid "N"
-#~ msgstr "N"
-
-#, fuzzy
-#~ msgid "Re- initialize"
-#~ msgstr "initialer"
-
-#, fuzzy
-#~ msgid "Image has been re- initialized for Exif metadata..."
-#~ msgstr "Bild har reinitialiserats för Exif-metadata..."
-
-#~ msgid "Double click a day to return the date."
-#~ msgstr "Dubbelklicka på en dag för få datumet."
-
-#~ msgid "Sub Navigation Menu Item: Year %04d"
-#~ msgstr "Underliggande navigationsmenyrad: år %04d"
-
-#~ msgid "html|Home"
-#~ msgstr "Hem"
-
-#~ msgid "Main Navigation Menu Item: %s"
-#~ msgstr "Huvudnavigationsmenyrad: %s"
-
-#~ msgid "Objects changed after <date time>"
-#~ msgstr "Objekt ändrat efter <datum tid>"
-
-#~ msgid ""
-#~ "Matches object records changed after a specified date/time (yyyy-mm-dd hh:"
-#~ "mm:ss) or in range, if a second date/time is given."
-#~ msgstr ""
-#~ "Matchar objektposter ändrade efter en specificerad datum/tid (yyyy-mm-dd "
-#~ "hh:mm:ss) eller i intervall, om ett andra datum/tid givits."
-
-#~ msgid "Note %(ind)d - Type: %(type)s"
-#~ msgstr "Notis %(ind)d - Typ: %(type)s"
-
-#~ msgid ""
-#~ "Allows you to select a date from a pop-up window calendar. \n"
-#~ "  Warning:  You will still need to edit the time..."
-#~ msgstr ""
-#~ "Ger dig möjlighet att välja datum från ett kalenderfönster. \n"
-#~ " Varning: Du måste fortfarande redigera tidpunkt..."
-
-#~ msgid "  Tag %(name)s\n"
-#~ msgstr "  Flagga %(name)s\n"
-
-#~ msgid ""
-#~ "\n"
-#~ "\n"
-#~ "Objects merged-overwritten on import:\n"
-#~ msgstr ""
-#~ "\n"
-#~ "\n"
-#~ "Objekt som infogats-överskrivits vid import:\n"
-
-#~ msgid "Go to the next person in the history"
-#~ msgstr "Gå till nästa person i historiken"
-
-#~ msgid "Go to the previous person in the history"
-#~ msgstr "Gå till föregående person i historiken"
-
-#~ msgid " and "
-#~ msgstr " och "
-
-#~ msgid ""
-#~ "Welcome to Gramps!\n"
-#~ "\n"
-#~ "Gramps is a software package designed for genealogical research. Although "
-#~ "similar to other genealogical programs, Gramps offers some unique and "
-#~ "powerful features.\n"
-#~ "\n"
-#~ "Gramps is an Open Source Software package, which means you are free to "
-#~ "make copies and distribute it to anyone you like. It's developed and "
-#~ "maintained by a worldwide team of volunteers whose goal is to make Gramps "
-#~ "powerful, yet easy to use.\n"
-#~ "\n"
-#~ "Getting Started\n"
-#~ "\n"
-#~ "The first thing you must do is to create a new Family Tree. To create a "
-#~ "new Family Tree (sometimes called a database) select \"Family Trees\" "
-#~ "from the menu, pick \"Manage Family Trees\", press \"New\" and name your "
-#~ "database. For more details, please read the User Manual, or the on-line "
-#~ "manual at http://gramps-project.org.\n"
-#~ "\n"
-#~ "You are currently reading from the \"Gramplets\" page, where you can add "
-#~ "your own gramplets.\n"
-#~ "\n"
-#~ "You can right-click on the background of this page to add additional "
-#~ "gramplets and change the number of columns. You can also drag the "
-#~ "Properties button to reposition the gramplet on this page, and detach the "
-#~ "gramplet to float above Gramps. If you close Gramps with a gramplet "
-#~ "detached, it will re-open detached the next time you start Gramps."
-#~ msgstr ""
-#~ "Välkommen till Gramps!\n"
-#~ "\n"
-#~ "Gramps är ett programvarupaket avsett för släktforskning. Fastän det "
-#~ "liknar andra släktforskningsprogram erbjuder Gramps några unika och "
-#~ "kraftfulla möjligheter.\n"
-#~ "\n"
-#~ "Gramps är ett Open Source Software-paket, vilket innebär att du är fri "
-#~ "att göra kopior och sprida dem till vem du vill. Det utvecklas och "
-#~ "underhålls av ett världsomspännande nät av frivilliga, vars mål är att "
-#~ "göra Gramps kraftfullt, men ändå enkelt att använda.\n"
-#~ "\n"
-#~ "Börja med Gramps!\n"
-#~ "\n"
-#~ "Det första du måste göra är att skapa ett Släktträd. För att skapa ett "
-#~ "nytt Släktträd (ibland kallat databas), välj  \"Släktträd\" från menyn, "
-#~ "markera \"Hantera Släktträd\", tryck \"Nytt\" och get att namn på din "
-#~ "databas. Avsluta med vagnretur. För ytterligare detaljer hänvisas till "
-#~ "användarhandboken eller den tillgängliga handboken på http://gramps-"
-#~ "project.org.\n"
-#~ "\n"
-#~ "Du läser just nu från \"Gramplet\"-sidan, där du kan lägga till dina egna "
-#~ "mini-hjälpmedel.\n"
-#~ "\n"
-#~ "Du kan högerklicka på denna sidas bakgrund för att lägga till ytterligare "
-#~ "Gramplet och ändra antal kolumner. Du kan även dra Egenskapsknappen "
-#~ "(upptill till vänster) för att placera om fönstret på denna sida samt "
-#~ "även koppla loss det så att det flyter ovanpå Gramps. Om du stänger "
-#~ "Gramps med ett losskopplat fönster, kommer det att öppnas losskopplat, "
-#~ "nästa gång du startar Gramps."
-
-#~ msgid "Afrikaans"
-#~ msgstr "Afrikaans"
-
-#~ msgid "Amharic"
-#~ msgstr "Amhariska"
-
-#~ msgid "Azerbaijani"
-#~ msgstr "Azerbaijanska"
-
-#~ msgid "Belarusian"
-#~ msgstr "Vitryska"
-
-#~ msgid "Bengali"
-#~ msgstr "Bengaliska"
-
-#~ msgid "Kashubian"
-#~ msgstr "Kashubiska"
-
-#~ msgid "Welsh"
-#~ msgstr "Walesiska"
-
-#~ msgid "German - Old Spelling"
-#~ msgstr "Tyska - Gammalstafning"
-
-#~ msgid "Estonian"
-#~ msgstr "Estniska"
-
-#~ msgid "Persian"
-#~ msgstr "Persiska"
-
-#~ msgid "Faroese"
-#~ msgstr "Färöiska"
-
-#~ msgid "Frisian"
-#~ msgstr "Frisiska"
-
-#~ msgid "Irish"
-#~ msgstr "Irländska"
-
-#~ msgid "Scottish Gaelic"
-#~ msgstr "Skotsk gaeliska"
-
-#~ msgid "Galician"
-#~ msgstr "Galizisk"
-
-#~ msgid "Gujarati"
-#~ msgstr "Gujarati"
-
-#~ msgid "Hindi"
-#~ msgstr "Hinduiska"
-
-#~ msgid "Hiligaynon"
-#~ msgstr "Hiligaynon"
-
-#~ msgid "Upper Sorbian"
-#~ msgstr "Övre sorbiska"
-
-#~ msgid "Armenian"
-#~ msgstr "Armeniska"
-
-#~ msgid "Interlingua"
-#~ msgstr "Interlingua"
-
-#~ msgid "Indonesian"
-#~ msgstr "Indonesiska"
-
-#~ msgid "Kurdi"
-#~ msgstr "Kurdiska"
-
-#~ msgid "Latin"
-#~ msgstr "Latin"
-
-#~ msgid "Latvian"
-#~ msgstr "Lettiska"
-
-#~ msgid "Malagasy"
-#~ msgstr "Malagassiska"
-
-#~ msgid "Maori"
-#~ msgstr "Maori"
-
-#~ msgid "Mongolian"
-#~ msgstr "Mongoliska"
-
-#~ msgid "Marathi"
-#~ msgstr "Marathi"
-
-#~ msgid "Malay"
-#~ msgstr "Malajiska"
-
-#~ msgid "Maltese"
-#~ msgstr "Maltesiska"
-
-#~ msgid "Low Saxon"
-#~ msgstr "Lägre Saxiska"
-
-#~ msgid "Chichewa"
-#~ msgstr "Chica"
-
-#~ msgid "Oriya"
-#~ msgstr "Oriya"
-
-#~ msgid "Punjabi"
-#~ msgstr "Punjabiska"
-
-#~ msgid "Brazilian Portuguese"
-#~ msgstr "Brasiliansk portugisiska"
-
-#~ msgid "Quechua"
-#~ msgstr "Quechua"
-
-#~ msgid "Kinyarwanda"
-#~ msgstr "Kinyarwanda"
-
-#~ msgid "Sardinian"
-#~ msgstr "Sardinska"
-
-#~ msgid "Swahili"
-#~ msgstr "Swahili"
-
-#~ msgid "Telugu"
-#~ msgstr "Telugu"
-
-#~ msgid "Tetum"
-#~ msgstr "Tetum"
-
-#~ msgid "Tagalog"
-#~ msgstr "Tagalog"
-
-#~ msgid "Setswana"
-#~ msgstr "Setswana"
-
-#~ msgid "Uzbek"
-#~ msgstr "Uzbekiska"
-
-#~ msgid "Walloon"
-#~ msgstr "Vallonska"
-
-#~ msgid "Yiddish"
-#~ msgstr "Jiddish"
-
-#~ msgid "Zulu"
-#~ msgstr "Zulu"
-
-#~ msgid ""
-#~ "Warning: spelling checker language limited to locale 'en'; install "
-#~ "pyenchant/python-enchant for better options."
-#~ msgstr ""
-#~ "Varning: rättstavning begränsad till '%s'; installera pyenchant/python-"
-#~ "enchant för bättre valmöjligheter."
-
-#~ msgid ""
-#~ "Warning: spelling checker language limited to locale '%s'; install "
-#~ "pyenchant/python-enchant for better options."
-#~ msgstr ""
-#~ "Varning: rättstavning begränsad till '%s'; installera pyenchant/python-"
-#~ "enchant för bättre valmöjligheter."
-
-#~ msgid ""
-#~ "Warning: spelling checker disabled; install pyenchant/python-enchant to "
-#~ "enable."
-#~ msgstr ""
-#~ "Varning: rättstavning bortkopplad; installera pyenchant/python-enchant "
-#~ "för att få med."
-
-#~ msgid "Place Details Gramplet"
-#~ msgstr "Gramplet med platsdetaljer"
-
-#~ msgid "Media Preview Gramplet"
-#~ msgstr "Gramplet för förhandsgranskning av media"
-
-#~ msgid "Person Residence Gramplet"
-#~ msgstr "Gramplet med en persons bostad"
-
-#~ msgid "Person Events Gramplet"
-#~ msgstr "Gramplet med personhändelser"
-
-#~ msgid "Family Events Gramplet"
-#~ msgstr "Gramplet för familjehändelser"
-
-#~ msgid "Person Attributes Gramplet"
-#~ msgstr "Gramplet med personattribut"
-
-#~ msgid "Event Attributes Gramplet"
-#~ msgstr "Gramplet med händelseattribut"
-
-#~ msgid "Family Attributes Gramplet"
-#~ msgstr "Gramplet med familjeattribut"
-
-#~ msgid "Media Attributes Gramplet"
-#~ msgstr "Gramplet med mediaattribut"
-
-#~ msgid "Person Notes Gramplet"
-#~ msgstr "Gramplet för personnotiser"
-
-#~ msgid "Event Notes Gramplet"
-#~ msgstr "Gramplet för händelsenotiser"
-
-#~ msgid "Family Notes Gramplet"
-#~ msgstr "Gramplet för familjenotiser"
-
-#~ msgid "Place Notes Gramplet"
-#~ msgstr "Gramplet för platsnotiser"
-
-#~ msgid "Source Notes Gramplet"
-#~ msgstr "Gramplet för källnotiser"
-
-#~ msgid "Repository Notes Gramplet"
-#~ msgstr "Gramplet för arkivplatsnotiser"
-
-#~ msgid "Media Notes Gramplet"
-#~ msgstr "Gramplet för medianotiser"
-
-#~ msgid "Event Sources Gramplet"
-#~ msgstr "Gramplet för händelsekällor"
-
-#~ msgid "Family Sources Gramplet"
-#~ msgstr "Gramplet för familjekällor"
-
-#~ msgid "Media Sources Gramplet"
-#~ msgstr "Gramplet för mediakällor"
-
-#~ msgid "Person Filter Gramplet"
-#~ msgstr "Gramplet för personfilter"
-
-#~ msgid "Family Filter Gramplet"
-#~ msgstr "Gramplet för familjefilter"
-
-#~ msgid "Event Filter Gramplet"
-#~ msgstr "Gramplet för händelsefilter"
-
-#~ msgid "Source Filter Gramplet"
-#~ msgstr "Gramplet för källfilter"
-
-#~ msgid "Place Filter Gramplet"
-#~ msgstr "Gramplet för platsfilter"
-
-#~ msgid "Media Filter Gramplet"
-#~ msgstr "Gramplet för mediafilter"
-
-#~ msgid "Repository Filter Gramplet"
-#~ msgstr "Gramplet för arkivplatsfilter"
-
-#~ msgid "Note Filter Gramplet"
-#~ msgstr "Gramplet för notisfilter"
-
-#~ msgid "Age on Date Gramplet"
-#~ msgstr "Gramplet med ålder vid visst datum"
-
-#~ msgid "Age Stats Gramplet"
-#~ msgstr "Gramplet med åldersstatistik"
-
-#~ msgid "Attributes Gramplet"
-#~ msgstr "Gramplet med attribut"
-
-#~ msgid "Calendar Gramplet"
-#~ msgstr "Kalendergramplet"
-
-#~ msgid "Fan Chart Gramplet"
-#~ msgstr "Gramplet med cirkelantavla"
-
-#~ msgid "FAQ Gramplet"
-#~ msgstr "FAQ för Gramplet"
-
-#~ msgid "Given Name Cloud Gramplet"
-#~ msgstr "Gramplet med förnamnsstatistik"
-
-#~ msgid "Pedigree Gramplet"
-#~ msgstr "Gramplet med antavla"
-
-#~ msgid "Plugin Manager Gramplet"
-#~ msgstr "Gramplet med hantering av insticksmoduler"
-
-#~ msgid "Quick View Gramplet"
-#~ msgstr "Snabbrapport-Gramplet"
-
-#~ msgid "Relatives Gramplet"
-#~ msgstr "Gramplet med släktingar"
-
-#~ msgid "Session Log Gramplet"
-#~ msgstr "Gramplet med körningslogg"
-
-#~ msgid "Statistics Gramplet"
-#~ msgstr "Gramplet med statistik"
-
-#~ msgid "Surname Cloud Gramplet"
-#~ msgstr "Gramplet med efternamnsstatistik"
-
-#~ msgid "TODO Gramplet"
-#~ msgstr "Att-Göra-Gramplet"
-
-#~ msgid "Top Surnames Gramplet"
-#~ msgstr "Gramplet med de vanligaste efternamnen"
-
-#~ msgid "Welcome Gramplet"
-#~ msgstr "Välkomstfönster"
-
-#~ msgid "What's Next Gramplet"
-#~ msgstr "Gramplet med nästa uppgift"
-
-#~ msgid "Gramplet %s is running"
-#~ msgstr "Gramplet %s körs"
-
-#~ msgid "Gramplet %s updated"
-#~ msgstr "Gramplet %s uppdaterad"
-
-#~ msgid "places"
-#~ msgstr "platser"
-
-#~ msgid "events"
-#~ msgstr "händelser"
-
-#~ msgid "Original image has been deleted!"
-#~ msgstr "Ursprungsbilden har raderats!"
-
-#~ msgid "Image fields have been cleared..."
-#~ msgstr "Bildfält har rensats..."
-
-#~ msgid "GeoView"
-#~ msgstr "GeoView"
-
-#~ msgid "Exif Viewer Gramplet"
-#~ msgstr "Gramplet för Exif-visning"
-
-#~ msgid "Gramplet showing exif tags for a media object"
-#~ msgstr "Gramplet visande exif-information för ett mediaobjekt"
-
-#~ msgid "Exif"
-#~ msgstr "Exif"
-
-#~ msgid "Clear the entry field in the places selection box."
-#~ msgstr "Rensa inmatningsfältet i valrutan för platser."
-
-#~ msgid ""
-#~ "Save the zoom and coordinates between places map, person map, family map "
-#~ "and event map."
-#~ msgstr ""
-#~ "Spara zoominställning och koordinater mellan platskarta, personkarta, "
-#~ "familjekarta och händelsekarta."
-
-#~ msgid ""
-#~ "Select the maps provider. You can choose between OpenStreetMap and Google "
-#~ "maps."
-#~ msgstr ""
-#~ "Välj tillhandahållare av karttjänster. Du kan välja mellan OpenStreetMap "
-#~ "(gröna häftstift) och Google maps (röda häftstift)."
-
-#~ msgid "Prior page."
-#~ msgstr "Föregående sida."
-
-#~ msgid "The current page/the last page."
-#~ msgstr "Den aktuella sida/sista sidan."
-
-#~ msgid "Next page."
-#~ msgstr "Nästa sida."
-
-#~ msgid "The number of places which have no coordinates."
-#~ msgstr "Antal platser utan koordinater."
-
-#~ msgid "You can adjust the time period with the two following values."
-#~ msgstr "Du kan justera tidsperioden med följand två värden."
-
-#~ msgid "The number of years before the first event date"
-#~ msgstr "Antal år innan datum för första händelse."
-
-#~ msgid "Crosshair on the map."
-#~ msgstr "Hårkors på kartan."
-
-#~ msgid ""
-#~ "Show the coordinates in the statusbar either in degrees\n"
-#~ "or in internal Gramps format ( D.D8 )"
-#~ msgstr ""
-#~ "Visa koordinater i statusraden i antingen grader\n"
-#~ "eller i Gramps interna format ( D.D8 )"
-
-#~ msgid ""
-#~ "The maximum number of markers per page. If the time to load one page is "
-#~ "too long, reduce this value"
-#~ msgstr ""
-#~ "Maximalt antal markörer per sida. Om tiden för att ladda en sida blir för "
-#~ "lång, minska detta värde."
-
-#~ msgid "Test the network "
-#~ msgstr "Test av nätvetverk "
-
-#~ msgid "Time out for the network connection test"
-#~ msgstr "Time-out för nätverksanslutningstestet"
-
-#~ msgid ""
-#~ "Time in seconds between two network tests.\n"
-#~ "Must be greater or equal to 10 seconds"
-#~ msgstr ""
-#~ "Tid i sekunder mellan två nätverkstester.\n"
-#~ "Måste vara minst 10 sekunder."
-
-#~ msgid ""
-#~ "Host to test for http. Please, change this and select one of your choice."
-#~ msgstr "Värd för http. Ändra detta till något som passar dig."
-
-#~ msgid "The network"
-#~ msgstr "Nätverket"
-
-#~ msgid "Select the place for which you want to see the info bubble."
-#~ msgstr "Välj den plats som du vill se information om i bubblan."
-
-#~ msgid "Time period"
-#~ msgstr "Tidsperiod"
-
-#~ msgid "All"
-#~ msgstr "Alla"
-
-#~ msgid "Zoom"
-#~ msgstr "Zooma"
-
-#~ msgid ""
-#~ "Add the location centred on the map as a new place in Gramps. Double "
-#~ "click the location to centre on the map."
-#~ msgstr ""
-#~ "Lägg till platsen mitt på kartan som en ny plats i Gramps. Dubbelklicka "
-#~ "på en plats för att centrera den."
-
-#~ msgid "_Link Place"
-#~ msgstr "_Länka Plats"
-
-#~ msgid ""
-#~ "Link the location centred on the map to a place in Gramps. Double click "
-#~ "the location to centre on the map."
-#~ msgstr ""
-#~ "Länka platsen mitt på kartan till en plats i Gramps. Dubbelklicka på en "
-#~ "plats för att centrera den."
-
-#~ msgid "Attempt to view all places in the family tree."
-#~ msgstr "Försök att visa alla platser i släktträdet."
-
-#~ msgid "Attempt to view all the places where the selected people lived."
-#~ msgstr "Försök att visa alla platser, där de valda  personerna bodde."
-
-#~ msgid "_Family"
-#~ msgstr "_Familj"
-
-#~ msgid "Attempt to view places of the selected people's family."
-#~ msgstr "Försök att visa platser för den valda personens familj."
-
-#~ msgid "_Event"
-#~ msgstr "H_ändelse"
-
-#~ msgid "Attempt to view places connected to all events."
-#~ msgstr "Försök att visa platser kopplade till all händelser."
-
-#~ msgid "List of places without coordinates"
-#~ msgstr "Lista på platser utan koordinater"
-
-#~ msgid ""
-#~ "Here is the list of all places in the family tree for which we have no "
-#~ "coordinates.<br> This means no longitude or latitude.<p>"
-#~ msgstr ""
-#~ "Här är en lista på all platser i släktträdet för vilka det saknas "
-#~ "koordinater.<br> Detta innebär ingen longitud eller latitud.<p>"
-
-#~ msgid "Back to prior page"
-#~ msgstr "Backa till föregående sida"
-
-#~ msgid "No location."
-#~ msgstr "Ingen plats."
-
-#~ msgid "You have no places in your family tree  with coordinates."
-#~ msgstr "Du har inga platser med koordinater, i ditt släktträd."
-
-#~ msgid "You are looking at the default map."
-#~ msgstr "De ser nu på startkartbilden."
-
-#~ msgid "%s : birth place."
-#~ msgstr "%s : födelseort."
-
-#~ msgid "birth place."
-#~ msgstr "födelseort."
-
-#~ msgid "%s : death place."
-#~ msgstr "%s : dödsort."
-
-#~ msgid "death place."
-#~ msgstr "dödsort."
-
-#~ msgid "Id : %s"
-#~ msgstr "Id : %s"
-
-#~ msgid "All places in the family tree with coordinates."
-#~ msgstr "Samtliga platser inom släktträdet med koordinater."
-
-#~ msgid "All events in the family tree with coordinates."
-#~ msgstr "Samtliga händelser i släktträdet med koordinater."
-
-#~ msgid ""
-#~ "All %(name)s people's family places in the family tree with coordinates."
-#~ msgstr ""
-#~ "Samtliga %(name)s personers familjers platser i släktträd med koordinater."
-
-#~ msgid ""
-#~ "Cannot center the map. No location with coordinates.That may happen for "
-#~ "one of the following reasons : <ul><li>The filter you use returned "
-#~ "nothing.</li><li>The active person has no places with coordinates.</"
-#~ "li><li>The active person's family members have no places with coordinates."
-#~ "</li><li>You have no places.</li><li>You have no active person set.</li>"
-#~ msgstr ""
-#~ "Kan ej centrera kartan. Ingen plats med koordinater finns. Orsakerna är "
-#~ "som följer: <ul><li>Den aktiva personen har inga platser med koordinater."
-#~ "</li><li>Den aktiva personens familjemedlemmar har inga platser med "
-#~ "koordinater.</li><li>Du har inga platser.</li><li>Du har ingen aktiv "
-#~ "person satt.</li>"
-
-#~ msgid "Not yet implemented ..."
-#~ msgstr "Inte infört ännu ..."
-
-#~ msgid ""
-#~ "Invalid path for const.ROOT_DIR:<br> avoid parenthesis into this parameter"
-#~ msgstr ""
-#~ "Ogiltig sökväg för const.ROOT_DIR:<br> undvik parenteser i denna parameter"
-
-#~ msgid ""
-#~ "You don't see a map here for one of the following reasons :"
-#~ "<br><ol><li>Your database is empty or not yet selected.</li><li>You have "
-#~ "not selected a person yet.</li><li>You have no places in your database.</"
-#~ "li><li>The selected places have no coordinates.</li></ol>"
-#~ msgstr ""
-#~ "Du ser ingen karta på grund av :<br><ol><li>Din databas är tom eller inte "
-#~ "ännu vald.</li><li>Du har inte ännu valt en person.</li><li>Du har inga "
-#~ "platser i din databas.</li><li>De valda platserna saknar koordinater.</"
-#~ "li></ol>"
-
-#~ msgid "Start page for the Geography View"
-#~ msgstr "Begynnelsesida för den geografisk vyn"
-
-#~ msgid "Geographic View"
-#~ msgstr "Geografisk vy"
-
-#~ msgid ""
-#~ "The view showing events on an interactive internet map (internet "
-#~ "connection needed)"
-#~ msgstr ""
-#~ "Vyn visar händelser på en interaktiva internet-karta. (Du måste vara "
-#~ "uppkopplad.)"
-
-#~ msgid "Fixed Zoom"
-#~ msgstr "Fast zoom"
-
-#~ msgid "Free Zoom"
-#~ msgstr "Fri zoom"
-
-#~ msgid "Show Person"
-#~ msgstr "Visa person"
-
-#~ msgid "Show Family"
-#~ msgstr "Visa familj"
-
-#~ msgid ""
-#~ "Latitude (position above the Equator) of the place in decimal or degree "
-#~ "notation.\\nEg, valid values are 12.0154, 50&#xB0;52'21.92\"\\nN, "
-#~ "N50&#xBA;52'21.92\"\\n or 50:52:21.92\\nYou can set these values via the "
-#~ "Geography View by searching the place, or via a map service in the place "
-#~ "view."
-#~ msgstr ""
-#~ "Latitud (position relativt ekvatorn) för platsen som decimal- eller "
-#~ "gradnotation.\n"
-#~ "Giltiga värden är t. ex. 12.0154, 50&#xB0;52'21.92''N, "
-#~ "N50&#xB0;52'21.92'' eller 50:52:21.92.\n"
-#~ "Du kan bestämma dessa värden via Geografivyn genom att söka efter platsen "
-#~ "eller via en karttjänst i platsvyn."
-
-#~ msgid "%(mother)s and %(father)s"
-#~ msgstr "%(mother)s och %(father)s"
-
-#~ msgid ""
-#~ "Latitude (position above the Equator) of the place in decimal or degree "
-#~ "notation."
-#~ msgstr ""
-#~ "Latitud (position relativt ekvatorn) för platsen i decimal- eller "
-#~ "gradnotation."
-
-#~ msgid ""
-#~ "Whether to resize the page to fit the size \n"
-#~ "of the tree.  Note:  the page will have a \n"
-#~ "non standard size."
-#~ msgstr ""
-#~ "Huruvida skala om sidan att passa till storleken \n"
-#~ "på trädet. Notera: sidan kommer att få en\n"
-#~ "från standard avvikande storlek."
-
-#~ msgid "Include a personal note"
-#~ msgstr "Ta med personnotiser"
-
-#~ msgid "Add a personal note"
-#~ msgstr "Lägg till en personnotis"
-
-#~ msgid ""
-#~ "When merging people where one person doesn't exist, that \"person\" must "
-#~ "be the person that will be deleted from the database."
-#~ msgstr ""
-#~ "Vid ihopslagning av personer, där en person inte finns, så måste den "
-#~ "\"personen\" vara den person, som kommer att tas bort från databasen."
-
-#~ msgid "Not Applicable"
-#~ msgstr "Ej tillämpbart"
-
-#~ msgid "Whether to compress the tree."
-#~ msgstr "Huruvida trädet skall komprimeras."
-
-#~ msgid ""
-#~ "Main\n"
-#~ "Display Format"
-#~ msgstr ""
-#~ "Huvud\n"
-#~ "visningsformat"
-
-#~ msgid ""
-#~ "Use Main/Secondary\n"
-#~ "Display Format for"
-#~ msgstr ""
-#~ "Använd huvud/andrahans\n"
-#~ "visningsformat för"
-
-#~ msgid "Mothers use Main, and Fathers use the Secondary"
-#~ msgstr "Mödrar använder huvud och fäder använder andrahands"
-
-#~ msgid "Fathers use Main, and Mothers use the Secondary"
-#~ msgstr "Fäder använder huvud och mödrar använder andrahands"
-
-#~ msgid "Print"
-#~ msgstr "Utskrift"
-
-#~ msgid "Print a border"
-#~ msgstr "Skriv ut en ram"
-
-#~ msgid "Whether spouses can have a different format."
-#~ msgstr "Huruvida  makar kan skilda format."
-
-#~ msgid "Media References Gramplet"
-#~ msgstr "Gramplet för mediareferenser"
-
-#~ msgid "Gramplet showing all of the references to this media object"
-#~ msgstr "Gramplet visande alla referenser till detta mediaobjekt"
-
-#~ msgid "%s - %s."
-#~ msgstr "%s - %s."
-
-#~ msgid ""
-#~ "A parent and child cannot be merged. To merge these people, you must "
-#~ "first break the relationship between them"
-#~ msgstr ""
-#~ "En förälder och ett barn kan inte slås samman. För att slå samman dessa "
-#~ "personer, måste du först bryta släktskapet mellan dem."
-
-#~ msgid "One page report"
-#~ msgstr "Rapport på en sida"
-
-#~ msgid ""
-#~ "The python binding library, pyexiv2, to exiv2 is not installed on this "
-#~ "computer.\n"
-#~ " It can be downloaded from here: %s\n"
-#~ "\n"
-#~ "You will need to download at least %s .  I recommend that you download "
-#~ "and install, %s ."
-#~ msgstr ""
-#~ "pyexiv2, pythons bindingsbibliotek, till exiv2, är ej installerat på "
-#~ "denna dator.\n"
-#~ " Kan laddas ner från: %s\n"
-#~ "Du måste ladda ner minst %s. Rekommenderas %s."
-
-#~ msgid "Artist/ Author"
-#~ msgstr "Artist/författare"
-
-#~ msgid "Keywords"
-#~ msgstr "Nyckelord"
-
-#~ msgid "Object with at least one direct source >= <confidence level>"
-#~ msgstr "Händelser med minst en direkt källa >=<konfidensnivå>"
-
-#~ msgid ""
-#~ "Matches objects with at least one direct source with confidence level(s)"
-#~ msgstr "Matchar händelser med minst en direkt källa med konfidensnivå(er)"
-
-#~ msgid "Part of the Given name that is the normally used name."
-#~ msgstr "Del av förnamnet, som är det normalt använda namnet. "
-
-#~ msgid "Media Metadata Gramplet"
-#~ msgstr "Gramplet för mediametadata "
-
-#~ msgid "Active Image"
-#~ msgstr "Aktiv bild"
-
-#~ msgid "A note to be used as the publisher contact."
-#~ msgstr "En notis, som skall användas som utgivarkontakt."
-
-#~ msgid "An image to be used as the publisher contact."
-#~ msgstr "En bild, som skall användas som utgivarkontakt."
-
-#~ msgid "Select Gramplet"
-#~ msgstr "Välj Gramplet"
-
-#~ msgid "Marker type:"
-#~ msgstr "Markeringstyp:"
-
-#~ msgid "Cannot remove tab"
-#~ msgstr "Kan inte ta bort flik"
-
-#~ msgid "The filter tab cannot be removed"
-#~ msgstr "Filterfliken kan ek tas bort"
-
-#~ msgid "%d media object was referenced but not found\n"
-#~ msgid_plural "%d media objects were referenced but not found\n"
-#~ msgstr[0] "%d mediaobjekt, som refererats till, kunde inte hittas\n"
-#~ msgstr[1] "%d mediaobjekt, som refererats till, kunde inte hittas\n"
-
-#~ msgid "Show Sp_ouses"
-#~ msgstr "Visa makar"
-
-#~ msgid "bytes"
-#~ msgstr "byte"
-
-#~ msgid "Total size of media objects: %d bytes"
-#~ msgstr "Sammanlagd storlek på mediaobjekt: %d byte"
-
-#~ msgid "_Add a gramplet"
-#~ msgstr "_Lägg till ett Gramplet"
-
-#~ msgid "_Undelete gramplet"
-#~ msgstr "_Återta ett Gramplet"
-
-#~ msgid "Unkonwn"
-#~ msgstr "Okänd"
-
-#~ msgid "Date of the event."
-#~ msgstr "Händelsens datum."
-
-#~ msgid ""
-#~ "The role of the person in this event. Use 'Primary' for the main "
-#~ "beneficiary, use a descriptive role otherwise (Eg., Witness, "
-#~ "Celebrant, ...)"
-#~ msgstr ""
-#~ "Den roll personen har i händelsen. Använd 'Primär' för huvudpersonen och "
-#~ "använd beskrivande ord för andra roller (T. ex. Vittne, ...)"
-
-#~ msgid ""
-#~ "Date associated with this source reference. Typically used to store the "
-#~ "log date (when text was added to the original source)."
-#~ msgstr ""
-#~ "Datum kopplat till denna källreferens. Används typiskt för att spara "
-#~ "loggningsdatum (när text lagts till orginalkällan)."
-
-#~ msgid "<b>Filter</b>"
-#~ msgstr "<b>Filter</b>"
-
-#~ msgid "More Name Details"
-#~ msgstr "Ytterligare namndetaljer"
-
-#~ msgid ""
-#~ "Open the name editor to edit the preferred name in detail. This allows to "
-#~ "set eg. Family Nick Name, Date, ..."
-#~ msgstr ""
-#~ "Öppna namneredigeraren för att redigera förstahandsnamnet i detalj. Detta "
-#~ "ger dig möjlighet att bestämma familjesmeknamn, datum, ..."
-
-#~ msgid "_Prefix:"
-#~ msgstr "_Prefix:"
-
-#~ msgid "Add_ress:"
-#~ msgstr "Adr_ess:"
-
-#~ msgid "_State/Province:"
-#~ msgstr "L_än/delstat:"
-
-#~ msgid ""
-#~ "If media is an image, select a region of the image that is referenced. "
-#~ "Point (0,0) is the top left corner. Do this by giving two corners on a "
-#~ "diagonal of the rectangular region you want to use."
-#~ msgstr ""
-#~ "Om media är en bild, välj ett område på bilden som dess referens. Punkt "
-#~ "(0,0) är övre vänstra hörnet. Gör detta genom att ange två diagonala hörn "
-#~ "hos det rektangulära område du vill använda."
-
-#~ msgid "CALL"
-#~ msgstr "TILLTALSNAMN"
-
-#~ msgid ""
-#~ "The following keywords will be replaced with the name:\n"
-#~ "<tt>  \n"
-#~ "  <b>Given</b>      - given name (first name)\n"
-#~ "  <b>Surname</b>    - surname (last name)\n"
-#~ "  <b>Title</b>      - title (Dr., Mrs.)\n"
-#~ "  <b>Prefix</b>     - prefix (von, de, de la)\n"
-#~ "  <b>Suffix</b>     - suffix (Jr., Sr.)\n"
-#~ "  <b>Call</b>       - call name, or nickname\n"
-#~ "  <b>Common</b>     - call name, otherwise first part of Given\n"
-#~ "  <b>Patronymic</b> - patronymic (father's name)\n"
-#~ "  <b>Initials</b>   - persons's first letters of given names\n"
-#~ "</tt>\n"
-#~ "Use the same keyword in UPPERCASE to force to upper. Parentheses and "
-#~ "commas\n"
-#~ "will be removed around empty fields. Other text will appear literally."
-#~ msgstr ""
-#~ "Följande nyckelord kommer att bytas ut med namnet:\n"
-#~ "<tt>  \n"
-#~ "  <b>Förnamn</b>      - förnamn (första namn)\n"
-#~ "  <b>Efternamn</b>    - efternamn (sista namn)\n"
-#~ "  <b>Titel</b>        - titel (Dr., Fru.)\n"
-#~ "  <b>Prefix</b>       - prefix (von, de, de la)\n"
-#~ "  <b>Suffix</b>       - suffix (Jr., Sr., d.y., d.ä.)\n"
-#~ "  <b>Tilltalsnamn</b> - tilltalsnamn, eller smeknamn\n"
-#~ "  <b>Vanligt</b>      - tilltalsnamn, annars första delen av förnamn\n"
-#~ "  <b>Patronymikon</b> - patronymikon (faders namn)\n"
-#~ "  <b>Initialer</b>    - personens först bokstäver från förnamn\n"
-#~ "</tt>\n"
-#~ "Använd samma nyckelord med STORA bokstäver för att tvinga detta.\n"
-#~ "Parenteser och komma tas bort runt tomma fält. Annan text visas "
-#~ "bokstavligt."
-
-#~ msgid "The format definition is invalid"
-#~ msgstr "Formatdefinitionen är ogiltig"
-
-#~ msgid "What would you like to do?"
-#~ msgstr "Vad skulle du vilja göra?"
-
-#~ msgid "_Continue anyway"
-#~ msgstr "_Fortsätta i alla fall"
-
-#~ msgid "_Modify format"
-#~ msgstr "_Ändra format"
-
-#~ msgid "Both Format name and definition have to be defined."
-#~ msgstr "Både formatnamn och definition måste anges."
-
-#~ msgid "Database Processing"
-#~ msgstr "Databearbetning"
-
-#~ msgid "Database Repair"
-#~ msgstr "Reparera databas"
-
-#~ msgid "Marker Report"
-#~ msgstr "Markeringsrapport"
-
-#~ msgid "Checking people for proper date formats"
-#~ msgstr "Kontroller personer så att riktigt datumformat används"
-
-#~ msgid "Checking families for proper date formats"
-#~ msgstr "Kontrollerar familjer så att riktigt datumformat används"
-
-#~ msgid "Attribute:"
-#~ msgstr "Attribut:"
-
-#~ msgid "Objects with the <attribute>"
-#~ msgstr "Objekt med <attribut>"
-
-#~ msgid "Matches objects with the given attribute of a particular value"
-#~ msgstr ""
-#~ "Matchar objekt där det angivna attributet\n"
-#~ "har ett specifikt värde"
-
-#~ msgid "Events matching parameters"
-#~ msgstr "Parametrar för matchning av händelser"
-
-#~ msgid "Matches events with particular parameters"
-#~ msgstr "Matchar händelser med specifika parametrar"
-
-#~ msgid "Objects having notes containing <regular expression>"
-#~ msgstr "Objekt med notiser som innehåller <reguljärt uttryck>"
-
-#~ msgid "Objects having notes containing <substring>"
-#~ msgstr "Objekt med <delsträng> i notiser"
-
-#~ msgid "Objects with a reference count of <count>"
-#~ msgstr "Objekt med en referensräknar på <antal>"
-
-#~ msgid "Objects matching the <filter>"
-#~ msgstr "Objekt som matchar <filter>"
-
-#~ msgid "Objects with <Id>"
-#~ msgstr "Objekt med <Id>"
-
-#~ msgid "Matches markers of a particular type"
-#~ msgstr "Matchar markeringar av en speciell typen"
-
-#~ msgid "Matches all people whose records are complete"
-#~ msgstr "Matchar alla personer vars poster är fullständiga"
-
-#~ msgid "People with <marker>"
-#~ msgstr "Personer med <markör>"
-
-#~ msgid "Matches people with a marker of a particular value"
-#~ msgstr "Matchar personer med en markering av ett visst värde"
-
-#~ msgid "Families with <marker>"
-#~ msgstr "Familjer med <markör>"
-
-#~ msgid "Matches Families with a marker of a particular value"
-#~ msgstr "Matchar familjer som har en markör av ett visst värde"
-
-#~ msgid "Events with <marker>"
-#~ msgstr "Händelser med <markör>"
-
-#~ msgid "Matches Events with a marker of a particular value"
-#~ msgstr "Matchar händelser, som har en markör av ett visst värde"
-
-#~ msgid "Call _Name:"
-#~ msgstr "_Tilltalsnamn:"
-
-#~ msgid "Edit the preferred name"
-#~ msgstr "Redigera det föredragna namnet"
-
-#~ msgid "Gi_ven:"
-#~ msgstr "_Förnamn:"
-
-#~ msgid ""
-#~ "Patronimic: component of a personal name based on the name of one's "
-#~ "father, grandfather, .... \n"
-#~ "Title: A title used to refer to the person, such as 'Dr.' or 'Rev.'"
-#~ msgstr ""
-#~ "Patronymikon: del av ett personnamn, i Sverige grundat på faders förnamn\n"
-#~ "Titel: Personens titel. "
-
-#~ msgid "_Gender:"
-#~ msgstr "K_ön:"
-
-#~ msgid "_Marker:"
-#~ msgstr "_Markering:"
-
-#~ msgid "_Publication information:"
-#~ msgstr "_Publiceringsinformation:"
-
-#~ msgid "_Publication Information:"
-#~ msgstr "_Publiceringsinformation:"
-
-#~ msgid "P_atronymic:"
-#~ msgstr "Patronymi_kon:"
-
-#~ msgid "Tit_le:"
-#~ msgstr "Tite_l:"
-
-#~ msgid "Marker:"
-#~ msgstr "Markering:"
-
-#~ msgid "_Marker"
-#~ msgstr "_Markering"
-
-#~ msgid ""
-#~ "Below is a list of the nicknames, titles and family name prefixes that "
-#~ "Gramps can extract from the \n"
-#~ "current database. If you accept the changes, Gramps will modify the "
-#~ "entries\n"
-#~ "that have been selected."
-#~ msgstr ""
-#~ "Nedan följer en lista över smeknamn, titlar och efternamnsprefix som "
-#~ "Gramps kan hämtas från \n"
-#~ "den aktuella databasen. Om du accepterar ändringarna, så kommer Gramps "
-#~ "att\n"
-#~ "modifiera de valda posterna."
-
-#~ msgid "Updating View"
-#~ msgstr "Uppdaterar vy"
-
-#~ msgid "Tag people with %s"
-#~ msgstr "Flagga personer med %s"
-
-#~ msgid "Source Reference"
-#~ msgstr "Källreferens"
-
-#~ msgid "Repository Reference"
-#~ msgstr "Arkivplatsreferens"
-
-#~ msgid "Paste"
-#~ msgstr "Klistra in"
-
-#~ msgid "Cut"
-#~ msgstr "Klipp ut"
-
-#~ msgid "The Copyright License for these files are: "
-#~ msgstr "Copyright för dessa filer är: "
-
-#~ msgid "Download Copyright License"
-#~ msgstr "Ladda ner copyrightlicens"
-
-#~ msgid "The copyright to be used for this download file?"
-#~ msgstr "Den copyright, som skall användas för denna nedladdningsfil?"
-
-#~ msgid "Event Link"
-#~ msgstr "Händelselänk"
-
-#~ msgid "Person Link"
-#~ msgstr "Personlänk"
-
-#~ msgid "Source Link"
-#~ msgstr "Källänk"
-
-#~ msgid "Repository Link"
-#~ msgstr "Länk till arkivplats"
-
-#~ msgid "Lat."
-#~ msgstr "Lat."
-
-#~ msgid "Long."
-#~ msgstr "Long."
-
-#~ msgid "<b><i>Gramplet</i></b>"
-#~ msgstr "<b><i>Gramplet</i></b>"
-
-#~ msgid "Compare and _Merge..."
-#~ msgstr "Jämför och slå sa_mman..."
-
-#~ msgid "_Fast Merge..."
-#~ msgstr "Sna_bbsammanslagning..."
-
-#~ msgid "Sealed to "
-#~ msgstr "Beseglad till "
-
-#~ msgid "_Do not include unlinked records"
-#~ msgstr "Ta inte med _olänkade poster"
-
-#~ msgid "Search Url"
-#~ msgstr "Söksida Url"
-
-#~ msgid "Home Url"
-#~ msgstr "Hemsida Url"
-
-#~ msgid "EW"
-#~ msgstr "ÖV"
-
-#~ msgid " Date"
-#~ msgstr " Datum"
-
-#~ msgid " Place"
-#~ msgstr " Plats"
-
-#~ msgid "%(comment)s : birth place."
-#~ msgstr "%(comment)s : födelseort."
-
-#~ msgid "%(comment)s : death place."
-#~ msgstr "%(comment)s : åldersskillnad."
-
-#~ msgid "Link/ Description"
-#~ msgstr "Länk/beskrivning"
-
-#~ msgid "Latitude/ Longitude"
-#~ msgstr "Latitud/Longitud"
-
-#~ msgid "License"
-#~ msgstr "Licens"
-
-#~ msgid "<b>Mouse</b>"
-#~ msgstr "<b>Mus</b>"
-
-#~ msgid "Wheel scrolls"
-#~ msgstr "Mushjulsriktning"
-
-#~ msgid "<b>Tree</b>"
-#~ msgstr "<b>Träd</b>"
-
-#~ msgid "Direction:"
-#~ msgstr "Riktning:"
-
-#~ msgid "Top to Bottom"
-#~ msgstr "Uppåt <-> neråt"
-
-#~ msgid "Bottom to Top"
-#~ msgstr "Neråt <-> uppåt"
-
-#~ msgid "Left to Right"
-#~ msgstr "Vänster <-> höger"
-
-#~ msgid "Right to Left"
-#~ msgstr "Höger <-> vänster"
-
-#~ msgid "%d generation"
-#~ msgid_plural "%d generations"
-#~ msgstr[0] "%d generation"
-#~ msgstr[1] "%d generationer"
-
-#~ msgid "No views loaded"
-#~ msgstr "Inga vyer laddad"
-
-#~ msgid ""
-#~ "No view plugins are loaded. Go to Help->Plugin Manager, and make sure "
-#~ "some plugins of type 'View' are enabled. Then restart Gramps"
-#~ msgstr ""
-#~ "Inga insticksprogram för vyer är laddade. Gå till Hjälp-"
-#~ ">Instickshanterare och se till att några insticksprogram av typen 'View' "
-#~ "är tillåtna. Starta om Gramps."
-
-#~ msgid "Creating event page %02d of %02d"
-#~ msgstr "Skapar händelseförteckning, sida %02d av %02d"
-
-#~ msgid "Download page note"
-#~ msgstr "Notis för nedladdningssida"
-
-#~ msgid "A note to be used on the download page"
-#~ msgstr "En notis, som skall användas på nedladdningssidan"
-
-#~ msgid "Whether to include a link to the home person"
-#~ msgstr "Huruvida ta med en länk till hempersonen"
-
-#~ msgid "The Style Sheet to be used for the web page"
-#~ msgstr "Det mallblad, som skall användas för webbsidan"
-
-#~ msgid "Matches people with a certain number of items in the source"
-#~ msgstr "Matchar personer med en viss antal källor"
-
-#~ msgid "January 1"
-#~ msgstr "1 januari"
-
-#~ msgid "March 1"
-#~ msgstr "1 mars"
-
-#~ msgid "March 25"
-#~ msgstr "25 mars"
-
-#~ msgid "September 1"
-#~ msgstr "1 september"
-
-#~ msgid "Use system fonts"
-#~ msgstr "Använd systemets teckensnitt"
-
-#~ msgid "Use font:"
-#~ msgstr "Använd teckensnitt"
-
-#~ msgid "Default font"
-#~ msgstr "Standardteckensnitt"
-
-#~ msgid "Last modified"
-#~ msgstr "Senast ändrat"
-
-#~ msgid "Show Repository Reference"
-#~ msgstr "Visa arkivplatsreferens"
-
-#~ msgid "'%s' is for NOT this version of Gramps."
-#~ msgstr "'%s' är EJ för denna version av Gramps."
-
-#~ msgid "Export Complete: %d second"
-#~ msgid_plural "Export Complete: %d seconds"
-#~ msgstr[0] "Exporten klar: %d sekund"
-#~ msgstr[1] "Exporten klar: %d sekunder"
-
-#~ msgid "Django import"
-#~ msgstr "Django-import"
-
-#~ msgid "Select filter to restrict people"
-#~ msgstr "Välj ett filter, som begränsar personurvalet"
-
-#~ msgid "Calculated Date Estimates"
-#~ msgstr "Beräknade datumuppskattningar"
-
-#~ msgid "Source to remove and/or add"
-#~ msgstr "Källa som skall tas bort eller läggas till"
-
-#~ msgid "Remove previously added events, notes, and source"
-#~ msgstr "Tar bort tidigare tillagda händelser, notiser och källor"
-
-#~ msgid ""
-#~ "Remove calculated events, notes, and source; occurs immediately on Execute"
-#~ msgstr ""
-#~ "Tag bort beräknade händelser, notiser och källor; sker omedelbart vi Utför"
-
-#~ msgid "Do not add birth events"
-#~ msgstr "Lägg inte till födelsehändelser"
-
-#~ msgid "Add birth events without dates"
-#~ msgstr "Lägg till födelsehändelser utan datum"
-
-#~ msgid "Add birth events with dates"
-#~ msgstr "Lägg till födelsehändelser med datum"
-
-#~ msgid "Add a birth events with or without estimated dates"
-#~ msgstr "Lägg till födelsehändelser med eller utan uppskattade datum"
-
-#~ msgid "Do not add death events"
-#~ msgstr "Lägg inte till dödshändelser"
-
-#~ msgid "Add death events with dates"
-#~ msgstr "Lägg till dödshändelser med datum"
-
-#~ msgid "Add death events with or without estimated dates"
-#~ msgstr "Lägg till dödshändelser med eller utan uppskattade datum"
-
-#~ msgid "Maximum age"
-#~ msgstr "Maximiålder"
-
-#~ msgid "Maximum age that one can live to"
-#~ msgstr "Högsta tänkbara levnadsålder"
-
-#~ msgid "Maximum age difference between siblings"
-#~ msgstr "Största åldersskillnader mellan syskon"
-
-#~ msgid "Estimated Dates"
-#~ msgstr "Uppskattade datum"
-
-#~ msgid "Approximate (about)"
-#~ msgstr "Approximativt (omkring)"
-
-#~ msgid "Extremes (after and before)"
-#~ msgstr "Extremvärden (efter och före)"
-
-#~ msgid "Dates on events are either about or after/before"
-#~ msgstr "Datum för händelser är antingen omkring eller efter/före"
-
-#~ msgid "Help"
-#~ msgstr "Hjälp"
-
-#~ msgid ""
-#~ "The Calculate Estimated Dates Tool is used to add and remove birth and "
-#~ "death events for people that are missing these events.\n"
-#~ "\n"
-#~ "To use:\n"
-#~ "1. Go to the Options tab\n"
-#~ "2. Check the [ ] Remove option to remove previous estimates\n"
-#~ "3. Select the Add date options to date events with or without dates\n"
-#~ "4. Click on Execute\n"
-#~ "5. Select the people with which to add events\n"
-#~ "6. Click on 'Add Selected Events' button to create\n"
-#~ "\n"
-#~ "NOTES: if you decide to make an event permanent, remove it from the "
-#~ "Source. Otherwise, it will get removed the next time you automatically "
-#~ "remove these events.\n"
-#~ "\n"
-#~ "You may have to run the tool repeatedly (without removing previous "
-#~ "events) to add all of the events possible."
-#~ msgstr ""
-#~ "Verktyget beräkna uppskattade datum används för att lägga till och ta "
-#~ "bort födelse- och dödshändelser för personer som saknar dessa händelser.\n"
-#~ "\n"
-#~ "Vid användning:\n"
-#~ "1. Gå till valfliken\n"
-#~ "2. Markera i [ ] tag-bort-valet för att ta bort tidigare uppskattningar\n"
-#~ "3. Välj lägg-till-valet för att datera händelser med eller utan datum.\n"
-#~ "4. Klicka på Verkställ\n"
-#~ "5. Välj de personer för vilka händelser skall läggas till\n"
-#~ "6. Klicka på 'Lägg till valda händelser'-knappen för att skapa dem\n"
-#~ "\n"
-#~ "NOTERA: om du bestämmer dig för att göra en händelse permanent, tag bort "
-#~ "den från källan. Annars kommer denna att tagas bort nästa gång du "
-#~ "automatiskt tar bort dessa händelser.\n"
-#~ "\n"
-#~ "Du kan behöva köra detta verktyg flera gånger (utan att ta bort "
-#~ "föregående händelser) för att lägga till alla möjliga händelser."
-
-#~ msgid "Calculate Estimated Dates"
-#~ msgstr "Beräknade uppskattade datum"
-
-#~ msgid "Add Selected Events"
-#~ msgstr "Lägg till valda händelser"
-
-#~ msgid "Remove Events, Notes, and Source and Reselect Data"
-#~ msgstr "Tag bort händelser, notiser och källor samt välj om data"
-
-#~ msgid ""
-#~ "Are you sure you want to remove previous events, notes, and source and "
-#~ "reselect data?"
-#~ msgstr ""
-#~ "Är du säker på att du vill ta bort händelser, notiser och källor samt "
-#~ "välj om data?"
-
-#~ msgid "Remove and Run Select Again"
-#~ msgstr "Ta bort och kör välj igen"
-
-#~ msgid "Reselect Data"
-#~ msgstr "Väljer om data"
-
-#~ msgid "Run Select Again"
-#~ msgstr "Kör välj igen"
-
-#~ msgid "Evidence"
-#~ msgstr "Bevis"
-
-#~ msgid "Relative"
-#~ msgstr "Släkting"
-
-#~ msgid "Processing...\n"
-#~ msgstr "Arbetar...\n"
-
-#~ msgid "Removing old estimations... "
-#~ msgstr "tar bort gamla uppskattningar... "
-
-#~ msgid "Removed date estimates"
-#~ msgstr "Borttagna datumuppskattningar"
-
-#~ msgid ""
-#~ "Selecting... \n"
-#~ "\n"
-#~ msgstr ""
-#~ "Väljer... \n"
-#~ "\n"
-
-#~ msgid "Add birth and death events"
-#~ msgstr "Lägg till födelse- och dödshändelseer"
-
-#~ msgid "Add birth event"
-#~ msgstr "Lägg till födelsehändelse"
-
-#~ msgid "Add death event"
-#~ msgstr "Lägg till dödshändelse"
-
-#~ msgid "No events to be added."
-#~ msgstr "Inga händelser att lägga till."
-
-#~ msgid "Selecting... "
-#~ msgstr "Väljer... "
-
-#~ msgid "Adding events '%s'..."
-#~ msgstr "Lägger till händelser '%s'..."
-
-#~ msgid "Added birth event based on %(evidence)s, from %(name)s"
-#~ msgstr "Tillagd födelsehändelse grundat på %(evidence)s, från %(name)s"
-
-#~ msgid "Added birth event based on %s"
-#~ msgstr "Lagt födelsehändelse grundat på %s"
-
-#~ msgid "Added death event based on %(evidence)s, from %(person)s"
-#~ msgstr "Tillagd dödshändelse grundat på %(evidence)s, från %(person)s"
-
-#~ msgid "Added death event based on %s"
-#~ msgstr "Lagt till dödshändelse grundat på %s"
-
-#~ msgid "Estimated death date"
-#~ msgstr "Uppskattat dödsdatum"
-
-#~ msgid " Done! Committing..."
-#~ msgstr " Klart! Uppdaterar..."
-
-#~ msgid "Add date estimates"
-#~ msgstr "Lagt till datumuppskattningar"
-
-#~ msgid "Added %d events."
-#~ msgstr "Lägg till %d händelser."
-
-#~ msgid "Calculates estimated dates for birth and death."
-#~ msgstr "Beräkna uppskattningar av datum för födelse och död."
-
-#~ msgid "Version A"
-#~ msgstr "Version A"
-
-#~ msgid "Version B"
-#~ msgstr "Version B"
-
-#~ msgid "Automatic"
-#~ msgstr "Automatisk"
-
-#~ msgid "Version C"
-#~ msgstr "Version C"
-
-#~ msgid ""
-#~ "Your family tree groups name %s together with %s, did not change this "
-#~ "grouping to %s"
-#~ msgstr ""
-#~ "Ditt släktträd grupperar namn %s tillsammans med %s, ändrade inte detta "
-#~ "till gruppering till %s"
-
-#~ msgid "%s and %s are the same person."
-#~ msgstr "%s och %s är samma person."
-
-#~ msgid "Relationships of %s to %s"
-#~ msgstr "Släktskap för %s till %s"
-
-#~ msgid "Added birth event based on %s, from %s"
-#~ msgstr "Lagt till födelsehändelse grundat på %s, från %s"
-
-#~ msgid "Added death event based on %s, from %s"
-#~ msgstr "Lagt till dödshändelse grundat på %s, från %s"
-
-#~ msgid "%d broken child/family link was fixed\n"
-#~ msgid_plural "%d broken child-family links were found\n"
-#~ msgstr[0] "%d trasig barn-/familjelänk lagades\n"
-#~ msgstr[1] "%d trasiga barn-/familjelänkar lagades\n"
-
-#~ msgid "%d media object was referenced, but not found\n"
-#~ msgid_plural "%d media objects were referenced, but not found\n"
-#~ msgstr[0] "%d mediaobjekt, som refererats till, kunde inte hittas\n"
-#~ msgstr[1] "%d mediaobjekt, som refererats till, kunde inte hittas\n"
-
-#~ msgid "%d note object was referenced but not found\n"
-#~ msgid_plural "%d note objects were referenced but not found\n"
-#~ msgstr[0] "%d notisobjekt, som refererats till, kunde inte hittas\n"
-#~ msgstr[1] "%d notisobjekt, som refererats till, kunde inte hittas\n"
-
-#~ msgid "Their common ancestors are %s and %s."
-#~ msgstr "Deras gemensamma ana är %s och %s."


### PR DESCRIPTION
I'm having an updated swedish translation for Gramps, that I hoping you have some interest in. It's reworked but mostly based on the earlier translator, which so sadly died last year. Over 500 untranslated strings is now translated though, some touches, spellings and grammar errors is also fixed. I've done it with the Gramps 5.0 pot-file, and I've tested it with that version, I don't see anything wrong. Hope it is useful.