### PR TITLE
Geography: Add custom tiles provider

### DIFF
--- a/gramps/gen/config.py
+++ b/gramps/gen/config.py
@@ -186,6 +186,7 @@ register('geography.zoom_when_center', 12)
 register('geography.show_cross', False)
 register('geography.path', "")
 register('geography.use-keypad', True)
+register('geography.personal-map', "")
 
 # note that other calls to "register" are done in realtime (when
 # needed), for instance to four 'interface.clipboard' variables --

--- a/gramps/plugins/lib/maps/constants.py
+++ b/gramps/plugins/lib/maps/constants.py
@@ -64,6 +64,7 @@ VIRTUAL_EARTH_HYBRID = 13
 YAHOO_STREET = 14
 YAHOO_SATELLITE = 15
 YAHOO_HYBRID = 16
+PERSONAL = 30
 
 TILES_PATH = {
     OPENSTREETMAP           : "openstreetmap",
@@ -82,6 +83,7 @@ TILES_PATH = {
     YAHOO_STREET            : "yahoostreet",
     YAHOO_SATELLITE         : "yahoosat",
     YAHOO_HYBRID            : "yahoohybrid",
+    PERSONAL                : "personal",
 }
 
 MAP_TITLE = {
@@ -101,6 +103,7 @@ MAP_TITLE = {
     YAHOO_STREET            : "Yahoo street",
     YAHOO_SATELLITE         : "Yahoo sat",
     YAHOO_HYBRID            : "Yahoo hybrid",
+    PERSONAL                : "Personal map",
 }
 
 MAP_TYPE = {
@@ -114,5 +117,6 @@ MAP_TYPE = {
     VIRTUAL_EARTH_STREET    : osmgpsmap.MapSource_t.VIRTUAL_EARTH_STREET,
     VIRTUAL_EARTH_SATELLITE : osmgpsmap.MapSource_t.VIRTUAL_EARTH_SATELLITE,
     VIRTUAL_EARTH_HYBRID    : osmgpsmap.MapSource_t.VIRTUAL_EARTH_HYBRID,
+    PERSONAL                : None,
 }
 

--- a/gramps/plugins/lib/maps/geography.py
+++ b/gramps/plugins/lib/maps/geography.py
@@ -1269,26 +1269,26 @@ class GeoGraphyView(OsmGps, NavigationView):
                                     'from the keyboard.'),
                                   5, 'geography.use-keypad',
                                   extra_callback=self.update_shortcuts)
-        label = configdialog.add_text(grid,
-                              _('If you want to use a specific map provider,'
-                                ' You can set the following field to the'
-                                ' provider\'s url.\ni.e:\n'
-                                'http://tile.stamen.com/toner/#Z/#X/#Y.png\n'
-                                'http://tile.stamen.com/terrain/#Z/#X/#Y.jpg\n'
-                                'http://tile.stamen.com/watercolor/#Z/#X/#Y.jpg'
-                                '\nhttp://tile.xn--pnvkarte-m4a.de/tilegen/#Z/'
-                                '#X/#Y.png\n',
-                                ),
-                              6, line_wrap=False)
+        label = configdialog.add_text(
+            grid,
+            _('If you want to use a specific map provider,'
+              ' You can set the following field to the'
+              ' provider\'s url.\ni.e:\n'
+              'http://tile.stamen.com/toner/#Z/#X/#Y.png\n'
+              'http://tile.stamen.com/terrain/#Z/#X/#Y.jpg\n'
+              'http://tile.stamen.com/watercolor/#Z/#X/#Y.jpg\n'
+              'http://tile.xn--pnvkarte-m4a.de/tilegen/#Z/#X/#Y.png\n'
+             ),
+            6, line_wrap=False)
         # set the possibility to copy/paste the urls
         label.set_selectable(True)
         start = label.get_text().find("http")
         end = label.get_text().find("http", start + 1)
-        label.select_region(start,end)
+        label.select_region(start, end)
         url = configdialog.add_entry(grid, _("Personal map"),
-                              7, 'geography.personal-map',
-                              self.choosen_map,
-                              )
+                                     7, 'geography.personal-map',
+                                     self.choosen_map,
+                                    )
         if config.get('geography.personal-map') != "":
             url.set_text(config.get('geography.personal-map'))
         return _('The map'), grid

--- a/gramps/plugins/lib/maps/geography.py
+++ b/gramps/plugins/lib/maps/geography.py
@@ -125,6 +125,7 @@ class GeoGraphyView(OsmGps, NavigationView):
         ('geography.map_service', constants.OPENSTREETMAP),
         ('geography.max_places', 5000),
         ('geography.use-keypad', True),
+        ('geography.personal-map', ""),
         )
 
     def __init__(self, title, pdata, dbstate, uistate,
@@ -143,6 +144,8 @@ class GeoGraphyView(OsmGps, NavigationView):
         self.lock = config.get("geography.lock")
         if config.get('geography.path') == "":
             config.set('geography.path', GEOGRAPHY_PATH)
+        if not config.is_set('geography.personal-map'):
+            config.set('geography.personal-map', "")
 
         self.uistate = uistate
         self.uistate.connect('font-changed', self.font_changed)
@@ -1266,7 +1269,51 @@ class GeoGraphyView(OsmGps, NavigationView):
                                     'from the keyboard.'),
                                   5, 'geography.use-keypad',
                                   extra_callback=self.update_shortcuts)
