### PR TITLE
Fix CLI crash when generating reports

### DIFF
--- a/gramps/cli/grampscli.py
+++ b/gramps/cli/grampscli.py
@@ -64,6 +64,7 @@ from gramps.gen.db.exceptions import (DbUpgradeRequiredError,
 from gramps.gen.plug import BasePluginManager
 from gramps.gen.utils.config import get_researcher
 from gramps.gen.recentfiles import recent_files
+from gramps.gen.filters import reload_custom_filters
 
 #-------------------------------------------------------------------------
 #
@@ -373,6 +374,7 @@ def startcli(errors, argparser):
 
     #load the plugins
     climanager.do_reg_plugins(dbstate, uistate=None)
+    reload_custom_filters()
     # handle the arguments
     from .arghandler import ArgHandler
     handler = ArgHandler(dbstate, argparser, climanager)


### PR DESCRIPTION
Fixes [#11318](https://gramps-project.org/bugs/view.php?id=11318), [#11213](https://gramps-project.org/bugs/view.php?id=11213)

The custom filters were not getting initialized in CLI mode after previous https://github.com/gramps-project/gramps/commit/8366ceb8964b948b53be2d07171b146fff039acf

I need to remember that not everything is about the GUI...