### PR TITLE
Correct English translation strings for unmarried partners

### DIFF
--- a/gramps/gen/relationship.py
+++ b/gramps/gen/relationship.py
@@ -2181,18 +2181,18 @@ class RelationshipCalculator:
                 return trans_text("gender unknown|ex-spouse")
         elif spouse_type == self.PARTNER_UNMARRIED:
             if gender == MALE:
-                return trans_text("unmarried|husband")
+                return trans_text("male,unmarried|partner")
             elif gender == FEMALE:
-                return trans_text("unmarried|wife")
+                return trans_text("female,unmarried|partner")
             else:
-                return trans_text("gender unknown,unmarried|spouse")
+                return trans_text("gender unknown,unmarried|partner")
         elif spouse_type == self.PARTNER_EX_UNMARRIED:
             if gender == MALE:
-                return trans_text("unmarried|ex-husband")
+                return trans_text("male,unmarried|ex-partner")
             elif gender == FEMALE:
-                return trans_text("unmarried|ex-wife")
+                return trans_text("female,unmarried|ex-partner")
             else:
-                return trans_text("gender unknown,unmarried|ex-spouse")
+                return trans_text("gender unknown,unmarried|ex-partner")
         elif spouse_type == self.PARTNER_CIVIL_UNION:
             if gender == MALE:
                 return trans_text("male,civil union|partner")

