### PR TITLE
Fix for re-entrant main window close when user hits 'x' again

### DIFF
--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -496,7 +496,7 @@ class ViewManager(CLIManager):
         """
         Connects the signals needed
         """
-        self.window.connect('delete-event', self.quit)
+        self.del_event = self.window.connect('delete-event', self.quit)
         self.notebook.connect('switch-page', self.view_changed)
         if _GTKOSXAPPLICATION:
             self.macapp.connect('NSApplicationWillTerminate', self.quit)
@@ -801,12 +801,22 @@ class ViewManager(CLIManager):
         self.dbstate.no_database()
         self.post_close_db()
 
+    def no_del_event(self, *obj):
+        """ Routine to prevent window destroy with default handler if user
+        hits 'x' multiple times. """
+        return True
+
     def quit(self, *obj):
         """
         Closes out the program, backing up data
         """
         # mark interface insenstitive to prevent unexpected events
         self.uistate.set_sensitive(False)
+        # the following prevents reentering quit if user hits 'x' again
+        self.window.disconnect(self.del_event)
+        # the following prevents premature closing of main window if user
+        # hits 'x' multiple times.
+        self.window.connect('delete-event', self.no_del_event)
 
         # backup data
         if config.get('database.backup-on-exit'):


### PR DESCRIPTION
Fixes [#10897](https://gramps-project.org/bugs/view.php?id=10897)
and maybe [#10895](https://gramps-project.org/bugs/view.php?id=10895),[#10882](https://gramps-project.org/bugs/view.php?id=10882)  (I did https://github.com/gramps-project/gramps/pull/716 to try to fix 10882).

What happens is the user hits the main Gramps window 'x' button more than once while Gramps is closing.  It is easy to replicate when autobackup is on and it takes a bit of time to complete.  The viewmanager 'close' routine gets re-entered, which starts the close process again.  This can easily happen with autobackup on because its progress bar has the Gtk events pending call (to allow progress update), but that also allows the 'delete-event' to occur again.

Found this while trying to replicate https://gramps-project.org/bugs/view.php?id=10895.  The fix was to prevent the 'delete-event' from happening again.
