### PR TITLE
Fix Window family tree title for non-ASCII chars on Windows

### DIFF
--- a/gramps/cli/grampscli.py
+++ b/gramps/cli/grampscli.py
@@ -280,7 +280,7 @@ class CLIManager:
             # Attempt to figure out the database title
             path = os.path.join(filename, "name.txt")
             try:
-                with open(path) as ifile:
+                with open(path, encoding='utf8') as ifile:
                     title = ifile.readline().strip()
             except:
                 title = filename

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -757,7 +757,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         if self._directory:
             filepath = os.path.join(self._directory, "name.txt")
             try:
-                with open(filepath, "r") as name_file:
+                with open(filepath, "r", encoding='utf8') as name_file:
                     name = name_file.readline().strip()
             except (OSError, IOError) as msg:
                 LOG.error(str(msg))


### PR DESCRIPTION
Fixes [#11390](https://gramps-project.org/bugs/view.php?id=11390)

As it says, if Family Tree name contained non-ASCII characters, the titlebar on Windows would display it wrong.  Turned out to be reading of a utf8 file without the 'encoding' set.  On Windows this results in using the default encoding which is one of the code pages, NOT utf8.

I scanned other uses of file 'open', and some other potential trouble spots are;
gen.plug.docgen.stylesheet (writing the XML stylesheet)
gen.plug.docgen.odstab (also writing the XML stylesheet and meta)
gen.utils.lds (XML temple info, currently contains no non-ASCII chars)
gui.views.listview write_tabbed_data (writes CSV of view)
plugins.docgen.htmldoc (XML CSS of the textdoc)

I did NOT attempt to test/debug each case.