### PR TITLE
Make the narratives notes placement an option.

### DIFF
--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -1797,8 +1797,15 @@ class NavWebOptions(MenuReportOptions):
         self.__graphgens.set_help(_("The number of generations to include in "
                                     "the ancestor graph"))
         addopt("graphgens", self.__graphgens)
-
         self.__graph_changed()
+
+        notes = BooleanOption(
+            _('Include narrative notes just after name, gender'), True)
+        notes.set_help(
+            _('Include narrative notes just after name, gender and'
+              ' age at death (default) or include them just before'
+              ' attributes.'))
+        addopt("notes", notes)
 
     def __add_page_generation_options(self, menu):
         """

--- a/gramps/plugins/webreport/person.py
+++ b/gramps/plugins/webreport/person.py
@@ -490,11 +490,12 @@ class PersonPages(BasePage):
                 individualdetail += thumbnail
             individualdetail += (name, summary)
 
-            # display Narrative Notes
-            notelist = person.get_note_list()
-            sect8 = self.display_note_list(notelist)
-            if sect8 is not None:
-                individualdetail += sect8
+            if self.report.options['notes']:
+                # display Narrative Notes
+                notelist = person.get_note_list()
+                sect8 = self.display_note_list(notelist)
+                if sect8 is not None:
+                    individualdetail += sect8
 
             # display a person's events
             sect2 = self.display_ind_events(place_lat_long)
@@ -556,6 +557,13 @@ class PersonPages(BasePage):
             sect7 = self.disp_add_img_as_gallery(media_list, person)
             if sect7 is not None:
                 individualdetail += sect7
+
+            if not self.report.options['notes']:
+                # display Narrative Notes
+                notelist = person.get_note_list()
+                sect8 = self.display_note_list(notelist)
+                if sect8 is not None:
+                    individualdetail += sect8
 
             # display attributes
             attrlist = person.get_attribute_list()


### PR DESCRIPTION
From 5.1 the narrative notes are placed just after the name, gender and
age at death. This follow the feature request #6772.
Some people want to have this placement an option to have the same
functionality as before

Fixes [#11283](https://gramps-project.org/bugs/view.php?id=11283)