### PR TITLE
Fix Progen import to correctly handle AKA surnames

### DIFF
--- a/gramps/plugins/importer/importprogen.py
+++ b/gramps/plugins/importer/importprogen.py
@@ -258,7 +258,8 @@ class ProgenOptions(ManagedWindow):
 
         # display window if GUI active
         if self.uistate:
-            ManagedWindow.__init__(self, self.uistate, [], self.__class__)
+            ManagedWindow.__init__(self, self.uistate, [], self.__class__,
+                                   modal=True)
             self._display()
 
     def __on_source_button_toggled(self, widget):
@@ -580,6 +581,7 @@ class ProgenOptions(ManagedWindow):
         widget.grab_focus()
 
         # creates a modal window and display immediatly!
+        self.show()
         self.glade.toplevel.run()
 
     def _collect(self):

--- a/gramps/plugins/lib/libprogen.py
+++ b/gramps/plugins/lib/libprogen.py
@@ -1332,9 +1332,10 @@ class ProgenParser(UpdateCallback):
                     if attr:
                         person.add_attribute(attr)
                 else:
-                    self.__add_name(person, citation.handle, NameType.AKA,
-                        ' '.join(alias_text[0:-1]),
-                        '', alias_text[-1].split(), '')
+                    self.__add_name(
+                        person, citation.handle if citation else None,
+                        NameType.AKA, ' '.join(alias_text[0:-1]),
+                        '', alias_text[-1], '')
 
             # process F09 Person Code
             refn_code = recflds[person_ix[9]]   # F09: INDI REFN/INDI CODE

--- a/gramps/plugins/lib/libprogen.py
+++ b/gramps/plugins/lib/libprogen.py
@@ -729,7 +729,8 @@ class ProgenParser(UpdateCallback):
 
         # provide feedback about import progress (GUI / TXT)
         if self.uistate:
-            self.progress = ProgressMeter(_("Import from Pro-Gen"), '')
+            self.progress = ProgressMeter(_("Import from Pro-Gen"), '',
+                                          parent=self.uistate.window)
         else:
             UpdateCallback.__init__(self, user.callback)
 


### PR DESCRIPTION
Bug [#11462](https://gramps-project.org/bugs/view.php?id=11462)
User imported a Progen file with some AKA names; these created a surname in a list, which is not valid.
This PR first commit corrects that.

I also noticed that the import dialog and progress meter were not properly over Gramps; they did not have the transient parent set.
Second commit fixes that.