### PR TITLE
fix finddupes tool when run from Match Threshold screen again after merge. 

### DIFF
--- a/gramps/plugins/tool/finddupes.py
+++ b/gramps/plugins/tool/finddupes.py
@@ -193,6 +193,7 @@ class DuplicatePeopleTool(tool.Tool, ManagedWindow):
         index = 0
         males = {}
         females = {}
+        self.map = {}
 
         length = self.db.get_number_of_people()
 


### PR DESCRIPTION
Avoids HandleError because potentials dict is not cleared and tries to display merged out person object.

Fixes [#11044](https://gramps-project.org/bugs/view.php?id=11044)