### PR TITLE
Fix crash when addon/plugin contains an id with space

### DIFF
--- a/gramps/gui/managedwindow.py
+++ b/gramps/gui/managedwindow.py
@@ -280,7 +280,7 @@ class GrampsWindowManager:
         return func
 
     def generate_id(self, item):
-        return 'wm/' + str(item.window_id)
+        return 'wm/' + str(item.window_id).replace(' ', '_')
 
     def display_menu_list(self, data, action_data, mlist):
         menuitem = ('<item>\n'


### PR DESCRIPTION
Fixes [#11202](https://gramps-project.org/bugs/view.php?id=11202)

The updated uimanager and managedwindow uses the plugin id to create actions for plugins that make a window to support the menus. If the plugin id contains a space, Gramps crashes.