### PR TITLE
We should stay on the selected item in list views:

### DIFF
--- a/gramps/gen/merge/mergefamilyquery.py
+++ b/gramps/gen/merge/mergefamilyquery.py
@@ -133,7 +133,8 @@ class MergeFamilyQuery:
         old_handle = self.titanic.get_handle()
 
         with DbTxn(_('Merge Family'), self.database) as trans:
-
+            # commit family in case Phoenix GrampsID, relationship has changed
+            self.database.commit_family(self.phoenix, trans)
             if self.phoenix_fh != self.titanic_fh:
                 if self.phoenix_fh:
                     phoenix_father = self.database.get_person_from_handle(
@@ -161,6 +162,8 @@ class MergeFamilyQuery:
                     titanic_mother = None
                 self.merge_person(phoenix_mother, titanic_mother,
                                   'mother', trans)
+            # Reload families from db in case the merge_person above changed
+            # them
             self.phoenix = self.database.get_family_from_handle(new_handle)
             self.titanic = self.database.get_family_from_handle(old_handle)
 
@@ -174,8 +177,6 @@ class MergeFamilyQuery:
                     self.phoenix_mh)
             else:
                 phoenix_mother = None
-            self.phoenix = self.database.get_family_from_handle(new_handle)
-            self.titanic = self.database.get_family_from_handle(old_handle)
             self.phoenix.merge(self.titanic)
             self.database.commit_family(self.phoenix, trans)
             for childref in self.titanic.get_child_ref_list():

--- a/gramps/gui/merge/mergecitation.py
+++ b/gramps/gui/merge/mergecitation.py
@@ -150,9 +150,6 @@ class MergeCitation(ManagedWindow):
         else:
             phoenix = self.citation2
             titanic = self.citation1
-            # Add second handle to history so that when merge is complete,
-            # phoenix is the selected row.
-            self.uistate.set_active(phoenix.get_handle(), 'Citation')
 
         if self.get_widget("page_btn1").get_active() ^ use_handle1:
             phoenix.set_page(titanic.get_page())
@@ -165,5 +162,8 @@ class MergeCitation(ManagedWindow):
 
         query = MergeCitationQuery(self.dbstate, phoenix, titanic)
         query.execute()
+        # Add the selected handle to history so that when merge is complete,
+        # phoenix is the selected row.
+        self.uistate.set_active(phoenix.get_handle(), 'Citation')
         self.uistate.set_busy_cursor(False)
         self.close()

--- a/gramps/gui/merge/mergeevent.py
+++ b/gramps/gui/merge/mergeevent.py
@@ -167,9 +167,6 @@ class MergeEvent(ManagedWindow):
         else:
             phoenix = self.ev2
             titanic = self.ev1
-            # Add second handle to history so that when merge is complete,
-            # phoenix is the selected row.
-            self.uistate.set_active(phoenix.get_handle(), 'Event')
 
         if self.get_widget("type_btn1").get_active() ^ use_handle1:
             phoenix.set_type(titanic.get_type())
@@ -185,5 +182,8 @@ class MergeEvent(ManagedWindow):
 
         query = MergeEventQuery(self.dbstate, phoenix, titanic)
         query.execute()
+        # Add the selected handle to history so that when merge is complete,
+        # phoenix is the selected row.
+        self.uistate.set_active(phoenix.get_handle(), 'Event')
         self.uistate.set_busy_cursor(False)
         self.close()

--- a/gramps/gui/merge/mergefamily.py
+++ b/gramps/gui/merge/mergefamily.py
@@ -203,9 +203,6 @@ class MergeFamily(ManagedWindow):
         else:
             phoenix = self.fy2
             titanic = self.fy1
-            # Add second handle to history so that when merge is complete,
-            # phoenix is the selected row.
-            self.uistate.set_active(phoenix.get_handle(), 'Family')
 
         phoenix_fh = phoenix.get_father_handle()
         phoenix_mh = phoenix.get_mother_handle()
@@ -223,6 +220,9 @@ class MergeFamily(ManagedWindow):
             query = MergeFamilyQuery(self.database, phoenix, titanic,
                                      phoenix_fh, phoenix_mh)
             query.execute()
