### PR TITLE
Set correct font resolution for Mac when drawing text directly to cairo.

### DIFF
--- a/gramps/gui/widgets/fanchart.py
+++ b/gramps/gui/widgets/fanchart.py
@@ -63,6 +63,7 @@ from gramps.gen.utils.alive import probably_alive
 from gramps.gen.utils.libformatting import FormattingHelper
 from gramps.gen.utils.db import (find_children, find_parents, find_witnessed_people,
                                  get_age, get_timeperiod, preset_name)
+from gramps.gen.constfunc import is_quartz
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.const import (
     PIXELS_PER_GENERATION,
@@ -675,6 +676,8 @@ class FanChartBaseWidget(Gtk.DrawingArea):
 
     def draw_radial_text(self, cr, text, radiusin, radiusout, start_rad, stop_rad, font, flipped):
         layout = self.create_pango_layout(text)
+        if is_quartz():
+            PangoCairo.context_set_resolution(layout.get_context(), 72)
         layout.set_font_description(font)
         layout.set_wrap(Pango.WrapMode.WORD_CHAR)
 
@@ -706,6 +709,8 @@ class FanChartBaseWidget(Gtk.DrawingArea):
         Text not fitting a single line will be char-wrapped away.
         """
         layout = self.create_pango_layout(text)
+        if is_quartz():
+            PangoCairo.context_set_resolution(layout.get_context(), 72)
         layout.set_font_description(font)
         layout.set_wrap(Pango.WrapMode.WORD_CHAR)
 
@@ -776,6 +781,8 @@ class FanChartBaseWidget(Gtk.DrawingArea):
             cr.set_source_rgb(color[0], color[1], color[2])
             cr.fill()
             layout = self.create_pango_layout(text)
+            if is_quartz():
+                PangoCairo.context_set_resolution(layout.get_context(), 72)
             layout.set_font_description(font)
             cr.move_to(startw+gradwidth+4, starth)
             cr.set_source_rgb(0, 0, 0) #black

--- a/gramps/plugins/docgen/cairodoc.py
+++ b/gramps/plugins/docgen/cairodoc.py
@@ -46,6 +46,7 @@ import cairo
 # Gramps modules
 #
 #------------------------------------------------------------------------
+from gramps.gen.constfunc import is_quartz
 import gramps.plugins.lib.libcairodoc as libcairodoc
 from gramps.gen.plug.docgen import INDEX_TYPE_ALP, INDEX_TYPE_TOC
 from gramps.gen.errors import ReportError
@@ -109,6 +110,8 @@ class CairoDocgen(libcairodoc.CairoDoc):
                 pango_context = fontmap.create_context()
                 options = cairo.FontOptions()
                 options.set_hint_metrics(cairo.HINT_METRICS_OFF)
+                if is_quartz():
+                    PangoCairo.context_set_resolution(pango_context, 72)
                 PangoCairo.context_set_font_options(pango_context, options)
                 layout = Pango.Layout(pango_context)
                 PangoCairo.update_context(cr, pango_context)

--- a/gramps/plugins/lib/maps/messagelayer.py
+++ b/gramps/plugins/lib/maps/messagelayer.py
@@ -48,6 +48,7 @@ from gi.repository import Pango, PangoCairo
 # Gramps Modules
 #
 #-------------------------------------------------------------------------
+from gramps.gen.constfunc import is_quartz
 
 #-------------------------------------------------------------------------
 #
@@ -131,6 +132,8 @@ class MessageLayer(GObject.GObject, osmgpsmap.MapLayer):
         ctx.save()
         ctx.move_to(100, 5)
         layout = PangoCairo.create_layout(ctx)
+        if is_quartz():
+            PangoCairo.context_set_resolution(layout.get_context(), 72)
         layout.set_font_description(descr)
         layout.set_indent(Pango.SCALE * 0)
         layout.set_alignment(Pango.Alignment.LEFT)

--- a/gramps/plugins/view/pedigreeview.py
+++ b/gramps/plugins/view/pedigreeview.py
@@ -260,6 +260,8 @@ class PersonBoxWidgetCairo(_PersonWidgetBase):
         alh = self.get_allocated_height()
         if not self.textlayout:
             self.textlayout = PangoCairo.create_layout(context)
+            if is_quartz():
+                PangoCairo.context_set_resolution(self.textlayout.get_context(), 72)
             # The following seems like it Should work, but it doesn't
             # font_desc = self.get_style_context().get_property(
             #     "font", Gtk.StateFlags.NORMAL)


### PR DESCRIPTION
Fixes [#0010924](https://gramps-project.org/bugs/view.php?id=10924)

If accepted will cherry-pick to master.