### PR TITLE
Add tooltip for Gramplet Bar

### DIFF
--- a/gramps/gui/widgets/grampletbar.py
+++ b/gramps/gui/widgets/grampletbar.py
@@ -115,6 +115,7 @@ class GrampletBar(Gtk.Notebook):
         book_button.add(box)
         book_button.set_relief(Gtk.ReliefStyle.NONE)
         book_button.connect('clicked', self.__button_clicked)
+        book_button.set_property("tooltip-text", _("Gramplet Bar Menu"))
         book_button.show()
         self.set_action_widget(book_button, Gtk.PackType.END)
 


### PR DESCRIPTION
To improve discoverability of the Gramplet Bar Menu (Currently a nameless down arrow at end of each Gramplet bar title tab) add a tooltip.

Issue #9042

 - [x] Wiki improved to mention existence of "Gramplet Bar Menu" ( https://gramps-project.org/wiki/index.php/Gramps_5.0_Wiki_Manual_-_Main_Window#Gramplet_Bar_Menu )


![gramplet-bar-menu-tooltip-example50](https://user-images.githubusercontent.com/8924713/51068280-0656a280-1670-11e9-92a0-d2c8a758a33e.png)

Previously part of PR #765 