### PR TITLE
Fix contents of enclosed_by secondary dbapi column

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -2461,4 +2461,5 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         enclosed_by = ""
         for placeref in place.get_placeref_list():
             enclosed_by = placeref.ref
+            break
         return enclosed_by


### PR DESCRIPTION
The enclosed_by column should contain the first value in the list
instead of the last.

Resolves [#10907](https://gramps-project.org/bugs/view.php?id=10907).