### PR TITLE
Gedcom fixes for mime and finding media

### DIFF
--- a/data/tests/exp_sample_ged.ged
+++ b/data/tests/exp_sample_ged.ged
@@ -1,12 +1,12 @@
 0 HEAD
 1 SOUR Gramps
-2 VERS 5.0.1
+2 VERS 5.0.2
 2 NAME Gramps
-1 DATE 7 NOV 2018
-2 TIME 16:03:33
+1 DATE 5 MAR 2019
+2 TIME 09:11:15
 1 SUBM @SUBM@
 1 FILE C:\Users\prc\AppData\Roaming\gramps\temp\exp_sample_ged.ged
-1 COPR Copyright (c) 2018 Alex Roitman,,,.
+1 COPR Copyright (c) 2019 Alex Roitman,,,.
 1 GEDC
 2 VERS 5.5.1
 2 FORM LINEAGE-LINKED
@@ -1420,8 +1420,8 @@
 0 @N0018@ NOTE Another Citation Note
 0 @N0019@ NOTE A bad photo for sure
 0 @O0000@ OBJE
-1 FILE c:\users\prc\workspace\grampsm\main\data\tests\O0.jpg
-2 FORM jpeg
+1 FILE c:\msys64\mingw64\share\gramps\tests\O0.jpg
+2 FORM jpg
 2 TITL Michael O'Toole 2015-11
 1 NOTE @N0019@
 1 CHAN

--- a/data/tests/imp_FTM_16dec2015a-mod1.gramps
+++ b/data/tests/imp_FTM_16dec2015a-mod1.gramps
@@ -3,41 +3,41 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-08-29" version="5.0.0-alpha1"/>
+    <created date="2019-03-13" version="5.0.2"/>
     <researcher>
     </researcher>
   </header>
   <events>
-    <event handle="_0000000500000005" change="1472500305" id="E0000">
+    <event handle="_0000000500000005" change="1" id="E0000">
       <type>Birth</type>
       <dateval val="1816"/>
       <place hlink="_0000000700000007"/>
       <citationref hlink="_0000000600000006"/>
     </event>
-    <event handle="_0000000800000008" change="1472500305" id="E0001">
+    <event handle="_0000000800000008" change="1" id="E0001">
       <type>Residence</type>
       <dateval val="1850"/>
       <place hlink="_0000000a0000000a"/>
       <citationref hlink="_0000000900000009"/>
     </event>
-    <event handle="_0000000b0000000b" change="1472500305" id="E0002">
+    <event handle="_0000000b0000000b" change="1" id="E0002">
       <type>Death</type>
       <datestr val="1850/1860"/>
       <place hlink="_0000000c0000000c"/>
     </event>
-    <event handle="_0000000f0000000f" change="1472500305" id="E0003">
+    <event handle="_0000000f0000000f" change="1" id="E0003">
       <type>Marriage</type>
       <dateval val="1841" type="about"/>
       <place hlink="_0000001000000010"/>
     </event>
-    <event handle="_0000001100000011" change="1472500305" id="E0004">
+    <event handle="_0000001100000011" change="1" id="E0004">
       <type>Marriage</type>
       <dateval val="1847-08"/>
       <place hlink="_0000001200000012"/>
     </event>
   </events>
   <people>
-    <person handle="_0000000100000001" change="1472500305" id="I0278">
+    <person handle="_0000000100000001" change="1" id="I0278">
       <gender>M</gender>
       <name type="Birth Name">
         <first>Andrew</first>
@@ -54,13 +54,13 @@
     </person>
   </people>
   <families>
-    <family handle="_0000000d0000000d" change="1472500305" id="F0073">
+    <family handle="_0000000d0000000d" change="1" id="F0073">
       <rel type="Married"/>
       <father hlink="_0000000100000001"/>
       <eventref hlink="_0000000f0000000f" role="Family"/>
       <childref hlink="_0000000100000001"/>
     </family>