+        label = configdialog.add_text(grid,
+                              _('If you want to use a specific map provider,'
+                                ' You can set the following field to the'
+                                ' provider\'s url.\ni.e:\n'
+                                'http://tile.stamen.com/toner/#Z/#X/#Y.png\n'
+                                'http://tile.stamen.com/terrain/#Z/#X/#Y.jpg\n'
+                                'http://tile.stamen.com/watercolor/#Z/#X/#Y.jpg'
+                                '\nhttp://tile.xn--pnvkarte-m4a.de/tilegen/#Z/'
+                                '#X/#Y.png\n',
+                                ),
+                              6, line_wrap=False)
+        # set the possibility to copy/paste the urls
+        label.set_selectable(True)
+        start = label.get_text().find("http")
+        end = label.get_text().find("http", start + 1)
+        label.select_region(start,end)
+        url = configdialog.add_entry(grid, _("Personal map"),
+                              7, 'geography.personal-map',
+                              self.choosen_map,
+                              )
+        if config.get('geography.personal-map') != "":
+            url.set_text(config.get('geography.personal-map'))
         return _('The map'), grid
+
+    def choosen_map(self, *obj):
+        """
+        Save the provider map path in the config section.
+        """
+        map_source = obj[0].get_text()
+        name = constants.TILES_PATH[constants.PERSONAL]
+        print(self.current_map, constants.PERSONAL,
+              map_source, config.get('geography.personal-map'))
+        config.set('geography.personal-map', map_source)
+        self.clear_map(None, name)
+        if map_source == "":
+            print("reset osm")
+            config.set("geography.map_service", constants.OPENSTREETMAP)
+            self.change_map(self.osm, config.get("geography.map_service"))
+            self.reload_tiles()
+            return
+        if map_source != config.get('geography.personal-map'):
+            print("set personal")
+            config.set("geography.map_service", constants.PERSONAL)
+            self.change_new_map(name, map_source)
+            self.reload_tiles()
 
     def set_tilepath(self, *obj):
         """

--- a/gramps/plugins/lib/maps/osmgps.py
+++ b/gramps/plugins/lib/maps/osmgps.py
@@ -147,6 +147,15 @@ class OsmGps:
         """
         Change the current map
         """
+        if map_type == constants.PERSONAL:
+            map_source = config.get('geography.personal-map')
+            if map_source == "":
+                return
+            name = constants.TILES_PATH[map_type]
+            self.change_new_map(name, map_source)
+            config.set("geography.map_service", map_type)
+            self.current_map = map_type
+            return
         if obj is not None:
             self.osm.layer_remove_all()
             self.osm.image_remove_all()
@@ -277,8 +286,12 @@ class OsmGps:
         pt2 = bbox[1]
         self.zoom = config.get("geography.zoom")
         tile_size = float(256)
-        # get the file extension depending on the map provider
-        img_format = self.osm.source_get_image_format(map_idx)
+        if map_idx != constants.PERSONAL:
+            # get the file extension depending on the map provider
+            img_format = self.osm.source_get_image_format(map_idx)
+        else:
+            filename = config.get("geography.personal-map")
+            img_format = os.path.splitext(filename)[1]
         # calculate the number of images to download in rows and columns
         pt1_x = floor(lon2pixel(self.zoom, pt1.rlon, tile_size) / tile_size)
         pt1_y = floor(lat2pixel(self.zoom, pt1.rlat, tile_size) / tile_size)

--- a/gramps/plugins/view/geoclose.py
+++ b/gramps/plugins/view/geoclose.py
@@ -204,6 +204,7 @@ class GeoClose(GeoGraphyView):
         ('geography.center-lat', 0.0),
         ('geography.center-lon', 0.0),
         ('geography.use-keypad', True),
+        ('geography.personal-map', ""),
 
         ('geography.map_service', constants.OPENSTREETMAP),
         ('geography.max_places', 5000),

--- a/gramps/plugins/view/geofamclose.py
+++ b/gramps/plugins/view/geofamclose.py
@@ -203,6 +203,7 @@ class GeoFamClose(GeoGraphyView):
         ('geography.center-lat', 0.0),
         ('geography.center-lon', 0.0),
         ('geography.use-keypad', True),
+        ('geography.personal-map', ""),
 
         ('geography.map_service', constants.OPENSTREETMAP),
         ('geography.max_places', 5000),

--- a/gramps/plugins/view/geomoves.py
+++ b/gramps/plugins/view/geomoves.py
@@ -191,6 +191,7 @@ class GeoMoves(GeoGraphyView):
         ('geography.center-lat', 0.0),
         ('geography.center-lon', 0.0),
         ('geography.use-keypad', True),
+        ('geography.personal-map', ""),
 
         ('geography.map_service', constants.OPENSTREETMAP),
         ('geography.max_places', 5000),

--- a/gramps/plugins/view/geoperson.py
+++ b/gramps/plugins/view/geoperson.py
@@ -191,6 +191,7 @@ class GeoPerson(GeoGraphyView):
         ('geography.center-lat', 0.0),
         ('geography.center-lon', 0.0),
         ('geography.use-keypad', True),
+        ('geography.personal-map', ""),
 
         #('geography.gps_mode', GPS_DISABLED),
         #('geography.gps_update_rate', float(1.0)),

--- a/gramps/plugins/view/geoplaces.py
+++ b/gramps/plugins/view/geoplaces.py
@@ -176,6 +176,7 @@ class GeoPlaces(GeoGraphyView):
         ('geography.map_service', constants.OPENSTREETMAP),
         ('geography.max_places', 5000),
         ('geography.use-keypad', True),
+        ('geography.personal-map', ""),
 
         # specific to geoplaces :
 


### PR DESCRIPTION
Fixes [#11416](https://gramps-project.org/bugs/view.php?id=11416)

I have added a personal map field entry in the geography views.
If this field is not a null string, you can select it in the change map menu.