### PR TITLE
Add support for GEDCOM import _FREL/_MREL tags in INDI/FAMC

### DIFF
--- a/data/tests/exp_sample.gramps
+++ b/data/tests/exp_sample.gramps
@@ -1278,7 +1278,7 @@
       <rel type="Unknown"/>
       <father hlink="_0000000b0000000b"/>
       <mother hlink="_0000002600000026"/>
-      <childref hlink="_0000006f0000006f"/>
+      <childref hlink="_0000006f0000006f" frel="Adopted" mrel="Foster"/>
     </family>
     <family handle="_0000001000000010" change="1198222526" id="F0014">
       <rel type="Unknown"/>

--- a/data/tests/exp_sample_ged.ged
+++ b/data/tests/exp_sample_ged.ged
@@ -2,8 +2,8 @@
 1 SOUR Gramps
 2 VERS 5.0.2
 2 NAME Gramps
-1 DATE 31 JUL 2019
-2 TIME 10:58:33
+1 DATE 4 AUG 2019
+2 TIME 15:26:44
 1 SUBM @SUBM@
 1 FILE C:\Users\prc\AppData\Roaming\gramps\temp\exp_sample_ged.ged
 1 COPR Copyright (c) 2019 Alex Roitman,,,.
@@ -629,8 +629,12 @@
 2 TYPE Birth of Lloyd Smith
 2 DATE 13 MAR 1935
 2 PLAC San Francisco, San Francisco Co., CA
+1 ADOP Y
+2 FAMC @F0009@
+3 ADOP HUSB
 1 FAMC @F0009@
-2 PEDI birth
+2 _FREL Adopted
+2 _MREL Foster
 1 FAMS @F0008@
 1 CHAN
 2 DATE 4 SEP 2016
@@ -1040,7 +1044,7 @@
 2 SURN Tester
 1 SEX M
 1 FAMC @F0016@
-2 PEDI Unknown
+2 PEDI Sponsored
 1 CHAN
 2 DATE 29 OCT 2016
 3 TIME 16:27:59

--- a/data/tests/imp_sample.ged
+++ b/data/tests/imp_sample.ged
@@ -83,6 +83,8 @@
 2 DATE 11 AUG 1966
 2 PLAC San Francisco, San Francisco Co., CA
 1 FAMC @F8@
+2 _FREL Adopted
+2 _MREL Foster
 1 CHAN
 2 DATE 21 DEC 2007
 3 TIME 01:35:26

--- a/data/tests/imp_sample.gramps
+++ b/data/tests/imp_sample.gramps
@@ -3,7 +3,7 @@
 "http://gramps-project.org/xml/1.7.1/grampsxml.dtd">
 <database xmlns="http://gramps-project.org/xml/1.7.1/">
   <header>
-    <created date="2019-07-31" version="5.0.2"/>
+    <created date="2019-08-04" version="5.0.2"/>
     <researcher>
       <resname>Alex Roitman,,,</resname>
       <resaddr>Not Provided</resaddr>
@@ -1134,7 +1134,7 @@
       <mother hlink="_000000b6000000b6"/>
       <eventref hlink="_000000e3000000e3" role="Family"/>
       <childref hlink="_0000004800000048" mrel="Adopted" frel="Adopted"/>
-      <childref hlink="_0000001900000019"/>
+      <childref hlink="_0000001900000019" mrel="Foster" frel="Adopted"/>
       <childref hlink="_0000007b0000007b" mrel="Adopted" frel="Adopted"/>
       <noteref hlink="_000000e4000000e4"/>
     </family>
@@ -1566,8 +1566,8 @@ Filename omitted                                                    Line    48: 
     <note handle="_0000003d0000003d" change="1" id="N0012" type="GEDCOM import">
       <text>Records not imported into INDI (individual) Gramps ID I0016:
 
-Warn: ADDR overwritten                                              Line   204: 3 ADR1 456 Main St again
-ADDR element ignored '459 Main St.'                                 Line   202: 2 ADDR 459 Main St., The Village, San Francisco, CA, USA
+Warn: ADDR overwritten                                              Line   206: 3 ADR1 456 Main St again
+ADDR element ignored '459 Main St.'                                 Line   204: 2 ADDR 459 Main St., The Village, San Francisco, CA, USA
 </text>
       <style name="fontface" value="Monospace">
         <range start="0" end="304"/>
@@ -1579,7 +1579,7 @@ ADDR element ignored '459 Main St.'                                 Line   202: 
     <note handle="_0000004700000047" change="1" id="N0014" type="GEDCOM import">
       <text>Records not imported into INDI (individual) Gramps ID I0018:
 