--- a/po/ar.po
+++ b/po/ar.po
@@ -10233,27 +10233,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "زوج سابق(ـة)"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "زوج"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "زوجة"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "زوج"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "زوج سابق"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "زوجة سابقة"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "زوج سابق(ـة)"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/bg.po
+++ b/po/bg.po
@@ -10463,27 +10463,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "полът неизвестен бивш/а съпруг/а"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "без брак съпруг"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "без брак съпруга"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "неизвестен пол, неженен брачен партньор"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "без брак бивш съпруг"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "без брак бивша съпруга"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "неизвестен пол, неженен бивш брачен партньор"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/br.po
+++ b/po/br.po
@@ -10094,27 +10094,27 @@ msgid "gender unknown|ex-spouse"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/ca.po
+++ b/po/ca.po
@@ -10392,27 +10392,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "ex-cònjuge"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "company"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "companya"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "parella"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "ex-company"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "ex-companya"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "ex-parella"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/cs.po
+++ b/po/cs.po
@@ -10227,27 +10227,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "bývalý partner"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "druh"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "družka"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "druh(družka)"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "bývalý manžel"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "bývalý manželka"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "druh(družka)"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/da.po
+++ b/po/da.po
@@ -10286,27 +10286,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "fhv. ægtefælle"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "mand"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "hustru"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "ægtefælle"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "fhv. mand"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "fhv. hustru"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "fhv. ægtefælle"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/de.po
+++ b/po/de.po
@@ -10399,27 +10399,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "Ex-Partner(in)"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "Lebensgefährte"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "Lebensgefährtin"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "Partner(in)"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "Ex-Lebensgefährte"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "Ex-Lebensgefährtin"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "Ex-Lebensgefährt(e/in)"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/el.po
+++ b/po/el.po
@@ -10689,27 +10689,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "πρώην σύζυγος"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "ο σύντροφος"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "η σύντροφος"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "σύντροφος"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "ο πρώην σύντροφος"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "η πρώην σύντροφος"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "πρώην σύντροφος"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -9539,27 +9539,27 @@ msgid "gender unknown|ex-spouse"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/eo.po
+++ b/po/eo.po
@@ -9782,27 +9782,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "eksgeedzo"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "fraŭlo|edzo"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "fraŭlino|edzino"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "geedzo"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "eksedzo"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "eksedzino"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "eksgeedzo"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/es.po
+++ b/po/es.po
@@ -10598,27 +10598,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "ex-cónyuge"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "compañero"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "compañera"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "pareja"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "ex-compañero"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "ex-compañera"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "ex-pareja"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/fi.po
+++ b/po/fi.po
@@ -9198,27 +9198,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "ent. puoliso"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "avomies"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "avovaimo"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "avopuoliso"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "ent. avomies"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "ent. avovaimo"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "ent. avopuoliso"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/fr.po
+++ b/po/fr.po
@@ -10948,27 +10948,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "l'ancien conjoint"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "le conjoint"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "la conjointe"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "le conjoint"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "l'ancien conjoint"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "l'ancienne conjointe"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "l'ancien conjoint"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/ga.po
+++ b/po/ga.po
@@ -9604,27 +9604,27 @@ msgid "gender unknown|ex-spouse"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/he.po
+++ b/po/he.po
@@ -9780,27 +9780,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "בן/בת זוג לשעבר"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "בעל"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "אישה"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "בן/הת זוג"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "בעל לשעבר"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "אישה לשעבר"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "בן/בת זוג לשעבר"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/hr.po
+++ b/po/hr.po
@@ -10256,27 +10256,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "bivši supružnik"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "partner"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "partnerica"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "partner"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "bivši partner"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "bivša partnerica"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "bivši partner"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/hu.po
+++ b/po/hu.po
@@ -10275,27 +10275,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "volt házastárs"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "férj"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "feleség"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "házastárs"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "volt férj"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "volt feleség"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "volt házastárs"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/is.po
+++ b/po/is.po
@@ -10103,27 +10103,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "fv-maki"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "maki"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "maki"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "maki"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "fv-maki"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "fv-maki"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "fv-maki"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/it.po
+++ b/po/it.po
@@ -10281,27 +10281,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "ex consorte"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "compagno"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "compagna"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "compagno/a"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "ex compagno"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "ex compagna"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "ex compagno/a"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/ja.po
+++ b/po/ja.po
@@ -9870,27 +9870,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "性別不明|前配偶者"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "未婚|夫"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "未婚|妻"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "性別不明,未婚|配偶者"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "未婚|前夫"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "未婚|前妻"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "性別不明,未婚|前配偶者"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/lt.po
+++ b/po/lt.po
@@ -10241,27 +10241,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "buvęs sutuoktinis"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "vyras"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "žmona"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "sutuoktinis"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "Buvęs sugyventinis"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "Buvusi sugyventinė"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "buvęs partneris"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/mk.po
+++ b/po/mk.po
@@ -10541,30 +10541,30 @@ msgid "gender unknown|ex-spouse"
 msgstr "пол непознат|сопружник"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "немажен|сопруг"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "немажена|сопруга"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "пол непознат, немажен|сопружник"
 
 #: ../gramps/gen/relationship.py:2191
 #, fuzzy
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "немажен|сопруг"
 
 #: ../gramps/gen/relationship.py:2193
 #, fuzzy
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "немажена|сопруга"
 
 #: ../gramps/gen/relationship.py:2195
 #, fuzzy
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "пол непознат, немажен|сопружник"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/nb.po
+++ b/po/nb.po
@@ -7488,27 +7488,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "tidligere ektefelle"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "mann"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "kone"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "partner"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "tidligere partner"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "tidligere partner"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "tidligere partner"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/nl.po
+++ b/po/nl.po
@@ -10515,29 +10515,29 @@ msgid "gender unknown|ex-spouse"
 msgstr "ex echtgenoot of echtgenote"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "partner"
 
 # maitresse?
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "partner"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "partner"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "expartner"
 
 # maitresse?
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "expartner"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "expartner"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/nn.po
+++ b/po/nn.po
@@ -10369,27 +10369,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "tidlegare ektefelle"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "mann"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "kvinne"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "partner"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "tidlegare partner"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "tidlegare partner"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "tidlegare partner"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/pl.po
+++ b/po/pl.po
@@ -10421,27 +10421,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "były partner"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "kawaler"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "panna"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "partner"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "kawaler/rozwodnik"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "panna/rozwódka"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "partner"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10335,27 +10335,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "ex-cônjuge"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "companheiro"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "companheira"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "companheiro(a)"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "ex-companheiro"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "ex-companheira"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "ex-companheiro(a)"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -10298,27 +10298,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "ex-cônjuge"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "companheiro"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "companheira"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "companheiro(a)"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "ex-companheiro"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "ex-companheira"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "ex-companheiro(a)"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/ro.po
+++ b/po/ro.po
@@ -10429,31 +10429,31 @@ msgstr "necunoscut"
 
 #: ../gramps/gen/relationship.py:2184
 #, fuzzy
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "Necăsătorit(ă)"
 
 #: ../gramps/gen/relationship.py:2186
 #, fuzzy
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "Necăsătorit(ă)"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2191
 #, fuzzy
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "Necăsătorit(ă)"
 
 #: ../gramps/gen/relationship.py:2193
 #, fuzzy
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "Necăsătorit(ă)"
 
 #: ../gramps/gen/relationship.py:2195
 #, fuzzy
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "necunoscut"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/ru.po
+++ b/po/ru.po
@@ -10306,27 +10306,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "бывший супруг"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "гражданский муж"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "гражданская жена"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "гражданский супруг"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "бывший гражданский муж"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "бывшая гражданская жена"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "бывший гражданский супруг(-а)"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/sk.po
+++ b/po/sk.po
@@ -10216,27 +10216,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "bývalý partner/-ka"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "druh"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "družka"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "druh/družka"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "druh"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "družka"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "druh/družka"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/sl.po
+++ b/po/sl.po
@@ -10232,27 +10232,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "bivši zakonec"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "partner"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "partnerka"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "partner"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "bivši partner"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "bivša partnerka"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "bivši partner"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/sq.po
+++ b/po/sq.po
@@ -10498,27 +10498,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "gjinia e panjohur|ish-bashkëshort"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "i pamartuar|bashkëshorti"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "e pamartuar|bashkëshorte"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "gjinia e panjohur, pamartuar|bashkëshort"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "i pamartuar|ish-bashkëshorti"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "e pamartuar|ish-bashkëshorte"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "gjinia e panjohur, pamartuar|bashkëshort"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/sr.po
+++ b/po/sr.po
@@ -10307,27 +10307,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "бивши супружник"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "супруг"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "супруга"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "супруг"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "бивши супруг"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "бивша супруга"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "бивши супружник"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/sr_Latn.po
+++ b/po/sr_Latn.po
@@ -9527,27 +9527,27 @@ msgid "gender unknown|ex-spouse"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/sv.po
+++ b/po/sv.po
@@ -7494,27 +7494,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "ex-make/maka"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "sambo"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "sambo"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "sambo"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "ex-make"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "ex-maka"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "ex-sambo"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/ta.po
+++ b/po/ta.po
@@ -10000,29 +10000,29 @@ msgid "gender unknown|ex-spouse"
 msgstr "பாலினம் தெரியவில்லை"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2193
 #, fuzzy
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "மணமாகாத"
 
 #: ../gramps/gen/relationship.py:2195
 #, fuzzy
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "பாலினம் தெரியாதது,தெரியாத உறவு|பங்குதாரர்"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/tr.po
+++ b/po/tr.po
@@ -9617,27 +9617,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "eski eş"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "nikahsız koca"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "nikahsız karı"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "eş"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "ayrılmış nikahsız koca"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "ayrılmış nikahsız karı"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "eski eş"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/uk.po
+++ b/po/uk.po
@@ -10215,27 +10215,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "колишній(я) чоловік(дружина)"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "партнер"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "партнерша"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "партнер/партнерша"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "колишній партнер"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "колишня партнерша"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "колишній(я) партнер(партнерша)"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/vi.po
+++ b/po/vi.po
@@ -10175,27 +10175,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "bạn đời trước "
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "vợ "
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "vợ "
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "bạn đời "
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "chồng trước "
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "vợ trước "
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "bạn đời "
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -10116,27 +10116,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "前配偶"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "男伴"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "女伴"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "伴侣"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "前男伴"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "前女伴"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "前伴侣"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -10117,27 +10117,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "前配偶"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "男伴"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "女伴"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "伴侶"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "前男伴"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "前女伴"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "前伴侶"
 
 #: ../gramps/gen/relationship.py:2198

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -10116,27 +10116,27 @@ msgid "gender unknown|ex-spouse"
 msgstr "前配偶"
 
 #: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
+msgid "male,unmarried|partner"
 msgstr "男伴"
 
 #: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
+msgid "female,unmarried|partner"
 msgstr "女伴"
 
 #: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
+msgid "gender unknown,unmarried|partner"
 msgstr "伴侶"
 
 #: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
+msgid "male,unmarried|ex-partner"
 msgstr "前男伴"
 
 #: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
+msgid "female,unmarried|ex-partner"
 msgstr "前女伴"
 
 #: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
+msgid "gender unknown,unmarried|ex-partner"
 msgstr "前伴侶"
 
 #: ../gramps/gen/relationship.py:2198


### PR DESCRIPTION
Previously, unmarried male and female partners were referred to as "husband" and "wife" respectively in English, although other languages had correct translations. This PR adjusts this by adjusting the relevant translation strings so that the correct English is after the pipe, with additional disambiguating information before the pipe to allow the translations to keep working.

This fixes [#11109](https://gramps-project.org/bugs/view.php?id=11109)