### PR TITLE
Fix example gramps files so media is found

### DIFF
--- a/example/gramps/data.gramps
+++ b/example/gramps/data.gramps
@@ -15,7 +15,7 @@
       <resphone>(555)123-4567</resphone>
       <resemail>anyone@someplace.com</resemail>
     </researcher>
-    <mediapath>{GRAMPS_RESOURCES}/example/gramps</mediapath>
+    <mediapath>{GRAMPS_RESOURCES}/doc/gramps/example/gramps</mediapath>
   </header>
   <tags>
     <tag handle="_c7642d9389b54417e8b" change="1370206720" name="tag1" color="#000000000000" priority="0"/>

--- a/example/gramps/example.gramps
+++ b/example/gramps/example.gramps
@@ -7,7 +7,7 @@
     <researcher>
       <resname>Alex Roitman,,,</resname>
     </researcher>
-    <mediapath>{GRAMPS_RESOURCES}/example/gramps</mediapath>
+    <mediapath>{GRAMPS_RESOURCES}/doc/gramps/example/gramps</mediapath>
   </header>
   <name-formats>
     <format number="-1" name="SURNAME, Given (Common)" fmt_str="SURNAME, given (common)" active="1"/>


### PR DESCRIPTION
Fixes [#11015](https://gramps-project.org/bugs/view.php?id=11015)

On Windows the location of the example files is "c:\program files\grampsaio64-5.0.1\share\doc\gramps\example\gramps".

On my Ubuntu install from the .deb file these files are in "/usr/share/doc/gramps/example/gramps"

Since the default GRAMPS_RESOURCES value for each system is the 'share', to find the media files we need to append "/doc/gramps/example/gramps" to have the example files work properly.