### PR TITLE
Fix missing menus/buttons when operating in non-English languages

### DIFF
--- a/gramps/gui/uimanager.py
+++ b/gramps/gui/uimanager.py
@@ -213,8 +213,17 @@ class UIManager():
         # need to copy the tree so we can preserve original for later edits.
         editable = copy.deepcopy(self.et_xml)
         iterator(editable)  # clean up tree to builder specifications
-        xml_str = ET.tostring(editable, encoding="unicode")
-        #print(xml_str)
+        # The following should work, but seems to have a Gtk bug
+        # xml_str = ET.tostring(editable, encoding="unicode")
+
+        xml_str = ET.tostring(editable).decode(encoding='ascii')
+
+        # debugging
+        # with open('try.xml', 'w', encoding='utf8') as file:
+        #     file.write(xml_str)
+        # with open('try.xml', encoding='utf8') as file:
+        #     xml_str = file.read()
+        # print(xml_str)
         self.builder = Gtk.Builder()
         self.builder.set_translation_domain(glocale.get_localedomain())
         self.builder.add_from_string(xml_str)

--- a/gramps/gui/views/tags.py
+++ b/gramps/gui/views/tags.py
@@ -246,8 +246,8 @@ class Tags(DbGUIElement):
         </item>'''
 
         for tag_name, handle in self.__tag_list:
-            tag_menu += menuitem % (handle, tag_name)
-            actions.append(('TAG_%s' % handle,
+            tag_menu += menuitem % (handle, escape(tag_name))
+            actions.append(('TAG-%s' % handle,
                             make_callback(self.tag_selected_rows, handle)))
         tag_menu = TAG_MENU % tag_menu
 


### PR DESCRIPTION
Fixes [#11292](https://gramps-project.org/bugs/view.php?id=11292)

Actually two bugs; if the users Tag included XML invalid characters, the Tag button would disappear. 

Also there was a hard to find Gtk bug where it appears that too many non-ASCII strings in the XML for Gtk Builder would cause parts of the XML to be lost.  Fixed by making the XML ASCII (all non-ASCII characters in labels, and tooltips had to be converted to their HTML forms).  Fortunately the ElementTree code could do just that.