### PR TITLE
Make GuiDestinationOption Folder Icon start in users directory

### DIFF
--- a/gramps/gui/plug/_guioptions.py
+++ b/gramps/gui/plug/_guioptions.py
@@ -1756,7 +1756,8 @@ class GuiDestinationOption(Gtk.Box):
                     name = get_curr_dir
             fcd.set_current_folder(name)
         else:
-            fcd.set_current_name(name)
+            fcd.set_current_name(os.path.basename(name))
+            fcd.set_current_folder(os.path.dirname(name))
 
         status = fcd.run()
         if status == Gtk.ResponseType.OK:


### PR DESCRIPTION
Fixes [#10917](https://gramps-project.org/bugs/view.php?id=10917)

User points out that the GuiDestinationOption, when used in the file mode, has a bad initial setting for the starting directory (typically where the Gramps code is located, which is not writable on Windows).  The user can override by selecting a different directory, but naive users may not pay attention to this.

This patch makes this file selector behave like the more commonly used FileEntry dialog, in that the filename is split and the basename is put at the top of the dialog, and the current directory is set to the users previous directory.