### PR TITLE
Fix exception when editing Note with italics/bold etc. in non English

### DIFF
--- a/gramps/gui/widgets/styledtexteditor.py
+++ b/gramps/gui/widgets/styledtexteditor.py
@@ -774,7 +774,8 @@ class StyledTextEditor(Gtk.TextView):
         for style, style_value in changed_styles.items():
             if style in types:
                 action = self.uimanager.get_action(
-                    self.action_group, str(StyledTextTagType(style)).upper())
+                    self.action_group,
+                    StyledTextTagType(style).xml_str().upper())
                 action.change_state(Variant.new_boolean(style_value))
             elif (style == StyledTextTagType.FONTFACE):
                 self.fontface.set_text(style_value)


### PR DESCRIPTION
Note editing with italics etc.
When identifying the style by its StyledTextTagType was using str() which returned in users language, should have used xml_str method.

Fixes [#11284](https://gramps-project.org/bugs/view.php?id=11284)