### PR TITLE
Change Relationship Graph so parents are on same rank

### DIFF
--- a/gramps/plugins/graph/gvrelgraph.py
+++ b/gramps/plugins/graph/gvrelgraph.py
@@ -522,6 +522,8 @@ class RelGraphReport(Report):
                                   "invis",
                                   "none",
                                   "none")
+                self.doc.add_samerank(first.get_gramps_id(),
+                                      second.get_gramps_id())
             if f_handle in self.persons:
                 father = self._db.get_person_from_handle(f_handle)
                 self.doc.add_link(father.get_gramps_id(),


### PR DESCRIPTION
A recent change (https://github.com/gramps-project/gramps/pull/733) caused parents to end up on different 'levels' of the graph.

Several users have objected to this.

This PR causes the parents to end up back at the same level.  It doesn't revert the earlier change, the invisible line between parents is still there, which in most cases keeps the parents a bit closer together.