### PR TITLE
extrapage can now point to joomla, drupal, ...

### DIFF
--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -1530,7 +1530,10 @@ class BasePage: # pylint: disable=C1001
                     while cols <= num_cols and index < number_items:
                         url_fname, nav_text = menu_items[index]
 
-                        hyper = self.get_nav_menu_hyperlink(url_fname, nav_text)
+                        if url_fname.startswith('http'):
+                            hyper = Html("a", nav_text, href=url_fname, title=nav_text, inline=True)
+                        else:
+                            hyper = self.get_nav_menu_hyperlink(url_fname, nav_text)
 
                         # Define 'currentsection' to correctly set navlink item
                         # CSS id 'CurrentSection' for Navigation styling.


### PR DESCRIPTION
If the url starts with "http", we don't calculate the new hyperlink.

So now you can add an extra page like this in the Extra pages of the narrative web options:

Extra page name: drupal
Your extra page path: http://my.drupal.site.web/

Fixes [#10945](https://gramps-project.org/bugs/view.php?id=10945)