### PR TITLE
Fix Statusbar HandleError on merge families

### DIFF
--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -732,7 +732,8 @@ class ListView(NavigationView):
                                           [self.drag_list_info().target()],
                                           Gdk.DragAction.COPY)
 
-        self.uistate.modify_statusbar(self.dbstate)
+        if self.uistate.viewmanager.active_page == self:
+            self.uistate.modify_statusbar(self.dbstate)
 
     def row_add(self, handle_list):
         """


### PR DESCRIPTION
Fixes [#11320](https://gramps-project.org/bugs/view.php?id=11320), [#11294](https://gramps-project.org/bugs/view.php?id=11294), [#11279](https://gramps-project.org/bugs/view.php?id=11279)

These were difficult to replicate...

To replicate it is necessary to have the two families to be merged have to have the one to be merged out (deleted) before the one to keep in the family view.
It is necessary to have the person that is one of the parents in the family, and that is going to be merged out (deleted) selected in People view.
Then to switch to Family view and merge the two families, selecting the one to keep as the one WITHOUT the person selected in People view.

There may be other constraints, I tested after opening Gramps in Family view, switching to People view to select the person and then switching back to Family view.

Under the covers, Gramps is sending signals to various places, and with this sequence the signals to delete the person(s) come before the one to delete the family. When the signal arrives at the People view code, it removes the person in the list, and then does a "change_active" call which causes the family view (which is active) to redo its Status bar; it tries to display the last status again, but the family to display is already gone, although the signal to tell the history code has not yet arrived. Thus the HandleError. 

I initially tried to have the signals arrive in family first order, this fixed this, but the mirror image of this bug appeared when merging persons that resulted in family merges.  So this did not work.

I decided to avoid the status bar update entirely unless the update was initiated in the active view.  Since in this case the update was initiated by the People view, this fixed this issue.  The status bar gets updated by its own signals from the family view as well, so no updates were lost.