### PR TITLE
Have a better narrative web site

### DIFF
--- a/data/css/Web_Basic-Ash.css
+++ b/data/css/Web_Basic-Ash.css
@@ -21,6 +21,8 @@ Copyright 2008 Jason M. Simanek
 Copyright 2009 Stephane Charette
 Copyright (C) 2008-2011 Rob G. Healey <robhealey1@gmail.com>
 Copyright 2011 Michiel D. Nauta
+Copyright 2018 Theo van Rijn
+Copyright (C) 2019      Serge Noiraud
 
 This file is part of the GRAMPS program.
 
@@ -59,12 +61,19 @@ the page.
 
 body {
     font-family: sans-serif;
-    font-size: 90%;
+    font-size: 100%;
     color: black;
     margin: 0px;
     background-color: #EEE;
 }
 body > div {
+    clear: both;
+}
+#outerwrapper {
+    margin: 5px auto;
+    width: 98%;
+}
+#outerwrapper > div {
     clear: both;
 }
 .content {
@@ -75,8 +84,18 @@ body > div {
     float: right;
     margin: 2em;
 }
+#ThumbnailPreview div.snapshot {
+    float: right;
+    margin: 0;
+}
 .fullclear {
     clear: both;
+}
+/* Less whitespace on smaller real estate. */
+@media only screen and (max-width: 1080px) {
+    .content {
+        padding: 0em 0.5em;
+    }
 }
 
 /* General Text
@@ -203,6 +222,93 @@ div#alphanav ul li a:hover {
     text-decoration: none;
     background-color: black;
     color: white;
+}
+
+/* Responsive navigation */
+a.navIcon {
+    display: none;
+}
+
+div#header::after {
+    content: "";
+    clear: both;
+    display: table;
+}
+
+div#nav::after {
+    content: "";
+    clear: both;
+    display: table;
+}
+
+@media only screen and (max-width: 1080px) {
+
+    /* Use less & all realestate on mobiles. */
+    div#outerwrapper {
+        margin: 5px auto;
+        width: 100%;
+    }
+
+    .nav {
+        background: none; /* Works in IE too. */
+/*
+        width: 200px;
+        position: absolute;
+        z-index: 10;
+*/
+    }
+
+    /* Undo some of the #nav styles  - to enable the class .nav */
+    .nav ul, #subnavigation ul {
+        list-style: none;
+        min-width: unset;
+        width: 200px;
+        height: 32px;
+        margin: 0;
+        padding: 0;
+    }
+    .nav ul li, #subnavigation ul li {
+        float: unset;
+        display: unset
+    }
+
+    /* Start with hidden menu options */
+    /* .nav li:not(:first-child) {display: none;} */
+    .nav li {display: none;}
+    .nav ul {display: none;}
+
+    a.navIcon {
+        font-size:1.3em;
+        display: block;
+        margin: 0.1em 0.4em 0.4em 0.4em;
+        float: left;
+    }
+
+    .nav.responsive {position: absolute; display: block; z-index: 100;}
+    .nav.responsive a.icon {
+        position: absolute;
+        right: 0;
+        top: 0;
+        margin-right: 10px;
+    }
+    .nav.responsive li {
+        /* float: left; */
+        display: block;
+        text-align: left;
+        background-color: #EEE;
+        /* required by IE */
+        float: left;
+        clear: both;
+        width: 200px;
+    }
+
+    div#nav ul, #subnavigation ul {
+        padding-left: 0px;
+    }
+
+    .content {
+        padding: 0em 0.5em;
+    }
 }
 
 /* Main Table
@@ -367,7 +473,16 @@ table.eventlist tbody tr td.ColumnSources {
     margin: 0px auto;
     display: block;
     border: solid 1px #999;
+    max-width: 800px;
+    height: auto;
 }
+
+@media only screen and (max-width: 1080px) {
+    #GalleryDisplay img {
+        max-width: 100%;
+    }
+}
+
 #GalleryDetail h3 {
     text-align: center;
 }
@@ -384,13 +499,10 @@ div#SourceDetail {
     overflow: hidden;
 }
 #Contact #summaryarea {
-    width: 50em;
-    margin: 2em auto;
-    padding: 3em;
     background-color: #EEE;
     border: solid 1px #999;
 }
-#Contact img {
+#Contact #GalleryDisplay img {
     float: right;
     border: solid 1px #999;
 }
@@ -404,6 +516,12 @@ div#SourceDetail {
 #Contact #city:after {
     content: ",";
 }
+@media only screen and (max-width: 1080px) {
+    #Contact,
+    #Contact #GalleryDisplay img {
+        max-width: 100%;
+    }
+}
 
 /* Download
 ----------------------------------------------------- */
@@ -413,20 +531,29 @@ div#SourceDetail {
 
 /* Subsection
 ----------------------------------------------------- */
-#Home, #Introduction {
-    overflow: hidden;
-}
-#Home img, #Introduction img {
+#Home #GalleryDisplay, #Introduction #GalleryDisplay {
     float: right;
     margin: 1em;
+}
+#Home #GalleryDisplay img, #Introduction #GalleryDisplay img {
+    display: block;
     max-width: 950px;
+    height: auto;
+    float: right;
+}
+@media only screen and (max-width: 1080px) {
+    #Home #GalleryDisplay img, #Introduction #GalleryDisplay img,
+          #Contact #GalleryDisplay img {
+        margin: 0 auto;
+        max-width: 100%;
+    }
 }
 #Home p, #Introduction p {
     padding-left: 15px;
 }
 .subsection {
     clear: both;
-    overflow: visible;
+    overflow: hidden;
 }
 .subsection p {
     margin: 0px;
@@ -449,12 +576,33 @@ div#families table.attrlist td.ColumnType {
 
 /* Subsection : Gallery
 ----------------------------------------------------- */
+#gallery {
+    background-color: green;
+}
+#indivgallery {
+    background-color: white;
+}
+#gallery .gallerycell {
+    float: left;
+    width: 130px;
+    height: 150px;
+    text-align: center;
+    margin: 0;
+    background-color: white;
+    border-top: solid 1px #999;
+    border-right: solid 1px #999;
+}
+#gallery .thumbnail {
+    font-size: smaller;
+    margin: 3em auto;
+}
 #indivgallery .thumbnail {
     float: left;
     width: 130px;
     font-size: smaller;
     text-align: center;
     margin: 0.8em 0.5em;
+    background-color: white;
 }
 #indivgallery h4 + .thumbnail {
     margin-left: 15px;
@@ -462,12 +610,49 @@ div#families table.attrlist td.ColumnType {
      *          first thumnail on each next row should also have a margin-left
      *          of 15 px. */
 }
+#gallery div.indexno {
+    float: right;
+    width: 1.8em;
+    font-size: large;
+    text-align: center;
+    background-color: #CCC;
+    color: #555;
+    margin: 0;
+}
+#indivgallery div.date {
+    float: right;
+    width: 1.8em;
+    font-size: large;
+    text-align: center;
+    background-color: #CCC;
+    color: #555;
+}
+#indivgallery .thumbnail ul {
+    font-size: smaller;
+    list-style: none;
+    padding: 0px;
+}
+#indivgallery .thumbnail ul li:first-child {
+    border-style: none;
+}
+#indivgallery .thumbnail ul li {
+    border-top: dashed 1px #CCC;
+    border-top-style: dashed;
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+}
+#gallery img {
+    border: solid 1px #999;
+}
 #indivgallery img {
     border: solid 1px #999;
 }
 #indivgallery span {
 /* ## remove this line and the comment markers from the line below to hide description in Indivifual Gallery
     display: none; */
+}
+div.snapshot div.thumbnail {
+    text-align: center;
 }
 
 /* Subsection : Narrative
@@ -532,6 +717,7 @@ a.familymap {
 }
 #footer > * {
     background-color: #EEE;
+    font-size: 80%;
 }
 #footer p#createdate {
     float: left;

--- a/data/css/Web_Basic-Blue.css
+++ b/data/css/Web_Basic-Blue.css
@@ -3,6 +3,8 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2008-2011 Rob G. Healey <robhealey1@gmail.com>
+# Copyright (C) 2018      Theo van Rijn
+# Copyright (C) 2019      Serge Noiraud
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -72,6 +74,13 @@ img {
 .thumbnail a:hover {
     background: none;
 }
+#outerwrapper {
+    margin: 5px auto;
+    width: 98%;
+}
+#outerwrapper > div {
+    clear: both;
+}
 .content {
     background-color: #FFF;
     color: #000;
@@ -94,12 +103,22 @@ img {
     width: 96px;
     margin: 0 auto;
 }
+#ThumbnailPreview div.snapshot {
+    float: right;
+    margin: 0;
+}
 .fullclear {
     width: 100%;
     height: 1px;
     margin: 0;
     padding: 0;
     clear: both;
+}
+/* Less whitespace on smaller real estate. */
+@media only screen and (max-width: 1080px) {
+    .content {
+        padding: 0em 0.5em;
+    }
 }
 
 /* General Text
@@ -221,6 +240,55 @@ p#user_header {
     margin-right: 10px;
 }
 
+/* Navigation
+----------------------------------------------------- */
+div#nav, #subnavigation {
+    border: solid 1px #EEE; /* needed by IE7 */
+    background-color: #13A926;
+}
+#subnavigation ul {
+    overflow: hidden;
+}
+div#nav ul, #subnavigation ul {
+    list-style: none;
+    margin: 0px;
+    padding-left: 15px;
+}
+#subnavigation ul {
+    border-bottom: solid 1px #999;
+}
+div#nav ul li, #subnavigation ul li {
+    float: left;
+}
+div#nav ul li a, #subnavigation ul li a {
+    display: block;
+    font-size: smaller;
+    font-weight: bold;
+    padding: 5px;
+    border-bottom: solid 1px #EEE;
+}
+div#nav ul li a:hover, #subnavigation ul li a:hover {
+    text-decoration: none;
+    background-color: #CCC;
+    border-bottom: solid 1px black;
+}
+div#nav ul li.CurrentSection a {
+    position: relative;
+    top: 1px;
+    border: solid 1px #999;
+    border-bottom-style: none;
+    background-color: white;
+}
+#nav ul li.CurrentSection a:hover {
+    background-color: #903;
+}
+
+/* Webcal
+----------------------------------------------------- */
+#subnavigation ul li.CurrentSection a {
+    background-color: white;
+}
+
 /* Footer
 ----------------------------------------------------- */
 div#footer {
@@ -268,6 +336,129 @@ div#footer p#copyright img {
     font: normal 1em/1.2em serif;
     margin: 0;
     padding: 0;