-Tag recognized but not supported                                    Line   245: 2 TYPE first generaton
+Tag recognized but not supported                                    Line   247: 2 TYPE first generaton
 </text>
       <style name="fontface" value="Monospace">
         <range start="0" end="165"/>
@@ -1611,7 +1611,7 @@ Company. He enlisted in the army at Sparks 7 December 1917 and served as a Corpo
     <note handle="_000000cf000000cf" change="1" id="N0021" type="GEDCOM import">
       <text>Records not imported into FAM (family) Gramps ID F0010:
 
-Tag recognized but not supported                                    Line   863: 2 _STAT 
+Tag recognized but not supported                                    Line   865: 2 _STAT 
 </text>
       <style name="fontface" value="Monospace">
         <range start="0" end="146"/>
@@ -1620,8 +1620,8 @@ Tag recognized but not supported                                    Line   863: 
     <note handle="_000000d4000000d4" change="1" id="N0022" type="GEDCOM import">
       <text>Records not imported into FAM (family) Gramps ID F0011:
 
-Could not import Magnes&amp;Anna_smiths_marr_cert.jpg                   Line   878: 3 OBJE 
-Could not import Magnes&amp;Anna_smiths_marr_cert.jpg                   Line   881: 2 OBJE 
+Could not import Magnes&amp;Anna_smiths_marr_cert.jpg                   Line   880: 3 OBJE 
+Could not import Magnes&amp;Anna_smiths_marr_cert.jpg                   Line   883: 2 OBJE 
 </text>
       <style name="fontface" value="Monospace">
         <range start="0" end="233"/>
@@ -1630,7 +1630,7 @@ Could not import Magnes&amp;Anna_smiths_marr_cert.jpg                   Line   8
     <note handle="_000000d9000000d9" change="1" id="N0023" type="GEDCOM import">
       <text>Records not imported into FAM (family) Gramps ID F0012:
 
-Could not import John&amp;Alice_smiths_marr_cert.jpg                    Line   905: 1 OBJE 
+Could not import John&amp;Alice_smiths_marr_cert.jpg                    Line   907: 1 OBJE 
 </text>
       <style name="fontface" value="Monospace">
         <range start="0" end="145"/>
@@ -1639,7 +1639,7 @@ Could not import John&amp;Alice_smiths_marr_cert.jpg                    Line   9
     <note handle="_000000e4000000e4" change="1" id="N0024" type="GEDCOM import">
       <text>Records not imported into FAM (family) Gramps ID F0008:
 
-Tag recognized but not supported                                    Line  1005: 1 ADDR 123 Main st, Grantville, Virginia, USA
+Tag recognized but not supported                                    Line  1007: 1 ADDR 123 Main st, Grantville, Virginia, USA
 </text>
       <style name="fontface" value="Monospace">
         <range start="0" end="183"/>
@@ -1663,8 +1663,8 @@ Tag recognized but not supported                                    Line  1005: 
     <note handle="_000000ee000000ee" change="1" id="N0030" type="GEDCOM import">
       <text>Records not imported into SOUR (source) Gramps ID S0003:
 
-Tag recognized but not supported                                    Line  1045: 1 DATA 
-Skipped subordinate line                                            Line  1046: 2 AGNC NYC Public Library
+Tag recognized but not supported                                    Line  1047: 1 DATA 
+Skipped subordinate line                                            Line  1048: 2 AGNC NYC Public Library
 </text>
       <style name="fontface" value="Monospace">
         <range start="0" end="252"/>
@@ -1679,9 +1679,9 @@ Skipped subordinate line                                            Line  1046: 
     <note handle="_000000f5000000f5" change="1" id="N0033" type="GEDCOM import">
       <text>Records not imported into REPO (repository) Gramps ID R0003:
 
-REFN ignored                                                        Line  1075: 3 REFN blah blah
-Skipped subordinate line                                            Line  1076: 4 TYPE who knows
-Could not import Attic_photo.jpg                                    Line  1079: 3 OBJE 
+REFN ignored                                                        Line  1077: 3 REFN blah blah
+Skipped subordinate line                                            Line  1078: 4 TYPE who knows
+Could not import Attic_photo.jpg                                    Line  1081: 3 OBJE 
 </text>
       <style name="fontface" value="Monospace">
         <range start="0" end="344"/>
@@ -1690,7 +1690,7 @@ Could not import Attic_photo.jpg                                    Line  1079: 
     <note handle="_000000f6000000f6" change="1" id="N0034" type="GEDCOM import">
       <text>Records not imported into Top Level:
 
-Unknown tag                                                         Line  1106: 0 XXX an unknown token at level 0
+Unknown tag                                                         Line  1108: 0 XXX an unknown token at level 0
 </text>
       <style name="fontface" value="Monospace">
         <range start="0" end="152"/>
