### PR TITLE
Fix GEDCOM import when family is missing; import created a missing note

### DIFF
--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -3222,6 +3222,7 @@ class GedcomParser(UpdateCallback):
                         make_unknown(gramps_id, self.explanation.handle,
                                      class_func, commit_func, self.trans,
                                      db=self.dbase)
+                        self.missing_references += 1
                         self.__add_msg(_("Error: %(msg)s  '%(gramps_id)s'"
                                          " (input as @%(xref)s@) not in input"
                                          " GEDCOM. Record synthesised") %


### PR DESCRIPTION
Fixes [#11472](https://gramps-project.org/bugs/view.php?id=11472)

User had a GEDCOM file that was missing a family that was referenced in an individual as a parent.

The GEDCOM code has a check for this, and created the missing family, however, due to the bug, the associated explanation note was not committed, leaving the db with a bad reference to that note.