### PR TITLE
Allow addon Reports to specify a help button URL for options dialog

### DIFF
--- a/gramps/gui/plug/report/_reportdialog.py
+++ b/gramps/gui/plug/report/_reportdialog.py
@@ -581,7 +581,10 @@ class ReportDialog(ManagedWindow):
         pass
 
     def on_help_clicked(self, *obj):
-        from ...display import display_help
+        from ...display import display_help, display_url
+        if hasattr(self.options, 'help_url'):
+            display_url(self.options.help_url)
+            return
         display_help(URL_REPORT_PAGE, self.report_name.replace(" ", "_"))
 
     def on_style_edit_clicked(self, *obj):


### PR DESCRIPTION
Fixes [#10910](https://gramps-project.org/bugs/view.php?id=10910)

At the moment, using the 'Help' button on an addon report causes the standard 'Reports' page to pop up.
For example the Help for DescendLines pops up https://gramps-project.org/wiki/index.php?title=Gramps_5.0_Wiki_Manual_-_Reports#Descendants_Lines
Which has nothing to do with the addon.

This PR allows an addon to set the URL for the help button.  In the report's ReportOptions class, the coder would add a line like:
`help_url = "https://www.gramps-project.org/wiki/index.php/DescendantsLines"`
or `help_url = URL_WIKISTRING + "DescendantsLines"`
where help_url is a class attribute.