### PR TITLE
fix crash when using sidebar filter and merging in another view

### DIFF
--- a/gramps/gui/views/treemodels/flatbasemodel.py
+++ b/gramps/gui/views/treemodels/flatbasemodel.py
@@ -396,9 +396,9 @@ class FlatNodeMap:
             self.__corr = (len(self._index2hndl) - 1, -1)
         return Gtk.TreePath((self.real_path(insert_pos),))
 
-    def delete(self, srtkey_hndl):
+    def delete(self, handle):
         """
-        Delete the row with the given (sortkey, handle).
+        Delete the row with the given (handle).
         This then rebuilds the hndl2index, subtracting one from each item
         greater than the deleted index.
         path of deleted row is returned
@@ -411,14 +411,10 @@ class FlatNodeMap:
         """
         #remove it from the full list first
         if not self._identical:
-            del_pos = bisect.bisect_left(self._fullhndl, srtkey_hndl)
-            #check that indeed this is correct:
-            if not self._fullhndl[del_pos][1] == srtkey_hndl[1]:
-                raise KeyError('Handle %s not in list of all handles' %  \
-                                                srtkey_hndl[1])
-            del self._fullhndl[del_pos]
+            for indx in range(len(self._fullhndl)):
+                if self._fullhndl[indx][1] == handle:
+                    del self._fullhndl[indx]
         #now remove it from the index maps
-        handle = srtkey_hndl[1]
         try:
             index = self._hndl2index[handle]
         except KeyError:
@@ -431,9 +427,10 @@ class FlatNodeMap:
         if self._reverse:
             self.__corr = (len(self._index2hndl) - 1, -1)
         #update the handle2path map so it remains correct
-        for srt_key,hndl in self._index2hndl[index:]:
+        for dummy_srt_key, hndl in self._index2hndl[index:]:
             self._hndl2index[hndl] -= 1
         return Gtk.TreePath((delpath,))
+
 
 #-------------------------------------------------------------------------
 #
@@ -657,14 +654,10 @@ class FlatBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
         """
         Delete a row, called after the object with handle is deleted
         """
-        assert isinstance(handle, str)
-        if self.node_map.get_path_from_handle(handle) is None:
-            return # row is not currently displayed
-        self.clear_cache(handle)
-        delete_val = (self.node_map.get_sortkey(handle), handle)
-        delete_path = self.node_map.delete(delete_val)
+        delete_path = self.node_map.delete(handle)
         #delete_path is an integer from 0 to n-1
         if delete_path is not None:
+            self.clear_cache(handle)
             self.row_deleted(delete_path)
 
     def update_row_by_handle(self, handle):


### PR DESCRIPTION
Fixes [#11089](https://gramps-project.org/bugs/view.php?id=11089), [#11064](https://gramps-project.org/bugs/view.php?id=11064), [#11134](https://gramps-project.org/bugs/view.php?id=11134)

Took quite a while to figure out how to replicate this (multiple days over several attempts).
To replicate:
1) add two sources that will be merged.
2) Go to Source flat view
3) Use the sidebar filter to select for one of the sources (the other must be hidden)
4) go to Citation Tree view
5) select the two sources and start the merge
6) Make sure that the source that will go away (NOT the primary data source) is the one that is hidden in step 3
7) Ok to finish the merge. You should get the exception.

This is an issue with the use of the sidebar filter. One of the 'caches' (FlatNodeMap._fullhndl) of handle data is not getting updated for deletes (which is one step of a merge); only when a sidebar filter is active.
When the sidebar filter tried to use the list of items from that cache, it got HandleError for the bad handle.

It was difficult to replicate because you had to have a sidebar filter active, and you had to merge out/delete an object that was hidden due to the filter, and the view with the filter active had to NOT be the active view.