### PR TITLE
Avoid leading and trailing spaces when copy/paste

### DIFF
--- a/gramps/gui/editors/editplace.py
+++ b/gramps/gui/editors/editplace.py
@@ -182,8 +182,8 @@ class EditPlace(EditPrimary):
     def set_latlongitude(self, value):
         try:
             coma = value.index(',')
-            self.longitude.set_text(value[coma+1:])
-            self.latitude.set_text(value[:coma])
+            self.longitude.set_text(value[coma+1:].strip())
+            self.latitude.set_text(value[:coma].strip())
             self.top.get_object("lat_entry").validate(force=True)
             self.top.get_object("lon_entry").validate(force=True)
             self.obj.set_latitude(self.latitude.get_value())

--- a/gramps/gui/editors/editplaceref.py
+++ b/gramps/gui/editors/editplaceref.py
@@ -175,8 +175,8 @@ class EditPlaceRef(EditReference):
     def set_latlongitude(self, value):
         try:
             coma = value.index(',')
-            self.longitude.set_text(value[coma+1:])
-            self.latitude.set_text(value[:coma])
+            self.longitude.set_text(value[coma+1:].strip())
+            self.latitude.set_text(value[:coma].strip())
             self.top.get_object("lat_entry").validate(force=True)
             self.top.get_object("lon_entry").validate(force=True)
             self.source.set_latitude(self.latitude.get_value())


### PR DESCRIPTION
coordinates from a map provider.

Fixes [#10937](https://gramps-project.org/bugs/view.php?id=10937)