### PR TITLE
Fix dialogs for 'Help' button closes the dialog, and non-functional 'Help'

### DIFF
--- a/gramps/gui/glade/baseselector.glade
+++ b/gramps/gui/glade/baseselector.glade
@@ -65,6 +65,7 @@
                 <property name="expand">False</property>
                 <property name="fill">False</property>
                 <property name="position">2</property>
+                <property name="secondary">True</property>
               </packing>
             </child>
           </object>
@@ -161,7 +162,6 @@
     <action-widgets>
       <action-widget response="-6">cancelbutton1</action-widget>
       <action-widget response="-5">okbutton1</action-widget>
-      <action-widget response="-11">help</action-widget>
     </action-widgets>
   </object>
 </interface>

--- a/gramps/gui/glade/dbman.glade
+++ b/gramps/gui/glade/dbman.glade
@@ -159,6 +159,7 @@
                 <property name="expand">False</property>
                 <property name="fill">False</property>
                 <property name="position">2</property>
+                <property name="secondary">True</property>
               </packing>
             </child>
           </object>
@@ -375,7 +376,6 @@
     <action-widgets>
       <action-widget response="-7">cancel_btn</action-widget>
       <action-widget response="-5">connect_btn</action-widget>
-      <action-widget response="-11">help_btn</action-widget>
     </action-widgets>
   </object>
 </interface>

--- a/gramps/gui/plug/report/_bookdialog.py
+++ b/gramps/gui/plug/report/_bookdialog.py
@@ -929,7 +929,10 @@ class BookDialog(DocReportDialog):
                                  'book', self.title, track=track)
         self.options.options_dict['bookname'] = self.book.get_name()
 
-        response = self.window.run()
+        while True:
+            response = self.window.run()
+            if response != Gtk.ResponseType.HELP:
+                break
         if response == Gtk.ResponseType.OK:
             handler = self.options.handler
             if self.book.get_paper_name() != handler.get_paper_name():

--- a/gramps/gui/selectors/baseselector.py
+++ b/gramps/gui/selectors/baseselector.py
@@ -36,6 +36,8 @@ from ..managedwindow import ManagedWindow
 from ..filters import SearchBar
 from ..glade import Glade
 from ..widgets.interactivesearchbox import InteractiveSearchBox
+from ..display import display_help
+from gramps.gen.const import URL_MANUAL_PAGE
 
 #-------------------------------------------------------------------------
 #
@@ -86,6 +88,9 @@ class BaseSelector(ManagedWindow):
         self.tree.set_headers_clickable(True)
         self.tree.connect('row-activated', self._on_row_activated)
         self.tree.grab_focus()
+        self.define_help_button(
+            self.glade.get_object('help'), self.WIKI_HELP_PAGE,
+            self.WIKI_HELP_SEC)
 
         # connect to signal for custom interactive-search
         self.searchbox = InteractiveSearchBox(self.tree)
@@ -358,3 +363,7 @@ class BaseSelector(ManagedWindow):
     def close(self, *obj):
         ManagedWindow.close(self)
         self._cleanup_on_exit()
+
+    def define_help_button(self, button, webpage='', section=''):
+        """ Setup to deal with help button """
+        button.connect('clicked', lambda x: display_help(webpage, section))

--- a/gramps/gui/selectors/selectcitation.py
+++ b/gramps/gui/selectors/selectcitation.py
@@ -39,7 +39,6 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
 from ..views.treemodels import CitationTreeModel
 from .baseselector import BaseSelector
-from ..display import display_help
 from gramps.gen.const import URL_MANUAL_SECT2
 
 #-------------------------------------------------------------------------
@@ -47,8 +46,6 @@ from gramps.gen.const import URL_MANUAL_SECT2
 # Constants
 #
 #-------------------------------------------------------------------------
-WIKI_HELP_PAGE = URL_MANUAL_SECT2
-WIKI_HELP_SEC = _('manual|Select_Source_or_Citation_selector')
 
 #-------------------------------------------------------------------------
 #
@@ -84,3 +81,6 @@ class SelectCitation(BaseSelector):
             return self.db.get_source_from_handle(handle)
         else:
             return self.db.get_citation_from_handle(handle)
