### PR TITLE
Add context menu entries for Gramplet Bar

### DIFF
--- a/gramps/gui/widgets/grampletbar.py
+++ b/gramps/gui/widgets/grampletbar.py
@@ -55,7 +55,7 @@ from gi.repository import Gtk
 #-------------------------------------------------------------------------
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
-from gramps.gen.const import URL_MANUAL_PAGE, VERSION_DIR
+from gramps.gen.const import URL_MANUAL_PAGE, URL_WIKISTRING, VERSION_DIR
 from gramps.gen.config import config
 from gramps.gen.constfunc import win
 from ..managedwindow import ManagedWindow
@@ -76,7 +76,9 @@ from ..dialog import QuestionDialog
 # Constants
 #
 #-------------------------------------------------------------------------
-WIKI_HELP_PAGE = URL_MANUAL_PAGE + '_-_Gramplets'
+WIKI_HELP_PAGE = URL_WIKISTRING + URL_MANUAL_PAGE + '_-_Gramplets'
+WIKI_HELP_GRAMPLETBAR = URL_WIKISTRING + URL_MANUAL_PAGE + '_-_Main_Window#Gramplet_Bar_Menu'
+WIKI_HELP_ABOUT_GRAMPLETS = URL_WIKISTRING + URL_MANUAL_PAGE + '_-_Gramplets#What_is_a_Gramplet'
 NL = "\n"
 
 #-------------------------------------------------------------------------
@@ -510,6 +512,21 @@ class GrampletBar(Gtk.Notebook):
         rd_menu.show()
         menu.append(rd_menu)
 
+        # Separator.
+        rs_menu = Gtk.SeparatorMenuItem()
+        rs_menu.show()
+        menu.append(rs_menu)
+
+        rh_menu = Gtk.MenuItem(label=_('Gramplet Bar Help'))
+        rh_menu.connect("activate", self.on_help_grampletbar_clicked)
+        rh_menu.show()
+        menu.append(rh_menu)
+
+        rg_menu = Gtk.MenuItem(label=_('About Gramplets'))
+        rg_menu.connect("activate", self.on_help_gramplets_clicked)
+        rg_menu.show()
+        menu.append(rg_menu)
+
         menu.show_all()
         menu.popup(None, None, cb_menu_position, button, 0, 0)
 
@@ -574,6 +591,14 @@ class GrampletBar(Gtk.Notebook):
         def gramplet_panel(configdialog):
             return title, gui_options
         return gramplet_panel
+
+    def on_help_grampletbar_clicked(self, dummy):
+        """ Button: Display the relevant portion of Gramps manual"""
+        display_url(WIKI_HELP_GRAMPLETBAR)
+
+    def on_help_gramplets_clicked(self, dummy):
+        """ Button: Display the relevant portion of Gramps manual"""
+        display_url(WIKI_HELP_ABOUT_GRAMPLETS)
 
 #-------------------------------------------------------------------------
 #


### PR DESCRIPTION
Link to help for Gramplets and the Gramplet Bar Menu

Issue [#10919](https://gramps-project.org/bugs/view.php?id=10919)

![add gramplet help context entries](https://user-images.githubusercontent.com/8924713/67167285-ba494300-f3e3-11e9-9120-45def24b199f.png)
)

- [ ] [Update user manual](https://gramps-project.org/wiki/index.php/Gramps_5.1_Wiki_Manual_-_Main_Window#Gramplet_Bar_Menu) (when rolled over for Gramps5.2)