+}
+
+/* Responsive navigation */
+a.navIcon {
+    display: none;
+}
+
+div#header::after {
+    content: "";
+    clear: both;
+    display: table;
+}
+
+/* Alphabet Navigation
+----------------------------------------------------- */
+div#alphanav {
+    background-color: #EEE;
+}
+div#alphanav ul {
+    list-style: none;
+    border-width: 2px 0px 4px 0px;
+    border-style: solid;
+    border-color: black;
+    margin: 0px;
+    padding-left: 15px;
+    /* float container stretch, see www.quirksmode.org/css/clearing.html */
+    overflow: hidden;
+}
+div#alphanav ul li {
+    float: left;
+    font-size: larger;
+    font-weight: bold;
+}
+div#alphanav ul li:after {
+    content: " |";
+}
+div#alphanav ul li a {
+    display: block;
+    padding: 4px 8px;
+    line-height: 100%;
+    float: left;
+
+}
+div#alphanav ul li a:hover {
+    text-decoration: none;
+    background-color: black;
+    color: white;
+}
+
+div#nav::after {
+    content: "";
+    clear: both;
+    display: table;
+}
+
+@media only screen and (max-width: 1080px) {
+
+    /* Use less & all realestate on mobiles. */
+    div#outerwrapper {
+        margin: 5px auto;
+        width: 100%;
+    }
+
+    .nav {
+        background: none; /* Works in IE too. */
+/*
+        width: 200px;
+        position: absolute;
+        z-index: 10;
+*/
+    }
+
+    /* Undo some of the #nav styles  - to enable the class .nav */
+    .nav ul, #subnavigation ul {
+        list-style: none;
+        min-width: unset;
+        width: 200px;
+        height: 32px;
+        margin: 0;
+        padding: 0;
+    }
+    .nav ul li, #subnavigation ul li {
+        float: unset;
+        display: unset
+    }
+
+    /* Start with hidden menu options */
+    /* .nav li:not(:first-child) {display: none;} */
+    .nav li {display: none;}
+    .nav ul {display: none;}
+
+    a.navIcon {
+        font-size:1.3em;
+        display: block;
+        margin: 0.1em 0.4em 0.4em 0.4em;
+        float: left;
+    }
+
+    .nav.responsive {position: absolute; display: block; z-index: 100;}
+    .nav.responsive a.icon {
+        /* position: absolute; */
+        right: 0;
+        top: 0;
+        margin-right: 10px;
+    }
+    .nav.responsive li {
+        /* float: left; */
+        display: block;
+        text-align: left;
+        background-color: #13A926;
+        /* required by IE */
+        float: left;
+        clear: both;
+        width: 200px;
+    }
+
+    div#nav ul, #subnavigation ul {
+        padding-left: 0px;
+    }
+
+    .content {
+        padding: 0em 0.5em;
+    }
 }
 
 /* Main Table
@@ -578,6 +769,26 @@ div#EventDetail table.eventlist tbody tr td.ColumnDate {
     margin: 0;
     padding: 0;
 }
+#gallery {
+    background-color: green;
+}
+#indivgallery {
+    background-color: white;
+}
+#gallery .gallerycell {
+    float: left;
+    width: 130px;
+    height: 150px;
+    text-align: center;
+    margin: 0;
+    background-color: white;
+    border-top: solid 1px #999;
+    border-right: solid 1px #999;
+}
+#gallery .thumbnail {
+    font-size: smaller;
+    margin: 3em auto;
+}
 #Gallery table.infolist tbody tr td {
     border-bottom: dashed 1px #000;
 }
@@ -627,7 +838,16 @@ div#EventDetail table.eventlist tbody tr td.ColumnDate {
 }
 #GalleryDisplay img {
     margin: 0 auto;
+    max-width: 800px;
+    height: auto;
 }
+
+@media only screen and (max-width: 1080px) {
+    #GalleryDisplay img {
+        max-width: 100%;
+    }
+}
+
 #GalleryDetail div#summaryarea{
     margin: 0;
     padding: 2em 0 0 0;
@@ -679,48 +899,51 @@ body#ThumbnailPreview div#references table.infolist tbody tr td.ColumnName {
 /* Contact
 ------------------------------------------------- */
 #Contact #summaryarea {
-    width: 500px;
-    margin: 0 auto;
-    padding: 3em;
     border: double 4px #000;
     background-color: #BCEAF6;
 }
-#Contact #summaryarea img {
+#Contact #summaryarea #GalleryDisplay img {
     float: right;
     margin: 0;
 }
-#researcher {
+@media only screen and (max-width: 1080px) {
+    #Contact, #Contact #summaryarea #researcher,
+    #Contact #summaryarea #GalleryDisplay img {
+        max-width: 100%;
+    }
+}
+
+#Contact #summaryarea #researcher {
     font: normal 1.5em/1.4em serif;
     margin-top: .3em;
 }
-#researcher h3 {
+#Contact #summaryarea #researcher h3 {
     font: normal 1.2em/1.4em serif;
     padding: 0;
     text-align: left;
 }
-#researcher span {
-    float: left;
+#Contact #summaryarea #researcher span {
     display: block;
     font: normal .9em/1.4em serif;
     margin-right: .4em;
 }
-#streetaddress {
+#Contact #summaryarea #streetaddress {
     width: 100%;
 }
-#locality, .locality {
+#Contact #summaryarea #locality, .locality {
     display: block;
     width: 100%;
 }
-#city:after {
+#Contact #summaryarea #city:after {
     content: ",";
 }
-#country {
+#Contact #summaryarea #country {
     clear: left;
 }
-#email {
+#Contact #summaryarea #email {
     clear: left;
 }
-#email a {
+#Contact #summaryarea #email a {
     text-decoration: none;
 }
 
@@ -813,16 +1036,28 @@ div#AddressBookList table.addressbook tbody tr td.ColumnWebLinks {
 
 /* Subsections
 ----------------------------------------------------- */
-#Home, #Introduction, #Contact {
-    padding: 2em 0 3em 0;
+#Home #GalleryDisplay, #Introduction #GalleryDisplay,
+                       #Contact #GalleryDisplay {
+    float: right;
+    margin: 0;
+    border: 0px;
+}
+#Home #GalleryDisplay img, #Introduction #GalleryDisplay img,
+                       #Contact #GalleryDisplay img {
+    display: block;
+    max-width: 950px;
+    height: auto;
+    float: right;
+}
+@media only screen and (max-width: 1080px) {
+    #Home #GalleryDisplay img, #Introduction #GalleryDisplay img,
+          #Contact #GalleryDisplay img {
+        margin: 0 auto;
+        max-width: 100%;
+    }
 }
 #Home p, #Introduction p {
     margin: 0 20px 1em 20px;
-}
-#Home img, #Introduction img {
-    float: right;
-    margin: 0;
-    padding: 0 20px 3em 2em;
 }
 #Home a, #Introduction a, #Contact a {
     color: #000;
@@ -926,6 +1161,15 @@ div#IndividualDetail div#parents table.infolist tr td {
 div#families {
     margin: 0;
     padding: 0;
+}
+div#families .infolist h4 {
+    font: bold 1.2em sans-serif;
+    color: #FFF;
+    padding: 0px 0px 0px 20px;
+    border-width: 4px 0px 4px 0px;
+    border-style: solid;
+    border-color: #00029D;
+    background-color: #13A926;
 }
 div#families table.infolist tbody tr.BeginFamily {
     border-top: solid 1px #000;
@@ -1094,6 +1338,7 @@ div.Residence table.infolist tr td {
     float: left;
     width: 130px;
     text-align: center;
+    background-color: white;
 }
 #indivgallery div.thumbnail a {
     display: block;
@@ -1116,6 +1361,43 @@ div.Residence table.infolist tr td {
     width: 80%;
     margin: 0 auto;
     padding: 0;
+}
+#gallery div.indexno {
+    float: right;
+    width: 1.8em;
+    font-size: large;
+    text-align: center;
+    background-color: #CCC;
+    color: #555;
+    margin: 0;
+}
+#indivgallery div.date {
+    float: right;
+    width: 1.8em;
+    font-size: large;
+    text-align: center;
+    background-color: #CCC;
+    color: #555;
+}
+#indivgallery .thumbnail ul {
+    font-size: smaller;
+    list-style: none;
+    padding: 0px;
+}
+#indivgallery .thumbnail ul li:first-child {
+    border-style: none;
+}
+#indivgallery .thumbnail ul li {
+    border-top: dashed 1px #CCC;
+    border-top-style: dashed;
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+}
+#gallery img {
+    border: solid 1px #999;
+}
+div.snapshot div.thumbnail {
+    text-align: center;
 }
 
 /* Subsections : Narrative

--- a/data/css/Web_Basic-Cypress.css
+++ b/data/css/Web_Basic-Cypress.css
@@ -21,6 +21,8 @@ Copyright 2008 Jason M. Simanek
 Copyright 2009 Stephane Charette
 Copyright (C) 2008-2011 Rob G. Healey <robhealey1@gmail.com>
 Copyright 2011 Michiel D. Nauta
+Copyright 2018 Theo van Rijn
+Copyright (C) 2019      Serge Noiraud
 
 This file is part of the GRAMPS program.
 
@@ -59,12 +61,19 @@ the page.
 
 body {
     font-family: sans-serif;
-    font-size: 90%;
+    font-size: 100%;
     color: black;
     margin: 0px;
     background-color: #454;
 }
 body > div {
+    clear: both;
+}
+#outerwrapper {
+    margin: 5px auto;
+    width: 98%;
+}
+#outerwrapper > div {
     clear: both;
 }
 .content {
@@ -75,8 +84,18 @@ body > div {
     float: right;
     margin: 2em;
 }
+#ThumbnailPreview div.snapshot {
+    float: right;
+    margin: 0;
+}
 .fullclear {
     clear: both;
+}
+/* Less whitespace on smaller real estate. */
+@media only screen and (max-width: 1080px) {
+    .content {
+        padding: 0em 0.5em;
+    }
 }
 
 /* General Text
@@ -207,6 +226,98 @@ div#alphanav ul li a:hover {
     text-decoration: none;
     background-color: black;
     color: white;
+}
+
+/* Responsive navigation */
+a.navIcon {
+    display: none;
+}
+
+div#header::after {
+    content: "";
+    clear: both;
+    display: table;
+}
+
+div#nav::after {
+    content: "";
+    clear: both;
+    display: table;
+}
+
+@media only screen and (max-width: 1080px) {
+
+    /* Use less & all realestate on mobiles. */
+    div#outerwrapper {
+        margin: 5px auto;
+        width: 100%;
+    }
+
+    .nav {
+        background: none; /* Works in IE too. */
+/*
+        width: 200px;
+        position: absolute;
+        z-index: 10;
+*/
+    }
+
+    /* Undo some of the #nav styles  - to enable the class .nav */
+    .nav ul, #subnavigation ul {
+        list-style: none;
+        min-width: unset;
+        width: 200px;
+        height: 32px;
+        margin: 0;
+        padding: 0;
+    }
+    .nav ul li, #subnavigation ul li {
+        float: unset;
+        display: unset
+    }
+
+    /* Start with hidden menu options */
+    /* .nav li:not(:first-child) {display: none;} */
+    .nav li {display: none;}
+    .nav ul {display: none;}
+
+    a.navIcon {
+        font-size:1.3em;
+        display: block;
+        margin: 0.1em 0.4em 0.4em 0.4em;
+        float: left;
+    }
+
+    .nav.responsive {position: absolute; display: block; z-index: 100;}
+    .nav.responsive a.icon {
+        position: absolute;
+        right: 0;
+        top: 0;
+        margin-right: 10px;
+    }
+    .nav.responsive li {
+        /* float: left; */
+        display: block;
+        text-align: left;
+        color: #454;
+        background-color: #E0E6E0;
+        /* required by IE */
+        float: left;
+        clear: both;
+        width: 200px;
+    }
+    .nav.responsive li#CurrentSection a {
+        color: #454;
+        background-color: white;
+    }
+
+    div#nav ul, #subnavigation ul {
+        padding-left: 0px;
+    }
+
+    .content {
+        padding: 0em 0.5em;
+    }
 }
 
 /* Main Table
@@ -413,7 +524,16 @@ table.eventlist tbody tr td.ColumnSources {
     margin: 0px auto;
     display: block;
     border: solid 1px #7C8F7C;
+    max-width: 800px;
+    height: auto;
 }
+
+@media only screen and (max-width: 1080px) {
+    #GalleryDisplay img {
+        max-width: 100%;
+    }
+}
+
 #GalleryDetail h3 {
     text-align: center;
 }
@@ -430,13 +550,10 @@ div#SourceDetail {
     overflow: hidden;
 }
 #Contact #summaryarea {
-    width: 40em;
-    margin: 2em auto;
-    padding: 3em;
     background-color: #E0E6E0;
     border: solid 1px #7C8F7C;
 }
-#Contact img {
+#Contact #summaryarea #GalleryDisplay img {
     float: right;
     border: solid 1px #7C8F7C;
 }
@@ -463,20 +580,31 @@ div#SourceDetail {
 
 /* Subsection
 ----------------------------------------------------- */
-#Home, #Introduction {
-    overflow: hidden;
-}
-#Home img, #Introduction img {
+#Home #GalleryDisplay, #Introduction #GalleryDisplay, #Contact #GalleryDisplay {
     float: right;
-    margin: 1em;
+    margin: 0;
+    border: 0px;
+}
+#Home #GalleryDisplay img, #Introduction #GalleryDisplay img,
+      #Contact #GalleryDisplay img {
+    display: block;
     max-width: 950px;
