### PR TITLE
Fix References Tab to update on Deletes of items when editor is open

### DIFF
--- a/gramps/gui/editors/displaytabs/backreflist.py
+++ b/gramps/gui/editors/displaytabs/backreflist.py
@@ -67,6 +67,12 @@ class BackRefList(EmbeddedList):
                               _('_References'), refmodel)
         self._callback = callback
         self.connectid = self.model.connect('row-inserted', self.update_label)
+        self.db_connect = []
+        for item in ['person', 'family', 'source', 'citation', 'event',
+                     'media', 'place', 'repository', 'note']:
+            self.db_connect.append(self.dbstate.db.connect(
+                '%s-delete' % item, self.model.delete_row))
+        self.tree.set_reorderable(False)
         self.track_ref_for_deletion("model")
 
     def update_label(self, *obj):
@@ -80,6 +86,8 @@ class BackRefList(EmbeddedList):
 
     def _cleanup_local_connects(self):
         self.model.disconnect(self.connectid)
+        for item in self.db_connect:
+            self.dbstate.db.disconnect(item)
 
     def _cleanup_on_exit(self):
         # model may be destroyed already in closing managedwindow

--- a/gramps/gui/editors/displaytabs/backrefmodel.py
+++ b/gramps/gui/editors/displaytabs/backrefmodel.py
@@ -55,6 +55,7 @@ class BackRefModel(Gtk.ListStore):
         self.sref_list = sref_list
         self.count = 0
         self.loading = False
+        self.hndl_iter = {}
         self.idle = GLib.idle_add(self.load_model().__next__)
 
     def destroy(self):
@@ -145,7 +146,17 @@ class BackRefModel(Gtk.ListStore):
             # We need to use localized string in the model.
             # we also need to keep class names to get the object type,
             # but we don't need to show that in the view.
-            self.append(row=[_(dtype), gid, name, handle, dtype])
+
+            self.hndl_iter[ref[1]] = self.append(
+                row=[_(dtype), gid, name, handle, dtype])
             yield True
         self.loading = False
         yield False
+
+    def delete_row(self, hndl_list):
+        """ Remove rows of the model based on the handles """
+        for hndl in hndl_list:
+            miter = self.hndl_iter.get(hndl, None)
+            if miter is not None:
+                self.remove(miter)
+                del self.hndl_iter[hndl]


### PR DESCRIPTION
Fixes [#11231](https://gramps-project.org/bugs/view.php?id=11231)

The References Tab of the various editors had no way to update on changes to the db made elsewhere.  For most part this just leaves the tab out of date on changes, but when a referenced item is deleted or merged out of existence that leaves an entry on the tab that will cause an exception if a user tries to edit it.

This PR adds code to remove items that are deleted. 

Other updates (added or modified items) will not update, that would have required a rescan of backlinks on every db change, which would have required more extensive modifications.