@@ -1699,13 +1699,13 @@ Unknown tag                                                         Line  1106: 
     <note handle="_000000f8000000f8" change="1" id="N0035" type="GEDCOM import">
       <text>Records not imported into Top Level:
 
-Unknown tag                                                         Line  1109: 1 @X1@ XXX and unknown token xref definition
+Unknown tag                                                         Line  1111: 1 @X1@ XXX and unknown token xref definition
 </text>
       <style name="fontface" value="Monospace">
         <range start="0" end="163"/>
       </style>
     </note>
-    <note handle="_000000f9000000f9" change="1564588949" id="N0036" type="General">
+    <note handle="_000000f9000000f9" change="1564950708" id="N0036" type="General">
       <text>Objects referenced by this note were missing in a file imported on 12/25/1999 12:00:00 AM.</text>
     </note>
   </notes>

--- a/gramps/plugins/export/exportgedcom.py
+++ b/gramps/plugins/export/exportgedcom.py
@@ -735,14 +735,14 @@ class GedcomWriter(UpdateCallback):
                                 child.mrel == ChildRefType.FOSTER:
                             self._writeln(2, 'PEDI foster')
                         elif child.frel == child.mrel:
-                            self._writeln(2, 'PEDI Unknown')
+                            self._writeln(2, 'PEDI %s' % str(child.frel))
                         else:
                             self._writeln(2, '_FREL %s' %
                                           PEDIGREE_TYPES.get(child.frel.value,
-                                                             "Unknown"))
+                                                             str(child.frel)))
                             self._writeln(2, '_MREL %s' %
                                           PEDIGREE_TYPES.get(child.mrel.value,
-                                                             "Unknown"))
+                                                             str(child.mrel)))
 
     def _parent_families(self, person):
         """

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -528,7 +528,7 @@ RELATION_TYPES = (
 PEDIGREE_TYPES = {
     'birth'  : ChildRefType(),
     'natural': ChildRefType(),
-    'step'   : TYPE_ADOPT,
+    'step'   : ChildRefType(ChildRefType.STEPCHILD),
     'adopted': TYPE_ADOPT,
     'foster' : TYPE_FOSTER, }
 
@@ -2226,8 +2226,12 @@ class GedcomParser(UpdateCallback):
 
         self.famc_parse_tbl = {
             # n FAMC @<XREF:FAM>@ {1:1}
-            # +1 PEDI <PEDIGREE_LINKAGE_TYPE> {0:M} p.*
+            # +1 PEDI <PEDIGREE_LINKAGE_TYPE> {0:1} p.*
             TOKEN_PEDI   : self.__person_famc_pedi,
+            # +1 _FREL <Father PEDIGREE_LINKAGE_TYPE> {0:1}  non-standard
+            TOKEN__FREL  : self.__person_famc_frel,
+            # +1 _MREL <Mother PEDIGREE_LINKAGE_TYPE> {0:1}  non-standard
+            TOKEN__MREL  : self.__person_famc_mrel,
             # +1 <<NOTE_STRUCTURE>> {0:M} p.*
             TOKEN_NOTE   : self.__person_famc_note,
             TOKEN_RNOTE  : self.__person_famc_note,
@@ -4717,7 +4721,9 @@ class GedcomParser(UpdateCallback):
         person is a child of.
 
         n FAMC @<XREF:FAM>@ {1:1}
-        +1 PEDI <PEDIGREE_LINKAGE_TYPE> {0:M} p.*
+        +1 PEDI <PEDIGREE_LINKAGE_TYPE> {0:1} p.*
+        +1 _FREL <Father relationship type> {0:1}   non-standard Extension
+        +1 _MREL <Mother relationship type> {0:1}   non-standard Extension
         +1 <<NOTE_STRUCTURE>> {0:M} p.*
 
         @param line: The current line in GedLine format
@@ -4744,15 +4750,9 @@ class GedcomParser(UpdateCallback):
         # if the handle is not already in the person's parent family list, we
         # need to add it to thie list.
 
-        flist = [fam[0] for fam in
-                 state.person.get_parent_family_handle_list()]
+        flist = state.person.get_parent_family_handle_list()
         if handle not in flist:
-            if sub_state.ftype and int(sub_state.ftype) in RELATION_TYPES:
-                state.person.add_parent_family_handle(handle)
-            else:
-                if state.person.get_main_parents_family_handle() == handle:
-                    state.person.set_main_parent_family_handle(None)
-                state.person.add_parent_family_handle(handle)
+            state.person.add_parent_family_handle(handle)
 
             # search childrefs
             family, _new = self.dbase.find_family_from_handle(handle,
@@ -4761,17 +4761,19 @@ class GedcomParser(UpdateCallback):
 
             for ref in family.get_child_ref_list():
                 if ref.ref == state.person.handle:
-                    if sub_state.ftype:
-                        ref.set_mother_relation(sub_state.ftype)
-                        ref.set_father_relation(sub_state.ftype)
                     break
             else:
                 ref = ChildRef()
                 ref.ref = state.person.handle
-                if sub_state.ftype:
-                    ref.set_mother_relation(sub_state.ftype)
-                    ref.set_father_relation(sub_state.ftype)
                 family.add_child_ref(ref)
+            if sub_state.ftype:
+                ref.set_mother_relation(sub_state.ftype)
+                ref.set_father_relation(sub_state.ftype)
+            else:
+                if sub_state.frel:
+                    ref.set_father_relation(sub_state.frel)
+                if sub_state.mrel:
+                    ref.set_mother_relation(sub_state.mrel)
             self.dbase.commit_family(family, self.trans)
 
     def __person_famc_pedi(self, line, state):
@@ -4789,6 +4791,40 @@ class GedcomParser(UpdateCallback):
         """
         state.ftype = PEDIGREE_TYPES.get(line.data.lower(),
                                          ChildRefType.UNKNOWN)
