### PR TITLE
Update _pythonmime.py

### DIFF
--- a/gramps/gen/mime/_pythonmime.py
+++ b/gramps/gen/mime/_pythonmime.py
@@ -29,6 +29,8 @@ _type_map = {
     'application/x-gedcom' : 'GEDCOM database',
     'application/x-gramps-package': 'Gramps package',
     'image/jpeg' : 'JPEG image',
+    'image/tiff' : 'TIFF image',
+    'image/png' : 'PNG image',
     'application/pdf' : 'PDF document',
     'text/rtf' : 'Rich Text File',
 }


### PR DESCRIPTION
When editing a Media image, Unknown is displayed if the image is a Tiff or Png.  This changes this to display TIFF image or PNG image instead.  Just a cosmetic change.