-    <family handle="_0000000e0000000e" change="1472500305" id="F0074">
+    <family handle="_0000000e0000000e" change="1" id="F0074">
       <rel type="Married"/>
       <father hlink="_0000000100000001"/>
       <eventref hlink="_0000001100000011" role="Family"/>
@@ -68,19 +68,19 @@
     </family>
   </families>
   <citations>
-    <citation handle="_0000000400000004" change="1472500305" id="C0000">
+    <citation handle="_0000000400000004" change="1" id="C0000">
       <page>Year: 1850; Census Place: District 14, Cape Girardeau, Missouri; Roll: M432_394; Page: 435B; Image: 248</page>
       <confidence>2</confidence>
       <objref hlink="_0000000300000003"/>
       <sourceref hlink="_0000000200000002"/>
     </citation>
-    <citation handle="_0000000600000006" change="1472500305" id="C0001">
+    <citation handle="_0000000600000006" change="1" id="C0001">
       <page>Year: 1850; Census Place: District 14, Cape Girardeau, Missouri; Roll: M432_394; Page: 435B; Image: 248</page>
       <confidence>2</confidence>
       <objref hlink="_0000000300000003"/>
       <sourceref hlink="_0000000200000002"/>
     </citation>
-    <citation handle="_0000000900000009" change="1472500305" id="C0002">
+    <citation handle="_0000000900000009" change="1" id="C0002">
       <page>Year: 1850; Census Place: District 14, Cape Girardeau, Missouri; Roll: M432_394; Page: 435B; Image: 248</page>
       <confidence>2</confidence>
       <objref hlink="_0000000300000003"/>
@@ -88,7 +88,7 @@
     </citation>
   </citations>
   <sources>
-    <source handle="_0000000200000002" change="1472500305" id="S0029">
+    <source handle="_0000000200000002" change="1" id="S0029">
       <stitle>1850 United States Federal Census</stitle>
       <sauthor>Ancestry.com</sauthor>
       <spubinfo>Name: Ancestry.com Operations, Inc.; Location: Provo, UT, USA; Date: 2009;</spubinfo>
@@ -96,42 +96,43 @@
     </source>
   </sources>
   <places>
-    <placeobj handle="_0000000700000007" change="1472500305" id="P0000" type="Unknown">
+    <placeobj handle="_0000000700000007" change="1" id="P0000" type="Unknown">
       <ptitle>Tennessee, USA</ptitle>
       <pname value="Tennessee, USA"/>
     </placeobj>
-    <placeobj handle="_0000000a0000000a" change="1472500305" id="P0001" type="Unknown">
+    <placeobj handle="_0000000a0000000a" change="1" id="P0001" type="Unknown">
       <ptitle>District 14, Cape Girardeau, Missouri, USA</ptitle>
       <pname value="District 14, Cape Girardeau, Missouri, USA"/>
     </placeobj>
-    <placeobj handle="_0000000c0000000c" change="1472500305" id="P0002" type="Unknown">
+    <placeobj handle="_0000000c0000000c" change="1" id="P0002" type="Unknown">
       <ptitle>Bollinger Co. MO</ptitle>
       <pname value="Bollinger Co. MO"/>
     </placeobj>
-    <placeobj handle="_0000001000000010" change="1472500305" id="P0003" type="Unknown">
+    <placeobj handle="_0000001000000010" change="1" id="P0003" type="Unknown">
       <ptitle>Union Co.?, IL</ptitle>
       <pname value="Union Co.?, IL"/>
     </placeobj>
-    <placeobj handle="_0000001200000012" change="1472500305" id="P0004" type="Unknown">
+    <placeobj handle="_0000001200000012" change="1" id="P0004" type="Unknown">
       <ptitle>Wayne, Missouri, United States</ptitle>
       <pname value="Wayne, Missouri, United States"/>
     </placeobj>
   </places>
   <objects>
-    <object handle="_0000000300000003" change="1472500305" id="M159">
+    <object handle="_0000000300000003" change="1" id="M159">
       <file src="1850 United States Federal Census(11)-1.jpg" mime="image/jpeg" description="1850 United States Federal Census"/>
       <noteref hlink="_0000001400000014"/>
       <noteref hlink="_0000001500000015"/>
     </object>
