### PR TITLE
Fix 'Generate Book' dialog for crash on 'x' close

### DIFF
--- a/gramps/gui/plug/report/_bookdialog.py
+++ b/gramps/gui/plug/report/_bookdialog.py
@@ -951,7 +951,8 @@ class BookDialog(DocReportDialog):
                 self.make_book()
             except (IOError, OSError) as msg:
                 ErrorDialog(str(msg), parent=self.window)
-        self.close()
+        if response != Gtk.ResponseType.DELETE_EVENT:  # already closed
+            self.close()
 
     def setup_style_frame(self):
         pass


### PR DESCRIPTION
Fixes [#10901](https://gramps-project.org/bugs/view.php?id=10901)

Close got called twice when using the 'x' from titlebar...