### PR TITLE
Fix Descendent Tree report for crash when person has multiple

### DIFF
--- a/gramps/plugins/drawreport/descendtree.py
+++ b/gramps/plugins/drawreport/descendtree.py
@@ -538,7 +538,6 @@ class RecurseDown:
 
                 spouse_handle = utils.find_spouse(person, family)
                 if (self.max_spouses > s_level and
-                        spouse_handle and
                         spouse_handle not in self.families_seen):
                     def _spouse_box(who):
                         return self.add_person_box((x_level, s_level+1),


### PR DESCRIPTION
families and one of them doesn't have a spouse.

Fixes ([#10661](https://gramps-project.org/bugs/view.php?id=10661))  ([#10971](https://gramps-project.org/bugs/view.php?id=10971))  ([#10983](https://gramps-project.org/bugs/view.php?id=10983))

This seems to fix the specific issue with the reporters crash, and I have not found any obvious issues with the half dozen other trees I tried.
The problem was created with an attempt to fix HandleErrors, a later commit did a more thorough job of dealing with them so the specific line deleted in this PR is no longer needed.