### PR TITLE
Fix typo in CitationListModel for sort change

### DIFF
--- a/gramps/gui/views/treemodels/citationlistmodel.py
+++ b/gramps/gui/views/treemodels/citationlistmodel.py
@@ -91,7 +91,7 @@ class CitationListModel(CitationBaseModel, FlatBaseModel):
             self.citation_src_abbr,
             self.citation_src_pinfo,
             self.citation_src_private,
-            self.citation_src_sort_chan,
+            self.citation_src_sort_change,
             self.citation_tag_color
             ]
         FlatBaseModel.__init__(self, db, uistate, scol, order, search=search,


### PR DESCRIPTION
Oops; this is what happens when you do 'minor textual changes' after the testing and then don't test them again...