### PR TITLE
Fix Media editor when using double click the preview of added media

### DIFF
--- a/gramps/gui/editors/editmedia.py
+++ b/gramps/gui/editors/editmedia.py
@@ -245,12 +245,13 @@ class EditMedia(EditPrimary):
             self.view_media(obj)
 
     def view_media(self, obj):
-        ref_obj = self.dbstate.db.get_media_from_handle(self.obj.handle)
+        if self.obj.handle:
+            ref_obj = self.dbstate.db.get_media_from_handle(self.obj.handle)
 
-        if ref_obj:
-            media_path = media_path_full(self.dbstate.db,
-                                               ref_obj.get_path())
-            open_file_with_default_application(media_path, self.uistate)
+            if ref_obj:
+                media_path = media_path_full(self.dbstate.db,
+                                             ref_obj.get_path())
+                open_file_with_default_application(media_path, self.uistate)
 
     def select_file(self, val):
         self.determine_mime()


### PR DESCRIPTION
Fixes [#10923](https://gramps-project.org/bugs/view.php?id=10923)

Got a Nonetype error because the media object wasn't in database yet.