+            # Add the selected handle to history so that when merge is complete,
+            # phoenix is the selected row.
+            self.uistate.set_active(phoenix.get_handle(), 'Family')
         except MergeError as err:
             ErrorDialog(_("Cannot merge people"), str(err),
                         parent=self.window)

--- a/gramps/gui/merge/mergemedia.py
+++ b/gramps/gui/merge/mergemedia.py
@@ -147,9 +147,6 @@ class MergeMedia(ManagedWindow):
         else:
             phoenix = self.mo2
             titanic = self.mo1
-            # Add second handle to history so that when merge is complete,
-            # phoenix is the selected row.
-            self.uistate.set_active(phoenix.get_handle(), 'Media')
 
         if self.get_widget("path_btn1").get_active() ^ use_handle1:
             phoenix.set_path(titanic.get_path())
@@ -163,4 +160,7 @@ class MergeMedia(ManagedWindow):
 
         query = MergeMediaQuery(self.dbstate, phoenix, titanic)
         query.execute()
+        # Add the selected handle to history so that when merge is complete,
+        # phoenix is the selected row.
+        self.uistate.set_active(phoenix.get_handle(), 'Media')
         self.close()

--- a/gramps/gui/merge/mergenote.py
+++ b/gramps/gui/merge/mergenote.py
@@ -159,9 +159,6 @@ class MergeNote(ManagedWindow):
         else:
             phoenix = self.no2
             titanic = self.no1
-            # Add second handle to history so that when merge is complete,
-            # phoenix is the selected row.
-            self.uistate.set_active(phoenix.get_handle(), 'Note')
 
         if self.get_widget("text_btn1").get_active() ^ use_handle1:
             phoenix.set_styledtext(titanic.get_styledtext())
@@ -174,4 +171,7 @@ class MergeNote(ManagedWindow):
 
         query = MergeNoteQuery(self.dbstate, phoenix, titanic)
         query.execute()
+        # Add the selected handle to history so that when merge is complete,
+        # phoenix is the selected row.
+        self.uistate.set_active(phoenix.get_handle(), 'Note')
         self.close()

--- a/gramps/gui/merge/mergeperson.py
+++ b/gramps/gui/merge/mergeperson.py
@@ -321,9 +321,6 @@ class MergePerson(ManagedWindow):
         else:
             phoenix = self.pr2
             titanic = self.pr1
-            # Add second handle to history so that when merge is complete,
-            # phoenix is the selected row.
-            self.uistate.set_active(phoenix.get_handle(), 'Person')
 
         if self.get_widget("name_btn1").get_active() ^ use_handle1:
             swapname = phoenix.get_primary_name()
@@ -347,6 +344,9 @@ class MergePerson(ManagedWindow):
                       "handle.  We recommend that you go to Relationships "
                       "view and see if additional manual merging of families "
                       "is necessary."), parent=self.window)
+            # Add the selected handle to history so that when merge is complete,
+            # phoenix is the selected row.
+            self.uistate.set_active(phoenix.get_handle(), 'Person')
         except MergeError as err:
             ErrorDialog(_("Cannot merge people"), str(err),
                         parent=self.window)

--- a/gramps/gui/merge/mergeplace.py
+++ b/gramps/gui/merge/mergeplace.py
@@ -197,9 +197,6 @@ class MergePlace(ManagedWindow):
         else:
             phoenix = self.pl2
             titanic = self.pl1
-            # Add second handle to history so that when merge is complete,
-            # phoenix is the selected row.
-            self.uistate.set_active(phoenix.get_handle(), 'Place')
 
         if self.get_widget("title_btn1").get_active() ^ use_handle1:
             phoenix.set_title(titanic.get_title())
@@ -218,6 +215,9 @@ class MergePlace(ManagedWindow):
 
         query = MergePlaceQuery(self.dbstate, phoenix, titanic)
         query.execute()
+        # Add the selected handle to history so that when merge is complete,
+        # phoenix is the selected row.
+        self.uistate.set_active(phoenix.get_handle(), 'Place')
 
         if self.callback:
             self.callback()

