### PR TITLE
Fix relationshippathbetween filter rule when parent is missing

### DIFF
--- a/gramps/gen/filters/rules/person/_relationshippathbetween.py
+++ b/gramps/gen/filters/rules/person/_relationshippathbetween.py
@@ -75,6 +75,8 @@ class RelationshipPathBetween(Rule):
                         self.desc_list(child_ref.ref, map, 0)
 
     def apply_filter(self, rank, handle, plist, pmap):
+        if not handle:
+            return
         person = self.db.get_person_from_handle(handle)
         if person is None:
             return


### PR DESCRIPTION
Fixes [#11049](https://gramps-project.org/bugs/view.php?id=11049)

Another HandleError issue, this one hidden by the raw except.  Filter rule just did not work if a family in the path had a missing parent.