### PR TITLE
Fix dbapi reindex_reference_maps tool to properly close transaction

### DIFF
--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -787,6 +787,7 @@ class DBAPI(DbGeneric):
         Reindex all primary records in the database.
         """
         callback(4)
+        self._txn_begin()
         self.dbapi.execute("DELETE FROM reference")
         primary_table = (
             (self.get_person_cursor, Person),
@@ -818,6 +819,7 @@ class DBAPI(DbGeneric):
                              obj.__class__.__name__,
                              ref_handle,
                              ref_class_name])
+        self._txn_commit()
         callback(5)
 
     def rebuild_secondary(self, callback=None):


### PR DESCRIPTION
Fixes [#11195](https://gramps-project.org/bugs/view.php?id=11195)

Bug appears with dbapi after running this tool when next trying to edit anything.  Also appears after Check & repair if map rebuild was necessary.  This adds an explicit transaction (so as to avoid the implicit transaction which is broken in at least some versions of dbapi).

The one call to this method internal to dbapi is made during (after) a batch transaction, in this case a transaction was already present, but the _txn_begin and _txn_commit already check for that to avoid the double transactions.
Tested with reindex_reference_maps tool, check & repair, and with an import (which runs batch transaction).