--- a/gramps/gui/merge/mergerepository.py
+++ b/gramps/gui/merge/mergerepository.py
@@ -140,9 +140,6 @@ class MergeRepository(ManagedWindow):
         else:
             phoenix = self.rp2
             titanic = self.rp1
-            # Add second handle to history so that when merge is complete,
-            # phoenix is the selected row.
-            self.uistate.set_active(phoenix.get_handle(), 'Repository')
 
         if self.get_widget("name_btn1").get_active() ^ use_handle1:
             phoenix.set_name(titanic.get_name())
@@ -153,5 +150,8 @@ class MergeRepository(ManagedWindow):
 
         query = MergeRepositoryQuery(self.dbstate, phoenix, titanic)
         query.execute()
+        # Add the selected handle to history so that when merge is complete,
+        # phoenix is the selected row.
+        self.uistate.set_active(phoenix.get_handle(), 'Repository')
         self.uistate.set_busy_cursor(False)
         self.close()

--- a/gramps/gui/merge/mergesource.py
+++ b/gramps/gui/merge/mergesource.py
@@ -159,9 +159,6 @@ class MergeSource(ManagedWindow):
         else:
             phoenix = self.src2
             titanic = self.src1
-            # Add second handle to history so that when merge is complete,
-            # phoenix is the selected row.
-            self.uistate.set_active(phoenix.get_handle(), 'Source')
 
         if self.get_widget("title_btn1").get_active() ^ use_handle1:
             phoenix.set_title(titanic.get_title())
@@ -176,5 +173,8 @@ class MergeSource(ManagedWindow):
 
         query = MergeSourceQuery(self.dbstate, phoenix, titanic)
         query.execute()
+        # Add the selected handle to history so that when merge is complete,
+        # phoenix is the selected row.
+        self.uistate.set_active(phoenix.get_handle(), 'Source')
         self.uistate.set_busy_cursor(False)
         self.close()

--- a/gramps/plugins/test/db_undo_and_signals_test.py
+++ b/gramps/plugins/test/db_undo_and_signals_test.py
@@ -181,7 +181,7 @@ class DbTestClassBase(object):
             ('family-delete', ['0000000600000006']),
             ('person-update', ['0000000100000001', '0000000200000002',
                                '0000000100000001', '0000000200000002']),
-            ('family-update', ['0000000500000005'])]
+            ('family-update', ['0000000500000005', '0000000500000005'])]
         self.assertEqual(sigs, self.sigs, msg="merge families")
         fam_cnt = self.db.get_number_of_families()
         pers_cnt = self.db.get_number_of_people()
@@ -222,7 +222,7 @@ class DbTestClassBase(object):
             ('person-update', ['0000000200000002', '0000000100000001',
                                '0000000200000002', '0000000100000001']),
             ('family-update', ['0000000500000005', '0000000600000006',
-                               '0000000600000006'])]
+                               '0000000600000006', '0000000500000005'])]
         self.assertEqual(sigs, self.sigs, msg="undo merge signals check")
         fam_cnt = self.db.get_number_of_families()
         pers_cnt = self.db.get_number_of_people()
@@ -303,7 +303,7 @@ class DbTestClassBase(object):
             ('family-delete', ['0000000600000006']),
             ('person-update', ['0000000100000001', '0000000200000002',
                                '0000000100000001', '0000000200000002']),
-            ('family-update', ['0000000500000005'])]
+            ('family-update', ['0000000500000005', '0000000500000005'])]
         self.assertEqual(sigs, self.sigs, msg="merge families")
         fam_cnt = self.db.get_number_of_families()
         pers_cnt = self.db.get_number_of_people()


### PR DESCRIPTION
Fixes [#10966](https://gramps-project.org/bugs/view.php?id=10966)

When we try to merge two objects, we should stay on the selected row
in list views.
This problem occurs for persons, families, events, places, sources,
citations, repositories, media and notes.

Another problem:
In case we select the first family and select the gramps_id of the
second family, the new gramps_id is ignored: problem in MergeFamilyQuery