### PR TITLE
Fix various Entry fields so Undo/Redo works

### DIFF
--- a/gramps/gui/widgets/monitoredwidgets.py
+++ b/gramps/gui/widgets/monitoredwidgets.py
@@ -64,8 +64,6 @@ from gramps.gen.errors import ValidationError
 _RETURN = Gdk.keyval_from_name("Return")
 _KP_ENTER = Gdk.keyval_from_name("KP_Enter")
 
-# table for skipping illegal control chars
-INVISIBLE = dict.fromkeys(list(range(32)))
 
 #-------------------------------------------------------------------------
 #
@@ -141,14 +139,10 @@ class MonitoredEntry:
         self.obj.connect(signal, callback, *data)
 
     def _on_quit(self, obj, event):
-        text = obj.get_text().translate(INVISIBLE).strip()
-        self.set_val(text)
-        obj.set_text(text)
+        self.set_val(obj.get_text().strip())
 
     def _on_change(self, obj):
-        new_text = obj.get_text().translate(INVISIBLE)
-        self.set_val(new_text)
-        obj.set_text(new_text)
+        self.set_val(obj.get_text())
         if self.changed:
             self.changed(obj)
 

--- a/gramps/gui/widgets/undoableentry.py
+++ b/gramps/gui/widgets/undoableentry.py
@@ -47,6 +47,11 @@ from gi.repository import Gtk
 #-------------------------------------------------------------------------
 from .undoablebuffer import Stack
 
+
+# table for skipping illegal control chars
+INVISIBLE = dict.fromkeys(list(range(32)))
+
+
 class UndoableInsertEntry:
     """something that has been inserted into our Gtk.editable"""
     def __init__(self, text, length, position):
@@ -156,6 +161,7 @@ class UndoableEntry(Gtk.Entry, Gtk.Editable):
                 return False
             return True
 
+        text = text.translate(INVISIBLE)
         if not self.undo_in_progress:
             self.__empty_redo_stack()
         while not self.not_undoable_action:


### PR DESCRIPTION
Fixes [#11380](https://gramps-project.org/bugs/view.php?id=11380) [#11339](https://gramps-project.org/bugs/view.php?id=11339)

In prior versions of Gramps you could use the undo/redo keys to edit items in the text entries.  This no longer works.
This is related to the changes to suppress odd characters and leading/trailing spaces. The Gtk.Entry.set_text() call is effectively clearing the undo/redo list at every keystroke or when you leave the field.

In this PR I move the odd characters cleanup into UndoableEntry.do_insert_text instead of MonitoredEntry.

I scanned the users of MonitoredEntry and they all appeared to use Glade files, I scanned the glade files for anyone using just plain Entry (none found), they all appeared to use UndoableEntry or ValidatableMaskedEntry, so this should cover everyone. 

