### PR TITLE
Help issues for bug 9042

### DIFF
--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -49,7 +49,7 @@ from gi.repository import Pango
 #-------------------------------------------------------------------------
 from gramps.gen.config import config
 from gramps.gen.const import GRAMPS_LOCALE as glocale
-from gramps.gen.const import HOME_DIR, URL_WIKISTRING
+from gramps.gen.const import HOME_DIR, URL_WIKISTRING, URL_MANUAL_PAGE
 from gramps.gen.datehandler import get_date_formats
 from gramps.gen.display.name import displayer as _nd
 from gramps.gen.display.name import NameDisplayError
@@ -64,6 +64,7 @@ from .managedwindow import ManagedWindow
 from .widgets import MarkupLabel, BasicLabel
 from .dialog import ErrorDialog, QuestionDialog2, OkDialog
 from .editors.editplaceformat import EditPlaceFormat
+from .display import display_help
 from .glade import Glade
 from gramps.gen.plug.utils import available_updates
 from .plug import PluginWindows
@@ -90,6 +91,9 @@ COL_NUM  = 0
 COL_NAME = 1
 COL_FMT  = 2
 COL_EXPL = 3
+
+WIKI_HELP_PAGE = URL_MANUAL_PAGE + "_-_Settings"
+WIKI_HELP_SEC = _('Preferences')
 
 #-------------------------------------------------------------------------
 #
@@ -204,6 +208,8 @@ class ConfigureDialog(ManagedWindow):
             self.panel.append_page(widget, MarkupLabel(labeltitle))
 
     def done(self, obj, value):
+        if value == Gtk.ResponseType.HELP:
+            return
         if self.__on_close:
             self.__on_close()
         self.close()
@@ -523,6 +529,9 @@ class GrampsPreferences(ConfigureDialog):
         ConfigureDialog.__init__(self, uistate, dbstate, page_funcs,
                                  GrampsPreferences, config,
                                  on_close=update_constants)
+        help_btn = self.window.add_button(_('_Help'), Gtk.ResponseType.HELP)
+        help_btn.connect(
+            'clicked', lambda x: display_help(WIKI_HELP_PAGE, WIKI_HELP_SEC))
         self.setup_configs('interface.grampspreferences', 700, 450)
 
     def add_researcher_panel(self, configdialog):

--- a/gramps/gui/display.py
+++ b/gramps/gui/display.py
@@ -26,6 +26,7 @@
 import os
 import webbrowser
 import sys
+from urllib.parse import quote
 #------------------------------------------------------------------------
 #
 # Gramps modules
@@ -65,9 +66,9 @@ def display_help(webpage='', section=''):
     if not webpage:
         link = URL_WIKISTRING + URL_MANUAL_PAGE + EXTENSION
     else:
-        link = URL_WIKISTRING + webpage + EXTENSION
+        link = URL_WIKISTRING + quote(webpage) + EXTENSION
         if section:
-            link = link + '#' + section
+            link += '#' + quote(section.replace(' ', '_')).replace('%', '.')
     display_url(link)
 
 def display_url(link, uistate=None):

--- a/gramps/gui/glade/book.glade
+++ b/gramps/gui/glade/book.glade
@@ -493,6 +493,23 @@
                 <property name="position">1</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkButton" id="button14">
+                <property name="label" translatable="yes">_Help</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_book_help_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+                <property name="secondary">True</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/gramps/gui/glade/styleeditor.glade
+++ b/gramps/gui/glade/styleeditor.glade
@@ -116,6 +116,22 @@
                 <property name="position">1</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkButton" id="help_btn">
+                <property name="label">gtk-help</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+                <signal name="clicked" handler="on_help_btn_style_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+                <property name="secondary">True</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -1749,6 +1765,22 @@
                 <property name="expand">False</property>
                 <property name="fill">False</property>
                 <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="help_btn_styles">
+                <property name="label">gtk-help</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+                <signal name="clicked" handler="on_help_btn_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+                <property name="secondary">True</property>
               </packing>
             </child>
           </object>

