### PR TITLE
Fix Preferences dialog so General tab appears first, not Symbols

### DIFF
--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -2194,7 +2194,8 @@ class GrampsPreferences(ConfigureDialog):
                         my_characters +
                         "</big></big></big></big>")
         self.grid.attach(text, 1, 8, 8, 1)
-        self.grid.show_all()
+        scrollw.show_all()
+        text.show_all()
 
     def stop_looking_for_font(self, *args, **kwargs):
         self.progress.close()


### PR DESCRIPTION
Fixes [#11210](https://gramps-project.org/bugs/view.php?id=11210)