### PR TITLE
Avoid invalid characters in the entry fields

### DIFF
--- a/gramps/gui/editors/displaytabs/surnametab.py
+++ b/gramps/gui/editors/displaytabs/surnametab.py
@@ -50,6 +50,9 @@ from ...ddtargets import DdTargets
 from gramps.gen.lib import Surname, NameOriginType
 from ...utils import match_primary_mask, no_match_primary_mask
 
+# table for skipping illegal control chars
+INVISIBLE = dict.fromkeys(list(range(32)))
+
 #-------------------------------------------------------------------------
 #
 # SurnameTab
@@ -281,7 +284,8 @@ class SurnameTab(EmbeddedList):
         colnr must be the column in the model.
         """
         node = self.model.get_iter(path)
-        self.model.set_value(node, colnr, new_text)
+        text = new_text.translate(INVISIBLE).strip()
+        self.model.set_value(node, colnr, text)
         self.update()
 
     def on_orig_edited(self, cellr, path, new_text, colnr):

--- a/gramps/gui/widgets/monitoredwidgets.py
+++ b/gramps/gui/widgets/monitoredwidgets.py
@@ -64,6 +64,9 @@ from gramps.gen.errors import ValidationError
 _RETURN = Gdk.keyval_from_name("Return")
 _KP_ENTER = Gdk.keyval_from_name("KP_Enter")
 
+# table for skipping illegal control chars
+INVISIBLE = dict.fromkeys(list(range(32)))
+
 #-------------------------------------------------------------------------
 #
 # MonitoredCheckbox class
@@ -112,6 +115,7 @@ class MonitoredEntry:
         if get_val():
             self.obj.set_text(get_val())
         self.obj.connect('changed', self._on_change)
+        self.obj.connect('focus-out-event', self._on_quit)
         self.obj.set_editable(not read_only)
 
         if autolist:
@@ -136,8 +140,15 @@ class MonitoredEntry:
     def connect(self, signal, callback, *data):
         self.obj.connect(signal, callback, *data)
 
+    def _on_quit(self, obj, event):
+        text = obj.get_text().translate(INVISIBLE).strip()
+        self.set_val(text)
+        obj.set_text(text)
+
     def _on_change(self, obj):
-        self.set_val(obj.get_text())
+        new_text = obj.get_text().translate(INVISIBLE)
+        self.set_val(new_text)
+        obj.set_text(new_text)
         if self.changed:
             self.changed(obj)
 


### PR DESCRIPTION
In this patch:
 1 - If you copy/paste strings from another application,
     you can add CR, LF, TAB and other special characters. I remove them.
 2 - suppress all leading and trailing spaces for these entry field.

This PR modify the MonitoredEntry class used by all views and the SurnameTab used in the person editor and in the EditName class.