### PR TITLE
Add buttons for arrangement of GalleryTab media order

### DIFF
--- a/gramps/gui/editors/displaytabs/buttontab.py
+++ b/gramps/gui/editors/displaytabs/buttontab.py
@@ -73,7 +73,10 @@ class ButtonTab(GrampsTab):
         'jump'  : _('Jump To'),
         'up'    : _('Move Up'),
         'down'  : _('Move Down'),
+        'left'  : _('Move Left'),
+        'right' : _('Move right')
     }
+    L_R = 2  # indicator for left/right move buttons
 
     def __init__(self, dbstate, uistate, track, name, share_button=False,
                     move_buttons=False, jump_button=False, top_label=None):
@@ -142,10 +145,14 @@ class ButtonTab(GrampsTab):
             self.share_btn = None
 
         if move_buttons:
-            self.up_btn = SimpleButton('go-up', self.up_button_clicked)
-            self.up_btn.set_tooltip_text(self._MSG['up'])
-            self.down_btn = SimpleButton('go-down', self.down_button_clicked)
-            self.down_btn.set_tooltip_text(self._MSG['down'])
+            l_r = move_buttons == self.L_R
+            self.up_btn = SimpleButton('go-previous' if l_r else 'go-up',
+                                       self.up_button_clicked)
+            self.up_btn.set_tooltip_text(self._MSG['left' if l_r else 'up'])
+            self.down_btn = SimpleButton('go-next' if l_r else 'go-down',
+                                         self.down_button_clicked)
+            self.down_btn.set_tooltip_text(
+                self._MSG['right' if l_r else 'down'])
             self.track_ref_for_deletion("up_btn")
             self.track_ref_for_deletion("down_btn")
         else:

--- a/gramps/gui/editors/displaytabs/gallerytab.py
+++ b/gramps/gui/editors/displaytabs/gallerytab.py
@@ -81,7 +81,8 @@ class GalleryTab(ButtonTab, DbGUIElement):
 
     def __init__(self, dbstate, uistate, track,  media_list, update=None):
         self.iconlist = Gtk.IconView()
-        ButtonTab.__init__(self, dbstate, uistate, track, _('_Gallery'), True)
+        ButtonTab.__init__(self, dbstate, uistate, track, _('_Gallery'), True,
+                           move_buttons=ButtonTab.L_R)
         DbGUIElement.__init__(self, dbstate.db)
         self.track_ref_for_deletion("iconlist")
         self.media_list = media_list
@@ -396,6 +397,50 @@ class GalleryTab(ButtonTab, DbGUIElement):
             if handle in ref_handles:
                 self.rebuild()
                 break
+
+    def up_button_clicked(self, obj):
+        """ Deal with up button """
+        ref = self.get_selected()
+        if ref:
+            pos = self.find_index(ref)
+            if pos > 0 :
+                self._move_up(pos, ref)
+
+    def down_button_clicked(self, obj):
+        """ Deal with down button """
+        ref = self.get_selected()
+        if ref:
+            pos = self.find_index(ref)
+            if pos >= 0 and pos < len(self.get_data()) - 1:
+                self._move_down(pos, ref)
+
+    def _move_up(self, row_from, obj):
+        """
+        Move the item a position up in the EmbeddedList.
+        Eg: 0,1,2,3 needs to become 0,2,1,3, here row_from = 2
+        """
+        dlist = self.get_data()
+        del dlist[row_from]
+        dlist.insert(row_from - 1, obj)
+        self.changed = True
+        self.rebuild()
+        #select the row
+        path = Gtk.TreePath.new_from_string(str(row_from - 1))
+        self.iconlist.select_path(path)
+
+    def _move_down(self, row_from, obj):
+        """
+        Move the item a position down in the EmbeddedList.
+        Eg: 0,1,2,3 needs to become 0,2,1,3, here row_from = 1
+        """
+        dlist = self.get_data()
+        del dlist[row_from]
+        dlist.insert(row_from + 1, obj)
+        self.changed = True
+        self.rebuild()
+        #select the row
+        path = Gtk.TreePath.new_from_string(str(row_from + 1))
+        self.iconlist.select_path(path)
 
     def _set_dnd(self):
         """


### PR DESCRIPTION
Gramps Issue [#10359](https://gramps-project.org/bugs/view.php?id=10359) mentioned that it was difficult to shuffle the media items in the gallery, in part because there was no up/down buttons like in the other tabs to rearrange the media items.   User was trying to select a particular one for main photo (first one).

This PR adds the buttons.  I made them left/right since in this tab the media items appear in that order.
![gallery](https://user-images.githubusercontent.com/18122203/52001878-1b13a280-2486-11e9-8ed0-187bc4ebe55b.png)
