### PR TITLE
Fix GEDCOM importer to properly handle multiple surnames per 5.5.1

### DIFF
--- a/data/tests/exp_sample_ged.ged
+++ b/data/tests/exp_sample_ged.ged
@@ -2,8 +2,8 @@
 1 SOUR Gramps
 2 VERS 5.0.2
 2 NAME Gramps
-1 DATE 5 MAR 2019
-2 TIME 09:11:15
+1 DATE 31 JUL 2019
+2 TIME 10:58:33
 1 SUBM @SUBM@
 1 FILE C:\Users\prc\AppData\Roaming\gramps\temp\exp_sample_ged.ged
 1 COPR Copyright (c) 2019 Alex Roitman,,,.
@@ -885,7 +885,7 @@
 0 @I0046@ INDI
 1 NAME Tom /Von Tester y tested/
 2 GIVN Tom
-2 SPFX Von, 
+2 SPFX Von
 2 SURN Tester y, tested
 2 NICK TesterNickname
 1 SEX M
@@ -1420,7 +1420,7 @@
 0 @N0018@ NOTE Another Citation Note
 0 @N0019@ NOTE A bad photo for sure
 0 @O0000@ OBJE
-1 FILE c:\msys64\mingw64\share\gramps\tests\O0.jpg
+1 FILE c:\users\prc\workspace\grampsm\main\data\tests\O0.jpg
 2 FORM jpg
 2 TITL Michael O'Toole 2015-11
 1 NOTE @N0019@

--- a/data/tests/imp_sample.ged
+++ b/data/tests/imp_sample.ged
@@ -50,9 +50,9 @@
 0 @I0@ INDI
 1 NAME Anna /Hansdotter/
 2 GIVN Anna
+2 SURN Hansdotter, Smith
+2 SPFX Vrow, huh
 2 SURN Hansdotter
-2 SPFX Vrow
-2 SURN Smith
 2 _AKA Anna Smith
 2 _AKA Hanna
 2 NOTE Hans daughter? N0000

--- a/data/tests/imp_sample.gramps
+++ b/data/tests/imp_sample.gramps
@@ -3,7 +3,7 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2019-03-05" version="5.0.2"/>
+    <created date="2019-07-31" version="5.0.2"/>
     <researcher>
       <resname>Alex Roitman,,,</resname>
       <resaddr>Not Provided</resaddr>
@@ -617,7 +617,8 @@
       <gender>F</gender>
       <name type="Birth Name">
         <first>Anna</first>
-        <surname prefix="Vrow">Smith</surname>
+        <surname prefix="Vrow">Hansdotter</surname>
+        <surname prim="0">Smith</surname>
         <noteref hlink="_0000001100000011"/>
       </name>
       <name alt="1" type="Also Known As">
@@ -1704,7 +1705,7 @@ Unknown tag                                                         Line  1109: 
         <range start="0" end="163"/>
       </style>
     </note>
-    <note handle="_000000f9000000f9" change="1551800790" id="N0036" type="General">
+    <note handle="_000000f9000000f9" change="1564588949" id="N0036" type="General">
       <text>Objects referenced by this note were missing in a file imported on 12/25/1999 12:00:00 AM.</text>
     </note>
   </notes>

--- a/gramps/plugins/export/exportgedcom.py
+++ b/gramps/plugins/export/exportgedcom.py
@@ -1290,15 +1290,17 @@ class GedcomWriter(UpdateCallback):
 
         firstname = name.get_first_name().strip()
         surns = []
-        surprefs = []
+        surprefix = ''
         for surn in name.get_surname_list():
             surns.append(surn.get_surname().replace('/', '?'))
             if surn.get_connector():
                 #we store connector with the surname
                 surns[-1] = surns[-1] + ' ' + surn.get_connector()
-            surprefs.append(surn.get_prefix().replace('/', '?'))
         surname = ', '.join(surns)
-        surprefix = ', '.join(surprefs)
+        if name.get_surname_list():
+            # GEDCOM only supports a single surname prefix
+            surn = name.get_surname_list()[0]
+            surprefix = surn.get_prefix().replace('/', '?')
         suffix = name.get_suffix()
         title = name.get_title()
         nick = name.get_nick_name()

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -4318,11 +4318,12 @@ class GedcomParser(UpdateCallback):
         @param state: The current state
         @type state: CurrentState
         """
+        spfx = line.data.strip().split(", ")[0]
         if state.name.get_surname_list():
-            state.name.get_surname_list()[0].set_prefix(line.data.strip())
+            state.name.get_surname_list()[0].set_prefix(spfx)
         else:
             surn = Surname()
-            surn.set_prefix(line.data.strip())
+            surn.set_prefix(spfx)
             surn.set_primary()
             state.name.set_surname_list([surn])
         self.__skip_subordinate_levels(state.level + 1, state)
@@ -4334,13 +4335,17 @@ class GedcomParser(UpdateCallback):
         @param state: The current state
         @type state: CurrentState
         """
-        if state.name.get_surname_list():
-            state.name.get_surname_list()[0].set_surname(line.data.strip())
-        else:
-            surn = Surname()
-            surn.set_surname(line.data.strip())
-            surn.set_primary()
-            state.name.set_surname_list([surn])
+        names = line.data.strip().split(", ")
+        overwrite = bool(state.name.get_surname_list())
+        for name in names:
+            if overwrite:
+                state.name.get_surname_list()[0].set_surname(name)
+                overwrite = False
+            else:
+                surn = Surname()
+                surn.set_surname(name)
+                surn.set_primary(primary=not state.name.get_surname_list())
+                state.name.get_surname_list().append(surn)
         self.__skip_subordinate_levels(state.level + 1, state)
 
     def __name_marnm(self, line, state):


### PR DESCRIPTION
Fixes [#11228](https://gramps-project.org/bugs/view.php?id=11228)

The GEDCOM spec allows multiple surnames, separated by commas on the SURN tag line.  Gramps was exporting that format, but was not supporting the import of that format.  This corrects that.

In addition, the GEDCOM exporter was putting out a comma separated list for the surname prefix tag, presumably to match up with the multiple surnames.  This is not legal according to the GEDCOM spec.  Only a single surname prefix is supported.  I modified the exporter to put out the prefix for the first surname, the others are dropped.