### PR TITLE
Fix up Event Editors Place display for bidi text with Gramps ID

### DIFF
--- a/gramps/gui/editors/objectentries.py
+++ b/gramps/gui/editors/objectentries.py
@@ -311,7 +311,10 @@ class PlaceEntry(ObjEntry):
 
     def get_label(self, place):
         place_title = place_displayer.display(self.db, place)
-        return "%s [%s]" % (place_title, place.gramps_id)
+        # When part of the place title contains RTL text, the gramps_id gets
+        # messed up; so use Unicode FSI/PDI and LRM chars to isolate it.
+        # see bug 10124 and PR924
+        return "%s \u2068[%s]\u200e\u2069" % (place_title, place.gramps_id)
 
     def call_editor(self, obj=None):
         if obj is None:
@@ -356,7 +359,7 @@ class SourceEntry(ObjEntry):
         return self.db.get_source_from_handle(handle)
 
     def get_label(self, source):
-        return "%s [%s]" % (source.get_title(), source.gramps_id)
+        return "%s \u2068[%s]\u200e\u2069" % (source.get_title(), source.gramps_id)
 
     def call_editor(self, obj=None):
         if obj is None:
@@ -402,7 +405,8 @@ class MediaEntry(ObjEntry):
         return self.db.get_media_from_handle(handle)
 
     def get_label(self, object):
-        return "%s [%s]" % (object.get_description(), object.gramps_id)
+        return "%s \u2068[%s]\u200e\u2069" % (object.get_description(),
+                                              object.gramps_id)
 
     def call_editor(self, obj=None):
         if obj is None:
@@ -462,7 +466,7 @@ class NoteEntry(ObjEntry):
         txt = " ".join(note.get().split())
         if len(txt) > 35:
             txt = txt[:35] + "..."
-        return "%s [%s]" % (txt, note.gramps_id)
+        return "%s \u2068[%s]\u200e\u2069" % (txt, note.gramps_id)
 
     def call_editor(self, obj=None):
         if obj is None:


### PR DESCRIPTION
Fixes [#10124](https://gramps-project.org/bugs/view.php?id=10124)

Some versions of Gtk/Pango have trouble with text containing both LTR and RTL characters.  The bug notes this shows up in our Event Editor on the 'Place" field, where we have the place displayer title and the Gramps ID concatenated into the same string. 

In older versions of Gtk (3.18.9 tested) the bracket around the Gramps ID would get mangled to the beginning of the string:
![image](https://user-images.githubusercontent.com/18122203/66233924-0ab96480-e6b2-11e9-8899-d61d68687ea6.png)
fixed (somewhat):
![image](https://user-images.githubusercontent.com/18122203/66233620-6cc59a00-e6b1-11e9-8dcf-590a4ab3cc96.png)

In newer versions of Gtk (3.24.3 tested) it was better to start with:
![image](https://user-images.githubusercontent.com/18122203/66234079-65eb5700-e6b2-11e9-9da9-dbf442f1a970.png)
fixed:
![image](https://user-images.githubusercontent.com/18122203/66234283-ed38ca80-e6b2-11e9-9211-2fdf6603a36f.png)

The older version of Gtk/Pango doesn't seem to properly interpret all of the potential Unicode bidi control characters, so the fix shown is the best I can do.  The fixed version of the newer Gtk version is what is desired.

I note that the Place displayer should be fixed up to use more appropriate separators than just commas for RTL text, but that is another issue.
