### PR TITLE
Fix import file chooser filter to accept upper case extensions

### DIFF
--- a/gramps/gui/dbloader.py
+++ b/gramps/gui/dbloader.py
@@ -317,6 +317,13 @@ def add_all_files_filter(chooser):
     mime_filter.add_pattern('*')
     chooser.add_filter(mime_filter)
 
+
+def icase(ext):
+    """
+    Return a glob reresenting a case insensitive file extension.
+    """
+    return ''.join(['[{}{}]'.format(s.lower(), s.upper()) for s in ext])
+
 #-------------------------------------------------------------------------
 #
 # Format selectors: explictly set the format of the file
@@ -446,9 +453,7 @@ class GrampsImportFileDialog(ManagedWindow):
             file_filter = Gtk.FileFilter()
             name = "%s (.%s)" % (plugin.get_name(), plugin.get_extension())
             file_filter.set_name(name)
-            file_filter.add_pattern("*.%s" % plugin.get_extension())
-            file_filter.add_pattern(plugin.get_extension().capitalize())
-            file_filter.add_pattern("*.%s" % plugin.get_extension().upper())
+            file_filter.add_pattern("*.%s" % icase(plugin.get_extension()))
             import_dialog.add_filter(file_filter)
 
         (box, type_selector) = format_maker()

--- a/gramps/gui/dbloader.py
+++ b/gramps/gui/dbloader.py
@@ -448,6 +448,7 @@ class GrampsImportFileDialog(ManagedWindow):
             file_filter.set_name(name)
             file_filter.add_pattern("*.%s" % plugin.get_extension())
             file_filter.add_pattern(plugin.get_extension().capitalize())
+            file_filter.add_pattern("*.%s" % plugin.get_extension().upper())
             import_dialog.add_filter(file_filter)
 
         (box, type_selector) = format_maker()


### PR DESCRIPTION
Fixes [#11463](https://gramps-project.org/bugs/view.php?id=11463)

User noted that import file dialog with filter enabled doesn't find all uppercase extensions.  It is possible the original code contained an error, as it was looking for capitalized extension, rather than upper case, and I cannot imagine anyone using capitalized extensions in their file names.

However I decided to simply add the Uppercase extension to the filter criteria.