### PR TITLE
Narrative web: markers incorrectly placed.

### DIFF
--- a/data/css/Web_Basic-Cypress.css
+++ b/data/css/Web_Basic-Cypress.css
@@ -791,7 +791,7 @@ a.familymap {
 /* Overwritten
 ----------------------------------------------------- */
 body#FamilyMap {
-    background-color: #E0E6E0 ! important;
+    background-color: #454 ! important;
 }
 
 /* Calendar Styles

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -177,6 +177,9 @@ OSM_MARKERS = """
     var tracelife = %s;
     var iconStyle = new ol.style.Style({
       image: new ol.style.Icon(({
+        anchor: [0.2, 48],
+        anchorXUnits: 'fraction',
+        anchorYUnits: 'pixels',
         opacity: 1.0,
         src: marker_png
       }))


### PR DESCRIPTION
 - Narrative web: In the map pages, the markers are not placed where it should be.
    reproducible when zoom in/zoom out.

 - Narrative web: background not correctly set in the map page.
    If you use the Web_Basic-Cypress.css, the foreground and background
    use the same color, so you see nothing. you must hover the fields to see the text

Fixes [#11208](https://gramps-project.org/bugs/view.php?id=11208)