--- a/gramps/gui/plug/report/_bookdialog.py
+++ b/gramps/gui/plug/report/_bookdialog.py
@@ -978,6 +978,9 @@ class BookDialog(DocReportDialog):
         whether the document requires table support, etc."""
         self.format_menu = _BookFormatComboBox(active)
 
+    def on_help_clicked(self, *obj):
+        display_help(WIKI_HELP_PAGE, GENERATE_WIKI_HELP_SEC)
+
     def make_document(self):
         """Create a document of the type requested by the user."""
         user = User(uistate=self.uistate)

--- a/gramps/gui/plug/report/_bookdialog.py
+++ b/gramps/gui/plug/report/_bookdialog.py
@@ -59,6 +59,8 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 from ...listmodel import ListModel
 from gramps.gen.errors import FilterError, ReportError
+from gramps.gen.const import URL_MANUAL_PAGE
+from ...display import display_help
 from ...pluginmanager import GuiPluginManager
 from ...dialog import WarningDialog, ErrorDialog, QuestionDialog2
 from gramps.gen.plug.menu import PersonOption, FamilyOption
@@ -85,6 +87,10 @@ _UNSUPPORTED = _("Unsupported")
 
 _RETURN = Gdk.keyval_from_name("Return")
 _KP_ENTER = Gdk.keyval_from_name("KP_Enter")
+WIKI_HELP_PAGE = URL_MANUAL_PAGE + "_-_Reports_-_part_3"
+WIKI_HELP_SEC = _('Books')
+GENERATE_WIKI_HELP_SEC = _('Generate_Book_dialog')
+
 #------------------------------------------------------------------------
 #
 # Private Functions
@@ -173,6 +179,7 @@ class BookListDisplay:
             "on_booklist_ok_clicked"     : self.on_booklist_ok_clicked,
             "on_booklist_delete_clicked" : self.on_booklist_delete_clicked,
             "on_book_ok_clicked"         : self.do_nothing,
+            "on_book_help_clicked"       : self.do_nothing,
             "destroy_passed_object"      : self.do_nothing,
             "on_setup_clicked"           : self.do_nothing,
             "on_down_clicked"            : self.do_nothing,
@@ -342,6 +349,8 @@ class BookSelector(ManagedWindow):
             "on_save_clicked"       : self.on_save_clicked,
             "on_open_clicked"       : self.on_open_clicked,
             "on_edit_clicked"       : self.on_edit_clicked,
+            "on_book_help_clicked"  : lambda x: display_help(WIKI_HELP_PAGE,
+                                                             WIKI_HELP_SEC),
             "on_book_ok_clicked"    : self.on_book_ok_clicked,
             "destroy_passed_object" : self.on_close_clicked,
 

--- a/gramps/gui/plug/report/_styleeditor.py
+++ b/gramps/gui/plug/report/_styleeditor.py
@@ -58,6 +58,10 @@ from ...listmodel import ListModel
 from ...managedwindow import ManagedWindow
 from ...glade import Glade
 from ...dialog import ErrorDialog
+from ...display import display_help
+from gramps.gen.const import URL_MANUAL_PAGE
+
+WIKI_HELP_PAGE = URL_MANUAL_PAGE + "_-_Settings"
 
 #------------------------------------------------------------------------
 #
@@ -100,8 +104,11 @@ class StyleListDisplay(ManagedWindow):
             "on_button_press" : self.on_button_press,
             "on_edit_clicked" : self.on_edit_clicked,
             "on_cancel_clicked" : self.__cancel,
+            "on_help_btn_clicked" : lambda x: display_help(
+                WIKI_HELP_PAGE, _('manual|Document_Styles_dialog')),
             "on_cancel_style_clicked" : dummy_callback,
             "on_save_style_clicked" : dummy_callback,
+            "on_help_btn_style_clicked" : dummy_callback,
             })
 
         self.list = ListModel(self.top.get_object("list"),
@@ -230,12 +237,15 @@ class StyleEditor(ManagedWindow):
         self.top.connect_signals({
             "on_save_style_clicked" : self.on_save_style_clicked,
             "on_cancel_style_clicked" : self.__cancel,
+            "on_help_btn_style_clicked" : lambda x: display_help(
+                WIKI_HELP_PAGE, _('manual|Style_editor_dialog')),
             "on_cancel_clicked" : dummy_callback,
             "on_ok_clicked" : dummy_callback,
             "on_add_clicked" : dummy_callback,
             "on_delete_clicked" : dummy_callback,
             "on_button_press" : dummy_callback,
             "on_edit_clicked" : dummy_callback,
+            "on_help_btn_clicked" : dummy_callback,
             })
 
         self.pname = self.top.get_object('pname')

--- a/gramps/gui/selectors/selectperson.py
+++ b/gramps/gui/selectors/selectperson.py
@@ -67,7 +67,7 @@ class SelectPerson(BaseSelector):
         elif title == _("Select Child"):
             self.WIKI_HELP_SEC = _('manual|Select_Child_selector')
         else:
-            self.WIKI_HELP_SEC = _('manual|Person_Reference_Editor')
+            self.WIKI_HELP_SEC = _('manual|Select_Person_selector')
 
         BaseSelector.__init__(self, dbstate, uistate, track, filter,
                               skip, show_search_bar, default)

--- a/gramps/gui/selectors/selectrepository.py
+++ b/gramps/gui/selectors/selectrepository.py
@@ -72,4 +72,4 @@ class SelectRepository(BaseSelector):
         return self.db.get_repository_from_handle
 
     WIKI_HELP_PAGE = URL_MANUAL_SECT2
-    WIKI_HELP_SEC = _('manual|Repositories')
+    WIKI_HELP_SEC = _('manual|Select_Repository_selector')

--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -365,6 +365,8 @@ class GuiGramplet:
         self.gstate = kwargs.get("state", "maximized")
         self.data = kwargs.get("data", [])
         self.help_url = kwargs.get("help_url", WIKI_HELP_PAGE)
+        if self.help_url == 'None':
+            self.help_url = None  # to fix up the config file vers of None
         ##########
         self.use_markup = False
         self.pui = None # user code

--- a/gramps/gui/widgets/reorderfam.py
+++ b/gramps/gui/widgets/reorderfam.py
@@ -46,10 +46,22 @@ _LOG = logging.getLogger("gui.widgets.reorderfam")
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
 from gramps.gen.db import DbTxn
+from gramps.gen.const import URL_MANUAL_PAGE
 from ..listmodel import ListModel
+from ..display import display_help
 from ..managedwindow import ManagedWindow
 from ..glade import Glade
 from gramps.gen.display.name import displayer as name_displayer
+
+#-------------------------------------------------------------------------
+#
+# Constants
+#
+#-------------------------------------------------------------------------
+
+WIKI_HELP_PAGE = URL_MANUAL_PAGE + "_-_Categories"
+WIKI_HELP_SEC = _('manual|Reorder_Relationships_dialog')
+
 
 #-------------------------------------------------------------------------
 #
@@ -93,7 +105,8 @@ class Reorder(ManagedWindow):
 
         xml.get_object('ok').connect('clicked', self.ok_clicked)
         xml.get_object('cancel').connect('clicked', self.cancel_clicked)
-
+        xml.get_object('help').connect(
+            'clicked', lambda x: display_help(WIKI_HELP_PAGE, WIKI_HELP_SEC))
         fup = xml.get_object('fup')
         fup.connect('clicked', self.fup_clicked)
         fup.set_sensitive(fenable)

--- a/gramps/plugins/tool/mediamanager.py
+++ b/gramps/plugins/tool/mediamanager.py
@@ -65,7 +65,7 @@ from gramps.gui.managedwindow import ManagedWindow
 #
 #-------------------------------------------------------------------------
 WIKI_HELP_PAGE = '%s_-_Tools' % URL_MANUAL_PAGE
-WIKI_HELP_SEC = _('manual|Media_Manager...')
+WIKI_HELP_SEC = _('manual|Media_Manager')
 
 #-------------------------------------------------------------------------
 #
@@ -87,6 +87,10 @@ class MediaMan(ManagedWindow, tool.Tool):
         self.assistant = Gtk.Assistant()
         self.set_window(self.assistant, None, _('Media Manager'))
         self.setup_configs('interface.mediaman', 780, 600)
+
+        help_btn = Gtk.Button.new_with_label(_('Help'))
+        help_btn.connect('clicked', self.on_help_clicked)
+        self.assistant.add_action_widget(help_btn)
 
         self.assistant.connect('close', self.do_close)
         self.assistant.connect('cancel', self.do_close)

--- a/gramps/plugins/tool/relcalc.glade
+++ b/gramps/plugins/tool/relcalc.glade
@@ -3,7 +3,6 @@
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkDialog" id="relcalc">
-    <property name="visible">False</property>
     <property name="can_focus">False</property>
     <property name="type_hint">dialog</property>
     <signal name="delete-event" handler="on_delete_event" swapped="no"/>
@@ -32,6 +31,21 @@
                 <property name="expand">False</property>
                 <property name="fill">False</property>
                 <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="help_btn">
+                <property name="label">gtk-help</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+                <property name="secondary">True</property>
               </packing>
             </child>
           </object>

--- a/gramps/plugins/tool/relcalc.py
+++ b/gramps/plugins/tool/relcalc.py
@@ -49,6 +49,8 @@ from gramps.gui.managedwindow import ManagedWindow
 from gramps.gui.views.treemodels import PeopleBaseModel, PersonTreeModel
 from gramps.plugins.lib.libpersonview import BasePersonView
 from gramps.gen.relationship import get_relationship_calculator
+from gramps.gen.const import URL_MANUAL_PAGE
+from gramps.gui.display import display_help
 
 from gramps.gui.dialog import ErrorDialog
 from gramps.gui.plug import tool
@@ -61,6 +63,8 @@ from gramps.gui.glade import Glade
 #-------------------------------------------------------------------------
 
 column_names = [column[0] for column in BasePersonView.COLUMNS]
+WIKI_HELP_PAGE = URL_MANUAL_PAGE + "_-_Tools"
+WIKI_HELP_SEC = _('Relationship Calculator')
 
 #-------------------------------------------------------------------------
 #
@@ -144,6 +148,9 @@ class RelCalc(tool.Tool, ManagedWindow):
         self.changedkey = self.sel.connect('changed',self.on_apply_clicked)
         self.closebtn = self.glade.get_object("button5")
         self.closebtn.connect('clicked', self.close)
+        help_btn = self.glade.get_object("help_btn")
+        help_btn.connect('clicked', lambda x: display_help(WIKI_HELP_PAGE,
+                                                           WIKI_HELP_SEC))
 
         if not self.person:
             self.window.hide()

--- a/po/ar.po
+++ b/po/ar.po
@@ -13638,7 +13638,7 @@ msgstr "محرر الموقع"
 #: ../gramps/gui/editors/editmedia.py:68
 #, fuzzy
 msgid "manual|New_Media_dialog"
-msgstr "manual|Media_Manager..."
+msgstr "manual|Media_Manager"
 
 #: ../gramps/gui/editors/editmedia.py:99
 #: ../gramps/gui/editors/editmediaref.py:409
@@ -32221,8 +32221,8 @@ msgid "Looking for possible loop for each person"
 msgstr "بحث عن {number_of} من الأشخاص"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "manual|Media_Manager..."
+msgid "manual|Media_Manager"
+msgstr "manual|Media_Manager"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/bg.po
+++ b/po/bg.po
@@ -33269,8 +33269,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Търсене за %d лице"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr ""
+msgid "manual|Media_Manager"
+msgstr "Управление_на_медиите"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/br.po
+++ b/po/br.po
@@ -32756,8 +32756,8 @@ msgid "Looking for possible loop for each person"
 msgstr "O klask restroù roadennoù"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr ""
+msgid "manual|Media_Manager"
+msgstr "Ardoer_molladoù"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/ca.po
+++ b/po/ca.po
@@ -32910,8 +32910,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Buscant possibles bucles en cada persona"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "Gestor_audiovisuals..."
+msgid "manual|Media_Manager"
+msgstr "Gestor_audiovisuals"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/cs.po
+++ b/po/cs.po
@@ -32435,8 +32435,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Hledá se možné zacyklení pro každou osobu"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "Správce médií..."
+msgid "manual|Media_Manager"
+msgstr "Správce médií"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/da.po
+++ b/po/da.po
@@ -32661,8 +32661,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Leder efter mulige løkker for alle personer"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "manual|Media_Manager..."
+msgid "manual|Media_Manager"
+msgstr "Mediehåndtering"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/de.po
+++ b/po/de.po
@@ -32968,8 +32968,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Suche nach möglicher Schleife für jede Person"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "Medienverwalter..."
+msgid "manual|Media_Manager"
+msgstr "Medienverwaltung"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/el.po
+++ b/po/el.po
@@ -33870,7 +33870,7 @@ msgid "Looking for possible loop for each person"
 msgstr "Αναζήτηση για %d άτομο"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
+msgid "manual|Media_Manager"
 msgstr "Διαχειριστής Μέσων"
 
 #: ../gramps/plugins/tool/mediamanager.py:88

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -30640,8 +30640,8 @@ msgid "Looking for possible loop for each person"
 msgstr ""
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr ""
+msgid "manual|Media_Manager"
+msgstr "Media Manager"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/eo.po
+++ b/po/eo.po
@@ -32172,7 +32172,7 @@ msgid "Descendant"
 msgstr "Praido"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
+msgid "manual|Media_Manager"
 msgstr "Aŭdvidaĵa-administrilo..."
 
 #: ../gramps/plugins/tool/mediamanager.py:88

--- a/po/es.po
+++ b/po/es.po
@@ -33400,8 +33400,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Buscando %d persona"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "Administrador_de_objetos_audiovisuales..."
+msgid "manual|Media_Manager"
+msgstr "Administrador_de_objetos_audiovisuales"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/fi.po
+++ b/po/fi.po
@@ -31529,8 +31529,8 @@ msgstr "Haetaan mahdollinen silmukka jokaiselle henkilölle"
 
 # WIKI_HELP_SEC tools
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "Median_hallinta..."
+msgid "manual|Media_Manager"
+msgstr "Median_hallinta"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/fr.po
+++ b/po/fr.po
@@ -34856,7 +34856,7 @@ msgstr "Recherche d'une éventuelle boucle pour chaque individu"
 # manuel wiki
 # points de suspension et url ?
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
+msgid "manual|Media_Manager"
 msgstr "Gestionnaire de media"
 
 #: ../gramps/plugins/tool/mediamanager.py:88

--- a/po/ga.po
+++ b/po/ga.po
@@ -30964,7 +30964,7 @@ msgid "Looking for possible loop for each person"
 msgstr ""
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
+msgid "manual|Media_Manager"
 msgstr ""
 
 #: ../gramps/plugins/tool/mediamanager.py:88

--- a/po/gramps.pot
+++ b/po/gramps.pot
@@ -30590,7 +30590,7 @@ msgid "Looking for possible loop for each person"
 msgstr ""
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
+msgid "manual|Media_Manager"
 msgstr ""
 
 #: ../gramps/plugins/tool/mediamanager.py:88

--- a/po/he.po
+++ b/po/he.po
@@ -31696,8 +31696,8 @@ msgid "Looking for possible loop for each person"
 msgstr "מחפש אדם %d"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr ""
+msgid "manual|Media_Manager"
+msgstr "מנהל מדיה"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/hr.po
+++ b/po/hr.po
@@ -32583,8 +32583,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Traženje moguće petlje za svaku osobu"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "Upravljač_medija ..."
+msgid "manual|Media_Manager"
+msgstr "Upravljač_medija"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/hu.po
+++ b/po/hu.po
@@ -32696,8 +32696,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Lehetséges hurok keresése minden személynél"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "_Médiakezelő..."
+msgid "manual|Media_Manager"
+msgstr "_Médiakezelő"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/is.po
+++ b/po/is.po
@@ -31869,8 +31869,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Leita að mögulegum hringbeiningum fyrir hvern einstakling"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "Gagnastjórnun..."
+msgid "manual|Media_Manager"
+msgstr "Gagnastjórnun"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/it.po
+++ b/po/it.po
@@ -32759,8 +32759,8 @@ msgstr "Ricerca di {number_of} persona"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
 #, fuzzy
-msgid "manual|Media_Manager..."
-msgstr "Gestore_oggetti_multimediali..."
+msgid "manual|Media_Manager"
+msgstr "Gestore_oggetti_multimediali"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/ja.po
+++ b/po/ja.po
@@ -32127,8 +32127,8 @@ msgid "Looking for possible loop for each person"
 msgstr "月 (0 で全て)"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "メディアマネージャ(_M)..."
+msgid "manual|Media_Manager"
+msgstr "メディアマネージャ(_M)"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/lt.po
+++ b/po/lt.po
@@ -32719,8 +32719,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Ieškoma kiekvieno asmens galimų ciklų"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "Garso/vaizdo tvarkymo įrankis..."
+msgid "manual|Media_Manager"
+msgstr "Garso/vaizdo tvarkymo įrankis"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/mk.po
+++ b/po/mk.po
@@ -33884,8 +33884,8 @@ msgstr "Пребарување на настани со проблеми"
 # медиски?!?!?
 #: ../gramps/plugins/tool/mediamanager.py:68
 #, fuzzy
-msgid "manual|Media_Manager..."
-msgstr "Медиумски управувач"
+msgid "manual|Media_Manager"
+msgstr "Управувач на медиуми"
 
 # медиски?!?!?
 #: ../gramps/plugins/tool/mediamanager.py:88

--- a/po/nb.po
+++ b/po/nb.po
@@ -26477,7 +26477,7 @@ msgid "Looking for possible loop for each person"
 msgstr ""
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
+msgid "manual|Media_Manager"
 msgstr "Mediabehandler..."
 
 #: ../gramps/plugins/tool/mediamanager.py:88 ../gramps/plugins/tool/mediamanager.py:114 ../gramps/plugins/tool/tools.gpr.py:176

--- a/po/nl.po
+++ b/po/nl.po
@@ -33348,7 +33348,7 @@ msgid "Looking for possible loop for each person"
 msgstr "Voor elke persoon naar mogelijke lussen zoeken"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
+msgid "manual|Media_Manager"
 msgstr "Media_manager..."
 
 #: ../gramps/plugins/tool/mediamanager.py:88

--- a/po/nn.po
+++ b/po/nn.po
@@ -33009,8 +33009,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Søkjer etter {number_of} person"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "Mediahandsamar..."
+msgid "manual|Media_Manager"
+msgstr "Mediahandsamar"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/pl.po
+++ b/po/pl.po
@@ -33158,8 +33158,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Wyszukiwanie dla {number_of} osoby"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "Zarządzanie mediami..."
+msgid "manual|Media_Manager"
+msgstr "Zarządzanie mediami"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -32780,7 +32780,7 @@ msgid "Looking for possible loop for each person"
 msgstr "Procurando por possíveis referências circulares para cada pessoa"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
+msgid "manual|Media_Manager"
 msgstr ""
 
 #: ../gramps/plugins/tool/mediamanager.py:88

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -32737,8 +32737,8 @@ msgid "Looking for possible loop for each person"
 msgstr "A procurar possível ciclo para cada indivíduo"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "Gestor_de_multimédia..."
+msgid "manual|Media_Manager"
+msgstr "Gestor_de_multimédia"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/ro.po
+++ b/po/ro.po
@@ -33511,7 +33511,7 @@ msgid "Looking for possible loop for each person"
 msgstr "Caută posibile persoane duplicate"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
+msgid "manual|Media_Manager"
 msgstr ""
 
 #: ../gramps/plugins/tool/mediamanager.py:88

--- a/po/ru.po
+++ b/po/ru.po
@@ -32843,8 +32843,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Поиск возможного цикла для каждого лица"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "Управление_документами..."
+msgid "manual|Media_Manager"
+msgstr "Управление_документами"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/sk.po
+++ b/po/sk.po
@@ -13643,7 +13643,7 @@ msgstr "Editor lokality"
 #: ../gramps/gui/editors/editmedia.py:68
 #, fuzzy
 msgid "manual|New_Media_dialog"
-msgstr "manual|Media_Manager..."
+msgstr "manual|Media_Manager"
 
 #: ../gramps/gui/editors/editmedia.py:99
 #: ../gramps/gui/editors/editmediaref.py:409
@@ -32606,8 +32606,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Hľadanie {number_of} osoby"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "manual|Media_Manager..."
+msgid "manual|Media_Manager"
+msgstr "manual|Media_Manager"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/sl.po
+++ b/po/sl.po
@@ -32648,8 +32648,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Iskanje morebitne zanke pri vsaki osebi"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "Upravljalnik_zunanjih_predmetov..."
+msgid "manual|Media_Manager"
+msgstr "Upravljalnik_zunanjih_predmetov"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/sq.po
+++ b/po/sq.po
@@ -33606,7 +33606,7 @@ msgstr "Kërkim i 1 personi"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
 #, fuzzy
-msgid "manual|Media_Manager..."
+msgid "manual|Media_Manager"
 msgstr "Media Menaxher"
 
 #: ../gramps/plugins/tool/mediamanager.py:88

--- a/po/sr.po
+++ b/po/sr.po
@@ -32681,8 +32681,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Тражим {number_of} особу"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "Управник_медија..."
+msgid "manual|Media_Manager"
+msgstr "Управник_медија"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/sr_Latn.po
+++ b/po/sr_Latn.po
@@ -30759,7 +30759,7 @@ msgid "Looking for possible loop for each person"
 msgstr ""
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
+msgid "manual|Media_Manager"
 msgstr ""
 
 #: ../gramps/plugins/tool/mediamanager.py:88

--- a/po/sv.po
+++ b/po/sv.po
@@ -32502,8 +32502,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Söker efter möjliga slingor för alla personer"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "Media_hanterare..."
+msgid "manual|Media_Manager"
+msgstr "Media_hanterare"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/ta.po
+++ b/po/ta.po
@@ -32049,7 +32049,7 @@ msgid "Looking for possible loop for each person"
 msgstr ""
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
+msgid "manual|Media_Manager"
 msgstr ""
 
 #: ../gramps/plugins/tool/mediamanager.py:88

--- a/po/tr.po
+++ b/po/tr.po
@@ -30945,8 +30945,8 @@ msgid "Looking for possible loop for each person"
 msgstr ""
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "Ortam_Yöneticisi..."
+msgid "manual|Media_Manager"
+msgstr "Ortam_Yöneticisi"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/uk.po
+++ b/po/uk.po
@@ -32535,7 +32535,7 @@ msgid "Looking for possible loop for each person"
 msgstr "Пошук можливого циклу (замикання) для кожної особи"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
+msgid "manual|Media_Manager"
 msgstr ""
 
 #: ../gramps/plugins/tool/mediamanager.py:88

--- a/po/vi.po
+++ b/po/vi.po
@@ -32410,8 +32410,8 @@ msgid "Looking for possible loop for each person"
 msgstr "Tìm trùng lắp có thể có cho cá nhân"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "Quản_lý_đa_phương_tiện..."
+msgid "manual|Media_Manager"
+msgstr "Quản_lý_đa_phương_tiện"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -32676,8 +32676,8 @@ msgid "Looking for possible loop for each person"
 msgstr "寻找 %d 个成员"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "媒体管理器(_M)..."
+msgid "manual|Media_Manager"
+msgstr "媒体管理器(_M)"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -32677,8 +32677,8 @@ msgid "Looking for possible loop for each person"
 msgstr "尋找 %d 個成員"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "媒體管理器(_M)..."
+msgid "manual|Media_Manager"
+msgstr "媒體管理器(_M)"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -32676,8 +32676,8 @@ msgid "Looking for possible loop for each person"
 msgstr "尋找 %d 個成員"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "媒體管理器(_M)..."
+msgid "manual|Media_Manager"
+msgstr "媒體管理器(_M)"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
 #: ../gramps/plugins/tool/mediamanager.py:114


### PR DESCRIPTION
This PR contains commits for a number of issues listed in https://gramps-project.org/bugs/view.php?id=9042.

- Media Manager: add help button and remove '...' 
- Edit/Preferences: add Help button
- Style Editor, Document Styles dialog: add help buttons
- Fix Select Person dialog Help button URL 
- Fix Select Repository dialog Help button URL 
- Relationship Calculator: Add help button 
- Reorder Relationships dialog; add Help button 
- Generate Book Dialog; Fix Help URL 
- Manage Book dialog; add help button 
- Fix Detached Gramplets Help button URL when 'help_url' not in .gpr (the URL had a #section of 'None')
- Fix help URLs when they contain illegal characters and to match wiki section targetID algorithm (specifically fixed 'What's Next' Gramplet URL, but also fixes up many international section parts).

I did not fix everything in 9042, but only the ones that seemed more critical.  Some appeared to involve the wiki only.  I also noticed that a some of the international wiki pages are going to need help to work properly with the help sections in particular.  The section headers need to match the Gramps translations, and that is not always the case.  For example, the French and German Gramplets pages headers don't match, the wiki editor added 'Gramplet' to the header in many cases.

@sam-m888 I';; leave it to you to update the 9042 bug report appropriately as you test the PR, I'm not quite sure if I understand all of your notations...