-    <object handle="_0000001600000016" change="1472500305" id="M158">
-      <file src="D:/Users/PRC/Downloads/1850 United States Federal Census(11)-1.jpg" mime="image/jpeg" description="D:\Users\PRC\Downloads\1850 United States Federal Census(11)-1.jpg"/>
+    <object handle="_0000001600000016" change="1" id="M158">
+      <file src="/Users/PRC/Downloads/1850 United States Federal Census(11)-1.jpg" mime="image/jpeg" description="/Users/PRC/Downloads/1850 United States Federal Census(11)-1.jpg"/>
+      <noteref hlink="_0000001700000017"/>
     </object>
-    <object handle="_0000001700000017" change="1472500305" id="M157">
+    <object handle="_0000001800000018" change="1" id="M157">
       <file src="http://1.gravatar.com/avatar/77e02a3c8c665155ad1acaac8c2742e0?s=120&amp;d=mm&amp;r=pg" mime="unknown" description="http://1.gravatar.com/avatar/77e02a3c8c665155ad1acaac8c2742e0?s=120&amp;d=mm&amp;r=pg"/>
     </object>
   </objects>
   <repositories>
-    <repository handle="_0000001300000013" change="1472500305" id="R0001">
+    <repository handle="_0000001300000013" change="1" id="R0001">
       <rname>Ancestry.com</rname>
       <type>Library</type>
       <address>
@@ -140,15 +141,25 @@
     </repository>
   </repositories>
   <notes>
-    <note handle="_0000001400000014" change="1472500305" id="N0000" type="Media Note">
-      <text>Year: 1850; Census Place: District 14, Cape Girardeau, Missouri; Roll: M432_394; Page: 435B; Image: 248</text>
+    <note handle="_0000001400000014" change="1" id="N0000" type="Media Note">
+      <text>Year: 1850; Census Place: District 14, Cape Girardeau, Missouri; Roll: M432_394; Page: 435B; Image: 248 </text>
     </note>
-    <note handle="_0000001500000015" change="1472500305" id="N0001" type="GEDCOM import">
+    <note handle="_0000001500000015" change="1" id="N0001" type="GEDCOM import">
       <text>Records not imported into OBJE (multi-media object) Gramps ID M159:
 
-Could not import 1850 United States Federal Census(11)-1.jpg        Line    70: 1 FILE 1850 United States Federal Census(11)-1.jpg</text>
+Could not import 1850 United States Federal Census(11)-1.jpg        Line    70: 1 FILE 1850 United States Federal Census(11)-1.jpg
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="200"/>
+      </style>
+    </note>
+    <note handle="_0000001700000017" change="1" id="N0002" type="GEDCOM import">
+      <text>Records not imported into OBJE (multi-media object) Gramps ID M158:
+
+Could not import D:\Users\PRC\Downloads\1850 United States Federa   Line    75: 1 FILE D:\Users\PRC\Downloads\1850 United States Federal Census(11)-1.jpg
+</text>
+      <style name="fontface" value="Monospace">
+        <range start="0" end="223"/>
       </style>
     </note>
   </notes>

--- a/data/tests/imp_MediaTest.gramps
+++ b/data/tests/imp_MediaTest.gramps
@@ -3,7 +3,7 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2019-02-01" version="5.0.2"/>
+    <created date="2019-03-05" version="5.0.2"/>
     <researcher>
     </researcher>
   </header>
@@ -69,7 +69,7 @@
       <noteref hlink="_0000000b0000000b"/>
     </object>
     <object handle="_0000000400000004" change="548708291" id="M1">
-      <file src="" mime="" description="Multimedia link to linked form v5.5 blob"/>
+      <file src="" mime="image/jpeg" description="Multimedia link to linked form v5.5 blob"/>
       <attribute type="REFN" value="Ref12345M1">
         <noteref hlink="_0000001200000012"/>
       </attribute>