+    height: auto;
+    float: right;
+}
+@media only screen and (max-width: 1080px) {
+    #Home #GalleryDisplay img, #Introduction #GalleryDisplay img,
+          #Contact #GalleryDisplay img {
+        margin: 0 auto;
+        max-width: 100%;
+    }
 }
 #Home p, #Introduction p {
     padding-left: 15px;
 }
 .subsection {
     clear: both;
-    overflow: visible;
+    overflow: hidden;
 }
 .subsection p {
     margin: 0px;
@@ -499,12 +627,33 @@ div#families table.attrlist td.ColumnType {
 
 /* Subsection : Gallery
 ----------------------------------------------------- */
+#gallery {
+    background-color: green;
+}
+#indivgallery {
+    background-color: white;
+}
+#gallery .gallerycell {
+    float: left;
+    width: 130px;
+    height: 150px;
+    text-align: center;
+    margin: 0;
+    background-color: white;
+    border-top: solid 1px #999;
+    border-right: solid 1px #999;
+}
+#gallery .thumbnail {
+    font-size: smaller;
+    margin: 3em auto;
+}
 #indivgallery .thumbnail {
     float: left;
     width: 130px;
     font-size: smaller;
     text-align: center;
     margin: 0.8em 0.5em;
+    background-color: white;
 }
 #indivgallery h4 + .thumbnail {
     margin-left: 15px;
@@ -512,12 +661,49 @@ div#families table.attrlist td.ColumnType {
      *          first thumnail on each next row should also have a margin-left
      *          of 15 px. */
 }
+#gallery div.indexno {
+    float: right;
+    width: 1.8em;
+    font-size: large;
+    text-align: center;
+    background-color: #CCC;
+    color: #555;
+    margin: 0;
+}
+#indivgallery div.date {
+    float: right;
+    width: 1.8em;
+    font-size: large;
+    text-align: center;
+    background-color: #CCC;
+    color: #555;
+}
+#indivgallery .thumbnail ul {
+    font-size: smaller;
+    list-style: none;
+    padding: 0px;
+}
+#indivgallery .thumbnail ul li:first-child {
+    border-style: none;
+}
+#indivgallery .thumbnail ul li {
+    border-top: dashed 1px #CCC;
+    border-top-style: dashed;
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+}
+#gallery img {
+    border: solid 1px #999;
+}
 #indivgallery img {
     border: solid 1px #7C8F7C;
 }
 #indivgallery span {
 /* ## remove this line and the comment markers from the line below to hide description in Indivifual Gallery
     display: none; */
+}
+div.snapshot div.thumbnail {
+    text-align: center;
 }
 
 /* Subsection : Narrative
@@ -577,6 +763,7 @@ a.familymap {
 #footer {
     clear: both;
     color: #E0E6E0;
+    font-size: 80%;
     padding-top: 1em;
     background-color: #9DBF9D;
     border-top: solid 1px #454;

--- a/data/css/Web_Basic-Lilac.css
+++ b/data/css/Web_Basic-Lilac.css
@@ -21,6 +21,8 @@ Copyright 2008 Jason M. Simanek
 Copyright 2009 Stephane Charette
 Copyright (C) 2008-2011 Rob G. Healey <robhealey1@gmail.com>
 Copyright 2011 Michiel D. Nauta
+Copyright 2018 Theo van Rijn
+Copyright (C) 2019      Serge Noiraud
 
 This file is part of the GRAMPS program.
 
@@ -67,6 +69,13 @@ body {
 body > div {
     clear: both;
 }
+#outerwrapper {
+    margin: 5px auto;
+    width: 98%;
+}
+#outerwrapper > div {
+    clear: both;
+}
 .content {
     background-color: #FAFAFF;
     border-top: solid 1px #669;
@@ -75,8 +84,18 @@ body > div {
     float: right;
     margin: 2em;
 }
+#ThumbnailPreview div.snapshot {
+    float: right;
+    margin: 0;
+}
 .fullclear {
     clear: both;
+}
+/* Less whitespace on smaller real estate. */
+@media only screen and (max-width: 1080px) {
+    .content {
+        padding: 0em 0.5em;
+    }
 }
 
 /* General Text
@@ -205,6 +224,93 @@ div#alphanav ul li a:hover {
     text-decoration: none;
     background-color: black;
     color: #FAFAFF;
+}
+
+/* Responsive navigation */
+a.navIcon {
+    display: none;
+}
+
+div#header::after {
+    content: "";
+    clear: both;
+    display: table;
+}
+
+div#nav::after {
+    content: "";
+    clear: both;
+    display: table;
+}
+
+@media only screen and (max-width: 1080px) {
+
+    /* Use less & all realestate on mobiles. */
+    div#outerwrapper {
+        margin: 5px auto;
+        width: 100%;
+    }
+
+    .nav {
+        background: none; /* Works in IE too. */
+/*
+        width: 200px;
+        position: absolute;
+        z-index: 10;
+*/
+    }
+
+    /* Undo some of the #nav styles  - to enable the class .nav */
+    .nav ul, #subnavigation ul {
+        list-style: none;
+        min-width: unset;
+        width: 200px;
+        height: 32px;
+        margin: 0;
+        padding: 0;
+    }
+    .nav ul li, #subnavigation ul li {
+        float: unset;
+        display: unset
+    }
+
+    /* Start with hidden menu options */
+    /* .nav li:not(:first-child) {display: none;} */
+    .nav li {display: none;}
+    .nav ul {display: none;}
+
+    a.navIcon {
+        font-size:1.3em;
+        display: block;
+        margin: 0.1em 0.4em 0.4em 0.4em;
+        float: left;
+    }
+
+    .nav.responsive {position: absolute; display: block; z-index: 100;}
+    .nav.responsive a.icon {
+        position: absolute;
+        right: 0;
+        top: 0;
+        margin-right: 10px;
+    }
+    .nav.responsive li {
+        /* float: left; */
+        display: block;
+        text-align: left;
+        background-color: #669;
+        /* required by IE */
+        float: left;
+        clear: both;
+        width: 200px;
+    }
+
+    div#nav ul, #subnavigation ul {
+        padding-left: 0px;
+    }
+
+    .content {
+        padding: 0em 0.5em;
+    }
 }
 
 /* Main Table
@@ -406,6 +512,14 @@ table.eventlist tbody tr td.ColumnSources {
     margin: 0px auto;
     display: block;
     border: solid 1px #669;
+    max-width: 800px;
+    height: auto;
+}
+
+@media only screen and (max-width: 1080px) {
+    #GalleryDisplay img {
+        max-width: 100%;
+    }
 }
 #GalleryDetail h3 {
     text-align: center;
@@ -423,13 +537,10 @@ div#SourceDetail {
     overflow: hidden;
 }
 #Contact #summaryarea {
-    width: 40em;
-    margin: 2em auto;
-    padding: 3em;
     background-color: #E0E0E9;
     border: solid 1px #669;
 }
-#Contact img {
+#Contact #summaryarea #GalleryDisplay img {
     float: right;
     border: solid 1px #669;
 }
@@ -456,20 +567,31 @@ div#SourceDetail {
 
 /* Subsection
 ----------------------------------------------------- */
-#Home, #Introduction {
-    overflow: hidden;
-}
-#Home img, #Introduction img {
+#Home #GalleryDisplay, #Introduction #GalleryDisplay, #Contact #GalleryDisplay {
     float: right;
-    margin: 1em;
+    margin: 0;
+    border: 0px;
+}
+#Home #GalleryDisplay img, #Introduction #GalleryDisplay img,
+      #Contact #GalleryDisplay img {
+    display: block;
     max-width: 950px;
+    height: auto;
+    float: right;
+}
+@media only screen and (max-width: 1080px) {
+    #Home #GalleryDisplay img, #Introduction #GalleryDisplay img,
+          #Contact #GalleryDisplay img {
+        margin: 0 auto;
+        max-width: 100%;
+    }
 }
 #Home p, #Introduction p {
     padding-left: 15px;
 }
 .subsection {
     clear: both;
-    overflow: visible;
+    overflow: hidden;
 }
 .subsection p {
     margin: 0px;
@@ -492,12 +614,33 @@ div#families table.attrlist td.ColumnType {
 
 /* Subsection : Gallery
 ----------------------------------------------------- */
+#gallery {
+    background-color: green;
+}
+#indivgallery {
+    background-color: white;
+}
+#gallery .gallerycell {
+    float: left;
+    width: 130px;
+    height: 150px;
+    text-align: center;
+    margin: 0;
+    background-color: white;
+    border-top: solid 1px #999;
+    border-right: solid 1px #999;
+}
+#gallery .thumbnail {
+    font-size: smaller;
+    margin: 3em auto;
+}
 #indivgallery .thumbnail {
     float: left;
     width: 130px;
     font-size: smaller;
     text-align: center;
     margin: 0.8em 0.5em;
+    background-color: white;
 }
 #indivgallery h4 + .thumbnail {
     margin-left: 15px;
@@ -505,12 +648,49 @@ div#families table.attrlist td.ColumnType {
      *          first thumnail on each next row should also have a margin-left
      *          of 15 px. */
 }
+#gallery div.indexno {
+    float: right;
+    width: 1.8em;
+    font-size: large;
+    text-align: center;
+    background-color: #CCC;
+    color: #555;
+    margin: 0;
+}
+#indivgallery div.date {
+    float: right;
+    width: 1.8em;
+    font-size: large;
+    text-align: center;
+    background-color: #CCC;
+    color: #555;
+}
+#indivgallery .thumbnail ul {
+    font-size: smaller;
+    list-style: none;
+    padding: 0px;
+}
+#indivgallery .thumbnail ul li:first-child {
+    border-style: none;
+}
+#indivgallery .thumbnail ul li {
+    border-top: dashed 1px #CCC;
+    border-top-style: dashed;
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+}
+#gallery img {
+    border: solid 1px #999;
+}
 #indivgallery img {
     border: solid 1px #669;
 }
 #indivgallery span {
 /* ## remove this line and the comment markers from the line below to hide description in Indivifual Gallery
     display: none; */
