### PR TITLE
Fix duplicated accelerators

### DIFF
--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -353,7 +353,7 @@ class ViewManager(CLIManager):
         Initialize the actions lists for the UIManager
         """
         self._app_actionlist = [
-            ('quit', self.quit, "<PRIMARY>q"),
+            ('quit', self.quit, None if is_quartz() else "<PRIMARY>q"),
             ('preferences', self.preferences_activate),
             ('about', self.display_about_box), ]
 

--- a/gramps/plugins/lib/maps/geography.py
+++ b/gramps/plugins/lib/maps/geography.py
@@ -308,7 +308,7 @@ class GeoGraphyView(OsmGps, NavigationView):
         another method.
         """
         NavigationView.define_actions(self)
-        self._add_action('PrintView', self.printview, '<Primary>P')
+        self._add_action('PrintView', self.printview, '<PRIMARY><SHIFT>P')
 
     def config_connect(self):
         """

--- a/gramps/plugins/view/fanchart2wayview.py
+++ b/gramps/plugins/view/fanchart2wayview.py
@@ -157,7 +157,7 @@ class FanChart2WayView(fanchart2way.FanChart2WayGrampsGUI, NavigationView):
         """
         NavigationView.define_actions(self)
 
-        self._add_action('PrintView', self.printview, "<PRIMARY>P")
+        self._add_action('PrintView', self.printview, "<PRIMARY><SHIFT>P")
         self._add_action('PRIMARY-J', self.jump, '<PRIMARY>J')
 
     def build_tree(self):

--- a/gramps/plugins/view/fanchartdescview.py
+++ b/gramps/plugins/view/fanchartdescview.py
@@ -152,7 +152,7 @@ class FanChartDescView(fanchartdesc.FanChartDescGrampsGUI, NavigationView):
         """
         NavigationView.define_actions(self)
 
-        self._add_action('PrintView', self.printview, "<PRIMARY>P")
+        self._add_action('PrintView', self.printview, "<PRIMARY><SHIFT>P")
         self._add_action('PRIMARY-J', self.jump, '<PRIMARY>J')
 
     def build_tree(self):

--- a/gramps/plugins/view/fanchartview.py
+++ b/gramps/plugins/view/fanchartview.py
@@ -165,7 +165,7 @@ class FanChartView(fanchart.FanChartGrampsGUI, NavigationView):
       <section id='CommonEdit' groups='RW'>
         <item>
           <attribute name="action">win.PrintView</attribute>
-          <attribute name="label" translatable="yes">_Print...</attribute>
+          <attribute name="label" translatable="yes">Print...</attribute>
         </item>
       </section>
 ''',
@@ -232,7 +232,7 @@ class FanChartView(fanchart.FanChartGrampsGUI, NavigationView):
         <property name="action-name">win.PrintView</property>
         <property name="tooltip_text" translatable="yes">'''
         '''Print or save the Fan Chart View</property>
-        <property name="label" translatable="yes">_Print...</property>
+        <property name="label" translatable="yes">Print...</property>
         <property name="use-underline">True</property>
       </object>
       <packing>
@@ -249,7 +249,7 @@ class FanChartView(fanchart.FanChartGrampsGUI, NavigationView):
         """
         NavigationView.define_actions(self)
 
-        self._add_action('PrintView', self.printview, "<PRIMARY>P")
+        self._add_action('PrintView', self.printview, "<PRIMARY><SHIFT>P")
         self._add_action('PRIMARY-J', self.jump, '<PRIMARY>J')
 
     def build_tree(self):

