### PR TITLE
Simplify get_name_format in the name file of the display module

### DIFF
--- a/gramps/gen/display/name.py
+++ b/gramps/gen/display/name.py
@@ -495,29 +495,32 @@ class NameDisplay:
         """
         Get a list of tuples (num, name,fmt_str,act)
         """
-        the_list = []
 
-        keys = self.sort_by_ascending_positives_followed_by_negatives_in_reverse_order(self.name_formats)
+        formats = [
+            (index, name, format_string, active)
+            for index, (name, format_string, active, *_) in self.name_formats.items()
+            if (also_default or index) and
+               (not only_custom or index < 0) and
+               (not only_active or active)
+        ]
 
-        for num in keys:
-            if ((also_default or num) and
-                (not only_custom or (num < 0)) and
-                (not only_active or self.name_formats[num][_F_ACT])):
-                the_list.append((num,) + self.name_formats[num][_F_NAME:_F_FN])
+        return self.sort_by_ascending_positives_followed_by_negatives_in_reverse_order(formats)
 
-        return the_list
 
-    def sort_by_ascending_positives_followed_by_negatives_in_reverse_order(self, iterable):
+    def sort_by_ascending_positives_followed_by_negatives_in_reverse_order(self, formats):
         """
-        Sorts the iterable with positive keys first,
+        Sorts the formats with positive keys first,
         and negative keys last.
         The positives will be in ascending order and
         the negatives in the reverse of their original order
         in the iterable.
-        E.g. [-3, -1, -2, 1, 0, 2, 3] => [0, 1, 2, 3, -2, -1, -3]
+        E.g. key ordering: -3, -1, -2, 1, 0, 2, 3 => 0, 1, 2, 3, -2, -1, -3
         """
-        key_function = cmp_to_key(lambda x, y: x - y if x >= 0 and y >= 0 else y)
-        return sorted(iterable, key=key_function)
+        def compare_function(t, k):
+            x, y = t[0], k[0]
+            return x - y if x >= 0 and y >= 0 else y
+
+        return sorted(formats, key=cmp_to_key(compare_function))
 
     def _is_format_valid(self, num):
         try:

