### PR TITLE
[Tree doc Tex] fix issues around localization

### DIFF
--- a/gramps/gen/plug/docgen/treedoc.py
+++ b/gramps/gen/plug/docgen/treedoc.py
@@ -347,7 +347,7 @@ class TreeDocBase(BaseDoc, TreeDoc):
         trans = glocale.language[0][:2]
         lang_en = _locale._get_language_string(trans).lower()
         if lang_en in LANG_SUPPORT:
-            self.write(0, '\\gtrset{language=%s}\n' % lang_en.lower())
+            self.write(0, '\\gtrset{language=%s}\n' % lang_en)
         self.write(0, '\\begin{document}\n')
 
         if self.nodecolor == 'preferences':

--- a/gramps/gen/plug/docgen/treedoc.py
+++ b/gramps/gen/plug/docgen/treedoc.py
@@ -47,6 +47,8 @@ from ...constfunc import win
 from ...config import config
 from ...const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
+from ...utils.grampslocale import GrampsLocale
+_locale = GrampsLocale(lang='en_US')
 
 #-------------------------------------------------------------------------
 #
@@ -339,6 +341,8 @@ class TreeDocBase(BaseDoc, TreeDoc):
         self.write(0, '\\usepackage[%s,%s]{geometry}\n' % (paper, margin))
         self.write(0, '\\usepackage[all]{genealogytree}\n')
         self.write(0, '\\usepackage{color}\n')
+        lang_en = _locale._get_language_string(glocale.language[0])
+        self.write(0, '\\gtrset{language=%s}\n' % lang_en.lower())
         self.write(0, '\\begin{document}\n')
 
         if self.nodecolor == 'preferences':

--- a/gramps/gen/plug/docgen/treedoc.py
+++ b/gramps/gen/plug/docgen/treedoc.py
@@ -50,8 +50,8 @@ _ = glocale.translation.gettext
 from ...utils.grampslocale import GrampsLocale
 _locale = GrampsLocale(lang='en')
 
-LANG_SUPPORT = ['danish', 'dutch', 'english', 'french', 'german', 'italian',
-                'spanish', 'swedish']
+LATIN = ['french', 'italian', 'spanish']
+LANG_SUPPORT = ['danish', 'dutch', 'german', 'swedish'] + LATIN
 
 #-------------------------------------------------------------------------
 #
@@ -348,6 +348,7 @@ class TreeDocBase(BaseDoc, TreeDoc):
         lang_en = _locale._get_language_string(trans).lower()
         if lang_en in LANG_SUPPORT:
             self.write(0, '\\gtrset{language=%s}\n' % lang_en)
+        if lang_en in LATIN:
             self.write(0, '\\usepackage{lmodern}\n')
         self.write(0, '\\begin{document}\n')
 

--- a/gramps/gen/plug/docgen/treedoc.py
+++ b/gramps/gen/plug/docgen/treedoc.py
@@ -344,6 +344,7 @@ class TreeDocBase(BaseDoc, TreeDoc):
         self.write(0, '\\usepackage[%s,%s]{geometry}\n' % (paper, margin))
         self.write(0, '\\usepackage[all]{genealogytree}\n')
         self.write(0, '\\usepackage{color}\n')
+        self.write(0, '\\usepackage{lmodern}\n')
         trans = glocale.language[0][:2]
         lang_en = _locale._get_language_string(trans).lower()
         if lang_en in LANG_SUPPORT:

--- a/gramps/gen/plug/docgen/treedoc.py
+++ b/gramps/gen/plug/docgen/treedoc.py
@@ -344,11 +344,11 @@ class TreeDocBase(BaseDoc, TreeDoc):
         self.write(0, '\\usepackage[%s,%s]{geometry}\n' % (paper, margin))
         self.write(0, '\\usepackage[all]{genealogytree}\n')
         self.write(0, '\\usepackage{color}\n')
-        self.write(0, '\\usepackage{lmodern}\n')
         trans = glocale.language[0][:2]
         lang_en = _locale._get_language_string(trans).lower()
         if lang_en in LANG_SUPPORT:
             self.write(0, '\\gtrset{language=%s}\n' % lang_en)
+            self.write(0, '\\usepackage{lmodern}\n')
         self.write(0, '\\begin{document}\n')
 
         if self.nodecolor == 'preferences':

--- a/gramps/gen/plug/docgen/treedoc.py
+++ b/gramps/gen/plug/docgen/treedoc.py
@@ -48,7 +48,10 @@ from ...config import config
 from ...const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 from ...utils.grampslocale import GrampsLocale
-_locale = GrampsLocale(lang='en_US')
+_locale = GrampsLocale(lang='en')
+
+LANG_SUPPORT = ['danish', 'dutch', 'english', 'french', 'german', 'italian',
+                'spanish', 'swedish']
 
 #-------------------------------------------------------------------------
 #
