### PR TITLE
Fix Navigator sidebar so can change view type with proper resize

### DIFF
--- a/gramps/gui/navigator.py
+++ b/gramps/gui/navigator.py
@@ -199,7 +199,10 @@ class Navigator:
         Add a page to the sidebar for a plugin.
         """
         self.pages.append((title, sidebar))
-        index = self.notebook.append_page(sidebar.get_top(), Gtk.Label(label=title))
+        page = sidebar.get_top()
+        # hide for now so notebook is only size of active page
+        page.get_child().hide()
+        index = self.notebook.append_page(page, Gtk.Label(label=title))
 
         menu_item = Gtk.MenuItem(label=title)
         if order == START:
@@ -276,9 +279,15 @@ class Navigator:
         old_page = notebook.get_current_page()
         if old_page != -1:
             self.pages[old_page][1].inactive()
+            # hide so notebook is only size of active page
+            notebook.get_nth_page(old_page).get_child().hide()
+
         self.pages[index][1].active(self.active_cat, self.active_view)
+        notebook.get_nth_page(index).get_child().show()
+        notebook.queue_resize()
         if self.active_view is not None:
-            self.pages[index][1].view_changed(self.active_cat, self.active_view)
+            self.pages[index][1].view_changed(self.active_cat,
+                                              self.active_view)
         self.title_label.set_text(self.pages[index][0])
 
     def cb_close_clicked(self, button):

--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -407,7 +407,7 @@ class ViewManager(CLIManager):
 
         self.navigator = Navigator(self)
         self.ebox.add(self.navigator.get_top())
-        hpane.add1(self.ebox)
+        hpane.pack1(self.ebox, False, False)
         hpane.show()
 
         self.notebook = Gtk.Notebook()


### PR DESCRIPTION
Fixes [#6422](https://gramps-project.org/bugs/view.php?id=6422), [#11164](https://gramps-project.org/bugs/view.php?id=11164)

When switching the navigation sidebar types, the sidebar resizes upward to the longest label in the pane, but will not resize downward again until a restart.  Worse, if the user tries to resize downward manually, the sidebar disappears off the screen to the left.

This fixes this.

The sidebar now resizes automatically to the smallest possible.

If the user deliberately grabs the pane divider and adjusts it, it then remains fixed (allowing upsize only) until the end of the session.  I cannot see why a user would ever want to resize now, however.