### PR TITLE
Add missing 'get_number_of_citations' method

### DIFF
--- a/gramps/gen/db/dummydb.py
+++ b/gramps/gen/db/dummydb.py
@@ -756,7 +756,7 @@ class DummyDb(M_A_M_B("NewBaseClass", (DbReadBase, Callback, object,), {})):
         if not self.db_is_open:
             LOG.warning("database is closed")
         return 0
-    
+
     def get_number_of_citations(self):
         """
         Return the number of citations currently in the database.

--- a/gramps/gen/db/dummydb.py
+++ b/gramps/gen/db/dummydb.py
@@ -32,7 +32,7 @@ database to fetch data from). Thus, dbstate.db cannot be left as 'None' because
 None has no 'is_open' attribute. Therefore this database class is provided so
 that it can be instantiated for dbstate.db.
 
-FIXME: Ideally, only is_open() needs to be implemented here, bacause that is the
+FIXME: Ideally, only is_open() needs to be implemented here, because that is the
 only method that should really be called, but the Gramps code is not perfect,
 and many other methods are called. Calls of other methods could be considered
 bugs, so when these are fixed, this class could be reduced.

--- a/gramps/gen/db/dummydb.py
+++ b/gramps/gen/db/dummydb.py
@@ -756,6 +756,14 @@ class DummyDb(M_A_M_B("NewBaseClass", (DbReadBase, Callback, object,), {})):
         if not self.db_is_open:
             LOG.warning("database is closed")
         return 0
+    
+    def get_number_of_citations(self):
+        """
+        Return the number of citations currently in the database.
+        """
+        if not self.db_is_open:
+            LOG.warning("database is closed")
+        return 0
 
     def get_number_of_tags(self):
         """

--- a/gramps/plugins/db/bsddb/test/db_test.py
+++ b/gramps/plugins/db/bsddb/test/db_test.py
@@ -81,6 +81,7 @@ class DbTest(unittest.TestCase):
         "get_number_of_places",
         "get_number_of_repositories",
         "get_number_of_sources",
+        "get_number_of_citations",
         "get_number_of_tags",
         "get_media_from_gramps_id",
         "get_media_from_handle",


### PR DESCRIPTION
I got a cryptic issue (_can reproduce it via etree gramplet or calling self.db.get_number_of_citations() without db loaded_). 
The method for citation objects seems missing and it returns a "NotImplementedError"
on some specific cases. I suppose it can raise an error too if number of citations is 0
after changes on db status but I cannot provide a proper testcase for this hypothesis.
So, just use the same method as the others primary objects on dummydb module.

See #857 and more details on [addons](https://github.com/gramps-project/addons-source/pull/214). 

Also missing on gramps50 and gramps51 branches.