### PR TITLE
Fix Gramps -v error when Gtk is not present

### DIFF
--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -212,7 +212,7 @@ def show_settings():
                         Gtk.get_minor_version(), Gtk.get_micro_version())
         except:  # any failure to 'get' the version
             gtkver_str = 'unknown version'
-    except ImportError:
+    except (ImportError, ValueError):
         gtkver_str = 'not found'
     # no DISPLAY is a RuntimeError in an older pygtk (e.g. 2.17 in Fedora 14)
     except RuntimeError:


### PR DESCRIPTION
Via email a user noted a bug when "Gramps -v" was used with Gtk not installed (and gi was).
When the "gi.require_version('Gtk', '3.0')" was added during Gramps 5.0.0 timeframe, a corresponding exception was not.