### PR TITLE
Fix dbapi db to warn/prevent opening newer schema versions

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -47,6 +47,7 @@ from . import (DbReadBase, DbWriteBase, DbUndo, DBLOGNAME, DBUNDOFN,
                REPOSITORY_KEY, NOTE_KEY, TAG_KEY, TXNADD, TXNUPD, TXNDEL,
                KEY_TO_NAME_MAP, DBMODE_R, DBMODE_W)
 from .utils import write_lock_file, clear_lock_file
+from .exceptions import DbVersionError
 from ..errors import HandleError
 from ..utils.callback import Callback
 from ..updatecallback import UpdateCallback
@@ -658,6 +659,12 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         self.nmap_index = self._get_metadata('nmap_index', 0)
 
         self.db_is_open = True
+
+        # Check on db version to see if too new
+        dbversion = int(self._get_metadata('version', default='0'))
+        if dbversion > self.VERSION[0]:
+            self.close()
+            raise DbVersionError(dbversion, 18, self.VERSION[0])
 
     def _close(self):
         """


### PR DESCRIPTION
While testing the [enhanced places GEPS](https://github.com/gramps-project/gramps/pull/809), I inadvertently opened the upgraded db with Gramps51 branch code, and it crashed.  Seems we forgot to perform the check for a newer schema version for dbapi dbs.

I think we should get this into gramps51 branch sometime before we release gramps52 (assuming that gramps52 bumps the schema version), to avoid similar crashes.