+}
+div.snapshot div.thumbnail {
+    text-align: center;
 }
 
 /* Subsection : Narrative
@@ -575,6 +755,7 @@ a.familymap {
 }
 #footer > * {
     background-color: #E0E0E9;
+    font-size: 80%;
 }
 #footer p#createdate {
     float: left;

--- a/data/css/Web_Basic-Peach.css
+++ b/data/css/Web_Basic-Peach.css
@@ -21,6 +21,8 @@ Copyright 2008 Jason M. Simanek
 Copyright 2009 Stephane Charette
 Copyright (C) 2008-2011 Rob G. Healey <robhealey1@gmail.com>
 Copyright 2011 Michiel D. Nauta
+Copyright 2018 Theo van Rijn
+Copyright (C) 2019      Serge Noiraud
 
 This file is part of the GRAMPS program.
 
@@ -59,12 +61,19 @@ the page.
 
 body {
     font-family: sans-serif;
-    font-size: 90%;
+    font-size: 100%;
     color: #36220B;
     margin: 0px;
     background-color: #FFE09F;
 }
 body > div {
+    clear: both;
+}
+#outerwrapper {
+    margin: 5px auto;
+    width: 98%;
+}
+#outerwrapper > div {
     clear: both;
 }
 .content {
@@ -75,8 +84,18 @@ body > div {
     float: right;
     margin: 2em;
 }
+#ThumbnailPreview div.snapshot {
+    float: right;
+    margin: 0;
+}
 .fullclear {
     clear: both;
+}
+/* Less whitespace on smaller real estate. */
+@media only screen and (max-width: 1080px) {
+    .content {
+        padding: 0em 0.5em;
+    }
 }
 
 /* General Text
@@ -205,6 +224,93 @@ div#alphanav ul li a:hover {
     text-decoration: none;
     background-color: #36220B;
     color: #FFFBE7;
+}
+
+/* Responsive navigation */
+a.navIcon {
+    display: none;
+}
+
+div#header::after {
+    content: "";
+    clear: both;
+    display: table;
+}
+
+div#nav::after {
+    content: "";
+    clear: both;
+    display: table;
+}
+
+@media only screen and (max-width: 1080px) {
+
+    /* Use less & all realestate on mobiles. */
+    div#outerwrapper {
+        margin: 5px auto;
+        width: 100%;
+    }
+
+    .nav {
+        background: none; /* Works in IE too. */
+/*
+        width: 200px;
+        position: absolute;
+        z-index: 10;
+*/
+    }
+
+    /* Undo some of the #nav styles  - to enable the class .nav */
+    .nav ul, #subnavigation ul {
+        list-style: none;
+        min-width: unset;
+        width: 200px;
+        height: 32px;
+        margin: 0;
+        padding: 0;
+    }
+    .nav ul li, #subnavigation ul li {
+        float: unset;
+        display: unset
+    }
+
+    /* Start with hidden menu options */
+    /* .nav li:not(:first-child) {display: none;} */
+    .nav li {display: none;}
+    .nav ul {display: none;}
+
+    a.navIcon {
+        font-size:1.3em;
+        display: block;
+        margin: 0.1em 0.4em 0.4em 0.4em;
+        float: left;
+    }
+
+    .nav.responsive {position: absolute; display: block; z-index: 100;}
+    .nav.responsive a.icon {
+        position: absolute;
+        right: 0;
+        top: 0;
+        margin-right: 10px;
+    }
+    .nav.responsive li {
+        /* float: left; */
+        display: block;
+        text-align: left;
+        background-color: #FFC35E;
+        /* required by IE */
+        float: left;
+        clear: both;
+        width: 200px;
+    }
+
+    div#nav ul, #subnavigation ul {
+        padding-left: 0px;
+    }
+
+    .content {
+        padding: 0em 0.5em;
+    }
 }
 
 /* Main Table
@@ -406,6 +512,14 @@ table.eventlist tbody tr td.ColumnSources {
     margin: 0px auto;
     display: block;
     border: solid 1px #EA8414;
+    max-width: 800px;
+    height: auto;
+}
+
+@media only screen and (max-width: 1080px) {
+    #GalleryDisplay img {
+        max-width: 100%;
+    }
 }
 #GalleryDetail h3 {
     text-align: center;
@@ -423,13 +537,10 @@ div#SourceDetail {
     overflow: hidden;
 }
 #Contact #summaryarea {
-    width: 40em;
-    margin: 2em auto;
-    padding: 3em;
     background-color: #FFE09F;
     border: solid 1px #EA8414;
 }
-#Contact img {
+#Contact #summaryarea #GalleryDisplay img {
     float: right;
     border: solid 1px #EA8414;
 }
@@ -456,13 +567,24 @@ div#SourceDetail {
 
 /* Subsection
 ----------------------------------------------------- */
-#Home, #Introduction {
-    overflow: hidden;
-}
-#Home img, #Introduction img {
+#Home #GalleryDisplay, #Introduction #GalleryDisplay, #Contact #GalleryDisplay {
     float: right;
-    margin: 1em;
+    margin: 0;
+    border: 0px;
+}
+#Home #GalleryDisplay img, #Introduction #GalleryDisplay img,
+      #Contact #GalleryDisplay img {
+    display: block;
     max-width: 950px;
+    height: auto;
+    float: right;
+}
+@media only screen and (max-width: 1080px) {
+    #Home #GalleryDisplay img, #Introduction #GalleryDisplay img,
+          #Contact #GalleryDisplay img {
+        margin: 0 auto;
+        max-width: 100%;
+    }
 }
 #Home p, #Introduction p {
     padding-left: 15px;
@@ -492,12 +614,33 @@ div#families table.attrlist td.ColumnType {
 
 /* Subsection : Gallery
 ----------------------------------------------------- */
+#gallery {
+    background-color: green;
+}
+#indivgallery {
+    background-color: white;
+}
+#gallery .gallerycell {
+    float: left;
+    width: 130px;
+    height: 150px;
+    text-align: center;
+    margin: 0;
+    background-color: white;
+    border-top: solid 1px #999;
+    border-right: solid 1px #999;
+}
+#gallery .thumbnail {
+    font-size: smaller;
+    margin: 3em auto;
+}
 #indivgallery .thumbnail {
     float: left;
     width: 130px;
     font-size: smaller;
     text-align: center;
     margin: 0.8em 0.5em;
+    background-color: white;
 }
 #indivgallery h4 + .thumbnail {
     margin-left: 15px;
@@ -505,12 +648,49 @@ div#families table.attrlist td.ColumnType {
      *          first thumnail on each next row should also have a margin-left
      *          of 15 px. */
 }
+#gallery div.indexno {
+    float: right;
+    width: 1.8em;
+    font-size: large;
+    text-align: center;
+    background-color: #CCC;
+    color: #555;
+    margin: 0;
+}
+#indivgallery div.date {
+    float: right;
+    width: 1.8em;
+    font-size: large;
+    text-align: center;
+    background-color: #CCC;
+    color: #555;
+}
+#indivgallery .thumbnail ul {
+    font-size: smaller;
+    list-style: none;
+    padding: 0px;
+}
+#indivgallery .thumbnail ul li:first-child {
+    border-style: none;
+}
+#indivgallery .thumbnail ul li {
+    border-top: dashed 1px #CCC;
+    border-top-style: dashed;
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+}
+#gallery img {
+    border: solid 1px #999;
+}
 #indivgallery img {
     border: solid 1px #8C581C;
 }
 #indivgallery span {
 /* ## remove this line and the comment markers from the line below to hide description in Indivifual Gallery
     display: none; */
+}
+div.snapshot div.thumbnail {
+    text-align: center;
 }
 
 /* Subsection : Narrative
@@ -575,6 +755,7 @@ a.familymap {
 }
 #footer > * {
     background-color: #FFE09F;
+    font-size: 80%;
 }
 #footer p#createdate {
     float: left;

--- a/data/css/Web_Basic-Spruce.css
+++ b/data/css/Web_Basic-Spruce.css
@@ -21,6 +21,9 @@ Copyright 2008 Jason M. Simanek
 Copyright 2009 Stephane Charette
 Copyright (C) 2008-2011 Rob G. Healey <robhealey1@gmail.com>
 Copyright 2011 Michiel D. Nauta
+Copyright 2018 Theo van Rijn
+Copyright (C) 2019      Serge Noiraud
+
 
 This file is part of the GRAMPS program.
 
@@ -59,12 +62,19 @@ the page.
 
 body {
     font-family: sans-serif;
-    font-size: 90%;
+    font-size: 100%;
     color: black;
     margin: 0px;
     background-color: #EAEEF4;
 }
 body > div {
+    clear: both;
+}
+#outerwrapper {
+    margin: 5px auto;
+    width: 98%;
+}
+#outerwrapper > div {
     clear: both;
 }
 .content {
@@ -75,8 +85,18 @@ body > div {
     float: right;
     margin: 2em;
 }
+#ThumbnailPreview div.snapshot {
+    float: right;
+    margin: 0;
+}
 .fullclear {
     clear: both;
+}
+/* Less whitespace on smaller real estate. */
+@media only screen and (max-width: 1080px) {
+    .content {
+        padding: 0em 0.5em;
+    }
 }
 
 /* General Text
@@ -205,6 +225,93 @@ div#alphanav ul li a:hover {
     text-decoration: none;
     background-color: black;
     color: #FFF;
+}
+
+/* Responsive navigation */
+a.navIcon {
+    display: none;
+}
+
+div#header::after {
+    content: "";
+    clear: both;
+    display: table;
+}
+
+div#nav::after {
+    content: "";
+    clear: both;
+    display: table;
+}
+
+@media only screen and (max-width: 1080px) {
+
+    /* Use less & all realestate on mobiles. */
+    div#outerwrapper {
+        margin: 5px auto;
+        width: 100%;
+    }
+
+    .nav {
+        background: none; /* Works in IE too. */
+/*
+        width: 200px;
+        position: absolute;
+        z-index: 10;
+*/
+    }
+
+    /* Undo some of the #nav styles  - to enable the class .nav */
+    .nav ul, #subnavigation ul {
+        list-style: none;
+        min-width: unset;
+        width: 200px;
+        height: 32px;
+        margin: 0;
+        padding: 0;
+    }
+    .nav ul li, #subnavigation ul li {
+        float: unset;
+        display: unset
+    }
+
+    /* Start with hidden menu options */
+    /* .nav li:not(:first-child) {display: none;} */
+    .nav li {display: none;}
+    .nav ul {display: none;}
+
+    a.navIcon {
+        font-size:1.3em;
+        display: block;
+        margin: 0.1em 0.4em 0.4em 0.4em;
+        float: left;
+    }
+
+    .nav.responsive {position: absolute; display: block; z-index: 100;}
+    .nav.responsive a.icon {
+        position: absolute;
+        right: 0;
+        top: 0;
+        margin-right: 10px;
+    }
+    .nav.responsive li {
+        /* float: left; */
+        display: block;
+        text-align: left;
+        background-color: #EEE;
+        /* required by IE */
+        float: left;
+        clear: both;
+        width: 200px;
+    }
+
+    div#nav ul, #subnavigation ul {
+        padding-left: 0px;
+    }
+
+    .content {
+        padding: 0em 0.5em;
+    }
 }
 
 /* Main Table
@@ -406,6 +513,14 @@ table.eventlist tbody tr td.ColumnSources {
     margin: 0px auto;
     display: block;
     border: solid 1px #7CA3DD;
+    max-width: 800px;
+    height: auto;
+}
+
+@media only screen and (max-width: 1080px) {
+    #GalleryDisplay img {
+        max-width: 100%;
+    }
 }
 #GalleryDetail h3 {
     text-align: center;
@@ -423,13 +538,10 @@ div#SourceDetail {
     overflow: hidden;
 }
 #Contact #summaryarea {
-    width: 40em;
-    margin: 2em auto;
-    padding: 3em;
     background-color: #EAEEF4;
     border: solid 1px #7CA3DD;
 }
-#Contact img {
+#Contact #summaryarea #GalleryDisplay img {
     float: right;
     border: solid 1px #7CA3DD;
 }
@@ -456,20 +568,31 @@ div#SourceDetail {
 
 /* Subsection
 ----------------------------------------------------- */
-#Home, #Introduction {
-    overflow: hidden;
-}
-#Home img, #Introduction img {
+#Home #GalleryDisplay, #Introduction #GalleryDisplay, #Contact #GalleryDisplay {
     float: right;
-    margin: 1em;
+    margin: 0;
+    border: 0px;
+}
+#Home #GalleryDisplay img, #Introduction #GalleryDisplay img,
+      #Contact #GalleryDisplay img {
+    display: block;
     max-width: 950px;
+    height: auto;
+    float: right;
+}
+@media only screen and (max-width: 1080px) {
+    #Home #GalleryDisplay img, #Introduction #GalleryDisplay img,
+          #Contact #GalleryDisplay img {
+        margin: 0 auto;
+        max-width: 100%;
+    }
 }
 #Home p, #Introduction p {
     padding-left: 15px;
 }
 .subsection {
     clear: both;
-    overflow: visible;
+    overflow: hidden;
 }
 .subsection p {
     margin: 0px;
@@ -492,12 +615,33 @@ div#families table.attrlist td.ColumnType {
 
 /* Subsection : Gallery
 ----------------------------------------------------- */
+#gallery {
+    background-color: green;
+}
+#indivgallery {
+    background-color: white;
+}
+#gallery .gallerycell {
+    float: left;
+    width: 130px;
+    height: 150px;
+    text-align: center;
+    margin: 0;
+    background-color: white;
+    border-top: solid 1px #999;
+    border-right: solid 1px #999;
+}
+#gallery .thumbnail {
+    font-size: smaller;
+    margin: 3em auto;
+}
 #indivgallery .thumbnail {
     float: left;
     width: 130px;
     font-size: smaller;
     text-align: center;
     margin: 0.8em 0.5em;
+    background-color: white;
 }
 #indivgallery h4 + .thumbnail {
     margin-left: 15px;
@@ -505,12 +649,49 @@ div#families table.attrlist td.ColumnType {
      *          first thumnail on each next row should also have a margin-left
      *          of 15 px. */
 }
