### PR TITLE
Fix AncestorTree so add siblings to center person works

### DIFF
--- a/gramps/plugins/drawreport/ancestortree.py
+++ b/gramps/plugins/drawreport/ancestortree.py
@@ -352,7 +352,7 @@ class MakeAncestorTree(AscendPerson):
             mee = self.add_person((1, 1, move+rrr), kid, self.center_family)
             line.add_from(mee)
             #mee.level = (0, 1, level - (len(mykids)//2)+rrr)
-
+        mee.line_to = line
 
     def start(self, person_id):
         """ go ahead and make it happen """

--- a/gramps/plugins/lib/librecurse.py
+++ b/gramps/plugins/lib/librecurse.py
@@ -518,7 +518,9 @@ class AscendPerson(_StopRecurse, _PersonSeen):
         """
         A simple header to make sure we pass in the correct information
         """
-        return self.__iterate(1, 1, person_handle, None)
+        person = self.database.get_person_from_handle(person_handle)
+        return self.__iterate(1, 1, person_handle,
+                              person.get_main_parents_family_handle())
 
 
 #------------


### PR DESCRIPTION
Fixes [#11215](https://gramps-project.org/bugs/view.php?id=11215)

Looks like a previous bug fix broke the "add siblings feature".  This PR fixes that.