### PR TITLE
Narrative web: some strings not translated

### DIFF
--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -2265,7 +2265,7 @@ class BasePage: # pylint: disable=C1001
                     if conf == conf_strings[Citation.CONF_NORMAL]:
                         conf = None
                     else:
-                        conf = _(conf)
+                        conf = self._(conf)
                     for (label, data) in [[self._("Date"),
                                            self.rlocale.get_date(sref.date)],
                                           [self._("Page"), sref.page],

--- a/gramps/plugins/webreport/person.py
+++ b/gramps/plugins/webreport/person.py
@@ -904,11 +904,11 @@ class PersonPages(BasePage):
                         trow.extend(
                             Html("td", data, class_=colclass, inline=True)
                             for data, colclass in [
-                                (date, "ColumnDate"),
+                                (self.rlocale.get_date(date), "ColumnDate"),
                                 (self.place_link(handle, placetitle,
                                                  uplink=True),
                                  "ColumnPlace"),
-                                (str(etype), "ColumnType")
+                                (self._(str(etype)), "ColumnType")
                             ]
                         )
 


### PR DESCRIPTION
The confidence and the date are not translated in the family map page.
The date doesn't use the specified date format.

Fixes [#11207](https://gramps-project.org/bugs/view.php?id=11207)