+#gallery div.indexno {
+    float: right;
+    width: 1.8em;
+    font-size: large;
+    text-align: center;
+    background-color: #CCC;
+    color: #555;
+    margin: 0;
+}
+#indivgallery div.date {
+    float: right;
+    width: 1.8em;
+    font-size: large;
+    text-align: center;
+    background-color: #CCC;
+    color: #555;
+}
+#indivgallery .thumbnail ul {
+    font-size: smaller;
+    list-style: none;
+    padding: 0px;
+}
+#indivgallery .thumbnail ul li:first-child {
+    border-style: none;
+}
+#indivgallery .thumbnail ul li {
+    border-top: dashed 1px #CCC;
+    border-top-style: dashed;
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+}
+#gallery img {
+    border: solid 1px #999;
+}
 #indivgallery img {
     border: solid 1px #7CA3DD;
 }
 #indivgallery span {
 /* ## remove this line and the comment markers from the line below to hide description in Indivifual Gallery
     display: none; */
+}
+div.snapshot div.thumbnail {
+    text-align: center;
 }
 
 /* Subsection : Narrative
@@ -575,6 +756,7 @@ a.familymap {
 }
 #footer > * {
     background-color: #EAEEF4;
+    font-size: 80%;
 }
 #footer p#createdate {
     float: left;

--- a/data/css/Web_Mainz.css
+++ b/data/css/Web_Mainz.css
@@ -19,6 +19,8 @@ Copyright 2008 Jason M. Simanek
 Copyright 2009 Stephane Charette
 Copyright (C) 2008-2011 Rob G. Healey <robhealey1@gmail.com>
 Copyright 2011 Michiel D. Nauta
+Copyright 2018 Theo van Rijn
+Copyright (C) 2019      Serge Noiraud
 
 This file is part of the GRAMPS program.
 
@@ -62,7 +64,7 @@ General Elements
 -----------------------------------------------------------------*/
 body {
     font-family: Georgia, serif;
-    font-size: 90%;
+    font-size: 100%;
     color: #7D5925;
     background: url(../images/Web_Mainz_Bkgd.png) black repeat;
 }
@@ -73,8 +75,19 @@ body > div {
     overflow: hidden;
     padding: 0px 1.5em;
 }
+#outerwrapper {
+    margin: 5px auto;
+    width: 98%;
+}
+#outerwrapper > div {
+    clear: both;
+}
 .content {
     padding: 1.5em 1.5em;
+}
+#ThumbnailPreview div.snapshot {
+    float: right;
+    margin: 0;
 }
 div.snapshot div.thumbnail {
     text-align: center;
@@ -82,6 +95,13 @@ div.snapshot div.thumbnail {
 div.snapshot a {
     display: inline;
 }
+/* Less whitespace on smaller real estate. */
+@media only screen and (max-width: 1080px) {
+    .content {
+        padding: 0em 0.5em;
+    }
+}
+
 
 /* General Text
 -----------------------------------------------------------------*/
@@ -202,6 +222,93 @@ div#alphanav ul li a:hover {
     text-decoration: none;
     background-color: black;
     color: white;
+}
+
+/* Responsive navigation */
+a.navIcon {
+    display: none;
+}
+
+div#header::after {
+    content: "";
+    clear: both;
+    display: table;
+}
+
+div#nav::after {
+    content: "";
+    clear: both;
+    display: table;
+}
+
+@media only screen and (max-width: 1080px) {
+
+    /* Use less & all realestate on mobiles. */
+    div#outerwrapper {
+        margin: 5px auto;
+        width: 100%;
+    }
+
+    .nav {
+        background: none; /* Works in IE too. */
+/*
+        width: 200px;
+        position: absolute;
+        z-index: 10;
+*/
+    }
+
+    /* Undo some of the #nav styles  - to enable the class .nav */
+    .nav ul, #subnavigation ul {
+        list-style: none;
+        min-width: unset;
+        width: 200px;
+        height: 32px;
+        margin: 0;
+        padding: 0;
+    }
+    .nav ul li, #subnavigation ul li {
+        float: unset;
+        display: unset
+    }
+
+    /* Start with hidden menu options */
+    /* .nav li:not(:first-child) {display: none;} */
+    .nav li {display: none;}
+    .nav ul {display: none;}
+
+    a.navIcon {
+        font-size:1.3em;
+        display: block;
+        margin: 0.1em 0.4em 0.4em 0.4em;
+        float: left;
+    }
+
+    .nav.responsive {position: absolute; display: block; z-index: 100;}
+    .nav.responsive a.icon {
+        position: absolute;
+        right: 0;
+        top: 0;
+        margin-right: 10px;
+    }
+    .nav.responsive li {
+        /* float: left; */
+        display: block;
+        text-align: left;
+        background-color: #D8C19F;
+        /* required by IE */
+        float: left;
+        clear: both;
+        width: 200px;
+    }
+
+    div#nav ul, #subnavigation ul {
+        padding-left: 0px;
+    }
+
+    .content {
+        padding: 0em 0.5em;
+    }
 }
 
 /* Main Table
@@ -361,6 +468,14 @@ table.eventlist tbody tr td.ColumnSources {
     margin: 0px auto;
     display:block;
     border: solid 1px #7D5925;
+    max-width: 800px;
+    height: auto;
+}
+
+@media only screen and (max-width: 1080px) {
+    #GalleryDisplay img {
+        max-width: 100%;
+    }
 }
 
 /*    Sources
@@ -376,7 +491,7 @@ div#SourceDetail {
     padding-bottom: 0px;
     margin: 0px;
 }
-#Contact img {
+#Contact #summaryarea #GalleryDisplay img {
     display: block;
     margin: 0px auto 1em auto;
     border: solid 1px #7D5925;
@@ -402,16 +517,31 @@ div#SourceDetail {
 
 /* SubSection
 -----------------------------------------------------------------*/
-#Home img, #Introduction img {
+#Home #GalleryDisplay, #Introduction #GalleryDisplay, #Contact #GalleryDisplay {
+    float: right;
+    margin-left: 10px;
+    margin-right: 10px;
+}
+#Home #GalleryDisplay img, #Introduction #GalleryDisplay img,
+      #Contact #GalleryDisplay {
     display: block;
-    margin: 1em auto;
     max-width: 950px;
+    height: auto;
+    float: right;
+}
+@media only screen and (max-width: 1080px) {
+    #Home #GalleryDisplay img, #Introduction #GalleryDisplay img,
+          #Contact #GalleryDisplay {
+        margin: 0 auto;
+        max-width: 100%;
+    }
 }
 #Home a, #Introduction a, #Contact a {
     color: black;
 }
 .subsection {
     clear: both;
+    overflow: hidden;
 }
 .subsection p {
     margin: 0px;
@@ -428,9 +558,32 @@ div#families table.fixed_subtables table.eventlist th:first-child {
 div#families table.fixed_subtables table.eventlist th:last-child {
     width: 5em;
 }
+div#families .infolist h4 {
+    text-align: left;
+}
 
 /* SubSection : Gallery
 -----------------------------------------------------------------*/
+#gallery {
+    background-color: green;
+}
+#indivgallery {
+    background-color: white;
+}
+#gallery .gallerycell {
+    float: left;
+    width: 130px;
+    height: 150px;
+    text-align: center;
+    margin: 0;
+    background-color: white;
+    border-top: solid 1px #999;
+    border-right: solid 1px #999;
+}
+#gallery .thumbnail {
+    font-size: smaller;
+    margin: 3em auto;
+}
 #indivgallery {
     /* float container stretch, see www.quirksmode.org/css/clearing.html */
     overflow: hidden;
@@ -441,6 +594,7 @@ div#families table.fixed_subtables table.eventlist th:last-child {
     font-size: smaller;
     text-align: center;
     margin: 0.5em;
+    background-color: white;
 }
 #indivgallery img {
     border: solid 1px #7D5925;
@@ -448,6 +602,43 @@ div#families table.fixed_subtables table.eventlist th:last-child {
 #indivgallery span {
 /* ## remove this line and the comment markers from the line below to hide the description in Individual Gallery
     display: none; */
+}
+#gallery div.indexno {
+    float: right;
+    width: 1.8em;
+    font-size: large;
+    text-align: center;
+    background-color: #CCC;
+    color: #555;
+    margin: 0;
+}
+#indivgallery div.date {
+    float: right;
+    width: 1.8em;
+    font-size: large;
+    text-align: center;
+    background-color: #CCC;
+    color: #555;
+}
+#indivgallery .thumbnail ul {
+    font-size: smaller;
+    list-style: none;
+    padding: 0px;
+}
+#indivgallery .thumbnail ul li:first-child {
+    border-style: none;
+}
+#indivgallery .thumbnail ul li {
+    border-top: dashed 1px #CCC;
+    border-top-style: dashed;
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+}
+#gallery img {
+    border: solid 1px #999;
+}
+div.snapshot div.thumbnail {
+    text-align: center;
 }
 
 /* SubSection : Narrative
@@ -514,6 +705,9 @@ div.grampsstylednote p {
     float: right;
     width: 40%;
     text-align: right;
+}
+#footer > * {
+    font-size: 80%;
 }
 
 /* Overwritten

--- a/data/css/Web_Nebraska.css
+++ b/data/css/Web_Nebraska.css
@@ -19,6 +19,8 @@ Go to <http://gramps-project.org/> to learn more!
 Copyright 2008 Jason M. Simanek
 Copyright 2009 Stephane Charette
 Copyright (C) 2008-2011 Rob G. Healey <robhealey1@gmail.com>
+Copyright 2018 Theo van Rijn
+Copyright (C) 2019      Serge Noiraud
 
 This file is part of the GRAMPS program.
 
@@ -82,9 +84,20 @@ img {
 .thumbnail a:hover {
     background:none;
 }
+#outerwrapper {
+    margin: 5px auto;
+    width: 98%;
+}
+#outerwrapper > div {
+    clear: both;
+}
 .content {
     padding-top: 1cm;
     background-color:#FFF;
+}
+#ThumbnailPreview div.snapshot {
+    float: right;
+    margin: 0;
 }
 .content div.snapshot {
     float:right;
@@ -99,6 +112,12 @@ img {
 }
 .content div.snapshot div.thumbnail span {
     display:none;
+}
+/* Less whitespace on smaller real estate. */
+@media only screen and (max-width: 1080px) {
+    .content {
+        padding: 0em 0.5em;
+    }
 }
 .fullclear {
     width:100%;
@@ -252,6 +271,100 @@ div#nav ul li.CurrentSection a:hover {
 }
 div#subnavigation ul li.CurrentSection a {
     border-width: 0 0 1px 0;
+}
+
+/* Responsive navigation */
+a.navIcon {
+    display: none;
+    color: #FFF;
+}
+
+div#header::after {
+    content: "";
+    clear: both;
+    display: table;
+}
+
+div#nav::after {
+    content: "";
+    clear: both;
+    display: table;
+}
+
+@media only screen and (max-width: 1080px) {
+
+    /* Use less & all realestate on mobiles. */
+    div#outerwrapper {
+        margin: 5px auto;
+        width: 100%;
+    }
+
+    .nav {
+        background: none; /* Works in IE too. */
+/*
+        width: 200px;
+        position: absolute;
+        z-index: 10;
+*/
+    }
+
+    /* Undo some of the #nav styles  - to enable the class .nav */
+    .nav ul, #subnavigation ul {
+        list-style: none;
+        min-width: unset;
+        width: 200px;
+        height: 32px;
+        margin: 0;
+        padding: 0;
+    }
+    .nav ul li, #subnavigation ul li {
+        float: unset;
+        display: unset
+    }
+
+    /* Start with hidden menu options */
+    /* .nav li:not(:first-child) {display: none;} */
+    .nav li {display: none;}
+    .nav ul {display: none;}
+
+    a.navIcon {
+        font-size:1.3em;
+        display: block;
+        margin: 0.1em 0.4em 0.4em 0.4em;
+        float: left;
+    color: #FFF;
+    }
+
+    .nav.responsive {position: absolute; display: block; z-index: 100;}
+    .nav.responsive a.icon {
+        position: absolute;
+        right: 0;
+        top: 0;
+        margin-right: 10px;
+    }
+    .nav.responsive ::after {
+        /* need to remove the "|" when we are in the dropdown menu. */
+        color: #A97;
+        background-color: #A97;
+    }
+    .nav.responsive li {
+        /* float: left; */
+        display: block;
+        text-align: left;
+        background-color: #A97;
+        /* required by IE */
+        float: left;
+        clear: both;
+        width: 200px;
+    }
+
+    div#nav ul, #subnavigation ul {
+        padding-left: 0px;
+    }
+
+    .content {
+        padding: 0em 0.5em;
+    }
 }
 
 /* Main Table
@@ -634,6 +747,14 @@ table.eventlist tbody tr td.ColumnSources {
 }
 #GalleryDisplay img {
     margin:0 auto;
+    max-width: 800px;
+    height: auto;
+}
+
+@media only screen and (max-width: 1080px) {
+    #GalleryDisplay img {
+        max-width: 100%;
+    }
 }
 #GalleryDetail div#summaryarea{
     margin:0;
@@ -679,7 +800,6 @@ body#ThumbnailPreview div#references table.infolist tbody tr td.ColumnName {
 /* Contact
 ----------------------------------------------------- */
 #Contact #summaryarea {