@@ -341,8 +344,10 @@ class TreeDocBase(BaseDoc, TreeDoc):
         self.write(0, '\\usepackage[%s,%s]{geometry}\n' % (paper, margin))
         self.write(0, '\\usepackage[all]{genealogytree}\n')
         self.write(0, '\\usepackage{color}\n')
-        lang_en = _locale._get_language_string(glocale.language[0])
-        self.write(0, '\\gtrset{language=%s}\n' % lang_en.lower())
+        trans = glocale.language[0][:2]
+        lang_en = _locale._get_language_string(trans).lower()
+        if lang_en in LANG_SUPPORT:
+            self.write(0, '\\gtrset{language=%s}\n' % lang_en.lower())
         self.write(0, '\\begin{document}\n')
 
         if self.nodecolor == 'preferences':

--- a/gramps/gen/plug/docgen/treedoc.py
+++ b/gramps/gen/plug/docgen/treedoc.py
@@ -48,7 +48,8 @@ from ...config import config
 from ...const import GRAMPS_LOCALE as glocale
 from ...utils.grampslocale import GrampsLocale
 _ = glocale.translation.gettext
-locale = GrampsLocale(lang='en')
+
+LOCALE = GrampsLocale(lang='en')
 
 LATIN = ['french', 'italian', 'spanish']
 LANG_SUPPORT = ['danish', 'dutch', 'german', 'swedish'] + LATIN
@@ -345,7 +346,7 @@ class TreeDocBase(BaseDoc, TreeDoc):
         self.write(0, '\\usepackage[all]{genealogytree}\n')
         self.write(0, '\\usepackage{color}\n')
         trans = glocale.language[0][:2]
-        lang = locale._get_language_string(trans).lower()
+        lang = LOCALE._get_language_string(trans).lower()
         if lang in LANG_SUPPORT:
             self.write(0, '\\gtrset{language=%s}\n' % lang)
         if lang in LATIN:

--- a/gramps/gen/plug/docgen/treedoc.py
+++ b/gramps/gen/plug/docgen/treedoc.py
@@ -345,10 +345,10 @@ class TreeDocBase(BaseDoc, TreeDoc):
         self.write(0, '\\usepackage[all]{genealogytree}\n')
         self.write(0, '\\usepackage{color}\n')
         trans = glocale.language[0][:2]
-        lang_en = _locale._get_language_string(trans).lower()
-        if lang_en in LANG_SUPPORT:
-            self.write(0, '\\gtrset{language=%s}\n' % lang_en)
-        if lang_en in LATIN:
+        lang = _locale._get_language_string(trans).lower()
+        if lang in LANG_SUPPORT:
+            self.write(0, '\\gtrset{language=%s}\n' % lang)
+        if lang in LATIN:
             self.write(0, '\\usepackage{lmodern}\n')
         self.write(0, '\\begin{document}\n')
 

--- a/gramps/gen/plug/docgen/treedoc.py
+++ b/gramps/gen/plug/docgen/treedoc.py
@@ -46,9 +46,9 @@ from ..menu import NumberOption, TextOption, EnumeratedListOption
 from ...constfunc import win
 from ...config import config
 from ...const import GRAMPS_LOCALE as glocale
-_ = glocale.translation.gettext
 from ...utils.grampslocale import GrampsLocale
-_locale = GrampsLocale(lang='en')
+_ = glocale.translation.gettext
+locale = GrampsLocale(lang='en')
 
 LATIN = ['french', 'italian', 'spanish']
 LANG_SUPPORT = ['danish', 'dutch', 'german', 'swedish'] + LATIN
@@ -345,7 +345,7 @@ class TreeDocBase(BaseDoc, TreeDoc):
         self.write(0, '\\usepackage[all]{genealogytree}\n')
         self.write(0, '\\usepackage{color}\n')
         trans = glocale.language[0][:2]
-        lang = _locale._get_language_string(trans).lower()
+        lang = locale._get_language_string(trans).lower()
         if lang in LANG_SUPPORT:
             self.write(0, '\\gtrset{language=%s}\n' % lang)
         if lang in LATIN:

--- a/gramps/gen/plug/docgen/treedoc.py
+++ b/gramps/gen/plug/docgen/treedoc.py
@@ -350,7 +350,9 @@ class TreeDocBase(BaseDoc, TreeDoc):
         if lang in LANG_SUPPORT:
             self.write(0, '\\gtrset{language=%s}\n' % lang)
         if lang in LATIN:
-            self.write(0, '\\usepackage{lmodern}\n')
+            self.write(0, '\\IfFileExists{lmodern.sty}{\n')
+            self.write(0, '    \\usepackage{lmodern}\n')
+            self.write(0, '}{}\n')
         self.write(0, '\\begin{document}\n')
 
         if self.nodecolor == 'preferences':


### PR DESCRIPTION
* specific non-ASCII glyphs related to our locale are not properly displayed on PDF
* date cannot be parsed (one date format and in english)
* genealogytree macro needs a lang set in english