### PR TITLE
Fix Python time.clock deprecation

### DIFF
--- a/gramps/gen/filters/rules/test/person_rules_test.py
+++ b/gramps/gen/filters/rules/test/person_rules_test.py
@@ -24,7 +24,7 @@ Unittest that tests person-specific filter rules
 """
 import unittest
 import os
-import time
+from time import perf_counter
 import inspect
 
 from ....db.utils import import_as_dict
@@ -95,11 +95,11 @@ class BaseTest(unittest.TestCase):
             filter_.add_rule(rule)
         filter_.set_logical_op(l_op)
         filter_.set_invert(invert)
-        stime = time.clock()
+        stime = perf_counter()
         results = filter_.apply(self.db)
         if __debug__:
             rulename = inspect.stack()[1][3]
-            print("%s: %.2f\n" % (rulename, time.clock() - stime))
+            print("%s: %.2f\n" % (rulename, perf_counter() - stime))
         return set(results)
 
     def test_Complex_1(self):

--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -32,7 +32,7 @@ Provide the base classes for GRAMPS' DataView classes
 from abc import abstractmethod
 import os
 import pickle
-import time
+from time import perf_counter
 import logging
 from collections import deque
 
@@ -315,7 +315,7 @@ class ListView(NavigationView):
 
     def build_tree(self, force_sidebar=False, preserve_col=True):
         if self.active:
-            cput0 = time.clock()
+            cput0 = perf_counter()
             if not self.search_bar.is_visible():
                 filter_info = (True, self.generic_filter, False)
             else:
@@ -341,26 +341,26 @@ class ListView(NavigationView):
                     ErrorDialog(msg1, msg2,
                                 parent=self.uistate.window)
 
-            cput1 = time.clock()
+            cput1 = perf_counter()
             self.build_columns(preserve_col)
-            cput2 = time.clock()
+            cput2 = perf_counter()
             self.list.set_model(self.model)
-            cput3 = time.clock()
+            cput3 = perf_counter()
             self.__display_column_sort()
             self.goto_active(None)
 
             self.dirty = False
-            cput4 = time.clock()
+            cput4 = perf_counter()
             self.uistate.show_filter_results(self.dbstate,
                                              self.model.displayed(),
                                              self.model.total())
             LOG.debug(self.__class__.__name__ + ' build_tree ' +
-                    str(time.clock() - cput0) + ' sec')
+                    str(perf_counter() - cput0) + ' sec')
             LOG.debug('parts ' + str(cput1-cput0) + ' , '
                              + str(cput2-cput1) + ' , '
                              + str(cput3-cput2) + ' , '
                              + str(cput4-cput3) + ' , '
-                             + str(time.clock() - cput4))
+                             + str(perf_counter() - cput4))
 
         else:
             self.dirty = True
@@ -619,7 +619,7 @@ class ListView(NavigationView):
         """
         self.uistate.set_busy_cursor(True)
         self.uistate.push_message(self.dbstate, _("Column clicked, sorting..."))
-        cput = time.clock()
+        cput = perf_counter()
         same_col = False
         if self.sort_col != data:
             order = Gtk.SortType.ASCENDING
@@ -671,7 +671,7 @@ class ListView(NavigationView):
         self.uistate.set_busy_cursor(False)
 
         LOG.debug('   ' + self.__class__.__name__ + ' column_clicked ' +
-                    str(time.clock() - cput) + ' sec')
+                    str(perf_counter() - cput) + ' sec')
 
     def __display_column_sort(self):
         for i, c in enumerate(self.columns):
@@ -751,10 +751,10 @@ class ListView(NavigationView):
         """
         if self.active or \
            (not self.dirty and not self._dirty_on_change_inactive):
-            cput = time.clock()
+            cput = perf_counter()
             list(map(self.model.add_row_by_handle, handle_list))
             LOG.debug('   ' + self.__class__.__name__ + ' row_add ' +
-                    str(time.clock() - cput) + ' sec')
+                    str(perf_counter() - cput) + ' sec')
             if self.active:
                 self.uistate.show_filter_results(self.dbstate,
                                                  self.model.displayed(),
@@ -770,12 +770,12 @@ class ListView(NavigationView):
             self.model.prev_handle = None
         if self.active or \
            (not self.dirty and not self._dirty_on_change_inactive):
-            cput = time.clock()
+            cput = perf_counter()
             #store selected handles
             self._sel_handles_before_update = self.selected_handles()
             list(map(self.model.update_row_by_handle, handle_list))
             LOG.debug('   ' + self.__class__.__name__ + ' row_update ' +
-                    str(time.clock() - cput) + ' sec')
+                    str(perf_counter() - cput) + ' sec')
             # Ensure row is still selected after a change of postion in tree.
             if self._sel_handles_before_update:
                 #we can only set one selected again, we take last
@@ -791,10 +791,10 @@ class ListView(NavigationView):
         """
         if self.active or \
            (not self.dirty and not self._dirty_on_change_inactive):
