### PR TITLE
Fix crash for multiple deletes in one transaction

### DIFF
--- a/gramps/gui/displaystate.py
+++ b/gramps/gui/displaystate.py
@@ -116,30 +116,6 @@ class History(Callback):
             if initial_person:
                 self.push(initial_person.get_handle())
 
-    def remove(self, handle, old_id=None):
-        """
-        Remove a handle from the history list
-        """
-        if old_id:
-            del_id = old_id
-        else:
-            del_id = handle
-
-        history_count = self.history.count(del_id)
-        for c in range(history_count):
-            self.history.remove(del_id)
-            self.index -= 1
-
-        mhc = self.mru.count(del_id)
-        for c in range(mhc):
-            self.mru.remove(del_id)
-        self.emit('mru-changed', (self.mru, ))
-        if self.history:
-            newact = self.history[self.index]
-            if not isinstance(newact, str):
-                newact = str(newact)
-            self.emit('active-changed', (newact,))
-
     def push(self, handle):
         """
         Pushes the handle on the history stack
@@ -229,8 +205,21 @@ class History(Callback):
         Called in response to an object-delete signal.
         Removes a list of handles from the history.
         """
-        for handle in handle_list:
-            self.remove(handle)
+        for del_id in handle_list:
+            history_count = self.history.count(del_id)
+            for dummy in range(history_count):
+                self.history.remove(del_id)
+                self.index -= 1
+
+            mhc = self.mru.count(del_id)
+            for dummy in range(mhc):
+                self.mru.remove(del_id)
+        if self.history:
+            newact = self.history[self.index]
+            if not isinstance(newact, str):
+                newact = str(newact)
+            self.emit('active-changed', (newact,))
+        self.emit('mru-changed', (self.mru, ))
 
     def history_changed(self):
         """

--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -792,9 +792,19 @@ class ListView(NavigationView):
         if self.active or \
            (not self.dirty and not self._dirty_on_change_inactive):
             cput = time.clock()
-            list(map(self.model.delete_row_by_handle, handle_list))
-            LOG.debug('   '  + self.__class__.__name__ + ' row_delete ' +
-                    str(time.clock() - cput) + ' sec')
+            for hndl in handle_list:
+                if hndl != handle_list[-1]:
+                    # For multiple deletes, row updates can result in a
+                    # selection changed signal to a handle already
+                    # deleted.  In these cases we don't want to change the
+                    # active to non-existant handles.
+                    self.model.dont_change_active = True
+                else:
+                    # Allow active changed on last item deleted
+                    self.model.dont_change_active = False
+                self.model.delete_row_by_handle(hndl)
+            LOG.debug('   ' + self.__class__.__name__ + ' row_delete ' +
+                      str(time.clock() - cput) + ' sec')
             if self.active:
                 self.uistate.show_filter_results(self.dbstate,
                                                  self.model.displayed(),


### PR DESCRIPTION
Fixes [#11117](https://gramps-project.org/bugs/view.php?id=11117)

Found while trying to undo a GetGOV load that brought in several enclosed places.
The basic problem is that several parts of our code were trying to handle deletes one handle at a time after the db had deleted the actual objects and created the multiple delete signal.  For the MRU update code this resulted in attempting to rebuild MRU entries on other already deleted handles.  For the listview code, the one at a time deletion indirectly caused active changed to rows/handles that were also already gone.  Both resulted in HandleError crashes.
