### PR TITLE
Deal with SQLite db corrupted by None name mapping

### DIFF
--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -330,9 +330,11 @@ class DBAPI(DbGeneric):
         """
         Return the defined names that have been assigned to a default grouping.
         """
-        self.dbapi.execute("SELECT name FROM name_group ORDER BY name")
+        self.dbapi.execute("SELECT name, grouping FROM name_group "
+                           "ORDER BY name")
         rows = self.dbapi.fetchall()
-        return [row[0] for row in rows]
+        # not None test below fixes db corrupted by 11011 for export
+        return [row[0] for row in rows if row[1] is not None]
 
     def get_name_group_mapping(self, key):
         """
@@ -341,7 +343,8 @@ class DBAPI(DbGeneric):
         self.dbapi.execute(
             "SELECT grouping FROM name_group WHERE name = ?", [key])
         row = self.dbapi.fetchone()
-        if row:
+        if row and row[0] is not None:
+            # not None test fixes db corrupted by 11011
             return row[0]
         else:
             return key
@@ -566,7 +569,7 @@ class DBAPI(DbGeneric):
         self.dbapi.execute("SELECT grouping FROM name_group WHERE name = ?",
                            [key])
         row = self.dbapi.fetchone()
-        return True if row else False
+        return row and row[0] is not None
 
     def set_name_group_mapping(self, name, grouping):
         """

--- a/gramps/plugins/importer/importxml.py
+++ b/gramps/plugins/importer/importxml.py
@@ -1754,7 +1754,7 @@ class GrampsParser(UpdateCallback):
                             ' with "%(parent)s", did not change this grouping to "%(value)s".') % {
                             'key' : key, 'parent' : present, 'value' : value }
                     self.user.warn(_("Gramps ignored a name grouping"), msg)
-            else:
+            elif value != 'None':  # None test fixes file corrupted by 11011
                 self.db.set_name_group_mapping(key, value)
 
     def start_last(self, attrs):


### PR DESCRIPTION
Fixes [#11011](https://gramps-project.org/bugs/view.php?id=11011)

Submitter points out that just fixing the original bug dealt with in #771 is not sufficient.  The db may have been corrupted, and worse yet, XML backups of the corrupted db may have been made.

This PR fixes dbapi to ignore corrupted entries in the current db, and fixes XML import to ignore a bad group_as in the XML file.