+
+    def __person_famc_frel(self, line, state):
+        """
+        Parses the _FREL tag attached to a INDI.FAMC record. No values are set
+        at this point, because we have to do some post processing. Instead, we
+        assign the frel field of the state variable. We convert the text from
+        the line to an index into the PEDIGREE_TYPES dictionary, which will map
+        to the correct ChildTypeRef.
+
+        @param line: The current line in GedLine format
+        @type line: GedLine
+        @param state: The current state
+        @type state: CurrentState
+        """
+        state.frel = PEDIGREE_TYPES.get(line.data.lower().strip(), None)
+        if state.frel is None:
+            state.frel = ChildRefType(line.data.capitalize().strip())
+
+    def __person_famc_mrel(self, line, state):
+        """
+        Parses the _MREL tag attached to a INDI.FAMC record. No values are set
+        at this point, because we have to do some post processing. Instead, we
+        assign the mrel field of the state variable. We convert the text from
+        the line to an index into the PEDIGREE_TYPES dictionary, which will map
+        to the correct ChildTypeRef.
+
+        @param line: The current line in GedLine format
+        @type line: GedLine
+        @param state: The current state
+        @type state: CurrentState
+        """
+        state.mrel = PEDIGREE_TYPES.get(line.data.lower().strip(), None)
+        if state.mrel is None:
+            state.mrel = ChildRefType(line.data.capitalize().strip())
 
     def __person_famc_note(self, line, state):
         """
@@ -6090,8 +6126,6 @@ class GedcomParser(UpdateCallback):
                 int(sub_state.frel) == ChildRefType.BIRTH):
             sub_state.mrel = sub_state.frel = TYPE_ADOPT
 
-        if state.person.get_main_parents_family_handle() == handle:
-            state.person.set_main_parent_family_handle(None)
         state.person.add_parent_family_handle(handle)
 
         reflist = [ref for ref in family.get_child_ref_list()
@@ -6132,8 +6166,6 @@ class GedcomParser(UpdateCallback):
         """
         handle = self.__find_family_handle(self.fid_map[line.data])
 
-        if state.person.get_main_parents_family_handle() == handle:
-            state.person.set_main_parent_family_handle(None)
         state.person.add_parent_family_handle(handle)
 
         frel = mrel = ChildRefType.BIRTH

--- a/gramps/plugins/test/imports_test.py
+++ b/gramps/plugins/test/imports_test.py
@@ -51,7 +51,11 @@ TEST_DIR = os.path.abspath(os.path.join(DATA_DIR, "tests"))
 # ------------------------------------------------------------------
 
 # These tests assume a US date and time format.
-locale.setlocale(locale.LC_ALL, 'en_US.utf8')
+try:
+    locale.setlocale(locale.LC_ALL, 'en_US.utf8')
+except locale.Error:     # seems to fail on Windows system for some reason
+    locale.setlocale(locale.LC_ALL, 'English_United States')
+
 
 def mock_time(*args):
     """


### PR DESCRIPTION
Improve support for GEDCOM export of _FREL/_MREL in INDI/FAMC

Fixes [#10750](https://gramps-project.org/bugs/view.php?id=10750)

A user noted that Gramps could not import its own exported GED file properly when child relationships were different for mother and father.  We have export support for that case, but did not have import support.

This PR allows us to properly support AGES! and a few other programs GEDCOM files.

The export support was enhanced to export all relationship types, the import support was simply added.  Tests were modified to improve test coverage to include these cases, as a side effect, some of the notes in test files have different line numbers.

Found a couple of non-functional lines in the code and removed them while I was analyzing the support.