### PR TITLE
Fix duplicated "døde døde" Norwegion Translation for libnarrate

### DIFF
--- a/po/nb.po
+++ b/po/nb.po
@@ -27070,7 +27070,7 @@ msgstr "Han døde %(death_date)s."
 #: ../gramps/plugins/lib/libnarrate.py:308
 #, python-format
 msgid "He died %(death_date)s at the age of %(age)s."
-msgstr "Han døde døde %(death_date)s, i en alder av %(age)s."
+msgstr "Han døde %(death_date)s, i en alder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:311
 #, python-format


### PR DESCRIPTION
Fixes [#11429](https://gramps-project.org/bugs/view.php?id=11429)