### PR TITLE
Fix Name editor crash after clearing a group_as name on dbapi dbs

### DIFF
--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -576,14 +576,18 @@ class DBAPI(DbGeneric):
         self.dbapi.execute("SELECT 1 FROM name_group WHERE name = ?",
                            [name])
         row = self.dbapi.fetchone()
-        if row:
+        if row and grouping is not None:
             self.dbapi.execute("UPDATE name_group SET grouping=? "
                                "WHERE name = ?", [grouping, name])
+        elif row and grouping is None:
+            self.dbapi.execute("DELETE FROM name_group WHERE name = ?", [name])
+            grouping = ''
         else:
             self.dbapi.execute(
                 "INSERT INTO name_group (name, grouping) VALUES (?, ?)",
                 [name, grouping])
         self._txn_commit()
+        self.emit('person-groupname-rebuild', (name, grouping))
 
     def _commit_base(self, obj, obj_key, trans, change_time):
         """


### PR DESCRIPTION
Fixes [#10981](https://gramps-project.org/bugs/view.php?id=10981)

Looks like the dbapi code for set_name_group_mapping is not properly removing the name_group when a 'None' grouping value is provided.
Also the method was not emitting a signal for the GUI to update.