-            cput = time.clock()
+            cput = perf_counter()
             list(map(self.model.delete_row_by_handle, handle_list))
             LOG.debug('   '  + self.__class__.__name__ + ' row_delete ' +
-                    str(time.clock() - cput) + ' sec')
+                    str(perf_counter() - cput) + ' sec')
             if self.active:
                 self.uistate.show_filter_results(self.dbstate,
                                                  self.model.displayed(),

--- a/gramps/gui/views/treemodels/flatbasemodel.py
+++ b/gramps/gui/views/treemodels/flatbasemodel.py
@@ -53,7 +53,7 @@ It keeps a FlatNodeMap, and obtains data from database as needed
 #-------------------------------------------------------------------------
 import logging
 import bisect
-import time
+from time import perf_counter
 
 _LOG = logging.getLogger(".gui.basetreemodel")
 
@@ -451,7 +451,7 @@ class FlatBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
     def __init__(self, db, uistate, scol=0, order=Gtk.SortType.ASCENDING,
                  search=None, skip=set(),
                  sort_map=None):
-        cput = time.clock()
+        cput = perf_counter()
         GObject.GObject.__init__(self)
         BaseModel.__init__(self)
         self.uistate = uistate
@@ -486,7 +486,7 @@ class FlatBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
 
         self.rebuild_data()
         _LOG.debug(self.__class__.__name__ + ' __init__ ' +
-                    str(time.clock() - cput) + ' sec')
+                    str(perf_counter() - cput) + ' sec')
 
     def destroy(self):
         """

--- a/gramps/gui/views/treemodels/treebasemodel.py
+++ b/gramps/gui/views/treemodels/treebasemodel.py
@@ -32,7 +32,7 @@ This module provides the model that is used for all hierarchical treeviews.
 # Standard python modules
 #
 #-------------------------------------------------------------------------
-import time
+from time import perf_counter
 import logging
 
 _LOG = logging.getLogger(".gui.treebasemodel")
@@ -278,7 +278,7 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
     def __init__(self, db, uistate, search=None, skip=set(), scol=0,
                  order=Gtk.SortType.ASCENDING, sort_map=None, nrgroups = 1,
                  group_can_have_handle = False, has_secondary=False):
-        cput = time.clock()
+        cput = perf_counter()
         GObject.GObject.__init__(self)
         BaseModel.__init__(self)
 
@@ -341,7 +341,7 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
             self.rebuild_data(self.current_filter, skip=skip)
 
         _LOG.debug(self.__class__.__name__ + ' __init__ ' +
-                    str(time.clock() - cput) + ' sec')
+                    str(perf_counter() - cput) + ' sec')
 
     def destroy(self):
         """
@@ -484,7 +484,7 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
         the filter functions. When called internally (from __init__) both
         data_filter and data_filter2 will have been set from set_search
         """
-        cput = time.clock()
+        cput = perf_counter()
         self.clear_cache()
         self._in_build = True
 
@@ -504,7 +504,7 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
             self.current_filter2 = data_filter2
 
         _LOG.debug(self.__class__.__name__ + ' rebuild_data ' +
-                    str(time.clock() - cput) + ' sec')
+                    str(perf_counter() - cput) + ' sec')
 
     def _rebuild_search(self, dfilter, dfilter2, skip):
         """
@@ -743,7 +743,7 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
         self.clear_path_cache()
         if self._get_node(handle) is not None:
             return # row already exists
-        cput = time.clock()
+        cput = perf_counter()
         data = self.map(handle)
         if data:
             if not self.search or \
@@ -755,7 +755,7 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
                 self.add_row2(handle, self.map2(handle))
 
         _LOG.debug(self.__class__.__name__ + ' add_row_by_handle ' +
-                    str(time.clock() - cput) + ' sec')
+                    str(perf_counter() - cput) + ' sec')
         _LOG.debug("displayed %d / total: %d" %
                    (self.__displayed, self.__total))
 
@@ -764,7 +764,7 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
         Delete a row from the model.
         """
         assert isinstance(handle, str)
-        cput = time.clock()
+        cput = perf_counter()
         self.clear_cache(handle)
         node = self._get_node(handle)
         if node is None:
@@ -786,7 +786,7 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
             parent = next_parent
 
         _LOG.debug(self.__class__.__name__ + ' delete_row_by_handle ' +
-                    str(time.clock() - cput) + ' sec')
+                    str(perf_counter() - cput) + ' sec')
         _LOG.debug("displayed %d / total: %d" %
                    (self.__displayed, self.__total))
 


### PR DESCRIPTION
This also requires pushing our minimum Python version requirement to 3.3, but that is done in #789.