### PR TITLE
Fix XML import to add tags to Events, Sources, Places, Repos, Cits

### DIFF
--- a/gramps/plugins/importer/importxml.py
+++ b/gramps/plugins/importer/importxml.py
@@ -1149,6 +1149,8 @@ class GrampsParser(UpdateCallback):
         self.placeobj.title = attrs.get('title', '')
         self.locations = 0
         self.update(self.p.CurrentLineNumber)
+        if self.default_tag:
+            self.placeobj.add_tag(self.default_tag.handle)
         return self.placeobj
 
     def start_location(self, attrs):
@@ -1276,6 +1278,8 @@ class GrampsParser(UpdateCallback):
             self.event.private = bool(attrs.get("priv"))
             self.event.change = int(attrs.get('change', self.change))
             self.info.add('new-object', EVENT_KEY, self.event)
+        if self.default_tag:
+            self.event.add_tag(self.default_tag.handle)
         return self.event
 
     def start_eventref(self, attrs):
@@ -2089,6 +2093,8 @@ class GrampsParser(UpdateCallback):
                 self.conf if self.__xml_version >= (1, 5, 1)
                 else 0 ) # See bug# 7125
         self.info.add('new-object', CITATION_KEY, self.citation)
+        if self.default_tag:
+            self.citation.add_tag(self.default_tag.handle)
         return self.citation
 
     def start_sourceref(self, attrs):
@@ -2143,6 +2149,8 @@ class GrampsParser(UpdateCallback):
         self.source.private = bool(attrs.get("priv"))
         self.source.change = int(attrs.get('change', self.change))
         self.info.add('new-object', SOURCE_KEY, self.source)
+        if self.default_tag:
+            self.source.add_tag(self.default_tag.handle)
         return self.source
 
     def start_reporef(self, attrs):
@@ -2261,6 +2269,8 @@ class GrampsParser(UpdateCallback):
         self.repo.private = bool(attrs.get("priv"))
         self.repo.change = int(attrs.get('change', self.change))
         self.info.add('new-object', REPOSITORY_KEY, self.repo)
+        if self.default_tag:
+            self.repo.add_tag(self.default_tag.handle)
         return self.repo
 
     def stop_people(self, *tag):


### PR DESCRIPTION
Fixes [#11004](https://gramps-project.org/bugs/view.php?id=11004)

Apparently the feature to add a tags was originally not going to work with all object types.  https://github.com/gramps-project/gramps/commit/771ae761e28d166b5c8d93eaa0f28cf65602b4b4
added support for the original planned tagged objects, but when all objects became taggable, the XML import default tag stuff did not get updated.  https://github.com/gramps-project/gramps/commit/9c66c62d5c6e1b245c055b6a21566cc6c627bb0f