### PR TITLE
Fix improper escaping in odt output for TOC/Bookmark etc.

### DIFF
--- a/gramps/plugins/docgen/odfdoc.py
+++ b/gramps/plugins/docgen/odfdoc.py
@@ -1541,7 +1541,7 @@ class ODFDoc(BaseDoc, TextDoc, DrawDoc):
         Insert a mark at this point in the document.
         """
         if mark:
-            key = escape(mark.key, ESC_MAP)
+            key = escape(mark.key)
             key = key.replace('"', '&quot;')
             if mark.type == INDEX_TYPE_ALP:
                 self.cntnt.write(


### PR DESCRIPTION
Fixes [#11378](https://gramps-project.org/bugs/view.php?id=11378)

For the index, toc, bookmark etc. normal XML escape is correct, the original code also added sub-tags for line break and tab which was NOT correct.