### PR TITLE
WEBCAL: Wrong web calendar title on home page

### DIFF
--- a/gramps/plugins/webreport/webcal.py
+++ b/gramps/plugins/webreport/webcal.py
@@ -126,7 +126,7 @@ class WebCalReport(Report):
         self._ = self.rlocale.translation.sgettext
 
         self.html_dir = mgobn('target')
-        self.title_text = mgobn('title')
+        self.title_text = html_escape(mgobn('title'))
         filter_option = options.menu.get_option_by_name('filter')
         self.filter = filter_option.get_filter()
         self.name_format = mgobn('name_format')
@@ -1598,7 +1598,7 @@ class WebCalReport(Report):
         output_file = self.create_file('index', "")
 
         # page title
-        title = self._("My Family Calendar")
+        title = self.title_text
 
         nr_up = 0
 


### PR DESCRIPTION
Fixes [#11354](https://gramps-project.org/bugs/view.php?id=11354)

This PR solves the possibility to have ">", "<" in the title