+
+    WIKI_HELP_PAGE = URL_MANUAL_SECT2
+    WIKI_HELP_SEC = _('manual|Select_Source_or_Citation_selector')

--- a/gramps/gui/selectors/selectevent.py
+++ b/gramps/gui/selectors/selectevent.py
@@ -34,7 +34,6 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
 from ..views.treemodels import EventModel
 from .baseselector import BaseSelector
-from ..display import display_help
 from gramps.gen.const import URL_MANUAL_SECT1
 
 #-------------------------------------------------------------------------
@@ -42,8 +41,6 @@ from gramps.gen.const import URL_MANUAL_SECT1
 # Constants
 #
 #-------------------------------------------------------------------------
-WIKI_HELP_PAGE = URL_MANUAL_SECT1
-WIKI_HELP_SEC = _('manual|Select_Event_selector')
 
 #-------------------------------------------------------------------------
 #
@@ -77,3 +74,6 @@ class SelectEvent(BaseSelector):
 
     def get_from_handle_func(self):
         return self.db.get_event_from_handle
+
+    WIKI_HELP_PAGE = URL_MANUAL_SECT1
+    WIKI_HELP_SEC = _('manual|Select_Event_selector')

--- a/gramps/gui/selectors/selectfamily.py
+++ b/gramps/gui/selectors/selectfamily.py
@@ -34,7 +34,6 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
 from ..views.treemodels import FamilyModel
 from .baseselector import BaseSelector
-from ..display import display_help
 from gramps.gen.const import URL_MANUAL_PAGE
 
 #-------------------------------------------------------------------------
@@ -42,8 +41,6 @@ from gramps.gen.const import URL_MANUAL_PAGE
 # Constants
 #
 #-------------------------------------------------------------------------
-WIKI_HELP_PAGE = '%s_-_Categories' % URL_MANUAL_PAGE
-WIKI_HELP_SEC = _('manual|Select_Family_selector')
 
 #-------------------------------------------------------------------------
 #
@@ -74,3 +71,6 @@ class SelectFamily(BaseSelector):
 
     def get_from_handle_func(self):
         return self.db.get_family_from_handle
+
+    WIKI_HELP_PAGE = '%s_-_Categories' % URL_MANUAL_PAGE
+    WIKI_HELP_SEC = _('manual|Select_Family_selector')

--- a/gramps/gui/selectors/selectnote.py
+++ b/gramps/gui/selectors/selectnote.py
@@ -37,7 +37,6 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
 from ..views.treemodels import NoteModel
 from .baseselector import BaseSelector
-from ..display import display_help
 from gramps.gen.const import URL_MANUAL_SECT1
 
 #-------------------------------------------------------------------------
@@ -45,8 +44,6 @@ from gramps.gen.const import URL_MANUAL_SECT1
 # Constants
 #
 #-------------------------------------------------------------------------
-WIKI_HELP_PAGE = URL_MANUAL_SECT1
-WIKI_HELP_SEC = _('manual|Select_Note_selector')
 
 #-------------------------------------------------------------------------
 #
@@ -80,3 +77,6 @@ class SelectNote(BaseSelector):
 
     def get_from_handle_func(self):
         return self.db.get_note_from_handle
+
+    WIKI_HELP_PAGE = URL_MANUAL_SECT1
+    WIKI_HELP_SEC = _('manual|Select_Note_selector')

--- a/gramps/gui/selectors/selectobject.py
+++ b/gramps/gui/selectors/selectobject.py
@@ -48,7 +48,6 @@ from gramps.gen.utils.file import media_path_full
 from gramps.gen.utils.thumbnails import get_thumbnail_image
 from ..views.treemodels import MediaModel
 from .baseselector import BaseSelector
-from ..display import display_help
 from gramps.gen.const import URL_MANUAL_SECT1
 
 #-------------------------------------------------------------------------
@@ -56,8 +55,6 @@ from gramps.gen.const import URL_MANUAL_SECT1
 # Constants
 #
 #-------------------------------------------------------------------------
