### PR TITLE
Allow Tools with Notebook tabs to expand to fill the window

### DIFF
--- a/gramps/gui/plug/_windows.py
+++ b/gramps/gui/plug/_windows.py
@@ -768,7 +768,7 @@ class ToolManagedWindowBase(ManagedWindow):
 
         self.notebook = Gtk.Notebook()
         self.notebook.set_border_width(6)
-        self.window.get_content_area().add(self.notebook)
+        self.window.get_content_area().pack_start(self.notebook, True, True, 0)
 
         self.results_text = Gtk.TextView()
         self.results_text.connect('button-press-event',


### PR DESCRIPTION
Fixes [#10762](https://gramps-project.org/bugs/view.php?id=10762)

User "petpil" (Gramps Bugtracker) noted that the Calculate Estimated Dates addon would not expand the size of its window content when the window was stretched.  That addon used the ToolManagedWindowBatch which uses a Gtk Notebook to support several tabs.  He also submitted a patch which fixes the problem.

The Gtk.Container.add method originally used apparently did not have expand/fill settings to allow the expansion.  The Gtk.Box.pack_start used instead does.

I tested this with all the users of ToolManagedWindowBatch and ToolManagedWindow which inherit from ToolManagedWindowBase, and did not see any bad/unexpected side effects.  The Calculate Estimated Dates addon was the only one that really could use this, as it was the only one which I spotted using a potentially large widget in the notebook tab.