### PR TITLE
Bump required Python version to 3.3 on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Requirements
 ============
 The following packages **MUST** be installed in order for Gramps to work:
 
-* **Python** 3.2 or greater - The programming language used by Gramps. https://www.python.org/
+* **Python** 3.3 or greater - The programming language used by Gramps. https://www.python.org/
 * **GTK** 3.12 or greater - A cross-platform widget toolkit for creating graphical user interfaces. http://www.gtk.org/
 * **pygobject** 3.12 or greater - Python Bindings for GLib/GObject/GIO/GTK+ https://wiki.gnome.org/Projects/PyGObject
 


### PR DESCRIPTION
As mentioned on the release announcement
https://gramps-project.org/introduction-WP/2019/08/gramps-5-1-0-released/