-WIKI_HELP_PAGE = URL_MANUAL_SECT1
-WIKI_HELP_SEC = _('manual|Select_Media_Object_selector')
 
 #-------------------------------------------------------------------------
 #
@@ -106,3 +103,6 @@ class SelectObject(BaseSelector):
         pix = get_thumbnail_image(media_path_full(self.db, obj.get_path()))
         self.preview.set_from_pixbuf(pix)
         gc.collect()
+
+    WIKI_HELP_PAGE = URL_MANUAL_SECT1
+    WIKI_HELP_SEC = _('manual|Select_Media_Object_selector')

--- a/gramps/gui/selectors/selectperson.py
+++ b/gramps/gui/selectors/selectperson.py
@@ -36,7 +36,6 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
 from ..views.treemodels import PeopleBaseModel, PersonTreeModel
 from .baseselector import BaseSelector
-from ..display import display_help
 from gramps.gen.const import URL_MANUAL_SECT1
 
 #-------------------------------------------------------------------------
@@ -45,17 +44,6 @@ from gramps.gen.const import URL_MANUAL_SECT1
 #
 #-------------------------------------------------------------------------
 
-# This dialog changes depending on the string pass for the title.
-# https://gramps-project.org/wiki/index.php?title=Gramps_4.2_Wiki_Manual_-_Entering_and_editing_data:_detailed_-_part_1#Select_Child_selector
-# https://gramps-project.org/wiki/index.php?title=Gramps_4.2_Wiki_Manual_-_Entering_and_editing_data:_detailed_-_part_1#Select_Father_selector
-# https://gramps-project.org/wiki/index.php?title=Gramps_4.2_Wiki_Manual_-_Entering_and_editing_data:_detailed_-_part_1#Select_Mother_selector
-
-WIKI_HELP_PAGE = URL_MANUAL_SECT1
-WIKI_HELP_SEC = _('manual|Select_Child_selector')
-WIKI_HELP_PAGE2 = URL_MANUAL_SECT1
-WIKI_HELP_SEC2 = _('manual|Select_Father_selector')
-WIKI_HELP_PAGE3 = URL_MANUAL_SECT1
-WIKI_HELP_SEC3 = _('manual|Select_Mother_selector')
 
 #-------------------------------------------------------------------------
 #
@@ -71,6 +59,15 @@ class SelectPerson(BaseSelector):
         # instead of the default defined for get_window_title()
         if title is not None:
             self.title = title
+        self.WIKI_HELP_PAGE = URL_MANUAL_SECT1
+        if title == _("Select Father"):
+            self.WIKI_HELP_SEC = _('manual|Select_Father_selector')
+        elif title == _("Select Mother"):
+            self.WIKI_HELP_SEC = _('manual|Select_Mother_selector')
+        elif title == _("Select Child"):
+            self.WIKI_HELP_SEC = _('manual|Select_Child_selector')
+        else:
+            self.WIKI_HELP_SEC = _('manual|Person_Reference_Editor')
 
         BaseSelector.__init__(self, dbstate, uistate, track, filter,
                               skip, show_search_bar, default)

--- a/gramps/gui/selectors/selectplace.py
+++ b/gramps/gui/selectors/selectplace.py
@@ -35,7 +35,6 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
 from ..views.treemodels.placemodel import PlaceTreeModel
 from .baseselector import BaseSelector
-from ..display import display_help
 from gramps.gen.const import URL_MANUAL_SECT2
 
 #-------------------------------------------------------------------------
@@ -43,8 +42,6 @@ from gramps.gen.const import URL_MANUAL_SECT2
 # Constants
 #
 #-------------------------------------------------------------------------
-WIKI_HELP_PAGE = URL_MANUAL_SECT2
-WIKI_HELP_SEC = _('manual|Select_Place_selector')
 
 #-------------------------------------------------------------------------
 #
@@ -76,3 +73,6 @@ class SelectPlace(BaseSelector):
 
     def get_from_handle_func(self):
         return self.db.get_place_from_handle
+
+    WIKI_HELP_PAGE = URL_MANUAL_SECT2
+    WIKI_HELP_SEC = _('manual|Select_Place_selector')

