### PR TITLE
Add first class support for Occupation attribute

### DIFF
--- a/gramps/gen/lib/attrtype.py
+++ b/gramps/gen/lib/attrtype.py
@@ -54,6 +54,7 @@ class AttributeType(GrampsType):
     MOTHER_AGE = 12
     WITNESS = 13
     TIME = 14
+    OCCUPATION = 15
 
     _CUSTOM = CUSTOM
     _DEFAULT = ID
@@ -75,6 +76,7 @@ class AttributeType(GrampsType):
         (MOTHER_AGE, _T_("Mother's Age"), "Mother Age"),
         (WITNESS, _T_("Witness"), "Witness"),
         (TIME, _T_("Time"), "Time"),
+        (OCCUPATION, _T_("Occupation"), "Occupation"),
         ]
 
     _DATAMAP = [(base[0], _(base[1]), base[2]) for base in _BASEMAP]

--- a/gramps/gen/plug/docgen/treedoc.py
+++ b/gramps/gen/plug/docgen/treedoc.py
@@ -449,10 +449,12 @@ class TreeDocBase(BaseDoc, TreeDoc):
                         event = db.get_event_from_handle(eventref.ref)
                         self.write_event(db, level+1, event)
         for attr in person.get_attribute_list():
-            if str(attr.get_type()) == 'Occupation':
+            # Comparison with 'Occupation' for backwards compatibility with Gramps 5.0
+            attr_type = str(attr.get_type())
+            if attr_type in ('Occupation', _('Occupation')):
                 self.write(level+1, 'profession = {%s},\n' %
                            escape(attr.get_value()))
-            if str(attr.get_type()) == 'Comment':
+            if attr_type == 'Comment':
                 self.write(level+1, 'comment = {%s},\n' %
                            escape(attr.get_value()))
         for mediaref in person.get_media_list():


### PR DESCRIPTION
This was already used in PersonDetails and (incorrectly) in TreeDoc.
Add it to the list in AttributeType, provide translations and fix
usage in TreeDoc in case the user is not running with English translation.