### PR TITLE
Fix Preferences/Genealogical Symbols when only one font is present that passes

### DIFF
--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -2093,9 +2093,9 @@ class GrampsPreferences(ConfigureDialog):
                 self.all_avail_fonts, callback=self.utf8_update_font,
                 valueactive=True, setactive=active_val)
             if len(available_fonts) == 1:
-                single_font = self.all_avail_fonts[choosefont.get_active()][1]
+                single_font = self.all_avail_fonts[choosefont.get_active()][0]
                 config.set('utf8.selected-font',
-                           self.all_avail_fonts[single_font])
+                           self.all_avail_fonts[single_font][1])
                 self.utf8_show_example()
             symbols = Symbols()
             all_sbls = symbols.get_death_symbols()


### PR DESCRIPTION
Fixes [#11395](https://gramps-project.org/bugs/view.php?id=11395)

If user has only a single font available that passes check for the Genealogical Symbols being all present, the original code crashed.  [Apparently never tested...](https://github.com/gramps-project/gramps/pull/598)