### PR TITLE
Escape for name, dates and places in graph reports

### DIFF
--- a/gramps/plugins/graph/gvfamilylines.py
+++ b/gramps/plugins/graph/gvfamilylines.py
@@ -33,6 +33,7 @@ Family Lines, a Graphviz-based plugin for Gramps.
 #
 #------------------------------------------------------------------------
 from functools import partial
+import html
 
 #------------------------------------------------------------------------
 #
@@ -818,10 +819,10 @@ class FamilyLinesReport(Report):
             if bth_event and self._incdates:
                 date = bth_event.get_date_object()
                 if self._just_years and date.get_year_valid():
-                    birth_str = self._get_date( # localized year
+                    birth_str = self.get_date( # localized year
                         Date(date.get_year()))
                 else:
-                    birth_str = self._get_date(date)
+                    birth_str = self.get_date(date)
 
             # get birth place (one of:  hamlet, village, town, city, parish,
             # county, province, region, state or country)
@@ -834,10 +835,10 @@ class FamilyLinesReport(Report):
             if dth_event and self._incdates:
                 date = dth_event.get_date_object()
                 if self._just_years and date.get_year_valid():
-                    death_str = self._get_date( # localized year
+                    death_str = self.get_date( # localized year
                         Date(date.get_year()))
                 else:
-                    death_str = self._get_date(date)
+                    death_str = self.get_date(date)
 
             # get death place (one of:  hamlet, village, town, city, parish,
             # county, province, region, state or country)
@@ -876,8 +877,7 @@ class FamilyLinesReport(Report):
                 label += '<TD>'
 
             # at the very least, the label must have the person's name
-            name = name.replace('"', '&#34;')
-            label += name.replace('<', '&#60;').replace('>', '&#62;')
+            label += html.escape(name)
             if self.includeid == 1: # same line
                 label += " (%s)" % p_id
             elif self.includeid == 2: # own line
@@ -964,10 +964,10 @@ class FamilyLinesReport(Report):
                         if self._incdates:
                             date = event.get_date_object()
                             if self._just_years and date.get_year_valid():
-                                wedding_date = self._get_date( # localized year
+                                wedding_date = self.get_date( # localized year
                                     Date(date.get_year()))
                             else:
-                                wedding_date = self._get_date(date)
+                                wedding_date = self.get_date(date)
                         # get the wedding location
                         if self._incplaces:
                             wedding_place = self.get_event_place(event)
@@ -1090,6 +1090,9 @@ class FamilyLinesReport(Report):
             place = self._db.get_place_from_handle(place_handle)
             if place:
                 place_text = _pd.display(self._db, place)
-                place_text = place_text.replace('<', '&#60;')
-                place_text = place_text.replace('>', '&#62;')
+                place_text = html.escape(place_text)
         return place_text
+
+    def get_date(self, date):
+        """ return a formatted date """
+        return html.escape(self._get_date(date))

--- a/gramps/plugins/graph/gvhourglass.py
+++ b/gramps/plugins/graph/gvhourglass.py
@@ -32,6 +32,7 @@ Generate an hourglass graph using the Graphviz generator.
 # python modules
 #
 #------------------------------------------------------------------------
+import html
 
 #------------------------------------------------------------------------
 #
@@ -251,18 +252,17 @@ class HourGlassReport(Report):
         """
         p_id = person.get_gramps_id()
         name = self._name_display.display(person)
-        name = name.replace('"', '&#34;')
-        name = name.replace('<', '&#60;').replace('>', '&#62;')
+        name = html.escape(name)
 
         birth_evt = get_birth_or_fallback(self.__db, person)
         if birth_evt:
-            birth = self._get_date(birth_evt.get_date_object())
+            birth = self.get_date(birth_evt.get_date_object())
         else:
             birth = ""
 
         death_evt = get_death_or_fallback(self.__db, person)
         if death_evt:
-            death = self._get_date(death_evt.get_date_object())
+            death = self.get_date(death_evt.get_date_object())
         else:
             death = ""
 
@@ -295,7 +295,7 @@ class HourGlassReport(Report):
         label = ""
         marriage = utils.find_marriage(self.__db, family)
         if marriage:
-            label = self._get_date(marriage.get_date_object())
+            label = self.get_date(marriage.get_date_object())
         if self.includeid == 1 and label: # same line
             label = "%s (%s)" % (label, family_id)
         elif self.includeid == 1 and not label:
@@ -343,7 +343,9 @@ class HourGlassReport(Report):
             else:
                 fill = self.colors['unknown']
         return(shape, style, color, fill)
-
+    def get_date(self, date):
+        """ return a formatted date """
+        return html.escape(self._get_date(date))
 
 #------------------------------------------------------------------------
 #

--- a/gramps/plugins/graph/gvrelgraph.py
+++ b/gramps/plugins/graph/gvrelgraph.py
@@ -40,6 +40,7 @@ Create a relationship graph using Graphviz
 #
 #------------------------------------------------------------------------
 from functools import partial
+import html
 
 #------------------------------------------------------------------------
 #
@@ -616,8 +617,7 @@ class RelGraphReport(Report):
 
         # at the very least, the label must have the person's name
         p_name = self._name_display.display(person)
-        p_name = p_name.replace('"', '&#34;')
-        label += p_name.replace('<', '&#60;').replace('>', '&#62;')
+        label += html.escape(p_name)
         p_id = person.get_gramps_id()
         if self.includeid == 1: # same line
             label += " (%s)" % p_id
@@ -751,10 +751,10 @@ class RelGraphReport(Report):
             event_date = event.get_date_object()
             if event_date.get_year_valid():
                 if self.event_choice in [4, 5]:
-                    return self._get_date( # localized year
+                    return self.get_date( # localized year
                         Date(event_date.get_year()))
                 elif self.event_choice in [1, 2, 3, 7]:
-                    return self._get_date(event_date)
+                    return self.get_date(event_date)
         return ''
 
     def get_place_string(self, event):
@@ -768,8 +768,11 @@ class RelGraphReport(Report):
         """
         if event and self.event_choice in [2, 3, 5, 6, 7]:
             place = _pd.display_event(self._db, event)
-            return place.replace('<', '&#60;').replace('>', '&#62;')
+            return html.escape(place)
         return ''
+    def get_date(self, date):
+        """ return a formatted date """
+        return html.escape(self._get_date(date))
 
 #------------------------------------------------------------------------
 #


### PR DESCRIPTION
Currently if the birth date or the death date contain XML special characters (example: birth date = "1867 <?>"), the item is rendered incorrectly in the report, when images are included. Escaping special characters with html.escape solves the problem.