@@ -118,7 +118,7 @@
       <citationref hlink="_0000002700000027"/>
     </object>
     <object handle="_0000000c0000000c" change="1" id="O0002">
-      <file src="http://www.geni.com/photo/view?photo_id=6000000001341319061" mime="unknown" description="Multimedia link embedded form v5.5 URL"/>
+      <file src="http://www.geni.com/photo/view?photo_id=6000000001341319061" mime="text/html" description="Multimedia link embedded form v5.5 URL"/>
       <noteref hlink="_0000000b0000000b"/>
     </object>
     <object handle="_0000000d0000000d" change="1" id="M7">
@@ -130,7 +130,7 @@
       <noteref hlink="_0000002900000029"/>
     </object>
     <object handle="_0000001500000015" change="1" id="M2">
-      <file src="" mime="" description="2nd blob Multimedia link to linked form v5.5 blob"/>
+      <file src="" mime="image/jpeg" description="2nd blob Multimedia link to linked form v5.5 blob"/>
       <noteref hlink="_0000001600000016"/>
     </object>
   </objects>

--- a/data/tests/imp_sample.gramps
+++ b/data/tests/imp_sample.gramps
@@ -3,7 +3,7 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2016-10-24" version="5.0.0-alpha1"/>
+    <created date="2019-03-05" version="5.0.2"/>
     <researcher>
       <resname>Alex Roitman,,,</resname>
       <resaddr>Not Provided</resaddr>
@@ -1456,13 +1456,13 @@
       <noteref hlink="_000000f9000000f9"/>
     </object>
     <object handle="_000000d1000000d1" change="1" id="O0001">
-      <file src="Magnes&amp;Anna_smiths_marr_cert.jpg" mime="unknown" description="Magnes&amp;Anna_smiths_marr_cert.jpg"/>
+      <file src="Magnes&amp;Anna_smiths_marr_cert.jpg" mime="image/jpeg" description="Magnes&amp;Anna_smiths_marr_cert.jpg"/>
     </object>
     <object handle="_000000d8000000d8" change="1" id="O0002">
-      <file src="John&amp;Alice_smiths_marr_cert.jpg" mime="unknown" description="John&amp;Alice_smiths_marr_cert.jpg"/>
+      <file src="John&amp;Alice_smiths_marr_cert.jpg" mime="image/jpeg" description="John&amp;Alice_smiths_marr_cert.jpg"/>
     </object>
     <object handle="_000000f1000000f1" change="1" id="O0003">
-      <file src="Attic_photo.jpg" mime="unknown" description="Attic_photo.jpg"/>
+      <file src="Attic_photo.jpg" mime="image/jpeg" description="Attic_photo.jpg"/>
     </object>
   </objects>
   <repositories>
@@ -1506,7 +1506,8 @@
     <note handle="_0000000100000001" change="1" id="N0000" type="GEDCOM import">
       <text>Records not imported into HEAD (header):
 
-GEDCOM FORM not supported                                           Line    14: 2 FORM NOT LINEAGE-LINKED</text>
+GEDCOM FORM not supported                                           Line    14: 2 FORM NOT LINEAGE-LINKED
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="148"/>
       </style>
@@ -1514,7 +1515,8 @@ GEDCOM FORM not supported                                           Line    14: 
     <note handle="_0000000200000002" change="1" id="N0001" type="GEDCOM import">
       <text>Records not imported into SUBM (Submitter): (@SUBM@) Alex Roitman,,,:
 
-Line ignored as not understood                                      Line    23: 2 NOTE No address provided (note not supported)</text>
+Line ignored as not understood                                      Line    23: 2 NOTE No address provided (note not supported)
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="199"/>
       </style>
@@ -1523,7 +1525,8 @@ Line ignored as not understood                                      Line    23: 
       <text>Records not imported into FAM (family) Gramps ID F0003:
 
 Line ignored as not understood                                      Line    46: 2 SOUR Not really allowed here
-Filename omitted                                                    Line    48: 1 OBJE</text>
+Filename omitted                                                    Line    48: 1 OBJE 
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="256"/>
       </style>
