### PR TITLE
Fix Relationship Graph; extra people when using filters & subgraphs

### DIFF
--- a/gramps/plugins/graph/gvrelgraph.py
+++ b/gramps/plugins/graph/gvrelgraph.py
@@ -488,13 +488,13 @@ class RelGraphReport(Report):
             self.doc.start_subgraph(fam_id)
             f_handle = fam.get_father_handle()
             m_handle = fam.get_mother_handle()
-            if f_handle:
+            if f_handle in self.persons:
                 father = self._db.get_person_from_handle(f_handle)
                 self.doc.add_link(father.get_gramps_id(),
                                   fam_id, "",
                                   self.arrowheadstyle,
                                   self.arrowtailstyle)
-            if m_handle:
+            if m_handle in self.persons:
                 mother = self._db.get_person_from_handle(m_handle)
                 self.doc.add_link(mother.get_gramps_id(),
                                   fam_id, "",


### PR DESCRIPTION
subgraph option wasn't checking parents against filtered results

Fixes [#10947](https://gramps-project.org/bugs/view.php?id=10947)

Submitter noticed extra people in his graph when using the subgraph option and a filter which should have prevented their view; the nodes were present, although the names and info was not (only the GrampsID).
Turns out they were parents of already existing persons and Family nodes was on.

The add_link method added a node if one was not already present.