-    width:500px;
     margin:0 auto;
     padding:3em;
     background-color:#F1ECE2;
@@ -697,7 +817,6 @@ body#ThumbnailPreview div#references table.infolist tbody tr td.ColumnName {
     padding:0;
 }
 #researcher span {
-    float:left;
     display:block;
     font:normal .9em/1.4em serif;
     margin-right:.4em;
@@ -779,20 +898,32 @@ table.download td.Modified {
 
 /* Subsections
 ----------------------------------------------------- */
-#Home, #Introduction, #Contact {
-    padding:2em 0 3em 0;
+#Home #GalleryDisplay, #Introduction #GalleryDisplay, #Contact #GalleryDisplay {
+    float: right;
+    margin-left: 10px;
+    margin-right: 10px;
 }
+#Home #GalleryDisplay img, #Introduction #GalleryDisplay img,
+      #Contact #GalleryDisplay img {
+    display: block;
+    max-width: 950px;
+    height: auto;
+    float: right;
+}
+@media only screen and (max-width: 1080px) {
+    #Home #GalleryDisplay img, #Introduction #GalleryDisplay img,
+          #Contact #GalleryDisplay img {
+        max-width: 100%;
+    }
+}
+
 #Home p, #Introduction p {
     margin:0 20px 1em 20px;
-}
-#Home img, #Introduction img {
-    float:right;
-    margin:0;
-    padding:0 20px 3em 2em;
 }
 #Home a, #Introduction a, #Contact a {
     color: #000;
     text-decoration: none;
+    overflow: hidden;
 }
 div.subsection{
     padding-bottom:.5em;
@@ -926,6 +1057,26 @@ div#Addresses table.infolist tr td a, div#Addresses table.infolist tr td p a {
 
 /* Subsections : Gallery
 ----------------------------------------------------- */
+#gallery {
+    background-color: green;
+}
+#indivgallery {
+    background-color: white;
+}
+#gallery .gallerycell {
+    float: left;
+    width: 130px;
+    height: 150px;
+    text-align: center;
+    margin: 0;
+    background-color: white;
+    border-top: solid 1px #999;
+    border-right: solid 1px #999;
+}
+#gallery .thumbnail {
+    font-size: smaller;
+    margin: 3em auto;
+}
 #indivgallery h4 {
     margin-bottom:1em;
 }
@@ -934,6 +1085,41 @@ div#Addresses table.infolist tr td a, div#Addresses table.infolist tr td p a {
     float:left;
     width:130px;
     text-align:center;
+    background-color: white;
+}
+#gallery div.indexno {
+    float: right;
+    width: 1.8em;
+    font-size: large;
+    text-align: center;
+    background-color: #CCC;
+    color: #555;
+    margin: 0;
+}
+#indivgallery div.date {
+    float: right;
+    width: 1.8em;
+    font-size: large;
+    text-align: center;
+    background-color: #CCC;
+    color: #555;
+}
+#indivgallery .thumbnail ul {
+    font-size: smaller;
+    list-style: none;
+    padding: 0px;
+}
+#indivgallery .thumbnail ul li:first-child {
+    border-style: none;
+}
+#indivgallery .thumbnail ul li {
+    border-top: dashed 1px #CCC;
+    border-top-style: dashed;
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+}
+#gallery img {
+    border: solid 1px #999;
 }
 #indivgallery .thumbnail a {
     display:block;
@@ -956,6 +1142,9 @@ div#Addresses table.infolist tr td a, div#Addresses table.infolist tr td p a {
     width:80%;
     margin:0 auto;
     padding:0;
