### PR TITLE
Narrative web: Sort problem with places.

### DIFF
--- a/gramps/gui/managedwindow.py
+++ b/gramps/gui/managedwindow.py
@@ -280,7 +280,7 @@ class GrampsWindowManager:
         return func
 
     def generate_id(self, item):
-        return 'wm/' + str(item.window_id)
+        return 'wm/' + str(item.window_id).replace(' ', '_')
 
     def display_menu_list(self, data, action_data, mlist):
         menuitem = ('<item>\n'

--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -353,7 +353,7 @@ class ViewManager(CLIManager):
         Initialize the actions lists for the UIManager
         """
         self._app_actionlist = [
-            ('quit', self.quit, "<PRIMARY>q"),
+            ('quit', self.quit, None if is_quartz() else "<PRIMARY>q"),
             ('preferences', self.preferences_activate),
             ('about', self.display_about_box), ]
 

--- a/gramps/plugins/lib/maps/geography.py
+++ b/gramps/plugins/lib/maps/geography.py
@@ -308,7 +308,7 @@ class GeoGraphyView(OsmGps, NavigationView):
         another method.
         """
         NavigationView.define_actions(self)
-        self._add_action('PrintView', self.printview, '<Primary>P')
+        self._add_action('PrintView', self.printview, '<PRIMARY><SHIFT>P')
 
     def config_connect(self):
         """

--- a/gramps/plugins/lib/maps/markerlayer.py
+++ b/gramps/plugins/lib/maps/markerlayer.py
@@ -117,9 +117,9 @@ class MarkerLayer(GObject.GObject, osmgpsmap.MapLayer):
         """
         max_interval = self.max_value - self.nb_ref_by_places
         min_interval = self.nb_ref_by_places - self.min_value
-        if max_interval == 0: # This to avoid divide by zero
+        if max_interval <= 0: # This to avoid divide by zero
             max_interval = 0.01
-        if min_interval == 0: # This to avoid divide by zero
+        if min_interval <= 0: # This to avoid divide by zero
             min_interval = 0.01
         _LOG.debug("%s", time.strftime("start drawing   : "
                    "%a %d %b %Y %H:%M:%S", time.gmtime()))
@@ -127,13 +127,13 @@ class MarkerLayer(GObject.GObject, osmgpsmap.MapLayer):
             # the icon size in 48, so the standard icon size is 0.6 * 48 = 28.8
             size = 0.6
             mark = float(marker[2])
-            if mark > self.nb_ref_by_places:
-                # at maximum, we'll have an icon size = (0.6 + 0.3) * 48 = 43.2
-                size += (0.3 * ((mark - self.nb_ref_by_places)
+            if mark > self.nb_ref_by_places or max_interval > 3:
+                # at maximum, we'll have an icon size = (0.6 + 0.2) * 48 = 38.4
+                size += (0.2 * ((mark - self.nb_ref_by_places)
                                  / max_interval))
             else:
-                # at minimum, we'll have an icon size = (0.6 - 0.3) * 48 = 14.4
-                size -= (0.3 * ((self.nb_ref_by_places - mark)
+                # at minimum, we'll have an icon size = (0.6 - 0.2) * 48 = 19.2
+                size -= (0.2 * ((self.nb_ref_by_places - mark)
                                  / min_interval))
 
             conv_pt = osmgpsmap.MapPoint.new_degrees(float(marker[0][0]),

--- a/gramps/plugins/view/fanchart2wayview.py
+++ b/gramps/plugins/view/fanchart2wayview.py
@@ -157,7 +157,7 @@ class FanChart2WayView(fanchart2way.FanChart2WayGrampsGUI, NavigationView):
         """
         NavigationView.define_actions(self)
 
-        self._add_action('PrintView', self.printview, "<PRIMARY>P")
+        self._add_action('PrintView', self.printview, "<PRIMARY><SHIFT>P")
         self._add_action('PRIMARY-J', self.jump, '<PRIMARY>J')
 
     def build_tree(self):

--- a/gramps/plugins/view/fanchartdescview.py
+++ b/gramps/plugins/view/fanchartdescview.py
@@ -152,7 +152,7 @@ class FanChartDescView(fanchartdesc.FanChartDescGrampsGUI, NavigationView):
         """
         NavigationView.define_actions(self)
 
-        self._add_action('PrintView', self.printview, "<PRIMARY>P")
+        self._add_action('PrintView', self.printview, "<PRIMARY><SHIFT>P")
         self._add_action('PRIMARY-J', self.jump, '<PRIMARY>J')
 
     def build_tree(self):

--- a/gramps/plugins/view/fanchartview.py
+++ b/gramps/plugins/view/fanchartview.py
@@ -165,7 +165,7 @@ class FanChartView(fanchart.FanChartGrampsGUI, NavigationView):
       <section id='CommonEdit' groups='RW'>
         <item>
           <attribute name="action">win.PrintView</attribute>
-          <attribute name="label" translatable="yes">_Print...</attribute>
+          <attribute name="label" translatable="yes">Print...</attribute>
         </item>
       </section>
 ''',
@@ -232,7 +232,7 @@ class FanChartView(fanchart.FanChartGrampsGUI, NavigationView):
         <property name="action-name">win.PrintView</property>
         <property name="tooltip_text" translatable="yes">'''
         '''Print or save the Fan Chart View</property>
-        <property name="label" translatable="yes">_Print...</property>
+        <property name="label" translatable="yes">Print...</property>
         <property name="use-underline">True</property>
       </object>
       <packing>
@@ -249,7 +249,7 @@ class FanChartView(fanchart.FanChartGrampsGUI, NavigationView):
         """
         NavigationView.define_actions(self)
 
-        self._add_action('PrintView', self.printview, "<PRIMARY>P")
+        self._add_action('PrintView', self.printview, "<PRIMARY><SHIFT>P")
         self._add_action('PRIMARY-J', self.jump, '<PRIMARY>J')
 
     def build_tree(self):

--- a/gramps/plugins/view/geoclose.py
+++ b/gramps/plugins/view/geoclose.py
@@ -92,7 +92,7 @@ _UI_DEF = [
       <section id='CommonEdit' groups='RW'>
         <item>
           <attribute name="action">win.PrintView</attribute>
-          <attribute name="label" translatable="yes">_Print...</attribute>
+          <attribute name="label" translatable="yes">Print...</attribute>
         </item>
       </section>
     ''',
@@ -172,7 +172,7 @@ _UI_DEF = [
         <property name="action-name">win.PrintView</property>
         <property name="tooltip_text" translatable="yes">'''
     '''Print or save the Map</property>
-        <property name="label" translatable="yes">_Print...</property>
+        <property name="label" translatable="yes">Print...</property>
         <property name="use-underline">True</property>
       </object>
       <packing>

--- a/gramps/plugins/view/geoevents.py
+++ b/gramps/plugins/view/geoevents.py
@@ -82,7 +82,7 @@ _UI_DEF = ['''
       <section id='CommonEdit' groups='RW'>
         <item>
           <attribute name="action">win.PrintView</attribute>
-          <attribute name="label" translatable="yes">_Print...</attribute>
+          <attribute name="label" translatable="yes">Print...</attribute>
         </item>
       </section>
     ''',
@@ -133,7 +133,7 @@ _UI_DEF = ['''
         <property name="icon-name">document-print</property>
         <property name="action-name">win.PrintView</property>
         <property name="tooltip_text" translatable="yes">Print or save the Map</property>
-        <property name="label" translatable="yes">_Print...</property>
+        <property name="label" translatable="yes">Print...</property>
         <property name="use-underline">True</property>
        </object>
       <packing>

--- a/gramps/plugins/view/geofamclose.py
+++ b/gramps/plugins/view/geofamclose.py
@@ -90,7 +90,7 @@ _UI_DEF = [
       <section id='CommonEdit' groups='RW'>
         <item>
           <attribute name="action">win.PrintView</attribute>
-          <attribute name="label" translatable="yes">_Print...</attribute>
+          <attribute name="label" translatable="yes">Print...</attribute>
         </item>
       </section>
 ''',
@@ -170,7 +170,7 @@ _UI_DEF = [
         <property name="action-name">win.PrintView</property>
         <property name="tooltip_text" translatable="yes">'''
     '''Print or save the Map</property>
-        <property name="label" translatable="yes">_Print...</property>
+        <property name="label" translatable="yes">Print...</property>
         <property name="use-underline">True</property>
       </object>
       <packing>

--- a/gramps/plugins/view/geofamily.py
+++ b/gramps/plugins/view/geofamily.py
@@ -82,7 +82,7 @@ _UI_DEF = [
       <section id='CommonEdit' groups='RW'>
         <item>
           <attribute name="action">win.PrintView</attribute>
-          <attribute name="label" translatable="yes">_Print...</attribute>
+          <attribute name="label" translatable="yes">Print...</attribute>
         </item>
       </section>
 ''',
@@ -136,7 +136,7 @@ _UI_DEF = [
         <property name="action-name">win.PrintView</property>
         <property name="tooltip_text" translatable="yes">'''
     '''Print or save the Map</property>
-        <property name="label" translatable="yes">_Print...</property>
+        <property name="label" translatable="yes">Print...</property>
         <property name="use-underline">True</property>
       </object>
       <packing>

--- a/gramps/plugins/view/geomoves.py
+++ b/gramps/plugins/view/geomoves.py
@@ -89,7 +89,7 @@ _UI_DEF = [
       <section id='CommonEdit' groups='RW'>
         <item>
           <attribute name="action">win.PrintView</attribute>
-          <attribute name="label" translatable="yes">_Print...</attribute>
+          <attribute name="label" translatable="yes">Print...</attribute>
         </item>
       </section>
 ''',
@@ -156,7 +156,7 @@ _UI_DEF = [
         <property name="action-name">win.PrintView</property>
         <property name="tooltip_text" translatable="yes">'''
     '''Print or save the Map</property>
-        <property name="label" translatable="yes">_Print...</property>
+        <property name="label" translatable="yes">Print...</property>
         <property name="use-underline">True</property>
       </object>
       <packing>

--- a/gramps/plugins/view/geoperson.py
+++ b/gramps/plugins/view/geoperson.py
@@ -90,7 +90,7 @@ _UI_DEF = [
       <section id='CommonEdit' groups='RW'>
         <item>
           <attribute name="action">win.PrintView</attribute>
-          <attribute name="label" translatable="yes">_Print...</attribute>
+          <attribute name="label" translatable="yes">Print...</attribute>
         </item>
       </section>
 ''',

--- a/gramps/plugins/view/geoplaces.py
+++ b/gramps/plugins/view/geoplaces.py
@@ -85,7 +85,7 @@ _UI_DEF = [
       <section id='CommonEdit' groups='RW'>
         <item>
           <attribute name="action">win.PrintView</attribute>
-          <attribute name="label" translatable="yes">_Print...</attribute>
+          <attribute name="label" translatable="yes">Print...</attribute>
         </item>
       </section>
 ''',
@@ -139,7 +139,7 @@ _UI_DEF = [
         <property name="action-name">win.PrintView</property>
         <property name="tooltip_text" translatable="yes">'''
     '''Print or save the Map</property>
-        <property name="label" translatable="yes">_Print...</property>
+        <property name="label" translatable="yes">Print...</property>
         <property name="use-underline">True</property>
       </object>
       <packing>

--- a/gramps/plugins/webreport/person.py
+++ b/gramps/plugins/webreport/person.py
@@ -712,12 +712,10 @@ class PersonPages(BasePage):
             src_js += "ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"
             head += Html("script", type="text/javascript",
                          src=src_js, inline=True)
-            src_js = self.secure_mode
-            src_js += "openlayers.org/en/latest/build/ol.js"
+            src_js = "https://openlayers.org/en/latest/build/ol.js"
             head += Html("script", type="text/javascript",
                          src=src_js, inline=True)
-            url = self.secure_mode
-            url += "openlayers.org/en/latest/css/ol.css"
+            url = "https://openlayers.org/en/latest/css/ol.css"
             head += Html("link", href=url, type="text/javascript",
                          rel="stylesheet")
             src_js = self.secure_mode

--- a/gramps/plugins/webreport/place.py
+++ b/gramps/plugins/webreport/place.py
@@ -390,12 +390,10 @@ class PlacePages(BasePage):
                                    "jquery.min.js")
                         head += Html("script", type="text/javascript",
                                      src=src_js, inline=True)
-                        src_js = self.secure_mode
-                        src_js += "openlayers.org/en/latest/build/ol.js"
+                        src_js = "https://openlayers.org/en/latest/build/ol.js"
                         head += Html("script", type="text/javascript",
                                      src=src_js, inline=True)
-                        url = self.secure_mode
-                        url += "openlayers.org/en/latest/css/ol.css"
+                        url = "https://openlayers.org/en/latest/css/ol.css"
                         head += Html("link", href=url, type="text/javascript",
                                      rel="stylesheet")
                         src_js = self.secure_mode

--- a/po/de.po
+++ b/po/de.po
@@ -14,8 +14,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-06-20 21:13+0200\n"
-"PO-Revision-Date: 2019-06-20 22:00+0200\n"
+"POT-Creation-Date: 2019-07-09 20:03+0200\n"
+"PO-Revision-Date: 2019-07-09 20:19+0200\n"
 "Last-Translator: Mirko Leonhäuser <mirko@leonhaeuser.de>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
 "Language: de\n"
@@ -6682,7 +6682,7 @@ msgstr "Fundstellen"
 #: ../gramps/plugins/view/noteview.py:110 ../gramps/plugins/view/view.gpr.py:97
 #: ../gramps/plugins/view/view.gpr.py:105
 #: ../gramps/plugins/webreport/basepage.py:1264
-#: ../gramps/plugins/webreport/person.py:1242
+#: ../gramps/plugins/webreport/person.py:1240
 msgid "Notes"
 msgstr "Notizen"
 
@@ -6758,7 +6758,7 @@ msgstr "Notizen"
 #: ../gramps/plugins/webreport/event.py:177
 #: ../gramps/plugins/webreport/media.py:230
 #: ../gramps/plugins/webreport/media.py:564
-#: ../gramps/plugins/webreport/person.py:892
+#: ../gramps/plugins/webreport/person.py:890
 msgid "Date"
 msgstr "Datum"
 
@@ -7088,7 +7088,7 @@ msgstr "Fundstelle"
 #: ../gramps/plugins/webreport/event.py:178
 #: ../gramps/plugins/webreport/event.py:391
 #: ../gramps/plugins/webreport/media.py:541
-#: ../gramps/plugins/webreport/person.py:1470
+#: ../gramps/plugins/webreport/person.py:1468
 #: ../gramps/plugins/webreport/repository.py:245
 #: ../gramps/plugins/webreport/source.py:261
 msgid "Gramps ID"
@@ -7960,7 +7960,7 @@ msgstr "annul."
 #: ../gramps/plugins/textreport/tagreport.py:252
 #: ../gramps/plugins/view/familyview.py:80
 #: ../gramps/plugins/view/relview.py:1053
-#: ../gramps/plugins/webreport/person.py:1631
+#: ../gramps/plugins/webreport/person.py:1629
 msgid "Father"
 msgstr "Vater"
 
@@ -7982,7 +7982,7 @@ msgstr "Vater"
 #: ../gramps/plugins/textreport/tagreport.py:258
 #: ../gramps/plugins/view/familyview.py:81
 #: ../gramps/plugins/view/relview.py:1054
-#: ../gramps/plugins/webreport/person.py:1644
+#: ../gramps/plugins/webreport/person.py:1642
 msgid "Mother"
 msgstr "Mutter"
 
@@ -8011,7 +8011,7 @@ msgstr "Kinder"
 #: ../gramps/plugins/webreport/basepage.py:1650
 #: ../gramps/plugins/webreport/event.py:141
 #: ../gramps/plugins/webreport/event.py:366
-#: ../gramps/plugins/webreport/person.py:1529
+#: ../gramps/plugins/webreport/person.py:1527
 msgid "Events"
 msgstr "Ereignisse"
 
@@ -8290,7 +8290,7 @@ msgstr "Region"
 #: ../gramps/plugins/tool/removeunused.py:201
 #: ../gramps/plugins/tool/verify.py:579 ../gramps/plugins/view/repoview.py:85
 #: ../gramps/plugins/webreport/basepage.py:397
-#: ../gramps/plugins/webreport/person.py:1855
+#: ../gramps/plugins/webreport/person.py:1853
 msgid "Name"
 msgstr "Name"
 
@@ -8645,7 +8645,7 @@ msgstr "Kind-Referenzen Notiz"
 #: ../gramps/plugins/tool/reorderids.glade:761
 #: ../gramps/plugins/webreport/event.py:180
 #: ../gramps/plugins/webreport/family.py:188
-#: ../gramps/plugins/webreport/person.py:1240
+#: ../gramps/plugins/webreport/person.py:1238
 msgid "Person"
 msgstr "Person"
 
@@ -8659,7 +8659,7 @@ msgstr "Person"
 #: ../gramps/plugins/lib/libpersonview.py:100
 #: ../gramps/plugins/quickview/siblings.py:48
 #: ../gramps/plugins/textreport/indivcomplete.py:928
-#: ../gramps/plugins/webreport/person.py:1481
+#: ../gramps/plugins/webreport/person.py:1479
 msgid "Gender"
 msgstr "Geschlecht"
 
@@ -15156,7 +15156,7 @@ msgstr "Beteiligte"
 #: ../gramps/gui/widgets/reorderfam.py:103
 #: ../gramps/plugins/textreport/tagreport.py:264
 #: ../gramps/plugins/view/familyview.py:82
-#: ../gramps/plugins/webreport/person.py:1241
+#: ../gramps/plugins/webreport/person.py:1239
 msgid "Relationship"
 msgstr "Beziehung"
 
@@ -15166,7 +15166,7 @@ msgstr "alle"
 
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:134
 #: ../gramps/plugins/export/exportcsv.py:357
-#: ../gramps/plugins/webreport/person.py:1856
+#: ../gramps/plugins/webreport/person.py:1854
 msgid "Birth date"
 msgstr "Geburtsdatum"
 
@@ -15178,7 +15178,7 @@ msgstr "Beispiel: \"%(msg1)s\" oder \"%(msg2)s\""
 
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:136
 #: ../gramps/plugins/export/exportcsv.py:359
-#: ../gramps/plugins/webreport/person.py:1857
+#: ../gramps/plugins/webreport/person.py:1855
 msgid "Death date"
 msgstr "Sterbedatum"
 
@@ -18169,7 +18169,7 @@ msgstr "Personen zusammenfassen"
 #: ../gramps/plugins/view/relview.py:659 ../gramps/plugins/view/relview.py:1017
 #: ../gramps/plugins/view/relview.py:1052
 #: ../gramps/plugins/webreport/person.py:232
-#: ../gramps/plugins/webreport/person.py:1839
+#: ../gramps/plugins/webreport/person.py:1837
 #: ../gramps/plugins/webreport/surname.py:154
 msgid "Parents"
 msgstr "Eltern"
@@ -20395,6 +20395,19 @@ msgid "Generates documents in plain text format (.txt)."
 msgstr "Erstellt Dokumente als einfachen Text (.txt)."
 
 #: ../gramps/plugins/docgen/docgen.gpr.py:55
+#: ../gramps/plugins/view/fanchartview.py:164
+#: ../gramps/plugins/view/fanchartview.py:227
+#: ../gramps/plugins/view/geoclose.py:91 ../gramps/plugins/view/geoclose.py:167
+#: ../gramps/plugins/view/geoevents.py:81
+#: ../gramps/plugins/view/geoevents.py:129
+#: ../gramps/plugins/view/geofamclose.py:89
+#: ../gramps/plugins/view/geofamclose.py:165
+#: ../gramps/plugins/view/geofamily.py:81
+#: ../gramps/plugins/view/geofamily.py:131
+#: ../gramps/plugins/view/geomoves.py:88 ../gramps/plugins/view/geomoves.py:151
+#: ../gramps/plugins/view/geoperson.py:89
+#: ../gramps/plugins/view/geoplaces.py:84
+#: ../gramps/plugins/view/geoplaces.py:134
 msgid "Print..."
 msgstr "Drucken..."
 
@@ -22774,7 +22787,7 @@ msgstr "Gramplet zeigt die Nachkommen der aktiven Person"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:104
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:111
-#: ../gramps/plugins/webreport/person.py:1177
+#: ../gramps/plugins/webreport/person.py:1175
 msgid "Ancestors"
 msgstr "Vorfahren"
 
@@ -22843,7 +22856,7 @@ msgstr "Gramplet zeigt alle Vornamen als Textwolke"
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:205
 #: ../gramps/plugins/view/pedigreeview.py:528
 #: ../gramps/plugins/view/view.gpr.py:127
-#: ../gramps/plugins/webreport/person.py:1346
+#: ../gramps/plugins/webreport/person.py:1344
 msgid "Pedigree"
 msgstr "Ahnentafel"
 
@@ -23258,7 +23271,7 @@ msgstr "Gramplet zeigt die rückwärts Referenzen für eine Person"
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:981
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:995
 #: ../gramps/plugins/webreport/basepage.py:2959
-#: ../gramps/plugins/webreport/person.py:878
+#: ../gramps/plugins/webreport/person.py:876
 #: ../gramps/plugins/webreport/thumbnail.py:164
 msgid "References"
 msgstr "Referenzen"
@@ -25526,6 +25539,8 @@ msgid ""
 "Enable/Disable\n"
 "all object tags."
 msgstr ""
+"Aktiviere/Deaktiviere\n"
+"alle Objekte Markierungen."
 
 #: ../gramps/plugins/importer/importprogen.glade:1198
 msgid "Tag Text"
@@ -25605,7 +25620,7 @@ msgstr ""
 
 #: ../gramps/plugins/importer/importprogen.glade:1515
 msgid "Diverse"
-msgstr ""
+msgstr "Verschieden"
 
 #: ../gramps/plugins/importer/importprogen.glade:1526
 msgid "REFN"
@@ -30492,14 +30507,12 @@ msgid "Adding children."
 msgstr "Kinder hinzufügen."
 
 #: ../gramps/plugins/lib/libprogen.py:1927
-#, fuzzy
 msgid "Cannot find father for I%(person)s (Father=%(father))"
-msgstr "Kann den Vater für I%(person)s (Vater=%(father)) nicht finden"
+msgstr ""
 
 #: ../gramps/plugins/lib/libprogen.py:1930
-#, fuzzy
 msgid "Cannot find mother for I%(person)s (Mother=%(mother))"
-msgstr "Kann die Mutter für I%(person)s (Mutter=%(mother)) nicht finden"
+msgstr ""
 
 #: ../gramps/plugins/lib/librecords.py:55
 msgid "Youngest living person"
@@ -30943,7 +30956,7 @@ msgstr "Ereignisort"
 #: ../gramps/plugins/quickview/all_events.py:60
 #: ../gramps/plugins/quickview/all_events.py:109
 #: ../gramps/plugins/quickview/all_events.py:124
-#: ../gramps/plugins/webreport/person.py:894
+#: ../gramps/plugins/webreport/person.py:892
 msgid "Event Type"
 msgstr "Ereignisart"
 
@@ -31218,7 +31231,7 @@ msgstr "Personen"
 #: ../gramps/plugins/webreport/basepage.py:1531
 #: ../gramps/plugins/webreport/basepage.py:1583
 #: ../gramps/plugins/webreport/basepage.py:1652
-#: ../gramps/plugins/webreport/person.py:1243
+#: ../gramps/plugins/webreport/person.py:1241
 #: ../gramps/plugins/webreport/source.py:130
 #: ../gramps/plugins/webreport/source.py:227
 msgid "Sources"
@@ -32671,7 +32684,7 @@ msgid "Alternate Parents"
 msgstr "Alternative Eltern"
 
 #: ../gramps/plugins/textreport/indivcomplete.py:445
-#: ../gramps/plugins/webreport/person.py:1228
+#: ../gramps/plugins/webreport/person.py:1226
 msgid "Associations"
 msgstr "Verknüpfungen"
 
@@ -35808,22 +35821,6 @@ msgstr "Viertelkreis"
 msgid "Show gramps id"
 msgstr "Zeige Gramps ID"
 
-#: ../gramps/plugins/view/fanchartview.py:164
-#: ../gramps/plugins/view/fanchartview.py:227
-#: ../gramps/plugins/view/geoclose.py:91 ../gramps/plugins/view/geoclose.py:167
-#: ../gramps/plugins/view/geoevents.py:81
-#: ../gramps/plugins/view/geoevents.py:129
-#: ../gramps/plugins/view/geofamclose.py:89
-#: ../gramps/plugins/view/geofamclose.py:165
-#: ../gramps/plugins/view/geofamily.py:81
-#: ../gramps/plugins/view/geofamily.py:131
-#: ../gramps/plugins/view/geomoves.py:88 ../gramps/plugins/view/geomoves.py:151
-#: ../gramps/plugins/view/geoperson.py:89
-#: ../gramps/plugins/view/geoplaces.py:84
-#: ../gramps/plugins/view/geoplaces.py:134
-msgid "_Print..."
-msgstr "_Drucken..."
-
 #: ../gramps/plugins/view/fanchartview.py:227
 msgid "Print or save the Fan Chart View"
 msgstr "Drucke oder speichere die Fächergrafikansicht"
@@ -36974,7 +36971,7 @@ msgstr "Heilige der letzten Tage/ HLT Ordination"
 #: ../gramps/plugins/webreport/basepage.py:2344
 #: ../gramps/plugins/webreport/basepage.py:2345
 #: ../gramps/plugins/webreport/person.py:630
-#: ../gramps/plugins/webreport/person.py:941
+#: ../gramps/plugins/webreport/person.py:939
 msgid "Family Map"
 msgstr "Familienkarte"
 
@@ -37826,13 +37823,13 @@ msgstr "<fehlt>"
 msgid "Surnames %(surname)s beginning with letter %(letter)s"
 msgstr "Nachnamen %(surname)s beginnend mit Buchstaben %(letter)s"
 
-#: ../gramps/plugins/webreport/person.py:792
+#: ../gramps/plugins/webreport/person.py:790
 #, python-format
 msgid "Tracking %s"
 msgstr "Verfolge %s"
 
 #. page description
-#: ../gramps/plugins/webreport/person.py:797
+#: ../gramps/plugins/webreport/person.py:795
 msgid ""
 "This map page represents that person and any descendants with all of their "
 "event/ places. If you place your mouse over the marker it will display the "
@@ -37846,47 +37843,47 @@ msgstr ""
 "nach Datum sortiert (wenn vorhanden). Klicken auf einen Ort im "
 "Referenzbereich bringt dich auf die Ortsseite."
 
-#: ../gramps/plugins/webreport/person.py:868
+#: ../gramps/plugins/webreport/person.py:866
 msgid "Drop Markers"
 msgstr "Markierungen auslassen"
 
-#: ../gramps/plugins/webreport/person.py:893
+#: ../gramps/plugins/webreport/person.py:891
 msgid "Place Title"
 msgstr "Ortstitel"
 
-#: ../gramps/plugins/webreport/person.py:1440
+#: ../gramps/plugins/webreport/person.py:1438
 msgid "Call Name"
 msgstr "Rufname"
 
-#: ../gramps/plugins/webreport/person.py:1458
+#: ../gramps/plugins/webreport/person.py:1456
 msgid "Nick Name"
 msgstr "Spitzname"
 
-#: ../gramps/plugins/webreport/person.py:1504
+#: ../gramps/plugins/webreport/person.py:1502
 msgid "Age at Death"
 msgstr "Alter beim Tod"
 
-#: ../gramps/plugins/webreport/person.py:1634
+#: ../gramps/plugins/webreport/person.py:1632
 msgid "Stepfather"
 msgstr "Stiefvater"
 
-#: ../gramps/plugins/webreport/person.py:1647
+#: ../gramps/plugins/webreport/person.py:1645
 msgid "Stepmother"
 msgstr "Stiefmutter"
 
-#: ../gramps/plugins/webreport/person.py:1675
+#: ../gramps/plugins/webreport/person.py:1673
 msgid "Not siblings"
 msgstr "Keine Geschwister"
 
-#: ../gramps/plugins/webreport/person.py:1817
+#: ../gramps/plugins/webreport/person.py:1815
 msgid "Relation to the center person"
 msgstr "Beziehung zur Hauptperson"
 
-#: ../gramps/plugins/webreport/person.py:1854
+#: ../gramps/plugins/webreport/person.py:1852
 msgid "Relation to main person"
 msgstr "Beziehung zur Hauptperson"
 
-#: ../gramps/plugins/webreport/person.py:1858
+#: ../gramps/plugins/webreport/person.py:1856
 msgid "Relation within this family (if not by birth)"
 msgstr "Beziehung innerhalb dieser Familie (wenn nicht durch Geburt)"
 
@@ -37916,7 +37913,7 @@ msgid "Places beginning with letter %s"
 msgstr "Orte mit dem Buchstaben %s"
 
 #. section title
-#: ../gramps/plugins/webreport/place.py:408
+#: ../gramps/plugins/webreport/place.py:406
 msgid "Place Map"
 msgstr "Ortskarte"
 
@@ -38408,6 +38405,9 @@ msgstr "Nebraska"
 #: ../gramps/plugins/webstuff/webstuff.py:143
 msgid "No style sheet"
 msgstr "Kein Stylesheet"
+
+#~ msgid "_Print..."
+#~ msgstr "_Drucken..."
 
 #~ msgid "unmarried|husband"
 #~ msgstr "Lebensgefährte"

--- a/po/de.po
+++ b/po/de.po
@@ -14,8 +14,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-05-18 21:54+0200\n"
-"PO-Revision-Date: 2019-05-26 21:18+0200\n"
+"POT-Creation-Date: 2019-06-20 21:13+0200\n"
+"PO-Revision-Date: 2019-06-20 22:00+0200\n"
 "Last-Translator: Mirko Leonhäuser <mirko@leonhaeuser.de>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
 "Language: de\n"
@@ -1129,7 +1129,7 @@ msgstr ""
 "hervorragend auf jeder Desktopumgebung, die du bevorzugst. Hauptsache, die "
 "benötigten GTK-Bibliotheken sind installiert."
 
-#: ../gramps/cli/arghandler.py:228
+#: ../gramps/cli/arghandler.py:229
 #, python-format
 msgid ""
 "Error: Family Tree '%s' already exists.\n"
@@ -1138,7 +1138,7 @@ msgstr ""
 "Fehler: Stammbaum '%s' existiert bereits.\n"
 "Die Option '-C' kann nicht verwendet werden."
 
-#: ../gramps/cli/arghandler.py:240
+#: ../gramps/cli/arghandler.py:241
 #, python-format
 msgid ""
 "Error: Input Family Tree \"%s\" does not exist.\n"
@@ -1149,19 +1149,19 @@ msgstr ""
 "Wenn es GEDCOM Gramps-XML oder grdb ist, verwende stattdessen die -i Option "
 "zum Import in einen Stammbaum."
 
-#: ../gramps/cli/arghandler.py:254
+#: ../gramps/cli/arghandler.py:255
 #, python-format
 msgid "Error: Import file %s not found."
 msgstr "FEHLER: die Importdatei %s wurde nicht gefunden."
 
-#: ../gramps/cli/arghandler.py:272
+#: ../gramps/cli/arghandler.py:273
 #, python-format
 msgid "Error: Unrecognized type: \"%(format)s\" for import file: %(filename)s"
 msgstr ""
 "FEHLER: Nicht erkanntes Format: \"%(format)s\" für die Importdatei: "
 "%(filename)s"
 
-#: ../gramps/cli/arghandler.py:292
+#: ../gramps/cli/arghandler.py:293
 #, python-format
 msgid ""
 "WARNING: Output file already exists!\n"
@@ -1172,44 +1172,44 @@ msgstr ""
 "ACHTUNG: Sie wird überschrieben:\n"
 "   %s"
 
-#: ../gramps/cli/arghandler.py:295
+#: ../gramps/cli/arghandler.py:296
 msgid "OK to overwrite?"
 msgstr "Überschreiben o.k.?"
 
-#: ../gramps/cli/arghandler.py:296 ../gramps/cli/clidbman.py:429
+#: ../gramps/cli/arghandler.py:297 ../gramps/cli/clidbman.py:429
 msgid "no"
 msgstr "nein"
 
-#: ../gramps/cli/arghandler.py:296 ../gramps/cli/arghandler.py:297
+#: ../gramps/cli/arghandler.py:297 ../gramps/cli/arghandler.py:298
 #: ../gramps/cli/clidbman.py:429
 msgid "yes"
 msgstr "ja"
 
-#: ../gramps/cli/arghandler.py:299
+#: ../gramps/cli/arghandler.py:300
 #, python-format
 msgid "Will overwrite the existing file: %s"
 msgstr "Überschreibt die bestehende Datei: %s"
 
-#: ../gramps/cli/arghandler.py:319
+#: ../gramps/cli/arghandler.py:320
 #, python-format
 msgid "ERROR: Unrecognized format for export file %s"
 msgstr "FEHLER: Nicht erkanntes Format für die Exportdatei %s"
 
-#: ../gramps/cli/arghandler.py:385 ../gramps/gen/plug/utils.py:316
+#: ../gramps/cli/arghandler.py:386 ../gramps/gen/plug/utils.py:316
 #, python-format
 msgid "Error: cannot open '%s'"
 msgstr "FEHLER: Kann '%s' nicht öffnen"
 
-#: ../gramps/cli/arghandler.py:404
+#: ../gramps/cli/arghandler.py:405
 msgid "List of known Family Trees in your database path\n"
 msgstr "Liste bekannter Stammbäume in deinem Datenbankpfad\n"
 
-#: ../gramps/cli/arghandler.py:412
+#: ../gramps/cli/arghandler.py:413
 #, python-format
 msgid "%(full_DB_path)s with name \"%(f_t_name)s\""
 msgstr "%(full_DB_path)s mit Name \"%(f_t_name)s\""
 
-#: ../gramps/cli/arghandler.py:430 ../gramps/cli/clidbman.py:188
+#: ../gramps/cli/arghandler.py:431 ../gramps/cli/clidbman.py:188
 msgid "Gramps Family Trees:"
 msgstr "Gramps-Stammbäume:"
 
@@ -1220,99 +1220,99 @@ msgstr "Gramps-Stammbäume:"
 #. constants
 #.
 #. -------------------------------------------------------------------------
-#: ../gramps/cli/arghandler.py:436 ../gramps/cli/arghandler.py:438
-#: ../gramps/cli/arghandler.py:443 ../gramps/cli/arghandler.py:444
-#: ../gramps/cli/arghandler.py:446 ../gramps/cli/clidbman.py:69
+#: ../gramps/cli/arghandler.py:437 ../gramps/cli/arghandler.py:439
+#: ../gramps/cli/arghandler.py:444 ../gramps/cli/arghandler.py:445
+#: ../gramps/cli/arghandler.py:447 ../gramps/cli/clidbman.py:69
 #: ../gramps/cli/clidbman.py:169 ../gramps/cli/clidbman.py:197
 #: ../gramps/gui/clipboard.py:916 ../gramps/gui/configure.py:1798
 msgid "Family Tree"
 msgstr "Stammbaum"
 
 #. translators: used in French+Russian, ignore otherwise
-#: ../gramps/cli/arghandler.py:444 ../gramps/cli/arghandler.py:448
+#: ../gramps/cli/arghandler.py:445 ../gramps/cli/arghandler.py:449
 #: ../gramps/gen/plug/report/endnotes.py:199
 #, python-format
 msgid "\"%s\""
 msgstr "\"%s\""
 
-#: ../gramps/cli/arghandler.py:456
+#: ../gramps/cli/arghandler.py:457
 #, python-format
 msgid "Performing action: %s."
 msgstr "Ausführen von Aktion: %s."
 
-#: ../gramps/cli/arghandler.py:460 ../gramps/gen/plug/report/stdoptions.py:285
+#: ../gramps/cli/arghandler.py:461 ../gramps/gen/plug/report/stdoptions.py:285
 #, python-format
 msgid "Using options string: %s"
 msgstr "Verwende Optionstext: %s"
 
-#: ../gramps/cli/arghandler.py:466
+#: ../gramps/cli/arghandler.py:467
 #, python-format
 msgid "Exporting: file %(filename)s, format %(format)s."
 msgstr "Exportiere: Datei %(filename)s, Format %(format)s."
 
-#: ../gramps/cli/arghandler.py:477
+#: ../gramps/cli/arghandler.py:478
 msgid "Cleaning up."
 msgstr "Räume auf."
 
-#: ../gramps/cli/arghandler.py:510
+#: ../gramps/cli/arghandler.py:514
 msgid "Created empty Family Tree successfully"
 msgstr "Leerer Stammbaum erfolgreich erstellt"
 
-#: ../gramps/cli/arghandler.py:513 ../gramps/cli/arghandler.py:539
+#: ../gramps/cli/arghandler.py:517 ../gramps/cli/arghandler.py:543
 msgid "Error opening the file."
 msgstr "Fehler beim Öffnen der Datei."
 
-#: ../gramps/cli/arghandler.py:514 ../gramps/cli/arghandler.py:540
+#: ../gramps/cli/arghandler.py:518 ../gramps/cli/arghandler.py:544
 msgid "Exiting..."
 msgstr "Beenden..."
 
-#: ../gramps/cli/arghandler.py:518
+#: ../gramps/cli/arghandler.py:522
 #, python-format
 msgid "Importing: file %(filename)s, format %(format)s."
 msgstr "Importiere: Datei %(filename)s, Format %(format)s."
 
-#: ../gramps/cli/arghandler.py:537
+#: ../gramps/cli/arghandler.py:541
 msgid "Opened successfully!"
 msgstr "Erfolgreich geöffnet!"
 
-#: ../gramps/cli/arghandler.py:551
+#: ../gramps/cli/arghandler.py:555
 msgid "Database is locked, cannot open it!"
 msgstr "Die Datenbank kann nicht geöffnet werden, sie ist gesperrt!"
 
-#: ../gramps/cli/arghandler.py:552
+#: ../gramps/cli/arghandler.py:556
 #, python-format
 msgid "  Info: %s"
 msgstr " Info: %s"
 
-#: ../gramps/cli/arghandler.py:555
+#: ../gramps/cli/arghandler.py:559
 msgid "Database needs recovery, cannot open it!"
 msgstr ""
 "Die Datenbank kann nicht geöffnet werden, sie benötigt eine "
 "Wiederherstellung!"
 
-#: ../gramps/cli/arghandler.py:558
+#: ../gramps/cli/arghandler.py:562
 msgid "Database backend unavailable, cannot open it!"
 msgstr "Datenbank Backend ist nicht verfügbar, kann sie nicht öffnen!"
 
-#: ../gramps/cli/arghandler.py:609 ../gramps/cli/arghandler.py:658
-#: ../gramps/cli/arghandler.py:705
+#: ../gramps/cli/arghandler.py:613 ../gramps/cli/arghandler.py:662
+#: ../gramps/cli/arghandler.py:709
 msgid "Ignoring invalid options string."
 msgstr "Ignoriere ungültigen Optionstext."
 
 #. name exists, but is not in the list of valid report names
-#: ../gramps/cli/arghandler.py:633
+#: ../gramps/cli/arghandler.py:637
 msgid "Unknown report name."
 msgstr "Unbekannter Berichtname."
 
-#: ../gramps/cli/arghandler.py:635
+#: ../gramps/cli/arghandler.py:639
 #, python-format
 msgid "Report name not given. Please use one of %(donottranslate)s=reportname"
 msgstr ""
 "Der Berichtname ist nicht angegeben. Bitte verwende einen von "
 "%(donottranslate)s=reportname"
 
-#: ../gramps/cli/arghandler.py:639 ../gramps/cli/arghandler.py:687
-#: ../gramps/cli/arghandler.py:721
+#: ../gramps/cli/arghandler.py:643 ../gramps/cli/arghandler.py:691
+#: ../gramps/cli/arghandler.py:725
 #, python-format
 msgid ""
 "%s\n"
@@ -1321,29 +1321,29 @@ msgstr ""
 "%s\n"
 " Verfügbare Namen sind:"
 
-#: ../gramps/cli/arghandler.py:681
+#: ../gramps/cli/arghandler.py:685
 msgid "Unknown tool name."
 msgstr "Unbekannter Werkzeugname."
 
-#: ../gramps/cli/arghandler.py:683
+#: ../gramps/cli/arghandler.py:687
 #, python-format
 msgid "Tool name not given. Please use one of %(donottranslate)s=toolname."
 msgstr ""
 "Der Werkzeugname ist nicht angegeben. Bitte verwende einen von "
 "%(donottranslate)s=toolname."
 
-#: ../gramps/cli/arghandler.py:715
+#: ../gramps/cli/arghandler.py:719
 msgid "Unknown book name."
 msgstr "Unbekannter Buchname."
 
-#: ../gramps/cli/arghandler.py:717
+#: ../gramps/cli/arghandler.py:721
 #, python-format
 msgid "Book name not given. Please use one of %(donottranslate)s=bookname."
 msgstr ""
 "Der Buchname ist nicht angegeben. Bitte verwende einen von "
 "%(donottranslate)s=bookname."
 
-#: ../gramps/cli/arghandler.py:726
+#: ../gramps/cli/arghandler.py:730
 #, python-format
 msgid "Unknown action: %s."
 msgstr "Unbekannte Aktion: %s."
@@ -1434,13 +1434,13 @@ msgstr ""
 "(nur nicht-GUI Modus 'Graphical User Interface')\n"
 "  -v,--version                          Zeigt die Versionen\n"
 " -S, --safe                             Startet Gramps im 'Sicheren Modus'\n"
-"                                          (temporäre Verwendung der Standard"
-" Werte)\n"
+"                                          (temporäre Verwendung der Standard "
+"Werte)\n"
 "  -D, --default=[APXFE]                Setzt Werte auf Standard zurück;\n"
 "                 A - Erweiterungen werden gelöscht\n"
 "                 P - Einstellungen auf Standard\n"
-"                 X - Bücher werden gelöscht, Berichte und Werkzeuge auf"
-" Standard zurückgesetzt\n"
+"                 X - Bücher werden gelöscht, Berichte und Werkzeuge auf "
+"Standard zurückgesetzt\n"
 "                 F - Filter werden gelöscht\n"
 "                 E - Alles wir auf Standard gesetzt oder gelöscht\n"
 
@@ -1805,7 +1805,7 @@ msgstr "Gesperrt durch %s"
 #: ../gramps/plugins/gramplet/relativegramplet.py:137
 #: ../gramps/plugins/graph/gvfamilylines.py:287
 #: ../gramps/plugins/graph/gvhourglass.py:427
-#: ../gramps/plugins/graph/gvrelgraph.py:940
+#: ../gramps/plugins/graph/gvrelgraph.py:948
 #: ../gramps/plugins/lib/libprogen.py:1057
 #: ../gramps/plugins/lib/maps/geography.py:802
 #: ../gramps/plugins/lib/maps/geography.py:812
@@ -1846,7 +1846,7 @@ msgstr "Gesperrt durch %s"
 #: ../gramps/plugins/view/geofamily.py:517
 #: ../gramps/plugins/view/geomoves.py:662
 #: ../gramps/plugins/view/geoperson.py:543
-#: ../gramps/plugins/view/geoplaces.py:590
+#: ../gramps/plugins/view/geoplaces.py:592
 #: ../gramps/plugins/view/relview.py:589 ../gramps/plugins/view/relview.py:1160
 #: ../gramps/plugins/view/relview.py:1215
 #: ../gramps/plugins/webreport/basepage.py:1838
@@ -2054,7 +2054,7 @@ msgstr "   Gültige Optionen sind:"
 #: ../gramps/plugins/gramplet/whatsnext.py:441
 #: ../gramps/plugins/gramplet/whatsnext.py:474
 #: ../gramps/plugins/gramplet/whatsnext.py:496
-#: ../gramps/plugins/graph/gvrelgraph.py:705
+#: ../gramps/plugins/graph/gvrelgraph.py:707
 #: ../gramps/plugins/textreport/descendreport.py:270
 #: ../gramps/plugins/textreport/descendreport.py:280
 #: ../gramps/plugins/textreport/descendreport.py:286
@@ -3015,7 +3015,7 @@ msgstr "Fr"
 msgid "Sat"
 msgstr "Sa"
 
-#: ../gramps/gen/db/base.py:1816 ../gramps/gui/widgets/fanchart.py:1826
+#: ../gramps/gen/db/base.py:1816 ../gramps/gui/widgets/fanchart.py:2077
 msgid "Add child to family"
 msgstr "Füge ein Kind zur Familie hinzu"
 
@@ -3559,21 +3559,21 @@ msgstr "Anwendung ..."
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1093
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1107
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1121
-#: ../gramps/plugins/graph/gvrelgraph.py:799
+#: ../gramps/plugins/graph/gvrelgraph.py:801
 #: ../gramps/plugins/quickview/quickview.gpr.py:130
 #: ../gramps/plugins/textreport/birthdayreport.py:473
 #: ../gramps/plugins/textreport/familygroup.py:714
 #: ../gramps/plugins/textreport/indivcomplete.py:1062
 #: ../gramps/plugins/textreport/recordsreport.py:217
 #: ../gramps/plugins/tool/sortevents.py:168
-#: ../gramps/plugins/webreport/narrativeweb.py:1638
+#: ../gramps/plugins/webreport/narrativeweb.py:1639
 #: ../gramps/plugins/webreport/webcal.py:1671
 msgid "Filter"
 msgstr "Filter"
 
 #: ../gramps/gen/filters/rules/_changedsincebase.py:56
 #: ../gramps/gen/filters/rules/_everything.py:45
-#: ../gramps/gen/filters/rules/_hasattributebase.py:51
+#: ../gramps/gen/filters/rules/_hasattributebase.py:53
 #: ../gramps/gen/filters/rules/_hasgallerybase.py:48
 #: ../gramps/gen/filters/rules/_hasgrampsid.py:48
 #: ../gramps/gen/filters/rules/_hasldsbase.py:51
@@ -4877,7 +4877,7 @@ msgstr "Typ:"
 
 #: ../gramps/gen/filters/rules/media/_hasmedia.py:48
 #: ../gramps/gui/glade/mergemedia.glade:245
-#: ../gramps/gui/glade/mergemedia.glade:261 ../gramps/gui/viewmanager.py:1664
+#: ../gramps/gui/glade/mergemedia.glade:261 ../gramps/gui/viewmanager.py:1663
 msgid "Path:"
 msgstr "Pfad:"
 
@@ -5370,7 +5370,7 @@ msgstr "Einzelner Nachname:"
 
 #: ../gramps/gen/filters/rules/person/_hasnameof.py:54
 #: ../gramps/gen/lib/surname.py:98
-#: ../gramps/gui/editors/displaytabs/surnametab.py:76
+#: ../gramps/gui/editors/displaytabs/surnametab.py:79
 msgid "Connector"
 msgstr "Verbinder"
 
@@ -5473,7 +5473,7 @@ msgstr "Liefert Personen mit der vorgegebenen Beziehung."
 
 #: ../gramps/gen/filters/rules/person/_hasrelationship.py:50
 #: ../gramps/gen/filters/rules/person/_havealtfamilies.py:45
-#: ../gramps/gen/filters/rules/person/_havechildren.py:44
+#: ../gramps/gen/filters/rules/person/_havechildren.py:48
 #: ../gramps/gen/filters/rules/person/_ischildoffiltermatch.py:48
 #: ../gramps/gen/filters/rules/person/_isparentoffiltermatch.py:48
 #: ../gramps/gen/filters/rules/person/_issiblingoffiltermatch.py:47
@@ -5568,11 +5568,11 @@ msgstr "Adoptierte Personen"
 msgid "Matches people who were adopted"
 msgstr "Liefert Personen, die adoptiert wurden"
 
-#: ../gramps/gen/filters/rules/person/_havechildren.py:42
+#: ../gramps/gen/filters/rules/person/_havechildren.py:46
 msgid "People with children"
 msgstr "Personen mit Kindern"
 
-#: ../gramps/gen/filters/rules/person/_havechildren.py:43
+#: ../gramps/gen/filters/rules/person/_havechildren.py:47
 msgid "Matches people who have children"
 msgstr "Liefert Personen, die Kinder haben"
 
@@ -5690,7 +5690,7 @@ msgstr ""
 #: ../gramps/plugins/gramplet/statsgramplet.py:149
 #: ../gramps/plugins/graph/gvfamilylines.py:283
 #: ../gramps/plugins/graph/gvhourglass.py:423
-#: ../gramps/plugins/graph/gvrelgraph.py:936
+#: ../gramps/plugins/graph/gvrelgraph.py:944
 #: ../gramps/plugins/webreport/statistics.py:124
 #: ../gramps/plugins/webreport/statistics.py:189
 msgid "Females"
@@ -5766,7 +5766,7 @@ msgstr ""
 #: ../gramps/plugins/gramplet/statsgramplet.py:146
 #: ../gramps/plugins/graph/gvfamilylines.py:279
 #: ../gramps/plugins/graph/gvhourglass.py:419
-#: ../gramps/plugins/graph/gvrelgraph.py:932
+#: ../gramps/plugins/graph/gvrelgraph.py:940
 #: ../gramps/plugins/webreport/statistics.py:122
 #: ../gramps/plugins/webreport/statistics.py:187
 msgid "Males"
@@ -6766,7 +6766,7 @@ msgstr "Datum"
 #: ../gramps/gen/lib/placetype.py:71
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:72
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:54
-#: ../gramps/plugins/view/geoplaces.py:599
+#: ../gramps/plugins/view/geoplaces.py:601
 #: ../gramps/plugins/view/repoview.py:89
 #: ../gramps/plugins/webreport/basepage.py:1128
 #: ../gramps/plugins/webreport/basepage.py:2587
@@ -6778,7 +6778,7 @@ msgstr "Straße"
 #: ../gramps/gen/lib/placetype.py:70 ../gramps/gui/configure.py:612
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:73
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:55
-#: ../gramps/plugins/view/geoplaces.py:596
+#: ../gramps/plugins/view/geoplaces.py:598
 #: ../gramps/plugins/view/repoview.py:90
 #: ../gramps/plugins/webreport/basepage.py:1129
 #: ../gramps/plugins/webreport/basepage.py:2588
@@ -6790,7 +6790,7 @@ msgstr "Lokalität"
 #: ../gramps/gen/lib/placetype.py:68 ../gramps/gui/configure.py:615
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:74
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:56
-#: ../gramps/plugins/view/geoplaces.py:647
+#: ../gramps/plugins/view/geoplaces.py:649
 #: ../gramps/plugins/view/repoview.py:91
 #: ../gramps/plugins/webreport/basepage.py:1130
 #: ../gramps/plugins/webreport/basepage.py:2589
@@ -6803,7 +6803,7 @@ msgstr "Stadt"
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:57
 #: ../gramps/gui/views/treemodels/placemodel.py:312
 #: ../gramps/plugins/lib/maps/placeselection.py:151
-#: ../gramps/plugins/view/geoplaces.py:629
+#: ../gramps/plugins/view/geoplaces.py:631
 #: ../gramps/plugins/webreport/basepage.py:1132
 #: ../gramps/plugins/webreport/basepage.py:2592
 #: ../gramps/plugins/webreport/basepage.py:2657
@@ -6815,7 +6815,7 @@ msgstr "Kreis"
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:58
 #: ../gramps/gui/views/treemodels/placemodel.py:312
 #: ../gramps/plugins/lib/maps/placeselection.py:150
-#: ../gramps/plugins/view/geoplaces.py:626
+#: ../gramps/plugins/view/geoplaces.py:628
 msgid "State"
 msgstr "Bundesland"
 
@@ -6825,7 +6825,7 @@ msgstr "Bundesland"
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:59
 #: ../gramps/gui/views/treemodels/placemodel.py:312
 #: ../gramps/plugins/lib/maps/placeselection.py:149
-#: ../gramps/plugins/view/geoplaces.py:623
+#: ../gramps/plugins/view/geoplaces.py:625
 #: ../gramps/plugins/view/repoview.py:93
 #: ../gramps/plugins/webreport/basepage.py:1134
 #: ../gramps/plugins/webreport/basepage.py:2596
@@ -6879,7 +6879,7 @@ msgstr "Wert"
 #: ../gramps/gen/lib/srcmediatype.py:57 ../gramps/gen/lib/urltype.py:48
 #: ../gramps/gui/autocomp.py:179
 #: ../gramps/plugins/textreport/indivcomplete.py:74
-#: ../gramps/plugins/view/geoplaces.py:593
+#: ../gramps/plugins/view/geoplaces.py:595
 msgid "Custom"
 msgstr "Selbst definiert"
 
@@ -7048,7 +7048,7 @@ msgstr "Pflegekind"
 #: ../gramps/gui/editors/editcitation.py:119
 #: ../gramps/gui/editors/editcitation.py:125
 #: ../gramps/gui/editors/editlink.py:100
-#: ../gramps/gui/editors/filtereditor.py:302
+#: ../gramps/gui/editors/filtereditor.py:302 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/views/treemodels/citationtreemodel.py:170
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:116
 #: ../gramps/plugins/importer/importprogen.glade:209
@@ -7114,7 +7114,7 @@ msgstr "Vertraulichkeit"
 #: ../gramps/gui/clipboard.py:761 ../gramps/gui/configure.py:652
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:78
 #: ../gramps/gui/editors/editlink.py:99 ../gramps/gui/editors/editsource.py:86
-#: ../gramps/gui/editors/filtereditor.py:298
+#: ../gramps/gui/editors/filtereditor.py:298 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/views/treemodels/citationtreemodel.py:170
 #: ../gramps/plugins/export/exportcsv.py:466
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:115
@@ -7140,7 +7140,7 @@ msgstr "Quelle"
 #: ../gramps/gen/lib/media.py:134 ../gramps/gen/lib/person.py:206
 #: ../gramps/gen/lib/place.py:166 ../gramps/gen/lib/src.py:117
 #: ../gramps/gui/clipboard.py:636 ../gramps/gui/editors/editlink.py:94
-#: ../gramps/gui/editors/filtereditor.py:299
+#: ../gramps/gui/editors/filtereditor.py:299 ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:111
 #: ../gramps/plugins/quickview/filterbyname.py:109
 #: ../gramps/plugins/quickview/filterbyname.py:134
@@ -7385,6 +7385,7 @@ msgstr "nur Text"
 #: ../gramps/gui/editors/editlink.py:92
 #: ../gramps/gui/editors/filtereditor.py:296
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:138
+#: ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:109
 #: ../gramps/plugins/importer/importprogen.glade:696
 #: ../gramps/plugins/quickview/filterbyname.py:175
@@ -7407,7 +7408,7 @@ msgstr "Ereignis"
 #: ../gramps/gui/editors/editlink.py:97
 #: ../gramps/gui/editors/filtereditor.py:297
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:108
-#: ../gramps/gui/glade/editevent.glade:270
+#: ../gramps/gui/glade/editevent.glade:270 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/plug/_guioptions.py:1354
 #: ../gramps/gui/selectors/selectevent.py:69
 #: ../gramps/gui/views/treemodels/placemodel.py:312
@@ -7504,7 +7505,7 @@ msgstr "Lebensereignisse"
 #: ../gramps/gui/editors/displaytabs/personeventembedlist.py:52
 #: ../gramps/gui/editors/editfamily.py:561 ../gramps/gui/editors/editlink.py:93
 #: ../gramps/gui/editors/filtereditor.py:295
-#: ../gramps/gui/glade/editldsord.glade:267
+#: ../gramps/gui/glade/editldsord.glade:267 ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/export/exportcsv.py:506
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:110
 #: ../gramps/plugins/importer/importcsv.py:227
@@ -7986,12 +7987,12 @@ msgid "Mother"
 msgstr "Mutter"
 
 #. Go over children and build their menu
-#: ../gramps/gen/lib/family.py:161 ../gramps/gui/widgets/fanchart.py:1709
+#: ../gramps/gen/lib/family.py:161 ../gramps/gui/widgets/fanchart.py:1957
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:855
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:869
 #: ../gramps/plugins/textreport/familygroup.py:646
 #: ../gramps/plugins/textreport/indivcomplete.py:678
-#: ../gramps/plugins/view/pedigreeview.py:1835
+#: ../gramps/plugins/view/pedigreeview.py:1829
 #: ../gramps/plugins/view/relview.py:1570
 #: ../gramps/plugins/webreport/basepage.py:381
 msgid "Children"
@@ -8210,7 +8211,7 @@ msgid "Location"
 msgstr "Standort"
 
 #: ../gramps/gen/lib/location.py:107 ../gramps/gen/lib/placetype.py:69
-#: ../gramps/plugins/view/geoplaces.py:644
+#: ../gramps/plugins/view/geoplaces.py:646
 msgid "Parish"
 msgstr "Kirchengemeinde"
 
@@ -8236,7 +8237,7 @@ msgid "Media ref"
 msgstr "Medienref"
 
 #: ../gramps/gen/lib/mediaref.py:110 ../gramps/gen/lib/placetype.py:73
-#: ../gramps/plugins/view/geoplaces.py:635
+#: ../gramps/plugins/view/geoplaces.py:637
 msgid "Region"
 msgstr "Region"
 
@@ -8264,7 +8265,7 @@ msgstr "Region"
 #: ../gramps/gui/plug/report/_bookdialog.py:383
 #: ../gramps/gui/selectors/selectperson.py:90
 #: ../gramps/gui/selectors/selectplace.py:67
-#: ../gramps/gui/views/bookmarks.py:282 ../gramps/gui/views/tags.py:444
+#: ../gramps/gui/views/bookmarks.py:281 ../gramps/gui/views/tags.py:444
 #: ../gramps/gui/views/treemodels/peoplemodel.py:611
 #: ../gramps/plugins/export/exportcsv.py:286
 #: ../gramps/plugins/gramplet/ancestor.py:63
@@ -8329,7 +8330,7 @@ msgstr "Suffix"
 #: ../gramps/gui/selectors/selectplace.py:70
 #: ../gramps/gui/selectors/selectrepository.py:66
 #: ../gramps/gui/selectors/selectsource.py:66
-#: ../gramps/gui/widgets/grampletpane.py:1602
+#: ../gramps/gui/widgets/grampletpane.py:1601
 #: ../gramps/plugins/export/exportcsv.py:286
 #: ../gramps/plugins/gramplet/persondetails.py:164
 #: ../gramps/plugins/importer/importprogen.glade:140
@@ -8462,7 +8463,7 @@ msgstr "Name nach der Hochzeit"
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:113
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:108
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:91
-#: ../gramps/gui/glade/editnote.glade:326
+#: ../gramps/gui/glade/editnote.glade:326 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/views/treemodels/mediamodel.py:117
 #: ../gramps/plugins/drawreport/ancestortree.py:974
 #: ../gramps/plugins/drawreport/descendtree.py:1701
@@ -8614,7 +8615,7 @@ msgstr "Kind-Referenzen Notiz"
 #: ../gramps/gen/lib/person.py:173 ../gramps/gui/clipboard.py:719
 #: ../gramps/gui/configure.py:643 ../gramps/gui/editors/editlink.py:96
 #: ../gramps/gui/editors/filtereditor.py:294
-#: ../gramps/gui/glade/editpersonref.glade:211
+#: ../gramps/gui/glade/editpersonref.glade:211 ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/export/exportcsv.py:354
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:108
 #: ../gramps/plugins/importer/importcsv.py:209
@@ -8680,7 +8681,7 @@ msgstr "Ereignisreferenzen"
 
 #: ../gramps/gen/lib/person.py:199 ../gramps/plugins/graph/gvfamilylines.py:292
 #: ../gramps/plugins/graph/gvhourglass.py:432
-#: ../gramps/plugins/graph/gvrelgraph.py:946
+#: ../gramps/plugins/graph/gvrelgraph.py:954
 #: ../gramps/plugins/quickview/filterbyname.py:94
 #: ../gramps/plugins/quickview/filterbyname.py:119
 #: ../gramps/plugins/textreport/indivcomplete.py:641
@@ -8799,52 +8800,52 @@ msgstr "Sprache"
 msgid "Place ref"
 msgstr "Orts ref"
 
-#: ../gramps/gen/lib/placetype.py:72 ../gramps/plugins/view/geoplaces.py:632
+#: ../gramps/gen/lib/placetype.py:72 ../gramps/plugins/view/geoplaces.py:634
 msgid "Province"
 msgstr "Provinz"
 
-#: ../gramps/gen/lib/placetype.py:74 ../gramps/plugins/view/geoplaces.py:638
+#: ../gramps/gen/lib/placetype.py:74 ../gramps/plugins/view/geoplaces.py:640
 msgid "Department"
 msgstr "Amt"
 
-#: ../gramps/gen/lib/placetype.py:75 ../gramps/plugins/view/geoplaces.py:602
+#: ../gramps/gen/lib/placetype.py:75 ../gramps/plugins/view/geoplaces.py:604
 msgid "Neighborhood"
 msgstr "Viertel"
 
-#: ../gramps/gen/lib/placetype.py:76 ../gramps/plugins/view/geoplaces.py:641
+#: ../gramps/gen/lib/placetype.py:76 ../gramps/plugins/view/geoplaces.py:643
 msgid "District"
 msgstr "Bezirk"
 
-#: ../gramps/gen/lib/placetype.py:77 ../gramps/plugins/view/geoplaces.py:605
+#: ../gramps/gen/lib/placetype.py:77 ../gramps/plugins/view/geoplaces.py:607
 msgid "Borough"
 msgstr "Borough"
 
-#: ../gramps/gen/lib/placetype.py:78 ../gramps/plugins/view/geoplaces.py:653
+#: ../gramps/gen/lib/placetype.py:78 ../gramps/plugins/view/geoplaces.py:655
 msgid "Municipality"
 msgstr "Gemeinde"
 
-#: ../gramps/gen/lib/placetype.py:79 ../gramps/plugins/view/geoplaces.py:650
+#: ../gramps/gen/lib/placetype.py:79 ../gramps/plugins/view/geoplaces.py:652
 msgid "Town"
 msgstr "Kleinstadt"
 
-#: ../gramps/gen/lib/placetype.py:80 ../gramps/plugins/view/geoplaces.py:608
+#: ../gramps/gen/lib/placetype.py:80 ../gramps/plugins/view/geoplaces.py:610
 msgid "Village"
 msgstr "Dorf"
 
-#: ../gramps/gen/lib/placetype.py:81 ../gramps/plugins/view/geoplaces.py:611
+#: ../gramps/gen/lib/placetype.py:81 ../gramps/plugins/view/geoplaces.py:613
 msgid "Hamlet"
 msgstr "Weiler"
 
-#: ../gramps/gen/lib/placetype.py:82 ../gramps/plugins/view/geoplaces.py:614
+#: ../gramps/gen/lib/placetype.py:82 ../gramps/plugins/view/geoplaces.py:616
 msgid "Farm"
 msgstr "Hof"
 
-#: ../gramps/gen/lib/placetype.py:83 ../gramps/plugins/view/geoplaces.py:617
+#: ../gramps/gen/lib/placetype.py:83 ../gramps/plugins/view/geoplaces.py:619
 msgid "Building"
 msgstr "Gebäude"
 
 #: ../gramps/gen/lib/placetype.py:84 ../gramps/plugins/gramplet/leak.py:95
-#: ../gramps/plugins/view/geoplaces.py:620
+#: ../gramps/plugins/view/geoplaces.py:622
 #: ../gramps/plugins/webreport/basepage.py:2802
 #: ../gramps/plugins/webreport/source.py:164
 msgid "Number"
@@ -8855,7 +8856,7 @@ msgstr "Standortnummer/Signatur"
 #: ../gramps/gui/configure.py:664 ../gramps/gui/editors/editlink.py:98
 #: ../gramps/gui/editors/editrepository.py:77
 #: ../gramps/gui/editors/editrepository.py:79
-#: ../gramps/gui/editors/filtereditor.py:300
+#: ../gramps/gui/editors/filtereditor.py:300 ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:114
 #: ../gramps/plugins/quickview/filterbyname.py:205
 #: ../gramps/plugins/quickview/filterbyname.py:264
@@ -9018,6 +9019,7 @@ msgstr "Gestylte Textmarkierung"
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:114
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:109
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:92
+#: ../gramps/gui/views/tags.py:61 ../gramps/gui/views/tags.py:71
 #: ../gramps/plugins/textreport/tagreport.py:909
 #: ../gramps/plugins/textreport/tagreport.py:913
 msgid "Tag"
@@ -9028,14 +9030,17 @@ msgid "Ranges"
 msgstr "Bereiche"
 
 #: ../gramps/gen/lib/styledtexttagtype.py:61
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Bold"
 msgstr "Fett"
 
 #: ../gramps/gen/lib/styledtexttagtype.py:62
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Italic"
 msgstr "Kursiv"
 
 #: ../gramps/gen/lib/styledtexttagtype.py:63
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Underline"
 msgstr "Unterstrichen"
 
@@ -9063,6 +9068,7 @@ msgstr "Hochgestellt"
 #: ../gramps/gui/glade/editlink.glade:171
 #: ../gramps/gui/widgets/styledtextbuffer.py:565
 #: ../gramps/gui/widgets/styledtextbuffer.py:605
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Link"
 msgstr "Verknüpfung"
 
@@ -9073,7 +9079,7 @@ msgstr "Verknüpfung"
 #: ../gramps/gui/configure.py:848 ../gramps/gui/configure.py:850
 #: ../gramps/gui/configure.py:853 ../gramps/gui/configure.py:854
 #: ../gramps/gui/configure.py:855 ../gramps/gui/configure.py:856
-#: ../gramps/gui/editors/displaytabs/surnametab.py:75
+#: ../gramps/gui/editors/displaytabs/surnametab.py:78
 #: ../gramps/gui/plug/_guioptions.py:88 ../gramps/gui/plug/_guioptions.py:1508
 #: ../gramps/plugins/drawreport/statisticschart.py:340
 #: ../gramps/plugins/export/exportcsv.py:354
@@ -9086,7 +9092,7 @@ msgid "Surname"
 msgstr "Nachname"
 
 #: ../gramps/gen/lib/surname.py:93 ../gramps/gen/utils/keyword.py:71
-#: ../gramps/gui/editors/displaytabs/surnametab.py:74
+#: ../gramps/gui/editors/displaytabs/surnametab.py:77
 #: ../gramps/gui/glade/editperson.glade:470
 #: ../gramps/plugins/export/exportcsv.py:355
 #: ../gramps/plugins/importer/importcsv.py:167
@@ -9394,7 +9400,7 @@ msgstr "Datei %s ist bereits geöffnet, erst schließen."
 #: ../gramps/plugins/lib/libhtmlbackend.py:253
 #: ../gramps/plugins/lib/libhtmlbackend.py:259
 #: ../gramps/plugins/lib/libhtmlbackend.py:263
-#: ../gramps/plugins/webreport/narrativeweb.py:332
+#: ../gramps/plugins/webreport/narrativeweb.py:333
 #, python-format
 msgid "Could not create %s"
 msgstr "Konnte %s nicht erstellen"
@@ -9425,22 +9431,22 @@ msgid "TrueType / FreeSans"
 msgstr "Truetype / FreeSans"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:72
-#: ../gramps/plugins/view/pedigreeview.py:2125
+#: ../gramps/plugins/view/pedigreeview.py:2119
 msgid "Vertical (↓)"
 msgstr "Vertikal (↓)"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:73
-#: ../gramps/plugins/view/pedigreeview.py:2126
+#: ../gramps/plugins/view/pedigreeview.py:2120
 msgid "Vertical (↑)"
 msgstr "Vertikal (↑)"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:74
-#: ../gramps/plugins/view/pedigreeview.py:2127
+#: ../gramps/plugins/view/pedigreeview.py:2121
 msgid "Horizontal (→)"
 msgstr "Horizontal (→)"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:75
-#: ../gramps/plugins/view/pedigreeview.py:2128
+#: ../gramps/plugins/view/pedigreeview.py:2122
 msgid "Horizontal (←)"
 msgstr "Horizontal (←)"
 
@@ -9519,6 +9525,7 @@ msgstr "Graphviz Layout"
 
 #. ###############################
 #: ../gramps/gen/plug/docgen/graphdoc.py:143
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Font family"
 msgstr "Schriftfamilie"
 
@@ -9532,6 +9539,7 @@ msgstr ""
 "www.nongnu.org/freefont/"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:152
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Font size"
 msgstr "Schriftgröße"
 
@@ -10227,14 +10235,14 @@ msgstr "Ob (und wo) Gramps-IDs enthalten sind"
 #. #########################
 #. ###############################
 #: ../gramps/gen/plug/report/stdoptions.py:328
-#: ../gramps/gui/viewmanager.py:1723
+#: ../gramps/gui/viewmanager.py:1722
 #: ../gramps/plugins/graph/gvfamilylines.py:218
-#: ../gramps/plugins/graph/gvrelgraph.py:851
+#: ../gramps/plugins/graph/gvrelgraph.py:859
 #: ../gramps/plugins/textreport/detancestralreport.py:900
 #: ../gramps/plugins/textreport/detdescendantreport.py:1085
 #: ../gramps/plugins/textreport/familygroup.py:752
 #: ../gramps/plugins/textreport/indivcomplete.py:1102
-#: ../gramps/plugins/webreport/narrativeweb.py:1985
+#: ../gramps/plugins/webreport/narrativeweb.py:1986
 msgid "Include"
 msgstr "Einbeziehen"
 
@@ -10418,7 +10426,7 @@ msgstr ""
 "lösche sie und starte Gramps neu."
 
 #: ../gramps/gen/relationship.py:1273
-#: ../gramps/plugins/view/pedigreeview.py:1606
+#: ../gramps/plugins/view/pedigreeview.py:1600
 msgid "Relationship loop detected"
 msgstr "Verwandtschaftsschleife entdeckt"
 
@@ -10493,30 +10501,6 @@ msgstr "Ex-Lebensgefährtin"
 
 #: ../gramps/gen/relationship.py:2195
 msgid "gender unknown,unmarried|ex-partner"
-msgstr "Ex-Lebensgefährt(e/in)"
-
-#: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
-msgstr "Lebensgefährte"
-
-#: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
-msgstr "Lebensgefährtin"
-
-#: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
-msgstr "Partner(in)"
-
-#: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
-msgstr "Ex-Lebensgefährte"
-
-#: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
-msgstr "Ex-Lebensgefährtin"
-
-#: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
 msgstr "Ex-Lebensgefährt(e/in)"
 
 #: ../gramps/gen/relationship.py:2198
@@ -10969,7 +10953,7 @@ msgstr "SUFFIX"
 
 #. name, sort, width, modelcol
 #: ../gramps/gen/utils/keyword.py:61
-#: ../gramps/gui/editors/displaytabs/surnametab.py:79
+#: ../gramps/gui/editors/displaytabs/surnametab.py:82
 msgid "Name|Primary"
 msgstr "Primär"
 
@@ -11319,7 +11303,7 @@ msgstr "Für eine andere Reihenfolge ziehe die Spalte an eine neue Position."
 
 #: ../gramps/gui/columnorder.py:107 ../gramps/gui/configure.py:1842
 #: ../gramps/gui/configure.py:1866 ../gramps/gui/configure.py:1892
-#: ../gramps/gui/plug/_dialogs.py:130 ../gramps/gui/viewmanager.py:1795
+#: ../gramps/gui/plug/_dialogs.py:130 ../gramps/gui/viewmanager.py:1794
 #: ../gramps/plugins/lib/maps/geography.py:997
 #: ../gramps/plugins/lib/maps/geography.py:1294
 msgid "_Apply"
@@ -11329,7 +11313,7 @@ msgstr "_Anwenden"
 #: ../gramps/gui/columnorder.py:128 ../gramps/gui/configure.py:1353
 #: ../gramps/plugins/drawreport/ancestortree.py:909
 #: ../gramps/plugins/drawreport/descendtree.py:1652
-#: ../gramps/plugins/webreport/narrativeweb.py:1765
+#: ../gramps/plugins/webreport/narrativeweb.py:1766
 msgid "Display"
 msgstr "Anzeige"
 
@@ -11363,10 +11347,11 @@ msgstr "Namenseditor anzeigen"
 #: ../gramps/gui/glade/editplaceformat.glade:23
 #: ../gramps/gui/glade/plugins.glade:22 ../gramps/gui/glade/rule.glade:24
 #: ../gramps/gui/glade/rule.glade:1024 ../gramps/gui/glade/tipofday.glade:117
-#: ../gramps/gui/glade/updateaddons.glade:25 ../gramps/gui/plug/_windows.py:105
-#: ../gramps/gui/plug/_windows.py:693 ../gramps/gui/plug/_windows.py:749
+#: ../gramps/gui/glade/updateaddons.glade:25 ../gramps/gui/grampsgui.py:56
+#: ../gramps/gui/plug/_windows.py:105 ../gramps/gui/plug/_windows.py:693
+#: ../gramps/gui/plug/_windows.py:749
 #: ../gramps/gui/plug/quick/_textbufdoc.py:60 ../gramps/gui/undohistory.py:90
-#: ../gramps/gui/viewmanager.py:1658 ../gramps/gui/views/bookmarks.py:299
+#: ../gramps/gui/viewmanager.py:1657 ../gramps/gui/views/bookmarks.py:298
 #: ../gramps/gui/views/tags.py:466 ../gramps/gui/widgets/grampletbar.py:636
 #: ../gramps/gui/widgets/grampletpane.py:239
 #: ../gramps/plugins/lib/maps/placeselection.py:120
@@ -11506,9 +11491,9 @@ msgstr "%s: "
 #: ../gramps/gui/glade/mergesource.glade:53
 #: ../gramps/gui/glade/reorder.glade:54 ../gramps/gui/glade/rule.glade:41
 #: ../gramps/gui/glade/rule.glade:351 ../gramps/gui/glade/rule.glade:781
-#: ../gramps/gui/logger/_errorview.py:175
+#: ../gramps/gui/grampsgui.py:56 ../gramps/gui/logger/_errorview.py:175
 #: ../gramps/gui/plug/report/_reportdialog.py:159
-#: ../gramps/gui/undohistory.py:82 ../gramps/gui/views/bookmarks.py:300
+#: ../gramps/gui/undohistory.py:82 ../gramps/gui/views/bookmarks.py:299
 #: ../gramps/gui/views/tags.py:467 ../gramps/gui/views/tags.py:681
 #: ../gramps/gui/widgets/grampletbar.py:642
 #: ../gramps/gui/widgets/grampletpane.py:244
@@ -11526,9 +11511,8 @@ msgid ""
 "Enter information about yourself so people can contact you when you "
 "distribute your Family Tree"
 msgstr ""
-"Gib Informationen über dich ein, so dass dich Personen kontaktieren können,"
-" wenn du "
-"deinen Stammbaum weitergibst."
+"Gib Informationen über dich ein, so dass dich Personen kontaktieren können, "
+"wenn du deinen Stammbaum weitergibst."
 
 #: ../gramps/gui/configure.py:617
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:75
@@ -11684,8 +11668,8 @@ msgstr "Unterdrücke Warnung, wenn mit geänderten Daten abgebrochen wird."
 #: ../gramps/gui/configure.py:808
 msgid "Suppress warning about missing researcher when exporting to GEDCOM"
 msgstr ""
-"Unterdrücke Warnung, wenn die Information zum Forscher beim Export zu GEDCOM"
-" fehlt."
+"Unterdrücke Warnung, wenn die Information zum Forscher beim Export zu GEDCOM "
+"fehlt."
 
 #: ../gramps/gui/configure.py:813
 msgid "Show plugin status dialog on plugin load error"
@@ -11730,11 +11714,11 @@ msgstr "Beispiel"
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:122
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:129
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:115
-#: ../gramps/gui/editors/editfamily.py:195
+#: ../gramps/gui/editors/editfamily.py:195 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/plug/report/_bookdialog.py:665 ../gramps/gui/views/tags.py:458
-#: ../gramps/gui/widgets/fanchart.py:1777
-#: ../gramps/gui/widgets/fanchart.py:1819
-#: ../gramps/plugins/view/pedigreeview.py:1709
+#: ../gramps/gui/widgets/fanchart.py:2028
+#: ../gramps/gui/widgets/fanchart.py:2070
+#: ../gramps/plugins/view/pedigreeview.py:1703
 msgid "_Add"
 msgstr "_Hinzufügen"
 
@@ -11746,11 +11730,11 @@ msgstr "_Hinzufügen"
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:123
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:130
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:116
-#: ../gramps/gui/glade/editlink.glade:222
+#: ../gramps/gui/glade/editlink.glade:222 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/plug/report/_bookdialog.py:639 ../gramps/gui/views/tags.py:459
-#: ../gramps/gui/widgets/fanchart.py:1574
-#: ../gramps/plugins/view/pedigreeview.py:1744
-#: ../gramps/plugins/view/pedigreeview.py:1972
+#: ../gramps/gui/widgets/fanchart.py:1817
+#: ../gramps/plugins/view/pedigreeview.py:1738
+#: ../gramps/plugins/view/pedigreeview.py:1966
 msgid "_Edit"
 msgstr "_Bearbeiten"
 
@@ -11762,7 +11746,7 @@ msgstr "_Bearbeiten"
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:117
 #: ../gramps/gui/editors/editfamily.py:198
 #: ../gramps/gui/plug/report/_bookdialog.py:634
-#: ../gramps/gui/views/bookmarks.py:295 ../gramps/gui/views/tags.py:460
+#: ../gramps/gui/views/bookmarks.py:294 ../gramps/gui/views/tags.py:460
 msgid "_Remove"
 msgstr "_Entfernen"
 
@@ -11794,8 +11778,8 @@ msgstr "Ortsformat (automatischer Ortstitel)"
 #: ../gramps/gui/configure.py:1243
 msgid "Enables automatic place title generation using specifed format."
 msgstr ""
-"aktiviert automatische Ortstitelgeneration unter Verwendung des angegebenen"
-" Formats"
+"aktiviert automatische Ortstitelgeneration unter Verwendung des angegebenen "
+"Formats"
 
 #: ../gramps/gui/configure.py:1254
 msgid "Years"
@@ -11851,9 +11835,9 @@ msgid ""
 "Show or hide text beside Navigator buttons (People, Families, Events...).\n"
 "Requires Gramps restart to apply."
 msgstr ""
-"Zeigt oder versteckt Text neben Navigationsschaltflächen (Personen, Familien,"
-" Ereignisse...)\n "
-"Benötigt zur Aktivierung einen Gramps Neustart."
+"Zeigt oder versteckt Text neben Navigationsschaltflächen (Personen, "
+"Familien, Ereignisse...)\n"
+" Benötigt zur Aktivierung einen Gramps Neustart."
 
 #: ../gramps/gui/configure.py:1348
 msgid "Show close button in gramplet bar tabs"
@@ -11862,8 +11846,8 @@ msgstr "Zeige die Schaltfläche 'Schließen' in den Gramplet-Reitern."
 #: ../gramps/gui/configure.py:1351
 msgid "Show close button to simplify removing gramplets from bars."
 msgstr ""
-"Zeige Schließen Schaltflächen um das Entfernen von Gramplets von Leisten zu"
-" vereinfachen."
+"Zeige Schließen Schaltflächen um das Entfernen von Gramplets von Leisten zu "
+"vereinfachen."
 
 #: ../gramps/gui/configure.py:1370
 msgid "Default text used for conditions"
@@ -12240,7 +12224,7 @@ msgstr "Wähle ein Medienverzeichnis"
 #: ../gramps/gui/plug/_guioptions.py:1744 ../gramps/gui/plug/_windows.py:440
 #: ../gramps/gui/plug/report/_fileentry.py:64
 #: ../gramps/gui/plug/report/_reportdialog.py:162 ../gramps/gui/utils.py:180
-#: ../gramps/gui/viewmanager.py:1793 ../gramps/gui/views/listview.py:1054
+#: ../gramps/gui/viewmanager.py:1792 ../gramps/gui/views/listview.py:1064
 #: ../gramps/gui/views/navigationview.py:348 ../gramps/gui/views/tags.py:682
 #: ../gramps/gui/widgets/progressdialog.py:437
 #: ../gramps/plugins/importer/importprogen.glade:1714
@@ -12256,7 +12240,7 @@ msgstr "_Abbrechen"
 msgid "Select database directory"
 msgstr "Wähle ein Datenbankverzeichnis."
 
-#: ../gramps/gui/configure.py:1887 ../gramps/gui/viewmanager.py:1790
+#: ../gramps/gui/configure.py:1887 ../gramps/gui/viewmanager.py:1789
 msgid "Select backup directory"
 msgstr "Sicherungsverzeichnis wählen"
 
@@ -12268,20 +12252,20 @@ msgid ""
 "If you select the \"use symbols\" checkbox, Gramps will use the selected "
 "font if it exists."
 msgstr ""
-"Dieser Reiter gibt dir die Möglichkeit einen Zeichensatz zu verwenden, der"
-" alle genealogischen Symbole anzeigen kann\n"
+"Dieser Reiter gibt dir die Möglichkeit einen Zeichensatz zu verwenden, der "
+"alle genealogischen Symbole anzeigen kann\n"
 "\n"
-"Wenn du \"Symbole verwenden\" Kästchen aktivierst, verwendet Gramps die"
-" gewählte Schriftart, wenn sie existiert."
+"Wenn du \"Symbole verwenden\" Kästchen aktivierst, verwendet Gramps die "
+"gewählte Schriftart, wenn sie existiert."
 
 #: ../gramps/gui/configure.py:1960
 msgid ""
 "This can be useful if you want to add phonetic in a note to show how to "
 "pronounce a name or if you mix multiple languages like greek and russian."
 msgstr ""
-"Dies kann hilfreich sein um phonetisch in einer Notiz zu verwenden um zu"
-" zeigen wie ein Name ausgesprochen wird wenn du verschiedene Sprachen mischt"
-" wie Griechisch und Russisch. "
+"Dies kann hilfreich sein um phonetisch in einer Notiz zu verwenden um zu "
+"zeigen wie ein Name ausgesprochen wird wenn du verschiedene Sprachen mischt "
+"wie Griechisch und Russisch. "
 
 #: ../gramps/gui/configure.py:1967
 msgid "Use symbols"
@@ -12293,8 +12277,8 @@ msgid ""
 "before you can continue (10 minutes or more). \n"
 "If you cancel the process, nothing will be changed."
 msgstr ""
-"Gib acht, wenn du auf die \"Versuche zu finden\" Schaltfläche klickst. Es"
-" kann eine Weile dauern bevor du fortsetzen kannst (10 Minuten oder länger).\n"
+"Gib acht, wenn du auf die \"Versuche zu finden\" Schaltfläche klickst. Es "
+"kann eine Weile dauern bevor du fortsetzen kannst (10 Minuten oder länger).\n"
 "Wenn du den Prozess abbrichst, wird nichts verändert."
 
 #: ../gramps/gui/configure.py:1982
@@ -12302,8 +12286,8 @@ msgid ""
 "You have already run the tool to search for genealogy fonts.\n"
 "Run it again only if you added fonts on your system."
 msgstr ""
-"Du hast das Werkzeug zum Finden Genealogischer Schriftarten schon laufen"
-" lassen.\n"
+"Du hast das Werkzeug zum Finden Genealogischer Schriftarten schon laufen "
+"lassen.\n"
 "Starte es nur erneut wenn du Schriftarten deinem System hinzugefügt hast."
 
 #: ../gramps/gui/configure.py:1987
@@ -12331,8 +12315,8 @@ msgid ""
 "I am not able to select genealogical fonts. Please, install the module "
 "fontconfig for python 3."
 msgstr ""
-"Ich kann keine genealogischen Zeichensätze wählen. Bitte installiere das"
-" Modul fontconfig für Python 3."
+"Ich kann keine genealogischen Zeichensätze wählen. Bitte installiere das "
+"Modul fontconfig für Python 3."
 
 #: ../gramps/gui/configure.py:2047
 msgid "Checking available genealogical fonts"
@@ -12347,8 +12331,8 @@ msgid ""
 "You have no font with genealogical symbols on your system. Gramps will not "
 "be able to use symbols."
 msgstr ""
-"Du hast keinen Zeichensatz mit genealogischen Symbolen auf deinem System."
-" Gramps wird es nicht möglich sein, Symbole zu verwenden."
+"Du hast keinen Zeichensatz mit genealogischen Symbolen auf deinem System. "
+"Gramps wird es nicht möglich sein, Symbole zu verwenden."
 
 #: ../gramps/gui/configure.py:2162
 msgid "What you will see"
@@ -12555,7 +12539,7 @@ msgstr "Datumsinformation"
 #: ../gramps/gui/glade/styleeditor.glade:1754
 #: ../gramps/gui/plug/_guioptions.py:80
 #: ../gramps/gui/plug/report/_reportdialog.py:166 ../gramps/gui/utils.py:194
-#: ../gramps/gui/viewmanager.py:1660 ../gramps/gui/views/tags.py:683
+#: ../gramps/gui/viewmanager.py:1659 ../gramps/gui/views/tags.py:683
 #: ../gramps/plugins/tool/check.py:781 ../gramps/plugins/tool/patchnames.py:118
 #: ../gramps/plugins/tool/populatesources.py:91
 #: ../gramps/plugins/tool/testcasegenerator.py:328
@@ -12864,48 +12848,48 @@ msgstr ""
 "Bitte versuche nicht, diesen wichtigen Dialog zu umgehen.\n"
 "Wähle stattdessen eine der verfügbaren Optionen."
 
-#: ../gramps/gui/displaystate.py:290
+#: ../gramps/gui/displaystate.py:279
 msgid "Cannot load database"
 msgstr "Kann Datenbank nicht laden"
 
-#: ../gramps/gui/displaystate.py:408
+#: ../gramps/gui/displaystate.py:397
 #: ../gramps/plugins/gramplet/persondetails.py:173
 msgid "No active person"
 msgstr "Keine aktive Person"
 
-#: ../gramps/gui/displaystate.py:409
+#: ../gramps/gui/displaystate.py:398
 msgid "No active family"
 msgstr "Keine aktive Familie"
 
-#: ../gramps/gui/displaystate.py:410
+#: ../gramps/gui/displaystate.py:399
 msgid "No active event"
 msgstr "Kein aktives Ereignis"
 
-#: ../gramps/gui/displaystate.py:411
+#: ../gramps/gui/displaystate.py:400
 msgid "No active place"
 msgstr "Kein aktiver Ort"
 
-#: ../gramps/gui/displaystate.py:412
+#: ../gramps/gui/displaystate.py:401
 msgid "No active source"
 msgstr "Keine aktive Quelle"
 
-#: ../gramps/gui/displaystate.py:413
+#: ../gramps/gui/displaystate.py:402
 msgid "No active citation"
 msgstr "Keine aktive Fundstelle"
 
-#: ../gramps/gui/displaystate.py:414
+#: ../gramps/gui/displaystate.py:403
 msgid "No active repository"
 msgstr "Kein aktiver Aufbewahrungsort"
 
-#: ../gramps/gui/displaystate.py:415
+#: ../gramps/gui/displaystate.py:404
 msgid "No active media"
 msgstr "Keine aktiven Medien"
 
-#: ../gramps/gui/displaystate.py:416
+#: ../gramps/gui/displaystate.py:405
 msgid "No active note"
 msgstr "Keine aktive Notiz"
 
-#: ../gramps/gui/displaystate.py:655 ../gramps/plugins/gramplet/todo.py:200
+#: ../gramps/gui/displaystate.py:644 ../gramps/plugins/gramplet/todo.py:200
 msgid "No active object"
 msgstr "Kein aktives Objekt"
 
@@ -13042,7 +13026,7 @@ msgstr "_Attribute"
 #: ../gramps/gui/selectors/selectplace.py:68
 #: ../gramps/gui/selectors/selectrepository.py:67
 #: ../gramps/gui/selectors/selectsource.py:68
-#: ../gramps/gui/views/bookmarks.py:282
+#: ../gramps/gui/views/bookmarks.py:281
 #: ../gramps/gui/views/navigationview.py:343
 #: ../gramps/plugins/gramplet/locations.py:88
 #: ../gramps/plugins/lib/libpersonview.py:99
@@ -13086,6 +13070,7 @@ msgstr "%(part1)s - %(part2)s"
 #: ../gramps/gui/glade/rule.glade:422 ../gramps/gui/glade/rule.glade:429
 #: ../gramps/gui/glade/styleeditor.glade:1864
 #: ../gramps/gui/glade/styleeditor.glade:1871
+#: ../gramps/plugins/view/relview.py:471
 msgid "Add"
 msgstr "Hinzufügen"
 
@@ -13106,6 +13091,7 @@ msgstr "Entfernen"
 #: ../gramps/gui/editors/displaytabs/buttontab.py:72
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:148
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:130
+#: ../gramps/plugins/view/relview.py:471
 msgid "Share"
 msgstr "Beteiligen"
 
@@ -13266,6 +13252,7 @@ msgid "verb:look at this|_View"
 msgstr "_Anschauen"
 
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:147
+#: ../gramps/plugins/view/mediaview.py:395
 msgid "Open Containing _Folder"
 msgstr "Enthaltenen _Ordner öffnen"
 
@@ -13588,36 +13575,36 @@ msgstr ""
 "Um die Aufbewahrungsortreferenz zu bearbeiten, muss der Aufbewahrungsort "
 "geschlossen werden."
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:64
+#: ../gramps/gui/editors/displaytabs/surnametab.py:67
 msgid "Create and add a new surname"
 msgstr "Neuen Nachnamen erstellen und hinzufügen"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:65
+#: ../gramps/gui/editors/displaytabs/surnametab.py:68
 msgid "Remove the selected surname"
 msgstr "Gewählten Nachnamen entfernen"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:66
+#: ../gramps/gui/editors/displaytabs/surnametab.py:69
 msgid "Edit the selected surname"
 msgstr "Gewählten Nachnamen bearbeiten"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:67
+#: ../gramps/gui/editors/displaytabs/surnametab.py:70
 msgid "Move the selected surname upwards"
 msgstr "Gewählten Nachnamen nach oben verschieben"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:68
+#: ../gramps/gui/editors/displaytabs/surnametab.py:71
 msgid "Move the selected surname downwards"
 msgstr "Gewählten Nachnamen nach unten verschieben"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:78
+#: ../gramps/gui/editors/displaytabs/surnametab.py:81
 #: ../gramps/plugins/lib/libgedcom.py:712
 msgid "Origin"
 msgstr "Ursprung"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:82
+#: ../gramps/gui/editors/displaytabs/surnametab.py:85
 msgid "Multiple Surnames"
 msgstr "Mehrere Nachnamen"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:89
+#: ../gramps/gui/editors/displaytabs/surnametab.py:92
 msgid "Family Surnames"
 msgstr "Familie Nachnamen"
 
@@ -14195,7 +14182,7 @@ msgstr "%(mother)s [%(gramps_id)s]"
 msgid "manual|Link_Editor"
 msgstr "Verknüpfungeditor"
 
-#: ../gramps/gui/editors/editlink.py:87 ../gramps/gui/editors/editlink.py:238
+#: ../gramps/gui/editors/editlink.py:87 ../gramps/gui/editors/editlink.py:239
 msgid "Link Editor"
 msgstr "Verknüpfungeditor"
 
@@ -14426,12 +14413,22 @@ msgid "Edit Person"
 msgstr "Person bearbeiten"
 
 #: ../gramps/gui/editors/editperson.py:644
+#: ../gramps/plugins/view/mediaview.py:379
+#: ../gramps/plugins/view/mediaview.py:395
 msgid "View"
 msgstr "Ansicht"
 
 #: ../gramps/gui/editors/editperson.py:646
 msgid "Edit Object Properties"
 msgstr "Objekteigenschaften bearbeiten"
+
+#: ../gramps/gui/editors/editperson.py:687
+msgid "Make Active Person"
+msgstr "Als Aktive Person setzen"
+
+#: ../gramps/gui/editors/editperson.py:687
+msgid "Make Home Person"
+msgstr "Als Hauptperson setzen"
 
 #: ../gramps/gui/editors/editperson.py:807
 msgid "Problem changing the gender"
@@ -14560,8 +14557,8 @@ msgstr ""
 
 #: ../gramps/gui/editors/editplace.py:217
 #: ../gramps/plugins/lib/maps/geography.py:891
-#: ../gramps/plugins/view/geoplaces.py:494
-#: ../gramps/plugins/view/geoplaces.py:520
+#: ../gramps/plugins/view/geoplaces.py:496
+#: ../gramps/plugins/view/geoplaces.py:522
 msgid "Edit Place"
 msgstr "Ort bearbeiten"
 
@@ -15108,8 +15105,8 @@ msgstr "%s ist nicht"
 msgid "%s does not contain"
 msgstr "%s enthält nicht"
 
-#: ../gramps/gui/filters/_searchbar.py:168 ../gramps/gui/views/listview.py:1188
-#: ../gramps/gui/views/listview.py:1208 ../gramps/plugins/gramplet/leak.py:193
+#: ../gramps/gui/filters/_searchbar.py:168 ../gramps/gui/views/listview.py:1198
+#: ../gramps/gui/views/listview.py:1218 ../gramps/plugins/gramplet/leak.py:193
 #: ../gramps/plugins/gramplet/leak.py:200
 msgid "Updating display..."
 msgstr "Anzeige wird aktualisiert..."
@@ -15269,6 +15266,36 @@ msgid "Configure currently selected item"
 msgstr "Den gewählten Artikel konfigurieren"
 
 #: ../gramps/gui/glade/book.glade:540 ../gramps/gui/glade/dbman.glade:266
+#: ../gramps/plugins/lib/libpersonview.py:226
+#: ../gramps/plugins/lib/libpersonview.py:303
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:303
+#: ../gramps/plugins/lib/libplaceview.py:362
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:195
+#: ../gramps/plugins/view/citationlistview.py:254
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:209
+#: ../gramps/plugins/view/eventview.py:268
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:168
+#: ../gramps/plugins/view/familyview.py:227
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/mediaview.py:268
+#: ../gramps/plugins/view/mediaview.py:327
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:168
+#: ../gramps/plugins/view/noteview.py:227
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/repoview.py:181
+#: ../gramps/plugins/view/repoview.py:240
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:167
+#: ../gramps/plugins/view/sourceview.py:226
+#: ../gramps/plugins/view/sourceview.py:278
 msgid "_Delete"
 msgstr "_Löschen"
 
@@ -15448,7 +15475,7 @@ msgstr "_Ohne speichern schließen"
 
 #: ../gramps/gui/glade/dialog.glade:873
 #: ../gramps/gui/plug/report/_bookdialog.py:637
-#: ../gramps/gui/views/listview.py:1055
+#: ../gramps/gui/views/listview.py:1065
 #: ../gramps/gui/widgets/grampletpane.py:588
 #: ../gramps/plugins/tool/eventcmp.py:400
 msgid "_Save"
@@ -15966,7 +15993,7 @@ msgid "_Tags:"
 msgstr "_Markierung:"
 
 #: ../gramps/gui/glade/editfamily.glade:764
-#: ../gramps/gui/widgets/monitoredwidgets.py:842
+#: ../gramps/gui/widgets/monitoredwidgets.py:853
 msgid "Edit the tag list"
 msgstr "Markierungenliste bearbeiten"
 
@@ -16976,7 +17003,7 @@ msgid "Note 2"
 msgstr "Notiz 2"
 
 #: ../gramps/gui/glade/mergenote.glade:278
-#: ../gramps/gui/glade/mergenote.glade:294 ../gramps/gui/views/listview.py:1059
+#: ../gramps/gui/glade/mergenote.glade:294 ../gramps/gui/views/listview.py:1069
 msgid "Format:"
 msgstr "Format:"
 
@@ -17480,6 +17507,41 @@ msgid "_Display on startup"
 msgstr "_Beim Starten anzeigen"
 
 #: ../gramps/gui/glade/tipofday.glade:102
+#: ../gramps/plugins/lib/libpersonview.py:206
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libplaceview.py:289
+#: ../gramps/plugins/lib/libplaceview.py:332
+#: ../gramps/plugins/view/citationlistview.py:181
+#: ../gramps/plugins/view/citationlistview.py:224
+#: ../gramps/plugins/view/citationtreeview.py:323
+#: ../gramps/plugins/view/eventview.py:195
+#: ../gramps/plugins/view/eventview.py:238
+#: ../gramps/plugins/view/familyview.py:154
+#: ../gramps/plugins/view/familyview.py:197
+#: ../gramps/plugins/view/fanchartview.py:144
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:71 ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoevents.py:67
+#: ../gramps/plugins/view/geoevents.py:101
+#: ../gramps/plugins/view/geofamclose.py:69
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geofamily.py:67
+#: ../gramps/plugins/view/geofamily.py:101
+#: ../gramps/plugins/view/geomoves.py:68 ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:69
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/geoplaces.py:70
+#: ../gramps/plugins/view/geoplaces.py:104
+#: ../gramps/plugins/view/mediaview.py:254
+#: ../gramps/plugins/view/mediaview.py:297
+#: ../gramps/plugins/view/noteview.py:154
+#: ../gramps/plugins/view/noteview.py:197
+#: ../gramps/plugins/view/pedigreeview.py:652
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428 ../gramps/plugins/view/repoview.py:167
+#: ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/sourceview.py:153
+#: ../gramps/plugins/view/sourceview.py:196
 msgid "_Forward"
 msgstr "_Vor"
 
@@ -17518,6 +17580,159 @@ msgstr "_Alles wählen"
 #: ../gramps/gui/glade/updateaddons.glade:120
 msgid "Select _None"
 msgstr "_Nichts wählen"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Books..."
+msgstr "Bücher..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Clip_board"
+msgstr "Zwischena_blage"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Configure the active view"
+msgstr "Die aktive Ansicht konfigurieren"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Connect to a recent database"
+msgstr "Mit neuer Datenbank verbinden"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "F_ull Screen"
+msgstr "Vollbild"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Gramps _Home Page"
+msgstr "Gramps _Homepage"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Gramps _Mailing Lists"
+msgstr "Gramps _Mailinglisten"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Make Backup..."
+msgstr "Erstelle Sicherung..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Manage databases"
+msgstr "Datenbanken verwalten"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Open _Recent"
+msgstr "_Zuletzt geöffnet"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Open the Clipboard dialog"
+msgstr "Öffnet den Zwischenablagedialog"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Open the reports dialog"
+msgstr "Öffnet den Berichtsdialog"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Open the tools dialog"
+msgstr "Öffnet den Werkzeugdialog"
+
+#: ../gramps/gui/grampsgui.py:56 ../gramps/gui/tipofday.py:67
+#: ../gramps/gui/tipofday.py:68 ../gramps/gui/tipofday.py:121
+msgid "Tip of the Day"
+msgstr "Tipp des Tages"
+
+#: ../gramps/gui/grampsgui.py:56 ../gramps/gui/undohistory.py:73
+msgid "Undo History"
+msgstr "Bearbeitungschronik"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Abandon Changes and Quit"
+msgstr "Änderungen _verwerfen und beenden"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_About"
+msgstr "_Info"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Bookmarks"
+msgstr "_Lesezeichen"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Configure..."
+msgstr "_Konfigurieren..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Export..."
+msgstr "_Export..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Extra Reports/Tools"
+msgstr "_Weitere Berichte/Werkzeuge"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_FAQ"
+msgstr "Häufig gestellte _Fragen"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Family Trees"
+msgstr "_Stammbäume"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Go"
+msgstr "_Gehe zu"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Import..."
+msgstr "_Import..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Key Bindings"
+msgstr "Tastatur_kürzel"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Manage Family Trees..."
+msgstr "Stammbäume _verwalten..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Navigator"
+msgstr "_Navigator"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Plugin Manager"
+msgstr "_Zusatzmodulverwaltung"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Preferences..."
+msgstr "_Einstellungen..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Quit"
+msgstr "_Beenden"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Report a Bug"
+msgstr "_Programmfehler melden"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Reports"
+msgstr "Be_richte"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Toolbar"
+msgstr "_Werkzeugleiste"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Tools"
+msgstr "_Werkzeuge"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_User Manual"
+msgstr "_Benutzerhandbuch"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_View"
+msgstr "_Ansicht"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Windows"
+msgstr "_Fenster"
 
 #: ../gramps/gui/grampsgui.py:423
 msgid ""
@@ -17947,10 +18162,10 @@ msgstr "Personen zusammenfassen"
 
 #. Go over parents and build their menu
 #: ../gramps/gui/merge/mergeperson.py:224
-#: ../gramps/gui/widgets/fanchart.py:1744
+#: ../gramps/gui/widgets/fanchart.py:1994
 #: ../gramps/plugins/quickview/all_relations.py:305
 #: ../gramps/plugins/tool/notrelated.py:128
-#: ../gramps/plugins/view/pedigreeview.py:1872
+#: ../gramps/plugins/view/pedigreeview.py:1866
 #: ../gramps/plugins/view/relview.py:659 ../gramps/plugins/view/relview.py:1017
 #: ../gramps/plugins/view/relview.py:1052
 #: ../gramps/plugins/webreport/person.py:232
@@ -17971,9 +18186,9 @@ msgstr "Keine Eltern gefunden"
 
 #. Go over spouses and build their menu
 #: ../gramps/gui/merge/mergeperson.py:238
-#: ../gramps/gui/widgets/fanchart.py:1614
+#: ../gramps/gui/widgets/fanchart.py:1857
 #: ../gramps/plugins/textreport/kinshipreport.py:133
-#: ../gramps/plugins/view/pedigreeview.py:1759
+#: ../gramps/plugins/view/pedigreeview.py:1753
 msgid "Spouses"
 msgstr "(Ehe-)Partner"
 
@@ -18608,6 +18823,19 @@ msgstr ""
 msgid "Use Compression"
 msgstr "Verwende Komprimierung"
 
+#: ../gramps/gui/plug/quick/_quickreports.py:97
+msgid "Web Connection"
+msgstr "Webverbindung"
+
+#: ../gramps/gui/plug/quick/_quickreports.py:142
+#: ../gramps/gui/plug/quick/_textbufdoc.py:74
+#: ../gramps/gui/plug/quick/_textbufdoc.py:154
+#: ../gramps/gui/plug/quick/_textbufdoc.py:156
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:216
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:223
+msgid "Quick View"
+msgstr "Schnellansicht"
+
 #: ../gramps/gui/plug/quick/_quicktable.py:134
 #: ../gramps/plugins/gramplet/descendant.py:113
 msgid "Copy all"
@@ -18616,14 +18844,6 @@ msgstr "Alles kopieren"
 #: ../gramps/gui/plug/quick/_quicktable.py:161
 msgid "See data not in Filter"
 msgstr "Daten nicht im Filter ansehen"
-
-#: ../gramps/gui/plug/quick/_textbufdoc.py:74
-#: ../gramps/gui/plug/quick/_textbufdoc.py:154
-#: ../gramps/gui/plug/quick/_textbufdoc.py:156
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:216
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:223
-msgid "Quick View"
-msgstr "Schnellansicht"
 
 #: ../gramps/gui/plug/report/_bookdialog.py:92
 msgid "Generate_Book_dialog"
@@ -18711,12 +18931,12 @@ msgid "Please select a book item to configure."
 msgstr "Bitte ein Buchelement zum konfigurieren wählen."
 
 #: ../gramps/gui/plug/report/_bookdialog.py:631
-#: ../gramps/gui/views/bookmarks.py:293 ../gramps/gui/views/tags.py:456
+#: ../gramps/gui/views/bookmarks.py:292 ../gramps/gui/views/tags.py:456
 msgid "_Up"
 msgstr "_Hoch"
 
 #: ../gramps/gui/plug/report/_bookdialog.py:632
-#: ../gramps/gui/views/bookmarks.py:294 ../gramps/gui/views/tags.py:457
+#: ../gramps/gui/views/bookmarks.py:293 ../gramps/gui/views/tags.py:457
 msgid "_Down"
 msgstr "_Runter"
 
@@ -18837,7 +19057,7 @@ msgstr "Stil"
 #: ../gramps/plugins/drawreport/timeline.py:414
 #: ../gramps/plugins/graph/gvfamilylines.py:120
 #: ../gramps/plugins/graph/gvhourglass.py:364
-#: ../gramps/plugins/graph/gvrelgraph.py:795
+#: ../gramps/plugins/graph/gvrelgraph.py:797
 #: ../gramps/plugins/textreport/alphabeticalindex.py:93
 #: ../gramps/plugins/textreport/ancestorreport.py:288
 #: ../gramps/plugins/textreport/birthdayreport.py:471
@@ -18855,7 +19075,7 @@ msgstr "Stil"
 #: ../gramps/plugins/textreport/summary.py:286
 #: ../gramps/plugins/textreport/tableofcontents.py:92
 #: ../gramps/plugins/textreport/tagreport.py:901
-#: ../gramps/plugins/webreport/narrativeweb.py:1612
+#: ../gramps/plugins/webreport/narrativeweb.py:1613
 #: ../gramps/plugins/webreport/webcal.py:1656
 msgid "Report Options"
 msgstr "Berichtsoptionen"
@@ -19171,11 +19391,6 @@ msgstr ""
 msgid "Spelling checker initialization failed: %s"
 msgstr "Die Einrichtung der Rechtschreibprüfung ist fehlgeschlagen: %s"
 
-#: ../gramps/gui/tipofday.py:67 ../gramps/gui/tipofday.py:68
-#: ../gramps/gui/tipofday.py:121
-msgid "Tip of the Day"
-msgstr "Tipp des Tages"
-
 #: ../gramps/gui/tipofday.py:87
 msgid "Failed to display tip of the day"
 msgstr "Den Tipp des Tages anzuzeigen ist fehlgeschlagen."
@@ -19190,10 +19405,6 @@ msgstr ""
 "Kann die Tipps nicht von externer Datei lesen.\n"
 "\n"
 "%s"
-
-#: ../gramps/gui/undohistory.py:73
-msgid "Undo History"
-msgstr "Bearbeitungschronik"
 
 #: ../gramps/gui/undohistory.py:84 ../gramps/gui/viewmanager.py:1120
 msgid "_Undo"
@@ -19352,11 +19563,11 @@ msgstr "Automatisches Backup..."
 msgid "Error saving backup data"
 msgstr "Fehler beim Speichern der Sicherungsdaten."
 
-#: ../gramps/gui/viewmanager.py:1482
+#: ../gramps/gui/viewmanager.py:1481
 msgid "Failed Loading View"
 msgstr "Laden der Ansicht fehlgeschlagen"
 
-#: ../gramps/gui/viewmanager.py:1483
+#: ../gramps/gui/viewmanager.py:1482
 #, python-format
 msgid ""
 "The view %(name)s did not load and reported an error.\n"
@@ -19381,11 +19592,11 @@ msgstr ""
 "Wenn du nicht willst, das Gramps weiter versucht diese Ansicht zu laden, "
 "kannst du sie in der Zusatzmodulverwaltung über das Hilfemenü verstecken."
 
-#: ../gramps/gui/viewmanager.py:1575
+#: ../gramps/gui/viewmanager.py:1574
 msgid "Failed Loading Plugin"
 msgstr "Laden des Zusatzmodul fehlgeschlagen"
 
-#: ../gramps/gui/viewmanager.py:1576
+#: ../gramps/gui/viewmanager.py:1575
 #, python-format
 msgid ""
 "The plugin %(name)s did not load and reported an error.\n"
@@ -19411,55 +19622,55 @@ msgstr ""
 "laden, kannst du es in der Zusatzmodulverwaltung über das Hilfemenü "
 "verstecken."
 
-#: ../gramps/gui/viewmanager.py:1656
+#: ../gramps/gui/viewmanager.py:1655
 msgid "Gramps XML Backup"
 msgstr "Gramps XML Sicherung"
 
-#: ../gramps/gui/viewmanager.py:1685
+#: ../gramps/gui/viewmanager.py:1684
 msgid "File:"
 msgstr "Datei:"
 
-#: ../gramps/gui/viewmanager.py:1717
+#: ../gramps/gui/viewmanager.py:1716
 msgid "Media:"
 msgstr "Medium:"
 
-#: ../gramps/gui/viewmanager.py:1724
+#: ../gramps/gui/viewmanager.py:1723
 #: ../gramps/plugins/gramplet/statsgramplet.py:196
 #: ../gramps/plugins/webreport/statistics.py:145
 msgid "Megabyte|MB"
 msgstr "MB"
 
-#: ../gramps/gui/viewmanager.py:1726
+#: ../gramps/gui/viewmanager.py:1725
 msgid "Exclude"
 msgstr "Ausschließen"
 
-#: ../gramps/gui/viewmanager.py:1746
+#: ../gramps/gui/viewmanager.py:1745
 msgid "Backup file already exists! Overwrite?"
 msgstr "Sicherungsdatei existiert bereits! Überschreiben?"
 
-#: ../gramps/gui/viewmanager.py:1747
+#: ../gramps/gui/viewmanager.py:1746
 #, python-format
 msgid "The file '%s' exists."
 msgstr "Die Datei '%s' existiert."
 
-#: ../gramps/gui/viewmanager.py:1748
+#: ../gramps/gui/viewmanager.py:1747
 msgid "Proceed and overwrite"
 msgstr "Fortsetzen und überschreiben"
 
-#: ../gramps/gui/viewmanager.py:1749
+#: ../gramps/gui/viewmanager.py:1748
 msgid "Cancel the backup"
 msgstr "Sicherung abbrechen"
 
-#: ../gramps/gui/viewmanager.py:1764
+#: ../gramps/gui/viewmanager.py:1763
 msgid "Making backup..."
 msgstr "Erstelle Sicherung..."
 
-#: ../gramps/gui/viewmanager.py:1777
+#: ../gramps/gui/viewmanager.py:1776
 #, python-format
 msgid "Backup saved to '%s'"
 msgstr "Sicherung gespeichert in '%s'"
 
-#: ../gramps/gui/viewmanager.py:1780
+#: ../gramps/gui/viewmanager.py:1779
 msgid "Backup aborted"
 msgstr "Sicherung abgebrochen"
 
@@ -19468,8 +19679,8 @@ msgid "manual|Bookmarks"
 msgstr "Lesezeichen"
 
 #. this is meaningless while it's modal
-#: ../gramps/gui/views/bookmarks.py:266 ../gramps/gui/views/bookmarks.py:276
-#: ../gramps/gui/views/bookmarks.py:372
+#: ../gramps/gui/views/bookmarks.py:265 ../gramps/gui/views/bookmarks.py:275
+#: ../gramps/gui/views/bookmarks.py:371
 #: ../gramps/plugins/lib/libpersonview.py:205
 #: ../gramps/plugins/lib/libplaceview.py:288
 #: ../gramps/plugins/view/citationlistview.py:180
@@ -19486,13 +19697,13 @@ msgstr "Lesezeichen"
 #: ../gramps/plugins/view/geoplaces.py:103
 #: ../gramps/plugins/view/mediaview.py:253
 #: ../gramps/plugins/view/noteview.py:153
-#: ../gramps/plugins/view/pedigreeview.py:689
+#: ../gramps/plugins/view/pedigreeview.py:683
 #: ../gramps/plugins/view/relview.py:427 ../gramps/plugins/view/repoview.py:166
 #: ../gramps/plugins/view/sourceview.py:152
 msgid "Organize Bookmarks"
 msgstr "Lesezeichen organisieren"
 
-#: ../gramps/gui/views/bookmarks.py:475
+#: ../gramps/gui/views/bookmarks.py:474
 msgid "Cannot bookmark this reference"
 msgstr "Kann kein Lesezeichen für diese Referenz erstellen"
 
@@ -19556,19 +19767,19 @@ msgstr "%s löschen?"
 msgid "Column clicked, sorting..."
 msgstr "Spalte geklickt, sortiere..."
 
-#: ../gramps/gui/views/listview.py:1051
+#: ../gramps/gui/views/listview.py:1061
 msgid "Export View as Spreadsheet"
 msgstr "Ansicht als Tabelle exportieren"
 
-#: ../gramps/gui/views/listview.py:1064
+#: ../gramps/gui/views/listview.py:1074
 msgid "CSV"
 msgstr "CSV"
 
-#: ../gramps/gui/views/listview.py:1065
+#: ../gramps/gui/views/listview.py:1075
 msgid "OpenDocument Spreadsheet"
 msgstr "OpenDocument Tabelle"
 
-#: ../gramps/gui/views/listview.py:1256
+#: ../gramps/gui/views/listview.py:1266
 msgid "Columns"
 msgstr "Spalten"
 
@@ -19589,21 +19800,11 @@ msgstr ""
 msgid "No Home Person"
 msgstr "Keine Hauptperson"
 
-#: ../gramps/gui/views/navigationview.py:339
-msgid ""
-"You need to set a 'default person' to go to. Select the People View, select "
-"the person you want as 'Home Person', then confirm your choice via the menu "
-"Edit -> Set Home Person."
-msgstr ""
-"Du musst eine 'Hauptperson' setzen, um dorthin zu springen. Gehe zur "
-"Personenansicht, wähle die Person, die du als 'Hauptperson' setzen willst "
-"und bestätige deine Wahl über Menü Bearbeiten -> Hauptperson setzen."
-
 #: ../gramps/gui/views/navigationview.py:324
 msgid ""
 "You need to set a 'default person' to go to. Select the People View, select "
 "the person you want as 'Home Person', then confirm your choice via the menu "
-"Edit ->Set Home Person."
+"Edit -> Set Home Person."
 msgstr ""
 "Du musst eine 'Hauptperson' setzen, um dorthin zu springen. Gehe zur "
 "Personenansicht, wähle die Person, die du als 'Hauptperson' setzen willst "
@@ -19618,6 +19819,14 @@ msgstr "Springe zur Gramps-ID"
 #, python-format
 msgid "Error: %s is not a valid Gramps ID"
 msgstr "Fehler: %s ist keine gültige Gramps-ID"
+
+#: ../gramps/gui/views/pageview.py:103
+msgid "_Bottombar"
+msgstr "_Fußleiste"
+
+#: ../gramps/gui/views/pageview.py:103
+msgid "_Sidebar"
+msgstr "_Seitenleiste"
 
 #: ../gramps/gui/views/pageview.py:562
 #, python-format
@@ -19639,6 +19848,18 @@ msgstr "Ansicht %s konfigurieren"
 #, python-format
 msgid "View %(name)s: %(msg)s"
 msgstr "Ansicht %(name)s: %(msg)s"
+
+#: ../gramps/gui/views/tags.py:71
+msgid "Tag selected rows"
+msgstr "Ausgewählte Zeilen markieren"
+
+#: ../gramps/gui/views/tags.py:93
+msgid "New Tag..."
+msgstr "Neue Markierung..."
+
+#: ../gramps/gui/views/tags.py:93
+msgid "Organize Tags..."
+msgstr "Markierungen organisieren...."
 
 #: ../gramps/gui/views/tags.py:112
 msgid "manual|Organize_Tags_Window"
@@ -19751,43 +19972,43 @@ msgstr "Diesen Abschnitt ausklappen"
 msgid "Collapse this section"
 msgstr "Diesen Abschnitt einklappen"
 
-#: ../gramps/gui/widgets/fanchart.py:1582 ../gramps/plugins/view/relview.py:966
+#: ../gramps/gui/widgets/fanchart.py:1825 ../gramps/plugins/view/relview.py:966
 msgid "Edit family"
 msgstr "Familie bearbeiten"
 
-#: ../gramps/gui/widgets/fanchart.py:1598 ../gramps/plugins/view/relview.py:967
+#: ../gramps/gui/widgets/fanchart.py:1841 ../gramps/plugins/view/relview.py:967
 msgid "Reorder families"
 msgstr "Familien wieder ordnen"
 
-#: ../gramps/gui/widgets/fanchart.py:1604
-#: ../gramps/plugins/view/pedigreeview.py:1749
-#: ../gramps/plugins/view/pedigreeview.py:1977
+#: ../gramps/gui/widgets/fanchart.py:1847
+#: ../gramps/plugins/view/pedigreeview.py:1743
+#: ../gramps/plugins/view/pedigreeview.py:1971
 msgid "_Copy"
 msgstr "_Kopieren"
 
 #. Go over siblings and build their menu
-#: ../gramps/gui/widgets/fanchart.py:1648
+#: ../gramps/gui/widgets/fanchart.py:1891
 #: ../gramps/plugins/quickview/quickview.gpr.py:319
-#: ../gramps/plugins/view/pedigreeview.py:1793
+#: ../gramps/plugins/view/pedigreeview.py:1787
 #: ../gramps/plugins/view/relview.py:1068
 msgid "Siblings"
 msgstr "Geschwister"
 
 #. Go over parents and build their menu
-#: ../gramps/gui/widgets/fanchart.py:1786
-#: ../gramps/plugins/view/pedigreeview.py:1920
+#: ../gramps/gui/widgets/fanchart.py:2037
+#: ../gramps/plugins/view/pedigreeview.py:1914
 msgid "Related"
 msgstr "Verknüpft"
 
-#: ../gramps/gui/widgets/fanchart.py:1834
+#: ../gramps/gui/widgets/fanchart.py:2085
 msgid "Add partner to person"
 msgstr "Partner zu einer Person hinzufügen"
 
-#: ../gramps/gui/widgets/fanchart.py:1841
+#: ../gramps/gui/widgets/fanchart.py:2092
 msgid "Add a person"
 msgstr "Eine Person hinzufügen"
 
-#: ../gramps/gui/widgets/fanchart.py:1916
+#: ../gramps/gui/widgets/fanchart.py:2182
 #: ../gramps/plugins/view/relview.py:1709
 msgid "Add Child to Family"
 msgstr "Kind zur Familie hinzufügen"
@@ -19814,6 +20035,7 @@ msgstr ""
 "Entfernen oder Wiederherstellen von Gramplets."
 
 #: ../gramps/gui/widgets/grampletbar.py:487
+#: ../gramps/gui/widgets/grampletpane.py:1442
 msgid "Add a gramplet"
 msgstr "Ein Gramplet hinzufügen"
 
@@ -19853,19 +20075,23 @@ msgstr "Rechtsklick zum Hinzufügen von Gramplets."
 msgid "Untitled Gramplet"
 msgstr "Unbenanntes Gramplet"
 
-#: ../gramps/gui/widgets/grampletpane.py:1574
+#: ../gramps/gui/widgets/grampletpane.py:1442
+msgid "Restore a gramplet"
+msgstr "Gramplet wiederherstellen"
+
+#: ../gramps/gui/widgets/grampletpane.py:1573
 msgid "Number of Columns"
 msgstr "Spaltenanzahl"
 
-#: ../gramps/gui/widgets/grampletpane.py:1579
+#: ../gramps/gui/widgets/grampletpane.py:1578
 msgid "Gramplet Layout"
 msgstr "Gramplet-Layout"
 
-#: ../gramps/gui/widgets/grampletpane.py:1609
+#: ../gramps/gui/widgets/grampletpane.py:1608
 msgid "Use maximum height available"
 msgstr "Verwende maximale verfügbare Höhe"
 
-#: ../gramps/gui/widgets/grampletpane.py:1615
+#: ../gramps/gui/widgets/grampletpane.py:1614
 msgid "Height if not maximized"
 msgstr "Höhe, wenn nicht maximiert"
 
@@ -19880,11 +20106,11 @@ msgstr ""
 "Zum Bearbeiten die Bearbeitungsschaltfläche klicken (Im Einstellungsdialog "
 "aktivieren)."
 
-#: ../gramps/gui/widgets/monitoredwidgets.py:651
+#: ../gramps/gui/widgets/monitoredwidgets.py:662
 msgid "Bad Date"
 msgstr "Ungültiges Datum"
 
-#: ../gramps/gui/widgets/monitoredwidgets.py:654
+#: ../gramps/gui/widgets/monitoredwidgets.py:665
 msgid "Date more than one year in the future"
 msgstr "Datum liegt mehr als ein Jahr in der Zukunft"
 
@@ -19925,6 +20151,26 @@ msgstr "Beziehungen neu ordnen"
 #, python-format
 msgid "Reorder Relationships: %s"
 msgstr "Beziehungen neu ordnen: %s"
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Background Color"
+msgstr "Hintergrundfarbe"
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Clear Markup"
+msgstr "Markierungen löschen"
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Font Color"
+msgstr "Schriftfarbe"
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Redo"
+msgstr "Wiederherstellen"
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Undo"
+msgstr "Rückgängig"
 
 #: ../gramps/gui/widgets/styledtexteditor.py:401
 msgid ""
@@ -20258,13 +20504,13 @@ msgid "of %d"
 msgstr "von %d"
 
 #: ../gramps/plugins/docgen/htmldoc.py:273
-#: ../gramps/plugins/webreport/narrativeweb.py:1516
+#: ../gramps/plugins/webreport/narrativeweb.py:1517
 #: ../gramps/plugins/webreport/webcal.py:270
 msgid "Possible destination error"
 msgstr "Möglicher Fehler im Ziel."
 
 #: ../gramps/plugins/docgen/htmldoc.py:274
-#: ../gramps/plugins/webreport/narrativeweb.py:1517
+#: ../gramps/plugins/webreport/narrativeweb.py:1518
 #: ../gramps/plugins/webreport/webcal.py:271
 msgid ""
 "You appear to have set your target directory to a directory used for data "
@@ -20362,7 +20608,7 @@ msgstr "Ahnendiagramm für %s"
 #: ../gramps/plugins/drawreport/descendtree.py:689
 #: ../gramps/plugins/drawreport/fanchart.py:194
 #: ../gramps/plugins/graph/gvhourglass.py:109
-#: ../gramps/plugins/graph/gvrelgraph.py:182
+#: ../gramps/plugins/graph/gvrelgraph.py:184
 #: ../gramps/plugins/textreport/ancestorreport.py:117
 #: ../gramps/plugins/textreport/birthdayreport.py:115
 #: ../gramps/plugins/textreport/descendreport.py:453
@@ -20393,7 +20639,7 @@ msgstr "Drucke den Baum..."
 #: ../gramps/plugins/drawreport/calendarreport.py:472
 #: ../gramps/plugins/drawreport/fanchart.py:689
 #: ../gramps/plugins/graph/gvhourglass.py:366
-#: ../gramps/plugins/graph/gvrelgraph.py:805
+#: ../gramps/plugins/graph/gvrelgraph.py:807
 #: ../gramps/plugins/textreport/ancestorreport.py:290
 #: ../gramps/plugins/textreport/descendreport.py:522
 #: ../gramps/plugins/textreport/detancestralreport.py:831
@@ -20590,7 +20836,7 @@ msgstr "Ob leere Seiten enthalten sind."
 #: ../gramps/plugins/drawreport/timeline.py:435
 #: ../gramps/plugins/graph/gvfamilylines.py:169
 #: ../gramps/plugins/graph/gvhourglass.py:402
-#: ../gramps/plugins/graph/gvrelgraph.py:833
+#: ../gramps/plugins/graph/gvrelgraph.py:841
 #: ../gramps/plugins/textreport/ancestorreport.py:310
 #: ../gramps/plugins/textreport/birthdayreport.py:500
 #: ../gramps/plugins/textreport/descendreport.py:557
@@ -20899,7 +21145,7 @@ msgstr ""
 
 #: ../gramps/plugins/drawreport/calendarreport.py:473
 #: ../gramps/plugins/drawreport/fanchart.py:690
-#: ../gramps/plugins/graph/gvrelgraph.py:806
+#: ../gramps/plugins/graph/gvrelgraph.py:808
 #: ../gramps/plugins/textreport/ancestorreport.py:291
 #: ../gramps/plugins/textreport/descendreport.py:523
 #: ../gramps/plugins/textreport/detancestralreport.py:832
@@ -21620,7 +21866,7 @@ msgstr "Legt fest, welche Personen im Bericht enthalten sind."
 #: ../gramps/plugins/textreport/indivcomplete.py:1068
 #: ../gramps/plugins/textreport/recordsreport.py:223
 #: ../gramps/plugins/tool/sortevents.py:173
-#: ../gramps/plugins/webreport/narrativeweb.py:1644
+#: ../gramps/plugins/webreport/narrativeweb.py:1645
 #: ../gramps/plugins/webreport/webcal.py:1677
 msgid "Filter Person"
 msgstr "Personenfilter"
@@ -21700,8 +21946,8 @@ msgid ""
 "Whether to include counts of the number of people who lack the given "
 "information."
 msgstr ""
-"Ob die Anzahl von Personen denen die angegebenen Informationen fehlen"
-" aufgenommen werden"
+"Ob die Anzahl von Personen denen die angegebenen Informationen fehlen "
+"aufgenommen werden"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:1102
 msgid "Charts 3"
@@ -21769,7 +22015,7 @@ msgstr "Legt fest, welche Personen im Bericht enthalten sind."
 #: ../gramps/plugins/drawreport/timeline.py:423
 #: ../gramps/plugins/textreport/recordsreport.py:224
 #: ../gramps/plugins/tool/sortevents.py:174
-#: ../gramps/plugins/webreport/narrativeweb.py:1645
+#: ../gramps/plugins/webreport/narrativeweb.py:1646
 #: ../gramps/plugins/webreport/webcal.py:1678
 msgid "The center person for the filter"
 msgstr "Die Hauptperson für den Filter"
@@ -22276,9 +22522,9 @@ msgstr "Anwenden"
 msgid "Double-click on a row to edit the selected event."
 msgstr "Das gewählte Ereignis bearbeiten: Doppelklick auf eine Zeile."
 
-#: ../gramps/plugins/gramplet/fanchart2waygramplet.py:86
-#: ../gramps/plugins/gramplet/fanchartdescgramplet.py:64
-#: ../gramps/plugins/gramplet/fanchartgramplet.py:67
+#: ../gramps/plugins/gramplet/fanchart2waygramplet.py:78
+#: ../gramps/plugins/gramplet/fanchartdescgramplet.py:65
+#: ../gramps/plugins/gramplet/fanchartgramplet.py:68
 msgid ""
 "Click to expand/contract person\n"
 "Right-click for options\n"
@@ -22595,7 +22841,7 @@ msgstr "Gramplet zeigt alle Vornamen als Textwolke"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:199
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:205
-#: ../gramps/plugins/view/pedigreeview.py:530
+#: ../gramps/plugins/view/pedigreeview.py:528
 #: ../gramps/plugins/view/view.gpr.py:127
 #: ../gramps/plugins/webreport/person.py:1346
 msgid "Pedigree"
@@ -23331,8 +23577,8 @@ msgstr "Maus für Optionen über Links bewegen"
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:58
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:67
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:78
-#: ../gramps/plugins/view/fanchartdescview.py:263
-#: ../gramps/plugins/view/fanchartview.py:360
+#: ../gramps/plugins/view/fanchartdescview.py:280
+#: ../gramps/plugins/view/fanchartview.py:378
 msgid "Max generations"
 msgstr "Max. Generationen"
 
@@ -23954,7 +24200,7 @@ msgid "Produces an hourglass graph using Graphviz."
 msgstr "Erstellt ein Stundenglasdiagramm mit Graphviz."
 
 #: ../gramps/plugins/graph/graphplugins.gpr.py:81
-#: ../gramps/plugins/graph/gvrelgraph.py:205
+#: ../gramps/plugins/graph/gvrelgraph.py:207
 msgid "Relationship Graph"
 msgstr "Beziehungengrafik"
 
@@ -24057,19 +24303,19 @@ msgstr ""
 
 #: ../gramps/plugins/graph/gvfamilylines.py:144
 #: ../gramps/plugins/graph/gvhourglass.py:380
-#: ../gramps/plugins/graph/gvrelgraph.py:810
+#: ../gramps/plugins/graph/gvrelgraph.py:812
 msgid "Arrowhead direction"
 msgstr "Pfeilrichtungen"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:147
 #: ../gramps/plugins/graph/gvhourglass.py:383
-#: ../gramps/plugins/graph/gvrelgraph.py:813
+#: ../gramps/plugins/graph/gvrelgraph.py:815
 msgid "Choose the direction that the arrows point."
 msgstr "Richtung der Pfeile auswählen."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:150
 #: ../gramps/plugins/graph/gvhourglass.py:386
-#: ../gramps/plugins/graph/gvrelgraph.py:816
+#: ../gramps/plugins/graph/gvrelgraph.py:818
 msgid "Graph coloring"
 msgstr "Diagrammfärbung"
 
@@ -24089,8 +24335,8 @@ msgstr "Abgerundete Ecken"
 #: ../gramps/plugins/graph/gvfamilylines.py:162
 msgid "Use rounded corners e.g. to differentiate between women and men."
 msgstr ""
-"Verwende abgerundete Ecken, z.B. um zwischen Frauen und Männern zu"
-" unterscheiden."
+"Verwende abgerundete Ecken, z.B. um zwischen Frauen und Männern zu "
+"unterscheiden."
 
 #. --------------------------------
 #: ../gramps/plugins/graph/gvfamilylines.py:184
@@ -24171,7 +24417,7 @@ msgstr ""
 "Ob die Anzahl der Kinder für Familien mit mehr als einem Kind enthalten ist."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:246
-#: ../gramps/plugins/graph/gvrelgraph.py:896
+#: ../gramps/plugins/graph/gvrelgraph.py:904
 msgid "Include thumbnail images of people"
 msgstr "Mit Miniaturbildern der Personen"
 
@@ -24184,17 +24430,17 @@ msgid "Thumbnail location"
 msgstr "Miniaturbild Position"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:255
-#: ../gramps/plugins/graph/gvrelgraph.py:903
+#: ../gramps/plugins/graph/gvrelgraph.py:911
 msgid "Above the name"
 msgstr "Über dem Namen"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:256
-#: ../gramps/plugins/graph/gvrelgraph.py:904
+#: ../gramps/plugins/graph/gvrelgraph.py:912
 msgid "Beside the name"
 msgstr "Neben dem Namen"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:257
-#: ../gramps/plugins/graph/gvrelgraph.py:906
+#: ../gramps/plugins/graph/gvrelgraph.py:914
 msgid "Where the thumbnail image should appear relative to the name"
 msgstr ""
 "Legt fest, wo das Miniaturbild im Verhältnis zum Namen erscheinen soll."
@@ -24223,25 +24469,25 @@ msgstr "Farben, die für verschiedene Familienlinien verwendet werden."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:280
 #: ../gramps/plugins/graph/gvhourglass.py:420
-#: ../gramps/plugins/graph/gvrelgraph.py:933
+#: ../gramps/plugins/graph/gvrelgraph.py:941
 msgid "The color to use to display men."
 msgstr "Die Farbe, die für die Anzeige von Männern verwendet wird."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:284
 #: ../gramps/plugins/graph/gvhourglass.py:424
-#: ../gramps/plugins/graph/gvrelgraph.py:937
+#: ../gramps/plugins/graph/gvrelgraph.py:945
 msgid "The color to use to display women."
 msgstr "Die Farbe, die für die Anzeige von Frauen verwendet wird."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:288
 #: ../gramps/plugins/graph/gvhourglass.py:428
-#: ../gramps/plugins/graph/gvrelgraph.py:942
+#: ../gramps/plugins/graph/gvrelgraph.py:950
 msgid "The color to use when the gender is unknown."
 msgstr "Die Farbe die verwendet wird, wenn das Geschlecht unbekannt ist."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:293
 #: ../gramps/plugins/graph/gvhourglass.py:433
-#: ../gramps/plugins/graph/gvrelgraph.py:947
+#: ../gramps/plugins/graph/gvrelgraph.py:955
 msgid "The color to use to display families."
 msgstr "Die Farbe, die für die Anzeige von Familien verwendet wird."
 
@@ -24347,7 +24593,7 @@ msgid "The number of generations of ancestors to include in the graph"
 msgstr "Die Anzahl der Vorfahrengenerationen in der Grafik"
 
 #: ../gramps/plugins/graph/gvhourglass.py:389
-#: ../gramps/plugins/graph/gvrelgraph.py:819
+#: ../gramps/plugins/graph/gvrelgraph.py:821
 msgid ""
 "Males will be shown with blue, females with red.  If the sex of an "
 "individual is unknown it will be shown with gray."
@@ -24357,19 +24603,19 @@ msgstr ""
 
 #. see bug report #2180
 #: ../gramps/plugins/graph/gvhourglass.py:394
-#: ../gramps/plugins/graph/gvrelgraph.py:825
+#: ../gramps/plugins/graph/gvrelgraph.py:827
 msgid "Use rounded corners"
 msgstr "Abgerundete Ecken verwenden"
 
 #: ../gramps/plugins/graph/gvhourglass.py:396
-#: ../gramps/plugins/graph/gvrelgraph.py:826
+#: ../gramps/plugins/graph/gvrelgraph.py:828
 msgid "Use rounded corners to differentiate between women and men."
 msgstr ""
 "Benutze abgerundete Ecken, um zwischen Frauen und Männern zu unterscheiden."
 
 #. ###############################
 #: ../gramps/plugins/graph/gvhourglass.py:416
-#: ../gramps/plugins/graph/gvrelgraph.py:929
+#: ../gramps/plugins/graph/gvrelgraph.py:937
 msgid "Graph Style"
 msgstr "Diagrammstil"
 
@@ -24383,9 +24629,9 @@ msgid ""
 "that fathers are always on the left branch and mothers are on the right "
 "branch."
 msgstr ""
-"Erzwinge Sosa /Sosa-Stradonitz / Ahnentafel Layout Reihenfolge für alle"
-" Ahnen, so das Väter sich immer auf dem linken Zweig und Mütter auf dem"
-" rechten Zweig befinden."
+"Erzwinge Sosa /Sosa-Stradonitz / Ahnentafel Layout Reihenfolge für alle "
+"Ahnen, so das Väter sich immer auf dem linken Zweig und Mütter auf dem "
+"rechten Zweig befinden."
 
 #: ../gramps/plugins/graph/gvhourglass.py:441
 msgid "Ahnentafel number visible"
@@ -24396,80 +24642,90 @@ msgid ""
 "Show Sosa / Sosa-Stradonitz / Ahnentafel number under all others "
 "informations."
 msgstr ""
-"Zeige Sosa / Sosa-Stradonitz / Ahnentafelnummer unter allen anderen"
-" Informationen."
+"Zeige Sosa / Sosa-Stradonitz / Ahnentafelnummer unter allen anderen "
+"Informationen."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:206
+#: ../gramps/plugins/graph/gvrelgraph.py:208
 #: ../gramps/plugins/textreport/indivcomplete.py:834
 #: ../gramps/plugins/textreport/notelinkreport.py:103
 #: ../gramps/plugins/textreport/placereport.py:160
 msgid "Generating report"
 msgstr "Erstelle Bericht"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:801
+#: ../gramps/plugins/graph/gvrelgraph.py:803
 msgid "Determines what people are included in the graph"
 msgstr "Legt fest, welche Personen in der Grafik enthalten sind."
 
+#. see bug report #11112
+#: ../gramps/plugins/graph/gvrelgraph.py:833
+msgid "Use hexagons"
+msgstr "Verwende Sechsecke"
+
+#: ../gramps/plugins/graph/gvrelgraph.py:834
+msgid "Use hexagons to differentiate those of unknown gender."
+msgstr ""
+"Verwende Sechsecke um diese von unbekanntes Geschlecht zu unterscheiden."
+
 #. ###############################
-#: ../gramps/plugins/graph/gvrelgraph.py:854
+#: ../gramps/plugins/graph/gvrelgraph.py:862
 msgid "Dates and/or Places"
 msgstr "Daten und/oder Orte"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:855
+#: ../gramps/plugins/graph/gvrelgraph.py:863
 msgid "Do not include any dates or places"
 msgstr "Keine Daten oder Orte aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:856
+#: ../gramps/plugins/graph/gvrelgraph.py:864
 msgid "Include (birth, marriage, death) dates, but no places"
 msgstr "Geburts-, Hochzeits- und Sterbedaten aufnehmen, aber keine Orte"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:858
+#: ../gramps/plugins/graph/gvrelgraph.py:866
 msgid "Include (birth, marriage, death) dates, and places"
 msgstr "Geburts-, Hochzeits- und Sterbedaten und Orte aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:860
+#: ../gramps/plugins/graph/gvrelgraph.py:868
 msgid "Include (birth, marriage, death) dates, and places if no dates"
 msgstr ""
 "Geburts-, Hochzeits- und Sterbedaten aufnehmen und Orte wenn kein Datum "
 "vorhanden"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:862
+#: ../gramps/plugins/graph/gvrelgraph.py:870
 msgid "Include (birth, marriage, death) years, but no places"
 msgstr "Geburts-, Hochzeits- und Sterbejahre aber keine Orte aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:864
+#: ../gramps/plugins/graph/gvrelgraph.py:872
 msgid "Include (birth, marriage, death) years, and places"
 msgstr "Geburts-, Hochzeits- und Sterbejahre und Orte aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:866
+#: ../gramps/plugins/graph/gvrelgraph.py:874
 msgid "Include (birth, marriage, death) places, but no dates"
 msgstr "Geburts-, Hochzeits- und Sterbeorte aber keine Daten aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:868
+#: ../gramps/plugins/graph/gvrelgraph.py:876
 msgid "Include (birth, marriage, death) dates and places on same line"
 msgstr ""
 "(Geburts-, Hochzeits- und Sterbe)daten und Orte in der selben Zeile aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:871
+#: ../gramps/plugins/graph/gvrelgraph.py:879
 msgid "Whether to include dates and/or places"
 msgstr "Ob Daten und oder Orte enthalten sind."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:874
+#: ../gramps/plugins/graph/gvrelgraph.py:882
 msgid "Show all family nodes"
 msgstr "Zeige alle Familienknoten"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:875
+#: ../gramps/plugins/graph/gvrelgraph.py:883
 msgid ""
 "Show family nodes even if the output contains only one member of the family."
 msgstr ""
-"Zeige Familkienknoten sogar wenn die Ausgabe nur ein Mitglied der Familie"
-" enthält."
+"Zeige Familkienknoten sogar wenn die Ausgabe nur ein Mitglied der Familie "
+"enthält."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:879
+#: ../gramps/plugins/graph/gvrelgraph.py:887
 msgid "Include URLs"
 msgstr "URLs aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:880
+#: ../gramps/plugins/graph/gvrelgraph.py:888
 msgid ""
 "Include a URL in each graph node so that PDF and imagemap files can be "
 "generated that contain active links to the files generated by the 'Narrated "
@@ -24479,70 +24735,70 @@ msgstr ""
 "erzeugt werden können, die Links zu den mit \"Erzählende Website generieren"
 "\" erstellten Dateien enthalten."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:888
+#: ../gramps/plugins/graph/gvrelgraph.py:896
 #: ../gramps/plugins/textreport/birthdayreport.py:568
 #: ../gramps/plugins/textreport/indivcomplete.py:1145
 msgid "Include relationship to center person"
 msgstr "Mit Beziehungen zur Hauptperson"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:889
+#: ../gramps/plugins/graph/gvrelgraph.py:897
 msgid "Whether to show every person's relationship to the center person"
 msgstr "Ob die Beziehung jeder Person zur Hauptperson gezeigt wird."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:898
+#: ../gramps/plugins/graph/gvrelgraph.py:906
 msgid "Whether to include thumbnails of people."
 msgstr "Ob Miniaturbildern von Personen enthalten sein werden."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:902
+#: ../gramps/plugins/graph/gvrelgraph.py:910
 msgid "Thumbnail Location"
 msgstr "Miniaturbilder Position"
 
 #. occupation = BooleanOption(_("Include occupation"), False)
-#: ../gramps/plugins/graph/gvrelgraph.py:910
+#: ../gramps/plugins/graph/gvrelgraph.py:918
 msgid "Include occupation"
 msgstr "Beruf aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:911
+#: ../gramps/plugins/graph/gvrelgraph.py:919
 msgid "Do not include any occupation"
 msgstr "Keinen Beruf aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:912
+#: ../gramps/plugins/graph/gvrelgraph.py:920
 msgid "Include description of most recent occupation"
 msgstr "Beschreibung des aktuellsten Berufs aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:914
+#: ../gramps/plugins/graph/gvrelgraph.py:922
 msgid "Include date, description and place of all occupations"
 msgstr "Datum, Beschreibung und Ort aller Berufe aufnehmen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:916
+#: ../gramps/plugins/graph/gvrelgraph.py:924
 msgid "Whether to include the last occupation"
 msgstr "Ob der letzte Beruf aufgenommen wird"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:920
+#: ../gramps/plugins/graph/gvrelgraph.py:928
 msgid "Include relationship debugging numbers also"
 msgstr "Mit Beziehungen Fehlerprüfungnummern"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:923
+#: ../gramps/plugins/graph/gvrelgraph.py:931
 msgid ""
 "Whether to include 'Ga' and 'Gb' also, to debug the relationship calculator"
 msgstr ""
 "Ob zur Fehlerbehebung beim Beziehungsrechner auch 'Ga' und 'Gb' "
 "berücksichtigt werden."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:951
+#: ../gramps/plugins/graph/gvrelgraph.py:959
 msgid "Indicate non-birth relationships with dotted lines"
 msgstr "Nicht-leibliche Verwandtschaft durch gestrichelte Linie andeuten."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:952
+#: ../gramps/plugins/graph/gvrelgraph.py:960
 msgid "Non-birth relationships will show up as dotted lines in the graph."
 msgstr ""
 "Nicht-leibliche Verwandtschaft erscheint im Graph als gestrichelte Linie."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:956
+#: ../gramps/plugins/graph/gvrelgraph.py:964
 msgid "Show family nodes"
 msgstr "Familienknoten anzeigen"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:957
+#: ../gramps/plugins/graph/gvrelgraph.py:965
 msgid "Families will show up as ellipses, linked to parents and children."
 msgstr ""
 "Familien werden als Ellipsen, verbunden mit den Eltern und Kindern, gezeigt."
@@ -25210,6 +25466,8 @@ msgid ""
 "Citation attribute text\n"
 "(Text, import Filename & (System-)Date)."
 msgstr ""
+"Fundstellen Attribute Text\n"
+"(Text, Importdateiname & (System-)Datum)."
 
 #: ../gramps/plugins/importer/importprogen.glade:362
 msgid "Import Text"
@@ -25220,6 +25478,8 @@ msgid ""
 "Default Tagtext\n"
 "(out of Settings)."
 msgstr ""
+"Standard Markierungstext\n"
+"(aus den Einstellungen)"
 
 #: ../gramps/plugins/importer/importprogen.glade:443
 msgid "Import Filename."
@@ -25268,9 +25528,8 @@ msgid ""
 msgstr ""
 
 #: ../gramps/plugins/importer/importprogen.glade:1198
-#, fuzzy
 msgid "Tag Text"
-msgstr "Einfacher Text"
+msgstr "Markierung Text"
 
 #: ../gramps/plugins/importer/importprogen.glade:1217
 msgid "Import Objects"
@@ -25281,35 +25540,44 @@ msgid ""
 "Enable/Disable\n"
 "Person import."
 msgstr ""
+"Aktiviere/Deaktiviere\n"
+"Personenimport."
 
 #: ../gramps/plugins/importer/importprogen.glade:1260
 msgid ""
 "Enable/Disable\n"
 "Family import."
 msgstr ""
+"Aktiviere/Deaktiviere\n"
+"Familienimport."
 
 #: ../gramps/plugins/importer/importprogen.glade:1279
 msgid ""
 "Enable/Disable\n"
 "Child import."
 msgstr ""
+"Aktiviere/Deaktiviere\n"
+"Kinderimport."
 
 #: ../gramps/plugins/importer/importprogen.glade:1330
 msgid ""
 "Use original Person\n"
 "Identifier as Gramps ID."
 msgstr ""
+"Verwende original Personen\n"
+"Kennung als Gramps ID."
 
 #: ../gramps/plugins/importer/importprogen.glade:1349
 msgid ""
 "Use original Family\n"
 "Identifier as Gramps ID."
 msgstr ""
+"Verwende original Familien\n"
+"Kennung als Gramps ID."
 
 #: ../gramps/plugins/importer/importprogen.glade:1369
-#, fuzzy
 msgid "Identifier"
-msgstr "Umwandler"
+msgstr "Kennung"
 
 #: ../gramps/plugins/importer/importprogen.glade:1400
 msgid "Name change"
@@ -25320,18 +25588,20 @@ msgid "Event date"
 msgstr "Ereignisdatum"
 
 #: ../gramps/plugins/importer/importprogen.glade:1476
-#, fuzzy
 msgid ""
 "Store birth date in\n"
 "event description."
-msgstr "Ereignisbeschreibung extrahieren"
+msgstr ""
+"Speichere Geburtsdatum in\n"
+"Ereignisbeschreibung."
 
 #: ../gramps/plugins/importer/importprogen.glade:1495
-#, fuzzy
 msgid ""
 "Store death date in\n"
 "event description."
-msgstr "Ereignisbeschreibung extrahieren"
+msgstr ""
+"Speichere Sterbedatum in\n"
+"Ereignisbeschreibung."
 
 #: ../gramps/plugins/importer/importprogen.glade:1515
 msgid "Diverse"
@@ -25355,16 +25625,16 @@ msgid ""
 "Use death information\n"
 "as death cause event."
 msgstr ""
+"Verwende Todesinformationen\n"
+"als Todesursache Ereignis."
 
 #: ../gramps/plugins/importer/importprogen.glade:1598
-#, fuzzy
 msgid "(-cause)"
-msgstr "Ursache"
+msgstr "(-Ursache)"
 
 #: ../gramps/plugins/importer/importprogen.glade:1610
-#, fuzzy
 msgid "Male surname"
-msgstr "Nachnamen wählen"
+msgstr "Männlicher Nachname"
 
 #: ../gramps/plugins/importer/importprogen.glade:1614
 msgid ""
@@ -25373,9 +25643,8 @@ msgid ""
 msgstr ""
 
 #: ../gramps/plugins/importer/importprogen.glade:1629
-#, fuzzy
 msgid "Female surname"
-msgstr "Nachnamen wählen"
+msgstr "Weiblicher Nachname"
 
 #: ../gramps/plugins/importer/importprogen.glade:1633
 msgid ""
@@ -25856,7 +26125,7 @@ msgid "Common Law Marriage"
 msgstr "Eheähnliche Gemeinschaft "
 
 #: ../gramps/plugins/lib/libgedcom.py:699
-#: ../gramps/plugins/webreport/narrativeweb.py:1625
+#: ../gramps/plugins/webreport/narrativeweb.py:1626
 #: ../gramps/plugins/webreport/webcal.py:1661
 msgid "Destination"
 msgstr "Ziel"
@@ -29674,6 +29943,172 @@ msgstr "Ausgewählte Person löschen"
 msgid "Merge the selected persons"
 msgstr "Gewählte Personen zusammenfassen"
 
+#: ../gramps/plugins/lib/libpersonview.py:186
+#: ../gramps/plugins/lib/libplaceview.py:269
+#: ../gramps/plugins/view/citationlistview.py:161
+#: ../gramps/plugins/view/citationtreeview.py:303
+#: ../gramps/plugins/view/eventview.py:175
+#: ../gramps/plugins/view/familyview.py:134
+#: ../gramps/plugins/view/mediaview.py:234
+#: ../gramps/plugins/view/noteview.py:134
+#: ../gramps/plugins/view/repoview.py:147
+#: ../gramps/plugins/view/sourceview.py:133
+msgid "Export View..."
+msgstr "Ansicht exportieren..."
+
+#: ../gramps/plugins/lib/libpersonview.py:194
+#: ../gramps/plugins/lib/libplaceview.py:277
+#: ../gramps/plugins/view/citationlistview.py:169
+#: ../gramps/plugins/view/citationtreeview.py:311
+#: ../gramps/plugins/view/eventview.py:183
+#: ../gramps/plugins/view/familyview.py:142
+#: ../gramps/plugins/view/fanchartview.py:172
+#: ../gramps/plugins/view/geoclose.py:99 ../gramps/plugins/view/geoevents.py:89
+#: ../gramps/plugins/view/geofamclose.py:97
+#: ../gramps/plugins/view/geofamily.py:89 ../gramps/plugins/view/geomoves.py:96
+#: ../gramps/plugins/view/geoperson.py:97
+#: ../gramps/plugins/view/geoplaces.py:92
+#: ../gramps/plugins/view/mediaview.py:242
+#: ../gramps/plugins/view/noteview.py:142
+#: ../gramps/plugins/view/pedigreeview.py:672
+#: ../gramps/plugins/view/relview.py:364 ../gramps/plugins/view/relview.py:416
+#: ../gramps/plugins/view/repoview.py:155
+#: ../gramps/plugins/view/sourceview.py:141
+msgid "_Add Bookmark"
+msgstr "Lesezeichen _hinzufügen"
+
+#: ../gramps/plugins/lib/libpersonview.py:206
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:289
+#: ../gramps/plugins/lib/libplaceview.py:332
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:181
+#: ../gramps/plugins/view/citationlistview.py:224
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:323
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:195
+#: ../gramps/plugins/view/eventview.py:238
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:154
+#: ../gramps/plugins/view/familyview.py:197
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/fanchartview.py:144
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:71 ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoevents.py:67
+#: ../gramps/plugins/view/geoevents.py:101
+#: ../gramps/plugins/view/geofamclose.py:69
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geofamily.py:67
+#: ../gramps/plugins/view/geofamily.py:101
+#: ../gramps/plugins/view/geomoves.py:68 ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:69
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/geoplaces.py:70
+#: ../gramps/plugins/view/geoplaces.py:104
+#: ../gramps/plugins/view/mediaview.py:254
+#: ../gramps/plugins/view/mediaview.py:297
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:154
+#: ../gramps/plugins/view/noteview.py:197
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/pedigreeview.py:652
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428 ../gramps/plugins/view/repoview.py:167
+#: ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:153
+#: ../gramps/plugins/view/sourceview.py:196
+#: ../gramps/plugins/view/sourceview.py:278
+msgid "_Back"
+msgstr "_Zurück"
+
+#: ../gramps/plugins/lib/libpersonview.py:206
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/view/fanchartview.py:144
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:71 ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geofamclose.py:69
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geomoves.py:68 ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:69
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/pedigreeview.py:652
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/pedigreeview.py:1647
+#: ../gramps/plugins/view/relview.py:364 ../gramps/plugins/view/relview.py:428
+msgid "_Home"
+msgstr "_Anfang"
+
+#: ../gramps/plugins/lib/libpersonview.py:226
+#: ../gramps/plugins/lib/libpersonview.py:303
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:303
+#: ../gramps/plugins/lib/libplaceview.py:362
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:195
+#: ../gramps/plugins/view/citationlistview.py:254
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:209
+#: ../gramps/plugins/view/eventview.py:268
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:168
+#: ../gramps/plugins/view/familyview.py:227
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/mediaview.py:268
+#: ../gramps/plugins/view/mediaview.py:327
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:168
+#: ../gramps/plugins/view/noteview.py:227
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/repoview.py:181
+#: ../gramps/plugins/view/repoview.py:240
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:167
+#: ../gramps/plugins/view/sourceview.py:226
+#: ../gramps/plugins/view/sourceview.py:278
+msgid "_Add..."
+msgstr "_Hinzufügen..."
+
+#: ../gramps/plugins/lib/libpersonview.py:226
+#: ../gramps/plugins/lib/libpersonview.py:303
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:303
+#: ../gramps/plugins/lib/libplaceview.py:362
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:195
+#: ../gramps/plugins/view/citationlistview.py:254
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:209
+#: ../gramps/plugins/view/eventview.py:268
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:168
+#: ../gramps/plugins/view/familyview.py:227
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/mediaview.py:268
+#: ../gramps/plugins/view/mediaview.py:327
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:168
+#: ../gramps/plugins/view/noteview.py:227
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/repoview.py:181
+#: ../gramps/plugins/view/repoview.py:240
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:167
+#: ../gramps/plugins/view/sourceview.py:226
+#: ../gramps/plugins/view/sourceview.py:278
+msgid "_Merge..."
+msgstr "_Zusammenfassen..."
+
 #: ../gramps/plugins/lib/libpersonview.py:245
 #: ../gramps/plugins/lib/libpersonview.py:403
 #: ../gramps/plugins/lib/libplaceview.py:322
@@ -29696,6 +30131,99 @@ msgstr "Gewählte Personen zusammenfassen"
 #: ../gramps/plugins/view/sourceview.py:315
 msgid "action|_Edit..."
 msgstr "_Bearbeiten..."
+
+#: ../gramps/plugins/lib/libpersonview.py:246
+#: ../gramps/plugins/view/pedigreeview.py:684
+#: ../gramps/plugins/view/relview.py:385
+msgid "Person Filter Editor"
+msgstr "Filtereditor für Personen"
+
+#: ../gramps/plugins/lib/libpersonview.py:246
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/view/pedigreeview.py:1657
+msgid "Set _Home Person"
+msgstr "Hauptperson _setzen"
+
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428
+msgid "Go to the default person"
+msgstr "Springe zur Hauptperson"
+
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libplaceview.py:332
+#: ../gramps/plugins/view/citationlistview.py:224
+#: ../gramps/plugins/view/citationtreeview.py:374
+#: ../gramps/plugins/view/eventview.py:238
+#: ../gramps/plugins/view/familyview.py:197
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoevents.py:101
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geofamily.py:101
+#: ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/geoplaces.py:104
+#: ../gramps/plugins/view/mediaview.py:297
+#: ../gramps/plugins/view/noteview.py:197
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428 ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/sourceview.py:196
+msgid "Go to the next object in the history"
+msgstr "Gehe zum nächsten Objekt in der Chronik."
+
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libplaceview.py:332
+#: ../gramps/plugins/view/citationlistview.py:224
+#: ../gramps/plugins/view/citationtreeview.py:374
+#: ../gramps/plugins/view/eventview.py:238
+#: ../gramps/plugins/view/familyview.py:197
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoevents.py:101
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geofamily.py:101
+#: ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/geoplaces.py:104
+#: ../gramps/plugins/view/mediaview.py:297
+#: ../gramps/plugins/view/noteview.py:197
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428 ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/sourceview.py:196
+msgid "Go to the previous object in the history"
+msgstr "Gehe zum vorherigen Objekt in der Chronik."
+
+#: ../gramps/plugins/lib/libpersonview.py:303
+#: ../gramps/plugins/lib/libplaceview.py:362
+#: ../gramps/plugins/view/citationlistview.py:254
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/eventview.py:268
+#: ../gramps/plugins/view/familyview.py:227
+#: ../gramps/plugins/view/mediaview.py:327
+#: ../gramps/plugins/view/noteview.py:227 ../gramps/plugins/view/relview.py:385
+#: ../gramps/plugins/view/relview.py:471 ../gramps/plugins/view/repoview.py:240
+#: ../gramps/plugins/view/sourceview.py:226
+msgid "Edit..."
+msgstr "Bearbeiten..."
+
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:278
+msgid "Forward"
+msgstr "Weiter"
 
 #: ../gramps/plugins/lib/libpersonview.py:454
 msgid "_Delete Person"
@@ -29751,6 +30279,26 @@ msgid ""
 msgstr ""
 "Du musst einen Ort auswählen, um ihn auf der Karte darstellen zu können. "
 "Einige Karten Services unterstützen auch eine mehrfache Ortsauswahl."
+
+#: ../gramps/plugins/lib/libplaceview.py:323
+msgid "Place Filter Editor"
+msgstr "Ortsfiltereditor"
+
+#: ../gramps/plugins/lib/libplaceview.py:415
+msgid "_Look up with Map Service"
+msgstr "_Nachschlagen mit Kartenservice"
+
+#: ../gramps/plugins/lib/libplaceview.py:466
+msgid ""
+"Attempt to see selected locations with a Map Service (OpenstreetMap, Google "
+"Maps, ...)"
+msgstr ""
+"Versuche, ausgewählte Orte mit einem Kartenservice zu zeigen (OpenstreetMap, "
+"Google Maps, ...)."
+
+#: ../gramps/plugins/lib/libplaceview.py:466
+msgid "Select a Map Service"
+msgstr "Einen Kartenservice wählen"
 
 #: ../gramps/plugins/lib/libplaceview.py:506
 msgid "Cannot delete place."
@@ -29835,9 +30383,8 @@ msgid "Provides the Base needed for the List People views."
 msgstr "Liefert die Basis, die für die Listenpersonenansicht benötigt wird."
 
 #: ../gramps/plugins/lib/libplugins.gpr.py:247
-#, fuzzy
 msgid "Provides common functionality for Pro-Gen import"
-msgstr "Liefert gemeinsame Funktionalität für Gramps-XML Import/Export."
+msgstr "Liefert gemeinsame Funktionalität für Pro-Gen Import"
 
 #: ../gramps/plugins/lib/libplugins.gpr.py:265
 msgid "Provides the Base needed for the List Place views."
@@ -29934,7 +30481,7 @@ msgstr "Hochzeit"
 
 #: ../gramps/plugins/lib/libprogen.py:1829
 msgid "future"
-msgstr ""
+msgstr "Zukunft"
 
 #. We have seen some case insensitivity in DEF files ...
 #. F13: Father
@@ -29947,11 +30494,12 @@ msgstr "Kinder hinzufügen."
 #: ../gramps/plugins/lib/libprogen.py:1927
 #, fuzzy
 msgid "Cannot find father for I%(person)s (Father=%(father))"
-msgstr "Kann den Vater für I%(person)s (Father=%(id)d) nicht finden"
+msgstr "Kann den Vater für I%(person)s (Vater=%(father)) nicht finden"
 
 #: ../gramps/plugins/lib/libprogen.py:1930
+#, fuzzy
 msgid "Cannot find mother for I%(person)s (Mother=%(mother))"
-msgstr ""
+msgstr "Kann die Mutter für I%(person)s (Mutter=%(mother)) nicht finden"
 
 #: ../gramps/plugins/lib/librecords.py:55
 msgid "Youngest living person"
@@ -30133,8 +30681,8 @@ msgstr "Deine Gtk Version ist zu alt."
 #: ../gramps/plugins/view/geoperson.py:508
 #: ../gramps/plugins/view/geoperson.py:529
 #: ../gramps/plugins/view/geoperson.py:569
-#: ../gramps/plugins/view/geoplaces.py:499
-#: ../gramps/plugins/view/geoplaces.py:524
+#: ../gramps/plugins/view/geoplaces.py:501
+#: ../gramps/plugins/view/geoplaces.py:526
 msgid "Center on this place"
 msgstr "Auf diesen Ort zentrieren"
 
@@ -30334,7 +30882,7 @@ msgid "Open on maps.google.com"
 msgstr "Öffnen auf maps.google.com"
 
 #: ../gramps/plugins/mapservices/mapservice.gpr.py:71
-#: ../gramps/plugins/webreport/narrativeweb.py:2036
+#: ../gramps/plugins/webreport/narrativeweb.py:2037
 msgid "OpenStreetMap"
 msgstr "OpenStreetMap"
 
@@ -30474,6 +31022,7 @@ msgid "Parent"
 msgstr "Elter"
 
 #: ../gramps/plugins/quickview/all_relations.py:286
+#: ../gramps/plugins/view/relview.py:471
 #: ../gramps/plugins/webreport/basepage.py:2368
 #: ../gramps/plugins/webreport/basepage.py:2370
 #: ../gramps/plugins/webreport/person.py:227
@@ -34562,8 +35111,8 @@ msgid ""
 "Searches the entire database, looking for trailing or leading spaces for "
 "places and people. Search comma in coordinates fields in places."
 msgstr ""
-"Durchsucht die gesamte Datenbank nach angehängten oder führenden Leerzeichen"
-" bei Orten und Personen. Suche Kommas in Koordinatenfeldern von Orten."
+"Durchsucht die gesamte Datenbank nach angehängten oder führenden Leerzeichen "
+"bei Orten und Personen. Suche Kommas in Koordinatenfeldern von Orten."
 
 #: ../gramps/plugins/tool/toolsdebug.gpr.py:64
 msgid "Dump Gender Statistics"
@@ -34872,6 +35421,11 @@ msgstr "Gewählte Fundstellen zusammenfassen"
 msgid "Citation View"
 msgstr "Fundstellenansicht"
 
+#: ../gramps/plugins/view/citationlistview.py:215
+#: ../gramps/plugins/view/citationtreeview.py:365
+msgid "Citation Filter Editor"
+msgstr "Filtereditor für Fundstellen"
+
 #: ../gramps/plugins/view/citationlistview.py:395
 msgid ""
 "This citation cannot be edited at this time. Either the associated citation "
@@ -34930,6 +35484,29 @@ msgstr "Die gewählten Fundstellen oder Quellen zusammenfassen"
 msgid "Citation Tree View"
 msgstr "Fundstellenbaumansicht"
 
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/citationtreeview.py:475
+msgid "Add citation..."
+msgstr "Fundstelle hinzufügen..."
+
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+msgid "Add source..."
+msgstr "Quelle hinzufügen..."
+
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/persontreeview.py:87
+#: ../gramps/plugins/view/placetreeview.py:77
+msgid "Collapse all Nodes"
+msgstr "Alle Knoten schließen"
+
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/persontreeview.py:87
+#: ../gramps/plugins/view/placetreeview.py:77
+msgid "Expand all Nodes"
+msgstr "Alle Knoten aufklappen"
+
 #: ../gramps/plugins/view/citationtreeview.py:651
 msgid ""
 "This source cannot be edited at this time. Either the associated Source "
@@ -34978,6 +35555,10 @@ msgstr "Gewähltes Ereignis löschen"
 msgid "Merge the selected events"
 msgstr "Die gewählten Ereignisse zusammenfassen"
 
+#: ../gramps/plugins/view/eventview.py:229
+msgid "Event Filter Editor"
+msgstr "Filtereditor für Ereignisse"
+
 #: ../gramps/plugins/view/eventview.py:385
 msgid "_Delete Event"
 msgstr "Ereignis _löschen"
@@ -35021,6 +35602,18 @@ msgstr "Gewählte Familie löschen"
 msgid "Merge the selected families"
 msgstr "Die gewählten Familien zusammenfassen"
 
+#: ../gramps/plugins/view/familyview.py:188
+msgid "Family Filter Editor"
+msgstr "Familienfiltereditor"
+
+#: ../gramps/plugins/view/familyview.py:279
+msgid "Make Father Active Person"
+msgstr "Vater als aktive Person setzen"
+
+#: ../gramps/plugins/view/familyview.py:279
+msgid "Make Mother Active Person"
+msgstr "Mutter als aktive Person setzen"
+
 #: ../gramps/plugins/view/familyview.py:372
 msgid "_Delete Family"
 msgstr "Familie _löschen"
@@ -35044,166 +35637,219 @@ msgstr ""
 "durchzuführen. Eine zweite Familie kann durch Anklicken bei gehaltener Strg-"
 "Taste gewählt werden."
 
-#: ../gramps/plugins/view/fanchart2wayview.py:263
+#: ../gramps/plugins/view/fanchart2wayview.py:280
 msgid "Max ancestor generations"
 msgstr "Max. Vorfahrengenerationen"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:266
+#: ../gramps/plugins/view/fanchart2wayview.py:283
 msgid "Max descendant generations"
 msgstr "Max. Nachkommengenerationen"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:270
-#: ../gramps/plugins/view/fanchartdescview.py:267
-#: ../gramps/plugins/view/fanchartview.py:364
+#: ../gramps/plugins/view/fanchart2wayview.py:286
+#: ../gramps/plugins/view/fanchartdescview.py:283
+#: ../gramps/plugins/view/fanchartview.py:381
 msgid "Text Font"
 msgstr "Text Schrift"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:274
-#: ../gramps/plugins/view/fanchartdescview.py:271
-#: ../gramps/plugins/view/fanchartview.py:368
+#: ../gramps/plugins/view/fanchart2wayview.py:291
+#: ../gramps/plugins/view/fanchartdescview.py:288
+#: ../gramps/plugins/view/fanchartview.py:386
 msgid "Gender colors"
 msgstr "Geschlechtsfarben"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:275
-#: ../gramps/plugins/view/fanchartdescview.py:272
-#: ../gramps/plugins/view/fanchartview.py:369
+#: ../gramps/plugins/view/fanchart2wayview.py:292
+#: ../gramps/plugins/view/fanchartdescview.py:289
+#: ../gramps/plugins/view/fanchartview.py:387
 msgid "Generation based gradient"
 msgstr "Auf Generationen basierender Farbverlauf"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:276
-#: ../gramps/plugins/view/fanchartdescview.py:273
-#: ../gramps/plugins/view/fanchartview.py:370
+#: ../gramps/plugins/view/fanchart2wayview.py:293
+#: ../gramps/plugins/view/fanchartdescview.py:290
+#: ../gramps/plugins/view/fanchartview.py:388
 msgid "Age (0-100) based gradient"
 msgstr "Auf Alter (0-100) basierender Farbverlauf"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:278
-#: ../gramps/plugins/view/fanchartdescview.py:275
-#: ../gramps/plugins/view/fanchartview.py:372
+#: ../gramps/plugins/view/fanchart2wayview.py:294
+#: ../gramps/plugins/view/fanchartdescview.py:292
+#: ../gramps/plugins/view/fanchartview.py:389
 msgid "Single main (filter) color"
 msgstr "Einzelne Haupt(filter)farbe"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:279
-#: ../gramps/plugins/view/fanchartdescview.py:276
-#: ../gramps/plugins/view/fanchartview.py:373
+#: ../gramps/plugins/view/fanchart2wayview.py:295
+#: ../gramps/plugins/view/fanchartdescview.py:293
+#: ../gramps/plugins/view/fanchartview.py:390
 msgid "Time period based gradient"
 msgstr "Auf Zeitraum basierender Farbverlauf"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:280
-#: ../gramps/plugins/view/fanchartdescview.py:277
-#: ../gramps/plugins/view/fanchartview.py:374
+#: ../gramps/plugins/view/fanchart2wayview.py:296
+#: ../gramps/plugins/view/fanchartdescview.py:294
+#: ../gramps/plugins/view/fanchartview.py:391
 msgid "White"
 msgstr "Weiß"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:281
-#: ../gramps/plugins/view/fanchartdescview.py:278
-#: ../gramps/plugins/view/fanchartview.py:375
+#: ../gramps/plugins/view/fanchart2wayview.py:297
+#: ../gramps/plugins/view/fanchartdescview.py:295
+#: ../gramps/plugins/view/fanchartview.py:392
 msgid "Color scheme classic report"
 msgstr "Farbschema klassischer Bericht"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:282
-#: ../gramps/plugins/view/fanchartdescview.py:279
-#: ../gramps/plugins/view/fanchartview.py:376
+#: ../gramps/plugins/view/fanchart2wayview.py:298
+#: ../gramps/plugins/view/fanchartdescview.py:296
+#: ../gramps/plugins/view/fanchartview.py:393
 msgid "Color scheme classic view"
 msgstr "Farbschema klassische Ansicht"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:291
-#: ../gramps/plugins/view/fanchartdescview.py:288
-#: ../gramps/plugins/view/fanchartview.py:385
+#: ../gramps/plugins/view/fanchart2wayview.py:306
+#: ../gramps/plugins/view/fanchartdescview.py:304
+#: ../gramps/plugins/view/fanchartview.py:401
 msgid "Background"
 msgstr "Hintergrund"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:300
+#: ../gramps/plugins/view/fanchart2wayview.py:313
 msgid "Add global background colored gradient"
 msgstr "Allgemeinen Farbverlauf Hintergrund hinzufügen"
 
 #. colors, stored as hex values
-#: ../gramps/plugins/view/fanchart2wayview.py:304
-#: ../gramps/plugins/view/fanchartdescview.py:295
-#: ../gramps/plugins/view/fanchartview.py:391
+#: ../gramps/plugins/view/fanchart2wayview.py:317
+#: ../gramps/plugins/view/fanchartdescview.py:309
+#: ../gramps/plugins/view/fanchartview.py:406
 msgid "Start gradient/Main color"
 msgstr "Start Farbverlauf/Hauptfarbe"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:306
-#: ../gramps/plugins/view/fanchartdescview.py:297
-#: ../gramps/plugins/view/fanchartview.py:393
+#: ../gramps/plugins/view/fanchart2wayview.py:319
+#: ../gramps/plugins/view/fanchartdescview.py:311
+#: ../gramps/plugins/view/fanchartview.py:408
 msgid "End gradient/2nd color"
 msgstr "Ende Farbverlauf/2. Farbe"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:308
-#: ../gramps/plugins/view/fanchartdescview.py:299
+#: ../gramps/plugins/view/fanchart2wayview.py:321
+#: ../gramps/plugins/view/fanchartdescview.py:313
 msgid "Color for duplicates"
 msgstr "Farbe für Duplikate"
 
 #. algo for the fan angle distribution
-#: ../gramps/plugins/view/fanchart2wayview.py:311
-#: ../gramps/plugins/view/fanchartdescview.py:309
+#: ../gramps/plugins/view/fanchart2wayview.py:324
+#: ../gramps/plugins/view/fanchartdescview.py:323
 msgid "Fan chart distribution"
 msgstr "Fächergrafik Verteilung"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:314
-#: ../gramps/plugins/view/fanchartdescview.py:312
+#: ../gramps/plugins/view/fanchart2wayview.py:327
+#: ../gramps/plugins/view/fanchartdescview.py:326
 msgid "Homogeneous children distribution"
 msgstr "Einheitliche Kinderaufteilung"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:316
-#: ../gramps/plugins/view/fanchartdescview.py:314
-msgid "Size  proportional to number of descendants"
+#: ../gramps/plugins/view/fanchart2wayview.py:329
+#: ../gramps/plugins/view/fanchartdescview.py:328
+msgid "Size proportional to number of descendants"
 msgstr "Größe proportional zur Anzahl der Nachkommen"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:322
-#: ../gramps/plugins/view/fanchartdescview.py:320
-#: ../gramps/plugins/view/fanchartview.py:404
+#. show names one two line
+#: ../gramps/plugins/view/fanchart2wayview.py:335
+#: ../gramps/plugins/view/fanchartdescview.py:334
+#: ../gramps/plugins/view/fanchartview.py:418
 msgid "Show names on two lines"
 msgstr "Zeige Namen in zwei Zeilen"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:327
-#: ../gramps/plugins/view/fanchartdescview.py:325
-#: ../gramps/plugins/view/fanchartview.py:409
+#. Flip names
+#: ../gramps/plugins/view/fanchart2wayview.py:339
+#: ../gramps/plugins/view/fanchartdescview.py:338
+#: ../gramps/plugins/view/fanchartview.py:422
 msgid "Flip name on the left of the fan"
 msgstr "Kippe Namen links im Fächer"
+
+#. Show gramps id
+#: ../gramps/plugins/view/fanchart2wayview.py:343
+msgid "Show the gramps id"
+msgstr "Zeigt die Gramps ID"
 
 #. options we don't show on the dialog
 #. #configdialog.add_checkbox(table,
 #. #        _('Allow radial text'),
 #. #        ??, 'interface.fanview-radialtext')
-#: ../gramps/plugins/view/fanchart2wayview.py:330
-#: ../gramps/plugins/view/fanchartdescview.py:328
-#: ../gramps/plugins/view/fanchartview.py:421
-#: ../gramps/plugins/view/pedigreeview.py:2134
+#: ../gramps/plugins/view/fanchart2wayview.py:346
+#: ../gramps/plugins/view/fanchartdescview.py:345
+#: ../gramps/plugins/view/fanchartview.py:437
+#: ../gramps/plugins/view/pedigreeview.py:2128
 #: ../gramps/plugins/view/relview.py:1857
 msgid "Layout"
 msgstr "Layout"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:529
-#: ../gramps/plugins/view/fanchartdescview.py:517
-#: ../gramps/plugins/view/fanchartview.py:625
+#: ../gramps/plugins/view/fanchart2wayview.py:580
+#: ../gramps/plugins/view/fanchartdescview.py:568
+#: ../gramps/plugins/view/fanchartview.py:666
 msgid "No preview available"
 msgstr "Keine Vorschau verfügbar."
 
 #. form of the fan
-#: ../gramps/plugins/view/fanchartdescview.py:302
-#: ../gramps/plugins/view/fanchartview.py:396
+#: ../gramps/plugins/view/fanchartdescview.py:316
+#: ../gramps/plugins/view/fanchartview.py:411
 msgid "Fan chart type"
 msgstr "Fächergrafikart"
 
-#: ../gramps/plugins/view/fanchartdescview.py:304
-#: ../gramps/plugins/view/fanchartview.py:398
+#: ../gramps/plugins/view/fanchartdescview.py:318
+#: ../gramps/plugins/view/fanchartview.py:413
 msgid "Full Circle"
 msgstr "Vollkreis"
 
-#: ../gramps/plugins/view/fanchartdescview.py:305
-#: ../gramps/plugins/view/fanchartview.py:398
+#: ../gramps/plugins/view/fanchartdescview.py:319
+#: ../gramps/plugins/view/fanchartview.py:413
 msgid "Half Circle"
 msgstr "Halbkreis"
 
-#: ../gramps/plugins/view/fanchartdescview.py:306
-#: ../gramps/plugins/view/fanchartview.py:399
+#: ../gramps/plugins/view/fanchartdescview.py:320
+#: ../gramps/plugins/view/fanchartview.py:414
 msgid "Quadrant"
 msgstr "Viertelkreis"
 
-#: ../gramps/plugins/view/fanchartview.py:414
+#. show gramps_id
+#. Show the gramps_id
+#: ../gramps/plugins/view/fanchartdescview.py:342
+#: ../gramps/plugins/view/fanchartview.py:430
+msgid "Show gramps id"
+msgstr "Zeige Gramps ID"
+
+#: ../gramps/plugins/view/fanchartview.py:164
+#: ../gramps/plugins/view/fanchartview.py:227
+#: ../gramps/plugins/view/geoclose.py:91 ../gramps/plugins/view/geoclose.py:167
+#: ../gramps/plugins/view/geoevents.py:81
+#: ../gramps/plugins/view/geoevents.py:129
+#: ../gramps/plugins/view/geofamclose.py:89
+#: ../gramps/plugins/view/geofamclose.py:165
+#: ../gramps/plugins/view/geofamily.py:81
+#: ../gramps/plugins/view/geofamily.py:131
+#: ../gramps/plugins/view/geomoves.py:88 ../gramps/plugins/view/geomoves.py:151
+#: ../gramps/plugins/view/geoperson.py:89
+#: ../gramps/plugins/view/geoplaces.py:84
+#: ../gramps/plugins/view/geoplaces.py:134
+msgid "_Print..."
+msgstr "_Drucken..."
+
+#: ../gramps/plugins/view/fanchartview.py:227
+msgid "Print or save the Fan Chart View"
+msgstr "Drucke oder speichere die Fächergrafikansicht"
+
+#. options users should not change:
+#: ../gramps/plugins/view/fanchartview.py:426
 msgid "Show children ring"
 msgstr "Kinderring zeigen"
+
+#: ../gramps/plugins/view/geoclose.py:111
+msgid "Select the person which is the reference for life ways"
+msgstr "Wähle die Referenzperson für Lebenswege"
+
+#: ../gramps/plugins/view/geoclose.py:111
+msgid "reference _Person"
+msgstr "Referenz _Person"
+
+#: ../gramps/plugins/view/geoclose.py:167
+#: ../gramps/plugins/view/geoevents.py:129
+#: ../gramps/plugins/view/geofamclose.py:165
+#: ../gramps/plugins/view/geofamily.py:131
+#: ../gramps/plugins/view/geomoves.py:151
+#: ../gramps/plugins/view/geoperson.py:152
+#: ../gramps/plugins/view/geoplaces.py:134
+msgid "Print or save the Map"
+msgstr "Die Karte drucken oder speichern"
 
 #: ../gramps/plugins/view/geoclose.py:220
 #: ../gramps/plugins/view/geography.gpr.py:160
@@ -35301,10 +35947,9 @@ msgid ""
 "with coordinates. You can use the history to navigate on the map. You can "
 "use filtering."
 msgstr ""
-"Klicke rechts auf die Karte und wähle 'zeige alle Ereignisse', um alle"
-" bekannten "
-"Ereignisse mit Koordinaten zu zeigen. Du kannst den Verlauf verwenden um auf"
-" der Karte zu navigieren. Du kannst Filter verwenden."
+"Klicke rechts auf die Karte und wähle 'zeige alle Ereignisse', um alle "
+"bekannten Ereignisse mit Koordinaten zu zeigen. Du kannst den Verlauf "
+"verwenden um auf der Karte zu navigieren. Du kannst Filter verwenden."
 
 #: ../gramps/plugins/view/geoevents.py:408
 #: ../gramps/plugins/view/geoevents.py:440
@@ -35317,10 +35962,19 @@ msgstr "Zeigt alle Ereignisse"
 
 #: ../gramps/plugins/view/geoevents.py:459
 #: ../gramps/plugins/view/geoevents.py:464
-#: ../gramps/plugins/view/geoplaces.py:549
-#: ../gramps/plugins/view/geoplaces.py:554
+#: ../gramps/plugins/view/geoplaces.py:551
+#: ../gramps/plugins/view/geoplaces.py:556
 msgid "Centering on Place"
 msgstr "Auf Ort zentrieren"
+
+#: ../gramps/plugins/view/geofamclose.py:109
+msgid "Select the family which is the reference for life ways"
+msgstr "Wähle die Familie für die Referenz für Lebenswege"
+
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geoperson.py:152
+msgid "reference _Family"
+msgstr "Referenz_familie"
 
 #: ../gramps/plugins/view/geofamclose.py:220
 #: ../gramps/plugins/view/geography.gpr.py:142
@@ -35613,7 +36267,7 @@ msgstr ""
 "Orte mit Koordinaten zu zeigen. Du kannst die Markierungsfarbe abhängig vom "
 "Ortstyp ändern. Du kannst Filter verwenden."
 
-#: ../gramps/plugins/view/geoplaces.py:445
+#: ../gramps/plugins/view/geoplaces.py:447
 msgid ""
 "Right click on the map and select 'show all places' to show all known places "
 "with coordinates. You can use the history to navigate on the map. You can "
@@ -35624,45 +36278,45 @@ msgstr ""
 "Karte zu navigieren. Du kannst die Markierungsfarbe abhängig vom Ortstyp "
 "ändern. Du kannst Filter verwenden."
 
-#: ../gramps/plugins/view/geoplaces.py:460
+#: ../gramps/plugins/view/geoplaces.py:462
 msgid "The place name in the status bar is disabled."
 msgstr "Der Ortename in der Statusleiste ist deaktiviert."
 
-#: ../gramps/plugins/view/geoplaces.py:465
+#: ../gramps/plugins/view/geoplaces.py:467
 #, python-format
 msgid "The maximum number of places is reached (%d)."
 msgstr "Maximale Anzahl der Orte (%d) ist erreicht."
 
-#: ../gramps/plugins/view/geoplaces.py:468
+#: ../gramps/plugins/view/geoplaces.py:470
 msgid "Some information are missing."
 msgstr "Einige Informationen fehlen."
 
-#: ../gramps/plugins/view/geoplaces.py:470
+#: ../gramps/plugins/view/geoplaces.py:472
 msgid "Please, use filtering to reduce this number."
 msgstr "Bitte verwende Filter, um die Anzahl zu reduzieren."
 
-#: ../gramps/plugins/view/geoplaces.py:472
+#: ../gramps/plugins/view/geoplaces.py:474
 msgid "You can modify this value in the geography option."
 msgstr "Du kannst diesen Wert in den Geografieoptionen ändern."
 
-#: ../gramps/plugins/view/geoplaces.py:474
+#: ../gramps/plugins/view/geoplaces.py:476
 msgid "In this case, it may take time to show all markers."
 msgstr "In diesem Fall kann es etwas dauern, alle Markierungen anzuzeigen."
 
-#: ../gramps/plugins/view/geoplaces.py:506
-#: ../gramps/plugins/view/geoplaces.py:530
+#: ../gramps/plugins/view/geoplaces.py:508
+#: ../gramps/plugins/view/geoplaces.py:532
 msgid "Bookmark this place"
 msgstr "Ein Lesezeichen für diesen Ort erstellen"
 
-#: ../gramps/plugins/view/geoplaces.py:545
+#: ../gramps/plugins/view/geoplaces.py:547
 msgid "Show all places"
 msgstr "Alle Orte zeigen"
 
-#: ../gramps/plugins/view/geoplaces.py:657
+#: ../gramps/plugins/view/geoplaces.py:659
 msgid "Custom places name"
 msgstr "Benutzerdefinierter Ortsname"
 
-#: ../gramps/plugins/view/geoplaces.py:666
+#: ../gramps/plugins/view/geoplaces.py:668
 msgid "The places marker color"
 msgstr "Die Ortemakierungsfarbe"
 
@@ -35677,6 +36331,14 @@ msgstr "Das ausgewählte Medienobjekt löschen"
 #: ../gramps/plugins/view/mediaview.py:115
 msgid "Merge the selected media objects"
 msgstr "Die ausgewählten Medienobjekte zusammenfassen"
+
+#: ../gramps/plugins/view/mediaview.py:288
+msgid "Media Filter Editor"
+msgstr "Filtereditor für Medienobjekte"
+
+#: ../gramps/plugins/view/mediaview.py:379
+msgid "View in the default viewer"
+msgstr "Im voreingestellten Programm anzeigen"
 
 #: ../gramps/plugins/view/mediaview.py:483
 msgid "Cannot merge media objects."
@@ -35699,6 +36361,10 @@ msgstr "Gewählte Notiz löschen"
 #: ../gramps/plugins/view/noteview.py:96
 msgid "Merge the selected notes"
 msgstr "Die gewählten Notizen zusammenfassen"
+
+#: ../gramps/plugins/view/noteview.py:188
+msgid "Note Filter Editor"
+msgstr "Filtereditor für Notizen"
 
 #: ../gramps/plugins/view/noteview.py:357
 msgid "Cannot merge notes."
@@ -35737,92 +36403,85 @@ msgstr "▭"
 msgid "short for cremated|crem."
 msgstr "⚱"
 
-#: ../gramps/plugins/view/pedigreeview.py:1211
+#: ../gramps/plugins/view/pedigreeview.py:1205
 msgid "Jump to child..."
 msgstr "Springe zu Kind..."
 
-#: ../gramps/plugins/view/pedigreeview.py:1225
+#: ../gramps/plugins/view/pedigreeview.py:1219
 msgid "Jump to father"
 msgstr "Springe zum Vater"
 
-#: ../gramps/plugins/view/pedigreeview.py:1239
+#: ../gramps/plugins/view/pedigreeview.py:1233
 msgid "Jump to mother"
 msgstr "Springe zur Mutter"
 
-#: ../gramps/plugins/view/pedigreeview.py:1607
+#: ../gramps/plugins/view/pedigreeview.py:1601
 msgid "A person was found to be his/her own ancestor."
 msgstr "Es wurde eine Person gefunden, die ihr eigener Vorfahre ist."
 
-#: ../gramps/plugins/view/pedigreeview.py:1651
+#: ../gramps/plugins/view/pedigreeview.py:1645
 msgid "Pre_vious"
 msgstr "_Vorherige"
 
-#: ../gramps/plugins/view/pedigreeview.py:1652
+#: ../gramps/plugins/view/pedigreeview.py:1646
 msgid "_Next"
 msgstr "_Nächste"
 
-#: ../gramps/plugins/view/pedigreeview.py:1653
-msgid "_Home"
-msgstr "_Anfang"
-
-#: ../gramps/plugins/view/pedigreeview.py:1663
-msgid "Set _Home Person"
-msgstr "Hauptperson _setzen"
-
 #. Mouse scroll direction setting.
-#: ../gramps/plugins/view/pedigreeview.py:1681
+#: ../gramps/plugins/view/pedigreeview.py:1675
 msgid "Mouse scroll direction"
 msgstr "Mausrollradrichtung"
 
-#: ../gramps/plugins/view/pedigreeview.py:1685
+#: ../gramps/plugins/view/pedigreeview.py:1679
 msgid "Top <-> Bottom"
 msgstr "Oben <-> Unten"
 
-#: ../gramps/plugins/view/pedigreeview.py:1692
+#: ../gramps/plugins/view/pedigreeview.py:1686
 msgid "Left <-> Right"
 msgstr "Links <-> Rechts"
 
-#: ../gramps/plugins/view/pedigreeview.py:1909
+#: ../gramps/plugins/view/pedigreeview.py:1903
+#: ../gramps/plugins/view/relview.py:385
 msgid "Add New Parents..."
 msgstr "Neue Eltern hinzufügen..."
 
-#: ../gramps/plugins/view/pedigreeview.py:2104
+#: ../gramps/plugins/view/pedigreeview.py:2098
 msgid "Show images"
 msgstr "Bilder anzeigen"
 
-#: ../gramps/plugins/view/pedigreeview.py:2107
+#: ../gramps/plugins/view/pedigreeview.py:2101
 msgid "Show marriage data"
 msgstr "Heiratsdaten anzeigen"
 
-#: ../gramps/plugins/view/pedigreeview.py:2110
+#: ../gramps/plugins/view/pedigreeview.py:2104
 msgid "Show unknown people"
 msgstr "Zeige unbekannte Personen"
 
-#: ../gramps/plugins/view/pedigreeview.py:2113
+#: ../gramps/plugins/view/pedigreeview.py:2107
 msgid "Show tags"
 msgstr "Markierungen anzeigen"
 
-#: ../gramps/plugins/view/pedigreeview.py:2116
+#: ../gramps/plugins/view/pedigreeview.py:2110
 msgid "Tree style"
 msgstr "Baumstil"
 
-#: ../gramps/plugins/view/pedigreeview.py:2118
+#: ../gramps/plugins/view/pedigreeview.py:2112
 msgid "Standard"
 msgstr "Standard"
 
-#: ../gramps/plugins/view/pedigreeview.py:2119
+#: ../gramps/plugins/view/pedigreeview.py:2113
 msgid "Compact"
 msgstr "Kompakt"
 
-#: ../gramps/plugins/view/pedigreeview.py:2120
+#: ../gramps/plugins/view/pedigreeview.py:2114
 msgid "Expanded"
 msgstr "Erweitert"
 
-#: ../gramps/plugins/view/pedigreeview.py:2123
+#: ../gramps/plugins/view/pedigreeview.py:2117
 msgid "Tree direction"
 msgstr "Baumausrichtung"
 
-#: ../gramps/plugins/view/pedigreeview.py:2130
+#: ../gramps/plugins/view/pedigreeview.py:2124
 msgid "Tree size"
 msgstr "Baumgröße"
 
@@ -35842,6 +36501,50 @@ msgstr "Orteansicht"
 msgid "Place Tree View"
 msgstr "Ortebaumansicht"
 
+#: ../gramps/plugins/view/placetreeview.py:77
+msgid "Collapse this Entire Group"
+msgstr "Diese komplette Gruppe einklappen"
+
+#: ../gramps/plugins/view/placetreeview.py:77
+msgid "Expand this Entire Group"
+msgstr "Diese komplette Gruppe ausklappen"
+
+#: ../gramps/plugins/view/relview.py:364
+msgid "Organize Bookmarks..."
+msgstr "Organisiere Lesezeichen..."
+
+#: ../gramps/plugins/view/relview.py:385
+msgid "Add Existing Parents..."
+msgstr "Existierende Eltern hinzufügen..."
+
+#: ../gramps/plugins/view/relview.py:385
+msgid "Add Partner..."
+msgstr "Partner hinzufügen..."
+
+#: ../gramps/plugins/view/relview.py:385 ../gramps/plugins/view/relview.py:471
+msgid "_Reorder"
+msgstr "Neu _ordnen"
+
+#: ../gramps/plugins/view/relview.py:471 ../gramps/plugins/view/relview.py:964
+msgid "Add a new family with person as parent"
+msgstr "Eine neue Familie mit aktiver Person als Elternteil hinzufügen"
+
+#: ../gramps/plugins/view/relview.py:471 ../gramps/plugins/view/relview.py:958
+msgid "Add a new set of parents"
+msgstr "Neues Elternpaar hinzufügen"
+
+#: ../gramps/plugins/view/relview.py:471 ../gramps/plugins/view/relview.py:959
+msgid "Add person as child to an existing family"
+msgstr "Person als Kind zu bestehender Familie hinzufügen"
+
+#: ../gramps/plugins/view/relview.py:471
+msgid "Change order of parents and families"
+msgstr "Reihenfolge von Eltern und Familien ändern"
+
+#: ../gramps/plugins/view/relview.py:471
+msgid "Edit the active person"
+msgstr "Bearbeitet die aktive Person"
+
 #: ../gramps/plugins/view/relview.py:768
 msgid "Alive"
 msgstr "Lebt"
@@ -35850,14 +36553,6 @@ msgstr "Lebt"
 #, python-format
 msgid "%(date)s in %(place)s"
 msgstr "%(date)s in %(place)s"
-
-#: ../gramps/plugins/view/relview.py:958
-msgid "Add a new set of parents"
-msgstr "Neues Elternpaar hinzufügen"
-
-#: ../gramps/plugins/view/relview.py:959
-msgid "Add person as child to an existing family"
-msgstr "Person als Kind zu bestehender Familie hinzufügen"
 
 #: ../gramps/plugins/view/relview.py:960
 msgid "Edit parents"
@@ -35870,10 +36565,6 @@ msgstr "Eltern neu ordnen"
 #: ../gramps/plugins/view/relview.py:962
 msgid "Remove person as child of these parents"
 msgstr "Entferne Person als Kind dieser Eltern"
-
-#: ../gramps/plugins/view/relview.py:964
-msgid "Add a new family with person as parent"
-msgstr "Eine neue Familie mit aktiver Person als Elternteil hinzufügen"
 
 #: ../gramps/plugins/view/relview.py:968
 msgid "Remove person as parent in this family"
@@ -36011,6 +36702,10 @@ msgstr "Gewählten Aufbewahrungsort löschen"
 msgid "Merge the selected repositories"
 msgstr "Die gewählten Aufbewahrungsort zusammenfassen"
 
+#: ../gramps/plugins/view/repoview.py:201
+msgid "Repository Filter Editor"
+msgstr "Filtereditor für Aufbewahrungsorte"
+
 #: ../gramps/plugins/view/repoview.py:363
 msgid "Cannot merge repositories."
 msgstr "Kann Aufbewahrungsorte nicht zusammenfassen."
@@ -36036,6 +36731,10 @@ msgstr "Die gewählte Quelle löschen"
 #: ../gramps/plugins/view/sourceview.py:101
 msgid "Merge the selected sources"
 msgstr "Die gewählten Quellen zusammenfassen"
+
+#: ../gramps/plugins/view/sourceview.py:187
+msgid "Source Filter Editor"
+msgstr "Filtereditor für Quellen"
 
 #: ../gramps/plugins/view/sourceview.py:348
 msgid "Cannot merge sources."
@@ -36237,7 +36936,7 @@ msgstr "Miniaturbilder"
 #: ../gramps/plugins/webreport/basepage.py:1535
 #: ../gramps/plugins/webreport/basepage.py:1668
 #: ../gramps/plugins/webreport/download.py:94
-#: ../gramps/plugins/webreport/narrativeweb.py:1898
+#: ../gramps/plugins/webreport/narrativeweb.py:1899
 msgid "Download"
 msgstr "Download"
 
@@ -36318,12 +37017,12 @@ msgstr "Erstelle Ereignisseiten"
 #: ../gramps/plugins/webreport/family.py:108
 #: ../gramps/plugins/webreport/media.py:116
 #: ../gramps/plugins/webreport/media.py:244
-#: ../gramps/plugins/webreport/narrativeweb.py:500
-#: ../gramps/plugins/webreport/narrativeweb.py:1083
-#: ../gramps/plugins/webreport/narrativeweb.py:1141
-#: ../gramps/plugins/webreport/narrativeweb.py:1164
-#: ../gramps/plugins/webreport/narrativeweb.py:1173
-#: ../gramps/plugins/webreport/narrativeweb.py:1216
+#: ../gramps/plugins/webreport/narrativeweb.py:501
+#: ../gramps/plugins/webreport/narrativeweb.py:1084
+#: ../gramps/plugins/webreport/narrativeweb.py:1142
+#: ../gramps/plugins/webreport/narrativeweb.py:1165
+#: ../gramps/plugins/webreport/narrativeweb.py:1174
+#: ../gramps/plugins/webreport/narrativeweb.py:1217
 #: ../gramps/plugins/webreport/person.py:141
 #: ../gramps/plugins/webreport/place.py:117
 #: ../gramps/plugins/webreport/repository.py:102
@@ -36432,303 +37131,303 @@ msgstr "Dateityp"
 msgid "Missing media object:"
 msgstr "Fehlendes Medienobjekt"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:284
+#: ../gramps/plugins/webreport/narrativeweb.py:285
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
 msgstr "Weder %(current)s noch %(parent)s ist ein Verzeichnis"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:293
-#: ../gramps/plugins/webreport/narrativeweb.py:299
-#: ../gramps/plugins/webreport/narrativeweb.py:312
-#: ../gramps/plugins/webreport/narrativeweb.py:318
+#: ../gramps/plugins/webreport/narrativeweb.py:294
+#: ../gramps/plugins/webreport/narrativeweb.py:300
+#: ../gramps/plugins/webreport/narrativeweb.py:313
+#: ../gramps/plugins/webreport/narrativeweb.py:319
 #, python-format
 msgid "Could not create the directory: %s"
 msgstr "Kann Verzeichnis nicht erstellen: %s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:325
+#: ../gramps/plugins/webreport/narrativeweb.py:326
 msgid "Invalid file name"
 msgstr "Ungültiger Dateiname"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:326
+#: ../gramps/plugins/webreport/narrativeweb.py:327
 msgid "The archive file must be a file, not a directory"
 msgstr "Das Archiv muss eine Datei sein, kein Verzeichnis"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:462
+#: ../gramps/plugins/webreport/narrativeweb.py:463
 #, python-format
 msgid "ID=%(grampsid)s, path=%(dir)s"
 msgstr "ID=%(grampsid)s, Pfad=%(dir)s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:467
+#: ../gramps/plugins/webreport/narrativeweb.py:468
 msgid "Missing media objects:"
 msgstr "Fehlende Medienobjekte:"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:499
+#: ../gramps/plugins/webreport/narrativeweb.py:500
 msgid "Constructing list of other objects..."
 msgstr "Erstelle Liste der anderen Objekte..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:744
+#: ../gramps/plugins/webreport/narrativeweb.py:745
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr "Familie von %(husband)s und %(spouse)s"
 
 #. Only the name of the husband is known
 #. Only the name of the wife is known
-#: ../gramps/plugins/webreport/narrativeweb.py:750
-#: ../gramps/plugins/webreport/narrativeweb.py:754
+#: ../gramps/plugins/webreport/narrativeweb.py:751
+#: ../gramps/plugins/webreport/narrativeweb.py:755
 #, python-format
 msgid "Family of %s"
 msgstr "Familie von %s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1082
+#: ../gramps/plugins/webreport/narrativeweb.py:1083
 msgid "Creating GENDEX file"
 msgstr "Erstelle GENDEX-Datei"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1140
+#: ../gramps/plugins/webreport/narrativeweb.py:1141
 msgid "Creating surname pages"
 msgstr "Erstelle Nachnamensseiten"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1165
+#: ../gramps/plugins/webreport/narrativeweb.py:1166
 msgid "Creating thumbnail preview page..."
 msgstr "Erstelle Miniaturbild Vorschauseite..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1174
+#: ../gramps/plugins/webreport/narrativeweb.py:1175
 msgid "Creating statistics page..."
 msgstr "Erstelle Statistikseite.."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1215
+#: ../gramps/plugins/webreport/narrativeweb.py:1216
 msgid "Creating address book pages ..."
 msgstr "Erstelle Adressbuchseiten ..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1615
+#: ../gramps/plugins/webreport/narrativeweb.py:1616
 msgid "Store web pages in .tar.gz archive"
 msgstr "Webseiten in ein .tar.gz Archiv abspeichern"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1617
+#: ../gramps/plugins/webreport/narrativeweb.py:1618
 msgid "Whether to store the web pages in an archive file"
 msgstr "Ob die Webseiten in einer Archivdatei gespeichert werden."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1628
+#: ../gramps/plugins/webreport/narrativeweb.py:1629
 #: ../gramps/plugins/webreport/webcal.py:1663
 msgid "The destination directory for the web files"
 msgstr "Das Zielverzeichnis für die Webdateien"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1634
+#: ../gramps/plugins/webreport/narrativeweb.py:1635
 msgid "My Family Tree"
 msgstr "Mein Stammbaum"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1634
+#: ../gramps/plugins/webreport/narrativeweb.py:1635
 msgid "Web site title"
 msgstr "Webseitentitel"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1635
+#: ../gramps/plugins/webreport/narrativeweb.py:1636
 msgid "The title of the web site"
 msgstr "Der Titel der Website"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1640
+#: ../gramps/plugins/webreport/narrativeweb.py:1641
 msgid "Select filter to restrict people that appear on web site"
 msgstr ""
 "Filter wählen, um Personen zu begrenzen, die auf der Website erscheinen."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1649
+#: ../gramps/plugins/webreport/narrativeweb.py:1650
 msgid "Show the relationship between the current person and the active person"
 msgstr "Zeige die Beziehung zwischen der aktuellen und der aktiven Person"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1652
+#: ../gramps/plugins/webreport/narrativeweb.py:1653
 msgid ""
 "For each person page, show the relationship between this person and the "
 "active person."
 msgstr ""
-"Für jede Personenseite, zeige die Beziehung zwischen dieser Person und der"
-" aktiven Person."
+"Für jede Personenseite, zeige die Beziehung zwischen dieser Person und der "
+"aktiven Person."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1670
+#: ../gramps/plugins/webreport/narrativeweb.py:1671
 msgid "Html options"
 msgstr "Html-Optionen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1673
+#: ../gramps/plugins/webreport/narrativeweb.py:1674
 #: ../gramps/plugins/webreport/webcal.py:1684
 msgid "File extension"
 msgstr "Dateierweiterung"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1676
+#: ../gramps/plugins/webreport/narrativeweb.py:1677
 #: ../gramps/plugins/webreport/webcal.py:1687
 msgid "The extension to be used for the web files"
 msgstr "Die Erweiterung, die für die Webdateien verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1679
+#: ../gramps/plugins/webreport/narrativeweb.py:1680
 #: ../gramps/plugins/webreport/webcal.py:1690
 msgid "Copyright"
 msgstr "Copyright"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1682
+#: ../gramps/plugins/webreport/narrativeweb.py:1683
 #: ../gramps/plugins/webreport/webcal.py:1693
 msgid "The copyright to be used for the web files"
 msgstr "Das Copyright, das für die Webdateien verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1691
+#: ../gramps/plugins/webreport/narrativeweb.py:1692
 #: ../gramps/plugins/webreport/webcal.py:1702
 msgid "The stylesheet to be used for the web pages"
 msgstr "Die Layoutvorlage, für die Webseiten verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1696
+#: ../gramps/plugins/webreport/narrativeweb.py:1697
 msgid "Horizontal -- Default"
 msgstr "Horizontal -- Standard"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1697
+#: ../gramps/plugins/webreport/narrativeweb.py:1698
 msgid "Vertical   -- Left Side"
 msgstr "Vertikal -- Linke Seite"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1698
+#: ../gramps/plugins/webreport/narrativeweb.py:1699
 msgid "Fade       -- WebKit Browsers Only"
 msgstr "Überblenden  -- Nur WebKit Browser"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1699
-#: ../gramps/plugins/webreport/narrativeweb.py:1713
+#: ../gramps/plugins/webreport/narrativeweb.py:1700
+#: ../gramps/plugins/webreport/narrativeweb.py:1714
 msgid "Drop-Down  -- WebKit Browsers Only"
 msgstr "Drop-Down  -- Nur WebKit Browser"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1701
+#: ../gramps/plugins/webreport/narrativeweb.py:1702
 msgid "Navigation Menu Layout"
 msgstr "Navigationsmenülayout"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1705
+#: ../gramps/plugins/webreport/narrativeweb.py:1706
 msgid "Choose which layout for the Navigation Menus."
 msgstr "Wähle das Layout für die Navigationsmenüs."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1712
+#: ../gramps/plugins/webreport/narrativeweb.py:1713
 msgid "Normal Outline Style"
 msgstr "Normaler Umrandungsstil"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1716
+#: ../gramps/plugins/webreport/narrativeweb.py:1717
 msgid "Citation Referents Layout"
 msgstr "Fundstelle Referenzen Layout"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1720
+#: ../gramps/plugins/webreport/narrativeweb.py:1721
 msgid ""
 "Determine the default layout for the Source Page's Citation Referents section"
 msgstr ""
 "Bestimmt das Standardlayout für den Fundstellenreferenzabschnitt der "
 "Quellenseite"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1724
+#: ../gramps/plugins/webreport/narrativeweb.py:1725
 msgid "Include ancestor's tree"
 msgstr "Mit Ahnentafel"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1725
+#: ../gramps/plugins/webreport/narrativeweb.py:1726
 msgid "Whether to include an ancestor graph on each individual page"
 msgstr "Ob jede Personenseite eine Ahnentafel enthält"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1730
+#: ../gramps/plugins/webreport/narrativeweb.py:1731
 msgid "Add previous/next"
 msgstr "Zurück/Vor hinzufügen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1731
+#: ../gramps/plugins/webreport/narrativeweb.py:1732
 msgid "Add previous/next to the navigation bar."
 msgstr "Zurück/Vor zur Navigationsleiste hinzufügen."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1734
+#: ../gramps/plugins/webreport/narrativeweb.py:1735
 msgid "This is a secure site (https)"
 msgstr "Dies ist eine sichere Site (https)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1736
+#: ../gramps/plugins/webreport/narrativeweb.py:1737
 msgid "Whether to use http:// or https://"
 msgstr "Ob http:// oder https:// verwendet wird"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1743
+#: ../gramps/plugins/webreport/narrativeweb.py:1744
 msgid "Extra pages"
 msgstr "Extraseiten"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1746
+#: ../gramps/plugins/webreport/narrativeweb.py:1747
 msgid "Extra page name"
 msgstr "Name der Extraseite"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1749
+#: ../gramps/plugins/webreport/narrativeweb.py:1750
 msgid "Your extra page name like it is shown in the menubar"
 msgstr "Name deiner Extraseite wie er in der Menüleiste angezeigt wird"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1754
+#: ../gramps/plugins/webreport/narrativeweb.py:1755
 msgid "Your extra page path"
 msgstr "Pfad zu deiner Extraseite"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1757
+#: ../gramps/plugins/webreport/narrativeweb.py:1758
 msgid "Your extra page path without extension"
 msgstr "Pfad zu deiner Extraseite ohne Erweiterung"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1777
+#: ../gramps/plugins/webreport/narrativeweb.py:1778
 msgid "Sort all children in birth order"
 msgstr "Alle Kinder in Reihenfolge der Geburt sortieren"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1779
+#: ../gramps/plugins/webreport/narrativeweb.py:1780
 msgid "Whether to display children in birth order or in entry order?"
 msgstr "Kinder in der Reihenfolge der Geburt oder Eingabe anzeigen?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1783
+#: ../gramps/plugins/webreport/narrativeweb.py:1784
 msgid "Do we display coordinates in the places list?"
 msgstr "Koordinaten in der Orteliste anzeigen?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1785
+#: ../gramps/plugins/webreport/narrativeweb.py:1786
 msgid "Whether to display latitude/longitude in the places list?"
 msgstr "Ob Längen/Breitengrade in der Orteliste anzeigt werden."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1789
+#: ../gramps/plugins/webreport/narrativeweb.py:1790
 msgid "Sort places references either by date or by name"
 msgstr "Ortsreferenz entweder nach Datum oder Namen sortieren"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1791
+#: ../gramps/plugins/webreport/narrativeweb.py:1792
 msgid "Sort the places references by date or by name. Not set means by date."
 msgstr ""
-"Sortiert Ortsreferenzen nach Datum oder Namen. Keine Angabe bedeutet nach"
-" Datum."
+"Sortiert Ortsreferenzen nach Datum oder Namen. Keine Angabe bedeutet nach "
+"Datum."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1795
+#: ../gramps/plugins/webreport/narrativeweb.py:1796
 msgid "Graph generations"
 msgstr "Generationengrafik"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1796
+#: ../gramps/plugins/webreport/narrativeweb.py:1797
 msgid "The number of generations to include in the ancestor graph"
 msgstr "Anzahl der in der Ahnengrafik berücksichtigten Generationen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1806
+#: ../gramps/plugins/webreport/narrativeweb.py:1807
 msgid "Page Generation"
 msgstr "Seiten Generation"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1809
+#: ../gramps/plugins/webreport/narrativeweb.py:1810
 msgid "Home page note"
 msgstr "Homepagenotiz"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1810
+#: ../gramps/plugins/webreport/narrativeweb.py:1811
 msgid "A note to be used on the home page"
 msgstr "Eine Notiz, die auf der Homepage verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1813
+#: ../gramps/plugins/webreport/narrativeweb.py:1814
 msgid "Home page image"
 msgstr "Homepagebild"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1814
+#: ../gramps/plugins/webreport/narrativeweb.py:1815
 msgid "An image to be used on the home page"
 msgstr "Ein Bild, das auf der Homepage verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1817
+#: ../gramps/plugins/webreport/narrativeweb.py:1818
 msgid "Introduction note"
 msgstr "Einleitungsnotiz"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1818
+#: ../gramps/plugins/webreport/narrativeweb.py:1819
 msgid "A note to be used as the introduction"
 msgstr "Eine Notiz, die als Einleitung verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1821
+#: ../gramps/plugins/webreport/narrativeweb.py:1822
 msgid "Introduction image"
 msgstr "Einleitungsbild"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1822
+#: ../gramps/plugins/webreport/narrativeweb.py:1823
 msgid "An image to be used as the introduction"
 msgstr "Ein Bild, das als Einleitung verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1825
+#: ../gramps/plugins/webreport/narrativeweb.py:1826
 msgid "Publisher contact note"
 msgstr "Kontakt-Notiz des Herausgebers"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1826
+#: ../gramps/plugins/webreport/narrativeweb.py:1827
 msgid ""
 "A note to be used as the publisher contact.\n"
 "If no publisher information is given,\n"
@@ -36738,11 +37437,11 @@ msgstr ""
 "Wenn keine Herausgeber Informationen angegeben sind,\n"
 "wird keine Kontaktseite erstellt"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1832
+#: ../gramps/plugins/webreport/narrativeweb.py:1833
 msgid "Publisher contact image"
 msgstr "Bild für Kontakt mit dem Herausgeber"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1833
+#: ../gramps/plugins/webreport/narrativeweb.py:1834
 msgid ""
 "An image to be used as the publisher contact.\n"
 "If no publisher information is given,\n"
@@ -36752,47 +37451,47 @@ msgstr ""
 "Wenn keine Herausgeber Informationen angegeben sind,\n"
 "wird keine Kontaktseite erstellt"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1839
+#: ../gramps/plugins/webreport/narrativeweb.py:1840
 msgid "HTML user header"
 msgstr "HTML Kopfzeile"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1840
+#: ../gramps/plugins/webreport/narrativeweb.py:1841
 msgid "A note to be used as the page header"
 msgstr "Eine Notiz, die als Kopfzeile benutzt wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1843
+#: ../gramps/plugins/webreport/narrativeweb.py:1844
 msgid "HTML user footer"
 msgstr "HTML Fußzeile"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1844
+#: ../gramps/plugins/webreport/narrativeweb.py:1845
 msgid "A note to be used as the page footer"
 msgstr "Eine Notiz, die als Fußzeile benutzt wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1851
+#: ../gramps/plugins/webreport/narrativeweb.py:1852
 msgid "Images Generation"
 msgstr "Bilder Erstellung"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1854
+#: ../gramps/plugins/webreport/narrativeweb.py:1855
 msgid "Include images and media objects"
 msgstr "Bilder und Medienobjekte aufnehmen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1856
+#: ../gramps/plugins/webreport/narrativeweb.py:1857
 msgid "Whether to include a gallery of media objects"
 msgstr "Ob eine Galerie mit Medienobjekten aufgenommen wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1862
+#: ../gramps/plugins/webreport/narrativeweb.py:1863
 msgid "Include unused images and media objects"
 msgstr "Unbenutzte Bilder und Medienobjekte aufnehmen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1863
+#: ../gramps/plugins/webreport/narrativeweb.py:1864
 msgid "Whether to include unused or unreferenced media objects"
 msgstr "Ob unbenutzte nicht referenzierte Medienobjekte aufgenommen werden"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1868
+#: ../gramps/plugins/webreport/narrativeweb.py:1869
 msgid "Create and only use thumbnail- sized images"
 msgstr "Erstelle und verwende nur Miniaturbilder"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1870
+#: ../gramps/plugins/webreport/narrativeweb.py:1871
 msgid ""
 "This option allows you to create only thumbnail images instead of the full-"
 "sized images on the Media Page. This will allow you to have a much smaller "
@@ -36803,11 +37502,11 @@ msgstr ""
 "ist die Datenmenge, die du zu deinen Website Anbieter hoch laden musst "
 "erheblich kleiner."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1879
+#: ../gramps/plugins/webreport/narrativeweb.py:1880
 msgid "Max width of initial image"
 msgstr "Max. Breite für Anfangsbild"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1881
+#: ../gramps/plugins/webreport/narrativeweb.py:1882
 msgid ""
 "This allows you to set the maximum width of the image shown on the media "
 "page. Set to 0 for no limit."
@@ -36815,11 +37514,11 @@ msgstr ""
 "Dies erlaubt dir, die maximale Breite des Bildes zu bestimmen, das auf der "
 "Medienseite gezeigt wird. Setze 0 für unbegrenzt."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1886
+#: ../gramps/plugins/webreport/narrativeweb.py:1887
 msgid "Max height of initial image"
 msgstr "Max. Höhe für Anfangsbild"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1888
+#: ../gramps/plugins/webreport/narrativeweb.py:1889
 msgid ""
 "This allows you to set the maximum height of the image shown on the media "
 "page. Set to 0 for no limit."
@@ -36827,162 +37526,162 @@ msgstr ""
 "Dies erlaubt dir, die maximale Höhe des Bildes zu bestimmen, das auf der "
 "Medienseite gezeigt wird. Setze 0 für unbegrenzt."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1901
+#: ../gramps/plugins/webreport/narrativeweb.py:1902
 msgid "Include download page"
 msgstr "Enthält eine Downloadseite"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1903
+#: ../gramps/plugins/webreport/narrativeweb.py:1904
 msgid "Whether to include a database download option"
 msgstr "Ob in die Datenbank eine download Option aufgenommen wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1908
-#: ../gramps/plugins/webreport/narrativeweb.py:1920
+#: ../gramps/plugins/webreport/narrativeweb.py:1909
+#: ../gramps/plugins/webreport/narrativeweb.py:1921
 msgid "Download Filename"
 msgstr "Download Dateiname"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1911
-#: ../gramps/plugins/webreport/narrativeweb.py:1923
+#: ../gramps/plugins/webreport/narrativeweb.py:1912
+#: ../gramps/plugins/webreport/narrativeweb.py:1924
 msgid "File to be used for downloading of database"
 msgstr "Datei, die für das Herunterladen der Datenbank verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1914
-#: ../gramps/plugins/webreport/narrativeweb.py:1926
+#: ../gramps/plugins/webreport/narrativeweb.py:1915
+#: ../gramps/plugins/webreport/narrativeweb.py:1927
 msgid "Description for download"
 msgstr "Beschreibung für Download"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1915
+#: ../gramps/plugins/webreport/narrativeweb.py:1916
 msgid "Smith Family Tree"
 msgstr "Smith Stammbaum"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1916
-#: ../gramps/plugins/webreport/narrativeweb.py:1928
+#: ../gramps/plugins/webreport/narrativeweb.py:1917
+#: ../gramps/plugins/webreport/narrativeweb.py:1929
 msgid "Give a description for this file."
 msgstr "Gib eine Beschreibung für die Datei."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1927
+#: ../gramps/plugins/webreport/narrativeweb.py:1928
 msgid "Johnson Family Tree"
 msgstr "Johnson Stammbaum"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1937
+#: ../gramps/plugins/webreport/narrativeweb.py:1938
 #: ../gramps/plugins/webreport/webcal.py:1868
 msgid "Advanced Options"
 msgstr "Erweiterte Optionen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1940
+#: ../gramps/plugins/webreport/narrativeweb.py:1941
 #: ../gramps/plugins/webreport/webcal.py:1870
 msgid "Character set encoding"
 msgstr "Codierung der Zeichensetzung"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1944
+#: ../gramps/plugins/webreport/narrativeweb.py:1945
 #: ../gramps/plugins/webreport/webcal.py:1874
 msgid "The encoding to be used for the web files"
 msgstr "Die Kodierung, die für die Webdateien verwendet wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1948
+#: ../gramps/plugins/webreport/narrativeweb.py:1949
 msgid "Include link to active person on every page"
 msgstr "Link zur aktiven Person auf jeder Seite"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1950
+#: ../gramps/plugins/webreport/narrativeweb.py:1951
 msgid "Include a link to the active person (if they have a webpage)"
 msgstr "Link zur aktiven Person auf jeder Seite (wenn sie eine Website hat)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1954
+#: ../gramps/plugins/webreport/narrativeweb.py:1955
 msgid "Include a column for birth dates on the index pages"
 msgstr "Spalte für Geburtsdaten auf den Indexseiten"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1955
+#: ../gramps/plugins/webreport/narrativeweb.py:1956
 msgid "Whether to include a birth column"
 msgstr "Ob eine Spalte für Geburt aufgenommen wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1959
+#: ../gramps/plugins/webreport/narrativeweb.py:1960
 msgid "Include a column for death dates on the index pages"
 msgstr "Spalte für Todesdaten auf den Indexseiten"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1960
+#: ../gramps/plugins/webreport/narrativeweb.py:1961
 msgid "Whether to include a death column"
 msgstr "Ob eine Spalte für Tod aufgenommen wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1963
+#: ../gramps/plugins/webreport/narrativeweb.py:1964
 msgid "Include a column for partners on the index pages"
 msgstr "Spalte für Partner auf den Indexseiten"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1965
+#: ../gramps/plugins/webreport/narrativeweb.py:1966
 msgid "Whether to include a partners column"
 msgstr "Ob eine Spalte für Partner aufgenommen wird"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1968
+#: ../gramps/plugins/webreport/narrativeweb.py:1969
 msgid "Include a column for parents on the index pages"
 msgstr "Spalte für Eltern auf den Indexseiten"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1970
+#: ../gramps/plugins/webreport/narrativeweb.py:1971
 msgid "Whether to include a parents column"
 msgstr "Ob eine Spalte für Eltern aufgenommen wird"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1974
+#: ../gramps/plugins/webreport/narrativeweb.py:1975
 msgid "Include half and/ or step-siblings on the individual pages"
 msgstr "Halb- und/oder Stiefgeschwister auf den Personenseiten aufnehmen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1977
+#: ../gramps/plugins/webreport/narrativeweb.py:1978
 msgid ""
 "Whether to include half and/ or step-siblings with the parents and siblings"
 msgstr ""
 "Ob Halb- und/oder Stiefgeschwister mit den Eltern und Geschwistern "
 "aufgenommen werden."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1988
+#: ../gramps/plugins/webreport/narrativeweb.py:1989
 msgid "Include family pages"
 msgstr "Familienseiten aufnehmen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1989
+#: ../gramps/plugins/webreport/narrativeweb.py:1990
 msgid "Whether or not to include family pages."
 msgstr "Ob Familienseiten enthalten sind."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1992
+#: ../gramps/plugins/webreport/narrativeweb.py:1993
 msgid "Include event pages"
 msgstr "Ereignisseiten aufnehmen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1994
+#: ../gramps/plugins/webreport/narrativeweb.py:1995
 msgid "Add a complete events list and relevant pages or not"
 msgstr ""
 "Eine komplette Ereignisliste und entsprechende Seiten aufnehmen oder nicht"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1997
+#: ../gramps/plugins/webreport/narrativeweb.py:1998
 msgid "Include places pages"
 msgstr "Ortsseiten aufnehmen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1999
+#: ../gramps/plugins/webreport/narrativeweb.py:2000
 msgid "Whether or not to include the places Pages."
 msgstr "Ob Orteseiten enthalten sind."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2002
+#: ../gramps/plugins/webreport/narrativeweb.py:2003
 msgid "Include sources pages"
 msgstr "Quellenseiten aufnehmen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2004
+#: ../gramps/plugins/webreport/narrativeweb.py:2005
 msgid "Whether or not to include the sources Pages."
 msgstr "Ob die Quellenseiten enthalten sind."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2007
+#: ../gramps/plugins/webreport/narrativeweb.py:2008
 msgid "Include repository pages"
 msgstr "Aufbewahrungsorteseiten aufnehmen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2009
+#: ../gramps/plugins/webreport/narrativeweb.py:2010
 msgid "Whether or not to include the Repository Pages."
 msgstr "Ob Aufbewahrungsorteseiten enthalten sind."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2013
+#: ../gramps/plugins/webreport/narrativeweb.py:2014
 msgid "Include GENDEX file (/gendex.txt)"
 msgstr "GENDEX-Datei (/gendex.txt) aufnehmen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2014
+#: ../gramps/plugins/webreport/narrativeweb.py:2015
 msgid "Whether to include a GENDEX file or not"
 msgstr "Ob eine GENDEX-Datei aufgenommen wird."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2017
+#: ../gramps/plugins/webreport/narrativeweb.py:2018
 msgid "Include address book pages"
 msgstr "Adressbuchseiten einbeziehen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2018
+#: ../gramps/plugins/webreport/narrativeweb.py:2019
 msgid ""
 "Whether or not to add Address Book pages,which can include e-mail and "
 "website addresses and personal address/ residence events."
@@ -36990,35 +37689,35 @@ msgstr ""
 "Ob Adressbuchseiten enthalten sind, die E-mail-, Webseiten-, und persönliche "
 "Adressen und Wohnortsereignisse enthalten können."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2024
+#: ../gramps/plugins/webreport/narrativeweb.py:2025
 msgid "Include the statistics page"
 msgstr "Statistikseite aufnehmen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2025
+#: ../gramps/plugins/webreport/narrativeweb.py:2026
 msgid "Whether or not to add statistics page"
 msgstr "Ob eine Statistikseite enthalten ist."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2032
+#: ../gramps/plugins/webreport/narrativeweb.py:2033
 msgid "Place Map Options"
 msgstr "Ortekarteoptionen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2037
+#: ../gramps/plugins/webreport/narrativeweb.py:2038
 msgid "Google"
 msgstr "Google"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2038
+#: ../gramps/plugins/webreport/narrativeweb.py:2039
 msgid "Map Service"
 msgstr "Kartenservice"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2042
+#: ../gramps/plugins/webreport/narrativeweb.py:2043
 msgid "Choose your choice of map service for creating the Place Map Pages."
 msgstr "Wähle den Kartenservice zum Erstellen der Ortskartenseiten."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2048
+#: ../gramps/plugins/webreport/narrativeweb.py:2049
 msgid "Include Place map on Place Pages"
 msgstr "Mit Orte Karte auf den Ortsseiten"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2050
+#: ../gramps/plugins/webreport/narrativeweb.py:2051
 msgid ""
 "Whether to include a place map on the Place Pages, where Latitude/ Longitude "
 "are available."
@@ -37026,11 +37725,11 @@ msgstr ""
 "Ob eine Ortskarte auf der Ortsseite aufgenommen wird, wo Längen-/"
 "Breitenangaben vorhanden sind."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2055
+#: ../gramps/plugins/webreport/narrativeweb.py:2056
 msgid "Include Family Map Pages with all places shown on the map"
 msgstr "Mit Familien Kartenseite mit allen Orten angezeigt auf der Karte"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2059
+#: ../gramps/plugins/webreport/narrativeweb.py:2060
 msgid ""
 "Whether or not to add an individual page map showing all the places on this "
 "page. This will allow you to see how your family traveled around the country."
@@ -37038,23 +37737,23 @@ msgstr ""
 "Ob eine persönliche Kartenseite, die alle Orte zeigt, hinzugefügt wird. Dies "
 "ermöglicht es dir zu sehen, wie deine Familie im Land gewandert ist."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2067
+#: ../gramps/plugins/webreport/narrativeweb.py:2068
 msgid "Family Links"
 msgstr "Familienverknüpfungen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2068
+#: ../gramps/plugins/webreport/narrativeweb.py:2069
 msgid "Drop"
 msgstr "Abbrechen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2069
+#: ../gramps/plugins/webreport/narrativeweb.py:2070
 msgid "Markers"
 msgstr "Markierungen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2070
+#: ../gramps/plugins/webreport/narrativeweb.py:2071
 msgid "Google/ FamilyMap Option"
 msgstr "Google/ FamilienKarte Option"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2075
+#: ../gramps/plugins/webreport/narrativeweb.py:2076
 msgid ""
 "Select which option that you would like to have for the Google Maps Family "
 "Map pages..."
@@ -37062,36 +37761,36 @@ msgstr ""
 "Wähle welche Option du für die Google Maps Familienkartenseiten haben "
 "möchtest..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2079
+#: ../gramps/plugins/webreport/narrativeweb.py:2080
 msgid "Google maps API key"
 msgstr "GoogleMaps API Schlüssel"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2080
+#: ../gramps/plugins/webreport/narrativeweb.py:2081
 msgid "The API key used for the Google maps"
 msgstr "Der API-Schlüssel, der für Google Maps verwendet wird"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2089
+#: ../gramps/plugins/webreport/narrativeweb.py:2090
 msgid "Other inclusion (CMS, Web Calendar, Php)"
 msgstr "Andere Einbindungen (CMS, Webkalender, PHP)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2093
+#: ../gramps/plugins/webreport/narrativeweb.py:2094
 msgid "Do we include these pages in a cms web ?"
 msgstr "Integrieren wir diese Seiten in ein CMS-Web?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2097
-#: ../gramps/plugins/webreport/narrativeweb.py:2114
+#: ../gramps/plugins/webreport/narrativeweb.py:2098
+#: ../gramps/plugins/webreport/narrativeweb.py:2115
 msgid "URI"
 msgstr "URI"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2103
+#: ../gramps/plugins/webreport/narrativeweb.py:2104
 msgid "Where do you place your web site ? default = /NAVWEB"
 msgstr "Wo speicherst du deine Website? Standard = /NAVWEB"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2110
+#: ../gramps/plugins/webreport/narrativeweb.py:2111
 msgid "Do we include the web calendar ?"
 msgstr "Integrieren wir den Webkalender?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2120
+#: ../gramps/plugins/webreport/narrativeweb.py:2121
 msgid "Where do you place your web site ? default = /WEBCAL"
 msgstr "Wo speicherst du deine Website? Standard = /WEBCAL"
 
@@ -37603,9 +38302,9 @@ msgid ""
 "Show data only after this year. Default is current year -  'maximum age "
 "probably alive' which is defined in the dates preference tab."
 msgstr ""
-"Zeige Daten nur nach dem Jahr. Standard ist aktuelles Jahr - 'maximales alter"
-" wahrscheinlich am leben' was in dem Daten-Einstellungen Reiter eingestellt"
-" ist."
+"Zeige Daten nur nach dem Jahr. Standard ist aktuelles Jahr - 'maximales "
+"alter wahrscheinlich am leben' was in dem Daten-Einstellungen Reiter "
+"eingestellt ist."
 
 #: ../gramps/plugins/webreport/webcal.py:1912
 msgid "Link prefix"
@@ -37710,6 +38409,33 @@ msgstr "Nebraska"
 msgid "No style sheet"
 msgstr "Kein Stylesheet"
 
+#~ msgid "unmarried|husband"
+#~ msgstr "Lebensgefährte"
+
+#~ msgid "unmarried|wife"
+#~ msgstr "Lebensgefährtin"
+
+#~ msgid "gender unknown,unmarried|spouse"
+#~ msgstr "Partner(in)"
+
+#~ msgid "unmarried|ex-husband"
+#~ msgstr "Ex-Lebensgefährte"
+
+#~ msgid "unmarried|ex-wife"
+#~ msgstr "Ex-Lebensgefährtin"
+
+#~ msgid "gender unknown,unmarried|ex-spouse"
+#~ msgstr "Ex-Lebensgefährt(e/in)"
+
+#~ msgid ""
+#~ "You need to set a 'default person' to go to. Select the People View, "
+#~ "select the person you want as 'Home Person', then confirm your choice via "
+#~ "the menu Edit ->Set Home Person."
+#~ msgstr ""
+#~ "Du musst eine 'Hauptperson' setzen, um dorthin zu springen. Gehe zur "
+#~ "Personenansicht, wähle die Person, die du als 'Hauptperson' setzen willst "
+#~ "und bestätige deine Wahl über Menü Bearbeiten -> Hauptperson setzen."
+
 #~ msgid ""
 #~ "<b>Improving Gramps</b><br/>Users are encouraged to request enhancements "
 #~ "to Gramps. Requesting an enhancement can be done either through the "
@@ -37776,134 +38502,20 @@ msgstr "Kein Stylesheet"
 #~ msgid "Border Family"
 #~ msgstr "Familie Rand"
 
-#~ msgid "Make Active Person"
-#~ msgstr "Als Aktive Person setzen"
-
-#~ msgid "Make Home Person"
-#~ msgstr "Als Hauptperson setzen"
-
 #~ msgid "Web Connect"
 #~ msgstr "Webverbindung"
 
 #~ msgid "manual|Repositories"
 #~ msgstr "Aufbewahrungsorte"
 
-#~ msgid "Connect to a recent database"
-#~ msgstr "Mit neuer Datenbank verbinden"
-
-#~ msgid "_Family Trees"
-#~ msgstr "_Stammbäume"
-
-#~ msgid "_Manage Family Trees..."
-#~ msgstr "Stammbäume _verwalten..."
-
-#~ msgid "Manage databases"
-#~ msgstr "Datenbanken verwalten"
-
-#~ msgid "Open _Recent"
-#~ msgstr "_Zuletzt geöffnet"
-
 #~ msgid "Open an existing database"
 #~ msgstr "Eine existierende Datenbank öffnen"
-
-#~ msgid "_Quit"
-#~ msgstr "_Beenden"
-
-#~ msgid "_View"
-#~ msgstr "_Ansicht"
-
-#~ msgid "_Preferences..."
-#~ msgstr "_Einstellungen..."
-
-#~ msgid "Gramps _Home Page"
-#~ msgstr "Gramps _Homepage"
-
-#~ msgid "Gramps _Mailing Lists"
-#~ msgstr "Gramps _Mailinglisten"
-
-#~ msgid "_Report a Bug"
-#~ msgstr "_Programmfehler melden"
-
-#~ msgid "_Extra Reports/Tools"
-#~ msgstr "_Weitere Berichte/Werkzeuge"
-
-#~ msgid "_About"
-#~ msgstr "_Info"
-
-#~ msgid "_Plugin Manager"
-#~ msgstr "_Zusatzmodulverwaltung"
-
-#~ msgid "_FAQ"
-#~ msgstr "Häufig gestellte _Fragen"
-
-#~ msgid "_Key Bindings"
-#~ msgstr "Tastatur_kürzel"
-
-#~ msgid "_User Manual"
-#~ msgstr "_Benutzerhandbuch"
 
 #~ msgid "Close the current database"
 #~ msgstr "Schließe die aktuelle Datenbank"
 
-#~ msgid "_Export..."
-#~ msgstr "_Export..."
-
-#~ msgid "Make Backup..."
-#~ msgstr "Erstelle Sicherung..."
-
 #~ msgid "Make a Gramps XML backup of the database"
 #~ msgstr "Gramps-XML Sicherung der Datenbank erstellen"
-
-#~ msgid "_Abandon Changes and Quit"
-#~ msgstr "Änderungen _verwerfen und beenden"
-
-#~ msgid "_Reports"
-#~ msgstr "Be_richte"
-
-#~ msgid "Open the reports dialog"
-#~ msgstr "Öffnet den Berichtsdialog"
-
-#~ msgid "_Go"
-#~ msgstr "_Gehe zu"
-
-#~ msgid "Books..."
-#~ msgstr "Bücher..."
-
-#~ msgid "_Windows"
-#~ msgstr "_Fenster"
-
-#~ msgid "Clip_board"
-#~ msgstr "Zwischena_blage"
-
-#~ msgid "Open the Clipboard dialog"
-#~ msgstr "Öffnet den Zwischenablagedialog"
-
-#~ msgid "_Import..."
-#~ msgstr "_Import..."
-
-#~ msgid "_Tools"
-#~ msgstr "_Werkzeuge"
-
-#~ msgid "Open the tools dialog"
-#~ msgstr "Öffnet den Werkzeugdialog"
-
-#~ msgid "_Bookmarks"
-#~ msgstr "_Lesezeichen"
-
-#~ msgid "_Configure..."
-#~ msgstr "_Konfigurieren..."
-
-#~ msgid "Configure the active view"
-#~ msgstr "Die aktive Ansicht konfigurieren"
-
-#~ msgid "_Navigator"
-#~ msgstr "_Navigator"
-
-#~ msgid "_Toolbar"
-#~ msgstr "_Werkzeugleiste"
-
-#~ msgid "F_ull Screen"
-#~ msgstr "Vollbild"
 
 #~ msgid "Undo History..."
 #~ msgstr "Bearbeitungschronik..."
@@ -37911,65 +38523,11 @@ msgstr "Kein Stylesheet"
 #~ msgid "Key %s is not bound"
 #~ msgstr "Schlüssel %s ist nicht eingebunden"
 
-#~ msgid "_Add..."
-#~ msgstr "_Hinzufügen..."
-
-#~ msgid "_Merge..."
-#~ msgstr "_Zusammenfassen..."
-
-#~ msgid "Export View..."
-#~ msgstr "Ansicht exportieren..."
-
 #~ msgid "_Delete Item"
 #~ msgstr "Element _löschen"
 
-#~ msgid "_Add Bookmark"
-#~ msgstr "Lesezeichen _hinzufügen"
-
 #~ msgid "%(title)s..."
 #~ msgstr "%(title)s..."
-
-#~ msgid "Go to the next object in the history"
-#~ msgstr "Gehe zum nächsten Objekt in der Chronik."
-
-#~ msgid "_Back"
-#~ msgstr "_Zurück"
-
-#~ msgid "Go to the previous object in the history"
-#~ msgstr "Gehe zum vorherigen Objekt in der Chronik."
-
-#~ msgid "Go to the default person"
-#~ msgstr "Springe zur Hauptperson"
-
-#~ msgid "_Sidebar"
-#~ msgstr "_Seitenleiste"
-
-#~ msgid "_Bottombar"
-#~ msgstr "_Fußleiste"
-
-#~ msgid "New Tag..."
-#~ msgstr "Neue Markierung..."
-
-#~ msgid "Organize Tags..."
-#~ msgstr "Markierungen organisieren...."
-
-#~ msgid "Tag selected rows"
-#~ msgstr "Ausgewählte Zeilen markieren"
-
-#~ msgid "Font Color"
-#~ msgstr "Schriftfarbe"
-
-#~ msgid "Background Color"
-#~ msgstr "Hintergrundfarbe"
-
-#~ msgid "Clear Markup"
-#~ msgstr "Markierungen löschen"
-
-#~ msgid "Undo"
-#~ msgstr "Rückgängig"
-
-#~ msgid "Redo"
-#~ msgstr "Wiederherstellen"
 
 #~ msgid "%(genders)s born %(year_from)04d-%(year_to)04d"
 #~ msgstr "%(genders)s geboren %(year_from)04d-%(year_to)04d"
@@ -37995,27 +38553,8 @@ msgstr "Kein Stylesheet"
 #~ msgid "Not a Pro-Gen file"
 #~ msgstr "Keine Pro-Gen Datei"
 
-#~ msgid "Person Filter Editor"
-#~ msgstr "Filtereditor für Personen"
-
-#~ msgid "Web Connection"
-#~ msgstr "Webverbindung"
-
 #~ msgid "Loading..."
 #~ msgstr "Lade..."
-
-#~ msgid ""
-#~ "Attempt to see selected locations with a Map Service (OpenstreetMap, "
-#~ "Google Maps, ...)"
-#~ msgstr ""
-#~ "Versuche, ausgewählte Orte mit einem Kartenservice zu zeigen "
-#~ "(OpenstreetMap, Google Maps, ...)."
-
-#~ msgid "Select a Map Service"
-#~ msgstr "Einen Kartenservice wählen"
-
-#~ msgid "_Look up with Map Service"
-#~ msgstr "_Nachschlagen mit Kartenservice"
 
 #~ msgid ""
 #~ "Attempt to see this location with a Map Service (OpenstreetMap, Google "
@@ -38024,65 +38563,11 @@ msgstr "Kein Stylesheet"
 #~ "Versuche diesen Ort mit einem Kartenservice zu zeigen (OpenstreetMap, "
 #~ "Google Maps, ...)"
 
-#~ msgid "Place Filter Editor"
-#~ msgstr "Ortsfiltereditor"
-
-#~ msgid "_Print..."
-#~ msgstr "_Drucken..."
-
-#~ msgid "Print or save the Map"
-#~ msgstr "Die Karte drucken oder speichern"
-
 #~ msgid "Map Menu"
 #~ msgstr "Kartenmenü"
 
 #~ msgid "manual|Media_Manager..."
 #~ msgstr "Medienverwalter..."
-
-#~ msgid "Citation Filter Editor"
-#~ msgstr "Filtereditor für Fundstellen"
-
-#~ msgid "Add source..."
-#~ msgstr "Quelle hinzufügen..."
-
-#~ msgid "Add citation..."
-#~ msgstr "Fundstelle hinzufügen..."
-
-#~ msgid "Expand all Nodes"
-#~ msgstr "Alle Knoten aufklappen"
-
-#~ msgid "Collapse all Nodes"
-#~ msgstr "Alle Knoten schließen"
-
-#~ msgid "Restore a gramplet"
-#~ msgstr "Gramplet wiederherstellen"
-
-#~ msgid "Event Filter Editor"
-#~ msgstr "Filtereditor für Ereignisse"
-
-#~ msgid "Family Filter Editor"
-#~ msgstr "Familienfiltereditor"
-
-#~ msgid "Make Father Active Person"
-#~ msgstr "Vater als aktive Person setzen"
-
-#~ msgid "Make Mother Active Person"
-#~ msgstr "Mutter als aktive Person setzen"
-
-#~ msgid "Print or save the Fan Chart View"
-#~ msgstr "Drucke oder speichere die Fächergrafikansicht"
-
-#~ msgid "reference _Person"
-#~ msgstr "Referenz _Person"
-
-#~ msgid "Select the person which is the reference for life ways"
-#~ msgstr "Wähle die Referenzperson für Lebenswege"
-
-#~ msgid "reference _Family"
-#~ msgstr "Referenz_familie"
-
-#~ msgid "Select the family which is the reference for life ways"
-#~ msgstr "Wähle die Familie für die Referenz für Lebenswege"
 
 #~ msgid ""
 #~ "Geography functionality will not be available.\n"
@@ -38091,47 +38576,8 @@ msgstr "Kein Stylesheet"
 #~ "Geografie-Funktionalität wird nicht zur Verfügung stehen.\n"
 #~ "Um es für Gramps zu erstellen siehe %(gramps_wiki_build_osmgps_url)s"
 
-#~ msgid "Media Filter Editor"
-#~ msgstr "Filtereditor für Medienobjekte"
-
-#~ msgid "View in the default viewer"
-#~ msgstr "Im voreingestellten Programm anzeigen"
-
 #~ msgid "Open the folder containing the media file"
 #~ msgstr "Öffne den Ordner, der die Mediendateien enthält"
-
-#~ msgid "Note Filter Editor"
-#~ msgstr "Filtereditor für Notizen"
-
-#~ msgid "Expand this Entire Group"
-#~ msgstr "Diese komplette Gruppe ausklappen"
-
-#~ msgid "Collapse this Entire Group"
-#~ msgstr "Diese komplette Gruppe einklappen"
-
-#~ msgid "_Reorder"
-#~ msgstr "Neu _ordnen"
-
-#~ msgid "Change order of parents and families"
-#~ msgstr "Reihenfolge von Eltern und Familien ändern"
-
-#~ msgid "Edit..."
-#~ msgstr "Bearbeiten..."
-
-#~ msgid "Edit the active person"
-#~ msgstr "Bearbeitet die aktive Person"
-
-#~ msgid "Add Partner..."
-#~ msgstr "Partner hinzufügen..."
-
-#~ msgid "Add Existing Parents..."
-#~ msgstr "Existierende Eltern hinzufügen..."
-
-#~ msgid "Repository Filter Editor"
-#~ msgstr "Filtereditor für Aufbewahrungsorte"
-
-#~ msgid "Source Filter Editor"
-#~ msgstr "Filtereditor für Quellen"
 
 #~ msgid " (%s) "
 #~ msgstr " (%s) "
@@ -38742,9 +39188,6 @@ msgstr "Kein Stylesheet"
 
 #~ msgid "Death place id"
 #~ msgstr "Sterbeort ID"
-
-#~ msgid "Gramps id"
-#~ msgstr "Gramps id"
 
 #~ msgid "Parent2"
 #~ msgstr "Elter2"
@@ -43130,4 +43573,3 @@ msgstr "Kein Stylesheet"
 
 #~ msgid "Creating event page %02d of %02d"
 #~ msgstr "Erstelle Ereignisseite %02d von %02d"
-

--- a/po/fi.po
+++ b/po/fi.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gramps_5_fi\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-06-13 17:22-0500\n"
-"PO-Revision-Date: 2019-06-15 23:43+0300\n"
+"POT-Creation-Date: 2019-07-16 12:47+0300\n"
+"PO-Revision-Date: 2019-07-16 12:50+0300\n"
 "Last-Translator: Matti Niemelä <niememat@gmail.com>\n"
 "Language-Team: suomi <niememat@gmail.com>\n"
 "Language: fi\n"
@@ -1088,7 +1088,7 @@ msgstr ""
 "valitsemastasi Linuksin käyttöliittymästä. Ainoa edellytys toimivuudelle on, "
 "että GTK kirjastot on asennettuna."
 
-#: ../gramps/cli/arghandler.py:228
+#: ../gramps/cli/arghandler.py:229
 #, python-format
 msgid ""
 "Error: Family Tree '%s' already exists.\n"
@@ -1097,7 +1097,7 @@ msgstr ""
 "Virhe: Sukupuu '%s' löytyy jo.\n"
 "'-C' valintaa ei voi käyttää."
 
-#: ../gramps/cli/arghandler.py:240
+#: ../gramps/cli/arghandler.py:241
 #, python-format
 msgid ""
 "Error: Input Family Tree \"%s\" does not exist.\n"
@@ -1108,18 +1108,18 @@ msgstr ""
 "Jos tuot GEDCOM, Gramps-xml tai grdb tiedostoa, käytä tuonnissa sen sijaan -"
 "i valintaa."
 
-#: ../gramps/cli/arghandler.py:254
+#: ../gramps/cli/arghandler.py:255
 #, python-format
 msgid "Error: Import file %s not found."
 msgstr "Virhe: Tuotavaa tiedostoa %s ei löytynyt."
 
-#: ../gramps/cli/arghandler.py:272
+#: ../gramps/cli/arghandler.py:273
 #, python-format
 msgid "Error: Unrecognized type: \"%(format)s\" for import file: %(filename)s"
 msgstr ""
 "Virhe: Tunnistamaton tyyppi: \"%(format)s\" tuotaessa tiedostoa: %(filename)s"
 
-#: ../gramps/cli/arghandler.py:292
+#: ../gramps/cli/arghandler.py:293
 #, python-format
 msgid ""
 "WARNING: Output file already exists!\n"
@@ -1130,44 +1130,44 @@ msgstr ""
 "VAROITUS: Se korvataan uudella:\n"
 "   %s"
 
-#: ../gramps/cli/arghandler.py:295
+#: ../gramps/cli/arghandler.py:296
 msgid "OK to overwrite?"
 msgstr "Onko korvaaminen OK?"
 
-#: ../gramps/cli/arghandler.py:296 ../gramps/cli/clidbman.py:429
+#: ../gramps/cli/arghandler.py:297 ../gramps/cli/clidbman.py:429
 msgid "no"
 msgstr "ei"
 
-#: ../gramps/cli/arghandler.py:296 ../gramps/cli/arghandler.py:297
+#: ../gramps/cli/arghandler.py:297 ../gramps/cli/arghandler.py:298
 #: ../gramps/cli/clidbman.py:429
 msgid "yes"
 msgstr "kyllä"
 
-#: ../gramps/cli/arghandler.py:299
+#: ../gramps/cli/arghandler.py:300
 #, python-format
 msgid "Will overwrite the existing file: %s"
 msgstr "Korvaa aiemman tiedoston: %s"
 
-#: ../gramps/cli/arghandler.py:319
+#: ../gramps/cli/arghandler.py:320
 #, python-format
 msgid "ERROR: Unrecognized format for export file %s"
 msgstr "VIRHE: Tuotavan tiedoston %s tyyppi tuntematon"
 
-#: ../gramps/cli/arghandler.py:385 ../gramps/gen/plug/utils.py:316
+#: ../gramps/cli/arghandler.py:386 ../gramps/gen/plug/utils.py:316
 #, python-format
 msgid "Error: cannot open '%s'"
 msgstr "Virhe: ei voi avata ”%s”"
 
-#: ../gramps/cli/arghandler.py:404
+#: ../gramps/cli/arghandler.py:405
 msgid "List of known Family Trees in your database path\n"
 msgstr "Tietokantapolussasi olevien sukupuiden luettelo\n"
 
-#: ../gramps/cli/arghandler.py:412
+#: ../gramps/cli/arghandler.py:413
 #, python-format
 msgid "%(full_DB_path)s with name \"%(f_t_name)s\""
 msgstr "%(full_DB_path)s nimeltään \"%(f_t_name)s\""
 
-#: ../gramps/cli/arghandler.py:430 ../gramps/cli/clidbman.py:188
+#: ../gramps/cli/arghandler.py:431 ../gramps/cli/clidbman.py:188
 msgid "Gramps Family Trees:"
 msgstr "Gramps Sukupuut:"
 
@@ -1178,96 +1178,96 @@ msgstr "Gramps Sukupuut:"
 #. constants
 #.
 #. -------------------------------------------------------------------------
-#: ../gramps/cli/arghandler.py:436 ../gramps/cli/arghandler.py:438
-#: ../gramps/cli/arghandler.py:443 ../gramps/cli/arghandler.py:444
-#: ../gramps/cli/arghandler.py:446 ../gramps/cli/clidbman.py:69
+#: ../gramps/cli/arghandler.py:437 ../gramps/cli/arghandler.py:439
+#: ../gramps/cli/arghandler.py:444 ../gramps/cli/arghandler.py:445
+#: ../gramps/cli/arghandler.py:447 ../gramps/cli/clidbman.py:69
 #: ../gramps/cli/clidbman.py:169 ../gramps/cli/clidbman.py:197
 #: ../gramps/gui/clipboard.py:916 ../gramps/gui/configure.py:1798
 msgid "Family Tree"
 msgstr "Sukupuu"
 
 #. translators: used in French+Russian, ignore otherwise
-#: ../gramps/cli/arghandler.py:444 ../gramps/cli/arghandler.py:448
+#: ../gramps/cli/arghandler.py:445 ../gramps/cli/arghandler.py:449
 #: ../gramps/gen/plug/report/endnotes.py:199
 #, python-format
 msgid "\"%s\""
 msgstr "\"%s\""
 
-#: ../gramps/cli/arghandler.py:456
+#: ../gramps/cli/arghandler.py:457
 #, python-format
 msgid "Performing action: %s."
 msgstr "Suorittaa toimintoa: %s."
 
-#: ../gramps/cli/arghandler.py:460 ../gramps/gen/plug/report/stdoptions.py:285
+#: ../gramps/cli/arghandler.py:461 ../gramps/gen/plug/report/stdoptions.py:285
 #, python-format
 msgid "Using options string: %s"
 msgstr "Käyttää valittua merkkijonoa: %s"
 
-#: ../gramps/cli/arghandler.py:466
+#: ../gramps/cli/arghandler.py:467
 #, python-format
 msgid "Exporting: file %(filename)s, format %(format)s."
 msgstr "Viedään: tiedosto %(filename)s, muodossa %(format)s."
 
-#: ../gramps/cli/arghandler.py:477
+#: ../gramps/cli/arghandler.py:478
 msgid "Cleaning up."
 msgstr "Siivotaan."
 
-#: ../gramps/cli/arghandler.py:510
+#: ../gramps/cli/arghandler.py:514
 msgid "Created empty Family Tree successfully"
 msgstr "Tyhjä sukupuu luotu onnistuneesti"
 
-#: ../gramps/cli/arghandler.py:513 ../gramps/cli/arghandler.py:539
+#: ../gramps/cli/arghandler.py:517 ../gramps/cli/arghandler.py:543
 msgid "Error opening the file."
 msgstr "Virhe tiedoston avauksessa."
 
-#: ../gramps/cli/arghandler.py:514 ../gramps/cli/arghandler.py:540
+#: ../gramps/cli/arghandler.py:518 ../gramps/cli/arghandler.py:544
 msgid "Exiting..."
 msgstr "Lopettamassa..."
 
-#: ../gramps/cli/arghandler.py:518
+#: ../gramps/cli/arghandler.py:522
 #, python-format
 msgid "Importing: file %(filename)s, format %(format)s."
 msgstr "Tuodaan: tiedosto %(filename)s, muotoa %(format)s."
 
-#: ../gramps/cli/arghandler.py:537
+#: ../gramps/cli/arghandler.py:541
 msgid "Opened successfully!"
 msgstr "Avattu onnistuneesti!"
 
-#: ../gramps/cli/arghandler.py:551
+#: ../gramps/cli/arghandler.py:555
 msgid "Database is locked, cannot open it!"
 msgstr "Sukupuu on lukittu, avaus ei onnistu!"
 
-#: ../gramps/cli/arghandler.py:552
+#: ../gramps/cli/arghandler.py:556
 #, python-format
 msgid "  Info: %s"
 msgstr "  Tiedot: %s"
 
-#: ../gramps/cli/arghandler.py:555
+#: ../gramps/cli/arghandler.py:559
 msgid "Database needs recovery, cannot open it!"
 msgstr "Tietokanta pitää palauttaa (recovery), sitä ei voi avata!"
 
-#: ../gramps/cli/arghandler.py:558
+#: ../gramps/cli/arghandler.py:562
 msgid "Database backend unavailable, cannot open it!"
 msgstr "Tietokantaohjelmisto ei ole käytettävissä, sukupuuta ei voi avata!"
 
-#: ../gramps/cli/arghandler.py:609 ../gramps/cli/arghandler.py:658
-#: ../gramps/cli/arghandler.py:705
+#: ../gramps/cli/arghandler.py:613 ../gramps/cli/arghandler.py:662
+#: ../gramps/cli/arghandler.py:709
 msgid "Ignoring invalid options string."
 msgstr "Virheellinen merkkijono valinta ohitetaan."
 
 #. name exists, but is not in the list of valid report names
-#: ../gramps/cli/arghandler.py:633
+#: ../gramps/cli/arghandler.py:637
 msgid "Unknown report name."
 msgstr "Raportin nimi tuntematon."
 
-#: ../gramps/cli/arghandler.py:635
+#: ../gramps/cli/arghandler.py:639
 #, python-format
 msgid "Report name not given. Please use one of %(donottranslate)s=reportname"
 msgstr ""
 "Raportin nimeä ei annettu. Käytä jotain näistä %(donottranslate)s=reportname"
 
-#: ../gramps/cli/arghandler.py:639 ../gramps/cli/arghandler.py:687
-#: ../gramps/cli/arghandler.py:721
+#: ../gramps/cli/arghandler.py:643 ../gramps/cli/arghandler.py:691
+#: ../gramps/cli/arghandler.py:725
 #, python-format
 msgid ""
 "%s\n"
@@ -1276,26 +1276,26 @@ msgstr ""
 "%s\n"
 " Saatavilla olevat nimet ovat:"
 
-#: ../gramps/cli/arghandler.py:681
+#: ../gramps/cli/arghandler.py:685
 msgid "Unknown tool name."
 msgstr "Työkalun nimi tuntematon."
 
-#: ../gramps/cli/arghandler.py:683
+#: ../gramps/cli/arghandler.py:687
 #, python-format
 msgid "Tool name not given. Please use one of %(donottranslate)s=toolname."
 msgstr ""
 "Työkalun nimi puuttuu. Käytä jotain näistä %(donottranslate)s=toolname."
 
-#: ../gramps/cli/arghandler.py:715
+#: ../gramps/cli/arghandler.py:719
 msgid "Unknown book name."
 msgstr "Tuntematon kirjan nimi."
 
-#: ../gramps/cli/arghandler.py:717
+#: ../gramps/cli/arghandler.py:721
 #, python-format
 msgid "Book name not given. Please use one of %(donottranslate)s=bookname."
 msgstr "Kirjan nimi puuttuu. Käytä jotain näistä %(donottranslate)s=bookname."
 
-#: ../gramps/cli/arghandler.py:726
+#: ../gramps/cli/arghandler.py:730
 #, python-format
 msgid "Unknown action: %s."
 msgstr "Toimenpide tuntematon: %s."
@@ -1790,7 +1790,7 @@ msgstr "Lukittu %s toimesta"
 #: ../gramps/plugins/view/geofamily.py:517
 #: ../gramps/plugins/view/geomoves.py:662
 #: ../gramps/plugins/view/geoperson.py:543
-#: ../gramps/plugins/view/geoplaces.py:590
+#: ../gramps/plugins/view/geoplaces.py:592
 #: ../gramps/plugins/view/relview.py:589 ../gramps/plugins/view/relview.py:1160
 #: ../gramps/plugins/view/relview.py:1215
 #: ../gramps/plugins/webreport/basepage.py:1838
@@ -5317,7 +5317,7 @@ msgstr "Yksittäinen sukunimi:"
 
 #: ../gramps/gen/filters/rules/person/_hasnameof.py:54
 #: ../gramps/gen/lib/surname.py:98
-#: ../gramps/gui/editors/displaytabs/surnametab.py:76
+#: ../gramps/gui/editors/displaytabs/surnametab.py:79
 msgid "Connector"
 msgstr "Yhdistäjä"
 
@@ -6596,7 +6596,7 @@ msgstr "Lainaukset"
 #: ../gramps/plugins/view/noteview.py:110 ../gramps/plugins/view/view.gpr.py:97
 #: ../gramps/plugins/view/view.gpr.py:105
 #: ../gramps/plugins/webreport/basepage.py:1264
-#: ../gramps/plugins/webreport/person.py:1242
+#: ../gramps/plugins/webreport/person.py:1240
 msgid "Notes"
 msgstr "Lisätiedot"
 
@@ -6672,7 +6672,7 @@ msgstr "Lisätiedot"
 #: ../gramps/plugins/webreport/event.py:177
 #: ../gramps/plugins/webreport/media.py:230
 #: ../gramps/plugins/webreport/media.py:564
-#: ../gramps/plugins/webreport/person.py:892
+#: ../gramps/plugins/webreport/person.py:890
 msgid "Date"
 msgstr "Päivämäärä"
 
@@ -6680,7 +6680,7 @@ msgstr "Päivämäärä"
 #: ../gramps/gen/lib/placetype.py:71
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:72
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:54
-#: ../gramps/plugins/view/geoplaces.py:599
+#: ../gramps/plugins/view/geoplaces.py:601
 #: ../gramps/plugins/view/repoview.py:89
 #: ../gramps/plugins/webreport/basepage.py:1128
 #: ../gramps/plugins/webreport/basepage.py:2587
@@ -6692,7 +6692,7 @@ msgstr "Katu"
 #: ../gramps/gen/lib/placetype.py:70 ../gramps/gui/configure.py:612
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:73
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:55
-#: ../gramps/plugins/view/geoplaces.py:596
+#: ../gramps/plugins/view/geoplaces.py:598
 #: ../gramps/plugins/view/repoview.py:90
 #: ../gramps/plugins/webreport/basepage.py:1129
 #: ../gramps/plugins/webreport/basepage.py:2588
@@ -6704,7 +6704,7 @@ msgstr "Taajama"
 #: ../gramps/gen/lib/placetype.py:68 ../gramps/gui/configure.py:615
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:74
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:56
-#: ../gramps/plugins/view/geoplaces.py:647
+#: ../gramps/plugins/view/geoplaces.py:649
 #: ../gramps/plugins/view/repoview.py:91
 #: ../gramps/plugins/webreport/basepage.py:1130
 #: ../gramps/plugins/webreport/basepage.py:2589
@@ -6717,7 +6717,7 @@ msgstr "Paikkakunta"
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:57
 #: ../gramps/gui/views/treemodels/placemodel.py:312
 #: ../gramps/plugins/lib/maps/placeselection.py:151
-#: ../gramps/plugins/view/geoplaces.py:629
+#: ../gramps/plugins/view/geoplaces.py:631
 #: ../gramps/plugins/webreport/basepage.py:1132
 #: ../gramps/plugins/webreport/basepage.py:2592
 #: ../gramps/plugins/webreport/basepage.py:2657
@@ -6729,7 +6729,7 @@ msgstr "Maakunta"
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:58
 #: ../gramps/gui/views/treemodels/placemodel.py:312
 #: ../gramps/plugins/lib/maps/placeselection.py:150
-#: ../gramps/plugins/view/geoplaces.py:626
+#: ../gramps/plugins/view/geoplaces.py:628
 msgid "State"
 msgstr "Lääni tai Osavaltio"
 
@@ -6739,7 +6739,7 @@ msgstr "Lääni tai Osavaltio"
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:59
 #: ../gramps/gui/views/treemodels/placemodel.py:312
 #: ../gramps/plugins/lib/maps/placeselection.py:149
-#: ../gramps/plugins/view/geoplaces.py:623
+#: ../gramps/plugins/view/geoplaces.py:625
 #: ../gramps/plugins/view/repoview.py:93
 #: ../gramps/plugins/webreport/basepage.py:1134
 #: ../gramps/plugins/webreport/basepage.py:2596
@@ -6793,7 +6793,7 @@ msgstr "Arvo"
 #: ../gramps/gen/lib/srcmediatype.py:57 ../gramps/gen/lib/urltype.py:48
 #: ../gramps/gui/autocomp.py:179
 #: ../gramps/plugins/textreport/indivcomplete.py:74
-#: ../gramps/plugins/view/geoplaces.py:593
+#: ../gramps/plugins/view/geoplaces.py:595
 msgid "Custom"
 msgstr "Käyttäjän antama"
 
@@ -7002,7 +7002,7 @@ msgstr "Lainaus"
 #: ../gramps/plugins/webreport/event.py:178
 #: ../gramps/plugins/webreport/event.py:391
 #: ../gramps/plugins/webreport/media.py:541
-#: ../gramps/plugins/webreport/person.py:1470
+#: ../gramps/plugins/webreport/person.py:1468
 #: ../gramps/plugins/webreport/repository.py:245
 #: ../gramps/plugins/webreport/source.py:261
 msgid "Gramps ID"
@@ -7874,7 +7874,7 @@ msgstr "peruut."
 #: ../gramps/plugins/textreport/tagreport.py:252
 #: ../gramps/plugins/view/familyview.py:80
 #: ../gramps/plugins/view/relview.py:1053
-#: ../gramps/plugins/webreport/person.py:1631
+#: ../gramps/plugins/webreport/person.py:1629
 msgid "Father"
 msgstr "Isä"
 
@@ -7896,7 +7896,7 @@ msgstr "Isä"
 #: ../gramps/plugins/textreport/tagreport.py:258
 #: ../gramps/plugins/view/familyview.py:81
 #: ../gramps/plugins/view/relview.py:1054
-#: ../gramps/plugins/webreport/person.py:1644
+#: ../gramps/plugins/webreport/person.py:1642
 msgid "Mother"
 msgstr "Äiti"
 
@@ -7925,7 +7925,7 @@ msgstr "Lapset"
 #: ../gramps/plugins/webreport/basepage.py:1650
 #: ../gramps/plugins/webreport/event.py:141
 #: ../gramps/plugins/webreport/event.py:366
-#: ../gramps/plugins/webreport/person.py:1529
+#: ../gramps/plugins/webreport/person.py:1527
 msgid "Events"
 msgstr "Tapahtumat"
 
@@ -8125,7 +8125,7 @@ msgid "Location"
 msgstr "Sijainti"
 
 #: ../gramps/gen/lib/location.py:107 ../gramps/gen/lib/placetype.py:69
-#: ../gramps/plugins/view/geoplaces.py:644
+#: ../gramps/plugins/view/geoplaces.py:646
 msgid "Parish"
 msgstr "Seurakunta"
 
@@ -8151,7 +8151,7 @@ msgid "Media ref"
 msgstr "Median viite"
 
 #: ../gramps/gen/lib/mediaref.py:110 ../gramps/gen/lib/placetype.py:73
-#: ../gramps/plugins/view/geoplaces.py:635
+#: ../gramps/plugins/view/geoplaces.py:637
 msgid "Region"
 msgstr "Seutukunta"
 
@@ -8204,7 +8204,7 @@ msgstr "Seutukunta"
 #: ../gramps/plugins/tool/removeunused.py:201
 #: ../gramps/plugins/tool/verify.py:579 ../gramps/plugins/view/repoview.py:85
 #: ../gramps/plugins/webreport/basepage.py:397
-#: ../gramps/plugins/webreport/person.py:1855
+#: ../gramps/plugins/webreport/person.py:1853
 msgid "Name"
 msgstr "Nimi"
 
@@ -8560,7 +8560,7 @@ msgstr "Lapsiviitteen lisätietoja"
 #: ../gramps/plugins/tool/reorderids.glade:761
 #: ../gramps/plugins/webreport/event.py:180
 #: ../gramps/plugins/webreport/family.py:188
-#: ../gramps/plugins/webreport/person.py:1240
+#: ../gramps/plugins/webreport/person.py:1238
 msgid "Person"
 msgstr "Henkilö"
 
@@ -8574,7 +8574,7 @@ msgstr "Henkilö"
 #: ../gramps/plugins/lib/libpersonview.py:100
 #: ../gramps/plugins/quickview/siblings.py:48
 #: ../gramps/plugins/textreport/indivcomplete.py:928
-#: ../gramps/plugins/webreport/person.py:1481
+#: ../gramps/plugins/webreport/person.py:1479
 msgid "Gender"
 msgstr "Sukupuoli"
 
@@ -8715,52 +8715,52 @@ msgstr "Kieli"
 msgid "Place ref"
 msgstr "Paikkaviite"
 
-#: ../gramps/gen/lib/placetype.py:72 ../gramps/plugins/view/geoplaces.py:632
+#: ../gramps/gen/lib/placetype.py:72 ../gramps/plugins/view/geoplaces.py:634
 msgid "Province"
 msgstr "Provinssi"
 
-#: ../gramps/gen/lib/placetype.py:74 ../gramps/plugins/view/geoplaces.py:638
+#: ../gramps/gen/lib/placetype.py:74 ../gramps/plugins/view/geoplaces.py:640
 msgid "Department"
 msgstr "Virasto"
 
-#: ../gramps/gen/lib/placetype.py:75 ../gramps/plugins/view/geoplaces.py:602
+#: ../gramps/gen/lib/placetype.py:75 ../gramps/plugins/view/geoplaces.py:604
 msgid "Neighborhood"
 msgstr "Kulmakunta"
 
-#: ../gramps/gen/lib/placetype.py:76 ../gramps/plugins/view/geoplaces.py:641
+#: ../gramps/gen/lib/placetype.py:76 ../gramps/plugins/view/geoplaces.py:643
 msgid "District"
 msgstr "Piirikunta"
 
-#: ../gramps/gen/lib/placetype.py:77 ../gramps/plugins/view/geoplaces.py:548
+#: ../gramps/gen/lib/placetype.py:77 ../gramps/plugins/view/geoplaces.py:607
 msgid "Borough"
 msgstr "Kaupunginosa/Kauppala"
 
-#: ../gramps/gen/lib/placetype.py:78 ../gramps/plugins/view/geoplaces.py:653
+#: ../gramps/gen/lib/placetype.py:78 ../gramps/plugins/view/geoplaces.py:655
 msgid "Municipality"
 msgstr "Kunta"
 
-#: ../gramps/gen/lib/placetype.py:79 ../gramps/plugins/view/geoplaces.py:650
+#: ../gramps/gen/lib/placetype.py:79 ../gramps/plugins/view/geoplaces.py:652
 msgid "Town"
 msgstr "Kaupunki"
 
-#: ../gramps/gen/lib/placetype.py:80 ../gramps/plugins/view/geoplaces.py:608
+#: ../gramps/gen/lib/placetype.py:80 ../gramps/plugins/view/geoplaces.py:610
 msgid "Village"
 msgstr "Kylä"
 
-#: ../gramps/gen/lib/placetype.py:81 ../gramps/plugins/view/geoplaces.py:611
+#: ../gramps/gen/lib/placetype.py:81 ../gramps/plugins/view/geoplaces.py:613
 msgid "Hamlet"
 msgstr "Taloryhmä tai Osakylä"
 
-#: ../gramps/gen/lib/placetype.py:82 ../gramps/plugins/view/geoplaces.py:614
+#: ../gramps/gen/lib/placetype.py:82 ../gramps/plugins/view/geoplaces.py:616
 msgid "Farm"
 msgstr "Tila tai Talo"
 
-#: ../gramps/gen/lib/placetype.py:83 ../gramps/plugins/view/geoplaces.py:617
+#: ../gramps/gen/lib/placetype.py:83 ../gramps/plugins/view/geoplaces.py:619
 msgid "Building"
 msgstr "Rakennus tai Torppa"
 
 #: ../gramps/gen/lib/placetype.py:84 ../gramps/plugins/gramplet/leak.py:95
-#: ../gramps/plugins/view/geoplaces.py:620
+#: ../gramps/plugins/view/geoplaces.py:622
 #: ../gramps/plugins/webreport/basepage.py:2802
 #: ../gramps/plugins/webreport/source.py:164
 msgid "Number"
@@ -8994,7 +8994,7 @@ msgstr "Linkki"
 #: ../gramps/gui/configure.py:848 ../gramps/gui/configure.py:850
 #: ../gramps/gui/configure.py:853 ../gramps/gui/configure.py:854
 #: ../gramps/gui/configure.py:855 ../gramps/gui/configure.py:856
-#: ../gramps/gui/editors/displaytabs/surnametab.py:75
+#: ../gramps/gui/editors/displaytabs/surnametab.py:78
 #: ../gramps/gui/plug/_guioptions.py:88 ../gramps/gui/plug/_guioptions.py:1508
 #: ../gramps/plugins/drawreport/statisticschart.py:340
 #: ../gramps/plugins/export/exportcsv.py:354
@@ -9007,7 +9007,7 @@ msgid "Surname"
 msgstr "Sukunimi"
 
 #: ../gramps/gen/lib/surname.py:93 ../gramps/gen/utils/keyword.py:71
-#: ../gramps/gui/editors/displaytabs/surnametab.py:74
+#: ../gramps/gui/editors/displaytabs/surnametab.py:77
 #: ../gramps/gui/glade/editperson.glade:470
 #: ../gramps/plugins/export/exportcsv.py:355
 #: ../gramps/plugins/importer/importcsv.py:167
@@ -10421,30 +10421,6 @@ msgstr "ent. avovaimo"
 msgid "gender unknown,unmarried|ex-partner"
 msgstr "ent. avopuoliso"
 
-#: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
-msgstr "avomies"
-
-#: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
-msgstr "avovaimo"
-
-#: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
-msgstr "avopuoliso"
-
-#: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
-msgstr "ent. avomies"
-
-#: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
-msgstr "ent. avovaimo"
-
-#: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
-msgstr "ent. avopuoliso"
-
 #: ../gramps/gen/relationship.py:2198
 msgid "male,civil union|partner"
 msgstr "virallinen mieskumppani"
@@ -10893,7 +10869,7 @@ msgstr "LOPPULIITE"
 
 #. name, sort, width, modelcol
 #: ../gramps/gen/utils/keyword.py:61
-#: ../gramps/gui/editors/displaytabs/surnametab.py:79
+#: ../gramps/gui/editors/displaytabs/surnametab.py:82
 msgid "Name|Primary"
 msgstr "Päänimi"
 
@@ -12196,7 +12172,7 @@ msgstr "Valitse mediatiedostojen hakemisto"
 #: ../gramps/gui/plug/_guioptions.py:1744 ../gramps/gui/plug/_windows.py:440
 #: ../gramps/gui/plug/report/_fileentry.py:64
 #: ../gramps/gui/plug/report/_reportdialog.py:162 ../gramps/gui/utils.py:180
-#: ../gramps/gui/viewmanager.py:1792 ../gramps/gui/views/listview.py:1054
+#: ../gramps/gui/viewmanager.py:1792 ../gramps/gui/views/listview.py:1064
 #: ../gramps/gui/views/navigationview.py:348 ../gramps/gui/views/tags.py:682
 #: ../gramps/gui/widgets/progressdialog.py:437
 #: ../gramps/plugins/importer/importprogen.glade:1714
@@ -12820,48 +12796,48 @@ msgstr ""
 "Älä yritä väkisin sulkea tätä tärkeää ikkunaa.\n"
 "Valitse sen sijaan jokin esitetyistä vaihtoehdoista"
 
-#: ../gramps/gui/displaystate.py:290
+#: ../gramps/gui/displaystate.py:279
 msgid "Cannot load database"
 msgstr "Tietokantaa ei voi ladata"
 
-#: ../gramps/gui/displaystate.py:408
+#: ../gramps/gui/displaystate.py:397
 #: ../gramps/plugins/gramplet/persondetails.py:173
 msgid "No active person"
 msgstr "Ei aktiivista henkilöä"
 
-#: ../gramps/gui/displaystate.py:409
+#: ../gramps/gui/displaystate.py:398
 msgid "No active family"
 msgstr "Ei aktiivista perhettä"
 
-#: ../gramps/gui/displaystate.py:410
+#: ../gramps/gui/displaystate.py:399
 msgid "No active event"
 msgstr "Ei aktiivista tapahtumaa"
 
-#: ../gramps/gui/displaystate.py:411
+#: ../gramps/gui/displaystate.py:400
 msgid "No active place"
 msgstr "Aktiivista paikkaa ei ole asetettu"
 
-#: ../gramps/gui/displaystate.py:412
+#: ../gramps/gui/displaystate.py:401
 msgid "No active source"
 msgstr "Aktiivista lähdettä ei ole asetettu"
 
-#: ../gramps/gui/displaystate.py:413
+#: ../gramps/gui/displaystate.py:402
 msgid "No active citation"
 msgstr "Aktiivista lainausta ei ole asetettu"
 
-#: ../gramps/gui/displaystate.py:414
+#: ../gramps/gui/displaystate.py:403
 msgid "No active repository"
 msgstr "Aktiivista arkistoa ei ole asetettu"
 
-#: ../gramps/gui/displaystate.py:415
+#: ../gramps/gui/displaystate.py:404
 msgid "No active media"
 msgstr "Aktiivista mediatiedostoa ei ole asetettu"
 
-#: ../gramps/gui/displaystate.py:416
+#: ../gramps/gui/displaystate.py:405
 msgid "No active note"
 msgstr "Aktiivista lisätietoa ei ole asetettu"
 
-#: ../gramps/gui/displaystate.py:655 ../gramps/plugins/gramplet/todo.py:200
+#: ../gramps/gui/displaystate.py:644 ../gramps/plugins/gramplet/todo.py:200
 msgid "No active object"
 msgstr "Ei aktiivista kohdetta"
 
@@ -13535,36 +13511,36 @@ msgstr ""
 "\n"
 "Muokataksesi arkistoviitettä, sinun pitää sulkea arkisto."
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:64
+#: ../gramps/gui/editors/displaytabs/surnametab.py:67
 msgid "Create and add a new surname"
 msgstr "Luo ja lisää uusi sukunimi"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:65
+#: ../gramps/gui/editors/displaytabs/surnametab.py:68
 msgid "Remove the selected surname"
 msgstr "Poista valittu sukunimi"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:66
+#: ../gramps/gui/editors/displaytabs/surnametab.py:69
 msgid "Edit the selected surname"
 msgstr "Muokkaa valittua sukunimeä"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:67
+#: ../gramps/gui/editors/displaytabs/surnametab.py:70
 msgid "Move the selected surname upwards"
 msgstr "Siirrä valittu sukunimi ylöspäin"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:68
+#: ../gramps/gui/editors/displaytabs/surnametab.py:71
 msgid "Move the selected surname downwards"
 msgstr "Siirrä valittu sukunimi alaspäin"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:78
+#: ../gramps/gui/editors/displaytabs/surnametab.py:81
 #: ../gramps/plugins/lib/libgedcom.py:712
 msgid "Origin"
 msgstr "Alkuperä"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:82
+#: ../gramps/gui/editors/displaytabs/surnametab.py:85
 msgid "Multiple Surnames"
 msgstr "Useita sukunimiä"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:89
+#: ../gramps/gui/editors/displaytabs/surnametab.py:92
 msgid "Family Surnames"
 msgstr "Sukunimet"
 
@@ -14516,8 +14492,8 @@ msgstr ""
 
 #: ../gramps/gui/editors/editplace.py:217
 #: ../gramps/plugins/lib/maps/geography.py:891
-#: ../gramps/plugins/view/geoplaces.py:494
-#: ../gramps/plugins/view/geoplaces.py:520
+#: ../gramps/plugins/view/geoplaces.py:496
+#: ../gramps/plugins/view/geoplaces.py:522
 msgid "Edit Place"
 msgstr "Muokkaa paikkaa"
 
@@ -15059,8 +15035,8 @@ msgstr "Näppäin %s ei ole sidottu mihinkään"
 msgid "%s does not contain"
 msgstr "%s ei sisällä"
 
-#: ../gramps/gui/filters/_searchbar.py:168 ../gramps/gui/views/listview.py:1188
-#: ../gramps/gui/views/listview.py:1208 ../gramps/plugins/gramplet/leak.py:193
+#: ../gramps/gui/filters/_searchbar.py:168 ../gramps/gui/views/listview.py:1198
+#: ../gramps/gui/views/listview.py:1218 ../gramps/plugins/gramplet/leak.py:193
 #: ../gramps/plugins/gramplet/leak.py:200
 msgid "Updating display..."
 msgstr "Päivitetään näyttöä..."
@@ -15110,7 +15086,7 @@ msgstr "Pääosalliset"
 #: ../gramps/gui/widgets/reorderfam.py:103
 #: ../gramps/plugins/textreport/tagreport.py:264
 #: ../gramps/plugins/view/familyview.py:82
-#: ../gramps/plugins/webreport/person.py:1241
+#: ../gramps/plugins/webreport/person.py:1239
 msgid "Relationship"
 msgstr "Suhde"
 
@@ -15120,7 +15096,7 @@ msgstr "mikä tahansa"
 
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:134
 #: ../gramps/plugins/export/exportcsv.py:357
-#: ../gramps/plugins/webreport/person.py:1856
+#: ../gramps/plugins/webreport/person.py:1854
 msgid "Birth date"
 msgstr "Syntymäaika"
 
@@ -15132,7 +15108,7 @@ msgstr "esimerkki: \"%(msg1)s\" tai \"%(msg2)s\""
 
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:136
 #: ../gramps/plugins/export/exportcsv.py:359
-#: ../gramps/plugins/webreport/person.py:1857
+#: ../gramps/plugins/webreport/person.py:1855
 msgid "Death date"
 msgstr "Kuolinaika"
 
@@ -15429,7 +15405,7 @@ msgstr "Sulje tallentamatta"
 
 #: ../gramps/gui/glade/dialog.glade:873
 #: ../gramps/gui/plug/report/_bookdialog.py:637
-#: ../gramps/gui/views/listview.py:1055
+#: ../gramps/gui/views/listview.py:1065
 #: ../gramps/gui/widgets/grampletpane.py:588
 #: ../gramps/plugins/tool/eventcmp.py:400
 msgid "_Save"
@@ -15942,7 +15918,7 @@ msgid "_Tags:"
 msgstr "Tagit:"
 
 #: ../gramps/gui/glade/editfamily.glade:764
-#: ../gramps/gui/widgets/monitoredwidgets.py:842
+#: ../gramps/gui/widgets/monitoredwidgets.py:853
 msgid "Edit the tag list"
 msgstr "Muokkaa tagi listaa"
 
@@ -16907,7 +16883,7 @@ msgid "Note 2"
 msgstr "Lisätieto 2"
 
 #: ../gramps/gui/glade/mergenote.glade:278
-#: ../gramps/gui/glade/mergenote.glade:294 ../gramps/gui/views/listview.py:1059
+#: ../gramps/gui/glade/mergenote.glade:294 ../gramps/gui/views/listview.py:1069
 msgid "Format:"
 msgstr "Muotoiltu:"
 
@@ -18068,7 +18044,7 @@ msgstr "Sulauta henkilöt"
 #: ../gramps/plugins/view/relview.py:659 ../gramps/plugins/view/relview.py:1017
 #: ../gramps/plugins/view/relview.py:1052
 #: ../gramps/plugins/webreport/person.py:232
-#: ../gramps/plugins/webreport/person.py:1839
+#: ../gramps/plugins/webreport/person.py:1837
 #: ../gramps/plugins/webreport/surname.py:154
 msgid "Parents"
 msgstr "Vanhemmat"
@@ -19667,19 +19643,19 @@ msgstr "Poista %s?"
 msgid "Column clicked, sorting..."
 msgstr "Sarake valittu, lajitellaan..."
 
-#: ../gramps/gui/views/listview.py:1051
+#: ../gramps/gui/views/listview.py:1061
 msgid "Export View as Spreadsheet"
 msgstr "Vie näkymä taulukkolaskentamuotoon"
 
-#: ../gramps/gui/views/listview.py:1064
+#: ../gramps/gui/views/listview.py:1074
 msgid "CSV"
 msgstr "CSV"
 
-#: ../gramps/gui/views/listview.py:1065
+#: ../gramps/gui/views/listview.py:1075
 msgid "OpenDocument Spreadsheet"
 msgstr "OpenDocument laskentataulukko"
 
-#: ../gramps/gui/views/listview.py:1256
+#: ../gramps/gui/views/listview.py:1266
 msgid "Columns"
 msgstr "Sarakkeet"
 
@@ -19700,7 +19676,7 @@ msgid "No Home Person"
 msgstr "Kotihenkilöä ei ole asetettu"
 
 # 20190612
-#: ../gramps/gui/views/navigationview.py:339
+#: ../gramps/gui/views/navigationview.py:324
 msgid ""
 "You need to set a 'default person' to go to. Select the People View, select "
 "the person you want as 'Home Person', then confirm your choice via the menu "
@@ -19708,15 +19684,6 @@ msgid ""
 msgstr ""
 "Lähtöhenkilö on valittava. Avaa Henkilöt näkymä ja valitse hänet. Vahvista "
 "valintasi Muokkaa-> Aseta kotihenkilö-valinnalla."
-
-#: ../gramps/gui/views/navigationview.py:324
-msgid ""
-"You need to set a 'default person' to go to. Select the People View, select "
-"the person you want as 'Home Person', then confirm your choice via the menu "
-"Edit ->Set Home Person."
-msgstr ""
-"Lähtöhenkilö on valittava. Avaa Henkilöt näkymä ja valitse hänet. Vahvista "
-"valintasi Muokkaa->Aseta kotihenkilö-valinnalla."
 
 #: ../gramps/gui/views/navigationview.py:334
 #: ../gramps/gui/views/navigationview.py:337
@@ -20014,11 +19981,11 @@ msgstr ""
 "Napsauta päivitä kuvaketta (jonka aktivoit määritysten asetus valinnoissa ) "
 "päivittääksesi"
 
-#: ../gramps/gui/widgets/monitoredwidgets.py:651
+#: ../gramps/gui/widgets/monitoredwidgets.py:662
 msgid "Bad Date"
 msgstr "Virheellinen päivämäärä"
 
-#: ../gramps/gui/widgets/monitoredwidgets.py:654
+#: ../gramps/gui/widgets/monitoredwidgets.py:665
 msgid "Date more than one year in the future"
 msgstr "Päivämäärä yli vuoden päässä tulevaisuudessa"
 
@@ -20300,6 +20267,19 @@ msgid "Generates documents in plain text format (.txt)."
 msgstr "Tuottaa dokumentteja muotoilemattomana tekstinä (.txt)."
 
 #: ../gramps/plugins/docgen/docgen.gpr.py:55
+#: ../gramps/plugins/view/fanchartview.py:164
+#: ../gramps/plugins/view/fanchartview.py:227
+#: ../gramps/plugins/view/geoclose.py:91 ../gramps/plugins/view/geoclose.py:167
+#: ../gramps/plugins/view/geoevents.py:81
+#: ../gramps/plugins/view/geoevents.py:129
+#: ../gramps/plugins/view/geofamclose.py:89
+#: ../gramps/plugins/view/geofamclose.py:165
+#: ../gramps/plugins/view/geofamily.py:81
+#: ../gramps/plugins/view/geofamily.py:131
+#: ../gramps/plugins/view/geomoves.py:88 ../gramps/plugins/view/geomoves.py:151
+#: ../gramps/plugins/view/geoperson.py:89
+#: ../gramps/plugins/view/geoplaces.py:84
+#: ../gramps/plugins/view/geoplaces.py:134
 msgid "Print..."
 msgstr "Tulosta..."
 
@@ -22667,7 +22647,7 @@ msgstr "Gramplet näyttää aktiivisen henkilöt jälkeläiset"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:104
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:111
-#: ../gramps/plugins/webreport/person.py:1177
+#: ../gramps/plugins/webreport/person.py:1175
 msgid "Ancestors"
 msgstr "Esivanhemmat"
 
@@ -22735,7 +22715,7 @@ msgstr "Gramplet näyttää kaikki etunimet pilvikaaviona"
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:205
 #: ../gramps/plugins/view/pedigreeview.py:528
 #: ../gramps/plugins/view/view.gpr.py:127
-#: ../gramps/plugins/webreport/person.py:1346
+#: ../gramps/plugins/webreport/person.py:1344
 msgid "Pedigree"
 msgstr "Esipolvien taulu"
 
@@ -23150,7 +23130,7 @@ msgstr "Gramplet näyttää henkilöön tulevat linkit"
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:981
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:995
 #: ../gramps/plugins/webreport/basepage.py:2959
-#: ../gramps/plugins/webreport/person.py:878
+#: ../gramps/plugins/webreport/person.py:876
 #: ../gramps/plugins/webreport/thumbnail.py:164
 msgid "References"
 msgstr "Viitteet"
@@ -29979,7 +29959,7 @@ msgstr "_Sulauta..."
 #: ../gramps/plugins/lib/libplaceview.py:322
 #: ../gramps/plugins/lib/libplaceview.py:457
 #: ../gramps/plugins/view/citationlistview.py:214
-#: ../gramps/plugins/view/citationlistview.py:342
+#: ../gramps/plugins/view/citationlistview.py:343
 #: ../gramps/plugins/view/citationtreeview.py:364
 #: ../gramps/plugins/view/citationtreeview.py:527
 #: ../gramps/plugins/view/eventview.py:228
@@ -30535,8 +30515,8 @@ msgstr "GTK versio on liian vanha."
 #: ../gramps/plugins/view/geoperson.py:508
 #: ../gramps/plugins/view/geoperson.py:529
 #: ../gramps/plugins/view/geoperson.py:569
-#: ../gramps/plugins/view/geoplaces.py:499
-#: ../gramps/plugins/view/geoplaces.py:524
+#: ../gramps/plugins/view/geoplaces.py:501
+#: ../gramps/plugins/view/geoplaces.py:526
 msgid "Center on this place"
 msgstr "Keskitä tähän paikkaan"
 
@@ -30794,7 +30774,7 @@ msgstr "Tapahtumapaikka"
 #: ../gramps/plugins/quickview/all_events.py:60
 #: ../gramps/plugins/quickview/all_events.py:109
 #: ../gramps/plugins/quickview/all_events.py:124
-#: ../gramps/plugins/webreport/person.py:894
+#: ../gramps/plugins/webreport/person.py:892
 msgid "Event Type"
 msgstr "Tapahtumatyyppi"
 
@@ -31071,7 +31051,7 @@ msgstr "Henkilöt"
 #: ../gramps/plugins/webreport/basepage.py:1531
 #: ../gramps/plugins/webreport/basepage.py:1583
 #: ../gramps/plugins/webreport/basepage.py:1652
-#: ../gramps/plugins/webreport/person.py:1243
+#: ../gramps/plugins/webreport/person.py:1241
 #: ../gramps/plugins/webreport/source.py:130
 #: ../gramps/plugins/webreport/source.py:227
 msgid "Sources"
@@ -32514,7 +32494,7 @@ msgid "Alternate Parents"
 msgstr "Vaihtoehtoiset vanhemmat"
 
 #: ../gramps/plugins/textreport/indivcomplete.py:445
-#: ../gramps/plugins/webreport/person.py:1228
+#: ../gramps/plugins/webreport/person.py:1226
 msgid "Associations"
 msgstr "Liitokset"
 
@@ -35256,7 +35236,7 @@ msgstr "Lainaus näkymä"
 msgid "Citation Filter Editor"
 msgstr "Näkymäsuodin muokkain"
 
-#: ../gramps/plugins/view/citationlistview.py:394
+#: ../gramps/plugins/view/citationlistview.py:395
 msgid ""
 "This citation cannot be edited at this time. Either the associated citation "
 "is already being edited or another object that is associated with the same "
@@ -35269,14 +35249,14 @@ msgstr ""
 "\n"
 "Muokataksesi tapahtumaa, sinun pitää sulkea em. muu kohde."
 
-#: ../gramps/plugins/view/citationlistview.py:407
-#: ../gramps/plugins/view/citationlistview.py:418
+#: ../gramps/plugins/view/citationlistview.py:408
+#: ../gramps/plugins/view/citationlistview.py:419
 #: ../gramps/plugins/view/citationtreeview.py:664
 #: ../gramps/plugins/view/citationtreeview.py:677
 msgid "Cannot merge citations."
 msgstr "Lainausten sulautus ei onnistu."
 
-#: ../gramps/plugins/view/citationlistview.py:408
+#: ../gramps/plugins/view/citationlistview.py:409
 #: ../gramps/plugins/view/citationtreeview.py:665
 msgid ""
 "Exactly two citations must be selected to perform a merge. A second citation "
@@ -35286,7 +35266,7 @@ msgstr ""
 "Kaksi lainausta pitää olla valittuna sulautettavaksi. Toinen lainaus voidaan "
 "valita pitämällä Control-näppäintä alhaalla napsautettaessa."
 
-#: ../gramps/plugins/view/citationlistview.py:419
+#: ../gramps/plugins/view/citationlistview.py:420
 #: ../gramps/plugins/view/citationtreeview.py:678
 msgid ""
 "The two selected citations must have the same source to perform a merge. If "
@@ -35632,22 +35612,6 @@ msgstr "Sektori"
 msgid "Show gramps id"
 msgstr "Näytä gramps-ID"
 
-#: ../gramps/plugins/view/fanchartview.py:164
-#: ../gramps/plugins/view/fanchartview.py:227
-#: ../gramps/plugins/view/geoclose.py:91 ../gramps/plugins/view/geoclose.py:167
-#: ../gramps/plugins/view/geoevents.py:81
-#: ../gramps/plugins/view/geoevents.py:129
-#: ../gramps/plugins/view/geofamclose.py:89
-#: ../gramps/plugins/view/geofamclose.py:165
-#: ../gramps/plugins/view/geofamily.py:81
-#: ../gramps/plugins/view/geofamily.py:131
-#: ../gramps/plugins/view/geomoves.py:88 ../gramps/plugins/view/geomoves.py:151
-#: ../gramps/plugins/view/geoperson.py:89
-#: ../gramps/plugins/view/geoplaces.py:84
-#: ../gramps/plugins/view/geoplaces.py:134
-msgid "_Print..."
-msgstr "_Tulosta..."
-
 #: ../gramps/plugins/view/fanchartview.py:227
 msgid "Print or save the Fan Chart View"
 msgstr "Tulostaa tai tallentaa Viuhkakaavio näkymän"
@@ -35787,8 +35751,8 @@ msgstr "Näytä kaikki tapahtumapaikat"
 
 #: ../gramps/plugins/view/geoevents.py:459
 #: ../gramps/plugins/view/geoevents.py:464
-#: ../gramps/plugins/view/geoplaces.py:549
-#: ../gramps/plugins/view/geoplaces.py:554
+#: ../gramps/plugins/view/geoplaces.py:551
+#: ../gramps/plugins/view/geoplaces.py:556
 msgid "Centering on Place"
 msgstr "Keskitä paikkaan"
 
@@ -36081,7 +36045,7 @@ msgstr ""
 "näyttää kaikkien paikkojen tunnetut sijainnit. Voit muuttaa markkerien väriä "
 "paikkatyypeittäin. Voit käyttää suodatusta."
 
-#: ../gramps/plugins/view/geoplaces.py:445
+#: ../gramps/plugins/view/geoplaces.py:447
 msgid ""
 "Right click on the map and select 'show all places' to show all known places "
 "with coordinates. You can use the history to navigate on the map. You can "
@@ -36092,45 +36056,45 @@ msgstr ""
 "haluat navigoida kartalla. Voit muuttaa markkerien väriä paikkatyypeittäin. "
 "Voit käyttää suodatusta."
 
-#: ../gramps/plugins/view/geoplaces.py:460
+#: ../gramps/plugins/view/geoplaces.py:462
 msgid "The place name in the status bar is disabled."
 msgstr "Paikannimi tilapalkissa on poistettu käytöstä."
 
-#: ../gramps/plugins/view/geoplaces.py:465
+#: ../gramps/plugins/view/geoplaces.py:467
 #, python-format
 msgid "The maximum number of places is reached (%d)."
 msgstr "Enin määrä paikkoja saavutettu (%d)."
 
-#: ../gramps/plugins/view/geoplaces.py:468
+#: ../gramps/plugins/view/geoplaces.py:470
 msgid "Some information are missing."
 msgstr "Joitakin tietoja puuttuu."
 
-#: ../gramps/plugins/view/geoplaces.py:470
+#: ../gramps/plugins/view/geoplaces.py:472
 msgid "Please, use filtering to reduce this number."
 msgstr "Tämän luvun pienentämiseksi käytä suodatusta."
 
-#: ../gramps/plugins/view/geoplaces.py:472
+#: ../gramps/plugins/view/geoplaces.py:474
 msgid "You can modify this value in the geography option."
 msgstr "Voit muuttaa tämän arvon karttavalinnoissa."
 
-#: ../gramps/plugins/view/geoplaces.py:474
+#: ../gramps/plugins/view/geoplaces.py:476
 msgid "In this case, it may take time to show all markers."
 msgstr "Tässä tapauksessa kaikkien markkereiden näyttäminen vie aikaa."
 
-#: ../gramps/plugins/view/geoplaces.py:506
-#: ../gramps/plugins/view/geoplaces.py:530
+#: ../gramps/plugins/view/geoplaces.py:508
+#: ../gramps/plugins/view/geoplaces.py:532
 msgid "Bookmark this place"
 msgstr "Kirjanmerkkaa tämä paikka"
 
-#: ../gramps/plugins/view/geoplaces.py:545
+#: ../gramps/plugins/view/geoplaces.py:547
 msgid "Show all places"
 msgstr "Näytä kaikki paikat"
 
-#: ../gramps/plugins/view/geoplaces.py:657
+#: ../gramps/plugins/view/geoplaces.py:659
 msgid "Custom places name"
 msgstr "Mukautettujen paikkojen nimi"
 
-#: ../gramps/plugins/view/geoplaces.py:666
+#: ../gramps/plugins/view/geoplaces.py:668
 msgid "The places marker color"
 msgstr "Paikkojen merkintävärit"
 
@@ -36783,7 +36747,7 @@ msgstr "Mormonisakramentti"
 #: ../gramps/plugins/webreport/basepage.py:2344
 #: ../gramps/plugins/webreport/basepage.py:2345
 #: ../gramps/plugins/webreport/person.py:630
-#: ../gramps/plugins/webreport/person.py:941
+#: ../gramps/plugins/webreport/person.py:939
 msgid "Family Map"
 msgstr "Perhekartta"
 
@@ -37636,13 +37600,13 @@ msgstr "<puuttuva>"
 msgid "Surnames %(surname)s beginning with letter %(letter)s"
 msgstr "Sukunimet %(surname)s alkaen kirjaimella %(letter)s"
 
-#: ../gramps/plugins/webreport/person.py:792
+#: ../gramps/plugins/webreport/person.py:790
 #, python-format
 msgid "Tracking %s"
 msgstr "Jäljitetään %s"
 
 #. page description
-#: ../gramps/plugins/webreport/person.py:797
+#: ../gramps/plugins/webreport/person.py:795
 msgid ""
 "This map page represents that person and any descendants with all of their "
 "event/ places. If you place your mouse over the marker it will display the "
@@ -37655,47 +37619,47 @@ msgstr ""
 "viitteistä ovat aikajärjestyksessä (jos löytyy). Napsauttamalla nimeä "
 "viitteiden osassa siirryt valitun paikan sivulle."
 
-#: ../gramps/plugins/webreport/person.py:868
+#: ../gramps/plugins/webreport/person.py:866
 msgid "Drop Markers"
 msgstr "Pudota markkerit"
 
-#: ../gramps/plugins/webreport/person.py:893
+#: ../gramps/plugins/webreport/person.py:891
 msgid "Place Title"
 msgstr "Paikan nimi"
 
-#: ../gramps/plugins/webreport/person.py:1440
+#: ../gramps/plugins/webreport/person.py:1438
 msgid "Call Name"
 msgstr "Kutsumanimi"
 
-#: ../gramps/plugins/webreport/person.py:1458
+#: ../gramps/plugins/webreport/person.py:1456
 msgid "Nick Name"
 msgstr "Lempinimi"
 
-#: ../gramps/plugins/webreport/person.py:1504
+#: ../gramps/plugins/webreport/person.py:1502
 msgid "Age at Death"
 msgstr "Ikä kuollessa"
 
-#: ../gramps/plugins/webreport/person.py:1634
+#: ../gramps/plugins/webreport/person.py:1632
 msgid "Stepfather"
 msgstr "Isäpuoli"
 
-#: ../gramps/plugins/webreport/person.py:1647
+#: ../gramps/plugins/webreport/person.py:1645
 msgid "Stepmother"
 msgstr "Äitipuoli"
 
-#: ../gramps/plugins/webreport/person.py:1675
+#: ../gramps/plugins/webreport/person.py:1673
 msgid "Not siblings"
 msgstr "Ei sisaruksia"
 
-#: ../gramps/plugins/webreport/person.py:1817
+#: ../gramps/plugins/webreport/person.py:1815
 msgid "Relation to the center person"
 msgstr "Suhde kotihenkilöön"
 
-#: ../gramps/plugins/webreport/person.py:1854
+#: ../gramps/plugins/webreport/person.py:1852
 msgid "Relation to main person"
 msgstr "Suhde päähenkilöön"
 
-#: ../gramps/plugins/webreport/person.py:1858
+#: ../gramps/plugins/webreport/person.py:1856
 msgid "Relation within this family (if not by birth)"
 msgstr "Suhde tähän perheeseen (jollei syntymän kautta)"
 
@@ -37725,7 +37689,7 @@ msgid "Places beginning with letter %s"
 msgstr "Kirjaimella %s alkavat paikat"
 
 #. section title
-#: ../gramps/plugins/webreport/place.py:408
+#: ../gramps/plugins/webreport/place.py:406
 msgid "Place Map"
 msgstr "Paikkakartta"
 
@@ -38220,6 +38184,35 @@ msgstr "Nebraska"
 msgid "No style sheet"
 msgstr "Ei tyylitiedostoa"
 
+#~ msgid "unmarried|husband"
+#~ msgstr "avomies"
+
+#~ msgid "unmarried|wife"
+#~ msgstr "avovaimo"
+
+#~ msgid "gender unknown,unmarried|spouse"
+#~ msgstr "avopuoliso"
+
+#~ msgid "unmarried|ex-husband"
+#~ msgstr "ent. avomies"
+
+#~ msgid "unmarried|ex-wife"
+#~ msgstr "ent. avovaimo"
+
+#~ msgid "gender unknown,unmarried|ex-spouse"
+#~ msgstr "ent. avopuoliso"
+
+#~ msgid ""
+#~ "You need to set a 'default person' to go to. Select the People View, "
+#~ "select the person you want as 'Home Person', then confirm your choice via "
+#~ "the menu Edit ->Set Home Person."
+#~ msgstr ""
+#~ "Lähtöhenkilö on valittava. Avaa Henkilöt näkymä ja valitse hänet. "
+#~ "Vahvista valintasi Muokkaa->Aseta kotihenkilö-valinnalla."
+
+#~ msgid "_Print..."
+#~ msgstr "_Tulosta..."
+
 #~ msgid "Size  proportional to number of descendants"
 #~ msgstr "Kokoon suhteutettu määrä jälkeläisiä"
 
@@ -38439,4 +38432,3 @@ msgstr "Ei tyylitiedostoa"
 
 #~ msgid " (%s) "
 #~ msgstr " (%s) "
-

--- a/po/hu.po
+++ b/po/hu.po
@@ -6,22 +6,22 @@
 # Egyeki Gergely <egeri@elte.hu>, 2003, 2004.
 # Arpad Horvath <horvath.arpad@szgti.bmf.hu>, 2006.
 # Kolesár András <translation@kolesar.hu>, 2009.
-# Nemeséri Lajos <nemeseril@gmail.com>,2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018.
+# Nemeséri Lajos <nemeseril@gmail.com>, 2011-2019.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: GRAMPS 5.0.X\n"
+"Project-Id-Version: GRAMPS 5.1.X\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-24 14:13+0100\n"
-"PO-Revision-Date: 2018-12-20 13:49+0100\n"
+"POT-Creation-Date: 2019-06-13 17:22-0500\n"
+"PO-Revision-Date: 2019-07-10 15:32+0200\n"
 "Last-Translator: Nemeséri Lajos <nemeseril@gmail.com>\n"
-"Language-Team: magyar <>\n"
+"Language-Team: Hungarian <x@gmail.com>\n"
 "Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Gtranslator 2.91.7\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Gtranslator 3.32.1\n"
 
 #: ../data/gramps.appdata.xml.in.h:1
 msgid ""
@@ -664,16 +664,16 @@ msgstr ""
 msgid ""
 "<b>Improving Gramps</b><br/>Users are encouraged to request enhancements to "
 "Gramps. Requesting an enhancement can be done either through the gramps-"
-"users or gramps-devel mailing lists, or by going to http://bugs.gramps-"
-"project.org and creating a Feature Request. Filing a Feature Request is "
+"users or gramps-devel mailing lists, or by going to https://gramps-project."
+"org/bugs/ and creating a Feature Request. Filing a Feature Request is "
 "preferred but it can be good to discuss your ideas on the email lists."
 msgstr ""
 "<b>A GRAMPS továbbfejlesztése</b><br/>A felhasználókat arra bátorítjuk, hogy "
 "kérjenek fejlesztéseket a GRAMPS-hoz. Fejlesztés kérése lehetséges a GRAMPS-"
-"felhasználók, vagy a GRAMPS-fejlesztők levelezési listáján, esetleg a http://"
-"bugs.gramps-project.org címen egy Szolgáltatás Igénylése létrehozásával. A "
-"Szolgáltatás igénylés kitöltése a leginkább javasolt, de az ötlet "
-"megtárgyalására a levelező lista a jobb hely."
+"felhasználók, vagy a GRAMPS-fejlesztők levelezési listáján, esetleg a "
+"https://gramps-project.org/bugs/ címen egy Szolgáltatás Igénylése "
+"létrehozásával. A Szolgáltatás igénylés kitöltése a leginkább javasolt, de "
+"előtte célszerű az ötlet megtárgyalása a levelező listán."
 
 #: ../data/tips.xml.in.h:30
 msgid ""
@@ -897,11 +897,11 @@ msgstr ""
 #: ../data/tips.xml.in.h:46
 msgid ""
 "<b>Reporting Bugs in Gramps</b><br/>The best way to report a bug in Gramps "
-"is to use the Gramps bug tracking system at http://bugs.gramps-project.org"
+"is to use the Gramps bug tracking system at https://gramps-project.org/bugs/"
 msgstr ""
-"<b>GRAMPS hibák bejelentése</b><br/>A legjobb út a GRAMPS hibáinak "
-"bejelentésére a GRAMPS hibakövető rendszer használata itt: http://bugs."
-"gramps-project.org"
+"<b>GRAMPS hibák bejelentése</b><br/>A hibák bejelentésének legmegfelelőbb "
+"útja a GRAMPS hibakövető rendszer használata. Lásd: https://gramps-project."
+"org/bugs/"
 
 #: ../data/tips.xml.in.h:47
 msgid ""
@@ -1170,6 +1170,11 @@ msgstr "Létező fájl felülírása: %s"
 msgid "ERROR: Unrecognized format for export file %s"
 msgstr "HIBA: Nem felismerhető formátum a(z) %s fájl exportáláshoz"
 
+#: ../gramps/cli/arghandler.py:385 ../gramps/gen/plug/utils.py:316
+#, python-format
+msgid "Error: cannot open '%s'"
+msgstr "Hiba: '%s' nem megnyitható"
+
 #: ../gramps/cli/arghandler.py:404
 msgid "List of known Family Trees in your database path\n"
 msgstr "Ismert Családfák listája az ön adatbázis útvonalában\n"
@@ -1194,7 +1199,7 @@ msgstr "GRAMPS családfa:"
 #: ../gramps/cli/arghandler.py:443 ../gramps/cli/arghandler.py:444
 #: ../gramps/cli/arghandler.py:446 ../gramps/cli/clidbman.py:69
 #: ../gramps/cli/clidbman.py:169 ../gramps/cli/clidbman.py:197
-#: ../gramps/gui/clipboard.py:916 ../gramps/gui/configure.py:1574
+#: ../gramps/gui/clipboard.py:916 ../gramps/gui/configure.py:1798
 msgid "Family Tree"
 msgstr "Családfa"
 
@@ -1314,7 +1319,7 @@ msgstr ""
 msgid "Unknown action: %s."
 msgstr "Ismeretlen művelet: %s."
 
-#: ../gramps/cli/argparser.py:55
+#: ../gramps/cli/argparser.py:56
 msgid ""
 "\n"
 "Usage: gramps.py [OPTION...]\n"
@@ -1349,6 +1354,16 @@ msgid ""
 "  -q, --quiet                            Suppress progress indication output "
 "(non-GUI mode only)\n"
 "  -v, --version                          Show versions\n"
+"  -S, --safe                             Start Gramps in 'Safe mode'\n"
+"                                          (temporarily use default "
+"settings)\n"
+"  -D, --default=[APXFE]                  Reset settings to default;\n"
+"                 A - addons are cleared\n"
+"                 P - Preferences to default\n"
+"                 X - Books are cleared, reports and tool settings to "
+"default\n"
+"                 F - filters are cleared\n"
+"                 E - Everything is set to default or cleared\n"
 msgstr ""
 "\n"
 "Használat: gramps.py [OPTION...]\n"
@@ -1385,8 +1400,20 @@ msgstr ""
 "  -q, --quiet                            A haladásjelző kimenet tiltása "
 "(csak nem grafikus módban)\n"
 "  -v, --version                          Verziók mutatása\n"
+"  -S, --safe                             A GRAMPS indítása 'Biztonsági mód'-"
+"ban\n"
+"                                          (alap beállítások ideiglenes "
+"használata)\n"
+"  -D, --default=[APXFE]                  A beállítások alaphelyzetbe "
+"állítása;\n"
+"                 A - beépülők kikapcsolása\n"
+"                 P - Beállítások alaphelyzetbe\n"
+"                 X - Könyvek kiürítése, a jelentések és a lehetőségek "
+"alaphelyzetbe állítása\n"
+"                 F - a szűrők kikapcsolása\n"
+"                 E - Minden alaphelyzetbe állítása, vagy kikapcsolása\n"
 
-#: ../gramps/cli/argparser.py:86
+#: ../gramps/cli/argparser.py:95
 msgid ""
 "\n"
 "Example of usage of Gramps command line interface\n"
@@ -1503,11 +1530,11 @@ msgstr ""
 "Megjegyzés: Ezek a példák bash shell-hez készültek.\n"
 "A szintaktika különbözhet más shellek és a Windows esetén.\n"
 
-#: ../gramps/cli/argparser.py:248 ../gramps/cli/argparser.py:421
+#: ../gramps/cli/argparser.py:257 ../gramps/cli/argparser.py:470
 msgid "Error parsing the arguments"
 msgstr "Hiba a paraméterek feldolgozásakor"
 
-#: ../gramps/cli/argparser.py:250
+#: ../gramps/cli/argparser.py:259
 #, python-format
 msgid ""
 "Error parsing the arguments: %s \n"
@@ -1517,12 +1544,12 @@ msgstr ""
 "Írja be: gramps --help a parancsok megtekintéséhez, vagy a kézikönyv lapok "
 "olvasásához."
 
-#: ../gramps/cli/argparser.py:268
+#: ../gramps/cli/argparser.py:277
 #, python-format
 msgid "Trying to open: %s ..."
 msgstr "Megnyitási kísérlet: %s ..."
 
-#: ../gramps/cli/argparser.py:312
+#: ../gramps/cli/argparser.py:321
 #, python-format
 msgid ""
 "WARNING: %(strerr)s (errno=%(errno)s):\n"
@@ -1531,42 +1558,42 @@ msgstr ""
 "FIGYELEM: %(strerr)s (errno=%(errno)s):\n"
 "FIGYELEM: %(name)s\n"
 
-#: ../gramps/cli/argparser.py:324
+#: ../gramps/cli/argparser.py:333
 #, python-format
 msgid "Unknown action: %s. Ignoring."
 msgstr "Ismeretlen művelet: %s. Figyelmen kívül hagyás."
 
-#: ../gramps/cli/argparser.py:334
+#: ../gramps/cli/argparser.py:343
 msgid "setup debugging"
 msgstr "hibakeresés beállítása"
 
-#: ../gramps/cli/argparser.py:345
+#: ../gramps/cli/argparser.py:355
 #, python-format
 msgid "Gramps config settings from %s:"
 msgstr "GRAMPS konfigurációs beállítások %s-ből:"
 
-#: ../gramps/cli/argparser.py:362
+#: ../gramps/cli/argparser.py:373
 #, python-format
 msgid "Current Gramps config setting: %(name)s:%(value)s"
 msgstr "A jelenlegi GRAMPS konfigurációs beállítások: %(name)s:%(value)s"
 
 #. does a user want the default config value?
-#: ../gramps/cli/argparser.py:369
+#: ../gramps/cli/argparser.py:380
 msgid "DEFAULT"
 msgstr "ALAPÉRTELMEZETT"
 
 #. translators: indent "New" to match "Current"
-#: ../gramps/cli/argparser.py:376
+#: ../gramps/cli/argparser.py:387
 #, python-format
 msgid "    New Gramps config setting: %(name)s:%(value)s"
 msgstr "    Új GRAMPS konfigurációs beállítások: %(name)s:%(value)s"
 
-#: ../gramps/cli/argparser.py:384
+#: ../gramps/cli/argparser.py:395
 #, python-format
 msgid "Gramps: no such config setting: '%s'"
 msgstr "GRAMPS: nincs ilyen konfigurációs beállítás: '%s'"
 
-#: ../gramps/cli/argparser.py:422
+#: ../gramps/cli/argparser.py:471
 #, python-format
 msgid ""
 "Error parsing the arguments: %s \n"
@@ -1600,11 +1627,11 @@ msgstr ""
 msgid "Path"
 msgstr "Útvonal"
 
-#: ../gramps/cli/clidbman.py:171 ../gramps/gen/plug/_pluginreg.py:90
+#: ../gramps/cli/clidbman.py:171 ../gramps/gen/plug/_pluginreg.py:91
 msgid "Database"
 msgstr "Adatbázis"
 
-#: ../gramps/cli/clidbman.py:172 ../gramps/gui/dbman.py:411
+#: ../gramps/cli/clidbman.py:172 ../gramps/gui/dbman.py:410
 msgid "Last accessed"
 msgstr "Utoljára használt"
 
@@ -1622,20 +1649,22 @@ msgstr "\"%s\" családfa:"
 #. translators: needed for French, ignore otherwise
 #: ../gramps/cli/clidbman.py:201 ../gramps/gen/plug/report/utils.py:160
 #: ../gramps/gui/editors/editattribute.py:135
-#: ../gramps/gui/editors/editname.py:310 ../gramps/gui/plug/_windows.py:685
-#: ../gramps/gui/plug/_windows.py:1116
-#: ../gramps/plugins/gramplet/whatsnext.py:493
-#: ../gramps/plugins/textreport/detancestralreport.py:471
-#: ../gramps/plugins/textreport/detdescendantreport.py:503
+#: ../gramps/gui/editors/editname.py:310 ../gramps/gui/plug/_windows.py:687
+#: ../gramps/gui/plug/_windows.py:1118
+#: ../gramps/plugins/gramplet/whatsnext.py:494
+#: ../gramps/plugins/textreport/birthdayreport.py:187
+#: ../gramps/plugins/textreport/birthdayreport.py:191
+#: ../gramps/plugins/textreport/detancestralreport.py:475
+#: ../gramps/plugins/textreport/detdescendantreport.py:505
 #: ../gramps/plugins/textreport/familygroup.py:140
 #: ../gramps/plugins/textreport/familygroup.py:306
-#: ../gramps/plugins/textreport/indivcomplete.py:916
-#: ../gramps/plugins/textreport/indivcomplete.py:956
-#: ../gramps/plugins/textreport/indivcomplete.py:1027
+#: ../gramps/plugins/textreport/indivcomplete.py:917
+#: ../gramps/plugins/textreport/indivcomplete.py:957
+#: ../gramps/plugins/textreport/indivcomplete.py:1028
 #: ../gramps/plugins/textreport/placereport.py:185
-#: ../gramps/plugins/webreport/basepage.py:700
-#: ../gramps/plugins/webreport/basepage.py:2194
-#: ../gramps/plugins/webreport/basepage.py:2239
+#: ../gramps/plugins/webreport/basepage.py:715
+#: ../gramps/plugins/webreport/basepage.py:2275
+#: ../gramps/plugins/webreport/basepage.py:2320
 #, python-format
 msgid "%(str1)s: %(str2)s"
 msgstr "%(str1)s: %(str2)s"
@@ -1650,7 +1679,7 @@ msgid "Import finished..."
 msgstr "Az importálás befejeződött..."
 
 #. Create a new database
-#: ../gramps/cli/clidbman.py:366 ../gramps/plugins/importer/importcsv.py:343
+#: ../gramps/cli/clidbman.py:366 ../gramps/plugins/importer/importcsv.py:359
 msgid "Importing data..."
 msgstr "Adatok importálása..."
 
@@ -1665,7 +1694,7 @@ msgid ""
 "\"%s\"?"
 msgstr "Biztos benne, hogy a \"%s\" nevű Családfát el akarja távolítani?"
 
-#: ../gramps/cli/clidbman.py:436 ../gramps/gui/dbman.py:739
+#: ../gramps/cli/clidbman.py:436 ../gramps/gui/dbman.py:738
 msgid "Could not delete Family Tree"
 msgstr "A Családfa nem törölhető"
 
@@ -1692,8 +1721,8 @@ msgstr ""
 "    %s\n"
 "\n"
 
-#: ../gramps/cli/clidbman.py:535 ../gramps/gui/configure.py:1415
-#: ../gramps/gui/configure.py:1562
+#: ../gramps/cli/clidbman.py:535 ../gramps/gui/configure.py:1633
+#: ../gramps/gui/configure.py:1786
 msgid "Never"
 msgstr "Soha"
 
@@ -1713,9 +1742,9 @@ msgstr "%s által zárolt"
 #. 00-00-yyyy
 #. oo-oo-yyyy
 #. dd-mm-00 (does this mean we do not know about the year?)
-#. This function tries to parse the text and create a proper Gramps Date()
-#. object. If all else fails we create a MOD_TEXTONLY Date() object.
-#: ../gramps/cli/clidbman.py:553 ../gramps/gen/lib/attrtype.py:62
+#. Function tries to parse the text and create a proper Gramps Date()
+#. object. If all else fails create a MOD_TEXTONLY Date() object.
+#: ../gramps/cli/clidbman.py:553 ../gramps/gen/lib/attrtype.py:63
 #: ../gramps/gen/lib/childreftype.py:73 ../gramps/gen/lib/eventroletype.py:52
 #: ../gramps/gen/lib/eventtype.py:162 ../gramps/gen/lib/familyreltype.py:50
 #: ../gramps/gen/lib/grampstype.py:34 ../gramps/gen/lib/nameorigintype.py:73
@@ -1727,71 +1756,69 @@ msgstr "%s által zárolt"
 #: ../gramps/gen/utils/unknown.py:120 ../gramps/gen/utils/unknown.py:122
 #: ../gramps/gen/utils/unknown.py:126 ../gramps/gen/utils/unknown.py:132
 #: ../gramps/gen/utils/unknown.py:137 ../gramps/gui/clipboard.py:185
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:125
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:143
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:173
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:191
 #: ../gramps/gui/editors/editmedia.py:178
 #: ../gramps/gui/editors/editmediaref.py:143
-#: ../gramps/plugins/db/bsddb/write.py:2292
+#: ../gramps/plugins/db/bsddb/write.py:2294
 #: ../gramps/plugins/gramplet/persondetails.py:213
 #: ../gramps/plugins/gramplet/persondetails.py:219
 #: ../gramps/plugins/gramplet/persondetails.py:221
 #: ../gramps/plugins/gramplet/persondetails.py:222
-#: ../gramps/plugins/gramplet/relativegramplet.py:124
-#: ../gramps/plugins/gramplet/relativegramplet.py:135
-#: ../gramps/plugins/graph/gvfamilylines.py:280
-#: ../gramps/plugins/graph/gvhourglass.py:376
-#: ../gramps/plugins/graph/gvrelgraph.py:903
-#: ../gramps/plugins/importer/importprogen.py:986
-#: ../gramps/plugins/lib/maps/geography.py:839
-#: ../gramps/plugins/lib/maps/geography.py:849
-#: ../gramps/plugins/lib/maps/geography.py:850
+#: ../gramps/plugins/gramplet/relativegramplet.py:126
+#: ../gramps/plugins/gramplet/relativegramplet.py:137
+#: ../gramps/plugins/graph/gvfamilylines.py:287
+#: ../gramps/plugins/graph/gvhourglass.py:427
+#: ../gramps/plugins/graph/gvrelgraph.py:948
+#: ../gramps/plugins/lib/libprogen.py:1057
+#: ../gramps/plugins/lib/maps/geography.py:802
+#: ../gramps/plugins/lib/maps/geography.py:812
+#: ../gramps/plugins/lib/maps/geography.py:813
 #: ../gramps/plugins/quickview/all_relations.py:277
 #: ../gramps/plugins/quickview/all_relations.py:294
 #: ../gramps/plugins/textreport/descendreport.py:322
-#: ../gramps/plugins/textreport/detancestralreport.py:211
-#: ../gramps/plugins/textreport/detancestralreport.py:295
-#: ../gramps/plugins/textreport/detancestralreport.py:585
-#: ../gramps/plugins/textreport/detancestralreport.py:587
-#: ../gramps/plugins/textreport/detancestralreport.py:594
-#: ../gramps/plugins/textreport/detancestralreport.py:596
-#: ../gramps/plugins/textreport/detancestralreport.py:611
-#: ../gramps/plugins/textreport/detancestralreport.py:666
-#: ../gramps/plugins/textreport/detancestralreport.py:668
-#: ../gramps/plugins/textreport/detancestralreport.py:675
-#: ../gramps/plugins/textreport/detancestralreport.py:677
-#: ../gramps/plugins/textreport/detancestralreport.py:735
-#: ../gramps/plugins/textreport/detdescendantreport.py:335
-#: ../gramps/plugins/textreport/detdescendantreport.py:433
-#: ../gramps/plugins/textreport/detdescendantreport.py:609
-#: ../gramps/plugins/textreport/detdescendantreport.py:649
+#: ../gramps/plugins/textreport/detancestralreport.py:213
+#: ../gramps/plugins/textreport/detancestralreport.py:297
+#: ../gramps/plugins/textreport/detancestralreport.py:589
+#: ../gramps/plugins/textreport/detancestralreport.py:591
+#: ../gramps/plugins/textreport/detancestralreport.py:598
+#: ../gramps/plugins/textreport/detancestralreport.py:600
+#: ../gramps/plugins/textreport/detancestralreport.py:615
+#: ../gramps/plugins/textreport/detancestralreport.py:672
+#: ../gramps/plugins/textreport/detancestralreport.py:674
+#: ../gramps/plugins/textreport/detancestralreport.py:681
+#: ../gramps/plugins/textreport/detancestralreport.py:683
+#: ../gramps/plugins/textreport/detancestralreport.py:741
+#: ../gramps/plugins/textreport/detdescendantreport.py:337
+#: ../gramps/plugins/textreport/detdescendantreport.py:435
+#: ../gramps/plugins/textreport/detdescendantreport.py:611
 #: ../gramps/plugins/textreport/detdescendantreport.py:651
-#: ../gramps/plugins/textreport/detdescendantreport.py:658
+#: ../gramps/plugins/textreport/detdescendantreport.py:653
 #: ../gramps/plugins/textreport/detdescendantreport.py:660
-#: ../gramps/plugins/textreport/detdescendantreport.py:688
-#: ../gramps/plugins/textreport/detdescendantreport.py:833
+#: ../gramps/plugins/textreport/detdescendantreport.py:662
+#: ../gramps/plugins/textreport/detdescendantreport.py:690
+#: ../gramps/plugins/textreport/detdescendantreport.py:837
 #: ../gramps/plugins/textreport/indivcomplete.py:85
-#: ../gramps/plugins/textreport/indivcomplete.py:939
-#: ../gramps/plugins/tool/check.py:2405 ../gramps/plugins/tool/check.py:2431
+#: ../gramps/plugins/textreport/indivcomplete.py:940
+#: ../gramps/plugins/tool/check.py:2440 ../gramps/plugins/tool/check.py:2466
 #: ../gramps/plugins/tool/dumpgenderstats.py:74
 #: ../gramps/plugins/tool/dumpgenderstats.py:97
 #: ../gramps/plugins/tool/dumpgenderstats.py:100
-#: ../gramps/plugins/view/geoclose.py:523
-#: ../gramps/plugins/view/geofamclose.py:271
-#: ../gramps/plugins/view/geofamclose.py:715
-#: ../gramps/plugins/view/geofamily.py:467
-#: ../gramps/plugins/view/geomoves.py:596
-#: ../gramps/plugins/view/geoperson.py:477
-#: ../gramps/plugins/view/geoplaces.py:531
-#: ../gramps/plugins/view/relview.py:460 ../gramps/plugins/view/relview.py:995
-#: ../gramps/plugins/view/relview.py:1050
-#: ../gramps/plugins/webreport/basepage.py:1759
-#: ../gramps/plugins/webreport/basepage.py:1788
-#: ../gramps/plugins/webreport/basepage.py:1793
-#: ../gramps/plugins/webreport/basepage.py:1800
-#: ../gramps/plugins/webreport/basepage.py:2183
-#: ../gramps/plugins/webreport/basepage.py:2280
-#: ../gramps/plugins/webreport/basepage.py:2395
-#: ../gramps/plugins/db/bsddb/write.py:2294
+#: ../gramps/plugins/view/geoclose.py:595
+#: ../gramps/plugins/view/geofamclose.py:349
+#: ../gramps/plugins/view/geofamclose.py:785
+#: ../gramps/plugins/view/geofamily.py:517
+#: ../gramps/plugins/view/geomoves.py:662
+#: ../gramps/plugins/view/geoperson.py:543
+#: ../gramps/plugins/view/geoplaces.py:590
+#: ../gramps/plugins/view/relview.py:589 ../gramps/plugins/view/relview.py:1160
+#: ../gramps/plugins/view/relview.py:1215
+#: ../gramps/plugins/webreport/basepage.py:1838
+#: ../gramps/plugins/webreport/basepage.py:1868
+#: ../gramps/plugins/webreport/basepage.py:1873
+#: ../gramps/plugins/webreport/basepage.py:1880
+#: ../gramps/plugins/webreport/basepage.py:2264
+#: ../gramps/plugins/webreport/basepage.py:2436
 msgid "Unknown"
 msgstr "Ismeretlen"
 
@@ -1806,12 +1833,12 @@ msgid "ERROR: %s"
 msgstr "HIBA: %s"
 
 #: ../gramps/cli/grampscli.py:106 ../gramps/cli/user.py:200
-#: ../gramps/gui/dialog.py:249
+#: ../gramps/gui/dialog.py:295
 msgid "Low level database corruption detected"
 msgstr "Alacsony szintű adatbázis hibát észleltem"
 
 #: ../gramps/cli/grampscli.py:108 ../gramps/cli/user.py:201
-#: ../gramps/gui/dialog.py:250
+#: ../gramps/gui/dialog.py:296
 msgid ""
 "Gramps has detected a problem in the underlying Berkeley database. This can "
 "be repaired from the Family Tree Manager. Select the database and click on "
@@ -1825,7 +1852,7 @@ msgid "Read only database"
 msgstr "Csak olvasható adatbázis"
 
 #: ../gramps/cli/grampscli.py:154 ../gramps/gui/dbloader.py:166
-#: ../gramps/gui/dbloader.py:561 ../gramps/gui/dbloader.py:562
+#: ../gramps/gui/dbloader.py:535
 msgid "You do not have write access to the selected file."
 msgstr "Nincs írási joga a kiválasztott fájlra."
 
@@ -1841,7 +1868,7 @@ msgid "Cannot open database"
 msgstr "Az adatbázis nem megnyitható"
 
 #: ../gramps/cli/grampscli.py:211 ../gramps/gui/dbloader.py:296
-#: ../gramps/gui/dbloader.py:518 ../gramps/gui/dbloader.py:519
+#: ../gramps/gui/dbloader.py:492
 #, python-format
 msgid "Could not open file: %s"
 msgstr "Nem megnyitható fájl: %s"
@@ -1982,15 +2009,15 @@ msgstr "   Érvényes beállítások:"
 #: ../gramps/gen/plug/report/endnotes.py:204
 #: ../gramps/gen/plug/report/endnotes.py:210
 #: ../gramps/plugins/drawreport/descendtree.py:352
-#: ../gramps/plugins/drawreport/fanchart.py:362
-#: ../gramps/plugins/drawreport/fanchart.py:378
+#: ../gramps/plugins/drawreport/fanchart.py:364
+#: ../gramps/plugins/drawreport/fanchart.py:380
 #: ../gramps/plugins/gramplet/persondetails.py:237
-#: ../gramps/plugins/gramplet/whatsnext.py:370
-#: ../gramps/plugins/gramplet/whatsnext.py:392
-#: ../gramps/plugins/gramplet/whatsnext.py:440
-#: ../gramps/plugins/gramplet/whatsnext.py:473
-#: ../gramps/plugins/gramplet/whatsnext.py:495
-#: ../gramps/plugins/graph/gvrelgraph.py:674
+#: ../gramps/plugins/gramplet/whatsnext.py:371
+#: ../gramps/plugins/gramplet/whatsnext.py:393
+#: ../gramps/plugins/gramplet/whatsnext.py:441
+#: ../gramps/plugins/gramplet/whatsnext.py:474
+#: ../gramps/plugins/gramplet/whatsnext.py:496
+#: ../gramps/plugins/graph/gvrelgraph.py:707
 #: ../gramps/plugins/textreport/descendreport.py:270
 #: ../gramps/plugins/textreport/descendreport.py:280
 #: ../gramps/plugins/textreport/descendreport.py:286
@@ -2058,11 +2085,11 @@ msgstr "Nem sikerült összesítőt írni. "
 msgid "Failed to make '%s' report."
 msgstr "Nem sikerült '%s' összesítőt írni."
 
-#: ../gramps/cli/user.py:217 ../gramps/gui/dialog.py:235
+#: ../gramps/cli/user.py:217 ../gramps/gui/dialog.py:281
 msgid "Error detected in database"
 msgstr "Hibát észleltem az adatbázisban"
 
-#: ../gramps/cli/user.py:218 ../gramps/gui/dialog.py:236
+#: ../gramps/cli/user.py:218 ../gramps/gui/dialog.py:282
 #, python-format
 msgid ""
 "Gramps has detected an error in the database. This can usually be resolved "
@@ -2079,27 +2106,27 @@ msgstr ""
 "el egy hibajelentést a %(gramps_bugtracker_url)s címen.\n"
 "\n"
 
-#: ../gramps/gen/config.py:242
+#: ../gramps/gen/config.py:247
 msgid "Imported %Y/%m/%d %H:%M:%S"
 msgstr "Importált %Y/%m/%d %H:%M:%S"
 
-#: ../gramps/gen/config.py:253
+#: ../gramps/gen/config.py:258
 msgid "Missing Given Name"
 msgstr "Hiányzó keresztnév"
 
-#: ../gramps/gen/config.py:254
+#: ../gramps/gen/config.py:259
 msgid "Missing Record"
 msgstr "Hiányzó felvétel"
 
-#: ../gramps/gen/config.py:255
+#: ../gramps/gen/config.py:260
 msgid "Missing Surname"
 msgstr "Hiányzó vezetéknév"
 
-#: ../gramps/gen/config.py:262 ../gramps/gen/config.py:264
+#: ../gramps/gen/config.py:267 ../gramps/gen/config.py:269
 msgid "[Living]"
 msgstr "[Élő]"
 
-#: ../gramps/gen/config.py:263
+#: ../gramps/gen/config.py:268
 msgid "Private Record"
 msgstr "Bizalmas felvétel"
 
@@ -2108,11 +2135,11 @@ msgstr "Bizalmas felvétel"
 #. http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
 #. to learn how to select proper inflection to be used in your localized
 #. DateDisplayer code!
-#: ../gramps/gen/config.py:306 ../gramps/gen/datehandler/_datestrings.py:79
+#: ../gramps/gen/config.py:320 ../gramps/gen/datehandler/_datestrings.py:79
 msgid "localized lexeme inflections||January"
 msgstr "január"
 
-#: ../gramps/gen/const.py:221
+#: ../gramps/gen/const.py:229
 msgid ""
 "Gramps\n"
 " (Genealogical Research and Analysis Management Programming System)\n"
@@ -2123,15 +2150,16 @@ msgstr ""
 " = Származástani kutatás és elemzés kezelő programrendszer egy személyi "
 "családfakutató program."
 
-#: ../gramps/gen/const.py:251
+#: ../gramps/gen/const.py:259
 msgid "surname|none"
 msgstr "vezetéknév|nincs"
 
-#: ../gramps/gen/const.py:252
+#: ../gramps/gen/const.py:260
 msgid "given-name|none"
 msgstr "utónév|nincs"
 
-#: ../gramps/gen/const.py:256 ../gramps/plugins/webreport/basepage.py:140
+#: ../gramps/gen/const.py:264 ../gramps/plugins/gramplet/todo.py:202
+#: ../gramps/plugins/webreport/basepage.py:147
 msgid ":"
 msgstr ":"
 
@@ -2182,11 +2210,7 @@ msgstr "Nap Hónap Év"
 msgid "DAY MON YEAR"
 msgstr "NAP HÓ ÉV"
 
-#. TRANSLATORS: see
-#. http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
-#. to learn how to select proper inflection for your language.
 #: ../gramps/gen/datehandler/_datedisplay.py:181
-#: ../gramps/plugins/drawreport/calendarreport.py:233
 #, python-brace-format
 msgid "{long_month} {year}"
 msgstr "{long_month} {year}"
@@ -2448,25 +2472,25 @@ msgid "{date_quality}{noncompound_modifier}{date}{nonstd_calendar_and_ny}"
 msgstr "{date_quality}{noncompound_modifier}{date}{nonstd_calendar_and_ny}"
 
 #. TRANSLATORS: this month is ALREADY inflected: ignore it
-#: ../gramps/gen/datehandler/_datedisplay.py:639
+#: ../gramps/gen/datehandler/_datedisplay.py:649
 #, python-brace-format
 msgid "{long_month} {day:d}, {year}"
 msgstr "{year} {long_month} {day:d}"
 
 #. TRANSLATORS: this month is ALREADY inflected: ignore it
-#: ../gramps/gen/datehandler/_datedisplay.py:665
+#: ../gramps/gen/datehandler/_datedisplay.py:675
 #, python-brace-format
 msgid "{short_month} {day:d}, {year}"
 msgstr "{year} {short_month} {day:d}"
 
 #. TRANSLATORS: this month is ALREADY inflected: ignore it
-#: ../gramps/gen/datehandler/_datedisplay.py:691
+#: ../gramps/gen/datehandler/_datedisplay.py:701
 #, python-brace-format
 msgid "{day:d} {long_month} {year}"
 msgstr "{year} {long_month} {day:d}"
 
 #. TRANSLATORS: this month is ALREADY inflected: ignore it
-#: ../gramps/gen/datehandler/_datedisplay.py:717
+#: ../gramps/gen/datehandler/_datedisplay.py:727
 #, python-brace-format
 msgid "{day:d} {short_month} {year}"
 msgstr "{year} {short_month} {day:d}"
@@ -2951,7 +2975,7 @@ msgstr "P"
 msgid "Sat"
 msgstr "Szo"
 
-#: ../gramps/gen/db/base.py:1816 ../gramps/gui/widgets/fanchart.py:1798
+#: ../gramps/gen/db/base.py:1816 ../gramps/gui/widgets/fanchart.py:2077
 msgid "Add child to family"
 msgstr "Gyermek családhoz adása"
 
@@ -3215,7 +3239,6 @@ msgstr ""
 #: ../gramps/gen/db/generic.py:161 ../gramps/gen/db/generic.py:211
 #: ../gramps/gen/db/generic.py:2018 ../gramps/plugins/db/bsddb/undoredo.py:251
 #: ../gramps/plugins/db/bsddb/undoredo.py:293
-#: ../gramps/plugins/db/bsddb/write.py:2139
 #: ../gramps/plugins/db/bsddb/write.py:2141
 #, python-format
 msgid "_Undo %s"
@@ -3228,90 +3251,75 @@ msgstr "%s _visszavonása"
 msgid "_Redo %s"
 msgstr "%s _ismétlése"
 
-#: ../gramps/gen/db/generic.py:2410 ../gramps/plugins/db/bsddb/read.py:1935
-#: ../gramps/plugins/db/bsddb/write.py:2294
+#: ../gramps/gen/db/generic.py:2410 ../gramps/plugins/db/bsddb/read.py:1938
 #: ../gramps/plugins/db/bsddb/write.py:2296
 msgid "Number of people"
 msgstr "Emberek száma"
 
-#: ../gramps/gen/db/generic.py:2411 ../gramps/plugins/db/bsddb/read.py:1936
-#: ../gramps/plugins/db/bsddb/write.py:2295
-#: ../gramps/plugins/gramplet/statsgramplet.py:117
-#: ../gramps/plugins/webreport/statistics.py:130
-#: ../gramps/plugins/webreport/statistics.py:195
+#: ../gramps/gen/db/generic.py:2411 ../gramps/plugins/db/bsddb/read.py:1939
 #: ../gramps/plugins/db/bsddb/write.py:2297
+#: ../gramps/plugins/gramplet/statsgramplet.py:170
+#: ../gramps/plugins/webreport/statistics.py:131
+#: ../gramps/plugins/webreport/statistics.py:196
 msgid "Number of families"
 msgstr "Családok száma"
 
-#: ../gramps/gen/db/generic.py:2412 ../gramps/plugins/db/bsddb/read.py:1937
-#: ../gramps/plugins/db/bsddb/write.py:2296
-#: ../gramps/plugins/webreport/statistics.py:158
-#: ../gramps/plugins/webreport/statistics.py:207
+#: ../gramps/gen/db/generic.py:2412 ../gramps/plugins/db/bsddb/read.py:1940
 #: ../gramps/plugins/db/bsddb/write.py:2298
+#: ../gramps/plugins/webreport/statistics.py:159
+#: ../gramps/plugins/webreport/statistics.py:208
 msgid "Number of sources"
 msgstr "Források száma"
 
-#: ../gramps/gen/db/generic.py:2413 ../gramps/plugins/db/bsddb/read.py:1938
-#: ../gramps/plugins/db/bsddb/write.py:2297
-#: ../gramps/plugins/webreport/statistics.py:162
-#: ../gramps/plugins/webreport/statistics.py:210
+#: ../gramps/gen/db/generic.py:2413 ../gramps/plugins/db/bsddb/read.py:1941
 #: ../gramps/plugins/db/bsddb/write.py:2299
+#: ../gramps/plugins/webreport/statistics.py:163
+#: ../gramps/plugins/webreport/statistics.py:211
 msgid "Number of citations"
 msgstr "Idézetek száma"
 
-#: ../gramps/gen/db/generic.py:2414 ../gramps/plugins/db/bsddb/read.py:1939
-#: ../gramps/plugins/db/bsddb/write.py:2298
-#: ../gramps/plugins/webreport/statistics.py:151
-#: ../gramps/plugins/webreport/statistics.py:201
+#: ../gramps/gen/db/generic.py:2414 ../gramps/plugins/db/bsddb/read.py:1942
 #: ../gramps/plugins/db/bsddb/write.py:2300
+#: ../gramps/plugins/webreport/statistics.py:152
+#: ../gramps/plugins/webreport/statistics.py:202
 msgid "Number of events"
 msgstr "Események száma"
 
-#: ../gramps/gen/db/generic.py:2415 ../gramps/plugins/db/bsddb/read.py:1940
-#: ../gramps/plugins/db/bsddb/write.py:2299
+#: ../gramps/gen/db/generic.py:2415 ../gramps/plugins/db/bsddb/read.py:1943
 #: ../gramps/plugins/db/bsddb/write.py:2301
 msgid "Number of media"
 msgstr "Médiumok száma"
 
-#: ../gramps/gen/db/generic.py:2416 ../gramps/plugins/db/bsddb/read.py:1941
-#: ../gramps/plugins/db/bsddb/write.py:2300
-#: ../gramps/plugins/webreport/statistics.py:154
-#: ../gramps/plugins/webreport/statistics.py:204
+#: ../gramps/gen/db/generic.py:2416 ../gramps/plugins/db/bsddb/read.py:1944
 #: ../gramps/plugins/db/bsddb/write.py:2302
+#: ../gramps/plugins/webreport/statistics.py:155
+#: ../gramps/plugins/webreport/statistics.py:205
 msgid "Number of places"
 msgstr "Helyek száma"
 
-#: ../gramps/gen/db/generic.py:2417 ../gramps/plugins/db/bsddb/read.py:1942
-#: ../gramps/plugins/db/bsddb/write.py:2301
-#: ../gramps/plugins/webreport/statistics.py:166
-#: ../gramps/plugins/webreport/statistics.py:213
+#: ../gramps/gen/db/generic.py:2417 ../gramps/plugins/db/bsddb/read.py:1945
 #: ../gramps/plugins/db/bsddb/write.py:2303
+#: ../gramps/plugins/webreport/statistics.py:167
+#: ../gramps/plugins/webreport/statistics.py:214
 msgid "Number of repositories"
 msgstr "Tárolók száma"
 
-#: ../gramps/gen/db/generic.py:2418 ../gramps/plugins/db/bsddb/read.py:1943
-#: ../gramps/plugins/db/bsddb/write.py:2302
+#: ../gramps/gen/db/generic.py:2418 ../gramps/plugins/db/bsddb/read.py:1946
 #: ../gramps/plugins/db/bsddb/write.py:2304
 msgid "Number of notes"
 msgstr "Megjegyzések száma"
 
-#: ../gramps/gen/db/generic.py:2419 ../gramps/plugins/db/bsddb/read.py:1944
-#: ../gramps/plugins/db/bsddb/write.py:2303
+#: ../gramps/gen/db/generic.py:2419 ../gramps/plugins/db/bsddb/read.py:1947
 #: ../gramps/plugins/db/bsddb/write.py:2305
 msgid "Number of tags"
 msgstr "Címek száma"
 
-#: ../gramps/gen/db/generic.py:2420 ../gramps/plugins/db/bsddb/write.py:2304
-#: ../gramps/plugins/db/bsddb/write.py:2306
+#: ../gramps/gen/db/generic.py:2420 ../gramps/plugins/db/bsddb/write.py:2306
 msgid "Schema version"
 msgstr "Séma változat"
 
 #. translators: needed for Arabic, ignore otherwise
-#. need for spacing on the french translation
-#. translators: needed for Arabic, ignore otherwise
-#: ../gramps/gen/display/name.py:349
-#: ../gramps/gui/views/treemodels/placemodel.py:131
-#: ../gramps/plugins/lib/libtreebase.py:707
+#: ../gramps/gen/display/name.py:349 ../gramps/plugins/lib/libtreebase.py:707
 msgid ","
 msgstr ","
 
@@ -3324,15 +3332,15 @@ msgid "Surname, Given Suffix"
 msgstr "Vezetéknév, adott utótag"
 
 #: ../gramps/gen/display/name.py:356 ../gramps/gen/utils/keyword.py:55
-#: ../gramps/gui/configure.py:688 ../gramps/gui/configure.py:690
-#: ../gramps/gui/configure.py:695 ../gramps/gui/configure.py:697
-#: ../gramps/gui/configure.py:699 ../gramps/gui/configure.py:700
-#: ../gramps/gui/configure.py:701 ../gramps/gui/configure.py:702
-#: ../gramps/gui/configure.py:704 ../gramps/gui/configure.py:705
-#: ../gramps/gui/configure.py:706 ../gramps/gui/configure.py:707
-#: ../gramps/gui/configure.py:708 ../gramps/gui/configure.py:709
+#: ../gramps/gui/configure.py:844 ../gramps/gui/configure.py:846
+#: ../gramps/gui/configure.py:851 ../gramps/gui/configure.py:853
+#: ../gramps/gui/configure.py:855 ../gramps/gui/configure.py:856
+#: ../gramps/gui/configure.py:857 ../gramps/gui/configure.py:858
+#: ../gramps/gui/configure.py:860 ../gramps/gui/configure.py:861
+#: ../gramps/gui/configure.py:862 ../gramps/gui/configure.py:863
+#: ../gramps/gui/configure.py:864 ../gramps/gui/configure.py:865
 #: ../gramps/plugins/export/exportcsv.py:354
-#: ../gramps/plugins/importer/importcsv.py:162
+#: ../gramps/plugins/importer/importcsv.py:163
 msgid "Given"
 msgstr "Keresztnév"
 
@@ -3356,18 +3364,18 @@ msgid "Person|title"
 msgstr "cím"
 
 #: ../gramps/gen/display/name.py:604 ../gramps/gen/display/name.py:704
-#: ../gramps/plugins/importer/importcsv.py:161
+#: ../gramps/plugins/importer/importcsv.py:162
 msgid "given"
 msgstr "adott"
 
 #: ../gramps/gen/display/name.py:606 ../gramps/gen/display/name.py:706
-#: ../gramps/plugins/importer/importcsv.py:158
+#: ../gramps/plugins/importer/importcsv.py:159
 msgid "surname"
 msgstr "vezetéknév"
 
 #: ../gramps/gen/display/name.py:608 ../gramps/gen/display/name.py:708
-#: ../gramps/gui/editors/editperson.py:385
-#: ../gramps/plugins/importer/importcsv.py:167
+#: ../gramps/gui/editors/editperson.py:379
+#: ../gramps/plugins/importer/importcsv.py:168
 msgid "suffix"
 msgstr "utótag"
 
@@ -3424,8 +3432,8 @@ msgid "Remaining names|rest"
 msgstr "a többi"
 
 #: ../gramps/gen/display/name.py:645 ../gramps/gen/display/name.py:737
-#: ../gramps/gui/editors/editperson.py:406
-#: ../gramps/plugins/importer/importcsv.py:166
+#: ../gramps/gui/editors/editperson.py:400
+#: ../gramps/plugins/importer/importcsv.py:167
 msgid "prefix"
 msgstr "előtag"
 
@@ -3450,7 +3458,7 @@ msgstr "Rossz névformátum karakterlánc: %s"
 msgid "ERROR, Edit Name format in Preferences"
 msgstr "HIBA, szerkessze a Név-formátumot a Beállítások-ban"
 
-#: ../gramps/gen/filters/_filterparser.py:116
+#: ../gramps/gen/filters/_filterparser.py:119
 #, python-format
 msgid ""
 "WARNING: Too many arguments in filter '%s'!\n"
@@ -3459,7 +3467,7 @@ msgstr ""
 "FIGYELEM: túl sok argumentum van a(z) '%s' szűrőben!\n"
 "Beolvasás próbája az argumentumok egy részével."
 
-#: ../gramps/gen/filters/_filterparser.py:124
+#: ../gramps/gen/filters/_filterparser.py:127
 #, python-format
 msgid ""
 "WARNING: Too few arguments in filter '%s'!\n"
@@ -3468,13 +3476,13 @@ msgstr ""
 "FIGYELEM: túl kevés argumentum van a(z) '%s' szűrőben!\n"
 "         Beolvasás próbája a pótlás reményében."
 
-#: ../gramps/gen/filters/_filterparser.py:132
+#: ../gramps/gen/filters/_filterparser.py:135
 #, python-format
 msgid "ERROR: filter %s could not be correctly loaded. Edit the filter!"
 msgstr "HIBA: a(z) %s szűrő nem beolvasható. Szerkessze a szűrőt!"
 
-#: ../gramps/gen/filters/_genericfilter.py:139
-#: ../gramps/gen/filters/_genericfilter.py:169
+#: ../gramps/gen/filters/_genericfilter.py:143
+#: ../gramps/gen/filters/_genericfilter.py:174
 msgid "Applying ..."
 msgstr "Alkalmazás ..."
 
@@ -3482,12 +3490,12 @@ msgstr "Alkalmazás ..."
 #. ###############################
 #. #########################
 #. ###############################
-#: ../gramps/gen/filters/_genericfilter.py:139
-#: ../gramps/gen/filters/_genericfilter.py:169
-#: ../gramps/gui/editors/filtereditor.py:1105
-#: ../gramps/plugins/drawreport/calendarreport.py:470
-#: ../gramps/plugins/drawreport/statisticschart.py:990
-#: ../gramps/plugins/drawreport/timeline.py:415
+#: ../gramps/gen/filters/_genericfilter.py:143
+#: ../gramps/gen/filters/_genericfilter.py:174
+#: ../gramps/gui/editors/filtereditor.py:1119
+#: ../gramps/plugins/drawreport/calendarreport.py:466
+#: ../gramps/plugins/drawreport/statisticschart.py:1012
+#: ../gramps/plugins/drawreport/timeline.py:416
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1009
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1023
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1037
@@ -3497,22 +3505,21 @@ msgstr "Alkalmazás ..."
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1093
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1107
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1121
-#: ../gramps/plugins/graph/gvrelgraph.py:767
+#: ../gramps/plugins/graph/gvrelgraph.py:801
 #: ../gramps/plugins/quickview/quickview.gpr.py:130
-#: ../gramps/plugins/textreport/birthdayreport.py:411
+#: ../gramps/plugins/textreport/birthdayreport.py:473
 #: ../gramps/plugins/textreport/familygroup.py:714
-#: ../gramps/plugins/textreport/indivcomplete.py:1061
+#: ../gramps/plugins/textreport/indivcomplete.py:1062
 #: ../gramps/plugins/textreport/recordsreport.py:217
-#: ../gramps/plugins/tool/sortevents.py:167
-#: ../gramps/plugins/webreport/narrativeweb.py:1602
-#: ../gramps/plugins/webreport/webcal.py:1626
-#: ../gramps/plugins/drawreport/statisticschart.py:1001
+#: ../gramps/plugins/tool/sortevents.py:168
+#: ../gramps/plugins/webreport/narrativeweb.py:1639
+#: ../gramps/plugins/webreport/webcal.py:1671
 msgid "Filter"
 msgstr "Szűrő"
 
 #: ../gramps/gen/filters/rules/_changedsincebase.py:56
 #: ../gramps/gen/filters/rules/_everything.py:45
-#: ../gramps/gen/filters/rules/_hasattributebase.py:51
+#: ../gramps/gen/filters/rules/_hasattributebase.py:53
 #: ../gramps/gen/filters/rules/_hasgallerybase.py:48
 #: ../gramps/gen/filters/rules/_hasgrampsid.py:48
 #: ../gramps/gen/filters/rules/_hasldsbase.py:51
@@ -3629,7 +3636,7 @@ msgstr "Kötet/Oldal:"
 #: ../gramps/gen/filters/rules/person/_hasevent.py:49
 #: ../gramps/gen/filters/rules/person/_hasfamilyevent.py:49
 #: ../gramps/gen/filters/rules/place/_hascitation.py:49
-#: ../gramps/gui/editors/filtereditor.py:578
+#: ../gramps/gui/editors/filtereditor.py:583
 #: ../gramps/gui/glade/mergecitation.glade:245
 #: ../gramps/gui/glade/mergecitation.glade:261
 #: ../gramps/gui/glade/mergeevent.glade:245
@@ -3686,7 +3693,7 @@ msgstr "Eseményszűrők"
 #: ../gramps/gen/filters/rules/person/_hasaddress.py:48
 #: ../gramps/gen/filters/rules/person/_hasassociation.py:48
 #: ../gramps/gen/filters/rules/source/_hasrepository.py:46
-#: ../gramps/gui/editors/filtereditor.py:513
+#: ../gramps/gui/editors/filtereditor.py:518
 msgid "Number must be:"
 msgstr "Ilyen szám kell:"
 
@@ -3697,14 +3704,14 @@ msgstr "Ilyen szám kell:"
 #: ../gramps/gen/filters/rules/person/_hasaddress.py:48
 #: ../gramps/gen/filters/rules/person/_hasassociation.py:48
 #: ../gramps/gen/filters/rules/source/_hasrepository.py:46
-#: ../gramps/gui/editors/filtereditor.py:508
+#: ../gramps/gui/editors/filtereditor.py:513
 msgid "Number of instances:"
 msgstr "Példák száma:"
 
 #: ../gramps/gen/filters/rules/_hasgrampsid.py:45
 #: ../gramps/gen/filters/rules/family/_isancestorof.py:44
 #: ../gramps/gen/filters/rules/family/_isdescendantof.py:44
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:157
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:132
 #: ../gramps/gen/filters/rules/person/_hascommonancestorwith.py:45
 #: ../gramps/gen/filters/rules/person/_isancestorof.py:44
 #: ../gramps/gen/filters/rules/person/_isdescendantfamilyof.py:49
@@ -3719,8 +3726,7 @@ msgstr "Példák száma:"
 #: ../gramps/gen/filters/rules/person/_relationshippathbetween.py:45
 #: ../gramps/gen/filters/rules/place/_isenclosedby.py:48
 #: ../gramps/gen/filters/rules/place/_withinarea.py:50
-#: ../gramps/gui/editors/filtereditor.py:517
-#: ../gramps/gui/glade/editplaceref.glade:244
+#: ../gramps/gui/editors/filtereditor.py:522
 #: ../gramps/gui/glade/editplaceref.glade:245
 msgid "ID:"
 msgstr "Azonosító:"
@@ -3749,12 +3755,12 @@ msgid "Substring:"
 msgstr "Karakterláncrész:"
 
 #: ../gramps/gen/filters/rules/_hasreferencecountbase.py:42
-#: ../gramps/gui/editors/filtereditor.py:511
+#: ../gramps/gui/editors/filtereditor.py:516
 msgid "Reference count must be:"
 msgstr "Ilyen hivatkozási szám kell:"
 
 #: ../gramps/gen/filters/rules/_hasreferencecountbase.py:42
-#: ../gramps/gui/editors/filtereditor.py:507
+#: ../gramps/gui/editors/filtereditor.py:512
 msgid "Reference count:"
 msgstr "Hivatkozás szám:"
 
@@ -3763,12 +3769,12 @@ msgstr "Hivatkozás szám:"
 #: ../gramps/gen/filters/rules/media/_hassourceof.py:45
 #: ../gramps/gen/filters/rules/person/_hassourceof.py:45
 #: ../gramps/gen/filters/rules/place/_hassourceof.py:45
-#: ../gramps/gui/editors/filtereditor.py:520
+#: ../gramps/gui/editors/filtereditor.py:525
 msgid "Source ID:"
 msgstr "Forrás azonosító:"
 
 #: ../gramps/gen/filters/rules/_matchesfilterbase.py:54
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:157
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:132
 #: ../gramps/gen/filters/rules/person/_hascommonancestorwithfiltermatch.py:47
 #: ../gramps/gen/filters/rules/person/_isancestoroffiltermatch.py:46
 #: ../gramps/gen/filters/rules/person/_ischildoffiltermatch.py:46
@@ -3777,7 +3783,7 @@ msgstr "Forrás azonosító:"
 #: ../gramps/gen/filters/rules/person/_isparentoffiltermatch.py:46
 #: ../gramps/gen/filters/rules/person/_issiblingoffiltermatch.py:45
 #: ../gramps/gen/filters/rules/person/_isspouseoffiltermatch.py:46
-#: ../gramps/gui/editors/filtereditor.py:522
+#: ../gramps/gui/editors/filtereditor.py:527
 msgid "Filter name:"
 msgstr "Szűrőnév:"
 
@@ -3790,22 +3796,31 @@ msgstr "A(z) %s szűrő nem található a meghatározott felhasználói szűrők
 #: ../gramps/gen/filters/rules/_matchessourcefilterbase.py:47
 #: ../gramps/gen/filters/rules/citation/_matchessourcefilter.py:48
 #: ../gramps/gen/filters/rules/event/_matchessourcefilter.py:48
-#: ../gramps/gui/editors/filtereditor.py:530
+#: ../gramps/gui/editors/filtereditor.py:535
 msgid "Source filter name:"
 msgstr "Forrás szűrő neve:"
 
-#: ../gramps/gen/filters/rules/_rule.py:53
+#: ../gramps/gen/filters/rules/_rule.py:55
 msgid "Miscellaneous filters"
 msgstr "Vegyes szűrők"
 
-#: ../gramps/gen/filters/rules/_rule.py:54 ../gramps/gui/glade/rule.glade:950
-#: ../gramps/plugins/view/geoclose.py:535
-#: ../gramps/plugins/view/geofamclose.py:727
-#: ../gramps/plugins/view/geofamily.py:480
-#: ../gramps/plugins/view/geomoves.py:609
-#: ../gramps/plugins/view/geoperson.py:488
+#: ../gramps/gen/filters/rules/_rule.py:56 ../gramps/gui/glade/rule.glade:950
+#: ../gramps/plugins/view/geoclose.py:607
+#: ../gramps/plugins/view/geofamclose.py:797
+#: ../gramps/plugins/view/geofamily.py:530
+#: ../gramps/plugins/view/geomoves.py:675
+#: ../gramps/plugins/view/geoperson.py:554
 msgid "No description"
 msgstr "Nincs leírás"
+
+#. more references to a filter than expected
+#: ../gramps/gen/filters/rules/_rule.py:94
+msgid "The filter definition contains a loop."
+msgstr "A szűrő meghatározása hurkot tartalmaz."
+
+#: ../gramps/gen/filters/rules/_rule.py:95
+msgid "One rule references another which eventually references the first."
+msgstr "Egy szabály egy másikra hivatkozik, ami meg az elsőre hivatkozik."
 
 #: ../gramps/gen/filters/rules/citation/_allcitations.py:45
 msgid "Every citation"
@@ -3870,7 +3885,7 @@ msgstr "Bizalmasnak jelölt idézet találatok"
 #: ../gramps/gen/filters/rules/person/_matchessourceconfidence.py:43
 #: ../gramps/gen/filters/rules/place/_hascitation.py:50
 #: ../gramps/gen/filters/rules/place/_matchessourceconfidence.py:43
-#: ../gramps/gui/editors/filtereditor.py:575
+#: ../gramps/gui/editors/filtereditor.py:580
 msgid "Confidence level:"
 msgstr "Megbízhatósági szint:"
 
@@ -3931,7 +3946,7 @@ msgstr "Megadott hivatkozási számnak megfelelő idézet találatok"
 #: ../gramps/gen/filters/rules/media/_hasmedia.py:46
 #: ../gramps/gen/filters/rules/place/_hasplace.py:48
 #: ../gramps/gen/filters/rules/place/_hastitle.py:48
-#: ../gramps/gui/glade/editplaceref.glade:200
+#: ../gramps/gui/glade/editplaceref.glade:201
 #: ../gramps/gui/glade/mergedata.glade:759
 #: ../gramps/gui/glade/mergedata.glade:775
 #: ../gramps/gui/glade/mergemedia.glade:212
@@ -3940,7 +3955,6 @@ msgstr "Megadott hivatkozási számnak megfelelő idézet találatok"
 #: ../gramps/gui/glade/mergeplace.glade:220
 #: ../gramps/gui/glade/mergesource.glade:212
 #: ../gramps/gui/glade/mergesource.glade:228
-#: ../gramps/gui/glade/editplaceref.glade:201
 msgid "Title:"
 msgstr "Cím:"
 
@@ -4015,7 +4029,7 @@ msgstr ""
 #: ../gramps/gen/filters/rules/place/_hastag.py:48
 #: ../gramps/gen/filters/rules/repository/_hastag.py:48
 #: ../gramps/gen/filters/rules/source/_hastag.py:48
-#: ../gramps/gui/editors/filtereditor.py:571
+#: ../gramps/gui/editors/filtereditor.py:576
 msgid "Tag:"
 msgstr "Címke:"
 
@@ -4046,7 +4060,7 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/citation/_matchesrepositoryfilter.py:45
 #: ../gramps/gen/filters/rules/source/_matchesrepositoryfilter.py:43
-#: ../gramps/gui/editors/filtereditor.py:532
+#: ../gramps/gui/editors/filtereditor.py:537
 msgid "Repository filter name:"
 msgstr "Tároló szűrő neve:"
 
@@ -4123,8 +4137,8 @@ msgid "Matches events that are indicated as private"
 msgstr "Bizalmas jelölésnek megfelelő események"
 
 #: ../gramps/gen/filters/rules/event/_hasattribute.py:44
-#: ../gramps/gui/editors/filtereditor.py:106
-#: ../gramps/gui/editors/filtereditor.py:545
+#: ../gramps/gui/editors/filtereditor.py:107
+#: ../gramps/gui/editors/filtereditor.py:550
 msgid "Event attribute:"
 msgstr "Esemény jellemző:"
 
@@ -4156,8 +4170,8 @@ msgstr "Meghatározott értékű idézetnek megfelelő események"
 #: ../gramps/gen/filters/rules/event/_hasdata.py:47
 #: ../gramps/gen/filters/rules/event/_hastype.py:45
 #: ../gramps/gen/filters/rules/person/_iswitness.py:44
-#: ../gramps/gui/editors/filtereditor.py:103
-#: ../gramps/gui/editors/filtereditor.py:538
+#: ../gramps/gui/editors/filtereditor.py:104
+#: ../gramps/gui/editors/filtereditor.py:543
 msgid "Event type:"
 msgstr "Esemény típus:"
 
@@ -4167,7 +4181,7 @@ msgstr "Esemény típus:"
 #: ../gramps/gen/filters/rules/person/_hasdeath.py:48
 #: ../gramps/gen/filters/rules/person/_hasevent.py:50
 #: ../gramps/gen/filters/rules/person/_hasfamilyevent.py:50
-#: ../gramps/gui/editors/filtereditor.py:505
+#: ../gramps/gui/editors/filtereditor.py:510
 #: ../gramps/gui/glade/mergeevent.glade:278
 #: ../gramps/gui/glade/mergeevent.glade:294
 msgid "Place:"
@@ -4193,7 +4207,7 @@ msgid "Matches events with data of a particular value"
 msgstr "Meghatározott értékű adatnak megfelelő események"
 
 #: ../gramps/gen/filters/rules/event/_hasdayofweek.py:38
-#: ../gramps/gui/editors/filtereditor.py:580
+#: ../gramps/gui/editors/filtereditor.py:585
 msgid "Day of Week:"
 msgstr "A hét napja:"
 
@@ -4290,13 +4304,13 @@ msgid "Matches events matched by the specified filter name"
 msgstr "Meghatározott szűrőnévnek megfelelő események"
 
 #: ../gramps/gen/filters/rules/event/_matchespersonfilter.py:50
-#: ../gramps/gui/editors/filtereditor.py:567
+#: ../gramps/gui/editors/filtereditor.py:572
 msgid "Include Family events:"
 msgstr "Családi eseményekkel együtt:"
 
 #. filters of another namespace, name may be same as caller!
 #: ../gramps/gen/filters/rules/event/_matchespersonfilter.py:50
-#: ../gramps/gui/editors/filtereditor.py:526
+#: ../gramps/gui/editors/filtereditor.py:531
 msgid "Person filter name:"
 msgstr "Személyszűrő neve:"
 
@@ -4310,7 +4324,7 @@ msgstr ""
 "Meghatározott személyszűrő névvel egyező személynek megfelelő események"
 
 #: ../gramps/gen/filters/rules/event/_matchesplacefilter.py:49
-#: ../gramps/gui/editors/filtereditor.py:534
+#: ../gramps/gui/editors/filtereditor.py:539
 msgid "Place filter name:"
 msgstr "Hely szűrő neve:"
 
@@ -4438,8 +4452,8 @@ msgstr "Családok, ahol az apának megszabott (részleges) neve van"
 
 #: ../gramps/gen/filters/rules/family/_hasattribute.py:44
 #: ../gramps/gen/filters/rules/person/_hasfamilyattribute.py:44
-#: ../gramps/gui/editors/filtereditor.py:105
-#: ../gramps/gui/editors/filtereditor.py:543
+#: ../gramps/gui/editors/filtereditor.py:106
+#: ../gramps/gui/editors/filtereditor.py:548
 msgid "Family attribute:"
 msgstr "Család jellemző:"
 
@@ -4461,16 +4475,16 @@ msgstr "Család találatok meghatározott értékű idézettel"
 
 #: ../gramps/gen/filters/rules/family/_hasevent.py:47
 #: ../gramps/gen/filters/rules/person/_hasfamilyevent.py:48
-#: ../gramps/gui/editors/filtereditor.py:102
-#: ../gramps/gui/editors/filtereditor.py:539
+#: ../gramps/gui/editors/filtereditor.py:103
+#: ../gramps/gui/editors/filtereditor.py:544
 msgid "Family event:"
 msgstr "Családi esemény:"
 
 #: ../gramps/gen/filters/rules/family/_hasevent.py:51
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:83
-#: ../gramps/gui/selectors/selectevent.py:70
+#: ../gramps/gui/selectors/selectevent.py:67
 #: ../gramps/plugins/gramplet/events.py:92
-#: ../gramps/plugins/view/eventview.py:90
+#: ../gramps/plugins/view/eventview.py:86
 msgid "Main Participants"
 msgstr "Fő résztvevők"
 
@@ -4544,8 +4558,8 @@ msgstr "Bizonyos hivatkozási számnak megfelelő család objektumok"
 
 #: ../gramps/gen/filters/rules/family/_hasreltype.py:45
 #: ../gramps/gen/filters/rules/person/_hasrelationship.py:46
-#: ../gramps/gui/editors/filtereditor.py:108
-#: ../gramps/gui/editors/filtereditor.py:549
+#: ../gramps/gui/editors/filtereditor.py:109
+#: ../gramps/gui/editors/filtereditor.py:554
 msgid "Relationship type:"
 msgstr "Kapcsolat típus:"
 
@@ -4595,7 +4609,7 @@ msgstr "Ikrekkel rendelkező családok"
 #: ../gramps/gen/filters/rules/person/_isdescendantfamilyof.py:49
 #: ../gramps/gen/filters/rules/person/_isdescendantof.py:45
 #: ../gramps/gen/filters/rules/place/_isenclosedby.py:48
-#: ../gramps/gui/editors/filtereditor.py:561
+#: ../gramps/gui/editors/filtereditor.py:566
 msgid "Inclusive:"
 msgstr "Bezárólag:"
 
@@ -4746,8 +4760,8 @@ msgstr ""
 "intervallumában."
 
 #: ../gramps/gen/filters/rules/media/_hasattribute.py:44
-#: ../gramps/gui/editors/filtereditor.py:107
-#: ../gramps/gui/editors/filtereditor.py:547
+#: ../gramps/gui/editors/filtereditor.py:108
+#: ../gramps/gui/editors/filtereditor.py:552
 msgid "Media attribute:"
 msgstr "Média jellemző:"
 
@@ -4778,8 +4792,8 @@ msgstr "Meghatározott GRAMPS azonosítójú média objektum egyezése"
 #: ../gramps/gen/filters/rules/media/_hasmedia.py:47
 #: ../gramps/gen/filters/rules/repository/_hasrepo.py:47
 #: ../gramps/gui/glade/editmediaref.glade:521
-#: ../gramps/gui/glade/editplace.glade:366
-#: ../gramps/gui/glade/editplaceref.glade:317
+#: ../gramps/gui/glade/editplace.glade:367
+#: ../gramps/gui/glade/editplaceref.glade:318
 #: ../gramps/gui/glade/mergeevent.glade:212
 #: ../gramps/gui/glade/mergeevent.glade:228
 #: ../gramps/gui/glade/mergenote.glade:245
@@ -4788,15 +4802,12 @@ msgstr "Meghatározott GRAMPS azonosítójú média objektum egyezése"
 #: ../gramps/gui/glade/mergeplace.glade:502
 #: ../gramps/gui/glade/mergerepository.glade:245
 #: ../gramps/gui/glade/mergerepository.glade:261
-#: ../gramps/gui/glade/editplace.glade:367
-#: ../gramps/gui/glade/editplaceref.glade:318
 msgid "Type:"
 msgstr "Típus:"
 
 #: ../gramps/gen/filters/rules/media/_hasmedia.py:48
 #: ../gramps/gui/glade/mergemedia.glade:245
-#: ../gramps/gui/glade/mergemedia.glade:261 ../gramps/gui/viewmanager.py:1872
-#: ../gramps/gui/viewmanager.py:1870
+#: ../gramps/gui/glade/mergemedia.glade:261 ../gramps/gui/viewmanager.py:1663
 msgid "Path:"
 msgstr "Útvonal:"
 
@@ -4928,8 +4939,8 @@ msgstr "Meghatározott GRAMPS azonosítójú jegyzettel egyezés"
 
 #: ../gramps/gen/filters/rules/note/_hasnote.py:47
 #: ../gramps/gen/filters/rules/note/_hastype.py:45
-#: ../gramps/gui/editors/filtereditor.py:109
-#: ../gramps/gui/editors/filtereditor.py:551
+#: ../gramps/gui/editors/filtereditor.py:110
+#: ../gramps/gui/editors/filtereditor.py:556
 msgid "Note type:"
 msgstr "Jegyzet típus:"
 
@@ -5019,34 +5030,18 @@ msgstr ""
 "Személy adatok találatai, melyek egy meghatározott dátum-idő (éééé-hh-nn óó:"
 "pp:ss), vagy időintervallum - ha a második dátum-idő adott - után változtak."
 
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:53
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:176
-msgid "Finding relationship paths"
-msgstr "Kapcsolati útvonalak keresése"
-
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:54
-#: ../gramps/gen/filters/rules/person/_hascommonancestorwithfiltermatch.py:69
-#: ../gramps/gen/filters/rules/person/_isancestoroffiltermatch.py:67
-#: ../gramps/gen/filters/rules/person/_ischildoffiltermatch.py:58
-#: ../gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py:60
-#: ../gramps/gen/filters/rules/person/_isdescendantoffiltermatch.py:67
-#: ../gramps/gen/filters/rules/person/_isparentoffiltermatch.py:58
-#: ../gramps/gen/filters/rules/person/_issiblingoffiltermatch.py:57
-msgid "Retrieving all sub-filter matches"
-msgstr "Az összes al-szűrő találat helyreállítása"
-
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:158
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:133
 msgid "Relationship path between <person> and people matching <filter>"
 msgstr "Kapcsolati útvonal <person> és a <filter> személy-találatok között"
 
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:159
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:134
 #: ../gramps/gen/filters/rules/person/_isrelatedwith.py:46
 #: ../gramps/gen/filters/rules/person/_relationshippathbetween.py:47
 #: ../gramps/gen/filters/rules/person/_relationshippathbetweenbookmarks.py:52
 msgid "Relationship filters"
 msgstr "Kapcsolatszűrők"
 
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:160
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:135
 msgid ""
 "Searches over the database starting from a specified person and returns "
 "everyone between that person and a set of target people specified with a "
@@ -5060,7 +5055,23 @@ msgstr ""
 "a meghatározott és a célszemélyek között. Az összes útvonal nem "
 "szükségképpen a legrövidebb."
 
-#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:177
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:152
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:164
+msgid "Finding relationship paths"
+msgstr "Kapcsolati útvonalak keresése"
+
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:153
+#: ../gramps/gen/filters/rules/person/_hascommonancestorwithfiltermatch.py:69
+#: ../gramps/gen/filters/rules/person/_isancestoroffiltermatch.py:67
+#: ../gramps/gen/filters/rules/person/_ischildoffiltermatch.py:58
+#: ../gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py:60
+#: ../gramps/gen/filters/rules/person/_isdescendantoffiltermatch.py:67
+#: ../gramps/gen/filters/rules/person/_isparentoffiltermatch.py:58
+#: ../gramps/gen/filters/rules/person/_issiblingoffiltermatch.py:57
+msgid "Retrieving all sub-filter matches"
+msgstr "Az összes al-szűrő találat helyreállítása"
+
+#: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:165
 msgid "Evaluating people"
 msgstr "Emberek értékelése"
 
@@ -5117,8 +5128,8 @@ msgid "Matches people with a certain number of associations"
 msgstr "Egy meghatározott számú társításnak megfelelő emberek"
 
 #: ../gramps/gen/filters/rules/person/_hasattribute.py:44
-#: ../gramps/gui/editors/filtereditor.py:104
-#: ../gramps/gui/editors/filtereditor.py:541
+#: ../gramps/gui/editors/filtereditor.py:105
+#: ../gramps/gui/editors/filtereditor.py:546
 msgid "Personal attribute:"
 msgstr "Személyes jellemző:"
 
@@ -5187,8 +5198,8 @@ msgid "Matches people with death data of a particular value"
 msgstr "Egy meghatározott értékű halálozási adatnak megfelelő emberek"
 
 #: ../gramps/gen/filters/rules/person/_hasevent.py:48
-#: ../gramps/gui/editors/filtereditor.py:101
-#: ../gramps/gui/editors/filtereditor.py:538
+#: ../gramps/gui/editors/filtereditor.py:102
+#: ../gramps/gui/editors/filtereditor.py:543
 msgid "Personal event:"
 msgstr "Személyes esemény:"
 
@@ -5197,7 +5208,7 @@ msgid "Main Participants:"
 msgstr "Fő résztvevők:"
 
 #: ../gramps/gen/filters/rules/person/_hasevent.py:53
-#: ../gramps/gui/editors/filtereditor.py:569
+#: ../gramps/gui/editors/filtereditor.py:574
 msgid "Primary Role:"
 msgstr "Elsődleges szerep:"
 
@@ -5307,8 +5318,8 @@ msgid "Matches people with a specified (partial) name"
 msgstr "Meghatározott (részleges) névvel rendelkező emberek"
 
 #: ../gramps/gen/filters/rules/person/_hasnameorigintype.py:46
-#: ../gramps/gui/editors/filtereditor.py:111
-#: ../gramps/gui/editors/filtereditor.py:555
+#: ../gramps/gui/editors/filtereditor.py:112
+#: ../gramps/gui/editors/filtereditor.py:560
 msgid "Surname origin type:"
 msgstr "Vezetéknév eredeti típusa:"
 
@@ -5321,8 +5332,8 @@ msgid "Matches people with a surname origin"
 msgstr "Eredeti vezetéknévnek megfelelő emberek"
 
 #: ../gramps/gen/filters/rules/person/_hasnametype.py:46
-#: ../gramps/gui/editors/filtereditor.py:110
-#: ../gramps/gui/editors/filtereditor.py:553
+#: ../gramps/gui/editors/filtereditor.py:111
+#: ../gramps/gui/editors/filtereditor.py:558
 msgid "Name type:"
 msgstr "Név típus:"
 
@@ -5385,7 +5396,7 @@ msgstr "Egy meghatározott kapcsolatnak megfelelő emberek"
 
 #: ../gramps/gen/filters/rules/person/_hasrelationship.py:50
 #: ../gramps/gen/filters/rules/person/_havealtfamilies.py:45
-#: ../gramps/gen/filters/rules/person/_havechildren.py:44
+#: ../gramps/gen/filters/rules/person/_havechildren.py:48
 #: ../gramps/gen/filters/rules/person/_ischildoffiltermatch.py:48
 #: ../gramps/gen/filters/rules/person/_isparentoffiltermatch.py:48
 #: ../gramps/gen/filters/rules/person/_issiblingoffiltermatch.py:47
@@ -5402,13 +5413,12 @@ msgstr "Családszűrők"
 #: ../gramps/gui/glade/editfamily.glade:372
 #: ../gramps/gui/glade/editplaceformat.glade:200
 #: ../gramps/gui/glade/editplacename.glade:183
-#: ../gramps/gui/glade/editplaceref.glade:214
+#: ../gramps/gui/glade/editplaceref.glade:215
 #: ../gramps/gui/glade/mergeperson.glade:222
 #: ../gramps/gui/glade/mergeperson.glade:238
 #: ../gramps/gui/glade/mergeplace.glade:425
 #: ../gramps/gui/glade/mergeplace.glade:442
 #: ../gramps/plugins/gramplet/soundgen.py:65
-#: ../gramps/gui/glade/editplaceref.glade:215
 msgid "Name:"
 msgstr "Név:"
 
@@ -5449,7 +5459,7 @@ msgid "Matches people with the particular tag"
 msgstr "Meghatározott címkével rendelkező emberek"
 
 #: ../gramps/gen/filters/rules/person/_hastextmatchingsubstringof.py:47
-#: ../gramps/gui/editors/filtereditor.py:563
+#: ../gramps/gui/editors/filtereditor.py:568
 msgid "Case sensitive:"
 msgstr "Nagybetű érzékeny:"
 
@@ -5477,11 +5487,11 @@ msgstr "Örökbefogadott emberek"
 msgid "Matches people who were adopted"
 msgstr "Örökbefogadott emberek találatai"
 
-#: ../gramps/gen/filters/rules/person/_havechildren.py:42
+#: ../gramps/gen/filters/rules/person/_havechildren.py:46
 msgid "People with children"
 msgstr "Emberek gyermekekkel"
 
-#: ../gramps/gen/filters/rules/person/_havechildren.py:43
+#: ../gramps/gen/filters/rules/person/_havechildren.py:47
 msgid "Matches people who have children"
 msgstr "Gyermekekkel rendelkező emberek"
 
@@ -5595,12 +5605,12 @@ msgstr ""
 "Emberek, akik egy meghatározott személynek kétszeres, vagy többszörös ősei"
 
 #: ../gramps/gen/filters/rules/person/_isfemale.py:45
-#: ../gramps/plugins/gramplet/statsgramplet.py:108
-#: ../gramps/plugins/graph/gvfamilylines.py:276
-#: ../gramps/plugins/graph/gvhourglass.py:372
-#: ../gramps/plugins/graph/gvrelgraph.py:899
-#: ../gramps/plugins/webreport/statistics.py:123
-#: ../gramps/plugins/webreport/statistics.py:188
+#: ../gramps/plugins/gramplet/statsgramplet.py:149
+#: ../gramps/plugins/graph/gvfamilylines.py:283
+#: ../gramps/plugins/graph/gvhourglass.py:423
+#: ../gramps/plugins/graph/gvrelgraph.py:944
+#: ../gramps/plugins/webreport/statistics.py:124
+#: ../gramps/plugins/webreport/statistics.py:189
 msgid "Females"
 msgstr "Nők"
 
@@ -5614,7 +5624,7 @@ msgstr "Minden nő találat"
 #: ../gramps/gen/filters/rules/person/_islessthannthgenerationdescendantof.py:45
 #: ../gramps/gen/filters/rules/person/_ismorethannthgenerationancestorof.py:45
 #: ../gramps/gen/filters/rules/person/_ismorethannthgenerationdescendantof.py:45
-#: ../gramps/gui/editors/filtereditor.py:515
+#: ../gramps/gui/editors/filtereditor.py:520
 msgid "Number of generations:"
 msgstr "A generációk száma:"
 
@@ -5665,12 +5675,12 @@ msgstr ""
 #. -------------------------
 #. ###############################
 #: ../gramps/gen/filters/rules/person/_ismale.py:45
-#: ../gramps/plugins/gramplet/statsgramplet.py:105
-#: ../gramps/plugins/graph/gvfamilylines.py:272
-#: ../gramps/plugins/graph/gvhourglass.py:368
-#: ../gramps/plugins/graph/gvrelgraph.py:895
-#: ../gramps/plugins/webreport/statistics.py:121
-#: ../gramps/plugins/webreport/statistics.py:186
+#: ../gramps/plugins/gramplet/statsgramplet.py:146
+#: ../gramps/plugins/graph/gvfamilylines.py:279
+#: ../gramps/plugins/graph/gvhourglass.py:419
+#: ../gramps/plugins/graph/gvrelgraph.py:940
+#: ../gramps/plugins/webreport/statistics.py:122
+#: ../gramps/plugins/webreport/statistics.py:187
 msgid "Males"
 msgstr "Férfiak"
 
@@ -5742,7 +5752,7 @@ msgstr "Emberek találatai, akik egy esemény tanúi"
 
 #: ../gramps/gen/filters/rules/person/_matcheseventfilter.py:51
 #: ../gramps/gen/filters/rules/place/_matcheseventfilter.py:49
-#: ../gramps/gui/editors/filtereditor.py:528
+#: ../gramps/gui/editors/filtereditor.py:533
 msgid "Event filter name:"
 msgstr "Esemény szűrő neve:"
 
@@ -5932,18 +5942,16 @@ msgid "Matches places with a citation of a particular value"
 msgstr "Egy meghatározott értékű idézetnek megfelelő helyszínek"
 
 #: ../gramps/gen/filters/rules/place/_hasdata.py:49
-#: ../gramps/gui/editors/filtereditor.py:112
-#: ../gramps/gui/editors/filtereditor.py:557
+#: ../gramps/gui/editors/filtereditor.py:113
+#: ../gramps/gui/editors/filtereditor.py:562
 msgid "Place type:"
 msgstr "Hely típus:"
 
 #: ../gramps/gen/filters/rules/place/_hasdata.py:50
-#: ../gramps/gui/glade/editplace.glade:279
-#: ../gramps/gui/glade/editplaceref.glade:510
-#: ../gramps/gui/glade/mergeplace.glade:545
-#: ../gramps/gui/glade/mergeplace.glade:562
 #: ../gramps/gui/glade/editplace.glade:280
 #: ../gramps/gui/glade/editplaceref.glade:511
+#: ../gramps/gui/glade/mergeplace.glade:545
+#: ../gramps/gui/glade/mergeplace.glade:562
 msgid "Code:"
 msgstr "Kód:"
 
@@ -6087,18 +6095,16 @@ msgid "Matches places with a particular title"
 msgstr "A meghatározott címnek megfelelő helyek"
 
 #: ../gramps/gen/filters/rules/place/_inlatlonneighborhood.py:49
-#: ../gramps/gui/glade/editplaceref.glade:258
+#: ../gramps/gui/glade/editplaceref.glade:259
 #: ../gramps/gui/glade/mergeplace.glade:236
 #: ../gramps/gui/glade/mergeplace.glade:251
-#: ../gramps/gui/glade/editplaceref.glade:259
 msgid "Latitude:"
 msgstr "Szélességi fok:"
 
 #: ../gramps/gen/filters/rules/place/_inlatlonneighborhood.py:49
-#: ../gramps/gui/glade/editplaceref.glade:331
+#: ../gramps/gui/glade/editplaceref.glade:332
 #: ../gramps/gui/glade/mergeplace.glade:267
 #: ../gramps/gui/glade/mergeplace.glade:282
-#: ../gramps/gui/glade/editplaceref.glade:332
 msgid "Longitude:"
 msgstr "Hosszúsági fok:"
 
@@ -6178,7 +6184,7 @@ msgid "Matches places whose Gramps ID matches the regular expression"
 msgstr "Reguláris kifejezéssel egyező GRAMPS azonosítónak megfelelő helyek"
 
 #: ../gramps/gen/filters/rules/place/_withinarea.py:50
-#: ../gramps/gui/editors/filtereditor.py:584
+#: ../gramps/gui/editors/filtereditor.py:589
 msgid "Units:"
 msgstr "Egységek:"
 
@@ -6462,13 +6468,13 @@ msgstr "Bizalmas jelölésnek megfelelő források"
 
 #. We encounter a PLAC, having previously encountered an ADDR
 #: ../gramps/gen/lib/address.py:97 ../gramps/gui/clipboard.py:298
-#: ../gramps/gui/configure.py:537 ../gramps/gui/editors/editaddress.py:167
+#: ../gramps/gui/configure.py:610 ../gramps/gui/editors/editaddress.py:167
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:106
 #: ../gramps/plugins/gramplet/repositorydetails.py:136
-#: ../gramps/plugins/lib/libgedcom.py:5607
-#: ../gramps/plugins/lib/libgedcom.py:5774
+#: ../gramps/plugins/lib/libgedcom.py:5596
+#: ../gramps/plugins/lib/libgedcom.py:5763
 #: ../gramps/plugins/textreport/familygroup.py:352
-#: ../gramps/plugins/webreport/addressbooklist.py:112
+#: ../gramps/plugins/webreport/addressbooklist.py:113
 msgid "Address"
 msgstr "Lakcím"
 
@@ -6491,11 +6497,11 @@ msgstr "Lakcím"
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:66
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:80
 #: ../gramps/gui/editors/displaytabs/notetab.py:79
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:67
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:69
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:70
 #: ../gramps/gui/editors/displaytabs/srcattrembedlist.py:65
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:68
-#: ../gramps/gui/editors/editfamily.py:134
+#: ../gramps/gui/editors/editfamily.py:136
 #: ../gramps/gui/glade/editaddress.glade:297
 #: ../gramps/gui/glade/editattribute.glade:153
 #: ../gramps/gui/glade/editchildref.glade:180
@@ -6511,24 +6517,24 @@ msgstr "Lakcím"
 #: ../gramps/gui/glade/editnote.glade:233
 #: ../gramps/gui/glade/editperson.glade:417
 #: ../gramps/gui/glade/editpersonref.glade:158
-#: ../gramps/gui/glade/editplace.glade:328
-#: ../gramps/gui/glade/editplaceref.glade:431
+#: ../gramps/gui/glade/editplace.glade:329
+#: ../gramps/gui/glade/editplaceref.glade:432
 #: ../gramps/gui/glade/editreporef.glade:195
 #: ../gramps/gui/glade/editreporef.glade:404
 #: ../gramps/gui/glade/editrepository.glade:212
 #: ../gramps/gui/glade/editsource.glade:295
 #: ../gramps/gui/glade/editurl.glade:156
+#: ../gramps/plugins/importer/importprogen.glade:108
+#: ../gramps/plugins/importer/importprogen.glade:244
 #: ../gramps/plugins/lib/libpersonview.py:110
-#: ../gramps/plugins/lib/libplaceview.py:91
+#: ../gramps/plugins/lib/libplaceview.py:92
 #: ../gramps/plugins/view/citationlistview.py:102
 #: ../gramps/plugins/view/citationtreeview.py:97
-#: ../gramps/plugins/view/eventview.py:87
+#: ../gramps/plugins/view/eventview.py:83
 #: ../gramps/plugins/view/familyview.py:84
 #: ../gramps/plugins/view/mediaview.py:99 ../gramps/plugins/view/noteview.py:82
 #: ../gramps/plugins/view/repoview.py:97
 #: ../gramps/plugins/view/sourceview.py:87
-#: ../gramps/gui/glade/editplace.glade:329
-#: ../gramps/gui/glade/editplaceref.glade:432
 msgid "Private"
 msgstr "Bizalmas"
 
@@ -6571,9 +6577,8 @@ msgstr "Idézetek"
 #: ../gramps/plugins/textreport/tagreport.py:488
 #: ../gramps/plugins/view/noteview.py:110 ../gramps/plugins/view/view.gpr.py:97
 #: ../gramps/plugins/view/view.gpr.py:105
-#: ../gramps/plugins/webreport/basepage.py:631
-#: ../gramps/plugins/webreport/basepage.py:1245
-#: ../gramps/plugins/webreport/person.py:1169
+#: ../gramps/plugins/webreport/basepage.py:1264
+#: ../gramps/plugins/webreport/person.py:1242
 msgid "Notes"
 msgstr "Jegyzetek"
 
@@ -6590,7 +6595,7 @@ msgstr "Jegyzetek"
 #: ../gramps/gui/editors/displaytabs/familyldsembedlist.py:52
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:62
 #: ../gramps/gui/editors/displaytabs/placenameembedlist.py:64
-#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:61
+#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:63
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:113
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:107
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:91
@@ -6613,7 +6618,7 @@ msgstr "Jegyzetek"
 #: ../gramps/gui/glade/editname.glade:581
 #: ../gramps/gui/glade/editplacename.glade:132
 #: ../gramps/gui/glade/editplacename.glade:142
-#: ../gramps/gui/selectors/selectevent.py:71
+#: ../gramps/gui/selectors/selectevent.py:68
 #: ../gramps/plugins/export/exportcsv.py:288
 #: ../gramps/plugins/export/exportcsv.py:466
 #: ../gramps/plugins/gramplet/ageondategramplet.py:66
@@ -6621,7 +6626,11 @@ msgstr "Jegyzetek"
 #: ../gramps/plugins/gramplet/events.py:87
 #: ../gramps/plugins/gramplet/locations.py:87
 #: ../gramps/plugins/gramplet/personresidence.py:60
-#: ../gramps/plugins/importer/importcsv.py:220
+#: ../gramps/plugins/importer/importcsv.py:236
+#: ../gramps/plugins/importer/importprogen.glade:458
+#: ../gramps/plugins/importer/importprogen.glade:496
+#: ../gramps/plugins/importer/importprogen.glade:503
+#: ../gramps/plugins/importer/importprogen.glade:1145
 #: ../gramps/plugins/quickview/onthisday.py:80
 #: ../gramps/plugins/quickview/onthisday.py:81
 #: ../gramps/plugins/quickview/onthisday.py:82
@@ -6635,17 +6644,17 @@ msgstr "Jegyzetek"
 #: ../gramps/plugins/tool/sortevents.py:54
 #: ../gramps/plugins/view/citationlistview.py:100
 #: ../gramps/plugins/view/citationtreeview.py:95
-#: ../gramps/plugins/view/eventview.py:85
+#: ../gramps/plugins/view/eventview.py:81
 #: ../gramps/plugins/view/mediaview.py:98
-#: ../gramps/plugins/webreport/basepage.py:620
-#: ../gramps/plugins/webreport/basepage.py:912
-#: ../gramps/plugins/webreport/basepage.py:942
-#: ../gramps/plugins/webreport/basepage.py:1108
-#: ../gramps/plugins/webreport/basepage.py:2188
-#: ../gramps/plugins/webreport/event.py:176
-#: ../gramps/plugins/webreport/media.py:229
-#: ../gramps/plugins/webreport/media.py:592
-#: ../gramps/plugins/webreport/person.py:872
+#: ../gramps/plugins/webreport/basepage.py:641
+#: ../gramps/plugins/webreport/basepage.py:930
+#: ../gramps/plugins/webreport/basepage.py:961
+#: ../gramps/plugins/webreport/basepage.py:1127
+#: ../gramps/plugins/webreport/basepage.py:2269
+#: ../gramps/plugins/webreport/event.py:177
+#: ../gramps/plugins/webreport/media.py:230
+#: ../gramps/plugins/webreport/media.py:564
+#: ../gramps/plugins/webreport/person.py:892
 msgid "Date"
 msgstr "Dátum"
 
@@ -6653,88 +6662,89 @@ msgstr "Dátum"
 #: ../gramps/gen/lib/placetype.py:71
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:72
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:54
-#: ../gramps/plugins/view/geoplaces.py:540
+#: ../gramps/plugins/view/geoplaces.py:599
 #: ../gramps/plugins/view/repoview.py:89
-#: ../gramps/plugins/webreport/basepage.py:1109
-#: ../gramps/plugins/webreport/basepage.py:2546
-#: ../gramps/plugins/webreport/basepage.py:2611
+#: ../gramps/plugins/webreport/basepage.py:1128
+#: ../gramps/plugins/webreport/basepage.py:2587
+#: ../gramps/plugins/webreport/basepage.py:2653
 msgid "Street"
 msgstr "Utca"
 
 #: ../gramps/gen/lib/address.py:115 ../gramps/gen/lib/location.py:93
-#: ../gramps/gen/lib/placetype.py:70 ../gramps/gui/configure.py:538
+#: ../gramps/gen/lib/placetype.py:70 ../gramps/gui/configure.py:612
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:73
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:55
-#: ../gramps/plugins/view/geoplaces.py:537
+#: ../gramps/plugins/view/geoplaces.py:596
 #: ../gramps/plugins/view/repoview.py:90
-#: ../gramps/plugins/webreport/basepage.py:1110
-#: ../gramps/plugins/webreport/basepage.py:2547
-#: ../gramps/plugins/webreport/basepage.py:2612
+#: ../gramps/plugins/webreport/basepage.py:1129
+#: ../gramps/plugins/webreport/basepage.py:2588
+#: ../gramps/plugins/webreport/basepage.py:2654
 msgid "Locality"
 msgstr "Helyszín"
 
 #: ../gramps/gen/lib/address.py:117 ../gramps/gen/lib/location.py:95
-#: ../gramps/gen/lib/placetype.py:68 ../gramps/gui/configure.py:539
+#: ../gramps/gen/lib/placetype.py:68 ../gramps/gui/configure.py:615
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:74
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:56
-#: ../gramps/plugins/view/geoplaces.py:588
+#: ../gramps/plugins/view/geoplaces.py:647
 #: ../gramps/plugins/view/repoview.py:91
-#: ../gramps/plugins/webreport/basepage.py:1111
-#: ../gramps/plugins/webreport/basepage.py:2548
-#: ../gramps/plugins/webreport/basepage.py:2613
+#: ../gramps/plugins/webreport/basepage.py:1130
+#: ../gramps/plugins/webreport/basepage.py:2589
+#: ../gramps/plugins/webreport/basepage.py:2655
 msgid "City"
 msgstr "Város"
 
 #: ../gramps/gen/lib/address.py:119 ../gramps/gen/lib/location.py:97
 #: ../gramps/gen/lib/placetype.py:67
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:57
-#: ../gramps/gui/views/treemodels/placemodel.py:305
-#: ../gramps/plugins/lib/maps/placeselection.py:137
-#: ../gramps/plugins/view/geoplaces.py:570
-#: ../gramps/plugins/webreport/basepage.py:1113
-#: ../gramps/plugins/webreport/basepage.py:2551
-#: ../gramps/plugins/webreport/basepage.py:2615
+#: ../gramps/gui/views/treemodels/placemodel.py:312
+#: ../gramps/plugins/lib/maps/placeselection.py:151
+#: ../gramps/plugins/view/geoplaces.py:629
+#: ../gramps/plugins/webreport/basepage.py:1132
+#: ../gramps/plugins/webreport/basepage.py:2592
+#: ../gramps/plugins/webreport/basepage.py:2657
 msgid "County"
 msgstr "Megye"
 
 #: ../gramps/gen/lib/address.py:121 ../gramps/gen/lib/location.py:99
 #: ../gramps/gen/lib/placetype.py:66
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:58
-#: ../gramps/gui/views/treemodels/placemodel.py:305
-#: ../gramps/plugins/lib/maps/placeselection.py:136
-#: ../gramps/plugins/view/geoplaces.py:567
+#: ../gramps/gui/views/treemodels/placemodel.py:312
+#: ../gramps/plugins/lib/maps/placeselection.py:150
+#: ../gramps/plugins/view/geoplaces.py:626
 msgid "State"
 msgstr "Állam"
 
 #: ../gramps/gen/lib/address.py:123 ../gramps/gen/lib/location.py:101
-#: ../gramps/gen/lib/placetype.py:65 ../gramps/gui/configure.py:541
+#: ../gramps/gen/lib/placetype.py:65 ../gramps/gui/configure.py:620
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:76
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:59
-#: ../gramps/gui/views/treemodels/placemodel.py:305
-#: ../gramps/plugins/lib/maps/placeselection.py:135
-#: ../gramps/plugins/view/geoplaces.py:564
+#: ../gramps/gui/views/treemodels/placemodel.py:312
+#: ../gramps/plugins/lib/maps/placeselection.py:149
+#: ../gramps/plugins/view/geoplaces.py:623
 #: ../gramps/plugins/view/repoview.py:93
-#: ../gramps/plugins/webreport/basepage.py:1115
-#: ../gramps/plugins/webreport/basepage.py:2555
-#: ../gramps/plugins/webreport/basepage.py:2618
-#: ../gramps/plugins/webreport/place.py:178
+#: ../gramps/plugins/webreport/basepage.py:1134
+#: ../gramps/plugins/webreport/basepage.py:2596
+#: ../gramps/plugins/webreport/basepage.py:2660
+#: ../gramps/plugins/webreport/place.py:183
+#: ../gramps/plugins/webreport/place.py:195
 msgid "Country"
 msgstr "Ország"
 
 #: ../gramps/gen/lib/address.py:125 ../gramps/gen/lib/location.py:103
-#: ../gramps/plugins/webreport/basepage.py:1114
-#: ../gramps/plugins/webreport/basepage.py:2554
-#: ../gramps/plugins/webreport/basepage.py:2617
+#: ../gramps/plugins/webreport/basepage.py:1133
+#: ../gramps/plugins/webreport/basepage.py:2595
+#: ../gramps/plugins/webreport/basepage.py:2659
 msgid "Postal Code"
 msgstr "Irányítószám"
 
 #: ../gramps/gen/lib/address.py:127 ../gramps/gen/lib/location.py:105
-#: ../gramps/gui/configure.py:543 ../gramps/plugins/export/exportgedcom.py:795
-#: ../gramps/plugins/export/exportgedcom.py:1168
+#: ../gramps/gui/configure.py:626 ../gramps/plugins/export/exportgedcom.py:788
+#: ../gramps/plugins/export/exportgedcom.py:1161
 #: ../gramps/plugins/gramplet/repositorydetails.py:124
-#: ../gramps/plugins/lib/libgedcom.py:4135
-#: ../gramps/plugins/lib/libgedcom.py:5871
-#: ../gramps/plugins/webreport/basepage.py:1116
+#: ../gramps/plugins/lib/libgedcom.py:4129
+#: ../gramps/plugins/lib/libgedcom.py:5860
+#: ../gramps/plugins/webreport/basepage.py:1135
 msgid "Phone"
 msgstr "Telefon"
 
@@ -6751,12 +6761,12 @@ msgstr "Jellemző"
 #: ../gramps/plugins/gramplet/attributes.py:57
 #: ../gramps/plugins/lib/libmetadata.py:173
 #: ../gramps/plugins/tool/patchnames.py:410
-#: ../gramps/plugins/webreport/basepage.py:1007
-#: ../gramps/plugins/webreport/basepage.py:1244
+#: ../gramps/plugins/webreport/basepage.py:1026
+#: ../gramps/plugins/webreport/basepage.py:1263
 msgid "Value"
 msgstr "Érték"
 
-#: ../gramps/gen/lib/attrtype.py:63 ../gramps/gen/lib/childreftype.py:74
+#: ../gramps/gen/lib/attrtype.py:64 ../gramps/gen/lib/childreftype.py:74
 #: ../gramps/gen/lib/eventroletype.py:53 ../gramps/gen/lib/eventtype.py:163
 #: ../gramps/gen/lib/familyreltype.py:51 ../gramps/gen/lib/markertype.py:52
 #: ../gramps/gen/lib/nameorigintype.py:74 ../gramps/gen/lib/nametype.py:47
@@ -6765,96 +6775,103 @@ msgstr "Érték"
 #: ../gramps/gen/lib/srcmediatype.py:57 ../gramps/gen/lib/urltype.py:48
 #: ../gramps/gui/autocomp.py:179
 #: ../gramps/plugins/textreport/indivcomplete.py:74
-#: ../gramps/plugins/view/geoplaces.py:534
+#: ../gramps/plugins/view/geoplaces.py:593
 msgid "Custom"
 msgstr "Egyéni"
 
-#: ../gramps/gen/lib/attrtype.py:64
+#: ../gramps/gen/lib/attrtype.py:65
 msgid "Caste"
 msgstr "Kaszt"
 
 #. 2 name (version)
-#: ../gramps/gen/lib/attrtype.py:65 ../gramps/gen/lib/event.py:148
+#: ../gramps/gen/lib/attrtype.py:66 ../gramps/gen/lib/event.py:148
 #: ../gramps/gen/lib/media.py:147 ../gramps/gen/lib/url.py:96
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:75
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:67
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:104
-#: ../gramps/gui/glade/rule.glade:931 ../gramps/gui/glade/styleeditor.glade:262
+#: ../gramps/gui/glade/rule.glade:931 ../gramps/gui/glade/styleeditor.glade:278
 #: ../gramps/gui/plug/_windows.py:134 ../gramps/gui/plug/_windows.py:243
-#: ../gramps/gui/plug/_windows.py:620 ../gramps/gui/plug/_windows.py:1105
-#: ../gramps/gui/selectors/selectevent.py:73
+#: ../gramps/gui/plug/_windows.py:622 ../gramps/gui/plug/_windows.py:1107
+#: ../gramps/gui/selectors/selectevent.py:70
 #: ../gramps/plugins/gramplet/coordinates.py:90
 #: ../gramps/plugins/gramplet/events.py:86
 #: ../gramps/plugins/lib/libmetadata.py:100
 #: ../gramps/plugins/textreport/placereport.py:226
 #: ../gramps/plugins/textreport/placereport.py:303
 #: ../gramps/plugins/tool/sortevents.py:57
-#: ../gramps/plugins/view/eventview.py:82
-#: ../gramps/plugins/webreport/basepage.py:622
-#: ../gramps/plugins/webreport/basepage.py:915
-#: ../gramps/plugins/webreport/basepage.py:2059
-#: ../gramps/plugins/webreport/basepage.py:2740
-#: ../gramps/plugins/webreport/download.py:127
+#: ../gramps/plugins/view/eventview.py:78
+#: ../gramps/plugins/webreport/basepage.py:643
+#: ../gramps/plugins/webreport/basepage.py:933
+#: ../gramps/plugins/webreport/basepage.py:2140
+#: ../gramps/plugins/webreport/basepage.py:2872
+#: ../gramps/plugins/webreport/download.py:128
 msgid "Description"
 msgstr "Leírás"
 
-#: ../gramps/gen/lib/attrtype.py:66
+#: ../gramps/gen/lib/attrtype.py:67
 msgid "Identification Number"
 msgstr "Azonosító szám"
 
-#: ../gramps/gen/lib/attrtype.py:67
+#: ../gramps/gen/lib/attrtype.py:68
 msgid "National Origin"
 msgstr "Nemzeti eredet"
 
-#: ../gramps/gen/lib/attrtype.py:68 ../gramps/plugins/lib/libpersonview.py:108
+#: ../gramps/gen/lib/attrtype.py:69 ../gramps/plugins/lib/libpersonview.py:108
 msgid "Number of Children"
 msgstr "Gyermekek száma"
 
-#: ../gramps/gen/lib/attrtype.py:69
+#: ../gramps/gen/lib/attrtype.py:70
 msgid "Social Security Number"
 msgstr "Társadalombiztosítási szám"
 
-#: ../gramps/gen/lib/attrtype.py:70 ../gramps/gen/utils/keyword.py:72
-#: ../gramps/gui/configure.py:691 ../gramps/gui/configure.py:693
-#: ../gramps/gui/configure.py:698 ../gramps/gui/configure.py:705
+#: ../gramps/gen/lib/attrtype.py:71 ../gramps/gen/utils/keyword.py:72
+#: ../gramps/gui/configure.py:847 ../gramps/gui/configure.py:849
+#: ../gramps/gui/configure.py:854 ../gramps/gui/configure.py:861
 #: ../gramps/plugins/tool/patchnames.py:435
 msgid "Nickname"
 msgstr "Becenév"
 
-#: ../gramps/gen/lib/attrtype.py:71
+#: ../gramps/gen/lib/attrtype.py:72
 msgid "Cause"
 msgstr "Ügy"
 
-#: ../gramps/gen/lib/attrtype.py:72
+#: ../gramps/gen/lib/attrtype.py:73
 msgid "Agency"
 msgstr "Ügynökség"
 
-#: ../gramps/gen/lib/attrtype.py:73
+#: ../gramps/gen/lib/attrtype.py:74
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:88
-#: ../gramps/plugins/drawreport/statisticschart.py:371
+#: ../gramps/plugins/drawreport/statisticschart.py:377
 #: ../gramps/plugins/gramplet/agestats.py:176
 #: ../gramps/plugins/gramplet/events.py:89
 #: ../gramps/plugins/quickview/ageondate.py:54
 msgid "Age"
 msgstr "Kor"
 
-#: ../gramps/gen/lib/attrtype.py:74
+#: ../gramps/gen/lib/attrtype.py:75
 msgid "Father's Age"
 msgstr "Édesapa kora"
 
-#: ../gramps/gen/lib/attrtype.py:75
+#: ../gramps/gen/lib/attrtype.py:76
 msgid "Mother's Age"
 msgstr "Édesanya kora"
 
-#: ../gramps/gen/lib/attrtype.py:76 ../gramps/gen/lib/eventroletype.py:60
+#: ../gramps/gen/lib/attrtype.py:77 ../gramps/gen/lib/eventroletype.py:60
 msgid "Witness"
 msgstr "Tanú"
 
-#: ../gramps/gen/lib/attrtype.py:77
+#: ../gramps/gen/lib/attrtype.py:78
 msgid "Time"
 msgstr "Idő"
 
-#: ../gramps/gen/lib/childref.py:105 ../gramps/gui/editors/editchildref.py:195
+#: ../gramps/gen/lib/attrtype.py:79 ../gramps/gen/lib/eventtype.py:190
+#: ../gramps/gen/lib/nameorigintype.py:85
+#: ../gramps/gen/plug/docgen/treedoc.py:454
+#: ../gramps/plugins/gramplet/persondetails.py:163
+msgid "Occupation"
+msgstr "Foglalkozása"
+
+#: ../gramps/gen/lib/childref.py:105 ../gramps/gui/editors/editchildref.py:190
 msgid "Child Reference"
 msgstr "Gyermek hivatkozás"
 
@@ -6870,34 +6887,38 @@ msgid "Handle"
 msgstr "Kezelés"
 
 #: ../gramps/gen/lib/childreftype.py:67 ../gramps/gen/plug/docgen/treedoc.py:72
-#: ../gramps/gui/configure.py:83
+#: ../gramps/gui/configure.py:87
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:201
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:175
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:209
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:155
 #: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:154
-#: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:250
+#: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:252
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:191
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:171
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:154
 #: ../gramps/gui/glade/editplaceformat.glade:185
-#: ../gramps/plugins/tool/check.py:2459
+#: ../gramps/plugins/graph/gvfamilylines.py:82
+#: ../gramps/plugins/tool/check.py:2494
 msgid "None"
 msgstr "Nincs"
 
 #: ../gramps/gen/lib/childreftype.py:68 ../gramps/gen/lib/eventtype.py:165
 #: ../gramps/gui/merge/mergeperson.py:189
+#: ../gramps/plugins/export/exportvcalendar.py:156
+#: ../gramps/plugins/export/exportvcalendar.py:161
 #: ../gramps/plugins/gramplet/ancestor.py:64
 #: ../gramps/plugins/gramplet/descendant.py:63
+#: ../gramps/plugins/importer/importprogen.glade:1472
 #: ../gramps/plugins/quickview/all_relations.py:270
 #: ../gramps/plugins/quickview/lineage.py:93
 #: ../gramps/plugins/textreport/familygroup.py:320
 #: ../gramps/plugins/textreport/familygroup.py:528
 #: ../gramps/plugins/textreport/familygroup.py:530
 #: ../gramps/plugins/textreport/tagreport.py:170
-#: ../gramps/plugins/view/relview.py:602
-#: ../gramps/plugins/webreport/person.py:213
-#: ../gramps/plugins/webreport/surname.py:130
+#: ../gramps/plugins/view/relview.py:733
+#: ../gramps/plugins/webreport/person.py:219
+#: ../gramps/plugins/webreport/surname.py:141
 msgid "Birth"
 msgstr "Születés"
 
@@ -6919,13 +6940,16 @@ msgstr "Nevelt"
 
 #. 8
 #: ../gramps/gen/lib/citation.py:97 ../gramps/gen/lib/notetype.py:79
-#: ../gramps/gui/clipboard.py:468 ../gramps/gui/configure.py:563
+#: ../gramps/gui/clipboard.py:468 ../gramps/gui/configure.py:655
 #: ../gramps/gui/editors/editcitation.py:119
 #: ../gramps/gui/editors/editcitation.py:125
 #: ../gramps/gui/editors/editlink.py:100
-#: ../gramps/gui/editors/filtereditor.py:301 ../gramps/gui/viewmanager.py:617
+#: ../gramps/gui/editors/filtereditor.py:302 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/views/treemodels/citationtreemodel.py:170
-#: ../gramps/plugins/gramplet/quickviewgramplet.py:115
+#: ../gramps/plugins/gramplet/quickviewgramplet.py:116
+#: ../gramps/plugins/importer/importprogen.glade:209
+#: ../gramps/plugins/importer/importprogen.glade:739
+#: ../gramps/plugins/lib/libprogen.py:935
 #: ../gramps/plugins/quickview/quickview.gpr.py:209
 #: ../gramps/plugins/quickview/references.py:89
 #: ../gramps/plugins/tool/reorderids.glade:823
@@ -6937,7 +6961,7 @@ msgstr "Idézet"
 #: ../gramps/gen/lib/note.py:116 ../gramps/gen/lib/person.py:180
 #: ../gramps/gen/lib/place.py:141 ../gramps/gen/lib/repo.py:93
 #: ../gramps/gen/lib/src.py:104 ../gramps/gen/plug/report/stdoptions.py:321
-#: ../gramps/plugins/importer/importcsv.py:206
+#: ../gramps/plugins/importer/importcsv.py:207
 #: ../gramps/plugins/quickview/filterbyname.py:154
 #: ../gramps/plugins/quickview/filterbyname.py:165
 #: ../gramps/plugins/quickview/filterbyname.py:175
@@ -6956,40 +6980,44 @@ msgstr "Idézet"
 #: ../gramps/plugins/quickview/filterbyname.py:276
 #: ../gramps/plugins/tool/findloop.py:112
 #: ../gramps/plugins/tool/findloop.py:116
-#: ../gramps/plugins/webreport/basepage.py:2521
-#: ../gramps/plugins/webreport/event.py:177
-#: ../gramps/plugins/webreport/event.py:389
-#: ../gramps/plugins/webreport/media.py:569
-#: ../gramps/plugins/webreport/person.py:1396
-#: ../gramps/plugins/webreport/repository.py:243
-#: ../gramps/plugins/webreport/source.py:259
+#: ../gramps/plugins/webreport/basepage.py:2562
+#: ../gramps/plugins/webreport/event.py:178
+#: ../gramps/plugins/webreport/event.py:391
+#: ../gramps/plugins/webreport/media.py:541
+#: ../gramps/plugins/webreport/person.py:1470
+#: ../gramps/plugins/webreport/repository.py:245
+#: ../gramps/plugins/webreport/source.py:261
 msgid "Gramps ID"
 msgstr "GRAMPS azonosító"
 
 #: ../gramps/gen/lib/citation.py:108
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:82
-#: ../gramps/plugins/webreport/basepage.py:2190
+#: ../gramps/plugins/importer/importprogen.glade:295
+#: ../gramps/plugins/webreport/basepage.py:2271
 msgid "Page"
 msgstr "Oldal"
 
 #: ../gramps/gen/lib/citation.py:112
+#: ../gramps/plugins/importer/importprogen.glade:261
 #: ../gramps/plugins/view/citationlistview.py:101
 #: ../gramps/plugins/view/citationtreeview.py:96
-#: ../gramps/plugins/webreport/basepage.py:2191
+#: ../gramps/plugins/webreport/basepage.py:2272
 msgid "Confidence"
 msgstr "Megbízhatóság"
 
 #. 7
 #: ../gramps/gen/lib/citation.py:115 ../gramps/gen/lib/src.py:97
-#: ../gramps/gui/clipboard.py:761 ../gramps/gui/configure.py:561
+#: ../gramps/gui/clipboard.py:761 ../gramps/gui/configure.py:652
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:78
 #: ../gramps/gui/editors/editlink.py:99 ../gramps/gui/editors/editsource.py:86
-#: ../gramps/gui/editors/filtereditor.py:297 ../gramps/gui/viewmanager.py:615
+#: ../gramps/gui/editors/filtereditor.py:298 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/views/treemodels/citationtreemodel.py:170
 #: ../gramps/plugins/export/exportcsv.py:466
-#: ../gramps/plugins/gramplet/quickviewgramplet.py:114
-#: ../gramps/plugins/importer/importcsv.py:169
-#: ../gramps/plugins/importer/importprogen.py:873
+#: ../gramps/plugins/gramplet/quickviewgramplet.py:115
+#: ../gramps/plugins/importer/importcsv.py:170
+#: ../gramps/plugins/importer/importprogen.glade:52
+#: ../gramps/plugins/importer/importprogen.glade:724
+#: ../gramps/plugins/lib/libprogen.py:882
 #: ../gramps/plugins/quickview/filterbyname.py:195
 #: ../gramps/plugins/quickview/filterbyname.py:258
 #: ../gramps/plugins/quickview/quickview.gpr.py:205
@@ -7008,8 +7036,8 @@ msgstr "Forrás"
 #: ../gramps/gen/lib/media.py:134 ../gramps/gen/lib/person.py:206
 #: ../gramps/gen/lib/place.py:166 ../gramps/gen/lib/src.py:117
 #: ../gramps/gui/clipboard.py:636 ../gramps/gui/editors/editlink.py:94
-#: ../gramps/gui/editors/filtereditor.py:298 ../gramps/gui/viewmanager.py:621
-#: ../gramps/plugins/gramplet/quickviewgramplet.py:110
+#: ../gramps/gui/editors/filtereditor.py:299 ../gramps/gui/grampsgui.py:56
+#: ../gramps/plugins/gramplet/quickviewgramplet.py:111
 #: ../gramps/plugins/quickview/filterbyname.py:109
 #: ../gramps/plugins/quickview/filterbyname.py:134
 #: ../gramps/plugins/quickview/filterbyname.py:215
@@ -7021,13 +7049,13 @@ msgstr "Forrás"
 #: ../gramps/plugins/tool/reorderids.glade:848
 #: ../gramps/plugins/view/mediaview.py:129
 #: ../gramps/plugins/view/view.gpr.py:82 ../gramps/plugins/view/view.gpr.py:90
-#: ../gramps/plugins/webreport/basepage.py:1492
-#: ../gramps/plugins/webreport/basepage.py:1558
-#: ../gramps/plugins/webreport/basepage.py:1627
-#: ../gramps/plugins/webreport/basepage.py:1674
-#: ../gramps/plugins/webreport/basepage.py:1963
+#: ../gramps/plugins/webreport/basepage.py:1533
+#: ../gramps/plugins/webreport/basepage.py:1592
+#: ../gramps/plugins/webreport/basepage.py:1660
+#: ../gramps/plugins/webreport/basepage.py:1707
+#: ../gramps/plugins/webreport/basepage.py:2044
 #: ../gramps/plugins/webreport/media.py:196
-#: ../gramps/plugins/webreport/media.py:390
+#: ../gramps/plugins/webreport/media.py:378
 msgid "Media"
 msgstr "Média"
 
@@ -7053,14 +7081,15 @@ msgstr "Utoljára változott"
 #: ../gramps/gui/glade/editmediaref.glade:726
 #: ../gramps/gui/glade/editnote.glade:284
 #: ../gramps/gui/glade/editperson.glade:683
-#: ../gramps/gui/selectors/selectnote.py:77
+#: ../gramps/gui/selectors/selectnote.py:74
+#: ../gramps/plugins/importer/importprogen.glade:527
 #: ../gramps/plugins/lib/libpersonview.py:111
-#: ../gramps/plugins/lib/libplaceview.py:92
+#: ../gramps/plugins/lib/libplaceview.py:93
 #: ../gramps/plugins/textreport/indivcomplete.py:549
 #: ../gramps/plugins/tool/notrelated.py:129
 #: ../gramps/plugins/view/citationlistview.py:103
 #: ../gramps/plugins/view/citationtreeview.py:98
-#: ../gramps/plugins/view/eventview.py:88
+#: ../gramps/plugins/view/eventview.py:84
 #: ../gramps/plugins/view/familyview.py:85
 #: ../gramps/plugins/view/mediaview.py:100
 #: ../gramps/plugins/view/noteview.py:83 ../gramps/plugins/view/repoview.py:98
@@ -7077,14 +7106,16 @@ msgstr "Címkék"
 #: ../gramps/gen/lib/date.py:274 ../gramps/gen/lib/date.py:422
 #: ../gramps/gen/mime/_pythonmime.py:48 ../gramps/gen/mime/_pythonmime.py:56
 #: ../gramps/gen/mime/_winmime.py:57 ../gramps/gen/utils/db.py:523
-#: ../gramps/gui/editors/editperson.py:348
+#: ../gramps/gui/editors/editperson.py:342
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:94
 #: ../gramps/gui/merge/mergeperson.py:64
 #: ../gramps/gui/views/treemodels/peoplemodel.py:97
+#: ../gramps/plugins/lib/libgedcom.py:5393
+#: ../gramps/plugins/lib/libgedcom.py:6704
 #: ../gramps/plugins/textreport/indivcomplete.py:663
 #: ../gramps/plugins/tool/dumpgenderstats.py:46
-#: ../gramps/plugins/view/relview.py:642
-#: ../gramps/plugins/webreport/person.py:414
+#: ../gramps/plugins/view/relview.py:775
+#: ../gramps/plugins/webreport/person.py:431
 msgid "unknown"
 msgstr "ismeretlen"
 
@@ -7101,7 +7132,7 @@ msgstr "több mint"
 
 #: ../gramps/gen/lib/date.py:288 ../gramps/gen/lib/date.py:303
 #: ../gramps/gen/lib/date.py:307 ../gramps/gen/lib/date.py:311
-#: ../gramps/gen/lib/date.py:348 ../gramps/gui/editors/filtereditor.py:251
+#: ../gramps/gen/lib/date.py:348 ../gramps/gui/editors/filtereditor.py:252
 msgid "less than"
 msgstr "kevesebb mint"
 
@@ -7112,15 +7143,16 @@ msgid "age|about"
 msgstr "nagyjából"
 
 #: ../gramps/gen/lib/date.py:295 ../gramps/gen/lib/date.py:339
-#: ../gramps/gen/lib/date.py:358
+#: ../gramps/gen/lib/date.py:358 ../gramps/plugins/webreport/basepage.py:2924
 msgid "between"
 msgstr "között"
 
 #: ../gramps/gen/lib/date.py:298 ../gramps/gen/lib/date.py:342
 #: ../gramps/gen/lib/date.py:360 ../gramps/gui/merge/mergefamily.py:155
 #: ../gramps/plugins/quickview/all_relations.py:282
-#: ../gramps/plugins/view/relview.py:978
-#: ../gramps/plugins/webreport/basepage.py:830
+#: ../gramps/plugins/view/relview.py:1143
+#: ../gramps/plugins/webreport/basepage.py:846
+#: ../gramps/plugins/webreport/basepage.py:2925
 msgid "and"
 msgstr "és"
 
@@ -7177,7 +7209,7 @@ msgstr "Módosító"
 msgid "Quality"
 msgstr "Minőség"
 
-#: ../gramps/gen/lib/date.py:716 ../gramps/gui/editors/filtereditor.py:820
+#: ../gramps/gen/lib/date.py:716 ../gramps/gui/editors/filtereditor.py:834
 #: ../gramps/gui/glade/rule.glade:967
 msgid "Values"
 msgstr "Értékek"
@@ -7185,8 +7217,10 @@ msgstr "Értékek"
 #: ../gramps/gen/lib/date.py:719 ../gramps/gen/lib/placename.py:99
 #: ../gramps/gen/lib/styledtext.py:321
 #: ../gramps/gen/plug/report/_constants.py:54 ../gramps/gui/clipboard.py:613
-#: ../gramps/gui/clipboard.py:621 ../gramps/gui/configure.py:1224
+#: ../gramps/gui/clipboard.py:621 ../gramps/gui/configure.py:1395
 #: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:101
+#: ../gramps/plugins/importer/importprogen.glade:403
+#: ../gramps/plugins/importer/importprogen.glade:1107
 #: ../gramps/plugins/textreport/custombooktext.py:132
 #: ../gramps/plugins/textreport/tagreport.py:511
 msgid "Text"
@@ -7220,8 +7254,7 @@ msgstr "dátum-módosító|nincs"
 msgid "about"
 msgstr "nagyjából"
 
-#: ../gramps/gen/lib/date.py:1872
-#: ../gramps/plugins/importer/importprogen.py:1722
+#: ../gramps/gen/lib/date.py:1872 ../gramps/plugins/lib/libprogen.py:1839
 #: ../gramps/plugins/lib/libsubstkeyword.py:313
 msgid "after"
 msgstr "később mint"
@@ -7244,43 +7277,45 @@ msgstr "csak szöveg"
 
 #. 0 this order range above
 #: ../gramps/gen/lib/event.py:136 ../gramps/gen/lib/eventref.py:109
-#: ../gramps/gui/clipboard.py:335 ../gramps/gui/configure.py:567
+#: ../gramps/gui/clipboard.py:335 ../gramps/gui/configure.py:661
 #: ../gramps/gui/editors/editlink.py:92
-#: ../gramps/gui/editors/filtereditor.py:295
+#: ../gramps/gui/editors/filtereditor.py:296
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:138
-#: ../gramps/gui/viewmanager.py:611
-#: ../gramps/plugins/gramplet/quickviewgramplet.py:108
+#: ../gramps/gui/grampsgui.py:56
+#: ../gramps/plugins/gramplet/quickviewgramplet.py:109
+#: ../gramps/plugins/importer/importprogen.glade:696
 #: ../gramps/plugins/quickview/filterbyname.py:175
 #: ../gramps/plugins/quickview/filterbyname.py:246
 #: ../gramps/plugins/quickview/quickview.gpr.py:204
 #: ../gramps/plugins/quickview/references.py:87
-#: ../gramps/plugins/textreport/placereport.py:457
+#: ../gramps/plugins/textreport/placereport.py:458
 #: ../gramps/plugins/tool/reorderids.glade:787
-#: ../gramps/plugins/webreport/basepage.py:619
+#: ../gramps/plugins/webreport/basepage.py:640
 msgid "Event"
 msgstr "Esemény"
 
 #. 5
 #: ../gramps/gen/lib/event.py:151 ../gramps/gen/lib/ldsord.py:186
 #: ../gramps/gen/lib/place.py:134 ../gramps/gui/clipboard.py:355
-#: ../gramps/gui/configure.py:559
+#: ../gramps/gui/configure.py:649
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:81
 #: ../gramps/gui/editors/displaytabs/familyldsembedlist.py:55
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:65
 #: ../gramps/gui/editors/editlink.py:97
-#: ../gramps/gui/editors/filtereditor.py:296
+#: ../gramps/gui/editors/filtereditor.py:297
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:108
-#: ../gramps/gui/glade/editevent.glade:270
-#: ../gramps/gui/plug/_guioptions.py:1352
-#: ../gramps/gui/selectors/selectevent.py:72 ../gramps/gui/viewmanager.py:613
-#: ../gramps/gui/views/treemodels/placemodel.py:305
+#: ../gramps/gui/glade/editevent.glade:270 ../gramps/gui/grampsgui.py:56
+#: ../gramps/gui/plug/_guioptions.py:1354
+#: ../gramps/gui/selectors/selectevent.py:69
+#: ../gramps/gui/views/treemodels/placemodel.py:312
 #: ../gramps/plugins/export/exportcsv.py:286
 #: ../gramps/plugins/export/exportcsv.py:466
 #: ../gramps/plugins/gramplet/coordinates.py:93
 #: ../gramps/plugins/gramplet/events.py:91
 #: ../gramps/plugins/gramplet/personresidence.py:61
-#: ../gramps/plugins/gramplet/quickviewgramplet.py:112
-#: ../gramps/plugins/importer/importcsv.py:221
+#: ../gramps/plugins/gramplet/quickviewgramplet.py:113
+#: ../gramps/plugins/importer/importcsv.py:237
+#: ../gramps/plugins/importer/importprogen.glade:710
 #: ../gramps/plugins/quickview/filterbyname.py:185
 #: ../gramps/plugins/quickview/filterbyname.py:252
 #: ../gramps/plugins/quickview/onthisday.py:80
@@ -7292,11 +7327,10 @@ msgstr "Esemény"
 #: ../gramps/plugins/textreport/indivcomplete.py:709
 #: ../gramps/plugins/tool/reorderids.glade:799
 #: ../gramps/plugins/tool/sortevents.py:58
-#: ../gramps/plugins/view/eventview.py:86
-#: ../gramps/plugins/webreport/basepage.py:621
-#: ../gramps/plugins/webreport/basepage.py:914
-#: ../gramps/plugins/webreport/basepage.py:944
-#: ../gramps/gui/plug/_guioptions.py:1354
+#: ../gramps/plugins/view/eventview.py:82
+#: ../gramps/plugins/webreport/basepage.py:642
+#: ../gramps/plugins/webreport/basepage.py:932
+#: ../gramps/plugins/webreport/basepage.py:963
 msgid "Place"
 msgstr "Hely"
 
@@ -7315,9 +7349,9 @@ msgstr "Esemény hivatkozás"
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:659
 #: ../gramps/plugins/textreport/indivcomplete.py:472
 #: ../gramps/plugins/textreport/indivcomplete.py:692
-#: ../gramps/plugins/webreport/basepage.py:428
-#: ../gramps/plugins/webreport/basepage.py:996
-#: ../gramps/plugins/webreport/basepage.py:1228
+#: ../gramps/plugins/webreport/basepage.py:447
+#: ../gramps/plugins/webreport/basepage.py:1015
+#: ../gramps/plugins/webreport/basepage.py:1247
 msgid "Attributes"
 msgstr "Tulajdonságok"
 
@@ -7362,15 +7396,18 @@ msgstr "Élet események"
 #. get the family events
 #: ../gramps/gen/lib/eventtype.py:139 ../gramps/gen/lib/family.py:145
 #: ../gramps/gen/lib/ldsord.py:188 ../gramps/gui/clipboard.py:739
-#: ../gramps/gui/configure.py:557
+#: ../gramps/gui/configure.py:646
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:59
 #: ../gramps/gui/editors/displaytabs/personeventembedlist.py:52
-#: ../gramps/gui/editors/editfamily.py:499 ../gramps/gui/editors/editlink.py:93
-#: ../gramps/gui/editors/filtereditor.py:294
-#: ../gramps/gui/glade/editldsord.glade:267 ../gramps/gui/viewmanager.py:609
+#: ../gramps/gui/editors/editfamily.py:561 ../gramps/gui/editors/editlink.py:93
+#: ../gramps/gui/editors/filtereditor.py:295
+#: ../gramps/gui/glade/editldsord.glade:267 ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/export/exportcsv.py:506
-#: ../gramps/plugins/gramplet/quickviewgramplet.py:109
-#: ../gramps/plugins/importer/importcsv.py:211
+#: ../gramps/plugins/gramplet/quickviewgramplet.py:110
+#: ../gramps/plugins/importer/importcsv.py:227
+#: ../gramps/plugins/importer/importprogen.glade:682
+#: ../gramps/plugins/importer/importprogen.glade:1256
+#: ../gramps/plugins/importer/importprogen.glade:1345
 #: ../gramps/plugins/quickview/all_events.py:83
 #: ../gramps/plugins/quickview/all_relations.py:270
 #: ../gramps/plugins/quickview/filterbyname.py:165
@@ -7379,9 +7416,9 @@ msgstr "Élet események"
 #: ../gramps/plugins/quickview/references.py:86
 #: ../gramps/plugins/textreport/recordsreport.py:271
 #: ../gramps/plugins/tool/reorderids.glade:774
-#: ../gramps/plugins/view/relview.py:1360
-#: ../gramps/plugins/view/relview.py:1382
-#: ../gramps/plugins/webreport/family.py:188
+#: ../gramps/plugins/view/relview.py:1529
+#: ../gramps/plugins/view/relview.py:1552
+#: ../gramps/plugins/webreport/family.py:189
 msgid "Family"
 msgstr "Család"
 
@@ -7407,26 +7444,31 @@ msgstr "Törvényes"
 
 #: ../gramps/gen/lib/eventtype.py:153 ../gramps/gen/lib/eventtype.py:195
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:463
-#: ../gramps/plugins/webreport/addressbooklist.py:113
-#: ../gramps/plugins/webreport/basepage.py:2718
+#: ../gramps/plugins/lib/libprogen.py:1827
+#: ../gramps/plugins/lib/libprogen.py:1830
+#: ../gramps/plugins/webreport/addressbooklist.py:114
+#: ../gramps/plugins/webreport/basepage.py:2849
 msgid "Residence"
 msgstr "Lakóhely"
 
 #: ../gramps/gen/lib/eventtype.py:155 ../gramps/gui/glade/mergedata.glade:523
 #: ../gramps/gui/glade/mergedata.glade:610
-#: ../gramps/plugins/lib/maps/placeselection.py:138
-#: ../gramps/plugins/lib/maps/placeselection.py:189
+#: ../gramps/plugins/lib/maps/placeselection.py:152
+#: ../gramps/plugins/lib/maps/placeselection.py:203
 msgid "Other"
 msgstr "Egyéb"
 
 #: ../gramps/gen/lib/eventtype.py:166 ../gramps/gui/merge/mergeperson.py:194
+#: ../gramps/plugins/export/exportvcalendar.py:174
+#: ../gramps/plugins/export/exportvcalendar.py:179
+#: ../gramps/plugins/importer/importprogen.glade:1491
 #: ../gramps/plugins/textreport/familygroup.py:328
 #: ../gramps/plugins/textreport/familygroup.py:534
 #: ../gramps/plugins/textreport/familygroup.py:536
 #: ../gramps/plugins/textreport/tagreport.py:176
-#: ../gramps/plugins/view/relview.py:613 ../gramps/plugins/view/relview.py:640
-#: ../gramps/plugins/webreport/person.py:217
-#: ../gramps/plugins/webreport/surname.py:134
+#: ../gramps/plugins/view/relview.py:744 ../gramps/plugins/view/relview.py:773
+#: ../gramps/plugins/webreport/person.py:223
+#: ../gramps/plugins/webreport/surname.py:145
 msgid "Death"
 msgstr "Halál"
 
@@ -7523,11 +7565,6 @@ msgstr "Nemesi cím"
 msgid "Number of Marriages"
 msgstr "Házasságok száma"
 
-#: ../gramps/gen/lib/eventtype.py:190 ../gramps/gen/lib/nameorigintype.py:85
-#: ../gramps/plugins/gramplet/persondetails.py:163
-msgid "Occupation"
-msgstr "Foglalkozása"
-
 #: ../gramps/gen/lib/eventtype.py:191
 msgid "Ordination"
 msgstr "Felszentelés"
@@ -7553,14 +7590,16 @@ msgstr "Nyugdíjazás"
 msgid "Will"
 msgstr "Végrendelet"
 
+#. feature requests 2356, 1657: avoid genitive form
 #: ../gramps/gen/lib/eventtype.py:198 ../gramps/gen/plug/docgen/treedoc.py:150
 #: ../gramps/gui/merge/mergeperson.py:258
 #: ../gramps/plugins/export/exportcsv.py:465
-#: ../gramps/plugins/importer/importcsv.py:219
+#: ../gramps/plugins/export/exportvcalendar.py:136
+#: ../gramps/plugins/importer/importcsv.py:235
 #: ../gramps/plugins/textreport/familygroup.py:406
 #: ../gramps/plugins/textreport/familygroup.py:415
 #: ../gramps/plugins/textreport/familygroup.py:606
-#: ../gramps/plugins/webreport/family.py:189
+#: ../gramps/plugins/webreport/family.py:190
 msgid "Marriage"
 msgstr "Házasság"
 
@@ -7584,7 +7623,7 @@ msgstr "Házasság kihírdetése"
 msgid "Engagement"
 msgstr "Eljegyzés"
 
-#: ../gramps/gen/lib/eventtype.py:204 ../gramps/plugins/webreport/family.py:190
+#: ../gramps/gen/lib/eventtype.py:204 ../gramps/plugins/webreport/family.py:191
 msgid "Divorce"
 msgstr "Válás"
 
@@ -7804,20 +7843,20 @@ msgstr "megsem."
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:122
 #: ../gramps/gui/glade/editfamily.glade:192
 #: ../gramps/gui/merge/mergeperson.py:231
-#: ../gramps/gui/selectors/selectfamily.py:70
-#: ../gramps/gui/widgets/reorderfam.py:84
+#: ../gramps/gui/selectors/selectfamily.py:67
+#: ../gramps/gui/widgets/reorderfam.py:96
 #: ../gramps/plugins/gramplet/persondetails.py:224
-#: ../gramps/plugins/importer/importcsv.py:216
+#: ../gramps/plugins/importer/importcsv.py:232
 #: ../gramps/plugins/quickview/all_relations.py:300
 #: ../gramps/plugins/textreport/familygroup.py:232
 #: ../gramps/plugins/textreport/familygroup.py:243
 #: ../gramps/plugins/textreport/indivcomplete.py:329
 #: ../gramps/plugins/textreport/indivcomplete.py:331
-#: ../gramps/plugins/textreport/indivcomplete.py:928
+#: ../gramps/plugins/textreport/indivcomplete.py:929
 #: ../gramps/plugins/textreport/tagreport.py:252
 #: ../gramps/plugins/view/familyview.py:80
-#: ../gramps/plugins/view/relview.py:893
-#: ../gramps/plugins/webreport/person.py:1558
+#: ../gramps/plugins/view/relview.py:1053
+#: ../gramps/plugins/webreport/person.py:1631
 msgid "Father"
 msgstr "Apa"
 
@@ -7826,32 +7865,32 @@ msgstr "Apa"
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:123
 #: ../gramps/gui/glade/editfamily.glade:470
 #: ../gramps/gui/merge/mergeperson.py:234
-#: ../gramps/gui/selectors/selectfamily.py:71
-#: ../gramps/gui/widgets/reorderfam.py:85
+#: ../gramps/gui/selectors/selectfamily.py:68
+#: ../gramps/gui/widgets/reorderfam.py:97
 #: ../gramps/plugins/gramplet/persondetails.py:225
-#: ../gramps/plugins/importer/importcsv.py:213
+#: ../gramps/plugins/importer/importcsv.py:229
 #: ../gramps/plugins/quickview/all_relations.py:297
 #: ../gramps/plugins/textreport/familygroup.py:249
 #: ../gramps/plugins/textreport/familygroup.py:260
 #: ../gramps/plugins/textreport/indivcomplete.py:338
 #: ../gramps/plugins/textreport/indivcomplete.py:340
-#: ../gramps/plugins/textreport/indivcomplete.py:929
+#: ../gramps/plugins/textreport/indivcomplete.py:930
 #: ../gramps/plugins/textreport/tagreport.py:258
 #: ../gramps/plugins/view/familyview.py:81
-#: ../gramps/plugins/view/relview.py:894
-#: ../gramps/plugins/webreport/person.py:1571
+#: ../gramps/plugins/view/relview.py:1054
+#: ../gramps/plugins/webreport/person.py:1644
 msgid "Mother"
 msgstr "Anya"
 
 #. Go over children and build their menu
-#: ../gramps/gen/lib/family.py:161 ../gramps/gui/widgets/fanchart.py:1681
+#: ../gramps/gen/lib/family.py:161 ../gramps/gui/widgets/fanchart.py:1957
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:855
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:869
 #: ../gramps/plugins/textreport/familygroup.py:646
 #: ../gramps/plugins/textreport/indivcomplete.py:678
-#: ../gramps/plugins/view/pedigreeview.py:1754
-#: ../gramps/plugins/view/relview.py:1400
-#: ../gramps/plugins/webreport/basepage.py:362
+#: ../gramps/plugins/view/pedigreeview.py:1829
+#: ../gramps/plugins/view/relview.py:1570
+#: ../gramps/plugins/webreport/basepage.py:381
 msgid "Children"
 msgstr "Gyermekek"
 
@@ -7861,14 +7900,14 @@ msgstr "Gyermekek"
 #: ../gramps/plugins/quickview/filterbyname.py:97
 #: ../gramps/plugins/quickview/filterbyname.py:122
 #: ../gramps/plugins/textreport/tagreport.py:324
-#: ../gramps/plugins/view/eventview.py:126
+#: ../gramps/plugins/view/eventview.py:122
 #: ../gramps/plugins/view/view.gpr.py:37 ../gramps/plugins/view/view.gpr.py:45
-#: ../gramps/plugins/webreport/basepage.py:1488
-#: ../gramps/plugins/webreport/basepage.py:1555
-#: ../gramps/plugins/webreport/basepage.py:1617
+#: ../gramps/plugins/webreport/basepage.py:1529
+#: ../gramps/plugins/webreport/basepage.py:1589
+#: ../gramps/plugins/webreport/basepage.py:1650
 #: ../gramps/plugins/webreport/event.py:141
-#: ../gramps/plugins/webreport/event.py:365
-#: ../gramps/plugins/webreport/person.py:1455
+#: ../gramps/plugins/webreport/event.py:366
+#: ../gramps/plugins/webreport/person.py:1529
 msgid "Events"
 msgstr "Események"
 
@@ -7877,7 +7916,7 @@ msgid "LDS ordinances"
 msgstr "Mormon rend(szer)"
 
 #: ../gramps/gen/lib/familyreltype.py:47
-#: ../gramps/plugins/webreport/webcal.py:2044
+#: ../gramps/plugins/webreport/webcal.py:2114
 msgid "Married"
 msgstr "Házas"
 
@@ -7900,7 +7939,7 @@ msgstr "Élettársi kapcsolat"
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:61
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:74
 #: ../gramps/gui/editors/displaytabs/notetab.py:77
-#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:60
+#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:62
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:69
 #: ../gramps/gui/editors/displaytabs/srcattrembedlist.py:63
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:65
@@ -7910,21 +7949,21 @@ msgstr "Élettársi kapcsolat"
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:109
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:105
 #: ../gramps/gui/merge/mergeperson.py:253 ../gramps/gui/plug/_windows.py:123
-#: ../gramps/gui/plug/_windows.py:239 ../gramps/gui/plug/_windows.py:1103
-#: ../gramps/gui/plug/report/_bookdialog.py:374
-#: ../gramps/gui/plug/report/_bookdialog.py:378
-#: ../gramps/gui/selectors/selectevent.py:69
-#: ../gramps/gui/selectors/selectnote.py:76
-#: ../gramps/gui/selectors/selectobject.py:82
-#: ../gramps/gui/selectors/selectplace.py:72
+#: ../gramps/gui/plug/_windows.py:239 ../gramps/gui/plug/_windows.py:1105
+#: ../gramps/gui/plug/report/_bookdialog.py:384
+#: ../gramps/gui/plug/report/_bookdialog.py:388
+#: ../gramps/gui/selectors/selectevent.py:66
+#: ../gramps/gui/selectors/selectnote.py:73
+#: ../gramps/gui/selectors/selectobject.py:79
+#: ../gramps/gui/selectors/selectplace.py:69
 #: ../gramps/plugins/export/exportcsv.py:287
 #: ../gramps/plugins/gramplet/backlinks.py:55
 #: ../gramps/plugins/gramplet/coordinates.py:89
 #: ../gramps/plugins/gramplet/events.py:85
 #: ../gramps/plugins/gramplet/locations.py:86
 #: ../gramps/plugins/gramplet/placedetails.py:126
-#: ../gramps/plugins/importer/importcsv.py:224
-#: ../gramps/plugins/lib/libplaceview.py:87
+#: ../gramps/plugins/importer/importcsv.py:240
+#: ../gramps/plugins/lib/libplaceview.py:88
 #: ../gramps/plugins/quickview/filterbyname.py:326
 #: ../gramps/plugins/quickview/linkreferences.py:45
 #: ../gramps/plugins/quickview/onthisday.py:80
@@ -7941,16 +7980,16 @@ msgstr "Élettársi kapcsolat"
 #: ../gramps/plugins/textreport/tagreport.py:665
 #: ../gramps/plugins/tool/patchnames.py:407
 #: ../gramps/plugins/tool/sortevents.py:55
-#: ../gramps/plugins/view/eventview.py:84
+#: ../gramps/plugins/view/eventview.py:80
 #: ../gramps/plugins/view/mediaview.py:96 ../gramps/plugins/view/noteview.py:81
 #: ../gramps/plugins/view/repoview.py:87
-#: ../gramps/plugins/webreport/basepage.py:941
-#: ../gramps/plugins/webreport/basepage.py:1243
-#: ../gramps/plugins/webreport/basepage.py:2058
-#: ../gramps/plugins/webreport/basepage.py:2675
-#: ../gramps/plugins/webreport/event.py:175
-#: ../gramps/plugins/webreport/repository.py:162
-#: ../gramps/plugins/webreport/repository.py:251
+#: ../gramps/plugins/webreport/basepage.py:960
+#: ../gramps/plugins/webreport/basepage.py:1262
+#: ../gramps/plugins/webreport/basepage.py:2139
+#: ../gramps/plugins/webreport/basepage.py:2806
+#: ../gramps/plugins/webreport/event.py:176
+#: ../gramps/plugins/webreport/repository.py:163
+#: ../gramps/plugins/webreport/repository.py:253
 msgid "Type"
 msgstr "Típus"
 
@@ -7985,7 +8024,8 @@ msgstr "Megszakított"
 #: ../gramps/plugins/export/exportcsv.py:506
 #: ../gramps/plugins/gramplet/children.py:93
 #: ../gramps/plugins/gramplet/children.py:192
-#: ../gramps/plugins/importer/importcsv.py:210
+#: ../gramps/plugins/importer/importcsv.py:226
+#: ../gramps/plugins/importer/importprogen.glade:1275
 #: ../gramps/plugins/tool/findloop.py:118
 msgid "Child"
 msgstr "Gyermek"
@@ -8034,7 +8074,7 @@ msgstr "Tisztázatlan"
 #: ../gramps/gui/editors/editldsord.py:442
 #: ../gramps/plugins/textreport/indivcomplete.py:499
 #: ../gramps/plugins/textreport/indivcomplete.py:704
-#: ../gramps/plugins/webreport/basepage.py:416
+#: ../gramps/plugins/webreport/basepage.py:435
 msgid "LDS Ordinance"
 msgstr "Mormon rend"
 
@@ -8043,13 +8083,13 @@ msgstr "Mormon rend"
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:64
 #: ../gramps/plugins/textreport/indivcomplete.py:509
 #: ../gramps/plugins/textreport/indivcomplete.py:708
-#: ../gramps/plugins/webreport/basepage.py:943
+#: ../gramps/plugins/webreport/basepage.py:962
 msgid "Temple"
 msgstr "Templom"
 
 #. icon_column = Gtk.TreeViewColumn(_('Status'), render,
 #. icon_name=ICON_COL)
-#: ../gramps/gen/lib/ldsord.py:192 ../gramps/gui/dbman.py:395
+#: ../gramps/gen/lib/ldsord.py:192 ../gramps/gui/dbman.py:394
 #: ../gramps/gui/editors/displaytabs/familyldsembedlist.py:53
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:63
 #: ../gramps/gui/plug/_windows.py:127 ../gramps/gui/plug/_windows.py:184
@@ -8057,17 +8097,17 @@ msgstr "Templom"
 #: ../gramps/plugins/textreport/indivcomplete.py:508
 #: ../gramps/plugins/textreport/indivcomplete.py:707
 #: ../gramps/plugins/textreport/notelinkreport.py:95
-#: ../gramps/plugins/webreport/basepage.py:945
+#: ../gramps/plugins/webreport/basepage.py:964
 msgid "Status"
 msgstr "Állapot"
 
 #: ../gramps/gen/lib/location.py:87 ../gramps/gen/lib/nameorigintype.py:86
-#: ../gramps/gui/clipboard.py:318 ../gramps/gui/plug/_windows.py:625
+#: ../gramps/gui/clipboard.py:318 ../gramps/gui/plug/_windows.py:627
 msgid "Location"
 msgstr "Helyszín"
 
 #: ../gramps/gen/lib/location.py:107 ../gramps/gen/lib/placetype.py:69
-#: ../gramps/plugins/view/geoplaces.py:585
+#: ../gramps/plugins/view/geoplaces.py:644
 msgid "Parish"
 msgstr "Egyházközség"
 
@@ -8093,7 +8133,7 @@ msgid "Media ref"
 msgstr "Média hivatkozás"
 
 #: ../gramps/gen/lib/mediaref.py:110 ../gramps/gen/lib/placetype.py:73
-#: ../gramps/plugins/view/geoplaces.py:576
+#: ../gramps/plugins/view/geoplaces.py:635
 msgid "Region"
 msgstr "Régió"
 
@@ -8103,25 +8143,25 @@ msgstr "Régió"
 #. Add column with object name
 #: ../gramps/gen/lib/name.py:143 ../gramps/gen/lib/repo.py:96
 #: ../gramps/gen/lib/tag.py:122 ../gramps/gui/clipboard.py:562
-#: ../gramps/gui/configure.py:536
+#: ../gramps/gui/configure.py:608
 #: ../gramps/gui/editors/displaytabs/backreflist.py:61
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:73
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:64
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:66
 #: ../gramps/gui/editors/displaytabs/placenameembedlist.py:63
-#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:59
-#: ../gramps/gui/editors/editfamily.py:123
+#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:61
+#: ../gramps/gui/editors/editfamily.py:125
 #: ../gramps/gui/editors/editname.py:310
-#: ../gramps/gui/editors/filtereditor.py:820
-#: ../gramps/gui/editors/filtereditor.py:975
+#: ../gramps/gui/editors/filtereditor.py:834
+#: ../gramps/gui/editors/filtereditor.py:989
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:131
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:108
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:104
-#: ../gramps/gui/plug/_guioptions.py:1174 ../gramps/gui/plug/_windows.py:130
-#: ../gramps/gui/plug/_windows.py:1104
-#: ../gramps/gui/plug/report/_bookdialog.py:373
-#: ../gramps/gui/selectors/selectperson.py:93
-#: ../gramps/gui/selectors/selectplace.py:70
-#: ../gramps/gui/views/bookmarks.py:269 ../gramps/gui/views/tags.py:410
+#: ../gramps/gui/plug/_guioptions.py:1176 ../gramps/gui/plug/_windows.py:130
+#: ../gramps/gui/plug/_windows.py:1106
+#: ../gramps/gui/plug/report/_bookdialog.py:383
+#: ../gramps/gui/selectors/selectperson.py:90
+#: ../gramps/gui/selectors/selectplace.py:67
+#: ../gramps/gui/views/bookmarks.py:281 ../gramps/gui/views/tags.py:444
 #: ../gramps/gui/views/treemodels/peoplemodel.py:611
 #: ../gramps/plugins/export/exportcsv.py:286
 #: ../gramps/plugins/gramplet/ancestor.py:63
@@ -8129,11 +8169,11 @@ msgstr "Régió"
 #: ../gramps/plugins/gramplet/descendant.py:62
 #: ../gramps/plugins/gramplet/locations.py:85
 #: ../gramps/plugins/gramplet/placedetails.py:125
-#: ../gramps/plugins/importer/importcsv.py:223
+#: ../gramps/plugins/importer/importcsv.py:239
 #: ../gramps/plugins/lib/libpersonview.py:98
-#: ../gramps/plugins/lib/libplaceview.py:84
+#: ../gramps/plugins/lib/libplaceview.py:85
 #: ../gramps/plugins/quickview/filterbyname.py:306
-#: ../gramps/plugins/textreport/indivcomplete.py:926
+#: ../gramps/plugins/textreport/indivcomplete.py:927
 #: ../gramps/plugins/textreport/tagreport.py:164
 #: ../gramps/plugins/textreport/tagreport.py:430
 #: ../gramps/plugins/textreport/tagreport.py:659
@@ -8144,35 +8184,34 @@ msgstr "Régió"
 #: ../gramps/plugins/tool/dumpgenderstats.py:99
 #: ../gramps/plugins/tool/notrelated.py:126
 #: ../gramps/plugins/tool/removeunused.py:201
-#: ../gramps/plugins/tool/verify.py:576 ../gramps/plugins/view/repoview.py:85
-#: ../gramps/plugins/webreport/basepage.py:378
-#: ../gramps/plugins/webreport/person.py:1775
-#: ../gramps/gui/plug/_guioptions.py:1176
+#: ../gramps/plugins/tool/verify.py:579 ../gramps/plugins/view/repoview.py:85
+#: ../gramps/plugins/webreport/basepage.py:397
+#: ../gramps/plugins/webreport/person.py:1855
 msgid "Name"
 msgstr "Név"
 
-#: ../gramps/gen/lib/name.py:159 ../gramps/plugins/importer/importcsv.py:162
+#: ../gramps/gen/lib/name.py:159 ../gramps/plugins/importer/importcsv.py:163
 msgid "Given name"
 msgstr "Utónév"
 
-#: ../gramps/gen/lib/name.py:162 ../gramps/plugins/webreport/basepage.py:1486
-#: ../gramps/plugins/webreport/basepage.py:1538
-#: ../gramps/plugins/webreport/basepage.py:1541
-#: ../gramps/plugins/webreport/basepage.py:1609
-#: ../gramps/plugins/webreport/person.py:275
-#: ../gramps/plugins/webreport/surnamelist.py:97
-#: ../gramps/plugins/webreport/surnamelist.py:147
+#: ../gramps/gen/lib/name.py:162 ../gramps/plugins/webreport/basepage.py:1527
+#: ../gramps/plugins/webreport/basepage.py:1572
+#: ../gramps/plugins/webreport/basepage.py:1575
+#: ../gramps/plugins/webreport/basepage.py:1642
+#: ../gramps/plugins/webreport/person.py:292
+#: ../gramps/plugins/webreport/surnamelist.py:98
+#: ../gramps/plugins/webreport/surnamelist.py:148
 msgid "Surnames"
 msgstr "Vezetéknevek"
 
 #: ../gramps/gen/lib/name.py:164 ../gramps/gen/utils/keyword.py:60
-#: ../gramps/gui/configure.py:688 ../gramps/gui/configure.py:690
-#: ../gramps/gui/configure.py:692 ../gramps/gui/configure.py:694
-#: ../gramps/gui/configure.py:695 ../gramps/gui/configure.py:700
-#: ../gramps/gui/configure.py:702 ../gramps/gui/configure.py:707
-#: ../gramps/gui/configure.py:709 ../gramps/gui/glade/editperson.glade:229
+#: ../gramps/gui/configure.py:844 ../gramps/gui/configure.py:846
+#: ../gramps/gui/configure.py:848 ../gramps/gui/configure.py:850
+#: ../gramps/gui/configure.py:851 ../gramps/gui/configure.py:856
+#: ../gramps/gui/configure.py:858 ../gramps/gui/configure.py:863
+#: ../gramps/gui/configure.py:865 ../gramps/gui/glade/editperson.glade:229
 #: ../gramps/plugins/export/exportcsv.py:355
-#: ../gramps/plugins/importer/importcsv.py:167
+#: ../gramps/plugins/importer/importcsv.py:168
 msgid "Suffix"
 msgstr "Utótag"
 
@@ -8183,21 +8222,21 @@ msgstr "Utótag"
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:105
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:88
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:87
-#: ../gramps/gui/selectors/selectobject.py:80
-#: ../gramps/gui/selectors/selectplace.py:73
-#: ../gramps/gui/selectors/selectrepository.py:69
-#: ../gramps/gui/selectors/selectsource.py:69
-#: ../gramps/gui/widgets/grampletpane.py:1570
+#: ../gramps/gui/selectors/selectobject.py:77
+#: ../gramps/gui/selectors/selectplace.py:70
+#: ../gramps/gui/selectors/selectrepository.py:66
+#: ../gramps/gui/selectors/selectsource.py:66
+#: ../gramps/gui/widgets/grampletpane.py:1601
 #: ../gramps/plugins/export/exportcsv.py:286
 #: ../gramps/plugins/gramplet/persondetails.py:164
-#: ../gramps/plugins/lib/libplaceview.py:86
+#: ../gramps/plugins/importer/importprogen.glade:140
+#: ../gramps/plugins/lib/libplaceview.py:87
 #: ../gramps/plugins/textreport/tagreport.py:424
 #: ../gramps/plugins/textreport/tagreport.py:575
 #: ../gramps/plugins/textreport/tagreport.py:745
 #: ../gramps/plugins/view/mediaview.py:94
 #: ../gramps/plugins/view/sourceview.py:82
-#: ../gramps/plugins/webreport/basepage.py:2673
-#: ../gramps/gui/widgets/grampletpane.py:1567
+#: ../gramps/plugins/webreport/basepage.py:2804
 msgid "Title"
 msgstr "Cím"
 
@@ -8213,7 +8252,7 @@ msgstr "Rendezés alapja"
 msgid "Display as"
 msgstr "Megjelenítés mint"
 
-#: ../gramps/gen/lib/name.py:175 ../gramps/plugins/importer/importcsv.py:163
+#: ../gramps/gen/lib/name.py:175 ../gramps/plugins/importer/importcsv.py:164
 msgid "Call name"
 msgstr "Hívó név"
 
@@ -8239,12 +8278,12 @@ msgstr "%(surname)s, %(first)s %(suffix)s"
 #. translators: needed for Arabic, ignore otherwise
 #: ../gramps/gen/lib/name.py:465 ../gramps/gen/lib/name.py:480
 #: ../gramps/gen/plug/report/utils.py:257
-#: ../gramps/plugins/graph/gvfamilylines.py:483
-#: ../gramps/plugins/textreport/detancestralreport.py:450
-#: ../gramps/plugins/textreport/detdescendantreport.py:485
+#: ../gramps/plugins/graph/gvfamilylines.py:490
+#: ../gramps/plugins/textreport/detancestralreport.py:454
+#: ../gramps/plugins/textreport/detdescendantreport.py:487
 #: ../gramps/plugins/textreport/indivcomplete.py:202
 #: ../gramps/plugins/textreport/indivcomplete.py:210
-#: ../gramps/plugins/textreport/indivcomplete.py:1017
+#: ../gramps/plugins/textreport/indivcomplete.py:1018
 #, python-format
 msgid "%(str1)s, %(str2)s"
 msgstr "%(str1)s, %(str2)s"
@@ -8268,7 +8307,7 @@ msgid "Surname|Taken"
 msgstr "Felvett"
 
 #: ../gramps/gen/lib/nameorigintype.py:79 ../gramps/gen/utils/keyword.py:65
-#: ../gramps/gui/configure.py:701
+#: ../gramps/gui/configure.py:857
 msgid "Patronymic"
 msgstr "Apai név"
 
@@ -8306,12 +8345,12 @@ msgstr "Házassági név"
 
 #. ###############################
 #. 3
-#: ../gramps/gen/lib/note.py:109 ../gramps/gen/plug/docgen/graphdoc.py:254
+#: ../gramps/gen/lib/note.py:109 ../gramps/gen/plug/docgen/graphdoc.py:265
 #: ../gramps/gen/plug/docgen/treedoc.py:199 ../gramps/gui/clipboard.py:375
-#: ../gramps/gui/configure.py:571 ../gramps/gui/editors/editlink.py:95
+#: ../gramps/gui/configure.py:667 ../gramps/gui/editors/editlink.py:95
 #: ../gramps/gui/editors/editmedia.py:98 ../gramps/gui/editors/editmedia.py:181
 #: ../gramps/gui/editors/editmediaref.py:146
-#: ../gramps/gui/editors/filtereditor.py:300
+#: ../gramps/gui/editors/filtereditor.py:301
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:109
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:115
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:109
@@ -8320,14 +8359,15 @@ msgstr "Házassági név"
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:113
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:108
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:91
-#: ../gramps/gui/glade/editnote.glade:326 ../gramps/gui/viewmanager.py:623
+#: ../gramps/gui/glade/editnote.glade:326 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/views/treemodels/mediamodel.py:117
 #: ../gramps/plugins/drawreport/ancestortree.py:974
-#: ../gramps/plugins/drawreport/descendtree.py:1696
+#: ../gramps/plugins/drawreport/descendtree.py:1701
 #: ../gramps/plugins/export/exportcsv.py:361
 #: ../gramps/plugins/export/exportcsv.py:466
-#: ../gramps/plugins/gramplet/quickviewgramplet.py:111
-#: ../gramps/plugins/importer/importcsv.py:170
+#: ../gramps/plugins/gramplet/quickviewgramplet.py:112
+#: ../gramps/plugins/importer/importcsv.py:171
+#: ../gramps/plugins/importer/importprogen.glade:753
 #: ../gramps/plugins/quickview/filterbyname.py:225
 #: ../gramps/plugins/quickview/filterbyname.py:276
 #: ../gramps/plugins/quickview/quickview.gpr.py:208
@@ -8338,13 +8378,13 @@ msgstr "Házassági név"
 msgid "Note"
 msgstr "Megjegyzés"
 
-#: ../gramps/gen/lib/note.py:119 ../gramps/gui/configure.py:864
+#: ../gramps/gen/lib/note.py:119 ../gramps/gui/configure.py:1023
 #: ../gramps/gui/editors/editplaceformat.py:72
 #: ../gramps/plugins/tool/reorderids.glade:1447
 msgid "Format"
 msgstr "Formátum"
 
-#: ../gramps/gen/lib/notetype.py:75 ../gramps/gui/configure.py:1460
+#: ../gramps/gen/lib/notetype.py:75 ../gramps/gui/configure.py:1681
 #: ../gramps/gui/editors/editeventref.py:89
 #: ../gramps/gui/editors/editmediaref.py:107
 #: ../gramps/gui/editors/editplaceref.py:71
@@ -8355,13 +8395,11 @@ msgstr "Formátum"
 #: ../gramps/gui/glade/editmediaref.glade:756
 #: ../gramps/gui/glade/editname.glade:671
 #: ../gramps/gui/glade/editperson.glade:382
-#: ../gramps/gui/glade/editplaceref.glade:160
-#: ../gramps/gui/glade/editplaceref.glade:664
+#: ../gramps/gui/glade/editplaceref.glade:161
+#: ../gramps/gui/glade/editplaceref.glade:665
 #: ../gramps/gui/glade/editreporef.glade:225
 #: ../gramps/gui/glade/editreporef.glade:445
 #: ../gramps/plugins/tool/verify.glade:406
-#: ../gramps/gui/glade/editplaceref.glade:161
-#: ../gramps/gui/glade/editplaceref.glade:665
 msgid "General"
 msgstr "Általános"
 
@@ -8377,7 +8415,7 @@ msgstr "Másolat"
 msgid "Source text"
 msgstr "Forrás szöveg"
 
-#: ../gramps/gen/lib/notetype.py:80 ../gramps/gen/plug/_pluginreg.py:78
+#: ../gramps/gen/lib/notetype.py:80 ../gramps/gen/plug/_pluginreg.py:79
 #: ../gramps/gui/logger/_errorview.py:174
 msgid "Report"
 msgstr "összesítés"
@@ -8464,7 +8502,6 @@ msgid "Child Reference Note"
 msgstr "Gyermek hivatkozás jegyzet"
 
 #. 4
-#. ('AddNewMenu', None, _('New')),
 #. ------------------------------------------------------------------------
 #.
 #. References
@@ -8472,12 +8509,15 @@ msgstr "Gyermek hivatkozás jegyzet"
 #. ------------------------------------------------------------------------
 #. functions for the actual quickreports
 #: ../gramps/gen/lib/person.py:173 ../gramps/gui/clipboard.py:719
-#: ../gramps/gui/configure.py:555 ../gramps/gui/editors/editlink.py:96
-#: ../gramps/gui/editors/filtereditor.py:293
-#: ../gramps/gui/glade/editpersonref.glade:211 ../gramps/gui/viewmanager.py:607
+#: ../gramps/gui/configure.py:643 ../gramps/gui/editors/editlink.py:96
+#: ../gramps/gui/editors/filtereditor.py:294
+#: ../gramps/gui/glade/editpersonref.glade:211 ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/export/exportcsv.py:354
-#: ../gramps/plugins/gramplet/quickviewgramplet.py:107
-#: ../gramps/plugins/importer/importcsv.py:208
+#: ../gramps/plugins/gramplet/quickviewgramplet.py:108
+#: ../gramps/plugins/importer/importcsv.py:209
+#: ../gramps/plugins/importer/importprogen.glade:667
+#: ../gramps/plugins/importer/importprogen.glade:1237
+#: ../gramps/plugins/importer/importprogen.glade:1326
 #: ../gramps/plugins/quickview/ageondate.py:54
 #: ../gramps/plugins/quickview/attributematch.py:34
 #: ../gramps/plugins/quickview/filterbyname.py:154
@@ -8496,26 +8536,26 @@ msgstr "Gyermek hivatkozás jegyzet"
 #: ../gramps/plugins/quickview/samesurnames.py:160
 #: ../gramps/plugins/textreport/placereport.py:226
 #: ../gramps/plugins/textreport/placereport.py:302
-#: ../gramps/plugins/textreport/placereport.py:457
+#: ../gramps/plugins/textreport/placereport.py:458
 #: ../gramps/plugins/tool/eventcmp.py:253
 #: ../gramps/plugins/tool/reorderids.glade:761
-#: ../gramps/plugins/webreport/event.py:179
-#: ../gramps/plugins/webreport/family.py:187
-#: ../gramps/plugins/webreport/person.py:1167
+#: ../gramps/plugins/webreport/event.py:180
+#: ../gramps/plugins/webreport/family.py:188
+#: ../gramps/plugins/webreport/person.py:1240
 msgid "Person"
 msgstr "Személy"
 
-#: ../gramps/gen/lib/person.py:184 ../gramps/gui/editors/editfamily.py:124
+#: ../gramps/gen/lib/person.py:184 ../gramps/gui/editors/editfamily.py:126
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:133
 #: ../gramps/gui/merge/mergeperson.py:184
-#: ../gramps/gui/selectors/selectperson.py:95
-#: ../gramps/plugins/drawreport/statisticschart.py:338
+#: ../gramps/gui/selectors/selectperson.py:92
+#: ../gramps/plugins/drawreport/statisticschart.py:344
 #: ../gramps/plugins/export/exportcsv.py:356
-#: ../gramps/plugins/importer/importcsv.py:168
+#: ../gramps/plugins/importer/importcsv.py:169
 #: ../gramps/plugins/lib/libpersonview.py:100
 #: ../gramps/plugins/quickview/siblings.py:48
-#: ../gramps/plugins/textreport/indivcomplete.py:927
-#: ../gramps/plugins/webreport/person.py:1407
+#: ../gramps/plugins/textreport/indivcomplete.py:928
+#: ../gramps/plugins/webreport/person.py:1481
 msgid "Gender"
 msgstr "Nem"
 
@@ -8535,9 +8575,9 @@ msgstr "Születési hivatkozás index"
 msgid "Event references"
 msgstr "Esemény hivatkozások"
 
-#: ../gramps/gen/lib/person.py:199 ../gramps/plugins/graph/gvfamilylines.py:285
-#: ../gramps/plugins/graph/gvhourglass.py:381
-#: ../gramps/plugins/graph/gvrelgraph.py:909
+#: ../gramps/gen/lib/person.py:199 ../gramps/plugins/graph/gvfamilylines.py:292
+#: ../gramps/plugins/graph/gvhourglass.py:432
+#: ../gramps/plugins/graph/gvrelgraph.py:954
 #: ../gramps/plugins/quickview/filterbyname.py:94
 #: ../gramps/plugins/quickview/filterbyname.py:119
 #: ../gramps/plugins/textreport/indivcomplete.py:641
@@ -8545,11 +8585,11 @@ msgstr "Esemény hivatkozások"
 #: ../gramps/plugins/tool/verify.glade:753
 #: ../gramps/plugins/view/familyview.py:116
 #: ../gramps/plugins/view/view.gpr.py:52 ../gramps/plugins/view/view.gpr.py:60
-#: ../gramps/plugins/webreport/basepage.py:256
-#: ../gramps/plugins/webreport/basepage.py:304
-#: ../gramps/plugins/webreport/basepage.py:1487
-#: ../gramps/plugins/webreport/basepage.py:1546
-#: ../gramps/plugins/webreport/basepage.py:1610
+#: ../gramps/plugins/webreport/basepage.py:277
+#: ../gramps/plugins/webreport/basepage.py:323
+#: ../gramps/plugins/webreport/basepage.py:1528
+#: ../gramps/plugins/webreport/basepage.py:1580
+#: ../gramps/plugins/webreport/basepage.py:1643
 #: ../gramps/plugins/webreport/family.py:131
 msgid "Families"
 msgstr "Családok"
@@ -8561,7 +8601,7 @@ msgstr "Kiinduló/gyökér családok"
 #: ../gramps/gen/lib/person.py:209 ../gramps/gen/lib/repo.py:103
 #: ../gramps/gui/merge/mergeperson.py:268
 #: ../gramps/plugins/textreport/indivcomplete.py:420
-#: ../gramps/plugins/webreport/basepage.py:1065
+#: ../gramps/plugins/webreport/basepage.py:1084
 msgid "Addresses"
 msgstr "Lakcímek"
 
@@ -8582,25 +8622,25 @@ msgid "Person ref"
 msgstr "Személy hivatkozás"
 
 #: ../gramps/gen/lib/personref.py:115
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:66
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:68
 msgid "Association"
 msgstr "Társítás"
 
 #: ../gramps/gen/lib/place.py:145 ../gramps/plugins/export/exportcsv.py:287
 #: ../gramps/plugins/gramplet/coordinates.py:96
 #: ../gramps/plugins/gramplet/placedetails.py:136
-#: ../gramps/plugins/lib/libplaceview.py:90
-#: ../gramps/plugins/webreport/basepage.py:2538
-#: ../gramps/plugins/webreport/place.py:180
+#: ../gramps/plugins/lib/libplaceview.py:91
+#: ../gramps/plugins/webreport/basepage.py:2579
+#: ../gramps/plugins/webreport/place.py:185
 msgid "Longitude"
 msgstr "Hosszúság"
 
 #: ../gramps/gen/lib/place.py:147 ../gramps/plugins/export/exportcsv.py:287
 #: ../gramps/plugins/gramplet/coordinates.py:95
 #: ../gramps/plugins/gramplet/placedetails.py:134
-#: ../gramps/plugins/lib/libplaceview.py:89
-#: ../gramps/plugins/webreport/basepage.py:2530
-#: ../gramps/plugins/webreport/place.py:179
+#: ../gramps/plugins/lib/libplaceview.py:90
+#: ../gramps/plugins/webreport/basepage.py:2571
+#: ../gramps/plugins/webreport/place.py:184
 msgid "Latitude"
 msgstr "Szélesség"
 
@@ -8611,29 +8651,29 @@ msgstr "Szélesség"
 #: ../gramps/plugins/view/view.gpr.py:221
 #: ../gramps/plugins/view/view.gpr.py:229
 #: ../gramps/plugins/view/view.gpr.py:244
-#: ../gramps/plugins/webreport/basepage.py:1489
-#: ../gramps/plugins/webreport/basepage.py:1552
-#: ../gramps/plugins/webreport/basepage.py:1618
-#: ../gramps/plugins/webreport/place.py:138
-#: ../gramps/plugins/webreport/place.py:292
+#: ../gramps/plugins/webreport/basepage.py:1530
+#: ../gramps/plugins/webreport/basepage.py:1586
+#: ../gramps/plugins/webreport/basepage.py:1651
+#: ../gramps/plugins/webreport/place.py:141
+#: ../gramps/plugins/webreport/place.py:308
 msgid "Places"
 msgstr "Helyek"
 
 #: ../gramps/gen/lib/place.py:154 ../gramps/gui/merge/mergeperson.py:199
 #: ../gramps/plugins/textreport/indivcomplete.py:391
-#: ../gramps/plugins/webreport/basepage.py:2581
+#: ../gramps/plugins/webreport/basepage.py:2623
 msgid "Alternate Names"
 msgstr "Alternatív nevek"
 
 #: ../gramps/gen/lib/place.py:157
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:110
 #: ../gramps/plugins/export/exportcsv.py:288
-#: ../gramps/plugins/importer/importcsv.py:227
-#: ../gramps/plugins/lib/libplaceview.py:88
+#: ../gramps/plugins/importer/importcsv.py:243
+#: ../gramps/plugins/lib/libplaceview.py:89
 msgid "Code"
 msgstr "Kód"
 
-#: ../gramps/gen/lib/place.py:160 ../gramps/plugins/webreport/basepage.py:2605
+#: ../gramps/gen/lib/place.py:160 ../gramps/plugins/webreport/basepage.py:2647
 msgid "Alternate Locations"
 msgstr "Alternatív helyszínek"
 
@@ -8648,7 +8688,7 @@ msgstr "Helynév"
 
 #: ../gramps/gen/lib/placename.py:103
 #: ../gramps/gui/editors/displaytabs/placenameembedlist.py:65
-#: ../gramps/plugins/webreport/basepage.py:2583
+#: ../gramps/plugins/webreport/basepage.py:2625
 msgid "Language"
 msgstr "Nyelv"
 
@@ -8656,64 +8696,64 @@ msgstr "Nyelv"
 msgid "Place ref"
 msgstr "Helyszín hivatkozás"
 
-#: ../gramps/gen/lib/placetype.py:72 ../gramps/plugins/view/geoplaces.py:573
+#: ../gramps/gen/lib/placetype.py:72 ../gramps/plugins/view/geoplaces.py:632
 msgid "Province"
 msgstr "Tartomány"
 
-#: ../gramps/gen/lib/placetype.py:74 ../gramps/plugins/view/geoplaces.py:579
+#: ../gramps/gen/lib/placetype.py:74 ../gramps/plugins/view/geoplaces.py:638
 msgid "Department"
 msgstr "Osztály"
 
-#: ../gramps/gen/lib/placetype.py:75 ../gramps/plugins/view/geoplaces.py:543
+#: ../gramps/gen/lib/placetype.py:75 ../gramps/plugins/view/geoplaces.py:602
 msgid "Neighborhood"
 msgstr "Szomszédság"
 
-#: ../gramps/gen/lib/placetype.py:76 ../gramps/plugins/view/geoplaces.py:582
+#: ../gramps/gen/lib/placetype.py:76 ../gramps/plugins/view/geoplaces.py:641
 msgid "District"
 msgstr "Kerület"
 
-#: ../gramps/gen/lib/placetype.py:77 ../gramps/plugins/view/geoplaces.py:546
+#: ../gramps/gen/lib/placetype.py:77 ../gramps/plugins/view/geoplaces.py:605
 msgid "Borough"
 msgstr "Város"
 
-#: ../gramps/gen/lib/placetype.py:78 ../gramps/plugins/view/geoplaces.py:594
+#: ../gramps/gen/lib/placetype.py:78 ../gramps/plugins/view/geoplaces.py:653
 msgid "Municipality"
 msgstr "Törvényhatóság"
 
-#: ../gramps/gen/lib/placetype.py:79 ../gramps/plugins/view/geoplaces.py:591
+#: ../gramps/gen/lib/placetype.py:79 ../gramps/plugins/view/geoplaces.py:650
 msgid "Town"
 msgstr "Város"
 
-#: ../gramps/gen/lib/placetype.py:80 ../gramps/plugins/view/geoplaces.py:549
+#: ../gramps/gen/lib/placetype.py:80 ../gramps/plugins/view/geoplaces.py:608
 msgid "Village"
 msgstr "Falu"
 
-#: ../gramps/gen/lib/placetype.py:81 ../gramps/plugins/view/geoplaces.py:552
+#: ../gramps/gen/lib/placetype.py:81 ../gramps/plugins/view/geoplaces.py:611
 msgid "Hamlet"
 msgstr "Falucska"
 
-#: ../gramps/gen/lib/placetype.py:82 ../gramps/plugins/view/geoplaces.py:555
+#: ../gramps/gen/lib/placetype.py:82 ../gramps/plugins/view/geoplaces.py:614
 msgid "Farm"
 msgstr "Gazdaság"
 
-#: ../gramps/gen/lib/placetype.py:83 ../gramps/plugins/view/geoplaces.py:558
+#: ../gramps/gen/lib/placetype.py:83 ../gramps/plugins/view/geoplaces.py:617
 msgid "Building"
 msgstr "Épület"
 
-#: ../gramps/gen/lib/placetype.py:84 ../gramps/plugins/gramplet/leak.py:89
-#: ../gramps/plugins/view/geoplaces.py:561
-#: ../gramps/plugins/webreport/basepage.py:2671
-#: ../gramps/plugins/webreport/source.py:163
+#: ../gramps/gen/lib/placetype.py:84 ../gramps/plugins/gramplet/leak.py:95
+#: ../gramps/plugins/view/geoplaces.py:620
+#: ../gramps/plugins/webreport/basepage.py:2802
+#: ../gramps/plugins/webreport/source.py:164
 msgid "Number"
 msgstr "Szám"
 
 #. 6
 #: ../gramps/gen/lib/repo.py:86 ../gramps/gui/clipboard.py:781
-#: ../gramps/gui/configure.py:569 ../gramps/gui/editors/editlink.py:98
+#: ../gramps/gui/configure.py:664 ../gramps/gui/editors/editlink.py:98
 #: ../gramps/gui/editors/editrepository.py:77
 #: ../gramps/gui/editors/editrepository.py:79
-#: ../gramps/gui/editors/filtereditor.py:299 ../gramps/gui/viewmanager.py:619
-#: ../gramps/plugins/gramplet/quickviewgramplet.py:113
+#: ../gramps/gui/editors/filtereditor.py:300 ../gramps/gui/grampsgui.py:56
+#: ../gramps/plugins/gramplet/quickviewgramplet.py:114
 #: ../gramps/plugins/quickview/filterbyname.py:205
 #: ../gramps/plugins/quickview/filterbyname.py:264
 #: ../gramps/plugins/tool/reorderids.glade:835
@@ -8769,12 +8809,12 @@ msgstr "Széf"
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:81
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:106
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:88
-#: ../gramps/gui/selectors/selectsource.py:70
+#: ../gramps/gui/selectors/selectsource.py:67
 #: ../gramps/plugins/gramplet/citations.py:84
 #: ../gramps/plugins/textreport/tagreport.py:751
 #: ../gramps/plugins/view/sourceview.py:84
-#: ../gramps/plugins/webreport/source.py:164
-#: ../gramps/plugins/webreport/source.py:260
+#: ../gramps/plugins/webreport/source.py:165
+#: ../gramps/plugins/webreport/source.py:262
 msgid "Author"
 msgstr "Szerző"
 
@@ -8786,7 +8826,7 @@ msgstr "Kiadás információ"
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:107
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:89
 #: ../gramps/plugins/view/sourceview.py:85
-#: ../gramps/plugins/webreport/source.py:261
+#: ../gramps/plugins/webreport/source.py:263
 msgid "Abbreviation"
 msgstr "Rövidítés"
 
@@ -8796,11 +8836,11 @@ msgstr "Rövidítés"
 #: ../gramps/plugins/view/repoview.py:129
 #: ../gramps/plugins/view/view.gpr.py:252
 #: ../gramps/plugins/view/view.gpr.py:260
-#: ../gramps/plugins/webreport/basepage.py:1491
-#: ../gramps/plugins/webreport/basepage.py:1620
-#: ../gramps/plugins/webreport/basepage.py:2662
+#: ../gramps/plugins/webreport/basepage.py:1532
+#: ../gramps/plugins/webreport/basepage.py:1653
+#: ../gramps/plugins/webreport/basepage.py:2793
 #: ../gramps/plugins/webreport/repository.py:138
-#: ../gramps/plugins/webreport/repository.py:223
+#: ../gramps/plugins/webreport/repository.py:224
 msgid "Repositories"
 msgstr "Tárolók"
 
@@ -8875,7 +8915,7 @@ msgstr "Formázott Szöveg Fül"
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:114
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:109
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:92
-#: ../gramps/gui/views/tags.py:226 ../gramps/gui/views/tags.py:231
+#: ../gramps/gui/views/tags.py:61 ../gramps/gui/views/tags.py:71
 #: ../gramps/plugins/textreport/tagreport.py:909
 #: ../gramps/plugins/textreport/tagreport.py:913
 msgid "Tag"
@@ -8886,20 +8926,17 @@ msgid "Ranges"
 msgstr "Tartományok"
 
 #: ../gramps/gen/lib/styledtexttagtype.py:61
-#: ../gramps/gui/widgets/styledtexteditor.py:456
-#: ../gramps/gui/widgets/styledtexteditor.py:455
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Bold"
 msgstr "Félkövér"
 
 #: ../gramps/gen/lib/styledtexttagtype.py:62
-#: ../gramps/gui/widgets/styledtexteditor.py:454
-#: ../gramps/gui/widgets/styledtexteditor.py:453
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Italic"
 msgstr "Dölt"
 
 #: ../gramps/gen/lib/styledtexttagtype.py:63
-#: ../gramps/gui/widgets/styledtexteditor.py:458
-#: ../gramps/gui/widgets/styledtexteditor.py:457
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Underline"
 msgstr "Aláhúzott"
 
@@ -8927,29 +8964,26 @@ msgstr "Felsőjel/hatvány"
 #: ../gramps/gui/glade/editlink.glade:171
 #: ../gramps/gui/widgets/styledtextbuffer.py:565
 #: ../gramps/gui/widgets/styledtextbuffer.py:605
-#: ../gramps/gui/widgets/styledtexteditor.py:470
-#: ../gramps/gui/widgets/styledtexteditor.py:471
-#: ../gramps/gui/widgets/styledtexteditor.py:469
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Link"
 msgstr "Hivatkozás"
 
 #. show surname and first name
 #: ../gramps/gen/lib/surname.py:87 ../gramps/gen/lib/surname.py:91
 #: ../gramps/gen/utils/keyword.py:56 ../gramps/gui/clipboard.py:596
-#: ../gramps/gui/configure.py:688 ../gramps/gui/configure.py:690
-#: ../gramps/gui/configure.py:692 ../gramps/gui/configure.py:694
-#: ../gramps/gui/configure.py:697 ../gramps/gui/configure.py:698
-#: ../gramps/gui/configure.py:699 ../gramps/gui/configure.py:700
+#: ../gramps/gui/configure.py:844 ../gramps/gui/configure.py:846
+#: ../gramps/gui/configure.py:848 ../gramps/gui/configure.py:850
+#: ../gramps/gui/configure.py:853 ../gramps/gui/configure.py:854
+#: ../gramps/gui/configure.py:855 ../gramps/gui/configure.py:856
 #: ../gramps/gui/editors/displaytabs/surnametab.py:75
-#: ../gramps/gui/plug/_guioptions.py:88 ../gramps/gui/plug/_guioptions.py:1506
-#: ../gramps/plugins/drawreport/statisticschart.py:334
+#: ../gramps/gui/plug/_guioptions.py:88 ../gramps/gui/plug/_guioptions.py:1508
+#: ../gramps/plugins/drawreport/statisticschart.py:340
 #: ../gramps/plugins/export/exportcsv.py:354
-#: ../gramps/plugins/importer/importcsv.py:159
+#: ../gramps/plugins/importer/importcsv.py:160
 #: ../gramps/plugins/quickview/filterbyname.py:354
-#: ../gramps/plugins/webreport/person.py:207
+#: ../gramps/plugins/webreport/person.py:213
 #: ../gramps/plugins/webreport/surname.py:98
-#: ../gramps/plugins/webreport/surnamelist.py:146
-#: ../gramps/gui/plug/_guioptions.py:1508
+#: ../gramps/plugins/webreport/surnamelist.py:147
 msgid "Surname"
 msgstr "Vezetéknév"
 
@@ -8957,7 +8991,7 @@ msgstr "Vezetéknév"
 #: ../gramps/gui/editors/displaytabs/surnametab.py:74
 #: ../gramps/gui/glade/editperson.glade:470
 #: ../gramps/plugins/export/exportcsv.py:355
-#: ../gramps/plugins/importer/importcsv.py:166
+#: ../gramps/plugins/importer/importcsv.py:167
 msgid "Prefix"
 msgstr "Előtag"
 
@@ -8972,10 +9006,9 @@ msgid "%(first)s %(second)s"
 msgstr "%(first)s %(second)s"
 
 #: ../gramps/gen/lib/tag.py:125 ../gramps/gen/plug/docgen/treedoc.py:168
-#: ../gramps/gui/glade/styleeditor.glade:384
-#: ../gramps/gui/glade/styleeditor.glade:1433
-#: ../gramps/gui/plug/_guioptions.py:1507 ../gramps/gui/views/tags.py:411
-#: ../gramps/gui/plug/_guioptions.py:1509
+#: ../gramps/gui/glade/styleeditor.glade:400
+#: ../gramps/gui/glade/styleeditor.glade:1449
+#: ../gramps/gui/plug/_guioptions.py:1509 ../gramps/gui/views/tags.py:445
 msgid "Color"
 msgstr "Szín"
 
@@ -9085,7 +9118,7 @@ msgstr "A(z) %s gramplet hibát okozott"
 #. Constants
 #.
 #. -------------------------------------------------------------------------
-#: ../gramps/gen/plug/_manager.py:61
+#: ../gramps/gen/plug/_manager.py:62
 msgid "No description was provided"
 msgstr "Nincs leírása"
 
@@ -9107,73 +9140,77 @@ msgstr "Biztos"
 msgid "Unstable"
 msgstr "Bizonytalan"
 
-#: ../gramps/gen/plug/_pluginreg.py:79
+#: ../gramps/gen/plug/_pluginreg.py:80
 msgid "Quickreport"
 msgstr "Gyorsjelentés"
 
-#: ../gramps/gen/plug/_pluginreg.py:80
+#: ../gramps/gen/plug/_pluginreg.py:81
 msgid "Tool"
 msgstr "Eszköz"
 
-#: ../gramps/gen/plug/_pluginreg.py:81
+#: ../gramps/gen/plug/_pluginreg.py:82
 msgid "Importer"
 msgstr "Importáló"
 
-#: ../gramps/gen/plug/_pluginreg.py:82
+#: ../gramps/gen/plug/_pluginreg.py:83
 msgid "Exporter"
 msgstr "Exportáló"
 
-#: ../gramps/gen/plug/_pluginreg.py:83
+#: ../gramps/gen/plug/_pluginreg.py:84
 msgid "Doc creator"
 msgstr "Irat szerző"
 
-#: ../gramps/gen/plug/_pluginreg.py:84
+#: ../gramps/gen/plug/_pluginreg.py:85
 msgid "Plugin lib"
 msgstr "Beépülő könyvtár"
 
-#: ../gramps/gen/plug/_pluginreg.py:85
+#: ../gramps/gen/plug/_pluginreg.py:86
 msgid "Map service"
 msgstr "Térkép szolgáltatás"
 
-#: ../gramps/gen/plug/_pluginreg.py:86
+#: ../gramps/gen/plug/_pluginreg.py:87
 msgid "Gramps View"
 msgstr "GRAMPS nézet"
 
-#: ../gramps/gen/plug/_pluginreg.py:87 ../gramps/plugins/view/relview.py:136
+#: ../gramps/gen/plug/_pluginreg.py:88 ../gramps/plugins/view/relview.py:131
 #: ../gramps/plugins/view/view.gpr.py:112
 #: ../gramps/plugins/view/view.gpr.py:120
 msgid "Relationships"
 msgstr "Kapcsolatok"
 
-#: ../gramps/gen/plug/_pluginreg.py:88 ../gramps/gen/plug/_pluginreg.py:425
+#: ../gramps/gen/plug/_pluginreg.py:89 ../gramps/gen/plug/_pluginreg.py:434
 #: ../gramps/gui/glade/grampletpane.glade:156
-#: ../gramps/gui/widgets/grampletbar.py:627
-#: ../gramps/gui/widgets/grampletpane.py:220
-#: ../gramps/gui/widgets/grampletpane.py:979
-#: ../gramps/gui/widgets/grampletpane.py:976
+#: ../gramps/gui/widgets/grampletbar.py:628
+#: ../gramps/gui/widgets/grampletpane.py:227
+#: ../gramps/gui/widgets/grampletpane.py:982
 msgid "Gramplet"
 msgstr "Gramplet"
 
-#: ../gramps/gen/plug/_pluginreg.py:89
+#: ../gramps/gen/plug/_pluginreg.py:90
 msgid "Sidebar"
 msgstr "Oldalsáv"
 
+#: ../gramps/gen/plug/_pluginreg.py:92
+msgid "Rule"
+msgstr "Szabály"
+
 #. add miscellaneous column
-#: ../gramps/gen/plug/_pluginreg.py:516
+#: ../gramps/gen/plug/_pluginreg.py:528
 #: ../gramps/plugins/gramplet/faqgramplet.py:135
-#: ../gramps/plugins/webreport/basepage.py:1677
-#: ../gramps/plugins/webreport/statistics.py:150
-#: ../gramps/plugins/webreport/statistics.py:200
+#: ../gramps/plugins/importer/importprogen.glade:1306
+#: ../gramps/plugins/webreport/basepage.py:1710
+#: ../gramps/plugins/webreport/statistics.py:151
+#: ../gramps/plugins/webreport/statistics.py:201
 msgid "Miscellaneous"
 msgstr "Egyebek"
 
-#: ../gramps/gen/plug/_pluginreg.py:1145 ../gramps/gen/plug/_pluginreg.py:1171
-#: ../gramps/gen/plug/_pluginreg.py:1176
+#: ../gramps/gen/plug/_pluginreg.py:1178 ../gramps/gen/plug/_pluginreg.py:1204
+#: ../gramps/gen/plug/_pluginreg.py:1209
 #, python-format
 msgid "ERROR: Failed reading plugin registration %(filename)s"
 msgstr "HIBA: %(filename)s beépülő regisztrációs olvasási hiba"
 
-#: ../gramps/gen/plug/_pluginreg.py:1154
+#: ../gramps/gen/plug/_pluginreg.py:1187
 #, python-format
 msgid ""
 "WARNING: Plugin %(plugin_name)s has no translation for any of your "
@@ -9182,7 +9219,7 @@ msgstr ""
 "FIGYELEM: A %(plugin_name)s beépülőnek nincs a beállított nyelveken "
 "fordítása, ezért helyette az angolt (USA) használom"
 
-#: ../gramps/gen/plug/_pluginreg.py:1191
+#: ../gramps/gen/plug/_pluginreg.py:1224
 #, python-format
 msgid ""
 "ERROR: Plugin file %(filename)s has a version of \"%(gramps_target_version)s"
@@ -9191,12 +9228,12 @@ msgstr ""
 "HIBA: A %(filename)s beépülő fájl verziója \"%(gramps_target_version)s\", "
 "ami érvénytelen a GRAMPS \"%(gramps_version)s\"-hoz."
 
-#: ../gramps/gen/plug/_pluginreg.py:1212
+#: ../gramps/gen/plug/_pluginreg.py:1245
 #, python-format
 msgid "ERROR: Wrong python file %(filename)s in register file %(regfile)s"
 msgstr "HIBA: Rossz %(filename)s python fájl a %(regfile)s regiszter fájlban"
 
-#: ../gramps/gen/plug/_pluginreg.py:1220
+#: ../gramps/gen/plug/_pluginreg.py:1253
 #, python-format
 msgid ""
 "ERROR: Python file %(filename)s in register file %(regfile)s does not exist"
@@ -9232,8 +9269,8 @@ msgstr "A %s fájl már nyitva van, először zárja be."
 #: ../gramps/gen/utils/docgen/odstab.py:496
 #: ../gramps/gen/utils/docgen/odstab.py:499
 #: ../gramps/plugins/docgen/asciidoc.py:177
-#: ../gramps/plugins/docgen/cairodoc.py:197
 #: ../gramps/plugins/docgen/cairodoc.py:200
+#: ../gramps/plugins/docgen/cairodoc.py:203
 #: ../gramps/plugins/docgen/odfdoc.py:1154
 #: ../gramps/plugins/docgen/odfdoc.py:1157
 #: ../gramps/plugins/docgen/rtfdoc.py:93 ../gramps/plugins/docgen/rtfdoc.py:96
@@ -9242,18 +9279,18 @@ msgstr "A %s fájl már nyitva van, először zárja be."
 #: ../gramps/plugins/export/exportcsv.py:261
 #: ../gramps/plugins/export/exportcsv.py:265
 #: ../gramps/plugins/export/exportftree.py:135
-#: ../gramps/plugins/export/exportgedcom.py:1567
+#: ../gramps/plugins/export/exportgedcom.py:1600
 #: ../gramps/plugins/export/exportgeneweb.py:108
 #: ../gramps/plugins/export/exportgeneweb.py:112
-#: ../gramps/plugins/export/exportvcalendar.py:119
-#: ../gramps/plugins/export/exportvcalendar.py:123
+#: ../gramps/plugins/export/exportvcalendar.py:120
+#: ../gramps/plugins/export/exportvcalendar.py:124
 #: ../gramps/plugins/export/exportvcard.py:71
 #: ../gramps/plugins/export/exportvcard.py:75
 #: ../gramps/plugins/lib/libhtmlbackend.py:249
 #: ../gramps/plugins/lib/libhtmlbackend.py:253
 #: ../gramps/plugins/lib/libhtmlbackend.py:259
 #: ../gramps/plugins/lib/libhtmlbackend.py:263
-#: ../gramps/plugins/webreport/narrativeweb.py:316
+#: ../gramps/plugins/webreport/narrativeweb.py:333
 #, python-format
 msgid "Could not create %s"
 msgstr "Nem létrehozható %s"
@@ -9263,7 +9300,7 @@ msgstr "Nem létrehozható %s"
 #. Private Constants
 #.
 #. -------------------------------------------------------------------------
-#: ../gramps/gen/plug/docgen/graphdoc.py:66
+#: ../gramps/gen/plug/docgen/graphdoc.py:68
 #: ../gramps/gen/plug/docgen/treedoc.py:67
 #: ../gramps/gen/plug/docgen/treedoc.py:73
 #: ../gramps/gen/plug/report/stdoptions.py:60
@@ -9271,118 +9308,118 @@ msgstr "Nem létrehozható %s"
 #: ../gramps/gen/plug/report/stdoptions.py:244
 #: ../gramps/gen/plug/report/stdoptions.py:248
 #: ../gramps/gen/plug/report/stdoptions.py:338
+#: ../gramps/plugins/importer/importprogen.glade:380
 msgid "Default"
 msgstr "Alapértelmezett"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:67
+#: ../gramps/gen/plug/docgen/graphdoc.py:69
 msgid "PostScript / Helvetica"
 msgstr "PostScript / Helvetica"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:68
+#: ../gramps/gen/plug/docgen/graphdoc.py:70
 msgid "TrueType / FreeSans"
 msgstr "TrueType / FreeSans"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:70
-#: ../gramps/plugins/view/pedigreeview.py:2044
+#: ../gramps/gen/plug/docgen/graphdoc.py:72
+#: ../gramps/plugins/view/pedigreeview.py:2119
 msgid "Vertical (↓)"
 msgstr "Függőleges (↓)"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:71
-#: ../gramps/plugins/view/pedigreeview.py:2045
+#: ../gramps/gen/plug/docgen/graphdoc.py:73
+#: ../gramps/plugins/view/pedigreeview.py:2120
 msgid "Vertical (↑)"
 msgstr "Függőleges (↑)"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:72
-#: ../gramps/plugins/view/pedigreeview.py:2046
+#: ../gramps/gen/plug/docgen/graphdoc.py:74
+#: ../gramps/plugins/view/pedigreeview.py:2121
 msgid "Horizontal (→)"
 msgstr "Vízszintes (→)"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:73
-#: ../gramps/plugins/view/pedigreeview.py:2047
+#: ../gramps/gen/plug/docgen/graphdoc.py:75
+#: ../gramps/plugins/view/pedigreeview.py:2122
 msgid "Horizontal (←)"
 msgstr "Vízszintes (←)"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:75
+#: ../gramps/gen/plug/docgen/graphdoc.py:82
 msgid "Bottom, left"
 msgstr "Alul, baloldalt"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:76
+#: ../gramps/gen/plug/docgen/graphdoc.py:83
 msgid "Bottom, right"
 msgstr "Alul, jobboldalt"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:77
+#: ../gramps/gen/plug/docgen/graphdoc.py:84
 msgid "Top, left"
 msgstr "Felül, baloldalt"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:78
+#: ../gramps/gen/plug/docgen/graphdoc.py:85
 msgid "Top, Right"
 msgstr "Felül, jobboldalt"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:79
+#: ../gramps/gen/plug/docgen/graphdoc.py:86
 msgid "Right, bottom"
 msgstr "Jobbra, alul"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:80
+#: ../gramps/gen/plug/docgen/graphdoc.py:87
 msgid "Right, top"
 msgstr "Jobbra, felül"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:81
+#: ../gramps/gen/plug/docgen/graphdoc.py:88
 msgid "Left, bottom"
 msgstr "Balra, lent"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:82
+#: ../gramps/gen/plug/docgen/graphdoc.py:89
 msgid "Left, top"
 msgstr "Balra, fent"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:84
+#: ../gramps/gen/plug/docgen/graphdoc.py:91
 msgid "Compress to minimal size"
 msgstr "Nyomja össze a legkisebb méretre"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:85
+#: ../gramps/gen/plug/docgen/graphdoc.py:92
 msgid "Fill the given area"
 msgstr "Töltse ki az adott területet"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:86
+#: ../gramps/gen/plug/docgen/graphdoc.py:93
 msgid "Expand uniformly"
 msgstr "Egyenletesen kiterjeszt"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:88
+#: ../gramps/gen/plug/docgen/graphdoc.py:95
 #: ../gramps/gen/plug/docgen/treedoc.py:86
-#: ../gramps/gui/glade/styleeditor.glade:1343
+#: ../gramps/gui/glade/styleeditor.glade:1359
 msgid "Top"
 msgstr "Felül"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:89
+#: ../gramps/gen/plug/docgen/graphdoc.py:96
 #: ../gramps/gen/plug/docgen/treedoc.py:87
-#: ../gramps/gui/glade/styleeditor.glade:1358
+#: ../gramps/gui/glade/styleeditor.glade:1374
 msgid "Bottom"
 msgstr "Alul"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:91
+#: ../gramps/gen/plug/docgen/graphdoc.py:98
 msgid "Straight"
 msgstr "Egyenes"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:92
+#: ../gramps/gen/plug/docgen/graphdoc.py:99
 msgid "Curved"
 msgstr "Göbített"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:93
+#: ../gramps/gen/plug/docgen/graphdoc.py:100
 msgid "Orthogonal"
 msgstr "Merőleges"
 
 #. ###############################
-#: ../gramps/gen/plug/docgen/graphdoc.py:134
+#: ../gramps/gen/plug/docgen/graphdoc.py:141
 msgid "Graphviz Layout"
 msgstr "Graphviz Réteg"
 
 #. ###############################
-#: ../gramps/gen/plug/docgen/graphdoc.py:136
-#: ../gramps/gui/widgets/styledtexteditor.py:480
-#: ../gramps/gui/widgets/styledtexteditor.py:479
+#: ../gramps/gen/plug/docgen/graphdoc.py:143
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Font family"
 msgstr "Betű család"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:139
+#: ../gramps/gen/plug/docgen/graphdoc.py:146
 msgid ""
 "Choose the font family. If international characters don't show, use FreeSans "
 "font. FreeSans is available from: http://www.nongnu.org/freefont/"
@@ -9391,29 +9428,28 @@ msgstr ""
 "használja a FreeSans betűt. A FreeSans elérhető itt: http://www.nongnu.org/"
 "freefont/"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:145
-#: ../gramps/gui/widgets/styledtexteditor.py:492
-#: ../gramps/gui/widgets/styledtexteditor.py:491
+#: ../gramps/gen/plug/docgen/graphdoc.py:152
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Font size"
 msgstr "Betű méret"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:146
+#: ../gramps/gen/plug/docgen/graphdoc.py:153
 msgid "The font size, in points."
 msgstr "A betűméret, pontokban."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:149
+#: ../gramps/gen/plug/docgen/graphdoc.py:156
 msgid "Graph Direction"
 msgstr "Diagram irány"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:152
+#: ../gramps/gen/plug/docgen/graphdoc.py:159
 msgid "Whether graph goes from top to bottom or left to right."
 msgstr "A diagram felülről lefelé, vagy balról jobbra menjen-e."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:156
+#: ../gramps/gen/plug/docgen/graphdoc.py:163
 msgid "Number of Horizontal Pages"
 msgstr "A fekvő oldalak száma"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:157
+#: ../gramps/gen/plug/docgen/graphdoc.py:164
 msgid ""
 "Graphviz can create very large graphs by spreading the graph across a "
 "rectangular array of pages. This controls the number pages in the array "
@@ -9424,11 +9460,11 @@ msgstr ""
 "vízszintesen. Ghostscripten keresztül csak .dot és .pdf állományokra "
 "érvényes."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:164
+#: ../gramps/gen/plug/docgen/graphdoc.py:171
 msgid "Number of Vertical Pages"
 msgstr "Függőleges lapok száma"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:165
+#: ../gramps/gen/plug/docgen/graphdoc.py:172
 msgid ""
 "Graphviz can create very large graphs by spreading the graph across a "
 "rectangular array of pages. This controls the number pages in the array "
@@ -9439,11 +9475,11 @@ msgstr ""
 "függőlegesen. Ghostscripten keresztül csak .dot és .pdf állományokra "
 "érvényes."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:172
+#: ../gramps/gen/plug/docgen/graphdoc.py:179
 msgid "Paging Direction"
 msgstr "Lapozás iránya"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:175
+#: ../gramps/gen/plug/docgen/graphdoc.py:182
 msgid ""
 "The order in which the graph pages are output. This option only applies if "
 "the horizontal pages or vertical pages are greater than 1."
@@ -9451,25 +9487,33 @@ msgstr ""
 "A kimeneti grafikon lapjainak sorrendje. Csak akkor érvényes, ha a lapok "
 "száma vízszintesen, vagy függőlegesen nagyobb mint 1."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:180
+#: ../gramps/gen/plug/docgen/graphdoc.py:187
 msgid "Connecting lines"
 msgstr "Vonalak összekötése"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:183
+#: ../gramps/gen/plug/docgen/graphdoc.py:190
 msgid "How the lines between objects will be drawn."
 msgstr "Ahogyan az objektumok közötti vonalak rajzolásra kerülnek."
 
+#: ../gramps/gen/plug/docgen/graphdoc.py:193
+msgid "Alternate line attachment"
+msgstr "Alternatív sor hozzáadása"
+
+#: ../gramps/gen/plug/docgen/graphdoc.py:194
+msgid "Whether lines attach to nodes differently"
+msgstr "Legyenek-e a sorok a csomóponthoz másképpen csatlakoztatva"
+
 #. ###############################
-#: ../gramps/gen/plug/docgen/graphdoc.py:199
+#: ../gramps/gen/plug/docgen/graphdoc.py:210
 msgid "Graphviz Options"
 msgstr "Graphviz Feltételek"
 
 #. ###############################
-#: ../gramps/gen/plug/docgen/graphdoc.py:202
+#: ../gramps/gen/plug/docgen/graphdoc.py:213
 msgid "Aspect ratio"
 msgstr "Méretarány"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:206
+#: ../gramps/gen/plug/docgen/graphdoc.py:217
 msgid ""
 "Affects node spacing and scaling of the graph.\n"
 "If the graph is smaller than the print area:\n"
@@ -9499,11 +9543,11 @@ msgstr ""
 "megnöveli a csomópont közöket.\n"
 "  A kiterjesztés a grafikont egyenletesen illeszti be a nyomtatási területre."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:222
+#: ../gramps/gen/plug/docgen/graphdoc.py:233
 msgid "DPI"
 msgstr "DPI - pont/hüvelyk"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:223
+#: ../gramps/gen/plug/docgen/graphdoc.py:234
 msgid ""
 "Dots per inch.  When creating images such as .gif or .png files for the web, "
 "try numbers such as 100 or 300 DPI.  PostScript and PDF files always use 72 "
@@ -9513,11 +9557,11 @@ msgstr ""
 "létre, próbáljon 100, vagy 300 DPI-t használni.  A PostScript és PDF fájlok "
 "mindig 72 DPI-t használnak."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:230
+#: ../gramps/gen/plug/docgen/graphdoc.py:241
 msgid "Node spacing"
 msgstr "Csomópont köz"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:231
+#: ../gramps/gen/plug/docgen/graphdoc.py:242
 msgid ""
 "The minimum amount of free space, in inches, between individual nodes.  For "
 "vertical graphs, this corresponds to spacing between columns.  For "
@@ -9527,11 +9571,11 @@ msgstr ""
 "Függőleges grafikonoknál ez az oszlopok, vízszintes grafikonoknál pedig a "
 "sorok közötti távolságra vonatkozik."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:238
+#: ../gramps/gen/plug/docgen/graphdoc.py:249
 msgid "Rank spacing"
 msgstr "érték köz"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:239
+#: ../gramps/gen/plug/docgen/graphdoc.py:250
 msgid ""
 "The minimum amount of free space, in inches, between ranks.  For vertical "
 "graphs, this corresponds to spacing between rows.  For horizontal graphs, "
@@ -9541,11 +9585,11 @@ msgstr ""
 "Függőleges grafikonoknál ez a sorok, vízszintes grafikonoknál pedig az "
 "oszlopok közötti távolságra vonatkozik."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:246
+#: ../gramps/gen/plug/docgen/graphdoc.py:257
 msgid "Use subgraphs"
 msgstr "Al-grafikonok használata"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:247
+#: ../gramps/gen/plug/docgen/graphdoc.py:258
 msgid ""
 "Subgraphs can help Graphviz position spouses together, but with non-trivial "
 "graphs will result in longer lines and larger graphs."
@@ -9555,67 +9599,67 @@ msgstr ""
 "eredményezhet."
 
 #. ###############################
-#: ../gramps/gen/plug/docgen/graphdoc.py:257
+#: ../gramps/gen/plug/docgen/graphdoc.py:268
 msgid "Note to add to the graph"
 msgstr "Grafikonhoz jegyzet adása"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:259
+#: ../gramps/gen/plug/docgen/graphdoc.py:270
 msgid "This text will be added to the graph."
 msgstr "Ez a szöveg a grafikonba kerül."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:262
+#: ../gramps/gen/plug/docgen/graphdoc.py:273
 #: ../gramps/gen/plug/docgen/treedoc.py:206
 msgid "Note location"
 msgstr "A jegyzet helye"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:265
+#: ../gramps/gen/plug/docgen/graphdoc.py:276
 #: ../gramps/gen/plug/docgen/treedoc.py:209
 msgid "Whether note will appear on top or bottom of the page."
 msgstr "Az oldal tetején, vagy az alján jelenjen-e meg a jegyzet."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:269
+#: ../gramps/gen/plug/docgen/graphdoc.py:280
 #: ../gramps/gen/plug/docgen/treedoc.py:213
 msgid "Note size"
 msgstr "A jegyzet mérete"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:270
+#: ../gramps/gen/plug/docgen/graphdoc.py:281
 msgid "The size of note text, in points."
 msgstr "A jegyzetszöveg mérete pontokban."
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1013
+#: ../gramps/gen/plug/docgen/graphdoc.py:1073
 msgid "PDF (Ghostscript)"
 msgstr "PDF (Ghostscript)"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1019
+#: ../gramps/gen/plug/docgen/graphdoc.py:1079
 msgid "PDF (Graphviz)"
 msgstr "PDF (Graphviz)"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1025
+#: ../gramps/gen/plug/docgen/graphdoc.py:1085
 #: ../gramps/plugins/docgen/docgen.gpr.py:161
 msgid "PostScript"
 msgstr "PostScript"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1031
+#: ../gramps/gen/plug/docgen/graphdoc.py:1091
 msgid "Structured Vector Graphics (SVG)"
 msgstr "Strukturált vektorgrafika (SVG)"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1037
+#: ../gramps/gen/plug/docgen/graphdoc.py:1097
 msgid "Compressed Structured Vector Graphs (SVGZ)"
 msgstr "Tömörített strukturált vektorgrafika (SVGZ)"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1043
+#: ../gramps/gen/plug/docgen/graphdoc.py:1103
 msgid "JPEG image"
 msgstr "JPEG kép"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1049
+#: ../gramps/gen/plug/docgen/graphdoc.py:1109
 msgid "GIF image"
 msgstr "GIF kép"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1055
+#: ../gramps/gen/plug/docgen/graphdoc.py:1115
 msgid "PNG image"
 msgstr "PNG kép"
 
-#: ../gramps/gen/plug/docgen/graphdoc.py:1061
+#: ../gramps/gen/plug/docgen/graphdoc.py:1121
 msgid "Graphviz File"
 msgstr "Graphviz fájl"
 
@@ -9661,8 +9705,9 @@ msgstr "Alul"
 msgid "Not shown"
 msgstr "Nem mutatott"
 
-#: ../gramps/gen/plug/docgen/treedoc.py:74 ../gramps/gui/configure.py:158
-#: ../gramps/gui/configure.py:1715 ../gramps/gui/views/pageview.py:606
+#: ../gramps/gen/plug/docgen/treedoc.py:74 ../gramps/gui/configure.py:99
+#: ../gramps/gui/configure.py:166 ../gramps/gui/configure.py:1946
+#: ../gramps/gui/views/pageview.py:591
 msgid "Preferences"
 msgstr "Beállítások"
 
@@ -9715,13 +9760,14 @@ msgid "Small"
 msgstr "Kicsi"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:93 ../gramps/gen/utils/string.py:57
-#: ../gramps/gui/editors/editcitation.py:212
-#: ../gramps/plugins/graph/gvfamilylines.py:255
+#: ../gramps/gui/editors/editcitation.py:214
+#: ../gramps/plugins/graph/gvfamilylines.py:262
+#: ../gramps/plugins/importer/importprogen.py:487
 msgid "Normal"
 msgstr "Átlagos"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:94
-#: ../gramps/plugins/graph/gvfamilylines.py:256
+#: ../gramps/plugins/graph/gvfamilylines.py:263
 msgid "Large"
 msgstr "Nagy"
 
@@ -9791,7 +9837,7 @@ msgstr "Csomópont szín."
 #. #################
 #: ../gramps/gen/plug/docgen/treedoc.py:175
 #: ../gramps/plugins/drawreport/ancestortree.py:791
-#: ../gramps/plugins/drawreport/descendtree.py:1522
+#: ../gramps/plugins/drawreport/descendtree.py:1527
 msgid "Tree Options"
 msgstr "Fa feltételek"
 
@@ -9839,11 +9885,11 @@ msgstr "Ez a szöveg a családfához kerül."
 msgid "The size of note text."
 msgstr "A jegyzetszöveg mérete."
 
-#: ../gramps/gen/plug/docgen/treedoc.py:653
+#: ../gramps/gen/plug/docgen/treedoc.py:655
 msgid "PDF"
 msgstr "PDF"
 
-#: ../gramps/gen/plug/docgen/treedoc.py:659
+#: ../gramps/gen/plug/docgen/treedoc.py:661
 msgid "LaTeX File"
 msgstr "LaTeX fájl"
 
@@ -9862,8 +9908,13 @@ msgstr "Érvényes értékek: "
 #. Private Constants
 #.
 #. ------------------------------------------------------------------------
+#. -------------------------------------------------------------------------
+#.
+#. Constants
+#.
+#. -------------------------------------------------------------------------
 #: ../gramps/gen/plug/report/_book.py:71 ../gramps/gui/plug/_dialogs.py:59
-#: ../gramps/gui/plug/report/_bookdialog.py:84 ../gramps/gui/viewmanager.py:122
+#: ../gramps/gui/plug/report/_bookdialog.py:86 ../gramps/gui/viewmanager.py:112
 msgid "Unsupported"
 msgstr "Nem támogatott"
 
@@ -9884,6 +9935,7 @@ msgid "Web Pages"
 msgstr "Web oldalak"
 
 #: ../gramps/gen/plug/report/_constants.py:49
+#: ../gramps/gui/plug/report/_bookdialog.py:91
 msgid "Books"
 msgstr "Könyvek"
 
@@ -9901,8 +9953,8 @@ msgstr "Ábrák"
 
 #: ../gramps/gen/plug/report/endnotes.py:61
 #: ../gramps/plugins/textreport/ancestorreport.py:376
-#: ../gramps/plugins/textreport/detancestralreport.py:982
-#: ../gramps/plugins/textreport/detdescendantreport.py:1187
+#: ../gramps/plugins/textreport/detancestralreport.py:990
+#: ../gramps/plugins/textreport/detdescendantreport.py:1193
 #: ../gramps/plugins/textreport/endoflinereport.py:326
 msgid "The style used for the generation header."
 msgstr "A fejléc generálásához használt stílus."
@@ -9938,8 +9990,8 @@ msgstr "Végjegyzetek"
 #. show "> Family: ..." and nothing else
 #. show "V Family: ..." and the rest
 #: ../gramps/gen/plug/report/endnotes.py:175
-#: ../gramps/gui/editors/editfamily.py:945
-#: ../gramps/gui/editors/editfamily.py:952
+#: ../gramps/gui/editors/editfamily.py:995
+#: ../gramps/gui/editors/editfamily.py:1002
 #: ../gramps/gui/plug/report/_docreportdialog.py:186
 #: ../gramps/gui/plug/report/_docreportdialog.py:237
 #: ../gramps/gui/plug/report/_graphreportdialog.py:154
@@ -9947,28 +9999,33 @@ msgstr "Végjegyzetek"
 #: ../gramps/gui/plug/report/_reportdialog.py:377
 #: ../gramps/gui/plug/report/_reportdialog.py:401
 #: ../gramps/gui/plug/report/_reportdialog.py:472
-#: ../gramps/gui/plug/report/_reportdialog.py:620
-#: ../gramps/plugins/gramplet/statsgramplet.py:105
-#: ../gramps/plugins/gramplet/statsgramplet.py:108
-#: ../gramps/plugins/gramplet/statsgramplet.py:111
-#: ../gramps/plugins/gramplet/statsgramplet.py:117
-#: ../gramps/plugins/gramplet/statsgramplet.py:122
-#: ../gramps/plugins/gramplet/statsgramplet.py:128
-#: ../gramps/plugins/gramplet/statsgramplet.py:132
-#: ../gramps/plugins/gramplet/statsgramplet.py:137
-#: ../gramps/plugins/gramplet/statsgramplet.py:141
+#: ../gramps/gui/plug/report/_reportdialog.py:623
+#: ../gramps/plugins/gramplet/statsgramplet.py:146
+#: ../gramps/plugins/gramplet/statsgramplet.py:149
+#: ../gramps/plugins/gramplet/statsgramplet.py:152
+#: ../gramps/plugins/gramplet/statsgramplet.py:156
+#: ../gramps/plugins/gramplet/statsgramplet.py:160
+#: ../gramps/plugins/gramplet/statsgramplet.py:164
+#: ../gramps/plugins/gramplet/statsgramplet.py:170
+#: ../gramps/plugins/gramplet/statsgramplet.py:175
+#: ../gramps/plugins/gramplet/statsgramplet.py:181
+#: ../gramps/plugins/gramplet/statsgramplet.py:185
+#: ../gramps/plugins/gramplet/statsgramplet.py:189
+#: ../gramps/plugins/gramplet/statsgramplet.py:194
+#: ../gramps/plugins/gramplet/statsgramplet.py:198
 #: ../gramps/plugins/textreport/familygroup.py:410
-#: ../gramps/plugins/textreport/indivcomplete.py:924
-#: ../gramps/plugins/textreport/indivcomplete.py:926
+#: ../gramps/plugins/textreport/indivcomplete.py:925
 #: ../gramps/plugins/textreport/indivcomplete.py:927
 #: ../gramps/plugins/textreport/indivcomplete.py:928
 #: ../gramps/plugins/textreport/indivcomplete.py:929
-#: ../gramps/plugins/view/relview.py:530 ../gramps/plugins/view/relview.py:592
-#: ../gramps/plugins/view/relview.py:604 ../gramps/plugins/view/relview.py:623
-#: ../gramps/plugins/view/relview.py:635 ../gramps/plugins/view/relview.py:640
-#: ../gramps/plugins/view/relview.py:648 ../gramps/plugins/view/relview.py:858
-#: ../gramps/plugins/view/relview.py:892 ../gramps/plugins/view/relview.py:1360
-#: ../gramps/plugins/view/relview.py:1382
+#: ../gramps/plugins/textreport/indivcomplete.py:930
+#: ../gramps/plugins/view/relview.py:659 ../gramps/plugins/view/relview.py:723
+#: ../gramps/plugins/view/relview.py:735 ../gramps/plugins/view/relview.py:756
+#: ../gramps/plugins/view/relview.py:768 ../gramps/plugins/view/relview.py:773
+#: ../gramps/plugins/view/relview.py:780 ../gramps/plugins/view/relview.py:1017
+#: ../gramps/plugins/view/relview.py:1052
+#: ../gramps/plugins/view/relview.py:1529
+#: ../gramps/plugins/view/relview.py:1552
 #, python-format
 msgid "%s:"
 msgstr "%s:"
@@ -9981,13 +10038,13 @@ msgstr "Fordítás"
 msgid "The translation to be used for the report."
 msgstr "Az összegzőhöz használandó fordítás."
 
-#: ../gramps/gen/plug/report/stdoptions.py:73 ../gramps/gui/configure.py:1030
-#: ../gramps/plugins/webreport/webcal.py:1675
+#: ../gramps/gen/plug/report/stdoptions.py:73 ../gramps/gui/configure.py:1194
+#: ../gramps/plugins/webreport/webcal.py:1720
 msgid "Name format"
 msgstr "Név formátum"
 
 #: ../gramps/gen/plug/report/stdoptions.py:78
-#: ../gramps/plugins/webreport/webcal.py:1679
+#: ../gramps/plugins/webreport/webcal.py:1724
 msgid "Select the format to display names"
 msgstr "Válasszon névmegjelenítés formátumot"
 
@@ -10036,7 +10093,7 @@ msgstr "Évek száma a halálozástól az élőnek gondoltig"
 msgid "Whether to restrict data on recently-dead people"
 msgstr "Legyen-e adat szűrés a jelenleg halottakra"
 
-#: ../gramps/gen/plug/report/stdoptions.py:257 ../gramps/gui/configure.py:1058
+#: ../gramps/gen/plug/report/stdoptions.py:257 ../gramps/gui/configure.py:1222
 msgid "Date format"
 msgstr "Dátum formátum"
 
@@ -10066,15 +10123,14 @@ msgstr "Legyen-e (és hol) GRAMPS Azonosító a nevek mellett"
 #. #########################
 #. ###############################
 #: ../gramps/gen/plug/report/stdoptions.py:328
-#: ../gramps/gui/viewmanager.py:1931
-#: ../gramps/plugins/graph/gvfamilylines.py:211
-#: ../gramps/plugins/graph/gvrelgraph.py:819
-#: ../gramps/plugins/textreport/detancestralreport.py:892
-#: ../gramps/plugins/textreport/detdescendantreport.py:1079
+#: ../gramps/gui/viewmanager.py:1722
+#: ../gramps/plugins/graph/gvfamilylines.py:218
+#: ../gramps/plugins/graph/gvrelgraph.py:859
+#: ../gramps/plugins/textreport/detancestralreport.py:900
+#: ../gramps/plugins/textreport/detdescendantreport.py:1085
 #: ../gramps/plugins/textreport/familygroup.py:752
-#: ../gramps/plugins/textreport/indivcomplete.py:1101
-#: ../gramps/plugins/webreport/narrativeweb.py:1901
-#: ../gramps/gui/viewmanager.py:1929
+#: ../gramps/plugins/textreport/indivcomplete.py:1102
+#: ../gramps/plugins/webreport/narrativeweb.py:1986
 msgid "Include"
 msgstr "Beleértve"
 
@@ -10082,7 +10138,7 @@ msgstr "Beleértve"
 msgid "Whether to include Gramps IDs"
 msgstr "Legyenek-e GRAMPS Azonosítók benne"
 
-#: ../gramps/gen/plug/report/stdoptions.py:337 ../gramps/gui/configure.py:1072
+#: ../gramps/gen/plug/report/stdoptions.py:337
 msgid "Place format"
 msgstr "Hely formátuma"
 
@@ -10091,17 +10147,17 @@ msgid "Select the format to display places"
 msgstr "Válasszon a hely megjelenítéshez formátumot"
 
 #: ../gramps/gen/plug/report/utils.py:158
-#: ../gramps/plugins/textreport/indivcomplete.py:918
+#: ../gramps/plugins/textreport/indivcomplete.py:919
 msgid "File does not exist"
 msgstr "Nem létező fájl"
 
 #: ../gramps/gen/plug/report/utils.py:159
-#: ../gramps/plugins/textreport/indivcomplete.py:914
+#: ../gramps/plugins/textreport/indivcomplete.py:915
 #: ../gramps/plugins/textreport/simplebooktitle.py:106
-#: ../gramps/plugins/webreport/basepage.py:1720
-#: ../gramps/plugins/webreport/basepage.py:1923
-#: ../gramps/plugins/webreport/basepage.py:1989
-#: ../gramps/plugins/webreport/basepage.py:1997
+#: ../gramps/plugins/webreport/basepage.py:1799
+#: ../gramps/plugins/webreport/basepage.py:2004
+#: ../gramps/plugins/webreport/basepage.py:2070
+#: ../gramps/plugins/webreport/basepage.py:2078
 msgid "Could not add photo to page"
 msgstr "Nem tud fotót adni az oldalhoz"
 
@@ -10119,9 +10175,8 @@ msgstr "Teljes adatbázis"
 
 #. feature request 2356: avoid genitive form
 #: ../gramps/gen/plug/report/utils.py:301
-#: ../gramps/gui/plug/export/_exportoptions.py:452
-#: ../gramps/plugins/textreport/descendreport.py:488
 #: ../gramps/gui/plug/export/_exportoptions.py:455
+#: ../gramps/plugins/textreport/descendreport.py:488
 #, python-format
 msgid "Descendants of %s"
 msgstr "%s leszármazottai"
@@ -10129,7 +10184,6 @@ msgstr "%s leszármazottai"
 #. feature request 2356: avoid genitive form
 #: ../gramps/gen/plug/report/utils.py:305
 #: ../gramps/gen/plug/report/utils.py:382
-#: ../gramps/gui/plug/export/_exportoptions.py:457
 #: ../gramps/gui/plug/export/_exportoptions.py:460
 #, python-format
 msgid "Descendant Families of %s"
@@ -10137,31 +10191,26 @@ msgstr "%s leszármazott családjai"
 
 #. feature request 2356: avoid genitive form
 #: ../gramps/gen/plug/report/utils.py:309
-#: ../gramps/gui/plug/export/_exportoptions.py:462
 #: ../gramps/gui/plug/export/_exportoptions.py:465
 #, python-format
 msgid "Ancestors of %s"
 msgstr "%s ősei"
 
 #: ../gramps/gen/plug/report/utils.py:312
-#: ../gramps/gui/plug/export/_exportoptions.py:466
 #: ../gramps/gui/plug/export/_exportoptions.py:469
 #, python-format
 msgid "People with common ancestor with %s"
 msgstr "Közös őssel rendelkezők %s személlyel"
 
-#: ../gramps/gen/plug/report/utils.py:354 ../gramps/gui/plug/_guioptions.py:895
-#: ../gramps/gui/plug/_guioptions.py:897
+#: ../gramps/gen/plug/report/utils.py:354 ../gramps/gui/plug/_guioptions.py:897
 msgid "unknown father"
 msgstr "ismeretlen apa"
 
-#: ../gramps/gen/plug/report/utils.py:360 ../gramps/gui/plug/_guioptions.py:901
-#: ../gramps/gui/plug/_guioptions.py:903
+#: ../gramps/gen/plug/report/utils.py:360 ../gramps/gui/plug/_guioptions.py:903
 msgid "unknown mother"
 msgstr "ismeretlen anya"
 
-#: ../gramps/gen/plug/report/utils.py:362 ../gramps/gui/plug/_guioptions.py:903
-#: ../gramps/gui/plug/_guioptions.py:905
+#: ../gramps/gen/plug/report/utils.py:362 ../gramps/gui/plug/_guioptions.py:905
 #, python-format
 msgid "%(father_name)s and %(mother_name)s (%(family_id)s)"
 msgstr "%(father_name)s és %(mother_name)s (%(family_id)s)"
@@ -10194,11 +10243,6 @@ msgstr "'%s' nem megnyitható"
 #, python-format
 msgid "Error in reading '%s'"
 msgstr "'%s' olvasási hiba"
-
-#: ../gramps/gen/plug/utils.py:316
-#, python-format
-msgid "Error: cannot open '%s'"
-msgstr "Hiba: '%s' nem megnyitható"
 
 #: ../gramps/gen/plug/utils.py:320
 #, python-format
@@ -10269,7 +10313,7 @@ msgstr ""
 "indítsa újra a GRAMPS-ot."
 
 #: ../gramps/gen/relationship.py:1273
-#: ../gramps/plugins/view/pedigreeview.py:1531
+#: ../gramps/plugins/view/pedigreeview.py:1600
 msgid "Relationship loop detected"
 msgstr "Körkapcsolatot észleltem"
 
@@ -10297,12 +10341,12 @@ msgid "undefined"
 msgstr "meghatározatlan"
 
 #: ../gramps/gen/relationship.py:2170
-#: ../gramps/plugins/importer/importcsv.py:217
+#: ../gramps/plugins/importer/importcsv.py:233
 msgid "husband"
 msgstr "férj"
 
 #: ../gramps/gen/relationship.py:2172
-#: ../gramps/plugins/importer/importcsv.py:214
+#: ../gramps/plugins/importer/importcsv.py:230
 msgid "wife"
 msgstr "feleség"
 
@@ -10320,30 +10364,6 @@ msgstr "volt feleség"
 
 #: ../gramps/gen/relationship.py:2181
 msgid "gender unknown|ex-spouse"
-msgstr "volt házastárs"
-
-#: ../gramps/gen/relationship.py:2184
-msgid "male,unmarried|partner"
-msgstr "férj"
-
-#: ../gramps/gen/relationship.py:2186
-msgid "female,unmarried|partner"
-msgstr "feleség"
-
-#: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|partner"
-msgstr "házastárs"
-
-#: ../gramps/gen/relationship.py:2191
-msgid "male,unmarried|ex-partner"
-msgstr "volt férj"
-
-#: ../gramps/gen/relationship.py:2193
-msgid "female,unmarried|ex-partner"
-msgstr "volt feleség"
-
-#: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-partner"
 msgstr "volt házastárs"
 
 #: ../gramps/gen/relationship.py:2184
@@ -10427,11 +10447,11 @@ msgstr ""
 "Családi rokonság fordító nem elérhető a(z) '%s' nyelvhez. Helyette az "
 "'angol' lesz."
 
-#: ../gramps/gen/utils/alive.py:145 ../gramps/plugins/importer/importcsv.py:201
+#: ../gramps/gen/utils/alive.py:145 ../gramps/plugins/importer/importcsv.py:202
 msgid "death date"
 msgstr "halálozási dátum"
 
-#: ../gramps/gen/utils/alive.py:150 ../gramps/plugins/importer/importcsv.py:177
+#: ../gramps/gen/utils/alive.py:150 ../gramps/plugins/importer/importcsv.py:178
 msgid "birth date"
 msgstr "születési dátum"
 
@@ -10781,10 +10801,10 @@ msgstr "Cím"
 msgid "GIVEN"
 msgstr "KERESZTNÉV"
 
-#: ../gramps/gen/utils/keyword.py:56 ../gramps/gui/configure.py:695
-#: ../gramps/gui/configure.py:702 ../gramps/gui/configure.py:704
-#: ../gramps/gui/configure.py:705 ../gramps/gui/configure.py:706
-#: ../gramps/gui/configure.py:707 ../gramps/gui/configure.py:708
+#: ../gramps/gen/utils/keyword.py:56 ../gramps/gui/configure.py:851
+#: ../gramps/gui/configure.py:858 ../gramps/gui/configure.py:860
+#: ../gramps/gui/configure.py:861 ../gramps/gui/configure.py:862
+#: ../gramps/gui/configure.py:863 ../gramps/gui/configure.py:864
 msgid "SURNAME"
 msgstr "VEZETÉKNÉV"
 
@@ -10800,9 +10820,9 @@ msgstr "Hívó"
 msgid "Name|COMMON"
 msgstr "KÖZÖS"
 
-#: ../gramps/gen/utils/keyword.py:58 ../gramps/gui/configure.py:692
-#: ../gramps/gui/configure.py:694 ../gramps/gui/configure.py:697
-#: ../gramps/gui/configure.py:698 ../gramps/gui/configure.py:704
+#: ../gramps/gen/utils/keyword.py:58 ../gramps/gui/configure.py:848
+#: ../gramps/gui/configure.py:850 ../gramps/gui/configure.py:853
+#: ../gramps/gui/configure.py:854 ../gramps/gui/configure.py:860
 msgid "Name|Common"
 msgstr "Közös"
 
@@ -10884,7 +10904,7 @@ msgstr "Apai név[con]"
 msgid "RAWSURNAMES"
 msgstr "NYERS VEZETÉKNEVEK"
 
-#: ../gramps/gen/utils/keyword.py:69 ../gramps/gui/configure.py:709
+#: ../gramps/gen/utils/keyword.py:69 ../gramps/gui/configure.py:865
 msgid "Rawsurnames"
 msgstr "Nyers vezetéknevek"
 
@@ -10932,21 +10952,21 @@ msgstr "%(east_longitude)s K"
 msgid "%(west_longitude)s W"
 msgstr "%(west_longitude)s NY"
 
-#: ../gramps/gen/utils/string.py:46 ../gramps/gui/editors/editperson.py:347
+#: ../gramps/gen/utils/string.py:46 ../gramps/gui/editors/editperson.py:341
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:94
 #: ../gramps/gui/merge/mergeperson.py:64
 #: ../gramps/gui/views/treemodels/peoplemodel.py:97
 #: ../gramps/plugins/tool/dumpgenderstats.py:46
-#: ../gramps/plugins/webreport/person.py:412
+#: ../gramps/plugins/webreport/person.py:429
 msgid "male"
 msgstr "férfi"
 
-#: ../gramps/gen/utils/string.py:47 ../gramps/gui/editors/editperson.py:346
+#: ../gramps/gen/utils/string.py:47 ../gramps/gui/editors/editperson.py:340
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:94
 #: ../gramps/gui/merge/mergeperson.py:64
 #: ../gramps/gui/views/treemodels/peoplemodel.py:97
 #: ../gramps/plugins/tool/dumpgenderstats.py:46
-#: ../gramps/plugins/webreport/person.py:413
+#: ../gramps/plugins/webreport/person.py:430
 msgid "female"
 msgstr "nő"
 
@@ -10958,21 +10978,25 @@ msgstr "ismeretlen"
 msgid "Invalid"
 msgstr "Rokkant"
 
-#: ../gramps/gen/utils/string.py:55 ../gramps/gui/editors/editcitation.py:214
+#: ../gramps/gen/utils/string.py:55 ../gramps/gui/editors/editcitation.py:216
+#: ../gramps/plugins/importer/importprogen.py:489
 msgid "Very High"
 msgstr "Nagyon magas"
 
-#: ../gramps/gen/utils/string.py:56 ../gramps/gui/editors/editcitation.py:213
+#: ../gramps/gen/utils/string.py:56 ../gramps/gui/editors/editcitation.py:215
+#: ../gramps/plugins/importer/importprogen.py:488
 #: ../gramps/plugins/tool/finddupes.py:62
 msgid "High"
 msgstr "Magas"
 
-#: ../gramps/gen/utils/string.py:58 ../gramps/gui/editors/editcitation.py:211
+#: ../gramps/gen/utils/string.py:58 ../gramps/gui/editors/editcitation.py:213
+#: ../gramps/plugins/importer/importprogen.py:486
 #: ../gramps/plugins/tool/finddupes.py:60
 msgid "Low"
 msgstr "Alacsony"
 
-#: ../gramps/gen/utils/string.py:59 ../gramps/gui/editors/editcitation.py:210
+#: ../gramps/gen/utils/string.py:59 ../gramps/gui/editors/editcitation.py:212
+#: ../gramps/plugins/importer/importprogen.py:485
 msgid "Very Low"
 msgstr "Nagyon alacsony"
 
@@ -11021,7 +11045,7 @@ msgstr ""
 "A(z) %s importált fájlból a hivatkozott feljegyzés szerinti objektumok "
 "hiányoztak."
 
-#: ../gramps/grampsapp.py:158
+#: ../gramps/grampsapp.py:172
 #, python-format
 msgid ""
 "Your Python version does not meet the requirements. At least python %(v1)d."
@@ -11034,16 +11058,16 @@ msgstr ""
 "\n"
 "A GRAMPS most leáll."
 
-#: ../gramps/grampsapp.py:414 ../gramps/grampsapp.py:421
-#: ../gramps/grampsapp.py:465
+#: ../gramps/grampsapp.py:428 ../gramps/grampsapp.py:435
+#: ../gramps/grampsapp.py:491
 msgid "Configuration error:"
 msgstr "Konfigurációs hiba:"
 
-#: ../gramps/grampsapp.py:418
+#: ../gramps/grampsapp.py:432
 msgid "Error reading configuration"
 msgstr "Konfiguráció olvasási hiba"
 
-#: ../gramps/grampsapp.py:422
+#: ../gramps/grampsapp.py:436
 #, python-format
 msgid ""
 "A definition for the MIME-type %s could not be found \n"
@@ -11128,25 +11152,25 @@ msgstr "Gyermek hivatkozás"
 msgid "%(frel)s %(mrel)s"
 msgstr "%(frel)s %(mrel)s"
 
-#: ../gramps/gui/clipboard.py:1384 ../gramps/gui/clipboard.py:1390
-#: ../gramps/gui/clipboard.py:1428 ../gramps/gui/clipboard.py:1473
+#: ../gramps/gui/clipboard.py:1357 ../gramps/gui/clipboard.py:1363
+#: ../gramps/gui/clipboard.py:1401 ../gramps/gui/clipboard.py:1446
 #: ../gramps/gui/glade/clipboard.glade:7
 msgid "Clipboard"
 msgstr "Vágólap"
 
 #. Now add more items to popup menu, if available
 #. See details (edit, etc):
-#: ../gramps/gui/clipboard.py:1520 ../gramps/gui/plug/quick/_quicktable.py:141
+#: ../gramps/gui/clipboard.py:1493 ../gramps/gui/plug/quick/_quicktable.py:141
 #, python-format
 msgid "the object|See %s details"
 msgstr "Lásd %s részleteit"
 
-#: ../gramps/gui/clipboard.py:1529 ../gramps/gui/plug/quick/_quicktable.py:149
+#: ../gramps/gui/clipboard.py:1502 ../gramps/gui/plug/quick/_quicktable.py:149
 #, python-format
 msgid "the object|Make %s active"
 msgstr "Tegye %s-t aktívvá"
 
-#: ../gramps/gui/clipboard.py:1551
+#: ../gramps/gui/clipboard.py:1524
 #, python-format
 msgid "the object|Create Filter from %s selected..."
 msgstr "Szűrő létrehozása a kiválasztott %s-bó(ő)l..."
@@ -11160,20 +11184,19 @@ msgstr "Fa nézet: a(z) \"%s\" első oszlop nem változtatható"
 msgid "Drag and drop the columns to change the order"
 msgstr "Húzd és ejtsd az oszlopokat a sorrend változtatásához"
 
-#: ../gramps/gui/columnorder.py:107 ../gramps/gui/configure.py:1615
-#: ../gramps/gui/configure.py:1637 ../gramps/gui/configure.py:1660
-#: ../gramps/gui/plug/_dialogs.py:130 ../gramps/gui/viewmanager.py:2002
-#: ../gramps/plugins/lib/maps/geography.py:1011
-#: ../gramps/plugins/lib/maps/geography.py:1266
-#: ../gramps/gui/viewmanager.py:2001
+#: ../gramps/gui/columnorder.py:107 ../gramps/gui/configure.py:1842
+#: ../gramps/gui/configure.py:1866 ../gramps/gui/configure.py:1892
+#: ../gramps/gui/plug/_dialogs.py:130 ../gramps/gui/viewmanager.py:1794
+#: ../gramps/plugins/lib/maps/geography.py:997
+#: ../gramps/plugins/lib/maps/geography.py:1294
 msgid "_Apply"
 msgstr "_Alkalmaz"
 
 #. #################
-#: ../gramps/gui/columnorder.py:128 ../gramps/gui/configure.py:1188
+#: ../gramps/gui/columnorder.py:128 ../gramps/gui/configure.py:1353
 #: ../gramps/plugins/drawreport/ancestortree.py:909
-#: ../gramps/plugins/drawreport/descendtree.py:1647
-#: ../gramps/plugins/webreport/narrativeweb.py:1698
+#: ../gramps/plugins/drawreport/descendtree.py:1652
+#: ../gramps/plugins/webreport/narrativeweb.py:1766
 msgid "Display"
 msgstr "Megjelenítés"
 
@@ -11181,46 +11204,45 @@ msgstr "Megjelenítés"
 msgid "Column Name"
 msgstr "Oszlopnév"
 
-#: ../gramps/gui/configure.py:82
+#: ../gramps/gui/configure.py:86
 msgid "Father's surname"
 msgstr "Az apa vezetékneve"
 
-#: ../gramps/gui/configure.py:84
+#: ../gramps/gui/configure.py:88
 msgid "Combination of mother's and father's surname"
 msgstr "Az anya és az apa vezetéknevének kombinációja"
 
-#: ../gramps/gui/configure.py:85
+#: ../gramps/gui/configure.py:89
 msgid "Icelandic style"
 msgstr "Izlandi stílus"
 
-#: ../gramps/gui/configure.py:107 ../gramps/gui/configure.py:108
+#: ../gramps/gui/configure.py:114 ../gramps/gui/configure.py:115
 msgid "Display Name Editor"
 msgstr "Névszerkesztő mutatása"
 
 #. self.window.connect('response', self.close)
-#: ../gramps/gui/configure.py:109 ../gramps/gui/configure.py:183
-#: ../gramps/gui/dialog.py:215 ../gramps/gui/dialog.py:261
-#: ../gramps/gui/dialog.py:287 ../gramps/gui/glade/book.glade:466
-#: ../gramps/gui/glade/book.glade:539 ../gramps/gui/glade/clipboard.glade:71
+#: ../gramps/gui/configure.py:116 ../gramps/gui/configure.py:189
+#: ../gramps/gui/dialog.py:261 ../gramps/gui/dialog.py:307
+#: ../gramps/gui/dialog.py:333 ../gramps/gui/glade/book.glade:466
+#: ../gramps/gui/glade/book.glade:556 ../gramps/gui/glade/clipboard.glade:71
 #: ../gramps/gui/glade/dialog.glade:20 ../gramps/gui/glade/dialog.glade:141
 #: ../gramps/gui/glade/displaystate.glade:23
 #: ../gramps/gui/glade/editplaceformat.glade:23
 #: ../gramps/gui/glade/plugins.glade:22 ../gramps/gui/glade/rule.glade:24
 #: ../gramps/gui/glade/rule.glade:1024 ../gramps/gui/glade/tipofday.glade:117
-#: ../gramps/gui/glade/updateaddons.glade:25 ../gramps/gui/plug/_windows.py:105
-#: ../gramps/gui/plug/_windows.py:691 ../gramps/gui/plug/_windows.py:747
+#: ../gramps/gui/glade/updateaddons.glade:25 ../gramps/gui/grampsgui.py:56
+#: ../gramps/gui/plug/_windows.py:105 ../gramps/gui/plug/_windows.py:693
+#: ../gramps/gui/plug/_windows.py:749
 #: ../gramps/gui/plug/quick/_textbufdoc.py:60 ../gramps/gui/undohistory.py:90
-#: ../gramps/gui/viewmanager.py:543 ../gramps/gui/viewmanager.py:1866
-#: ../gramps/gui/views/bookmarks.py:286 ../gramps/gui/views/tags.py:432
-#: ../gramps/gui/widgets/grampletbar.py:635
-#: ../gramps/gui/widgets/grampletpane.py:232
-#: ../gramps/plugins/lib/maps/placeselection.py:111
+#: ../gramps/gui/viewmanager.py:1657 ../gramps/gui/views/bookmarks.py:298
+#: ../gramps/gui/views/tags.py:466 ../gramps/gui/widgets/grampletbar.py:636
+#: ../gramps/gui/widgets/grampletpane.py:239
+#: ../gramps/plugins/lib/maps/placeselection.py:120
 #: ../gramps/plugins/tool/dumpgenderstats.py:85
-#: ../gramps/gui/viewmanager.py:1864
 msgid "_Close"
 msgstr "_Bezárás"
 
-#: ../gramps/gui/configure.py:112
+#: ../gramps/gui/configure.py:119
 msgid ""
 "The following keywords are replaced with the appropriate name parts:<tt>\n"
 "  <b>Given</b>   - given name (first name)     <b>Surname</b>  - surnames "
@@ -11282,397 +11304,504 @@ msgstr ""
 "cím, <i>Sr</i> utótag, <i>Ed</i> becenév, \n"
 "     <i>Underhills</i> családi bece/gúnynév, <i>Jose</i> hívó név.\n"
 
-#: ../gramps/gui/configure.py:140
+#: ../gramps/gui/configure.py:148
 msgid " Name Editor"
 msgstr " Névszerkesztő"
 
-#: ../gramps/gui/configure.py:234 ../gramps/gui/configure.py:240
-#: ../gramps/gui/configure.py:847
+#: ../gramps/gui/configure.py:242 ../gramps/gui/configure.py:248
+#: ../gramps/gui/configure.py:1007
 msgid "Invalid or incomplete format definition."
 msgstr "Hibás, vagy nem teljes formátum meghatározás."
 
 #. label for the combo
 #. translators: needed for French, ignore otherwise
-#: ../gramps/gui/configure.py:342 ../gramps/gui/configure.py:366
-#: ../gramps/gui/configure.py:387 ../gramps/gui/configure.py:403
-#: ../gramps/gui/configure.py:434 ../gramps/gui/configure.py:471
-#: ../gramps/gui/configure.py:493 ../gramps/gui/configure.py:594
-#: ../gramps/gui/configure.py:1030 ../gramps/gui/configure.py:1058
-#: ../gramps/gui/configure.py:1072 ../gramps/gui/configure.py:1107
-#: ../gramps/gui/configure.py:1121 ../gramps/gui/configure.py:1134
-#: ../gramps/gui/configure.py:1147 ../gramps/gui/configure.py:1171
-#: ../gramps/gui/configure.py:1424 ../gramps/gui/configure.py:1442
-#: ../gramps/gui/configure.py:1515 ../gramps/gui/configure.py:1570
-#: ../gramps/gui/views/navigationview.py:358
+#: ../gramps/gui/configure.py:386 ../gramps/gui/configure.py:413
+#: ../gramps/gui/configure.py:435 ../gramps/gui/configure.py:451
+#: ../gramps/gui/configure.py:482 ../gramps/gui/configure.py:519
+#: ../gramps/gui/configure.py:541 ../gramps/gui/configure.py:689
+#: ../gramps/gui/configure.py:1194 ../gramps/gui/configure.py:1222
+#: ../gramps/gui/configure.py:1240 ../gramps/gui/configure.py:1267
+#: ../gramps/gui/configure.py:1281 ../gramps/gui/configure.py:1294
+#: ../gramps/gui/configure.py:1307 ../gramps/gui/configure.py:1332
+#: ../gramps/gui/configure.py:1642 ../gramps/gui/configure.py:1660
+#: ../gramps/gui/configure.py:1743 ../gramps/gui/configure.py:1794
+#: ../gramps/gui/views/navigationview.py:343
 #: ../gramps/plugins/gramplet/sessionloggramplet.py:90
 #, python-format
 msgid "%s: "
 msgstr "%s: "
 
-#: ../gramps/gui/configure.py:533
-msgid ""
-"Enter your information so people can contact you when you distribute your "
-"Family Tree"
-msgstr ""
-"Vigye be adatait, így fel tudják venni Önnel a kapcsolatot, amikor "
-"közzéteszi a Családfáját"
+#: ../gramps/gui/configure.py:575 ../gramps/gui/editors/edittaglist.py:118
+#: ../gramps/gui/glade/addmedia.glade:55
+#: ../gramps/gui/glade/baseselector.glade:56 ../gramps/gui/glade/book.glade:498
+#: ../gramps/gui/glade/clipboard.glade:21 ../gramps/gui/glade/dbman.glade:150
+#: ../gramps/gui/glade/editaddress.glade:55
+#: ../gramps/gui/glade/editattribute.glade:54
+#: ../gramps/gui/glade/editchildref.glade:58
+#: ../gramps/gui/glade/editcitation.glade:27
+#: ../gramps/gui/glade/editdate.glade:53 ../gramps/gui/glade/editevent.glade:58
+#: ../gramps/gui/glade/editeventref.glade:22
+#: ../gramps/gui/glade/editfamily.glade:60
+#: ../gramps/gui/glade/editldsord.glade:75
+#: ../gramps/gui/glade/editlink.glade:58
+#: ../gramps/gui/glade/editlocation.glade:54
+#: ../gramps/gui/glade/editmedia.glade:55
+#: ../gramps/gui/glade/editmediaref.glade:75
+#: ../gramps/gui/glade/editname.glade:59 ../gramps/gui/glade/editnote.glade:53
+#: ../gramps/gui/glade/editperson.glade:82
+#: ../gramps/gui/glade/editpersonref.glade:57
+#: ../gramps/gui/glade/editplace.glade:52
+#: ../gramps/gui/glade/editplacename.glade:55
+#: ../gramps/gui/glade/editplaceref.glade:22
+#: ../gramps/gui/glade/editreporef.glade:61
+#: ../gramps/gui/glade/editrepository.glade:59
+#: ../gramps/gui/glade/editsource.glade:58 ../gramps/gui/glade/editurl.glade:57
+#: ../gramps/gui/glade/mergecitation.glade:53
+#: ../gramps/gui/glade/mergedata.glade:77
+#: ../gramps/gui/glade/mergedata.glade:278
+#: ../gramps/gui/glade/mergedata.glade:468
+#: ../gramps/gui/glade/mergedata.glade:698
+#: ../gramps/gui/glade/mergeevent.glade:53
+#: ../gramps/gui/glade/mergefamily.glade:53
+#: ../gramps/gui/glade/mergemedia.glade:53
+#: ../gramps/gui/glade/mergenote.glade:53
+#: ../gramps/gui/glade/mergeperson.glade:53
+#: ../gramps/gui/glade/mergeplace.glade:51
+#: ../gramps/gui/glade/mergerepository.glade:53
+#: ../gramps/gui/glade/mergesource.glade:53
+#: ../gramps/gui/glade/reorder.glade:54 ../gramps/gui/glade/rule.glade:41
+#: ../gramps/gui/glade/rule.glade:351 ../gramps/gui/glade/rule.glade:781
+#: ../gramps/gui/grampsgui.py:56 ../gramps/gui/logger/_errorview.py:175
+#: ../gramps/gui/plug/report/_reportdialog.py:159
+#: ../gramps/gui/undohistory.py:82 ../gramps/gui/views/bookmarks.py:299
+#: ../gramps/gui/views/tags.py:467 ../gramps/gui/views/tags.py:681
+#: ../gramps/gui/widgets/grampletbar.py:642
+#: ../gramps/gui/widgets/grampletpane.py:244
+#: ../gramps/plugins/importer/importprogen.glade:1749
+#: ../gramps/plugins/tool/testcasegenerator.py:329
+msgid "_Help"
+msgstr "_Súgó"
 
-#: ../gramps/gui/configure.py:540
+#: ../gramps/gui/configure.py:597
+msgid "Researcher information"
+msgstr "Kutató információ"
+
+#: ../gramps/gui/configure.py:602
+msgid ""
+"Enter information about yourself so people can contact you when you "
+"distribute your Family Tree"
+msgstr ""
+"Vigye be saját adatait, így mások fel tudják venni Önnel a kapcsolatot, "
+"amikor közzéteszi a Családfáját"
+
+#: ../gramps/gui/configure.py:617
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:75
 #: ../gramps/plugins/view/repoview.py:92
 msgid "State/County"
 msgstr "Állam/Tartomány"
 
-#: ../gramps/gui/configure.py:542 ../gramps/plugins/view/repoview.py:94
+#: ../gramps/gui/configure.py:623 ../gramps/plugins/view/repoview.py:94
 msgid "ZIP/Postal Code"
 msgstr "Irányítószám"
 
-#: ../gramps/gui/configure.py:544 ../gramps/gui/plug/_windows.py:623
+#: ../gramps/gui/configure.py:628 ../gramps/gui/plug/_windows.py:625
 #: ../gramps/plugins/view/repoview.py:95
 msgid "Email"
 msgstr "E-mail"
 
-#: ../gramps/gui/configure.py:545
+#: ../gramps/gui/configure.py:629
 msgid "Researcher"
 msgstr "Kutató"
 
-#: ../gramps/gui/configure.py:565 ../gramps/gui/editors/editperson.py:646
-#: ../gramps/gui/widgets/photo.py:86
+#: ../gramps/gui/configure.py:638
+msgid "Gramps ID format settings"
+msgstr "GRAMPS azonosító formátum beállítások"
+
+#: ../gramps/gui/configure.py:658 ../gramps/gui/editors/editperson.py:641
+#: ../gramps/gui/widgets/photo.py:87
 msgid "Media Object"
 msgstr "Média objektum"
 
-#: ../gramps/gui/configure.py:573
+#: ../gramps/gui/configure.py:669
 msgid "ID Formats"
 msgstr "Azonosító formátumok"
 
-#: ../gramps/gui/configure.py:583
-msgid "Set the colors used for boxes in the graphical views"
-msgstr "Állítsa be grafikus nézetekhez a dobozok színeit"
+#: ../gramps/gui/configure.py:677
+msgid "Colors used for boxes in the graphical views"
+msgstr "A grafikus nézetek dobozaihoz használt színek"
 
-#: ../gramps/gui/configure.py:588
+#: ../gramps/gui/configure.py:683
 msgid "Light colors"
 msgstr "Világos színek"
 
-#: ../gramps/gui/configure.py:589
+#: ../gramps/gui/configure.py:684
 msgid "Dark colors"
 msgstr "Sötét színek"
 
-#: ../gramps/gui/configure.py:594
+#: ../gramps/gui/configure.py:689
 msgid "Color scheme"
 msgstr "Szín rendszer"
 
-#: ../gramps/gui/configure.py:598
+#: ../gramps/gui/configure.py:693
 msgid "Restore to defaults"
 msgstr "Alaphelyzetbe állítás"
 
-#: ../gramps/gui/configure.py:604
-msgid "Male Alive"
-msgstr "Élő férfi"
+#: ../gramps/gui/configure.py:695
+msgid "Restore colors for current theme to default."
+msgstr "A jelenlegi téma színeinek visszaállítása az alapértelmezettekre."
 
-#: ../gramps/gui/configure.py:605
-msgid "Male Dead"
-msgstr "Halott férfi"
+#: ../gramps/gui/configure.py:701
+msgid "Colors for Male persons"
+msgstr "Színek férfiakhoz"
 
-#: ../gramps/gui/configure.py:606
-msgid "Female Alive"
-msgstr "Élő nő"
+#: ../gramps/gui/configure.py:702
+msgid "Colors for Female persons"
+msgstr "Színek nőkhöz"
 
-#: ../gramps/gui/configure.py:607
-msgid "Female Dead"
-msgstr "Halott nő"
+#: ../gramps/gui/configure.py:703
+msgid "Colors for Unknown persons"
+msgstr "Színek ismeretlenekhez"
 
-#: ../gramps/gui/configure.py:608
-msgid "Unknown Alive"
-msgstr "Élő ismeretlen"
+#: ../gramps/gui/configure.py:704
+msgid "Colors for Family nodes"
+msgstr "Színek Család-csomópontokhoz"
 
-#: ../gramps/gui/configure.py:609
-msgid "Unknown Dead"
-msgstr "Halott ismeretlen"
+#: ../gramps/gui/configure.py:705
+msgid "Other colors"
+msgstr "Egyéb színek"
 
-#: ../gramps/gui/configure.py:610
-msgid "Family Node"
-msgstr "Család csomópont"
+#: ../gramps/gui/configure.py:707
+msgid "Background for Alive"
+msgstr "Élők háttere"
 
-#: ../gramps/gui/configure.py:611
-msgid "Family Divorced"
-msgstr "Elvált családok"
+#: ../gramps/gui/configure.py:708
+msgid "Background for Dead"
+msgstr "Holtak háttere"
 
-#: ../gramps/gui/configure.py:612
-msgid "Home Person"
-msgstr "Kiinduló személy"
+#: ../gramps/gui/configure.py:709
+msgid "Border for Alive"
+msgstr "Élők kerete"
 
-#: ../gramps/gui/configure.py:613
-msgid "Border Male Alive"
-msgstr "Élő férfi kerete"
+#: ../gramps/gui/configure.py:710
+msgid "Border for Dead"
+msgstr "Holtak kerete"
 
-#: ../gramps/gui/configure.py:614
-msgid "Border Male Dead"
-msgstr "Halott férfi kerete"
+#. for family
+#: ../gramps/gui/configure.py:730
+msgid "Default background"
+msgstr "Alapértelmezett háttér"
 
-#: ../gramps/gui/configure.py:615
-msgid "Border Female Alive"
-msgstr "Élő nő kerete"
+#: ../gramps/gui/configure.py:731
+msgid "Background for Married"
+msgstr "Házasok háttere"
 
-#: ../gramps/gui/configure.py:616
-msgid "Border Female Dead"
-msgstr "Halott nő kerete"
+#: ../gramps/gui/configure.py:732
+msgid "Background for Unmarried"
+msgstr "Nem házasok háttere"
 
-#: ../gramps/gui/configure.py:617
-msgid "Border Unknown Alive"
-msgstr "Élő ismeretlen kerete"
+#: ../gramps/gui/configure.py:734
+msgid "Background for Civil union"
+msgstr "Élettársi kapcsolat háttere"
 
-#: ../gramps/gui/configure.py:618
-msgid "Border Unknown Dead"
-msgstr "Ismeretlen halott kerete"
+#: ../gramps/gui/configure.py:736
+msgid "Background for Unknown"
+msgstr "Ismeretlen háttere"
 
-#: ../gramps/gui/configure.py:619
-msgid "Border Family"
-msgstr "Család kerete"
+#: ../gramps/gui/configure.py:737
+msgid "Background for Divorced"
+msgstr "Elváltak háttere"
 
-#: ../gramps/gui/configure.py:620
-msgid "Border Family Divorced"
-msgstr "Elvált család kerete"
+#: ../gramps/gui/configure.py:738
+msgid "Default border"
+msgstr "Alapértelmezett kerete"
 
-#: ../gramps/gui/configure.py:628
+#: ../gramps/gui/configure.py:739
+msgid "Border for Divorced"
+msgstr "Elváltak kerete"
+
+#. for other
+#: ../gramps/gui/configure.py:742
+msgid "Background for Home Person"
+msgstr "Kiinduló személy háttere"
+
+#: ../gramps/gui/configure.py:761
+#, python-format
+msgid "<b>%s</b>"
+msgstr "<b>%s</b>"
+
+#: ../gramps/gui/configure.py:774
 msgid "Colors"
 msgstr "Színek"
 
-#: ../gramps/gui/configure.py:647
-msgid "Suppress warning when adding parents to a child."
-msgstr "Figyelmeztetés tiltása, ha gyermekhez adunk szülőket."
+#: ../gramps/gui/configure.py:794
+msgid "Warnings and Error dialogs"
+msgstr "Figyelmeztető és Hiba üzenetek"
 
-#: ../gramps/gui/configure.py:651
-msgid "Suppress warning when canceling with changed data."
-msgstr "Figyelmeztetés tiltása, ha változtatott adatokkal szakítunk meg."
+#: ../gramps/gui/configure.py:800
+msgid "Suppress warning when adding parents to a child"
+msgstr "Figyelmeztetés tiltása, ha szülőket adunk gyermekhez"
 
-#: ../gramps/gui/configure.py:655
-msgid "Suppress warning about missing researcher when exporting to GEDCOM."
+#: ../gramps/gui/configure.py:804
+msgid "Suppress warning when canceling with changed data"
+msgstr "Figyelmeztetés tiltása, ha változtatott adatokkal szakítunk meg"
+
+#: ../gramps/gui/configure.py:808
+msgid "Suppress warning about missing researcher when exporting to GEDCOM"
 msgstr ""
-"Figyelmeztetés tiltása hiányzó kutató esetén, amikor GEDCOM-ba exportálunk."
+"Figyelmeztetés tiltása hiányzó kutató esetén, amikor GEDCOM-ba exportálunk"
 
-#: ../gramps/gui/configure.py:660
-msgid "Show plugin status dialog on plugin load error."
-msgstr "Beépülő állapot párbeszéd ablak, vagy beépülő betöltés hiba mutatása."
+#: ../gramps/gui/configure.py:813
+msgid "Show plugin status dialog on plugin load error"
+msgstr "Beépülő állapot párbeszéd ablak mutatása beépülő betöltés hiba esetén"
 
-#: ../gramps/gui/configure.py:663
+#: ../gramps/gui/configure.py:816
 msgid "Warnings"
 msgstr "Figyelmeztetések"
 
-#: ../gramps/gui/configure.py:689 ../gramps/gui/configure.py:703
+#: ../gramps/gui/configure.py:845 ../gramps/gui/configure.py:859
 msgid "Common"
 msgstr "Közös"
 
-#: ../gramps/gui/configure.py:696 ../gramps/plugins/export/exportcsv.py:355
-#: ../gramps/plugins/importer/importcsv.py:164
+#: ../gramps/gui/configure.py:852 ../gramps/plugins/export/exportcsv.py:355
+#: ../gramps/plugins/importer/importcsv.py:165
 msgid "Call"
 msgstr "Hívó"
 
-#: ../gramps/gui/configure.py:701
+#: ../gramps/gui/configure.py:857
 msgid "NotPatronymic"
 msgstr "Nem apai név"
 
-#: ../gramps/gui/configure.py:778
+#: ../gramps/gui/configure.py:935
 msgid "Enter to save, Esc to cancel editing"
 msgstr "Üssön Enter-t mentéshez, Esc-t a szerkesztés megszakításához"
 
-#: ../gramps/gui/configure.py:825
+#: ../gramps/gui/configure.py:984
 msgid "This format exists already."
 msgstr "Ez a formátum már létezik."
 
-#: ../gramps/gui/configure.py:874
+#: ../gramps/gui/configure.py:1033
 msgid "Example"
 msgstr "Példa"
 
 #. show an add button
 #. we now construct an add menu
-#: ../gramps/gui/configure.py:894
+#: ../gramps/gui/configure.py:1054
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:147
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:154
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:314
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:127
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:129
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:122
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:129
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:115
-#: ../gramps/gui/editors/editfamily.py:148
-#: ../gramps/gui/plug/report/_bookdialog.py:653
-#: ../gramps/gui/viewmanager.py:605 ../gramps/gui/views/tags.py:424
-#: ../gramps/gui/widgets/fanchart.py:1749
-#: ../gramps/gui/widgets/fanchart.py:1791
-#: ../gramps/plugins/view/pedigreeview.py:1628
+#: ../gramps/gui/editors/editfamily.py:195 ../gramps/gui/grampsgui.py:56
+#: ../gramps/gui/plug/report/_bookdialog.py:665 ../gramps/gui/views/tags.py:458
+#: ../gramps/gui/widgets/fanchart.py:2028
+#: ../gramps/gui/widgets/fanchart.py:2070
+#: ../gramps/plugins/view/pedigreeview.py:1703
 msgid "_Add"
 msgstr "_Hozzáadás"
 
-#: ../gramps/gui/configure.py:897
+#: ../gramps/gui/configure.py:1057
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:149
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:155
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:315
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:129
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:131
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:123
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:130
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:116
-#: ../gramps/gui/glade/editlink.glade:222
-#: ../gramps/gui/plug/report/_bookdialog.py:627
-#: ../gramps/gui/viewmanager.py:518 ../gramps/gui/views/tags.py:425
-#: ../gramps/gui/widgets/fanchart.py:1546
-#: ../gramps/plugins/view/pedigreeview.py:1663
-#: ../gramps/plugins/view/pedigreeview.py:1891
+#: ../gramps/gui/glade/editlink.glade:222 ../gramps/gui/grampsgui.py:56
+#: ../gramps/gui/plug/report/_bookdialog.py:639 ../gramps/gui/views/tags.py:459
+#: ../gramps/gui/widgets/fanchart.py:1817
+#: ../gramps/plugins/view/pedigreeview.py:1738
+#: ../gramps/plugins/view/pedigreeview.py:1966
 msgid "_Edit"
 msgstr "_Szerkesztés"
 
-#: ../gramps/gui/configure.py:901
+#: ../gramps/gui/configure.py:1061
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:150
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:156
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:130
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:132
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:124
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:117
-#: ../gramps/gui/editors/editfamily.py:151
-#: ../gramps/gui/plug/report/_bookdialog.py:622
-#: ../gramps/gui/views/bookmarks.py:282 ../gramps/gui/views/tags.py:426
+#: ../gramps/gui/editors/editfamily.py:198
+#: ../gramps/gui/plug/report/_bookdialog.py:634
+#: ../gramps/gui/views/bookmarks.py:294 ../gramps/gui/views/tags.py:460
 msgid "_Remove"
 msgstr "_Eltávolítás"
 
-#: ../gramps/gui/configure.py:1034 ../gramps/gui/configure.py:1076
+#: ../gramps/gui/configure.py:1153
+msgid "Appearance and format settings"
+msgstr "Megjelenítés és formátum beállítások"
+
+#: ../gramps/gui/configure.py:1198 ../gramps/gui/configure.py:1237
 #: ../gramps/gui/editors/displaytabs/buttontab.py:71
 #: ../gramps/gui/glade/editfamily.glade:286
 #: ../gramps/gui/glade/editfamily.glade:594
 #: ../gramps/gui/glade/editperson.glade:12
 #: ../gramps/gui/glade/editperson.glade:516 ../gramps/gui/glade/rule.glade:463
-#: ../gramps/gui/glade/styleeditor.glade:1871
+#: ../gramps/gui/glade/styleeditor.glade:1903
 #: ../gramps/gui/plug/_windows.py:152 ../gramps/gui/plug/_windows.py:207
 #: ../gramps/plugins/gramplet/coordinates.py:142
 #: ../gramps/plugins/gramplet/descendant.py:110
 msgid "Edit"
 msgstr "Szerkesztés"
 
-#: ../gramps/gui/configure.py:1044
+#: ../gramps/gui/configure.py:1208
 msgid "Consider single pa/matronymic as surname"
 msgstr "Tekintse az apai/anyai nevet vezetéknévnek"
 
-#: ../gramps/gui/configure.py:1085
-msgid "Enable automatic place title generation"
-msgstr "Az automatikus helynév létrehozás bekapcsolása"
+#: ../gramps/gui/configure.py:1240
+msgid "Place format (auto place title)"
+msgstr "Hely formátum (automatikus helycím)"
 
-#: ../gramps/gui/configure.py:1094
+#: ../gramps/gui/configure.py:1243
+msgid "Enables automatic place title generation using specifed format."
+msgstr ""
+"Az automatikus helynév létrehozás bekapcsolása meghatározott formátumban."
+
+#: ../gramps/gui/configure.py:1254
 msgid "Years"
 msgstr "Évek"
 
-#: ../gramps/gui/configure.py:1095
+#: ../gramps/gui/configure.py:1255
 msgid "Years, Months"
 msgstr "Évek, Hónapok"
 
-#: ../gramps/gui/configure.py:1096
+#: ../gramps/gui/configure.py:1256
 msgid "Years, Months, Days"
 msgstr "Évek, Hónapok, Napok"
 
-#: ../gramps/gui/configure.py:1108
+#: ../gramps/gui/configure.py:1268
 msgid "Age display precision (requires restart)"
 msgstr "Kort szabatosan mutat (újraindítást igényel)"
 
-#: ../gramps/gui/configure.py:1121
+#: ../gramps/gui/configure.py:1281
 msgid "Calendar on reports"
 msgstr "Naptár a jelentéseken"
 
-#: ../gramps/gui/configure.py:1134
+#: ../gramps/gui/configure.py:1294
 msgid "Surname guessing"
 msgstr "Becsült vezetéknév"
 
-#: ../gramps/gui/configure.py:1147
+#: ../gramps/gui/configure.py:1307
 msgid "Default family relationship"
 msgstr "Alapértelmezett családi kapcsolat"
 
-#: ../gramps/gui/configure.py:1154
+#: ../gramps/gui/configure.py:1314
 msgid "Height multiple surname box (pixels)"
 msgstr "Többszörös vezetéknév doboz magassága (pixelben)"
 
-#: ../gramps/gui/configure.py:1161
+#: ../gramps/gui/configure.py:1321
 msgid "Active person's name and ID"
 msgstr "Aktív személy neve és azonosítója"
 
-#: ../gramps/gui/configure.py:1162
+#: ../gramps/gui/configure.py:1322
 #: ../gramps/plugins/textreport/indivcomplete.py:370
 msgid "Relationship to home person"
 msgstr "Kapcsolat a kiinduló személyhez"
 
-#: ../gramps/gui/configure.py:1171
+#: ../gramps/gui/configure.py:1332
 msgid "Status bar"
 msgstr "Állapotsor"
 
-#: ../gramps/gui/configure.py:1178
+#: ../gramps/gui/configure.py:1339
 msgid "Show text label beside Navigator buttons (requires restart)"
 msgstr "Feliratok mutatása az oldalsáv gombok mellett (újraindítást igényel)"
 
-#: ../gramps/gui/configure.py:1184
+#: ../gramps/gui/configure.py:1342
+msgid ""
+"Show or hide text beside Navigator buttons (People, Families, Events...).\n"
+"Requires Gramps restart to apply."
+msgstr ""
+"Feliratok mutatása a vezérlő gombok mellett (Emberek, Családok, "
+"Események...).\n"
+"A GRAMPS újraindítását igényli."
+
+#: ../gramps/gui/configure.py:1348
 msgid "Show close button in gramplet bar tabs"
 msgstr "Mutassa a bezáró gombot a gramplet sáv füleken"
 
-#: ../gramps/gui/configure.py:1204
+#: ../gramps/gui/configure.py:1351
+msgid "Show close button to simplify removing gramplets from bars."
+msgstr ""
+"Mutasson bezáró gombot egyszerűsítendő a grampletek eltávolítását a sávokról."
+
+#: ../gramps/gui/configure.py:1370
+msgid "Default text used for conditions"
+msgstr "Alapértelmezett szöveg az állapotokhoz."
+
+#: ../gramps/gui/configure.py:1375
 msgid "Missing surname"
 msgstr "Hiányzó vezetéknév"
 
-#: ../gramps/gui/configure.py:1207
+#: ../gramps/gui/configure.py:1378
 msgid "Missing given name"
 msgstr "Hiányzó keresztnév"
 
-#: ../gramps/gui/configure.py:1210
+#: ../gramps/gui/configure.py:1381
 msgid "Missing record"
 msgstr "Hiányzó okmány"
 
-#: ../gramps/gui/configure.py:1213
+#: ../gramps/gui/configure.py:1384
 msgid "Private surname"
 msgstr "Bizalmas vezetéknév"
 
-#: ../gramps/gui/configure.py:1217
+#: ../gramps/gui/configure.py:1388
 msgid "Private given name"
 msgstr "Bizalmas keresztnév"
 
-#: ../gramps/gui/configure.py:1221
+#: ../gramps/gui/configure.py:1392
 msgid "Private record"
 msgstr "Bizalmas okmány"
 
-#: ../gramps/gui/configure.py:1286
+#: ../gramps/gui/configure.py:1461
 msgid "Change is not immediate"
 msgstr "A változás nem azonnali"
 
-#: ../gramps/gui/configure.py:1287
+#: ../gramps/gui/configure.py:1462
 msgid ""
 "Changing the date format will not take effect until the next time Gramps is "
 "started."
 msgstr ""
 "A dátum formátum megváltoztatása nem lép életbe a GRAMPS újraindításáig."
 
-#: ../gramps/gui/configure.py:1306
+#: ../gramps/gui/configure.py:1487
+msgid "Dates settings used for calculation operations"
+msgstr "Dátum beállítások a számolási műveletekhez"
+
+#: ../gramps/gui/configure.py:1493
 msgid "Date about range"
 msgstr "Dátum a tartomány körül"
 
-#: ../gramps/gui/configure.py:1309
+#: ../gramps/gui/configure.py:1497
 msgid "Date after range"
 msgstr "Dátum a tartomány után"
 
-#: ../gramps/gui/configure.py:1312
+#: ../gramps/gui/configure.py:1501
 msgid "Date before range"
 msgstr "Dátum a tartomány előtt"
 
-#: ../gramps/gui/configure.py:1315
+#: ../gramps/gui/configure.py:1505
 msgid "Maximum age probably alive"
 msgstr "A valószínűleg élő legidősebbje"
 
-#: ../gramps/gui/configure.py:1318
+#: ../gramps/gui/configure.py:1509
 msgid "Maximum sibling age difference"
 msgstr "A legnagyobb korkülönbség testvérek között"
 
-#: ../gramps/gui/configure.py:1321
+#: ../gramps/gui/configure.py:1513
 msgid "Minimum years between generations"
 msgstr "A legtöbb év generációk között"
 
-#: ../gramps/gui/configure.py:1324
+#: ../gramps/gui/configure.py:1517
 msgid "Average years between generations"
 msgstr "Generációk közötti évek átlaga"
 
-#: ../gramps/gui/configure.py:1327
+#: ../gramps/gui/configure.py:1521
 msgid "Markup for invalid date format"
 msgstr "Hibás dátumformátum jelölése"
 
-#: ../gramps/gui/configure.py:1330
+#: ../gramps/gui/configure.py:1525
 #, python-format
 msgid ""
 "Convenience markups are:\n"
@@ -11703,29 +11832,45 @@ msgstr ""
 "Például: &lt;u&gt;&lt;b&gt;%s&lt;/b&gt;&lt;/u&gt;\n"
 " <u><b>aláhúzott félkövér dátum</b></u>ot fog mutatni.\n"
 
-#: ../gramps/gui/configure.py:1344
+#: ../gramps/gui/configure.py:1540
 msgid "Dates"
 msgstr "Dátumok"
 
-#: ../gramps/gui/configure.py:1355
+#: ../gramps/gui/configure.py:1548
+msgid "General Gramps settings"
+msgstr "Általános GRAMPS beállítások"
+
+#: ../gramps/gui/configure.py:1555
 msgid "Use alternate Font handler for GUI and Reports (requires restart)"
 msgstr ""
 "Váltakozó Betűkészlet-kezelő használata GUI-hoz és Összesítőkhöz "
 "(újraindítást igényel)"
 
-#: ../gramps/gui/configure.py:1361
+#: ../gramps/gui/configure.py:1558
+msgid "Can help to fix problems with fonts."
+msgstr "Segíthet megoldani a betűtípusok problémáit."
+
+#: ../gramps/gui/configure.py:1561
 msgid "Add default source on GEDCOM import"
 msgstr "Alapértelmezett forrás hozzáadása a GEDCOM importhoz"
 
-#: ../gramps/gui/configure.py:1365
+#: ../gramps/gui/configure.py:1580
 msgid "Add tag on import"
 msgstr "Címke hozzáadása az importhoz"
 
-#: ../gramps/gui/configure.py:1376
+#: ../gramps/gui/configure.py:1583
+msgid ""
+"Specifed tag will be added on import.\n"
+"Clear to set default value."
+msgstr ""
+"Importnál meghatározott felirat lesz hozzáadva.\n"
+"Alapértelmezett értékhez törölje."
+
+#: ../gramps/gui/configure.py:1588
 msgid "Enable spelling checker"
 msgstr "Helyesírás-ellenőrző bekapcsolása"
 
-#: ../gramps/gui/configure.py:1385
+#: ../gramps/gui/configure.py:1597
 #, python-format
 msgid ""
 "GtkSpell not loaded. Spell checking will not be available.\n"
@@ -11734,156 +11879,186 @@ msgstr ""
 "A GtkSpell nincs betöltve. Helyesírás ellenőrzés nem lehetséges.\n"
 "Felépítését a GRAMPS-hoz lásd: %(gramps_wiki_build_spell_url)s"
 
-#: ../gramps/gui/configure.py:1392
+#: ../gramps/gui/configure.py:1603
 msgid "Display Tip of the Day"
 msgstr "A nap tippjének mutatása"
 
-#: ../gramps/gui/configure.py:1397
+#: ../gramps/gui/configure.py:1605
+msgid "Show useful information about using Gramps on startup."
+msgstr "GRAMPS indításakor hasznos információk mutatása."
+
+#: ../gramps/gui/configure.py:1608
 msgid "Remember last view displayed"
 msgstr "Emlékezzen az utolsó nézetre"
 
-#: ../gramps/gui/configure.py:1402
+#: ../gramps/gui/configure.py:1610
+msgid "Remember last view displayed and open it next time."
+msgstr "Emlékezzen az utolsó nézetre és legközelebb így nyissa meg."
+
+#: ../gramps/gui/configure.py:1613
 msgid "Max generations for relationships"
 msgstr "Kapcsolatok legnagyobb generációja"
 
-#: ../gramps/gui/configure.py:1408
+#: ../gramps/gui/configure.py:1619
 msgid "Base path for relative media paths"
 msgstr "Relatív média útvonalak alap útvonala"
 
-#: ../gramps/gui/configure.py:1416
+#: ../gramps/gui/configure.py:1625
+msgid "Third party addons management"
+msgstr "Harmadik féltől származó beépülők kezelése"
+
+#: ../gramps/gui/configure.py:1634
 msgid "Once a month"
 msgstr "Egyszer egy hónapban"
 
-#: ../gramps/gui/configure.py:1417
+#: ../gramps/gui/configure.py:1635
 msgid "Once a week"
 msgstr "Egyszer egy héten"
 
-#: ../gramps/gui/configure.py:1418
+#: ../gramps/gui/configure.py:1636
 msgid "Once a day"
 msgstr "Egyszer egy nap"
 
-#: ../gramps/gui/configure.py:1419
+#: ../gramps/gui/configure.py:1637
 msgid "Always"
 msgstr "Mindig"
 
-#: ../gramps/gui/configure.py:1424
+#: ../gramps/gui/configure.py:1642
 msgid "Check for addon updates"
 msgstr "Frissített bővítmények keresése"
 
-#: ../gramps/gui/configure.py:1430
+#: ../gramps/gui/configure.py:1648
 msgid "Updated addons only"
 msgstr "Csak a frissített bővítményeket"
 
-#: ../gramps/gui/configure.py:1431
+#: ../gramps/gui/configure.py:1649
 msgid "New addons only"
 msgstr "Csak az új bővítményeket"
 
-#: ../gramps/gui/configure.py:1432
+#: ../gramps/gui/configure.py:1650
 msgid "New and updated addons"
 msgstr "Új és frissített bővítmények"
 
-#: ../gramps/gui/configure.py:1442
+#: ../gramps/gui/configure.py:1660
 msgid "What to check"
 msgstr "Mit ellenőrizzen"
 
-#: ../gramps/gui/configure.py:1447
+#: ../gramps/gui/configure.py:1665
 msgid "Where to check"
 msgstr "Hol ellenőrizzen"
 
-#: ../gramps/gui/configure.py:1451
+#: ../gramps/gui/configure.py:1670
 msgid "Do not ask about previously notified addons"
 msgstr "Ne kérdezzen a korábban értesített bővítményekről"
 
-#: ../gramps/gui/configure.py:1456
+#: ../gramps/gui/configure.py:1675
 msgid "Check for updated addons now"
 msgstr "Frissített bővítmények keresése most"
 
-#: ../gramps/gui/configure.py:1466
+#: ../gramps/gui/configure.py:1687
 msgid "Checking Addons Failed"
 msgstr "A Beépülők ellenőrzése meghiúsult"
 
-#: ../gramps/gui/configure.py:1467
+#: ../gramps/gui/configure.py:1688
 msgid "The addon repository appears to be unavailable. Please try again later."
 msgstr "A beépülő tároló úgy tűnik nem elérhető. Kérem próbálja meg később."
 
-#: ../gramps/gui/configure.py:1480
+#: ../gramps/gui/configure.py:1701
 msgid "There are no available addons of this type"
 msgstr "Nincsenek ilyen típusú elérhető bővítmények"
 
-#: ../gramps/gui/configure.py:1481
+#: ../gramps/gui/configure.py:1702
 #, python-format
 msgid "Checked for '%s'"
 msgstr "Ellenőrzött '%s'-re"
 
-#: ../gramps/gui/configure.py:1482
+#: ../gramps/gui/configure.py:1703
 msgid "' and '"
 msgstr "' és '"
 
 #. List of translated strings used here
 #. Dead code for l10n
-#: ../gramps/gui/configure.py:1487
+#: ../gramps/gui/configure.py:1708
 msgid "new"
 msgstr "új"
 
-#: ../gramps/gui/configure.py:1487
+#: ../gramps/gui/configure.py:1708
 msgid "update"
 msgstr "frissítés"
 
-#: ../gramps/gui/configure.py:1515
+#: ../gramps/gui/configure.py:1737
+msgid "Family tree database settings and Backup management"
+msgstr "Családfa adatbázis beállítások és Mentés kezelése"
+
+#: ../gramps/gui/configure.py:1743
 msgid "Database backend"
 msgstr "Adatbázis háttér"
 
-#: ../gramps/gui/configure.py:1522
+#: ../gramps/gui/configure.py:1750
 msgid "Host"
 msgstr "Gazda"
 
-#: ../gramps/gui/configure.py:1526
+#: ../gramps/gui/configure.py:1755
 msgid "Port"
 msgstr "Port"
 
-#: ../gramps/gui/configure.py:1534
+#: ../gramps/gui/configure.py:1763
 msgid "Family Tree Database path"
 msgstr "Családfa adatbázis útvonal"
 
-#: ../gramps/gui/configure.py:1543
+#: ../gramps/gui/configure.py:1767
 msgid "Automatically load last Family Tree"
 msgstr "Automatikusan töltse be a legutóbbi Családfát"
 
-#: ../gramps/gui/configure.py:1549
+#: ../gramps/gui/configure.py:1769
+msgid ""
+"Don't open dialog to choose family tree to load on startup, just load last "
+"used."
+msgstr ""
+"Ne nyisson meg párbeszéd ablakot családfa választáshoz induláskor, töltse be "
+"a legutóbbit."
+
+#: ../gramps/gui/configure.py:1774
 msgid "Backup path"
 msgstr "Mentés útvonal"
 
-#: ../gramps/gui/configure.py:1556
+#: ../gramps/gui/configure.py:1779
 msgid "Backup on exit"
 msgstr "Mentés kilépéskor"
 
-#: ../gramps/gui/configure.py:1563
+#: ../gramps/gui/configure.py:1781
+msgid "Backup Your family tree on exit to Backup path specified above."
+msgstr ""
+"Családfájának biztonsági mentése kilépéskor a fent meghatározott Biztonsági "
+"mentés útvonalon."
+
+#: ../gramps/gui/configure.py:1787
 msgid "Every 15 minutes"
 msgstr "Minden 15 perc"
 
-#: ../gramps/gui/configure.py:1564
+#: ../gramps/gui/configure.py:1788
 msgid "Every 30 minutes"
 msgstr "Minden 30 perc"
 
-#: ../gramps/gui/configure.py:1565
+#: ../gramps/gui/configure.py:1789
 msgid "Every hour"
 msgstr "Minden óra"
 
-#: ../gramps/gui/configure.py:1570
+#: ../gramps/gui/configure.py:1794
 msgid "Autobackup"
 msgstr "Automentés"
 
-#: ../gramps/gui/configure.py:1610
+#: ../gramps/gui/configure.py:1837
 msgid "Select media directory"
 msgstr "A média könyvtár kiválasztása"
 
-#: ../gramps/gui/configure.py:1613 ../gramps/gui/configure.py:1636
-#: ../gramps/gui/configure.py:1658 ../gramps/gui/dbloader.py:422
-#: ../gramps/gui/dbloader.py:456 ../gramps/gui/editors/edittaglist.py:119
+#: ../gramps/gui/configure.py:1840 ../gramps/gui/configure.py:1865
+#: ../gramps/gui/configure.py:1890 ../gramps/gui/dbloader.py:401
+#: ../gramps/gui/dbloader.py:435 ../gramps/gui/editors/edittaglist.py:119
 #: ../gramps/gui/glade/addmedia.glade:22
 #: ../gramps/gui/glade/baseselector.glade:24
 #: ../gramps/gui/glade/configure.glade:23 ../gramps/gui/glade/dialog.glade:417
-#: ../gramps/gui/glade/dialog.glade:701 ../gramps/gui/glade/dialog.glade:842
+#: ../gramps/gui/glade/dialog.glade:714 ../gramps/gui/glade/dialog.glade:856
 #: ../gramps/gui/glade/editaddress.glade:21
 #: ../gramps/gui/glade/editattribute.glade:21
 #: ../gramps/gui/glade/editchildref.glade:22
@@ -11901,7 +12076,7 @@ msgstr "A média könyvtár kiválasztása"
 #: ../gramps/gui/glade/editpersonref.glade:21
 #: ../gramps/gui/glade/editplace.glade:21
 #: ../gramps/gui/glade/editplacename.glade:21
-#: ../gramps/gui/glade/editplaceref.glade:38
+#: ../gramps/gui/glade/editplaceref.glade:39
 #: ../gramps/gui/glade/editreporef.glade:22
 #: ../gramps/gui/glade/editrepository.glade:22
 #: ../gramps/gui/glade/editsource.glade:23 ../gramps/gui/glade/editurl.glade:21
@@ -11920,32 +12095,123 @@ msgstr "A média könyvtár kiválasztása"
 #: ../gramps/gui/glade/mergesource.glade:21
 #: ../gramps/gui/glade/reorder.glade:22 ../gramps/gui/glade/rule.glade:316
 #: ../gramps/gui/glade/rule.glade:747 ../gramps/gui/glade/styleeditor.glade:86
-#: ../gramps/gui/glade/styleeditor.glade:1721
+#: ../gramps/gui/glade/styleeditor.glade:1737
 #: ../gramps/gui/logger/_errorview.py:173 ../gramps/gui/plug/_guioptions.py:79
-#: ../gramps/gui/plug/_guioptions.py:1742 ../gramps/gui/plug/_windows.py:440
+#: ../gramps/gui/plug/_guioptions.py:1744 ../gramps/gui/plug/_windows.py:440
 #: ../gramps/gui/plug/report/_fileentry.py:64
 #: ../gramps/gui/plug/report/_reportdialog.py:162 ../gramps/gui/utils.py:180
-#: ../gramps/gui/viewmanager.py:2000 ../gramps/gui/views/listview.py:1046
-#: ../gramps/gui/views/navigationview.py:363 ../gramps/gui/views/tags.py:648
+#: ../gramps/gui/viewmanager.py:1792 ../gramps/gui/views/listview.py:1054
+#: ../gramps/gui/views/navigationview.py:348 ../gramps/gui/views/tags.py:682
 #: ../gramps/gui/widgets/progressdialog.py:437
-#: ../gramps/plugins/lib/maps/geography.py:1010
-#: ../gramps/plugins/lib/maps/geography.py:1264
+#: ../gramps/plugins/importer/importprogen.glade:1714
+#: ../gramps/plugins/lib/maps/geography.py:996
+#: ../gramps/plugins/lib/maps/geography.py:1292
 #: ../gramps/plugins/tool/check.py:780 ../gramps/plugins/tool/eventcmp.py:398
 #: ../gramps/plugins/tool/populatesources.py:90
 #: ../gramps/plugins/tool/testcasegenerator.py:327
-#: ../gramps/gui/glade/editplaceref.glade:39
-#: ../gramps/gui/plug/_guioptions.py:1744 ../gramps/gui/viewmanager.py:1999
 msgid "_Cancel"
 msgstr "Még_se"
 
-#: ../gramps/gui/configure.py:1633
+#: ../gramps/gui/configure.py:1862
 msgid "Select database directory"
 msgstr "Adatbázis könyvtár kiválasztása"
 
-#: ../gramps/gui/configure.py:1655 ../gramps/gui/viewmanager.py:1997
-#: ../gramps/gui/viewmanager.py:1996
+#: ../gramps/gui/configure.py:1887 ../gramps/gui/viewmanager.py:1789
 msgid "Select backup directory"
 msgstr "Válassza ki a mentési könyvtárat"
+
+#: ../gramps/gui/configure.py:1954
+msgid ""
+"This tab gives you the possibility to use one font which is able to show all "
+"genealogical symbols\n"
+"\n"
+"If you select the \"use symbols\" checkbox, Gramps will use the selected "
+"font if it exists."
+msgstr ""
+"Ez a fül lehetőséget ad olyan font típus alkalmazására, mely képes "
+"megmutatni az összes genealógiai jelet\n"
+"\n"
+"Ha bejelöli a \"használjon jeleket\" jelölőnégyzetet, a GRAMPS a "
+"kiválasztott fontkészlet jeleit fogja használni, ha léteznek."
+
+#: ../gramps/gui/configure.py:1960
+msgid ""
+"This can be useful if you want to add phonetic in a note to show how to "
+"pronounce a name or if you mix multiple languages like greek and russian."
+msgstr ""
+"Ez hasznos lehet, ha fonetikai jeleket akar hozzáadni megmutatandó egy név "
+"kiejtését, vagy több nyelvet kíván keverten használni, mint pl. görög és "
+"orosz."
+
+#: ../gramps/gui/configure.py:1967
+msgid "Use symbols"
+msgstr "Jelek használata"
+
+#: ../gramps/gui/configure.py:1972
+msgid ""
+"Be careful, if you click on the \"Try to find\" button, it can take a while "
+"before you can continue (10 minutes or more). \n"
+"If you cancel the process, nothing will be changed."
+msgstr ""
+"Legyen óvatos, ha a \"Próbáljon keresni\" gombra klikkel, eltarthat egy "
+"darabig, mire folytatni tudja a munkát (10 perc, vagy több). \n"
+"Ha megszakítja a folyamatot, semmi sem fog megváltozni."
+
+#: ../gramps/gui/configure.py:1982
+msgid ""
+"You have already run the tool to search for genealogy fonts.\n"
+"Run it again only if you added fonts on your system."
+msgstr ""
+"Már fut egy származástani font kereső eszköz.\n"
+"Csak akkor futtassa újra, ha új fontokat adott a rendszeréhez."
+
+#: ../gramps/gui/configure.py:1987
+msgid "Try to find"
+msgstr "Próbáljon keresni"
+
+#: ../gramps/gui/configure.py:1998 ../gramps/gui/configure.py:2099
+msgid "Choose font"
+msgstr "Betűtípus választás"
+
+#: ../gramps/gui/configure.py:2011 ../gramps/gui/configure.py:2116
+msgid "Select default death symbol"
+msgstr "Alapértelmezett halott jel"
+
+#: ../gramps/gui/configure.py:2020
+msgid "Genealogical Symbols"
+msgstr "Származástani Jelek"
+
+#: ../gramps/gui/configure.py:2029
+msgid "Cannot look for genealogical fonts"
+msgstr "Származástani fontok nem kereshetőek"
+
+#: ../gramps/gui/configure.py:2030
+msgid ""
+"I am not able to select genealogical fonts. Please, install the module "
+"fontconfig for python 3."
+msgstr ""
+"Nem tudok származástani fontokat választani. Kérem, telepítse a python 3 "
+"fontconfig modult."
+
+#: ../gramps/gui/configure.py:2047
+msgid "Checking available genealogical fonts"
+msgstr "Az elérhető származástani fontok ellenőrzése"
+
+#: ../gramps/gui/configure.py:2051
+msgid "Looking for all fonts with genealogical symbols."
+msgstr "Az összes, származástani jeleket tartalmazó font keresése."
+
+#: ../gramps/gui/configure.py:2124
+msgid ""
+"You have no font with genealogical symbols on your system. Gramps will not "
+"be able to use symbols."
+msgstr ""
+"Rendszerén nem található származástani jeleket tartalmazó font. A GRAMPS nem "
+"lesz képes ilyen jeleket használni."
+
+#: ../gramps/gui/configure.py:2162
+msgid "What you will see"
+msgstr "Amit látni fog"
 
 #: ../gramps/gui/dbloader.py:120 ../gramps/gui/plug/tool.py:109
 msgid "Undo history warning"
@@ -11991,9 +12257,10 @@ msgstr ""
 
 #: ../gramps/gui/dbloader.py:220 ../gramps/gui/dbloader.py:235
 #: ../gramps/gui/dbloader.py:250 ../gramps/gui/dbloader.py:265
-#: ../gramps/gui/plug/report/_bookdialog.py:243
-#: ../gramps/gui/plug/report/_bookdialog.py:739
-#: ../gramps/gui/viewmanager.py:845
+#: ../gramps/gui/glade/dialog.glade:701
+#: ../gramps/gui/plug/report/_bookdialog.py:250
+#: ../gramps/gui/plug/report/_bookdialog.py:751
+#: ../gramps/gui/viewmanager.py:624
 msgid "Cancel"
 msgstr "Mégse"
 
@@ -12009,39 +12276,39 @@ msgstr ""
 "A Backup elkészült,\n"
 "kérem, frissítse vissza a Családfámat"
 
-#: ../gramps/gui/dbloader.py:337
+#: ../gramps/gui/dbloader.py:316
 msgid "All files"
 msgstr "Az összes fájl"
 
-#: ../gramps/gui/dbloader.py:378
+#: ../gramps/gui/dbloader.py:357
 msgid "Automatically detected"
 msgstr "Automatikusan felismerve"
 
-#: ../gramps/gui/dbloader.py:387
+#: ../gramps/gui/dbloader.py:366
 msgid "Select file _type:"
 msgstr "Válasszon fájl _típust:"
 
-#: ../gramps/gui/dbloader.py:401 ../gramps/gui/dbloader.py:423
+#: ../gramps/gui/dbloader.py:380 ../gramps/gui/dbloader.py:402
 msgid "Login"
 msgstr "Bejelentkezés"
 
-#: ../gramps/gui/dbloader.py:409
+#: ../gramps/gui/dbloader.py:388
 msgid "Username: "
 msgstr "Felhasználó név: "
 
-#: ../gramps/gui/dbloader.py:414
+#: ../gramps/gui/dbloader.py:393
 msgid "Password: "
 msgstr "Jelszó: "
 
-#: ../gramps/gui/dbloader.py:446
+#: ../gramps/gui/dbloader.py:425
 msgid "Import Family Tree"
 msgstr "Családfa importálása"
 
-#: ../gramps/gui/dbloader.py:457
+#: ../gramps/gui/dbloader.py:436
 msgid "Import"
 msgstr "Import"
 
-#: ../gramps/gui/dbloader.py:519 ../gramps/gui/dbloader.py:520
+#: ../gramps/gui/dbloader.py:493
 #, python-format
 msgid ""
 "File type \"%s\" is unknown to Gramps.\n"
@@ -12054,29 +12321,28 @@ msgstr ""
 "Érvényes típusok: GRAMPS adatbázis, GRAMPS XML, GRAMPS csomag, GEDCOM és "
 "mások."
 
-#: ../gramps/gui/dbloader.py:542 ../gramps/gui/dbloader.py:549
-#: ../gramps/gui/dbloader.py:543 ../gramps/gui/dbloader.py:550
+#: ../gramps/gui/dbloader.py:516 ../gramps/gui/dbloader.py:523
 msgid "Cannot open file"
 msgstr "Nem megnyitható fájl"
 
-#: ../gramps/gui/dbloader.py:543 ../gramps/gui/dbloader.py:544
+#: ../gramps/gui/dbloader.py:517
 msgid "The selected file is a directory, not a file.\n"
 msgstr "A kiválasztott fájl nem fájl, hanem könyvtár\n"
 
-#: ../gramps/gui/dbloader.py:550 ../gramps/gui/dbloader.py:551
+#: ../gramps/gui/dbloader.py:524
 msgid "You do not have read access to the selected file."
 msgstr "Nincs olvasási joga a kiválasztott fájlra."
 
-#: ../gramps/gui/dbloader.py:560 ../gramps/gui/dbloader.py:561
+#: ../gramps/gui/dbloader.py:534
 msgid "Cannot create file"
 msgstr "A fájl nem hozható létre"
 
-#: ../gramps/gui/dbloader.py:584 ../gramps/gui/dbloader.py:585
+#: ../gramps/gui/dbloader.py:558
 #, python-format
 msgid "Could not import file: %s"
 msgstr "A fájl nem importálható: %s"
 
-#: ../gramps/gui/dbloader.py:585 ../gramps/gui/dbloader.py:586
+#: ../gramps/gui/dbloader.py:559
 msgid ""
 "This file incorrectly identifies its character set, so it cannot be "
 "accurately imported. Please fix the encoding, and import again"
@@ -12093,7 +12359,7 @@ msgstr "%s_-_Családfák_Kezelése..."
 msgid "Family_Trees_manager_window"
 msgstr "_Családfa_kezelő_ablak"
 
-#: ../gramps/gui/dbman.py:112 ../gramps/gui/glade/dbman.glade:345
+#: ../gramps/gui/dbman.py:112 ../gramps/gui/glade/dbman.glade:346
 msgid "_Archive"
 msgstr "_Archív"
 
@@ -12108,7 +12374,7 @@ msgstr "Adatbázis információ"
 #: ../gramps/gui/dbman.py:121 ../gramps/gui/editors/edittaglist.py:120
 #: ../gramps/gui/glade/addmedia.glade:38
 #: ../gramps/gui/glade/baseselector.glade:40 ../gramps/gui/glade/book.glade:482
-#: ../gramps/gui/glade/book.glade:555 ../gramps/gui/glade/configure.glade:39
+#: ../gramps/gui/glade/book.glade:572 ../gramps/gui/glade/configure.glade:39
 #: ../gramps/gui/glade/dbman.glade:24 ../gramps/gui/glade/editaddress.glade:36
 #: ../gramps/gui/glade/editattribute.glade:37
 #: ../gramps/gui/glade/editchildref.glade:38
@@ -12126,7 +12392,7 @@ msgstr "Adatbázis információ"
 #: ../gramps/gui/glade/editpersonref.glade:37
 #: ../gramps/gui/glade/editplace.glade:36
 #: ../gramps/gui/glade/editplacename.glade:36
-#: ../gramps/gui/glade/editplaceref.glade:54
+#: ../gramps/gui/glade/editplaceref.glade:55
 #: ../gramps/gui/glade/editreporef.glade:41
 #: ../gramps/gui/glade/editrepository.glade:40
 #: ../gramps/gui/glade/editsource.glade:40 ../gramps/gui/glade/editurl.glade:37
@@ -12144,14 +12410,13 @@ msgstr "Adatbázis információ"
 #: ../gramps/gui/glade/mergesource.glade:37
 #: ../gramps/gui/glade/reorder.glade:38 ../gramps/gui/glade/rule.glade:333
 #: ../gramps/gui/glade/rule.glade:764 ../gramps/gui/glade/styleeditor.glade:103
-#: ../gramps/gui/glade/styleeditor.glade:1738
+#: ../gramps/gui/glade/styleeditor.glade:1754
 #: ../gramps/gui/plug/_guioptions.py:80
 #: ../gramps/gui/plug/report/_reportdialog.py:166 ../gramps/gui/utils.py:194
-#: ../gramps/gui/viewmanager.py:1868 ../gramps/gui/views/tags.py:649
+#: ../gramps/gui/viewmanager.py:1659 ../gramps/gui/views/tags.py:683
 #: ../gramps/plugins/tool/check.py:781 ../gramps/plugins/tool/patchnames.py:118
 #: ../gramps/plugins/tool/populatesources.py:91
 #: ../gramps/plugins/tool/testcasegenerator.py:328
-#: ../gramps/gui/glade/editplaceref.glade:55 ../gramps/gui/viewmanager.py:1866
 msgid "_OK"
 msgstr "_Rendben"
 
@@ -12163,20 +12428,20 @@ msgstr "Beállítások"
 msgid "Family Trees"
 msgstr "Családfák"
 
-#: ../gramps/gui/dbman.py:382
+#: ../gramps/gui/dbman.py:381
 msgid "Family Tree name"
 msgstr "Családfa név"
 
-#: ../gramps/gui/dbman.py:402
+#: ../gramps/gui/dbman.py:401
 msgid "Database Type"
 msgstr "Adatbázis típus"
 
-#: ../gramps/gui/dbman.py:509
+#: ../gramps/gui/dbman.py:508
 #, python-format
 msgid "Break the lock on the '%s' database?"
 msgstr "Oldjuk fel a zárolást a(z) '%s' adatbázison?"
 
-#: ../gramps/gui/dbman.py:510
+#: ../gramps/gui/dbman.py:509
 msgid ""
 "Gramps believes that someone else is actively editing this database. You "
 "cannot edit this database while it is locked. If no one is editing the "
@@ -12188,15 +12453,15 @@ msgstr ""
 "adatbázist, akkor nyugodtan feloldhatja a zárolást. Ugyanakkor, ha valaki "
 "dolgozik az adatbázissal és ön feloldja a zárolást, az adatbázis megsérülhet."
 
-#: ../gramps/gui/dbman.py:516
+#: ../gramps/gui/dbman.py:515
 msgid "Break lock"
 msgstr "Feloldás"
 
-#: ../gramps/gui/dbman.py:608
+#: ../gramps/gui/dbman.py:607
 msgid "Rename failed"
 msgstr "Sikertelen átnevezés"
 
-#: ../gramps/gui/dbman.py:609
+#: ../gramps/gui/dbman.py:608
 #, python-format
 msgid ""
 "An attempt to rename a version failed with the following message:\n"
@@ -12207,54 +12472,54 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dbman.py:627
+#: ../gramps/gui/dbman.py:626
 msgid "Could not rename the Family Tree."
 msgstr "A családfát nem lehet átnevezni."
 
-#: ../gramps/gui/dbman.py:628
+#: ../gramps/gui/dbman.py:627
 msgid "Family Tree already exists, choose a unique name."
 msgstr "Ez a családfa már létezik, válasszon új egyedi nevet."
 
-#: ../gramps/gui/dbman.py:675
+#: ../gramps/gui/dbman.py:674
 msgid "Extracting archive..."
 msgstr "Archív kibontása..."
 
-#: ../gramps/gui/dbman.py:680
+#: ../gramps/gui/dbman.py:679
 msgid "Importing archive..."
 msgstr "Archív importálása..."
 
-#: ../gramps/gui/dbman.py:696
+#: ../gramps/gui/dbman.py:695
 #, python-format
 msgid "Remove the '%s' Family Tree?"
 msgstr "Eltávolítja a(z) '%s' Családfát?"
 
-#: ../gramps/gui/dbman.py:697
+#: ../gramps/gui/dbman.py:696
 msgid "Removing this Family Tree will permanently destroy the data."
 msgstr "A Családfa eltávolítása örökre megsemmisíti az adatokat."
 
-#: ../gramps/gui/dbman.py:699
+#: ../gramps/gui/dbman.py:698
 msgid "Remove Family Tree"
 msgstr "A Családfa eltávolítása"
 
-#: ../gramps/gui/dbman.py:704
+#: ../gramps/gui/dbman.py:703
 #, python-format
 msgid "Remove the '%(revision)s' version of '%(database)s'"
 msgstr "A(z) '%(database)s' '%(revision)s' verziójának eltávolítása"
 
-#: ../gramps/gui/dbman.py:708
+#: ../gramps/gui/dbman.py:707
 msgid ""
 "Removing this version will prevent you from extracting it in the future."
 msgstr "A változat eltávolításával megelőzi a fájl kicsomagolását a jövőben."
 
-#: ../gramps/gui/dbman.py:710
+#: ../gramps/gui/dbman.py:709
 msgid "Remove version"
 msgstr "A változat eltávolítása"
 
-#: ../gramps/gui/dbman.py:765
+#: ../gramps/gui/dbman.py:764
 msgid "Deletion failed"
 msgstr "Sikertelen törlés"
 
-#: ../gramps/gui/dbman.py:766
+#: ../gramps/gui/dbman.py:765
 #, python-format
 msgid ""
 "An attempt to delete a version failed with the following message:\n"
@@ -12265,58 +12530,58 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dbman.py:784
+#: ../gramps/gui/dbman.py:783
 #, python-format
 msgid "Convert the '%s' database?"
 msgstr "Alakítsuk át a(z) '%s' adatbázist?"
 
-#: ../gramps/gui/dbman.py:785
+#: ../gramps/gui/dbman.py:784
 #, python-format
 msgid ""
 "Do you wish to convert this family tree into a %(database_type)s database?"
 msgstr "Kívánja ezt a családfát konvertálni %(database_type)s adatbázisba?"
 
-#: ../gramps/gui/dbman.py:787
+#: ../gramps/gui/dbman.py:786
 msgid "Convert"
 msgstr "Átalakítás"
 
-#: ../gramps/gui/dbman.py:797
+#: ../gramps/gui/dbman.py:796
 #, python-format
 msgid "Opening the '%s' database"
 msgstr "A(z) '%s' adatbázis megnyitása"
 
-#: ../gramps/gui/dbman.py:798
+#: ../gramps/gui/dbman.py:797
 msgid "An attempt to convert the database failed. Perhaps it needs updating."
 msgstr ""
 "Az adatbázis átalakítási kísérlete meghiúsult. Valószínűleg frissíteni kell."
 
-#: ../gramps/gui/dbman.py:809 ../gramps/gui/dbman.py:835
+#: ../gramps/gui/dbman.py:808 ../gramps/gui/dbman.py:834
 #, python-format
 msgid "Converting the '%s' database"
 msgstr "A(z) '%s' adatbázis átalakítása"
 
-#: ../gramps/gui/dbman.py:810
+#: ../gramps/gui/dbman.py:809
 msgid "An attempt to export the database failed."
 msgstr "Az adatbázis exportálási kísérlete meghiúsult."
 
-#: ../gramps/gui/dbman.py:814
+#: ../gramps/gui/dbman.py:813
 msgid "Converting data..."
 msgstr "Adatátalakítás..."
 
-#: ../gramps/gui/dbman.py:819 ../gramps/gui/dbman.py:822
+#: ../gramps/gui/dbman.py:818 ../gramps/gui/dbman.py:821
 #, python-format
 msgid "(Converted #%d)"
 msgstr "(Átalakítva #%d)"
 
-#: ../gramps/gui/dbman.py:836
+#: ../gramps/gui/dbman.py:835
 msgid "An attempt to import into the database failed."
 msgstr "Az adatbázis importálási kísérlete meghiúsult."
 
-#: ../gramps/gui/dbman.py:893
+#: ../gramps/gui/dbman.py:892
 msgid "Repair Family Tree?"
 msgstr "Javítja a Családfát?"
 
-#: ../gramps/gui/dbman.py:894
+#: ../gramps/gui/dbman.py:893
 #, python-format
 msgid ""
 "If you click %(bold_start)sProceed%(bold_end)s, Gramps will attempt to "
@@ -12366,31 +12631,31 @@ msgstr ""
 "megoldódhat. Ha erről van szó, kikapcsolhatja a javítás gombot a "
 "%(recover_file)s fájl törlésével a Családfa könyvtárában."
 
-#: ../gramps/gui/dbman.py:925
+#: ../gramps/gui/dbman.py:924
 msgid "Proceed, I have taken a backup"
 msgstr "Folytassa, van biztonsági mentésem"
 
-#: ../gramps/gui/dbman.py:926
+#: ../gramps/gui/dbman.py:925
 msgid "Stop"
 msgstr "Állj"
 
-#: ../gramps/gui/dbman.py:945
+#: ../gramps/gui/dbman.py:944
 msgid "Rebuilding database from backup files"
 msgstr "Az adatbázis újraépítése biztonsági fájlból"
 
-#: ../gramps/gui/dbman.py:950
+#: ../gramps/gui/dbman.py:949
 msgid "Error restoring backup data"
 msgstr "Hiba a mentett adatok helyreállításakor"
 
-#: ../gramps/gui/dbman.py:989
+#: ../gramps/gui/dbman.py:988
 msgid "Could not create Family Tree"
 msgstr "A Családfa nem hozható létre"
 
-#: ../gramps/gui/dbman.py:1110
+#: ../gramps/gui/dbman.py:1109
 msgid "Retrieve failed"
 msgstr "Sikertelen helyreállítás"
 
-#: ../gramps/gui/dbman.py:1111
+#: ../gramps/gui/dbman.py:1110
 #, python-format
 msgid ""
 "An attempt to retrieve the data failed with the following message:\n"
@@ -12401,11 +12666,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dbman.py:1150 ../gramps/gui/dbman.py:1176
+#: ../gramps/gui/dbman.py:1149 ../gramps/gui/dbman.py:1175
 msgid "Archiving failed"
 msgstr "Sikertelen archiválás"
 
-#: ../gramps/gui/dbman.py:1151
+#: ../gramps/gui/dbman.py:1150
 #, python-format
 msgid ""
 "An attempt to create the archive failed with the following message:\n"
@@ -12416,15 +12681,15 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dbman.py:1156
+#: ../gramps/gui/dbman.py:1155
 msgid "Creating data to be archived..."
 msgstr "Az archiválandó adatok létrehozása..."
 
-#: ../gramps/gui/dbman.py:1165
+#: ../gramps/gui/dbman.py:1164
 msgid "Saving archive..."
 msgstr "Archívum mentése..."
 
-#: ../gramps/gui/dbman.py:1177
+#: ../gramps/gui/dbman.py:1176
 #, python-format
 msgid ""
 "An attempt to archive the data failed with the following message:\n"
@@ -12435,12 +12700,12 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/dialog.py:388 ../gramps/gui/dialog.py:466
+#: ../gramps/gui/dialog.py:434 ../gramps/gui/dialog.py:512
 #: ../gramps/gui/utils.py:309
 msgid "Attempt to force closing the dialog"
 msgstr "Kísérlet a párbeszédablak erőltetett bezárására"
 
-#: ../gramps/gui/dialog.py:389 ../gramps/gui/dialog.py:467
+#: ../gramps/gui/dialog.py:435 ../gramps/gui/dialog.py:513
 msgid ""
 "Please do not force closing this important dialog.\n"
 "Instead select one of the available options"
@@ -12448,48 +12713,48 @@ msgstr ""
 "Kérem ne erőltesse e fontos párbeszédablak bezárását.\n"
 "Ehelyett válaszon egy elérhető lehetőséget"
 
-#: ../gramps/gui/displaystate.py:268
+#: ../gramps/gui/displaystate.py:290
 msgid "Cannot load database"
 msgstr "Az adatbázis nem betölthető"
 
-#: ../gramps/gui/displaystate.py:388
+#: ../gramps/gui/displaystate.py:408
 #: ../gramps/plugins/gramplet/persondetails.py:173
 msgid "No active person"
 msgstr "Nincs aktív személy"
 
-#: ../gramps/gui/displaystate.py:389
+#: ../gramps/gui/displaystate.py:409
 msgid "No active family"
 msgstr "Nincs aktív család"
 
-#: ../gramps/gui/displaystate.py:390
+#: ../gramps/gui/displaystate.py:410
 msgid "No active event"
 msgstr "Nincs aktív esemény"
 
-#: ../gramps/gui/displaystate.py:391
+#: ../gramps/gui/displaystate.py:411
 msgid "No active place"
 msgstr "Nincs aktív hely"
 
-#: ../gramps/gui/displaystate.py:392
+#: ../gramps/gui/displaystate.py:412
 msgid "No active source"
 msgstr "Nincs aktív forrás"
 
-#: ../gramps/gui/displaystate.py:393
+#: ../gramps/gui/displaystate.py:413
 msgid "No active citation"
 msgstr "Nincs aktív idézet"
 
-#: ../gramps/gui/displaystate.py:394
+#: ../gramps/gui/displaystate.py:414
 msgid "No active repository"
 msgstr "Nincs aktív tároló"
 
-#: ../gramps/gui/displaystate.py:395
+#: ../gramps/gui/displaystate.py:415
 msgid "No active media"
 msgstr "Nincs aktív média"
 
-#: ../gramps/gui/displaystate.py:396
+#: ../gramps/gui/displaystate.py:416
 msgid "No active note"
 msgstr "Nincs aktív jegyzet"
 
-#: ../gramps/gui/displaystate.py:627
+#: ../gramps/gui/displaystate.py:655 ../gramps/plugins/gramplet/todo.py:200
 msgid "No active object"
 msgstr "Nincs aktív objektum"
 
@@ -12598,11 +12863,11 @@ msgstr "_Tulajdonságok"
 #: ../gramps/gui/editors/displaytabs/backreflist.py:60
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:83
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:79
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:65
-#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:58
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:67
+#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:60
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:66
-#: ../gramps/gui/editors/editfamily.py:122
-#: ../gramps/gui/editors/filtereditor.py:978
+#: ../gramps/gui/editors/editfamily.py:124
+#: ../gramps/gui/editors/filtereditor.py:992
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:104
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:111
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:103
@@ -12614,36 +12879,34 @@ msgstr "_Tulajdonságok"
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:103
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:86
 #: ../gramps/gui/merge/mergeperson.py:182
-#: ../gramps/gui/plug/_guioptions.py:1175
-#: ../gramps/gui/plug/_guioptions.py:1353
-#: ../gramps/gui/selectors/selectcitation.py:75
-#: ../gramps/gui/selectors/selectevent.py:74
-#: ../gramps/gui/selectors/selectfamily.py:69
-#: ../gramps/gui/selectors/selectnote.py:75
-#: ../gramps/gui/selectors/selectobject.py:81
-#: ../gramps/gui/selectors/selectperson.py:94
-#: ../gramps/gui/selectors/selectplace.py:71
-#: ../gramps/gui/selectors/selectrepository.py:70
-#: ../gramps/gui/selectors/selectsource.py:71
-#: ../gramps/gui/views/bookmarks.py:269
-#: ../gramps/gui/views/navigationview.py:358
+#: ../gramps/gui/plug/_guioptions.py:1177
+#: ../gramps/gui/plug/_guioptions.py:1355
+#: ../gramps/gui/selectors/selectcitation.py:72
+#: ../gramps/gui/selectors/selectevent.py:71
+#: ../gramps/gui/selectors/selectfamily.py:66
+#: ../gramps/gui/selectors/selectnote.py:72
+#: ../gramps/gui/selectors/selectobject.py:78
+#: ../gramps/gui/selectors/selectperson.py:91
+#: ../gramps/gui/selectors/selectplace.py:68
+#: ../gramps/gui/selectors/selectrepository.py:67
+#: ../gramps/gui/selectors/selectsource.py:68
+#: ../gramps/gui/views/bookmarks.py:281
+#: ../gramps/gui/views/navigationview.py:343
 #: ../gramps/plugins/gramplet/locations.py:88
 #: ../gramps/plugins/lib/libpersonview.py:99
-#: ../gramps/plugins/lib/libplaceview.py:85
+#: ../gramps/plugins/lib/libplaceview.py:86
 #: ../gramps/plugins/tool/eventcmp.py:253
 #: ../gramps/plugins/tool/notrelated.py:127
 #: ../gramps/plugins/tool/patchnames.py:404
 #: ../gramps/plugins/tool/removeunused.py:195
-#: ../gramps/plugins/tool/sortevents.py:56 ../gramps/plugins/tool/verify.py:569
+#: ../gramps/plugins/tool/sortevents.py:56 ../gramps/plugins/tool/verify.py:572
 #: ../gramps/plugins/view/citationlistview.py:99
 #: ../gramps/plugins/view/citationtreeview.py:94
-#: ../gramps/plugins/view/eventview.py:83
+#: ../gramps/plugins/view/eventview.py:79
 #: ../gramps/plugins/view/familyview.py:79
 #: ../gramps/plugins/view/mediaview.py:95 ../gramps/plugins/view/noteview.py:80
-#: ../gramps/plugins/view/relview.py:592 ../gramps/plugins/view/repoview.py:86
+#: ../gramps/plugins/view/relview.py:723 ../gramps/plugins/view/repoview.py:86
 #: ../gramps/plugins/view/sourceview.py:83
-#: ../gramps/gui/plug/_guioptions.py:1177
-#: ../gramps/gui/plug/_guioptions.py:1355
 msgid "ID"
 msgstr "Azonosító"
 
@@ -12669,9 +12932,9 @@ msgstr "%(part1)s - %(part2)s"
 #: ../gramps/gui/glade/editperson.glade:361
 #: ../gramps/gui/glade/editplaceformat.glade:72
 #: ../gramps/gui/glade/rule.glade:422 ../gramps/gui/glade/rule.glade:429
-#: ../gramps/gui/glade/styleeditor.glade:1832
-#: ../gramps/gui/glade/styleeditor.glade:1839
-#: ../gramps/plugins/view/relview.py:410
+#: ../gramps/gui/glade/styleeditor.glade:1864
+#: ../gramps/gui/glade/styleeditor.glade:1871
+#: ../gramps/plugins/view/relview.py:471
 msgid "Add"
 msgstr "Hozzáad"
 
@@ -12684,15 +12947,15 @@ msgstr "Hozzáad"
 #: ../gramps/gui/glade/grampletpane.glade:104
 #: ../gramps/gui/glade/grampletpane.glade:111
 #: ../gramps/gui/glade/rule.glade:490 ../gramps/gui/glade/rule.glade:497
-#: ../gramps/gui/glade/styleeditor.glade:1896
-#: ../gramps/gui/glade/styleeditor.glade:1903
+#: ../gramps/gui/glade/styleeditor.glade:1928
+#: ../gramps/gui/glade/styleeditor.glade:1935
 msgid "Remove"
 msgstr "Eltávolít"
 
 #: ../gramps/gui/editors/displaytabs/buttontab.py:72
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:148
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:128
-#: ../gramps/plugins/view/relview.py:414
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:130
+#: ../gramps/plugins/view/relview.py:471
 msgid "Share"
 msgstr "Megoszt"
 
@@ -12707,6 +12970,14 @@ msgstr "Mozgatás felfelé"
 #: ../gramps/gui/editors/displaytabs/buttontab.py:75
 msgid "Move Down"
 msgstr "Mozgatás lefelé"
+
+#: ../gramps/gui/editors/displaytabs/buttontab.py:76
+msgid "Move Left"
+msgstr "Mozgatás balra"
+
+#: ../gramps/gui/editors/displaytabs/buttontab.py:77
+msgid "Move right"
+msgstr "Mozgatás jobbra"
 
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:69
 msgid "Create and add a new citation and new source"
@@ -12742,14 +13013,14 @@ msgstr "_Idézetek forrása"
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:256
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:277
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:267
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:332
-#: ../gramps/plugins/view/citationtreeview.py:454
-#: ../gramps/plugins/view/citationtreeview.py:497
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:334
+#: ../gramps/plugins/view/citationtreeview.py:590
+#: ../gramps/plugins/view/citationtreeview.py:633
 msgid "Cannot share this reference"
 msgstr "A hivatkozás nem megosztható"
 
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:192
-#: ../gramps/plugins/view/citationtreeview.py:505
+#: ../gramps/plugins/view/citationtreeview.py:641
 msgid ""
 "This citation cannot be created at this time. Either the associated Source "
 "object is already being edited, or another citation associated with the same "
@@ -12814,10 +13085,10 @@ msgstr ""
 
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:281
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:347
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:353
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:355
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:168
 #: ../gramps/plugins/drawreport/ancestortree.py:1095
-#: ../gramps/plugins/drawreport/descendtree.py:1805
+#: ../gramps/plugins/drawreport/descendtree.py:1810
 msgid "Cannot edit this reference"
 msgstr "A hivatkozás nem szerkeszthető"
 
@@ -12840,26 +13111,26 @@ msgid "_Gallery"
 msgstr "_Galéria"
 
 #. Translators: _View means "to look at this"
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:140
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:142
 msgid "verb:look at this|_View"
 msgstr "ige:lásd|_View"
 
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:145
-#: ../gramps/plugins/view/mediaview.py:215
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:147
+#: ../gramps/plugins/view/mediaview.py:395
 msgid "Open Containing _Folder"
 msgstr "A tartalmazó _mappa megnyitása"
 
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:153
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:155
 msgid "_Make Active Media"
 msgstr "Legyen aktív a _média"
 
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:257
-#: ../gramps/gui/editors/editperson.py:961
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:259
+#: ../gramps/gui/editors/editperson.py:960
 #: ../gramps/plugins/textreport/indivcomplete.py:602
 msgid "Non existing media found in the Gallery"
 msgstr "A galériában nem létező média található"
 
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:307
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:309
 msgid ""
 "This media reference cannot be edited at this time. Either the associated "
 "media object is already being edited or another media reference that is "
@@ -12873,8 +13144,8 @@ msgstr ""
 "\n"
 "A médiahivatkozás szerkesztéséhez be kell zárnia a média objektumot."
 
-#: ../gramps/gui/editors/displaytabs/gallerytab.py:540
-#: ../gramps/plugins/view/mediaview.py:197
+#: ../gramps/gui/editors/displaytabs/gallerytab.py:578
+#: ../gramps/plugins/view/mediaview.py:192
 msgid "Drag Media Object"
 msgstr "A médiaobjektum megfogása"
 
@@ -12949,16 +13220,16 @@ msgstr "Alapértelmezett névként beállít"
 #.
 #. -------------------------------------------------------------------------
 #: ../gramps/gui/editors/displaytabs/namemodel.py:56
-#: ../gramps/gui/plug/_guioptions.py:1256 ../gramps/gui/views/tags.py:498
+#: ../gramps/gui/plug/_guioptions.py:1258 ../gramps/gui/viewmanager.py:1025
+#: ../gramps/gui/views/tags.py:532
 #: ../gramps/plugins/quickview/all_relations.py:306
-#: ../gramps/gui/plug/_guioptions.py:1258
 msgid "Yes"
 msgstr "Igen"
 
 #: ../gramps/gui/editors/displaytabs/namemodel.py:57
-#: ../gramps/gui/plug/_guioptions.py:1255 ../gramps/gui/views/tags.py:499
+#: ../gramps/gui/plug/_guioptions.py:1257 ../gramps/gui/viewmanager.py:1025
+#: ../gramps/gui/views/tags.py:533
 #: ../gramps/plugins/quickview/all_relations.py:310
-#: ../gramps/gui/plug/_guioptions.py:1257
 msgid "No"
 msgstr "Nem"
 
@@ -13000,7 +13271,7 @@ msgstr "A kiválasztott jegyzet mozgatása lefelé"
 #: ../gramps/gui/glade/editmedia.glade:188
 #: ../gramps/gui/glade/editmediaref.glade:190
 #: ../gramps/gui/glade/editmediaref.glade:503
-#: ../gramps/gui/selectors/selectnote.py:74
+#: ../gramps/gui/selectors/selectnote.py:71
 #: ../gramps/plugins/view/noteview.py:79
 msgid "Preview"
 msgstr "Előnézet"
@@ -13011,7 +13282,7 @@ msgstr "_Jegyzetek"
 
 #. add personal column
 #: ../gramps/gui/editors/displaytabs/personeventembedlist.py:50
-#: ../gramps/plugins/webreport/basepage.py:1663
+#: ../gramps/plugins/webreport/basepage.py:1696
 msgid "Personal"
 msgstr "Személyes"
 
@@ -13043,40 +13314,40 @@ msgstr ""
 "Kiválasztott személyes esemény mozgatása lefelé, vagy család sorrendjének "
 "változtatása"
 
-#: ../gramps/gui/editors/displaytabs/personeventembedlist.py:130
+#: ../gramps/gui/editors/displaytabs/personeventembedlist.py:134
 msgid "Cannot change Family"
 msgstr "Nem változtatható család"
 
-#: ../gramps/gui/editors/displaytabs/personeventembedlist.py:131
+#: ../gramps/gui/editors/displaytabs/personeventembedlist.py:135
 msgid "You cannot change Family events in the Person Editor"
 msgstr "Nem változtathatja meg a családi eseményeket a Személy szerkesztőben"
 
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:54
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:56
 msgid "Create and add a new association"
 msgstr "Új társítás létrehozása és hozzáadása"
 
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:55
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:57
 msgid "Remove the existing association"
 msgstr "Létező társítás eltávolítása"
 
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:56
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:58
 msgid "Edit the selected association"
 msgstr "Kiválasztott társítás szerkesztése"
 
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:57
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:59
 msgid "Move the selected association upwards"
 msgstr "A kiválasztott társítás mozgatása felfelé"
 
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:58
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:60
 msgid "Move the selected association downwards"
 msgstr "A kiválasztott társítás mozgatása lefelé"
 
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:73
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:76
 msgid "_Associations"
 msgstr "_Társítások"
 
-#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:90
-#: ../gramps/plugins/importer/importprogen.py:1388
+#: ../gramps/gui/editors/displaytabs/personrefembedlist.py:138
+#: ../gramps/plugins/lib/libprogen.py:1467
 msgid "Godfather"
 msgstr "Keresztapa"
 
@@ -13105,17 +13376,19 @@ msgstr "A kiválasztott helynév mozgatása lefelé"
 msgid "Alternative Names"
 msgstr "Választható nevek"
 
-#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:69
+#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:72
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:111
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1302
+#: ../gramps/plugins/webreport/basepage.py:2696
+#: ../gramps/plugins/webreport/basepage.py:2714
 msgid "Enclosed By"
 msgstr "által mellékelve"
 
-#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:141
+#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:189
 msgid "Place cycle detected"
 msgstr "Feltárt helység ciklus"
 
-#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:142
+#: ../gramps/gui/editors/displaytabs/placerefembedlist.py:190
 msgid "The place you are adding is already enclosed by this place"
 msgstr "A hely, amit most hozzáad a hely által már mellékelve van"
 
@@ -13183,7 +13456,7 @@ msgid "Move the selected surname downwards"
 msgstr "A kiválasztott vezetéknév mozgatása lefelé"
 
 #: ../gramps/gui/editors/displaytabs/surnametab.py:78
-#: ../gramps/plugins/lib/libgedcom.py:720
+#: ../gramps/plugins/lib/libgedcom.py:712
 msgid "Origin"
 msgstr "Eredet"
 
@@ -13225,7 +13498,7 @@ msgstr "_Internet"
 
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:118
 #: ../gramps/gui/glade/editurl.glade:200
-#: ../gramps/gui/views/navigationview.py:364
+#: ../gramps/gui/views/navigationview.py:349
 msgid "_Jump to"
 msgstr "_Ugrás"
 
@@ -13265,7 +13538,7 @@ msgid "manual|Child_Reference_Editor"
 msgstr "manual|Gyermek_hivatkozás_szerkesztő"
 
 #: ../gramps/gui/editors/editchildref.py:99
-#: ../gramps/gui/editors/editchildref.py:195
+#: ../gramps/gui/editors/editchildref.py:190
 msgid "Child Reference Editor"
 msgstr "Gyermek hivatkozás szerkesztő"
 
@@ -13278,15 +13551,15 @@ msgstr "manual|Új_Idézetek_párbeszéd_ablak"
 msgid "New Citation"
 msgstr "Új idézet"
 
-#: ../gramps/gui/editors/editcitation.py:277
+#: ../gramps/gui/editors/editcitation.py:299
 msgid "Edit Citation"
 msgstr "Idézet szerkesztése"
 
-#: ../gramps/gui/editors/editcitation.py:285
+#: ../gramps/gui/editors/editcitation.py:307
 msgid "No source selected"
 msgstr "Nincs forrás kiválasztva"
 
-#: ../gramps/gui/editors/editcitation.py:286
+#: ../gramps/gui/editors/editcitation.py:308
 msgid ""
 "A source is anything (personal testimony, video recording, photograph, "
 "newspaper column, gravestone...) from which information can be derived. To "
@@ -13299,14 +13572,14 @@ msgstr ""
 "először válassza ki a forrást, majd a forrás 'Kötet/Oldal' mezőjében "
 "rögzítse a hivatkozott információ helyét."
 
-#: ../gramps/gui/editors/editcitation.py:300
+#: ../gramps/gui/editors/editcitation.py:322
 msgid "Cannot save citation. ID already exists."
 msgstr "Az idézet nem menthető. Az azonosító már létezik."
 
-#: ../gramps/gui/editors/editcitation.py:301
-#: ../gramps/gui/editors/editevent.py:249
-#: ../gramps/gui/editors/editmedia.py:298
-#: ../gramps/gui/editors/editperson.py:846
+#: ../gramps/gui/editors/editcitation.py:323
+#: ../gramps/gui/editors/editevent.py:251
+#: ../gramps/gui/editors/editmedia.py:300
+#: ../gramps/gui/editors/editperson.py:845
 #: ../gramps/gui/editors/editplace.py:318
 #: ../gramps/gui/editors/editreference.py:288
 #: ../gramps/gui/editors/editrepository.py:189
@@ -13322,17 +13595,17 @@ msgstr ""
 "azonosítót, vagy hagyja üresen a helyet a következő lehetséges azonosító "
 "értékhez."
 
-#: ../gramps/gui/editors/editcitation.py:311
+#: ../gramps/gui/editors/editcitation.py:333
 #, python-format
 msgid "Add Citation (%s)"
 msgstr "(%s) idézet hozzáadása"
 
-#: ../gramps/gui/editors/editcitation.py:316
+#: ../gramps/gui/editors/editcitation.py:338
 #, python-format
 msgid "Edit Citation (%s)"
 msgstr "(%s) idézet szerkesztése"
 
-#: ../gramps/gui/editors/editcitation.py:354
+#: ../gramps/gui/editors/editcitation.py:376
 #, python-format
 msgid "Delete Citation (%s)"
 msgstr "(%s) idézet eltávolítása"
@@ -13392,60 +13665,60 @@ msgid "manual|New_Event_dialog"
 msgstr "manual|Új_Esemény_párbeszéd_ablak"
 
 #: ../gramps/gui/editors/editevent.py:98
-#: ../gramps/gui/editors/editeventref.py:261
+#: ../gramps/gui/editors/editeventref.py:263
 #, python-format
 msgid "Event: %s"
 msgstr "Esemény: %s"
 
 #: ../gramps/gui/editors/editevent.py:100
-#: ../gramps/gui/editors/editeventref.py:263
+#: ../gramps/gui/editors/editeventref.py:265
 msgid "New Event"
 msgstr "Új esemény"
 
-#: ../gramps/gui/editors/editevent.py:228
-#: ../gramps/plugins/view/geoclose.py:547
-#: ../gramps/plugins/view/geoevents.py:343
-#: ../gramps/plugins/view/geoevents.py:377
-#: ../gramps/plugins/view/geofamclose.py:738
-#: ../gramps/plugins/view/geofamily.py:432
-#: ../gramps/plugins/view/geomoves.py:620
-#: ../gramps/plugins/view/geoperson.py:437
-#: ../gramps/plugins/view/geoperson.py:458
-#: ../gramps/plugins/view/geoperson.py:499
+#: ../gramps/gui/editors/editevent.py:230
+#: ../gramps/plugins/view/geoclose.py:619
+#: ../gramps/plugins/view/geoevents.py:396
+#: ../gramps/plugins/view/geoevents.py:430
+#: ../gramps/plugins/view/geofamclose.py:808
+#: ../gramps/plugins/view/geofamily.py:482
+#: ../gramps/plugins/view/geomoves.py:686
+#: ../gramps/plugins/view/geoperson.py:503
+#: ../gramps/plugins/view/geoperson.py:524
+#: ../gramps/plugins/view/geoperson.py:565
 msgid "Edit Event"
 msgstr "Esemény szerkesztése"
 
-#: ../gramps/gui/editors/editevent.py:237
-#: ../gramps/gui/editors/editevent.py:261
+#: ../gramps/gui/editors/editevent.py:239
+#: ../gramps/gui/editors/editevent.py:263
 msgid "Cannot save event"
 msgstr "Az esemény nem menthető"
 
-#: ../gramps/gui/editors/editevent.py:238
+#: ../gramps/gui/editors/editevent.py:240
 msgid "No data exists for this event. Please enter data or cancel the edit."
 msgstr ""
 "Az eseményhez nincs adat. Kérem vigyen be adatot, vagy szakítsa meg a "
 "szerkesztést."
 
-#: ../gramps/gui/editors/editevent.py:248
+#: ../gramps/gui/editors/editevent.py:250
 #: ../gramps/gui/editors/editreference.py:277
 msgid "Cannot save event. ID already exists."
 msgstr "Az esemény nem menthető. Az azonosító már létezik."
 
-#: ../gramps/gui/editors/editevent.py:262
+#: ../gramps/gui/editors/editevent.py:264
 msgid "The event type cannot be empty"
 msgstr "Az esemény típus nem lehet üres"
 
-#: ../gramps/gui/editors/editevent.py:268
+#: ../gramps/gui/editors/editevent.py:270
 #, python-format
 msgid "Add Event (%s)"
 msgstr "(%s) esemény hozzáadása"
 
-#: ../gramps/gui/editors/editevent.py:273
+#: ../gramps/gui/editors/editevent.py:275
 #, python-format
 msgid "Edit Event (%s)"
 msgstr "(%s) esemény szerkesztése"
 
-#: ../gramps/gui/editors/editevent.py:318
+#: ../gramps/gui/editors/editevent.py:338
 #, python-format
 msgid "Delete Event (%s)"
 msgstr "(%s) esemény törlése"
@@ -13455,7 +13728,7 @@ msgid "manual|Event_Reference_Editor_dialog"
 msgstr "manual|Esemény_hivatkozás_szerkesztő_párbeszéd_ablak"
 
 #: ../gramps/gui/editors/editeventref.py:76
-#: ../gramps/gui/editors/editeventref.py:264
+#: ../gramps/gui/editors/editeventref.py:266
 msgid "Event Reference Editor"
 msgstr "Esemény hivatkozás szerkesztő"
 
@@ -13467,56 +13740,56 @@ msgstr "Esemény hivatkozás szerkesztő"
 msgid "_General"
 msgstr "Á_ltalános"
 
-#: ../gramps/gui/editors/editeventref.py:269
+#: ../gramps/gui/editors/editeventref.py:271
 msgid "Modify Event"
 msgstr "Esemény módosítás"
 
-#: ../gramps/gui/editors/editeventref.py:274
+#: ../gramps/gui/editors/editeventref.py:276
 msgid "Add Event"
 msgstr "Esemény hozzáadása"
 
-#: ../gramps/gui/editors/editfamily.py:91
+#: ../gramps/gui/editors/editfamily.py:92
 msgid "manual|Family_Editor_dialog"
 msgstr "manual|Család_szerkesztő_párbeszéd_ablak"
 
-#: ../gramps/gui/editors/editfamily.py:111
+#: ../gramps/gui/editors/editfamily.py:113
 msgid "Create a new person and add the child to the family"
 msgstr "Egy új személy létrehozása és gyermek hozzáadása a családhoz"
 
-#: ../gramps/gui/editors/editfamily.py:112
+#: ../gramps/gui/editors/editfamily.py:114
 msgid "Remove the child from the family"
 msgstr "Gyermek eltávolítása a családból"
 
-#: ../gramps/gui/editors/editfamily.py:113
+#: ../gramps/gui/editors/editfamily.py:115
 msgid "Edit the child reference"
 msgstr "Gyermek hivatkozás szerkesztése"
 
-#: ../gramps/gui/editors/editfamily.py:114
+#: ../gramps/gui/editors/editfamily.py:116
 msgid "Add an existing person as a child of the family"
 msgstr "Létező személy hozzáadása gyermekként a családhoz"
 
-#: ../gramps/gui/editors/editfamily.py:115
+#: ../gramps/gui/editors/editfamily.py:117
 msgid "Move the child up in the children list"
 msgstr "A gyermek mozgatása a gyermeklistán felfelé"
 
-#: ../gramps/gui/editors/editfamily.py:116
+#: ../gramps/gui/editors/editfamily.py:118
 msgid "Move the child down in the children list"
 msgstr "A gyermek mozgatása a gyermeklistán lefelé"
 
-#: ../gramps/gui/editors/editfamily.py:121
+#: ../gramps/gui/editors/editfamily.py:123
 msgid "#"
 msgstr "#"
 
-#: ../gramps/gui/editors/editfamily.py:125
+#: ../gramps/gui/editors/editfamily.py:127
 msgid "Paternal"
 msgstr "Apai"
 
-#: ../gramps/gui/editors/editfamily.py:126
+#: ../gramps/gui/editors/editfamily.py:128
 msgid "Maternal"
 msgstr "Anyai"
 
-#: ../gramps/gui/editors/editfamily.py:127
-#: ../gramps/gui/selectors/selectperson.py:96
+#: ../gramps/gui/editors/editfamily.py:129
+#: ../gramps/gui/selectors/selectperson.py:93
 #: ../gramps/plugins/gramplet/children.py:94
 #: ../gramps/plugins/gramplet/children.py:193
 #: ../gramps/plugins/lib/libpersonview.py:101
@@ -13532,60 +13805,61 @@ msgstr "Anyai"
 #: ../gramps/plugins/quickview/samesurnames.py:115
 #: ../gramps/plugins/quickview/samesurnames.py:160
 #: ../gramps/plugins/quickview/siblings.py:48
-#: ../gramps/plugins/webreport/basepage.py:379
+#: ../gramps/plugins/webreport/basepage.py:398
 msgid "Birth Date"
 msgstr "Születési dátum"
 
-#: ../gramps/gui/editors/editfamily.py:128
-#: ../gramps/gui/selectors/selectperson.py:98
+#: ../gramps/gui/editors/editfamily.py:130
+#: ../gramps/gui/selectors/selectperson.py:95
 #: ../gramps/plugins/gramplet/children.py:96
 #: ../gramps/plugins/gramplet/children.py:195
 #: ../gramps/plugins/lib/libpersonview.py:103
 #: ../gramps/plugins/quickview/lineage.py:61
 #: ../gramps/plugins/quickview/lineage.py:93
-#: ../gramps/plugins/webreport/basepage.py:380
+#: ../gramps/plugins/webreport/basepage.py:399
 msgid "Death Date"
 msgstr "Halálozási dátum"
 
-#: ../gramps/gui/editors/editfamily.py:129
-#: ../gramps/gui/selectors/selectperson.py:97
+#: ../gramps/gui/editors/editfamily.py:131
+#: ../gramps/gui/selectors/selectperson.py:94
 #: ../gramps/plugins/lib/libpersonview.py:102
 msgid "Birth Place"
 msgstr "Születési hely"
 
-#: ../gramps/gui/editors/editfamily.py:130
-#: ../gramps/gui/selectors/selectperson.py:99
+#: ../gramps/gui/editors/editfamily.py:132
+#: ../gramps/gui/selectors/selectperson.py:96
 #: ../gramps/plugins/lib/libpersonview.py:104
 msgid "Death Place"
 msgstr "Halálozási hely"
 
-#: ../gramps/gui/editors/editfamily.py:142
+#: ../gramps/gui/editors/editfamily.py:145
 msgid "Chil_dren"
 msgstr "Gyerme_kek"
 
-#: ../gramps/gui/editors/editfamily.py:147
+#: ../gramps/gui/editors/editfamily.py:194
 msgid "Edit child"
 msgstr "Gyermek szerkesztése"
 
-#: ../gramps/gui/editors/editfamily.py:149
+#: ../gramps/gui/editors/editfamily.py:196
 msgid "Add an existing child"
 msgstr "Egy létező gyermek hozzáadása"
 
-#: ../gramps/gui/editors/editfamily.py:150
+#: ../gramps/gui/editors/editfamily.py:197
 msgid "Edit relationship"
 msgstr "Kapcsolat szerkesztése"
 
-#: ../gramps/gui/editors/editfamily.py:217
-#: ../gramps/gui/editors/editfamily.py:232
-#: ../gramps/plugins/view/relview.py:1556
+#: ../gramps/gui/editors/editfamily.py:267
+#: ../gramps/gui/editors/editfamily.py:282
+#: ../gramps/gui/selectors/selectperson.py:67
+#: ../gramps/plugins/view/relview.py:1727
 msgid "Select Child"
 msgstr "Gyermek kiválasztása"
 
-#: ../gramps/gui/editors/editfamily.py:365
+#: ../gramps/gui/editors/editfamily.py:417
 msgid "Adding parents to a person"
 msgstr "Szülők hozzáadása egy személyhez"
 
-#: ../gramps/gui/editors/editfamily.py:366
+#: ../gramps/gui/editors/editfamily.py:418
 msgid ""
 "It is possible to accidentally create multiple families with the same "
 "parents. To help avoid this problem, only the buttons to select parents are "
@@ -13597,11 +13871,11 @@ msgstr ""
 "család létrehozásakor. A további mezők csak egy szülő kiválasztása után "
 "lesznek elérhetőek."
 
-#: ../gramps/gui/editors/editfamily.py:461
+#: ../gramps/gui/editors/editfamily.py:523
 msgid "Family has changed"
 msgstr "Család változott"
 
-#: ../gramps/gui/editors/editfamily.py:462
+#: ../gramps/gui/editors/editfamily.py:524
 #, python-format
 msgid ""
 "The %(object)s you are editing has changed outside this editor. This can be "
@@ -13616,60 +13890,62 @@ msgstr ""
 "A mutatott információ hibátlansága biztosításához az itt mutatott adat "
 "frissítve lett. Néhány korábbi szerkesztése elveszhetett."
 
-#: ../gramps/gui/editors/editfamily.py:467
-#: ../gramps/plugins/importer/importcsv.py:211
-#: ../gramps/plugins/view/familyview.py:262
+#: ../gramps/gui/editors/editfamily.py:529
+#: ../gramps/plugins/importer/importcsv.py:227
+#: ../gramps/plugins/view/familyview.py:387
 msgid "family"
 msgstr "család"
 
-#: ../gramps/gui/editors/editfamily.py:498
-#: ../gramps/gui/editors/editfamily.py:501
+#: ../gramps/gui/editors/editfamily.py:560
+#: ../gramps/gui/editors/editfamily.py:563
 msgid "New Family"
 msgstr "Új család"
 
-#: ../gramps/gui/editors/editfamily.py:505
-#: ../gramps/gui/editors/editfamily.py:1134
-#: ../gramps/plugins/view/geofamily.py:424
+#: ../gramps/gui/editors/editfamily.py:567
+#: ../gramps/gui/editors/editfamily.py:1184
+#: ../gramps/plugins/view/geofamily.py:474
 msgid "Edit Family"
 msgstr "Család szerkesztése"
 
-#: ../gramps/gui/editors/editfamily.py:536
+#: ../gramps/gui/editors/editfamily.py:598
 msgid "Select a person as the mother"
 msgstr "Egy személy kiválasztása anyaként"
 
-#: ../gramps/gui/editors/editfamily.py:537
+#: ../gramps/gui/editors/editfamily.py:599
 msgid "Add a new person as the mother"
 msgstr "Egy új személy hozzáadása anyaként"
 
-#: ../gramps/gui/editors/editfamily.py:538
+#: ../gramps/gui/editors/editfamily.py:600
 msgid "Remove the person as the mother"
 msgstr "Egy személy eltávolítása mint anya"
 
-#: ../gramps/gui/editors/editfamily.py:551
+#: ../gramps/gui/editors/editfamily.py:613
 msgid "Select a person as the father"
 msgstr "Egy személy kiválasztása apaként"
 
-#: ../gramps/gui/editors/editfamily.py:552
+#: ../gramps/gui/editors/editfamily.py:614
 msgid "Add a new person as the father"
 msgstr "Egy új személy hozzáadása apaként"
 
-#: ../gramps/gui/editors/editfamily.py:553
+#: ../gramps/gui/editors/editfamily.py:615
 msgid "Remove the person as the father"
 msgstr "Egy személy eltávolítása mint apa"
 
-#: ../gramps/gui/editors/editfamily.py:834
+#: ../gramps/gui/editors/editfamily.py:884
+#: ../gramps/gui/selectors/selectperson.py:65
 msgid "Select Mother"
 msgstr "Anya kiválasztása"
 
-#: ../gramps/gui/editors/editfamily.py:879
+#: ../gramps/gui/editors/editfamily.py:929
+#: ../gramps/gui/selectors/selectperson.py:63
 msgid "Select Father"
 msgstr "Apa kiválasztása"
 
-#: ../gramps/gui/editors/editfamily.py:903
+#: ../gramps/gui/editors/editfamily.py:953
 msgid "Duplicate Family"
 msgstr "Család megkettőzése"
 
-#: ../gramps/gui/editors/editfamily.py:904
+#: ../gramps/gui/editors/editfamily.py:954
 msgid ""
 "A family with these parents already exists in the database. If you save, you "
 "will create a duplicate family. It is recommended that you cancel the "
@@ -13679,45 +13955,45 @@ msgstr ""
 "megkettőzött családot fog létrehozni. Javasolt a szerkesztés megszakítása "
 "ebben az ablakban és válassza a létező családot"
 
-#: ../gramps/gui/editors/editfamily.py:954
+#: ../gramps/gui/editors/editfamily.py:1004
 #, python-format
 msgid "Edit %s"
 msgstr "%s szerkesztése"
 
-#: ../gramps/gui/editors/editfamily.py:1063
+#: ../gramps/gui/editors/editfamily.py:1113
 msgid "A father cannot be his own child"
 msgstr "Apa nem lehet a saját gyermeke"
 
-#: ../gramps/gui/editors/editfamily.py:1064
+#: ../gramps/gui/editors/editfamily.py:1114
 #, python-format
 msgid "%s is listed as both the father and child of the family."
 msgstr "%s apaként és gyermekként is szerepel a családban."
 
-#: ../gramps/gui/editors/editfamily.py:1074
+#: ../gramps/gui/editors/editfamily.py:1124
 msgid "A mother cannot be her own child"
 msgstr "Anya nem lehet a saját gyermeke"
 
-#: ../gramps/gui/editors/editfamily.py:1075
+#: ../gramps/gui/editors/editfamily.py:1125
 #, python-format
 msgid "%s is listed as both the mother and child of the family."
 msgstr "%s anyaként és gyermekként is szerepel a családban."
 
-#: ../gramps/gui/editors/editfamily.py:1083
+#: ../gramps/gui/editors/editfamily.py:1133
 msgid "Cannot save family"
 msgstr "Nem menthető család"
 
-#: ../gramps/gui/editors/editfamily.py:1084
+#: ../gramps/gui/editors/editfamily.py:1134
 msgid "No data exists for this family. Please enter data or cancel the edit."
 msgstr ""
 "Nincs adat erről a családról. Adjon meg adatot, vagy szakítsa meg a "
 "szerkesztést."
 
-#: ../gramps/gui/editors/editfamily.py:1092
+#: ../gramps/gui/editors/editfamily.py:1142
 msgid "Cannot save family. ID already exists."
 msgstr "A család nem menthető. Az azonosító már létezik."
 
-#: ../gramps/gui/editors/editfamily.py:1093
-#: ../gramps/gui/editors/editnote.py:327
+#: ../gramps/gui/editors/editfamily.py:1143
+#: ../gramps/gui/editors/editnote.py:328
 #: ../gramps/gui/editors/editreference.py:295
 #, python-format
 msgid ""
@@ -13729,7 +14005,7 @@ msgstr ""
 "érték már használt. Kérem vigyen be más azonosítót, vagy hagyja üresen a "
 "helyet a következő lehetséges azonosító értékhez."
 
-#: ../gramps/gui/editors/editfamily.py:1108
+#: ../gramps/gui/editors/editfamily.py:1158
 msgid "Add Family"
 msgstr "Család hozzáadása"
 
@@ -13763,7 +14039,7 @@ msgstr "%(mother)s [%(gramps_id)s]"
 msgid "manual|Link_Editor"
 msgstr "manual|Hivatkozás_szerkesztő"
 
-#: ../gramps/gui/editors/editlink.py:87 ../gramps/gui/editors/editlink.py:238
+#: ../gramps/gui/editors/editlink.py:87 ../gramps/gui/editors/editlink.py:239
 msgid "Link Editor"
 msgstr "Hivatkozás szerkesztő"
 
@@ -13794,27 +14070,27 @@ msgstr "Új média"
 msgid "Edit Media Object"
 msgstr "Média objektum szerkesztése"
 
-#: ../gramps/gui/editors/editmedia.py:286
+#: ../gramps/gui/editors/editmedia.py:288
 msgid "Cannot save media object"
 msgstr "Nem menthető média objektum"
 
-#: ../gramps/gui/editors/editmedia.py:287
+#: ../gramps/gui/editors/editmedia.py:289
 msgid ""
 "No data exists for this media object. Please enter data or cancel the edit."
 msgstr ""
 "Nincs adat erről a média objektumról. Adjon meg adatot, vagy szakítsa meg a "
 "szerkesztést."
 
-#: ../gramps/gui/editors/editmedia.py:297
+#: ../gramps/gui/editors/editmedia.py:299
 #: ../gramps/gui/editors/editreference.py:280
 msgid "Cannot save media object. ID already exists."
 msgstr "A média objektum nem menthető. Az azonosító már létezik."
 
-#: ../gramps/gui/editors/editmedia.py:312
+#: ../gramps/gui/editors/editmedia.py:314
 msgid "There is no media matching the current path value!"
 msgstr "Nincs a jelenlegi útvonal értéknek megfelelő média!"
 
-#: ../gramps/gui/editors/editmedia.py:313
+#: ../gramps/gui/editors/editmedia.py:315
 #, python-format
 msgid ""
 "You have attempted to use the path with value '%(path)s'. This path does not "
@@ -13823,19 +14099,19 @@ msgstr ""
 "Ön egy '%(path)s' útvonalat próbál használni. Ez az útvonal nem létezik! "
 "Kérem vigyen be más útvonalat"
 
-#: ../gramps/gui/editors/editmedia.py:324
-#: ../gramps/gui/editors/editmediaref.py:526
+#: ../gramps/gui/editors/editmedia.py:326
+#: ../gramps/gui/editors/editmediaref.py:527
 #, python-format
 msgid "Add Media Object (%s)"
 msgstr "(%s) média objektum hozzáadása"
 
-#: ../gramps/gui/editors/editmedia.py:329
-#: ../gramps/gui/editors/editmediaref.py:520
+#: ../gramps/gui/editors/editmedia.py:331
+#: ../gramps/gui/editors/editmediaref.py:521
 #, python-format
 msgid "Edit Media Object (%s)"
 msgstr "(%s) média objektum szerkesztése"
 
-#: ../gramps/gui/editors/editmedia.py:369
+#: ../gramps/gui/editors/editmedia.py:371
 msgid "Remove Media Object"
 msgstr "Média objektum eltávolítása"
 
@@ -13864,7 +14140,7 @@ msgid "manual|Name_Editor"
 msgstr "manual|_Névszerkesztő"
 
 #: ../gramps/gui/editors/editname.py:174
-#: ../gramps/gui/editors/editperson.py:324
+#: ../gramps/gui/editors/editperson.py:318
 msgid "Call name must be the given name that is normally used."
 msgstr "A hívó névnek az általában használt keresztnévnek kell lennie."
 
@@ -13937,34 +14213,34 @@ msgstr "Új jegyzet - %(context)s"
 msgid "New Note"
 msgstr "Új jegyzet"
 
-#: ../gramps/gui/editors/editnote.py:189
+#: ../gramps/gui/editors/editnote.py:188
 msgid "_Note"
 msgstr "_Jegyzet"
 
-#: ../gramps/gui/editors/editnote.py:293 ../gramps/gui/editors/editnote.py:342
-#: ../gramps/gui/editors/objectentries.py:436
+#: ../gramps/gui/editors/editnote.py:294 ../gramps/gui/editors/editnote.py:343
+#: ../gramps/gui/editors/objectentries.py:433
 msgid "Edit Note"
 msgstr "Jegyzet szerkesztése"
 
-#: ../gramps/gui/editors/editnote.py:317
+#: ../gramps/gui/editors/editnote.py:318
 msgid "Cannot save note"
 msgstr "Nem menthető jegyzet"
 
-#: ../gramps/gui/editors/editnote.py:318
+#: ../gramps/gui/editors/editnote.py:319
 msgid "No data exists for this note. Please enter data or cancel the edit."
 msgstr ""
 "Nincs adat erről a jegyzetről. Adjon meg adatot, vagy szakítsa meg a "
 "szerkesztést."
 
-#: ../gramps/gui/editors/editnote.py:326
+#: ../gramps/gui/editors/editnote.py:327
 msgid "Cannot save note. ID already exists."
 msgstr "A jegyzet nem menthető. Az azonosító már létezik."
 
-#: ../gramps/gui/editors/editnote.py:337
+#: ../gramps/gui/editors/editnote.py:338
 msgid "Add Note"
 msgstr "Jegyzet hozzáadása"
 
-#: ../gramps/gui/editors/editnote.py:360
+#: ../gramps/gui/editors/editnote.py:361
 #, python-format
 msgid "Delete Note (%s)"
 msgstr "(%s) jegyzet törlése"
@@ -13987,33 +14263,34 @@ msgstr "Új személy"
 msgid "manual|Editing_information_about_people"
 msgstr "manual|Információ_szerkesztés_emberekről"
 
-#: ../gramps/gui/editors/editperson.py:606
-#: ../gramps/plugins/view/geofamily.py:428
+#: ../gramps/gui/editors/editperson.py:600
+#: ../gramps/plugins/view/geofamily.py:478
 msgid "Edit Person"
 msgstr "Személy szerkesztése"
 
-#: ../gramps/gui/editors/editperson.py:649
-#: ../gramps/plugins/view/mediaview.py:211
+#: ../gramps/gui/editors/editperson.py:644
+#: ../gramps/plugins/view/mediaview.py:379
+#: ../gramps/plugins/view/mediaview.py:395
 msgid "View"
 msgstr "Nézet"
 
-#: ../gramps/gui/editors/editperson.py:651
+#: ../gramps/gui/editors/editperson.py:646
 msgid "Edit Object Properties"
 msgstr "Objektum tulajdonságok szerkesztése"
 
-#: ../gramps/gui/editors/editperson.py:690
+#: ../gramps/gui/editors/editperson.py:687
 msgid "Make Active Person"
 msgstr "Legyen aktív személy"
 
-#: ../gramps/gui/editors/editperson.py:694
+#: ../gramps/gui/editors/editperson.py:687
 msgid "Make Home Person"
 msgstr "Legyen kiinduló személy"
 
-#: ../gramps/gui/editors/editperson.py:808
+#: ../gramps/gui/editors/editperson.py:807
 msgid "Problem changing the gender"
 msgstr "Probléma a nem megváltoztatásakor"
 
-#: ../gramps/gui/editors/editperson.py:809
+#: ../gramps/gui/editors/editperson.py:808
 msgid ""
 "Changing the gender caused problems with marriage information.\n"
 "Please check the person's marriages."
@@ -14021,39 +14298,39 @@ msgstr ""
 "A nem megváltoztatása problémát okozott a házassági információban.\n"
 "Kérem ellenőrizze a személy házasságait."
 
-#: ../gramps/gui/editors/editperson.py:820
+#: ../gramps/gui/editors/editperson.py:819
 msgid "Cannot save person"
 msgstr "Nem menthető személy"
 
-#: ../gramps/gui/editors/editperson.py:821
+#: ../gramps/gui/editors/editperson.py:820
 msgid "No data exists for this person. Please enter data or cancel the edit."
 msgstr ""
 "Nincs adat erről a személyről. Adjon meg adatot, vagy szakítsa meg a "
 "szerkesztést."
 
-#: ../gramps/gui/editors/editperson.py:845
+#: ../gramps/gui/editors/editperson.py:844
 msgid "Cannot save person. ID already exists."
 msgstr "A személy nem menthető. Az azonosító már létezik."
 
-#: ../gramps/gui/editors/editperson.py:860
+#: ../gramps/gui/editors/editperson.py:859
 #, python-format
 msgid "Add Person (%s)"
 msgstr "(%s) személy hozzáadása"
 
-#: ../gramps/gui/editors/editperson.py:866
-#: ../gramps/plugins/view/relview.py:572 ../gramps/plugins/view/relview.py:989
-#: ../gramps/plugins/view/relview.py:1044
-#: ../gramps/plugins/view/relview.py:1163
-#: ../gramps/plugins/view/relview.py:1270
+#: ../gramps/gui/editors/editperson.py:865
+#: ../gramps/plugins/view/relview.py:703 ../gramps/plugins/view/relview.py:1154
+#: ../gramps/plugins/view/relview.py:1209
+#: ../gramps/plugins/view/relview.py:1323
+#: ../gramps/plugins/view/relview.py:1430
 #, python-format
 msgid "Edit Person (%s)"
 msgstr "(%s) személy szerkesztése"
 
-#: ../gramps/gui/editors/editperson.py:1098
+#: ../gramps/gui/editors/editperson.py:1097
 msgid "Unknown gender specified"
 msgstr "Ismeretlen nem megadása"
 
-#: ../gramps/gui/editors/editperson.py:1100
+#: ../gramps/gui/editors/editperson.py:1099
 msgid ""
 "The gender of the person is currently unknown. Usually, this is a mistake. "
 "Please specify the gender."
@@ -14061,15 +14338,15 @@ msgstr ""
 "A személy neme jelenleg ismeretlen. általában ez tévedés. Válassza ki a "
 "személy nemét."
 
-#: ../gramps/gui/editors/editperson.py:1103
+#: ../gramps/gui/editors/editperson.py:1102
 msgid "_Male"
 msgstr "_Férfi"
 
-#: ../gramps/gui/editors/editperson.py:1104
+#: ../gramps/gui/editors/editperson.py:1103
 msgid "_Female"
 msgstr "_Nő"
 
-#: ../gramps/gui/editors/editperson.py:1105
+#: ../gramps/gui/editors/editperson.py:1104
 msgid "_Unknown"
 msgstr "_Ismeretlen"
 
@@ -14078,19 +14355,19 @@ msgid "manual|Person_Reference_Editor"
 msgstr "manual|Személy_hivatkozás_szerkesztő"
 
 #: ../gramps/gui/editors/editpersonref.py:93
-#: ../gramps/gui/editors/editpersonref.py:222
+#: ../gramps/gui/editors/editpersonref.py:213
 msgid "Person Reference Editor"
 msgstr "Személy hivatkozás szerkesztő"
 
-#: ../gramps/gui/editors/editpersonref.py:222
+#: ../gramps/gui/editors/editpersonref.py:213
 msgid "Person Reference"
 msgstr "Személy hivatkozás"
 
-#: ../gramps/gui/editors/editpersonref.py:239
+#: ../gramps/gui/editors/editpersonref.py:230
 msgid "No person selected"
 msgstr "Nincs kiválasztott személy"
 
-#: ../gramps/gui/editors/editpersonref.py:240
+#: ../gramps/gui/editors/editpersonref.py:231
 msgid "You must either select a person or Cancel the edit"
 msgstr "Válasszon személyt, vagy szakítsa meg a szerkesztést"
 
@@ -14099,8 +14376,7 @@ msgid "manual|Place_Editor_dialog"
 msgstr "manual|Hely_Szerkesztő_párbeszéd_ablak"
 
 #: ../gramps/gui/editors/editplace.py:91
-#: ../gramps/gui/glade/editplace.glade:354 ../gramps/gui/merge/mergeplace.py:55
-#: ../gramps/gui/glade/editplace.glade:355
+#: ../gramps/gui/glade/editplace.glade:355 ../gramps/gui/merge/mergeplace.py:55
 msgid "place|Name:"
 msgstr "Hely név:"
 
@@ -14136,9 +14412,9 @@ msgstr ""
 "(szintaktika: 18\\u00b09'48.21\"E, -18.2412 or -18:9:48.21)"
 
 #: ../gramps/gui/editors/editplace.py:217
-#: ../gramps/plugins/lib/maps/geography.py:924
-#: ../gramps/plugins/view/geoplaces.py:435
-#: ../gramps/plugins/view/geoplaces.py:461
+#: ../gramps/plugins/lib/maps/geography.py:891
+#: ../gramps/plugins/view/geoplaces.py:494
+#: ../gramps/plugins/view/geoplaces.py:520
 msgid "Edit Place"
 msgstr "Hely szerkesztése"
 
@@ -14213,11 +14489,11 @@ msgstr "Hely módosítása"
 msgid "Add Place"
 msgstr "Hely hozzáadása"
 
-#: ../gramps/gui/editors/editprimary.py:238
+#: ../gramps/gui/editors/editprimary.py:244
 msgid "Save Changes?"
 msgstr "Változások mentése?"
 
-#: ../gramps/gui/editors/editprimary.py:239
+#: ../gramps/gui/editors/editprimary.py:245
 msgid "If you close without saving, the changes you have made will be lost"
 msgstr "Ha mentés nélkül zárja be, akkor a változtatások elvesznek"
 
@@ -14340,56 +14616,6 @@ msgstr "manual|Címke_kiválasztó_párbeszéd_ablak"
 msgid "Tag selection"
 msgstr "Címke kiválasztása"
 
-#: ../gramps/gui/editors/edittaglist.py:118
-#: ../gramps/gui/glade/addmedia.glade:55
-#: ../gramps/gui/glade/baseselector.glade:56
-#: ../gramps/gui/glade/clipboard.glade:21 ../gramps/gui/glade/dbman.glade:150
-#: ../gramps/gui/glade/editaddress.glade:55
-#: ../gramps/gui/glade/editattribute.glade:54
-#: ../gramps/gui/glade/editchildref.glade:58
-#: ../gramps/gui/glade/editcitation.glade:27
-#: ../gramps/gui/glade/editdate.glade:53 ../gramps/gui/glade/editevent.glade:58
-#: ../gramps/gui/glade/editeventref.glade:22
-#: ../gramps/gui/glade/editfamily.glade:60
-#: ../gramps/gui/glade/editldsord.glade:75
-#: ../gramps/gui/glade/editlink.glade:58
-#: ../gramps/gui/glade/editlocation.glade:54
-#: ../gramps/gui/glade/editmedia.glade:55
-#: ../gramps/gui/glade/editmediaref.glade:75
-#: ../gramps/gui/glade/editname.glade:59 ../gramps/gui/glade/editnote.glade:53
-#: ../gramps/gui/glade/editperson.glade:82
-#: ../gramps/gui/glade/editpersonref.glade:57
-#: ../gramps/gui/glade/editplace.glade:52
-#: ../gramps/gui/glade/editplacename.glade:55
-#: ../gramps/gui/glade/editplaceref.glade:22
-#: ../gramps/gui/glade/editreporef.glade:61
-#: ../gramps/gui/glade/editrepository.glade:59
-#: ../gramps/gui/glade/editsource.glade:58 ../gramps/gui/glade/editurl.glade:57
-#: ../gramps/gui/glade/mergecitation.glade:53
-#: ../gramps/gui/glade/mergedata.glade:77
-#: ../gramps/gui/glade/mergedata.glade:278
-#: ../gramps/gui/glade/mergedata.glade:468
-#: ../gramps/gui/glade/mergedata.glade:698
-#: ../gramps/gui/glade/mergeevent.glade:53
-#: ../gramps/gui/glade/mergefamily.glade:53
-#: ../gramps/gui/glade/mergemedia.glade:53
-#: ../gramps/gui/glade/mergenote.glade:53
-#: ../gramps/gui/glade/mergeperson.glade:53
-#: ../gramps/gui/glade/mergeplace.glade:51
-#: ../gramps/gui/glade/mergerepository.glade:53
-#: ../gramps/gui/glade/mergesource.glade:53
-#: ../gramps/gui/glade/reorder.glade:54 ../gramps/gui/glade/rule.glade:41
-#: ../gramps/gui/glade/rule.glade:351 ../gramps/gui/glade/rule.glade:781
-#: ../gramps/gui/logger/_errorview.py:175
-#: ../gramps/gui/plug/report/_reportdialog.py:159
-#: ../gramps/gui/undohistory.py:82 ../gramps/gui/viewmanager.py:521
-#: ../gramps/gui/views/bookmarks.py:287 ../gramps/gui/views/tags.py:433
-#: ../gramps/gui/views/tags.py:647 ../gramps/gui/widgets/grampletbar.py:641
-#: ../gramps/gui/widgets/grampletpane.py:237
-#: ../gramps/plugins/tool/testcasegenerator.py:329
-msgid "_Help"
-msgstr "_Súgó"
-
 #: ../gramps/gui/editors/editurl.py:47
 msgid "manual|Internet_Address_Editor"
 msgstr "manual|Internet_cím_szerkesztő"
@@ -14398,121 +14624,121 @@ msgstr "manual|Internet_cím_szerkesztő"
 msgid "Internet Address Editor"
 msgstr "Internet hozzáférés szerkesztő"
 
-#: ../gramps/gui/editors/filtereditor.py:83
+#: ../gramps/gui/editors/filtereditor.py:84
 msgid "manual|Add_Rule_dialog"
 msgstr "manual|Szabály_hozzáadás_párbeszéd_ablak"
 
-#: ../gramps/gui/editors/filtereditor.py:84
+#: ../gramps/gui/editors/filtereditor.py:85
 msgid "manual|Define_Filter_dialog"
 msgstr "manual|Szűrő_meghatározás_párbeszéd_ablak"
 
-#: ../gramps/gui/editors/filtereditor.py:85
+#: ../gramps/gui/editors/filtereditor.py:86
 msgid "manual|Custom_Filters"
 msgstr "manual|Egyéni_szűrők"
 
-#: ../gramps/gui/editors/filtereditor.py:89
+#: ../gramps/gui/editors/filtereditor.py:90
 msgid "Person Filters"
 msgstr "Személyszűrők"
 
-#: ../gramps/gui/editors/filtereditor.py:90
+#: ../gramps/gui/editors/filtereditor.py:91
 msgid "Family Filters"
 msgstr "Család szűrők"
 
-#: ../gramps/gui/editors/filtereditor.py:91
+#: ../gramps/gui/editors/filtereditor.py:92
 msgid "Event Filters"
 msgstr "Esemény szűrők"
 
-#: ../gramps/gui/editors/filtereditor.py:92
+#: ../gramps/gui/editors/filtereditor.py:93
 msgid "Place Filters"
 msgstr "Hely szűrők"
 
-#: ../gramps/gui/editors/filtereditor.py:93
+#: ../gramps/gui/editors/filtereditor.py:94
 msgid "Source Filters"
 msgstr "Forrás szűrők"
 
-#: ../gramps/gui/editors/filtereditor.py:94
+#: ../gramps/gui/editors/filtereditor.py:95
 msgid "Media Filters"
 msgstr "Médiaszűrők"
 
-#: ../gramps/gui/editors/filtereditor.py:95
+#: ../gramps/gui/editors/filtereditor.py:96
 msgid "Repository Filters"
 msgstr "Tároló szűrők"
 
-#: ../gramps/gui/editors/filtereditor.py:96
+#: ../gramps/gui/editors/filtereditor.py:97
 msgid "Note Filters"
 msgstr "Jegyzet szűrők"
 
-#: ../gramps/gui/editors/filtereditor.py:97
+#: ../gramps/gui/editors/filtereditor.py:98
 msgid "Citation Filters"
 msgstr "Idézet szűrők"
 
-#: ../gramps/gui/editors/filtereditor.py:251
+#: ../gramps/gui/editors/filtereditor.py:252
 msgid "equal to"
 msgstr "egyenlő"
 
-#: ../gramps/gui/editors/filtereditor.py:251
+#: ../gramps/gui/editors/filtereditor.py:252
 msgid "greater than"
 msgstr "nagyobb mint"
 
-#: ../gramps/gui/editors/filtereditor.py:289
+#: ../gramps/gui/editors/filtereditor.py:290
 msgid "Not a valid ID"
 msgstr "Nem érvényes azonosító"
 
-#: ../gramps/gui/editors/filtereditor.py:318
+#: ../gramps/gui/editors/filtereditor.py:319
 msgid "Select..."
 msgstr "Kiválasztás..."
 
-#: ../gramps/gui/editors/filtereditor.py:323
+#: ../gramps/gui/editors/filtereditor.py:324
 #, python-format
 msgid "Select %s from a list"
 msgstr "%s kiválasztása listáról"
 
-#: ../gramps/gui/editors/filtereditor.py:390
+#: ../gramps/gui/editors/filtereditor.py:391
 msgid "Give or select a source ID, leave empty to find objects with no source."
 msgstr ""
 "Adja meg, vagy válassza ki a forrás azonosítót, hagyja üresen a mezőt forrás "
 "nélküli objektumok keresésekor."
 
-#: ../gramps/gui/editors/filtereditor.py:562
+#: ../gramps/gui/editors/filtereditor.py:567
 msgid "Include selected Gramps ID"
 msgstr "A kiválasztott GRAMPS Azonosítókkal együtt"
 
-#: ../gramps/gui/editors/filtereditor.py:564
+#: ../gramps/gui/editors/filtereditor.py:569
 msgid "Use exact case of letters"
 msgstr "Használjon pontos kis/nagy betűket"
 
-#: ../gramps/gui/editors/filtereditor.py:565
+#: ../gramps/gui/editors/filtereditor.py:570
 msgid "Regular-Expression matching:"
 msgstr "Reguláris kifejezésnek megfelelőek:"
 
-#: ../gramps/gui/editors/filtereditor.py:566
+#: ../gramps/gui/editors/filtereditor.py:571
 msgid "Use regular expression"
 msgstr "Használjon reguláris kifejezést"
 
-#: ../gramps/gui/editors/filtereditor.py:568
+#: ../gramps/gui/editors/filtereditor.py:573
 msgid "Also family events where person is spouse"
 msgstr "Családi eseményeket szintén, ahol a személy házastárs"
 
-#: ../gramps/gui/editors/filtereditor.py:570
+#: ../gramps/gui/editors/filtereditor.py:575
 msgid "Only include primary participants"
 msgstr "Csak elsődleges résztvevőkkel"
 
-#: ../gramps/gui/editors/filtereditor.py:586
+#: ../gramps/gui/editors/filtereditor.py:591
 #: ../gramps/gui/widgets/placewithin.py:73
 msgid "degrees"
 msgstr "fok"
 
-#: ../gramps/gui/editors/filtereditor.py:586
+#: ../gramps/gui/editors/filtereditor.py:591
 #: ../gramps/gui/widgets/placewithin.py:73
 msgid "kilometers"
 msgstr "kilométer"
 
-#: ../gramps/gui/editors/filtereditor.py:586
+#: ../gramps/gui/editors/filtereditor.py:591
 #: ../gramps/gui/widgets/placewithin.py:73
 msgid "miles"
 msgstr "mérföld"
 
-#: ../gramps/gui/editors/filtereditor.py:597
+#: ../gramps/gui/editors/filtereditor.py:605
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:76
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:80
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:97
@@ -14525,7 +14751,7 @@ msgstr "mérföld"
 msgid "Use regular expressions"
 msgstr "Reguláris kifejezések használata"
 
-#: ../gramps/gui/editors/filtereditor.py:598
+#: ../gramps/gui/editors/filtereditor.py:606
 msgid ""
 "Interpret the contents of string fields as regular expressions.\n"
 "A decimal point will match any character. A question mark will match zero or "
@@ -14543,44 +14769,44 @@ msgstr ""
 "jelöli. A hiányjel (^) egy sor kezdetét jelöli. A dollárjel a sor végét "
 "jelöli."
 
-#: ../gramps/gui/editors/filtereditor.py:627
+#: ../gramps/gui/editors/filtereditor.py:635
 msgid "Rule Name"
 msgstr "Szabály neve"
 
-#: ../gramps/gui/editors/filtereditor.py:758
-#: ../gramps/gui/editors/filtereditor.py:762 ../gramps/gui/glade/rule.glade:914
+#: ../gramps/gui/editors/filtereditor.py:772
+#: ../gramps/gui/editors/filtereditor.py:776 ../gramps/gui/glade/rule.glade:914
 msgid "No rule selected"
 msgstr "Nincs szabály kiválasztva"
 
-#: ../gramps/gui/editors/filtereditor.py:815
+#: ../gramps/gui/editors/filtereditor.py:829
 msgid "Define filter"
 msgstr "Szűrő meghatározása"
 
-#: ../gramps/gui/editors/filtereditor.py:919
+#: ../gramps/gui/editors/filtereditor.py:933
 msgid "Add Rule"
 msgstr "Szabály hozzáadása"
 
-#: ../gramps/gui/editors/filtereditor.py:931
+#: ../gramps/gui/editors/filtereditor.py:945
 msgid "Edit Rule"
 msgstr "Szabály szerkesztése"
 
-#: ../gramps/gui/editors/filtereditor.py:966
+#: ../gramps/gui/editors/filtereditor.py:980
 msgid "Filter Test"
 msgstr "Szűrő tesztelése"
 
-#: ../gramps/gui/editors/filtereditor.py:1105
+#: ../gramps/gui/editors/filtereditor.py:1119
 msgid "Comment"
 msgstr "Megjegyzés"
 
-#: ../gramps/gui/editors/filtereditor.py:1113
+#: ../gramps/gui/editors/filtereditor.py:1127
 msgid "Custom Filter Editor"
 msgstr "Egyéni szűrő szerkesztő"
 
-#: ../gramps/gui/editors/filtereditor.py:1185
+#: ../gramps/gui/editors/filtereditor.py:1199
 msgid "Delete Filter?"
 msgstr "A szűrő törlése?"
 
-#: ../gramps/gui/editors/filtereditor.py:1186
+#: ../gramps/gui/editors/filtereditor.py:1200
 msgid ""
 "This filter is currently being used as the base for other filters. Deleting "
 "this filter will result in removing all other filters that depend on it."
@@ -14588,117 +14814,114 @@ msgstr ""
 "Ez a szűrő használatban van és alapja más szűrőknek. A szűrő törlése minden "
 "más tőle függő szűrőt is eltávolít."
 
-#: ../gramps/gui/editors/filtereditor.py:1190
+#: ../gramps/gui/editors/filtereditor.py:1204
 msgid "Delete Filter"
 msgstr "A szűrő törlése"
 
-#: ../gramps/gui/editors/objectentries.py:294
+#: ../gramps/gui/editors/objectentries.py:291
 msgid "To select a place, use drag-and-drop or use the buttons"
 msgstr ""
 "Hely kiválasztásához használja a fogd-és-ejtsd módszert, vagy a gombokat"
 
-#: ../gramps/gui/editors/objectentries.py:296
+#: ../gramps/gui/editors/objectentries.py:293
 msgid "No place given, click button to select one"
 msgstr "Nincs megadva hely, kattintson a gombon egynek a kiválasztásához"
 
-#: ../gramps/gui/editors/objectentries.py:297
+#: ../gramps/gui/editors/objectentries.py:294
 msgid "Edit place"
 msgstr "Hely szerkesztése"
 
-#: ../gramps/gui/editors/objectentries.py:298
+#: ../gramps/gui/editors/objectentries.py:295
 msgid "Select an existing place"
 msgstr "Egy létező hely kiválasztása"
 
-#: ../gramps/gui/editors/objectentries.py:299
-#: ../gramps/plugins/lib/libplaceview.py:102
+#: ../gramps/gui/editors/objectentries.py:296
+#: ../gramps/plugins/lib/libplaceview.py:103
 msgid "Add a new place"
 msgstr "Új hely hozzáadása"
 
-#: ../gramps/gui/editors/objectentries.py:300
+#: ../gramps/gui/editors/objectentries.py:297
 msgid "Remove place"
 msgstr "Hely eltávolítása"
 
-#: ../gramps/gui/editors/objectentries.py:341
+#: ../gramps/gui/editors/objectentries.py:338
 msgid "To select a source, use drag-and-drop or use the buttons"
 msgstr ""
 "Forrás kiválasztásához használja a fogd-és-ejtsd módszert, vagy a gombokat"
 
-#: ../gramps/gui/editors/objectentries.py:343
+#: ../gramps/gui/editors/objectentries.py:340
 msgid "First add a source using the button"
 msgstr "Először adjon hozzá forrást a gombbal"
 
-#: ../gramps/gui/editors/objectentries.py:344
+#: ../gramps/gui/editors/objectentries.py:341
 msgid "Edit source"
 msgstr "Forrás szerkesztése"
 
-#: ../gramps/gui/editors/objectentries.py:345
+#: ../gramps/gui/editors/objectentries.py:342
 msgid "Select an existing source"
 msgstr "Egy létező forrás kiválasztása"
 
-#: ../gramps/gui/editors/objectentries.py:346
+#: ../gramps/gui/editors/objectentries.py:343
 #: ../gramps/plugins/view/citationlistview.py:125
 #: ../gramps/plugins/view/citationtreeview.py:122
 #: ../gramps/plugins/view/sourceview.py:98
 msgid "Add a new source"
 msgstr "Új forrás hozzáadása"
 
-#: ../gramps/gui/editors/objectentries.py:347
+#: ../gramps/gui/editors/objectentries.py:344
 msgid "Remove source"
 msgstr "Forrás eltávolítása"
 
-#: ../gramps/gui/editors/objectentries.py:387
+#: ../gramps/gui/editors/objectentries.py:384
 msgid "To select a media object, use drag-and-drop or use the buttons"
 msgstr ""
 "Média objektum kiválasztásához használja a fogd-és-ejtsd módszert, vagy a "
 "gombokat"
 
-#: ../gramps/gui/editors/objectentries.py:389
-#: ../gramps/gui/plug/_guioptions.py:1114
+#: ../gramps/gui/editors/objectentries.py:386
 #: ../gramps/gui/plug/_guioptions.py:1116
 msgid "No image given, click button to select one"
 msgstr "Nincs megadva kép, kattintson a gombon egynek a kiválasztásához"
 
-#: ../gramps/gui/editors/objectentries.py:390
+#: ../gramps/gui/editors/objectentries.py:387
 msgid "Edit media object"
 msgstr "Média objektum szerkesztése"
 
-#: ../gramps/gui/editors/objectentries.py:391
-#: ../gramps/gui/plug/_guioptions.py:1092
+#: ../gramps/gui/editors/objectentries.py:388
 #: ../gramps/gui/plug/_guioptions.py:1094
 msgid "Select an existing media object"
 msgstr "Egy létező média objektum kiválasztása"
 
-#: ../gramps/gui/editors/objectentries.py:392
+#: ../gramps/gui/editors/objectentries.py:389
 #: ../gramps/plugins/view/mediaview.py:112
 msgid "Add a new media object"
 msgstr "Új média objektum hozzáadása"
 
-#: ../gramps/gui/editors/objectentries.py:393
+#: ../gramps/gui/editors/objectentries.py:390
 msgid "Remove media object"
 msgstr "Média objektum eltávolítása"
 
-#: ../gramps/gui/editors/objectentries.py:433
+#: ../gramps/gui/editors/objectentries.py:430
 msgid "To select a note, use drag-and-drop or use the buttons"
 msgstr ""
 "Jegyzet kiválasztásához használja a fogd-és-ejtsd módszert, vagy a gombokat"
 
-#: ../gramps/gui/editors/objectentries.py:435
-#: ../gramps/gui/plug/_guioptions.py:1012
+#: ../gramps/gui/editors/objectentries.py:432
 #: ../gramps/gui/plug/_guioptions.py:1014
 msgid "No note given, click button to select one"
 msgstr "Nincs megadva jegyzet, kattintson a gombon egynek a kiválasztásához"
 
-#: ../gramps/gui/editors/objectentries.py:437
-#: ../gramps/gui/plug/_guioptions.py:987 ../gramps/gui/plug/_guioptions.py:989
+#: ../gramps/gui/editors/objectentries.py:434
+#: ../gramps/gui/plug/_guioptions.py:989
 msgid "Select an existing note"
 msgstr "Egy létező jegyzet kiválasztása"
 
-#: ../gramps/gui/editors/objectentries.py:438
+#: ../gramps/gui/editors/objectentries.py:435
 #: ../gramps/plugins/view/noteview.py:93
 msgid "Add a new note"
 msgstr "Új jegyzet hozzáadása"
 
-#: ../gramps/gui/editors/objectentries.py:439
+#: ../gramps/gui/editors/objectentries.py:436
 msgid "Remove note"
 msgstr "Jegyzet eltávolítása"
 
@@ -14732,8 +14955,9 @@ msgstr "%s nem"
 msgid "%s does not contain"
 msgstr "%s nem tartalmazza"
 
-#: ../gramps/gui/filters/_searchbar.py:168 ../gramps/gui/views/listview.py:1177
-#: ../gramps/gui/views/listview.py:1197
+#: ../gramps/gui/filters/_searchbar.py:168 ../gramps/gui/views/listview.py:1188
+#: ../gramps/gui/views/listview.py:1208 ../gramps/plugins/gramplet/leak.py:193
+#: ../gramps/plugins/gramplet/leak.py:200
 msgid "Updating display..."
 msgstr "Képernyő frissítése..."
 
@@ -14779,10 +15003,10 @@ msgid "Participants"
 msgstr "Résztvevők"
 
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:125
-#: ../gramps/gui/widgets/reorderfam.py:91
+#: ../gramps/gui/widgets/reorderfam.py:103
 #: ../gramps/plugins/textreport/tagreport.py:264
 #: ../gramps/plugins/view/familyview.py:82
-#: ../gramps/plugins/webreport/person.py:1168
+#: ../gramps/plugins/webreport/person.py:1241
 msgid "Relationship"
 msgstr "Rokonság"
 
@@ -14792,7 +15016,7 @@ msgstr "mind"
 
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:134
 #: ../gramps/plugins/export/exportcsv.py:357
-#: ../gramps/plugins/webreport/person.py:1776
+#: ../gramps/plugins/webreport/person.py:1856
 msgid "Birth date"
 msgstr "Születési dátum"
 
@@ -14804,7 +15028,7 @@ msgstr "példa: \"%(msg1)s\", vagy \"%(msg2)s\""
 
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:136
 #: ../gramps/plugins/export/exportcsv.py:359
-#: ../gramps/plugins/webreport/person.py:1777
+#: ../gramps/plugins/webreport/person.py:1857
 msgid "Death date"
 msgstr "Halálozás dátuma"
 
@@ -14831,9 +15055,8 @@ msgstr "Kép"
 #: ../gramps/gui/glade/addmedia.glade:167
 #: ../gramps/gui/glade/editmedia.glade:111
 #: ../gramps/gui/glade/editmediaref.glade:409
-#: ../gramps/gui/glade/editplace.glade:90
-#: ../gramps/gui/glade/editsource.glade:97
 #: ../gramps/gui/glade/editplace.glade:91
+#: ../gramps/gui/glade/editsource.glade:97
 msgid "_Title:"
 msgstr "_Cím:"
 
@@ -14841,16 +15064,22 @@ msgstr "_Cím:"
 msgid "Convert to a relative path"
 msgstr "Relatív útvonallá alakítás"
 
-#: ../gramps/gui/glade/baseselector.glade:120
+#: ../gramps/gui/glade/baseselector.glade:121
 msgid "Show all"
 msgstr "Mindent megmutat"
+
+#: ../gramps/gui/glade/baseselector.glade:141
+#: ../gramps/gui/views/treemodels/treebasemodel.py:535
+#: ../gramps/gui/views/treemodels/treebasemodel.py:580
+msgid "Loading items..."
+msgstr "Elemek betöltése..."
 
 #: ../gramps/gui/glade/book.glade:51
 msgid "Book _name:"
 msgstr "_Könyvnév:"
 
 #: ../gramps/gui/glade/book.glade:90
-#: ../gramps/gui/plug/report/_bookdialog.py:624
+#: ../gramps/gui/plug/report/_bookdialog.py:636
 msgid "Clear the book"
 msgstr "A könyv kitakarítása"
 
@@ -14886,9 +15115,37 @@ msgstr "A kiválasztás egy lépéssel lejjebb vitele a könyvben"
 msgid "Configure currently selected item"
 msgstr "A kiválasztott elem beállítása"
 
-#: ../gramps/gui/glade/book.glade:523 ../gramps/gui/glade/dbman.glade:265
-#: ../gramps/gui/views/listview.py:213
-#: ../gramps/plugins/lib/libpersonview.py:393
+#: ../gramps/gui/glade/book.glade:540 ../gramps/gui/glade/dbman.glade:266
+#: ../gramps/plugins/lib/libpersonview.py:226
+#: ../gramps/plugins/lib/libpersonview.py:303
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:303
+#: ../gramps/plugins/lib/libplaceview.py:362
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:195
+#: ../gramps/plugins/view/citationlistview.py:254
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:209
+#: ../gramps/plugins/view/eventview.py:268
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:168
+#: ../gramps/plugins/view/familyview.py:227
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/mediaview.py:268
+#: ../gramps/plugins/view/mediaview.py:327
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:168
+#: ../gramps/plugins/view/noteview.py:227
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/repoview.py:181
+#: ../gramps/plugins/view/repoview.py:240
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:167
+#: ../gramps/plugins/view/sourceview.py:226
+#: ../gramps/plugins/view/sourceview.py:278
 msgid "_Delete"
 msgstr "_Törlés"
 
@@ -14952,28 +15209,28 @@ msgstr "_Ablak bezárása"
 msgid "_Load Family Tree"
 msgstr "Családfa _betöltése"
 
-#: ../gramps/gui/glade/dbman.glade:234 ../gramps/gui/glade/editlink.glade:208
+#: ../gramps/gui/glade/dbman.glade:235 ../gramps/gui/glade/editlink.glade:208
 msgid "_New"
 msgstr "_Új"
 
-#: ../gramps/gui/glade/dbman.glade:250
+#: ../gramps/gui/glade/dbman.glade:251
 msgid "_Info"
 msgstr "_Információ"
 
-#: ../gramps/gui/glade/dbman.glade:281
+#: ../gramps/gui/glade/dbman.glade:282
 msgid "_Rename"
 msgstr "_Átnevezés"
 
-#: ../gramps/gui/glade/dbman.glade:297
+#: ../gramps/gui/glade/dbman.glade:298
 #: ../gramps/gui/glade/grampletpane.glade:137
 msgid "Close"
 msgstr "Bezárás"
 
-#: ../gramps/gui/glade/dbman.glade:313
+#: ../gramps/gui/glade/dbman.glade:314
 msgid "Con_vert"
 msgstr "Át_alakítás"
 
-#: ../gramps/gui/glade/dbman.glade:329
+#: ../gramps/gui/glade/dbman.glade:330
 msgid "Re_pair"
 msgstr "Ja_vítás"
 
@@ -15023,7 +15280,7 @@ msgstr ""
 msgid "Cancel the rest of the operations"
 msgstr "A hátralévő műveletek megszakítása"
 
-#: ../gramps/gui/glade/dialog.glade:433
+#: ../gramps/gui/glade/dialog.glade:433 ../gramps/gui/views/listview.py:572
 #: ../gramps/plugins/tool/reorderids.glade:21
 msgid "_No"
 msgstr "_Nem"
@@ -15033,7 +15290,7 @@ msgstr "_Nem"
 msgid "Do not apply the operation to this item"
 msgstr "Ne alkalmazza a műveletet ehhez az elemhez"
 
-#: ../gramps/gui/glade/dialog.glade:449
+#: ../gramps/gui/glade/dialog.glade:449 ../gramps/gui/views/listview.py:572
 #: ../gramps/plugins/tool/reorderids.glade:37
 msgid "_Yes"
 msgstr "_Igen"
@@ -15057,25 +15314,24 @@ msgstr ""
 "Ha a gombot bejelöli, a következő válasza minden hátralevő kijelölt elemre "
 "alkalmazva lesz"
 
-#: ../gramps/gui/glade/dialog.glade:763 ../gramps/gui/glade/dialog.glade:780
-#: ../gramps/gui/glade/dialog.glade:892
+#: ../gramps/gui/glade/dialog.glade:776 ../gramps/gui/glade/dialog.glade:793
+#: ../gramps/gui/glade/dialog.glade:906
 msgid "label"
 msgstr "címke"
 
-#: ../gramps/gui/glade/dialog.glade:827
+#: ../gramps/gui/glade/dialog.glade:841
 msgid "Close _without saving"
 msgstr "Bezárás _mentés nélkül"
 
-#: ../gramps/gui/glade/dialog.glade:859
-#: ../gramps/gui/plug/report/_bookdialog.py:625
-#: ../gramps/gui/views/listview.py:1047
-#: ../gramps/gui/widgets/grampletpane.py:582
+#: ../gramps/gui/glade/dialog.glade:873
+#: ../gramps/gui/plug/report/_bookdialog.py:637
+#: ../gramps/gui/views/listview.py:1055
+#: ../gramps/gui/widgets/grampletpane.py:588
 #: ../gramps/plugins/tool/eventcmp.py:400
-#: ../gramps/gui/widgets/grampletpane.py:579
 msgid "_Save"
 msgstr "Menté_s"
 
-#: ../gramps/gui/glade/dialog.glade:932
+#: ../gramps/gui/glade/dialog.glade:946
 msgid "Do not ask again"
 msgstr "Ne kérdezze mégegyszer"
 
@@ -15106,7 +15362,6 @@ msgstr "A változások jóváhagyása és az ablak bezárása"
 #: ../gramps/gui/glade/editmedia.glade:125
 #: ../gramps/gui/glade/editmediaref.glade:546
 #: ../gramps/gui/glade/editplacename.glade:93
-#: ../gramps/gui/glade/editplaceref.glade:117
 #: ../gramps/gui/glade/editplaceref.glade:118
 msgid "_Date:"
 msgstr "_Dátum:"
@@ -15187,15 +15442,15 @@ msgstr ""
 #: ../gramps/gui/glade/editnote.glade:226
 #: ../gramps/gui/glade/editperson.glade:410
 #: ../gramps/gui/glade/editpersonref.glade:151
-#: ../gramps/gui/glade/editplace.glade:321
-#: ../gramps/gui/glade/editplaceref.glade:424
+#: ../gramps/gui/glade/editplace.glade:322
+#: ../gramps/gui/glade/editplaceref.glade:425
 #: ../gramps/gui/glade/editreporef.glade:188
 #: ../gramps/gui/glade/editreporef.glade:397
 #: ../gramps/gui/glade/editrepository.glade:205
 #: ../gramps/gui/glade/editsource.glade:288
 #: ../gramps/gui/glade/editurl.glade:149
-#: ../gramps/gui/glade/editplace.glade:322
-#: ../gramps/gui/glade/editplaceref.glade:425
+#: ../gramps/plugins/importer/importprogen.glade:101
+#: ../gramps/plugins/importer/importprogen.glade:237
 msgid "Privacy"
 msgstr "Bizalmasság"
 
@@ -15208,6 +15463,7 @@ msgstr "Bizalmasság"
 #: ../gramps/gui/glade/editmediaref.glade:573
 #: ../gramps/gui/glade/editname.glade:562
 #: ../gramps/gui/glade/editplacename.glade:123
+#: ../gramps/plugins/importer/importprogen.glade:486
 msgid "Invoke date editor"
 msgstr "Meghívott dátumszerkesztő"
 
@@ -15276,7 +15532,7 @@ msgstr "A gyermek személyszerkesztőjének megnyitása"
 #: ../gramps/gui/glade/editchildref.glade:240
 #: ../gramps/gui/glade/editfamily.glade:279
 #: ../gramps/gui/glade/editfamily.glade:587 ../gramps/gui/glade/rule.glade:456
-#: ../gramps/gui/glade/styleeditor.glade:1864
+#: ../gramps/gui/glade/styleeditor.glade:1896
 msgid "Edition"
 msgstr "Kiadás"
 
@@ -15346,11 +15602,10 @@ msgstr ""
 #: ../gramps/gui/glade/editmediaref.glade:394
 #: ../gramps/gui/glade/editnote.glade:166
 #: ../gramps/gui/glade/editperson.glade:617
-#: ../gramps/gui/glade/editplace.glade:163
+#: ../gramps/gui/glade/editplace.glade:164
 #: ../gramps/gui/glade/editreporef.glade:352
 #: ../gramps/gui/glade/editrepository.glade:165
 #: ../gramps/gui/glade/editsource.glade:263
-#: ../gramps/gui/glade/editplace.glade:164
 msgid "_ID:"
 msgstr "_Azonosító:"
 
@@ -15361,12 +15616,10 @@ msgstr "Egyedi azonosító az idézet azonosításához"
 #: ../gramps/gui/glade/editcitation.glade:360
 #: ../gramps/gui/glade/editevent.glade:390
 #: ../gramps/gui/glade/editeventref.glade:465
-#: ../gramps/gui/glade/editplace.glade:397
-#: ../gramps/gui/glade/editplaceref.glade:544
-#: ../gramps/gui/glade/editrepository.glade:234
-#: ../gramps/gui/glade/editsource.glade:229
 #: ../gramps/gui/glade/editplace.glade:398
 #: ../gramps/gui/glade/editplaceref.glade:545
+#: ../gramps/gui/glade/editrepository.glade:234
+#: ../gramps/gui/glade/editsource.glade:229
 msgid "Tags:"
 msgstr "Címkék:"
 
@@ -15489,9 +15742,8 @@ msgid "A unique ID to identify the event"
 msgstr "Egyedi azonosító az esemény azonosításához"
 
 #: ../gramps/gui/glade/editeventref.glade:85
-#: ../gramps/gui/glade/editplaceref.glade:85
-#: ../gramps/gui/glade/editreporef.glade:97
 #: ../gramps/gui/glade/editplaceref.glade:86
+#: ../gramps/gui/glade/editreporef.glade:97
 msgid "Reference information"
 msgstr "Forrásinformáció"
 
@@ -15508,9 +15760,8 @@ msgstr ""
 "hatással lesz az eseményre magára, az esemény minden résztvevőjére."
 
 #: ../gramps/gui/glade/editeventref.glade:624
-#: ../gramps/gui/glade/editplaceref.glade:693
-#: ../gramps/gui/glade/editreporef.glade:460
 #: ../gramps/gui/glade/editplaceref.glade:694
+#: ../gramps/gui/glade/editreporef.glade:460
 msgid "Shared information"
 msgstr "Megosztott információ"
 
@@ -15602,7 +15853,7 @@ msgid "_Family:"
 msgstr "_Család:"
 
 #: ../gramps/gui/glade/editldsord.glade:248
-#: ../gramps/gui/selectors/selectfamily.py:62
+#: ../gramps/gui/selectors/selectfamily.py:59
 msgid "Select Family"
 msgstr "Család kiválasztása"
 
@@ -16080,8 +16331,6 @@ msgid "Select a person that has an association to the edited person."
 msgstr ""
 "Válasszon egy személyt, aki a szerkesztett személlyel kapcsolattal bír."
 
-#: ../gramps/gui/glade/editplace.glade:105
-#: ../gramps/gui/glade/editplaceref.glade:228
 #: ../gramps/gui/glade/editplace.glade:106
 #: ../gramps/gui/glade/editplaceref.glade:229
 msgid ""
@@ -16091,25 +16340,19 @@ msgstr ""
 "Vagy használja a lenti két mezőt koordináták (szélesség és hosszúság) "
 "bevitelére,"
 
-#: ../gramps/gui/glade/editplace.glade:119
 #: ../gramps/gui/glade/editplace.glade:120
 msgid "L_atitude:"
 msgstr "Szé_lességi fok:"
 
-#: ../gramps/gui/glade/editplace.glade:134
 #: ../gramps/gui/glade/editplace.glade:135
 msgid "_Longitude:"
 msgstr "Hoss_zúság:"
 
-#: ../gramps/gui/glade/editplace.glade:148
-#: ../gramps/gui/glade/editplaceref.glade:445
 #: ../gramps/gui/glade/editplace.glade:149
 #: ../gramps/gui/glade/editplaceref.glade:446
 msgid "Full title of this place."
 msgstr "A hely teljes neve."
 
-#: ../gramps/gui/glade/editplace.glade:176
-#: ../gramps/gui/glade/editplaceref.glade:459
 #: ../gramps/gui/glade/editplace.glade:177
 #: ../gramps/gui/glade/editplaceref.glade:460
 msgid ""
@@ -16124,8 +16367,6 @@ msgstr ""
 "Beállíthatja az értékeket a Földrajzi nézetben a helyre kereséssel, vagy a "
 "Hely nézet térkép szolgáltatásán keresztül."
 
-#: ../gramps/gui/glade/editplace.glade:191
-#: ../gramps/gui/glade/editplaceref.glade:474
 #: ../gramps/gui/glade/editplace.glade:192
 #: ../gramps/gui/glade/editplaceref.glade:475
 msgid ""
@@ -16143,8 +16384,6 @@ msgstr ""
 "Beállíthatja az értékeket a Földrajzi nézetben a helyre kereséssel, vagy a "
 "Hely nézet térkép szolgáltatásán keresztül."
 
-#: ../gramps/gui/glade/editplace.glade:212
-#: ../gramps/gui/glade/editplaceref.glade:350
 #: ../gramps/gui/glade/editplace.glade:213
 #: ../gramps/gui/glade/editplaceref.glade:351
 msgid ""
@@ -16154,8 +16393,6 @@ msgstr ""
 "vagy használja a másolás/beillesztést kedvenc térkép szolgáltatásából "
 "(formátum: szélesség, hosszúság) a következő mezőbe:"
 
-#: ../gramps/gui/glade/editplace.glade:237
-#: ../gramps/gui/glade/editplaceref.glade:375
 #: ../gramps/gui/glade/editplace.glade:238
 #: ../gramps/gui/glade/editplaceref.glade:376
 msgid ""
@@ -16164,36 +16401,26 @@ msgstr ""
 "Mező pl. a google, openstreetmap oldalakról származó információ "
 "beillesztéséhez ... "
 
-#: ../gramps/gui/glade/editplace.glade:264
-#: ../gramps/gui/glade/editplaceref.glade:495
 #: ../gramps/gui/glade/editplace.glade:265
 #: ../gramps/gui/glade/editplaceref.glade:496
 msgid "A unique ID to identify the place"
 msgstr "Egyedi azonosító a hely azonosításához"
 
-#: ../gramps/gui/glade/editplace.glade:292
-#: ../gramps/gui/glade/editplaceref.glade:523
 #: ../gramps/gui/glade/editplace.glade:293
 #: ../gramps/gui/glade/editplaceref.glade:524
 msgid "Code associated with this place. Eg Country Code or Postal Code."
 msgstr "A helyhez tartozó kód. Pl. országkód, vagy irányítószám."
 
-#: ../gramps/gui/glade/editplace.glade:377
-#: ../gramps/gui/glade/editplaceref.glade:396
 #: ../gramps/gui/glade/editplace.glade:378
 #: ../gramps/gui/glade/editplaceref.glade:397
 msgid "What type of place this is. Eg 'Country', 'City', ... ."
 msgstr "Milyen típusú esemény ez. Pl. 'Ország', 'Város', ... ."
 
-#: ../gramps/gui/glade/editplace.glade:440
-#: ../gramps/gui/glade/editplaceref.glade:598
 #: ../gramps/gui/glade/editplace.glade:441
 #: ../gramps/gui/glade/editplaceref.glade:599
 msgid "The name of this place."
 msgstr "A hely neve."
 
-#: ../gramps/gui/glade/editplace.glade:455
-#: ../gramps/gui/glade/editplaceref.glade:617
 #: ../gramps/gui/glade/editplace.glade:456
 #: ../gramps/gui/glade/editplaceref.glade:618
 msgid "Invoke place name editor."
@@ -16225,7 +16452,7 @@ msgid "Street Number"
 msgstr "Utca Házszám"
 
 #: ../gramps/gui/glade/editplacename.glade:156
-#: ../gramps/plugins/webreport/basepage.py:2585
+#: ../gramps/plugins/webreport/basepage.py:2621
 msgid "Date range in which the name is valid."
 msgstr "Dátum intervallum, amikor a név érvényes."
 
@@ -16241,7 +16468,6 @@ msgstr ""
 "A név írásának nyelve. Érvényes kód a két karakteres ISO kód. Pl.:  en, .fr, "
 "de, hu, nl ..."
 
-#: ../gramps/gui/glade/editplaceref.glade:294
 #: ../gramps/gui/glade/editplaceref.glade:295
 msgid ""
 "<b>Note:</b> Any changes in the enclosing place information will be "
@@ -16456,7 +16682,7 @@ msgstr "_Összevonás és bezárás"
 
 #. name, click?, width, toggle
 #: ../gramps/gui/glade/mergedata.glade:173
-#: ../gramps/gui/glade/mergedata.glade:189 ../gramps/gui/plug/_windows.py:1098
+#: ../gramps/gui/glade/mergedata.glade:189 ../gramps/gui/plug/_windows.py:1100
 #: ../gramps/plugins/tool/changenames.py:196
 #: ../gramps/plugins/tool/patchnames.py:401
 msgid "Select"
@@ -16583,7 +16809,7 @@ msgid "Note 2"
 msgstr "Jegyzet 2"
 
 #: ../gramps/gui/glade/mergenote.glade:278
-#: ../gramps/gui/glade/mergenote.glade:294 ../gramps/gui/views/listview.py:1051
+#: ../gramps/gui/glade/mergenote.glade:294 ../gramps/gui/views/listview.py:1059
 msgid "Format:"
 msgstr "Formátum:"
 
@@ -16704,14 +16930,14 @@ msgstr "Elrendezés:"
 #: ../gramps/gui/glade/papermenu.glade:271
 #: ../gramps/gui/glade/papermenu.glade:284
 #: ../gramps/gui/glade/papermenu.glade:345
-#: ../gramps/gui/glade/styleeditor.glade:602
-#: ../gramps/gui/glade/styleeditor.glade:615
-#: ../gramps/gui/glade/styleeditor.glade:628
-#: ../gramps/gui/glade/styleeditor.glade:724
-#: ../gramps/gui/glade/styleeditor.glade:737
-#: ../gramps/gui/glade/styleeditor.glade:869
-#: ../gramps/gui/glade/styleeditor.glade:1298
-#: ../gramps/gui/glade/styleeditor.glade:1644
+#: ../gramps/gui/glade/styleeditor.glade:618
+#: ../gramps/gui/glade/styleeditor.glade:631
+#: ../gramps/gui/glade/styleeditor.glade:644
+#: ../gramps/gui/glade/styleeditor.glade:740
+#: ../gramps/gui/glade/styleeditor.glade:753
+#: ../gramps/gui/glade/styleeditor.glade:885
+#: ../gramps/gui/glade/styleeditor.glade:1314
+#: ../gramps/gui/glade/styleeditor.glade:1660
 #: ../gramps/gui/plug/report/_papermenu.py:211
 msgid "cm"
 msgstr "cm"
@@ -16841,10 +17067,10 @@ msgstr "A kiválasztott szabály szerkesztése"
 msgid "Delete the selected rule"
 msgstr "A kiválasztott szabály törlése"
 
-#: ../gramps/gui/glade/rule.glade:521 ../gramps/gui/glade/styleeditor.glade:403
+#: ../gramps/gui/glade/rule.glade:521 ../gramps/gui/glade/styleeditor.glade:419
 #: ../gramps/plugins/tool/finddupes.glade:132
 #: ../gramps/plugins/tool/mergecitations.glade:132
-#: ../gramps/plugins/tool/sortevents.py:82
+#: ../gramps/plugins/tool/sortevents.py:83
 msgid "Options"
 msgstr "Lehetőségek"
 
@@ -16868,215 +17094,215 @@ msgstr "A szűrőfeltételekkel nem egyező értékek visszaadása"
 msgid "Selected Rule"
 msgstr "Kiválasztott szabály"
 
-#: ../gramps/gui/glade/styleeditor.glade:158
+#: ../gramps/gui/glade/styleeditor.glade:174
 msgid "Style sheet n_ame:"
 msgstr "Stíluslap _név:"
 
-#: ../gramps/gui/glade/styleeditor.glade:177
+#: ../gramps/gui/glade/styleeditor.glade:193
 msgid "Style name"
 msgstr "Stílusnév"
 
-#: ../gramps/gui/glade/styleeditor.glade:286
+#: ../gramps/gui/glade/styleeditor.glade:302
 msgid "Type face"
 msgstr "Betűkép"
 
-#: ../gramps/gui/glade/styleeditor.glade:299
+#: ../gramps/gui/glade/styleeditor.glade:315
 msgid "_Roman (Times, serif)"
 msgstr "_Roman (Times, serif)"
 
-#: ../gramps/gui/glade/styleeditor.glade:316
+#: ../gramps/gui/glade/styleeditor.glade:332
 msgid "_Swiss (Arial, Helvetica, sans-serif)"
 msgstr "_Swiss (Arial, Helvetica, sans-serif)"
 
-#: ../gramps/gui/glade/styleeditor.glade:339
+#: ../gramps/gui/glade/styleeditor.glade:355
 msgid "Size"
 msgstr "Méret"
 
-#: ../gramps/gui/glade/styleeditor.glade:369
-#: ../gramps/gui/plug/report/_styleeditor.py:257
+#: ../gramps/gui/glade/styleeditor.glade:385
+#: ../gramps/gui/plug/report/_styleeditor.py:268
 msgid "point size|pt"
 msgstr "pont"
 
-#: ../gramps/gui/glade/styleeditor.glade:416
+#: ../gramps/gui/glade/styleeditor.glade:432
 msgid "_Bold"
 msgstr "_Félkövér"
 
-#: ../gramps/gui/glade/styleeditor.glade:433
+#: ../gramps/gui/glade/styleeditor.glade:449
 msgid "_Italic"
 msgstr "_Dölt"
 
-#: ../gramps/gui/glade/styleeditor.glade:450
+#: ../gramps/gui/glade/styleeditor.glade:466
 msgid "_Underline"
 msgstr "_Aláhúzott"
 
-#: ../gramps/gui/glade/styleeditor.glade:526
+#: ../gramps/gui/glade/styleeditor.glade:542
 msgid "Font options"
 msgstr "Betűkészletek"
 
-#: ../gramps/gui/glade/styleeditor.glade:551
+#: ../gramps/gui/glade/styleeditor.glade:567
 msgid "Alignment"
 msgstr "Elrendezés"
 
-#: ../gramps/gui/glade/styleeditor.glade:570
-#: ../gramps/plugins/drawreport/fanchart.py:704
+#: ../gramps/gui/glade/styleeditor.glade:586
+#: ../gramps/plugins/drawreport/fanchart.py:706
 msgid "Background color"
 msgstr "Háttérszín"
 
-#: ../gramps/gui/glade/styleeditor.glade:587
+#: ../gramps/gui/glade/styleeditor.glade:603
 msgid "First li_ne:"
 msgstr "_Első sor:"
 
-#: ../gramps/gui/glade/styleeditor.glade:642
+#: ../gramps/gui/glade/styleeditor.glade:658
 msgid "R_ight:"
 msgstr "_Jobb:"
 
-#: ../gramps/gui/glade/styleeditor.glade:658
+#: ../gramps/gui/glade/styleeditor.glade:674
 msgid "L_eft:"
 msgstr "_Bal:"
 
-#: ../gramps/gui/glade/styleeditor.glade:676
+#: ../gramps/gui/glade/styleeditor.glade:692
 msgid "Spacing"
 msgstr "Sorköz"
 
-#: ../gramps/gui/glade/styleeditor.glade:693
+#: ../gramps/gui/glade/styleeditor.glade:709
 msgid "Abo_ve:"
 msgstr "_Felette:"
 
-#: ../gramps/gui/glade/styleeditor.glade:709
+#: ../gramps/gui/glade/styleeditor.glade:725
 msgid "Belo_w:"
 msgstr "_Alatta:"
 
-#: ../gramps/gui/glade/styleeditor.glade:753
-#: ../gramps/gui/glade/styleeditor.glade:1256
-#: ../gramps/plugins/drawreport/calendarreport.py:653
+#: ../gramps/gui/glade/styleeditor.glade:769
+#: ../gramps/gui/glade/styleeditor.glade:1272
+#: ../gramps/plugins/drawreport/calendarreport.py:649
 msgid "Borders"
 msgstr "Szegélyek"
 
-#: ../gramps/gui/glade/styleeditor.glade:840
+#: ../gramps/gui/glade/styleeditor.glade:856
 msgid "_Padding:"
 msgstr "_Kitöltés:"
 
-#: ../gramps/gui/glade/styleeditor.glade:894
+#: ../gramps/gui/glade/styleeditor.glade:910
 msgid "Indentation"
 msgstr "Behúzás"
 
-#: ../gramps/gui/glade/styleeditor.glade:924
+#: ../gramps/gui/glade/styleeditor.glade:940
 msgid "_Left"
 msgstr "_Bal"
 
-#: ../gramps/gui/glade/styleeditor.glade:942
+#: ../gramps/gui/glade/styleeditor.glade:958
 msgid "_Right"
 msgstr "_Jobb"
 
-#: ../gramps/gui/glade/styleeditor.glade:960
+#: ../gramps/gui/glade/styleeditor.glade:976
 msgid "J_ustify"
 msgstr "_Sorkizárt"
 
-#: ../gramps/gui/glade/styleeditor.glade:978
+#: ../gramps/gui/glade/styleeditor.glade:994
 msgid "Cen_ter"
 msgstr "_Középre"
 
-#: ../gramps/gui/glade/styleeditor.glade:1008
+#: ../gramps/gui/glade/styleeditor.glade:1024
 msgid "Le_ft"
 msgstr "Ba_l"
 
-#: ../gramps/gui/glade/styleeditor.glade:1026
+#: ../gramps/gui/glade/styleeditor.glade:1042
 msgid "Righ_t"
 msgstr "Job_b"
 
-#: ../gramps/gui/glade/styleeditor.glade:1043
+#: ../gramps/gui/glade/styleeditor.glade:1059
 msgid "_Top"
 msgstr "_Fent"
 
-#: ../gramps/gui/glade/styleeditor.glade:1060
+#: ../gramps/gui/glade/styleeditor.glade:1076
 msgid "_Bottom"
 msgstr "_Lent"
 
-#: ../gramps/gui/glade/styleeditor.glade:1124
+#: ../gramps/gui/glade/styleeditor.glade:1140
 msgid "Paragraph options"
 msgstr "Bekezdés beállítások"
 
-#: ../gramps/gui/glade/styleeditor.glade:1146
+#: ../gramps/gui/glade/styleeditor.glade:1162
 msgid "Width"
 msgstr "Szélesség"
 
-#: ../gramps/gui/glade/styleeditor.glade:1161
+#: ../gramps/gui/glade/styleeditor.glade:1177
 msgid "Column widths"
 msgstr "Oszlop szélességek"
 
-#: ../gramps/gui/glade/styleeditor.glade:1205
+#: ../gramps/gui/glade/styleeditor.glade:1221
 msgid "%"
 msgstr "%"
 
-#: ../gramps/gui/glade/styleeditor.glade:1231
+#: ../gramps/gui/glade/styleeditor.glade:1247
 msgid "Table options"
 msgstr "Táblázat beállítások"
 
-#: ../gramps/gui/glade/styleeditor.glade:1287
+#: ../gramps/gui/glade/styleeditor.glade:1303
 msgid "Padding:"
 msgstr "Kitöltés:"
 
-#: ../gramps/gui/glade/styleeditor.glade:1312
+#: ../gramps/gui/glade/styleeditor.glade:1328
 msgid "Left"
 msgstr "Bal"
 
-#: ../gramps/gui/glade/styleeditor.glade:1328
+#: ../gramps/gui/glade/styleeditor.glade:1344
 msgid "Right"
 msgstr "Jobb"
 
-#: ../gramps/gui/glade/styleeditor.glade:1387
+#: ../gramps/gui/glade/styleeditor.glade:1403
 msgid "Cell options"
 msgstr "Cella beállítások"
 
-#: ../gramps/gui/glade/styleeditor.glade:1412
+#: ../gramps/gui/glade/styleeditor.glade:1428
 msgid "Line"
 msgstr "Vonal"
 
-#: ../gramps/gui/glade/styleeditor.glade:1452
+#: ../gramps/gui/glade/styleeditor.glade:1468
 msgid "Style:"
 msgstr "Stílus:"
 
-#: ../gramps/gui/glade/styleeditor.glade:1465
+#: ../gramps/gui/glade/styleeditor.glade:1481
 msgid "Width:"
 msgstr "Szélesség:"
 
-#: ../gramps/gui/glade/styleeditor.glade:1478
+#: ../gramps/gui/glade/styleeditor.glade:1494
 msgid "Line:"
 msgstr "Vonaltípus:"
 
-#: ../gramps/gui/glade/styleeditor.glade:1491
+#: ../gramps/gui/glade/styleeditor.glade:1507
 msgid "Fill:"
 msgstr "Kitöltés:"
 
-#: ../gramps/gui/glade/styleeditor.glade:1506
+#: ../gramps/gui/glade/styleeditor.glade:1522
 msgid "Shadow"
 msgstr "Árnyék"
 
-#: ../gramps/gui/glade/styleeditor.glade:1582
+#: ../gramps/gui/glade/styleeditor.glade:1598
 msgid "pt"
 msgstr "pont"
 
-#: ../gramps/gui/glade/styleeditor.glade:1605
+#: ../gramps/gui/glade/styleeditor.glade:1621
 msgid "Spacing:"
 msgstr "Sorköz:"
 
-#: ../gramps/gui/glade/styleeditor.glade:1627
+#: ../gramps/gui/glade/styleeditor.glade:1643
 msgid "Draw shadow"
 msgstr "Árnyék rajzolása"
 
-#: ../gramps/gui/glade/styleeditor.glade:1669
+#: ../gramps/gui/glade/styleeditor.glade:1685
 msgid "Draw options"
 msgstr "Rajzolási beállítások"
 
-#: ../gramps/gui/glade/styleeditor.glade:1823
+#: ../gramps/gui/glade/styleeditor.glade:1855
 msgid "Add a new style"
 msgstr "Új stílus hozzáadása"
 
-#: ../gramps/gui/glade/styleeditor.glade:1855
+#: ../gramps/gui/glade/styleeditor.glade:1887
 msgid "Edit the selected style"
 msgstr "A kiválasztott stílus szerkesztése"
 
-#: ../gramps/gui/glade/styleeditor.glade:1887
+#: ../gramps/gui/glade/styleeditor.glade:1919
 msgid "Delete the selected style"
 msgstr "A kiválasztott stílus törlése"
 
@@ -17085,7 +17311,41 @@ msgid "_Display on startup"
 msgstr "_Megjelenítés induláskor"
 
 #: ../gramps/gui/glade/tipofday.glade:102
-#: ../gramps/gui/views/navigationview.py:294
+#: ../gramps/plugins/lib/libpersonview.py:206
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libplaceview.py:289
+#: ../gramps/plugins/lib/libplaceview.py:332
+#: ../gramps/plugins/view/citationlistview.py:181
+#: ../gramps/plugins/view/citationlistview.py:224
+#: ../gramps/plugins/view/citationtreeview.py:323
+#: ../gramps/plugins/view/eventview.py:195
+#: ../gramps/plugins/view/eventview.py:238
+#: ../gramps/plugins/view/familyview.py:154
+#: ../gramps/plugins/view/familyview.py:197
+#: ../gramps/plugins/view/fanchartview.py:144
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:71 ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoevents.py:67
+#: ../gramps/plugins/view/geoevents.py:101
+#: ../gramps/plugins/view/geofamclose.py:69
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geofamily.py:67
+#: ../gramps/plugins/view/geofamily.py:101
+#: ../gramps/plugins/view/geomoves.py:68 ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:69
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/geoplaces.py:70
+#: ../gramps/plugins/view/geoplaces.py:104
+#: ../gramps/plugins/view/mediaview.py:254
+#: ../gramps/plugins/view/mediaview.py:297
+#: ../gramps/plugins/view/noteview.py:154
+#: ../gramps/plugins/view/noteview.py:197
+#: ../gramps/plugins/view/pedigreeview.py:652
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428 ../gramps/plugins/view/repoview.py:167
+#: ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/sourceview.py:153
+#: ../gramps/plugins/view/sourceview.py:196
 msgid "_Forward"
 msgstr "_Előre"
 
@@ -17094,7 +17354,7 @@ msgid "Install Selected _Addons"
 msgstr "Kiválasztott _bővítmények telepítése"
 
 #: ../gramps/gui/glade/updateaddons.glade:72
-#: ../gramps/gui/plug/_windows.py:1078
+#: ../gramps/gui/plug/_windows.py:1080
 msgid "Available Gramps Updates for Addons"
 msgstr "Elérhető GRAMPS bővítmény frissítések"
 
@@ -17125,7 +17385,160 @@ msgstr "_Mindent kijelöl"
 msgid "Select _None"
 msgstr "Egyik _sem"
 
-#: ../gramps/gui/grampsgui.py:60
+#: ../gramps/gui/grampsgui.py:56
+msgid "Books..."
+msgstr "Könyvek..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Clip_board"
+msgstr "Vá_gólap"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Configure the active view"
+msgstr "Aktív nézet beállítása"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Connect to a recent database"
+msgstr "Jelenlegi adatbázishoz kapcsolódás"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "F_ull Screen"
+msgstr "Teljes ké_pernyő"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Gramps _Home Page"
+msgstr "GRAMPS _honlap"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Gramps _Mailing Lists"
+msgstr "GRAMPS _levelezőlista"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Make Backup..."
+msgstr "Biztonsági másolat készítése..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Manage databases"
+msgstr "Adatbázisok kezelése"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Open _Recent"
+msgstr "Jelenlegi _megnyitása"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Open the Clipboard dialog"
+msgstr "Vágólap párbeszédablak megnyitása"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Open the reports dialog"
+msgstr "Összesítők párbeszédablak megnyitása"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Open the tools dialog"
+msgstr "Eszközök párbeszédablak megnyitása"
+
+#: ../gramps/gui/grampsgui.py:56 ../gramps/gui/tipofday.py:67
+#: ../gramps/gui/tipofday.py:68 ../gramps/gui/tipofday.py:121
+msgid "Tip of the Day"
+msgstr "A nap tippje"
+
+#: ../gramps/gui/grampsgui.py:56 ../gramps/gui/undohistory.py:73
+msgid "Undo History"
+msgstr "Történet visszavonása"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Abandon Changes and Quit"
+msgstr "_A változások elvetése és kilépés"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_About"
+msgstr "Né_vjegy"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Bookmarks"
+msgstr "_Könyvjelzők"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Configure..."
+msgstr "_Beállítás..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Export..."
+msgstr "_Exportálás..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Extra Reports/Tools"
+msgstr "_Extra összesítők/eszközök"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_FAQ"
+msgstr "_GYIK"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Family Trees"
+msgstr "Család_fák"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Go"
+msgstr "_Menj"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Import..."
+msgstr "_Importálás..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Key Bindings"
+msgstr "_Gyorsbillentyűk"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Manage Family Trees..."
+msgstr "Családfák _kezelése..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Navigator"
+msgstr "_Navigátor"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Plugin Manager"
+msgstr "_Beépülő kezelő"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Preferences..."
+msgstr "_Beállítások..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Quit"
+msgstr "_Kilépés"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Report a Bug"
+msgstr "_Hiba jelentése"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Reports"
+msgstr "Ö_sszesítők"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Toolbar"
+msgstr "_Eszközsáv"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Tools"
+msgstr "_Eszközök"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_User Manual"
+msgstr "_Felhasználói kézikönyv"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_View"
+msgstr "_Nézet"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Windows"
+msgstr "Ab_lakok"
+
+#: ../gramps/gui/grampsgui.py:423
 msgid ""
 "Your version of gi (gnome-introspection) seems to be too old. You need a "
 "version which has the function 'require_version' to start Gramps"
@@ -17133,7 +17546,7 @@ msgstr ""
 "A gi (gnome-instrospection) verziója túl régi. A GRAMPS indításához olyan "
 "változatra van szüksége, mely a 'require_version' funkcióval rendelkezik"
 
-#: ../gramps/gui/grampsgui.py:74
+#: ../gramps/gui/grampsgui.py:437
 #, python-format
 msgid ""
 "Your pygobject version does not meet the requirements.\n"
@@ -17148,7 +17561,7 @@ msgstr ""
 "\n"
 "A GRAMPS most leáll."
 
-#: ../gramps/gui/grampsgui.py:92
+#: ../gramps/gui/grampsgui.py:455
 msgid ""
 "Gdk, Gtk, Pango or PangoCairo typelib not installed.\n"
 "Install Gnome Introspection, and pygobject version 3.12 or later.\n"
@@ -17164,7 +17577,7 @@ msgstr ""
 "\n"
 "A GRAMPS most leáll."
 
-#: ../gramps/gui/grampsgui.py:103
+#: ../gramps/gui/grampsgui.py:466
 #, python-format
 msgid ""
 "Your Gtk version does not meet the requirements.\n"
@@ -17177,7 +17590,7 @@ msgstr ""
 "\n"
 "A GRAMPS most leáll."
 
-#: ../gramps/gui/grampsgui.py:114
+#: ../gramps/gui/grampsgui.py:477
 msgid ""
 "\n"
 "cairo python support not installed. Install cairo for your version of "
@@ -17191,16 +17604,16 @@ msgstr ""
 "\n"
 "A GRAMPS most leáll."
 
-#: ../gramps/gui/grampsgui.py:145
+#: ../gramps/gui/grampsgui.py:508
 msgid "Danger: This is unstable code!"
 msgstr "Veszély: ez nem stabil kód!"
 
-#: ../gramps/gui/grampsgui.py:146
+#: ../gramps/gui/grampsgui.py:509
 #, python-format
 msgid "This Gramps ('%s') is a development release.\n"
 msgstr "Ez a GRAMPS ('%s') egy fejlesztői változat.\n"
 
-#: ../gramps/gui/grampsgui.py:148
+#: ../gramps/gui/grampsgui.py:511
 #, python-format
 msgid ""
 "This version is not meant for normal usage. Use at your own risk.\n"
@@ -17231,11 +17644,11 @@ msgstr ""
 "%(bold_start)sBIZTONSÁGI MENTÉST%(bold_end)s, valamint minden mostani és "
 "későbbi alkalomkor exportálja adatait XML formátumba."
 
-#: ../gramps/gui/grampsgui.py:178
+#: ../gramps/gui/grampsgui.py:541
 msgid "Gramps detected an incomplete GTK installation"
 msgstr "A GRAMPS befejezetlen GTK telepítést észlelt"
 
-#: ../gramps/gui/grampsgui.py:180
+#: ../gramps/gui/grampsgui.py:543
 #, python-format
 msgid ""
 "GTK translations for the current language (%(language)s) are missing.\n"
@@ -17254,11 +17667,15 @@ msgstr ""
 "ami\n"
 "általában a /usr/share/doc/gramps helyen található.\n"
 
-#: ../gramps/gui/grampsgui.py:297
+#: ../gramps/gui/grampsgui.py:659
 msgid "Error parsing arguments"
 msgstr "Hiba a paraméterek feldolgozásakor"
 
-#: ../gramps/gui/grampsgui.py:347 ../gramps/gui/grampsgui.py:386
+#: ../gramps/gui/grampsgui.py:678
+msgid "Gramps terminated because of no DISPLAY"
+msgstr "DISPLAY hiánya miatt a GRAMPS leállt"
+
+#: ../gramps/gui/grampsgui.py:701 ../gramps/gui/grampsgui.py:775
 msgid ""
 "\n"
 "Gramps failed to start. Please report a bug about this.\n"
@@ -17275,10 +17692,6 @@ msgstr ""
 "ezt követően töltse be újra a Családfát.\n"
 "A gramps.ini fájlban manuálisan is megváltoztathatja az induló nézetet a \n"
 "last-view paraméter változtatásával.\n"
-
-#: ../gramps/gui/grampsgui.py:365
-msgid "Gramps terminated because of no DISPLAY"
-msgstr "DISPLAY hiánya miatt a GRAMPS leállt"
 
 #: ../gramps/gui/logger/_errorreportassistant.py:97
 msgid "Error Report Assistant"
@@ -17510,7 +17923,7 @@ msgstr "Családok összefűzése"
 
 #: ../gramps/gui/merge/mergefamily.py:227
 #: ../gramps/gui/merge/mergeperson.py:351
-#: ../gramps/plugins/lib/libpersonview.py:429
+#: ../gramps/plugins/lib/libpersonview.py:534
 msgid "Cannot merge people"
 msgstr "Nem összefűzhető emberek"
 
@@ -17546,15 +17959,15 @@ msgstr "Emberek összefűzése"
 
 #. Go over parents and build their menu
 #: ../gramps/gui/merge/mergeperson.py:224
-#: ../gramps/gui/widgets/fanchart.py:1716
+#: ../gramps/gui/widgets/fanchart.py:1994
 #: ../gramps/plugins/quickview/all_relations.py:305
 #: ../gramps/plugins/tool/notrelated.py:128
-#: ../gramps/plugins/view/pedigreeview.py:1791
-#: ../gramps/plugins/view/relview.py:530 ../gramps/plugins/view/relview.py:858
-#: ../gramps/plugins/view/relview.py:892
-#: ../gramps/plugins/webreport/person.py:226
-#: ../gramps/plugins/webreport/person.py:1759
-#: ../gramps/plugins/webreport/surname.py:143
+#: ../gramps/plugins/view/pedigreeview.py:1866
+#: ../gramps/plugins/view/relview.py:659 ../gramps/plugins/view/relview.py:1017
+#: ../gramps/plugins/view/relview.py:1052
+#: ../gramps/plugins/webreport/person.py:232
+#: ../gramps/plugins/webreport/person.py:1839
+#: ../gramps/plugins/webreport/surname.py:154
 msgid "Parents"
 msgstr "Szülők"
 
@@ -17570,19 +17983,19 @@ msgstr "Nincsenek szülők"
 
 #. Go over spouses and build their menu
 #: ../gramps/gui/merge/mergeperson.py:238
-#: ../gramps/gui/widgets/fanchart.py:1586
+#: ../gramps/gui/widgets/fanchart.py:1857
 #: ../gramps/plugins/textreport/kinshipreport.py:133
-#: ../gramps/plugins/view/pedigreeview.py:1678
+#: ../gramps/plugins/view/pedigreeview.py:1753
 msgid "Spouses"
 msgstr "Házastársak"
 
 #: ../gramps/gui/merge/mergeperson.py:249
-#: ../gramps/gui/selectors/selectperson.py:100
-#: ../gramps/gui/widgets/reorderfam.py:90
+#: ../gramps/gui/selectors/selectperson.py:97
+#: ../gramps/gui/widgets/reorderfam.py:102
 #: ../gramps/plugins/gramplet/children.py:98
 #: ../gramps/plugins/lib/libpersonview.py:105
 #: ../gramps/plugins/textreport/familygroup.py:570
-#: ../gramps/plugins/view/relview.py:1385
+#: ../gramps/plugins/view/relview.py:1555
 msgid "Spouse"
 msgstr "Házastárs"
 
@@ -17591,11 +18004,11 @@ msgid "No spouses or children found"
 msgstr "Nincsenek házastársak, vagy gyermekek"
 
 #. Add column with the warning text
-#: ../gramps/gui/merge/mergeperson.py:344 ../gramps/plugins/tool/verify.py:562
+#: ../gramps/gui/merge/mergeperson.py:341 ../gramps/plugins/tool/verify.py:565
 msgid "Warning"
 msgstr "Figyelmeztetés"
 
-#: ../gramps/gui/merge/mergeperson.py:345
+#: ../gramps/gui/merge/mergeperson.py:342
 msgid ""
 "The persons have been merged.\n"
 "However, the families for this merge were too complex to automatically "
@@ -17651,8 +18064,7 @@ msgstr "_Futtatás"
 msgid "Run selected tool"
 msgstr "Kiválasztott eszköz futtatása"
 
-#: ../gramps/gui/plug/_guioptions.py:82 ../gramps/gui/plug/_guioptions.py:163
-#: ../gramps/gui/plug/_guioptions.py:165
+#: ../gramps/gui/plug/_guioptions.py:82 ../gramps/gui/plug/_guioptions.py:165
 msgid "Select surname"
 msgstr "Vezetéknév választása"
 
@@ -17669,52 +18081,46 @@ msgstr "Vezetéknév keresés"
 msgid "Finding surnames"
 msgstr "Vezetéknév keresés"
 
-#: ../gramps/gui/plug/_guioptions.py:684 ../gramps/gui/plug/_guioptions.py:686
+#: ../gramps/gui/plug/_guioptions.py:686
 msgid "Select a different person"
 msgstr "Válasszon egy másik személyt"
 
-#: ../gramps/gui/plug/_guioptions.py:711 ../gramps/gui/plug/_guioptions.py:713
+#: ../gramps/gui/plug/_guioptions.py:713
 msgid "Select a person for the report"
 msgstr "Válasszon egy személyt az összesítőből"
 
-#: ../gramps/gui/plug/_guioptions.py:794 ../gramps/gui/plug/_guioptions.py:796
+#: ../gramps/gui/plug/_guioptions.py:796
 msgid "Select a different family"
 msgstr "Válasszon egy másik családot"
 
-#: ../gramps/gui/plug/_guioptions.py:1251
 #: ../gramps/gui/plug/_guioptions.py:1253
 #, python-format
 msgid "Also include %s?"
 msgstr "%s-t is bezárólag?"
 
-#: ../gramps/gui/plug/_guioptions.py:1253
-#: ../gramps/gui/selectors/selectperson.py:86
 #: ../gramps/gui/plug/_guioptions.py:1255
+#: ../gramps/gui/selectors/selectperson.py:83
 msgid "Select Person"
 msgstr "Személy kiválasztása"
 
-#: ../gramps/gui/plug/_guioptions.py:1577
 #: ../gramps/gui/plug/_guioptions.py:1579
 #, python-format
 msgid "Select color for %s"
 msgstr "Szín kiválasztása ehhez: %s"
 
-#: ../gramps/gui/plug/_guioptions.py:1740
-#: ../gramps/gui/plug/report/_reportdialog.py:452
 #: ../gramps/gui/plug/_guioptions.py:1742
+#: ../gramps/gui/plug/report/_reportdialog.py:452
 msgid "Save As"
 msgstr "Mentés másként"
 
-#: ../gramps/gui/plug/_guioptions.py:1744 ../gramps/gui/plug/_windows.py:442
-#: ../gramps/gui/plug/report/_bookdialog.py:626
+#: ../gramps/gui/plug/_guioptions.py:1746 ../gramps/gui/plug/_windows.py:442
+#: ../gramps/gui/plug/report/_bookdialog.py:638
 #: ../gramps/gui/plug/report/_fileentry.py:66
-#: ../gramps/gui/plug/_guioptions.py:1746
 msgid "_Open"
 msgstr "_Megnyitás"
 
-#: ../gramps/gui/plug/_guioptions.py:1821
-#: ../gramps/gui/plug/report/_reportdialog.py:329
 #: ../gramps/gui/plug/_guioptions.py:1823
+#: ../gramps/gui/plug/report/_reportdialog.py:329
 msgid "Style Editor"
 msgstr "Stílusszerkesztő"
 
@@ -17753,6 +18159,8 @@ msgid "Loaded"
 msgstr "Betöltött"
 
 #: ../gramps/gui/plug/_windows.py:179
+#: ../gramps/plugins/importer/importprogen.glade:431
+#: ../gramps/plugins/importer/importprogen.glade:1126
 msgid "File"
 msgstr "Fájl"
 
@@ -17833,75 +18241,76 @@ msgstr "Beépülő betöltése"
 msgid "Fail"
 msgstr "Sikertelen"
 
-#: ../gramps/gui/plug/_windows.py:515 ../gramps/gui/widgets/grampletbar.py:548
+#: ../gramps/gui/plug/_windows.py:515 ../gramps/gui/widgets/grampletbar.py:549
 msgid "OK"
 msgstr "Rendben"
 
-#: ../gramps/gui/plug/_windows.py:619
+#: ../gramps/gui/plug/_windows.py:621
 msgid "Plugin name"
 msgstr "Beépülő név"
 
-#: ../gramps/gui/plug/_windows.py:621
+#: ../gramps/gui/plug/_windows.py:623
 msgid "Version"
 msgstr "Verzió"
 
-#: ../gramps/gui/plug/_windows.py:622
+#: ../gramps/gui/plug/_windows.py:624
 msgid "Authors"
 msgstr "Szerzők"
 
-#: ../gramps/gui/plug/_windows.py:624
+#: ../gramps/gui/plug/_windows.py:626
 #: ../gramps/gui/plug/report/_reportdialog.py:472
 msgid "Filename"
 msgstr "Fájlnév"
 
-#: ../gramps/gui/plug/_windows.py:627
+#: ../gramps/gui/plug/_windows.py:629
 msgid "Detailed Info"
 msgstr "Részletes információ"
 
-#: ../gramps/gui/plug/_windows.py:686
+#: ../gramps/gui/plug/_windows.py:688
 msgid "Plugin Error"
 msgstr "Beépülő hiba"
 
-#: ../gramps/gui/plug/_windows.py:751
+#: ../gramps/gui/plug/_windows.py:753
 msgid "_Execute"
 msgstr "Vé_grehajtani"
 
-#: ../gramps/gui/plug/_windows.py:1047
+#: ../gramps/gui/plug/_windows.py:1049
+#: ../gramps/plugins/importer/importprogen.py:457
 #: ../gramps/plugins/tool/ownereditor.py:164
 #: ../gramps/plugins/tool/reorderids.py:218
 msgid "Main window"
 msgstr "Fő ablak"
 
-#: ../gramps/gui/plug/_windows.py:1175
+#: ../gramps/gui/plug/_windows.py:1177
 msgid "Downloading and installing selected addons..."
 msgstr "A kiválasztott bővítmények letöltése és telepítése..."
 
-#: ../gramps/gui/plug/_windows.py:1210
+#: ../gramps/gui/plug/_windows.py:1212
 msgid "Installation Errors"
 msgstr "Telepítési hibák"
 
-#: ../gramps/gui/plug/_windows.py:1211
+#: ../gramps/gui/plug/_windows.py:1213
 msgid "The following addons had errors: "
 msgstr "A következő kiegészítők hibásak: "
 
-#: ../gramps/gui/plug/_windows.py:1217 ../gramps/gui/plug/_windows.py:1225
+#: ../gramps/gui/plug/_windows.py:1219 ../gramps/gui/plug/_windows.py:1227
 msgid "Done downloading and installing addons"
 msgstr "A bővítmények letöltése és telepítése végrehajtva"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/gui/plug/_windows.py:1219
+#: ../gramps/gui/plug/_windows.py:1221
 #, python-brace-format
 msgid "{number_of} addon was installed."
 msgid_plural "{number_of} addons were installed."
 msgstr[0] "{number_of} bővítmény volt telepítve."
 msgstr[1] "{number_of} bővítmény volt telepítve."
 
-#: ../gramps/gui/plug/_windows.py:1222
+#: ../gramps/gui/plug/_windows.py:1224
 msgid "If you have installed a 'Gramps View', you will need to restart Gramps."
 msgstr ""
 "Ha telepítette a 'GRAMPS nézet'-et, akkor a GRAMPS-ot újra kell indítania."
 
-#: ../gramps/gui/plug/_windows.py:1226
+#: ../gramps/gui/plug/_windows.py:1228
 msgid "No addons were installed."
 msgstr "Bővítmények nem voltak telepítve."
 
@@ -17927,7 +18336,7 @@ msgid "Select save file"
 msgstr "Fájl mentés kiválasztása"
 
 #: ../gramps/gui/plug/export/_exportassistant.py:359
-#: ../gramps/plugins/tool/mediamanager.py:105
+#: ../gramps/plugins/tool/mediamanager.py:109
 msgid "Final confirmation"
 msgstr "Végső megerősítés"
 
@@ -18051,12 +18460,12 @@ msgstr ""
 "Ha meggondolja magát a folyamat alatt, bármikor nyugodtan megnyomhatja a "
 "Megszakítás gombot és a jelenlegi adatbázis változatlan marad."
 
-#: ../gramps/gui/plug/export/_exportassistant.py:602
+#: ../gramps/gui/plug/export/_exportassistant.py:597
 msgid "Error exporting your Family Tree"
 msgstr "Hiba történt a Családfa exportjánál"
 
-#: ../gramps/gui/plug/export/_exportassistant.py:610
-#: ../gramps/gui/plug/export/_exportassistant.py:644
+#: ../gramps/gui/plug/export/_exportassistant.py:605
+#: ../gramps/gui/plug/export/_exportassistant.py:639
 msgid "Please wait while your data is selected and exported"
 msgstr "Kérem várjon, amíg adatai kiválasztásra és exportálásra kerülnek"
 
@@ -18076,7 +18485,6 @@ msgstr "Szűretlen családfa:"
 #. translators: leave all/any {...} untranslated
 #: ../gramps/gui/plug/export/_exportoptions.py:167
 #: ../gramps/gui/plug/export/_exportoptions.py:274
-#: ../gramps/gui/plug/export/_exportoptions.py:574
 #: ../gramps/gui/plug/export/_exportoptions.py:577
 #, python-brace-format
 msgid "{number_of} Person"
@@ -18147,103 +18555,77 @@ msgstr "Kattintson a hivatkozás-szűrő alkalmazása utáni előnézethez"
 msgid "Hide order"
 msgstr "Sorrend elrejtése"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:589
 #: ../gramps/gui/plug/export/_exportoptions.py:592
 msgid "Filtering private data"
 msgstr "Személyes adatok szűrése"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:598
 #: ../gramps/gui/plug/export/_exportoptions.py:601
 msgid "Filtering living persons"
 msgstr "Élő személyek szűrése"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:615
 #: ../gramps/gui/plug/export/_exportoptions.py:618
 msgid "Applying selected person filter"
 msgstr "A kiválasztott személyszűrő alkalmazása"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:625
 #: ../gramps/gui/plug/export/_exportoptions.py:628
 msgid "Applying selected note filter"
 msgstr "A kiválasztott megjegyzés szűrő alkalmazása"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:634
 #: ../gramps/gui/plug/export/_exportoptions.py:637
 msgid "Filtering referenced records"
 msgstr "A hivatkozott mezők szűrése"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:675
 #: ../gramps/gui/plug/export/_exportoptions.py:678
 msgid "Cannot edit a system filter"
 msgstr "Nem tudja szerkeszteni a rendszer szűrőt"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:676
 #: ../gramps/gui/plug/export/_exportoptions.py:679
 msgid "Please select a different filter to edit"
 msgstr "Szerkesztéshez kérem válasszon másik szűrőt"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:706
-#: ../gramps/gui/plug/export/_exportoptions.py:730
 #: ../gramps/gui/plug/export/_exportoptions.py:709
 #: ../gramps/gui/plug/export/_exportoptions.py:733
 msgid "Include all selected people"
 msgstr "Minden kiválasztott emberrel bezárólag"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:720
 #: ../gramps/gui/plug/export/_exportoptions.py:723
 msgid "Include all selected notes"
 msgstr "Minden kiválasztott jegyzettel bezárólag"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:731
 #: ../gramps/gui/plug/export/_exportoptions.py:734
 msgid "Replace given names of living people"
 msgstr "Élő emberek keresztnevének cseréje"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:732
 #: ../gramps/gui/plug/export/_exportoptions.py:735
 msgid "Replace complete name of living people"
 msgstr "Élő emberek teljes nevének cseréje"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:733
 #: ../gramps/gui/plug/export/_exportoptions.py:736
 msgid "Do not include living people"
 msgstr "Élő emberek kizárása"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:742
 #: ../gramps/gui/plug/export/_exportoptions.py:745
 msgid "Include all selected records"
 msgstr "Minden kiválasztott feljegyzéssel bezárólag"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:743
 #: ../gramps/gui/plug/export/_exportoptions.py:746
 msgid "Do not include records not linked to a selected person"
 msgstr "A kiválasztott személyre nem hivatkozó feljegyzések kizárásával"
 
-#: ../gramps/gui/plug/export/_exportoptions.py:764
 #: ../gramps/gui/plug/export/_exportoptions.py:767
 msgid "Use Compression"
 msgstr "Használjon kompressziót"
 
-#: ../gramps/gui/plug/quick/_quickreports.py:94
-msgid "Web Connect"
+#: ../gramps/gui/plug/quick/_quickreports.py:97
+msgid "Web Connection"
 msgstr "Web kapcsolat"
 
-#: ../gramps/gui/plug/quick/_quickreports.py:140
+#: ../gramps/gui/plug/quick/_quickreports.py:142
 #: ../gramps/gui/plug/quick/_textbufdoc.py:74
 #: ../gramps/gui/plug/quick/_textbufdoc.py:154
 #: ../gramps/gui/plug/quick/_textbufdoc.py:156
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:216
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:223
-#: ../gramps/plugins/lib/libpersonview.py:384
-#: ../gramps/plugins/lib/libplaceview.py:155
-#: ../gramps/plugins/view/citationlistview.py:182
-#: ../gramps/plugins/view/citationtreeview.py:316
-#: ../gramps/plugins/view/eventview.py:247
-#: ../gramps/plugins/view/familyview.py:211
-#: ../gramps/plugins/view/mediaview.py:219
-#: ../gramps/plugins/view/noteview.py:201
-#: ../gramps/plugins/view/repoview.py:153
-#: ../gramps/plugins/view/sourceview.py:138
 msgid "Quick View"
 msgstr "Gyorsnézet"
 
@@ -18256,61 +18638,65 @@ msgstr "Minden másolása"
 msgid "See data not in Filter"
 msgstr "Szűrőben nem levő adatok megtekintése"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:166
+#: ../gramps/gui/plug/report/_bookdialog.py:92
+msgid "Generate_Book_dialog"
+msgstr "Könyv_létrehozása_párbeszédablak"
+
+#: ../gramps/gui/plug/report/_bookdialog.py:172
 msgid "Available Books"
 msgstr "Elérhető könyvek"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:240
+#: ../gramps/gui/plug/report/_bookdialog.py:247
 msgid "Discard Unsaved Changes"
 msgstr "Nem mentett változások elvetése"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:241
+#: ../gramps/gui/plug/report/_bookdialog.py:248
 msgid "You have made changes which have not been saved."
 msgstr "Vannak változások, amiket nem mentett."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:242
-#: ../gramps/gui/plug/report/_bookdialog.py:738
+#: ../gramps/gui/plug/report/_bookdialog.py:249
+#: ../gramps/gui/plug/report/_bookdialog.py:750
 msgid "Proceed"
 msgstr "Tovább"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:301
+#: ../gramps/gui/plug/report/_bookdialog.py:309
 msgid "Name of the book. MANDATORY"
 msgstr "A könyv neve. KÖTELEZŐ"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:323
+#: ../gramps/gui/plug/report/_bookdialog.py:331
 msgid "Manage Books"
 msgstr "Könyvek kezelése"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:362
+#: ../gramps/gui/plug/report/_bookdialog.py:372
 msgid "New Book"
 msgstr "Új könyv"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:365
+#: ../gramps/gui/plug/report/_bookdialog.py:375
 msgid "_Available items"
 msgstr "_Elérhető elemek"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:369
+#: ../gramps/gui/plug/report/_bookdialog.py:379
 msgid "Current _book"
 msgstr "Jelenlegi _könyv"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:377
-#: ../gramps/plugins/drawreport/statisticschart.py:307
+#: ../gramps/gui/plug/report/_bookdialog.py:387
+#: ../gramps/plugins/drawreport/statisticschart.py:312
 msgid "Item name"
 msgstr "Elem neve"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:380
+#: ../gramps/gui/plug/report/_bookdialog.py:390
 msgid "Subject"
 msgstr "Tárgy"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:394
+#: ../gramps/gui/plug/report/_bookdialog.py:404
 msgid "Book selection list"
 msgstr "Könyvválasztó lista"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:446
+#: ../gramps/gui/plug/report/_bookdialog.py:456
 msgid "Different database"
 msgstr "Más adatbázis"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:447
+#: ../gramps/gui/plug/report/_bookdialog.py:457
 #, python-format
 msgid ""
 "This book was created with the references to database %s.\n"
@@ -18328,43 +18714,43 @@ msgstr ""
 "Ezért minden elem központi személye a jelenleg megnyitott adatbázis aktív "
 "személyéhez lesz állítva."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:553
+#: ../gramps/gui/plug/report/_bookdialog.py:563
 msgid "No selected book item"
 msgstr "Nincs kiválasztott könyv elem"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:554
+#: ../gramps/gui/plug/report/_bookdialog.py:564
 msgid "Please select a book item to configure."
 msgstr "Konfiguráláshoz kérem válasszon egy könyv elemet."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:619
-#: ../gramps/gui/views/bookmarks.py:280 ../gramps/gui/views/tags.py:422
+#: ../gramps/gui/plug/report/_bookdialog.py:631
+#: ../gramps/gui/views/bookmarks.py:292 ../gramps/gui/views/tags.py:456
 msgid "_Up"
 msgstr "_Fel"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:620
-#: ../gramps/gui/views/bookmarks.py:281 ../gramps/gui/views/tags.py:423
+#: ../gramps/gui/plug/report/_bookdialog.py:632
+#: ../gramps/gui/views/bookmarks.py:293 ../gramps/gui/views/tags.py:457
 msgid "_Down"
 msgstr "_Le"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:621
+#: ../gramps/gui/plug/report/_bookdialog.py:633
 msgid "Setup"
 msgstr "Beállítás"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:710
-#: ../gramps/gui/plug/report/_bookdialog.py:721
+#: ../gramps/gui/plug/report/_bookdialog.py:722
+#: ../gramps/gui/plug/report/_bookdialog.py:733
 msgid "No items"
 msgstr "Nincsenek elemek"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:711
-#: ../gramps/gui/plug/report/_bookdialog.py:722
+#: ../gramps/gui/plug/report/_bookdialog.py:723
+#: ../gramps/gui/plug/report/_bookdialog.py:734
 msgid "This book has no items."
 msgstr "A könyvben nincsenek elemek."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:728
+#: ../gramps/gui/plug/report/_bookdialog.py:740
 msgid "No book name"
 msgstr "Nincs könyv név"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:729
+#: ../gramps/gui/plug/report/_bookdialog.py:741
 msgid ""
 "You are about to save away a book with no name.\n"
 "\n"
@@ -18374,19 +18760,19 @@ msgstr ""
 "\n"
 "Kérem adjon egy nevet mentés előtt."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:735
+#: ../gramps/gui/plug/report/_bookdialog.py:747
 msgid "Book name already exists"
 msgstr "A könyvnév már létezik"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:736
+#: ../gramps/gui/plug/report/_bookdialog.py:748
 msgid "You are about to save away a book with a name which already exists."
 msgstr "Olyan nevű könyvet mentene, amilyen név már létezik."
 
-#: ../gramps/gui/plug/report/_bookdialog.py:926
+#: ../gramps/gui/plug/report/_bookdialog.py:938
 msgid "Generate Book"
 msgstr "Könyv létrehozása"
 
-#: ../gramps/gui/plug/report/_bookdialog.py:969
+#: ../gramps/gui/plug/report/_bookdialog.py:985
 msgid "Gramps Book"
 msgstr "GRAMPS könyv"
 
@@ -18430,8 +18816,8 @@ msgid "Configuration"
 msgstr "Beállítás"
 
 #: ../gramps/gui/plug/report/_reportdialog.py:324
-#: ../gramps/gui/plug/report/_styleeditor.py:108
-#: ../gramps/gui/plug/report/_styleeditor.py:259
+#: ../gramps/gui/plug/report/_styleeditor.py:115
+#: ../gramps/gui/plug/report/_styleeditor.py:270
 msgid "Style"
 msgstr "Stílus"
 
@@ -18455,34 +18841,33 @@ msgstr "Stílus"
 #. ###############################
 #: ../gramps/gui/plug/report/_reportdialog.py:366
 #: ../gramps/plugins/drawreport/ancestortree.py:835
-#: ../gramps/plugins/drawreport/calendarreport.py:466
-#: ../gramps/plugins/drawreport/descendtree.py:1568
-#: ../gramps/plugins/drawreport/fanchart.py:685
-#: ../gramps/plugins/drawreport/statisticschart.py:986
-#: ../gramps/plugins/drawreport/timeline.py:413
-#: ../gramps/plugins/graph/gvfamilylines.py:115
-#: ../gramps/plugins/graph/gvhourglass.py:315
-#: ../gramps/plugins/graph/gvrelgraph.py:763
+#: ../gramps/plugins/drawreport/calendarreport.py:462
+#: ../gramps/plugins/drawreport/descendtree.py:1573
+#: ../gramps/plugins/drawreport/fanchart.py:687
+#: ../gramps/plugins/drawreport/statisticschart.py:1008
+#: ../gramps/plugins/drawreport/timeline.py:414
+#: ../gramps/plugins/graph/gvfamilylines.py:120
+#: ../gramps/plugins/graph/gvhourglass.py:364
+#: ../gramps/plugins/graph/gvrelgraph.py:797
 #: ../gramps/plugins/textreport/alphabeticalindex.py:93
 #: ../gramps/plugins/textreport/ancestorreport.py:288
-#: ../gramps/plugins/textreport/birthdayreport.py:409
+#: ../gramps/plugins/textreport/birthdayreport.py:471
 #: ../gramps/plugins/textreport/descendreport.py:520
-#: ../gramps/plugins/textreport/detancestralreport.py:820
-#: ../gramps/plugins/textreport/detdescendantreport.py:997
+#: ../gramps/plugins/textreport/detancestralreport.py:828
+#: ../gramps/plugins/textreport/detdescendantreport.py:1003
 #: ../gramps/plugins/textreport/endoflinereport.py:270
 #: ../gramps/plugins/textreport/familygroup.py:710
-#: ../gramps/plugins/textreport/indivcomplete.py:1058
+#: ../gramps/plugins/textreport/indivcomplete.py:1059
 #: ../gramps/plugins/textreport/kinshipreport.py:356
 #: ../gramps/plugins/textreport/numberofancestorsreport.py:202
-#: ../gramps/plugins/textreport/placereport.py:438
+#: ../gramps/plugins/textreport/placereport.py:439
 #: ../gramps/plugins/textreport/recordsreport.py:215
 #: ../gramps/plugins/textreport/simplebooktitle.py:134
 #: ../gramps/plugins/textreport/summary.py:286
 #: ../gramps/plugins/textreport/tableofcontents.py:92
 #: ../gramps/plugins/textreport/tagreport.py:901
-#: ../gramps/plugins/webreport/narrativeweb.py:1576
-#: ../gramps/plugins/webreport/webcal.py:1611
-#: ../gramps/plugins/drawreport/statisticschart.py:997
+#: ../gramps/plugins/webreport/narrativeweb.py:1613
+#: ../gramps/plugins/webreport/webcal.py:1656
 msgid "Report Options"
 msgstr "Összesítő lehetőségek"
 
@@ -18553,73 +18938,81 @@ msgstr ""
 "\n"
 "Válasszon másik könyvtárat, vagy hozzon létre egyet."
 
-#: ../gramps/gui/plug/report/_reportdialog.py:665
-#: ../gramps/gui/plug/tool.py:136 ../gramps/plugins/tool/relcalc.py:150
+#: ../gramps/gui/plug/report/_reportdialog.py:668
+#: ../gramps/gui/plug/tool.py:136 ../gramps/plugins/tool/relcalc.py:157
 msgid "Active person has not been set"
 msgstr "Aktív személy nincs beállítva"
 
-#: ../gramps/gui/plug/report/_reportdialog.py:666
+#: ../gramps/gui/plug/report/_reportdialog.py:669
 msgid "You must select an active person for this report to work properly."
 msgstr "Az összesítő helyes működéséhez aktív személyt kell kiválasztania."
 
-#: ../gramps/gui/plug/report/_reportdialog.py:721
-#: ../gramps/gui/plug/report/_reportdialog.py:728
+#: ../gramps/gui/plug/report/_reportdialog.py:724
+#: ../gramps/gui/plug/report/_reportdialog.py:731
 msgid "Report could not be created"
 msgstr "Az összesítő nem létrehozható"
 
 #: ../gramps/gui/plug/report/_stylecombobox.py:66
 #: ../gramps/gui/plug/report/_stylecombobox.py:85
-#: ../gramps/gui/plug/report/_styleeditor.py:127
-#: ../gramps/gui/plug/report/_styleeditor.py:171
-#: ../gramps/gui/plug/report/_styleeditor.py:184
+#: ../gramps/gui/plug/report/_styleeditor.py:134
+#: ../gramps/gui/plug/report/_styleeditor.py:179
+#: ../gramps/gui/plug/report/_styleeditor.py:192
 #: ../gramps/plugins/importer/importgedcom.glade:12 gtklist.h:1
 msgid "default"
 msgstr "alapérték"
 
-#: ../gramps/gui/plug/report/_styleeditor.py:92
-#: ../gramps/gui/plug/report/_styleeditor.py:118
+#: ../gramps/gui/plug/report/_styleeditor.py:96
+#: ../gramps/gui/plug/report/_styleeditor.py:125
 msgid "Document Styles"
 msgstr "Dokumentum stílusok"
 
-#: ../gramps/gui/plug/report/_styleeditor.py:140
+#: ../gramps/gui/plug/report/_styleeditor.py:108
+msgid "manual|Document_Styles_dialog"
+msgstr "manual|Dokumentum_Stílus_párbeszéd ablak"
+
+#: ../gramps/gui/plug/report/_styleeditor.py:147
 msgid "New Style"
 msgstr "Új stílus"
 
-#: ../gramps/gui/plug/report/_styleeditor.py:150
+#: ../gramps/gui/plug/report/_styleeditor.py:157
 msgid "Error saving stylesheet"
 msgstr "Hiba a stíluslap mentésekor"
 
 #. How to handle missing information
-#: ../gramps/gui/plug/report/_styleeditor.py:166
-#: ../gramps/gui/plug/report/_styleeditor.py:180
-#: ../gramps/plugins/textreport/detancestralreport.py:952
-#: ../gramps/plugins/textreport/detdescendantreport.py:1155
+#: ../gramps/gui/plug/report/_styleeditor.py:174
+#: ../gramps/gui/plug/report/_styleeditor.py:188
+#: ../gramps/plugins/textreport/detancestralreport.py:960
+#: ../gramps/plugins/textreport/detdescendantreport.py:1161
 msgid "Missing information"
 msgstr "Hiányzó információ"
 
-#: ../gramps/gui/plug/report/_styleeditor.py:166
-#: ../gramps/gui/plug/report/_styleeditor.py:180
+#: ../gramps/gui/plug/report/_styleeditor.py:174
+#: ../gramps/gui/plug/report/_styleeditor.py:188
 msgid "Select a style"
 msgstr "Stílus kiválasztása"
 
-#: ../gramps/gui/plug/report/_styleeditor.py:226
-#: ../gramps/gui/plug/report/_styleeditor.py:298
+#: ../gramps/gui/plug/report/_styleeditor.py:234
+#: ../gramps/gui/plug/report/_styleeditor.py:309
 msgid "Style editor"
 msgstr "Stílus szerkesztő"
 
-#: ../gramps/gui/plug/report/_styleeditor.py:341
-#: ../gramps/gui/plug/report/_styleeditor.py:369
-#: ../gramps/gui/plug/report/_styleeditor.py:387
-#: ../gramps/gui/plug/report/_styleeditor.py:420
+#: ../gramps/gui/plug/report/_styleeditor.py:242
+msgid "manual|Style_editor_dialog"
+msgstr "manual|Stílus_szerkesztő_párbeszéd ablak"
+
+#: ../gramps/gui/plug/report/_styleeditor.py:352
+#: ../gramps/gui/plug/report/_styleeditor.py:380
+#: ../gramps/gui/plug/report/_styleeditor.py:398
+#: ../gramps/gui/plug/report/_styleeditor.py:431
 msgid "No description available"
 msgstr "Nincs elérhető leírás"
 
-#: ../gramps/gui/plug/report/_styleeditor.py:344
+#: ../gramps/gui/plug/report/_styleeditor.py:355
 #, python-format
 msgid "(Embedded style '%s' must be edited separately)"
 msgstr "(A beépített '%s' stílust külön kell szerkeszteni)"
 
-#: ../gramps/gui/plug/report/_styleeditor.py:397
+#: ../gramps/gui/plug/report/_styleeditor.py:408
 #, python-format
 msgid "Column %d:"
 msgstr "Oszlop %d:"
@@ -18668,94 +19061,102 @@ msgstr ""
 msgid "_Proceed with the tool"
 msgstr "_Folytassa az eszközzel"
 
-#: ../gramps/gui/plug/tool.py:137 ../gramps/plugins/tool/relcalc.py:151
+#: ../gramps/gui/plug/tool.py:137 ../gramps/plugins/tool/relcalc.py:158
 msgid "You must select an active person for this tool to work properly."
 msgstr "Az eszköz helyes működéséhez aktív személyt kell kiválasztania."
 
-#: ../gramps/gui/selectors/selectcitation.py:51
-msgid "manual|Select_Source_or_Citation_selector"
-msgstr "manual|Forrás_vagy_idézet_kiválasztó"
-
-#: ../gramps/gui/selectors/selectcitation.py:67
+#: ../gramps/gui/selectors/selectcitation.py:64
 msgid "Select Source or Citation"
 msgstr "Forrás, vagy idézet kiválasztása"
 
-#: ../gramps/gui/selectors/selectcitation.py:74
+#: ../gramps/gui/selectors/selectcitation.py:71
 #: ../gramps/plugins/view/citationtreeview.py:93
 msgid "Source: Title or Citation: Volume/Page"
 msgstr "Forrás: Cím vagy Idézet: Kötet/Oldal"
 
-#: ../gramps/gui/selectors/selectcitation.py:76
-#: ../gramps/gui/selectors/selectevent.py:75
-#: ../gramps/gui/selectors/selectfamily.py:72
-#: ../gramps/gui/selectors/selectnote.py:78
-#: ../gramps/gui/selectors/selectobject.py:83
-#: ../gramps/gui/selectors/selectperson.py:101
-#: ../gramps/gui/selectors/selectplace.py:74
-#: ../gramps/gui/selectors/selectrepository.py:71
-#: ../gramps/gui/selectors/selectsource.py:72
+#: ../gramps/gui/selectors/selectcitation.py:73
+#: ../gramps/gui/selectors/selectevent.py:72
+#: ../gramps/gui/selectors/selectfamily.py:69
+#: ../gramps/gui/selectors/selectnote.py:75
+#: ../gramps/gui/selectors/selectobject.py:80
+#: ../gramps/gui/selectors/selectperson.py:98
+#: ../gramps/gui/selectors/selectplace.py:71
+#: ../gramps/gui/selectors/selectrepository.py:68
+#: ../gramps/gui/selectors/selectsource.py:69
 msgid "Last Change"
 msgstr "Utolsó változás"
 
-#: ../gramps/gui/selectors/selectevent.py:46
-msgid "manual|Select_Event_selector"
-msgstr "manual|Esemény_választó_kiválasztása"
+#: ../gramps/gui/selectors/selectcitation.py:86
+msgid "manual|Select_Source_or_Citation_selector"
+msgstr "manual|Forrás_vagy_idézet_kiválasztó"
 
-#: ../gramps/gui/selectors/selectevent.py:62
+#: ../gramps/gui/selectors/selectevent.py:59
 msgid "Select Event"
 msgstr "Esemény kiválasztása"
 
-#: ../gramps/gui/selectors/selectfamily.py:46
+#: ../gramps/gui/selectors/selectevent.py:79
+msgid "manual|Select_Event_selector"
+msgstr "manual|Esemény_választó_kiválasztása"
+
+#: ../gramps/gui/selectors/selectfamily.py:76
 msgid "manual|Select_Family_selector"
 msgstr "manual|Család_választó_kiválasztása"
 
-#: ../gramps/gui/selectors/selectnote.py:49
-msgid "manual|Select_Note_selector"
-msgstr "manual|Jegyzet_választó_kiválasztása"
-
-#: ../gramps/gui/selectors/selectnote.py:67
+#: ../gramps/gui/selectors/selectnote.py:64
 msgid "Select Note"
 msgstr "Jegyzet kiválasztása"
 
-#: ../gramps/gui/selectors/selectobject.py:60
-msgid "manual|Select_Media_Object_selector"
-msgstr "manual|Média_objektum_választó_kiválasztása"
+#: ../gramps/gui/selectors/selectnote.py:82
+msgid "manual|Select_Note_selector"
+msgstr "manual|Jegyzet_választó_kiválasztása"
 
-#: ../gramps/gui/selectors/selectobject.py:70
+#: ../gramps/gui/selectors/selectobject.py:67
 msgid "Select Media Object"
 msgstr "Média objektum kiválasztása"
 
-#: ../gramps/gui/selectors/selectperson.py:54
-msgid "manual|Select_Child_selector"
-msgstr "manual|Gyermek_választó_kiválasztása"
+#: ../gramps/gui/selectors/selectobject.py:108
+msgid "manual|Select_Media_Object_selector"
+msgstr "manual|Média_objektum_választó_kiválasztása"
 
-#: ../gramps/gui/selectors/selectperson.py:56
+#: ../gramps/gui/selectors/selectperson.py:64
 msgid "manual|Select_Father_selector"
 msgstr "manual|Apa_választó_kiválasztása"
 
-#: ../gramps/gui/selectors/selectperson.py:58
+#: ../gramps/gui/selectors/selectperson.py:66
 msgid "manual|Select_Mother_selector"
 msgstr "manual|Anya_választó_kiválasztása"
 
-#: ../gramps/gui/selectors/selectplace.py:47
-msgid "manual|Select_Place_selector"
-msgstr "manual|Hely_választó_kiválasztása"
+#: ../gramps/gui/selectors/selectperson.py:68
+msgid "manual|Select_Child_selector"
+msgstr "manual|Gyermek_választó_kiválasztása"
 
-#: ../gramps/gui/selectors/selectplace.py:63
+#: ../gramps/gui/selectors/selectperson.py:70
+msgid "manual|Select_Person_selector"
+msgstr "manual|Személy_választó_kiválasztása"
+
+#: ../gramps/gui/selectors/selectplace.py:60
 msgid "Select Place"
 msgstr "Hely kiválasztása"
 
-#: ../gramps/gui/selectors/selectrepository.py:46
-msgid "manual|Repositories"
-msgstr "manual|Tárolók"
+#: ../gramps/gui/selectors/selectplace.py:90
+msgid "manual|Select_Place_selector"
+msgstr "manual|Hely_választó_kiválasztása"
 
-#: ../gramps/gui/selectors/selectrepository.py:62
+#: ../gramps/gui/selectors/selectrepository.py:59
 msgid "Select Repository"
 msgstr "Tároló kiválasztása"
 
-#: ../gramps/gui/selectors/selectsource.py:62
+#: ../gramps/gui/selectors/selectrepository.py:75
+msgid "manual|Select_Repository_selector"
+msgstr "manual|Tároló_választó_kiválasztása"
+
+#: ../gramps/gui/selectors/selectsource.py:59
 msgid "Select Source"
 msgstr "Forrás kiválasztása"
+
+#: ../gramps/gui/selectors/selectsource.py:76
+msgid "manual|Select_Source_selector"
+msgstr "manual|Forrás_választó_kiválasztása"
 
 #: ../gramps/gui/spell.py:92
 msgid "Off"
@@ -18778,11 +19179,6 @@ msgstr ""
 msgid "Spelling checker initialization failed: %s"
 msgstr "A helyesírás ellenőrző nem indult el: %s"
 
-#: ../gramps/gui/tipofday.py:67 ../gramps/gui/tipofday.py:68
-#: ../gramps/gui/tipofday.py:121 ../gramps/gui/viewmanager.py:538
-msgid "Tip of the Day"
-msgstr "A nap tippje"
-
 #: ../gramps/gui/tipofday.py:87
 msgid "Failed to display tip of the day"
 msgstr "Nem sikerült a nap tippjét megjeleníteni"
@@ -18798,17 +19194,11 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../gramps/gui/undohistory.py:73
-msgid "Undo History"
-msgstr "Történet visszavonása"
-
-#: ../gramps/gui/undohistory.py:84 ../gramps/gui/viewmanager.py:647
-#: ../gramps/gui/viewmanager.py:1331 ../gramps/gui/viewmanager.py:1329
+#: ../gramps/gui/undohistory.py:84 ../gramps/gui/viewmanager.py:1120
 msgid "_Undo"
 msgstr "Viss_zavonás"
 
-#: ../gramps/gui/undohistory.py:86 ../gramps/gui/viewmanager.py:652
-#: ../gramps/gui/viewmanager.py:1348 ../gramps/gui/viewmanager.py:1346
+#: ../gramps/gui/undohistory.py:86 ../gramps/gui/viewmanager.py:1140
 msgid "_Redo"
 msgstr "I_smétlés"
 
@@ -18868,7 +19258,7 @@ msgstr "Hiba a külső programból"
 msgid "File %s does not exist"
 msgstr "Nem létező %s fájl"
 
-#: ../gramps/gui/utils.py:613
+#: ../gramps/gui/utils.py:627
 msgid ""
 "Cannot open new citation editor at this time. Either the citation is already "
 "being edited, or the associated source is already being edited, and opening "
@@ -18886,195 +19276,28 @@ msgstr ""
 "Az idézet szerkesztéséhez zárja be a forrás szerkesztését, majd csak az "
 "idézethez nyisson meg egy szerkesztőt"
 
-#: ../gramps/gui/utils.py:626
+#: ../gramps/gui/utils.py:640
 msgid "Cannot open new citation editor"
 msgstr "Nem megnyitható az idézet-szerkesztő"
 
-#: ../gramps/gui/viewmanager.py:470 ../gramps/gui/viewmanager.py:1267
-#: ../gramps/gui/viewmanager.py:1265
+#: ../gramps/gui/viewmanager.py:331 ../gramps/gui/viewmanager.py:1052
 msgid "No Family Tree"
 msgstr "Nincs Családfa"
 
-#: ../gramps/gui/viewmanager.py:492
-msgid "Connect to a recent database"
-msgstr "Jelenlegi adatbázishoz kapcsolódás"
-
-#: ../gramps/gui/viewmanager.py:510
-msgid "_Family Trees"
-msgstr "Család_fák"
-
-#: ../gramps/gui/viewmanager.py:511
-msgid "_Manage Family Trees..."
-msgstr "Családfák _kezelése..."
-
-#: ../gramps/gui/viewmanager.py:512
-msgid "Manage databases"
-msgstr "Adatbázisok kezelése"
-
-#: ../gramps/gui/viewmanager.py:513
-msgid "Open _Recent"
-msgstr "Jelenlegi _megnyitása"
-
-#: ../gramps/gui/viewmanager.py:514
-msgid "Open an existing database"
-msgstr "Jelenlegi adatbázis megnyitása"
-
-#: ../gramps/gui/viewmanager.py:515
-msgid "_Quit"
-msgstr "_Kilépés"
-
-#: ../gramps/gui/viewmanager.py:517
-msgid "_View"
-msgstr "_Nézet"
-
-#: ../gramps/gui/viewmanager.py:519
-msgid "_Preferences..."
-msgstr "_Beállítások..."
-
-#: ../gramps/gui/viewmanager.py:522
-msgid "Gramps _Home Page"
-msgstr "GRAMPS _honlap"
-
-#: ../gramps/gui/viewmanager.py:524
-msgid "Gramps _Mailing Lists"
-msgstr "GRAMPS _levelezőlista"
-
-#: ../gramps/gui/viewmanager.py:526
-msgid "_Report a Bug"
-msgstr "_Hiba jelentése"
-
-#: ../gramps/gui/viewmanager.py:528
-msgid "_Extra Reports/Tools"
-msgstr "_Extra összesítők/eszközök"
-
-#: ../gramps/gui/viewmanager.py:530
-msgid "_About"
-msgstr "Né_vjegy"
-
-#: ../gramps/gui/viewmanager.py:532
-msgid "_Plugin Manager"
-msgstr "_Beépülő kezelő"
-
-#: ../gramps/gui/viewmanager.py:534
-msgid "_FAQ"
-msgstr "_GYIK"
-
-#: ../gramps/gui/viewmanager.py:535
-msgid "_Key Bindings"
-msgstr "_Gyorsbillentyűk"
-
-#: ../gramps/gui/viewmanager.py:536
-msgid "_User Manual"
-msgstr "_Felhasználói kézikönyv"
-
-#: ../gramps/gui/viewmanager.py:544
-msgid "Close the current database"
-msgstr "Zárja be a jelenlegi adatbázist"
-
-#: ../gramps/gui/viewmanager.py:545
-msgid "_Export..."
-msgstr "_Exportálás..."
-
-#: ../gramps/gui/viewmanager.py:547
-msgid "Make Backup..."
-msgstr "Biztonsági másolat készítése..."
-
-#: ../gramps/gui/viewmanager.py:548
-msgid "Make a Gramps XML backup of the database"
-msgstr "GRAMPS XML adatbázis biztonsági mentés készítése"
-
-#: ../gramps/gui/viewmanager.py:550
-msgid "_Abandon Changes and Quit"
-msgstr "_A változások elvetése és kilépés"
-
-#: ../gramps/gui/viewmanager.py:551 ../gramps/gui/viewmanager.py:554
-msgid "_Reports"
-msgstr "Ö_sszesítők"
-
-#: ../gramps/gui/viewmanager.py:552
-msgid "Open the reports dialog"
-msgstr "Összesítők párbeszédablak megnyitása"
-
-#: ../gramps/gui/viewmanager.py:553
-msgid "_Go"
-msgstr "_Menj"
-
-#: ../gramps/gui/viewmanager.py:555
-msgid "Books..."
-msgstr "Könyvek..."
-
-#: ../gramps/gui/viewmanager.py:556
-msgid "_Windows"
-msgstr "Ab_lakok"
-
-#: ../gramps/gui/viewmanager.py:603
-msgid "Clip_board"
-msgstr "Vá_gólap"
-
-#: ../gramps/gui/viewmanager.py:604
-msgid "Open the Clipboard dialog"
-msgstr "Vágólap párbeszédablak megnyitása"
-
-#. --------------------------------------
-#: ../gramps/gui/viewmanager.py:626
-msgid "_Import..."
-msgstr "_Importálás..."
-
-#: ../gramps/gui/viewmanager.py:628 ../gramps/gui/viewmanager.py:631
-msgid "_Tools"
-msgstr "_Eszközök"
-
-#: ../gramps/gui/viewmanager.py:629
-msgid "Open the tools dialog"
-msgstr "Eszközök párbeszédablak megnyitása"
-
-#: ../gramps/gui/viewmanager.py:630
-msgid "_Bookmarks"
-msgstr "_Könyvjelzők"
-
-#: ../gramps/gui/viewmanager.py:632
-msgid "_Configure..."
-msgstr "_Beállítás..."
-
-#: ../gramps/gui/viewmanager.py:633
-msgid "Configure the active view"
-msgstr "Aktív nézet beállítása"
-
-#: ../gramps/gui/viewmanager.py:638
-msgid "_Navigator"
-msgstr "_Navigátor"
-
-#: ../gramps/gui/viewmanager.py:640
-msgid "_Toolbar"
-msgstr "_Eszközsáv"
-
-#: ../gramps/gui/viewmanager.py:642
-msgid "F_ull Screen"
-msgstr "Teljes ké_pernyő"
-
-#: ../gramps/gui/viewmanager.py:658
-msgid "Undo History..."
-msgstr "Történet visszavonása..."
-
-#: ../gramps/gui/viewmanager.py:681
-#, python-format
-msgid "Key %s is not bound"
-msgstr "%s kulcs nem kötött"
-
 #. registering plugins
-#: ../gramps/gui/viewmanager.py:788
+#: ../gramps/gui/viewmanager.py:557
 msgid "Registering plugins..."
 msgstr "Bővítmények regisztrálása..."
 
-#: ../gramps/gui/viewmanager.py:796
+#: ../gramps/gui/viewmanager.py:565
 msgid "Ready"
 msgstr "Kész"
 
-#: ../gramps/gui/viewmanager.py:841
+#: ../gramps/gui/viewmanager.py:620
 msgid "Abort changes?"
 msgstr "Változások elvetése?"
 
-#: ../gramps/gui/viewmanager.py:842
+#: ../gramps/gui/viewmanager.py:621
 msgid ""
 "Aborting changes will return the database to the state it was before you "
 "started this editing session."
@@ -19082,15 +19305,15 @@ msgstr ""
 "A változások elvetése visszaadja adatbázisának a szerkesztés megkezdése "
 "előtti állapotát."
 
-#: ../gramps/gui/viewmanager.py:844
+#: ../gramps/gui/viewmanager.py:623
 msgid "Abort changes"
 msgstr "Változások elvetése"
 
-#: ../gramps/gui/viewmanager.py:855
+#: ../gramps/gui/viewmanager.py:634
 msgid "Cannot abandon session's changes"
 msgstr "A munkamenet változások elvetése nem lehetséges"
 
-#: ../gramps/gui/viewmanager.py:856
+#: ../gramps/gui/viewmanager.py:635
 msgid ""
 "Changes cannot be completely abandoned because the number of changes made in "
 "the session exceeded the limit."
@@ -19098,31 +19321,40 @@ msgstr ""
 "A munkamenet változások elvetése teljesen nem lehetséges, mert a "
 "munkamenetben a változások száma meghaladja a korlátot."
 
-#: ../gramps/gui/viewmanager.py:1017
+#: ../gramps/gui/viewmanager.py:802
 msgid "View failed to load. Check error output."
 msgstr "A nézet betöltése meghiúsult. Ellenőrizze a hibakimenetet."
 
-#: ../gramps/gui/viewmanager.py:1169
+#: ../gramps/gui/viewmanager.py:948
+#: ../gramps/plugins/importer/importprogen.py:195
 msgid "Import Statistics"
 msgstr "Statisztikák importálása"
 
-#: ../gramps/gui/viewmanager.py:1237 ../gramps/gui/viewmanager.py:1240
+#: ../gramps/gui/viewmanager.py:1019
 msgid "Read Only"
 msgstr "Csak olvasható"
 
-#: ../gramps/gui/viewmanager.py:1394 ../gramps/gui/viewmanager.py:1392
+#: ../gramps/gui/viewmanager.py:1023
+msgid "Gramps had a problem the last time it was run."
+msgstr "A GRAMPS legutóbbi futtatásakor probléma volt."
+
+#: ../gramps/gui/viewmanager.py:1024
+msgid "Would you like to run the Check and Repair tool?"
+msgstr "Kívánja futtatni az Ellenőrzés és Javítás eszközt?"
+
+#: ../gramps/gui/viewmanager.py:1189
 msgid "Autobackup..."
 msgstr "Automentés..."
 
-#: ../gramps/gui/viewmanager.py:1399 ../gramps/gui/viewmanager.py:1397
+#: ../gramps/gui/viewmanager.py:1194
 msgid "Error saving backup data"
 msgstr "Biztonsági adatmentés hiba"
 
-#: ../gramps/gui/viewmanager.py:1690 ../gramps/gui/viewmanager.py:1688
+#: ../gramps/gui/viewmanager.py:1481
 msgid "Failed Loading View"
 msgstr "A nézet betöltése nem sikerült"
 
-#: ../gramps/gui/viewmanager.py:1691 ../gramps/gui/viewmanager.py:1689
+#: ../gramps/gui/viewmanager.py:1482
 #, python-format
 msgid ""
 "The view %(name)s did not load and reported an error.\n"
@@ -19147,11 +19379,11 @@ msgstr ""
 "Ha szeretné, hogy a GRAMPS ne töltse be újra a nézetet, akkor azt elrejtheti "
 "a Súgó menü Bővítmény-kezelőjének használatával."
 
-#: ../gramps/gui/viewmanager.py:1783 ../gramps/gui/viewmanager.py:1781
+#: ../gramps/gui/viewmanager.py:1574
 msgid "Failed Loading Plugin"
 msgstr "A bővítmény betöltése nem sikerült"
 
-#: ../gramps/gui/viewmanager.py:1784 ../gramps/gui/viewmanager.py:1782
+#: ../gramps/gui/viewmanager.py:1575
 #, python-format
 msgid ""
 "The plugin %(name)s did not load and reported an error.\n"
@@ -19176,115 +19408,112 @@ msgstr ""
 "Ha szeretné, hogy a GRAMPS ne töltse be újra a bővítményt, akkor rejtse el a "
 "Súgó menü Bővítmény-kezelőjének használatával."
 
-#: ../gramps/gui/viewmanager.py:1864 ../gramps/gui/viewmanager.py:1862
+#: ../gramps/gui/viewmanager.py:1655
 msgid "Gramps XML Backup"
 msgstr "GRAMPS XML biztonsági mentés"
 
-#: ../gramps/gui/viewmanager.py:1893 ../gramps/gui/viewmanager.py:1891
+#: ../gramps/gui/viewmanager.py:1684
 msgid "File:"
 msgstr "Fájl:"
 
-#: ../gramps/gui/viewmanager.py:1925 ../gramps/gui/viewmanager.py:1923
+#: ../gramps/gui/viewmanager.py:1716
 msgid "Media:"
 msgstr "Média:"
 
-#: ../gramps/gui/viewmanager.py:1932
-#: ../gramps/plugins/gramplet/statsgramplet.py:139
-#: ../gramps/plugins/webreport/statistics.py:144
-#: ../gramps/gui/viewmanager.py:1930
+#: ../gramps/gui/viewmanager.py:1723
+#: ../gramps/plugins/gramplet/statsgramplet.py:196
+#: ../gramps/plugins/webreport/statistics.py:145
 msgid "Megabyte|MB"
 msgstr "MB"
 
-#: ../gramps/gui/viewmanager.py:1934 ../gramps/gui/viewmanager.py:1932
+#: ../gramps/gui/viewmanager.py:1725
 msgid "Exclude"
 msgstr "Kizárva"
 
-#: ../gramps/gui/viewmanager.py:1954 ../gramps/gui/viewmanager.py:1952
+#: ../gramps/gui/viewmanager.py:1745
 msgid "Backup file already exists! Overwrite?"
 msgstr "A mentési fájl már létezik. Felülírja?"
 
-#: ../gramps/gui/viewmanager.py:1955 ../gramps/gui/viewmanager.py:1953
+#: ../gramps/gui/viewmanager.py:1746
 #, python-format
 msgid "The file '%s' exists."
 msgstr "A(z) '%s' fájl már létezik."
 
-#: ../gramps/gui/viewmanager.py:1956 ../gramps/gui/viewmanager.py:1954
+#: ../gramps/gui/viewmanager.py:1747
 msgid "Proceed and overwrite"
 msgstr "Folytatás és felülírás"
 
-#: ../gramps/gui/viewmanager.py:1957 ../gramps/gui/viewmanager.py:1955
+#: ../gramps/gui/viewmanager.py:1748
 msgid "Cancel the backup"
 msgstr "A mentés megszakítása"
 
-#: ../gramps/gui/viewmanager.py:1972 ../gramps/gui/viewmanager.py:1970
+#: ../gramps/gui/viewmanager.py:1763
 msgid "Making backup..."
 msgstr "Mentés készítése..."
 
-#: ../gramps/gui/viewmanager.py:1985 ../gramps/gui/viewmanager.py:1983
+#: ../gramps/gui/viewmanager.py:1776
 #, python-format
 msgid "Backup saved to '%s'"
 msgstr "A másolat ide mentve: '%s'"
 
-#: ../gramps/gui/viewmanager.py:1988 ../gramps/gui/viewmanager.py:1986
+#: ../gramps/gui/viewmanager.py:1779
 msgid "Backup aborted"
 msgstr "A mentés megszakítva"
 
-#: ../gramps/gui/views/bookmarks.py:66
+#: ../gramps/gui/views/bookmarks.py:69
 msgid "manual|Bookmarks"
 msgstr "Könyvjelzők"
 
 #. this is meaningless while it's modal
-#: ../gramps/gui/views/bookmarks.py:253 ../gramps/gui/views/bookmarks.py:263
-#: ../gramps/gui/views/bookmarks.py:359
-#: ../gramps/gui/views/navigationview.py:277
+#: ../gramps/gui/views/bookmarks.py:265 ../gramps/gui/views/bookmarks.py:275
+#: ../gramps/gui/views/bookmarks.py:371
+#: ../gramps/plugins/lib/libpersonview.py:205
+#: ../gramps/plugins/lib/libplaceview.py:288
+#: ../gramps/plugins/view/citationlistview.py:180
+#: ../gramps/plugins/view/citationtreeview.py:322
+#: ../gramps/plugins/view/eventview.py:194
+#: ../gramps/plugins/view/familyview.py:153
+#: ../gramps/plugins/view/fanchartview.py:183
+#: ../gramps/plugins/view/geoclose.py:110
+#: ../gramps/plugins/view/geoevents.py:100
+#: ../gramps/plugins/view/geofamclose.py:108
+#: ../gramps/plugins/view/geofamily.py:100
+#: ../gramps/plugins/view/geomoves.py:107
+#: ../gramps/plugins/view/geoperson.py:108
+#: ../gramps/plugins/view/geoplaces.py:103
+#: ../gramps/plugins/view/mediaview.py:253
+#: ../gramps/plugins/view/noteview.py:153
+#: ../gramps/plugins/view/pedigreeview.py:683
+#: ../gramps/plugins/view/relview.py:427 ../gramps/plugins/view/repoview.py:166
+#: ../gramps/plugins/view/sourceview.py:152
 msgid "Organize Bookmarks"
 msgstr "Könyvjelzők szerkesztése"
 
-#: ../gramps/gui/views/bookmarks.py:462
+#: ../gramps/gui/views/bookmarks.py:474
 msgid "Cannot bookmark this reference"
 msgstr "A hivatkozás nem könyvjelzőzhető"
 
-#: ../gramps/gui/views/listview.py:211
-#: ../gramps/plugins/lib/libpersonview.py:391
-msgid "_Add..."
-msgstr "_Hozzáadás..."
-
-#: ../gramps/gui/views/listview.py:215
-#: ../gramps/plugins/lib/libpersonview.py:395
-msgid "_Merge..."
-msgstr "Öss_zefűzés..."
-
-#: ../gramps/gui/views/listview.py:217
-#: ../gramps/plugins/lib/libpersonview.py:397
-msgid "Export View..."
-msgstr "Nézet exportálása..."
-
-#: ../gramps/gui/views/listview.py:223
-#: ../gramps/plugins/lib/libpersonview.py:382
-msgid "action|_Edit..."
-msgstr "_Szerkesztés..."
-
-#: ../gramps/gui/views/listview.py:442
+#: ../gramps/gui/views/listview.py:439
 msgid "Active object not visible"
 msgstr "Aktív objektum nem látható"
 
-#: ../gramps/gui/views/listview.py:452
-#: ../gramps/gui/views/navigationview.py:257
-#: ../gramps/plugins/lib/maps/geography.py:204
-#: ../gramps/plugins/lib/maps/geography.py:220
-#: ../gramps/plugins/view/familyview.py:222
+#: ../gramps/gui/views/listview.py:449
+#: ../gramps/gui/views/navigationview.py:256
+#: ../gramps/plugins/lib/maps/geography.py:207
+#: ../gramps/plugins/lib/maps/geography.py:224
+#: ../gramps/plugins/view/familyview.py:347
 msgid "Could Not Set a Bookmark"
 msgstr "Könyvjelző nem beállítható"
 
-#: ../gramps/gui/views/listview.py:453
+#: ../gramps/gui/views/listview.py:450
 msgid "A bookmark could not be set because nothing was selected."
 msgstr "A könyvjelző nem beállítható, mert semmi sincs kiválasztva."
 
-#: ../gramps/gui/views/listview.py:545
+#: ../gramps/gui/views/listview.py:542
 msgid "Multiple Selection Delete"
 msgstr "Többszörös törlés kiválasztás"
 
-#: ../gramps/gui/views/listview.py:546
+#: ../gramps/gui/views/listview.py:543
 msgid ""
 "More than one item has been selected for deletion. Select the option "
 "indicating how to delete the items:"
@@ -19292,15 +19521,15 @@ msgstr ""
 "Több mint egy elem lett kiválasztva törlésre. Válassza ki, hogyan töröljük "
 "az elemeket:"
 
-#: ../gramps/gui/views/listview.py:548
+#: ../gramps/gui/views/listview.py:545
 msgid "Delete All"
 msgstr "Minden törlése"
 
-#: ../gramps/gui/views/listview.py:549
+#: ../gramps/gui/views/listview.py:546
 msgid "Confirm Each Delete"
 msgstr "Minden törlés jóváhagyása"
 
-#: ../gramps/gui/views/listview.py:560
+#: ../gramps/gui/views/listview.py:561
 msgid ""
 "This item is currently being used. Deleting it will remove it from the "
 "database and from all other items that reference it."
@@ -19308,88 +19537,51 @@ msgstr ""
 "Ez az elem most használatban van. Törlése eltávolítja azt az adatbázisból, "
 "és minden más elemből, ami hivatkozik rá."
 
-#: ../gramps/gui/views/listview.py:564 ../gramps/plugins/view/familyview.py:269
+#: ../gramps/gui/views/listview.py:565 ../gramps/plugins/view/eventview.py:407
+#: ../gramps/plugins/view/familyview.py:394
 msgid "Deleting item will remove it from the database."
 msgstr "Az elem törlésével eltávolítja azt az adatbázisból."
 
 #: ../gramps/gui/views/listview.py:571
-#: ../gramps/plugins/lib/libpersonview.py:317
-#: ../gramps/plugins/view/familyview.py:262
+#: ../gramps/plugins/lib/libpersonview.py:468
+#: ../gramps/plugins/view/familyview.py:387
 #, python-format
 msgid "Delete %s?"
 msgstr "%s törlése?"
 
-#: ../gramps/gui/views/listview.py:572
-msgid "_Delete Item"
-msgstr "Elem _törlése"
-
-#: ../gramps/gui/views/listview.py:614
+#: ../gramps/gui/views/listview.py:620
 msgid "Column clicked, sorting..."
 msgstr "Oszlop volt kattintva, válogatás..."
 
-#: ../gramps/gui/views/listview.py:1043
+#: ../gramps/gui/views/listview.py:1051
 msgid "Export View as Spreadsheet"
 msgstr "Nézet exportálása mint táblázat"
 
-#: ../gramps/gui/views/listview.py:1056
+#: ../gramps/gui/views/listview.py:1064
 msgid "CSV"
 msgstr "CSV"
 
-#: ../gramps/gui/views/listview.py:1057
+#: ../gramps/gui/views/listview.py:1065
 msgid "OpenDocument Spreadsheet"
 msgstr "Open Document táblázat"
 
-#: ../gramps/gui/views/listview.py:1245
+#: ../gramps/gui/views/listview.py:1256
 msgid "Columns"
 msgstr "Oszlopok"
 
-#: ../gramps/gui/views/navigationview.py:253
+#: ../gramps/gui/views/navigationview.py:252
 #, python-format
 msgid "%s has been bookmarked"
 msgstr "%s könyvjelzőzve lett"
 
-#: ../gramps/gui/views/navigationview.py:258
-#: ../gramps/plugins/lib/maps/geography.py:205
-#: ../gramps/plugins/lib/maps/geography.py:221
-#: ../gramps/plugins/view/familyview.py:223
+#: ../gramps/gui/views/navigationview.py:257
+#: ../gramps/plugins/lib/maps/geography.py:208
+#: ../gramps/plugins/lib/maps/geography.py:225
+#: ../gramps/plugins/view/familyview.py:348
 msgid "A bookmark could not be set because no one was selected."
 msgstr "A könyvjelző nem beállítható, mert semmi sincs kiválasztva."
 
-#: ../gramps/gui/views/navigationview.py:274
-msgid "_Add Bookmark"
-msgstr "_Könyvjelző hozzáadása"
-
-#: ../gramps/gui/views/navigationview.py:277
-#, python-format
-msgid "%(title)s..."
-msgstr "%(title)s..."
-
-#: ../gramps/gui/views/navigationview.py:295
-msgid "Go to the next object in the history"
-msgstr "A történet következő objektumára ugrás"
-
-#: ../gramps/gui/views/navigationview.py:302
-msgid "_Back"
-msgstr "_Vissza"
-
-#: ../gramps/gui/views/navigationview.py:303
-msgid "Go to the previous object in the history"
-msgstr "A történet előző objektumára ugrás"
-
-#: ../gramps/gui/views/navigationview.py:307
-#: ../gramps/plugins/view/pedigreeview.py:1578
-msgid "_Home"
-msgstr "_Kezdés"
-
-#: ../gramps/gui/views/navigationview.py:309
-msgid "Go to the default person"
-msgstr "A kiinduló személyhez ugrás"
-
-#: ../gramps/gui/views/navigationview.py:313
-msgid "Set _Home Person"
-msgstr "A kii_nduló személy beállítása"
-
-#: ../gramps/gui/views/navigationview.py:338
+#: ../gramps/gui/views/navigationview.py:323
 msgid "No Home Person"
 msgstr "Nincs kiinduló személy"
 
@@ -19403,7 +19595,7 @@ msgstr ""
 "nézetet, válasszon egy személyt 'Kiinduló személy'-nek, majd hagyja jóvá a "
 "Szerkesztés -> Kiinduló személy beállítása menün keresztül."
 
-#: ../gramps/gui/views/navigationview.py:339
+#: ../gramps/gui/views/navigationview.py:324
 msgid ""
 "You need to set a 'default person' to go to. Select the People View, select "
 "the person you want as 'Home Person', then confirm your choice via the menu "
@@ -19413,89 +19605,89 @@ msgstr ""
 "nézetet, válasszon egy személyt 'Kiinduló személy'-nek, majd hagyja jóvá a "
 "Szerkesztés -> Kiinduló személy beállítása menün keresztül."
 
-#: ../gramps/gui/views/navigationview.py:349
-#: ../gramps/gui/views/navigationview.py:352
+#: ../gramps/gui/views/navigationview.py:334
+#: ../gramps/gui/views/navigationview.py:337
 msgid "Jump to by Gramps ID"
 msgstr "A GRAMPS azonosítóhoz ugrás"
 
-#: ../gramps/gui/views/navigationview.py:376
+#: ../gramps/gui/views/navigationview.py:361
 #, python-format
 msgid "Error: %s is not a valid Gramps ID"
 msgstr "Hiba: %s nem érvényes GRAMPS azonosító"
 
-#: ../gramps/gui/views/pageview.py:438
-msgid "_Sidebar"
-msgstr "_Oldalsáv"
-
-#: ../gramps/gui/views/pageview.py:441
+#: ../gramps/gui/views/pageview.py:103
 msgid "_Bottombar"
 msgstr "_Alsósáv"
 
-#: ../gramps/gui/views/pageview.py:577
+#: ../gramps/gui/views/pageview.py:103
+msgid "_Sidebar"
+msgstr "_Oldalsáv"
+
+#: ../gramps/gui/views/pageview.py:562
 #, python-format
 msgid "Configure %(cat)s - %(view)s"
 msgstr "%(cat)s - %(view)s beállítása"
 
-#: ../gramps/gui/views/pageview.py:594
+#: ../gramps/gui/views/pageview.py:579
 #, python-format
 msgid "%(cat)s - %(view)s"
 msgstr "%(cat)s - %(view)s"
 
-#: ../gramps/gui/views/pageview.py:614
+#: ../gramps/gui/views/pageview.py:599
 #, python-format
 msgid "Configure %s View"
 msgstr "%s nézet beállítása"
 
 #. top widget at the top
-#: ../gramps/gui/views/pageview.py:628
+#: ../gramps/gui/views/pageview.py:613
 #, python-format
 msgid "View %(name)s: %(msg)s"
 msgstr "%(name)s nézete: %(msg)s"
 
-#: ../gramps/gui/views/tags.py:87
-msgid "manual|Organize_Tags_Window"
-msgstr "manual|Címkék_szervezése_ablak"
-
-#: ../gramps/gui/views/tags.py:88
-msgid "manual|New_Tag_dialog"
-msgstr "manual|Új_Címke_párbeszéd_ablak"
-
-#: ../gramps/gui/views/tags.py:227
-msgid "New Tag..."
-msgstr "Új címke..."
-
-#: ../gramps/gui/views/tags.py:229
-msgid "Organize Tags..."
-msgstr "Címkék szervezése..."
-
-#: ../gramps/gui/views/tags.py:232
+#: ../gramps/gui/views/tags.py:71
 msgid "Tag selected rows"
 msgstr "Címke által választott sorok"
 
-#: ../gramps/gui/views/tags.py:272
+#: ../gramps/gui/views/tags.py:93
+msgid "New Tag..."
+msgstr "Új címke..."
+
+#: ../gramps/gui/views/tags.py:93
+msgid "Organize Tags..."
+msgstr "Címkék szervezése..."
+
+#: ../gramps/gui/views/tags.py:112
+msgid "manual|Organize_Tags_Window"
+msgstr "manual|Címkék_szervezése_ablak"
+
+#: ../gramps/gui/views/tags.py:113
+msgid "manual|New_Tag_dialog"
+msgstr "manual|Új_Címke_párbeszéd_ablak"
+
+#: ../gramps/gui/views/tags.py:306
 msgid "Adding Tags"
 msgstr "Címkék hozzáadása"
 
-#: ../gramps/gui/views/tags.py:277
+#: ../gramps/gui/views/tags.py:311
 #, python-format
 msgid "Tag Selection (%s)"
 msgstr "Címke kiválasztás: (%s)"
 
-#: ../gramps/gui/views/tags.py:326 ../gramps/gui/views/tags.py:334
-#: ../gramps/gui/views/tags.py:402
+#: ../gramps/gui/views/tags.py:360 ../gramps/gui/views/tags.py:368
+#: ../gramps/gui/views/tags.py:436
 msgid "Organize Tags"
 msgstr "Címkék szervezése"
 
-#: ../gramps/gui/views/tags.py:353
+#: ../gramps/gui/views/tags.py:387
 msgid "Change Tag Priority"
 msgstr "Címkék sorrendiség változtatása"
 
-#: ../gramps/gui/views/tags.py:495
+#: ../gramps/gui/views/tags.py:529
 #, python-format
 msgid "Remove tag '%s'?"
 msgstr "'%s' címke eltávolítása?"
 
-#: ../gramps/gui/views/tags.py:496
+#: ../gramps/gui/views/tags.py:530
 msgid ""
 "The tag definition will be removed.  The tag will be also removed from all "
 "objects in the database."
@@ -19503,67 +19695,61 @@ msgstr ""
 "A címke meghatározás eltávolításra kerül. A címke az adatbázis minden "
 "objektumából is letávoéításra kerül."
 
-#: ../gramps/gui/views/tags.py:528
+#: ../gramps/gui/views/tags.py:562
 msgid "Removing Tags"
 msgstr "Címkék eltávolítása"
 
-#: ../gramps/gui/views/tags.py:533
+#: ../gramps/gui/views/tags.py:567
 #, python-format
 msgid "Delete Tag (%s)"
 msgstr "(%s) címke eltávolítása"
 
-#: ../gramps/gui/views/tags.py:558
+#: ../gramps/gui/views/tags.py:592
 #, python-format
 msgid "Tag: %s"
 msgstr "Címke: %s"
 
-#: ../gramps/gui/views/tags.py:560
+#: ../gramps/gui/views/tags.py:594
 msgid "New Tag"
 msgstr "Új címke"
 
-#: ../gramps/gui/views/tags.py:607
+#: ../gramps/gui/views/tags.py:641
 msgid "Cannot save tag"
 msgstr "Nem menthető címke"
 
-#: ../gramps/gui/views/tags.py:608
+#: ../gramps/gui/views/tags.py:642
 msgid "The tag name cannot be empty"
 msgstr "A címke neve nem lehet üres"
 
-#: ../gramps/gui/views/tags.py:613
+#: ../gramps/gui/views/tags.py:647
 #, python-format
 msgid "Add Tag (%s)"
 msgstr "(%s) címke hozzáadása"
 
-#: ../gramps/gui/views/tags.py:619
+#: ../gramps/gui/views/tags.py:653
 #, python-format
 msgid "Edit Tag (%s)"
 msgstr "(%s) címke szerkesztése"
 
-#: ../gramps/gui/views/tags.py:634
+#: ../gramps/gui/views/tags.py:668
 msgid "Tag Name:"
 msgstr "Címke név:"
 
-#: ../gramps/gui/views/tags.py:641
+#: ../gramps/gui/views/tags.py:675
 #, python-format
 msgid "%(title)s - Gramps"
 msgstr "%(title)s - GRAMPS"
 
-#: ../gramps/gui/views/tags.py:641
+#: ../gramps/gui/views/tags.py:675
 msgid "Pick a Color"
 msgstr "Színválasztás"
 
-#: ../gramps/gui/views/treemodels/placemodel.py:138
-#: ../gramps/gui/views/treemodels/placemodel.py:146
-#: ../gramps/gui/views/treemodels/placemodel.py:154
-#: ../gramps/gui/views/treemodels/placemodel.py:162
+#: ../gramps/gui/views/treemodels/placemodel.py:145
+#: ../gramps/gui/views/treemodels/placemodel.py:153
+#: ../gramps/gui/views/treemodels/placemodel.py:161
+#: ../gramps/gui/views/treemodels/placemodel.py:169
 msgid "Error in format"
 msgstr "Formátumhiba"
-
-#: ../gramps/gui/views/treemodels/treebasemodel.py:534
-#: ../gramps/gui/views/treemodels/treebasemodel.py:579
-#: ../gramps/gui/glade/baseselector.glade:140
-msgid "Loading items..."
-msgstr "Elemek betöltése..."
 
 #: ../gramps/gui/widgets/buttons.py:159
 msgid "Record is private"
@@ -19581,58 +19767,61 @@ msgstr "A szakasz kibontása"
 msgid "Collapse this section"
 msgstr "A szakasz összecsukása"
 
-#: ../gramps/gui/widgets/fanchart.py:1554 ../gramps/plugins/view/relview.py:807
+#: ../gramps/gui/widgets/fanchart.py:1825 ../gramps/plugins/view/relview.py:966
 msgid "Edit family"
 msgstr "Család szerkesztése"
 
-#: ../gramps/gui/widgets/fanchart.py:1570 ../gramps/plugins/view/relview.py:808
+#: ../gramps/gui/widgets/fanchart.py:1841 ../gramps/plugins/view/relview.py:967
 msgid "Reorder families"
 msgstr "Családok újrarendezése"
 
-#: ../gramps/gui/widgets/fanchart.py:1576
-#: ../gramps/plugins/view/pedigreeview.py:1668
-#: ../gramps/plugins/view/pedigreeview.py:1896
+#: ../gramps/gui/widgets/fanchart.py:1847
+#: ../gramps/plugins/view/pedigreeview.py:1743
+#: ../gramps/plugins/view/pedigreeview.py:1971
 msgid "_Copy"
 msgstr "_Másolás"
 
 #. Go over siblings and build their menu
-#: ../gramps/gui/widgets/fanchart.py:1620
+#: ../gramps/gui/widgets/fanchart.py:1891
 #: ../gramps/plugins/quickview/quickview.gpr.py:319
-#: ../gramps/plugins/view/pedigreeview.py:1712
-#: ../gramps/plugins/view/relview.py:908
+#: ../gramps/plugins/view/pedigreeview.py:1787
+#: ../gramps/plugins/view/relview.py:1068
 msgid "Siblings"
 msgstr "Testvérek"
 
 #. Go over parents and build their menu
-#: ../gramps/gui/widgets/fanchart.py:1758
-#: ../gramps/plugins/view/pedigreeview.py:1839
+#: ../gramps/gui/widgets/fanchart.py:2037
+#: ../gramps/plugins/view/pedigreeview.py:1914
 msgid "Related"
 msgstr "Összefüggő"
 
-#: ../gramps/gui/widgets/fanchart.py:1806
+#: ../gramps/gui/widgets/fanchart.py:2085
 msgid "Add partner to person"
 msgstr "Partner hozzáadása egy személyhez"
 
-#: ../gramps/gui/widgets/fanchart.py:1813
+#: ../gramps/gui/widgets/fanchart.py:2092
 msgid "Add a person"
 msgstr "Személy hozzáadása"
 
-#: ../gramps/gui/widgets/fanchart.py:1888
-#: ../gramps/plugins/view/relview.py:1538
+#: ../gramps/gui/widgets/fanchart.py:2182
+#: ../gramps/plugins/view/relview.py:1709
 msgid "Add Child to Family"
 msgstr "Gyermek hozzáadása a családhoz"
 
-#: ../gramps/gui/widgets/grampletbar.py:206
-#: ../gramps/gui/widgets/grampletpane.py:1189
-#: ../gramps/gui/widgets/grampletpane.py:1186
+#: ../gramps/gui/widgets/grampletbar.py:118
+msgid "Gramplet Bar Menu"
+msgstr "Gramplet sáv menü"
+
+#: ../gramps/gui/widgets/grampletbar.py:207
+#: ../gramps/gui/widgets/grampletpane.py:1190
 msgid "Unnamed Gramplet"
 msgstr "Névtelen gramplet"
 
-#: ../gramps/gui/widgets/grampletbar.py:358
+#: ../gramps/gui/widgets/grampletbar.py:359
 msgid "Gramplet Bar"
 msgstr "Gramplet sáv"
 
-#: ../gramps/gui/widgets/grampletbar.py:360
+#: ../gramps/gui/widgets/grampletbar.py:361
 msgid ""
 "Select the down arrow on the right corner for adding, removing or restoring "
 "gramplets."
@@ -19640,24 +19829,24 @@ msgstr ""
 "Gramplet hozzáadásához, eltávolításához, vagy visszaállításához válassza a "
 "lefelé nyilat a jobb sarokban."
 
-#: ../gramps/gui/widgets/grampletbar.py:486
-#: ../gramps/plugins/view/dashboardview.py:100
+#: ../gramps/gui/widgets/grampletbar.py:487
+#: ../gramps/gui/widgets/grampletpane.py:1442
 msgid "Add a gramplet"
 msgstr "Gramplet hozzáadása"
 
-#: ../gramps/gui/widgets/grampletbar.py:496
+#: ../gramps/gui/widgets/grampletbar.py:497
 msgid "Remove a gramplet"
 msgstr "Gramplet eltávolítása"
 
-#: ../gramps/gui/widgets/grampletbar.py:506
+#: ../gramps/gui/widgets/grampletbar.py:507
 msgid "Restore default gramplets"
 msgstr "Alapértelmezett Gramplet helyreállítása"
 
-#: ../gramps/gui/widgets/grampletbar.py:545
+#: ../gramps/gui/widgets/grampletbar.py:546
 msgid "Restore to defaults?"
 msgstr "Alaphelyzetre visszaállítás?"
 
-#: ../gramps/gui/widgets/grampletbar.py:546
+#: ../gramps/gui/widgets/grampletbar.py:547
 msgid ""
 "The gramplet bar will be restored to contain its default gramplets.  This "
 "action cannot be undone."
@@ -19666,39 +19855,36 @@ msgstr ""
 "műveletet nem lehet visszavonni."
 
 #. default tooltip
-#: ../gramps/gui/widgets/grampletpane.py:811
-#: ../gramps/gui/widgets/grampletpane.py:808
+#: ../gramps/gui/widgets/grampletpane.py:814
 msgid "Drag Properties Button to move and click it for setup"
 msgstr "Mozgatáshoz fogja meg a beállítás gombot, és kattintson a beállításhoz"
 
 #. build the GUI:
-#: ../gramps/gui/widgets/grampletpane.py:1007
-#: ../gramps/gui/widgets/grampletpane.py:1004
+#: ../gramps/gui/widgets/grampletpane.py:1012
 msgid "Right click to add gramplets"
 msgstr "Jobb kattintás grampletek hozzáadásához"
 
-#: ../gramps/gui/widgets/grampletpane.py:1054
-#: ../gramps/gui/widgets/grampletpane.py:1051
+#: ../gramps/gui/widgets/grampletpane.py:1055
 msgid "Untitled Gramplet"
 msgstr "Névtelen Grampletek"
 
-#: ../gramps/gui/widgets/grampletpane.py:1542
-#: ../gramps/gui/widgets/grampletpane.py:1539
+#: ../gramps/gui/widgets/grampletpane.py:1442
+msgid "Restore a gramplet"
+msgstr "Gramplet visszaállítása"
+
+#: ../gramps/gui/widgets/grampletpane.py:1573
 msgid "Number of Columns"
 msgstr "Oszlopok száma"
 
-#: ../gramps/gui/widgets/grampletpane.py:1547
-#: ../gramps/gui/widgets/grampletpane.py:1544
+#: ../gramps/gui/widgets/grampletpane.py:1578
 msgid "Gramplet Layout"
 msgstr "Gramplet elrendezés"
 
-#: ../gramps/gui/widgets/grampletpane.py:1577
-#: ../gramps/gui/widgets/grampletpane.py:1574
+#: ../gramps/gui/widgets/grampletpane.py:1608
 msgid "Use maximum height available"
 msgstr "Használja az elérhető legnagyobb magasságot"
 
-#: ../gramps/gui/widgets/grampletpane.py:1583
-#: ../gramps/gui/widgets/grampletpane.py:1580
+#: ../gramps/gui/widgets/grampletpane.py:1614
 msgid "Height if not maximized"
 msgstr "Magasság, ha nem maximalizált"
 
@@ -19728,7 +19914,7 @@ msgid ""
 msgstr ""
 "A képen dupla kattintással nézheti meg azt az alapértelmezett nézőkében."
 
-#: ../gramps/gui/widgets/photo.py:87
+#: ../gramps/gui/widgets/photo.py:88
 msgid "Make Active Media"
 msgstr "Legyen aktív a média"
 
@@ -19745,17 +19931,40 @@ msgstr ""
 msgid "Progress Information"
 msgstr "Haladás információ"
 
-#: ../gramps/gui/widgets/reorderfam.py:79
+#: ../gramps/gui/widgets/reorderfam.py:63
+msgid "manual|Reorder_Relationships_dialog"
+msgstr "manual|Rokonság_Újrarendezés_párbeszéd ablak"
+
+#: ../gramps/gui/widgets/reorderfam.py:91
 msgid "Reorder Relationships"
 msgstr "Rokonságok átrendezése"
 
-#: ../gramps/gui/widgets/reorderfam.py:168
+#: ../gramps/gui/widgets/reorderfam.py:181
 #, python-format
 msgid "Reorder Relationships: %s"
 msgstr "Rokonságok átrendezése: %s"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:318
-#: ../gramps/gui/widgets/styledtexteditor.py:317
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Background Color"
+msgstr "Háttérszín"
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Clear Markup"
+msgstr "Jelölés tisztítás"
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Font Color"
+msgstr "Betű szín"
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Redo"
+msgstr "Ismétlés"
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Undo"
+msgstr "Visszavonás"
+
+#: ../gramps/gui/widgets/styledtexteditor.py:401
 msgid ""
 "\n"
 "Command-Click to follow link"
@@ -19763,8 +19972,7 @@ msgstr ""
 "\n"
 "Parancsgomb-Kattintás a hivatkozás követésére"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:319
-#: ../gramps/gui/widgets/styledtexteditor.py:318
+#: ../gramps/gui/widgets/styledtexteditor.py:402
 msgid ""
 "\n"
 "Ctrl-Click to follow link"
@@ -19773,90 +19981,53 @@ msgstr ""
 "Ctrl-Kattintás a hivatkozás követésére"
 
 #. spell checker submenu
-#: ../gramps/gui/widgets/styledtexteditor.py:367
-#: ../gramps/gui/widgets/styledtexteditor.py:366
+#: ../gramps/gui/widgets/styledtexteditor.py:450
 msgid "Spellcheck"
 msgstr "Helyesírás-ellenőrző"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:372
-#: ../gramps/gui/widgets/styledtexteditor.py:371
+#: ../gramps/gui/widgets/styledtexteditor.py:455
 msgid "Search selection on web"
 msgstr "A kiválasztás keresése a weben"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:383
-#: ../gramps/gui/widgets/styledtexteditor.py:382
+#: ../gramps/gui/widgets/styledtexteditor.py:466
 msgid "_Send Mail To..."
 msgstr "_Levél küldése..."
 
-#: ../gramps/gui/widgets/styledtexteditor.py:385
-#: ../gramps/gui/widgets/styledtexteditor.py:384
+#: ../gramps/gui/widgets/styledtexteditor.py:468
 msgid "Copy _E-mail Address"
 msgstr "_E-mail cím másolása"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:388
-#: ../gramps/gui/widgets/styledtexteditor.py:387
+#: ../gramps/gui/widgets/styledtexteditor.py:471
 msgid "_Open Link"
 msgstr "_Hivatkozás megnyitása"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:390
-#: ../gramps/gui/widgets/styledtexteditor.py:389
+#: ../gramps/gui/widgets/styledtexteditor.py:473
 msgid "Copy _Link Address"
 msgstr "Hivatkozás _cím másolása"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:394
-#: ../gramps/gui/widgets/styledtexteditor.py:393
+#: ../gramps/gui/widgets/styledtexteditor.py:477
 msgid "_Edit Link"
 msgstr "Hivatkozás s_zerkesztése"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:466
-#: ../gramps/gui/widgets/styledtexteditor.py:465
-msgid "Font Color"
-msgstr "Betű szín"
-
-#: ../gramps/gui/widgets/styledtexteditor.py:468
-#: ../gramps/gui/widgets/styledtexteditor.py:467
-msgid "Background Color"
-msgstr "Háttérszín"
-
-#: ../gramps/gui/widgets/styledtexteditor.py:472
-#: ../gramps/gui/widgets/styledtexteditor.py:473
-#: ../gramps/gui/widgets/styledtexteditor.py:471
-msgid "Clear Markup"
-msgstr "Jelölés tisztítás"
-
-#: ../gramps/gui/widgets/styledtexteditor.py:513
-#: ../gramps/gui/widgets/styledtexteditor.py:514
-#: ../gramps/gui/widgets/styledtexteditor.py:512
-msgid "Undo"
-msgstr "Visszavonás"
-
-#: ../gramps/gui/widgets/styledtexteditor.py:517
-#: ../gramps/gui/widgets/styledtexteditor.py:518
-#: ../gramps/gui/widgets/styledtexteditor.py:516
-msgid "Redo"
-msgstr "Ismétlés"
-
-#: ../gramps/gui/widgets/styledtexteditor.py:645
-#: ../gramps/gui/widgets/styledtexteditor.py:644
+#: ../gramps/gui/widgets/styledtexteditor.py:697
 msgid "Select font color"
 msgstr "Betűszín kiválasztása"
 
-#: ../gramps/gui/widgets/styledtexteditor.py:649
-#: ../gramps/gui/widgets/styledtexteditor.py:648
+#: ../gramps/gui/widgets/styledtexteditor.py:701
 msgid "Select background color"
 msgstr "Háttérszín kiválasztása"
 
-#: ../gramps/gui/widgets/validatedmaskedentry.py:1154
+#: ../gramps/gui/widgets/validatedmaskedentry.py:1140
 #, python-format
 msgid "'%s' is not a valid value for this field"
 msgstr "'%s' érvénytelen érték ehhez a mezőhöz"
 
-#: ../gramps/gui/widgets/validatedmaskedentry.py:1197
+#: ../gramps/gui/widgets/validatedmaskedentry.py:1179
 msgid "This field is mandatory"
 msgstr "Ez a mező kötelező"
 
 #. used on AgeOnDateGramplet
-#: ../gramps/gui/widgets/validatedmaskedentry.py:1246
+#: ../gramps/gui/widgets/validatedmaskedentry.py:1228
 #, python-format
 msgid "'%s' is not a valid date value"
 msgstr "'%s' érvénytelen adatérték"
@@ -19950,7 +20121,6 @@ msgstr ""
 msgid "Upgrade Statistics"
 msgstr "Statisztikák frissítése"
 
-#: ../gramps/plugins/db/bsddb/write.py:1153
 #: ../gramps/plugins/db/bsddb/write.py:1154
 #, python-format
 msgid ""
@@ -19964,12 +20134,10 @@ msgstr ""
 
 #. Make a tuple of the functions and classes that we need for
 #. each of the primary object tables.
-#: ../gramps/plugins/db/bsddb/write.py:1220
 #: ../gramps/plugins/db/bsddb/write.py:1221
 msgid "Rebuild reference map"
 msgstr "Referencia-térkép újraépítése"
 
-#: ../gramps/plugins/db/bsddb/write.py:1984
 #: ../gramps/plugins/db/bsddb/write.py:1986
 #, python-format
 msgid ""
@@ -19979,9 +20147,8 @@ msgstr ""
 "Egy második tranzakció is indult, míg egy még folyamatban van; a(z) \"%s\" "
 "aktív az adatbázisban."
 
-#: ../gramps/plugins/db/bsddb/write.py:2305
-#: ../gramps/plugins/db/dbapi/sqlite.py:61
 #: ../gramps/plugins/db/bsddb/write.py:2307
+#: ../gramps/plugins/db/dbapi/sqlite.py:61
 msgid "Database version"
 msgstr "Adatbázis verzió"
 
@@ -20131,14 +20298,14 @@ msgid "of %d"
 msgstr "%d-hez"
 
 #: ../gramps/plugins/docgen/htmldoc.py:273
-#: ../gramps/plugins/webreport/narrativeweb.py:1485
-#: ../gramps/plugins/webreport/webcal.py:269
+#: ../gramps/plugins/webreport/narrativeweb.py:1517
+#: ../gramps/plugins/webreport/webcal.py:270
 msgid "Possible destination error"
 msgstr "Lehetséges irány hiba"
 
 #: ../gramps/plugins/docgen/htmldoc.py:274
-#: ../gramps/plugins/webreport/narrativeweb.py:1486
-#: ../gramps/plugins/webreport/webcal.py:270
+#: ../gramps/plugins/webreport/narrativeweb.py:1518
+#: ../gramps/plugins/webreport/webcal.py:271
 msgid ""
 "You appear to have set your target directory to a directory used for data "
 "storage. This could create problems with file management. It is recommended "
@@ -20149,7 +20316,7 @@ msgstr ""
 "fájlkezelés során problémákat okozhat. Ajánlott a létrehozott web-oldal más "
 "könyvtárban tárolása."
 
-#: ../gramps/plugins/docgen/htmldoc.py:553
+#: ../gramps/plugins/docgen/htmldoc.py:567
 #, python-format
 msgid "Could not create jpeg version of image %(name)s"
 msgstr "Nem hozható létre a %(name)s kép jpeg változata"
@@ -20183,7 +20350,7 @@ msgid "transparent background"
 msgstr "átlátszó háttér"
 
 #: ../gramps/plugins/docgen/svgdrawdoc.py:351
-#: ../gramps/plugins/drawreport/fanchart.py:705
+#: ../gramps/plugins/drawreport/fanchart.py:707
 msgid "white"
 msgstr "fehér"
 
@@ -20232,15 +20399,15 @@ msgstr "%s származás grafikonja"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:362
 #: ../gramps/plugins/drawreport/calendarreport.py:114
-#: ../gramps/plugins/drawreport/descendtree.py:690
+#: ../gramps/plugins/drawreport/descendtree.py:689
 #: ../gramps/plugins/drawreport/fanchart.py:194
-#: ../gramps/plugins/graph/gvhourglass.py:106
-#: ../gramps/plugins/graph/gvrelgraph.py:181
+#: ../gramps/plugins/graph/gvhourglass.py:109
+#: ../gramps/plugins/graph/gvrelgraph.py:184
 #: ../gramps/plugins/textreport/ancestorreport.py:117
-#: ../gramps/plugins/textreport/birthdayreport.py:111
+#: ../gramps/plugins/textreport/birthdayreport.py:115
 #: ../gramps/plugins/textreport/descendreport.py:453
-#: ../gramps/plugins/textreport/detancestralreport.py:166
-#: ../gramps/plugins/textreport/detdescendantreport.py:183
+#: ../gramps/plugins/textreport/detancestralreport.py:167
+#: ../gramps/plugins/textreport/detdescendantreport.py:184
 #: ../gramps/plugins/textreport/endoflinereport.py:91
 #: ../gramps/plugins/textreport/kinshipreport.py:106
 #: ../gramps/plugins/textreport/numberofancestorsreport.py:84
@@ -20263,14 +20430,14 @@ msgid "Printing the Tree..."
 msgstr "Fa nyomtatása..."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:793
-#: ../gramps/plugins/drawreport/calendarreport.py:476
-#: ../gramps/plugins/drawreport/fanchart.py:687
-#: ../gramps/plugins/graph/gvhourglass.py:317
-#: ../gramps/plugins/graph/gvrelgraph.py:773
+#: ../gramps/plugins/drawreport/calendarreport.py:472
+#: ../gramps/plugins/drawreport/fanchart.py:689
+#: ../gramps/plugins/graph/gvhourglass.py:366
+#: ../gramps/plugins/graph/gvrelgraph.py:807
 #: ../gramps/plugins/textreport/ancestorreport.py:290
 #: ../gramps/plugins/textreport/descendreport.py:522
-#: ../gramps/plugins/textreport/detancestralreport.py:823
-#: ../gramps/plugins/textreport/detdescendantreport.py:1000
+#: ../gramps/plugins/textreport/detancestralreport.py:831
+#: ../gramps/plugins/textreport/detdescendantreport.py:1006
 #: ../gramps/plugins/textreport/endoflinereport.py:272
 #: ../gramps/plugins/textreport/kinshipreport.py:358
 #: ../gramps/plugins/textreport/numberofancestorsreport.py:204
@@ -20291,17 +20458,17 @@ msgid ""
 msgstr "Csak a központi személyt, vagy annak minden testvérét is mutassa-e"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:804
-#: ../gramps/plugins/drawreport/descendtree.py:1533
-#: ../gramps/plugins/drawreport/fanchart.py:691
+#: ../gramps/plugins/drawreport/descendtree.py:1538
+#: ../gramps/plugins/drawreport/fanchart.py:693
 #: ../gramps/plugins/textreport/ancestorreport.py:294
 #: ../gramps/plugins/textreport/descendreport.py:537
-#: ../gramps/plugins/textreport/detancestralreport.py:832
-#: ../gramps/plugins/textreport/detdescendantreport.py:1023
+#: ../gramps/plugins/textreport/detancestralreport.py:840
+#: ../gramps/plugins/textreport/detdescendantreport.py:1029
 msgid "Generations"
 msgstr "Generációk"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:805
-#: ../gramps/plugins/drawreport/descendtree.py:1534
+#: ../gramps/plugins/drawreport/descendtree.py:1539
 msgid "The number of generations to include in the tree"
 msgstr "Generációk száma a fában"
 
@@ -20318,7 +20485,7 @@ msgid "The number of generations of empty boxes that will be displayed"
 msgstr "Az ábrázolandó üres dobozok generáció száma"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:818
-#: ../gramps/plugins/drawreport/descendtree.py:1551
+#: ../gramps/plugins/drawreport/descendtree.py:1556
 msgid "Compress tree"
 msgstr "Fa tömörítése"
 
@@ -20329,13 +20496,13 @@ msgid ""
 msgstr "Ismeretlen emberek mellől bármennyi plusz szóközt el kell-e távolítani"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:837
-#: ../gramps/plugins/drawreport/descendtree.py:1570
+#: ../gramps/plugins/drawreport/descendtree.py:1575
 msgid "Report Title"
 msgstr "Összegzés cím"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:838
-#: ../gramps/plugins/drawreport/descendtree.py:1571
-#: ../gramps/plugins/drawreport/descendtree.py:1744
+#: ../gramps/plugins/drawreport/descendtree.py:1576
+#: ../gramps/plugins/drawreport/descendtree.py:1749
 msgid "Do not include a title"
 msgstr "Ne legyen cím"
 
@@ -20344,22 +20511,22 @@ msgid "Include Report Title"
 msgstr "Összegzés cím is"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:840
-#: ../gramps/plugins/drawreport/descendtree.py:1579
+#: ../gramps/plugins/drawreport/descendtree.py:1584
 msgid "Choose a title for the report"
 msgstr "Válasszon egy összegzés címet"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:843
-#: ../gramps/plugins/drawreport/descendtree.py:1583
+#: ../gramps/plugins/drawreport/descendtree.py:1588
 msgid "Include a border"
 msgstr "Szegély is"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:844
-#: ../gramps/plugins/drawreport/descendtree.py:1584
+#: ../gramps/plugins/drawreport/descendtree.py:1589
 msgid "Whether to make a border around the report."
 msgstr "Legyen-e kerete az összegzésnek."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:847
-#: ../gramps/plugins/drawreport/descendtree.py:1587
+#: ../gramps/plugins/drawreport/descendtree.py:1592
 msgid "Include Page Numbers"
 msgstr "Oldalszámok is"
 
@@ -20368,32 +20535,32 @@ msgid "Whether to print page numbers on each page."
 msgstr "Legyenek-e minden lapon oldalszámok nyomtatva."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:851
-#: ../gramps/plugins/drawreport/descendtree.py:1591
+#: ../gramps/plugins/drawreport/descendtree.py:1596
 msgid "Scale tree to fit"
 msgstr "Fa teljes kitöltésre"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:852
-#: ../gramps/plugins/drawreport/descendtree.py:1592
+#: ../gramps/plugins/drawreport/descendtree.py:1597
 msgid "Do not scale tree"
 msgstr "Ne méretezze a fát"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:853
-#: ../gramps/plugins/drawreport/descendtree.py:1593
+#: ../gramps/plugins/drawreport/descendtree.py:1598
 msgid "Scale tree to fit page width only"
 msgstr "Fa csak lapszélességre méretezése"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:854
-#: ../gramps/plugins/drawreport/descendtree.py:1594
+#: ../gramps/plugins/drawreport/descendtree.py:1599
 msgid "Scale tree to fit the size of the page"
 msgstr "Fa méretezése a teljes lapra"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:856
-#: ../gramps/plugins/drawreport/descendtree.py:1596
+#: ../gramps/plugins/drawreport/descendtree.py:1601
 msgid "Whether to scale the tree to fit a specific paper size"
 msgstr "Legyen-e a fa egy meghatározott papírméretre méretezve"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:863
-#: ../gramps/plugins/drawreport/descendtree.py:1603
+#: ../gramps/plugins/drawreport/descendtree.py:1608
 msgid ""
 "Resize Page to Fit Tree size\n"
 "\n"
@@ -20404,7 +20571,7 @@ msgstr ""
 "Figyelem: a 'Papír tulajdonságai' fülön megadott értékeket felülírja"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:869
-#: ../gramps/plugins/drawreport/descendtree.py:1609
+#: ../gramps/plugins/drawreport/descendtree.py:1614
 msgid ""
 "Whether to resize the page to fit the size \n"
 "of the tree.  Note:  the page will have a \n"
@@ -20437,12 +20604,12 @@ msgstr ""
 "  bármilyen magassági- és oldalköz el lesz távolítva"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:889
-#: ../gramps/plugins/drawreport/descendtree.py:1629
+#: ../gramps/plugins/drawreport/descendtree.py:1634
 msgid "Include Blank Pages"
 msgstr "Üres oldalak is"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:890
-#: ../gramps/plugins/drawreport/descendtree.py:1630
+#: ../gramps/plugins/drawreport/descendtree.py:1635
 msgid "Whether to include pages that are blank."
 msgstr "Legyenek-e benne üres lapok is."
 
@@ -20455,26 +20622,25 @@ msgstr "Legyenek-e benne üres lapok is."
 #. #########################
 #. ###############################
 #: ../gramps/plugins/drawreport/ancestortree.py:896
-#: ../gramps/plugins/drawreport/calendarreport.py:494
-#: ../gramps/plugins/drawreport/descendtree.py:1634
-#: ../gramps/plugins/drawreport/fanchart.py:728
-#: ../gramps/plugins/drawreport/statisticschart.py:1045
-#: ../gramps/plugins/drawreport/timeline.py:434
-#: ../gramps/plugins/graph/gvfamilylines.py:162
-#: ../gramps/plugins/graph/gvhourglass.py:352
-#: ../gramps/plugins/graph/gvrelgraph.py:801
+#: ../gramps/plugins/drawreport/calendarreport.py:490
+#: ../gramps/plugins/drawreport/descendtree.py:1639
+#: ../gramps/plugins/drawreport/fanchart.py:730
+#: ../gramps/plugins/drawreport/statisticschart.py:1074
+#: ../gramps/plugins/drawreport/timeline.py:435
+#: ../gramps/plugins/graph/gvfamilylines.py:169
+#: ../gramps/plugins/graph/gvhourglass.py:402
+#: ../gramps/plugins/graph/gvrelgraph.py:841
 #: ../gramps/plugins/textreport/ancestorreport.py:310
-#: ../gramps/plugins/textreport/birthdayreport.py:438
+#: ../gramps/plugins/textreport/birthdayreport.py:500
 #: ../gramps/plugins/textreport/descendreport.py:557
-#: ../gramps/plugins/textreport/detancestralreport.py:848
-#: ../gramps/plugins/textreport/detdescendantreport.py:1039
+#: ../gramps/plugins/textreport/detancestralreport.py:856
+#: ../gramps/plugins/textreport/detdescendantreport.py:1045
 #: ../gramps/plugins/textreport/familygroup.py:732
-#: ../gramps/plugins/textreport/indivcomplete.py:1082
+#: ../gramps/plugins/textreport/indivcomplete.py:1083
 #: ../gramps/plugins/textreport/kinshipreport.py:382
-#: ../gramps/plugins/textreport/placereport.py:461
+#: ../gramps/plugins/textreport/placereport.py:462
 #: ../gramps/plugins/textreport/recordsreport.py:243
-#: ../gramps/plugins/webreport/webcal.py:1664
-#: ../gramps/plugins/drawreport/statisticschart.py:1056
+#: ../gramps/plugins/webreport/webcal.py:1709
 msgid "Report Options (2)"
 msgstr "Összesítő lehetőségek (2)"
 
@@ -20529,17 +20695,17 @@ msgid "The display format for the center person"
 msgstr "A központi személy ábrázolásának formátuma"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:941
-#: ../gramps/plugins/drawreport/descendtree.py:1670
+#: ../gramps/plugins/drawreport/descendtree.py:1675
 msgid "Include Marriage box"
 msgstr "Házasság dobozzal bezárólag"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:943
-#: ../gramps/plugins/drawreport/descendtree.py:1672
+#: ../gramps/plugins/drawreport/descendtree.py:1677
 msgid "Whether to include a separate marital box in the report"
 msgstr "Legyen-e különálló házasság doboz az összesítőben"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:947
-#: ../gramps/plugins/drawreport/descendtree.py:1676
+#: ../gramps/plugins/drawreport/descendtree.py:1681
 msgid ""
 "Marriage\n"
 "Display Format"
@@ -20548,19 +20714,19 @@ msgstr ""
 "Ábrázolásformátum"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:949
-#: ../gramps/plugins/drawreport/descendtree.py:1678
+#: ../gramps/plugins/drawreport/descendtree.py:1683
 msgid "Display format for the marital box."
 msgstr "A házasság doboz ábrázolásformátuma."
 
 #. #################
 #: ../gramps/plugins/drawreport/ancestortree.py:954
-#: ../gramps/plugins/drawreport/descendtree.py:1683
+#: ../gramps/plugins/drawreport/descendtree.py:1688
 #: ../gramps/plugins/lib/libmetadata.py:104
 msgid "Advanced"
 msgstr "Haladó"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:957
-#: ../gramps/plugins/drawreport/descendtree.py:1686
+#: ../gramps/plugins/drawreport/descendtree.py:1691
 msgid ""
 "Replace Display Format:\n"
 "'Replace this'/' with this'"
@@ -20569,7 +20735,7 @@ msgstr ""
 "'Ezt helyettesítse'/'ezzel'"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:959
-#: ../gramps/plugins/drawreport/descendtree.py:1688
+#: ../gramps/plugins/drawreport/descendtree.py:1693
 msgid ""
 "i.e.\n"
 "United States of America/U.S.A"
@@ -20584,17 +20750,17 @@ msgstr ""
 #. _("Whether to include thumbnails of people."))
 #. menu.add_option(category_name, "includeImages", self.__include_images)
 #: ../gramps/plugins/drawreport/ancestortree.py:969
-#: ../gramps/plugins/drawreport/descendtree.py:1691
+#: ../gramps/plugins/drawreport/descendtree.py:1696
 msgid "Include a note"
 msgstr "Jegyzet is"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:970
-#: ../gramps/plugins/drawreport/descendtree.py:1692
+#: ../gramps/plugins/drawreport/descendtree.py:1697
 msgid "Whether to include a note on the report."
 msgstr "Legyen-e az összegzésben jegyzet is."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:975
-#: ../gramps/plugins/drawreport/descendtree.py:1697
+#: ../gramps/plugins/drawreport/descendtree.py:1702
 msgid ""
 "Add a note\n"
 "\n"
@@ -20605,12 +20771,12 @@ msgstr ""
 "$T beszúrja a mai dátumot"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:980
-#: ../gramps/plugins/drawreport/descendtree.py:1702
+#: ../gramps/plugins/drawreport/descendtree.py:1707
 msgid "Note Location"
 msgstr "A jegyzet helye"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:983
-#: ../gramps/plugins/drawreport/descendtree.py:1705
+#: ../gramps/plugins/drawreport/descendtree.py:1710
 msgid "Where to place the note."
 msgstr "Hol legyen elhelyezve a jegyzet."
 
@@ -20623,13 +20789,13 @@ msgid "Make the inter-box spacing bigger or smaller"
 msgstr "A dobozbeli térköz nagyobbá, vagy kisebbé tétele"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:993
-#: ../gramps/plugins/drawreport/descendtree.py:1714
+#: ../gramps/plugins/drawreport/descendtree.py:1719
 msgid "box shadow scale factor"
 msgstr "doboz árnyék skála együttható"
 
 #. down to 0
 #: ../gramps/plugins/drawreport/ancestortree.py:995
-#: ../gramps/plugins/drawreport/descendtree.py:1716
+#: ../gramps/plugins/drawreport/descendtree.py:1721
 msgid "Make the box shadow bigger or smaller"
 msgstr "A doboz árnyék nagyobbá, vagy kisebbé tétele"
 
@@ -20646,20 +20812,20 @@ msgid " Generations of empty boxes for unknown ancestors"
 msgstr " Ismeretlen ősök üres dobozainak generációi"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:1049
-#: ../gramps/plugins/drawreport/descendtree.py:1776
-#: ../gramps/plugins/drawreport/fanchart.py:769
-#: ../gramps/plugins/drawreport/timeline.py:479
+#: ../gramps/plugins/drawreport/descendtree.py:1781
+#: ../gramps/plugins/drawreport/fanchart.py:771
+#: ../gramps/plugins/drawreport/timeline.py:480
 #: ../gramps/plugins/textreport/alphabeticalindex.py:120
 #: ../gramps/plugins/textreport/ancestorreport.py:386
-#: ../gramps/plugins/textreport/detancestralreport.py:1020
-#: ../gramps/plugins/textreport/detdescendantreport.py:1225
+#: ../gramps/plugins/textreport/detancestralreport.py:1028
+#: ../gramps/plugins/textreport/detdescendantreport.py:1231
 #: ../gramps/plugins/textreport/endoflinereport.py:317
 #: ../gramps/plugins/textreport/familygroup.py:878
-#: ../gramps/plugins/textreport/indivcomplete.py:1236
+#: ../gramps/plugins/textreport/indivcomplete.py:1237
 #: ../gramps/plugins/textreport/kinshipreport.py:424
 #: ../gramps/plugins/textreport/notelinkreport.py:206
 #: ../gramps/plugins/textreport/numberofancestorsreport.py:233
-#: ../gramps/plugins/textreport/placereport.py:570
+#: ../gramps/plugins/textreport/placereport.py:571
 #: ../gramps/plugins/textreport/recordsreport.py:335
 #: ../gramps/plugins/textreport/summary.py:329
 #: ../gramps/plugins/textreport/tagreport.py:975
@@ -20667,35 +20833,34 @@ msgid "The basic style used for the text display."
 msgstr "A mutatott szöveg alap stílusa."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:1059
-#: ../gramps/plugins/drawreport/descendtree.py:1796
+#: ../gramps/plugins/drawreport/descendtree.py:1801
 #: ../gramps/plugins/textreport/familygroup.py:890
 #: ../gramps/plugins/textreport/tagreport.py:993
 msgid "The basic style used for the note display."
 msgstr "Jegyzet ábrázolásának alap stílusa."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:1068
-#: ../gramps/plugins/drawreport/descendtree.py:1767
-#: ../gramps/plugins/drawreport/fanchart.py:759
-#: ../gramps/plugins/drawreport/statisticschart.py:1130
-#: ../gramps/plugins/drawreport/timeline.py:497
+#: ../gramps/plugins/drawreport/descendtree.py:1772
+#: ../gramps/plugins/drawreport/fanchart.py:761
+#: ../gramps/plugins/drawreport/statisticschart.py:1159
+#: ../gramps/plugins/drawreport/timeline.py:498
 #: ../gramps/plugins/textreport/alphabeticalindex.py:103
 #: ../gramps/plugins/textreport/ancestorreport.py:363
 #: ../gramps/plugins/textreport/descendreport.py:584
-#: ../gramps/plugins/textreport/detancestralreport.py:972
-#: ../gramps/plugins/textreport/detdescendantreport.py:1177
+#: ../gramps/plugins/textreport/detancestralreport.py:980
+#: ../gramps/plugins/textreport/detdescendantreport.py:1183
 #: ../gramps/plugins/textreport/endoflinereport.py:299
 #: ../gramps/plugins/textreport/familygroup.py:869
-#: ../gramps/plugins/textreport/indivcomplete.py:1204
+#: ../gramps/plugins/textreport/indivcomplete.py:1205
 #: ../gramps/plugins/textreport/kinshipreport.py:406
 #: ../gramps/plugins/textreport/notelinkreport.py:186
 #: ../gramps/plugins/textreport/numberofancestorsreport.py:226
-#: ../gramps/plugins/textreport/placereport.py:503
+#: ../gramps/plugins/textreport/placereport.py:504
 #: ../gramps/plugins/textreport/recordsreport.py:308
 #: ../gramps/plugins/textreport/simplebooktitle.py:171
 #: ../gramps/plugins/textreport/summary.py:310
 #: ../gramps/plugins/textreport/tableofcontents.py:102
 #: ../gramps/plugins/textreport/tagreport.py:944
-#: ../gramps/plugins/drawreport/statisticschart.py:1141
 msgid "The style used for the title."
 msgstr "A címhez használt stílus."
 
@@ -20712,36 +20877,35 @@ msgstr "Készült a GRAMPS segítségével"
 #. to see "nearby" comments
 #: ../gramps/plugins/drawreport/calendarreport.py:199
 #: ../gramps/plugins/drawreport/calendarreport.py:225
-#: ../gramps/plugins/drawreport/calendarreport.py:319
+#: ../gramps/plugins/drawreport/calendarreport.py:315
 msgid "Calendar Report"
 msgstr "Naptár összesítő"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:200
-#: ../gramps/plugins/textreport/birthdayreport.py:218
+#: ../gramps/plugins/textreport/birthdayreport.py:225
 msgid "Formatting months..."
 msgstr "Hónapok formázása..."
 
-#: ../gramps/plugins/drawreport/calendarreport.py:320
-#: ../gramps/plugins/textreport/birthdayreport.py:263
-#: ../gramps/plugins/webreport/webcal.py:1275
+#: ../gramps/plugins/drawreport/calendarreport.py:316
+#: ../gramps/plugins/textreport/birthdayreport.py:270
+#: ../gramps/plugins/webreport/webcal.py:1285
 msgid "Reading database..."
 msgstr "Adatbázis olvasás..."
 
-#: ../gramps/plugins/drawreport/calendarreport.py:365
+#: ../gramps/plugins/drawreport/calendarreport.py:361
 #, python-format
 msgid "%(person)s, birth"
 msgstr "%(person)s, születés"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/drawreport/calendarreport.py:369
+#: ../gramps/plugins/drawreport/calendarreport.py:365
 #, python-brace-format
 msgid "{person}, {age}"
 msgid_plural "{person}, {age}"
 msgstr[0] "{person}, {age}"
 msgstr[1] "{person}, {age}"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:425
-#: ../gramps/plugins/textreport/birthdayreport.py:373
+#: ../gramps/plugins/drawreport/calendarreport.py:421
 #, python-format
 msgid ""
 "%(spouse)s and\n"
@@ -20751,8 +20915,7 @@ msgstr ""
 " %(person)s, esküvője"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/drawreport/calendarreport.py:431
-#: ../gramps/plugins/textreport/birthdayreport.py:378
+#: ../gramps/plugins/drawreport/calendarreport.py:427
 #, python-brace-format
 msgid ""
 "{spouse} and\n"
@@ -20767,185 +20930,185 @@ msgstr[1] ""
 "{spouse} és\n"
 " {person}, {nyears}"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:472
-#: ../gramps/plugins/webreport/webcal.py:1628
+#: ../gramps/plugins/drawreport/calendarreport.py:468
+#: ../gramps/plugins/webreport/webcal.py:1673
 msgid "Select filter to restrict people that appear on calendar"
 msgstr "Válasszon szűrőt emberek megjelenésének kizárásához a naptárban"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:477
-#: ../gramps/plugins/drawreport/fanchart.py:688
-#: ../gramps/plugins/graph/gvrelgraph.py:774
+#: ../gramps/plugins/drawreport/calendarreport.py:473
+#: ../gramps/plugins/drawreport/fanchart.py:690
+#: ../gramps/plugins/graph/gvrelgraph.py:808
 #: ../gramps/plugins/textreport/ancestorreport.py:291
 #: ../gramps/plugins/textreport/descendreport.py:523
-#: ../gramps/plugins/textreport/detancestralreport.py:824
-#: ../gramps/plugins/textreport/detdescendantreport.py:1001
+#: ../gramps/plugins/textreport/detancestralreport.py:832
+#: ../gramps/plugins/textreport/detdescendantreport.py:1007
 #: ../gramps/plugins/textreport/endoflinereport.py:273
 #: ../gramps/plugins/textreport/kinshipreport.py:359
 #: ../gramps/plugins/textreport/numberofancestorsreport.py:205
 msgid "The center person for the report"
 msgstr "Az összesítő központi személye"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:481
-#: ../gramps/plugins/textreport/birthdayreport.py:426
+#: ../gramps/plugins/drawreport/calendarreport.py:477
+#: ../gramps/plugins/textreport/birthdayreport.py:488
 msgid "Text Area 1"
 msgstr "1. szöveg terület"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:482
+#: ../gramps/plugins/drawreport/calendarreport.py:478
 msgid "First line of text at bottom of calendar"
 msgstr "A naptár alján levő szöveg első sora"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:485
-#: ../gramps/plugins/textreport/birthdayreport.py:430
+#: ../gramps/plugins/drawreport/calendarreport.py:481
+#: ../gramps/plugins/textreport/birthdayreport.py:492
 msgid "Text Area 2"
 msgstr "2. szöveg terület"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:486
+#: ../gramps/plugins/drawreport/calendarreport.py:482
 msgid "Second line of text at bottom of calendar"
 msgstr "A naptár alján levő szöveg második sora"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:489
-#: ../gramps/plugins/textreport/birthdayreport.py:434
+#: ../gramps/plugins/drawreport/calendarreport.py:485
+#: ../gramps/plugins/textreport/birthdayreport.py:496
 msgid "Text Area 3"
 msgstr "3. szöveg terület"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:490
+#: ../gramps/plugins/drawreport/calendarreport.py:486
 msgid "Third line of text at bottom of calendar"
 msgstr "A naptár alján levő szöveg harmadik sora"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:505
-#: ../gramps/plugins/textreport/birthdayreport.py:445
-#: ../gramps/plugins/webreport/webcal.py:1684
+#: ../gramps/plugins/drawreport/calendarreport.py:501
+#: ../gramps/plugins/textreport/birthdayreport.py:507
+#: ../gramps/plugins/webreport/webcal.py:1729
 msgid "Include only living people"
 msgstr "Csak élő emberek"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:506
-#: ../gramps/plugins/webreport/webcal.py:1685
+#: ../gramps/plugins/drawreport/calendarreport.py:502
+#: ../gramps/plugins/webreport/webcal.py:1730
 msgid "Include only living people in the calendar"
 msgstr "Csak élő emberek a naptárban"
 
 #. #########################
 #. Content options
 #. Content
-#: ../gramps/plugins/drawreport/calendarreport.py:512
-#: ../gramps/plugins/textreport/birthdayreport.py:453
-#: ../gramps/plugins/textreport/detancestralreport.py:865
-#: ../gramps/plugins/textreport/detdescendantreport.py:1056
-#: ../gramps/plugins/view/relview.py:1703
+#: ../gramps/plugins/drawreport/calendarreport.py:508
+#: ../gramps/plugins/textreport/birthdayreport.py:523
+#: ../gramps/plugins/textreport/detancestralreport.py:873
+#: ../gramps/plugins/textreport/detdescendantreport.py:1062
+#: ../gramps/plugins/view/relview.py:1874
 msgid "Content"
 msgstr "Tartalom"
 
 #. #########################
-#: ../gramps/plugins/drawreport/calendarreport.py:516
-#: ../gramps/plugins/drawreport/calendarreport.py:518
+#: ../gramps/plugins/drawreport/calendarreport.py:512
+#: ../gramps/plugins/drawreport/calendarreport.py:514
 msgid "Year of calendar"
 msgstr "Naptári év"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:521
-#: ../gramps/plugins/textreport/birthdayreport.py:460
-#: ../gramps/plugins/webreport/webcal.py:1721
+#: ../gramps/plugins/drawreport/calendarreport.py:517
+#: ../gramps/plugins/textreport/birthdayreport.py:530
+#: ../gramps/plugins/webreport/webcal.py:1766
 msgid "Country for holidays"
 msgstr "Szabadságok országa"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:532
-#: ../gramps/plugins/textreport/birthdayreport.py:471
+#: ../gramps/plugins/drawreport/calendarreport.py:528
+#: ../gramps/plugins/textreport/birthdayreport.py:541
 msgid "Select the country to see associated holidays"
 msgstr "Ország választása a hozzá társított szabadságok megnézéséhez"
 
 #. Default selection ????
-#: ../gramps/plugins/drawreport/calendarreport.py:535
-#: ../gramps/plugins/webreport/webcal.py:1737
+#: ../gramps/plugins/drawreport/calendarreport.py:531
+#: ../gramps/plugins/webreport/webcal.py:1784
 msgid "First day of week"
 msgstr "A hét első napja"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:543
-#: ../gramps/plugins/webreport/webcal.py:1740
+#: ../gramps/plugins/drawreport/calendarreport.py:539
+#: ../gramps/plugins/webreport/webcal.py:1787
 msgid "Select the first day of the week for the calendar"
 msgstr "A naptári hét első napjának választása"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:546
-#: ../gramps/plugins/textreport/birthdayreport.py:474
-#: ../gramps/plugins/webreport/webcal.py:1744
+#: ../gramps/plugins/drawreport/calendarreport.py:542
+#: ../gramps/plugins/textreport/birthdayreport.py:544
+#: ../gramps/plugins/webreport/webcal.py:1791
 msgid "Birthday surname"
 msgstr "Születésnapi vezetéknév"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:549
-#: ../gramps/plugins/textreport/birthdayreport.py:477
-#: ../gramps/plugins/webreport/webcal.py:1745
+#: ../gramps/plugins/drawreport/calendarreport.py:545
+#: ../gramps/plugins/textreport/birthdayreport.py:547
+#: ../gramps/plugins/webreport/webcal.py:1792
 msgid "Wives use husband's surname (from first family listed)"
 msgstr "A férj vezetéknevét használó feleségek (az első felsorolt családnál)"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:552
-#: ../gramps/plugins/textreport/birthdayreport.py:480
-#: ../gramps/plugins/webreport/webcal.py:1747
+#: ../gramps/plugins/drawreport/calendarreport.py:548
+#: ../gramps/plugins/textreport/birthdayreport.py:550
+#: ../gramps/plugins/webreport/webcal.py:1794
 msgid "Wives use husband's surname (from last family listed)"
 msgstr "A férj vezetéknevét használó feleségek (az utolsó felsorolt családnál)"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:553
-#: ../gramps/plugins/textreport/birthdayreport.py:481
-#: ../gramps/plugins/webreport/webcal.py:1749
+#: ../gramps/plugins/drawreport/calendarreport.py:549
+#: ../gramps/plugins/textreport/birthdayreport.py:551
+#: ../gramps/plugins/webreport/webcal.py:1796
 msgid "Wives use their own surname"
 msgstr "Saját vezetéknevet használó feleségek"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:554
-#: ../gramps/plugins/textreport/birthdayreport.py:482
-#: ../gramps/plugins/webreport/webcal.py:1750
+#: ../gramps/plugins/drawreport/calendarreport.py:550
+#: ../gramps/plugins/textreport/birthdayreport.py:552
+#: ../gramps/plugins/webreport/webcal.py:1797
 msgid "Select married women's displayed surname"
 msgstr "A megjelenített vezetéknevű házas nők választása"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:557
-#: ../gramps/plugins/textreport/birthdayreport.py:485
-#: ../gramps/plugins/webreport/webcal.py:1760
+#: ../gramps/plugins/drawreport/calendarreport.py:553
+#: ../gramps/plugins/textreport/birthdayreport.py:555
+#: ../gramps/plugins/webreport/webcal.py:1882
 msgid "Include birthdays"
 msgstr "Születésnapok is"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:558
-#: ../gramps/plugins/textreport/birthdayreport.py:486
+#: ../gramps/plugins/drawreport/calendarreport.py:554
+#: ../gramps/plugins/textreport/birthdayreport.py:556
 msgid "Whether to include birthdays"
 msgstr "Legyenek-e benne születésnapok is"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:561
-#: ../gramps/plugins/textreport/birthdayreport.py:489
-#: ../gramps/plugins/webreport/webcal.py:1764
+#: ../gramps/plugins/drawreport/calendarreport.py:557
+#: ../gramps/plugins/textreport/birthdayreport.py:559
+#: ../gramps/plugins/webreport/webcal.py:1886
 msgid "Include anniversaries"
 msgstr "Évfordulók is"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:562
-#: ../gramps/plugins/textreport/birthdayreport.py:490
+#: ../gramps/plugins/drawreport/calendarreport.py:558
+#: ../gramps/plugins/textreport/birthdayreport.py:560
 msgid "Whether to include anniversaries"
 msgstr "Legyenek-e benne évfordulók is"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:631
+#: ../gramps/plugins/drawreport/calendarreport.py:627
 msgid "Title text and background color"
 msgstr "Címszöveg és háttérszín"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:635
+#: ../gramps/plugins/drawreport/calendarreport.py:631
 msgid "Calendar day numbers"
 msgstr "Naptár napszámok"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:638
+#: ../gramps/plugins/drawreport/calendarreport.py:634
 msgid "Daily text display"
 msgstr "Napi szöveg mutatása"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:640
+#: ../gramps/plugins/drawreport/calendarreport.py:636
 msgid "Holiday text display"
 msgstr "Szabadság szöveg mutatása"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:643
+#: ../gramps/plugins/drawreport/calendarreport.py:639
 msgid "Days of the week text"
 msgstr "A hét napjai szöveg"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:647
-#: ../gramps/plugins/textreport/birthdayreport.py:575
+#: ../gramps/plugins/drawreport/calendarreport.py:643
+#: ../gramps/plugins/textreport/birthdayreport.py:649
 msgid "Text at bottom, line 1"
 msgstr "Szöveg alul, 1. sor"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:649
-#: ../gramps/plugins/textreport/birthdayreport.py:577
+#: ../gramps/plugins/drawreport/calendarreport.py:645
+#: ../gramps/plugins/textreport/birthdayreport.py:651
 msgid "Text at bottom, line 2"
 msgstr "Szöveg alul, 2. sor"
 
-#: ../gramps/plugins/drawreport/calendarreport.py:651
-#: ../gramps/plugins/textreport/birthdayreport.py:579
+#: ../gramps/plugins/drawreport/calendarreport.py:647
+#: ../gramps/plugins/textreport/birthdayreport.py:653
 msgid "Text at bottom, line 3"
 msgstr "Szöveg alul, 3. sor"
 
@@ -20999,85 +21162,85 @@ msgstr "%(father1)s és %(mother1)s családgrafikonja"
 msgid "Cousin Chart for %(names)s"
 msgstr "Unokatestvér grafikon %(names)s részére"
 
-#: ../gramps/plugins/drawreport/descendtree.py:759
+#: ../gramps/plugins/drawreport/descendtree.py:758
 #, python-format
 msgid "Family %s is not in the Database"
 msgstr "%s család nincs az adatbázisban"
 
 #. if self.name == "familial_descend_tree":
-#: ../gramps/plugins/drawreport/descendtree.py:1525
-#: ../gramps/plugins/drawreport/descendtree.py:1529
+#: ../gramps/plugins/drawreport/descendtree.py:1530
+#: ../gramps/plugins/drawreport/descendtree.py:1534
 msgid "Report for"
 msgstr "Összegzés"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1526
+#: ../gramps/plugins/drawreport/descendtree.py:1531
 msgid "The main person for the report"
 msgstr "Az összegzés fő személye"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1530
+#: ../gramps/plugins/drawreport/descendtree.py:1535
 msgid "The main family for the report"
 msgstr "Az összegzés fő családja"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1537
+#: ../gramps/plugins/drawreport/descendtree.py:1542
 msgid "Level of Spouses"
 msgstr "Házastársak szintje"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1538
+#: ../gramps/plugins/drawreport/descendtree.py:1543
 msgid "0=no Spouses, 1=include Spouses, 2=include Spouses of the spouse, etc"
 msgstr "0= nincs házastárs, 1=házastársak is, 2=házastárs házastársai is, stb"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1543
+#: ../gramps/plugins/drawreport/descendtree.py:1548
 msgid "Start with the parent(s) of the selected first"
 msgstr "Kezdje az első kiválasztott szülővel"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1546
+#: ../gramps/plugins/drawreport/descendtree.py:1551
 msgid "Will show the parents, brother and sisters of the selected person."
 msgstr "A kiválasztott személy szüleit, testvéreit fogja mutatni."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1552
+#: ../gramps/plugins/drawreport/descendtree.py:1557
 msgid "Whether to move people up, where possible, resulting in a smaller tree"
 msgstr ""
 "Legyenek-e emberek mozgatva felfelé, ahol lehetséges, ha az kisebb fát "
 "eredményez"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1556
+#: ../gramps/plugins/drawreport/descendtree.py:1561
 msgid "Bold direct descendants"
 msgstr "Egyenes leszármazott félkövéren"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1558
+#: ../gramps/plugins/drawreport/descendtree.py:1563
 msgid ""
 "Whether to bold those people that are direct (not step or half) descendants."
 msgstr ""
 "Legyenek-e félkövérek az egyenesági leszármazottak (nem fél-, vagy mostoha)."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1563
+#: ../gramps/plugins/drawreport/descendtree.py:1568
 msgid "Indent Spouses"
 msgstr "Házastársak behúzása"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1564
+#: ../gramps/plugins/drawreport/descendtree.py:1569
 msgid "Whether to indent the spouses in the tree."
 msgstr "Legyenek-e behúzva a házastársak a fában."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1572
-#: ../gramps/plugins/drawreport/descendtree.py:1745
+#: ../gramps/plugins/drawreport/descendtree.py:1577
+#: ../gramps/plugins/drawreport/descendtree.py:1750
 msgid "Descendant Chart for [selected person(s)]"
 msgstr "[kiválasztott személy(ek)] leszármazotti grafikonja"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1575
-#: ../gramps/plugins/drawreport/descendtree.py:1749
+#: ../gramps/plugins/drawreport/descendtree.py:1580
+#: ../gramps/plugins/drawreport/descendtree.py:1754
 msgid "Family Chart for [names of chosen family]"
 msgstr "[a választott család neveinek] család grafikonja"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1578
-#: ../gramps/plugins/drawreport/descendtree.py:1753
+#: ../gramps/plugins/drawreport/descendtree.py:1583
+#: ../gramps/plugins/drawreport/descendtree.py:1758
 msgid "Cousin Chart for [names of children]"
 msgstr "[gyermekek nevei] unokatestvér grafikonja"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1588
+#: ../gramps/plugins/drawreport/descendtree.py:1593
 msgid "Whether to include page numbers on each page."
 msgstr "Legyenek-e lapszámok minden lapon."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1649
+#: ../gramps/plugins/drawreport/descendtree.py:1654
 msgid ""
 "Descendant\n"
 "Display Format"
@@ -21085,7 +21248,7 @@ msgstr ""
 "Leszármazott\n"
 "Ábrázolásformátum"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1653
+#: ../gramps/plugins/drawreport/descendtree.py:1658
 msgid "Display format for a descendant."
 msgstr "Leszármazott ábrázolásformátuma."
 
@@ -21095,7 +21258,7 @@ msgstr "Leszármazott ábrázolásformátuma."
 #. True)
 #. diffspouse.set_help(_("Whether spouses can have a different format."))
 #. menu.add_option(category_name, "diffspouse", diffspouse)
-#: ../gramps/plugins/drawreport/descendtree.py:1663
+#: ../gramps/plugins/drawreport/descendtree.py:1668
 msgid ""
 "Spousal\n"
 "Display Format"
@@ -21103,19 +21266,19 @@ msgstr ""
 "Házastársi\n"
 "Ábrázolásformátum"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1667
+#: ../gramps/plugins/drawreport/descendtree.py:1672
 msgid "Display format for a spouse."
 msgstr "Házastárs ábrázolásformátuma."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1709
+#: ../gramps/plugins/drawreport/descendtree.py:1714
 msgid "inter-box Y scale factor"
 msgstr "dobozbeli Y skála együttható"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1711
+#: ../gramps/plugins/drawreport/descendtree.py:1716
 msgid "Make the inter-box Y bigger or smaller"
 msgstr "A dobozbeli Y nagyobbá, vagy kisebbé tétele"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1787
+#: ../gramps/plugins/drawreport/descendtree.py:1792
 msgid "The bold style used for the text display."
 msgstr "Szövegábrázolásnál félkövér stílus használata."
 
@@ -21181,10 +21344,6 @@ msgstr "Legyező diagramokat hoz létre"
 
 #. extract requested items from the database and count them
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:197
-#: ../gramps/plugins/drawreport/statisticschart.py:801
-#: ../gramps/plugins/drawreport/statisticschart.py:811
-#: ../gramps/plugins/drawreport/statisticschart.py:845
-#: ../gramps/plugins/drawreport/statisticschart.py:846
 #: ../gramps/plugins/drawreport/statisticschart.py:812
 #: ../gramps/plugins/drawreport/statisticschart.py:822
 #: ../gramps/plugins/drawreport/statisticschart.py:856
@@ -21198,7 +21357,7 @@ msgstr ""
 "Statisztikai oszlop- és kör diagramokat hoz létre az adatbázis embereiről"
 
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:221
-#: ../gramps/plugins/drawreport/timeline.py:274
+#: ../gramps/plugins/drawreport/timeline.py:275
 msgid "Timeline Chart"
 msgstr "Idővonal grafikon"
 
@@ -21221,468 +21380,442 @@ msgstr ""
 "%(person)s\n"
 "%(generations)d generációs legyező grafikonja"
 
-#: ../gramps/plugins/drawreport/fanchart.py:692
+#: ../gramps/plugins/drawreport/fanchart.py:694
 #: ../gramps/plugins/textreport/ancestorreport.py:296
 #: ../gramps/plugins/textreport/descendreport.py:538
-#: ../gramps/plugins/textreport/detancestralreport.py:833
-#: ../gramps/plugins/textreport/detdescendantreport.py:1024
+#: ../gramps/plugins/textreport/detancestralreport.py:841
+#: ../gramps/plugins/textreport/detdescendantreport.py:1030
 msgid "The number of generations to include in the report"
 msgstr "Az összegzésben szereplő generációk száma"
 
-#: ../gramps/plugins/drawreport/fanchart.py:696
+#: ../gramps/plugins/drawreport/fanchart.py:698
 msgid "Type of graph"
 msgstr "A grafikon típusa"
 
-#: ../gramps/plugins/drawreport/fanchart.py:697
+#: ../gramps/plugins/drawreport/fanchart.py:699
 msgid "full circle"
 msgstr "teljes kör"
 
-#: ../gramps/plugins/drawreport/fanchart.py:698
+#: ../gramps/plugins/drawreport/fanchart.py:700
 msgid "half circle"
 msgstr "félkör"
 
-#: ../gramps/plugins/drawreport/fanchart.py:699
+#: ../gramps/plugins/drawreport/fanchart.py:701
 msgid "quarter circle"
 msgstr "negyedkör"
 
-#: ../gramps/plugins/drawreport/fanchart.py:700
+#: ../gramps/plugins/drawreport/fanchart.py:702
 msgid "The form of the graph: full circle, half circle, or quarter circle."
 msgstr "A diagram formája: teljes kör, félkör, vagy negyedkör."
 
-#: ../gramps/plugins/drawreport/fanchart.py:706
+#: ../gramps/plugins/drawreport/fanchart.py:708
 msgid "generation dependent"
 msgstr "létrehozás függő"
 
-#: ../gramps/plugins/drawreport/fanchart.py:707
+#: ../gramps/plugins/drawreport/fanchart.py:709
 msgid "Background color is either white or generation dependent"
 msgstr "A háttérszín vagy fehér, vagy létrehozás függő"
 
-#: ../gramps/plugins/drawreport/fanchart.py:711
+#: ../gramps/plugins/drawreport/fanchart.py:713
 msgid "Orientation of radial texts"
 msgstr "A sugárirányú szöveg iránya"
 
-#: ../gramps/plugins/drawreport/fanchart.py:713
+#: ../gramps/plugins/drawreport/fanchart.py:715
 msgid "upright"
 msgstr "felfelé"
 
-#: ../gramps/plugins/drawreport/fanchart.py:714
+#: ../gramps/plugins/drawreport/fanchart.py:716
 msgid "roundabout"
 msgstr "körben"
 
-#: ../gramps/plugins/drawreport/fanchart.py:715
+#: ../gramps/plugins/drawreport/fanchart.py:717
 msgid "Print radial texts upright or roundabout"
 msgstr "Sugárirányú szöveg nyomtatása felfelé, vagy körben"
 
-#: ../gramps/plugins/drawreport/fanchart.py:717
+#: ../gramps/plugins/drawreport/fanchart.py:719
 msgid "Draw empty boxes"
 msgstr "Üres dobozok rajzolása"
 
-#: ../gramps/plugins/drawreport/fanchart.py:718
+#: ../gramps/plugins/drawreport/fanchart.py:720
 msgid "Draw the background although there is no information"
 msgstr "Háttér rajzolása, bár nincs információ"
 
-#: ../gramps/plugins/drawreport/fanchart.py:722
+#: ../gramps/plugins/drawreport/fanchart.py:724
 msgid "Use one font style for all generations"
 msgstr "Egy betű stílus használata minden generációra"
 
-#: ../gramps/plugins/drawreport/fanchart.py:724
+#: ../gramps/plugins/drawreport/fanchart.py:726
 msgid ""
 "You can customize font and color for each generation in the style editor"
 msgstr ""
 "A stílus szerkesztőben minden generációra külön betűt és színt állíthat be"
 
-#: ../gramps/plugins/drawreport/fanchart.py:780
+#: ../gramps/plugins/drawreport/fanchart.py:782
 #, python-format
 msgid "The style used for the text display of generation \"%d\""
 msgstr "A \"%d\" generációk mutatásánál használt szöveg stílusa "
 
-#: ../gramps/plugins/drawreport/statisticschart.py:306
+#: ../gramps/plugins/drawreport/statisticschart.py:311
 msgid "Item count"
 msgstr "Elemszám"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:310
+#: ../gramps/plugins/drawreport/statisticschart.py:315
+#: ../gramps/plugins/graph/gvfamilylines.py:85
 msgid "Both"
 msgstr "Mindkettő"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:311
-#: ../gramps/plugins/drawreport/statisticschart.py:413
-#: ../gramps/plugins/drawreport/statisticschart.py:774
+#: ../gramps/plugins/drawreport/statisticschart.py:316
+#: ../gramps/plugins/drawreport/statisticschart.py:419
+#: ../gramps/plugins/drawreport/statisticschart.py:794
 #: ../gramps/plugins/tool/verify.glade:645
-#: ../gramps/plugins/drawreport/statisticschart.py:785
 msgid "Men"
 msgstr "Férfiak"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:312
-#: ../gramps/plugins/drawreport/statisticschart.py:415
-#: ../gramps/plugins/drawreport/statisticschart.py:776
+#: ../gramps/plugins/drawreport/statisticschart.py:317
+#: ../gramps/plugins/drawreport/statisticschart.py:421
+#: ../gramps/plugins/drawreport/statisticschart.py:796
 #: ../gramps/plugins/tool/verify.glade:525
-#: ../gramps/plugins/drawreport/statisticschart.py:787
 msgid "Women"
 msgstr "Nők"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:332
+#: ../gramps/plugins/drawreport/statisticschart.py:338
 msgid "person|Title"
 msgstr "Cím"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:336
+#: ../gramps/plugins/drawreport/statisticschart.py:342
 msgid "Forename"
 msgstr "Utónév"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:340
+#: ../gramps/plugins/drawreport/statisticschart.py:346
 msgid "Birth year"
 msgstr "Születési év"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:342
+#: ../gramps/plugins/drawreport/statisticschart.py:348
 msgid "Death year"
 msgstr "Halálozási év"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:344
+#: ../gramps/plugins/drawreport/statisticschart.py:350
 msgid "Birth month"
 msgstr "Születési hónap"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:346
+#: ../gramps/plugins/drawreport/statisticschart.py:352
 msgid "Death month"
 msgstr "Halálozási hónap"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:348
+#: ../gramps/plugins/drawreport/statisticschart.py:354
 #: ../gramps/plugins/export/exportcsv.py:357
-#: ../gramps/plugins/importer/importcsv.py:172
+#: ../gramps/plugins/importer/importcsv.py:173
 msgid "Birth place"
 msgstr "Születési hely"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:350
+#: ../gramps/plugins/drawreport/statisticschart.py:356
 #: ../gramps/plugins/export/exportcsv.py:359
 msgid "Death place"
 msgstr "Halálozási hely"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:352
+#: ../gramps/plugins/drawreport/statisticschart.py:358
 msgid "Marriage place"
 msgstr "Házasság helye"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:355
+#: ../gramps/plugins/drawreport/statisticschart.py:361
 msgid "Number of relationships"
 msgstr "Kapcsolatok száma"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:359
+#: ../gramps/plugins/drawreport/statisticschart.py:365
 msgid "Age when first child born"
 msgstr "Kora az első gyermek születésekor"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:363
+#: ../gramps/plugins/drawreport/statisticschart.py:369
 msgid "Age when last child born"
 msgstr "Kora az utolsó gyermek születésekor"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:365
+#: ../gramps/plugins/drawreport/statisticschart.py:371
 msgid "Number of children"
 msgstr "Gyermekek száma"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:367
+#: ../gramps/plugins/drawreport/statisticschart.py:373
 msgid "Age at marriage"
 msgstr "Kora házasságkötéskor"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:369
+#: ../gramps/plugins/drawreport/statisticschart.py:375
 msgid "Age at death"
 msgstr "Kora halálakor"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:373
+#: ../gramps/plugins/drawreport/statisticschart.py:379
 msgid "Event type"
 msgstr "Eseménytípus"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:387
+#: ../gramps/plugins/drawreport/statisticschart.py:393
 msgid "(Preferred) title missing"
 msgstr "(Elsődleges) cím hiányzik"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:396
+#. the list of keys that represent "missing" information
+#: ../gramps/plugins/drawreport/statisticschart.py:402
+#: ../gramps/plugins/drawreport/statisticschart.py:928
 msgid "(Preferred) forename missing"
 msgstr "(Elsődleges) utónév hiányzik"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:406
+#: ../gramps/plugins/drawreport/statisticschart.py:412
 msgid "(Preferred) surname missing"
 msgstr "(Elsődleges) vezetéknév hiányzik"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:416
+#: ../gramps/plugins/drawreport/statisticschart.py:422
 msgid "Gender unknown"
 msgstr "Ismeretlen nemű"
 
+#. localized year
 #. inadequate information
-#: ../gramps/plugins/drawreport/statisticschart.py:425
-#: ../gramps/plugins/drawreport/statisticschart.py:434
-#: ../gramps/plugins/drawreport/statisticschart.py:541
-#: ../gramps/plugins/drawreport/statisticschart.py:445
-#: ../gramps/plugins/drawreport/statisticschart.py:552
+#: ../gramps/plugins/drawreport/statisticschart.py:431
+#: ../gramps/plugins/drawreport/statisticschart.py:451
+#: ../gramps/plugins/drawreport/statisticschart.py:558
+#: ../gramps/plugins/drawreport/statisticschart.py:929
 msgid "Date(s) missing"
 msgstr "Dátum(ok) hiányzik"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:443
-#: ../gramps/plugins/drawreport/statisticschart.py:457
-#: ../gramps/plugins/drawreport/statisticschart.py:454
-#: ../gramps/plugins/drawreport/statisticschart.py:468
+#: ../gramps/plugins/drawreport/statisticschart.py:460
+#: ../gramps/plugins/drawreport/statisticschart.py:474
 msgid "Place missing"
 msgstr "Hely hiányzik"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:465
-#: ../gramps/plugins/drawreport/statisticschart.py:476
+#: ../gramps/plugins/drawreport/statisticschart.py:482
 msgid "Already dead"
 msgstr "Már halott"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:472
-#: ../gramps/plugins/drawreport/statisticschart.py:483
+#: ../gramps/plugins/drawreport/statisticschart.py:489
 msgid "Still alive"
 msgstr "Még él"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:480
-#: ../gramps/plugins/drawreport/statisticschart.py:492
-#: ../gramps/plugins/drawreport/statisticschart.py:491
-#: ../gramps/plugins/drawreport/statisticschart.py:503
+#: ../gramps/plugins/drawreport/statisticschart.py:497
+#: ../gramps/plugins/drawreport/statisticschart.py:509
 msgid "Events missing"
 msgstr "Események hiányoznak"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:500
-#: ../gramps/plugins/drawreport/statisticschart.py:508
-#: ../gramps/plugins/drawreport/statisticschart.py:511
-#: ../gramps/plugins/drawreport/statisticschart.py:519
+#: ../gramps/plugins/drawreport/statisticschart.py:517
+#: ../gramps/plugins/drawreport/statisticschart.py:525
+#: ../gramps/plugins/drawreport/statisticschart.py:932
 msgid "Children missing"
 msgstr "Gyermekek hiányoznak"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:530
-#: ../gramps/plugins/drawreport/statisticschart.py:541
+#: ../gramps/plugins/drawreport/statisticschart.py:547
+#: ../gramps/plugins/drawreport/statisticschart.py:931
 msgid "Birth missing"
 msgstr "Születés hiányzik"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:631
-#: ../gramps/plugins/drawreport/statisticschart.py:642
+#: ../gramps/plugins/drawreport/statisticschart.py:648
+#: ../gramps/plugins/drawreport/statisticschart.py:930
 msgid "Personal information missing"
 msgstr "Személyes információ hiányzik"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:769
-#: ../gramps/plugins/drawreport/timeline.py:118
+#: ../gramps/plugins/drawreport/statisticschart.py:789
+#: ../gramps/plugins/drawreport/timeline.py:119
 #: ../gramps/plugins/textreport/placereport.py:99
 #: ../gramps/plugins/textreport/recordsreport.py:91
 #: ../gramps/plugins/textreport/tagreport.py:100
-#: ../gramps/plugins/drawreport/statisticschart.py:780
 #, python-format
 msgid "(Living people: %(option_name)s)"
 msgstr "(Élő emberek: %(option_name)s)"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:788
-#: ../gramps/plugins/drawreport/statisticschart.py:799
+#: ../gramps/plugins/drawreport/statisticschart.py:801
 #, python-format
-msgid "%(genders)s born %(year_from)04d-%(year_to)04d"
-msgstr "%(year_from)04d-%(year_to)04d született %(genders)s"
+msgid "%s born"
+msgstr "%s született"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:792
 #: ../gramps/plugins/drawreport/statisticschart.py:803
-#, python-format
-msgid "Persons born %(year_from)04d-%(year_to)04d"
-msgstr "%(year_from)04d-%(year_to)04d született személyek"
+msgid "Persons born"
+msgstr "Született személyek"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:802
 #: ../gramps/plugins/drawreport/statisticschart.py:813
 msgid "Collecting data..."
 msgstr "Adatgyűjtés..."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:812
 #: ../gramps/plugins/drawreport/statisticschart.py:823
 msgid "Sorting data..."
 msgstr "Adatrendezés..."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:847
 #: ../gramps/plugins/drawreport/statisticschart.py:858
 msgid "Saving charts..."
 msgstr "Diagram mentése..."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:901
-#: ../gramps/plugins/drawreport/statisticschart.py:939
-#: ../gramps/plugins/drawreport/statisticschart.py:912
-#: ../gramps/plugins/drawreport/statisticschart.py:950
+#: ../gramps/plugins/drawreport/statisticschart.py:911
+#: ../gramps/plugins/drawreport/statisticschart.py:960
 #, python-format
 msgid "%s (persons):"
 msgstr "%s (személyek):"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:991
+#: ../gramps/plugins/drawreport/statisticschart.py:1013
 #: ../gramps/plugins/textreport/recordsreport.py:219
-#: ../gramps/plugins/drawreport/statisticschart.py:1002
 msgid "Determines what people are included in the report."
 msgstr "Meghatározza, milyen emberek kerülnek az összegzőbe."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:996
-#: ../gramps/plugins/drawreport/timeline.py:421
-#: ../gramps/plugins/textreport/birthdayreport.py:417
-#: ../gramps/plugins/textreport/indivcomplete.py:1067
+#: ../gramps/plugins/drawreport/statisticschart.py:1018
+#: ../gramps/plugins/drawreport/timeline.py:422
+#: ../gramps/plugins/textreport/birthdayreport.py:479
+#: ../gramps/plugins/textreport/indivcomplete.py:1068
 #: ../gramps/plugins/textreport/recordsreport.py:223
-#: ../gramps/plugins/tool/sortevents.py:172
-#: ../gramps/plugins/webreport/narrativeweb.py:1608
-#: ../gramps/plugins/webreport/webcal.py:1632
-#: ../gramps/plugins/drawreport/statisticschart.py:1007
+#: ../gramps/plugins/tool/sortevents.py:173
+#: ../gramps/plugins/webreport/narrativeweb.py:1645
+#: ../gramps/plugins/webreport/webcal.py:1677
 msgid "Filter Person"
 msgstr "Személyszűrő"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:997
-#: ../gramps/plugins/textreport/birthdayreport.py:418
-#: ../gramps/plugins/textreport/indivcomplete.py:1068
-#: ../gramps/plugins/drawreport/statisticschart.py:1008
+#: ../gramps/plugins/drawreport/statisticschart.py:1019
+#: ../gramps/plugins/textreport/birthdayreport.py:480
+#: ../gramps/plugins/textreport/indivcomplete.py:1069
 msgid "The center person for the filter."
 msgstr "A szűrő központi személye."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1001
-#: ../gramps/plugins/drawreport/statisticschart.py:1012
+#: ../gramps/plugins/drawreport/statisticschart.py:1023
 msgid "Sort chart items by"
 msgstr "A diagram elemeit eszerint rendezze"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1006
-#: ../gramps/plugins/drawreport/statisticschart.py:1017
+#: ../gramps/plugins/drawreport/statisticschart.py:1028
 msgid "Select how the statistical data is sorted."
 msgstr "Válasszon, hogyan legyenek rendezve a statisztikai adatok."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1009
-#: ../gramps/plugins/drawreport/statisticschart.py:1020
+#: ../gramps/plugins/drawreport/statisticschart.py:1031
 msgid "Sort in reverse order"
 msgstr "Ellentétes sorrendbe rendez"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1010
-#: ../gramps/plugins/drawreport/statisticschart.py:1021
+#: ../gramps/plugins/drawreport/statisticschart.py:1032
 msgid "Check to reverse the sorting order."
 msgstr "Jelölje be az ellentétes sorrendbe rendezéshez."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1014
-#: ../gramps/plugins/drawreport/statisticschart.py:1025
+#: ../gramps/plugins/drawreport/statisticschart.py:1036
 msgid "People Born After"
 msgstr "Utána született emberek"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1016
-#: ../gramps/plugins/drawreport/statisticschart.py:1027
+#: ../gramps/plugins/drawreport/statisticschart.py:1038
 msgid "Birth year from which to include people."
 msgstr "E születési évtől legyenek benne az emberek."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1019
-#: ../gramps/plugins/drawreport/statisticschart.py:1030
+#: ../gramps/plugins/drawreport/statisticschart.py:1041
 msgid "People Born Before"
 msgstr "Előtte született emberek"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1021
-#: ../gramps/plugins/drawreport/statisticschart.py:1032
+#: ../gramps/plugins/drawreport/statisticschart.py:1043
 msgid "Birth year until which to include people"
 msgstr "E születési évig legyenek benne az emberek"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1024
-#: ../gramps/plugins/drawreport/statisticschart.py:1035
+#: ../gramps/plugins/drawreport/statisticschart.py:1046
 msgid "Include people without known birth years"
 msgstr "Ismert születési év nélküli emberekkel együtt"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1026
-#: ../gramps/plugins/drawreport/statisticschart.py:1037
+#: ../gramps/plugins/drawreport/statisticschart.py:1048
 msgid "Whether to include people without known birth years."
 msgstr "Legyenek-e benne ismert születési év nélküli emberek."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1030
-#: ../gramps/plugins/drawreport/statisticschart.py:1041
+#: ../gramps/plugins/drawreport/statisticschart.py:1052
 msgid "Genders included"
 msgstr "Figyelembe vett nemek"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1035
-#: ../gramps/plugins/drawreport/statisticschart.py:1046
+#: ../gramps/plugins/drawreport/statisticschart.py:1057
 msgid "Select which genders are included into statistics."
 msgstr "Válasszon, milyen neműek legyenek benne a statisztikában."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1039
-#: ../gramps/plugins/drawreport/statisticschart.py:1050
+#: ../gramps/plugins/drawreport/statisticschart.py:1061
 msgid "Max. items for a pie"
 msgstr "Kördiagram max. elemszáma"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1040
-#: ../gramps/plugins/drawreport/statisticschart.py:1051
+#: ../gramps/plugins/drawreport/statisticschart.py:1062
 msgid ""
 "With fewer items pie chart and legend will be used instead of a bar chart."
 msgstr "Kevesebb elem esetén kördiagramot használok oszlopdiagram helyett."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1073
-#: ../gramps/plugins/drawreport/statisticschart.py:1084
+#: ../gramps/plugins/drawreport/statisticschart.py:1066
+msgid "Include counts of missing information"
+msgstr "A hiányzó információk számával együtt"
+
+#: ../gramps/plugins/drawreport/statisticschart.py:1068
+msgid ""
+"Whether to include counts of the number of people who lack the given "
+"information."
+msgstr "Legyen-e benne a hiányzó keresztnevű személyek száma is."
+
+#: ../gramps/plugins/drawreport/statisticschart.py:1102
 msgid "Charts 3"
 msgstr "3. diagramok"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1075
-#: ../gramps/plugins/drawreport/statisticschart.py:1086
+#: ../gramps/plugins/drawreport/statisticschart.py:1104
 msgid "Charts 2"
 msgstr "2. diagramok"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1077
-#: ../gramps/plugins/drawreport/statisticschart.py:1088
+#: ../gramps/plugins/drawreport/statisticschart.py:1106
 msgid "Charts 1"
 msgstr "1. diagramok"
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1079
-#: ../gramps/plugins/drawreport/statisticschart.py:1090
+#: ../gramps/plugins/drawreport/statisticschart.py:1108
 msgid "Include charts with indicated data."
 msgstr "A jelölt dátumú diagramokkal együtt."
 
-#: ../gramps/plugins/drawreport/statisticschart.py:1121
-#: ../gramps/plugins/textreport/placereport.py:601
-#: ../gramps/plugins/drawreport/statisticschart.py:1132
+#: ../gramps/plugins/drawreport/statisticschart.py:1150
+#: ../gramps/plugins/textreport/placereport.py:602
 msgid "The style used for the items and values."
 msgstr "A elemekhez és az értékekhez használt stílus."
 
-#: ../gramps/plugins/drawreport/timeline.py:65
+#: ../gramps/plugins/drawreport/timeline.py:66
 msgid "sorted by|Birth Date"
 msgstr "Születési dátum"
 
-#: ../gramps/plugins/drawreport/timeline.py:66
+#: ../gramps/plugins/drawreport/timeline.py:67
 msgid "sorted by|Name"
 msgstr "Név"
 
 #. Sort the people as requested
-#: ../gramps/plugins/drawreport/timeline.py:156
-#: ../gramps/plugins/drawreport/timeline.py:168
-#: ../gramps/plugins/drawreport/timeline.py:337
+#: ../gramps/plugins/drawreport/timeline.py:157
+#: ../gramps/plugins/drawreport/timeline.py:169
+#: ../gramps/plugins/drawreport/timeline.py:338
 msgid "Timeline"
 msgstr "Idővonal"
 
-#: ../gramps/plugins/drawreport/timeline.py:157
+#: ../gramps/plugins/drawreport/timeline.py:158
 msgid "Sorting dates..."
 msgstr "Dátumok rendezése..."
 
-#: ../gramps/plugins/drawreport/timeline.py:168
+#: ../gramps/plugins/drawreport/timeline.py:169
 msgid "Calculating timeline..."
 msgstr "Idővonal számítása..."
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/drawreport/timeline.py:276
+#: ../gramps/plugins/drawreport/timeline.py:277
 #, python-format
 msgid "Sorted by %s"
 msgstr "%s szerint rendezve"
 
-#: ../gramps/plugins/drawreport/timeline.py:311
+#: ../gramps/plugins/drawreport/timeline.py:312
+#: ../gramps/plugins/lib/libgedcom.py:7832
 msgid "No Date Information"
 msgstr "Nincs dátum információ"
 
-#: ../gramps/plugins/drawreport/timeline.py:338
+#: ../gramps/plugins/drawreport/timeline.py:339
 msgid "Finding date range..."
 msgstr "Dátum intervallum keresése..."
 
-#: ../gramps/plugins/drawreport/timeline.py:417
+#: ../gramps/plugins/drawreport/timeline.py:418
 msgid "Determines what people are included in the report"
 msgstr "Meghatározza, mely emberek legyenek az összesítőben"
 
-#: ../gramps/plugins/drawreport/timeline.py:422
+#: ../gramps/plugins/drawreport/timeline.py:423
 #: ../gramps/plugins/textreport/recordsreport.py:224
-#: ../gramps/plugins/tool/sortevents.py:173
-#: ../gramps/plugins/webreport/narrativeweb.py:1609
-#: ../gramps/plugins/webreport/webcal.py:1633
+#: ../gramps/plugins/tool/sortevents.py:174
+#: ../gramps/plugins/webreport/narrativeweb.py:1646
+#: ../gramps/plugins/webreport/webcal.py:1678
 msgid "The center person for the filter"
 msgstr "A szűrő központi személye"
 
-#: ../gramps/plugins/drawreport/timeline.py:426
-#: ../gramps/plugins/tool/sortevents.py:179
+#: ../gramps/plugins/drawreport/timeline.py:427
+#: ../gramps/plugins/tool/sortevents.py:180
 msgid "Sort by"
 msgstr "Rendezés eszerint"
 
-#: ../gramps/plugins/drawreport/timeline.py:431
-#: ../gramps/plugins/tool/sortevents.py:184
+#: ../gramps/plugins/drawreport/timeline.py:432
+#: ../gramps/plugins/tool/sortevents.py:185
 msgid "Sorting method to use"
 msgstr "Használt rendezési módszer"
 
-#: ../gramps/plugins/drawreport/timeline.py:488
-#: ../gramps/plugins/textreport/indivcomplete.py:1216
+#: ../gramps/plugins/drawreport/timeline.py:489
+#: ../gramps/plugins/textreport/indivcomplete.py:1217
 #: ../gramps/plugins/textreport/notelinkreport.py:196
-#: ../gramps/plugins/textreport/placereport.py:532
+#: ../gramps/plugins/textreport/placereport.py:533
 #: ../gramps/plugins/textreport/recordsreport.py:327
 #: ../gramps/plugins/textreport/tagreport.py:965
 msgid "The style used for the section headers."
@@ -21831,13 +21964,13 @@ msgid "Include marriages"
 msgstr "Házasságokkal együtt"
 
 #: ../gramps/plugins/export/exportcsv.py:138
-#: ../gramps/plugins/textreport/detancestralreport.py:894
-#: ../gramps/plugins/textreport/detdescendantreport.py:1081
+#: ../gramps/plugins/textreport/detancestralreport.py:902
+#: ../gramps/plugins/textreport/detdescendantreport.py:1087
 msgid "Include children"
 msgstr "Gyermekekkel együtt"
 
 #: ../gramps/plugins/export/exportcsv.py:139
-#: ../gramps/plugins/graph/gvfamilylines.py:227
+#: ../gramps/plugins/graph/gvfamilylines.py:234
 msgid "Include places"
 msgstr "Helyekkel együtt"
 
@@ -21888,60 +22021,64 @@ msgid "Burial source"
 msgstr "Temetés forrása"
 
 #: ../gramps/plugins/export/exportcsv.py:465
-#: ../gramps/plugins/importer/importcsv.py:217
+#: ../gramps/plugins/importer/importcsv.py:233
 #: ../gramps/plugins/textreport/familygroup.py:627
-#: ../gramps/plugins/webreport/basepage.py:2325
+#: ../gramps/plugins/webreport/basepage.py:2366
 msgid "Husband"
 msgstr "Férj"
 
 #: ../gramps/plugins/export/exportcsv.py:465
-#: ../gramps/plugins/importer/importcsv.py:214
+#: ../gramps/plugins/importer/importcsv.py:230
 #: ../gramps/plugins/textreport/familygroup.py:636
-#: ../gramps/plugins/webreport/basepage.py:2323
+#: ../gramps/plugins/webreport/basepage.py:2364
 msgid "Wife"
 msgstr "Feleség"
 
-#: ../gramps/plugins/export/exportgedcom.py:405
+#: ../gramps/plugins/export/exportgedcom.py:398
 msgid "Writing individuals"
 msgstr "Egyének beírása"
 
-#: ../gramps/plugins/export/exportgedcom.py:797
-#: ../gramps/plugins/export/exportgedcom.py:1079
-#: ../gramps/plugins/export/exportgedcom.py:1170
-#: ../gramps/plugins/lib/libgedcom.py:4150
-#: ../gramps/plugins/lib/libgedcom.py:5883
+#: ../gramps/plugins/export/exportgedcom.py:790
+#: ../gramps/plugins/export/exportgedcom.py:1072
+#: ../gramps/plugins/export/exportgedcom.py:1163
+#: ../gramps/plugins/lib/libgedcom.py:4144
+#: ../gramps/plugins/lib/libgedcom.py:5872
 #: ../gramps/plugins/lib/libgedcom.py:7017
 msgid "FAX"
 msgstr "FAX"
 
-#: ../gramps/plugins/export/exportgedcom.py:811
+#: ../gramps/plugins/export/exportgedcom.py:804
 #: ../gramps/plugins/textreport/familygroup.py:673
 msgid "Writing families"
 msgstr "Családok beírása"
 
-#: ../gramps/plugins/export/exportgedcom.py:978
+#: ../gramps/plugins/export/exportgedcom.py:971
 msgid "Writing sources"
 msgstr "Források beírása"
 
-#: ../gramps/plugins/export/exportgedcom.py:1013
+#: ../gramps/plugins/export/exportgedcom.py:1006
 msgid "Writing notes"
 msgstr "Jegyzetek írása"
 
-#: ../gramps/plugins/export/exportgedcom.py:1056
+#: ../gramps/plugins/export/exportgedcom.py:1049
 msgid "Writing repositories"
 msgstr "Tárolók írása"
 
-#: ../gramps/plugins/export/exportgedcom.py:1172
-#: ../gramps/plugins/lib/libgedcom.py:5895
+#: ../gramps/plugins/export/exportgedcom.py:1165
+#: ../gramps/plugins/lib/libgedcom.py:5884
 msgid "EMAIL"
 msgstr "EMAIL"
 
-#: ../gramps/plugins/export/exportgedcom.py:1174
-#: ../gramps/plugins/lib/libgedcom.py:5907
+#: ../gramps/plugins/export/exportgedcom.py:1167
+#: ../gramps/plugins/lib/libgedcom.py:5896
 msgid "WWW"
 msgstr "WWW"
 
-#: ../gramps/plugins/export/exportgedcom.py:1570
+#: ../gramps/plugins/export/exportgedcom.py:1429
+msgid "Writing media"
+msgstr "Média írása"
+
+#: ../gramps/plugins/export/exportgedcom.py:1603
 msgid "GEDCOM Export failed"
 msgstr "Sikertelen GEDCOM exportálás"
 
@@ -21956,31 +22093,6 @@ msgstr "Nincs a kiválasztásnak megfelelő család"
 #, python-format
 msgid "Failure writing %s"
 msgstr "Hiba %s írásakor"
-
-#. feature requests 2356, 1657: avoid genitive form
-#: ../gramps/plugins/export/exportvcalendar.py:135
-#, python-format
-msgid "Marriage of %s"
-msgstr "%s házassága"
-
-#. feature requests 2356, 1657: avoid genitive form
-#: ../gramps/plugins/export/exportvcalendar.py:154
-#: ../gramps/plugins/export/exportvcalendar.py:159
-#, python-format
-msgid "Birth of %s"
-msgstr "%s születése"
-
-#. feature requests 2356, 1657: avoid genitive form
-#: ../gramps/plugins/export/exportvcalendar.py:172
-#: ../gramps/plugins/export/exportvcalendar.py:178
-#, python-format
-msgid "Death of %s"
-msgstr "%s halála"
-
-#: ../gramps/plugins/export/exportvcalendar.py:237
-#, python-format
-msgid "Anniversary: %s"
-msgstr "évforduló: %s"
 
 #: ../gramps/plugins/export/exportxml.py:140
 msgid ""
@@ -22059,7 +22171,7 @@ msgstr "Anya-gyermek életkor különbség eloszlás"
 #: ../gramps/plugins/gramplet/agestats.py:235
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:262
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:269
-#: ../gramps/plugins/webreport/basepage.py:1498
+#: ../gramps/plugins/webreport/basepage.py:1539
 #: ../gramps/plugins/webreport/statistics.py:84
 msgid "Statistics"
 msgstr "Statisztika"
@@ -22112,7 +22224,7 @@ msgstr ""
 
 #: ../gramps/plugins/gramplet/attributes.py:56
 #: ../gramps/plugins/lib/libmetadata.py:172
-#: ../gramps/plugins/webreport/basepage.py:1005
+#: ../gramps/plugins/webreport/basepage.py:1024
 msgid "Key"
 msgstr "Kulcs"
 
@@ -22189,9 +22301,9 @@ msgstr "Alkalmaz"
 msgid "Double-click on a row to edit the selected event."
 msgstr "A kiválasztott esemény szerkesztéséhez kattintson kettőt a soron."
 
-#: ../gramps/plugins/gramplet/fanchart2waygramplet.py:86
-#: ../gramps/plugins/gramplet/fanchartdescgramplet.py:64
-#: ../gramps/plugins/gramplet/fanchartgramplet.py:67
+#: ../gramps/plugins/gramplet/fanchart2waygramplet.py:78
+#: ../gramps/plugins/gramplet/fanchartdescgramplet.py:65
+#: ../gramps/plugins/gramplet/fanchartgramplet.py:68
 msgid ""
 "Click to expand/contract person\n"
 "Right-click for options\n"
@@ -22374,7 +22486,7 @@ msgstr "Részletekért kattintson kétszer a keresztnéven"
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:50
 #: ../gramps/plugins/gramplet/recordsgramplet.py:43
 #: ../gramps/plugins/gramplet/relativegramplet.py:40
-#: ../gramps/plugins/gramplet/statsgramplet.py:53
+#: ../gramps/plugins/gramplet/statsgramplet.py:58
 #: ../gramps/plugins/gramplet/surnamecloudgramplet.py:70
 #: ../gramps/plugins/gramplet/topsurnamesgramplet.py:52
 #: ../gramps/plugins/gramplet/topsurnamesgramplet.py:60
@@ -22384,7 +22496,7 @@ msgstr "Nincs betöltött családfa."
 
 #: ../gramps/plugins/gramplet/givennamegramplet.py:70
 #: ../gramps/plugins/gramplet/recordsgramplet.py:50
-#: ../gramps/plugins/gramplet/statsgramplet.py:69
+#: ../gramps/plugins/gramplet/statsgramplet.py:71
 #: ../gramps/plugins/gramplet/surnamecloudgramplet.py:93
 #: ../gramps/plugins/gramplet/topsurnamesgramplet.py:70
 msgid "Processing..."
@@ -22438,7 +22550,7 @@ msgstr "Aktív személy leszármazottait mutató gramplet"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:104
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:111
-#: ../gramps/plugins/webreport/person.py:1086
+#: ../gramps/plugins/webreport/person.py:1177
 msgid "Ancestors"
 msgstr "Ősök"
 
@@ -22452,7 +22564,7 @@ msgid "Gramplet showing active person's direct ancestors as a fanchart"
 msgstr "Aktív személy közvetlen őseit legyeződiagramként mutató gramplet"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:138
-#: ../gramps/plugins/view/fanchartdescview.py:75
+#: ../gramps/plugins/view/fanchartdescview.py:76
 msgid "Descendant Fan Chart"
 msgstr "Leszármazott legyező ábra"
 
@@ -22466,7 +22578,7 @@ msgid "Descendant Fan"
 msgstr "Leszármazott legyező"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:155
-#: ../gramps/plugins/view/fanchart2wayview.py:78
+#: ../gramps/plugins/view/fanchart2wayview.py:79
 msgid "2-Way Fan Chart"
 msgstr "Kétutas legyező diagram"
 
@@ -22505,7 +22617,7 @@ msgstr "Az összes keresztnevet szövegfelhőként mutató gramplet"
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:205
 #: ../gramps/plugins/view/pedigreeview.py:528
 #: ../gramps/plugins/view/view.gpr.py:127
-#: ../gramps/plugins/webreport/person.py:1272
+#: ../gramps/plugins/webreport/person.py:1346
 msgid "Pedigree"
 msgstr "Családfa"
 
@@ -22919,10 +23031,9 @@ msgstr "Egy személy vissza-hivatkozásait mutató gramplet"
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:967
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:981
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:995
-#: ../gramps/plugins/webreport/basepage.py:2269
-#: ../gramps/plugins/webreport/basepage.py:2810
-#: ../gramps/plugins/webreport/person.py:858
-#: ../gramps/plugins/webreport/thumbnail.py:210
+#: ../gramps/plugins/webreport/basepage.py:2959
+#: ../gramps/plugins/webreport/person.py:878
+#: ../gramps/plugins/webreport/thumbnail.py:164
 msgid "References"
 msgstr "Hivatkozások"
 
@@ -22951,7 +23062,7 @@ msgid "Gramplet showing the backlink references for a place"
 msgstr "Egy hely vissza-hivatkozásait mutató gramplet"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:931
-#: ../gramps/plugins/webreport/basepage.py:2153
+#: ../gramps/plugins/webreport/basepage.py:2234
 msgid "Source References"
 msgstr "Forrás hivatkozások"
 
@@ -23157,6 +23268,8 @@ msgid "Gramplet showing the places enclosed by the active place"
 msgstr "Egy aktív hely által mellékelt helyeket mutató gramplet"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1308
+#: ../gramps/plugins/webreport/basepage.py:2673
+#: ../gramps/plugins/webreport/basepage.py:2736
 msgid "Place Encloses"
 msgstr "Hely Mellékelte"
 
@@ -23185,35 +23298,47 @@ msgstr "Geográfiai koordináták Család Eseményekhez"
 msgid "Gramplet showing the events for all the family"
 msgstr "A teljes család eseményeit mutató gramplet"
 
-#: ../gramps/plugins/gramplet/leak.py:93
+#: ../gramps/plugins/gramplet/leak.py:99
+msgid "Referrer"
+msgstr "Utaló személy"
+
+#: ../gramps/plugins/gramplet/leak.py:103
 msgid "Uncollected object"
 msgstr "Nem összegyűjtött objektum"
 
-#: ../gramps/plugins/gramplet/leak.py:102
+#: ../gramps/plugins/gramplet/leak.py:112
 msgid "Refresh"
 msgstr "Frissítés"
 
-#: ../gramps/plugins/gramplet/leak.py:133
+#: ../gramps/plugins/gramplet/leak.py:122
+msgid "Press Refresh to see initial results"
+msgstr "A kezdeti eredményekhez nyomja meg a Frissítés gombot"
+
+#: ../gramps/plugins/gramplet/leak.py:158
 #, python-format
 msgid "Referrers of %d"
 msgstr "%d hivatkozói"
 
-#: ../gramps/plugins/gramplet/leak.py:147
+#: ../gramps/plugins/gramplet/leak.py:181
 #, python-format
 msgid "%d refers to"
 msgstr "%d hivatkozik erre"
 
-#: ../gramps/plugins/gramplet/leak.py:172
+#: ../gramps/plugins/gramplet/leak.py:198
 #, python-format
 msgid "Uncollected Objects: %s"
 msgstr "Nem összegyűjtött objektumok: %s"
+
+#: ../gramps/plugins/gramplet/leak.py:239
+msgid "Reference Error"
+msgstr "Hivatkozási hiba"
 
 #: ../gramps/plugins/gramplet/locations.py:81
 msgid "Double-click on a row to edit the selected place."
 msgstr "A kiválasztott hely szerkesztéséhez kattintson kétszer a soron."
 
 #: ../gramps/plugins/gramplet/notes.py:111
-#: ../gramps/plugins/gramplet/todo.py:135
+#: ../gramps/plugins/gramplet/todo.py:137
 #: ../gramps/plugins/gramplet/todogramplet.py:151
 #, python-format
 msgid "%(current)d of %(total)d"
@@ -23226,8 +23351,8 @@ msgstr "Lehetőségekért mozgassa az egeret a linkre"
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:58
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:67
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:78
-#: ../gramps/plugins/view/fanchartdescview.py:295
-#: ../gramps/plugins/view/fanchartview.py:291
+#: ../gramps/plugins/view/fanchartdescview.py:280
+#: ../gramps/plugins/view/fanchartview.py:378
 msgid "Max generations"
 msgstr "Legtöbb generáció"
 
@@ -23294,8 +23419,8 @@ msgstr " 1 személyből 1 (%(percent)s kész)\n"
 #. Create the Generation title, set an index marker
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:267
 #: ../gramps/plugins/textreport/ancestorreport.py:218
-#: ../gramps/plugins/textreport/detancestralreport.py:226
-#: ../gramps/plugins/textreport/detdescendantreport.py:353
+#: ../gramps/plugins/textreport/detancestralreport.py:228
+#: ../gramps/plugins/textreport/detdescendantreport.py:355
 #: ../gramps/plugins/textreport/endoflinereport.py:186
 #, python-format
 msgid "Generation %d"
@@ -23345,17 +23470,17 @@ msgid "%(date)s."
 msgstr "%(date)s."
 
 #. Add types:
-#: ../gramps/plugins/gramplet/quickviewgramplet.py:70
-#: ../gramps/plugins/gramplet/quickviewgramplet.py:106
-#: ../gramps/plugins/gramplet/quickviewgramplet.py:128
-#: ../gramps/plugins/gramplet/quickviewgramplet.py:143
+#: ../gramps/plugins/gramplet/quickviewgramplet.py:71
+#: ../gramps/plugins/gramplet/quickviewgramplet.py:107
+#: ../gramps/plugins/gramplet/quickviewgramplet.py:129
+#: ../gramps/plugins/gramplet/quickviewgramplet.py:144
 msgid "View Type"
 msgstr "Nézet típus"
 
-#: ../gramps/plugins/gramplet/quickviewgramplet.py:72
-#: ../gramps/plugins/gramplet/quickviewgramplet.py:79
-#: ../gramps/plugins/gramplet/quickviewgramplet.py:122
-#: ../gramps/plugins/gramplet/quickviewgramplet.py:144
+#: ../gramps/plugins/gramplet/quickviewgramplet.py:73
+#: ../gramps/plugins/gramplet/quickviewgramplet.py:80
+#: ../gramps/plugins/gramplet/quickviewgramplet.py:123
+#: ../gramps/plugins/gramplet/quickviewgramplet.py:145
 msgid "Quick Views"
 msgstr "Gyorsnézetek"
 
@@ -23379,26 +23504,26 @@ msgstr "Aktív személy: %s"
 
 #: ../gramps/plugins/gramplet/relativegramplet.py:88
 #, python-format
-msgid "%d. Partner: "
-msgstr "%d. Társ: "
+msgid "%(count)d. %(relation)s: "
+msgstr "%(count)d. %(relation)s: "
 
-#: ../gramps/plugins/gramplet/relativegramplet.py:92
+#: ../gramps/plugins/gramplet/relativegramplet.py:94
 #, python-format
 msgid "%d. Partner: Not known"
 msgstr "%d. Társ: nem ismert"
 
-#: ../gramps/plugins/gramplet/relativegramplet.py:107
+#: ../gramps/plugins/gramplet/relativegramplet.py:109
 msgid "Parents:"
 msgstr "Szülők:"
 
-#: ../gramps/plugins/gramplet/relativegramplet.py:119
-#: ../gramps/plugins/gramplet/relativegramplet.py:123
+#: ../gramps/plugins/gramplet/relativegramplet.py:121
+#: ../gramps/plugins/gramplet/relativegramplet.py:125
 #, python-format
 msgid "   %d.a Mother: "
 msgstr "   %d.a Anya: "
 
-#: ../gramps/plugins/gramplet/relativegramplet.py:130
-#: ../gramps/plugins/gramplet/relativegramplet.py:134
+#: ../gramps/plugins/gramplet/relativegramplet.py:132
+#: ../gramps/plugins/gramplet/relativegramplet.py:136
 #, python-format
 msgid "   %d.b Father: "
 msgstr "   %d.b Apa: "
@@ -23440,77 +23565,93 @@ msgstr "Kiválasztva"
 msgid "SoundEx code:"
 msgstr "SoundEx-kód:"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:54
+#: ../gramps/plugins/gramplet/statsgramplet.py:59
 msgid "Double-click item to see matches"
 msgstr "Kattintson kettőt az elemen a találatok megnézéséhez"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:87
+#: ../gramps/plugins/gramplet/statsgramplet.py:94
 #: ../gramps/plugins/textreport/summary.py:240
-#: ../gramps/plugins/webreport/statistics.py:105
+#: ../gramps/plugins/webreport/statistics.py:106
 msgid "less than 1"
 msgstr "kevesebb mint 1"
 
 #. -------------------------
-#: ../gramps/plugins/gramplet/statsgramplet.py:99
-#: ../gramps/plugins/graph/gvfamilylines.py:269
+#: ../gramps/plugins/gramplet/statsgramplet.py:140
+#: ../gramps/plugins/graph/gvfamilylines.py:276
 #: ../gramps/plugins/textreport/summary.py:113
-#: ../gramps/plugins/webreport/basepage.py:1485
-#: ../gramps/plugins/webreport/basepage.py:1543
-#: ../gramps/plugins/webreport/basepage.py:1608
-#: ../gramps/plugins/webreport/person.py:174
-#: ../gramps/plugins/webreport/statistics.py:116
-#: ../gramps/plugins/webreport/statistics.py:182
+#: ../gramps/plugins/webreport/basepage.py:1526
+#: ../gramps/plugins/webreport/basepage.py:1577
+#: ../gramps/plugins/webreport/basepage.py:1641
+#: ../gramps/plugins/webreport/person.py:179
+#: ../gramps/plugins/webreport/statistics.py:117
+#: ../gramps/plugins/webreport/statistics.py:183
 msgid "Individuals"
 msgstr "Személyek"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:101
-#: ../gramps/plugins/webreport/statistics.py:119
-#: ../gramps/plugins/webreport/statistics.py:183
+#: ../gramps/plugins/gramplet/statsgramplet.py:142
+#: ../gramps/plugins/webreport/statistics.py:120
+#: ../gramps/plugins/webreport/statistics.py:184
 msgid "Number of individuals"
 msgstr "Személyek száma"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:111
-#: ../gramps/plugins/webreport/statistics.py:125
-#: ../gramps/plugins/webreport/statistics.py:190
+#: ../gramps/plugins/gramplet/statsgramplet.py:152
+#: ../gramps/plugins/webreport/statistics.py:126
+#: ../gramps/plugins/webreport/statistics.py:191
 msgid "Individuals with unknown gender"
 msgstr "Személyek ismeretlen nemmel"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:115
+#: ../gramps/plugins/gramplet/statsgramplet.py:156
+msgid "Incomplete names"
+msgstr "Hiányos nevek"
+
+#: ../gramps/plugins/gramplet/statsgramplet.py:160
+msgid "Individuals missing birth dates"
+msgstr "Személyek hiányzó születési dátummal"
+
+#: ../gramps/plugins/gramplet/statsgramplet.py:164
+msgid "Disconnected individuals"
+msgstr "Nem kapcsolt személyek"
+
+#: ../gramps/plugins/gramplet/statsgramplet.py:168
 #: ../gramps/plugins/textreport/summary.py:211
-#: ../gramps/plugins/webreport/statistics.py:129
-#: ../gramps/plugins/webreport/statistics.py:194
+#: ../gramps/plugins/webreport/statistics.py:130
+#: ../gramps/plugins/webreport/statistics.py:195
 msgid "Family Information"
 msgstr "Családinformáció"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:122
-#: ../gramps/plugins/webreport/statistics.py:132
+#: ../gramps/plugins/gramplet/statsgramplet.py:175
+#: ../gramps/plugins/webreport/statistics.py:133
 msgid "Unique surnames"
 msgstr "Különleges vezetéknevek"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:126
+#: ../gramps/plugins/gramplet/statsgramplet.py:179
 #: ../gramps/plugins/textreport/summary.py:228
-#: ../gramps/plugins/webreport/statistics.py:136
+#: ../gramps/plugins/webreport/statistics.py:137
 msgid "Media Objects"
 msgstr "Média objektumok"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:128
-#: ../gramps/plugins/webreport/statistics.py:138
+#: ../gramps/plugins/gramplet/statsgramplet.py:181
+msgid "Individuals with media objects"
+msgstr "Személyek média objektumokkal"
+
+#: ../gramps/plugins/gramplet/statsgramplet.py:185
+#: ../gramps/plugins/webreport/statistics.py:139
 msgid "Total number of media object references"
 msgstr "A média objektum hivatkozások összes száma"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:132
-#: ../gramps/plugins/webreport/statistics.py:140
+#: ../gramps/plugins/gramplet/statsgramplet.py:189
+#: ../gramps/plugins/webreport/statistics.py:141
 msgid "Number of unique media objects"
 msgstr "Különleges média objektumok száma"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:137
-#: ../gramps/plugins/webreport/statistics.py:142
+#: ../gramps/plugins/gramplet/statsgramplet.py:194
+#: ../gramps/plugins/webreport/statistics.py:143
 msgid "Total size of media objects"
 msgstr "Média objektumok teljes mérete"
 
-#: ../gramps/plugins/gramplet/statsgramplet.py:141
+#: ../gramps/plugins/gramplet/statsgramplet.py:198
 #: ../gramps/plugins/textreport/summary.py:258
-#: ../gramps/plugins/webreport/statistics.py:146
+#: ../gramps/plugins/webreport/statistics.py:147
 msgid "Missing Media Objects"
 msgstr "Hiányzó média objektumok"
 
@@ -23546,25 +23687,29 @@ msgstr "Az összes különleges vezetéknév"
 msgid "Total surnames showing"
 msgstr "Összes vezetéknév mutatása"
 
-#: ../gramps/plugins/gramplet/todo.py:58
+#: ../gramps/plugins/gramplet/todo.py:60
 #: ../gramps/plugins/gramplet/todogramplet.py:60
 msgid "Previous To Do note"
 msgstr "Előző teendő feljegyzés"
 
-#: ../gramps/plugins/gramplet/todo.py:62
+#: ../gramps/plugins/gramplet/todo.py:64
 #: ../gramps/plugins/gramplet/todogramplet.py:64
 msgid "Next To Do note"
 msgstr "Következő teendő feljegyzés"
 
-#: ../gramps/plugins/gramplet/todo.py:66
+#: ../gramps/plugins/gramplet/todo.py:68
 #: ../gramps/plugins/gramplet/todogramplet.py:68
 msgid "Edit the selected To Do note"
 msgstr "A kiválasztott Teendő jegyzet szerkesztése"
 
-#: ../gramps/plugins/gramplet/todo.py:70
+#: ../gramps/plugins/gramplet/todo.py:72
 #: ../gramps/plugins/gramplet/todogramplet.py:72
 msgid "Add a new To Do note"
 msgstr "Új Teendő jegyzet hozzáadása"
+
+#: ../gramps/plugins/gramplet/todo.py:201
+msgid "First select the object to which you want to attach a note"
+msgstr "Először válassza ki az objektumot, amihez megjegyzést kíván fűzni"
 
 #: ../gramps/plugins/gramplet/todogramplet.py:149
 msgid "Unattached"
@@ -23711,97 +23856,97 @@ msgstr "Egy család befejezését jelző címke"
 msgid "Tag to indicate that a person or family should be ignored"
 msgstr "Egy személy, vagy család kihagyandóságát jelző címke"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:163
+#: ../gramps/plugins/gramplet/whatsnext.py:164
 msgid "No Home Person set."
 msgstr "Nincs kiinduló személy beállítva."
 
-#: ../gramps/plugins/gramplet/whatsnext.py:345
+#: ../gramps/plugins/gramplet/whatsnext.py:346
 msgid "first name unknown"
 msgstr "ismeretlen keresztnév"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:348
+#: ../gramps/plugins/gramplet/whatsnext.py:349
 msgid "surname unknown"
 msgstr "ismeretlen vezetéknév"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:352
-#: ../gramps/plugins/gramplet/whatsnext.py:383
-#: ../gramps/plugins/gramplet/whatsnext.py:410
-#: ../gramps/plugins/gramplet/whatsnext.py:417
-#: ../gramps/plugins/gramplet/whatsnext.py:455
-#: ../gramps/plugins/gramplet/whatsnext.py:462
+#: ../gramps/plugins/gramplet/whatsnext.py:353
+#: ../gramps/plugins/gramplet/whatsnext.py:384
+#: ../gramps/plugins/gramplet/whatsnext.py:411
+#: ../gramps/plugins/gramplet/whatsnext.py:418
+#: ../gramps/plugins/gramplet/whatsnext.py:456
+#: ../gramps/plugins/gramplet/whatsnext.py:463
 msgid "(person with unknown name)"
 msgstr "(személy ismeretlen névvel)"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:365
+#: ../gramps/plugins/gramplet/whatsnext.py:366
 msgid "birth event missing"
 msgstr "születési esemény hiányzik"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:369
-#: ../gramps/plugins/gramplet/whatsnext.py:391
-#: ../gramps/plugins/gramplet/whatsnext.py:439
-#: ../gramps/plugins/gramplet/whatsnext.py:472
+#: ../gramps/plugins/gramplet/whatsnext.py:370
+#: ../gramps/plugins/gramplet/whatsnext.py:392
+#: ../gramps/plugins/gramplet/whatsnext.py:440
+#: ../gramps/plugins/gramplet/whatsnext.py:473
 #, python-format
 msgid ": %(list)s\n"
 msgstr ": %(list)s\n"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:387
+#: ../gramps/plugins/gramplet/whatsnext.py:388
 msgid "person not complete"
 msgstr "a személy nem befejezett"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:406
-#: ../gramps/plugins/gramplet/whatsnext.py:413
-#: ../gramps/plugins/gramplet/whatsnext.py:451
-#: ../gramps/plugins/gramplet/whatsnext.py:458
+#: ../gramps/plugins/gramplet/whatsnext.py:407
+#: ../gramps/plugins/gramplet/whatsnext.py:414
+#: ../gramps/plugins/gramplet/whatsnext.py:452
+#: ../gramps/plugins/gramplet/whatsnext.py:459
 msgid "(unknown person)"
 msgstr "(ismeretlen személy)"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:419
-#: ../gramps/plugins/gramplet/whatsnext.py:464
+#: ../gramps/plugins/gramplet/whatsnext.py:420
+#: ../gramps/plugins/gramplet/whatsnext.py:465
 #, python-format
 msgid "%(name1)s and %(name2)s"
 msgstr "%(name1)s és %(name2)s"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:433
+#: ../gramps/plugins/gramplet/whatsnext.py:434
 msgid "marriage event missing"
 msgstr "házassági esemény hiányzik"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:435
+#: ../gramps/plugins/gramplet/whatsnext.py:436
 msgid "relation type unknown"
 msgstr "ismeretlen kapcsolat típus"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:468
+#: ../gramps/plugins/gramplet/whatsnext.py:469
 msgid "family not complete"
 msgstr "a család nem befejezett"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:483
+#: ../gramps/plugins/gramplet/whatsnext.py:484
 msgid "date unknown"
 msgstr "ismeretlen dátum"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:485
+#: ../gramps/plugins/gramplet/whatsnext.py:486
 msgid "date incomplete"
 msgstr "hiányos dátum"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:489
+#: ../gramps/plugins/gramplet/whatsnext.py:490
 msgid "place unknown"
 msgstr "ismeretlen hely"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:501
+#: ../gramps/plugins/gramplet/whatsnext.py:502
 msgid "spouse missing"
 msgstr "hiányzó házastárs"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:505
+#: ../gramps/plugins/gramplet/whatsnext.py:506
 msgid "father missing"
 msgstr "hiányzó apa"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:509
+#: ../gramps/plugins/gramplet/whatsnext.py:510
 msgid "mother missing"
 msgstr "hiányzó anya"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:513
+#: ../gramps/plugins/gramplet/whatsnext.py:514
 msgid "parents missing"
 msgstr "hiányzó szülők"
 
-#: ../gramps/plugins/gramplet/whatsnext.py:520
+#: ../gramps/plugins/gramplet/whatsnext.py:521
 #, python-format
 msgid ": %s\n"
 msgstr ": %s\n"
@@ -23823,7 +23968,7 @@ msgid "Produces an hourglass graph using Graphviz."
 msgstr "Óraüveg diagramot hoz létre GrahWiz-zel."
 
 #: ../gramps/plugins/graph/graphplugins.gpr.py:81
-#: ../gramps/plugins/graph/gvrelgraph.py:204
+#: ../gramps/plugins/graph/gvrelgraph.py:207
 msgid "Relationship Graph"
 msgstr "Kapcsolat diagram"
 
@@ -23837,19 +23982,19 @@ msgstr "Kapcsolat diagramot hoz létre GrahWiz-zel."
 #.
 #. ------------------------------------------------------------------------
 #: ../gramps/plugins/graph/gvfamilylines.py:73
-#: ../gramps/plugins/graph/gvhourglass.py:57
+#: ../gramps/plugins/graph/gvhourglass.py:58
 #: ../gramps/plugins/graph/gvrelgraph.py:72
 msgid "B&W outline"
 msgstr "Fekete-fehér körvonal"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:74
-#: ../gramps/plugins/graph/gvhourglass.py:58
+#: ../gramps/plugins/graph/gvhourglass.py:59
 #: ../gramps/plugins/graph/gvrelgraph.py:73
 msgid "Colored outline"
 msgstr "Színes keret"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:75
-#: ../gramps/plugins/graph/gvhourglass.py:59
+#: ../gramps/plugins/graph/gvhourglass.py:60
 #: ../gramps/plugins/graph/gvrelgraph.py:74
 msgid "Color fill"
 msgstr "Szín kitöltés"
@@ -23874,12 +24019,28 @@ msgstr "Leszármazottak <-> ősök"
 msgid "Descendants - Ancestors"
 msgstr "Leszármazottak - ősök"
 
+#: ../gramps/plugins/graph/gvfamilylines.py:83
+#: ../gramps/plugins/textreport/indivcomplete.py:938
+#: ../gramps/plugins/tool/dumpgenderstats.py:73
+#: ../gramps/plugins/tool/dumpgenderstats.py:97
+#: ../gramps/plugins/tool/dumpgenderstats.py:99
+msgid "Female"
+msgstr "Nő"
+
+#: ../gramps/plugins/graph/gvfamilylines.py:84
+#: ../gramps/plugins/textreport/indivcomplete.py:936
+#: ../gramps/plugins/tool/dumpgenderstats.py:72
+#: ../gramps/plugins/tool/dumpgenderstats.py:96
+#: ../gramps/plugins/tool/dumpgenderstats.py:99
+msgid "Male"
+msgstr "Férfi"
+
 #. ---------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:119
+#: ../gramps/plugins/graph/gvfamilylines.py:124
 msgid "Follow parents to determine \"family lines\""
 msgstr "Szülők követése a \"családvonalak\" meghatározásához"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:121
+#: ../gramps/plugins/graph/gvfamilylines.py:126
 msgid ""
 "Parents and their ancestors will be considered when determining \"family "
 "lines\"."
@@ -23887,19 +24048,19 @@ msgstr ""
 "Szülők és azok ősei lesznek figyelembe véve \"családvonalak\" "
 "meghatározásakor."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:125
+#: ../gramps/plugins/graph/gvfamilylines.py:130
 msgid "Follow children to determine \"family lines\""
 msgstr "Gyermekek követése \"családvonalak\" meghatározásához"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:127
+#: ../gramps/plugins/graph/gvfamilylines.py:132
 msgid "Children will be considered when determining \"family lines\"."
 msgstr "Gyermekek lesznek figyelembe véve \"családvonalak\" meghatározásakor."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:131
+#: ../gramps/plugins/graph/gvfamilylines.py:136
 msgid "Try to remove extra people and families"
 msgstr "Plusz emberek és családok eltávolításának kísérlete"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:133
+#: ../gramps/plugins/graph/gvfamilylines.py:138
 msgid ""
 "People and families not directly related to people of interest will be "
 "removed when determining \"family lines\"."
@@ -23907,25 +24068,25 @@ msgstr ""
 "A célszemélyekhez nem közvetlenül kapcsolódó személyek és családok "
 "eltávolításra kerülnek a \"családvonalak\" meghatározásakor."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:139
-#: ../gramps/plugins/graph/gvhourglass.py:331
-#: ../gramps/plugins/graph/gvrelgraph.py:778
+#: ../gramps/plugins/graph/gvfamilylines.py:144
+#: ../gramps/plugins/graph/gvhourglass.py:380
+#: ../gramps/plugins/graph/gvrelgraph.py:812
 msgid "Arrowhead direction"
 msgstr "Nyílhegy iránya"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:142
-#: ../gramps/plugins/graph/gvhourglass.py:334
-#: ../gramps/plugins/graph/gvrelgraph.py:781
+#: ../gramps/plugins/graph/gvfamilylines.py:147
+#: ../gramps/plugins/graph/gvhourglass.py:383
+#: ../gramps/plugins/graph/gvrelgraph.py:815
 msgid "Choose the direction that the arrows point."
 msgstr "Válassza ki az irányt, amerre a nyíl mutatni fog."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:145
-#: ../gramps/plugins/graph/gvhourglass.py:337
-#: ../gramps/plugins/graph/gvrelgraph.py:784
+#: ../gramps/plugins/graph/gvfamilylines.py:150
+#: ../gramps/plugins/graph/gvhourglass.py:386
+#: ../gramps/plugins/graph/gvrelgraph.py:818
 msgid "Graph coloring"
 msgstr "Diagram színezés"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:148
+#: ../gramps/plugins/graph/gvfamilylines.py:153
 msgid ""
 "Males will be shown with blue, females with red, unless otherwise set above "
 "for filled. If the sex of an individual is unknown it will be shown with "
@@ -23934,30 +24095,26 @@ msgstr ""
 "A férfiak kékkel, a nők pirossal lesznek mutatva, amíg fentebb más nem lesz "
 "beállítva. Ha egy személy neme ismeretlen, az szürke lesz."
 
-#. see bug report #2180
-#: ../gramps/plugins/graph/gvfamilylines.py:154
-#: ../gramps/plugins/graph/gvhourglass.py:345
-#: ../gramps/plugins/graph/gvrelgraph.py:793
-msgid "Use rounded corners"
-msgstr "Lekerekített sarkok használata"
+#: ../gramps/plugins/graph/gvfamilylines.py:159
+msgid "Rounded corners"
+msgstr "Lekerekített sarkok"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:156
-#: ../gramps/plugins/graph/gvhourglass.py:347
-#: ../gramps/plugins/graph/gvrelgraph.py:794
-msgid "Use rounded corners to differentiate between women and men."
-msgstr "Lekerekített sarkok használata a nők és férfiak megkülönböztetéséhez."
+#: ../gramps/plugins/graph/gvfamilylines.py:162
+msgid "Use rounded corners e.g. to differentiate between women and men."
+msgstr ""
+"Lekerekített sarkok használata pl. nők és férfiak megkülönböztetéséhez."
 
 #. --------------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:177
+#: ../gramps/plugins/graph/gvfamilylines.py:184
 msgid "People of Interest"
 msgstr "Célszemélyek"
 
 #. --------------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:180
+#: ../gramps/plugins/graph/gvfamilylines.py:187
 msgid "People of interest"
 msgstr "Célszemélyek"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:181
+#: ../gramps/plugins/graph/gvfamilylines.py:188
 msgid ""
 "People of interest are used as a starting point when determining \"family "
 "lines\"."
@@ -23965,44 +24122,44 @@ msgstr ""
 "A célszemélyeket mint kiindulási pont használjuk, amikor \"családvonalakat\" "
 "határozunk meg."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:185
+#: ../gramps/plugins/graph/gvfamilylines.py:192
 msgid "Limit the number of ancestors"
 msgstr "Ősök számának korlátozása"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:187
+#: ../gramps/plugins/graph/gvfamilylines.py:194
 msgid "Whether to limit the number of ancestors."
 msgstr "Korlátozva legyen-e az ősök száma."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:193
+#: ../gramps/plugins/graph/gvfamilylines.py:200
 msgid "The maximum number of ancestors to include."
 msgstr "A vizsgált ősök legnagyobb száma."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:197
+#: ../gramps/plugins/graph/gvfamilylines.py:204
 msgid "Limit the number of descendants"
 msgstr "Leszármazottak számának korlátozása"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:200
+#: ../gramps/plugins/graph/gvfamilylines.py:207
 msgid "Whether to limit the number of descendants."
 msgstr "Legyen-e korlátozva a leszármazottak száma."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:206
+#: ../gramps/plugins/graph/gvfamilylines.py:213
 msgid "The maximum number of descendants to include."
 msgstr "A vizsgálandó leszármazottak legnagyobb száma."
 
 #. --------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:215
+#: ../gramps/plugins/graph/gvfamilylines.py:222
 msgid "Include dates"
 msgstr "Dátumokkal együtt"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:216
+#: ../gramps/plugins/graph/gvfamilylines.py:223
 msgid "Whether to include dates for people and families."
 msgstr "Benne legyenek-e dátumok az embereknél és a családoknál."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:221
+#: ../gramps/plugins/graph/gvfamilylines.py:228
 msgid "Limit dates to years only"
 msgstr "Dátumok korlátozása csak évekre"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:222
+#: ../gramps/plugins/graph/gvfamilylines.py:229
 msgid ""
 "Prints just dates' year, neither month or day nor date approximation or "
 "interval are shown."
@@ -24010,198 +24167,198 @@ msgstr ""
 "Csak a dátum évét nyomtatja, sem a hónap, vagy nap; sem a közelített, vagy a "
 "dátumköz nem mutatott."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:228
+#: ../gramps/plugins/graph/gvfamilylines.py:235
 msgid "Whether to include placenames for people and families."
 msgstr "Benne legyenek-e a helynevek az embereknél és családoknál."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:232
+#: ../gramps/plugins/graph/gvfamilylines.py:239
 msgid "Include the number of children"
 msgstr "A gyermekek számával együtt"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:234
+#: ../gramps/plugins/graph/gvfamilylines.py:241
 msgid ""
 "Whether to include the number of children for families with more than 1 "
 "child."
 msgstr ""
 "Mutatva legyenek-e a családok gyermekszámai egynél több gyermek esetén."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:239
-#: ../gramps/plugins/graph/gvrelgraph.py:859
+#: ../gramps/plugins/graph/gvfamilylines.py:246
+#: ../gramps/plugins/graph/gvrelgraph.py:904
 msgid "Include thumbnail images of people"
 msgstr "Az emberek bélyegképeivel együtt"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:242
+#: ../gramps/plugins/graph/gvfamilylines.py:249
 msgid "Whether to include thumbnail images of people."
 msgstr "Legyenek-e benne az emberek bélyegképei."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:247
+#: ../gramps/plugins/graph/gvfamilylines.py:254
 msgid "Thumbnail location"
 msgstr "Bélyegkép helye"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:248
-#: ../gramps/plugins/graph/gvrelgraph.py:866
+#: ../gramps/plugins/graph/gvfamilylines.py:255
+#: ../gramps/plugins/graph/gvrelgraph.py:911
 msgid "Above the name"
 msgstr "A név felett"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:249
-#: ../gramps/plugins/graph/gvrelgraph.py:867
+#: ../gramps/plugins/graph/gvfamilylines.py:256
+#: ../gramps/plugins/graph/gvrelgraph.py:912
 msgid "Beside the name"
 msgstr "A név mellett"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:250
-#: ../gramps/plugins/graph/gvrelgraph.py:869
+#: ../gramps/plugins/graph/gvfamilylines.py:257
+#: ../gramps/plugins/graph/gvrelgraph.py:914
 msgid "Where the thumbnail image should appear relative to the name"
 msgstr "Hol jelenjen meg a bélyegkép a névhez viszonyítva"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:254
+#: ../gramps/plugins/graph/gvfamilylines.py:261
 msgid "Thumbnail size"
 msgstr "Bélyegkép méret"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:257
+#: ../gramps/plugins/graph/gvfamilylines.py:264
 msgid "Size of the thumbnail image"
 msgstr "A bélyegkép mérete"
 
 #. ----------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:261
+#: ../gramps/plugins/graph/gvfamilylines.py:268
 msgid "Family Colors"
 msgstr "Család színek"
 
 #. ----------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:264
+#: ../gramps/plugins/graph/gvfamilylines.py:271
 msgid "Family colors"
 msgstr "Család színek"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:265
+#: ../gramps/plugins/graph/gvfamilylines.py:272
 msgid "Colors to use for various family lines."
 msgstr "A különböző családvonalakhoz használt színek."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:273
-#: ../gramps/plugins/graph/gvhourglass.py:369
-#: ../gramps/plugins/graph/gvrelgraph.py:896
+#: ../gramps/plugins/graph/gvfamilylines.py:280
+#: ../gramps/plugins/graph/gvhourglass.py:420
+#: ../gramps/plugins/graph/gvrelgraph.py:941
 msgid "The color to use to display men."
 msgstr "Férfiakat mutató szín."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:277
-#: ../gramps/plugins/graph/gvhourglass.py:373
-#: ../gramps/plugins/graph/gvrelgraph.py:900
+#: ../gramps/plugins/graph/gvfamilylines.py:284
+#: ../gramps/plugins/graph/gvhourglass.py:424
+#: ../gramps/plugins/graph/gvrelgraph.py:945
 msgid "The color to use to display women."
 msgstr "Nőket mutató szín."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:281
-#: ../gramps/plugins/graph/gvhourglass.py:377
-#: ../gramps/plugins/graph/gvrelgraph.py:905
+#: ../gramps/plugins/graph/gvfamilylines.py:288
+#: ../gramps/plugins/graph/gvhourglass.py:428
+#: ../gramps/plugins/graph/gvrelgraph.py:950
 msgid "The color to use when the gender is unknown."
 msgstr "Ismeretlen nem színe."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:286
-#: ../gramps/plugins/graph/gvhourglass.py:382
-#: ../gramps/plugins/graph/gvrelgraph.py:910
+#: ../gramps/plugins/graph/gvfamilylines.py:293
+#: ../gramps/plugins/graph/gvhourglass.py:433
+#: ../gramps/plugins/graph/gvrelgraph.py:955
 msgid "The color to use to display families."
 msgstr "Családokat mutató szín."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:398
+#: ../gramps/plugins/graph/gvfamilylines.py:405
 #: ../gramps/plugins/textreport/familygroup.py:680
 #: ../gramps/plugins/textreport/indivcomplete.py:829
 msgid "Empty report"
 msgstr "Üres összesítő"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:399
+#: ../gramps/plugins/graph/gvfamilylines.py:406
 #: ../gramps/plugins/textreport/familygroup.py:681
 #: ../gramps/plugins/textreport/indivcomplete.py:830
 msgid "You did not specify anybody"
 msgstr "Senkit sem határozott meg"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:458
+#: ../gramps/plugins/graph/gvfamilylines.py:465
 msgid "Number of people in database:"
 msgstr "Személyek száma az adatbázisban:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:461
+#: ../gramps/plugins/graph/gvfamilylines.py:468
 msgid "Number of people of interest:"
 msgstr "Célszemélyek száma:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:464
+#: ../gramps/plugins/graph/gvfamilylines.py:471
 msgid "Number of families in database:"
 msgstr "Családok száma az adatbázisban:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:467
+#: ../gramps/plugins/graph/gvfamilylines.py:474
 msgid "Number of families of interest:"
 msgstr "Cél családok száma:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:471
+#: ../gramps/plugins/graph/gvfamilylines.py:478
 msgid "Additional people removed:"
 msgstr "További eltávolított személyek:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:474
+#: ../gramps/plugins/graph/gvfamilylines.py:481
 msgid "Additional families removed:"
 msgstr "További eltávolított családok:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:477
+#: ../gramps/plugins/graph/gvfamilylines.py:484
 msgid "Initial list of people of interest:"
 msgstr "Célszemélyek kezdő listája:"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/graph/gvfamilylines.py:970
+#: ../gramps/plugins/graph/gvfamilylines.py:982
 #, python-brace-format
 msgid "{number_of} child"
 msgid_plural "{number_of} children"
 msgstr[0] "{number_of} gyermek"
 msgstr[1] "{number_of} gyermek"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:1045
+#: ../gramps/plugins/graph/gvfamilylines.py:1057
 #, python-format
 msgid "father: %s"
 msgstr "apa: %s"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:1055
+#: ../gramps/plugins/graph/gvfamilylines.py:1067
 #, python-format
 msgid "mother: %s"
 msgstr "anya: %s"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:1068
+#: ../gramps/plugins/graph/gvfamilylines.py:1080
 #, python-format
 msgid "child: %s"
 msgstr "gyermek: %s"
 
-#: ../gramps/plugins/graph/gvhourglass.py:61
+#: ../gramps/plugins/graph/gvhourglass.py:62
 msgid "Center -> Others"
 msgstr "Központi -> Mások"
 
-#: ../gramps/plugins/graph/gvhourglass.py:62
+#: ../gramps/plugins/graph/gvhourglass.py:63
 msgid "Center <- Others"
 msgstr "Központi <- Mások"
 
-#: ../gramps/plugins/graph/gvhourglass.py:63
+#: ../gramps/plugins/graph/gvhourglass.py:64
 msgid "Center <-> Other"
 msgstr "Központi <-> Más"
 
-#: ../gramps/plugins/graph/gvhourglass.py:64
+#: ../gramps/plugins/graph/gvhourglass.py:65
 msgid "Center - Other"
 msgstr "Központi - Más"
 
-#: ../gramps/plugins/graph/gvhourglass.py:318
+#: ../gramps/plugins/graph/gvhourglass.py:367
 msgid "The Center person for the graph"
 msgstr "A diagram központi személye"
 
-#: ../gramps/plugins/graph/gvhourglass.py:321
+#: ../gramps/plugins/graph/gvhourglass.py:370
 #: ../gramps/plugins/textreport/kinshipreport.py:362
 msgid "Max Descendant Generations"
 msgstr "Leszármazott generációk legnagyobb száma"
 
-#: ../gramps/plugins/graph/gvhourglass.py:322
+#: ../gramps/plugins/graph/gvhourglass.py:371
 msgid "The number of generations of descendants to include in the graph"
 msgstr "A diagramban szereplő leszármazott generációk száma"
 
-#: ../gramps/plugins/graph/gvhourglass.py:326
+#: ../gramps/plugins/graph/gvhourglass.py:375
 #: ../gramps/plugins/textreport/kinshipreport.py:366
 msgid "Max Ancestor Generations"
 msgstr "Ős generációk legnagyobb száma"
 
-#: ../gramps/plugins/graph/gvhourglass.py:327
+#: ../gramps/plugins/graph/gvhourglass.py:376
 msgid "The number of generations of ancestors to include in the graph"
 msgstr "A diagramban szereplő ősök generációinak száma"
 
-#: ../gramps/plugins/graph/gvhourglass.py:340
-#: ../gramps/plugins/graph/gvrelgraph.py:787
+#: ../gramps/plugins/graph/gvhourglass.py:389
+#: ../gramps/plugins/graph/gvrelgraph.py:821
 msgid ""
 "Males will be shown with blue, females with red.  If the sex of an "
 "individual is unknown it will be shown with gray."
@@ -24209,73 +24366,130 @@ msgstr ""
 "A férfiak kékkel, a nők pirossal lesznek mutatva. Ha egy személy neme "
 "ismeretlen, az szürke lesz."
 
+#. see bug report #2180
+#: ../gramps/plugins/graph/gvhourglass.py:394
+#: ../gramps/plugins/graph/gvrelgraph.py:827
+msgid "Use rounded corners"
+msgstr "Lekerekített sarkok használata"
+
+#: ../gramps/plugins/graph/gvhourglass.py:396
+#: ../gramps/plugins/graph/gvrelgraph.py:828
+msgid "Use rounded corners to differentiate between women and men."
+msgstr "Lekerekített sarkok használata a nők és férfiak megkülönböztetéséhez."
+
 #. ###############################
-#: ../gramps/plugins/graph/gvhourglass.py:365
-#: ../gramps/plugins/graph/gvrelgraph.py:892
+#: ../gramps/plugins/graph/gvhourglass.py:416
+#: ../gramps/plugins/graph/gvrelgraph.py:937
 msgid "Graph Style"
 msgstr "Diagram stílus"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:205
+#: ../gramps/plugins/graph/gvhourglass.py:436
+msgid "Force Ahnentafel order"
+msgstr "Kikényszerített leszármazási sorrend"
+
+#: ../gramps/plugins/graph/gvhourglass.py:438
+msgid ""
+"Force Sosa / Sosa-Stradonitz / Ahnentafel layout order for all ancestors, so "
+"that fathers are always on the left branch and mothers are on the right "
+"branch."
+msgstr ""
+"Minden ős kikényszerített Sosa / Sosa-Stradonitz / Leszármazási rétegű "
+"rendezése, hogy az apák mindig bal, az anyák a jobb oldali csoportokba "
+"kerülnek."
+
+#: ../gramps/plugins/graph/gvhourglass.py:441
+msgid "Ahnentafel number visible"
+msgstr "Látható leszármazási szám"
+
+#: ../gramps/plugins/graph/gvhourglass.py:443
+msgid ""
+"Show Sosa / Sosa-Stradonitz / Ahnentafel number under all others "
+"informations."
+msgstr ""
+"Mindenki más információi alatt a Sosa / Sosa-Stradonitz / Leszármazási szám "
+"mutatása"
+
+#: ../gramps/plugins/graph/gvrelgraph.py:208
 #: ../gramps/plugins/textreport/indivcomplete.py:834
 #: ../gramps/plugins/textreport/notelinkreport.py:103
 #: ../gramps/plugins/textreport/placereport.py:160
 msgid "Generating report"
 msgstr "Összesítő generálása"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:769
+#: ../gramps/plugins/graph/gvrelgraph.py:803
 msgid "Determines what people are included in the graph"
 msgstr "Meghatározza, kik legyenek a diagramban"
 
+#. see bug report #11112
+#: ../gramps/plugins/graph/gvrelgraph.py:833
+msgid "Use hexagons"
+msgstr "Hatszögek használata"
+
+#: ../gramps/plugins/graph/gvrelgraph.py:834
+msgid "Use hexagons to differentiate those of unknown gender."
+msgstr "Hatszögek használata ismeretlen neműek megkülönböztetéséhez."
+
 #. ###############################
-#: ../gramps/plugins/graph/gvrelgraph.py:822
+#: ../gramps/plugins/graph/gvrelgraph.py:862
 msgid "Dates and/or Places"
 msgstr "Dátumok és/vagy helyek"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:823
+#: ../gramps/plugins/graph/gvrelgraph.py:863
 msgid "Do not include any dates or places"
 msgstr "Ne legyen benne egyetlen dátum vagy hely"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:824
+#: ../gramps/plugins/graph/gvrelgraph.py:864
 msgid "Include (birth, marriage, death) dates, but no places"
 msgstr "Születési, házassági és halálozási időpontokkal együtt, de hely nélkül"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:826
+#: ../gramps/plugins/graph/gvrelgraph.py:866
 msgid "Include (birth, marriage, death) dates, and places"
 msgstr "Születési, házassági, halálozási időpontokkal együtt, és helyekkel"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:828
+#: ../gramps/plugins/graph/gvrelgraph.py:868
 msgid "Include (birth, marriage, death) dates, and places if no dates"
 msgstr ""
 "Születési, házassági, halálozási időpontokkal együtt, és helyek ha nincsenek "
 "dátumok"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:830
+#: ../gramps/plugins/graph/gvrelgraph.py:870
 msgid "Include (birth, marriage, death) years, but no places"
 msgstr "Születési, házassági, halálozási évekkel együtt, de helyek nélkül"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:832
+#: ../gramps/plugins/graph/gvrelgraph.py:872
 msgid "Include (birth, marriage, death) years, and places"
 msgstr "Születési, házassági, halálozási évekkel együtt, és helyek"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:834
+#: ../gramps/plugins/graph/gvrelgraph.py:874
 msgid "Include (birth, marriage, death) places, but no dates"
 msgstr "Születési, házassági, halálozási évekkel együtt, de dátumok nélkül"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:836
+#: ../gramps/plugins/graph/gvrelgraph.py:876
 msgid "Include (birth, marriage, death) dates and places on same line"
 msgstr ""
 "Születési, házassági, halálozási időpontokkal és helyekkel ugyanabban a "
 "sorban"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:839
+#: ../gramps/plugins/graph/gvrelgraph.py:879
 msgid "Whether to include dates and/or places"
 msgstr "Legyenek-e benne a dátumok és/vagy helyek"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:842
+#: ../gramps/plugins/graph/gvrelgraph.py:882
+msgid "Show all family nodes"
+msgstr "Minden Család-csomópont mutatása"
+
+#: ../gramps/plugins/graph/gvrelgraph.py:883
+msgid ""
+"Show family nodes even if the output contains only one member of the family."
+msgstr ""
+"Család-csomópont mutatása akkor is, ha a kimeneten csak egy családtag van a "
+"családban."
+
+#: ../gramps/plugins/graph/gvrelgraph.py:887
 msgid "Include URLs"
 msgstr "URL-ekkel együtt"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:843
+#: ../gramps/plugins/graph/gvrelgraph.py:888
 msgid ""
 "Include a URL in each graph node so that PDF and imagemap files can be "
 "generated that contain active links to the files generated by the 'Narrated "
@@ -24285,68 +24499,68 @@ msgstr ""
 "imagemap fájlok létrehozáskor tartalmazzanak aktív linkeket a 'Web Site "
 "Létrehozó' összegző által létrehozott fájlokhoz."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:851
-#: ../gramps/plugins/textreport/birthdayreport.py:494
-#: ../gramps/plugins/textreport/indivcomplete.py:1144
+#: ../gramps/plugins/graph/gvrelgraph.py:896
+#: ../gramps/plugins/textreport/birthdayreport.py:568
+#: ../gramps/plugins/textreport/indivcomplete.py:1145
 msgid "Include relationship to center person"
 msgstr "A központi személyre vonatkozó kapcsolatokkal együtt"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:852
+#: ../gramps/plugins/graph/gvrelgraph.py:897
 msgid "Whether to show every person's relationship to the center person"
 msgstr "Mutassa-e minden személy kapcsolatát a központi személlyel"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:861
+#: ../gramps/plugins/graph/gvrelgraph.py:906
 msgid "Whether to include thumbnails of people."
 msgstr "Legyenek-e benne az emberek bélyegképei."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:865
+#: ../gramps/plugins/graph/gvrelgraph.py:910
 msgid "Thumbnail Location"
 msgstr "Bélyegkép helye"
 
 #. occupation = BooleanOption(_("Include occupation"), False)
-#: ../gramps/plugins/graph/gvrelgraph.py:873
+#: ../gramps/plugins/graph/gvrelgraph.py:918
 msgid "Include occupation"
 msgstr "A foglalkozással együtt"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:874
+#: ../gramps/plugins/graph/gvrelgraph.py:919
 msgid "Do not include any occupation"
 msgstr "Ne legyen semmilyen foglalkozás"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:875
+#: ../gramps/plugins/graph/gvrelgraph.py:920
 msgid "Include description of most recent occupation"
 msgstr "A legfrissebb foglalkozás leírásával együtt"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:877
+#: ../gramps/plugins/graph/gvrelgraph.py:922
 msgid "Include date, description and place of all occupations"
 msgstr "Az összes foglalkozás dátummal, leírással és hellyel együtt"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:879
+#: ../gramps/plugins/graph/gvrelgraph.py:924
 msgid "Whether to include the last occupation"
 msgstr "Legyen-e benne az utolsó foglalkozás"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:883
+#: ../gramps/plugins/graph/gvrelgraph.py:928
 msgid "Include relationship debugging numbers also"
 msgstr "A kapcsolatok hibakeresési számaival együtt"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:886
+#: ../gramps/plugins/graph/gvrelgraph.py:931
 msgid ""
 "Whether to include 'Ga' and 'Gb' also, to debug the relationship calculator"
 msgstr ""
 "Legyen-e a 'Ga' és 'Gb' is benne a kapcsolat kalkulátor hibakeresésénél"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:914
+#: ../gramps/plugins/graph/gvrelgraph.py:959
 msgid "Indicate non-birth relationships with dotted lines"
 msgstr "A nem édes-szülői kapcsolatot pontozott vonal jelezze"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:915
+#: ../gramps/plugins/graph/gvrelgraph.py:960
 msgid "Non-birth relationships will show up as dotted lines in the graph."
 msgstr "A nem édes-szülői kapcsolatokat pontozott vonalak jelzik a grafikonon."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:919
+#: ../gramps/plugins/graph/gvrelgraph.py:964
 msgid "Show family nodes"
 msgstr "Család-csomópontok mutatása"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:920
+#: ../gramps/plugins/graph/gvrelgraph.py:965
 msgid "Families will show up as ellipses, linked to parents and children."
 msgstr ""
 "A családok a gyermekekre és szülőkre hivatkozó ellipszisként jelennek meg."
@@ -24403,11 +24617,11 @@ msgstr "Adatimportálás Pro-Gen fájlokból"
 msgid "Import data from vCard files"
 msgstr "Adatimportálás vCard fájlokból"
 
-#: ../gramps/plugins/importer/importcsv.py:123
+#: ../gramps/plugins/importer/importcsv.py:124
 #: ../gramps/plugins/importer/importgedcom.py:129
 #: ../gramps/plugins/importer/importgedcom.py:143
-#: ../gramps/plugins/importer/importgeneweb.py:152
-#: ../gramps/plugins/importer/importgeneweb.py:158
+#: ../gramps/plugins/importer/importgeneweb.py:153
+#: ../gramps/plugins/importer/importgeneweb.py:159
 #: ../gramps/plugins/importer/importvcard.py:69
 #: ../gramps/plugins/importer/importvcard.py:72
 #, python-format
@@ -24418,200 +24632,296 @@ msgstr "%s nem megnyitható\n"
 #. # (but the imports_test.py unittest currently requires it, so here it is)
 #. # a "VCARD import report" happens in VCardParser so this is not needed:
 #. # (but the imports_test.py unittest currently requires it, so here it is)
-#: ../gramps/plugins/importer/importcsv.py:125
+#: ../gramps/plugins/importer/importcsv.py:126
 #: ../gramps/plugins/importer/importgedcom.py:154
-#: ../gramps/plugins/importer/importgeneweb.py:161
-#: ../gramps/plugins/importer/importprogen.py:92
+#: ../gramps/plugins/importer/importgeneweb.py:162
+#: ../gramps/plugins/importer/importprogen.py:197
 #: ../gramps/plugins/importer/importvcard.py:76
 msgid "Results"
 msgstr "Eredmények"
 
-#: ../gramps/plugins/importer/importcsv.py:125
+#: ../gramps/plugins/importer/importcsv.py:126
 #: ../gramps/plugins/importer/importgedcom.py:154
-#: ../gramps/plugins/importer/importgeneweb.py:161
-#: ../gramps/plugins/importer/importprogen.py:92
+#: ../gramps/plugins/importer/importgeneweb.py:162
+#: ../gramps/plugins/importer/importprogen.py:197
 #: ../gramps/plugins/importer/importvcard.py:76
 msgid "done"
 msgstr "kész"
 
-#: ../gramps/plugins/importer/importcsv.py:161
+#: ../gramps/plugins/importer/importcsv.py:162
 msgid "given name"
 msgstr "utónév"
 
-#: ../gramps/plugins/importer/importcsv.py:164
+#: ../gramps/plugins/importer/importcsv.py:165
 msgid "call"
 msgstr "hívás"
 
-#: ../gramps/plugins/importer/importcsv.py:165
+#: ../gramps/plugins/importer/importcsv.py:166
 msgid "Person or Place|title"
 msgstr "Person or Place|cím"
 
-#: ../gramps/plugins/importer/importcsv.py:165
+#: ../gramps/plugins/importer/importcsv.py:166
 msgid "title"
 msgstr "cím"
 
-#: ../gramps/plugins/importer/importcsv.py:168
+#: ../gramps/plugins/importer/importcsv.py:169
 msgid "gender"
 msgstr "nem"
 
-#: ../gramps/plugins/importer/importcsv.py:169
+#: ../gramps/plugins/importer/importcsv.py:170
 msgid "source"
 msgstr "forrás"
 
-#: ../gramps/plugins/importer/importcsv.py:170
+#: ../gramps/plugins/importer/importcsv.py:171
 msgid "note"
 msgstr "jegyzet"
 
-#: ../gramps/plugins/importer/importcsv.py:172
+#: ../gramps/plugins/importer/importcsv.py:173
 msgid "birth place"
 msgstr "születési hely"
 
-#: ../gramps/plugins/importer/importcsv.py:174
+#: ../gramps/plugins/importer/importcsv.py:175
 msgid "birth place id"
 msgstr "születési hely azonosító"
 
-#: ../gramps/plugins/importer/importcsv.py:179
+#: ../gramps/plugins/importer/importcsv.py:180
 msgid "birth source"
 msgstr "születés forrása"
 
-#: ../gramps/plugins/importer/importcsv.py:181
+#: ../gramps/plugins/importer/importcsv.py:182
 msgid "baptism place"
 msgstr "keresztelés helye"
 
-#: ../gramps/plugins/importer/importcsv.py:183
+#: ../gramps/plugins/importer/importcsv.py:184
 msgid "baptism place id"
 msgstr "keresztelés helyének azonosítója"
 
-#: ../gramps/plugins/importer/importcsv.py:185
+#: ../gramps/plugins/importer/importcsv.py:186
 msgid "baptism date"
 msgstr "keresztelés dátuma"
 
-#: ../gramps/plugins/importer/importcsv.py:187
+#: ../gramps/plugins/importer/importcsv.py:188
 msgid "baptism source"
 msgstr "keresztelés forrása"
 
-#: ../gramps/plugins/importer/importcsv.py:188
+#: ../gramps/plugins/importer/importcsv.py:189
 msgid "burial place"
 msgstr "temetési hely"
 
-#: ../gramps/plugins/importer/importcsv.py:190
+#: ../gramps/plugins/importer/importcsv.py:191
 msgid "burial place id"
 msgstr "temetés helyének azonosítója"
 
-#: ../gramps/plugins/importer/importcsv.py:192
+#: ../gramps/plugins/importer/importcsv.py:193
 msgid "burial date"
 msgstr "temetés dátuma"
 
-#: ../gramps/plugins/importer/importcsv.py:194
+#: ../gramps/plugins/importer/importcsv.py:195
 msgid "burial source"
 msgstr "temetés forrása"
 
-#: ../gramps/plugins/importer/importcsv.py:196
+#: ../gramps/plugins/importer/importcsv.py:197
 msgid "death place"
 msgstr "halálozás helye"
 
-#: ../gramps/plugins/importer/importcsv.py:198
+#: ../gramps/plugins/importer/importcsv.py:199
 msgid "death place id"
 msgstr "halálozási helyének azonosítója"
 
-#: ../gramps/plugins/importer/importcsv.py:203
+#: ../gramps/plugins/importer/importcsv.py:204
 msgid "death source"
 msgstr "halálozás forrása"
 
-#: ../gramps/plugins/importer/importcsv.py:205
+#: ../gramps/plugins/importer/importcsv.py:206
 msgid "death cause"
 msgstr "halál ok"
 
-#: ../gramps/plugins/importer/importcsv.py:208
+#: ../gramps/plugins/importer/importcsv.py:209
 msgid "person"
 msgstr "személy"
 
-#. ----------------------------------
 #: ../gramps/plugins/importer/importcsv.py:210
+msgid "Occupation description"
+msgstr "Foglalkozás leírás"
+
+#: ../gramps/plugins/importer/importcsv.py:210
+msgid "occupationdescr"
+msgstr "occupationdescr"
+
+#: ../gramps/plugins/importer/importcsv.py:211
+msgid "Occupation date"
+msgstr "Foglalkozás dátuma"
+
+#: ../gramps/plugins/importer/importcsv.py:211
+msgid "occupationdate"
+msgstr "occupationdate"
+
+#: ../gramps/plugins/importer/importcsv.py:212
+msgid "Occupation place"
+msgstr "Foglalkozás helye"
+
+#: ../gramps/plugins/importer/importcsv.py:212
+msgid "occupationplace"
+msgstr "occupationplace"
+
+#: ../gramps/plugins/importer/importcsv.py:213
+msgid "Occupation place id"
+msgstr "Foglalkozás hely azonosító"
+
+#: ../gramps/plugins/importer/importcsv.py:213
+msgid "occupationplace_id"
+msgstr "occupationplace_id"
+
+#: ../gramps/plugins/importer/importcsv.py:214
+msgid "Occupation source"
+msgstr "Foglalkozás forrása"
+
+#: ../gramps/plugins/importer/importcsv.py:214
+msgid "occupationsource"
+msgstr "occupationsource"
+
+#: ../gramps/plugins/importer/importcsv.py:216
+msgid "residence date"
+msgstr "lakhely dátum"
+
+#: ../gramps/plugins/importer/importcsv.py:216
+msgid "residencedate"
+msgstr "residencedate"
+
+#: ../gramps/plugins/importer/importcsv.py:217
+msgid "residence place"
+msgstr "lakhely hely"
+
+#: ../gramps/plugins/importer/importcsv.py:217
+msgid "residenceplace"
+msgstr "residenceplace"
+
+#: ../gramps/plugins/importer/importcsv.py:218
+msgid "residence place id"
+msgstr "lakhely helyének azonosítója"
+
+#: ../gramps/plugins/importer/importcsv.py:218
+msgid "residenceplace_id"
+msgstr "residenceplace_id"
+
+#: ../gramps/plugins/importer/importcsv.py:219
+msgid "residence source"
+msgstr "lakhely forrás"
+
+#: ../gramps/plugins/importer/importcsv.py:219
+msgid "residencesource"
+msgstr "residencesource"
+
+#: ../gramps/plugins/importer/importcsv.py:221
+msgid "attribute type"
+msgstr "jellemző típus"
+
+#: ../gramps/plugins/importer/importcsv.py:221
+msgid "attributetype"
+msgstr "attributetype"
+
+#: ../gramps/plugins/importer/importcsv.py:222
+msgid "attribute value"
+msgstr "jellemző érték"
+
+#: ../gramps/plugins/importer/importcsv.py:222
+msgid "attributevalue"
+msgstr "attributevalue"
+
+#: ../gramps/plugins/importer/importcsv.py:223
+msgid "attribute source"
+msgstr "jellemző forrás"
+
+#: ../gramps/plugins/importer/importcsv.py:223
+msgid "attributesource"
+msgstr "attributesource"
+
+#. ----------------------------------
+#: ../gramps/plugins/importer/importcsv.py:226
 msgid "child"
 msgstr "gyermek"
 
 #. ----------------------------------
-#: ../gramps/plugins/importer/importcsv.py:213
+#: ../gramps/plugins/importer/importcsv.py:229
 msgid "mother"
 msgstr "anya"
 
-#: ../gramps/plugins/importer/importcsv.py:215
+#: ../gramps/plugins/importer/importcsv.py:231
 msgid "parent2"
 msgstr "2. szülő"
 
-#: ../gramps/plugins/importer/importcsv.py:216
+#: ../gramps/plugins/importer/importcsv.py:232
 msgid "father"
 msgstr "apa"
 
-#: ../gramps/plugins/importer/importcsv.py:218
+#: ../gramps/plugins/importer/importcsv.py:234
 msgid "parent1"
 msgstr "1. szülő"
 
-#: ../gramps/plugins/importer/importcsv.py:219
+#: ../gramps/plugins/importer/importcsv.py:235
 msgid "marriage"
 msgstr "házasság"
 
-#: ../gramps/plugins/importer/importcsv.py:220
+#: ../gramps/plugins/importer/importcsv.py:236
 msgid "date"
 msgstr "dátum"
 
-#: ../gramps/plugins/importer/importcsv.py:221
+#: ../gramps/plugins/importer/importcsv.py:237
 msgid "place"
 msgstr "hely"
 
-#: ../gramps/plugins/importer/importcsv.py:222
+#: ../gramps/plugins/importer/importcsv.py:238
 msgid "place id"
 msgstr "hely azonosító"
 
-#: ../gramps/plugins/importer/importcsv.py:223
+#: ../gramps/plugins/importer/importcsv.py:239
 msgid "name"
 msgstr "név"
 
-#: ../gramps/plugins/importer/importcsv.py:224
+#: ../gramps/plugins/importer/importcsv.py:240
 msgid "type"
 msgstr "típus"
 
-#: ../gramps/plugins/importer/importcsv.py:225
+#: ../gramps/plugins/importer/importcsv.py:241
 msgid "latitude"
 msgstr "szélesség"
 
-#: ../gramps/plugins/importer/importcsv.py:226
+#: ../gramps/plugins/importer/importcsv.py:242
 msgid "longitude"
 msgstr "hosszúság"
 
-#: ../gramps/plugins/importer/importcsv.py:227
+#: ../gramps/plugins/importer/importcsv.py:243
 msgid "code"
 msgstr "kód"
 
-#: ../gramps/plugins/importer/importcsv.py:228
+#: ../gramps/plugins/importer/importcsv.py:244
 msgid "enclosed by"
 msgstr "mellékelte"
 
-#: ../gramps/plugins/importer/importcsv.py:229
+#: ../gramps/plugins/importer/importcsv.py:245
 msgid "enclosed_by"
 msgstr "_mellékelte"
 
-#: ../gramps/plugins/importer/importcsv.py:256
+#: ../gramps/plugins/importer/importcsv.py:272
 #, python-format
 msgid "format error: line %(line)d: %(zero)s"
 msgstr "formátum hiba: %(line)d sor: %(zero)s"
 
-#: ../gramps/plugins/importer/importcsv.py:337
+#: ../gramps/plugins/importer/importcsv.py:353
 msgid "CSV Import"
 msgstr "CSV importálás"
 
-#: ../gramps/plugins/importer/importcsv.py:339
+#: ../gramps/plugins/importer/importcsv.py:355
 msgid "Reading data..."
 msgstr "Adatok olvasása..."
 
-#: ../gramps/plugins/importer/importcsv.py:346
+#: ../gramps/plugins/importer/importcsv.py:362
 msgid "CSV import"
 msgstr "CSV importálás"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/importer/importcsv.py:354
-#: ../gramps/plugins/importer/importgeneweb.py:273
+#: ../gramps/plugins/importer/importcsv.py:370
+#: ../gramps/plugins/importer/importgeneweb.py:274
 #: ../gramps/plugins/importer/importvcard.py:249
 #, python-brace-format
 msgid "Import Complete: {number_of} second"
@@ -24672,99 +24982,99 @@ msgstr "%s nem importálható"
 msgid "Error reading GEDCOM file"
 msgstr "GEDCOM fájl olvasási hiba"
 
-#: ../gramps/plugins/importer/importgeneweb.py:79
+#: ../gramps/plugins/importer/importgeneweb.py:80
 msgid "Accomplishment"
 msgstr "Teljesítés"
 
-#: ../gramps/plugins/importer/importgeneweb.py:80
+#: ../gramps/plugins/importer/importgeneweb.py:81
 msgid "Acquisition"
 msgstr "Gyűjtés"
 
-#: ../gramps/plugins/importer/importgeneweb.py:81
+#: ../gramps/plugins/importer/importgeneweb.py:82
 msgid "Adhesion"
 msgstr "Tapadás"
 
-#: ../gramps/plugins/importer/importgeneweb.py:82
-#: ../gramps/plugins/importer/importgeneweb.py:94
+#: ../gramps/plugins/importer/importgeneweb.py:83
+#: ../gramps/plugins/importer/importgeneweb.py:95
 msgid "Award"
 msgstr "Díj"
 
-#: ../gramps/plugins/importer/importgeneweb.py:88
+#: ../gramps/plugins/importer/importgeneweb.py:89
 msgid "Change Name"
 msgstr "Név változtatása"
 
-#: ../gramps/plugins/importer/importgeneweb.py:89
-#: ../gramps/plugins/lib/libgedcom.py:705
+#: ../gramps/plugins/importer/importgeneweb.py:90
+#: ../gramps/plugins/lib/libgedcom.py:697
 msgid "Circumcision"
 msgstr "Körülmetélés"
 
-#: ../gramps/plugins/importer/importgeneweb.py:93
+#: ../gramps/plugins/importer/importgeneweb.py:94
 msgid "Military Demobilisation"
 msgstr "Katonai leszerelés"
 
-#: ../gramps/plugins/importer/importgeneweb.py:99
+#: ../gramps/plugins/importer/importgeneweb.py:100
 msgid "Dotation"
 msgstr "Hozomány"
 
-#: ../gramps/plugins/importer/importgeneweb.py:100
-#: ../gramps/plugins/lib/libgedcom.py:711
+#: ../gramps/plugins/importer/importgeneweb.py:101
+#: ../gramps/plugins/lib/libgedcom.py:703
 msgid "Excommunication"
 msgstr "Kiátkozás"
 
-#: ../gramps/plugins/importer/importgeneweb.py:102
+#: ../gramps/plugins/importer/importgeneweb.py:103
 msgid "LDS Family Link"
 msgstr "UNSZ család hivatkozások"
 
-#: ../gramps/plugins/importer/importgeneweb.py:103
-#: ../gramps/plugins/lib/libgedcom.py:713
+#: ../gramps/plugins/importer/importgeneweb.py:104
+#: ../gramps/plugins/lib/libgedcom.py:705
 msgid "Funeral"
 msgstr "Temetés"
 
-#: ../gramps/plugins/importer/importgeneweb.py:105
+#: ../gramps/plugins/importer/importgeneweb.py:106
 msgid "Hospitalisation"
 msgstr "Kórházba utalás"
 
-#: ../gramps/plugins/importer/importgeneweb.py:106
+#: ../gramps/plugins/importer/importgeneweb.py:107
 msgid "Illness"
 msgstr "Betegség"
 
-#: ../gramps/plugins/importer/importgeneweb.py:108
+#: ../gramps/plugins/importer/importgeneweb.py:109
 msgid "List Passenger"
 msgstr "Utaslista"
 
-#: ../gramps/plugins/importer/importgeneweb.py:109
+#: ../gramps/plugins/importer/importgeneweb.py:110
 msgid "Military Distinction"
 msgstr "Katonai kíválóság"
 
-#: ../gramps/plugins/importer/importgeneweb.py:110
+#: ../gramps/plugins/importer/importgeneweb.py:111
 msgid "Militaty Mobilisation"
 msgstr "Katonai bevonulás"
 
-#: ../gramps/plugins/importer/importgeneweb.py:111
+#: ../gramps/plugins/importer/importgeneweb.py:112
 msgid "Military Promotion"
 msgstr "Katonai előléptetés"
 
-#: ../gramps/plugins/importer/importgeneweb.py:119
+#: ../gramps/plugins/importer/importgeneweb.py:120
 msgid "LDS Seal to child"
 msgstr "UNSZ gyermekhez kötés"
 
-#: ../gramps/plugins/importer/importgeneweb.py:122
+#: ../gramps/plugins/importer/importgeneweb.py:123
 msgid "Sold property"
 msgstr "Tulajdon eladása"
 
-#: ../gramps/plugins/importer/importgeneweb.py:129
+#: ../gramps/plugins/importer/importgeneweb.py:130
 msgid "No mention"
 msgstr "Nincs említés"
 
-#: ../gramps/plugins/importer/importgeneweb.py:132
+#: ../gramps/plugins/importer/importgeneweb.py:133
 msgid "Separated"
 msgstr "Különválasztott"
 
-#: ../gramps/plugins/importer/importgeneweb.py:196
+#: ../gramps/plugins/importer/importgeneweb.py:197
 msgid "GeneWeb import"
 msgstr "GeneWeb import"
 
-#: ../gramps/plugins/importer/importgeneweb.py:911
+#: ../gramps/plugins/importer/importgeneweb.py:912
 #, python-brace-format
 msgid "Invalid date {date} in {gw_snippet}, preserving date as text."
 msgstr ""
@@ -24838,8 +25148,7 @@ msgstr ""
 "médiaobjektumok megfelelő útvonalára állította."
 
 #: ../gramps/plugins/importer/importgrdb.py:61
-#: ../gramps/plugins/importer/importprogen.py:81
-#: ../gramps/plugins/importer/importprogen.py:90
+#: ../gramps/plugins/importer/importprogen.py:189
 #: ../gramps/plugins/importer/importxml.py:440
 #: ../gramps/plugins/importer/importxml.py:443
 #, python-format
@@ -24863,55 +25172,287 @@ msgstr ""
 "majd importálja a GRAMPS XML fájlt ebbe a verzióba. Kérem nézze meg ezt:"
 "%(gramps_wiki_migrate_two_to_three_url)s"
 
-#: ../gramps/plugins/importer/importprogen.py:87
-#: ../gramps/plugins/importer/importprogen.py:517
-msgid "Pro-Gen data error"
-msgstr "Pro-Gen adathiba"
+#: ../gramps/plugins/importer/importprogen.glade:49
+#: ../gramps/plugins/importer/importprogen.glade:70
+msgid ""
+"Source reference\n"
+"(out of Settings)"
+msgstr ""
+"Forrás hivatkozás\n"
+"(Beállításokon kívül)"
 
-#: ../gramps/plugins/importer/importprogen.py:183
-msgid "Not a Pro-Gen file"
-msgstr "Nem Pro-Gen fájl"
+#: ../gramps/plugins/importer/importprogen.glade:124
+msgid ""
+"Source reference text\n"
+"(Text & import Filename)."
+msgstr ""
+"Forrás hivatkozás szöveg\n"
+"(Szöveg & Fájlnév import)"
 
-#: ../gramps/plugins/importer/importprogen.py:396
-#, python-format
-msgid "Field '%(fldname)s' not found"
-msgstr "'%(fldname)s' mező nem található"
+#: ../gramps/plugins/importer/importprogen.glade:155
+#: ../gramps/plugins/importer/importprogen.glade:325
+msgid "Attribut"
+msgstr "Jellemző"
 
-#: ../gramps/plugins/importer/importprogen.py:460
-#, python-format
-msgid "Cannot find DEF file: %(dname)s"
-msgstr "DEF fájl nem található: %(dname)s"
+#: ../gramps/plugins/importer/importprogen.glade:171
+msgid ""
+"Source attribute text\n"
+"(Text, import Filename & (System-)Date)."
+msgstr ""
+"Jellemző szöveg forrása\n"
+"(Szöveg, Fájlnév importálás & (Rendszer)Dátum)."
 
-#. Raise a error message
-#: ../gramps/plugins/importer/importprogen.py:516
-msgid "Not a supported Pro-Gen import file language"
-msgstr "Nem támogatott a Pro-Gen import fájl nyelve"
+#: ../gramps/plugins/importer/importprogen.glade:190
+#: ../gramps/plugins/importer/importprogen.glade:207
+msgid "Citation reference."
+msgstr "Idézet hivatkozás."
 
-#. self.reset(_("Import from Pro-Gen"))  # non-functional for now
-#: ../gramps/plugins/importer/importprogen.py:527
-msgid "Pro-Gen import"
-msgstr "Pro-Gen import"
+#: ../gramps/plugins/importer/importprogen.glade:274
+msgid ""
+"Citation confidence level\n"
+"(Very low - very high)."
+msgstr ""
+"Idézet bizalom szint\n"
+"(nagyon alacsony - nagyon magas)."
 
-#: ../gramps/plugins/importer/importprogen.py:586
+#: ../gramps/plugins/importer/importprogen.glade:308
+msgid ""
+"Citation volume/page text\n"
+"(Text & (System-)Date)."
+msgstr ""
+"Idézet kötet/oldal szöveg\n"
+"(Szöveg & (Rendszer-)Dátum)."
+
+#: ../gramps/plugins/importer/importprogen.glade:341
+msgid ""
+"Citation attribute text\n"
+"(Text, import Filename & (System-)Date)."
+msgstr ""
+"Idézet jellemző szöveg\n"
+"(Szöveg, Fájlnév importálás & (Rendszer-)Dátum)."
+
+#: ../gramps/plugins/importer/importprogen.glade:362
+msgid "Import Text"
+msgstr "Szöveg importálás"
+
+#: ../gramps/plugins/importer/importprogen.glade:415
+msgid ""
+"Default Tagtext\n"
+"(out of Settings)."
+msgstr ""
+"Alapértelmezett fülszöveg\n"
+"(a Beállításokon kívül)."
+
+#: ../gramps/plugins/importer/importprogen.glade:443
+msgid "Import Filename."
+msgstr "Fájlnév importálás."
+
+#: ../gramps/plugins/importer/importprogen.glade:492
+msgid "Default (System-)Date."
+msgstr "Alapértelmezett (Rendszer-)Dátum."
+
+#: ../gramps/plugins/importer/importprogen.glade:766
+#: ../gramps/plugins/importer/importprogen.glade:781
+#: ../gramps/plugins/importer/importprogen.glade:796
+#: ../gramps/plugins/importer/importprogen.glade:811
+#: ../gramps/plugins/importer/importprogen.glade:826
+#: ../gramps/plugins/importer/importprogen.glade:841
+#: ../gramps/plugins/importer/importprogen.glade:856
+msgid "Combined default text + filename + date."
+msgstr "Kombinált alapértelmezett szöveg + fájlnév + dátum."
+
+#: ../gramps/plugins/importer/importprogen.glade:1111
+msgid ""
+"Copy Default Text\n"
+"to all Tag Text'."
+msgstr ""
+"Alapértelmezett szöveg másolása\n"
+"minden Szöveg fülre."
+
+#: ../gramps/plugins/importer/importprogen.glade:1130
+msgid ""
+"Copy Default Filename\n"
+"to all sensitive Tag Text'."
+msgstr ""
+"Alapértelmezett fájlnév másolása\n"
+"minden érzékeny Szöveg fülre."
+
+#: ../gramps/plugins/importer/importprogen.glade:1149
+msgid ""
+"Copy Default Date\n"
+"to all sensitive Tag Text'."
+msgstr ""
+"Alapértelmezett dátum másolása\n"
+"minden érzékeny Szöveg fülre."
+
+#: ../gramps/plugins/importer/importprogen.glade:1164
+msgid "  Objects"
+msgstr "  Objektumok"
+
+#: ../gramps/plugins/importer/importprogen.glade:1168
+msgid ""
+"Enable/Disable\n"
+"all object tags."
+msgstr ""
+"Minden objektum fül\n"
+"ki/bekapcsolása."
+
+#: ../gramps/plugins/importer/importprogen.glade:1198
+msgid "Tag Text"
+msgstr "Szöveg fül"
+
+#: ../gramps/plugins/importer/importprogen.glade:1217
+msgid "Import Objects"
+msgstr "Objektumok importálása"
+
+#: ../gramps/plugins/importer/importprogen.glade:1241
+msgid ""
+"Enable/Disable\n"
+"Person import."
+msgstr ""
+"Személy importálás\n"
+"ki/bekapcsolása."
+
+#: ../gramps/plugins/importer/importprogen.glade:1260
+msgid ""
+"Enable/Disable\n"
+"Family import."
+msgstr ""
+"Család importálás\n"
+"ki/bekapcsolása."
+
+#: ../gramps/plugins/importer/importprogen.glade:1279
+msgid ""
+"Enable/Disable\n"
+"Child import."
+msgstr ""
+"Gyermek importálás\n"
+"ki/bekapcsolása."
+
+#: ../gramps/plugins/importer/importprogen.glade:1330
+msgid ""
+"Use original Person\n"
+"Identifier as Gramps ID."
+msgstr ""
+"Az eredeti Személy azonosító\n"
+"használata, mint GRAMPS ID."
+
+#: ../gramps/plugins/importer/importprogen.glade:1349
+msgid ""
+"Use original Family\n"
+"Identifier as Gramps ID."
+msgstr ""
+"Az eredeti Család azonosító\n"
+"használata, mint GRAMPS ID."
+
+#: ../gramps/plugins/importer/importprogen.glade:1369
+msgid "Identifier"
+msgstr "Azonosító"
+
+#: ../gramps/plugins/importer/importprogen.glade:1400
+msgid "Name change"
+msgstr "Névváltoztatás"
+
+#: ../gramps/plugins/importer/importprogen.glade:1461
+msgid "Event date"
+msgstr "Esemény dátum"
+
+#: ../gramps/plugins/importer/importprogen.glade:1476
+msgid ""
+"Store birth date in\n"
+"event description."
+msgstr ""
+"Születési dátum tárolása\n"
+"esemény leírásban."
+
+#: ../gramps/plugins/importer/importprogen.glade:1495
+msgid ""
+"Store death date in\n"
+"event description."
+msgstr ""
+"Halálozási dátum tárolása\n"
+"esemény leírásban."
+
+#: ../gramps/plugins/importer/importprogen.glade:1515
+msgid "Diverse"
+msgstr "Különböző"
+
+#: ../gramps/plugins/importer/importprogen.glade:1526
+msgid "REFN"
+msgstr "REFN"
+
+#: ../gramps/plugins/importer/importprogen.glade:1530
+msgid ""
+"Store REFN number\n"
+"in event description."
+msgstr ""
+"REFN szám tárolása\n"
+"esemény leírásban."
+
+#: ../gramps/plugins/importer/importprogen.glade:1548
+#: ../gramps/plugins/importer/importprogen.glade:1595
+msgid ""
+"Use death information\n"
+"as death cause event."
+msgstr ""
+"Halálozási információ használata\n"
+"mint halál ok esemény."
+
+#: ../gramps/plugins/importer/importprogen.glade:1598
+msgid "(-cause)"
+msgstr "(-ok)"
+
+#: ../gramps/plugins/importer/importprogen.glade:1610
+msgid "Male surname"
+msgstr "Férfi vezetékneve"
+
+#: ../gramps/plugins/importer/importprogen.glade:1614
+msgid ""
+"Change name of male\n"
+"to e.g. wifes name."
+msgstr ""
+"Férfinév változtatása\n"
+"pl. feleség nevére."
+
+#: ../gramps/plugins/importer/importprogen.glade:1629
+msgid "Female surname"
+msgstr "Nő vezetékneve"
+
+#: ../gramps/plugins/importer/importprogen.glade:1633
+msgid ""
+"Change name of female\n"
+"to e.g. husbands name."
+msgstr ""
+"Nő nevének változtatása\n"
+"pl. a férj nevére."
+
+#: ../gramps/plugins/importer/importprogen.glade:1692
+msgid "Option"
+msgstr "Lehetőség"
+
+#: ../gramps/plugins/importer/importprogen.glade:1731
+msgid "_Ok"
+msgstr "_Rendben"
+
+#: ../gramps/plugins/importer/importprogen.py:62
+msgid "manual|Import_from_another_genealogy_program"
+msgstr "manual|Más_származástani_programból_importálás"
+
+#: ../gramps/plugins/importer/importprogen.py:121
 #, python-format
 msgid "Import from Pro-Gen (%s)"
 msgstr "(%s) Pro-Genből importálás"
 
-#. Hmmm. Just use the plain text.
-#: ../gramps/plugins/importer/importprogen.py:1066
-#, python-format
-msgid "Date did not match: '%(text)s' (%(msg)s)"
-msgstr "A dátum nem egyezik: '%(text)s' (%(msg)s)"
+#: ../gramps/plugins/importer/importprogen.py:186
+#: ../gramps/plugins/lib/libprogen.py:492
+#: ../gramps/plugins/lib/libprogen.py:516
+msgid "Pro-Gen data error"
+msgstr "Pro-Gen adathiba"
 
-#: ../gramps/plugins/importer/importprogen.py:1790
-#, python-format
-msgid "Cannot find father for I%(person)s (Father=%(id)d)"
-msgstr "Nem található apa I%(person)s (Father=%(id)d)) számára"
-
-#: ../gramps/plugins/importer/importprogen.py:1793
-#, python-format
-msgid "Cannot find mother for I%(person)s (Mother=%(mother)d)"
-msgstr "Nem található anya I%(person)s (Mother=%(mother)d) számára"
+#: ../gramps/plugins/importer/importprogen.py:457
+#: ../gramps/plugins/importer/importprogen.py:465
+msgid "Import Pro-Gen"
+msgstr "Pro-Gen importálás"
 
 #: ../gramps/plugins/importer/importvcard.py:228
 #, python-format
@@ -25157,26 +25698,26 @@ msgstr ""
 "Összevonásra jelölt objektumok:\n"
 
 #. there is no old style XML
-#: ../gramps/plugins/importer/importxml.py:808
-#: ../gramps/plugins/importer/importxml.py:1289
-#: ../gramps/plugins/importer/importxml.py:1563
-#: ../gramps/plugins/importer/importxml.py:1984
+#: ../gramps/plugins/importer/importxml.py:809
+#: ../gramps/plugins/importer/importxml.py:1294
+#: ../gramps/plugins/importer/importxml.py:1568
+#: ../gramps/plugins/importer/importxml.py:1989
 msgid "The Gramps Xml you are trying to import is malformed."
 msgstr "Az importálni próbált GRAMPS XML hibás formátumú."
 
-#: ../gramps/plugins/importer/importxml.py:809
+#: ../gramps/plugins/importer/importxml.py:810
 msgid "Attributes that link the data together are missing."
 msgstr "Az adatokat összefűző jellemzők hiányoznak."
 
-#: ../gramps/plugins/importer/importxml.py:922
+#: ../gramps/plugins/importer/importxml.py:923
 msgid "Gramps XML import"
 msgstr "GRAMPS XML import"
 
-#: ../gramps/plugins/importer/importxml.py:957
+#: ../gramps/plugins/importer/importxml.py:958
 msgid "Could not change media path"
 msgstr "A média útvonal nem változtatható meg"
 
-#: ../gramps/plugins/importer/importxml.py:958
+#: ../gramps/plugins/importer/importxml.py:959
 #, python-format
 msgid ""
 "The opened file has media path %s, which conflicts with the media path of "
@@ -25189,7 +25730,7 @@ msgstr ""
 "megfelelő könyvtárba, vagy változtassa meg a média útvonalat a "
 "Beállításokban."
 
-#: ../gramps/plugins/importer/importxml.py:1017
+#: ../gramps/plugins/importer/importxml.py:1018
 msgid ""
 "The .gramps file you are importing does not contain information about the "
 "version of Gramps with, which it was produced.\n"
@@ -25201,11 +25742,11 @@ msgstr ""
 "\n"
 "A fájl nem kerül importálásra."
 
-#: ../gramps/plugins/importer/importxml.py:1020
+#: ../gramps/plugins/importer/importxml.py:1021
 msgid "Import file misses Gramps version"
 msgstr "GRAMPS változatszám hiánya az importálandó fájlban"
 
-#: ../gramps/plugins/importer/importxml.py:1022
+#: ../gramps/plugins/importer/importxml.py:1023
 #, python-format
 msgid ""
 "The .gramps file you are importing was made by version %(newer)s of Gramps, "
@@ -25216,7 +25757,7 @@ msgstr ""
 "futó alkalmazás korábbi, %(older)s változatú. A fájl nem lesz importálva. "
 "Frissítsen a GRAMPS legutóbbi változatára, majd próbálja újra."
 
-#: ../gramps/plugins/importer/importxml.py:1030
+#: ../gramps/plugins/importer/importxml.py:1031
 #, python-format
 msgid ""
 "The .gramps file you are importing was made by version %(oldgramps)s of "
@@ -25237,11 +25778,11 @@ msgstr ""
 "  %(gramps_wiki_xml_url)s\n"
 " további információért."
 
-#: ../gramps/plugins/importer/importxml.py:1041
+#: ../gramps/plugins/importer/importxml.py:1042
 msgid "The file will not be imported"
 msgstr "A fájl nem kerül importálásra"
 
-#: ../gramps/plugins/importer/importxml.py:1043
+#: ../gramps/plugins/importer/importxml.py:1044
 #, python-format
 msgid ""
 "The .gramps file you are importing was made by version %(oldgramps)s of "
@@ -25264,25 +25805,25 @@ msgstr ""
 "  %(gramps_wiki_xml_url)s\n"
 "további információért."
 
-#: ../gramps/plugins/importer/importxml.py:1056
+#: ../gramps/plugins/importer/importxml.py:1057
 msgid "Old xml file"
 msgstr "Régi XML fájl"
 
-#: ../gramps/plugins/importer/importxml.py:1209
-#: ../gramps/plugins/importer/importxml.py:2701
+#: ../gramps/plugins/importer/importxml.py:1212
+#: ../gramps/plugins/importer/importxml.py:2712
 #, python-format
 msgid "Witness name: %s"
 msgstr "Tanú neve: %s"
 
-#: ../gramps/plugins/importer/importxml.py:1290
+#: ../gramps/plugins/importer/importxml.py:1295
 msgid "Any event reference must have a 'hlink' attribute."
 msgstr "Bármely eseményhivatkozásnak 'hlink' jellemzővel kell rendelkeznie."
 
-#: ../gramps/plugins/importer/importxml.py:1564
+#: ../gramps/plugins/importer/importxml.py:1569
 msgid "Any person reference must have a 'hlink' attribute."
 msgstr "Bármely személyhivatkozásnak 'hlink' jellemzővel kell rendelkeznie."
 
-#: ../gramps/plugins/importer/importxml.py:1753
+#: ../gramps/plugins/importer/importxml.py:1758
 #, python-format
 msgid ""
 "Your Family Tree groups name \"%(key)s\" together with \"%(parent)s\", did "
@@ -25291,31 +25832,31 @@ msgstr ""
 "A \"%(key)s\" Családfa csoportnév együtt a(z) \"%(parent)s\"-l nem "
 "változtatja meg ezt a csoportosítást \"%(value)s\" értékre."
 
-#: ../gramps/plugins/importer/importxml.py:1756
+#: ../gramps/plugins/importer/importxml.py:1761
 msgid "Gramps ignored a name grouping"
 msgstr "A GRAMPS a névtérkép értéket elveti"
 
-#: ../gramps/plugins/importer/importxml.py:1815
+#: ../gramps/plugins/importer/importxml.py:1820
 msgid "Unknown when imported"
 msgstr "Ismeretlen importáláskor"
 
-#: ../gramps/plugins/importer/importxml.py:1985
+#: ../gramps/plugins/importer/importxml.py:1990
 msgid "Any note reference must have a 'hlink' attribute."
 msgstr "Bármely jegyzethivatkozásnak 'hlink' jellemzővel kell rendelkeznie."
 
 #. TRANSLATORS: leave the {date} and {xml} untranslated in the format string,
 #. but you may re-order them if needed.
-#: ../gramps/plugins/importer/importxml.py:2519
+#: ../gramps/plugins/importer/importxml.py:2530
 #, python-brace-format
 msgid "Invalid date {date} in XML {xml}, preserving XML as text"
 msgstr "Érvénytelen a {date} dátum az {xml} XML}-ben, XML rögzítése szövegként"
 
-#: ../gramps/plugins/importer/importxml.py:2571
+#: ../gramps/plugins/importer/importxml.py:2582
 #, python-format
 msgid "Witness comment: %s"
 msgstr "Tanú megjegyzés: %s"
 
-#: ../gramps/plugins/importer/importxml.py:3224
+#: ../gramps/plugins/importer/importxml.py:3235
 #, python-format
 msgid ""
 "Error: family '%(family)s' father '%(father)s' does not refer back to the "
@@ -25324,7 +25865,7 @@ msgstr ""
 "Hiba: a '%(family)s' család '%(father)s' apja nem hivatkozik vissza a "
 "családra. Hivatkozás hozzáadva."
 
-#: ../gramps/plugins/importer/importxml.py:3240
+#: ../gramps/plugins/importer/importxml.py:3251
 #, python-format
 msgid ""
 "Error: family '%(family)s' mother '%(mother)s' does not refer back to the "
@@ -25333,7 +25874,7 @@ msgstr ""
 "Hiba: a '%(family)s' család '%(mother)s' anyja nem hivatkozik vissza a "
 "családra. Hivatkozás hozzáadva."
 
-#: ../gramps/plugins/importer/importxml.py:3262
+#: ../gramps/plugins/importer/importxml.py:3273
 #, python-format
 msgid ""
 "Error: family '%(family)s' child '%(child)s' does not refer back to the "
@@ -25352,117 +25893,117 @@ msgstr ""
 "formátummal.\n"
 " %(filename)s írása %(impliedext)s formátumban."
 
-#: ../gramps/plugins/lib/libgedcom.py:706
+#: ../gramps/plugins/lib/libgedcom.py:698
 msgid "Common Law Marriage"
 msgstr "Élettársi viszony"
 
-#: ../gramps/plugins/lib/libgedcom.py:707
-#: ../gramps/plugins/webreport/narrativeweb.py:1589
-#: ../gramps/plugins/webreport/webcal.py:1615
+#: ../gramps/plugins/lib/libgedcom.py:699
+#: ../gramps/plugins/webreport/narrativeweb.py:1626
+#: ../gramps/plugins/webreport/webcal.py:1661
 msgid "Destination"
 msgstr "Célhely"
 
-#: ../gramps/plugins/lib/libgedcom.py:708
+#: ../gramps/plugins/lib/libgedcom.py:700
 msgid "DNA"
 msgstr "DNS"
 
-#: ../gramps/plugins/lib/libgedcom.py:709
+#: ../gramps/plugins/lib/libgedcom.py:701
 msgid "Cause of Death"
 msgstr "Halál oka"
 
-#: ../gramps/plugins/lib/libgedcom.py:710
+#: ../gramps/plugins/lib/libgedcom.py:702
 msgid "Employment"
 msgstr "Foglalkozás"
 
-#: ../gramps/plugins/lib/libgedcom.py:712
+#: ../gramps/plugins/lib/libgedcom.py:704
 msgid "Eye Color"
 msgstr "Szemszín"
 
-#: ../gramps/plugins/lib/libgedcom.py:714
+#: ../gramps/plugins/lib/libgedcom.py:706
 msgid "Height"
 msgstr "Magasság"
 
-#: ../gramps/plugins/lib/libgedcom.py:715
+#: ../gramps/plugins/lib/libgedcom.py:707
 msgid "Initiatory (LDS)"
 msgstr "Beavatás (mormon egyház)"
 
-#: ../gramps/plugins/lib/libgedcom.py:716
+#: ../gramps/plugins/lib/libgedcom.py:708
 msgid "Military ID"
 msgstr "Katonai azonosító"
 
-#: ../gramps/plugins/lib/libgedcom.py:717
+#: ../gramps/plugins/lib/libgedcom.py:709
 msgid "Mission (LDS)"
 msgstr "Misszió (mormon egyház)"
 
-#: ../gramps/plugins/lib/libgedcom.py:718
+#: ../gramps/plugins/lib/libgedcom.py:710
 msgid "Namesake"
 msgstr "Névrokon"
 
-#: ../gramps/plugins/lib/libgedcom.py:719
+#: ../gramps/plugins/lib/libgedcom.py:711
 msgid "Ordinance"
 msgstr "Szertartás"
 
-#: ../gramps/plugins/lib/libgedcom.py:721
+#: ../gramps/plugins/lib/libgedcom.py:713
 msgid "Separation"
 msgstr "Különélés"
 
 #. Applies to Families
-#: ../gramps/plugins/lib/libgedcom.py:722
+#: ../gramps/plugins/lib/libgedcom.py:714
 msgid "Weight"
 msgstr "Súly"
 
-#: ../gramps/plugins/lib/libgedcom.py:934
+#: ../gramps/plugins/lib/libgedcom.py:926
 msgid "Line ignored "
 msgstr "A vonal kihagyva "
 
 #. e.g. Illegal character (oxAB) (0xCB)... 1 NOTE xyz?pqr?lmn
-#: ../gramps/plugins/lib/libgedcom.py:1547
+#: ../gramps/plugins/lib/libgedcom.py:1539
 #, python-format
 msgid "Illegal character%s"
 msgstr "Nem megengedett %s karakter"
 
-#: ../gramps/plugins/lib/libgedcom.py:1827
+#: ../gramps/plugins/lib/libgedcom.py:1819
 msgid "Your GEDCOM file is corrupted. It appears to have been truncated."
 msgstr "A GEDCOM fájl hibás. Csonkának tűnik."
 
-#: ../gramps/plugins/lib/libgedcom.py:1911
+#: ../gramps/plugins/lib/libgedcom.py:1903
 #, python-format
 msgid "Import from GEDCOM (%s)"
 msgstr "Importálás: GEDCOM (%s)"
 
-#: ../gramps/plugins/lib/libgedcom.py:2745
-#: ../gramps/plugins/lib/libgedcom.py:3199
+#: ../gramps/plugins/lib/libgedcom.py:2736
+#: ../gramps/plugins/lib/libgedcom.py:3193
 msgid "GEDCOM import"
 msgstr "GEDCOM importálás"
 
-#: ../gramps/plugins/lib/libgedcom.py:2773
+#: ../gramps/plugins/lib/libgedcom.py:2764
 msgid "GEDCOM import report: No errors detected"
 msgstr "GEDCOM import jelentés: Nincs hiba"
 
-#: ../gramps/plugins/lib/libgedcom.py:2775
+#: ../gramps/plugins/lib/libgedcom.py:2766
 #, python-format
 msgid "GEDCOM import report: %s errors detected"
 msgstr "GEDCOM import jelentés: %s hiba történt"
 
-#: ../gramps/plugins/lib/libgedcom.py:3092
-#: ../gramps/plugins/lib/libgedcom.py:3117
-#: ../gramps/plugins/lib/libgedcom.py:3130
+#: ../gramps/plugins/lib/libgedcom.py:3086
+#: ../gramps/plugins/lib/libgedcom.py:3111
+#: ../gramps/plugins/lib/libgedcom.py:3124
 msgid "Line ignored as not understood"
 msgstr "A sor kihagyva, mert nem értelmezhető"
 
-#: ../gramps/plugins/lib/libgedcom.py:3119
+#: ../gramps/plugins/lib/libgedcom.py:3113
 msgid "Tag recognized but not supported"
 msgstr "Címke felismerve, de nem támogatott"
 
-#: ../gramps/plugins/lib/libgedcom.py:3155
+#: ../gramps/plugins/lib/libgedcom.py:3149
 msgid "Skipped subordinate line"
 msgstr "Alárendelt vonal átugrása"
 
-#: ../gramps/plugins/lib/libgedcom.py:3188
+#: ../gramps/plugins/lib/libgedcom.py:3182
 msgid "Records not imported into "
 msgstr "Adat nem importálható "
 
-#: ../gramps/plugins/lib/libgedcom.py:3226
+#: ../gramps/plugins/lib/libgedcom.py:3220
 #, python-format
 msgid ""
 "Error: %(msg)s  '%(gramps_id)s' (input as @%(xref)s@) not in input GEDCOM. "
@@ -25471,7 +26012,7 @@ msgstr ""
 "Hiba: %(msg)s  '%(gramps_id)s' (bemenet, mint @%(xref)s@) nem GEDCOM "
 "bemenet. Az adatrekord generált"
 
-#: ../gramps/plugins/lib/libgedcom.py:3235
+#: ../gramps/plugins/lib/libgedcom.py:3229
 #, python-format
 msgid ""
 "Error: %(msg)s '%(gramps_id)s' (input as @%(xref)s@) not in input GEDCOM. "
@@ -25480,7 +26021,7 @@ msgstr ""
 "Hiba: %(msg)s  '%(gramps_id)s' (bemenet, mint @%(xref)s@) nem GEDCOM "
 "bemenet. Az adatrekord 'Ismeretlen' jelzéssel létrehozva"
 
-#: ../gramps/plugins/lib/libgedcom.py:3279
+#: ../gramps/plugins/lib/libgedcom.py:3273
 #, python-format
 msgid ""
 "Error: family '%(family)s' (input as @%(orig_family)s@) person %(person)s "
@@ -25491,7 +26032,7 @@ msgstr ""
 "személye (bemenet, mint %(orig_person)s) nem tagja a hivatkozott családnak. "
 "A család hivatkozás a személytől eltávolítva"
 
-#: ../gramps/plugins/lib/libgedcom.py:3357
+#: ../gramps/plugins/lib/libgedcom.py:3351
 #, python-format
 msgid ""
 "\n"
@@ -25511,106 +26052,106 @@ msgstr ""
 #. message means that the element %s was ignored, but
 #. expressed the wrong way round because the message is
 #. truncated for output
-#: ../gramps/plugins/lib/libgedcom.py:3431
+#: ../gramps/plugins/lib/libgedcom.py:3425
 #, python-format
 msgid "ADDR element ignored '%s'"
 msgstr "Az ADDR elem figyelmen kívül hagyta: '%s'"
 
-#: ../gramps/plugins/lib/libgedcom.py:3452
+#: ../gramps/plugins/lib/libgedcom.py:3446
 msgid "TRLR (trailer)"
 msgstr "TRLR (utó-adat)"
 
-#: ../gramps/plugins/lib/libgedcom.py:3481
+#: ../gramps/plugins/lib/libgedcom.py:3475
 msgid "(Submitter):"
 msgstr "(Benyújtó):"
 
-#: ../gramps/plugins/lib/libgedcom.py:3505
+#: ../gramps/plugins/lib/libgedcom.py:3499
 #: ../gramps/plugins/lib/libgedcom.py:7273
 msgid "GEDCOM data"
 msgstr "GEDCOM adat"
 
-#: ../gramps/plugins/lib/libgedcom.py:3550
+#: ../gramps/plugins/lib/libgedcom.py:3544
 msgid "Unknown tag"
 msgstr "Ismeretlen címke"
 
-#: ../gramps/plugins/lib/libgedcom.py:3552
-#: ../gramps/plugins/lib/libgedcom.py:3566
-#: ../gramps/plugins/lib/libgedcom.py:3570
-#: ../gramps/plugins/lib/libgedcom.py:3591
+#: ../gramps/plugins/lib/libgedcom.py:3546
+#: ../gramps/plugins/lib/libgedcom.py:3560
+#: ../gramps/plugins/lib/libgedcom.py:3564
+#: ../gramps/plugins/lib/libgedcom.py:3585
 msgid "Top Level"
 msgstr "Felső szint"
 
-#: ../gramps/plugins/lib/libgedcom.py:3666
+#: ../gramps/plugins/lib/libgedcom.py:3660
 #, python-format
 msgid "INDI (individual) Gramps ID %s"
 msgstr "INDI (egyéni) GRAMPS Azonosító: %s"
 
-#: ../gramps/plugins/lib/libgedcom.py:3785
+#: ../gramps/plugins/lib/libgedcom.py:3779
 msgid "Empty Alias <NAME PERSONAL> ignored"
 msgstr "<NAME PERSONAL> Üres Álnév figyelmen kívül hagyása"
 
-#: ../gramps/plugins/lib/libgedcom.py:4979
+#: ../gramps/plugins/lib/libgedcom.py:4973
 #, python-format
 msgid "FAM (family) Gramps ID %s"
 msgstr "FAM (család) GRAMPS Azonosító: %s"
 
-#: ../gramps/plugins/lib/libgedcom.py:5341
-#: ../gramps/plugins/lib/libgedcom.py:6705
+#: ../gramps/plugins/lib/libgedcom.py:5335
+#: ../gramps/plugins/lib/libgedcom.py:6694
 msgid "Filename omitted"
 msgstr "A fájlnév kimaradt"
 
-#: ../gramps/plugins/lib/libgedcom.py:5374
-#: ../gramps/plugins/lib/libgedcom.py:6746
+#: ../gramps/plugins/lib/libgedcom.py:5369
+#: ../gramps/plugins/lib/libgedcom.py:6747
 #, python-format
 msgid "Could not import %s"
 msgstr "%s nem importálható"
 
-#: ../gramps/plugins/lib/libgedcom.py:5431
+#: ../gramps/plugins/lib/libgedcom.py:5435
 #: ../gramps/plugins/lib/libgedcom.py:6846
 msgid "Media-Type"
 msgstr "Médiatípus"
 
-#: ../gramps/plugins/lib/libgedcom.py:5455
+#: ../gramps/plugins/lib/libgedcom.py:5459
 #: ../gramps/plugins/lib/libgedcom.py:6736
 msgid "Multiple FILE in a single OBJE ignored"
 msgstr "Figyelembe nem vett többszörös FILE egy egyszerű OBJE-ben"
 
 #. We have previously found a PLAC
-#: ../gramps/plugins/lib/libgedcom.py:5609
+#: ../gramps/plugins/lib/libgedcom.py:5598
 msgid "A second PLAC ignored"
 msgstr "A második PLAC figyelmen kívül hagyása"
 
 #. For RootsMagic etc. Place Details e.g. address, hospital, ...
-#: ../gramps/plugins/lib/libgedcom.py:5748
+#: ../gramps/plugins/lib/libgedcom.py:5737
 msgid "Detail"
 msgstr "Részlet"
 
 #. We have perviously found an ADDR, or have populated
 #. location from PLAC title
-#: ../gramps/plugins/lib/libgedcom.py:5761
+#: ../gramps/plugins/lib/libgedcom.py:5750
 msgid "Location already populated; ADDR ignored"
 msgstr "A helyzet már betöltött; az ADDR figyelmen kívül hagyása"
 
-#: ../gramps/plugins/lib/libgedcom.py:6166
+#: ../gramps/plugins/lib/libgedcom.py:6155
 #: ../gramps/plugins/lib/libgedcom.py:7054
 msgid "Warn: ADDR overwritten"
 msgstr "Figyelmeztetés: ADDR felülírva"
 
-#: ../gramps/plugins/lib/libgedcom.py:6331
+#: ../gramps/plugins/lib/libgedcom.py:6320
 msgid "Citation Justification"
 msgstr "Idézet igazolás"
 
-#: ../gramps/plugins/lib/libgedcom.py:6358
+#: ../gramps/plugins/lib/libgedcom.py:6347
 msgid "REFN ignored"
 msgstr "REFN kihagyva"
 
 #. SOURce with the given gramps_id had no title
-#: ../gramps/plugins/lib/libgedcom.py:6457
+#: ../gramps/plugins/lib/libgedcom.py:6446
 #, python-format
 msgid "No title - ID %s"
 msgstr "Nincs cím - Azonosító: %s"
 
-#: ../gramps/plugins/lib/libgedcom.py:6462
+#: ../gramps/plugins/lib/libgedcom.py:6451
 #, python-format
 msgid "SOUR (source) Gramps ID %s"
 msgstr "SOUR (forrás) GRAMPS Azonosító: %s"
@@ -25626,7 +26167,7 @@ msgid "REPO (repository) Gramps ID %s"
 msgstr "REPO (tároló) GRAPMS Azonosító: %s"
 
 #: ../gramps/plugins/lib/libgedcom.py:7003
-#: ../gramps/plugins/lib/libgedcom.py:7988
+#: ../gramps/plugins/lib/libgedcom.py:7991
 msgid "Only one phone number supported"
 msgstr "Csak egy telefonszám támogatott"
 
@@ -25768,11 +26309,11 @@ msgstr "Benyújtás: Rend eljárás jelölő"
 
 #. Okay we have no clue which temple this is.
 #. We should tell the user and store it anyway.
-#: ../gramps/plugins/lib/libgedcom.py:7926
+#: ../gramps/plugins/lib/libgedcom.py:7929
 msgid "Invalid temple code"
 msgstr "Szabálytalan templomkód"
 
-#: ../gramps/plugins/lib/libgedcom.py:8022
+#: ../gramps/plugins/lib/libgedcom.py:8025
 msgid ""
 "Your GEDCOM file is corrupted. The file appears to be encoded using the "
 "UTF16 character set, but is missing the BOM marker."
@@ -25780,7 +26321,7 @@ msgstr ""
 "A GEDCOM fájl hibás. Úgy tűnik UTF16 karakterkészlettel kódolt, de hiányzik "
 "a BOM jel."
 
-#: ../gramps/plugins/lib/libgedcom.py:8025
+#: ../gramps/plugins/lib/libgedcom.py:8028
 msgid "Your GEDCOM file is empty."
 msgstr "A GEDCOM fájl üres."
 
@@ -25955,7 +26496,7 @@ msgid "She was born on %(birth_date)s."
 msgstr "Született: %(birth_date)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:125
-#: ../gramps/plugins/webreport/webcal.py:2028
+#: ../gramps/plugins/webreport/webcal.py:2091
 #, python-format
 msgid "Born %(birth_date)s."
 msgstr "Született: %(birth_date)s."
@@ -26345,7 +26886,7 @@ msgstr "A lány halálozási dátuma %(death_date)s, ekkor kora %(age)s volt."
 #. latin cross for html code
 #: ../gramps/plugins/lib/libnarrate.py:283
 #: ../gramps/plugins/lib/libnarrate.py:316
-#: ../gramps/plugins/webreport/webcal.py:2018
+#: ../gramps/plugins/webreport/webcal.py:2081
 #, python-format
 msgid "Died %(death_date)s."
 msgstr "Meghalt: %(death_date)s."
@@ -29193,10 +29734,10 @@ msgid "Number of To Do Notes"
 msgstr "A teendő feljegyzések száma"
 
 #: ../gramps/plugins/lib/libpersonview.py:112
-#: ../gramps/plugins/lib/libplaceview.py:93
+#: ../gramps/plugins/lib/libplaceview.py:94
 #: ../gramps/plugins/view/citationlistview.py:104
 #: ../gramps/plugins/view/citationtreeview.py:99
-#: ../gramps/plugins/view/eventview.py:89
+#: ../gramps/plugins/view/eventview.py:85
 #: ../gramps/plugins/view/familyview.py:86
 #: ../gramps/plugins/view/mediaview.py:101
 #: ../gramps/plugins/view/noteview.py:84 ../gramps/plugins/view/repoview.py:99
@@ -29220,30 +29761,302 @@ msgstr "Kiválasztott személy törlése"
 msgid "Merge the selected persons"
 msgstr "Kiválasztott személyek egyesítése"
 
+#: ../gramps/plugins/lib/libpersonview.py:186
+#: ../gramps/plugins/lib/libplaceview.py:269
+#: ../gramps/plugins/view/citationlistview.py:161
+#: ../gramps/plugins/view/citationtreeview.py:303
+#: ../gramps/plugins/view/eventview.py:175
+#: ../gramps/plugins/view/familyview.py:134
+#: ../gramps/plugins/view/mediaview.py:234
+#: ../gramps/plugins/view/noteview.py:134
+#: ../gramps/plugins/view/repoview.py:147
+#: ../gramps/plugins/view/sourceview.py:133
+msgid "Export View..."
+msgstr "Nézet exportálása..."
+
+#: ../gramps/plugins/lib/libpersonview.py:194
+#: ../gramps/plugins/lib/libplaceview.py:277
+#: ../gramps/plugins/view/citationlistview.py:169
+#: ../gramps/plugins/view/citationtreeview.py:311
+#: ../gramps/plugins/view/eventview.py:183
+#: ../gramps/plugins/view/familyview.py:142
+#: ../gramps/plugins/view/fanchartview.py:172
+#: ../gramps/plugins/view/geoclose.py:99 ../gramps/plugins/view/geoevents.py:89
+#: ../gramps/plugins/view/geofamclose.py:97
+#: ../gramps/plugins/view/geofamily.py:89 ../gramps/plugins/view/geomoves.py:96
+#: ../gramps/plugins/view/geoperson.py:97
+#: ../gramps/plugins/view/geoplaces.py:92
+#: ../gramps/plugins/view/mediaview.py:242
+#: ../gramps/plugins/view/noteview.py:142
+#: ../gramps/plugins/view/pedigreeview.py:672
+#: ../gramps/plugins/view/relview.py:364 ../gramps/plugins/view/relview.py:416
+#: ../gramps/plugins/view/repoview.py:155
+#: ../gramps/plugins/view/sourceview.py:141
+msgid "_Add Bookmark"
+msgstr "_Könyvjelző hozzáadása"
+
+#: ../gramps/plugins/lib/libpersonview.py:206
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:289
+#: ../gramps/plugins/lib/libplaceview.py:332
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:181
+#: ../gramps/plugins/view/citationlistview.py:224
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:323
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:195
+#: ../gramps/plugins/view/eventview.py:238
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:154
+#: ../gramps/plugins/view/familyview.py:197
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/fanchartview.py:144
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:71 ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoevents.py:67
+#: ../gramps/plugins/view/geoevents.py:101
+#: ../gramps/plugins/view/geofamclose.py:69
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geofamily.py:67
+#: ../gramps/plugins/view/geofamily.py:101
+#: ../gramps/plugins/view/geomoves.py:68 ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:69
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/geoplaces.py:70
+#: ../gramps/plugins/view/geoplaces.py:104
+#: ../gramps/plugins/view/mediaview.py:254
+#: ../gramps/plugins/view/mediaview.py:297
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:154
+#: ../gramps/plugins/view/noteview.py:197
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/pedigreeview.py:652
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428 ../gramps/plugins/view/repoview.py:167
+#: ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:153
+#: ../gramps/plugins/view/sourceview.py:196
+#: ../gramps/plugins/view/sourceview.py:278
+msgid "_Back"
+msgstr "_Vissza"
+
+#: ../gramps/plugins/lib/libpersonview.py:206
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/view/fanchartview.py:144
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:71 ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geofamclose.py:69
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geomoves.py:68 ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:69
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/pedigreeview.py:652
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/pedigreeview.py:1647
+#: ../gramps/plugins/view/relview.py:364 ../gramps/plugins/view/relview.py:428
+msgid "_Home"
+msgstr "_Kezdés"
+
+#: ../gramps/plugins/lib/libpersonview.py:226
 #: ../gramps/plugins/lib/libpersonview.py:303
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:303
+#: ../gramps/plugins/lib/libplaceview.py:362
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:195
+#: ../gramps/plugins/view/citationlistview.py:254
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:209
+#: ../gramps/plugins/view/eventview.py:268
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:168
+#: ../gramps/plugins/view/familyview.py:227
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/mediaview.py:268
+#: ../gramps/plugins/view/mediaview.py:327
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:168
+#: ../gramps/plugins/view/noteview.py:227
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/repoview.py:181
+#: ../gramps/plugins/view/repoview.py:240
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:167
+#: ../gramps/plugins/view/sourceview.py:226
+#: ../gramps/plugins/view/sourceview.py:278
+msgid "_Add..."
+msgstr "_Hozzáadás..."
+
+#: ../gramps/plugins/lib/libpersonview.py:226
+#: ../gramps/plugins/lib/libpersonview.py:303
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:303
+#: ../gramps/plugins/lib/libplaceview.py:362
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:195
+#: ../gramps/plugins/view/citationlistview.py:254
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:209
+#: ../gramps/plugins/view/eventview.py:268
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:168
+#: ../gramps/plugins/view/familyview.py:227
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/mediaview.py:268
+#: ../gramps/plugins/view/mediaview.py:327
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:168
+#: ../gramps/plugins/view/noteview.py:227
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/repoview.py:181
+#: ../gramps/plugins/view/repoview.py:240
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:167
+#: ../gramps/plugins/view/sourceview.py:226
+#: ../gramps/plugins/view/sourceview.py:278
+msgid "_Merge..."
+msgstr "Öss_zefűzés..."
+
+#: ../gramps/plugins/lib/libpersonview.py:245
+#: ../gramps/plugins/lib/libpersonview.py:403
+#: ../gramps/plugins/lib/libplaceview.py:322
+#: ../gramps/plugins/lib/libplaceview.py:457
+#: ../gramps/plugins/view/citationlistview.py:214
+#: ../gramps/plugins/view/citationlistview.py:342
+#: ../gramps/plugins/view/citationtreeview.py:364
+#: ../gramps/plugins/view/citationtreeview.py:527
+#: ../gramps/plugins/view/eventview.py:228
+#: ../gramps/plugins/view/eventview.py:357
+#: ../gramps/plugins/view/familyview.py:187
+#: ../gramps/plugins/view/familyview.py:328
+#: ../gramps/plugins/view/mediaview.py:287
+#: ../gramps/plugins/view/mediaview.py:441
+#: ../gramps/plugins/view/noteview.py:187
+#: ../gramps/plugins/view/noteview.py:316
+#: ../gramps/plugins/view/repoview.py:200
+#: ../gramps/plugins/view/repoview.py:329
+#: ../gramps/plugins/view/sourceview.py:186
+#: ../gramps/plugins/view/sourceview.py:315
+msgid "action|_Edit..."
+msgstr "_Szerkesztés..."
+
+#: ../gramps/plugins/lib/libpersonview.py:246
+#: ../gramps/plugins/view/pedigreeview.py:684
+#: ../gramps/plugins/view/relview.py:385
+msgid "Person Filter Editor"
+msgstr "Személyszűrő szerkesztő"
+
+#: ../gramps/plugins/lib/libpersonview.py:246
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/view/pedigreeview.py:1657
+msgid "Set _Home Person"
+msgstr "A kii_nduló személy beállítása"
+
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428
+msgid "Go to the default person"
+msgstr "A kiinduló személyhez ugrás"
+
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libplaceview.py:332
+#: ../gramps/plugins/view/citationlistview.py:224
+#: ../gramps/plugins/view/citationtreeview.py:374
+#: ../gramps/plugins/view/eventview.py:238
+#: ../gramps/plugins/view/familyview.py:197
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoevents.py:101
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geofamily.py:101
+#: ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/geoplaces.py:104
+#: ../gramps/plugins/view/mediaview.py:297
+#: ../gramps/plugins/view/noteview.py:197
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428 ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/sourceview.py:196
+msgid "Go to the next object in the history"
+msgstr "A történet következő objektumára ugrás"
+
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libplaceview.py:332
+#: ../gramps/plugins/view/citationlistview.py:224
+#: ../gramps/plugins/view/citationtreeview.py:374
+#: ../gramps/plugins/view/eventview.py:238
+#: ../gramps/plugins/view/familyview.py:197
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoevents.py:101
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geofamily.py:101
+#: ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/geoplaces.py:104
+#: ../gramps/plugins/view/mediaview.py:297
+#: ../gramps/plugins/view/noteview.py:197
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428 ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/sourceview.py:196
+msgid "Go to the previous object in the history"
+msgstr "A történet előző objektumára ugrás"
+
+#: ../gramps/plugins/lib/libpersonview.py:303
+#: ../gramps/plugins/lib/libplaceview.py:362
+#: ../gramps/plugins/view/citationlistview.py:254
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/eventview.py:268
+#: ../gramps/plugins/view/familyview.py:227
+#: ../gramps/plugins/view/mediaview.py:327
+#: ../gramps/plugins/view/noteview.py:227 ../gramps/plugins/view/relview.py:385
+#: ../gramps/plugins/view/relview.py:471 ../gramps/plugins/view/repoview.py:240
+#: ../gramps/plugins/view/sourceview.py:226
+msgid "Edit..."
+msgstr "Szerkesztés..."
+
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:278
+msgid "Forward"
+msgstr "Előre"
+
+#: ../gramps/plugins/lib/libpersonview.py:454
 msgid "_Delete Person"
 msgstr "_Személy törlése"
 
-#: ../gramps/plugins/lib/libpersonview.py:321
+#: ../gramps/plugins/lib/libpersonview.py:472
 msgid "Deleting the person will remove the person from the database."
 msgstr "Személy törlésekor az kikerül az adatbázisból."
 
-#: ../gramps/plugins/lib/libpersonview.py:344
+#: ../gramps/plugins/lib/libpersonview.py:495
 #, python-format
 msgid "Delete Person (%s)"
 msgstr "Személy törlése (%s)"
 
-#: ../gramps/plugins/lib/libpersonview.py:380
-#: ../gramps/plugins/view/pedigreeview.py:695
-#: ../gramps/plugins/view/relview.py:423
-msgid "Person Filter Editor"
-msgstr "Személyszűrő szerkesztő"
-
-#: ../gramps/plugins/lib/libpersonview.py:385
-msgid "Web Connection"
-msgstr "Web kapcsolat"
-
-#: ../gramps/plugins/lib/libpersonview.py:430
+#: ../gramps/plugins/lib/libpersonview.py:535
 msgid ""
 "Exactly two people must be selected to perform a merge. A second person can "
 "be selected by holding down the control key while clicking on the desired "
@@ -29252,65 +30065,31 @@ msgstr ""
 "Pontosan két személyt kell kiválasztani az egyesítéshez. A második személy a "
 "ctrl gomb lenyomásával és a másik jelöltre kattintással választható ki."
 
-#: ../gramps/plugins/lib/libplaceview.py:103
+#: ../gramps/plugins/lib/libplaceview.py:104
 msgid "Edit the selected place"
 msgstr "Kiválasztott helyszín szerkesztése"
 
-#: ../gramps/plugins/lib/libplaceview.py:104
+#: ../gramps/plugins/lib/libplaceview.py:105
 msgid "Delete the selected place"
 msgstr "Kiválasztott helyszín törlése"
 
-#: ../gramps/plugins/lib/libplaceview.py:105
+#: ../gramps/plugins/lib/libplaceview.py:106
 msgid "Merge the selected places"
 msgstr "Kiválasztott helyszínek egyesítése"
 
-#: ../gramps/plugins/lib/libplaceview.py:143
-msgid "Loading..."
-msgstr "Betöltés..."
-
-#: ../gramps/plugins/lib/libplaceview.py:144
-#: ../gramps/plugins/lib/libplaceview.py:202
-msgid ""
-"Attempt to see selected locations with a Map Service (OpenstreetMap, Google "
-"Maps, ...)"
-msgstr ""
-"Kiválasztott helyszín megtekintése Térképszolgáltatással (OpenstreetMap, "
-"Google Maps, ...)"
-
-#: ../gramps/plugins/lib/libplaceview.py:147
-#: ../gramps/plugins/lib/libplaceview.py:200
-msgid "Select a Map Service"
-msgstr "Térképszolgáltatás kiválasztása"
-
-#: ../gramps/plugins/lib/libplaceview.py:149
-msgid "_Look up with Map Service"
-msgstr "_Megtekintés Térképszolgáltatással"
-
-#: ../gramps/plugins/lib/libplaceview.py:151
-msgid ""
-"Attempt to see this location with a Map Service (OpenstreetMap, Google "
-"Maps, ...)"
-msgstr ""
-"A helyszín megtekintése Térképszolgáltatással (OpenstreetMap, Google "
-"Maps, ...)"
-
-#: ../gramps/plugins/lib/libplaceview.py:153
-msgid "Place Filter Editor"
-msgstr "Helyszínszűrő szerkesztő"
-
-#: ../gramps/plugins/lib/libplaceview.py:262
+#: ../gramps/plugins/lib/libplaceview.py:229
 msgid "No map service is available."
 msgstr "Térképszolgáltatás nem elérhető."
 
-#: ../gramps/plugins/lib/libplaceview.py:263
+#: ../gramps/plugins/lib/libplaceview.py:230
 msgid "Check your installation."
 msgstr "Ellenőrizze a telepítést."
 
-#: ../gramps/plugins/lib/libplaceview.py:271
+#: ../gramps/plugins/lib/libplaceview.py:238
 msgid "No place selected."
 msgstr "Nincs hely kiválasztva."
 
-#: ../gramps/plugins/lib/libplaceview.py:272
+#: ../gramps/plugins/lib/libplaceview.py:239
 msgid ""
 "You need to select a place to be able to view it on a map. Some Map Services "
 "might support multiple selections."
@@ -29318,11 +30097,31 @@ msgstr ""
 "A helyet előbb ki kell választania, hogy láthassa a térképen. Néhány "
 "térképszolgáltatás megengedheti a többszörös kiválasztást is."
 
-#: ../gramps/plugins/lib/libplaceview.py:366
+#: ../gramps/plugins/lib/libplaceview.py:323
+msgid "Place Filter Editor"
+msgstr "Helyszínszűrő szerkesztő"
+
+#: ../gramps/plugins/lib/libplaceview.py:415
+msgid "_Look up with Map Service"
+msgstr "_Megtekintés Térképszolgáltatással"
+
+#: ../gramps/plugins/lib/libplaceview.py:466
+msgid ""
+"Attempt to see selected locations with a Map Service (OpenstreetMap, Google "
+"Maps, ...)"
+msgstr ""
+"Kiválasztott helyszín megtekintése Térképszolgáltatással (OpenstreetMap, "
+"Google Maps, ...)"
+
+#: ../gramps/plugins/lib/libplaceview.py:466
+msgid "Select a Map Service"
+msgstr "Térképszolgáltatás kiválasztása"
+
+#: ../gramps/plugins/lib/libplaceview.py:506
 msgid "Cannot delete place."
 msgstr "A hely nem törölhető."
 
-#: ../gramps/plugins/lib/libplaceview.py:367
+#: ../gramps/plugins/lib/libplaceview.py:507
 msgid ""
 "This place is currently referenced by another place. First remove the places "
 "it contains."
@@ -29330,12 +30129,12 @@ msgstr ""
 "Egy másik hely hivatkozik erre a helyre. Először távolítsa el az ezt "
 "tartalmazó helyet."
 
-#: ../gramps/plugins/lib/libplaceview.py:408
-#: ../gramps/plugins/lib/libplaceview.py:416
+#: ../gramps/plugins/lib/libplaceview.py:548
+#: ../gramps/plugins/lib/libplaceview.py:556
 msgid "Cannot merge places."
 msgstr "A helyek nem egyesíthetőek."
 
-#: ../gramps/plugins/lib/libplaceview.py:409
+#: ../gramps/plugins/lib/libplaceview.py:549
 msgid ""
 "Exactly two places must be selected to perform a merge. A second place can "
 "be selected by holding down the control key while clicking on the desired "
@@ -29344,7 +30143,7 @@ msgstr ""
 "Pontosan két helyszínt kell kiválasztani az egyesítéshez. A második helyszín "
 "a ctrl gomb lenyomásával és a másik helyszínre kattintással választható ki."
 
-#: ../gramps/plugins/lib/libplaceview.py:417
+#: ../gramps/plugins/lib/libplaceview.py:557
 msgid "Merging these places would create a cycle in the place hierarchy."
 msgstr "A helyek összefűzése a helyek rangsorában ciklikusságot okozhat."
 
@@ -29364,52 +30163,154 @@ msgstr "Rekurzív rutint biztosít a jelentésekhez"
 msgid "Provides common functionality for Gramps XML import/export."
 msgstr "Közös funkcionalitást biztosít a GRAMPS XML importhoz/exporthoz."
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:106
+#: ../gramps/plugins/lib/libplugins.gpr.py:107
 msgid "Provides holiday information for different countries."
 msgstr "Különböző országok ünnepnapjait adja meg."
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:124
+#: ../gramps/plugins/lib/libplugins.gpr.py:125
 msgid "Manages a HTML file implementing DocBackend."
 msgstr "DocBackend használatával HTML fájlt kezel."
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:142
+#: ../gramps/plugins/lib/libplugins.gpr.py:143
 msgid "Common constants for html files."
 msgstr "HTML fájlok közös állandói."
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:160
+#: ../gramps/plugins/lib/libplugins.gpr.py:161
 msgid "Manages an HTML DOM tree."
 msgstr "HTML DOM fát kezel."
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:178
+#: ../gramps/plugins/lib/libplugins.gpr.py:179
 msgid "Provides base functionality for map services."
 msgstr "Alap funkcionalitást biztosít térképszolgáltatáshoz."
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:195
+#: ../gramps/plugins/lib/libplugins.gpr.py:196
 msgid "Provides Textual Narration."
 msgstr "Szöveges elbeszélést biztosít."
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:212
+#: ../gramps/plugins/lib/libplugins.gpr.py:213
 msgid "Manages an ODF file implementing DocBackend."
 msgstr "DocBackend használatával ODF fájlt kezel."
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:229
+#: ../gramps/plugins/lib/libplugins.gpr.py:230
 msgid "Provides the Base needed for the List People views."
 msgstr "A szükséges alapot biztosítja az Emberlista nézethez."
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:246
+#: ../gramps/plugins/lib/libplugins.gpr.py:247
+msgid "Provides common functionality for Pro-Gen import"
+msgstr "Általános funkcionalitást biztosít a Pro-Gen importhoz"
+
+#: ../gramps/plugins/lib/libplugins.gpr.py:265
 msgid "Provides the Base needed for the List Place views."
 msgstr "A szükséges alapot biztosítja az Helyszínlista nézethez."
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:263
+#: ../gramps/plugins/lib/libplugins.gpr.py:282
 msgid "Provides variable substitution on display lines."
 msgstr "Változó helyettesítést biztosít sorok megjelenítéséhez."
 
-#: ../gramps/plugins/lib/libplugins.gpr.py:279
+#: ../gramps/plugins/lib/libplugins.gpr.py:299
 msgid ""
 "Provides the base needed for the ancestor and descendant graphical reports."
 msgstr ""
 "A szükséges alapokat biztosítja az ősök és leszármazottak grafikus "
 "összesítőihez."
+
+#: ../gramps/plugins/lib/libprogen.py:375
+#, python-format
+msgid "Field '%(fldname)s' not found"
+msgstr "'%(fldname)s' mező nem található"
+
+#: ../gramps/plugins/lib/libprogen.py:491
+#, python-format
+msgid "Not a (right) DEF file: %(dname)s"
+msgstr "Nem (megfelelő) DEF fájl: %(dname)s"
+
+#: ../gramps/plugins/lib/libprogen.py:498
+#: ../gramps/plugins/lib/libprogen.py:732
+msgid "Import from Pro-Gen"
+msgstr "Pro-Genből importálás"
+
+#. start feedback about import progress (GUI / TXT)
+#: ../gramps/plugins/lib/libprogen.py:498
+msgid "Initializing."
+msgstr "Kezdőérték adás."
+
+#. Raise a error message
+#: ../gramps/plugins/lib/libprogen.py:515
+msgid "Not a supported Pro-Gen import file language"
+msgstr "Nem támogatott a Pro-Gen import fájl nyelve"
+
+#: ../gramps/plugins/lib/libprogen.py:531
+msgid "Pro-Gen import"
+msgstr "Pro-Gen import"
+
+#: ../gramps/plugins/lib/libprogen.py:539
+msgid "Saving."
+msgstr "Mentés."
+
+#: ../gramps/plugins/lib/libprogen.py:928
+msgid "Pro-Gen Import"
+msgstr "Pro-Gen import"
+
+#. Hmmm. Just use the plain text.
+#: ../gramps/plugins/lib/libprogen.py:1137
+#, python-format
+msgid "Date did not match: '%(text)s' (%(msg)s)"
+msgstr "A dátum nem egyezik: '%(text)s' (%(msg)s)"
+
+#: ../gramps/plugins/lib/libprogen.py:1152
+#, python-format
+msgid "Time: %s"
+msgstr "Idő: %s"
+
+#. start feedback about import progress (GUI/TXT)
+#: ../gramps/plugins/lib/libprogen.py:1206
+msgid "Importing persons."
+msgstr "Személyek importálása."
+
+#: ../gramps/plugins/lib/libprogen.py:1412
+msgid "see address on "
+msgstr "lásd a címet:"
+
+#: ../gramps/plugins/lib/libprogen.py:1415
+msgid "see also address"
+msgstr "lásd a címet is"
+
+#: ../gramps/plugins/lib/libprogen.py:1515
+msgid "Death cause"
+msgstr "Halál ok"
+
+#. start feedback about import progress (GUI/TXT)
+#: ../gramps/plugins/lib/libprogen.py:1584
+msgid "Importing families."
+msgstr "Családok importálása."
+
+#: ../gramps/plugins/lib/libprogen.py:1689
+msgid "Civil union"
+msgstr "Élettársi kapcsolat"
+
+#: ../gramps/plugins/lib/libprogen.py:1794
+msgid "Wedding"
+msgstr "Esküvő"
+
+#: ../gramps/plugins/lib/libprogen.py:1829
+msgid "future"
+msgstr "jövő"
+
+#. We have seen some case insensitivity in DEF files ...
+#. F13: Father
+#. F14: Mother
+#. start feedback about import progress (GUI/TXT)
+#: ../gramps/plugins/lib/libprogen.py:1901
+msgid "Adding children."
+msgstr "Gyermekek hozzáadása."
+
+#: ../gramps/plugins/lib/libprogen.py:1927
+msgid "Cannot find father for I%(person)s (Father=%(father))"
+msgstr "Nem található apa I%(person)s (Father=%(father)) számára"
+
+#: ../gramps/plugins/lib/libprogen.py:1930
+msgid "Cannot find mother for I%(person)s (Mother=%(mother))"
+msgstr "Nem található anya I%(person)s (Mother=%(mother)) számára"
 
 #: ../gramps/plugins/lib/librecords.py:55
 msgid "Youngest living person"
@@ -29526,92 +30427,77 @@ msgstr "Bal alsó"
 msgid "Bottom Right"
 msgstr "Jobb alsó"
 
-#: ../gramps/plugins/lib/maps/geography.py:309
-#: ../gramps/plugins/view/fanchart2wayview.py:191
-#: ../gramps/plugins/view/fanchartdescview.py:186
-#: ../gramps/plugins/view/fanchartview.py:182
-msgid "_Print..."
-msgstr "_Nyomtatás..."
-
-#: ../gramps/plugins/lib/maps/geography.py:311
-msgid "Print or save the Map"
-msgstr "A térkép nyomtatása vagy mentése"
-
-#: ../gramps/plugins/lib/maps/geography.py:348
-msgid "Map Menu"
-msgstr "Térkép menü"
-
-#: ../gramps/plugins/lib/maps/geography.py:351
+#: ../gramps/plugins/lib/maps/geography.py:355
 msgid "Remove cross hair"
 msgstr "Célkereszt eltávolítása"
 
-#: ../gramps/plugins/lib/maps/geography.py:353
+#: ../gramps/plugins/lib/maps/geography.py:357
 msgid "Add cross hair"
 msgstr "Célkereszt hozzáadása"
 
-#: ../gramps/plugins/lib/maps/geography.py:360
+#: ../gramps/plugins/lib/maps/geography.py:364
 msgid "Unlock zoom and position"
 msgstr "Ismeretlen hely és nagyítás"
 
-#: ../gramps/plugins/lib/maps/geography.py:362
+#: ../gramps/plugins/lib/maps/geography.py:366
 msgid "Lock zoom and position"
 msgstr "Hely és nagyítás zárolása"
 
-#: ../gramps/plugins/lib/maps/geography.py:369
+#: ../gramps/plugins/lib/maps/geography.py:373
 msgid "Add place"
 msgstr "Hely hozzáadása"
 
-#: ../gramps/plugins/lib/maps/geography.py:374
+#: ../gramps/plugins/lib/maps/geography.py:378
 msgid "Link place"
 msgstr "Hely hivatkozása"
 
-#: ../gramps/plugins/lib/maps/geography.py:379
+#: ../gramps/plugins/lib/maps/geography.py:383
 msgid "Add place from kml"
 msgstr "Hely hozzáadása kml-ből"
 
-#: ../gramps/plugins/lib/maps/geography.py:384
+#: ../gramps/plugins/lib/maps/geography.py:388
 msgid "Center here"
 msgstr "Központosítsa ide"
 
-#: ../gramps/plugins/lib/maps/geography.py:397
+#: ../gramps/plugins/lib/maps/geography.py:401
 #, python-format
 msgid "Replace '%(map)s' by =>"
 msgstr "'%(map)s' helyettesítése ezzel =>"
 
-#: ../gramps/plugins/lib/maps/geography.py:416
+#: ../gramps/plugins/lib/maps/geography.py:418
 #, python-format
 msgid "Reload all visible tiles for '%(map)s'."
 msgstr "Az összes látható csempe újratöltése a '%(map)s'-hoz."
 
-#: ../gramps/plugins/lib/maps/geography.py:426
+#: ../gramps/plugins/lib/maps/geography.py:427
 #, python-format
 msgid "Clear the '%(map)s' tiles cache."
 msgstr "Ürítse ki a '%(map)s' mozaik gyorsítótárat."
 
-#: ../gramps/plugins/lib/maps/geography.py:886
+#: ../gramps/plugins/lib/maps/geography.py:850
 msgid "You can't use the print functionality"
 msgstr "A nyomtatás funkciót nem használhatja"
 
-#: ../gramps/plugins/lib/maps/geography.py:887
+#: ../gramps/plugins/lib/maps/geography.py:851
 msgid "Your Gtk version is too old."
 msgstr "A Gtk változata túl öreg."
 
-#: ../gramps/plugins/lib/maps/geography.py:928
-#: ../gramps/plugins/view/geoclose.py:552
-#: ../gramps/plugins/view/geoevents.py:348
-#: ../gramps/plugins/view/geoevents.py:381
-#: ../gramps/plugins/view/geofamclose.py:743
-#: ../gramps/plugins/view/geofamily.py:436
-#: ../gramps/plugins/view/geomoves.py:625
-#: ../gramps/plugins/view/geoperson.py:442
-#: ../gramps/plugins/view/geoperson.py:463
-#: ../gramps/plugins/view/geoperson.py:503
-#: ../gramps/plugins/view/geoplaces.py:440
-#: ../gramps/plugins/view/geoplaces.py:465
+#: ../gramps/plugins/lib/maps/geography.py:895
+#: ../gramps/plugins/view/geoclose.py:624
+#: ../gramps/plugins/view/geoevents.py:401
+#: ../gramps/plugins/view/geoevents.py:434
+#: ../gramps/plugins/view/geofamclose.py:813
+#: ../gramps/plugins/view/geofamily.py:486
+#: ../gramps/plugins/view/geomoves.py:691
+#: ../gramps/plugins/view/geoperson.py:508
+#: ../gramps/plugins/view/geoperson.py:529
+#: ../gramps/plugins/view/geoperson.py:569
+#: ../gramps/plugins/view/geoplaces.py:499
+#: ../gramps/plugins/view/geoplaces.py:524
 msgid "Center on this place"
 msgstr "Központosítson erre a helyre"
 
-#: ../gramps/plugins/lib/maps/geography.py:1007
+#: ../gramps/plugins/lib/maps/geography.py:993
 msgid "Select a kml file used to add places"
 msgstr "Kml fájl kiválasztása hely hozzáadásához"
 
@@ -29636,19 +30522,19 @@ msgstr ""
 "\n"
 "%(bold_start)sKérését nem tudom feldolgozni%(bold_end)s.\n"
 
-#: ../gramps/plugins/lib/maps/geography.py:1203
+#: ../gramps/plugins/lib/maps/geography.py:1228
 msgid "Nothing for this view."
 msgstr "Ez a nézet üres."
 
-#: ../gramps/plugins/lib/maps/geography.py:1204
+#: ../gramps/plugins/lib/maps/geography.py:1229
 msgid "Specific parameters"
 msgstr "Sajátos paraméterek"
 
-#: ../gramps/plugins/lib/maps/geography.py:1222
+#: ../gramps/plugins/lib/maps/geography.py:1247
 msgid "Where to save the tiles for offline mode."
 msgstr "Hova mentse a csempéket offline módhoz."
 
-#: ../gramps/plugins/lib/maps/geography.py:1226
+#: ../gramps/plugins/lib/maps/geography.py:1253
 msgid ""
 "If you have no more space in your file system. You can remove all tiles "
 "placed in the above path.\n"
@@ -29658,15 +30544,15 @@ msgstr ""
 "eltávolíthatja az összes csempét a fenti útvonalból.\n"
 "Legyen óvatos! Ha nincs internet kapcsolata, nem lesz térképe sem."
 
-#: ../gramps/plugins/lib/maps/geography.py:1231
+#: ../gramps/plugins/lib/maps/geography.py:1258
 msgid "Zoom used when centering"
 msgstr "Nagyítás volt központosításkor"
 
-#: ../gramps/plugins/lib/maps/geography.py:1235
+#: ../gramps/plugins/lib/maps/geography.py:1261
 msgid "The maximum number of places to show"
 msgstr "A megmutatandó helyek maximális száma"
 
-#: ../gramps/plugins/lib/maps/geography.py:1239
+#: ../gramps/plugins/lib/maps/geography.py:1265
 msgid ""
 "Use keypad for shortcuts :\n"
 "Either we choose the + and - from the keypad if we select this,\n"
@@ -29676,11 +30562,11 @@ msgstr ""
 "A számbillentyűzeten választhatja a + és - billentyűt,\n"
 "vagy használja a megfelelő karaktereket a billentyűzeten."
 
-#: ../gramps/plugins/lib/maps/geography.py:1245
+#: ../gramps/plugins/lib/maps/geography.py:1271
 msgid "The map"
 msgstr "A térkép"
 
-#: ../gramps/plugins/lib/maps/geography.py:1261
+#: ../gramps/plugins/lib/maps/geography.py:1289
 msgid "Select tile cache directory for offline mode"
 msgstr "Válassza ki a gyorsítótár könyvtárat offline módhoz"
 
@@ -29695,12 +30581,12 @@ msgstr "A csempék rejtett %s könyvtára nem létrehozható"
 msgid "Can't create tiles cache directory for '%s'."
 msgstr "A csempék rejtett '%s' könyvtára nem hozható létre."
 
-#: ../gramps/plugins/lib/maps/placeselection.py:110
-#: ../gramps/plugins/lib/maps/placeselection.py:112
+#: ../gramps/plugins/lib/maps/placeselection.py:119
+#: ../gramps/plugins/lib/maps/placeselection.py:121
 msgid "Place Selection in a region"
 msgstr "Helykiválasztás a régióban"
 
-#: ../gramps/plugins/lib/maps/placeselection.py:113
+#: ../gramps/plugins/lib/maps/placeselection.py:122
 msgid ""
 "Choose the radius of the selection.\n"
 "On the map you should see a circle or an oval depending on the latitude."
@@ -29709,26 +30595,43 @@ msgstr ""
 "A szélességi foktól függően a térképen egy kört, vagy egy oválist kell "
 "látnia."
 
-#: ../gramps/plugins/lib/maps/placeselection.py:151
+#: ../gramps/plugins/lib/maps/placeselection.py:125
+msgid ""
+"\n"
+"In the following table you may have :\n"
+" - a green row related to a selected place."
+msgstr ""
+"\n"
+"Az alábbi táblázatban Önnek lehet :\n"
+" - a kiválasztott helyhez tartozó zöld sora."
+
+#: ../gramps/plugins/lib/maps/placeselection.py:128
+msgid ""
+"\n"
+" - a red row related to a geocoding result."
+msgstr ""
+"\n"
+" - a geokód eredményre vonatkozó vörös sor."
+
+#: ../gramps/plugins/lib/maps/placeselection.py:165
 msgid "The green values in the row correspond to the current place values."
 msgstr "A sor zöld értékei a jelenlegi hely értékeire vonatkoznak."
 
-#. here, we could add value from geography names services ...
 #. if we found no place, we must create a default place.
-#: ../gramps/plugins/lib/maps/placeselection.py:198
+#: ../gramps/plugins/lib/maps/placeselection.py:223
 msgid "New place with empty fields"
 msgstr "Új helyszín üres mezőkkel"
 
-#: ../gramps/plugins/lib/maps/placeselection.py:273
+#: ../gramps/plugins/lib/maps/placeselection.py:298
 msgid "you have a wrong latitude for:"
 msgstr "rossz szélesség a helyre:"
 
-#: ../gramps/plugins/lib/maps/placeselection.py:275
-#: ../gramps/plugins/lib/maps/placeselection.py:285
+#: ../gramps/plugins/lib/maps/placeselection.py:300
+#: ../gramps/plugins/lib/maps/placeselection.py:310
 msgid "Please, correct this before linking"
 msgstr "Kérem, javítsa ezt, mielőtt összekapcsolná"
 
-#: ../gramps/plugins/lib/maps/placeselection.py:283
+#: ../gramps/plugins/lib/maps/placeselection.py:308
 msgid "you have a wrong longitude for:"
 msgstr "rossz hosszúság a helyre:"
 
@@ -29789,7 +30692,7 @@ msgid "Open on maps.google.com"
 msgstr "A maps.google.com-on nyissa meg"
 
 #: ../gramps/plugins/mapservices/mapservice.gpr.py:71
-#: ../gramps/plugins/webreport/narrativeweb.py:1942
+#: ../gramps/plugins/webreport/narrativeweb.py:2037
 msgid "OpenStreetMap"
 msgstr "OpenStreetMap"
 
@@ -29850,7 +30753,7 @@ msgstr "Esemény helye"
 #: ../gramps/plugins/quickview/all_events.py:60
 #: ../gramps/plugins/quickview/all_events.py:109
 #: ../gramps/plugins/quickview/all_events.py:124
-#: ../gramps/plugins/webreport/person.py:874
+#: ../gramps/plugins/webreport/person.py:894
 msgid "Event Type"
 msgstr "Eseménytípus"
 
@@ -29887,13 +30790,13 @@ msgid "Home person not set."
 msgstr "A kiinduló személy nincs beállítva."
 
 #: ../gramps/plugins/quickview/all_relations.py:79
-#: ../gramps/plugins/tool/relcalc.py:194
+#: ../gramps/plugins/tool/relcalc.py:201
 #, python-format
 msgid "%(person)s and %(active_person)s are the same person."
 msgstr "%(person)s és %(active_person)s ugyanaz a személy."
 
 #: ../gramps/plugins/quickview/all_relations.py:88
-#: ../gramps/plugins/tool/relcalc.py:207
+#: ../gramps/plugins/tool/relcalc.py:214
 #, python-format
 msgid "%(person)s is the %(relationship)s of %(active_person)s."
 msgstr "%(active_person)s %(relationship)s-ja %(person)s."
@@ -29928,11 +30831,11 @@ msgid "Parent"
 msgstr "Szülő"
 
 #: ../gramps/plugins/quickview/all_relations.py:286
-#: ../gramps/plugins/view/relview.py:406
-#: ../gramps/plugins/webreport/basepage.py:2327
-#: ../gramps/plugins/webreport/basepage.py:2329
-#: ../gramps/plugins/webreport/person.py:221
-#: ../gramps/plugins/webreport/surname.py:138
+#: ../gramps/plugins/view/relview.py:471
+#: ../gramps/plugins/webreport/basepage.py:2368
+#: ../gramps/plugins/webreport/basepage.py:2370
+#: ../gramps/plugins/webreport/person.py:227
+#: ../gramps/plugins/webreport/surname.py:149
 msgid "Partner"
 msgstr "Társ"
 
@@ -30116,14 +31019,14 @@ msgstr "Emberek"
 #: ../gramps/plugins/view/view.gpr.py:267
 #: ../gramps/plugins/view/view.gpr.py:275
 #: ../gramps/plugins/view/view.gpr.py:306
-#: ../gramps/plugins/webreport/basepage.py:630
-#: ../gramps/plugins/webreport/basepage.py:946
-#: ../gramps/plugins/webreport/basepage.py:1120
-#: ../gramps/plugins/webreport/basepage.py:1246
-#: ../gramps/plugins/webreport/basepage.py:1490
-#: ../gramps/plugins/webreport/basepage.py:1549
-#: ../gramps/plugins/webreport/basepage.py:1619
-#: ../gramps/plugins/webreport/person.py:1170
+#: ../gramps/plugins/webreport/basepage.py:644
+#: ../gramps/plugins/webreport/basepage.py:965
+#: ../gramps/plugins/webreport/basepage.py:1139
+#: ../gramps/plugins/webreport/basepage.py:1265
+#: ../gramps/plugins/webreport/basepage.py:1531
+#: ../gramps/plugins/webreport/basepage.py:1583
+#: ../gramps/plugins/webreport/basepage.py:1652
+#: ../gramps/plugins/webreport/person.py:1243
 #: ../gramps/plugins/webreport/source.py:130
 #: ../gramps/plugins/webreport/source.py:227
 msgid "Sources"
@@ -30256,7 +31159,7 @@ msgstr "Nincs születési kapcsolat a gyermekkel"
 
 #: ../gramps/plugins/quickview/lineage.py:160
 #: ../gramps/plugins/quickview/lineage.py:180
-#: ../gramps/plugins/tool/verify.py:1058
+#: ../gramps/plugins/tool/verify.py:1062
 msgid "Unknown gender"
 msgstr "Ismeretlen nem"
 
@@ -30448,7 +31351,7 @@ msgid "No references for this %s"
 msgstr "Nincs hivatkozás erre: %s"
 
 #: ../gramps/plugins/quickview/reporef.py:62
-#: ../gramps/plugins/webreport/basepage.py:2677
+#: ../gramps/plugins/webreport/basepage.py:2808
 msgid "Call number"
 msgstr "Hívószám"
 
@@ -30689,14 +31592,14 @@ msgid "Ahnentafel Report for %s"
 msgstr "%s őstábla összegzője"
 
 #: ../gramps/plugins/textreport/ancestorreport.py:301
-#: ../gramps/plugins/textreport/detancestralreport.py:838
-#: ../gramps/plugins/textreport/detdescendantreport.py:1029
+#: ../gramps/plugins/textreport/detancestralreport.py:846
+#: ../gramps/plugins/textreport/detdescendantreport.py:1035
 msgid "Page break between generations"
 msgstr "Generációk közötti oldaltörés"
 
 #: ../gramps/plugins/textreport/ancestorreport.py:303
-#: ../gramps/plugins/textreport/detancestralreport.py:840
-#: ../gramps/plugins/textreport/detdescendantreport.py:1031
+#: ../gramps/plugins/textreport/detancestralreport.py:848
+#: ../gramps/plugins/textreport/detdescendantreport.py:1037
 msgid "Whether to start a new page after each generation."
 msgstr "Legyen-e minden generáció új oldalon."
 
@@ -30709,8 +31612,8 @@ msgid "Whether a line break should follow the name."
 msgstr "A sortörés a nevet követően legyen-e."
 
 #: ../gramps/plugins/textreport/birthdayreport.py:65
-#: ../gramps/plugins/textreport/birthdayreport.py:217
-#: ../gramps/plugins/textreport/birthdayreport.py:262
+#: ../gramps/plugins/textreport/birthdayreport.py:224
+#: ../gramps/plugins/textreport/birthdayreport.py:269
 #: ../gramps/plugins/textreport/textplugins.gpr.py:59
 msgid "Birthday and Anniversary Report"
 msgstr "Születésnap és ünnep összegző"
@@ -30719,78 +31622,143 @@ msgstr "Születésnap és ünnep összegző"
 msgid "My Birthday Report"
 msgstr "Születésnapom Jelentés"
 
+#: ../gramps/plugins/textreport/birthdayreport.py:68
+msgid "✝"
+msgstr "✝"
+
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/textreport/birthdayreport.py:214
+#: ../gramps/plugins/textreport/birthdayreport.py:221
 #, python-format
 msgid "Relationships shown are to %s"
 msgstr "A mutatott kapcsolatok vonatkoznak: %s"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:320
+#: ../gramps/plugins/textreport/birthdayreport.py:333
 #, python-format
-msgid "%(person)s, birth%(relation)s"
-msgstr "%(person)s, születés%(relation)s"
+msgid "* %(person)s, birth%(relation)s"
+msgstr "* %(person)s, születés%(relation)s"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/textreport/birthdayreport.py:325
+#: ../gramps/plugins/textreport/birthdayreport.py:338
 #, python-brace-format
-msgid "{person}, {age}{relation}"
-msgid_plural "{person}, {age}{relation}"
-msgstr[0] "{person}, {age}{relation}"
-msgstr[1] "{person}, {age}{relation}"
+msgid "* {year}{person}{dead}, {age}{relation}"
+msgid_plural "* {year}{person}{dead}, {age}{relation}"
+msgstr[0] "* {year}{person}{dead}, {age}{relation}"
+msgstr[1] "* {year}{person}{dead}, {age}{relation}"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:413
+#: ../gramps/plugins/textreport/birthdayreport.py:402
+#, python-format
+msgid ""
+"⚭ %(spouse)s and\n"
+" %(person)s, wedding"
+msgstr ""
+"⚭ %(spouse)s és\n"
+" %(person)s, esküvője"
+
+#. translators: leave all/any {...} untranslated
+#: ../gramps/plugins/textreport/birthdayreport.py:407
+#, python-brace-format
+msgid ""
+"⚭ {year}{spouse}{deadtxt2} and\n"
+" {person}{deadtxt1}, {nyears}"
+msgid_plural ""
+"⚭ {year}{spouse}{deadtxt2} and\n"
+" {person}{deadtxt1}, {nyears}"
+msgstr[0] ""
+"⚭ {year}{spouse}{deadtxt2} és\n"
+" {person}{deadtxt1}, {nyears}"
+msgstr[1] ""
+"⚭ {year}{spouse}{deadtxt2} és\n"
+" {person}{deadtxt1}, {nyears}"
+
+#: ../gramps/plugins/textreport/birthdayreport.py:442
+#, python-brace-format
+msgid "✝ {person}, death {relation}"
+msgstr "✝ {person}, {relation} halála"
+
+#: ../gramps/plugins/textreport/birthdayreport.py:444
+#, python-brace-format
+msgid "✝ {year}{person}, {age}{relation}"
+msgid_plural "✝ {year}{person}, {age}{relation}"
+msgstr[0] "✝ {year}{person}, {age}{relation}"
+msgstr[1] "✝ {year}{person}, {age}{relation}"
+
+#: ../gramps/plugins/textreport/birthdayreport.py:475
 #: ../gramps/plugins/textreport/familygroup.py:716
-#: ../gramps/plugins/textreport/indivcomplete.py:1063
+#: ../gramps/plugins/textreport/indivcomplete.py:1064
 msgid "Select the filter to be applied to the report."
 msgstr "Válassza ki a használandó összesítő-szűrőt."
 
-#: ../gramps/plugins/textreport/birthdayreport.py:422
+#: ../gramps/plugins/textreport/birthdayreport.py:484
 msgid "Title text"
 msgstr "Címszöveg"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:423
+#: ../gramps/plugins/textreport/birthdayreport.py:485
 msgid "Title of report"
 msgstr "A jelentés címe"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:427
+#: ../gramps/plugins/textreport/birthdayreport.py:489
 msgid "First line of text at bottom of report"
 msgstr "A jelentés alján levő szöveg első sora"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:431
+#: ../gramps/plugins/textreport/birthdayreport.py:493
 msgid "Second line of text at bottom of report"
 msgstr "A jelentés alján levő szöveg második sora"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:435
+#: ../gramps/plugins/textreport/birthdayreport.py:497
 msgid "Third line of text at bottom of report"
 msgstr "A jelentés alján levő szöveg harmadik sora"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:446
+#: ../gramps/plugins/textreport/birthdayreport.py:508
 msgid "Include only living people in the report"
 msgstr "Csak élő emberek legyenek a jelentésben"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:455
-#: ../gramps/plugins/textreport/birthdayreport.py:457
+#: ../gramps/plugins/textreport/birthdayreport.py:511
+msgid "Dead Symbol"
+msgstr "Halálozás jel"
+
+#: ../gramps/plugins/textreport/birthdayreport.py:512
+msgid "This will show after name to indicate that person is dead"
+msgstr "A nevet követően jelöli a személy halálát"
+
+#: ../gramps/plugins/textreport/birthdayreport.py:519
+msgid "Show event year"
+msgstr "Esemény évének mutatása"
+
+#: ../gramps/plugins/textreport/birthdayreport.py:520
+msgid "Prints the year the event took place in the report"
+msgstr "A jelentésben kinyomtatja az évet, amikor az esemény történt"
+
+#: ../gramps/plugins/textreport/birthdayreport.py:525
+#: ../gramps/plugins/textreport/birthdayreport.py:527
 msgid "Year of report"
 msgstr "A jelentés éve"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:496
-#: ../gramps/plugins/textreport/indivcomplete.py:1146
+#: ../gramps/plugins/textreport/birthdayreport.py:563
+msgid "Include death anniversaries"
+msgstr "Halálozási évfordulókkal együtt"
+
+#: ../gramps/plugins/textreport/birthdayreport.py:564
+msgid "Whether to include anniversaries of death"
+msgstr "Legyenek-e benne halálozási évfordulók is"
+
+#: ../gramps/plugins/textreport/birthdayreport.py:570
+#: ../gramps/plugins/textreport/indivcomplete.py:1147
 msgid "Whether to include relationships to the center person"
 msgstr "Legyen-e benne családi kapcsolat a központi személyhez"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:565
+#: ../gramps/plugins/textreport/birthdayreport.py:639
 msgid "Title text style"
 msgstr "Cím szövegstílus"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:568
+#: ../gramps/plugins/textreport/birthdayreport.py:642
 msgid "Data text display"
 msgstr "Adatszöveg mutatása"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:570
+#: ../gramps/plugins/textreport/birthdayreport.py:644
 msgid "Day text style"
 msgstr "Nap szövegstílus"
 
-#: ../gramps/plugins/textreport/birthdayreport.py:573
+#: ../gramps/plugins/textreport/birthdayreport.py:647
 msgid "Month text style"
 msgstr "Hónap szövegstílus"
 
@@ -30846,7 +31814,7 @@ msgid "%s sp."
 msgstr "%s ht."
 
 #: ../gramps/plugins/textreport/descendreport.py:526
-#: ../gramps/plugins/textreport/detdescendantreport.py:1005
+#: ../gramps/plugins/textreport/detdescendantreport.py:1011
 msgid "Numbering system"
 msgstr "Számozási rendszer"
 
@@ -30855,17 +31823,17 @@ msgid "Simple numbering"
 msgstr "Egyszerű számozás"
 
 #: ../gramps/plugins/textreport/descendreport.py:529
-#: ../gramps/plugins/textreport/detdescendantreport.py:1009
+#: ../gramps/plugins/textreport/detdescendantreport.py:1015
 msgid "d'Aboville numbering"
 msgstr "d'Aboville-számozás"
 
 #: ../gramps/plugins/textreport/descendreport.py:530
-#: ../gramps/plugins/textreport/detdescendantreport.py:1007
+#: ../gramps/plugins/textreport/detdescendantreport.py:1013
 msgid "Henry numbering"
 msgstr "Henry-számozás"
 
 #: ../gramps/plugins/textreport/descendreport.py:531
-#: ../gramps/plugins/textreport/detdescendantreport.py:1008
+#: ../gramps/plugins/textreport/detdescendantreport.py:1014
 msgid "Modified Henry numbering"
 msgstr "Módosított Henry-számozás"
 
@@ -30878,7 +31846,7 @@ msgid "Meurgey de Tupigny numbering"
 msgstr "Meurgey de Tupigny számozás"
 
 #: ../gramps/plugins/textreport/descendreport.py:534
-#: ../gramps/plugins/textreport/detdescendantreport.py:1012
+#: ../gramps/plugins/textreport/detdescendantreport.py:1018
 msgid "The numbering system to be used"
 msgstr "A használandó számozási rendszer"
 
@@ -30917,57 +31885,57 @@ msgid "The style used for the spouse level %d display."
 msgstr "%d házastársi szint ábrázolásának stílusa."
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/textreport/detancestralreport.py:214
+#: ../gramps/plugins/textreport/detancestralreport.py:216
 #, python-format
 msgid "Ancestral Report for %s"
 msgstr "%s származás összegzője"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:277
-#: ../gramps/plugins/textreport/detdescendantreport.py:888
-#: ../gramps/plugins/textreport/detdescendantreport.py:906
-#: ../gramps/plugins/textreport/detdescendantreport.py:917
-#: ../gramps/plugins/textreport/detdescendantreport.py:943
+#: ../gramps/plugins/textreport/detancestralreport.py:279
+#: ../gramps/plugins/textreport/detdescendantreport.py:894
+#: ../gramps/plugins/textreport/detdescendantreport.py:912
+#: ../gramps/plugins/textreport/detdescendantreport.py:923
+#: ../gramps/plugins/textreport/detdescendantreport.py:949
 #, python-format
 msgid "More about %(person_name)s:"
 msgstr "Még több %(person_name)s:"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:315
+#: ../gramps/plugins/textreport/detancestralreport.py:317
 #, python-format
 msgid "%(name)s is the same person as [%(id_str)s]."
 msgstr "%(name)s ugyanaz a személy, mint [%(id_str)s]."
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/textreport/detancestralreport.py:357
-#: ../gramps/plugins/textreport/detdescendantreport.py:875
+#: ../gramps/plugins/textreport/detancestralreport.py:361
+#: ../gramps/plugins/textreport/detdescendantreport.py:881
 #, python-format
 msgid "Notes for %s"
 msgstr "%s jegyzetei"
 
 #. translators: needed for French, ignore otherwise
-#: ../gramps/plugins/textreport/detancestralreport.py:375
-#: ../gramps/plugins/textreport/detancestralreport.py:426
-#: ../gramps/plugins/textreport/detancestralreport.py:494
-#: ../gramps/plugins/textreport/detdescendantreport.py:519
-#: ../gramps/plugins/textreport/detdescendantreport.py:811
-#: ../gramps/plugins/textreport/detdescendantreport.py:896
-#: ../gramps/plugins/textreport/detdescendantreport.py:952
+#: ../gramps/plugins/textreport/detancestralreport.py:379
+#: ../gramps/plugins/textreport/detancestralreport.py:430
+#: ../gramps/plugins/textreport/detancestralreport.py:498
+#: ../gramps/plugins/textreport/detdescendantreport.py:521
+#: ../gramps/plugins/textreport/detdescendantreport.py:815
+#: ../gramps/plugins/textreport/detdescendantreport.py:902
+#: ../gramps/plugins/textreport/detdescendantreport.py:958
 #, python-format
 msgid "%(type)s: %(value)s%(endnotes)s"
 msgstr "%(type)s: %(value)s%(endnotes)s"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:404
-#: ../gramps/plugins/textreport/detdescendantreport.py:930
+#: ../gramps/plugins/textreport/detancestralreport.py:408
+#: ../gramps/plugins/textreport/detdescendantreport.py:936
 msgid "Address: "
 msgstr "Lakcím: "
 
 #. translators: needed for Arabic, ignore otherwise
-#: ../gramps/plugins/textreport/detancestralreport.py:413
-#: ../gramps/plugins/textreport/detdescendantreport.py:933
+#: ../gramps/plugins/textreport/detancestralreport.py:417
+#: ../gramps/plugins/textreport/detdescendantreport.py:939
 #, python-format
 msgid "%s, "
 msgstr "%s, "
 
-#: ../gramps/plugins/textreport/detancestralreport.py:475
+#: ../gramps/plugins/textreport/detancestralreport.py:479
 #, python-format
 msgid "%(event_role)s at %(event_name)s of %(primary_person)s: %(event_text)s"
 msgstr ""
@@ -30975,199 +31943,199 @@ msgstr ""
 "ben)"
 
 #. translators: needed for Arabic, ignore otherwise
-#: ../gramps/plugins/textreport/detancestralreport.py:491
-#: ../gramps/plugins/textreport/detdescendantreport.py:413
-#: ../gramps/plugins/textreport/detdescendantreport.py:516
+#: ../gramps/plugins/textreport/detancestralreport.py:495
+#: ../gramps/plugins/textreport/detdescendantreport.py:415
+#: ../gramps/plugins/textreport/detdescendantreport.py:518
 #: ../gramps/plugins/textreport/familygroup.py:137
 msgid "; "
 msgstr "; "
 
-#: ../gramps/plugins/textreport/detancestralreport.py:600
-#: ../gramps/plugins/textreport/detdescendantreport.py:677
+#: ../gramps/plugins/textreport/detancestralreport.py:604
+#: ../gramps/plugins/textreport/detdescendantreport.py:679
 #, python-format
 msgid "Children of %(mother_name)s and %(father_name)s"
 msgstr "%(mother_name)s és %(father_name)s gyermekei"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:684
-#: ../gramps/plugins/textreport/detdescendantreport.py:784
-#: ../gramps/plugins/textreport/detdescendantreport.py:803
+#: ../gramps/plugins/textreport/detancestralreport.py:690
+#: ../gramps/plugins/textreport/detdescendantreport.py:788
+#: ../gramps/plugins/textreport/detdescendantreport.py:807
 #, python-format
 msgid "More about %(mother_name)s and %(father_name)s:"
 msgstr "Még több %(mother_name)s és %(father_name)s:"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:739
-#: ../gramps/plugins/textreport/detdescendantreport.py:612
+#: ../gramps/plugins/textreport/detancestralreport.py:745
+#: ../gramps/plugins/textreport/detdescendantreport.py:614
 #, python-format
 msgid "Spouse: %s"
 msgstr "Házastárs: %s"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:743
-#: ../gramps/plugins/textreport/detdescendantreport.py:616
+#: ../gramps/plugins/textreport/detancestralreport.py:749
+#: ../gramps/plugins/textreport/detdescendantreport.py:618
 #, python-format
 msgid "Relationship with: %s"
 msgstr "Kapcsolat vele: %s"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:827
+#: ../gramps/plugins/textreport/detancestralreport.py:835
 msgid "Sosa-Stradonitz number"
 msgstr "Sosa-Stradonicz szám"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:829
+#: ../gramps/plugins/textreport/detancestralreport.py:837
 msgid "The Sosa-Stradonitz number of the central person."
 msgstr "A központi személy Sosa-Stradonitz száma."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:843
-#: ../gramps/plugins/textreport/detdescendantreport.py:1034
-#: ../gramps/plugins/textreport/indivcomplete.py:1076
+#: ../gramps/plugins/textreport/detancestralreport.py:851
+#: ../gramps/plugins/textreport/detdescendantreport.py:1040
+#: ../gramps/plugins/textreport/indivcomplete.py:1077
 msgid "Page break before end notes"
 msgstr "Végjegyzet előtt oldaltörés"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:845
-#: ../gramps/plugins/textreport/detdescendantreport.py:1036
-#: ../gramps/plugins/textreport/indivcomplete.py:1078
+#: ../gramps/plugins/textreport/detancestralreport.py:853
+#: ../gramps/plugins/textreport/detdescendantreport.py:1042
+#: ../gramps/plugins/textreport/indivcomplete.py:1079
 msgid "Whether to start a new page before the end notes."
 msgstr "Legyen-e oldaltörés a végjegyzet előtt."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:867
-#: ../gramps/plugins/textreport/detdescendantreport.py:1058
+#: ../gramps/plugins/textreport/detancestralreport.py:875
+#: ../gramps/plugins/textreport/detdescendantreport.py:1064
 msgid "Use complete sentences"
 msgstr "Teljes mondatok használata"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:869
-#: ../gramps/plugins/textreport/detdescendantreport.py:1060
+#: ../gramps/plugins/textreport/detancestralreport.py:877
+#: ../gramps/plugins/textreport/detdescendantreport.py:1066
 msgid "Whether to use complete sentences or succinct language."
 msgstr "Teljes mondatok, vagy tőszavak legyenek-e használva."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:873
-#: ../gramps/plugins/textreport/detdescendantreport.py:1064
+#: ../gramps/plugins/textreport/detancestralreport.py:881
+#: ../gramps/plugins/textreport/detdescendantreport.py:1070
 msgid "Use full dates instead of only the year"
 msgstr "Csak év helyett a teljes dátum használata"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:875
-#: ../gramps/plugins/textreport/detdescendantreport.py:1066
+#: ../gramps/plugins/textreport/detancestralreport.py:883
+#: ../gramps/plugins/textreport/detdescendantreport.py:1072
 msgid "Whether to use full dates instead of just year."
 msgstr "Legyen-e használva csak év helyett a teljes dátum."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:878
-#: ../gramps/plugins/textreport/detdescendantreport.py:1069
+#: ../gramps/plugins/textreport/detancestralreport.py:886
+#: ../gramps/plugins/textreport/detdescendantreport.py:1075
 msgid "Compute death age"
 msgstr "Halálozási kor számolása"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:879
-#: ../gramps/plugins/textreport/detdescendantreport.py:1070
+#: ../gramps/plugins/textreport/detancestralreport.py:887
+#: ../gramps/plugins/textreport/detdescendantreport.py:1076
 msgid "Whether to compute a person's age at death."
 msgstr "Legyen-e számolva a személy halálozási kora."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:882
+#: ../gramps/plugins/textreport/detancestralreport.py:890
 msgid "Omit duplicate ancestors"
 msgstr "Kettőzött ősök mellőzése"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:883
+#: ../gramps/plugins/textreport/detancestralreport.py:891
 msgid "Whether to omit duplicate ancestors."
 msgstr "Mellőzve legyenek-e a kettőzött ősök."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:886
-#: ../gramps/plugins/textreport/detdescendantreport.py:1073
+#: ../gramps/plugins/textreport/detancestralreport.py:894
+#: ../gramps/plugins/textreport/detdescendantreport.py:1079
 msgid "Use callname for common name"
 msgstr "Hívónév használata általánosként"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:887
-#: ../gramps/plugins/textreport/detdescendantreport.py:1074
+#: ../gramps/plugins/textreport/detancestralreport.py:895
+#: ../gramps/plugins/textreport/detdescendantreport.py:1080
 msgid "Whether to use the call name as the first name."
 msgstr "Legyen-e használva keresztnév helyett a hívónév."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:895
-#: ../gramps/plugins/textreport/detdescendantreport.py:1082
+#: ../gramps/plugins/textreport/detancestralreport.py:903
+#: ../gramps/plugins/textreport/detdescendantreport.py:1088
 msgid "Whether to list children."
 msgstr "Legyenek-e listázva a gyerekek."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:898
-#: ../gramps/plugins/textreport/detdescendantreport.py:1085
+#: ../gramps/plugins/textreport/detancestralreport.py:906
+#: ../gramps/plugins/textreport/detdescendantreport.py:1091
 msgid "Include spouses of children"
 msgstr "A gyermekek házastársaival együtt"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:900
-#: ../gramps/plugins/textreport/detdescendantreport.py:1087
+#: ../gramps/plugins/textreport/detancestralreport.py:908
+#: ../gramps/plugins/textreport/detdescendantreport.py:1093
 msgid "Whether to list the spouses of the children."
 msgstr "Legyenek-e listázva a gyermekek házastársai."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:903
-#: ../gramps/plugins/textreport/detdescendantreport.py:1099
+#: ../gramps/plugins/textreport/detancestralreport.py:911
+#: ../gramps/plugins/textreport/detdescendantreport.py:1105
 msgid "Include events"
 msgstr "Eseményekkel"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:904
-#: ../gramps/plugins/textreport/detdescendantreport.py:1100
+#: ../gramps/plugins/textreport/detancestralreport.py:912
+#: ../gramps/plugins/textreport/detdescendantreport.py:1106
 msgid "Whether to include events."
 msgstr "Legyenek-e benne események is."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:907
+#: ../gramps/plugins/textreport/detancestralreport.py:915
 msgid "Include other events"
 msgstr "Más eseményekkel együtt"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:908
+#: ../gramps/plugins/textreport/detancestralreport.py:916
 msgid "Whether to include other events people participated in."
 msgstr "Legyenek-e benne a résztvevő személyek más eseményei is."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:913
-#: ../gramps/plugins/textreport/detdescendantreport.py:1104
+#: ../gramps/plugins/textreport/detancestralreport.py:921
+#: ../gramps/plugins/textreport/detdescendantreport.py:1110
 msgid "Include descendant reference in child list"
 msgstr "Leszármazott hivatkozással a gyermek listában"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:915
-#: ../gramps/plugins/textreport/detdescendantreport.py:1106
+#: ../gramps/plugins/textreport/detancestralreport.py:923
+#: ../gramps/plugins/textreport/detdescendantreport.py:1112
 msgid "Whether to add descendant references in child list."
 msgstr "Legyen-e a gyermek listában leszármazott hivatkozás."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:919
-#: ../gramps/plugins/textreport/detdescendantreport.py:1110
-#: ../gramps/plugins/textreport/indivcomplete.py:1121
+#: ../gramps/plugins/textreport/detancestralreport.py:927
+#: ../gramps/plugins/textreport/detdescendantreport.py:1116
+#: ../gramps/plugins/textreport/indivcomplete.py:1122
 msgid "Include Photo/Images from Gallery"
 msgstr "A galéria fotóival/képeivel"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:920
-#: ../gramps/plugins/textreport/detdescendantreport.py:1111
-#: ../gramps/plugins/textreport/indivcomplete.py:1122
+#: ../gramps/plugins/textreport/detancestralreport.py:928
+#: ../gramps/plugins/textreport/detdescendantreport.py:1117
+#: ../gramps/plugins/textreport/indivcomplete.py:1123
 msgid "Whether to include images."
 msgstr "Legyenek-e benne képek is."
 
 #. #########################
 #. ###############################
-#: ../gramps/plugins/textreport/detancestralreport.py:923
-#: ../gramps/plugins/textreport/detdescendantreport.py:1114
+#: ../gramps/plugins/textreport/detancestralreport.py:931
+#: ../gramps/plugins/textreport/detdescendantreport.py:1120
 #: ../gramps/plugins/textreport/familygroup.py:782
-#: ../gramps/plugins/textreport/indivcomplete.py:1126
+#: ../gramps/plugins/textreport/indivcomplete.py:1127
 msgid "Include (2)"
 msgstr "(2) beleértve"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:925
-#: ../gramps/plugins/textreport/detdescendantreport.py:1116
+#: ../gramps/plugins/textreport/detancestralreport.py:933
+#: ../gramps/plugins/textreport/detdescendantreport.py:1122
 msgid "Include notes"
 msgstr "Jegyzetekkel"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:926
-#: ../gramps/plugins/textreport/detdescendantreport.py:1117
+#: ../gramps/plugins/textreport/detancestralreport.py:934
+#: ../gramps/plugins/textreport/detdescendantreport.py:1123
 msgid "Whether to include notes."
 msgstr "Legyenek-e benne jegyzetek is."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:929
-#: ../gramps/plugins/textreport/detdescendantreport.py:1120
+#: ../gramps/plugins/textreport/detancestralreport.py:937
+#: ../gramps/plugins/textreport/detdescendantreport.py:1126
 msgid "Include sources"
 msgstr "Forrásokkal"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:930
-#: ../gramps/plugins/textreport/detdescendantreport.py:1121
+#: ../gramps/plugins/textreport/detancestralreport.py:938
+#: ../gramps/plugins/textreport/detdescendantreport.py:1127
 msgid "Whether to include source references."
 msgstr "Legyenek-e benne források is."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:933
-#: ../gramps/plugins/textreport/detdescendantreport.py:1124
-#: ../gramps/plugins/textreport/indivcomplete.py:1113
+#: ../gramps/plugins/textreport/detancestralreport.py:941
+#: ../gramps/plugins/textreport/detdescendantreport.py:1130
+#: ../gramps/plugins/textreport/indivcomplete.py:1114
 msgid "Include sources notes"
 msgstr "Forrásjegyzetekkel"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:935
-#: ../gramps/plugins/textreport/detdescendantreport.py:1126
-#: ../gramps/plugins/textreport/indivcomplete.py:1115
+#: ../gramps/plugins/textreport/detancestralreport.py:943
+#: ../gramps/plugins/textreport/detdescendantreport.py:1132
+#: ../gramps/plugins/textreport/indivcomplete.py:1116
 msgid ""
 "Whether to include source notes in the Endnotes section. Only works if "
 "Include sources is selected."
@@ -31175,153 +32143,153 @@ msgstr ""
 "Legyenek-e forrásjegyzetek a végjegyzet részben. Csak a Forrásjegyzetek "
 "kiválasztása esetén működik."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:939
-#: ../gramps/plugins/textreport/detdescendantreport.py:1130
+#: ../gramps/plugins/textreport/detancestralreport.py:947
+#: ../gramps/plugins/textreport/detdescendantreport.py:1136
 msgid "Include attributes"
 msgstr "Jellemzőkkel"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:940
-#: ../gramps/plugins/textreport/detdescendantreport.py:1131
+#: ../gramps/plugins/textreport/detancestralreport.py:948
+#: ../gramps/plugins/textreport/detdescendantreport.py:1137
 #: ../gramps/plugins/textreport/familygroup.py:773
-#: ../gramps/plugins/textreport/indivcomplete.py:1136
+#: ../gramps/plugins/textreport/indivcomplete.py:1137
 msgid "Whether to include attributes."
 msgstr "Legyenek-e benne jellemzők is."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:943
-#: ../gramps/plugins/textreport/detdescendantreport.py:1134
+#: ../gramps/plugins/textreport/detancestralreport.py:951
+#: ../gramps/plugins/textreport/detdescendantreport.py:1140
 msgid "Include addresses"
 msgstr "Lakcímekkel"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:944
-#: ../gramps/plugins/textreport/detdescendantreport.py:1135
+#: ../gramps/plugins/textreport/detancestralreport.py:952
+#: ../gramps/plugins/textreport/detdescendantreport.py:1141
 msgid "Whether to include addresses."
 msgstr "Legyenek-e benne lakcímek."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:947
-#: ../gramps/plugins/textreport/detdescendantreport.py:1138
+#: ../gramps/plugins/textreport/detancestralreport.py:955
+#: ../gramps/plugins/textreport/detdescendantreport.py:1144
 msgid "Include alternative names"
 msgstr "Alternatív nevekkel"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:948
-#: ../gramps/plugins/textreport/detdescendantreport.py:1139
+#: ../gramps/plugins/textreport/detancestralreport.py:956
+#: ../gramps/plugins/textreport/detdescendantreport.py:1145
 msgid "Whether to include other names."
 msgstr "Legyenek-e benne más nevek is."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:954
-#: ../gramps/plugins/textreport/detdescendantreport.py:1158
+#: ../gramps/plugins/textreport/detancestralreport.py:962
+#: ../gramps/plugins/textreport/detdescendantreport.py:1164
 msgid "Replace missing places with ______"
 msgstr "Hiányzó helyek helyettesítése ezzel: ______"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:955
-#: ../gramps/plugins/textreport/detdescendantreport.py:1160
+#: ../gramps/plugins/textreport/detancestralreport.py:963
+#: ../gramps/plugins/textreport/detdescendantreport.py:1166
 msgid "Whether to replace missing Places with blanks."
 msgstr "A hiányzó helyek legyenek-e szóközökkel helyettesítve."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:958
-#: ../gramps/plugins/textreport/detdescendantreport.py:1163
+#: ../gramps/plugins/textreport/detancestralreport.py:966
+#: ../gramps/plugins/textreport/detdescendantreport.py:1169
 msgid "Replace missing dates with ______"
 msgstr "Hiányzó dátumok helyettesítése ezzel: ______"
 
-#: ../gramps/plugins/textreport/detancestralreport.py:959
-#: ../gramps/plugins/textreport/detdescendantreport.py:1164
+#: ../gramps/plugins/textreport/detancestralreport.py:967
+#: ../gramps/plugins/textreport/detdescendantreport.py:1170
 msgid "Whether to replace missing Dates with blanks."
 msgstr "A hiányzó dátumok legyenek-e szóközökkel helyettesítve."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:992
-#: ../gramps/plugins/textreport/detdescendantreport.py:1197
+#: ../gramps/plugins/textreport/detancestralreport.py:1000
+#: ../gramps/plugins/textreport/detdescendantreport.py:1203
 msgid "The style used for the children list title."
 msgstr "Gyermek lista címstílusa."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:1003
-#: ../gramps/plugins/textreport/detdescendantreport.py:1208
+#: ../gramps/plugins/textreport/detancestralreport.py:1011
+#: ../gramps/plugins/textreport/detdescendantreport.py:1214
 #: ../gramps/plugins/textreport/familygroup.py:900
 msgid "The style used for the text related to the children."
 msgstr "A gyermekekre vonatkozó szöveg stílusa."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:1013
-#: ../gramps/plugins/textreport/detdescendantreport.py:1218
+#: ../gramps/plugins/textreport/detancestralreport.py:1021
+#: ../gramps/plugins/textreport/detdescendantreport.py:1224
 msgid "The style used for the note header."
 msgstr "A megjegyzés fejléchez használt stílus."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:1027
-#: ../gramps/plugins/textreport/detdescendantreport.py:1232
+#: ../gramps/plugins/textreport/detancestralreport.py:1035
+#: ../gramps/plugins/textreport/detdescendantreport.py:1238
 #: ../gramps/plugins/textreport/tableofcontents.py:117
 msgid "The style used for first level headings."
 msgstr "Az első szintű fejléc stílusa."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:1037
-#: ../gramps/plugins/textreport/detdescendantreport.py:1242
+#: ../gramps/plugins/textreport/detancestralreport.py:1045
+#: ../gramps/plugins/textreport/detdescendantreport.py:1248
 #: ../gramps/plugins/textreport/kinshipreport.py:416
 #: ../gramps/plugins/textreport/summary.py:319
 #: ../gramps/plugins/textreport/tableofcontents.py:123
 msgid "The style used for second level headings."
 msgstr "A második szintű fejléc stílusa."
 
-#: ../gramps/plugins/textreport/detancestralreport.py:1047
-#: ../gramps/plugins/textreport/detdescendantreport.py:1252
+#: ../gramps/plugins/textreport/detancestralreport.py:1055
+#: ../gramps/plugins/textreport/detdescendantreport.py:1258
 #: ../gramps/plugins/textreport/endoflinereport.py:335
-#: ../gramps/plugins/textreport/placereport.py:544
+#: ../gramps/plugins/textreport/placereport.py:545
 msgid "The style used for details."
 msgstr "A részletekhez használt stílus."
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/textreport/detdescendantreport.py:340
+#: ../gramps/plugins/textreport/detdescendantreport.py:342
 #, python-format
 msgid "Descendant Report for %(person_name)s"
 msgstr "%(person_name)s leszármazás összesítője"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:634
+#: ../gramps/plugins/textreport/detdescendantreport.py:636
 #, python-format
 msgid "Ref: %(number)s. %(name)s"
 msgstr "Hiv.: %(number)s. %(name)s"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:761
+#: ../gramps/plugins/textreport/detdescendantreport.py:765
 #, python-format
 msgid "Notes for %(mother_name)s and %(father_name)s:"
 msgstr "%(mother_name)s és %(father_name)s jegyzetei:"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1011
+#: ../gramps/plugins/textreport/detdescendantreport.py:1017
 msgid "Record (Modified Register) numbering"
 msgstr "Számozás (Módosított regiszter) felvétele"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1015
+#: ../gramps/plugins/textreport/detdescendantreport.py:1021
 msgid "Report structure"
 msgstr "Összegzés felépítés"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1018
+#: ../gramps/plugins/textreport/detdescendantreport.py:1024
 msgid "show people by generations"
 msgstr "személyek ábrázolása generációk szerint"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1019
+#: ../gramps/plugins/textreport/detdescendantreport.py:1025
 msgid "show people by lineage"
 msgstr "személyek ábrázolása származás szerint"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1020
+#: ../gramps/plugins/textreport/detdescendantreport.py:1026
 msgid "How people are organized in the report"
 msgstr "A személyek hogyan legyenek szervezve az összesítőben"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1090
+#: ../gramps/plugins/textreport/detdescendantreport.py:1096
 #: ../gramps/plugins/textreport/kinshipreport.py:370
 msgid "Include spouses"
 msgstr "Házastársakkal"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1092
+#: ../gramps/plugins/textreport/detdescendantreport.py:1098
 msgid "Whether to include detailed spouse information."
 msgstr "Legyenek-e benne részletes házastársi információk is."
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1095
+#: ../gramps/plugins/textreport/detdescendantreport.py:1101
 msgid "Include spouse reference"
 msgstr "Házastársi hivatkozással együtt"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1096
+#: ../gramps/plugins/textreport/detdescendantreport.py:1102
 msgid "Whether to include reference to spouse."
 msgstr "Legyenek-e benne házastársi hivatkozások is."
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1143
+#: ../gramps/plugins/textreport/detdescendantreport.py:1149
 msgid "Include sign of succession ('+') in child-list"
 msgstr "öröklési jellel ('+') a gyermek listában"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1144
+#: ../gramps/plugins/textreport/detdescendantreport.py:1150
 msgid ""
 "Whether to include a sign ('+') before the descendant number in the child-"
 "list to indicate a child has succession."
@@ -31329,11 +32297,11 @@ msgstr ""
 "Legyen-e a gyermek lista leszármazási száma előtt '+' jel, hogy jelölje, a "
 "gyermeknek van utóda."
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1149
+#: ../gramps/plugins/textreport/detdescendantreport.py:1155
 msgid "Include path to start-person"
 msgstr "A kiinduló személy útvonalával"
 
-#: ../gramps/plugins/textreport/detdescendantreport.py:1150
+#: ../gramps/plugins/textreport/detdescendantreport.py:1156
 msgid ""
 "Whether to include the path of descendancy from the start-person to each "
 "descendant."
@@ -31354,7 +32322,7 @@ msgid "All the ancestors of %s who are missing a parent"
 msgstr "%s összes őse, aki elvesztette szülőjét"
 
 #: ../gramps/plugins/textreport/endoflinereport.py:308
-#: ../gramps/plugins/textreport/placereport.py:518
+#: ../gramps/plugins/textreport/placereport.py:519
 #: ../gramps/plugins/textreport/recordsreport.py:318
 #: ../gramps/plugins/textreport/simplebooktitle.py:181
 #: ../gramps/plugins/textreport/tagreport.py:955
@@ -31503,7 +32471,7 @@ msgid "Alternate Parents"
 msgstr "Alternatív szülők"
 
 #: ../gramps/plugins/textreport/indivcomplete.py:445
-#: ../gramps/plugins/webreport/person.py:1155
+#: ../gramps/plugins/webreport/person.py:1228
 msgid "Associations"
 msgstr "Társítások"
 
@@ -31512,104 +32480,90 @@ msgid "Images"
 msgstr "Képek"
 
 #: ../gramps/plugins/textreport/indivcomplete.py:833
-#: ../gramps/plugins/textreport/indivcomplete.py:855
+#: ../gramps/plugins/textreport/indivcomplete.py:856
 #: ../gramps/plugins/textreport/textplugins.gpr.py:214
 msgid "Complete Individual Report"
 msgstr "Teljes egyéni összesítő"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:935
-#: ../gramps/plugins/tool/dumpgenderstats.py:72
-#: ../gramps/plugins/tool/dumpgenderstats.py:96
-#: ../gramps/plugins/tool/dumpgenderstats.py:99
-msgid "Male"
-msgstr "Férfi"
-
-#: ../gramps/plugins/textreport/indivcomplete.py:937
-#: ../gramps/plugins/tool/dumpgenderstats.py:73
-#: ../gramps/plugins/tool/dumpgenderstats.py:97
-#: ../gramps/plugins/tool/dumpgenderstats.py:99
-msgid "Female"
-msgstr "Nő"
-
-#: ../gramps/plugins/textreport/indivcomplete.py:951
+#: ../gramps/plugins/textreport/indivcomplete.py:952
 msgid "(image)"
 msgstr "(kép)"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1072
+#: ../gramps/plugins/textreport/indivcomplete.py:1073
 msgid "List events chronologically"
 msgstr "Események időrendi listázása"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1073
+#: ../gramps/plugins/textreport/indivcomplete.py:1074
 msgid "Whether to sort events into chronological order."
 msgstr "Legyenek-e az események időrendbe állítva."
 
 #. ###############################
-#: ../gramps/plugins/textreport/indivcomplete.py:1104
+#: ../gramps/plugins/textreport/indivcomplete.py:1105
 msgid "Include Notes"
 msgstr "Jegyzetekkel együtt"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1105
+#: ../gramps/plugins/textreport/indivcomplete.py:1106
 msgid "Whether to include Person and Family Notes."
 msgstr "Legyenek-e benne személy és család megjegyzések is."
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1108
+#: ../gramps/plugins/textreport/indivcomplete.py:1109
 msgid "Include Source Information"
 msgstr "Forrás információval"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1109
+#: ../gramps/plugins/textreport/indivcomplete.py:1110
 msgid "Whether to cite sources."
 msgstr "Legyenek-e idézve a források."
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1131
+#: ../gramps/plugins/textreport/indivcomplete.py:1132
 msgid "Include Tags"
 msgstr "Jelölésekkel együtt"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1132
+#: ../gramps/plugins/textreport/indivcomplete.py:1133
 msgid "Whether to include tags."
 msgstr "Legyenek-e benne jelölések is."
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1135
+#: ../gramps/plugins/textreport/indivcomplete.py:1136
 msgid "Include Attributes"
 msgstr "Jellemzőkkel együtt"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1139
+#: ../gramps/plugins/textreport/indivcomplete.py:1140
 msgid "Include Census Events"
 msgstr "Népszámlálási eseményekkel együtt"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1140
+#: ../gramps/plugins/textreport/indivcomplete.py:1141
 msgid "Whether to include Census Events."
 msgstr "Legyenek-e benne népszámlálási események is."
 
 #. ###############################
-#: ../gramps/plugins/textreport/indivcomplete.py:1150
+#: ../gramps/plugins/textreport/indivcomplete.py:1151
 msgid "Sections"
 msgstr "Bekezdések"
 
 #. ###############################
-#: ../gramps/plugins/textreport/indivcomplete.py:1153
+#: ../gramps/plugins/textreport/indivcomplete.py:1154
 msgid "Event groups"
 msgstr "Eseménycsoportok"
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1154
+#: ../gramps/plugins/textreport/indivcomplete.py:1155
 msgid "Check if a separate section is required."
 msgstr "Ellenőrizze, kell-e külön bekezdés."
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1227
+#: ../gramps/plugins/textreport/indivcomplete.py:1228
 msgid "The style used for the spouse's name."
 msgstr "Házastárs nevéhez használt stílus."
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1246
+#: ../gramps/plugins/textreport/indivcomplete.py:1247
 #: ../gramps/plugins/textreport/notelinkreport.py:217
-#: ../gramps/plugins/textreport/placereport.py:556
+#: ../gramps/plugins/textreport/placereport.py:557
 #: ../gramps/plugins/textreport/tagreport.py:986
 msgid "The basic style used for table headings."
 msgstr "A táblázat fejlécének stílusa."
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1256
+#: ../gramps/plugins/textreport/indivcomplete.py:1257
 msgid "The style used for image notes."
 msgstr "A kép megjegyzésekhez használt stílus."
 
-#: ../gramps/plugins/textreport/indivcomplete.py:1266
+#: ../gramps/plugins/textreport/indivcomplete.py:1267
 msgid "The style used for image descriptions."
 msgstr "A kép leírásához használt stílus."
 
@@ -31738,27 +32692,27 @@ msgstr "Ezzel a hellyel kapcsolatos személyek"
 msgid "%(father)s (%(father_id)s) and %(mother)s (%(mother_id)s)"
 msgstr "%(father)s (%(father_id)s) és %(mother)s (%(mother_id)s)"
 
-#: ../gramps/plugins/textreport/placereport.py:444
+#: ../gramps/plugins/textreport/placereport.py:445
 msgid "Select using filter"
 msgstr "Szűrőhasználat kiválasztása"
 
-#: ../gramps/plugins/textreport/placereport.py:445
+#: ../gramps/plugins/textreport/placereport.py:446
 msgid "Select places using a filter"
 msgstr "Helykiválasztás szűrővel"
 
-#: ../gramps/plugins/textreport/placereport.py:452
+#: ../gramps/plugins/textreport/placereport.py:453
 msgid "Select places individually"
 msgstr "Egyéni helykiválasztás"
 
-#: ../gramps/plugins/textreport/placereport.py:453
+#: ../gramps/plugins/textreport/placereport.py:454
 msgid "List of places to report on"
 msgstr "Az összegzőben levő helyek listája"
 
-#: ../gramps/plugins/textreport/placereport.py:456
+#: ../gramps/plugins/textreport/placereport.py:457
 msgid "Center on"
 msgstr "Legyen ez a központi"
 
-#: ../gramps/plugins/textreport/placereport.py:458
+#: ../gramps/plugins/textreport/placereport.py:459
 msgid "If report is event or person centered"
 msgstr "Ha az összegzőben központi esemény, vagy személy van"
 
@@ -32320,106 +33274,111 @@ msgstr "Törött szülőkapcsolatok keresése"
 msgid "Looking for event problems"
 msgstr "Eseményproblémák keresése"
 
-#: ../gramps/plugins/tool/check.py:1240
+#. Now we go through our backlinks and the dbs table comparing them
+#. check that each real reference has a backlink in the db table
+#. Now we go through the db table and make checks against ours
+#. Check for db backlinks that don't have a reference object at all
+#: ../gramps/plugins/tool/check.py:1240 ../gramps/plugins/tool/check.py:1269
+#: ../gramps/plugins/tool/check.py:1294
 msgid "Looking for backlink reference problems"
 msgstr "Visszahivatkozási problémák keresése"
 
-#: ../gramps/plugins/tool/check.py:1294
+#: ../gramps/plugins/tool/check.py:1329
 msgid "Looking for person reference problems"
 msgstr "Személyhivatkozási problémák keresése"
 
-#: ../gramps/plugins/tool/check.py:1327
+#: ../gramps/plugins/tool/check.py:1362
 msgid "Looking for family reference problems"
 msgstr "Családhivatkozási problémák keresése"
 
-#: ../gramps/plugins/tool/check.py:1353
+#: ../gramps/plugins/tool/check.py:1388
 msgid "Looking for repository reference problems"
 msgstr "Tárolóhivatkozási problémák keresése"
 
-#: ../gramps/plugins/tool/check.py:1388
+#: ../gramps/plugins/tool/check.py:1423
 msgid "Looking for place reference problems"
 msgstr "Helyhivatkozási problémák keresése"
 
-#: ../gramps/plugins/tool/check.py:1499
+#: ../gramps/plugins/tool/check.py:1534
 msgid "Looking for citation reference problems"
 msgstr "Idézet hivatkozási problémák keresése"
 
-#: ../gramps/plugins/tool/check.py:1617
+#: ../gramps/plugins/tool/check.py:1652
 msgid "Looking for source reference problems"
 msgstr "Forrás hivatkozási problémák keresése"
 
-#: ../gramps/plugins/tool/check.py:1659
+#: ../gramps/plugins/tool/check.py:1694
 msgid "Looking for media object reference problems"
 msgstr "Médiaobjektum hivatkozási problémák keresése"
 
-#: ../gramps/plugins/tool/check.py:1781
+#: ../gramps/plugins/tool/check.py:1816
 msgid "Looking for note reference problems"
 msgstr "Jegyzethivatkozási problémák keresése"
 
-#: ../gramps/plugins/tool/check.py:1909
+#: ../gramps/plugins/tool/check.py:1944
 msgid "Updating checksums on media"
 msgstr "Média ellenőrző összegének frissítése"
 
-#: ../gramps/plugins/tool/check.py:1935
+#: ../gramps/plugins/tool/check.py:1970
 msgid "Looking for tag reference problems"
 msgstr "Címke hivatkozási problémák keresése"
 
-#: ../gramps/plugins/tool/check.py:2080
+#: ../gramps/plugins/tool/check.py:2115
 msgid "Looking for media source reference problems"
 msgstr "Média forrás hivatkozási problémák keresése"
 
-#: ../gramps/plugins/tool/check.py:2148
+#: ../gramps/plugins/tool/check.py:2183
 msgid "Looking for Duplicated Gramps ID problems"
 msgstr "Kettőzött GRAMPS-azonosító problémák keresése"
 
-#: ../gramps/plugins/tool/check.py:2380
+#: ../gramps/plugins/tool/check.py:2415
 msgid "No errors were found"
 msgstr "Nincs hiba"
 
-#: ../gramps/plugins/tool/check.py:2381
+#: ../gramps/plugins/tool/check.py:2416
 msgid "The database has passed internal checks"
 msgstr "Az adatbázis megfelelt a belső ellenőrzésnek"
 
-#: ../gramps/plugins/tool/check.py:2384
+#: ../gramps/plugins/tool/check.py:2419
 msgid "No errors were found: the database has passed internal checks."
 msgstr "Nincs hiba: az adatbázis megfelelt a belső ellenőrzésnek."
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2391
+#: ../gramps/plugins/tool/check.py:2426
 #, python-brace-format
 msgid "{quantity} broken child/family link was fixed\n"
 msgid_plural "{quantity} broken child/family links were fixed\n"
 msgstr[0] "{quantity} törött gyermek/család hivatkozás javítva\n"
 msgstr[1] "{quantity} törött gyermek/család hivatkozás javítva\n"
 
-#: ../gramps/plugins/tool/check.py:2399
+#: ../gramps/plugins/tool/check.py:2434
 msgid "Non existing child"
 msgstr "Nem létező gyermek"
 
-#: ../gramps/plugins/tool/check.py:2410
+#: ../gramps/plugins/tool/check.py:2445
 #, python-format
 msgid "%(person)s was removed from the family of %(family)s\n"
 msgstr "%(family)s családjából %(person)s személy lett eltávolítva\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2417
+#: ../gramps/plugins/tool/check.py:2452
 #, python-brace-format
 msgid "{quantity} broken spouse/family link was fixed\n"
 msgid_plural "{quantity} broken spouse/family links were fixed\n"
 msgstr[0] "{quantity} törött házastárs/család hivatkozás javítva\n"
 msgstr[1] "{quantity} törött házastárs/család hivatkozás javítva\n"
 
-#: ../gramps/plugins/tool/check.py:2425 ../gramps/plugins/tool/check.py:2453
+#: ../gramps/plugins/tool/check.py:2460 ../gramps/plugins/tool/check.py:2488
 msgid "Non existing person"
 msgstr "Nem létező személy"
 
-#: ../gramps/plugins/tool/check.py:2436 ../gramps/plugins/tool/check.py:2464
+#: ../gramps/plugins/tool/check.py:2471 ../gramps/plugins/tool/check.py:2499
 #, python-format
 msgid "%(person)s was restored to the family of %(family)s\n"
 msgstr "%(family)s családjába %(person)s személy vissza lett helyezve\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2443
+#: ../gramps/plugins/tool/check.py:2478
 #, python-brace-format
 msgid "{quantity} duplicate spouse/family link was found\n"
 msgid_plural "{quantity} duplicate spouse/family links were found\n"
@@ -32427,7 +33386,7 @@ msgstr[0] "{quantity} kettőzött házastárs/család kapcsolatot találtam\n"
 msgstr[1] "{quantity} kettőzött házastárs/család kapcsolatot találtam\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2471
+#: ../gramps/plugins/tool/check.py:2506
 #, python-brace-format
 msgid "{quantity} family with no parents or children found, removed.\n"
 msgid_plural ""
@@ -32438,7 +33397,7 @@ msgstr[1] ""
 "{quantity} szülők, vagy gyermekek nélküli család találat, eltávolítva.\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2483
+#: ../gramps/plugins/tool/check.py:2518
 #, python-brace-format
 msgid "{quantity} corrupted family relationship fixed\n"
 msgid_plural "{quantity} corrupted family relationships fixed\n"
@@ -32446,14 +33405,14 @@ msgstr[0] "{quantity} hibás családi kapcsolat kijavítva\n"
 msgstr[1] "{quantity} hibás családi kapcsolat kijavítva\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2491
+#: ../gramps/plugins/tool/check.py:2526
 #, python-brace-format
 msgid "{quantity} place alternate name fixed\n"
 msgid_plural "{quantity} place alternate names fixed\n"
 msgstr[0] "{quantity} hely helyettesítő név javításra került\n"
 msgstr[1] "{quantity} hely helyettesítő név javításra került\n"
 
-#: ../gramps/plugins/tool/check.py:2500
+#: ../gramps/plugins/tool/check.py:2535
 #, python-brace-format
 msgid "{quantity} person was referenced but not found\n"
 msgid_plural "{quantity} persons were referenced, but not found\n"
@@ -32461,7 +33420,7 @@ msgstr[0] "{quantity} személyre van hivatkozás, de az nem található\n"
 msgstr[1] "{quantity} személyre van hivatkozás, de azok nem találhatóak\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2508
+#: ../gramps/plugins/tool/check.py:2543
 #, python-brace-format
 msgid "{quantity} family was referenced but not found\n"
 msgid_plural "{quantity} families were referenced, but not found\n"
@@ -32469,14 +33428,14 @@ msgstr[0] "{quantity} családra hivatkoznak, de azok nem találhatóak\n"
 msgstr[1] "{quantity} családra hivatkoznak, de az nem található\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2518
+#: ../gramps/plugins/tool/check.py:2553
 #, python-brace-format
 msgid "{quantity} date was corrected\n"
 msgid_plural "{quantity} dates were corrected\n"
 msgstr[0] "{quantity} dátum kijavítva\n"
 msgstr[1] "{quantity} dátum kijavítva\n"
 
-#: ../gramps/plugins/tool/check.py:2527
+#: ../gramps/plugins/tool/check.py:2562
 #, python-brace-format
 msgid "{quantity} repository was referenced but not found\n"
 msgid_plural "{quantity} repositories were referenced, but not found\n"
@@ -32484,14 +33443,14 @@ msgstr[0] "{quantity} tárolóra volt hivatkozás, de az nem található\n"
 msgstr[1] "{quantity} tárolóra volt hivatkozás, de azok nem találhatóak\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2537 ../gramps/plugins/tool/check.py:2624
+#: ../gramps/plugins/tool/check.py:2572 ../gramps/plugins/tool/check.py:2659
 #, python-brace-format
 msgid "{quantity} media object was referenced but not found\n"
 msgid_plural "{quantity} media objects were referenced, but not found\n"
 msgstr[0] "{quantity} médiaobjektumra hivatkoznak, de az nem található\n"
 msgstr[1] "{quantity} médiaobjektumra hivatkoznak, de azok nem találhatóak\n"
 
-#: ../gramps/plugins/tool/check.py:2548
+#: ../gramps/plugins/tool/check.py:2583
 #, python-brace-format
 msgid "Reference to {quantity} missing media object was kept\n"
 msgid_plural "References to {quantity} media objects were kept\n"
@@ -32499,7 +33458,7 @@ msgstr[0] "{quantity} elveszett médiaobjektum hivatkozás megtartva\n"
 msgstr[1] "{quantity} elveszett médiaobjektum hivatkozás megtartva\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2556
+#: ../gramps/plugins/tool/check.py:2591
 #, python-brace-format
 msgid "{quantity} missing media object was replaced\n"
 msgid_plural "{quantity} missing media objects were replaced\n"
@@ -32507,7 +33466,7 @@ msgstr[0] "{quantity} elveszett médiaobjektum áthelyezve\n"
 msgstr[1] "{quantity} elveszett médiaobjektum áthelyezve\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2564
+#: ../gramps/plugins/tool/check.py:2599
 #, python-brace-format
 msgid "{quantity} missing media object was removed\n"
 msgid_plural "{quantity} missing media objects were removed\n"
@@ -32515,7 +33474,7 @@ msgstr[0] "{quantity} elveszett médiaobjektum eltávolítva\n"
 msgstr[1] "{quantity} elveszett médiaobjektum eltávolítva\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2572
+#: ../gramps/plugins/tool/check.py:2607
 #, python-brace-format
 msgid "{quantity} event was referenced but not found\n"
 msgid_plural "{quantity} events were referenced, but not found\n"
@@ -32523,7 +33482,7 @@ msgstr[0] "{quantity} eseményre van hivatkozás, de az nem található\n"
 msgstr[1] "{quantity} eseményre van hivatkozás, de azok nem találhatók\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2580
+#: ../gramps/plugins/tool/check.py:2615
 #, python-brace-format
 msgid "{quantity} invalid birth event name was fixed\n"
 msgid_plural "{quantity} invalid birth event names were fixed\n"
@@ -32531,7 +33490,7 @@ msgstr[0] "{quantity} érvénytelen születési esemény neve javításra kerül
 msgstr[1] "{quantity} érvénytelen születési esemény neve javításra került\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2588
+#: ../gramps/plugins/tool/check.py:2623
 #, python-brace-format
 msgid "{quantity} invalid death event name was fixed\n"
 msgid_plural "{quantity} invalid death event names were fixed\n"
@@ -32539,21 +33498,21 @@ msgstr[0] "{quantity} érvénytelen halálozási esemény neve javításra kerü
 msgstr[1] "{quantity} érvénytelen halálozási esemény neve javításra került\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2596
+#: ../gramps/plugins/tool/check.py:2631
 #, python-brace-format
 msgid "{quantity} place was referenced but not found\n"
 msgid_plural "{quantity} places were referenced, but not found\n"
 msgstr[0] "{quantity} helységre hivatkoztak, de az nem található\n"
 msgstr[1] "{quantity} helységre hivatkoztak, de azok nem találhatók\n"
 
-#: ../gramps/plugins/tool/check.py:2605
+#: ../gramps/plugins/tool/check.py:2640
 #, python-brace-format
 msgid "{quantity} citation was referenced but not found\n"
 msgid_plural "{quantity} citations were referenced, but not found\n"
 msgstr[0] "{quantity} idézetre hivatkoztak, de az nem található\n"
 msgstr[1] "{quantity} idézetre hivatkoztak, de azok nem találhatók\n"
 
-#: ../gramps/plugins/tool/check.py:2615
+#: ../gramps/plugins/tool/check.py:2650
 #, python-brace-format
 msgid "{quantity} source was referenced but not found\n"
 msgid_plural "{quantity} sources were referenced, but not found\n"
@@ -32561,7 +33520,7 @@ msgstr[0] "{quantity} forrásra hivatkoznak, de az nem található\n"
 msgstr[1] "{quantity} helységre hivatkoznak, de azok nem találhatóak\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2633
+#: ../gramps/plugins/tool/check.py:2668
 #, python-brace-format
 msgid "{quantity} note object was referenced but not found\n"
 msgid_plural "{quantity} note objects were referenced, but not found\n"
@@ -32570,7 +33529,7 @@ msgstr[1] ""
 "{quantity} jegyzet objektumra hivatkoznak, de azok nem találhatóak\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2643 ../gramps/plugins/tool/check.py:2653
+#: ../gramps/plugins/tool/check.py:2678 ../gramps/plugins/tool/check.py:2688
 #, python-brace-format
 msgid "{quantity} tag object was referenced but not found\n"
 msgid_plural "{quantity} tag objects were referenced, but not found\n"
@@ -32579,7 +33538,7 @@ msgstr[1] ""
 "{quantity} címke objektumra van hivatkozás, de azok nem találhatóak\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2663
+#: ../gramps/plugins/tool/check.py:2698
 #, python-brace-format
 msgid "{quantity} invalid name format reference was removed\n"
 msgid_plural "{quantity} invalid name format references were removed\n"
@@ -32588,7 +33547,7 @@ msgstr[0] ""
 msgstr[1] ""
 "{quantity} érvénytelen névformátum-hivatkozás került eltávolításra\n"
 
-#: ../gramps/plugins/tool/check.py:2674
+#: ../gramps/plugins/tool/check.py:2709
 #, python-brace-format
 msgid "{quantity} invalid source citation was fixed\n"
 msgid_plural "{quantity} invalid source citations were fixed\n"
@@ -32596,14 +33555,14 @@ msgstr[0] "{quantity} érvénytelen születési esemény neve javításra kerül
 msgstr[1] "{quantity} érvénytelen születési esemény neve javításra került\n"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/tool/check.py:2683
+#: ../gramps/plugins/tool/check.py:2718
 #, python-brace-format
 msgid "{quantity} Duplicated Gramps ID fixed\n"
 msgid_plural "{quantity} Duplicated Gramps IDs fixed\n"
 msgstr[0] "{quantity} GRAMPS-azonosító kijavítva\n"
 msgstr[1] "{quantity} GRAMPS-azonosító kijavítva\n"
 
-#: ../gramps/plugins/tool/check.py:2690
+#: ../gramps/plugins/tool/check.py:2725
 #, python-format
 msgid ""
 "%(empty_obj)d empty objects removed:\n"
@@ -32626,22 +33585,22 @@ msgstr ""
 "   %(repo)d tárolóobjektum\n"
 "   %(note)d jegyzet objektum\n"
 
-#: ../gramps/plugins/tool/check.py:2712
+#: ../gramps/plugins/tool/check.py:2747
 #, python-format
 msgid "%d bad backlinks were fixed;\n"
 msgstr "%d rossz visszahivatkozás javítva;\n"
 
-#: ../gramps/plugins/tool/check.py:2714
+#: ../gramps/plugins/tool/check.py:2749
 #: ../gramps/plugins/tool/rebuildrefmap.py:92
 #: ../gramps/plugins/tool/rebuildrefmap.py:95
 msgid "All reference maps have been rebuilt."
 msgstr "Minden hivatkozási térkép újraépült."
 
-#: ../gramps/plugins/tool/check.py:2742
+#: ../gramps/plugins/tool/check.py:2777
 msgid "Integrity Check Results"
 msgstr "Teljesség-ellenőrzés eredményei"
 
-#: ../gramps/plugins/tool/check.py:2748
+#: ../gramps/plugins/tool/check.py:2783
 msgid "Check and Repair"
 msgstr "Ellenőrzés és javítás"
 
@@ -32880,35 +33839,35 @@ msgstr "Kettőződések keresése"
 msgid "Looking for duplicate people"
 msgstr "Kettőzött emberek keresése"
 
-#: ../gramps/plugins/tool/finddupes.py:199
+#: ../gramps/plugins/tool/finddupes.py:200
 msgid "Pass 1: Building preliminary lists"
 msgstr "1. lépés: Előzetes lista készítése"
 
-#: ../gramps/plugins/tool/finddupes.py:217
+#: ../gramps/plugins/tool/finddupes.py:218
 msgid "Pass 2: Calculating potential matches"
 msgstr "2. lépés: lehetséges egyezések számítása"
 
-#: ../gramps/plugins/tool/finddupes.py:555
+#: ../gramps/plugins/tool/finddupes.py:556
 msgid "Potential Merges"
 msgstr "Lehetséges összevonások"
 
-#: ../gramps/plugins/tool/finddupes.py:571
+#: ../gramps/plugins/tool/finddupes.py:573
 msgid "Rating"
 msgstr "Értékelés"
 
-#: ../gramps/plugins/tool/finddupes.py:572
+#: ../gramps/plugins/tool/finddupes.py:574
 msgid "First Person"
 msgstr "Első személy"
 
-#: ../gramps/plugins/tool/finddupes.py:573
+#: ../gramps/plugins/tool/finddupes.py:575
 msgid "Second Person"
 msgstr "Második személy"
 
-#: ../gramps/plugins/tool/finddupes.py:583
+#: ../gramps/plugins/tool/finddupes.py:585
 msgid "Merge candidates"
 msgstr "Jelöltek összevonása"
 
-#: ../gramps/plugins/tool/finddupes.py:583
+#: ../gramps/plugins/tool/finddupes.py:585
 msgid "Merge persons"
 msgstr "Személyek összefűzése"
 
@@ -32933,27 +33892,31 @@ msgid "Looking for possible loop for each person"
 msgstr "Lehetséges hurok keresése minden személynél"
 
 #: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager..."
-msgstr "_Médiakezelő..."
+msgid "manual|Media_Manager"
+msgstr "_Médiakezelő"
 
 #: ../gramps/plugins/tool/mediamanager.py:88
-#: ../gramps/plugins/tool/mediamanager.py:114
+#: ../gramps/plugins/tool/mediamanager.py:118
 #: ../gramps/plugins/tool/tools.gpr.py:176
 msgid "Media Manager"
 msgstr "Médiakezelő"
 
-#: ../gramps/plugins/tool/mediamanager.py:97
-#: ../gramps/plugins/webreport/basepage.py:1483
-#: ../gramps/plugins/webreport/basepage.py:1606
+#: ../gramps/plugins/tool/mediamanager.py:91
+msgid "Help"
+msgstr "Súgó"
+
+#: ../gramps/plugins/tool/mediamanager.py:101
+#: ../gramps/plugins/webreport/basepage.py:1523
+#: ../gramps/plugins/webreport/basepage.py:1639
 #: ../gramps/plugins/webreport/introduction.py:78
 msgid "Introduction"
 msgstr "Bevezetés"
 
-#: ../gramps/plugins/tool/mediamanager.py:100
+#: ../gramps/plugins/tool/mediamanager.py:104
 msgid "Selection"
 msgstr "Kiválasztás"
 
-#: ../gramps/plugins/tool/mediamanager.py:229
+#: ../gramps/plugins/tool/mediamanager.py:233
 #, python-format
 msgid ""
 "This tool allows batch operations on media objects stored in Gramps. An "
@@ -32991,22 +33954,22 @@ msgstr ""
 "kívül, önállóan teheti meg. Ebben az esetben ezzel az eszközzel a "
 "médiaobjektum tárolásának útvonalát, korrekt helyét pontosíthatja."
 
-#: ../gramps/plugins/tool/mediamanager.py:340
+#: ../gramps/plugins/tool/mediamanager.py:344
 msgid "Affected path"
 msgstr "Érintett útvonal"
 
-#: ../gramps/plugins/tool/mediamanager.py:347
+#: ../gramps/plugins/tool/mediamanager.py:351
 msgid ""
 "Press Apply to proceed, Cancel to abort, or Back to revisit your options."
 msgstr ""
 "Válassza az Alkalmaz-gombot a folytatáshoz, a Mégsem-gombot a "
 "megszakításhoz, vagy a Vissza-gombot a beállítások változtatásához."
 
-#: ../gramps/plugins/tool/mediamanager.py:385
+#: ../gramps/plugins/tool/mediamanager.py:389
 msgid "Operation successfully finished"
 msgstr "A művelet sikeresen zárult"
 
-#: ../gramps/plugins/tool/mediamanager.py:387
+#: ../gramps/plugins/tool/mediamanager.py:391
 msgid ""
 "The operation you requested has finished successfully. You may press Close "
 "now to continue."
@@ -33014,11 +33977,11 @@ msgstr ""
 "Az kért folyamat sikeresen befejeződött. Nyomja meg a Bezárás-gombot a "
 "folytatáshoz."
 
-#: ../gramps/plugins/tool/mediamanager.py:390
+#: ../gramps/plugins/tool/mediamanager.py:394
 msgid "Operation failed"
 msgstr "Sikertelen művelet"
 
-#: ../gramps/plugins/tool/mediamanager.py:392
+#: ../gramps/plugins/tool/mediamanager.py:396
 msgid ""
 "There was an error while performing the requested operation. You may try "
 "starting the tool again."
@@ -33026,7 +33989,7 @@ msgstr ""
 "Hiba lépett fel a kért folyamat végrehajtásakor. Megpróbálhatja az eszköz "
 "újraindítását."
 
-#: ../gramps/plugins/tool/mediamanager.py:427
+#: ../gramps/plugins/tool/mediamanager.py:431
 #, python-format
 msgid ""
 "The following action is to be performed:\n"
@@ -33037,11 +34000,11 @@ msgstr ""
 "\n"
 "Művelet:\t%s"
 
-#: ../gramps/plugins/tool/mediamanager.py:484
+#: ../gramps/plugins/tool/mediamanager.py:488
 msgid "Replace _substrings in the path"
 msgstr "_Karakterláncrész helyettesítése az útvonalban"
 
-#: ../gramps/plugins/tool/mediamanager.py:485
+#: ../gramps/plugins/tool/mediamanager.py:489
 msgid ""
 "This tool allows replacing specified substring in the path of media objects "
 "with another substring. This can be useful when you move your media files "
@@ -33051,19 +34014,19 @@ msgstr ""
 "médiaobjektumok útvonalaiban másikkal helyettesítsen. Ez akkor lehet "
 "hasznos, ha médiafájljait egyik könyvtárból másikba helyezi"
 
-#: ../gramps/plugins/tool/mediamanager.py:491
+#: ../gramps/plugins/tool/mediamanager.py:495
 msgid "Replace substring settings"
 msgstr "Karakterláncrész helyettesítésének beállításai"
 
-#: ../gramps/plugins/tool/mediamanager.py:504
+#: ../gramps/plugins/tool/mediamanager.py:508
 msgid "_Replace:"
 msgstr "_Csere:"
 
-#: ../gramps/plugins/tool/mediamanager.py:514
+#: ../gramps/plugins/tool/mediamanager.py:518
 msgid "_With:"
 msgstr "_Ezzel:"
 
-#: ../gramps/plugins/tool/mediamanager.py:528
+#: ../gramps/plugins/tool/mediamanager.py:532
 #, python-format
 msgid ""
 "The following action is to be performed:\n"
@@ -33078,11 +34041,11 @@ msgstr ""
 "Átnevezendő:\t\t%(src_fname)s\n"
 "Ezzel:\t\t%(dest_fname)s"
 
-#: ../gramps/plugins/tool/mediamanager.py:569
+#: ../gramps/plugins/tool/mediamanager.py:573
 msgid "Convert paths from relative to _absolute"
 msgstr "Az útvonalak átalakítása relatívból _abszolútba"
 
-#: ../gramps/plugins/tool/mediamanager.py:570
+#: ../gramps/plugins/tool/mediamanager.py:574
 msgid ""
 "This tool allows converting relative media paths to the absolute ones. It "
 "does this by prepending the base path as given in the Preferences, or if "
@@ -33092,11 +34055,11 @@ msgstr ""
 "változtatását. Ezt a Beállításokban megadott alap útvonaltól, vagy, ha az "
 "nincs megadva, akkor a felhasználó könyvtárától függően teszi."
 
-#: ../gramps/plugins/tool/mediamanager.py:603
+#: ../gramps/plugins/tool/mediamanager.py:607
 msgid "Convert paths from absolute to r_elative"
 msgstr "Az útvonal átalakítása abszolútból r_elatívba"
 
-#: ../gramps/plugins/tool/mediamanager.py:604
+#: ../gramps/plugins/tool/mediamanager.py:608
 msgid ""
 "This tool allows converting absolute media paths to a relative path. The "
 "relative path is relative viz-a-viz the base path as given in the "
@@ -33109,15 +34072,15 @@ msgstr ""
 "lehetővé teszi, hogy kapcsolja a fájl helyét az alap útvonalhoz, amit kedve "
 "szerint változtathat."
 
-#: ../gramps/plugins/tool/mediamanager.py:640
+#: ../gramps/plugins/tool/mediamanager.py:644
 msgid "Add images not included in database"
 msgstr "Az adatbázisban nem szereplő képek hozzáadása"
 
-#: ../gramps/plugins/tool/mediamanager.py:641
+#: ../gramps/plugins/tool/mediamanager.py:645
 msgid "Check directories for images not included in database"
 msgstr "Az adatbázisban nem szereplő képek könyvtárainak ellenőrzése"
 
-#: ../gramps/plugins/tool/mediamanager.py:642
+#: ../gramps/plugins/tool/mediamanager.py:646
 msgid ""
 "This tool adds images in directories that are referenced by existing images "
 "in the database."
@@ -33397,40 +34360,44 @@ msgstr "A nemi statisztika a névhez feltételezett nemmel újraépült."
 msgid "Reference maps rebuilt"
 msgstr "Hivatkozási térképek újraépültek"
 
-#: ../gramps/plugins/tool/relcalc.glade:76
+#: ../gramps/plugins/tool/relcalc.glade:90
 msgid "Select a person to determine the relationship"
 msgstr "Válasszon ki egy személyt a kapcsolat meghatározásához"
 
-#: ../gramps/plugins/tool/relcalc.py:106
+#: ../gramps/plugins/tool/relcalc.py:67 ../gramps/plugins/tool/tools.gpr.py:331
+msgid "Relationship Calculator"
+msgstr "Kapcsolat meghatározó"
+
+#: ../gramps/plugins/tool/relcalc.py:110
 #, python-format
 msgid "Relationship calculator: %(person_name)s"
 msgstr "Kapcsolat-meghatározó: %(person_name)s"
 
-#: ../gramps/plugins/tool/relcalc.py:111
+#: ../gramps/plugins/tool/relcalc.py:115
 #, python-format
 msgid "Relationship to %(person_name)s"
 msgstr "Kapcsolat vele: %(person_name)s"
 
-#: ../gramps/plugins/tool/relcalc.py:168
+#: ../gramps/plugins/tool/relcalc.py:175
 msgid "Relationship Calculator tool"
 msgstr "Kapcsolatmeghatározó-eszköz"
 
-#: ../gramps/plugins/tool/relcalc.py:200
+#: ../gramps/plugins/tool/relcalc.py:207
 #, python-format
 msgid "%(person)s and %(active_person)s are not related."
 msgstr "%(person)s és %(active_person)s között nincs kapcsolat."
 
-#: ../gramps/plugins/tool/relcalc.py:219
+#: ../gramps/plugins/tool/relcalc.py:226
 #, python-format
 msgid "Their common ancestor is %s."
 msgstr "Közös ősük %s."
 
-#: ../gramps/plugins/tool/relcalc.py:225
+#: ../gramps/plugins/tool/relcalc.py:232
 #, python-format
 msgid "Their common ancestors are %(ancestor1)s and %(ancestor2)s."
 msgstr "Közös őseik %(ancestor1)s és %(ancestor2)s."
 
-#: ../gramps/plugins/tool/relcalc.py:231
+#: ../gramps/plugins/tool/relcalc.py:238
 msgid "Their common ancestors are: "
 msgstr "Közös őseik: "
 
@@ -33489,7 +34456,7 @@ msgstr "Használatlan objektumok"
 #. Add mark column
 #. Add ignore column
 #: ../gramps/plugins/tool/removeunused.py:184
-#: ../gramps/plugins/tool/verify.py:551
+#: ../gramps/plugins/tool/verify.py:554
 msgid "Mark"
 msgstr "Jelölés"
 
@@ -33598,39 +34565,39 @@ msgstr "Használatlan azonosítók keresése és kiosztása"
 msgid "Sort Events"
 msgstr "Események válogatása"
 
-#: ../gramps/plugins/tool/sortevents.py:97
+#: ../gramps/plugins/tool/sortevents.py:98
 msgid "Sort event changes"
 msgstr "Esemény változások válogatása"
 
-#: ../gramps/plugins/tool/sortevents.py:112
+#: ../gramps/plugins/tool/sortevents.py:113
 msgid "Sorting personal events..."
 msgstr "Személyes események válogatása..."
 
-#: ../gramps/plugins/tool/sortevents.py:134
+#: ../gramps/plugins/tool/sortevents.py:135
 msgid "Sorting family events..."
 msgstr "Családi események válogatása..."
 
-#: ../gramps/plugins/tool/sortevents.py:165
+#: ../gramps/plugins/tool/sortevents.py:166
 msgid "Tool Options"
 msgstr "Eszköz feltételek"
 
-#: ../gramps/plugins/tool/sortevents.py:168
+#: ../gramps/plugins/tool/sortevents.py:169
 msgid "Select the people to sort"
 msgstr "Ember kiválasztása válogatáshoz"
 
-#: ../gramps/plugins/tool/sortevents.py:187
+#: ../gramps/plugins/tool/sortevents.py:188
 msgid "Sort descending"
 msgstr "Csökkenő sorrend"
 
-#: ../gramps/plugins/tool/sortevents.py:188
+#: ../gramps/plugins/tool/sortevents.py:189
 msgid "Set the sort order"
 msgstr "Sorrend beállítása"
 
-#: ../gramps/plugins/tool/sortevents.py:191
+#: ../gramps/plugins/tool/sortevents.py:192
 msgid "Include family events"
 msgstr "Családi eseményekkel"
 
-#: ../gramps/plugins/tool/sortevents.py:192
+#: ../gramps/plugins/tool/sortevents.py:193
 msgid "Sort family events of the person"
 msgstr "A személy családi eseményeinek válogatása"
 
@@ -33683,21 +34650,21 @@ msgstr ""
 "Emberek számának generálása\n"
 "(A szám csak becsült, mert családokat generálunk)"
 
-#: ../gramps/plugins/tool/testcasegenerator.py:375
-#: ../gramps/plugins/tool/testcasegenerator.py:385
-#: ../gramps/plugins/tool/testcasegenerator.py:391
+#: ../gramps/plugins/tool/testcasegenerator.py:377
+#: ../gramps/plugins/tool/testcasegenerator.py:387
+#: ../gramps/plugins/tool/testcasegenerator.py:393
 msgid "Generating testcases"
 msgstr "Teszt esetek generálása"
 
-#: ../gramps/plugins/tool/testcasegenerator.py:376
+#: ../gramps/plugins/tool/testcasegenerator.py:378
 msgid "Generating low level database errors"
 msgstr "Alacsony szintű adatbázis hibák generálása"
 
-#: ../gramps/plugins/tool/testcasegenerator.py:386
+#: ../gramps/plugins/tool/testcasegenerator.py:388
 msgid "Generating database errors"
 msgstr "Adatbázis hibák generálása"
 
-#: ../gramps/plugins/tool/testcasegenerator.py:392
+#: ../gramps/plugins/tool/testcasegenerator.py:394
 msgid "Generating families"
 msgstr "Családok generálása"
 
@@ -33735,36 +34702,36 @@ msgstr "Családok generálása"
 #. This is NOT detected as an error by plugins/tool/Check.py
 #. Creates a person with a birth event pointing to nonexisting place
 #. Creates a person with an event pointing to nonexisting place
-#: ../gramps/plugins/tool/testcasegenerator.py:468
-#: ../gramps/plugins/tool/testcasegenerator.py:504
-#: ../gramps/plugins/tool/testcasegenerator.py:553
-#: ../gramps/plugins/tool/testcasegenerator.py:570
-#: ../gramps/plugins/tool/testcasegenerator.py:596
-#: ../gramps/plugins/tool/testcasegenerator.py:666
-#: ../gramps/plugins/tool/testcasegenerator.py:701
-#: ../gramps/plugins/tool/testcasegenerator.py:721
-#: ../gramps/plugins/tool/testcasegenerator.py:739
-#: ../gramps/plugins/tool/testcasegenerator.py:758
-#: ../gramps/plugins/tool/testcasegenerator.py:779
-#: ../gramps/plugins/tool/testcasegenerator.py:797
-#: ../gramps/plugins/tool/testcasegenerator.py:815
-#: ../gramps/plugins/tool/testcasegenerator.py:833
-#: ../gramps/plugins/tool/testcasegenerator.py:860
-#: ../gramps/plugins/tool/testcasegenerator.py:886
-#: ../gramps/plugins/tool/testcasegenerator.py:913
-#: ../gramps/plugins/tool/testcasegenerator.py:949
-#: ../gramps/plugins/tool/testcasegenerator.py:960
-#: ../gramps/plugins/tool/testcasegenerator.py:971
-#: ../gramps/plugins/tool/testcasegenerator.py:982
-#: ../gramps/plugins/tool/testcasegenerator.py:998
-#: ../gramps/plugins/tool/testcasegenerator.py:1015
-#: ../gramps/plugins/tool/testcasegenerator.py:1039
-#: ../gramps/plugins/tool/testcasegenerator.py:1055
-#: ../gramps/plugins/tool/testcasegenerator.py:1072
-#: ../gramps/plugins/tool/testcasegenerator.py:1105
-#: ../gramps/plugins/tool/testcasegenerator.py:1552
-#: ../gramps/plugins/tool/testcasegenerator.py:1658
-#: ../gramps/plugins/tool/testcasegenerator.py:1683
+#: ../gramps/plugins/tool/testcasegenerator.py:470
+#: ../gramps/plugins/tool/testcasegenerator.py:506
+#: ../gramps/plugins/tool/testcasegenerator.py:555
+#: ../gramps/plugins/tool/testcasegenerator.py:572
+#: ../gramps/plugins/tool/testcasegenerator.py:598
+#: ../gramps/plugins/tool/testcasegenerator.py:668
+#: ../gramps/plugins/tool/testcasegenerator.py:703
+#: ../gramps/plugins/tool/testcasegenerator.py:723
+#: ../gramps/plugins/tool/testcasegenerator.py:741
+#: ../gramps/plugins/tool/testcasegenerator.py:760
+#: ../gramps/plugins/tool/testcasegenerator.py:781
+#: ../gramps/plugins/tool/testcasegenerator.py:799
+#: ../gramps/plugins/tool/testcasegenerator.py:817
+#: ../gramps/plugins/tool/testcasegenerator.py:835
+#: ../gramps/plugins/tool/testcasegenerator.py:862
+#: ../gramps/plugins/tool/testcasegenerator.py:888
+#: ../gramps/plugins/tool/testcasegenerator.py:915
+#: ../gramps/plugins/tool/testcasegenerator.py:951
+#: ../gramps/plugins/tool/testcasegenerator.py:962
+#: ../gramps/plugins/tool/testcasegenerator.py:973
+#: ../gramps/plugins/tool/testcasegenerator.py:984
+#: ../gramps/plugins/tool/testcasegenerator.py:1000
+#: ../gramps/plugins/tool/testcasegenerator.py:1017
+#: ../gramps/plugins/tool/testcasegenerator.py:1041
+#: ../gramps/plugins/tool/testcasegenerator.py:1057
+#: ../gramps/plugins/tool/testcasegenerator.py:1074
+#: ../gramps/plugins/tool/testcasegenerator.py:1107
+#: ../gramps/plugins/tool/testcasegenerator.py:1554
+#: ../gramps/plugins/tool/testcasegenerator.py:1660
+#: ../gramps/plugins/tool/testcasegenerator.py:1685
 #, python-format
 msgid "Testcase generator step %d"
 msgstr "Teszt eset generálás %d lépés"
@@ -33877,10 +34844,6 @@ msgstr "Nemi statisztika újraépítése"
 msgid "Rebuilds gender statistics for name gender guessing..."
 msgstr "Újraépíti a nemi statisztikát a név feltételezett nemével..."
 
-#: ../gramps/plugins/tool/tools.gpr.py:331
-msgid "Relationship Calculator"
-msgstr "Kapcsolat meghatározó"
-
 #: ../gramps/plugins/tool/tools.gpr.py:332
 msgid "Calculates the relationship between two people"
 msgstr "Két ember közötti kapcsolatot határoz meg"
@@ -33922,6 +34885,18 @@ msgstr ""
 #: ../gramps/plugins/tool/tools.gpr.py:466
 msgid "Searches the entire database, looking for a possible loop."
 msgstr "Kutatás a teljes adatbázisban, lehetséges hurok keresése."
+
+#: ../gramps/plugins/tool/tools.gpr.py:489
+msgid "Clean input data"
+msgstr "Bemeneti adatok tisztítása"
+
+#: ../gramps/plugins/tool/tools.gpr.py:490
+msgid ""
+"Searches the entire database, looking for trailing or leading spaces for "
+"places and people. Search comma in coordinates fields in places."
+msgstr ""
+"Keresés a teljes adatbázisban helyek és személyek előtti, vagy utáni "
+"szóközökre. Helyek koordinátamezőiben vessző keresése."
 
 #: ../gramps/plugins/tool/toolsdebug.gpr.py:64
 msgid "Dump Gender Statistics"
@@ -33998,7 +34973,7 @@ msgstr "Legnagyobb korkülönbség a _gyermekek között évben"
 msgid "Maximum _span of years for all children"
 msgstr "Az összes gyermek legnagyobb idő_intervalluma években"
 
-#: ../gramps/plugins/tool/verify.glade:984 ../gramps/plugins/tool/verify.py:670
+#: ../gramps/plugins/tool/verify.glade:984 ../gramps/plugins/tool/verify.py:673
 msgid "_Hide marked"
 msgstr "Megjelöltek _elrejtése"
 
@@ -34016,153 +34991,165 @@ msgstr "Adatbázis ellenőrző-eszköz"
 msgid "%(severity)s: %(msg)s, %(type)s: %(gid)s, %(name)s"
 msgstr "%(severity)s: %(msg)s, %(type)s: %(gid)s, %(name)s"
 
-#: ../gramps/plugins/tool/verify.py:499
+#: ../gramps/plugins/tool/verify.py:502
 msgid "Data Verification Results"
 msgstr "Adatbázis ellenőrzés eredményei"
 
-#: ../gramps/plugins/tool/verify.py:660
+#: ../gramps/plugins/tool/verify.py:663
 msgid "_Show all"
 msgstr "_Minden mutatása"
 
-#: ../gramps/plugins/tool/verify.py:941
+#: ../gramps/plugins/tool/verify.py:945
 msgid "Baptism before birth"
 msgstr "Vízkeresztség születés előtt"
 
-#: ../gramps/plugins/tool/verify.py:957
+#: ../gramps/plugins/tool/verify.py:961
 msgid "Death before baptism"
 msgstr "Vízkeresztség halálozás előtt"
 
-#: ../gramps/plugins/tool/verify.py:973
+#: ../gramps/plugins/tool/verify.py:977
 msgid "Burial before birth"
 msgstr "Temetés születés előtt"
 
-#: ../gramps/plugins/tool/verify.py:989
+#: ../gramps/plugins/tool/verify.py:993
 msgid "Burial before death"
 msgstr "Temetés a halál előtt"
 
-#: ../gramps/plugins/tool/verify.py:1005
+#: ../gramps/plugins/tool/verify.py:1009
 msgid "Death before birth"
 msgstr "Születés előtti halál"
 
-#: ../gramps/plugins/tool/verify.py:1021
+#: ../gramps/plugins/tool/verify.py:1025
 msgid "Burial before baptism"
 msgstr "Temetés vízkeresztség előtt"
 
-#: ../gramps/plugins/tool/verify.py:1044
+#: ../gramps/plugins/tool/verify.py:1048
 msgid "Old age at death"
 msgstr "Halálozási kor"
 
-#: ../gramps/plugins/tool/verify.py:1071
+#: ../gramps/plugins/tool/verify.py:1075
 msgid "Multiple parents"
 msgstr "Több szülő"
 
-#: ../gramps/plugins/tool/verify.py:1093
+#: ../gramps/plugins/tool/verify.py:1097
 msgid "Married often"
 msgstr "Gyakori házasság"
 
-#: ../gramps/plugins/tool/verify.py:1117
+#: ../gramps/plugins/tool/verify.py:1121
 msgid "Old and unmarried"
 msgstr "Idős és nem házasodott"
 
-#: ../gramps/plugins/tool/verify.py:1149
+#: ../gramps/plugins/tool/verify.py:1153
 msgid "Too many children"
 msgstr "Túl sok gyermek"
 
-#: ../gramps/plugins/tool/verify.py:1167
+#: ../gramps/plugins/tool/verify.py:1171
 msgid "Same sex marriage"
 msgstr "Azonos nemű házasság"
 
-#: ../gramps/plugins/tool/verify.py:1180
+#: ../gramps/plugins/tool/verify.py:1184
 msgid "Female husband"
 msgstr "Női férj"
 
-#: ../gramps/plugins/tool/verify.py:1193
+#: ../gramps/plugins/tool/verify.py:1197
 msgid "Male wife"
 msgstr "Férfi feleség"
 
-#: ../gramps/plugins/tool/verify.py:1223
+#: ../gramps/plugins/tool/verify.py:1227
 msgid "Husband and wife with the same surname"
 msgstr "Férj és feleség azonos vezetéknévvel"
 
-#: ../gramps/plugins/tool/verify.py:1253
+#: ../gramps/plugins/tool/verify.py:1257
 msgid "Large age difference between spouses"
 msgstr "Nagy korkülönbség házastársak között"
 
-#: ../gramps/plugins/tool/verify.py:1289
+#: ../gramps/plugins/tool/verify.py:1293
 msgid "Marriage before birth"
 msgstr "Házasság születés előtt"
 
-#: ../gramps/plugins/tool/verify.py:1325
+#: ../gramps/plugins/tool/verify.py:1329
 msgid "Marriage after death"
 msgstr "Házasság halál után"
 
-#: ../gramps/plugins/tool/verify.py:1366
+#: ../gramps/plugins/tool/verify.py:1370
 msgid "Early marriage"
 msgstr "Korai házasság"
 
-#: ../gramps/plugins/tool/verify.py:1405
+#: ../gramps/plugins/tool/verify.py:1409
 msgid "Late marriage"
 msgstr "Késői házasság"
 
-#: ../gramps/plugins/tool/verify.py:1454
+#: ../gramps/plugins/tool/verify.py:1458
 msgid "Old father"
 msgstr "Idős apa"
 
-#: ../gramps/plugins/tool/verify.py:1458
+#: ../gramps/plugins/tool/verify.py:1462
 msgid "Old mother"
 msgstr "Idős anya"
 
-#: ../gramps/plugins/tool/verify.py:1507
+#: ../gramps/plugins/tool/verify.py:1511
 msgid "Young father"
 msgstr "Fiatal apa"
 
-#: ../gramps/plugins/tool/verify.py:1511
+#: ../gramps/plugins/tool/verify.py:1515
 msgid "Young mother"
 msgstr "Fiatal anya"
 
-#: ../gramps/plugins/tool/verify.py:1555
+#: ../gramps/plugins/tool/verify.py:1559
 msgid "Unborn father"
 msgstr "Meg nem született apa"
 
-#: ../gramps/plugins/tool/verify.py:1559
+#: ../gramps/plugins/tool/verify.py:1563
 msgid "Unborn mother"
 msgstr "Meg nem született anya"
 
-#: ../gramps/plugins/tool/verify.py:1610
+#: ../gramps/plugins/tool/verify.py:1614
 msgid "Dead father"
 msgstr "Halott apa"
 
-#: ../gramps/plugins/tool/verify.py:1614
+#: ../gramps/plugins/tool/verify.py:1618
 msgid "Dead mother"
 msgstr "Halott anya"
 
-#: ../gramps/plugins/tool/verify.py:1640
+#: ../gramps/plugins/tool/verify.py:1644
 msgid "Large year span for all children"
 msgstr "Nagy évkülönbség az összes gyermeknél"
 
-#: ../gramps/plugins/tool/verify.py:1667
+#: ../gramps/plugins/tool/verify.py:1671
 msgid "Large age differences between children"
 msgstr "Nagy korkülönbség a gyermekek között"
 
-#: ../gramps/plugins/tool/verify.py:1680
+#: ../gramps/plugins/tool/verify.py:1684
 msgid "Disconnected individual"
 msgstr "Kapcsolat nélküli egyén"
 
-#: ../gramps/plugins/tool/verify.py:1707
+#: ../gramps/plugins/tool/verify.py:1711
 msgid "Invalid birth date"
 msgstr "Érvénytelen születési dátum"
 
-#: ../gramps/plugins/tool/verify.py:1734
+#: ../gramps/plugins/tool/verify.py:1738
 msgid "Invalid death date"
 msgstr "Érvénytelen halálozási dátum"
 
-#: ../gramps/plugins/tool/verify.py:1754
+#: ../gramps/plugins/tool/verify.py:1758
 msgid "Marriage date but not married"
 msgstr "Házassági dátum, de nem is házas"
 
-#: ../gramps/plugins/tool/verify.py:1782
+#: ../gramps/plugins/tool/verify.py:1786
 msgid "Old age but no death"
 msgstr "Öreg korú, de nem halott"
+
+#: ../gramps/plugins/tool/verify.py:1802
+msgid "Birth equals death"
+msgstr "Születés egyenlő halál"
+
+#: ../gramps/plugins/tool/verify.py:1820
+msgid "Birth equals marriage"
+msgstr "Születés egyenlő házasság"
+
+#: ../gramps/plugins/tool/verify.py:1838
+msgid "Death equals marriage"
+msgstr "Halál egyenlő házasság"
 
 #: ../gramps/plugins/view/citationlistview.py:105
 msgid "Source: Title"
@@ -34217,12 +35204,12 @@ msgstr "Kiválasztott idézetek összefűzése"
 msgid "Citation View"
 msgstr "Idézet nézet"
 
-#: ../gramps/plugins/view/citationlistview.py:180
-#: ../gramps/plugins/view/citationtreeview.py:314
+#: ../gramps/plugins/view/citationlistview.py:215
+#: ../gramps/plugins/view/citationtreeview.py:365
 msgid "Citation Filter Editor"
 msgstr "Idézet-szűrő szerkesztő"
 
-#: ../gramps/plugins/view/citationlistview.py:298
+#: ../gramps/plugins/view/citationlistview.py:394
 msgid ""
 "This citation cannot be edited at this time. Either the associated citation "
 "is already being edited or another object that is associated with the same "
@@ -34236,15 +35223,15 @@ msgstr ""
 "\n"
 "Az idézet szerkesztéséhez be kell zárnia az objektumot."
 
-#: ../gramps/plugins/view/citationlistview.py:311
-#: ../gramps/plugins/view/citationlistview.py:322
-#: ../gramps/plugins/view/citationtreeview.py:528
-#: ../gramps/plugins/view/citationtreeview.py:541
+#: ../gramps/plugins/view/citationlistview.py:407
+#: ../gramps/plugins/view/citationlistview.py:418
+#: ../gramps/plugins/view/citationtreeview.py:664
+#: ../gramps/plugins/view/citationtreeview.py:677
 msgid "Cannot merge citations."
 msgstr "Nem összefűzhető idézetek."
 
-#: ../gramps/plugins/view/citationlistview.py:312
-#: ../gramps/plugins/view/citationtreeview.py:529
+#: ../gramps/plugins/view/citationlistview.py:408
+#: ../gramps/plugins/view/citationtreeview.py:665
 msgid ""
 "Exactly two citations must be selected to perform a merge. A second citation "
 "can be selected by holding down the control key while clicking on the "
@@ -34254,8 +35241,8 @@ msgstr ""
 "Ctrl-gomb lenyomása és a kiválasztott idézetre való egyidejű kattintással "
 "választhatja ki."
 
-#: ../gramps/plugins/view/citationlistview.py:323
-#: ../gramps/plugins/view/citationtreeview.py:542
+#: ../gramps/plugins/view/citationlistview.py:419
+#: ../gramps/plugins/view/citationtreeview.py:678
 msgid ""
 "The two selected citations must have the same source to perform a merge. If "
 "you want to merge these two citations, then you must merge the sources first."
@@ -34280,27 +35267,30 @@ msgstr "A kiválasztott idézetek, vagy források összefűzése"
 msgid "Citation Tree View"
 msgstr "Idézet-fa nézet"
 
-#: ../gramps/plugins/view/citationtreeview.py:301
-msgid "Add source..."
-msgstr "Forrás hozzáadása..."
-
-#: ../gramps/plugins/view/citationtreeview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/citationtreeview.py:475
 msgid "Add citation..."
 msgstr "Idézet hozzáadása..."
 
-#: ../gramps/plugins/view/citationtreeview.py:322
-#: ../gramps/plugins/view/persontreeview.py:82
-#: ../gramps/plugins/view/placetreeview.py:74
-msgid "Expand all Nodes"
-msgstr "Minden csomópont kibontása"
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+msgid "Add source..."
+msgstr "Forrás hozzáadása..."
 
-#: ../gramps/plugins/view/citationtreeview.py:324
-#: ../gramps/plugins/view/persontreeview.py:84
-#: ../gramps/plugins/view/placetreeview.py:76
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/persontreeview.py:87
+#: ../gramps/plugins/view/placetreeview.py:77
 msgid "Collapse all Nodes"
 msgstr "Minden csomópont bezárása"
 
-#: ../gramps/plugins/view/citationtreeview.py:515
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/persontreeview.py:87
+#: ../gramps/plugins/view/placetreeview.py:77
+msgid "Expand all Nodes"
+msgstr "Minden csomópont kibontása"
+
+#: ../gramps/plugins/view/citationtreeview.py:651
 msgid ""
 "This source cannot be edited at this time. Either the associated Source "
 "object is already being edited, or another citation associated with the same "
@@ -34314,11 +35304,11 @@ msgstr ""
 "\n"
 "A forrás szerkesztéséhez be kell zárnia az objektumot."
 
-#: ../gramps/plugins/view/citationtreeview.py:554
+#: ../gramps/plugins/view/citationtreeview.py:690
 msgid "Cannot perform merge."
 msgstr "Nem megvalósítható összefűzés."
 
-#: ../gramps/plugins/view/citationtreeview.py:555
+#: ../gramps/plugins/view/citationtreeview.py:691
 msgid ""
 "Both objects must be of the same type, either both must be sources, or both "
 "must be citations."
@@ -34327,39 +35317,45 @@ msgstr ""
 "vagy mindkettő idézet."
 
 #: ../gramps/plugins/view/dashboardview.py:51
+#: ../gramps/plugins/view/dashboardview.py:83
 #: ../gramps/plugins/view/view.gpr.py:67 ../gramps/plugins/view/view.gpr.py:75
 msgid "Dashboard"
 msgstr "Műszerfal"
 
-#: ../gramps/plugins/view/dashboardview.py:101
-msgid "Restore a gramplet"
-msgstr "Gramplet visszaállítása"
-
-#: ../gramps/plugins/view/eventview.py:100
+#: ../gramps/plugins/view/eventview.py:96
 msgid "Add a new event"
 msgstr "Új esemény hozzáadása"
 
-#: ../gramps/plugins/view/eventview.py:101
+#: ../gramps/plugins/view/eventview.py:97
 msgid "Edit the selected event"
 msgstr "Kiválasztott esemény szerkesztése"
 
-#: ../gramps/plugins/view/eventview.py:102
+#: ../gramps/plugins/view/eventview.py:98
 msgid "Delete the selected event"
 msgstr "Kiválasztott esemény törlése"
 
-#: ../gramps/plugins/view/eventview.py:103
+#: ../gramps/plugins/view/eventview.py:99
 msgid "Merge the selected events"
 msgstr "Kiválasztott események összefűzése"
 
-#: ../gramps/plugins/view/eventview.py:244
+#: ../gramps/plugins/view/eventview.py:229
 msgid "Event Filter Editor"
 msgstr "Eseményszűrő-szerkesztő"
 
-#: ../gramps/plugins/view/eventview.py:296
+#: ../gramps/plugins/view/eventview.py:385
+msgid "_Delete Event"
+msgstr "_Esemény törlése"
+
+#: ../gramps/plugins/view/eventview.py:400
+#, python-brace-format
+msgid "Delete {type} [{gid}]?"
+msgstr "{type} [{gid}] törlése?"
+
+#: ../gramps/plugins/view/eventview.py:443
 msgid "Cannot merge event objects."
 msgstr "Az esemény-objektumok nem összefűzhetőek."
 
-#: ../gramps/plugins/view/eventview.py:297
+#: ../gramps/plugins/view/eventview.py:444
 msgid ""
 "Exactly two events must be selected to perform a merge. A second object can "
 "be selected by holding down the control key while clicking on the desired "
@@ -34389,32 +35385,32 @@ msgstr "A kiválasztott család törlése"
 msgid "Merge the selected families"
 msgstr "A kiválasztott családok öszefűzése"
 
-#: ../gramps/plugins/view/familyview.py:202
+#: ../gramps/plugins/view/familyview.py:188
 msgid "Family Filter Editor"
 msgstr "Családszűrő-szerkesztő"
 
-#: ../gramps/plugins/view/familyview.py:207
+#: ../gramps/plugins/view/familyview.py:279
 msgid "Make Father Active Person"
 msgstr "Az apa aktívvá tétele"
 
-#: ../gramps/plugins/view/familyview.py:209
+#: ../gramps/plugins/view/familyview.py:279
 msgid "Make Mother Active Person"
 msgstr "Az anya aktívvá tétele"
 
-#: ../gramps/plugins/view/familyview.py:247
+#: ../gramps/plugins/view/familyview.py:372
 msgid "_Delete Family"
 msgstr "Család _törlése"
 
-#: ../gramps/plugins/view/familyview.py:283
+#: ../gramps/plugins/view/familyview.py:408
 #, python-format
 msgid "Family [%s]"
 msgstr "[%s] család"
 
-#: ../gramps/plugins/view/familyview.py:307
+#: ../gramps/plugins/view/familyview.py:432
 msgid "Cannot merge families."
 msgstr "A családok összefűzése nem lehetséges."
 
-#: ../gramps/plugins/view/familyview.py:308
+#: ../gramps/plugins/view/familyview.py:433
 msgid ""
 "Exactly two families must be selected to perform a merge. A second family "
 "can be selected by holding down the control key while clicking on the "
@@ -34424,201 +35420,248 @@ msgstr ""
 "Ctrl-gomb lenyomása és a kiválasztott családra való egyidejű kattintással "
 "választhatja ki."
 
-#: ../gramps/plugins/view/fanchart2wayview.py:193
-#: ../gramps/plugins/view/fanchartdescview.py:188
-#: ../gramps/plugins/view/fanchartview.py:184
-msgid "Print or save the Fan Chart View"
-msgstr "Legyezőgrafikon nézet nyomtatása, vagy mentése"
-
-#: ../gramps/plugins/view/fanchart2wayview.py:295
+#: ../gramps/plugins/view/fanchart2wayview.py:280
 msgid "Max ancestor generations"
 msgstr "Ős generációk legnagyobb száma"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:298
+#: ../gramps/plugins/view/fanchart2wayview.py:283
 msgid "Max descendant generations"
 msgstr "Leszármazott generációk legnagyobb száma"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:302
-#: ../gramps/plugins/view/fanchartdescview.py:299
-#: ../gramps/plugins/view/fanchartview.py:295
+#: ../gramps/plugins/view/fanchart2wayview.py:286
+#: ../gramps/plugins/view/fanchartdescview.py:283
+#: ../gramps/plugins/view/fanchartview.py:381
 msgid "Text Font"
 msgstr "Szöveg betű"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:306
-#: ../gramps/plugins/view/fanchartdescview.py:303
-#: ../gramps/plugins/view/fanchartview.py:299
+#: ../gramps/plugins/view/fanchart2wayview.py:291
+#: ../gramps/plugins/view/fanchartdescview.py:288
+#: ../gramps/plugins/view/fanchartview.py:386
 msgid "Gender colors"
 msgstr "Nem színek"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:307
-#: ../gramps/plugins/view/fanchartdescview.py:304
-#: ../gramps/plugins/view/fanchartview.py:300
+#: ../gramps/plugins/view/fanchart2wayview.py:292
+#: ../gramps/plugins/view/fanchartdescview.py:289
+#: ../gramps/plugins/view/fanchartview.py:387
 msgid "Generation based gradient"
 msgstr "Generáció alapú átmenet"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:308
-#: ../gramps/plugins/view/fanchartdescview.py:305
-#: ../gramps/plugins/view/fanchartview.py:301
+#: ../gramps/plugins/view/fanchart2wayview.py:293
+#: ../gramps/plugins/view/fanchartdescview.py:290
+#: ../gramps/plugins/view/fanchartview.py:388
 msgid "Age (0-100) based gradient"
 msgstr "Kor (0-100) alapú átmenet"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:310
-#: ../gramps/plugins/view/fanchartdescview.py:307
-#: ../gramps/plugins/view/fanchartview.py:303
+#: ../gramps/plugins/view/fanchart2wayview.py:294
+#: ../gramps/plugins/view/fanchartdescview.py:292
+#: ../gramps/plugins/view/fanchartview.py:389
 msgid "Single main (filter) color"
 msgstr "Egyszeres fő (szűrő) szín"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:311
-#: ../gramps/plugins/view/fanchartdescview.py:308
-#: ../gramps/plugins/view/fanchartview.py:304
+#: ../gramps/plugins/view/fanchart2wayview.py:295
+#: ../gramps/plugins/view/fanchartdescview.py:293
+#: ../gramps/plugins/view/fanchartview.py:390
 msgid "Time period based gradient"
 msgstr "Időintervallum alapú átmenet"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:312
-#: ../gramps/plugins/view/fanchartdescview.py:309
-#: ../gramps/plugins/view/fanchartview.py:305
+#: ../gramps/plugins/view/fanchart2wayview.py:296
+#: ../gramps/plugins/view/fanchartdescview.py:294
+#: ../gramps/plugins/view/fanchartview.py:391
 msgid "White"
 msgstr "Fehér"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:313
-#: ../gramps/plugins/view/fanchartdescview.py:310
-#: ../gramps/plugins/view/fanchartview.py:306
+#: ../gramps/plugins/view/fanchart2wayview.py:297
+#: ../gramps/plugins/view/fanchartdescview.py:295
+#: ../gramps/plugins/view/fanchartview.py:392
 msgid "Color scheme classic report"
 msgstr "Klasszikus szín séma jelentés"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:314
-#: ../gramps/plugins/view/fanchartdescview.py:311
-#: ../gramps/plugins/view/fanchartview.py:307
+#: ../gramps/plugins/view/fanchart2wayview.py:298
+#: ../gramps/plugins/view/fanchartdescview.py:296
+#: ../gramps/plugins/view/fanchartview.py:393
 msgid "Color scheme classic view"
 msgstr "Klasszikus szín séma nézet"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:323
-#: ../gramps/plugins/view/fanchartdescview.py:320
-#: ../gramps/plugins/view/fanchartview.py:316
+#: ../gramps/plugins/view/fanchart2wayview.py:306
+#: ../gramps/plugins/view/fanchartdescview.py:304
+#: ../gramps/plugins/view/fanchartview.py:401
 msgid "Background"
 msgstr "Háttér"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:332
+#: ../gramps/plugins/view/fanchart2wayview.py:313
 msgid "Add global background colored gradient"
 msgstr "Általános háttér színátmenet hozzáadása"
 
 #. colors, stored as hex values
-#: ../gramps/plugins/view/fanchart2wayview.py:336
-#: ../gramps/plugins/view/fanchartdescview.py:327
-#: ../gramps/plugins/view/fanchartview.py:322
+#: ../gramps/plugins/view/fanchart2wayview.py:317
+#: ../gramps/plugins/view/fanchartdescview.py:309
+#: ../gramps/plugins/view/fanchartview.py:406
 msgid "Start gradient/Main color"
 msgstr "Átmenet indítása/Fő szín"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:338
-#: ../gramps/plugins/view/fanchartdescview.py:329
-#: ../gramps/plugins/view/fanchartview.py:324
+#: ../gramps/plugins/view/fanchart2wayview.py:319
+#: ../gramps/plugins/view/fanchartdescview.py:311
+#: ../gramps/plugins/view/fanchartview.py:408
 msgid "End gradient/2nd color"
 msgstr "Átmenet vége/2. szín"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:340
-#: ../gramps/plugins/view/fanchartdescview.py:331
+#: ../gramps/plugins/view/fanchart2wayview.py:321
+#: ../gramps/plugins/view/fanchartdescview.py:313
 msgid "Color for duplicates"
 msgstr "Másolatok színe"
 
 #. algo for the fan angle distribution
-#: ../gramps/plugins/view/fanchart2wayview.py:343
-#: ../gramps/plugins/view/fanchartdescview.py:341
+#: ../gramps/plugins/view/fanchart2wayview.py:324
+#: ../gramps/plugins/view/fanchartdescview.py:323
 msgid "Fan chart distribution"
 msgstr "Legyezőgrafikon felosztás"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:346
-#: ../gramps/plugins/view/fanchartdescview.py:344
+#: ../gramps/plugins/view/fanchart2wayview.py:327
+#: ../gramps/plugins/view/fanchartdescview.py:326
 msgid "Homogeneous children distribution"
 msgstr "Homogén gyermek felosztás"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:348
-#: ../gramps/plugins/view/fanchartdescview.py:346
-msgid "Size  proportional to number of descendants"
+#: ../gramps/plugins/view/fanchart2wayview.py:329
+#: ../gramps/plugins/view/fanchartdescview.py:328
+msgid "Size proportional to number of descendants"
 msgstr "A méret arányos a leszármazottak számával"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:354
-#: ../gramps/plugins/view/fanchartdescview.py:352
-#: ../gramps/plugins/view/fanchartview.py:335
+#. show names one two line
+#: ../gramps/plugins/view/fanchart2wayview.py:335
+#: ../gramps/plugins/view/fanchartdescview.py:334
+#: ../gramps/plugins/view/fanchartview.py:418
 msgid "Show names on two lines"
 msgstr "Nevek mutatása két sorban"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:359
-#: ../gramps/plugins/view/fanchartdescview.py:357
-#: ../gramps/plugins/view/fanchartview.py:340
+#. Flip names
+#: ../gramps/plugins/view/fanchart2wayview.py:339
+#: ../gramps/plugins/view/fanchartdescview.py:338
+#: ../gramps/plugins/view/fanchartview.py:422
 msgid "Flip name on the left of the fan"
 msgstr "A legyező bal oldalán a név megfordítása"
+
+#. Show gramps id
+#: ../gramps/plugins/view/fanchart2wayview.py:343
+msgid "Show the gramps id"
+msgstr "GRAMPS ID mutatása"
 
 #. options we don't show on the dialog
 #. #configdialog.add_checkbox(table,
 #. #        _('Allow radial text'),
 #. #        ??, 'interface.fanview-radialtext')
-#: ../gramps/plugins/view/fanchart2wayview.py:362
-#: ../gramps/plugins/view/fanchartdescview.py:360
-#: ../gramps/plugins/view/fanchartview.py:352
-#: ../gramps/plugins/view/pedigreeview.py:2053
-#: ../gramps/plugins/view/relview.py:1686
+#: ../gramps/plugins/view/fanchart2wayview.py:346
+#: ../gramps/plugins/view/fanchartdescview.py:345
+#: ../gramps/plugins/view/fanchartview.py:437
+#: ../gramps/plugins/view/pedigreeview.py:2128
+#: ../gramps/plugins/view/relview.py:1857
 msgid "Layout"
 msgstr "Elrendezés"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:561
-#: ../gramps/plugins/view/fanchartdescview.py:549
-#: ../gramps/plugins/view/fanchartview.py:556
+#: ../gramps/plugins/view/fanchart2wayview.py:580
+#: ../gramps/plugins/view/fanchartdescview.py:568
+#: ../gramps/plugins/view/fanchartview.py:666
 msgid "No preview available"
 msgstr "Előnézet nem elérhető"
 
 #. form of the fan
-#: ../gramps/plugins/view/fanchartdescview.py:334
-#: ../gramps/plugins/view/fanchartview.py:327
+#: ../gramps/plugins/view/fanchartdescview.py:316
+#: ../gramps/plugins/view/fanchartview.py:411
 msgid "Fan chart type"
 msgstr "Legyezőgrafikon típus"
 
-#: ../gramps/plugins/view/fanchartdescview.py:336
-#: ../gramps/plugins/view/fanchartview.py:329
+#: ../gramps/plugins/view/fanchartdescview.py:318
+#: ../gramps/plugins/view/fanchartview.py:413
 msgid "Full Circle"
 msgstr "Teljes kör"
 
-#: ../gramps/plugins/view/fanchartdescview.py:337
-#: ../gramps/plugins/view/fanchartview.py:329
+#: ../gramps/plugins/view/fanchartdescview.py:319
+#: ../gramps/plugins/view/fanchartview.py:413
 msgid "Half Circle"
 msgstr "Félkör"
 
-#: ../gramps/plugins/view/fanchartdescview.py:338
-#: ../gramps/plugins/view/fanchartview.py:330
+#: ../gramps/plugins/view/fanchartdescview.py:320
+#: ../gramps/plugins/view/fanchartview.py:414
 msgid "Quadrant"
 msgstr "Körnegyedes"
 
-#: ../gramps/plugins/view/fanchartview.py:345
+#. show gramps_id
+#. Show the gramps_id
+#: ../gramps/plugins/view/fanchartdescview.py:342
+#: ../gramps/plugins/view/fanchartview.py:430
+msgid "Show gramps id"
+msgstr "GRAMPS azonosító mutatása"
+
+#: ../gramps/plugins/view/fanchartview.py:164
+#: ../gramps/plugins/view/fanchartview.py:227
+#: ../gramps/plugins/view/geoclose.py:91 ../gramps/plugins/view/geoclose.py:167
+#: ../gramps/plugins/view/geoevents.py:81
+#: ../gramps/plugins/view/geoevents.py:129
+#: ../gramps/plugins/view/geofamclose.py:89
+#: ../gramps/plugins/view/geofamclose.py:165
+#: ../gramps/plugins/view/geofamily.py:81
+#: ../gramps/plugins/view/geofamily.py:131
+#: ../gramps/plugins/view/geomoves.py:88 ../gramps/plugins/view/geomoves.py:151
+#: ../gramps/plugins/view/geoperson.py:89
+#: ../gramps/plugins/view/geoplaces.py:84
+#: ../gramps/plugins/view/geoplaces.py:134
+msgid "_Print..."
+msgstr "_Nyomtatás..."
+
+#: ../gramps/plugins/view/fanchartview.py:227
+msgid "Print or save the Fan Chart View"
+msgstr "Legyezőgrafikon nézet nyomtatása, vagy mentése"
+
+#. options users should not change:
+#: ../gramps/plugins/view/fanchartview.py:426
 msgid "Show children ring"
 msgstr "Gyermek gyűrű mutatása"
 
-#: ../gramps/plugins/view/geoclose.py:143
-#: ../gramps/plugins/view/geography.gpr.py:159
+#: ../gramps/plugins/view/geoclose.py:111
+msgid "Select the person which is the reference for life ways"
+msgstr "Válassza ki a személyt, aki kiinduló lesz az életutakhoz"
+
+#: ../gramps/plugins/view/geoclose.py:111
+msgid "reference _Person"
+msgstr "hivatkozott _Személy"
+
+#: ../gramps/plugins/view/geoclose.py:167
+#: ../gramps/plugins/view/geoevents.py:129
+#: ../gramps/plugins/view/geofamclose.py:165
+#: ../gramps/plugins/view/geofamily.py:131
+#: ../gramps/plugins/view/geomoves.py:151
+#: ../gramps/plugins/view/geoperson.py:152
+#: ../gramps/plugins/view/geoplaces.py:134
+msgid "Print or save the Map"
+msgstr "A térkép nyomtatása vagy mentése"
+
+#: ../gramps/plugins/view/geoclose.py:220
+#: ../gramps/plugins/view/geography.gpr.py:160
 msgid "Have they been able to meet?"
 msgstr "Találkozhattak?"
 
-#: ../gramps/plugins/view/geoclose.py:177
+#: ../gramps/plugins/view/geoclose.py:254
 msgid "GeoClose"
 msgstr "GeoClose"
 
-#: ../gramps/plugins/view/geoclose.py:230
+#: ../gramps/plugins/view/geoclose.py:308
 #, python-format
 msgid "Reference : %(name)s ( %(birth)s - %(death)s )"
 msgstr "Hivatkozás: %(name)s ( %(birth)s - %(death)s )"
 
-#: ../gramps/plugins/view/geoclose.py:236
+#: ../gramps/plugins/view/geoclose.py:314
 #, python-format
 msgid "The other : %(name)s ( %(birth)s - %(death)s )"
 msgstr "A másik: %(name)s ( %(birth)s - %(death)s )"
 
-#: ../gramps/plugins/view/geoclose.py:241
+#: ../gramps/plugins/view/geoclose.py:319
 msgid "The other person is unknown"
 msgstr "A másik személy ismeretlen"
 
-#: ../gramps/plugins/view/geoclose.py:248
+#: ../gramps/plugins/view/geoclose.py:326
 msgid "You must choose one reference person."
 msgstr "Egy hivatkozott személyt választania kell."
 
-#: ../gramps/plugins/view/geoclose.py:249
+#: ../gramps/plugins/view/geoclose.py:327
 msgid ""
 "Go to the person view and select the people you want to compare. Return to "
 "this view and use the history."
@@ -34626,32 +35669,24 @@ msgstr ""
 "Menjen a személy nézetbe és válassza ki az összehasonlítandó személyt. "
 "Térjen vissza ehhez a nézethez és használja a történetet."
 
-#: ../gramps/plugins/view/geoclose.py:299
-msgid "reference _Person"
-msgstr "hivatkozott _Személy"
-
-#: ../gramps/plugins/view/geoclose.py:300
-msgid "Select the person which is the reference for life ways"
-msgstr "Válassza ki a személyt, aki kiinduló lesz az életutakhoz"
-
-#: ../gramps/plugins/view/geoclose.py:315
+#: ../gramps/plugins/view/geoclose.py:385
 msgid "Select the person which will be our reference."
 msgstr "Válassza ki a személyt, aki a kiindulásunk lesz."
 
-#: ../gramps/plugins/view/geoclose.py:414
-#: ../gramps/plugins/view/geofamclose.py:499
-#: ../gramps/plugins/view/geofamily.py:209
-#: ../gramps/plugins/view/geomoves.py:292
-#: ../gramps/plugins/view/geoperson.py:336
+#: ../gramps/plugins/view/geoclose.py:484
+#: ../gramps/plugins/view/geofamclose.py:569
+#: ../gramps/plugins/view/geofamily.py:258
+#: ../gramps/plugins/view/geomoves.py:358
+#: ../gramps/plugins/view/geoperson.py:402
 #, python-format
 msgid "%(eventtype)s : %(name)s"
 msgstr "%(eventtype)s : %(name)s"
 
-#: ../gramps/plugins/view/geoclose.py:570
+#: ../gramps/plugins/view/geoclose.py:642
 msgid "Choose and bookmark the new reference person"
 msgstr "Válassza ki és jelölje meg a kiinduló személyt"
 
-#: ../gramps/plugins/view/geoclose.py:593
+#: ../gramps/plugins/view/geoclose.py:665
 msgid ""
 "The meeting zone probability radius.\n"
 "The colored zone is approximative.\n"
@@ -34667,75 +35702,94 @@ msgstr ""
 "Az 1-es érték kb. 4,6 mérföldet, vagy 7,5 km-t jelent.\n"
 "Az érték tized fokokban van."
 
-#: ../gramps/plugins/view/geoclose.py:604
-#: ../gramps/plugins/view/geofamclose.py:795
+#: ../gramps/plugins/view/geoclose.py:676
+#: ../gramps/plugins/view/geofamclose.py:865
 msgid "The selection parameters"
 msgstr "A kiválasztás paraméterei"
 
-#: ../gramps/plugins/view/geoevents.py:116
+#: ../gramps/plugins/view/geoevents.py:161
 msgid "Events places map"
 msgstr "Eseményhelyek térkép"
 
-#: ../gramps/plugins/view/geoevents.py:141
+#: ../gramps/plugins/view/geoevents.py:186
 msgid "GeoEvents"
 msgstr "Geo-esemény"
 
-#: ../gramps/plugins/view/geoevents.py:260
+#: ../gramps/plugins/view/geoevents.py:305
 msgid "incomplete or unreferenced event ?"
 msgstr "hiányos, vagy nem hivakozott esemény?"
 
-#: ../gramps/plugins/view/geoevents.py:297
-#: ../gramps/plugins/view/geoevents.py:310
+#: ../gramps/plugins/view/geoevents.py:344
+#: ../gramps/plugins/view/geoevents.py:357
 msgid "Selecting all events"
 msgstr "Minden esemény kiválasztása"
 
-#: ../gramps/plugins/view/geoevents.py:355
-#: ../gramps/plugins/view/geoevents.py:387
+#: ../gramps/plugins/view/geoevents.py:368
+msgid ""
+"Right click on the map and select 'show all events' to show all known events "
+"with coordinates. You can use the history to navigate on the map. You can "
+"use filtering."
+msgstr ""
+"Jobb klikk a térképen, majd a 'minden esemény mutatása' kijelölése "
+"megjeleníti az összes ismert eseményt koordinátákkal. Használhatja az "
+"előzményeket a térképen. Használhat szűrőket."
+
+#: ../gramps/plugins/view/geoevents.py:408
+#: ../gramps/plugins/view/geoevents.py:440
 msgid "Bookmark this event"
 msgstr "Jelölje meg ezt az eseményt"
 
-#: ../gramps/plugins/view/geoevents.py:402
+#: ../gramps/plugins/view/geoevents.py:455
 msgid "Show all events"
 msgstr "Összes esemény mutatása"
 
-#: ../gramps/plugins/view/geoevents.py:406
-#: ../gramps/plugins/view/geoevents.py:411
-#: ../gramps/plugins/view/geoplaces.py:490
-#: ../gramps/plugins/view/geoplaces.py:495
+#: ../gramps/plugins/view/geoevents.py:459
+#: ../gramps/plugins/view/geoevents.py:464
+#: ../gramps/plugins/view/geoplaces.py:549
+#: ../gramps/plugins/view/geoplaces.py:554
 msgid "Centering on Place"
 msgstr "Középre a helyszínen"
 
-#: ../gramps/plugins/view/geofamclose.py:143
-#: ../gramps/plugins/view/geography.gpr.py:141
+#: ../gramps/plugins/view/geofamclose.py:109
+msgid "Select the family which is the reference for life ways"
+msgstr "Válassza ki a kiinduló családot az életutak hivatkozáshoz"
+
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geoperson.py:152
+msgid "reference _Family"
+msgstr "kiinduló _Család"
+
+#: ../gramps/plugins/view/geofamclose.py:220
+#: ../gramps/plugins/view/geography.gpr.py:142
 msgid "Have these two families been able to meet?"
 msgstr "Találkozhatott ez a két család?"
 
-#: ../gramps/plugins/view/geofamclose.py:174
+#: ../gramps/plugins/view/geofamclose.py:251
 msgid "GeoFamClose"
 msgstr "GeoFamClose"
 
-#: ../gramps/plugins/view/geofamclose.py:217
-#: ../gramps/plugins/view/geofamily.py:293
+#: ../gramps/plugins/view/geofamclose.py:294
+#: ../gramps/plugins/view/geofamily.py:342
 #, python-format
 msgid "%(gramps_id)s : %(father)s and %(mother)s"
 msgstr "%(gramps_id)s : %(father)s és %(mother)s"
 
-#: ../gramps/plugins/view/geofamclose.py:264
+#: ../gramps/plugins/view/geofamclose.py:342
 #, python-format
 msgid "Family reference : %s"
 msgstr "Kiinduló család: %s"
 
-#: ../gramps/plugins/view/geofamclose.py:267
-#: ../gramps/plugins/view/geofamclose.py:270
+#: ../gramps/plugins/view/geofamclose.py:345
+#: ../gramps/plugins/view/geofamclose.py:348
 #, python-format
 msgid "The other family : %s"
 msgstr "A másik család: %s"
 
-#: ../gramps/plugins/view/geofamclose.py:277
+#: ../gramps/plugins/view/geofamclose.py:355
 msgid "You must choose one reference family."
 msgstr "Egy kiinduló családot választania kell."
 
-#: ../gramps/plugins/view/geofamclose.py:279
+#: ../gramps/plugins/view/geofamclose.py:357
 msgid ""
 "Go to the family view and select the families you want to compare. Return to "
 "this view and use the history."
@@ -34743,43 +35797,35 @@ msgstr ""
 "Menjen a család nézetbe és válassza ki az összehasonlítandó családot. Térjen "
 "vissza ebbe a nézetbe és használja a történetet."
 
-#: ../gramps/plugins/view/geofamclose.py:295
-msgid "reference _Family"
-msgstr "kiinduló _Család"
-
-#: ../gramps/plugins/view/geofamclose.py:296
-msgid "Select the family which is the reference for life ways"
-msgstr "Válassza ki a kiinduló családot az életutak hivatkozáshoz"
-
-#: ../gramps/plugins/view/geofamclose.py:611
-#: ../gramps/plugins/view/geofamily.py:347
+#: ../gramps/plugins/view/geofamclose.py:681
+#: ../gramps/plugins/view/geofamily.py:396
 #, python-format
 msgid "Father : %(id)s : %(name)s"
 msgstr "Apa : %(id)s : %(name)s"
 
-#: ../gramps/plugins/view/geofamclose.py:620
-#: ../gramps/plugins/view/geofamily.py:356
+#: ../gramps/plugins/view/geofamclose.py:690
+#: ../gramps/plugins/view/geofamily.py:405
 #, python-format
 msgid "Mother : %(id)s : %(name)s"
 msgstr "Anya : %(id)s : %(name)s"
 
-#: ../gramps/plugins/view/geofamclose.py:632
-#: ../gramps/plugins/view/geofamily.py:368
+#: ../gramps/plugins/view/geofamclose.py:702
+#: ../gramps/plugins/view/geofamily.py:417
 #, python-format
 msgid "Child : %(id)s - %(index)d : %(name)s"
 msgstr "Gyermek : %(id)s - %(index)d : %(name)s"
 
-#: ../gramps/plugins/view/geofamclose.py:642
-#: ../gramps/plugins/view/geofamily.py:377
+#: ../gramps/plugins/view/geofamclose.py:712
+#: ../gramps/plugins/view/geofamily.py:426
 #, python-format
 msgid "Person : %(id)s %(name)s has no family."
 msgstr "Személy : %(id)s %(name)s nincs családja."
 
-#: ../gramps/plugins/view/geofamclose.py:761
+#: ../gramps/plugins/view/geofamclose.py:831
 msgid "Choose and bookmark the new reference family"
 msgstr "Válassza ki és jelölje meg a kiinduló családot"
 
-#: ../gramps/plugins/view/geofamclose.py:784
+#: ../gramps/plugins/view/geofamclose.py:854
 msgid ""
 "The meeting zone probability radius.\n"
 "The colored zone is approximative.\n"
@@ -34795,65 +35841,76 @@ msgstr ""
 "Az 1-es érték kb. 4,6 mérföldet, vagy 7,5 km-t jelent.\n"
 "Az érték tized fokokban van."
 
-#: ../gramps/plugins/view/geofamily.py:115
+#: ../gramps/plugins/view/geofamily.py:164
 msgid "Family places map"
 msgstr "Családhelyek térkép"
 
-#: ../gramps/plugins/view/geofamily.py:137
+#: ../gramps/plugins/view/geofamily.py:186
 msgid "GeoFamily"
 msgstr "GeoFamily"
 
-#: ../gramps/plugins/view/geofamily.py:321
+#: ../gramps/plugins/view/geofamily.py:370
 #, python-format
 msgid "Family places for %s"
 msgstr "Családhelyek %s számára"
 
-#: ../gramps/plugins/view/geography.gpr.py:71
+#: ../gramps/plugins/view/geography.gpr.py:67
 msgid "OsmGpsMap module not loaded."
 msgstr "Az OsmGpsMap modul nem betölthető."
 
-#: ../gramps/plugins/view/geography.gpr.py:72
-#, python-format
+#: ../gramps/plugins/view/geography.gpr.py:68
 msgid ""
 "Geography functionality will not be available.\n"
-"To build it for Gramps see %(gramps_wiki_build_osmgps_url)s"
+"Try to install:\n"
+" gir1.2-osmgpsmap-1.0 (debian, ubuntu, ...)\n"
+" osm-gps-map-gobject-1.0.1 for fedora, ...\n"
+" typelib-1_0-OsmGpsMap-1_0 for openSuse\n"
+" ...\n"
+"To build it for Gramps see the Wiki (<F1>)\n"
+" and search for 'build from source'"
 msgstr ""
-"A térképészeti funkció nem lesz elérhető.\n"
-"A GRAMPS-hoz felépítéshez lásd: %(gramps_wiki_build_osmgps_url)s"
+"Földrajzi funkciók nem lesznek elérhetőek.\n"
+"Próbálja telepíteni:\n"
+" gir1.2-osmgpsmap-1.0 (debian, ubuntu, ...)\n"
+" osm-gps-map-gobject-1.0.1 fedorára, ...\n"
+" typelib-1_0-OsmGpsMap-1_0 openSuse-re\n"
+" ...\n"
+"GRAMPS-hoz építésre lásd a Wiki-t (<F1>)\n"
+" és keressen a 'felépítés forrásból' szövegre"
 
-#: ../gramps/plugins/view/geography.gpr.py:86
+#: ../gramps/plugins/view/geography.gpr.py:87
 msgid "All known places for one Person"
 msgstr "Minden ismert helyszín egy Személyhez"
 
-#: ../gramps/plugins/view/geography.gpr.py:87
+#: ../gramps/plugins/view/geography.gpr.py:88
 msgid "A view showing the places visited by one person during his life."
 msgstr ""
 "A nézet egy személy egész élete alatt felkeresett helyszíneket mutatja."
 
-#: ../gramps/plugins/view/geography.gpr.py:95
-#: ../gramps/plugins/view/geography.gpr.py:112
-#: ../gramps/plugins/view/geography.gpr.py:133
-#: ../gramps/plugins/view/geography.gpr.py:151
-#: ../gramps/plugins/view/geography.gpr.py:169
-#: ../gramps/plugins/view/geography.gpr.py:185
-#: ../gramps/plugins/view/geography.gpr.py:202
+#: ../gramps/plugins/view/geography.gpr.py:96
+#: ../gramps/plugins/view/geography.gpr.py:113
+#: ../gramps/plugins/view/geography.gpr.py:134
+#: ../gramps/plugins/view/geography.gpr.py:152
+#: ../gramps/plugins/view/geography.gpr.py:170
+#: ../gramps/plugins/view/geography.gpr.py:186
+#: ../gramps/plugins/view/geography.gpr.py:203
 msgid "Geography"
 msgstr "Földrajz"
 
-#: ../gramps/plugins/view/geography.gpr.py:103
+#: ../gramps/plugins/view/geography.gpr.py:104
 msgid "All known places for one Family"
 msgstr "Minden ismert helyszín egy Családhoz"
 
-#: ../gramps/plugins/view/geography.gpr.py:104
+#: ../gramps/plugins/view/geography.gpr.py:105
 msgid "A view showing the places visited by one family during all their life."
 msgstr ""
 "A nézet egy család teljes élete alatt felkeresett helyszíneket mutatja."
 
-#: ../gramps/plugins/view/geography.gpr.py:120
+#: ../gramps/plugins/view/geography.gpr.py:121
 msgid "Every residence or move for a person and any descendants"
 msgstr "Egy személy és bármely leszármazottainak minden lakóhelye és költözése"
 
-#: ../gramps/plugins/view/geography.gpr.py:122
+#: ../gramps/plugins/view/geography.gpr.py:123
 msgid ""
 "A view showing all the places visited by all persons during their life.\n"
 "This is for a person and any descendant.\n"
@@ -34864,7 +35921,7 @@ msgstr ""
 "Ez egy személy és annak leszármazottaira vonatkozik.\n"
 "Láthatóak az intervallumra vonatkozó dátumok."
 
-#: ../gramps/plugins/view/geography.gpr.py:142
+#: ../gramps/plugins/view/geography.gpr.py:143
 msgid ""
 "A view showing the places visited by all family's members during their life: "
 "have these two people been able to meet?"
@@ -34872,7 +35929,7 @@ msgstr ""
 "A nézet minden családtag teljes élete alatt felkeresett helyszíneket "
 "mutatja: találkozhattak ezek az emberek?"
 
-#: ../gramps/plugins/view/geography.gpr.py:160
+#: ../gramps/plugins/view/geography.gpr.py:161
 msgid ""
 "A view showing the places visited by two persons during their life: have "
 "these two people been able to meet?"
@@ -34880,77 +35937,77 @@ msgstr ""
 "A nézet két személy egész élete alatt felkeresett helyszíneket mutatja: "
 "találkozhatott ez a két ember?"
 
-#: ../gramps/plugins/view/geography.gpr.py:177
+#: ../gramps/plugins/view/geography.gpr.py:178
 msgid "All known Places"
 msgstr "Minden ismert helyszín"
 
-#: ../gramps/plugins/view/geography.gpr.py:178
+#: ../gramps/plugins/view/geography.gpr.py:179
 msgid "A view showing all places of the database."
 msgstr "A nézet az adatbázis összes helyszínét mutatja."
 
-#: ../gramps/plugins/view/geography.gpr.py:193
+#: ../gramps/plugins/view/geography.gpr.py:194
 msgid "All places related to Events"
 msgstr "Eseményekhez tartozó minden helyszín"
 
-#: ../gramps/plugins/view/geography.gpr.py:194
+#: ../gramps/plugins/view/geography.gpr.py:195
 msgid "A view showing all the event places of the database."
 msgstr "A nézet az adatbázis összes eseményhelyszínét mutatja."
 
-#: ../gramps/plugins/view/geomoves.py:142
+#: ../gramps/plugins/view/geomoves.py:207
 msgid "Descendance of the active person."
 msgstr "Az aktív személy leszármazása."
 
-#: ../gramps/plugins/view/geomoves.py:173
+#: ../gramps/plugins/view/geomoves.py:238
 msgid "GeoMoves"
 msgstr "GeoMoves"
 
-#: ../gramps/plugins/view/geomoves.py:490
+#: ../gramps/plugins/view/geomoves.py:556
 #, python-format
 msgid "All descendance for %s"
 msgstr "%s minden leszármazottja"
 
-#: ../gramps/plugins/view/geomoves.py:632
+#: ../gramps/plugins/view/geomoves.py:698
 msgid "Bookmark this person"
 msgstr "Jelölje meg ezt a személyt"
 
-#: ../gramps/plugins/view/geomoves.py:664
+#: ../gramps/plugins/view/geomoves.py:730
 msgid "The maximum number of generations.\n"
 msgstr "A generációk maximális száma.\n"
 
-#: ../gramps/plugins/view/geomoves.py:671
+#: ../gramps/plugins/view/geomoves.py:737
 msgid "Time in milliseconds between drawing two generations.\n"
 msgstr "Idő milliszekundumban két generáció rajzolása között.\n"
 
-#: ../gramps/plugins/view/geomoves.py:677
+#: ../gramps/plugins/view/geomoves.py:743
 msgid "The parameters for moves"
 msgstr "A mozgások paraméterei"
 
-#: ../gramps/plugins/view/geoperson.py:146
+#: ../gramps/plugins/view/geoperson.py:211
 msgid "Person places map"
 msgstr "Személy-hely térkép"
 
-#: ../gramps/plugins/view/geoperson.py:170
+#: ../gramps/plugins/view/geoperson.py:235
 msgid "GeoPerson"
 msgstr "GeoPerson"
 
-#: ../gramps/plugins/view/geoperson.py:315
+#: ../gramps/plugins/view/geoperson.py:381
 #, python-format
 msgid "Person places for %s"
 msgstr "Személy-helyek %s számára"
 
-#: ../gramps/plugins/view/geoperson.py:519
+#: ../gramps/plugins/view/geoperson.py:585
 msgid "Animate"
 msgstr "Megelevenít"
 
-#: ../gramps/plugins/view/geoperson.py:542
+#: ../gramps/plugins/view/geoperson.py:608
 msgid "Animation speed in milliseconds (big value means slower)"
 msgstr "Animációs sebesség milliszekundumban (a nagyobb érték a lassabb)"
 
-#: ../gramps/plugins/view/geoperson.py:550
+#: ../gramps/plugins/view/geoperson.py:616
 msgid "How many steps between two markers when we are on large move ?"
 msgstr "Hány lépés legyen két jel között, ha hosszú mozgásban vagyunk?"
 
-#: ../gramps/plugins/view/geoperson.py:557
+#: ../gramps/plugins/view/geoperson.py:623
 msgid ""
 "The minimum latitude/longitude to select large move.\n"
 "The value is in tenth of degree."
@@ -34958,24 +36015,24 @@ msgstr ""
 "Minimálisan kiválasztható szélességi/hosszúsági fok nagy mozgáshoz.\n"
 "Az érték tized fokokban értendő."
 
-#: ../gramps/plugins/view/geoperson.py:564
+#: ../gramps/plugins/view/geoperson.py:630
 msgid "The animation parameters"
 msgstr "Animációs paraméterek"
 
-#: ../gramps/plugins/view/geoplaces.py:157
+#: ../gramps/plugins/view/geoplaces.py:207
 msgid "Places map"
 msgstr "Helyek térképe"
 
-#: ../gramps/plugins/view/geoplaces.py:185
+#: ../gramps/plugins/view/geoplaces.py:236
 msgid "GeoPlaces"
 msgstr "GeoPlaces"
 
-#: ../gramps/plugins/view/geoplaces.py:348
-#: ../gramps/plugins/view/geoplaces.py:361
+#: ../gramps/plugins/view/geoplaces.py:407
+#: ../gramps/plugins/view/geoplaces.py:420
 msgid "Selecting all places"
 msgstr "Minden hely kiválasztása"
 
-#: ../gramps/plugins/view/geoplaces.py:373
+#: ../gramps/plugins/view/geoplaces.py:432
 msgid ""
 "Right click on the map and select 'show all places' to show all known places "
 "with coordinates. You can change the markers color depending on place type. "
@@ -34985,7 +36042,7 @@ msgstr ""
 "az összes ismert hely koordinátáját. Megváltoztathatja a hely típusától "
 "függő kiemelő színt. Használhat szűrőket."
 
-#: ../gramps/plugins/view/geoplaces.py:386
+#: ../gramps/plugins/view/geoplaces.py:445
 msgid ""
 "Right click on the map and select 'show all places' to show all known places "
 "with coordinates. You can use the history to navigate on the map. You can "
@@ -34995,41 +36052,45 @@ msgstr ""
 "az összes ismert hely koordinátáját. Megváltoztathatja a hely típusától "
 "függő kiemelő színt. Használhat szűrőket."
 
-#: ../gramps/plugins/view/geoplaces.py:401
+#: ../gramps/plugins/view/geoplaces.py:460
 msgid "The place name in the status bar is disabled."
 msgstr "A helyszín-név az állapot sorban kikapcsolva."
 
-#: ../gramps/plugins/view/geoplaces.py:406
+#: ../gramps/plugins/view/geoplaces.py:465
 #, python-format
 msgid "The maximum number of places is reached (%d)."
 msgstr "A elért helyszínek maximális száma (%d)."
 
-#: ../gramps/plugins/view/geoplaces.py:409
+#: ../gramps/plugins/view/geoplaces.py:468
 msgid "Some information are missing."
 msgstr "Valamilyen információ hiányzik."
 
-#: ../gramps/plugins/view/geoplaces.py:411
+#: ../gramps/plugins/view/geoplaces.py:470
 msgid "Please, use filtering to reduce this number."
 msgstr "A szám csökkentéséhez kérem használja a szűrést."
 
-#: ../gramps/plugins/view/geoplaces.py:413
+#: ../gramps/plugins/view/geoplaces.py:472
 msgid "You can modify this value in the geography option."
 msgstr "Módosíthatja az értéket a földrajzi opcióban."
 
-#: ../gramps/plugins/view/geoplaces.py:415
+#: ../gramps/plugins/view/geoplaces.py:474
 msgid "In this case, it may take time to show all markers."
 msgstr "Ebben az esetben az összes jelzés mutatása eltart egy darabig."
 
-#: ../gramps/plugins/view/geoplaces.py:447
-#: ../gramps/plugins/view/geoplaces.py:471
+#: ../gramps/plugins/view/geoplaces.py:506
+#: ../gramps/plugins/view/geoplaces.py:530
 msgid "Bookmark this place"
 msgstr "Jelölje meg ezt a helyet"
 
-#: ../gramps/plugins/view/geoplaces.py:486
+#: ../gramps/plugins/view/geoplaces.py:545
 msgid "Show all places"
 msgstr "Összes helyszín mutatása"
 
-#: ../gramps/plugins/view/geoplaces.py:596
+#: ../gramps/plugins/view/geoplaces.py:657
+msgid "Custom places name"
+msgstr "Szokásos helynév"
+
+#: ../gramps/plugins/view/geoplaces.py:666
 msgid "The places marker color"
 msgstr "A helyek kiemelő színe"
 
@@ -35045,23 +36106,19 @@ msgstr "A kiválasztott médiaobjektum törlése"
 msgid "Merge the selected media objects"
 msgstr "A kiválasztott médiaobjektum összefűzése"
 
-#: ../gramps/plugins/view/mediaview.py:209
+#: ../gramps/plugins/view/mediaview.py:288
 msgid "Media Filter Editor"
 msgstr "Médiaszűrő szerkesztő"
 
-#: ../gramps/plugins/view/mediaview.py:212
+#: ../gramps/plugins/view/mediaview.py:379
 msgid "View in the default viewer"
 msgstr "Nézet az alapértelmezett nézőkében"
 
-#: ../gramps/plugins/view/mediaview.py:216
-msgid "Open the folder containing the media file"
-msgstr "Médiafájlt tartalmazó mappa megnyitása"
-
-#: ../gramps/plugins/view/mediaview.py:350
+#: ../gramps/plugins/view/mediaview.py:483
 msgid "Cannot merge media objects."
 msgstr "Nem összefűzhető médiaobjektumok."
 
-#: ../gramps/plugins/view/mediaview.py:351
+#: ../gramps/plugins/view/mediaview.py:484
 msgid ""
 "Exactly two media objects must be selected to perform a merge. A second "
 "object can be selected by holding down the control key while clicking on the "
@@ -35079,15 +36136,15 @@ msgstr "A kiválasztott jegyzet törlése"
 msgid "Merge the selected notes"
 msgstr "A kiválasztott jegyzetek összefűzése"
 
-#: ../gramps/plugins/view/noteview.py:199
+#: ../gramps/plugins/view/noteview.py:188
 msgid "Note Filter Editor"
 msgstr "Jegyzetszűrő szerkesztő"
 
-#: ../gramps/plugins/view/noteview.py:241
+#: ../gramps/plugins/view/noteview.py:357
 msgid "Cannot merge notes."
 msgstr "Nem összefűzhető jegyzetek."
 
-#: ../gramps/plugins/view/noteview.py:242
+#: ../gramps/plugins/view/noteview.py:358
 msgid ""
 "Exactly two notes must be selected to perform a merge. A second note can be "
 "selected by holding down the control key while clicking on the desired note."
@@ -35120,85 +36177,85 @@ msgstr "elt."
 msgid "short for cremated|crem."
 msgstr "hamv."
 
-#: ../gramps/plugins/view/pedigreeview.py:1146
+#: ../gramps/plugins/view/pedigreeview.py:1205
 msgid "Jump to child..."
 msgstr "Ugrás gyermekhez..."
 
-#: ../gramps/plugins/view/pedigreeview.py:1160
+#: ../gramps/plugins/view/pedigreeview.py:1219
 msgid "Jump to father"
 msgstr "Ugrás apához"
 
-#: ../gramps/plugins/view/pedigreeview.py:1174
+#: ../gramps/plugins/view/pedigreeview.py:1233
 msgid "Jump to mother"
 msgstr "Ugrás anyához"
 
-#: ../gramps/plugins/view/pedigreeview.py:1532
+#: ../gramps/plugins/view/pedigreeview.py:1601
 msgid "A person was found to be his/her own ancestor."
 msgstr "A talált személy a saját őse."
 
-#: ../gramps/plugins/view/pedigreeview.py:1576
+#: ../gramps/plugins/view/pedigreeview.py:1645
 msgid "Pre_vious"
 msgstr "El_őző"
 
-#: ../gramps/plugins/view/pedigreeview.py:1577
+#: ../gramps/plugins/view/pedigreeview.py:1646
 msgid "_Next"
 msgstr "_Következő"
 
 #. Mouse scroll direction setting.
-#: ../gramps/plugins/view/pedigreeview.py:1600
+#: ../gramps/plugins/view/pedigreeview.py:1675
 msgid "Mouse scroll direction"
 msgstr "Egérgörgetés iránya"
 
-#: ../gramps/plugins/view/pedigreeview.py:1604
+#: ../gramps/plugins/view/pedigreeview.py:1679
 msgid "Top <-> Bottom"
 msgstr "Felül <-> Alul"
 
-#: ../gramps/plugins/view/pedigreeview.py:1611
+#: ../gramps/plugins/view/pedigreeview.py:1686
 msgid "Left <-> Right"
 msgstr "Balra <-> Jobbra"
 
-#: ../gramps/plugins/view/pedigreeview.py:1828
-#: ../gramps/plugins/view/relview.py:412
+#: ../gramps/plugins/view/pedigreeview.py:1903
+#: ../gramps/plugins/view/relview.py:385
 msgid "Add New Parents..."
 msgstr "Új szülők hozzáadása..."
 
-#: ../gramps/plugins/view/pedigreeview.py:2023
+#: ../gramps/plugins/view/pedigreeview.py:2098
 msgid "Show images"
 msgstr "Képek mutatása"
 
-#: ../gramps/plugins/view/pedigreeview.py:2026
+#: ../gramps/plugins/view/pedigreeview.py:2101
 msgid "Show marriage data"
 msgstr "Házassági adatok mutatása"
 
-#: ../gramps/plugins/view/pedigreeview.py:2029
+#: ../gramps/plugins/view/pedigreeview.py:2104
 msgid "Show unknown people"
 msgstr "Ismeretlen emberek mutatása"
 
-#: ../gramps/plugins/view/pedigreeview.py:2032
+#: ../gramps/plugins/view/pedigreeview.py:2107
 msgid "Show tags"
 msgstr "Címkék mutatása"
 
-#: ../gramps/plugins/view/pedigreeview.py:2035
+#: ../gramps/plugins/view/pedigreeview.py:2110
 msgid "Tree style"
 msgstr "A fa stílusa"
 
-#: ../gramps/plugins/view/pedigreeview.py:2037
+#: ../gramps/plugins/view/pedigreeview.py:2112
 msgid "Standard"
 msgstr "Szabványos"
 
-#: ../gramps/plugins/view/pedigreeview.py:2038
+#: ../gramps/plugins/view/pedigreeview.py:2113
 msgid "Compact"
 msgstr "Tömör"
 
-#: ../gramps/plugins/view/pedigreeview.py:2039
+#: ../gramps/plugins/view/pedigreeview.py:2114
 msgid "Expanded"
 msgstr "Kiterjesztett"
 
-#: ../gramps/plugins/view/pedigreeview.py:2042
+#: ../gramps/plugins/view/pedigreeview.py:2117
 msgid "Tree direction"
 msgstr "A fa iránya"
 
-#: ../gramps/plugins/view/pedigreeview.py:2049
+#: ../gramps/plugins/view/pedigreeview.py:2124
 msgid "Tree size"
 msgstr "A fa mérete"
 
@@ -35218,180 +36275,184 @@ msgstr "Hely nézet"
 msgid "Place Tree View"
 msgstr "Helyfa nézet"
 
-#: ../gramps/plugins/view/placetreeview.py:70
-msgid "Expand this Entire Group"
-msgstr "A teljes csoport kibontása"
-
-#: ../gramps/plugins/view/placetreeview.py:72
+#: ../gramps/plugins/view/placetreeview.py:77
 msgid "Collapse this Entire Group"
 msgstr "A teljes csoport bezárása"
 
-#: ../gramps/plugins/view/relview.py:398
-msgid "_Reorder"
-msgstr "_átrendezés"
+#: ../gramps/plugins/view/placetreeview.py:77
+msgid "Expand this Entire Group"
+msgstr "A teljes csoport kibontása"
 
-#: ../gramps/plugins/view/relview.py:399
-msgid "Change order of parents and families"
-msgstr "Szülők és családok sorrendjének változtatása"
+#: ../gramps/plugins/view/relview.py:364
+msgid "Organize Bookmarks..."
+msgstr "Könyvjelzők szervezése..."
 
-#: ../gramps/plugins/view/relview.py:404
-msgid "Edit..."
-msgstr "Szerkesztés..."
-
-#: ../gramps/plugins/view/relview.py:405
-msgid "Edit the active person"
-msgstr "Aktív személy szerkesztése"
-
-#: ../gramps/plugins/view/relview.py:407 ../gramps/plugins/view/relview.py:409
-#: ../gramps/plugins/view/relview.py:805
-msgid "Add a new family with person as parent"
-msgstr "Új család hozzáadása szülőszeméllyel"
-
-#: ../gramps/plugins/view/relview.py:408
-msgid "Add Partner..."
-msgstr "Társ hozzáadása..."
-
-#: ../gramps/plugins/view/relview.py:411 ../gramps/plugins/view/relview.py:413
-#: ../gramps/plugins/view/relview.py:799
-msgid "Add a new set of parents"
-msgstr "Új szülők hozzáadása"
-
-#: ../gramps/plugins/view/relview.py:415 ../gramps/plugins/view/relview.py:419
-#: ../gramps/plugins/view/relview.py:800
-msgid "Add person as child to an existing family"
-msgstr "Személy hozzáadása létező családhoz gyermekként"
-
-#: ../gramps/plugins/view/relview.py:418
+#: ../gramps/plugins/view/relview.py:385
 msgid "Add Existing Parents..."
 msgstr "Létező szülők hozzáadása..."
 
-#: ../gramps/plugins/view/relview.py:635
+#: ../gramps/plugins/view/relview.py:385
+msgid "Add Partner..."
+msgstr "Társ hozzáadása..."
+
+#: ../gramps/plugins/view/relview.py:385 ../gramps/plugins/view/relview.py:471
+msgid "_Reorder"
+msgstr "_átrendezés"
+
+#: ../gramps/plugins/view/relview.py:471 ../gramps/plugins/view/relview.py:964
+msgid "Add a new family with person as parent"
+msgstr "Új család hozzáadása szülőszeméllyel"
+
+#: ../gramps/plugins/view/relview.py:471 ../gramps/plugins/view/relview.py:958
+msgid "Add a new set of parents"
+msgstr "Új szülők hozzáadása"
+
+#: ../gramps/plugins/view/relview.py:471 ../gramps/plugins/view/relview.py:959
+msgid "Add person as child to an existing family"
+msgstr "Személy hozzáadása létező családhoz gyermekként"
+
+#: ../gramps/plugins/view/relview.py:471
+msgid "Change order of parents and families"
+msgstr "Szülők és családok sorrendjének változtatása"
+
+#: ../gramps/plugins/view/relview.py:471
+msgid "Edit the active person"
+msgstr "Aktív személy szerkesztése"
+
+#: ../gramps/plugins/view/relview.py:768
 msgid "Alive"
 msgstr "Élő"
 
-#: ../gramps/plugins/view/relview.py:704 ../gramps/plugins/view/relview.py:731
+#: ../gramps/plugins/view/relview.py:836 ../gramps/plugins/view/relview.py:863
 #, python-format
 msgid "%(date)s in %(place)s"
 msgstr "%(date)s, %(place)s"
 
-#: ../gramps/plugins/view/relview.py:801
+#: ../gramps/plugins/view/relview.py:960
 msgid "Edit parents"
 msgstr "Szülők szerkesztése"
 
-#: ../gramps/plugins/view/relview.py:802
+#: ../gramps/plugins/view/relview.py:961
 msgid "Reorder parents"
 msgstr "Szülők újrarendezése"
 
-#: ../gramps/plugins/view/relview.py:803
+#: ../gramps/plugins/view/relview.py:962
 msgid "Remove person as child of these parents"
 msgstr "Személy - mint a szülők gyermeke - eltávolítása"
 
-#: ../gramps/plugins/view/relview.py:809
+#: ../gramps/plugins/view/relview.py:968
 msgid "Remove person as parent in this family"
 msgstr "Személy - mint szülő a családban - eltávolítása"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/view/relview.py:869 ../gramps/plugins/view/relview.py:923
+#: ../gramps/plugins/view/relview.py:1028
+#: ../gramps/plugins/view/relview.py:1083
 #, python-brace-format
 msgid " ({number_of} sibling)"
 msgid_plural " ({number_of} siblings)"
 msgstr[0] " ({number_of} testvér)"
 msgstr[1] " ({number_of} testvér)"
 
-#: ../gramps/plugins/view/relview.py:876 ../gramps/plugins/view/relview.py:930
+#: ../gramps/plugins/view/relview.py:1035
+#: ../gramps/plugins/view/relview.py:1090
 msgid " (1 brother)"
 msgstr " (1 fiútestvér)"
 
-#: ../gramps/plugins/view/relview.py:878 ../gramps/plugins/view/relview.py:932
+#: ../gramps/plugins/view/relview.py:1037
+#: ../gramps/plugins/view/relview.py:1092
 msgid " (1 sister)"
 msgstr " (1 lánytestvér)"
 
-#: ../gramps/plugins/view/relview.py:880 ../gramps/plugins/view/relview.py:934
+#: ../gramps/plugins/view/relview.py:1039
+#: ../gramps/plugins/view/relview.py:1094
 msgid " (1 sibling)"
 msgstr " (1 testvér)"
 
-#: ../gramps/plugins/view/relview.py:882 ../gramps/plugins/view/relview.py:936
+#: ../gramps/plugins/view/relview.py:1041
+#: ../gramps/plugins/view/relview.py:1096
 msgid " (only child)"
 msgstr " (csak gyermek)"
 
-#: ../gramps/plugins/view/relview.py:948 ../gramps/plugins/view/relview.py:1430
+#: ../gramps/plugins/view/relview.py:1109
+#: ../gramps/plugins/view/relview.py:1601
 msgid "Add new child to family"
 msgstr "Új gyermek hozzáadása a családhoz"
 
-#: ../gramps/plugins/view/relview.py:952 ../gramps/plugins/view/relview.py:1434
+#: ../gramps/plugins/view/relview.py:1113
+#: ../gramps/plugins/view/relview.py:1605
 msgid "Add existing child to family"
 msgstr "Létező gyermek hozzáadása a családhoz"
 
-#: ../gramps/plugins/view/relview.py:1220
+#: ../gramps/plugins/view/relview.py:1380
 #, python-format
 msgid "%(birthabbrev)s %(birthdate)s, %(deathabbrev)s %(deathdate)s"
 msgstr "%(birthabbrev)s %(birthdate)s, %(deathabbrev)s %(deathdate)s"
 
-#: ../gramps/plugins/view/relview.py:1227
-#: ../gramps/plugins/view/relview.py:1229
+#: ../gramps/plugins/view/relview.py:1387
+#: ../gramps/plugins/view/relview.py:1389
 #, python-format
 msgid "%(event)s %(date)s"
 msgstr "%(event)s %(date)s"
 
-#: ../gramps/plugins/view/relview.py:1288
+#: ../gramps/plugins/view/relview.py:1448
 #, python-format
 msgid "Relationship type: %s"
 msgstr "Kapcsolattípus: %s"
 
-#: ../gramps/plugins/view/relview.py:1326
+#: ../gramps/plugins/view/relview.py:1495
 #, python-format
 msgid "%(event_type)s: %(date)s in %(place)s"
 msgstr "%(event_type)s: %(date)s, %(place)s"
 
-#: ../gramps/plugins/view/relview.py:1330
+#: ../gramps/plugins/view/relview.py:1499
 #, python-format
 msgid "%(event_type)s: %(date)s"
 msgstr "%(event_type)s: %(date)s"
 
-#: ../gramps/plugins/view/relview.py:1334
+#: ../gramps/plugins/view/relview.py:1503
 #, python-format
 msgid "%(event_type)s: %(place)s"
 msgstr "%(event_type)s: %(place)s"
 
-#: ../gramps/plugins/view/relview.py:1345
+#: ../gramps/plugins/view/relview.py:1514
 msgid "Broken family detected"
 msgstr "Törött család található"
 
-#: ../gramps/plugins/view/relview.py:1346
+#: ../gramps/plugins/view/relview.py:1515
 msgid "Please run the Check and Repair Database tool"
 msgstr "Kérem futtassa az Adatbázis ellenőrzése és javítása eszközt"
 
 #. translators: leave all/any {...} untranslated
-#: ../gramps/plugins/view/relview.py:1369
-#: ../gramps/plugins/view/relview.py:1414
+#: ../gramps/plugins/view/relview.py:1538
+#: ../gramps/plugins/view/relview.py:1584
 #, python-brace-format
 msgid " ({number_of} child)"
 msgid_plural " ({number_of} children)"
 msgstr[0] " ({number_of} gyermek)"
 msgstr[1] " ({number_of} gyermek)"
 
-#: ../gramps/plugins/view/relview.py:1373
-#: ../gramps/plugins/view/relview.py:1418
+#: ../gramps/plugins/view/relview.py:1542
+#: ../gramps/plugins/view/relview.py:1588
 msgid " (no children)"
 msgstr " (nincs gyermek)"
 
-#: ../gramps/plugins/view/relview.py:1675
+#: ../gramps/plugins/view/relview.py:1846
 msgid "Use shading"
 msgstr "Árnyékolás használata"
 
-#: ../gramps/plugins/view/relview.py:1678
+#: ../gramps/plugins/view/relview.py:1849
 msgid "Display edit buttons"
 msgstr "Szerkesztőgombok mutatása"
 
-#: ../gramps/plugins/view/relview.py:1680
+#: ../gramps/plugins/view/relview.py:1851
 msgid "View links as website links"
 msgstr "Hivatkozások nézete, mint webhivatkozás"
 
-#: ../gramps/plugins/view/relview.py:1697
+#: ../gramps/plugins/view/relview.py:1868
 msgid "Show Details"
 msgstr "Részletek mutatása"
 
-#: ../gramps/plugins/view/relview.py:1700
+#: ../gramps/plugins/view/relview.py:1871
 msgid "Show Siblings"
 msgstr "Testvérek mutatása"
 
@@ -35415,15 +36476,15 @@ msgstr "A kiválasztott tároló törlése"
 msgid "Merge the selected repositories"
 msgstr "A kiválasztott tárolók összefűzése"
 
-#: ../gramps/plugins/view/repoview.py:150
+#: ../gramps/plugins/view/repoview.py:201
 msgid "Repository Filter Editor"
 msgstr "Tárolószűrő szerkesztő"
 
-#: ../gramps/plugins/view/repoview.py:245
+#: ../gramps/plugins/view/repoview.py:363
 msgid "Cannot merge repositories."
 msgstr "Nem összefűzhető tárolók."
 
-#: ../gramps/plugins/view/repoview.py:246
+#: ../gramps/plugins/view/repoview.py:364
 msgid ""
 "Exactly two repositories must be selected to perform a merge. A second "
 "repository can be selected by holding down the control key while clicking on "
@@ -35445,15 +36506,15 @@ msgstr "A kiválasztott forrás törlése"
 msgid "Merge the selected sources"
 msgstr "A kiválasztott források összefűzése"
 
-#: ../gramps/plugins/view/sourceview.py:136
+#: ../gramps/plugins/view/sourceview.py:187
 msgid "Source Filter Editor"
 msgstr "Forrásszűrő szerkesztő"
 
-#: ../gramps/plugins/view/sourceview.py:229
+#: ../gramps/plugins/view/sourceview.py:348
 msgid "Cannot merge sources."
 msgstr "Nem összefűzhető források."
 
-#: ../gramps/plugins/view/sourceview.py:230
+#: ../gramps/plugins/view/sourceview.py:349
 msgid ""
 "Exactly two sources must be selected to perform a merge. A second source can "
 "be selected by holding down the control key while clicking on the desired "
@@ -35559,14 +36620,14 @@ msgstr "Idézeteket és forrásokat fa formátumban mutató nézet."
 #. Add xml, doctype, meta and stylesheets
 #: ../gramps/plugins/webreport/addressbook.py:87
 #: ../gramps/plugins/webreport/addressbooklist.py:81
-#: ../gramps/plugins/webreport/basepage.py:1495
-#: ../gramps/plugins/webreport/basepage.py:1561
-#: ../gramps/plugins/webreport/basepage.py:1636
+#: ../gramps/plugins/webreport/basepage.py:1536
+#: ../gramps/plugins/webreport/basepage.py:1595
+#: ../gramps/plugins/webreport/basepage.py:1669
 msgid "Address Book"
 msgstr "Címjegyzék"
 
 #. Address Book Page message
-#: ../gramps/plugins/webreport/addressbooklist.py:89
+#: ../gramps/plugins/webreport/addressbooklist.py:90
 msgid ""
 "This page contains an index of all the individuals in the database, sorted "
 "by their surname, with one of the following: Address, Residence, or Web "
@@ -35578,45 +36639,46 @@ msgstr ""
 "hivatkozás. Kiválasztva egy családnevet azok személyes címlista  oldalára "
 "jutunk."
 
-#: ../gramps/plugins/webreport/addressbooklist.py:111
+#: ../gramps/plugins/webreport/addressbooklist.py:112
 msgid "Full Name"
 msgstr "Teljes név"
 
-#: ../gramps/plugins/webreport/addressbooklist.py:114
-#: ../gramps/plugins/webreport/basepage.py:2045
+#: ../gramps/plugins/webreport/addressbooklist.py:115
+#: ../gramps/plugins/webreport/basepage.py:2126
 msgid "Web Links"
 msgstr "Web-hivatkozások"
 
 #. add section title
-#: ../gramps/plugins/webreport/basepage.py:350
-#: ../gramps/plugins/webreport/basepage.py:2026
+#: ../gramps/plugins/webreport/basepage.py:369
+#: ../gramps/plugins/webreport/basepage.py:2107
 msgid "Narrative"
 msgstr "Elbeszélés"
 
-#: ../gramps/plugins/webreport/basepage.py:1112
-#: ../gramps/plugins/webreport/basepage.py:2552
-#: ../gramps/plugins/webreport/basepage.py:2616
-#: ../gramps/plugins/webreport/place.py:177
+#: ../gramps/plugins/webreport/basepage.py:1131
+#: ../gramps/plugins/webreport/basepage.py:2593
+#: ../gramps/plugins/webreport/basepage.py:2658
+#: ../gramps/plugins/webreport/place.py:182
+#: ../gramps/plugins/webreport/place.py:194
 msgid "State/ Province"
 msgstr "Állam/megye"
 
-#: ../gramps/plugins/webreport/basepage.py:1286
+#: ../gramps/plugins/webreport/basepage.py:1306
 #, python-format
 msgid "Generated by %(gramps_home_html_start)sGramps%(html_end)s %(version)s"
 msgstr "Készült a %(gramps_home_html_start)sGRAMPS%(html_end)s %(version)s-al"
 
-#: ../gramps/plugins/webreport/basepage.py:1296
+#: ../gramps/plugins/webreport/basepage.py:1316
 #, python-format
 msgid "Last change was the %(date)s"
 msgstr "Az utolsó változás dátuma %(date)s"
 
-#: ../gramps/plugins/webreport/basepage.py:1299
+#: ../gramps/plugins/webreport/basepage.py:1319
 #, python-format
 msgid " on %(date)s"
 msgstr " %(date)s-én(án)"
 
-#: ../gramps/plugins/webreport/basepage.py:1320
-#: ../gramps/plugins/webreport/basepage.py:1325
+#: ../gramps/plugins/webreport/basepage.py:1340
+#: ../gramps/plugins/webreport/basepage.py:1345
 #, python-format
 msgid "%(http_break)sCreated for %(subject_url)s"
 msgstr "%(http_break)sKészült %(subject_url)s számára"
@@ -35625,88 +36687,83 @@ msgstr "%(http_break)sKészült %(subject_url)s számára"
 #. is the style sheet either Basic-Blue or Visually Impaired,
 #. and menu layout is Drop Down?
 #. Basic Blue style sheet with navigation menus
-#: ../gramps/plugins/webreport/basepage.py:1441
+#: ../gramps/plugins/webreport/basepage.py:1476
 #: ../gramps/plugins/webstuff/webstuff.py:64
 msgid "Basic-Blue"
 msgstr "Alap-kék"
 
 #. Visually Impaired style sheet with its navigation menus
-#: ../gramps/plugins/webreport/basepage.py:1442
+#: ../gramps/plugins/webreport/basepage.py:1477
 #: ../gramps/plugins/webstuff/webstuff.py:96
 msgid "Visually Impaired"
 msgstr "Vizuálisan fogyatékos"
 
-#: ../gramps/plugins/webreport/basepage.py:1481
-#: ../gramps/plugins/webreport/basepage.py:1659
+#: ../gramps/plugins/webreport/basepage.py:1521
+#: ../gramps/plugins/webreport/basepage.py:1692
 msgid "Html|Home"
 msgstr "Kezdőlap"
 
-#: ../gramps/plugins/webreport/basepage.py:1493
-#: ../gramps/plugins/webreport/basepage.py:1628
-#: ../gramps/plugins/webreport/thumbnail.py:111
+#: ../gramps/plugins/webreport/basepage.py:1534
+#: ../gramps/plugins/webreport/basepage.py:1661
+#: ../gramps/plugins/webreport/thumbnail.py:112
 msgid "Thumbnails"
 msgstr "Bélyegképek"
 
-#: ../gramps/plugins/webreport/basepage.py:1494
-#: ../gramps/plugins/webreport/basepage.py:1635
+#: ../gramps/plugins/webreport/basepage.py:1535
+#: ../gramps/plugins/webreport/basepage.py:1668
 #: ../gramps/plugins/webreport/download.py:94
-#: ../gramps/plugins/webreport/narrativeweb.py:1814
+#: ../gramps/plugins/webreport/narrativeweb.py:1899
 msgid "Download"
 msgstr "Letöltés"
 
 #. add contact column
-#: ../gramps/plugins/webreport/basepage.py:1497
-#: ../gramps/plugins/webreport/basepage.py:1643
-#: ../gramps/plugins/webreport/basepage.py:1680
-#: ../gramps/plugins/webreport/contact.py:76
+#: ../gramps/plugins/webreport/basepage.py:1538
+#: ../gramps/plugins/webreport/basepage.py:1676
+#: ../gramps/plugins/webreport/basepage.py:1713
+#: ../gramps/plugins/webreport/contact.py:77
 msgid "Contact"
 msgstr "Elérés"
 
-#: ../gramps/plugins/webreport/basepage.py:1499
+#: ../gramps/plugins/webreport/basepage.py:1540
 #: ../gramps/plugins/webreport/webplugins.gpr.py:58
 msgid "Web Calendar"
 msgstr "Web-naptár"
 
-#: ../gramps/plugins/webreport/basepage.py:1579
-#: ../gramps/plugins/webreport/media.py:410
+#: ../gramps/plugins/webreport/basepage.py:1612
+#: ../gramps/plugins/webreport/media.py:399
 msgid "Previous"
 msgstr "Előző"
 
-#: ../gramps/plugins/webreport/basepage.py:1581
-#: ../gramps/plugins/webreport/media.py:421
+#: ../gramps/plugins/webreport/basepage.py:1614
+#: ../gramps/plugins/webreport/media.py:410
 msgid "Next"
 msgstr "Következő"
 
-#: ../gramps/plugins/webreport/basepage.py:2093
+#: ../gramps/plugins/webreport/basepage.py:2174
 msgid " [Click to Go]"
 msgstr " [Kattintson az induláshoz]"
 
-#: ../gramps/plugins/webreport/basepage.py:2117
+#: ../gramps/plugins/webreport/basepage.py:2198
 msgid "Latter-Day Saints/ LDS Ordinance"
 msgstr "Utolsó Napok Szentjei/Mormon rend"
 
-#: ../gramps/plugins/webreport/basepage.py:2303
-#: ../gramps/plugins/webreport/basepage.py:2304
-#: ../gramps/plugins/webreport/person.py:611
-#: ../gramps/plugins/webreport/person.py:921
+#: ../gramps/plugins/webreport/basepage.py:2344
+#: ../gramps/plugins/webreport/basepage.py:2345
+#: ../gramps/plugins/webreport/person.py:630
+#: ../gramps/plugins/webreport/person.py:941
 msgid "Family Map"
 msgstr "Családtérkép"
 
-#: ../gramps/plugins/webreport/basepage.py:2549
-#: ../gramps/plugins/webreport/basepage.py:2614
+#: ../gramps/plugins/webreport/basepage.py:2590
+#: ../gramps/plugins/webreport/basepage.py:2656
 msgid "Church Parish"
 msgstr "Egyházmegye"
 
-#: ../gramps/plugins/webreport/basepage.py:2570
+#: ../gramps/plugins/webreport/basepage.py:2611
 msgid "Locations"
 msgstr "Koordináták"
 
-#: ../gramps/plugins/webreport/basepage.py:2781
-#, python-format
-msgid " (%s) "
-msgstr " (%s) "
-
-#: ../gramps/plugins/webreport/download.py:100
+#: ../gramps/plugins/webreport/download.py:101
 msgid ""
 "This page is for the user/ creator of this Family Tree/ Narrative website to "
 "share a couple of files with you regarding their family.  If there are any "
@@ -35720,11 +36777,11 @@ msgstr ""
 "letöltő oldal és a fájlok  ugyanolyan szerzői jog alá esik, mint maguk a web-"
 "oldalak."
 
-#: ../gramps/plugins/webreport/download.py:126
+#: ../gramps/plugins/webreport/download.py:127
 msgid "File Name"
 msgstr "Fájlnév"
 
-#: ../gramps/plugins/webreport/download.py:128
+#: ../gramps/plugins/webreport/download.py:129
 msgid "Last Modified"
 msgstr "Utoljára módosítva"
 
@@ -35734,22 +36791,22 @@ msgstr "Eseményoldalak létrehozása"
 
 #: ../gramps/plugins/webreport/event.py:114
 #: ../gramps/plugins/webreport/family.py:108
-#: ../gramps/plugins/webreport/media.py:114
-#: ../gramps/plugins/webreport/media.py:243
-#: ../gramps/plugins/webreport/narrativeweb.py:484
-#: ../gramps/plugins/webreport/narrativeweb.py:1051
-#: ../gramps/plugins/webreport/narrativeweb.py:1109
-#: ../gramps/plugins/webreport/narrativeweb.py:1134
-#: ../gramps/plugins/webreport/narrativeweb.py:1143
-#: ../gramps/plugins/webreport/narrativeweb.py:1186
-#: ../gramps/plugins/webreport/person.py:136
-#: ../gramps/plugins/webreport/place.py:114
+#: ../gramps/plugins/webreport/media.py:116
+#: ../gramps/plugins/webreport/media.py:244
+#: ../gramps/plugins/webreport/narrativeweb.py:501
+#: ../gramps/plugins/webreport/narrativeweb.py:1084
+#: ../gramps/plugins/webreport/narrativeweb.py:1142
+#: ../gramps/plugins/webreport/narrativeweb.py:1165
+#: ../gramps/plugins/webreport/narrativeweb.py:1174
+#: ../gramps/plugins/webreport/narrativeweb.py:1217
+#: ../gramps/plugins/webreport/person.py:141
+#: ../gramps/plugins/webreport/place.py:117
 #: ../gramps/plugins/webreport/repository.py:102
 #: ../gramps/plugins/webreport/source.py:103
 msgid "Narrated Web Site Report"
 msgstr "Leíró web-oldal összesítő"
 
-#: ../gramps/plugins/webreport/event.py:147
+#: ../gramps/plugins/webreport/event.py:148
 msgid ""
 "This page contains an index of all the events in the database, sorted by "
 "their type and date (if one is present). Clicking on an event&#8217;s Gramps "
@@ -35759,14 +36816,15 @@ msgstr ""
 "típus és dátum szerint (ha van). Az esemény GRAMPS azonosítójára kattintva  "
 "az esemény oldalára jutunk."
 
-#: ../gramps/plugins/webreport/event.py:173
-#: ../gramps/plugins/webreport/family.py:185
-#: ../gramps/plugins/webreport/place.py:175
-#: ../gramps/plugins/webreport/surnamelist.py:139
+#: ../gramps/plugins/webreport/event.py:174
+#: ../gramps/plugins/webreport/family.py:186
+#: ../gramps/plugins/webreport/place.py:180
+#: ../gramps/plugins/webreport/place.py:192
+#: ../gramps/plugins/webreport/surnamelist.py:140
 msgid "Letter"
 msgstr "Betű"
 
-#: ../gramps/plugins/webreport/event.py:245
+#: ../gramps/plugins/webreport/event.py:246
 #, python-format
 msgid "Event types beginning with letter %s"
 msgstr "%s betűvel kezdődő eseménytípusok"
@@ -35776,7 +36834,7 @@ msgid "Creating family pages..."
 msgstr "Családoldalak létrehozása..."
 
 #. Families list page message
-#: ../gramps/plugins/webreport/family.py:140
+#: ../gramps/plugins/webreport/family.py:141
 msgid ""
 "This page contains an index of all the families/ relationships in the "
 "database, sorted by their family name/ surname. Clicking on a person&#8217;s "
@@ -35786,20 +36844,20 @@ msgstr ""
 "tartalmazza a család neve/vezetékneve szerint. A személy nevére kattintva a "
 "név a család/kapcsolat oldalára juttat."
 
-#: ../gramps/plugins/webreport/family.py:231
+#: ../gramps/plugins/webreport/family.py:232
 msgid "Families beginning with letter "
 msgstr "Családok, melyek kezdőbetűje "
 
-#: ../gramps/plugins/webreport/home.py:77
-#: ../gramps/plugins/webreport/webcal.py:570
+#: ../gramps/plugins/webreport/home.py:78
+#: ../gramps/plugins/webreport/webcal.py:576
 msgid "Home"
 msgstr "Kezdőlap"
 
-#: ../gramps/plugins/webreport/media.py:113
+#: ../gramps/plugins/webreport/media.py:115
 msgid "Creating media pages"
 msgstr "Médiaoldalak létrehozása"
 
-#: ../gramps/plugins/webreport/media.py:203
+#: ../gramps/plugins/webreport/media.py:204
 msgid ""
 "This page contains an index of all the media objects in the database, sorted "
 "by their title. Clicking on the title will take you to that media "
@@ -35811,23 +36869,23 @@ msgstr ""
 "jutunk. Ha a kép felett látható a média mérete, rákattintva a teljes méret "
 "látható  lesz. "
 
-#: ../gramps/plugins/webreport/media.py:227
+#: ../gramps/plugins/webreport/media.py:228
 msgid "Media | Name"
 msgstr "Médianév"
 
-#: ../gramps/plugins/webreport/media.py:230
+#: ../gramps/plugins/webreport/media.py:231
 msgid "Mime Type"
 msgstr "MIME-típus"
 
-#: ../gramps/plugins/webreport/media.py:242
+#: ../gramps/plugins/webreport/media.py:243
 msgid "Creating list of media pages"
 msgstr "Médiaoldal-lista létrehozása"
 
-#: ../gramps/plugins/webreport/media.py:286
+#: ../gramps/plugins/webreport/media.py:280
 msgid "Below unused media objects"
 msgstr "Alább a használatlan média objektumok"
 
-#: ../gramps/plugins/webreport/media.py:411
+#: ../gramps/plugins/webreport/media.py:400
 #, python-format
 msgid ""
 "%(strong1_strt)s%(page_number)d%(strong_end)s of %(strong2_strt)s"
@@ -35837,270 +36895,314 @@ msgstr ""
 "%(page_number)d%(strong_end)s-a(e)"
 
 #. missing media error message
-#: ../gramps/plugins/webreport/media.py:424
+#: ../gramps/plugins/webreport/media.py:413
 msgid "The file has been moved or deleted."
 msgstr "A fájl mozgatva, vagy törölve lett."
 
-#: ../gramps/plugins/webreport/media.py:580
+#: ../gramps/plugins/webreport/media.py:552
 msgid "File Type"
 msgstr "Fájltípus"
 
-#: ../gramps/plugins/webreport/media.py:683
+#: ../gramps/plugins/webreport/media.py:655
 msgid "Missing media object:"
 msgstr "Hiányzó médiaobjektum:"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:270
+#: ../gramps/plugins/webreport/narrativeweb.py:285
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
 msgstr "Sem %(current)s, sem %(parent)s nem mappa"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:279
-#: ../gramps/plugins/webreport/narrativeweb.py:284
-#: ../gramps/plugins/webreport/narrativeweb.py:297
-#: ../gramps/plugins/webreport/narrativeweb.py:302
+#: ../gramps/plugins/webreport/narrativeweb.py:294
+#: ../gramps/plugins/webreport/narrativeweb.py:300
+#: ../gramps/plugins/webreport/narrativeweb.py:313
+#: ../gramps/plugins/webreport/narrativeweb.py:319
 #, python-format
 msgid "Could not create the directory: %s"
 msgstr "Nem lehet létrehozni a mappát : %s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:309
+#: ../gramps/plugins/webreport/narrativeweb.py:326
 msgid "Invalid file name"
 msgstr "Szabálytalan fájlnév"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:310
+#: ../gramps/plugins/webreport/narrativeweb.py:327
 msgid "The archive file must be a file, not a directory"
 msgstr "Az archívumnak fájlnak kell lennie, nem mappának"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:446
+#: ../gramps/plugins/webreport/narrativeweb.py:463
 #, python-format
 msgid "ID=%(grampsid)s, path=%(dir)s"
 msgstr "Azonosító=%(grampsid)s, path=%(dir)s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:451
+#: ../gramps/plugins/webreport/narrativeweb.py:468
 msgid "Missing media objects:"
 msgstr "Hiányzó médiaobjektumok:"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:483
+#: ../gramps/plugins/webreport/narrativeweb.py:500
 msgid "Constructing list of other objects..."
 msgstr "Más objektum-lista felépítése..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:728
+#: ../gramps/plugins/webreport/narrativeweb.py:745
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr "%(husband)s és %(spouse)s családja"
 
 #. Only the name of the husband is known
 #. Only the name of the wife is known
-#: ../gramps/plugins/webreport/narrativeweb.py:734
-#: ../gramps/plugins/webreport/narrativeweb.py:738
+#: ../gramps/plugins/webreport/narrativeweb.py:751
+#: ../gramps/plugins/webreport/narrativeweb.py:755
 #, python-format
 msgid "Family of %s"
 msgstr "%s családja"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1050
+#: ../gramps/plugins/webreport/narrativeweb.py:1083
 msgid "Creating GENDEX file"
 msgstr "GENDEX fájl létrehozása"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1108
+#: ../gramps/plugins/webreport/narrativeweb.py:1141
 msgid "Creating surname pages"
 msgstr "Családnév oldalak létrehozása"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1135
-#: ../gramps/plugins/webreport/thumbnail.py:206
+#: ../gramps/plugins/webreport/narrativeweb.py:1166
 msgid "Creating thumbnail preview page..."
 msgstr "Bélyegkép előnézet oldal létrehozása..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1144
+#: ../gramps/plugins/webreport/narrativeweb.py:1175
 msgid "Creating statistics page..."
 msgstr "Statisztikai oldal létrehozása..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1185
+#: ../gramps/plugins/webreport/narrativeweb.py:1216
 msgid "Creating address book pages ..."
 msgstr "Címlista oldalak létrehozása ..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1579
+#: ../gramps/plugins/webreport/narrativeweb.py:1616
 msgid "Store web pages in .tar.gz archive"
 msgstr "A honlapot .tar.gz archívumban tárolja"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1581
+#: ../gramps/plugins/webreport/narrativeweb.py:1618
 msgid "Whether to store the web pages in an archive file"
 msgstr "Legyen-e a web-oldal archívum fájlban tárolva"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1592
-#: ../gramps/plugins/webreport/webcal.py:1618
+#: ../gramps/plugins/webreport/narrativeweb.py:1629
+#: ../gramps/plugins/webreport/webcal.py:1663
 msgid "The destination directory for the web files"
 msgstr "A web-fájlok cél könyvtára"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1598
+#: ../gramps/plugins/webreport/narrativeweb.py:1635
 msgid "My Family Tree"
 msgstr "Családfám"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1598
+#: ../gramps/plugins/webreport/narrativeweb.py:1635
 msgid "Web site title"
 msgstr "A web-oldal neve"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1599
+#: ../gramps/plugins/webreport/narrativeweb.py:1636
 msgid "The title of the web site"
 msgstr "A web-oldal megnevezése"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1604
+#: ../gramps/plugins/webreport/narrativeweb.py:1641
 msgid "Select filter to restrict people that appear on web site"
 msgstr "Válasszon szűrőt a weboldalon megjelenő személyekhez"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1624
+#: ../gramps/plugins/webreport/narrativeweb.py:1650
+msgid "Show the relationship between the current person and the active person"
+msgstr "Kapcsolat mutatása a kiválasztott és a kiinduló személy között"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1653
+msgid ""
+"For each person page, show the relationship between this person and the "
+"active person."
+msgstr ""
+"Minden személy oldalon a kapcsolat mutatása a kiválasztott és a kiinduló "
+"személy között."
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1671
 msgid "Html options"
 msgstr "Html beállítások"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1627
-#: ../gramps/plugins/webreport/webcal.py:1639
+#: ../gramps/plugins/webreport/narrativeweb.py:1674
+#: ../gramps/plugins/webreport/webcal.py:1684
 msgid "File extension"
 msgstr "Fájlkiterjesztés"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1630
-#: ../gramps/plugins/webreport/webcal.py:1642
+#: ../gramps/plugins/webreport/narrativeweb.py:1677
+#: ../gramps/plugins/webreport/webcal.py:1687
 msgid "The extension to be used for the web files"
 msgstr "A web-fájlokhoz használandó kiterjesztés"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1633
-#: ../gramps/plugins/webreport/webcal.py:1645
+#: ../gramps/plugins/webreport/narrativeweb.py:1680
+#: ../gramps/plugins/webreport/webcal.py:1690
 msgid "Copyright"
 msgstr "Szerzői jog"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1636
-#: ../gramps/plugins/webreport/webcal.py:1648
+#: ../gramps/plugins/webreport/narrativeweb.py:1683
+#: ../gramps/plugins/webreport/webcal.py:1693
 msgid "The copyright to be used for the web files"
 msgstr "A web-fájlokra vonatkozó szerzői jog"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1639
-#: ../gramps/plugins/webreport/webcal.py:1654
-msgid "StyleSheet"
-msgstr "Stíluslap"
-
-#: ../gramps/plugins/webreport/narrativeweb.py:1644
-#: ../gramps/plugins/webreport/webcal.py:1657
+#: ../gramps/plugins/webreport/narrativeweb.py:1692
+#: ../gramps/plugins/webreport/webcal.py:1702
 msgid "The stylesheet to be used for the web pages"
 msgstr "A weboldalhoz használandó stíluslap"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1649
+#: ../gramps/plugins/webreport/narrativeweb.py:1697
 msgid "Horizontal -- Default"
 msgstr "Vízszintes -- alapértelmezett"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1650
+#: ../gramps/plugins/webreport/narrativeweb.py:1698
 msgid "Vertical   -- Left Side"
 msgstr "Függőleges -- bal oldal"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1651
+#: ../gramps/plugins/webreport/narrativeweb.py:1699
 msgid "Fade       -- WebKit Browsers Only"
 msgstr "Homályosít      -- csak WebKit böngészők"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1652
-#: ../gramps/plugins/webreport/narrativeweb.py:1666
+#: ../gramps/plugins/webreport/narrativeweb.py:1700
+#: ../gramps/plugins/webreport/narrativeweb.py:1714
 msgid "Drop-Down  -- WebKit Browsers Only"
 msgstr "Legördülő  -- csak WebKit böngészők"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1654
+#: ../gramps/plugins/webreport/narrativeweb.py:1702
 msgid "Navigation Menu Layout"
 msgstr "Navigációs menü elrendezés"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1658
+#: ../gramps/plugins/webreport/narrativeweb.py:1706
 msgid "Choose which layout for the Navigation Menus."
 msgstr "Válassza ki a Navigációs menü elrendezését."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1665
+#: ../gramps/plugins/webreport/narrativeweb.py:1713
 msgid "Normal Outline Style"
 msgstr "Normál kontúr stílus"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1669
+#: ../gramps/plugins/webreport/narrativeweb.py:1717
 msgid "Citation Referents Layout"
 msgstr "Idézet hivatkozások elrendezés"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1673
+#: ../gramps/plugins/webreport/narrativeweb.py:1721
 msgid ""
 "Determine the default layout for the Source Page's Citation Referents section"
 msgstr ""
 "Meghatározza a Forrás oldal idézet hivatkozások részének alapértelmezett "
 "elrendezését"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1677
+#: ../gramps/plugins/webreport/narrativeweb.py:1725
 msgid "Include ancestor's tree"
 msgstr "Az ős-fával"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1678
+#: ../gramps/plugins/webreport/narrativeweb.py:1726
 msgid "Whether to include an ancestor graph on each individual page"
 msgstr "Legyen-e minden személy oldalán az ős-grafikon is"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1683
-msgid "Graph generations"
-msgstr "Generációk grafikonja"
+#: ../gramps/plugins/webreport/narrativeweb.py:1731
+msgid "Add previous/next"
+msgstr "Előző/következő hozzáadása"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1684
-msgid "The number of generations to include in the ancestor graph"
-msgstr "Az ős grafikonba kerülő generációk száma"
+#: ../gramps/plugins/webreport/narrativeweb.py:1732
+msgid "Add previous/next to the navigation bar."
+msgstr "Előző/következő hozzáadása a navigációs sávhoz."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1689
+#: ../gramps/plugins/webreport/narrativeweb.py:1735
 msgid "This is a secure site (https)"
 msgstr "Ez egy biztonságos oldal (https)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1691
+#: ../gramps/plugins/webreport/narrativeweb.py:1737
 msgid "Whether to use http:// or https://"
 msgstr "http://- vagy https://-t használjon"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1707
-msgid "Suppress Gramps ID"
-msgstr "GRAMPS-azonosító tiltása"
+#: ../gramps/plugins/webreport/narrativeweb.py:1744
+msgid "Extra pages"
+msgstr "Többlet lap"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1708
-msgid "Whether to include the Gramps ID of objects"
-msgstr "Legyen-e az objektum GRAMPS-azonosítóval"
+#: ../gramps/plugins/webreport/narrativeweb.py:1747
+msgid "Extra page name"
+msgstr "Többlet lap neve"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1713
+#: ../gramps/plugins/webreport/narrativeweb.py:1750
+msgid "Your extra page name like it is shown in the menubar"
+msgstr "A többlet lap neve, ahogyan a menüsávban látható"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1755
+msgid "Your extra page path"
+msgstr "Többlet lapjának útvonala"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1758
+msgid "Your extra page path without extension"
+msgstr "Többlet lapjának útvonala kiterjesztés nélkül"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1778
 msgid "Sort all children in birth order"
 msgstr "Rendezze az összes gyermeket születési sorrendbe"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1715
+#: ../gramps/plugins/webreport/narrativeweb.py:1780
 msgid "Whether to display children in birth order or in entry order?"
 msgstr "Legyenek-e a gyermekek születési, vagy belépési sorrenbe rendezve?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1722
+#: ../gramps/plugins/webreport/narrativeweb.py:1784
+msgid "Do we display coordinates in the places list?"
+msgstr "Mutassuk-e a koordinátákat a helylistában?"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1786
+msgid "Whether to display latitude/longitude in the places list?"
+msgstr "Mutassuk-e a hosszúságot/szélességet a helylistában?"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1790
+msgid "Sort places references either by date or by name"
+msgstr "Helyek hivatkozásainak dátum és név szerinti rendezése"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1792
+msgid "Sort the places references by date or by name. Not set means by date."
+msgstr ""
+"Helyek hivatkozásainak rendezése dátum, vagy név szerint. Ha nincs beállítás "
+"az dátum szerinti rendezést jelent."
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1796
+msgid "Graph generations"
+msgstr "Generációk grafikonja"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1797
+msgid "The number of generations to include in the ancestor graph"
+msgstr "Az ős grafikonba kerülő generációk száma"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:1807
 msgid "Page Generation"
 msgstr "Generáció oldal"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1725
+#: ../gramps/plugins/webreport/narrativeweb.py:1810
 msgid "Home page note"
 msgstr "Kezdő oldal szöveg"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1726
+#: ../gramps/plugins/webreport/narrativeweb.py:1811
 msgid "A note to be used on the home page"
 msgstr "A kezdőlapon megjelenő szöveg"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1729
+#: ../gramps/plugins/webreport/narrativeweb.py:1814
 msgid "Home page image"
 msgstr "Kezdőlap kép"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1730
+#: ../gramps/plugins/webreport/narrativeweb.py:1815
 msgid "An image to be used on the home page"
 msgstr "Egy kép, ami a kezdőlapon lesz"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1733
+#: ../gramps/plugins/webreport/narrativeweb.py:1818
 msgid "Introduction note"
 msgstr "Bevezető szöveg"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1734
+#: ../gramps/plugins/webreport/narrativeweb.py:1819
 msgid "A note to be used as the introduction"
 msgstr "Egy szöveg, ami a bevezetésben lesz"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1737
+#: ../gramps/plugins/webreport/narrativeweb.py:1822
 msgid "Introduction image"
 msgstr "Bevezető kép"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1738
+#: ../gramps/plugins/webreport/narrativeweb.py:1823
 msgid "An image to be used as the introduction"
 msgstr "Egy kép, ami a bevezetésben lesz"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1741
+#: ../gramps/plugins/webreport/narrativeweb.py:1826
 msgid "Publisher contact note"
 msgstr "A kiadó kapcsolat információja"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1742
+#: ../gramps/plugins/webreport/narrativeweb.py:1827
 msgid ""
 "A note to be used as the publisher contact.\n"
 "If no publisher information is given,\n"
@@ -36110,11 +37212,11 @@ msgstr ""
 "Ha nincs kiadói információ, akkor\n"
 "nem lesz kapcsolati oldal létrehozva"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1748
+#: ../gramps/plugins/webreport/narrativeweb.py:1833
 msgid "Publisher contact image"
 msgstr "A kiadó kapcsolati képe"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1749
+#: ../gramps/plugins/webreport/narrativeweb.py:1834
 msgid ""
 "An image to be used as the publisher contact.\n"
 "If no publisher information is given,\n"
@@ -36124,47 +37226,47 @@ msgstr ""
 "Ha nincs kiadói információ, akkor\n"
 "nem lesz kapcsolati oldal létrehozva"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1755
+#: ../gramps/plugins/webreport/narrativeweb.py:1840
 msgid "HTML user header"
 msgstr "HTML felhasználói fejléc"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1756
+#: ../gramps/plugins/webreport/narrativeweb.py:1841
 msgid "A note to be used as the page header"
 msgstr "Egy szöveg, ami az oldal fejlécében lesz"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1759
+#: ../gramps/plugins/webreport/narrativeweb.py:1844
 msgid "HTML user footer"
 msgstr "HTML felhasználói lábléc"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1760
+#: ../gramps/plugins/webreport/narrativeweb.py:1845
 msgid "A note to be used as the page footer"
 msgstr "Egy szöveg, ami az oldal láblécében lesz"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1767
+#: ../gramps/plugins/webreport/narrativeweb.py:1852
 msgid "Images Generation"
 msgstr "Képek generálása"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1770
+#: ../gramps/plugins/webreport/narrativeweb.py:1855
 msgid "Include images and media objects"
 msgstr "Képekkel és médiaobjektumokkal"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1772
+#: ../gramps/plugins/webreport/narrativeweb.py:1857
 msgid "Whether to include a gallery of media objects"
 msgstr "Legyen-e benne a médiaobjektumok galériája"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1778
+#: ../gramps/plugins/webreport/narrativeweb.py:1863
 msgid "Include unused images and media objects"
 msgstr "A nem használt képekkel és médiaobjektumokkal"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1779
+#: ../gramps/plugins/webreport/narrativeweb.py:1864
 msgid "Whether to include unused or unreferenced media objects"
 msgstr "Legyenek-e benne nem használt, vagy nem-hivatkozott médiaobjektumok"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1784
+#: ../gramps/plugins/webreport/narrativeweb.py:1869
 msgid "Create and only use thumbnail- sized images"
 msgstr "Csak bélyegkép méretű képek létrehozása és használata"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1786
+#: ../gramps/plugins/webreport/narrativeweb.py:1871
 msgid ""
 "This option allows you to create only thumbnail images instead of the full-"
 "sized images on the Media Page. This will allow you to have a much smaller "
@@ -36174,11 +37276,11 @@ msgstr ""
 "hanem bélyegkép méretű képek létrehozását. Ez a web-kiszolgáló oldalra "
 "sokkal kisebb feltöltési méretet tesz lehetővé."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1795
+#: ../gramps/plugins/webreport/narrativeweb.py:1880
 msgid "Max width of initial image"
 msgstr "A kezdőkép maximális szélessége"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1797
+#: ../gramps/plugins/webreport/narrativeweb.py:1882
 msgid ""
 "This allows you to set the maximum width of the image shown on the media "
 "page. Set to 0 for no limit."
@@ -36186,11 +37288,11 @@ msgstr ""
 "Lehetővé teszi a kép maximális mutatott szélességének beállítását a média "
 "oldalon. állítsa 0-ra, ha nincs korlát."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1802
+#: ../gramps/plugins/webreport/narrativeweb.py:1887
 msgid "Max height of initial image"
 msgstr "A kezdőkép maximális magassága"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1804
+#: ../gramps/plugins/webreport/narrativeweb.py:1889
 msgid ""
 "This allows you to set the maximum height of the image shown on the media "
 "page. Set to 0 for no limit."
@@ -36198,144 +37300,160 @@ msgstr ""
 "Lehetővé teszi a kép maximális mutatott magasságának beállítását a média "
 "oldalon. állítsa 0-ra, ha nincs korlát."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1817
+#: ../gramps/plugins/webreport/narrativeweb.py:1902
 msgid "Include download page"
 msgstr "Letöltés lappal együtt"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1819
+#: ../gramps/plugins/webreport/narrativeweb.py:1904
 msgid "Whether to include a database download option"
 msgstr "Legyen-e letöltés opcióhoz adatbázis benne"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1824
-#: ../gramps/plugins/webreport/narrativeweb.py:1836
+#: ../gramps/plugins/webreport/narrativeweb.py:1909
+#: ../gramps/plugins/webreport/narrativeweb.py:1921
 msgid "Download Filename"
 msgstr "Fájlnév letöltés"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1827
-#: ../gramps/plugins/webreport/narrativeweb.py:1839
+#: ../gramps/plugins/webreport/narrativeweb.py:1912
+#: ../gramps/plugins/webreport/narrativeweb.py:1924
 msgid "File to be used for downloading of database"
 msgstr "Az adatbázis letöltéséhez használandó fájl"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1830
-#: ../gramps/plugins/webreport/narrativeweb.py:1842
+#: ../gramps/plugins/webreport/narrativeweb.py:1915
+#: ../gramps/plugins/webreport/narrativeweb.py:1927
 msgid "Description for download"
 msgstr "A letöltés leírása"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1831
+#: ../gramps/plugins/webreport/narrativeweb.py:1916
 msgid "Smith Family Tree"
 msgstr "Smith családfa"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1832
-#: ../gramps/plugins/webreport/narrativeweb.py:1844
+#: ../gramps/plugins/webreport/narrativeweb.py:1917
+#: ../gramps/plugins/webreport/narrativeweb.py:1929
 msgid "Give a description for this file."
 msgstr "Adja meg a fájl leírását."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1843
+#: ../gramps/plugins/webreport/narrativeweb.py:1928
 msgid "Johnson Family Tree"
 msgstr "Johnson családfa"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1853
-#: ../gramps/plugins/webreport/webcal.py:1829
+#: ../gramps/plugins/webreport/narrativeweb.py:1938
+#: ../gramps/plugins/webreport/webcal.py:1868
 msgid "Advanced Options"
 msgstr "Haladó opciók"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1856
-#: ../gramps/plugins/webreport/webcal.py:1831
+#: ../gramps/plugins/webreport/narrativeweb.py:1941
+#: ../gramps/plugins/webreport/webcal.py:1870
 msgid "Character set encoding"
 msgstr "Karakterkészlet kódolás"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1860
-#: ../gramps/plugins/webreport/webcal.py:1835
+#: ../gramps/plugins/webreport/narrativeweb.py:1945
+#: ../gramps/plugins/webreport/webcal.py:1874
 msgid "The encoding to be used for the web files"
 msgstr "A web-oldal karakterkódja"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1864
+#: ../gramps/plugins/webreport/narrativeweb.py:1949
 msgid "Include link to active person on every page"
 msgstr "Aktív személy hivatkozással minden oldalon"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1866
+#: ../gramps/plugins/webreport/narrativeweb.py:1951
 msgid "Include a link to the active person (if they have a webpage)"
 msgstr "Együtt egy hivatkozással aktív személyhez (ha van web-oldala)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1870
+#: ../gramps/plugins/webreport/narrativeweb.py:1955
 msgid "Include a column for birth dates on the index pages"
 msgstr "Legyen oszlop a születési dátumokhoz az index oldalakon"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1871
+#: ../gramps/plugins/webreport/narrativeweb.py:1956
 msgid "Whether to include a birth column"
 msgstr "Legyen-e születési oszlop"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1875
+#: ../gramps/plugins/webreport/narrativeweb.py:1960
 msgid "Include a column for death dates on the index pages"
 msgstr "Legyen oszlop a halálozási dátumokhoz az index oldalakon"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1876
+#: ../gramps/plugins/webreport/narrativeweb.py:1961
 msgid "Whether to include a death column"
 msgstr "Legyen-e halálozási oszlop"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1879
+#: ../gramps/plugins/webreport/narrativeweb.py:1964
 msgid "Include a column for partners on the index pages"
 msgstr "Legyen oszlop a társaknak az index oldalakon"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1881
+#: ../gramps/plugins/webreport/narrativeweb.py:1966
 msgid "Whether to include a partners column"
 msgstr "Legyen-e társak oszlop"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1884
+#: ../gramps/plugins/webreport/narrativeweb.py:1969
 msgid "Include a column for parents on the index pages"
 msgstr "Legyen oszlop a szülőknek az index oldalakon"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1886
+#: ../gramps/plugins/webreport/narrativeweb.py:1971
 msgid "Whether to include a parents column"
 msgstr "Legyen-e szülők oszlop"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1890
+#: ../gramps/plugins/webreport/narrativeweb.py:1975
 msgid "Include half and/ or step-siblings on the individual pages"
 msgstr "Legyen fél- és/vagy mostohatestvér az egyes oldalakon"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1893
+#: ../gramps/plugins/webreport/narrativeweb.py:1978
 msgid ""
 "Whether to include half and/ or step-siblings with the parents and siblings"
 msgstr ""
 "Benne legyenek-e a fél- és/vagy mostohatestvérek a szülőkkel és testvérekkel"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1904
+#: ../gramps/plugins/webreport/narrativeweb.py:1989
 msgid "Include family pages"
 msgstr "Családi oldalakkal együtt"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1905
+#: ../gramps/plugins/webreport/narrativeweb.py:1990
 msgid "Whether or not to include family pages."
 msgstr "Legyenek-e benne családi oldalak is."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1908
+#: ../gramps/plugins/webreport/narrativeweb.py:1993
 msgid "Include event pages"
 msgstr "Esemény oldalakkal együtt"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1910
+#: ../gramps/plugins/webreport/narrativeweb.py:1995
 msgid "Add a complete events list and relevant pages or not"
 msgstr "Adjon-e hozzá eseménylistát és fontos oldalakat, vagy sem"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1913
+#: ../gramps/plugins/webreport/narrativeweb.py:1998
+msgid "Include places pages"
+msgstr "Hely oldalakkal együtt"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:2000
+msgid "Whether or not to include the places Pages."
+msgstr "Legyenek-e benne Hely oldalak, vagy sem."
+
+#: ../gramps/plugins/webreport/narrativeweb.py:2003
+msgid "Include sources pages"
+msgstr "Forrás oldalakkal"
+
+#: ../gramps/plugins/webreport/narrativeweb.py:2005
+msgid "Whether or not to include the sources Pages."
+msgstr "Legyenek-e benne Forrás oldalak, vagy sem."
+
+#: ../gramps/plugins/webreport/narrativeweb.py:2008
 msgid "Include repository pages"
 msgstr "Tároló oldalakkal együtt"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1915
+#: ../gramps/plugins/webreport/narrativeweb.py:2010
 msgid "Whether or not to include the Repository Pages."
 msgstr "Legyenek-e benne Tároló oldalak, vagy sem."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1919
+#: ../gramps/plugins/webreport/narrativeweb.py:2014
 msgid "Include GENDEX file (/gendex.txt)"
 msgstr "GENDEX-fájllal (/gendex.txt)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1920
+#: ../gramps/plugins/webreport/narrativeweb.py:2015
 msgid "Whether to include a GENDEX file or not"
 msgstr "Legyen-e benne GENDEX-fájl, vagy sem"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1923
+#: ../gramps/plugins/webreport/narrativeweb.py:2018
 msgid "Include address book pages"
 msgstr "Címlista oldalakkal együtt"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1924
+#: ../gramps/plugins/webreport/narrativeweb.py:2019
 msgid ""
 "Whether or not to add Address Book pages,which can include e-mail and "
 "website addresses and personal address/ residence events."
@@ -36343,35 +37461,35 @@ msgstr ""
 "Legyenek-e hozzáadva olyan Címlista oldalak (vagy sem), melyek e-mail-, web-"
 "oldal- és személyes lak-/lakóhely címeket tartalmaznak."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1930
+#: ../gramps/plugins/webreport/narrativeweb.py:2025
 msgid "Include the statistics page"
 msgstr "Statisztikai oldallal együtt"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1931
+#: ../gramps/plugins/webreport/narrativeweb.py:2026
 msgid "Whether or not to add statistics page"
 msgstr "Legyen, vagy ne legyen statisztikai oldal hozzáadás"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1938
+#: ../gramps/plugins/webreport/narrativeweb.py:2033
 msgid "Place Map Options"
 msgstr "Helytérkép opciók"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1943
+#: ../gramps/plugins/webreport/narrativeweb.py:2038
 msgid "Google"
 msgstr "Google"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1944
+#: ../gramps/plugins/webreport/narrativeweb.py:2039
 msgid "Map Service"
 msgstr "Térképszolgáltatás"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1948
+#: ../gramps/plugins/webreport/narrativeweb.py:2043
 msgid "Choose your choice of map service for creating the Place Map Pages."
 msgstr "A Helytérkép oldalak létrehozásához válasszon egy térképszolgáltatást."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1954
+#: ../gramps/plugins/webreport/narrativeweb.py:2049
 msgid "Include Place map on Place Pages"
 msgstr "Helytérképpel a Helyek oldalon"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1956
+#: ../gramps/plugins/webreport/narrativeweb.py:2051
 msgid ""
 "Whether to include a place map on the Place Pages, where Latitude/ Longitude "
 "are available."
@@ -36379,11 +37497,11 @@ msgstr ""
 "Legyen-e helytérkép a Helyek oldalon, ahol a szélességi/hosszúsági fokok "
 "elérhetőek."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1961
+#: ../gramps/plugins/webreport/narrativeweb.py:2056
 msgid "Include Family Map Pages with all places shown on the map"
 msgstr "Családtérkép oldalakkal az összes hely jelölésével a térképen"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1965
+#: ../gramps/plugins/webreport/narrativeweb.py:2060
 msgid ""
 "Whether or not to add an individual page map showing all the places on this "
 "page. This will allow you to see how your family traveled around the country."
@@ -36391,23 +37509,23 @@ msgstr ""
 "Legyen-e egyéni oldalhoz térkép hozzáadva, ami jelöli az összes helyet az "
 "oldalon. Ez lehetővé teszi a család országon belüli utazásainak bemutatását."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1973
+#: ../gramps/plugins/webreport/narrativeweb.py:2068
 msgid "Family Links"
 msgstr "Család hivatkozások"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1974
+#: ../gramps/plugins/webreport/narrativeweb.py:2069
 msgid "Drop"
 msgstr "Eldobás"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1975
+#: ../gramps/plugins/webreport/narrativeweb.py:2070
 msgid "Markers"
 msgstr "Jelzők"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1976
+#: ../gramps/plugins/webreport/narrativeweb.py:2071
 msgid "Google/ FamilyMap Option"
 msgstr "Google/ CsaládTérkép opció"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1981
+#: ../gramps/plugins/webreport/narrativeweb.py:2076
 msgid ""
 "Select which option that you would like to have for the Google Maps Family "
 "Map pages..."
@@ -36415,45 +37533,45 @@ msgstr ""
 "Válassza ki, milyen opciókkal szeretné a Google Térképeken a Családtérkép "
 "oldalakat megjeleníteni..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1985
+#: ../gramps/plugins/webreport/narrativeweb.py:2080
 msgid "Google maps API key"
 msgstr "Google térkép API kulcs"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1986
+#: ../gramps/plugins/webreport/narrativeweb.py:2081
 msgid "The API key used for the Google maps"
 msgstr "A Google térképhez használt API kulcs"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1995
+#: ../gramps/plugins/webreport/narrativeweb.py:2090
 msgid "Other inclusion (CMS, Web Calendar, Php)"
 msgstr "Egyéb számításba veendő (CMS, Web-naptár, Php)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1999
+#: ../gramps/plugins/webreport/narrativeweb.py:2094
 msgid "Do we include these pages in a cms web ?"
 msgstr "Betegyük ezeket a lapokat a cms web-be ?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2003
-#: ../gramps/plugins/webreport/narrativeweb.py:2020
+#: ../gramps/plugins/webreport/narrativeweb.py:2098
+#: ../gramps/plugins/webreport/narrativeweb.py:2115
 msgid "URI"
 msgstr "URI"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2009
+#: ../gramps/plugins/webreport/narrativeweb.py:2104
 msgid "Where do you place your web site ? default = /NAVWEB"
 msgstr "Hol van az Ön web helye ? Alapértelmezett = /NAVWEB"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2016
+#: ../gramps/plugins/webreport/narrativeweb.py:2111
 msgid "Do we include the web calendar ?"
 msgstr "Betegyük a web-naptárt ?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2026
+#: ../gramps/plugins/webreport/narrativeweb.py:2121
 msgid "Where do you place your web site ? default = /WEBCAL"
 msgstr "Hol van az Ön web-helye ? Alapértelmezett = /WEBCAL"
 
-#: ../gramps/plugins/webreport/person.py:135
+#: ../gramps/plugins/webreport/person.py:140
 msgid "Creating individual pages"
 msgstr "Egyéni oldalak elkészítése"
 
 #. Individual List page message
-#: ../gramps/plugins/webreport/person.py:182
+#: ../gramps/plugins/webreport/person.py:188
 msgid ""
 "This page contains an index of all the individuals in the database, sorted "
 "by their last names. Selecting the person&#8217;s name will take you to that "
@@ -36463,29 +37581,29 @@ msgstr ""
 "családnevük szerint. Kiválasztva egy nevet a személy saját oldalára jutunk."
 
 #. Name Column
-#: ../gramps/plugins/webreport/person.py:209
-#: ../gramps/plugins/webreport/surname.py:126
+#: ../gramps/plugins/webreport/person.py:215
+#: ../gramps/plugins/webreport/surname.py:137
 msgid "Given Name"
 msgstr "Utónév"
 
-#: ../gramps/plugins/webreport/person.py:243
-#: ../gramps/plugins/webreport/surname.py:93
-#: ../gramps/plugins/webreport/surnamelist.py:190
+#: ../gramps/plugins/webreport/person.py:251
+#: ../gramps/plugins/webreport/surname.py:94
+#: ../gramps/plugins/webreport/surnamelist.py:192
 msgid "<absent>"
 msgstr "<hiányzó>"
 
-#: ../gramps/plugins/webreport/person.py:264
+#: ../gramps/plugins/webreport/person.py:281
 #, python-format
 msgid "Surnames %(surname)s beginning with letter %(letter)s"
 msgstr "%(letter)s betűvel kezdődő %(surname)s vezetéknevek"
 
-#: ../gramps/plugins/webreport/person.py:772
+#: ../gramps/plugins/webreport/person.py:792
 #, python-format
 msgid "Tracking %s"
 msgstr "%s követése"
 
 #. page description
-#: ../gramps/plugins/webreport/person.py:777
+#: ../gramps/plugins/webreport/person.py:797
 msgid ""
 "This map page represents that person and any descendants with all of their "
 "event/ places. If you place your mouse over the marker it will display the "
@@ -36499,56 +37617,56 @@ msgstr ""
 "(ha van bármilyen). A Hivatkozás részben a helyszín nevére kattintva a "
 "helyszín oldalára kerülünk."
 
-#: ../gramps/plugins/webreport/person.py:848
+#: ../gramps/plugins/webreport/person.py:868
 msgid "Drop Markers"
 msgstr "Jelölések dobása"
 
-#: ../gramps/plugins/webreport/person.py:873
+#: ../gramps/plugins/webreport/person.py:893
 msgid "Place Title"
 msgstr "Helycím"
 
-#: ../gramps/plugins/webreport/person.py:1366
+#: ../gramps/plugins/webreport/person.py:1440
 msgid "Call Name"
 msgstr "Hívónév"
 
-#: ../gramps/plugins/webreport/person.py:1384
+#: ../gramps/plugins/webreport/person.py:1458
 msgid "Nick Name"
 msgstr "Becenév"
 
-#: ../gramps/plugins/webreport/person.py:1430
+#: ../gramps/plugins/webreport/person.py:1504
 msgid "Age at Death"
 msgstr "Kora a halálakor"
 
-#: ../gramps/plugins/webreport/person.py:1561
+#: ../gramps/plugins/webreport/person.py:1634
 msgid "Stepfather"
 msgstr "Mostohaapa"
 
-#: ../gramps/plugins/webreport/person.py:1574
+#: ../gramps/plugins/webreport/person.py:1647
 msgid "Stepmother"
 msgstr "Mostohaanya"
 
-#: ../gramps/plugins/webreport/person.py:1602
+#: ../gramps/plugins/webreport/person.py:1675
 msgid "Not siblings"
 msgstr "Nem testvérek"
 
-#: ../gramps/plugins/webreport/person.py:1737
+#: ../gramps/plugins/webreport/person.py:1817
 msgid "Relation to the center person"
 msgstr "Kapcsolat a kiinduló személlyel"
 
-#: ../gramps/plugins/webreport/person.py:1774
+#: ../gramps/plugins/webreport/person.py:1854
 msgid "Relation to main person"
 msgstr "Kapcsolat a kiinduló személyhez"
 
-#: ../gramps/plugins/webreport/person.py:1778
+#: ../gramps/plugins/webreport/person.py:1858
 msgid "Relation within this family (if not by birth)"
 msgstr "Kapcsolat a családon belül (ha az nem születési)"
 
-#: ../gramps/plugins/webreport/place.py:113
+#: ../gramps/plugins/webreport/place.py:116
 msgid "Creating place pages"
 msgstr "Helyoldalak létrehozása"
 
 #. place list page message
-#: ../gramps/plugins/webreport/place.py:147
+#: ../gramps/plugins/webreport/place.py:151
 msgid ""
 "This page contains an index of all the places in the database, sorted by "
 "their title. Clicking on a place&#8217;s title will take you to that "
@@ -36558,17 +37676,18 @@ msgstr ""
 "címük/titulusuk szerint. Kiválasztva egy nevet a személy saját oldalára "
 "jutunk."
 
-#: ../gramps/plugins/webreport/place.py:176
+#: ../gramps/plugins/webreport/place.py:181
+#: ../gramps/plugins/webreport/place.py:193
 msgid "Place Name | Name"
 msgstr "Helyszín név"
 
-#: ../gramps/plugins/webreport/place.py:224
+#: ../gramps/plugins/webreport/place.py:239
 #, python-format
 msgid "Places beginning with letter %s"
 msgstr "%s betűvel kezdődő helyek"
 
 #. section title
-#: ../gramps/plugins/webreport/place.py:392
+#: ../gramps/plugins/webreport/place.py:408
 msgid "Place Map"
 msgstr "Helytérkép"
 
@@ -36577,7 +37696,7 @@ msgstr "Helytérkép"
 msgid "Creating repository pages"
 msgstr "Tárolóoldalak létrehozása"
 
-#: ../gramps/plugins/webreport/repository.py:146
+#: ../gramps/plugins/webreport/repository.py:147
 msgid ""
 "This page contains an index of all the repositories in the database, sorted "
 "by their title. Clicking on a repositories&#8217;s title will take you to "
@@ -36586,7 +37705,7 @@ msgstr ""
 "Ez az oldal az adatbázisban található összes tároló listáját tartalmazza "
 "címük szerint. Kiválasztva egy tároló címét a tároló oldalára jutunk."
 
-#: ../gramps/plugins/webreport/repository.py:164
+#: ../gramps/plugins/webreport/repository.py:165
 msgid "Repository |Name"
 msgstr "Név"
 
@@ -36594,7 +37713,7 @@ msgstr "Név"
 msgid "Creating source pages"
 msgstr "Forrásoldalak létrehozása"
 
-#: ../gramps/plugins/webreport/source.py:146
+#: ../gramps/plugins/webreport/source.py:147
 msgid ""
 "This page contains an index of all the sources in the database, sorted by "
 "their title. Clicking on a source&#8217;s title will take you to that "
@@ -36604,24 +37723,24 @@ msgstr ""
 "címük szerint listázva. Kiválasztva egy forrás címét a forrás oldalára "
 "jutunk."
 
-#: ../gramps/plugins/webreport/source.py:165
+#: ../gramps/plugins/webreport/source.py:166
 msgid "Source Name|Name"
 msgstr "Forrásnév"
 
-#: ../gramps/plugins/webreport/source.py:263
+#: ../gramps/plugins/webreport/source.py:265
 msgid "Publication information"
 msgstr "Kiadvány információ"
 
-#: ../gramps/plugins/webreport/statistics.py:113
+#: ../gramps/plugins/webreport/statistics.py:114
 msgid "Database overview"
 msgstr "Adatbázis áttekintés"
 
-#: ../gramps/plugins/webreport/statistics.py:178
+#: ../gramps/plugins/webreport/statistics.py:179
 msgid "Narrative web content report for"
 msgstr "Leíró web-tartalom összesítő"
 
 #. feature request 2356: avoid genitive form
-#: ../gramps/plugins/webreport/surname.py:109
+#: ../gramps/plugins/webreport/surname.py:120
 #, python-format
 msgid ""
 "This page contains an index of all the individuals in the database with the "
@@ -36636,7 +37755,7 @@ msgid "Surnames by person count"
 msgstr "Vezetéknevek személyek száma szerint"
 
 #. page message
-#: ../gramps/plugins/webreport/surnamelist.py:108
+#: ../gramps/plugins/webreport/surnamelist.py:109
 msgid ""
 "This page contains an index of all the surnames in the database. Selecting a "
 "link will lead to a list of individuals in the database with this same "
@@ -36646,16 +37765,16 @@ msgstr ""
 "Egy hivatkozást kiválasztva az adatbázis azonos családnevű személyek "
 "listájához  jutunk."
 
-#: ../gramps/plugins/webreport/surnamelist.py:154
+#: ../gramps/plugins/webreport/surnamelist.py:155
 msgid "Number of People"
 msgstr "Emberek száma"
 
-#: ../gramps/plugins/webreport/surnamelist.py:203
+#: ../gramps/plugins/webreport/surnamelist.py:205
 #, python-format
 msgid "Surnames beginning with letter %s"
 msgstr "%s betűvel kezdődő vezetéknevek"
 
-#: ../gramps/plugins/webreport/thumbnail.py:116
+#: ../gramps/plugins/webreport/thumbnail.py:118
 msgid ""
 "This page displays a indexed list of all the media objects in this "
 "database.  It is sorted by media title.  There is an index of all the media "
@@ -36666,27 +37785,23 @@ msgstr ""
 "tartalmazza címük szerint. Ez az adatbázisban levő média objektum egy "
 "indexe. A bélyegképre kattintva a kép oldalára jutunk."
 
-#: ../gramps/plugins/webreport/thumbnail.py:135
-msgid "Thumbnail Preview"
-msgstr "Bélyegkép előnézet"
-
 #. _('translation')
 #. Number of directory levels up to get to self.html_dir / root
 #. Number of directory levels up to get to root
 #. generate progress pass for "Year At A Glance"
-#: ../gramps/plugins/webreport/webcal.py:328
-#: ../gramps/plugins/webreport/webcal.py:967
-#: ../gramps/plugins/webreport/webcal.py:1053
-#: ../gramps/plugins/webreport/webcal.py:1274
+#: ../gramps/plugins/webreport/webcal.py:332
+#: ../gramps/plugins/webreport/webcal.py:975
+#: ../gramps/plugins/webreport/webcal.py:1061
+#: ../gramps/plugins/webreport/webcal.py:1284
 msgid "Web Calendar Report"
 msgstr "Web naptár összesítő"
 
-#: ../gramps/plugins/webreport/webcal.py:329
+#: ../gramps/plugins/webreport/webcal.py:333
 #, python-format
 msgid "Calculating Holidays for year %04d"
 msgstr "%04d év ünnepnapjainak meghatározása"
 
-#: ../gramps/plugins/webreport/webcal.py:486
+#: ../gramps/plugins/webreport/webcal.py:491
 #, python-format
 msgid ""
 "the \"WebCal\" will be the potential-email Subject|Created for "
@@ -36695,39 +37810,39 @@ msgstr ""
 "Létrehozva a %(html_email_author_start)sWebCal%(html_email_author_end)s "
 "számára"
 
-#: ../gramps/plugins/webreport/webcal.py:494
+#: ../gramps/plugins/webreport/webcal.py:497
 #, python-format
 msgid "Created for %(author)s"
 msgstr "Készült %(author)s számára"
 
 #. Add a link for year_glance() if requested
-#: ../gramps/plugins/webreport/webcal.py:576
+#: ../gramps/plugins/webreport/webcal.py:582
 msgid "Year Glance"
 msgstr "Év pillantás"
 
-#: ../gramps/plugins/webreport/webcal.py:615
+#: ../gramps/plugins/webreport/webcal.py:623
 msgid "NarrativeWeb Home"
 msgstr "Elbeszélő web kezdőoldal"
 
-#: ../gramps/plugins/webreport/webcal.py:617
+#: ../gramps/plugins/webreport/webcal.py:625
 msgid "Full year at a Glance"
 msgstr "Teljes év Pillantásra"
 
-#: ../gramps/plugins/webreport/webcal.py:968
+#: ../gramps/plugins/webreport/webcal.py:976
 msgid "Formatting months ..."
 msgstr "Hónapok formázása..."
 
-#: ../gramps/plugins/webreport/webcal.py:1054
+#: ../gramps/plugins/webreport/webcal.py:1062
 msgid "Creating Year At A Glance calendar"
 msgstr "EgyévPillantás naptár létrehozása"
 
 #. page title
-#: ../gramps/plugins/webreport/webcal.py:1059
+#: ../gramps/plugins/webreport/webcal.py:1068
 #, python-format
 msgid "%(year)d, At A Glance"
 msgstr "%(year)d, Pillantás"
 
-#: ../gramps/plugins/webreport/webcal.py:1074
+#: ../gramps/plugins/webreport/webcal.py:1083
 msgid ""
 "This calendar is meant to give you access to all your data at a glance "
 "compressed into one page. Clicking on a date will take you to a page that "
@@ -36738,227 +37853,259 @@ msgstr ""
 "oldalra juthat, ahol a dátum minden eseménye (ha van) látható.\n"
 
 #. page title
-#: ../gramps/plugins/webreport/webcal.py:1127
+#: ../gramps/plugins/webreport/webcal.py:1137
 msgid "One Day Within A Year"
 msgstr "Egy nap az éven belül"
 
-#: ../gramps/plugins/webreport/webcal.py:1431
+#: ../gramps/plugins/webreport/webcal.py:1473
 #, python-format
 msgid "%(spouse)s and %(person)s"
 msgstr "%(spouse)s és %(person)s"
 
-#. Display date as user set in preferences
-#: ../gramps/plugins/webreport/webcal.py:1451
+#: ../gramps/plugins/webreport/webcal.py:1496
 #, python-format
 msgid "Generated by %(gramps_home_html_start)sGramps%(html_end)s on %(date)s"
 msgstr "Készült a %(gramps_home_html_start)sGramps%(html_end)s-al %(date)s-n"
 
 #. page title
-#: ../gramps/plugins/webreport/webcal.py:1557
-#: ../gramps/plugins/webreport/webcal.py:1622
+#: ../gramps/plugins/webreport/webcal.py:1601
+#: ../gramps/plugins/webreport/webcal.py:1667
 msgid "My Family Calendar"
 msgstr "Családi naptáram"
 
-#: ../gramps/plugins/webreport/webcal.py:1622
+#: ../gramps/plugins/webreport/webcal.py:1667
 msgid "Calendar Title"
 msgstr "Naptárcím"
 
-#: ../gramps/plugins/webreport/webcal.py:1623
+#: ../gramps/plugins/webreport/webcal.py:1668
 msgid "The title of the calendar"
 msgstr "A naptár címe"
 
-#: ../gramps/plugins/webreport/webcal.py:1695
+#: ../gramps/plugins/webreport/webcal.py:1699
+msgid "StyleSheet"
+msgstr "Stíluslap"
+
+#: ../gramps/plugins/webreport/webcal.py:1740
 msgid "Content Options"
 msgstr "Tartalom opciók"
 
-#: ../gramps/plugins/webreport/webcal.py:1700
+#: ../gramps/plugins/webreport/webcal.py:1745
 msgid "Create multiple year calendars"
 msgstr "Többéves naptár létrehozása"
 
-#: ../gramps/plugins/webreport/webcal.py:1702
+#: ../gramps/plugins/webreport/webcal.py:1747
 msgid "Whether to create Multiple year calendars or not."
 msgstr "Legyen-e több évet tartalmazó naptár létrehozva, vagy sem."
 
-#: ../gramps/plugins/webreport/webcal.py:1707
+#: ../gramps/plugins/webreport/webcal.py:1752
 msgid "Start Year for the Calendar(s)"
 msgstr "A(z) (s) naptár kezdő éve"
 
-#: ../gramps/plugins/webreport/webcal.py:1709
+#: ../gramps/plugins/webreport/webcal.py:1754
 msgid "Enter the starting year for the calendars between 1900 - 3000"
 msgstr "Írja be 1900 - 3000 között a naptár kezdőévét"
 
-#: ../gramps/plugins/webreport/webcal.py:1713
+#: ../gramps/plugins/webreport/webcal.py:1758
 msgid "End Year for the Calendar(s)"
 msgstr "A(z) (s) naptár utolsó éve"
 
-#: ../gramps/plugins/webreport/webcal.py:1715
+#: ../gramps/plugins/webreport/webcal.py:1760
 msgid "Enter the ending year for the calendars between 1900 - 3000."
 msgstr "Írja be 1900 - 3000 között a naptár utolsó évét."
 
-#: ../gramps/plugins/webreport/webcal.py:1732
+#: ../gramps/plugins/webreport/webcal.py:1779
 msgid "Holidays will be included for the selected country"
 msgstr "Az ünnepnapok a kiválasztott országra fognak vonatkozni"
 
-#: ../gramps/plugins/webreport/webcal.py:1755
+#: ../gramps/plugins/webreport/webcal.py:1802
 msgid "Home link"
 msgstr "Kezdő hivatkozás"
 
-#: ../gramps/plugins/webreport/webcal.py:1756
+#: ../gramps/plugins/webreport/webcal.py:1803
 msgid ""
 "The link to be included to direct the user to the main page of the web site"
 msgstr "Hivatkozás, ami a felhasználót a web-oldal fő oldalára viszi"
 
-#: ../gramps/plugins/webreport/webcal.py:1761
-msgid "Include birthdays in the calendar"
-msgstr "Születésnapok a naptárban is"
-
-#: ../gramps/plugins/webreport/webcal.py:1765
-msgid "Include anniversaries in the calendar"
-msgstr "Évfordulók a naptárban is"
-
-#: ../gramps/plugins/webreport/webcal.py:1772
+#: ../gramps/plugins/webreport/webcal.py:1811
 msgid "Jan - Jun Notes"
 msgstr "Jan - Jún jegyzetek"
 
-#: ../gramps/plugins/webreport/webcal.py:1774
+#: ../gramps/plugins/webreport/webcal.py:1813
 msgid "January Note"
 msgstr "Januári jegyzet"
 
-#: ../gramps/plugins/webreport/webcal.py:1775
+#: ../gramps/plugins/webreport/webcal.py:1814
 msgid "The note for the month of January"
 msgstr "Januárra vonatkozó szöveg"
 
-#: ../gramps/plugins/webreport/webcal.py:1778
+#: ../gramps/plugins/webreport/webcal.py:1817
 msgid "February Note"
 msgstr "Februári jegyzet"
 
-#: ../gramps/plugins/webreport/webcal.py:1779
+#: ../gramps/plugins/webreport/webcal.py:1818
 msgid "The note for the month of February"
 msgstr "Februárra vonatkozó szöveg"
 
-#: ../gramps/plugins/webreport/webcal.py:1782
+#: ../gramps/plugins/webreport/webcal.py:1821
 msgid "March Note"
 msgstr "Márciusi jegyzet"
 
-#: ../gramps/plugins/webreport/webcal.py:1783
+#: ../gramps/plugins/webreport/webcal.py:1822
 msgid "The note for the month of March"
 msgstr "Márciusra vonatkozó szöveg"
 
-#: ../gramps/plugins/webreport/webcal.py:1786
+#: ../gramps/plugins/webreport/webcal.py:1825
 msgid "April Note"
 msgstr "Áprilisi jegyzet"
 
-#: ../gramps/plugins/webreport/webcal.py:1787
+#: ../gramps/plugins/webreport/webcal.py:1826
 msgid "The note for the month of April"
 msgstr "Áprilisra vonatkozó szöveg"
 
-#: ../gramps/plugins/webreport/webcal.py:1790
+#: ../gramps/plugins/webreport/webcal.py:1829
 msgid "May Note"
 msgstr "Májusi jegyzet"
 
-#: ../gramps/plugins/webreport/webcal.py:1791
+#: ../gramps/plugins/webreport/webcal.py:1830
 msgid "The note for the month of May"
 msgstr "Májusra vonatkozó szöveg"
 
-#: ../gramps/plugins/webreport/webcal.py:1794
+#: ../gramps/plugins/webreport/webcal.py:1833
 msgid "June Note"
 msgstr "Júniusi jegyzet"
 
-#: ../gramps/plugins/webreport/webcal.py:1795
+#: ../gramps/plugins/webreport/webcal.py:1834
 msgid "The note for the month of June"
 msgstr "Júniusra vonatkozó szöveg"
 
-#: ../gramps/plugins/webreport/webcal.py:1798
+#: ../gramps/plugins/webreport/webcal.py:1837
 msgid "Jul - Dec Notes"
 msgstr "Júl - Dec jegyzetek"
 
-#: ../gramps/plugins/webreport/webcal.py:1800
+#: ../gramps/plugins/webreport/webcal.py:1839
 msgid "July Note"
 msgstr "Júliusi jegyzet"
 
-#: ../gramps/plugins/webreport/webcal.py:1801
+#: ../gramps/plugins/webreport/webcal.py:1840
 msgid "The note for the month of July"
 msgstr "Júliusra vonatkozó szöveg"
 
-#: ../gramps/plugins/webreport/webcal.py:1804
+#: ../gramps/plugins/webreport/webcal.py:1843
 msgid "August Note"
 msgstr "Augusztusi jegyzet"
 
-#: ../gramps/plugins/webreport/webcal.py:1805
+#: ../gramps/plugins/webreport/webcal.py:1844
 msgid "The note for the month of August"
 msgstr "Augusztusra vonatkozó szöveg"
 
-#: ../gramps/plugins/webreport/webcal.py:1808
+#: ../gramps/plugins/webreport/webcal.py:1847
 msgid "September Note"
 msgstr "Szeptemberi jegyzet"
 
-#: ../gramps/plugins/webreport/webcal.py:1809
+#: ../gramps/plugins/webreport/webcal.py:1848
 msgid "The note for the month of September"
 msgstr "Szeptemberre vonatkozó szöveg"
 
-#: ../gramps/plugins/webreport/webcal.py:1812
+#: ../gramps/plugins/webreport/webcal.py:1851
 msgid "October Note"
 msgstr "Októberi jegyzet"
 
-#: ../gramps/plugins/webreport/webcal.py:1813
+#: ../gramps/plugins/webreport/webcal.py:1852
 msgid "The note for the month of October"
 msgstr "Októberre vonatkozó szöveg"
 
-#: ../gramps/plugins/webreport/webcal.py:1816
+#: ../gramps/plugins/webreport/webcal.py:1855
 msgid "November Note"
 msgstr "Novemberi jegyzet"
 
-#: ../gramps/plugins/webreport/webcal.py:1817
+#: ../gramps/plugins/webreport/webcal.py:1856
 msgid "The note for the month of November"
 msgstr "Novemberre vonatkozó szöveg"
 
-#: ../gramps/plugins/webreport/webcal.py:1820
+#: ../gramps/plugins/webreport/webcal.py:1859
 msgid "December Note"
 msgstr "Decemberi jegyzet"
 
-#: ../gramps/plugins/webreport/webcal.py:1821
+#: ../gramps/plugins/webreport/webcal.py:1860
 msgid "The note for the month of December"
 msgstr "Decemberre vonatkozó szöveg"
 
-#: ../gramps/plugins/webreport/webcal.py:1838
+#: ../gramps/plugins/webreport/webcal.py:1877
 msgid "Create one day event pages for Year At A Glance calendar"
 msgstr "Egy év - egy pillantás naptárhoz egynapos eseményoldal létrehozása"
 
-#: ../gramps/plugins/webreport/webcal.py:1840
+#: ../gramps/plugins/webreport/webcal.py:1879
 msgid "Whether to create one day pages or not"
 msgstr "Legyen-e egynapos oldal létrehozva, vagy sem"
 
-#: ../gramps/plugins/webreport/webcal.py:1843
+#: ../gramps/plugins/webreport/webcal.py:1883
+msgid "Include birthdays in the calendar"
+msgstr "Születésnapok a naptárban is"
+
+#: ../gramps/plugins/webreport/webcal.py:1887
+msgid "Include anniversaries in the calendar"
+msgstr "Évfordulók a naptárban is"
+
+#: ../gramps/plugins/webreport/webcal.py:1890
+msgid "Include death dates"
+msgstr "Halálozás dátumokkal együtt"
+
+#: ../gramps/plugins/webreport/webcal.py:1891
+msgid "Include death anniversaries in the calendar"
+msgstr "Halálozási évfordulók a naptárban is"
+
+#: ../gramps/plugins/webreport/webcal.py:1894
 msgid "Link to Narrated Web Report"
 msgstr "Leíró web-oldal összesítőre hivatkozás"
 
-#: ../gramps/plugins/webreport/webcal.py:1844
+#: ../gramps/plugins/webreport/webcal.py:1895
 msgid "Whether to link data to web report or not"
 msgstr "Legyen-e adathivatkozás a web összesítőre, vagy sem"
 
-#: ../gramps/plugins/webreport/webcal.py:1850
+#: ../gramps/plugins/webreport/webcal.py:1901
+msgid "Show data only after year"
+msgstr "Adat mutatása az év után"
+
+#: ../gramps/plugins/webreport/webcal.py:1904
+msgid ""
+"Show data only after this year. Default is current year -  'maximum age "
+"probably alive' which is defined in the dates preference tab."
+msgstr ""
+"Adat mutatása csak ezután az év után. Alapértelmezett a jelenlegi év - 'a "
+"valószínűleg élő legmagasabb kor' az adatok beállítása fülön meghatározott. "
+
+#: ../gramps/plugins/webreport/webcal.py:1912
 msgid "Link prefix"
 msgstr "Hivatkozás előtag"
 
-#: ../gramps/plugins/webreport/webcal.py:1851
+#: ../gramps/plugins/webreport/webcal.py:1913
 msgid "A Prefix on the links to take you to Narrated Web Report"
 msgstr "Egy hivatkozás előtag, ami Leíró web-oldal összesítőre visz"
 
-#: ../gramps/plugins/webreport/webcal.py:2029
+#: ../gramps/plugins/webreport/webcal.py:2092
 #, python-format
 msgid "%s old"
 msgstr "%s éves"
 
-#: ../gramps/plugins/webreport/webcal.py:2040
+#: ../gramps/plugins/webreport/webcal.py:2102
+#, python-format
+msgid "%s since death"
+msgstr "%s óta halott"
+
+#: ../gramps/plugins/webreport/webcal.py:2103
+msgid "death"
+msgstr "halál"
+
+#: ../gramps/plugins/webreport/webcal.py:2110
 #, python-format
 msgid "%(couple)s, <em>wedding</em>"
 msgstr "%(couple)s, <em>esküvő</em>"
 
-#: ../gramps/plugins/webreport/webcal.py:2048
+#: ../gramps/plugins/webreport/webcal.py:2118
 msgid "Until"
 msgstr "-ig"
 
-#: ../gramps/plugins/webreport/webcal.py:2057
+#: ../gramps/plugins/webreport/webcal.py:2127
 #, python-brace-format
 msgid "{couple}, {years} year anniversary"
 msgid_plural "{couple}, {years} year anniversary"
@@ -37029,190 +38176,307 @@ msgstr "Nebraska"
 msgid "No style sheet"
 msgstr "Nincs stíluslap"
 
-#: ../gramps/cli/argparser.py:53
-msgid ""
-"\n"
-"Usage: gramps.py [OPTION...]\n"
-"  --load-modules=MODULE1,MODULE2,...     Dynamic modules to load\n"
-"\n"
-"Help options\n"
-"  -?, --help                             Show this help message\n"
-"  --usage                                Display brief usage message\n"
-"\n"
-"Application options\n"
-"  -O, --open=FAMILY_TREE                 Open Family Tree\n"
-"  -C, --create=FAMILY_TREE               Create on open if new Family Tree\n"
-"  -i, --import=FILENAME                  Import file\n"
-"  -e, --export=FILENAME                  Export file\n"
-"  -r, --remove=FAMILY_TREE_PATTERN       Remove matching Family Tree(s) (use "
-"regular expressions)\n"
-"  -f, --format=FORMAT                    Specify Family Tree format\n"
-"  -a, --action=ACTION                    Specify action\n"
-"  -p, --options=OPTIONS_STRING           Specify options\n"
-"  -d, --debug=LOGGER_NAME                Enable debug logs\n"
-"  -l [FAMILY_TREE_PATTERN...]            List Family Trees\n"
-"  -L [FAMILY_TREE_PATTERN...]            List Family Trees in Detail\n"
-"  -t [FAMILY_TREE_PATTERN...]            List Family Trees, tab delimited\n"
-"  -u, --force-unlock                     Force unlock of Family Tree\n"
-"  -s, --show                             Show config settings\n"
-"  -c, --config=[config.setting[:value]]  Set config setting(s) and start "
-"Gramps\n"
-"  -y, --yes                              Don't ask to confirm dangerous "
-"actions (non-GUI mode only)\n"
-"  -q, --quiet                            Suppress progress indication output "
-"(non-GUI mode only)\n"
-"  -v, --version                          Show versions\n"
-msgstr ""
-"\n"
-"Használat: gramps.py [OPTION...]\n"
-"  --load-modules=MODULE1,MODULE2,...     A betöltendő dinamikus modulok\n"
-"\n"
-"Súgó opciók\n"
-"  -?, --help                             Ennek a Súgóüzeneteknek a mutatása\n"
-"  --usage                                Rövid használati üzenetek mutatása\n"
-"\n"
-"Alkalmazás opciók\n"
-"  -O, --open=FAMILY_TREE                 Családfa megnyitása\n"
-"  -C, --create=FAMILY_TREE               Ha új Családfa, annak létrehozása a "
-"megnyitotton\n"
-"  -i, --import=FILENAME                  Fájl importálása\n"
-"  -e, --export=FILENAME                  Fájl exportálása\n"
-"  -r, --remove=FAMILY_TREE_PATTERN       Az egyező Családfa(ák) eltávolítása "
-"(reguláris kifejezések használatával)\n"
-"  -f, --format=FORMAT                    Családfa formátum meghatározása\n"
-"  -a, --action=ACTION                    Tevékenység meghatározása\n"
-"  -p, --options=OPTIONS_STRING           Opciók meghatározása\n"
-"  -d, --debug=LOGGER_NAME                Hibakereső logok bekapcsolása\n"
-"  -l [FAMILY_TREE_PATTERN...]            Családfák listázása\n"
-"  -L [FAMILY_TREE_PATTERN...]            Családfák részletes listázása\n"
-"  -t [FAMILY_TREE_PATTERN...]            Családfák listázása tabulátor "
-"korlátozással\n"
-"  -u, --force-unlock                     Családfa kényszerített feloldása\n"
-"  -s, --show                             Beállítások mutatása\n"
-"  -c, --config=[config.setting[:value]]  Beállítás(ok) megadása és a GRAMPS "
-"indítása\n"
-"  .y, --yes                              Ne kérdezzen rá a veszélyes "
-"műveletekre (csak nem grafikus módban)\n"
-"  -q, --quiet                            A haladásjelző kimenet elrejtése "
-"(csak nem grafikus módban)\n"
-"  -v, --version                          Verziók mutatása\n"
+#~ msgid ""
+#~ "<b>Improving Gramps</b><br/>Users are encouraged to request enhancements "
+#~ "to Gramps. Requesting an enhancement can be done either through the "
+#~ "gramps-users or gramps-devel mailing lists, or by going to http://bugs."
+#~ "gramps-project.org and creating a Feature Request. Filing a Feature "
+#~ "Request is preferred but it can be good to discuss your ideas on the "
+#~ "email lists."
+#~ msgstr ""
+#~ "<b>A GRAMPS továbbfejlesztése</b><br/>A felhasználókat arra bátorítjuk, "
+#~ "hogy kérjenek fejlesztéseket a GRAMPS-hoz. Fejlesztés kérése lehetséges a "
+#~ "GRAMPS-felhasználók, vagy a GRAMPS-fejlesztők levelezési listáján, "
+#~ "esetleg a http://bugs.gramps-project.org címen egy Szolgáltatás Igénylése "
+#~ "létrehozásával. A Szolgáltatás igénylés kitöltése a leginkább javasolt, "
+#~ "de az ötlet megtárgyalására a levelező lista a jobb hely."
 
-#: ../gramps/gui/configure.py:565
-msgid "Gender Male Alive"
-msgstr "Élő férfi"
+#~ msgid ""
+#~ "<b>Reporting Bugs in Gramps</b><br/>The best way to report a bug in "
+#~ "Gramps is to use the Gramps bug tracking system at http://bugs.gramps-"
+#~ "project.org"
+#~ msgstr ""
+#~ "<b>GRAMPS hibák bejelentése</b><br/>A legjobb út a GRAMPS hibáinak "
+#~ "bejelentésére a GRAMPS hibakövető rendszer használata itt: http://bugs."
+#~ "gramps-project.org"
 
-#: ../gramps/gui/configure.py:571
-msgid "Border Male Death"
-msgstr "Halott férfi határa"
+#~ msgid "Male Alive"
+#~ msgstr "Élő férfi"
 
-#: ../gramps/gui/configure.py:573
-msgid "Gender Female Alive"
-msgstr "Élő nő"
+#~ msgid "Male Dead"
+#~ msgstr "Halott férfi"
 
-#: ../gramps/gui/configure.py:579
-msgid "Border Female Death"
-msgstr "Halott nő határa"
+#~ msgid "Female Alive"
+#~ msgstr "Élő nő"
 
-#: ../gramps/gui/configure.py:589
-msgid "Gender Unknown Alive"
-msgstr "Élő ismeretlen nemű"
+#~ msgid "Female Dead"
+#~ msgstr "Halott nő"
 
-#: ../gramps/gui/configure.py:595
-msgid "Border Unknown Death"
-msgstr "Ismeretlen halott határa"
+#~ msgid "Unknown Alive"
+#~ msgstr "Élő ismeretlen"
 
-#: ../gramps/gui/editors/editplace.py:199
-#: ../gramps/gui/editors/editplaceref.py:192
-msgid "Invalid latitude (syntax: 18\\u00b09'"
-msgstr "Érvénytelen szélességi fok (szintaktika: 18\\u00b09'"
+#~ msgid "Unknown Dead"
+#~ msgstr "Halott ismeretlen"
 
-#: ../gramps/gui/editors/editplace.py:202
-#: ../gramps/gui/editors/editplaceref.py:195
-msgid "Invalid longitude (syntax: 18\\u00b09'"
-msgstr "Érvénytelen hosszúsági fok (szintaktika: 18\\u00b09'"
+#~ msgid "Family Node"
+#~ msgstr "Család csomópont"
 
-#: ../gramps/gui/editors/editrepository.py:60
-msgid "manual|New_Repositories_dialog"
-msgstr "manual|Új_Tárolók_párbeszéd_ablak"
+#~ msgid "Family Divorced"
+#~ msgstr "Elvált családok"
 
-#: ../gramps/gui/editors/filtereditor.py:1186
-msgid ""
-"This filter is currently being used as the base for other filters. "
-"Deletingthis filter will result in removing all other filters that depend on "
-"it."
-msgstr ""
-"Ez a szűrő alapja más szűrőknek. A szűrő törlése minden más tőle függő "
-"szűrőt is eltávolít."
+#~ msgid "Home Person"
+#~ msgstr "Kiinduló személy"
 
-#: ../gramps/gui/glade/editcitation.glade:201
-msgid ""
-"Conveys the submitter's quantitative evaluation of the credibility of a "
-"piece of information, based upon its supporting evidence. It is not intended "
-"to eliminate the receiver's need to evaluate the evidence for themselves.\n"
-"Very Low =Unreliable evidence or estimated data\n"
-"Low =Questionable reliability of evidence (interviews, census, oral "
-"genealogies, or potential for bias for example, an autobiography)\n"
-"High =Secondary evidence, data officially recorded sometime after event\n"
-"Very High =Direct and primary evidence used, or by dominance of the evidence "
-msgstr ""
-"Az előterjesztő információdarabjának hitelességét mutatja a támogató "
-"bizonyíték alapján végzett minőségellenőrzést követően. Ez nem csökkenti a "
-"befogadó kötelességét magának a bizonyítéknak az ellenőrzésében.\n"
-"Nagyon alacsony =Megbízhatatlan bizonyíték, vagy feltételezett adat\n"
-"Alacsony =A bizonyíték (riport, népszámlálás, szóbeli származástan, vagy "
-"potenciálisan elfogult, például egy önéletrajz) kérdéses megbízhatóságú\n"
-"Magas =Másodlagos bizonyíték, az adatokat hivatalosan néha az esemény után "
-"rögzítették\n"
-"Nagyon magas =Közvetlen és elsődleges bizonyíték ismert, vagy a bizonyíték "
-"túlsúlya alapján "
+#~ msgid "Border Female Alive"
+#~ msgstr "Élő nő kerete"
 
-#: ../gramps/gui/glade/editplace.glade:105
-#: ../gramps/gui/glade/editplaceref.glade:228
-msgid ""
-"Either use the two fields below to enter coordinates(latitude and longitude),"
-msgstr ""
-"A lenti két mezőt használja koordináták (szélesség és hosszúság) bevitelére,"
+#~ msgid "Border Female Dead"
+#~ msgstr "Halott nő kerete"
 
-#: ../gramps/plugins/db/bsddb/write.py:2303
-msgid "Database db version"
-msgstr "Adatbázis db verzió"
+#~ msgid "Border Unknown Alive"
+#~ msgstr "Élő ismeretlen kerete"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:5367
-#, python-format
-msgid ""
-"%(strong1_start)s%(page_number)d%(strong_end)s of %(strong2_start)s"
-"%(total_pages)d%(strong_end)s"
-msgstr ""
-"%(strong1_start)s%(page_number)d%(strong_end)s a(z) %(strong2_start)s"
-"%(total_pages)d%(strong_end)s-bó(ő)l"
+#~ msgid "Border Unknown Dead"
+#~ msgstr "Ismeretlen halott kerete"
 
-#: ../data/tips.xml.in.h:29
-msgid ""
-"<b>Improving Gramps</b><br/>Users are encouraged to request enhancements to "
-"Gramps. Requesting an enhancement can be done either through the gramps-"
-"users or gramps-devel mailing lists, or by going to https://gramps-project."
-"org/bugs/ and creating a Feature Request. Filing a Feature Request is "
-"preferred but it can be good to discuss your ideas on the email lists."
-msgstr ""
-"<b>A GRAMPS továbbfejlesztése</b><br/>A felhasználókat arra bátorítjuk, hogy "
-"kérjenek fejlesztéseket a GRAMPS-hoz. Fejlesztés kérése lehetséges a GRAMPS-"
-"felhasználók, vagy a GRAMPS-fejlesztők levelezési listáján, esetleg a "
-"https://gramps-project.org/bugs/ címen egy Szolgáltatás Igénylése "
-"létrehozásával. A Szolgáltatás igénylés kitöltése a leginkább javasolt, de "
-"előtte célszerű az ötlet megtárgyalása a levelező listán."
+#~ msgid "Border Family"
+#~ msgstr "Család kerete"
 
-#: ../data/tips.xml.in.h:46
-msgid ""
-"<b>Reporting Bugs in Gramps</b><br/>The best way to report a bug in Gramps "
-"is to use the Gramps bug tracking system at https://gramps-project.org/bugs"
-msgstr ""
-"<b>GRAMPS hibák bejelentése</b><br/>A legjobb út a GRAMPS hibáinak "
-"bejelentésére a GRAMPS hibakövető rendszer használata itt: https://gramps-"
-"project.org/bugs"
+#~ msgid "Web Connect"
+#~ msgstr "Web kapcsolat"
 
-#: ../gramps/plugins/tool/mediamanager.py:68
-msgid "manual|Media_Manager"
-msgstr "_Médiakezelő"
+#~ msgid "manual|Repositories"
+#~ msgstr "manual|Tárolók"
+
+#~ msgid "Open an existing database"
+#~ msgstr "Jelenlegi adatbázis megnyitása"
+
+#~ msgid "Close the current database"
+#~ msgstr "Zárja be a jelenlegi adatbázist"
+
+#~ msgid "Make a Gramps XML backup of the database"
+#~ msgstr "GRAMPS XML adatbázis biztonsági mentés készítése"
+
+#~ msgid "Undo History..."
+#~ msgstr "Történet visszavonása..."
+
+#~ msgid "Key %s is not bound"
+#~ msgstr "%s kulcs nem kötött"
+
+#~ msgid "_Delete Item"
+#~ msgstr "Elem _törlése"
+
+#~ msgid "%(title)s..."
+#~ msgstr "%(title)s..."
+
+#~ msgid "%(genders)s born %(year_from)04d-%(year_to)04d"
+#~ msgstr "%(year_from)04d-%(year_to)04d született %(genders)s"
+
+#~ msgid "Persons born %(year_from)04d-%(year_to)04d"
+#~ msgstr "%(year_from)04d-%(year_to)04d született személyek"
+
+#~ msgid "Marriage of %s"
+#~ msgstr "%s házassága"
+
+#~ msgid "Birth of %s"
+#~ msgstr "%s születése"
+
+#~ msgid "Death of %s"
+#~ msgstr "%s halála"
+
+#~ msgid "Anniversary: %s"
+#~ msgstr "évforduló: %s"
+
+#~ msgid "%d. Partner: "
+#~ msgstr "%d. Társ: "
+
+#~ msgid "Not a Pro-Gen file"
+#~ msgstr "Nem Pro-Gen fájl"
+
+#~ msgid "Loading..."
+#~ msgstr "Betöltés..."
+
+#~ msgid ""
+#~ "Attempt to see this location with a Map Service (OpenstreetMap, Google "
+#~ "Maps, ...)"
+#~ msgstr ""
+#~ "A helyszín megtekintése Térképszolgáltatással (OpenstreetMap, Google "
+#~ "Maps, ...)"
+
+#~ msgid "Map Menu"
+#~ msgstr "Térkép menü"
+
+#~ msgid "manual|Media_Manager..."
+#~ msgstr "_Médiakezelő..."
+
+#~ msgid ""
+#~ "Geography functionality will not be available.\n"
+#~ "To build it for Gramps see %(gramps_wiki_build_osmgps_url)s"
+#~ msgstr ""
+#~ "A térképészeti funkció nem lesz elérhető.\n"
+#~ "A GRAMPS-hoz felépítéshez lásd: %(gramps_wiki_build_osmgps_url)s"
+
+#~ msgid "Open the folder containing the media file"
+#~ msgstr "Médiafájlt tartalmazó mappa megnyitása"
+
+#~ msgid " (%s) "
+#~ msgstr " (%s) "
+
+#~ msgid "Suppress Gramps ID"
+#~ msgstr "GRAMPS-azonosító tiltása"
+
+#~ msgid "Whether to include the Gramps ID of objects"
+#~ msgstr "Legyen-e az objektum GRAMPS-azonosítóval"
+
+#~ msgid "Thumbnail Preview"
+#~ msgstr "Bélyegkép előnézet"
+
+#~ msgid ""
+#~ "\n"
+#~ "Usage: gramps.py [OPTION...]\n"
+#~ "  --load-modules=MODULE1,MODULE2,...     Dynamic modules to load\n"
+#~ "\n"
+#~ "Help options\n"
+#~ "  -?, --help                             Show this help message\n"
+#~ "  --usage                                Display brief usage message\n"
+#~ "\n"
+#~ "Application options\n"
+#~ "  -O, --open=FAMILY_TREE                 Open Family Tree\n"
+#~ "  -C, --create=FAMILY_TREE               Create on open if new Family "
+#~ "Tree\n"
+#~ "  -i, --import=FILENAME                  Import file\n"
+#~ "  -e, --export=FILENAME                  Export file\n"
+#~ "  -r, --remove=FAMILY_TREE_PATTERN       Remove matching Family Tree(s) "
+#~ "(use regular expressions)\n"
+#~ "  -f, --format=FORMAT                    Specify Family Tree format\n"
+#~ "  -a, --action=ACTION                    Specify action\n"
+#~ "  -p, --options=OPTIONS_STRING           Specify options\n"
+#~ "  -d, --debug=LOGGER_NAME                Enable debug logs\n"
+#~ "  -l [FAMILY_TREE_PATTERN...]            List Family Trees\n"
+#~ "  -L [FAMILY_TREE_PATTERN...]            List Family Trees in Detail\n"
+#~ "  -t [FAMILY_TREE_PATTERN...]            List Family Trees, tab "
+#~ "delimited\n"
+#~ "  -u, --force-unlock                     Force unlock of Family Tree\n"
+#~ "  -s, --show                             Show config settings\n"
+#~ "  -c, --config=[config.setting[:value]]  Set config setting(s) and start "
+#~ "Gramps\n"
+#~ "  -y, --yes                              Don't ask to confirm dangerous "
+#~ "actions (non-GUI mode only)\n"
+#~ "  -q, --quiet                            Suppress progress indication "
+#~ "output (non-GUI mode only)\n"
+#~ "  -v, --version                          Show versions\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Használat: gramps.py [OPTION...]\n"
+#~ "  --load-modules=MODULE1,MODULE2,...     A betöltendő dinamikus modulok\n"
+#~ "\n"
+#~ "Súgó opciók\n"
+#~ "  -?, --help                             Ennek a Súgóüzeneteknek a "
+#~ "mutatása\n"
+#~ "  --usage                                Rövid használati üzenetek "
+#~ "mutatása\n"
+#~ "\n"
+#~ "Alkalmazás opciók\n"
+#~ "  -O, --open=FAMILY_TREE                 Családfa megnyitása\n"
+#~ "  -C, --create=FAMILY_TREE               Ha új Családfa, annak "
+#~ "létrehozása a megnyitotton\n"
+#~ "  -i, --import=FILENAME                  Fájl importálása\n"
+#~ "  -e, --export=FILENAME                  Fájl exportálása\n"
+#~ "  -r, --remove=FAMILY_TREE_PATTERN       Az egyező Családfa(ák) "
+#~ "eltávolítása (reguláris kifejezések használatával)\n"
+#~ "  -f, --format=FORMAT                    Családfa formátum meghatározása\n"
+#~ "  -a, --action=ACTION                    Tevékenység meghatározása\n"
+#~ "  -p, --options=OPTIONS_STRING           Opciók meghatározása\n"
+#~ "  -d, --debug=LOGGER_NAME                Hibakereső logok bekapcsolása\n"
+#~ "  -l [FAMILY_TREE_PATTERN...]            Családfák listázása\n"
+#~ "  -L [FAMILY_TREE_PATTERN...]            Családfák részletes listázása\n"
+#~ "  -t [FAMILY_TREE_PATTERN...]            Családfák listázása tabulátor "
+#~ "korlátozással\n"
+#~ "  -u, --force-unlock                     Családfa kényszerített "
+#~ "feloldása\n"
+#~ "  -s, --show                             Beállítások mutatása\n"
+#~ "  -c, --config=[config.setting[:value]]  Beállítás(ok) megadása és a "
+#~ "GRAMPS indítása\n"
+#~ "  .y, --yes                              Ne kérdezzen rá a veszélyes "
+#~ "műveletekre (csak nem grafikus módban)\n"
+#~ "  -q, --quiet                            A haladásjelző kimenet elrejtése "
+#~ "(csak nem grafikus módban)\n"
+#~ "  -v, --version                          Verziók mutatása\n"
+
+#~ msgid "Gender Male Alive"
+#~ msgstr "Élő férfi"
+
+#~ msgid "Border Male Death"
+#~ msgstr "Halott férfi határa"
+
+#~ msgid "Gender Female Alive"
+#~ msgstr "Élő nő"
+
+#~ msgid "Border Female Death"
+#~ msgstr "Halott nő határa"
+
+#~ msgid "Gender Unknown Alive"
+#~ msgstr "Élő ismeretlen nemű"
+
+#~ msgid "Border Unknown Death"
+#~ msgstr "Ismeretlen halott határa"
+
+#~ msgid "Invalid latitude (syntax: 18\\u00b09'"
+#~ msgstr "Érvénytelen szélességi fok (szintaktika: 18\\u00b09'"
+
+#~ msgid "Invalid longitude (syntax: 18\\u00b09'"
+#~ msgstr "Érvénytelen hosszúsági fok (szintaktika: 18\\u00b09'"
+
+#~ msgid "manual|New_Repositories_dialog"
+#~ msgstr "manual|Új_Tárolók_párbeszéd_ablak"
+
+#~ msgid ""
+#~ "This filter is currently being used as the base for other filters. "
+#~ "Deletingthis filter will result in removing all other filters that depend "
+#~ "on it."
+#~ msgstr ""
+#~ "Ez a szűrő alapja más szűrőknek. A szűrő törlése minden más tőle függő "
+#~ "szűrőt is eltávolít."
+
+#~ msgid ""
+#~ "Conveys the submitter's quantitative evaluation of the credibility of a "
+#~ "piece of information, based upon its supporting evidence. It is not "
+#~ "intended to eliminate the receiver's need to evaluate the evidence for "
+#~ "themselves.\n"
+#~ "Very Low =Unreliable evidence or estimated data\n"
+#~ "Low =Questionable reliability of evidence (interviews, census, oral "
+#~ "genealogies, or potential for bias for example, an autobiography)\n"
+#~ "High =Secondary evidence, data officially recorded sometime after event\n"
+#~ "Very High =Direct and primary evidence used, or by dominance of the "
+#~ "evidence "
+#~ msgstr ""
+#~ "Az előterjesztő információdarabjának hitelességét mutatja a támogató "
+#~ "bizonyíték alapján végzett minőségellenőrzést követően. Ez nem csökkenti "
+#~ "a befogadó kötelességét magának a bizonyítéknak az ellenőrzésében.\n"
+#~ "Nagyon alacsony =Megbízhatatlan bizonyíték, vagy feltételezett adat\n"
+#~ "Alacsony =A bizonyíték (riport, népszámlálás, szóbeli származástan, vagy "
+#~ "potenciálisan elfogult, például egy önéletrajz) kérdéses megbízhatóságú\n"
+#~ "Magas =Másodlagos bizonyíték, az adatokat hivatalosan néha az esemény "
+#~ "után rögzítették\n"
+#~ "Nagyon magas =Közvetlen és elsődleges bizonyíték ismert, vagy a "
+#~ "bizonyíték túlsúlya alapján "
+
+#~ msgid ""
+#~ "Either use the two fields below to enter coordinates(latitude and "
+#~ "longitude),"
+#~ msgstr ""
+#~ "A lenti két mezőt használja koordináták (szélesség és hosszúság) "
+#~ "bevitelére,"
+
+#~ msgid "Database db version"
+#~ msgstr "Adatbázis db verzió"
+
+#~ msgid ""
+#~ "%(strong1_start)s%(page_number)d%(strong_end)s of %(strong2_start)s"
+#~ "%(total_pages)d%(strong_end)s"
+#~ msgstr ""
+#~ "%(strong1_start)s%(page_number)d%(strong_end)s a(z) %(strong2_start)s"
+#~ "%(total_pages)d%(strong_end)s-bó(ő)l"
 
 #~ msgid "Gender Male Death"
 #~ msgstr "Halott férfi"
@@ -37225,9 +38489,6 @@ msgstr "_Médiakezelő"
 
 #~ msgid "Suppress comma after house number"
 #~ msgstr "A házszám utáni vessző letitása"
-
-#~ msgid "Full place name"
-#~ msgstr "Teljes helynév"
 
 #~ msgid "-> Hamlet/Village/Town/City"
 #~ msgstr "-> Falucska/Község/Város/Nagyváros"
@@ -37452,20 +38713,8 @@ msgstr "_Médiakezelő"
 #~ msgid "Families:"
 #~ msgstr "Családok:"
 
-#~ msgid "Import from Pro-Gen"
-#~ msgstr "Pro-Genből importálás"
-
-#~ msgid "Initializing"
-#~ msgstr "Kezdőérték adás"
-
 #~ msgid "Importing individuals"
 #~ msgstr "Egyének importálása"
-
-#~ msgid "Importing families"
-#~ msgstr "Családok importálása"
-
-#~ msgid "Adding children"
-#~ msgstr "Gyermekek hozzáadása"
 
 #~ msgid "Select the first day of the week for the report"
 #~ msgstr "A hét első napjának kiválasztása a jelentéshez"
@@ -37636,12 +38885,6 @@ msgstr "_Médiakezelő"
 #~ msgid "Death place id"
 #~ msgstr "Halálozási helyének azonosítója"
 
-#~ msgid "Death cause"
-#~ msgstr "Halál ok"
-
-#~ msgid "Gramps id"
-#~ msgstr "GRAMPS azonosító"
-
 #~ msgid "Parent2"
 #~ msgstr "Szülő2"
 
@@ -37743,18 +38986,6 @@ msgstr "_Médiakezelő"
 
 #~ msgid "Dictionary (in-memory) Database Backend"
 #~ msgstr "Szótár Adatbázis (memórián belüli) Háttér"
-
-#~ msgid "Incomplete names"
-#~ msgstr "Hiányos nevek"
-
-#~ msgid "Individuals missing birth dates"
-#~ msgstr "Személyek hiányzó születési dátummal"
-
-#~ msgid "Disconnected individuals"
-#~ msgstr "Nem kapcsolt személyek"
-
-#~ msgid "Individuals with media objects"
-#~ msgstr "Személyek média objektumokkal"
 
 #~ msgid "Marriages/Children"
 #~ msgstr "Házasságok/Gyermekek"
@@ -37994,9 +39225,6 @@ msgstr "_Médiakezelő"
 
 #~ msgid "Add Parents"
 #~ msgstr "Szülők hozzáadása"
-
-#~ msgid "Add Spouse"
-#~ msgstr "Házastárs hozzáadása"
 
 #~ msgid "Tools"
 #~ msgstr "Eszközök"
@@ -38780,9 +40008,6 @@ msgstr "_Médiakezelő"
 #~ msgid "<b>Women</b>"
 #~ msgstr "<b>Nők</b>"
 
-#~ msgid "<b>Men</b>"
-#~ msgstr "<b>Férfiak</b>"
-
 #~ msgid "<b>Families</b>"
 #~ msgstr "<b>Családok</b>"
 
@@ -39427,9 +40652,6 @@ msgstr "_Médiakezelő"
 
 #~ msgid " and "
 #~ msgstr " és "
-
-#~ msgid "Referenced Sources"
-#~ msgstr "Hivatkozott források"
 
 #~ msgid "Every object"
 #~ msgstr "Minden objektum"
@@ -40222,4 +41444,3 @@ msgstr "_Médiakezelő"
 
 #~ msgid "Family Sources"
 #~ msgstr "Család források"
-

--- a/po/ru.po
+++ b/po/ru.po
@@ -16,8 +16,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gramps50\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-05-15 13:30+0300\n"
-"PO-Revision-Date: 2019-05-16 16:18+0300\n"
+"POT-Creation-Date: 2019-06-21 10:20+0300\n"
+"PO-Revision-Date: 2019-06-21 10:53+0300\n"
 "Last-Translator: Ivan Komaritsyn <vantu5z@mail.ru>\n"
 "Language-Team: Russian\n"
 "Language: ru\n"
@@ -1099,7 +1099,7 @@ msgstr ""
 "работает с любой оконной системой. Если необходимые библиотеки GTK "
 "установлены, то программа будет работать."
 
-#: ../gramps/cli/arghandler.py:228
+#: ../gramps/cli/arghandler.py:229
 #, python-format
 msgid ""
 "Error: Family Tree '%s' already exists.\n"
@@ -1108,7 +1108,7 @@ msgstr ""
 "Ошибка: Древо «%s» уже существует.\n"
 "Параметр «-C» нельзя использовать."
 
-#: ../gramps/cli/arghandler.py:240
+#: ../gramps/cli/arghandler.py:241
 #, python-format
 msgid ""
 "Error: Input Family Tree \"%s\" does not exist.\n"
@@ -1120,18 +1120,18 @@ msgstr ""
 "используйте\n"
 "опцию -i для импорта в семейное древо."
 
-#: ../gramps/cli/arghandler.py:254
+#: ../gramps/cli/arghandler.py:255
 #, python-format
 msgid "Error: Import file %s not found."
 msgstr "Ошибка: Файл для импорта %s не найден."
 
-#: ../gramps/cli/arghandler.py:272
+#: ../gramps/cli/arghandler.py:273
 #, python-format
 msgid "Error: Unrecognized type: \"%(format)s\" for import file: %(filename)s"
 msgstr ""
 "Ошибка: Формат «%(format)s» не распознан для входного файла: %(filename)s"
 
-#: ../gramps/cli/arghandler.py:292
+#: ../gramps/cli/arghandler.py:293
 #, python-format
 msgid ""
 "WARNING: Output file already exists!\n"
@@ -1142,44 +1142,44 @@ msgstr ""
 "ВНИМАНИЕ: Он будет перезаписан:\n"
 "   %s"
 
-#: ../gramps/cli/arghandler.py:295
+#: ../gramps/cli/arghandler.py:296
 msgid "OK to overwrite?"
 msgstr "Перезаписать?"
 
-#: ../gramps/cli/arghandler.py:296 ../gramps/cli/clidbman.py:429
+#: ../gramps/cli/arghandler.py:297 ../gramps/cli/clidbman.py:429
 msgid "no"
 msgstr "нет"
 
-#: ../gramps/cli/arghandler.py:296 ../gramps/cli/arghandler.py:297
+#: ../gramps/cli/arghandler.py:297 ../gramps/cli/arghandler.py:298
 #: ../gramps/cli/clidbman.py:429
 msgid "yes"
 msgstr "да"
 
-#: ../gramps/cli/arghandler.py:299
+#: ../gramps/cli/arghandler.py:300
 #, python-format
 msgid "Will overwrite the existing file: %s"
 msgstr "Будет перезаписан существующий файл: %s"
 
-#: ../gramps/cli/arghandler.py:319
+#: ../gramps/cli/arghandler.py:320
 #, python-format
 msgid "ERROR: Unrecognized format for export file %s"
 msgstr "ОШИБКА: Неопознанный формат для файла экспорта %s"
 
-#: ../gramps/cli/arghandler.py:385 ../gramps/gen/plug/utils.py:316
+#: ../gramps/cli/arghandler.py:386 ../gramps/gen/plug/utils.py:316
 #, python-format
 msgid "Error: cannot open '%s'"
 msgstr "Ошибка: не удалось открыть '%s'"
 
-#: ../gramps/cli/arghandler.py:404
+#: ../gramps/cli/arghandler.py:405
 msgid "List of known Family Trees in your database path\n"
 msgstr "Список семейных древ по указанному пути к базе данных\n"
 
-#: ../gramps/cli/arghandler.py:412
+#: ../gramps/cli/arghandler.py:413
 #, python-format
 msgid "%(full_DB_path)s with name \"%(f_t_name)s\""
 msgstr "%(full_DB_path)s под именем \"%(f_t_name)s\""
 
-#: ../gramps/cli/arghandler.py:430 ../gramps/cli/clidbman.py:188
+#: ../gramps/cli/arghandler.py:431 ../gramps/cli/clidbman.py:188
 msgid "Gramps Family Trees:"
 msgstr "Семейные древа Gramps:"
 
@@ -1190,95 +1190,95 @@ msgstr "Семейные древа Gramps:"
 #. constants
 #.
 #. -------------------------------------------------------------------------
-#: ../gramps/cli/arghandler.py:436 ../gramps/cli/arghandler.py:438
-#: ../gramps/cli/arghandler.py:443 ../gramps/cli/arghandler.py:444
-#: ../gramps/cli/arghandler.py:446 ../gramps/cli/clidbman.py:69
+#: ../gramps/cli/arghandler.py:437 ../gramps/cli/arghandler.py:439
+#: ../gramps/cli/arghandler.py:444 ../gramps/cli/arghandler.py:445
+#: ../gramps/cli/arghandler.py:447 ../gramps/cli/clidbman.py:69
 #: ../gramps/cli/clidbman.py:169 ../gramps/cli/clidbman.py:197
 #: ../gramps/gui/clipboard.py:916 ../gramps/gui/configure.py:1798
 msgid "Family Tree"
 msgstr "Семейное древо"
 
 #. translators: used in French+Russian, ignore otherwise
-#: ../gramps/cli/arghandler.py:444 ../gramps/cli/arghandler.py:448
+#: ../gramps/cli/arghandler.py:445 ../gramps/cli/arghandler.py:449
 #: ../gramps/gen/plug/report/endnotes.py:199
 #, python-format
 msgid "\"%s\""
 msgstr "\"%s\""
 
-#: ../gramps/cli/arghandler.py:456
+#: ../gramps/cli/arghandler.py:457
 #, python-format
 msgid "Performing action: %s."
 msgstr "Выполняется действие: %s."
 
-#: ../gramps/cli/arghandler.py:460 ../gramps/gen/plug/report/stdoptions.py:285
+#: ../gramps/cli/arghandler.py:461 ../gramps/gen/plug/report/stdoptions.py:285
 #, python-format
 msgid "Using options string: %s"
 msgstr "Используется строка параметров: %s"
 
-#: ../gramps/cli/arghandler.py:466
+#: ../gramps/cli/arghandler.py:467
 #, python-format
 msgid "Exporting: file %(filename)s, format %(format)s."
 msgstr "Экспорт: файл %(filename)s, формат %(format)s."
 
-#: ../gramps/cli/arghandler.py:477
+#: ../gramps/cli/arghandler.py:478
 msgid "Cleaning up."
 msgstr "Проведение очистки."
 
-#: ../gramps/cli/arghandler.py:510
+#: ../gramps/cli/arghandler.py:514
 msgid "Created empty Family Tree successfully"
 msgstr "Успешно создано пустое семейное древо"
 
-#: ../gramps/cli/arghandler.py:513 ../gramps/cli/arghandler.py:539
+#: ../gramps/cli/arghandler.py:517 ../gramps/cli/arghandler.py:543
 msgid "Error opening the file."
 msgstr "Ошибка открытия файла."
 
-#: ../gramps/cli/arghandler.py:514 ../gramps/cli/arghandler.py:540
+#: ../gramps/cli/arghandler.py:518 ../gramps/cli/arghandler.py:544
 msgid "Exiting..."
 msgstr "Выход..."
 
-#: ../gramps/cli/arghandler.py:518
+#: ../gramps/cli/arghandler.py:522
 #, python-format
 msgid "Importing: file %(filename)s, format %(format)s."
 msgstr "Импорт: файл %(filename)s, формат %(format)s."
 
-#: ../gramps/cli/arghandler.py:537
+#: ../gramps/cli/arghandler.py:541
 msgid "Opened successfully!"
 msgstr "База данных успешно открыта!"
 
-#: ../gramps/cli/arghandler.py:551
+#: ../gramps/cli/arghandler.py:555
 msgid "Database is locked, cannot open it!"
 msgstr "База данных заблокирована, не удалось её открыть!"
 
-#: ../gramps/cli/arghandler.py:552
+#: ../gramps/cli/arghandler.py:556
 #, python-format
 msgid "  Info: %s"
 msgstr "  Информация: %s"
 
-#: ../gramps/cli/arghandler.py:555
+#: ../gramps/cli/arghandler.py:559
 msgid "Database needs recovery, cannot open it!"
 msgstr "База данных нуждается в восстановлении, не удалось её открыть!"
 
-#: ../gramps/cli/arghandler.py:558
+#: ../gramps/cli/arghandler.py:562
 msgid "Database backend unavailable, cannot open it!"
 msgstr "База данных недоступна, не удалось её открыть!"
 
-#: ../gramps/cli/arghandler.py:609 ../gramps/cli/arghandler.py:658
-#: ../gramps/cli/arghandler.py:705
+#: ../gramps/cli/arghandler.py:613 ../gramps/cli/arghandler.py:662
+#: ../gramps/cli/arghandler.py:709
 msgid "Ignoring invalid options string."
 msgstr "Игнорируется неверная строка параметров."
 
 #. name exists, but is not in the list of valid report names
-#: ../gramps/cli/arghandler.py:633
+#: ../gramps/cli/arghandler.py:637
 msgid "Unknown report name."
 msgstr "Неизвестное название отчёта."
 
-#: ../gramps/cli/arghandler.py:635
+#: ../gramps/cli/arghandler.py:639
 #, python-format
 msgid "Report name not given. Please use one of %(donottranslate)s=reportname"
 msgstr "Не задано имя отчёта. Пожалуйста, укажите %(donottranslate)s=ИмяОтчёта"
 
-#: ../gramps/cli/arghandler.py:639 ../gramps/cli/arghandler.py:687
-#: ../gramps/cli/arghandler.py:721
+#: ../gramps/cli/arghandler.py:643 ../gramps/cli/arghandler.py:691
+#: ../gramps/cli/arghandler.py:725
 #, python-format
 msgid ""
 "%s\n"
@@ -1287,29 +1287,29 @@ msgstr ""
 "%s\n"
 " Доступные отчёты:"
 
-#: ../gramps/cli/arghandler.py:681
+#: ../gramps/cli/arghandler.py:685
 msgid "Unknown tool name."
 msgstr "Неизвестное название инструмента."
 
-#: ../gramps/cli/arghandler.py:683
+#: ../gramps/cli/arghandler.py:687
 #, python-format
 msgid "Tool name not given. Please use one of %(donottranslate)s=toolname."
 msgstr ""
 "Не задано имя инструмента. Пожалуйста, укажите "
 "%(donottranslate)s=ИмяИнструмента."
 
-#: ../gramps/cli/arghandler.py:715
+#: ../gramps/cli/arghandler.py:719
 msgid "Unknown book name."
 msgstr "Неизвестное название книги."
 
-#: ../gramps/cli/arghandler.py:717
+#: ../gramps/cli/arghandler.py:721
 #, python-format
 msgid "Book name not given. Please use one of %(donottranslate)s=bookname."
 msgstr ""
 "Не задано название книги. Пожалуйста, укажите одно из "
 "%(donottranslate)s=bookname."
 
-#: ../gramps/cli/arghandler.py:726
+#: ../gramps/cli/arghandler.py:730
 #, python-format
 msgid "Unknown action: %s."
 msgstr "Неизвестное действие: %s."
@@ -1401,7 +1401,8 @@ msgstr ""
 "прогресса\n"
 "                                         (только в режиме командной строки)\n"
 "  -v, --version                          Показать версию\n"
-"  -S, --safe                             Запускает Gramps в 'безопасном режиме'\n"
+"  -S, --safe                             Запускает Gramps в 'безопасном "
+"режиме'\n"
 "                                          (временно используются настройки "
 "по умолчанию)\n"
 "  -D, --default=[APXFE]                  Сброс настроек по умолчанию;\n"
@@ -1771,7 +1772,7 @@ msgstr "Заблокировано %s"
 #: ../gramps/plugins/gramplet/relativegramplet.py:137
 #: ../gramps/plugins/graph/gvfamilylines.py:287
 #: ../gramps/plugins/graph/gvhourglass.py:427
-#: ../gramps/plugins/graph/gvrelgraph.py:940
+#: ../gramps/plugins/graph/gvrelgraph.py:948
 #: ../gramps/plugins/lib/libprogen.py:1057
 #: ../gramps/plugins/lib/maps/geography.py:802
 #: ../gramps/plugins/lib/maps/geography.py:812
@@ -1812,7 +1813,7 @@ msgstr "Заблокировано %s"
 #: ../gramps/plugins/view/geofamily.py:517
 #: ../gramps/plugins/view/geomoves.py:662
 #: ../gramps/plugins/view/geoperson.py:543
-#: ../gramps/plugins/view/geoplaces.py:590
+#: ../gramps/plugins/view/geoplaces.py:592
 #: ../gramps/plugins/view/relview.py:589 ../gramps/plugins/view/relview.py:1160
 #: ../gramps/plugins/view/relview.py:1215
 #: ../gramps/plugins/webreport/basepage.py:1838
@@ -2020,7 +2021,7 @@ msgstr "   Разрешённые параметры:"
 #: ../gramps/plugins/gramplet/whatsnext.py:441
 #: ../gramps/plugins/gramplet/whatsnext.py:474
 #: ../gramps/plugins/gramplet/whatsnext.py:496
-#: ../gramps/plugins/graph/gvrelgraph.py:705
+#: ../gramps/plugins/graph/gvrelgraph.py:707
 #: ../gramps/plugins/textreport/descendreport.py:270
 #: ../gramps/plugins/textreport/descendreport.py:280
 #: ../gramps/plugins/textreport/descendreport.py:286
@@ -2978,7 +2979,7 @@ msgstr "Пт"
 msgid "Sat"
 msgstr "Сб"
 
-#: ../gramps/gen/db/base.py:1816 ../gramps/gui/widgets/fanchart.py:1826
+#: ../gramps/gen/db/base.py:1816 ../gramps/gui/widgets/fanchart.py:2077
 msgid "Add child to family"
 msgstr "Добавить ребёнка в семью"
 
@@ -3515,21 +3516,21 @@ msgstr "Применение ..."
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1093
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1107
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1121
-#: ../gramps/plugins/graph/gvrelgraph.py:799
+#: ../gramps/plugins/graph/gvrelgraph.py:801
 #: ../gramps/plugins/quickview/quickview.gpr.py:130
 #: ../gramps/plugins/textreport/birthdayreport.py:473
 #: ../gramps/plugins/textreport/familygroup.py:714
 #: ../gramps/plugins/textreport/indivcomplete.py:1062
 #: ../gramps/plugins/textreport/recordsreport.py:217
 #: ../gramps/plugins/tool/sortevents.py:168
-#: ../gramps/plugins/webreport/narrativeweb.py:1638
+#: ../gramps/plugins/webreport/narrativeweb.py:1639
 #: ../gramps/plugins/webreport/webcal.py:1671
 msgid "Filter"
 msgstr "Фильтр"
 
 #: ../gramps/gen/filters/rules/_changedsincebase.py:56
 #: ../gramps/gen/filters/rules/_everything.py:45
-#: ../gramps/gen/filters/rules/_hasattributebase.py:51
+#: ../gramps/gen/filters/rules/_hasattributebase.py:53
 #: ../gramps/gen/filters/rules/_hasgallerybase.py:48
 #: ../gramps/gen/filters/rules/_hasgrampsid.py:48
 #: ../gramps/gen/filters/rules/_hasldsbase.py:51
@@ -4812,7 +4813,7 @@ msgstr "Тип:"
 
 #: ../gramps/gen/filters/rules/media/_hasmedia.py:48
 #: ../gramps/gui/glade/mergemedia.glade:245
-#: ../gramps/gui/glade/mergemedia.glade:261 ../gramps/gui/viewmanager.py:1664
+#: ../gramps/gui/glade/mergemedia.glade:261 ../gramps/gui/viewmanager.py:1663
 msgid "Path:"
 msgstr "Путь:"
 
@@ -5295,7 +5296,7 @@ msgstr "Единственная фамилия:"
 
 #: ../gramps/gen/filters/rules/person/_hasnameof.py:54
 #: ../gramps/gen/lib/surname.py:98
-#: ../gramps/gui/editors/displaytabs/surnametab.py:76
+#: ../gramps/gui/editors/displaytabs/surnametab.py:79
 msgid "Connector"
 msgstr "Связка"
 
@@ -5398,7 +5399,7 @@ msgstr "Выбирает людей, состоящих в указанном о
 
 #: ../gramps/gen/filters/rules/person/_hasrelationship.py:50
 #: ../gramps/gen/filters/rules/person/_havealtfamilies.py:45
-#: ../gramps/gen/filters/rules/person/_havechildren.py:44
+#: ../gramps/gen/filters/rules/person/_havechildren.py:48
 #: ../gramps/gen/filters/rules/person/_ischildoffiltermatch.py:48
 #: ../gramps/gen/filters/rules/person/_isparentoffiltermatch.py:48
 #: ../gramps/gen/filters/rules/person/_issiblingoffiltermatch.py:47
@@ -5490,11 +5491,11 @@ msgstr "Лица, являющиеся приёмными детьми"
 msgid "Matches people who were adopted"
 msgstr "Выбирает людей, являющихся приёмными детьми"
 
-#: ../gramps/gen/filters/rules/person/_havechildren.py:42
+#: ../gramps/gen/filters/rules/person/_havechildren.py:46
 msgid "People with children"
 msgstr "Лица с детьми"
 
-#: ../gramps/gen/filters/rules/person/_havechildren.py:43
+#: ../gramps/gen/filters/rules/person/_havechildren.py:47
 msgid "Matches people who have children"
 msgstr "Выбирает людей, имеющих детей"
 
@@ -5606,7 +5607,7 @@ msgstr ""
 #: ../gramps/plugins/gramplet/statsgramplet.py:149
 #: ../gramps/plugins/graph/gvfamilylines.py:283
 #: ../gramps/plugins/graph/gvhourglass.py:423
-#: ../gramps/plugins/graph/gvrelgraph.py:936
+#: ../gramps/plugins/graph/gvrelgraph.py:944
 #: ../gramps/plugins/webreport/statistics.py:124
 #: ../gramps/plugins/webreport/statistics.py:189
 msgid "Females"
@@ -5681,7 +5682,7 @@ msgstr ""
 #: ../gramps/plugins/gramplet/statsgramplet.py:146
 #: ../gramps/plugins/graph/gvfamilylines.py:279
 #: ../gramps/plugins/graph/gvhourglass.py:419
-#: ../gramps/plugins/graph/gvrelgraph.py:932
+#: ../gramps/plugins/graph/gvrelgraph.py:940
 #: ../gramps/plugins/webreport/statistics.py:122
 #: ../gramps/plugins/webreport/statistics.py:187
 msgid "Males"
@@ -6661,7 +6662,7 @@ msgstr "Дата"
 #: ../gramps/gen/lib/placetype.py:71
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:72
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:54
-#: ../gramps/plugins/view/geoplaces.py:599
+#: ../gramps/plugins/view/geoplaces.py:601
 #: ../gramps/plugins/view/repoview.py:89
 #: ../gramps/plugins/webreport/basepage.py:1128
 #: ../gramps/plugins/webreport/basepage.py:2587
@@ -6673,7 +6674,7 @@ msgstr "Улица"
 #: ../gramps/gen/lib/placetype.py:70 ../gramps/gui/configure.py:612
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:73
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:55
-#: ../gramps/plugins/view/geoplaces.py:596
+#: ../gramps/plugins/view/geoplaces.py:598
 #: ../gramps/plugins/view/repoview.py:90
 #: ../gramps/plugins/webreport/basepage.py:1129
 #: ../gramps/plugins/webreport/basepage.py:2588
@@ -6685,7 +6686,7 @@ msgstr "Местность"
 #: ../gramps/gen/lib/placetype.py:68 ../gramps/gui/configure.py:615
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:74
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:56
-#: ../gramps/plugins/view/geoplaces.py:647
+#: ../gramps/plugins/view/geoplaces.py:649
 #: ../gramps/plugins/view/repoview.py:91
 #: ../gramps/plugins/webreport/basepage.py:1130
 #: ../gramps/plugins/webreport/basepage.py:2589
@@ -6698,7 +6699,7 @@ msgstr "Город"
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:57
 #: ../gramps/gui/views/treemodels/placemodel.py:312
 #: ../gramps/plugins/lib/maps/placeselection.py:151
-#: ../gramps/plugins/view/geoplaces.py:629
+#: ../gramps/plugins/view/geoplaces.py:631
 #: ../gramps/plugins/webreport/basepage.py:1132
 #: ../gramps/plugins/webreport/basepage.py:2592
 #: ../gramps/plugins/webreport/basepage.py:2657
@@ -6710,7 +6711,7 @@ msgstr "Область/Район/Уезд"
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:58
 #: ../gramps/gui/views/treemodels/placemodel.py:312
 #: ../gramps/plugins/lib/maps/placeselection.py:150
-#: ../gramps/plugins/view/geoplaces.py:626
+#: ../gramps/plugins/view/geoplaces.py:628
 msgid "State"
 msgstr "Республика"
 
@@ -6720,7 +6721,7 @@ msgstr "Республика"
 #: ../gramps/gui/editors/displaytabs/locationembedlist.py:59
 #: ../gramps/gui/views/treemodels/placemodel.py:312
 #: ../gramps/plugins/lib/maps/placeselection.py:149
-#: ../gramps/plugins/view/geoplaces.py:623
+#: ../gramps/plugins/view/geoplaces.py:625
 #: ../gramps/plugins/view/repoview.py:93
 #: ../gramps/plugins/webreport/basepage.py:1134
 #: ../gramps/plugins/webreport/basepage.py:2596
@@ -6774,7 +6775,7 @@ msgstr "Значение"
 #: ../gramps/gen/lib/srcmediatype.py:57 ../gramps/gen/lib/urltype.py:48
 #: ../gramps/gui/autocomp.py:179
 #: ../gramps/plugins/textreport/indivcomplete.py:74
-#: ../gramps/plugins/view/geoplaces.py:593
+#: ../gramps/plugins/view/geoplaces.py:595
 msgid "Custom"
 msgstr "Другой"
 
@@ -6943,7 +6944,7 @@ msgstr "Воспитанник"
 #: ../gramps/gui/editors/editcitation.py:119
 #: ../gramps/gui/editors/editcitation.py:125
 #: ../gramps/gui/editors/editlink.py:100
-#: ../gramps/gui/editors/filtereditor.py:302
+#: ../gramps/gui/editors/filtereditor.py:302 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/views/treemodels/citationtreemodel.py:170
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:116
 #: ../gramps/plugins/importer/importprogen.glade:209
@@ -7009,7 +7010,7 @@ msgstr "Достоверность"
 #: ../gramps/gui/clipboard.py:761 ../gramps/gui/configure.py:652
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:78
 #: ../gramps/gui/editors/editlink.py:99 ../gramps/gui/editors/editsource.py:86
-#: ../gramps/gui/editors/filtereditor.py:298
+#: ../gramps/gui/editors/filtereditor.py:298 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/views/treemodels/citationtreemodel.py:170
 #: ../gramps/plugins/export/exportcsv.py:466
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:115
@@ -7035,7 +7036,7 @@ msgstr "Источник"
 #: ../gramps/gen/lib/media.py:134 ../gramps/gen/lib/person.py:206
 #: ../gramps/gen/lib/place.py:166 ../gramps/gen/lib/src.py:117
 #: ../gramps/gui/clipboard.py:636 ../gramps/gui/editors/editlink.py:94
-#: ../gramps/gui/editors/filtereditor.py:299
+#: ../gramps/gui/editors/filtereditor.py:299 ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:111
 #: ../gramps/plugins/quickview/filterbyname.py:109
 #: ../gramps/plugins/quickview/filterbyname.py:134
@@ -7283,6 +7284,7 @@ msgstr "только текст"
 #: ../gramps/gui/editors/editlink.py:92
 #: ../gramps/gui/editors/filtereditor.py:296
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:138
+#: ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:109
 #: ../gramps/plugins/importer/importprogen.glade:696
 #: ../gramps/plugins/quickview/filterbyname.py:175
@@ -7305,7 +7307,7 @@ msgstr "Событие"
 #: ../gramps/gui/editors/editlink.py:97
 #: ../gramps/gui/editors/filtereditor.py:297
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:108
-#: ../gramps/gui/glade/editevent.glade:270
+#: ../gramps/gui/glade/editevent.glade:270 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/plug/_guioptions.py:1354
 #: ../gramps/gui/selectors/selectevent.py:69
 #: ../gramps/gui/views/treemodels/placemodel.py:312
@@ -7403,7 +7405,7 @@ msgstr "События"
 #: ../gramps/gui/editors/displaytabs/personeventembedlist.py:52
 #: ../gramps/gui/editors/editfamily.py:561 ../gramps/gui/editors/editlink.py:93
 #: ../gramps/gui/editors/filtereditor.py:295
-#: ../gramps/gui/glade/editldsord.glade:267
+#: ../gramps/gui/glade/editldsord.glade:267 ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/export/exportcsv.py:506
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:110
 #: ../gramps/plugins/importer/importcsv.py:227
@@ -7885,12 +7887,12 @@ msgid "Mother"
 msgstr "Мать"
 
 #. Go over children and build their menu
-#: ../gramps/gen/lib/family.py:161 ../gramps/gui/widgets/fanchart.py:1709
+#: ../gramps/gen/lib/family.py:161 ../gramps/gui/widgets/fanchart.py:1957
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:855
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:869
 #: ../gramps/plugins/textreport/familygroup.py:646
 #: ../gramps/plugins/textreport/indivcomplete.py:678
-#: ../gramps/plugins/view/pedigreeview.py:1835
+#: ../gramps/plugins/view/pedigreeview.py:1829
 #: ../gramps/plugins/view/relview.py:1570
 #: ../gramps/plugins/webreport/basepage.py:381
 msgid "Children"
@@ -8121,7 +8123,7 @@ msgid "Location"
 msgstr "Расположение"
 
 #: ../gramps/gen/lib/location.py:107 ../gramps/gen/lib/placetype.py:69
-#: ../gramps/plugins/view/geoplaces.py:644
+#: ../gramps/plugins/view/geoplaces.py:646
 msgid "Parish"
 msgstr "Приход"
 
@@ -8149,7 +8151,7 @@ msgid "Media ref"
 msgstr "Ссылка на документ"
 
 #: ../gramps/gen/lib/mediaref.py:110 ../gramps/gen/lib/placetype.py:73
-#: ../gramps/plugins/view/geoplaces.py:635
+#: ../gramps/plugins/view/geoplaces.py:637
 msgid "Region"
 msgstr "Регион"
 
@@ -8177,7 +8179,7 @@ msgstr "Регион"
 #: ../gramps/gui/plug/report/_bookdialog.py:383
 #: ../gramps/gui/selectors/selectperson.py:90
 #: ../gramps/gui/selectors/selectplace.py:67
-#: ../gramps/gui/views/bookmarks.py:282 ../gramps/gui/views/tags.py:444
+#: ../gramps/gui/views/bookmarks.py:281 ../gramps/gui/views/tags.py:444
 #: ../gramps/gui/views/treemodels/peoplemodel.py:611
 #: ../gramps/plugins/export/exportcsv.py:286
 #: ../gramps/plugins/gramplet/ancestor.py:63
@@ -8242,7 +8244,7 @@ msgstr "Суффикс"
 #: ../gramps/gui/selectors/selectplace.py:70
 #: ../gramps/gui/selectors/selectrepository.py:66
 #: ../gramps/gui/selectors/selectsource.py:66
-#: ../gramps/gui/widgets/grampletpane.py:1602
+#: ../gramps/gui/widgets/grampletpane.py:1601
 #: ../gramps/plugins/export/exportcsv.py:286
 #: ../gramps/plugins/gramplet/persondetails.py:164
 #: ../gramps/plugins/importer/importprogen.glade:140
@@ -8375,7 +8377,7 @@ msgstr "Фамилия в браке"
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:113
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:108
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:91
-#: ../gramps/gui/glade/editnote.glade:326
+#: ../gramps/gui/glade/editnote.glade:326 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/views/treemodels/mediamodel.py:117
 #: ../gramps/plugins/drawreport/ancestortree.py:974
 #: ../gramps/plugins/drawreport/descendtree.py:1701
@@ -8527,7 +8529,7 @@ msgstr "Заметка о ссылке на ребёнка"
 #: ../gramps/gen/lib/person.py:173 ../gramps/gui/clipboard.py:719
 #: ../gramps/gui/configure.py:643 ../gramps/gui/editors/editlink.py:96
 #: ../gramps/gui/editors/filtereditor.py:294
-#: ../gramps/gui/glade/editpersonref.glade:211
+#: ../gramps/gui/glade/editpersonref.glade:211 ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/export/exportcsv.py:354
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:108
 #: ../gramps/plugins/importer/importcsv.py:209
@@ -8593,7 +8595,7 @@ msgstr "Ссылки на событие"
 
 #: ../gramps/gen/lib/person.py:199 ../gramps/plugins/graph/gvfamilylines.py:292
 #: ../gramps/plugins/graph/gvhourglass.py:432
-#: ../gramps/plugins/graph/gvrelgraph.py:946
+#: ../gramps/plugins/graph/gvrelgraph.py:954
 #: ../gramps/plugins/quickview/filterbyname.py:94
 #: ../gramps/plugins/quickview/filterbyname.py:119
 #: ../gramps/plugins/textreport/indivcomplete.py:641
@@ -8712,52 +8714,52 @@ msgstr "Язык"
 msgid "Place ref"
 msgstr "Ссылка на место"
 
-#: ../gramps/gen/lib/placetype.py:72 ../gramps/plugins/view/geoplaces.py:632
+#: ../gramps/gen/lib/placetype.py:72 ../gramps/plugins/view/geoplaces.py:634
 msgid "Province"
 msgstr "Провинция"
 
-#: ../gramps/gen/lib/placetype.py:74 ../gramps/plugins/view/geoplaces.py:638
+#: ../gramps/gen/lib/placetype.py:74 ../gramps/plugins/view/geoplaces.py:640
 msgid "Department"
 msgstr "Департамент"
 
-#: ../gramps/gen/lib/placetype.py:75 ../gramps/plugins/view/geoplaces.py:602
+#: ../gramps/gen/lib/placetype.py:75 ../gramps/plugins/view/geoplaces.py:604
 msgid "Neighborhood"
 msgstr "Соседство"
 
-#: ../gramps/gen/lib/placetype.py:76 ../gramps/plugins/view/geoplaces.py:641
+#: ../gramps/gen/lib/placetype.py:76 ../gramps/plugins/view/geoplaces.py:643
 msgid "District"
 msgstr "Округ"
 
-#: ../gramps/gen/lib/placetype.py:77 ../gramps/plugins/view/geoplaces.py:605
+#: ../gramps/gen/lib/placetype.py:77 ../gramps/plugins/view/geoplaces.py:607
 msgid "Borough"
 msgstr "Район"
 
-#: ../gramps/gen/lib/placetype.py:78 ../gramps/plugins/view/geoplaces.py:653
+#: ../gramps/gen/lib/placetype.py:78 ../gramps/plugins/view/geoplaces.py:655
 msgid "Municipality"
 msgstr "Муниципальная"
 
-#: ../gramps/gen/lib/placetype.py:79 ../gramps/plugins/view/geoplaces.py:650
+#: ../gramps/gen/lib/placetype.py:79 ../gramps/plugins/view/geoplaces.py:652
 msgid "Town"
 msgstr "Город (небольшой)"
 
-#: ../gramps/gen/lib/placetype.py:80 ../gramps/plugins/view/geoplaces.py:608
+#: ../gramps/gen/lib/placetype.py:80 ../gramps/plugins/view/geoplaces.py:610
 msgid "Village"
 msgstr "Посёлок"
 
-#: ../gramps/gen/lib/placetype.py:81 ../gramps/plugins/view/geoplaces.py:611
+#: ../gramps/gen/lib/placetype.py:81 ../gramps/plugins/view/geoplaces.py:613
 msgid "Hamlet"
 msgstr "Деревня"
 
-#: ../gramps/gen/lib/placetype.py:82 ../gramps/plugins/view/geoplaces.py:614
+#: ../gramps/gen/lib/placetype.py:82 ../gramps/plugins/view/geoplaces.py:616
 msgid "Farm"
 msgstr "Ферма"
 
-#: ../gramps/gen/lib/placetype.py:83 ../gramps/plugins/view/geoplaces.py:617
+#: ../gramps/gen/lib/placetype.py:83 ../gramps/plugins/view/geoplaces.py:619
 msgid "Building"
 msgstr "Здание"
 
 #: ../gramps/gen/lib/placetype.py:84 ../gramps/plugins/gramplet/leak.py:95
-#: ../gramps/plugins/view/geoplaces.py:620
+#: ../gramps/plugins/view/geoplaces.py:622
 #: ../gramps/plugins/webreport/basepage.py:2802
 #: ../gramps/plugins/webreport/source.py:164
 msgid "Number"
@@ -8768,7 +8770,7 @@ msgstr "Номер"
 #: ../gramps/gui/configure.py:664 ../gramps/gui/editors/editlink.py:98
 #: ../gramps/gui/editors/editrepository.py:77
 #: ../gramps/gui/editors/editrepository.py:79
-#: ../gramps/gui/editors/filtereditor.py:300
+#: ../gramps/gui/editors/filtereditor.py:300 ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:114
 #: ../gramps/plugins/quickview/filterbyname.py:205
 #: ../gramps/plugins/quickview/filterbyname.py:264
@@ -8931,6 +8933,7 @@ msgstr "Стилизованные теги текста"
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:114
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:109
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:92
+#: ../gramps/gui/views/tags.py:61 ../gramps/gui/views/tags.py:71
 #: ../gramps/plugins/textreport/tagreport.py:909
 #: ../gramps/plugins/textreport/tagreport.py:913
 msgid "Tag"
@@ -8941,14 +8944,17 @@ msgid "Ranges"
 msgstr "Диапазоны"
 
 #: ../gramps/gen/lib/styledtexttagtype.py:61
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Bold"
 msgstr "Жирный"
 
 #: ../gramps/gen/lib/styledtexttagtype.py:62
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Italic"
 msgstr "Курсив"
 
 #: ../gramps/gen/lib/styledtexttagtype.py:63
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Underline"
 msgstr "Подчёркнутый"
 
@@ -8976,6 +8982,7 @@ msgstr "Верхний индекс"
 #: ../gramps/gui/glade/editlink.glade:171
 #: ../gramps/gui/widgets/styledtextbuffer.py:565
 #: ../gramps/gui/widgets/styledtextbuffer.py:605
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Link"
 msgstr "Ссылка"
 
@@ -8986,7 +8993,7 @@ msgstr "Ссылка"
 #: ../gramps/gui/configure.py:848 ../gramps/gui/configure.py:850
 #: ../gramps/gui/configure.py:853 ../gramps/gui/configure.py:854
 #: ../gramps/gui/configure.py:855 ../gramps/gui/configure.py:856
-#: ../gramps/gui/editors/displaytabs/surnametab.py:75
+#: ../gramps/gui/editors/displaytabs/surnametab.py:78
 #: ../gramps/gui/plug/_guioptions.py:88 ../gramps/gui/plug/_guioptions.py:1508
 #: ../gramps/plugins/drawreport/statisticschart.py:340
 #: ../gramps/plugins/export/exportcsv.py:354
@@ -8999,7 +9006,7 @@ msgid "Surname"
 msgstr "Фамилия"
 
 #: ../gramps/gen/lib/surname.py:93 ../gramps/gen/utils/keyword.py:71
-#: ../gramps/gui/editors/displaytabs/surnametab.py:74
+#: ../gramps/gui/editors/displaytabs/surnametab.py:77
 #: ../gramps/gui/glade/editperson.glade:470
 #: ../gramps/plugins/export/exportcsv.py:355
 #: ../gramps/plugins/importer/importcsv.py:167
@@ -9304,7 +9311,7 @@ msgstr "Файл %s уже открыт, сначала закройте его.
 #: ../gramps/plugins/lib/libhtmlbackend.py:253
 #: ../gramps/plugins/lib/libhtmlbackend.py:259
 #: ../gramps/plugins/lib/libhtmlbackend.py:263
-#: ../gramps/plugins/webreport/narrativeweb.py:332
+#: ../gramps/plugins/webreport/narrativeweb.py:333
 #, python-format
 msgid "Could not create %s"
 msgstr "Ошибка при создании %s"
@@ -9335,22 +9342,22 @@ msgid "TrueType / FreeSans"
 msgstr "TrueType / FreeSans"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:72
-#: ../gramps/plugins/view/pedigreeview.py:2125
+#: ../gramps/plugins/view/pedigreeview.py:2119
 msgid "Vertical (↓)"
 msgstr "Вертикально (↓)"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:73
-#: ../gramps/plugins/view/pedigreeview.py:2126
+#: ../gramps/plugins/view/pedigreeview.py:2120
 msgid "Vertical (↑)"
 msgstr "Вертикально (↑)"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:74
-#: ../gramps/plugins/view/pedigreeview.py:2127
+#: ../gramps/plugins/view/pedigreeview.py:2121
 msgid "Horizontal (→)"
 msgstr "Горизонтально (→)"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:75
-#: ../gramps/plugins/view/pedigreeview.py:2128
+#: ../gramps/plugins/view/pedigreeview.py:2122
 msgid "Horizontal (←)"
 msgstr "Горизонтально (←)"
 
@@ -9429,6 +9436,7 @@ msgstr "Разметка Graphviz"
 
 #. ###############################
 #: ../gramps/gen/plug/docgen/graphdoc.py:143
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Font family"
 msgstr "Гарнитура шрифта"
 
@@ -9442,6 +9450,7 @@ msgstr ""
 "freefont/"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:152
+#: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Font size"
 msgstr "Размер шрифта"
 
@@ -10134,14 +10143,14 @@ msgstr "Как и где включать номера-идентификато�
 #. #########################
 #. ###############################
 #: ../gramps/gen/plug/report/stdoptions.py:328
-#: ../gramps/gui/viewmanager.py:1723
+#: ../gramps/gui/viewmanager.py:1722
 #: ../gramps/plugins/graph/gvfamilylines.py:218
-#: ../gramps/plugins/graph/gvrelgraph.py:851
+#: ../gramps/plugins/graph/gvrelgraph.py:859
 #: ../gramps/plugins/textreport/detancestralreport.py:900
 #: ../gramps/plugins/textreport/detdescendantreport.py:1085
 #: ../gramps/plugins/textreport/familygroup.py:752
 #: ../gramps/plugins/textreport/indivcomplete.py:1102
-#: ../gramps/plugins/webreport/narrativeweb.py:1985
+#: ../gramps/plugins/webreport/narrativeweb.py:1986
 msgid "Include"
 msgstr "Включить"
 
@@ -10325,7 +10334,7 @@ msgstr ""
 "перезапустите Gramps."
 
 #: ../gramps/gen/relationship.py:1273
-#: ../gramps/plugins/view/pedigreeview.py:1606
+#: ../gramps/plugins/view/pedigreeview.py:1600
 msgid "Relationship loop detected"
 msgstr "Обнаружен цикл в отношениях"
 
@@ -10399,30 +10408,6 @@ msgstr "бывшая гражданская жена"
 
 #: ../gramps/gen/relationship.py:2195
 msgid "gender unknown,unmarried|ex-partner"
-msgstr "бывший гражданский супруг(-а)"
-
-#: ../gramps/gen/relationship.py:2184
-msgid "unmarried|husband"
-msgstr "гражданский муж"
-
-#: ../gramps/gen/relationship.py:2186
-msgid "unmarried|wife"
-msgstr "гражданская жена"
-
-#: ../gramps/gen/relationship.py:2188
-msgid "gender unknown,unmarried|spouse"
-msgstr "гражданский супруг"
-
-#: ../gramps/gen/relationship.py:2191
-msgid "unmarried|ex-husband"
-msgstr "бывший гражданский муж"
-
-#: ../gramps/gen/relationship.py:2193
-msgid "unmarried|ex-wife"
-msgstr "бывшая гражданская жена"
-
-#: ../gramps/gen/relationship.py:2195
-msgid "gender unknown,unmarried|ex-spouse"
 msgstr "бывший гражданский супруг(-а)"
 
 #: ../gramps/gen/relationship.py:2198
@@ -10876,7 +10861,7 @@ msgstr "СУФФИКС"
 
 #. name, sort, width, modelcol
 #: ../gramps/gen/utils/keyword.py:61
-#: ../gramps/gui/editors/displaytabs/surnametab.py:79
+#: ../gramps/gui/editors/displaytabs/surnametab.py:82
 msgid "Name|Primary"
 msgstr "Главное"
 
@@ -11222,7 +11207,7 @@ msgstr "Перетаскивайте столбцы с помощью мыши, 
 
 #: ../gramps/gui/columnorder.py:107 ../gramps/gui/configure.py:1842
 #: ../gramps/gui/configure.py:1866 ../gramps/gui/configure.py:1892
-#: ../gramps/gui/plug/_dialogs.py:130 ../gramps/gui/viewmanager.py:1795
+#: ../gramps/gui/plug/_dialogs.py:130 ../gramps/gui/viewmanager.py:1794
 #: ../gramps/plugins/lib/maps/geography.py:997
 #: ../gramps/plugins/lib/maps/geography.py:1294
 msgid "_Apply"
@@ -11232,7 +11217,7 @@ msgstr "П_рименить"
 #: ../gramps/gui/columnorder.py:128 ../gramps/gui/configure.py:1353
 #: ../gramps/plugins/drawreport/ancestortree.py:909
 #: ../gramps/plugins/drawreport/descendtree.py:1652
-#: ../gramps/plugins/webreport/narrativeweb.py:1765
+#: ../gramps/plugins/webreport/narrativeweb.py:1766
 msgid "Display"
 msgstr "Отображение"
 
@@ -11266,10 +11251,11 @@ msgstr "Показать «Редактор имён»"
 #: ../gramps/gui/glade/editplaceformat.glade:23
 #: ../gramps/gui/glade/plugins.glade:22 ../gramps/gui/glade/rule.glade:24
 #: ../gramps/gui/glade/rule.glade:1024 ../gramps/gui/glade/tipofday.glade:117
-#: ../gramps/gui/glade/updateaddons.glade:25 ../gramps/gui/plug/_windows.py:105
-#: ../gramps/gui/plug/_windows.py:693 ../gramps/gui/plug/_windows.py:749
+#: ../gramps/gui/glade/updateaddons.glade:25 ../gramps/gui/grampsgui.py:56
+#: ../gramps/gui/plug/_windows.py:105 ../gramps/gui/plug/_windows.py:693
+#: ../gramps/gui/plug/_windows.py:749
 #: ../gramps/gui/plug/quick/_textbufdoc.py:60 ../gramps/gui/undohistory.py:90
-#: ../gramps/gui/viewmanager.py:1658 ../gramps/gui/views/bookmarks.py:299
+#: ../gramps/gui/viewmanager.py:1657 ../gramps/gui/views/bookmarks.py:298
 #: ../gramps/gui/views/tags.py:466 ../gramps/gui/widgets/grampletbar.py:636
 #: ../gramps/gui/widgets/grampletpane.py:239
 #: ../gramps/plugins/lib/maps/placeselection.py:120
@@ -11407,9 +11393,9 @@ msgstr "%s: "
 #: ../gramps/gui/glade/mergesource.glade:53
 #: ../gramps/gui/glade/reorder.glade:54 ../gramps/gui/glade/rule.glade:41
 #: ../gramps/gui/glade/rule.glade:351 ../gramps/gui/glade/rule.glade:781
-#: ../gramps/gui/logger/_errorview.py:175
+#: ../gramps/gui/grampsgui.py:56 ../gramps/gui/logger/_errorview.py:175
 #: ../gramps/gui/plug/report/_reportdialog.py:159
-#: ../gramps/gui/undohistory.py:82 ../gramps/gui/views/bookmarks.py:300
+#: ../gramps/gui/undohistory.py:82 ../gramps/gui/views/bookmarks.py:299
 #: ../gramps/gui/views/tags.py:467 ../gramps/gui/views/tags.py:681
 #: ../gramps/gui/widgets/grampletbar.py:642
 #: ../gramps/gui/widgets/grampletpane.py:244
@@ -11631,11 +11617,11 @@ msgstr "Пример"
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:122
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:129
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:115
-#: ../gramps/gui/editors/editfamily.py:195
+#: ../gramps/gui/editors/editfamily.py:195 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/plug/report/_bookdialog.py:665 ../gramps/gui/views/tags.py:458
-#: ../gramps/gui/widgets/fanchart.py:1777
-#: ../gramps/gui/widgets/fanchart.py:1819
-#: ../gramps/plugins/view/pedigreeview.py:1709
+#: ../gramps/gui/widgets/fanchart.py:2028
+#: ../gramps/gui/widgets/fanchart.py:2070
+#: ../gramps/plugins/view/pedigreeview.py:1703
 msgid "_Add"
 msgstr "До_бавить"
 
@@ -11647,11 +11633,11 @@ msgstr "До_бавить"
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:123
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:130
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:116
-#: ../gramps/gui/glade/editlink.glade:222
+#: ../gramps/gui/glade/editlink.glade:222 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/plug/report/_bookdialog.py:639 ../gramps/gui/views/tags.py:459
-#: ../gramps/gui/widgets/fanchart.py:1574
-#: ../gramps/plugins/view/pedigreeview.py:1744
-#: ../gramps/plugins/view/pedigreeview.py:1972
+#: ../gramps/gui/widgets/fanchart.py:1817
+#: ../gramps/plugins/view/pedigreeview.py:1738
+#: ../gramps/plugins/view/pedigreeview.py:1966
 msgid "_Edit"
 msgstr "_Правка"
 
@@ -11663,7 +11649,7 @@ msgstr "_Правка"
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:117
 #: ../gramps/gui/editors/editfamily.py:198
 #: ../gramps/gui/plug/report/_bookdialog.py:634
-#: ../gramps/gui/views/bookmarks.py:295 ../gramps/gui/views/tags.py:460
+#: ../gramps/gui/views/bookmarks.py:294 ../gramps/gui/views/tags.py:460
 msgid "_Remove"
 msgstr "_Удалить"
 
@@ -12138,7 +12124,7 @@ msgstr "Выбрать каталог документов"
 #: ../gramps/gui/plug/_guioptions.py:1744 ../gramps/gui/plug/_windows.py:440
 #: ../gramps/gui/plug/report/_fileentry.py:64
 #: ../gramps/gui/plug/report/_reportdialog.py:162 ../gramps/gui/utils.py:180
-#: ../gramps/gui/viewmanager.py:1793 ../gramps/gui/views/listview.py:1054
+#: ../gramps/gui/viewmanager.py:1792 ../gramps/gui/views/listview.py:1064
 #: ../gramps/gui/views/navigationview.py:348 ../gramps/gui/views/tags.py:682
 #: ../gramps/gui/widgets/progressdialog.py:437
 #: ../gramps/plugins/importer/importprogen.glade:1714
@@ -12154,7 +12140,7 @@ msgstr "_Отменить"
 msgid "Select database directory"
 msgstr "Выбрать каталог базы данных"
 
-#: ../gramps/gui/configure.py:1887 ../gramps/gui/viewmanager.py:1790
+#: ../gramps/gui/configure.py:1887 ../gramps/gui/viewmanager.py:1789
 msgid "Select backup directory"
 msgstr "Выберите каталог для резервного копирования"
 
@@ -12448,7 +12434,7 @@ msgstr "Информация о базе данных"
 #: ../gramps/gui/glade/styleeditor.glade:1754
 #: ../gramps/gui/plug/_guioptions.py:80
 #: ../gramps/gui/plug/report/_reportdialog.py:166 ../gramps/gui/utils.py:194
-#: ../gramps/gui/viewmanager.py:1660 ../gramps/gui/views/tags.py:683
+#: ../gramps/gui/viewmanager.py:1659 ../gramps/gui/views/tags.py:683
 #: ../gramps/plugins/tool/check.py:781 ../gramps/plugins/tool/patchnames.py:118
 #: ../gramps/plugins/tool/populatesources.py:91
 #: ../gramps/plugins/tool/testcasegenerator.py:328
@@ -12753,48 +12739,48 @@ msgstr ""
 "Пожалуйста, не закрывайте этот важный диалог силой.\n"
 "Вместо этого, выберите одну из предлагаемых возможностей"
 
-#: ../gramps/gui/displaystate.py:290
+#: ../gramps/gui/displaystate.py:279
 msgid "Cannot load database"
 msgstr "Не удалось загрузить базу данных"
 
-#: ../gramps/gui/displaystate.py:408
+#: ../gramps/gui/displaystate.py:397
 #: ../gramps/plugins/gramplet/persondetails.py:173
 msgid "No active person"
 msgstr "Не выбрано лицо"
 
-#: ../gramps/gui/displaystate.py:409
+#: ../gramps/gui/displaystate.py:398
 msgid "No active family"
 msgstr "Не выбрана семья"
 
-#: ../gramps/gui/displaystate.py:410
+#: ../gramps/gui/displaystate.py:399
 msgid "No active event"
 msgstr "Не выбрано событие"
 
-#: ../gramps/gui/displaystate.py:411
+#: ../gramps/gui/displaystate.py:400
 msgid "No active place"
 msgstr "Не выбрано место"
 
-#: ../gramps/gui/displaystate.py:412
+#: ../gramps/gui/displaystate.py:401
 msgid "No active source"
 msgstr "Не выбран источник"
 
-#: ../gramps/gui/displaystate.py:413
+#: ../gramps/gui/displaystate.py:402
 msgid "No active citation"
 msgstr "Не выбрана цитата"
 
-#: ../gramps/gui/displaystate.py:414
+#: ../gramps/gui/displaystate.py:403
 msgid "No active repository"
 msgstr "Не выбрано хранилище"
 
-#: ../gramps/gui/displaystate.py:415
+#: ../gramps/gui/displaystate.py:404
 msgid "No active media"
 msgstr "Не выбран объект"
 
-#: ../gramps/gui/displaystate.py:416
+#: ../gramps/gui/displaystate.py:405
 msgid "No active note"
 msgstr "Не выбрана заметка"
 
-#: ../gramps/gui/displaystate.py:655 ../gramps/plugins/gramplet/todo.py:200
+#: ../gramps/gui/displaystate.py:644 ../gramps/plugins/gramplet/todo.py:200
 msgid "No active object"
 msgstr "Не выбран объект"
 
@@ -12931,7 +12917,7 @@ msgstr "Атрибуты"
 #: ../gramps/gui/selectors/selectplace.py:68
 #: ../gramps/gui/selectors/selectrepository.py:67
 #: ../gramps/gui/selectors/selectsource.py:68
-#: ../gramps/gui/views/bookmarks.py:282
+#: ../gramps/gui/views/bookmarks.py:281
 #: ../gramps/gui/views/navigationview.py:343
 #: ../gramps/plugins/gramplet/locations.py:88
 #: ../gramps/plugins/lib/libpersonview.py:99
@@ -12975,6 +12961,7 @@ msgstr "%(part1)s - %(part2)s"
 #: ../gramps/gui/glade/rule.glade:422 ../gramps/gui/glade/rule.glade:429
 #: ../gramps/gui/glade/styleeditor.glade:1864
 #: ../gramps/gui/glade/styleeditor.glade:1871
+#: ../gramps/plugins/view/relview.py:471
 msgid "Add"
 msgstr "Добавить"
 
@@ -12997,6 +12984,7 @@ msgstr "Удалить"
 #: ../gramps/gui/editors/displaytabs/buttontab.py:72
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:148
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:130
+#: ../gramps/plugins/view/relview.py:471
 msgid "Share"
 msgstr "Добавить из существующих"
 
@@ -13155,6 +13143,7 @@ msgid "verb:look at this|_View"
 msgstr "_Посмотреть"
 
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:147
+#: ../gramps/plugins/view/mediaview.py:395
 msgid "Open Containing _Folder"
 msgstr "Открыть папку с этим _документом"
 
@@ -13467,36 +13456,36 @@ msgstr ""
 "\n"
 "Для правки данной ссылки необходимо закрыть предыдущую правку."
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:64
+#: ../gramps/gui/editors/displaytabs/surnametab.py:67
 msgid "Create and add a new surname"
 msgstr "Создать и добавить новую фамилию"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:65
+#: ../gramps/gui/editors/displaytabs/surnametab.py:68
 msgid "Remove the selected surname"
 msgstr "Удалить выделенную фамилию"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:66
+#: ../gramps/gui/editors/displaytabs/surnametab.py:69
 msgid "Edit the selected surname"
 msgstr "Редактировать выделенную фамилию"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:67
+#: ../gramps/gui/editors/displaytabs/surnametab.py:70
 msgid "Move the selected surname upwards"
 msgstr "Переместить выделенную фамилию выше"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:68
+#: ../gramps/gui/editors/displaytabs/surnametab.py:71
 msgid "Move the selected surname downwards"
 msgstr "Переместить выделенную фамилию ниже"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:78
+#: ../gramps/gui/editors/displaytabs/surnametab.py:81
 #: ../gramps/plugins/lib/libgedcom.py:712
 msgid "Origin"
 msgstr "Имяобразование"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:82
+#: ../gramps/gui/editors/displaytabs/surnametab.py:85
 msgid "Multiple Surnames"
 msgstr "Множественные фамилии"
 
-#: ../gramps/gui/editors/displaytabs/surnametab.py:89
+#: ../gramps/gui/editors/displaytabs/surnametab.py:92
 msgid "Family Surnames"
 msgstr "Семейные фамилии"
 
@@ -14068,7 +14057,7 @@ msgstr "%(mother)s [%(gramps_id)s]"
 msgid "manual|Link_Editor"
 msgstr "Редактор_ссылок"
 
-#: ../gramps/gui/editors/editlink.py:87 ../gramps/gui/editors/editlink.py:238
+#: ../gramps/gui/editors/editlink.py:87 ../gramps/gui/editors/editlink.py:239
 msgid "Link Editor"
 msgstr "Редактор ссылок"
 
@@ -14298,12 +14287,22 @@ msgid "Edit Person"
 msgstr "Редактировать информацию о человеке"
 
 #: ../gramps/gui/editors/editperson.py:644
+#: ../gramps/plugins/view/mediaview.py:379
+#: ../gramps/plugins/view/mediaview.py:395
 msgid "View"
 msgstr "Посмотреть"
 
 #: ../gramps/gui/editors/editperson.py:646
 msgid "Edit Object Properties"
 msgstr "Редактировать свойства"
+
+#: ../gramps/gui/editors/editperson.py:687
+msgid "Make Active Person"
+msgstr "Установить активное лицо"
+
+#: ../gramps/gui/editors/editperson.py:687
+msgid "Make Home Person"
+msgstr "Установить базовое лицо"
 
 #: ../gramps/gui/editors/editperson.py:807
 msgid "Problem changing the gender"
@@ -14431,8 +14430,8 @@ msgstr ""
 
 #: ../gramps/gui/editors/editplace.py:217
 #: ../gramps/plugins/lib/maps/geography.py:891
-#: ../gramps/plugins/view/geoplaces.py:494
-#: ../gramps/plugins/view/geoplaces.py:520
+#: ../gramps/plugins/view/geoplaces.py:496
+#: ../gramps/plugins/view/geoplaces.py:522
 msgid "Edit Place"
 msgstr "Редактировать место"
 
@@ -14970,8 +14969,8 @@ msgstr "%s не"
 msgid "%s does not contain"
 msgstr "%s не содержит"
 
-#: ../gramps/gui/filters/_searchbar.py:168 ../gramps/gui/views/listview.py:1188
-#: ../gramps/gui/views/listview.py:1208 ../gramps/plugins/gramplet/leak.py:193
+#: ../gramps/gui/filters/_searchbar.py:168 ../gramps/gui/views/listview.py:1198
+#: ../gramps/gui/views/listview.py:1218 ../gramps/plugins/gramplet/leak.py:193
 #: ../gramps/plugins/gramplet/leak.py:200
 msgid "Updating display..."
 msgstr "Обновление экрана..."
@@ -15132,6 +15131,36 @@ msgid "Configure currently selected item"
 msgstr "Настроить выделенный элемент"
 
 #: ../gramps/gui/glade/book.glade:540 ../gramps/gui/glade/dbman.glade:266
+#: ../gramps/plugins/lib/libpersonview.py:226
+#: ../gramps/plugins/lib/libpersonview.py:303
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:303
+#: ../gramps/plugins/lib/libplaceview.py:362
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:195
+#: ../gramps/plugins/view/citationlistview.py:254
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:209
+#: ../gramps/plugins/view/eventview.py:268
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:168
+#: ../gramps/plugins/view/familyview.py:227
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/mediaview.py:268
+#: ../gramps/plugins/view/mediaview.py:327
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:168
+#: ../gramps/plugins/view/noteview.py:227
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/repoview.py:181
+#: ../gramps/plugins/view/repoview.py:240
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:167
+#: ../gramps/plugins/view/sourceview.py:226
+#: ../gramps/plugins/view/sourceview.py:278
 msgid "_Delete"
 msgstr "_Удалить"
 
@@ -15312,7 +15341,7 @@ msgstr "Закрыть _без сохранения"
 
 #: ../gramps/gui/glade/dialog.glade:873
 #: ../gramps/gui/plug/report/_bookdialog.py:637
-#: ../gramps/gui/views/listview.py:1055
+#: ../gramps/gui/views/listview.py:1065
 #: ../gramps/gui/widgets/grampletpane.py:588
 #: ../gramps/plugins/tool/eventcmp.py:400
 msgid "_Save"
@@ -15826,7 +15855,7 @@ msgid "_Tags:"
 msgstr "Метки:"
 
 #: ../gramps/gui/glade/editfamily.glade:764
-#: ../gramps/gui/widgets/monitoredwidgets.py:842
+#: ../gramps/gui/widgets/monitoredwidgets.py:853
 msgid "Edit the tag list"
 msgstr "Редактировать список меток"
 
@@ -16802,7 +16831,7 @@ msgid "Note 2"
 msgstr "Заметка №2"
 
 #: ../gramps/gui/glade/mergenote.glade:278
-#: ../gramps/gui/glade/mergenote.glade:294 ../gramps/gui/views/listview.py:1059
+#: ../gramps/gui/glade/mergenote.glade:294 ../gramps/gui/views/listview.py:1069
 msgid "Format:"
 msgstr "Формат:"
 
@@ -17307,6 +17336,41 @@ msgid "_Display on startup"
 msgstr "_Показывать при запуске"
 
 #: ../gramps/gui/glade/tipofday.glade:102
+#: ../gramps/plugins/lib/libpersonview.py:206
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libplaceview.py:289
+#: ../gramps/plugins/lib/libplaceview.py:332
+#: ../gramps/plugins/view/citationlistview.py:181
+#: ../gramps/plugins/view/citationlistview.py:224
+#: ../gramps/plugins/view/citationtreeview.py:323
+#: ../gramps/plugins/view/eventview.py:195
+#: ../gramps/plugins/view/eventview.py:238
+#: ../gramps/plugins/view/familyview.py:154
+#: ../gramps/plugins/view/familyview.py:197
+#: ../gramps/plugins/view/fanchartview.py:144
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:71 ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoevents.py:67
+#: ../gramps/plugins/view/geoevents.py:101
+#: ../gramps/plugins/view/geofamclose.py:69
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geofamily.py:67
+#: ../gramps/plugins/view/geofamily.py:101
+#: ../gramps/plugins/view/geomoves.py:68 ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:69
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/geoplaces.py:70
+#: ../gramps/plugins/view/geoplaces.py:104
+#: ../gramps/plugins/view/mediaview.py:254
+#: ../gramps/plugins/view/mediaview.py:297
+#: ../gramps/plugins/view/noteview.py:154
+#: ../gramps/plugins/view/noteview.py:197
+#: ../gramps/plugins/view/pedigreeview.py:652
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428 ../gramps/plugins/view/repoview.py:167
+#: ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/sourceview.py:153
+#: ../gramps/plugins/view/sourceview.py:196
 msgid "_Forward"
 msgstr "_Вперёд"
 
@@ -17344,6 +17408,159 @@ msgstr "Выбрать _все"
 #: ../gramps/gui/glade/updateaddons.glade:120
 msgid "Select _None"
 msgstr "_Отменить выбор"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Books..."
+msgstr "Книги..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Clip_board"
+msgstr "Буфер обмена"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Configure the active view"
+msgstr "Настроить активный вид"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Connect to a recent database"
+msgstr "Открыть недавно использовавшуюся базу данных"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "F_ull Screen"
+msgstr "Полно_экранный режим"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Gramps _Home Page"
+msgstr "_Домашняя страница Gramps"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Gramps _Mailing Lists"
+msgstr "_Списки рассылки Gramps"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Make Backup..."
+msgstr "Сделать резервную копию..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Manage databases"
+msgstr "Управление базами данных"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Open _Recent"
+msgstr "Открыть не_давнее"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Open the Clipboard dialog"
+msgstr "Открыть диалог «Буфер обмена»"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Open the reports dialog"
+msgstr "Открыть диалог отчётов"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "Open the tools dialog"
+msgstr "Открыть диалог инструментов"
+
+#: ../gramps/gui/grampsgui.py:56 ../gramps/gui/tipofday.py:67
+#: ../gramps/gui/tipofday.py:68 ../gramps/gui/tipofday.py:121
+msgid "Tip of the Day"
+msgstr "Совет дня"
+
+#: ../gramps/gui/grampsgui.py:56 ../gramps/gui/undohistory.py:73
+msgid "Undo History"
+msgstr "История откатов"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Abandon Changes and Quit"
+msgstr "От_казаться от изменений и выйти"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_About"
+msgstr "О _программе"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Bookmarks"
+msgstr "_Закладки"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Configure..."
+msgstr "Настроить вид..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Export..."
+msgstr "_Экспорт..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Extra Reports/Tools"
+msgstr "_Дополнительные отчёты/инструменты"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_FAQ"
+msgstr "_ЧАВО"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Family Trees"
+msgstr "_Семейные древа"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Go"
+msgstr "Пере_ход"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Import..."
+msgstr "_Импорт..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Key Bindings"
+msgstr "_Горячие клавиши"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Manage Family Trees..."
+msgstr "_Управление семейными древами..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Navigator"
+msgstr "_Навигатор"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Plugin Manager"
+msgstr "_Менеджер дополнений"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Preferences..."
+msgstr "_Настройки..."
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Quit"
+msgstr "_Выйти"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Report a Bug"
+msgstr "О_тправить отчёт об ошибке"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Reports"
+msgstr "_Отчёты"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Toolbar"
+msgstr "_Панель инструментов"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Tools"
+msgstr "_Инструменты"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_User Manual"
+msgstr "_Руководство пользователя"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_View"
+msgstr "_Вид"
+
+#: ../gramps/gui/grampsgui.py:56
+msgid "_Windows"
+msgstr "_Окна"
 
 #: ../gramps/gui/grampsgui.py:423
 msgid ""
@@ -17767,10 +17984,10 @@ msgstr "Объединить людей"
 
 #. Go over parents and build their menu
 #: ../gramps/gui/merge/mergeperson.py:224
-#: ../gramps/gui/widgets/fanchart.py:1744
+#: ../gramps/gui/widgets/fanchart.py:1994
 #: ../gramps/plugins/quickview/all_relations.py:305
 #: ../gramps/plugins/tool/notrelated.py:128
-#: ../gramps/plugins/view/pedigreeview.py:1872
+#: ../gramps/plugins/view/pedigreeview.py:1866
 #: ../gramps/plugins/view/relview.py:659 ../gramps/plugins/view/relview.py:1017
 #: ../gramps/plugins/view/relview.py:1052
 #: ../gramps/plugins/webreport/person.py:232
@@ -17791,9 +18008,9 @@ msgstr "Родители не найдены"
 
 #. Go over spouses and build their menu
 #: ../gramps/gui/merge/mergeperson.py:238
-#: ../gramps/gui/widgets/fanchart.py:1614
+#: ../gramps/gui/widgets/fanchart.py:1857
 #: ../gramps/plugins/textreport/kinshipreport.py:133
-#: ../gramps/plugins/view/pedigreeview.py:1759
+#: ../gramps/plugins/view/pedigreeview.py:1753
 msgid "Spouses"
 msgstr "Супруги"
 
@@ -18426,6 +18643,19 @@ msgstr "Не включать записи не связанные с выбра
 msgid "Use Compression"
 msgstr "Использовать сжатие"
 
+#: ../gramps/gui/plug/quick/_quickreports.py:97
+msgid "Web Connection"
+msgstr "Веб соединение"
+
+#: ../gramps/gui/plug/quick/_quickreports.py:142
+#: ../gramps/gui/plug/quick/_textbufdoc.py:74
+#: ../gramps/gui/plug/quick/_textbufdoc.py:154
+#: ../gramps/gui/plug/quick/_textbufdoc.py:156
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:216
+#: ../gramps/plugins/gramplet/gramplet.gpr.py:223
+msgid "Quick View"
+msgstr "Быстрый просмотр"
+
 #: ../gramps/gui/plug/quick/_quicktable.py:134
 #: ../gramps/plugins/gramplet/descendant.py:113
 msgid "Copy all"
@@ -18434,14 +18664,6 @@ msgstr "Копировать всё"
 #: ../gramps/gui/plug/quick/_quicktable.py:161
 msgid "See data not in Filter"
 msgstr "Смотреть данные, неподходящие под фильтр"
-
-#: ../gramps/gui/plug/quick/_textbufdoc.py:74
-#: ../gramps/gui/plug/quick/_textbufdoc.py:154
-#: ../gramps/gui/plug/quick/_textbufdoc.py:156
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:216
-#: ../gramps/plugins/gramplet/gramplet.gpr.py:223
-msgid "Quick View"
-msgstr "Быстрый просмотр"
 
 #: ../gramps/gui/plug/report/_bookdialog.py:92
 msgid "Generate_Book_dialog"
@@ -18527,12 +18749,12 @@ msgid "Please select a book item to configure."
 msgstr "Выберите элемент книги для настройки."
 
 #: ../gramps/gui/plug/report/_bookdialog.py:631
-#: ../gramps/gui/views/bookmarks.py:293 ../gramps/gui/views/tags.py:456
+#: ../gramps/gui/views/bookmarks.py:292 ../gramps/gui/views/tags.py:456
 msgid "_Up"
 msgstr "_Вверх"
 
 #: ../gramps/gui/plug/report/_bookdialog.py:632
-#: ../gramps/gui/views/bookmarks.py:294 ../gramps/gui/views/tags.py:457
+#: ../gramps/gui/views/bookmarks.py:293 ../gramps/gui/views/tags.py:457
 msgid "_Down"
 msgstr "В_низ"
 
@@ -18652,7 +18874,7 @@ msgstr "Стиль"
 #: ../gramps/plugins/drawreport/timeline.py:414
 #: ../gramps/plugins/graph/gvfamilylines.py:120
 #: ../gramps/plugins/graph/gvhourglass.py:364
-#: ../gramps/plugins/graph/gvrelgraph.py:795
+#: ../gramps/plugins/graph/gvrelgraph.py:797
 #: ../gramps/plugins/textreport/alphabeticalindex.py:93
 #: ../gramps/plugins/textreport/ancestorreport.py:288
 #: ../gramps/plugins/textreport/birthdayreport.py:471
@@ -18670,7 +18892,7 @@ msgstr "Стиль"
 #: ../gramps/plugins/textreport/summary.py:286
 #: ../gramps/plugins/textreport/tableofcontents.py:92
 #: ../gramps/plugins/textreport/tagreport.py:901
-#: ../gramps/plugins/webreport/narrativeweb.py:1612
+#: ../gramps/plugins/webreport/narrativeweb.py:1613
 #: ../gramps/plugins/webreport/webcal.py:1656
 msgid "Report Options"
 msgstr "Параметры отчёта"
@@ -18982,11 +19204,6 @@ msgstr ""
 msgid "Spelling checker initialization failed: %s"
 msgstr "Ошибка при инициализации проверки правописания: %s"
 
-#: ../gramps/gui/tipofday.py:67 ../gramps/gui/tipofday.py:68
-#: ../gramps/gui/tipofday.py:121
-msgid "Tip of the Day"
-msgstr "Совет дня"
-
 #: ../gramps/gui/tipofday.py:87
 msgid "Failed to display tip of the day"
 msgstr "Не удалось показать совет дня"
@@ -19001,10 +19218,6 @@ msgstr ""
 "Не удалось прочитать советы из внешнего файла.\n"
 "\n"
 "%s"
-
-#: ../gramps/gui/undohistory.py:73
-msgid "Undo History"
-msgstr "История откатов"
 
 #: ../gramps/gui/undohistory.py:84 ../gramps/gui/viewmanager.py:1120
 msgid "_Undo"
@@ -19160,11 +19373,11 @@ msgstr "Автоматическое резервное копирование..
 msgid "Error saving backup data"
 msgstr "Ошибка сохранения резервной копии"
 
-#: ../gramps/gui/viewmanager.py:1482
+#: ../gramps/gui/viewmanager.py:1481
 msgid "Failed Loading View"
 msgstr "Не удалось загрузить вид"
 
-#: ../gramps/gui/viewmanager.py:1483
+#: ../gramps/gui/viewmanager.py:1482
 #, python-format
 msgid ""
 "The view %(name)s did not load and reported an error.\n"
@@ -19189,11 +19402,11 @@ msgstr ""
 "Если не хотите, чтобы Gramps пыталась загрузить этот вид в следующий раз, "
 "спрячьте его, с помощью «Справка / Менеджер дополнений»."
 
-#: ../gramps/gui/viewmanager.py:1575
+#: ../gramps/gui/viewmanager.py:1574
 msgid "Failed Loading Plugin"
 msgstr "Ошибка загрузки модуля"
 
-#: ../gramps/gui/viewmanager.py:1576
+#: ../gramps/gui/viewmanager.py:1575
 #, python-format
 msgid ""
 "The plugin %(name)s did not load and reported an error.\n"
@@ -19218,55 +19431,55 @@ msgstr ""
 "Если не хотите, чтобы Gramps пыталась загрузить этот модуль в следующий раз, "
 "спрячьте его, с помощью «Справка / Менеджер дополнений»."
 
-#: ../gramps/gui/viewmanager.py:1656
+#: ../gramps/gui/viewmanager.py:1655
 msgid "Gramps XML Backup"
 msgstr "Резервная копия Gramps в XML"
 
-#: ../gramps/gui/viewmanager.py:1685
+#: ../gramps/gui/viewmanager.py:1684
 msgid "File:"
 msgstr "Файл:"
 
-#: ../gramps/gui/viewmanager.py:1717
+#: ../gramps/gui/viewmanager.py:1716
 msgid "Media:"
 msgstr "Альбом:"
 
-#: ../gramps/gui/viewmanager.py:1724
+#: ../gramps/gui/viewmanager.py:1723
 #: ../gramps/plugins/gramplet/statsgramplet.py:196
 #: ../gramps/plugins/webreport/statistics.py:145
 msgid "Megabyte|MB"
 msgstr "Мб"
 
-#: ../gramps/gui/viewmanager.py:1726
+#: ../gramps/gui/viewmanager.py:1725
 msgid "Exclude"
 msgstr "Исключить"
 
-#: ../gramps/gui/viewmanager.py:1746
+#: ../gramps/gui/viewmanager.py:1745
 msgid "Backup file already exists! Overwrite?"
 msgstr "Файл с резервной копией уже существует! Перезаписать?"
 
-#: ../gramps/gui/viewmanager.py:1747
+#: ../gramps/gui/viewmanager.py:1746
 #, python-format
 msgid "The file '%s' exists."
 msgstr "Файл «%s» уже существует."
 
-#: ../gramps/gui/viewmanager.py:1748
+#: ../gramps/gui/viewmanager.py:1747
 msgid "Proceed and overwrite"
 msgstr "Продолжить и перезаписать"
 
-#: ../gramps/gui/viewmanager.py:1749
+#: ../gramps/gui/viewmanager.py:1748
 msgid "Cancel the backup"
 msgstr "Отменить резервное копирование"
 
-#: ../gramps/gui/viewmanager.py:1764
+#: ../gramps/gui/viewmanager.py:1763
 msgid "Making backup..."
 msgstr "Создание резервной копии..."
 
-#: ../gramps/gui/viewmanager.py:1777
+#: ../gramps/gui/viewmanager.py:1776
 #, python-format
 msgid "Backup saved to '%s'"
 msgstr "Резервная копия сохранена в '%s'"
 
-#: ../gramps/gui/viewmanager.py:1780
+#: ../gramps/gui/viewmanager.py:1779
 msgid "Backup aborted"
 msgstr "Резервное копирование прервано"
 
@@ -19275,8 +19488,8 @@ msgid "manual|Bookmarks"
 msgstr "Закладки"
 
 #. this is meaningless while it's modal
-#: ../gramps/gui/views/bookmarks.py:266 ../gramps/gui/views/bookmarks.py:276
-#: ../gramps/gui/views/bookmarks.py:372
+#: ../gramps/gui/views/bookmarks.py:265 ../gramps/gui/views/bookmarks.py:275
+#: ../gramps/gui/views/bookmarks.py:371
 #: ../gramps/plugins/lib/libpersonview.py:205
 #: ../gramps/plugins/lib/libplaceview.py:288
 #: ../gramps/plugins/view/citationlistview.py:180
@@ -19293,13 +19506,13 @@ msgstr "Закладки"
 #: ../gramps/plugins/view/geoplaces.py:103
 #: ../gramps/plugins/view/mediaview.py:253
 #: ../gramps/plugins/view/noteview.py:153
-#: ../gramps/plugins/view/pedigreeview.py:689
+#: ../gramps/plugins/view/pedigreeview.py:683
 #: ../gramps/plugins/view/relview.py:427 ../gramps/plugins/view/repoview.py:166
 #: ../gramps/plugins/view/sourceview.py:152
 msgid "Organize Bookmarks"
 msgstr "Редактор закладок"
 
-#: ../gramps/gui/views/bookmarks.py:475
+#: ../gramps/gui/views/bookmarks.py:474
 msgid "Cannot bookmark this reference"
 msgstr "Не удалось добавить закладку"
 
@@ -19362,19 +19575,19 @@ msgstr "Удалить %s?"
 msgid "Column clicked, sorting..."
 msgstr "Выбран столбец, сортировка..."
 
-#: ../gramps/gui/views/listview.py:1051
+#: ../gramps/gui/views/listview.py:1061
 msgid "Export View as Spreadsheet"
 msgstr "Экспортировать вид в таблицу"
 
-#: ../gramps/gui/views/listview.py:1064
+#: ../gramps/gui/views/listview.py:1074
 msgid "CSV"
 msgstr "CSV"
 
-#: ../gramps/gui/views/listview.py:1065
+#: ../gramps/gui/views/listview.py:1075
 msgid "OpenDocument Spreadsheet"
 msgstr "Таблица OpenDocument"
 
-#: ../gramps/gui/views/listview.py:1256
+#: ../gramps/gui/views/listview.py:1266
 msgid "Columns"
 msgstr "Колонки"
 
@@ -19394,21 +19607,11 @@ msgstr "Нельзя создать закладку: никто не выдел
 msgid "No Home Person"
 msgstr "Базовое лицо не назначено"
 
-#: ../gramps/gui/views/navigationview.py:339
-msgid ""
-"You need to set a 'default person' to go to. Select the People View, select "
-"the person you want as 'Home Person', then confirm your choice via the menu "
-"Edit -> Set Home Person."
-msgstr ""
-"Нужно назначить «базовое лицо». Выберите вид «Люди», выберите лицо, которое "
-"хотите назначить в качестве базового, затем подтвердите выбор из меню "
-"«Правка -> Установить базовое лицо»."
-
 #: ../gramps/gui/views/navigationview.py:324
 msgid ""
 "You need to set a 'default person' to go to. Select the People View, select "
 "the person you want as 'Home Person', then confirm your choice via the menu "
-"Edit ->Set Home Person."
+"Edit -> Set Home Person."
 msgstr ""
 "Нужно назначить «базовое лицо». Выберите вид «Люди», выберите лицо, которое "
 "хотите назначить в качестве базового, затем подтвердите выбор из меню "
@@ -19423,6 +19626,14 @@ msgstr "Перейти на Gramps ID"
 #, python-format
 msgid "Error: %s is not a valid Gramps ID"
 msgstr "Ошибка: %s не является корректным Gramps ID"
+
+#: ../gramps/gui/views/pageview.py:103
+msgid "_Bottombar"
+msgstr "_Нижняя панель"
+
+#: ../gramps/gui/views/pageview.py:103
+msgid "_Sidebar"
+msgstr "_Боковая панель"
 
 #: ../gramps/gui/views/pageview.py:562
 #, python-format
@@ -19444,6 +19655,18 @@ msgstr "Настроить вид %s"
 #, python-format
 msgid "View %(name)s: %(msg)s"
 msgstr "Вид %(name)s: %(msg)s"
+
+#: ../gramps/gui/views/tags.py:71
+msgid "Tag selected rows"
+msgstr "Добавить метки к выделенным строкам"
+
+#: ../gramps/gui/views/tags.py:93
+msgid "New Tag..."
+msgstr "Новая метка..."
+
+#: ../gramps/gui/views/tags.py:93
+msgid "Organize Tags..."
+msgstr "Управление метками..."
 
 #: ../gramps/gui/views/tags.py:112
 msgid "manual|Organize_Tags_Window"
@@ -19555,43 +19778,43 @@ msgstr "Развернуть"
 msgid "Collapse this section"
 msgstr "Свернуть"
 
-#: ../gramps/gui/widgets/fanchart.py:1582 ../gramps/plugins/view/relview.py:966
+#: ../gramps/gui/widgets/fanchart.py:1825 ../gramps/plugins/view/relview.py:966
 msgid "Edit family"
 msgstr "Редактировать семью"
 
-#: ../gramps/gui/widgets/fanchart.py:1598 ../gramps/plugins/view/relview.py:967
+#: ../gramps/gui/widgets/fanchart.py:1841 ../gramps/plugins/view/relview.py:967
 msgid "Reorder families"
 msgstr "Упорядочить семьи"
 
-#: ../gramps/gui/widgets/fanchart.py:1604
-#: ../gramps/plugins/view/pedigreeview.py:1749
-#: ../gramps/plugins/view/pedigreeview.py:1977
+#: ../gramps/gui/widgets/fanchart.py:1847
+#: ../gramps/plugins/view/pedigreeview.py:1743
+#: ../gramps/plugins/view/pedigreeview.py:1971
 msgid "_Copy"
 msgstr "_Копировать"
 
 #. Go over siblings and build their menu
-#: ../gramps/gui/widgets/fanchart.py:1648
+#: ../gramps/gui/widgets/fanchart.py:1891
 #: ../gramps/plugins/quickview/quickview.gpr.py:319
-#: ../gramps/plugins/view/pedigreeview.py:1793
+#: ../gramps/plugins/view/pedigreeview.py:1787
 #: ../gramps/plugins/view/relview.py:1068
 msgid "Siblings"
 msgstr "Братья/Сёстры"
 
 #. Go over parents and build their menu
-#: ../gramps/gui/widgets/fanchart.py:1786
-#: ../gramps/plugins/view/pedigreeview.py:1920
+#: ../gramps/gui/widgets/fanchart.py:2037
+#: ../gramps/plugins/view/pedigreeview.py:1914
 msgid "Related"
 msgstr "Связанные"
 
-#: ../gramps/gui/widgets/fanchart.py:1834
+#: ../gramps/gui/widgets/fanchart.py:2085
 msgid "Add partner to person"
 msgstr "Добавить партнёра к лицу"
 
-#: ../gramps/gui/widgets/fanchart.py:1841
+#: ../gramps/gui/widgets/fanchart.py:2092
 msgid "Add a person"
 msgstr "Добавить новое лицо"
 
-#: ../gramps/gui/widgets/fanchart.py:1916
+#: ../gramps/gui/widgets/fanchart.py:2182
 #: ../gramps/plugins/view/relview.py:1709
 msgid "Add Child to Family"
 msgstr "Добавить ребёнка в семью"
@@ -19618,6 +19841,7 @@ msgstr ""
 "или восстановить грамплеты."
 
 #: ../gramps/gui/widgets/grampletbar.py:487
+#: ../gramps/gui/widgets/grampletpane.py:1442
 msgid "Add a gramplet"
 msgstr "Добавить грамплет"
 
@@ -19656,19 +19880,23 @@ msgstr "Щёлкните правой кнопкой мыши, чтобы доб
 msgid "Untitled Gramplet"
 msgstr "Безымянный грамплет"
 
-#: ../gramps/gui/widgets/grampletpane.py:1574
+#: ../gramps/gui/widgets/grampletpane.py:1442
+msgid "Restore a gramplet"
+msgstr "Восстановить грамплет"
+
+#: ../gramps/gui/widgets/grampletpane.py:1573
 msgid "Number of Columns"
 msgstr "Количество колонок"
 
-#: ../gramps/gui/widgets/grampletpane.py:1579
+#: ../gramps/gui/widgets/grampletpane.py:1578
 msgid "Gramplet Layout"
 msgstr "Размещение грамплета"
 
-#: ../gramps/gui/widgets/grampletpane.py:1609
+#: ../gramps/gui/widgets/grampletpane.py:1608
 msgid "Use maximum height available"
 msgstr "Использовать всю доступную высоту"
 
-#: ../gramps/gui/widgets/grampletpane.py:1615
+#: ../gramps/gui/widgets/grampletpane.py:1614
 msgid "Height if not maximized"
 msgstr "Высота не максимизирована"
 
@@ -19683,11 +19911,11 @@ msgstr ""
 "Щелчок по кнопке «правка» (включается через конфигурационный диалог) для "
 "правки"
 
-#: ../gramps/gui/widgets/monitoredwidgets.py:651
+#: ../gramps/gui/widgets/monitoredwidgets.py:662
 msgid "Bad Date"
 msgstr "Неверная дата"
 
-#: ../gramps/gui/widgets/monitoredwidgets.py:654
+#: ../gramps/gui/widgets/monitoredwidgets.py:665
 msgid "Date more than one year in the future"
 msgstr "Эта дата более чем через год в будущем"
 
@@ -19727,6 +19955,26 @@ msgstr "Упорядочить отношения"
 #, python-format
 msgid "Reorder Relationships: %s"
 msgstr "Упорядочить отношения: %s"
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Background Color"
+msgstr "Цвет фона"
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Clear Markup"
+msgstr "Стереть разметку"
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Font Color"
+msgstr "Цвет шрифта"
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Redo"
+msgstr "Вернуть"
+
+#: ../gramps/gui/widgets/styledtexteditor.py:78
+msgid "Undo"
+msgstr "Откатить"
 
 #: ../gramps/gui/widgets/styledtexteditor.py:401
 msgid ""
@@ -20053,13 +20301,13 @@ msgid "of %d"
 msgstr "из %d"
 
 #: ../gramps/plugins/docgen/htmldoc.py:273
-#: ../gramps/plugins/webreport/narrativeweb.py:1516
+#: ../gramps/plugins/webreport/narrativeweb.py:1517
 #: ../gramps/plugins/webreport/webcal.py:270
 msgid "Possible destination error"
 msgstr "Возможно, некорректный выбор директории назначения"
 
 #: ../gramps/plugins/docgen/htmldoc.py:274
-#: ../gramps/plugins/webreport/narrativeweb.py:1517
+#: ../gramps/plugins/webreport/narrativeweb.py:1518
 #: ../gramps/plugins/webreport/webcal.py:271
 msgid ""
 "You appear to have set your target directory to a directory used for data "
@@ -20156,7 +20404,7 @@ msgstr "Граф предков для %s"
 #: ../gramps/plugins/drawreport/descendtree.py:689
 #: ../gramps/plugins/drawreport/fanchart.py:194
 #: ../gramps/plugins/graph/gvhourglass.py:109
-#: ../gramps/plugins/graph/gvrelgraph.py:182
+#: ../gramps/plugins/graph/gvrelgraph.py:184
 #: ../gramps/plugins/textreport/ancestorreport.py:117
 #: ../gramps/plugins/textreport/birthdayreport.py:115
 #: ../gramps/plugins/textreport/descendreport.py:453
@@ -20187,7 +20435,7 @@ msgstr "Печать древа..."
 #: ../gramps/plugins/drawreport/calendarreport.py:472
 #: ../gramps/plugins/drawreport/fanchart.py:689
 #: ../gramps/plugins/graph/gvhourglass.py:366
-#: ../gramps/plugins/graph/gvrelgraph.py:805
+#: ../gramps/plugins/graph/gvrelgraph.py:807
 #: ../gramps/plugins/textreport/ancestorreport.py:290
 #: ../gramps/plugins/textreport/descendreport.py:522
 #: ../gramps/plugins/textreport/detancestralreport.py:831
@@ -20387,7 +20635,7 @@ msgstr "Включать ли пустые страницы."
 #: ../gramps/plugins/drawreport/timeline.py:435
 #: ../gramps/plugins/graph/gvfamilylines.py:169
 #: ../gramps/plugins/graph/gvhourglass.py:402
-#: ../gramps/plugins/graph/gvrelgraph.py:833
+#: ../gramps/plugins/graph/gvrelgraph.py:841
 #: ../gramps/plugins/textreport/ancestorreport.py:310
 #: ../gramps/plugins/textreport/birthdayreport.py:500
 #: ../gramps/plugins/textreport/descendreport.py:557
@@ -20703,7 +20951,7 @@ msgstr "Задайте фильтр, чтобы ограничить лиц, к�
 # !!!FIXME!!!
 #: ../gramps/plugins/drawreport/calendarreport.py:473
 #: ../gramps/plugins/drawreport/fanchart.py:690
-#: ../gramps/plugins/graph/gvrelgraph.py:806
+#: ../gramps/plugins/graph/gvrelgraph.py:808
 #: ../gramps/plugins/textreport/ancestorreport.py:291
 #: ../gramps/plugins/textreport/descendreport.py:523
 #: ../gramps/plugins/textreport/detancestralreport.py:832
@@ -21422,7 +21670,7 @@ msgstr "Определяет какие люди будут включены в 
 #: ../gramps/plugins/textreport/indivcomplete.py:1068
 #: ../gramps/plugins/textreport/recordsreport.py:223
 #: ../gramps/plugins/tool/sortevents.py:173
-#: ../gramps/plugins/webreport/narrativeweb.py:1644
+#: ../gramps/plugins/webreport/narrativeweb.py:1645
 #: ../gramps/plugins/webreport/webcal.py:1677
 msgid "Filter Person"
 msgstr "Фильтр по лицу"
@@ -21570,7 +21818,7 @@ msgstr "Определяет какие люди будут включены в 
 #: ../gramps/plugins/drawreport/timeline.py:423
 #: ../gramps/plugins/textreport/recordsreport.py:224
 #: ../gramps/plugins/tool/sortevents.py:174
-#: ../gramps/plugins/webreport/narrativeweb.py:1645
+#: ../gramps/plugins/webreport/narrativeweb.py:1646
 #: ../gramps/plugins/webreport/webcal.py:1678
 msgid "The center person for the filter"
 msgstr "Главное лицо для фильтра"
@@ -22074,9 +22322,9 @@ msgstr "Применить"
 msgid "Double-click on a row to edit the selected event."
 msgstr "Щёлкните на строке дважды для правки выбранного события."
 
-#: ../gramps/plugins/gramplet/fanchart2waygramplet.py:86
-#: ../gramps/plugins/gramplet/fanchartdescgramplet.py:64
-#: ../gramps/plugins/gramplet/fanchartgramplet.py:67
+#: ../gramps/plugins/gramplet/fanchart2waygramplet.py:78
+#: ../gramps/plugins/gramplet/fanchartdescgramplet.py:65
+#: ../gramps/plugins/gramplet/fanchartgramplet.py:68
 msgid ""
 "Click to expand/contract person\n"
 "Right-click for options\n"
@@ -22388,7 +22636,7 @@ msgstr "Показывает имена в виде текстового обл�
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:199
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:205
-#: ../gramps/plugins/view/pedigreeview.py:530
+#: ../gramps/plugins/view/pedigreeview.py:528
 #: ../gramps/plugins/view/view.gpr.py:127
 #: ../gramps/plugins/webreport/person.py:1346
 msgid "Pedigree"
@@ -23130,8 +23378,8 @@ msgstr "Наведите курсор на имя для дополнитель�
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:58
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:67
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:78
-#: ../gramps/plugins/view/fanchartdescview.py:263
-#: ../gramps/plugins/view/fanchartview.py:360
+#: ../gramps/plugins/view/fanchartdescview.py:280
+#: ../gramps/plugins/view/fanchartview.py:378
 msgid "Max generations"
 msgstr "Максимальное число поколений"
 
@@ -23770,7 +24018,7 @@ msgstr ""
 "Graphviz."
 
 #: ../gramps/plugins/graph/graphplugins.gpr.py:81
-#: ../gramps/plugins/graph/gvrelgraph.py:205
+#: ../gramps/plugins/graph/gvrelgraph.py:207
 msgid "Relationship Graph"
 msgstr "Граф отношений"
 
@@ -23870,19 +24118,19 @@ msgstr ""
 
 #: ../gramps/plugins/graph/gvfamilylines.py:144
 #: ../gramps/plugins/graph/gvhourglass.py:380
-#: ../gramps/plugins/graph/gvrelgraph.py:810
+#: ../gramps/plugins/graph/gvrelgraph.py:812
 msgid "Arrowhead direction"
 msgstr "Направление стрелок"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:147
 #: ../gramps/plugins/graph/gvhourglass.py:383
-#: ../gramps/plugins/graph/gvrelgraph.py:813
+#: ../gramps/plugins/graph/gvrelgraph.py:815
 msgid "Choose the direction that the arrows point."
 msgstr "Выберите направление стрелок."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:150
 #: ../gramps/plugins/graph/gvhourglass.py:386
-#: ../gramps/plugins/graph/gvrelgraph.py:816
+#: ../gramps/plugins/graph/gvrelgraph.py:818
 msgid "Graph coloring"
 msgstr "Расцветка графа"
 
@@ -23983,7 +24231,7 @@ msgstr ""
 "Включать или нет число детей для семей, в которых более одного ребенка."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:246
-#: ../gramps/plugins/graph/gvrelgraph.py:896
+#: ../gramps/plugins/graph/gvrelgraph.py:904
 msgid "Include thumbnail images of people"
 msgstr "Включать изображения людей"
 
@@ -23996,17 +24244,17 @@ msgid "Thumbnail location"
 msgstr "Позиция изображения"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:255
-#: ../gramps/plugins/graph/gvrelgraph.py:903
+#: ../gramps/plugins/graph/gvrelgraph.py:911
 msgid "Above the name"
 msgstr "Над именем"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:256
-#: ../gramps/plugins/graph/gvrelgraph.py:904
+#: ../gramps/plugins/graph/gvrelgraph.py:912
 msgid "Beside the name"
 msgstr "Под именем"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:257
-#: ../gramps/plugins/graph/gvrelgraph.py:906
+#: ../gramps/plugins/graph/gvrelgraph.py:914
 msgid "Where the thumbnail image should appear relative to the name"
 msgstr "Размещение изображения относительно имени человека"
 
@@ -24034,25 +24282,25 @@ msgstr "Цвета для отображения разных семейных �
 
 #: ../gramps/plugins/graph/gvfamilylines.py:280
 #: ../gramps/plugins/graph/gvhourglass.py:420
-#: ../gramps/plugins/graph/gvrelgraph.py:933
+#: ../gramps/plugins/graph/gvrelgraph.py:941
 msgid "The color to use to display men."
 msgstr "Цвет для отображения мужчин."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:284
 #: ../gramps/plugins/graph/gvhourglass.py:424
-#: ../gramps/plugins/graph/gvrelgraph.py:937
+#: ../gramps/plugins/graph/gvrelgraph.py:945
 msgid "The color to use to display women."
 msgstr "Цвет для отображения женщин."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:288
 #: ../gramps/plugins/graph/gvhourglass.py:428
-#: ../gramps/plugins/graph/gvrelgraph.py:942
+#: ../gramps/plugins/graph/gvrelgraph.py:950
 msgid "The color to use when the gender is unknown."
 msgstr "Цвет для отображения людей неуказанного пола."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:293
 #: ../gramps/plugins/graph/gvhourglass.py:433
-#: ../gramps/plugins/graph/gvrelgraph.py:947
+#: ../gramps/plugins/graph/gvrelgraph.py:955
 msgid "The color to use to display families."
 msgstr "Цвет для отображения семей."
 
@@ -24159,7 +24407,7 @@ msgid "The number of generations of ancestors to include in the graph"
 msgstr "Сколько поколений предков отображать на графе"
 
 #: ../gramps/plugins/graph/gvhourglass.py:389
-#: ../gramps/plugins/graph/gvrelgraph.py:819
+#: ../gramps/plugins/graph/gvrelgraph.py:821
 msgid ""
 "Males will be shown with blue, females with red.  If the sex of an "
 "individual is unknown it will be shown with gray."
@@ -24169,12 +24417,12 @@ msgstr ""
 
 #. see bug report #2180
 #: ../gramps/plugins/graph/gvhourglass.py:394
-#: ../gramps/plugins/graph/gvrelgraph.py:825
+#: ../gramps/plugins/graph/gvrelgraph.py:827
 msgid "Use rounded corners"
 msgstr "Закруглять углы"
 
 #: ../gramps/plugins/graph/gvhourglass.py:396
-#: ../gramps/plugins/graph/gvrelgraph.py:826
+#: ../gramps/plugins/graph/gvrelgraph.py:828
 msgid "Use rounded corners to differentiate between women and men."
 msgstr ""
 "Использовать закругленные углы для обозначения различия между мужчинами и "
@@ -24182,7 +24430,7 @@ msgstr ""
 
 #. ###############################
 #: ../gramps/plugins/graph/gvhourglass.py:416
-#: ../gramps/plugins/graph/gvrelgraph.py:929
+#: ../gramps/plugins/graph/gvrelgraph.py:937
 msgid "Graph Style"
 msgstr "Стиль графа"
 
@@ -24209,74 +24457,84 @@ msgid ""
 "informations."
 msgstr ""
 
-#: ../gramps/plugins/graph/gvrelgraph.py:206
+#: ../gramps/plugins/graph/gvrelgraph.py:208
 #: ../gramps/plugins/textreport/indivcomplete.py:834
 #: ../gramps/plugins/textreport/notelinkreport.py:103
 #: ../gramps/plugins/textreport/placereport.py:160
 msgid "Generating report"
 msgstr "Создаётся отчёт"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:801
+#: ../gramps/plugins/graph/gvrelgraph.py:803
 msgid "Determines what people are included in the graph"
 msgstr "Определяет каких людей следует включать в граф"
 
+#. see bug report #11112
+#: ../gramps/plugins/graph/gvrelgraph.py:833
+msgid "Use hexagons"
+msgstr "Использовать шестиугольники"
+
+#: ../gramps/plugins/graph/gvrelgraph.py:834
+msgid "Use hexagons to differentiate those of unknown gender."
+msgstr ""
+"Использовать шестиугольники для выделения лиц с неизвестным полом."
+
 #. ###############################
-#: ../gramps/plugins/graph/gvrelgraph.py:854
+#: ../gramps/plugins/graph/gvrelgraph.py:862
 msgid "Dates and/or Places"
 msgstr "Даты и/или Места"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:855
+#: ../gramps/plugins/graph/gvrelgraph.py:863
 msgid "Do not include any dates or places"
 msgstr "Не включать даты и места"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:856
+#: ../gramps/plugins/graph/gvrelgraph.py:864
 msgid "Include (birth, marriage, death) dates, but no places"
 msgstr "Включать даты рождения, брака и смерти, но не места"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:858
+#: ../gramps/plugins/graph/gvrelgraph.py:866
 msgid "Include (birth, marriage, death) dates, and places"
 msgstr "Включать даты рождения, брака, смерти и места"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:860
+#: ../gramps/plugins/graph/gvrelgraph.py:868
 msgid "Include (birth, marriage, death) dates, and places if no dates"
 msgstr "Включать даты рождения, брака, смерти и места. если нет дат"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:862
+#: ../gramps/plugins/graph/gvrelgraph.py:870
 msgid "Include (birth, marriage, death) years, but no places"
 msgstr "Включать года рождения, брака и смерти, но не места"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:864
+#: ../gramps/plugins/graph/gvrelgraph.py:872
 msgid "Include (birth, marriage, death) years, and places"
 msgstr "Включать года рождения, брака, смерти и места"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:866
+#: ../gramps/plugins/graph/gvrelgraph.py:874
 msgid "Include (birth, marriage, death) places, but no dates"
 msgstr "Включать мета рождения, брака и смерти, но не даты"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:868
+#: ../gramps/plugins/graph/gvrelgraph.py:876
 msgid "Include (birth, marriage, death) dates and places on same line"
 msgstr "Включать даты (рождения, брака, смерти) и места в одну строку"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:871
+#: ../gramps/plugins/graph/gvrelgraph.py:879
 msgid "Whether to include dates and/or places"
 msgstr "Включать или нет даты и/или места"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:874
+#: ../gramps/plugins/graph/gvrelgraph.py:882
 msgid "Show all family nodes"
 msgstr "Показать все семейные узлы"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:875
+#: ../gramps/plugins/graph/gvrelgraph.py:883
 msgid ""
 "Show family nodes even if the output contains only one member of the family."
 msgstr ""
 "Показывать семейные узлы даже, если в выводе представлен только один член "
 "семьи."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:879
+#: ../gramps/plugins/graph/gvrelgraph.py:887
 msgid "Include URLs"
 msgstr "Включать URL"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:880
+#: ../gramps/plugins/graph/gvrelgraph.py:888
 msgid ""
 "Include a URL in each graph node so that PDF and imagemap files can be "
 "generated that contain active links to the files generated by the 'Narrated "
@@ -24286,68 +24544,68 @@ msgstr ""
 "или imagemap содержали ссылки на файлы, созданные отчётом «Повествовательный "
 "веб-сайт»."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:888
+#: ../gramps/plugins/graph/gvrelgraph.py:896
 #: ../gramps/plugins/textreport/birthdayreport.py:568
 #: ../gramps/plugins/textreport/indivcomplete.py:1145
 msgid "Include relationship to center person"
 msgstr "Включать родство по отношению к центральному лицу"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:889
+#: ../gramps/plugins/graph/gvrelgraph.py:897
 msgid "Whether to show every person's relationship to the center person"
 msgstr "Включать ли родство каждого лица по отношению к центральному лицу"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:898
+#: ../gramps/plugins/graph/gvrelgraph.py:906
 msgid "Whether to include thumbnails of people."
 msgstr "Включать или нет изображения людей."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:902
+#: ../gramps/plugins/graph/gvrelgraph.py:910
 msgid "Thumbnail Location"
 msgstr "Размещение изображения"
 
 #. occupation = BooleanOption(_("Include occupation"), False)
-#: ../gramps/plugins/graph/gvrelgraph.py:910
+#: ../gramps/plugins/graph/gvrelgraph.py:918
 msgid "Include occupation"
 msgstr "Включить данные о профессии"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:911
+#: ../gramps/plugins/graph/gvrelgraph.py:919
 msgid "Do not include any occupation"
 msgstr "Не включать данные о профессии"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:912
+#: ../gramps/plugins/graph/gvrelgraph.py:920
 msgid "Include description of most recent occupation"
 msgstr "Включать описание профессии"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:914
+#: ../gramps/plugins/graph/gvrelgraph.py:922
 msgid "Include date, description and place of all occupations"
 msgstr "Включать даты, описания и места всех профессий"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:916
+#: ../gramps/plugins/graph/gvrelgraph.py:924
 msgid "Whether to include the last occupation"
 msgstr "Включать ли последнюю профессию"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:920
+#: ../gramps/plugins/graph/gvrelgraph.py:928
 msgid "Include relationship debugging numbers also"
 msgstr "Включать также отладочные числа отношений"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:923
+#: ../gramps/plugins/graph/gvrelgraph.py:931
 msgid ""
 "Whether to include 'Ga' and 'Gb' also, to debug the relationship calculator"
 msgstr "Необходимо ли включать 'Ga' и 'Gb', для отладки калькулятора отношений"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:951
+#: ../gramps/plugins/graph/gvrelgraph.py:959
 msgid "Indicate non-birth relationships with dotted lines"
 msgstr "Показывать пунктиром отношения, не являющиеся родительскими"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:952
+#: ../gramps/plugins/graph/gvrelgraph.py:960
 msgid "Non-birth relationships will show up as dotted lines in the graph."
 msgstr ""
 "Отношения, не являющиеся родительскими, будут показаны на графе пунктиром."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:956
+#: ../gramps/plugins/graph/gvrelgraph.py:964
 msgid "Show family nodes"
 msgstr "Показать семейные узлы"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:957
+#: ../gramps/plugins/graph/gvrelgraph.py:965
 msgid "Families will show up as ellipses, linked to parents and children."
 msgstr "Семьи будут показаны эллипсами, связывающими родителей и детей."
 
@@ -25658,7 +25916,7 @@ msgid "Common Law Marriage"
 msgstr "Гражданский брак"
 
 #: ../gramps/plugins/lib/libgedcom.py:699
-#: ../gramps/plugins/webreport/narrativeweb.py:1625
+#: ../gramps/plugins/webreport/narrativeweb.py:1626
 #: ../gramps/plugins/webreport/webcal.py:1661
 msgid "Destination"
 msgstr "Расположение"
@@ -29518,6 +29776,172 @@ msgstr "Удалить выделенное лицо"
 msgid "Merge the selected persons"
 msgstr "Объединить выделенные лица"
 
+#: ../gramps/plugins/lib/libpersonview.py:186
+#: ../gramps/plugins/lib/libplaceview.py:269
+#: ../gramps/plugins/view/citationlistview.py:161
+#: ../gramps/plugins/view/citationtreeview.py:303
+#: ../gramps/plugins/view/eventview.py:175
+#: ../gramps/plugins/view/familyview.py:134
+#: ../gramps/plugins/view/mediaview.py:234
+#: ../gramps/plugins/view/noteview.py:134
+#: ../gramps/plugins/view/repoview.py:147
+#: ../gramps/plugins/view/sourceview.py:133
+msgid "Export View..."
+msgstr "Экспортировать вид..."
+
+#: ../gramps/plugins/lib/libpersonview.py:194
+#: ../gramps/plugins/lib/libplaceview.py:277
+#: ../gramps/plugins/view/citationlistview.py:169
+#: ../gramps/plugins/view/citationtreeview.py:311
+#: ../gramps/plugins/view/eventview.py:183
+#: ../gramps/plugins/view/familyview.py:142
+#: ../gramps/plugins/view/fanchartview.py:172
+#: ../gramps/plugins/view/geoclose.py:99 ../gramps/plugins/view/geoevents.py:89
+#: ../gramps/plugins/view/geofamclose.py:97
+#: ../gramps/plugins/view/geofamily.py:89 ../gramps/plugins/view/geomoves.py:96
+#: ../gramps/plugins/view/geoperson.py:97
+#: ../gramps/plugins/view/geoplaces.py:92
+#: ../gramps/plugins/view/mediaview.py:242
+#: ../gramps/plugins/view/noteview.py:142
+#: ../gramps/plugins/view/pedigreeview.py:672
+#: ../gramps/plugins/view/relview.py:364 ../gramps/plugins/view/relview.py:416
+#: ../gramps/plugins/view/repoview.py:155
+#: ../gramps/plugins/view/sourceview.py:141
+msgid "_Add Bookmark"
+msgstr "_Добавить закладку"
+
+#: ../gramps/plugins/lib/libpersonview.py:206
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:289
+#: ../gramps/plugins/lib/libplaceview.py:332
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:181
+#: ../gramps/plugins/view/citationlistview.py:224
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:323
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:195
+#: ../gramps/plugins/view/eventview.py:238
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:154
+#: ../gramps/plugins/view/familyview.py:197
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/fanchartview.py:144
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:71 ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoevents.py:67
+#: ../gramps/plugins/view/geoevents.py:101
+#: ../gramps/plugins/view/geofamclose.py:69
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geofamily.py:67
+#: ../gramps/plugins/view/geofamily.py:101
+#: ../gramps/plugins/view/geomoves.py:68 ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:69
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/geoplaces.py:70
+#: ../gramps/plugins/view/geoplaces.py:104
+#: ../gramps/plugins/view/mediaview.py:254
+#: ../gramps/plugins/view/mediaview.py:297
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:154
+#: ../gramps/plugins/view/noteview.py:197
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/pedigreeview.py:652
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428 ../gramps/plugins/view/repoview.py:167
+#: ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:153
+#: ../gramps/plugins/view/sourceview.py:196
+#: ../gramps/plugins/view/sourceview.py:278
+msgid "_Back"
+msgstr "_Назад"
+
+#: ../gramps/plugins/lib/libpersonview.py:206
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/view/fanchartview.py:144
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:71 ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geofamclose.py:69
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geomoves.py:68 ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:69
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/pedigreeview.py:652
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/pedigreeview.py:1647
+#: ../gramps/plugins/view/relview.py:364 ../gramps/plugins/view/relview.py:428
+msgid "_Home"
+msgstr "До_мой"
+
+#: ../gramps/plugins/lib/libpersonview.py:226
+#: ../gramps/plugins/lib/libpersonview.py:303
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:303
+#: ../gramps/plugins/lib/libplaceview.py:362
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:195
+#: ../gramps/plugins/view/citationlistview.py:254
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:209
+#: ../gramps/plugins/view/eventview.py:268
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:168
+#: ../gramps/plugins/view/familyview.py:227
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/mediaview.py:268
+#: ../gramps/plugins/view/mediaview.py:327
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:168
+#: ../gramps/plugins/view/noteview.py:227
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/repoview.py:181
+#: ../gramps/plugins/view/repoview.py:240
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:167
+#: ../gramps/plugins/view/sourceview.py:226
+#: ../gramps/plugins/view/sourceview.py:278
+msgid "_Add..."
+msgstr "До_бавить..."
+
+#: ../gramps/plugins/lib/libpersonview.py:226
+#: ../gramps/plugins/lib/libpersonview.py:303
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:303
+#: ../gramps/plugins/lib/libplaceview.py:362
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:195
+#: ../gramps/plugins/view/citationlistview.py:254
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:209
+#: ../gramps/plugins/view/eventview.py:268
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:168
+#: ../gramps/plugins/view/familyview.py:227
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/mediaview.py:268
+#: ../gramps/plugins/view/mediaview.py:327
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:168
+#: ../gramps/plugins/view/noteview.py:227
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/repoview.py:181
+#: ../gramps/plugins/view/repoview.py:240
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:167
+#: ../gramps/plugins/view/sourceview.py:226
+#: ../gramps/plugins/view/sourceview.py:278
+msgid "_Merge..."
+msgstr "_Объединить..."
+
 #: ../gramps/plugins/lib/libpersonview.py:245
 #: ../gramps/plugins/lib/libpersonview.py:403
 #: ../gramps/plugins/lib/libplaceview.py:322
@@ -29540,6 +29964,100 @@ msgstr "Объединить выделенные лица"
 #: ../gramps/plugins/view/sourceview.py:315
 msgid "action|_Edit..."
 msgstr "Редактировать..."
+
+#: ../gramps/plugins/lib/libpersonview.py:246
+#: ../gramps/plugins/view/pedigreeview.py:684
+#: ../gramps/plugins/view/relview.py:385
+msgid "Person Filter Editor"
+msgstr "Редактор фильтров людей"
+
+#: ../gramps/plugins/lib/libpersonview.py:246
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/view/pedigreeview.py:1657
+msgid "Set _Home Person"
+msgstr "У_становить базовое лицо"
+
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428
+msgid "Go to the default person"
+msgstr "Перейти на базовое лицо"
+
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libplaceview.py:332
+#: ../gramps/plugins/view/citationlistview.py:224
+#: ../gramps/plugins/view/citationtreeview.py:374
+#: ../gramps/plugins/view/eventview.py:238
+#: ../gramps/plugins/view/familyview.py:197
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoevents.py:101
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geofamily.py:101
+#: ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/geoplaces.py:104
+#: ../gramps/plugins/view/mediaview.py:297
+#: ../gramps/plugins/view/noteview.py:197
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428 ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/sourceview.py:196
+msgid "Go to the next object in the history"
+msgstr "Перейти на следующий объект в истории"
+
+#: ../gramps/plugins/lib/libpersonview.py:260
+#: ../gramps/plugins/lib/libplaceview.py:332
+#: ../gramps/plugins/view/citationlistview.py:224
+#: ../gramps/plugins/view/citationtreeview.py:374
+#: ../gramps/plugins/view/eventview.py:238
+#: ../gramps/plugins/view/familyview.py:197
+#: ../gramps/plugins/view/fanchartview.py:184
+#: ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoevents.py:101
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geofamily.py:101
+#: ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geoperson.py:109
+#: ../gramps/plugins/view/geoplaces.py:104
+#: ../gramps/plugins/view/mediaview.py:297
+#: ../gramps/plugins/view/noteview.py:197
+#: ../gramps/plugins/view/pedigreeview.py:693
+#: ../gramps/plugins/view/relview.py:428 ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/sourceview.py:196
+msgid "Go to the previous object in the history"
+msgstr "Перейти на предыдущий объект в истории"
+
+#: ../gramps/plugins/lib/libpersonview.py:303
+#: ../gramps/plugins/lib/libplaceview.py:362
+#: ../gramps/plugins/view/citationlistview.py:254
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/eventview.py:268
+#: ../gramps/plugins/view/familyview.py:227
+#: ../gramps/plugins/view/mediaview.py:327
+#: ../gramps/plugins/view/noteview.py:227 ../gramps/plugins/view/relview.py:385
+#: ../gramps/plugins/view/relview.py:471 ../gramps/plugins/view/repoview.py:240
+#: ../gramps/plugins/view/sourceview.py:226
+msgid "Edit..."
+msgstr "Редактировать..."
+
+#: ../gramps/plugins/lib/libpersonview.py:355
+#: ../gramps/plugins/lib/libplaceview.py:415
+#: ../gramps/plugins/view/citationlistview.py:306
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/eventview.py:320
+#: ../gramps/plugins/view/familyview.py:279
+#: ../gramps/plugins/view/mediaview.py:395
+#: ../gramps/plugins/view/noteview.py:279
+#: ../gramps/plugins/view/repoview.py:292
+#: ../gramps/plugins/view/sourceview.py:278
+#, fuzzy
+msgid "Forward"
+msgstr "_Вперёд"
 
 #: ../gramps/plugins/lib/libpersonview.py:454
 msgid "_Delete Person"
@@ -29595,6 +30113,26 @@ msgid ""
 msgstr ""
 "Необходимо выбрать место прежде чем увидеть его на карте. Некоторые службы "
 "поддерживают множественный выбор."
+
+#: ../gramps/plugins/lib/libplaceview.py:323
+msgid "Place Filter Editor"
+msgstr "Редактор фильтров мест"
+
+#: ../gramps/plugins/lib/libplaceview.py:415
+msgid "_Look up with Map Service"
+msgstr "Посмотреть на катре"
+
+#: ../gramps/plugins/lib/libplaceview.py:466
+msgid ""
+"Attempt to see selected locations with a Map Service (OpenstreetMap, Google "
+"Maps, ...)"
+msgstr ""
+"Попытаться посмотреть выделенные места в картографической службе "
+"(OpenstreetMap, Google Maps, ...)"
+
+#: ../gramps/plugins/lib/libplaceview.py:466
+msgid "Select a Map Service"
+msgstr "Выберите картографическую службу"
 
 #: ../gramps/plugins/lib/libplaceview.py:506
 msgid "Cannot delete place."
@@ -29971,8 +30509,8 @@ msgstr "Версия Gtk слишком старая."
 #: ../gramps/plugins/view/geoperson.py:508
 #: ../gramps/plugins/view/geoperson.py:529
 #: ../gramps/plugins/view/geoperson.py:569
-#: ../gramps/plugins/view/geoplaces.py:499
-#: ../gramps/plugins/view/geoplaces.py:524
+#: ../gramps/plugins/view/geoplaces.py:501
+#: ../gramps/plugins/view/geoplaces.py:526
 msgid "Center on this place"
 msgstr "Центрировать на этом месте"
 
@@ -30171,7 +30709,7 @@ msgid "Open on maps.google.com"
 msgstr "Открыть на maps.google.com"
 
 #: ../gramps/plugins/mapservices/mapservice.gpr.py:71
-#: ../gramps/plugins/webreport/narrativeweb.py:2036
+#: ../gramps/plugins/webreport/narrativeweb.py:2037
 msgid "OpenStreetMap"
 msgstr "OpenStreetMap"
 
@@ -30310,6 +30848,7 @@ msgid "Parent"
 msgstr "Родители"
 
 #: ../gramps/plugins/quickview/all_relations.py:286
+#: ../gramps/plugins/view/relview.py:471
 #: ../gramps/plugins/webreport/basepage.py:2368
 #: ../gramps/plugins/webreport/basepage.py:2370
 #: ../gramps/plugins/webreport/person.py:227
@@ -34734,6 +35273,11 @@ msgstr "Объединить выделенные цитаты"
 msgid "Citation View"
 msgstr "Вид «Цитаты»"
 
+#: ../gramps/plugins/view/citationlistview.py:215
+#: ../gramps/plugins/view/citationtreeview.py:365
+msgid "Citation Filter Editor"
+msgstr "Редактор фильтра цитат"
+
 #: ../gramps/plugins/view/citationlistview.py:395
 msgid ""
 "This citation cannot be edited at this time. Either the associated citation "
@@ -34791,6 +35335,29 @@ msgstr "Объединить выделенные цитаты или выдел
 msgid "Citation Tree View"
 msgstr "Древо цитат"
 
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+#: ../gramps/plugins/view/citationtreeview.py:475
+msgid "Add citation..."
+msgstr "Добавить цитату..."
+
+#: ../gramps/plugins/view/citationtreeview.py:337
+#: ../gramps/plugins/view/citationtreeview.py:400
+msgid "Add source..."
+msgstr "Добавить источник..."
+
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/persontreeview.py:87
+#: ../gramps/plugins/view/placetreeview.py:77
+msgid "Collapse all Nodes"
+msgstr "Свернуть все узлы"
+
+#: ../gramps/plugins/view/citationtreeview.py:475
+#: ../gramps/plugins/view/persontreeview.py:87
+#: ../gramps/plugins/view/placetreeview.py:77
+msgid "Expand all Nodes"
+msgstr "Развернуть все узлы"
+
 #: ../gramps/plugins/view/citationtreeview.py:651
 msgid ""
 "This source cannot be edited at this time. Either the associated Source "
@@ -34837,6 +35404,10 @@ msgstr "Удалить выделенное событие"
 msgid "Merge the selected events"
 msgstr "Объединить выделенные события"
 
+#: ../gramps/plugins/view/eventview.py:229
+msgid "Event Filter Editor"
+msgstr "Редактор фильтров событий"
+
 #: ../gramps/plugins/view/eventview.py:385
 msgid "_Delete Event"
 msgstr "_Удалить событие"
@@ -34880,6 +35451,18 @@ msgstr "Удалить выделенную семью"
 msgid "Merge the selected families"
 msgstr "Объединить выделенные семьи"
 
+#: ../gramps/plugins/view/familyview.py:188
+msgid "Family Filter Editor"
+msgstr "Редактор фильтров семей"
+
+#: ../gramps/plugins/view/familyview.py:279
+msgid "Make Father Active Person"
+msgstr "Установить отца как активное лицо"
+
+#: ../gramps/plugins/view/familyview.py:279
+msgid "Make Mother Active Person"
+msgstr "Установить мать как активное лицо"
+
 #: ../gramps/plugins/view/familyview.py:372
 msgid "_Delete Family"
 msgstr "_Удалить семью"
@@ -34903,167 +35486,221 @@ msgstr ""
 "быть выбрана нажатием и удержанием клавиши Control в момент щелчка по строке "
 "с желаемой семьёй."
 
-#: ../gramps/plugins/view/fanchart2wayview.py:263
+#: ../gramps/plugins/view/fanchart2wayview.py:280
 msgid "Max ancestor generations"
 msgstr "Максимум поколений предков"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:266
+#: ../gramps/plugins/view/fanchart2wayview.py:283
 msgid "Max descendant generations"
 msgstr "Максимум поколений потомков"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:270
-#: ../gramps/plugins/view/fanchartdescview.py:267
-#: ../gramps/plugins/view/fanchartview.py:364
+#: ../gramps/plugins/view/fanchart2wayview.py:286
+#: ../gramps/plugins/view/fanchartdescview.py:283
+#: ../gramps/plugins/view/fanchartview.py:381
 msgid "Text Font"
 msgstr "Шрифт текста"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:274
-#: ../gramps/plugins/view/fanchartdescview.py:271
-#: ../gramps/plugins/view/fanchartview.py:368
+#: ../gramps/plugins/view/fanchart2wayview.py:291
+#: ../gramps/plugins/view/fanchartdescview.py:288
+#: ../gramps/plugins/view/fanchartview.py:386
 msgid "Gender colors"
 msgstr "Расцветка по половому признаку"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:275
-#: ../gramps/plugins/view/fanchartdescview.py:272
-#: ../gramps/plugins/view/fanchartview.py:369
+#: ../gramps/plugins/view/fanchart2wayview.py:292
+#: ../gramps/plugins/view/fanchartdescview.py:289
+#: ../gramps/plugins/view/fanchartview.py:387
 msgid "Generation based gradient"
 msgstr "Градиентная заливка, зависит от поколения"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:276
-#: ../gramps/plugins/view/fanchartdescview.py:273
-#: ../gramps/plugins/view/fanchartview.py:370
+#: ../gramps/plugins/view/fanchart2wayview.py:293
+#: ../gramps/plugins/view/fanchartdescview.py:290
+#: ../gramps/plugins/view/fanchartview.py:388
 msgid "Age (0-100) based gradient"
 msgstr "Градиентная заливка, зависит от возраста (0-100)"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:278
-#: ../gramps/plugins/view/fanchartdescview.py:275
-#: ../gramps/plugins/view/fanchartview.py:372
+#: ../gramps/plugins/view/fanchart2wayview.py:294
+#: ../gramps/plugins/view/fanchartdescview.py:292
+#: ../gramps/plugins/view/fanchartview.py:389
 msgid "Single main (filter) color"
 msgstr "Одиночный цвет фильтра"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:279
-#: ../gramps/plugins/view/fanchartdescview.py:276
-#: ../gramps/plugins/view/fanchartview.py:373
+#: ../gramps/plugins/view/fanchart2wayview.py:295
+#: ../gramps/plugins/view/fanchartdescview.py:293
+#: ../gramps/plugins/view/fanchartview.py:390
 msgid "Time period based gradient"
 msgstr "Градиентная заливка, зависит от периода времени"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:280
-#: ../gramps/plugins/view/fanchartdescview.py:277
-#: ../gramps/plugins/view/fanchartview.py:374
+#: ../gramps/plugins/view/fanchart2wayview.py:296
+#: ../gramps/plugins/view/fanchartdescview.py:294
+#: ../gramps/plugins/view/fanchartview.py:391
 msgid "White"
 msgstr "Белый"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:281
-#: ../gramps/plugins/view/fanchartdescview.py:278
-#: ../gramps/plugins/view/fanchartview.py:375
+#: ../gramps/plugins/view/fanchart2wayview.py:297
+#: ../gramps/plugins/view/fanchartdescview.py:295
+#: ../gramps/plugins/view/fanchartview.py:392
 msgid "Color scheme classic report"
 msgstr "Цветовая схема классического отчёта"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:282
-#: ../gramps/plugins/view/fanchartdescview.py:279
-#: ../gramps/plugins/view/fanchartview.py:376
+#: ../gramps/plugins/view/fanchart2wayview.py:298
+#: ../gramps/plugins/view/fanchartdescview.py:296
+#: ../gramps/plugins/view/fanchartview.py:393
 msgid "Color scheme classic view"
 msgstr "Цветовая схема классического вида"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:291
-#: ../gramps/plugins/view/fanchartdescview.py:288
-#: ../gramps/plugins/view/fanchartview.py:385
+#: ../gramps/plugins/view/fanchart2wayview.py:306
+#: ../gramps/plugins/view/fanchartdescview.py:304
+#: ../gramps/plugins/view/fanchartview.py:401
 msgid "Background"
 msgstr "Цвет фона"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:300
+#: ../gramps/plugins/view/fanchart2wayview.py:313
 msgid "Add global background colored gradient"
 msgstr "Добавить фон с градиентным разделением"
 
 #. colors, stored as hex values
-#: ../gramps/plugins/view/fanchart2wayview.py:304
-#: ../gramps/plugins/view/fanchartdescview.py:295
-#: ../gramps/plugins/view/fanchartview.py:391
+#: ../gramps/plugins/view/fanchart2wayview.py:317
+#: ../gramps/plugins/view/fanchartdescview.py:309
+#: ../gramps/plugins/view/fanchartview.py:406
 msgid "Start gradient/Main color"
 msgstr "Начало градиента / основной цвет"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:306
-#: ../gramps/plugins/view/fanchartdescview.py:297
-#: ../gramps/plugins/view/fanchartview.py:393
+#: ../gramps/plugins/view/fanchart2wayview.py:319
+#: ../gramps/plugins/view/fanchartdescview.py:311
+#: ../gramps/plugins/view/fanchartview.py:408
 msgid "End gradient/2nd color"
 msgstr "Завершение градиента / второй цвет"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:308
-#: ../gramps/plugins/view/fanchartdescview.py:299
+#: ../gramps/plugins/view/fanchart2wayview.py:321
+#: ../gramps/plugins/view/fanchartdescview.py:313
 msgid "Color for duplicates"
 msgstr "Цвет для дубликатов"
 
 #. algo for the fan angle distribution
-#: ../gramps/plugins/view/fanchart2wayview.py:311
-#: ../gramps/plugins/view/fanchartdescview.py:309
+#: ../gramps/plugins/view/fanchart2wayview.py:324
+#: ../gramps/plugins/view/fanchartdescview.py:323
 msgid "Fan chart distribution"
 msgstr "Распределение по веерной карте"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:314
-#: ../gramps/plugins/view/fanchartdescview.py:312
+#: ../gramps/plugins/view/fanchart2wayview.py:327
+#: ../gramps/plugins/view/fanchartdescview.py:326
 msgid "Homogeneous children distribution"
 msgstr "Равномерное распределение детей"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:316
-#: ../gramps/plugins/view/fanchartdescview.py:314
-msgid "Size  proportional to number of descendants"
+#: ../gramps/plugins/view/fanchart2wayview.py:329
+#: ../gramps/plugins/view/fanchartdescview.py:328
+msgid "Size proportional to number of descendants"
 msgstr "Установить размер пропорционально числу потомков"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:322
-#: ../gramps/plugins/view/fanchartdescview.py:320
-#: ../gramps/plugins/view/fanchartview.py:404
+#. show names one two line
+#: ../gramps/plugins/view/fanchart2wayview.py:335
+#: ../gramps/plugins/view/fanchartdescview.py:334
+#: ../gramps/plugins/view/fanchartview.py:418
 msgid "Show names on two lines"
 msgstr "Показывать имена в две строки"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:327
-#: ../gramps/plugins/view/fanchartdescview.py:325
-#: ../gramps/plugins/view/fanchartview.py:409
+#. Flip names
+#: ../gramps/plugins/view/fanchart2wayview.py:339
+#: ../gramps/plugins/view/fanchartdescview.py:338
+#: ../gramps/plugins/view/fanchartview.py:422
 msgid "Flip name on the left of the fan"
 msgstr "Разворачивать имена относительно левого края карты"
+
+#. Show gramps id
+#: ../gramps/plugins/view/fanchart2wayview.py:343
+msgid "Show the gramps id"
+msgstr "Показывать идетнификатор Gramps"
 
 # может быть "Вывод"?
 #. options we don't show on the dialog
 #. #configdialog.add_checkbox(table,
 #. #        _('Allow radial text'),
 #. #        ??, 'interface.fanview-radialtext')
-#: ../gramps/plugins/view/fanchart2wayview.py:330
-#: ../gramps/plugins/view/fanchartdescview.py:328
-#: ../gramps/plugins/view/fanchartview.py:421
-#: ../gramps/plugins/view/pedigreeview.py:2134
+#: ../gramps/plugins/view/fanchart2wayview.py:346
+#: ../gramps/plugins/view/fanchartdescview.py:345
+#: ../gramps/plugins/view/fanchartview.py:437
+#: ../gramps/plugins/view/pedigreeview.py:2128
 #: ../gramps/plugins/view/relview.py:1857
 msgid "Layout"
 msgstr "Представление"
 
-#: ../gramps/plugins/view/fanchart2wayview.py:529
-#: ../gramps/plugins/view/fanchartdescview.py:517
-#: ../gramps/plugins/view/fanchartview.py:625
+#: ../gramps/plugins/view/fanchart2wayview.py:580
+#: ../gramps/plugins/view/fanchartdescview.py:568
+#: ../gramps/plugins/view/fanchartview.py:666
 msgid "No preview available"
 msgstr "Предварительный просмотр недоступен"
 
 #. form of the fan
-#: ../gramps/plugins/view/fanchartdescview.py:302
-#: ../gramps/plugins/view/fanchartview.py:396
+#: ../gramps/plugins/view/fanchartdescview.py:316
+#: ../gramps/plugins/view/fanchartview.py:411
 msgid "Fan chart type"
 msgstr "Форма веерной карты"
 
-#: ../gramps/plugins/view/fanchartdescview.py:304
-#: ../gramps/plugins/view/fanchartview.py:398
+#: ../gramps/plugins/view/fanchartdescview.py:318
+#: ../gramps/plugins/view/fanchartview.py:413
 msgid "Full Circle"
 msgstr "Полный круг"
 
-#: ../gramps/plugins/view/fanchartdescview.py:305
-#: ../gramps/plugins/view/fanchartview.py:398
+#: ../gramps/plugins/view/fanchartdescview.py:319
+#: ../gramps/plugins/view/fanchartview.py:413
 msgid "Half Circle"
 msgstr "Полукруг"
 
-#: ../gramps/plugins/view/fanchartdescview.py:306
-#: ../gramps/plugins/view/fanchartview.py:399
+#: ../gramps/plugins/view/fanchartdescview.py:320
+#: ../gramps/plugins/view/fanchartview.py:414
 msgid "Quadrant"
 msgstr "Квадрант"
 
-#: ../gramps/plugins/view/fanchartview.py:414
+#. show gramps_id
+#. Show the gramps_id
+#: ../gramps/plugins/view/fanchartdescview.py:342
+#: ../gramps/plugins/view/fanchartview.py:430
+msgid "Show gramps id"
+msgstr "Показывать Gramps ID"
+
+#: ../gramps/plugins/view/fanchartview.py:164
+#: ../gramps/plugins/view/fanchartview.py:227
+#: ../gramps/plugins/view/geoclose.py:91 ../gramps/plugins/view/geoclose.py:167
+#: ../gramps/plugins/view/geoevents.py:81
+#: ../gramps/plugins/view/geoevents.py:129
+#: ../gramps/plugins/view/geofamclose.py:89
+#: ../gramps/plugins/view/geofamclose.py:165
+#: ../gramps/plugins/view/geofamily.py:81
+#: ../gramps/plugins/view/geofamily.py:131
+#: ../gramps/plugins/view/geomoves.py:88 ../gramps/plugins/view/geomoves.py:151
+#: ../gramps/plugins/view/geoperson.py:89
+#: ../gramps/plugins/view/geoplaces.py:84
+#: ../gramps/plugins/view/geoplaces.py:134
+msgid "_Print..."
+msgstr "Напечатать..."
+
+#: ../gramps/plugins/view/fanchartview.py:227
+msgid "Print or save the Fan Chart View"
+msgstr "Напечатать или сохранить Fan Chart View"
+
+#. options users should not change:
+#: ../gramps/plugins/view/fanchartview.py:426
 msgid "Show children ring"
 msgstr "Отображать кольцо детей"
+
+#: ../gramps/plugins/view/geoclose.py:111
+msgid "Select the person which is the reference for life ways"
+msgstr ""
+"Выберите лицо, относительно которого будут рассчитаны жизненные маршруты"
+
+#: ../gramps/plugins/view/geoclose.py:111
+msgid "reference _Person"
+msgstr "Исходное лицо"
+
+#: ../gramps/plugins/view/geoclose.py:167
+#: ../gramps/plugins/view/geoevents.py:129
+#: ../gramps/plugins/view/geofamclose.py:165
+#: ../gramps/plugins/view/geofamily.py:131
+#: ../gramps/plugins/view/geomoves.py:151
+#: ../gramps/plugins/view/geoperson.py:152
+#: ../gramps/plugins/view/geoplaces.py:134
+msgid "Print or save the Map"
+msgstr "Напечатать или сохранить карту"
 
 #: ../gramps/plugins/view/geoclose.py:220
 #: ../gramps/plugins/view/geography.gpr.py:160
@@ -35176,10 +35813,19 @@ msgstr "Отображать все события"
 
 #: ../gramps/plugins/view/geoevents.py:459
 #: ../gramps/plugins/view/geoevents.py:464
-#: ../gramps/plugins/view/geoplaces.py:549
-#: ../gramps/plugins/view/geoplaces.py:554
+#: ../gramps/plugins/view/geoplaces.py:551
+#: ../gramps/plugins/view/geoplaces.py:556
 msgid "Centering on Place"
 msgstr "Центрирование на месте"
+
+#: ../gramps/plugins/view/geofamclose.py:109
+msgid "Select the family which is the reference for life ways"
+msgstr "Выберите исходную семью, жизненный путь которой хотите проследить"
+
+#: ../gramps/plugins/view/geofamclose.py:109
+#: ../gramps/plugins/view/geoperson.py:152
+msgid "reference _Family"
+msgstr "Исходная семья"
 
 #: ../gramps/plugins/view/geofamclose.py:220
 #: ../gramps/plugins/view/geography.gpr.py:142
@@ -35462,7 +36108,7 @@ msgstr ""
 "показать все имеющиеся места с координатами. Цвет маркеров можно установить "
 "в соответствии с типом места. Поддерживается использование фильтров."
 
-#: ../gramps/plugins/view/geoplaces.py:445
+#: ../gramps/plugins/view/geoplaces.py:447
 msgid ""
 "Right click on the map and select 'show all places' to show all known places "
 "with coordinates. You can use the history to navigate on the map. You can "
@@ -35473,46 +36119,46 @@ msgstr ""
 "историей. Цвет маркеров можно установить в соответствии с типом места. "
 "Поддерживается использование фильтров."
 
-#: ../gramps/plugins/view/geoplaces.py:460
+#: ../gramps/plugins/view/geoplaces.py:462
 msgid "The place name in the status bar is disabled."
 msgstr "Название места в статус панели недоступно."
 
-#: ../gramps/plugins/view/geoplaces.py:465
+#: ../gramps/plugins/view/geoplaces.py:467
 #, python-format
 msgid "The maximum number of places is reached (%d)."
 msgstr "Достигнуто максимально разрешённое число местоположений (%d)."
 
-#: ../gramps/plugins/view/geoplaces.py:468
+#: ../gramps/plugins/view/geoplaces.py:470
 msgid "Some information are missing."
 msgstr "Часть информации отсутствует."
 
-#: ../gramps/plugins/view/geoplaces.py:470
+#: ../gramps/plugins/view/geoplaces.py:472
 msgid "Please, use filtering to reduce this number."
 msgstr "Пожалуйста, используйте фильтр, чтобы уменьшить их число."
 
-#: ../gramps/plugins/view/geoplaces.py:472
+#: ../gramps/plugins/view/geoplaces.py:474
 msgid "You can modify this value in the geography option."
 msgstr "Это значение можно изменить в параметрах географии."
 
-#: ../gramps/plugins/view/geoplaces.py:474
+#: ../gramps/plugins/view/geoplaces.py:476
 msgid "In this case, it may take time to show all markers."
 msgstr ""
 "Поэтому, это может занять значительное время, чтобы отобразить все маркеры."
 
-#: ../gramps/plugins/view/geoplaces.py:506
-#: ../gramps/plugins/view/geoplaces.py:530
+#: ../gramps/plugins/view/geoplaces.py:508
+#: ../gramps/plugins/view/geoplaces.py:532
 msgid "Bookmark this place"
 msgstr "Добавить закладку на это местоположение"
 
-#: ../gramps/plugins/view/geoplaces.py:545
+#: ../gramps/plugins/view/geoplaces.py:547
 msgid "Show all places"
 msgstr "Показать все местоположения"
 
-#: ../gramps/plugins/view/geoplaces.py:657
+#: ../gramps/plugins/view/geoplaces.py:659
 msgid "Custom places name"
 msgstr "Пользовательские названия мест"
 
-#: ../gramps/plugins/view/geoplaces.py:666
+#: ../gramps/plugins/view/geoplaces.py:668
 msgid "The places marker color"
 msgstr "Цвет маркеров мест"
 
@@ -35527,6 +36173,14 @@ msgstr "Удалить выделенный документ"
 #: ../gramps/plugins/view/mediaview.py:115
 msgid "Merge the selected media objects"
 msgstr "Объединить выделенные документы"
+
+#: ../gramps/plugins/view/mediaview.py:288
+msgid "Media Filter Editor"
+msgstr "Редактор фильтров документов"
+
+#: ../gramps/plugins/view/mediaview.py:379
+msgid "View in the default viewer"
+msgstr "Просмотр в программе по умолчанию"
 
 #: ../gramps/plugins/view/mediaview.py:483
 msgid "Cannot merge media objects."
@@ -35549,6 +36203,10 @@ msgstr "Удалить выделенную заметку"
 #: ../gramps/plugins/view/noteview.py:96
 msgid "Merge the selected notes"
 msgstr "Объединить выделенные заметки"
+
+#: ../gramps/plugins/view/noteview.py:188
+msgid "Note Filter Editor"
+msgstr "Редактор фильтров заметок"
 
 #: ../gramps/plugins/view/noteview.py:357
 msgid "Cannot merge notes."
@@ -35587,92 +36245,85 @@ msgstr "похор."
 msgid "short for cremated|crem."
 msgstr "крем."
 
-#: ../gramps/plugins/view/pedigreeview.py:1211
+#: ../gramps/plugins/view/pedigreeview.py:1205
 msgid "Jump to child..."
 msgstr "Перейти к ребёнку..."
 
-#: ../gramps/plugins/view/pedigreeview.py:1225
+#: ../gramps/plugins/view/pedigreeview.py:1219
 msgid "Jump to father"
 msgstr "Перейти к отцу"
 
-#: ../gramps/plugins/view/pedigreeview.py:1239
+#: ../gramps/plugins/view/pedigreeview.py:1233
 msgid "Jump to mother"
 msgstr "Перейти к матери"
 
-#: ../gramps/plugins/view/pedigreeview.py:1607
+#: ../gramps/plugins/view/pedigreeview.py:1601
 msgid "A person was found to be his/her own ancestor."
 msgstr "Лицо является собственным предком."
 
-#: ../gramps/plugins/view/pedigreeview.py:1651
+#: ../gramps/plugins/view/pedigreeview.py:1645
 msgid "Pre_vious"
 msgstr "Пр_едыдущее"
 
-#: ../gramps/plugins/view/pedigreeview.py:1652
+#: ../gramps/plugins/view/pedigreeview.py:1646
 msgid "_Next"
 msgstr "_Следующее"
 
-#: ../gramps/plugins/view/pedigreeview.py:1653
-msgid "_Home"
-msgstr "До_мой"
-
-#: ../gramps/plugins/view/pedigreeview.py:1663
-msgid "Set _Home Person"
-msgstr "У_становить базовое лицо"
-
 #. Mouse scroll direction setting.
-#: ../gramps/plugins/view/pedigreeview.py:1681
+#: ../gramps/plugins/view/pedigreeview.py:1675
 msgid "Mouse scroll direction"
 msgstr "Направление прокрутки колёсика мыши"
 
-#: ../gramps/plugins/view/pedigreeview.py:1685
+#: ../gramps/plugins/view/pedigreeview.py:1679
 msgid "Top <-> Bottom"
 msgstr "Вверх <-> Вниз"
 
-#: ../gramps/plugins/view/pedigreeview.py:1692
+#: ../gramps/plugins/view/pedigreeview.py:1686
 msgid "Left <-> Right"
 msgstr "Влево <-> Вправо"
 
-#: ../gramps/plugins/view/pedigreeview.py:1909
+#: ../gramps/plugins/view/pedigreeview.py:1903
+#: ../gramps/plugins/view/relview.py:385
 msgid "Add New Parents..."
 msgstr "Добавить родителей..."
 
-#: ../gramps/plugins/view/pedigreeview.py:2104
+#: ../gramps/plugins/view/pedigreeview.py:2098
 msgid "Show images"
 msgstr "Показывать изображения"
 
-#: ../gramps/plugins/view/pedigreeview.py:2107
+#: ../gramps/plugins/view/pedigreeview.py:2101
 msgid "Show marriage data"
 msgstr "Показывать данные о браках"
 
-#: ../gramps/plugins/view/pedigreeview.py:2110
+#: ../gramps/plugins/view/pedigreeview.py:2104
 msgid "Show unknown people"
 msgstr "Показывать неизвестных людей"
 
-#: ../gramps/plugins/view/pedigreeview.py:2113
+#: ../gramps/plugins/view/pedigreeview.py:2107
 msgid "Show tags"
 msgstr "Показывать метки"
 
-#: ../gramps/plugins/view/pedigreeview.py:2116
+#: ../gramps/plugins/view/pedigreeview.py:2110
 msgid "Tree style"
 msgstr "Стиль древа"
 
-#: ../gramps/plugins/view/pedigreeview.py:2118
+#: ../gramps/plugins/view/pedigreeview.py:2112
 msgid "Standard"
 msgstr "Стандартный"
 
-#: ../gramps/plugins/view/pedigreeview.py:2119
+#: ../gramps/plugins/view/pedigreeview.py:2113
 msgid "Compact"
 msgstr "Компактный"
 
-#: ../gramps/plugins/view/pedigreeview.py:2120
+#: ../gramps/plugins/view/pedigreeview.py:2114
 msgid "Expanded"
 msgstr "Расширенный"
 
-#: ../gramps/plugins/view/pedigreeview.py:2123
+#: ../gramps/plugins/view/pedigreeview.py:2117
 msgid "Tree direction"
 msgstr "Направление стрелок"
 
-#: ../gramps/plugins/view/pedigreeview.py:2130
+#: ../gramps/plugins/view/pedigreeview.py:2124
 msgid "Tree size"
 msgstr "Размер древа"
 
@@ -35692,6 +36343,50 @@ msgstr "Вид «Места»"
 msgid "Place Tree View"
 msgstr "Вид «Иерархия мест»"
 
+#: ../gramps/plugins/view/placetreeview.py:77
+msgid "Collapse this Entire Group"
+msgstr "Свернуть всю группу"
+
+#: ../gramps/plugins/view/placetreeview.py:77
+msgid "Expand this Entire Group"
+msgstr "Развернуть всю группу"
+
+#: ../gramps/plugins/view/relview.py:364
+msgid "Organize Bookmarks..."
+msgstr "Редактор закладок..."
+
+#: ../gramps/plugins/view/relview.py:385
+msgid "Add Existing Parents..."
+msgstr "Добавить существующий набор родителей..."
+
+#: ../gramps/plugins/view/relview.py:385
+msgid "Add Partner..."
+msgstr "Добавить партнёра..."
+
+#: ../gramps/plugins/view/relview.py:385 ../gramps/plugins/view/relview.py:471
+msgid "_Reorder"
+msgstr "_Упорядочить"
+
+#: ../gramps/plugins/view/relview.py:471 ../gramps/plugins/view/relview.py:964
+msgid "Add a new family with person as parent"
+msgstr "Добавить новую семью с лицом в качестве родителя"
+
+#: ../gramps/plugins/view/relview.py:471 ../gramps/plugins/view/relview.py:958
+msgid "Add a new set of parents"
+msgstr "Добавляет новый набор родителей"
+
+#: ../gramps/plugins/view/relview.py:471 ../gramps/plugins/view/relview.py:959
+msgid "Add person as child to an existing family"
+msgstr "Добавить лицо ребёнком в существующую семью"
+
+#: ../gramps/plugins/view/relview.py:471
+msgid "Change order of parents and families"
+msgstr "Изменить порядок родителей и семей"
+
+#: ../gramps/plugins/view/relview.py:471
+msgid "Edit the active person"
+msgstr "Редактировать активное лицо"
+
 #: ../gramps/plugins/view/relview.py:768
 msgid "Alive"
 msgstr "Возраст"
@@ -35700,14 +36395,6 @@ msgstr "Возраст"
 #, python-format
 msgid "%(date)s in %(place)s"
 msgstr "%(date)s в %(place)s"
-
-#: ../gramps/plugins/view/relview.py:958
-msgid "Add a new set of parents"
-msgstr "Добавляет новый набор родителей"
-
-#: ../gramps/plugins/view/relview.py:959
-msgid "Add person as child to an existing family"
-msgstr "Добавить лицо ребёнком в существующую семью"
 
 #: ../gramps/plugins/view/relview.py:960
 msgid "Edit parents"
@@ -35720,10 +36407,6 @@ msgstr "Упорядочить родителей"
 #: ../gramps/plugins/view/relview.py:962
 msgid "Remove person as child of these parents"
 msgstr "Удалить лицо как ребёнка этих родителей"
-
-#: ../gramps/plugins/view/relview.py:964
-msgid "Add a new family with person as parent"
-msgstr "Добавить новую семью с лицом в качестве родителя"
 
 #: ../gramps/plugins/view/relview.py:968
 msgid "Remove person as parent in this family"
@@ -35863,6 +36546,10 @@ msgstr "Удалить выделенное хранилище"
 msgid "Merge the selected repositories"
 msgstr "Объединить выделенные хранилища"
 
+#: ../gramps/plugins/view/repoview.py:201
+msgid "Repository Filter Editor"
+msgstr "Редактор фильтров хранилищ"
+
 #: ../gramps/plugins/view/repoview.py:363
 msgid "Cannot merge repositories."
 msgstr "Не удалось объединить хранилища."
@@ -35888,6 +36575,10 @@ msgstr "Удалить выделенный источник"
 #: ../gramps/plugins/view/sourceview.py:101
 msgid "Merge the selected sources"
 msgstr "Объединить выделенные источники"
+
+#: ../gramps/plugins/view/sourceview.py:187
+msgid "Source Filter Editor"
+msgstr "Редактор фильтров источников"
 
 #: ../gramps/plugins/view/sourceview.py:348
 msgid "Cannot merge sources."
@@ -36089,7 +36780,7 @@ msgstr "Миниатюры"
 #: ../gramps/plugins/webreport/basepage.py:1535
 #: ../gramps/plugins/webreport/basepage.py:1668
 #: ../gramps/plugins/webreport/download.py:94
-#: ../gramps/plugins/webreport/narrativeweb.py:1898
+#: ../gramps/plugins/webreport/narrativeweb.py:1899
 msgid "Download"
 msgstr "Загрузить"
 
@@ -36172,12 +36863,12 @@ msgstr "Создание страниц событий"
 #: ../gramps/plugins/webreport/family.py:108
 #: ../gramps/plugins/webreport/media.py:116
 #: ../gramps/plugins/webreport/media.py:244
-#: ../gramps/plugins/webreport/narrativeweb.py:500
-#: ../gramps/plugins/webreport/narrativeweb.py:1083
-#: ../gramps/plugins/webreport/narrativeweb.py:1141
-#: ../gramps/plugins/webreport/narrativeweb.py:1164
-#: ../gramps/plugins/webreport/narrativeweb.py:1173
-#: ../gramps/plugins/webreport/narrativeweb.py:1216
+#: ../gramps/plugins/webreport/narrativeweb.py:501
+#: ../gramps/plugins/webreport/narrativeweb.py:1084
+#: ../gramps/plugins/webreport/narrativeweb.py:1142
+#: ../gramps/plugins/webreport/narrativeweb.py:1165
+#: ../gramps/plugins/webreport/narrativeweb.py:1174
+#: ../gramps/plugins/webreport/narrativeweb.py:1217
 #: ../gramps/plugins/webreport/person.py:141
 #: ../gramps/plugins/webreport/place.py:117
 #: ../gramps/plugins/webreport/repository.py:102
@@ -36286,107 +36977,107 @@ msgstr "Тип файла"
 msgid "Missing media object:"
 msgstr "Документ утерян:"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:284
+#: ../gramps/plugins/webreport/narrativeweb.py:285
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
 msgstr "Ни %(current)s, ни %(parent)s не являются каталогами"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:293
-#: ../gramps/plugins/webreport/narrativeweb.py:299
-#: ../gramps/plugins/webreport/narrativeweb.py:312
-#: ../gramps/plugins/webreport/narrativeweb.py:318
+#: ../gramps/plugins/webreport/narrativeweb.py:294
+#: ../gramps/plugins/webreport/narrativeweb.py:300
+#: ../gramps/plugins/webreport/narrativeweb.py:313
+#: ../gramps/plugins/webreport/narrativeweb.py:319
 #, python-format
 msgid "Could not create the directory: %s"
 msgstr "Ошибка создания каталога: %s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:325
+#: ../gramps/plugins/webreport/narrativeweb.py:326
 msgid "Invalid file name"
 msgstr "Некорректное имя файла"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:326
+#: ../gramps/plugins/webreport/narrativeweb.py:327
 msgid "The archive file must be a file, not a directory"
 msgstr "Архивом должен быть файл, а не каталог"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:462
+#: ../gramps/plugins/webreport/narrativeweb.py:463
 #, python-format
 msgid "ID=%(grampsid)s, path=%(dir)s"
 msgstr "ID=%(grampsid)s, путь=%(dir)s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:467
+#: ../gramps/plugins/webreport/narrativeweb.py:468
 msgid "Missing media objects:"
 msgstr "Утерянные документы:"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:499
+#: ../gramps/plugins/webreport/narrativeweb.py:500
 msgid "Constructing list of other objects..."
 msgstr "Составляется список других объектов..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:744
+#: ../gramps/plugins/webreport/narrativeweb.py:745
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr "Семья %(husband)s и %(spouse)s"
 
 #. Only the name of the husband is known
 #. Only the name of the wife is known
-#: ../gramps/plugins/webreport/narrativeweb.py:750
-#: ../gramps/plugins/webreport/narrativeweb.py:754
+#: ../gramps/plugins/webreport/narrativeweb.py:751
+#: ../gramps/plugins/webreport/narrativeweb.py:755
 #, python-format
 msgid "Family of %s"
 msgstr "Семья %s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1082
+#: ../gramps/plugins/webreport/narrativeweb.py:1083
 msgid "Creating GENDEX file"
 msgstr "Создание файла GENDEX"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1140
+#: ../gramps/plugins/webreport/narrativeweb.py:1141
 msgid "Creating surname pages"
 msgstr "Создание страниц фамилий"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1165
+#: ../gramps/plugins/webreport/narrativeweb.py:1166
 msgid "Creating thumbnail preview page..."
 msgstr "Создание страницы предпросмотра изображений..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1174
+#: ../gramps/plugins/webreport/narrativeweb.py:1175
 msgid "Creating statistics page..."
 msgstr "Создание страницы статистики..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1215
+#: ../gramps/plugins/webreport/narrativeweb.py:1216
 msgid "Creating address book pages ..."
 msgstr "Создание страницы адресной книги..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1615
+#: ../gramps/plugins/webreport/narrativeweb.py:1616
 msgid "Store web pages in .tar.gz archive"
 msgstr "Сохранить веб-страницы в архиве .tar.gz"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1617
+#: ../gramps/plugins/webreport/narrativeweb.py:1618
 msgid "Whether to store the web pages in an archive file"
 msgstr "Сохранить веб-страницы в сжатом архиве"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1628
+#: ../gramps/plugins/webreport/narrativeweb.py:1629
 #: ../gramps/plugins/webreport/webcal.py:1663
 msgid "The destination directory for the web files"
 msgstr "Каталог размещения веб файлов"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1634
+#: ../gramps/plugins/webreport/narrativeweb.py:1635
 msgid "My Family Tree"
 msgstr "Моё семейное древо"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1634
+#: ../gramps/plugins/webreport/narrativeweb.py:1635
 msgid "Web site title"
 msgstr "Название сайта"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1635
+#: ../gramps/plugins/webreport/narrativeweb.py:1636
 msgid "The title of the web site"
 msgstr "Название этого веб-сайта"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1640
+#: ../gramps/plugins/webreport/narrativeweb.py:1641
 msgid "Select filter to restrict people that appear on web site"
 msgstr "Выберите фильтр для отбора лиц в отчёт"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1649
+#: ../gramps/plugins/webreport/narrativeweb.py:1650
 msgid "Show the relationship between the current person and the active person"
 msgstr "Показывает все взаимоотношения между лицом и активным лицом"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1652
+#: ../gramps/plugins/webreport/narrativeweb.py:1653
 msgid ""
 "For each person page, show the relationship between this person and the "
 "active person."
@@ -36394,194 +37085,194 @@ msgstr ""
 "Для каждой страницы лица показывает все взаимоотношения между этим лицом и "
 "активным лицом."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1670
+#: ../gramps/plugins/webreport/narrativeweb.py:1671
 msgid "Html options"
 msgstr "Параметры HTML"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1673
+#: ../gramps/plugins/webreport/narrativeweb.py:1674
 #: ../gramps/plugins/webreport/webcal.py:1684
 msgid "File extension"
 msgstr "Расширение файла"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1676
+#: ../gramps/plugins/webreport/narrativeweb.py:1677
 #: ../gramps/plugins/webreport/webcal.py:1687
 msgid "The extension to be used for the web files"
 msgstr "Расширение файлов веб-сайта"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1679
+#: ../gramps/plugins/webreport/narrativeweb.py:1680
 #: ../gramps/plugins/webreport/webcal.py:1690
 msgid "Copyright"
 msgstr "Авторское право"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1682
+#: ../gramps/plugins/webreport/narrativeweb.py:1683
 #: ../gramps/plugins/webreport/webcal.py:1693
 msgid "The copyright to be used for the web files"
 msgstr "Авторские права, которые будут использоваться для веб-страниц"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1691
+#: ../gramps/plugins/webreport/narrativeweb.py:1692
 #: ../gramps/plugins/webreport/webcal.py:1702
 msgid "The stylesheet to be used for the web pages"
 msgstr "Таблица стилей для веб-страниц"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1696
+#: ../gramps/plugins/webreport/narrativeweb.py:1697
 msgid "Horizontal -- Default"
 msgstr "Горизонтально (по умолчанию)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1697
+#: ../gramps/plugins/webreport/narrativeweb.py:1698
 msgid "Vertical   -- Left Side"
 msgstr "Вертикально (слева)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1698
+#: ../gramps/plugins/webreport/narrativeweb.py:1699
 msgid "Fade       -- WebKit Browsers Only"
 msgstr "Fade (только для WebKit браузеров)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1699
-#: ../gramps/plugins/webreport/narrativeweb.py:1713
+#: ../gramps/plugins/webreport/narrativeweb.py:1700
+#: ../gramps/plugins/webreport/narrativeweb.py:1714
 msgid "Drop-Down  -- WebKit Browsers Only"
 msgstr "Drop-Down (только для WebKit браузеров)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1701
+#: ../gramps/plugins/webreport/narrativeweb.py:1702
 msgid "Navigation Menu Layout"
 msgstr "Раскладка меню навигации"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1705
+#: ../gramps/plugins/webreport/narrativeweb.py:1706
 msgid "Choose which layout for the Navigation Menus."
 msgstr "Выберите раскладку для меню навигации."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1712
+#: ../gramps/plugins/webreport/narrativeweb.py:1713
 msgid "Normal Outline Style"
 msgstr "Обычный стиль с подчеркиванием"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1716
+#: ../gramps/plugins/webreport/narrativeweb.py:1717
 msgid "Citation Referents Layout"
 msgstr "Отображение ссылок на цитаты"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1720
+#: ../gramps/plugins/webreport/narrativeweb.py:1721
 msgid ""
 "Determine the default layout for the Source Page's Citation Referents section"
 msgstr ""
 "Определяет стиль вывода на странице источников в разделе ссылок на цитаты"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1724
+#: ../gramps/plugins/webreport/narrativeweb.py:1725
 msgid "Include ancestor's tree"
 msgstr "Включить древо предков"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1725
+#: ../gramps/plugins/webreport/narrativeweb.py:1726
 msgid "Whether to include an ancestor graph on each individual page"
 msgstr "Включать ли граф предков на каждой индивидуальной странице"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1730
+#: ../gramps/plugins/webreport/narrativeweb.py:1731
 msgid "Add previous/next"
 msgstr "Добавить предыдущий/следующий"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1731
+#: ../gramps/plugins/webreport/narrativeweb.py:1732
 msgid "Add previous/next to the navigation bar."
 msgstr "Добавить предыдущий/следующий на панель навигации."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1734
+#: ../gramps/plugins/webreport/narrativeweb.py:1735
 msgid "This is a secure site (https)"
 msgstr "Это защищённый сайт (https)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1736
+#: ../gramps/plugins/webreport/narrativeweb.py:1737
 msgid "Whether to use http:// or https://"
 msgstr "Использовать http:// или https://"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1743
+#: ../gramps/plugins/webreport/narrativeweb.py:1744
 msgid "Extra pages"
 msgstr "Дополнительные страницы"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1746
+#: ../gramps/plugins/webreport/narrativeweb.py:1747
 msgid "Extra page name"
 msgstr "Название дополнительной страницы"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1749
+#: ../gramps/plugins/webreport/narrativeweb.py:1750
 msgid "Your extra page name like it is shown in the menubar"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1754
+#: ../gramps/plugins/webreport/narrativeweb.py:1755
 msgid "Your extra page path"
 msgstr "Путь к дополнительной странице"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1757
+#: ../gramps/plugins/webreport/narrativeweb.py:1758
 msgid "Your extra page path without extension"
 msgstr "Путь к дополнительной странице без расширения"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1777
+#: ../gramps/plugins/webreport/narrativeweb.py:1778
 msgid "Sort all children in birth order"
 msgstr "Сортировать всех детей в порядке рождения"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1779
+#: ../gramps/plugins/webreport/narrativeweb.py:1780
 msgid "Whether to display children in birth order or in entry order?"
 msgstr ""
 "Показывать детей в порядке рождения или в порядке ввода их в базу данных?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1783
+#: ../gramps/plugins/webreport/narrativeweb.py:1784
 msgid "Do we display coordinates in the places list?"
 msgstr "Отображать координаты в списке мест?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1785
+#: ../gramps/plugins/webreport/narrativeweb.py:1786
 msgid "Whether to display latitude/longitude in the places list?"
 msgstr "Отображать широту/долготу в списке мест?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1789
+#: ../gramps/plugins/webreport/narrativeweb.py:1790
 msgid "Sort places references either by date or by name"
 msgstr "Сортировать ссылки на места по дате или имени"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1791
+#: ../gramps/plugins/webreport/narrativeweb.py:1792
 msgid "Sort the places references by date or by name. Not set means by date."
 msgstr ""
 "Сортировка ссылок на места по дате или имени. Если не установлено, то по "
 "дате."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1795
+#: ../gramps/plugins/webreport/narrativeweb.py:1796
 msgid "Graph generations"
 msgstr "Граф поколений"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1796
+#: ../gramps/plugins/webreport/narrativeweb.py:1797
 msgid "The number of generations to include in the ancestor graph"
 msgstr "Количество поколений для графа предков"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1806
+#: ../gramps/plugins/webreport/narrativeweb.py:1807
 msgid "Page Generation"
 msgstr "Создание страниц"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1809
+#: ../gramps/plugins/webreport/narrativeweb.py:1810
 msgid "Home page note"
 msgstr "Заметка для главной страницы"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1810
+#: ../gramps/plugins/webreport/narrativeweb.py:1811
 msgid "A note to be used on the home page"
 msgstr "Заметка которая будет отображаться на главной странице"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1813
+#: ../gramps/plugins/webreport/narrativeweb.py:1814
 msgid "Home page image"
 msgstr "Изображение для главной страницы"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1814
+#: ../gramps/plugins/webreport/narrativeweb.py:1815
 msgid "An image to be used on the home page"
 msgstr "Изображение для использования на главной странице"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1817
+#: ../gramps/plugins/webreport/narrativeweb.py:1818
 msgid "Introduction note"
 msgstr "Заметка для введения"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1818
+#: ../gramps/plugins/webreport/narrativeweb.py:1819
 msgid "A note to be used as the introduction"
 msgstr "Заметка для использования в качестве введения"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1821
+#: ../gramps/plugins/webreport/narrativeweb.py:1822
 msgid "Introduction image"
 msgstr "Изображение для введения"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1822
+#: ../gramps/plugins/webreport/narrativeweb.py:1823
 msgid "An image to be used as the introduction"
 msgstr "Изображение для использования во введении"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1825
+#: ../gramps/plugins/webreport/narrativeweb.py:1826
 msgid "Publisher contact note"
 msgstr "Заметка с данными издателя"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1826
+#: ../gramps/plugins/webreport/narrativeweb.py:1827
 msgid ""
 "A note to be used as the publisher contact.\n"
 "If no publisher information is given,\n"
@@ -36591,13 +37282,13 @@ msgstr ""
 "Если информация не предоставлена, страница\n"
 "об издателе не будет создана"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1832
+#: ../gramps/plugins/webreport/narrativeweb.py:1833
 msgid "Publisher contact image"
 msgstr ""
 "Изображение для страницы\n"
 "с информацией об издателе"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1833
+#: ../gramps/plugins/webreport/narrativeweb.py:1834
 msgid ""
 "An image to be used as the publisher contact.\n"
 "If no publisher information is given,\n"
@@ -36607,51 +37298,51 @@ msgstr ""
 "Если информация не предоставлена, страница\n"
 "об издателе не будет создана"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1839
+#: ../gramps/plugins/webreport/narrativeweb.py:1840
 msgid "HTML user header"
 msgstr "Верхний колонтитул (HTML)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1840
+#: ../gramps/plugins/webreport/narrativeweb.py:1841
 msgid "A note to be used as the page header"
 msgstr "Заметка для использования в качестве верхнего колонтитула"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1843
+#: ../gramps/plugins/webreport/narrativeweb.py:1844
 msgid "HTML user footer"
 msgstr "Нижний колонтитул (HTML)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1844
+#: ../gramps/plugins/webreport/narrativeweb.py:1845
 msgid "A note to be used as the page footer"
 msgstr "Заметка для использования в качестве нижнего колонтитула"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1851
+#: ../gramps/plugins/webreport/narrativeweb.py:1852
 msgid "Images Generation"
 msgstr "Создание изображений"
 
 # !!!FIXME!!!
-#: ../gramps/plugins/webreport/narrativeweb.py:1854
+#: ../gramps/plugins/webreport/narrativeweb.py:1855
 msgid "Include images and media objects"
 msgstr "Включать изображения и документы"
 
 # !!!FIXME!!!
-#: ../gramps/plugins/webreport/narrativeweb.py:1856
+#: ../gramps/plugins/webreport/narrativeweb.py:1857
 msgid "Whether to include a gallery of media objects"
 msgstr "Включать ли галерею документов"
 
 # !!!FIXME!!!
-#: ../gramps/plugins/webreport/narrativeweb.py:1862
+#: ../gramps/plugins/webreport/narrativeweb.py:1863
 msgid "Include unused images and media objects"
 msgstr "Включать неиспользуемые изображения и документы"
 
 # !!!FIXME!!!
-#: ../gramps/plugins/webreport/narrativeweb.py:1863
+#: ../gramps/plugins/webreport/narrativeweb.py:1864
 msgid "Whether to include unused or unreferenced media objects"
 msgstr "Включать ли неиспользуемые документы"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1868
+#: ../gramps/plugins/webreport/narrativeweb.py:1869
 msgid "Create and only use thumbnail- sized images"
 msgstr "Создать и использовать только эскизы - уменьшенные изображения"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1870
+#: ../gramps/plugins/webreport/narrativeweb.py:1871
 msgid ""
 "This option allows you to create only thumbnail images instead of the full-"
 "sized images on the Media Page. This will allow you to have a much smaller "
@@ -36661,11 +37352,11 @@ msgstr ""
 "чтобы использовать полноразмерные изображения. Это позволит получить намного "
 "меньший размер данных для загрузки на хостинг."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1879
+#: ../gramps/plugins/webreport/narrativeweb.py:1880
 msgid "Max width of initial image"
 msgstr "Макс. ширина изображения"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1881
+#: ../gramps/plugins/webreport/narrativeweb.py:1882
 msgid ""
 "This allows you to set the maximum width of the image shown on the media "
 "page. Set to 0 for no limit."
@@ -36673,11 +37364,11 @@ msgstr ""
 "Это поле позволяет задать максимальную ширину изображения на странице с "
 "документами. Укажите 0, чтобы не ограничивать ширину."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1886
+#: ../gramps/plugins/webreport/narrativeweb.py:1887
 msgid "Max height of initial image"
 msgstr "Макс. высота изображения"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1888
+#: ../gramps/plugins/webreport/narrativeweb.py:1889
 msgid ""
 "This allows you to set the maximum height of the image shown on the media "
 "page. Set to 0 for no limit."
@@ -36685,159 +37376,159 @@ msgstr ""
 "Это поле позволяет задать максимальную высоту изображения на странице с "
 "документами. Укажите 0, чтобы не ограничивать высоту."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1901
+#: ../gramps/plugins/webreport/narrativeweb.py:1902
 msgid "Include download page"
 msgstr "Включить страницу загрузки"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1903
+#: ../gramps/plugins/webreport/narrativeweb.py:1904
 msgid "Whether to include a database download option"
 msgstr "Включать ли возможность загрузки базы данных"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1908
-#: ../gramps/plugins/webreport/narrativeweb.py:1920
+#: ../gramps/plugins/webreport/narrativeweb.py:1909
+#: ../gramps/plugins/webreport/narrativeweb.py:1921
 msgid "Download Filename"
 msgstr "Имя файла"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1911
-#: ../gramps/plugins/webreport/narrativeweb.py:1923
+#: ../gramps/plugins/webreport/narrativeweb.py:1912
+#: ../gramps/plugins/webreport/narrativeweb.py:1924
 msgid "File to be used for downloading of database"
 msgstr "Файл с базой данных, который Вы хотите предоставить для скачивания"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1914
-#: ../gramps/plugins/webreport/narrativeweb.py:1926
+#: ../gramps/plugins/webreport/narrativeweb.py:1915
+#: ../gramps/plugins/webreport/narrativeweb.py:1927
 msgid "Description for download"
 msgstr "Описание"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1915
+#: ../gramps/plugins/webreport/narrativeweb.py:1916
 msgid "Smith Family Tree"
 msgstr "Семейное древо Ивановых"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1916
-#: ../gramps/plugins/webreport/narrativeweb.py:1928
+#: ../gramps/plugins/webreport/narrativeweb.py:1917
+#: ../gramps/plugins/webreport/narrativeweb.py:1929
 msgid "Give a description for this file."
 msgstr "Опишите этот файл."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1927
+#: ../gramps/plugins/webreport/narrativeweb.py:1928
 msgid "Johnson Family Tree"
 msgstr "Семейное древо Сидоровых"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1937
+#: ../gramps/plugins/webreport/narrativeweb.py:1938
 #: ../gramps/plugins/webreport/webcal.py:1868
 msgid "Advanced Options"
 msgstr "Дополнительные настройки"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1940
+#: ../gramps/plugins/webreport/narrativeweb.py:1941
 #: ../gramps/plugins/webreport/webcal.py:1870
 msgid "Character set encoding"
 msgstr "Кодировка символов"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1944
+#: ../gramps/plugins/webreport/narrativeweb.py:1945
 #: ../gramps/plugins/webreport/webcal.py:1874
 msgid "The encoding to be used for the web files"
 msgstr "Кодировка, которая будет использоваться для веб-страниц"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1948
+#: ../gramps/plugins/webreport/narrativeweb.py:1949
 msgid "Include link to active person on every page"
 msgstr "Включать ли на каждой странице ссылку на главное лицо"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1950
+#: ../gramps/plugins/webreport/narrativeweb.py:1951
 msgid "Include a link to the active person (if they have a webpage)"
 msgstr "Включить ссылку на активное лицо (если есть веб-страница)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1954
+#: ../gramps/plugins/webreport/narrativeweb.py:1955
 msgid "Include a column for birth dates on the index pages"
 msgstr "Включить колонку с датами рождений на индексных страницах"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1955
+#: ../gramps/plugins/webreport/narrativeweb.py:1956
 msgid "Whether to include a birth column"
 msgstr "Включать ли колонку с датами рождений"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1959
+#: ../gramps/plugins/webreport/narrativeweb.py:1960
 msgid "Include a column for death dates on the index pages"
 msgstr "Включить колонку с датами смерти на индексных страницах"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1960
+#: ../gramps/plugins/webreport/narrativeweb.py:1961
 msgid "Whether to include a death column"
 msgstr "Включать ли колонку с датами смерти"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1963
+#: ../gramps/plugins/webreport/narrativeweb.py:1964
 msgid "Include a column for partners on the index pages"
 msgstr "Включить колонку с данными о партнёре на индексных страницах"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1965
+#: ../gramps/plugins/webreport/narrativeweb.py:1966
 msgid "Whether to include a partners column"
 msgstr "Включать ли колонку с данными о партнёре"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1968
+#: ../gramps/plugins/webreport/narrativeweb.py:1969
 msgid "Include a column for parents on the index pages"
 msgstr "Включить колонку с данными о родителях на индексных страницах"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1970
+#: ../gramps/plugins/webreport/narrativeweb.py:1971
 msgid "Whether to include a parents column"
 msgstr "Включать ли колонку с данными о родителях"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1974
+#: ../gramps/plugins/webreport/narrativeweb.py:1975
 msgid "Include half and/ or step-siblings on the individual pages"
 msgstr "Включать братьев и сестёр на индивидуальной странице"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1977
+#: ../gramps/plugins/webreport/narrativeweb.py:1978
 msgid ""
 "Whether to include half and/ or step-siblings with the parents and siblings"
 msgstr "Включать братьев и сестёр с их родителями и братьями/сёстрами"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1988
+#: ../gramps/plugins/webreport/narrativeweb.py:1989
 msgid "Include family pages"
 msgstr "Включить семейные страницы"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1989
+#: ../gramps/plugins/webreport/narrativeweb.py:1990
 msgid "Whether or not to include family pages."
 msgstr "Включать или нет семейные страницы."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1992
+#: ../gramps/plugins/webreport/narrativeweb.py:1993
 msgid "Include event pages"
 msgstr "Включить страницы с событиями"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1994
+#: ../gramps/plugins/webreport/narrativeweb.py:1995
 msgid "Add a complete events list and relevant pages or not"
 msgstr "Включать ли полный список событий на отдельных страницах"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1997
+#: ../gramps/plugins/webreport/narrativeweb.py:1998
 msgid "Include places pages"
 msgstr "Включить места"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1999
+#: ../gramps/plugins/webreport/narrativeweb.py:2000
 msgid "Whether or not to include the places Pages."
 msgstr "Включать или нет страницы с местами."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2002
+#: ../gramps/plugins/webreport/narrativeweb.py:2003
 msgid "Include sources pages"
 msgstr "Включать источники"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2004
+#: ../gramps/plugins/webreport/narrativeweb.py:2005
 msgid "Whether or not to include the sources Pages."
 msgstr "Включать или нет страницы с источниками."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2007
+#: ../gramps/plugins/webreport/narrativeweb.py:2008
 msgid "Include repository pages"
 msgstr "Включить страницы с источниками"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2009
+#: ../gramps/plugins/webreport/narrativeweb.py:2010
 msgid "Whether or not to include the Repository Pages."
 msgstr "Включать или нет страницы с источниками."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2013
+#: ../gramps/plugins/webreport/narrativeweb.py:2014
 msgid "Include GENDEX file (/gendex.txt)"
 msgstr "Включить файл GENDEX (/gendex.txt)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2014
+#: ../gramps/plugins/webreport/narrativeweb.py:2015
 msgid "Whether to include a GENDEX file or not"
 msgstr "Включать ли файл GENDEX"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2017
+#: ../gramps/plugins/webreport/narrativeweb.py:2018
 msgid "Include address book pages"
 msgstr "Включить страницы с адресами"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2018
+#: ../gramps/plugins/webreport/narrativeweb.py:2019
 msgid ""
 "Whether or not to add Address Book pages,which can include e-mail and "
 "website addresses and personal address/ residence events."
@@ -36845,35 +37536,35 @@ msgstr ""
 "Добавлять или нет страницы с адресами, которые могут содержать адреса "
 "электронной почты, веб-страницы и почтовые адреса, места жительство."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2024
+#: ../gramps/plugins/webreport/narrativeweb.py:2025
 msgid "Include the statistics page"
 msgstr "Включать страницу статистики"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2025
+#: ../gramps/plugins/webreport/narrativeweb.py:2026
 msgid "Whether or not to add statistics page"
 msgstr "Включать или нет страницу статистики."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2032
+#: ../gramps/plugins/webreport/narrativeweb.py:2033
 msgid "Place Map Options"
 msgstr "Отображение мест на карте"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2037
+#: ../gramps/plugins/webreport/narrativeweb.py:2038
 msgid "Google"
 msgstr "Карты Google"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2038
+#: ../gramps/plugins/webreport/narrativeweb.py:2039
 msgid "Map Service"
 msgstr "Картографический сервис"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2042
+#: ../gramps/plugins/webreport/narrativeweb.py:2043
 msgid "Choose your choice of map service for creating the Place Map Pages."
 msgstr "Выберите картографический сервис для создания страниц мест на карте."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2048
+#: ../gramps/plugins/webreport/narrativeweb.py:2049
 msgid "Include Place map on Place Pages"
 msgstr "Включить карту на страницах с местоположениями"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2050
+#: ../gramps/plugins/webreport/narrativeweb.py:2051
 msgid ""
 "Whether to include a place map on the Place Pages, where Latitude/ Longitude "
 "are available."
@@ -36881,11 +37572,11 @@ msgstr ""
 "Включать ли карту на странице с местоположениями для мест с известными "
 "широтой и долготой."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2055
+#: ../gramps/plugins/webreport/narrativeweb.py:2056
 msgid "Include Family Map Pages with all places shown on the map"
 msgstr "Включать страницы карт семьи со всеми местами отмеченными на карте"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2059
+#: ../gramps/plugins/webreport/narrativeweb.py:2060
 msgid ""
 "Whether or not to add an individual page map showing all the places on this "
 "page. This will allow you to see how your family traveled around the country."
@@ -36894,58 +37585,58 @@ msgstr ""
 "упомянутые на данной странице. Это позволит видеть, как ваша семья "
 "переезжала."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2067
+#: ../gramps/plugins/webreport/narrativeweb.py:2068
 msgid "Family Links"
 msgstr "Семейные связи"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2068
+#: ../gramps/plugins/webreport/narrativeweb.py:2069
 msgid "Drop"
 msgstr "Не показывать маркеры"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2069
+#: ../gramps/plugins/webreport/narrativeweb.py:2070
 msgid "Markers"
 msgstr "Маркеры"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2070
+#: ../gramps/plugins/webreport/narrativeweb.py:2071
 msgid "Google/ FamilyMap Option"
 msgstr "Настройки Google/ Семейной карты"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2075
+#: ../gramps/plugins/webreport/narrativeweb.py:2076
 msgid ""
 "Select which option that you would like to have for the Google Maps Family "
 "Map pages..."
 msgstr "Выберите параметр для страниц с картами Google и Семейными картами..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2079
+#: ../gramps/plugins/webreport/narrativeweb.py:2080
 msgid "Google maps API key"
 msgstr "API-ключ для карт Google"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2080
+#: ../gramps/plugins/webreport/narrativeweb.py:2081
 msgid "The API key used for the Google maps"
 msgstr "API-ключ используемый для карт Google"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2089
+#: ../gramps/plugins/webreport/narrativeweb.py:2090
 msgid "Other inclusion (CMS, Web Calendar, Php)"
 msgstr "Включить другое (CMS, Веб-календарь, Php)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2093
+#: ../gramps/plugins/webreport/narrativeweb.py:2094
 msgid "Do we include these pages in a cms web ?"
 msgstr "Включать эти страницы в cms веб?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2097
-#: ../gramps/plugins/webreport/narrativeweb.py:2114
+#: ../gramps/plugins/webreport/narrativeweb.py:2098
+#: ../gramps/plugins/webreport/narrativeweb.py:2115
 msgid "URI"
 msgstr "URI"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2103
+#: ../gramps/plugins/webreport/narrativeweb.py:2104
 msgid "Where do you place your web site ? default = /NAVWEB"
 msgstr "Где размещён веб сайт? по умолчанию = /NAVWEB"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2110
+#: ../gramps/plugins/webreport/narrativeweb.py:2111
 msgid "Do we include the web calendar ?"
 msgstr "Включать веб-календарь?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2120
+#: ../gramps/plugins/webreport/narrativeweb.py:2121
 msgid "Where do you place your web site ? default = /WEBCAL"
 msgstr "Где размещён веб сайт? по умолчанию = /WEBCAL"
 
@@ -37552,6 +38243,33 @@ msgstr "Небраска"
 msgid "No style sheet"
 msgstr "Без стилевого листа"
 
+#~ msgid "unmarried|husband"
+#~ msgstr "гражданский муж"
+
+#~ msgid "unmarried|wife"
+#~ msgstr "гражданская жена"
+
+#~ msgid "gender unknown,unmarried|spouse"
+#~ msgstr "гражданский супруг"
+
+#~ msgid "unmarried|ex-husband"
+#~ msgstr "бывший гражданский муж"
+
+#~ msgid "unmarried|ex-wife"
+#~ msgstr "бывшая гражданская жена"
+
+#~ msgid "gender unknown,unmarried|ex-spouse"
+#~ msgstr "бывший гражданский супруг(-а)"
+
+#~ msgid ""
+#~ "You need to set a 'default person' to go to. Select the People View, "
+#~ "select the person you want as 'Home Person', then confirm your choice via "
+#~ "the menu Edit ->Set Home Person."
+#~ msgstr ""
+#~ "Нужно назначить «базовое лицо». Выберите вид «Люди», выберите лицо, "
+#~ "которое хотите назначить в качестве базового, затем подтвердите выбор из "
+#~ "меню «Правка -> Установить базовое лицо»."
+
 #~ msgid ""
 #~ "<b>Improving Gramps</b><br/>Users are encouraged to request enhancements "
 #~ "to Gramps. Requesting an enhancement can be done either through the "
@@ -37618,134 +38336,20 @@ msgstr "Без стилевого листа"
 #~ msgid "Border Family"
 #~ msgstr "Рамка для семьи"
 
-#~ msgid "Make Active Person"
-#~ msgstr "Установить активное лицо"
-
-#~ msgid "Make Home Person"
-#~ msgstr "Установить базовое лицо"
-
 #~ msgid "Web Connect"
 #~ msgstr "Веб содержимое"
 
 #~ msgid "manual|Repositories"
 #~ msgstr "Хранилища"
 
-#~ msgid "Connect to a recent database"
-#~ msgstr "Открыть недавно использовавшуюся базу данных"
-
-#~ msgid "_Family Trees"
-#~ msgstr "_Семейные древа"
-
-#~ msgid "_Manage Family Trees..."
-#~ msgstr "_Управление семейными древами..."
-
-#~ msgid "Manage databases"
-#~ msgstr "Управление базами данных"
-
-#~ msgid "Open _Recent"
-#~ msgstr "Открыть не_давнее"
-
 #~ msgid "Open an existing database"
 #~ msgstr "Открыть существующую базу данных"
-
-#~ msgid "_Quit"
-#~ msgstr "_Выйти"
-
-#~ msgid "_View"
-#~ msgstr "_Вид"
-
-#~ msgid "_Preferences..."
-#~ msgstr "_Настройки..."
-
-#~ msgid "Gramps _Home Page"
-#~ msgstr "_Домашняя страница Gramps"
-
-#~ msgid "Gramps _Mailing Lists"
-#~ msgstr "_Списки рассылки Gramps"
-
-#~ msgid "_Report a Bug"
-#~ msgstr "О_тправить отчёт об ошибке"
-
-#~ msgid "_Extra Reports/Tools"
-#~ msgstr "_Дополнительные отчёты/инструменты"
-
-#~ msgid "_About"
-#~ msgstr "О _программе"
-
-#~ msgid "_Plugin Manager"
-#~ msgstr "_Менеджер дополнений"
-
-#~ msgid "_FAQ"
-#~ msgstr "_ЧАВО"
-
-#~ msgid "_Key Bindings"
-#~ msgstr "_Горячие клавиши"
-
-#~ msgid "_User Manual"
-#~ msgstr "_Руководство пользователя"
 
 #~ msgid "Close the current database"
 #~ msgstr "Закрыть текущую базу данных"
 
-#~ msgid "_Export..."
-#~ msgstr "_Экспорт..."
-
-#~ msgid "Make Backup..."
-#~ msgstr "Сделать резервную копию..."
-
 #~ msgid "Make a Gramps XML backup of the database"
 #~ msgstr "Сделать резервную копию базы данных в формате Gramps XML"
-
-#~ msgid "_Abandon Changes and Quit"
-#~ msgstr "От_казаться от изменений и выйти"
-
-#~ msgid "_Reports"
-#~ msgstr "_Отчёты"
-
-#~ msgid "Open the reports dialog"
-#~ msgstr "Открыть диалог отчётов"
-
-#~ msgid "_Go"
-#~ msgstr "Пере_ход"
-
-#~ msgid "Books..."
-#~ msgstr "Книги..."
-
-#~ msgid "_Windows"
-#~ msgstr "_Окна"
-
-#~ msgid "Clip_board"
-#~ msgstr "Буфер обмена"
-
-#~ msgid "Open the Clipboard dialog"
-#~ msgstr "Открыть диалог «Буфер обмена»"
-
-#~ msgid "_Import..."
-#~ msgstr "_Импорт..."
-
-#~ msgid "_Tools"
-#~ msgstr "_Инструменты"
-
-#~ msgid "Open the tools dialog"
-#~ msgstr "Открыть диалог инструментов"
-
-#~ msgid "_Bookmarks"
-#~ msgstr "_Закладки"
-
-#~ msgid "_Configure..."
-#~ msgstr "Настроить вид..."
-
-#~ msgid "Configure the active view"
-#~ msgstr "Настроить активный вид"
-
-#~ msgid "_Navigator"
-#~ msgstr "_Навигатор"
-
-#~ msgid "_Toolbar"
-#~ msgstr "_Панель инструментов"
-
-#~ msgid "F_ull Screen"
-#~ msgstr "Полно_экранный режим"
 
 #~ msgid "Undo History..."
 #~ msgstr "История откатов..."
@@ -37753,65 +38357,11 @@ msgstr "Без стилевого листа"
 #~ msgid "Key %s is not bound"
 #~ msgstr "Клавиша %s не назначена"
 
-#~ msgid "_Add..."
-#~ msgstr "До_бавить..."
-
-#~ msgid "_Merge..."
-#~ msgstr "_Объединить..."
-
-#~ msgid "Export View..."
-#~ msgstr "Экспортировать вид..."
-
 #~ msgid "_Delete Item"
 #~ msgstr "У_далить элемент"
 
-#~ msgid "_Add Bookmark"
-#~ msgstr "_Добавить закладку"
-
 #~ msgid "%(title)s..."
 #~ msgstr "%(title)s..."
-
-#~ msgid "Go to the next object in the history"
-#~ msgstr "Перейти на следующий объект в истории"
-
-#~ msgid "_Back"
-#~ msgstr "_Назад"
-
-#~ msgid "Go to the previous object in the history"
-#~ msgstr "Перейти на предыдущий объект в истории"
-
-#~ msgid "Go to the default person"
-#~ msgstr "Перейти на базовое лицо"
-
-#~ msgid "_Sidebar"
-#~ msgstr "_Боковая панель"
-
-#~ msgid "_Bottombar"
-#~ msgstr "_Нижняя панель"
-
-#~ msgid "New Tag..."
-#~ msgstr "Новая метка..."
-
-#~ msgid "Organize Tags..."
-#~ msgstr "Управление метками..."
-
-#~ msgid "Tag selected rows"
-#~ msgstr "Добавить метки к выделенным строкам"
-
-#~ msgid "Font Color"
-#~ msgstr "Цвет шрифта"
-
-#~ msgid "Background Color"
-#~ msgstr "Цвет фона"
-
-#~ msgid "Clear Markup"
-#~ msgstr "Стереть разметку"
-
-#~ msgid "Undo"
-#~ msgstr "Откатить"
-
-#~ msgid "Redo"
-#~ msgstr "Вернуть"
 
 #~ msgid "%(genders)s born %(year_from)04d-%(year_to)04d"
 #~ msgstr "%(genders)s рождённые %(year_from)04d-%(year_to)04d"
@@ -37837,27 +38387,8 @@ msgstr "Без стилевого листа"
 #~ msgid "Not a Pro-Gen file"
 #~ msgstr "Файл не является файлом Pro-Gen"
 
-#~ msgid "Person Filter Editor"
-#~ msgstr "Редактор фильтров людей"
-
-#~ msgid "Web Connection"
-#~ msgstr "Веб соединение"
-
 #~ msgid "Loading..."
 #~ msgstr "Загрузка..."
-
-#~ msgid ""
-#~ "Attempt to see selected locations with a Map Service (OpenstreetMap, "
-#~ "Google Maps, ...)"
-#~ msgstr ""
-#~ "Попытаться посмотреть выделенные места в картографической службе "
-#~ "(OpenstreetMap, Google Maps, ...)"
-
-#~ msgid "Select a Map Service"
-#~ msgstr "Выберите картографическую службу"
-
-#~ msgid "_Look up with Map Service"
-#~ msgstr "Посмотреть на катре"
 
 #~ msgid ""
 #~ "Attempt to see this location with a Map Service (OpenstreetMap, Google "
@@ -37866,66 +38397,11 @@ msgstr "Без стилевого листа"
 #~ "Попытаться посмотреть это  место в картографической службе "
 #~ "(OpenstreetMap, Google Maps, ...)"
 
-#~ msgid "Place Filter Editor"
-#~ msgstr "Редактор фильтров мест"
-
-#~ msgid "_Print..."
-#~ msgstr "Напечатать..."
-
-#~ msgid "Print or save the Map"
-#~ msgstr "Напечатать или сохранить карту"
-
 #~ msgid "Map Menu"
 #~ msgstr "Меню карты"
 
 #~ msgid "manual|Media_Manager..."
 #~ msgstr "Управление_документами..."
-
-#~ msgid "Citation Filter Editor"
-#~ msgstr "Редактор фильтра цитат"
-
-#~ msgid "Add source..."
-#~ msgstr "Добавить источник..."
-
-#~ msgid "Add citation..."
-#~ msgstr "Добавить цитату..."
-
-#~ msgid "Expand all Nodes"
-#~ msgstr "Развернуть все узлы"
-
-#~ msgid "Collapse all Nodes"
-#~ msgstr "Свернуть все узлы"
-
-#~ msgid "Restore a gramplet"
-#~ msgstr "Восстановить грамплет"
-
-#~ msgid "Event Filter Editor"
-#~ msgstr "Редактор фильтров событий"
-
-#~ msgid "Family Filter Editor"
-#~ msgstr "Редактор фильтров семей"
-
-#~ msgid "Make Father Active Person"
-#~ msgstr "Установить отца как активное лицо"
-
-#~ msgid "Make Mother Active Person"
-#~ msgstr "Установить мать как активное лицо"
-
-#~ msgid "Print or save the Fan Chart View"
-#~ msgstr "Напечатать или сохранить Fan Chart View"
-
-#~ msgid "reference _Person"
-#~ msgstr "Исходное лицо"
-
-#~ msgid "Select the person which is the reference for life ways"
-#~ msgstr ""
-#~ "Выберите лицо, относительно которого будут рассчитаны жизненные маршруты"
-
-#~ msgid "reference _Family"
-#~ msgstr "Исходная семья"
-
-#~ msgid "Select the family which is the reference for life ways"
-#~ msgstr "Выберите исходную семью, жизненный путь которой хотите проследить"
 
 #~ msgid ""
 #~ "Geography functionality will not be available.\n"
@@ -37936,47 +38412,8 @@ msgstr "Без стилевого листа"
 #~ "Инструкция по сборке соответствующего модуля доступна на "
 #~ "%(gramps_wiki_build_osmgps_url)s"
 
-#~ msgid "Media Filter Editor"
-#~ msgstr "Редактор фильтров документов"
-
-#~ msgid "View in the default viewer"
-#~ msgstr "Просмотр в программе по умолчанию"
-
 #~ msgid "Open the folder containing the media file"
 #~ msgstr "Открыть папку, содержащую данный документ"
-
-#~ msgid "Note Filter Editor"
-#~ msgstr "Редактор фильтров заметок"
-
-#~ msgid "Expand this Entire Group"
-#~ msgstr "Развернуть всю группу"
-
-#~ msgid "Collapse this Entire Group"
-#~ msgstr "Свернуть всю группу"
-
-#~ msgid "_Reorder"
-#~ msgstr "_Упорядочить"
-
-#~ msgid "Change order of parents and families"
-#~ msgstr "Изменить порядок родителей и семей"
-
-#~ msgid "Edit..."
-#~ msgstr "Редактировать..."
-
-#~ msgid "Edit the active person"
-#~ msgstr "Редактировать активное лицо"
-
-#~ msgid "Add Partner..."
-#~ msgstr "Добавить партнёра..."
-
-#~ msgid "Add Existing Parents..."
-#~ msgstr "Добавить существующий набор родителей..."
-
-#~ msgid "Repository Filter Editor"
-#~ msgstr "Редактор фильтров хранилищ"
-
-#~ msgid "Source Filter Editor"
-#~ msgstr "Редактор фильтров источников"
 
 #~ msgid " (%s) "
 #~ msgstr " (%s) "
@@ -38581,9 +39018,6 @@ msgstr "Без стилевого листа"
 
 #~ msgid "Death place id"
 #~ msgstr "Место смерти (id)"
-
-#~ msgid "Gramps id"
-#~ msgstr "Gramps id"
 
 #~ msgid "Parent2"
 #~ msgstr "Родитель2"
@@ -41726,4 +42160,3 @@ msgstr "Без стилевого листа"
 #~ "Используйте https://gramps-project.org/bugs/ чтобы сообщить об ошибке в "
 #~ "официально поддерживаемых  видах, или свяжитесь с автором "
 #~ "(%(firstauthoremail)s) в противном случае. "
-

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,10 +14,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: gramps50\n"
+"Project-Id-Version: gramps51\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-06-21 10:20+0300\n"
-"PO-Revision-Date: 2019-06-21 10:53+0300\n"
+"POT-Creation-Date: 2019-07-18 08:37+0300\n"
+"PO-Revision-Date: 2019-07-18 08:39+0300\n"
 "Last-Translator: Ivan Komaritsyn <vantu5z@mail.ru>\n"
 "Language-Team: Russian\n"
 "Language: ru\n"
@@ -6578,7 +6578,7 @@ msgstr "Цитаты"
 #: ../gramps/plugins/view/noteview.py:110 ../gramps/plugins/view/view.gpr.py:97
 #: ../gramps/plugins/view/view.gpr.py:105
 #: ../gramps/plugins/webreport/basepage.py:1264
-#: ../gramps/plugins/webreport/person.py:1242
+#: ../gramps/plugins/webreport/person.py:1240
 msgid "Notes"
 msgstr "Заметки"
 
@@ -6654,7 +6654,7 @@ msgstr "Заметки"
 #: ../gramps/plugins/webreport/event.py:177
 #: ../gramps/plugins/webreport/media.py:230
 #: ../gramps/plugins/webreport/media.py:564
-#: ../gramps/plugins/webreport/person.py:892
+#: ../gramps/plugins/webreport/person.py:890
 msgid "Date"
 msgstr "Дата"
 
@@ -6984,7 +6984,7 @@ msgstr "Цитата"
 #: ../gramps/plugins/webreport/event.py:178
 #: ../gramps/plugins/webreport/event.py:391
 #: ../gramps/plugins/webreport/media.py:541
-#: ../gramps/plugins/webreport/person.py:1470
+#: ../gramps/plugins/webreport/person.py:1468
 #: ../gramps/plugins/webreport/repository.py:245
 #: ../gramps/plugins/webreport/source.py:261
 msgid "Gramps ID"
@@ -7860,7 +7860,7 @@ msgstr "аннул."
 #: ../gramps/plugins/textreport/tagreport.py:252
 #: ../gramps/plugins/view/familyview.py:80
 #: ../gramps/plugins/view/relview.py:1053
-#: ../gramps/plugins/webreport/person.py:1631
+#: ../gramps/plugins/webreport/person.py:1629
 msgid "Father"
 msgstr "Отец"
 
@@ -7882,7 +7882,7 @@ msgstr "Отец"
 #: ../gramps/plugins/textreport/tagreport.py:258
 #: ../gramps/plugins/view/familyview.py:81
 #: ../gramps/plugins/view/relview.py:1054
-#: ../gramps/plugins/webreport/person.py:1644
+#: ../gramps/plugins/webreport/person.py:1642
 msgid "Mother"
 msgstr "Мать"
 
@@ -7911,7 +7911,7 @@ msgstr "Дети"
 #: ../gramps/plugins/webreport/basepage.py:1650
 #: ../gramps/plugins/webreport/event.py:141
 #: ../gramps/plugins/webreport/event.py:366
-#: ../gramps/plugins/webreport/person.py:1529
+#: ../gramps/plugins/webreport/person.py:1527
 msgid "Events"
 msgstr "События"
 
@@ -8204,7 +8204,7 @@ msgstr "Регион"
 #: ../gramps/plugins/tool/removeunused.py:201
 #: ../gramps/plugins/tool/verify.py:579 ../gramps/plugins/view/repoview.py:85
 #: ../gramps/plugins/webreport/basepage.py:397
-#: ../gramps/plugins/webreport/person.py:1855
+#: ../gramps/plugins/webreport/person.py:1853
 msgid "Name"
 msgstr "Имя"
 
@@ -8559,7 +8559,7 @@ msgstr "Заметка о ссылке на ребёнка"
 #: ../gramps/plugins/tool/reorderids.glade:761
 #: ../gramps/plugins/webreport/event.py:180
 #: ../gramps/plugins/webreport/family.py:188
-#: ../gramps/plugins/webreport/person.py:1240
+#: ../gramps/plugins/webreport/person.py:1238
 msgid "Person"
 msgstr "Лицо"
 
@@ -8573,7 +8573,7 @@ msgstr "Лицо"
 #: ../gramps/plugins/lib/libpersonview.py:100
 #: ../gramps/plugins/quickview/siblings.py:48
 #: ../gramps/plugins/textreport/indivcomplete.py:928
-#: ../gramps/plugins/webreport/person.py:1481
+#: ../gramps/plugins/webreport/person.py:1479
 msgid "Gender"
 msgstr "Пол"
 
@@ -15020,7 +15020,7 @@ msgstr "Участники"
 #: ../gramps/gui/widgets/reorderfam.py:103
 #: ../gramps/plugins/textreport/tagreport.py:264
 #: ../gramps/plugins/view/familyview.py:82
-#: ../gramps/plugins/webreport/person.py:1241
+#: ../gramps/plugins/webreport/person.py:1239
 msgid "Relationship"
 msgstr "Отношение"
 
@@ -15030,7 +15030,7 @@ msgstr "любой"
 
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:134
 #: ../gramps/plugins/export/exportcsv.py:357
-#: ../gramps/plugins/webreport/person.py:1856
+#: ../gramps/plugins/webreport/person.py:1854
 msgid "Birth date"
 msgstr "Дата рождения"
 
@@ -15042,7 +15042,7 @@ msgstr "пример: «%(msg1)s» или «%(msg2)s»"
 
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:136
 #: ../gramps/plugins/export/exportcsv.py:359
-#: ../gramps/plugins/webreport/person.py:1857
+#: ../gramps/plugins/webreport/person.py:1855
 msgid "Death date"
 msgstr "Дата смерти"
 
@@ -17991,7 +17991,7 @@ msgstr "Объединить людей"
 #: ../gramps/plugins/view/relview.py:659 ../gramps/plugins/view/relview.py:1017
 #: ../gramps/plugins/view/relview.py:1052
 #: ../gramps/plugins/webreport/person.py:232
-#: ../gramps/plugins/webreport/person.py:1839
+#: ../gramps/plugins/webreport/person.py:1837
 #: ../gramps/plugins/webreport/surname.py:154
 msgid "Parents"
 msgstr "Родители"
@@ -20191,6 +20191,19 @@ msgid "Generates documents in plain text format (.txt)."
 msgstr "Создаёт документы в формате «просто текст» (.txt)."
 
 #: ../gramps/plugins/docgen/docgen.gpr.py:55
+#: ../gramps/plugins/view/fanchartview.py:164
+#: ../gramps/plugins/view/fanchartview.py:227
+#: ../gramps/plugins/view/geoclose.py:91 ../gramps/plugins/view/geoclose.py:167
+#: ../gramps/plugins/view/geoevents.py:81
+#: ../gramps/plugins/view/geoevents.py:129
+#: ../gramps/plugins/view/geofamclose.py:89
+#: ../gramps/plugins/view/geofamclose.py:165
+#: ../gramps/plugins/view/geofamily.py:81
+#: ../gramps/plugins/view/geofamily.py:131
+#: ../gramps/plugins/view/geomoves.py:88 ../gramps/plugins/view/geomoves.py:151
+#: ../gramps/plugins/view/geoperson.py:89
+#: ../gramps/plugins/view/geoplaces.py:84
+#: ../gramps/plugins/view/geoplaces.py:134
 msgid "Print..."
 msgstr "Печать..."
 
@@ -22572,7 +22585,7 @@ msgstr "Показывает потомков активного лица"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:104
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:111
-#: ../gramps/plugins/webreport/person.py:1177
+#: ../gramps/plugins/webreport/person.py:1175
 msgid "Ancestors"
 msgstr "Предки"
 
@@ -22638,7 +22651,7 @@ msgstr "Показывает имена в виде текстового обл�
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:205
 #: ../gramps/plugins/view/pedigreeview.py:528
 #: ../gramps/plugins/view/view.gpr.py:127
-#: ../gramps/plugins/webreport/person.py:1346
+#: ../gramps/plugins/webreport/person.py:1344
 msgid "Pedigree"
 msgstr "Родословная"
 
@@ -23057,7 +23070,7 @@ msgstr "Показывает все записи, ссылающиеся на в
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:981
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:995
 #: ../gramps/plugins/webreport/basepage.py:2959
-#: ../gramps/plugins/webreport/person.py:878
+#: ../gramps/plugins/webreport/person.py:876
 #: ../gramps/plugins/webreport/thumbnail.py:164
 msgid "References"
 msgstr "Ссылки"
@@ -24475,8 +24488,7 @@ msgstr "Использовать шестиугольники"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:834
 msgid "Use hexagons to differentiate those of unknown gender."
-msgstr ""
-"Использовать шестиугольники для выделения лиц с неизвестным полом."
+msgstr "Использовать шестиугольники для выделения лиц с неизвестным полом."
 
 #. ###############################
 #: ../gramps/plugins/graph/gvrelgraph.py:862
@@ -30770,7 +30782,7 @@ msgstr "Место события"
 #: ../gramps/plugins/quickview/all_events.py:60
 #: ../gramps/plugins/quickview/all_events.py:109
 #: ../gramps/plugins/quickview/all_events.py:124
-#: ../gramps/plugins/webreport/person.py:894
+#: ../gramps/plugins/webreport/person.py:892
 msgid "Event Type"
 msgstr "Тип события"
 
@@ -31045,7 +31057,7 @@ msgstr "Люди"
 #: ../gramps/plugins/webreport/basepage.py:1531
 #: ../gramps/plugins/webreport/basepage.py:1583
 #: ../gramps/plugins/webreport/basepage.py:1652
-#: ../gramps/plugins/webreport/person.py:1243
+#: ../gramps/plugins/webreport/person.py:1241
 #: ../gramps/plugins/webreport/source.py:130
 #: ../gramps/plugins/webreport/source.py:227
 msgid "Sources"
@@ -32502,7 +32514,7 @@ msgid "Alternate Parents"
 msgstr "Альтернативные родители"
 
 #: ../gramps/plugins/textreport/indivcomplete.py:445
-#: ../gramps/plugins/webreport/person.py:1228
+#: ../gramps/plugins/webreport/person.py:1226
 msgid "Associations"
 msgstr "Связи"
 
@@ -35658,22 +35670,6 @@ msgstr "Квадрант"
 msgid "Show gramps id"
 msgstr "Показывать Gramps ID"
 
-#: ../gramps/plugins/view/fanchartview.py:164
-#: ../gramps/plugins/view/fanchartview.py:227
-#: ../gramps/plugins/view/geoclose.py:91 ../gramps/plugins/view/geoclose.py:167
-#: ../gramps/plugins/view/geoevents.py:81
-#: ../gramps/plugins/view/geoevents.py:129
-#: ../gramps/plugins/view/geofamclose.py:89
-#: ../gramps/plugins/view/geofamclose.py:165
-#: ../gramps/plugins/view/geofamily.py:81
-#: ../gramps/plugins/view/geofamily.py:131
-#: ../gramps/plugins/view/geomoves.py:88 ../gramps/plugins/view/geomoves.py:151
-#: ../gramps/plugins/view/geoperson.py:89
-#: ../gramps/plugins/view/geoplaces.py:84
-#: ../gramps/plugins/view/geoplaces.py:134
-msgid "_Print..."
-msgstr "Напечатать..."
-
 #: ../gramps/plugins/view/fanchartview.py:227
 msgid "Print or save the Fan Chart View"
 msgstr "Напечатать или сохранить Fan Chart View"
@@ -36818,7 +36814,7 @@ msgstr "С.П.Д."
 #: ../gramps/plugins/webreport/basepage.py:2344
 #: ../gramps/plugins/webreport/basepage.py:2345
 #: ../gramps/plugins/webreport/person.py:630
-#: ../gramps/plugins/webreport/person.py:941
+#: ../gramps/plugins/webreport/person.py:939
 msgid "Family Map"
 msgstr "Карта семьи"
 
@@ -37671,13 +37667,13 @@ msgstr "<отсутствует>"
 msgid "Surnames %(surname)s beginning with letter %(letter)s"
 msgstr "Фамилии %(surname)s на букву %(letter)s"
 
-#: ../gramps/plugins/webreport/person.py:792
+#: ../gramps/plugins/webreport/person.py:790
 #, python-format
 msgid "Tracking %s"
 msgstr "Отслеживание %s"
 
 #. page description
-#: ../gramps/plugins/webreport/person.py:797
+#: ../gramps/plugins/webreport/person.py:795
 msgid ""
 "This map page represents that person and any descendants with all of their "
 "event/ places. If you place your mouse over the marker it will display the "
@@ -37690,47 +37686,47 @@ msgstr ""
 "Отметки и ссылки хранятся с сортировкой по дате (если такая есть). Клик на "
 "имени места в разделе ссылок перенесёт Вас на страницу данного места."
 
-#: ../gramps/plugins/webreport/person.py:868
+#: ../gramps/plugins/webreport/person.py:866
 msgid "Drop Markers"
 msgstr "Не показывать маркеры"
 
-#: ../gramps/plugins/webreport/person.py:893
+#: ../gramps/plugins/webreport/person.py:891
 msgid "Place Title"
 msgstr "Название места"
 
-#: ../gramps/plugins/webreport/person.py:1440
+#: ../gramps/plugins/webreport/person.py:1438
 msgid "Call Name"
 msgstr "Имя в быту"
 
-#: ../gramps/plugins/webreport/person.py:1458
+#: ../gramps/plugins/webreport/person.py:1456
 msgid "Nick Name"
 msgstr "Прозвище"
 
-#: ../gramps/plugins/webreport/person.py:1504
+#: ../gramps/plugins/webreport/person.py:1502
 msgid "Age at Death"
 msgstr "Возраст на момент смерти"
 
-#: ../gramps/plugins/webreport/person.py:1634
+#: ../gramps/plugins/webreport/person.py:1632
 msgid "Stepfather"
 msgstr "Отчим"
 
-#: ../gramps/plugins/webreport/person.py:1647
+#: ../gramps/plugins/webreport/person.py:1645
 msgid "Stepmother"
 msgstr "Мачеха"
 
-#: ../gramps/plugins/webreport/person.py:1675
+#: ../gramps/plugins/webreport/person.py:1673
 msgid "Not siblings"
 msgstr "Не братья/сестры"
 
-#: ../gramps/plugins/webreport/person.py:1817
+#: ../gramps/plugins/webreport/person.py:1815
 msgid "Relation to the center person"
 msgstr "Родство с базовым лицом"
 
-#: ../gramps/plugins/webreport/person.py:1854
+#: ../gramps/plugins/webreport/person.py:1852
 msgid "Relation to main person"
 msgstr "Родство с базовым лицом"
 
-#: ../gramps/plugins/webreport/person.py:1858
+#: ../gramps/plugins/webreport/person.py:1856
 msgid "Relation within this family (if not by birth)"
 msgstr "Отношение к этой семье (для не родных)"
 
@@ -37759,7 +37755,7 @@ msgid "Places beginning with letter %s"
 msgstr "Места на букву %s"
 
 #. section title
-#: ../gramps/plugins/webreport/place.py:408
+#: ../gramps/plugins/webreport/place.py:406
 msgid "Place Map"
 msgstr "Карта места"
 


### PR DESCRIPTION
Fixes #10868.

Places list is not sorted depending on the selected language.

If you start gramps in english or another language then try to generated
a narrative web report in another language, the navigation alphabet is
incorrect. This is true for the place list and the person list.
The problem was related to pyICU.