@@ -1562,7 +1565,8 @@ Filename omitted                                                    Line    48: 
       <text>Records not imported into INDI (individual) Gramps ID I0016:
 
 Warn: ADDR overwritten                                              Line   204: 3 ADR1 456 Main St again
-ADDR element ignored '459 Main St.'                                 Line   202: 2 ADDR 459 Main St., The Village, San Francisco, CA, USA</text>
+ADDR element ignored '459 Main St.'                                 Line   202: 2 ADDR 459 Main St., The Village, San Francisco, CA, USA
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="304"/>
       </style>
@@ -1573,7 +1577,8 @@ ADDR element ignored '459 Main St.'                                 Line   202: 
     <note handle="_0000004700000047" change="1" id="N0014" type="GEDCOM import">
       <text>Records not imported into INDI (individual) Gramps ID I0018:
 
-Tag recognized but not supported                                    Line   245: 2 TYPE first generaton</text>
+Tag recognized but not supported                                    Line   245: 2 TYPE first generaton
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="165"/>
       </style>
@@ -1604,7 +1609,8 @@ Company. He enlisted in the army at Sparks 7 December 1917 and served as a Corpo
     <note handle="_000000cf000000cf" change="1" id="N0021" type="GEDCOM import">
       <text>Records not imported into FAM (family) Gramps ID F0010:
 
-Tag recognized but not supported                                    Line   863: 2 _STAT</text>
+Tag recognized but not supported                                    Line   863: 2 _STAT 
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="146"/>
       </style>
@@ -1613,7 +1619,8 @@ Tag recognized but not supported                                    Line   863: 
       <text>Records not imported into FAM (family) Gramps ID F0011:
 
 Could not import Magnes&amp;Anna_smiths_marr_cert.jpg                   Line   878: 3 OBJE 
-Could not import Magnes&amp;Anna_smiths_marr_cert.jpg                   Line   881: 2 OBJE</text>
+Could not import Magnes&amp;Anna_smiths_marr_cert.jpg                   Line   881: 2 OBJE 
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="233"/>
       </style>
@@ -1621,7 +1628,8 @@ Could not import Magnes&amp;Anna_smiths_marr_cert.jpg                   Line   8
     <note handle="_000000d9000000d9" change="1" id="N0023" type="GEDCOM import">
       <text>Records not imported into FAM (family) Gramps ID F0012:
 
-Could not import John&amp;Alice_smiths_marr_cert.jpg                    Line   905: 1 OBJE</text>
+Could not import John&amp;Alice_smiths_marr_cert.jpg                    Line   905: 1 OBJE 
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="145"/>
       </style>
@@ -1629,7 +1637,8 @@ Could not import John&amp;Alice_smiths_marr_cert.jpg                    Line   9
     <note handle="_000000e4000000e4" change="1" id="N0024" type="GEDCOM import">
       <text>Records not imported into FAM (family) Gramps ID F0008:
 
-Tag recognized but not supported                                    Line  1005: 1 ADDR 123 Main st, Grantville, Virginia, USA</text>
+Tag recognized but not supported                                    Line  1005: 1 ADDR 123 Main st, Grantville, Virginia, USA
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="183"/>
       </style>
@@ -1653,7 +1662,8 @@ Tag recognized but not supported                                    Line  1005: 
       <text>Records not imported into SOUR (source) Gramps ID S0003:
 
 Tag recognized but not supported                                    Line  1045: 1 DATA 
-Skipped subordinate line                                            Line  1046: 2 AGNC NYC Public Library</text>
+Skipped subordinate line                                            Line  1046: 2 AGNC NYC Public Library
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="252"/>
       </style>
@@ -1669,7 +1679,8 @@ Skipped subordinate line                                            Line  1046: 
 
 REFN ignored                                                        Line  1075: 3 REFN blah blah
 Skipped subordinate line                                            Line  1076: 4 TYPE who knows
