### PR TITLE
Narrativeweb: Referenced regions problems

### DIFF
--- a/data/css/Web_Basic-Ash.css
+++ b/data/css/Web_Basic-Ash.css
@@ -473,11 +473,10 @@ table.eventlist tbody tr td.ColumnSources {
     margin: 0px auto;
     display: block;
     border: solid 1px #999;
-    max-width: 800px;
     height: auto;
 }
 
-@media only screen and (max-width: 1080px) {
+@media only screen and (max-width: 1600px) {
     #GalleryDisplay img {
         max-width: 100%;
     }

--- a/data/css/Web_Basic-Blue.css
+++ b/data/css/Web_Basic-Blue.css
@@ -838,11 +838,10 @@ div#EventDetail table.eventlist tbody tr td.ColumnDate {
 }
 #GalleryDisplay img {
     margin: 0 auto;
-    max-width: 800px;
     height: auto;
 }
 
-@media only screen and (max-width: 1080px) {
+@media only screen and (max-width: 1600px) {
     #GalleryDisplay img {
         max-width: 100%;
     }

--- a/data/css/Web_Basic-Cypress.css
+++ b/data/css/Web_Basic-Cypress.css
@@ -524,11 +524,10 @@ table.eventlist tbody tr td.ColumnSources {
     margin: 0px auto;
     display: block;
     border: solid 1px #7C8F7C;
-    max-width: 800px;
     height: auto;
 }
 
-@media only screen and (max-width: 1080px) {
+@media only screen and (max-width: 1600px) {
     #GalleryDisplay img {
         max-width: 100%;
     }

--- a/data/css/Web_Basic-Lilac.css
+++ b/data/css/Web_Basic-Lilac.css
@@ -512,15 +512,15 @@ table.eventlist tbody tr td.ColumnSources {
     margin: 0px auto;
     display: block;
     border: solid 1px #669;
-    max-width: 800px;
     height: auto;
 }
 
-@media only screen and (max-width: 1080px) {
+@media only screen and (max-width: 1600px) {
     #GalleryDisplay img {
         max-width: 100%;
     }
 }
+
 #GalleryDetail h3 {
     text-align: center;
 }

--- a/data/css/Web_Basic-Peach.css
+++ b/data/css/Web_Basic-Peach.css
@@ -512,11 +512,10 @@ table.eventlist tbody tr td.ColumnSources {
     margin: 0px auto;
     display: block;
     border: solid 1px #EA8414;
-    max-width: 800px;
     height: auto;
 }
 
-@media only screen and (max-width: 1080px) {
+@media only screen and (max-width: 1600px) {
     #GalleryDisplay img {
         max-width: 100%;
     }

--- a/data/css/Web_Basic-Spruce.css
+++ b/data/css/Web_Basic-Spruce.css
@@ -513,11 +513,10 @@ table.eventlist tbody tr td.ColumnSources {
     margin: 0px auto;
     display: block;
     border: solid 1px #7CA3DD;
-    max-width: 800px;
     height: auto;
 }
 
-@media only screen and (max-width: 1080px) {
+@media only screen and (max-width: 1600px) {
     #GalleryDisplay img {
         max-width: 100%;
     }

--- a/data/css/Web_Mainz.css
+++ b/data/css/Web_Mainz.css
@@ -468,11 +468,10 @@ table.eventlist tbody tr td.ColumnSources {
     margin: 0px auto;
     display:block;
     border: solid 1px #7D5925;
-    max-width: 800px;
     height: auto;
 }
 
-@media only screen and (max-width: 1080px) {
+@media only screen and (max-width: 1600px) {
     #GalleryDisplay img {
         max-width: 100%;
     }

--- a/data/css/Web_Nebraska.css
+++ b/data/css/Web_Nebraska.css
@@ -747,11 +747,10 @@ table.eventlist tbody tr td.ColumnSources {
 }
 #GalleryDisplay img {
     margin:0 auto;
-    max-width: 800px;
     height: auto;
 }
 
-@media only screen and (max-width: 1080px) {
+@media only screen and (max-width: 1600px) {
     #GalleryDisplay img {
         max-width: 100%;
     }

--- a/gramps/plugins/webreport/media.py
+++ b/gramps/plugins/webreport/media.py
@@ -472,8 +472,11 @@ class MediaPages(BasePage):
                                 if orig_image_path != newpath:
                                     url = self.report.build_url_fname(
                                         newpath, None, self.uplink)
+                                s_width = 'width: %dpx;' % max_width
                                 mediadisplay += Html("a", href=url) + (
-                                    Html("img", src=url, alt=esc_page_title)
+                                    Html("img", src=url,
+                                         style=s_width,
+                                         alt=esc_page_title)
                                 )
                     else:
                         dirname = tempfile.mkdtemp()
@@ -507,9 +510,11 @@ class MediaPages(BasePage):
                                 url = self.report.build_url_fname(newpath,
                                                                   None,
                                                                   self.uplink)
+                                s_width = 'width: 48px;'
                                 hyper = Html("a", href=url,
                                              title=esc_page_title) + (
                                                  Html("img", src=img_url,
+                                                      style=s_width,
                                                       alt=esc_page_title)
                                                  )
                                 mediadisplay += hyper
@@ -521,7 +526,9 @@ class MediaPages(BasePage):
                         summaryarea += mediadisplay
                         url = self.report.build_url_image("document.png",
                                                           "images", self.uplink)
+                        s_width = 'width: 48px;'
                         mediadisplay += Html("img", src=url,
+                                             style=s_width,
                                              alt=esc_page_title,
                                              title=esc_page_title)
 


### PR DESCRIPTION
When image width > 800, the referenced regions are incorrectly placed

Fixes [#011414](https://gramps-project.org/bugs/view.php?id=11414)