### PR TITLE
Fix ExportPkg so errors are not lost, and has progress bar for media

### DIFF
--- a/gramps/gui/plug/export/_exportassistant.py
+++ b/gramps/gui/plug/export/_exportassistant.py
@@ -586,11 +586,11 @@ class ExportAssistant(ManagedWindow, Gtk.Assistant):
             ix = self.get_selected_format_index()
             config.set('behavior.recent-export-type', ix)
             export_function = self.map_exporters[ix].get_export_function()
-            success = export_function(self.dbstate.db,
-                            filename,
-                            User(error=ErrorDialog, parent=self.uistate.window,
-                                 callback=self.callback),
-                            self.option_box_instance)
+            success = export_function(
+                self.dbstate.db, filename,
+                User(error=ErrorDialog, parent=self.window,
+                     callback=self.callback),
+                self.option_box_instance)
         except:
             #an error not catched in the export_function itself
             success = False


### PR DESCRIPTION
Fixes [#11457](https://gramps-project.org/bugs/view.php?id=11457)

The original bug has a user trying to backup to a drive with insufficient space.  There was no error message and the spinning cursor never went away, as if the backup was still in progress.  Turns out the exportpkg code had generated an exception which was not visible in the GUI (it was written to stderror).

In the first commit I fixed up the export code to report errors correctly at all stages of the export.  I also added a status/progressbar for the media backup portion so the user could have an indication that something was happening.

During debug, I found that when the export pkg was run via the normal Export assistant (as opposed to "Make backup..."), the error message was not visible under the export assistant dialog, due to a bad Gtk parent window.  The second commit fixes that.

I stripped out some dead commented out code and did a small bit of pylint to try to make codacy a bit happier...