### PR TITLE
Fix Person Editor Events to properly update during external changes

### DIFF
--- a/gramps/gui/editors/displaytabs/personeventembedlist.py
+++ b/gramps/gui/editors/displaytabs/personeventembedlist.py
@@ -92,6 +92,10 @@ class PersonEventEmbedList(EventEmbedList):
                     self._data.append(family.get_event_ref_list())
                     self._groups.append((family_handle, self._FAMNAME,
                                          groupname))
+            #we register all events that need to be tracked
+            for group in self._data:
+                self.callman.register_handles(
+                    {'event': [eref.ref for eref in group]})
             self.changed = False
 
         return self._data


### PR DESCRIPTION
like Event delete or update.

Fixes [#11051](https://gramps-project.org/bugs/view.php?id=11051)

Looks like someone simply forgot to register the handles with the callman...

I checked other similar cases and did not see any other issues.