-Could not import Attic_photo.jpg                                    Line  1079: 3 OBJE</text>
+Could not import Attic_photo.jpg                                    Line  1079: 3 OBJE 
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="344"/>
       </style>
@@ -1677,7 +1688,8 @@ Could not import Attic_photo.jpg                                    Line  1079: 
     <note handle="_000000f6000000f6" change="1" id="N0034" type="GEDCOM import">
       <text>Records not imported into Top Level:
 
-Unknown tag                                                         Line  1106: 0 XXX an unknown token at level 0</text>
+Unknown tag                                                         Line  1106: 0 XXX an unknown token at level 0
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="152"/>
       </style>
@@ -1685,12 +1697,13 @@ Unknown tag                                                         Line  1106: 
     <note handle="_000000f8000000f8" change="1" id="N0035" type="GEDCOM import">
       <text>Records not imported into Top Level:
 
-Unknown tag                                                         Line  1109: 1 @X1@ XXX and unknown token xref definition</text>
+Unknown tag                                                         Line  1109: 1 @X1@ XXX and unknown token xref definition
+</text>
       <style name="fontface" value="Monospace">
         <range start="0" end="163"/>
       </style>
     </note>
-    <note handle="_000000f9000000f9" change="1477325896" id="N0036" type="General">
+    <note handle="_000000f9000000f9" change="1551799781" id="N0036" type="General">
       <text>Objects referenced by this note were missing in a file imported on 12/25/1999 12:00:00 AM.</text>
     </note>
   </notes>

--- a/gramps/plugins/export/exportgedcom.py
+++ b/gramps/plugins/export/exportgedcom.py
@@ -104,15 +104,6 @@ LANGUAGES = {
 #
 #-------------------------------------------------------------------------
 
-MIME2GED = {
-    "image/bmp"   : "bmp",
-    "image/gif"   : "gif",
-    "image/jpeg"  : "jpeg",
-    "image/x-pcx" : "pcx",
-    "image/tiff"  : "tiff",
-    "audio/x-wav" : "wav"
-}
-
 QUALITY_MAP = {
     Citation.CONF_VERY_HIGH : "3",
     Citation.CONF_HIGH      : "2",
@@ -1467,8 +1458,7 @@ class GedcomWriter(UpdateCallback):
         gramps_id = media.get_gramps_id()
 
         self._writeln(0, '@%s@' % gramps_id, 'OBJE')
-        mime = media.get_mime_type()
-        form = MIME2GED.get(mime, mime)
+        form = os.path.splitext(media.get_path())[1][1:]
         path = media_path_full(self.dbase, media.get_path())
         self._writeln(1, 'FILE', path, limit=255)
         if form:

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -5379,7 +5379,7 @@ class GedcomParser(UpdateCallback):
                 if sub_state.title:
                     photo.set_description(sub_state.title)
                 else:
-                    photo.set_description(path)
+                    photo.set_description(path.replace('\\', '/'))
                 full_path = os.path.abspath(path)
                 # deal with mime types
                 value = mimetypes.guess_type(full_path)
@@ -6752,7 +6752,7 @@ class GedcomParser(UpdateCallback):
 
         state.media.set_path(path)
         if not state.media.get_description():
-            state.media.set_description(path)
+            state.media.set_description(path.replace('\\', '/'))
 
     def __obje_title(self, line, state):
         """


### PR DESCRIPTION
While working this bug several issues turned up.  First of all, Gramps was using a very abbreviated set of tables of mime types to deal with the file extension to mime types for Gedcom import export.  The user was using '.png' files and this type was not in the list.  So Gramps was putting up a generic icon for the thumbnail instead of the appropriate preview.

The first commit deals with this.

Another issue was that the user commented that even when he preset the 'base path for relative media paths' before importing, the media was still listed as 'not found', even though it seemed to be working.

The Gedcom import was not using this in its determination of file presence.

The last issue was specific to Windows machines, the coded that tried to determine if a media path was a URL or a filename was not working for filenames with Windows drive letters.

The second commit deals with these two issues.

Fixes [#11041](https://gramps-project.org/bugs/view.php?id=11041)