### PR TITLE
Bug11151  Fix Language update_po.py to scan for XML fragments in Python files.

### DIFF
--- a/gramps/gui/displaystate.py
+++ b/gramps/gui/displaystate.py
@@ -252,7 +252,7 @@ _RCT_TOP = '<placeholder id="OpenRecentMenu">'
 _RCT_MENU = '''
             <item>
               <attribute name="action">win.%s</attribute>
-              <attribute name="label" translatable="no">%s</attribute>
+              <attribute name="label">%s</attribute>
             </item>'''
 _RCT_BTM = '\n          </placeholder>\n'
 _RCT_BAR_TOP = ('<object class="GtkMenu"  id="OpenBtnMenu">\n'
@@ -262,7 +262,7 @@ _RCT_BAR = '''
 <child>
     <object class="GtkMenuItem">
         <property name="action-name">win.%s</property>
-        <property name="label" translatable="yes">%s</property>
+        <property name="label">%s</property>
         <property name="use_underline">False</property>
         <property name="visible">True</property>
     </object>

--- a/gramps/gui/plug/quick/_quickreports.py
+++ b/gramps/gui/plug/quick/_quickreports.py
@@ -65,7 +65,7 @@ from gramps.gen.simple import make_basic_stylesheet
 
 MENUITEM = ('<item>\n'
             '<attribute name="action">{prefix}.{action}</attribute>\n'
-            '<attribute name="label" translatable="yes">'
+            '<attribute name="label">'
             '{label}</attribute>\n'
             '</item>\n')
 

--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -1112,7 +1112,7 @@ class ViewManager(CLIManager):
         _menu = '''<placeholder id="undo">
         <item>
           <attribute name="action">win.Undo</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         </placeholder>
         '''
@@ -1132,7 +1132,7 @@ class ViewManager(CLIManager):
         _menu = '''<placeholder id="redo">
         <item>
           <attribute name="action">win.Redo</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         </placeholder>
         '''
@@ -1405,8 +1405,7 @@ class ViewManager(CLIManager):
         """
         menuitem = ('<item>\n'
                     '<attribute name="action">win.%s</attribute>\n'
-                    '<attribute name="label" translatable="yes">'
-                    '%s...</attribute>\n'
+                    '<attribute name="label">%s...</attribute>\n'
                     '</item>\n')
 
         actions = []
@@ -1426,7 +1425,7 @@ class ViewManager(CLIManager):
 
         for key in catlist:
             ofile.write('<submenu>\n<attribute name="label"'
-                        ' translatable="yes">%s</attribute>\n' % key[1])
+                        '>%s</attribute>\n' % key[1])
             pdatas = hash_data[key]
             pdatas.sort(key=lambda x: x.name)
             for pdata in pdatas:
@@ -1440,7 +1439,7 @@ class ViewManager(CLIManager):
         # and the unsupported category at the end of the menu
         if _UNSUPPORTED in hash_data:
             ofile.write('<submenu>\n<attribute name="label"'
-                        ' translatable="yes">%s</attribute>\n' %
+                        '>%s</attribute>\n' %
                         _UNSUPPORTED[1])
             pdatas = hash_data[_UNSUPPORTED]
             pdatas.sort(key=lambda x: x.name)

--- a/gramps/gui/views/bookmarks.py
+++ b/gramps/gui/views/bookmarks.py
@@ -151,8 +151,7 @@ class Bookmarks(metaclass=ABCMeta):
         """Create the pulldown menu."""
         menuitem = ('<item>\n'
                     '<attribute name="action">win.%s</attribute>\n'
-                    '<attribute name="label" translatable="yes">'
-                    '%s</attribute>\n'
+                    '<attribute name="label">%s</attribute>\n'
                     '</item>\n')
         text = StringIO()
 

--- a/gramps/gui/views/navigationview.py
+++ b/gramps/gui/views/navigationview.py
@@ -425,7 +425,7 @@ class NavigationView(PageView):
         """
         menuitem = '''        <item>
               <attribute name="action">win.%s%02d</attribute>
-              <attribute name="label" translatable="yes">%s</attribute>
+              <attribute name="label">%s</attribute>
             </item>
             '''
         menus = ''

--- a/gramps/gui/views/tags.py
+++ b/gramps/gui/views/tags.py
@@ -242,7 +242,7 @@ class Tags(DbGUIElement):
         menuitem = '''
         <item>
           <attribute name="action">win.TAG_%s</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>'''
 
         for tag_name, handle in self.__tag_list:

--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -1455,8 +1455,7 @@ class GrampletPane(Gtk.ScrolledWindow):
         ''')
         menuitem = ('<item>\n'
                     '<attribute name="action">win.%s</attribute>\n'
-                    '<attribute name="label" translatable="yes">'
-                    '%s</attribute>\n'
+                    '<attribute name="label">%s</attribute>\n'
                     '</item>\n')
 
         if is_right_click(event):

--- a/gramps/plugins/lib/libpersonview.py
+++ b/gramps/plugins/lib/libpersonview.py
@@ -231,7 +231,7 @@ class BasePersonView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>
@@ -306,7 +306,7 @@ class BasePersonView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-add</property>
         <property name="action-name">win.Add</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Add...</property>
         <property name="use-underline">True</property>
       </object>
@@ -318,7 +318,7 @@ class BasePersonView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gtk-edit</property>
         <property name="action-name">win.Edit</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">Edit...</property>
         <property name="use-underline">True</property>
       </object>
@@ -330,7 +330,7 @@ class BasePersonView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-remove</property>
         <property name="action-name">win.Remove</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Delete</property>
         <property name="use-underline">True</property>
       </object>
@@ -342,7 +342,7 @@ class BasePersonView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gramps-merge</property>
         <property name="action-name">win.Merge</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Merge...</property>
         <property name="use-underline">True</property>
       </object>
@@ -382,7 +382,7 @@ class BasePersonView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>

--- a/gramps/plugins/lib/libplaceview.py
+++ b/gramps/plugins/lib/libplaceview.py
@@ -171,7 +171,7 @@ class PlaceBaseView(ListView):
             <item>
               <attribute name="action">win.MapChoice</attribute>
               <attribute name="target">%s</attribute>
-              <attribute name="label" translatable="yes">%s</attribute>
+              <attribute name="label">%s</attribute>
             </item>
             '''
         menu = ''
@@ -308,7 +308,7 @@ class PlaceBaseView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>
@@ -365,7 +365,7 @@ class PlaceBaseView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-add</property>
         <property name="action-name">win.Add</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Add...</property>
         <property name="use-underline">True</property>
       </object>
@@ -377,7 +377,7 @@ class PlaceBaseView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gtk-edit</property>
         <property name="action-name">win.Edit</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">Edit...</property>
         <property name="use-underline">True</property>
       </object>
@@ -389,7 +389,7 @@ class PlaceBaseView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-remove</property>
         <property name="action-name">win.Remove</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Delete</property>
         <property name="use-underline">True</property>
       </object>
@@ -401,7 +401,7 @@ class PlaceBaseView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gramps-merge</property>
         <property name="action-name">win.Merge</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Merge...</property>
         <property name="use-underline">True</property>
       </object>
@@ -431,7 +431,7 @@ class PlaceBaseView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>
@@ -471,7 +471,7 @@ class PlaceBaseView(ListView):
         <property name="tooltip_text" translatable="yes">'''
         '''Attempt to see selected locations with a Map Service '''
         '''(OpenstreetMap, Google Maps, ...)</property>
-        <property name="label" translatable="yes">%s</property>
+        <property name="label">%s</property>
         <property name="use-underline">True</property>
       </object>
       <packing>

--- a/gramps/plugins/view/citationlistview.py
+++ b/gramps/plugins/view/citationlistview.py
@@ -200,7 +200,7 @@ class CitationListView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>
@@ -257,7 +257,7 @@ class CitationListView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-add</property>
         <property name="action-name">win.Add</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Add...</property>
         <property name="use-underline">True</property>
       </object>
@@ -269,7 +269,7 @@ class CitationListView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gtk-edit</property>
         <property name="action-name">win.Edit</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">Edit...</property>
         <property name="use-underline">True</property>
       </object>
@@ -281,7 +281,7 @@ class CitationListView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-remove</property>
         <property name="action-name">win.Remove</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Delete</property>
         <property name="use-underline">True</property>
       </object>
@@ -293,7 +293,7 @@ class CitationListView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gramps-merge</property>
         <property name="action-name">win.Merge</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text" >%s</property>
         <property name="label" translatable="yes">_Merge...</property>
         <property name="use-underline">True</property>
       </object>
@@ -324,7 +324,6 @@ class CitationListView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>

--- a/gramps/plugins/view/citationtreeview.py
+++ b/gramps/plugins/view/citationtreeview.py
@@ -350,7 +350,7 @@ class CitationTreeView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>
@@ -403,7 +403,7 @@ class CitationTreeView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-add</property>
         <property name="action-name">win.Add</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Add...</property>
         <property name="use-underline">True</property>
       </object>
@@ -415,7 +415,7 @@ class CitationTreeView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gramps-source</property>
         <property name="action-name">win.AddSource</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">Add source...</property>
       </object>
       <packing>
@@ -426,7 +426,7 @@ class CitationTreeView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gramps-citation</property>
         <property name="action-name">win.AddCitation</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">Add citation...</property>
       </object>
       <packing>
@@ -437,7 +437,7 @@ class CitationTreeView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gtk-edit</property>
         <property name="action-name">win.Edit</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">Edit...</property>
         <property name="use-underline">True</property>
       </object>
@@ -449,7 +449,7 @@ class CitationTreeView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-remove</property>
         <property name="action-name">win.Remove</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Delete</property>
         <property name="use-underline">True</property>
       </object>
@@ -461,7 +461,7 @@ class CitationTreeView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gramps-merge</property>
         <property name="action-name">win.Merge</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Merge...</property>
         <property name="use-underline">True</property>
       </object>
@@ -508,7 +508,7 @@ class CitationTreeView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>

--- a/gramps/plugins/view/eventview.py
+++ b/gramps/plugins/view/eventview.py
@@ -214,7 +214,7 @@ class EventView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>
@@ -271,7 +271,7 @@ class EventView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-add</property>
         <property name="action-name">win.Add</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Add...</property>
         <property name="use-underline">True</property>
       </object>
@@ -283,7 +283,7 @@ class EventView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gtk-edit</property>
         <property name="action-name">win.Edit</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">Edit...</property>
         <property name="use-underline">True</property>
       </object>
@@ -295,7 +295,7 @@ class EventView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-remove</property>
         <property name="action-name">win.Remove</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Delete</property>
         <property name="use-underline">True</property>
       </object>
@@ -307,7 +307,7 @@ class EventView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gramps-merge</property>
         <property name="action-name">win.Merge</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Merge...</property>
         <property name="use-underline">True</property>
       </object>
@@ -338,7 +338,7 @@ class EventView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>

--- a/gramps/plugins/view/familyview.py
+++ b/gramps/plugins/view/familyview.py
@@ -173,7 +173,7 @@ class FamilyView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>
@@ -230,7 +230,7 @@ class FamilyView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-add</property>
         <property name="action-name">win.Add</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Add...</property>
         <property name="use-underline">True</property>
       </object>
@@ -242,7 +242,7 @@ class FamilyView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gtk-edit</property>
         <property name="action-name">win.Edit</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">Edit...</property>
         <property name="use-underline">True</property>
       </object>
@@ -254,7 +254,7 @@ class FamilyView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-remove</property>
         <property name="action-name">win.Remove</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Delete</property>
         <property name="use-underline">True</property>
       </object>
@@ -266,7 +266,7 @@ class FamilyView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gramps-merge</property>
         <property name="action-name">win.Merge</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Merge...</property>
         <property name="use-underline">True</property>
       </object>
@@ -297,7 +297,7 @@ class FamilyView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>

--- a/gramps/plugins/view/geofamily.py
+++ b/gramps/plugins/view/geofamily.py
@@ -104,8 +104,8 @@ _UI_DEF = [
       <object class="GtkToolButton">
         <property name="icon-name">go-previous</property>
         <property name="action-name">win.Back</property>
-        <property name="tooltip_text" translatable="yes">...
-    ...Go to the previous object in the history</property>
+        <property name="tooltip_text" translatable="yes">'''
+    '''Go to the previous object in the history</property>
         <property name="label" translatable="yes">_Back</property>
         <property name="use-underline">True</property>
       </object>

--- a/gramps/plugins/view/mediaview.py
+++ b/gramps/plugins/view/mediaview.py
@@ -273,7 +273,7 @@ class MediaView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>
@@ -330,7 +330,7 @@ class MediaView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-add</property>
         <property name="action-name">win.Add</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Add...</property>
         <property name="use-underline">True</property>
       </object>
@@ -342,7 +342,7 @@ class MediaView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gtk-edit</property>
         <property name="action-name">win.Edit</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">Edit...</property>
         <property name="use-underline">True</property>
       </object>
@@ -354,7 +354,7 @@ class MediaView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-remove</property>
         <property name="action-name">win.Remove</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Delete</property>
         <property name="use-underline">True</property>
       </object>
@@ -366,7 +366,7 @@ class MediaView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gramps-merge</property>
         <property name="action-name">win.Merge</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Merge...</property>
         <property name="use-underline">True</property>
       </object>
@@ -422,7 +422,7 @@ class MediaView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>

--- a/gramps/plugins/view/noteview.py
+++ b/gramps/plugins/view/noteview.py
@@ -147,7 +147,7 @@ class NoteView(ListView):
         </item>
         <item>
           <attribute name="action">win.EditBook</attribute>
-          <attribute name="label" translatable="no">%s...</attribute>
+          <attribute name="label">%s...</attribute>
         </item>
       </section>
 ''' % _('Organize Bookmarks'),
@@ -173,7 +173,7 @@ class NoteView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>
@@ -230,7 +230,7 @@ class NoteView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-add</property>
         <property name="action-name">win.Add</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Add...</property>
         <property name="use-underline">True</property>
       </object>
@@ -242,7 +242,7 @@ class NoteView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gtk-edit</property>
         <property name="action-name">win.Edit</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">Edit...</property>
         <property name="use-underline">True</property>
       </object>
@@ -254,7 +254,7 @@ class NoteView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-remove</property>
         <property name="action-name">win.Remove</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Delete</property>
         <property name="use-underline">True</property>
       </object>
@@ -266,7 +266,7 @@ class NoteView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gramps-merge</property>
         <property name="action-name">win.Merge</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Merge...</property>
         <property name="use-underline">True</property>
       </object>
@@ -297,7 +297,7 @@ class NoteView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>

--- a/gramps/plugins/view/repoview.py
+++ b/gramps/plugins/view/repoview.py
@@ -186,7 +186,7 @@ class RepositoryView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>
@@ -243,7 +243,7 @@ class RepositoryView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-add</property>
         <property name="action-name">win.Add</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Add...</property>
         <property name="use-underline">True</property>
       </object>
@@ -255,7 +255,7 @@ class RepositoryView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gtk-edit</property>
         <property name="action-name">win.Edit</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">Edit...</property>
         <property name="use-underline">True</property>
       </object>
@@ -267,7 +267,7 @@ class RepositoryView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-remove</property>
         <property name="action-name">win.Remove</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Delete</property>
         <property name="use-underline">True</property>
       </object>
@@ -279,7 +279,7 @@ class RepositoryView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gramps-merge</property>
         <property name="action-name">win.Merge</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Merge...</property>
         <property name="use-underline">True</property>
       </object>
@@ -310,7 +310,7 @@ class RepositoryView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>

--- a/gramps/plugins/view/sourceview.py
+++ b/gramps/plugins/view/sourceview.py
@@ -172,7 +172,7 @@ class SourceView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>
@@ -229,7 +229,7 @@ class SourceView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-add</property>
         <property name="action-name">win.Add</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Add...</property>
         <property name="use-underline">True</property>
       </object>
@@ -241,7 +241,7 @@ class SourceView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gtk-edit</property>
         <property name="action-name">win.Edit</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">Edit...</property>
         <property name="use-underline">True</property>
       </object>
@@ -253,7 +253,7 @@ class SourceView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">list-remove</property>
         <property name="action-name">win.Remove</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Delete</property>
         <property name="use-underline">True</property>
       </object>
@@ -265,7 +265,7 @@ class SourceView(ListView):
       <object class="GtkToolButton">
         <property name="icon-name">gramps-merge</property>
         <property name="action-name">win.Merge</property>
-        <property name="tooltip_text" translatable="yes">%s</property>
+        <property name="tooltip_text">%s</property>
         <property name="label" translatable="yes">_Merge...</property>
         <property name="use-underline">True</property>
       </object>
@@ -296,7 +296,7 @@ class SourceView(ListView):
         </item>
         <item>
           <attribute name="action">win.Edit</attribute>
-          <attribute name="label" translatable="yes">%s</attribute>
+          <attribute name="label">%s</attribute>
         </item>
         <item>
           <attribute name="action">win.Remove</attribute>

--- a/po/gramps.pot
+++ b/po/gramps.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-26 11:20-0600\n"
+"POT-Creation-Date: 2019-06-13 17:22-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -883,7 +883,7 @@ msgstr ""
 #: ../gramps/cli/arghandler.py:443 ../gramps/cli/arghandler.py:444
 #: ../gramps/cli/arghandler.py:446 ../gramps/cli/clidbman.py:69
 #: ../gramps/cli/clidbman.py:169 ../gramps/cli/clidbman.py:197
-#: ../gramps/gui/clipboard.py:916 ../gramps/gui/configure.py:1583
+#: ../gramps/gui/clipboard.py:916 ../gramps/gui/configure.py:1798
 msgid "Family Tree"
 msgstr ""
 
@@ -997,7 +997,7 @@ msgstr ""
 msgid "Unknown action: %s."
 msgstr ""
 
-#: ../gramps/cli/argparser.py:55
+#: ../gramps/cli/argparser.py:56
 msgid ""
 "\n"
 "Usage: gramps.py [OPTION...]\n"
@@ -1032,9 +1032,19 @@ msgid ""
 "  -q, --quiet                            Suppress progress indication output "
 "(non-GUI mode only)\n"
 "  -v, --version                          Show versions\n"
+"  -S, --safe                             Start Gramps in 'Safe mode'\n"
+"                                          (temporarily use default "
+"settings)\n"
+"  -D, --default=[APXFE]                  Reset settings to default;\n"
+"                 A - addons are cleared\n"
+"                 P - Preferences to default\n"
+"                 X - Books are cleared, reports and tool settings to "
+"default\n"
+"                 F - filters are cleared\n"
+"                 E - Everything is set to default or cleared\n"
 msgstr ""
 
-#: ../gramps/cli/argparser.py:86
+#: ../gramps/cli/argparser.py:95
 msgid ""
 "\n"
 "Example of usage of Gramps command line interface\n"
@@ -1093,65 +1103,65 @@ msgid ""
 "Syntax may be different for other shells and for Windows.\n"
 msgstr ""
 
-#: ../gramps/cli/argparser.py:248 ../gramps/cli/argparser.py:421
+#: ../gramps/cli/argparser.py:257 ../gramps/cli/argparser.py:470
 msgid "Error parsing the arguments"
 msgstr ""
 
-#: ../gramps/cli/argparser.py:250
+#: ../gramps/cli/argparser.py:259
 #, python-format
 msgid ""
 "Error parsing the arguments: %s \n"
 "Type gramps --help for an overview of commands, or read the manual pages."
 msgstr ""
 
-#: ../gramps/cli/argparser.py:268
+#: ../gramps/cli/argparser.py:277
 #, python-format
 msgid "Trying to open: %s ..."
 msgstr ""
 
-#: ../gramps/cli/argparser.py:312
+#: ../gramps/cli/argparser.py:321
 #, python-format
 msgid ""
 "WARNING: %(strerr)s (errno=%(errno)s):\n"
 "WARNING: %(name)s\n"
 msgstr ""
 
-#: ../gramps/cli/argparser.py:324
+#: ../gramps/cli/argparser.py:333
 #, python-format
 msgid "Unknown action: %s. Ignoring."
 msgstr ""
 
-#: ../gramps/cli/argparser.py:334
+#: ../gramps/cli/argparser.py:343
 msgid "setup debugging"
 msgstr ""
 
-#: ../gramps/cli/argparser.py:345
+#: ../gramps/cli/argparser.py:355
 #, python-format
 msgid "Gramps config settings from %s:"
 msgstr ""
 
-#: ../gramps/cli/argparser.py:362
+#: ../gramps/cli/argparser.py:373
 #, python-format
 msgid "Current Gramps config setting: %(name)s:%(value)s"
 msgstr ""
 
 #. does a user want the default config value?
-#: ../gramps/cli/argparser.py:369
+#: ../gramps/cli/argparser.py:380
 msgid "DEFAULT"
 msgstr ""
 
 #. translators: indent "New" to match "Current"
-#: ../gramps/cli/argparser.py:376
+#: ../gramps/cli/argparser.py:387
 #, python-format
 msgid "    New Gramps config setting: %(name)s:%(value)s"
 msgstr ""
 
-#: ../gramps/cli/argparser.py:384
+#: ../gramps/cli/argparser.py:395
 #, python-format
 msgid "Gramps: no such config setting: '%s'"
 msgstr ""
 
-#: ../gramps/cli/argparser.py:422
+#: ../gramps/cli/argparser.py:471
 #, python-format
 msgid ""
 "Error parsing the arguments: %s \n"
@@ -1181,11 +1191,11 @@ msgstr ""
 msgid "Path"
 msgstr ""
 
-#: ../gramps/cli/clidbman.py:171 ../gramps/gen/plug/_pluginreg.py:90
+#: ../gramps/cli/clidbman.py:171 ../gramps/gen/plug/_pluginreg.py:91
 msgid "Database"
 msgstr ""
 
-#: ../gramps/cli/clidbman.py:172 ../gramps/gui/dbman.py:411
+#: ../gramps/cli/clidbman.py:172 ../gramps/gui/dbman.py:410
 msgid "Last accessed"
 msgstr ""
 
@@ -1203,22 +1213,22 @@ msgstr ""
 #. translators: needed for French, ignore otherwise
 #: ../gramps/cli/clidbman.py:201 ../gramps/gen/plug/report/utils.py:160
 #: ../gramps/gui/editors/editattribute.py:135
-#: ../gramps/gui/editors/editname.py:310 ../gramps/gui/plug/_windows.py:685
-#: ../gramps/gui/plug/_windows.py:1116
+#: ../gramps/gui/editors/editname.py:310 ../gramps/gui/plug/_windows.py:687
+#: ../gramps/gui/plug/_windows.py:1118
 #: ../gramps/plugins/gramplet/whatsnext.py:494
-#: ../gramps/plugins/textreport/birthdayreport.py:183
 #: ../gramps/plugins/textreport/birthdayreport.py:187
-#: ../gramps/plugins/textreport/detancestralreport.py:472
-#: ../gramps/plugins/textreport/detdescendantreport.py:504
+#: ../gramps/plugins/textreport/birthdayreport.py:191
+#: ../gramps/plugins/textreport/detancestralreport.py:475
+#: ../gramps/plugins/textreport/detdescendantreport.py:505
 #: ../gramps/plugins/textreport/familygroup.py:140
 #: ../gramps/plugins/textreport/familygroup.py:306
 #: ../gramps/plugins/textreport/indivcomplete.py:917
 #: ../gramps/plugins/textreport/indivcomplete.py:957
 #: ../gramps/plugins/textreport/indivcomplete.py:1028
 #: ../gramps/plugins/textreport/placereport.py:185
-#: ../gramps/plugins/webreport/basepage.py:692
-#: ../gramps/plugins/webreport/basepage.py:2186
-#: ../gramps/plugins/webreport/basepage.py:2231
+#: ../gramps/plugins/webreport/basepage.py:715
+#: ../gramps/plugins/webreport/basepage.py:2275
+#: ../gramps/plugins/webreport/basepage.py:2320
 #, python-format
 msgid "%(str1)s: %(str2)s"
 msgstr ""
@@ -1233,7 +1243,7 @@ msgid "Import finished..."
 msgstr ""
 
 #. Create a new database
-#: ../gramps/cli/clidbman.py:366 ../gramps/plugins/importer/importcsv.py:343
+#: ../gramps/cli/clidbman.py:366 ../gramps/plugins/importer/importcsv.py:359
 msgid "Importing data..."
 msgstr ""
 
@@ -1248,7 +1258,7 @@ msgid ""
 "\"%s\"?"
 msgstr ""
 
-#: ../gramps/cli/clidbman.py:436 ../gramps/gui/dbman.py:739
+#: ../gramps/cli/clidbman.py:436 ../gramps/gui/dbman.py:738
 msgid "Could not delete Family Tree"
 msgstr ""
 
@@ -1268,8 +1278,8 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../gramps/cli/clidbman.py:535 ../gramps/gui/configure.py:1424
-#: ../gramps/gui/configure.py:1571
+#: ../gramps/cli/clidbman.py:535 ../gramps/gui/configure.py:1633
+#: ../gramps/gui/configure.py:1786
 msgid "Never"
 msgstr ""
 
@@ -1289,9 +1299,9 @@ msgstr ""
 #. 00-00-yyyy
 #. oo-oo-yyyy
 #. dd-mm-00 (does this mean we do not know about the year?)
-#. This function tries to parse the text and create a proper Gramps Date()
-#. object. If all else fails we create a MOD_TEXTONLY Date() object.
-#: ../gramps/cli/clidbman.py:553 ../gramps/gen/lib/attrtype.py:62
+#. Function tries to parse the text and create a proper Gramps Date()
+#. object. If all else fails create a MOD_TEXTONLY Date() object.
+#: ../gramps/cli/clidbman.py:553 ../gramps/gen/lib/attrtype.py:63
 #: ../gramps/gen/lib/childreftype.py:73 ../gramps/gen/lib/eventroletype.py:52
 #: ../gramps/gen/lib/eventtype.py:162 ../gramps/gen/lib/familyreltype.py:50
 #: ../gramps/gen/lib/grampstype.py:34 ../gramps/gen/lib/nameorigintype.py:73
@@ -1303,8 +1313,8 @@ msgstr ""
 #: ../gramps/gen/utils/unknown.py:120 ../gramps/gen/utils/unknown.py:122
 #: ../gramps/gen/utils/unknown.py:126 ../gramps/gen/utils/unknown.py:132
 #: ../gramps/gen/utils/unknown.py:137 ../gramps/gui/clipboard.py:185
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:125
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:143
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:173
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:191
 #: ../gramps/gui/editors/editmedia.py:178
 #: ../gramps/gui/editors/editmediaref.py:143
 #: ../gramps/plugins/db/bsddb/write.py:2294
@@ -1312,61 +1322,60 @@ msgstr ""
 #: ../gramps/plugins/gramplet/persondetails.py:219
 #: ../gramps/plugins/gramplet/persondetails.py:221
 #: ../gramps/plugins/gramplet/persondetails.py:222
-#: ../gramps/plugins/gramplet/relativegramplet.py:124
-#: ../gramps/plugins/gramplet/relativegramplet.py:135
-#: ../gramps/plugins/graph/gvfamilylines.py:280
-#: ../gramps/plugins/graph/gvhourglass.py:376
-#: ../gramps/plugins/graph/gvrelgraph.py:904
-#: ../gramps/plugins/importer/importprogen.py:986
-#: ../gramps/plugins/lib/maps/geography.py:839
-#: ../gramps/plugins/lib/maps/geography.py:849
-#: ../gramps/plugins/lib/maps/geography.py:850
+#: ../gramps/plugins/gramplet/relativegramplet.py:126
+#: ../gramps/plugins/gramplet/relativegramplet.py:137
+#: ../gramps/plugins/graph/gvfamilylines.py:287
+#: ../gramps/plugins/graph/gvhourglass.py:427
+#: ../gramps/plugins/graph/gvrelgraph.py:948
+#: ../gramps/plugins/lib/libprogen.py:1057
+#: ../gramps/plugins/lib/maps/geography.py:802
+#: ../gramps/plugins/lib/maps/geography.py:812
+#: ../gramps/plugins/lib/maps/geography.py:813
 #: ../gramps/plugins/quickview/all_relations.py:277
 #: ../gramps/plugins/quickview/all_relations.py:294
 #: ../gramps/plugins/textreport/descendreport.py:322
-#: ../gramps/plugins/textreport/detancestralreport.py:212
-#: ../gramps/plugins/textreport/detancestralreport.py:296
-#: ../gramps/plugins/textreport/detancestralreport.py:586
-#: ../gramps/plugins/textreport/detancestralreport.py:588
-#: ../gramps/plugins/textreport/detancestralreport.py:595
-#: ../gramps/plugins/textreport/detancestralreport.py:597
-#: ../gramps/plugins/textreport/detancestralreport.py:612
-#: ../gramps/plugins/textreport/detancestralreport.py:667
-#: ../gramps/plugins/textreport/detancestralreport.py:669
-#: ../gramps/plugins/textreport/detancestralreport.py:676
-#: ../gramps/plugins/textreport/detancestralreport.py:678
-#: ../gramps/plugins/textreport/detancestralreport.py:736
-#: ../gramps/plugins/textreport/detdescendantreport.py:336
-#: ../gramps/plugins/textreport/detdescendantreport.py:434
-#: ../gramps/plugins/textreport/detdescendantreport.py:610
-#: ../gramps/plugins/textreport/detdescendantreport.py:650
-#: ../gramps/plugins/textreport/detdescendantreport.py:652
-#: ../gramps/plugins/textreport/detdescendantreport.py:659
-#: ../gramps/plugins/textreport/detdescendantreport.py:661
-#: ../gramps/plugins/textreport/detdescendantreport.py:689
-#: ../gramps/plugins/textreport/detdescendantreport.py:834
+#: ../gramps/plugins/textreport/detancestralreport.py:213
+#: ../gramps/plugins/textreport/detancestralreport.py:297
+#: ../gramps/plugins/textreport/detancestralreport.py:589
+#: ../gramps/plugins/textreport/detancestralreport.py:591
+#: ../gramps/plugins/textreport/detancestralreport.py:598
+#: ../gramps/plugins/textreport/detancestralreport.py:600
+#: ../gramps/plugins/textreport/detancestralreport.py:615
+#: ../gramps/plugins/textreport/detancestralreport.py:672
+#: ../gramps/plugins/textreport/detancestralreport.py:674
+#: ../gramps/plugins/textreport/detancestralreport.py:681
+#: ../gramps/plugins/textreport/detancestralreport.py:683
+#: ../gramps/plugins/textreport/detancestralreport.py:741
+#: ../gramps/plugins/textreport/detdescendantreport.py:337
+#: ../gramps/plugins/textreport/detdescendantreport.py:435
+#: ../gramps/plugins/textreport/detdescendantreport.py:611
+#: ../gramps/plugins/textreport/detdescendantreport.py:651
+#: ../gramps/plugins/textreport/detdescendantreport.py:653
+#: ../gramps/plugins/textreport/detdescendantreport.py:660
+#: ../gramps/plugins/textreport/detdescendantreport.py:662
+#: ../gramps/plugins/textreport/detdescendantreport.py:690
+#: ../gramps/plugins/textreport/detdescendantreport.py:837
 #: ../gramps/plugins/textreport/indivcomplete.py:85
 #: ../gramps/plugins/textreport/indivcomplete.py:940
 #: ../gramps/plugins/tool/check.py:2440 ../gramps/plugins/tool/check.py:2466
 #: ../gramps/plugins/tool/dumpgenderstats.py:74
 #: ../gramps/plugins/tool/dumpgenderstats.py:97
 #: ../gramps/plugins/tool/dumpgenderstats.py:100
-#: ../gramps/plugins/view/geoclose.py:525
-#: ../gramps/plugins/view/geofamclose.py:271
-#: ../gramps/plugins/view/geofamclose.py:715
-#: ../gramps/plugins/view/geofamily.py:467
-#: ../gramps/plugins/view/geomoves.py:596
-#: ../gramps/plugins/view/geoperson.py:477
-#: ../gramps/plugins/view/geoplaces.py:531
-#: ../gramps/plugins/view/relview.py:460 ../gramps/plugins/view/relview.py:995
-#: ../gramps/plugins/view/relview.py:1050
-#: ../gramps/plugins/webreport/basepage.py:1751
-#: ../gramps/plugins/webreport/basepage.py:1780
-#: ../gramps/plugins/webreport/basepage.py:1785
-#: ../gramps/plugins/webreport/basepage.py:1792
-#: ../gramps/plugins/webreport/basepage.py:2175
-#: ../gramps/plugins/webreport/basepage.py:2272
-#: ../gramps/plugins/webreport/basepage.py:2387
+#: ../gramps/plugins/view/geoclose.py:595
+#: ../gramps/plugins/view/geofamclose.py:349
+#: ../gramps/plugins/view/geofamclose.py:785
+#: ../gramps/plugins/view/geofamily.py:517
+#: ../gramps/plugins/view/geomoves.py:662
+#: ../gramps/plugins/view/geoperson.py:543
+#: ../gramps/plugins/view/geoplaces.py:590
+#: ../gramps/plugins/view/relview.py:589 ../gramps/plugins/view/relview.py:1160
+#: ../gramps/plugins/view/relview.py:1215
+#: ../gramps/plugins/webreport/basepage.py:1838
+#: ../gramps/plugins/webreport/basepage.py:1868
+#: ../gramps/plugins/webreport/basepage.py:1873
+#: ../gramps/plugins/webreport/basepage.py:1880
+#: ../gramps/plugins/webreport/basepage.py:2264
+#: ../gramps/plugins/webreport/basepage.py:2436
 msgid "Unknown"
 msgstr ""
 
@@ -1381,12 +1390,12 @@ msgid "ERROR: %s"
 msgstr ""
 
 #: ../gramps/cli/grampscli.py:106 ../gramps/cli/user.py:200
-#: ../gramps/gui/dialog.py:249
+#: ../gramps/gui/dialog.py:295
 msgid "Low level database corruption detected"
 msgstr ""
 
 #: ../gramps/cli/grampscli.py:108 ../gramps/cli/user.py:201
-#: ../gramps/gui/dialog.py:250
+#: ../gramps/gui/dialog.py:296
 msgid ""
 "Gramps has detected a problem in the underlying Berkeley database. This can "
 "be repaired from the Family Tree Manager. Select the database and click on "
@@ -1561,7 +1570,7 @@ msgstr ""
 #: ../gramps/plugins/gramplet/whatsnext.py:441
 #: ../gramps/plugins/gramplet/whatsnext.py:474
 #: ../gramps/plugins/gramplet/whatsnext.py:496
-#: ../gramps/plugins/graph/gvrelgraph.py:674
+#: ../gramps/plugins/graph/gvrelgraph.py:707
 #: ../gramps/plugins/textreport/descendreport.py:270
 #: ../gramps/plugins/textreport/descendreport.py:280
 #: ../gramps/plugins/textreport/descendreport.py:286
@@ -1622,11 +1631,11 @@ msgstr ""
 msgid "Failed to make '%s' report."
 msgstr ""
 
-#: ../gramps/cli/user.py:217 ../gramps/gui/dialog.py:235
+#: ../gramps/cli/user.py:217 ../gramps/gui/dialog.py:281
 msgid "Error detected in database"
 msgstr ""
 
-#: ../gramps/cli/user.py:218 ../gramps/gui/dialog.py:236
+#: ../gramps/cli/user.py:218 ../gramps/gui/dialog.py:282
 #, python-format
 msgid ""
 "Gramps has detected an error in the database. This can usually be resolved "
@@ -1637,27 +1646,27 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../gramps/gen/config.py:242
+#: ../gramps/gen/config.py:247
 msgid "Imported %Y/%m/%d %H:%M:%S"
 msgstr ""
 
-#: ../gramps/gen/config.py:253
+#: ../gramps/gen/config.py:258
 msgid "Missing Given Name"
 msgstr ""
 
-#: ../gramps/gen/config.py:254
+#: ../gramps/gen/config.py:259
 msgid "Missing Record"
 msgstr ""
 
-#: ../gramps/gen/config.py:255
+#: ../gramps/gen/config.py:260
 msgid "Missing Surname"
 msgstr ""
 
-#: ../gramps/gen/config.py:262 ../gramps/gen/config.py:264
+#: ../gramps/gen/config.py:267 ../gramps/gen/config.py:269
 msgid "[Living]"
 msgstr ""
 
-#: ../gramps/gen/config.py:263
+#: ../gramps/gen/config.py:268
 msgid "Private Record"
 msgstr ""
 
@@ -1666,27 +1675,27 @@ msgstr ""
 #. http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
 #. to learn how to select proper inflection to be used in your localized
 #. DateDisplayer code!
-#: ../gramps/gen/config.py:306 ../gramps/gen/datehandler/_datestrings.py:79
+#: ../gramps/gen/config.py:320 ../gramps/gen/datehandler/_datestrings.py:79
 msgid "localized lexeme inflections||January"
 msgstr ""
 
-#: ../gramps/gen/const.py:221
+#: ../gramps/gen/const.py:229
 msgid ""
 "Gramps\n"
 " (Genealogical Research and Analysis Management Programming System)\n"
 "is a personal genealogy program."
 msgstr ""
 
-#: ../gramps/gen/const.py:251
+#: ../gramps/gen/const.py:259
 msgid "surname|none"
 msgstr ""
 
-#: ../gramps/gen/const.py:252
+#: ../gramps/gen/const.py:260
 msgid "given-name|none"
 msgstr ""
 
-#: ../gramps/gen/const.py:256 ../gramps/plugins/gramplet/todo.py:202
-#: ../gramps/plugins/webreport/basepage.py:140
+#: ../gramps/gen/const.py:264 ../gramps/plugins/gramplet/todo.py:202
+#: ../gramps/plugins/webreport/basepage.py:147
 msgid ":"
 msgstr ""
 
@@ -2497,7 +2506,7 @@ msgstr ""
 msgid "Sat"
 msgstr ""
 
-#: ../gramps/gen/db/base.py:1816 ../gramps/gui/widgets/fanchart.py:1808
+#: ../gramps/gen/db/base.py:1816 ../gramps/gui/widgets/fanchart.py:2077
 msgid "Add child to family"
 msgstr ""
 
@@ -2687,29 +2696,29 @@ msgstr ""
 #: ../gramps/gen/db/generic.py:2411 ../gramps/plugins/db/bsddb/read.py:1939
 #: ../gramps/plugins/db/bsddb/write.py:2297
 #: ../gramps/plugins/gramplet/statsgramplet.py:170
-#: ../gramps/plugins/webreport/statistics.py:130
-#: ../gramps/plugins/webreport/statistics.py:195
+#: ../gramps/plugins/webreport/statistics.py:131
+#: ../gramps/plugins/webreport/statistics.py:196
 msgid "Number of families"
 msgstr ""
 
 #: ../gramps/gen/db/generic.py:2412 ../gramps/plugins/db/bsddb/read.py:1940
 #: ../gramps/plugins/db/bsddb/write.py:2298
-#: ../gramps/plugins/webreport/statistics.py:158
-#: ../gramps/plugins/webreport/statistics.py:207
+#: ../gramps/plugins/webreport/statistics.py:159
+#: ../gramps/plugins/webreport/statistics.py:208
 msgid "Number of sources"
 msgstr ""
 
 #: ../gramps/gen/db/generic.py:2413 ../gramps/plugins/db/bsddb/read.py:1941
 #: ../gramps/plugins/db/bsddb/write.py:2299
-#: ../gramps/plugins/webreport/statistics.py:162
-#: ../gramps/plugins/webreport/statistics.py:210
+#: ../gramps/plugins/webreport/statistics.py:163
+#: ../gramps/plugins/webreport/statistics.py:211
 msgid "Number of citations"
 msgstr ""
 
 #: ../gramps/gen/db/generic.py:2414 ../gramps/plugins/db/bsddb/read.py:1942
 #: ../gramps/plugins/db/bsddb/write.py:2300
-#: ../gramps/plugins/webreport/statistics.py:151
-#: ../gramps/plugins/webreport/statistics.py:201
+#: ../gramps/plugins/webreport/statistics.py:152
+#: ../gramps/plugins/webreport/statistics.py:202
 msgid "Number of events"
 msgstr ""
 
@@ -2720,15 +2729,15 @@ msgstr ""
 
 #: ../gramps/gen/db/generic.py:2416 ../gramps/plugins/db/bsddb/read.py:1944
 #: ../gramps/plugins/db/bsddb/write.py:2302
-#: ../gramps/plugins/webreport/statistics.py:154
-#: ../gramps/plugins/webreport/statistics.py:204
+#: ../gramps/plugins/webreport/statistics.py:155
+#: ../gramps/plugins/webreport/statistics.py:205
 msgid "Number of places"
 msgstr ""
 
 #: ../gramps/gen/db/generic.py:2417 ../gramps/plugins/db/bsddb/read.py:1945
 #: ../gramps/plugins/db/bsddb/write.py:2303
-#: ../gramps/plugins/webreport/statistics.py:166
-#: ../gramps/plugins/webreport/statistics.py:213
+#: ../gramps/plugins/webreport/statistics.py:167
+#: ../gramps/plugins/webreport/statistics.py:214
 msgid "Number of repositories"
 msgstr ""
 
@@ -2760,15 +2769,15 @@ msgid "Surname, Given Suffix"
 msgstr ""
 
 #: ../gramps/gen/display/name.py:356 ../gramps/gen/utils/keyword.py:55
-#: ../gramps/gui/configure.py:697 ../gramps/gui/configure.py:699
-#: ../gramps/gui/configure.py:704 ../gramps/gui/configure.py:706
-#: ../gramps/gui/configure.py:708 ../gramps/gui/configure.py:709
-#: ../gramps/gui/configure.py:710 ../gramps/gui/configure.py:711
-#: ../gramps/gui/configure.py:713 ../gramps/gui/configure.py:714
-#: ../gramps/gui/configure.py:715 ../gramps/gui/configure.py:716
-#: ../gramps/gui/configure.py:717 ../gramps/gui/configure.py:718
+#: ../gramps/gui/configure.py:844 ../gramps/gui/configure.py:846
+#: ../gramps/gui/configure.py:851 ../gramps/gui/configure.py:853
+#: ../gramps/gui/configure.py:855 ../gramps/gui/configure.py:856
+#: ../gramps/gui/configure.py:857 ../gramps/gui/configure.py:858
+#: ../gramps/gui/configure.py:860 ../gramps/gui/configure.py:861
+#: ../gramps/gui/configure.py:862 ../gramps/gui/configure.py:863
+#: ../gramps/gui/configure.py:864 ../gramps/gui/configure.py:865
 #: ../gramps/plugins/export/exportcsv.py:354
-#: ../gramps/plugins/importer/importcsv.py:162
+#: ../gramps/plugins/importer/importcsv.py:163
 msgid "Given"
 msgstr ""
 
@@ -2792,18 +2801,18 @@ msgid "Person|title"
 msgstr ""
 
 #: ../gramps/gen/display/name.py:604 ../gramps/gen/display/name.py:704
-#: ../gramps/plugins/importer/importcsv.py:161
+#: ../gramps/plugins/importer/importcsv.py:162
 msgid "given"
 msgstr ""
 
 #: ../gramps/gen/display/name.py:606 ../gramps/gen/display/name.py:706
-#: ../gramps/plugins/importer/importcsv.py:158
+#: ../gramps/plugins/importer/importcsv.py:159
 msgid "surname"
 msgstr ""
 
 #: ../gramps/gen/display/name.py:608 ../gramps/gen/display/name.py:708
-#: ../gramps/gui/editors/editperson.py:386
-#: ../gramps/plugins/importer/importcsv.py:167
+#: ../gramps/gui/editors/editperson.py:379
+#: ../gramps/plugins/importer/importcsv.py:168
 msgid "suffix"
 msgstr ""
 
@@ -2860,8 +2869,8 @@ msgid "Remaining names|rest"
 msgstr ""
 
 #: ../gramps/gen/display/name.py:645 ../gramps/gen/display/name.py:737
-#: ../gramps/gui/editors/editperson.py:407
-#: ../gramps/plugins/importer/importcsv.py:166
+#: ../gramps/gui/editors/editperson.py:400
+#: ../gramps/plugins/importer/importcsv.py:167
 msgid "prefix"
 msgstr ""
 
@@ -2905,8 +2914,8 @@ msgstr ""
 msgid "ERROR: filter %s could not be correctly loaded. Edit the filter!"
 msgstr ""
 
-#: ../gramps/gen/filters/_genericfilter.py:139
-#: ../gramps/gen/filters/_genericfilter.py:169
+#: ../gramps/gen/filters/_genericfilter.py:143
+#: ../gramps/gen/filters/_genericfilter.py:174
 msgid "Applying ..."
 msgstr ""
 
@@ -2914,11 +2923,11 @@ msgstr ""
 #. ###############################
 #. #########################
 #. ###############################
-#: ../gramps/gen/filters/_genericfilter.py:139
-#: ../gramps/gen/filters/_genericfilter.py:169
-#: ../gramps/gui/editors/filtereditor.py:1105
+#: ../gramps/gen/filters/_genericfilter.py:143
+#: ../gramps/gen/filters/_genericfilter.py:174
+#: ../gramps/gui/editors/filtereditor.py:1119
 #: ../gramps/plugins/drawreport/calendarreport.py:466
-#: ../gramps/plugins/drawreport/statisticschart.py:1001
+#: ../gramps/plugins/drawreport/statisticschart.py:1012
 #: ../gramps/plugins/drawreport/timeline.py:416
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1009
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1023
@@ -2929,21 +2938,21 @@ msgstr ""
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1093
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1107
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1121
-#: ../gramps/plugins/graph/gvrelgraph.py:768
+#: ../gramps/plugins/graph/gvrelgraph.py:801
 #: ../gramps/plugins/quickview/quickview.gpr.py:130
-#: ../gramps/plugins/textreport/birthdayreport.py:414
+#: ../gramps/plugins/textreport/birthdayreport.py:473
 #: ../gramps/plugins/textreport/familygroup.py:714
 #: ../gramps/plugins/textreport/indivcomplete.py:1062
 #: ../gramps/plugins/textreport/recordsreport.py:217
-#: ../gramps/plugins/tool/sortevents.py:167
-#: ../gramps/plugins/webreport/narrativeweb.py:1602
-#: ../gramps/plugins/webreport/webcal.py:1633
+#: ../gramps/plugins/tool/sortevents.py:168
+#: ../gramps/plugins/webreport/narrativeweb.py:1639
+#: ../gramps/plugins/webreport/webcal.py:1671
 msgid "Filter"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/_changedsincebase.py:56
 #: ../gramps/gen/filters/rules/_everything.py:45
-#: ../gramps/gen/filters/rules/_hasattributebase.py:51
+#: ../gramps/gen/filters/rules/_hasattributebase.py:53
 #: ../gramps/gen/filters/rules/_hasgallerybase.py:48
 #: ../gramps/gen/filters/rules/_hasgrampsid.py:48
 #: ../gramps/gen/filters/rules/_hasldsbase.py:51
@@ -3058,7 +3067,7 @@ msgstr ""
 #: ../gramps/gen/filters/rules/person/_hasevent.py:49
 #: ../gramps/gen/filters/rules/person/_hasfamilyevent.py:49
 #: ../gramps/gen/filters/rules/place/_hascitation.py:49
-#: ../gramps/gui/editors/filtereditor.py:578
+#: ../gramps/gui/editors/filtereditor.py:583
 #: ../gramps/gui/glade/mergecitation.glade:245
 #: ../gramps/gui/glade/mergecitation.glade:261
 #: ../gramps/gui/glade/mergeevent.glade:245
@@ -3115,7 +3124,7 @@ msgstr ""
 #: ../gramps/gen/filters/rules/person/_hasaddress.py:48
 #: ../gramps/gen/filters/rules/person/_hasassociation.py:48
 #: ../gramps/gen/filters/rules/source/_hasrepository.py:46
-#: ../gramps/gui/editors/filtereditor.py:513
+#: ../gramps/gui/editors/filtereditor.py:518
 msgid "Number must be:"
 msgstr ""
 
@@ -3126,14 +3135,14 @@ msgstr ""
 #: ../gramps/gen/filters/rules/person/_hasaddress.py:48
 #: ../gramps/gen/filters/rules/person/_hasassociation.py:48
 #: ../gramps/gen/filters/rules/source/_hasrepository.py:46
-#: ../gramps/gui/editors/filtereditor.py:508
+#: ../gramps/gui/editors/filtereditor.py:513
 msgid "Number of instances:"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/_hasgrampsid.py:45
 #: ../gramps/gen/filters/rules/family/_isancestorof.py:44
 #: ../gramps/gen/filters/rules/family/_isdescendantof.py:44
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:157
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:132
 #: ../gramps/gen/filters/rules/person/_hascommonancestorwith.py:45
 #: ../gramps/gen/filters/rules/person/_isancestorof.py:44
 #: ../gramps/gen/filters/rules/person/_isdescendantfamilyof.py:49
@@ -3148,7 +3157,7 @@ msgstr ""
 #: ../gramps/gen/filters/rules/person/_relationshippathbetween.py:45
 #: ../gramps/gen/filters/rules/place/_isenclosedby.py:48
 #: ../gramps/gen/filters/rules/place/_withinarea.py:50
-#: ../gramps/gui/editors/filtereditor.py:517
+#: ../gramps/gui/editors/filtereditor.py:522
 #: ../gramps/gui/glade/editplaceref.glade:245
 msgid "ID:"
 msgstr ""
@@ -3177,12 +3186,12 @@ msgid "Substring:"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/_hasreferencecountbase.py:42
-#: ../gramps/gui/editors/filtereditor.py:511
+#: ../gramps/gui/editors/filtereditor.py:516
 msgid "Reference count must be:"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/_hasreferencecountbase.py:42
-#: ../gramps/gui/editors/filtereditor.py:507
+#: ../gramps/gui/editors/filtereditor.py:512
 msgid "Reference count:"
 msgstr ""
 
@@ -3191,12 +3200,12 @@ msgstr ""
 #: ../gramps/gen/filters/rules/media/_hassourceof.py:45
 #: ../gramps/gen/filters/rules/person/_hassourceof.py:45
 #: ../gramps/gen/filters/rules/place/_hassourceof.py:45
-#: ../gramps/gui/editors/filtereditor.py:520
+#: ../gramps/gui/editors/filtereditor.py:525
 msgid "Source ID:"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/_matchesfilterbase.py:54
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:157
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:132
 #: ../gramps/gen/filters/rules/person/_hascommonancestorwithfiltermatch.py:47
 #: ../gramps/gen/filters/rules/person/_isancestoroffiltermatch.py:46
 #: ../gramps/gen/filters/rules/person/_ischildoffiltermatch.py:46
@@ -3205,7 +3214,7 @@ msgstr ""
 #: ../gramps/gen/filters/rules/person/_isparentoffiltermatch.py:46
 #: ../gramps/gen/filters/rules/person/_issiblingoffiltermatch.py:45
 #: ../gramps/gen/filters/rules/person/_isspouseoffiltermatch.py:46
-#: ../gramps/gui/editors/filtereditor.py:522
+#: ../gramps/gui/editors/filtereditor.py:527
 msgid "Filter name:"
 msgstr ""
 
@@ -3218,7 +3227,7 @@ msgstr ""
 #: ../gramps/gen/filters/rules/_matchessourcefilterbase.py:47
 #: ../gramps/gen/filters/rules/citation/_matchessourcefilter.py:48
 #: ../gramps/gen/filters/rules/event/_matchessourcefilter.py:48
-#: ../gramps/gui/editors/filtereditor.py:530
+#: ../gramps/gui/editors/filtereditor.py:535
 msgid "Source filter name:"
 msgstr ""
 
@@ -3227,11 +3236,11 @@ msgid "Miscellaneous filters"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/_rule.py:56 ../gramps/gui/glade/rule.glade:950
-#: ../gramps/plugins/view/geoclose.py:537
-#: ../gramps/plugins/view/geofamclose.py:727
-#: ../gramps/plugins/view/geofamily.py:480
-#: ../gramps/plugins/view/geomoves.py:609
-#: ../gramps/plugins/view/geoperson.py:488
+#: ../gramps/plugins/view/geoclose.py:607
+#: ../gramps/plugins/view/geofamclose.py:797
+#: ../gramps/plugins/view/geofamily.py:530
+#: ../gramps/plugins/view/geomoves.py:675
+#: ../gramps/plugins/view/geoperson.py:554
 msgid "No description"
 msgstr ""
 
@@ -3305,7 +3314,7 @@ msgstr ""
 #: ../gramps/gen/filters/rules/person/_matchessourceconfidence.py:43
 #: ../gramps/gen/filters/rules/place/_hascitation.py:50
 #: ../gramps/gen/filters/rules/place/_matchessourceconfidence.py:43
-#: ../gramps/gui/editors/filtereditor.py:575
+#: ../gramps/gui/editors/filtereditor.py:580
 msgid "Confidence level:"
 msgstr ""
 
@@ -3442,7 +3451,7 @@ msgstr ""
 #: ../gramps/gen/filters/rules/place/_hastag.py:48
 #: ../gramps/gen/filters/rules/repository/_hastag.py:48
 #: ../gramps/gen/filters/rules/source/_hastag.py:48
-#: ../gramps/gui/editors/filtereditor.py:571
+#: ../gramps/gui/editors/filtereditor.py:576
 msgid "Tag:"
 msgstr ""
 
@@ -3472,7 +3481,7 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/citation/_matchesrepositoryfilter.py:45
 #: ../gramps/gen/filters/rules/source/_matchesrepositoryfilter.py:43
-#: ../gramps/gui/editors/filtereditor.py:532
+#: ../gramps/gui/editors/filtereditor.py:537
 msgid "Repository filter name:"
 msgstr ""
 
@@ -3542,8 +3551,8 @@ msgid "Matches events that are indicated as private"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/event/_hasattribute.py:44
-#: ../gramps/gui/editors/filtereditor.py:106
-#: ../gramps/gui/editors/filtereditor.py:545
+#: ../gramps/gui/editors/filtereditor.py:107
+#: ../gramps/gui/editors/filtereditor.py:550
 msgid "Event attribute:"
 msgstr ""
 
@@ -3575,8 +3584,8 @@ msgstr ""
 #: ../gramps/gen/filters/rules/event/_hasdata.py:47
 #: ../gramps/gen/filters/rules/event/_hastype.py:45
 #: ../gramps/gen/filters/rules/person/_iswitness.py:44
-#: ../gramps/gui/editors/filtereditor.py:103
-#: ../gramps/gui/editors/filtereditor.py:538
+#: ../gramps/gui/editors/filtereditor.py:104
+#: ../gramps/gui/editors/filtereditor.py:543
 msgid "Event type:"
 msgstr ""
 
@@ -3586,7 +3595,7 @@ msgstr ""
 #: ../gramps/gen/filters/rules/person/_hasdeath.py:48
 #: ../gramps/gen/filters/rules/person/_hasevent.py:50
 #: ../gramps/gen/filters/rules/person/_hasfamilyevent.py:50
-#: ../gramps/gui/editors/filtereditor.py:505
+#: ../gramps/gui/editors/filtereditor.py:510
 #: ../gramps/gui/glade/mergeevent.glade:278
 #: ../gramps/gui/glade/mergeevent.glade:294
 msgid "Place:"
@@ -3612,7 +3621,7 @@ msgid "Matches events with data of a particular value"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/event/_hasdayofweek.py:38
-#: ../gramps/gui/editors/filtereditor.py:580
+#: ../gramps/gui/editors/filtereditor.py:585
 msgid "Day of Week:"
 msgstr ""
 
@@ -3705,13 +3714,13 @@ msgid "Matches events matched by the specified filter name"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/event/_matchespersonfilter.py:50
-#: ../gramps/gui/editors/filtereditor.py:567
+#: ../gramps/gui/editors/filtereditor.py:572
 msgid "Include Family events:"
 msgstr ""
 
 #. filters of another namespace, name may be same as caller!
 #: ../gramps/gen/filters/rules/event/_matchespersonfilter.py:50
-#: ../gramps/gui/editors/filtereditor.py:526
+#: ../gramps/gui/editors/filtereditor.py:531
 msgid "Person filter name:"
 msgstr ""
 
@@ -3724,7 +3733,7 @@ msgid "Matches events of persons matched by the specified person filter name"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/event/_matchesplacefilter.py:49
-#: ../gramps/gui/editors/filtereditor.py:534
+#: ../gramps/gui/editors/filtereditor.py:539
 msgid "Place filter name:"
 msgstr ""
 
@@ -3845,8 +3854,8 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/family/_hasattribute.py:44
 #: ../gramps/gen/filters/rules/person/_hasfamilyattribute.py:44
-#: ../gramps/gui/editors/filtereditor.py:105
-#: ../gramps/gui/editors/filtereditor.py:543
+#: ../gramps/gui/editors/filtereditor.py:106
+#: ../gramps/gui/editors/filtereditor.py:548
 msgid "Family attribute:"
 msgstr ""
 
@@ -3868,8 +3877,8 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/family/_hasevent.py:47
 #: ../gramps/gen/filters/rules/person/_hasfamilyevent.py:48
-#: ../gramps/gui/editors/filtereditor.py:102
-#: ../gramps/gui/editors/filtereditor.py:539
+#: ../gramps/gui/editors/filtereditor.py:103
+#: ../gramps/gui/editors/filtereditor.py:544
 msgid "Family event:"
 msgstr ""
 
@@ -3877,7 +3886,7 @@ msgstr ""
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:83
 #: ../gramps/gui/selectors/selectevent.py:67
 #: ../gramps/plugins/gramplet/events.py:92
-#: ../gramps/plugins/view/eventview.py:90
+#: ../gramps/plugins/view/eventview.py:86
 msgid "Main Participants"
 msgstr ""
 
@@ -3947,8 +3956,8 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/family/_hasreltype.py:45
 #: ../gramps/gen/filters/rules/person/_hasrelationship.py:46
-#: ../gramps/gui/editors/filtereditor.py:108
-#: ../gramps/gui/editors/filtereditor.py:549
+#: ../gramps/gui/editors/filtereditor.py:109
+#: ../gramps/gui/editors/filtereditor.py:554
 msgid "Relationship type:"
 msgstr ""
 
@@ -3998,7 +4007,7 @@ msgstr ""
 #: ../gramps/gen/filters/rules/person/_isdescendantfamilyof.py:49
 #: ../gramps/gen/filters/rules/person/_isdescendantof.py:45
 #: ../gramps/gen/filters/rules/place/_isenclosedby.py:48
-#: ../gramps/gui/editors/filtereditor.py:561
+#: ../gramps/gui/editors/filtereditor.py:566
 msgid "Inclusive:"
 msgstr ""
 
@@ -4140,8 +4149,8 @@ msgid ""
 msgstr ""
 
 #: ../gramps/gen/filters/rules/media/_hasattribute.py:44
-#: ../gramps/gui/editors/filtereditor.py:107
-#: ../gramps/gui/editors/filtereditor.py:547
+#: ../gramps/gui/editors/filtereditor.py:108
+#: ../gramps/gui/editors/filtereditor.py:552
 msgid "Media attribute:"
 msgstr ""
 
@@ -4187,7 +4196,7 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/media/_hasmedia.py:48
 #: ../gramps/gui/glade/mergemedia.glade:245
-#: ../gramps/gui/glade/mergemedia.glade:261 ../gramps/gui/viewmanager.py:1879
+#: ../gramps/gui/glade/mergemedia.glade:261 ../gramps/gui/viewmanager.py:1663
 msgid "Path:"
 msgstr ""
 
@@ -4308,8 +4317,8 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/note/_hasnote.py:47
 #: ../gramps/gen/filters/rules/note/_hastype.py:45
-#: ../gramps/gui/editors/filtereditor.py:109
-#: ../gramps/gui/editors/filtereditor.py:551
+#: ../gramps/gui/editors/filtereditor.py:110
+#: ../gramps/gui/editors/filtereditor.py:556
 msgid "Note type:"
 msgstr ""
 
@@ -4395,12 +4404,32 @@ msgid ""
 "ss) or in the range, if a second date-time is given."
 msgstr ""
 
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:53
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:176
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:133
+msgid "Relationship path between <person> and people matching <filter>"
+msgstr ""
+
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:134
+#: ../gramps/gen/filters/rules/person/_isrelatedwith.py:46
+#: ../gramps/gen/filters/rules/person/_relationshippathbetween.py:47
+#: ../gramps/gen/filters/rules/person/_relationshippathbetweenbookmarks.py:52
+msgid "Relationship filters"
+msgstr ""
+
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:135
+msgid ""
+"Searches over the database starting from a specified person and returns "
+"everyone between that person and a set of target people specified with a "
+"filter.  This produces a set of relationship paths (including by marriage) "
+"between the specified person and the target people.  Each path is not "
+"necessarily the shortest path."
+msgstr ""
+
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:152
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:164
 msgid "Finding relationship paths"
 msgstr ""
 
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:54
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:153
 #: ../gramps/gen/filters/rules/person/_hascommonancestorwithfiltermatch.py:69
 #: ../gramps/gen/filters/rules/person/_isancestoroffiltermatch.py:67
 #: ../gramps/gen/filters/rules/person/_ischildoffiltermatch.py:58
@@ -4411,27 +4440,7 @@ msgstr ""
 msgid "Retrieving all sub-filter matches"
 msgstr ""
 
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:158
-msgid "Relationship path between <person> and people matching <filter>"
-msgstr ""
-
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:159
-#: ../gramps/gen/filters/rules/person/_isrelatedwith.py:46
-#: ../gramps/gen/filters/rules/person/_relationshippathbetween.py:47
-#: ../gramps/gen/filters/rules/person/_relationshippathbetweenbookmarks.py:52
-msgid "Relationship filters"
-msgstr ""
-
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:160
-msgid ""
-"Searches over the database starting from a specified person and returns "
-"everyone between that person and a set of target people specified with a "
-"filter.  This produces a set of relationship paths (including by marriage) "
-"between the specified person and the target people.  Each path is not "
-"necessarily the shortest path."
-msgstr ""
-
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:177
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:165
 msgid "Evaluating people"
 msgstr ""
 
@@ -4486,8 +4495,8 @@ msgid "Matches people with a certain number of associations"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/person/_hasattribute.py:44
-#: ../gramps/gui/editors/filtereditor.py:104
-#: ../gramps/gui/editors/filtereditor.py:541
+#: ../gramps/gui/editors/filtereditor.py:105
+#: ../gramps/gui/editors/filtereditor.py:546
 msgid "Personal attribute:"
 msgstr ""
 
@@ -4553,8 +4562,8 @@ msgid "Matches people with death data of a particular value"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/person/_hasevent.py:48
-#: ../gramps/gui/editors/filtereditor.py:101
-#: ../gramps/gui/editors/filtereditor.py:538
+#: ../gramps/gui/editors/filtereditor.py:102
+#: ../gramps/gui/editors/filtereditor.py:543
 msgid "Personal event:"
 msgstr ""
 
@@ -4563,7 +4572,7 @@ msgid "Main Participants:"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/person/_hasevent.py:53
-#: ../gramps/gui/editors/filtereditor.py:569
+#: ../gramps/gui/editors/filtereditor.py:574
 msgid "Primary Role:"
 msgstr ""
 
@@ -4673,8 +4682,8 @@ msgid "Matches people with a specified (partial) name"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/person/_hasnameorigintype.py:46
-#: ../gramps/gui/editors/filtereditor.py:111
-#: ../gramps/gui/editors/filtereditor.py:555
+#: ../gramps/gui/editors/filtereditor.py:112
+#: ../gramps/gui/editors/filtereditor.py:560
 msgid "Surname origin type:"
 msgstr ""
 
@@ -4687,8 +4696,8 @@ msgid "Matches people with a surname origin"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/person/_hasnametype.py:46
-#: ../gramps/gui/editors/filtereditor.py:110
-#: ../gramps/gui/editors/filtereditor.py:553
+#: ../gramps/gui/editors/filtereditor.py:111
+#: ../gramps/gui/editors/filtereditor.py:558
 msgid "Name type:"
 msgstr ""
 
@@ -4750,7 +4759,7 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/person/_hasrelationship.py:50
 #: ../gramps/gen/filters/rules/person/_havealtfamilies.py:45
-#: ../gramps/gen/filters/rules/person/_havechildren.py:44
+#: ../gramps/gen/filters/rules/person/_havechildren.py:48
 #: ../gramps/gen/filters/rules/person/_ischildoffiltermatch.py:48
 #: ../gramps/gen/filters/rules/person/_isparentoffiltermatch.py:48
 #: ../gramps/gen/filters/rules/person/_issiblingoffiltermatch.py:47
@@ -4811,7 +4820,7 @@ msgid "Matches people with the particular tag"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/person/_hastextmatchingsubstringof.py:47
-#: ../gramps/gui/editors/filtereditor.py:563
+#: ../gramps/gui/editors/filtereditor.py:568
 msgid "Case sensitive:"
 msgstr ""
 
@@ -4839,11 +4848,11 @@ msgstr ""
 msgid "Matches people who were adopted"
 msgstr ""
 
-#: ../gramps/gen/filters/rules/person/_havechildren.py:42
+#: ../gramps/gen/filters/rules/person/_havechildren.py:46
 msgid "People with children"
 msgstr ""
 
-#: ../gramps/gen/filters/rules/person/_havechildren.py:43
+#: ../gramps/gen/filters/rules/person/_havechildren.py:47
 msgid "Matches people who have children"
 msgstr ""
 
@@ -4950,11 +4959,11 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/person/_isfemale.py:45
 #: ../gramps/plugins/gramplet/statsgramplet.py:149
-#: ../gramps/plugins/graph/gvfamilylines.py:276
-#: ../gramps/plugins/graph/gvhourglass.py:372
-#: ../gramps/plugins/graph/gvrelgraph.py:900
-#: ../gramps/plugins/webreport/statistics.py:123
-#: ../gramps/plugins/webreport/statistics.py:188
+#: ../gramps/plugins/graph/gvfamilylines.py:283
+#: ../gramps/plugins/graph/gvhourglass.py:423
+#: ../gramps/plugins/graph/gvrelgraph.py:944
+#: ../gramps/plugins/webreport/statistics.py:124
+#: ../gramps/plugins/webreport/statistics.py:189
 msgid "Females"
 msgstr ""
 
@@ -4968,7 +4977,7 @@ msgstr ""
 #: ../gramps/gen/filters/rules/person/_islessthannthgenerationdescendantof.py:45
 #: ../gramps/gen/filters/rules/person/_ismorethannthgenerationancestorof.py:45
 #: ../gramps/gen/filters/rules/person/_ismorethannthgenerationdescendantof.py:45
-#: ../gramps/gui/editors/filtereditor.py:515
+#: ../gramps/gui/editors/filtereditor.py:520
 msgid "Number of generations:"
 msgstr ""
 
@@ -5015,11 +5024,11 @@ msgstr ""
 #. ###############################
 #: ../gramps/gen/filters/rules/person/_ismale.py:45
 #: ../gramps/plugins/gramplet/statsgramplet.py:146
-#: ../gramps/plugins/graph/gvfamilylines.py:272
-#: ../gramps/plugins/graph/gvhourglass.py:368
-#: ../gramps/plugins/graph/gvrelgraph.py:896
-#: ../gramps/plugins/webreport/statistics.py:121
-#: ../gramps/plugins/webreport/statistics.py:186
+#: ../gramps/plugins/graph/gvfamilylines.py:279
+#: ../gramps/plugins/graph/gvhourglass.py:419
+#: ../gramps/plugins/graph/gvrelgraph.py:940
+#: ../gramps/plugins/webreport/statistics.py:122
+#: ../gramps/plugins/webreport/statistics.py:187
 msgid "Males"
 msgstr ""
 
@@ -5089,7 +5098,7 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/person/_matcheseventfilter.py:51
 #: ../gramps/gen/filters/rules/place/_matcheseventfilter.py:49
-#: ../gramps/gui/editors/filtereditor.py:528
+#: ../gramps/gui/editors/filtereditor.py:533
 msgid "Event filter name:"
 msgstr ""
 
@@ -5265,8 +5274,8 @@ msgid "Matches places with a citation of a particular value"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/place/_hasdata.py:49
-#: ../gramps/gui/editors/filtereditor.py:112
-#: ../gramps/gui/editors/filtereditor.py:557
+#: ../gramps/gui/editors/filtereditor.py:113
+#: ../gramps/gui/editors/filtereditor.py:562
 msgid "Place type:"
 msgstr ""
 
@@ -5498,7 +5507,7 @@ msgid "Matches places whose Gramps ID matches the regular expression"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/place/_withinarea.py:50
-#: ../gramps/gui/editors/filtereditor.py:584
+#: ../gramps/gui/editors/filtereditor.py:589
 msgid "Units:"
 msgstr ""
 
@@ -5760,13 +5769,13 @@ msgstr ""
 
 #. We encounter a PLAC, having previously encountered an ADDR
 #: ../gramps/gen/lib/address.py:97 ../gramps/gui/clipboard.py:298
-#: ../gramps/gui/configure.py:546 ../gramps/gui/editors/editaddress.py:167
+#: ../gramps/gui/configure.py:610 ../gramps/gui/editors/editaddress.py:167
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:106
 #: ../gramps/plugins/gramplet/repositorydetails.py:136
-#: ../gramps/plugins/lib/libgedcom.py:5607
-#: ../gramps/plugins/lib/libgedcom.py:5774
+#: ../gramps/plugins/lib/libgedcom.py:5596
+#: ../gramps/plugins/lib/libgedcom.py:5763
 #: ../gramps/plugins/textreport/familygroup.py:352
-#: ../gramps/plugins/webreport/addressbooklist.py:112
+#: ../gramps/plugins/webreport/addressbooklist.py:113
 msgid "Address"
 msgstr ""
 
@@ -5789,11 +5798,11 @@ msgstr ""
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:66
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:80
 #: ../gramps/gui/editors/displaytabs/notetab.py:79
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:67
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:69
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:70
 #: ../gramps/gui/editors/displaytabs/srcattrembedlist.py:65
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:68
-#: ../gramps/gui/editors/editfamily.py:134
+#: ../gramps/gui/editors/editfamily.py:136
 #: ../gramps/gui/glade/editaddress.glade:297
 #: ../gramps/gui/glade/editattribute.glade:153
 #: ../gramps/gui/glade/editchildref.glade:180
@@ -5816,11 +5825,13 @@ msgstr ""
 #: ../gramps/gui/glade/editrepository.glade:212
 #: ../gramps/gui/glade/editsource.glade:295
 #: ../gramps/gui/glade/editurl.glade:156
+#: ../gramps/plugins/importer/importprogen.glade:108
+#: ../gramps/plugins/importer/importprogen.glade:244
 #: ../gramps/plugins/lib/libpersonview.py:110
 #: ../gramps/plugins/lib/libplaceview.py:92
 #: ../gramps/plugins/view/citationlistview.py:102
 #: ../gramps/plugins/view/citationtreeview.py:97
-#: ../gramps/plugins/view/eventview.py:87
+#: ../gramps/plugins/view/eventview.py:83
 #: ../gramps/plugins/view/familyview.py:84
 #: ../gramps/plugins/view/mediaview.py:99 ../gramps/plugins/view/noteview.py:82
 #: ../gramps/plugins/view/repoview.py:97
@@ -5867,8 +5878,8 @@ msgstr ""
 #: ../gramps/plugins/textreport/tagreport.py:488
 #: ../gramps/plugins/view/noteview.py:110 ../gramps/plugins/view/view.gpr.py:97
 #: ../gramps/plugins/view/view.gpr.py:105
-#: ../gramps/plugins/webreport/basepage.py:1237
-#: ../gramps/plugins/webreport/person.py:1169
+#: ../gramps/plugins/webreport/basepage.py:1264
+#: ../gramps/plugins/webreport/person.py:1242
 msgid "Notes"
 msgstr ""
 
@@ -5885,7 +5896,7 @@ msgstr ""
 #: ../gramps/gui/editors/displaytabs/familyldsembedlist.py:52
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:62
 #: ../gramps/gui/editors/displaytabs/placenameembedlist.py:64
-#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:61
+#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:63
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:113
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:107
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:91
@@ -5916,7 +5927,11 @@ msgstr ""
 #: ../gramps/plugins/gramplet/events.py:87
 #: ../gramps/plugins/gramplet/locations.py:87
 #: ../gramps/plugins/gramplet/personresidence.py:60
-#: ../gramps/plugins/importer/importcsv.py:220
+#: ../gramps/plugins/importer/importcsv.py:236
+#: ../gramps/plugins/importer/importprogen.glade:458
+#: ../gramps/plugins/importer/importprogen.glade:496
+#: ../gramps/plugins/importer/importprogen.glade:503
+#: ../gramps/plugins/importer/importprogen.glade:1145
 #: ../gramps/plugins/quickview/onthisday.py:80
 #: ../gramps/plugins/quickview/onthisday.py:81
 #: ../gramps/plugins/quickview/onthisday.py:82
@@ -5930,17 +5945,17 @@ msgstr ""
 #: ../gramps/plugins/tool/sortevents.py:54
 #: ../gramps/plugins/view/citationlistview.py:100
 #: ../gramps/plugins/view/citationtreeview.py:95
-#: ../gramps/plugins/view/eventview.py:85
+#: ../gramps/plugins/view/eventview.py:81
 #: ../gramps/plugins/view/mediaview.py:98
-#: ../gramps/plugins/webreport/basepage.py:620
-#: ../gramps/plugins/webreport/basepage.py:904
-#: ../gramps/plugins/webreport/basepage.py:934
-#: ../gramps/plugins/webreport/basepage.py:1100
-#: ../gramps/plugins/webreport/basepage.py:2180
-#: ../gramps/plugins/webreport/event.py:176
-#: ../gramps/plugins/webreport/media.py:229
-#: ../gramps/plugins/webreport/media.py:592
-#: ../gramps/plugins/webreport/person.py:872
+#: ../gramps/plugins/webreport/basepage.py:641
+#: ../gramps/plugins/webreport/basepage.py:930
+#: ../gramps/plugins/webreport/basepage.py:961
+#: ../gramps/plugins/webreport/basepage.py:1127
+#: ../gramps/plugins/webreport/basepage.py:2269
+#: ../gramps/plugins/webreport/event.py:177
+#: ../gramps/plugins/webreport/media.py:230
+#: ../gramps/plugins/webreport/media.py:564
+#: ../gramps/plugins/webreport/person.py:892
 msgid "Date"
 msgstr ""
 
@@ -5948,35 +5963,35 @@ msgstr ""
 #: ../gramps/gen/lib/placetype.py:71
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:72
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:54
-#: ../gramps/plugins/view/geoplaces.py:540
+#: ../gramps/plugins/view/geoplaces.py:599
 #: ../gramps/plugins/view/repoview.py:89
-#: ../gramps/plugins/webreport/basepage.py:1101
-#: ../gramps/plugins/webreport/basepage.py:2538
-#: ../gramps/plugins/webreport/basepage.py:2603
+#: ../gramps/plugins/webreport/basepage.py:1128
+#: ../gramps/plugins/webreport/basepage.py:2587
+#: ../gramps/plugins/webreport/basepage.py:2653
 msgid "Street"
 msgstr ""
 
 #: ../gramps/gen/lib/address.py:115 ../gramps/gen/lib/location.py:93
-#: ../gramps/gen/lib/placetype.py:70 ../gramps/gui/configure.py:547
+#: ../gramps/gen/lib/placetype.py:70 ../gramps/gui/configure.py:612
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:73
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:55
-#: ../gramps/plugins/view/geoplaces.py:537
+#: ../gramps/plugins/view/geoplaces.py:596
 #: ../gramps/plugins/view/repoview.py:90
-#: ../gramps/plugins/webreport/basepage.py:1102
-#: ../gramps/plugins/webreport/basepage.py:2539
-#: ../gramps/plugins/webreport/basepage.py:2604
+#: ../gramps/plugins/webreport/basepage.py:1129
+#: ../gramps/plugins/webreport/basepage.py:2588
+#: ../gramps/plugins/webreport/basepage.py:2654
 msgid "Locality"
 msgstr ""
 
 #: ../gramps/gen/lib/address.py:117 ../gramps/gen/lib/location.py:95
-#: ../gramps/gen/lib/placetype.py:68 ../gramps/gui/configure.py:548
+#: ../gramps/gen/lib/placetype.py:68 ../gramps/gui/configure.py:615
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:74
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:56
-#: ../gramps/plugins/view/geoplaces.py:588
+#: ../gramps/plugins/view/geoplaces.py:647
 #: ../gramps/plugins/view/repoview.py:91
-#: ../gramps/plugins/webreport/basepage.py:1103
-#: ../gramps/plugins/webreport/basepage.py:2540
-#: ../gramps/plugins/webreport/basepage.py:2605
+#: ../gramps/plugins/webreport/basepage.py:1130
+#: ../gramps/plugins/webreport/basepage.py:2589
+#: ../gramps/plugins/webreport/basepage.py:2655
 msgid "City"
 msgstr ""
 
@@ -5984,11 +5999,11 @@ msgstr ""
 #: ../gramps/gen/lib/placetype.py:67
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:57
 #: ../gramps/gui/views/treemodels/placemodel.py:312
-#: ../gramps/plugins/lib/maps/placeselection.py:137
-#: ../gramps/plugins/view/geoplaces.py:570
-#: ../gramps/plugins/webreport/basepage.py:1105
-#: ../gramps/plugins/webreport/basepage.py:2543
-#: ../gramps/plugins/webreport/basepage.py:2607
+#: ../gramps/plugins/lib/maps/placeselection.py:151
+#: ../gramps/plugins/view/geoplaces.py:629
+#: ../gramps/plugins/webreport/basepage.py:1132
+#: ../gramps/plugins/webreport/basepage.py:2592
+#: ../gramps/plugins/webreport/basepage.py:2657
 msgid "County"
 msgstr ""
 
@@ -5996,40 +6011,41 @@ msgstr ""
 #: ../gramps/gen/lib/placetype.py:66
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:58
 #: ../gramps/gui/views/treemodels/placemodel.py:312
-#: ../gramps/plugins/lib/maps/placeselection.py:136
-#: ../gramps/plugins/view/geoplaces.py:567
+#: ../gramps/plugins/lib/maps/placeselection.py:150
+#: ../gramps/plugins/view/geoplaces.py:626
 msgid "State"
 msgstr ""
 
 #: ../gramps/gen/lib/address.py:123 ../gramps/gen/lib/location.py:101
-#: ../gramps/gen/lib/placetype.py:65 ../gramps/gui/configure.py:550
+#: ../gramps/gen/lib/placetype.py:65 ../gramps/gui/configure.py:620
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:76
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:59
 #: ../gramps/gui/views/treemodels/placemodel.py:312
-#: ../gramps/plugins/lib/maps/placeselection.py:135
-#: ../gramps/plugins/view/geoplaces.py:564
+#: ../gramps/plugins/lib/maps/placeselection.py:149
+#: ../gramps/plugins/view/geoplaces.py:623
 #: ../gramps/plugins/view/repoview.py:93
-#: ../gramps/plugins/webreport/basepage.py:1107
-#: ../gramps/plugins/webreport/basepage.py:2547
-#: ../gramps/plugins/webreport/basepage.py:2610
-#: ../gramps/plugins/webreport/place.py:178
+#: ../gramps/plugins/webreport/basepage.py:1134
+#: ../gramps/plugins/webreport/basepage.py:2596
+#: ../gramps/plugins/webreport/basepage.py:2660
+#: ../gramps/plugins/webreport/place.py:183
+#: ../gramps/plugins/webreport/place.py:195
 msgid "Country"
 msgstr ""
 
 #: ../gramps/gen/lib/address.py:125 ../gramps/gen/lib/location.py:103
-#: ../gramps/plugins/webreport/basepage.py:1106
-#: ../gramps/plugins/webreport/basepage.py:2546
-#: ../gramps/plugins/webreport/basepage.py:2609
+#: ../gramps/plugins/webreport/basepage.py:1133
+#: ../gramps/plugins/webreport/basepage.py:2595
+#: ../gramps/plugins/webreport/basepage.py:2659
 msgid "Postal Code"
 msgstr ""
 
 #: ../gramps/gen/lib/address.py:127 ../gramps/gen/lib/location.py:105
-#: ../gramps/gui/configure.py:552 ../gramps/plugins/export/exportgedcom.py:797
-#: ../gramps/plugins/export/exportgedcom.py:1170
+#: ../gramps/gui/configure.py:626 ../gramps/plugins/export/exportgedcom.py:788
+#: ../gramps/plugins/export/exportgedcom.py:1161
 #: ../gramps/plugins/gramplet/repositorydetails.py:124
-#: ../gramps/plugins/lib/libgedcom.py:4135
-#: ../gramps/plugins/lib/libgedcom.py:5871
-#: ../gramps/plugins/webreport/basepage.py:1108
+#: ../gramps/plugins/lib/libgedcom.py:4129
+#: ../gramps/plugins/lib/libgedcom.py:5860
+#: ../gramps/plugins/webreport/basepage.py:1135
 msgid "Phone"
 msgstr ""
 
@@ -6046,12 +6062,12 @@ msgstr ""
 #: ../gramps/plugins/gramplet/attributes.py:57
 #: ../gramps/plugins/lib/libmetadata.py:173
 #: ../gramps/plugins/tool/patchnames.py:410
-#: ../gramps/plugins/webreport/basepage.py:999
-#: ../gramps/plugins/webreport/basepage.py:1236
+#: ../gramps/plugins/webreport/basepage.py:1026
+#: ../gramps/plugins/webreport/basepage.py:1263
 msgid "Value"
 msgstr ""
 
-#: ../gramps/gen/lib/attrtype.py:63 ../gramps/gen/lib/childreftype.py:74
+#: ../gramps/gen/lib/attrtype.py:64 ../gramps/gen/lib/childreftype.py:74
 #: ../gramps/gen/lib/eventroletype.py:53 ../gramps/gen/lib/eventtype.py:163
 #: ../gramps/gen/lib/familyreltype.py:51 ../gramps/gen/lib/markertype.py:52
 #: ../gramps/gen/lib/nameorigintype.py:74 ../gramps/gen/lib/nametype.py:47
@@ -6060,23 +6076,23 @@ msgstr ""
 #: ../gramps/gen/lib/srcmediatype.py:57 ../gramps/gen/lib/urltype.py:48
 #: ../gramps/gui/autocomp.py:179
 #: ../gramps/plugins/textreport/indivcomplete.py:74
-#: ../gramps/plugins/view/geoplaces.py:534
+#: ../gramps/plugins/view/geoplaces.py:593
 msgid "Custom"
 msgstr ""
 
-#: ../gramps/gen/lib/attrtype.py:64
+#: ../gramps/gen/lib/attrtype.py:65
 msgid "Caste"
 msgstr ""
 
 #. 2 name (version)
-#: ../gramps/gen/lib/attrtype.py:65 ../gramps/gen/lib/event.py:148
+#: ../gramps/gen/lib/attrtype.py:66 ../gramps/gen/lib/event.py:148
 #: ../gramps/gen/lib/media.py:147 ../gramps/gen/lib/url.py:96
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:75
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:67
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:104
 #: ../gramps/gui/glade/rule.glade:931 ../gramps/gui/glade/styleeditor.glade:278
 #: ../gramps/gui/plug/_windows.py:134 ../gramps/gui/plug/_windows.py:243
-#: ../gramps/gui/plug/_windows.py:620 ../gramps/gui/plug/_windows.py:1105
+#: ../gramps/gui/plug/_windows.py:622 ../gramps/gui/plug/_windows.py:1107
 #: ../gramps/gui/selectors/selectevent.py:70
 #: ../gramps/plugins/gramplet/coordinates.py:90
 #: ../gramps/plugins/gramplet/events.py:86
@@ -6084,72 +6100,79 @@ msgstr ""
 #: ../gramps/plugins/textreport/placereport.py:226
 #: ../gramps/plugins/textreport/placereport.py:303
 #: ../gramps/plugins/tool/sortevents.py:57
-#: ../gramps/plugins/view/eventview.py:82
-#: ../gramps/plugins/webreport/basepage.py:622
-#: ../gramps/plugins/webreport/basepage.py:907
-#: ../gramps/plugins/webreport/basepage.py:2051
-#: ../gramps/plugins/webreport/basepage.py:2732
-#: ../gramps/plugins/webreport/download.py:127
+#: ../gramps/plugins/view/eventview.py:78
+#: ../gramps/plugins/webreport/basepage.py:643
+#: ../gramps/plugins/webreport/basepage.py:933
+#: ../gramps/plugins/webreport/basepage.py:2140
+#: ../gramps/plugins/webreport/basepage.py:2872
+#: ../gramps/plugins/webreport/download.py:128
 msgid "Description"
 msgstr ""
 
-#: ../gramps/gen/lib/attrtype.py:66
+#: ../gramps/gen/lib/attrtype.py:67
 msgid "Identification Number"
 msgstr ""
 
-#: ../gramps/gen/lib/attrtype.py:67
+#: ../gramps/gen/lib/attrtype.py:68
 msgid "National Origin"
 msgstr ""
 
-#: ../gramps/gen/lib/attrtype.py:68 ../gramps/plugins/lib/libpersonview.py:108
+#: ../gramps/gen/lib/attrtype.py:69 ../gramps/plugins/lib/libpersonview.py:108
 msgid "Number of Children"
 msgstr ""
 
-#: ../gramps/gen/lib/attrtype.py:69
+#: ../gramps/gen/lib/attrtype.py:70
 msgid "Social Security Number"
 msgstr ""
 
-#: ../gramps/gen/lib/attrtype.py:70 ../gramps/gen/utils/keyword.py:72
-#: ../gramps/gui/configure.py:700 ../gramps/gui/configure.py:702
-#: ../gramps/gui/configure.py:707 ../gramps/gui/configure.py:714
+#: ../gramps/gen/lib/attrtype.py:71 ../gramps/gen/utils/keyword.py:72
+#: ../gramps/gui/configure.py:847 ../gramps/gui/configure.py:849
+#: ../gramps/gui/configure.py:854 ../gramps/gui/configure.py:861
 #: ../gramps/plugins/tool/patchnames.py:435
 msgid "Nickname"
 msgstr ""
 
-#: ../gramps/gen/lib/attrtype.py:71
+#: ../gramps/gen/lib/attrtype.py:72
 msgid "Cause"
 msgstr ""
 
-#: ../gramps/gen/lib/attrtype.py:72
+#: ../gramps/gen/lib/attrtype.py:73
 msgid "Agency"
 msgstr ""
 
-#: ../gramps/gen/lib/attrtype.py:73
+#: ../gramps/gen/lib/attrtype.py:74
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:88
-#: ../gramps/plugins/drawreport/statisticschart.py:371
+#: ../gramps/plugins/drawreport/statisticschart.py:377
 #: ../gramps/plugins/gramplet/agestats.py:176
 #: ../gramps/plugins/gramplet/events.py:89
 #: ../gramps/plugins/quickview/ageondate.py:54
 msgid "Age"
 msgstr ""
 
-#: ../gramps/gen/lib/attrtype.py:74
+#: ../gramps/gen/lib/attrtype.py:75
 msgid "Father's Age"
 msgstr ""
 
-#: ../gramps/gen/lib/attrtype.py:75
+#: ../gramps/gen/lib/attrtype.py:76
 msgid "Mother's Age"
 msgstr ""
 
-#: ../gramps/gen/lib/attrtype.py:76 ../gramps/gen/lib/eventroletype.py:60
+#: ../gramps/gen/lib/attrtype.py:77 ../gramps/gen/lib/eventroletype.py:60
 msgid "Witness"
 msgstr ""
 
-#: ../gramps/gen/lib/attrtype.py:77
+#: ../gramps/gen/lib/attrtype.py:78
 msgid "Time"
 msgstr ""
 
-#: ../gramps/gen/lib/childref.py:105 ../gramps/gui/editors/editchildref.py:195
+#: ../gramps/gen/lib/attrtype.py:79 ../gramps/gen/lib/eventtype.py:190
+#: ../gramps/gen/lib/nameorigintype.py:85
+#: ../gramps/gen/plug/docgen/treedoc.py:454
+#: ../gramps/plugins/gramplet/persondetails.py:163
+msgid "Occupation"
+msgstr ""
+
+#: ../gramps/gen/lib/childref.py:105 ../gramps/gui/editors/editchildref.py:190
 msgid "Child Reference"
 msgstr ""
 
@@ -6165,34 +6188,38 @@ msgid "Handle"
 msgstr ""
 
 #: ../gramps/gen/lib/childreftype.py:67 ../gramps/gen/plug/docgen/treedoc.py:72
-#: ../gramps/gui/configure.py:84
+#: ../gramps/gui/configure.py:87
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:201
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:175
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:209
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:155
 #: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:154
-#: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:250
+#: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:252
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:191
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:171
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:154
 #: ../gramps/gui/glade/editplaceformat.glade:185
+#: ../gramps/plugins/graph/gvfamilylines.py:82
 #: ../gramps/plugins/tool/check.py:2494
 msgid "None"
 msgstr ""
 
 #: ../gramps/gen/lib/childreftype.py:68 ../gramps/gen/lib/eventtype.py:165
 #: ../gramps/gui/merge/mergeperson.py:189
+#: ../gramps/plugins/export/exportvcalendar.py:156
+#: ../gramps/plugins/export/exportvcalendar.py:161
 #: ../gramps/plugins/gramplet/ancestor.py:64
 #: ../gramps/plugins/gramplet/descendant.py:63
+#: ../gramps/plugins/importer/importprogen.glade:1472
 #: ../gramps/plugins/quickview/all_relations.py:270
 #: ../gramps/plugins/quickview/lineage.py:93
 #: ../gramps/plugins/textreport/familygroup.py:320
 #: ../gramps/plugins/textreport/familygroup.py:528
 #: ../gramps/plugins/textreport/familygroup.py:530
 #: ../gramps/plugins/textreport/tagreport.py:170
-#: ../gramps/plugins/view/relview.py:602
-#: ../gramps/plugins/webreport/person.py:213
-#: ../gramps/plugins/webreport/surname.py:130
+#: ../gramps/plugins/view/relview.py:733
+#: ../gramps/plugins/webreport/person.py:219
+#: ../gramps/plugins/webreport/surname.py:141
 msgid "Birth"
 msgstr ""
 
@@ -6214,13 +6241,16 @@ msgstr ""
 
 #. 8
 #: ../gramps/gen/lib/citation.py:97 ../gramps/gen/lib/notetype.py:79
-#: ../gramps/gui/clipboard.py:468 ../gramps/gui/configure.py:572
+#: ../gramps/gui/clipboard.py:468 ../gramps/gui/configure.py:655
 #: ../gramps/gui/editors/editcitation.py:119
 #: ../gramps/gui/editors/editcitation.py:125
 #: ../gramps/gui/editors/editlink.py:100
-#: ../gramps/gui/editors/filtereditor.py:301 ../gramps/gui/viewmanager.py:616
+#: ../gramps/gui/editors/filtereditor.py:302 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/views/treemodels/citationtreemodel.py:170
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:116
+#: ../gramps/plugins/importer/importprogen.glade:209
+#: ../gramps/plugins/importer/importprogen.glade:739
+#: ../gramps/plugins/lib/libprogen.py:935
 #: ../gramps/plugins/quickview/quickview.gpr.py:209
 #: ../gramps/plugins/quickview/references.py:89
 #: ../gramps/plugins/tool/reorderids.glade:823
@@ -6232,7 +6262,7 @@ msgstr ""
 #: ../gramps/gen/lib/note.py:116 ../gramps/gen/lib/person.py:180
 #: ../gramps/gen/lib/place.py:141 ../gramps/gen/lib/repo.py:93
 #: ../gramps/gen/lib/src.py:104 ../gramps/gen/plug/report/stdoptions.py:321
-#: ../gramps/plugins/importer/importcsv.py:206
+#: ../gramps/plugins/importer/importcsv.py:207
 #: ../gramps/plugins/quickview/filterbyname.py:154
 #: ../gramps/plugins/quickview/filterbyname.py:165
 #: ../gramps/plugins/quickview/filterbyname.py:175
@@ -6251,40 +6281,44 @@ msgstr ""
 #: ../gramps/plugins/quickview/filterbyname.py:276
 #: ../gramps/plugins/tool/findloop.py:112
 #: ../gramps/plugins/tool/findloop.py:116
-#: ../gramps/plugins/webreport/basepage.py:2513
-#: ../gramps/plugins/webreport/event.py:177
-#: ../gramps/plugins/webreport/event.py:389
-#: ../gramps/plugins/webreport/media.py:569
-#: ../gramps/plugins/webreport/person.py:1396
-#: ../gramps/plugins/webreport/repository.py:243
-#: ../gramps/plugins/webreport/source.py:259
+#: ../gramps/plugins/webreport/basepage.py:2562
+#: ../gramps/plugins/webreport/event.py:178
+#: ../gramps/plugins/webreport/event.py:391
+#: ../gramps/plugins/webreport/media.py:541
+#: ../gramps/plugins/webreport/person.py:1470
+#: ../gramps/plugins/webreport/repository.py:245
+#: ../gramps/plugins/webreport/source.py:261
 msgid "Gramps ID"
 msgstr ""
 
 #: ../gramps/gen/lib/citation.py:108
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:82
-#: ../gramps/plugins/webreport/basepage.py:2182
+#: ../gramps/plugins/importer/importprogen.glade:295
+#: ../gramps/plugins/webreport/basepage.py:2271
 msgid "Page"
 msgstr ""
 
 #: ../gramps/gen/lib/citation.py:112
+#: ../gramps/plugins/importer/importprogen.glade:261
 #: ../gramps/plugins/view/citationlistview.py:101
 #: ../gramps/plugins/view/citationtreeview.py:96
-#: ../gramps/plugins/webreport/basepage.py:2183
+#: ../gramps/plugins/webreport/basepage.py:2272
 msgid "Confidence"
 msgstr ""
 
 #. 7
 #: ../gramps/gen/lib/citation.py:115 ../gramps/gen/lib/src.py:97
-#: ../gramps/gui/clipboard.py:761 ../gramps/gui/configure.py:570
+#: ../gramps/gui/clipboard.py:761 ../gramps/gui/configure.py:652
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:78
 #: ../gramps/gui/editors/editlink.py:99 ../gramps/gui/editors/editsource.py:86
-#: ../gramps/gui/editors/filtereditor.py:297 ../gramps/gui/viewmanager.py:614
+#: ../gramps/gui/editors/filtereditor.py:298 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/views/treemodels/citationtreemodel.py:170
 #: ../gramps/plugins/export/exportcsv.py:466
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:115
-#: ../gramps/plugins/importer/importcsv.py:169
-#: ../gramps/plugins/importer/importprogen.py:873
+#: ../gramps/plugins/importer/importcsv.py:170
+#: ../gramps/plugins/importer/importprogen.glade:52
+#: ../gramps/plugins/importer/importprogen.glade:724
+#: ../gramps/plugins/lib/libprogen.py:882
 #: ../gramps/plugins/quickview/filterbyname.py:195
 #: ../gramps/plugins/quickview/filterbyname.py:258
 #: ../gramps/plugins/quickview/quickview.gpr.py:205
@@ -6303,7 +6337,7 @@ msgstr ""
 #: ../gramps/gen/lib/media.py:134 ../gramps/gen/lib/person.py:206
 #: ../gramps/gen/lib/place.py:166 ../gramps/gen/lib/src.py:117
 #: ../gramps/gui/clipboard.py:636 ../gramps/gui/editors/editlink.py:94
-#: ../gramps/gui/editors/filtereditor.py:298 ../gramps/gui/viewmanager.py:620
+#: ../gramps/gui/editors/filtereditor.py:299 ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:111
 #: ../gramps/plugins/quickview/filterbyname.py:109
 #: ../gramps/plugins/quickview/filterbyname.py:134
@@ -6316,13 +6350,13 @@ msgstr ""
 #: ../gramps/plugins/tool/reorderids.glade:848
 #: ../gramps/plugins/view/mediaview.py:129
 #: ../gramps/plugins/view/view.gpr.py:82 ../gramps/plugins/view/view.gpr.py:90
-#: ../gramps/plugins/webreport/basepage.py:1484
-#: ../gramps/plugins/webreport/basepage.py:1550
-#: ../gramps/plugins/webreport/basepage.py:1619
-#: ../gramps/plugins/webreport/basepage.py:1666
-#: ../gramps/plugins/webreport/basepage.py:1955
+#: ../gramps/plugins/webreport/basepage.py:1533
+#: ../gramps/plugins/webreport/basepage.py:1592
+#: ../gramps/plugins/webreport/basepage.py:1660
+#: ../gramps/plugins/webreport/basepage.py:1707
+#: ../gramps/plugins/webreport/basepage.py:2044
 #: ../gramps/plugins/webreport/media.py:196
-#: ../gramps/plugins/webreport/media.py:390
+#: ../gramps/plugins/webreport/media.py:378
 msgid "Media"
 msgstr ""
 
@@ -6349,13 +6383,14 @@ msgstr ""
 #: ../gramps/gui/glade/editnote.glade:284
 #: ../gramps/gui/glade/editperson.glade:683
 #: ../gramps/gui/selectors/selectnote.py:74
+#: ../gramps/plugins/importer/importprogen.glade:527
 #: ../gramps/plugins/lib/libpersonview.py:111
 #: ../gramps/plugins/lib/libplaceview.py:93
 #: ../gramps/plugins/textreport/indivcomplete.py:549
 #: ../gramps/plugins/tool/notrelated.py:129
 #: ../gramps/plugins/view/citationlistview.py:103
 #: ../gramps/plugins/view/citationtreeview.py:98
-#: ../gramps/plugins/view/eventview.py:88
+#: ../gramps/plugins/view/eventview.py:84
 #: ../gramps/plugins/view/familyview.py:85
 #: ../gramps/plugins/view/mediaview.py:100
 #: ../gramps/plugins/view/noteview.py:83 ../gramps/plugins/view/repoview.py:98
@@ -6372,14 +6407,16 @@ msgstr ""
 #: ../gramps/gen/lib/date.py:274 ../gramps/gen/lib/date.py:422
 #: ../gramps/gen/mime/_pythonmime.py:48 ../gramps/gen/mime/_pythonmime.py:56
 #: ../gramps/gen/mime/_winmime.py:57 ../gramps/gen/utils/db.py:523
-#: ../gramps/gui/editors/editperson.py:349
+#: ../gramps/gui/editors/editperson.py:342
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:94
 #: ../gramps/gui/merge/mergeperson.py:64
 #: ../gramps/gui/views/treemodels/peoplemodel.py:97
+#: ../gramps/plugins/lib/libgedcom.py:5393
+#: ../gramps/plugins/lib/libgedcom.py:6704
 #: ../gramps/plugins/textreport/indivcomplete.py:663
 #: ../gramps/plugins/tool/dumpgenderstats.py:46
-#: ../gramps/plugins/view/relview.py:642
-#: ../gramps/plugins/webreport/person.py:414
+#: ../gramps/plugins/view/relview.py:775
+#: ../gramps/plugins/webreport/person.py:431
 msgid "unknown"
 msgstr ""
 
@@ -6396,7 +6433,7 @@ msgstr ""
 
 #: ../gramps/gen/lib/date.py:288 ../gramps/gen/lib/date.py:303
 #: ../gramps/gen/lib/date.py:307 ../gramps/gen/lib/date.py:311
-#: ../gramps/gen/lib/date.py:348 ../gramps/gui/editors/filtereditor.py:251
+#: ../gramps/gen/lib/date.py:348 ../gramps/gui/editors/filtereditor.py:252
 msgid "less than"
 msgstr ""
 
@@ -6407,15 +6444,16 @@ msgid "age|about"
 msgstr ""
 
 #: ../gramps/gen/lib/date.py:295 ../gramps/gen/lib/date.py:339
-#: ../gramps/gen/lib/date.py:358
+#: ../gramps/gen/lib/date.py:358 ../gramps/plugins/webreport/basepage.py:2924
 msgid "between"
 msgstr ""
 
 #: ../gramps/gen/lib/date.py:298 ../gramps/gen/lib/date.py:342
 #: ../gramps/gen/lib/date.py:360 ../gramps/gui/merge/mergefamily.py:155
 #: ../gramps/plugins/quickview/all_relations.py:282
-#: ../gramps/plugins/view/relview.py:978
-#: ../gramps/plugins/webreport/basepage.py:822
+#: ../gramps/plugins/view/relview.py:1143
+#: ../gramps/plugins/webreport/basepage.py:846
+#: ../gramps/plugins/webreport/basepage.py:2925
 msgid "and"
 msgstr ""
 
@@ -6472,7 +6510,7 @@ msgstr ""
 msgid "Quality"
 msgstr ""
 
-#: ../gramps/gen/lib/date.py:716 ../gramps/gui/editors/filtereditor.py:820
+#: ../gramps/gen/lib/date.py:716 ../gramps/gui/editors/filtereditor.py:834
 #: ../gramps/gui/glade/rule.glade:967
 msgid "Values"
 msgstr ""
@@ -6480,8 +6518,10 @@ msgstr ""
 #: ../gramps/gen/lib/date.py:719 ../gramps/gen/lib/placename.py:99
 #: ../gramps/gen/lib/styledtext.py:321
 #: ../gramps/gen/plug/report/_constants.py:54 ../gramps/gui/clipboard.py:613
-#: ../gramps/gui/clipboard.py:621 ../gramps/gui/configure.py:1233
+#: ../gramps/gui/clipboard.py:621 ../gramps/gui/configure.py:1395
 #: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:101
+#: ../gramps/plugins/importer/importprogen.glade:403
+#: ../gramps/plugins/importer/importprogen.glade:1107
 #: ../gramps/plugins/textreport/custombooktext.py:132
 #: ../gramps/plugins/textreport/tagreport.py:511
 msgid "Text"
@@ -6515,8 +6555,7 @@ msgstr ""
 msgid "about"
 msgstr ""
 
-#: ../gramps/gen/lib/date.py:1872
-#: ../gramps/plugins/importer/importprogen.py:1722
+#: ../gramps/gen/lib/date.py:1872 ../gramps/plugins/lib/libprogen.py:1839
 #: ../gramps/plugins/lib/libsubstkeyword.py:313
 msgid "after"
 msgstr ""
@@ -6539,35 +6578,36 @@ msgstr ""
 
 #. 0 this order range above
 #: ../gramps/gen/lib/event.py:136 ../gramps/gen/lib/eventref.py:109
-#: ../gramps/gui/clipboard.py:335 ../gramps/gui/configure.py:576
+#: ../gramps/gui/clipboard.py:335 ../gramps/gui/configure.py:661
 #: ../gramps/gui/editors/editlink.py:92
-#: ../gramps/gui/editors/filtereditor.py:295
+#: ../gramps/gui/editors/filtereditor.py:296
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:138
-#: ../gramps/gui/viewmanager.py:610
+#: ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:109
+#: ../gramps/plugins/importer/importprogen.glade:696
 #: ../gramps/plugins/quickview/filterbyname.py:175
 #: ../gramps/plugins/quickview/filterbyname.py:246
 #: ../gramps/plugins/quickview/quickview.gpr.py:204
 #: ../gramps/plugins/quickview/references.py:87
 #: ../gramps/plugins/textreport/placereport.py:458
 #: ../gramps/plugins/tool/reorderids.glade:787
-#: ../gramps/plugins/webreport/basepage.py:619
+#: ../gramps/plugins/webreport/basepage.py:640
 msgid "Event"
 msgstr ""
 
 #. 5
 #: ../gramps/gen/lib/event.py:151 ../gramps/gen/lib/ldsord.py:186
 #: ../gramps/gen/lib/place.py:134 ../gramps/gui/clipboard.py:355
-#: ../gramps/gui/configure.py:568
+#: ../gramps/gui/configure.py:649
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:81
 #: ../gramps/gui/editors/displaytabs/familyldsembedlist.py:55
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:65
 #: ../gramps/gui/editors/editlink.py:97
-#: ../gramps/gui/editors/filtereditor.py:296
+#: ../gramps/gui/editors/filtereditor.py:297
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:108
-#: ../gramps/gui/glade/editevent.glade:270
+#: ../gramps/gui/glade/editevent.glade:270 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/plug/_guioptions.py:1354
-#: ../gramps/gui/selectors/selectevent.py:69 ../gramps/gui/viewmanager.py:612
+#: ../gramps/gui/selectors/selectevent.py:69
 #: ../gramps/gui/views/treemodels/placemodel.py:312
 #: ../gramps/plugins/export/exportcsv.py:286
 #: ../gramps/plugins/export/exportcsv.py:466
@@ -6575,7 +6615,8 @@ msgstr ""
 #: ../gramps/plugins/gramplet/events.py:91
 #: ../gramps/plugins/gramplet/personresidence.py:61
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:113
-#: ../gramps/plugins/importer/importcsv.py:221
+#: ../gramps/plugins/importer/importcsv.py:237
+#: ../gramps/plugins/importer/importprogen.glade:710
 #: ../gramps/plugins/quickview/filterbyname.py:185
 #: ../gramps/plugins/quickview/filterbyname.py:252
 #: ../gramps/plugins/quickview/onthisday.py:80
@@ -6587,10 +6628,10 @@ msgstr ""
 #: ../gramps/plugins/textreport/indivcomplete.py:709
 #: ../gramps/plugins/tool/reorderids.glade:799
 #: ../gramps/plugins/tool/sortevents.py:58
-#: ../gramps/plugins/view/eventview.py:86
-#: ../gramps/plugins/webreport/basepage.py:621
-#: ../gramps/plugins/webreport/basepage.py:906
-#: ../gramps/plugins/webreport/basepage.py:936
+#: ../gramps/plugins/view/eventview.py:82
+#: ../gramps/plugins/webreport/basepage.py:642
+#: ../gramps/plugins/webreport/basepage.py:932
+#: ../gramps/plugins/webreport/basepage.py:963
 msgid "Place"
 msgstr ""
 
@@ -6609,9 +6650,9 @@ msgstr ""
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:659
 #: ../gramps/plugins/textreport/indivcomplete.py:472
 #: ../gramps/plugins/textreport/indivcomplete.py:692
-#: ../gramps/plugins/webreport/basepage.py:428
-#: ../gramps/plugins/webreport/basepage.py:988
-#: ../gramps/plugins/webreport/basepage.py:1220
+#: ../gramps/plugins/webreport/basepage.py:447
+#: ../gramps/plugins/webreport/basepage.py:1015
+#: ../gramps/plugins/webreport/basepage.py:1247
 msgid "Attributes"
 msgstr ""
 
@@ -6656,15 +6697,18 @@ msgstr ""
 #. get the family events
 #: ../gramps/gen/lib/eventtype.py:139 ../gramps/gen/lib/family.py:145
 #: ../gramps/gen/lib/ldsord.py:188 ../gramps/gui/clipboard.py:739
-#: ../gramps/gui/configure.py:566
+#: ../gramps/gui/configure.py:646
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:59
 #: ../gramps/gui/editors/displaytabs/personeventembedlist.py:52
-#: ../gramps/gui/editors/editfamily.py:498 ../gramps/gui/editors/editlink.py:93
-#: ../gramps/gui/editors/filtereditor.py:294
-#: ../gramps/gui/glade/editldsord.glade:267 ../gramps/gui/viewmanager.py:608
+#: ../gramps/gui/editors/editfamily.py:561 ../gramps/gui/editors/editlink.py:93
+#: ../gramps/gui/editors/filtereditor.py:295
+#: ../gramps/gui/glade/editldsord.glade:267 ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/export/exportcsv.py:506
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:110
-#: ../gramps/plugins/importer/importcsv.py:211
+#: ../gramps/plugins/importer/importcsv.py:227
+#: ../gramps/plugins/importer/importprogen.glade:682
+#: ../gramps/plugins/importer/importprogen.glade:1256
+#: ../gramps/plugins/importer/importprogen.glade:1345
 #: ../gramps/plugins/quickview/all_events.py:83
 #: ../gramps/plugins/quickview/all_relations.py:270
 #: ../gramps/plugins/quickview/filterbyname.py:165
@@ -6673,9 +6717,9 @@ msgstr ""
 #: ../gramps/plugins/quickview/references.py:86
 #: ../gramps/plugins/textreport/recordsreport.py:271
 #: ../gramps/plugins/tool/reorderids.glade:774
-#: ../gramps/plugins/view/relview.py:1360
-#: ../gramps/plugins/view/relview.py:1382
-#: ../gramps/plugins/webreport/family.py:188
+#: ../gramps/plugins/view/relview.py:1529
+#: ../gramps/plugins/view/relview.py:1552
+#: ../gramps/plugins/webreport/family.py:189
 msgid "Family"
 msgstr ""
 
@@ -6701,26 +6745,31 @@ msgstr ""
 
 #: ../gramps/gen/lib/eventtype.py:153 ../gramps/gen/lib/eventtype.py:195
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:463
-#: ../gramps/plugins/webreport/addressbooklist.py:113
-#: ../gramps/plugins/webreport/basepage.py:2710
+#: ../gramps/plugins/lib/libprogen.py:1827
+#: ../gramps/plugins/lib/libprogen.py:1830
+#: ../gramps/plugins/webreport/addressbooklist.py:114
+#: ../gramps/plugins/webreport/basepage.py:2849
 msgid "Residence"
 msgstr ""
 
 #: ../gramps/gen/lib/eventtype.py:155 ../gramps/gui/glade/mergedata.glade:523
 #: ../gramps/gui/glade/mergedata.glade:610
-#: ../gramps/plugins/lib/maps/placeselection.py:138
-#: ../gramps/plugins/lib/maps/placeselection.py:189
+#: ../gramps/plugins/lib/maps/placeselection.py:152
+#: ../gramps/plugins/lib/maps/placeselection.py:203
 msgid "Other"
 msgstr ""
 
 #: ../gramps/gen/lib/eventtype.py:166 ../gramps/gui/merge/mergeperson.py:194
+#: ../gramps/plugins/export/exportvcalendar.py:174
+#: ../gramps/plugins/export/exportvcalendar.py:179
+#: ../gramps/plugins/importer/importprogen.glade:1491
 #: ../gramps/plugins/textreport/familygroup.py:328
 #: ../gramps/plugins/textreport/familygroup.py:534
 #: ../gramps/plugins/textreport/familygroup.py:536
 #: ../gramps/plugins/textreport/tagreport.py:176
-#: ../gramps/plugins/view/relview.py:613 ../gramps/plugins/view/relview.py:640
-#: ../gramps/plugins/webreport/person.py:217
-#: ../gramps/plugins/webreport/surname.py:134
+#: ../gramps/plugins/view/relview.py:744 ../gramps/plugins/view/relview.py:773
+#: ../gramps/plugins/webreport/person.py:223
+#: ../gramps/plugins/webreport/surname.py:145
 msgid "Death"
 msgstr ""
 
@@ -6817,11 +6866,6 @@ msgstr ""
 msgid "Number of Marriages"
 msgstr ""
 
-#: ../gramps/gen/lib/eventtype.py:190 ../gramps/gen/lib/nameorigintype.py:85
-#: ../gramps/plugins/gramplet/persondetails.py:163
-msgid "Occupation"
-msgstr ""
-
 #: ../gramps/gen/lib/eventtype.py:191
 msgid "Ordination"
 msgstr ""
@@ -6847,14 +6891,16 @@ msgstr ""
 msgid "Will"
 msgstr ""
 
+#. feature requests 2356, 1657: avoid genitive form
 #: ../gramps/gen/lib/eventtype.py:198 ../gramps/gen/plug/docgen/treedoc.py:150
 #: ../gramps/gui/merge/mergeperson.py:258
 #: ../gramps/plugins/export/exportcsv.py:465
-#: ../gramps/plugins/importer/importcsv.py:219
+#: ../gramps/plugins/export/exportvcalendar.py:136
+#: ../gramps/plugins/importer/importcsv.py:235
 #: ../gramps/plugins/textreport/familygroup.py:406
 #: ../gramps/plugins/textreport/familygroup.py:415
 #: ../gramps/plugins/textreport/familygroup.py:606
-#: ../gramps/plugins/webreport/family.py:189
+#: ../gramps/plugins/webreport/family.py:190
 msgid "Marriage"
 msgstr ""
 
@@ -6878,7 +6924,7 @@ msgstr ""
 msgid "Engagement"
 msgstr ""
 
-#: ../gramps/gen/lib/eventtype.py:204 ../gramps/plugins/webreport/family.py:190
+#: ../gramps/gen/lib/eventtype.py:204 ../gramps/plugins/webreport/family.py:191
 msgid "Divorce"
 msgstr ""
 
@@ -7101,7 +7147,7 @@ msgstr ""
 #: ../gramps/gui/selectors/selectfamily.py:67
 #: ../gramps/gui/widgets/reorderfam.py:96
 #: ../gramps/plugins/gramplet/persondetails.py:224
-#: ../gramps/plugins/importer/importcsv.py:216
+#: ../gramps/plugins/importer/importcsv.py:232
 #: ../gramps/plugins/quickview/all_relations.py:300
 #: ../gramps/plugins/textreport/familygroup.py:232
 #: ../gramps/plugins/textreport/familygroup.py:243
@@ -7110,8 +7156,8 @@ msgstr ""
 #: ../gramps/plugins/textreport/indivcomplete.py:929
 #: ../gramps/plugins/textreport/tagreport.py:252
 #: ../gramps/plugins/view/familyview.py:80
-#: ../gramps/plugins/view/relview.py:893
-#: ../gramps/plugins/webreport/person.py:1558
+#: ../gramps/plugins/view/relview.py:1053
+#: ../gramps/plugins/webreport/person.py:1631
 msgid "Father"
 msgstr ""
 
@@ -7123,7 +7169,7 @@ msgstr ""
 #: ../gramps/gui/selectors/selectfamily.py:68
 #: ../gramps/gui/widgets/reorderfam.py:97
 #: ../gramps/plugins/gramplet/persondetails.py:225
-#: ../gramps/plugins/importer/importcsv.py:213
+#: ../gramps/plugins/importer/importcsv.py:229
 #: ../gramps/plugins/quickview/all_relations.py:297
 #: ../gramps/plugins/textreport/familygroup.py:249
 #: ../gramps/plugins/textreport/familygroup.py:260
@@ -7132,20 +7178,20 @@ msgstr ""
 #: ../gramps/plugins/textreport/indivcomplete.py:930
 #: ../gramps/plugins/textreport/tagreport.py:258
 #: ../gramps/plugins/view/familyview.py:81
-#: ../gramps/plugins/view/relview.py:894
-#: ../gramps/plugins/webreport/person.py:1571
+#: ../gramps/plugins/view/relview.py:1054
+#: ../gramps/plugins/webreport/person.py:1644
 msgid "Mother"
 msgstr ""
 
 #. Go over children and build their menu
-#: ../gramps/gen/lib/family.py:161 ../gramps/gui/widgets/fanchart.py:1691
+#: ../gramps/gen/lib/family.py:161 ../gramps/gui/widgets/fanchart.py:1957
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:855
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:869
 #: ../gramps/plugins/textreport/familygroup.py:646
 #: ../gramps/plugins/textreport/indivcomplete.py:678
-#: ../gramps/plugins/view/pedigreeview.py:1756
-#: ../gramps/plugins/view/relview.py:1400
-#: ../gramps/plugins/webreport/basepage.py:362
+#: ../gramps/plugins/view/pedigreeview.py:1829
+#: ../gramps/plugins/view/relview.py:1570
+#: ../gramps/plugins/webreport/basepage.py:381
 msgid "Children"
 msgstr ""
 
@@ -7155,14 +7201,14 @@ msgstr ""
 #: ../gramps/plugins/quickview/filterbyname.py:97
 #: ../gramps/plugins/quickview/filterbyname.py:122
 #: ../gramps/plugins/textreport/tagreport.py:324
-#: ../gramps/plugins/view/eventview.py:126
+#: ../gramps/plugins/view/eventview.py:122
 #: ../gramps/plugins/view/view.gpr.py:37 ../gramps/plugins/view/view.gpr.py:45
-#: ../gramps/plugins/webreport/basepage.py:1480
-#: ../gramps/plugins/webreport/basepage.py:1547
-#: ../gramps/plugins/webreport/basepage.py:1609
+#: ../gramps/plugins/webreport/basepage.py:1529
+#: ../gramps/plugins/webreport/basepage.py:1589
+#: ../gramps/plugins/webreport/basepage.py:1650
 #: ../gramps/plugins/webreport/event.py:141
-#: ../gramps/plugins/webreport/event.py:365
-#: ../gramps/plugins/webreport/person.py:1455
+#: ../gramps/plugins/webreport/event.py:366
+#: ../gramps/plugins/webreport/person.py:1529
 msgid "Events"
 msgstr ""
 
@@ -7171,7 +7217,7 @@ msgid "LDS ordinances"
 msgstr ""
 
 #: ../gramps/gen/lib/familyreltype.py:47
-#: ../gramps/plugins/webreport/webcal.py:2051
+#: ../gramps/plugins/webreport/webcal.py:2114
 msgid "Married"
 msgstr ""
 
@@ -7194,7 +7240,7 @@ msgstr ""
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:61
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:74
 #: ../gramps/gui/editors/displaytabs/notetab.py:77
-#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:60
+#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:62
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:69
 #: ../gramps/gui/editors/displaytabs/srcattrembedlist.py:63
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:65
@@ -7204,9 +7250,9 @@ msgstr ""
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:109
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:105
 #: ../gramps/gui/merge/mergeperson.py:253 ../gramps/gui/plug/_windows.py:123
-#: ../gramps/gui/plug/_windows.py:239 ../gramps/gui/plug/_windows.py:1103
-#: ../gramps/gui/plug/report/_bookdialog.py:383
-#: ../gramps/gui/plug/report/_bookdialog.py:387
+#: ../gramps/gui/plug/_windows.py:239 ../gramps/gui/plug/_windows.py:1105
+#: ../gramps/gui/plug/report/_bookdialog.py:384
+#: ../gramps/gui/plug/report/_bookdialog.py:388
 #: ../gramps/gui/selectors/selectevent.py:66
 #: ../gramps/gui/selectors/selectnote.py:73
 #: ../gramps/gui/selectors/selectobject.py:79
@@ -7217,7 +7263,7 @@ msgstr ""
 #: ../gramps/plugins/gramplet/events.py:85
 #: ../gramps/plugins/gramplet/locations.py:86
 #: ../gramps/plugins/gramplet/placedetails.py:126
-#: ../gramps/plugins/importer/importcsv.py:224
+#: ../gramps/plugins/importer/importcsv.py:240
 #: ../gramps/plugins/lib/libplaceview.py:88
 #: ../gramps/plugins/quickview/filterbyname.py:326
 #: ../gramps/plugins/quickview/linkreferences.py:45
@@ -7235,16 +7281,16 @@ msgstr ""
 #: ../gramps/plugins/textreport/tagreport.py:665
 #: ../gramps/plugins/tool/patchnames.py:407
 #: ../gramps/plugins/tool/sortevents.py:55
-#: ../gramps/plugins/view/eventview.py:84
+#: ../gramps/plugins/view/eventview.py:80
 #: ../gramps/plugins/view/mediaview.py:96 ../gramps/plugins/view/noteview.py:81
 #: ../gramps/plugins/view/repoview.py:87
-#: ../gramps/plugins/webreport/basepage.py:933
-#: ../gramps/plugins/webreport/basepage.py:1235
-#: ../gramps/plugins/webreport/basepage.py:2050
-#: ../gramps/plugins/webreport/basepage.py:2667
-#: ../gramps/plugins/webreport/event.py:175
-#: ../gramps/plugins/webreport/repository.py:162
-#: ../gramps/plugins/webreport/repository.py:251
+#: ../gramps/plugins/webreport/basepage.py:960
+#: ../gramps/plugins/webreport/basepage.py:1262
+#: ../gramps/plugins/webreport/basepage.py:2139
+#: ../gramps/plugins/webreport/basepage.py:2806
+#: ../gramps/plugins/webreport/event.py:176
+#: ../gramps/plugins/webreport/repository.py:163
+#: ../gramps/plugins/webreport/repository.py:253
 msgid "Type"
 msgstr ""
 
@@ -7279,7 +7325,8 @@ msgstr ""
 #: ../gramps/plugins/export/exportcsv.py:506
 #: ../gramps/plugins/gramplet/children.py:93
 #: ../gramps/plugins/gramplet/children.py:192
-#: ../gramps/plugins/importer/importcsv.py:210
+#: ../gramps/plugins/importer/importcsv.py:226
+#: ../gramps/plugins/importer/importprogen.glade:1275
 #: ../gramps/plugins/tool/findloop.py:118
 msgid "Child"
 msgstr ""
@@ -7328,7 +7375,7 @@ msgstr ""
 #: ../gramps/gui/editors/editldsord.py:442
 #: ../gramps/plugins/textreport/indivcomplete.py:499
 #: ../gramps/plugins/textreport/indivcomplete.py:704
-#: ../gramps/plugins/webreport/basepage.py:416
+#: ../gramps/plugins/webreport/basepage.py:435
 msgid "LDS Ordinance"
 msgstr ""
 
@@ -7337,13 +7384,13 @@ msgstr ""
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:64
 #: ../gramps/plugins/textreport/indivcomplete.py:509
 #: ../gramps/plugins/textreport/indivcomplete.py:708
-#: ../gramps/plugins/webreport/basepage.py:935
+#: ../gramps/plugins/webreport/basepage.py:962
 msgid "Temple"
 msgstr ""
 
 #. icon_column = Gtk.TreeViewColumn(_('Status'), render,
 #. icon_name=ICON_COL)
-#: ../gramps/gen/lib/ldsord.py:192 ../gramps/gui/dbman.py:395
+#: ../gramps/gen/lib/ldsord.py:192 ../gramps/gui/dbman.py:394
 #: ../gramps/gui/editors/displaytabs/familyldsembedlist.py:53
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:63
 #: ../gramps/gui/plug/_windows.py:127 ../gramps/gui/plug/_windows.py:184
@@ -7351,17 +7398,17 @@ msgstr ""
 #: ../gramps/plugins/textreport/indivcomplete.py:508
 #: ../gramps/plugins/textreport/indivcomplete.py:707
 #: ../gramps/plugins/textreport/notelinkreport.py:95
-#: ../gramps/plugins/webreport/basepage.py:937
+#: ../gramps/plugins/webreport/basepage.py:964
 msgid "Status"
 msgstr ""
 
 #: ../gramps/gen/lib/location.py:87 ../gramps/gen/lib/nameorigintype.py:86
-#: ../gramps/gui/clipboard.py:318 ../gramps/gui/plug/_windows.py:625
+#: ../gramps/gui/clipboard.py:318 ../gramps/gui/plug/_windows.py:627
 msgid "Location"
 msgstr ""
 
 #: ../gramps/gen/lib/location.py:107 ../gramps/gen/lib/placetype.py:69
-#: ../gramps/plugins/view/geoplaces.py:585
+#: ../gramps/plugins/view/geoplaces.py:644
 msgid "Parish"
 msgstr ""
 
@@ -7387,7 +7434,7 @@ msgid "Media ref"
 msgstr ""
 
 #: ../gramps/gen/lib/mediaref.py:110 ../gramps/gen/lib/placetype.py:73
-#: ../gramps/plugins/view/geoplaces.py:576
+#: ../gramps/plugins/view/geoplaces.py:635
 msgid "Region"
 msgstr ""
 
@@ -7397,25 +7444,25 @@ msgstr ""
 #. Add column with object name
 #: ../gramps/gen/lib/name.py:143 ../gramps/gen/lib/repo.py:96
 #: ../gramps/gen/lib/tag.py:122 ../gramps/gui/clipboard.py:562
-#: ../gramps/gui/configure.py:545
+#: ../gramps/gui/configure.py:608
 #: ../gramps/gui/editors/displaytabs/backreflist.py:61
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:73
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:64
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:66
 #: ../gramps/gui/editors/displaytabs/placenameembedlist.py:63
-#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:59
-#: ../gramps/gui/editors/editfamily.py:123
+#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:61
+#: ../gramps/gui/editors/editfamily.py:125
 #: ../gramps/gui/editors/editname.py:310
-#: ../gramps/gui/editors/filtereditor.py:820
-#: ../gramps/gui/editors/filtereditor.py:975
+#: ../gramps/gui/editors/filtereditor.py:834
+#: ../gramps/gui/editors/filtereditor.py:989
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:131
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:108
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:104
 #: ../gramps/gui/plug/_guioptions.py:1176 ../gramps/gui/plug/_windows.py:130
-#: ../gramps/gui/plug/_windows.py:1104
-#: ../gramps/gui/plug/report/_bookdialog.py:382
+#: ../gramps/gui/plug/_windows.py:1106
+#: ../gramps/gui/plug/report/_bookdialog.py:383
 #: ../gramps/gui/selectors/selectperson.py:90
 #: ../gramps/gui/selectors/selectplace.py:67
-#: ../gramps/gui/views/bookmarks.py:278 ../gramps/gui/views/tags.py:410
+#: ../gramps/gui/views/bookmarks.py:281 ../gramps/gui/views/tags.py:444
 #: ../gramps/gui/views/treemodels/peoplemodel.py:611
 #: ../gramps/plugins/export/exportcsv.py:286
 #: ../gramps/plugins/gramplet/ancestor.py:63
@@ -7423,7 +7470,7 @@ msgstr ""
 #: ../gramps/plugins/gramplet/descendant.py:62
 #: ../gramps/plugins/gramplet/locations.py:85
 #: ../gramps/plugins/gramplet/placedetails.py:125
-#: ../gramps/plugins/importer/importcsv.py:223
+#: ../gramps/plugins/importer/importcsv.py:239
 #: ../gramps/plugins/lib/libpersonview.py:98
 #: ../gramps/plugins/lib/libplaceview.py:85
 #: ../gramps/plugins/quickview/filterbyname.py:306
@@ -7438,34 +7485,34 @@ msgstr ""
 #: ../gramps/plugins/tool/dumpgenderstats.py:99
 #: ../gramps/plugins/tool/notrelated.py:126
 #: ../gramps/plugins/tool/removeunused.py:201
-#: ../gramps/plugins/tool/verify.py:576 ../gramps/plugins/view/repoview.py:85
-#: ../gramps/plugins/webreport/basepage.py:378
-#: ../gramps/plugins/webreport/person.py:1775
+#: ../gramps/plugins/tool/verify.py:579 ../gramps/plugins/view/repoview.py:85
+#: ../gramps/plugins/webreport/basepage.py:397
+#: ../gramps/plugins/webreport/person.py:1855
 msgid "Name"
 msgstr ""
 
-#: ../gramps/gen/lib/name.py:159 ../gramps/plugins/importer/importcsv.py:162
+#: ../gramps/gen/lib/name.py:159 ../gramps/plugins/importer/importcsv.py:163
 msgid "Given name"
 msgstr ""
 
-#: ../gramps/gen/lib/name.py:162 ../gramps/plugins/webreport/basepage.py:1478
-#: ../gramps/plugins/webreport/basepage.py:1530
-#: ../gramps/plugins/webreport/basepage.py:1533
-#: ../gramps/plugins/webreport/basepage.py:1601
-#: ../gramps/plugins/webreport/person.py:275
-#: ../gramps/plugins/webreport/surnamelist.py:97
-#: ../gramps/plugins/webreport/surnamelist.py:147
+#: ../gramps/gen/lib/name.py:162 ../gramps/plugins/webreport/basepage.py:1527
+#: ../gramps/plugins/webreport/basepage.py:1572
+#: ../gramps/plugins/webreport/basepage.py:1575
+#: ../gramps/plugins/webreport/basepage.py:1642
+#: ../gramps/plugins/webreport/person.py:292
+#: ../gramps/plugins/webreport/surnamelist.py:98
+#: ../gramps/plugins/webreport/surnamelist.py:148
 msgid "Surnames"
 msgstr ""
 
 #: ../gramps/gen/lib/name.py:164 ../gramps/gen/utils/keyword.py:60
-#: ../gramps/gui/configure.py:697 ../gramps/gui/configure.py:699
-#: ../gramps/gui/configure.py:701 ../gramps/gui/configure.py:703
-#: ../gramps/gui/configure.py:704 ../gramps/gui/configure.py:709
-#: ../gramps/gui/configure.py:711 ../gramps/gui/configure.py:716
-#: ../gramps/gui/configure.py:718 ../gramps/gui/glade/editperson.glade:229
+#: ../gramps/gui/configure.py:844 ../gramps/gui/configure.py:846
+#: ../gramps/gui/configure.py:848 ../gramps/gui/configure.py:850
+#: ../gramps/gui/configure.py:851 ../gramps/gui/configure.py:856
+#: ../gramps/gui/configure.py:858 ../gramps/gui/configure.py:863
+#: ../gramps/gui/configure.py:865 ../gramps/gui/glade/editperson.glade:229
 #: ../gramps/plugins/export/exportcsv.py:355
-#: ../gramps/plugins/importer/importcsv.py:167
+#: ../gramps/plugins/importer/importcsv.py:168
 msgid "Suffix"
 msgstr ""
 
@@ -7480,16 +7527,17 @@ msgstr ""
 #: ../gramps/gui/selectors/selectplace.py:70
 #: ../gramps/gui/selectors/selectrepository.py:66
 #: ../gramps/gui/selectors/selectsource.py:66
-#: ../gramps/gui/widgets/grampletpane.py:1568
+#: ../gramps/gui/widgets/grampletpane.py:1601
 #: ../gramps/plugins/export/exportcsv.py:286
 #: ../gramps/plugins/gramplet/persondetails.py:164
+#: ../gramps/plugins/importer/importprogen.glade:140
 #: ../gramps/plugins/lib/libplaceview.py:87
 #: ../gramps/plugins/textreport/tagreport.py:424
 #: ../gramps/plugins/textreport/tagreport.py:575
 #: ../gramps/plugins/textreport/tagreport.py:745
 #: ../gramps/plugins/view/mediaview.py:94
 #: ../gramps/plugins/view/sourceview.py:82
-#: ../gramps/plugins/webreport/basepage.py:2665
+#: ../gramps/plugins/webreport/basepage.py:2804
 msgid "Title"
 msgstr ""
 
@@ -7505,7 +7553,7 @@ msgstr ""
 msgid "Display as"
 msgstr ""
 
-#: ../gramps/gen/lib/name.py:175 ../gramps/plugins/importer/importcsv.py:163
+#: ../gramps/gen/lib/name.py:175 ../gramps/plugins/importer/importcsv.py:164
 msgid "Call name"
 msgstr ""
 
@@ -7531,9 +7579,9 @@ msgstr ""
 #. translators: needed for Arabic, ignore otherwise
 #: ../gramps/gen/lib/name.py:465 ../gramps/gen/lib/name.py:480
 #: ../gramps/gen/plug/report/utils.py:257
-#: ../gramps/plugins/graph/gvfamilylines.py:483
-#: ../gramps/plugins/textreport/detancestralreport.py:451
-#: ../gramps/plugins/textreport/detdescendantreport.py:486
+#: ../gramps/plugins/graph/gvfamilylines.py:490
+#: ../gramps/plugins/textreport/detancestralreport.py:454
+#: ../gramps/plugins/textreport/detdescendantreport.py:487
 #: ../gramps/plugins/textreport/indivcomplete.py:202
 #: ../gramps/plugins/textreport/indivcomplete.py:210
 #: ../gramps/plugins/textreport/indivcomplete.py:1018
@@ -7560,7 +7608,7 @@ msgid "Surname|Taken"
 msgstr ""
 
 #: ../gramps/gen/lib/nameorigintype.py:79 ../gramps/gen/utils/keyword.py:65
-#: ../gramps/gui/configure.py:710
+#: ../gramps/gui/configure.py:857
 msgid "Patronymic"
 msgstr ""
 
@@ -7598,12 +7646,12 @@ msgstr ""
 
 #. ###############################
 #. 3
-#: ../gramps/gen/lib/note.py:109 ../gramps/gen/plug/docgen/graphdoc.py:254
+#: ../gramps/gen/lib/note.py:109 ../gramps/gen/plug/docgen/graphdoc.py:265
 #: ../gramps/gen/plug/docgen/treedoc.py:199 ../gramps/gui/clipboard.py:375
-#: ../gramps/gui/configure.py:580 ../gramps/gui/editors/editlink.py:95
+#: ../gramps/gui/configure.py:667 ../gramps/gui/editors/editlink.py:95
 #: ../gramps/gui/editors/editmedia.py:98 ../gramps/gui/editors/editmedia.py:181
 #: ../gramps/gui/editors/editmediaref.py:146
-#: ../gramps/gui/editors/filtereditor.py:300
+#: ../gramps/gui/editors/filtereditor.py:301
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:109
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:115
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:109
@@ -7612,14 +7660,15 @@ msgstr ""
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:113
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:108
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:91
-#: ../gramps/gui/glade/editnote.glade:326 ../gramps/gui/viewmanager.py:622
+#: ../gramps/gui/glade/editnote.glade:326 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/views/treemodels/mediamodel.py:117
 #: ../gramps/plugins/drawreport/ancestortree.py:974
-#: ../gramps/plugins/drawreport/descendtree.py:1702
+#: ../gramps/plugins/drawreport/descendtree.py:1701
 #: ../gramps/plugins/export/exportcsv.py:361
 #: ../gramps/plugins/export/exportcsv.py:466
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:112
-#: ../gramps/plugins/importer/importcsv.py:170
+#: ../gramps/plugins/importer/importcsv.py:171
+#: ../gramps/plugins/importer/importprogen.glade:753
 #: ../gramps/plugins/quickview/filterbyname.py:225
 #: ../gramps/plugins/quickview/filterbyname.py:276
 #: ../gramps/plugins/quickview/quickview.gpr.py:208
@@ -7630,13 +7679,13 @@ msgstr ""
 msgid "Note"
 msgstr ""
 
-#: ../gramps/gen/lib/note.py:119 ../gramps/gui/configure.py:873
+#: ../gramps/gen/lib/note.py:119 ../gramps/gui/configure.py:1023
 #: ../gramps/gui/editors/editplaceformat.py:72
 #: ../gramps/plugins/tool/reorderids.glade:1447
 msgid "Format"
 msgstr ""
 
-#: ../gramps/gen/lib/notetype.py:75 ../gramps/gui/configure.py:1469
+#: ../gramps/gen/lib/notetype.py:75 ../gramps/gui/configure.py:1681
 #: ../gramps/gui/editors/editeventref.py:89
 #: ../gramps/gui/editors/editmediaref.py:107
 #: ../gramps/gui/editors/editplaceref.py:71
@@ -7667,7 +7716,7 @@ msgstr ""
 msgid "Source text"
 msgstr ""
 
-#: ../gramps/gen/lib/notetype.py:80 ../gramps/gen/plug/_pluginreg.py:78
+#: ../gramps/gen/lib/notetype.py:80 ../gramps/gen/plug/_pluginreg.py:79
 #: ../gramps/gui/logger/_errorview.py:174
 msgid "Report"
 msgstr ""
@@ -7754,7 +7803,6 @@ msgid "Child Reference Note"
 msgstr ""
 
 #. 4
-#. ('AddNewMenu', None, _('New')),
 #. ------------------------------------------------------------------------
 #.
 #. References
@@ -7762,12 +7810,15 @@ msgstr ""
 #. ------------------------------------------------------------------------
 #. functions for the actual quickreports
 #: ../gramps/gen/lib/person.py:173 ../gramps/gui/clipboard.py:719
-#: ../gramps/gui/configure.py:564 ../gramps/gui/editors/editlink.py:96
-#: ../gramps/gui/editors/filtereditor.py:293
-#: ../gramps/gui/glade/editpersonref.glade:211 ../gramps/gui/viewmanager.py:606
+#: ../gramps/gui/configure.py:643 ../gramps/gui/editors/editlink.py:96
+#: ../gramps/gui/editors/filtereditor.py:294
+#: ../gramps/gui/glade/editpersonref.glade:211 ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/export/exportcsv.py:354
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:108
-#: ../gramps/plugins/importer/importcsv.py:208
+#: ../gramps/plugins/importer/importcsv.py:209
+#: ../gramps/plugins/importer/importprogen.glade:667
+#: ../gramps/plugins/importer/importprogen.glade:1237
+#: ../gramps/plugins/importer/importprogen.glade:1326
 #: ../gramps/plugins/quickview/ageondate.py:54
 #: ../gramps/plugins/quickview/attributematch.py:34
 #: ../gramps/plugins/quickview/filterbyname.py:154
@@ -7789,23 +7840,23 @@ msgstr ""
 #: ../gramps/plugins/textreport/placereport.py:458
 #: ../gramps/plugins/tool/eventcmp.py:253
 #: ../gramps/plugins/tool/reorderids.glade:761
-#: ../gramps/plugins/webreport/event.py:179
-#: ../gramps/plugins/webreport/family.py:187
-#: ../gramps/plugins/webreport/person.py:1167
+#: ../gramps/plugins/webreport/event.py:180
+#: ../gramps/plugins/webreport/family.py:188
+#: ../gramps/plugins/webreport/person.py:1240
 msgid "Person"
 msgstr ""
 
-#: ../gramps/gen/lib/person.py:184 ../gramps/gui/editors/editfamily.py:124
+#: ../gramps/gen/lib/person.py:184 ../gramps/gui/editors/editfamily.py:126
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:133
 #: ../gramps/gui/merge/mergeperson.py:184
 #: ../gramps/gui/selectors/selectperson.py:92
-#: ../gramps/plugins/drawreport/statisticschart.py:338
+#: ../gramps/plugins/drawreport/statisticschart.py:344
 #: ../gramps/plugins/export/exportcsv.py:356
-#: ../gramps/plugins/importer/importcsv.py:168
+#: ../gramps/plugins/importer/importcsv.py:169
 #: ../gramps/plugins/lib/libpersonview.py:100
 #: ../gramps/plugins/quickview/siblings.py:48
 #: ../gramps/plugins/textreport/indivcomplete.py:928
-#: ../gramps/plugins/webreport/person.py:1407
+#: ../gramps/plugins/webreport/person.py:1481
 msgid "Gender"
 msgstr ""
 
@@ -7825,9 +7876,9 @@ msgstr ""
 msgid "Event references"
 msgstr ""
 
-#: ../gramps/gen/lib/person.py:199 ../gramps/plugins/graph/gvfamilylines.py:285
-#: ../gramps/plugins/graph/gvhourglass.py:381
-#: ../gramps/plugins/graph/gvrelgraph.py:910
+#: ../gramps/gen/lib/person.py:199 ../gramps/plugins/graph/gvfamilylines.py:292
+#: ../gramps/plugins/graph/gvhourglass.py:432
+#: ../gramps/plugins/graph/gvrelgraph.py:954
 #: ../gramps/plugins/quickview/filterbyname.py:94
 #: ../gramps/plugins/quickview/filterbyname.py:119
 #: ../gramps/plugins/textreport/indivcomplete.py:641
@@ -7835,11 +7886,11 @@ msgstr ""
 #: ../gramps/plugins/tool/verify.glade:753
 #: ../gramps/plugins/view/familyview.py:116
 #: ../gramps/plugins/view/view.gpr.py:52 ../gramps/plugins/view/view.gpr.py:60
-#: ../gramps/plugins/webreport/basepage.py:256
-#: ../gramps/plugins/webreport/basepage.py:304
-#: ../gramps/plugins/webreport/basepage.py:1479
-#: ../gramps/plugins/webreport/basepage.py:1538
-#: ../gramps/plugins/webreport/basepage.py:1602
+#: ../gramps/plugins/webreport/basepage.py:277
+#: ../gramps/plugins/webreport/basepage.py:323
+#: ../gramps/plugins/webreport/basepage.py:1528
+#: ../gramps/plugins/webreport/basepage.py:1580
+#: ../gramps/plugins/webreport/basepage.py:1643
 #: ../gramps/plugins/webreport/family.py:131
 msgid "Families"
 msgstr ""
@@ -7851,7 +7902,7 @@ msgstr ""
 #: ../gramps/gen/lib/person.py:209 ../gramps/gen/lib/repo.py:103
 #: ../gramps/gui/merge/mergeperson.py:268
 #: ../gramps/plugins/textreport/indivcomplete.py:420
-#: ../gramps/plugins/webreport/basepage.py:1057
+#: ../gramps/plugins/webreport/basepage.py:1084
 msgid "Addresses"
 msgstr ""
 
@@ -7872,7 +7923,7 @@ msgid "Person ref"
 msgstr ""
 
 #: ../gramps/gen/lib/personref.py:115
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:66
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:68
 msgid "Association"
 msgstr ""
 
@@ -7880,8 +7931,8 @@ msgstr ""
 #: ../gramps/plugins/gramplet/coordinates.py:96
 #: ../gramps/plugins/gramplet/placedetails.py:136
 #: ../gramps/plugins/lib/libplaceview.py:91
-#: ../gramps/plugins/webreport/basepage.py:2530
-#: ../gramps/plugins/webreport/place.py:180
+#: ../gramps/plugins/webreport/basepage.py:2579
+#: ../gramps/plugins/webreport/place.py:185
 msgid "Longitude"
 msgstr ""
 
@@ -7889,8 +7940,8 @@ msgstr ""
 #: ../gramps/plugins/gramplet/coordinates.py:95
 #: ../gramps/plugins/gramplet/placedetails.py:134
 #: ../gramps/plugins/lib/libplaceview.py:90
-#: ../gramps/plugins/webreport/basepage.py:2522
-#: ../gramps/plugins/webreport/place.py:179
+#: ../gramps/plugins/webreport/basepage.py:2571
+#: ../gramps/plugins/webreport/place.py:184
 msgid "Latitude"
 msgstr ""
 
@@ -7901,29 +7952,29 @@ msgstr ""
 #: ../gramps/plugins/view/view.gpr.py:221
 #: ../gramps/plugins/view/view.gpr.py:229
 #: ../gramps/plugins/view/view.gpr.py:244
-#: ../gramps/plugins/webreport/basepage.py:1481
-#: ../gramps/plugins/webreport/basepage.py:1544
-#: ../gramps/plugins/webreport/basepage.py:1610
-#: ../gramps/plugins/webreport/place.py:138
-#: ../gramps/plugins/webreport/place.py:292
+#: ../gramps/plugins/webreport/basepage.py:1530
+#: ../gramps/plugins/webreport/basepage.py:1586
+#: ../gramps/plugins/webreport/basepage.py:1651
+#: ../gramps/plugins/webreport/place.py:141
+#: ../gramps/plugins/webreport/place.py:308
 msgid "Places"
 msgstr ""
 
 #: ../gramps/gen/lib/place.py:154 ../gramps/gui/merge/mergeperson.py:199
 #: ../gramps/plugins/textreport/indivcomplete.py:391
-#: ../gramps/plugins/webreport/basepage.py:2573
+#: ../gramps/plugins/webreport/basepage.py:2623
 msgid "Alternate Names"
 msgstr ""
 
 #: ../gramps/gen/lib/place.py:157
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:110
 #: ../gramps/plugins/export/exportcsv.py:288
-#: ../gramps/plugins/importer/importcsv.py:227
+#: ../gramps/plugins/importer/importcsv.py:243
 #: ../gramps/plugins/lib/libplaceview.py:89
 msgid "Code"
 msgstr ""
 
-#: ../gramps/gen/lib/place.py:160 ../gramps/plugins/webreport/basepage.py:2597
+#: ../gramps/gen/lib/place.py:160 ../gramps/plugins/webreport/basepage.py:2647
 msgid "Alternate Locations"
 msgstr ""
 
@@ -7938,7 +7989,7 @@ msgstr ""
 
 #: ../gramps/gen/lib/placename.py:103
 #: ../gramps/gui/editors/displaytabs/placenameembedlist.py:65
-#: ../gramps/plugins/webreport/basepage.py:2575
+#: ../gramps/plugins/webreport/basepage.py:2625
 msgid "Language"
 msgstr ""
 
@@ -7946,63 +7997,63 @@ msgstr ""
 msgid "Place ref"
 msgstr ""
 
-#: ../gramps/gen/lib/placetype.py:72 ../gramps/plugins/view/geoplaces.py:573
+#: ../gramps/gen/lib/placetype.py:72 ../gramps/plugins/view/geoplaces.py:632
 msgid "Province"
 msgstr ""
 
-#: ../gramps/gen/lib/placetype.py:74 ../gramps/plugins/view/geoplaces.py:579
+#: ../gramps/gen/lib/placetype.py:74 ../gramps/plugins/view/geoplaces.py:638
 msgid "Department"
 msgstr ""
 
-#: ../gramps/gen/lib/placetype.py:75 ../gramps/plugins/view/geoplaces.py:543
+#: ../gramps/gen/lib/placetype.py:75 ../gramps/plugins/view/geoplaces.py:602
 msgid "Neighborhood"
 msgstr ""
 
-#: ../gramps/gen/lib/placetype.py:76 ../gramps/plugins/view/geoplaces.py:582
+#: ../gramps/gen/lib/placetype.py:76 ../gramps/plugins/view/geoplaces.py:641
 msgid "District"
 msgstr ""
 
-#: ../gramps/gen/lib/placetype.py:77 ../gramps/plugins/view/geoplaces.py:546
+#: ../gramps/gen/lib/placetype.py:77 ../gramps/plugins/view/geoplaces.py:605
 msgid "Borough"
 msgstr ""
 
-#: ../gramps/gen/lib/placetype.py:78 ../gramps/plugins/view/geoplaces.py:594
+#: ../gramps/gen/lib/placetype.py:78 ../gramps/plugins/view/geoplaces.py:653
 msgid "Municipality"
 msgstr ""
 
-#: ../gramps/gen/lib/placetype.py:79 ../gramps/plugins/view/geoplaces.py:591
+#: ../gramps/gen/lib/placetype.py:79 ../gramps/plugins/view/geoplaces.py:650
 msgid "Town"
 msgstr ""
 
-#: ../gramps/gen/lib/placetype.py:80 ../gramps/plugins/view/geoplaces.py:549
+#: ../gramps/gen/lib/placetype.py:80 ../gramps/plugins/view/geoplaces.py:608
 msgid "Village"
 msgstr ""
 
-#: ../gramps/gen/lib/placetype.py:81 ../gramps/plugins/view/geoplaces.py:552
+#: ../gramps/gen/lib/placetype.py:81 ../gramps/plugins/view/geoplaces.py:611
 msgid "Hamlet"
 msgstr ""
 
-#: ../gramps/gen/lib/placetype.py:82 ../gramps/plugins/view/geoplaces.py:555
+#: ../gramps/gen/lib/placetype.py:82 ../gramps/plugins/view/geoplaces.py:614
 msgid "Farm"
 msgstr ""
 
-#: ../gramps/gen/lib/placetype.py:83 ../gramps/plugins/view/geoplaces.py:558
+#: ../gramps/gen/lib/placetype.py:83 ../gramps/plugins/view/geoplaces.py:617
 msgid "Building"
 msgstr ""
 
-#: ../gramps/gen/lib/placetype.py:84 ../gramps/plugins/gramplet/leak.py:89
-#: ../gramps/plugins/view/geoplaces.py:561
-#: ../gramps/plugins/webreport/basepage.py:2663
-#: ../gramps/plugins/webreport/source.py:163
+#: ../gramps/gen/lib/placetype.py:84 ../gramps/plugins/gramplet/leak.py:95
+#: ../gramps/plugins/view/geoplaces.py:620
+#: ../gramps/plugins/webreport/basepage.py:2802
+#: ../gramps/plugins/webreport/source.py:164
 msgid "Number"
 msgstr ""
 
 #. 6
 #: ../gramps/gen/lib/repo.py:86 ../gramps/gui/clipboard.py:781
-#: ../gramps/gui/configure.py:578 ../gramps/gui/editors/editlink.py:98
+#: ../gramps/gui/configure.py:664 ../gramps/gui/editors/editlink.py:98
 #: ../gramps/gui/editors/editrepository.py:77
 #: ../gramps/gui/editors/editrepository.py:79
-#: ../gramps/gui/editors/filtereditor.py:299 ../gramps/gui/viewmanager.py:618
+#: ../gramps/gui/editors/filtereditor.py:300 ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:114
 #: ../gramps/plugins/quickview/filterbyname.py:205
 #: ../gramps/plugins/quickview/filterbyname.py:264
@@ -8063,8 +8114,8 @@ msgstr ""
 #: ../gramps/plugins/gramplet/citations.py:84
 #: ../gramps/plugins/textreport/tagreport.py:751
 #: ../gramps/plugins/view/sourceview.py:84
-#: ../gramps/plugins/webreport/source.py:164
-#: ../gramps/plugins/webreport/source.py:260
+#: ../gramps/plugins/webreport/source.py:165
+#: ../gramps/plugins/webreport/source.py:262
 msgid "Author"
 msgstr ""
 
@@ -8076,7 +8127,7 @@ msgstr ""
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:107
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:89
 #: ../gramps/plugins/view/sourceview.py:85
-#: ../gramps/plugins/webreport/source.py:261
+#: ../gramps/plugins/webreport/source.py:263
 msgid "Abbreviation"
 msgstr ""
 
@@ -8086,11 +8137,11 @@ msgstr ""
 #: ../gramps/plugins/view/repoview.py:129
 #: ../gramps/plugins/view/view.gpr.py:252
 #: ../gramps/plugins/view/view.gpr.py:260
-#: ../gramps/plugins/webreport/basepage.py:1483
-#: ../gramps/plugins/webreport/basepage.py:1612
-#: ../gramps/plugins/webreport/basepage.py:2654
+#: ../gramps/plugins/webreport/basepage.py:1532
+#: ../gramps/plugins/webreport/basepage.py:1653
+#: ../gramps/plugins/webreport/basepage.py:2793
 #: ../gramps/plugins/webreport/repository.py:138
-#: ../gramps/plugins/webreport/repository.py:223
+#: ../gramps/plugins/webreport/repository.py:224
 msgid "Repositories"
 msgstr ""
 
@@ -8165,7 +8216,7 @@ msgstr ""
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:114
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:109
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:92
-#: ../gramps/gui/views/tags.py:226 ../gramps/gui/views/tags.py:231
+#: ../gramps/gui/views/tags.py:61 ../gramps/gui/views/tags.py:71
 #: ../gramps/plugins/textreport/tagreport.py:909
 #: ../gramps/plugins/textreport/tagreport.py:913
 msgid "Tag"
@@ -8176,17 +8227,17 @@ msgid "Ranges"
 msgstr ""
 
 #: ../gramps/gen/lib/styledtexttagtype.py:61
-#: ../gramps/gui/widgets/styledtexteditor.py:455
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Bold"
 msgstr ""
 
 #: ../gramps/gen/lib/styledtexttagtype.py:62
-#: ../gramps/gui/widgets/styledtexteditor.py:453
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Italic"
 msgstr ""
 
 #: ../gramps/gen/lib/styledtexttagtype.py:63
-#: ../gramps/gui/widgets/styledtexteditor.py:457
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Underline"
 msgstr ""
 
@@ -8214,27 +8265,26 @@ msgstr ""
 #: ../gramps/gui/glade/editlink.glade:171
 #: ../gramps/gui/widgets/styledtextbuffer.py:565
 #: ../gramps/gui/widgets/styledtextbuffer.py:605
-#: ../gramps/gui/widgets/styledtexteditor.py:469
-#: ../gramps/gui/widgets/styledtexteditor.py:470
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Link"
 msgstr ""
 
 #. show surname and first name
 #: ../gramps/gen/lib/surname.py:87 ../gramps/gen/lib/surname.py:91
 #: ../gramps/gen/utils/keyword.py:56 ../gramps/gui/clipboard.py:596
-#: ../gramps/gui/configure.py:697 ../gramps/gui/configure.py:699
-#: ../gramps/gui/configure.py:701 ../gramps/gui/configure.py:703
-#: ../gramps/gui/configure.py:706 ../gramps/gui/configure.py:707
-#: ../gramps/gui/configure.py:708 ../gramps/gui/configure.py:709
+#: ../gramps/gui/configure.py:844 ../gramps/gui/configure.py:846
+#: ../gramps/gui/configure.py:848 ../gramps/gui/configure.py:850
+#: ../gramps/gui/configure.py:853 ../gramps/gui/configure.py:854
+#: ../gramps/gui/configure.py:855 ../gramps/gui/configure.py:856
 #: ../gramps/gui/editors/displaytabs/surnametab.py:75
 #: ../gramps/gui/plug/_guioptions.py:88 ../gramps/gui/plug/_guioptions.py:1508
-#: ../gramps/plugins/drawreport/statisticschart.py:334
+#: ../gramps/plugins/drawreport/statisticschart.py:340
 #: ../gramps/plugins/export/exportcsv.py:354
-#: ../gramps/plugins/importer/importcsv.py:159
+#: ../gramps/plugins/importer/importcsv.py:160
 #: ../gramps/plugins/quickview/filterbyname.py:354
-#: ../gramps/plugins/webreport/person.py:207
+#: ../gramps/plugins/webreport/person.py:213
 #: ../gramps/plugins/webreport/surname.py:98
-#: ../gramps/plugins/webreport/surnamelist.py:146
+#: ../gramps/plugins/webreport/surnamelist.py:147
 msgid "Surname"
 msgstr ""
 
@@ -8242,7 +8292,7 @@ msgstr ""
 #: ../gramps/gui/editors/displaytabs/surnametab.py:74
 #: ../gramps/gui/glade/editperson.glade:470
 #: ../gramps/plugins/export/exportcsv.py:355
-#: ../gramps/plugins/importer/importcsv.py:166
+#: ../gramps/plugins/importer/importcsv.py:167
 msgid "Prefix"
 msgstr ""
 
@@ -8259,7 +8309,7 @@ msgstr ""
 #: ../gramps/gen/lib/tag.py:125 ../gramps/gen/plug/docgen/treedoc.py:168
 #: ../gramps/gui/glade/styleeditor.glade:400
 #: ../gramps/gui/glade/styleeditor.glade:1449
-#: ../gramps/gui/plug/_guioptions.py:1509 ../gramps/gui/views/tags.py:411
+#: ../gramps/gui/plug/_guioptions.py:1509 ../gramps/gui/views/tags.py:445
 msgid "Color"
 msgstr ""
 
@@ -8365,7 +8415,7 @@ msgstr ""
 #. Constants
 #.
 #. -------------------------------------------------------------------------
-#: ../gramps/gen/plug/_manager.py:61
+#: ../gramps/gen/plug/_manager.py:62
 msgid "No description was provided"
 msgstr ""
 
@@ -8385,91 +8435,96 @@ msgstr ""
 msgid "Unstable"
 msgstr ""
 
-#: ../gramps/gen/plug/_pluginreg.py:79
+#: ../gramps/gen/plug/_pluginreg.py:80
 msgid "Quickreport"
 msgstr ""
 
-#: ../gramps/gen/plug/_pluginreg.py:80
+#: ../gramps/gen/plug/_pluginreg.py:81
 msgid "Tool"
 msgstr ""
 
-#: ../gramps/gen/plug/_pluginreg.py:81
+#: ../gramps/gen/plug/_pluginreg.py:82
 msgid "Importer"
 msgstr ""
 
-#: ../gramps/gen/plug/_pluginreg.py:82
+#: ../gramps/gen/plug/_pluginreg.py:83
 msgid "Exporter"
 msgstr ""
 
-#: ../gramps/gen/plug/_pluginreg.py:83
+#: ../gramps/gen/plug/_pluginreg.py:84
 msgid "Doc creator"
 msgstr ""
 
-#: ../gramps/gen/plug/_pluginreg.py:84
+#: ../gramps/gen/plug/_pluginreg.py:85
 msgid "Plugin lib"
 msgstr ""
 
-#: ../gramps/gen/plug/_pluginreg.py:85
+#: ../gramps/gen/plug/_pluginreg.py:86
 msgid "Map service"
 msgstr ""
 
-#: ../gramps/gen/plug/_pluginreg.py:86
+#: ../gramps/gen/plug/_pluginreg.py:87
 msgid "Gramps View"
 msgstr ""
 
-#: ../gramps/gen/plug/_pluginreg.py:87 ../gramps/plugins/view/relview.py:136
+#: ../gramps/gen/plug/_pluginreg.py:88 ../gramps/plugins/view/relview.py:131
 #: ../gramps/plugins/view/view.gpr.py:112
 #: ../gramps/plugins/view/view.gpr.py:120
 msgid "Relationships"
 msgstr ""
 
-#: ../gramps/gen/plug/_pluginreg.py:88 ../gramps/gen/plug/_pluginreg.py:425
+#: ../gramps/gen/plug/_pluginreg.py:89 ../gramps/gen/plug/_pluginreg.py:434
 #: ../gramps/gui/glade/grampletpane.glade:156
-#: ../gramps/gui/widgets/grampletbar.py:627
-#: ../gramps/gui/widgets/grampletpane.py:220
-#: ../gramps/gui/widgets/grampletpane.py:978
+#: ../gramps/gui/widgets/grampletbar.py:628
+#: ../gramps/gui/widgets/grampletpane.py:227
+#: ../gramps/gui/widgets/grampletpane.py:982
 msgid "Gramplet"
 msgstr ""
 
-#: ../gramps/gen/plug/_pluginreg.py:89
+#: ../gramps/gen/plug/_pluginreg.py:90
 msgid "Sidebar"
 msgstr ""
 
+#: ../gramps/gen/plug/_pluginreg.py:92
+msgid "Rule"
+msgstr ""
+
 #. add miscellaneous column
-#: ../gramps/gen/plug/_pluginreg.py:516
+#: ../gramps/gen/plug/_pluginreg.py:528
 #: ../gramps/plugins/gramplet/faqgramplet.py:135
-#: ../gramps/plugins/webreport/basepage.py:1669
-#: ../gramps/plugins/webreport/statistics.py:150
-#: ../gramps/plugins/webreport/statistics.py:200
+#: ../gramps/plugins/importer/importprogen.glade:1306
+#: ../gramps/plugins/webreport/basepage.py:1710
+#: ../gramps/plugins/webreport/statistics.py:151
+#: ../gramps/plugins/webreport/statistics.py:201
 msgid "Miscellaneous"
 msgstr ""
 
-#: ../gramps/gen/plug/_pluginreg.py:1145 ../gramps/gen/plug/_pluginreg.py:1171
-#: ../gramps/gen/plug/_pluginreg.py:1176
+#: ../gramps/gen/plug/_pluginreg.py:1178 ../gramps/gen/plug/_pluginreg.py:1204
+#: ../gramps/gen/plug/_pluginreg.py:1209
 #, python-format
 msgid "ERROR: Failed reading plugin registration %(filename)s"
 msgstr ""
 
-#: ../gramps/gen/plug/_pluginreg.py:1154
+#: ../gramps/gen/plug/_pluginreg.py:1187
 #, python-format
 msgid ""
 "WARNING: Plugin %(plugin_name)s has no translation for any of your "
 "configured languages, using US English instead"
 msgstr ""
 
-#: ../gramps/gen/plug/_pluginreg.py:1191
+#: ../gramps/gen/plug/_pluginreg.py:1224
 #, python-format
 msgid ""
 "ERROR: Plugin file %(filename)s has a version of \"%(gramps_target_version)s"
 "\" which is invalid for Gramps \"%(gramps_version)s\"."
 msgstr ""
 
-#: ../gramps/gen/plug/_pluginreg.py:1212
+#: ../gramps/gen/plug/_pluginreg.py:1245
 #, python-format
 msgid "ERROR: Wrong python file %(filename)s in register file %(regfile)s"
 msgstr ""
 
-#: ../gramps/gen/plug/_pluginreg.py:1220
+#: ../gramps/gen/plug/_pluginreg.py:1253
 #, python-format
 msgid ""
 "ERROR: Python file %(filename)s in register file %(regfile)s does not exist"
@@ -8514,18 +8569,18 @@ msgstr ""
 #: ../gramps/plugins/export/exportcsv.py:261
 #: ../gramps/plugins/export/exportcsv.py:265
 #: ../gramps/plugins/export/exportftree.py:135
-#: ../gramps/plugins/export/exportgedcom.py:1610
+#: ../gramps/plugins/export/exportgedcom.py:1600
 #: ../gramps/plugins/export/exportgeneweb.py:108
 #: ../gramps/plugins/export/exportgeneweb.py:112
-#: ../gramps/plugins/export/exportvcalendar.py:119
-#: ../gramps/plugins/export/exportvcalendar.py:123
+#: ../gramps/plugins/export/exportvcalendar.py:120
+#: ../gramps/plugins/export/exportvcalendar.py:124
 #: ../gramps/plugins/export/exportvcard.py:71
 #: ../gramps/plugins/export/exportvcard.py:75
 #: ../gramps/plugins/lib/libhtmlbackend.py:249
 #: ../gramps/plugins/lib/libhtmlbackend.py:253
 #: ../gramps/plugins/lib/libhtmlbackend.py:259
 #: ../gramps/plugins/lib/libhtmlbackend.py:263
-#: ../gramps/plugins/webreport/narrativeweb.py:316
+#: ../gramps/plugins/webreport/narrativeweb.py:333
 #, python-format
 msgid "Could not create %s"
 msgstr ""
@@ -8535,7 +8590,7 @@ msgstr ""
 #. Private Constants
 #.
 #. -------------------------------------------------------------------------
-#: ../gramps/gen/plug/docgen/graphdoc.py:66
+#: ../gramps/gen/plug/docgen/graphdoc.py:68
 #: ../gramps/gen/plug/docgen/treedoc.py:67
 #: ../gramps/gen/plug/docgen/treedoc.py:73
 #: ../gramps/gen/plug/report/stdoptions.py:60
@@ -8543,190 +8598,199 @@ msgstr ""
 #: ../gramps/gen/plug/report/stdoptions.py:244
 #: ../gramps/gen/plug/report/stdoptions.py:248
 #: ../gramps/gen/plug/report/stdoptions.py:338
+#: ../gramps/plugins/importer/importprogen.glade:380
 msgid "Default"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:67
+#: ../gramps/gen/plug/docgen/graphdoc.py:69
 msgid "PostScript / Helvetica"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:68
+#: ../gramps/gen/plug/docgen/graphdoc.py:70
 msgid "TrueType / FreeSans"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:70
-#: ../gramps/plugins/view/pedigreeview.py:2046
+#: ../gramps/gen/plug/docgen/graphdoc.py:72
+#: ../gramps/plugins/view/pedigreeview.py:2119
 msgid "Vertical (↓)"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:71
-#: ../gramps/plugins/view/pedigreeview.py:2047
+#: ../gramps/gen/plug/docgen/graphdoc.py:73
+#: ../gramps/plugins/view/pedigreeview.py:2120
 msgid "Vertical (↑)"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:72
-#: ../gramps/plugins/view/pedigreeview.py:2048
+#: ../gramps/gen/plug/docgen/graphdoc.py:74
+#: ../gramps/plugins/view/pedigreeview.py:2121
 msgid "Horizontal (→)"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:73
-#: ../gramps/plugins/view/pedigreeview.py:2049
+#: ../gramps/gen/plug/docgen/graphdoc.py:75
+#: ../gramps/plugins/view/pedigreeview.py:2122
 msgid "Horizontal (←)"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:75
+#: ../gramps/gen/plug/docgen/graphdoc.py:82
 msgid "Bottom, left"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:76
+#: ../gramps/gen/plug/docgen/graphdoc.py:83
 msgid "Bottom, right"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:77
+#: ../gramps/gen/plug/docgen/graphdoc.py:84
 msgid "Top, left"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:78
+#: ../gramps/gen/plug/docgen/graphdoc.py:85
 msgid "Top, Right"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:79
+#: ../gramps/gen/plug/docgen/graphdoc.py:86
 msgid "Right, bottom"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:80
+#: ../gramps/gen/plug/docgen/graphdoc.py:87
 msgid "Right, top"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:81
+#: ../gramps/gen/plug/docgen/graphdoc.py:88
 msgid "Left, bottom"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:82
+#: ../gramps/gen/plug/docgen/graphdoc.py:89
 msgid "Left, top"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:84
+#: ../gramps/gen/plug/docgen/graphdoc.py:91
 msgid "Compress to minimal size"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:85
+#: ../gramps/gen/plug/docgen/graphdoc.py:92
 msgid "Fill the given area"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:86
+#: ../gramps/gen/plug/docgen/graphdoc.py:93
 msgid "Expand uniformly"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:88
+#: ../gramps/gen/plug/docgen/graphdoc.py:95
 #: ../gramps/gen/plug/docgen/treedoc.py:86
 #: ../gramps/gui/glade/styleeditor.glade:1359
 msgid "Top"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:89
+#: ../gramps/gen/plug/docgen/graphdoc.py:96
 #: ../gramps/gen/plug/docgen/treedoc.py:87
 #: ../gramps/gui/glade/styleeditor.glade:1374
 msgid "Bottom"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:91
+#: ../gramps/gen/plug/docgen/graphdoc.py:98
 msgid "Straight"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:92
+#: ../gramps/gen/plug/docgen/graphdoc.py:99
 msgid "Curved"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:93
+#: ../gramps/gen/plug/docgen/graphdoc.py:100
 msgid "Orthogonal"
 msgstr ""
 
 #. ###############################
-#: ../gramps/gen/plug/docgen/graphdoc.py:134
+#: ../gramps/gen/plug/docgen/graphdoc.py:141
 msgid "Graphviz Layout"
 msgstr ""
 
 #. ###############################
-#: ../gramps/gen/plug/docgen/graphdoc.py:136
-#: ../gramps/gui/widgets/styledtexteditor.py:479
+#: ../gramps/gen/plug/docgen/graphdoc.py:143
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Font family"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:139
+#: ../gramps/gen/plug/docgen/graphdoc.py:146
 msgid ""
 "Choose the font family. If international characters don't show, use FreeSans "
 "font. FreeSans is available from: http://www.nongnu.org/freefont/"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:145
-#: ../gramps/gui/widgets/styledtexteditor.py:491
+#: ../gramps/gen/plug/docgen/graphdoc.py:152
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Font size"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:146
+#: ../gramps/gen/plug/docgen/graphdoc.py:153
 msgid "The font size, in points."
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:149
+#: ../gramps/gen/plug/docgen/graphdoc.py:156
 msgid "Graph Direction"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:152
+#: ../gramps/gen/plug/docgen/graphdoc.py:159
 msgid "Whether graph goes from top to bottom or left to right."
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:156
+#: ../gramps/gen/plug/docgen/graphdoc.py:163
 msgid "Number of Horizontal Pages"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:157
+#: ../gramps/gen/plug/docgen/graphdoc.py:164
 msgid ""
 "Graphviz can create very large graphs by spreading the graph across a "
 "rectangular array of pages. This controls the number pages in the array "
 "horizontally. Only valid for dot and pdf via Ghostscript."
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:164
+#: ../gramps/gen/plug/docgen/graphdoc.py:171
 msgid "Number of Vertical Pages"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:165
+#: ../gramps/gen/plug/docgen/graphdoc.py:172
 msgid ""
 "Graphviz can create very large graphs by spreading the graph across a "
 "rectangular array of pages. This controls the number pages in the array "
 "vertically. Only valid for dot and pdf via Ghostscript."
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:172
+#: ../gramps/gen/plug/docgen/graphdoc.py:179
 msgid "Paging Direction"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:175
+#: ../gramps/gen/plug/docgen/graphdoc.py:182
 msgid ""
 "The order in which the graph pages are output. This option only applies if "
 "the horizontal pages or vertical pages are greater than 1."
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:180
+#: ../gramps/gen/plug/docgen/graphdoc.py:187
 msgid "Connecting lines"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:183
+#: ../gramps/gen/plug/docgen/graphdoc.py:190
 msgid "How the lines between objects will be drawn."
 msgstr ""
 
+#: ../gramps/gen/plug/docgen/graphdoc.py:193
+msgid "Alternate line attachment"
+msgstr ""
+
+#: ../gramps/gen/plug/docgen/graphdoc.py:194
+msgid "Whether lines attach to nodes differently"
+msgstr ""
+
 #. ###############################
-#: ../gramps/gen/plug/docgen/graphdoc.py:199
+#: ../gramps/gen/plug/docgen/graphdoc.py:210
 msgid "Graphviz Options"
 msgstr ""
 
 #. ###############################
-#: ../gramps/gen/plug/docgen/graphdoc.py:202
+#: ../gramps/gen/plug/docgen/graphdoc.py:213
 msgid "Aspect ratio"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:206
+#: ../gramps/gen/plug/docgen/graphdoc.py:217
 msgid ""
 "Affects node spacing and scaling of the graph.\n"
 "If the graph is smaller than the print area:\n"
@@ -8743,111 +8807,111 @@ msgid ""
 "  Expand will shrink the graph uniformly to fit the print area."
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:222
+#: ../gramps/gen/plug/docgen/graphdoc.py:233
 msgid "DPI"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:223
+#: ../gramps/gen/plug/docgen/graphdoc.py:234
 msgid ""
 "Dots per inch.  When creating images such as .gif or .png files for the web, "
 "try numbers such as 100 or 300 DPI.  PostScript and PDF files always use 72 "
 "DPI."
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:230
+#: ../gramps/gen/plug/docgen/graphdoc.py:241
 msgid "Node spacing"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:231
+#: ../gramps/gen/plug/docgen/graphdoc.py:242
 msgid ""
 "The minimum amount of free space, in inches, between individual nodes.  For "
 "vertical graphs, this corresponds to spacing between columns.  For "
 "horizontal graphs, this corresponds to spacing between rows."
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:238
+#: ../gramps/gen/plug/docgen/graphdoc.py:249
 msgid "Rank spacing"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:239
+#: ../gramps/gen/plug/docgen/graphdoc.py:250
 msgid ""
 "The minimum amount of free space, in inches, between ranks.  For vertical "
 "graphs, this corresponds to spacing between rows.  For horizontal graphs, "
 "this corresponds to spacing between columns."
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:246
+#: ../gramps/gen/plug/docgen/graphdoc.py:257
 msgid "Use subgraphs"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:247
+#: ../gramps/gen/plug/docgen/graphdoc.py:258
 msgid ""
 "Subgraphs can help Graphviz position spouses together, but with non-trivial "
 "graphs will result in longer lines and larger graphs."
 msgstr ""
 
 #. ###############################
-#: ../gramps/gen/plug/docgen/graphdoc.py:257
+#: ../gramps/gen/plug/docgen/graphdoc.py:268
 msgid "Note to add to the graph"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:259
+#: ../gramps/gen/plug/docgen/graphdoc.py:270
 msgid "This text will be added to the graph."
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:262
+#: ../gramps/gen/plug/docgen/graphdoc.py:273
 #: ../gramps/gen/plug/docgen/treedoc.py:206
 msgid "Note location"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:265
+#: ../gramps/gen/plug/docgen/graphdoc.py:276
 #: ../gramps/gen/plug/docgen/treedoc.py:209
 msgid "Whether note will appear on top or bottom of the page."
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:269
+#: ../gramps/gen/plug/docgen/graphdoc.py:280
 #: ../gramps/gen/plug/docgen/treedoc.py:213
 msgid "Note size"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:270
+#: ../gramps/gen/plug/docgen/graphdoc.py:281
 msgid "The size of note text, in points."
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1013
+#: ../gramps/gen/plug/docgen/graphdoc.py:1073
 msgid "PDF (Ghostscript)"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1019
+#: ../gramps/gen/plug/docgen/graphdoc.py:1079
 msgid "PDF (Graphviz)"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1025
+#: ../gramps/gen/plug/docgen/graphdoc.py:1085
 #: ../gramps/plugins/docgen/docgen.gpr.py:161
 msgid "PostScript"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1031
+#: ../gramps/gen/plug/docgen/graphdoc.py:1091
 msgid "Structured Vector Graphics (SVG)"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1037
+#: ../gramps/gen/plug/docgen/graphdoc.py:1097
 msgid "Compressed Structured Vector Graphs (SVGZ)"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1043
+#: ../gramps/gen/plug/docgen/graphdoc.py:1103
 msgid "JPEG image"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1049
+#: ../gramps/gen/plug/docgen/graphdoc.py:1109
 msgid "GIF image"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1055
+#: ../gramps/gen/plug/docgen/graphdoc.py:1115
 msgid "PNG image"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1061
+#: ../gramps/gen/plug/docgen/graphdoc.py:1121
 msgid "Graphviz File"
 msgstr ""
 
@@ -8893,9 +8957,9 @@ msgstr ""
 msgid "Not shown"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/treedoc.py:74 ../gramps/gui/configure.py:96
-#: ../gramps/gui/configure.py:162 ../gramps/gui/configure.py:1724
-#: ../gramps/gui/views/pageview.py:606
+#: ../gramps/gen/plug/docgen/treedoc.py:74 ../gramps/gui/configure.py:99
+#: ../gramps/gui/configure.py:166 ../gramps/gui/configure.py:1946
+#: ../gramps/gui/views/pageview.py:591
 msgid "Preferences"
 msgstr ""
 
@@ -8948,13 +9012,14 @@ msgid "Small"
 msgstr ""
 
 #: ../gramps/gen/plug/docgen/treedoc.py:93 ../gramps/gen/utils/string.py:57
-#: ../gramps/gui/editors/editcitation.py:212
-#: ../gramps/plugins/graph/gvfamilylines.py:255
+#: ../gramps/gui/editors/editcitation.py:214
+#: ../gramps/plugins/graph/gvfamilylines.py:262
+#: ../gramps/plugins/importer/importprogen.py:487
 msgid "Normal"
 msgstr ""
 
 #: ../gramps/gen/plug/docgen/treedoc.py:94
-#: ../gramps/plugins/graph/gvfamilylines.py:256
+#: ../gramps/plugins/graph/gvfamilylines.py:263
 msgid "Large"
 msgstr ""
 
@@ -9020,7 +9085,7 @@ msgstr ""
 #. #################
 #: ../gramps/gen/plug/docgen/treedoc.py:175
 #: ../gramps/plugins/drawreport/ancestortree.py:791
-#: ../gramps/plugins/drawreport/descendtree.py:1528
+#: ../gramps/plugins/drawreport/descendtree.py:1527
 msgid "Tree Options"
 msgstr ""
 
@@ -9065,11 +9130,11 @@ msgstr ""
 msgid "The size of note text."
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/treedoc.py:653
+#: ../gramps/gen/plug/docgen/treedoc.py:655
 msgid "PDF"
 msgstr ""
 
-#: ../gramps/gen/plug/docgen/treedoc.py:659
+#: ../gramps/gen/plug/docgen/treedoc.py:661
 msgid "LaTeX File"
 msgstr ""
 
@@ -9088,8 +9153,13 @@ msgstr ""
 #. Private Constants
 #.
 #. ------------------------------------------------------------------------
+#. -------------------------------------------------------------------------
+#.
+#. Constants
+#.
+#. -------------------------------------------------------------------------
 #: ../gramps/gen/plug/report/_book.py:71 ../gramps/gui/plug/_dialogs.py:59
-#: ../gramps/gui/plug/report/_bookdialog.py:86 ../gramps/gui/viewmanager.py:121
+#: ../gramps/gui/plug/report/_bookdialog.py:86 ../gramps/gui/viewmanager.py:112
 msgid "Unsupported"
 msgstr ""
 
@@ -9128,8 +9198,8 @@ msgstr ""
 
 #: ../gramps/gen/plug/report/endnotes.py:61
 #: ../gramps/plugins/textreport/ancestorreport.py:376
-#: ../gramps/plugins/textreport/detancestralreport.py:983
-#: ../gramps/plugins/textreport/detdescendantreport.py:1188
+#: ../gramps/plugins/textreport/detancestralreport.py:990
+#: ../gramps/plugins/textreport/detdescendantreport.py:1193
 #: ../gramps/plugins/textreport/endoflinereport.py:326
 msgid "The style used for the generation header."
 msgstr ""
@@ -9164,8 +9234,8 @@ msgstr ""
 #. show "> Family: ..." and nothing else
 #. show "V Family: ..." and the rest
 #: ../gramps/gen/plug/report/endnotes.py:175
-#: ../gramps/gui/editors/editfamily.py:946
-#: ../gramps/gui/editors/editfamily.py:953
+#: ../gramps/gui/editors/editfamily.py:995
+#: ../gramps/gui/editors/editfamily.py:1002
 #: ../gramps/gui/plug/report/_docreportdialog.py:186
 #: ../gramps/gui/plug/report/_docreportdialog.py:237
 #: ../gramps/gui/plug/report/_graphreportdialog.py:154
@@ -9193,12 +9263,13 @@ msgstr ""
 #: ../gramps/plugins/textreport/indivcomplete.py:928
 #: ../gramps/plugins/textreport/indivcomplete.py:929
 #: ../gramps/plugins/textreport/indivcomplete.py:930
-#: ../gramps/plugins/view/relview.py:530 ../gramps/plugins/view/relview.py:592
-#: ../gramps/plugins/view/relview.py:604 ../gramps/plugins/view/relview.py:623
-#: ../gramps/plugins/view/relview.py:635 ../gramps/plugins/view/relview.py:640
-#: ../gramps/plugins/view/relview.py:648 ../gramps/plugins/view/relview.py:858
-#: ../gramps/plugins/view/relview.py:892 ../gramps/plugins/view/relview.py:1360
-#: ../gramps/plugins/view/relview.py:1382
+#: ../gramps/plugins/view/relview.py:659 ../gramps/plugins/view/relview.py:723
+#: ../gramps/plugins/view/relview.py:735 ../gramps/plugins/view/relview.py:756
+#: ../gramps/plugins/view/relview.py:768 ../gramps/plugins/view/relview.py:773
+#: ../gramps/plugins/view/relview.py:780 ../gramps/plugins/view/relview.py:1017
+#: ../gramps/plugins/view/relview.py:1052
+#: ../gramps/plugins/view/relview.py:1529
+#: ../gramps/plugins/view/relview.py:1552
 #, python-format
 msgid "%s:"
 msgstr ""
@@ -9211,13 +9282,13 @@ msgstr ""
 msgid "The translation to be used for the report."
 msgstr ""
 
-#: ../gramps/gen/plug/report/stdoptions.py:73 ../gramps/gui/configure.py:1039
-#: ../gramps/plugins/webreport/webcal.py:1682
+#: ../gramps/gen/plug/report/stdoptions.py:73 ../gramps/gui/configure.py:1194
+#: ../gramps/plugins/webreport/webcal.py:1720
 msgid "Name format"
 msgstr ""
 
 #: ../gramps/gen/plug/report/stdoptions.py:78
-#: ../gramps/plugins/webreport/webcal.py:1686
+#: ../gramps/plugins/webreport/webcal.py:1724
 msgid "Select the format to display names"
 msgstr ""
 
@@ -9266,7 +9337,7 @@ msgstr ""
 msgid "Whether to restrict data on recently-dead people"
 msgstr ""
 
-#: ../gramps/gen/plug/report/stdoptions.py:257 ../gramps/gui/configure.py:1067
+#: ../gramps/gen/plug/report/stdoptions.py:257 ../gramps/gui/configure.py:1222
 msgid "Date format"
 msgstr ""
 
@@ -9296,14 +9367,14 @@ msgstr ""
 #. #########################
 #. ###############################
 #: ../gramps/gen/plug/report/stdoptions.py:328
-#: ../gramps/gui/viewmanager.py:1938
-#: ../gramps/plugins/graph/gvfamilylines.py:211
-#: ../gramps/plugins/graph/gvrelgraph.py:820
-#: ../gramps/plugins/textreport/detancestralreport.py:893
-#: ../gramps/plugins/textreport/detdescendantreport.py:1080
+#: ../gramps/gui/viewmanager.py:1722
+#: ../gramps/plugins/graph/gvfamilylines.py:218
+#: ../gramps/plugins/graph/gvrelgraph.py:859
+#: ../gramps/plugins/textreport/detancestralreport.py:900
+#: ../gramps/plugins/textreport/detdescendantreport.py:1085
 #: ../gramps/plugins/textreport/familygroup.py:752
 #: ../gramps/plugins/textreport/indivcomplete.py:1102
-#: ../gramps/plugins/webreport/narrativeweb.py:1901
+#: ../gramps/plugins/webreport/narrativeweb.py:1986
 msgid "Include"
 msgstr ""
 
@@ -9311,7 +9382,7 @@ msgstr ""
 msgid "Whether to include Gramps IDs"
 msgstr ""
 
-#: ../gramps/gen/plug/report/stdoptions.py:337 ../gramps/gui/configure.py:1081
+#: ../gramps/gen/plug/report/stdoptions.py:337
 msgid "Place format"
 msgstr ""
 
@@ -9327,10 +9398,10 @@ msgstr ""
 #: ../gramps/gen/plug/report/utils.py:159
 #: ../gramps/plugins/textreport/indivcomplete.py:915
 #: ../gramps/plugins/textreport/simplebooktitle.py:106
-#: ../gramps/plugins/webreport/basepage.py:1712
-#: ../gramps/plugins/webreport/basepage.py:1915
-#: ../gramps/plugins/webreport/basepage.py:1981
-#: ../gramps/plugins/webreport/basepage.py:1989
+#: ../gramps/plugins/webreport/basepage.py:1799
+#: ../gramps/plugins/webreport/basepage.py:2004
+#: ../gramps/plugins/webreport/basepage.py:2070
+#: ../gramps/plugins/webreport/basepage.py:2078
 msgid "Could not add photo to page"
 msgstr ""
 
@@ -9482,7 +9553,7 @@ msgid ""
 msgstr ""
 
 #: ../gramps/gen/relationship.py:1273
-#: ../gramps/plugins/view/pedigreeview.py:1533
+#: ../gramps/plugins/view/pedigreeview.py:1600
 msgid "Relationship loop detected"
 msgstr ""
 
@@ -9507,12 +9578,12 @@ msgid "undefined"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2170
-#: ../gramps/plugins/importer/importcsv.py:217
+#: ../gramps/plugins/importer/importcsv.py:233
 msgid "husband"
 msgstr ""
 
 #: ../gramps/gen/relationship.py:2172
-#: ../gramps/plugins/importer/importcsv.py:214
+#: ../gramps/plugins/importer/importcsv.py:230
 msgid "wife"
 msgstr ""
 
@@ -9611,11 +9682,11 @@ msgid ""
 "'english' instead."
 msgstr ""
 
-#: ../gramps/gen/utils/alive.py:145 ../gramps/plugins/importer/importcsv.py:201
+#: ../gramps/gen/utils/alive.py:145 ../gramps/plugins/importer/importcsv.py:202
 msgid "death date"
 msgstr ""
 
-#: ../gramps/gen/utils/alive.py:150 ../gramps/plugins/importer/importcsv.py:177
+#: ../gramps/gen/utils/alive.py:150 ../gramps/plugins/importer/importcsv.py:178
 msgid "birth date"
 msgstr ""
 
@@ -9960,10 +10031,10 @@ msgstr ""
 msgid "GIVEN"
 msgstr ""
 
-#: ../gramps/gen/utils/keyword.py:56 ../gramps/gui/configure.py:704
-#: ../gramps/gui/configure.py:711 ../gramps/gui/configure.py:713
-#: ../gramps/gui/configure.py:714 ../gramps/gui/configure.py:715
-#: ../gramps/gui/configure.py:716 ../gramps/gui/configure.py:717
+#: ../gramps/gen/utils/keyword.py:56 ../gramps/gui/configure.py:851
+#: ../gramps/gui/configure.py:858 ../gramps/gui/configure.py:860
+#: ../gramps/gui/configure.py:861 ../gramps/gui/configure.py:862
+#: ../gramps/gui/configure.py:863 ../gramps/gui/configure.py:864
 msgid "SURNAME"
 msgstr ""
 
@@ -9979,9 +10050,9 @@ msgstr ""
 msgid "Name|COMMON"
 msgstr ""
 
-#: ../gramps/gen/utils/keyword.py:58 ../gramps/gui/configure.py:701
-#: ../gramps/gui/configure.py:703 ../gramps/gui/configure.py:706
-#: ../gramps/gui/configure.py:707 ../gramps/gui/configure.py:713
+#: ../gramps/gen/utils/keyword.py:58 ../gramps/gui/configure.py:848
+#: ../gramps/gui/configure.py:850 ../gramps/gui/configure.py:853
+#: ../gramps/gui/configure.py:854 ../gramps/gui/configure.py:860
 msgid "Name|Common"
 msgstr ""
 
@@ -10063,7 +10134,7 @@ msgstr ""
 msgid "RAWSURNAMES"
 msgstr ""
 
-#: ../gramps/gen/utils/keyword.py:69 ../gramps/gui/configure.py:718
+#: ../gramps/gen/utils/keyword.py:69 ../gramps/gui/configure.py:865
 msgid "Rawsurnames"
 msgstr ""
 
@@ -10111,21 +10182,21 @@ msgstr ""
 msgid "%(west_longitude)s W"
 msgstr ""
 
-#: ../gramps/gen/utils/string.py:46 ../gramps/gui/editors/editperson.py:348
+#: ../gramps/gen/utils/string.py:46 ../gramps/gui/editors/editperson.py:341
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:94
 #: ../gramps/gui/merge/mergeperson.py:64
 #: ../gramps/gui/views/treemodels/peoplemodel.py:97
 #: ../gramps/plugins/tool/dumpgenderstats.py:46
-#: ../gramps/plugins/webreport/person.py:412
+#: ../gramps/plugins/webreport/person.py:429
 msgid "male"
 msgstr ""
 
-#: ../gramps/gen/utils/string.py:47 ../gramps/gui/editors/editperson.py:347
+#: ../gramps/gen/utils/string.py:47 ../gramps/gui/editors/editperson.py:340
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:94
 #: ../gramps/gui/merge/mergeperson.py:64
 #: ../gramps/gui/views/treemodels/peoplemodel.py:97
 #: ../gramps/plugins/tool/dumpgenderstats.py:46
-#: ../gramps/plugins/webreport/person.py:413
+#: ../gramps/plugins/webreport/person.py:430
 msgid "female"
 msgstr ""
 
@@ -10137,21 +10208,25 @@ msgstr ""
 msgid "Invalid"
 msgstr ""
 
-#: ../gramps/gen/utils/string.py:55 ../gramps/gui/editors/editcitation.py:214
+#: ../gramps/gen/utils/string.py:55 ../gramps/gui/editors/editcitation.py:216
+#: ../gramps/plugins/importer/importprogen.py:489
 msgid "Very High"
 msgstr ""
 
-#: ../gramps/gen/utils/string.py:56 ../gramps/gui/editors/editcitation.py:213
+#: ../gramps/gen/utils/string.py:56 ../gramps/gui/editors/editcitation.py:215
+#: ../gramps/plugins/importer/importprogen.py:488
 #: ../gramps/plugins/tool/finddupes.py:62
 msgid "High"
 msgstr ""
 
-#: ../gramps/gen/utils/string.py:58 ../gramps/gui/editors/editcitation.py:211
+#: ../gramps/gen/utils/string.py:58 ../gramps/gui/editors/editcitation.py:213
+#: ../gramps/plugins/importer/importprogen.py:486
 #: ../gramps/plugins/tool/finddupes.py:60
 msgid "Low"
 msgstr ""
 
-#: ../gramps/gen/utils/string.py:59 ../gramps/gui/editors/editcitation.py:210
+#: ../gramps/gen/utils/string.py:59 ../gramps/gui/editors/editcitation.py:212
+#: ../gramps/plugins/importer/importprogen.py:485
 msgid "Very Low"
 msgstr ""
 
@@ -10196,7 +10271,7 @@ msgstr ""
 msgid "Objects referenced by this note were missing in a file imported on %s."
 msgstr ""
 
-#: ../gramps/grampsapp.py:158
+#: ../gramps/grampsapp.py:172
 #, python-format
 msgid ""
 "Your Python version does not meet the requirements. At least python %(v1)d."
@@ -10205,16 +10280,16 @@ msgid ""
 "Gramps will terminate now."
 msgstr ""
 
-#: ../gramps/grampsapp.py:414 ../gramps/grampsapp.py:421
-#: ../gramps/grampsapp.py:465
+#: ../gramps/grampsapp.py:428 ../gramps/grampsapp.py:435
+#: ../gramps/grampsapp.py:491
 msgid "Configuration error:"
 msgstr ""
 
-#: ../gramps/grampsapp.py:418
+#: ../gramps/grampsapp.py:432
 msgid "Error reading configuration"
 msgstr ""
 
-#: ../gramps/grampsapp.py:422
+#: ../gramps/grampsapp.py:436
 #, python-format
 msgid ""
 "A definition for the MIME-type %s could not be found \n"
@@ -10290,25 +10365,25 @@ msgstr ""
 msgid "%(frel)s %(mrel)s"
 msgstr ""
 
-#: ../gramps/gui/clipboard.py:1384 ../gramps/gui/clipboard.py:1390
-#: ../gramps/gui/clipboard.py:1428 ../gramps/gui/clipboard.py:1473
+#: ../gramps/gui/clipboard.py:1357 ../gramps/gui/clipboard.py:1363
+#: ../gramps/gui/clipboard.py:1401 ../gramps/gui/clipboard.py:1446
 #: ../gramps/gui/glade/clipboard.glade:7
 msgid "Clipboard"
 msgstr ""
 
 #. Now add more items to popup menu, if available
 #. See details (edit, etc):
-#: ../gramps/gui/clipboard.py:1520 ../gramps/gui/plug/quick/_quicktable.py:141
+#: ../gramps/gui/clipboard.py:1493 ../gramps/gui/plug/quick/_quicktable.py:141
 #, python-format
 msgid "the object|See %s details"
 msgstr ""
 
-#: ../gramps/gui/clipboard.py:1529 ../gramps/gui/plug/quick/_quicktable.py:149
+#: ../gramps/gui/clipboard.py:1502 ../gramps/gui/plug/quick/_quicktable.py:149
 #, python-format
 msgid "the object|Make %s active"
 msgstr ""
 
-#: ../gramps/gui/clipboard.py:1551
+#: ../gramps/gui/clipboard.py:1524
 #, python-format
 msgid "the object|Create Filter from %s selected..."
 msgstr ""
@@ -10322,19 +10397,19 @@ msgstr ""
 msgid "Drag and drop the columns to change the order"
 msgstr ""
 
-#: ../gramps/gui/columnorder.py:107 ../gramps/gui/configure.py:1624
-#: ../gramps/gui/configure.py:1646 ../gramps/gui/configure.py:1669
-#: ../gramps/gui/plug/_dialogs.py:130 ../gramps/gui/viewmanager.py:2010
-#: ../gramps/plugins/lib/maps/geography.py:1011
-#: ../gramps/plugins/lib/maps/geography.py:1266
+#: ../gramps/gui/columnorder.py:107 ../gramps/gui/configure.py:1842
+#: ../gramps/gui/configure.py:1866 ../gramps/gui/configure.py:1892
+#: ../gramps/gui/plug/_dialogs.py:130 ../gramps/gui/viewmanager.py:1794
+#: ../gramps/plugins/lib/maps/geography.py:997
+#: ../gramps/plugins/lib/maps/geography.py:1294
 msgid "_Apply"
 msgstr ""
 
 #. #################
-#: ../gramps/gui/columnorder.py:128 ../gramps/gui/configure.py:1197
+#: ../gramps/gui/columnorder.py:128 ../gramps/gui/configure.py:1353
 #: ../gramps/plugins/drawreport/ancestortree.py:909
-#: ../gramps/plugins/drawreport/descendtree.py:1653
-#: ../gramps/plugins/webreport/narrativeweb.py:1698
+#: ../gramps/plugins/drawreport/descendtree.py:1652
+#: ../gramps/plugins/webreport/narrativeweb.py:1766
 msgid "Display"
 msgstr ""
 
@@ -10342,45 +10417,45 @@ msgstr ""
 msgid "Column Name"
 msgstr ""
 
-#: ../gramps/gui/configure.py:83
+#: ../gramps/gui/configure.py:86
 msgid "Father's surname"
 msgstr ""
 
-#: ../gramps/gui/configure.py:85
+#: ../gramps/gui/configure.py:88
 msgid "Combination of mother's and father's surname"
 msgstr ""
 
-#: ../gramps/gui/configure.py:86
+#: ../gramps/gui/configure.py:89
 msgid "Icelandic style"
 msgstr ""
 
-#: ../gramps/gui/configure.py:111 ../gramps/gui/configure.py:112
+#: ../gramps/gui/configure.py:114 ../gramps/gui/configure.py:115
 msgid "Display Name Editor"
 msgstr ""
 
 #. self.window.connect('response', self.close)
-#: ../gramps/gui/configure.py:113 ../gramps/gui/configure.py:187
-#: ../gramps/gui/dialog.py:215 ../gramps/gui/dialog.py:261
-#: ../gramps/gui/dialog.py:287 ../gramps/gui/glade/book.glade:466
+#: ../gramps/gui/configure.py:116 ../gramps/gui/configure.py:189
+#: ../gramps/gui/dialog.py:261 ../gramps/gui/dialog.py:307
+#: ../gramps/gui/dialog.py:333 ../gramps/gui/glade/book.glade:466
 #: ../gramps/gui/glade/book.glade:556 ../gramps/gui/glade/clipboard.glade:71
 #: ../gramps/gui/glade/dialog.glade:20 ../gramps/gui/glade/dialog.glade:141
 #: ../gramps/gui/glade/displaystate.glade:23
 #: ../gramps/gui/glade/editplaceformat.glade:23
 #: ../gramps/gui/glade/plugins.glade:22 ../gramps/gui/glade/rule.glade:24
 #: ../gramps/gui/glade/rule.glade:1024 ../gramps/gui/glade/tipofday.glade:117
-#: ../gramps/gui/glade/updateaddons.glade:25 ../gramps/gui/plug/_windows.py:105
-#: ../gramps/gui/plug/_windows.py:691 ../gramps/gui/plug/_windows.py:747
+#: ../gramps/gui/glade/updateaddons.glade:25 ../gramps/gui/grampsgui.py:56
+#: ../gramps/gui/plug/_windows.py:105 ../gramps/gui/plug/_windows.py:693
+#: ../gramps/gui/plug/_windows.py:749
 #: ../gramps/gui/plug/quick/_textbufdoc.py:60 ../gramps/gui/undohistory.py:90
-#: ../gramps/gui/viewmanager.py:542 ../gramps/gui/viewmanager.py:1873
-#: ../gramps/gui/views/bookmarks.py:295 ../gramps/gui/views/tags.py:432
-#: ../gramps/gui/widgets/grampletbar.py:635
-#: ../gramps/gui/widgets/grampletpane.py:232
-#: ../gramps/plugins/lib/maps/placeselection.py:111
+#: ../gramps/gui/viewmanager.py:1657 ../gramps/gui/views/bookmarks.py:298
+#: ../gramps/gui/views/tags.py:466 ../gramps/gui/widgets/grampletbar.py:636
+#: ../gramps/gui/widgets/grampletpane.py:239
+#: ../gramps/plugins/lib/maps/placeselection.py:120
 #: ../gramps/plugins/tool/dumpgenderstats.py:85
 msgid "_Close"
 msgstr ""
 
-#: ../gramps/gui/configure.py:116
+#: ../gramps/gui/configure.py:119
 msgid ""
 "The following keywords are replaced with the appropriate name parts:<tt>\n"
 "  <b>Given</b>   - given name (first name)     <b>Surname</b>  - surnames "
@@ -10412,34 +10487,34 @@ msgid ""
 "<i>Underhills</i>: Familynick, <i>Jose</i>: Call.\n"
 msgstr ""
 
-#: ../gramps/gui/configure.py:144
+#: ../gramps/gui/configure.py:148
 msgid " Name Editor"
 msgstr ""
 
-#: ../gramps/gui/configure.py:240 ../gramps/gui/configure.py:246
-#: ../gramps/gui/configure.py:856
+#: ../gramps/gui/configure.py:242 ../gramps/gui/configure.py:248
+#: ../gramps/gui/configure.py:1007
 msgid "Invalid or incomplete format definition."
 msgstr ""
 
 #. label for the combo
 #. translators: needed for French, ignore otherwise
-#: ../gramps/gui/configure.py:348 ../gramps/gui/configure.py:372
-#: ../gramps/gui/configure.py:393 ../gramps/gui/configure.py:409
-#: ../gramps/gui/configure.py:440 ../gramps/gui/configure.py:477
-#: ../gramps/gui/configure.py:499 ../gramps/gui/configure.py:603
-#: ../gramps/gui/configure.py:1039 ../gramps/gui/configure.py:1067
-#: ../gramps/gui/configure.py:1081 ../gramps/gui/configure.py:1116
-#: ../gramps/gui/configure.py:1130 ../gramps/gui/configure.py:1143
-#: ../gramps/gui/configure.py:1156 ../gramps/gui/configure.py:1180
-#: ../gramps/gui/configure.py:1433 ../gramps/gui/configure.py:1451
-#: ../gramps/gui/configure.py:1524 ../gramps/gui/configure.py:1579
-#: ../gramps/gui/views/navigationview.py:358
+#: ../gramps/gui/configure.py:386 ../gramps/gui/configure.py:413
+#: ../gramps/gui/configure.py:435 ../gramps/gui/configure.py:451
+#: ../gramps/gui/configure.py:482 ../gramps/gui/configure.py:519
+#: ../gramps/gui/configure.py:541 ../gramps/gui/configure.py:689
+#: ../gramps/gui/configure.py:1194 ../gramps/gui/configure.py:1222
+#: ../gramps/gui/configure.py:1240 ../gramps/gui/configure.py:1267
+#: ../gramps/gui/configure.py:1281 ../gramps/gui/configure.py:1294
+#: ../gramps/gui/configure.py:1307 ../gramps/gui/configure.py:1332
+#: ../gramps/gui/configure.py:1642 ../gramps/gui/configure.py:1660
+#: ../gramps/gui/configure.py:1743 ../gramps/gui/configure.py:1794
+#: ../gramps/gui/views/navigationview.py:343
 #: ../gramps/plugins/gramplet/sessionloggramplet.py:90
 #, python-format
 msgid "%s: "
 msgstr ""
 
-#: ../gramps/gui/configure.py:532 ../gramps/gui/editors/edittaglist.py:118
+#: ../gramps/gui/configure.py:575 ../gramps/gui/editors/edittaglist.py:118
 #: ../gramps/gui/glade/addmedia.glade:55
 #: ../gramps/gui/glade/baseselector.glade:56 ../gramps/gui/glade/book.glade:498
 #: ../gramps/gui/glade/clipboard.glade:21 ../gramps/gui/glade/dbman.glade:150
@@ -10479,236 +10554,266 @@ msgstr ""
 #: ../gramps/gui/glade/mergesource.glade:53
 #: ../gramps/gui/glade/reorder.glade:54 ../gramps/gui/glade/rule.glade:41
 #: ../gramps/gui/glade/rule.glade:351 ../gramps/gui/glade/rule.glade:781
-#: ../gramps/gui/logger/_errorview.py:175
+#: ../gramps/gui/grampsgui.py:56 ../gramps/gui/logger/_errorview.py:175
 #: ../gramps/gui/plug/report/_reportdialog.py:159
-#: ../gramps/gui/undohistory.py:82 ../gramps/gui/viewmanager.py:520
-#: ../gramps/gui/views/bookmarks.py:296 ../gramps/gui/views/tags.py:433
-#: ../gramps/gui/views/tags.py:647 ../gramps/gui/widgets/grampletbar.py:641
-#: ../gramps/gui/widgets/grampletpane.py:237
+#: ../gramps/gui/undohistory.py:82 ../gramps/gui/views/bookmarks.py:299
+#: ../gramps/gui/views/tags.py:467 ../gramps/gui/views/tags.py:681
+#: ../gramps/gui/widgets/grampletbar.py:642
+#: ../gramps/gui/widgets/grampletpane.py:244
+#: ../gramps/plugins/importer/importprogen.glade:1749
 #: ../gramps/plugins/tool/testcasegenerator.py:329
 msgid "_Help"
 msgstr ""
 
-#: ../gramps/gui/configure.py:542
-msgid ""
-"Enter your information so people can contact you when you distribute your "
-"Family Tree"
+#: ../gramps/gui/configure.py:597
+msgid "Researcher information"
 msgstr ""
 
-#: ../gramps/gui/configure.py:549
+#: ../gramps/gui/configure.py:602
+msgid ""
+"Enter information about yourself so people can contact you when you "
+"distribute your Family Tree"
+msgstr ""
+
+#: ../gramps/gui/configure.py:617
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:75
 #: ../gramps/plugins/view/repoview.py:92
 msgid "State/County"
 msgstr ""
 
-#: ../gramps/gui/configure.py:551 ../gramps/plugins/view/repoview.py:94
+#: ../gramps/gui/configure.py:623 ../gramps/plugins/view/repoview.py:94
 msgid "ZIP/Postal Code"
 msgstr ""
 
-#: ../gramps/gui/configure.py:553 ../gramps/gui/plug/_windows.py:623
+#: ../gramps/gui/configure.py:628 ../gramps/gui/plug/_windows.py:625
 #: ../gramps/plugins/view/repoview.py:95
 msgid "Email"
 msgstr ""
 
-#: ../gramps/gui/configure.py:554
+#: ../gramps/gui/configure.py:629
 msgid "Researcher"
 msgstr ""
 
-#: ../gramps/gui/configure.py:574 ../gramps/gui/editors/editperson.py:647
-#: ../gramps/gui/widgets/photo.py:86
+#: ../gramps/gui/configure.py:638
+msgid "Gramps ID format settings"
+msgstr ""
+
+#: ../gramps/gui/configure.py:658 ../gramps/gui/editors/editperson.py:641
+#: ../gramps/gui/widgets/photo.py:87
 msgid "Media Object"
 msgstr ""
 
-#: ../gramps/gui/configure.py:582
+#: ../gramps/gui/configure.py:669
 msgid "ID Formats"
 msgstr ""
 
-#: ../gramps/gui/configure.py:592
-msgid "Set the colors used for boxes in the graphical views"
+#: ../gramps/gui/configure.py:677
+msgid "Colors used for boxes in the graphical views"
 msgstr ""
 
-#: ../gramps/gui/configure.py:597
+#: ../gramps/gui/configure.py:683
 msgid "Light colors"
 msgstr ""
 
-#: ../gramps/gui/configure.py:598
+#: ../gramps/gui/configure.py:684
 msgid "Dark colors"
 msgstr ""
 
-#: ../gramps/gui/configure.py:603
+#: ../gramps/gui/configure.py:689
 msgid "Color scheme"
 msgstr ""
 
-#: ../gramps/gui/configure.py:607
+#: ../gramps/gui/configure.py:693
 msgid "Restore to defaults"
 msgstr ""
 
-#: ../gramps/gui/configure.py:613
-msgid "Male Alive"
+#: ../gramps/gui/configure.py:695
+msgid "Restore colors for current theme to default."
 msgstr ""
 
-#: ../gramps/gui/configure.py:614
-msgid "Male Dead"
+#: ../gramps/gui/configure.py:701
+msgid "Colors for Male persons"
 msgstr ""
 
-#: ../gramps/gui/configure.py:615
-msgid "Female Alive"
+#: ../gramps/gui/configure.py:702
+msgid "Colors for Female persons"
 msgstr ""
 
-#: ../gramps/gui/configure.py:616
-msgid "Female Dead"
+#: ../gramps/gui/configure.py:703
+msgid "Colors for Unknown persons"
 msgstr ""
 
-#: ../gramps/gui/configure.py:617
-msgid "Unknown Alive"
+#: ../gramps/gui/configure.py:704
+msgid "Colors for Family nodes"
 msgstr ""
 
-#: ../gramps/gui/configure.py:618
-msgid "Unknown Dead"
+#: ../gramps/gui/configure.py:705
+msgid "Other colors"
 msgstr ""
 
-#: ../gramps/gui/configure.py:619
-msgid "Family Node"
+#: ../gramps/gui/configure.py:707
+msgid "Background for Alive"
 msgstr ""
 
-#: ../gramps/gui/configure.py:620
-msgid "Family Divorced"
+#: ../gramps/gui/configure.py:708
+msgid "Background for Dead"
 msgstr ""
 
-#: ../gramps/gui/configure.py:621
-msgid "Home Person"
-msgstr ""
-
-#: ../gramps/gui/configure.py:622
-msgid "Border Male Alive"
-msgstr ""
-
-#: ../gramps/gui/configure.py:623
-msgid "Border Male Dead"
-msgstr ""
-
-#: ../gramps/gui/configure.py:624
-msgid "Border Female Alive"
-msgstr ""
-
-#: ../gramps/gui/configure.py:625
-msgid "Border Female Dead"
-msgstr ""
-
-#: ../gramps/gui/configure.py:626
-msgid "Border Unknown Alive"
-msgstr ""
-
-#: ../gramps/gui/configure.py:627
-msgid "Border Unknown Dead"
-msgstr ""
-
-#: ../gramps/gui/configure.py:628
-msgid "Border Family"
-msgstr ""
-
-#: ../gramps/gui/configure.py:629
-msgid "Border Family Divorced"
-msgstr ""
-
-#: ../gramps/gui/configure.py:637
-msgid "Colors"
-msgstr ""
-
-#: ../gramps/gui/configure.py:656
-msgid "Suppress warning when adding parents to a child."
-msgstr ""
-
-#: ../gramps/gui/configure.py:660
-msgid "Suppress warning when canceling with changed data."
-msgstr ""
-
-#: ../gramps/gui/configure.py:664
-msgid "Suppress warning about missing researcher when exporting to GEDCOM."
-msgstr ""
-
-#: ../gramps/gui/configure.py:669
-msgid "Show plugin status dialog on plugin load error."
-msgstr ""
-
-#: ../gramps/gui/configure.py:672
-msgid "Warnings"
-msgstr ""
-
-#: ../gramps/gui/configure.py:698 ../gramps/gui/configure.py:712
-msgid "Common"
-msgstr ""
-
-#: ../gramps/gui/configure.py:705 ../gramps/plugins/export/exportcsv.py:355
-#: ../gramps/plugins/importer/importcsv.py:164
-msgid "Call"
+#: ../gramps/gui/configure.py:709
+msgid "Border for Alive"
 msgstr ""
 
 #: ../gramps/gui/configure.py:710
+msgid "Border for Dead"
+msgstr ""
+
+#. for family
+#: ../gramps/gui/configure.py:730
+msgid "Default background"
+msgstr ""
+
+#: ../gramps/gui/configure.py:731
+msgid "Background for Married"
+msgstr ""
+
+#: ../gramps/gui/configure.py:732
+msgid "Background for Unmarried"
+msgstr ""
+
+#: ../gramps/gui/configure.py:734
+msgid "Background for Civil union"
+msgstr ""
+
+#: ../gramps/gui/configure.py:736
+msgid "Background for Unknown"
+msgstr ""
+
+#: ../gramps/gui/configure.py:737
+msgid "Background for Divorced"
+msgstr ""
+
+#: ../gramps/gui/configure.py:738
+msgid "Default border"
+msgstr ""
+
+#: ../gramps/gui/configure.py:739
+msgid "Border for Divorced"
+msgstr ""
+
+#. for other
+#: ../gramps/gui/configure.py:742
+msgid "Background for Home Person"
+msgstr ""
+
+#: ../gramps/gui/configure.py:761
+#, python-format
+msgid "<b>%s</b>"
+msgstr ""
+
+#: ../gramps/gui/configure.py:774
+msgid "Colors"
+msgstr ""
+
+#: ../gramps/gui/configure.py:794
+msgid "Warnings and Error dialogs"
+msgstr ""
+
+#: ../gramps/gui/configure.py:800
+msgid "Suppress warning when adding parents to a child"
+msgstr ""
+
+#: ../gramps/gui/configure.py:804
+msgid "Suppress warning when canceling with changed data"
+msgstr ""
+
+#: ../gramps/gui/configure.py:808
+msgid "Suppress warning about missing researcher when exporting to GEDCOM"
+msgstr ""
+
+#: ../gramps/gui/configure.py:813
+msgid "Show plugin status dialog on plugin load error"
+msgstr ""
+
+#: ../gramps/gui/configure.py:816
+msgid "Warnings"
+msgstr ""
+
+#: ../gramps/gui/configure.py:845 ../gramps/gui/configure.py:859
+msgid "Common"
+msgstr ""
+
+#: ../gramps/gui/configure.py:852 ../gramps/plugins/export/exportcsv.py:355
+#: ../gramps/plugins/importer/importcsv.py:165
+msgid "Call"
+msgstr ""
+
+#: ../gramps/gui/configure.py:857
 msgid "NotPatronymic"
 msgstr ""
 
-#: ../gramps/gui/configure.py:787
+#: ../gramps/gui/configure.py:935
 msgid "Enter to save, Esc to cancel editing"
 msgstr ""
 
-#: ../gramps/gui/configure.py:834
+#: ../gramps/gui/configure.py:984
 msgid "This format exists already."
 msgstr ""
 
-#: ../gramps/gui/configure.py:883
+#: ../gramps/gui/configure.py:1033
 msgid "Example"
 msgstr ""
 
 #. show an add button
 #. we now construct an add menu
-#: ../gramps/gui/configure.py:903
+#: ../gramps/gui/configure.py:1054
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:147
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:154
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:314
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:127
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:129
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:122
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:129
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:115
-#: ../gramps/gui/editors/editfamily.py:148
-#: ../gramps/gui/plug/report/_bookdialog.py:662
-#: ../gramps/gui/viewmanager.py:604 ../gramps/gui/views/tags.py:424
-#: ../gramps/gui/widgets/fanchart.py:1759
-#: ../gramps/gui/widgets/fanchart.py:1801
-#: ../gramps/plugins/view/pedigreeview.py:1630
+#: ../gramps/gui/editors/editfamily.py:195 ../gramps/gui/grampsgui.py:56
+#: ../gramps/gui/plug/report/_bookdialog.py:665 ../gramps/gui/views/tags.py:458
+#: ../gramps/gui/widgets/fanchart.py:2028
+#: ../gramps/gui/widgets/fanchart.py:2070
+#: ../gramps/plugins/view/pedigreeview.py:1703
 msgid "_Add"
 msgstr ""
 
-#: ../gramps/gui/configure.py:906
+#: ../gramps/gui/configure.py:1057
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:149
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:155
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:315
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:129
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:131
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:123
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:130
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:116
-#: ../gramps/gui/glade/editlink.glade:222
-#: ../gramps/gui/plug/report/_bookdialog.py:636
-#: ../gramps/gui/viewmanager.py:517 ../gramps/gui/views/tags.py:425
-#: ../gramps/gui/widgets/fanchart.py:1556
-#: ../gramps/plugins/view/pedigreeview.py:1665
-#: ../gramps/plugins/view/pedigreeview.py:1893
+#: ../gramps/gui/glade/editlink.glade:222 ../gramps/gui/grampsgui.py:56
+#: ../gramps/gui/plug/report/_bookdialog.py:639 ../gramps/gui/views/tags.py:459
+#: ../gramps/gui/widgets/fanchart.py:1817
+#: ../gramps/plugins/view/pedigreeview.py:1738
+#: ../gramps/plugins/view/pedigreeview.py:1966
 msgid "_Edit"
 msgstr ""
 
-#: ../gramps/gui/configure.py:910
+#: ../gramps/gui/configure.py:1061
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:150
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:156
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:130
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:132
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:124
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:117
-#: ../gramps/gui/editors/editfamily.py:151
-#: ../gramps/gui/plug/report/_bookdialog.py:631
-#: ../gramps/gui/views/bookmarks.py:291 ../gramps/gui/views/tags.py:426
+#: ../gramps/gui/editors/editfamily.py:198
+#: ../gramps/gui/plug/report/_bookdialog.py:634
+#: ../gramps/gui/views/bookmarks.py:294 ../gramps/gui/views/tags.py:460
 msgid "_Remove"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1043 ../gramps/gui/configure.py:1085
+#: ../gramps/gui/configure.py:1153
+msgid "Appearance and format settings"
+msgstr ""
+
+#: ../gramps/gui/configure.py:1198 ../gramps/gui/configure.py:1237
 #: ../gramps/gui/editors/displaytabs/buttontab.py:71
 #: ../gramps/gui/glade/editfamily.glade:286
 #: ../gramps/gui/glade/editfamily.glade:594
@@ -10721,134 +10826,156 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1053
+#: ../gramps/gui/configure.py:1208
 msgid "Consider single pa/matronymic as surname"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1094
-msgid "Enable automatic place title generation"
+#: ../gramps/gui/configure.py:1240
+msgid "Place format (auto place title)"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1103
+#: ../gramps/gui/configure.py:1243
+msgid "Enables automatic place title generation using specifed format."
+msgstr ""
+
+#: ../gramps/gui/configure.py:1254
 msgid "Years"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1104
+#: ../gramps/gui/configure.py:1255
 msgid "Years, Months"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1105
+#: ../gramps/gui/configure.py:1256
 msgid "Years, Months, Days"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1117
+#: ../gramps/gui/configure.py:1268
 msgid "Age display precision (requires restart)"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1130
+#: ../gramps/gui/configure.py:1281
 msgid "Calendar on reports"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1143
+#: ../gramps/gui/configure.py:1294
 msgid "Surname guessing"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1156
+#: ../gramps/gui/configure.py:1307
 msgid "Default family relationship"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1163
+#: ../gramps/gui/configure.py:1314
 msgid "Height multiple surname box (pixels)"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1170
+#: ../gramps/gui/configure.py:1321
 msgid "Active person's name and ID"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1171
+#: ../gramps/gui/configure.py:1322
 #: ../gramps/plugins/textreport/indivcomplete.py:370
 msgid "Relationship to home person"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1180
+#: ../gramps/gui/configure.py:1332
 msgid "Status bar"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1187
+#: ../gramps/gui/configure.py:1339
 msgid "Show text label beside Navigator buttons (requires restart)"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1193
+#: ../gramps/gui/configure.py:1342
+msgid ""
+"Show or hide text beside Navigator buttons (People, Families, Events...).\n"
+"Requires Gramps restart to apply."
+msgstr ""
+
+#: ../gramps/gui/configure.py:1348
 msgid "Show close button in gramplet bar tabs"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1213
+#: ../gramps/gui/configure.py:1351
+msgid "Show close button to simplify removing gramplets from bars."
+msgstr ""
+
+#: ../gramps/gui/configure.py:1370
+msgid "Default text used for conditions"
+msgstr ""
+
+#: ../gramps/gui/configure.py:1375
 msgid "Missing surname"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1216
+#: ../gramps/gui/configure.py:1378
 msgid "Missing given name"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1219
+#: ../gramps/gui/configure.py:1381
 msgid "Missing record"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1222
+#: ../gramps/gui/configure.py:1384
 msgid "Private surname"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1226
+#: ../gramps/gui/configure.py:1388
 msgid "Private given name"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1230
+#: ../gramps/gui/configure.py:1392
 msgid "Private record"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1295
+#: ../gramps/gui/configure.py:1461
 msgid "Change is not immediate"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1296
+#: ../gramps/gui/configure.py:1462
 msgid ""
 "Changing the date format will not take effect until the next time Gramps is "
 "started."
 msgstr ""
 
-#: ../gramps/gui/configure.py:1315
+#: ../gramps/gui/configure.py:1487
+msgid "Dates settings used for calculation operations"
+msgstr ""
+
+#: ../gramps/gui/configure.py:1493
 msgid "Date about range"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1318
+#: ../gramps/gui/configure.py:1497
 msgid "Date after range"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1321
+#: ../gramps/gui/configure.py:1501
 msgid "Date before range"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1324
+#: ../gramps/gui/configure.py:1505
 msgid "Maximum age probably alive"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1327
+#: ../gramps/gui/configure.py:1509
 msgid "Maximum sibling age difference"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1330
+#: ../gramps/gui/configure.py:1513
 msgid "Minimum years between generations"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1333
+#: ../gramps/gui/configure.py:1517
 msgid "Average years between generations"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1336
+#: ../gramps/gui/configure.py:1521
 msgid "Markup for invalid date format"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1339
+#: ../gramps/gui/configure.py:1525
 #, python-format
 msgid ""
 "Convenience markups are:\n"
@@ -10866,183 +10993,223 @@ msgid ""
 "will display <u><b>Underlined bold date</b></u>.\n"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1353
+#: ../gramps/gui/configure.py:1540
 msgid "Dates"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1364
+#: ../gramps/gui/configure.py:1548
+msgid "General Gramps settings"
+msgstr ""
+
+#: ../gramps/gui/configure.py:1555
 msgid "Use alternate Font handler for GUI and Reports (requires restart)"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1370
+#: ../gramps/gui/configure.py:1558
+msgid "Can help to fix problems with fonts."
+msgstr ""
+
+#: ../gramps/gui/configure.py:1561
 msgid "Add default source on GEDCOM import"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1374
+#: ../gramps/gui/configure.py:1580
 msgid "Add tag on import"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1385
+#: ../gramps/gui/configure.py:1583
+msgid ""
+"Specifed tag will be added on import.\n"
+"Clear to set default value."
+msgstr ""
+
+#: ../gramps/gui/configure.py:1588
 msgid "Enable spelling checker"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1394
+#: ../gramps/gui/configure.py:1597
 #, python-format
 msgid ""
 "GtkSpell not loaded. Spell checking will not be available.\n"
 "To build it for Gramps see %(gramps_wiki_build_spell_url)s"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1401
+#: ../gramps/gui/configure.py:1603
 msgid "Display Tip of the Day"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1406
+#: ../gramps/gui/configure.py:1605
+msgid "Show useful information about using Gramps on startup."
+msgstr ""
+
+#: ../gramps/gui/configure.py:1608
 msgid "Remember last view displayed"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1411
+#: ../gramps/gui/configure.py:1610
+msgid "Remember last view displayed and open it next time."
+msgstr ""
+
+#: ../gramps/gui/configure.py:1613
 msgid "Max generations for relationships"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1417
+#: ../gramps/gui/configure.py:1619
 msgid "Base path for relative media paths"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1425
+#: ../gramps/gui/configure.py:1625
+msgid "Third party addons management"
+msgstr ""
+
+#: ../gramps/gui/configure.py:1634
 msgid "Once a month"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1426
+#: ../gramps/gui/configure.py:1635
 msgid "Once a week"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1427
+#: ../gramps/gui/configure.py:1636
 msgid "Once a day"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1428
+#: ../gramps/gui/configure.py:1637
 msgid "Always"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1433
+#: ../gramps/gui/configure.py:1642
 msgid "Check for addon updates"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1439
+#: ../gramps/gui/configure.py:1648
 msgid "Updated addons only"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1440
+#: ../gramps/gui/configure.py:1649
 msgid "New addons only"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1441
+#: ../gramps/gui/configure.py:1650
 msgid "New and updated addons"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1451
+#: ../gramps/gui/configure.py:1660
 msgid "What to check"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1456
+#: ../gramps/gui/configure.py:1665
 msgid "Where to check"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1460
+#: ../gramps/gui/configure.py:1670
 msgid "Do not ask about previously notified addons"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1465
+#: ../gramps/gui/configure.py:1675
 msgid "Check for updated addons now"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1475
+#: ../gramps/gui/configure.py:1687
 msgid "Checking Addons Failed"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1476
+#: ../gramps/gui/configure.py:1688
 msgid "The addon repository appears to be unavailable. Please try again later."
 msgstr ""
 
-#: ../gramps/gui/configure.py:1489
+#: ../gramps/gui/configure.py:1701
 msgid "There are no available addons of this type"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1490
+#: ../gramps/gui/configure.py:1702
 #, python-format
 msgid "Checked for '%s'"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1491
+#: ../gramps/gui/configure.py:1703
 msgid "' and '"
 msgstr ""
 
 #. List of translated strings used here
 #. Dead code for l10n
-#: ../gramps/gui/configure.py:1496
+#: ../gramps/gui/configure.py:1708
 msgid "new"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1496
+#: ../gramps/gui/configure.py:1708
 msgid "update"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1524
+#: ../gramps/gui/configure.py:1737
+msgid "Family tree database settings and Backup management"
+msgstr ""
+
+#: ../gramps/gui/configure.py:1743
 msgid "Database backend"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1531
+#: ../gramps/gui/configure.py:1750
 msgid "Host"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1535
+#: ../gramps/gui/configure.py:1755
 msgid "Port"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1543
+#: ../gramps/gui/configure.py:1763
 msgid "Family Tree Database path"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1552
+#: ../gramps/gui/configure.py:1767
 msgid "Automatically load last Family Tree"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1558
+#: ../gramps/gui/configure.py:1769
+msgid ""
+"Don't open dialog to choose family tree to load on startup, just load last "
+"used."
+msgstr ""
+
+#: ../gramps/gui/configure.py:1774
 msgid "Backup path"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1565
+#: ../gramps/gui/configure.py:1779
 msgid "Backup on exit"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1572
+#: ../gramps/gui/configure.py:1781
+msgid "Backup Your family tree on exit to Backup path specified above."
+msgstr ""
+
+#: ../gramps/gui/configure.py:1787
 msgid "Every 15 minutes"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1573
+#: ../gramps/gui/configure.py:1788
 msgid "Every 30 minutes"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1574
+#: ../gramps/gui/configure.py:1789
 msgid "Every hour"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1579
+#: ../gramps/gui/configure.py:1794
 msgid "Autobackup"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1619
+#: ../gramps/gui/configure.py:1837
 msgid "Select media directory"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1622 ../gramps/gui/configure.py:1645
-#: ../gramps/gui/configure.py:1667 ../gramps/gui/dbloader.py:401
+#: ../gramps/gui/configure.py:1840 ../gramps/gui/configure.py:1865
+#: ../gramps/gui/configure.py:1890 ../gramps/gui/dbloader.py:401
 #: ../gramps/gui/dbloader.py:435 ../gramps/gui/editors/edittaglist.py:119
 #: ../gramps/gui/glade/addmedia.glade:22
 #: ../gramps/gui/glade/baseselector.glade:24
 #: ../gramps/gui/glade/configure.glade:23 ../gramps/gui/glade/dialog.glade:417
-#: ../gramps/gui/glade/dialog.glade:701 ../gramps/gui/glade/dialog.glade:842
+#: ../gramps/gui/glade/dialog.glade:714 ../gramps/gui/glade/dialog.glade:856
 #: ../gramps/gui/glade/editaddress.glade:21
 #: ../gramps/gui/glade/editattribute.glade:21
 #: ../gramps/gui/glade/editchildref.glade:22
@@ -11084,23 +11251,100 @@ msgstr ""
 #: ../gramps/gui/plug/_guioptions.py:1744 ../gramps/gui/plug/_windows.py:440
 #: ../gramps/gui/plug/report/_fileentry.py:64
 #: ../gramps/gui/plug/report/_reportdialog.py:162 ../gramps/gui/utils.py:180
-#: ../gramps/gui/viewmanager.py:2008 ../gramps/gui/views/listview.py:1060
-#: ../gramps/gui/views/navigationview.py:363 ../gramps/gui/views/tags.py:648
+#: ../gramps/gui/viewmanager.py:1792 ../gramps/gui/views/listview.py:1054
+#: ../gramps/gui/views/navigationview.py:348 ../gramps/gui/views/tags.py:682
 #: ../gramps/gui/widgets/progressdialog.py:437
-#: ../gramps/plugins/lib/maps/geography.py:1010
-#: ../gramps/plugins/lib/maps/geography.py:1264
+#: ../gramps/plugins/importer/importprogen.glade:1714
+#: ../gramps/plugins/lib/maps/geography.py:996
+#: ../gramps/plugins/lib/maps/geography.py:1292
 #: ../gramps/plugins/tool/check.py:780 ../gramps/plugins/tool/eventcmp.py:398
 #: ../gramps/plugins/tool/populatesources.py:90
 #: ../gramps/plugins/tool/testcasegenerator.py:327
 msgid "_Cancel"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1642
+#: ../gramps/gui/configure.py:1862
 msgid "Select database directory"
 msgstr ""
 
-#: ../gramps/gui/configure.py:1664 ../gramps/gui/viewmanager.py:2005
+#: ../gramps/gui/configure.py:1887 ../gramps/gui/viewmanager.py:1789
 msgid "Select backup directory"
+msgstr ""
+
+#: ../gramps/gui/configure.py:1954
+msgid ""
+"This tab gives you the possibility to use one font which is able to show all "
+"genealogical symbols\n"
+"\n"
+"If you select the \"use symbols\" checkbox, Gramps will use the selected "
+"font if it exists."
+msgstr ""
+
+#: ../gramps/gui/configure.py:1960
+msgid ""
+"This can be useful if you want to add phonetic in a note to show how to "
+"pronounce a name or if you mix multiple languages like greek and russian."
+msgstr ""
+
+#: ../gramps/gui/configure.py:1967
+msgid "Use symbols"
+msgstr ""
+
+#: ../gramps/gui/configure.py:1972
+msgid ""
+"Be careful, if you click on the \"Try to find\" button, it can take a while "
+"before you can continue (10 minutes or more). \n"
+"If you cancel the process, nothing will be changed."
+msgstr ""
+
+#: ../gramps/gui/configure.py:1982
+msgid ""
+"You have already run the tool to search for genealogy fonts.\n"
+"Run it again only if you added fonts on your system."
+msgstr ""
+
+#: ../gramps/gui/configure.py:1987
+msgid "Try to find"
+msgstr ""
+
+#: ../gramps/gui/configure.py:1998 ../gramps/gui/configure.py:2099
+msgid "Choose font"
+msgstr ""
+
+#: ../gramps/gui/configure.py:2011 ../gramps/gui/configure.py:2116
+msgid "Select default death symbol"
+msgstr ""
+
+#: ../gramps/gui/configure.py:2020
+msgid "Genealogical Symbols"
+msgstr ""
+
+#: ../gramps/gui/configure.py:2029
+msgid "Cannot look for genealogical fonts"
+msgstr ""
+
+#: ../gramps/gui/configure.py:2030
+msgid ""
+"I am not able to select genealogical fonts. Please, install the module "
+"fontconfig for python 3."
+msgstr ""
+
+#: ../gramps/gui/configure.py:2047
+msgid "Checking available genealogical fonts"
+msgstr ""
+
+#: ../gramps/gui/configure.py:2051
+msgid "Looking for all fonts with genealogical symbols."
+msgstr ""
+
+#: ../gramps/gui/configure.py:2124
+msgid ""
+"You have no font with genealogical symbols on your system. Gramps will not "
+"be able to use symbols."
+msgstr ""
+
+#: ../gramps/gui/configure.py:2162
+msgid "What you will see"
 msgstr ""
 
 #: ../gramps/gui/dbloader.py:120 ../gramps/gui/plug/tool.py:109
@@ -11139,9 +11383,10 @@ msgstr ""
 
 #: ../gramps/gui/dbloader.py:220 ../gramps/gui/dbloader.py:235
 #: ../gramps/gui/dbloader.py:250 ../gramps/gui/dbloader.py:265
+#: ../gramps/gui/glade/dialog.glade:701
 #: ../gramps/gui/plug/report/_bookdialog.py:250
-#: ../gramps/gui/plug/report/_bookdialog.py:748
-#: ../gramps/gui/viewmanager.py:854
+#: ../gramps/gui/plug/report/_bookdialog.py:751
+#: ../gramps/gui/viewmanager.py:624
 msgid "Cancel"
 msgstr ""
 
@@ -11286,7 +11531,7 @@ msgstr ""
 #: ../gramps/gui/glade/styleeditor.glade:1754
 #: ../gramps/gui/plug/_guioptions.py:80
 #: ../gramps/gui/plug/report/_reportdialog.py:166 ../gramps/gui/utils.py:194
-#: ../gramps/gui/viewmanager.py:1875 ../gramps/gui/views/tags.py:649
+#: ../gramps/gui/viewmanager.py:1659 ../gramps/gui/views/tags.py:683
 #: ../gramps/plugins/tool/check.py:781 ../gramps/plugins/tool/patchnames.py:118
 #: ../gramps/plugins/tool/populatesources.py:91
 #: ../gramps/plugins/tool/testcasegenerator.py:328
@@ -11301,20 +11546,20 @@ msgstr ""
 msgid "Family Trees"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:382
+#: ../gramps/gui/dbman.py:381
 msgid "Family Tree name"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:402
+#: ../gramps/gui/dbman.py:401
 msgid "Database Type"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:509
+#: ../gramps/gui/dbman.py:508
 #, python-format
 msgid "Break the lock on the '%s' database?"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:510
+#: ../gramps/gui/dbman.py:509
 msgid ""
 "Gramps believes that someone else is actively editing this database. You "
 "cannot edit this database while it is locked. If no one is editing the "
@@ -11322,15 +11567,15 @@ msgid ""
 "the database and you break the lock, you may corrupt the database."
 msgstr ""
 
-#: ../gramps/gui/dbman.py:516
+#: ../gramps/gui/dbman.py:515
 msgid "Break lock"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:608
+#: ../gramps/gui/dbman.py:607
 msgid "Rename failed"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:609
+#: ../gramps/gui/dbman.py:608
 #, python-format
 msgid ""
 "An attempt to rename a version failed with the following message:\n"
@@ -11338,54 +11583,54 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:627
+#: ../gramps/gui/dbman.py:626
 msgid "Could not rename the Family Tree."
 msgstr ""
 
-#: ../gramps/gui/dbman.py:628
+#: ../gramps/gui/dbman.py:627
 msgid "Family Tree already exists, choose a unique name."
 msgstr ""
 
-#: ../gramps/gui/dbman.py:675
+#: ../gramps/gui/dbman.py:674
 msgid "Extracting archive..."
 msgstr ""
 
-#: ../gramps/gui/dbman.py:680
+#: ../gramps/gui/dbman.py:679
 msgid "Importing archive..."
 msgstr ""
 
-#: ../gramps/gui/dbman.py:696
+#: ../gramps/gui/dbman.py:695
 #, python-format
 msgid "Remove the '%s' Family Tree?"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:697
+#: ../gramps/gui/dbman.py:696
 msgid "Removing this Family Tree will permanently destroy the data."
 msgstr ""
 
-#: ../gramps/gui/dbman.py:699
+#: ../gramps/gui/dbman.py:698
 msgid "Remove Family Tree"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:704
+#: ../gramps/gui/dbman.py:703
 #, python-format
 msgid "Remove the '%(revision)s' version of '%(database)s'"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:708
+#: ../gramps/gui/dbman.py:707
 msgid ""
 "Removing this version will prevent you from extracting it in the future."
 msgstr ""
 
-#: ../gramps/gui/dbman.py:710
+#: ../gramps/gui/dbman.py:709
 msgid "Remove version"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:765
+#: ../gramps/gui/dbman.py:764
 msgid "Deletion failed"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:766
+#: ../gramps/gui/dbman.py:765
 #, python-format
 msgid ""
 "An attempt to delete a version failed with the following message:\n"
@@ -11393,57 +11638,57 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:784
+#: ../gramps/gui/dbman.py:783
 #, python-format
 msgid "Convert the '%s' database?"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:785
+#: ../gramps/gui/dbman.py:784
 #, python-format
 msgid ""
 "Do you wish to convert this family tree into a %(database_type)s database?"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:787
+#: ../gramps/gui/dbman.py:786
 msgid "Convert"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:797
+#: ../gramps/gui/dbman.py:796
 #, python-format
 msgid "Opening the '%s' database"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:798
+#: ../gramps/gui/dbman.py:797
 msgid "An attempt to convert the database failed. Perhaps it needs updating."
 msgstr ""
 
-#: ../gramps/gui/dbman.py:809 ../gramps/gui/dbman.py:835
+#: ../gramps/gui/dbman.py:808 ../gramps/gui/dbman.py:834
 #, python-format
 msgid "Converting the '%s' database"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:810
+#: ../gramps/gui/dbman.py:809
 msgid "An attempt to export the database failed."
 msgstr ""
 
-#: ../gramps/gui/dbman.py:814
+#: ../gramps/gui/dbman.py:813
 msgid "Converting data..."
 msgstr ""
 
-#: ../gramps/gui/dbman.py:819 ../gramps/gui/dbman.py:822
+#: ../gramps/gui/dbman.py:818 ../gramps/gui/dbman.py:821
 #, python-format
 msgid "(Converted #%d)"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:836
+#: ../gramps/gui/dbman.py:835
 msgid "An attempt to import into the database failed."
 msgstr ""
 
-#: ../gramps/gui/dbman.py:893
+#: ../gramps/gui/dbman.py:892
 msgid "Repair Family Tree?"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:894
+#: ../gramps/gui/dbman.py:893
 #, python-format
 msgid ""
 "If you click %(bold_start)sProceed%(bold_end)s, Gramps will attempt to "
@@ -11470,31 +11715,31 @@ msgid ""
 "%(recover_file)s in the Family Tree directory."
 msgstr ""
 
-#: ../gramps/gui/dbman.py:925
+#: ../gramps/gui/dbman.py:924
 msgid "Proceed, I have taken a backup"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:926
+#: ../gramps/gui/dbman.py:925
 msgid "Stop"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:945
+#: ../gramps/gui/dbman.py:944
 msgid "Rebuilding database from backup files"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:950
+#: ../gramps/gui/dbman.py:949
 msgid "Error restoring backup data"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:989
+#: ../gramps/gui/dbman.py:988
 msgid "Could not create Family Tree"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:1110
+#: ../gramps/gui/dbman.py:1109
 msgid "Retrieve failed"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:1111
+#: ../gramps/gui/dbman.py:1110
 #, python-format
 msgid ""
 "An attempt to retrieve the data failed with the following message:\n"
@@ -11502,11 +11747,11 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:1150 ../gramps/gui/dbman.py:1176
+#: ../gramps/gui/dbman.py:1149 ../gramps/gui/dbman.py:1175
 msgid "Archiving failed"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:1151
+#: ../gramps/gui/dbman.py:1150
 #, python-format
 msgid ""
 "An attempt to create the archive failed with the following message:\n"
@@ -11514,15 +11759,15 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../gramps/gui/dbman.py:1156
+#: ../gramps/gui/dbman.py:1155
 msgid "Creating data to be archived..."
 msgstr ""
 
-#: ../gramps/gui/dbman.py:1165
+#: ../gramps/gui/dbman.py:1164
 msgid "Saving archive..."
 msgstr ""
 
-#: ../gramps/gui/dbman.py:1177
+#: ../gramps/gui/dbman.py:1176
 #, python-format
 msgid ""
 "An attempt to archive the data failed with the following message:\n"
@@ -11530,59 +11775,59 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../gramps/gui/dialog.py:388 ../gramps/gui/dialog.py:466
+#: ../gramps/gui/dialog.py:434 ../gramps/gui/dialog.py:512
 #: ../gramps/gui/utils.py:309
 msgid "Attempt to force closing the dialog"
 msgstr ""
 
-#: ../gramps/gui/dialog.py:389 ../gramps/gui/dialog.py:467
+#: ../gramps/gui/dialog.py:435 ../gramps/gui/dialog.py:513
 msgid ""
 "Please do not force closing this important dialog.\n"
 "Instead select one of the available options"
 msgstr ""
 
-#: ../gramps/gui/displaystate.py:268
+#: ../gramps/gui/displaystate.py:290
 msgid "Cannot load database"
 msgstr ""
 
-#: ../gramps/gui/displaystate.py:388
+#: ../gramps/gui/displaystate.py:408
 #: ../gramps/plugins/gramplet/persondetails.py:173
 msgid "No active person"
 msgstr ""
 
-#: ../gramps/gui/displaystate.py:389
+#: ../gramps/gui/displaystate.py:409
 msgid "No active family"
 msgstr ""
 
-#: ../gramps/gui/displaystate.py:390
+#: ../gramps/gui/displaystate.py:410
 msgid "No active event"
 msgstr ""
 
-#: ../gramps/gui/displaystate.py:391
+#: ../gramps/gui/displaystate.py:411
 msgid "No active place"
 msgstr ""
 
-#: ../gramps/gui/displaystate.py:392
+#: ../gramps/gui/displaystate.py:412
 msgid "No active source"
 msgstr ""
 
-#: ../gramps/gui/displaystate.py:393
+#: ../gramps/gui/displaystate.py:413
 msgid "No active citation"
 msgstr ""
 
-#: ../gramps/gui/displaystate.py:394
+#: ../gramps/gui/displaystate.py:414
 msgid "No active repository"
 msgstr ""
 
-#: ../gramps/gui/displaystate.py:395
+#: ../gramps/gui/displaystate.py:415
 msgid "No active media"
 msgstr ""
 
-#: ../gramps/gui/displaystate.py:396
+#: ../gramps/gui/displaystate.py:416
 msgid "No active note"
 msgstr ""
 
-#: ../gramps/gui/displaystate.py:633 ../gramps/plugins/gramplet/todo.py:200
+#: ../gramps/gui/displaystate.py:655 ../gramps/plugins/gramplet/todo.py:200
 msgid "No active object"
 msgstr ""
 
@@ -11687,11 +11932,11 @@ msgstr ""
 #: ../gramps/gui/editors/displaytabs/backreflist.py:60
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:83
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:79
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:65
-#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:58
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:67
+#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:60
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:66
-#: ../gramps/gui/editors/editfamily.py:122
-#: ../gramps/gui/editors/filtereditor.py:978
+#: ../gramps/gui/editors/editfamily.py:124
+#: ../gramps/gui/editors/filtereditor.py:992
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:104
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:111
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:103
@@ -11714,8 +11959,8 @@ msgstr ""
 #: ../gramps/gui/selectors/selectplace.py:68
 #: ../gramps/gui/selectors/selectrepository.py:67
 #: ../gramps/gui/selectors/selectsource.py:68
-#: ../gramps/gui/views/bookmarks.py:278
-#: ../gramps/gui/views/navigationview.py:358
+#: ../gramps/gui/views/bookmarks.py:281
+#: ../gramps/gui/views/navigationview.py:343
 #: ../gramps/plugins/gramplet/locations.py:88
 #: ../gramps/plugins/lib/libpersonview.py:99
 #: ../gramps/plugins/lib/libplaceview.py:86
@@ -11723,13 +11968,13 @@ msgstr ""
 #: ../gramps/plugins/tool/notrelated.py:127
 #: ../gramps/plugins/tool/patchnames.py:404
 #: ../gramps/plugins/tool/removeunused.py:195
-#: ../gramps/plugins/tool/sortevents.py:56 ../gramps/plugins/tool/verify.py:569
+#: ../gramps/plugins/tool/sortevents.py:56 ../gramps/plugins/tool/verify.py:572
 #: ../gramps/plugins/view/citationlistview.py:99
 #: ../gramps/plugins/view/citationtreeview.py:94
-#: ../gramps/plugins/view/eventview.py:83
+#: ../gramps/plugins/view/eventview.py:79
 #: ../gramps/plugins/view/familyview.py:79
 #: ../gramps/plugins/view/mediaview.py:95 ../gramps/plugins/view/noteview.py:80
-#: ../gramps/plugins/view/relview.py:592 ../gramps/plugins/view/repoview.py:86
+#: ../gramps/plugins/view/relview.py:723 ../gramps/plugins/view/repoview.py:86
 #: ../gramps/plugins/view/sourceview.py:83
 msgid "ID"
 msgstr ""
@@ -11758,7 +12003,7 @@ msgstr ""
 #: ../gramps/gui/glade/rule.glade:422 ../gramps/gui/glade/rule.glade:429
 #: ../gramps/gui/glade/styleeditor.glade:1864
 #: ../gramps/gui/glade/styleeditor.glade:1871
-#: ../gramps/plugins/view/relview.py:410
+#: ../gramps/plugins/view/relview.py:471
 msgid "Add"
 msgstr ""
 
@@ -11778,8 +12023,8 @@ msgstr ""
 
 #: ../gramps/gui/editors/displaytabs/buttontab.py:72
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:148
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:128
-#: ../gramps/plugins/view/relview.py:414
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:130
+#: ../gramps/plugins/view/relview.py:471
 msgid "Share"
 msgstr ""
 
@@ -11793,6 +12038,14 @@ msgstr ""
 
 #: ../gramps/gui/editors/displaytabs/buttontab.py:75
 msgid "Move Down"
+msgstr ""
+
+#: ../gramps/gui/editors/displaytabs/buttontab.py:76
+msgid "Move Left"
+msgstr ""
+
+#: ../gramps/gui/editors/displaytabs/buttontab.py:77
+msgid "Move right"
 msgstr ""
 
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:69
@@ -11829,14 +12082,14 @@ msgstr ""
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:256
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:277
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:267
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:332
-#: ../gramps/plugins/view/citationtreeview.py:454
-#: ../gramps/plugins/view/citationtreeview.py:497
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:334
+#: ../gramps/plugins/view/citationtreeview.py:590
+#: ../gramps/plugins/view/citationtreeview.py:633
 msgid "Cannot share this reference"
 msgstr ""
 
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:192
-#: ../gramps/plugins/view/citationtreeview.py:505
+#: ../gramps/plugins/view/citationtreeview.py:641
 msgid ""
 "This citation cannot be created at this time. Either the associated Source "
 "object is already being edited, or another citation associated with the same "
@@ -11891,10 +12144,10 @@ msgstr ""
 
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:281
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:347
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:353
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:355
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:168
 #: ../gramps/plugins/drawreport/ancestortree.py:1095
-#: ../gramps/plugins/drawreport/descendtree.py:1811
+#: ../gramps/plugins/drawreport/descendtree.py:1810
 msgid "Cannot edit this reference"
 msgstr ""
 
@@ -11917,26 +12170,26 @@ msgid "_Gallery"
 msgstr ""
 
 #. Translators: _View means "to look at this"
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:140
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:142
 msgid "verb:look at this|_View"
 msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:145
-#: ../gramps/plugins/view/mediaview.py:215
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:147
+#: ../gramps/plugins/view/mediaview.py:395
 msgid "Open Containing _Folder"
 msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:153
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:155
 msgid "_Make Active Media"
 msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:257
-#: ../gramps/gui/editors/editperson.py:962
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:259
+#: ../gramps/gui/editors/editperson.py:960
 #: ../gramps/plugins/textreport/indivcomplete.py:602
 msgid "Non existing media found in the Gallery"
 msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:307
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:309
 msgid ""
 "This media reference cannot be edited at this time. Either the associated "
 "media object is already being edited or another media reference that is "
@@ -11945,8 +12198,8 @@ msgid ""
 "To edit this media reference, you need to close the media object."
 msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:540
-#: ../gramps/plugins/view/mediaview.py:197
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:578
+#: ../gramps/plugins/view/mediaview.py:192
 msgid "Drag Media Object"
 msgstr ""
 
@@ -12021,13 +12274,15 @@ msgstr ""
 #.
 #. -------------------------------------------------------------------------
 #: ../gramps/gui/editors/displaytabs/namemodel.py:56
-#: ../gramps/gui/plug/_guioptions.py:1258 ../gramps/gui/views/tags.py:498
+#: ../gramps/gui/plug/_guioptions.py:1258 ../gramps/gui/viewmanager.py:1025
+#: ../gramps/gui/views/tags.py:532
 #: ../gramps/plugins/quickview/all_relations.py:306
 msgid "Yes"
 msgstr ""
 
 #: ../gramps/gui/editors/displaytabs/namemodel.py:57
-#: ../gramps/gui/plug/_guioptions.py:1257 ../gramps/gui/views/tags.py:499
+#: ../gramps/gui/plug/_guioptions.py:1257 ../gramps/gui/viewmanager.py:1025
+#: ../gramps/gui/views/tags.py:533
 #: ../gramps/plugins/quickview/all_relations.py:310
 msgid "No"
 msgstr ""
@@ -12081,7 +12336,7 @@ msgstr ""
 
 #. add personal column
 #: ../gramps/gui/editors/displaytabs/personeventembedlist.py:50
-#: ../gramps/plugins/webreport/basepage.py:1655
+#: ../gramps/plugins/webreport/basepage.py:1696
 msgid "Personal"
 msgstr ""
 
@@ -12109,40 +12364,40 @@ msgstr ""
 msgid "Move the selected event downwards or change family order"
 msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/personeventembedlist.py:130
+#: ../gramps/gui/editors/displaytabs/personeventembedlist.py:134
 msgid "Cannot change Family"
 msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/personeventembedlist.py:131
+#: ../gramps/gui/editors/displaytabs/personeventembedlist.py:135
 msgid "You cannot change Family events in the Person Editor"
 msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:54
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:56
 msgid "Create and add a new association"
 msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:55
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:57
 msgid "Remove the existing association"
 msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:56
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:58
 msgid "Edit the selected association"
 msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:57
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:59
 msgid "Move the selected association upwards"
 msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:58
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:60
 msgid "Move the selected association downwards"
 msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:73
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:76
 msgid "_Associations"
 msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:90
-#: ../gramps/plugins/importer/importprogen.py:1388
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:138
+#: ../gramps/plugins/lib/libprogen.py:1467
 msgid "Godfather"
 msgstr ""
 
@@ -12171,17 +12426,19 @@ msgstr ""
 msgid "Alternative Names"
 msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:69
+#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:72
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:111
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1302
+#: ../gramps/plugins/webreport/basepage.py:2696
+#: ../gramps/plugins/webreport/basepage.py:2714
 msgid "Enclosed By"
 msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:141
+#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:189
 msgid "Place cycle detected"
 msgstr ""
 
-#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:142
+#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:190
 msgid "The place you are adding is already enclosed by this place"
 msgstr ""
 
@@ -12244,7 +12501,7 @@ msgid "Move the selected surname downwards"
 msgstr ""
 
 #: ../gramps/gui/editors/displaytabs/surnametab.py:78
-#: ../gramps/plugins/lib/libgedcom.py:720
+#: ../gramps/plugins/lib/libgedcom.py:712
 msgid "Origin"
 msgstr ""
 
@@ -12286,7 +12543,7 @@ msgstr ""
 
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:118
 #: ../gramps/gui/glade/editurl.glade:200
-#: ../gramps/gui/views/navigationview.py:364
+#: ../gramps/gui/views/navigationview.py:349
 msgid "_Jump to"
 msgstr ""
 
@@ -12326,7 +12583,7 @@ msgid "manual|Child_Reference_Editor"
 msgstr ""
 
 #: ../gramps/gui/editors/editchildref.py:99
-#: ../gramps/gui/editors/editchildref.py:195
+#: ../gramps/gui/editors/editchildref.py:190
 msgid "Child Reference Editor"
 msgstr ""
 
@@ -12339,15 +12596,15 @@ msgstr ""
 msgid "New Citation"
 msgstr ""
 
-#: ../gramps/gui/editors/editcitation.py:277
+#: ../gramps/gui/editors/editcitation.py:299
 msgid "Edit Citation"
 msgstr ""
 
-#: ../gramps/gui/editors/editcitation.py:285
+#: ../gramps/gui/editors/editcitation.py:307
 msgid "No source selected"
 msgstr ""
 
-#: ../gramps/gui/editors/editcitation.py:286
+#: ../gramps/gui/editors/editcitation.py:308
 msgid ""
 "A source is anything (personal testimony, video recording, photograph, "
 "newspaper column, gravestone...) from which information can be derived. To "
@@ -12356,14 +12613,14 @@ msgid ""
 "Page' field."
 msgstr ""
 
-#: ../gramps/gui/editors/editcitation.py:300
+#: ../gramps/gui/editors/editcitation.py:322
 msgid "Cannot save citation. ID already exists."
 msgstr ""
 
-#: ../gramps/gui/editors/editcitation.py:301
-#: ../gramps/gui/editors/editevent.py:249
-#: ../gramps/gui/editors/editmedia.py:298
-#: ../gramps/gui/editors/editperson.py:847
+#: ../gramps/gui/editors/editcitation.py:323
+#: ../gramps/gui/editors/editevent.py:251
+#: ../gramps/gui/editors/editmedia.py:300
+#: ../gramps/gui/editors/editperson.py:845
 #: ../gramps/gui/editors/editplace.py:318
 #: ../gramps/gui/editors/editreference.py:288
 #: ../gramps/gui/editors/editrepository.py:189
@@ -12375,17 +12632,17 @@ msgid ""
 "leave blank to get the next available ID value."
 msgstr ""
 
-#: ../gramps/gui/editors/editcitation.py:311
+#: ../gramps/gui/editors/editcitation.py:333
 #, python-format
 msgid "Add Citation (%s)"
 msgstr ""
 
-#: ../gramps/gui/editors/editcitation.py:316
+#: ../gramps/gui/editors/editcitation.py:338
 #, python-format
 msgid "Edit Citation (%s)"
 msgstr ""
 
-#: ../gramps/gui/editors/editcitation.py:354
+#: ../gramps/gui/editors/editcitation.py:376
 #, python-format
 msgid "Delete Citation (%s)"
 msgstr ""
@@ -12444,58 +12701,58 @@ msgid "manual|New_Event_dialog"
 msgstr ""
 
 #: ../gramps/gui/editors/editevent.py:98
-#: ../gramps/gui/editors/editeventref.py:261
+#: ../gramps/gui/editors/editeventref.py:263
 #, python-format
 msgid "Event: %s"
 msgstr ""
 
 #: ../gramps/gui/editors/editevent.py:100
-#: ../gramps/gui/editors/editeventref.py:263
+#: ../gramps/gui/editors/editeventref.py:265
 msgid "New Event"
 msgstr ""
 
-#: ../gramps/gui/editors/editevent.py:228
-#: ../gramps/plugins/view/geoclose.py:549
-#: ../gramps/plugins/view/geoevents.py:343
-#: ../gramps/plugins/view/geoevents.py:377
-#: ../gramps/plugins/view/geofamclose.py:738
-#: ../gramps/plugins/view/geofamily.py:432
-#: ../gramps/plugins/view/geomoves.py:620
-#: ../gramps/plugins/view/geoperson.py:437
-#: ../gramps/plugins/view/geoperson.py:458
-#: ../gramps/plugins/view/geoperson.py:499
+#: ../gramps/gui/editors/editevent.py:230
+#: ../gramps/plugins/view/geoclose.py:619
+#: ../gramps/plugins/view/geoevents.py:396
+#: ../gramps/plugins/view/geoevents.py:430
+#: ../gramps/plugins/view/geofamclose.py:808
+#: ../gramps/plugins/view/geofamily.py:482
+#: ../gramps/plugins/view/geomoves.py:686
+#: ../gramps/plugins/view/geoperson.py:503
+#: ../gramps/plugins/view/geoperson.py:524
+#: ../gramps/plugins/view/geoperson.py:565
 msgid "Edit Event"
 msgstr ""
 
-#: ../gramps/gui/editors/editevent.py:237
-#: ../gramps/gui/editors/editevent.py:261
+#: ../gramps/gui/editors/editevent.py:239
+#: ../gramps/gui/editors/editevent.py:263
 msgid "Cannot save event"
 msgstr ""
 
-#: ../gramps/gui/editors/editevent.py:238
+#: ../gramps/gui/editors/editevent.py:240
 msgid "No data exists for this event. Please enter data or cancel the edit."
 msgstr ""
 
-#: ../gramps/gui/editors/editevent.py:248
+#: ../gramps/gui/editors/editevent.py:250
 #: ../gramps/gui/editors/editreference.py:277
 msgid "Cannot save event. ID already exists."
 msgstr ""
 
-#: ../gramps/gui/editors/editevent.py:262
+#: ../gramps/gui/editors/editevent.py:264
 msgid "The event type cannot be empty"
 msgstr ""
 
-#: ../gramps/gui/editors/editevent.py:268
+#: ../gramps/gui/editors/editevent.py:270
 #, python-format
 msgid "Add Event (%s)"
 msgstr ""
 
-#: ../gramps/gui/editors/editevent.py:273
+#: ../gramps/gui/editors/editevent.py:275
 #, python-format
 msgid "Edit Event (%s)"
 msgstr ""
 
-#: ../gramps/gui/editors/editevent.py:318
+#: ../gramps/gui/editors/editevent.py:338
 #, python-format
 msgid "Delete Event (%s)"
 msgstr ""
@@ -12505,7 +12762,7 @@ msgid "manual|Event_Reference_Editor_dialog"
 msgstr ""
 
 #: ../gramps/gui/editors/editeventref.py:76
-#: ../gramps/gui/editors/editeventref.py:264
+#: ../gramps/gui/editors/editeventref.py:266
 msgid "Event Reference Editor"
 msgstr ""
 
@@ -12517,55 +12774,55 @@ msgstr ""
 msgid "_General"
 msgstr ""
 
-#: ../gramps/gui/editors/editeventref.py:269
+#: ../gramps/gui/editors/editeventref.py:271
 msgid "Modify Event"
 msgstr ""
 
-#: ../gramps/gui/editors/editeventref.py:274
+#: ../gramps/gui/editors/editeventref.py:276
 msgid "Add Event"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:91
+#: ../gramps/gui/editors/editfamily.py:92
 msgid "manual|Family_Editor_dialog"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:111
+#: ../gramps/gui/editors/editfamily.py:113
 msgid "Create a new person and add the child to the family"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:112
+#: ../gramps/gui/editors/editfamily.py:114
 msgid "Remove the child from the family"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:113
+#: ../gramps/gui/editors/editfamily.py:115
 msgid "Edit the child reference"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:114
+#: ../gramps/gui/editors/editfamily.py:116
 msgid "Add an existing person as a child of the family"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:115
+#: ../gramps/gui/editors/editfamily.py:117
 msgid "Move the child up in the children list"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:116
+#: ../gramps/gui/editors/editfamily.py:118
 msgid "Move the child down in the children list"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:121
+#: ../gramps/gui/editors/editfamily.py:123
 msgid "#"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:125
+#: ../gramps/gui/editors/editfamily.py:127
 msgid "Paternal"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:126
+#: ../gramps/gui/editors/editfamily.py:128
 msgid "Maternal"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:127
+#: ../gramps/gui/editors/editfamily.py:129
 #: ../gramps/gui/selectors/selectperson.py:93
 #: ../gramps/plugins/gramplet/children.py:94
 #: ../gramps/plugins/gramplet/children.py:193
@@ -12582,61 +12839,61 @@ msgstr ""
 #: ../gramps/plugins/quickview/samesurnames.py:115
 #: ../gramps/plugins/quickview/samesurnames.py:160
 #: ../gramps/plugins/quickview/siblings.py:48
-#: ../gramps/plugins/webreport/basepage.py:379
+#: ../gramps/plugins/webreport/basepage.py:398
 msgid "Birth Date"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:128
+#: ../gramps/gui/editors/editfamily.py:130
 #: ../gramps/gui/selectors/selectperson.py:95
 #: ../gramps/plugins/gramplet/children.py:96
 #: ../gramps/plugins/gramplet/children.py:195
 #: ../gramps/plugins/lib/libpersonview.py:103
 #: ../gramps/plugins/quickview/lineage.py:61
 #: ../gramps/plugins/quickview/lineage.py:93
-#: ../gramps/plugins/webreport/basepage.py:380
+#: ../gramps/plugins/webreport/basepage.py:399
 msgid "Death Date"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:129
+#: ../gramps/gui/editors/editfamily.py:131
 #: ../gramps/gui/selectors/selectperson.py:94
 #: ../gramps/plugins/lib/libpersonview.py:102
 msgid "Birth Place"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:130
+#: ../gramps/gui/editors/editfamily.py:132
 #: ../gramps/gui/selectors/selectperson.py:96
 #: ../gramps/plugins/lib/libpersonview.py:104
 msgid "Death Place"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:142
+#: ../gramps/gui/editors/editfamily.py:145
 msgid "Chil_dren"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:147
+#: ../gramps/gui/editors/editfamily.py:194
 msgid "Edit child"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:149
+#: ../gramps/gui/editors/editfamily.py:196
 msgid "Add an existing child"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:150
+#: ../gramps/gui/editors/editfamily.py:197
 msgid "Edit relationship"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:217
-#: ../gramps/gui/editors/editfamily.py:232
+#: ../gramps/gui/editors/editfamily.py:267
+#: ../gramps/gui/editors/editfamily.py:282
 #: ../gramps/gui/selectors/selectperson.py:67
-#: ../gramps/plugins/view/relview.py:1556
+#: ../gramps/plugins/view/relview.py:1727
 msgid "Select Child"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:365
+#: ../gramps/gui/editors/editfamily.py:417
 msgid "Adding parents to a person"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:366
+#: ../gramps/gui/editors/editfamily.py:418
 msgid ""
 "It is possible to accidentally create multiple families with the same "
 "parents. To help avoid this problem, only the buttons to select parents are "
@@ -12644,11 +12901,11 @@ msgid ""
 "available after you attempt to select a parent."
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:460
+#: ../gramps/gui/editors/editfamily.py:523
 msgid "Family has changed"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:461
+#: ../gramps/gui/editors/editfamily.py:524
 #, python-format
 msgid ""
 "The %(object)s you are editing has changed outside this editor. This can be "
@@ -12658,105 +12915,105 @@ msgid ""
 "updated. Some edits you have made may have been lost."
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:466
-#: ../gramps/plugins/importer/importcsv.py:211
-#: ../gramps/plugins/view/familyview.py:262
+#: ../gramps/gui/editors/editfamily.py:529
+#: ../gramps/plugins/importer/importcsv.py:227
+#: ../gramps/plugins/view/familyview.py:387
 msgid "family"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:497
-#: ../gramps/gui/editors/editfamily.py:500
+#: ../gramps/gui/editors/editfamily.py:560
+#: ../gramps/gui/editors/editfamily.py:563
 msgid "New Family"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:504
-#: ../gramps/gui/editors/editfamily.py:1135
-#: ../gramps/plugins/view/geofamily.py:424
+#: ../gramps/gui/editors/editfamily.py:567
+#: ../gramps/gui/editors/editfamily.py:1184
+#: ../gramps/plugins/view/geofamily.py:474
 msgid "Edit Family"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:535
+#: ../gramps/gui/editors/editfamily.py:598
 msgid "Select a person as the mother"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:536
+#: ../gramps/gui/editors/editfamily.py:599
 msgid "Add a new person as the mother"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:537
+#: ../gramps/gui/editors/editfamily.py:600
 msgid "Remove the person as the mother"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:550
+#: ../gramps/gui/editors/editfamily.py:613
 msgid "Select a person as the father"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:551
+#: ../gramps/gui/editors/editfamily.py:614
 msgid "Add a new person as the father"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:552
+#: ../gramps/gui/editors/editfamily.py:615
 msgid "Remove the person as the father"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:835
+#: ../gramps/gui/editors/editfamily.py:884
 #: ../gramps/gui/selectors/selectperson.py:65
 msgid "Select Mother"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:880
+#: ../gramps/gui/editors/editfamily.py:929
 #: ../gramps/gui/selectors/selectperson.py:63
 msgid "Select Father"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:904
+#: ../gramps/gui/editors/editfamily.py:953
 msgid "Duplicate Family"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:905
+#: ../gramps/gui/editors/editfamily.py:954
 msgid ""
 "A family with these parents already exists in the database. If you save, you "
 "will create a duplicate family. It is recommended that you cancel the "
 "editing of this window, and select the existing family"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:955
+#: ../gramps/gui/editors/editfamily.py:1004
 #, python-format
 msgid "Edit %s"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:1064
+#: ../gramps/gui/editors/editfamily.py:1113
 msgid "A father cannot be his own child"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:1065
+#: ../gramps/gui/editors/editfamily.py:1114
 #, python-format
 msgid "%s is listed as both the father and child of the family."
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:1075
+#: ../gramps/gui/editors/editfamily.py:1124
 msgid "A mother cannot be her own child"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:1076
+#: ../gramps/gui/editors/editfamily.py:1125
 #, python-format
 msgid "%s is listed as both the mother and child of the family."
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:1084
+#: ../gramps/gui/editors/editfamily.py:1133
 msgid "Cannot save family"
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:1085
+#: ../gramps/gui/editors/editfamily.py:1134
 msgid "No data exists for this family. Please enter data or cancel the edit."
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:1093
+#: ../gramps/gui/editors/editfamily.py:1142
 msgid "Cannot save family. ID already exists."
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:1094
-#: ../gramps/gui/editors/editnote.py:327
+#: ../gramps/gui/editors/editfamily.py:1143
+#: ../gramps/gui/editors/editnote.py:328
 #: ../gramps/gui/editors/editreference.py:295
 #, python-format
 msgid ""
@@ -12765,7 +13022,7 @@ msgid ""
 "next available ID value."
 msgstr ""
 
-#: ../gramps/gui/editors/editfamily.py:1109
+#: ../gramps/gui/editors/editfamily.py:1158
 msgid "Add Family"
 msgstr ""
 
@@ -12799,7 +13056,7 @@ msgstr ""
 msgid "manual|Link_Editor"
 msgstr ""
 
-#: ../gramps/gui/editors/editlink.py:87 ../gramps/gui/editors/editlink.py:238
+#: ../gramps/gui/editors/editlink.py:87 ../gramps/gui/editors/editlink.py:239
 msgid "Link Editor"
 msgstr ""
 
@@ -12830,44 +13087,44 @@ msgstr ""
 msgid "Edit Media Object"
 msgstr ""
 
-#: ../gramps/gui/editors/editmedia.py:286
+#: ../gramps/gui/editors/editmedia.py:288
 msgid "Cannot save media object"
 msgstr ""
 
-#: ../gramps/gui/editors/editmedia.py:287
+#: ../gramps/gui/editors/editmedia.py:289
 msgid ""
 "No data exists for this media object. Please enter data or cancel the edit."
 msgstr ""
 
-#: ../gramps/gui/editors/editmedia.py:297
+#: ../gramps/gui/editors/editmedia.py:299
 #: ../gramps/gui/editors/editreference.py:280
 msgid "Cannot save media object. ID already exists."
 msgstr ""
 
-#: ../gramps/gui/editors/editmedia.py:312
+#: ../gramps/gui/editors/editmedia.py:314
 msgid "There is no media matching the current path value!"
 msgstr ""
 
-#: ../gramps/gui/editors/editmedia.py:313
+#: ../gramps/gui/editors/editmedia.py:315
 #, python-format
 msgid ""
 "You have attempted to use the path with value '%(path)s'. This path does not "
 "exist! Please enter a different path"
 msgstr ""
 
-#: ../gramps/gui/editors/editmedia.py:324
-#: ../gramps/gui/editors/editmediaref.py:526
+#: ../gramps/gui/editors/editmedia.py:326
+#: ../gramps/gui/editors/editmediaref.py:527
 #, python-format
 msgid "Add Media Object (%s)"
 msgstr ""
 
-#: ../gramps/gui/editors/editmedia.py:329
-#: ../gramps/gui/editors/editmediaref.py:520
+#: ../gramps/gui/editors/editmedia.py:331
+#: ../gramps/gui/editors/editmediaref.py:521
 #, python-format
 msgid "Edit Media Object (%s)"
 msgstr ""
 
-#: ../gramps/gui/editors/editmedia.py:369
+#: ../gramps/gui/editors/editmedia.py:371
 msgid "Remove Media Object"
 msgstr ""
 
@@ -12896,7 +13153,7 @@ msgid "manual|Name_Editor"
 msgstr ""
 
 #: ../gramps/gui/editors/editname.py:174
-#: ../gramps/gui/editors/editperson.py:325
+#: ../gramps/gui/editors/editperson.py:318
 msgid "Call name must be the given name that is normally used."
 msgstr ""
 
@@ -12965,32 +13222,32 @@ msgstr ""
 msgid "New Note"
 msgstr ""
 
-#: ../gramps/gui/editors/editnote.py:189
+#: ../gramps/gui/editors/editnote.py:188
 msgid "_Note"
 msgstr ""
 
-#: ../gramps/gui/editors/editnote.py:293 ../gramps/gui/editors/editnote.py:342
-#: ../gramps/gui/editors/objectentries.py:436
+#: ../gramps/gui/editors/editnote.py:294 ../gramps/gui/editors/editnote.py:343
+#: ../gramps/gui/editors/objectentries.py:433
 msgid "Edit Note"
 msgstr ""
 
-#: ../gramps/gui/editors/editnote.py:317
+#: ../gramps/gui/editors/editnote.py:318
 msgid "Cannot save note"
 msgstr ""
 
-#: ../gramps/gui/editors/editnote.py:318
+#: ../gramps/gui/editors/editnote.py:319
 msgid "No data exists for this note. Please enter data or cancel the edit."
 msgstr ""
 
-#: ../gramps/gui/editors/editnote.py:326
+#: ../gramps/gui/editors/editnote.py:327
 msgid "Cannot save note. ID already exists."
 msgstr ""
 
-#: ../gramps/gui/editors/editnote.py:337
+#: ../gramps/gui/editors/editnote.py:338
 msgid "Add Note"
 msgstr ""
 
-#: ../gramps/gui/editors/editnote.py:360
+#: ../gramps/gui/editors/editnote.py:361
 #, python-format
 msgid "Delete Note (%s)"
 msgstr ""
@@ -13013,83 +13270,84 @@ msgstr ""
 msgid "manual|Editing_information_about_people"
 msgstr ""
 
-#: ../gramps/gui/editors/editperson.py:607
-#: ../gramps/plugins/view/geofamily.py:428
+#: ../gramps/gui/editors/editperson.py:600
+#: ../gramps/plugins/view/geofamily.py:478
 msgid "Edit Person"
 msgstr ""
 
-#: ../gramps/gui/editors/editperson.py:650
-#: ../gramps/plugins/view/mediaview.py:211
+#: ../gramps/gui/editors/editperson.py:644
+#: ../gramps/plugins/view/mediaview.py:379
+#: ../gramps/plugins/view/mediaview.py:395
 msgid "View"
 msgstr ""
 
-#: ../gramps/gui/editors/editperson.py:652
+#: ../gramps/gui/editors/editperson.py:646
 msgid "Edit Object Properties"
 msgstr ""
 
-#: ../gramps/gui/editors/editperson.py:691
+#: ../gramps/gui/editors/editperson.py:687
 msgid "Make Active Person"
 msgstr ""
 
-#: ../gramps/gui/editors/editperson.py:695
+#: ../gramps/gui/editors/editperson.py:687
 msgid "Make Home Person"
 msgstr ""
 
-#: ../gramps/gui/editors/editperson.py:809
+#: ../gramps/gui/editors/editperson.py:807
 msgid "Problem changing the gender"
 msgstr ""
 
-#: ../gramps/gui/editors/editperson.py:810
+#: ../gramps/gui/editors/editperson.py:808
 msgid ""
 "Changing the gender caused problems with marriage information.\n"
 "Please check the person's marriages."
 msgstr ""
 
-#: ../gramps/gui/editors/editperson.py:821
+#: ../gramps/gui/editors/editperson.py:819
 msgid "Cannot save person"
 msgstr ""
 
-#: ../gramps/gui/editors/editperson.py:822
+#: ../gramps/gui/editors/editperson.py:820
 msgid "No data exists for this person. Please enter data or cancel the edit."
 msgstr ""
 
-#: ../gramps/gui/editors/editperson.py:846
+#: ../gramps/gui/editors/editperson.py:844
 msgid "Cannot save person. ID already exists."
 msgstr ""
 
-#: ../gramps/gui/editors/editperson.py:861
+#: ../gramps/gui/editors/editperson.py:859
 #, python-format
 msgid "Add Person (%s)"
 msgstr ""
 
-#: ../gramps/gui/editors/editperson.py:867
-#: ../gramps/plugins/view/relview.py:572 ../gramps/plugins/view/relview.py:989
-#: ../gramps/plugins/view/relview.py:1044
-#: ../gramps/plugins/view/relview.py:1163
-#: ../gramps/plugins/view/relview.py:1270
+#: ../gramps/gui/editors/editperson.py:865
+#: ../gramps/plugins/view/relview.py:703 ../gramps/plugins/view/relview.py:1154
+#: ../gramps/plugins/view/relview.py:1209
+#: ../gramps/plugins/view/relview.py:1323
+#: ../gramps/plugins/view/relview.py:1430
 #, python-format
 msgid "Edit Person (%s)"
 msgstr ""
 
-#: ../gramps/gui/editors/editperson.py:1099
+#: ../gramps/gui/editors/editperson.py:1097
 msgid "Unknown gender specified"
 msgstr ""
 
-#: ../gramps/gui/editors/editperson.py:1101
+#: ../gramps/gui/editors/editperson.py:1099
 msgid ""
 "The gender of the person is currently unknown. Usually, this is a mistake. "
 "Please specify the gender."
 msgstr ""
 
-#: ../gramps/gui/editors/editperson.py:1104
+#: ../gramps/gui/editors/editperson.py:1102
 msgid "_Male"
 msgstr ""
 
-#: ../gramps/gui/editors/editperson.py:1105
+#: ../gramps/gui/editors/editperson.py:1103
 msgid "_Female"
 msgstr ""
 
-#: ../gramps/gui/editors/editperson.py:1106
+#: ../gramps/gui/editors/editperson.py:1104
 msgid "_Unknown"
 msgstr ""
 
@@ -13098,19 +13356,19 @@ msgid "manual|Person_Reference_Editor"
 msgstr ""
 
 #: ../gramps/gui/editors/editpersonref.py:93
-#: ../gramps/gui/editors/editpersonref.py:222
+#: ../gramps/gui/editors/editpersonref.py:213
 msgid "Person Reference Editor"
 msgstr ""
 
-#: ../gramps/gui/editors/editpersonref.py:222
+#: ../gramps/gui/editors/editpersonref.py:213
 msgid "Person Reference"
 msgstr ""
 
-#: ../gramps/gui/editors/editpersonref.py:239
+#: ../gramps/gui/editors/editpersonref.py:230
 msgid "No person selected"
 msgstr ""
 
-#: ../gramps/gui/editors/editpersonref.py:240
+#: ../gramps/gui/editors/editpersonref.py:231
 msgid "You must either select a person or Cancel the edit"
 msgstr ""
 
@@ -13151,9 +13409,9 @@ msgid ""
 msgstr ""
 
 #: ../gramps/gui/editors/editplace.py:217
-#: ../gramps/plugins/lib/maps/geography.py:924
-#: ../gramps/plugins/view/geoplaces.py:435
-#: ../gramps/plugins/view/geoplaces.py:461
+#: ../gramps/plugins/lib/maps/geography.py:891
+#: ../gramps/plugins/view/geoplaces.py:494
+#: ../gramps/plugins/view/geoplaces.py:520
 msgid "Edit Place"
 msgstr ""
 
@@ -13228,11 +13486,11 @@ msgstr ""
 msgid "Add Place"
 msgstr ""
 
-#: ../gramps/gui/editors/editprimary.py:238
+#: ../gramps/gui/editors/editprimary.py:244
 msgid "Save Changes?"
 msgstr ""
 
-#: ../gramps/gui/editors/editprimary.py:239
+#: ../gramps/gui/editors/editprimary.py:245
 msgid "If you close without saving, the changes you have made will be lost"
 msgstr ""
 
@@ -13359,119 +13617,119 @@ msgstr ""
 msgid "Internet Address Editor"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:83
+#: ../gramps/gui/editors/filtereditor.py:84
 msgid "manual|Add_Rule_dialog"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:84
+#: ../gramps/gui/editors/filtereditor.py:85
 msgid "manual|Define_Filter_dialog"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:85
+#: ../gramps/gui/editors/filtereditor.py:86
 msgid "manual|Custom_Filters"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:89
+#: ../gramps/gui/editors/filtereditor.py:90
 msgid "Person Filters"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:90
+#: ../gramps/gui/editors/filtereditor.py:91
 msgid "Family Filters"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:91
+#: ../gramps/gui/editors/filtereditor.py:92
 msgid "Event Filters"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:92
+#: ../gramps/gui/editors/filtereditor.py:93
 msgid "Place Filters"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:93
+#: ../gramps/gui/editors/filtereditor.py:94
 msgid "Source Filters"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:94
+#: ../gramps/gui/editors/filtereditor.py:95
 msgid "Media Filters"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:95
+#: ../gramps/gui/editors/filtereditor.py:96
 msgid "Repository Filters"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:96
+#: ../gramps/gui/editors/filtereditor.py:97
 msgid "Note Filters"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:97
+#: ../gramps/gui/editors/filtereditor.py:98
 msgid "Citation Filters"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:251
+#: ../gramps/gui/editors/filtereditor.py:252
 msgid "equal to"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:251
+#: ../gramps/gui/editors/filtereditor.py:252
 msgid "greater than"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:289
+#: ../gramps/gui/editors/filtereditor.py:290
 msgid "Not a valid ID"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:318
+#: ../gramps/gui/editors/filtereditor.py:319
 msgid "Select..."
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:323
+#: ../gramps/gui/editors/filtereditor.py:324
 #, python-format
 msgid "Select %s from a list"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:390
+#: ../gramps/gui/editors/filtereditor.py:391
 msgid "Give or select a source ID, leave empty to find objects with no source."
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:562
+#: ../gramps/gui/editors/filtereditor.py:567
 msgid "Include selected Gramps ID"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:564
+#: ../gramps/gui/editors/filtereditor.py:569
 msgid "Use exact case of letters"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:565
+#: ../gramps/gui/editors/filtereditor.py:570
 msgid "Regular-Expression matching:"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:566
+#: ../gramps/gui/editors/filtereditor.py:571
 msgid "Use regular expression"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:568
+#: ../gramps/gui/editors/filtereditor.py:573
 msgid "Also family events where person is spouse"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:570
+#: ../gramps/gui/editors/filtereditor.py:575
 msgid "Only include primary participants"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:586
+#: ../gramps/gui/editors/filtereditor.py:591
 #: ../gramps/gui/widgets/placewithin.py:73
 msgid "degrees"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:586
+#: ../gramps/gui/editors/filtereditor.py:591
 #: ../gramps/gui/widgets/placewithin.py:73
 msgid "kilometers"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:586
+#: ../gramps/gui/editors/filtereditor.py:591
 #: ../gramps/gui/widgets/placewithin.py:73
 msgid "miles"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:597
+#: ../gramps/gui/editors/filtereditor.py:605
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:76
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:80
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:97
@@ -13484,7 +13742,7 @@ msgstr ""
 msgid "Use regular expressions"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:598
+#: ../gramps/gui/editors/filtereditor.py:606
 msgid ""
 "Interpret the contents of string fields as regular expressions.\n"
 "A decimal point will match any character. A question mark will match zero or "
@@ -13495,152 +13753,152 @@ msgid ""
 "a line."
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:627
+#: ../gramps/gui/editors/filtereditor.py:635
 msgid "Rule Name"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:758
-#: ../gramps/gui/editors/filtereditor.py:762 ../gramps/gui/glade/rule.glade:914
+#: ../gramps/gui/editors/filtereditor.py:772
+#: ../gramps/gui/editors/filtereditor.py:776 ../gramps/gui/glade/rule.glade:914
 msgid "No rule selected"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:815
+#: ../gramps/gui/editors/filtereditor.py:829
 msgid "Define filter"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:919
+#: ../gramps/gui/editors/filtereditor.py:933
 msgid "Add Rule"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:931
+#: ../gramps/gui/editors/filtereditor.py:945
 msgid "Edit Rule"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:966
+#: ../gramps/gui/editors/filtereditor.py:980
 msgid "Filter Test"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:1105
+#: ../gramps/gui/editors/filtereditor.py:1119
 msgid "Comment"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:1113
+#: ../gramps/gui/editors/filtereditor.py:1127
 msgid "Custom Filter Editor"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:1185
+#: ../gramps/gui/editors/filtereditor.py:1199
 msgid "Delete Filter?"
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:1186
+#: ../gramps/gui/editors/filtereditor.py:1200
 msgid ""
 "This filter is currently being used as the base for other filters. Deleting "
 "this filter will result in removing all other filters that depend on it."
 msgstr ""
 
-#: ../gramps/gui/editors/filtereditor.py:1190
+#: ../gramps/gui/editors/filtereditor.py:1204
 msgid "Delete Filter"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:294
+#: ../gramps/gui/editors/objectentries.py:291
 msgid "To select a place, use drag-and-drop or use the buttons"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:296
+#: ../gramps/gui/editors/objectentries.py:293
 msgid "No place given, click button to select one"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:297
+#: ../gramps/gui/editors/objectentries.py:294
 msgid "Edit place"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:298
+#: ../gramps/gui/editors/objectentries.py:295
 msgid "Select an existing place"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:299
+#: ../gramps/gui/editors/objectentries.py:296
 #: ../gramps/plugins/lib/libplaceview.py:103
 msgid "Add a new place"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:300
+#: ../gramps/gui/editors/objectentries.py:297
 msgid "Remove place"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:341
+#: ../gramps/gui/editors/objectentries.py:338
 msgid "To select a source, use drag-and-drop or use the buttons"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:343
+#: ../gramps/gui/editors/objectentries.py:340
 msgid "First add a source using the button"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:344
+#: ../gramps/gui/editors/objectentries.py:341
 msgid "Edit source"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:345
+#: ../gramps/gui/editors/objectentries.py:342
 msgid "Select an existing source"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:346
+#: ../gramps/gui/editors/objectentries.py:343
 #: ../gramps/plugins/view/citationlistview.py:125
 #: ../gramps/plugins/view/citationtreeview.py:122
 #: ../gramps/plugins/view/sourceview.py:98
 msgid "Add a new source"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:347
+#: ../gramps/gui/editors/objectentries.py:344
 msgid "Remove source"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:387
+#: ../gramps/gui/editors/objectentries.py:384
 msgid "To select a media object, use drag-and-drop or use the buttons"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:389
+#: ../gramps/gui/editors/objectentries.py:386
 #: ../gramps/gui/plug/_guioptions.py:1116
 msgid "No image given, click button to select one"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:390
+#: ../gramps/gui/editors/objectentries.py:387
 msgid "Edit media object"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:391
+#: ../gramps/gui/editors/objectentries.py:388
 #: ../gramps/gui/plug/_guioptions.py:1094
 msgid "Select an existing media object"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:392
+#: ../gramps/gui/editors/objectentries.py:389
 #: ../gramps/plugins/view/mediaview.py:112
 msgid "Add a new media object"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:393
+#: ../gramps/gui/editors/objectentries.py:390
 msgid "Remove media object"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:433
+#: ../gramps/gui/editors/objectentries.py:430
 msgid "To select a note, use drag-and-drop or use the buttons"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:435
+#: ../gramps/gui/editors/objectentries.py:432
 #: ../gramps/gui/plug/_guioptions.py:1014
 msgid "No note given, click button to select one"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:437
+#: ../gramps/gui/editors/objectentries.py:434
 #: ../gramps/gui/plug/_guioptions.py:989
 msgid "Select an existing note"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:438
+#: ../gramps/gui/editors/objectentries.py:435
 #: ../gramps/plugins/view/noteview.py:93
 msgid "Add a new note"
 msgstr ""
 
-#: ../gramps/gui/editors/objectentries.py:439
+#: ../gramps/gui/editors/objectentries.py:436
 msgid "Remove note"
 msgstr ""
 
@@ -13674,8 +13932,9 @@ msgstr ""
 msgid "%s does not contain"
 msgstr ""
 
-#: ../gramps/gui/filters/_searchbar.py:168 ../gramps/gui/views/listview.py:1194
-#: ../gramps/gui/views/listview.py:1214
+#: ../gramps/gui/filters/_searchbar.py:168 ../gramps/gui/views/listview.py:1188
+#: ../gramps/gui/views/listview.py:1208 ../gramps/plugins/gramplet/leak.py:193
+#: ../gramps/plugins/gramplet/leak.py:200
 msgid "Updating display..."
 msgstr ""
 
@@ -13724,7 +13983,7 @@ msgstr ""
 #: ../gramps/gui/widgets/reorderfam.py:103
 #: ../gramps/plugins/textreport/tagreport.py:264
 #: ../gramps/plugins/view/familyview.py:82
-#: ../gramps/plugins/webreport/person.py:1168
+#: ../gramps/plugins/webreport/person.py:1241
 msgid "Relationship"
 msgstr ""
 
@@ -13734,7 +13993,7 @@ msgstr ""
 
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:134
 #: ../gramps/plugins/export/exportcsv.py:357
-#: ../gramps/plugins/webreport/person.py:1776
+#: ../gramps/plugins/webreport/person.py:1856
 msgid "Birth date"
 msgstr ""
 
@@ -13746,7 +14005,7 @@ msgstr ""
 
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:136
 #: ../gramps/plugins/export/exportcsv.py:359
-#: ../gramps/plugins/webreport/person.py:1777
+#: ../gramps/plugins/webreport/person.py:1857
 msgid "Death date"
 msgstr ""
 
@@ -13787,8 +14046,8 @@ msgid "Show all"
 msgstr ""
 
 #: ../gramps/gui/glade/baseselector.glade:141
-#: ../gramps/gui/views/treemodels/treebasemodel.py:534
-#: ../gramps/gui/views/treemodels/treebasemodel.py:579
+#: ../gramps/gui/views/treemodels/treebasemodel.py:535
+#: ../gramps/gui/views/treemodels/treebasemodel.py:580
 msgid "Loading items..."
 msgstr ""
 
@@ -13797,7 +14056,7 @@ msgid "Book _name:"
 msgstr ""
 
 #: ../gramps/gui/glade/book.glade:90
-#: ../gramps/gui/plug/report/_bookdialog.py:633
+#: ../gramps/gui/plug/report/_bookdialog.py:636
 msgid "Clear the book"
 msgstr ""
 
@@ -13834,8 +14093,36 @@ msgid "Configure currently selected item"
 msgstr ""
 
 #: ../gramps/gui/glade/book.glade:540 ../gramps/gui/glade/dbman.glade:266
-#: ../gramps/gui/views/listview.py:214
-#: ../gramps/plugins/lib/libpersonview.py:393
+#: ../gramps/plugins/lib/libpersonview.py:226
+#: ../gramps/plugins/lib/libpersonview.py:303
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:303
+#: ../gramps/plugins/lib/libplaceview.py:362
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:195
+#: ../gramps/plugins/view/citationlistview.py:254
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:209
+#: ../gramps/plugins/view/eventview.py:268
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:168
+#: ../gramps/plugins/view/familyview.py:227
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/mediaview.py:268
+#: ../gramps/plugins/view/mediaview.py:327
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:168
+#: ../gramps/plugins/view/noteview.py:227
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/repoview.py:181
+#: ../gramps/plugins/view/repoview.py:240
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:167
+#: ../gramps/plugins/view/sourceview.py:226
+#: ../gramps/plugins/view/sourceview.py:278
 msgid "_Delete"
 msgstr ""
 
@@ -13959,7 +14246,7 @@ msgstr ""
 msgid "Cancel the rest of the operations"
 msgstr ""
 
-#: ../gramps/gui/glade/dialog.glade:433
+#: ../gramps/gui/glade/dialog.glade:433 ../gramps/gui/views/listview.py:572
 #: ../gramps/plugins/tool/reorderids.glade:21
 msgid "_No"
 msgstr ""
@@ -13969,7 +14256,7 @@ msgstr ""
 msgid "Do not apply the operation to this item"
 msgstr ""
 
-#: ../gramps/gui/glade/dialog.glade:449
+#: ../gramps/gui/glade/dialog.glade:449 ../gramps/gui/views/listview.py:572
 #: ../gramps/plugins/tool/reorderids.glade:37
 msgid "_Yes"
 msgstr ""
@@ -13991,24 +14278,24 @@ msgid ""
 "selected items"
 msgstr ""
 
-#: ../gramps/gui/glade/dialog.glade:763 ../gramps/gui/glade/dialog.glade:780
-#: ../gramps/gui/glade/dialog.glade:892
+#: ../gramps/gui/glade/dialog.glade:776 ../gramps/gui/glade/dialog.glade:793
+#: ../gramps/gui/glade/dialog.glade:906
 msgid "label"
 msgstr ""
 
-#: ../gramps/gui/glade/dialog.glade:827
+#: ../gramps/gui/glade/dialog.glade:841
 msgid "Close _without saving"
 msgstr ""
 
-#: ../gramps/gui/glade/dialog.glade:859
-#: ../gramps/gui/plug/report/_bookdialog.py:634
-#: ../gramps/gui/views/listview.py:1061
-#: ../gramps/gui/widgets/grampletpane.py:581
+#: ../gramps/gui/glade/dialog.glade:873
+#: ../gramps/gui/plug/report/_bookdialog.py:637
+#: ../gramps/gui/views/listview.py:1055
+#: ../gramps/gui/widgets/grampletpane.py:588
 #: ../gramps/plugins/tool/eventcmp.py:400
 msgid "_Save"
 msgstr ""
 
-#: ../gramps/gui/glade/dialog.glade:932
+#: ../gramps/gui/glade/dialog.glade:946
 msgid "Do not ask again"
 msgstr ""
 
@@ -14123,6 +14410,8 @@ msgstr ""
 #: ../gramps/gui/glade/editrepository.glade:205
 #: ../gramps/gui/glade/editsource.glade:288
 #: ../gramps/gui/glade/editurl.glade:149
+#: ../gramps/plugins/importer/importprogen.glade:101
+#: ../gramps/plugins/importer/importprogen.glade:237
 msgid "Privacy"
 msgstr ""
 
@@ -14135,6 +14424,7 @@ msgstr ""
 #: ../gramps/gui/glade/editmediaref.glade:573
 #: ../gramps/gui/glade/editname.glade:562
 #: ../gramps/gui/glade/editplacename.glade:123
+#: ../gramps/plugins/importer/importprogen.glade:486
 msgid "Invoke date editor"
 msgstr ""
 
@@ -15007,7 +15297,7 @@ msgid "Street Number"
 msgstr ""
 
 #: ../gramps/gui/glade/editplacename.glade:156
-#: ../gramps/plugins/webreport/basepage.py:2577
+#: ../gramps/plugins/webreport/basepage.py:2621
 msgid "Date range in which the name is valid."
 msgstr ""
 
@@ -15225,7 +15515,7 @@ msgstr ""
 
 #. name, click?, width, toggle
 #: ../gramps/gui/glade/mergedata.glade:173
-#: ../gramps/gui/glade/mergedata.glade:189 ../gramps/gui/plug/_windows.py:1098
+#: ../gramps/gui/glade/mergedata.glade:189 ../gramps/gui/plug/_windows.py:1100
 #: ../gramps/plugins/tool/changenames.py:196
 #: ../gramps/plugins/tool/patchnames.py:401
 msgid "Select"
@@ -15337,7 +15627,7 @@ msgid "Note 2"
 msgstr ""
 
 #: ../gramps/gui/glade/mergenote.glade:278
-#: ../gramps/gui/glade/mergenote.glade:294 ../gramps/gui/views/listview.py:1065
+#: ../gramps/gui/glade/mergenote.glade:294 ../gramps/gui/views/listview.py:1059
 msgid "Format:"
 msgstr ""
 
@@ -15584,7 +15874,7 @@ msgstr ""
 #: ../gramps/gui/glade/rule.glade:521 ../gramps/gui/glade/styleeditor.glade:419
 #: ../gramps/plugins/tool/finddupes.glade:132
 #: ../gramps/plugins/tool/mergecitations.glade:132
-#: ../gramps/plugins/tool/sortevents.py:82
+#: ../gramps/plugins/tool/sortevents.py:83
 msgid "Options"
 msgstr ""
 
@@ -15633,7 +15923,7 @@ msgid "Size"
 msgstr ""
 
 #: ../gramps/gui/glade/styleeditor.glade:385
-#: ../gramps/gui/plug/report/_styleeditor.py:267
+#: ../gramps/gui/plug/report/_styleeditor.py:268
 msgid "point size|pt"
 msgstr ""
 
@@ -15825,7 +16115,41 @@ msgid "_Display on startup"
 msgstr ""
 
 #: ../gramps/gui/glade/tipofday.glade:102
-#: ../gramps/gui/views/navigationview.py:294
+#: ../gramps/plugins/lib/libpersonview.py:206
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libplaceview.py:289
+#: ../gramps/plugins/lib/libplaceview.py:332
+#: ../gramps/plugins/view/citationlistview.py:181
+#: ../gramps/plugins/view/citationlistview.py:224
+#: ../gramps/plugins/view/citationtreeview.py:323
+#: ../gramps/plugins/view/eventview.py:195
+#: ../gramps/plugins/view/eventview.py:238
+#: ../gramps/plugins/view/familyview.py:154
+#: ../gramps/plugins/view/familyview.py:197
+#: ../gramps/plugins/view/fanchartview.py:144
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:71 ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoevents.py:67
+#: ../gramps/plugins/view/geoevents.py:101
+#: ../gramps/plugins/view/geofamclose.py:69
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geofamily.py:67
+#: ../gramps/plugins/view/geofamily.py:101
+#: ../gramps/plugins/view/geomoves.py:68 ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:69
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/geoplaces.py:70
+#: ../gramps/plugins/view/geoplaces.py:104
+#: ../gramps/plugins/view/mediaview.py:254
+#: ../gramps/plugins/view/mediaview.py:297
+#: ../gramps/plugins/view/noteview.py:154
+#: ../gramps/plugins/view/noteview.py:197
+#: ../gramps/plugins/view/pedigreeview.py:652
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428 ../gramps/plugins/view/repoview.py:167
+#: ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/sourceview.py:153
+#: ../gramps/plugins/view/sourceview.py:196
 msgid "_Forward"
 msgstr ""
 
@@ -15834,7 +16158,7 @@ msgid "Install Selected _Addons"
 msgstr ""
 
 #: ../gramps/gui/glade/updateaddons.glade:72
-#: ../gramps/gui/plug/_windows.py:1078
+#: ../gramps/gui/plug/_windows.py:1080
 msgid "Available Gramps Updates for Addons"
 msgstr ""
 
@@ -15857,13 +16181,166 @@ msgstr ""
 msgid "Select _None"
 msgstr ""
 
-#: ../gramps/gui/grampsgui.py:60
+#: ../gramps/gui/grampsgui.py:56
+msgid "Books..."
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Clip_board"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Configure the active view"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Connect to a recent database"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "F_ull Screen"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Gramps _Home Page"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Gramps _Mailing Lists"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Make Backup..."
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Manage databases"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Open _Recent"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Open the Clipboard dialog"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Open the reports dialog"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Open the tools dialog"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56 ../gramps/gui/tipofday.py:67
+#: ../gramps/gui/tipofday.py:68 ../gramps/gui/tipofday.py:121
+msgid "Tip of the Day"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56 ../gramps/gui/undohistory.py:73
+msgid "Undo History"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Abandon Changes and Quit"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_About"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Bookmarks"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Configure..."
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Export..."
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Extra Reports/Tools"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_FAQ"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Family Trees"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Go"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Import..."
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Key Bindings"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Manage Family Trees..."
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Navigator"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Plugin Manager"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Preferences..."
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Quit"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Report a Bug"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Reports"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Toolbar"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Tools"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_User Manual"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_View"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Windows"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:423
 msgid ""
 "Your version of gi (gnome-introspection) seems to be too old. You need a "
 "version which has the function 'require_version' to start Gramps"
 msgstr ""
 
-#: ../gramps/gui/grampsgui.py:74
+#: ../gramps/gui/grampsgui.py:437
 #, python-format
 msgid ""
 "Your pygobject version does not meet the requirements.\n"
@@ -15873,7 +16350,7 @@ msgid ""
 "Gramps will terminate now."
 msgstr ""
 
-#: ../gramps/gui/grampsgui.py:92
+#: ../gramps/gui/grampsgui.py:455
 msgid ""
 "Gdk, Gtk, Pango or PangoCairo typelib not installed.\n"
 "Install Gnome Introspection, and pygobject version 3.12 or later.\n"
@@ -15882,7 +16359,7 @@ msgid ""
 "Gramps will terminate now."
 msgstr ""
 
-#: ../gramps/gui/grampsgui.py:103
+#: ../gramps/gui/grampsgui.py:466
 #, python-format
 msgid ""
 "Your Gtk version does not meet the requirements.\n"
@@ -15891,7 +16368,7 @@ msgid ""
 "Gramps will terminate now."
 msgstr ""
 
-#: ../gramps/gui/grampsgui.py:114
+#: ../gramps/gui/grampsgui.py:477
 msgid ""
 "\n"
 "cairo python support not installed. Install cairo for your version of "
@@ -15900,16 +16377,16 @@ msgid ""
 "Gramps will terminate now."
 msgstr ""
 
-#: ../gramps/gui/grampsgui.py:145
+#: ../gramps/gui/grampsgui.py:508
 msgid "Danger: This is unstable code!"
 msgstr ""
 
-#: ../gramps/gui/grampsgui.py:146
+#: ../gramps/gui/grampsgui.py:509
 #, python-format
 msgid "This Gramps ('%s') is a development release.\n"
 msgstr ""
 
-#: ../gramps/gui/grampsgui.py:148
+#: ../gramps/gui/grampsgui.py:511
 #, python-format
 msgid ""
 "This version is not meant for normal usage. Use at your own risk.\n"
@@ -15926,11 +16403,11 @@ msgid ""
 "then."
 msgstr ""
 
-#: ../gramps/gui/grampsgui.py:178
+#: ../gramps/gui/grampsgui.py:541
 msgid "Gramps detected an incomplete GTK installation"
 msgstr ""
 
-#: ../gramps/gui/grampsgui.py:180
+#: ../gramps/gui/grampsgui.py:543
 #, python-format
 msgid ""
 "GTK translations for the current language (%(language)s) are missing.\n"
@@ -15941,11 +16418,15 @@ msgid ""
 "typically located in /usr/share/doc/gramps.\n"
 msgstr ""
 
-#: ../gramps/gui/grampsgui.py:297
+#: ../gramps/gui/grampsgui.py:659
 msgid "Error parsing arguments"
 msgstr ""
 
-#: ../gramps/gui/grampsgui.py:347 ../gramps/gui/grampsgui.py:389
+#: ../gramps/gui/grampsgui.py:678
+msgid "Gramps terminated because of no DISPLAY"
+msgstr ""
+
+#: ../gramps/gui/grampsgui.py:701 ../gramps/gui/grampsgui.py:775
 msgid ""
 "\n"
 "Gramps failed to start. Please report a bug about this.\n"
@@ -15954,10 +16435,6 @@ msgid ""
 "your Family Tree.\n"
 "You can also change manually the startup view in the gramps.ini file \n"
 "by changing the last-view parameter.\n"
-msgstr ""
-
-#: ../gramps/gui/grampsgui.py:365
-msgid "Gramps terminated because of no DISPLAY"
 msgstr ""
 
 #: ../gramps/gui/logger/_errorreportassistant.py:97
@@ -16150,7 +16627,7 @@ msgstr ""
 
 #: ../gramps/gui/merge/mergefamily.py:227
 #: ../gramps/gui/merge/mergeperson.py:351
-#: ../gramps/plugins/lib/libpersonview.py:429
+#: ../gramps/plugins/lib/libpersonview.py:534
 msgid "Cannot merge people"
 msgstr ""
 
@@ -16186,15 +16663,15 @@ msgstr ""
 
 #. Go over parents and build their menu
 #: ../gramps/gui/merge/mergeperson.py:224
-#: ../gramps/gui/widgets/fanchart.py:1726
+#: ../gramps/gui/widgets/fanchart.py:1994
 #: ../gramps/plugins/quickview/all_relations.py:305
 #: ../gramps/plugins/tool/notrelated.py:128
-#: ../gramps/plugins/view/pedigreeview.py:1793
-#: ../gramps/plugins/view/relview.py:530 ../gramps/plugins/view/relview.py:858
-#: ../gramps/plugins/view/relview.py:892
-#: ../gramps/plugins/webreport/person.py:226
-#: ../gramps/plugins/webreport/person.py:1759
-#: ../gramps/plugins/webreport/surname.py:143
+#: ../gramps/plugins/view/pedigreeview.py:1866
+#: ../gramps/plugins/view/relview.py:659 ../gramps/plugins/view/relview.py:1017
+#: ../gramps/plugins/view/relview.py:1052
+#: ../gramps/plugins/webreport/person.py:232
+#: ../gramps/plugins/webreport/person.py:1839
+#: ../gramps/plugins/webreport/surname.py:154
 msgid "Parents"
 msgstr ""
 
@@ -16210,9 +16687,9 @@ msgstr ""
 
 #. Go over spouses and build their menu
 #: ../gramps/gui/merge/mergeperson.py:238
-#: ../gramps/gui/widgets/fanchart.py:1596
+#: ../gramps/gui/widgets/fanchart.py:1857
 #: ../gramps/plugins/textreport/kinshipreport.py:133
-#: ../gramps/plugins/view/pedigreeview.py:1680
+#: ../gramps/plugins/view/pedigreeview.py:1753
 msgid "Spouses"
 msgstr ""
 
@@ -16222,7 +16699,7 @@ msgstr ""
 #: ../gramps/plugins/gramplet/children.py:98
 #: ../gramps/plugins/lib/libpersonview.py:105
 #: ../gramps/plugins/textreport/familygroup.py:570
-#: ../gramps/plugins/view/relview.py:1385
+#: ../gramps/plugins/view/relview.py:1555
 msgid "Spouse"
 msgstr ""
 
@@ -16231,11 +16708,11 @@ msgid "No spouses or children found"
 msgstr ""
 
 #. Add column with the warning text
-#: ../gramps/gui/merge/mergeperson.py:344 ../gramps/plugins/tool/verify.py:562
+#: ../gramps/gui/merge/mergeperson.py:341 ../gramps/plugins/tool/verify.py:565
 msgid "Warning"
 msgstr ""
 
-#: ../gramps/gui/merge/mergeperson.py:345
+#: ../gramps/gui/merge/mergeperson.py:342
 msgid ""
 "The persons have been merged.\n"
 "However, the families for this merge were too complex to automatically "
@@ -16337,7 +16814,7 @@ msgid "Save As"
 msgstr ""
 
 #: ../gramps/gui/plug/_guioptions.py:1746 ../gramps/gui/plug/_windows.py:442
-#: ../gramps/gui/plug/report/_bookdialog.py:635
+#: ../gramps/gui/plug/report/_bookdialog.py:638
 #: ../gramps/gui/plug/report/_fileentry.py:66
 msgid "_Open"
 msgstr ""
@@ -16382,6 +16859,8 @@ msgid "Loaded"
 msgstr ""
 
 #: ../gramps/gui/plug/_windows.py:179
+#: ../gramps/plugins/importer/importprogen.glade:431
+#: ../gramps/plugins/importer/importprogen.glade:1126
 msgid "File"
 msgstr ""
 
@@ -16462,74 +16941,75 @@ msgstr ""
 msgid "Fail"
 msgstr ""
 
-#: ../gramps/gui/plug/_windows.py:515 ../gramps/gui/widgets/grampletbar.py:548
+#: ../gramps/gui/plug/_windows.py:515 ../gramps/gui/widgets/grampletbar.py:549
 msgid "OK"
 msgstr ""
 
-#: ../gramps/gui/plug/_windows.py:619
+#: ../gramps/gui/plug/_windows.py:621
 msgid "Plugin name"
 msgstr ""
 
-#: ../gramps/gui/plug/_windows.py:621
+#: ../gramps/gui/plug/_windows.py:623
 msgid "Version"
 msgstr ""
 
-#: ../gramps/gui/plug/_windows.py:622
+#: ../gramps/gui/plug/_windows.py:624
 msgid "Authors"
 msgstr ""
 
-#: ../gramps/gui/plug/_windows.py:624
+#: ../gramps/gui/plug/_windows.py:626
 #: ../gramps/gui/plug/report/_reportdialog.py:472
 msgid "Filename"
 msgstr ""
 
-#: ../gramps/gui/plug/_windows.py:627
+#: ../gramps/gui/plug/_windows.py:629
 msgid "Detailed Info"
 msgstr ""
 
-#: ../gramps/gui/plug/_windows.py:686
+#: ../gramps/gui/plug/_windows.py:688
 msgid "Plugin Error"
 msgstr ""
 
-#: ../gramps/gui/plug/_windows.py:751
+#: ../gramps/gui/plug/_windows.py:753
 msgid "_Execute"
 msgstr ""
 
-#: ../gramps/gui/plug/_windows.py:1047
+#: ../gramps/gui/plug/_windows.py:1049
+#: ../gramps/plugins/importer/importprogen.py:457
 #: ../gramps/plugins/tool/ownereditor.py:164
 #: ../gramps/plugins/tool/reorderids.py:218
 msgid "Main window"
 msgstr ""
 
-#: ../gramps/gui/plug/_windows.py:1175
+#: ../gramps/gui/plug/_windows.py:1177
 msgid "Downloading and installing selected addons..."
 msgstr ""
 
-#: ../gramps/gui/plug/_windows.py:1210
+#: ../gramps/gui/plug/_windows.py:1212
 msgid "Installation Errors"
 msgstr ""
 
-#: ../gramps/gui/plug/_windows.py:1211
+#: ../gramps/gui/plug/_windows.py:1213
 msgid "The following addons had errors: "
 msgstr ""
 
-#: ../gramps/gui/plug/_windows.py:1217 ../gramps/gui/plug/_windows.py:1225
+#: ../gramps/gui/plug/_windows.py:1219 ../gramps/gui/plug/_windows.py:1227
 msgid "Done downloading and installing addons"
 msgstr ""
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/gui/plug/_windows.py:1219
+#: ../gramps/gui/plug/_windows.py:1221
 #, python-brace-format
 msgid "{number_of} addon was installed."
 msgid_plural "{number_of} addons were installed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gramps/gui/plug/_windows.py:1222
+#: ../gramps/gui/plug/_windows.py:1224
 msgid "If you have installed a 'Gramps View', you will need to restart Gramps."
 msgstr ""
 
-#: ../gramps/gui/plug/_windows.py:1226
+#: ../gramps/gui/plug/_windows.py:1228
 msgid "No addons were installed."
 msgstr ""
 
@@ -16795,26 +17275,16 @@ msgstr ""
 msgid "Use Compression"
 msgstr ""
 
-#: ../gramps/gui/plug/quick/_quickreports.py:94
-msgid "Web Connect"
+#: ../gramps/gui/plug/quick/_quickreports.py:97
+msgid "Web Connection"
 msgstr ""
 
-#: ../gramps/gui/plug/quick/_quickreports.py:140
+#: ../gramps/gui/plug/quick/_quickreports.py:142
 #: ../gramps/gui/plug/quick/_textbufdoc.py:74
 #: ../gramps/gui/plug/quick/_textbufdoc.py:154
 #: ../gramps/gui/plug/quick/_textbufdoc.py:156
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:216
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:223
-#: ../gramps/plugins/lib/libpersonview.py:384
-#: ../gramps/plugins/lib/libplaceview.py:167
-#: ../gramps/plugins/view/citationlistview.py:182
-#: ../gramps/plugins/view/citationtreeview.py:316
-#: ../gramps/plugins/view/eventview.py:247
-#: ../gramps/plugins/view/familyview.py:211
-#: ../gramps/plugins/view/mediaview.py:219
-#: ../gramps/plugins/view/noteview.py:201
-#: ../gramps/plugins/view/repoview.py:153
-#: ../gramps/plugins/view/sourceview.py:138
 msgid "Quick View"
 msgstr ""
 
@@ -16844,48 +17314,48 @@ msgid "You have made changes which have not been saved."
 msgstr ""
 
 #: ../gramps/gui/plug/report/_bookdialog.py:249
-#: ../gramps/gui/plug/report/_bookdialog.py:747
+#: ../gramps/gui/plug/report/_bookdialog.py:750
 msgid "Proceed"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:308
+#: ../gramps/gui/plug/report/_bookdialog.py:309
 msgid "Name of the book. MANDATORY"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:330
+#: ../gramps/gui/plug/report/_bookdialog.py:331
 msgid "Manage Books"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:371
+#: ../gramps/gui/plug/report/_bookdialog.py:372
 msgid "New Book"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:374
+#: ../gramps/gui/plug/report/_bookdialog.py:375
 msgid "_Available items"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:378
+#: ../gramps/gui/plug/report/_bookdialog.py:379
 msgid "Current _book"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:386
-#: ../gramps/plugins/drawreport/statisticschart.py:307
+#: ../gramps/gui/plug/report/_bookdialog.py:387
+#: ../gramps/plugins/drawreport/statisticschart.py:312
 msgid "Item name"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:389
+#: ../gramps/gui/plug/report/_bookdialog.py:390
 msgid "Subject"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:403
+#: ../gramps/gui/plug/report/_bookdialog.py:404
 msgid "Book selection list"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:455
+#: ../gramps/gui/plug/report/_bookdialog.py:456
 msgid "Different database"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:456
+#: ../gramps/gui/plug/report/_bookdialog.py:457
 #, python-format
 msgid ""
 "This book was created with the references to database %s.\n"
@@ -16896,62 +17366,62 @@ msgid ""
 "person of the currently opened database."
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:562
+#: ../gramps/gui/plug/report/_bookdialog.py:563
 msgid "No selected book item"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:563
+#: ../gramps/gui/plug/report/_bookdialog.py:564
 msgid "Please select a book item to configure."
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:628
-#: ../gramps/gui/views/bookmarks.py:289 ../gramps/gui/views/tags.py:422
+#: ../gramps/gui/plug/report/_bookdialog.py:631
+#: ../gramps/gui/views/bookmarks.py:292 ../gramps/gui/views/tags.py:456
 msgid "_Up"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:629
-#: ../gramps/gui/views/bookmarks.py:290 ../gramps/gui/views/tags.py:423
+#: ../gramps/gui/plug/report/_bookdialog.py:632
+#: ../gramps/gui/views/bookmarks.py:293 ../gramps/gui/views/tags.py:457
 msgid "_Down"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:630
+#: ../gramps/gui/plug/report/_bookdialog.py:633
 msgid "Setup"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:719
-#: ../gramps/gui/plug/report/_bookdialog.py:730
+#: ../gramps/gui/plug/report/_bookdialog.py:722
+#: ../gramps/gui/plug/report/_bookdialog.py:733
 msgid "No items"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:720
-#: ../gramps/gui/plug/report/_bookdialog.py:731
+#: ../gramps/gui/plug/report/_bookdialog.py:723
+#: ../gramps/gui/plug/report/_bookdialog.py:734
 msgid "This book has no items."
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:737
+#: ../gramps/gui/plug/report/_bookdialog.py:740
 msgid "No book name"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:738
+#: ../gramps/gui/plug/report/_bookdialog.py:741
 msgid ""
 "You are about to save away a book with no name.\n"
 "\n"
 "Please give it a name before saving it away."
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:744
+#: ../gramps/gui/plug/report/_bookdialog.py:747
 msgid "Book name already exists"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:745
+#: ../gramps/gui/plug/report/_bookdialog.py:748
 msgid "You are about to save away a book with a name which already exists."
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:935
+#: ../gramps/gui/plug/report/_bookdialog.py:938
 msgid "Generate Book"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_bookdialog.py:982
+#: ../gramps/gui/plug/report/_bookdialog.py:985
 msgid "Gramps Book"
 msgstr ""
 
@@ -16996,7 +17466,7 @@ msgstr ""
 
 #: ../gramps/gui/plug/report/_reportdialog.py:324
 #: ../gramps/gui/plug/report/_styleeditor.py:115
-#: ../gramps/gui/plug/report/_styleeditor.py:269
+#: ../gramps/gui/plug/report/_styleeditor.py:270
 msgid "Style"
 msgstr ""
 
@@ -17021,19 +17491,19 @@ msgstr ""
 #: ../gramps/gui/plug/report/_reportdialog.py:366
 #: ../gramps/plugins/drawreport/ancestortree.py:835
 #: ../gramps/plugins/drawreport/calendarreport.py:462
-#: ../gramps/plugins/drawreport/descendtree.py:1574
+#: ../gramps/plugins/drawreport/descendtree.py:1573
 #: ../gramps/plugins/drawreport/fanchart.py:687
-#: ../gramps/plugins/drawreport/statisticschart.py:997
+#: ../gramps/plugins/drawreport/statisticschart.py:1008
 #: ../gramps/plugins/drawreport/timeline.py:414
-#: ../gramps/plugins/graph/gvfamilylines.py:115
-#: ../gramps/plugins/graph/gvhourglass.py:315
-#: ../gramps/plugins/graph/gvrelgraph.py:764
+#: ../gramps/plugins/graph/gvfamilylines.py:120
+#: ../gramps/plugins/graph/gvhourglass.py:364
+#: ../gramps/plugins/graph/gvrelgraph.py:797
 #: ../gramps/plugins/textreport/alphabeticalindex.py:93
 #: ../gramps/plugins/textreport/ancestorreport.py:288
-#: ../gramps/plugins/textreport/birthdayreport.py:412
+#: ../gramps/plugins/textreport/birthdayreport.py:471
 #: ../gramps/plugins/textreport/descendreport.py:520
-#: ../gramps/plugins/textreport/detancestralreport.py:821
-#: ../gramps/plugins/textreport/detdescendantreport.py:998
+#: ../gramps/plugins/textreport/detancestralreport.py:828
+#: ../gramps/plugins/textreport/detdescendantreport.py:1003
 #: ../gramps/plugins/textreport/endoflinereport.py:270
 #: ../gramps/plugins/textreport/familygroup.py:710
 #: ../gramps/plugins/textreport/indivcomplete.py:1059
@@ -17045,8 +17515,8 @@ msgstr ""
 #: ../gramps/plugins/textreport/summary.py:286
 #: ../gramps/plugins/textreport/tableofcontents.py:92
 #: ../gramps/plugins/textreport/tagreport.py:901
-#: ../gramps/plugins/webreport/narrativeweb.py:1576
-#: ../gramps/plugins/webreport/webcal.py:1618
+#: ../gramps/plugins/webreport/narrativeweb.py:1613
+#: ../gramps/plugins/webreport/webcal.py:1656
 msgid "Report Options"
 msgstr ""
 
@@ -17124,8 +17594,8 @@ msgstr ""
 #: ../gramps/gui/plug/report/_stylecombobox.py:66
 #: ../gramps/gui/plug/report/_stylecombobox.py:85
 #: ../gramps/gui/plug/report/_styleeditor.py:134
-#: ../gramps/gui/plug/report/_styleeditor.py:178
-#: ../gramps/gui/plug/report/_styleeditor.py:191
+#: ../gramps/gui/plug/report/_styleeditor.py:179
+#: ../gramps/gui/plug/report/_styleeditor.py:192
 #: ../gramps/plugins/importer/importgedcom.glade:12 gtklist.h:1
 msgid "default"
 msgstr ""
@@ -17148,40 +17618,40 @@ msgid "Error saving stylesheet"
 msgstr ""
 
 #. How to handle missing information
-#: ../gramps/gui/plug/report/_styleeditor.py:173
-#: ../gramps/gui/plug/report/_styleeditor.py:187
-#: ../gramps/plugins/textreport/detancestralreport.py:953
-#: ../gramps/plugins/textreport/detdescendantreport.py:1156
+#: ../gramps/gui/plug/report/_styleeditor.py:174
+#: ../gramps/gui/plug/report/_styleeditor.py:188
+#: ../gramps/plugins/textreport/detancestralreport.py:960
+#: ../gramps/plugins/textreport/detdescendantreport.py:1161
 msgid "Missing information"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_styleeditor.py:173
-#: ../gramps/gui/plug/report/_styleeditor.py:187
+#: ../gramps/gui/plug/report/_styleeditor.py:174
+#: ../gramps/gui/plug/report/_styleeditor.py:188
 msgid "Select a style"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_styleeditor.py:233
-#: ../gramps/gui/plug/report/_styleeditor.py:308
+#: ../gramps/gui/plug/report/_styleeditor.py:234
+#: ../gramps/gui/plug/report/_styleeditor.py:309
 msgid "Style editor"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_styleeditor.py:241
+#: ../gramps/gui/plug/report/_styleeditor.py:242
 msgid "manual|Style_editor_dialog"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_styleeditor.py:351
-#: ../gramps/gui/plug/report/_styleeditor.py:379
-#: ../gramps/gui/plug/report/_styleeditor.py:397
-#: ../gramps/gui/plug/report/_styleeditor.py:430
+#: ../gramps/gui/plug/report/_styleeditor.py:352
+#: ../gramps/gui/plug/report/_styleeditor.py:380
+#: ../gramps/gui/plug/report/_styleeditor.py:398
+#: ../gramps/gui/plug/report/_styleeditor.py:431
 msgid "No description available"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_styleeditor.py:354
+#: ../gramps/gui/plug/report/_styleeditor.py:355
 #, python-format
 msgid "(Embedded style '%s' must be edited separately)"
 msgstr ""
 
-#: ../gramps/gui/plug/report/_styleeditor.py:407
+#: ../gramps/gui/plug/report/_styleeditor.py:408
 #, python-format
 msgid "Column %d:"
 msgstr ""
@@ -17340,11 +17810,6 @@ msgstr ""
 msgid "Spelling checker initialization failed: %s"
 msgstr ""
 
-#: ../gramps/gui/tipofday.py:67 ../gramps/gui/tipofday.py:68
-#: ../gramps/gui/tipofday.py:121 ../gramps/gui/viewmanager.py:537
-msgid "Tip of the Day"
-msgstr ""
-
 #: ../gramps/gui/tipofday.py:87
 msgid "Failed to display tip of the day"
 msgstr ""
@@ -17357,17 +17822,11 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../gramps/gui/undohistory.py:73
-msgid "Undo History"
-msgstr ""
-
-#: ../gramps/gui/undohistory.py:84 ../gramps/gui/viewmanager.py:646
-#: ../gramps/gui/viewmanager.py:1338
+#: ../gramps/gui/undohistory.py:84 ../gramps/gui/viewmanager.py:1120
 msgid "_Undo"
 msgstr ""
 
-#: ../gramps/gui/undohistory.py:86 ../gramps/gui/viewmanager.py:651
-#: ../gramps/gui/viewmanager.py:1355
+#: ../gramps/gui/undohistory.py:86 ../gramps/gui/viewmanager.py:1140
 msgid "_Redo"
 msgstr ""
 
@@ -17427,7 +17886,7 @@ msgstr ""
 msgid "File %s does not exist"
 msgstr ""
 
-#: ../gramps/gui/utils.py:613
+#: ../gramps/gui/utils.py:627
 msgid ""
 "Cannot open new citation editor at this time. Either the citation is already "
 "being edited, or the associated source is already being edited, and opening "
@@ -17438,238 +17897,81 @@ msgid ""
 "citation alone"
 msgstr ""
 
-#: ../gramps/gui/utils.py:626
+#: ../gramps/gui/utils.py:640
 msgid "Cannot open new citation editor"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:469 ../gramps/gui/viewmanager.py:1274
+#: ../gramps/gui/viewmanager.py:331 ../gramps/gui/viewmanager.py:1052
 msgid "No Family Tree"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:491
-msgid "Connect to a recent database"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:509
-msgid "_Family Trees"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:510
-msgid "_Manage Family Trees..."
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:511
-msgid "Manage databases"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:512
-msgid "Open _Recent"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:513
-msgid "Open an existing database"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:514
-msgid "_Quit"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:516
-msgid "_View"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:518
-msgid "_Preferences..."
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:521
-msgid "Gramps _Home Page"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:523
-msgid "Gramps _Mailing Lists"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:525
-msgid "_Report a Bug"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:527
-msgid "_Extra Reports/Tools"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:529
-msgid "_About"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:531
-msgid "_Plugin Manager"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:533
-msgid "_FAQ"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:534
-msgid "_Key Bindings"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:535
-msgid "_User Manual"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:543
-msgid "Close the current database"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:544
-msgid "_Export..."
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:546
-msgid "Make Backup..."
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:547
-msgid "Make a Gramps XML backup of the database"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:549
-msgid "_Abandon Changes and Quit"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:550 ../gramps/gui/viewmanager.py:553
-msgid "_Reports"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:551
-msgid "Open the reports dialog"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:552
-msgid "_Go"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:554
-msgid "Books..."
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:555
-msgid "_Windows"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:602
-msgid "Clip_board"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:603
-msgid "Open the Clipboard dialog"
-msgstr ""
-
-#. --------------------------------------
-#: ../gramps/gui/viewmanager.py:625
-msgid "_Import..."
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:627 ../gramps/gui/viewmanager.py:630
-msgid "_Tools"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:628
-msgid "Open the tools dialog"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:629
-msgid "_Bookmarks"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:631
-msgid "_Configure..."
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:632
-msgid "Configure the active view"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:637
-msgid "_Navigator"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:639
-msgid "_Toolbar"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:641
-msgid "F_ull Screen"
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:657
-msgid "Undo History..."
-msgstr ""
-
-#: ../gramps/gui/viewmanager.py:680
-#, python-format
-msgid "Key %s is not bound"
-msgstr ""
-
 #. registering plugins
-#: ../gramps/gui/viewmanager.py:787
+#: ../gramps/gui/viewmanager.py:557
 msgid "Registering plugins..."
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:795
+#: ../gramps/gui/viewmanager.py:565
 msgid "Ready"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:850
+#: ../gramps/gui/viewmanager.py:620
 msgid "Abort changes?"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:851
+#: ../gramps/gui/viewmanager.py:621
 msgid ""
 "Aborting changes will return the database to the state it was before you "
 "started this editing session."
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:853
+#: ../gramps/gui/viewmanager.py:623
 msgid "Abort changes"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:864
+#: ../gramps/gui/viewmanager.py:634
 msgid "Cannot abandon session's changes"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:865
+#: ../gramps/gui/viewmanager.py:635
 msgid ""
 "Changes cannot be completely abandoned because the number of changes made in "
 "the session exceeded the limit."
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1026
+#: ../gramps/gui/viewmanager.py:802
 msgid "View failed to load. Check error output."
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1178
+#: ../gramps/gui/viewmanager.py:948
+#: ../gramps/plugins/importer/importprogen.py:195
 msgid "Import Statistics"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1249
+#: ../gramps/gui/viewmanager.py:1019
 msgid "Read Only"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1401
+#: ../gramps/gui/viewmanager.py:1023
+msgid "Gramps had a problem the last time it was run."
+msgstr ""
+
+#: ../gramps/gui/viewmanager.py:1024
+msgid "Would you like to run the Check and Repair tool?"
+msgstr ""
+
+#: ../gramps/gui/viewmanager.py:1189
 msgid "Autobackup..."
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1406
+#: ../gramps/gui/viewmanager.py:1194
 msgid "Error saving backup data"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1697
+#: ../gramps/gui/viewmanager.py:1481
 msgid "Failed Loading View"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1698
+#: ../gramps/gui/viewmanager.py:1482
 #, python-format
 msgid ""
 "The view %(name)s did not load and reported an error.\n"
@@ -17684,11 +17986,11 @@ msgid ""
 "by using the Plugin Manager on the Help menu."
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1790
+#: ../gramps/gui/viewmanager.py:1574
 msgid "Failed Loading Plugin"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1791
+#: ../gramps/gui/viewmanager.py:1575
 #, python-format
 msgid ""
 "The plugin %(name)s did not load and reported an error.\n"
@@ -17703,359 +18005,320 @@ msgid ""
 "by using the Plugin Manager on the Help menu."
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1871
+#: ../gramps/gui/viewmanager.py:1655
 msgid "Gramps XML Backup"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1900
+#: ../gramps/gui/viewmanager.py:1684
 msgid "File:"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1932
+#: ../gramps/gui/viewmanager.py:1716
 msgid "Media:"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1939
+#: ../gramps/gui/viewmanager.py:1723
 #: ../gramps/plugins/gramplet/statsgramplet.py:196
-#: ../gramps/plugins/webreport/statistics.py:144
+#: ../gramps/plugins/webreport/statistics.py:145
 msgid "Megabyte|MB"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1941
+#: ../gramps/gui/viewmanager.py:1725
 msgid "Exclude"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1961
+#: ../gramps/gui/viewmanager.py:1745
 msgid "Backup file already exists! Overwrite?"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1962
+#: ../gramps/gui/viewmanager.py:1746
 #, python-format
 msgid "The file '%s' exists."
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1963
+#: ../gramps/gui/viewmanager.py:1747
 msgid "Proceed and overwrite"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1964
+#: ../gramps/gui/viewmanager.py:1748
 msgid "Cancel the backup"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1979
+#: ../gramps/gui/viewmanager.py:1763
 msgid "Making backup..."
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1992
+#: ../gramps/gui/viewmanager.py:1776
 #, python-format
 msgid "Backup saved to '%s'"
 msgstr ""
 
-#: ../gramps/gui/viewmanager.py:1995
+#: ../gramps/gui/viewmanager.py:1779
 msgid "Backup aborted"
 msgstr ""
 
-#: ../gramps/gui/views/bookmarks.py:67
+#: ../gramps/gui/views/bookmarks.py:69
 msgid "manual|Bookmarks"
 msgstr ""
 
 #. this is meaningless while it's modal
-#: ../gramps/gui/views/bookmarks.py:262 ../gramps/gui/views/bookmarks.py:272
-#: ../gramps/gui/views/bookmarks.py:368
-#: ../gramps/gui/views/navigationview.py:277
+#: ../gramps/gui/views/bookmarks.py:265 ../gramps/gui/views/bookmarks.py:275
+#: ../gramps/gui/views/bookmarks.py:371
+#: ../gramps/plugins/lib/libpersonview.py:205
+#: ../gramps/plugins/lib/libplaceview.py:288
+#: ../gramps/plugins/view/citationlistview.py:180
+#: ../gramps/plugins/view/citationtreeview.py:322
+#: ../gramps/plugins/view/eventview.py:194
+#: ../gramps/plugins/view/familyview.py:153
+#: ../gramps/plugins/view/fanchartview.py:183
+#: ../gramps/plugins/view/geoclose.py:110
+#: ../gramps/plugins/view/geoevents.py:100
+#: ../gramps/plugins/view/geofamclose.py:108
+#: ../gramps/plugins/view/geofamily.py:100
+#: ../gramps/plugins/view/geomoves.py:107
+#: ../gramps/plugins/view/geoperson.py:108
+#: ../gramps/plugins/view/geoplaces.py:103
+#: ../gramps/plugins/view/mediaview.py:253
+#: ../gramps/plugins/view/noteview.py:153
+#: ../gramps/plugins/view/pedigreeview.py:683
+#: ../gramps/plugins/view/relview.py:427 ../gramps/plugins/view/repoview.py:166
+#: ../gramps/plugins/view/sourceview.py:152
 msgid "Organize Bookmarks"
 msgstr ""
 
-#: ../gramps/gui/views/bookmarks.py:471
+#: ../gramps/gui/views/bookmarks.py:474
 msgid "Cannot bookmark this reference"
 msgstr ""
 
-#: ../gramps/gui/views/listview.py:212
-#: ../gramps/plugins/lib/libpersonview.py:391
-msgid "_Add..."
-msgstr ""
-
-#: ../gramps/gui/views/listview.py:216
-#: ../gramps/plugins/lib/libpersonview.py:395
-msgid "_Merge..."
-msgstr ""
-
-#: ../gramps/gui/views/listview.py:218
-#: ../gramps/plugins/lib/libpersonview.py:397
-msgid "Export View..."
-msgstr ""
-
-#: ../gramps/gui/views/listview.py:224
-#: ../gramps/plugins/lib/libpersonview.py:382
-msgid "action|_Edit..."
-msgstr ""
-
-#: ../gramps/gui/views/listview.py:449
+#: ../gramps/gui/views/listview.py:439
 msgid "Active object not visible"
 msgstr ""
 
-#: ../gramps/gui/views/listview.py:459
-#: ../gramps/gui/views/navigationview.py:257
-#: ../gramps/plugins/lib/maps/geography.py:204
-#: ../gramps/plugins/lib/maps/geography.py:220
-#: ../gramps/plugins/view/familyview.py:222
+#: ../gramps/gui/views/listview.py:449
+#: ../gramps/gui/views/navigationview.py:256
+#: ../gramps/plugins/lib/maps/geography.py:207
+#: ../gramps/plugins/lib/maps/geography.py:224
+#: ../gramps/plugins/view/familyview.py:347
 msgid "Could Not Set a Bookmark"
 msgstr ""
 
-#: ../gramps/gui/views/listview.py:460
+#: ../gramps/gui/views/listview.py:450
 msgid "A bookmark could not be set because nothing was selected."
 msgstr ""
 
-#: ../gramps/gui/views/listview.py:552
+#: ../gramps/gui/views/listview.py:542
 msgid "Multiple Selection Delete"
 msgstr ""
 
-#: ../gramps/gui/views/listview.py:553
+#: ../gramps/gui/views/listview.py:543
 msgid ""
 "More than one item has been selected for deletion. Select the option "
 "indicating how to delete the items:"
 msgstr ""
 
-#: ../gramps/gui/views/listview.py:555
+#: ../gramps/gui/views/listview.py:545
 msgid "Delete All"
 msgstr ""
 
-#: ../gramps/gui/views/listview.py:556
+#: ../gramps/gui/views/listview.py:546
 msgid "Confirm Each Delete"
 msgstr ""
 
-#: ../gramps/gui/views/listview.py:567
+#: ../gramps/gui/views/listview.py:561
 msgid ""
 "This item is currently being used. Deleting it will remove it from the "
 "database and from all other items that reference it."
 msgstr ""
 
-#: ../gramps/gui/views/listview.py:571 ../gramps/plugins/view/familyview.py:269
+#: ../gramps/gui/views/listview.py:565 ../gramps/plugins/view/eventview.py:407
+#: ../gramps/plugins/view/familyview.py:394
 msgid "Deleting item will remove it from the database."
 msgstr ""
 
-#: ../gramps/gui/views/listview.py:578
-#: ../gramps/plugins/lib/libpersonview.py:317
-#: ../gramps/plugins/view/familyview.py:262
+#: ../gramps/gui/views/listview.py:571
+#: ../gramps/plugins/lib/libpersonview.py:468
+#: ../gramps/plugins/view/familyview.py:387
 #, python-format
 msgid "Delete %s?"
 msgstr ""
 
-#: ../gramps/gui/views/listview.py:579
-msgid "_Delete Item"
-msgstr ""
-
-#: ../gramps/gui/views/listview.py:621
+#: ../gramps/gui/views/listview.py:620
 msgid "Column clicked, sorting..."
 msgstr ""
 
-#: ../gramps/gui/views/listview.py:1057
+#: ../gramps/gui/views/listview.py:1051
 msgid "Export View as Spreadsheet"
 msgstr ""
 
-#: ../gramps/gui/views/listview.py:1070
+#: ../gramps/gui/views/listview.py:1064
 msgid "CSV"
 msgstr ""
 
-#: ../gramps/gui/views/listview.py:1071
+#: ../gramps/gui/views/listview.py:1065
 msgid "OpenDocument Spreadsheet"
 msgstr ""
 
-#: ../gramps/gui/views/listview.py:1262
+#: ../gramps/gui/views/listview.py:1256
 msgid "Columns"
 msgstr ""
 
-#: ../gramps/gui/views/navigationview.py:253
+#: ../gramps/gui/views/navigationview.py:252
 #, python-format
 msgid "%s has been bookmarked"
 msgstr ""
 
-#: ../gramps/gui/views/navigationview.py:258
-#: ../gramps/plugins/lib/maps/geography.py:205
-#: ../gramps/plugins/lib/maps/geography.py:221
-#: ../gramps/plugins/view/familyview.py:223
+#: ../gramps/gui/views/navigationview.py:257
+#: ../gramps/plugins/lib/maps/geography.py:208
+#: ../gramps/plugins/lib/maps/geography.py:225
+#: ../gramps/plugins/view/familyview.py:348
 msgid "A bookmark could not be set because no one was selected."
 msgstr ""
 
-#: ../gramps/gui/views/navigationview.py:274
-msgid "_Add Bookmark"
-msgstr ""
-
-#: ../gramps/gui/views/navigationview.py:277
-#, python-format
-msgid "%(title)s..."
-msgstr ""
-
-#: ../gramps/gui/views/navigationview.py:295
-msgid "Go to the next object in the history"
-msgstr ""
-
-#: ../gramps/gui/views/navigationview.py:302
-msgid "_Back"
-msgstr ""
-
-#: ../gramps/gui/views/navigationview.py:303
-msgid "Go to the previous object in the history"
-msgstr ""
-
-#: ../gramps/gui/views/navigationview.py:307
-#: ../gramps/plugins/view/pedigreeview.py:1580
-msgid "_Home"
-msgstr ""
-
-#: ../gramps/gui/views/navigationview.py:309
-msgid "Go to the default person"
-msgstr ""
-
-#: ../gramps/gui/views/navigationview.py:313
-msgid "Set _Home Person"
-msgstr ""
-
-#: ../gramps/gui/views/navigationview.py:338
+#: ../gramps/gui/views/navigationview.py:323
 msgid "No Home Person"
 msgstr ""
 
-#: ../gramps/gui/views/navigationview.py:339
+#: ../gramps/gui/views/navigationview.py:324
 msgid ""
 "You need to set a 'default person' to go to. Select the People View, select "
 "the person you want as 'Home Person', then confirm your choice via the menu "
 "Edit ->Set Home Person."
 msgstr ""
 
-#: ../gramps/gui/views/navigationview.py:349
-#: ../gramps/gui/views/navigationview.py:352
+#: ../gramps/gui/views/navigationview.py:334
+#: ../gramps/gui/views/navigationview.py:337
 msgid "Jump to by Gramps ID"
 msgstr ""
 
-#: ../gramps/gui/views/navigationview.py:376
+#: ../gramps/gui/views/navigationview.py:361
 #, python-format
 msgid "Error: %s is not a valid Gramps ID"
 msgstr ""
 
-#: ../gramps/gui/views/pageview.py:438
-msgid "_Sidebar"
-msgstr ""
-
-#: ../gramps/gui/views/pageview.py:441
+#: ../gramps/gui/views/pageview.py:103
 msgid "_Bottombar"
 msgstr ""
 
-#: ../gramps/gui/views/pageview.py:577
+#: ../gramps/gui/views/pageview.py:103
+msgid "_Sidebar"
+msgstr ""
+
+#: ../gramps/gui/views/pageview.py:562
 #, python-format
 msgid "Configure %(cat)s - %(view)s"
 msgstr ""
 
-#: ../gramps/gui/views/pageview.py:594
+#: ../gramps/gui/views/pageview.py:579
 #, python-format
 msgid "%(cat)s - %(view)s"
 msgstr ""
 
-#: ../gramps/gui/views/pageview.py:614
+#: ../gramps/gui/views/pageview.py:599
 #, python-format
 msgid "Configure %s View"
 msgstr ""
 
 #. top widget at the top
-#: ../gramps/gui/views/pageview.py:628
+#: ../gramps/gui/views/pageview.py:613
 #, python-format
 msgid "View %(name)s: %(msg)s"
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:87
-msgid "manual|Organize_Tags_Window"
-msgstr ""
-
-#: ../gramps/gui/views/tags.py:88
-msgid "manual|New_Tag_dialog"
-msgstr ""
-
-#: ../gramps/gui/views/tags.py:227
-msgid "New Tag..."
-msgstr ""
-
-#: ../gramps/gui/views/tags.py:229
-msgid "Organize Tags..."
-msgstr ""
-
-#: ../gramps/gui/views/tags.py:232
+#: ../gramps/gui/views/tags.py:71
 msgid "Tag selected rows"
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:272
+#: ../gramps/gui/views/tags.py:93
+msgid "New Tag..."
+msgstr ""
+
+#: ../gramps/gui/views/tags.py:93
+msgid "Organize Tags..."
+msgstr ""
+
+#: ../gramps/gui/views/tags.py:112
+msgid "manual|Organize_Tags_Window"
+msgstr ""
+
+#: ../gramps/gui/views/tags.py:113
+msgid "manual|New_Tag_dialog"
+msgstr ""
+
+#: ../gramps/gui/views/tags.py:306
 msgid "Adding Tags"
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:277
+#: ../gramps/gui/views/tags.py:311
 #, python-format
 msgid "Tag Selection (%s)"
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:326 ../gramps/gui/views/tags.py:334
-#: ../gramps/gui/views/tags.py:402
+#: ../gramps/gui/views/tags.py:360 ../gramps/gui/views/tags.py:368
+#: ../gramps/gui/views/tags.py:436
 msgid "Organize Tags"
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:353
+#: ../gramps/gui/views/tags.py:387
 msgid "Change Tag Priority"
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:495
+#: ../gramps/gui/views/tags.py:529
 #, python-format
 msgid "Remove tag '%s'?"
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:496
+#: ../gramps/gui/views/tags.py:530
 msgid ""
 "The tag definition will be removed.  The tag will be also removed from all "
 "objects in the database."
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:528
+#: ../gramps/gui/views/tags.py:562
 msgid "Removing Tags"
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:533
+#: ../gramps/gui/views/tags.py:567
 #, python-format
 msgid "Delete Tag (%s)"
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:558
+#: ../gramps/gui/views/tags.py:592
 #, python-format
 msgid "Tag: %s"
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:560
+#: ../gramps/gui/views/tags.py:594
 msgid "New Tag"
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:607
+#: ../gramps/gui/views/tags.py:641
 msgid "Cannot save tag"
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:608
+#: ../gramps/gui/views/tags.py:642
 msgid "The tag name cannot be empty"
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:613
+#: ../gramps/gui/views/tags.py:647
 #, python-format
 msgid "Add Tag (%s)"
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:619
+#: ../gramps/gui/views/tags.py:653
 #, python-format
 msgid "Edit Tag (%s)"
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:634
+#: ../gramps/gui/views/tags.py:668
 msgid "Tag Name:"
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:641
+#: ../gramps/gui/views/tags.py:675
 #, python-format
 msgid "%(title)s - Gramps"
 msgstr ""
 
-#: ../gramps/gui/views/tags.py:641
+#: ../gramps/gui/views/tags.py:675
 msgid "Pick a Color"
 msgstr ""
 
@@ -18082,112 +18345,120 @@ msgstr ""
 msgid "Collapse this section"
 msgstr ""
 
-#: ../gramps/gui/widgets/fanchart.py:1564 ../gramps/plugins/view/relview.py:807
+#: ../gramps/gui/widgets/fanchart.py:1825 ../gramps/plugins/view/relview.py:966
 msgid "Edit family"
 msgstr ""
 
-#: ../gramps/gui/widgets/fanchart.py:1580 ../gramps/plugins/view/relview.py:808
+#: ../gramps/gui/widgets/fanchart.py:1841 ../gramps/plugins/view/relview.py:967
 msgid "Reorder families"
 msgstr ""
 
-#: ../gramps/gui/widgets/fanchart.py:1586
-#: ../gramps/plugins/view/pedigreeview.py:1670
-#: ../gramps/plugins/view/pedigreeview.py:1898
+#: ../gramps/gui/widgets/fanchart.py:1847
+#: ../gramps/plugins/view/pedigreeview.py:1743
+#: ../gramps/plugins/view/pedigreeview.py:1971
 msgid "_Copy"
 msgstr ""
 
 #. Go over siblings and build their menu
-#: ../gramps/gui/widgets/fanchart.py:1630
+#: ../gramps/gui/widgets/fanchart.py:1891
 #: ../gramps/plugins/quickview/quickview.gpr.py:319
-#: ../gramps/plugins/view/pedigreeview.py:1714
-#: ../gramps/plugins/view/relview.py:908
+#: ../gramps/plugins/view/pedigreeview.py:1787
+#: ../gramps/plugins/view/relview.py:1068
 msgid "Siblings"
 msgstr ""
 
 #. Go over parents and build their menu
-#: ../gramps/gui/widgets/fanchart.py:1768
-#: ../gramps/plugins/view/pedigreeview.py:1841
+#: ../gramps/gui/widgets/fanchart.py:2037
+#: ../gramps/plugins/view/pedigreeview.py:1914
 msgid "Related"
 msgstr ""
 
-#: ../gramps/gui/widgets/fanchart.py:1816
+#: ../gramps/gui/widgets/fanchart.py:2085
 msgid "Add partner to person"
 msgstr ""
 
-#: ../gramps/gui/widgets/fanchart.py:1823
+#: ../gramps/gui/widgets/fanchart.py:2092
 msgid "Add a person"
 msgstr ""
 
-#: ../gramps/gui/widgets/fanchart.py:1898
-#: ../gramps/plugins/view/relview.py:1538
+#: ../gramps/gui/widgets/fanchart.py:2182
+#: ../gramps/plugins/view/relview.py:1709
 msgid "Add Child to Family"
 msgstr ""
 
-#: ../gramps/gui/widgets/grampletbar.py:206
-#: ../gramps/gui/widgets/grampletpane.py:1188
+#: ../gramps/gui/widgets/grampletbar.py:118
+msgid "Gramplet Bar Menu"
+msgstr ""
+
+#: ../gramps/gui/widgets/grampletbar.py:207
+#: ../gramps/gui/widgets/grampletpane.py:1190
 msgid "Unnamed Gramplet"
 msgstr ""
 
-#: ../gramps/gui/widgets/grampletbar.py:358
+#: ../gramps/gui/widgets/grampletbar.py:359
 msgid "Gramplet Bar"
 msgstr ""
 
-#: ../gramps/gui/widgets/grampletbar.py:360
+#: ../gramps/gui/widgets/grampletbar.py:361
 msgid ""
 "Select the down arrow on the right corner for adding, removing or restoring "
 "gramplets."
 msgstr ""
 
-#: ../gramps/gui/widgets/grampletbar.py:486
-#: ../gramps/plugins/view/dashboardview.py:100
+#: ../gramps/gui/widgets/grampletbar.py:487
+#: ../gramps/gui/widgets/grampletpane.py:1442
 msgid "Add a gramplet"
 msgstr ""
 
-#: ../gramps/gui/widgets/grampletbar.py:496
+#: ../gramps/gui/widgets/grampletbar.py:497
 msgid "Remove a gramplet"
 msgstr ""
 
-#: ../gramps/gui/widgets/grampletbar.py:506
+#: ../gramps/gui/widgets/grampletbar.py:507
 msgid "Restore default gramplets"
 msgstr ""
 
-#: ../gramps/gui/widgets/grampletbar.py:545
+#: ../gramps/gui/widgets/grampletbar.py:546
 msgid "Restore to defaults?"
 msgstr ""
 
-#: ../gramps/gui/widgets/grampletbar.py:546
+#: ../gramps/gui/widgets/grampletbar.py:547
 msgid ""
 "The gramplet bar will be restored to contain its default gramplets.  This "
 "action cannot be undone."
 msgstr ""
 
 #. default tooltip
-#: ../gramps/gui/widgets/grampletpane.py:810
+#: ../gramps/gui/widgets/grampletpane.py:814
 msgid "Drag Properties Button to move and click it for setup"
 msgstr ""
 
 #. build the GUI:
-#: ../gramps/gui/widgets/grampletpane.py:1006
+#: ../gramps/gui/widgets/grampletpane.py:1012
 msgid "Right click to add gramplets"
 msgstr ""
 
-#: ../gramps/gui/widgets/grampletpane.py:1053
+#: ../gramps/gui/widgets/grampletpane.py:1055
 msgid "Untitled Gramplet"
 msgstr ""
 
-#: ../gramps/gui/widgets/grampletpane.py:1540
+#: ../gramps/gui/widgets/grampletpane.py:1442
+msgid "Restore a gramplet"
+msgstr ""
+
+#: ../gramps/gui/widgets/grampletpane.py:1573
 msgid "Number of Columns"
 msgstr ""
 
-#: ../gramps/gui/widgets/grampletpane.py:1545
+#: ../gramps/gui/widgets/grampletpane.py:1578
 msgid "Gramplet Layout"
 msgstr ""
 
-#: ../gramps/gui/widgets/grampletpane.py:1575
+#: ../gramps/gui/widgets/grampletpane.py:1608
 msgid "Use maximum height available"
 msgstr ""
 
-#: ../gramps/gui/widgets/grampletpane.py:1581
+#: ../gramps/gui/widgets/grampletpane.py:1614
 msgid "Height if not maximized"
 msgstr ""
 
@@ -18212,7 +18483,7 @@ msgid ""
 "application."
 msgstr ""
 
-#: ../gramps/gui/widgets/photo.py:87
+#: ../gramps/gui/widgets/photo.py:88
 msgid "Make Active Media"
 msgstr ""
 
@@ -18240,89 +18511,86 @@ msgstr ""
 msgid "Reorder Relationships: %s"
 msgstr ""
 
-#: ../gramps/gui/widgets/styledtexteditor.py:317
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Background Color"
+msgstr ""
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Clear Markup"
+msgstr ""
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Font Color"
+msgstr ""
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Redo"
+msgstr ""
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Undo"
+msgstr ""
+
+#: ../gramps/gui/widgets/styledtexteditor.py:401
 msgid ""
 "\n"
 "Command-Click to follow link"
 msgstr ""
 
-#: ../gramps/gui/widgets/styledtexteditor.py:318
+#: ../gramps/gui/widgets/styledtexteditor.py:402
 msgid ""
 "\n"
 "Ctrl-Click to follow link"
 msgstr ""
 
 #. spell checker submenu
-#: ../gramps/gui/widgets/styledtexteditor.py:366
+#: ../gramps/gui/widgets/styledtexteditor.py:450
 msgid "Spellcheck"
 msgstr ""
 
-#: ../gramps/gui/widgets/styledtexteditor.py:371
+#: ../gramps/gui/widgets/styledtexteditor.py:455
 msgid "Search selection on web"
 msgstr ""
 
-#: ../gramps/gui/widgets/styledtexteditor.py:382
+#: ../gramps/gui/widgets/styledtexteditor.py:466
 msgid "_Send Mail To..."
 msgstr ""
 
-#: ../gramps/gui/widgets/styledtexteditor.py:384
+#: ../gramps/gui/widgets/styledtexteditor.py:468
 msgid "Copy _E-mail Address"
 msgstr ""
 
-#: ../gramps/gui/widgets/styledtexteditor.py:387
+#: ../gramps/gui/widgets/styledtexteditor.py:471
 msgid "_Open Link"
 msgstr ""
 
-#: ../gramps/gui/widgets/styledtexteditor.py:389
+#: ../gramps/gui/widgets/styledtexteditor.py:473
 msgid "Copy _Link Address"
 msgstr ""
 
-#: ../gramps/gui/widgets/styledtexteditor.py:393
+#: ../gramps/gui/widgets/styledtexteditor.py:477
 msgid "_Edit Link"
 msgstr ""
 
-#: ../gramps/gui/widgets/styledtexteditor.py:465
-msgid "Font Color"
-msgstr ""
-
-#: ../gramps/gui/widgets/styledtexteditor.py:467
-msgid "Background Color"
-msgstr ""
-
-#: ../gramps/gui/widgets/styledtexteditor.py:471
-#: ../gramps/gui/widgets/styledtexteditor.py:472
-msgid "Clear Markup"
-msgstr ""
-
-#: ../gramps/gui/widgets/styledtexteditor.py:512
-#: ../gramps/gui/widgets/styledtexteditor.py:513
-msgid "Undo"
-msgstr ""
-
-#: ../gramps/gui/widgets/styledtexteditor.py:516
-#: ../gramps/gui/widgets/styledtexteditor.py:517
-msgid "Redo"
-msgstr ""
-
-#: ../gramps/gui/widgets/styledtexteditor.py:644
+#: ../gramps/gui/widgets/styledtexteditor.py:697
 msgid "Select font color"
 msgstr ""
 
-#: ../gramps/gui/widgets/styledtexteditor.py:648
+#: ../gramps/gui/widgets/styledtexteditor.py:701
 msgid "Select background color"
 msgstr ""
 
-#: ../gramps/gui/widgets/validatedmaskedentry.py:1154
+#: ../gramps/gui/widgets/validatedmaskedentry.py:1140
 #, python-format
 msgid "'%s' is not a valid value for this field"
 msgstr ""
 
-#: ../gramps/gui/widgets/validatedmaskedentry.py:1197
+#: ../gramps/gui/widgets/validatedmaskedentry.py:1179
 msgid "This field is mandatory"
 msgstr ""
 
 #. used on AgeOnDateGramplet
-#: ../gramps/gui/widgets/validatedmaskedentry.py:1246
+#: ../gramps/gui/widgets/validatedmaskedentry.py:1228
 #, python-format
 msgid "'%s' is not a valid date value"
 msgstr ""
@@ -18571,14 +18839,14 @@ msgid "of %d"
 msgstr ""
 
 #: ../gramps/plugins/docgen/htmldoc.py:273
-#: ../gramps/plugins/webreport/narrativeweb.py:1485
-#: ../gramps/plugins/webreport/webcal.py:274
+#: ../gramps/plugins/webreport/narrativeweb.py:1517
+#: ../gramps/plugins/webreport/webcal.py:270
 msgid "Possible destination error"
 msgstr ""
 
 #: ../gramps/plugins/docgen/htmldoc.py:274
-#: ../gramps/plugins/webreport/narrativeweb.py:1486
-#: ../gramps/plugins/webreport/webcal.py:275
+#: ../gramps/plugins/webreport/narrativeweb.py:1518
+#: ../gramps/plugins/webreport/webcal.py:271
 msgid ""
 "You appear to have set your target directory to a directory used for data "
 "storage. This could create problems with file management. It is recommended "
@@ -18665,15 +18933,15 @@ msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:362
 #: ../gramps/plugins/drawreport/calendarreport.py:114
-#: ../gramps/plugins/drawreport/descendtree.py:690
+#: ../gramps/plugins/drawreport/descendtree.py:689
 #: ../gramps/plugins/drawreport/fanchart.py:194
-#: ../gramps/plugins/graph/gvhourglass.py:106
-#: ../gramps/plugins/graph/gvrelgraph.py:181
+#: ../gramps/plugins/graph/gvhourglass.py:109
+#: ../gramps/plugins/graph/gvrelgraph.py:184
 #: ../gramps/plugins/textreport/ancestorreport.py:117
-#: ../gramps/plugins/textreport/birthdayreport.py:111
+#: ../gramps/plugins/textreport/birthdayreport.py:115
 #: ../gramps/plugins/textreport/descendreport.py:453
-#: ../gramps/plugins/textreport/detancestralreport.py:166
-#: ../gramps/plugins/textreport/detdescendantreport.py:183
+#: ../gramps/plugins/textreport/detancestralreport.py:167
+#: ../gramps/plugins/textreport/detdescendantreport.py:184
 #: ../gramps/plugins/textreport/endoflinereport.py:91
 #: ../gramps/plugins/textreport/kinshipreport.py:106
 #: ../gramps/plugins/textreport/numberofancestorsreport.py:84
@@ -18698,12 +18966,12 @@ msgstr ""
 #: ../gramps/plugins/drawreport/ancestortree.py:793
 #: ../gramps/plugins/drawreport/calendarreport.py:472
 #: ../gramps/plugins/drawreport/fanchart.py:689
-#: ../gramps/plugins/graph/gvhourglass.py:317
-#: ../gramps/plugins/graph/gvrelgraph.py:774
+#: ../gramps/plugins/graph/gvhourglass.py:366
+#: ../gramps/plugins/graph/gvrelgraph.py:807
 #: ../gramps/plugins/textreport/ancestorreport.py:290
 #: ../gramps/plugins/textreport/descendreport.py:522
-#: ../gramps/plugins/textreport/detancestralreport.py:824
-#: ../gramps/plugins/textreport/detdescendantreport.py:1001
+#: ../gramps/plugins/textreport/detancestralreport.py:831
+#: ../gramps/plugins/textreport/detdescendantreport.py:1006
 #: ../gramps/plugins/textreport/endoflinereport.py:272
 #: ../gramps/plugins/textreport/kinshipreport.py:358
 #: ../gramps/plugins/textreport/numberofancestorsreport.py:204
@@ -18724,17 +18992,17 @@ msgid ""
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:804
-#: ../gramps/plugins/drawreport/descendtree.py:1539
+#: ../gramps/plugins/drawreport/descendtree.py:1538
 #: ../gramps/plugins/drawreport/fanchart.py:693
 #: ../gramps/plugins/textreport/ancestorreport.py:294
 #: ../gramps/plugins/textreport/descendreport.py:537
-#: ../gramps/plugins/textreport/detancestralreport.py:833
-#: ../gramps/plugins/textreport/detdescendantreport.py:1024
+#: ../gramps/plugins/textreport/detancestralreport.py:840
+#: ../gramps/plugins/textreport/detdescendantreport.py:1029
 msgid "Generations"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:805
-#: ../gramps/plugins/drawreport/descendtree.py:1540
+#: ../gramps/plugins/drawreport/descendtree.py:1539
 msgid "The number of generations to include in the tree"
 msgstr ""
 
@@ -18749,7 +19017,7 @@ msgid "The number of generations of empty boxes that will be displayed"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:818
-#: ../gramps/plugins/drawreport/descendtree.py:1557
+#: ../gramps/plugins/drawreport/descendtree.py:1556
 msgid "Compress tree"
 msgstr ""
 
@@ -18760,13 +19028,13 @@ msgid ""
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:837
-#: ../gramps/plugins/drawreport/descendtree.py:1576
+#: ../gramps/plugins/drawreport/descendtree.py:1575
 msgid "Report Title"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:838
-#: ../gramps/plugins/drawreport/descendtree.py:1577
-#: ../gramps/plugins/drawreport/descendtree.py:1750
+#: ../gramps/plugins/drawreport/descendtree.py:1576
+#: ../gramps/plugins/drawreport/descendtree.py:1749
 msgid "Do not include a title"
 msgstr ""
 
@@ -18775,22 +19043,22 @@ msgid "Include Report Title"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:840
-#: ../gramps/plugins/drawreport/descendtree.py:1585
+#: ../gramps/plugins/drawreport/descendtree.py:1584
 msgid "Choose a title for the report"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:843
-#: ../gramps/plugins/drawreport/descendtree.py:1589
+#: ../gramps/plugins/drawreport/descendtree.py:1588
 msgid "Include a border"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:844
-#: ../gramps/plugins/drawreport/descendtree.py:1590
+#: ../gramps/plugins/drawreport/descendtree.py:1589
 msgid "Whether to make a border around the report."
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:847
-#: ../gramps/plugins/drawreport/descendtree.py:1593
+#: ../gramps/plugins/drawreport/descendtree.py:1592
 msgid "Include Page Numbers"
 msgstr ""
 
@@ -18799,32 +19067,32 @@ msgid "Whether to print page numbers on each page."
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:851
-#: ../gramps/plugins/drawreport/descendtree.py:1597
+#: ../gramps/plugins/drawreport/descendtree.py:1596
 msgid "Scale tree to fit"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:852
-#: ../gramps/plugins/drawreport/descendtree.py:1598
+#: ../gramps/plugins/drawreport/descendtree.py:1597
 msgid "Do not scale tree"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:853
-#: ../gramps/plugins/drawreport/descendtree.py:1599
+#: ../gramps/plugins/drawreport/descendtree.py:1598
 msgid "Scale tree to fit page width only"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:854
-#: ../gramps/plugins/drawreport/descendtree.py:1600
+#: ../gramps/plugins/drawreport/descendtree.py:1599
 msgid "Scale tree to fit the size of the page"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:856
-#: ../gramps/plugins/drawreport/descendtree.py:1602
+#: ../gramps/plugins/drawreport/descendtree.py:1601
 msgid "Whether to scale the tree to fit a specific paper size"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:863
-#: ../gramps/plugins/drawreport/descendtree.py:1609
+#: ../gramps/plugins/drawreport/descendtree.py:1608
 msgid ""
 "Resize Page to Fit Tree size\n"
 "\n"
@@ -18832,7 +19100,7 @@ msgid ""
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:869
-#: ../gramps/plugins/drawreport/descendtree.py:1615
+#: ../gramps/plugins/drawreport/descendtree.py:1614
 msgid ""
 "Whether to resize the page to fit the size \n"
 "of the tree.  Note:  the page will have a \n"
@@ -18851,12 +19119,12 @@ msgid ""
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:889
-#: ../gramps/plugins/drawreport/descendtree.py:1635
+#: ../gramps/plugins/drawreport/descendtree.py:1634
 msgid "Include Blank Pages"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:890
-#: ../gramps/plugins/drawreport/descendtree.py:1636
+#: ../gramps/plugins/drawreport/descendtree.py:1635
 msgid "Whether to include pages that are blank."
 msgstr ""
 
@@ -18870,24 +19138,24 @@ msgstr ""
 #. ###############################
 #: ../gramps/plugins/drawreport/ancestortree.py:896
 #: ../gramps/plugins/drawreport/calendarreport.py:490
-#: ../gramps/plugins/drawreport/descendtree.py:1640
+#: ../gramps/plugins/drawreport/descendtree.py:1639
 #: ../gramps/plugins/drawreport/fanchart.py:730
-#: ../gramps/plugins/drawreport/statisticschart.py:1056
+#: ../gramps/plugins/drawreport/statisticschart.py:1074
 #: ../gramps/plugins/drawreport/timeline.py:435
-#: ../gramps/plugins/graph/gvfamilylines.py:162
-#: ../gramps/plugins/graph/gvhourglass.py:352
-#: ../gramps/plugins/graph/gvrelgraph.py:802
+#: ../gramps/plugins/graph/gvfamilylines.py:169
+#: ../gramps/plugins/graph/gvhourglass.py:402
+#: ../gramps/plugins/graph/gvrelgraph.py:841
 #: ../gramps/plugins/textreport/ancestorreport.py:310
-#: ../gramps/plugins/textreport/birthdayreport.py:441
+#: ../gramps/plugins/textreport/birthdayreport.py:500
 #: ../gramps/plugins/textreport/descendreport.py:557
-#: ../gramps/plugins/textreport/detancestralreport.py:849
-#: ../gramps/plugins/textreport/detdescendantreport.py:1040
+#: ../gramps/plugins/textreport/detancestralreport.py:856
+#: ../gramps/plugins/textreport/detdescendantreport.py:1045
 #: ../gramps/plugins/textreport/familygroup.py:732
 #: ../gramps/plugins/textreport/indivcomplete.py:1083
 #: ../gramps/plugins/textreport/kinshipreport.py:382
 #: ../gramps/plugins/textreport/placereport.py:462
 #: ../gramps/plugins/textreport/recordsreport.py:243
-#: ../gramps/plugins/webreport/webcal.py:1671
+#: ../gramps/plugins/webreport/webcal.py:1709
 msgid "Report Options (2)"
 msgstr ""
 
@@ -18936,43 +19204,43 @@ msgid "The display format for the center person"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:941
-#: ../gramps/plugins/drawreport/descendtree.py:1676
+#: ../gramps/plugins/drawreport/descendtree.py:1675
 msgid "Include Marriage box"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:943
-#: ../gramps/plugins/drawreport/descendtree.py:1678
+#: ../gramps/plugins/drawreport/descendtree.py:1677
 msgid "Whether to include a separate marital box in the report"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:947
-#: ../gramps/plugins/drawreport/descendtree.py:1682
+#: ../gramps/plugins/drawreport/descendtree.py:1681
 msgid ""
 "Marriage\n"
 "Display Format"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:949
-#: ../gramps/plugins/drawreport/descendtree.py:1684
+#: ../gramps/plugins/drawreport/descendtree.py:1683
 msgid "Display format for the marital box."
 msgstr ""
 
 #. #################
 #: ../gramps/plugins/drawreport/ancestortree.py:954
-#: ../gramps/plugins/drawreport/descendtree.py:1689
+#: ../gramps/plugins/drawreport/descendtree.py:1688
 #: ../gramps/plugins/lib/libmetadata.py:104
 msgid "Advanced"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:957
-#: ../gramps/plugins/drawreport/descendtree.py:1692
+#: ../gramps/plugins/drawreport/descendtree.py:1691
 msgid ""
 "Replace Display Format:\n"
 "'Replace this'/' with this'"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:959
-#: ../gramps/plugins/drawreport/descendtree.py:1694
+#: ../gramps/plugins/drawreport/descendtree.py:1693
 msgid ""
 "i.e.\n"
 "United States of America/U.S.A"
@@ -18985,17 +19253,17 @@ msgstr ""
 #. _("Whether to include thumbnails of people."))
 #. menu.add_option(category_name, "includeImages", self.__include_images)
 #: ../gramps/plugins/drawreport/ancestortree.py:969
-#: ../gramps/plugins/drawreport/descendtree.py:1697
+#: ../gramps/plugins/drawreport/descendtree.py:1696
 msgid "Include a note"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:970
-#: ../gramps/plugins/drawreport/descendtree.py:1698
+#: ../gramps/plugins/drawreport/descendtree.py:1697
 msgid "Whether to include a note on the report."
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:975
-#: ../gramps/plugins/drawreport/descendtree.py:1703
+#: ../gramps/plugins/drawreport/descendtree.py:1702
 msgid ""
 "Add a note\n"
 "\n"
@@ -19003,12 +19271,12 @@ msgid ""
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:980
-#: ../gramps/plugins/drawreport/descendtree.py:1708
+#: ../gramps/plugins/drawreport/descendtree.py:1707
 msgid "Note Location"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:983
-#: ../gramps/plugins/drawreport/descendtree.py:1711
+#: ../gramps/plugins/drawreport/descendtree.py:1710
 msgid "Where to place the note."
 msgstr ""
 
@@ -19021,13 +19289,13 @@ msgid "Make the inter-box spacing bigger or smaller"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:993
-#: ../gramps/plugins/drawreport/descendtree.py:1720
+#: ../gramps/plugins/drawreport/descendtree.py:1719
 msgid "box shadow scale factor"
 msgstr ""
 
 #. down to 0
 #: ../gramps/plugins/drawreport/ancestortree.py:995
-#: ../gramps/plugins/drawreport/descendtree.py:1722
+#: ../gramps/plugins/drawreport/descendtree.py:1721
 msgid "Make the box shadow bigger or smaller"
 msgstr ""
 
@@ -19044,13 +19312,13 @@ msgid " Generations of empty boxes for unknown ancestors"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:1049
-#: ../gramps/plugins/drawreport/descendtree.py:1782
+#: ../gramps/plugins/drawreport/descendtree.py:1781
 #: ../gramps/plugins/drawreport/fanchart.py:771
 #: ../gramps/plugins/drawreport/timeline.py:480
 #: ../gramps/plugins/textreport/alphabeticalindex.py:120
 #: ../gramps/plugins/textreport/ancestorreport.py:386
-#: ../gramps/plugins/textreport/detancestralreport.py:1021
-#: ../gramps/plugins/textreport/detdescendantreport.py:1226
+#: ../gramps/plugins/textreport/detancestralreport.py:1028
+#: ../gramps/plugins/textreport/detdescendantreport.py:1231
 #: ../gramps/plugins/textreport/endoflinereport.py:317
 #: ../gramps/plugins/textreport/familygroup.py:878
 #: ../gramps/plugins/textreport/indivcomplete.py:1237
@@ -19065,22 +19333,22 @@ msgid "The basic style used for the text display."
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:1059
-#: ../gramps/plugins/drawreport/descendtree.py:1802
+#: ../gramps/plugins/drawreport/descendtree.py:1801
 #: ../gramps/plugins/textreport/familygroup.py:890
 #: ../gramps/plugins/textreport/tagreport.py:993
 msgid "The basic style used for the note display."
 msgstr ""
 
 #: ../gramps/plugins/drawreport/ancestortree.py:1068
-#: ../gramps/plugins/drawreport/descendtree.py:1773
+#: ../gramps/plugins/drawreport/descendtree.py:1772
 #: ../gramps/plugins/drawreport/fanchart.py:761
-#: ../gramps/plugins/drawreport/statisticschart.py:1141
+#: ../gramps/plugins/drawreport/statisticschart.py:1159
 #: ../gramps/plugins/drawreport/timeline.py:498
 #: ../gramps/plugins/textreport/alphabeticalindex.py:103
 #: ../gramps/plugins/textreport/ancestorreport.py:363
 #: ../gramps/plugins/textreport/descendreport.py:584
-#: ../gramps/plugins/textreport/detancestralreport.py:973
-#: ../gramps/plugins/textreport/detdescendantreport.py:1178
+#: ../gramps/plugins/textreport/detancestralreport.py:980
+#: ../gramps/plugins/textreport/detdescendantreport.py:1183
 #: ../gramps/plugins/textreport/endoflinereport.py:299
 #: ../gramps/plugins/textreport/familygroup.py:869
 #: ../gramps/plugins/textreport/indivcomplete.py:1205
@@ -19114,13 +19382,13 @@ msgid "Calendar Report"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:200
-#: ../gramps/plugins/textreport/birthdayreport.py:221
+#: ../gramps/plugins/textreport/birthdayreport.py:225
 msgid "Formatting months..."
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:316
-#: ../gramps/plugins/textreport/birthdayreport.py:266
-#: ../gramps/plugins/webreport/webcal.py:1282
+#: ../gramps/plugins/textreport/birthdayreport.py:270
+#: ../gramps/plugins/webreport/webcal.py:1285
 msgid "Reading database..."
 msgstr ""
 
@@ -19138,7 +19406,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:421
-#: ../gramps/plugins/textreport/birthdayreport.py:376
 #, python-format
 msgid ""
 "%(spouse)s and\n"
@@ -19147,7 +19414,6 @@ msgstr ""
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/drawreport/calendarreport.py:427
-#: ../gramps/plugins/textreport/birthdayreport.py:381
 #, python-brace-format
 msgid ""
 "{spouse} and\n"
@@ -19159,17 +19425,17 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:468
-#: ../gramps/plugins/webreport/webcal.py:1635
+#: ../gramps/plugins/webreport/webcal.py:1673
 msgid "Select filter to restrict people that appear on calendar"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:473
 #: ../gramps/plugins/drawreport/fanchart.py:690
-#: ../gramps/plugins/graph/gvrelgraph.py:775
+#: ../gramps/plugins/graph/gvrelgraph.py:808
 #: ../gramps/plugins/textreport/ancestorreport.py:291
 #: ../gramps/plugins/textreport/descendreport.py:523
-#: ../gramps/plugins/textreport/detancestralreport.py:825
-#: ../gramps/plugins/textreport/detdescendantreport.py:1002
+#: ../gramps/plugins/textreport/detancestralreport.py:832
+#: ../gramps/plugins/textreport/detdescendantreport.py:1007
 #: ../gramps/plugins/textreport/endoflinereport.py:273
 #: ../gramps/plugins/textreport/kinshipreport.py:359
 #: ../gramps/plugins/textreport/numberofancestorsreport.py:205
@@ -19177,7 +19443,7 @@ msgid "The center person for the report"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:477
-#: ../gramps/plugins/textreport/birthdayreport.py:429
+#: ../gramps/plugins/textreport/birthdayreport.py:488
 msgid "Text Area 1"
 msgstr ""
 
@@ -19186,7 +19452,7 @@ msgid "First line of text at bottom of calendar"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:481
-#: ../gramps/plugins/textreport/birthdayreport.py:433
+#: ../gramps/plugins/textreport/birthdayreport.py:492
 msgid "Text Area 2"
 msgstr ""
 
@@ -19195,7 +19461,7 @@ msgid "Second line of text at bottom of calendar"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:485
-#: ../gramps/plugins/textreport/birthdayreport.py:437
+#: ../gramps/plugins/textreport/birthdayreport.py:496
 msgid "Text Area 3"
 msgstr ""
 
@@ -19204,13 +19470,13 @@ msgid "Third line of text at bottom of calendar"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:501
-#: ../gramps/plugins/textreport/birthdayreport.py:448
-#: ../gramps/plugins/webreport/webcal.py:1691
+#: ../gramps/plugins/textreport/birthdayreport.py:507
+#: ../gramps/plugins/webreport/webcal.py:1729
 msgid "Include only living people"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:502
-#: ../gramps/plugins/webreport/webcal.py:1692
+#: ../gramps/plugins/webreport/webcal.py:1730
 msgid "Include only living people in the calendar"
 msgstr ""
 
@@ -19218,10 +19484,10 @@ msgstr ""
 #. Content options
 #. Content
 #: ../gramps/plugins/drawreport/calendarreport.py:508
-#: ../gramps/plugins/textreport/birthdayreport.py:456
-#: ../gramps/plugins/textreport/detancestralreport.py:866
-#: ../gramps/plugins/textreport/detdescendantreport.py:1057
-#: ../gramps/plugins/view/relview.py:1703
+#: ../gramps/plugins/textreport/birthdayreport.py:523
+#: ../gramps/plugins/textreport/detancestralreport.py:873
+#: ../gramps/plugins/textreport/detdescendantreport.py:1062
+#: ../gramps/plugins/view/relview.py:1874
 msgid "Content"
 msgstr ""
 
@@ -19232,76 +19498,76 @@ msgid "Year of calendar"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:517
-#: ../gramps/plugins/textreport/birthdayreport.py:463
-#: ../gramps/plugins/webreport/webcal.py:1728
+#: ../gramps/plugins/textreport/birthdayreport.py:530
+#: ../gramps/plugins/webreport/webcal.py:1766
 msgid "Country for holidays"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:528
-#: ../gramps/plugins/textreport/birthdayreport.py:474
+#: ../gramps/plugins/textreport/birthdayreport.py:541
 msgid "Select the country to see associated holidays"
 msgstr ""
 
 #. Default selection ????
 #: ../gramps/plugins/drawreport/calendarreport.py:531
-#: ../gramps/plugins/webreport/webcal.py:1744
+#: ../gramps/plugins/webreport/webcal.py:1784
 msgid "First day of week"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:539
-#: ../gramps/plugins/webreport/webcal.py:1747
+#: ../gramps/plugins/webreport/webcal.py:1787
 msgid "Select the first day of the week for the calendar"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:542
-#: ../gramps/plugins/textreport/birthdayreport.py:477
-#: ../gramps/plugins/webreport/webcal.py:1751
+#: ../gramps/plugins/textreport/birthdayreport.py:544
+#: ../gramps/plugins/webreport/webcal.py:1791
 msgid "Birthday surname"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:545
-#: ../gramps/plugins/textreport/birthdayreport.py:480
-#: ../gramps/plugins/webreport/webcal.py:1752
+#: ../gramps/plugins/textreport/birthdayreport.py:547
+#: ../gramps/plugins/webreport/webcal.py:1792
 msgid "Wives use husband's surname (from first family listed)"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:548
-#: ../gramps/plugins/textreport/birthdayreport.py:483
-#: ../gramps/plugins/webreport/webcal.py:1754
+#: ../gramps/plugins/textreport/birthdayreport.py:550
+#: ../gramps/plugins/webreport/webcal.py:1794
 msgid "Wives use husband's surname (from last family listed)"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:549
-#: ../gramps/plugins/textreport/birthdayreport.py:484
-#: ../gramps/plugins/webreport/webcal.py:1756
+#: ../gramps/plugins/textreport/birthdayreport.py:551
+#: ../gramps/plugins/webreport/webcal.py:1796
 msgid "Wives use their own surname"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:550
-#: ../gramps/plugins/textreport/birthdayreport.py:485
-#: ../gramps/plugins/webreport/webcal.py:1757
+#: ../gramps/plugins/textreport/birthdayreport.py:552
+#: ../gramps/plugins/webreport/webcal.py:1797
 msgid "Select married women's displayed surname"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:553
-#: ../gramps/plugins/textreport/birthdayreport.py:488
-#: ../gramps/plugins/webreport/webcal.py:1767
+#: ../gramps/plugins/textreport/birthdayreport.py:555
+#: ../gramps/plugins/webreport/webcal.py:1882
 msgid "Include birthdays"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:554
-#: ../gramps/plugins/textreport/birthdayreport.py:489
+#: ../gramps/plugins/textreport/birthdayreport.py:556
 msgid "Whether to include birthdays"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:557
-#: ../gramps/plugins/textreport/birthdayreport.py:492
-#: ../gramps/plugins/webreport/webcal.py:1771
+#: ../gramps/plugins/textreport/birthdayreport.py:559
+#: ../gramps/plugins/webreport/webcal.py:1886
 msgid "Include anniversaries"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:558
-#: ../gramps/plugins/textreport/birthdayreport.py:493
+#: ../gramps/plugins/textreport/birthdayreport.py:560
 msgid "Whether to include anniversaries"
 msgstr ""
 
@@ -19326,17 +19592,17 @@ msgid "Days of the week text"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:643
-#: ../gramps/plugins/textreport/birthdayreport.py:578
+#: ../gramps/plugins/textreport/birthdayreport.py:649
 msgid "Text at bottom, line 1"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:645
-#: ../gramps/plugins/textreport/birthdayreport.py:580
+#: ../gramps/plugins/textreport/birthdayreport.py:651
 msgid "Text at bottom, line 2"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:647
-#: ../gramps/plugins/textreport/birthdayreport.py:582
+#: ../gramps/plugins/textreport/birthdayreport.py:653
 msgid "Text at bottom, line 3"
 msgstr ""
 
@@ -19389,88 +19655,88 @@ msgstr ""
 msgid "Cousin Chart for %(names)s"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:759
+#: ../gramps/plugins/drawreport/descendtree.py:758
 #, python-format
 msgid "Family %s is not in the Database"
 msgstr ""
 
 #. if self.name == "familial_descend_tree":
-#: ../gramps/plugins/drawreport/descendtree.py:1531
-#: ../gramps/plugins/drawreport/descendtree.py:1535
+#: ../gramps/plugins/drawreport/descendtree.py:1530
+#: ../gramps/plugins/drawreport/descendtree.py:1534
 msgid "Report for"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1532
+#: ../gramps/plugins/drawreport/descendtree.py:1531
 msgid "The main person for the report"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1536
+#: ../gramps/plugins/drawreport/descendtree.py:1535
 msgid "The main family for the report"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1543
+#: ../gramps/plugins/drawreport/descendtree.py:1542
 msgid "Level of Spouses"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1544
+#: ../gramps/plugins/drawreport/descendtree.py:1543
 msgid "0=no Spouses, 1=include Spouses, 2=include Spouses of the spouse, etc"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1549
+#: ../gramps/plugins/drawreport/descendtree.py:1548
 msgid "Start with the parent(s) of the selected first"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1552
+#: ../gramps/plugins/drawreport/descendtree.py:1551
 msgid "Will show the parents, brother and sisters of the selected person."
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1558
+#: ../gramps/plugins/drawreport/descendtree.py:1557
 msgid "Whether to move people up, where possible, resulting in a smaller tree"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1562
+#: ../gramps/plugins/drawreport/descendtree.py:1561
 msgid "Bold direct descendants"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1564
+#: ../gramps/plugins/drawreport/descendtree.py:1563
 msgid ""
 "Whether to bold those people that are direct (not step or half) descendants."
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1569
+#: ../gramps/plugins/drawreport/descendtree.py:1568
 msgid "Indent Spouses"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1570
+#: ../gramps/plugins/drawreport/descendtree.py:1569
 msgid "Whether to indent the spouses in the tree."
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1578
-#: ../gramps/plugins/drawreport/descendtree.py:1751
+#: ../gramps/plugins/drawreport/descendtree.py:1577
+#: ../gramps/plugins/drawreport/descendtree.py:1750
 msgid "Descendant Chart for [selected person(s)]"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1581
-#: ../gramps/plugins/drawreport/descendtree.py:1755
+#: ../gramps/plugins/drawreport/descendtree.py:1580
+#: ../gramps/plugins/drawreport/descendtree.py:1754
 msgid "Family Chart for [names of chosen family]"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1584
-#: ../gramps/plugins/drawreport/descendtree.py:1759
+#: ../gramps/plugins/drawreport/descendtree.py:1583
+#: ../gramps/plugins/drawreport/descendtree.py:1758
 msgid "Cousin Chart for [names of children]"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1594
+#: ../gramps/plugins/drawreport/descendtree.py:1593
 msgid "Whether to include page numbers on each page."
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1655
+#: ../gramps/plugins/drawreport/descendtree.py:1654
 msgid ""
 "Descendant\n"
 "Display Format"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1659
+#: ../gramps/plugins/drawreport/descendtree.py:1658
 msgid "Display format for a descendant."
 msgstr ""
 
@@ -19480,25 +19746,25 @@ msgstr ""
 #. True)
 #. diffspouse.set_help(_("Whether spouses can have a different format."))
 #. menu.add_option(category_name, "diffspouse", diffspouse)
-#: ../gramps/plugins/drawreport/descendtree.py:1669
+#: ../gramps/plugins/drawreport/descendtree.py:1668
 msgid ""
 "Spousal\n"
 "Display Format"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1673
+#: ../gramps/plugins/drawreport/descendtree.py:1672
 msgid "Display format for a spouse."
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1715
+#: ../gramps/plugins/drawreport/descendtree.py:1714
 msgid "inter-box Y scale factor"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1717
+#: ../gramps/plugins/drawreport/descendtree.py:1716
 msgid "Make the inter-box Y bigger or smaller"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/descendtree.py:1793
+#: ../gramps/plugins/drawreport/descendtree.py:1792
 msgid "The bold style used for the text display."
 msgstr ""
 
@@ -19600,8 +19866,8 @@ msgstr ""
 #: ../gramps/plugins/drawreport/fanchart.py:694
 #: ../gramps/plugins/textreport/ancestorreport.py:296
 #: ../gramps/plugins/textreport/descendreport.py:538
-#: ../gramps/plugins/textreport/detancestralreport.py:834
-#: ../gramps/plugins/textreport/detdescendantreport.py:1025
+#: ../gramps/plugins/textreport/detancestralreport.py:841
+#: ../gramps/plugins/textreport/detdescendantreport.py:1030
 msgid "The number of generations to include in the report"
 msgstr ""
 
@@ -19671,150 +19937,158 @@ msgstr ""
 msgid "The style used for the text display of generation \"%d\""
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:306
+#: ../gramps/plugins/drawreport/statisticschart.py:311
 msgid "Item count"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:310
+#: ../gramps/plugins/drawreport/statisticschart.py:315
+#: ../gramps/plugins/graph/gvfamilylines.py:85
 msgid "Both"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:311
-#: ../gramps/plugins/drawreport/statisticschart.py:413
-#: ../gramps/plugins/drawreport/statisticschart.py:785
+#: ../gramps/plugins/drawreport/statisticschart.py:316
+#: ../gramps/plugins/drawreport/statisticschart.py:419
+#: ../gramps/plugins/drawreport/statisticschart.py:794
 #: ../gramps/plugins/tool/verify.glade:645
 msgid "Men"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:312
-#: ../gramps/plugins/drawreport/statisticschart.py:415
-#: ../gramps/plugins/drawreport/statisticschart.py:787
+#: ../gramps/plugins/drawreport/statisticschart.py:317
+#: ../gramps/plugins/drawreport/statisticschart.py:421
+#: ../gramps/plugins/drawreport/statisticschart.py:796
 #: ../gramps/plugins/tool/verify.glade:525
 msgid "Women"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:332
+#: ../gramps/plugins/drawreport/statisticschart.py:338
 msgid "person|Title"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:336
+#: ../gramps/plugins/drawreport/statisticschart.py:342
 msgid "Forename"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:340
+#: ../gramps/plugins/drawreport/statisticschart.py:346
 msgid "Birth year"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:342
+#: ../gramps/plugins/drawreport/statisticschart.py:348
 msgid "Death year"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:344
+#: ../gramps/plugins/drawreport/statisticschart.py:350
 msgid "Birth month"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:346
+#: ../gramps/plugins/drawreport/statisticschart.py:352
 msgid "Death month"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:348
+#: ../gramps/plugins/drawreport/statisticschart.py:354
 #: ../gramps/plugins/export/exportcsv.py:357
-#: ../gramps/plugins/importer/importcsv.py:172
+#: ../gramps/plugins/importer/importcsv.py:173
 msgid "Birth place"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:350
+#: ../gramps/plugins/drawreport/statisticschart.py:356
 #: ../gramps/plugins/export/exportcsv.py:359
 msgid "Death place"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:352
+#: ../gramps/plugins/drawreport/statisticschart.py:358
 msgid "Marriage place"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:355
+#: ../gramps/plugins/drawreport/statisticschart.py:361
 msgid "Number of relationships"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:359
+#: ../gramps/plugins/drawreport/statisticschart.py:365
 msgid "Age when first child born"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:363
+#: ../gramps/plugins/drawreport/statisticschart.py:369
 msgid "Age when last child born"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:365
+#: ../gramps/plugins/drawreport/statisticschart.py:371
 msgid "Number of children"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:367
+#: ../gramps/plugins/drawreport/statisticschart.py:373
 msgid "Age at marriage"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:369
+#: ../gramps/plugins/drawreport/statisticschart.py:375
 msgid "Age at death"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:373
+#: ../gramps/plugins/drawreport/statisticschart.py:379
 msgid "Event type"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:387
+#: ../gramps/plugins/drawreport/statisticschart.py:393
 msgid "(Preferred) title missing"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:396
+#. the list of keys that represent "missing" information
+#: ../gramps/plugins/drawreport/statisticschart.py:402
+#: ../gramps/plugins/drawreport/statisticschart.py:928
 msgid "(Preferred) forename missing"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:406
+#: ../gramps/plugins/drawreport/statisticschart.py:412
 msgid "(Preferred) surname missing"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:416
+#: ../gramps/plugins/drawreport/statisticschart.py:422
 msgid "Gender unknown"
 msgstr ""
 
+#. localized year
 #. inadequate information
-#: ../gramps/plugins/drawreport/statisticschart.py:425
-#: ../gramps/plugins/drawreport/statisticschart.py:445
-#: ../gramps/plugins/drawreport/statisticschart.py:552
+#: ../gramps/plugins/drawreport/statisticschart.py:431
+#: ../gramps/plugins/drawreport/statisticschart.py:451
+#: ../gramps/plugins/drawreport/statisticschart.py:558
+#: ../gramps/plugins/drawreport/statisticschart.py:929
 msgid "Date(s) missing"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:454
-#: ../gramps/plugins/drawreport/statisticschart.py:468
+#: ../gramps/plugins/drawreport/statisticschart.py:460
+#: ../gramps/plugins/drawreport/statisticschart.py:474
 msgid "Place missing"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:476
+#: ../gramps/plugins/drawreport/statisticschart.py:482
 msgid "Already dead"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:483
+#: ../gramps/plugins/drawreport/statisticschart.py:489
 msgid "Still alive"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:491
-#: ../gramps/plugins/drawreport/statisticschart.py:503
+#: ../gramps/plugins/drawreport/statisticschart.py:497
+#: ../gramps/plugins/drawreport/statisticschart.py:509
 msgid "Events missing"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:511
-#: ../gramps/plugins/drawreport/statisticschart.py:519
+#: ../gramps/plugins/drawreport/statisticschart.py:517
+#: ../gramps/plugins/drawreport/statisticschart.py:525
+#: ../gramps/plugins/drawreport/statisticschart.py:932
 msgid "Children missing"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:541
+#: ../gramps/plugins/drawreport/statisticschart.py:547
+#: ../gramps/plugins/drawreport/statisticschart.py:931
 msgid "Birth missing"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:642
+#: ../gramps/plugins/drawreport/statisticschart.py:648
+#: ../gramps/plugins/drawreport/statisticschart.py:930
 msgid "Personal information missing"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:780
+#: ../gramps/plugins/drawreport/statisticschart.py:789
 #: ../gramps/plugins/drawreport/timeline.py:119
 #: ../gramps/plugins/textreport/placereport.py:99
 #: ../gramps/plugins/textreport/recordsreport.py:91
@@ -19823,14 +20097,13 @@ msgstr ""
 msgid "(Living people: %(option_name)s)"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:799
+#: ../gramps/plugins/drawreport/statisticschart.py:801
 #, python-format
-msgid "%(genders)s born %(year_from)04d-%(year_to)04d"
+msgid "%s born"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/statisticschart.py:803
-#, python-format
-msgid "Persons born %(year_from)04d-%(year_to)04d"
+msgid "Persons born"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/statisticschart.py:813
@@ -19845,108 +20118,118 @@ msgstr ""
 msgid "Saving charts..."
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:912
-#: ../gramps/plugins/drawreport/statisticschart.py:950
+#: ../gramps/plugins/drawreport/statisticschart.py:911
+#: ../gramps/plugins/drawreport/statisticschart.py:960
 #, python-format
 msgid "%s (persons):"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1002
+#: ../gramps/plugins/drawreport/statisticschart.py:1013
 #: ../gramps/plugins/textreport/recordsreport.py:219
 msgid "Determines what people are included in the report."
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1007
+#: ../gramps/plugins/drawreport/statisticschart.py:1018
 #: ../gramps/plugins/drawreport/timeline.py:422
-#: ../gramps/plugins/textreport/birthdayreport.py:420
+#: ../gramps/plugins/textreport/birthdayreport.py:479
 #: ../gramps/plugins/textreport/indivcomplete.py:1068
 #: ../gramps/plugins/textreport/recordsreport.py:223
-#: ../gramps/plugins/tool/sortevents.py:172
-#: ../gramps/plugins/webreport/narrativeweb.py:1608
-#: ../gramps/plugins/webreport/webcal.py:1639
+#: ../gramps/plugins/tool/sortevents.py:173
+#: ../gramps/plugins/webreport/narrativeweb.py:1645
+#: ../gramps/plugins/webreport/webcal.py:1677
 msgid "Filter Person"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1008
-#: ../gramps/plugins/textreport/birthdayreport.py:421
+#: ../gramps/plugins/drawreport/statisticschart.py:1019
+#: ../gramps/plugins/textreport/birthdayreport.py:480
 #: ../gramps/plugins/textreport/indivcomplete.py:1069
 msgid "The center person for the filter."
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1012
+#: ../gramps/plugins/drawreport/statisticschart.py:1023
 msgid "Sort chart items by"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1017
+#: ../gramps/plugins/drawreport/statisticschart.py:1028
 msgid "Select how the statistical data is sorted."
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1020
+#: ../gramps/plugins/drawreport/statisticschart.py:1031
 msgid "Sort in reverse order"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1021
+#: ../gramps/plugins/drawreport/statisticschart.py:1032
 msgid "Check to reverse the sorting order."
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1025
+#: ../gramps/plugins/drawreport/statisticschart.py:1036
 msgid "People Born After"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1027
+#: ../gramps/plugins/drawreport/statisticschart.py:1038
 msgid "Birth year from which to include people."
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1030
+#: ../gramps/plugins/drawreport/statisticschart.py:1041
 msgid "People Born Before"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1032
+#: ../gramps/plugins/drawreport/statisticschart.py:1043
 msgid "Birth year until which to include people"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1035
+#: ../gramps/plugins/drawreport/statisticschart.py:1046
 msgid "Include people without known birth years"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1037
+#: ../gramps/plugins/drawreport/statisticschart.py:1048
 msgid "Whether to include people without known birth years."
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1041
+#: ../gramps/plugins/drawreport/statisticschart.py:1052
 msgid "Genders included"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1046
+#: ../gramps/plugins/drawreport/statisticschart.py:1057
 msgid "Select which genders are included into statistics."
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1050
+#: ../gramps/plugins/drawreport/statisticschart.py:1061
 msgid "Max. items for a pie"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1051
+#: ../gramps/plugins/drawreport/statisticschart.py:1062
 msgid ""
 "With fewer items pie chart and legend will be used instead of a bar chart."
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1084
+#: ../gramps/plugins/drawreport/statisticschart.py:1066
+msgid "Include counts of missing information"
+msgstr ""
+
+#: ../gramps/plugins/drawreport/statisticschart.py:1068
+msgid ""
+"Whether to include counts of the number of people who lack the given "
+"information."
+msgstr ""
+
+#: ../gramps/plugins/drawreport/statisticschart.py:1102
 msgid "Charts 3"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1086
+#: ../gramps/plugins/drawreport/statisticschart.py:1104
 msgid "Charts 2"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1088
+#: ../gramps/plugins/drawreport/statisticschart.py:1106
 msgid "Charts 1"
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1090
+#: ../gramps/plugins/drawreport/statisticschart.py:1108
 msgid "Include charts with indicated data."
 msgstr ""
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1132
+#: ../gramps/plugins/drawreport/statisticschart.py:1150
 #: ../gramps/plugins/textreport/placereport.py:602
 msgid "The style used for the items and values."
 msgstr ""
@@ -19981,6 +20264,7 @@ msgid "Sorted by %s"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/timeline.py:312
+#: ../gramps/plugins/lib/libgedcom.py:7832
 msgid "No Date Information"
 msgstr ""
 
@@ -19994,19 +20278,19 @@ msgstr ""
 
 #: ../gramps/plugins/drawreport/timeline.py:423
 #: ../gramps/plugins/textreport/recordsreport.py:224
-#: ../gramps/plugins/tool/sortevents.py:173
-#: ../gramps/plugins/webreport/narrativeweb.py:1609
-#: ../gramps/plugins/webreport/webcal.py:1640
+#: ../gramps/plugins/tool/sortevents.py:174
+#: ../gramps/plugins/webreport/narrativeweb.py:1646
+#: ../gramps/plugins/webreport/webcal.py:1678
 msgid "The center person for the filter"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/timeline.py:427
-#: ../gramps/plugins/tool/sortevents.py:179
+#: ../gramps/plugins/tool/sortevents.py:180
 msgid "Sort by"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/timeline.py:432
-#: ../gramps/plugins/tool/sortevents.py:184
+#: ../gramps/plugins/tool/sortevents.py:185
 msgid "Sorting method to use"
 msgstr ""
 
@@ -20157,13 +20441,13 @@ msgid "Include marriages"
 msgstr ""
 
 #: ../gramps/plugins/export/exportcsv.py:138
-#: ../gramps/plugins/textreport/detancestralreport.py:895
-#: ../gramps/plugins/textreport/detdescendantreport.py:1082
+#: ../gramps/plugins/textreport/detancestralreport.py:902
+#: ../gramps/plugins/textreport/detdescendantreport.py:1087
 msgid "Include children"
 msgstr ""
 
 #: ../gramps/plugins/export/exportcsv.py:139
-#: ../gramps/plugins/graph/gvfamilylines.py:227
+#: ../gramps/plugins/graph/gvfamilylines.py:234
 msgid "Include places"
 msgstr ""
 
@@ -20213,64 +20497,64 @@ msgid "Burial source"
 msgstr ""
 
 #: ../gramps/plugins/export/exportcsv.py:465
-#: ../gramps/plugins/importer/importcsv.py:217
+#: ../gramps/plugins/importer/importcsv.py:233
 #: ../gramps/plugins/textreport/familygroup.py:627
-#: ../gramps/plugins/webreport/basepage.py:2317
+#: ../gramps/plugins/webreport/basepage.py:2366
 msgid "Husband"
 msgstr ""
 
 #: ../gramps/plugins/export/exportcsv.py:465
-#: ../gramps/plugins/importer/importcsv.py:214
+#: ../gramps/plugins/importer/importcsv.py:230
 #: ../gramps/plugins/textreport/familygroup.py:636
-#: ../gramps/plugins/webreport/basepage.py:2315
+#: ../gramps/plugins/webreport/basepage.py:2364
 msgid "Wife"
 msgstr ""
 
-#: ../gramps/plugins/export/exportgedcom.py:407
+#: ../gramps/plugins/export/exportgedcom.py:398
 msgid "Writing individuals"
 msgstr ""
 
-#: ../gramps/plugins/export/exportgedcom.py:799
-#: ../gramps/plugins/export/exportgedcom.py:1081
-#: ../gramps/plugins/export/exportgedcom.py:1172
-#: ../gramps/plugins/lib/libgedcom.py:4150
-#: ../gramps/plugins/lib/libgedcom.py:5883
+#: ../gramps/plugins/export/exportgedcom.py:790
+#: ../gramps/plugins/export/exportgedcom.py:1072
+#: ../gramps/plugins/export/exportgedcom.py:1163
+#: ../gramps/plugins/lib/libgedcom.py:4144
+#: ../gramps/plugins/lib/libgedcom.py:5872
 #: ../gramps/plugins/lib/libgedcom.py:7017
 msgid "FAX"
 msgstr ""
 
-#: ../gramps/plugins/export/exportgedcom.py:813
+#: ../gramps/plugins/export/exportgedcom.py:804
 #: ../gramps/plugins/textreport/familygroup.py:673
 msgid "Writing families"
 msgstr ""
 
-#: ../gramps/plugins/export/exportgedcom.py:980
+#: ../gramps/plugins/export/exportgedcom.py:971
 msgid "Writing sources"
 msgstr ""
 
-#: ../gramps/plugins/export/exportgedcom.py:1015
+#: ../gramps/plugins/export/exportgedcom.py:1006
 msgid "Writing notes"
 msgstr ""
 
-#: ../gramps/plugins/export/exportgedcom.py:1058
+#: ../gramps/plugins/export/exportgedcom.py:1049
 msgid "Writing repositories"
 msgstr ""
 
-#: ../gramps/plugins/export/exportgedcom.py:1174
-#: ../gramps/plugins/lib/libgedcom.py:5895
+#: ../gramps/plugins/export/exportgedcom.py:1165
+#: ../gramps/plugins/lib/libgedcom.py:5884
 msgid "EMAIL"
 msgstr ""
 
-#: ../gramps/plugins/export/exportgedcom.py:1176
-#: ../gramps/plugins/lib/libgedcom.py:5907
+#: ../gramps/plugins/export/exportgedcom.py:1167
+#: ../gramps/plugins/lib/libgedcom.py:5896
 msgid "WWW"
 msgstr ""
 
-#: ../gramps/plugins/export/exportgedcom.py:1438
+#: ../gramps/plugins/export/exportgedcom.py:1429
 msgid "Writing media"
 msgstr ""
 
-#: ../gramps/plugins/export/exportgedcom.py:1613
+#: ../gramps/plugins/export/exportgedcom.py:1603
 msgid "GEDCOM Export failed"
 msgstr ""
 
@@ -20284,31 +20568,6 @@ msgstr ""
 #: ../gramps/plugins/export/exportxml.py:173
 #, python-format
 msgid "Failure writing %s"
-msgstr ""
-
-#. feature requests 2356, 1657: avoid genitive form
-#: ../gramps/plugins/export/exportvcalendar.py:135
-#, python-format
-msgid "Marriage of %s"
-msgstr ""
-
-#. feature requests 2356, 1657: avoid genitive form
-#: ../gramps/plugins/export/exportvcalendar.py:154
-#: ../gramps/plugins/export/exportvcalendar.py:159
-#, python-format
-msgid "Birth of %s"
-msgstr ""
-
-#. feature requests 2356, 1657: avoid genitive form
-#: ../gramps/plugins/export/exportvcalendar.py:172
-#: ../gramps/plugins/export/exportvcalendar.py:178
-#, python-format
-msgid "Death of %s"
-msgstr ""
-
-#: ../gramps/plugins/export/exportvcalendar.py:237
-#, python-format
-msgid "Anniversary: %s"
 msgstr ""
 
 #: ../gramps/plugins/export/exportxml.py:140
@@ -20380,7 +20639,7 @@ msgstr ""
 #: ../gramps/plugins/gramplet/agestats.py:235
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:262
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:269
-#: ../gramps/plugins/webreport/basepage.py:1490
+#: ../gramps/plugins/webreport/basepage.py:1539
 #: ../gramps/plugins/webreport/statistics.py:84
 msgid "Statistics"
 msgstr ""
@@ -20431,7 +20690,7 @@ msgstr ""
 
 #: ../gramps/plugins/gramplet/attributes.py:56
 #: ../gramps/plugins/lib/libmetadata.py:172
-#: ../gramps/plugins/webreport/basepage.py:997
+#: ../gramps/plugins/webreport/basepage.py:1024
 msgid "Key"
 msgstr ""
 
@@ -20506,9 +20765,9 @@ msgstr ""
 msgid "Double-click on a row to edit the selected event."
 msgstr ""
 
-#: ../gramps/plugins/gramplet/fanchart2waygramplet.py:86
-#: ../gramps/plugins/gramplet/fanchartdescgramplet.py:64
-#: ../gramps/plugins/gramplet/fanchartgramplet.py:67
+#: ../gramps/plugins/gramplet/fanchart2waygramplet.py:78
+#: ../gramps/plugins/gramplet/fanchartdescgramplet.py:65
+#: ../gramps/plugins/gramplet/fanchartgramplet.py:68
 msgid ""
 "Click to expand/contract person\n"
 "Right-click for options\n"
@@ -20720,7 +20979,7 @@ msgstr ""
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:104
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:111
-#: ../gramps/plugins/webreport/person.py:1086
+#: ../gramps/plugins/webreport/person.py:1177
 msgid "Ancestors"
 msgstr ""
 
@@ -20734,7 +20993,7 @@ msgid "Gramplet showing active person's direct ancestors as a fanchart"
 msgstr ""
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:138
-#: ../gramps/plugins/view/fanchartdescview.py:75
+#: ../gramps/plugins/view/fanchartdescview.py:76
 msgid "Descendant Fan Chart"
 msgstr ""
 
@@ -20748,7 +21007,7 @@ msgid "Descendant Fan"
 msgstr ""
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:155
-#: ../gramps/plugins/view/fanchart2wayview.py:78
+#: ../gramps/plugins/view/fanchart2wayview.py:79
 msgid "2-Way Fan Chart"
 msgstr ""
 
@@ -20783,9 +21042,9 @@ msgstr ""
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:199
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:205
-#: ../gramps/plugins/view/pedigreeview.py:530
+#: ../gramps/plugins/view/pedigreeview.py:528
 #: ../gramps/plugins/view/view.gpr.py:127
-#: ../gramps/plugins/webreport/person.py:1272
+#: ../gramps/plugins/webreport/person.py:1346
 msgid "Pedigree"
 msgstr ""
 
@@ -21197,10 +21456,9 @@ msgstr ""
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:967
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:981
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:995
-#: ../gramps/plugins/webreport/basepage.py:2261
-#: ../gramps/plugins/webreport/basepage.py:2802
-#: ../gramps/plugins/webreport/person.py:858
-#: ../gramps/plugins/webreport/thumbnail.py:210
+#: ../gramps/plugins/webreport/basepage.py:2959
+#: ../gramps/plugins/webreport/person.py:878
+#: ../gramps/plugins/webreport/thumbnail.py:164
 msgid "References"
 msgstr ""
 
@@ -21229,7 +21487,7 @@ msgid "Gramplet showing the backlink references for a place"
 msgstr ""
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:931
-#: ../gramps/plugins/webreport/basepage.py:2145
+#: ../gramps/plugins/webreport/basepage.py:2234
 msgid "Source References"
 msgstr ""
 
@@ -21435,6 +21693,8 @@ msgid "Gramplet showing the places enclosed by the active place"
 msgstr ""
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1308
+#: ../gramps/plugins/webreport/basepage.py:2673
+#: ../gramps/plugins/webreport/basepage.py:2736
 msgid "Place Encloses"
 msgstr ""
 
@@ -21463,27 +21723,39 @@ msgstr ""
 msgid "Gramplet showing the events for all the family"
 msgstr ""
 
-#: ../gramps/plugins/gramplet/leak.py:93
+#: ../gramps/plugins/gramplet/leak.py:99
+msgid "Referrer"
+msgstr ""
+
+#: ../gramps/plugins/gramplet/leak.py:103
 msgid "Uncollected object"
 msgstr ""
 
-#: ../gramps/plugins/gramplet/leak.py:102
+#: ../gramps/plugins/gramplet/leak.py:112
 msgid "Refresh"
 msgstr ""
 
-#: ../gramps/plugins/gramplet/leak.py:133
+#: ../gramps/plugins/gramplet/leak.py:122
+msgid "Press Refresh to see initial results"
+msgstr ""
+
+#: ../gramps/plugins/gramplet/leak.py:158
 #, python-format
 msgid "Referrers of %d"
 msgstr ""
 
-#: ../gramps/plugins/gramplet/leak.py:147
+#: ../gramps/plugins/gramplet/leak.py:181
 #, python-format
 msgid "%d refers to"
 msgstr ""
 
-#: ../gramps/plugins/gramplet/leak.py:172
+#: ../gramps/plugins/gramplet/leak.py:198
 #, python-format
 msgid "Uncollected Objects: %s"
+msgstr ""
+
+#: ../gramps/plugins/gramplet/leak.py:239
+msgid "Reference Error"
 msgstr ""
 
 #: ../gramps/plugins/gramplet/locations.py:81
@@ -21504,8 +21776,8 @@ msgstr ""
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:58
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:67
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:78
-#: ../gramps/plugins/view/fanchartdescview.py:295
-#: ../gramps/plugins/view/fanchartview.py:291
+#: ../gramps/plugins/view/fanchartdescview.py:280
+#: ../gramps/plugins/view/fanchartview.py:378
 msgid "Max generations"
 msgstr ""
 
@@ -21570,8 +21842,8 @@ msgstr ""
 #. Create the Generation title, set an index marker
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:267
 #: ../gramps/plugins/textreport/ancestorreport.py:218
-#: ../gramps/plugins/textreport/detancestralreport.py:227
-#: ../gramps/plugins/textreport/detdescendantreport.py:354
+#: ../gramps/plugins/textreport/detancestralreport.py:228
+#: ../gramps/plugins/textreport/detdescendantreport.py:355
 #: ../gramps/plugins/textreport/endoflinereport.py:186
 #, python-format
 msgid "Generation %d"
@@ -21653,26 +21925,26 @@ msgstr ""
 
 #: ../gramps/plugins/gramplet/relativegramplet.py:88
 #, python-format
-msgid "%d. Partner: "
+msgid "%(count)d. %(relation)s: "
 msgstr ""
 
-#: ../gramps/plugins/gramplet/relativegramplet.py:92
+#: ../gramps/plugins/gramplet/relativegramplet.py:94
 #, python-format
 msgid "%d. Partner: Not known"
 msgstr ""
 
-#: ../gramps/plugins/gramplet/relativegramplet.py:107
+#: ../gramps/plugins/gramplet/relativegramplet.py:109
 msgid "Parents:"
 msgstr ""
 
-#: ../gramps/plugins/gramplet/relativegramplet.py:119
-#: ../gramps/plugins/gramplet/relativegramplet.py:123
+#: ../gramps/plugins/gramplet/relativegramplet.py:121
+#: ../gramps/plugins/gramplet/relativegramplet.py:125
 #, python-format
 msgid "   %d.a Mother: "
 msgstr ""
 
-#: ../gramps/plugins/gramplet/relativegramplet.py:130
-#: ../gramps/plugins/gramplet/relativegramplet.py:134
+#: ../gramps/plugins/gramplet/relativegramplet.py:132
+#: ../gramps/plugins/gramplet/relativegramplet.py:136
 #, python-format
 msgid "   %d.b Father: "
 msgstr ""
@@ -21718,32 +21990,32 @@ msgstr ""
 
 #: ../gramps/plugins/gramplet/statsgramplet.py:94
 #: ../gramps/plugins/textreport/summary.py:240
-#: ../gramps/plugins/webreport/statistics.py:105
+#: ../gramps/plugins/webreport/statistics.py:106
 msgid "less than 1"
 msgstr ""
 
 #. -------------------------
 #: ../gramps/plugins/gramplet/statsgramplet.py:140
-#: ../gramps/plugins/graph/gvfamilylines.py:269
+#: ../gramps/plugins/graph/gvfamilylines.py:276
 #: ../gramps/plugins/textreport/summary.py:113
-#: ../gramps/plugins/webreport/basepage.py:1477
-#: ../gramps/plugins/webreport/basepage.py:1535
-#: ../gramps/plugins/webreport/basepage.py:1600
-#: ../gramps/plugins/webreport/person.py:174
-#: ../gramps/plugins/webreport/statistics.py:116
-#: ../gramps/plugins/webreport/statistics.py:182
+#: ../gramps/plugins/webreport/basepage.py:1526
+#: ../gramps/plugins/webreport/basepage.py:1577
+#: ../gramps/plugins/webreport/basepage.py:1641
+#: ../gramps/plugins/webreport/person.py:179
+#: ../gramps/plugins/webreport/statistics.py:117
+#: ../gramps/plugins/webreport/statistics.py:183
 msgid "Individuals"
 msgstr ""
 
 #: ../gramps/plugins/gramplet/statsgramplet.py:142
-#: ../gramps/plugins/webreport/statistics.py:119
-#: ../gramps/plugins/webreport/statistics.py:183
+#: ../gramps/plugins/webreport/statistics.py:120
+#: ../gramps/plugins/webreport/statistics.py:184
 msgid "Number of individuals"
 msgstr ""
 
 #: ../gramps/plugins/gramplet/statsgramplet.py:152
-#: ../gramps/plugins/webreport/statistics.py:125
-#: ../gramps/plugins/webreport/statistics.py:190
+#: ../gramps/plugins/webreport/statistics.py:126
+#: ../gramps/plugins/webreport/statistics.py:191
 msgid "Individuals with unknown gender"
 msgstr ""
 
@@ -21761,19 +22033,19 @@ msgstr ""
 
 #: ../gramps/plugins/gramplet/statsgramplet.py:168
 #: ../gramps/plugins/textreport/summary.py:211
-#: ../gramps/plugins/webreport/statistics.py:129
-#: ../gramps/plugins/webreport/statistics.py:194
+#: ../gramps/plugins/webreport/statistics.py:130
+#: ../gramps/plugins/webreport/statistics.py:195
 msgid "Family Information"
 msgstr ""
 
 #: ../gramps/plugins/gramplet/statsgramplet.py:175
-#: ../gramps/plugins/webreport/statistics.py:132
+#: ../gramps/plugins/webreport/statistics.py:133
 msgid "Unique surnames"
 msgstr ""
 
 #: ../gramps/plugins/gramplet/statsgramplet.py:179
 #: ../gramps/plugins/textreport/summary.py:228
-#: ../gramps/plugins/webreport/statistics.py:136
+#: ../gramps/plugins/webreport/statistics.py:137
 msgid "Media Objects"
 msgstr ""
 
@@ -21782,23 +22054,23 @@ msgid "Individuals with media objects"
 msgstr ""
 
 #: ../gramps/plugins/gramplet/statsgramplet.py:185
-#: ../gramps/plugins/webreport/statistics.py:138
+#: ../gramps/plugins/webreport/statistics.py:139
 msgid "Total number of media object references"
 msgstr ""
 
 #: ../gramps/plugins/gramplet/statsgramplet.py:189
-#: ../gramps/plugins/webreport/statistics.py:140
+#: ../gramps/plugins/webreport/statistics.py:141
 msgid "Number of unique media objects"
 msgstr ""
 
 #: ../gramps/plugins/gramplet/statsgramplet.py:194
-#: ../gramps/plugins/webreport/statistics.py:142
+#: ../gramps/plugins/webreport/statistics.py:143
 msgid "Total size of media objects"
 msgstr ""
 
 #: ../gramps/plugins/gramplet/statsgramplet.py:198
 #: ../gramps/plugins/textreport/summary.py:258
-#: ../gramps/plugins/webreport/statistics.py:146
+#: ../gramps/plugins/webreport/statistics.py:147
 msgid "Missing Media Objects"
 msgstr ""
 
@@ -22091,7 +22363,7 @@ msgid "Produces an hourglass graph using Graphviz."
 msgstr ""
 
 #: ../gramps/plugins/graph/graphplugins.gpr.py:81
-#: ../gramps/plugins/graph/gvrelgraph.py:204
+#: ../gramps/plugins/graph/gvrelgraph.py:207
 msgid "Relationship Graph"
 msgstr ""
 
@@ -22105,19 +22377,19 @@ msgstr ""
 #.
 #. ------------------------------------------------------------------------
 #: ../gramps/plugins/graph/gvfamilylines.py:73
-#: ../gramps/plugins/graph/gvhourglass.py:57
+#: ../gramps/plugins/graph/gvhourglass.py:58
 #: ../gramps/plugins/graph/gvrelgraph.py:72
 msgid "B&W outline"
 msgstr ""
 
 #: ../gramps/plugins/graph/gvfamilylines.py:74
-#: ../gramps/plugins/graph/gvhourglass.py:58
+#: ../gramps/plugins/graph/gvhourglass.py:59
 #: ../gramps/plugins/graph/gvrelgraph.py:73
 msgid "Colored outline"
 msgstr ""
 
 #: ../gramps/plugins/graph/gvfamilylines.py:75
-#: ../gramps/plugins/graph/gvhourglass.py:59
+#: ../gramps/plugins/graph/gvhourglass.py:60
 #: ../gramps/plugins/graph/gvrelgraph.py:74
 msgid "Color fill"
 msgstr ""
@@ -22142,458 +22414,519 @@ msgstr ""
 msgid "Descendants - Ancestors"
 msgstr ""
 
+#: ../gramps/plugins/graph/gvfamilylines.py:83
+#: ../gramps/plugins/textreport/indivcomplete.py:938
+#: ../gramps/plugins/tool/dumpgenderstats.py:73
+#: ../gramps/plugins/tool/dumpgenderstats.py:97
+#: ../gramps/plugins/tool/dumpgenderstats.py:99
+msgid "Female"
+msgstr ""
+
+#: ../gramps/plugins/graph/gvfamilylines.py:84
+#: ../gramps/plugins/textreport/indivcomplete.py:936
+#: ../gramps/plugins/tool/dumpgenderstats.py:72
+#: ../gramps/plugins/tool/dumpgenderstats.py:96
+#: ../gramps/plugins/tool/dumpgenderstats.py:99
+msgid "Male"
+msgstr ""
+
 #. ---------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:119
+#: ../gramps/plugins/graph/gvfamilylines.py:124
 msgid "Follow parents to determine \"family lines\""
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:121
+#: ../gramps/plugins/graph/gvfamilylines.py:126
 msgid ""
 "Parents and their ancestors will be considered when determining \"family "
 "lines\"."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:125
+#: ../gramps/plugins/graph/gvfamilylines.py:130
 msgid "Follow children to determine \"family lines\""
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:127
+#: ../gramps/plugins/graph/gvfamilylines.py:132
 msgid "Children will be considered when determining \"family lines\"."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:131
+#: ../gramps/plugins/graph/gvfamilylines.py:136
 msgid "Try to remove extra people and families"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:133
+#: ../gramps/plugins/graph/gvfamilylines.py:138
 msgid ""
 "People and families not directly related to people of interest will be "
 "removed when determining \"family lines\"."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:139
-#: ../gramps/plugins/graph/gvhourglass.py:331
-#: ../gramps/plugins/graph/gvrelgraph.py:779
+#: ../gramps/plugins/graph/gvfamilylines.py:144
+#: ../gramps/plugins/graph/gvhourglass.py:380
+#: ../gramps/plugins/graph/gvrelgraph.py:812
 msgid "Arrowhead direction"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:142
-#: ../gramps/plugins/graph/gvhourglass.py:334
-#: ../gramps/plugins/graph/gvrelgraph.py:782
+#: ../gramps/plugins/graph/gvfamilylines.py:147
+#: ../gramps/plugins/graph/gvhourglass.py:383
+#: ../gramps/plugins/graph/gvrelgraph.py:815
 msgid "Choose the direction that the arrows point."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:145
-#: ../gramps/plugins/graph/gvhourglass.py:337
-#: ../gramps/plugins/graph/gvrelgraph.py:785
+#: ../gramps/plugins/graph/gvfamilylines.py:150
+#: ../gramps/plugins/graph/gvhourglass.py:386
+#: ../gramps/plugins/graph/gvrelgraph.py:818
 msgid "Graph coloring"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:148
+#: ../gramps/plugins/graph/gvfamilylines.py:153
 msgid ""
 "Males will be shown with blue, females with red, unless otherwise set above "
 "for filled. If the sex of an individual is unknown it will be shown with "
 "gray."
 msgstr ""
 
-#. see bug report #2180
-#: ../gramps/plugins/graph/gvfamilylines.py:154
-#: ../gramps/plugins/graph/gvhourglass.py:345
-#: ../gramps/plugins/graph/gvrelgraph.py:794
-msgid "Use rounded corners"
+#: ../gramps/plugins/graph/gvfamilylines.py:159
+msgid "Rounded corners"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:156
-#: ../gramps/plugins/graph/gvhourglass.py:347
-#: ../gramps/plugins/graph/gvrelgraph.py:795
-msgid "Use rounded corners to differentiate between women and men."
+#: ../gramps/plugins/graph/gvfamilylines.py:162
+msgid "Use rounded corners e.g. to differentiate between women and men."
 msgstr ""
 
 #. --------------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:177
+#: ../gramps/plugins/graph/gvfamilylines.py:184
 msgid "People of Interest"
 msgstr ""
 
 #. --------------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:180
+#: ../gramps/plugins/graph/gvfamilylines.py:187
 msgid "People of interest"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:181
+#: ../gramps/plugins/graph/gvfamilylines.py:188
 msgid ""
 "People of interest are used as a starting point when determining \"family "
 "lines\"."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:185
+#: ../gramps/plugins/graph/gvfamilylines.py:192
 msgid "Limit the number of ancestors"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:187
+#: ../gramps/plugins/graph/gvfamilylines.py:194
 msgid "Whether to limit the number of ancestors."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:193
+#: ../gramps/plugins/graph/gvfamilylines.py:200
 msgid "The maximum number of ancestors to include."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:197
+#: ../gramps/plugins/graph/gvfamilylines.py:204
 msgid "Limit the number of descendants"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:200
+#: ../gramps/plugins/graph/gvfamilylines.py:207
 msgid "Whether to limit the number of descendants."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:206
+#: ../gramps/plugins/graph/gvfamilylines.py:213
 msgid "The maximum number of descendants to include."
 msgstr ""
 
 #. --------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:215
+#: ../gramps/plugins/graph/gvfamilylines.py:222
 msgid "Include dates"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:216
+#: ../gramps/plugins/graph/gvfamilylines.py:223
 msgid "Whether to include dates for people and families."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:221
+#: ../gramps/plugins/graph/gvfamilylines.py:228
 msgid "Limit dates to years only"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:222
+#: ../gramps/plugins/graph/gvfamilylines.py:229
 msgid ""
 "Prints just dates' year, neither month or day nor date approximation or "
 "interval are shown."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:228
+#: ../gramps/plugins/graph/gvfamilylines.py:235
 msgid "Whether to include placenames for people and families."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:232
+#: ../gramps/plugins/graph/gvfamilylines.py:239
 msgid "Include the number of children"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:234
+#: ../gramps/plugins/graph/gvfamilylines.py:241
 msgid ""
 "Whether to include the number of children for families with more than 1 "
 "child."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:239
-#: ../gramps/plugins/graph/gvrelgraph.py:860
+#: ../gramps/plugins/graph/gvfamilylines.py:246
+#: ../gramps/plugins/graph/gvrelgraph.py:904
 msgid "Include thumbnail images of people"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:242
+#: ../gramps/plugins/graph/gvfamilylines.py:249
 msgid "Whether to include thumbnail images of people."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:247
+#: ../gramps/plugins/graph/gvfamilylines.py:254
 msgid "Thumbnail location"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:248
-#: ../gramps/plugins/graph/gvrelgraph.py:867
+#: ../gramps/plugins/graph/gvfamilylines.py:255
+#: ../gramps/plugins/graph/gvrelgraph.py:911
 msgid "Above the name"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:249
-#: ../gramps/plugins/graph/gvrelgraph.py:868
+#: ../gramps/plugins/graph/gvfamilylines.py:256
+#: ../gramps/plugins/graph/gvrelgraph.py:912
 msgid "Beside the name"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:250
-#: ../gramps/plugins/graph/gvrelgraph.py:870
+#: ../gramps/plugins/graph/gvfamilylines.py:257
+#: ../gramps/plugins/graph/gvrelgraph.py:914
 msgid "Where the thumbnail image should appear relative to the name"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:254
+#: ../gramps/plugins/graph/gvfamilylines.py:261
 msgid "Thumbnail size"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:257
+#: ../gramps/plugins/graph/gvfamilylines.py:264
 msgid "Size of the thumbnail image"
 msgstr ""
 
 #. ----------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:261
+#: ../gramps/plugins/graph/gvfamilylines.py:268
 msgid "Family Colors"
 msgstr ""
 
 #. ----------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:264
+#: ../gramps/plugins/graph/gvfamilylines.py:271
 msgid "Family colors"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:265
+#: ../gramps/plugins/graph/gvfamilylines.py:272
 msgid "Colors to use for various family lines."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:273
-#: ../gramps/plugins/graph/gvhourglass.py:369
-#: ../gramps/plugins/graph/gvrelgraph.py:897
+#: ../gramps/plugins/graph/gvfamilylines.py:280
+#: ../gramps/plugins/graph/gvhourglass.py:420
+#: ../gramps/plugins/graph/gvrelgraph.py:941
 msgid "The color to use to display men."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:277
-#: ../gramps/plugins/graph/gvhourglass.py:373
-#: ../gramps/plugins/graph/gvrelgraph.py:901
+#: ../gramps/plugins/graph/gvfamilylines.py:284
+#: ../gramps/plugins/graph/gvhourglass.py:424
+#: ../gramps/plugins/graph/gvrelgraph.py:945
 msgid "The color to use to display women."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:281
-#: ../gramps/plugins/graph/gvhourglass.py:377
-#: ../gramps/plugins/graph/gvrelgraph.py:906
+#: ../gramps/plugins/graph/gvfamilylines.py:288
+#: ../gramps/plugins/graph/gvhourglass.py:428
+#: ../gramps/plugins/graph/gvrelgraph.py:950
 msgid "The color to use when the gender is unknown."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:286
-#: ../gramps/plugins/graph/gvhourglass.py:382
-#: ../gramps/plugins/graph/gvrelgraph.py:911
+#: ../gramps/plugins/graph/gvfamilylines.py:293
+#: ../gramps/plugins/graph/gvhourglass.py:433
+#: ../gramps/plugins/graph/gvrelgraph.py:955
 msgid "The color to use to display families."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:398
+#: ../gramps/plugins/graph/gvfamilylines.py:405
 #: ../gramps/plugins/textreport/familygroup.py:680
 #: ../gramps/plugins/textreport/indivcomplete.py:829
 msgid "Empty report"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:399
+#: ../gramps/plugins/graph/gvfamilylines.py:406
 #: ../gramps/plugins/textreport/familygroup.py:681
 #: ../gramps/plugins/textreport/indivcomplete.py:830
 msgid "You did not specify anybody"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:458
+#: ../gramps/plugins/graph/gvfamilylines.py:465
 msgid "Number of people in database:"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:461
+#: ../gramps/plugins/graph/gvfamilylines.py:468
 msgid "Number of people of interest:"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:464
+#: ../gramps/plugins/graph/gvfamilylines.py:471
 msgid "Number of families in database:"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:467
+#: ../gramps/plugins/graph/gvfamilylines.py:474
 msgid "Number of families of interest:"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:471
+#: ../gramps/plugins/graph/gvfamilylines.py:478
 msgid "Additional people removed:"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:474
+#: ../gramps/plugins/graph/gvfamilylines.py:481
 msgid "Additional families removed:"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:477
+#: ../gramps/plugins/graph/gvfamilylines.py:484
 msgid "Initial list of people of interest:"
 msgstr ""
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/graph/gvfamilylines.py:973
+#: ../gramps/plugins/graph/gvfamilylines.py:982
 #, python-brace-format
 msgid "{number_of} child"
 msgid_plural "{number_of} children"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:1048
+#: ../gramps/plugins/graph/gvfamilylines.py:1057
 #, python-format
 msgid "father: %s"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:1058
+#: ../gramps/plugins/graph/gvfamilylines.py:1067
 #, python-format
 msgid "mother: %s"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:1071
+#: ../gramps/plugins/graph/gvfamilylines.py:1080
 #, python-format
 msgid "child: %s"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvhourglass.py:61
+#: ../gramps/plugins/graph/gvhourglass.py:62
 msgid "Center -> Others"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvhourglass.py:62
+#: ../gramps/plugins/graph/gvhourglass.py:63
 msgid "Center <- Others"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvhourglass.py:63
+#: ../gramps/plugins/graph/gvhourglass.py:64
 msgid "Center <-> Other"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvhourglass.py:64
+#: ../gramps/plugins/graph/gvhourglass.py:65
 msgid "Center - Other"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvhourglass.py:318
+#: ../gramps/plugins/graph/gvhourglass.py:367
 msgid "The Center person for the graph"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvhourglass.py:321
+#: ../gramps/plugins/graph/gvhourglass.py:370
 #: ../gramps/plugins/textreport/kinshipreport.py:362
 msgid "Max Descendant Generations"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvhourglass.py:322
+#: ../gramps/plugins/graph/gvhourglass.py:371
 msgid "The number of generations of descendants to include in the graph"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvhourglass.py:326
+#: ../gramps/plugins/graph/gvhourglass.py:375
 #: ../gramps/plugins/textreport/kinshipreport.py:366
 msgid "Max Ancestor Generations"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvhourglass.py:327
+#: ../gramps/plugins/graph/gvhourglass.py:376
 msgid "The number of generations of ancestors to include in the graph"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvhourglass.py:340
-#: ../gramps/plugins/graph/gvrelgraph.py:788
+#: ../gramps/plugins/graph/gvhourglass.py:389
+#: ../gramps/plugins/graph/gvrelgraph.py:821
 msgid ""
 "Males will be shown with blue, females with red.  If the sex of an "
 "individual is unknown it will be shown with gray."
 msgstr ""
 
+#. see bug report #2180
+#: ../gramps/plugins/graph/gvhourglass.py:394
+#: ../gramps/plugins/graph/gvrelgraph.py:827
+msgid "Use rounded corners"
+msgstr ""
+
+#: ../gramps/plugins/graph/gvhourglass.py:396
+#: ../gramps/plugins/graph/gvrelgraph.py:828
+msgid "Use rounded corners to differentiate between women and men."
+msgstr ""
+
 #. ###############################
-#: ../gramps/plugins/graph/gvhourglass.py:365
-#: ../gramps/plugins/graph/gvrelgraph.py:893
+#: ../gramps/plugins/graph/gvhourglass.py:416
+#: ../gramps/plugins/graph/gvrelgraph.py:937
 msgid "Graph Style"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:205
+#: ../gramps/plugins/graph/gvhourglass.py:436
+msgid "Force Ahnentafel order"
+msgstr ""
+
+#: ../gramps/plugins/graph/gvhourglass.py:438
+msgid ""
+"Force Sosa / Sosa-Stradonitz / Ahnentafel layout order for all ancestors, so "
+"that fathers are always on the left branch and mothers are on the right "
+"branch."
+msgstr ""
+
+#: ../gramps/plugins/graph/gvhourglass.py:441
+msgid "Ahnentafel number visible"
+msgstr ""
+
+#: ../gramps/plugins/graph/gvhourglass.py:443
+msgid ""
+"Show Sosa / Sosa-Stradonitz / Ahnentafel number under all others "
+"informations."
+msgstr ""
+
+#: ../gramps/plugins/graph/gvrelgraph.py:208
 #: ../gramps/plugins/textreport/indivcomplete.py:834
 #: ../gramps/plugins/textreport/notelinkreport.py:103
 #: ../gramps/plugins/textreport/placereport.py:160
 msgid "Generating report"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:770
+#: ../gramps/plugins/graph/gvrelgraph.py:803
 msgid "Determines what people are included in the graph"
 msgstr ""
 
+#. see bug report #11112
+#: ../gramps/plugins/graph/gvrelgraph.py:833
+msgid "Use hexagons"
+msgstr ""
+
+#: ../gramps/plugins/graph/gvrelgraph.py:834
+msgid "Use hexagons to differentiate those of unknown gender."
+msgstr ""
+
 #. ###############################
-#: ../gramps/plugins/graph/gvrelgraph.py:823
+#: ../gramps/plugins/graph/gvrelgraph.py:862
 msgid "Dates and/or Places"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:824
+#: ../gramps/plugins/graph/gvrelgraph.py:863
 msgid "Do not include any dates or places"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:825
+#: ../gramps/plugins/graph/gvrelgraph.py:864
 msgid "Include (birth, marriage, death) dates, but no places"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:827
+#: ../gramps/plugins/graph/gvrelgraph.py:866
 msgid "Include (birth, marriage, death) dates, and places"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:829
+#: ../gramps/plugins/graph/gvrelgraph.py:868
 msgid "Include (birth, marriage, death) dates, and places if no dates"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:831
+#: ../gramps/plugins/graph/gvrelgraph.py:870
 msgid "Include (birth, marriage, death) years, but no places"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:833
+#: ../gramps/plugins/graph/gvrelgraph.py:872
 msgid "Include (birth, marriage, death) years, and places"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:835
+#: ../gramps/plugins/graph/gvrelgraph.py:874
 msgid "Include (birth, marriage, death) places, but no dates"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:837
+#: ../gramps/plugins/graph/gvrelgraph.py:876
 msgid "Include (birth, marriage, death) dates and places on same line"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:840
+#: ../gramps/plugins/graph/gvrelgraph.py:879
 msgid "Whether to include dates and/or places"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:843
+#: ../gramps/plugins/graph/gvrelgraph.py:882
+msgid "Show all family nodes"
+msgstr ""
+
+#: ../gramps/plugins/graph/gvrelgraph.py:883
+msgid ""
+"Show family nodes even if the output contains only one member of the family."
+msgstr ""
+
+#: ../gramps/plugins/graph/gvrelgraph.py:887
 msgid "Include URLs"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:844
+#: ../gramps/plugins/graph/gvrelgraph.py:888
 msgid ""
 "Include a URL in each graph node so that PDF and imagemap files can be "
 "generated that contain active links to the files generated by the 'Narrated "
 "Web Site' report."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:852
-#: ../gramps/plugins/textreport/birthdayreport.py:497
+#: ../gramps/plugins/graph/gvrelgraph.py:896
+#: ../gramps/plugins/textreport/birthdayreport.py:568
 #: ../gramps/plugins/textreport/indivcomplete.py:1145
 msgid "Include relationship to center person"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:853
+#: ../gramps/plugins/graph/gvrelgraph.py:897
 msgid "Whether to show every person's relationship to the center person"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:862
+#: ../gramps/plugins/graph/gvrelgraph.py:906
 msgid "Whether to include thumbnails of people."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:866
+#: ../gramps/plugins/graph/gvrelgraph.py:910
 msgid "Thumbnail Location"
 msgstr ""
 
 #. occupation = BooleanOption(_("Include occupation"), False)
-#: ../gramps/plugins/graph/gvrelgraph.py:874
+#: ../gramps/plugins/graph/gvrelgraph.py:918
 msgid "Include occupation"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:875
+#: ../gramps/plugins/graph/gvrelgraph.py:919
 msgid "Do not include any occupation"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:876
+#: ../gramps/plugins/graph/gvrelgraph.py:920
 msgid "Include description of most recent occupation"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:878
+#: ../gramps/plugins/graph/gvrelgraph.py:922
 msgid "Include date, description and place of all occupations"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:880
+#: ../gramps/plugins/graph/gvrelgraph.py:924
 msgid "Whether to include the last occupation"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:884
+#: ../gramps/plugins/graph/gvrelgraph.py:928
 msgid "Include relationship debugging numbers also"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:887
+#: ../gramps/plugins/graph/gvrelgraph.py:931
 msgid ""
 "Whether to include 'Ga' and 'Gb' also, to debug the relationship calculator"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:915
+#: ../gramps/plugins/graph/gvrelgraph.py:959
 msgid "Indicate non-birth relationships with dotted lines"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:916
+#: ../gramps/plugins/graph/gvrelgraph.py:960
 msgid "Non-birth relationships will show up as dotted lines in the graph."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:920
+#: ../gramps/plugins/graph/gvrelgraph.py:964
 msgid "Show family nodes"
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:921
+#: ../gramps/plugins/graph/gvrelgraph.py:965
 msgid "Families will show up as ellipses, linked to parents and children."
 msgstr ""
 
@@ -22645,7 +22978,7 @@ msgstr ""
 msgid "Import data from vCard files"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:123
+#: ../gramps/plugins/importer/importcsv.py:124
 #: ../gramps/plugins/importer/importgedcom.py:129
 #: ../gramps/plugins/importer/importgedcom.py:143
 #: ../gramps/plugins/importer/importgeneweb.py:153
@@ -22660,199 +22993,295 @@ msgstr ""
 #. # (but the imports_test.py unittest currently requires it, so here it is)
 #. # a "VCARD import report" happens in VCardParser so this is not needed:
 #. # (but the imports_test.py unittest currently requires it, so here it is)
-#: ../gramps/plugins/importer/importcsv.py:125
+#: ../gramps/plugins/importer/importcsv.py:126
 #: ../gramps/plugins/importer/importgedcom.py:154
 #: ../gramps/plugins/importer/importgeneweb.py:162
-#: ../gramps/plugins/importer/importprogen.py:92
+#: ../gramps/plugins/importer/importprogen.py:197
 #: ../gramps/plugins/importer/importvcard.py:76
 msgid "Results"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:125
+#: ../gramps/plugins/importer/importcsv.py:126
 #: ../gramps/plugins/importer/importgedcom.py:154
 #: ../gramps/plugins/importer/importgeneweb.py:162
-#: ../gramps/plugins/importer/importprogen.py:92
+#: ../gramps/plugins/importer/importprogen.py:197
 #: ../gramps/plugins/importer/importvcard.py:76
 msgid "done"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:161
+#: ../gramps/plugins/importer/importcsv.py:162
 msgid "given name"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:164
+#: ../gramps/plugins/importer/importcsv.py:165
 msgid "call"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:165
+#: ../gramps/plugins/importer/importcsv.py:166
 msgid "Person or Place|title"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:165
+#: ../gramps/plugins/importer/importcsv.py:166
 msgid "title"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:168
+#: ../gramps/plugins/importer/importcsv.py:169
 msgid "gender"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:169
+#: ../gramps/plugins/importer/importcsv.py:170
 msgid "source"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:170
+#: ../gramps/plugins/importer/importcsv.py:171
 msgid "note"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:172
+#: ../gramps/plugins/importer/importcsv.py:173
 msgid "birth place"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:174
+#: ../gramps/plugins/importer/importcsv.py:175
 msgid "birth place id"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:179
+#: ../gramps/plugins/importer/importcsv.py:180
 msgid "birth source"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:181
+#: ../gramps/plugins/importer/importcsv.py:182
 msgid "baptism place"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:183
+#: ../gramps/plugins/importer/importcsv.py:184
 msgid "baptism place id"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:185
+#: ../gramps/plugins/importer/importcsv.py:186
 msgid "baptism date"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:187
+#: ../gramps/plugins/importer/importcsv.py:188
 msgid "baptism source"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:188
+#: ../gramps/plugins/importer/importcsv.py:189
 msgid "burial place"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:190
+#: ../gramps/plugins/importer/importcsv.py:191
 msgid "burial place id"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:192
+#: ../gramps/plugins/importer/importcsv.py:193
 msgid "burial date"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:194
+#: ../gramps/plugins/importer/importcsv.py:195
 msgid "burial source"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:196
+#: ../gramps/plugins/importer/importcsv.py:197
 msgid "death place"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:198
+#: ../gramps/plugins/importer/importcsv.py:199
 msgid "death place id"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:203
+#: ../gramps/plugins/importer/importcsv.py:204
 msgid "death source"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:205
+#: ../gramps/plugins/importer/importcsv.py:206
 msgid "death cause"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:208
+#: ../gramps/plugins/importer/importcsv.py:209
 msgid "person"
 msgstr ""
 
-#. ----------------------------------
 #: ../gramps/plugins/importer/importcsv.py:210
+msgid "Occupation description"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:210
+msgid "occupationdescr"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:211
+msgid "Occupation date"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:211
+msgid "occupationdate"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:212
+msgid "Occupation place"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:212
+msgid "occupationplace"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:213
+msgid "Occupation place id"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:213
+msgid "occupationplace_id"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:214
+msgid "Occupation source"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:214
+msgid "occupationsource"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:216
+msgid "residence date"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:216
+msgid "residencedate"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:217
+msgid "residence place"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:217
+msgid "residenceplace"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:218
+msgid "residence place id"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:218
+msgid "residenceplace_id"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:219
+msgid "residence source"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:219
+msgid "residencesource"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:221
+msgid "attribute type"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:221
+msgid "attributetype"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:222
+msgid "attribute value"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:222
+msgid "attributevalue"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:223
+msgid "attribute source"
+msgstr ""
+
+#: ../gramps/plugins/importer/importcsv.py:223
+msgid "attributesource"
+msgstr ""
+
+#. ----------------------------------
+#: ../gramps/plugins/importer/importcsv.py:226
 msgid "child"
 msgstr ""
 
 #. ----------------------------------
-#: ../gramps/plugins/importer/importcsv.py:213
+#: ../gramps/plugins/importer/importcsv.py:229
 msgid "mother"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:215
+#: ../gramps/plugins/importer/importcsv.py:231
 msgid "parent2"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:216
+#: ../gramps/plugins/importer/importcsv.py:232
 msgid "father"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:218
+#: ../gramps/plugins/importer/importcsv.py:234
 msgid "parent1"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:219
+#: ../gramps/plugins/importer/importcsv.py:235
 msgid "marriage"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:220
+#: ../gramps/plugins/importer/importcsv.py:236
 msgid "date"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:221
+#: ../gramps/plugins/importer/importcsv.py:237
 msgid "place"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:222
+#: ../gramps/plugins/importer/importcsv.py:238
 msgid "place id"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:223
+#: ../gramps/plugins/importer/importcsv.py:239
 msgid "name"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:224
+#: ../gramps/plugins/importer/importcsv.py:240
 msgid "type"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:225
+#: ../gramps/plugins/importer/importcsv.py:241
 msgid "latitude"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:226
+#: ../gramps/plugins/importer/importcsv.py:242
 msgid "longitude"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:227
+#: ../gramps/plugins/importer/importcsv.py:243
 msgid "code"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:228
+#: ../gramps/plugins/importer/importcsv.py:244
 msgid "enclosed by"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:229
+#: ../gramps/plugins/importer/importcsv.py:245
 msgid "enclosed_by"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:256
+#: ../gramps/plugins/importer/importcsv.py:272
 #, python-format
 msgid "format error: line %(line)d: %(zero)s"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:337
+#: ../gramps/plugins/importer/importcsv.py:353
 msgid "CSV Import"
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:339
+#: ../gramps/plugins/importer/importcsv.py:355
 msgid "Reading data..."
 msgstr ""
 
-#: ../gramps/plugins/importer/importcsv.py:346
+#: ../gramps/plugins/importer/importcsv.py:362
 msgid "CSV import"
 msgstr ""
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/importer/importcsv.py:354
+#: ../gramps/plugins/importer/importcsv.py:370
 #: ../gramps/plugins/importer/importgeneweb.py:274
 #: ../gramps/plugins/importer/importvcard.py:249
 #, python-brace-format
@@ -22932,7 +23361,7 @@ msgid "Change Name"
 msgstr ""
 
 #: ../gramps/plugins/importer/importgeneweb.py:90
-#: ../gramps/plugins/lib/libgedcom.py:705
+#: ../gramps/plugins/lib/libgedcom.py:697
 msgid "Circumcision"
 msgstr ""
 
@@ -22945,7 +23374,7 @@ msgid "Dotation"
 msgstr ""
 
 #: ../gramps/plugins/importer/importgeneweb.py:101
-#: ../gramps/plugins/lib/libgedcom.py:711
+#: ../gramps/plugins/lib/libgedcom.py:703
 msgid "Excommunication"
 msgstr ""
 
@@ -22954,7 +23383,7 @@ msgid "LDS Family Link"
 msgstr ""
 
 #: ../gramps/plugins/importer/importgeneweb.py:104
-#: ../gramps/plugins/lib/libgedcom.py:713
+#: ../gramps/plugins/lib/libgedcom.py:705
 msgid "Funeral"
 msgstr ""
 
@@ -23060,8 +23489,7 @@ msgid ""
 msgstr ""
 
 #: ../gramps/plugins/importer/importgrdb.py:61
-#: ../gramps/plugins/importer/importprogen.py:81
-#: ../gramps/plugins/importer/importprogen.py:90
+#: ../gramps/plugins/importer/importprogen.py:189
 #: ../gramps/plugins/importer/importxml.py:440
 #: ../gramps/plugins/importer/importxml.py:443
 #, python-format
@@ -23079,54 +23507,242 @@ msgid ""
 "into that version. Please refer to:%(gramps_wiki_migrate_two_to_three_url)s"
 msgstr ""
 
-#: ../gramps/plugins/importer/importprogen.py:87
-#: ../gramps/plugins/importer/importprogen.py:517
-msgid "Pro-Gen data error"
+#: ../gramps/plugins/importer/importprogen.glade:49
+#: ../gramps/plugins/importer/importprogen.glade:70
+msgid ""
+"Source reference\n"
+"(out of Settings)"
 msgstr ""
 
-#: ../gramps/plugins/importer/importprogen.py:183
-msgid "Not a Pro-Gen file"
+#: ../gramps/plugins/importer/importprogen.glade:124
+msgid ""
+"Source reference text\n"
+"(Text & import Filename)."
 msgstr ""
 
-#: ../gramps/plugins/importer/importprogen.py:396
-#, python-format
-msgid "Field '%(fldname)s' not found"
+#: ../gramps/plugins/importer/importprogen.glade:155
+#: ../gramps/plugins/importer/importprogen.glade:325
+msgid "Attribut"
 msgstr ""
 
-#: ../gramps/plugins/importer/importprogen.py:460
-#, python-format
-msgid "Cannot find DEF file: %(dname)s"
+#: ../gramps/plugins/importer/importprogen.glade:171
+msgid ""
+"Source attribute text\n"
+"(Text, import Filename & (System-)Date)."
 msgstr ""
 
-#. Raise a error message
-#: ../gramps/plugins/importer/importprogen.py:516
-msgid "Not a supported Pro-Gen import file language"
+#: ../gramps/plugins/importer/importprogen.glade:190
+#: ../gramps/plugins/importer/importprogen.glade:207
+msgid "Citation reference."
 msgstr ""
 
-#. self.reset(_("Import from Pro-Gen"))  # non-functional for now
-#: ../gramps/plugins/importer/importprogen.py:527
-msgid "Pro-Gen import"
+#: ../gramps/plugins/importer/importprogen.glade:274
+msgid ""
+"Citation confidence level\n"
+"(Very low - very high)."
 msgstr ""
 
-#: ../gramps/plugins/importer/importprogen.py:586
+#: ../gramps/plugins/importer/importprogen.glade:308
+msgid ""
+"Citation volume/page text\n"
+"(Text & (System-)Date)."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:341
+msgid ""
+"Citation attribute text\n"
+"(Text, import Filename & (System-)Date)."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:362
+msgid "Import Text"
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:415
+msgid ""
+"Default Tagtext\n"
+"(out of Settings)."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:443
+msgid "Import Filename."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:492
+msgid "Default (System-)Date."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:766
+#: ../gramps/plugins/importer/importprogen.glade:781
+#: ../gramps/plugins/importer/importprogen.glade:796
+#: ../gramps/plugins/importer/importprogen.glade:811
+#: ../gramps/plugins/importer/importprogen.glade:826
+#: ../gramps/plugins/importer/importprogen.glade:841
+#: ../gramps/plugins/importer/importprogen.glade:856
+msgid "Combined default text + filename + date."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1111
+msgid ""
+"Copy Default Text\n"
+"to all Tag Text'."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1130
+msgid ""
+"Copy Default Filename\n"
+"to all sensitive Tag Text'."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1149
+msgid ""
+"Copy Default Date\n"
+"to all sensitive Tag Text'."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1164
+msgid "  Objects"
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1168
+msgid ""
+"Enable/Disable\n"
+"all object tags."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1198
+msgid "Tag Text"
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1217
+msgid "Import Objects"
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1241
+msgid ""
+"Enable/Disable\n"
+"Person import."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1260
+msgid ""
+"Enable/Disable\n"
+"Family import."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1279
+msgid ""
+"Enable/Disable\n"
+"Child import."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1330
+msgid ""
+"Use original Person\n"
+"Identifier as Gramps ID."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1349
+msgid ""
+"Use original Family\n"
+"Identifier as Gramps ID."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1369
+msgid "Identifier"
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1400
+msgid "Name change"
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1461
+msgid "Event date"
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1476
+msgid ""
+"Store birth date in\n"
+"event description."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1495
+msgid ""
+"Store death date in\n"
+"event description."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1515
+msgid "Diverse"
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1526
+msgid "REFN"
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1530
+msgid ""
+"Store REFN number\n"
+"in event description."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1548
+#: ../gramps/plugins/importer/importprogen.glade:1595
+msgid ""
+"Use death information\n"
+"as death cause event."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1598
+msgid "(-cause)"
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1610
+msgid "Male surname"
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1614
+msgid ""
+"Change name of male\n"
+"to e.g. wifes name."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1629
+msgid "Female surname"
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1633
+msgid ""
+"Change name of female\n"
+"to e.g. husbands name."
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1692
+msgid "Option"
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.glade:1731
+msgid "_Ok"
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.py:62
+msgid "manual|Import_from_another_genealogy_program"
+msgstr ""
+
+#: ../gramps/plugins/importer/importprogen.py:121
 #, python-format
 msgid "Import from Pro-Gen (%s)"
 msgstr ""
 
-#. Hmmm. Just use the plain text.
-#: ../gramps/plugins/importer/importprogen.py:1066
-#, python-format
-msgid "Date did not match: '%(text)s' (%(msg)s)"
+#: ../gramps/plugins/importer/importprogen.py:186
+#: ../gramps/plugins/lib/libprogen.py:492
+#: ../gramps/plugins/lib/libprogen.py:516
+msgid "Pro-Gen data error"
 msgstr ""
 
-#: ../gramps/plugins/importer/importprogen.py:1790
-#, python-format
-msgid "Cannot find father for I%(person)s (Father=%(id)d)"
-msgstr ""
-
-#: ../gramps/plugins/importer/importprogen.py:1793
-#, python-format
-msgid "Cannot find mother for I%(person)s (Mother=%(mother)d)"
+#: ../gramps/plugins/importer/importprogen.py:457
+#: ../gramps/plugins/importer/importprogen.py:465
+msgid "Import Pro-Gen"
 msgstr ""
 
 #: ../gramps/plugins/importer/importvcard.py:228
@@ -23348,26 +23964,26 @@ msgid ""
 msgstr ""
 
 #. there is no old style XML
-#: ../gramps/plugins/importer/importxml.py:808
-#: ../gramps/plugins/importer/importxml.py:1289
-#: ../gramps/plugins/importer/importxml.py:1563
-#: ../gramps/plugins/importer/importxml.py:1984
+#: ../gramps/plugins/importer/importxml.py:809
+#: ../gramps/plugins/importer/importxml.py:1294
+#: ../gramps/plugins/importer/importxml.py:1568
+#: ../gramps/plugins/importer/importxml.py:1989
 msgid "The Gramps Xml you are trying to import is malformed."
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:809
+#: ../gramps/plugins/importer/importxml.py:810
 msgid "Attributes that link the data together are missing."
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:922
+#: ../gramps/plugins/importer/importxml.py:923
 msgid "Gramps XML import"
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:957
+#: ../gramps/plugins/importer/importxml.py:958
 msgid "Could not change media path"
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:958
+#: ../gramps/plugins/importer/importxml.py:959
 #, python-format
 msgid ""
 "The opened file has media path %s, which conflicts with the media path of "
@@ -23376,7 +23992,7 @@ msgid ""
 "Preferences."
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:1017
+#: ../gramps/plugins/importer/importxml.py:1018
 msgid ""
 "The .gramps file you are importing does not contain information about the "
 "version of Gramps with, which it was produced.\n"
@@ -23384,11 +24000,11 @@ msgid ""
 "The file will not be imported."
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:1020
+#: ../gramps/plugins/importer/importxml.py:1021
 msgid "Import file misses Gramps version"
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:1022
+#: ../gramps/plugins/importer/importxml.py:1023
 #, python-format
 msgid ""
 "The .gramps file you are importing was made by version %(newer)s of Gramps, "
@@ -23396,7 +24012,7 @@ msgid ""
 "imported. Please upgrade to the latest version of Gramps and try again."
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:1030
+#: ../gramps/plugins/importer/importxml.py:1031
 #, python-format
 msgid ""
 "The .gramps file you are importing was made by version %(oldgramps)s of "
@@ -23409,11 +24025,11 @@ msgid ""
 " for more info."
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:1041
+#: ../gramps/plugins/importer/importxml.py:1042
 msgid "The file will not be imported"
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:1043
+#: ../gramps/plugins/importer/importxml.py:1044
 #, python-format
 msgid ""
 "The .gramps file you are importing was made by version %(oldgramps)s of "
@@ -23427,70 +24043,70 @@ msgid ""
 "for more info."
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:1056
+#: ../gramps/plugins/importer/importxml.py:1057
 msgid "Old xml file"
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:1209
-#: ../gramps/plugins/importer/importxml.py:2701
+#: ../gramps/plugins/importer/importxml.py:1212
+#: ../gramps/plugins/importer/importxml.py:2712
 #, python-format
 msgid "Witness name: %s"
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:1290
+#: ../gramps/plugins/importer/importxml.py:1295
 msgid "Any event reference must have a 'hlink' attribute."
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:1564
+#: ../gramps/plugins/importer/importxml.py:1569
 msgid "Any person reference must have a 'hlink' attribute."
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:1753
+#: ../gramps/plugins/importer/importxml.py:1758
 #, python-format
 msgid ""
 "Your Family Tree groups name \"%(key)s\" together with \"%(parent)s\", did "
 "not change this grouping to \"%(value)s\"."
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:1756
+#: ../gramps/plugins/importer/importxml.py:1761
 msgid "Gramps ignored a name grouping"
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:1815
+#: ../gramps/plugins/importer/importxml.py:1820
 msgid "Unknown when imported"
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:1985
+#: ../gramps/plugins/importer/importxml.py:1990
 msgid "Any note reference must have a 'hlink' attribute."
 msgstr ""
 
 #. TRANSLATORS: leave the {date} and {xml} untranslated in the format string,
 #. but you may re-order them if needed.
-#: ../gramps/plugins/importer/importxml.py:2519
+#: ../gramps/plugins/importer/importxml.py:2530
 #, python-brace-format
 msgid "Invalid date {date} in XML {xml}, preserving XML as text"
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:2571
+#: ../gramps/plugins/importer/importxml.py:2582
 #, python-format
 msgid "Witness comment: %s"
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:3224
+#: ../gramps/plugins/importer/importxml.py:3235
 #, python-format
 msgid ""
 "Error: family '%(family)s' father '%(father)s' does not refer back to the "
 "family. Reference added."
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:3240
+#: ../gramps/plugins/importer/importxml.py:3251
 #, python-format
 msgid ""
 "Error: family '%(family)s' mother '%(mother)s' does not refer back to the "
 "family. Reference added."
 msgstr ""
 
-#: ../gramps/plugins/importer/importxml.py:3262
+#: ../gramps/plugins/importer/importxml.py:3273
 #, python-format
 msgid ""
 "Error: family '%(family)s' child '%(child)s' does not refer back to the "
@@ -23504,131 +24120,131 @@ msgid ""
 " Writing to %(filename)s in format %(impliedext)s."
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:706
+#: ../gramps/plugins/lib/libgedcom.py:698
 msgid "Common Law Marriage"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:707
-#: ../gramps/plugins/webreport/narrativeweb.py:1589
-#: ../gramps/plugins/webreport/webcal.py:1622
+#: ../gramps/plugins/lib/libgedcom.py:699
+#: ../gramps/plugins/webreport/narrativeweb.py:1626
+#: ../gramps/plugins/webreport/webcal.py:1661
 msgid "Destination"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:708
+#: ../gramps/plugins/lib/libgedcom.py:700
 msgid "DNA"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:709
+#: ../gramps/plugins/lib/libgedcom.py:701
 msgid "Cause of Death"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:710
+#: ../gramps/plugins/lib/libgedcom.py:702
 msgid "Employment"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:712
+#: ../gramps/plugins/lib/libgedcom.py:704
 msgid "Eye Color"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:714
+#: ../gramps/plugins/lib/libgedcom.py:706
 msgid "Height"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:715
+#: ../gramps/plugins/lib/libgedcom.py:707
 msgid "Initiatory (LDS)"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:716
+#: ../gramps/plugins/lib/libgedcom.py:708
 msgid "Military ID"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:717
+#: ../gramps/plugins/lib/libgedcom.py:709
 msgid "Mission (LDS)"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:718
+#: ../gramps/plugins/lib/libgedcom.py:710
 msgid "Namesake"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:719
+#: ../gramps/plugins/lib/libgedcom.py:711
 msgid "Ordinance"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:721
+#: ../gramps/plugins/lib/libgedcom.py:713
 msgid "Separation"
 msgstr ""
 
 #. Applies to Families
-#: ../gramps/plugins/lib/libgedcom.py:722
+#: ../gramps/plugins/lib/libgedcom.py:714
 msgid "Weight"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:934
+#: ../gramps/plugins/lib/libgedcom.py:926
 msgid "Line ignored "
 msgstr ""
 
 #. e.g. Illegal character (oxAB) (0xCB)... 1 NOTE xyz?pqr?lmn
-#: ../gramps/plugins/lib/libgedcom.py:1547
+#: ../gramps/plugins/lib/libgedcom.py:1539
 #, python-format
 msgid "Illegal character%s"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:1827
+#: ../gramps/plugins/lib/libgedcom.py:1819
 msgid "Your GEDCOM file is corrupted. It appears to have been truncated."
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:1911
+#: ../gramps/plugins/lib/libgedcom.py:1903
 #, python-format
 msgid "Import from GEDCOM (%s)"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:2745
-#: ../gramps/plugins/lib/libgedcom.py:3199
+#: ../gramps/plugins/lib/libgedcom.py:2736
+#: ../gramps/plugins/lib/libgedcom.py:3193
 msgid "GEDCOM import"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:2773
+#: ../gramps/plugins/lib/libgedcom.py:2764
 msgid "GEDCOM import report: No errors detected"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:2775
+#: ../gramps/plugins/lib/libgedcom.py:2766
 #, python-format
 msgid "GEDCOM import report: %s errors detected"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:3092
-#: ../gramps/plugins/lib/libgedcom.py:3117
-#: ../gramps/plugins/lib/libgedcom.py:3130
+#: ../gramps/plugins/lib/libgedcom.py:3086
+#: ../gramps/plugins/lib/libgedcom.py:3111
+#: ../gramps/plugins/lib/libgedcom.py:3124
 msgid "Line ignored as not understood"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:3119
+#: ../gramps/plugins/lib/libgedcom.py:3113
 msgid "Tag recognized but not supported"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:3155
+#: ../gramps/plugins/lib/libgedcom.py:3149
 msgid "Skipped subordinate line"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:3188
+#: ../gramps/plugins/lib/libgedcom.py:3182
 msgid "Records not imported into "
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:3226
+#: ../gramps/plugins/lib/libgedcom.py:3220
 #, python-format
 msgid ""
 "Error: %(msg)s  '%(gramps_id)s' (input as @%(xref)s@) not in input GEDCOM. "
 "Record synthesised"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:3235
+#: ../gramps/plugins/lib/libgedcom.py:3229
 #, python-format
 msgid ""
 "Error: %(msg)s '%(gramps_id)s' (input as @%(xref)s@) not in input GEDCOM. "
 "Record with typifying attribute 'Unknown' created"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:3279
+#: ../gramps/plugins/lib/libgedcom.py:3273
 #, python-format
 msgid ""
 "Error: family '%(family)s' (input as @%(orig_family)s@) person %(person)s "
@@ -23636,7 +24252,7 @@ msgid ""
 "reference removed from person"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:3357
+#: ../gramps/plugins/lib/libgedcom.py:3351
 #, python-format
 msgid ""
 "\n"
@@ -23650,106 +24266,106 @@ msgstr ""
 #. message means that the element %s was ignored, but
 #. expressed the wrong way round because the message is
 #. truncated for output
-#: ../gramps/plugins/lib/libgedcom.py:3431
+#: ../gramps/plugins/lib/libgedcom.py:3425
 #, python-format
 msgid "ADDR element ignored '%s'"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:3452
+#: ../gramps/plugins/lib/libgedcom.py:3446
 msgid "TRLR (trailer)"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:3481
+#: ../gramps/plugins/lib/libgedcom.py:3475
 msgid "(Submitter):"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:3505
+#: ../gramps/plugins/lib/libgedcom.py:3499
 #: ../gramps/plugins/lib/libgedcom.py:7273
 msgid "GEDCOM data"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:3550
+#: ../gramps/plugins/lib/libgedcom.py:3544
 msgid "Unknown tag"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:3552
-#: ../gramps/plugins/lib/libgedcom.py:3566
-#: ../gramps/plugins/lib/libgedcom.py:3570
-#: ../gramps/plugins/lib/libgedcom.py:3591
+#: ../gramps/plugins/lib/libgedcom.py:3546
+#: ../gramps/plugins/lib/libgedcom.py:3560
+#: ../gramps/plugins/lib/libgedcom.py:3564
+#: ../gramps/plugins/lib/libgedcom.py:3585
 msgid "Top Level"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:3666
+#: ../gramps/plugins/lib/libgedcom.py:3660
 #, python-format
 msgid "INDI (individual) Gramps ID %s"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:3785
+#: ../gramps/plugins/lib/libgedcom.py:3779
 msgid "Empty Alias <NAME PERSONAL> ignored"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:4979
+#: ../gramps/plugins/lib/libgedcom.py:4973
 #, python-format
 msgid "FAM (family) Gramps ID %s"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:5341
-#: ../gramps/plugins/lib/libgedcom.py:6705
+#: ../gramps/plugins/lib/libgedcom.py:5335
+#: ../gramps/plugins/lib/libgedcom.py:6694
 msgid "Filename omitted"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:5374
-#: ../gramps/plugins/lib/libgedcom.py:6746
+#: ../gramps/plugins/lib/libgedcom.py:5369
+#: ../gramps/plugins/lib/libgedcom.py:6747
 #, python-format
 msgid "Could not import %s"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:5431
+#: ../gramps/plugins/lib/libgedcom.py:5435
 #: ../gramps/plugins/lib/libgedcom.py:6846
 msgid "Media-Type"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:5455
+#: ../gramps/plugins/lib/libgedcom.py:5459
 #: ../gramps/plugins/lib/libgedcom.py:6736
 msgid "Multiple FILE in a single OBJE ignored"
 msgstr ""
 
 #. We have previously found a PLAC
-#: ../gramps/plugins/lib/libgedcom.py:5609
+#: ../gramps/plugins/lib/libgedcom.py:5598
 msgid "A second PLAC ignored"
 msgstr ""
 
 #. For RootsMagic etc. Place Details e.g. address, hospital, ...
-#: ../gramps/plugins/lib/libgedcom.py:5748
+#: ../gramps/plugins/lib/libgedcom.py:5737
 msgid "Detail"
 msgstr ""
 
 #. We have perviously found an ADDR, or have populated
 #. location from PLAC title
-#: ../gramps/plugins/lib/libgedcom.py:5761
+#: ../gramps/plugins/lib/libgedcom.py:5750
 msgid "Location already populated; ADDR ignored"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:6166
+#: ../gramps/plugins/lib/libgedcom.py:6155
 #: ../gramps/plugins/lib/libgedcom.py:7054
 msgid "Warn: ADDR overwritten"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:6331
+#: ../gramps/plugins/lib/libgedcom.py:6320
 msgid "Citation Justification"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:6358
+#: ../gramps/plugins/lib/libgedcom.py:6347
 msgid "REFN ignored"
 msgstr ""
 
 #. SOURce with the given gramps_id had no title
-#: ../gramps/plugins/lib/libgedcom.py:6457
+#: ../gramps/plugins/lib/libgedcom.py:6446
 #, python-format
 msgid "No title - ID %s"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:6462
+#: ../gramps/plugins/lib/libgedcom.py:6451
 #, python-format
 msgid "SOUR (source) Gramps ID %s"
 msgstr ""
@@ -23765,7 +24381,7 @@ msgid "REPO (repository) Gramps ID %s"
 msgstr ""
 
 #: ../gramps/plugins/lib/libgedcom.py:7003
-#: ../gramps/plugins/lib/libgedcom.py:7988
+#: ../gramps/plugins/lib/libgedcom.py:7991
 msgid "Only one phone number supported"
 msgstr ""
 
@@ -23905,17 +24521,17 @@ msgstr ""
 
 #. Okay we have no clue which temple this is.
 #. We should tell the user and store it anyway.
-#: ../gramps/plugins/lib/libgedcom.py:7926
+#: ../gramps/plugins/lib/libgedcom.py:7929
 msgid "Invalid temple code"
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:8022
+#: ../gramps/plugins/lib/libgedcom.py:8025
 msgid ""
 "Your GEDCOM file is corrupted. The file appears to be encoded using the "
 "UTF16 character set, but is missing the BOM marker."
 msgstr ""
 
-#: ../gramps/plugins/lib/libgedcom.py:8025
+#: ../gramps/plugins/lib/libgedcom.py:8028
 msgid "Your GEDCOM file is empty."
 msgstr ""
 
@@ -24083,7 +24699,7 @@ msgid "She was born on %(birth_date)s."
 msgstr ""
 
 #: ../gramps/plugins/lib/libnarrate.py:125
-#: ../gramps/plugins/webreport/webcal.py:2035
+#: ../gramps/plugins/webreport/webcal.py:2091
 #, python-format
 msgid "Born %(birth_date)s."
 msgstr ""
@@ -24435,7 +25051,7 @@ msgstr ""
 #. latin cross for html code
 #: ../gramps/plugins/lib/libnarrate.py:283
 #: ../gramps/plugins/lib/libnarrate.py:316
-#: ../gramps/plugins/webreport/webcal.py:2025
+#: ../gramps/plugins/webreport/webcal.py:2081
 #, python-format
 msgid "Died %(death_date)s."
 msgstr ""
@@ -27007,7 +27623,7 @@ msgstr ""
 #: ../gramps/plugins/lib/libplaceview.py:94
 #: ../gramps/plugins/view/citationlistview.py:104
 #: ../gramps/plugins/view/citationtreeview.py:99
-#: ../gramps/plugins/view/eventview.py:89
+#: ../gramps/plugins/view/eventview.py:85
 #: ../gramps/plugins/view/familyview.py:86
 #: ../gramps/plugins/view/mediaview.py:101
 #: ../gramps/plugins/view/noteview.py:84 ../gramps/plugins/view/repoview.py:99
@@ -27031,30 +27647,302 @@ msgstr ""
 msgid "Merge the selected persons"
 msgstr ""
 
+#: ../gramps/plugins/lib/libpersonview.py:186
+#: ../gramps/plugins/lib/libplaceview.py:269
+#: ../gramps/plugins/view/citationlistview.py:161
+#: ../gramps/plugins/view/citationtreeview.py:303
+#: ../gramps/plugins/view/eventview.py:175
+#: ../gramps/plugins/view/familyview.py:134
+#: ../gramps/plugins/view/mediaview.py:234
+#: ../gramps/plugins/view/noteview.py:134
+#: ../gramps/plugins/view/repoview.py:147
+#: ../gramps/plugins/view/sourceview.py:133
+msgid "Export View..."
+msgstr ""
+
+#: ../gramps/plugins/lib/libpersonview.py:194
+#: ../gramps/plugins/lib/libplaceview.py:277
+#: ../gramps/plugins/view/citationlistview.py:169
+#: ../gramps/plugins/view/citationtreeview.py:311
+#: ../gramps/plugins/view/eventview.py:183
+#: ../gramps/plugins/view/familyview.py:142
+#: ../gramps/plugins/view/fanchartview.py:172
+#: ../gramps/plugins/view/geoclose.py:99 ../gramps/plugins/view/geoevents.py:89
+#: ../gramps/plugins/view/geofamclose.py:97
+#: ../gramps/plugins/view/geofamily.py:89 ../gramps/plugins/view/geomoves.py:96
+#: ../gramps/plugins/view/geoperson.py:97
+#: ../gramps/plugins/view/geoplaces.py:92
+#: ../gramps/plugins/view/mediaview.py:242
+#: ../gramps/plugins/view/noteview.py:142
+#: ../gramps/plugins/view/pedigreeview.py:672
+#: ../gramps/plugins/view/relview.py:364 ../gramps/plugins/view/relview.py:416
+#: ../gramps/plugins/view/repoview.py:155
+#: ../gramps/plugins/view/sourceview.py:141
+msgid "_Add Bookmark"
+msgstr ""
+
+#: ../gramps/plugins/lib/libpersonview.py:206
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:289
+#: ../gramps/plugins/lib/libplaceview.py:332
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:181
+#: ../gramps/plugins/view/citationlistview.py:224
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:323
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:195
+#: ../gramps/plugins/view/eventview.py:238
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:154
+#: ../gramps/plugins/view/familyview.py:197
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/fanchartview.py:144
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:71 ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoevents.py:67
+#: ../gramps/plugins/view/geoevents.py:101
+#: ../gramps/plugins/view/geofamclose.py:69
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geofamily.py:67
+#: ../gramps/plugins/view/geofamily.py:101
+#: ../gramps/plugins/view/geomoves.py:68 ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:69
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/geoplaces.py:70
+#: ../gramps/plugins/view/geoplaces.py:104
+#: ../gramps/plugins/view/mediaview.py:254
+#: ../gramps/plugins/view/mediaview.py:297
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:154
+#: ../gramps/plugins/view/noteview.py:197
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/pedigreeview.py:652
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428 ../gramps/plugins/view/repoview.py:167
+#: ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:153
+#: ../gramps/plugins/view/sourceview.py:196
+#: ../gramps/plugins/view/sourceview.py:278
+msgid "_Back"
+msgstr ""
+
+#: ../gramps/plugins/lib/libpersonview.py:206
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/view/fanchartview.py:144
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:71 ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geofamclose.py:69
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geomoves.py:68 ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:69
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/pedigreeview.py:652
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/pedigreeview.py:1647
+#: ../gramps/plugins/view/relview.py:364 ../gramps/plugins/view/relview.py:428
+msgid "_Home"
+msgstr ""
+
+#: ../gramps/plugins/lib/libpersonview.py:226
 #: ../gramps/plugins/lib/libpersonview.py:303
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:303
+#: ../gramps/plugins/lib/libplaceview.py:362
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:195
+#: ../gramps/plugins/view/citationlistview.py:254
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:209
+#: ../gramps/plugins/view/eventview.py:268
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:168
+#: ../gramps/plugins/view/familyview.py:227
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/mediaview.py:268
+#: ../gramps/plugins/view/mediaview.py:327
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:168
+#: ../gramps/plugins/view/noteview.py:227
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/repoview.py:181
+#: ../gramps/plugins/view/repoview.py:240
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:167
+#: ../gramps/plugins/view/sourceview.py:226
+#: ../gramps/plugins/view/sourceview.py:278
+msgid "_Add..."
+msgstr ""
+
+#: ../gramps/plugins/lib/libpersonview.py:226
+#: ../gramps/plugins/lib/libpersonview.py:303
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:303
+#: ../gramps/plugins/lib/libplaceview.py:362
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:195
+#: ../gramps/plugins/view/citationlistview.py:254
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:209
+#: ../gramps/plugins/view/eventview.py:268
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:168
+#: ../gramps/plugins/view/familyview.py:227
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/mediaview.py:268
+#: ../gramps/plugins/view/mediaview.py:327
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:168
+#: ../gramps/plugins/view/noteview.py:227
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/repoview.py:181
+#: ../gramps/plugins/view/repoview.py:240
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:167
+#: ../gramps/plugins/view/sourceview.py:226
+#: ../gramps/plugins/view/sourceview.py:278
+msgid "_Merge..."
+msgstr ""
+
+#: ../gramps/plugins/lib/libpersonview.py:245
+#: ../gramps/plugins/lib/libpersonview.py:403
+#: ../gramps/plugins/lib/libplaceview.py:322
+#: ../gramps/plugins/lib/libplaceview.py:457
+#: ../gramps/plugins/view/citationlistview.py:214
+#: ../gramps/plugins/view/citationlistview.py:342
+#: ../gramps/plugins/view/citationtreeview.py:364
+#: ../gramps/plugins/view/citationtreeview.py:527
+#: ../gramps/plugins/view/eventview.py:228
+#: ../gramps/plugins/view/eventview.py:357
+#: ../gramps/plugins/view/familyview.py:187
+#: ../gramps/plugins/view/familyview.py:328
+#: ../gramps/plugins/view/mediaview.py:287
+#: ../gramps/plugins/view/mediaview.py:441
+#: ../gramps/plugins/view/noteview.py:187
+#: ../gramps/plugins/view/noteview.py:316
+#: ../gramps/plugins/view/repoview.py:200
+#: ../gramps/plugins/view/repoview.py:329
+#: ../gramps/plugins/view/sourceview.py:186
+#: ../gramps/plugins/view/sourceview.py:315
+msgid "action|_Edit..."
+msgstr ""
+
+#: ../gramps/plugins/lib/libpersonview.py:246
+#: ../gramps/plugins/view/pedigreeview.py:684
+#: ../gramps/plugins/view/relview.py:385
+msgid "Person Filter Editor"
+msgstr ""
+
+#: ../gramps/plugins/lib/libpersonview.py:246
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/view/pedigreeview.py:1657
+msgid "Set _Home Person"
+msgstr ""
+
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428
+msgid "Go to the default person"
+msgstr ""
+
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libplaceview.py:332
+#: ../gramps/plugins/view/citationlistview.py:224
+#: ../gramps/plugins/view/citationtreeview.py:374
+#: ../gramps/plugins/view/eventview.py:238
+#: ../gramps/plugins/view/familyview.py:197
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoevents.py:101
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geofamily.py:101
+#: ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/geoplaces.py:104
+#: ../gramps/plugins/view/mediaview.py:297
+#: ../gramps/plugins/view/noteview.py:197
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428 ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/sourceview.py:196
+msgid "Go to the next object in the history"
+msgstr ""
+
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libplaceview.py:332
+#: ../gramps/plugins/view/citationlistview.py:224
+#: ../gramps/plugins/view/citationtreeview.py:374
+#: ../gramps/plugins/view/eventview.py:238
+#: ../gramps/plugins/view/familyview.py:197
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoevents.py:101
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geofamily.py:101
+#: ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/geoplaces.py:104
+#: ../gramps/plugins/view/mediaview.py:297
+#: ../gramps/plugins/view/noteview.py:197
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428 ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/sourceview.py:196
+msgid "Go to the previous object in the history"
+msgstr ""
+
+#: ../gramps/plugins/lib/libpersonview.py:303
+#: ../gramps/plugins/lib/libplaceview.py:362
+#: ../gramps/plugins/view/citationlistview.py:254
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/eventview.py:268
+#: ../gramps/plugins/view/familyview.py:227
+#: ../gramps/plugins/view/mediaview.py:327
+#: ../gramps/plugins/view/noteview.py:227 ../gramps/plugins/view/relview.py:385
+#: ../gramps/plugins/view/relview.py:471 ../gramps/plugins/view/repoview.py:240
+#: ../gramps/plugins/view/sourceview.py:226
+msgid "Edit..."
+msgstr ""
+
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:278
+msgid "Forward"
+msgstr ""
+
+#: ../gramps/plugins/lib/libpersonview.py:454
 msgid "_Delete Person"
 msgstr ""
 
-#: ../gramps/plugins/lib/libpersonview.py:321
+#: ../gramps/plugins/lib/libpersonview.py:472
 msgid "Deleting the person will remove the person from the database."
 msgstr ""
 
-#: ../gramps/plugins/lib/libpersonview.py:344
+#: ../gramps/plugins/lib/libpersonview.py:495
 #, python-format
 msgid "Delete Person (%s)"
 msgstr ""
 
-#: ../gramps/plugins/lib/libpersonview.py:380
-#: ../gramps/plugins/view/pedigreeview.py:697
-#: ../gramps/plugins/view/relview.py:423
-msgid "Person Filter Editor"
-msgstr ""
-
-#: ../gramps/plugins/lib/libpersonview.py:385
-msgid "Web Connection"
-msgstr ""
-
-#: ../gramps/plugins/lib/libpersonview.py:430
+#: ../gramps/plugins/lib/libpersonview.py:535
 msgid ""
 "Exactly two people must be selected to perform a merge. A second person can "
 "be selected by holding down the control key while clicking on the desired "
@@ -27073,77 +27961,65 @@ msgstr ""
 msgid "Merge the selected places"
 msgstr ""
 
-#: ../gramps/plugins/lib/libplaceview.py:155
-msgid "Loading..."
-msgstr ""
-
-#: ../gramps/plugins/lib/libplaceview.py:156
-#: ../gramps/plugins/lib/libplaceview.py:214
-msgid ""
-"Attempt to see selected locations with a Map Service (OpenstreetMap, Google "
-"Maps, ...)"
-msgstr ""
-
-#: ../gramps/plugins/lib/libplaceview.py:159
-#: ../gramps/plugins/lib/libplaceview.py:212
-msgid "Select a Map Service"
-msgstr ""
-
-#: ../gramps/plugins/lib/libplaceview.py:161
-msgid "_Look up with Map Service"
-msgstr ""
-
-#: ../gramps/plugins/lib/libplaceview.py:163
-msgid ""
-"Attempt to see this location with a Map Service (OpenstreetMap, Google "
-"Maps, ...)"
-msgstr ""
-
-#: ../gramps/plugins/lib/libplaceview.py:165
-msgid "Place Filter Editor"
-msgstr ""
-
-#: ../gramps/plugins/lib/libplaceview.py:264
+#: ../gramps/plugins/lib/libplaceview.py:229
 msgid "No map service is available."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplaceview.py:265
+#: ../gramps/plugins/lib/libplaceview.py:230
 msgid "Check your installation."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplaceview.py:273
+#: ../gramps/plugins/lib/libplaceview.py:238
 msgid "No place selected."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplaceview.py:274
+#: ../gramps/plugins/lib/libplaceview.py:239
 msgid ""
 "You need to select a place to be able to view it on a map. Some Map Services "
 "might support multiple selections."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplaceview.py:368
+#: ../gramps/plugins/lib/libplaceview.py:323
+msgid "Place Filter Editor"
+msgstr ""
+
+#: ../gramps/plugins/lib/libplaceview.py:415
+msgid "_Look up with Map Service"
+msgstr ""
+
+#: ../gramps/plugins/lib/libplaceview.py:466
+msgid ""
+"Attempt to see selected locations with a Map Service (OpenstreetMap, Google "
+"Maps, ...)"
+msgstr ""
+
+#: ../gramps/plugins/lib/libplaceview.py:466
+msgid "Select a Map Service"
+msgstr ""
+
+#: ../gramps/plugins/lib/libplaceview.py:506
 msgid "Cannot delete place."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplaceview.py:369
+#: ../gramps/plugins/lib/libplaceview.py:507
 msgid ""
 "This place is currently referenced by another place. First remove the places "
 "it contains."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplaceview.py:410
-#: ../gramps/plugins/lib/libplaceview.py:418
+#: ../gramps/plugins/lib/libplaceview.py:548
+#: ../gramps/plugins/lib/libplaceview.py:556
 msgid "Cannot merge places."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplaceview.py:411
+#: ../gramps/plugins/lib/libplaceview.py:549
 msgid ""
 "Exactly two places must be selected to perform a merge. A second place can "
 "be selected by holding down the control key while clicking on the desired "
 "place."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplaceview.py:419
+#: ../gramps/plugins/lib/libplaceview.py:557
 msgid "Merging these places would create a cycle in the place hierarchy."
 msgstr ""
 
@@ -27163,49 +28039,151 @@ msgstr ""
 msgid "Provides common functionality for Gramps XML import/export."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:106
+#: ../gramps/plugins/lib/libplugins.gpr.py:107
 msgid "Provides holiday information for different countries."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:124
+#: ../gramps/plugins/lib/libplugins.gpr.py:125
 msgid "Manages a HTML file implementing DocBackend."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:142
+#: ../gramps/plugins/lib/libplugins.gpr.py:143
 msgid "Common constants for html files."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:160
+#: ../gramps/plugins/lib/libplugins.gpr.py:161
 msgid "Manages an HTML DOM tree."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:178
+#: ../gramps/plugins/lib/libplugins.gpr.py:179
 msgid "Provides base functionality for map services."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:195
+#: ../gramps/plugins/lib/libplugins.gpr.py:196
 msgid "Provides Textual Narration."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:212
+#: ../gramps/plugins/lib/libplugins.gpr.py:213
 msgid "Manages an ODF file implementing DocBackend."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:229
+#: ../gramps/plugins/lib/libplugins.gpr.py:230
 msgid "Provides the Base needed for the List People views."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:246
+#: ../gramps/plugins/lib/libplugins.gpr.py:247
+msgid "Provides common functionality for Pro-Gen import"
+msgstr ""
+
+#: ../gramps/plugins/lib/libplugins.gpr.py:265
 msgid "Provides the Base needed for the List Place views."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:263
+#: ../gramps/plugins/lib/libplugins.gpr.py:282
 msgid "Provides variable substitution on display lines."
 msgstr ""
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:279
+#: ../gramps/plugins/lib/libplugins.gpr.py:299
 msgid ""
 "Provides the base needed for the ancestor and descendant graphical reports."
+msgstr ""
+
+#: ../gramps/plugins/lib/libprogen.py:375
+#, python-format
+msgid "Field '%(fldname)s' not found"
+msgstr ""
+
+#: ../gramps/plugins/lib/libprogen.py:491
+#, python-format
+msgid "Not a (right) DEF file: %(dname)s"
+msgstr ""
+
+#: ../gramps/plugins/lib/libprogen.py:498
+#: ../gramps/plugins/lib/libprogen.py:732
+msgid "Import from Pro-Gen"
+msgstr ""
+
+#. start feedback about import progress (GUI / TXT)
+#: ../gramps/plugins/lib/libprogen.py:498
+msgid "Initializing."
+msgstr ""
+
+#. Raise a error message
+#: ../gramps/plugins/lib/libprogen.py:515
+msgid "Not a supported Pro-Gen import file language"
+msgstr ""
+
+#: ../gramps/plugins/lib/libprogen.py:531
+msgid "Pro-Gen import"
+msgstr ""
+
+#: ../gramps/plugins/lib/libprogen.py:539
+msgid "Saving."
+msgstr ""
+
+#: ../gramps/plugins/lib/libprogen.py:928
+msgid "Pro-Gen Import"
+msgstr ""
+
+#. Hmmm. Just use the plain text.
+#: ../gramps/plugins/lib/libprogen.py:1137
+#, python-format
+msgid "Date did not match: '%(text)s' (%(msg)s)"
+msgstr ""
+
+#: ../gramps/plugins/lib/libprogen.py:1152
+#, python-format
+msgid "Time: %s"
+msgstr ""
+
+#. start feedback about import progress (GUI/TXT)
+#: ../gramps/plugins/lib/libprogen.py:1206
+msgid "Importing persons."
+msgstr ""
+
+#: ../gramps/plugins/lib/libprogen.py:1412
+msgid "see address on "
+msgstr ""
+
+#: ../gramps/plugins/lib/libprogen.py:1415
+msgid "see also address"
+msgstr ""
+
+#: ../gramps/plugins/lib/libprogen.py:1515
+msgid "Death cause"
+msgstr ""
+
+#. start feedback about import progress (GUI/TXT)
+#: ../gramps/plugins/lib/libprogen.py:1584
+msgid "Importing families."
+msgstr ""
+
+#: ../gramps/plugins/lib/libprogen.py:1689
+msgid "Civil union"
+msgstr ""
+
+#: ../gramps/plugins/lib/libprogen.py:1794
+msgid "Wedding"
+msgstr ""
+
+#: ../gramps/plugins/lib/libprogen.py:1829
+msgid "future"
+msgstr ""
+
+#. We have seen some case insensitivity in DEF files ...
+#. F13: Father
+#. F14: Mother
+#. start feedback about import progress (GUI/TXT)
+#: ../gramps/plugins/lib/libprogen.py:1901
+msgid "Adding children."
+msgstr ""
+
+#: ../gramps/plugins/lib/libprogen.py:1927
+msgid "Cannot find father for I%(person)s (Father=%(father))"
+msgstr ""
+
+#: ../gramps/plugins/lib/libprogen.py:1930
+msgid "Cannot find mother for I%(person)s (Mother=%(mother))"
 msgstr ""
 
 #: ../gramps/plugins/lib/librecords.py:55
@@ -27323,92 +28301,77 @@ msgstr ""
 msgid "Bottom Right"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:309
-#: ../gramps/plugins/view/fanchart2wayview.py:191
-#: ../gramps/plugins/view/fanchartdescview.py:186
-#: ../gramps/plugins/view/fanchartview.py:182
-msgid "_Print..."
-msgstr ""
-
-#: ../gramps/plugins/lib/maps/geography.py:311
-msgid "Print or save the Map"
-msgstr ""
-
-#: ../gramps/plugins/lib/maps/geography.py:348
-msgid "Map Menu"
-msgstr ""
-
-#: ../gramps/plugins/lib/maps/geography.py:351
+#: ../gramps/plugins/lib/maps/geography.py:355
 msgid "Remove cross hair"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:353
+#: ../gramps/plugins/lib/maps/geography.py:357
 msgid "Add cross hair"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:360
+#: ../gramps/plugins/lib/maps/geography.py:364
 msgid "Unlock zoom and position"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:362
+#: ../gramps/plugins/lib/maps/geography.py:366
 msgid "Lock zoom and position"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:369
+#: ../gramps/plugins/lib/maps/geography.py:373
 msgid "Add place"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:374
+#: ../gramps/plugins/lib/maps/geography.py:378
 msgid "Link place"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:379
+#: ../gramps/plugins/lib/maps/geography.py:383
 msgid "Add place from kml"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:384
+#: ../gramps/plugins/lib/maps/geography.py:388
 msgid "Center here"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:397
+#: ../gramps/plugins/lib/maps/geography.py:401
 #, python-format
 msgid "Replace '%(map)s' by =>"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:416
+#: ../gramps/plugins/lib/maps/geography.py:418
 #, python-format
 msgid "Reload all visible tiles for '%(map)s'."
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:426
+#: ../gramps/plugins/lib/maps/geography.py:427
 #, python-format
 msgid "Clear the '%(map)s' tiles cache."
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:886
+#: ../gramps/plugins/lib/maps/geography.py:850
 msgid "You can't use the print functionality"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:887
+#: ../gramps/plugins/lib/maps/geography.py:851
 msgid "Your Gtk version is too old."
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:928
-#: ../gramps/plugins/view/geoclose.py:554
-#: ../gramps/plugins/view/geoevents.py:348
-#: ../gramps/plugins/view/geoevents.py:381
-#: ../gramps/plugins/view/geofamclose.py:743
-#: ../gramps/plugins/view/geofamily.py:436
-#: ../gramps/plugins/view/geomoves.py:625
-#: ../gramps/plugins/view/geoperson.py:442
-#: ../gramps/plugins/view/geoperson.py:463
-#: ../gramps/plugins/view/geoperson.py:503
-#: ../gramps/plugins/view/geoplaces.py:440
-#: ../gramps/plugins/view/geoplaces.py:465
+#: ../gramps/plugins/lib/maps/geography.py:895
+#: ../gramps/plugins/view/geoclose.py:624
+#: ../gramps/plugins/view/geoevents.py:401
+#: ../gramps/plugins/view/geoevents.py:434
+#: ../gramps/plugins/view/geofamclose.py:813
+#: ../gramps/plugins/view/geofamily.py:486
+#: ../gramps/plugins/view/geomoves.py:691
+#: ../gramps/plugins/view/geoperson.py:508
+#: ../gramps/plugins/view/geoperson.py:529
+#: ../gramps/plugins/view/geoperson.py:569
+#: ../gramps/plugins/view/geoplaces.py:499
+#: ../gramps/plugins/view/geoplaces.py:524
 msgid "Center on this place"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:1007
+#: ../gramps/plugins/lib/maps/geography.py:993
 msgid "Select a kml file used to add places"
 msgstr ""
 
@@ -27427,45 +28390,45 @@ msgid ""
 "%(bold_start)sI can't proceed with your request%(bold_end)s.\n"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:1203
+#: ../gramps/plugins/lib/maps/geography.py:1228
 msgid "Nothing for this view."
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:1204
+#: ../gramps/plugins/lib/maps/geography.py:1229
 msgid "Specific parameters"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:1222
+#: ../gramps/plugins/lib/maps/geography.py:1247
 msgid "Where to save the tiles for offline mode."
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:1226
+#: ../gramps/plugins/lib/maps/geography.py:1253
 msgid ""
 "If you have no more space in your file system. You can remove all tiles "
 "placed in the above path.\n"
 "Be careful! If you have no internet, you'll get no map."
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:1231
+#: ../gramps/plugins/lib/maps/geography.py:1258
 msgid "Zoom used when centering"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:1235
+#: ../gramps/plugins/lib/maps/geography.py:1261
 msgid "The maximum number of places to show"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:1239
+#: ../gramps/plugins/lib/maps/geography.py:1265
 msgid ""
 "Use keypad for shortcuts :\n"
 "Either we choose the + and - from the keypad if we select this,\n"
 "or we use the characters from the keyboard."
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:1245
+#: ../gramps/plugins/lib/maps/geography.py:1271
 msgid "The map"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/geography.py:1261
+#: ../gramps/plugins/lib/maps/geography.py:1289
 msgid "Select tile cache directory for offline mode"
 msgstr ""
 
@@ -27480,37 +28443,49 @@ msgstr ""
 msgid "Can't create tiles cache directory for '%s'."
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/placeselection.py:110
-#: ../gramps/plugins/lib/maps/placeselection.py:112
+#: ../gramps/plugins/lib/maps/placeselection.py:119
+#: ../gramps/plugins/lib/maps/placeselection.py:121
 msgid "Place Selection in a region"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/placeselection.py:113
+#: ../gramps/plugins/lib/maps/placeselection.py:122
 msgid ""
 "Choose the radius of the selection.\n"
 "On the map you should see a circle or an oval depending on the latitude."
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/placeselection.py:151
+#: ../gramps/plugins/lib/maps/placeselection.py:125
+msgid ""
+"\n"
+"In the following table you may have :\n"
+" - a green row related to a selected place."
+msgstr ""
+
+#: ../gramps/plugins/lib/maps/placeselection.py:128
+msgid ""
+"\n"
+" - a red row related to a geocoding result."
+msgstr ""
+
+#: ../gramps/plugins/lib/maps/placeselection.py:165
 msgid "The green values in the row correspond to the current place values."
 msgstr ""
 
-#. here, we could add value from geography names services ...
 #. if we found no place, we must create a default place.
-#: ../gramps/plugins/lib/maps/placeselection.py:198
+#: ../gramps/plugins/lib/maps/placeselection.py:223
 msgid "New place with empty fields"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/placeselection.py:273
+#: ../gramps/plugins/lib/maps/placeselection.py:298
 msgid "you have a wrong latitude for:"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/placeselection.py:275
-#: ../gramps/plugins/lib/maps/placeselection.py:285
+#: ../gramps/plugins/lib/maps/placeselection.py:300
+#: ../gramps/plugins/lib/maps/placeselection.py:310
 msgid "Please, correct this before linking"
 msgstr ""
 
-#: ../gramps/plugins/lib/maps/placeselection.py:283
+#: ../gramps/plugins/lib/maps/placeselection.py:308
 msgid "you have a wrong longitude for:"
 msgstr ""
 
@@ -27569,7 +28544,7 @@ msgid "Open on maps.google.com"
 msgstr ""
 
 #: ../gramps/plugins/mapservices/mapservice.gpr.py:71
-#: ../gramps/plugins/webreport/narrativeweb.py:1942
+#: ../gramps/plugins/webreport/narrativeweb.py:2037
 msgid "OpenStreetMap"
 msgstr ""
 
@@ -27628,7 +28603,7 @@ msgstr ""
 #: ../gramps/plugins/quickview/all_events.py:60
 #: ../gramps/plugins/quickview/all_events.py:109
 #: ../gramps/plugins/quickview/all_events.py:124
-#: ../gramps/plugins/webreport/person.py:874
+#: ../gramps/plugins/webreport/person.py:894
 msgid "Event Type"
 msgstr ""
 
@@ -27704,11 +28679,11 @@ msgid "Parent"
 msgstr ""
 
 #: ../gramps/plugins/quickview/all_relations.py:286
-#: ../gramps/plugins/view/relview.py:406
-#: ../gramps/plugins/webreport/basepage.py:2319
-#: ../gramps/plugins/webreport/basepage.py:2321
-#: ../gramps/plugins/webreport/person.py:221
-#: ../gramps/plugins/webreport/surname.py:138
+#: ../gramps/plugins/view/relview.py:471
+#: ../gramps/plugins/webreport/basepage.py:2368
+#: ../gramps/plugins/webreport/basepage.py:2370
+#: ../gramps/plugins/webreport/person.py:227
+#: ../gramps/plugins/webreport/surname.py:149
 msgid "Partner"
 msgstr ""
 
@@ -27891,14 +28866,14 @@ msgstr ""
 #: ../gramps/plugins/view/view.gpr.py:267
 #: ../gramps/plugins/view/view.gpr.py:275
 #: ../gramps/plugins/view/view.gpr.py:306
-#: ../gramps/plugins/webreport/basepage.py:623
-#: ../gramps/plugins/webreport/basepage.py:938
-#: ../gramps/plugins/webreport/basepage.py:1112
-#: ../gramps/plugins/webreport/basepage.py:1238
-#: ../gramps/plugins/webreport/basepage.py:1482
-#: ../gramps/plugins/webreport/basepage.py:1541
-#: ../gramps/plugins/webreport/basepage.py:1611
-#: ../gramps/plugins/webreport/person.py:1170
+#: ../gramps/plugins/webreport/basepage.py:644
+#: ../gramps/plugins/webreport/basepage.py:965
+#: ../gramps/plugins/webreport/basepage.py:1139
+#: ../gramps/plugins/webreport/basepage.py:1265
+#: ../gramps/plugins/webreport/basepage.py:1531
+#: ../gramps/plugins/webreport/basepage.py:1583
+#: ../gramps/plugins/webreport/basepage.py:1652
+#: ../gramps/plugins/webreport/person.py:1243
 #: ../gramps/plugins/webreport/source.py:130
 #: ../gramps/plugins/webreport/source.py:227
 msgid "Sources"
@@ -28025,7 +29000,7 @@ msgstr ""
 
 #: ../gramps/plugins/quickview/lineage.py:160
 #: ../gramps/plugins/quickview/lineage.py:180
-#: ../gramps/plugins/tool/verify.py:1058
+#: ../gramps/plugins/tool/verify.py:1062
 msgid "Unknown gender"
 msgstr ""
 
@@ -28217,7 +29192,7 @@ msgid "No references for this %s"
 msgstr ""
 
 #: ../gramps/plugins/quickview/reporef.py:62
-#: ../gramps/plugins/webreport/basepage.py:2669
+#: ../gramps/plugins/webreport/basepage.py:2808
 msgid "Call number"
 msgstr ""
 
@@ -28458,14 +29433,14 @@ msgid "Ahnentafel Report for %s"
 msgstr ""
 
 #: ../gramps/plugins/textreport/ancestorreport.py:301
-#: ../gramps/plugins/textreport/detancestralreport.py:839
-#: ../gramps/plugins/textreport/detdescendantreport.py:1030
+#: ../gramps/plugins/textreport/detancestralreport.py:846
+#: ../gramps/plugins/textreport/detdescendantreport.py:1035
 msgid "Page break between generations"
 msgstr ""
 
 #: ../gramps/plugins/textreport/ancestorreport.py:303
-#: ../gramps/plugins/textreport/detancestralreport.py:841
-#: ../gramps/plugins/textreport/detdescendantreport.py:1032
+#: ../gramps/plugins/textreport/detancestralreport.py:848
+#: ../gramps/plugins/textreport/detdescendantreport.py:1037
 msgid "Whether to start a new page after each generation."
 msgstr ""
 
@@ -28478,8 +29453,8 @@ msgid "Whether a line break should follow the name."
 msgstr ""
 
 #: ../gramps/plugins/textreport/birthdayreport.py:65
-#: ../gramps/plugins/textreport/birthdayreport.py:220
-#: ../gramps/plugins/textreport/birthdayreport.py:265
+#: ../gramps/plugins/textreport/birthdayreport.py:224
+#: ../gramps/plugins/textreport/birthdayreport.py:269
 #: ../gramps/plugins/textreport/textplugins.gpr.py:59
 msgid "Birthday and Anniversary Report"
 msgstr ""
@@ -28488,78 +29463,137 @@ msgstr ""
 msgid "My Birthday Report"
 msgstr ""
 
+#: ../gramps/plugins/textreport/birthdayreport.py:68
+msgid "✝"
+msgstr ""
+
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/textreport/birthdayreport.py:217
+#: ../gramps/plugins/textreport/birthdayreport.py:221
 #, python-format
 msgid "Relationships shown are to %s"
 msgstr ""
 
-#: ../gramps/plugins/textreport/birthdayreport.py:323
+#: ../gramps/plugins/textreport/birthdayreport.py:333
 #, python-format
-msgid "%(person)s, birth%(relation)s"
+msgid "* %(person)s, birth%(relation)s"
 msgstr ""
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/textreport/birthdayreport.py:328
+#: ../gramps/plugins/textreport/birthdayreport.py:338
 #, python-brace-format
-msgid "{person}, {age}{relation}"
-msgid_plural "{person}, {age}{relation}"
+msgid "* {year}{person}{dead}, {age}{relation}"
+msgid_plural "* {year}{person}{dead}, {age}{relation}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gramps/plugins/textreport/birthdayreport.py:416
+#: ../gramps/plugins/textreport/birthdayreport.py:402
+#, python-format
+msgid ""
+"⚭ %(spouse)s and\n"
+" %(person)s, wedding"
+msgstr ""
+
+#. translators: leave all/any {...} untranslated
+#: ../gramps/plugins/textreport/birthdayreport.py:407
+#, python-brace-format
+msgid ""
+"⚭ {year}{spouse}{deadtxt2} and\n"
+" {person}{deadtxt1}, {nyears}"
+msgid_plural ""
+"⚭ {year}{spouse}{deadtxt2} and\n"
+" {person}{deadtxt1}, {nyears}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gramps/plugins/textreport/birthdayreport.py:442
+#, python-brace-format
+msgid "✝ {person}, death {relation}"
+msgstr ""
+
+#: ../gramps/plugins/textreport/birthdayreport.py:444
+#, python-brace-format
+msgid "✝ {year}{person}, {age}{relation}"
+msgid_plural "✝ {year}{person}, {age}{relation}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../gramps/plugins/textreport/birthdayreport.py:475
 #: ../gramps/plugins/textreport/familygroup.py:716
 #: ../gramps/plugins/textreport/indivcomplete.py:1064
 msgid "Select the filter to be applied to the report."
 msgstr ""
 
-#: ../gramps/plugins/textreport/birthdayreport.py:425
+#: ../gramps/plugins/textreport/birthdayreport.py:484
 msgid "Title text"
 msgstr ""
 
-#: ../gramps/plugins/textreport/birthdayreport.py:426
+#: ../gramps/plugins/textreport/birthdayreport.py:485
 msgid "Title of report"
 msgstr ""
 
-#: ../gramps/plugins/textreport/birthdayreport.py:430
+#: ../gramps/plugins/textreport/birthdayreport.py:489
 msgid "First line of text at bottom of report"
 msgstr ""
 
-#: ../gramps/plugins/textreport/birthdayreport.py:434
+#: ../gramps/plugins/textreport/birthdayreport.py:493
 msgid "Second line of text at bottom of report"
 msgstr ""
 
-#: ../gramps/plugins/textreport/birthdayreport.py:438
+#: ../gramps/plugins/textreport/birthdayreport.py:497
 msgid "Third line of text at bottom of report"
 msgstr ""
 
-#: ../gramps/plugins/textreport/birthdayreport.py:449
+#: ../gramps/plugins/textreport/birthdayreport.py:508
 msgid "Include only living people in the report"
 msgstr ""
 
-#: ../gramps/plugins/textreport/birthdayreport.py:458
-#: ../gramps/plugins/textreport/birthdayreport.py:460
+#: ../gramps/plugins/textreport/birthdayreport.py:511
+msgid "Dead Symbol"
+msgstr ""
+
+#: ../gramps/plugins/textreport/birthdayreport.py:512
+msgid "This will show after name to indicate that person is dead"
+msgstr ""
+
+#: ../gramps/plugins/textreport/birthdayreport.py:519
+msgid "Show event year"
+msgstr ""
+
+#: ../gramps/plugins/textreport/birthdayreport.py:520
+msgid "Prints the year the event took place in the report"
+msgstr ""
+
+#: ../gramps/plugins/textreport/birthdayreport.py:525
+#: ../gramps/plugins/textreport/birthdayreport.py:527
 msgid "Year of report"
 msgstr ""
 
-#: ../gramps/plugins/textreport/birthdayreport.py:499
+#: ../gramps/plugins/textreport/birthdayreport.py:563
+msgid "Include death anniversaries"
+msgstr ""
+
+#: ../gramps/plugins/textreport/birthdayreport.py:564
+msgid "Whether to include anniversaries of death"
+msgstr ""
+
+#: ../gramps/plugins/textreport/birthdayreport.py:570
 #: ../gramps/plugins/textreport/indivcomplete.py:1147
 msgid "Whether to include relationships to the center person"
 msgstr ""
 
-#: ../gramps/plugins/textreport/birthdayreport.py:568
+#: ../gramps/plugins/textreport/birthdayreport.py:639
 msgid "Title text style"
 msgstr ""
 
-#: ../gramps/plugins/textreport/birthdayreport.py:571
+#: ../gramps/plugins/textreport/birthdayreport.py:642
 msgid "Data text display"
 msgstr ""
 
-#: ../gramps/plugins/textreport/birthdayreport.py:573
+#: ../gramps/plugins/textreport/birthdayreport.py:644
 msgid "Day text style"
 msgstr ""
 
-#: ../gramps/plugins/textreport/birthdayreport.py:576
+#: ../gramps/plugins/textreport/birthdayreport.py:647
 msgid "Month text style"
 msgstr ""
 
@@ -28615,7 +29649,7 @@ msgid "%s sp."
 msgstr ""
 
 #: ../gramps/plugins/textreport/descendreport.py:526
-#: ../gramps/plugins/textreport/detdescendantreport.py:1006
+#: ../gramps/plugins/textreport/detdescendantreport.py:1011
 msgid "Numbering system"
 msgstr ""
 
@@ -28624,17 +29658,17 @@ msgid "Simple numbering"
 msgstr ""
 
 #: ../gramps/plugins/textreport/descendreport.py:529
-#: ../gramps/plugins/textreport/detdescendantreport.py:1010
+#: ../gramps/plugins/textreport/detdescendantreport.py:1015
 msgid "d'Aboville numbering"
 msgstr ""
 
 #: ../gramps/plugins/textreport/descendreport.py:530
-#: ../gramps/plugins/textreport/detdescendantreport.py:1008
+#: ../gramps/plugins/textreport/detdescendantreport.py:1013
 msgid "Henry numbering"
 msgstr ""
 
 #: ../gramps/plugins/textreport/descendreport.py:531
-#: ../gramps/plugins/textreport/detdescendantreport.py:1009
+#: ../gramps/plugins/textreport/detdescendantreport.py:1014
 msgid "Modified Henry numbering"
 msgstr ""
 
@@ -28647,7 +29681,7 @@ msgid "Meurgey de Tupigny numbering"
 msgstr ""
 
 #: ../gramps/plugins/textreport/descendreport.py:534
-#: ../gramps/plugins/textreport/detdescendantreport.py:1013
+#: ../gramps/plugins/textreport/detdescendantreport.py:1018
 msgid "The numbering system to be used"
 msgstr ""
 
@@ -28686,417 +29720,417 @@ msgid "The style used for the spouse level %d display."
 msgstr ""
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/textreport/detancestralreport.py:215
+#: ../gramps/plugins/textreport/detancestralreport.py:216
 #, python-format
 msgid "Ancestral Report for %s"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:278
-#: ../gramps/plugins/textreport/detdescendantreport.py:889
-#: ../gramps/plugins/textreport/detdescendantreport.py:907
-#: ../gramps/plugins/textreport/detdescendantreport.py:918
-#: ../gramps/plugins/textreport/detdescendantreport.py:944
+#: ../gramps/plugins/textreport/detancestralreport.py:279
+#: ../gramps/plugins/textreport/detdescendantreport.py:894
+#: ../gramps/plugins/textreport/detdescendantreport.py:912
+#: ../gramps/plugins/textreport/detdescendantreport.py:923
+#: ../gramps/plugins/textreport/detdescendantreport.py:949
 #, python-format
 msgid "More about %(person_name)s:"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:316
+#: ../gramps/plugins/textreport/detancestralreport.py:317
 #, python-format
 msgid "%(name)s is the same person as [%(id_str)s]."
 msgstr ""
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/textreport/detancestralreport.py:358
-#: ../gramps/plugins/textreport/detdescendantreport.py:876
+#: ../gramps/plugins/textreport/detancestralreport.py:361
+#: ../gramps/plugins/textreport/detdescendantreport.py:881
 #, python-format
 msgid "Notes for %s"
 msgstr ""
 
 #. translators: needed for French, ignore otherwise
-#: ../gramps/plugins/textreport/detancestralreport.py:376
-#: ../gramps/plugins/textreport/detancestralreport.py:427
-#: ../gramps/plugins/textreport/detancestralreport.py:495
-#: ../gramps/plugins/textreport/detdescendantreport.py:520
-#: ../gramps/plugins/textreport/detdescendantreport.py:812
-#: ../gramps/plugins/textreport/detdescendantreport.py:897
-#: ../gramps/plugins/textreport/detdescendantreport.py:953
+#: ../gramps/plugins/textreport/detancestralreport.py:379
+#: ../gramps/plugins/textreport/detancestralreport.py:430
+#: ../gramps/plugins/textreport/detancestralreport.py:498
+#: ../gramps/plugins/textreport/detdescendantreport.py:521
+#: ../gramps/plugins/textreport/detdescendantreport.py:815
+#: ../gramps/plugins/textreport/detdescendantreport.py:902
+#: ../gramps/plugins/textreport/detdescendantreport.py:958
 #, python-format
 msgid "%(type)s: %(value)s%(endnotes)s"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:405
-#: ../gramps/plugins/textreport/detdescendantreport.py:931
+#: ../gramps/plugins/textreport/detancestralreport.py:408
+#: ../gramps/plugins/textreport/detdescendantreport.py:936
 msgid "Address: "
 msgstr ""
 
 #. translators: needed for Arabic, ignore otherwise
-#: ../gramps/plugins/textreport/detancestralreport.py:414
-#: ../gramps/plugins/textreport/detdescendantreport.py:934
+#: ../gramps/plugins/textreport/detancestralreport.py:417
+#: ../gramps/plugins/textreport/detdescendantreport.py:939
 #, python-format
 msgid "%s, "
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:476
+#: ../gramps/plugins/textreport/detancestralreport.py:479
 #, python-format
 msgid "%(event_role)s at %(event_name)s of %(primary_person)s: %(event_text)s"
 msgstr ""
 
 #. translators: needed for Arabic, ignore otherwise
-#: ../gramps/plugins/textreport/detancestralreport.py:492
-#: ../gramps/plugins/textreport/detdescendantreport.py:414
-#: ../gramps/plugins/textreport/detdescendantreport.py:517
+#: ../gramps/plugins/textreport/detancestralreport.py:495
+#: ../gramps/plugins/textreport/detdescendantreport.py:415
+#: ../gramps/plugins/textreport/detdescendantreport.py:518
 #: ../gramps/plugins/textreport/familygroup.py:137
 msgid "; "
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:601
-#: ../gramps/plugins/textreport/detdescendantreport.py:678
+#: ../gramps/plugins/textreport/detancestralreport.py:604
+#: ../gramps/plugins/textreport/detdescendantreport.py:679
 #, python-format
 msgid "Children of %(mother_name)s and %(father_name)s"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:685
-#: ../gramps/plugins/textreport/detdescendantreport.py:785
-#: ../gramps/plugins/textreport/detdescendantreport.py:804
+#: ../gramps/plugins/textreport/detancestralreport.py:690
+#: ../gramps/plugins/textreport/detdescendantreport.py:788
+#: ../gramps/plugins/textreport/detdescendantreport.py:807
 #, python-format
 msgid "More about %(mother_name)s and %(father_name)s:"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:740
-#: ../gramps/plugins/textreport/detdescendantreport.py:613
+#: ../gramps/plugins/textreport/detancestralreport.py:745
+#: ../gramps/plugins/textreport/detdescendantreport.py:614
 #, python-format
 msgid "Spouse: %s"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:744
-#: ../gramps/plugins/textreport/detdescendantreport.py:617
+#: ../gramps/plugins/textreport/detancestralreport.py:749
+#: ../gramps/plugins/textreport/detdescendantreport.py:618
 #, python-format
 msgid "Relationship with: %s"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:828
+#: ../gramps/plugins/textreport/detancestralreport.py:835
 msgid "Sosa-Stradonitz number"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:830
+#: ../gramps/plugins/textreport/detancestralreport.py:837
 msgid "The Sosa-Stradonitz number of the central person."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:844
-#: ../gramps/plugins/textreport/detdescendantreport.py:1035
+#: ../gramps/plugins/textreport/detancestralreport.py:851
+#: ../gramps/plugins/textreport/detdescendantreport.py:1040
 #: ../gramps/plugins/textreport/indivcomplete.py:1077
 msgid "Page break before end notes"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:846
-#: ../gramps/plugins/textreport/detdescendantreport.py:1037
+#: ../gramps/plugins/textreport/detancestralreport.py:853
+#: ../gramps/plugins/textreport/detdescendantreport.py:1042
 #: ../gramps/plugins/textreport/indivcomplete.py:1079
 msgid "Whether to start a new page before the end notes."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:868
-#: ../gramps/plugins/textreport/detdescendantreport.py:1059
+#: ../gramps/plugins/textreport/detancestralreport.py:875
+#: ../gramps/plugins/textreport/detdescendantreport.py:1064
 msgid "Use complete sentences"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:870
-#: ../gramps/plugins/textreport/detdescendantreport.py:1061
+#: ../gramps/plugins/textreport/detancestralreport.py:877
+#: ../gramps/plugins/textreport/detdescendantreport.py:1066
 msgid "Whether to use complete sentences or succinct language."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:874
-#: ../gramps/plugins/textreport/detdescendantreport.py:1065
+#: ../gramps/plugins/textreport/detancestralreport.py:881
+#: ../gramps/plugins/textreport/detdescendantreport.py:1070
 msgid "Use full dates instead of only the year"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:876
-#: ../gramps/plugins/textreport/detdescendantreport.py:1067
+#: ../gramps/plugins/textreport/detancestralreport.py:883
+#: ../gramps/plugins/textreport/detdescendantreport.py:1072
 msgid "Whether to use full dates instead of just year."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:879
-#: ../gramps/plugins/textreport/detdescendantreport.py:1070
+#: ../gramps/plugins/textreport/detancestralreport.py:886
+#: ../gramps/plugins/textreport/detdescendantreport.py:1075
 msgid "Compute death age"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:880
-#: ../gramps/plugins/textreport/detdescendantreport.py:1071
+#: ../gramps/plugins/textreport/detancestralreport.py:887
+#: ../gramps/plugins/textreport/detdescendantreport.py:1076
 msgid "Whether to compute a person's age at death."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:883
+#: ../gramps/plugins/textreport/detancestralreport.py:890
 msgid "Omit duplicate ancestors"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:884
+#: ../gramps/plugins/textreport/detancestralreport.py:891
 msgid "Whether to omit duplicate ancestors."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:887
-#: ../gramps/plugins/textreport/detdescendantreport.py:1074
+#: ../gramps/plugins/textreport/detancestralreport.py:894
+#: ../gramps/plugins/textreport/detdescendantreport.py:1079
 msgid "Use callname for common name"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:888
-#: ../gramps/plugins/textreport/detdescendantreport.py:1075
+#: ../gramps/plugins/textreport/detancestralreport.py:895
+#: ../gramps/plugins/textreport/detdescendantreport.py:1080
 msgid "Whether to use the call name as the first name."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:896
-#: ../gramps/plugins/textreport/detdescendantreport.py:1083
+#: ../gramps/plugins/textreport/detancestralreport.py:903
+#: ../gramps/plugins/textreport/detdescendantreport.py:1088
 msgid "Whether to list children."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:899
-#: ../gramps/plugins/textreport/detdescendantreport.py:1086
+#: ../gramps/plugins/textreport/detancestralreport.py:906
+#: ../gramps/plugins/textreport/detdescendantreport.py:1091
 msgid "Include spouses of children"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:901
-#: ../gramps/plugins/textreport/detdescendantreport.py:1088
+#: ../gramps/plugins/textreport/detancestralreport.py:908
+#: ../gramps/plugins/textreport/detdescendantreport.py:1093
 msgid "Whether to list the spouses of the children."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:904
-#: ../gramps/plugins/textreport/detdescendantreport.py:1100
+#: ../gramps/plugins/textreport/detancestralreport.py:911
+#: ../gramps/plugins/textreport/detdescendantreport.py:1105
 msgid "Include events"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:905
-#: ../gramps/plugins/textreport/detdescendantreport.py:1101
+#: ../gramps/plugins/textreport/detancestralreport.py:912
+#: ../gramps/plugins/textreport/detdescendantreport.py:1106
 msgid "Whether to include events."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:908
+#: ../gramps/plugins/textreport/detancestralreport.py:915
 msgid "Include other events"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:909
+#: ../gramps/plugins/textreport/detancestralreport.py:916
 msgid "Whether to include other events people participated in."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:914
-#: ../gramps/plugins/textreport/detdescendantreport.py:1105
+#: ../gramps/plugins/textreport/detancestralreport.py:921
+#: ../gramps/plugins/textreport/detdescendantreport.py:1110
 msgid "Include descendant reference in child list"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:916
-#: ../gramps/plugins/textreport/detdescendantreport.py:1107
+#: ../gramps/plugins/textreport/detancestralreport.py:923
+#: ../gramps/plugins/textreport/detdescendantreport.py:1112
 msgid "Whether to add descendant references in child list."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:920
-#: ../gramps/plugins/textreport/detdescendantreport.py:1111
+#: ../gramps/plugins/textreport/detancestralreport.py:927
+#: ../gramps/plugins/textreport/detdescendantreport.py:1116
 #: ../gramps/plugins/textreport/indivcomplete.py:1122
 msgid "Include Photo/Images from Gallery"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:921
-#: ../gramps/plugins/textreport/detdescendantreport.py:1112
+#: ../gramps/plugins/textreport/detancestralreport.py:928
+#: ../gramps/plugins/textreport/detdescendantreport.py:1117
 #: ../gramps/plugins/textreport/indivcomplete.py:1123
 msgid "Whether to include images."
 msgstr ""
 
 #. #########################
 #. ###############################
-#: ../gramps/plugins/textreport/detancestralreport.py:924
-#: ../gramps/plugins/textreport/detdescendantreport.py:1115
+#: ../gramps/plugins/textreport/detancestralreport.py:931
+#: ../gramps/plugins/textreport/detdescendantreport.py:1120
 #: ../gramps/plugins/textreport/familygroup.py:782
 #: ../gramps/plugins/textreport/indivcomplete.py:1127
 msgid "Include (2)"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:926
-#: ../gramps/plugins/textreport/detdescendantreport.py:1117
+#: ../gramps/plugins/textreport/detancestralreport.py:933
+#: ../gramps/plugins/textreport/detdescendantreport.py:1122
 msgid "Include notes"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:927
-#: ../gramps/plugins/textreport/detdescendantreport.py:1118
+#: ../gramps/plugins/textreport/detancestralreport.py:934
+#: ../gramps/plugins/textreport/detdescendantreport.py:1123
 msgid "Whether to include notes."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:930
-#: ../gramps/plugins/textreport/detdescendantreport.py:1121
+#: ../gramps/plugins/textreport/detancestralreport.py:937
+#: ../gramps/plugins/textreport/detdescendantreport.py:1126
 msgid "Include sources"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:931
-#: ../gramps/plugins/textreport/detdescendantreport.py:1122
+#: ../gramps/plugins/textreport/detancestralreport.py:938
+#: ../gramps/plugins/textreport/detdescendantreport.py:1127
 msgid "Whether to include source references."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:934
-#: ../gramps/plugins/textreport/detdescendantreport.py:1125
+#: ../gramps/plugins/textreport/detancestralreport.py:941
+#: ../gramps/plugins/textreport/detdescendantreport.py:1130
 #: ../gramps/plugins/textreport/indivcomplete.py:1114
 msgid "Include sources notes"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:936
-#: ../gramps/plugins/textreport/detdescendantreport.py:1127
+#: ../gramps/plugins/textreport/detancestralreport.py:943
+#: ../gramps/plugins/textreport/detdescendantreport.py:1132
 #: ../gramps/plugins/textreport/indivcomplete.py:1116
 msgid ""
 "Whether to include source notes in the Endnotes section. Only works if "
 "Include sources is selected."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:940
-#: ../gramps/plugins/textreport/detdescendantreport.py:1131
+#: ../gramps/plugins/textreport/detancestralreport.py:947
+#: ../gramps/plugins/textreport/detdescendantreport.py:1136
 msgid "Include attributes"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:941
-#: ../gramps/plugins/textreport/detdescendantreport.py:1132
+#: ../gramps/plugins/textreport/detancestralreport.py:948
+#: ../gramps/plugins/textreport/detdescendantreport.py:1137
 #: ../gramps/plugins/textreport/familygroup.py:773
 #: ../gramps/plugins/textreport/indivcomplete.py:1137
 msgid "Whether to include attributes."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:944
-#: ../gramps/plugins/textreport/detdescendantreport.py:1135
+#: ../gramps/plugins/textreport/detancestralreport.py:951
+#: ../gramps/plugins/textreport/detdescendantreport.py:1140
 msgid "Include addresses"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:945
-#: ../gramps/plugins/textreport/detdescendantreport.py:1136
+#: ../gramps/plugins/textreport/detancestralreport.py:952
+#: ../gramps/plugins/textreport/detdescendantreport.py:1141
 msgid "Whether to include addresses."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:948
-#: ../gramps/plugins/textreport/detdescendantreport.py:1139
+#: ../gramps/plugins/textreport/detancestralreport.py:955
+#: ../gramps/plugins/textreport/detdescendantreport.py:1144
 msgid "Include alternative names"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:949
-#: ../gramps/plugins/textreport/detdescendantreport.py:1140
+#: ../gramps/plugins/textreport/detancestralreport.py:956
+#: ../gramps/plugins/textreport/detdescendantreport.py:1145
 msgid "Whether to include other names."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:955
-#: ../gramps/plugins/textreport/detdescendantreport.py:1159
+#: ../gramps/plugins/textreport/detancestralreport.py:962
+#: ../gramps/plugins/textreport/detdescendantreport.py:1164
 msgid "Replace missing places with ______"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:956
-#: ../gramps/plugins/textreport/detdescendantreport.py:1161
+#: ../gramps/plugins/textreport/detancestralreport.py:963
+#: ../gramps/plugins/textreport/detdescendantreport.py:1166
 msgid "Whether to replace missing Places with blanks."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:959
-#: ../gramps/plugins/textreport/detdescendantreport.py:1164
+#: ../gramps/plugins/textreport/detancestralreport.py:966
+#: ../gramps/plugins/textreport/detdescendantreport.py:1169
 msgid "Replace missing dates with ______"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:960
-#: ../gramps/plugins/textreport/detdescendantreport.py:1165
+#: ../gramps/plugins/textreport/detancestralreport.py:967
+#: ../gramps/plugins/textreport/detdescendantreport.py:1170
 msgid "Whether to replace missing Dates with blanks."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:993
-#: ../gramps/plugins/textreport/detdescendantreport.py:1198
+#: ../gramps/plugins/textreport/detancestralreport.py:1000
+#: ../gramps/plugins/textreport/detdescendantreport.py:1203
 msgid "The style used for the children list title."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:1004
-#: ../gramps/plugins/textreport/detdescendantreport.py:1209
+#: ../gramps/plugins/textreport/detancestralreport.py:1011
+#: ../gramps/plugins/textreport/detdescendantreport.py:1214
 #: ../gramps/plugins/textreport/familygroup.py:900
 msgid "The style used for the text related to the children."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:1014
-#: ../gramps/plugins/textreport/detdescendantreport.py:1219
+#: ../gramps/plugins/textreport/detancestralreport.py:1021
+#: ../gramps/plugins/textreport/detdescendantreport.py:1224
 msgid "The style used for the note header."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:1028
-#: ../gramps/plugins/textreport/detdescendantreport.py:1233
+#: ../gramps/plugins/textreport/detancestralreport.py:1035
+#: ../gramps/plugins/textreport/detdescendantreport.py:1238
 #: ../gramps/plugins/textreport/tableofcontents.py:117
 msgid "The style used for first level headings."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:1038
-#: ../gramps/plugins/textreport/detdescendantreport.py:1243
+#: ../gramps/plugins/textreport/detancestralreport.py:1045
+#: ../gramps/plugins/textreport/detdescendantreport.py:1248
 #: ../gramps/plugins/textreport/kinshipreport.py:416
 #: ../gramps/plugins/textreport/summary.py:319
 #: ../gramps/plugins/textreport/tableofcontents.py:123
 msgid "The style used for second level headings."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detancestralreport.py:1048
-#: ../gramps/plugins/textreport/detdescendantreport.py:1253
+#: ../gramps/plugins/textreport/detancestralreport.py:1055
+#: ../gramps/plugins/textreport/detdescendantreport.py:1258
 #: ../gramps/plugins/textreport/endoflinereport.py:335
 #: ../gramps/plugins/textreport/placereport.py:545
 msgid "The style used for details."
 msgstr ""
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/textreport/detdescendantreport.py:341
+#: ../gramps/plugins/textreport/detdescendantreport.py:342
 #, python-format
 msgid "Descendant Report for %(person_name)s"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:635
+#: ../gramps/plugins/textreport/detdescendantreport.py:636
 #, python-format
 msgid "Ref: %(number)s. %(name)s"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:762
+#: ../gramps/plugins/textreport/detdescendantreport.py:765
 #, python-format
 msgid "Notes for %(mother_name)s and %(father_name)s:"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1012
+#: ../gramps/plugins/textreport/detdescendantreport.py:1017
 msgid "Record (Modified Register) numbering"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1016
+#: ../gramps/plugins/textreport/detdescendantreport.py:1021
 msgid "Report structure"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1019
+#: ../gramps/plugins/textreport/detdescendantreport.py:1024
 msgid "show people by generations"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1020
+#: ../gramps/plugins/textreport/detdescendantreport.py:1025
 msgid "show people by lineage"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1021
+#: ../gramps/plugins/textreport/detdescendantreport.py:1026
 msgid "How people are organized in the report"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1091
+#: ../gramps/plugins/textreport/detdescendantreport.py:1096
 #: ../gramps/plugins/textreport/kinshipreport.py:370
 msgid "Include spouses"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1093
+#: ../gramps/plugins/textreport/detdescendantreport.py:1098
 msgid "Whether to include detailed spouse information."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1096
+#: ../gramps/plugins/textreport/detdescendantreport.py:1101
 msgid "Include spouse reference"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1097
+#: ../gramps/plugins/textreport/detdescendantreport.py:1102
 msgid "Whether to include reference to spouse."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1144
+#: ../gramps/plugins/textreport/detdescendantreport.py:1149
 msgid "Include sign of succession ('+') in child-list"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1145
+#: ../gramps/plugins/textreport/detdescendantreport.py:1150
 msgid ""
 "Whether to include a sign ('+') before the descendant number in the child-"
 "list to indicate a child has succession."
 msgstr ""
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1150
+#: ../gramps/plugins/textreport/detdescendantreport.py:1155
 msgid "Include path to start-person"
 msgstr ""
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1151
+#: ../gramps/plugins/textreport/detdescendantreport.py:1156
 msgid ""
 "Whether to include the path of descendancy from the start-person to each "
 "descendant."
@@ -29264,7 +30298,7 @@ msgid "Alternate Parents"
 msgstr ""
 
 #: ../gramps/plugins/textreport/indivcomplete.py:445
-#: ../gramps/plugins/webreport/person.py:1155
+#: ../gramps/plugins/webreport/person.py:1228
 msgid "Associations"
 msgstr ""
 
@@ -29276,20 +30310,6 @@ msgstr ""
 #: ../gramps/plugins/textreport/indivcomplete.py:856
 #: ../gramps/plugins/textreport/textplugins.gpr.py:214
 msgid "Complete Individual Report"
-msgstr ""
-
-#: ../gramps/plugins/textreport/indivcomplete.py:936
-#: ../gramps/plugins/tool/dumpgenderstats.py:72
-#: ../gramps/plugins/tool/dumpgenderstats.py:96
-#: ../gramps/plugins/tool/dumpgenderstats.py:99
-msgid "Male"
-msgstr ""
-
-#: ../gramps/plugins/textreport/indivcomplete.py:938
-#: ../gramps/plugins/tool/dumpgenderstats.py:73
-#: ../gramps/plugins/tool/dumpgenderstats.py:97
-#: ../gramps/plugins/tool/dumpgenderstats.py:99
-msgid "Female"
 msgstr ""
 
 #: ../gramps/plugins/textreport/indivcomplete.py:952
@@ -30602,35 +31622,35 @@ msgstr ""
 msgid "Looking for duplicate people"
 msgstr ""
 
-#: ../gramps/plugins/tool/finddupes.py:199
+#: ../gramps/plugins/tool/finddupes.py:200
 msgid "Pass 1: Building preliminary lists"
 msgstr ""
 
-#: ../gramps/plugins/tool/finddupes.py:217
+#: ../gramps/plugins/tool/finddupes.py:218
 msgid "Pass 2: Calculating potential matches"
 msgstr ""
 
-#: ../gramps/plugins/tool/finddupes.py:555
+#: ../gramps/plugins/tool/finddupes.py:556
 msgid "Potential Merges"
 msgstr ""
 
-#: ../gramps/plugins/tool/finddupes.py:572
+#: ../gramps/plugins/tool/finddupes.py:573
 msgid "Rating"
 msgstr ""
 
-#: ../gramps/plugins/tool/finddupes.py:573
+#: ../gramps/plugins/tool/finddupes.py:574
 msgid "First Person"
 msgstr ""
 
-#: ../gramps/plugins/tool/finddupes.py:574
+#: ../gramps/plugins/tool/finddupes.py:575
 msgid "Second Person"
 msgstr ""
 
-#: ../gramps/plugins/tool/finddupes.py:584
+#: ../gramps/plugins/tool/finddupes.py:585
 msgid "Merge candidates"
 msgstr ""
 
-#: ../gramps/plugins/tool/finddupes.py:584
+#: ../gramps/plugins/tool/finddupes.py:585
 msgid "Merge persons"
 msgstr ""
 
@@ -30669,8 +31689,8 @@ msgid "Help"
 msgstr ""
 
 #: ../gramps/plugins/tool/mediamanager.py:101
-#: ../gramps/plugins/webreport/basepage.py:1475
-#: ../gramps/plugins/webreport/basepage.py:1598
+#: ../gramps/plugins/webreport/basepage.py:1523
+#: ../gramps/plugins/webreport/basepage.py:1639
 #: ../gramps/plugins/webreport/introduction.py:78
 msgid "Introduction"
 msgstr ""
@@ -31161,7 +32181,7 @@ msgstr ""
 #. Add mark column
 #. Add ignore column
 #: ../gramps/plugins/tool/removeunused.py:184
-#: ../gramps/plugins/tool/verify.py:551
+#: ../gramps/plugins/tool/verify.py:554
 msgid "Mark"
 msgstr ""
 
@@ -31264,39 +32284,39 @@ msgstr ""
 msgid "Sort Events"
 msgstr ""
 
-#: ../gramps/plugins/tool/sortevents.py:97
+#: ../gramps/plugins/tool/sortevents.py:98
 msgid "Sort event changes"
 msgstr ""
 
-#: ../gramps/plugins/tool/sortevents.py:112
+#: ../gramps/plugins/tool/sortevents.py:113
 msgid "Sorting personal events..."
 msgstr ""
 
-#: ../gramps/plugins/tool/sortevents.py:134
+#: ../gramps/plugins/tool/sortevents.py:135
 msgid "Sorting family events..."
 msgstr ""
 
-#: ../gramps/plugins/tool/sortevents.py:165
+#: ../gramps/plugins/tool/sortevents.py:166
 msgid "Tool Options"
 msgstr ""
 
-#: ../gramps/plugins/tool/sortevents.py:168
+#: ../gramps/plugins/tool/sortevents.py:169
 msgid "Select the people to sort"
 msgstr ""
 
-#: ../gramps/plugins/tool/sortevents.py:187
+#: ../gramps/plugins/tool/sortevents.py:188
 msgid "Sort descending"
 msgstr ""
 
-#: ../gramps/plugins/tool/sortevents.py:188
+#: ../gramps/plugins/tool/sortevents.py:189
 msgid "Set the sort order"
 msgstr ""
 
-#: ../gramps/plugins/tool/sortevents.py:191
+#: ../gramps/plugins/tool/sortevents.py:192
 msgid "Include family events"
 msgstr ""
 
-#: ../gramps/plugins/tool/sortevents.py:192
+#: ../gramps/plugins/tool/sortevents.py:193
 msgid "Sort family events of the person"
 msgstr ""
 
@@ -31570,6 +32590,16 @@ msgstr ""
 msgid "Searches the entire database, looking for a possible loop."
 msgstr ""
 
+#: ../gramps/plugins/tool/tools.gpr.py:489
+msgid "Clean input data"
+msgstr ""
+
+#: ../gramps/plugins/tool/tools.gpr.py:490
+msgid ""
+"Searches the entire database, looking for trailing or leading spaces for "
+"places and people. Search comma in coordinates fields in places."
+msgstr ""
+
 #: ../gramps/plugins/tool/toolsdebug.gpr.py:64
 msgid "Dump Gender Statistics"
 msgstr ""
@@ -31643,7 +32673,7 @@ msgstr ""
 msgid "Maximum _span of years for all children"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.glade:984 ../gramps/plugins/tool/verify.py:670
+#: ../gramps/plugins/tool/verify.glade:984 ../gramps/plugins/tool/verify.py:673
 msgid "_Hide marked"
 msgstr ""
 
@@ -31661,152 +32691,164 @@ msgstr ""
 msgid "%(severity)s: %(msg)s, %(type)s: %(gid)s, %(name)s"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:499
+#: ../gramps/plugins/tool/verify.py:502
 msgid "Data Verification Results"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:660
+#: ../gramps/plugins/tool/verify.py:663
 msgid "_Show all"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:941
+#: ../gramps/plugins/tool/verify.py:945
 msgid "Baptism before birth"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:957
+#: ../gramps/plugins/tool/verify.py:961
 msgid "Death before baptism"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:973
+#: ../gramps/plugins/tool/verify.py:977
 msgid "Burial before birth"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:989
+#: ../gramps/plugins/tool/verify.py:993
 msgid "Burial before death"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1005
+#: ../gramps/plugins/tool/verify.py:1009
 msgid "Death before birth"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1021
+#: ../gramps/plugins/tool/verify.py:1025
 msgid "Burial before baptism"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1044
+#: ../gramps/plugins/tool/verify.py:1048
 msgid "Old age at death"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1071
+#: ../gramps/plugins/tool/verify.py:1075
 msgid "Multiple parents"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1093
+#: ../gramps/plugins/tool/verify.py:1097
 msgid "Married often"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1117
+#: ../gramps/plugins/tool/verify.py:1121
 msgid "Old and unmarried"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1149
+#: ../gramps/plugins/tool/verify.py:1153
 msgid "Too many children"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1167
+#: ../gramps/plugins/tool/verify.py:1171
 msgid "Same sex marriage"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1180
+#: ../gramps/plugins/tool/verify.py:1184
 msgid "Female husband"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1193
+#: ../gramps/plugins/tool/verify.py:1197
 msgid "Male wife"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1223
+#: ../gramps/plugins/tool/verify.py:1227
 msgid "Husband and wife with the same surname"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1253
+#: ../gramps/plugins/tool/verify.py:1257
 msgid "Large age difference between spouses"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1289
+#: ../gramps/plugins/tool/verify.py:1293
 msgid "Marriage before birth"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1325
+#: ../gramps/plugins/tool/verify.py:1329
 msgid "Marriage after death"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1366
+#: ../gramps/plugins/tool/verify.py:1370
 msgid "Early marriage"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1405
+#: ../gramps/plugins/tool/verify.py:1409
 msgid "Late marriage"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1454
+#: ../gramps/plugins/tool/verify.py:1458
 msgid "Old father"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1458
+#: ../gramps/plugins/tool/verify.py:1462
 msgid "Old mother"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1507
+#: ../gramps/plugins/tool/verify.py:1511
 msgid "Young father"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1511
+#: ../gramps/plugins/tool/verify.py:1515
 msgid "Young mother"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1555
+#: ../gramps/plugins/tool/verify.py:1559
 msgid "Unborn father"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1559
+#: ../gramps/plugins/tool/verify.py:1563
 msgid "Unborn mother"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1610
+#: ../gramps/plugins/tool/verify.py:1614
 msgid "Dead father"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1614
+#: ../gramps/plugins/tool/verify.py:1618
 msgid "Dead mother"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1640
+#: ../gramps/plugins/tool/verify.py:1644
 msgid "Large year span for all children"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1667
+#: ../gramps/plugins/tool/verify.py:1671
 msgid "Large age differences between children"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1680
+#: ../gramps/plugins/tool/verify.py:1684
 msgid "Disconnected individual"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1707
+#: ../gramps/plugins/tool/verify.py:1711
 msgid "Invalid birth date"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1734
+#: ../gramps/plugins/tool/verify.py:1738
 msgid "Invalid death date"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1754
+#: ../gramps/plugins/tool/verify.py:1758
 msgid "Marriage date but not married"
 msgstr ""
 
-#: ../gramps/plugins/tool/verify.py:1782
+#: ../gramps/plugins/tool/verify.py:1786
 msgid "Old age but no death"
+msgstr ""
+
+#: ../gramps/plugins/tool/verify.py:1802
+msgid "Birth equals death"
+msgstr ""
+
+#: ../gramps/plugins/tool/verify.py:1820
+msgid "Birth equals marriage"
+msgstr ""
+
+#: ../gramps/plugins/tool/verify.py:1838
+msgid "Death equals marriage"
 msgstr ""
 
 #: ../gramps/plugins/view/citationlistview.py:105
@@ -31862,12 +32904,12 @@ msgstr ""
 msgid "Citation View"
 msgstr ""
 
-#: ../gramps/plugins/view/citationlistview.py:180
-#: ../gramps/plugins/view/citationtreeview.py:314
+#: ../gramps/plugins/view/citationlistview.py:215
+#: ../gramps/plugins/view/citationtreeview.py:365
 msgid "Citation Filter Editor"
 msgstr ""
 
-#: ../gramps/plugins/view/citationlistview.py:298
+#: ../gramps/plugins/view/citationlistview.py:394
 msgid ""
 "This citation cannot be edited at this time. Either the associated citation "
 "is already being edited or another object that is associated with the same "
@@ -31876,23 +32918,23 @@ msgid ""
 "To edit this citation, you need to close the object."
 msgstr ""
 
-#: ../gramps/plugins/view/citationlistview.py:311
-#: ../gramps/plugins/view/citationlistview.py:322
-#: ../gramps/plugins/view/citationtreeview.py:528
-#: ../gramps/plugins/view/citationtreeview.py:541
+#: ../gramps/plugins/view/citationlistview.py:407
+#: ../gramps/plugins/view/citationlistview.py:418
+#: ../gramps/plugins/view/citationtreeview.py:664
+#: ../gramps/plugins/view/citationtreeview.py:677
 msgid "Cannot merge citations."
 msgstr ""
 
-#: ../gramps/plugins/view/citationlistview.py:312
-#: ../gramps/plugins/view/citationtreeview.py:529
+#: ../gramps/plugins/view/citationlistview.py:408
+#: ../gramps/plugins/view/citationtreeview.py:665
 msgid ""
 "Exactly two citations must be selected to perform a merge. A second citation "
 "can be selected by holding down the control key while clicking on the "
 "desired citation."
 msgstr ""
 
-#: ../gramps/plugins/view/citationlistview.py:323
-#: ../gramps/plugins/view/citationtreeview.py:542
+#: ../gramps/plugins/view/citationlistview.py:419
+#: ../gramps/plugins/view/citationtreeview.py:678
 msgid ""
 "The two selected citations must have the same source to perform a merge. If "
 "you want to merge these two citations, then you must merge the sources first."
@@ -31914,27 +32956,30 @@ msgstr ""
 msgid "Citation Tree View"
 msgstr ""
 
-#: ../gramps/plugins/view/citationtreeview.py:301
-msgid "Add source..."
-msgstr ""
-
-#: ../gramps/plugins/view/citationtreeview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/citationtreeview.py:475
 msgid "Add citation..."
 msgstr ""
 
-#: ../gramps/plugins/view/citationtreeview.py:322
-#: ../gramps/plugins/view/persontreeview.py:82
-#: ../gramps/plugins/view/placetreeview.py:74
-msgid "Expand all Nodes"
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+msgid "Add source..."
 msgstr ""
 
-#: ../gramps/plugins/view/citationtreeview.py:324
-#: ../gramps/plugins/view/persontreeview.py:84
-#: ../gramps/plugins/view/placetreeview.py:76
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/persontreeview.py:87
+#: ../gramps/plugins/view/placetreeview.py:77
 msgid "Collapse all Nodes"
 msgstr ""
 
-#: ../gramps/plugins/view/citationtreeview.py:515
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/persontreeview.py:87
+#: ../gramps/plugins/view/placetreeview.py:77
+msgid "Expand all Nodes"
+msgstr ""
+
+#: ../gramps/plugins/view/citationtreeview.py:651
 msgid ""
 "This source cannot be edited at this time. Either the associated Source "
 "object is already being edited, or another citation associated with the same "
@@ -31943,50 +32988,56 @@ msgid ""
 "To edit this source, you need to close the object."
 msgstr ""
 
-#: ../gramps/plugins/view/citationtreeview.py:554
+#: ../gramps/plugins/view/citationtreeview.py:690
 msgid "Cannot perform merge."
 msgstr ""
 
-#: ../gramps/plugins/view/citationtreeview.py:555
+#: ../gramps/plugins/view/citationtreeview.py:691
 msgid ""
 "Both objects must be of the same type, either both must be sources, or both "
 "must be citations."
 msgstr ""
 
 #: ../gramps/plugins/view/dashboardview.py:51
+#: ../gramps/plugins/view/dashboardview.py:83
 #: ../gramps/plugins/view/view.gpr.py:67 ../gramps/plugins/view/view.gpr.py:75
 msgid "Dashboard"
 msgstr ""
 
-#: ../gramps/plugins/view/dashboardview.py:101
-msgid "Restore a gramplet"
-msgstr ""
-
-#: ../gramps/plugins/view/eventview.py:100
+#: ../gramps/plugins/view/eventview.py:96
 msgid "Add a new event"
 msgstr ""
 
-#: ../gramps/plugins/view/eventview.py:101
+#: ../gramps/plugins/view/eventview.py:97
 msgid "Edit the selected event"
 msgstr ""
 
-#: ../gramps/plugins/view/eventview.py:102
+#: ../gramps/plugins/view/eventview.py:98
 msgid "Delete the selected event"
 msgstr ""
 
-#: ../gramps/plugins/view/eventview.py:103
+#: ../gramps/plugins/view/eventview.py:99
 msgid "Merge the selected events"
 msgstr ""
 
-#: ../gramps/plugins/view/eventview.py:244
+#: ../gramps/plugins/view/eventview.py:229
 msgid "Event Filter Editor"
 msgstr ""
 
-#: ../gramps/plugins/view/eventview.py:296
+#: ../gramps/plugins/view/eventview.py:385
+msgid "_Delete Event"
+msgstr ""
+
+#: ../gramps/plugins/view/eventview.py:400
+#, python-brace-format
+msgid "Delete {type} [{gid}]?"
+msgstr ""
+
+#: ../gramps/plugins/view/eventview.py:443
 msgid "Cannot merge event objects."
 msgstr ""
 
-#: ../gramps/plugins/view/eventview.py:297
+#: ../gramps/plugins/view/eventview.py:444
 msgid ""
 "Exactly two events must be selected to perform a merge. A second object can "
 "be selected by holding down the control key while clicking on the desired "
@@ -32013,264 +33064,303 @@ msgstr ""
 msgid "Merge the selected families"
 msgstr ""
 
-#: ../gramps/plugins/view/familyview.py:202
+#: ../gramps/plugins/view/familyview.py:188
 msgid "Family Filter Editor"
 msgstr ""
 
-#: ../gramps/plugins/view/familyview.py:207
+#: ../gramps/plugins/view/familyview.py:279
 msgid "Make Father Active Person"
 msgstr ""
 
-#: ../gramps/plugins/view/familyview.py:209
+#: ../gramps/plugins/view/familyview.py:279
 msgid "Make Mother Active Person"
 msgstr ""
 
-#: ../gramps/plugins/view/familyview.py:247
+#: ../gramps/plugins/view/familyview.py:372
 msgid "_Delete Family"
 msgstr ""
 
-#: ../gramps/plugins/view/familyview.py:283
+#: ../gramps/plugins/view/familyview.py:408
 #, python-format
 msgid "Family [%s]"
 msgstr ""
 
-#: ../gramps/plugins/view/familyview.py:307
+#: ../gramps/plugins/view/familyview.py:432
 msgid "Cannot merge families."
 msgstr ""
 
-#: ../gramps/plugins/view/familyview.py:308
+#: ../gramps/plugins/view/familyview.py:433
 msgid ""
 "Exactly two families must be selected to perform a merge. A second family "
 "can be selected by holding down the control key while clicking on the "
 "desired family."
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:193
-#: ../gramps/plugins/view/fanchartdescview.py:188
-#: ../gramps/plugins/view/fanchartview.py:184
-msgid "Print or save the Fan Chart View"
-msgstr ""
-
-#: ../gramps/plugins/view/fanchart2wayview.py:295
+#: ../gramps/plugins/view/fanchart2wayview.py:280
 msgid "Max ancestor generations"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:298
+#: ../gramps/plugins/view/fanchart2wayview.py:283
 msgid "Max descendant generations"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:302
-#: ../gramps/plugins/view/fanchartdescview.py:299
-#: ../gramps/plugins/view/fanchartview.py:295
+#: ../gramps/plugins/view/fanchart2wayview.py:286
+#: ../gramps/plugins/view/fanchartdescview.py:283
+#: ../gramps/plugins/view/fanchartview.py:381
 msgid "Text Font"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:306
-#: ../gramps/plugins/view/fanchartdescview.py:303
-#: ../gramps/plugins/view/fanchartview.py:299
+#: ../gramps/plugins/view/fanchart2wayview.py:291
+#: ../gramps/plugins/view/fanchartdescview.py:288
+#: ../gramps/plugins/view/fanchartview.py:386
 msgid "Gender colors"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:307
-#: ../gramps/plugins/view/fanchartdescview.py:304
-#: ../gramps/plugins/view/fanchartview.py:300
+#: ../gramps/plugins/view/fanchart2wayview.py:292
+#: ../gramps/plugins/view/fanchartdescview.py:289
+#: ../gramps/plugins/view/fanchartview.py:387
 msgid "Generation based gradient"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:308
-#: ../gramps/plugins/view/fanchartdescview.py:305
-#: ../gramps/plugins/view/fanchartview.py:301
+#: ../gramps/plugins/view/fanchart2wayview.py:293
+#: ../gramps/plugins/view/fanchartdescview.py:290
+#: ../gramps/plugins/view/fanchartview.py:388
 msgid "Age (0-100) based gradient"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:310
-#: ../gramps/plugins/view/fanchartdescview.py:307
-#: ../gramps/plugins/view/fanchartview.py:303
+#: ../gramps/plugins/view/fanchart2wayview.py:294
+#: ../gramps/plugins/view/fanchartdescview.py:292
+#: ../gramps/plugins/view/fanchartview.py:389
 msgid "Single main (filter) color"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:311
-#: ../gramps/plugins/view/fanchartdescview.py:308
-#: ../gramps/plugins/view/fanchartview.py:304
+#: ../gramps/plugins/view/fanchart2wayview.py:295
+#: ../gramps/plugins/view/fanchartdescview.py:293
+#: ../gramps/plugins/view/fanchartview.py:390
 msgid "Time period based gradient"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:312
-#: ../gramps/plugins/view/fanchartdescview.py:309
-#: ../gramps/plugins/view/fanchartview.py:305
+#: ../gramps/plugins/view/fanchart2wayview.py:296
+#: ../gramps/plugins/view/fanchartdescview.py:294
+#: ../gramps/plugins/view/fanchartview.py:391
 msgid "White"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:313
-#: ../gramps/plugins/view/fanchartdescview.py:310
-#: ../gramps/plugins/view/fanchartview.py:306
+#: ../gramps/plugins/view/fanchart2wayview.py:297
+#: ../gramps/plugins/view/fanchartdescview.py:295
+#: ../gramps/plugins/view/fanchartview.py:392
 msgid "Color scheme classic report"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:314
-#: ../gramps/plugins/view/fanchartdescview.py:311
-#: ../gramps/plugins/view/fanchartview.py:307
+#: ../gramps/plugins/view/fanchart2wayview.py:298
+#: ../gramps/plugins/view/fanchartdescview.py:296
+#: ../gramps/plugins/view/fanchartview.py:393
 msgid "Color scheme classic view"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:323
-#: ../gramps/plugins/view/fanchartdescview.py:320
-#: ../gramps/plugins/view/fanchartview.py:316
+#: ../gramps/plugins/view/fanchart2wayview.py:306
+#: ../gramps/plugins/view/fanchartdescview.py:304
+#: ../gramps/plugins/view/fanchartview.py:401
 msgid "Background"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:332
+#: ../gramps/plugins/view/fanchart2wayview.py:313
 msgid "Add global background colored gradient"
 msgstr ""
 
 #. colors, stored as hex values
-#: ../gramps/plugins/view/fanchart2wayview.py:336
-#: ../gramps/plugins/view/fanchartdescview.py:327
-#: ../gramps/plugins/view/fanchartview.py:322
+#: ../gramps/plugins/view/fanchart2wayview.py:317
+#: ../gramps/plugins/view/fanchartdescview.py:309
+#: ../gramps/plugins/view/fanchartview.py:406
 msgid "Start gradient/Main color"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:338
-#: ../gramps/plugins/view/fanchartdescview.py:329
-#: ../gramps/plugins/view/fanchartview.py:324
+#: ../gramps/plugins/view/fanchart2wayview.py:319
+#: ../gramps/plugins/view/fanchartdescview.py:311
+#: ../gramps/plugins/view/fanchartview.py:408
 msgid "End gradient/2nd color"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:340
-#: ../gramps/plugins/view/fanchartdescview.py:331
+#: ../gramps/plugins/view/fanchart2wayview.py:321
+#: ../gramps/plugins/view/fanchartdescview.py:313
 msgid "Color for duplicates"
 msgstr ""
 
 #. algo for the fan angle distribution
-#: ../gramps/plugins/view/fanchart2wayview.py:343
-#: ../gramps/plugins/view/fanchartdescview.py:341
+#: ../gramps/plugins/view/fanchart2wayview.py:324
+#: ../gramps/plugins/view/fanchartdescview.py:323
 msgid "Fan chart distribution"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:346
-#: ../gramps/plugins/view/fanchartdescview.py:344
+#: ../gramps/plugins/view/fanchart2wayview.py:327
+#: ../gramps/plugins/view/fanchartdescview.py:326
 msgid "Homogeneous children distribution"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:348
-#: ../gramps/plugins/view/fanchartdescview.py:346
-msgid "Size  proportional to number of descendants"
+#: ../gramps/plugins/view/fanchart2wayview.py:329
+#: ../gramps/plugins/view/fanchartdescview.py:328
+msgid "Size proportional to number of descendants"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:354
-#: ../gramps/plugins/view/fanchartdescview.py:352
-#: ../gramps/plugins/view/fanchartview.py:335
+#. show names one two line
+#: ../gramps/plugins/view/fanchart2wayview.py:335
+#: ../gramps/plugins/view/fanchartdescview.py:334
+#: ../gramps/plugins/view/fanchartview.py:418
 msgid "Show names on two lines"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:359
-#: ../gramps/plugins/view/fanchartdescview.py:357
-#: ../gramps/plugins/view/fanchartview.py:340
+#. Flip names
+#: ../gramps/plugins/view/fanchart2wayview.py:339
+#: ../gramps/plugins/view/fanchartdescview.py:338
+#: ../gramps/plugins/view/fanchartview.py:422
 msgid "Flip name on the left of the fan"
+msgstr ""
+
+#. Show gramps id
+#: ../gramps/plugins/view/fanchart2wayview.py:343
+msgid "Show the gramps id"
 msgstr ""
 
 #. options we don't show on the dialog
 #. #configdialog.add_checkbox(table,
 #. #        _('Allow radial text'),
 #. #        ??, 'interface.fanview-radialtext')
-#: ../gramps/plugins/view/fanchart2wayview.py:362
-#: ../gramps/plugins/view/fanchartdescview.py:360
-#: ../gramps/plugins/view/fanchartview.py:352
-#: ../gramps/plugins/view/pedigreeview.py:2055
-#: ../gramps/plugins/view/relview.py:1686
+#: ../gramps/plugins/view/fanchart2wayview.py:346
+#: ../gramps/plugins/view/fanchartdescview.py:345
+#: ../gramps/plugins/view/fanchartview.py:437
+#: ../gramps/plugins/view/pedigreeview.py:2128
+#: ../gramps/plugins/view/relview.py:1857
 msgid "Layout"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchart2wayview.py:561
-#: ../gramps/plugins/view/fanchartdescview.py:549
-#: ../gramps/plugins/view/fanchartview.py:556
+#: ../gramps/plugins/view/fanchart2wayview.py:580
+#: ../gramps/plugins/view/fanchartdescview.py:568
+#: ../gramps/plugins/view/fanchartview.py:666
 msgid "No preview available"
 msgstr ""
 
 #. form of the fan
-#: ../gramps/plugins/view/fanchartdescview.py:334
-#: ../gramps/plugins/view/fanchartview.py:327
+#: ../gramps/plugins/view/fanchartdescview.py:316
+#: ../gramps/plugins/view/fanchartview.py:411
 msgid "Fan chart type"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchartdescview.py:336
-#: ../gramps/plugins/view/fanchartview.py:329
+#: ../gramps/plugins/view/fanchartdescview.py:318
+#: ../gramps/plugins/view/fanchartview.py:413
 msgid "Full Circle"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchartdescview.py:337
-#: ../gramps/plugins/view/fanchartview.py:329
+#: ../gramps/plugins/view/fanchartdescview.py:319
+#: ../gramps/plugins/view/fanchartview.py:413
 msgid "Half Circle"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchartdescview.py:338
-#: ../gramps/plugins/view/fanchartview.py:330
+#: ../gramps/plugins/view/fanchartdescview.py:320
+#: ../gramps/plugins/view/fanchartview.py:414
 msgid "Quadrant"
 msgstr ""
 
-#: ../gramps/plugins/view/fanchartview.py:345
+#. show gramps_id
+#. Show the gramps_id
+#: ../gramps/plugins/view/fanchartdescview.py:342
+#: ../gramps/plugins/view/fanchartview.py:430
+msgid "Show gramps id"
+msgstr ""
+
+#: ../gramps/plugins/view/fanchartview.py:164
+#: ../gramps/plugins/view/fanchartview.py:227
+#: ../gramps/plugins/view/geoclose.py:91 ../gramps/plugins/view/geoclose.py:167
+#: ../gramps/plugins/view/geoevents.py:81
+#: ../gramps/plugins/view/geoevents.py:129
+#: ../gramps/plugins/view/geofamclose.py:89
+#: ../gramps/plugins/view/geofamclose.py:165
+#: ../gramps/plugins/view/geofamily.py:81
+#: ../gramps/plugins/view/geofamily.py:131
+#: ../gramps/plugins/view/geomoves.py:88 ../gramps/plugins/view/geomoves.py:151
+#: ../gramps/plugins/view/geoperson.py:89
+#: ../gramps/plugins/view/geoplaces.py:84
+#: ../gramps/plugins/view/geoplaces.py:134
+msgid "_Print..."
+msgstr ""
+
+#: ../gramps/plugins/view/fanchartview.py:227
+msgid "Print or save the Fan Chart View"
+msgstr ""
+
+#. options users should not change:
+#: ../gramps/plugins/view/fanchartview.py:426
 msgid "Show children ring"
 msgstr ""
 
-#: ../gramps/plugins/view/geoclose.py:143
-#: ../gramps/plugins/view/geography.gpr.py:159
+#: ../gramps/plugins/view/geoclose.py:111
+msgid "Select the person which is the reference for life ways"
+msgstr ""
+
+#: ../gramps/plugins/view/geoclose.py:111
+msgid "reference _Person"
+msgstr ""
+
+#: ../gramps/plugins/view/geoclose.py:167
+#: ../gramps/plugins/view/geoevents.py:129
+#: ../gramps/plugins/view/geofamclose.py:165
+#: ../gramps/plugins/view/geofamily.py:131
+#: ../gramps/plugins/view/geomoves.py:151
+#: ../gramps/plugins/view/geoperson.py:152
+#: ../gramps/plugins/view/geoplaces.py:134
+msgid "Print or save the Map"
+msgstr ""
+
+#: ../gramps/plugins/view/geoclose.py:220
+#: ../gramps/plugins/view/geography.gpr.py:160
 msgid "Have they been able to meet?"
 msgstr ""
 
-#: ../gramps/plugins/view/geoclose.py:177
+#: ../gramps/plugins/view/geoclose.py:254
 msgid "GeoClose"
 msgstr ""
 
-#: ../gramps/plugins/view/geoclose.py:230
+#: ../gramps/plugins/view/geoclose.py:308
 #, python-format
 msgid "Reference : %(name)s ( %(birth)s - %(death)s )"
 msgstr ""
 
-#: ../gramps/plugins/view/geoclose.py:236
+#: ../gramps/plugins/view/geoclose.py:314
 #, python-format
 msgid "The other : %(name)s ( %(birth)s - %(death)s )"
 msgstr ""
 
-#: ../gramps/plugins/view/geoclose.py:241
+#: ../gramps/plugins/view/geoclose.py:319
 msgid "The other person is unknown"
 msgstr ""
 
-#: ../gramps/plugins/view/geoclose.py:248
+#: ../gramps/plugins/view/geoclose.py:326
 msgid "You must choose one reference person."
 msgstr ""
 
-#: ../gramps/plugins/view/geoclose.py:249
+#: ../gramps/plugins/view/geoclose.py:327
 msgid ""
 "Go to the person view and select the people you want to compare. Return to "
 "this view and use the history."
 msgstr ""
 
-#: ../gramps/plugins/view/geoclose.py:299
-msgid "reference _Person"
-msgstr ""
-
-#: ../gramps/plugins/view/geoclose.py:300
-msgid "Select the person which is the reference for life ways"
-msgstr ""
-
-#: ../gramps/plugins/view/geoclose.py:315
+#: ../gramps/plugins/view/geoclose.py:385
 msgid "Select the person which will be our reference."
 msgstr ""
 
-#: ../gramps/plugins/view/geoclose.py:414
-#: ../gramps/plugins/view/geofamclose.py:499
-#: ../gramps/plugins/view/geofamily.py:209
-#: ../gramps/plugins/view/geomoves.py:292
-#: ../gramps/plugins/view/geoperson.py:336
+#: ../gramps/plugins/view/geoclose.py:484
+#: ../gramps/plugins/view/geofamclose.py:569
+#: ../gramps/plugins/view/geofamily.py:258
+#: ../gramps/plugins/view/geomoves.py:358
+#: ../gramps/plugins/view/geoperson.py:402
 #, python-format
 msgid "%(eventtype)s : %(name)s"
 msgstr ""
 
-#: ../gramps/plugins/view/geoclose.py:572
+#: ../gramps/plugins/view/geoclose.py:642
 msgid "Choose and bookmark the new reference person"
 msgstr ""
 
-#: ../gramps/plugins/view/geoclose.py:595
+#: ../gramps/plugins/view/geoclose.py:665
 msgid ""
 "The meeting zone probability radius.\n"
 "The colored zone is approximative.\n"
@@ -32280,117 +33370,125 @@ msgid ""
 "The value is in tenth of degree."
 msgstr ""
 
-#: ../gramps/plugins/view/geoclose.py:606
-#: ../gramps/plugins/view/geofamclose.py:795
+#: ../gramps/plugins/view/geoclose.py:676
+#: ../gramps/plugins/view/geofamclose.py:865
 msgid "The selection parameters"
 msgstr ""
 
-#: ../gramps/plugins/view/geoevents.py:116
+#: ../gramps/plugins/view/geoevents.py:161
 msgid "Events places map"
 msgstr ""
 
-#: ../gramps/plugins/view/geoevents.py:141
+#: ../gramps/plugins/view/geoevents.py:186
 msgid "GeoEvents"
 msgstr ""
 
-#: ../gramps/plugins/view/geoevents.py:260
+#: ../gramps/plugins/view/geoevents.py:305
 msgid "incomplete or unreferenced event ?"
 msgstr ""
 
-#: ../gramps/plugins/view/geoevents.py:297
-#: ../gramps/plugins/view/geoevents.py:310
+#: ../gramps/plugins/view/geoevents.py:344
+#: ../gramps/plugins/view/geoevents.py:357
 msgid "Selecting all events"
 msgstr ""
 
-#: ../gramps/plugins/view/geoevents.py:355
-#: ../gramps/plugins/view/geoevents.py:387
+#: ../gramps/plugins/view/geoevents.py:368
+msgid ""
+"Right click on the map and select 'show all events' to show all known events "
+"with coordinates. You can use the history to navigate on the map. You can "
+"use filtering."
+msgstr ""
+
+#: ../gramps/plugins/view/geoevents.py:408
+#: ../gramps/plugins/view/geoevents.py:440
 msgid "Bookmark this event"
 msgstr ""
 
-#: ../gramps/plugins/view/geoevents.py:402
+#: ../gramps/plugins/view/geoevents.py:455
 msgid "Show all events"
 msgstr ""
 
-#: ../gramps/plugins/view/geoevents.py:406
-#: ../gramps/plugins/view/geoevents.py:411
-#: ../gramps/plugins/view/geoplaces.py:490
-#: ../gramps/plugins/view/geoplaces.py:495
+#: ../gramps/plugins/view/geoevents.py:459
+#: ../gramps/plugins/view/geoevents.py:464
+#: ../gramps/plugins/view/geoplaces.py:549
+#: ../gramps/plugins/view/geoplaces.py:554
 msgid "Centering on Place"
 msgstr ""
 
-#: ../gramps/plugins/view/geofamclose.py:143
-#: ../gramps/plugins/view/geography.gpr.py:141
+#: ../gramps/plugins/view/geofamclose.py:109
+msgid "Select the family which is the reference for life ways"
+msgstr ""
+
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geoperson.py:152
+msgid "reference _Family"
+msgstr ""
+
+#: ../gramps/plugins/view/geofamclose.py:220
+#: ../gramps/plugins/view/geography.gpr.py:142
 msgid "Have these two families been able to meet?"
 msgstr ""
 
-#: ../gramps/plugins/view/geofamclose.py:174
+#: ../gramps/plugins/view/geofamclose.py:251
 msgid "GeoFamClose"
 msgstr ""
 
-#: ../gramps/plugins/view/geofamclose.py:217
-#: ../gramps/plugins/view/geofamily.py:293
+#: ../gramps/plugins/view/geofamclose.py:294
+#: ../gramps/plugins/view/geofamily.py:342
 #, python-format
 msgid "%(gramps_id)s : %(father)s and %(mother)s"
 msgstr ""
 
-#: ../gramps/plugins/view/geofamclose.py:264
+#: ../gramps/plugins/view/geofamclose.py:342
 #, python-format
 msgid "Family reference : %s"
 msgstr ""
 
-#: ../gramps/plugins/view/geofamclose.py:267
-#: ../gramps/plugins/view/geofamclose.py:270
+#: ../gramps/plugins/view/geofamclose.py:345
+#: ../gramps/plugins/view/geofamclose.py:348
 #, python-format
 msgid "The other family : %s"
 msgstr ""
 
-#: ../gramps/plugins/view/geofamclose.py:277
+#: ../gramps/plugins/view/geofamclose.py:355
 msgid "You must choose one reference family."
 msgstr ""
 
-#: ../gramps/plugins/view/geofamclose.py:279
+#: ../gramps/plugins/view/geofamclose.py:357
 msgid ""
 "Go to the family view and select the families you want to compare. Return to "
 "this view and use the history."
 msgstr ""
 
-#: ../gramps/plugins/view/geofamclose.py:295
-msgid "reference _Family"
-msgstr ""
-
-#: ../gramps/plugins/view/geofamclose.py:296
-msgid "Select the family which is the reference for life ways"
-msgstr ""
-
-#: ../gramps/plugins/view/geofamclose.py:611
-#: ../gramps/plugins/view/geofamily.py:347
+#: ../gramps/plugins/view/geofamclose.py:681
+#: ../gramps/plugins/view/geofamily.py:396
 #, python-format
 msgid "Father : %(id)s : %(name)s"
 msgstr ""
 
-#: ../gramps/plugins/view/geofamclose.py:620
-#: ../gramps/plugins/view/geofamily.py:356
+#: ../gramps/plugins/view/geofamclose.py:690
+#: ../gramps/plugins/view/geofamily.py:405
 #, python-format
 msgid "Mother : %(id)s : %(name)s"
 msgstr ""
 
-#: ../gramps/plugins/view/geofamclose.py:632
-#: ../gramps/plugins/view/geofamily.py:368
+#: ../gramps/plugins/view/geofamclose.py:702
+#: ../gramps/plugins/view/geofamily.py:417
 #, python-format
 msgid "Child : %(id)s - %(index)d : %(name)s"
 msgstr ""
 
-#: ../gramps/plugins/view/geofamclose.py:642
-#: ../gramps/plugins/view/geofamily.py:377
+#: ../gramps/plugins/view/geofamclose.py:712
+#: ../gramps/plugins/view/geofamily.py:426
 #, python-format
 msgid "Person : %(id)s %(name)s has no family."
 msgstr ""
 
-#: ../gramps/plugins/view/geofamclose.py:761
+#: ../gramps/plugins/view/geofamclose.py:831
 msgid "Choose and bookmark the new reference family"
 msgstr ""
 
-#: ../gramps/plugins/view/geofamclose.py:784
+#: ../gramps/plugins/view/geofamclose.py:854
 msgid ""
 "The meeting zone probability radius.\n"
 "The colored zone is approximative.\n"
@@ -32400,221 +33498,230 @@ msgid ""
 "The value is in tenth of degree."
 msgstr ""
 
-#: ../gramps/plugins/view/geofamily.py:115
+#: ../gramps/plugins/view/geofamily.py:164
 msgid "Family places map"
 msgstr ""
 
-#: ../gramps/plugins/view/geofamily.py:137
+#: ../gramps/plugins/view/geofamily.py:186
 msgid "GeoFamily"
 msgstr ""
 
-#: ../gramps/plugins/view/geofamily.py:321
+#: ../gramps/plugins/view/geofamily.py:370
 #, python-format
 msgid "Family places for %s"
 msgstr ""
 
-#: ../gramps/plugins/view/geography.gpr.py:71
+#: ../gramps/plugins/view/geography.gpr.py:67
 msgid "OsmGpsMap module not loaded."
 msgstr ""
 
-#: ../gramps/plugins/view/geography.gpr.py:72
-#, python-format
+#: ../gramps/plugins/view/geography.gpr.py:68
 msgid ""
 "Geography functionality will not be available.\n"
-"To build it for Gramps see %(gramps_wiki_build_osmgps_url)s"
-msgstr ""
-
-#: ../gramps/plugins/view/geography.gpr.py:86
-msgid "All known places for one Person"
+"Try to install:\n"
+" gir1.2-osmgpsmap-1.0 (debian, ubuntu, ...)\n"
+" osm-gps-map-gobject-1.0.1 for fedora, ...\n"
+" typelib-1_0-OsmGpsMap-1_0 for openSuse\n"
+" ...\n"
+"To build it for Gramps see the Wiki (<F1>)\n"
+" and search for 'build from source'"
 msgstr ""
 
 #: ../gramps/plugins/view/geography.gpr.py:87
+msgid "All known places for one Person"
+msgstr ""
+
+#: ../gramps/plugins/view/geography.gpr.py:88
 msgid "A view showing the places visited by one person during his life."
 msgstr ""
 
-#: ../gramps/plugins/view/geography.gpr.py:95
-#: ../gramps/plugins/view/geography.gpr.py:112
-#: ../gramps/plugins/view/geography.gpr.py:133
-#: ../gramps/plugins/view/geography.gpr.py:151
-#: ../gramps/plugins/view/geography.gpr.py:169
-#: ../gramps/plugins/view/geography.gpr.py:185
-#: ../gramps/plugins/view/geography.gpr.py:202
+#: ../gramps/plugins/view/geography.gpr.py:96
+#: ../gramps/plugins/view/geography.gpr.py:113
+#: ../gramps/plugins/view/geography.gpr.py:134
+#: ../gramps/plugins/view/geography.gpr.py:152
+#: ../gramps/plugins/view/geography.gpr.py:170
+#: ../gramps/plugins/view/geography.gpr.py:186
+#: ../gramps/plugins/view/geography.gpr.py:203
 msgid "Geography"
 msgstr ""
 
-#: ../gramps/plugins/view/geography.gpr.py:103
+#: ../gramps/plugins/view/geography.gpr.py:104
 msgid "All known places for one Family"
 msgstr ""
 
-#: ../gramps/plugins/view/geography.gpr.py:104
+#: ../gramps/plugins/view/geography.gpr.py:105
 msgid "A view showing the places visited by one family during all their life."
 msgstr ""
 
-#: ../gramps/plugins/view/geography.gpr.py:120
+#: ../gramps/plugins/view/geography.gpr.py:121
 msgid "Every residence or move for a person and any descendants"
 msgstr ""
 
-#: ../gramps/plugins/view/geography.gpr.py:122
+#: ../gramps/plugins/view/geography.gpr.py:123
 msgid ""
 "A view showing all the places visited by all persons during their life.\n"
 "This is for a person and any descendant.\n"
 "You can see the dates corresponding to the period."
 msgstr ""
 
-#: ../gramps/plugins/view/geography.gpr.py:142
+#: ../gramps/plugins/view/geography.gpr.py:143
 msgid ""
 "A view showing the places visited by all family's members during their life: "
 "have these two people been able to meet?"
 msgstr ""
 
-#: ../gramps/plugins/view/geography.gpr.py:160
+#: ../gramps/plugins/view/geography.gpr.py:161
 msgid ""
 "A view showing the places visited by two persons during their life: have "
 "these two people been able to meet?"
 msgstr ""
 
-#: ../gramps/plugins/view/geography.gpr.py:177
+#: ../gramps/plugins/view/geography.gpr.py:178
 msgid "All known Places"
 msgstr ""
 
-#: ../gramps/plugins/view/geography.gpr.py:178
+#: ../gramps/plugins/view/geography.gpr.py:179
 msgid "A view showing all places of the database."
 msgstr ""
 
-#: ../gramps/plugins/view/geography.gpr.py:193
+#: ../gramps/plugins/view/geography.gpr.py:194
 msgid "All places related to Events"
 msgstr ""
 
-#: ../gramps/plugins/view/geography.gpr.py:194
+#: ../gramps/plugins/view/geography.gpr.py:195
 msgid "A view showing all the event places of the database."
 msgstr ""
 
-#: ../gramps/plugins/view/geomoves.py:142
+#: ../gramps/plugins/view/geomoves.py:207
 msgid "Descendance of the active person."
 msgstr ""
 
-#: ../gramps/plugins/view/geomoves.py:173
+#: ../gramps/plugins/view/geomoves.py:238
 msgid "GeoMoves"
 msgstr ""
 
-#: ../gramps/plugins/view/geomoves.py:490
+#: ../gramps/plugins/view/geomoves.py:556
 #, python-format
 msgid "All descendance for %s"
 msgstr ""
 
-#: ../gramps/plugins/view/geomoves.py:632
+#: ../gramps/plugins/view/geomoves.py:698
 msgid "Bookmark this person"
 msgstr ""
 
-#: ../gramps/plugins/view/geomoves.py:664
+#: ../gramps/plugins/view/geomoves.py:730
 msgid "The maximum number of generations.\n"
 msgstr ""
 
-#: ../gramps/plugins/view/geomoves.py:671
+#: ../gramps/plugins/view/geomoves.py:737
 msgid "Time in milliseconds between drawing two generations.\n"
 msgstr ""
 
-#: ../gramps/plugins/view/geomoves.py:677
+#: ../gramps/plugins/view/geomoves.py:743
 msgid "The parameters for moves"
 msgstr ""
 
-#: ../gramps/plugins/view/geoperson.py:146
+#: ../gramps/plugins/view/geoperson.py:211
 msgid "Person places map"
 msgstr ""
 
-#: ../gramps/plugins/view/geoperson.py:170
+#: ../gramps/plugins/view/geoperson.py:235
 msgid "GeoPerson"
 msgstr ""
 
-#: ../gramps/plugins/view/geoperson.py:315
+#: ../gramps/plugins/view/geoperson.py:381
 #, python-format
 msgid "Person places for %s"
 msgstr ""
 
-#: ../gramps/plugins/view/geoperson.py:519
+#: ../gramps/plugins/view/geoperson.py:585
 msgid "Animate"
 msgstr ""
 
-#: ../gramps/plugins/view/geoperson.py:542
+#: ../gramps/plugins/view/geoperson.py:608
 msgid "Animation speed in milliseconds (big value means slower)"
 msgstr ""
 
-#: ../gramps/plugins/view/geoperson.py:550
+#: ../gramps/plugins/view/geoperson.py:616
 msgid "How many steps between two markers when we are on large move ?"
 msgstr ""
 
-#: ../gramps/plugins/view/geoperson.py:557
+#: ../gramps/plugins/view/geoperson.py:623
 msgid ""
 "The minimum latitude/longitude to select large move.\n"
 "The value is in tenth of degree."
 msgstr ""
 
-#: ../gramps/plugins/view/geoperson.py:564
+#: ../gramps/plugins/view/geoperson.py:630
 msgid "The animation parameters"
 msgstr ""
 
-#: ../gramps/plugins/view/geoplaces.py:157
+#: ../gramps/plugins/view/geoplaces.py:207
 msgid "Places map"
 msgstr ""
 
-#: ../gramps/plugins/view/geoplaces.py:185
+#: ../gramps/plugins/view/geoplaces.py:236
 msgid "GeoPlaces"
 msgstr ""
 
-#: ../gramps/plugins/view/geoplaces.py:348
-#: ../gramps/plugins/view/geoplaces.py:361
+#: ../gramps/plugins/view/geoplaces.py:407
+#: ../gramps/plugins/view/geoplaces.py:420
 msgid "Selecting all places"
 msgstr ""
 
-#: ../gramps/plugins/view/geoplaces.py:373
+#: ../gramps/plugins/view/geoplaces.py:432
 msgid ""
 "Right click on the map and select 'show all places' to show all known places "
 "with coordinates. You can change the markers color depending on place type. "
 "You can use filtering."
 msgstr ""
 
-#: ../gramps/plugins/view/geoplaces.py:386
+#: ../gramps/plugins/view/geoplaces.py:445
 msgid ""
 "Right click on the map and select 'show all places' to show all known places "
 "with coordinates. You can use the history to navigate on the map. You can "
 "change the markers color depending on place type. You can use filtering."
 msgstr ""
 
-#: ../gramps/plugins/view/geoplaces.py:401
+#: ../gramps/plugins/view/geoplaces.py:460
 msgid "The place name in the status bar is disabled."
 msgstr ""
 
-#: ../gramps/plugins/view/geoplaces.py:406
+#: ../gramps/plugins/view/geoplaces.py:465
 #, python-format
 msgid "The maximum number of places is reached (%d)."
 msgstr ""
 
-#: ../gramps/plugins/view/geoplaces.py:409
+#: ../gramps/plugins/view/geoplaces.py:468
 msgid "Some information are missing."
 msgstr ""
 
-#: ../gramps/plugins/view/geoplaces.py:411
+#: ../gramps/plugins/view/geoplaces.py:470
 msgid "Please, use filtering to reduce this number."
 msgstr ""
 
-#: ../gramps/plugins/view/geoplaces.py:413
+#: ../gramps/plugins/view/geoplaces.py:472
 msgid "You can modify this value in the geography option."
 msgstr ""
 
-#: ../gramps/plugins/view/geoplaces.py:415
+#: ../gramps/plugins/view/geoplaces.py:474
 msgid "In this case, it may take time to show all markers."
 msgstr ""
 
-#: ../gramps/plugins/view/geoplaces.py:447
-#: ../gramps/plugins/view/geoplaces.py:471
+#: ../gramps/plugins/view/geoplaces.py:506
+#: ../gramps/plugins/view/geoplaces.py:530
 msgid "Bookmark this place"
 msgstr ""
 
-#: ../gramps/plugins/view/geoplaces.py:486
+#: ../gramps/plugins/view/geoplaces.py:545
 msgid "Show all places"
 msgstr ""
 
-#: ../gramps/plugins/view/geoplaces.py:596
+#: ../gramps/plugins/view/geoplaces.py:657
+msgid "Custom places name"
+msgstr ""
+
+#: ../gramps/plugins/view/geoplaces.py:666
 msgid "The places marker color"
 msgstr ""
 
@@ -32630,23 +33737,19 @@ msgstr ""
 msgid "Merge the selected media objects"
 msgstr ""
 
-#: ../gramps/plugins/view/mediaview.py:209
+#: ../gramps/plugins/view/mediaview.py:288
 msgid "Media Filter Editor"
 msgstr ""
 
-#: ../gramps/plugins/view/mediaview.py:212
+#: ../gramps/plugins/view/mediaview.py:379
 msgid "View in the default viewer"
 msgstr ""
 
-#: ../gramps/plugins/view/mediaview.py:216
-msgid "Open the folder containing the media file"
-msgstr ""
-
-#: ../gramps/plugins/view/mediaview.py:350
+#: ../gramps/plugins/view/mediaview.py:483
 msgid "Cannot merge media objects."
 msgstr ""
 
-#: ../gramps/plugins/view/mediaview.py:351
+#: ../gramps/plugins/view/mediaview.py:484
 msgid ""
 "Exactly two media objects must be selected to perform a merge. A second "
 "object can be selected by holding down the control key while clicking on the "
@@ -32661,15 +33764,15 @@ msgstr ""
 msgid "Merge the selected notes"
 msgstr ""
 
-#: ../gramps/plugins/view/noteview.py:199
+#: ../gramps/plugins/view/noteview.py:188
 msgid "Note Filter Editor"
 msgstr ""
 
-#: ../gramps/plugins/view/noteview.py:241
+#: ../gramps/plugins/view/noteview.py:357
 msgid "Cannot merge notes."
 msgstr ""
 
-#: ../gramps/plugins/view/noteview.py:242
+#: ../gramps/plugins/view/noteview.py:358
 msgid ""
 "Exactly two notes must be selected to perform a merge. A second note can be "
 "selected by holding down the control key while clicking on the desired note."
@@ -32699,85 +33802,85 @@ msgstr ""
 msgid "short for cremated|crem."
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:1148
+#: ../gramps/plugins/view/pedigreeview.py:1205
 msgid "Jump to child..."
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:1162
+#: ../gramps/plugins/view/pedigreeview.py:1219
 msgid "Jump to father"
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:1176
+#: ../gramps/plugins/view/pedigreeview.py:1233
 msgid "Jump to mother"
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:1534
+#: ../gramps/plugins/view/pedigreeview.py:1601
 msgid "A person was found to be his/her own ancestor."
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:1578
+#: ../gramps/plugins/view/pedigreeview.py:1645
 msgid "Pre_vious"
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:1579
+#: ../gramps/plugins/view/pedigreeview.py:1646
 msgid "_Next"
 msgstr ""
 
 #. Mouse scroll direction setting.
-#: ../gramps/plugins/view/pedigreeview.py:1602
+#: ../gramps/plugins/view/pedigreeview.py:1675
 msgid "Mouse scroll direction"
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:1606
+#: ../gramps/plugins/view/pedigreeview.py:1679
 msgid "Top <-> Bottom"
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:1613
+#: ../gramps/plugins/view/pedigreeview.py:1686
 msgid "Left <-> Right"
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:1830
-#: ../gramps/plugins/view/relview.py:412
+#: ../gramps/plugins/view/pedigreeview.py:1903
+#: ../gramps/plugins/view/relview.py:385
 msgid "Add New Parents..."
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:2025
+#: ../gramps/plugins/view/pedigreeview.py:2098
 msgid "Show images"
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:2028
+#: ../gramps/plugins/view/pedigreeview.py:2101
 msgid "Show marriage data"
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:2031
+#: ../gramps/plugins/view/pedigreeview.py:2104
 msgid "Show unknown people"
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:2034
+#: ../gramps/plugins/view/pedigreeview.py:2107
 msgid "Show tags"
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:2037
+#: ../gramps/plugins/view/pedigreeview.py:2110
 msgid "Tree style"
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:2039
+#: ../gramps/plugins/view/pedigreeview.py:2112
 msgid "Standard"
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:2040
+#: ../gramps/plugins/view/pedigreeview.py:2113
 msgid "Compact"
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:2041
+#: ../gramps/plugins/view/pedigreeview.py:2114
 msgid "Expanded"
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:2044
+#: ../gramps/plugins/view/pedigreeview.py:2117
 msgid "Tree direction"
 msgstr ""
 
-#: ../gramps/plugins/view/pedigreeview.py:2051
+#: ../gramps/plugins/view/pedigreeview.py:2124
 msgid "Tree size"
 msgstr ""
 
@@ -32797,180 +33900,184 @@ msgstr ""
 msgid "Place Tree View"
 msgstr ""
 
-#: ../gramps/plugins/view/placetreeview.py:70
-msgid "Expand this Entire Group"
-msgstr ""
-
-#: ../gramps/plugins/view/placetreeview.py:72
+#: ../gramps/plugins/view/placetreeview.py:77
 msgid "Collapse this Entire Group"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:398
-msgid "_Reorder"
+#: ../gramps/plugins/view/placetreeview.py:77
+msgid "Expand this Entire Group"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:399
-msgid "Change order of parents and families"
+#: ../gramps/plugins/view/relview.py:364
+msgid "Organize Bookmarks..."
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:404
-msgid "Edit..."
-msgstr ""
-
-#: ../gramps/plugins/view/relview.py:405
-msgid "Edit the active person"
-msgstr ""
-
-#: ../gramps/plugins/view/relview.py:407 ../gramps/plugins/view/relview.py:409
-#: ../gramps/plugins/view/relview.py:805
-msgid "Add a new family with person as parent"
-msgstr ""
-
-#: ../gramps/plugins/view/relview.py:408
-msgid "Add Partner..."
-msgstr ""
-
-#: ../gramps/plugins/view/relview.py:411 ../gramps/plugins/view/relview.py:413
-#: ../gramps/plugins/view/relview.py:799
-msgid "Add a new set of parents"
-msgstr ""
-
-#: ../gramps/plugins/view/relview.py:415 ../gramps/plugins/view/relview.py:419
-#: ../gramps/plugins/view/relview.py:800
-msgid "Add person as child to an existing family"
-msgstr ""
-
-#: ../gramps/plugins/view/relview.py:418
+#: ../gramps/plugins/view/relview.py:385
 msgid "Add Existing Parents..."
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:635
+#: ../gramps/plugins/view/relview.py:385
+msgid "Add Partner..."
+msgstr ""
+
+#: ../gramps/plugins/view/relview.py:385 ../gramps/plugins/view/relview.py:471
+msgid "_Reorder"
+msgstr ""
+
+#: ../gramps/plugins/view/relview.py:471 ../gramps/plugins/view/relview.py:964
+msgid "Add a new family with person as parent"
+msgstr ""
+
+#: ../gramps/plugins/view/relview.py:471 ../gramps/plugins/view/relview.py:958
+msgid "Add a new set of parents"
+msgstr ""
+
+#: ../gramps/plugins/view/relview.py:471 ../gramps/plugins/view/relview.py:959
+msgid "Add person as child to an existing family"
+msgstr ""
+
+#: ../gramps/plugins/view/relview.py:471
+msgid "Change order of parents and families"
+msgstr ""
+
+#: ../gramps/plugins/view/relview.py:471
+msgid "Edit the active person"
+msgstr ""
+
+#: ../gramps/plugins/view/relview.py:768
 msgid "Alive"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:704 ../gramps/plugins/view/relview.py:731
+#: ../gramps/plugins/view/relview.py:836 ../gramps/plugins/view/relview.py:863
 #, python-format
 msgid "%(date)s in %(place)s"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:801
+#: ../gramps/plugins/view/relview.py:960
 msgid "Edit parents"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:802
+#: ../gramps/plugins/view/relview.py:961
 msgid "Reorder parents"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:803
+#: ../gramps/plugins/view/relview.py:962
 msgid "Remove person as child of these parents"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:809
+#: ../gramps/plugins/view/relview.py:968
 msgid "Remove person as parent in this family"
 msgstr ""
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/view/relview.py:869 ../gramps/plugins/view/relview.py:923
+#: ../gramps/plugins/view/relview.py:1028
+#: ../gramps/plugins/view/relview.py:1083
 #, python-brace-format
 msgid " ({number_of} sibling)"
 msgid_plural " ({number_of} siblings)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gramps/plugins/view/relview.py:876 ../gramps/plugins/view/relview.py:930
+#: ../gramps/plugins/view/relview.py:1035
+#: ../gramps/plugins/view/relview.py:1090
 msgid " (1 brother)"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:878 ../gramps/plugins/view/relview.py:932
+#: ../gramps/plugins/view/relview.py:1037
+#: ../gramps/plugins/view/relview.py:1092
 msgid " (1 sister)"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:880 ../gramps/plugins/view/relview.py:934
+#: ../gramps/plugins/view/relview.py:1039
+#: ../gramps/plugins/view/relview.py:1094
 msgid " (1 sibling)"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:882 ../gramps/plugins/view/relview.py:936
+#: ../gramps/plugins/view/relview.py:1041
+#: ../gramps/plugins/view/relview.py:1096
 msgid " (only child)"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:948 ../gramps/plugins/view/relview.py:1430
+#: ../gramps/plugins/view/relview.py:1109
+#: ../gramps/plugins/view/relview.py:1601
 msgid "Add new child to family"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:952 ../gramps/plugins/view/relview.py:1434
+#: ../gramps/plugins/view/relview.py:1113
+#: ../gramps/plugins/view/relview.py:1605
 msgid "Add existing child to family"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:1220
+#: ../gramps/plugins/view/relview.py:1380
 #, python-format
 msgid "%(birthabbrev)s %(birthdate)s, %(deathabbrev)s %(deathdate)s"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:1227
-#: ../gramps/plugins/view/relview.py:1229
+#: ../gramps/plugins/view/relview.py:1387
+#: ../gramps/plugins/view/relview.py:1389
 #, python-format
 msgid "%(event)s %(date)s"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:1288
+#: ../gramps/plugins/view/relview.py:1448
 #, python-format
 msgid "Relationship type: %s"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:1326
+#: ../gramps/plugins/view/relview.py:1495
 #, python-format
 msgid "%(event_type)s: %(date)s in %(place)s"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:1330
+#: ../gramps/plugins/view/relview.py:1499
 #, python-format
 msgid "%(event_type)s: %(date)s"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:1334
+#: ../gramps/plugins/view/relview.py:1503
 #, python-format
 msgid "%(event_type)s: %(place)s"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:1345
+#: ../gramps/plugins/view/relview.py:1514
 msgid "Broken family detected"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:1346
+#: ../gramps/plugins/view/relview.py:1515
 msgid "Please run the Check and Repair Database tool"
 msgstr ""
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/view/relview.py:1369
-#: ../gramps/plugins/view/relview.py:1414
+#: ../gramps/plugins/view/relview.py:1538
+#: ../gramps/plugins/view/relview.py:1584
 #, python-brace-format
 msgid " ({number_of} child)"
 msgid_plural " ({number_of} children)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../gramps/plugins/view/relview.py:1373
-#: ../gramps/plugins/view/relview.py:1418
+#: ../gramps/plugins/view/relview.py:1542
+#: ../gramps/plugins/view/relview.py:1588
 msgid " (no children)"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:1675
+#: ../gramps/plugins/view/relview.py:1846
 msgid "Use shading"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:1678
+#: ../gramps/plugins/view/relview.py:1849
 msgid "Display edit buttons"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:1680
+#: ../gramps/plugins/view/relview.py:1851
 msgid "View links as website links"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:1697
+#: ../gramps/plugins/view/relview.py:1868
 msgid "Show Details"
 msgstr ""
 
-#: ../gramps/plugins/view/relview.py:1700
+#: ../gramps/plugins/view/relview.py:1871
 msgid "Show Siblings"
 msgstr ""
 
@@ -32994,15 +34101,15 @@ msgstr ""
 msgid "Merge the selected repositories"
 msgstr ""
 
-#: ../gramps/plugins/view/repoview.py:150
+#: ../gramps/plugins/view/repoview.py:201
 msgid "Repository Filter Editor"
 msgstr ""
 
-#: ../gramps/plugins/view/repoview.py:245
+#: ../gramps/plugins/view/repoview.py:363
 msgid "Cannot merge repositories."
 msgstr ""
 
-#: ../gramps/plugins/view/repoview.py:246
+#: ../gramps/plugins/view/repoview.py:364
 msgid ""
 "Exactly two repositories must be selected to perform a merge. A second "
 "repository can be selected by holding down the control key while clicking on "
@@ -33021,15 +34128,15 @@ msgstr ""
 msgid "Merge the selected sources"
 msgstr ""
 
-#: ../gramps/plugins/view/sourceview.py:136
+#: ../gramps/plugins/view/sourceview.py:187
 msgid "Source Filter Editor"
 msgstr ""
 
-#: ../gramps/plugins/view/sourceview.py:229
+#: ../gramps/plugins/view/sourceview.py:348
 msgid "Cannot merge sources."
 msgstr ""
 
-#: ../gramps/plugins/view/sourceview.py:230
+#: ../gramps/plugins/view/sourceview.py:349
 msgid ""
 "Exactly two sources must be selected to perform a merge. A second source can "
 "be selected by holding down the control key while clicking on the desired "
@@ -33130,14 +34237,14 @@ msgstr ""
 #. Add xml, doctype, meta and stylesheets
 #: ../gramps/plugins/webreport/addressbook.py:87
 #: ../gramps/plugins/webreport/addressbooklist.py:81
-#: ../gramps/plugins/webreport/basepage.py:1487
-#: ../gramps/plugins/webreport/basepage.py:1553
-#: ../gramps/plugins/webreport/basepage.py:1628
+#: ../gramps/plugins/webreport/basepage.py:1536
+#: ../gramps/plugins/webreport/basepage.py:1595
+#: ../gramps/plugins/webreport/basepage.py:1669
 msgid "Address Book"
 msgstr ""
 
 #. Address Book Page message
-#: ../gramps/plugins/webreport/addressbooklist.py:89
+#: ../gramps/plugins/webreport/addressbooklist.py:90
 msgid ""
 "This page contains an index of all the individuals in the database, sorted "
 "by their surname, with one of the following: Address, Residence, or Web "
@@ -33145,45 +34252,46 @@ msgid ""
 "Address Book page."
 msgstr ""
 
-#: ../gramps/plugins/webreport/addressbooklist.py:111
+#: ../gramps/plugins/webreport/addressbooklist.py:112
 msgid "Full Name"
 msgstr ""
 
-#: ../gramps/plugins/webreport/addressbooklist.py:114
-#: ../gramps/plugins/webreport/basepage.py:2037
+#: ../gramps/plugins/webreport/addressbooklist.py:115
+#: ../gramps/plugins/webreport/basepage.py:2126
 msgid "Web Links"
 msgstr ""
 
 #. add section title
-#: ../gramps/plugins/webreport/basepage.py:350
-#: ../gramps/plugins/webreport/basepage.py:2018
+#: ../gramps/plugins/webreport/basepage.py:369
+#: ../gramps/plugins/webreport/basepage.py:2107
 msgid "Narrative"
 msgstr ""
 
-#: ../gramps/plugins/webreport/basepage.py:1104
-#: ../gramps/plugins/webreport/basepage.py:2544
-#: ../gramps/plugins/webreport/basepage.py:2608
-#: ../gramps/plugins/webreport/place.py:177
+#: ../gramps/plugins/webreport/basepage.py:1131
+#: ../gramps/plugins/webreport/basepage.py:2593
+#: ../gramps/plugins/webreport/basepage.py:2658
+#: ../gramps/plugins/webreport/place.py:182
+#: ../gramps/plugins/webreport/place.py:194
 msgid "State/ Province"
 msgstr ""
 
-#: ../gramps/plugins/webreport/basepage.py:1278
+#: ../gramps/plugins/webreport/basepage.py:1306
 #, python-format
 msgid "Generated by %(gramps_home_html_start)sGramps%(html_end)s %(version)s"
 msgstr ""
 
-#: ../gramps/plugins/webreport/basepage.py:1288
+#: ../gramps/plugins/webreport/basepage.py:1316
 #, python-format
 msgid "Last change was the %(date)s"
 msgstr ""
 
-#: ../gramps/plugins/webreport/basepage.py:1291
+#: ../gramps/plugins/webreport/basepage.py:1319
 #, python-format
 msgid " on %(date)s"
 msgstr ""
 
-#: ../gramps/plugins/webreport/basepage.py:1312
-#: ../gramps/plugins/webreport/basepage.py:1317
+#: ../gramps/plugins/webreport/basepage.py:1340
+#: ../gramps/plugins/webreport/basepage.py:1345
 #, python-format
 msgid "%(http_break)sCreated for %(subject_url)s"
 msgstr ""
@@ -33192,88 +34300,83 @@ msgstr ""
 #. is the style sheet either Basic-Blue or Visually Impaired,
 #. and menu layout is Drop Down?
 #. Basic Blue style sheet with navigation menus
-#: ../gramps/plugins/webreport/basepage.py:1433
+#: ../gramps/plugins/webreport/basepage.py:1476
 #: ../gramps/plugins/webstuff/webstuff.py:64
 msgid "Basic-Blue"
 msgstr ""
 
 #. Visually Impaired style sheet with its navigation menus
-#: ../gramps/plugins/webreport/basepage.py:1434
+#: ../gramps/plugins/webreport/basepage.py:1477
 #: ../gramps/plugins/webstuff/webstuff.py:96
 msgid "Visually Impaired"
 msgstr ""
 
-#: ../gramps/plugins/webreport/basepage.py:1473
-#: ../gramps/plugins/webreport/basepage.py:1651
+#: ../gramps/plugins/webreport/basepage.py:1521
+#: ../gramps/plugins/webreport/basepage.py:1692
 msgid "Html|Home"
 msgstr ""
 
-#: ../gramps/plugins/webreport/basepage.py:1485
-#: ../gramps/plugins/webreport/basepage.py:1620
-#: ../gramps/plugins/webreport/thumbnail.py:111
+#: ../gramps/plugins/webreport/basepage.py:1534
+#: ../gramps/plugins/webreport/basepage.py:1661
+#: ../gramps/plugins/webreport/thumbnail.py:112
 msgid "Thumbnails"
 msgstr ""
 
-#: ../gramps/plugins/webreport/basepage.py:1486
-#: ../gramps/plugins/webreport/basepage.py:1627
+#: ../gramps/plugins/webreport/basepage.py:1535
+#: ../gramps/plugins/webreport/basepage.py:1668
 #: ../gramps/plugins/webreport/download.py:94
-#: ../gramps/plugins/webreport/narrativeweb.py:1814
+#: ../gramps/plugins/webreport/narrativeweb.py:1899
 msgid "Download"
 msgstr ""
 
 #. add contact column
-#: ../gramps/plugins/webreport/basepage.py:1489
-#: ../gramps/plugins/webreport/basepage.py:1635
-#: ../gramps/plugins/webreport/basepage.py:1672
-#: ../gramps/plugins/webreport/contact.py:76
+#: ../gramps/plugins/webreport/basepage.py:1538
+#: ../gramps/plugins/webreport/basepage.py:1676
+#: ../gramps/plugins/webreport/basepage.py:1713
+#: ../gramps/plugins/webreport/contact.py:77
 msgid "Contact"
 msgstr ""
 
-#: ../gramps/plugins/webreport/basepage.py:1491
+#: ../gramps/plugins/webreport/basepage.py:1540
 #: ../gramps/plugins/webreport/webplugins.gpr.py:58
 msgid "Web Calendar"
 msgstr ""
 
-#: ../gramps/plugins/webreport/basepage.py:1571
-#: ../gramps/plugins/webreport/media.py:410
+#: ../gramps/plugins/webreport/basepage.py:1612
+#: ../gramps/plugins/webreport/media.py:399
 msgid "Previous"
 msgstr ""
 
-#: ../gramps/plugins/webreport/basepage.py:1573
-#: ../gramps/plugins/webreport/media.py:421
+#: ../gramps/plugins/webreport/basepage.py:1614
+#: ../gramps/plugins/webreport/media.py:410
 msgid "Next"
 msgstr ""
 
-#: ../gramps/plugins/webreport/basepage.py:2085
+#: ../gramps/plugins/webreport/basepage.py:2174
 msgid " [Click to Go]"
 msgstr ""
 
-#: ../gramps/plugins/webreport/basepage.py:2109
+#: ../gramps/plugins/webreport/basepage.py:2198
 msgid "Latter-Day Saints/ LDS Ordinance"
 msgstr ""
 
-#: ../gramps/plugins/webreport/basepage.py:2295
-#: ../gramps/plugins/webreport/basepage.py:2296
-#: ../gramps/plugins/webreport/person.py:611
-#: ../gramps/plugins/webreport/person.py:921
+#: ../gramps/plugins/webreport/basepage.py:2344
+#: ../gramps/plugins/webreport/basepage.py:2345
+#: ../gramps/plugins/webreport/person.py:630
+#: ../gramps/plugins/webreport/person.py:941
 msgid "Family Map"
 msgstr ""
 
-#: ../gramps/plugins/webreport/basepage.py:2541
-#: ../gramps/plugins/webreport/basepage.py:2606
+#: ../gramps/plugins/webreport/basepage.py:2590
+#: ../gramps/plugins/webreport/basepage.py:2656
 msgid "Church Parish"
 msgstr ""
 
-#: ../gramps/plugins/webreport/basepage.py:2562
+#: ../gramps/plugins/webreport/basepage.py:2611
 msgid "Locations"
 msgstr ""
 
-#: ../gramps/plugins/webreport/basepage.py:2773
-#, python-format
-msgid " (%s) "
-msgstr ""
-
-#: ../gramps/plugins/webreport/download.py:100
+#: ../gramps/plugins/webreport/download.py:101
 msgid ""
 "This page is for the user/ creator of this Family Tree/ Narrative website to "
 "share a couple of files with you regarding their family.  If there are any "
@@ -33282,11 +34385,11 @@ msgid ""
 "web pages."
 msgstr ""
 
-#: ../gramps/plugins/webreport/download.py:126
+#: ../gramps/plugins/webreport/download.py:127
 msgid "File Name"
 msgstr ""
 
-#: ../gramps/plugins/webreport/download.py:128
+#: ../gramps/plugins/webreport/download.py:129
 msgid "Last Modified"
 msgstr ""
 
@@ -33296,36 +34399,37 @@ msgstr ""
 
 #: ../gramps/plugins/webreport/event.py:114
 #: ../gramps/plugins/webreport/family.py:108
-#: ../gramps/plugins/webreport/media.py:114
-#: ../gramps/plugins/webreport/media.py:243
-#: ../gramps/plugins/webreport/narrativeweb.py:484
-#: ../gramps/plugins/webreport/narrativeweb.py:1051
-#: ../gramps/plugins/webreport/narrativeweb.py:1109
-#: ../gramps/plugins/webreport/narrativeweb.py:1134
-#: ../gramps/plugins/webreport/narrativeweb.py:1143
-#: ../gramps/plugins/webreport/narrativeweb.py:1186
-#: ../gramps/plugins/webreport/person.py:136
-#: ../gramps/plugins/webreport/place.py:114
+#: ../gramps/plugins/webreport/media.py:116
+#: ../gramps/plugins/webreport/media.py:244
+#: ../gramps/plugins/webreport/narrativeweb.py:501
+#: ../gramps/plugins/webreport/narrativeweb.py:1084
+#: ../gramps/plugins/webreport/narrativeweb.py:1142
+#: ../gramps/plugins/webreport/narrativeweb.py:1165
+#: ../gramps/plugins/webreport/narrativeweb.py:1174
+#: ../gramps/plugins/webreport/narrativeweb.py:1217
+#: ../gramps/plugins/webreport/person.py:141
+#: ../gramps/plugins/webreport/place.py:117
 #: ../gramps/plugins/webreport/repository.py:102
 #: ../gramps/plugins/webreport/source.py:103
 msgid "Narrated Web Site Report"
 msgstr ""
 
-#: ../gramps/plugins/webreport/event.py:147
+#: ../gramps/plugins/webreport/event.py:148
 msgid ""
 "This page contains an index of all the events in the database, sorted by "
 "their type and date (if one is present). Clicking on an event&#8217;s Gramps "
 "ID will open a page for that event."
 msgstr ""
 
-#: ../gramps/plugins/webreport/event.py:173
-#: ../gramps/plugins/webreport/family.py:185
-#: ../gramps/plugins/webreport/place.py:175
-#: ../gramps/plugins/webreport/surnamelist.py:139
+#: ../gramps/plugins/webreport/event.py:174
+#: ../gramps/plugins/webreport/family.py:186
+#: ../gramps/plugins/webreport/place.py:180
+#: ../gramps/plugins/webreport/place.py:192
+#: ../gramps/plugins/webreport/surnamelist.py:140
 msgid "Letter"
 msgstr ""
 
-#: ../gramps/plugins/webreport/event.py:245
+#: ../gramps/plugins/webreport/event.py:246
 #, python-format
 msgid "Event types beginning with letter %s"
 msgstr ""
@@ -33335,27 +34439,27 @@ msgid "Creating family pages..."
 msgstr ""
 
 #. Families list page message
-#: ../gramps/plugins/webreport/family.py:140
+#: ../gramps/plugins/webreport/family.py:141
 msgid ""
 "This page contains an index of all the families/ relationships in the "
 "database, sorted by their family name/ surname. Clicking on a person&#8217;s "
 "name will take you to their family/ relationship&#8217;s page."
 msgstr ""
 
-#: ../gramps/plugins/webreport/family.py:231
+#: ../gramps/plugins/webreport/family.py:232
 msgid "Families beginning with letter "
 msgstr ""
 
-#: ../gramps/plugins/webreport/home.py:77
+#: ../gramps/plugins/webreport/home.py:78
 #: ../gramps/plugins/webreport/webcal.py:576
 msgid "Home"
 msgstr ""
 
-#: ../gramps/plugins/webreport/media.py:113
+#: ../gramps/plugins/webreport/media.py:115
 msgid "Creating media pages"
 msgstr ""
 
-#: ../gramps/plugins/webreport/media.py:203
+#: ../gramps/plugins/webreport/media.py:204
 msgid ""
 "This page contains an index of all the media objects in the database, sorted "
 "by their title. Clicking on the title will take you to that media "
@@ -33363,23 +34467,23 @@ msgid ""
 "on the image to see the full sized version.  "
 msgstr ""
 
-#: ../gramps/plugins/webreport/media.py:227
+#: ../gramps/plugins/webreport/media.py:228
 msgid "Media | Name"
 msgstr ""
 
-#: ../gramps/plugins/webreport/media.py:230
+#: ../gramps/plugins/webreport/media.py:231
 msgid "Mime Type"
 msgstr ""
 
-#: ../gramps/plugins/webreport/media.py:242
+#: ../gramps/plugins/webreport/media.py:243
 msgid "Creating list of media pages"
 msgstr ""
 
-#: ../gramps/plugins/webreport/media.py:286
+#: ../gramps/plugins/webreport/media.py:280
 msgid "Below unused media objects"
 msgstr ""
 
-#: ../gramps/plugins/webreport/media.py:411
+#: ../gramps/plugins/webreport/media.py:400
 #, python-format
 msgid ""
 "%(strong1_strt)s%(page_number)d%(strong_end)s of %(strong2_strt)s"
@@ -33387,599 +34491,655 @@ msgid ""
 msgstr ""
 
 #. missing media error message
-#: ../gramps/plugins/webreport/media.py:424
+#: ../gramps/plugins/webreport/media.py:413
 msgid "The file has been moved or deleted."
 msgstr ""
 
-#: ../gramps/plugins/webreport/media.py:580
+#: ../gramps/plugins/webreport/media.py:552
 msgid "File Type"
 msgstr ""
 
-#: ../gramps/plugins/webreport/media.py:683
+#: ../gramps/plugins/webreport/media.py:655
 msgid "Missing media object:"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:270
+#: ../gramps/plugins/webreport/narrativeweb.py:285
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:279
-#: ../gramps/plugins/webreport/narrativeweb.py:284
-#: ../gramps/plugins/webreport/narrativeweb.py:297
-#: ../gramps/plugins/webreport/narrativeweb.py:302
+#: ../gramps/plugins/webreport/narrativeweb.py:294
+#: ../gramps/plugins/webreport/narrativeweb.py:300
+#: ../gramps/plugins/webreport/narrativeweb.py:313
+#: ../gramps/plugins/webreport/narrativeweb.py:319
 #, python-format
 msgid "Could not create the directory: %s"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:309
+#: ../gramps/plugins/webreport/narrativeweb.py:326
 msgid "Invalid file name"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:310
+#: ../gramps/plugins/webreport/narrativeweb.py:327
 msgid "The archive file must be a file, not a directory"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:446
+#: ../gramps/plugins/webreport/narrativeweb.py:463
 #, python-format
 msgid "ID=%(grampsid)s, path=%(dir)s"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:451
+#: ../gramps/plugins/webreport/narrativeweb.py:468
 msgid "Missing media objects:"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:483
+#: ../gramps/plugins/webreport/narrativeweb.py:500
 msgid "Constructing list of other objects..."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:728
+#: ../gramps/plugins/webreport/narrativeweb.py:745
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr ""
 
 #. Only the name of the husband is known
 #. Only the name of the wife is known
-#: ../gramps/plugins/webreport/narrativeweb.py:734
-#: ../gramps/plugins/webreport/narrativeweb.py:738
+#: ../gramps/plugins/webreport/narrativeweb.py:751
+#: ../gramps/plugins/webreport/narrativeweb.py:755
 #, python-format
 msgid "Family of %s"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1050
+#: ../gramps/plugins/webreport/narrativeweb.py:1083
 msgid "Creating GENDEX file"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1108
+#: ../gramps/plugins/webreport/narrativeweb.py:1141
 msgid "Creating surname pages"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1135
-#: ../gramps/plugins/webreport/thumbnail.py:206
+#: ../gramps/plugins/webreport/narrativeweb.py:1166
 msgid "Creating thumbnail preview page..."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1144
+#: ../gramps/plugins/webreport/narrativeweb.py:1175
 msgid "Creating statistics page..."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1185
+#: ../gramps/plugins/webreport/narrativeweb.py:1216
 msgid "Creating address book pages ..."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1579
+#: ../gramps/plugins/webreport/narrativeweb.py:1616
 msgid "Store web pages in .tar.gz archive"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1581
+#: ../gramps/plugins/webreport/narrativeweb.py:1618
 msgid "Whether to store the web pages in an archive file"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1592
-#: ../gramps/plugins/webreport/webcal.py:1625
+#: ../gramps/plugins/webreport/narrativeweb.py:1629
+#: ../gramps/plugins/webreport/webcal.py:1663
 msgid "The destination directory for the web files"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1598
+#: ../gramps/plugins/webreport/narrativeweb.py:1635
 msgid "My Family Tree"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1598
+#: ../gramps/plugins/webreport/narrativeweb.py:1635
 msgid "Web site title"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1599
+#: ../gramps/plugins/webreport/narrativeweb.py:1636
 msgid "The title of the web site"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1604
+#: ../gramps/plugins/webreport/narrativeweb.py:1641
 msgid "Select filter to restrict people that appear on web site"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1624
+#: ../gramps/plugins/webreport/narrativeweb.py:1650
+msgid "Show the relationship between the current person and the active person"
+msgstr ""
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1653
+msgid ""
+"For each person page, show the relationship between this person and the "
+"active person."
+msgstr ""
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1671
 msgid "Html options"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1627
-#: ../gramps/plugins/webreport/webcal.py:1646
+#: ../gramps/plugins/webreport/narrativeweb.py:1674
+#: ../gramps/plugins/webreport/webcal.py:1684
 msgid "File extension"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1630
-#: ../gramps/plugins/webreport/webcal.py:1649
+#: ../gramps/plugins/webreport/narrativeweb.py:1677
+#: ../gramps/plugins/webreport/webcal.py:1687
 msgid "The extension to be used for the web files"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1633
-#: ../gramps/plugins/webreport/webcal.py:1652
+#: ../gramps/plugins/webreport/narrativeweb.py:1680
+#: ../gramps/plugins/webreport/webcal.py:1690
 msgid "Copyright"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1636
-#: ../gramps/plugins/webreport/webcal.py:1655
+#: ../gramps/plugins/webreport/narrativeweb.py:1683
+#: ../gramps/plugins/webreport/webcal.py:1693
 msgid "The copyright to be used for the web files"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1639
-#: ../gramps/plugins/webreport/webcal.py:1661
-msgid "StyleSheet"
-msgstr ""
-
-#: ../gramps/plugins/webreport/narrativeweb.py:1644
-#: ../gramps/plugins/webreport/webcal.py:1664
+#: ../gramps/plugins/webreport/narrativeweb.py:1692
+#: ../gramps/plugins/webreport/webcal.py:1702
 msgid "The stylesheet to be used for the web pages"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1649
+#: ../gramps/plugins/webreport/narrativeweb.py:1697
 msgid "Horizontal -- Default"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1650
+#: ../gramps/plugins/webreport/narrativeweb.py:1698
 msgid "Vertical   -- Left Side"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1651
+#: ../gramps/plugins/webreport/narrativeweb.py:1699
 msgid "Fade       -- WebKit Browsers Only"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1652
-#: ../gramps/plugins/webreport/narrativeweb.py:1666
+#: ../gramps/plugins/webreport/narrativeweb.py:1700
+#: ../gramps/plugins/webreport/narrativeweb.py:1714
 msgid "Drop-Down  -- WebKit Browsers Only"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1654
+#: ../gramps/plugins/webreport/narrativeweb.py:1702
 msgid "Navigation Menu Layout"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1658
+#: ../gramps/plugins/webreport/narrativeweb.py:1706
 msgid "Choose which layout for the Navigation Menus."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1665
+#: ../gramps/plugins/webreport/narrativeweb.py:1713
 msgid "Normal Outline Style"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1669
+#: ../gramps/plugins/webreport/narrativeweb.py:1717
 msgid "Citation Referents Layout"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1673
+#: ../gramps/plugins/webreport/narrativeweb.py:1721
 msgid ""
 "Determine the default layout for the Source Page's Citation Referents section"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1677
+#: ../gramps/plugins/webreport/narrativeweb.py:1725
 msgid "Include ancestor's tree"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1678
+#: ../gramps/plugins/webreport/narrativeweb.py:1726
 msgid "Whether to include an ancestor graph on each individual page"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1683
-msgid "Graph generations"
+#: ../gramps/plugins/webreport/narrativeweb.py:1731
+msgid "Add previous/next"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1684
-msgid "The number of generations to include in the ancestor graph"
+#: ../gramps/plugins/webreport/narrativeweb.py:1732
+msgid "Add previous/next to the navigation bar."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1689
+#: ../gramps/plugins/webreport/narrativeweb.py:1735
 msgid "This is a secure site (https)"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1691
+#: ../gramps/plugins/webreport/narrativeweb.py:1737
 msgid "Whether to use http:// or https://"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1707
-msgid "Suppress Gramps ID"
+#: ../gramps/plugins/webreport/narrativeweb.py:1744
+msgid "Extra pages"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1708
-msgid "Whether to include the Gramps ID of objects"
+#: ../gramps/plugins/webreport/narrativeweb.py:1747
+msgid "Extra page name"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1713
+#: ../gramps/plugins/webreport/narrativeweb.py:1750
+msgid "Your extra page name like it is shown in the menubar"
+msgstr ""
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1755
+msgid "Your extra page path"
+msgstr ""
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1758
+msgid "Your extra page path without extension"
+msgstr ""
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1778
 msgid "Sort all children in birth order"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1715
+#: ../gramps/plugins/webreport/narrativeweb.py:1780
 msgid "Whether to display children in birth order or in entry order?"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1722
+#: ../gramps/plugins/webreport/narrativeweb.py:1784
+msgid "Do we display coordinates in the places list?"
+msgstr ""
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1786
+msgid "Whether to display latitude/longitude in the places list?"
+msgstr ""
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1790
+msgid "Sort places references either by date or by name"
+msgstr ""
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1792
+msgid "Sort the places references by date or by name. Not set means by date."
+msgstr ""
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1796
+msgid "Graph generations"
+msgstr ""
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1797
+msgid "The number of generations to include in the ancestor graph"
+msgstr ""
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1807
 msgid "Page Generation"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1725
+#: ../gramps/plugins/webreport/narrativeweb.py:1810
 msgid "Home page note"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1726
+#: ../gramps/plugins/webreport/narrativeweb.py:1811
 msgid "A note to be used on the home page"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1729
+#: ../gramps/plugins/webreport/narrativeweb.py:1814
 msgid "Home page image"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1730
+#: ../gramps/plugins/webreport/narrativeweb.py:1815
 msgid "An image to be used on the home page"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1733
+#: ../gramps/plugins/webreport/narrativeweb.py:1818
 msgid "Introduction note"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1734
+#: ../gramps/plugins/webreport/narrativeweb.py:1819
 msgid "A note to be used as the introduction"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1737
+#: ../gramps/plugins/webreport/narrativeweb.py:1822
 msgid "Introduction image"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1738
+#: ../gramps/plugins/webreport/narrativeweb.py:1823
 msgid "An image to be used as the introduction"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1741
+#: ../gramps/plugins/webreport/narrativeweb.py:1826
 msgid "Publisher contact note"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1742
+#: ../gramps/plugins/webreport/narrativeweb.py:1827
 msgid ""
 "A note to be used as the publisher contact.\n"
 "If no publisher information is given,\n"
 "no contact page will be created"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1748
+#: ../gramps/plugins/webreport/narrativeweb.py:1833
 msgid "Publisher contact image"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1749
+#: ../gramps/plugins/webreport/narrativeweb.py:1834
 msgid ""
 "An image to be used as the publisher contact.\n"
 "If no publisher information is given,\n"
 "no contact page will be created"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1755
+#: ../gramps/plugins/webreport/narrativeweb.py:1840
 msgid "HTML user header"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1756
+#: ../gramps/plugins/webreport/narrativeweb.py:1841
 msgid "A note to be used as the page header"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1759
+#: ../gramps/plugins/webreport/narrativeweb.py:1844
 msgid "HTML user footer"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1760
+#: ../gramps/plugins/webreport/narrativeweb.py:1845
 msgid "A note to be used as the page footer"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1767
+#: ../gramps/plugins/webreport/narrativeweb.py:1852
 msgid "Images Generation"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1770
+#: ../gramps/plugins/webreport/narrativeweb.py:1855
 msgid "Include images and media objects"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1772
+#: ../gramps/plugins/webreport/narrativeweb.py:1857
 msgid "Whether to include a gallery of media objects"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1778
+#: ../gramps/plugins/webreport/narrativeweb.py:1863
 msgid "Include unused images and media objects"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1779
+#: ../gramps/plugins/webreport/narrativeweb.py:1864
 msgid "Whether to include unused or unreferenced media objects"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1784
+#: ../gramps/plugins/webreport/narrativeweb.py:1869
 msgid "Create and only use thumbnail- sized images"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1786
+#: ../gramps/plugins/webreport/narrativeweb.py:1871
 msgid ""
 "This option allows you to create only thumbnail images instead of the full-"
 "sized images on the Media Page. This will allow you to have a much smaller "
 "total upload size to your web hosting site."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1795
+#: ../gramps/plugins/webreport/narrativeweb.py:1880
 msgid "Max width of initial image"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1797
+#: ../gramps/plugins/webreport/narrativeweb.py:1882
 msgid ""
 "This allows you to set the maximum width of the image shown on the media "
 "page. Set to 0 for no limit."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1802
+#: ../gramps/plugins/webreport/narrativeweb.py:1887
 msgid "Max height of initial image"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1804
+#: ../gramps/plugins/webreport/narrativeweb.py:1889
 msgid ""
 "This allows you to set the maximum height of the image shown on the media "
 "page. Set to 0 for no limit."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1817
+#: ../gramps/plugins/webreport/narrativeweb.py:1902
 msgid "Include download page"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1819
+#: ../gramps/plugins/webreport/narrativeweb.py:1904
 msgid "Whether to include a database download option"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1824
-#: ../gramps/plugins/webreport/narrativeweb.py:1836
+#: ../gramps/plugins/webreport/narrativeweb.py:1909
+#: ../gramps/plugins/webreport/narrativeweb.py:1921
 msgid "Download Filename"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1827
-#: ../gramps/plugins/webreport/narrativeweb.py:1839
+#: ../gramps/plugins/webreport/narrativeweb.py:1912
+#: ../gramps/plugins/webreport/narrativeweb.py:1924
 msgid "File to be used for downloading of database"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1830
-#: ../gramps/plugins/webreport/narrativeweb.py:1842
+#: ../gramps/plugins/webreport/narrativeweb.py:1915
+#: ../gramps/plugins/webreport/narrativeweb.py:1927
 msgid "Description for download"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1831
+#: ../gramps/plugins/webreport/narrativeweb.py:1916
 msgid "Smith Family Tree"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1832
-#: ../gramps/plugins/webreport/narrativeweb.py:1844
+#: ../gramps/plugins/webreport/narrativeweb.py:1917
+#: ../gramps/plugins/webreport/narrativeweb.py:1929
 msgid "Give a description for this file."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1843
+#: ../gramps/plugins/webreport/narrativeweb.py:1928
 msgid "Johnson Family Tree"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1853
-#: ../gramps/plugins/webreport/webcal.py:1836
+#: ../gramps/plugins/webreport/narrativeweb.py:1938
+#: ../gramps/plugins/webreport/webcal.py:1868
 msgid "Advanced Options"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1856
-#: ../gramps/plugins/webreport/webcal.py:1838
+#: ../gramps/plugins/webreport/narrativeweb.py:1941
+#: ../gramps/plugins/webreport/webcal.py:1870
 msgid "Character set encoding"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1860
-#: ../gramps/plugins/webreport/webcal.py:1842
+#: ../gramps/plugins/webreport/narrativeweb.py:1945
+#: ../gramps/plugins/webreport/webcal.py:1874
 msgid "The encoding to be used for the web files"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1864
+#: ../gramps/plugins/webreport/narrativeweb.py:1949
 msgid "Include link to active person on every page"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1866
+#: ../gramps/plugins/webreport/narrativeweb.py:1951
 msgid "Include a link to the active person (if they have a webpage)"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1870
+#: ../gramps/plugins/webreport/narrativeweb.py:1955
 msgid "Include a column for birth dates on the index pages"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1871
+#: ../gramps/plugins/webreport/narrativeweb.py:1956
 msgid "Whether to include a birth column"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1875
+#: ../gramps/plugins/webreport/narrativeweb.py:1960
 msgid "Include a column for death dates on the index pages"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1876
+#: ../gramps/plugins/webreport/narrativeweb.py:1961
 msgid "Whether to include a death column"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1879
+#: ../gramps/plugins/webreport/narrativeweb.py:1964
 msgid "Include a column for partners on the index pages"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1881
+#: ../gramps/plugins/webreport/narrativeweb.py:1966
 msgid "Whether to include a partners column"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1884
+#: ../gramps/plugins/webreport/narrativeweb.py:1969
 msgid "Include a column for parents on the index pages"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1886
+#: ../gramps/plugins/webreport/narrativeweb.py:1971
 msgid "Whether to include a parents column"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1890
+#: ../gramps/plugins/webreport/narrativeweb.py:1975
 msgid "Include half and/ or step-siblings on the individual pages"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1893
+#: ../gramps/plugins/webreport/narrativeweb.py:1978
 msgid ""
 "Whether to include half and/ or step-siblings with the parents and siblings"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1904
+#: ../gramps/plugins/webreport/narrativeweb.py:1989
 msgid "Include family pages"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1905
+#: ../gramps/plugins/webreport/narrativeweb.py:1990
 msgid "Whether or not to include family pages."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1908
+#: ../gramps/plugins/webreport/narrativeweb.py:1993
 msgid "Include event pages"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1910
+#: ../gramps/plugins/webreport/narrativeweb.py:1995
 msgid "Add a complete events list and relevant pages or not"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1913
+#: ../gramps/plugins/webreport/narrativeweb.py:1998
+msgid "Include places pages"
+msgstr ""
+
+#: ../gramps/plugins/webreport/narrativeweb.py:2000
+msgid "Whether or not to include the places Pages."
+msgstr ""
+
+#: ../gramps/plugins/webreport/narrativeweb.py:2003
+msgid "Include sources pages"
+msgstr ""
+
+#: ../gramps/plugins/webreport/narrativeweb.py:2005
+msgid "Whether or not to include the sources Pages."
+msgstr ""
+
+#: ../gramps/plugins/webreport/narrativeweb.py:2008
 msgid "Include repository pages"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1915
+#: ../gramps/plugins/webreport/narrativeweb.py:2010
 msgid "Whether or not to include the Repository Pages."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1919
+#: ../gramps/plugins/webreport/narrativeweb.py:2014
 msgid "Include GENDEX file (/gendex.txt)"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1920
+#: ../gramps/plugins/webreport/narrativeweb.py:2015
 msgid "Whether to include a GENDEX file or not"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1923
+#: ../gramps/plugins/webreport/narrativeweb.py:2018
 msgid "Include address book pages"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1924
+#: ../gramps/plugins/webreport/narrativeweb.py:2019
 msgid ""
 "Whether or not to add Address Book pages,which can include e-mail and "
 "website addresses and personal address/ residence events."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1930
+#: ../gramps/plugins/webreport/narrativeweb.py:2025
 msgid "Include the statistics page"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1931
+#: ../gramps/plugins/webreport/narrativeweb.py:2026
 msgid "Whether or not to add statistics page"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1938
+#: ../gramps/plugins/webreport/narrativeweb.py:2033
 msgid "Place Map Options"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1943
+#: ../gramps/plugins/webreport/narrativeweb.py:2038
 msgid "Google"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1944
+#: ../gramps/plugins/webreport/narrativeweb.py:2039
 msgid "Map Service"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1948
+#: ../gramps/plugins/webreport/narrativeweb.py:2043
 msgid "Choose your choice of map service for creating the Place Map Pages."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1954
+#: ../gramps/plugins/webreport/narrativeweb.py:2049
 msgid "Include Place map on Place Pages"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1956
+#: ../gramps/plugins/webreport/narrativeweb.py:2051
 msgid ""
 "Whether to include a place map on the Place Pages, where Latitude/ Longitude "
 "are available."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1961
+#: ../gramps/plugins/webreport/narrativeweb.py:2056
 msgid "Include Family Map Pages with all places shown on the map"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1965
+#: ../gramps/plugins/webreport/narrativeweb.py:2060
 msgid ""
 "Whether or not to add an individual page map showing all the places on this "
 "page. This will allow you to see how your family traveled around the country."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1973
+#: ../gramps/plugins/webreport/narrativeweb.py:2068
 msgid "Family Links"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1974
+#: ../gramps/plugins/webreport/narrativeweb.py:2069
 msgid "Drop"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1975
+#: ../gramps/plugins/webreport/narrativeweb.py:2070
 msgid "Markers"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1976
+#: ../gramps/plugins/webreport/narrativeweb.py:2071
 msgid "Google/ FamilyMap Option"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1981
+#: ../gramps/plugins/webreport/narrativeweb.py:2076
 msgid ""
 "Select which option that you would like to have for the Google Maps Family "
 "Map pages..."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1985
+#: ../gramps/plugins/webreport/narrativeweb.py:2080
 msgid "Google maps API key"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1986
+#: ../gramps/plugins/webreport/narrativeweb.py:2081
 msgid "The API key used for the Google maps"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1995
+#: ../gramps/plugins/webreport/narrativeweb.py:2090
 msgid "Other inclusion (CMS, Web Calendar, Php)"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1999
+#: ../gramps/plugins/webreport/narrativeweb.py:2094
 msgid "Do we include these pages in a cms web ?"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2003
-#: ../gramps/plugins/webreport/narrativeweb.py:2020
+#: ../gramps/plugins/webreport/narrativeweb.py:2098
+#: ../gramps/plugins/webreport/narrativeweb.py:2115
 msgid "URI"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2009
+#: ../gramps/plugins/webreport/narrativeweb.py:2104
 msgid "Where do you place your web site ? default = /NAVWEB"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2016
+#: ../gramps/plugins/webreport/narrativeweb.py:2111
 msgid "Do we include the web calendar ?"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2026
+#: ../gramps/plugins/webreport/narrativeweb.py:2121
 msgid "Where do you place your web site ? default = /WEBCAL"
 msgstr ""
 
-#: ../gramps/plugins/webreport/person.py:135
+#: ../gramps/plugins/webreport/person.py:140
 msgid "Creating individual pages"
 msgstr ""
 
 #. Individual List page message
-#: ../gramps/plugins/webreport/person.py:182
+#: ../gramps/plugins/webreport/person.py:188
 msgid ""
 "This page contains an index of all the individuals in the database, sorted "
 "by their last names. Selecting the person&#8217;s name will take you to that "
@@ -33987,29 +35147,29 @@ msgid ""
 msgstr ""
 
 #. Name Column
-#: ../gramps/plugins/webreport/person.py:209
-#: ../gramps/plugins/webreport/surname.py:126
+#: ../gramps/plugins/webreport/person.py:215
+#: ../gramps/plugins/webreport/surname.py:137
 msgid "Given Name"
 msgstr ""
 
-#: ../gramps/plugins/webreport/person.py:243
-#: ../gramps/plugins/webreport/surname.py:93
-#: ../gramps/plugins/webreport/surnamelist.py:190
+#: ../gramps/plugins/webreport/person.py:251
+#: ../gramps/plugins/webreport/surname.py:94
+#: ../gramps/plugins/webreport/surnamelist.py:192
 msgid "<absent>"
 msgstr ""
 
-#: ../gramps/plugins/webreport/person.py:264
+#: ../gramps/plugins/webreport/person.py:281
 #, python-format
 msgid "Surnames %(surname)s beginning with letter %(letter)s"
 msgstr ""
 
-#: ../gramps/plugins/webreport/person.py:772
+#: ../gramps/plugins/webreport/person.py:792
 #, python-format
 msgid "Tracking %s"
 msgstr ""
 
 #. page description
-#: ../gramps/plugins/webreport/person.py:777
+#: ../gramps/plugins/webreport/person.py:797
 msgid ""
 "This map page represents that person and any descendants with all of their "
 "event/ places. If you place your mouse over the marker it will display the "
@@ -34018,73 +35178,74 @@ msgid ""
 "you to that place&#8217;s page."
 msgstr ""
 
-#: ../gramps/plugins/webreport/person.py:848
+#: ../gramps/plugins/webreport/person.py:868
 msgid "Drop Markers"
 msgstr ""
 
-#: ../gramps/plugins/webreport/person.py:873
+#: ../gramps/plugins/webreport/person.py:893
 msgid "Place Title"
 msgstr ""
 
-#: ../gramps/plugins/webreport/person.py:1366
+#: ../gramps/plugins/webreport/person.py:1440
 msgid "Call Name"
 msgstr ""
 
-#: ../gramps/plugins/webreport/person.py:1384
+#: ../gramps/plugins/webreport/person.py:1458
 msgid "Nick Name"
 msgstr ""
 
-#: ../gramps/plugins/webreport/person.py:1430
+#: ../gramps/plugins/webreport/person.py:1504
 msgid "Age at Death"
 msgstr ""
 
-#: ../gramps/plugins/webreport/person.py:1561
+#: ../gramps/plugins/webreport/person.py:1634
 msgid "Stepfather"
 msgstr ""
 
-#: ../gramps/plugins/webreport/person.py:1574
+#: ../gramps/plugins/webreport/person.py:1647
 msgid "Stepmother"
 msgstr ""
 
-#: ../gramps/plugins/webreport/person.py:1602
+#: ../gramps/plugins/webreport/person.py:1675
 msgid "Not siblings"
 msgstr ""
 
-#: ../gramps/plugins/webreport/person.py:1737
+#: ../gramps/plugins/webreport/person.py:1817
 msgid "Relation to the center person"
 msgstr ""
 
-#: ../gramps/plugins/webreport/person.py:1774
+#: ../gramps/plugins/webreport/person.py:1854
 msgid "Relation to main person"
 msgstr ""
 
-#: ../gramps/plugins/webreport/person.py:1778
+#: ../gramps/plugins/webreport/person.py:1858
 msgid "Relation within this family (if not by birth)"
 msgstr ""
 
-#: ../gramps/plugins/webreport/place.py:113
+#: ../gramps/plugins/webreport/place.py:116
 msgid "Creating place pages"
 msgstr ""
 
 #. place list page message
-#: ../gramps/plugins/webreport/place.py:147
+#: ../gramps/plugins/webreport/place.py:151
 msgid ""
 "This page contains an index of all the places in the database, sorted by "
 "their title. Clicking on a place&#8217;s title will take you to that "
 "place&#8217;s page."
 msgstr ""
 
-#: ../gramps/plugins/webreport/place.py:176
+#: ../gramps/plugins/webreport/place.py:181
+#: ../gramps/plugins/webreport/place.py:193
 msgid "Place Name | Name"
 msgstr ""
 
-#: ../gramps/plugins/webreport/place.py:224
+#: ../gramps/plugins/webreport/place.py:239
 #, python-format
 msgid "Places beginning with letter %s"
 msgstr ""
 
 #. section title
-#: ../gramps/plugins/webreport/place.py:392
+#: ../gramps/plugins/webreport/place.py:408
 msgid "Place Map"
 msgstr ""
 
@@ -34093,14 +35254,14 @@ msgstr ""
 msgid "Creating repository pages"
 msgstr ""
 
-#: ../gramps/plugins/webreport/repository.py:146
+#: ../gramps/plugins/webreport/repository.py:147
 msgid ""
 "This page contains an index of all the repositories in the database, sorted "
 "by their title. Clicking on a repositories&#8217;s title will take you to "
 "that repositories&#8217;s page."
 msgstr ""
 
-#: ../gramps/plugins/webreport/repository.py:164
+#: ../gramps/plugins/webreport/repository.py:165
 msgid "Repository |Name"
 msgstr ""
 
@@ -34108,31 +35269,31 @@ msgstr ""
 msgid "Creating source pages"
 msgstr ""
 
-#: ../gramps/plugins/webreport/source.py:146
+#: ../gramps/plugins/webreport/source.py:147
 msgid ""
 "This page contains an index of all the sources in the database, sorted by "
 "their title. Clicking on a source&#8217;s title will take you to that "
 "source&#8217;s page."
 msgstr ""
 
-#: ../gramps/plugins/webreport/source.py:165
+#: ../gramps/plugins/webreport/source.py:166
 msgid "Source Name|Name"
 msgstr ""
 
-#: ../gramps/plugins/webreport/source.py:263
+#: ../gramps/plugins/webreport/source.py:265
 msgid "Publication information"
 msgstr ""
 
-#: ../gramps/plugins/webreport/statistics.py:113
+#: ../gramps/plugins/webreport/statistics.py:114
 msgid "Database overview"
 msgstr ""
 
-#: ../gramps/plugins/webreport/statistics.py:178
+#: ../gramps/plugins/webreport/statistics.py:179
 msgid "Narrative web content report for"
 msgstr ""
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/webreport/surname.py:109
+#: ../gramps/plugins/webreport/surname.py:120
 #, python-format
 msgid ""
 "This page contains an index of all the individuals in the database with the "
@@ -34145,23 +35306,23 @@ msgid "Surnames by person count"
 msgstr ""
 
 #. page message
-#: ../gramps/plugins/webreport/surnamelist.py:108
+#: ../gramps/plugins/webreport/surnamelist.py:109
 msgid ""
 "This page contains an index of all the surnames in the database. Selecting a "
 "link will lead to a list of individuals in the database with this same "
 "surname."
 msgstr ""
 
-#: ../gramps/plugins/webreport/surnamelist.py:154
+#: ../gramps/plugins/webreport/surnamelist.py:155
 msgid "Number of People"
 msgstr ""
 
-#: ../gramps/plugins/webreport/surnamelist.py:203
+#: ../gramps/plugins/webreport/surnamelist.py:205
 #, python-format
 msgid "Surnames beginning with letter %s"
 msgstr ""
 
-#: ../gramps/plugins/webreport/thumbnail.py:116
+#: ../gramps/plugins/webreport/thumbnail.py:118
 msgid ""
 "This page displays a indexed list of all the media objects in this "
 "database.  It is sorted by media title.  There is an index of all the media "
@@ -34169,22 +35330,18 @@ msgid ""
 "image&#8217;s page."
 msgstr ""
 
-#: ../gramps/plugins/webreport/thumbnail.py:135
-msgid "Thumbnail Preview"
-msgstr ""
-
 #. _('translation')
 #. Number of directory levels up to get to self.html_dir / root
 #. Number of directory levels up to get to root
 #. generate progress pass for "Year At A Glance"
-#: ../gramps/plugins/webreport/webcal.py:333
-#: ../gramps/plugins/webreport/webcal.py:974
-#: ../gramps/plugins/webreport/webcal.py:1060
-#: ../gramps/plugins/webreport/webcal.py:1281
+#: ../gramps/plugins/webreport/webcal.py:332
+#: ../gramps/plugins/webreport/webcal.py:975
+#: ../gramps/plugins/webreport/webcal.py:1061
+#: ../gramps/plugins/webreport/webcal.py:1284
 msgid "Web Calendar Report"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:334
+#: ../gramps/plugins/webreport/webcal.py:333
 #, python-format
 msgid "Calculating Holidays for year %04d"
 msgstr ""
@@ -34196,7 +35353,7 @@ msgid ""
 "%(html_email_author_start)sWebCal%(html_email_author_end)s"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:499
+#: ../gramps/plugins/webreport/webcal.py:497
 #, python-format
 msgid "Created for %(author)s"
 msgstr ""
@@ -34206,29 +35363,29 @@ msgstr ""
 msgid "Year Glance"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:621
+#: ../gramps/plugins/webreport/webcal.py:623
 msgid "NarrativeWeb Home"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:623
+#: ../gramps/plugins/webreport/webcal.py:625
 msgid "Full year at a Glance"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:975
+#: ../gramps/plugins/webreport/webcal.py:976
 msgid "Formatting months ..."
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1061
+#: ../gramps/plugins/webreport/webcal.py:1062
 msgid "Creating Year At A Glance calendar"
 msgstr ""
 
 #. page title
-#: ../gramps/plugins/webreport/webcal.py:1066
+#: ../gramps/plugins/webreport/webcal.py:1068
 #, python-format
 msgid "%(year)d, At A Glance"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1081
+#: ../gramps/plugins/webreport/webcal.py:1083
 msgid ""
 "This calendar is meant to give you access to all your data at a glance "
 "compressed into one page. Clicking on a date will take you to a page that "
@@ -34236,227 +35393,257 @@ msgid ""
 msgstr ""
 
 #. page title
-#: ../gramps/plugins/webreport/webcal.py:1134
+#: ../gramps/plugins/webreport/webcal.py:1137
 msgid "One Day Within A Year"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1438
+#: ../gramps/plugins/webreport/webcal.py:1473
 #, python-format
 msgid "%(spouse)s and %(person)s"
 msgstr ""
 
-#. Display date as user set in preferences
-#: ../gramps/plugins/webreport/webcal.py:1458
+#: ../gramps/plugins/webreport/webcal.py:1496
 #, python-format
 msgid "Generated by %(gramps_home_html_start)sGramps%(html_end)s on %(date)s"
 msgstr ""
 
 #. page title
-#: ../gramps/plugins/webreport/webcal.py:1564
-#: ../gramps/plugins/webreport/webcal.py:1629
+#: ../gramps/plugins/webreport/webcal.py:1601
+#: ../gramps/plugins/webreport/webcal.py:1667
 msgid "My Family Calendar"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1629
+#: ../gramps/plugins/webreport/webcal.py:1667
 msgid "Calendar Title"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1630
+#: ../gramps/plugins/webreport/webcal.py:1668
 msgid "The title of the calendar"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1702
+#: ../gramps/plugins/webreport/webcal.py:1699
+msgid "StyleSheet"
+msgstr ""
+
+#: ../gramps/plugins/webreport/webcal.py:1740
 msgid "Content Options"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1707
+#: ../gramps/plugins/webreport/webcal.py:1745
 msgid "Create multiple year calendars"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1709
+#: ../gramps/plugins/webreport/webcal.py:1747
 msgid "Whether to create Multiple year calendars or not."
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1714
+#: ../gramps/plugins/webreport/webcal.py:1752
 msgid "Start Year for the Calendar(s)"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1716
+#: ../gramps/plugins/webreport/webcal.py:1754
 msgid "Enter the starting year for the calendars between 1900 - 3000"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1720
+#: ../gramps/plugins/webreport/webcal.py:1758
 msgid "End Year for the Calendar(s)"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1722
+#: ../gramps/plugins/webreport/webcal.py:1760
 msgid "Enter the ending year for the calendars between 1900 - 3000."
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1739
+#: ../gramps/plugins/webreport/webcal.py:1779
 msgid "Holidays will be included for the selected country"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1762
+#: ../gramps/plugins/webreport/webcal.py:1802
 msgid "Home link"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1763
+#: ../gramps/plugins/webreport/webcal.py:1803
 msgid ""
 "The link to be included to direct the user to the main page of the web site"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1768
-msgid "Include birthdays in the calendar"
-msgstr ""
-
-#: ../gramps/plugins/webreport/webcal.py:1772
-msgid "Include anniversaries in the calendar"
-msgstr ""
-
-#: ../gramps/plugins/webreport/webcal.py:1779
+#: ../gramps/plugins/webreport/webcal.py:1811
 msgid "Jan - Jun Notes"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1781
+#: ../gramps/plugins/webreport/webcal.py:1813
 msgid "January Note"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1782
+#: ../gramps/plugins/webreport/webcal.py:1814
 msgid "The note for the month of January"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1785
+#: ../gramps/plugins/webreport/webcal.py:1817
 msgid "February Note"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1786
+#: ../gramps/plugins/webreport/webcal.py:1818
 msgid "The note for the month of February"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1789
+#: ../gramps/plugins/webreport/webcal.py:1821
 msgid "March Note"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1790
+#: ../gramps/plugins/webreport/webcal.py:1822
 msgid "The note for the month of March"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1793
+#: ../gramps/plugins/webreport/webcal.py:1825
 msgid "April Note"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1794
+#: ../gramps/plugins/webreport/webcal.py:1826
 msgid "The note for the month of April"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1797
+#: ../gramps/plugins/webreport/webcal.py:1829
 msgid "May Note"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1798
+#: ../gramps/plugins/webreport/webcal.py:1830
 msgid "The note for the month of May"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1801
+#: ../gramps/plugins/webreport/webcal.py:1833
 msgid "June Note"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1802
+#: ../gramps/plugins/webreport/webcal.py:1834
 msgid "The note for the month of June"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1805
+#: ../gramps/plugins/webreport/webcal.py:1837
 msgid "Jul - Dec Notes"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1807
+#: ../gramps/plugins/webreport/webcal.py:1839
 msgid "July Note"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1808
+#: ../gramps/plugins/webreport/webcal.py:1840
 msgid "The note for the month of July"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1811
+#: ../gramps/plugins/webreport/webcal.py:1843
 msgid "August Note"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1812
+#: ../gramps/plugins/webreport/webcal.py:1844
 msgid "The note for the month of August"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1815
+#: ../gramps/plugins/webreport/webcal.py:1847
 msgid "September Note"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1816
+#: ../gramps/plugins/webreport/webcal.py:1848
 msgid "The note for the month of September"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1819
+#: ../gramps/plugins/webreport/webcal.py:1851
 msgid "October Note"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1820
+#: ../gramps/plugins/webreport/webcal.py:1852
 msgid "The note for the month of October"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1823
+#: ../gramps/plugins/webreport/webcal.py:1855
 msgid "November Note"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1824
+#: ../gramps/plugins/webreport/webcal.py:1856
 msgid "The note for the month of November"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1827
+#: ../gramps/plugins/webreport/webcal.py:1859
 msgid "December Note"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1828
+#: ../gramps/plugins/webreport/webcal.py:1860
 msgid "The note for the month of December"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1845
+#: ../gramps/plugins/webreport/webcal.py:1877
 msgid "Create one day event pages for Year At A Glance calendar"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1847
+#: ../gramps/plugins/webreport/webcal.py:1879
 msgid "Whether to create one day pages or not"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1850
+#: ../gramps/plugins/webreport/webcal.py:1883
+msgid "Include birthdays in the calendar"
+msgstr ""
+
+#: ../gramps/plugins/webreport/webcal.py:1887
+msgid "Include anniversaries in the calendar"
+msgstr ""
+
+#: ../gramps/plugins/webreport/webcal.py:1890
+msgid "Include death dates"
+msgstr ""
+
+#: ../gramps/plugins/webreport/webcal.py:1891
+msgid "Include death anniversaries in the calendar"
+msgstr ""
+
+#: ../gramps/plugins/webreport/webcal.py:1894
 msgid "Link to Narrated Web Report"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1851
+#: ../gramps/plugins/webreport/webcal.py:1895
 msgid "Whether to link data to web report or not"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1857
+#: ../gramps/plugins/webreport/webcal.py:1901
+msgid "Show data only after year"
+msgstr ""
+
+#: ../gramps/plugins/webreport/webcal.py:1904
+msgid ""
+"Show data only after this year. Default is current year -  'maximum age "
+"probably alive' which is defined in the dates preference tab."
+msgstr ""
+
+#: ../gramps/plugins/webreport/webcal.py:1912
 msgid "Link prefix"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1858
+#: ../gramps/plugins/webreport/webcal.py:1913
 msgid "A Prefix on the links to take you to Narrated Web Report"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:2036
+#: ../gramps/plugins/webreport/webcal.py:2092
 #, python-format
 msgid "%s old"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:2047
+#: ../gramps/plugins/webreport/webcal.py:2102
+#, python-format
+msgid "%s since death"
+msgstr ""
+
+#: ../gramps/plugins/webreport/webcal.py:2103
+msgid "death"
+msgstr ""
+
+#: ../gramps/plugins/webreport/webcal.py:2110
 #, python-format
 msgid "%(couple)s, <em>wedding</em>"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:2055
+#: ../gramps/plugins/webreport/webcal.py:2118
 msgid "Until"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:2064
+#: ../gramps/plugins/webreport/webcal.py:2127
 #, python-brace-format
 msgid "{couple}, {years} year anniversary"
 msgid_plural "{couple}, {years} year anniversary"


### PR DESCRIPTION
The [GEPS044](https://github.com/gramps-project/gramps/pull/637) updated uimanager work included a bunch of XML fragments as strings embedded in the Python files.  Unfortunately I did not realize that these would not be found by the standard xgettext utility.

I've updated our update_po script to scan for these fragments, searching for translatable strings, and adding them to the gramps.pot.

In the process I discovered a number of cases where I was attempting to translate (via the XML fragments) already translated strings.  The second commit corrects that (and updates gramps.pot).

Thanks to our Finnish translator "niememat" who spotted this issue.