### PR TITLE
OSM forward all http resquest to https.

### DIFF
--- a/gramps/plugins/webreport/person.py
+++ b/gramps/plugins/webreport/person.py
@@ -712,12 +712,10 @@ class PersonPages(BasePage):
             src_js += "ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"
             head += Html("script", type="text/javascript",
                          src=src_js, inline=True)
-            src_js = self.secure_mode
-            src_js += "openlayers.org/en/latest/build/ol.js"
+            src_js = "https://openlayers.org/en/latest/build/ol.js"
             head += Html("script", type="text/javascript",
                          src=src_js, inline=True)
-            url = self.secure_mode
-            url += "openlayers.org/en/latest/css/ol.css"
+            url = "https://openlayers.org/en/latest/css/ol.css"
             head += Html("link", href=url, type="text/javascript",
                          rel="stylesheet")
             src_js = self.secure_mode

--- a/gramps/plugins/webreport/place.py
+++ b/gramps/plugins/webreport/place.py
@@ -390,12 +390,10 @@ class PlacePages(BasePage):
                                    "jquery.min.js")
                         head += Html("script", type="text/javascript",
                                      src=src_js, inline=True)
-                        src_js = self.secure_mode
-                        src_js += "openlayers.org/en/latest/build/ol.js"
+                        src_js = "https://openlayers.org/en/latest/build/ol.js"
                         head += Html("script", type="text/javascript",
                                      src=src_js, inline=True)
-                        url = self.secure_mode
-                        url += "openlayers.org/en/latest/css/ol.css"
+                        url = "https://openlayers.org/en/latest/css/ol.css"
                         head += Html("link", href=url, type="text/javascript",
                                      rel="stylesheet")
                         src_js = self.secure_mode


### PR DESCRIPTION
After asking the OSM support, I was told OSM forward all http request to
https when we use .org url.
So it should work in all cases.

This has an energy cost, so it would be good for the planet to change http to https.

Fixes [#11057](https://gramps-project.org/bugs/view.php?id=11057)