--- a/gramps/plugins/view/geoclose.py
+++ b/gramps/plugins/view/geoclose.py
@@ -92,7 +92,7 @@ _UI_DEF = [
       <section id='CommonEdit' groups='RW'>
         <item>
           <attribute name="action">win.PrintView</attribute>
-          <attribute name="label" translatable="yes">_Print...</attribute>
+          <attribute name="label" translatable="yes">Print...</attribute>
         </item>
       </section>
     ''',
@@ -172,7 +172,7 @@ _UI_DEF = [
         <property name="action-name">win.PrintView</property>
         <property name="tooltip_text" translatable="yes">'''
     '''Print or save the Map</property>
-        <property name="label" translatable="yes">_Print...</property>
+        <property name="label" translatable="yes">Print...</property>
         <property name="use-underline">True</property>
       </object>
       <packing>

--- a/gramps/plugins/view/geoevents.py
+++ b/gramps/plugins/view/geoevents.py
@@ -82,7 +82,7 @@ _UI_DEF = ['''
       <section id='CommonEdit' groups='RW'>
         <item>
           <attribute name="action">win.PrintView</attribute>
-          <attribute name="label" translatable="yes">_Print...</attribute>
+          <attribute name="label" translatable="yes">Print...</attribute>
         </item>
       </section>
     ''',
@@ -133,7 +133,7 @@ _UI_DEF = ['''
         <property name="icon-name">document-print</property>
         <property name="action-name">win.PrintView</property>
         <property name="tooltip_text" translatable="yes">Print or save the Map</property>
-        <property name="label" translatable="yes">_Print...</property>
+        <property name="label" translatable="yes">Print...</property>
         <property name="use-underline">True</property>
        </object>
       <packing>

--- a/gramps/plugins/view/geofamclose.py
+++ b/gramps/plugins/view/geofamclose.py
@@ -90,7 +90,7 @@ _UI_DEF = [
       <section id='CommonEdit' groups='RW'>
         <item>
           <attribute name="action">win.PrintView</attribute>
-          <attribute name="label" translatable="yes">_Print...</attribute>
+          <attribute name="label" translatable="yes">Print...</attribute>
         </item>
       </section>
 ''',
@@ -170,7 +170,7 @@ _UI_DEF = [
         <property name="action-name">win.PrintView</property>
         <property name="tooltip_text" translatable="yes">'''
     '''Print or save the Map</property>
-        <property name="label" translatable="yes">_Print...</property>
+        <property name="label" translatable="yes">Print...</property>
         <property name="use-underline">True</property>
       </object>
       <packing>

--- a/gramps/plugins/view/geofamily.py
+++ b/gramps/plugins/view/geofamily.py
@@ -82,7 +82,7 @@ _UI_DEF = [
       <section id='CommonEdit' groups='RW'>
         <item>
           <attribute name="action">win.PrintView</attribute>
-          <attribute name="label" translatable="yes">_Print...</attribute>
+          <attribute name="label" translatable="yes">Print...</attribute>
         </item>
       </section>
 ''',
@@ -136,7 +136,7 @@ _UI_DEF = [
         <property name="action-name">win.PrintView</property>
         <property name="tooltip_text" translatable="yes">'''
     '''Print or save the Map</property>
-        <property name="label" translatable="yes">_Print...</property>
+        <property name="label" translatable="yes">Print...</property>
         <property name="use-underline">True</property>
       </object>
       <packing>

--- a/gramps/plugins/view/geomoves.py
+++ b/gramps/plugins/view/geomoves.py
@@ -89,7 +89,7 @@ _UI_DEF = [
       <section id='CommonEdit' groups='RW'>
         <item>
           <attribute name="action">win.PrintView</attribute>
-          <attribute name="label" translatable="yes">_Print...</attribute>
+          <attribute name="label" translatable="yes">Print...</attribute>
         </item>
       </section>
 ''',
@@ -156,7 +156,7 @@ _UI_DEF = [
         <property name="action-name">win.PrintView</property>
         <property name="tooltip_text" translatable="yes">'''
     '''Print or save the Map</property>
-        <property name="label" translatable="yes">_Print...</property>
+        <property name="label" translatable="yes">Print...</property>
         <property name="use-underline">True</property>
       </object>
       <packing>

--- a/gramps/plugins/view/geoperson.py
+++ b/gramps/plugins/view/geoperson.py
@@ -90,7 +90,7 @@ _UI_DEF = [
       <section id='CommonEdit' groups='RW'>
         <item>
           <attribute name="action">win.PrintView</attribute>
-          <attribute name="label" translatable="yes">_Print...</attribute>
+          <attribute name="label" translatable="yes">Print...</attribute>
         </item>
       </section>
 ''',

--- a/gramps/plugins/view/geoplaces.py
+++ b/gramps/plugins/view/geoplaces.py
@@ -85,7 +85,7 @@ _UI_DEF = [
       <section id='CommonEdit' groups='RW'>
         <item>
           <attribute name="action">win.PrintView</attribute>
-          <attribute name="label" translatable="yes">_Print...</attribute>
+          <attribute name="label" translatable="yes">Print...</attribute>
         </item>
       </section>
 ''',
@@ -139,7 +139,7 @@ _UI_DEF = [
         <property name="action-name">win.PrintView</property>
         <property name="tooltip_text" translatable="yes">'''
     '''Print or save the Map</property>
-        <property name="label" translatable="yes">_Print...</property>
+        <property name="label" translatable="yes">Print...</property>
         <property name="use-underline">True</property>
       </object>
       <packing>


### PR DESCRIPTION
This changes the accelerator keys for the Print graph command used in some of the chart views from the original `<PRIMARY>P` to `<PRIMARY><SHIFT>P`.  This avoids a conflict with the `<PRIMARY>P` used for the Previous View.

I noticed that the `<alt>P` mnemonic in the Edit menu was also duplicated between Print and Preferences and have removed that mnemonic for printing.  This doesn't create any new translations as we already have a "Print..." in our gramps.pot.

This also removes the extraneous accelerator `<PRIMARY>q` (for Quit) on OSX only, as that OS already had the same key combination assigned to 'Quit' by the OS.

Fixes [#11186](https://gramps-project.org/bugs/view.php?id=11186)