### PR TITLE
Fix for delete of a ref'd primary obj while editing an added obj.

### DIFF
--- a/gramps/gui/editors/displaytabs/eventembedlist.py
+++ b/gramps/gui/editors/displaytabs/eventembedlist.py
@@ -131,15 +131,15 @@ class EventEmbedList(DbGUIElement, GroupEmbeddedList):
             refs = self.get_data()[self._WORKGROUP]
             ref_list = [eref.ref for eref in refs]
             indexlist = []
-            last = 0
+            last = -1
             while True:
                 try:
-                    last = ref_list.index(handle)
+                    last = ref_list.index(handle, last + 1)
                     indexlist.append(last)
                 except ValueError:
                     break
             #remove the deleted workgroup events from the object
-            for index in indexlist.reverse():
+            for index in reversed(indexlist):
                 del refs[index]
         #now rebuild the display tab
         self.rebuild_callback()

--- a/gramps/gui/editors/editcitation.py
+++ b/gramps/gui/editors/editcitation.py
@@ -174,6 +174,8 @@ class EditCitation(EditPrimary):
 
         self._add_db_signal('citation-rebuild', self._do_close)
         self._add_db_signal('citation-delete', self.check_for_close)
+        self._add_db_signal('source-delete', self.source_delete)
+        self._add_db_signal('source-update', self.source_update)
 
     def _setup_fields(self):
         """
@@ -268,6 +270,26 @@ class EditCitation(EditPrimary):
         else:
             author = ''
         self.glade.get_object("author").set_text(author)
+
+    def source_update(self, hndls):
+        ''' Source changed outside of dialog, update text if its ours '''
+        handle = self.obj.get_reference_handle()
+        if handle and handle in hndls:
+            source = self.db.get_source_from_handle(handle)
+            s_lbl = "%s [%s]" % (source.get_title(), source.gramps_id)
+            self.glade.get_object("source").set_text(s_lbl)
+            author = source.get_author()
+            self.glade.get_object("author").set_text(author)
+
+    def source_delete(self, hndls):
+        ''' Source deleted outside of dialog, remove it if its ours'''
+        handle = self.obj.get_reference_handle()
+        if handle and handle in hndls:
+            self.obj.set_reference_handle(None)
+            self.glade.get_object("source").set_markup(
+                self.source_field.EMPTY_TEXT)
+            self.glade.get_object("author").set_text('')
+            self.source_field.set_button(False)
 
     def build_menu_names(self, source):
         """

--- a/gramps/gui/editors/editevent.py
+++ b/gramps/gui/editors/editevent.py
@@ -129,6 +129,8 @@ class EditEvent(EditPrimary):
         """
         self._add_db_signal('event-rebuild', self._do_close)
         self._add_db_signal('event-delete', self.check_for_close)
+        self._add_db_signal('place-delete', self.place_delete)
+        self._add_db_signal('place-update', self.place_update)
 
     def _setup_fields(self):
 
@@ -300,6 +302,24 @@ class EditEvent(EditPrimary):
         else:
             cmp_obj = self.empty_object()
             return cmp_obj.serialize(True)[1:] != self.obj.serialize()[1:]
+
+    def place_update(self, hndls):
+        ''' Place changed outside of dialog, update text if its ours '''
+        handle = self.obj.get_place_handle()
+        if handle and handle in hndls:
+            place = self.db.get_place_from_handle(handle)
+            p_lbl = "%s [%s]" % (place.get_title(), place.gramps_id)
+            self.top.get_object("place").set_text(p_lbl)
+
+    def place_delete(self, hndls):
+        ''' Place deleted outside of dialog, remove it if its ours'''
+        handle = self.obj.get_place_handle()
+        if handle and handle in hndls:
+            self.obj.set_place_handle(None)
+            self.top.get_object("place").set_markup(
+                self.place_field.EMPTY_TEXT)
+            self.place_field.set_button(False)
+
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gui/editors/editeventref.py
+++ b/gramps/gui/editors/editeventref.py
@@ -120,6 +120,8 @@ class EditEventRef(EditReference):
         """
         self._add_db_signal('event-rebuild', self.close)
         self._add_db_signal('event-delete', self.check_for_close)
+        self._add_db_signal('place-delete', self.place_delete)
+        self._add_db_signal('place-update', self.place_update)
 
     def _setup_fields(self):
 
@@ -279,3 +281,20 @@ class EditEventRef(EditReference):
             self.update(self.source_ref,self.source)
 
         self.close()
+
+    def place_update(self, hndls):
+        ''' Place changed outside of dialog, update text if its ours '''
+        handle = self.source.get_place_handle()
+        if handle and handle in hndls:
+            place = self.db.get_place_from_handle(handle)
+            p_lbl = "%s [%s]" % (place.get_title(), place.gramps_id)
+            self.top.get_object("eer_place").set_text(p_lbl)
+
+    def place_delete(self, hndls):
+        ''' Place deleted outside of dialog, remove it if its ours'''
+        handle = self.source.get_place_handle()
+        if handle and handle in hndls:
+            self.source.set_place_handle(None)
+            self.top.get_object("eer_place").set_markup(
+                self.place_field.EMPTY_TEXT)
+            self.place_field.set_button(False)

--- a/gramps/gui/editors/editperson.py
+++ b/gramps/gui/editors/editperson.py
@@ -274,9 +274,7 @@ class EditPerson(EditPrimary):
         self._add_db_signal('family-delete', self.family_change)
         self._add_db_signal('family-update', self.family_change)
         self._add_db_signal('family-add', self.family_change)
-        self._add_db_signal('event-update', self.event_updated)
         self._add_db_signal('event-rebuild', self.event_updated)
-        self._add_db_signal('event-delete', self.event_updated)
 
     def family_change(self, handle_list=[]):
         """


### PR DESCRIPTION
Also fixed to update the ref'd obj on changes from outside the editor.

Fixes [#10999](https://gramps-project.org/bugs/view.php?id=10999), [#11000](https://gramps-project.org/bugs/view.php?id=11000),[ #11001](https://gramps-project.org/bugs/view.php?id=11001), [#11002](https://gramps-project.org/bugs/view.php?id=11002)

In all cases we are adding a new primary object and in the object edit dialog.  Then the user uses a view to delete an object referenced in the open dialog.

I initially found one example of this bug, then decided to look around for other examples, after a few bug reports, I decided to switch this to a class of bugs and deal with them in one PR.

added Primary obj | the referenced deleted obj | affected files
------------------- | ---------------------------- | -------------
Person Add | Event Delete | eventembeddedlist.py, editperson.py
Family Add | Event Delete | eventembeddedlist.py
Person Add | Associated Person delete | personrefembedlist.py
Family Add | Mother/Father delete | editfamily.py
Family add | Child delete | editfamily.py
Citation Add | Source delete | editcitation.py
Event add | Place delete | editevent.py
Event Reference add | Place delete | editeventref.py
Place add | enclosed place delete | placerefembedlist.py 

It looks like @bmcage attempted to fix some of this some years ago, I followed his basic ideas in my fixes.
https://github.com/gramps-project/gramps/commit/ee69317b6243d532a336544560945c43b251aec5

