### PR TITLE
Translation problem when creating event filter

### DIFF
--- a/gramps/gui/autocomp.py
+++ b/gramps/gui/autocomp.py
@@ -171,7 +171,7 @@ class StandardCustomSelector:
             if self.active_key in items:
                 parent = None
             else:
-                parent = store.append(None, row=[None, heading, False])
+                parent = store.append(None, row=[None, _(heading), False])
             for item in items:
                 store.append(parent, row=[item, self.mapping[item], True])
 


### PR DESCRIPTION
If you create a filter with the rule name:
    "Events with a particular type"
or
    "Events with <data>"
The menus "Travel", "Academic"... are not translated

Fixes [#11293](https://gramps-project.org/bugs/view.php?id=11293)