### PR TITLE
Fix Lat/Long translated NSEW display and entry in rtl language;Store Lat/Long in place objects with NSEW always in English

### DIFF
--- a/gramps/gen/utils/place.py
+++ b/gramps/gen/utils/place.py
@@ -691,6 +691,38 @@ def __conv_SWED_RT90_WGS84(X, Y):
     return LAT, LON
 
 
+def translate_lat_to_en(latitude):
+    """ Translate the localized NS portion of a latitude to the English 'N'
+    and 'S' characters. """
+    if 'N' not in latitude and 'S' not in latitude:
+        # entry is not in english, convert to english
+        latitude = latitude.replace(North, 'N')
+        latitude = latitude.replace(South, 'S')
+        if glocale.rtl_locale:
+            # since Gtk.Entry doesn't handle mixed bidi strings like lat/long
+            # well, we always force ltr.  So depending on wether user makes it
+            # look right, or enters blindly, the translated NSEW could be
+            # normal or reversed, so,
+            # we also allow user to use reversed string
+            latitude = latitude.replace(North_, 'N')
+            latitude = latitude.replace(South_, 'S')
+    return latitude
+
+
+def translate_long_to_en(longitude):
+    """ Translate the localized EW portion of a latitude to the English 'E'
+    and 'W' characters. """
+    if 'E' not in longitude and 'W' not in longitude:
+        # entry is not in english, convert to english
+        longitude = longitude.replace(West, 'W')
+        longitude = longitude.replace(East, 'E')
+        if glocale.rtl_locale:
+            # we also allow user to use reversed string
+            longitude = longitude.replace(West_, 'W')
+            longitude = longitude.replace(East_, 'E')
+    return longitude
+
+
 #-------------------------------------------------------------------------
 #
 # For Testing the convert function in this module, apply it as a script:

--- a/gramps/gui/editors/editplace.py
+++ b/gramps/gui/editors/editplace.py
@@ -52,7 +52,8 @@ from .displaytabs import (PlaceRefEmbedList, PlaceNameEmbedList,
 from ..widgets import (MonitoredEntry, PrivacyButton, MonitoredTagList,
                        MonitoredDataType)
 from gramps.gen.errors import ValidationError, WindowActiveError
-from gramps.gen.utils.place import conv_lat_lon
+from gramps.gen.utils.place import (conv_lat_lon, North, South, East, West,
+                                    translate_lat_to_en, translate_long_to_en)
 from gramps.gen.display.place import displayer as place_displayer
 from gramps.gen.config import config
 from ..dialog import ErrorDialog
@@ -160,6 +161,9 @@ class EditPlace(EditPrimary):
 
         entry = self.top.get_object("lon_entry")
         entry.set_ltr_mode()
+        # get E,W translated to local
+        self.obj.set_longitude(self.obj.get_longitude().replace(
+            'E', East).replace('W', West))
         self.longitude = MonitoredEntry(
             entry,
             self.obj.set_longitude, self.obj.get_longitude,
@@ -170,6 +174,9 @@ class EditPlace(EditPrimary):
 
         entry = self.top.get_object("lat_entry")
         entry.set_ltr_mode()
+        # get N,S translated to local
+        self.obj.set_latitude(self.obj.get_latitude().replace(
+            'N', North).replace('S', South))
         self.latitude = MonitoredEntry(
             entry,
             self.obj.set_latitude, self.obj.get_latitude,
@@ -331,6 +338,11 @@ class EditPlace(EditPrimary):
             return
 
         place_title = place_displayer.display(self.db, self.obj)
+        # get localized E,W translated to English
+        self.obj.set_longitude(translate_long_to_en(self.obj.get_longitude()))
+        # get localized N,S translated to English
+        self.obj.set_latitude(translate_lat_to_en(self.obj.get_latitude()))
+
         if not self.obj.handle:
             with DbTxn(_("Add Place (%s)") % place_title,
                        self.db) as trans:

--- a/gramps/gui/editors/editplaceref.py
+++ b/gramps/gui/editors/editplaceref.py
@@ -34,7 +34,8 @@ from .displaytabs import (PlaceRefEmbedList, PlaceNameEmbedList,
 from gramps.gen.lib import NoteType
 from gramps.gen.db import DbTxn
 from gramps.gen.errors import ValidationError, WindowActiveError
-from gramps.gen.utils.place import conv_lat_lon
+from gramps.gen.utils.place import (conv_lat_lon, North, South, East, West,
+                                    translate_lat_to_en, translate_long_to_en)
 from gramps.gen.display.place import displayer as place_displayer
 from gramps.gen.config import config
 from ..dialog import ErrorDialog
@@ -153,6 +154,9 @@ class EditPlaceRef(EditReference):
 
         entry = self.top.get_object("lon_entry")
         entry.set_ltr_mode()
+        # get E,W translated to local
+        self.source.set_longitude(self.source.get_longitude().replace(
+            'E', East).replace('W', West))
         self.longitude = MonitoredEntry(
             entry,
             self.source.set_longitude, self.source.get_longitude,
@@ -163,6 +167,9 @@ class EditPlaceRef(EditReference):
 
         entry = self.top.get_object("lat_entry")
         entry.set_ltr_mode()
+        # get N,S translated to local
+        self.source.set_latitude(self.source.get_latitude().replace(
+            'N', North).replace('S', South))
         self.latitude = MonitoredEntry(
             entry,
             self.source.set_latitude, self.source.get_latitude,
@@ -310,6 +317,13 @@ class EditPlaceRef(EditReference):
             ErrorDialog(msg1, msg2, parent=self.window)
             self.ok_button.set_sensitive(True)
             return
+
+        # get localized E,W translated to English
+        self.source.set_longitude(translate_long_to_en(
+            self.source.get_longitude()))
+        # get localized N,S translated to English
+        self.source.set_latitude(translate_lat_to_en(
+            self.source.get_latitude()))
 
         if self.source.handle:
             with DbTxn(_("Modify Place"), self.db) as trans:


### PR DESCRIPTION
https://github.com/gramps-project/gramps/pull/922#issuecomment-562924935 noted that the already commited PR922 is displaying the translated NSEW characters reversed for rtl languages.  This is a consequence of that PRs change to make the entire Lat/Long strings display and enter in ltr mode.

There doesn't seem to be a completely ideal solution to this, as Gtk doesn't handle the mixed Lat/Long strings well at all.  I have decided to manually reverse the rtl portion of the string so the ltr override can display it correctly.  While this looks OK for output, the Lat/Long Entry in the editor doesn't work the way other bidi editors work.  When initially opening the editor with a correct Lat/Long in an rtl language, it looks OK, but if the user moves the cursor through it he will note that the cursor doesn't behave as perhaps expected.

If the user tries to make the text 'look right' while entering translated NSEW rtl characters, he has to enter them in reverse order.  If the user just types blindly, the order will end up correct.  So the lat/long functions are modified to accept the translated NSEW characters for rtl languages in either normal or reverse order.

The second commit modifies the editors to always store the lat/long with the NSEW characters in English.  This is another part of the overall fix for https://gramps-project.org/bugs/view.php?id=11335, it is a start on making sure that the when opening Gramps in another language or XML export/import with Gramps in another language doesn't get bad values for lat/long.

I chose to store the lat/long this way to preserve the users lat/long entries as much as possible; if he enters in Degree, Minutes, Seconds mode, it stays that way , if he enters in decimal degrees it stays that way etc.

Note: the final part of the overall fix is to 'upgrade' the db and modify any current language specific lat/long values to be always in English.  I propose to do this as part of the place enhancement GEPS045.