### PR TITLE
Fix '_havechildren.py' person filter

### DIFF
--- a/gramps/gen/filters/rules/person/_havechildren.py
+++ b/gramps/gen/filters/rules/person/_havechildren.py
@@ -2,6 +2,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2002-2006  Donald N. Allingham
+# Copyright (C) 2019  Matthias Kemmer
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -33,8 +34,11 @@ _ = glocale.translation.gettext
 #-------------------------------------------------------------------------
 from .. import Rule
 
+
 #-------------------------------------------------------------------------
+#
 # "People with children"
+#
 #-------------------------------------------------------------------------
 class HaveChildren(Rule):
     """People with children"""
@@ -43,7 +47,10 @@ class HaveChildren(Rule):
     description = _("Matches people who have children")
     category = _('Family filters')
 
-    def apply(self,db,person):
+    def apply(self, db, person):
+        have_children = False
         for family_handle in person.get_family_handle_list():
             family = db.get_family_from_handle(family_handle)
-            return (family is not None) and len(family.get_child_ref_list()) > 0
+            if (family is not None) and len(family.get_child_ref_list()) > 0:
+                have_children = True
+        return have_children

--- a/gramps/gen/filters/rules/person/_havechildren.py
+++ b/gramps/gen/filters/rules/person/_havechildren.py
@@ -48,9 +48,8 @@ class HaveChildren(Rule):
     category = _('Family filters')
 
     def apply(self, db, person):
-        have_children = False
         for family_handle in person.get_family_handle_list():
             family = db.get_family_from_handle(family_handle)
-            if (family is not None) and len(family.get_child_ref_list()) > 0:
-                have_children = True
-        return have_children
+            if family is not None and family.get_child_ref_list():
+                return True
+        return False

--- a/gramps/gen/filters/rules/test/person_rules_test.py
+++ b/gramps/gen/filters/rules/test/person_rules_test.py
@@ -575,7 +575,7 @@ class BaseTest(unittest.TestCase):
         """
         rule = HaveChildren([])
         # too many to list out to test explicitly
-        self.assertEqual(len(self.filter_with_rule(rule)), 901)
+        self.assertEqual(len(self.filter_with_rule(rule)), 905)
 
     def test_incompletenames(self):
         """


### PR DESCRIPTION
Check all families of a person for children and not only the first family:
Right now, if a person has two families and no children in the first family, this person is filtered as having no children, even if there are children in the second family.