### PR TITLE
Fix Dashboard for adding Gramplet crash in Slovenian

### DIFF
--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -1473,7 +1473,7 @@ class GrampletPane(Gtk.ScrolledWindow):
             plugs.sort(key=lambda x: x.name)
             for plug in plugs:
                 action_name = valid_action_name(plug.id)
-                a_menuitems += menuitem % (action_name, plug.name)
+                a_menuitems += menuitem % (action_name, escape(plug.name))
                 actions.append((action_name,
                                 make_callback(self.add_gramplet, plug.name)))
             names = [gramplet.title for gramplet in self.closed_gramplets]
@@ -1484,7 +1484,7 @@ class GrampletPane(Gtk.ScrolledWindow):
                     # 'name' could be non-ASCII when in non-English language
                     # action names must be in ASCII, so use 'id' instead.
                     action_name = valid_action_name(str(id(name)))
-                    r_menuitems += menuitem % (action_name, name)
+                    r_menuitems += menuitem % (action_name, escape(name))
                     actions.append((action_name,
                                     make_callback(self.restore_gramplet,
                                                   name)))


### PR DESCRIPTION
Fixes [#11491](https://gramps-project.org/bugs/view.php?id=11491)

The 'FAQ' Gramplet translate to "V&O" in Slovenian, and the '&' character is invalid in XML. Need to escape for the Gramplet name.