--- a/gramps/gui/selectors/selectrepository.py
+++ b/gramps/gui/selectors/selectrepository.py
@@ -34,7 +34,6 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
 from ..views.treemodels import RepositoryModel
 from .baseselector import BaseSelector
-from ..display import display_help
 from gramps.gen.const import URL_MANUAL_SECT2
 
 #-------------------------------------------------------------------------
@@ -42,8 +41,6 @@ from gramps.gen.const import URL_MANUAL_SECT2
 # Constants
 #
 #-------------------------------------------------------------------------
-WIKI_HELP_PAGE = URL_MANUAL_SECT2
-WIKI_HELP_SEC = _('manual|Repositories')
 
 #-------------------------------------------------------------------------
 #
@@ -73,3 +70,6 @@ class SelectRepository(BaseSelector):
 
     def get_from_handle_func(self):
         return self.db.get_repository_from_handle
+
+    WIKI_HELP_PAGE = URL_MANUAL_SECT2
+    WIKI_HELP_SEC = _('manual|Repositories')

--- a/gramps/gui/selectors/selectsource.py
+++ b/gramps/gui/selectors/selectsource.py
@@ -34,16 +34,13 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
 from ..views.treemodels import SourceModel
 from .baseselector import BaseSelector
-from ..display import display_help
-from gramps.gen.const import URL_MANUAL_PAGE
+from gramps.gen.const import URL_MANUAL_SECT2
 
 #-------------------------------------------------------------------------
 #
 # Constants
 #
 #-------------------------------------------------------------------------
-# WIKI_HELP_PAGE = '%s_-_xxx' % URL_MANUAL_PAGE # FIXME
-# WIKI_HELP_SEC = _('manual|xxxx') # FIXME
 
 #-------------------------------------------------------------------------
 #
@@ -74,3 +71,6 @@ class SelectSource(BaseSelector):
 
     def get_from_handle_func(self):
         return self.db.get_source_from_handle
+
+    WIKI_HELP_PAGE = URL_MANUAL_SECT2
+    WIKI_HELP_SEC = _('manual|Select_Source_selector')

--- a/gramps/plugins/tool/testcasegenerator.py
+++ b/gramps/plugins/tool/testcasegenerator.py
@@ -329,7 +329,13 @@ class TestcaseGenerator(tool.BatchTool):
         self.top.add_button(_('_Help'), Gtk.ResponseType.HELP)
         self.top.show_all()
 
-        response = self.top.run()
+        while True:
+            response = self.top.run()
+            if response == Gtk.ResponseType.HELP:
+                display_help(webpage=WIKI_HELP_PAGE,
+                             section=WIKI_HELP_SEC)
+            else:
+                break
         self.options_dict['lowlevel'] = int(
             self.check_lowlevel.get_active())
         self.options_dict['bugs'] = int(
@@ -348,14 +354,10 @@ class TestcaseGenerator(tool.BatchTool):
             self.entry_count.get_text())
         self.top.destroy()
 
-        if response == Gtk.ResponseType.HELP:
-            display_help(webpage=WIKI_HELP_PAGE,
-                         section=WIKI_HELP_SEC)
-        else:
-            if response == Gtk.ResponseType.OK:
-                self.run_tool(cli=False)
-                # Save options
-                self.options.handler.save_options()
+        if response == Gtk.ResponseType.OK:
+            self.run_tool(cli=False)
+            # Save options
+            self.options.handler.save_options()
 
     def on_dummy_data_clicked(self, obj):
         self.label.set_sensitive(obj.get_active())


### PR DESCRIPTION
Four commits deal with fixing the 'Help' button closes dialog as described in [Gramps issue#10589](https://gramps-project.org/bugs/view.php?id=10589)

In each case the dialog response was terminating the dialog unnecessarily.  For several of the cases, I could just eliminate the response via the glade file (although I had to define the 'Help' button as secondary to keep it to the left side of the dialog box).

For the other cases, (with no glade file), I re-ran the dialog when the Gtk ResponseCode was 'Help'.

While testing these, I noticed that the Selectors help buttons did not actually do anything, no web site popup.  So the remaining commit corrects that situation.
