### PR TITLE
Fix missing tooltip translations in the Note editor toolbar

### DIFF
--- a/gramps/gui/widgets/styledtexteditor.py
+++ b/gramps/gui/widgets/styledtexteditor.py
@@ -531,7 +531,9 @@ class StyledTextEditor(Gtk.TextView):
         """
         self.uimanager = uimanager
         # build the toolbar
-        builder = Gtk.Builder.new_from_string(FORMAT_TOOLBAR, -1)
+        builder = Gtk.Builder()
+        builder.set_translation_domain(glocale.get_localedomain())
+        builder.add_from_string(FORMAT_TOOLBAR)
         # define the actions...
         _actions = [
             ('ITALIC', self._on_toggle_action_activate, '<PRIMARY>i', False),


### PR DESCRIPTION
Fixes [#11289](https://gramps-project.org/bugs/view.php?id=11289)

Note Editor tooltips were not getting translated, at least on some Linux OSs.