+}
+div.snapshot div.thumbnail {
+    text-align: center;
 }
 
 /* Subsections : Narrative
@@ -1069,6 +1258,9 @@ div#pedigree {
     padding: 0;
     background-color: #542;
     border-top: solid 8px #A97;
+}
+#footer > * {
+    font-size: 80%;
 }
 #footer a, #footer a:visited {
     text-decoration: none;

--- a/gramps/plugins/webreport/addressbook.py
+++ b/gramps/plugins/webreport/addressbook.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2008-2011  Rob G. Healey <robhealey1@gmail.com>
 # Copyright (C) 2010       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2010       Jakim Friant
-# Copyright (C) 2010-2017  Serge Noiraud
+# Copyright (C) 2010-      Serge Noiraud
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Benny Malengier
 # Copyright (C) 2016       Allen Crider
@@ -84,12 +84,13 @@ class AddressBookPage(BasePage):
 
         # set the file name and open file
         output_file, sio = self.report.create_file(person_handle, "addr")
-        addressbookpage, head, body = self.write_header(_("Address Book"))
+        result = self.write_header(_("Address Book"))
+        addressbookpage, dummy_head, dummy_body, outerwrapper = result
 
         # begin address book page division and section title
         with Html("div", class_="content",
                   id="AddressBookDetail") as addressbookdetail:
-            body += addressbookdetail
+            outerwrapper += addressbookdetail
 
             link = self.new_person_link(person_handle, uplink=True,
                                         person=person)
@@ -113,7 +114,7 @@ class AddressBookPage(BasePage):
         # add fullclear for proper styling
         # and footer section to page
         footer = self.write_footer(None)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send page out for processing
         # and close the file

--- a/gramps/plugins/webreport/addressbooklist.py
+++ b/gramps/plugins/webreport/addressbooklist.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2008-2011  Rob G. Healey <robhealey1@gmail.com>
 # Copyright (C) 2010       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2010       Jakim Friant
-# Copyright (C) 2010-2017  Serge Noiraud
+# Copyright (C) 2010-      Serge Noiraud
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Benny Malengier
 # Copyright (C) 2016       Allen Crider
@@ -78,12 +78,13 @@ class AddressBookListPage(BasePage):
         output_file, sio = self.report.create_file("addressbook")
 
         # Add xml, doctype, meta and stylesheets
-        addressbooklistpage, head, body = self.write_header(_("Address Book"))
+        result = self.write_header(_("Address Book"))
+        addressbooklistpage, dummy_head, dummy_body, outerwrapper = result
 
         # begin AddressBookList division
         with Html("div", class_="content",
                   id="AddressBookList") as addressbooklist:
-            body += addressbooklist
+            outerwrapper += addressbooklist
 
             # Address Book Page message
             msg = _("This page contains an index of all the individuals in "
@@ -119,7 +120,7 @@ class AddressBookListPage(BasePage):
                 table += tbody
 
                 index = 1
-                for (sort_name, person_handle,
+                for (dummy_sort_name, person_handle,
                      has_add, has_res,
                      has_url) in has_url_addr_res:
 
@@ -163,7 +164,7 @@ class AddressBookListPage(BasePage):
 
         # Add footer and clearline
         footer = self.write_footer(None)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send the page out for processing
         # and close the file

--- a/gramps/plugins/webreport/citation.py
+++ b/gramps/plugins/webreport/citation.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2008-2011  Rob G. Healey <robhealey1@gmail.com>
 # Copyright (C) 2010       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2010       Jakim Friant
-# Copyright (C) 2010-2017  Serge Noiraud
+# Copyright (C) 2010-      Serge Noiraud
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Benny Malengier
 # Copyright (C) 2016       Allen Crider

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -3,7 +3,7 @@
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2010-2017  Serge Noiraud
+# Copyright (C) 2010-      Serge Noiraud
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -31,7 +31,6 @@ from unicodedata import normalize
 from collections import defaultdict
 from hashlib import md5
 import re
-import gc
 import logging
 from xml.sax.saxutils import escape
 
@@ -351,6 +350,7 @@ def sort_event_types(dbase, event_types, event_handle_list, rlocale):
 def _get_short_name(gender, name):
     """ Will get suffix for all people passed through it """
 
+    dummy_gender = gender
     short_name = name.get_first_name()
     suffix = name.get_suffix()
     if suffix:
@@ -475,6 +475,7 @@ def first_letter(string, rlocale=glocale):
     """
     Receives a string and returns the first letter
     """
+    dummy_rlocale = rlocale
     if string is None or len(string) < 1:
         return ' '
 
@@ -502,6 +503,7 @@ try:
         """
         Try to use the PyICU collation.
         """
+        dummy_rlocale = rlocale
 
         return PRIM_COLL.compare(prev_key, new_key) != 0
 
@@ -618,7 +620,7 @@ def alphabet_navigation(index_list, rlocale=glocale):
     with Html("div", id="alphanav") as alphabetnavigation:
 
         index = 0
-        for row in range(num_of_rows):
+        for dummy_row in range(num_of_rows):
             unordered = Html("ul")
 
             cols = 0

--- a/gramps/plugins/webreport/contact.py
+++ b/gramps/plugins/webreport/contact.py
@@ -12,10 +12,11 @@
 # Copyright (C) 2008-2011  Rob G. Healey <robhealey1@gmail.com>
 # Copyright (C) 2010       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2010       Jakim Friant
-# Copyright (C) 2010-2017  Serge Noiraud
+# Copyright (C) 2010-      Serge Noiraud
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Benny Malengier
 # Copyright (C) 2016       Allen Crider
+# Copyright (C) 2018       Theo van Rijn
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -73,17 +74,18 @@ class ContactPage(BasePage):
         BasePage.__init__(self, report, title)
 
         output_file, sio = self.report.create_file("contact")
-        contactpage, head, body = self.write_header(self._('Contact'))
+        result = self.write_header(self._('Contact'))
+        contactpage, head, dummy_body, outerwrapper = result
 
         # begin contact division
         with Html("div", class_="content", id="Contact") as section:
-            body += section
+            outerwrapper += section
 
             # begin summaryarea division
             with Html("div", id='summaryarea') as summaryarea:
                 section += summaryarea
 
-                contactimg = self.add_image('contactimg', 200)
+                contactimg = self.add_image('contactimg', head, 200)
                 if contactimg is not None:
                     summaryarea += contactimg
 
@@ -132,7 +134,7 @@ class ContactPage(BasePage):
         # add clearline for proper styling
         # add footer section
         footer = self.write_footer(None)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send page out for porcessing
         # and close the file

--- a/gramps/plugins/webreport/download.py
+++ b/gramps/plugins/webreport/download.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2008-2011  Rob G. Healey <robhealey1@gmail.com>
 # Copyright (C) 2010       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2010       Jakim Friant
-# Copyright (C) 2010-2017  Serge Noiraud
+# Copyright (C) 2010-      Serge Noiraud
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Benny Malengier
 # Copyright (C) 2016       Allen Crider
@@ -91,11 +91,12 @@ class DownloadPage(BasePage):
         if dlfname1 or dlfname2:
 
             output_file, sio = self.report.create_file("download")
-            downloadpage, head, body = self.write_header(self._('Download'))
+            result = self.write_header(self._('Download'))
+            downloadpage, dummy_head, dummy_body, outerwrapper = result
 
             # begin download page and table
             with Html("div", class_="content", id="Download") as download:
-                body += download
+                outerwrapper += download
 
                 msg = self._("This page is for the user/ creator "
                              "of this Family Tree/ Narrative website "
@@ -188,7 +189,7 @@ class DownloadPage(BasePage):
             # clear line for proper styling
             # create footer section
             footer = self.write_footer(None)
-            body += (FULLCLEAR, footer)
+            outerwrapper += (FULLCLEAR, footer)
 
             # send page out for processing
             # and close the file

--- a/gramps/plugins/webreport/event.py
+++ b/gramps/plugins/webreport/event.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2008-2011  Rob G. Healey <robhealey1@gmail.com>
 # Copyright (C) 2010       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2010       Jakim Friant
-# Copyright (C) 2010-2017  Serge Noiraud
+# Copyright (C) 2010-      Serge Noiraud
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Benny Malengier
 # Copyright (C) 2016       Allen Crider
@@ -138,11 +138,12 @@ class EventPages(BasePage):
         prev_letter = " "
 
         output_file, sio = self.report.create_file("events")
-        eventslistpage, head, body = self.write_header(self._("Events"))
+        result = self.write_header(self._("Events"))
+        eventslistpage, dummy_head, dummy_body, outerwrapper = result
 
         # begin events list  division
         with Html("div", class_="content", id="EventList") as eventlist:
-            body += eventlist
+            outerwrapper += eventlist
 
             msg = self._("This page contains an index of all the events in the "
                          "database, sorted by their type and date (if one is "
@@ -196,7 +197,7 @@ class EventPages(BasePage):
                     data_list = sorted(data_list, key=itemgetter(0, 1))
                     first_event = True
 
-                    for (sort_value, event_handle) in data_list:
+                    for (dummy_sort_value, event_handle) in data_list:
                         event = self.r_db.get_event_from_handle(event_handle)
                         _type = event.get_type()
                         gid = event.get_gramps_id()
@@ -299,7 +300,7 @@ class EventPages(BasePage):
         # add clearline for proper styling
         # add footer section
         footer = self.write_footer(ldatec)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send page ut for processing
         # and close the file
@@ -350,7 +351,7 @@ class EventPages(BasePage):
         event = report.database.get_event_from_handle(event_handle)
         BasePage.__init__(self, report, title, event.get_gramps_id())
         if not event:
-            return None
+            return
 
         ldatec = event.get_change_time()
         event_media_list = event.get_media_list()
@@ -362,11 +363,12 @@ class EventPages(BasePage):
         self.bibli = Bibliography()
 
         output_file, sio = self.report.create_file(event_handle, "evt")
-        eventpage, head, body = self.write_header(self._("Events"))
+        result = self.write_header(self._("Events"))
+        eventpage, dummy_head, dummy_body, outerwrapper = result
 
         # start event detail division
         with Html("div", class_="content", id="EventDetail") as eventdetail:
-            body += eventdetail
+            outerwrapper += eventdetail
 
             thumbnail = self.disp_first_img_as_thumbnail(event_media_list,
                                                          event)
@@ -442,7 +444,7 @@ class EventPages(BasePage):
         # add clearline for proper styling
         # add footer section
         footer = self.write_footer(ldatec)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send page out for processing
         # and close the page

--- a/gramps/plugins/webreport/family.py
+++ b/gramps/plugins/webreport/family.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2008-2011  Rob G. Healey <robhealey1@gmail.com>
 # Copyright (C) 2010       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2010       Jakim Friant
-# Copyright (C) 2010-2017  Serge Noiraud
+# Copyright (C) 2010-      Serge Noiraud
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Benny Malengier
 # Copyright (C) 2016       Allen Crider
@@ -128,13 +128,14 @@ class FamilyPages(BasePage):
         BasePage.__init__(self, report, title)
 
         output_file, sio = self.report.create_file("families")
-        familieslistpage, head, body = self.write_header(self._("Families"))
+        result = self.write_header(self._("Families"))
+        familieslistpage, dummy_head, dummy_body, outerwrapper = result
         ldatec = 0
         prev_letter = " "
 
         # begin Family Division
         with Html("div", class_="content", id="Relationships") as relationlist:
-            body += relationlist
+            outerwrapper += relationlist
 
             # Families list page message
             msg = self._("This page contains an index of all the "
@@ -299,7 +300,7 @@ class FamilyPages(BasePage):
         # add clearline for proper styling
         # add footer section
         footer = self.write_footer(ldatec)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send page out for processing
         # and close the file
@@ -328,12 +329,13 @@ class FamilyPages(BasePage):
         self.familymappages = report.options["familymappages"]
 
         output_file, sio = self.report.create_file(family.get_handle(), "fam")
-        familydetailpage, head, body = self.write_header(family_name)
+        result = self.write_header(family_name)
+        familydetailpage, dummy_head, dummy_body, outerwrapper = result
 
         # begin FamilyDetaill division
         with Html("div", class_="content",
                   id="RelationshipDetail") as relationshipdetail:
-            body += relationshipdetail
+            outerwrapper += relationshipdetail
 
             # family media list for initial thumbnail
             if self.create_media:
@@ -387,7 +389,7 @@ class FamilyPages(BasePage):
         # add clearline for proper styling
         # add footer section
         footer = self.write_footer(ldatec)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send page out for processing
         # and close the file

--- a/gramps/plugins/webreport/home.py
+++ b/gramps/plugins/webreport/home.py
@@ -12,10 +12,11 @@
 # Copyright (C) 2008-2011  Rob G. Healey <robhealey1@gmail.com>
 # Copyright (C) 2010       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2010       Jakim Friant
-# Copyright (C) 2010-2017  Serge Noiraud
+# Copyright (C) 2010-      Serge Noiraud
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Benny Malengier
 # Copyright (C) 2016       Allen Crider
+# Copyright (C) 2018       Theo van Rijn
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -74,13 +75,14 @@ class HomePage(BasePage):
         ldatec = 0
 
         output_file, sio = self.report.create_file("index")
-        homepage, head, body = self.write_header(self._('Home'))
+        result = self.write_header(self._('Home'))
+        homepage, head, dummy_body, outerwrapper = result
 
         # begin home division
         with Html("div", class_="content", id="Home") as section:
-            body += section
+            outerwrapper += section
 
-            homeimg = self.add_image('homeimg')
+            homeimg = self.add_image('homeimg', head)
             if homeimg is not None:
                 section += homeimg
 
@@ -98,7 +100,7 @@ class HomePage(BasePage):
         # create clear line for proper styling
         # create footer section
         footer = self.write_footer(ldatec)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send page out for processing
         # and close the file

--- a/gramps/plugins/webreport/introduction.py
+++ b/gramps/plugins/webreport/introduction.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2008-2011  Rob G. Healey <robhealey1@gmail.com>
 # Copyright (C) 2010       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2010       Jakim Friant
-# Copyright (C) 2010-2017  Serge Noiraud
+# Copyright (C) 2010-      Serge Noiraud
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Benny Malengier
 # Copyright (C) 2016       Allen Crider
@@ -75,13 +75,14 @@ class IntroductionPage(BasePage):
         ldatec = 0
 
         output_file, sio = self.report.create_file(report.intro_fname)
-        intropage, head, body = self.write_header(self._('Introduction'))
+        result = self.write_header(self._('Introduction'))
+        intropage, head, dummy_body, outerwrapper = result
 
         # begin Introduction division
         with Html("div", class_="content", id="Introduction") as section:
-            body += section
+            outerwrapper += section
 
-            introimg = self.add_image('introimg')
+            introimg = self.add_image('introimg', head)
             if introimg is not None:
                 section += introimg
 
@@ -99,7 +100,7 @@ class IntroductionPage(BasePage):
         # add clearline for proper styling
         # create footer section
         footer = self.write_footer(ldatec)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send page out for processing
         # and close the file

--- a/gramps/plugins/webreport/layout.py
+++ b/gramps/plugins/webreport/layout.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2008-2011  Rob G. Healey <robhealey1@gmail.com>
 # Copyright (C) 2010       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2010       Jakim Friant
-# Copyright (C) 2010-2017  Serge Noiraud
+# Copyright (C) 2010-      Serge Noiraud
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Benny Malengier
 # Copyright (C) 2016       Allen Crider

--- a/gramps/plugins/webreport/place.py
+++ b/gramps/plugins/webreport/place.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2008-2011  Rob G. Healey <robhealey1@gmail.com>
 # Copyright (C) 2010       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2010       Jakim Friant
-# Copyright (C) 2010-2017  Serge Noiraud
+# Copyright (C) 2010-      Serge Noiraud
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Benny Malengier
 # Copyright (C) 2016       Allen Crider
@@ -138,13 +138,14 @@ class PlacePages(BasePage):
         BasePage.__init__(self, report, title)
 
         output_file, sio = self.report.create_file("places")
-        placelistpage, head, body = self.write_header(self._("Places"))
+        result = self.write_header(self._("Places"))
+        placelistpage, dummy_head, dummy_body, outerwrapper = result
         ldatec = 0
         prev_letter = " "
 
         # begin places division
         with Html("div", class_="content", id="Places") as placelist:
-            body += placelist
+            outerwrapper += placelist
 
             # place list page message
             msg = self._("This page contains an index of all the places in the "
@@ -278,7 +279,7 @@ class PlacePages(BasePage):
         # add clearline for proper styling
         # add footer section
         footer = self.write_footer(ldatec)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send page out for processing
         # and close the file
@@ -295,7 +296,7 @@ class PlacePages(BasePage):
         """
         place = report.database.get_place_from_handle(place_handle)
         if not place:
-            return None
+            return
         BasePage.__init__(self, report, title, place.get_gramps_id())
         self.bibli = Bibliography()
         place_name = self.report.obj_dict[Place][place_handle][1]
@@ -304,7 +305,7 @@ class PlacePages(BasePage):
         output_file, sio = self.report.create_file(place_handle, "plc")
         self.uplink = True
         self.page_title = place_name
-        placepage, head, body = self.write_header(_("Places"))
+        placepage, head, body, outerwrapper = self.write_header(_("Places"))
 
         self.placemappages = self.report.options['placemappages']
         self.mapservice = self.report.options['mapservice']
@@ -312,7 +313,7 @@ class PlacePages(BasePage):
 
         # begin PlaceDetail Division
         with Html("div", class_="content", id="PlaceDetail") as placedetail:
-            body += placedetail
+            outerwrapper += placedetail
 
             if self.create_media:
                 media_list = place.get_media_list()
@@ -460,7 +461,7 @@ class PlacePages(BasePage):
         # add clearline for proper styling
         # add footer section
         footer = self.write_footer(ldatec)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send page out for processing
         # and close the file

--- a/gramps/plugins/webreport/repository.py
+++ b/gramps/plugins/webreport/repository.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2008-2011  Rob G. Healey <robhealey1@gmail.com>
 # Copyright (C) 2010       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2010       Jakim Friant
-# Copyright (C) 2010-2017  Serge Noiraud
+# Copyright (C) 2010-      Serge Noiraud
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Benny Malengier
 # Copyright (C) 2016       Allen Crider
@@ -115,7 +115,7 @@ class RepositoryPages(BasePage):
             self.repositorylistpage(self.report, title, repos_dict, keys)
 
             idx = 1
-            for index, key in enumerate(keys):
+            for dummy_index, key in enumerate(keys):
                 (repo, handle) = repos_dict[key]
                 step()
                 idx += 1
@@ -135,13 +135,14 @@ class RepositoryPages(BasePage):
         #inc_repos = self.report.options["inc_repository"]
 
         output_file, sio = self.report.create_file("repositories")
-        repolistpage, head, body = self.write_header(_("Repositories"))
+        result = self.write_header(_("Repositories"))
+        repolistpage, dummy_head, dummy_body, outerwrapper = result
 
         ldatec = 0
         # begin RepositoryList division
         with Html("div", class_="content",
                   id="RepositoryList") as repositorylist:
-            body += repositorylist
+            outerwrapper += repositorylist
 
             msg = self._("This page contains an index of "
                          "all the repositories in the "
@@ -199,7 +200,7 @@ class RepositoryPages(BasePage):
         # add clearline for proper styling
         # add footer section
         footer = self.write_footer(ldatec)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send page out for processing
         # and close the file
@@ -220,12 +221,13 @@ class RepositoryPages(BasePage):
 
         output_file, sio = self.report.create_file(handle, 'repo')
         self.uplink = True
-        repositorypage, head, body = self.write_header(_('Repositories'))
+        result = self.write_header(_('Repositories'))
+        repositorypage, dummy_head, dummy_body, outerwrapper = result
 
         # begin RepositoryDetail division and page title
         with Html("div", class_="content",
                   id="RepositoryDetail") as repositorydetail:
-            body += repositorydetail
+            outerwrapper += repositorydetail
 
             # repository name
             repositorydetail += Html("h3", html_escape(repo.name),
@@ -281,7 +283,7 @@ class RepositoryPages(BasePage):
         # add clearline for proper styling
         # add footer section
         footer = self.write_footer(ldatec)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send page out for processing
         # and close the file

--- a/gramps/plugins/webreport/source.py
+++ b/gramps/plugins/webreport/source.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2008-2011  Rob G. Healey <robhealey1@gmail.com>
 # Copyright (C) 2010       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2010       Jakim Friant
-# Copyright (C) 2010-2017  Serge Noiraud
+# Copyright (C) 2010-      Serge Noiraud
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Benny Malengier
 # Copyright (C) 2016       Allen Crider
@@ -127,11 +127,12 @@ class SourcePages(BasePage):
         source_dict = {}
 
         output_file, sio = self.report.create_file("sources")
-        sourcelistpage, head, body = self.write_header(self._("Sources"))
+        result = self.write_header(self._("Sources"))
+        sourcelistpage, dummy_head, dummy_body, outerwrapper = result
 
         # begin source list division
         with Html("div", class_="content", id="Sources") as sourceslist:
-            body += sourceslist
+            outerwrapper += sourceslist
 
             # Sort the sources
             for handle in source_handles:
@@ -195,7 +196,7 @@ class SourcePages(BasePage):
         # add clearline for proper styling
         # add footer section
         footer = self.write_footer(None)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send page out for processing
         # and close the file
@@ -223,13 +224,14 @@ class SourcePages(BasePage):
 
         output_file, sio = self.report.create_file(source_handle, "src")
         self.uplink = True
-        sourcepage, head, body = self.write_header(
-            "%s - %s" % (self._('Sources'), self.page_title))
+        result = self.write_header("%s - %s" % (self._('Sources'),
+                                                self.page_title))
+        sourcepage, dummy_head, dummy_body, outerwrapper = result
 
         ldatec = 0
         # begin source detail division
         with Html("div", class_="content", id="SourceDetail") as sourcedetail:
-            body += sourcedetail
+            outerwrapper += sourcedetail
 
             media_list = source.get_media_list()
             if self.create_media and media_list:
@@ -301,7 +303,7 @@ class SourcePages(BasePage):
         # add clearline for proper styling
         # add footer section
         footer = self.write_footer(ldatec)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send page out for processing
         # and close the file

--- a/gramps/plugins/webreport/statistics.py
+++ b/gramps/plugins/webreport/statistics.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2008-2011  Rob G. Healey <robhealey1@gmail.com>
 # Copyright (C) 2010       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2010       Jakim Friant
-# Copyright (C) 2010-2017  Serge Noiraud
+# Copyright (C) 2010-      Serge Noiraud
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Benny Malengier
 # Copyright (C) 2016       Allen Crider
@@ -81,7 +81,8 @@ class StatisticsPage(BasePage):
         self.report = report
         # set the file name and open file
         output_file, sio = self.report.create_file("statistics")
-        addressbookpage, head, body = self.write_header(_("Statistics"))
+        result = self.write_header(_("Statistics"))
+        addressbookpage, dummy_head, dummy_body, outerwrapper = result
         (males,
          females,
          unknown) = self.get_gender(report.database.iter_person_handles())
@@ -111,10 +112,10 @@ class StatisticsPage(BasePage):
 
         with Html("div", class_="content", id='EventDetail') as section:
             section += Html("h3", self._("Database overview"), inline=True)
-        body += section
+        outerwrapper += section
         with Html("div", class_="content", id='subsection narrative') as sec11:
             sec11 += Html("h4", self._("Individuals"), inline=True)
-        body += sec11
+        outerwrapper += sec11
         with Html("div", class_="content", id='subsection narrative') as sec1:
             sec1 += Html("br", self._("Number of individuals") + self.colon +
                          "%d" % npersons, inline=True)
@@ -124,14 +125,14 @@ class StatisticsPage(BasePage):
                          "%d" % females, inline=True)
             sec1 += Html("br", self._("Individuals with unknown gender") +
                          self.colon + "%d" % unknown, inline=True)
-        body += sec1
+        outerwrapper += sec1
         with Html("div", class_="content", id='subsection narrative') as sec2:
             sec2 += Html("h4", self._("Family Information"), inline=True)
             sec2 += Html("br", self._("Number of families") + self.colon +
                          "%d" % nfamilies, inline=True)
             sec2 += Html("br", self._("Unique surnames") + self.colon +
                          "%d" % nsurnames, inline=True)
-        body += sec2
+        outerwrapper += sec2
         with Html("div", class_="content", id='subsection narrative') as sec3:
             sec3 += Html("h4", self._("Media Objects"), inline=True)
             sec3 += Html("br",
@@ -145,7 +146,7 @@ class StatisticsPage(BasePage):
                          inline=True)
             sec3 += Html("br", self._("Missing Media Objects") +
                          self.colon + "%d" % len(notfound), inline=True)
-        body += sec3
+        outerwrapper += sec3
         with Html("div", class_="content", id='subsection narrative') as sec4:
             sec4 += Html("h4", self._("Miscellaneous"), inline=True)
             sec4 += Html("br", self._("Number of events") + self.colon +
@@ -166,7 +167,7 @@ class StatisticsPage(BasePage):
             sec4 += Html("br", self._("Number of repositories") +
                          self.colon + "%d" % nrepo,
                          inline=True)
-        body += sec4
+        outerwrapper += sec4
 
         (males,
          females,
@@ -177,7 +178,7 @@ class StatisticsPage(BasePage):
             section += Html("h3",
                             self._("Narrative web content report for") + origin,
                             inline=True)
-        body += section
+        outerwrapper += section
         with Html("div", class_="content", id='subsection narrative') as sec5:
             sec5 += Html("h4", self._("Individuals"), inline=True)
             sec5 += Html("br", self._("Number of individuals") + self.colon +
@@ -189,13 +190,13 @@ class StatisticsPage(BasePage):
                          "%d" % females, inline=True)
             sec5 += Html("br", self._("Individuals with unknown gender") +
                          self.colon + "%d" % unknown, inline=True)
-        body += sec5
+        outerwrapper += sec5
         with Html("div", class_="content", id='subsection narrative') as sec6:
             sec6 += Html("h4", self._("Family Information"), inline=True)
             sec6 += Html("br", self._("Number of families") + self.colon +
                          "%d" % len(self.report.bkref_dict[Family]),
                          inline=True)
-        body += sec6
+        outerwrapper += sec6
         with Html("div", class_="content", id='subsection narrative') as sec7:
             sec7 += Html("h4", self._("Miscellaneous"), inline=True)
             sec7 += Html("br", self._("Number of events") + self.colon +
@@ -213,12 +214,12 @@ class StatisticsPage(BasePage):
             sec7 += Html("br", self._("Number of repositories") + self.colon +
                          "%d" % len(self.report.bkref_dict[Repository]),
                          inline=True)
-        body += sec7
+        outerwrapper += sec7
 
         # add fullclear for proper styling
         # and footer section to page
         footer = self.write_footer(None)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send page out for processing
         # and close the file

--- a/gramps/plugins/webreport/surname.py
+++ b/gramps/plugins/webreport/surname.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2008-2011  Rob G. Healey <robhealey1@gmail.com>
 # Copyright (C) 2010       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2010       Jakim Friant
-# Copyright (C) 2010-2017  Serge Noiraud
+# Copyright (C) 2010-      Serge Noiraud
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Benny Malengier
 # Copyright (C) 2016       Allen Crider
@@ -95,13 +95,13 @@ class SurnamePage(BasePage):
 
         output_file, sio = self.report.create_file(name_to_md5(surname), "srn")
         self.uplink = True
-        (surnamepage, head,
-         body) = self.write_header("%s - %s" % (self._("Surname"), surname))
+        result = self.write_header("%s - %s" % (self._("Surname"), surname))
+        surnamepage, dummy_head, dummy_body, outerwrapper = result
         ldatec = 0
 
         # begin SurnameDetail division
         with Html("div", class_="content", id="SurnameDetail") as surnamedetail:
-            body += surnamedetail
+            outerwrapper += surnamedetail
 
             # section title
             # In case the user choose a format name like "*SURNAME*"
@@ -261,7 +261,7 @@ class SurnamePage(BasePage):
                                              class_="father", inline=True)
                             samerow = False
                         else:
-                            tcell = "&nbsp;" # pylint: disable=R0204
+                            tcell = "&nbsp;"
                             samerow = True
                         trow += Html("td", tcell,
                                      class_="ColumnParents", inline=samerow)
@@ -269,7 +269,7 @@ class SurnamePage(BasePage):
         # add clearline for proper styling
         # add footer section
         footer = self.write_footer(ldatec)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send page out for processing
         # and close the file

--- a/gramps/plugins/webreport/surnamelist.py
+++ b/gramps/plugins/webreport/surnamelist.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2008-2011  Rob G. Healey <robhealey1@gmail.com>
 # Copyright (C) 2010       Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2010       Jakim Friant
-# Copyright (C) 2010-2017  Serge Noiraud
+# Copyright (C) 2010-      Serge Noiraud
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Benny Malengier
 # Copyright (C) 2016       Allen Crider
@@ -95,15 +95,15 @@ class SurnameListPage(BasePage):
 
         if order_by == self.ORDER_BY_NAME:
             output_file, sio = self.report.create_file(filename)
-            surnamelistpage, head, body = self.write_header(self._('Surnames'))
+            result = self.write_header(self._('Surnames'))
         else:
             output_file, sio = self.report.create_file("surnames_count")
-            (surnamelistpage, head,
-             body) = self.write_header(self._('Surnames by person count'))
+            result = self.write_header(self._('Surnames by person count'))
+        surnamelistpage, dummy_head, dummy_body, outerwrapper = result
 
         # begin surnames division
         with Html("div", class_="content", id="surnames") as surnamelist:
-            body += surnamelist
+            outerwrapper += surnamelist
 
             # page message
             msg = self._('This page contains an index of all the '
@@ -233,7 +233,7 @@ class SurnameListPage(BasePage):
         # create footer section
         # add clearline for proper styling
         footer = self.write_footer(None)
-        body += (FULLCLEAR, footer)
+        outerwrapper += (FULLCLEAR, footer)
 
         # send page out for processing
         # and close the file

--- a/gramps/plugins/webstuff/webstuff.py
+++ b/gramps/plugins/webstuff/webstuff.py
@@ -62,7 +62,7 @@ def load_on_reg(dbstate, uistate, plugin):
 
         # Basic Blue style sheet with navigation menus
         ["Basic-Blue",    1, _("Basic-Blue"),
-         path_css('Web_Basic-Blue.css'),    "narrative-menus.css", [], [] ],
+         path_css('Web_Basic-Blue.css'),    None, [], [] ],
 
         # Basic Cypress style sheet
         ["Basic-Cypress", 1, _("Basic-Cypress"),


### PR DESCRIPTION
Fixes #10341, #10962, #11018, #11029

10341:
When we are on a mobile phone or a small device, we suppress the navigation tab.
In place, we have a new icon on the upper left which is used to show the dropdown menu.
Thanks to Theo van Rijn for showing me the way to do that.

10962:
For Home, Introduction and Contact, If we have an image and this image contains regions,
show the regions. We can go directly to the person page associated to this region.
If we click on the image,  we go directly to the associated media page. This will be true only if we selected "include images and media objects" and "create and only use thumbnail" is unselected

11018:
The first line identifying a family will be more legible.
The link is not useful in the parents and pedigree section for the current person.
Adapt some css files.

11029:
sort the place references either by date or by name.