--- a/gramps/gen/display/test/name_test.py
+++ b/gramps/gen/display/test/name_test.py
@@ -1,0 +1,154 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2000-2007  Donald N. Allingham
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+import unittest
+
+from gramps.gen.display.name import NameDisplay
+
+
+class NameTest(unittest.TestCase):
+
+    def setUp(self):
+        self.name_display = NameDisplay()
+
+    def test_get_name_format_for_all_without_default_format(self):
+        self.add_custom_name_format('Surname, Name|Common Suffix')
+        self.add_inactive_custom_name_format('SURNAME, Given Suffix (Call)')
+
+        actual_name_format = self.name_display.get_name_format(also_default=False, only_custom=False, only_active=False)
+
+        expected_name_format = [
+            (1, 'Surname, Given Suffix', '%l, %f %s', True),
+            (2, 'Given Surname Suffix', '%f %l %s', True),
+            (3, 'Patronymic, Given', '%y, %s %f', False),
+            (4, 'Given', '%f', True),
+            (5, 'Main Surnames, Given Patronymic Suffix Prefix', '%1m %2m %o, %f %1y %s %0m', True),
+            (-2, 'SURNAME, Given Suffix (Call)', 'SURNAME, Given Suffix (Call)', False),
+            (-1, 'Surname, Name|Common Suffix', 'Surname, Name|Common Suffix', True)
+        ]
+        self.assertEqual(expected_name_format, actual_name_format)
+
+    def test_get_name_format_for_all_active_without_default_format(self):
+
+        self.add_custom_name_format('Surname, Name|Common Suffix')
+        self.add_inactive_custom_name_format('SURNAME, Given Suffix (Call)')
+
+        actual_name_format = self.name_display.get_name_format(also_default=False, only_custom=False, only_active=True)
+
+        expected_name_format = [
+            (1, 'Surname, Given Suffix', '%l, %f %s', True),
+            (2, 'Given Surname Suffix', '%f %l %s', True),
+            (4, 'Given', '%f', True),
+            (5, 'Main Surnames, Given Patronymic Suffix Prefix', '%1m %2m %o, %f %1y %s %0m', True),
+            (-1, 'Surname, Name|Common Suffix', 'Surname, Name|Common Suffix', True)
+        ]
+        self.assertEqual(expected_name_format, actual_name_format)
+
+    def test_get_name_format_for_all_custom_formats_without_default_format(self):
+
+        self.add_custom_name_format('Surname, Name|Common Suffix')
+        self.add_inactive_custom_name_format('SURNAME, Given Suffix (Call)')
+
+        actual_name_format = self.name_display.get_name_format(also_default=False, only_custom=True, only_active=False)
+
+        expected_name_format = [
+            (-2, 'SURNAME, Given Suffix (Call)', 'SURNAME, Given Suffix (Call)', False),
+            (-1, 'Surname, Name|Common Suffix', 'Surname, Name|Common Suffix', True)
+        ]
+        self.assertEqual(expected_name_format, actual_name_format)
+
+    def test_get_name_format_for_active_custom_formats_without_default_format(self):
+        self.add_custom_name_format('Surname, Name|Common Suffix')
+        self.add_inactive_custom_name_format('SURNAME, Given Suffix (Call)')
+
+        actual_name_format = self.name_display.get_name_format(also_default=False, only_custom=True, only_active=True)
+
+        expected_name_format = [
+            (-1, 'Surname, Name|Common Suffix', 'Surname, Name|Common Suffix', True)
+        ]
+        self.assertEqual(expected_name_format, actual_name_format)
+
+    def test_get_name_format_for_all(self):
+        self.add_custom_name_format('Surname, Name|Common Suffix')
+        self.add_inactive_custom_name_format('SURNAME, Given Suffix (Call)')
+
+        actual_name_format = self.name_display.get_name_format(also_default=True, only_custom=False, only_active=False)
+
+        expected_name_format = [
+            (0, 'Default format (defined by Gramps preferences)', '', True),
+            (1, 'Surname, Given Suffix', '%l, %f %s', True),
+            (2, 'Given Surname Suffix', '%f %l %s', True),
+            (3, 'Patronymic, Given', '%y, %s %f', False),
+            (4, 'Given', '%f', True),
+            (5, 'Main Surnames, Given Patronymic Suffix Prefix', '%1m %2m %o, %f %1y %s %0m', True),
+            (-2, 'SURNAME, Given Suffix (Call)', 'SURNAME, Given Suffix (Call)', False),
+            (-1, 'Surname, Name|Common Suffix', 'Surname, Name|Common Suffix', True)
+        ]
+        self.assertEqual(expected_name_format, actual_name_format)
+
+    def test_get_name_format_for_all_active(self):
+        self.add_custom_name_format('Surname, Name|Common Suffix')
+        self.add_inactive_custom_name_format('SURNAME, Given Suffix (Call)')
+
+        actual_name_format = self.name_display.get_name_format(also_default=True, only_custom=False, only_active=True)
+
+        expected_name_format = [
+            (0, 'Default format (defined by Gramps preferences)', '', True),
+            (1, 'Surname, Given Suffix', '%l, %f %s', True),
+            (2, 'Given Surname Suffix', '%f %l %s', True),
+            (4, 'Given', '%f', True),
+            (5, 'Main Surnames, Given Patronymic Suffix Prefix', '%1m %2m %o, %f %1y %s %0m', True),
+            (-1, 'Surname, Name|Common Suffix', 'Surname, Name|Common Suffix', True)
+        ]
+        self.assertEqual(expected_name_format, actual_name_format)
+
+    def test_get_name_format_for_all_custom_formats(self):
+        self.add_custom_name_format('Surname, Name|Common Suffix')
+        self.add_inactive_custom_name_format('SURNAME, Given Suffix (Call)')
+
+        actual_name_format = self.name_display.get_name_format(also_default=True, only_custom=True, only_active=False)
+
+        expected_name_format = [
+            (-2, 'SURNAME, Given Suffix (Call)', 'SURNAME, Given Suffix (Call)', False),
+            (-1, 'Surname, Name|Common Suffix', 'Surname, Name|Common Suffix', True)
+        ]
+        self.assertEqual(expected_name_format, actual_name_format)
+
+    def test_get_name_format_for_active_custom_formats(self):
+        self.add_custom_name_format('Surname, Name|Common Suffix')
+        self.add_inactive_custom_name_format('SURNAME, Given Suffix (Call)')
+
+        actual_name_format = self.name_display.get_name_format(also_default=True, only_custom=True, only_active=True)
+
+        expected_name_format = [
+            (-1, 'Surname, Name|Common Suffix', 'Surname, Name|Common Suffix', True)
+        ]
+        self.assertEqual(expected_name_format, actual_name_format)
+
+    def add_custom_name_format(self, name_format):
+        self.name_display.add_name_format(name_format, name_format)
+
+    def add_inactive_custom_name_format(self, name_format):
+        index = self.name_display.add_name_format(name_format, name_format)
+        self.name_display.set_format_inactive(index)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR aims to simplify the get_name_format.

First, the PR brings the method under test coverage.
Second, the duplicated `cmp_to_key` function is 
replaced by the method in functools. 
Third, the sorting method is simplified by abstracting 
it away behind a method that is named after 
the sort order and by collapsing
cases as described [in the commit](https://github.com/gramps-project/gramps/commit/0d292291ff51e0859c29a8a09d9e4b0892046f9e).
Fourth, the steps in the method is reordered so the
name formats are filtered first and then sorted.
