### PR TITLE
Narrated Web: bad event links on media pages

### DIFF
--- a/gramps/gen/datehandler/_date_cs.py
+++ b/gramps/gen/datehandler/_date_cs.py
@@ -50,6 +50,15 @@ class DateParserCZ(DateParser):
     Converts a text string into a Date object
     """
 
+    quality_to_int = {
+        'přibližně'  : Date.QUAL_ESTIMATED,
+        'odhadem'    : Date.QUAL_ESTIMATED,
+        'odh.'       : Date.QUAL_ESTIMATED,
+        'vypočteno'  : Date.QUAL_CALCULATED,
+        'vypočtené'  : Date.QUAL_CALCULATED,
+        'vyp.'       : Date.QUAL_CALCULATED,
+    }
+
     bce = ["před naším letopočtem", "před Kristem",
            "př. n. l.", "př. Kr."] + DateParser.bce
 
@@ -57,6 +66,17 @@ class DateParserCZ(DateParser):
         """ Allow overriding so a subclass can modify it """
         # bug 9739 grampslocale.py gets '%-d.%-m.%Y' -- makes it be '%/d.%/m.%Y'
         self.dhformat = self.dhformat.replace('/', '') # so counteract that
+
+    def init_strings(self):
+        DateParser.init_strings(self)
+        self._text2 = re.compile(r'(\d+)?\.?\s+?%s\.?\s*((\d+)(/\d+)?)?\s*$'
+                                 % self._mon_str, re.IGNORECASE)
+        self._span = re.compile(
+            r"(od)\s+(?P<start>.+)\s+(do)\s+(?P<stop>.+)",
+            re.IGNORECASE)
+        self._range = re.compile(
+            r"(mezi)\s+(?P<start>.+)\s+(a)\s+(?P<stop>.+)",
+            re.IGNORECASE)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/plug/docgen/treedoc.py
+++ b/gramps/gen/plug/docgen/treedoc.py
@@ -302,7 +302,7 @@ class TreeDocBase(BaseDoc, TreeDoc):
         name = paper_size.get_name().lower()
         if name == 'custom size':
             width = str(paper_size.get_width())
-            height = str(paper_size.get_width())
+            height = str(paper_size.get_height())
             paper = 'papersize={%scm,%scm}' % (width, height)
         elif name in ('a', 'b', 'c', 'd', 'e'):
             paper = 'ansi' + name + 'paper'

--- a/gramps/gen/plug/docgen/treedoc.py
+++ b/gramps/gen/plug/docgen/treedoc.py
@@ -519,6 +519,7 @@ class TreeDocBase(BaseDoc, TreeDoc):
             date_str = date_str + '/' + stop_date
 
         place = escape(_pd.display_event(db, event))
+        place = place.replace("-", "\--")
 
         if modifier:
             event_type += '+'

--- a/gramps/gen/proxy/private.py
+++ b/gramps/gen/proxy/private.py
@@ -769,6 +769,7 @@ def sanitize_citation(db, citation):
     new_citation.set_gramps_id(citation.get_gramps_id())
     new_citation.set_handle(citation.get_handle())
     new_citation.set_change_time(citation.get_change_time())
+    new_citation.set_tag_list(citation.get_tag_list())
     copy_srcattributes(db, citation, new_citation)
     copy_notes(db, citation, new_citation)
     copy_media_ref_list(db, citation, new_citation)
@@ -914,6 +915,7 @@ def sanitize_source(db, source):
     new_source.set_gramps_id(source.get_gramps_id())
     new_source.set_handle(source.get_handle())
     new_source.set_change_time(source.get_change_time())
+    new_source.set_tag_list(source.get_tag_list())
 
     for repo_ref in source.get_reporef_list():
         if repo_ref and not repo_ref.get_privacy():
@@ -987,6 +989,7 @@ def sanitize_place(db, place):
     new_place.set_type(place.get_type())
     new_place.set_code(place.get_code())
     new_place.set_placeref_list(place.get_placeref_list())
+    new_place.set_tag_list(place.get_tag_list())
 
     copy_citation_ref_list(db, place, new_place)
     copy_notes(db, place, new_place)
@@ -1017,6 +1020,7 @@ def sanitize_event(db, event):
     new_event.set_handle(event.get_handle())
     new_event.set_date_object(event.get_date_object())
     new_event.set_change_time(event.get_change_time())
+    new_event.set_tag_list(event.get_tag_list())
 
     copy_citation_ref_list(db, event, new_event)
     copy_notes(db, event, new_event)
@@ -1120,6 +1124,7 @@ def sanitize_repository(db, repository):
     new_repository.set_gramps_id(repository.get_gramps_id())
     new_repository.set_handle(repository.get_handle())
     new_repository.set_change_time(repository.get_change_time())
+    new_repository.set_tag_list(repository.get_tag_list())
 
     copy_notes(db, repository, new_repository)
     copy_addresses(db, repository, new_repository)

--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -1840,7 +1840,7 @@ class BasePage: # pylint: disable=C1001
                         _linkurl = self.report.build_url_fname_html(_obj.handle,
                                                                     "ppl",
                                                                     linkurl)
-            elif classname == "Family":
+            elif classname == "Family" and self.inc_families:
                 _obj = self.r_db.get_family_from_handle(newhandle)
                 partner1_handle = _obj.get_father_handle()
                 partner2_handle = _obj.get_mother_handle()
@@ -1866,7 +1866,7 @@ class BasePage: # pylint: disable=C1001
                                                                 "ppl", True)
                 if not _name:
                     _name = self._("Unknown")
-            elif classname == "Event":
+            elif classname == "Event" and self.inc_events:
                 _obj = self.r_db.get_event_from_handle(newhandle)
                 _name = _obj.get_description()
                 if not _name:

--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -2030,12 +2030,6 @@ class BasePage: # pylint: disable=C1001
             if photoref.ref in photolist_handles:
                 photo = photolist_handles[photoref.ref]
                 photolist_ordered.append(photo)
-                try:
-                    if photo in photolist:
-                        photolist.remove(photo)
-                except ValueError:
-                    LOG.warning("Error trying to remove '%s' from photolist",
-                                photo)
         # and add any that are left (should there be any?)
         photolist_ordered += photolist
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -6,48 +6,48 @@
 # Copyright (C) 2008 PEL GRUP DE GRAMPS
 # Aquest fitxer es distribueix segons la mateixa llicència que Gramps
 #
-# Joan Creus <joan.creus at gmail dot com>, 2008, 2009, 2010, 2011, 2012, 2013.
-# Arnau <arnaullv at gmail dot com>, 2017.
 #
+# Joan Creus <joan.creus at gmail dot com>, 2008, 2009, 2010, 2011, 2012, 2013, 2019.
+# Arnau <arnaullv at gmail dot com>, 2017.
 msgid ""
 msgstr ""
 "Project-Id-Version: ca\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-10 17:16+0100\n"
-"PO-Revision-Date: 2018-02-23 13:12+0100\n"
-"Last-Translator: Arnau <arnaullv at gmail dot com>\n"
-"Language-Team: català; valencià <kde-i18n-ca@kde.org>\n"
+"POT-Creation-Date: 2019-10-17 11:43+1100\n"
+"PO-Revision-Date: 2019-12-21 18:20+0100\n"
+"Last-Translator: Joan Creus <joan.creusandreu at gmail dot com>\n"
+"Language-Team: Catalan <kde-i18n-ca@kde.org>\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.0.6\n"
+"X-Generator: Lokalize 19.04.3\n"
 
 #: ../data/gramps.appdata.xml.in.h:1
 msgid ""
-"Gramps is a genealogy program that is both intuitive for hobbyists and "
-"feature-complete for professional genealogists."
+"Gramps is a genealogy program that is both intuitive for hobbyists and"
+" feature-complete for professional genealogists."
 msgstr ""
-"Gramps és un programa de genealogia que és alhora intuïtiu per als "
-"afeccionats i complet per als professionals."
+"Gramps és un programa de genealogia que és alhora intuïtiu per als"
+" afeccionats i complet per als professionals."
 
 #: ../data/gramps.appdata.xml.in.h:2
 msgid ""
-"It gives you the ability to record the many details of the life of an "
-"individual as well as the complex relationships between various people, "
-"places and events."
+"It gives you the ability to record the many details of the life of an"
+" individual as well as the complex relationships between various people,"
+" places and events."
 msgstr ""
-"Permet de registrar la multitud de detalls de la vida d'una persona, així "
-"com les relacions complexes entre persones, llocs i esdeveniments diversos."
+"Permet de registrar la multitud de detalls de la vida d'una persona, així com"
+" les relacions complexes entre persones, llocs i esdeveniments diversos."
 
 #: ../data/gramps.appdata.xml.in.h:3
 msgid ""
-"All of your research is kept organized, searchable and as precise as you "
-"need it to be."
+"All of your research is kept organized, searchable and as precise as you need"
+" it to be."
 msgstr ""
-"Tota la investigació queda organitzada, s'hi poden fer cerques i és tan "
-"precisa com us cal."
+"Tota la investigació queda organitzada, s'hi poden fer cerques i és tan"
+" precisa com us cal."
 
 #: ../data/gramps.desktop.in.h:1
 msgid "Gramps"
@@ -289,825 +289,827 @@ msgstr "Sèrbia (Llatí)"
 
 #: ../data/tips.xml.in.h:1
 msgid ""
-"<b>Working with Dates</b><br/>A range of dates can be given by using the "
-"format &quot;between January 4, 2000 and March 20, 2003&quot;. You can also "
-"indicate the level of confidence in a date and even choose between seven "
-"different calendars. Try the button next to the date field in the Events "
-"Editor."
+"<b>Working with Dates</b><br/>A range of dates can be given by using the"
+" format &quot;between January 4, 2000 and March 20, 2003&quot;. You can also"
+" indicate the level of confidence in a date and even choose between seven"
+" different calendars. Try the button next to the date field in the Events"
+" Editor."
 msgstr ""
-"<b>Treballar amb Dates</b><br/>Es pot donar un rang de dates fent servir el "
-"format &quot;entre 4 de gener de 2000 i 20 de març de 2003&quot;. També pot "
-"indicar el nivell de confiança en una data i fins i tot triar entre set "
-"calendaris diferents. Provi el botó del costat del camp de data a l'Editor "
-"d'Esdeveniments."
+"<b>Treballar amb Dates</b><br/>Es pot donar un rang de dates fent servir el"
+" format &quot;entre 4 de gener de 2000 i 20 de març de 2003&quot;. També pot"
+" indicar el nivell de confiança en una data i fins i tot triar entre set"
+" calendaris diferents. Provi el botó del costat del camp de data a l'Editor"
+" d'Esdeveniments."
 
 #: ../data/tips.xml.in.h:2
 msgid ""
-"<b>Editing Objects</b><br/>In most cases double clicking on a name, source, "
-"place or media entry will bring up a window to allow you to edit the object. "
-"Note that the result can be dependent on context. For example, in the Family "
-"View clicking on a parent or child will bring up the Relationship Editor."
+"<b>Editing Objects</b><br/>In most cases double clicking on a name, source,"
+" place or media entry will bring up a window to allow you to edit the object."
+" Note that the result can be dependent on context. For example, in the Family"
+" View clicking on a parent or child will bring up the Relationship Editor."
 msgstr ""
-"<b>Edició d'Objectes</b><br/>En la majoria de casos, fer un doble clic sobre "
-"un nom, font, lloc, o medi farà sortir una finestra que li permetrà editar "
-"l'objecte. Fixi's que el resultat pot dependre del context. Per exemple, a "
-"la Vista de Família, clicar en un pare o fill farà sortir l'Editor de "
-"Relacions."
+"<b>Edició d'Objectes</b><br/>En la majoria de casos, fer un doble clic sobre"
+" un nom, font, lloc, o medi farà sortir una finestra que li permetrà editar"
+" l'objecte. Fixi's que el resultat pot dependre del context. Per exemple, a"
+" la Vista de Família, clicar en un pare o fill farà sortir l'Editor de"
+" Relacions."
 
 #: ../data/tips.xml.in.h:3
 msgid ""
-"<b>Adding Images</b><br/>An image can be added to any gallery or the Media "
-"View by dragging and dropping it from a file manager or a web browser. "
-"Actually you can add any type of file like this, useful for scans of "
-"documents and other digital sources."
+"<b>Adding Images</b><br/>An image can be added to any gallery or the Media"
+" View by dragging and dropping it from a file manager or a web browser."
+" Actually you can add any type of file like this, useful for scans of"
+" documents and other digital sources."
 msgstr ""
-"<b>Afegir Imatges</b><br/>Es pot afegir una imatge a qualsevol galeria o a "
-"la Vista de Medis Audiovisuals arrossegant-la i deixant-la des d'un gestor "
-"de fitxers o un navegador. De fet es pot afegir qualsevol tipus de fitxer "
-"així; és útil per documents escanejats i altres fonts digitals."
+"<b>Afegir Imatges</b><br/>Es pot afegir una imatge a qualsevol galeria o a la"
+" Vista de Medis Audiovisuals arrossegant-la i deixant-la des d'un gestor de"
+" fitxers o un navegador. De fet es pot afegir qualsevol tipus de fitxer així;"
+" és útil per documents escanejats i altres fonts digitals."
 
 #: ../data/tips.xml.in.h:4
 msgid ""
-"<b>Ordering Children in a Family</b><br/>The birth order of children in a "
-"family can be set by using drag and drop. This order is preserved even when "
-"they do not have birth dates."
+"<b>Ordering Children in a Family</b><br/>The birth order of children in a"
+" family can be set by using drag and drop. This order is preserved even when"
+" they do not have birth dates."
 msgstr ""
-"<b>Ordenar els Fills en una Família</b><br/>L'ordre de naixement dels fills "
-"en una família es pot fixar arrossegant i deixant. Aquest ordre es conserva "
-"fins i tot quan no tenen dates de naixement."
+"<b>Ordenar els Fills en una Família</b><br/>L'ordre de naixement dels fills"
+" en una família es pot fixar arrossegant i deixant. Aquest ordre es conserva"
+" fins i tot quan no tenen dates de naixement."
 
 #: ../data/tips.xml.in.h:5
 msgid ""
-"<b>Talk to Relatives Before It Is Too Late</b><br/>Your oldest relatives can "
-"be your most important source of information. They usually know things about "
-"the family that haven't been written down. They might tell you nuggets about "
-"people that may one day lead to a new avenue of research. At the very least, "
-"you will get to hear some great stories. Don't forget to record the "
-"conversations!"
+"<b>Talk to Relatives Before It Is Too Late</b><br/>Your oldest relatives can"
+" be your most important source of information. They usually know things about"
+" the family that haven't been written down. They might tell you nuggets about"
+" people that may one day lead to a new avenue of research. At the very least,"
+" you will get to hear some great stories. Don't forget to record the"
+" conversations!"
 msgstr ""
-"<b>Parli amb els Parents Abans No Sigui Massa Tard</b><br/>Els seus parents "
-"més grans poden ser la seva font d'informació més important. Sovint saben "
-"coses sobre la família que no s'han posat mai per escrit. Podrien donar "
-"petites informacions sobre gent que algun dia poden desembocar en una nova "
-"via de recerca. Com a mínim, podrà sentir alguna història boníssima. No "
-"s'oblidi de gravar les converses!"
+"<b>Parli amb els Parents Abans No Sigui Massa Tard</b><br/>Els seus parents"
+" més grans poden ser la seva font d'informació més important. Sovint saben"
+" coses sobre la família que no s'han posat mai per escrit. Podrien donar"
+" petites informacions sobre gent que algun dia poden desembocar en una nova"
+" via de recerca. Com a mínim, podrà sentir alguna història boníssima. No"
+" s'oblidi de gravar les converses!"
 
 #: ../data/tips.xml.in.h:6
 msgid ""
-"<b>Filtering People</b><br/>In the People View, you can 'filter' individuals "
-"based on many criteria. To define a new filter go to &quot;Edit &gt; Person "
-"Filter Editor&quot;. There you can name your filter and add and combine "
-"rules using the many preset rules. For example, you can define a filter to "
-"find all adopted people in the family tree. People without a birth date "
-"mentioned can also be filtered. To get the results save your filter and "
-"select it at the bottom of the Filter Sidebar, then click Apply. If the "
-"Filter Sidebar is not visible, select View &gt; Filter."
+"<b>Filtering People</b><br/>In the People View, you can 'filter' individuals"
+" based on many criteria. To define a new filter go to &quot;Edit &gt; Person"
+" Filter Editor&quot;. There you can name your filter and add and combine"
+" rules using the many preset rules. For example, you can define a filter to"
+" find all adopted people in the family tree. People without a birth date"
+" mentioned can also be filtered. To get the results save your filter and"
+" select it at the bottom of the Filter Sidebar, then click Apply. If the"
+" Filter Sidebar is not visible, select View &gt; Filter."
 msgstr ""
-"<b>Filtrar Persones</b><br/>A la Vista de Persones, es poden 'filtrar' "
-"individus segons criteris molt variats. Per definir un filtre nou, vagi a "
-"&quot;Edita &gt; Editor de Filtres de Persones&quot;. Allà pot posar nom al "
-"seu filtre i afegir i combinar regles fent servir la multitud de regles "
-"predeterminades. Per exemple, es pot definir un filtre per localitzar totes "
-"les persones adoptades de l'arbre genealògic. També es poden filtrar les "
-"persones sense data de naixement coneguda. Per obtenir els resultats, desi "
-"el filtre, seleccioni'l al capdavall de la Barra Lateral de Filtres, i "
-"cliqui Aplicar. Si la Barra Lateral de Filtres no és visible, seleccioni "
-"Veure &gt; Filtre."
+"<b>Filtrar Persones</b><br/>A la Vista de Persones, es poden 'filtrar'"
+" individus segons criteris molt variats. Per definir un filtre nou, vagi a"
+" &quot;Edita &gt; Editor de Filtres de Persones&quot;. Allà pot posar nom al"
+" seu filtre i afegir i combinar regles fent servir la multitud de regles"
+" predeterminades. Per exemple, es pot definir un filtre per localitzar totes"
+" les persones adoptades de l'arbre genealògic. També es poden filtrar les"
+" persones sense data de naixement coneguda. Per obtenir els resultats, desi"
+" el filtre, seleccioni'l al capdavall de la Barra Lateral de Filtres, i"
+" cliqui Aplicar. Si la Barra Lateral de Filtres no és visible, seleccioni"
+" Veure &gt; Filtre."
 
 #: ../data/tips.xml.in.h:7
 msgid ""
-"<b>Inverted Filtering</b><br/>Filters can easily be reversed by using the "
-"'invert' option. For instance, by inverting the 'People with children' "
-"filter you can select all people without children."
+"<b>Inverted Filtering</b><br/>Filters can easily be reversed by using the"
+" 'invert' option. For instance, by inverting the 'People with children'"
+" filter you can select all people without children."
 msgstr ""
-"<b>Filtratge Invers</b><br/>Els Filtres es poden invertir fàcilment amb "
-"l'opció 'invertir'. Per exemple, invertint el filtre de 'Persones amb fills' "
-"pot seleccionar totes les persones que no en tinguin."
+"<b>Filtratge Invers</b><br/>Els Filtres es poden invertir fàcilment amb"
+" l'opció 'invertir'. Per exemple, invertint el filtre de 'Persones amb fills'"
+" pot seleccionar totes les persones que no en tinguin."
 
 #: ../data/tips.xml.in.h:8
 msgid ""
-"<b>Locating People</b><br/>By default, each surname in the People View is "
-"listed only once. By clicking on the arrow to the left of a name, the list "
-"will expand to show all individuals with that last name. To locate any "
-"Family Name from a long list, select a Family Name (not a person) and start "
-"typing. The view will jump to the first Family Name matching the letters you "
-"enter."
+"<b>Locating People</b><br/>By default, each surname in the People View is"
+" listed only once. By clicking on the arrow to the left of a name, the list"
+" will expand to show all individuals with that last name. To locate any"
+" Family Name from a long list, select a Family Name (not a person) and start"
+" typing. The view will jump to the first Family Name matching the letters you"
+" enter."
 msgstr ""
-"<b>Trobant Persones</b><br/>Per defecte, cada cognom de la Vista de Persones "
-"es llista només un cop. Clicant a la fletxa de l'esquerra d'un nom, la "
-"llista s'expandeix per mostrar tots els individus amb aquest cognom. Per "
-"localitzar qualsevol Nom de Família d'una llista llarga, seleccioni un Nom "
-"de Família (no una persona) i comenci a escriure'l. La vista saltarà al "
-"primer Nom de Família que concordi amb les lletres que escrigui."
+"<b>Trobant Persones</b><br/>Per defecte, cada cognom de la Vista de Persones"
+" es llista només un cop. Clicant a la fletxa de l'esquerra d'un nom, la"
+" llista s'expandeix per mostrar tots els individus amb aquest cognom. Per"
+" localitzar qualsevol Nom de Família d'una llista llarga, seleccioni un Nom"
+" de Família (no una persona) i comenci a escriure'l. La vista saltarà al"
+" primer Nom de Família que concordi amb les lletres que escrigui."
 
 #: ../data/tips.xml.in.h:9
 msgid ""
-"<b>The Family View</b><br/>The Family View is used to display a typical "
-"family unit as two parents and their children."
+"<b>The Family View</b><br/>The Family View is used to display a typical"
+" family unit as two parents and their children."
 msgstr ""
-"<b>La Vista de Família</b><br/>La Vista de Família es fa servir per mostrar "
-"una unitat familiar típica com a dos pares i els seus fills."
+"<b>La Vista de Família</b><br/>La Vista de Família es fa servir per mostrar"
+" una unitat familiar típica com a dos pares i els seus fills."
 
 #: ../data/tips.xml.in.h:10
 msgid ""
-"<b>Changing the Active Person</b><br/>Changing the Active Person in views is "
-"easy. In the Relationship view just click on anyone. In the Ancestry View "
-"doubleclick on the person or right click to select any of their spouses, "
-"siblings, children or parents."
+"<b>Changing the Active Person</b><br/>Changing the Active Person in views is"
+" easy. In the Relationship view just click on anyone. In the Ancestry View"
+" doubleclick on the person or right click to select any of their spouses,"
+" siblings, children or parents."
 msgstr ""
-"<b>Canviar la Persona Activa</b><br/>Canviar la Persona Activa a les vistes "
-"és fàcil. A la vista de Relació cliqui a qualsevol persona. A la vista "
-"d'Avantpassats faci doble clic a la persona o clic dret per seleccionar "
-"qualsevol dels seus cònjuges, germans, fills o pares."
+"<b>Canviar la Persona Activa</b><br/>Canviar la Persona Activa a les vistes"
+" és fàcil. A la vista de Relació cliqui a qualsevol persona. A la vista"
+" d'Avantpassats faci doble clic a la persona o clic dret per seleccionar"
+" qualsevol dels seus cònjuges, germans, fills o pares."
 
 #: ../data/tips.xml.in.h:11
 msgid ""
-"<b>Who Was Born When?</b><br/>Under &quot;Tools &gt; Analysis and "
-"exploration &gt; Compare Individual Events...&quot; you can compare the data "
-"of individuals in your database. This is useful, say, if you wish to list "
-"the birth dates of everyone in your database. You can use a custom filter to "
-"narrow the results."
+"<b>Who Was Born When?</b><br/>Under &quot;Tools &gt; Analysis and exploration"
+" &gt; Compare Individual Events...&quot; you can compare the data of"
+" individuals in your database. This is useful, say, if you wish to list the"
+" birth dates of everyone in your database. You can use a custom filter to"
+" narrow the results."
 msgstr ""
-"<b>Qui Va Néixer Quan?</b><br/>A &quot;Eines &gt;Anàlisi i Exploració &gt; "
-"Comparar Esdeveniments Individuals...&quot; pot comparar dades dels "
-"individus de la base de dades. Això és útil, per exemple, si es volen "
-"llistar les dates de naixement de tothom de la base de dades. Pot utilitzar "
-"un filtre personalitzat per reduir el nombre de resultats."
+"<b>Qui Va Néixer Quan?</b><br/>A &quot;Eines &gt;Anàlisi i Exploració &gt;"
+" Comparar Esdeveniments Individuals...&quot; pot comparar dades dels"
+" individus de la base de dades. Això és útil, per exemple, si es volen"
+" llistar les dates de naixement de tothom de la base de dades. Pot utilitzar"
+" un filtre personalitzat per reduir el nombre de resultats."
 
 #: ../data/tips.xml.in.h:12
 msgid ""
-"<b>Gramps Tools</b><br/>Gramps comes with a rich set of tools. These allow "
-"you to undertake operations such as checking the database for errors and "
-"consistency. There are research and analysis tools such as event comparison, "
-"finding duplicate people, interactive descendant browser, and many others. "
-"All tools can be accessed through the &quot;Tools&quot; menu."
+"<b>Gramps Tools</b><br/>Gramps comes with a rich set of tools. These allow"
+" you to undertake operations such as checking the database for errors and"
+" consistency. There are research and analysis tools such as event comparison,"
+" finding duplicate people, interactive descendant browser, and many others."
+" All tools can be accessed through the &quot;Tools&quot; menu."
 msgstr ""
-"<b>Eines de Gramps</b><br/>Gramps ve amb un conjunt d'eines molt complet. "
-"Permeten dur a terme operacions com ara comprovar els errors i la "
-"consistència de la base de dades. Hi ha eines de recerca i anàlisi com ara "
-"la comparació d'esdeveniments, localització de persones duplicades, "
-"navegador de descendents interactiu, i molts d'altres. Totes les eines es "
-"poden trobar sota el menú d'&quot;Eines&quot;."
+"<b>Eines de Gramps</b><br/>Gramps ve amb un conjunt d'eines molt complet."
+" Permeten dur a terme operacions com ara comprovar els errors i la"
+" consistència de la base de dades. Hi ha eines de recerca i anàlisi com ara"
+" la comparació d'esdeveniments, localització de persones duplicades,"
+" navegador de descendents interactiu, i molts d'altres. Totes les eines es"
+" poden trobar sota el menú d'&quot;Eines&quot;."
 
 #: ../data/tips.xml.in.h:13
 msgid ""
-"<b>Calculating Relationships</b><br/>To check if two people in the database "
-"are related (by blood, not marriage) try the tool under &quot;Tools &gt; "
-"Utilities &gt; Relationship Calculator...&quot;. The exact relationship as "
-"well as all common ancestors are reported."
+"<b>Calculating Relationships</b><br/>To check if two people in the database"
+" are related (by blood, not marriage) try the tool under &quot;Tools &gt;"
+" Utilities &gt; Relationship Calculator...&quot;. The exact relationship as"
+" well as all common ancestors are reported."
 msgstr ""
-"<b>Càlcul de Parentesc</b><br/>Per comprovar si dues persones de la base de "
-"dades estan emparentades (per sang, no casament) provi l'eina que hi ha a "
-"&quot;Eines &gt; Utilitats &gt; Calculadora de Parentesc...&quot;. S'informa "
-"del parentesc precís així com dels avantpassats en comú."
+"<b>Càlcul de Parentesc</b><br/>Per comprovar si dues persones de la base de"
+" dades estan emparentades (per sang, no casament) provi l'eina que hi ha a"
+" &quot;Eines &gt; Utilitats &gt; Calculadora de Parentesc...&quot;. S'informa"
+" del parentesc precís així com dels avantpassats en comú."
 
 #: ../data/tips.xml.in.h:14
 msgid ""
-"<b>SoundEx can help with family research</b><br/>SoundEx solves a long "
-"standing problem in genealogy, how to handle spelling variations. The "
-"SoundEx Gramplet takes a surname and generates a simplified form that is "
-"equivalent for similar sounding names. Knowing the SoundEx Code for a "
-"surname is very helpful for researching Census Data files (microfiche) at a "
-"library or other research facility. To view the SoundEx codes for surnames "
-"in your database, add the SoundEx Gramplet."
+"<b>SoundEx can help with family research</b><br/>SoundEx solves a long"
+" standing problem in genealogy, how to handle spelling variations. The"
+" SoundEx Gramplet takes a surname and generates a simplified form that is"
+" equivalent for similar sounding names. Knowing the SoundEx Code for a"
+" surname is very helpful for researching Census Data files (microfiche) at a"
+" library or other research facility. To view the SoundEx codes for surnames"
+" in your database, add the SoundEx Gramplet."
 msgstr ""
-"<b>SoundEx pot ajudar en la recerca familiar</b><br/>SoundEx resòl un "
-"problema antic en genealogia: què fer-ne de les variacions ortogràfiques. La "
-"utilitat SoundEx agafa un cognom i en genera una forma simplificada que és "
-"equivalent per a noms que sonin de forma semblant. Conèixer el Codi SoundEx "
-"d'un cognom és molt pràctic per la recerca de fitxer de dades del Cens "
-"(microfitxes) en una biblioteca o altres llocs. Per obtenir els codis "
-"SoundEx per als cognoms de la seva base de dades, afegeixi el Gramplet de "
-"SoundEx."
+"<b>SoundEx pot ajudar en la recerca familiar</b><br/>SoundEx resòl un"
+" problema antic en genealogia: què fer-ne de les variacions ortogràfiques. La"
+" utilitat SoundEx agafa un cognom i en genera una forma simplificada que és"
+" equivalent per a noms que sonin de forma semblant. Conèixer el Codi SoundEx"
+" d'un cognom és molt pràctic per la recerca de fitxer de dades del Cens"
+" (microfitxes) en una biblioteca o altres llocs. Per obtenir els codis"
+" SoundEx per als cognoms de la seva base de dades, afegeixi el Gramplet de"
+" SoundEx."
 
 #: ../data/tips.xml.in.h:15
 msgid ""
-"<b>Setting Your Preferences</b><br/>&quot;Edit &gt; Preferences...&quot; "
-"lets you modify a number of settings, such as the path to your media files, "
-"and allows you to adjust many aspects of the Gramps presentation to your "
-"needs. Each separate view can also be configured under &quot;View &gt; "
-"Configure View...&quot;"
+"<b>Setting Your Preferences</b><br/>&quot;Edit &gt; Preferences...&quot; lets"
+" you modify a number of settings, such as the path to your media files, and"
+" allows you to adjust many aspects of the Gramps presentation to your needs."
+" Each separate view can also be configured under &quot;View &gt; Configure"
+" View...&quot;"
 msgstr ""
-"<b>Fixar les Preferències</b><br/>&quot;Edita &gt; Preferències...&quot; li "
-"permet de modificar una colla de paràmetres, com ara el camí als fitxers "
-"audiovisuals, i li permet d'adaptar molts aspectes de la presentació de "
-"Gramps a les seves necessitats. Cada vista es pot configurar també per "
-"separat a &quot;Vista &gt; Configurar Vista...&quot;"
+"<b>Fixar les Preferències</b><br/>&quot;Edita &gt; Preferències...&quot; li"
+" permet de modificar una colla de paràmetres, com ara el camí als fitxers"
+" audiovisuals, i li permet d'adaptar molts aspectes de la presentació de"
+" Gramps a les seves necessitats. Cada vista es pot configurar també per"
+" separat a &quot;Vista &gt; Configurar Vista...&quot;"
 
 #: ../data/tips.xml.in.h:16
 msgid ""
-"<b>Gramps Reports</b><br/>Gramps offers a wide variety of reports. The "
-"Graphical Reports and Graphs can present complex relationships easily and "
-"the Text Reports are particularly useful if you want to send the results of "
-"your family tree to members of the family via email. If you're ready to make "
-"a website for your family tree then there's a report for that as well."
+"<b>Gramps Reports</b><br/>Gramps offers a wide variety of reports. The"
+" Graphical Reports and Graphs can present complex relationships easily and"
+" the Text Reports are particularly useful if you want to send the results of"
+" your family tree to members of the family via email. If you're ready to make"
+" a website for your family tree then there's a report for that as well."
 msgstr ""
-"<b>Informes Gramps</b><br/>Gramps ofereix una gran varietat d'informes. Els "
-"Informes Gràfics i els Grafs poden presentar relacions complexes fàcilment, "
-"i els Informes de Text són especialment útils si vol enviar els resultats de "
-"l'arbre genealògic a la resta de la família per correu electrònic. Si ja "
-"està preparat per crear un web per al seu arbre genealògic, també hi ha un "
-"informe per això."
+"<b>Informes Gramps</b><br/>Gramps ofereix una gran varietat d'informes. Els"
+" Informes Gràfics i els Grafs poden presentar relacions complexes fàcilment,"
+" i els Informes de Text són especialment útils si vol enviar els resultats de"
+" l'arbre genealògic a la resta de la família per correu electrònic. Si ja"
+" està preparat per crear un web per al seu arbre genealògic, també hi ha un"
+" informe per això."
 
 #: ../data/tips.xml.in.h:17
 msgid ""
-"<b>Starting a New Family Tree</b><br/>A good way to start a new family tree "
-"is to enter all the members of the family into the database using the Person "
-"View (use &quot;Edit &gt; Add...&quot; or click on the Add a new person "
-"button from the People View). Then go to the Relationship View and create "
-"relationships between people."
+"<b>Starting a New Family Tree</b><br/>A good way to start a new family tree"
+" is to enter all the members of the family into the database using the Person"
+" View (use &quot;Edit &gt; Add...&quot; or click on the Add a new person"
+" button from the People View). Then go to the Relationship View and create"
+" relationships between people."
 msgstr ""
-"<b>Començar un Nou Arbre de Família</b><br/>: Una bona manera de començar un "
-"nou arbre de família és introduir tots els membres de la família a la base "
-"de dades fent servir la Vista de Persones (amb &quot;Edita &gt; Afegir..."
-"&quot; o clicar el botó Afegir Persona Nova de la Vista de Persones). "
-"Després, vagi a la Vista de Relació per crear les relacions entre persones."
+"<b>Començar un Nou Arbre de Família</b><br/>: Una bona manera de començar un"
+" nou arbre de família és introduir tots els membres de la família a la base"
+" de dades fent servir la Vista de Persones (amb &quot;Edita &gt;"
+" Afegir...&quot; o clicar el botó Afegir Persona Nova de la Vista de"
+" Persones). Després, vagi a la Vista de Relació per crear les relacions entre"
+" persones."
 
 #: ../data/tips.xml.in.h:18
 msgid ""
-"<b>What's That For?</b><br/>Unsure what a button does? Simply hold the mouse "
-"over a button and a tooltip will appear."
+"<b>What's That For?</b><br/>Unsure what a button does? Simply hold the mouse"
+" over a button and a tooltip will appear."
 msgstr ""
-"<b>Per Què És Això?</b><br/>No està segur del que fa algun botó? Deixi el "
-"ratolí al damunt d'un botó i apareixerà un petit text d'ajuda."
+"<b>Per Què És Això?</b><br/>No està segur del que fa algun botó? Deixi el"
+" ratolí al damunt d'un botó i apareixerà un petit text d'ajuda."
 
 #: ../data/tips.xml.in.h:19
 msgid ""
-"<b>Unsure of a Date?</b><br/>If you're unsure about the date an event "
-"occurred, Gramps allows you to enter a wide range of date formats based on a "
-"guess or an estimate. For instance, &quot;about 1908&quot; is a valid entry "
-"for a birth date in Gramps. Click the Date button next to the date field and "
-"see the Gramps Manual to learn more."
+"<b>Unsure of a Date?</b><br/>If you're unsure about the date an event"
+" occurred, Gramps allows you to enter a wide range of date formats based on a"
+" guess or an estimate. For instance, &quot;about 1908&quot; is a valid entry"
+" for a birth date in Gramps. Click the Date button next to the date field and"
+" see the Gramps Manual to learn more."
 msgstr ""
-"<b>No està segur d'una data?</b><br/>Si no està segur de la data en què va "
-"ocórrer un esdeveniment, Gramps li permet d'introduir una colla de formats "
-"de data basats en una suposició o estimació. Per exemple, &quot;al voltant "
-"de 1908&quot; és una entrada vàlida per una data de naixement a Gramps. "
-"Cliqui el botó del costat del camp de data i vegi el manual de Gramps per "
-"aprendre'n més."
+"<b>No està segur d'una data?</b><br/>Si no està segur de la data en què va"
+" ocórrer un esdeveniment, Gramps li permet d'introduir una colla de formats"
+" de data basats en una suposició o estimació. Per exemple, &quot;al voltant"
+" de 1908&quot; és una entrada vàlida per una data de naixement a Gramps."
+" Cliqui el botó del costat del camp de data i vegi el manual de Gramps per"
+" aprendre'n més."
 
 #: ../data/tips.xml.in.h:20
 msgid ""
-"<b>Duplicate Entries</b><br/>&quot;Tools &gt; Database Processing &gt; Find "
-"Possible Duplicate People...&quot; allows you to locate (and merge) entries "
-"of the same person entered more than once in the database."
+"<b>Duplicate Entries</b><br/>&quot;Tools &gt; Database Processing &gt; Find"
+" Possible Duplicate People...&quot; allows you to locate (and merge) entries"
+" of the same person entered more than once in the database."
 msgstr ""
-"<b>Entrades Duplicades</b><br/>&quot;Eines &gt; Procés de Base de Dades &gt; "
-"Trobar Persones Possiblement Duplicades...&quot; permet de localitzar (i "
-"combinar) entrades de la mateixa persona que s'hagin introduït més d'un cop "
-"a la base de dades."
+"<b>Entrades Duplicades</b><br/>&quot;Eines &gt; Procés de Base de Dades &gt;"
+" Trobar Persones Possiblement Duplicades...&quot; permet de localitzar (i"
+" combinar) entrades de la mateixa persona que s'hagin introduït més d'un cop"
+" a la base de dades."
 
 #: ../data/tips.xml.in.h:21
 msgid ""
-"<b>Merging Entries</b><br/>The function &quot;Edit &gt; Compare and Merge..."
-"&quot; allows you to combine separately listed people into one. Select the "
-"second entry by holding the Control key as you click. This is very useful "
-"for combining two databases with overlapping people, or combining "
-"erroneously entered differing names for one individual. This also works for "
-"the Places, Sources and Repositories views."
+"<b>Merging Entries</b><br/>The function &quot;Edit &gt; Compare and"
+" Merge...&quot; allows you to combine separately listed people into one."
+" Select the second entry by holding the Control key as you click. This is"
+" very useful for combining two databases with overlapping people, or"
+" combining erroneously entered differing names for one individual. This also"
+" works for the Places, Sources and Repositories views."
 msgstr ""
-"<b>Combinar Entrades</b><br/>La funció &quot;Edita &gt; Comparar i "
-"Combinar...&quot; li permet de combinar persones llistades per separat en "
-"una de sola. Seleccioni la segona entrada mantenint premuda la tecla de "
-"Control mentre clica. Això és molt útil per combinar dues bases de dades que "
-"tinguin gent en comú, o combinar noms diferents introduïts erròniament per "
-"un sol individu. Això també funciona per les vistes de Llocs, Fonts i "
-"Repositoris."
+"<b>Combinar Entrades</b><br/>La funció &quot;Edita &gt; Comparar i"
+" Combinar...&quot; li permet de combinar persones llistades per separat en"
+" una de sola. Seleccioni la segona entrada mantenint premuda la tecla de"
+" Control mentre clica. Això és molt útil per combinar dues bases de dades que"
+" tinguin gent en comú, o combinar noms diferents introduïts erròniament per"
+" un sol individu. Això també funciona per les vistes de Llocs, Fonts i"
+" Repositoris."
 
 #: ../data/tips.xml.in.h:22
 msgid ""
-"<b>Organising the Views</b><br/>Many of the views can present your data as "
-"either a hierarchical tree or as a simple list. Each view can also be "
-"configured to the way you like it. Have a look to the right of the top "
-"toolbar or under the &quot;View&quot; menu."
+"<b>Organising the Views</b><br/>Many of the views can present your data as"
+" either a hierarchical tree or as a simple list. Each view can also be"
+" configured to the way you like it. Have a look to the right of the top"
+" toolbar or under the &quot;View&quot; menu."
 msgstr ""
-"<b>Organitzar les Vistes</b><br/>Moltes de les vistes poden presentar les "
-"dades o bé com un arbre jeràrquic o com una simple llista. Cada vista pot "
-"també configurar-se de la manera que li agradi. Doni un cop d'ull a la dreta "
-"de la barra d'eines superior o al menú &quot;Vista&quot;."
+"<b>Organitzar les Vistes</b><br/>Moltes de les vistes poden presentar les"
+" dades o bé com un arbre jeràrquic o com una simple llista. Cada vista pot"
+" també configurar-se de la manera que li agradi. Doni un cop d'ull a la dreta"
+" de la barra d'eines superior o al menú &quot;Vista&quot;."
 
 #: ../data/tips.xml.in.h:23
 msgid ""
-"<b>Navigating Back and Forward</b><br/>Gramps maintains a list of previous "
-"active objects such as People and Events. You can move forward and backward "
-"through the list using &quot;Go &gt; Forward&quot; and &quot;Go &gt; "
-"Back&quot; or the arrow buttons."
+"<b>Navigating Back and Forward</b><br/>Gramps maintains a list of previous"
+" active objects such as People and Events. You can move forward and backward"
+" through the list using &quot;Go &gt; Forward&quot; and &quot;Go &gt;"
+" Back&quot; or the arrow buttons."
 msgstr ""
-"<b>Navegar Endavant i Enrere</b><br/>Gramps manté una llista dels objectes "
-"actius prèviament, com ara Persones, Esdeveniments. Pot moure's endavant i "
-"enrere per aquesta llista fent servir &quot;Anar &gt; Endavant&quot; i &quot;"
-"Anar &gt; Enrere&quot; o els botons de fletxa."
+"<b>Navegar Endavant i Enrere</b><br/>Gramps manté una llista dels objectes"
+" actius prèviament, com ara Persones, Esdeveniments. Pot moure's endavant i"
+" enrere per aquesta llista fent servir &quot;Anar &gt; Endavant&quot; i"
+" &quot;Anar &gt; Enrere&quot; o els botons de fletxa."
 
 #: ../data/tips.xml.in.h:24
 msgid ""
-"<b>Keyboard Shortcuts</b><br/>Tired of having to take your hand off the "
-"keyboard to use the mouse? Many functions in Gramps have keyboard shortcuts. "
-"If one exists for a function it is displayed on the right side of the menu."
+"<b>Keyboard Shortcuts</b><br/>Tired of having to take your hand off the"
+" keyboard to use the mouse? Many functions in Gramps have keyboard shortcuts."
+" If one exists for a function it is displayed on the right side of the menu."
 msgstr ""
-"<b>Dreceres de Teclat</b><br/>Està cansat de treure la mà del teclat per fer "
-"servir el ratolí? Moltes funcions de Gramps tenen dreceres de teclat. Si "
-"n'hi ha una per alguna funció, es mostra a la banda dreta del menú."
+"<b>Dreceres de Teclat</b><br/>Està cansat de treure la mà del teclat per fer"
+" servir el ratolí? Moltes funcions de Gramps tenen dreceres de teclat. Si"
+" n'hi ha una per alguna funció, es mostra a la banda dreta del menú."
 
 #: ../data/tips.xml.in.h:25
 msgid ""
-"<b>Read the Manual</b><br/>Don't forget to read the Gramps manual, &quot;"
-"Help &gt; User Manual&quot;. The developers have worked hard to make most "
-"operations intuitive but the manual is full of information that will make "
-"your time spent on genealogy more productive."
+"<b>Read the Manual</b><br/>Don't forget to read the Gramps manual, &quot;Help"
+" &gt; User Manual&quot;. The developers have worked hard to make most"
+" operations intuitive but the manual is full of information that will make"
+" your time spent on genealogy more productive."
 msgstr ""
-"<b>Llegeixi el Manual<b><br/>No s'oblidi de llegir el manual de Gramps, "
-"&quot;Ajuda &gt; Manual d'Usuari&quot;. Els desenvolupadors han treballat "
-"molt per fer que la majoria de les operacions siguin intuïtives, però el "
-"manual és ple d'informació que farà més productiu el temps que dediqui a la "
-"genealogia."
+"<b>Llegeixi el Manual<b><br/>No s'oblidi de llegir el manual de Gramps,"
+" &quot;Ajuda &gt; Manual d'Usuari&quot;. Els desenvolupadors han treballat"
+" molt per fer que la majoria de les operacions siguin intuïtives, però el"
+" manual és ple d'informació que farà més productiu el temps que dediqui a la"
+" genealogia."
 
 #: ../data/tips.xml.in.h:26
 msgid ""
-"<b>Adding Children</b><br/>To add children in Gramps there are two options. "
-"You can find one of their parents in the Families View and open the family. "
-"Then choose to create a new person or add an existing person. You can also "
-"add children (or siblings) from inside the Family Editor."
+"<b>Adding Children</b><br/>To add children in Gramps there are two options."
+" You can find one of their parents in the Families View and open the family."
+" Then choose to create a new person or add an existing person. You can also"
+" add children (or siblings) from inside the Family Editor."
 msgstr ""
-"<b>Afegint Fills</b><br/>Per afegir fills a Gramps hi ha dues opcions. Es "
-"pot trobar un dels pares a la Vista de Famílies i obrir la família. Llavors "
-"es pot triar si es crea una persona nova o se n'hi afegeix una d'existent. "
-"També es poden afegir fills (o germans) des de dins de l'Editor de Famílies."
+"<b>Afegint Fills</b><br/>Per afegir fills a Gramps hi ha dues opcions. Es pot"
+" trobar un dels pares a la Vista de Famílies i obrir la família. Llavors es"
+" pot triar si es crea una persona nova o se n'hi afegeix una d'existent."
+" També es poden afegir fills (o germans) des de dins de l'Editor de Famílies."
 
 #: ../data/tips.xml.in.h:27
 msgid ""
-"<b>Editing the Parent-Child Relationship</b><br/> You can edit the "
-"relationship of a child to its parents by double clicking the child in the "
-"Family Editor. Relationships can be any of Adopted, Birth, Foster, None, "
-"Sponsored, Stepchild and Unknown."
+"<b>Editing the Parent-Child Relationship</b><br/> You can edit the"
+" relationship of a child to its parents by double clicking the child in the"
+" Family Editor. Relationships can be any of Adopted, Birth, Foster, None,"
+" Sponsored, Stepchild and Unknown."
 msgstr ""
-"<b>Editar la Relació Pares-Fills</b><br/> Es pot editar la relació d'un fill "
-"amb els seus pares fent doble clic sobre el fill a l'Editor de Famílies. Les "
-"relacions poden ser Adoptat, Naixement, Acollit, Cap, Patrocinat, Fillastre "
-"i Desconegut."
+"<b>Editar la Relació Pares-Fills</b><br/> Es pot editar la relació d'un fill"
+" amb els seus pares fent doble clic sobre el fill a l'Editor de Famílies. Les"
+" relacions poden ser Adoptat, Naixement, Acollit, Cap, Patrocinat, Fillastre"
+" i Desconegut."
 
 #: ../data/tips.xml.in.h:28
 msgid ""
-"<b>Show All Checkbutton</b><br/>When adding an existing person as a spouse, "
-"the list of people shown is filtered to display only people who could "
-"realistically fit the role (based on dates in the database). In case Gramps "
-"is wrong in making this choice, you can override the filter by checking the "
-"Show All checkbutton."
+"<b>Show All Checkbutton</b><br/>When adding an existing person as a spouse,"
+" the list of people shown is filtered to display only people who could"
+" realistically fit the role (based on dates in the database). In case Gramps"
+" is wrong in making this choice, you can override the filter by checking the"
+" Show All checkbutton."
 msgstr ""
-"<b>Botó de Mostrar Tothom</b><br/>Quan s'afegeix una persona existent com a "
-"cònjuge o fill, la llista de gent que apareix es filtra per mostrar només "
-"persones que podrien, sent realistes, assumir aquest paper (basant-se en les "
-"dates de la base de dades). En cas que Gramps s'equivoqui en fer aquesta "
-"elecció, pot saltar-se aquest filtre marcant el botó de Mostrar Tothom."
+"<b>Botó de Mostrar Tothom</b><br/>Quan s'afegeix una persona existent com a"
+" cònjuge o fill, la llista de gent que apareix es filtra per mostrar només"
+" persones que podrien, sent realistes, assumir aquest paper (basant-se en les"
+" dates de la base de dades). En cas que Gramps s'equivoqui en fer aquesta"
+" elecció, pot saltar-se aquest filtre marcant el botó de Mostrar Tothom."
 
 #: ../data/tips.xml.in.h:29
 msgid ""
-"<b>Improving Gramps</b><br/>Users are encouraged to request enhancements to "
-"Gramps. Requesting an enhancement can be done either through the gramps-"
-"users or gramps-devel mailing lists, or by going to https://gramps-project."
-"org/bugs/ and creating a Feature Request. Filing a Feature Request is "
-"preferred but it can be good to discuss your ideas on the email lists."
+"<b>Improving Gramps</b><br/>Users are encouraged to request enhancements to"
+" Gramps. Requesting an enhancement can be done either through the"
+" gramps-users or gramps-devel mailing lists, or by going to"
+" https://gramps-project.org/bugs/ and creating a Feature Request. Filing a"
+" Feature Request is preferred but it can be good to discuss your ideas on the"
+" email lists."
 msgstr ""
-"<b>Millorar Gramps</b><br/>Animem als usuaris que sol·licitin millores a "
-"Gramps. Es pot demanar una millora mitjançant les llistes de correu gramps-"
-"users o gramps-devel, o bé anant a https://gramps-project.org/bugs/ i creant "
-"una Sol·licitud de Funció. És preferible omplir una Sol·licitud de Funció "
-"(Feature Request), però també pot ser bo de comentar les seves idees a les "
-"llistes de correu."
+"<b>Millorar Gramps</b><br/>Animem als usuaris que sol·licitin millores a"
+" Gramps. Es pot demanar una millora mitjançant les llistes de correu"
+" gramps-users o gramps-devel, o bé anant a https://gramps-project.org/bugs/ i"
+" creant una Sol·licitud de Funció. És preferible omplir una Sol·licitud de"
+" Funció (Feature Request), però també pot ser bo de comentar les seves idees"
+" a les llistes de correu."
 
 #: ../data/tips.xml.in.h:30
 msgid ""
-"<b>Gramps Mailing Lists</b><br/>Want answers to your questions about Gramps? "
-"Check out the gramps-users email list. Many helpful people are on the list, "
-"so you're likely to get an answer quickly. If you have questions related to "
-"the development of Gramps, try the gramps-devel list. You can see the lists "
-"by selecting &quot;Help &gt; Gramps Mailing Lists&quot;."
+"<b>Gramps Mailing Lists</b><br/>Want answers to your questions about Gramps?"
+" Check out the gramps-users email list. Many helpful people are on the list,"
+" so you're likely to get an answer quickly. If you have questions related to"
+" the development of Gramps, try the gramps-devel list. You can see the lists"
+" by selecting &quot;Help &gt; Gramps Mailing Lists&quot;."
 msgstr ""
-"<b>Llistes de correu de Gramps</b><br/>Té algun dubte sobre Gramps i li cal "
-"una resposta? Doni un cop d'ull a la llista gramps-users (en anglès). Hi ha "
-"molta gent amb ganes d'ajudar, i per tant és probable obtenir respostes "
-"ràpidament. Si té consultes sobre el desenvolupament de Gramps, provi gramps-"
-"devel (també en anglès). Pot veure les llistes fent &quot;Ajuda &gt; Llistes "
-"de Correu de Gramps&quot;."
+"<b>Llistes de correu de Gramps</b><br/>Té algun dubte sobre Gramps i li cal"
+" una resposta? Doni un cop d'ull a la llista gramps-users (en anglès). Hi ha"
+" molta gent amb ganes d'ajudar, i per tant és probable obtenir respostes"
+" ràpidament. Si té consultes sobre el desenvolupament de Gramps, provi"
+" gramps-devel (també en anglès). Pot veure les llistes fent &quot;Ajuda &gt;"
+" Llistes de Correu de Gramps&quot;."
 
 #: ../data/tips.xml.in.h:31
 msgid ""
-"<b>Contributing to Gramps</b><br/>Want to help with Gramps but can't write "
-"programs? Not a problem! A project as large as Gramps requires people with a "
-"wide variety of skills. Contributions can be anything from writing "
-"documentation to testing development versions and helping with the web site. "
-"Start by subscribing to the Gramps developers mailing list, gramps-devel, "
-"and introducing yourself. Subscription information can be found at &quot;"
-"Help &gt; Gramps Mailing Lists&quot;"
+"<b>Contributing to Gramps</b><br/>Want to help with Gramps but can't write"
+" programs? Not a problem! A project as large as Gramps requires people with a"
+" wide variety of skills. Contributions can be anything from writing"
+" documentation to testing development versions and helping with the web site."
+" Start by subscribing to the Gramps developers mailing list, gramps-devel,"
+" and introducing yourself. Subscription information can be found at"
+" &quot;Help &gt; Gramps Mailing Lists&quot;"
 msgstr ""
-"<b>Contribuir a Gramps</b><br/>Vol ajudar amb Gramps però no sap programar? "
-"Cap problema. Un projecte tan gros com Gramps necessita gent amb molta "
-"varietat de capacitats. Les contribucions poden anar des d'escriure "
-"documentació a provar versions de desenvolupament o ajudar amb el lloc web. "
-"Comenci subscrivint-se a la llista de distribució dels desenvolupadors de "
-"Gramps, gramps-devel, i presentant-se. Es pot trobar informació sobre "
-"subscripcions a &quot;Ajuda &gt; Llistes de Correu de Gramps&quot;"
+"<b>Contribuir a Gramps</b><br/>Vol ajudar amb Gramps però no sap programar?"
+" Cap problema. Un projecte tan gros com Gramps necessita gent amb molta"
+" varietat de capacitats. Les contribucions poden anar des d'escriure"
+" documentació a provar versions de desenvolupament o ajudar amb el lloc web."
+" Comenci subscrivint-se a la llista de distribució dels desenvolupadors de"
+" Gramps, gramps-devel, i presentant-se. Es pot trobar informació sobre"
+" subscripcions a &quot;Ajuda &gt; Llistes de Correu de Gramps&quot;"
 
 #: ../data/tips.xml.in.h:32
 msgid ""
-"<b>So What's in a Name?</b><br/>The name Gramps was suggested to the "
-"original developer, Don Allingham, by his father. It stands for "
-"<i>Genealogical Research and Analysis Management Program System</i>. It is a "
-"full-featured genealogy program letting you store, edit, and research "
-"genealogical data. The Gramps database back end is so robust that some users "
-"are managing genealogies containing hundreds of thousands of people."
+"<b>So What's in a Name?</b><br/>The name Gramps was suggested to the original"
+" developer, Don Allingham, by his father. It stands for <i>Genealogical"
+" Research and Analysis Management Program System</i>. It is a full-featured"
+" genealogy program letting you store, edit, and research genealogical data."
+" The Gramps database back end is so robust that some users are managing"
+" genealogies containing hundreds of thousands of people."
 msgstr ""
-"<b>Què me'n dius, del Nom?</b><br/>El nom Gramps el va suggerir el pare del "
-"desenvolupador original, Don Allingham. Gramps vol dir <i>Genealogical "
-"Research and Analysis Management Program System</i>, és a dir Sistema de "
-"Programació de Gestió de la Recerca i Anàlisi Genealògiques. És un programa "
-"de genealogia de plena funcionalitat que li deixa emmagatzemar, editar i fer "
-"recerca de dades genealògiques. El motor de base de dades de Gramps és tan "
-"robust que alguns usuaris poden gestionar genealogies que contenen centenars "
-"de milers de persones."
+"<b>Què me'n dius, del Nom?</b><br/>El nom Gramps el va suggerir el pare del"
+" desenvolupador original, Don Allingham. Gramps vol dir <i>Genealogical"
+" Research and Analysis Management Program System</i>, és a dir Sistema de"
+" Programació de Gestió de la Recerca i Anàlisi Genealògiques. És un programa"
+" de genealogia de plena funcionalitat que li deixa emmagatzemar, editar i fer"
+" recerca de dades genealògiques. El motor de base de dades de Gramps és tan"
+" robust que alguns usuaris poden gestionar genealogies que contenen centenars"
+" de milers de persones."
 
 #: ../data/tips.xml.in.h:33
 msgid ""
-"<b>Bookmarking Individuals</b><br/>The Bookmarks menu is a convenient place "
-"to store the names of frequently used individuals. Selecting a bookmark will "
-"make that person the Active Person. To bookmark someone make them the Active "
-"Person then go to &quot;Bookmarks &gt; Add Bookmark&quot; or press Ctrl+D. "
-"You can also bookmark most of the other objects."
+"<b>Bookmarking Individuals</b><br/>The Bookmarks menu is a convenient place"
+" to store the names of frequently used individuals. Selecting a bookmark will"
+" make that person the Active Person. To bookmark someone make them the Active"
+" Person then go to &quot;Bookmarks &gt; Add Bookmark&quot; or press Ctrl+D."
+" You can also bookmark most of the other objects."
 msgstr ""
-"<b>Marcar Individus com a Punts d'Interès</b><br/>El menú de Punts d'Interès "
-"és un lloc pràctic per guardar els noms de persones que es facin servir "
-"sovint. Seleccionar un punt d'interès farà que aquesta persona sigui "
-"l'Activa. Per crear un punt d'interès per alguna persona, cal fer-la la "
-"Persona Activa, i llavors anar a &quot;Punts d'Interès &gt; Afegir punt "
-"d'interès&quot; o prémer Ctrl+D. També es poden posar com a punts d'interès "
-"la majoria dels altre objectes."
+"<b>Marcar Individus com a Punts d'Interès</b><br/>El menú de Punts d'Interès"
+" és un lloc pràctic per guardar els noms de persones que es facin servir"
+" sovint. Seleccionar un punt d'interès farà que aquesta persona sigui"
+" l'Activa. Per crear un punt d'interès per alguna persona, cal fer-la la"
+" Persona Activa, i llavors anar a &quot;Punts d'Interès &gt; Afegir punt"
+" d'interès&quot; o prémer Ctrl+D. També es poden posar com a punts d'interès"
+" la majoria dels altre objectes."
 
 #: ../data/tips.xml.in.h:34
 msgid ""
-"<b>Incorrect Dates</b><br/>Everyone occasionally enters dates with an "
-"invalid format. Incorrect date formats will show up in Gramps with a either "
-"a reddish background or a red dot on the right edge of the field. You can "
-"fix the date using the Date Selection dialog which can be opened by clicking "
-"on the date button. The format of the date is set under &quot;Edit &gt; "
-"Preferences &gt; Display&quot;."
+"<b>Incorrect Dates</b><br/>Everyone occasionally enters dates with an invalid"
+" format. Incorrect date formats will show up in Gramps with a either a"
+" reddish background or a red dot on the right edge of the field. You can fix"
+" the date using the Date Selection dialog which can be opened by clicking on"
+" the date button. The format of the date is set under &quot;Edit &gt;"
+" Preferences &gt; Display&quot;."
 msgstr ""
-"<b>Dates Incorrectes</b><br/>Tothom, de tant en tant, introdueix dates amb "
-"un format no vàlid. Els formats de data incorrectes sortiran a Gramps amb un "
-"fons vermellós o un punt vermell a la vora dreta del camp. Pot arreglar la "
-"data utilitzant el diàleg de Selecció de Data, que es pot obrir clicant al "
-"botó de data. El format de la data es fixa a &quot;Edita &gt; Preferències "
-"&gt; Mostrar&quot;."
+"<b>Dates Incorrectes</b><br/>Tothom, de tant en tant, introdueix dates amb un"
+" format no vàlid. Els formats de data incorrectes sortiran a Gramps amb un"
+" fons vermellós o un punt vermell a la vora dreta del camp. Pot arreglar la"
+" data utilitzant el diàleg de Selecció de Data, que es pot obrir clicant al"
+" botó de data. El format de la data es fixa a &quot;Edita &gt; Preferències"
+" &gt; Mostrar&quot;."
 
 #: ../data/tips.xml.in.h:35
 msgid ""
-"<b>Listing Events</b><br/>Events are added using the editor opened with "
-"&quot;Person &gt; Edit Person &gt; Events&quot;. There is a long list of "
-"preset event types. You can add your own event types by typing in the text "
-"field, they will be added to the available events, but not translated."
+"<b>Listing Events</b><br/>Events are added using the editor opened with"
+" &quot;Person &gt; Edit Person &gt; Events&quot;. There is a long list of"
+" preset event types. You can add your own event types by typing in the text"
+" field, they will be added to the available events, but not translated."
 msgstr ""
-"<b>Llistar Esdeveniments</b><br/>Els esdeveniments s'afegeixen amb l'editor "
-"que s'obre fent &quot;Persona &gt; Editar Persona &gt; Esdeveniments&quot;. "
-"Hi ha una llarga llista de tipus d'esdeveniments predefinits. Pot afegir-hi "
-"els seus propis tipus d'esdeveniment escrivint al camp de text, s'afegiran "
-"als esdeveniments disponibles, però no es traduiran."
+"<b>Llistar Esdeveniments</b><br/>Els esdeveniments s'afegeixen amb l'editor"
+" que s'obre fent &quot;Persona &gt; Editar Persona &gt; Esdeveniments&quot;."
+" Hi ha una llarga llista de tipus d'esdeveniments predefinits. Pot afegir-hi"
+" els seus propis tipus d'esdeveniment escrivint al camp de text, s'afegiran"
+" als esdeveniments disponibles, però no es traduiran."
 
 #: ../data/tips.xml.in.h:36
 msgid ""
-"<b>Managing Names</b><br/>It is easy to manage people with several names in "
-"Gramps. In the Person Editor select the Names tab. You can add names of "
-"different types and set the preferred name by dragging it to the Preferred "
-"Name section."
+"<b>Managing Names</b><br/>It is easy to manage people with several names in"
+" Gramps. In the Person Editor select the Names tab. You can add names of"
+" different types and set the preferred name by dragging it to the Preferred"
+" Name section."
 msgstr ""
-"<b>Gestió de Noms<b><br/>És fàcil de gestionar persones amb noms diversos a "
-"Gramps. A l'Editor de Persones seleccioni la pestanya de Noms. S'hi poden "
-"afegir noms de diferents tipus i establir quin és el preferit arrossegant-lo "
-"a la secció de Nom Preferit."
+"<b>Gestió de Noms<b><br/>És fàcil de gestionar persones amb noms diversos a"
+" Gramps. A l'Editor de Persones seleccioni la pestanya de Noms. S'hi poden"
+" afegir noms de diferents tipus i establir quin és el preferit arrossegant-lo"
+" a la secció de Nom Preferit."
 
 #: ../data/tips.xml.in.h:37
 msgid ""
-"<b>Ancestor View</b><br/>The Ancestry View displays a traditional pedigree "
-"chart. Hold the mouse over an individual to see more information about them "
-"or right click on an individual to access other family members and settings. "
-"Play with the settings to see the different options."
+"<b>Ancestor View</b><br/>The Ancestry View displays a traditional pedigree"
+" chart. Hold the mouse over an individual to see more information about them"
+" or right click on an individual to access other family members and settings."
+" Play with the settings to see the different options."
 msgstr ""
-"<b>Vista d'Avantpassats</b><br/>La Vista d'Avantpassats mostra un esquema de "
-"pedigrí tradicional. Mantingui el ratolí sobre un individu per veure'n més "
-"informació o faci clic dret sobre algú per accedir a altres membres de la "
-"família i configuracions. Provi les configuracions per veure les diferents "
-"opcions."
+"<b>Vista d'Avantpassats</b><br/>La Vista d'Avantpassats mostra un esquema de"
+" pedigrí tradicional. Mantingui el ratolí sobre un individu per veure'n més"
+" informació o faci clic dret sobre algú per accedir a altres membres de la"
+" família i configuracions. Provi les configuracions per veure les diferents"
+" opcions."
 
 #: ../data/tips.xml.in.h:38
 msgid ""
-"<b>Managing Sources</b><br/>The Sources View shows a list of all sources in "
-"a single window. From here you can edit your sources, merge duplicates and "
-"see which individuals reference each source. You can use filters to group "
-"your sources."
+"<b>Managing Sources</b><br/>The Sources View shows a list of all sources in a"
+" single window. From here you can edit your sources, merge duplicates and see"
+" which individuals reference each source. You can use filters to group your"
+" sources."
 msgstr ""
-"<b>Gestió de Fonts</b><br/>La Vista de Fonts mostra una llista de totes les "
-"fonts en una sola finestra. Des d'allà pot editar les fonts, combinar les "
-"duplicades i veure quins individus hi fan referència. Pot fer servir filtres "
-"per agrupar les fonts."
+"<b>Gestió de Fonts</b><br/>La Vista de Fonts mostra una llista de totes les"
+" fonts en una sola finestra. Des d'allà pot editar les fonts, combinar les"
+" duplicades i veure quins individus hi fan referència. Pot fer servir filtres"
+" per agrupar les fonts."
 
 #: ../data/tips.xml.in.h:39
 msgid ""
-"<b>Managing Places</b><br/>The Places View shows a list of all places in the "
-"database. The list can be sorted by a number of different criteria, such as "
-"City, County or State."
+"<b>Managing Places</b><br/>The Places View shows a list of all places in the"
+" database. The list can be sorted by a number of different criteria, such as"
+" City, County or State."
 msgstr ""
-"<b>Gestió de Llocs</b><br/>La Vista de Llocs mostra una llista de tots els "
-"llocs de la base de dades. La llista es pot ordenar per una colla de "
-"criteris diferents, com Ciutat, Comarca, o Estat."
+"<b>Gestió de Llocs</b><br/>La Vista de Llocs mostra una llista de tots els"
+" llocs de la base de dades. La llista es pot ordenar per una colla de"
+" criteris diferents, com Ciutat, Comarca, o Estat."
 
 #: ../data/tips.xml.in.h:40
 msgid ""
-"<b>Media View</b><br/>The Media View shows a list of all media entered in "
-"the database. These can be graphic images, videos, sound clips, "
-"spreadsheets, documents, and more."
+"<b>Media View</b><br/>The Media View shows a list of all media entered in the"
+" database. These can be graphic images, videos, sound clips, spreadsheets,"
+" documents, and more."
 msgstr ""
-"<b>Vista d'Audiovisuals</b><br/>La Vista d'Audiovisuals mostra una llista de "
-"tots els medis audiovisuals introduïts a la base de dades. Poden ser imatges "
-"gràfiques, vídeos, talls de so, fulls de càlcul, documents, i més."
+"<b>Vista d'Audiovisuals</b><br/>La Vista d'Audiovisuals mostra una llista de"
+" tots els medis audiovisuals introduïts a la base de dades. Poden ser imatges"
+" gràfiques, vídeos, talls de so, fulls de càlcul, documents, i més."
 
 #: ../data/tips.xml.in.h:41
 msgid ""
-"<b>Filters</b><br/>Filters allow you to limit the people seen in the People "
-"View. In addition to the many preset filters, Custom Filters can be created "
-"limited only by your imagination. Custom filters are created from &quot;Edit "
-"&gt; Person Filter Editor&quot;."
+"<b>Filters</b><br/>Filters allow you to limit the people seen in the People"
+" View. In addition to the many preset filters, Custom Filters can be created"
+" limited only by your imagination. Custom filters are created from &quot;Edit"
+" &gt; Person Filter Editor&quot;."
 msgstr ""
-"<b>Filtres</b><br/>Els filtres permeten de limitar les persones que es veuen "
-"a la Vista de Persones. A més dels molts filtres proporcionats, es poden "
-"crear Filtres a Mida, limitats només per la pròpia imaginació. Els filtres a "
-"mida es poden crear des de &quot;Edita &gt; Editor de Filtres de "
-"Persones&quot;."
+"<b>Filtres</b><br/>Els filtres permeten de limitar les persones que es veuen"
+" a la Vista de Persones. A més dels molts filtres proporcionats, es poden"
+" crear Filtres a Mida, limitats només per la pròpia imaginació. Els filtres a"
+" mida es poden crear des de &quot;Edita &gt; Editor de Filtres de"
+" Persones&quot;."
 
 #: ../data/tips.xml.in.h:42
 msgid ""
-"<b>The GEDCOM File Format</b><br/>Gramps allows you to import from, and "
-"export to, the GEDCOM format. There is extensive support for the industry "
-"standard GEDCOM version 5.5, so you can exchange Gramps information to and "
-"from users of most other genealogy programs. Filters exist that make "
-"importing and exporting GEDCOM files trivial."
+"<b>The GEDCOM File Format</b><br/>Gramps allows you to import from, and"
+" export to, the GEDCOM format. There is extensive support for the industry"
+" standard GEDCOM version 5.5, so you can exchange Gramps information to and"
+" from users of most other genealogy programs. Filters exist that make"
+" importing and exporting GEDCOM files trivial."
 msgstr ""
-"<b>El Format de Fitxer GEDCOM</b><br/>Gramps li permet d'importar i exportar "
-"en format GEDCOM. Hi ha un suport generalitzat per la versió 5.5 de GEDCOM, "
-"l'estàndard de la indústria, de manera que es pot intercanviar informació de "
-"Gramps amb els usuaris de la majoria dels altres programes de genealogia. Hi "
-"ha filtres que fan que sigui trivial importar i exportar fitxers GEDCOM."
+"<b>El Format de Fitxer GEDCOM</b><br/>Gramps li permet d'importar i exportar"
+" en format GEDCOM. Hi ha un suport generalitzat per la versió 5.5 de GEDCOM,"
+" l'estàndard de la indústria, de manera que es pot intercanviar informació de"
+" Gramps amb els usuaris de la majoria dels altres programes de genealogia. Hi"
+" ha filtres que fan que sigui trivial importar i exportar fitxers GEDCOM."
 
 #: ../data/tips.xml.in.h:43
 msgid ""
-"<b>The Gramps XML Package</b><br/>You can export your Family Tree as a "
-"Gramps XML Package. This is a compressed file containing your family tree "
-"data and all the media files connected to the database (images for example). "
-"This file is completely portable so is useful for backups or sharing with "
-"other Gramps users. This format has the key advantage over GEDCOM that no "
-"information is ever lost when exporting and importing."
+"<b>The Gramps XML Package</b><br/>You can export your Family Tree as a Gramps"
+" XML Package. This is a compressed file containing your family tree data and"
+" all the media files connected to the database (images for example). This"
+" file is completely portable so is useful for backups or sharing with other"
+" Gramps users. This format has the key advantage over GEDCOM that no"
+" information is ever lost when exporting and importing."
 msgstr ""
-"<b>El Paquet XML de Gramps</b><br/>Pot exportar el seu arbre genealògic com "
-"a paquet XML de Gramps. Es tracta d'un fitxer comprimit que conté les dades "
-"del seu arbre genealògic i inclou tots els altres fitxers que fa servir la "
-"base de dades, com ara imatges. Aquest fitxer és completament portable, i "
-"per tant és útil per còpies de seguretat o per compartir amb d'altres "
-"usuaris de Gramps. Aquest format té un avantatge clau sobre GEDCOM en el fet "
-"que no es perd mai cap informació en exportar ni importar."
+"<b>El Paquet XML de Gramps</b><br/>Pot exportar el seu arbre genealògic com a"
+" paquet XML de Gramps. Es tracta d'un fitxer comprimit que conté les dades"
+" del seu arbre genealògic i inclou tots els altres fitxers que fa servir la"
+" base de dades, com ara imatges. Aquest fitxer és completament portable, i"
+" per tant és útil per còpies de seguretat o per compartir amb d'altres"
+" usuaris de Gramps. Aquest format té un avantatge clau sobre GEDCOM en el fet"
+" que no es perd mai cap informació en exportar ni importar."
 
 #: ../data/tips.xml.in.h:44
 msgid ""
-"<b>Web Family Tree Format</b><br/>Gramps can export data to the Web Family "
-"Tree (WFT) format. This format allows a family tree to be displayed online "
-"using a single file, instead of many html files."
+"<b>Web Family Tree Format</b><br/>Gramps can export data to the Web Family"
+" Tree (WFT) format. This format allows a family tree to be displayed online"
+" using a single file, instead of many html files."
 msgstr ""
-"<b>Format de l'Arbre Genealògic Web</b><br/>Gramps pot exportar dades al "
-"format Web Family Tree (WFT). Aquest format permet mostrar un arbre "
-"genealògic en línia amb un sol fitxer, en comptes de molts fitxers html."
+"<b>Format de l'Arbre Genealògic Web</b><br/>Gramps pot exportar dades al"
+" format Web Family Tree (WFT). Aquest format permet mostrar un arbre"
+" genealògic en línia amb un sol fitxer, en comptes de molts fitxers html."
 
 #: ../data/tips.xml.in.h:45
 msgid ""
-"<b>Making a Genealogy Website</b><br/>You can easily export your family tree "
-"to a web page. Select the entire database, family lines or selected "
-"individuals to a collection of web pages ready for upload to the World Wide "
-"Web."
+"<b>Making a Genealogy Website</b><br/>You can easily export your family tree"
+" to a web page. Select the entire database, family lines or selected"
+" individuals to a collection of web pages ready for upload to the World Wide"
+" Web."
 msgstr ""
-"<b>Fer un Lloc Web Genealògic</b><br/>Pot exportar fàcilment el seu arbre "
-"genealògic a una pàgina web. Seleccioni la base de dades sencera, línies "
-"familiars o individus concrets i creï una col·lecció de pàgines web a punt "
-"de pujar a un servidor web."
+"<b>Fer un Lloc Web Genealògic</b><br/>Pot exportar fàcilment el seu arbre"
+" genealògic a una pàgina web. Seleccioni la base de dades sencera, línies"
+" familiars o individus concrets i creï una col·lecció de pàgines web a punt"
+" de pujar a un servidor web."
 
 #: ../data/tips.xml.in.h:46
 msgid ""
-"<b>Reporting Bugs in Gramps</b><br/>The best way to report a bug in Gramps "
-"is to use the Gramps bug tracking system at https://gramps-project.org/bugs/"
+"<b>Reporting Bugs in Gramps</b><br/>The best way to report a bug in Gramps is"
+" to use the Gramps bug tracking system at https://gramps-project.org/bugs/"
 msgstr ""
-"<b>Informar d'Errors a Gramps</b><br/>La millor manera d'informar d'un error "
-"de programa a Gramps és fer servir el seu sistema de seguiment d'errors a "
-"https://gramps-project.org/bugs/"
+"<b>Informar d'Errors a Gramps</b><br/>La millor manera d'informar d'un error"
+" de programa a Gramps és fer servir el seu sistema de seguiment d'errors a"
+" https://gramps-project.org/bugs/"
 
 #: ../data/tips.xml.in.h:47
 msgid ""
-"<b>The Gramps Homepage</b><br/>The Gramps homepage is at http://gramps-"
-"project.org/"
+"<b>The Gramps Homepage</b><br/>The Gramps homepage is at"
+" http://gramps-project.org/"
 msgstr ""
-"<b>La Pàgina Principal de Gramps</b><br/>La pàgina principal de Gramps és a "
-"http://gramps-project.org/"
+"<b>La Pàgina Principal de Gramps</b><br/>La pàgina principal de Gramps és a"
+" http://gramps-project.org/"
 
 #: ../data/tips.xml.in.h:48
 msgid ""
-"<b>Privacy in Gramps</b><br/>Gramps helps you to keep personal information "
-"secure by allowing you to mark information as private. Data marked as "
-"private can be excluded from reports and data exports. Look for the padlock "
-"which toggles records between private and public."
+"<b>Privacy in Gramps</b><br/>Gramps helps you to keep personal information"
+" secure by allowing you to mark information as private. Data marked as"
+" private can be excluded from reports and data exports. Look for the padlock"
+" which toggles records between private and public."
 msgstr ""
-"<b>Privacitat a Gramps</b><br/>Gramps l'ajuda a mantenir segura la seva "
-"informació personal permetent-li de marcar informació com a privada. Les "
-"dades marcades com a privades poden excloure's dels informes i les "
-"exportacions de dades. Busqui el candau que commuta els registres entre "
-"privats i públics."
+"<b>Privacitat a Gramps</b><br/>Gramps l'ajuda a mantenir segura la seva"
+" informació personal permetent-li de marcar informació com a privada. Les"
+" dades marcades com a privades poden excloure's dels informes i les"
+" exportacions de dades. Busqui el candau que commuta els registres entre"
+" privats i públics."
 
 #: ../data/tips.xml.in.h:49
 msgid ""
-"<b>Keeping Good Records</b><br/>Be accurate when recording genealogical "
-"information. Don't make assumptions while recording primary information; "
-"write it exactly as you see it. Use bracketed comments to indicate your "
-"additions, deletions or comments. Use of the Latin 'sic' is recommended to "
-"confirm the accurate transcription of what appears to be an error in a "
-"source."
+"<b>Keeping Good Records</b><br/>Be accurate when recording genealogical"
+" information. Don't make assumptions while recording primary information;"
+" write it exactly as you see it. Use bracketed comments to indicate your"
+" additions, deletions or comments. Use of the Latin 'sic' is recommended to"
+" confirm the accurate transcription of what appears to be an error in a"
+" source."
 msgstr ""
-"<b>Guardar Bons Registres</b><br/>Sigui precís en registrar informació "
-"genealògica. No faci suposicions en registrar informació primària; escrigui-"
-"la exactament tal com la veu. Faci servir comentaris entre claudàtors per "
-"indicar els seus afegits, esborrats o comentaris. Es recomana l'ús del llatí "
-"'sic' per confirmar la transcripció precisa del que sembli ser un error en "
-"una font."
+"<b>Guardar Bons Registres</b><br/>Sigui precís en registrar informació"
+" genealògica. No faci suposicions en registrar informació primària;"
+" escrigui-la exactament tal com la veu. Faci servir comentaris entre"
+" claudàtors per indicar els seus afegits, esborrats o comentaris. Es recomana"
+" l'ús del llatí 'sic' per confirmar la transcripció precisa del que sembli"
+" ser un error en una font."
 
 #: ../data/tips.xml.in.h:50
 msgid ""
-"<b>Extra Reports and Tools</b><br/>Extra tools and reports can be added to "
-"Gramps with the &quot;Addon&quot; system. See them under &quot;Help &gt; "
-"Extra Reports/Tools&quot;. This is the best way for advanced users to "
-"experiment and create new functionality."
+"<b>Extra Reports and Tools</b><br/>Extra tools and reports can be added to"
+" Gramps with the &quot;Addon&quot; system. See them under &quot;Help &gt;"
+" Extra Reports/Tools&quot;. This is the best way for advanced users to"
+" experiment and create new functionality."
 msgstr ""
-"<b>Informes i Eines Addicionals</b><br/>Es poden afegir informes i eines "
-"addicionals a Gramps amb el sistema de &quot;Complements&quot;. Vegi-ho a "
-"&quot;Ajuda &gt; Informes Addicionals/Eines&quot;. Aquesta és la millor "
-"manera perquè els usuaris avançats experimentin i creïn noves funcionalitats."
+"<b>Informes i Eines Addicionals</b><br/>Es poden afegir informes i eines"
+" addicionals a Gramps amb el sistema de &quot;Complements&quot;. Vegi-ho a"
+" &quot;Ajuda &gt; Informes Addicionals/Eines&quot;. Aquesta és la millor"
+" manera perquè els usuaris avançats experimentin i creïn noves funcionalitats."
 
 #: ../data/tips.xml.in.h:51
 msgid ""
-"<b>Book Reports</b><br/>The Book report under &quot;Reports &gt; Books &gt; "
-"Book Report...&quot;, allows you to collect a variety of reports into a "
-"single document. This single report is easier to distribute than multiple "
-"reports, especially when printed."
+"<b>Book Reports</b><br/>The Book report under &quot;Reports &gt; Books &gt;"
+" Book Report...&quot;, allows you to collect a variety of reports into a"
+" single document. This single report is easier to distribute than multiple"
+" reports, especially when printed."
 msgstr ""
-"<b>Informes de Llibre</b><br/>L'informe de Llibre, a &quot;Informes &gt; "
-"Llibres &gt; Informe de Llibre...&quot;, li permet de recopilar un "
-"reguitzell d'informes en un sol document. Aquest informe únic és més fàcil "
-"de distribuir que informes múltiples, especialment quan s'imprimeix."
+"<b>Informes de Llibre</b><br/>L'informe de Llibre, a &quot;Informes &gt;"
+" Llibres &gt; Informe de Llibre...&quot;, li permet de recopilar un"
+" reguitzell d'informes en un sol document. Aquest informe únic és més fàcil"
+" de distribuir que informes múltiples, especialment quan s'imprimeix."
 
 #: ../data/tips.xml.in.h:52
 msgid ""
-"<b>Gramps Announcements</b><br/>Interested in getting notified when a new "
-"version of Gramps is released? Join the Gramps-announce mailing list at "
-"&quot;Help &gt; Gramps Mailing Lists&quot;"
+"<b>Gramps Announcements</b><br/>Interested in getting notified when a new"
+" version of Gramps is released? Join the Gramps-announce mailing list at"
+" &quot;Help &gt; Gramps Mailing Lists&quot;"
 msgstr ""
-"<b>Anuncis de Gramps</b><br/>Li interessa rebre una notificació quan surti "
-"una versió de Gramps? Apunti's a la llista de correu Gramps-announce a &quot;"
-"Ajuda &gt; Llistes de Correu de Gramps&quot;"
+"<b>Anuncis de Gramps</b><br/>Li interessa rebre una notificació quan surti"
+" una versió de Gramps? Apunti's a la llista de correu Gramps-announce a"
+" &quot;Ajuda &gt; Llistes de Correu de Gramps&quot;"
 
 #: ../data/tips.xml.in.h:53
 msgid ""
-"<b>Record Your Sources</b><br/>Information collected about your family is "
-"only as good as the source it came from. Take the time and trouble to record "
-"all the details of where the information came from. Whenever possible get a "
-"copy of original documents."
+"<b>Record Your Sources</b><br/>Information collected about your family is"
+" only as good as the source it came from. Take the time and trouble to record"
+" all the details of where the information came from. Whenever possible get a"
+" copy of original documents."
 msgstr ""
-"<b>Registri les Fonts</b><br/>La informació recollida sobre la família només "
-"és igual de bona que la font de la qual s'ha obtingut. Prengui's el temps i "
-"les molèsties que calguin per enregistrar tots els detalls sobre l'origen de "
-"la informació. Sempre que sigui possible, guardi una còpia dels documents "
-"originals."
+"<b>Registri les Fonts</b><br/>La informació recollida sobre la família només"
+" és igual de bona que la font de la qual s'ha obtingut. Prengui's el temps i"
+" les molèsties que calguin per enregistrar tots els detalls sobre l'origen de"
+" la informació. Sempre que sigui possible, guardi una còpia dels documents"
+" originals."
 
 #: ../data/tips.xml.in.h:54
 msgid ""
-"<b>Directing Your Research</b><br/>Go from what you know to what you do not. "
-"Always record everything that is known before making conjectures. Often the "
-"facts at hand suggest plenty of direction for more research. Don't waste "
-"time looking through thousands of records hoping for a trail when you have "
-"other unexplored leads."
+"<b>Directing Your Research</b><br/>Go from what you know to what you do not."
+" Always record everything that is known before making conjectures. Often the"
+" facts at hand suggest plenty of direction for more research. Don't waste"
+" time looking through thousands of records hoping for a trail when you have"
+" other unexplored leads."
 msgstr ""
-"<b>Direcció de la Recerca</b><br/>Vagi des del que coneix cap al desconegut. "
-"Registri sempre tot el que se sàpiga abans de fer conjectures. Sovint, els "
-"fets coneguts suggereixen moltes direccions per fer més recerques. No perdi "
-"el temps consultant milers de registres esperant trobar una pista mentre "
-"tingui altres vies sense explorar."
+"<b>Direcció de la Recerca</b><br/>Vagi des del que coneix cap al desconegut."
+" Registri sempre tot el que se sàpiga abans de fer conjectures. Sovint, els"
+" fets coneguts suggereixen moltes direccions per fer més recerques. No perdi"
+" el temps consultant milers de registres esperant trobar una pista mentre"
+" tingui altres vies sense explorar."
 
 #: ../data/tips.xml.in.h:55
 msgid ""
-"<b>The 'How and Why' of Your Genealogy</b><br/> Genealogy isn't only about "
-"dates and names. It is about people. Be descriptive. Include why things "
-"happened, and how descendants might have been shaped by the events they went "
-"through. Narratives go a long way in making your family history come alive."
+"<b>The 'How and Why' of Your Genealogy</b><br/> Genealogy isn't only about"
+" dates and names. It is about people. Be descriptive. Include why things"
+" happened, and how descendants might have been shaped by the events they went"
+" through. Narratives go a long way in making your family history come alive."
 msgstr ""
-"<b>El 'Com i el Per què' de la Seva Genealogia</b>La genealogia no tracta "
-"només de dates i noms. Tracta sobretot de persones. Sigui descriptiu. "
-"Inclogui el per què les coses van anar així, i com els descendents van ser "
-"influïts pels esdeveniments pels quals van haver de viure. Les narracions "
-"són fonamentals per donar vida a la història de la seva família."
+"<b>El 'Com i el Per què' de la Seva Genealogia</b>La genealogia no tracta"
+" només de dates i noms. Tracta sobretot de persones. Sigui descriptiu."
+" Inclogui el per què les coses van anar així, i com els descendents van ser"
+" influïts pels esdeveniments pels quals van haver de viure. Les narracions"
+" són fonamentals per donar vida a la història de la seva família."
 
 #: ../data/tips.xml.in.h:56
 msgid ""
-"<b>Don't speak English?</b><br/>Volunteers have translated Gramps into more "
-"than 40 languages. If Gramps supports your language and it is not being "
-"displayed, set the default language in your operating system and restart "
-"Gramps."
+"<b>Don't speak English?</b><br/>Volunteers have translated Gramps into more"
+" than 40 languages. If Gramps supports your language and it is not being"
+" displayed, set the default language in your operating system and restart"
+" Gramps."
 msgstr ""
-"<b>No parleu anglès?</b><br/>Gramps ha estat traduït per voluntaris a més de "
-"40 llengües. Si Gramps suporta la seva llengua però no hi surt, fixeu la "
-"llengua predeterminada al sistema operatiu i torneu a engegar Gramps."
+"<b>No parleu anglès?</b><br/>Gramps ha estat traduït per voluntaris a més de"
+" 40 llengües. Si Gramps suporta la seva llengua però no hi surt, fixeu la"
+" llengua predeterminada al sistema operatiu i torneu a engegar Gramps."
 
 #: ../data/tips.xml.in.h:57
 msgid ""
-"<b>Gramps Translators</b><br/>Gramps has been designed so that new "
-"translations can easily be added with little development effort. If you are "
-"interested in participating please email gramps-devel@lists.sf.net"
+"<b>Gramps Translators</b><br/>Gramps has been designed so that new"
+" translations can easily be added with little development effort. If you are"
+" interested in participating please email gramps-devel@lists.sf.net"
 msgstr ""
-"<b>Traductors de Gramps</b><br/>Gramps ha estat dissenyat perquè s'hi puguin "
-"afegir fàcilment traduccions noves amb poc esforç de desenvolupament. Si "
-"està interessat en participar-hi, enviï si us plau un email a gramps-"
-"devel@lists.sf.net"
+"<b>Traductors de Gramps</b><br/>Gramps ha estat dissenyat perquè s'hi puguin"
+" afegir fàcilment traduccions noves amb poc esforç de desenvolupament. Si"
+" està interessat en participar-hi, enviï si us plau un email a"
+" gramps-devel@lists.sf.net"
 
 #: ../data/tips.xml.in.h:58
 msgid ""
-"<b>Hello, привет or 喂</b><br/>Whatever script you use Gramps offers full "
-"Unicode support. Characters for all languages are properly displayed."
+"<b>Hello, привет or 喂</b><br/>Whatever script you use Gramps offers full"
+" Unicode support. Characters for all languages are properly displayed."
 msgstr ""
-"<b>Hola, привет o 喂</b><br/>Per qualsevol alfabet que faci servir, Gramps "
-"proporciona suport total d'Unicode. Es mostren correctament els caràcters de "
-"totes les llengües."
+"<b>Hola, привет o 喂</b><br/>Per qualsevol alfabet que faci servir, Gramps"
+" proporciona suport total d'Unicode. Es mostren correctament els caràcters de"
+" totes les llengües."
 
 #: ../data/tips.xml.in.h:59
 msgid ""
-"<b>The Home Person</b><br/>Anyone can be chosen as the Home Person in "
-"Gramps. Use &quot;Edit &gt; Set Home Person&quot; in the Person View. The "
-"home person is the person who is selected when the database is opened or "
-"when the home button is pressed."
+"<b>The Home Person</b><br/>Anyone can be chosen as the Home Person in Gramps."
+" Use &quot;Edit &gt; Set Home Person&quot; in the Person View. The home"
+" person is the person who is selected when the database is opened or when the"
+" home button is pressed."
 msgstr ""
-"<b>La Persona Base</b><br/>Es pot triar qualsevol com a Persona Base dins de "
-"Gramps. Faci &quot;Edita &gt; Fixar Persona Base&quot; a la Vista de "
-"Persones. La persona base és la persona que se selecciona quan s'obre la "
-"base de dades o quan es prem el botó de 'la casa'."
+"<b>La Persona Base</b><br/>Es pot triar qualsevol com a Persona Base dins de"
+" Gramps. Faci &quot;Edita &gt; Fixar Persona Base&quot; a la Vista de"
+" Persones. La persona base és la persona que se selecciona quan s'obre la"
+" base de dades o quan es prem el botó de 'la casa'."
 
 #: ../data/tips.xml.in.h:60
 msgid ""
-"<b>The Gramps Code</b><br/>Gramps is written in a computer language called "
-"Python using the GTK and GNOME libraries for the graphical interface. Gramps "
-"is supported on any computer system where these programs have been ported. "
-"Gramps is known to be run on Linux, BSD, Solaris, Windows and Mac OS X."
+"<b>The Gramps Code</b><br/>Gramps is written in a computer language called"
+" Python using the GTK and GNOME libraries for the graphical interface. Gramps"
+" is supported on any computer system where these programs have been ported."
+" Gramps is known to be run on Linux, BSD, Solaris, Windows and Mac OS X."
 msgstr ""
-"<b>El Codi Gramps</b><br/>Gramps està escrit en el llenguatge de programació "
-"Python fent servir les llibreries GTK i GNOME per a la interfície gràfica. "
-"Gramps està suportat per qualsevol sistema informàtic al qual s'hagin portat "
-"aquests programes. S'ha comprovat que funciona en Linux, BSD, Solaris, "
-"Windows i Mac OS X."
+"<b>El Codi Gramps</b><br/>Gramps està escrit en el llenguatge de programació"
+" Python fent servir les llibreries GTK i GNOME per a la interfície gràfica."
+" Gramps està suportat per qualsevol sistema informàtic al qual s'hagin portat"
+" aquests programes. S'ha comprovat que funciona en Linux, BSD, Solaris,"
+" Windows i Mac OS X."
 
 #: ../data/tips.xml.in.h:61
 msgid ""
-"<b>Open Source Software</b><br/>The Free/Libre and Open Source Software "
-"(FLOSS) development model means Gramps can be extended by any programmer "
-"since all of the source code is freely available under its license. So it's "
-"not just about free beer, it's also about freedom to study and change the "
-"tool. For more about Open Source software lookup the Free Software "
-"Foundation and the Open Source Initiative."
+"<b>Open Source Software</b><br/>The Free/Libre and Open Source Software"
+" (FLOSS) development model means Gramps can be extended by any programmer"
+" since all of the source code is freely available under its license. So it's"
+" not just about free beer, it's also about freedom to study and change the"
+" tool. For more about Open Source software lookup the Free Software"
+" Foundation and the Open Source Initiative."
 msgstr ""
-"<b>Programari de Codi Obert</b><br/>El model de desenvolupament Lliure i de "
-"Codi Obert (FLOSS) significa que qualsevol programador pot estendre Gramps, "
-"perquè tot el codi font és disponible lliurement sota la seva llicència. Per "
-"tant, no és només la gratuïtat, és també la llibertat d'estudiar i modificar "
-"l'eina. Per més informació sobre el programari de Codi Obert busqui la Free "
-"Software Foundation i la Open Source Initiative."
+"<b>Programari de Codi Obert</b><br/>El model de desenvolupament Lliure i de"
+" Codi Obert (FLOSS) significa que qualsevol programador pot estendre Gramps,"
+" perquè tot el codi font és disponible lliurement sota la seva llicència. Per"
+" tant, no és només la gratuïtat, és també la llibertat d'estudiar i modificar"
+" l'eina. Per més informació sobre el programari de Codi Obert busqui la Free"
+" Software Foundation i la Open Source Initiative."
 
 #: ../data/tips.xml.in.h:62
 msgid ""
-"<b>The Gramps Software License</b><br/>You are free to use and share Gramps "
-"with others. Gramps is freely distributable under the GNU General Public "
-"License, see http://www.gnu.org/licenses/licenses.html#GPL to read about the "
-"rights and restrictions of this license."
+"<b>The Gramps Software License</b><br/>You are free to use and share Gramps"
+" with others. Gramps is freely distributable under the GNU General Public"
+" License, see http://www.gnu.org/licenses/licenses.html#GPL to read about the"
+" rights and restrictions of this license."
 msgstr ""
-"<b>La Llicència de Programari de Gramps</b><br/>Té la llibertat d'utilitzar "
-"i compartir Gramps amb els altres. Gramps es pot distribuir lliurement sota "
-"la Llicència Pública General de GNU, veure http://www.gnu.org/licenses/"
-"licenses.html#GPL per llegir sobre els drets i les restriccions d'aquesta "
-"llicència. Una traducció no oficial al català és a http://ca.dodds.net/gnu/"
-"gpl.ca.html."
+"<b>La Llicència de Programari de Gramps</b><br/>Té la llibertat d'utilitzar i"
+" compartir Gramps amb els altres. Gramps es pot distribuir lliurement sota la"
+" Llicència Pública General de GNU, veure"
+" http://www.gnu.org/licenses/licenses.html#GPL per llegir sobre els drets i"
+" les restriccions d'aquesta llicència. Una traducció no oficial al català és"
+" a http://ca.dodds.net/gnu/gpl.ca.html."
 
 #: ../data/tips.xml.in.h:63
 msgid ""
-"<b>Gramps for Gnome or KDE?</b><br/>For Linux users Gramps works with "
-"whichever desktop environment you prefer. As long as the required GTK "
-"libraries are installed it will run fine."
+"<b>Gramps for Gnome or KDE?</b><br/>For Linux users Gramps works with"
+" whichever desktop environment you prefer. As long as the required GTK"
+" libraries are installed it will run fine."
 msgstr ""
-"<b>Gramps per Gnome o KDE?</b><br/>Per als usuaris de Linux, Gramps funciona "
-"amb qualsevol entorn d'escriptori que prefereixi. Mentre estiguin "
-"instal·lades les llibreries de GTK funcionarà correctament."
+"<b>Gramps per Gnome o KDE?</b><br/>Per als usuaris de Linux, Gramps funciona"
+" amb qualsevol entorn d'escriptori que prefereixi. Mentre estiguin"
+" instal·lades les llibreries de GTK funcionarà correctament."
 
 #: ../gramps/cli/arghandler.py:229
 #, python-format
@@ -1122,12 +1124,12 @@ msgstr ""
 #, python-format
 msgid ""
 "Error: Input Family Tree \"%s\" does not exist.\n"
-"If GEDCOM, Gramps-xml or grdb, use the -i option to import into a Family "
-"Tree instead."
+"If GEDCOM, Gramps-xml or grdb, use the -i option to import into a Family Tree"
+" instead."
 msgstr ""
 "Error: L'arbre genealògic d'entrada \"%s\" no existeix.\n"
-"Si és GEDCOM, Gramps-xml o grdb, utilitzi l'opció -i per importar-lo a "
-"l'arbre genealògic."
+"Si és GEDCOM, Gramps-xml o grdb, utilitzi l'opció -i per importar-lo a"
+" l'arbre genealògic."
 
 #: ../gramps/cli/arghandler.py:255
 #, python-format
@@ -1269,9 +1271,8 @@ msgid "Database needs recovery, cannot open it!"
 msgstr "La base de dades s'ha de recuperar, no es pot obrir!"
 
 #: ../gramps/cli/arghandler.py:562
-#, fuzzy
 msgid "Database backend unavailable, cannot open it!"
-msgstr "La base de dades està bloquejada, no es pot obrir!"
+msgstr "Backend de base de dades no disponible, no es pot obrir!"
 
 #: ../gramps/cli/arghandler.py:613 ../gramps/cli/arghandler.py:662
 #: ../gramps/cli/arghandler.py:709
@@ -1328,7 +1329,6 @@ msgid "Unknown action: %s."
 msgstr "Acció desconeguda: %s."
 
 #: ../gramps/cli/argparser.py:56
-#, fuzzy
 msgid ""
 "\n"
 "Usage: gramps.py [OPTION...]\n"
@@ -1345,8 +1345,8 @@ msgid ""
 "  -C, --create=FAMILY_TREE               Create on open if new Family Tree\n"
 "  -i, --import=FILENAME                  Import file\n"
 "  -e, --export=FILENAME                  Export file\n"
-"  -r, --remove=FAMILY_TREE_PATTERN       Remove matching Family Tree(s) (use "
-"regular expressions)\n"
+"  -r, --remove=FAMILY_TREE_PATTERN       Remove matching Family Tree(s) (use"
+" regular expressions)\n"
 "  -f, --format=FORMAT                    Specify Family Tree format\n"
 "  -a, --action=ACTION                    Specify action\n"
 "  -p, --options=OPTIONS_STRING           Specify options\n"
@@ -1356,21 +1356,19 @@ msgid ""
 "  -t [FAMILY_TREE_PATTERN...]            List Family Trees, tab delimited\n"
 "  -u, --force-unlock                     Force unlock of Family Tree\n"
 "  -s, --show                             Show config settings\n"
-"  -c, --config=[config.setting[:value]]  Set config setting(s) and start "
-"Gramps\n"
-"  -y, --yes                              Don't ask to confirm dangerous "
-"actions (non-GUI mode only)\n"
-"  -q, --quiet                            Suppress progress indication output "
-"(non-GUI mode only)\n"
+"  -c, --config=[config.setting[:value]]  Set config setting(s) and start"
+" Gramps\n"
+"  -y, --yes                              Don't ask to confirm dangerous"
+" actions (non-GUI mode only)\n"
+"  -q, --quiet                            Suppress progress indication output"
+" (non-GUI mode only)\n"
 "  -v, --version                          Show versions\n"
 "  -S, --safe                             Start Gramps in 'Safe mode'\n"
-"                                          (temporarily use default "
-"settings)\n"
+"                                          (temporarily use default settings)\n"
 "  -D, --default=[APXFE]                  Reset settings to default;\n"
 "                 A - addons are cleared\n"
 "                 P - Preferences to default\n"
-"                 X - Books are cleared, reports and tool settings to "
-"default\n"
+"                 X - Books are cleared, reports and tool settings to default\n"
 "                 F - filters are cleared\n"
 "                 E - Everything is set to default or cleared\n"
 msgstr ""
@@ -1386,82 +1384,95 @@ msgstr ""
 "  -O, --open=ARBRE_GEN                   Obre un Arbre Genealògic\n"
 "  -U, --username=USUARI                Usuari de la base de dades\n"
 "  -P, --password=CONTRASENYA                Contrasenya de la base de dades\n"
-"  -C, --create=ARBRE_GEN                 Crea en obrir si l'Arbre Genealògic "
-"és nou\n"
+"  -C, --create=ARBRE_GEN                 Crea en obrir si l'Arbre Genealògic"
+" és nou\n"
 "  -i, --import=FITXER                    Importa un fitxer\n"
 "  -e, --export=FITXER                    Exporta un fitxer\n"
-"  -f, --format=FORMAT                    Especifica un format d'Arbre "
-"Genealògic\n"
+"  -r, --remove=PATRO_ARBRE_GEN        Esborrar arbres genealògics que"
+" concordin (utilitzant expressions reglars)\n"
+"  -f, --format=FORMAT                    Especifica un format d'Arbre"
+" Genealògic\n"
 "  -a, --action=ACCIÓ                     Especifica una acció\n"
 "  -p, --options=CADENA_OPCIONS           Especifica opcions\n"
 "  -d, --debug=NOM_REGISTRE               Activa registres de depuració\n"
 "  -l [PATRÓ_ARBRE_GEN...]                Llista Arbres Genealògics\n"
-"  -L [PATRÓ_ARBRE_GEN...]                Llista Detalladament Arbres "
-"Genealògics\n"
-"  -t [PATRÓ_ARBRE_GEN...]                Llista Arbres Genealògics, "
-"delimitats per tabuladors\n"
-"  -u, --force-unlock                     Força el desbloqueig de l'Arbre "
-"Genealògic\n"
+"  -L [PATRÓ_ARBRE_GEN...]                Llista Detalladament Arbres"
+" Genealògics\n"
+"  -t [PATRÓ_ARBRE_GEN...]                Llista Arbres Genealògics,"
+" delimitats per tabuladors\n"
+"  -u, --force-unlock                     Força el desbloqueig de l'Arbre"
+" Genealògic\n"
 "  -s, --show                             Mostra paràmetres de configuració\n"
-"  -c, --config=[opció.conf[:valor]]      Estableix opcions de configuració i "
-"engegar Gramps\n"
-"  -y, --yes                              No demana la confirmació per a "
-"accions perilloses (només en el mode sense IGU)\n"
-"  -q, --quiet                            Suprimeix la sortida d'indicació de "
-"progrés (nomeś en el mode sense IGU)\n"
+"  -c, --config=[opció.conf[:valor]]      Estableix opcions de configuració i"
+" engegar Gramps\n"
+"  -y, --yes                              No demana la confirmació per a"
+" accions perilloses (només en el mode sense IGU)\n"
+"  -q, --quiet                            Suprimeix la sortida d'indicació de"
+" progrés (nomeś en el mode sense IGU)\n"
 "  -v, --version                          Mostra versions\n"
+"  -S, --safe                             Inicia Gramps en 'mode Segur'\n"
+"                                          (utilitzar temporalment els ajustos"
+" predeterminats)\n"
+"  -D, --default=[APXFE]                  Tornar els ajustos al valor"
+" predeterminat;\n"
+"                 A - s'esborren els complements\n"
+"                 P - Preferències predeterminades\n"
+"                 X - Es netegen els llibres, els informes i els ajustes de"
+" les eines al valor predeterminat\n"
+"                 F - s'esborren els filtres\n"
+"                 E - Tot queda al valor predeterminat o esborrat\n"
 
 #: ../gramps/cli/argparser.py:95
 msgid ""
 "\n"
 "Example of usage of Gramps command line interface\n"
 "\n"
-"1. To import four databases (whose formats can be determined from their "
-"names)\n"
+"1. To import four databases (whose formats can be determined from their"
+" names)\n"
 "and then check the resulting database for errors, one may type:\n"
-"gramps -i file1.ged -i file2.gpkg -i ~/db3.gramps -i file4.wft -a tool -p "
-"name=check.\n"
+"gramps -i file1.ged -i file2.gpkg -i ~/db3.gramps -i file4.wft -a tool -p"
+" name=check.\n"
 "\n"
-"2. To explicitly specify the formats in the above example, append filenames "
-"with appropriate -f options:\n"
-"gramps -i file1.ged -f gedcom -i file2.gpkg -f gramps-pkg -i ~/db3.gramps -f "
-"gramps-xml -i file4.wft -f wft -a tool -p name=check.\n"
+"2. To explicitly specify the formats in the above example, append filenames"
+" with appropriate -f options:\n"
+"gramps -i file1.ged -f gedcom -i file2.gpkg -f gramps-pkg -i ~/db3.gramps -f"
+" gramps-xml -i file4.wft -f wft -a tool -p name=check.\n"
 "\n"
 "3. To record the database resulting from all imports, supply -e flag\n"
 "(use -f if the filename does not allow Gramps to guess the format):\n"
 "gramps -i file1.ged -i file2.gpkg -e ~/new-package -f gramps-pkg\n"
 "\n"
-"4. To save any error messages of the above example into files outfile and "
-"errfile, run:\n"
-"gramps -i file1.ged -i file2.dpkg -e ~/new-package -f gramps-pkg >outfile "
-"2>errfile\n"
+"4. To save any error messages of the above example into files outfile and"
+" errfile, run:\n"
+"gramps -i file1.ged -i file2.dpkg -e ~/new-package -f gramps-pkg >outfile 2"
+">errfile\n"
 "\n"
-"5. To import three databases and start interactive Gramps session with the "
-"result:\n"
+"5. To import three databases and start interactive Gramps session with the"
+" result:\n"
 "gramps -i file1.ged -i file2.gpkg -i ~/db3.gramps\n"
 "\n"
-"6. To open a database and, based on that data, generate timeline report in "
-"PDF format\n"
+"6. To open a database and, based on that data, generate timeline report in"
+" PDF format\n"
 "putting the output into the my_timeline.pdf file:\n"
-"gramps -O 'Family Tree 1' -a report -p name=timeline,off=pdf,of=my_timeline."
-"pdf\n"
+"gramps -O 'Family Tree 1' -a report -p name=timeline,off=pdf,of=my_timeline.pd"
+"f\n"
 "\n"
 "7. To generate a summary of a database:\n"
 "gramps -O 'Family Tree 1' -a report -p name=summary\n"
 "\n"
 "8. Listing report options\n"
-"Use the name=timeline,show=all to find out about all available options for "
-"the timeline report.\n"
-"To find out details of a particular option, use show=option_name , e.g. "
-"name=timeline,show=off string.\n"
+"Use the name=timeline,show=all to find out about all available options for"
+" the timeline report.\n"
+"To find out details of a particular option, use show=option_name , e.g."
+" name=timeline,show=off string.\n"
 "To learn about available report names, use name=show string.\n"
 "\n"
 "9. To convert a Family Tree on the fly to a .gramps xml file:\n"
 "gramps -O 'Family Tree 1' -e output.gramps -f gramps-xml\n"
 "\n"
 "10. To generate a web site into an other locale (in german):\n"
-"LANGUAGE=de_DE; LANG=de_DE.UTF-8 gramps -O 'Family Tree 1' -a report -p "
-"name=navwebpage,target=/../de\n"
+"LANGUAGE=de_DE; LANG=de_DE.UTF-8 gramps -O 'Family Tree 1' -a report -p"
+" name=navwebpage,target=/../de\n"
 "\n"
 "11. Finally, to start normal interactive session type:\n"
 "gramps\n"
@@ -1472,63 +1483,61 @@ msgstr ""
 "\n"
 "Exemple d'ús de la interfície de línia de comandes de Gramps\n"
 "\n"
-"1. Per importar quatre bases de dades (els formats de les quals es poden "
-"determinar a partir del nom)\n"
-"i després comprovar si la base de dades resultant té errors, es pot fer "
-"escrivint:\n"
-"gramps -i fitxer1.ged -i fitxer2.gpkg -i ~/db3.gramps -i fitxer4.wft -a tool "
-"-p name=check. \n"
+"1. Per importar quatre bases de dades (els formats de les quals es poden"
+" determinar a partir del nom)\n"
+"i després comprovar si la base de dades resultant té errors, es pot fer"
+" escrivint:\n"
+"gramps -i fitxer1.ged -i fitxer2.gpkg -i ~/db3.gramps -i fitxer4.wft -a tool"
+" -p name=check. \n"
 "\n"
-"2. Per especificar explícitament els formats a l'exemple anterior, cal "
-"afegir als noms de fitxer les opcions -f apropiades:\n"
-"gramps -i fitxer1.ged -f gedcom -i fitxer2.gpkg -f gramps-pkg -i ~/db3."
-"gramps -f gramps-xml -i fitxer4.wft -f wft -a tool -p name=check. \n"
+"2. Per especificar explícitament els formats a l'exemple anterior, cal afegir"
+" als noms de fitxer les opcions -f apropiades:\n"
+"gramps -i fitxer1.ged -f gedcom -i fitxer2.gpkg -f gramps-pkg -i ~/db3.gramps"
+" -f gramps-xml -i fitxer4.wft -f wft -a tool -p name=check. \n"
 "\n"
-"3. Per gravar la base de dades que resulti de totes les importacions, donar "
-"l'opció -e\n"
-"(utilitzeu -f si el nom de fitxer no permet a Gramps d'endevinar-ne el "
-"format):\n"
+"3. Per gravar la base de dades que resulti de totes les importacions, donar"
+" l'opció -e\n"
+"(utilitzeu -f si el nom de fitxer no permet a Gramps d'endevinar-ne el"
+" format):\n"
 "gramps -i fitxer1.ged -i fitxer2.gpkg -e ~/paquet-nou -f gramps-pkg\n"
 "\n"
-"4. Per desar els missatges d'error de l'exemple anterior als fitxers "
-"fitxer_sortida i fitxer_errors, feu:\n"
+"4. Per desar els missatges d'error de l'exemple anterior als fitxers"
+" fitxer_sortida i fitxer_errors, feu:\n"
 "gramps -i fitxer1.ged -i fitxer2.dpkg -e ~/paquet-nou -f gramps-pkg "
 ">fitxer_sortida 2>fitxer_errors\n"
 "\n"
-"5. Per importar tres bases de dades i començar una sessió interactiva de "
-"Gramps amb el resultat:\n"
+"5. Per importar tres bases de dades i començar una sessió interactiva de"
+" Gramps amb el resultat:\n"
 "gramps -i fitxer1.ged -i fitxer2.gpkg -i ~/db3.gramps\n"
 "\n"
-"6. Per obrir una base de dades i, basant-se en aquestes dades, generar un "
-"informe de línia temporal en format PDF\n"
+"6. Per obrir una base de dades i, basant-se en aquestes dades, generar un"
+" informe de línia temporal en format PDF\n"
 "posant la sortida al fitxer la_meva_línia_temporal.pdf:\n"
-"gramps -O 'Arbre Genealògic 1' -a report -p name=timeline,off=pdf,"
-"of=la_meva_línia_temporal.pdf\n"
+"gramps -O 'Arbre Genealògic 1' -a report -p"
+" name=timeline,off=pdf,of=la_meva_línia_temporal.pdf\n"
 "\n"
 "7. Per generar un resum d'una base de dades:\n"
 "gramps -O 'Arbre Genealògic 1' -a report -p name=summary\n"
 "\n"
 "8. Llistar les opcions d'informes\n"
-"Utilitzeu name=timeline,show=all per trobar totes les opcions disponibles "
-"per a l'informe de línia temporal.\n"
-"Per esbrinar els detalls d'una opció concreta, feu show=nom_opció, p.ex. "
-"name=timeline,show=off string.\n"
+"Utilitzeu name=timeline,show=all per trobar totes les opcions disponibles per"
+" a l'informe de línia temporal.\n"
+"Per esbrinar els detalls d'una opció concreta, feu show=nom_opció, p.ex."
+" name=timeline,show=off string.\n"
 "Per saber els noms d'informe disponibles, utilitzar name=show string.\n"
 "\n"
-"9. Per convertir un arbre genealògic sobre la marxa a un fitxer xml ."
-"gramps:\n"
+"9. Per convertir un arbre genealògic sobre la marxa a un fitxer xml .gramps:\n"
 "gramps -O 'Arbre Genealògic 1' -e sortida.gramps -f gramps-xml\n"
 "\n"
 "10. Per generar un web en una altra llengua (en alemany):\n"
-"LANGUAGE=de_DE; LANG=de_DE.UTF-8 gramps -O 'Arbre Genealògic 1' -a report -p "
-"name=navwebpage,target=/../de\n"
+"LANGUAGE=de_DE; LANG=de_DE.UTF-8 gramps -O 'Arbre Genealògic 1' -a report -p"
+" name=navwebpage,target=/../de\n"
 "\n"
 "11. Finalment, per començar una sessió interactiva normal, escriviu:\n"
 "gramps\n"
 "\n"
 "Nota: Aquests exemples són per a l'intèrpret de comandes bash.\n"
-"La sintaxi pot ser diferent per altres intèrprets de comandes i per "
-"Windows.\n"
+"La sintaxi pot ser diferent per altres intèrprets de comandes i per Windows.\n"
 
 #: ../gramps/cli/argparser.py:257 ../gramps/cli/argparser.py:470
 msgid "Error parsing the arguments"
@@ -1599,8 +1608,8 @@ msgid ""
 "To use in the command-line mode, supply at least one input file to process."
 msgstr ""
 "Error processant els arguments: %s\n"
-"Per fer-ho servir al mode de línia de comandes, proporcioni almenys un "
-"fitxer d'entrada a processar."
+"Per fer-ho servir al mode de línia de comandes, proporcioni almenys un fitxer"
+" d'entrada a processar."
 
 #: ../gramps/cli/clidbman.py:72 ../gramps/cli/clidbman.py:166
 #: ../gramps/cli/clidbman.py:168 ../gramps/gui/clipboard.py:188
@@ -1769,9 +1778,9 @@ msgstr "Bloquejat per %s"
 #: ../gramps/plugins/gramplet/persondetails.py:222
 #: ../gramps/plugins/gramplet/relativegramplet.py:126
 #: ../gramps/plugins/gramplet/relativegramplet.py:137
-#: ../gramps/plugins/graph/gvfamilylines.py:287
-#: ../gramps/plugins/graph/gvhourglass.py:427
-#: ../gramps/plugins/graph/gvrelgraph.py:948
+#: ../gramps/plugins/graph/gvfamilylines.py:288
+#: ../gramps/plugins/graph/gvhourglass.py:429
+#: ../gramps/plugins/graph/gvrelgraph.py:951
 #: ../gramps/plugins/lib/libprogen.py:1057
 #: ../gramps/plugins/lib/maps/geography.py:802
 #: ../gramps/plugins/lib/maps/geography.py:812
@@ -1824,90 +1833,89 @@ msgstr "Bloquejat per %s"
 msgid "Unknown"
 msgstr "Desconegut"
 
-#: ../gramps/cli/grampscli.py:85
+#: ../gramps/cli/grampscli.py:86
 #, python-format
 msgid "WARNING: %s"
 msgstr "AVÍS: %s"
 
-#: ../gramps/cli/grampscli.py:92 ../gramps/cli/grampscli.py:254
+#: ../gramps/cli/grampscli.py:93 ../gramps/cli/grampscli.py:255
 #, python-format
 msgid "ERROR: %s"
 msgstr "ERROR: %s"
 
-#: ../gramps/cli/grampscli.py:106 ../gramps/cli/user.py:200
+#: ../gramps/cli/grampscli.py:107 ../gramps/cli/user.py:200
 #: ../gramps/gui/dialog.py:295
 msgid "Low level database corruption detected"
 msgstr "Detectada corrupció de la base de dades a nivell baix"
 
-#: ../gramps/cli/grampscli.py:108 ../gramps/cli/user.py:201
+#: ../gramps/cli/grampscli.py:109 ../gramps/cli/user.py:201
 #: ../gramps/gui/dialog.py:296
 msgid ""
-"Gramps has detected a problem in the underlying Berkeley database. This can "
-"be repaired from the Family Tree Manager. Select the database and click on "
-"the Repair button"
+"Gramps has detected a problem in the underlying Berkeley database. This can"
+" be repaired from the Family Tree Manager. Select the database and click on"
+" the Repair button"
 msgstr ""
-"Gramps ha detectat un problema a la base de dades Berkeley de nivell "
-"inferior. Això es pot reparar des del Gestor d'Arbres Genealògics. "
-"Seleccioni la base de dades i cliqui el botó Reparar"
+"Gramps ha detectat un problema a la base de dades Berkeley de nivell"
+" inferior. Això es pot reparar des del Gestor d'Arbres Genealògics."
+" Seleccioni la base de dades i cliqui el botó Reparar"
 
-#: ../gramps/cli/grampscli.py:153 ../gramps/gui/dbloader.py:165
+#: ../gramps/cli/grampscli.py:154 ../gramps/gui/dbloader.py:165
 msgid "Read only database"
 msgstr "Base de dades de només lectura"
 
-#: ../gramps/cli/grampscli.py:154 ../gramps/gui/dbloader.py:166
+#: ../gramps/cli/grampscli.py:155 ../gramps/gui/dbloader.py:166
 #: ../gramps/gui/dbloader.py:535
 msgid "You do not have write access to the selected file."
 msgstr "No té accés d'escriptura al fitxer seleccionat."
 
-#: ../gramps/cli/grampscli.py:180 ../gramps/cli/grampscli.py:183
-#: ../gramps/cli/grampscli.py:186 ../gramps/cli/grampscli.py:189
-#: ../gramps/cli/grampscli.py:192 ../gramps/cli/grampscli.py:195
-#: ../gramps/cli/grampscli.py:198 ../gramps/cli/grampscli.py:201
-#: ../gramps/cli/grampscli.py:204 ../gramps/cli/grampscli.py:207
+#: ../gramps/cli/grampscli.py:181 ../gramps/cli/grampscli.py:184
+#: ../gramps/cli/grampscli.py:187 ../gramps/cli/grampscli.py:190
+#: ../gramps/cli/grampscli.py:193 ../gramps/cli/grampscli.py:196
+#: ../gramps/cli/grampscli.py:199 ../gramps/cli/grampscli.py:202
+#: ../gramps/cli/grampscli.py:205 ../gramps/cli/grampscli.py:208
 #: ../gramps/gui/dbloader.py:277 ../gramps/gui/dbloader.py:280
 #: ../gramps/gui/dbloader.py:283 ../gramps/gui/dbloader.py:286
 #: ../gramps/gui/dbloader.py:289 ../gramps/gui/dbloader.py:292
 msgid "Cannot open database"
 msgstr "No es pot obrir la base de dades"
 
-#: ../gramps/cli/grampscli.py:211 ../gramps/gui/dbloader.py:296
+#: ../gramps/cli/grampscli.py:212 ../gramps/gui/dbloader.py:296
 #: ../gramps/gui/dbloader.py:492
 #, python-format
 msgid "Could not open file: %s"
 msgstr "No s'ha pogut obrir el fitxer: %s"
 
-#: ../gramps/cli/grampscli.py:267
+#: ../gramps/cli/grampscli.py:268
 msgid "Could not load a recent Family Tree."
 msgstr "No s'ha pogut carregar un arbre genealògic recent."
 
-#: ../gramps/cli/grampscli.py:268
+#: ../gramps/cli/grampscli.py:269
 msgid "Family Tree does not exist, as it has been deleted."
 msgstr "L'arbre genealògic no existeix, ja que ha estat esborrat."
 
-#: ../gramps/cli/grampscli.py:273
+#: ../gramps/cli/grampscli.py:274
 msgid "The database is locked."
 msgstr "La base de dades està bloquejada."
 
-#: ../gramps/cli/grampscli.py:274
+#: ../gramps/cli/grampscli.py:275
 msgid ""
-"Use the --force-unlock option if you are sure that the database is not in "
-"use."
+"Use the --force-unlock option if you are sure that the database is not in use."
 msgstr ""
-"Utilitzeu l'opció --force-unlock si esteu segurs que la base de dades no "
-"està en us."
+"Utilitzeu l'opció --force-unlock si esteu segurs que la base de dades no està"
+" en us."
 
 #. already errors encountered. Show first one on terminal and exit
-#: ../gramps/cli/grampscli.py:352
+#: ../gramps/cli/grampscli.py:353
 #, python-format
 msgid "Error encountered: %s"
 msgstr "Trobat error: %s"
 
-#: ../gramps/cli/grampscli.py:354 ../gramps/cli/grampscli.py:362
+#: ../gramps/cli/grampscli.py:355 ../gramps/cli/grampscli.py:363
 #, python-format
 msgid "  Details: %s"
 msgstr "  Detalls: %s"
 
-#: ../gramps/cli/grampscli.py:359
+#: ../gramps/cli/grampscli.py:360
 #, python-format
 msgid "Error encountered in argument parsing: %s"
 msgstr "Trobat error en la interpretació dels arguments: %s"
@@ -2011,7 +2019,7 @@ msgstr "  Les opcions vàlides són:"
 #: ../gramps/gen/plug/report/endnotes.py:197
 #: ../gramps/gen/plug/report/endnotes.py:204
 #: ../gramps/gen/plug/report/endnotes.py:210
-#: ../gramps/plugins/drawreport/descendtree.py:352
+#: ../gramps/plugins/drawreport/descendtree.py:358
 #: ../gramps/plugins/drawreport/fanchart.py:364
 #: ../gramps/plugins/drawreport/fanchart.py:380
 #: ../gramps/plugins/gramplet/persondetails.py:237
@@ -2033,8 +2041,8 @@ msgstr ", "
 #, python-format
 msgid "   Use '%(donottranslate)s' to see description and acceptable values"
 msgstr ""
-"  Utilitzeu '%(donottranslate)s' per veure'n la descripció i els valors "
-"acceptables"
+"  Utilitzeu '%(donottranslate)s' per veure'n la descripció i els valors"
+" acceptables"
 
 #: ../gramps/cli/plug/__init__.py:527
 #, python-format
@@ -2072,11 +2080,11 @@ msgstr "   Els valors disponibles són:"
 #: ../gramps/cli/plug/__init__.py:652
 #, python-format
 msgid ""
-"option '%(optionname)s' not valid. Use '%(donottranslate)s' to see all valid "
-"options."
+"option '%(optionname)s' not valid. Use '%(donottranslate)s' to see all valid"
+" options."
 msgstr ""
-"l'opció '%(optionname)s' no és vàlida. Utilitzeu '%(donottranslate)s' per "
-"veure totes les opcions vàlides."
+"l'opció '%(optionname)s' no és vàlida. Utilitzeu '%(donottranslate)s' per"
+" veure totes les opcions vàlides."
 
 #: ../gramps/cli/plug/__init__.py:669
 msgid "Failed to write report. "
@@ -2094,18 +2102,18 @@ msgstr "Detectat error a la base de dades"
 #: ../gramps/cli/user.py:218 ../gramps/gui/dialog.py:282
 #, python-format
 msgid ""
-"Gramps has detected an error in the database. This can usually be resolved "
-"by running the \"Check and Repair Database\" tool.\n"
+"Gramps has detected an error in the database. This can usually be resolved by"
+" running the \"Check and Repair Database\" tool.\n"
 "\n"
-"If this problem continues to exist after running this tool, please file a "
-"bug report at %(gramps_bugtracker_url)s\n"
+"If this problem continues to exist after running this tool, please file a bug"
+" report at %(gramps_bugtracker_url)s\n"
 "\n"
 msgstr ""
-"Gramps ha detectat un error a la base de dades. Normalment es pot resoldre "
-"executant l'eina de \"Comprova i Repara la Base de dades\".\n"
+"Gramps ha detectat un error a la base de dades. Normalment es pot resoldre"
+" executant l'eina de \"Comprova i Repara la Base de dades\".\n"
 "\n"
-"Si aquest problema continua després d'executar aquesta eina, informi si us "
-"plau del problema a %(gramps_bugtracker_url)s\n"
+"Si aquest problema continua després d'executar aquesta eina, informi si us"
+" plau del problema a %(gramps_bugtracker_url)s\n"
 "\n"
 
 #: ../gramps/gen/config.py:246
@@ -2169,15 +2177,15 @@ msgstr ":"
 #, python-format
 msgid "Date parser for '%s' not available, using default"
 msgstr ""
-"L'analitzador de dates per a '%s' no està disponible, s'utilitza el "
-"predeterminat"
+"L'analitzador de dates per a '%s' no està disponible, s'utilitza el"
+" predeterminat"
 
 #: ../gramps/gen/datehandler/__init__.py:100
 #, python-format
 msgid "Date displayer for '%s' not available, using default"
 msgstr ""
-"El visualitzador de dates per a '%s' no està disponible, s'utilitza el "
-"predeterminat"
+"El visualitzador de dates per a '%s' no està disponible, s'utilitza el"
+" predeterminat"
 
 #. format 0 - must always be ISO
 #: ../gramps/gen/datehandler/_datedisplay.py:70
@@ -3002,238 +3010,238 @@ msgstr "Esborra mare de la família"
 msgid ""
 "The schema version is not supported by this version of Gramps.\n"
 "\n"
-"This Family Tree is schema version %(tree_vers)s, and this version of Gramps "
-"supports versions %(min_vers)s to %(max_vers)s\n"
+"This Family Tree is schema version %(tree_vers)s, and this version of Gramps"
+" supports versions %(min_vers)s to %(max_vers)s\n"
 "\n"
-"Please upgrade to the corresponding version or use XML for porting data "
-"between different schema versions."
+"Please upgrade to the corresponding version or use XML for porting data"
+" between different schema versions."
 msgstr ""
-"La versió de l'esquema de base de dades no està suportada per aquesta versió "
-"de Gramps.\n"
-"Aquest Arbre Genealògic té la versió d'esquema %(tree_vers)s, i aquesta "
-"versió de Gramps suporta les versions entre %(min_vers)s i %(max_vers)s\n"
+"La versió de l'esquema de base de dades no està suportada per aquesta versió"
+" de Gramps.\n"
+"Aquest Arbre Genealògic té la versió d'esquema %(tree_vers)s, i aquesta"
+" versió de Gramps suporta les versions entre %(min_vers)s i %(max_vers)s\n"
 "\n"
-"Si us plau pugi a la versió corresponent, o faci servir XML per portar les "
-"dades entre versions d'esquema diferents."
+"Si us plau pugi a la versió corresponent, o faci servir XML per portar les"
+" dades entre versions d'esquema diferents."
 
 #: ../gramps/gen/db/exceptions.py:114
 #, python-format
 msgid ""
 "The Python version is not supported by this version of Gramps.\n"
 "\n"
-"This Family Tree is Python version %(tree_vers)s, and this version of Gramps "
-"supports versions %(min_vers)s to %(max_vers)s\n"
+"This Family Tree is Python version %(tree_vers)s, and this version of Gramps"
+" supports versions %(min_vers)s to %(max_vers)s\n"
 "\n"
-"Please upgrade to the corresponding version or use XML for porting data "
-"between different Python versions."
+"Please upgrade to the corresponding version or use XML for porting data"
+" between different Python versions."
 msgstr ""
 "La versió de Python no està suportada per aquesta versió de Gramps.\n"
-"Aquest Arbre Genealògic té la versió de Python %(tree_vers)s, i aquesta "
-"versió de Gramps suporta les versions entre %(min_vers)s a la %(max_vers)s\n"
+"Aquest Arbre Genealògic té la versió de Python %(tree_vers)s, i aquesta"
+" versió de Gramps suporta les versions entre %(min_vers)s a la %(max_vers)s\n"
 "\n"
-"Si us plau actualitzi a la versió corresponent, o faci servir XML per portar "
-"les dades entre versions de Python diferents."
+"Si us plau actualitzi a la versió corresponent, o faci servir XML per portar"
+" les dades entre versions de Python diferents."
 
 #: ../gramps/gen/db/exceptions.py:136
 #, python-format
 msgid ""
 "The Family Tree you are trying to load is in the Bsddb version "
 "%(env_version)s format. This version of Gramps uses Bsddb version "
-"%(bdb_version)s. So you are trying to load data created in a newer format "
-"into an older program, and this is bound to fail.\n"
+"%(bdb_version)s. So you are trying to load data created in a newer format"
+" into an older program, and this is bound to fail.\n"
 "\n"
 "You should start your %(bold_start)snewer%(bold_end)s version of Gramps and "
-"%(wiki_backup_html_start)smake a backup%(html_end)s of your Family Tree. You "
-"can then import this backup into this version of Gramps."
+"%(wiki_backup_html_start)smake a backup%(html_end)s of your Family Tree. You"
+" can then import this backup into this version of Gramps."
 msgstr ""
-"L'Arbre Genealògic que esteu intentant d'obrir està en el format de Bsddb de "
-"versió %(env_version)s. Aquesta versió de Gramps utilitza la versió de Bsddb "
-"%(bdb_version)s.  Per tant, esteu provant de carregar dades creades en un "
-"format més nou en un programa més antic, i això segur que fallarà.\n"
+"L'Arbre Genealògic que esteu intentant d'obrir està en el format de Bsddb de"
+" versió %(env_version)s. Aquesta versió de Gramps utilitza la versió de Bsddb"
+" %(bdb_version)s.  Per tant, esteu provant de carregar dades creades en un"
+" format més nou en un programa més antic, i això segur que fallarà.\n"
 "\n"
 "Heu d'engegar la versió  %(bold_start)snova%(bold_end)s de Gramps i "
-"%(wiki_backup_html_start)sfer una còpia de seguretat%(html_end)s del vostre "
-"Arbre Genealògic. Llavors ja podeu importar aquesta còpia de seguretat en "
-"aquesta versió de Gramps."
+"%(wiki_backup_html_start)sfer una còpia de seguretat%(html_end)s del vostre"
+" Arbre Genealògic. Llavors ja podeu importar aquesta còpia de seguretat en"
+" aquesta versió de Gramps."
 
 #: ../gramps/gen/db/exceptions.py:166
 #, python-format
 msgid ""
 "The Family Tree you are trying to load is in the Bsddb version "
 "%(env_version)s format. This version of Gramps uses Bsddb version "
-"%(bdb_version)s. So you are trying to load data created in a newer format "
-"into an older program. In this particular case, the difference is very "
-"small, so it may work.\n"
+"%(bdb_version)s. So you are trying to load data created in a newer format"
+" into an older program. In this particular case, the difference is very"
+" small, so it may work.\n"
 "\n"
-"If you have not already made a backup of your Family Tree, then you should "
-"start your %(bold_start)snewer%(bold_end)s version of Gramps and "
+"If you have not already made a backup of your Family Tree, then you should"
+" start your %(bold_start)snewer%(bold_end)s version of Gramps and "
 "%(wiki_backup_html_start)smake a backup%(html_end)s of your Family Tree."
 msgstr ""
-"L'Arbre Genealògic que esteu intentant d'obrir està en el format de Bsddb de "
-"versió %(env_version)s. Aquesta versió de Gramps utilitza la versió de Bsddb "
-"%(bdb_version)s. Per tant, esteu provant de carregar dades creades en un "
-"format més nou en un programa més antic. En aquest cas concret, la "
-"diferència és molt petita, i per tant, és possible que funcioni.\n"
+"L'Arbre Genealògic que esteu intentant d'obrir està en el format de Bsddb de"
+" versió %(env_version)s. Aquesta versió de Gramps utilitza la versió de Bsddb"
+" %(bdb_version)s. Per tant, esteu provant de carregar dades creades en un"
+" format més nou en un programa més antic. En aquest cas concret, la"
+" diferència és molt petita, i per tant, és possible que funcioni.\n"
 "\n"
-"Si encara no heu fet una còpia de seguretat del vostre Arbre Genealògic, el "
-"millor és que engegueu la versió %(bold_start)snova%(bold_end)s de Gramps i "
-"%(wiki_backup_html_start)sfeu una còpia de seguretat%(html_end)s del vostre "
-"Arbre Genealògic."
+"Si encara no heu fet una còpia de seguretat del vostre Arbre Genealògic, el"
+" millor és que engegueu la versió %(bold_start)snova%(bold_end)s de Gramps i "
+"%(wiki_backup_html_start)sfeu una còpia de seguretat%(html_end)s del vostre"
+" Arbre Genealògic."
 
 #: ../gramps/gen/db/exceptions.py:195
 #, python-format
 msgid ""
 "The Family Tree you are trying to load is in the Bsddb version "
 "%(env_version)s format. This version of Gramps uses Bsddb version "
-"%(bdb_version)s. Therefore you cannot load this Family Tree without "
-"upgrading the Bsddb version of the Family Tree.\n"
+"%(bdb_version)s. Therefore you cannot load this Family Tree without upgrading"
+" the Bsddb version of the Family Tree.\n"
 "\n"
-"Opening the Family Tree with this version of Gramps might irretrievably "
-"corrupt your Family Tree. You are strongly advised to backup your Family "
-"Tree.\n"
+"Opening the Family Tree with this version of Gramps might irretrievably"
+" corrupt your Family Tree. You are strongly advised to backup your Family"
+" Tree.\n"
 "\n"
-"If you have not already made a backup of your Family Tree, then you should "
-"start your %(bold_start)sold%(bold_end)s version of Gramps and "
+"If you have not already made a backup of your Family Tree, then you should"
+" start your %(bold_start)sold%(bold_end)s version of Gramps and "
 "%(wiki_backup_html_start)smake a backup%(html_end)s of your Family Tree."
 msgstr ""
-"L'Arbre Genealògic que esteu intentant d'obrir està en el format de Bsddb de "
-"versió %(env_version)s. Aquesta versió de Gramps utilitza la versió de Bsddb "
-"%(bdb_version)s. Per tant, no podeu carregar aquest Arbre Genealògic sense "
-"actualitzar la versió de Bsddb de l'Arbre Genealògic.\n"
+"L'Arbre Genealògic que esteu intentant d'obrir està en el format de Bsddb de"
+" versió %(env_version)s. Aquesta versió de Gramps utilitza la versió de Bsddb"
+" %(bdb_version)s. Per tant, no podeu carregar aquest Arbre Genealògic sense"
+" actualitzar la versió de Bsddb de l'Arbre Genealògic.\n"
 "\n"
-"Obrir l'Arbre Genealògic amb aquesta versió de Gramps podria corrompre de "
-"manera definitiva el vostre Arbre Genealògic. Us aconsellem ferventment de "
-"fer una còpia de seguretat de l'Arbre Genealògic.\n"
+"Obrir l'Arbre Genealògic amb aquesta versió de Gramps podria corrompre de"
+" manera definitiva el vostre Arbre Genealògic. Us aconsellem ferventment de"
+" fer una còpia de seguretat de l'Arbre Genealògic.\n"
 "\n"
-"Si encara no heu fet una còpia de seguretat del vostre Arbre Genealògic, el "
-"millor és que engegueu la versió %(bold_start)santiga%(bold_end)s de Gramps "
-"i %(wiki_backup_html_start)sfeu una còpia de seguretat%(html_end)s del "
-"vostre Arbre Genealògic."
+"Si encara no heu fet una còpia de seguretat del vostre Arbre Genealògic, el"
+" millor és que engegueu la versió %(bold_start)santiga%(bold_end)s de Gramps"
+" i %(wiki_backup_html_start)sfeu una còpia de seguretat%(html_end)s del"
+" vostre Arbre Genealògic."
 
 #: ../gramps/gen/db/exceptions.py:225
 msgid ""
-"Gramps has detected a problem in opening the 'environment' of the underlying "
-"Berkeley database used to store this Family Tree. The most likely cause is "
-"that the database was created with an old version of the Berkeley database "
-"program, and you are now using a new version. It is quite likely that your "
-"database has not been changed by Gramps.\n"
-"If possible, you should revert to your old version of Gramps and its support "
-"software; export your database to XML; close the database; then upgrade "
-"again to this version of Gramps and import the XML file in an empty Family "
-"Tree. Alternatively, it may be possible to use the Berkeley database "
-"recovery tools."
+"Gramps has detected a problem in opening the 'environment' of the underlying"
+" Berkeley database used to store this Family Tree. The most likely cause is"
+" that the database was created with an old version of the Berkeley database"
+" program, and you are now using a new version. It is quite likely that your"
+" database has not been changed by Gramps.\n"
+"If possible, you should revert to your old version of Gramps and its support"
+" software; export your database to XML; close the database; then upgrade"
+" again to this version of Gramps and import the XML file in an empty Family"
+" Tree. Alternatively, it may be possible to use the Berkeley database"
+" recovery tools."
 msgstr ""
-"Gramps ha detectat un problema en obrir l''entorn' de la base de dades "
-"Berkeley de nivell inferior que s'utilitza per guardar aquest Arbre "
-"Genealògic. La causa més probable és que la base de dades va ser creada amb "
-"una versió antiga de la base de dades Berkeley, i ara està fent servir una "
-"versió nova. És força probable que Gramps no hagi modificat la seva base de "
-"dades.\n"
-"Si és possible, hauria de tornar a la versió antiga de Gramps i el seu "
-"programari de suport; exportar la base de dades a XML; tancar la base de "
-"dades; llavors tornar a instal·lar aquesta nova versió i importar el fitxer "
-"XML sobre un Arbre Genealògic buit. De forma alternativa, pot ser possible "
-"d'utilitzar les eines de recuperació de la base de dades Berkeley."
+"Gramps ha detectat un problema en obrir l''entorn' de la base de dades"
+" Berkeley de nivell inferior que s'utilitza per guardar aquest Arbre"
+" Genealògic. La causa més probable és que la base de dades va ser creada amb"
+" una versió antiga de la base de dades Berkeley, i ara està fent servir una"
+" versió nova. És força probable que Gramps no hagi modificat la seva base de"
+" dades.\n"
+"Si és possible, hauria de tornar a la versió antiga de Gramps i el seu"
+" programari de suport; exportar la base de dades a XML; tancar la base de"
+" dades; llavors tornar a instal·lar aquesta nova versió i importar el fitxer"
+" XML sobre un Arbre Genealògic buit. De forma alternativa, pot ser possible"
+" d'utilitzar les eines de recuperació de la base de dades Berkeley."
 
 #: ../gramps/gen/db/exceptions.py:252
 #, python-format
 msgid ""
-"The Family Tree you are trying to load is in the schema version "
-"%(oldschema)s format. This version of Gramps uses schema version "
-"%(newschema)s. Therefore you cannot load this Family Tree without upgrading "
-"the schema version of the Family Tree.\n"
+"The Family Tree you are trying to load is in the schema version %(oldschema)s"
+" format. This version of Gramps uses schema version %(newschema)s. Therefore"
+" you cannot load this Family Tree without upgrading the schema version of the"
+" Family Tree.\n"
 "\n"
-"If you upgrade then you won't be able to use the previous version of Gramps, "
-"even if you subsequently %(wiki_manual_backup_html_start)sbackup%(html_end)s "
-"or %(wiki_manual_export_html_start)sexport%(html_end)s your upgraded Family "
-"Tree.\n"
+"If you upgrade then you won't be able to use the previous version of Gramps,"
+" even if you subsequently %(wiki_manual_backup_html_start)sbackup%(html_end)s"
+" or %(wiki_manual_export_html_start)sexport%(html_end)s your upgraded Family"
+" Tree.\n"
 "\n"
-"Upgrading is a difficult task which could irretrievably corrupt your Family "
-"Tree if it is interrupted or fails.\n"
+"Upgrading is a difficult task which could irretrievably corrupt your Family"
+" Tree if it is interrupted or fails.\n"
 "\n"
-"If you have not already made a backup of your Family Tree, then you should "
-"start your %(bold_start)sold%(bold_end)s version of Gramps and "
+"If you have not already made a backup of your Family Tree, then you should"
+" start your %(bold_start)sold%(bold_end)s version of Gramps and "
 "%(wiki_backup_html_start)smake a backup%(html_end)s of your Family Tree."
 msgstr ""
-"L'Arbre Genealògic que esteu provant de carregar està en el format de la "
-"versió d'esquema %(oldschema)s. Aquesta versió de Gramps utilitza la versió "
-"d'esquema %(newschema)s. Per tant, no podeu carregar aquest Arbre Genealògic "
-"sense actualitzar la versió d'esquema de l'Arbre Genealògic.\n"
+"L'Arbre Genealògic que esteu provant de carregar està en el format de la"
+" versió d'esquema %(oldschema)s. Aquesta versió de Gramps utilitza la versió"
+" d'esquema %(newschema)s. Per tant, no podeu carregar aquest Arbre Genealògic"
+" sense actualitzar la versió d'esquema de l'Arbre Genealògic.\n"
 "\n"
-"Si actualitzeu, llavors no podreu utilitzar la versió anterior de Gramps, "
-"encara que després %(wiki_manual_backup_html_start)sfeu una còpia de "
-"seguretat%(html_end)s o %(wiki_manual_export_html_start)sexporteu"
+"Si actualitzeu, llavors no podreu utilitzar la versió anterior de Gramps,"
+" encara que després %(wiki_manual_backup_html_start)sfeu una còpia de"
+" seguretat%(html_end)s o %(wiki_manual_export_html_start)sexporteu"
 "%(html_end)s l'Arbre Genealògic actualitzat.\n"
 "\n"
-"L'actualització és una tasca difícil que podria corrompre de manera "
-"definitiva el vostre Arbre Genealògic si s'interromp o falla.\n"
+"L'actualització és una tasca difícil que podria corrompre de manera"
+" definitiva el vostre Arbre Genealògic si s'interromp o falla.\n"
 "\n"
-"Si encara no heu fet una còpia de seguretat del vostre Arbre Genealògic, el "
-"millor és que engegueu la versió %(bold_start)santiga%(bold_end)s de Gramps "
-"i %(wiki_backup_html_start)sfeu una còpia de seguretat%(html_end)s del "
-"vostre Arbre Genealògic."
+"Si encara no heu fet una còpia de seguretat del vostre Arbre Genealògic, el"
+" millor és que engegueu la versió %(bold_start)santiga%(bold_end)s de Gramps"
+" i %(wiki_backup_html_start)sfeu una còpia de seguretat%(html_end)s del"
+" vostre Arbre Genealògic."
 
 #: ../gramps/gen/db/exceptions.py:290
 #, python-format
 msgid ""
 "The Family Tree you are trying to load was created with Python version "
 "%(db_python_version)s. This version of Gramps uses Python version "
-"%(current_python_version)s.  So you are trying to load data created in a "
-"newer format into an older program, and this is bound to fail.\n"
+"%(current_python_version)s.  So you are trying to load data created in a"
+" newer format into an older program, and this is bound to fail.\n"
 "\n"
 "You should start your %(bold_start)snewer%(bold_end)s version of Gramps and "
-"%(wiki_backup_html_start)smake a backup%(html_end)s of your Family Tree. You "
-"can then import this backup into this version of Gramps."
+"%(wiki_backup_html_start)smake a backup%(html_end)s of your Family Tree. You"
+" can then import this backup into this version of Gramps."
 msgstr ""
-"L'Arbre Genealògic que esteu provant de carregar es va crear amb la versió "
-"de Python %(db_python_version)s. Aquesta versió de Gramps utilitza la versió "
-"de Python %(current_python_version)s. Per tant, esteu provant de carregar "
-"dades creades en un format més nou en un programa més antic, i això segur "
-"que fallarà.\n"
+"L'Arbre Genealògic que esteu provant de carregar es va crear amb la versió de"
+" Python %(db_python_version)s. Aquesta versió de Gramps utilitza la versió de"
+" Python %(current_python_version)s. Per tant, esteu provant de carregar dades"
+" creades en un format més nou en un programa més antic, i això segur que"
+" fallarà.\n"
 "\n"
 "Hauríeu d'engegar la versió %(bold_start)snova%(bold_end)s de Gramps i "
-"%(wiki_backup_html_start)sfer una còpia de seguretat%(html_end)s del vostre "
-"Arbre Genealògic. Llavors ja podeu importar aquesta còpia de seguretat en "
-"aquesta versió de Gramps."
+"%(wiki_backup_html_start)sfer una còpia de seguretat%(html_end)s del vostre"
+" Arbre Genealògic. Llavors ja podeu importar aquesta còpia de seguretat en"
+" aquesta versió de Gramps."
 
 #: ../gramps/gen/db/exceptions.py:320
 #, python-format
 msgid ""
 "The Family Tree you are trying to load is in the Python version "
 "%(db_python_version)s format. This version of Gramps uses Python version "
-"%(current_python_version)s. Therefore you cannot load this Family Tree "
-"without upgrading the Python version of the Family Tree.\n"
+"%(current_python_version)s. Therefore you cannot load this Family Tree"
+" without upgrading the Python version of the Family Tree.\n"
 "\n"
-"If you upgrade then you won't be able to use the previous version of Gramps, "
-"even if you subsequently %(wiki_manual_backup_html_start)sbackup%(html_end)s "
-"or %(wiki_manual_export_html_start)sexport%(html_end)s your upgraded Family "
-"Tree.\n"
+"If you upgrade then you won't be able to use the previous version of Gramps,"
+" even if you subsequently %(wiki_manual_backup_html_start)sbackup%(html_end)s"
+" or %(wiki_manual_export_html_start)sexport%(html_end)s your upgraded Family"
+" Tree.\n"
 "\n"
-"Upgrading is a difficult task which could irretrievably corrupt your Family "
-"Tree if it is interrupted or fails.\n"
+"Upgrading is a difficult task which could irretrievably corrupt your Family"
+" Tree if it is interrupted or fails.\n"
 "\n"
-"If you have not already made a backup of your Family Tree, then you should "
-"start your %(bold_start)sold%(bold_end)s version of Gramps and "
+"If you have not already made a backup of your Family Tree, then you should"
+" start your %(bold_start)sold%(bold_end)s version of Gramps and "
 "%(wiki_backup_html_start)smake a backup%(html_end)s of your Family Tree."
 msgstr ""
-"L'Arbre Genealògic que esteu provant de carregar està en el format de la "
-"versió de Python %(db_python_version)s. Aquesta versió de Gramps utilitza la "
-"versió de Python %(current_python_version)s. Per tant, no podeu carregar "
-"aquest Arbre Genealògic sense actualitzar la versió de Python de l'Arbre "
-"Genealògic.\n"
+"L'Arbre Genealògic que esteu provant de carregar està en el format de la"
+" versió de Python %(db_python_version)s. Aquesta versió de Gramps utilitza la"
+" versió de Python %(current_python_version)s. Per tant, no podeu carregar"
+" aquest Arbre Genealògic sense actualitzar la versió de Python de l'Arbre"
+" Genealògic.\n"
 "\n"
-"Si actualitzeu, llavors no podreu utilitzar la versió anterior de Gramps, "
-"encara que després %(wiki_manual_backup_html_start)sfeu una còpia de "
-"seguretat%(html_end)s o %(wiki_manual_export_html_start)sexporteu"
+"Si actualitzeu, llavors no podreu utilitzar la versió anterior de Gramps,"
+" encara que després %(wiki_manual_backup_html_start)sfeu una còpia de"
+" seguretat%(html_end)s o %(wiki_manual_export_html_start)sexporteu"
 "%(html_end)s l'Arbre Genealògic actualitzat.\n"
 "\n"
-"L'actualització és una tasca difícil que podria corrompre de manera "
-"definitiva el vostre Arbre Genealògic si s'interromp o falla.\n"
+"L'actualització és una tasca difícil que podria corrompre de manera"
+" definitiva el vostre Arbre Genealògic si s'interromp o falla.\n"
 "\n"
-"Si encara no heu fet una còpia de seguretat del vostre Arbre Genealògic, el "
-"millor és que engegueu la versió %(bold_start)santiga%(bold_end)s de Gramps "
-"i %(wiki_backup_html_start)sfeu una còpia de seguretat%(html_end)s del "
-"vostre Arbre Genealògic."
+"Si encara no heu fet una còpia de seguretat del vostre Arbre Genealògic, el"
+" millor és que engegueu la versió %(bold_start)santiga%(bold_end)s de Gramps"
+" i %(wiki_backup_html_start)sfeu una còpia de seguretat%(html_end)s del"
+" vostre Arbre Genealògic."
 
 #: ../gramps/gen/db/exceptions.py:356
 #, python-format
@@ -3474,6 +3482,20 @@ msgstr "Cadena de format de nom %s incorrecta"
 msgid "ERROR, Edit Name format in Preferences"
 msgstr "ERROR, format de Nom d'Edició a Preferències"
 
+#: ../gramps/gen/display/place.py:73 ../gramps/gen/plug/utils.py:339
+#, python-format
+msgid "Error in '%s' file: cannot load."
+msgstr "Error en fitxer '%s': no es pot carregar."
+
+#. -------------------------------------------------------------------------
+#.
+#. Private Constants
+#.
+#. -------------------------------------------------------------------------
+#: ../gramps/gen/display/place.py:74 ../gramps/gen/plug/docgen/treedoc.py:63
+msgid "Full"
+msgstr "Sencer"
+
 #: ../gramps/gen/filters/_filterparser.py:119
 #, python-format
 msgid ""
@@ -3522,15 +3544,15 @@ msgstr "S'està aplicant ..."
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1093
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1107
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1121
-#: ../gramps/plugins/graph/gvrelgraph.py:801
+#: ../gramps/plugins/graph/gvrelgraph.py:804
 #: ../gramps/plugins/quickview/quickview.gpr.py:130
 #: ../gramps/plugins/textreport/birthdayreport.py:473
 #: ../gramps/plugins/textreport/familygroup.py:714
 #: ../gramps/plugins/textreport/indivcomplete.py:1062
 #: ../gramps/plugins/textreport/recordsreport.py:217
 #: ../gramps/plugins/tool/sortevents.py:168
-#: ../gramps/plugins/webreport/narrativeweb.py:1639
-#: ../gramps/plugins/webreport/webcal.py:1671
+#: ../gramps/plugins/webreport/narrativeweb.py:1643
+#: ../gramps/plugins/webreport/webcal.py:1672
 msgid "Filter"
 msgstr "Filtre"
 
@@ -3621,11 +3643,11 @@ msgstr "Format de data-hora incorrecte"
 #: ../gramps/gen/filters/rules/_changedsincebase.py:83
 #, python-format
 msgid ""
-"Only date-times in the iso format of yyyy-mm-dd hh:mm:ss, where the time "
-"part is optional, are accepted. %s does not satisfy."
+"Only date-times in the iso format of yyyy-mm-dd hh:mm:ss, where the time part"
+" is optional, are accepted. %s does not satisfy."
 msgstr ""
-"Només s'accepten data-hora en el format iso de aaaa-mm-dd hh:mm:ss, on la "
-"part de l'hora és opcional. %s no ho compleix."
+"Només s'accepten data-hora en el format iso de aaaa-mm-dd hh:mm:ss, on la"
+" part de l'hora és opcional. %s no ho compleix."
 
 #: ../gramps/gen/filters/rules/_hascitationbase.py:49
 #: ../gramps/gen/filters/rules/citation/_hascitation.py:48
@@ -3834,11 +3856,11 @@ msgstr "Sense descripció"
 #. more references to a filter than expected
 #: ../gramps/gen/filters/rules/_rule.py:94
 msgid "The filter definition contains a loop."
-msgstr ""
+msgstr "La definició del filtre conté un bucle."
 
 #: ../gramps/gen/filters/rules/_rule.py:95
 msgid "One rule references another which eventually references the first."
-msgstr ""
+msgstr "Una regla en referencia una altra que acaba referenciant la primera."
 
 #: ../gramps/gen/filters/rules/citation/_allcitations.py:45
 msgid "Every citation"
@@ -3878,12 +3900,12 @@ msgstr "Cites modificades després de <data hora>"
 
 #: ../gramps/gen/filters/rules/citation/_changedsince.py:47
 msgid ""
-"Matches citation records changed after a specified date-time (yyyy-mm-dd hh:"
-"mm:ss) or in the range, if a second date-time is given."
+"Matches citation records changed after a specified date-time (yyyy-mm-dd"
+" hh:mm:ss) or in the range, if a second date-time is given."
 msgstr ""
-"Concorda amb registres de cita modificats després d'una data-hora "
-"especificada (aaaa-mm-dd hh:mm:ss) o en un rang, si es dóna una segona data-"
-"hora."
+"Concorda amb registres de cita modificats després d'una data-hora"
+" especificada (aaaa-mm-dd hh:mm:ss) o en un rang, si es dóna una segona"
+" data-hora."
 
 #: ../gramps/gen/filters/rules/citation/_citationprivate.py:43
 msgid "Citations marked private"
@@ -3940,8 +3962,8 @@ msgstr "Cites amb notes que contenen <subcadena>"
 #: ../gramps/gen/filters/rules/citation/_hasnotematchingsubstringof.py:44
 msgid "Matches citations whose notes contain text matching a substring"
 msgstr ""
-"Concorda amb cites les notes de les quals continguin un text que contingui "
-"una subcadena"
+"Concorda amb cites les notes de les quals continguin un text que contingui"
+" una subcadena"
 
 #: ../gramps/gen/filters/rules/citation/_hasnoteregexp.py:42
 msgid "Citations having notes containing <text>"
@@ -3951,8 +3973,8 @@ msgstr "Cites amb notes que continguin <text>"
 msgid ""
 "Matches citations whose notes contain text matching a regular expression"
 msgstr ""
-"Concorda amb cites les notes de les quals continguin un text que concordi "
-"amb una expressió regular"
+"Concorda amb cites les notes de les quals continguin un text que concordi amb"
+" una expressió regular"
 
 #: ../gramps/gen/filters/rules/citation/_hasreferencecountof.py:43
 msgid "Citations with a reference count of <count>"
@@ -4033,11 +4055,11 @@ msgstr "Cites amb notes d'origen que continguin <text>"
 
 #: ../gramps/gen/filters/rules/citation/_hassourcenoteregexp.py:53
 msgid ""
-"Matches citations whose source notes contain a substring or match a regular "
-"expression"
+"Matches citations whose source notes contain a substring or match a regular"
+" expression"
 msgstr ""
-"Concorda amb cites les notes d'origen de les quals continguin un text que "
-"concordi amb una expressió regular"
+"Concorda amb cites les notes d'origen de les quals continguin un text que"
+" concordi amb una expressió regular"
 
 #: ../gramps/gen/filters/rules/citation/_hastag.py:48
 #: ../gramps/gen/filters/rules/event/_hastag.py:48
@@ -4085,19 +4107,19 @@ msgstr "Nom del filtre de repositori:"
 
 #: ../gramps/gen/filters/rules/citation/_matchesrepositoryfilter.py:46
 msgid ""
-"Citations with a source with a repository reference matching the <repository "
-"filter>"
+"Citations with a source with a repository reference matching the <repository"
+" filter>"
 msgstr ""
-"Cites que tinguin una font amb referència a repositori que concordi amb el "
-"<filtre de repositori>"
+"Cites que tinguin una font amb referència a repositori que concordi amb el <"
+"filtre de repositori>"
 
 #: ../gramps/gen/filters/rules/citation/_matchesrepositoryfilter.py:48
 msgid ""
-"Matches citations with sources with a repository reference that match a "
-"certain repository filter"
+"Matches citations with sources with a repository reference that match a"
+" certain repository filter"
 msgstr ""
-"Concorda amb cites que tinguin fonts amb una referència a repositori que "
-"concordi amb un cert filtre de repositoris"
+"Concorda amb cites que tinguin fonts amb una referència a repositori que"
+" concordi amb un cert filtre de repositoris"
 
 #: ../gramps/gen/filters/rules/citation/_matchessourcefilter.py:49
 msgid "Citations with source matching the <source filter>"
@@ -4107,8 +4129,8 @@ msgstr "Cites amb font que concordi amb el <filtre de font>"
 msgid ""
 "Matches citations with sources that match the specified source filter name"
 msgstr ""
-"Concorda amb cites que tinguin fonts que concorden amb el nom de filtre de "
-"font especificat"
+"Concorda amb cites que tinguin fonts que concorden amb el nom de filtre de"
+" font especificat"
 
 #: ../gramps/gen/filters/rules/citation/_regexpidof.py:48
 msgid "Citations with Id containing <text>"
@@ -4125,11 +4147,11 @@ msgstr "Cites amb Id de Font que contingui <text>"
 
 #: ../gramps/gen/filters/rules/citation/_regexpsourceidof.py:49
 msgid ""
-"Matches citations whose source has a Gramps ID that matches the regular "
-"expression"
+"Matches citations whose source has a Gramps ID that matches the regular"
+" expression"
 msgstr ""
-"Concorda amb cites on la font tingui un Id Gramps que compleixi l'expressió "
-"regular"
+"Concorda amb cites on la font tingui un Id Gramps que compleixi l'expressió"
+" regular"
 
 #: ../gramps/gen/filters/rules/event/_allevents.py:44
 msgid "Every event"
@@ -4145,12 +4167,12 @@ msgstr "Esdeveniments modificats després de <data hora>"
 
 #: ../gramps/gen/filters/rules/event/_changedsince.py:48
 msgid ""
-"Matches event records changed after a specified date/time (yyyy-mm-dd hh:mm:"
-"ss) or in the range, if a second date/time is given."
+"Matches event records changed after a specified date/time (yyyy-mm-dd"
+" hh:mm:ss) or in the range, if a second date/time is given."
 msgstr ""
-"Concorda amb registres d'esdeveniment modificats després d'una data-hora "
-"especificada (aaaa-mm-dd hh:mm:ss) o dins d'un rang, si es dóna una segona "
-"data-hora."
+"Concorda amb registres d'esdeveniment modificats després d'una data-hora"
+" especificada (aaaa-mm-dd hh:mm:ss) o dins d'un rang, si es dóna una segona"
+" data-hora."
 
 #: ../gramps/gen/filters/rules/event/_eventprivate.py:42
 msgid "Events marked private"
@@ -4182,8 +4204,8 @@ msgstr "Objectes amb l'atribut <atribut>"
 #: ../gramps/gen/filters/rules/event/_hasattribute.py:46
 msgid "Matches events with the event attribute of a particular value"
 msgstr ""
-"Concorda amb els objectes que tenen l'atribut d'esdeveniment amb un valor en "
-"particular"
+"Concorda amb els objectes que tenen l'atribut d'esdeveniment amb un valor en"
+" particular"
 
 #: ../gramps/gen/filters/rules/event/_hascitation.py:51
 msgid "Events with the <citation>"
@@ -4254,8 +4276,8 @@ msgstr "Esdeveniments amb <nombre> medis audiovisuals"
 #: ../gramps/gen/filters/rules/event/_hasgallery.py:46
 msgid "Matches events with a certain number of items in the gallery"
 msgstr ""
-"Concorda amb els esdeveniments que tinguin un cert nombre d'elements a la "
-"galeria"
+"Concorda amb els esdeveniments que tinguin un cert nombre d'elements a la"
+" galeria"
 
 #: ../gramps/gen/filters/rules/event/_hasidof.py:44
 msgid "Event with <Id>"
@@ -4280,8 +4302,8 @@ msgstr "Esdeveniments amb notes que continguin <subcadena>"
 #: ../gramps/gen/filters/rules/event/_hasnotematchingsubstringof.py:43
 msgid "Matches events whose notes contain text matching a substring"
 msgstr ""
-"Concorda amb esdeveniments les notes dels quals continguin un text que "
-"concordi amb una subcadena"
+"Concorda amb esdeveniments les notes dels quals continguin un text que"
+" concordi amb una subcadena"
 
 #: ../gramps/gen/filters/rules/event/_hasnoteregexp.py:41
 msgid "Events having notes containing <text>"
@@ -4290,8 +4312,8 @@ msgstr "Esdeveniments amb notes que continguin <text>"
 #: ../gramps/gen/filters/rules/event/_hasnoteregexp.py:42
 msgid "Matches events whose notes contain text matching a regular expression"
 msgstr ""
-"Concorda amb esdeveniments les notes dels quals continguin un text que "
-"concordi amb una expressió regular"
+"Concorda amb esdeveniments les notes dels quals continguin un text que"
+" concordi amb una expressió regular"
 
 #: ../gramps/gen/filters/rules/event/_hasreferencecountof.py:42
 msgid "Events with a reference count of <count>"
@@ -4308,8 +4330,7 @@ msgstr "Esdeveniments amb <nombre> fonts"
 #: ../gramps/gen/filters/rules/event/_hassourcecount.py:45
 msgid "Matches events with a certain number of sources connected to it"
 msgstr ""
-"Concorda amb esdeveniments que estiguin connectats amb un cert nombre de "
-"fonts"
+"Concorda amb esdeveniments que estiguin connectats amb un cert nombre de fonts"
 
 #: ../gramps/gen/filters/rules/event/_hastag.py:49
 msgid "Events with the <tag>"
@@ -4353,8 +4374,8 @@ msgstr "Esdeveniments de persones que concordin amb el <filtre de persona>"
 #: ../gramps/gen/filters/rules/event/_matchespersonfilter.py:52
 msgid "Matches events of persons matched by the specified person filter name"
 msgstr ""
-"Concorda amb esdeveniments de persones que concordin amb el nom de filtre de "
-"persona especificat"
+"Concorda amb esdeveniments de persones que concordin amb el nom de filtre de"
+" persona especificat"
 
 #: ../gramps/gen/filters/rules/event/_matchesplacefilter.py:49
 #: ../gramps/gui/editors/filtereditor.py:539
@@ -4367,11 +4388,11 @@ msgstr "Esdeveniments de llocs que concordin amb el <filtre de lloc>"
 
 #: ../gramps/gen/filters/rules/event/_matchesplacefilter.py:51
 msgid ""
-"Matches events that occurred at places that match the specified place filter "
-"name"
+"Matches events that occurred at places that match the specified place filter"
+" name"
 msgstr ""
-"Concorda amb esdeveniments que hagin ocorregut en llocs que concordin amb el "
-"nom de filtre de font especificat"
+"Concorda amb esdeveniments que hagin ocorregut en llocs que concordin amb el"
+" nom de filtre de font especificat"
 
 #: ../gramps/gen/filters/rules/event/_matchessourceconfidence.py:45
 msgid "Events with at least one direct source >= <confidence level>"
@@ -4380,8 +4401,8 @@ msgstr "Esdeveniments amb almenys una font directa >= <nivell de confiança>"
 #: ../gramps/gen/filters/rules/event/_matchessourceconfidence.py:46
 msgid "Matches events with at least one direct source with confidence level(s)"
 msgstr ""
-"Concorda amb esdeveniments que tinguin almenys una font directa amb "
-"nivell(s) de confiança"
+"Concorda amb esdeveniments que tinguin almenys una font directa amb nivell(s)"
+" de confiança"
 
 #: ../gramps/gen/filters/rules/event/_matchessourcefilter.py:49
 msgid "Events with source matching the <source filter>"
@@ -4390,8 +4411,8 @@ msgstr "Esdeveniments amb font que concordi amb el <filtre de font>"
 #: ../gramps/gen/filters/rules/event/_matchessourcefilter.py:50
 msgid "Matches events with sources that match the specified source filter name"
 msgstr ""
-"Concorda amb esdeveniments que tinguin fonts que concorden amb el nom de "
-"filtre de font especificat"
+"Concorda amb esdeveniments que tinguin fonts que concorden amb el nom de"
+" filtre de font especificat"
 
 #: ../gramps/gen/filters/rules/event/_regexpidof.py:47
 msgid "Events with Id containing <text>"
@@ -4400,8 +4421,8 @@ msgstr "Esdeveniments amb Id que contingui <text>"
 #: ../gramps/gen/filters/rules/event/_regexpidof.py:48
 msgid "Matches events whose Gramps ID matches the regular expression"
 msgstr ""
-"Concorda amb esdeveniments l'ID Gramps dels quals concorda amb l'expressió "
-"regular"
+"Concorda amb esdeveniments l'ID Gramps dels quals concorda amb l'expressió"
+" regular"
 
 #: ../gramps/gen/filters/rules/family/_allfamilies.py:44
 #: ../gramps/gen/plug/report/utils.py:378
@@ -4418,12 +4439,12 @@ msgstr "Famílies modificades després de <data hora>"
 
 #: ../gramps/gen/filters/rules/family/_changedsince.py:48
 msgid ""
-"Matches family records changed after a specified date-time (yyyy-mm-dd hh:mm:"
-"ss) or in the range, if a second date-time is given."
+"Matches family records changed after a specified date-time (yyyy-mm-dd"
+" hh:mm:ss) or in the range, if a second date-time is given."
 msgstr ""
-"Concorda amb registres familiars modificats després d'una data-hora "
-"especificada (aaaa-mm-dd hh:mm:ss) o dins d'un rang, si es dóna una segona "
-"data-hora."
+"Concorda amb registres familiars modificats després d'una data-hora"
+" especificada (aaaa-mm-dd hh:mm:ss) o dins d'un rang, si es dóna una segona"
+" data-hora."
 
 #: ../gramps/gen/filters/rules/family/_childhasidof.py:45
 #: ../gramps/gen/filters/rules/family/_fatherhasidof.py:45
@@ -4574,8 +4595,8 @@ msgstr "Famílies amb notes que contenen <subcadena>"
 #: ../gramps/gen/filters/rules/family/_hasnotematchingsubstringof.py:43
 msgid "Matches families whose notes contain text matching a substring"
 msgstr ""
-"Concorda amb famílies les notes de les quals continguin un text que "
-"contingui una subcadena"
+"Concorda amb famílies les notes de les quals continguin un text que contingui"
+" una subcadena"
 
 #: ../gramps/gen/filters/rules/family/_hasnoteregexp.py:41
 msgid "Families having notes containing <text>"
@@ -4584,8 +4605,8 @@ msgstr "Famílies amb notes que continguin <text>"
 #: ../gramps/gen/filters/rules/family/_hasnoteregexp.py:42
 msgid "Matches families whose notes contain text matching a regular expression"
 msgstr ""
-"Concorda amb famílies les notes de les quals continguin un text que concordi "
-"amb una expressió regular"
+"Concorda amb famílies les notes de les quals continguin un text que concordi"
+" amb una expressió regular"
 
 #: ../gramps/gen/filters/rules/family/_hasreferencecountof.py:42
 msgid "Families with a reference count of <count>"
@@ -4619,8 +4640,7 @@ msgstr "Famílies amb <nombre> fonts"
 #: ../gramps/gen/filters/rules/family/_hassourcecount.py:46
 msgid "Matches families with a certain number of sources connected to it"
 msgstr ""
-"Concorda amb les famílies que estiguin connectades amb un cert nombre de "
-"fonts"
+"Concorda amb les famílies que estiguin connectades amb un cert nombre de fonts"
 
 #: ../gramps/gen/filters/rules/family/_hassourceof.py:46
 msgid "Families with the <source>"
@@ -4698,8 +4718,8 @@ msgstr "Famílies amb almenys una font directa >= <nivell de confiança>"
 msgid ""
 "Matches families with at least one direct source with confidence level(s)"
 msgstr ""
-"Concorda amb les famílies que tinguin almenys una font directa amb nivell(s) "
-"de confiança"
+"Concorda amb les famílies que tinguin almenys una font directa amb nivell(s)"
+" de confiança"
 
 #: ../gramps/gen/filters/rules/family/_motherhasidof.py:46
 msgid "Families having mother with Id containing <text>"
@@ -4731,11 +4751,11 @@ msgstr "Famílies amb fills que compleixin <expressió regular>"
 
 #: ../gramps/gen/filters/rules/family/_regexpchildname.py:46
 msgid ""
-"Matches families where some child has a name that matches a specified "
-"regular expression"
+"Matches families where some child has a name that matches a specified regular"
+" expression"
 msgstr ""
-"Concorda amb famílies on algun nen tingui un nom que compleixi una expressió "
-"regular concreta"
+"Concorda amb famílies on algun nen tingui un nom que compleixi una expressió"
+" regular concreta"
 
 #: ../gramps/gen/filters/rules/family/_regexpfathername.py:45
 msgid "Families with father matching the <regex_name>"
@@ -4743,11 +4763,11 @@ msgstr "Famílies amb pare que concordi amb el <nom_expressió_regular>"
 
 #: ../gramps/gen/filters/rules/family/_regexpfathername.py:46
 msgid ""
-"Matches families whose father has a name matching a specified regular "
-"expression"
+"Matches families whose father has a name matching a specified regular"
+" expression"
 msgstr ""
-"Concorda amb famílies on el nom del pare concorda amb un nom (parcial) "
-"especificat"
+"Concorda amb famílies on el nom del pare concorda amb un nom (parcial)"
+" especificat"
 
 #: ../gramps/gen/filters/rules/family/_regexpidof.py:47
 msgid "Families with Id containing <text>"
@@ -4764,11 +4784,11 @@ msgstr "Famílies amb mare que concordi amb el <nom_expressió_regular>"
 
 #: ../gramps/gen/filters/rules/family/_regexpmothername.py:46
 msgid ""
-"Matches families whose mother has a name matching a specified regular "
-"expression"
+"Matches families whose mother has a name matching a specified regular"
+" expression"
 msgstr ""
-"Concorda amb famílies on la mare tingui un nom que compleixi una expressió "
-"regular concreta"
+"Concorda amb famílies on la mare tingui un nom que compleixi una expressió"
+" regular concreta"
 
 #: ../gramps/gen/filters/rules/family/_searchchildname.py:45
 msgid "Families with any child matching the <name>"
@@ -4801,12 +4821,12 @@ msgstr "Objectes audiovisuals modificats després de <data hora>"
 
 #: ../gramps/gen/filters/rules/media/_changedsince.py:46
 msgid ""
-"Matches media objects changed after a specified date:time (yyyy-mm-dd hh:mm:"
-"ss) or in the range, if a second date:time is given."
+"Matches media objects changed after a specified date:time (yyyy-mm-dd"
+" hh:mm:ss) or in the range, if a second date:time is given."
 msgstr ""
-"Concorda amb objectes audiovisuals modificats després d'una data-hora "
-"especificada (aaaa-mm-dd hh:mm:ss) o en un rang, si es dóna una segona data-"
-"hora."
+"Concorda amb objectes audiovisuals modificats després d'una data-hora"
+" especificada (aaaa-mm-dd hh:mm:ss) o en un rang, si es dóna una segona"
+" data-hora."
 
 #: ../gramps/gen/filters/rules/media/_hasattribute.py:44
 #: ../gramps/gui/editors/filtereditor.py:108
@@ -4821,8 +4841,8 @@ msgstr "Objectes audiovisuals amb atribut <atribut>"
 #: ../gramps/gen/filters/rules/media/_hasattribute.py:46
 msgid "Matches media objects with the attribute of a particular value"
 msgstr ""
-"Concorda amb els objectes audiovisuals que tenen l'atribut donat amb un "
-"valor en particular"
+"Concorda amb els objectes audiovisuals que tenen l'atribut donat amb un valor"
+" en particular"
 
 #: ../gramps/gen/filters/rules/media/_hascitation.py:50
 msgid "Media with the <citation>"
@@ -4879,8 +4899,8 @@ msgstr "Objectes audiovisuals amb notes que continguin <subcadena>"
 #: ../gramps/gen/filters/rules/media/_hasnotematchingsubstringof.py:43
 msgid "Matches media objects whose notes contain text matching a substring"
 msgstr ""
-"Concorda amb objectes audiovisuals les notes dels quals tinguin un text que "
-"contingui una subcadena"
+"Concorda amb objectes audiovisuals les notes dels quals tinguin un text que"
+" contingui una subcadena"
 
 #: ../gramps/gen/filters/rules/media/_hasnoteregexp.py:41
 msgid "Media objects having notes containing <text>"
@@ -4890,8 +4910,8 @@ msgstr "Objectes audiovisuals amb notes que continguin <text>"
 msgid ""
 "Matches media objects whose notes contain text matching a regular expression"
 msgstr ""
-"Concorda amb objectes audiovisuals les notes dels quals continguin text que "
-"compleixi una expressió regular"
+"Concorda amb objectes audiovisuals les notes dels quals continguin text que"
+" compleixi una expressió regular"
 
 #: ../gramps/gen/filters/rules/media/_hasreferencecountof.py:42
 msgid "Media objects with a reference count of <count>"
@@ -4908,8 +4928,8 @@ msgstr "Medis audiovisuals amb <nombre> fonts"
 #: ../gramps/gen/filters/rules/media/_hassourcecount.py:46
 msgid "Matches media with a certain number of sources connected to it"
 msgstr ""
-"Concorda amb els medis audiovisuals que estiguin connectats amb un cert "
-"nombre de fonts"
+"Concorda amb els medis audiovisuals que estiguin connectats amb un cert"
+" nombre de fonts"
 
 #: ../gramps/gen/filters/rules/media/_hassourceof.py:46
 msgid "Media with the <source>"
@@ -4935,8 +4955,8 @@ msgstr "Objectes audiovisuals que compleixin el <filtre>"
 #: ../gramps/gen/filters/rules/media/_matchesfilter.py:45
 msgid "Matches media objects matched by the specified filter name"
 msgstr ""
-"Concorda amb objectes audiovisuals que compleixin el nom de filtres "
-"especificat"
+"Concorda amb objectes audiovisuals que compleixin el nom de filtres"
+" especificat"
 
 #: ../gramps/gen/filters/rules/media/_matchessourceconfidence.py:44
 msgid "Media with a direct source >= <confidence level>"
@@ -4945,8 +4965,8 @@ msgstr "Medis audiovisuals amb una font directa >= <nivell de confiança>"
 #: ../gramps/gen/filters/rules/media/_matchessourceconfidence.py:45
 msgid "Matches media with at least one direct source with confidence level(s)"
 msgstr ""
-"Concorda amb els objectes audiovisuals que tinguin almenys una font directa "
-"amb nivell(s) de confiança"
+"Concorda amb els objectes audiovisuals que tinguin almenys una font directa"
+" amb nivell(s) de confiança"
 
 #: ../gramps/gen/filters/rules/media/_mediaprivate.py:42
 msgid "Media objects marked private"
@@ -4963,8 +4983,8 @@ msgstr "Objectes audiovisuals amb Id que contingui <text>"
 #: ../gramps/gen/filters/rules/media/_regexpidof.py:48
 msgid "Matches media objects whose Gramps ID matches the regular expression"
 msgstr ""
-"Concorda amb objectes audiovisuals l'Id Gramps dels quals compleixi "
-"l'expressió regular"
+"Concorda amb objectes audiovisuals l'Id Gramps dels quals compleixi"
+" l'expressió regular"
 
 #: ../gramps/gen/filters/rules/note/_allnotes.py:44
 msgid "Every note"
@@ -4980,12 +5000,12 @@ msgstr "Notes modificades després de <data hora>"
 
 #: ../gramps/gen/filters/rules/note/_changedsince.py:48
 msgid ""
-"Matches note records changed after a specified date-time (yyyy-mm-dd hh:mm:"
-"ss) or in the range, if a second date-time is given."
+"Matches note records changed after a specified date-time (yyyy-mm-dd"
+" hh:mm:ss) or in the range, if a second date-time is given."
 msgstr ""
-"Concorda amb registres de nota modificats després d'una data-hora "
-"especificada (aaaa-mm-dd hh:mm:ss) o en un rang, si es dóna una segona data-"
-"hora."
+"Concorda amb registres de nota modificats després d'una data-hora"
+" especificada (aaaa-mm-dd hh:mm:ss) o en un rang, si es dóna una segona"
+" data-hora."
 
 #: ../gramps/gen/filters/rules/note/_hasidof.py:44
 msgid "Note with <Id>"
@@ -5049,8 +5069,8 @@ msgstr "Notes que continguin <text>"
 #: ../gramps/gen/filters/rules/note/_matchesregexpof.py:45
 msgid "Matches notes that contain a substring or match a regular expression"
 msgstr ""
-"Concorda amb notes que continguin una subcadena o que concordin amb una "
-"expressió regular"
+"Concorda amb notes que continguin una subcadena o que concordin amb una"
+" expressió regular"
 
 #: ../gramps/gen/filters/rules/note/_matchessubstringof.py:44
 msgid "Notes containing <substring>"
@@ -5083,12 +5103,12 @@ msgstr "Persones modificades després de <data hora>"
 
 #: ../gramps/gen/filters/rules/person/_changedsince.py:48
 msgid ""
-"Matches person records changed after a specified date-time (yyyy-mm-dd hh:mm:"
-"ss) or in the range, if a second date-time is given."
+"Matches person records changed after a specified date-time (yyyy-mm-dd"
+" hh:mm:ss) or in the range, if a second date-time is given."
 msgstr ""
-"Concorda amb registres de persona modificats després d'una data-hora "
-"especificada (aaaa-mm-dd hh:mm:ss) o en un rang, si es dóna una segona data-"
-"hora."
+"Concorda amb registres de persona modificats després d'una data-hora"
+" especificada (aaaa-mm-dd hh:mm:ss) o en un rang, si es dóna una segona"
+" data-hora."
 
 #: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:133
 msgid "Relationship path between <person> and people matching <filter>"
@@ -5103,17 +5123,17 @@ msgstr "Filtres de parentesc"
 
 #: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:135
 msgid ""
-"Searches over the database starting from a specified person and returns "
-"everyone between that person and a set of target people specified with a "
-"filter.  This produces a set of relationship paths (including by marriage) "
-"between the specified person and the target people.  Each path is not "
-"necessarily the shortest path."
+"Searches over the database starting from a specified person and returns"
+" everyone between that person and a set of target people specified with a"
+" filter.  This produces a set of relationship paths (including by marriage)"
+" between the specified person and the target people.  Each path is not"
+" necessarily the shortest path."
 msgstr ""
-"Busca per la base de dades començant des d'una persona especificada i "
-"retorna tothom entre aquesta persona i un grup de persones objectiu "
-"especificades amb un filtre. Això produeix un conjunt de camins de parentesc "
-"(inclosos els de casament) entre la persona especificada i el grup objectiu. "
-"Cada camí no és necessàriament el més curt."
+"Busca per la base de dades començant des d'una persona especificada i retorna"
+" tothom entre aquesta persona i un grup de persones objectiu especificades"
+" amb un filtre. Això produeix un conjunt de camins de parentesc (inclosos els"
+" de casament) entre la persona especificada i el grup objectiu. Cada camí no"
+" és necessàriament el més curt."
 
 #: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:152
 #: ../gramps/gen/filters/rules/person/_deeprelationshippathbetween.py:164
@@ -5141,11 +5161,11 @@ msgstr "Persones desconnectades"
 
 #: ../gramps/gen/filters/rules/person/_disconnected.py:46
 msgid ""
-"Matches people that have no family relationships to any other person in the "
-"database"
+"Matches people that have no family relationships to any other person in the"
+" database"
 msgstr ""
-"Concorda amb persones que no tinguin cap parentesc familiar amb cap més "
-"persona de la base de dades"
+"Concorda amb persones que no tinguin cap parentesc familiar amb cap més"
+" persona de la base de dades"
 
 #: ../gramps/gen/filters/rules/person/_everyone.py:44
 msgid "Everyone"
@@ -5210,8 +5230,8 @@ msgstr "Persones amb <dades de naixement>"
 #: ../gramps/gen/filters/rules/person/_hasbirth.py:50
 msgid "Matches people with birth data of a particular value"
 msgstr ""
-"Concorda amb persones les dades de naixement de les quals tenen un valor "
-"concret"
+"Concorda amb persones les dades de naixement de les quals tenen un valor"
+" concret"
 
 #: ../gramps/gen/filters/rules/person/_hascitation.py:50
 msgid "People with the <citation>"
@@ -5250,8 +5270,8 @@ msgstr "Cerca de persones amb un avantpassat comú amb <filtre>"
 msgid ""
 "Matches people that have a common ancestor with anybody matched by a filter"
 msgstr ""
-"Concorda amb persones que tinguin un avantpassat comú amb qualsevol que "
-"coincideixi amb un filtre"
+"Concorda amb persones que tinguin un avantpassat comú amb qualsevol que"
+" coincideixi amb un filtre"
 
 #: ../gramps/gen/filters/rules/person/_hasdeath.py:49
 msgid "People with the <death data>"
@@ -5437,8 +5457,8 @@ msgstr "Persones amb notes que contenen <subcadena>"
 #: ../gramps/gen/filters/rules/person/_hasnotematchingsubstringof.py:43
 msgid "Matches people whose notes contain text matching a substring"
 msgstr ""
-"Concorda amb persones les notes de les quals continguin text que concordi "
-"amb una subcadena"
+"Concorda amb persones les notes de les quals continguin text que concordi amb"
+" una subcadena"
 
 #: ../gramps/gen/filters/rules/person/_hasnoteregexp.py:41
 msgid "People having notes containing <text>"
@@ -5447,8 +5467,8 @@ msgstr "Persones amb notes que continguin <text>"
 #: ../gramps/gen/filters/rules/person/_hasnoteregexp.py:42
 msgid "Matches people whose notes contain text matching a regular expression"
 msgstr ""
-"Concorda amb persones les notes de les quals continguin text que concordi "
-"amb una expressió regular"
+"Concorda amb persones les notes de les quals continguin text que concordi amb"
+" una expressió regular"
 
 #: ../gramps/gen/filters/rules/person/_hasrelationship.py:45
 msgid "Number of relationships:"
@@ -5500,11 +5520,11 @@ msgstr "Coincidència Soundex de Gent amb el <nom>"
 
 #: ../gramps/gen/filters/rules/person/_hassoundexname.py:43
 msgid ""
-"Soundex Match of people with a specified name. First name, Surname, Call "
-"name, and Nickname are searched in primary and alternate names."
+"Soundex Match of people with a specified name. First name, Surname, Call"
+" name, and Nickname are searched in primary and alternate names."
 msgstr ""
-"Coincidència Soundex de gent amb el nom especificat. El Nom de pila, Cognom, "
-"Nom habitual, i Sobrenom seran buscats als noms primaris i alternatius."
+"Coincidència Soundex de gent amb el nom especificat. El Nom de pila, Cognom,"
+" Nom habitual, i Sobrenom seran buscats als noms primaris i alternatius."
 
 #: ../gramps/gen/filters/rules/person/_hassourcecount.py:45
 msgid "People with <count> sources"
@@ -5543,8 +5563,8 @@ msgstr "Persones amb registres que continguin <subcadena>"
 #: ../gramps/gen/filters/rules/person/_hastextmatchingsubstringof.py:49
 msgid "Matches people whose records contain text matching a substring"
 msgstr ""
-"Concorda amb persones els registres de les quals continguin text que "
-"concordi amb una subcadena"
+"Concorda amb persones els registres de les quals continguin text que concordi"
+" amb una subcadena"
 
 #: ../gramps/gen/filters/rules/person/_hasunknowngender.py:45
 msgid "People with unknown gender"
@@ -5594,8 +5614,8 @@ msgstr "Avantpassats de <filtre>"
 #: ../gramps/gen/filters/rules/person/_isancestoroffiltermatch.py:49
 msgid "Matches people that are ancestors of anybody matched by a filter"
 msgstr ""
-"Concorda amb persones que siguin avantpassats de qualsevol que concordi amb "
-"algun filtre"
+"Concorda amb persones que siguin avantpassats de qualsevol que concordi amb"
+" algun filtre"
 
 #: ../gramps/gen/filters/rules/person/_isbookmarked.py:45
 msgid "Bookmarked people"
@@ -5637,11 +5657,11 @@ msgstr "Filtres de descendents"
 
 #: ../gramps/gen/filters/rules/person/_isdescendantfamilyof.py:52
 msgid ""
-"Matches people that are descendants or the spouse of a descendant of a "
-"specified person"
+"Matches people that are descendants or the spouse of a descendant of a"
+" specified person"
 msgstr ""
-"Concorda amb persones que siguin descendents o el cònjuge d'un descendent "
-"d'una persona específica"
+"Concorda amb persones que siguin descendents o el cònjuge d'un descendent"
+" d'una persona específica"
 
 #: ../gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py:47
 msgid "Descendant family members of <filter> match"
@@ -5649,11 +5669,11 @@ msgstr "Membres de la família descendents de <filtre>"
 
 #: ../gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py:49
 msgid ""
-"Matches people that are descendants or the spouse of anybody matched by a "
-"filter"
+"Matches people that are descendants or the spouse of anybody matched by a"
+" filter"
 msgstr ""
-"Concorda amb les persones que siguin descendents o el cònjuge d'algú que "
-"concordi amb un filtre"
+"Concorda amb les persones que siguin descendents o el cònjuge d'algú que"
+" concordi amb un filtre"
 
 #: ../gramps/gen/filters/rules/person/_isdescendantof.py:46
 msgid "Descendants of <person>"
@@ -5670,8 +5690,8 @@ msgstr "Descendents de <filtre>"
 #: ../gramps/gen/filters/rules/person/_isdescendantoffiltermatch.py:49
 msgid "Matches people that are descendants of anybody matched by a filter"
 msgstr ""
-"Concorda amb les persones que siguin descendents d'algú que concordi amb un "
-"filtre"
+"Concorda amb les persones que siguin descendents d'algú que concordi amb un"
+" filtre"
 
 #: ../gramps/gen/filters/rules/person/_isduplicatedancestorof.py:47
 msgid "Duplicated ancestors of <person>"
@@ -5680,14 +5700,14 @@ msgstr "Avantpassats duplicats de <persona>"
 #: ../gramps/gen/filters/rules/person/_isduplicatedancestorof.py:49
 msgid "Matches people that are ancestors twice or more of a specified person"
 msgstr ""
-"Concorda amb persones que siguin avantpassats dues vegades o més d'una "
-"persona especificada"
+"Concorda amb persones que siguin avantpassats dues vegades o més d'una"
+" persona especificada"
 
 #: ../gramps/gen/filters/rules/person/_isfemale.py:45
 #: ../gramps/plugins/gramplet/statsgramplet.py:149
-#: ../gramps/plugins/graph/gvfamilylines.py:283
-#: ../gramps/plugins/graph/gvhourglass.py:423
-#: ../gramps/plugins/graph/gvrelgraph.py:944
+#: ../gramps/plugins/graph/gvfamilylines.py:284
+#: ../gramps/plugins/graph/gvhourglass.py:425
+#: ../gramps/plugins/graph/gvrelgraph.py:947
 #: ../gramps/plugins/webreport/statistics.py:124
 #: ../gramps/plugins/webreport/statistics.py:189
 msgid "Females"
@@ -5713,11 +5733,11 @@ msgstr "Avantpassats de <persona> a no més de <N> generacions"
 
 #: ../gramps/gen/filters/rules/person/_islessthannthgenerationancestorof.py:48
 msgid ""
-"Matches people that are ancestors of a specified person not more than N "
-"generations away"
+"Matches people that are ancestors of a specified person not more than N"
+" generations away"
 msgstr ""
-"Concorda amb persones que són avantpassats d'una persona especificada a no "
-"més de N generacions"
+"Concorda amb persones que són avantpassats d'una persona especificada a no"
+" més de N generacions"
 
 #: ../gramps/gen/filters/rules/person/_islessthannthgenerationancestorofbookmarked.py:52
 msgid "Ancestors of bookmarked people not more than <N> generations away"
@@ -5726,11 +5746,11 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/person/_islessthannthgenerationancestorofbookmarked.py:55
 msgid ""
-"Matches ancestors of the people on the bookmark list not more than N "
-"generations away"
+"Matches ancestors of the people on the bookmark list not more than N"
+" generations away"
 msgstr ""
-"Concorda amb avantpassats de les persones de la llista de punts d'interès "
-"que no estiguin a més de N generacions"
+"Concorda amb avantpassats de les persones de la llista de punts d'interès que"
+" no estiguin a més de N generacions"
 
 #: ../gramps/gen/filters/rules/person/_islessthannthgenerationancestorofdefaultperson.py:47
 msgid "Ancestors of the default person not more than <N> generations away"
@@ -5740,8 +5760,8 @@ msgstr "Avantpassats de la persona predeterminada a no més de <N> generacions"
 msgid ""
 "Matches ancestors of the default person not more than N generations away"
 msgstr ""
-"Concorda amb avantpassats de la persona predeterminada que no estiguin a més "
-"de N generacions"
+"Concorda amb avantpassats de la persona predeterminada que no estiguin a més"
+" de N generacions"
 
 #: ../gramps/gen/filters/rules/person/_islessthannthgenerationdescendantof.py:46
 msgid "Descendants of <person> not more than <N> generations away"
@@ -5749,19 +5769,19 @@ msgstr "Descendents de <persona> a no més de <N> generacions"
 
 #: ../gramps/gen/filters/rules/person/_islessthannthgenerationdescendantof.py:49
 msgid ""
-"Matches people that are descendants of a specified person not more than N "
-"generations away"
+"Matches people that are descendants of a specified person not more than N"
+" generations away"
 msgstr ""
-"Concorda amb persones que són descendents d'una persona especificada a no "
-"més de N generacions"
+"Concorda amb persones que són descendents d'una persona especificada a no més"
+" de N generacions"
 
 #. -------------------------
 #. ###############################
 #: ../gramps/gen/filters/rules/person/_ismale.py:45
 #: ../gramps/plugins/gramplet/statsgramplet.py:146
-#: ../gramps/plugins/graph/gvfamilylines.py:279
-#: ../gramps/plugins/graph/gvhourglass.py:419
-#: ../gramps/plugins/graph/gvrelgraph.py:940
+#: ../gramps/plugins/graph/gvfamilylines.py:280
+#: ../gramps/plugins/graph/gvhourglass.py:421
+#: ../gramps/plugins/graph/gvrelgraph.py:943
 #: ../gramps/plugins/webreport/statistics.py:122
 #: ../gramps/plugins/webreport/statistics.py:187
 msgid "Males"
@@ -5777,11 +5797,11 @@ msgstr "Avantpassats de <persona> almenys a <N> generacions"
 
 #: ../gramps/gen/filters/rules/person/_ismorethannthgenerationancestorof.py:48
 msgid ""
-"Matches people that are ancestors of a specified person at least N "
-"generations away"
+"Matches people that are ancestors of a specified person at least N"
+" generations away"
 msgstr ""
-"Concorda amb persones que són avantpassats de la persona especificada "
-"almenys N generacions enrere"
+"Concorda amb persones que són avantpassats de la persona especificada almenys"
+" N generacions enrere"
 
 #: ../gramps/gen/filters/rules/person/_ismorethannthgenerationdescendantof.py:46
 msgid "Descendants of <person> at least <N> generations away"
@@ -5789,11 +5809,11 @@ msgstr "Descendents de <persona> almenys a <N> generacions"
 
 #: ../gramps/gen/filters/rules/person/_ismorethannthgenerationdescendantof.py:48
 msgid ""
-"Matches people that are descendants of a specified person at least N "
-"generations away"
+"Matches people that are descendants of a specified person at least N"
+" generations away"
 msgstr ""
-"Concorda amb persones que siguin descendents d'una persona especificada "
-"almenys a N generacions"
+"Concorda amb persones que siguin descendents d'una persona especificada"
+" almenys a N generacions"
 
 #: ../gramps/gen/filters/rules/person/_isparentoffiltermatch.py:47
 msgid "Parents of <filter> match"
@@ -5827,8 +5847,8 @@ msgstr "Cònjuges de <filtre>"
 #: ../gramps/gen/filters/rules/person/_isspouseoffiltermatch.py:48
 msgid "Matches people married to anybody matching a filter"
 msgstr ""
-"Concorda amb persones que estiguin casades amb qualsevol que compleixi un "
-"filtre"
+"Concorda amb persones que estiguin casades amb qualsevol que compleixi un"
+" filtre"
 
 #: ../gramps/gen/filters/rules/person/_iswitness.py:45
 msgid "Witnesses"
@@ -5852,8 +5872,8 @@ msgstr ""
 #: ../gramps/gen/filters/rules/person/_matcheseventfilter.py:53
 msgid "Matches persons who have events that match a certain event filter"
 msgstr ""
-"Concorda amb persones que tenen esdeveniments que concorden amb un cert "
-"filtre d'esdeveniments"
+"Concorda amb persones que tenen esdeveniments que concorden amb un cert"
+" filtre d'esdeveniments"
 
 #: ../gramps/gen/filters/rules/person/_matchesfilter.py:44
 msgid "People matching the <filter>"
@@ -5871,8 +5891,8 @@ msgstr "Persones que tenen almenys una font directa >= <nivell de confiança>"
 msgid ""
 "Matches persons with at least one direct source with confidence level(s)"
 msgstr ""
-"Concorda amb persones que tenen almenys una font directa amb nivell(s) de "
-"confiança"
+"Concorda amb persones que tenen almenys una font directa amb nivell(s) de"
+" confiança"
 
 #: ../gramps/gen/filters/rules/person/_missingparent.py:43
 msgid "People missing parents"
@@ -5880,11 +5900,11 @@ msgstr "Persones sense pares"
 
 #: ../gramps/gen/filters/rules/person/_missingparent.py:44
 msgid ""
-"Matches people that are children in a family with less than two parents or "
-"are not children in any family."
+"Matches people that are children in a family with less than two parents or"
+" are not children in any family."
 msgstr ""
-"Concorda amb persones que són fills en una família que tingui menys de dos "
-"pares o que no siguin fills de cap família."
+"Concorda amb persones que són fills en una família que tingui menys de dos"
+" pares o que no siguin fills de cap família."
 
 #: ../gramps/gen/filters/rules/person/_multiplemarriages.py:42
 msgid "People with multiple marriage records"
@@ -5963,8 +5983,8 @@ msgstr "Persones amb Id que contingui <text>"
 #: ../gramps/gen/filters/rules/person/_regexpidof.py:47
 msgid "Matches people whose Gramps ID matches the regular expression"
 msgstr ""
-"Concorda amb persones el Gramps Id de les quals concorda amb l'expressió "
-"regular"
+"Concorda amb persones el Gramps Id de les quals concorda amb l'expressió"
+" regular"
 
 #: ../gramps/gen/filters/rules/person/_regexpname.py:46
 msgid "People with a name matching <text>"
@@ -5972,11 +5992,10 @@ msgstr "Persones amb nom que concordi amb <text>"
 
 #: ../gramps/gen/filters/rules/person/_regexpname.py:47
 msgid ""
-"Matches people's names containing a substring or matching a regular "
-"expression"
+"Matches people's names containing a substring or matching a regular expression"
 msgstr ""
-"Concorda amb els noms de persona que continguin una subcadena o que "
-"concordin amb una expressió regular"
+"Concorda amb els noms de persona que continguin una subcadena o que concordin"
+" amb una expressió regular"
 
 #: ../gramps/gen/filters/rules/person/_relationshippathbetween.py:46
 msgid "Relationship path between <persons>"
@@ -5984,11 +6003,11 @@ msgstr "Camí de parentesc entre <persones>"
 
 #: ../gramps/gen/filters/rules/person/_relationshippathbetween.py:48
 msgid ""
-"Matches the ancestors of two persons back to a common ancestor, producing "
-"the relationship path between two persons."
+"Matches the ancestors of two persons back to a common ancestor, producing the"
+" relationship path between two persons."
 msgstr ""
-"Concorda amb els avantpassats de dues persones fins a un avantpassat comú, "
-"obtenint-se el camí de parentesc entre dues persones."
+"Concorda amb els avantpassats de dues persones fins a un avantpassat comú,"
+" obtenint-se el camí de parentesc entre dues persones."
 
 #: ../gramps/gen/filters/rules/person/_relationshippathbetweenbookmarks.py:51
 msgid "Relationship path between bookmarked persons"
@@ -5996,12 +6015,12 @@ msgstr "Camí de parentesc entre persones que són als punts d'interès"
 
 #: ../gramps/gen/filters/rules/person/_relationshippathbetweenbookmarks.py:53
 msgid ""
-"Matches the ancestors of bookmarked individuals back to common ancestors, "
-"producing the relationship path(s) between bookmarked persons."
+"Matches the ancestors of bookmarked individuals back to common ancestors,"
+" producing the relationship path(s) between bookmarked persons."
 msgstr ""
-"Concorda amb els avantpassats d'individus que siguin als punts d'interès "
-"fins als avantpassats comuns, obtenint-se el(s) camí(ins) de parentesc entre "
-"persones dels punts d'interès."
+"Concorda amb els avantpassats d'individus que siguin als punts d'interès fins"
+" als avantpassats comuns, obtenint-se el(s) camí(ins) de parentesc entre"
+" persones dels punts d'interès."
 
 #: ../gramps/gen/filters/rules/person/_searchname.py:46
 msgid "People matching the <name>"
@@ -6021,12 +6040,12 @@ msgstr "Llocs modificats després de <data hora>"
 
 #: ../gramps/gen/filters/rules/place/_changedsince.py:48
 msgid ""
-"Matches place records changed after a specified date-time (yyyy-mm-dd hh:mm:"
-"ss) or in the range, if a second date-time is given."
+"Matches place records changed after a specified date-time (yyyy-mm-dd"
+" hh:mm:ss) or in the range, if a second date-time is given."
 msgstr ""
-"Concorda amb registres de lloc modificats després d'una data-hora "
-"especificada (aaaa-mm-dd hh:mm:ss) o en un rang, si es dóna una segona data-"
-"hora."
+"Concorda amb registres de lloc modificats després d'una data-hora"
+" especificada (aaaa-mm-dd hh:mm:ss) o en un rang, si es dóna una segona"
+" data-hora."
 
 #: ../gramps/gen/filters/rules/place/_hascitation.py:51
 msgid "Place with the <citation>"
@@ -6105,8 +6124,8 @@ msgstr "Llocs amb notes que continguin <subcadena>"
 #: ../gramps/gen/filters/rules/place/_hasnotematchingsubstringof.py:43
 msgid "Matches places whose notes contain text matching a substring"
 msgstr ""
-"Concorda amb llocs les notes dels quals tinguin text que contingui una "
-"subcadena"
+"Concorda amb llocs les notes dels quals tinguin text que contingui una"
+" subcadena"
 
 #: ../gramps/gen/filters/rules/place/_hasnoteregexp.py:41
 msgid "Places having notes containing <text>"
@@ -6115,8 +6134,8 @@ msgstr "Llocs amb notes que continguin <text>"
 #: ../gramps/gen/filters/rules/place/_hasnoteregexp.py:42
 msgid "Matches places whose notes contain text matching a regular expression"
 msgstr ""
-"Concorda amb llocs les notes dels quals continguin text que compleixi una "
-"expressió regular"
+"Concorda amb llocs les notes dels quals continguin text que compleixi una"
+" expressió regular"
 
 #: ../gramps/gen/filters/rules/place/_hasplace.py:49
 msgid "Street:"
@@ -6218,13 +6237,13 @@ msgstr "Llocs a la vora de la posició donada"
 
 #: ../gramps/gen/filters/rules/place/_inlatlonneighborhood.py:52
 msgid ""
-"Matches places with latitude or longitude positioned in a rectangle of given "
-"height and width (in degrees), and with middlepoint the given latitude and "
-"longitude."
+"Matches places with latitude or longitude positioned in a rectangle of given"
+" height and width (in degrees), and with middlepoint the given latitude and"
+" longitude."
 msgstr ""
-"Concorda amb llocs que tinguin la latitud o la longitud posicionades en un "
-"rectangle de l'alçada i amplada donades (en graus), i amb el centre a la "
-"latitud i longitud donades."
+"Concorda amb llocs que tinguin la latitud o la longitud posicionades en un"
+" rectangle de l'alçada i amplada donades (en graus), i amb el centre a la"
+" latitud i longitud donades."
 
 #: ../gramps/gen/filters/rules/place/_isenclosedby.py:49
 msgid "Places enclosed by another place"
@@ -6240,11 +6259,11 @@ msgstr "Llocs d'esdeveniments que concorden amb el <filtre d'esdeveniment>"
 
 #: ../gramps/gen/filters/rules/place/_matcheseventfilter.py:51
 msgid ""
-"Matches places where events happened that match the specified event filter "
-"name"
+"Matches places where events happened that match the specified event filter"
+" name"
 msgstr ""
-"Concorda amb llocs on han ocorregut esdeveniments que concorden amb el nom "
-"de filtre d'esdeveniment especificat"
+"Concorda amb llocs on han ocorregut esdeveniments que concorden amb el nom de"
+" filtre d'esdeveniment especificat"
 
 #: ../gramps/gen/filters/rules/place/_matchesfilter.py:44
 msgid "Places matching the <filter>"
@@ -6261,8 +6280,8 @@ msgstr "Llocs que tenen almenys una font directa >= <nivell de confiança>"
 #: ../gramps/gen/filters/rules/place/_matchessourceconfidence.py:45
 msgid "Matches places with at least one direct source with confidence level(s)"
 msgstr ""
-"Concorda amb llocs que tenen almenys una font directa amb nivell(s) de "
-"confiança"
+"Concorda amb llocs que tenen almenys una font directa amb nivell(s) de"
+" confiança"
 
 #: ../gramps/gen/filters/rules/place/_placeprivate.py:42
 msgid "Places marked private"
@@ -6300,8 +6319,8 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/place/_withinarea.py:84
 msgid ""
-"The place you selected contains bad coordinates. Please, run the tool 'clean "
-"input data'"
+"The place you selected contains bad coordinates. Please, run the tool 'clean"
+" input data'"
 msgstr ""
 
 #: ../gramps/gen/filters/rules/repository/_allrepos.py:44
@@ -6318,12 +6337,12 @@ msgstr "Repositoris modificats després de <data hora>"
 
 #: ../gramps/gen/filters/rules/repository/_changedsince.py:48
 msgid ""
-"Matches repository records changed after a specified date/time (yyyy-mm-dd "
-"hh:mm:ss) or in the range, if a second date/time is given."
+"Matches repository records changed after a specified date/time (yyyy-mm-dd"
+" hh:mm:ss) or in the range, if a second date/time is given."
 msgstr ""
-"Concorda amb registres de repositori modificats després d'una data-hora "
-"especificades (aaaa-mm-dd hh:mm:ss) o dins d'un rang, si es dóna una segona "
-"data-hora."
+"Concorda amb registres de repositori modificats després d'una data-hora"
+" especificades (aaaa-mm-dd hh:mm:ss) o dins d'un rang, si es dóna una segona"
+" data-hora."
 
 #: ../gramps/gen/filters/rules/repository/_hasidof.py:44
 msgid "Repository with <Id>"
@@ -6340,8 +6359,8 @@ msgstr "Repositoris amb notes que continguin <subcadena>"
 #: ../gramps/gen/filters/rules/repository/_hasnotematchingsubstringof.py:43
 msgid "Matches repositories whose notes contain text matching a substring"
 msgstr ""
-"Concorda amb repositoris les notes dels quals tinguin text que contingui una "
-"subcadena"
+"Concorda amb repositoris les notes dels quals tinguin text que contingui una"
+" subcadena"
 
 #: ../gramps/gen/filters/rules/repository/_hasnoteregexp.py:41
 msgid "Repositories having notes containing <text>"
@@ -6351,8 +6370,8 @@ msgstr "Repositoris amb notes que continguin <text>"
 msgid ""
 "Matches repositories whose notes contain text matching a regular expression"
 msgstr ""
-"Concorda amb repositoris les notes dels quals continguin text que compleixi "
-"una expressió regular"
+"Concorda amb repositoris les notes dels quals continguin text que compleixi"
+" una expressió regular"
 
 #: ../gramps/gen/filters/rules/repository/_hasreferencecountof.py:42
 msgid "Repositories with a reference count of <count>"
@@ -6442,12 +6461,12 @@ msgstr "Fonts canviades després de <data hora>"
 
 #: ../gramps/gen/filters/rules/source/_changedsince.py:48
 msgid ""
-"Matches source records changed after a specified date-time (yyyy-mm-dd hh:mm:"
-"ss) or in the range, if a second date-time is given."
+"Matches source records changed after a specified date-time (yyyy-mm-dd"
+" hh:mm:ss) or in the range, if a second date-time is given."
 msgstr ""
-"Concorda amb registres de font modificats després d'una data-hora "
-"especificada (aaaa-mm-dd hh:mm:ss) o en un rang, si es dóna una segona data-"
-"hora."
+"Concorda amb registres de font modificats després d'una data-hora"
+" especificada (aaaa-mm-dd hh:mm:ss) o en un rang, si es dóna una segona"
+" data-hora."
 
 #: ../gramps/gen/filters/rules/source/_hasgallery.py:45
 msgid "Sources with <count> media"
@@ -6481,8 +6500,8 @@ msgstr "Fonts amb notes que contenen <subcadena>"
 #: ../gramps/gen/filters/rules/source/_hasnotematchingsubstringof.py:43
 msgid "Matches sources whose notes contain text matching a substring"
 msgstr ""
-"Concorda amb les fonts les notes de les quals contenen un text que concordi "
-"amb una subcadena"
+"Concorda amb les fonts les notes de les quals contenen un text que concordi"
+" amb una subcadena"
 
 #: ../gramps/gen/filters/rules/source/_hasnoteregexp.py:41
 msgid "Sources having notes containing <text>"
@@ -6491,8 +6510,8 @@ msgstr "Fonts amb notes que continguin <text>"
 #: ../gramps/gen/filters/rules/source/_hasnoteregexp.py:42
 msgid "Matches sources whose notes contain text matching a regular expression"
 msgstr ""
-"Concorda amb fonts les notes de les quals continguin text que compleixi una "
-"expressió regular"
+"Concorda amb fonts les notes de les quals continguin text que compleixi una"
+" expressió regular"
 
 #: ../gramps/gen/filters/rules/source/_hasreferencecountof.py:42
 msgid "Sources with a reference count of <count>"
@@ -6514,8 +6533,8 @@ msgstr ""
 #: ../gramps/gen/filters/rules/source/_hasrepositorycallnumberref.py:44
 msgid "Sources with repository reference containing <text> in \"Call Number\""
 msgstr ""
-"Fonts amb referència a repositori que contingui <text> a \"Número de "
-"Referència\""
+"Fonts amb referència a repositori que contingui <text> a \"Número de"
+" Referència\""
 
 #: ../gramps/gen/filters/rules/source/_hasrepositorycallnumberref.py:45
 msgid ""
@@ -6691,7 +6710,7 @@ msgstr "Cites"
 #: ../gramps/plugins/view/noteview.py:110 ../gramps/plugins/view/view.gpr.py:97
 #: ../gramps/plugins/view/view.gpr.py:105
 #: ../gramps/plugins/webreport/basepage.py:1264
-#: ../gramps/plugins/webreport/person.py:1248
+#: ../gramps/plugins/webreport/person.py:1255
 msgid "Notes"
 msgstr "Notes"
 
@@ -6979,7 +6998,7 @@ msgstr "Hora"
 
 #: ../gramps/gen/lib/attrtype.py:79 ../gramps/gen/lib/eventtype.py:190
 #: ../gramps/gen/lib/nameorigintype.py:85
-#: ../gramps/gen/plug/docgen/treedoc.py:454
+#: ../gramps/gen/plug/docgen/treedoc.py:451
 #: ../gramps/plugins/gramplet/persondetails.py:163
 msgid "Occupation"
 msgstr "Ocupació"
@@ -7006,20 +7025,19 @@ msgstr "Sobrenom"
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:209
 #: ../gramps/gui/filters/sidebar/_mediasidebarfilter.py:155
 #: ../gramps/gui/filters/sidebar/_notesidebarfilter.py:154
-#: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:252
+#: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:257
 #: ../gramps/gui/filters/sidebar/_placesidebarfilter.py:191
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:171
 #: ../gramps/gui/filters/sidebar/_sourcesidebarfilter.py:154
 #: ../gramps/gui/glade/editplaceformat.glade:185
-#: ../gramps/plugins/graph/gvfamilylines.py:82
+#: ../gramps/plugins/graph/gvfamilylines.py:83
 #: ../gramps/plugins/tool/check.py:2494
 msgid "None"
 msgstr "Cap"
 
 #: ../gramps/gen/lib/childreftype.py:68 ../gramps/gen/lib/eventtype.py:165
 #: ../gramps/gen/utils/symbols.py:72 ../gramps/gui/merge/mergeperson.py:189
-#: ../gramps/plugins/export/exportvcalendar.py:156
-#: ../gramps/plugins/export/exportvcalendar.py:161
+#: ../gramps/plugins/export/exportvcalendar.py:151
 #: ../gramps/plugins/gramplet/ancestor.py:64
 #: ../gramps/plugins/gramplet/descendant.py:63
 #: ../gramps/plugins/importer/importprogen.glade:1472
@@ -7096,7 +7114,7 @@ msgstr "Cita"
 #: ../gramps/plugins/webreport/event.py:178
 #: ../gramps/plugins/webreport/event.py:391
 #: ../gramps/plugins/webreport/media.py:541
-#: ../gramps/plugins/webreport/person.py:1476
+#: ../gramps/plugins/webreport/person.py:1483
 #: ../gramps/plugins/webreport/repository.py:245
 #: ../gramps/plugins/webreport/source.py:261
 msgid "Gramps ID"
@@ -7255,7 +7273,7 @@ msgid "age|about"
 msgstr "al voltant de"
 
 #: ../gramps/gen/lib/date.py:295 ../gramps/gen/lib/date.py:339
-#: ../gramps/gen/lib/date.py:358 ../gramps/plugins/webreport/basepage.py:2924
+#: ../gramps/gen/lib/date.py:358 ../gramps/plugins/webreport/basepage.py:2932
 msgid "between"
 msgstr "entre"
 
@@ -7264,7 +7282,7 @@ msgstr "entre"
 #: ../gramps/plugins/quickview/all_relations.py:282
 #: ../gramps/plugins/view/relview.py:1159
 #: ../gramps/plugins/webreport/basepage.py:846
-#: ../gramps/plugins/webreport/basepage.py:2925
+#: ../gramps/plugins/webreport/basepage.py:2933
 msgid "and"
 msgstr "i"
 
@@ -7363,15 +7381,18 @@ msgid "date-modifier|none"
 msgstr "cap"
 
 #: ../gramps/gen/lib/date.py:1872 ../gramps/plugins/lib/libsubstkeyword.py:314
+#: ../gramps/plugins/webreport/basepage.py:2941
 msgid "about"
 msgstr "al voltant de"
 
 #: ../gramps/gen/lib/date.py:1872 ../gramps/plugins/lib/libprogen.py:1839
 #: ../gramps/plugins/lib/libsubstkeyword.py:313
+#: ../gramps/plugins/webreport/basepage.py:2937
 msgid "after"
 msgstr "després de"
 
 #: ../gramps/gen/lib/date.py:1872 ../gramps/plugins/lib/libsubstkeyword.py:313
+#: ../gramps/plugins/webreport/basepage.py:2939
 msgid "before"
 msgstr "abans de"
 
@@ -7572,8 +7593,7 @@ msgid "Other"
 msgstr "Un altre"
 
 #: ../gramps/gen/lib/eventtype.py:166 ../gramps/gui/merge/mergeperson.py:194
-#: ../gramps/plugins/export/exportvcalendar.py:174
-#: ../gramps/plugins/export/exportvcalendar.py:179
+#: ../gramps/plugins/export/exportvcalendar.py:160
 #: ../gramps/plugins/importer/importprogen.glade:1491
 #: ../gramps/plugins/textreport/familygroup.py:328
 #: ../gramps/plugins/textreport/familygroup.py:534
@@ -7702,11 +7722,10 @@ msgstr "Jubilació"
 msgid "Will"
 msgstr "Testament"
 
-#. feature requests 2356, 1657: avoid genitive form
 #: ../gramps/gen/lib/eventtype.py:198 ../gramps/gen/plug/docgen/treedoc.py:150
 #: ../gramps/gen/utils/symbols.py:75 ../gramps/gui/merge/mergeperson.py:258
 #: ../gramps/plugins/export/exportcsv.py:465
-#: ../gramps/plugins/export/exportvcalendar.py:136
+#: ../gramps/plugins/export/exportvcalendar.py:138
 #: ../gramps/plugins/importer/importcsv.py:235
 #: ../gramps/plugins/textreport/familygroup.py:406
 #: ../gramps/plugins/textreport/familygroup.py:415
@@ -7969,7 +7988,7 @@ msgstr "annul."
 #: ../gramps/plugins/textreport/tagreport.py:252
 #: ../gramps/plugins/view/familyview.py:80
 #: ../gramps/plugins/view/relview.py:1069
-#: ../gramps/plugins/webreport/person.py:1637
+#: ../gramps/plugins/webreport/person.py:1644
 msgid "Father"
 msgstr "Pare"
 
@@ -7991,7 +8010,7 @@ msgstr "Pare"
 #: ../gramps/plugins/textreport/tagreport.py:258
 #: ../gramps/plugins/view/familyview.py:81
 #: ../gramps/plugins/view/relview.py:1070
-#: ../gramps/plugins/webreport/person.py:1650
+#: ../gramps/plugins/webreport/person.py:1657
 msgid "Mother"
 msgstr "Mare"
 
@@ -8001,7 +8020,7 @@ msgstr "Mare"
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:869
 #: ../gramps/plugins/textreport/familygroup.py:646
 #: ../gramps/plugins/textreport/indivcomplete.py:678
-#: ../gramps/plugins/view/pedigreeview.py:1829
+#: ../gramps/plugins/view/pedigreeview.py:1830
 #: ../gramps/plugins/view/relview.py:1595
 #: ../gramps/plugins/webreport/basepage.py:381
 msgid "Children"
@@ -8020,7 +8039,7 @@ msgstr "Fills"
 #: ../gramps/plugins/webreport/basepage.py:1650
 #: ../gramps/plugins/webreport/event.py:141
 #: ../gramps/plugins/webreport/event.py:366
-#: ../gramps/plugins/webreport/person.py:1535
+#: ../gramps/plugins/webreport/person.py:1542
 msgid "Events"
 msgstr "Esdeveniments"
 
@@ -8029,7 +8048,7 @@ msgid "LDS ordinances"
 msgstr "Ordenances de l'església mormona"
 
 #: ../gramps/gen/lib/familyreltype.py:47
-#: ../gramps/plugins/webreport/webcal.py:2114
+#: ../gramps/plugins/webreport/webcal.py:2115
 msgid "Married"
 msgstr "Casat"
 
@@ -8299,7 +8318,7 @@ msgstr "Regió"
 #: ../gramps/plugins/tool/removeunused.py:201
 #: ../gramps/plugins/tool/verify.py:579 ../gramps/plugins/view/repoview.py:85
 #: ../gramps/plugins/webreport/basepage.py:397
-#: ../gramps/plugins/webreport/person.py:1861
+#: ../gramps/plugins/webreport/person.py:1868
 msgid "Name"
 msgstr "Nom"
 
@@ -8391,7 +8410,7 @@ msgstr "%(surname)s, %(first)s %(suffix)s"
 #. translators: needed for Arabic, ignore otherwise
 #: ../gramps/gen/lib/name.py:465 ../gramps/gen/lib/name.py:480
 #: ../gramps/gen/plug/report/utils.py:257
-#: ../gramps/plugins/graph/gvfamilylines.py:490
+#: ../gramps/plugins/graph/gvfamilylines.py:491
 #: ../gramps/plugins/textreport/detancestralreport.py:454
 #: ../gramps/plugins/textreport/detdescendantreport.py:487
 #: ../gramps/plugins/textreport/indivcomplete.py:202
@@ -8475,7 +8494,7 @@ msgstr "Nom de Casat"
 #: ../gramps/gui/glade/editnote.glade:326 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/views/treemodels/mediamodel.py:117
 #: ../gramps/plugins/drawreport/ancestortree.py:974
-#: ../gramps/plugins/drawreport/descendtree.py:1701
+#: ../gramps/plugins/drawreport/descendtree.py:1707
 #: ../gramps/plugins/export/exportcsv.py:361
 #: ../gramps/plugins/export/exportcsv.py:466
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:112
@@ -8655,7 +8674,7 @@ msgstr "Nota de Referència a Fill"
 #: ../gramps/plugins/tool/reorderids.glade:761
 #: ../gramps/plugins/webreport/event.py:180
 #: ../gramps/plugins/webreport/family.py:188
-#: ../gramps/plugins/webreport/person.py:1246
+#: ../gramps/plugins/webreport/person.py:1253
 msgid "Person"
 msgstr "Persona"
 
@@ -8669,7 +8688,7 @@ msgstr "Persona"
 #: ../gramps/plugins/lib/libpersonview.py:100
 #: ../gramps/plugins/quickview/siblings.py:48
 #: ../gramps/plugins/textreport/indivcomplete.py:928
-#: ../gramps/plugins/webreport/person.py:1487
+#: ../gramps/plugins/webreport/person.py:1494
 msgid "Gender"
 msgstr "Gènere"
 
@@ -8689,9 +8708,9 @@ msgstr "Índex de la referència de naixement"
 msgid "Event references"
 msgstr "Referències d'esdeveniments"
 
-#: ../gramps/gen/lib/person.py:199 ../gramps/plugins/graph/gvfamilylines.py:292
-#: ../gramps/plugins/graph/gvhourglass.py:432
-#: ../gramps/plugins/graph/gvrelgraph.py:954
+#: ../gramps/gen/lib/person.py:199 ../gramps/plugins/graph/gvfamilylines.py:293
+#: ../gramps/plugins/graph/gvhourglass.py:434
+#: ../gramps/plugins/graph/gvrelgraph.py:957
 #: ../gramps/plugins/quickview/filterbyname.py:94
 #: ../gramps/plugins/quickview/filterbyname.py:119
 #: ../gramps/plugins/textreport/indivcomplete.py:641
@@ -9177,11 +9196,11 @@ msgstr "Un progenitor ha de ser o un pare o una mare."
 #: ../gramps/gen/merge/test/merge_ref_test.py:1923
 #: ../gramps/gen/merge/test/merge_ref_test.py:1947
 msgid ""
-"A parent and child cannot be merged. To merge these people, you must first "
-"break the relationship between them."
+"A parent and child cannot be merged. To merge these people, you must first"
+" break the relationship between them."
 msgstr ""
-"Un pare i un fill no es poden combinar. Per combinar aquestes persones, "
-"primer cal trencar la relació entre ells."
+"Un pare i un fill no es poden combinar. Per combinar aquestes persones,"
+" primer cal trencar la relació entre ells."
 
 #: ../gramps/gen/merge/mergefamilyquery.py:135
 msgid "Merge Family"
@@ -9198,11 +9217,11 @@ msgstr "Combina Notes"
 
 #: ../gramps/gen/merge/mergepersonquery.py:51
 msgid ""
-"Spouses cannot be merged. To merge these people, you must first break the "
-"relationship between them."
+"Spouses cannot be merged. To merge these people, you must first break the"
+" relationship between them."
 msgstr ""
-"Els cònjuges no es poden combinar. Per combinar aquestes persones, primer "
-"cal trencar la relació entre ells."
+"Els cònjuges no es poden combinar. Per combinar aquestes persones, primer cal"
+" trencar la relació entre ells."
 
 #: ../gramps/gen/merge/mergepersonquery.py:118
 msgid "Merge Person"
@@ -9305,9 +9324,8 @@ msgid "Sidebar"
 msgstr "Barra lateral"
 
 #: ../gramps/gen/plug/_pluginreg.py:92
-#, fuzzy
 msgid "Rule"
-msgstr "Afegeix Regla"
+msgstr "Regla"
 
 #. add miscellaneous column
 #: ../gramps/gen/plug/_pluginreg.py:528
@@ -9328,21 +9346,22 @@ msgstr "ERROR: Problema llegint el registre del connector %(filename)s"
 #: ../gramps/gen/plug/_pluginreg.py:1187
 #, python-format
 msgid ""
-"WARNING: Plugin %(plugin_name)s has no translation for any of your "
-"configured languages, using US English instead"
+"WARNING: Plugin %(plugin_name)s has no translation for any of your configured"
+" languages, using US English instead"
 msgstr ""
-"Avís: el connector %(plugin_name)s no té traducció per cap de les llengües "
-"que teniu configurades, s'utilitzarà l'anglès americà"
+"Avís: el connector %(plugin_name)s no té traducció per cap de les llengües"
+" que teniu configurades, s'utilitzarà l'anglès americà"
 
 #: ../gramps/gen/plug/_pluginreg.py:1224
 #, python-format
 msgid ""
-"ERROR: Plugin file %(filename)s has a version of \"%(gramps_target_version)s"
-"\" which is invalid for Gramps \"%(gramps_version)s\"."
+"ERROR: Plugin file %(filename)s has a version of \""
+"%(gramps_target_version)s\" which is invalid for Gramps \""
+"%(gramps_version)s\"."
 msgstr ""
-"ERROR: El fitxer de connector %(filename)s té una versió de "
-"\"%(gramps_target_version)s\" que no és vàlida per a Gramps "
-"\"%(gramps_version)s\"."
+"ERROR: El fitxer de connector %(filename)s té una versió de \""
+"%(gramps_target_version)s\" que no és vàlida per a Gramps \""
+"%(gramps_version)s\"."
 
 #: ../gramps/gen/plug/_pluginreg.py:1245
 #, python-format
@@ -9356,8 +9375,8 @@ msgstr ""
 msgid ""
 "ERROR: Python file %(filename)s in register file %(regfile)s does not exist"
 msgstr ""
-"ERROR: El fitxer de python %(filename)s al fitxer de registre %(regfile)s no "
-"existeix"
+"ERROR: El fitxer de python %(filename)s al fitxer de registre %(regfile)s no"
+" existeix"
 
 #: ../gramps/gen/plug/docbackend/docbackend.py:129
 msgid "Close file first"
@@ -9397,19 +9416,19 @@ msgstr "El fitxer %s ja està obert, tanqui'l primer."
 #: ../gramps/plugins/docgen/svgdrawdoc.py:91
 #: ../gramps/plugins/export/exportcsv.py:261
 #: ../gramps/plugins/export/exportcsv.py:265
-#: ../gramps/plugins/export/exportftree.py:135
+#: ../gramps/plugins/export/exportftree.py:136
 #: ../gramps/plugins/export/exportgedcom.py:1602
-#: ../gramps/plugins/export/exportgeneweb.py:108
-#: ../gramps/plugins/export/exportgeneweb.py:112
-#: ../gramps/plugins/export/exportvcalendar.py:120
-#: ../gramps/plugins/export/exportvcalendar.py:124
+#: ../gramps/plugins/export/exportgeneweb.py:109
+#: ../gramps/plugins/export/exportgeneweb.py:113
+#: ../gramps/plugins/export/exportvcalendar.py:123
+#: ../gramps/plugins/export/exportvcalendar.py:127
 #: ../gramps/plugins/export/exportvcard.py:71
 #: ../gramps/plugins/export/exportvcard.py:75
 #: ../gramps/plugins/lib/libhtmlbackend.py:249
 #: ../gramps/plugins/lib/libhtmlbackend.py:253
 #: ../gramps/plugins/lib/libhtmlbackend.py:259
 #: ../gramps/plugins/lib/libhtmlbackend.py:263
-#: ../gramps/plugins/webreport/narrativeweb.py:333
+#: ../gramps/plugins/webreport/narrativeweb.py:332
 #, python-format
 msgid "Could not create %s"
 msgstr "No s'ha pogut crear %s"
@@ -9440,22 +9459,22 @@ msgid "TrueType / FreeSans"
 msgstr "Truetype / FreeSans"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:72
-#: ../gramps/plugins/view/pedigreeview.py:2119
+#: ../gramps/plugins/view/pedigreeview.py:2120
 msgid "Vertical (↓)"
 msgstr "Vertical (↓)"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:73
-#: ../gramps/plugins/view/pedigreeview.py:2120
+#: ../gramps/plugins/view/pedigreeview.py:2121
 msgid "Vertical (↑)"
 msgstr "Vertical (↑)"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:74
-#: ../gramps/plugins/view/pedigreeview.py:2121
+#: ../gramps/plugins/view/pedigreeview.py:2122
 msgid "Horizontal (→)"
 msgstr "Horitzontal (→)"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:75
-#: ../gramps/plugins/view/pedigreeview.py:2122
+#: ../gramps/plugins/view/pedigreeview.py:2123
 msgid "Horizontal (←)"
 msgstr "Horitzontal (←)"
 
@@ -9540,12 +9559,12 @@ msgstr "Família de lletra"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:146
 msgid ""
-"Choose the font family. If international characters don't show, use FreeSans "
-"font. FreeSans is available from: http://www.nongnu.org/freefont/"
+"Choose the font family. If international characters don't show, use FreeSans"
+" font. FreeSans is available from: http://www.nongnu.org/freefont/"
 msgstr ""
-"Tria la família de lletra. Si els caràcters internacionals no apareixen, "
-"faci servir el tipus FreeSans. FreeSans es pot obtenir a: http://www.nongnu."
-"org/freefont/"
+"Tria la família de lletra. Si els caràcters internacionals no apareixen, faci"
+" servir el tipus FreeSans. FreeSans es pot obtenir a:"
+" http://www.nongnu.org/freefont/"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:152
 #: ../gramps/gui/widgets/styledtexteditor.py:78
@@ -9570,13 +9589,13 @@ msgstr "Nombre de Pàgines en Horitzontal"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:164
 msgid ""
-"Graphviz can create very large graphs by spreading the graph across a "
-"rectangular array of pages. This controls the number pages in the array "
-"horizontally. Only valid for dot and pdf via Ghostscript."
+"Graphviz can create very large graphs by spreading the graph across a"
+" rectangular array of pages. This controls the number pages in the array"
+" horizontally. Only valid for dot and pdf via Ghostscript."
 msgstr ""
-"Graphviz pot crear grafs molt grans estenent el graf per una graella "
-"rectangular de pàgines. Això controla el nombre de pàgines de la graella en "
-"horitzontal. Només és vàlid per dot i pdf via Ghostscript."
+"Graphviz pot crear grafs molt grans estenent el graf per una graella"
+" rectangular de pàgines. Això controla el nombre de pàgines de la graella en"
+" horitzontal. Només és vàlid per dot i pdf via Ghostscript."
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:171
 msgid "Number of Vertical Pages"
@@ -9584,13 +9603,13 @@ msgstr "Nombre de Pàgines en Vertical"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:172
 msgid ""
-"Graphviz can create very large graphs by spreading the graph across a "
-"rectangular array of pages. This controls the number pages in the array "
-"vertically. Only valid for dot and pdf via Ghostscript."
+"Graphviz can create very large graphs by spreading the graph across a"
+" rectangular array of pages. This controls the number pages in the array"
+" vertically. Only valid for dot and pdf via Ghostscript."
 msgstr ""
-"Graphviz pot crear grafs molt grans estenent el graf per una graella "
-"rectangular de pàgines. Això controla el nombre de pàgines de la graella en "
-"vertical. Només és vàlid per dot i pdf via Ghostscript."
+"Graphviz pot crear grafs molt grans estenent el graf per una graella"
+" rectangular de pàgines. Això controla el nombre de pàgines de la graella en"
+" vertical. Només és vàlid per dot i pdf via Ghostscript."
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:179
 msgid "Paging Direction"
@@ -9598,11 +9617,11 @@ msgstr "Direcció de Paginació"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:182
 msgid ""
-"The order in which the graph pages are output. This option only applies if "
-"the horizontal pages or vertical pages are greater than 1."
+"The order in which the graph pages are output. This option only applies if"
+" the horizontal pages or vertical pages are greater than 1."
 msgstr ""
-"L'ordre en què es generen les pàgines del graf. Aquesta opció només té "
-"sentit si les pàgines en horitzontal o vertical són més grans que 1."
+"L'ordre en què es generen les pàgines del graf. Aquesta opció només té sentit"
+" si les pàgines en horitzontal o vertical són més grans que 1."
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:187
 msgid "Connecting lines"
@@ -9637,31 +9656,31 @@ msgid ""
 "Affects node spacing and scaling of the graph.\n"
 "If the graph is smaller than the print area:\n"
 "  Compress will not change the node spacing. \n"
-"  Fill will increase the node spacing to fit the print area in both width "
-"and height.\n"
-"  Expand will increase the node spacing uniformly to preserve the aspect "
-"ratio.\n"
+"  Fill will increase the node spacing to fit the print area in both width and"
+" height.\n"
+"  Expand will increase the node spacing uniformly to preserve the aspect"
+" ratio.\n"
 "If the graph is larger than the print area:\n"
-"  Compress will shrink the graph to achieve tight packing at the expense of "
-"symmetry.\n"
-"  Fill will shrink the graph to fit the print area after first increasing "
-"the node spacing.\n"
+"  Compress will shrink the graph to achieve tight packing at the expense of"
+" symmetry.\n"
+"  Fill will shrink the graph to fit the print area after first increasing the"
+" node spacing.\n"
 "  Expand will shrink the graph uniformly to fit the print area."
 msgstr ""
 "Afecta l'espai entre nodes i l'escalat del graf.\n"
 "Si el graf és més petit que l'àrea d'impressió:\n"
 " Comprimir no modificarà l'espaiat entre nodes.\n"
-" Omplir augmentarà l'espaiat entre nodes per què càpiga dins de l'àrea "
-"d'impressió tant en amplada com en llargada.\n"
-" Expandir augmentarà l'espaiat entre nodes de manera uniforme per conservar "
-"la proporció.\n"
+" Omplir augmentarà l'espaiat entre nodes per què càpiga dins de l'àrea"
+" d'impressió tant en amplada com en llargada.\n"
+" Expandir augmentarà l'espaiat entre nodes de manera uniforme per conservar"
+" la proporció.\n"
 "Si el graf és més gran que l'àrea d'impressió:\n"
-" Comprimir encongirà el graf per aconseguir que càpiga en poc espai encara "
-"que es perdi simetria.\n"
-" Omplir encongirà el graf perquè càpiga dins de l'àrea d'impressió després "
-"d'haver augmentat l'espaiat entre nodes.\n"
-" Expandir encongirà el graf de manera uniforme perquè càpiga dins de l'àrea "
-"d'impressió."
+" Comprimir encongirà el graf per aconseguir que càpiga en poc espai encara"
+" que es perdi simetria.\n"
+" Omplir encongirà el graf perquè càpiga dins de l'àrea d'impressió després"
+" d'haver augmentat l'espaiat entre nodes.\n"
+" Expandir encongirà el graf de manera uniforme perquè càpiga dins de l'àrea"
+" d'impressió."
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:233
 msgid "DPI"
@@ -9669,13 +9688,13 @@ msgstr "DPI"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:234
 msgid ""
-"Dots per inch.  When creating images such as .gif or .png files for the web, "
-"try numbers such as 100 or 300 DPI.  PostScript and PDF files always use 72 "
-"DPI."
+"Dots per inch.  When creating images such as .gif or .png files for the web,"
+" try numbers such as 100 or 300 DPI.  PostScript and PDF files always use 72"
+" DPI."
 msgstr ""
-"Punts per polzada. Quan es creen imatges com ara .gif o .png per al web, "
-"proveu nombres com 100 o 300 DPI. Els fitxers Postcript i PDF sempre fan "
-"servir 72 DPI."
+"Punts per polzada. Quan es creen imatges com ara .gif o .png per al web,"
+" proveu nombres com 100 o 300 DPI. Els fitxers Postcript i PDF sempre fan"
+" servir 72 DPI."
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:241
 msgid "Node spacing"
@@ -9683,13 +9702,13 @@ msgstr "Espai entre nodes"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:242
 msgid ""
-"The minimum amount of free space, in inches, between individual nodes.  For "
-"vertical graphs, this corresponds to spacing between columns.  For "
-"horizontal graphs, this corresponds to spacing between rows."
+"The minimum amount of free space, in inches, between individual nodes.  For"
+" vertical graphs, this corresponds to spacing between columns.  For"
+" horizontal graphs, this corresponds to spacing between rows."
 msgstr ""
-"La quantitat mínima d'espai lliure, en polzades, entre nodes individuals. "
-"Per a grafs verticals, això correspon a l'espaiat entre columnes. Per als "
-"horitzontals, correspon a l'espaiat entre files."
+"La quantitat mínima d'espai lliure, en polzades, entre nodes individuals. Per"
+" a grafs verticals, això correspon a l'espaiat entre columnes. Per als"
+" horitzontals, correspon a l'espaiat entre files."
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:249
 msgid "Rank spacing"
@@ -9697,13 +9716,13 @@ msgstr "Espai entre rangs"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:250
 msgid ""
-"The minimum amount of free space, in inches, between ranks.  For vertical "
-"graphs, this corresponds to spacing between rows.  For horizontal graphs, "
-"this corresponds to spacing between columns."
+"The minimum amount of free space, in inches, between ranks.  For vertical"
+" graphs, this corresponds to spacing between rows.  For horizontal graphs,"
+" this corresponds to spacing between columns."
 msgstr ""
-"La quantitat mínima d'espai lliure, en polzades, entre rangs. Per a grafs "
-"verticals, això correspon a l'espaiat entre files. Per als horitzontals, "
-"correspon a l'espaiat entre columnes."
+"La quantitat mínima d'espai lliure, en polzades, entre rangs. Per a grafs"
+" verticals, això correspon a l'espaiat entre files. Per als horitzontals,"
+" correspon a l'espaiat entre columnes."
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:257
 msgid "Use subgraphs"
@@ -9711,12 +9730,12 @@ msgstr "Utilitza subgrafs"
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:258
 msgid ""
-"Subgraphs can help Graphviz position spouses together, but with non-trivial "
-"graphs will result in longer lines and larger graphs."
+"Subgraphs can help Graphviz position spouses together, but with non-trivial"
+" graphs will result in longer lines and larger graphs."
 msgstr ""
-"Els subgrafs poden ajudar a Graphviz a col·locar els cònjuges junts, però "
-"per grafs no trivials donarà com a resultat línies més llargues i grafs més "
-"grans."
+"Els subgrafs poden ajudar a Graphviz a col·locar els cònjuges junts, però per"
+" grafs no trivials donarà com a resultat línies més llargues i grafs més"
+" grans."
 
 #. ###############################
 #: ../gramps/gen/plug/docgen/graphdoc.py:268
@@ -9795,15 +9814,6 @@ msgstr "Legal"
 msgid "Custom Size"
 msgstr "Mida Personalitzada"
 
-#. -------------------------------------------------------------------------
-#.
-#. Private Constants
-#.
-#. -------------------------------------------------------------------------
-#: ../gramps/gen/plug/docgen/treedoc.py:63
-msgid "Full"
-msgstr "Sencer"
-
 #: ../gramps/gen/plug/docgen/treedoc.py:64
 #: ../gramps/plugins/tool/finddupes.py:61
 msgid "Medium"
@@ -9881,13 +9891,13 @@ msgstr "Petit"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:93 ../gramps/gen/utils/string.py:57
 #: ../gramps/gui/editors/editcitation.py:214
-#: ../gramps/plugins/graph/gvfamilylines.py:262
+#: ../gramps/plugins/graph/gvfamilylines.py:263
 #: ../gramps/plugins/importer/importprogen.py:487
 msgid "Normal"
 msgstr "Normal"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:94
-#: ../gramps/plugins/graph/gvfamilylines.py:263
+#: ../gramps/plugins/graph/gvfamilylines.py:264
 msgid "Large"
 msgstr "Gran"
 
@@ -9931,11 +9941,11 @@ msgstr "Mida del node"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:157
 msgid ""
-"One dimension of a node, in mm. If the timeflow is up or down then this is "
-"the width, otherwise it is the height."
+"One dimension of a node, in mm. If the timeflow is up or down then this is"
+" the width, otherwise it is the height."
 msgstr ""
-"Una mida d'un node, en mm. Si el fluxe de temps està per sobre o per sota, "
-"aleshores això és l'amplada, d'altra manera és l'alçada."
+"Una mida d'un node, en mm. Si el fluxe de temps està per sobre o per sota,"
+" aleshores això és l'amplada, d'altra manera és l'alçada."
 
 #: ../gramps/gen/plug/docgen/treedoc.py:162
 msgid "Level size"
@@ -9943,11 +9953,11 @@ msgstr "Mida del nivell"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:163
 msgid ""
-"One dimension of a node, in mm. If the timeflow is up or down then this is "
-"the height, otherwise it is the width."
+"One dimension of a node, in mm. If the timeflow is up or down then this is"
+" the height, otherwise it is the width."
 msgstr ""
-"Una mida d'un node, en mm. Si el fluxe de temps està per sobre o per sota, "
-"aleshores això és l'alçada, d'altra manera és l'amplada."
+"Una mida d'un node, en mm. Si el fluxe de temps està per sobre o per sota,"
+" aleshores això és l'alçada, d'altra manera és l'amplada."
 
 #: ../gramps/gen/plug/docgen/treedoc.py:171
 msgid "Node color."
@@ -9957,7 +9967,7 @@ msgstr "Color del node."
 #. #################
 #: ../gramps/gen/plug/docgen/treedoc.py:175
 #: ../gramps/plugins/drawreport/ancestortree.py:791
-#: ../gramps/plugins/drawreport/descendtree.py:1527
+#: ../gramps/plugins/drawreport/descendtree.py:1533
 msgid "Tree Options"
 msgstr "Opcions d'Arbre"
 
@@ -9984,13 +9994,13 @@ msgstr "Distància del nivell"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:191
 msgid ""
-"The minimum amount of free space, in mm, between levels.  For vertical "
-"graphs, this corresponds to spacing between rows.  For horizontal graphs, "
-"this corresponds to spacing between columns."
+"The minimum amount of free space, in mm, between levels.  For vertical"
+" graphs, this corresponds to spacing between rows.  For horizontal graphs,"
+" this corresponds to spacing between columns."
 msgstr ""
-"La quantitat mínima d'espai lliure, en mm, entre nivells.  Per a grafs "
-"verticals, això correspon a l'espaiat entre files.  Per als horitzontals, "
-"correspon a l'espaiat entre columnes."
+"La quantitat mínima d'espai lliure, en mm, entre nivells.  Per a grafs"
+" verticals, això correspon a l'espaiat entre files.  Per als horitzontals,"
+" correspon a l'espaiat entre columnes."
 
 #. ###############################
 #: ../gramps/gen/plug/docgen/treedoc.py:202
@@ -10005,11 +10015,11 @@ msgstr "Aquest text s'afegirà a l'arbre."
 msgid "The size of note text."
 msgstr "La mida del text de la nota."
 
-#: ../gramps/gen/plug/docgen/treedoc.py:655
+#: ../gramps/gen/plug/docgen/treedoc.py:652
 msgid "PDF"
 msgstr "PDF"
 
-#: ../gramps/gen/plug/docgen/treedoc.py:661
+#: ../gramps/gen/plug/docgen/treedoc.py:658
 msgid "LaTeX File"
 msgstr "Arxiu LaTeX"
 
@@ -10094,8 +10104,8 @@ msgstr "L'estil bàsic utilitzat per mostrar la referència de les notes finals.
 #: ../gramps/gen/plug/report/endnotes.py:92
 msgid "The basic style used for the endnotes reference notes display."
 msgstr ""
-"L'estil bàsic utilitzat per mostrar les notes de referència de les notes "
-"finals."
+"L'estil bàsic utilitzat per mostrar les notes de referència de les notes"
+" finals."
 
 #: ../gramps/gen/plug/report/endnotes.py:156
 msgid "Endnotes"
@@ -10158,12 +10168,12 @@ msgid "The translation to be used for the report."
 msgstr "La traducció que s'ha de fer servir per a l'informe."
 
 #: ../gramps/gen/plug/report/stdoptions.py:73 ../gramps/gui/configure.py:1194
-#: ../gramps/plugins/webreport/webcal.py:1720
+#: ../gramps/plugins/webreport/webcal.py:1721
 msgid "Name format"
 msgstr "Format de nom"
 
 #: ../gramps/gen/plug/report/stdoptions.py:78
-#: ../gramps/plugins/webreport/webcal.py:1724
+#: ../gramps/plugins/webreport/webcal.py:1725
 msgid "Select the format to display names"
 msgstr "Selecciona el format per mostrar els noms"
 
@@ -10243,13 +10253,13 @@ msgstr "Si s'ha d'incloure (i on) l'ID Gramps"
 #. ###############################
 #: ../gramps/gen/plug/report/stdoptions.py:328
 #: ../gramps/gui/viewmanager.py:1722
-#: ../gramps/plugins/graph/gvfamilylines.py:218
-#: ../gramps/plugins/graph/gvrelgraph.py:859
+#: ../gramps/plugins/graph/gvfamilylines.py:219
+#: ../gramps/plugins/graph/gvrelgraph.py:862
 #: ../gramps/plugins/textreport/detancestralreport.py:900
 #: ../gramps/plugins/textreport/detdescendantreport.py:1085
 #: ../gramps/plugins/textreport/familygroup.py:752
 #: ../gramps/plugins/textreport/indivcomplete.py:1102
-#: ../gramps/plugins/webreport/narrativeweb.py:1993
+#: ../gramps/plugins/webreport/narrativeweb.py:1997
 msgid "Include"
 msgstr "Incloure"
 
@@ -10373,11 +10383,6 @@ msgstr "Error: tipus de fitxer desconegut: '%s'"
 msgid "Examining '%s'..."
 msgstr "S'està xaminant '%s'..."
 
-#: ../gramps/gen/plug/utils.py:339
-#, python-format
-msgid "Error in '%s' file: cannot load."
-msgstr "Error en fitxer '%s': no es pot carregar."
-
 #: ../gramps/gen/plug/utils.py:353
 #, python-format
 msgid "'%s' is for this version of Gramps."
@@ -10425,16 +10430,16 @@ msgstr ""
 msgid ""
 "Error parsing list of recent DBs from file {fname}: {error}.\n"
 "This might indicate a damage to your files.\n"
-"If you're sure there is no problem with other files, delete it, and restart "
-"Gramps."
+"If you're sure there is no problem with other files, delete it, and restart"
+" Gramps."
 msgstr ""
 "Error analitzant la llista de BDs recents de l'arxiu {fname}: {error}.\n"
 "Això pot indicar que els seus arxius estan malmesos.\n"
-"Si està segur que no hi cap problema amb altres arxius, borri'l, i reiniciï "
-"Gramps."
+"Si està segur que no hi cap problema amb altres arxius, borri'l, i reiniciï"
+" Gramps."
 
 #: ../gramps/gen/relationship.py:1273
-#: ../gramps/plugins/view/pedigreeview.py:1600
+#: ../gramps/plugins/view/pedigreeview.py:1601
 msgid "Relationship loop detected"
 msgstr "Bucle de parentesc detectat"
 
@@ -10444,8 +10449,8 @@ msgid ""
 "Family Tree reaches back more than the maximum %d generations searched.\n"
 "It is possible that relationships have been missed"
 msgstr ""
-"L'Arbre Genealògic es remunta més enrere que el màxim de %d generacions "
-"buscades.\n"
+"L'Arbre Genealògic es remunta més enrere que el màxim de %d generacions"
+" buscades.\n"
 "És possible que no s'hagi detectat algun parentesc"
 
 #: ../gramps/gen/relationship.py:1406
@@ -10562,11 +10567,11 @@ msgstr "antic company"
 #: ../gramps/gen/relationship.py:2318
 #, python-format
 msgid ""
-"Family relationship translator not available for language '%s'. Using "
-"'english' instead."
+"Family relationship translator not available for language '%s'. Using"
+" 'english' instead."
 msgstr ""
-"El traductor de parentescos familiars no està disponible per a la llengua "
-"'%s'. S'utilitza l'anglès en comptes d'aquest."
+"El traductor de parentescos familiars no està disponible per a la llengua '"
+"%s'. S'utilitza l'anglès en comptes d'aquest."
 
 #: ../gramps/gen/utils/alive.py:145 ../gramps/plugins/importer/importcsv.py:202
 msgid "death date"
@@ -10903,11 +10908,11 @@ msgstr "Veure detalls"
 
 #: ../gramps/gen/utils/image.py:123
 msgid ""
-"WARNING: PIL module not loaded.  Image cropping in report files will be "
-"impaired."
+"WARNING: PIL module not loaded.  Image cropping in report files will be"
+" impaired."
 msgstr ""
-"AVÍS: No s'ha carregat el mòdul PIL. La funcionalitat de retall d'imatges "
-"als fitxers d'informe no estarà disponible."
+"AVÍS: No s'ha carregat el mòdul PIL. La funcionalitat de retall d'imatges als"
+" fitxers d'informe no estarà disponible."
 
 #: ../gramps/gen/utils/keyword.py:54
 msgid "Person|TITLE"
@@ -11143,15 +11148,15 @@ msgstr "Una relació no especificada entre home i dona"
 
 #: ../gramps/gen/utils/string.py:77
 msgid ""
-"The data can only be recovered by Undo operation or by quitting with "
-"abandoning changes."
+"The data can only be recovered by Undo operation or by quitting with"
+" abandoning changes."
 msgstr ""
-"Les dades només es poden recuperar amb operacions de Desfer o sortint "
-"abandonant els canvis."
+"Les dades només es poden recuperar amb operacions de Desfer o sortint"
+" abandonant els canvis."
 
 #. Name                     UNICODE       SUBSTITUTION
 #: ../gramps/gen/utils/symbols.py:61
-#: ../gramps/plugins/graph/gvfamilylines.py:83
+#: ../gramps/plugins/graph/gvfamilylines.py:84
 #: ../gramps/plugins/textreport/indivcomplete.py:938
 #: ../gramps/plugins/tool/dumpgenderstats.py:73
 #: ../gramps/plugins/tool/dumpgenderstats.py:97
@@ -11160,7 +11165,7 @@ msgid "Female"
 msgstr "Dona"
 
 #: ../gramps/gen/utils/symbols.py:62
-#: ../gramps/plugins/graph/gvfamilylines.py:84
+#: ../gramps/plugins/graph/gvfamilylines.py:85
 #: ../gramps/plugins/textreport/indivcomplete.py:936
 #: ../gramps/plugins/tool/dumpgenderstats.py:72
 #: ../gramps/plugins/tool/dumpgenderstats.py:96
@@ -11170,37 +11175,35 @@ msgstr "Home"
 
 #: ../gramps/gen/utils/symbols.py:63
 msgid "Asexuality, sexless, genderless"
-msgstr ""
+msgstr "Asexualitat, sense sexe, sense gènere"
 
 #: ../gramps/gen/utils/symbols.py:64
 msgid "Lesbianism"
-msgstr ""
+msgstr "Lesbianisme"
 
 #: ../gramps/gen/utils/symbols.py:65
 msgid "Male homosexuality"
-msgstr ""
+msgstr "Homosexualitat masculina"
 
 #: ../gramps/gen/utils/symbols.py:66
 msgid "Heterosexuality"
-msgstr ""
+msgstr "Heterosexualitat"
 
 #: ../gramps/gen/utils/symbols.py:67
 msgid "Transgender, hermaphrodite (in entomology)"
-msgstr ""
+msgstr "Transgènere, hermafrodita (en entomologia)"
 
 #: ../gramps/gen/utils/symbols.py:68
-#, fuzzy
 msgid "Transgender"
-msgstr "gènere"
+msgstr "Transgènere"
 
 #: ../gramps/gen/utils/symbols.py:69
 msgid "Neuter"
-msgstr ""
+msgstr "Neutre"
 
 #: ../gramps/gen/utils/symbols.py:71
-#, fuzzy
 msgid "Illegitimate"
-msgstr "estimat"
+msgstr "Il·legítim"
 
 #: ../gramps/gen/utils/symbols.py:73
 #, fuzzy
@@ -11208,9 +11211,8 @@ msgid "Baptism/Christening"
 msgstr "Baptisme"
 
 #: ../gramps/gen/utils/symbols.py:74
-#, fuzzy
 msgid "Engaged"
-msgstr "Compromís"
+msgstr "Compromès"
 
 #: ../gramps/gen/utils/symbols.py:77
 #, fuzzy
@@ -11218,30 +11220,27 @@ msgid "Unmarried partnership"
 msgstr "company"
 
 #: ../gramps/gen/utils/symbols.py:78
-#, fuzzy
 msgid "Buried"
-msgstr "Enterrament"
+msgstr "Enterrat"
 
 #: ../gramps/gen/utils/symbols.py:79
 msgid "Cremated/Funeral urn"
-msgstr ""
+msgstr "Cremat/Urna funerària"
 
 #: ../gramps/gen/utils/symbols.py:80
-#, fuzzy
 msgid "Killed in action"
-msgstr "Col·lecció"
+msgstr "Mort en combat"
 
 #: ../gramps/gen/utils/symbols.py:81
 msgid "Extinct"
-msgstr ""
+msgstr "Extint"
 
 #. The following is used in the global preferences in the display tab.
 #. Name
 #. UNICODE    SUBSTITUTION
 #: ../gramps/gen/utils/symbols.py:106
-#, fuzzy
 msgid "Nothing"
-msgstr "Dins de"
+msgstr "Res"
 
 #: ../gramps/gen/utils/symbols.py:108
 msgid "Skull and crossbones"
@@ -11249,11 +11248,11 @@ msgstr ""
 
 #: ../gramps/gen/utils/symbols.py:109
 msgid "Ankh"
-msgstr ""
+msgstr "Ankh"
 
 #: ../gramps/gen/utils/symbols.py:110
 msgid "Orthodox cross"
-msgstr ""
+msgstr "Creu ortodoxa"
 
 #: ../gramps/gen/utils/symbols.py:111
 msgid "Chi rho"
@@ -11261,11 +11260,11 @@ msgstr ""
 
 #: ../gramps/gen/utils/symbols.py:112
 msgid "Cross of Lorraine"
-msgstr ""
+msgstr "Creu de Lorena"
 
 #: ../gramps/gen/utils/symbols.py:113
 msgid "Cross of Jerusalem"
-msgstr ""
+msgstr "Creu de Jerusalem"
 
 #: ../gramps/gen/utils/symbols.py:114
 #, fuzzy
@@ -11287,7 +11286,7 @@ msgstr ""
 
 #: ../gramps/gen/utils/symbols.py:118
 msgid "Latin cross"
-msgstr ""
+msgstr "Creu llatina"
 
 #: ../gramps/gen/utils/symbols.py:119
 msgid "Shadowed White Latin cross"
@@ -11295,16 +11294,15 @@ msgstr ""
 
 #: ../gramps/gen/utils/symbols.py:120
 msgid "Maltese cross"
-msgstr ""
+msgstr "Creu de Malta"
 
 #: ../gramps/gen/utils/symbols.py:121
 msgid "Star of David"
-msgstr ""
+msgstr "Estrella de David"
 
 #: ../gramps/gen/utils/symbols.py:122
-#, fuzzy
 msgid "Dead"
-msgstr "Sexe Masculí Mort"
+msgstr "Mort"
 
 #: ../gramps/gen/utils/unknown.py:140
 msgid "Unknown, created to replace a missing note object."
@@ -11320,8 +11318,8 @@ msgstr "Desconegut, li faltava %(time)s (%(count)d)"
 #, python-format
 msgid "Objects referenced by this note were missing in a file imported on %s."
 msgstr ""
-"Els objectes referenciats per aquesta nota no hi eren en un fitxer importat "
-"el %s."
+"Els objectes referenciats per aquesta nota no hi eren en un fitxer importat"
+" el %s."
 
 #: ../gramps/grampsapp.py:172
 #, python-format
@@ -11331,8 +11329,8 @@ msgid ""
 "\n"
 "Gramps will terminate now."
 msgstr ""
-"La versió de Python no compleix els requeriments. Cal almenys la versió de "
-"python %(v1)d.%(v2)d.%(v3)d per executar Gramps.\n"
+"La versió de Python no compleix els requeriments. Cal almenys la versió de"
+" python %(v1)d.%(v2)d.%(v3)d per executar Gramps.\n"
 "\n"
 "Gramps s'aturarà."
 
@@ -11350,13 +11348,13 @@ msgstr "Error llegint configuració"
 msgid ""
 "A definition for the MIME-type %s could not be found \n"
 "\n"
-" Possibly the installation of Gramps was incomplete. Make sure the MIME-"
-"types of Gramps are properly installed."
+" Possibly the installation of Gramps was incomplete. Make sure the MIME-types"
+" of Gramps are properly installed."
 msgstr ""
 "No s'ha pogut trobar la definició per al tipus-MIME %s \n"
 "\n"
-"Possiblement la instal·lació de Gramps és incompleta. Asseguri's que els "
-"tipus-MIME de Gramps estan instal·lats correctament."
+"Possiblement la instal·lació de Gramps és incompleta. Asseguri's que els"
+" tipus-MIME de Gramps estan instal·lats correctament."
 
 #: ../gramps/gui/aboutdialog.py:97
 msgid ""
@@ -11473,8 +11471,8 @@ msgstr "_Aplica"
 #. #################
 #: ../gramps/gui/columnorder.py:128 ../gramps/gui/configure.py:1353
 #: ../gramps/plugins/drawreport/ancestortree.py:909
-#: ../gramps/plugins/drawreport/descendtree.py:1652
-#: ../gramps/plugins/webreport/narrativeweb.py:1766
+#: ../gramps/plugins/drawreport/descendtree.py:1658
+#: ../gramps/plugins/webreport/narrativeweb.py:1770
 msgid "Display"
 msgstr "Visualització"
 
@@ -11523,66 +11521,65 @@ msgstr "_Tanca"
 #: ../gramps/gui/configure.py:119
 msgid ""
 "The following keywords are replaced with the appropriate name parts:<tt>\n"
-"  <b>Given</b>   - given name (first name)     <b>Surname</b>  - surnames "
-"(with prefix and connectors)\n"
-"  <b>Title</b>   - title (Dr., Mrs.)           <b>Suffix</b>   - suffix "
-"(Jr., Sr.)\n"
+"  <b>Given</b>   - given name (first name)     <b>Surname</b>  - surnames"
+" (with prefix and connectors)\n"
+"  <b>Title</b>   - title (Dr., Mrs.)           <b>Suffix</b>   - suffix (Jr.,"
+" Sr.)\n"
 "  <b>Call</b>    - call name                   <b>Nickname</b> - nick name\n"
-"  <b>Initials</b>- first letters of given      <b>Common</b>   - nick name, "
-"call, or first of given\n"
+"  <b>Initials</b>- first letters of given      <b>Common</b>   - nick name,"
+" call, or first of given\n"
 "  <b>Prefix</b>  - all prefixes (von, de)\n"
 "Surnames:\n"
-"  <b>Rest</b>      - non primary surnames    <b>Notpatronymic</b>- all "
-"surnames, except pa/matronymic &amp; primary\n"
-"  <b>Familynick</b>- family nick name        <b>Rawsurnames</b>  - surnames "
-"(no prefixes and connectors)\n"
-"  <b>Primary, Primary[pre] or [sur] or [con]</b>- full primary surname, "
-"prefix, surname only, connector\n"
-"  <b>Patronymic, or [pre] or [sur] or [con]</b> - full pa/matronymic "
-"surname, prefix, surname only, connector\n"
+"  <b>Rest</b>      - non primary surnames    <b>Notpatronymic</b>- all"
+" surnames, except pa/matronymic &amp; primary\n"
+"  <b>Familynick</b>- family nick name        <b>Rawsurnames</b>  - surnames"
+" (no prefixes and connectors)\n"
+"  <b>Primary, Primary[pre] or [sur] or [con]</b>- full primary surname,"
+" prefix, surname only, connector\n"
+"  <b>Patronymic, or [pre] or [sur] or [con]</b> - full pa/matronymic surname,"
+" prefix, surname only, connector\n"
 "</tt>\n"
-"UPPERCASE keyword forces uppercase. Extra parentheses, commas are removed. "
-"Other text appears literally.\n"
+"UPPERCASE keyword forces uppercase. Extra parentheses, commas are removed."
+" Other text appears literally.\n"
 "\n"
-"<b>Example</b>: Dr. Edwin Jose von der Smith and Weston Wilson Sr (\"Ed\") - "
-"Underhills\n"
-"     <i>Edwin Jose</i>: Given, <i>von der</i>: Prefix, <i>Smith</i> and "
-"<i>Weston</i>: Primary, <i>and</i>: [con], <i>Wilson</i>: Patronymic,\n"
-"     <i>Dr.</i>: Title, <i>Sr</i>: Suffix, <i>Ed</i>: Nickname, "
-"<i>Underhills</i>: Familynick, <i>Jose</i>: Call.\n"
+"<b>Example</b>: Dr. Edwin Jose von der Smith and Weston Wilson Sr (\"Ed\") -"
+" Underhills\n"
+"     <i>Edwin Jose</i>: Given, <i>von der</i>: Prefix, <i>Smith</i> and <i"
+">Weston</i>: Primary, <i>and</i>: [con], <i>Wilson</i>: Patronymic,\n"
+"     <i>Dr.</i>: Title, <i>Sr</i>: Suffix, <i>Ed</i>: Nickname, <i"
+">Underhills</i>: Familynick, <i>Jose</i>: Call.\n"
 msgstr ""
-"Les següents paraules claus se substitueixen amb les parts del nom "
-"apropiades:\n"
+"Les següents paraules claus se substitueixen amb les parts del nom"
+" apropiades:\n"
 "<tt> \n"
-" <b>Nom de pila</b>       - nom de pila (primer) <b>Cognom</b>      - "
-"cognoms (amb prefix i connectors)\n"
-" <b>Títol</b>        - títol (Dr., Sra.)       <b>Sufix</b>          - sufix "
-"(Jr., Sr.)\n"
-" <b>Habitual</b>         - nom habitual          <b>Sobrenom</b>  - "
-"sobrenom\n"
-" <b>Inicials</b>    - primeres lletres del nom de pila <b>Comú</b>  - "
-"sobrenom o, si no n'hi ha, primer Nom de pila\n"
+" <b>Nom de pila</b>       - nom de pila (primer) <b>Cognom</b>      - cognoms"
+" (amb prefix i connectors)\n"
+" <b>Títol</b>        - títol (Dr., Sra.)       <b>Sufix</b>          - sufix"
+" (Jr., Sr.)\n"
+" <b>Habitual</b>         - nom habitual          <b>Sobrenom</b>  - sobrenom\n"
+" <b>Inicials</b>    - primeres lletres del nom de pila <b>Comú</b>  -"
+" sobrenom o, si no n'hi ha, primer Nom de pila\n"
 " <b>Prefix</b>  - tots els prefixos (von, de)\n"
 "Cognoms:\n"
-" <b>Resta</b>   - cognoms no primaris      <b<Nopatronímic</b>- tots els "
-"cognoms, excepte pa/matronímic &amp; primari\n"
-" <b>Mot de la família</b> - mot de la família   <b>Cognomsjustos</b>  - "
-"cognoms (sense prefixos ni connectors)\n"
-" <b>Primari, Primari[pre] o [cog] o [con]</b>- cognom primari complet, "
-"prefix, només cognom, connector \n"
-" <b>Patronímic, o [pre] o [cog] o [con]</b>. cognom pa/matronímic sencer, "
-"prefix, només cognom, connector \n"
+" <b>Resta</b>   - cognoms no primaris      <b<Nopatronímic</b>- tots els"
+" cognoms, excepte pa/matronímic &amp; primari\n"
+" <b>Mot de la família</b> - mot de la família   <b>Cognomsjustos</b>  -"
+" cognoms (sense prefixos ni connectors)\n"
+" <b>Primari, Primari[pre] o [cog] o [con]</b>- cognom primari complet,"
+" prefix, només cognom, connector \n"
+" <b>Patronímic, o [pre] o [cog] o [con]</b>. cognom pa/matronímic sencer,"
+" prefix, només cognom, connector \n"
 "</tt>\n"
-"Si la paraula clau està en MAJÚSCULA, força que s'escrigui en majúscula. Els "
-"parèntesis i comes addicionals es treuen. La resta del text apareix "
-"literalment.\n"
+"Si la paraula clau està en MAJÚSCULA, força que s'escrigui en majúscula. Els"
+" parèntesis i comes addicionals es treuen. La resta del text apareix"
+" literalment.\n"
 "\n"
-"<b>Exemple</b>:'Dr. Edwin Jose von der Smith and Weston Wilson Sr (\"Ed\") - "
-"Underhills'\n"
-"  <i>Edwin Jose</i> és el nom de pila, <i>von der</i> és el prefix, "
-"<i>Smith</i> i <i>Weston</i> cognoms, \n"
-"  <i>and</i> un connector, <i>Wilson</i> cognom patronímic, <i>Dr.</i> "
-"títol, <i>Sr</i> sufix, <i>Ed</i> sobrenom, \n"
+"<b>Exemple</b>:'Dr. Edwin Jose von der Smith and Weston Wilson Sr (\"Ed\") -"
+" Underhills'\n"
+"  <i>Edwin Jose</i> és el nom de pila, <i>von der</i> és el prefix, <i>Smith<"
+"/i> i <i>Weston</i> cognoms, \n"
+"  <i>and</i> un connector, <i>Wilson</i> cognom patronímic, <i>Dr.</i> títol,"
+" <i>Sr</i> sufix, <i>Ed</i> sobrenom, \n"
 "  <i>Underhills</i> mot de la família, <i>Jose</i> nom habitual.\n"
 
 #: ../gramps/gui/configure.py:148
@@ -11669,13 +11666,12 @@ msgid "Researcher information"
 msgstr "Informació de referència"
 
 #: ../gramps/gui/configure.py:602
-#, fuzzy
 msgid ""
-"Enter information about yourself so people can contact you when you "
-"distribute your Family Tree"
+"Enter information about yourself so people can contact you when you"
+" distribute your Family Tree"
 msgstr ""
-"Introduïu la vostra informació perquè la gent es pugui posar en contacte amb "
-"vostè quan distribuïu el vostre Arbre Genealògic"
+"Introduïu informació vostra perquè la gent es pugui posar en contacte amb"
+" vostè quan distribuïu el vostre Arbre Genealògic"
 
 #: ../gramps/gui/configure.py:617
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:75
@@ -11711,9 +11707,8 @@ msgid "ID Formats"
 msgstr "Formats d'ID"
 
 #: ../gramps/gui/configure.py:677
-#, fuzzy
 msgid "Colors used for boxes in the graphical views"
-msgstr "Fixa els color utilitzats per les caixes a les vistes gràfiques"
+msgstr "Colors utilitzats per a les caixes a les vistes gràfiques"
 
 #: ../gramps/gui/configure.py:683
 msgid "Light colors"
@@ -11736,100 +11731,83 @@ msgid "Restore colors for current theme to default."
 msgstr ""
 
 #: ../gramps/gui/configure.py:701
-#, fuzzy
 msgid "Colors for Male persons"
-msgstr "Color per als duplicats"
+msgstr "Colors per a persones Masculines"
 
 #: ../gramps/gui/configure.py:702
 msgid "Colors for Female persons"
-msgstr ""
+msgstr "Colors per a persones Femenines"
 
 #: ../gramps/gui/configure.py:703
-#, fuzzy
 msgid "Colors for Unknown persons"
-msgstr "(persona desconeguda)"
+msgstr "Colors per a persones Desconegudes"
 
 #: ../gramps/gui/configure.py:704
-#, fuzzy
 msgid "Colors for Family nodes"
-msgstr "Mostra nodes familiars"
+msgstr "Colors per a nodes familiars"
 
 #: ../gramps/gui/configure.py:705
-#, fuzzy
 msgid "Other colors"
-msgstr "Colors del Gènere"
+msgstr "Altres colors"
 
 #: ../gramps/gui/configure.py:707
-#, fuzzy
 msgid "Background for Alive"
-msgstr "Color de fons"
+msgstr "Color de fons per a Viu"
 
 #: ../gramps/gui/configure.py:708
-#, fuzzy
 msgid "Background for Dead"
-msgstr "Color de fons"
+msgstr "Color de fons per a Mort"
 
 #: ../gramps/gui/configure.py:709
-#, fuzzy
 msgid "Border for Alive"
-msgstr "Contorn Masculí Viu"
+msgstr "Contorn per a Viu"
 
 #: ../gramps/gui/configure.py:710
-#, fuzzy
 msgid "Border for Dead"
-msgstr "Contorn Masculí Mort"
+msgstr "Contorn per a Mort"
 
 #. for family
 #: ../gramps/gui/configure.py:730
-#, fuzzy
 msgid "Default background"
-msgstr "Persona predeterminada"
+msgstr "Color de fons predeterminat"
 
 #: ../gramps/gui/configure.py:731
-#, fuzzy
 msgid "Background for Married"
-msgstr "Color de fons"
+msgstr "Color de fons per a Casat"
 
 #: ../gramps/gui/configure.py:732
-#, fuzzy
 msgid "Background for Unmarried"
-msgstr "Color de fons"
+msgstr "Color de fons per a No casat"
 
 #: ../gramps/gui/configure.py:734
-#, fuzzy
 msgid "Background for Civil union"
-msgstr "Color de fons"
+msgstr "Color de fons per a Unió civil"
 
 #: ../gramps/gui/configure.py:736
-#, fuzzy
 msgid "Background for Unknown"
-msgstr "%dN"
+msgstr "Color de fons per a Desconegut"
 
 #: ../gramps/gui/configure.py:737
-#, fuzzy
 msgid "Background for Divorced"
-msgstr "Color de fons"
+msgstr "Color de fons per a Divorciat"
 
 #: ../gramps/gui/configure.py:738
-#, fuzzy
 msgid "Default border"
-msgstr "Persona predeterminada"
+msgstr "Contorn predeterminat"
 
 #: ../gramps/gui/configure.py:739
-#, fuzzy
 msgid "Border for Divorced"
-msgstr "Contorn Família divorciada"
+msgstr "Contorn per a Divorciat"
 
 #. for other
 #: ../gramps/gui/configure.py:742
-#, fuzzy
 msgid "Background for Home Person"
-msgstr "Parentesc amb la Persona Base"
+msgstr "Color de fons per a la Persona Base"
 
 #: ../gramps/gui/configure.py:761
 #, python-format
 msgid "<b>%s</b>"
-msgstr ""
+msgstr "<b>%s</b>"
 
 #: ../gramps/gui/configure.py:774
 msgid "Colors"
@@ -11837,29 +11815,25 @@ msgstr "Colors"
 
 #: ../gramps/gui/configure.py:794
 msgid "Warnings and Error dialogs"
-msgstr ""
+msgstr "Avisos i diàlegs d'error"
 
 #: ../gramps/gui/configure.py:800
-#, fuzzy
 msgid "Suppress warning when adding parents to a child"
-msgstr "Suprimir l'avís quan s'afegeixen progenitors a un fill."
+msgstr "Suprimir l'avís quan s'afegeixen progenitors a un fill"
 
 #: ../gramps/gui/configure.py:804
-#, fuzzy
 msgid "Suppress warning when canceling with changed data"
-msgstr "Suprimir l'avís quan es cancel·li amb dades modificades."
+msgstr "Suprimir l'avís quan es cancel·li amb dades modificades"
 
 #: ../gramps/gui/configure.py:808
-#, fuzzy
 msgid "Suppress warning about missing researcher when exporting to GEDCOM"
-msgstr "Suprimir l'avís sobre investigador inexistent quan s'exporti a GEDCOM."
+msgstr "Suprimir l'avís sobre investigador inexistent quan s'exporti a GEDCOM"
 
 #: ../gramps/gui/configure.py:813
-#, fuzzy
 msgid "Show plugin status dialog on plugin load error"
 msgstr ""
-"Mostra el diàleg d'estat del connector quan hi hagi un error de càrrega del "
-"connector."
+"Mostra el diàleg d'estat del connector quan hi hagi un error de càrrega del"
+" connector"
 
 #: ../gramps/gui/configure.py:816
 msgid "Warnings"
@@ -11904,7 +11878,7 @@ msgstr "Exemple"
 #: ../gramps/gui/plug/report/_bookdialog.py:665 ../gramps/gui/views/tags.py:458
 #: ../gramps/gui/widgets/fanchart.py:2028
 #: ../gramps/gui/widgets/fanchart.py:2070
-#: ../gramps/plugins/view/pedigreeview.py:1703
+#: ../gramps/plugins/view/pedigreeview.py:1704
 msgid "_Add"
 msgstr "_Afegeix"
 
@@ -11919,8 +11893,8 @@ msgstr "_Afegeix"
 #: ../gramps/gui/glade/editlink.glade:222 ../gramps/gui/grampsgui.py:56
 #: ../gramps/gui/plug/report/_bookdialog.py:639 ../gramps/gui/views/tags.py:459
 #: ../gramps/gui/widgets/fanchart.py:1817
-#: ../gramps/plugins/view/pedigreeview.py:1738
-#: ../gramps/plugins/view/pedigreeview.py:1966
+#: ../gramps/plugins/view/pedigreeview.py:1739
+#: ../gramps/plugins/view/pedigreeview.py:1967
 msgid "_Edit"
 msgstr "_Edita"
 
@@ -11937,9 +11911,8 @@ msgid "_Remove"
 msgstr "Esbo_rra"
 
 #: ../gramps/gui/configure.py:1153
-#, fuzzy
 msgid "Appearance and format settings"
-msgstr "Cadena de format de nom %s incorrecta"
+msgstr "Aparença i ajustos de format"
 
 #: ../gramps/gui/configure.py:1198 ../gramps/gui/configure.py:1237
 #: ../gramps/gui/editors/displaytabs/buttontab.py:71
@@ -12016,8 +11989,7 @@ msgstr "Barra d'estat"
 #: ../gramps/gui/configure.py:1339
 msgid "Show text label beside Navigator buttons (requires restart)"
 msgstr ""
-"Mostra l'etiqueta de text als botons de navegació (requereix tornar a "
-"engegar)"
+"Mostra l'etiqueta de text als botons de navegació (requereix tornar a engegar)"
 
 #: ../gramps/gui/configure.py:1342
 #, fuzzy
@@ -12025,8 +11997,7 @@ msgid ""
 "Show or hide text beside Navigator buttons (People, Families, Events...).\n"
 "Requires Gramps restart to apply."
 msgstr ""
-"Mostra l'etiqueta de text als botons de navegació (requereix tornar a "
-"engegar)"
+"Mostra l'etiqueta de text als botons de navegació (requereix tornar a engegar)"
 
 #: ../gramps/gui/configure.py:1348
 msgid "Show close button in gramplet bar tabs"
@@ -12072,49 +12043,21 @@ msgstr "El canvi no és immediat"
 
 #: ../gramps/gui/configure.py:1462
 msgid ""
-"Changing the date format will not take effect until the next time Gramps is "
-"started."
+"Changing the date format will not take effect until the next time Gramps is"
+" started."
 msgstr ""
-"Canviar el format de la data no tindrà efecte fins la propera vegada que "
-"s'engegui Gramps."
+"Canviar el format de la data no tindrà efecte fins la propera vegada que"
+" s'engegui Gramps."
 
 #: ../gramps/gui/configure.py:1487
 msgid "Dates settings used for calculation operations"
 msgstr ""
 
 #: ../gramps/gui/configure.py:1493
-msgid "Date about range"
-msgstr "Data al voltant d'un rang"
-
-#: ../gramps/gui/configure.py:1497
-msgid "Date after range"
-msgstr "Data després d'un rang"
-
-#: ../gramps/gui/configure.py:1501
-msgid "Date before range"
-msgstr "Data abans d'un rang"
-
-#: ../gramps/gui/configure.py:1505
-msgid "Maximum age probably alive"
-msgstr "Màxima edat per estar probablement viu"
-
-#: ../gramps/gui/configure.py:1509
-msgid "Maximum sibling age difference"
-msgstr "Màxima diferència d'edat entre germans"
-
-#: ../gramps/gui/configure.py:1513
-msgid "Minimum years between generations"
-msgstr "Anys mínims entre generacions"
-
-#: ../gramps/gui/configure.py:1517
-msgid "Average years between generations"
-msgstr "Anys mitjans entre generacions"
-
-#: ../gramps/gui/configure.py:1521
 msgid "Markup for invalid date format"
 msgstr "Marcador per format de data no vàlid"
 
-#: ../gramps/gui/configure.py:1525
+#: ../gramps/gui/configure.py:1497
 #, python-format
 msgid ""
 "Convenience markups are:\n"
@@ -12133,19 +12076,47 @@ msgid ""
 msgstr ""
 "Alguns marcadors útils són:\n"
 "<b>&lt;b&gt;Negreta&lt;/b&gt;</b>\n"
-"<big>&lt;big&gt;Fa que la mida de la lletra sigui relativament més "
-"grossa&lt;/big&gt;</big>\n"
+"<big>&lt;big&gt;Fa que la mida de la lletra sigui relativament més"
+" grossa&lt;/big&gt;</big>\n"
 "<i>&lt;i&gt;Cursiva&lt;/i&gt;</i>\n"
 "<s>&lt;s&gt;Ratllada&lt;/s&gt;</s>\n"
 "<sub>&lt;sub&gt;Subíndex&lt;/sub&gt;</sub>\n"
 "<sup>&lt;sup&gt;Superíndex&lt;/sup&gt;</sup>\n"
-"<small>&lt;small&gt;Fa que la mida de la lletra sigui relativament més "
-"petita&lt;/small&gt;</small>\n"
+"<small>&lt;small&gt;Fa que la mida de la lletra sigui relativament més"
+" petita&lt;/small&gt;</small>\n"
 "<tt>&lt;tt&gt;Tipus de lletra d'espai únic&lt;/tt&gt;</tt>\n"
 "<u>&lt;u&gt;Subratllat&lt;/u&gt;</u>\n"
 "\n"
 "Per exemple: &lt;u&gt;&lt;b&gt;%s&lt;/b&gt;&lt;/u&gt;\n"
 "mostrarà <u><b>la data subratllada i en negreta</b></u>.\n"
+
+#: ../gramps/gui/configure.py:1513
+msgid "Date about range"
+msgstr "Data al voltant d'un rang"
+
+#: ../gramps/gui/configure.py:1517
+msgid "Date after range"
+msgstr "Data després d'un rang"
+
+#: ../gramps/gui/configure.py:1521
+msgid "Date before range"
+msgstr "Data abans d'un rang"
+
+#: ../gramps/gui/configure.py:1525
+msgid "Maximum age probably alive"
+msgstr "Màxima edat per estar probablement viu"
+
+#: ../gramps/gui/configure.py:1529
+msgid "Maximum sibling age difference"
+msgstr "Màxima diferència d'edat entre germans"
+
+#: ../gramps/gui/configure.py:1533
+msgid "Minimum years between generations"
+msgstr "Anys mínims entre generacions"
+
+#: ../gramps/gui/configure.py:1537
+msgid "Average years between generations"
+msgstr "Anys mitjans entre generacions"
 
 #: ../gramps/gui/configure.py:1540
 msgid "Dates"
@@ -12209,7 +12180,7 @@ msgstr "Camí (path) base per carpetes de medis audiovisuals"
 
 #: ../gramps/gui/configure.py:1617
 msgid "Third party addons management"
-msgstr ""
+msgstr "Gestió de complements de tercers"
 
 #: ../gramps/gui/configure.py:1626
 msgid "Once a month"
@@ -12266,8 +12237,8 @@ msgstr "Ha fallat la comprovació de Complements"
 #: ../gramps/gui/configure.py:1680
 msgid "The addon repository appears to be unavailable. Please try again later."
 msgstr ""
-"Sembla que no està disponible el repositori de complements. Si us plau, "
-"proveu-ho més tard."
+"Sembla que no està disponible el repositori de complements. Si us plau,"
+" proveu-ho més tard."
 
 #: ../gramps/gui/configure.py:1693
 msgid "There are no available addons of this type"
@@ -12318,8 +12289,8 @@ msgstr "Carregar automàticament l'últim Arbre Genealògic"
 
 #: ../gramps/gui/configure.py:1761
 msgid ""
-"Don't open dialog to choose family tree to load on startup, just load last "
-"used."
+"Don't open dialog to choose family tree to load on startup, just load last"
+" used."
 msgstr ""
 
 #: ../gramps/gui/configure.py:1766
@@ -12402,7 +12373,7 @@ msgstr "Selecciona directori de medis audiovisuals"
 #: ../gramps/gui/plug/_guioptions.py:1744 ../gramps/gui/plug/_windows.py:440
 #: ../gramps/gui/plug/report/_fileentry.py:64
 #: ../gramps/gui/plug/report/_reportdialog.py:162 ../gramps/gui/utils.py:180
-#: ../gramps/gui/viewmanager.py:1792 ../gramps/gui/views/listview.py:1064
+#: ../gramps/gui/viewmanager.py:1792 ../gramps/gui/views/listview.py:1065
 #: ../gramps/gui/views/navigationview.py:348 ../gramps/gui/views/tags.py:682
 #: ../gramps/gui/widgets/progressdialog.py:437
 #: ../gramps/plugins/importer/importprogen.glade:1714
@@ -12424,17 +12395,17 @@ msgstr "Selecciona el directori de còpies de seguretat"
 
 #: ../gramps/gui/configure.py:1946
 msgid ""
-"This tab gives you the possibility to use one font which is able to show all "
-"genealogical symbols\n"
+"This tab gives you the possibility to use one font which is able to show all"
+" genealogical symbols\n"
 "\n"
-"If you select the \"use symbols\" checkbox, Gramps will use the selected "
-"font if it exists."
+"If you select the \"use symbols\" checkbox, Gramps will use the selected font"
+" if it exists."
 msgstr ""
 
 #: ../gramps/gui/configure.py:1952
 msgid ""
-"This can be useful if you want to add phonetic in a note to show how to "
-"pronounce a name or if you mix multiple languages like greek and russian."
+"This can be useful if you want to add phonetic in a note to show how to"
+" pronounce a name or if you mix multiple languages like greek and russian."
 msgstr ""
 
 #: ../gramps/gui/configure.py:1959
@@ -12443,8 +12414,8 @@ msgstr ""
 
 #: ../gramps/gui/configure.py:1964
 msgid ""
-"Be careful, if you click on the \"Try to find\" button, it can take a while "
-"before you can continue (10 minutes or more). \n"
+"Be careful, if you click on the \"Try to find\" button, it can take a while"
+" before you can continue (10 minutes or more). \n"
 "If you cancel the process, nothing will be changed."
 msgstr ""
 
@@ -12460,17 +12431,15 @@ msgstr ""
 
 #: ../gramps/gui/configure.py:1990 ../gramps/gui/configure.py:2091
 msgid "Choose font"
-msgstr ""
+msgstr "Triar tipus de lletra"
 
 #: ../gramps/gui/configure.py:2003 ../gramps/gui/configure.py:2108
-#, fuzzy
 msgid "Select default death symbol"
-msgstr "Fixa com a nom predeterminat"
+msgstr "Seleccionar símbol de mort predeterminat"
 
 #: ../gramps/gui/configure.py:2012
-#, fuzzy
 msgid "Genealogical Symbols"
-msgstr "Sistema Genealògic"
+msgstr "Símbols Genealògics"
 
 #: ../gramps/gui/configure.py:2021
 msgid "Cannot look for genealogical fonts"
@@ -12478,8 +12447,8 @@ msgstr ""
 
 #: ../gramps/gui/configure.py:2022
 msgid ""
-"I am not able to select genealogical fonts. Please, install the module "
-"fontconfig for python 3."
+"I am not able to select genealogical fonts. Please, install the module"
+" fontconfig for python 3."
 msgstr ""
 
 #: ../gramps/gui/configure.py:2039
@@ -12492,8 +12461,8 @@ msgstr ""
 
 #: ../gramps/gui/configure.py:2116
 msgid ""
-"You have no font with genealogical symbols on your system. Gramps will not "
-"be able to use symbols."
+"You have no font with genealogical symbols on your system. Gramps will not be"
+" able to use symbols."
 msgstr ""
 
 #: ../gramps/gui/configure.py:2154
@@ -12506,18 +12475,18 @@ msgstr "Avís d'historial de canvis"
 
 #: ../gramps/gui/dbloader.py:121
 msgid ""
-"Proceeding with import will erase the undo history for this session. In "
-"particular, you will not be able to revert the import or any changes made "
-"prior to it.\n"
+"Proceeding with import will erase the undo history for this session. In"
+" particular, you will not be able to revert the import or any changes made"
+" prior to it.\n"
 "\n"
-"If you think you may want to revert the import, please stop here and backup "
-"your database."
+"If you think you may want to revert the import, please stop here and backup"
+" your database."
 msgstr ""
-"Continuar amb la importació esborrarà l'historial de canvis d'aquesta "
-"sessió. En concret, no podrà desfer la importació ni cap canvi fet abans.\n"
+"Continuar amb la importació esborrarà l'historial de canvis d'aquesta sessió."
+" En concret, no podrà desfer la importació ni cap canvi fet abans.\n"
 "\n"
-"Si creu que pot necessitar desfer la importació, aturi el procés aquí, i "
-"faci una còpia de seguretat de la base de dades."
+"Si creu que pot necessitar desfer la importació, aturi el procés aquí, i faci"
+" una còpia de seguretat de la base de dades."
 
 #: ../gramps/gui/dbloader.py:126
 msgid "_Proceed with import"
@@ -12599,13 +12568,13 @@ msgstr "Importa"
 msgid ""
 "File type \"%s\" is unknown to Gramps.\n"
 "\n"
-"Valid types are: Gramps database, Gramps XML, Gramps package, GEDCOM, and "
-"others."
+"Valid types are: Gramps database, Gramps XML, Gramps package, GEDCOM, and"
+" others."
 msgstr ""
 "El tipus de fitxer \"%s\" és desconegut per Gramps.\n"
 "\n"
-"Els tipus vàlids són: base de dades Gramps, XML de Gramps, paquet Gramps, "
-"GEDCOM, i d'altres."
+"Els tipus vàlids són: base de dades Gramps, XML de Gramps, paquet Gramps,"
+" GEDCOM, i d'altres."
 
 #: ../gramps/gui/dbloader.py:516 ../gramps/gui/dbloader.py:523
 msgid "Cannot open file"
@@ -12630,12 +12599,12 @@ msgstr "No s'ha pogut importar el fitxer: %s"
 
 #: ../gramps/gui/dbloader.py:559
 msgid ""
-"This file incorrectly identifies its character set, so it cannot be "
-"accurately imported. Please fix the encoding, and import again"
+"This file incorrectly identifies its character set, so it cannot be"
+" accurately imported. Please fix the encoding, and import again"
 msgstr ""
-"Aquest fitxer identifica de forma incorrecta el seu joc de caràcters, i per "
-"tant no es pot importar acuradament. Resolgui si us plau la codificació, i "
-"torni a fer la importació"
+"Aquest fitxer identifica de forma incorrecta el seu joc de caràcters, i per"
+" tant no es pot importar acuradament. Resolgui si us plau la codificació, i"
+" torni a fer la importació"
 
 #: ../gramps/gui/dbman.py:97
 #, python-format
@@ -12730,16 +12699,16 @@ msgstr "Forçar el desbloqueig de la base de dades '%s'?"
 
 #: ../gramps/gui/dbman.py:509
 msgid ""
-"Gramps believes that someone else is actively editing this database. You "
-"cannot edit this database while it is locked. If no one is editing the "
-"database you may safely break the lock. However, if someone else is editing "
-"the database and you break the lock, you may corrupt the database."
+"Gramps believes that someone else is actively editing this database. You"
+" cannot edit this database while it is locked. If no one is editing the"
+" database you may safely break the lock. However, if someone else is editing"
+" the database and you break the lock, you may corrupt the database."
 msgstr ""
-"Gramps creu que hi ha algú més editant de forma activa aquesta base de "
-"dades. No pot editar aquesta base de dades mentre està bloquejada. Si ningú "
-"no l'està editant, pot forçar-ne el desbloqueig sense perill. No obstant, si "
-"algú altre l'està editant i en força el desbloqueig, pot corrompre la base "
-"de dades."
+"Gramps creu que hi ha algú més editant de forma activa aquesta base de dades."
+" No pot editar aquesta base de dades mentre està bloquejada. Si ningú no"
+" l'està editant, pot forçar-ne el desbloqueig sense perill. No obstant, si"
+" algú altre l'està editant i en força el desbloqueig, pot corrompre la base"
+" de dades."
 
 #: ../gramps/gui/dbman.py:515
 msgid "Break lock"
@@ -12829,8 +12798,7 @@ msgstr "Voleu convertir la base de dades '%s'?"
 msgid ""
 "Do you wish to convert this family tree into a %(database_type)s database?"
 msgstr ""
-"Vols convertir aquest arbre geneològic en una base de dades "
-"%(database_type)s?"
+"Vols convertir aquest arbre geneològic en una base de dades %(database_type)s?"
 
 #: ../gramps/gui/dbman.py:786
 msgid "Convert"
@@ -12844,8 +12812,8 @@ msgstr "Obrint la base de dades '%s'"
 #: ../gramps/gui/dbman.py:797
 msgid "An attempt to convert the database failed. Perhaps it needs updating."
 msgstr ""
-"Un intent de convertir la base de dades ha fallat. Pot ser es necessari "
-"actualizar."
+"Un intent de convertir la base de dades ha fallat. Pot ser es necessari"
+" actualizar."
 
 #: ../gramps/gui/dbman.py:808 ../gramps/gui/dbman.py:834
 #, python-format
@@ -12876,52 +12844,52 @@ msgstr "Reparar Arbre Genealògic?"
 #: ../gramps/gui/dbman.py:893
 #, python-format
 msgid ""
-"If you click %(bold_start)sProceed%(bold_end)s, Gramps will attempt to "
-"recover your Family Tree from the last good backup. There are several ways "
-"this can cause unwanted effects, so %(bold_start)sbackup%(bold_end)s the "
-"Family Tree first.\n"
+"If you click %(bold_start)sProceed%(bold_end)s, Gramps will attempt to"
+" recover your Family Tree from the last good backup. There are several ways"
+" this can cause unwanted effects, so %(bold_start)sbackup%(bold_end)s the"
+" Family Tree first.\n"
 "The Family Tree you have selected is stored in %(dirname)s.\n"
 "\n"
-"Before doing a repair, verify that the Family Tree can really no longer be "
-"opened, as the database back-end can recover from some errors "
-"automatically.\n"
+"Before doing a repair, verify that the Family Tree can really no longer be"
+" opened, as the database back-end can recover from some errors"
+" automatically.\n"
 "\n"
-"%(bold_start)sDetails:%(bold_end)s Repairing a Family Tree actually uses the "
-"last backup of the Family Tree, which Gramps stored on last use. If you have "
-"worked for several hours/days without closing Gramps, then all this "
-"information will be lost! If the repair fails, then the original Family Tree "
-"will be lost forever, hence a backup is needed. If the repair fails, or too "
-"much information is lost, you can fix the original Family Tree manually. For "
-"details, see the webpage\n"
+"%(bold_start)sDetails:%(bold_end)s Repairing a Family Tree actually uses the"
+" last backup of the Family Tree, which Gramps stored on last use. If you have"
+" worked for several hours/days without closing Gramps, then all this"
+" information will be lost! If the repair fails, then the original Family Tree"
+" will be lost forever, hence a backup is needed. If the repair fails, or too"
+" much information is lost, you can fix the original Family Tree manually. For"
+" details, see the webpage\n"
 "%(gramps_wiki_recover_url)s\n"
-"Before doing a repair, try to open the Family Tree in the normal manner. "
-"Several errors that trigger the repair button can be fixed automatically. If "
-"this is the case, you can disable the repair button by removing the file "
+"Before doing a repair, try to open the Family Tree in the normal manner."
+" Several errors that trigger the repair button can be fixed automatically. If"
+" this is the case, you can disable the repair button by removing the file "
 "%(recover_file)s in the Family Tree directory."
 msgstr ""
-"Si cliqueu %(bold_start)sContinuar%(bold_end)s, Gramps intentarà de "
-"recuperar l'Arbre Genealògic a partir de l'última còpia de seguretat bona. "
-"Hi ha diverses maneres en què això pot provocar efectes no desitjats, per "
-"tant, abans %(bold_start)sfeu una còpia%(bold_end)s de l'Arbre Genealògic.\n"
+"Si cliqueu %(bold_start)sContinuar%(bold_end)s, Gramps intentarà de recuperar"
+" l'Arbre Genealògic a partir de l'última còpia de seguretat bona. Hi ha"
+" diverses maneres en què això pot provocar efectes no desitjats, per tant,"
+" abans %(bold_start)sfeu una còpia%(bold_end)s de l'Arbre Genealògic.\n"
 "L'Arbre Genealògic que heu seleccionat està desat a %(dirname)s.\n"
 "\n"
-"Abans de fer una reparació, assegureu-vos que l'Arbre Genealògic segur que "
-"ja no es pot obrir, perquè el gestor de bases de dades intern pot recuperar "
-"alguns errors automàticament.\n"
+"Abans de fer una reparació, assegureu-vos que l'Arbre Genealògic segur que ja"
+" no es pot obrir, perquè el gestor de bases de dades intern pot recuperar"
+" alguns errors automàticament.\n"
 "\n"
-"%(bold_start)sDetalls:%(bold_end)s Reparar un Arbre Genealògic utilitza de "
-"fet l'última còpia de seguretat de l'Arbre Genealògic, que Gramps havia "
-"guardat l'últim cop que s'havia utilitzat. Si ha treballat unes quantes "
-"hores/dies sense tancar Gramps, tota aquesta informació s'haurà perdut! Si "
-"la reparació falla, l'Arbre Genealògic original s'haurà perdut per sempre, "
-"per tant cal una còpia de seguretat. Si la reparació falla, o es perd massa "
-"informació, podeu arreglar l'Arbre Genealògic original de forma manual. Per "
-"més detalls, vegeu la pàgina web\n"
+"%(bold_start)sDetalls:%(bold_end)s Reparar un Arbre Genealògic utilitza de"
+" fet l'última còpia de seguretat de l'Arbre Genealògic, que Gramps havia"
+" guardat l'últim cop que s'havia utilitzat. Si ha treballat unes quantes"
+" hores/dies sense tancar Gramps, tota aquesta informació s'haurà perdut! Si"
+" la reparació falla, l'Arbre Genealògic original s'haurà perdut per sempre,"
+" per tant cal una còpia de seguretat. Si la reparació falla, o es perd massa"
+" informació, podeu arreglar l'Arbre Genealògic original de forma manual. Per"
+" més detalls, vegeu la pàgina web\n"
 "%(gramps_wiki_recover_url)s\n"
-"Abans de fer una reparació, intenti d'obrir l'Arbre Genealògic de la manera "
-"normal. Alguns errors que fan sortir el botó de reparació es poden arreglar "
-"automàticament. Si és el cas, pot desactivar el botó de reparació esborrant "
-"el fitxer %(recover_file)s al directori de l'Arbre Genealògic."
+"Abans de fer una reparació, intenti d'obrir l'Arbre Genealògic de la manera"
+" normal. Alguns errors que fan sortir el botó de reparació es poden arreglar"
+" automàticament. Si és el cas, pot desactivar el botó de reparació esborrant"
+" el fitxer %(recover_file)s al directori de l'Arbre Genealògic."
 
 #: ../gramps/gui/dbman.py:924
 msgid "Proceed, I have taken a backup"
@@ -13080,12 +13048,12 @@ msgstr "No es pot importar %s"
 #: ../gramps/gui/editors/addmedia.py:170
 #, python-format
 msgid ""
-"Directory specified in preferences: Base path for relative media paths: %s "
-"does not exist. Change preferences or do not use relative path when importing"
+"Directory specified in preferences: Base path for relative media paths: %s"
+" does not exist. Change preferences or do not use relative path when importing"
 msgstr ""
-"Directori especificat a les preferències: el camí relatiu de base per als "
-"medis audiovisuals: %s no existeix. Modifiqui les preferències o no utilitzi "
-"camins relatius en importar"
+"Directori especificat a les preferències: el camí relatiu de base per als"
+" medis audiovisuals: %s no existeix. Modifiqui les preferències o no utilitzi"
+" camins relatius en importar"
 
 #: ../gramps/gui/editors/addmedia.py:238
 #, python-format
@@ -13094,11 +13062,10 @@ msgstr "No es pot mostrar %s"
 
 #: ../gramps/gui/editors/addmedia.py:239
 msgid ""
-"Gramps is not able to display the image file. This may be caused by a "
-"corrupt file."
+"Gramps is not able to display the image file. This may be caused by a corrupt"
+" file."
 msgstr ""
-"Gramps no pot mostrar el fitxer d'imatge. Pot ser degut a un fitxer "
-"corromput."
+"Gramps no pot mostrar el fitxer d'imatge. Pot ser degut a un fitxer corromput."
 
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:61
 msgid "Create and add a new address"
@@ -13319,15 +13286,15 @@ msgstr "No es pot compartir aquesta referència"
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:192
 #: ../gramps/plugins/view/citationtreeview.py:641
 msgid ""
-"This citation cannot be created at this time. Either the associated Source "
-"object is already being edited, or another citation associated with the same "
-"source is being edited.\n"
+"This citation cannot be created at this time. Either the associated Source"
+" object is already being edited, or another citation associated with the same"
+" source is being edited.\n"
 "\n"
 "To edit this citation, you need to close the object."
 msgstr ""
-"Aquesta cita no es pot crear en aquest moment. Pot ser que ja s'estigui "
-"editant la Font associada o que una altra cita que estigui associada amb la "
-"mateixa font s'estigui editant.\n"
+"Aquesta cita no es pot crear en aquest moment. Pot ser que ja s'estigui"
+" editant la Font associada o que una altra cita que estigui associada amb la"
+" mateixa font s'estigui editant.\n"
 "\n"
 "Per editar aquesta cita, cal tancar l'objecte."
 
@@ -13368,15 +13335,15 @@ msgstr "_Esdeveniments"
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:247
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:348
 msgid ""
-"This event reference cannot be edited at this time. Either the associated "
-"event is already being edited or another event reference that is associated "
-"with the same event is being edited.\n"
+"This event reference cannot be edited at this time. Either the associated"
+" event is already being edited or another event reference that is associated"
+" with the same event is being edited.\n"
 "\n"
 "To edit this event reference, you need to close the event."
 msgstr ""
-"Aquesta referència d'esdeveniment no es pot editar en aquest moment. O bé "
-"l'esdeveniment associat ja s'està editant, o s'està editant un altra "
-"referència d'esdeveniment que està associada amb el mateix.\n"
+"Aquesta referència d'esdeveniment no es pot editar en aquest moment. O bé"
+" l'esdeveniment associat ja s'està editant, o s'està editant un altra"
+" referència d'esdeveniment que està associada amb el mateix.\n"
 "\n"
 "Per editar aquesta referència d'esdeveniment, cal tancar l'esdeveniment."
 
@@ -13385,7 +13352,7 @@ msgstr ""
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:355
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:168
 #: ../gramps/plugins/drawreport/ancestortree.py:1095
-#: ../gramps/plugins/drawreport/descendtree.py:1810
+#: ../gramps/plugins/drawreport/descendtree.py:1816
 msgid "Cannot edit this reference"
 msgstr "No es pot editar aquesta referència"
 
@@ -13429,18 +13396,18 @@ msgstr "Medis audiovisuals no existents trobats a la Galeria"
 
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:309
 msgid ""
-"This media reference cannot be edited at this time. Either the associated "
-"media object is already being edited or another media reference that is "
-"associated with the same media object is being edited.\n"
+"This media reference cannot be edited at this time. Either the associated"
+" media object is already being edited or another media reference that is"
+" associated with the same media object is being edited.\n"
 "\n"
 "To edit this media reference, you need to close the media object."
 msgstr ""
-"Aquesta referència de medis audiovisuals no es pot editar en aquest moment. "
-"O bé el medi audiovisual associat ja s'està editant, o s'està editant una "
-"altra referència de medis que està associada amb el mateix objecte.\n"
+"Aquesta referència de medis audiovisuals no es pot editar en aquest moment. O"
+" bé el medi audiovisual associat ja s'està editant, o s'està editant una"
+" altra referència de medis que està associada amb el mateix objecte.\n"
 "\n"
-"Per editar aquesta referència de medis audiovisual, cal tancar l'objecte de "
-"medis."
+"Per editar aquesta referència de medis audiovisual, cal tancar l'objecte de"
+" medis."
 
 #: ../gramps/gui/editors/displaytabs/gallerytab.py:578
 #: ../gramps/plugins/view/mediaview.py:192
@@ -13719,16 +13686,16 @@ msgstr "_Repositoris"
 
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:169
 msgid ""
-"This repository reference cannot be edited at this time. Either the "
-"associated repository is already being edited or another repository "
-"reference that is associated with the same repository is being edited.\n"
+"This repository reference cannot be edited at this time. Either the"
+" associated repository is already being edited or another repository"
+" reference that is associated with the same repository is being edited.\n"
 "\n"
 "To edit this repository reference, you need to close the repository."
 msgstr ""
-"Aquesta referència a un repositori no es pot editar en aquest moment. Pot "
-"ser que ja s'estigui editant el repositori associat o que una altra "
-"referència de repositori que estigui associada amb el mateix repositori "
-"s'estigui editant.\n"
+"Aquesta referència a un repositori no es pot editar en aquest moment. Pot ser"
+" que ja s'estigui editant el repositori associat o que una altra referència"
+" de repositori que estigui associada amb el mateix repositori s'estigui"
+" editant.\n"
 "\n"
 "Per editar aquesta referència a un repositori, cal tancar el repositori."
 
@@ -13858,17 +13825,17 @@ msgstr "No s'ha seleccionat cap origen"
 
 #: ../gramps/gui/editors/editcitation.py:308
 msgid ""
-"A source is anything (personal testimony, video recording, photograph, "
-"newspaper column, gravestone...) from which information can be derived. To "
-"create a citation, first select the required source, and then record the "
-"location of the information referenced within the source in the 'Volume/"
-"Page' field."
+"A source is anything (personal testimony, video recording, photograph,"
+" newspaper column, gravestone...) from which information can be derived. To"
+" create a citation, first select the required source, and then record the"
+" location of the information referenced within the source in the"
+" 'Volume/Page' field."
 msgstr ""
-"Una font ho es tot (un testimoni personal, una gravació de vídeo, una "
-"fotografia, una columna de diari, una làpida...) des de la qual es pot "
-"treure informació. Per crear una cita, primer selecciona la font requerida, "
-"i després enregistra la ubicació de l'informació referenciada dins de la "
-"font al camp 'Volum/Pàgina'."
+"Una font ho es tot (un testimoni personal, una gravació de vídeo, una"
+" fotografia, una columna de diari, una làpida...) des de la qual es pot"
+" treure informació. Per crear una cita, primer selecciona la font requerida,"
+" i després enregistra la ubicació de l'informació referenciada dins de la"
+" font al camp 'Volum/Pàgina'."
 
 #: ../gramps/gui/editors/editcitation.py:322
 msgid "Cannot save citation. ID already exists."
@@ -13884,14 +13851,14 @@ msgstr "No es pot desar la cita. L'Id ja existeix."
 #: ../gramps/gui/editors/editsource.py:210
 #, python-format
 msgid ""
-"You have attempted to use the existing Gramps ID with value %(id)s. This "
-"value is already used by '%(prim_object)s'. Please enter a different ID or "
-"leave blank to get the next available ID value."
+"You have attempted to use the existing Gramps ID with value %(id)s. This"
+" value is already used by '%(prim_object)s'. Please enter a different ID or"
+" leave blank to get the next available ID value."
 msgstr ""
-"Ha intentat d'utilitzar l'Id de Gramps %(id)s, que ja existeix. Aquest valor "
-"ja està agafat per '%(prim_object)s'. Si us plau introdueixi un Id diferent, "
-"o deixi'l en blanc per agafar automàticament el següent valor d'Id "
-"disponible."
+"Ha intentat d'utilitzar l'Id de Gramps %(id)s, que ja existeix. Aquest valor"
+" ja està agafat per '%(prim_object)s'. Si us plau introdueixi un Id diferent,"
+" o deixi'l en blanc per agafar automàticament el següent valor d'Id"
+" disponible."
 
 #: ../gramps/gui/editors/editcitation.py:333
 #, python-format
@@ -13993,8 +13960,8 @@ msgstr "No es pot desar l'esdeveniment"
 #: ../gramps/gui/editors/editevent.py:240
 msgid "No data exists for this event. Please enter data or cancel the edit."
 msgstr ""
-"No hi han dades per aquest esdeveniment. Si us plau, introduïu dades o "
-"cancel·leu l'edició."
+"No hi han dades per aquest esdeveniment. Si us plau, introduïu dades o"
+" cancel·leu l'edició."
 
 #: ../gramps/gui/editors/editevent.py:250
 #: ../gramps/gui/editors/editreference.py:277
@@ -14158,15 +14125,15 @@ msgstr "Afegint pares a una persona"
 
 #: ../gramps/gui/editors/editfamily.py:418
 msgid ""
-"It is possible to accidentally create multiple families with the same "
-"parents. To help avoid this problem, only the buttons to select parents are "
-"available when you create a new family. The remaining fields will become "
-"available after you attempt to select a parent."
+"It is possible to accidentally create multiple families with the same"
+" parents. To help avoid this problem, only the buttons to select parents are"
+" available when you create a new family. The remaining fields will become"
+" available after you attempt to select a parent."
 msgstr ""
-"És possible de crear accidentalment diferents famílies amb els mateixos "
-"progenitors. Per ajudar a evitar aquest problema, només estan disponibles "
-"els botons de seleccionar progenitors quan es crea una família nova. La "
-"resta de camps quedaran disponibles després de seleccionar un progenitor."
+"És possible de crear accidentalment diferents famílies amb els mateixos"
+" progenitors. Per ajudar a evitar aquest problema, només estan disponibles"
+" els botons de seleccionar progenitors quan es crea una família nova. La"
+" resta de camps quedaran disponibles després de seleccionar un progenitor."
 
 #: ../gramps/gui/editors/editfamily.py:523
 msgid "Family has changed"
@@ -14175,18 +14142,18 @@ msgstr "La família ha canviat"
 #: ../gramps/gui/editors/editfamily.py:524
 #, python-format
 msgid ""
-"The %(object)s you are editing has changed outside this editor. This can be "
-"due to a change in one of the main views, for example a source used here is "
-"deleted in the source view.\n"
-"To make sure the information shown is still correct, the data shown has been "
-"updated. Some edits you have made may have been lost."
+"The %(object)s you are editing has changed outside this editor. This can be"
+" due to a change in one of the main views, for example a source used here is"
+" deleted in the source view.\n"
+"To make sure the information shown is still correct, the data shown has been"
+" updated. Some edits you have made may have been lost."
 msgstr ""
-"La %(object)s que està editant ha canviat fora d'aquest editor. Això pot ser "
-"degut a un canvi en una de les vistes principals, per exemple, una font que "
-"es faci servir aquí que s'hagi esborrat a la vista de fonts.\n"
-"Per assegurar-se que la informació mostrada encara és correcta, s'han "
-"actualitzat les dades mostrades. Algunes edicions que pugui haver fet es "
-"poden haver perdut."
+"La %(object)s que està editant ha canviat fora d'aquest editor. Això pot ser"
+" degut a un canvi en una de les vistes principals, per exemple, una font que"
+" es faci servir aquí que s'hagi esborrat a la vista de fonts.\n"
+"Per assegurar-se que la informació mostrada encara és correcta, s'han"
+" actualitzat les dades mostrades. Algunes edicions que pugui haver fet es"
+" poden haver perdut."
 
 #: ../gramps/gui/editors/editfamily.py:529
 #: ../gramps/plugins/importer/importcsv.py:227
@@ -14245,13 +14212,13 @@ msgstr "Família Duplicada"
 
 #: ../gramps/gui/editors/editfamily.py:954
 msgid ""
-"A family with these parents already exists in the database. If you save, you "
-"will create a duplicate family. It is recommended that you cancel the "
-"editing of this window, and select the existing family"
+"A family with these parents already exists in the database. If you save, you"
+" will create a duplicate family. It is recommended that you cancel the"
+" editing of this window, and select the existing family"
 msgstr ""
-"Ja existeix una família amb aquests pares a la base de dades. Si desa, "
-"crearà una família duplicada. Es recomana que cancel·li l'edició d'aquesta "
-"finestra, i seleccioni la família existent"
+"Ja existeix una família amb aquests pares a la base de dades. Si desa, crearà"
+" una família duplicada. Es recomana que cancel·li l'edició d'aquesta"
+" finestra, i seleccioni la família existent"
 
 #: ../gramps/gui/editors/editfamily.py:1004
 #, python-format
@@ -14283,8 +14250,8 @@ msgstr "No es pot desar la família"
 #: ../gramps/gui/editors/editfamily.py:1134
 msgid "No data exists for this family. Please enter data or cancel the edit."
 msgstr ""
-"No hi ha dades per aquesta família. Si us plau, introdueixi les dades, o "
-"cancel·li l'edició."
+"No hi ha dades per aquesta família. Si us plau, introdueixi les dades, o"
+" cancel·li l'edició."
 
 #: ../gramps/gui/editors/editfamily.py:1142
 msgid "Cannot save family. ID already exists."
@@ -14295,13 +14262,13 @@ msgstr "No es pot desar la família. L'Id ja existeix."
 #: ../gramps/gui/editors/editreference.py:295
 #, python-format
 msgid ""
-"You have attempted to use the existing Gramps ID with value %(id)s. This "
-"value is already used. Please enter a different ID or leave blank to get the "
-"next available ID value."
+"You have attempted to use the existing Gramps ID with value %(id)s. This"
+" value is already used. Please enter a different ID or leave blank to get the"
+" next available ID value."
 msgstr ""
-"Ha intentat d'utilitzar l'Id de Gramps %(id)s, que ja existeix. Aquest valor "
-"ja està en ús. Si us plau introdueixi un Id diferent, o deixi'l en blanc per "
-"agafar automàticament el següent valor d'Id disponible."
+"Ha intentat d'utilitzar l'Id de Gramps %(id)s, que ja existeix. Aquest valor"
+" ja està en ús. Si us plau introdueixi un Id diferent, o deixi'l en blanc per"
+" agafar automàticament el següent valor d'Id disponible."
 
 #: ../gramps/gui/editors/editfamily.py:1158
 msgid "Add Family"
@@ -14376,8 +14343,8 @@ msgstr "No es pot desar el medi audiovisual"
 msgid ""
 "No data exists for this media object. Please enter data or cancel the edit."
 msgstr ""
-"No hi ha dades per a aquest objecte audiovisual. Si us plau, introdueixi "
-"dades o cancel·li l'edició."
+"No hi ha dades per a aquest objecte audiovisual. Si us plau, introdueixi"
+" dades o cancel·li l'edició."
 
 #: ../gramps/gui/editors/editmedia.py:299
 #: ../gramps/gui/editors/editreference.py:280
@@ -14391,11 +14358,11 @@ msgstr "No hi ha cap mitjà que correspongui al valor de ruta actual!"
 #: ../gramps/gui/editors/editmedia.py:315
 #, python-format
 msgid ""
-"You have attempted to use the path with value '%(path)s'. This path does not "
-"exist! Please enter a different path"
+"You have attempted to use the path with value '%(path)s'. This path does not"
+" exist! Please enter a different path"
 msgstr ""
-"Ha intentat d'utilitzar un camí amb el valor '%(path)s'. Aquest camí no "
-"existeix! Si us plau introdueixi un camí diferent"
+"Ha intentat d'utilitzar un camí amb el valor '%(path)s'. Aquest camí no"
+" existeix! Si us plau introdueixi un camí diferent"
 
 #: ../gramps/gui/editors/editmedia.py:326
 #: ../gramps/gui/editors/editmediaref.py:527
@@ -14453,8 +14420,8 @@ msgstr "Trencar l'agrupació de noms global?"
 #: ../gramps/gui/editors/editname.py:381
 #, python-format
 msgid ""
-"All people with the name of %(surname)s will no longer be grouped with the "
-"name of %(group_name)s."
+"All people with the name of %(surname)s will no longer be grouped with the"
+" name of %(group_name)s."
 msgstr ""
 "Totes les persones amb nom %(surname)s deixaran d'agrupar-se amb el nom "
 "%(group_name)s."
@@ -14474,8 +14441,8 @@ msgstr "Agrupar totes les persones amb el mateix nom?"
 #: ../gramps/gui/editors/editname.py:413
 #, python-format
 msgid ""
-"You have the choice of grouping all people with the name of %(surname)s with "
-"the name of %(group_name)s, or just mapping this particular name."
+"You have the choice of grouping all people with the name of %(surname)s with"
+" the name of %(group_name)s, or just mapping this particular name."
 msgstr ""
 "Té l'opció d'agrupar totes les persones anomenades %(surname)s amb el nom de "
 "%(group_name)s, o només associar aquest nom en particular."
@@ -14527,8 +14494,8 @@ msgstr "No es pot desar la nota"
 #: ../gramps/gui/editors/editnote.py:319
 msgid "No data exists for this note. Please enter data or cancel the edit."
 msgstr ""
-"No hi ha dades per aquesta nota. Si us plau, introdueixi'n o cancel·li "
-"l'edició."
+"No hi ha dades per aquesta nota. Si us plau, introdueixi'n o cancel·li"
+" l'edició."
 
 #: ../gramps/gui/editors/editnote.py:327
 msgid "Cannot save note. ID already exists."
@@ -14603,8 +14570,8 @@ msgstr "No es pot desar la persona"
 #: ../gramps/gui/editors/editperson.py:820
 msgid "No data exists for this person. Please enter data or cancel the edit."
 msgstr ""
-"No hi ha dades per aquesta persona. Si us plau, introdueixi'n o cancel·li "
-"l'edició."
+"No hi ha dades per aquesta persona. Si us plau, introdueixi'n o cancel·li"
+" l'edició."
 
 #: ../gramps/gui/editors/editperson.py:844
 msgid "Cannot save person. ID already exists."
@@ -14630,11 +14597,11 @@ msgstr "S'ha especificat un gènere desconegut"
 
 #: ../gramps/gui/editors/editperson.py:1099
 msgid ""
-"The gender of the person is currently unknown. Usually, this is a mistake. "
-"Please specify the gender."
+"The gender of the person is currently unknown. Usually, this is a mistake."
+" Please specify the gender."
 msgstr ""
-"El gènere de la persona ara mateix és desconegut. Normalment, això és un "
-"error. Especifiqui si us plau el gènere."
+"El gènere de la persona ara mateix és desconegut. Normalment, això és un"
+" error. Especifiqui si us plau el gènere."
 
 #: ../gramps/gui/editors/editperson.py:1102
 msgid "_Male"
@@ -14847,8 +14814,8 @@ msgstr "No es pot desar el repositori"
 msgid ""
 "No data exists for this repository. Please enter data or cancel the edit."
 msgstr ""
-"No hi ha dades per aquest repositori. Si us plau, introdueixi'n o cancel·li "
-"l'edició."
+"No hi ha dades per aquest repositori. Si us plau, introdueixi'n o cancel·li"
+" l'edició."
 
 #: ../gramps/gui/editors/editrepository.py:199
 #, python-format
@@ -14884,8 +14851,8 @@ msgstr "No es pot desar la font"
 #: ../gramps/gui/editors/editsource.py:199
 msgid "No data exists for this source. Please enter data or cancel the edit."
 msgstr ""
-"No hi ha dades per aquesta font. Si us plau, introdueixi'n o cancel·li "
-"l'edició."
+"No hi ha dades per aquesta font. Si us plau, introdueixi'n o cancel·li"
+" l'edició."
 
 #: ../gramps/gui/editors/editsource.py:209
 msgid "Cannot save source. ID already exists."
@@ -14995,8 +14962,7 @@ msgstr "Selecciona'n %s d'una llista"
 #: ../gramps/gui/editors/filtereditor.py:391
 msgid "Give or select a source ID, leave empty to find objects with no source."
 msgstr ""
-"Donar o seleccionar un Id de font, deixar buit per trobar objectes sense "
-"font."
+"Donar o seleccionar un Id de font, deixar buit per trobar objectes sense font."
 
 #: ../gramps/gui/editors/filtereditor.py:567
 msgid "Include selected Gramps ID"
@@ -15053,21 +15019,20 @@ msgstr "Utilitza expressions regulars"
 #: ../gramps/gui/editors/filtereditor.py:606
 msgid ""
 "Interpret the contents of string fields as regular expressions.\n"
-"A decimal point will match any character. A question mark will match zero or "
-"one occurences of the previous character or group. An asterisk will match "
-"zero or more occurences. A plus sign will match one or more occurences. Use "
-"parentheses to group expressions. Specify alternatives using a vertical bar. "
-"A caret will match the start of a line. A dollar sign will match the end of "
-"a line."
+"A decimal point will match any character. A question mark will match zero or"
+" one occurences of the previous character or group. An asterisk will match"
+" zero or more occurences. A plus sign will match one or more occurences. Use"
+" parentheses to group expressions. Specify alternatives using a vertical bar."
+" A caret will match the start of a line. A dollar sign will match the end of"
+" a line."
 msgstr ""
 "Interpretar els continguts dels camps de cadena com a expressions regulars.\n"
-"El punt concordarà amb qualsevol caràcter. Un signe d'interrogació "
-"concordarà amb zero o una aparicions del caràcter o grup anteriors. Un "
-"asterisc concordarà amb zero o més aparicions. Un signe de suma concordarà "
-"amb una o més aparicions. Utilitzeu parèntesis per agrupar expressions. "
-"Especifiqueu alternatives amb la barra vertical. L'accent circumflex "
-"concorda amb l'inici de línia. Un signe de dòlar concorda amb el final de la "
-"línia."
+"El punt concordarà amb qualsevol caràcter. Un signe d'interrogació concordarà"
+" amb zero o una aparicions del caràcter o grup anteriors. Un asterisc"
+" concordarà amb zero o més aparicions. Un signe de suma concordarà amb una o"
+" més aparicions. Utilitzeu parèntesis per agrupar expressions. Especifiqueu"
+" alternatives amb la barra vertical. L'accent circumflex concorda amb l'inici"
+" de línia. Un signe de dòlar concorda amb el final de la línia."
 
 #: ../gramps/gui/editors/filtereditor.py:635
 msgid "Rule Name"
@@ -15108,11 +15073,11 @@ msgstr "Esborrar Filtre?"
 
 #: ../gramps/gui/editors/filtereditor.py:1200
 msgid ""
-"This filter is currently being used as the base for other filters. Deleting "
-"this filter will result in removing all other filters that depend on it."
+"This filter is currently being used as the base for other filters. Deleting"
+" this filter will result in removing all other filters that depend on it."
 msgstr ""
-"Aquest filtre està sent utilitzat com a base d'altres filtres. Esborrar-lo, "
-"provocarà esborrar tots els altres filtres que el referencien."
+"Aquest filtre està sent utilitzat com a base d'altres filtres. Esborrar-lo,"
+" provocarà esborrar tots els altres filtres que el referencien."
 
 #: ../gramps/gui/editors/filtereditor.py:1204
 msgid "Delete Filter"
@@ -15121,8 +15086,8 @@ msgstr "Esborra Filtre"
 #: ../gramps/gui/editors/objectentries.py:291
 msgid "To select a place, use drag-and-drop or use the buttons"
 msgstr ""
-"Per seleccionar un lloc, faci-ho arrossegant i deixant, o fent servir els "
-"botons"
+"Per seleccionar un lloc, faci-ho arrossegant i deixant, o fent servir els"
+" botons"
 
 #: ../gramps/gui/editors/objectentries.py:293
 msgid "No place given, click button to select one"
@@ -15176,8 +15141,8 @@ msgstr "Esborra una font"
 #: ../gramps/gui/editors/objectentries.py:384
 msgid "To select a media object, use drag-and-drop or use the buttons"
 msgstr ""
-"Per seleccionar un objecte audiovisual, faci arrossegar i deixar, o faci "
-"servir els botons"
+"Per seleccionar un objecte audiovisual, faci arrossegar i deixar, o faci"
+" servir els botons"
 
 #: ../gramps/gui/editors/objectentries.py:386
 #: ../gramps/gui/plug/_guioptions.py:1116
@@ -15256,8 +15221,8 @@ msgstr "%s no és"
 msgid "%s does not contain"
 msgstr "El %s no conté"
 
-#: ../gramps/gui/filters/_searchbar.py:168 ../gramps/gui/views/listview.py:1198
-#: ../gramps/gui/views/listview.py:1218 ../gramps/plugins/gramplet/leak.py:193
+#: ../gramps/gui/filters/_searchbar.py:168 ../gramps/gui/views/listview.py:1199
+#: ../gramps/gui/views/listview.py:1219 ../gramps/plugins/gramplet/leak.py:193
 #: ../gramps/plugins/gramplet/leak.py:200
 msgid "Updating display..."
 msgstr "Actualitzant visualització..."
@@ -15307,7 +15272,7 @@ msgstr "Participants"
 #: ../gramps/gui/widgets/reorderfam.py:103
 #: ../gramps/plugins/textreport/tagreport.py:264
 #: ../gramps/plugins/view/familyview.py:82
-#: ../gramps/plugins/webreport/person.py:1247
+#: ../gramps/plugins/webreport/person.py:1254
 msgid "Relationship"
 msgstr "Relació"
 
@@ -15317,7 +15282,7 @@ msgstr "qualsevol"
 
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:134
 #: ../gramps/plugins/export/exportcsv.py:357
-#: ../gramps/plugins/webreport/person.py:1862
+#: ../gramps/plugins/webreport/person.py:1869
 msgid "Birth date"
 msgstr "Data de naixement"
 
@@ -15329,7 +15294,7 @@ msgstr "exemple: \"%(msg1)s\" o \"%(msg2)s\""
 
 #: ../gramps/gui/filters/sidebar/_personsidebarfilter.py:136
 #: ../gramps/plugins/export/exportcsv.py:359
-#: ../gramps/plugins/webreport/person.py:1863
+#: ../gramps/plugins/webreport/person.py:1870
 msgid "Death date"
 msgstr "Data de defunció"
 
@@ -15570,13 +15535,13 @@ msgstr ""
 
 #: ../gramps/gui/glade/dialog.glade:370
 msgid ""
-"If you check this button, all the missing media files will be automatically "
-"treated according to the currently selected option. No further dialogs will "
-"be presented for any missing media files."
+"If you check this button, all the missing media files will be automatically"
+" treated according to the currently selected option. No further dialogs will"
+" be presented for any missing media files."
 msgstr ""
-"Si selecciona aquest botó, tots els mitjans audiovisuals que falten es "
-"tractaran automàticament segons digui l'opció seleccionada actualment. No es "
-"presentaran més diàlegs per possibles fitxers audiovisuals que faltin."
+"Si selecciona aquest botó, tots els mitjans audiovisuals que falten es"
+" tractaran automàticament segons digui l'opció seleccionada actualment. No es"
+" presentaran més diàlegs per possibles fitxers audiovisuals que faltin."
 
 #: ../gramps/gui/glade/dialog.glade:422
 msgid "Cancel the rest of the operations"
@@ -15610,14 +15575,16 @@ msgstr "_Utilitza aquesta resposta per a la resta d'elements"
 #: ../gramps/gui/glade/dialog.glade:533
 #: ../gramps/plugins/tool/reorderids.glade:121
 msgid ""
-"If you check this button, your next answer will apply to the rest of the "
-"selected items"
+"If you check this button, your next answer will apply to the rest of the"
+" selected items"
 msgstr ""
-"Si selecciona aquest botó, la seva propera resposta s'aplicarà per a la "
-"resta d'elements seleccionats"
+"Si selecciona aquest botó, la seva propera resposta s'aplicarà per a la resta"
+" d'elements seleccionats"
 
 #: ../gramps/gui/glade/dialog.glade:776 ../gramps/gui/glade/dialog.glade:793
 #: ../gramps/gui/glade/dialog.glade:906
+#: ../gramps/plugins/tool/removespaces.glade:115
+#: ../gramps/plugins/tool/removespaces.glade:172
 msgid "label"
 msgstr "etiqueta"
 
@@ -15627,7 +15594,7 @@ msgstr "_Tanca sense desar"
 
 #: ../gramps/gui/glade/dialog.glade:873
 #: ../gramps/gui/plug/report/_bookdialog.py:637
-#: ../gramps/gui/views/listview.py:1065
+#: ../gramps/gui/views/listview.py:1066
 #: ../gramps/gui/widgets/grampletpane.py:589
 #: ../gramps/plugins/tool/eventcmp.py:400
 msgid "_Save"
@@ -15713,8 +15680,8 @@ msgstr "Número de telèfon enllaçat a l'adreça."
 msgid ""
 "The state or county of the address in case a mail address must contain this."
 msgstr ""
-"L'estat o comarca de l'adreça en cas que una adreça de correu els hagi de "
-"contenir."
+"L'estat o comarca de l'adreça en cas que una adreça de correu els hagi de"
+" contenir."
 
 #: ../gramps/gui/glade/editaddress.glade:250
 msgid "Country of the address"
@@ -15728,8 +15695,8 @@ msgid ""
 msgstr ""
 "Adreça de correu. \n"
 "\n"
-"Nota: Utilitzeu l'Esdeveniment de Residència per a dades d'adreça "
-"genealògiques."
+"Nota: Utilitzeu l'Esdeveniment de Residència per a dades d'adreça"
+" genealògiques."
 
 #: ../gramps/gui/glade/editaddress.glade:290
 #: ../gramps/gui/glade/editattribute.glade:146
@@ -15800,23 +15767,23 @@ msgstr "El valor de l'atribut. P.ex. 1,8, Feia sol, o Ulls blaus."
 
 #: ../gramps/gui/glade/editattribute.glade:167
 msgid ""
-"The name of an attribute you want to use. For example: Height (for a "
-"person), Weather on this Day (for an event), ... \n"
-"Use this to store snippets of information you collect and want to correctly "
-"link to sources. Attributes can be used for people, families, events and "
-"media.\n"
+"The name of an attribute you want to use. For example: Height (for a person),"
+" Weather on this Day (for an event), ... \n"
+"Use this to store snippets of information you collect and want to correctly"
+" link to sources. Attributes can be used for people, families, events and"
+" media.\n"
 " \n"
-"Note: several predefined attributes refer to values present in the GEDCOM "
-"standard."
+"Note: several predefined attributes refer to values present in the GEDCOM"
+" standard."
 msgstr ""
-"El nom d'un atribut que vol utilitzar. Per exemple: Alçada (per una "
-"persona), Temps que feia aquell Dia (per un esdeveniment), ... \n"
-"Utilitzeu-ho per emmagatzemar bocinets d'informació que recolliu i que voleu "
-"enllaçar de forma correcta amb les fonts. Els atributs es poden utilitzar "
-"per persones, famílies, esdeveniments i medis audiovisuals.\n"
+"El nom d'un atribut que vol utilitzar. Per exemple: Alçada (per una persona),"
+" Temps que feia aquell Dia (per un esdeveniment), ... \n"
+"Utilitzeu-ho per emmagatzemar bocinets d'informació que recolliu i que voleu"
+" enllaçar de forma correcta amb les fonts. Els atributs es poden utilitzar"
+" per persones, famílies, esdeveniments i medis audiovisuals.\n"
 "\n"
-"Nota: alguns atributs predefinits es refereixen a valors presents a "
-"l'estàndard GEDCOM."
+"Nota: alguns atributs predefinits es refereixen a valors presents a"
+" l'estàndard GEDCOM."
 
 #: ../gramps/gui/glade/editchildref.glade:97
 msgid "Relationship to _Mother:"
@@ -15843,22 +15810,22 @@ msgstr "Edició"
 
 #: ../gramps/gui/glade/editcitation.glade:136
 msgid ""
-"Specific location within the information referenced. For a published work, "
-"this could include the volume of a multi-volume work and the page number(s). "
-"For a periodical, it could include volume, issue, and page numbers. For a "
-"newspaper, it could include a column number and page number. For an "
-"unpublished source, this could be a sheet number, page number, frame number, "
-"etc. A census record might have a line number or dwelling and family numbers "
-"in addition to the page number. "
+"Specific location within the information referenced. For a published work,"
+" this could include the volume of a multi-volume work and the page number(s)."
+" For a periodical, it could include volume, issue, and page numbers. For a"
+" newspaper, it could include a column number and page number. For an"
+" unpublished source, this could be a sheet number, page number, frame number,"
+" etc. A census record might have a line number or dwelling and family numbers"
+" in addition to the page number. "
 msgstr ""
-"Ubicació específica dins de la informació referenciada. Per una obra "
-"publicada, això podria incloure el volum dins d'una obra de diversos volums, "
-"i el(s) número(s) de pàgina. Per una publicació periòdica, podria incloure "
-"el volum, exemplar, i números de pàgina. Per un diari, podria incloure un "
-"número de columna i número de pàgina. Per una font no publicada, podria ser "
-"un número de full, de pàgina, de marc, etc. Un registre censal podria tenir "
-"un número de línia o d'habitatge i números de família apart del número de "
-"pàgina. "
+"Ubicació específica dins de la informació referenciada. Per una obra"
+" publicada, això podria incloure el volum dins d'una obra de diversos volums,"
+" i el(s) número(s) de pàgina. Per una publicació periòdica, podria incloure"
+" el volum, exemplar, i números de pàgina. Per un diari, podria incloure un"
+" número de columna i número de pàgina. Per una font no publicada, podria ser"
+" un número de full, de pàgina, de marc, etc. Un registre censal podria tenir"
+" un número de línia o d'habitatge i números de família apart del número de"
+" pàgina. "
 
 #: ../gramps/gui/glade/editcitation.glade:152
 msgid "_Volume/Page:"
@@ -15870,35 +15837,34 @@ msgstr "Con_fiança:"
 
 #: ../gramps/gui/glade/editcitation.glade:181
 msgid ""
-"The date of the entry in the source you are referencing, e.g. the date a "
-"house was visited during a census, or the date an entry was made in a birth "
-"log/registry. "
+"The date of the entry in the source you are referencing, e.g. the date a"
+" house was visited during a census, or the date an entry was made in a birth"
+" log/registry. "
 msgstr ""
-"La data de l'entrada en la font que esteu referenciant, per exemple, la data "
-"que es va visitar una casa durant un cens, o la data que es va omplir un "
-"registre de naixement. "
+"La data de l'entrada en la font que esteu referenciant, per exemple, la data"
+" que es va visitar una casa durant un cens, o la data que es va omplir un"
+" registre de naixement. "
 
 #: ../gramps/gui/glade/editcitation.glade:201
 #, fuzzy
 msgid ""
-"Conveys the submitter's quantitative evaluation of the credibility of a "
-"piece of information, based upon its supporting evidence. It is not intended "
-"to eliminate the receiver's need to evaluate the evidence for themselves.\n"
+"Conveys the submitter's quantitative evaluation of the credibility of a piece"
+" of information, based upon its supporting evidence. It is not intended to"
+" eliminate the receiver's need to evaluate the evidence for themselves.\n"
 "-Very Low =Unreliable evidence or estimated data.\n"
-"-Low =Questionable reliability of evidence (interviews, census, oral "
-"genealogies, or potential for bias for example, an autobiography).\n"
+"-Low =Questionable reliability of evidence (interviews, census, oral"
+" genealogies, or potential for bias for example, an autobiography).\n"
 "-High =Secondary evidence, data officially recorded sometime after event.\n"
-"-Very High =Direct and primary evidence used, or by dominance of the "
-"evidence."
+"-Very High =Direct and primary evidence used, or by dominance of the evidence."
 msgstr ""
-"Expressa l'avaluació quantitativa de la credibilitat d'una informació, "
-"segons qui l'aporta, basant-se en les proves que la suporten. No és per "
-"eliminar la necessitat del receptor d'avaluar les proves per si mateix.\n"
+"Expressa l'avaluació quantitativa de la credibilitat d'una informació, segons"
+" qui l'aporta, basant-se en les proves que la suporten. No és per eliminar la"
+" necessitat del receptor d'avaluar les proves per si mateix.\n"
 "Molt Baix =Proves no fiables o dades estimades\n"
-"Baix =Fiabilitat de la prova qüestionable (entrevistes, cens, genealogies "
-"orals, o biaix potencial, per exemple, una autobiografia)\n"
-"Alt =Prova secundària, dades registrades oficialment algun temps després de "
-"l'esdeveniment\n"
+"Baix =Fiabilitat de la prova qüestionable (entrevistes, cens, genealogies"
+" orals, o biaix potencial, per exemple, una autobiografia)\n"
+"Alt =Prova secundària, dades registrades oficialment algun temps després de"
+" l'esdeveniment\n"
 "Molt Alt =Prova directa i primària, o per evidència aclaparadora "
 
 #: ../gramps/gui/glade/editcitation.glade:226
@@ -16011,11 +15977,11 @@ msgstr "De_scripció:"
 
 #: ../gramps/gui/glade/editevent.glade:177
 msgid ""
-"Description of the event. Leave empty if you want to autogenerate this with "
-"the tool 'Extract Event Description'."
+"Description of the event. Leave empty if you want to autogenerate this with"
+" the tool 'Extract Event Description'."
 msgstr ""
-"Descripció de l'esdeveniment. Deixeu-ho buit si voleu autogenerar-ho amb "
-"l'eina 'Extreure Descripció de l'Esdeveniment'."
+"Descripció de l'esdeveniment. Deixeu-ho buit si voleu autogenerar-ho amb"
+" l'eina 'Extreure Descripció de l'Esdeveniment'."
 
 #: ../gramps/gui/glade/editevent.glade:194
 #: ../gramps/gui/glade/editeventref.glade:270
@@ -16039,11 +16005,11 @@ msgstr ""
 
 #: ../gramps/gui/glade/editevent.glade:326
 msgid ""
-"Date of the event. This can be an exact date, a range (from ... to, "
-"between, ...), or an inexact date (about, ...)."
+"Date of the event. This can be an exact date, a range (from ... to, between,"
+" ...), or an inexact date (about, ...)."
 msgstr ""
-"Data de l'esdeveniment. Pot ser una data exacta, un rang (de ... a, "
-"entre, ...), o una data inexacta (al voltant de, ...)."
+"Data de l'esdeveniment. Pot ser una data exacta, un rang (de ... a, entre,"
+" ...), o una data inexacta (al voltant de, ...)."
 
 #: ../gramps/gui/glade/editevent.glade:375
 #: ../gramps/gui/glade/editeventref.glade:451
@@ -16062,12 +16028,12 @@ msgstr "_Paper:"
 
 #: ../gramps/gui/glade/editeventref.glade:538
 msgid ""
-"<b>Note:</b> Any changes in the shared event information will be reflected "
-"in the event itself, for all participants in the event."
+"<b>Note:</b> Any changes in the shared event information will be reflected in"
+" the event itself, for all participants in the event."
 msgstr ""
-"<b>Nota:</b> Qualssevol canvis a la informació de l'esdeveniment compartit "
-"es reflectiran al propi esdeveniment, per a tots els participants a "
-"l'esdeveniment."
+"<b>Nota:</b> Qualssevol canvis a la informació de l'esdeveniment compartit es"
+" reflectiran al propi esdeveniment, per a tots els participants a"
+" l'esdeveniment."
 
 #: ../gramps/gui/glade/editeventref.glade:624
 #: ../gramps/gui/glade/editplaceref.glade:694
@@ -16131,11 +16097,11 @@ msgstr "_Tipus:"
 
 #: ../gramps/gui/glade/editfamily.glade:712
 msgid ""
-"The relationship type, eg 'Married' or 'Unmarried'. Use Events for more "
-"details."
+"The relationship type, eg 'Married' or 'Unmarried'. Use Events for more"
+" details."
 msgstr ""
-"El tipus de relació, p.ex. 'Casat' o 'No casat'. Utilitzeu els Esdeveniments "
-"per més detalls."
+"El tipus de relació, p.ex. 'Casat' o 'No casat'. Utilitzeu els Esdeveniments"
+" per més detalls."
 
 #: ../gramps/gui/glade/editfamily.glade:733
 #: ../gramps/gui/glade/editmedia.glade:360
@@ -16197,11 +16163,11 @@ msgstr "_Parròquia:"
 
 #: ../gramps/gui/glade/editlocation.glade:150
 msgid ""
-"Lowest clergical division of this place. Typically used for church sources "
-"that only mention the parish."
+"Lowest clergical division of this place. Typically used for church sources"
+" that only mention the parish."
 msgstr ""
-"Mínima divisió eclesiàstica d'aquest lloc. Utilitzat típicament per fonts "
-"eclesiàstiques que només mencionen la parròquia."
+"Mínima divisió eclesiàstica d'aquest lloc. Utilitzat típicament per fonts"
+" eclesiàstiques que només mencionen la parròquia."
 
 #: ../gramps/gui/glade/editlocation.glade:164
 msgid "Co_unty:"
@@ -16217,11 +16183,11 @@ msgstr "_Estat:"
 
 #: ../gramps/gui/glade/editlocation.glade:206
 msgid ""
-"Second level of place division, eg., in the USA a state, in Germany a "
-"Bundesland."
+"Second level of place division, eg., in the USA a state, in Germany a"
+" Bundesland."
 msgstr ""
-"Segon nivell de divisió del lloc, p.ex., als EUA un estat, a Alemanya un "
-"Bundesland."
+"Segon nivell de divisió del lloc, p.ex., als EUA un estat, a Alemanya un"
+" Bundesland."
 
 #: ../gramps/gui/glade/editlocation.glade:234
 msgid "The country where the place is."
@@ -16247,17 +16213,17 @@ msgstr "Visualització prèvia d'imatge"
 #: ../gramps/gui/glade/editmedia.glade:205
 msgid ""
 "Path of the media object on your computer.\n"
-"Gramps does not store the media internally, it only stores the path! Set the "
-"'Relative Path' in the Preferences to avoid retyping the common base "
-"directory where all your media is stored. The 'Media Manager' tool can help "
-"managing paths of a collection of media objects. "
+"Gramps does not store the media internally, it only stores the path! Set the"
+" 'Relative Path' in the Preferences to avoid retyping the common base"
+" directory where all your media is stored. The 'Media Manager' tool can help"
+" managing paths of a collection of media objects. "
 msgstr ""
 "Camí de l'objecte audiovisual al seu ordinador.\n"
-"Gramps no emmagatzema internament el medi audiovisual, només en guarda el "
-"camí! Ompliu el 'Camí Relatiu' a les Preferències per estalviar-vos de "
-"tornar a escriure el directori base on emmagatzemeu tots els medis "
-"audiovisuals. L'eina 'Gestor de Medis' pot ajudar a gestionar els camins "
-"d'una col·lecció d'objectes audiovisuals. "
+"Gramps no emmagatzema internament el medi audiovisual, només en guarda el"
+" camí! Ompliu el 'Camí Relatiu' a les Preferències per estalviar-vos de"
+" tornar a escriure el directori base on emmagatzemeu tots els medis"
+" audiovisuals. L'eina 'Gestor de Medis' pot ajudar a gestionar els camins"
+" d'una col·lecció d'objectes audiovisuals. "
 
 #: ../gramps/gui/glade/editmedia.glade:219
 #: ../gramps/gui/glade/editmediaref.glade:423
@@ -16267,8 +16233,8 @@ msgstr "Títol descriptiu per aquest objecte audiovisual."
 #: ../gramps/gui/glade/editmedia.glade:270
 msgid "Open File Browser to select a media file on your computer."
 msgstr ""
-"Obriu el Navegador de Fitxers per seleccionar un fitxer audiovisual al seu "
-"ordinador."
+"Obriu el Navegador de Fitxers per seleccionar un fitxer audiovisual al seu"
+" ordinador."
 
 #: ../gramps/gui/glade/editmedia.glade:279
 #: ../gramps/gui/glade/editmediaref.glade:660
@@ -16283,8 +16249,8 @@ msgstr "Un Id únic per identificar l'objecte Audiovisual."
 msgid ""
 "A date associated with the media, eg., for a picture the date it is taken."
 msgstr ""
-"Una data associada amb el medi audiovisual, p.ex. per una foto, la data en "
-"què es va fer."
+"Una data associada amb el medi audiovisual, p.ex. per una foto, la data en"
+" què es va fer."
 
 #: ../gramps/gui/glade/editmediaref.glade:119
 msgid "_Corner 2:  X"
@@ -16294,31 +16260,31 @@ msgstr "_Cantonada 2:  X"
 #: ../gramps/gui/glade/editmediaref.glade:162
 #: ../gramps/gui/glade/editmediaref.glade:240
 msgid ""
-"If media is an image, select the specific part of the image you want to "
-"reference.\n"
-"You can use the mouse on the picture to select a region, or use these "
-"spinbuttons to set the top left, and bottom right corner of the referenced "
-"region. Point (0,0) is the top left corner of the picture, and (100,100) the "
-"bottom right corner."
+"If media is an image, select the specific part of the image you want to"
+" reference.\n"
+"You can use the mouse on the picture to select a region, or use these"
+" spinbuttons to set the top left, and bottom right corner of the referenced"
+" region. Point (0,0) is the top left corner of the picture, and (100,100) the"
+" bottom right corner."
 msgstr ""
-"Si el medi audiovisual és una imatge, seleccioneu la part específica de la "
-"imatge que voleu referenciar.\n"
-"Podeu utilitzar el ratolí damunt de la foto per seleccionar una regió, o "
-"utilitzar aquests botons per marcar les cantonades superior esquerra i "
-"inferior dreta de la regió referenciada. El punt (0,0) és la cantonada "
-"superior esquerra, i (100,100) la cantonada inferior dreta."
+"Si el medi audiovisual és una imatge, seleccioneu la part específica de la"
+" imatge que voleu referenciar.\n"
+"Podeu utilitzar el ratolí damunt de la foto per seleccionar una regió, o"
+" utilitzar aquests botons per marcar les cantonades superior esquerra i"
+" inferior dreta de la regió referenciada. El punt (0,0) és la cantonada"
+" superior esquerra, i (100,100) la cantonada inferior dreta."
 
 #: ../gramps/gui/glade/editmediaref.glade:178
 msgid ""
 "Referenced region of the image media object.\n"
-"Select a region with clicking and holding the mouse button on the top left "
-"corner of the region you want, dragging the mouse to the bottom right corner "
-"of the region, and then releasing the mouse button."
+"Select a region with clicking and holding the mouse button on the top left"
+" corner of the region you want, dragging the mouse to the bottom right corner"
+" of the region, and then releasing the mouse button."
 msgstr ""
 "Regió referenciada de l'objecte audiovisual imatge.\n"
-"Seleccioneu una regió clicant i aguantant el botó del ratolí a la cantonada "
-"superior esquerra de la regió que voleu, arrossegant el ratolí a la "
-"cantonada inferior dreta de la regió, i deixant anar el botó del ratolí."
+"Seleccioneu una regió clicant i aguantant el botó del ratolí a la cantonada"
+" superior esquerra de la regió que voleu, arrossegant el ratolí a la"
+" cantonada inferior dreta de la regió, i deixant anar el botó del ratolí."
 
 #: ../gramps/gui/glade/editmediaref.glade:208
 msgid "_Corner 1:  X"
@@ -16326,27 +16292,27 @@ msgstr "_Cantonada 1:  X"
 
 #: ../gramps/gui/glade/editmediaref.glade:221
 msgid ""
-"If media is an image, select the specific part of the image you want to "
-"reference.\n"
-"You can use the mouse on the picture to select a region, or use these "
-"spinbuttons to set the top left, and bottom right corner of the referenced "
-"region. Point (0,0) is the top left corner of the picture, and (100,100) the "
-"bottom right corner.\n"
+"If media is an image, select the specific part of the image you want to"
+" reference.\n"
+"You can use the mouse on the picture to select a region, or use these"
+" spinbuttons to set the top left, and bottom right corner of the referenced"
+" region. Point (0,0) is the top left corner of the picture, and (100,100) the"
+" bottom right corner.\n"
 msgstr ""
-"Si el medi audiovisual és una imatge, seleccioneu la part específica de la "
-"imatge que voleu referenciar.\n"
-"Podeu utilitzar el ratolí damunt de la foto per seleccionar una regió, o "
-"utilitzar aquests botons per marcar les cantonades superior esquerra i "
-"inferior dreta de la regió referenciada. El punt (0,0) és la cantonada "
-"superior esquerra, i (100,100) la cantonada inferior dreta.\n"
+"Si el medi audiovisual és una imatge, seleccioneu la part específica de la"
+" imatge que voleu referenciar.\n"
+"Podeu utilitzar el ratolí damunt de la foto per seleccionar una regió, o"
+" utilitzar aquests botons per marcar les cantonades superior esquerra i"
+" inferior dreta de la regió referenciada. El punt (0,0) és la cantonada"
+" superior esquerra, i (100,100) la cantonada inferior dreta.\n"
 
 #: ../gramps/gui/glade/editmediaref.glade:459
 msgid ""
-"<b>Note:</b> Any changes in the shared media object information will be "
-"reflected in the media object itself."
+"<b>Note:</b> Any changes in the shared media object information will be"
+" reflected in the media object itself."
 msgstr ""
-"<b>Nota:</b> Qualssevol canvis a la informació del medi audiovisual "
-"compartit es reflectiran al propi medi audiovisual."
+"<b>Nota:</b> Qualssevol canvis a la informació del medi audiovisual compartit"
+" es reflectiran al propi medi audiovisual."
 
 #: ../gramps/gui/glade/editmediaref.glade:488
 msgid "Double click image to view in an external viewer"
@@ -16370,8 +16336,8 @@ msgstr "Informació Compartida"
 msgid ""
 "An identification of what type of Name this is, eg. Birth Name, Married Name."
 msgstr ""
-"Una identificació de quin tipus de Nom és, p.ex. Nom de Naixement, Nom de "
-"Casada."
+"Una identificació de quin tipus de Nom és, p.ex. Nom de Naixement, Nom de"
+" Casada."
 
 #: ../gramps/gui/glade/editname.glade:192
 #: ../gramps/gui/glade/editperson.glade:134
@@ -16403,13 +16369,13 @@ msgstr "_Sobrenom:"
 #: ../gramps/gui/glade/editname.glade:278
 #: ../gramps/gui/glade/editperson.glade:179
 msgid ""
-"Part of the Given name that is the normally used name. If background is red, "
-"call name is not part of Given name and will not be printed underlined in "
-"some reports."
+"Part of the Given name that is the normally used name. If background is red,"
+" call name is not part of Given name and will not be printed underlined in"
+" some reports."
 msgstr ""
-"La part del Nom de pila que és el nom que es fa servir normalment. Si el "
-"fons és vermell, el nom habitual no és part del nom de pila i no s'imprimirà "
-"subratllat en alguns informes."
+"La part del Nom de pila que és el nom que es fa servir normalment. Si el fons"
+" és vermell, el nom habitual no és part del nom de pila i no s'imprimirà"
+" subratllat en alguns informes."
 
 #: ../gramps/gui/glade/editname.glade:291
 #: ../gramps/gui/glade/editperson.glade:211
@@ -16424,8 +16390,8 @@ msgstr "Un sufix opcional per al nom, com ara \"Jr.\" o \"III\""
 #: ../gramps/gui/glade/editname.glade:317
 #: ../gramps/gui/glade/editperson.glade:259
 msgid ""
-"A descriptive name given in place of or in addition to the official given "
-"name."
+"A descriptive name given in place of or in addition to the official given"
+" name."
 msgstr ""
 "Un nom descriptiu que es dóna en comptes de, o a més del nom de pila oficial."
 
@@ -16439,11 +16405,11 @@ msgstr "Mot de la _Família:"
 
 #: ../gramps/gui/glade/editname.glade:398
 msgid ""
-"A non official name given to a family to distinguish them of people with the "
-"same family name. Often referred to as eg. Farm name."
+"A non official name given to a family to distinguish them of people with the"
+" same family name. Often referred to as eg. Farm name."
 msgstr ""
-"Un nom no oficial donat a una família per distingir-los d'altres persones "
-"amb el mateix nom de família. Sovint se'n diu, p.ex., nom del mas."
+"Un nom no oficial donat a una família per distingir-los d'altres persones amb"
+" el mateix nom de família. Sovint se'n diu, p.ex., nom del mas."
 
 #: ../gramps/gui/glade/editname.glade:424
 msgid "Family Names "
@@ -16463,15 +16429,15 @@ msgstr "_Mostra com a:"
 
 #: ../gramps/gui/glade/editname.glade:503
 msgid ""
-"People are displayed according to the name format given in the Preferences "
-"(the default).\n"
-"Here you can make sure this person is displayed according to a custom name "
-"format (extra formats can be set in the Preferences)."
+"People are displayed according to the name format given in the Preferences"
+" (the default).\n"
+"Here you can make sure this person is displayed according to a custom name"
+" format (extra formats can be set in the Preferences)."
 msgstr ""
-"Les persones es mostren segons el format de nom que es dóna a les "
-"Preferències (el predeterminat).\n"
-"Aquí es pot assegurar que aquesta persona es mostri segons un format de nom "
-"personalitzat (es poden crear formats addicionals a les Preferències)."
+"Les persones es mostren segons el format de nom que es dóna a les"
+" Preferències (el predeterminat).\n"
+"Aquí es pot assegurar que aquesta persona es mostri segons un format de nom"
+" personalitzat (es poden crear formats addicionals a les Preferències)."
 
 #: ../gramps/gui/glade/editname.glade:524
 msgid "Dat_e:"
@@ -16479,27 +16445,27 @@ msgstr "Dat_a:"
 
 #: ../gramps/gui/glade/editname.glade:538
 msgid ""
-"People are sorted according to the name format given in the Preferences (the "
-"default).\n"
-"Here you can make sure this person is sorted according to a custom name "
-"format (extra formats can be set in the Preferences)."
+"People are sorted according to the name format given in the Preferences (the"
+" default).\n"
+"Here you can make sure this person is sorted according to a custom name"
+" format (extra formats can be set in the Preferences)."
 msgstr ""
-"Les persones s'ordenen segons el format de nom que es dóna a les "
-"Preferències (el predeterminat).\n"
-"Aquí es pot assegurar que aquesta persona s'ordeni segons un format de nom "
-"personalitzat (es poden crear formats addicionals a les Preferències)."
+"Les persones s'ordenen segons el format de nom que es dóna a les Preferències"
+" (el predeterminat).\n"
+"Aquí es pot assegurar que aquesta persona s'ordeni segons un format de nom"
+" personalitzat (es poden crear formats addicionals a les Preferències)."
 
 #: ../gramps/gui/glade/editname.glade:601
 msgid ""
-"The Person Tree view groups people under the primary surname. You can "
-"override this by setting here a group value. \n"
-"You will be asked if you want to group this person only, or all people with "
-"this specific primary surname."
+"The Person Tree view groups people under the primary surname. You can"
+" override this by setting here a group value. \n"
+"You will be asked if you want to group this person only, or all people with"
+" this specific primary surname."
 msgstr ""
-"La vista d'Arbre de Persones agrupa persones sota el cognom primari. Pot "
-"modificar-ho posant aquí un valor de grup. \n"
-"Se li demanarà si vol agrupar aquesta persona i prou, o totes les persones "
-"que tenen aquest cognom primari concret."
+"La vista d'Arbre de Persones agrupa persones sota el cognom primari. Pot"
+" modificar-ho posant aquí un valor de grup. \n"
+"Se li demanarà si vol agrupar aquesta persona i prou, o totes les persones"
+" que tenen aquest cognom primari concret."
 
 #: ../gramps/gui/glade/editname.glade:615
 msgid "O_verride"
@@ -16507,11 +16473,11 @@ msgstr "Forçar"
 
 #: ../gramps/gui/glade/editname.glade:641
 msgid ""
-"A Date associated with this name. Eg. for a Married Name, date the name is "
-"first used or marriage date."
+"A Date associated with this name. Eg. for a Married Name, date the name is"
+" first used or marriage date."
 msgstr ""
-"Una Data associada amb aquest nom. P.ex. per un Nom de Casada, la data en "
-"què es fa servir el nom per primer cop, o la data del casament."
+"Una Data associada amb aquest nom. P.ex. per un Nom de Casada, la data en què"
+" es fa servir el nom per primer cop, o la data del casament."
 
 #: ../gramps/gui/glade/editnote.glade:101
 msgid "Styled Text Editor"
@@ -16531,16 +16497,16 @@ msgstr "_Preformatat"
 
 #: ../gramps/gui/glade/editnote.glade:198
 msgid ""
-"When active the whitespace in your note will be respected in reports. Use "
-"this to add formatting layout with spaces, eg a table. \n"
-"When not checked, notes are automatically cleaned in the reports, which will "
-"improve the report layout.\n"
+"When active the whitespace in your note will be respected in reports. Use"
+" this to add formatting layout with spaces, eg a table. \n"
+"When not checked, notes are automatically cleaned in the reports, which will"
+" improve the report layout.\n"
 "Use monospace font to keep preformatting."
 msgstr ""
-"Quan estigui actiu, els espais en blanc de la seva nota es respectaran als "
-"informes. Utilitzi-ho per donar format amb espais, com ara una taula. \n"
-"Quan no es marqui, les notes es netegen automàticament als informes, cosa "
-"que millorarà la distribució de l'informe.\n"
+"Quan estigui actiu, els espais en blanc de la seva nota es respectaran als"
+" informes. Utilitzi-ho per donar format amb espais, com ara una taula. \n"
+"Quan no es marqui, les notes es netegen automàticament als informes, cosa que"
+" millorarà la distribució de l'informe.\n"
 "Faci servir un tipus de lletra de mida fixa per mantenir el preformateig."
 
 #: ../gramps/gui/glade/editperson.glade:165
@@ -16558,16 +16524,16 @@ msgstr "Clica en una cel·la de la taula per editar."
 #: ../gramps/gui/glade/editperson.glade:355
 msgid ""
 "Use Multiple Surnames\n"
-"Indicate that the surname consists of different parts. Every surname has its "
-"own prefix and a possible connector to the next surname. Eg., the surname "
-"Ramón y Cajal can be stored as Ramón, which is inherited from the father, "
-"the connector y, and Cajal, which is inherited from the mother."
+"Indicate that the surname consists of different parts. Every surname has its"
+" own prefix and a possible connector to the next surname. Eg., the surname"
+" Ramón y Cajal can be stored as Ramón, which is inherited from the father,"
+" the connector y, and Cajal, which is inherited from the mother."
 msgstr ""
 "Utilitza Cognoms Múltiples\n"
-"Indica que el cognom consisteix en diferents parts. Cada cognom té el seu "
-"propi prefix i un possible connector amb el següent cognom. P.ex., el cognom "
-"Ramón y Cajal es pot desar com a Ramón, que prové del pare, el connector y, "
-"i Cajal, que prové de la mare."
+"Indica que el cognom consisteix en diferents parts. Cada cognom té el seu"
+" propi prefix i un possible connector amb el següent cognom. P.ex., el cognom"
+" Ramón y Cajal es pot desar com a Ramón, que prové del pare, el connector y,"
+" i Cajal, que prové de la mare."
 
 #: ../gramps/gui/glade/editperson.glade:399
 msgid "Set person as private data"
@@ -16579,11 +16545,11 @@ msgstr "_Cognom:"
 
 #: ../gramps/gui/glade/editperson.glade:466
 msgid ""
-"An optional prefix for the family that is not used in sorting, such as \"de"
-"\" or \"van\"."
+"An optional prefix for the family that is not used in sorting, such as \"de\""
+" or \"van\"."
 msgstr ""
-"Un prefix opcional per a la família que no es fa servir a l'ordenació, com "
-"ara \"de\" o \"van\"."
+"Un prefix opcional per a la família que no es fa servir a l'ordenació, com"
+" ara \"de\" o \"van\"."
 
 #: ../gramps/gui/glade/editperson.glade:485
 msgid ""
@@ -16601,11 +16567,11 @@ msgstr "O_rigen:"
 
 #: ../gramps/gui/glade/editperson.glade:551
 msgid ""
-"The origin of this family name for this family, eg 'Inherited' or "
-"'Patronymic'."
+"The origin of this family name for this family, eg 'Inherited' or"
+" 'Patronymic'."
 msgstr ""
-"L'origen d'aquest nom familiar per aquesta família, p.ex. 'Heredat' o "
-"'Patronímic'."
+"L'origen d'aquest nom familiar per aquesta família, p.ex. 'Heredat' o"
+" 'Patronímic'."
 
 #: ../gramps/gui/glade/editperson.glade:585
 msgid "G_ender:"
@@ -16631,23 +16597,23 @@ msgstr "_Associació:"
 msgid ""
 "Description of the association, eg. Godfather, Friend, ...\n"
 "\n"
-"Note: Use Events instead for relations connected to specific time frames or "
-"occasions. Events can be shared between people, each indicating their role "
-"in the event."
+"Note: Use Events instead for relations connected to specific time frames or"
+" occasions. Events can be shared between people, each indicating their role"
+" in the event."
 msgstr ""
 "Descripció de l'associació, p.ex. Padrí, Amic, ...\n"
 "\n"
-"Nota: Utilitzeu Esdeveniments en comptes de relacions connectades amb "
-"èpoques o ocasions concretes. Els Esdeveniments es poden compartir entre "
-"persones, cadascuna amb el seu paper dins de l'esdeveniment."
+"Nota: Utilitzeu Esdeveniments en comptes de relacions connectades amb èpoques"
+" o ocasions concretes. Els Esdeveniments es poden compartir entre persones,"
+" cadascuna amb el seu paper dins de l'esdeveniment."
 
 #: ../gramps/gui/glade/editpersonref.glade:176
 msgid ""
-"Use the select button to choose a person that has an association to the "
-"edited person."
+"Use the select button to choose a person that has an association to the"
+" edited person."
 msgstr ""
-"Utilitzeu el botó de selecció per triar una persona que té una associació "
-"amb la persona editada."
+"Utilitzeu el botó de selecció per triar una persona que té una associació amb"
+" la persona editada."
 
 #: ../gramps/gui/glade/editpersonref.glade:193
 msgid "Select a person that has an association to the edited person."
@@ -16656,11 +16622,9 @@ msgstr "Selecciona la persona que té una associació amb la persona editada."
 #: ../gramps/gui/glade/editplace.glade:106
 #: ../gramps/gui/glade/editplaceref.glade:229
 msgid ""
-"Either use the two fields below to enter coordinates (latitude and "
-"longitude),"
+"Either use the two fields below to enter coordinates (latitude and longitude),"
 msgstr ""
-"Utilitza els dos camps de sota per introduir coordenades (latitud i "
-"longitud),"
+"Utilitza els dos camps de sota per introduir coordenades (latitud i longitud),"
 
 #: ../gramps/gui/glade/editplace.glade:120
 msgid "L_atitude:"
@@ -16678,52 +16642,52 @@ msgstr "Nom complet d'aquest lloc."
 #: ../gramps/gui/glade/editplace.glade:177
 #: ../gramps/gui/glade/editplaceref.glade:460
 msgid ""
-"Latitude (position above the Equator) of the place in decimal or degree "
-"notation. \n"
+"Latitude (position above the Equator) of the place in decimal or degree"
+" notation. \n"
 "Eg, valid values are 12.0154, 50°52′21.92″N, N50°52′21.92″ or 50:52:21.92\n"
-"You can set these values via the Geography View by searching the place, or "
-"via a map service in the place view."
+"You can set these values via the Geography View by searching the place, or"
+" via a map service in the place view."
 msgstr ""
-"Latitud (posició sobre l'Equador) del lloc en notació decimal o "
-"sexagesimal. \n"
-"P.ex, poden ser valors vàlids 12.0154, 50°52′21.92″N, N50°52′21.92″ o "
-"50:52:21.92\n"
-"Pot omplir aquests valors mitjançant la Vista de Geografia buscant el lloc, "
-"o mitjançant un servei de mapes a la Vista de Lloc."
+"Latitud (posició sobre l'Equador) del lloc en notació decimal o sexagesimal."
+" \n"
+"P.ex, poden ser valors vàlids 12.0154, 50°52′21.92″N, N50°52′21.92″ o"
+" 50:52:21.92\n"
+"Pot omplir aquests valors mitjançant la Vista de Geografia buscant el lloc, o"
+" mitjançant un servei de mapes a la Vista de Lloc."
 
 #: ../gramps/gui/glade/editplace.glade:192
 #: ../gramps/gui/glade/editplaceref.glade:475
 msgid ""
-"Longitude (position relative to the Prime, or Greenwich, Meridian) of the "
-"place in decimal or degree notation. \n"
-"Eg, valid values are -124.3647, 124°52′21.92″E, E124°52′21.92″ or "
-"124:52:21.92\n"
-"You can set these values via the Geography View by searching the place, or "
-"via a map service in the place view."
+"Longitude (position relative to the Prime, or Greenwich, Meridian) of the"
+" place in decimal or degree notation. \n"
+"Eg, valid values are -124.3647, 124°52′21.92″E, E124°52′21.92″ or"
+" 124:52:21.92\n"
+"You can set these values via the Geography View by searching the place, or"
+" via a map service in the place view."
 msgstr ""
-"Longitud (posició relativa al Meridià zero, o de Greenwich) del lloc en "
-"notació decimal o sexagesimal. \n"
-"P.ex., poden ser valors vàlids: -124.3647, 124°52′21.92″E, E124°52′21.92″ o "
-"124:52:21.92\n"
-"Pot omplir aquests valors mitjançant la Vista de Geografia buscant el lloc, "
-"o mitjançant un servei de mapes a la Vista de Lloc."
+"Longitud (posició relativa al Meridià zero, o de Greenwich) del lloc en"
+" notació decimal o sexagesimal. \n"
+"P.ex., poden ser valors vàlids: -124.3647, 124°52′21.92″E, E124°52′21.92″ o"
+" 124:52:21.92\n"
+"Pot omplir aquests valors mitjançant la Vista de Geografia buscant el lloc, o"
+" mitjançant un servei de mapes a la Vista de Lloc."
 
 #: ../gramps/gui/glade/editplace.glade:213
 #: ../gramps/gui/glade/editplaceref.glade:351
 msgid ""
-"or use copy/paste from your favorite map provider (format : latitude,"
-"longitude) in the following field:"
+"or use copy/paste from your favorite map provider (format :"
+" latitude,longitude) in the following field:"
 msgstr ""
-"o utilitza copia/enganxa des del teu proveïdor de mapes preferit (format: "
-"latitud, longitud) al camp següent:"
+"o utilitza copia/enganxa des del teu proveïdor de mapes preferit (format:"
+" latitud, longitud) al camp següent:"
 
 #: ../gramps/gui/glade/editplace.glade:238
 #: ../gramps/gui/glade/editplaceref.glade:376
 msgid ""
 "Field used to paste info from a web page like google, openstreetmap, ... "
 msgstr ""
-"Camp utilitzat per enganxar informació des d'una pàgina web com ara google, "
-"openstreetmap, ... "
+"Camp utilitzat per enganxar informació des d'una pàgina web com ara google,"
+" openstreetmap, ... "
 
 #: ../gramps/gui/glade/editplace.glade:265
 #: ../gramps/gui/glade/editplaceref.glade:496
@@ -16786,19 +16750,19 @@ msgstr "Nom d'aquest lloc."
 
 #: ../gramps/gui/glade/editplacename.glade:196
 msgid ""
-"Language in which the name is written. Valid values are two character ISO "
-"codes. For example:  en, fr, de, nl ..."
+"Language in which the name is written. Valid values are two character ISO"
+" codes. For example:  en, fr, de, nl ..."
 msgstr ""
-"L'idioma en que està escrit el nom. Els valors vàlids són codis ISO de dos "
-"caràcters. Per exemple: en, fr, de, nl ..."
+"L'idioma en que està escrit el nom. Els valors vàlids són codis ISO de dos"
+" caràcters. Per exemple: en, fr, de, nl ..."
 
 #: ../gramps/gui/glade/editplaceref.glade:295
 msgid ""
-"<b>Note:</b> Any changes in the enclosing place information will be "
-"reflected in the place itself, for places that it encloses."
+"<b>Note:</b> Any changes in the enclosing place information will be reflected"
+" in the place itself, for places that it encloses."
 msgstr ""
-"<b>Nota:</b> Qualsevol canvi a la informació de lloc delimitant es "
-"reflectirà al propi lloc, per a tots els llocs que hi facin referència."
+"<b>Nota:</b> Qualsevol canvi a la informació de lloc delimitant es reflectirà"
+" al propi lloc, per a tots els llocs que hi facin referència."
 
 #: ../gramps/gui/glade/editreporef.glade:127
 msgid "_Media Type:"
@@ -16811,8 +16775,8 @@ msgstr "Nú_mero de Referència:"
 #: ../gramps/gui/glade/editreporef.glade:156
 msgid "On what type of media this source is available in the repository."
 msgstr ""
-"En quin tipus de medi audiovisual està disponible aquesta font dins del "
-"repositori."
+"En quin tipus de medi audiovisual està disponible aquesta font dins del"
+" repositori."
 
 #: ../gramps/gui/glade/editreporef.glade:209
 msgid "Id number of the source in the repository."
@@ -16832,13 +16796,13 @@ msgstr "Nom del repositori (on estan emmagatzemades les fonts)."
 
 #: ../gramps/gui/glade/editreporef.glade:329
 msgid ""
-"<b>Note:</b> Any changes in the shared repository information will be "
-"reflected in the repository itself, for all items that reference the "
-"repository."
+"<b>Note:</b> Any changes in the shared repository information will be"
+" reflected in the repository itself, for all items that reference the"
+" repository."
 msgstr ""
-"<b>Nota:</b> Qualssevol canvis a la informació del repositori compartit es "
-"reflectiran al propi repositori, per a tots els objectes que hi facin "
-"referència."
+"<b>Nota:</b> Qualssevol canvis a la informació del repositori compartit es"
+" reflectiran al propi repositori, per a tots els objectes que hi facin"
+" referència."
 
 #: ../gramps/gui/glade/editreporef.glade:370
 #: ../gramps/gui/glade/editrepository.glade:179
@@ -16868,19 +16832,18 @@ msgstr "Info. _pub.:"
 
 #: ../gramps/gui/glade/editsource.glade:168
 msgid ""
-"Publication Information, such as city and year of publication, name of "
-"publisher, ..."
+"Publication Information, such as city and year of publication, name of"
+" publisher, ..."
 msgstr ""
-"Informació de publicació, com ara ciutat i any de publicació, nom de "
-"l'editor, ..."
+"Informació de publicació, com ara ciutat i any de publicació, nom de"
+" l'editor, ..."
 
 #: ../gramps/gui/glade/editsource.glade:181
 msgid ""
-"Provide a short title used for sorting, filing, and retrieving source "
-"records."
+"Provide a short title used for sorting, filing, and retrieving source records."
 msgstr ""
-"Proporciona un títol curt que s'utilitza per ordenar, arxivar, i extreure "
-"registres de font."
+"Proporciona un títol curt que s'utilitza per ordenar, arxivar, i extreure"
+" registres de font."
 
 #: ../gramps/gui/glade/editsource.glade:194
 msgid "A_bbreviation:"
@@ -16904,8 +16867,8 @@ msgstr "Tipus d'adreça internet, p.ex. E-mail, Pàgina Web, ..."
 
 #: ../gramps/gui/glade/editurl.glade:189
 msgid ""
-"The internet address as needed to navigate to it, eg. http://gramps-project."
-"org"
+"The internet address as needed to navigate to it, eg."
+" http://gramps-project.org"
 msgstr ""
 "L'adreça internet tal com cal per navegar-hi, p.ex. http://gramps-project.org"
 
@@ -16988,8 +16951,8 @@ msgstr "Id Gramps:"
 #: ../gramps/gui/glade/mergecitation.glade:455
 msgid "Notes, media objects and data-items of both citations will be combined."
 msgstr ""
-"Es combinaran les notes, objectes audiovisuals i elements de dades de totes "
-"dues cites."
+"Es combinaran les notes, objectes audiovisuals i elements de dades de totes"
+" dues cites."
 
 #: ../gramps/gui/glade/mergecitation.glade:471
 #: ../gramps/gui/glade/mergeevent.glade:528
@@ -17023,8 +16986,8 @@ msgstr "Selecciona"
 msgid ""
 "Select the person that will provide the primary data for the merged person."
 msgstr ""
-"Selecciona la persona que proporcionarà les dades primàries per a la persona "
-"combinada."
+"Selecciona la persona que proporcionarà les dades primàries per a la persona"
+" combinada."
 
 #: ../gramps/gui/glade/mergedata.glade:564
 msgid "Title selection"
@@ -17060,8 +17023,8 @@ msgstr "Esdeveniment 2"
 msgid ""
 "Attributes, notes, sources and media objects of both events will be combined."
 msgstr ""
-"Es combinaran els atributs, les notes, les fonts i els objectes audiovisuals "
-"de tots dos esdeveniments."
+"Es combinaran els atributs, les notes, les fonts i els objectes audiovisuals"
+" de tots dos esdeveniments."
 
 #: ../gramps/gui/glade/mergefamily.glade:98
 msgid ""
@@ -17096,11 +17059,11 @@ msgstr "Família 2"
 
 #: ../gramps/gui/glade/mergefamily.glade:458
 msgid ""
-"Events, lds_ord, media objects, attributes, notes, sources and tags of both "
-"families will be combined."
+"Events, lds_ord, media objects, attributes, notes, sources and tags of both"
+" families will be combined."
 msgstr ""
-"Es combinaran esdeveniments, lds_ord, objectes audiovisuals, atributs, "
-"notes, fonts i etiquetes de totes dues famílies."
+"Es combinaran esdeveniments, lds_ord, objectes audiovisuals, atributs, notes,"
+" fonts i etiquetes de totes dues famílies."
 
 #: ../gramps/gui/glade/mergemedia.glade:97
 msgid ""
@@ -17140,7 +17103,7 @@ msgid "Note 2"
 msgstr "Nota 2"
 
 #: ../gramps/gui/glade/mergenote.glade:278
-#: ../gramps/gui/glade/mergenote.glade:294 ../gramps/gui/views/listview.py:1069
+#: ../gramps/gui/glade/mergenote.glade:294 ../gramps/gui/views/listview.py:1070
 msgid "Format:"
 msgstr "Format:"
 
@@ -17169,11 +17132,11 @@ msgstr "Gènere:"
 
 #: ../gramps/gui/glade/mergeperson.glade:409
 msgid ""
-"Events, media objects, addresses, attributes, urls, notes, sources and tags "
-"of both persons will be combined."
+"Events, media objects, addresses, attributes, urls, notes, sources and tags"
+" of both persons will be combined."
 msgstr ""
-"Es combinaran els esdeveniments, objectes audiovisuals, adreces, atributs, "
-"urls, notes, fonts i etiquetes de totes dues persones."
+"Es combinaran els esdeveniments, objectes audiovisuals, adreces, atributs,"
+" urls, notes, fonts i etiquetes de totes dues persones."
 
 #: ../gramps/gui/glade/mergeperson.glade:500
 msgid "Context Information"
@@ -17189,11 +17152,11 @@ msgstr ""
 
 #: ../gramps/gui/glade/mergeplace.glade:619
 msgid ""
-"Alternative names, sources, urls, media objects and notes of both places "
-"will be combined."
+"Alternative names, sources, urls, media objects and notes of both places will"
+" be combined."
 msgstr ""
-"Es combinaran els noms, alternatius, fonts, urls, objectes audiovisuals i "
-"notes de tots dos llocs."
+"Es combinaran els noms, alternatius, fonts, urls, objectes audiovisuals i"
+" notes de tots dos llocs."
 
 #: ../gramps/gui/glade/mergerepository.glade:97
 msgid ""
@@ -17225,11 +17188,11 @@ msgstr ""
 
 #: ../gramps/gui/glade/mergesource.glade:512
 msgid ""
-"Notes, media objects, data-items and repository references of both sources "
-"will be combined."
+"Notes, media objects, data-items and repository references of both sources"
+" will be combined."
 msgstr ""
-"Es combinaran les notes, objectes audiovisuals, elements de dades i "
-"referències a repositori de totes dues fonts."
+"Es combinaran les notes, objectes audiovisuals, elements de dades i"
+" referències a repositori de totes dues fonts."
 
 #: ../gramps/gui/glade/papermenu.glade:8
 msgid "Paper Settings"
@@ -17692,22 +17655,22 @@ msgstr "Actualitzacions de Gramps per Complements Disponibles"
 
 #: ../gramps/gui/glade/updateaddons.glade:89
 msgid ""
-"Gramps comes with a core set of plugins which provide all of the necessary "
-"features. However, you can extend this functionality with additional Addons. "
-"These addons provide reports, listings, views, gramplets, and more. Here you "
-"can select among the available extra addons, they will be retrieved from the "
-"internet off of the Gramps website, and installed locally on your computer. "
-"If you close this dialog now, you can install addons later from the menu "
-"under Edit -> Preferences."
+"Gramps comes with a core set of plugins which provide all of the necessary"
+" features. However, you can extend this functionality with additional Addons."
+" These addons provide reports, listings, views, gramplets, and more. Here you"
+" can select among the available extra addons, they will be retrieved from the"
+" internet off of the Gramps website, and installed locally on your computer."
+" If you close this dialog now, you can install addons later from the menu"
+" under Edit -> Preferences."
 msgstr ""
-"Gramps ve amb un conjunt bàsic de connectors que proporcionen totes les "
-"funcionalitats necessàries. No obstant, pot estendre aquesta funcionalitat "
-"amb Complements addicionals. Aquests complements proporcionen informes, "
-"llistats, vistes, gramplets, i més. Aquí pot seleccionar entre els "
-"complements addicionals disponibles, que es baixaran d'Internet des del web "
-"de Gramps, i s'instal·laran localment al seu ordinador. Si tanca aquest "
-"diàleg ara, pot instal·lar complements més tard des del menú Editar -> "
-"Preferències."
+"Gramps ve amb un conjunt bàsic de connectors que proporcionen totes les"
+" funcionalitats necessàries. No obstant, pot estendre aquesta funcionalitat"
+" amb Complements addicionals. Aquests complements proporcionen informes,"
+" llistats, vistes, gramplets, i més. Aquí pot seleccionar entre els"
+" complements addicionals disponibles, que es baixaran d'Internet des del web"
+" de Gramps, i s'instal·laran localment al seu ordinador. Si tanca aquest"
+" diàleg ara, pot instal·lar complements més tard des del menú Editar ->"
+" Preferències."
 
 #: ../gramps/gui/glade/updateaddons.glade:105
 msgid "_Select All"
@@ -17872,24 +17835,24 @@ msgstr "_Finestres"
 
 #: ../gramps/gui/grampsgui.py:423
 msgid ""
-"Your version of gi (gnome-introspection) seems to be too old. You need a "
-"version which has the function 'require_version' to start Gramps"
+"Your version of gi (gnome-introspection) seems to be too old. You need a"
+" version which has the function 'require_version' to start Gramps"
 msgstr ""
-"La vostra versió de gi (gnome-introspection) sembla que és massa vella. Cal "
-"una versió que tingui la funció 'require_version' per engegar Gramps"
+"La vostra versió de gi (gnome-introspection) sembla que és massa vella. Cal"
+" una versió que tingui la funció 'require_version' per engegar Gramps"
 
 #: ../gramps/gui/grampsgui.py:437
 #, python-format
 msgid ""
 "Your pygobject version does not meet the requirements.\n"
-"At least pygobject %(major)d.%(feature)d.%(minor)d is needed to start Gramps "
-"with a GUI.\n"
+"At least pygobject %(major)d.%(feature)d.%(minor)d is needed to start Gramps"
+" with a GUI.\n"
 "\n"
 "Gramps will terminate now."
 msgstr ""
 "La versió de pygobject no compleix els requeriments.\n"
-"Cal almenys la versió de pygobject %(major)d.%(feature)d.%(minor)d per "
-"executar Gramps amb interfície gràfica.\n"
+"Cal almenys la versió de pygobject %(major)d.%(feature)d.%(minor)d per"
+" executar Gramps amb interfície gràfica.\n"
 "\n"
 "Gramps s'aturarà."
 
@@ -17916,22 +17879,21 @@ msgid ""
 "Gramps will terminate now."
 msgstr ""
 "La versió de Gtk no compleix els requeriments.\n"
-"Cal almenys la versió %(major)d.%(minor)d per executar Gramps amb interfície "
-"gràfica.\n"
+"Cal almenys la versió %(major)d.%(minor)d per executar Gramps amb interfície"
+" gràfica.\n"
 "\n"
 "Gramps s'aturarà."
 
 #: ../gramps/gui/grampsgui.py:477
 msgid ""
 "\n"
-"cairo python support not installed. Install cairo for your version of "
-"python\n"
+"cairo python support not installed. Install cairo for your version of python\n"
 "\n"
 "Gramps will terminate now."
 msgstr ""
 "\n"
-"No s'ha instal·lat el suport python de cairo. Instal·leu el cairo per a la "
-"vostra versió de python\n"
+"No s'ha instal·lat el suport python de cairo. Instal·leu el cairo per a la"
+" vostra versió de python\n"
 "\n"
 "Gramps s'aturarà ara."
 
@@ -17956,12 +17918,12 @@ msgid ""
 "4) Corrupt your data.\n"
 "5) Save data in a format that is incompatible with the official release.\n"
 "\n"
-"%(bold_start)sBACKUP%(bold_end)s your existing databases before opening them "
-"with this version, and make sure to export your data to XML every now and "
-"then."
+"%(bold_start)sBACKUP%(bold_end)s your existing databases before opening them"
+" with this version, and make sure to export your data to XML every now and"
+" then."
 msgstr ""
-"Aquesta versió no està pensada per a un us normal. Utilitza-la sota la teva "
-"responsabilitat.\n"
+"Aquesta versió no està pensada per a un us normal. Utilitza-la sota la teva"
+" responsabilitat.\n"
 "\n"
 "Aquesta versió podria:\n"
 "1) Funcionar de manera diferent a com ho esperes.\n"
@@ -17970,9 +17932,9 @@ msgstr ""
 "4) Corrompre les teves dades.\n"
 "5) Desar les dades en un format incompatible amb la de l'edició oficial.\n"
 "\n"
-"%(bold_start)sFES CÒPIA DE SEGURETAT%(bold_end)s de les teves bases de dades "
-"existents abans d'obrir-les amb aquesta versió, i assegura't d'exportar les "
-"teves dades en XML de tant en tant."
+"%(bold_start)sFES CÒPIA DE SEGURETAT%(bold_end)s de les teves bases de dades"
+" existents abans d'obrir-les amb aquesta versió, i assegura't d'exportar les"
+" teves dades en XML de tant en tant."
 
 #: ../gramps/gui/grampsgui.py:541
 msgid "Gramps detected an incomplete GTK installation"
@@ -17990,11 +17952,11 @@ msgid ""
 msgstr ""
 "Les traduccions del GTK per a la llengua actual (%(language)s) no hi són.\n"
 "%(bold_start)sGramps%(bold_end)s continuarà igualment.\n"
-"Probablement, la interfície gràfica no quedarà bé, especialment en llengües "
-"que s'escriuen d'esquerra a dreta!\n"
+"Probablement, la interfície gràfica no quedarà bé, especialment en llengües"
+" que s'escriuen d'esquerra a dreta!\n"
 "\n"
-"Vegeu la documentació del README de Gramps per als prerequisits "
-"d'instal·lació,\n"
+"Vegeu la documentació del README de Gramps per als prerequisits"
+" d'instal·lació,\n"
 "que típicament es troba a /usr/share/doc/gramps.\n"
 
 #: ../gramps/gui/grampsgui.py:659
@@ -18010,18 +17972,18 @@ msgid ""
 "\n"
 "Gramps failed to start. Please report a bug about this.\n"
 "This could be because of an error in a (third party) View on startup.\n"
-"To use another view, don't load a Family Tree, change view, and then load "
-"your Family Tree.\n"
+"To use another view, don't load a Family Tree, change view, and then load"
+" your Family Tree.\n"
 "You can also change manually the startup view in the gramps.ini file \n"
 "by changing the last-view parameter.\n"
 msgstr ""
 "\n"
-"Gramps no s'ha pogut engegar. Si us plau, obriu un informe d'error sobre "
-"aquest problema.\n"
-"Pot haver estat a causa d'un error en alguna Vista (feta per tercers) en "
-"arrencar.\n"
-"Per utilitzar una altra vista, no carregueu cap Arbre Genealògic, canvieu de "
-"vista, i després carregueu el vostre Arbre Genealògic.\n"
+"Gramps no s'ha pogut engegar. Si us plau, obriu un informe d'error sobre"
+" aquest problema.\n"
+"Pot haver estat a causa d'un error en alguna Vista (feta per tercers) en"
+" arrencar.\n"
+"Per utilitzar una altra vista, no carregueu cap Arbre Genealògic, canvieu de"
+" vista, i després carregueu el vostre Arbre Genealògic.\n"
 "També podeu canviar manualment la vista d'arrencada al fitxer gramps.ini\n"
 "modificant el paràmetre last-view.\n"
 
@@ -18035,34 +17997,34 @@ msgstr "Informa d'un problema"
 
 #: ../gramps/gui/logger/_errorreportassistant.py:266
 msgid ""
-"This is the Bug Reporting Assistant. It will help you to make a bug report "
-"to the Gramps developers that will be as detailed as possible.\n"
+"This is the Bug Reporting Assistant. It will help you to make a bug report to"
+" the Gramps developers that will be as detailed as possible.\n"
 "\n"
-"The assistant will ask you a few questions and will gather some information "
-"about the error that has occurred and the operating environment. At the end "
-"of the assistant you will be asked to file a bug report on the Gramps bug "
-"tracking system. The assistant will place the bug report on the clip board "
-"so that you can paste it into the form on the bug tracking website and "
-"review exactly what information you want to include."
+"The assistant will ask you a few questions and will gather some information"
+" about the error that has occurred and the operating environment. At the end"
+" of the assistant you will be asked to file a bug report on the Gramps bug"
+" tracking system. The assistant will place the bug report on the clip board"
+" so that you can paste it into the form on the bug tracking website and"
+" review exactly what information you want to include."
 msgstr ""
-"Això és l'Assistent per Informar de Problemes. L'ajudarà a preparar un "
-"informe de problemes tan detallat com sigui possible per als desenvolupadors "
-"de Gramps.\n"
+"Això és l'Assistent per Informar de Problemes. L'ajudarà a preparar un"
+" informe de problemes tan detallat com sigui possible per als desenvolupadors"
+" de Gramps.\n"
 "\n"
-"L'assistent demanarà algunes preguntes i recollirà informació sobre l'error "
-"que hi ha hagut i l'entorn operatiu. Al final de l'assistent, se li demanarà "
-"que desi l'informe de problemes al sistema de seguiment de problemes de "
-"Gramps. L'assistent deixarà l'informe al portapapers perquè el pugui "
-"enganxar al web de seguiment de problemes, i repassar exactament quina "
-"informació hi vol incloure."
+"L'assistent demanarà algunes preguntes i recollirà informació sobre l'error"
+" que hi ha hagut i l'entorn operatiu. Al final de l'assistent, se li demanarà"
+" que desi l'informe de problemes al sistema de seguiment de problemes de"
+" Gramps. L'assistent deixarà l'informe al portapapers perquè el pugui"
+" enganxar al web de seguiment de problemes, i repassar exactament quina"
+" informació hi vol incloure."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:283
 msgid ""
-"If you can see that there is any personal information included in the error "
-"please remove it."
+"If you can see that there is any personal information included in the error"
+" please remove it."
 msgstr ""
-"Si veu que hi ha informació personal inclosa dins de l'error, esborri-la si "
-"us plau."
+"Si veu que hi ha informació personal inclosa dins de l'error, esborri-la si"
+" us plau."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:327
 #: ../gramps/gui/logger/_errorreportassistant.py:355
@@ -18071,23 +18033,23 @@ msgstr "Detalls de l'Error"
 
 #: ../gramps/gui/logger/_errorreportassistant.py:332
 msgid ""
-"This is the detailed Gramps error information, don't worry if you do not "
-"understand it. You will have the opportunity to add further detail about the "
-"error in the following pages of the assistant."
+"This is the detailed Gramps error information, don't worry if you do not"
+" understand it. You will have the opportunity to add further detail about the"
+" error in the following pages of the assistant."
 msgstr ""
-"Aquesta és la informació detallada sobre l'error de Gramps; no es preocupi "
-"si no l'entèn. A les pàgines següents d'aquest assistent tindrà "
-"l'oportunitat d'afegir més detalls sobre l'error."
+"Aquesta és la informació detallada sobre l'error de Gramps; no es preocupi si"
+" no l'entèn. A les pàgines següents d'aquest assistent tindrà l'oportunitat"
+" d'afegir més detalls sobre l'error."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:362
 msgid ""
-"Please check the information below and correct anything that you know to be "
-"wrong or remove anything that you would rather not have included in the bug "
-"report."
+"Please check the information below and correct anything that you know to be"
+" wrong or remove anything that you would rather not have included in the bug"
+" report."
 msgstr ""
-"Si us plau, comprovi la informació de sota i corregeixi qualsevol cosa que "
-"sàpiga que és incorrecta o tregui qualsevol cosa que prefereixi no incloure "
-"a l'informe d'error."
+"Si us plau, comprovi la informació de sota i corregeixi qualsevol cosa que"
+" sàpiga que és incorrecta o tregui qualsevol cosa que prefereixi no incloure"
+" a l'informe d'error."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:407
 #: ../gramps/gui/logger/_errorreportassistant.py:433
@@ -18096,19 +18058,19 @@ msgstr "Informació del Sistema"
 
 #: ../gramps/gui/logger/_errorreportassistant.py:412
 msgid ""
-"This is the information about your system that will help the developers to "
-"fix the bug."
+"This is the information about your system that will help the developers to"
+" fix the bug."
 msgstr ""
-"Aquesta és la informació sobre el seu sistema que ajudarà als "
-"desenvolupadors a solucionar el problema."
+"Aquesta és la informació sobre el seu sistema que ajudarà als desenvolupadors"
+" a solucionar el problema."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:440
 msgid ""
-"Please provide as much information as you can about what you were doing when "
-"the error occurred."
+"Please provide as much information as you can about what you were doing when"
+" the error occurred."
 msgstr ""
-"Si us plau, doneu tanta informació com pugueu sobre el que estàveu fent quan "
-"va ocórrer l'error."
+"Si us plau, doneu tanta informació com pugueu sobre el que estàveu fent quan"
+" va ocórrer l'error."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:479
 #: ../gramps/gui/logger/_errorreportassistant.py:504
@@ -18117,21 +18079,21 @@ msgstr "Informació Addicional"
 
 #: ../gramps/gui/logger/_errorreportassistant.py:484
 msgid ""
-"This is your opportunity to describe what you were doing when the error "
-"occurred."
+"This is your opportunity to describe what you were doing when the error"
+" occurred."
 msgstr ""
-"Aquesta es la seva oportunitat per descriure el que feia quan va ocórrer "
-"l'error."
+"Aquesta es la seva oportunitat per descriure el que feia quan va ocórrer"
+" l'error."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:511
 msgid ""
-"Please check that the information is correct, do not worry if you don't "
-"understand the detail of the error information. Just make sure that it does "
-"not contain anything that you do not want to be sent to the developers."
+"Please check that the information is correct, do not worry if you don't"
+" understand the detail of the error information. Just make sure that it does"
+" not contain anything that you do not want to be sent to the developers."
 msgstr ""
-"Si us plau, comprovi que la informació és correcta; no es preocupi si no "
-"entén el detall de la informació sobre l'error. Només asseguri's que no "
-"conté res que no vulgui que s'enviï als desenvolupadors."
+"Si us plau, comprovi que la informació és correcta; no es preocupi si no"
+" entén el detall de la informació sobre l'error. Només asseguri's que no"
+" conté res que no vulgui que s'enviï als desenvolupadors."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:543
 #: ../gramps/gui/logger/_errorreportassistant.py:570
@@ -18140,38 +18102,38 @@ msgstr "Resum de l'Informe d'Error"
 
 #: ../gramps/gui/logger/_errorreportassistant.py:548
 msgid ""
-"This is the completed bug report. The next page of the assistant will help "
-"you to file a bug on the Gramps bug tracking system website."
+"This is the completed bug report. The next page of the assistant will help"
+" you to file a bug on the Gramps bug tracking system website."
 msgstr ""
-"Aquest és l'informe d'error complet. La següent pàgina de l'assistent "
-"l'ajudarà a registrar l'error al web del sistema de seguiment d'errors de "
-"Gramps."
+"Aquest és l'informe d'error complet. La següent pàgina de l'assistent"
+" l'ajudarà a registrar l'error al web del sistema de seguiment d'errors de"
+" Gramps."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:579
 msgid ""
-"Use the two buttons below to first copy the bug report to the clipboard and "
-"then open a webbrowser to file a bug report at "
+"Use the two buttons below to first copy the bug report to the clipboard and"
+" then open a webbrowser to file a bug report at "
 msgstr ""
-"Faci servir els dos botons de sota, primer per copiar l'informe d'errors al "
-"portapapers i després obri un navegador per registrar l'informe a "
+"Faci servir els dos botons de sota, primer per copiar l'informe d'errors al"
+" portapapers i després obri un navegador per registrar l'informe a "
 
 #: ../gramps/gui/logger/_errorreportassistant.py:588
 msgid ""
-"Use this button to start a web browser and file a bug report on the Gramps "
-"bug tracking system."
+"Use this button to start a web browser and file a bug report on the Gramps"
+" bug tracking system."
 msgstr ""
-"Amb aquest botó s'engega un navegador i es registrarà un informe d'errors al "
-"sistema de seguiment d'errors de Gramps."
+"Amb aquest botó s'engega un navegador i es registrarà un informe d'errors al"
+" sistema de seguiment d'errors de Gramps."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:610
 msgid ""
-"Use this button to copy the bug report onto the clipboard. Then go to the "
-"bug tracking website by using the button below, paste the report and click "
-"submit report"
+"Use this button to copy the bug report onto the clipboard. Then go to the bug"
+" tracking website by using the button below, paste the report and click"
+" submit report"
 msgstr ""
-"Amb aquest botó, copiï l'informe d'error al portapapers. Llavors vagi al web "
-"de seguiment d'errors amb el botó de sota, enganxi l'informe i cliqui "
-"\"submit report\" (enviar informe)"
+"Amb aquest botó, copiï l'informe d'error al portapapers. Llavors vagi al web"
+" de seguiment d'errors amb el botó de sota, enganxi l'informe i cliqui"
+" \"submit report\" (enviar informe)"
 
 #: ../gramps/gui/logger/_errorreportassistant.py:642
 #: ../gramps/gui/logger/_errorreportassistant.py:669
@@ -18180,21 +18142,20 @@ msgstr "Envia Informe d'Error"
 
 #: ../gramps/gui/logger/_errorreportassistant.py:647
 msgid ""
-"This is the final step. Use the buttons on this page to start a web browser "
-"and file a bug report on the Gramps bug tracking system."
+"This is the final step. Use the buttons on this page to start a web browser"
+" and file a bug report on the Gramps bug tracking system."
 msgstr ""
-"Aquest és el pas final. Amb els botons d'aquesta pàgina, engegui un "
-"navegador i registri un informe d'error al sistema de seguiment d'errors de "
-"Gramps."
+"Aquest és el pas final. Amb els botons d'aquesta pàgina, engegui un navegador"
+" i registri un informe d'error al sistema de seguiment d'errors de Gramps."
 
 #: ../gramps/gui/logger/_errorreportassistant.py:676
 msgid ""
-"Gramps is an Open Source project. Its success depends on its users. User "
-"feedback is important. Thank you for taking the time to submit a bug report."
+"Gramps is an Open Source project. Its success depends on its users. User"
+" feedback is important. Thank you for taking the time to submit a bug report."
 msgstr ""
-"Gramps és un projecte de Codi Obert. El seu èxit depèn dels usuaris. És "
-"important l'opinió dels usuaris. Gràcies per dedicar el seu temps a fer un "
-"informe d'errors."
+"Gramps és un projecte de Codi Obert. El seu èxit depèn dels usuaris. És"
+" important l'opinió dels usuaris. Gràcies per dedicar el seu temps a fer un"
+" informe d'errors."
 
 #: ../gramps/gui/logger/_errorview.py:46
 msgid "manual|Error_Report"
@@ -18210,15 +18171,15 @@ msgstr "Gramps ha patit un error inesperat"
 
 #: ../gramps/gui/logger/_errorview.py:143
 msgid ""
-"Your data will be safe but it would be advisable to restart Gramps "
-"immediately. If you would like to report the problem to the Gramps team "
-"please click Report and the Error Reporting Wizard will help you to make a "
-"bug report."
+"Your data will be safe but it would be advisable to restart Gramps"
+" immediately. If you would like to report the problem to the Gramps team"
+" please click Report and the Error Reporting Wizard will help you to make a"
+" bug report."
 msgstr ""
-"Les dades no perillen però és aconsellable de rearrencar Gramps "
-"immediatament. Si vol informar del problema a l'equip de desenvolupament de "
-"Gramps, cliqui si us plau Informe i l'Assistent d'Informe d'Error l'ajudarà "
-"a fer un informe d'error."
+"Les dades no perillen però és aconsellable de rearrencar Gramps"
+" immediatament. Si vol informar del problema a l'equip de desenvolupament de"
+" Gramps, cliqui si us plau Informe i l'Assistent d'Informe d'Error l'ajudarà"
+" a fer un informe d'error."
 
 #: ../gramps/gui/logger/_errorview.py:152
 #: ../gramps/gui/logger/_errorview.py:167
@@ -18301,11 +18262,11 @@ msgstr "Combina Persones"
 #: ../gramps/gui/widgets/fanchart.py:1994
 #: ../gramps/plugins/quickview/all_relations.py:305
 #: ../gramps/plugins/tool/notrelated.py:128
-#: ../gramps/plugins/view/pedigreeview.py:1866
+#: ../gramps/plugins/view/pedigreeview.py:1867
 #: ../gramps/plugins/view/relview.py:667 ../gramps/plugins/view/relview.py:1033
 #: ../gramps/plugins/view/relview.py:1068
 #: ../gramps/plugins/webreport/person.py:232
-#: ../gramps/plugins/webreport/person.py:1845
+#: ../gramps/plugins/webreport/person.py:1852
 #: ../gramps/plugins/webreport/surname.py:154
 msgid "Parents"
 msgstr "Pares"
@@ -18324,7 +18285,7 @@ msgstr "No s'han trobat progenitors"
 #: ../gramps/gui/merge/mergeperson.py:238
 #: ../gramps/gui/widgets/fanchart.py:1857
 #: ../gramps/plugins/textreport/kinshipreport.py:133
-#: ../gramps/plugins/view/pedigreeview.py:1753
+#: ../gramps/plugins/view/pedigreeview.py:1754
 msgid "Spouses"
 msgstr "Cònjuges"
 
@@ -18350,14 +18311,14 @@ msgstr "Avís"
 #: ../gramps/gui/merge/mergeperson.py:342
 msgid ""
 "The persons have been merged.\n"
-"However, the families for this merge were too complex to automatically "
-"handle.  We recommend that you go to Relationships view and see if "
-"additional manual merging of families is necessary."
+"However, the families for this merge were too complex to automatically"
+" handle.  We recommend that you go to Relationships view and see if"
+" additional manual merging of families is necessary."
 msgstr ""
 "Les persones han estat combinades.\n"
-"De totes maneres, per aquesta combinació, les famílies eren massa complexes "
-"per gestionar-les automàticament. Recomanem anar a la vista de Relacions i "
-"veure si és necessari combinar altres famílies."
+"De totes maneres, per aquesta combinació, les famílies eren massa complexes"
+" per gestionar-les automàticament. Recomanem anar a la vista de Relacions i"
+" veure si és necessari combinar altres famílies."
 
 #: ../gramps/gui/merge/mergeplace.py:53
 msgid "manual|Merge_Places"
@@ -18616,7 +18577,7 @@ msgstr "_Executa"
 #: ../gramps/gui/plug/_windows.py:1049
 #: ../gramps/plugins/importer/importprogen.py:457
 #: ../gramps/plugins/tool/ownereditor.py:164
-#: ../gramps/plugins/tool/reorderids.py:218
+#: ../gramps/plugins/tool/reorderids.py:221
 msgid "Main window"
 msgstr "Finestra principal"
 
@@ -18696,8 +18657,8 @@ msgstr ""
 "\n"
 "Format:\t%s\n"
 "\n"
-"Premi Aplica per continuar, Enrere per revisar les opcions, o Cancel·la per "
-"aturar"
+"Premi Aplica per continuar, Enrere per revisar les opcions, o Cancel·la per"
+" aturar"
 
 #: ../gramps/gui/plug/export/_exportassistant.py:465
 #, python-format
@@ -18716,8 +18677,8 @@ msgstr ""
 "Nom:\t%(name)s\n"
 "Carpeta:\t%(folder)s\n"
 "\n"
-"Premi Aplica per continuar, Enrere per revisar les opcions, o Cancel·la per "
-"aturar"
+"Premi Aplica per continuar, Enrere per revisar les opcions, o Cancel·la per"
+" aturar"
 
 #: ../gramps/gui/plug/export/_exportassistant.py:475
 msgid ""
@@ -18725,8 +18686,8 @@ msgid ""
 "\n"
 "Press Back to return and select a valid filename."
 msgstr ""
-"El fitxer i carpeta seleccionats per desar no es poden crear ni s'han "
-"trobat.\n"
+"El fitxer i carpeta seleccionats per desar no es poden crear ni s'han"
+" trobat.\n"
 "\n"
 "Premi Enrere per tornar i seleccioni un nom de fitxer vàlid."
 
@@ -18736,19 +18697,19 @@ msgstr "Les dades s'han desat"
 
 #: ../gramps/gui/plug/export/_exportassistant.py:504
 msgid ""
-"The copy of your data has been successfully saved. You may press Close "
-"button now to continue.\n"
+"The copy of your data has been successfully saved. You may press Close button"
+" now to continue.\n"
 "\n"
-"Note: the database currently opened in your Gramps window is NOT the file "
-"you have just saved. Future editing of the currently opened database will "
-"not alter the copy you have just made. "
+"Note: the database currently opened in your Gramps window is NOT the file you"
+" have just saved. Future editing of the currently opened database will not"
+" alter the copy you have just made. "
 msgstr ""
-"La còpia de les dades s'ha desat amb èxit. Ara pot prémer el botó Tanca per "
-"continuar.\n"
+"La còpia de les dades s'ha desat amb èxit. Ara pot prémer el botó Tanca per"
+" continuar.\n"
 "\n"
-"Nota: la base de dades oberta actualment a la finestra Gramps NO és el "
-"fitxer que s'acaba de desar. Les edicions futures de la base de dades oberta "
-"actualment no modificaran la còpia que s'acaba de fer. "
+"Nota: la base de dades oberta actualment a la finestra Gramps NO és el fitxer"
+" que s'acaba de desar. Les edicions futures de la base de dades oberta"
+" actualment no modificaran la còpia que s'acaba de fer. "
 
 #. add test, what is dir
 #: ../gramps/gui/plug/export/_exportassistant.py:512
@@ -18762,42 +18723,42 @@ msgstr "Desar ha fallat"
 
 #: ../gramps/gui/plug/export/_exportassistant.py:516
 msgid ""
-"There was an error while saving your data. You may try starting the export "
-"again.\n"
+"There was an error while saving your data. You may try starting the export"
+" again.\n"
 "\n"
-"Note: your currently opened database is safe. It was only a copy of your "
-"data that failed to save."
+"Note: your currently opened database is safe. It was only a copy of your data"
+" that failed to save."
 msgstr ""
-"Hi ha hagut un error desant les dades. Pot provar de tornar a engegar "
-"l'exportació.\n"
+"Hi ha hagut un error desant les dades. Pot provar de tornar a engegar"
+" l'exportació.\n"
 "\n"
-"Nota: la base de dades que està oberta ara mateix no té cap problema. Només "
-"és una còpia de les dades que no s'ha pogut desar."
+"Nota: la base de dades que està oberta ara mateix no té cap problema. Només"
+" és una còpia de les dades que no s'ha pogut desar."
 
 #: ../gramps/gui/plug/export/_exportassistant.py:532
 msgid ""
-"Under normal circumstances, Gramps does not require you to directly save "
-"your changes. All changes you make are immediately saved to the database.\n"
+"Under normal circumstances, Gramps does not require you to directly save your"
+" changes. All changes you make are immediately saved to the database.\n"
 "\n"
-"This process will help you save a copy of your data in any of the several "
-"formats supported by Gramps. This can be used to make a copy of your data, "
-"backup your data, or convert it to a format that will allow you to transfer "
-"it to a different program.\n"
+"This process will help you save a copy of your data in any of the several"
+" formats supported by Gramps. This can be used to make a copy of your data,"
+" backup your data, or convert it to a format that will allow you to transfer"
+" it to a different program.\n"
 "\n"
-"If you change your mind during this process, you can safely press the Cancel "
-"button at any time and your present database will still be intact."
+"If you change your mind during this process, you can safely press the Cancel"
+" button at any time and your present database will still be intact."
 msgstr ""
-"En circumstàncies normals, Gramps no requereix desar els canvis "
-"explícitament. Tots els canvis que es fan es desen immediatament a la base "
-"de dades.\n"
+"En circumstàncies normals, Gramps no requereix desar els canvis"
+" explícitament. Tots els canvis que es fan es desen immediatament a la base"
+" de dades.\n"
 "\n"
-"Aquest procés li ajudarà a desar una còpia de les dades en qualsevol dels "
-"formats que suporta Gramps. Això es pot fer servir per copiar les dades, per "
-"desar una còpia de seguretat, o convertir-la a un format que permeti la "
-"transferència a un programa diferent.\n"
+"Aquest procés li ajudarà a desar una còpia de les dades en qualsevol dels"
+" formats que suporta Gramps. Això es pot fer servir per copiar les dades, per"
+" desar una còpia de seguretat, o convertir-la a un format que permeti la"
+" transferència a un programa diferent.\n"
 "\n"
-"Si canvia d'opinió durant aquest procés, pot prémer el botó de Cancel·lar "
-"sense por en qualsevol moment, i la base de dades actual seguirà intacta."
+"Si canvia d'opinió durant aquest procés, pot prémer el botó de Cancel·lar"
+" sense por en qualsevol moment, i la base de dades actual seguirà intacta."
 
 #: ../gramps/gui/plug/export/_exportassistant.py:597
 msgid "Error exporting your Family Tree"
@@ -19043,15 +19004,15 @@ msgid ""
 "\n"
 " This makes references to the central person saved in the book invalid.\n"
 "\n"
-"Therefore, the central person for each item is being set to the active "
-"person of the currently opened database."
+"Therefore, the central person for each item is being set to the active person"
+" of the currently opened database."
 msgstr ""
 "Aquest llibre es va crear amb referències a la base de dades %s.\n"
 "\n"
 " Això invalida les referències a la persona central guardades al llibre.\n"
 "\n"
-"Per tant, la persona central de cada element es fixa a la persona activa de "
-"la base de dades oberta actualment."
+"Per tant, la persona central de cada element es fixa a la persona activa de"
+" la base de dades oberta actualment."
 
 #: ../gramps/gui/plug/report/_bookdialog.py:563
 msgid "No selected book item"
@@ -19181,13 +19142,13 @@ msgstr "Estil"
 #: ../gramps/gui/plug/report/_reportdialog.py:366
 #: ../gramps/plugins/drawreport/ancestortree.py:835
 #: ../gramps/plugins/drawreport/calendarreport.py:462
-#: ../gramps/plugins/drawreport/descendtree.py:1573
+#: ../gramps/plugins/drawreport/descendtree.py:1579
 #: ../gramps/plugins/drawreport/fanchart.py:687
 #: ../gramps/plugins/drawreport/statisticschart.py:1008
 #: ../gramps/plugins/drawreport/timeline.py:414
-#: ../gramps/plugins/graph/gvfamilylines.py:120
-#: ../gramps/plugins/graph/gvhourglass.py:364
-#: ../gramps/plugins/graph/gvrelgraph.py:797
+#: ../gramps/plugins/graph/gvfamilylines.py:121
+#: ../gramps/plugins/graph/gvhourglass.py:366
+#: ../gramps/plugins/graph/gvrelgraph.py:800
 #: ../gramps/plugins/textreport/alphabeticalindex.py:93
 #: ../gramps/plugins/textreport/ancestorreport.py:288
 #: ../gramps/plugins/textreport/birthdayreport.py:471
@@ -19205,8 +19166,8 @@ msgstr "Estil"
 #: ../gramps/plugins/textreport/summary.py:286
 #: ../gramps/plugins/textreport/tableofcontents.py:92
 #: ../gramps/plugins/textreport/tagreport.py:901
-#: ../gramps/plugins/webreport/narrativeweb.py:1613
-#: ../gramps/plugins/webreport/webcal.py:1656
+#: ../gramps/plugins/webreport/narrativeweb.py:1617
+#: ../gramps/plugins/webreport/webcal.py:1657
 msgid "Report Options"
 msgstr "Opcions d'Informe"
 
@@ -19285,8 +19246,8 @@ msgstr "No s'ha fixat la persona activa"
 #: ../gramps/gui/plug/report/_reportdialog.py:669
 msgid "You must select an active person for this report to work properly."
 msgstr ""
-"Cal seleccionar una persona activa perquè aquest informe funcioni "
-"correctament."
+"Cal seleccionar una persona activa perquè aquest informe funcioni"
+" correctament."
 
 #: ../gramps/gui/plug/report/_reportdialog.py:724
 #: ../gramps/gui/plug/report/_reportdialog.py:731
@@ -19386,19 +19347,19 @@ msgstr "Utilitats"
 
 #: ../gramps/gui/plug/tool.py:110
 msgid ""
-"Proceeding with this tool will erase the undo history for this session. In "
-"particular, you will not be able to revert the changes made by this tool or "
-"any changes made prior to it.\n"
+"Proceeding with this tool will erase the undo history for this session. In"
+" particular, you will not be able to revert the changes made by this tool or"
+" any changes made prior to it.\n"
 "\n"
-"If you think you may want to revert running this tool, please stop here and "
-"backup your database."
+"If you think you may want to revert running this tool, please stop here and"
+" backup your database."
 msgstr ""
-"Continuar amb aquesta eina esborrarà l'historial de modificacions d'aquesta "
-"sessió. Més concretament, no es podran desfer els canvis fets per aquesta "
-"eina ni cap canvi fet abans.\n"
+"Continuar amb aquesta eina esborrarà l'historial de modificacions d'aquesta"
+" sessió. Més concretament, no es podran desfer els canvis fets per aquesta"
+" eina ni cap canvi fet abans.\n"
 "\n"
-"Si creu que pot fer-li falta desfer l'execució d'aquesta eina, si us plau "
-"aturi's aquí i faci una còpia de seguretat de la base de dades."
+"Si creu que pot fer-li falta desfer l'execució d'aquesta eina, si us plau"
+" aturi's aquí i faci una còpia de seguretat de la base de dades."
 
 #: ../gramps/gui/plug/tool.py:116
 msgid "_Proceed with the tool"
@@ -19515,11 +19476,11 @@ msgstr "Actiu"
 
 #: ../gramps/gui/spell.py:149
 msgid ""
-"You have no installed dictionaries. Either install one or disable spell "
-"checking"
+"You have no installed dictionaries. Either install one or disable spell"
+" checking"
 msgstr ""
-"No teniu diccionaris instal·lats. Instal·leu-ne un o deshabiliteu la "
-"correcció ortográfica"
+"No teniu diccionaris instal·lats. Instal·leu-ne un o deshabiliteu la"
+" correcció ortográfica"
 
 #: ../gramps/gui/spell.py:153
 #, python-format
@@ -19605,25 +19566,25 @@ msgstr "Error del programa extern"
 msgid "File %s does not exist"
 msgstr "El fitxer %s no existeix"
 
-#: ../gramps/gui/utils.py:627
+#: ../gramps/gui/utils.py:628
 msgid ""
-"Cannot open new citation editor at this time. Either the citation is already "
-"being edited, or the associated source is already being edited, and opening "
-"a citation editor (which also allows the source to be edited), would create "
-"ambiguity by opening two editors on the same source. \n"
+"Cannot open new citation editor at this time. Either the citation is already"
+" being edited, or the associated source is already being edited, and opening"
+" a citation editor (which also allows the source to be edited), would create"
+" ambiguity by opening two editors on the same source. \n"
 "\n"
-"To edit the citation, close the source editor and open an editor for the "
-"citation alone"
+"To edit the citation, close the source editor and open an editor for the"
+" citation alone"
 msgstr ""
-"No es pot obrir un nou editor de cites en aquest moment. O bé la cita ja "
-"s'està editant, o la font associada ja s'està editant, i obrir ara un editor "
-"de cites (que també permet que se n'editi la font), crearia una ambigüitat "
-"en obrir dos editors sobre la mateixa font.\n"
+"No es pot obrir un nou editor de cites en aquest moment. O bé la cita ja"
+" s'està editant, o la font associada ja s'està editant, i obrir ara un editor"
+" de cites (que també permet que se n'editi la font), crearia una ambigüitat"
+" en obrir dos editors sobre la mateixa font.\n"
 "\n"
-"Per editar la cita, tanqueu l'editor de fonts i obriu un editor només per a "
-"la cita"
+"Per editar la cita, tanqueu l'editor de fonts i obriu un editor només per a"
+" la cita"
 
-#: ../gramps/gui/utils.py:640
+#: ../gramps/gui/utils.py:641
 msgid "Cannot open new citation editor"
 msgstr "No es pot obrir un nou editor de cites"
 
@@ -19646,11 +19607,11 @@ msgstr "Avortar els canvis?"
 
 #: ../gramps/gui/viewmanager.py:621
 msgid ""
-"Aborting changes will return the database to the state it was before you "
-"started this editing session."
+"Aborting changes will return the database to the state it was before you"
+" started this editing session."
 msgstr ""
-"Avortar els canvis retornarà la base de dades a l'estat en què es trobava "
-"abans de començar aquesta sessió d'edició."
+"Avortar els canvis retornarà la base de dades a l'estat en què es trobava"
+" abans de començar aquesta sessió d'edició."
 
 #: ../gramps/gui/viewmanager.py:623
 msgid "Abort changes"
@@ -19662,11 +19623,11 @@ msgstr "No es poden abandonar els canvis de la sessió"
 
 #: ../gramps/gui/viewmanager.py:635
 msgid ""
-"Changes cannot be completely abandoned because the number of changes made in "
-"the session exceeded the limit."
+"Changes cannot be completely abandoned because the number of changes made in"
+" the session exceeded the limit."
 msgstr ""
-"Els canvis no es poden abandonar totalment perquè el nombre de canvis fets "
-"durant la sessió ha sobrepassat el límit."
+"Els canvis no es poden abandonar totalment perquè el nombre de canvis fets"
+" durant la sessió ha sobrepassat el límit."
 
 #: ../gramps/gui/viewmanager.py:802
 msgid "View failed to load. Check error output."
@@ -19710,22 +19671,21 @@ msgid ""
 "%(error_msg)s\n"
 "\n"
 "If you are unable to fix the fault yourself then you can submit a bug at "
-"%(gramps_bugtracker_url)s or contact the view author "
-"(%(firstauthoremail)s).\n"
+"%(gramps_bugtracker_url)s or contact the view author (%(firstauthoremail)s).\n"
 "\n"
-"If you do not want Gramps to try and load this view again, you can hide it "
-"by using the Plugin Manager on the Help menu."
+"If you do not want Gramps to try and load this view again, you can hide it by"
+" using the Plugin Manager on the Help menu."
 msgstr ""
 "La vista %(name)s no s'ha carregat i ha donat un error.\n"
 "\n"
 "%(error_msg)s\n"
 "\n"
 "Si no podeu solucionar el problema tot sol, podeu informar de l'error a "
-"%(gramps_bugtracker_url)s o poseu-vos en contacte amb l'autor del connector "
-"(%(firstauthoremail)s).\n"
+"%(gramps_bugtracker_url)s o poseu-vos en contacte amb l'autor del connector ("
+"%(firstauthoremail)s).\n"
 "\n"
-"Si no voleu que Gramps torni a provar de carregar aquesta vista, podeu "
-"amagar-la amb el Gestor de Connectors del menú d'Ajuda."
+"Si no voleu que Gramps torni a provar de carregar aquesta vista, podeu"
+" amagar-la amb el Gestor de Connectors del menú d'Ajuda."
 
 #: ../gramps/gui/viewmanager.py:1574
 msgid "Failed Loading Plugin"
@@ -19739,22 +19699,22 @@ msgid ""
 "%(error_msg)s\n"
 "\n"
 "If you are unable to fix the fault yourself then you can submit a bug at "
-"%(gramps_bugtracker_url)s or contact the plugin author "
-"(%(firstauthoremail)s).\n"
+"%(gramps_bugtracker_url)s or contact the plugin author ("
+"%(firstauthoremail)s).\n"
 "\n"
-"If you do not want Gramps to try and load this plugin again, you can hide it "
-"by using the Plugin Manager on the Help menu."
+"If you do not want Gramps to try and load this plugin again, you can hide it"
+" by using the Plugin Manager on the Help menu."
 msgstr ""
 "El connector %(name)s no s'ha carregat i ha donat un error.\n"
 "\n"
 "%(error_msg)s\n"
 "\n"
 "Si no podeu solucionar el problema tot sol, podeu informar de l'error a "
-"%(gramps_bugtracker_url)s o poseu-vos en contacte amb l'autor del connector "
-"(%(firstauthoremail)s).\n"
+"%(gramps_bugtracker_url)s o poseu-vos en contacte amb l'autor del connector ("
+"%(firstauthoremail)s).\n"
 "\n"
-"Si no voleu que Gramps torni a provar de carregar aquest connector, podeu "
-"amagar-lo amb el Gestor de Connectors del menú d'Ajuda."
+"Si no voleu que Gramps torni a provar de carregar aquest connector, podeu"
+" amagar-lo amb el Gestor de Connectors del menú d'Ajuda."
 
 #: ../gramps/gui/viewmanager.py:1655
 msgid "Gramps XML Backup"
@@ -19864,11 +19824,11 @@ msgstr "Esborrat de selecció múltiple"
 
 #: ../gramps/gui/views/listview.py:543
 msgid ""
-"More than one item has been selected for deletion. Select the option "
-"indicating how to delete the items:"
+"More than one item has been selected for deletion. Select the option"
+" indicating how to delete the items:"
 msgstr ""
-"S'ha seleccionat més d'un element per esborrar. Selecciona l'opció indicant "
-"com esborrar cadascun d'ells:"
+"S'ha seleccionat més d'un element per esborrar. Selecciona l'opció indicant"
+" com esborrar cadascun d'ells:"
 
 #: ../gramps/gui/views/listview.py:545
 msgid "Delete All"
@@ -19880,11 +19840,11 @@ msgstr "Confirma cada esborrat"
 
 #: ../gramps/gui/views/listview.py:561
 msgid ""
-"This item is currently being used. Deleting it will remove it from the "
-"database and from all other items that reference it."
+"This item is currently being used. Deleting it will remove it from the"
+" database and from all other items that reference it."
 msgstr ""
-"Aquest element està en ús. Esborrar-lo el traurà de la base de dades i de "
-"tots els altres elements que el referencien."
+"Aquest element està en ús. Esborrar-lo el traurà de la base de dades i de"
+" tots els altres elements que el referencien."
 
 #: ../gramps/gui/views/listview.py:565 ../gramps/plugins/view/eventview.py:407
 #: ../gramps/plugins/view/familyview.py:394
@@ -19902,19 +19862,19 @@ msgstr "Esborrar %s?"
 msgid "Column clicked, sorting..."
 msgstr "Columna clicada, ordenant..."
 
-#: ../gramps/gui/views/listview.py:1061
+#: ../gramps/gui/views/listview.py:1062
 msgid "Export View as Spreadsheet"
 msgstr "Exportar Vista com a Full de càlcul"
 
-#: ../gramps/gui/views/listview.py:1074
+#: ../gramps/gui/views/listview.py:1075
 msgid "CSV"
 msgstr "CSV"
 
-#: ../gramps/gui/views/listview.py:1075
+#: ../gramps/gui/views/listview.py:1076
 msgid "OpenDocument Spreadsheet"
 msgstr "Full de càlcul d'OpenDocument"
 
-#: ../gramps/gui/views/listview.py:1266
+#: ../gramps/gui/views/listview.py:1267
 msgid "Columns"
 msgstr "Columnes"
 
@@ -19929,8 +19889,7 @@ msgstr "%s s'ha desat com a punt d'interès"
 #: ../gramps/plugins/view/familyview.py:348
 msgid "A bookmark could not be set because no one was selected."
 msgstr ""
-"No s'ha pogut crear un punt d'interès perquè no n'hi havia cap de "
-"seleccionat."
+"No s'ha pogut crear un punt d'interès perquè no n'hi havia cap de seleccionat."
 
 #: ../gramps/gui/views/navigationview.py:323
 msgid "No Home Person"
@@ -19938,13 +19897,13 @@ msgstr "Persona base no fixada"
 
 #: ../gramps/gui/views/navigationview.py:324
 msgid ""
-"You need to set a 'default person' to go to. Select the People View, select "
-"the person you want as 'Home Person', then confirm your choice via the menu "
-"Edit -> Set Home Person."
+"You need to set a 'default person' to go to. Select the People View, select"
+" the person you want as 'Home Person', then confirm your choice via the menu"
+" Edit -> Set Home Person."
 msgstr ""
-"Heu de fixar una 'persona predeterminada' on anar. Seleccioneu la Vista de "
-"Persones, seleccioneu la persona que voleu com a 'Persona Base', i llavors "
-"confirmeu l'elecció amb el menú Edita -> Fixar Persona Base."
+"Heu de fixar una 'persona predeterminada' on anar. Seleccioneu la Vista de"
+" Persones, seleccioneu la persona que voleu com a 'Persona Base', i llavors"
+" confirmeu l'elecció amb el menú Edita -> Fixar Persona Base."
 
 #: ../gramps/gui/views/navigationview.py:334
 #: ../gramps/gui/views/navigationview.py:337
@@ -20030,11 +19989,11 @@ msgstr "Esborra l'etiqueta '%s'?"
 
 #: ../gramps/gui/views/tags.py:530
 msgid ""
-"The tag definition will be removed.  The tag will be also removed from all "
-"objects in the database."
+"The tag definition will be removed.  The tag will be also removed from all"
+" objects in the database."
 msgstr ""
-"Es traurà la definició de l'etiqueta. L'etiqueta també es traurà de tots els "
-"objectes de la base de dades."
+"Es traurà la definició de l'etiqueta. L'etiqueta també es traurà de tots els"
+" objectes de la base de dades."
 
 #: ../gramps/gui/views/tags.py:562
 msgid "Removing Tags"
@@ -20117,22 +20076,22 @@ msgid "Reorder families"
 msgstr "Reordena famílies"
 
 #: ../gramps/gui/widgets/fanchart.py:1847
-#: ../gramps/plugins/view/pedigreeview.py:1743
-#: ../gramps/plugins/view/pedigreeview.py:1971
+#: ../gramps/plugins/view/pedigreeview.py:1744
+#: ../gramps/plugins/view/pedigreeview.py:1972
 msgid "_Copy"
 msgstr "_Copiar"
 
 #. Go over siblings and build their menu
 #: ../gramps/gui/widgets/fanchart.py:1891
 #: ../gramps/plugins/quickview/quickview.gpr.py:319
-#: ../gramps/plugins/view/pedigreeview.py:1787
+#: ../gramps/plugins/view/pedigreeview.py:1788
 #: ../gramps/plugins/view/relview.py:1084
 msgid "Siblings"
 msgstr "Germans"
 
 #. Go over parents and build their menu
 #: ../gramps/gui/widgets/fanchart.py:2037
-#: ../gramps/plugins/view/pedigreeview.py:1914
+#: ../gramps/plugins/view/pedigreeview.py:1915
 msgid "Related"
 msgstr "Parents"
 
@@ -20165,11 +20124,11 @@ msgstr "Barra de Gramplets"
 
 #: ../gramps/gui/widgets/grampletbar.py:361
 msgid ""
-"Select the down arrow on the right corner for adding, removing or restoring "
-"gramplets."
+"Select the down arrow on the right corner for adding, removing or restoring"
+" gramplets."
 msgstr ""
-"Seleccioneu la fletxa cap avall de la cantonada dreta per afegir, treure, o "
-"recuperar gramplets."
+"Seleccioneu la fletxa cap avall de la cantonada dreta per afegir, treure, o"
+" recuperar gramplets."
 
 #: ../gramps/gui/widgets/grampletbar.py:488
 #: ../gramps/gui/widgets/grampletpane.py:1446
@@ -20190,11 +20149,11 @@ msgstr "Recupera la situació predeterminada?"
 
 #: ../gramps/gui/widgets/grampletbar.py:548
 msgid ""
-"The gramplet bar will be restored to contain its default gramplets.  This "
-"action cannot be undone."
+"The gramplet bar will be restored to contain its default gramplets.  This"
+" action cannot be undone."
 msgstr ""
-"La barra de gramplets es recuperarà perquè contingui els gramplets "
-"predeterminats. Aquesta acció no es pot desfer."
+"La barra de gramplets es recuperarà perquè contingui els gramplets"
+" predeterminats. Aquesta acció no es pot desfer."
 
 #. default tooltip
 #: ../gramps/gui/widgets/grampletpane.py:815
@@ -20250,11 +20209,11 @@ msgstr "Data més d'un any en el futur"
 
 #: ../gramps/gui/widgets/photo.py:56
 msgid ""
-"Double-click on the picture to view it in the default image viewer "
-"application."
+"Double-click on the picture to view it in the default image viewer"
+" application."
 msgstr ""
-"Feu doble clic a la imatge per veure-a a l'aplicació de visualitzar imatges "
-"predeterminada."
+"Feu doble clic a la imatge per veure-a a l'aplicació de visualitzar imatges"
+" predeterminada."
 
 #: ../gramps/gui/widgets/photo.py:88
 msgid "Make Active Media"
@@ -20263,11 +20222,11 @@ msgstr "Fes medis audiovisuals actius"
 #. initial tooltip when no place already selected.
 #: ../gramps/gui/widgets/placewithin.py:63
 msgid ""
-"Matches places within a given distance of the active place. You have no "
-"active place."
+"Matches places within a given distance of the active place. You have no"
+" active place."
 msgstr ""
-"Concorda amb llocs en una distància donada del lloc actiu. No tens cap lloc "
-"actiu."
+"Concorda amb llocs en una distància donada del lloc actiu. No tens cap lloc"
+" actiu."
 
 #: ../gramps/gui/widgets/progressdialog.py:298
 msgid "Progress Information"
@@ -20413,8 +20372,8 @@ msgstr ""
 msgid ""
 "%(n1)6d  Media Objects upgraded with %(n2)6d citations in %(n3)6d secs\n"
 msgstr ""
-"%(n1)6d  Objectes audiovisuals actualitzats amb %(n2)6d cites en %(n3)6d "
-"segons\n"
+"%(n1)6d  Objectes audiovisuals actualitzats amb %(n2)6d cites en %(n3)6d"
+" segons\n"
 
 #: ../gramps/plugins/db/bsddb/upgrade.py:414
 #, python-format
@@ -20464,12 +20423,12 @@ msgstr "Estadístiques de l'actualització"
 #: ../gramps/plugins/db/bsddb/write.py:1154
 #, python-format
 msgid ""
-"An attempt is made to save a reference key which is partly bytecode, this is "
-"not allowed.\n"
+"An attempt is made to save a reference key which is partly bytecode, this is"
+" not allowed.\n"
 "Key is %s"
 msgstr ""
-"S'ha fet un intent de desar una clau de referència que en part és binària, "
-"això no està permès.\n"
+"S'ha fet un intent de desar una clau de referència que en part és binària,"
+" això no està permès.\n"
 "La clau és %s"
 
 #. Make a tuple of the functions and classes that we need for
@@ -20481,11 +20440,11 @@ msgstr "Reconstruir mapa de referències"
 #: ../gramps/plugins/db/bsddb/write.py:1986
 #, python-format
 msgid ""
-"A second transaction is started while there is still a transaction, \"%s\", "
-"active in the database."
+"A second transaction is started while there is still a transaction, \"%s\","
+" active in the database."
 msgstr ""
-"S'ha engegat una segona transacció mentre encara n'hi ha una, \"%s\", "
-"d'activa a la base de dades."
+"S'ha engegat una segona transacció mentre encara n'hi ha una, \"%s\","
+" d'activa a la base de dades."
 
 #: ../gramps/plugins/db/bsddb/write.py:2307
 #: ../gramps/plugins/db/dbapi/sqlite.py:61
@@ -20651,24 +20610,24 @@ msgid "of %d"
 msgstr "de %d"
 
 #: ../gramps/plugins/docgen/htmldoc.py:273
-#: ../gramps/plugins/webreport/narrativeweb.py:1517
+#: ../gramps/plugins/webreport/narrativeweb.py:1521
 #: ../gramps/plugins/webreport/webcal.py:270
 msgid "Possible destination error"
 msgstr "Possible error de destí"
 
 #: ../gramps/plugins/docgen/htmldoc.py:274
-#: ../gramps/plugins/webreport/narrativeweb.py:1518
+#: ../gramps/plugins/webreport/narrativeweb.py:1522
 #: ../gramps/plugins/webreport/webcal.py:271
 msgid ""
-"You appear to have set your target directory to a directory used for data "
-"storage. This could create problems with file management. It is recommended "
-"that you consider using a different directory to store your generated web "
-"pages."
+"You appear to have set your target directory to a directory used for data"
+" storage. This could create problems with file management. It is recommended"
+" that you consider using a different directory to store your generated web"
+" pages."
 msgstr ""
-"Sembla que ha posat com a directori destí un directori que es fa servir per "
-"emmagatzemar dades. Això podria crear problemes amb la gestió de fitxers. Es "
-"recomana que sospesi de fer servir un altre directori per emmagatzemar les "
-"pàgines web generades."
+"Sembla que ha posat com a directori destí un directori que es fa servir per"
+" emmagatzemar dades. Això podria crear problemes amb la gestió de fitxers. Es"
+" recomana que sospesi de fer servir un altre directori per emmagatzemar les"
+" pàgines web generades."
 
 #: ../gramps/plugins/docgen/htmldoc.py:567
 #, python-format
@@ -20677,17 +20636,17 @@ msgstr "No s'ha pogut crear la versió jpeg de la imatge %(name)s"
 
 #: ../gramps/plugins/docgen/latexdoc.py:1240
 msgid "PIL (Python Imaging Library) not loaded."
-msgstr "No s'ha carregat PIL (Python Imaging Library)"
+msgstr "No s'ha carregat PIL (Python Imaging Library)."
 
 #: ../gramps/plugins/docgen/latexdoc.py:1241
 msgid ""
-"Production of jpg images from non-jpg images in LaTeX documents will not be "
-"available. Use your package manager to install python-imaging or python-"
-"pillow or python3-pillow"
+"Production of jpg images from non-jpg images in LaTeX documents will not be"
+" available. Use your package manager to install python-imaging or"
+" python-pillow or python3-pillow"
 msgstr ""
-"No estarà disponible la funcionalitat de crear imatges jpg a partir "
-"d'imatges no-jpg en documents LaTeX. Utilitzeu el gestor de paquets per "
-"instal·lar python-imaging o python-pillow o python3-pillow"
+"No estarà disponible la funcionalitat de crear imatges jpg a partir d'imatges"
+" no-jpg en documents LaTeX. Utilitzeu el gestor de paquets per instal·lar"
+" python-imaging o python-pillow o python3-pillow"
 
 #: ../gramps/plugins/docgen/odfdoc.py:1182
 #, python-format
@@ -20752,10 +20711,10 @@ msgstr "Gràfic d'Avantpassats per %s"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:362
 #: ../gramps/plugins/drawreport/calendarreport.py:114
-#: ../gramps/plugins/drawreport/descendtree.py:689
+#: ../gramps/plugins/drawreport/descendtree.py:695
 #: ../gramps/plugins/drawreport/fanchart.py:194
-#: ../gramps/plugins/graph/gvhourglass.py:109
-#: ../gramps/plugins/graph/gvrelgraph.py:184
+#: ../gramps/plugins/graph/gvhourglass.py:110
+#: ../gramps/plugins/graph/gvrelgraph.py:185
 #: ../gramps/plugins/textreport/ancestorreport.py:117
 #: ../gramps/plugins/textreport/birthdayreport.py:115
 #: ../gramps/plugins/textreport/descendreport.py:453
@@ -20785,8 +20744,8 @@ msgstr "Imprimint l'Arbre..."
 #: ../gramps/plugins/drawreport/ancestortree.py:793
 #: ../gramps/plugins/drawreport/calendarreport.py:472
 #: ../gramps/plugins/drawreport/fanchart.py:689
-#: ../gramps/plugins/graph/gvhourglass.py:366
-#: ../gramps/plugins/graph/gvrelgraph.py:807
+#: ../gramps/plugins/graph/gvhourglass.py:368
+#: ../gramps/plugins/graph/gvrelgraph.py:810
 #: ../gramps/plugins/textreport/ancestorreport.py:290
 #: ../gramps/plugins/textreport/descendreport.py:522
 #: ../gramps/plugins/textreport/detancestralreport.py:831
@@ -20812,7 +20771,7 @@ msgstr ""
 "Si s'ha de mostrar només la persona central o també tots el seus germans"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:804
-#: ../gramps/plugins/drawreport/descendtree.py:1538
+#: ../gramps/plugins/drawreport/descendtree.py:1544
 #: ../gramps/plugins/drawreport/fanchart.py:693
 #: ../gramps/plugins/textreport/ancestorreport.py:294
 #: ../gramps/plugins/textreport/descendreport.py:537
@@ -20822,7 +20781,7 @@ msgid "Generations"
 msgstr "Generacions"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:805
-#: ../gramps/plugins/drawreport/descendtree.py:1539
+#: ../gramps/plugins/drawreport/descendtree.py:1545
 msgid "The number of generations to include in the tree"
 msgstr "El nombre de generacions a incloure dins l'arbre"
 
@@ -20839,26 +20798,25 @@ msgid "The number of generations of empty boxes that will be displayed"
 msgstr "El nombre de generacions de caixes buides que es mostraran"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:818
-#: ../gramps/plugins/drawreport/descendtree.py:1556
+#: ../gramps/plugins/drawreport/descendtree.py:1562
 msgid "Compress tree"
 msgstr "Comprimir arbre"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:820
 msgid ""
-"Whether to remove any extra blank spaces set aside for people that are "
-"unknown"
+"Whether to remove any extra blank spaces set aside for people that are unknown"
 msgstr ""
-"Si s'han de treure tots els espais en blanc addicionals que s'hagin deixat "
-"per a persones desconegudes"
+"Si s'han de treure tots els espais en blanc addicionals que s'hagin deixat"
+" per a persones desconegudes"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:837
-#: ../gramps/plugins/drawreport/descendtree.py:1575
+#: ../gramps/plugins/drawreport/descendtree.py:1581
 msgid "Report Title"
 msgstr "Títol de l'Informe"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:838
-#: ../gramps/plugins/drawreport/descendtree.py:1576
-#: ../gramps/plugins/drawreport/descendtree.py:1749
+#: ../gramps/plugins/drawreport/descendtree.py:1582
+#: ../gramps/plugins/drawreport/descendtree.py:1755
 msgid "Do not include a title"
 msgstr "No incloure un títol"
 
@@ -20867,22 +20825,22 @@ msgid "Include Report Title"
 msgstr "Incloure el Títol de l'Informe"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:840
-#: ../gramps/plugins/drawreport/descendtree.py:1584
+#: ../gramps/plugins/drawreport/descendtree.py:1590
 msgid "Choose a title for the report"
 msgstr "Tria un títol per a l'informe"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:843
-#: ../gramps/plugins/drawreport/descendtree.py:1588
+#: ../gramps/plugins/drawreport/descendtree.py:1594
 msgid "Include a border"
 msgstr "Incloure una vora"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:844
-#: ../gramps/plugins/drawreport/descendtree.py:1589
+#: ../gramps/plugins/drawreport/descendtree.py:1595
 msgid "Whether to make a border around the report."
 msgstr "Si s'ha de fer una vora al voltant de l'informe."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:847
-#: ../gramps/plugins/drawreport/descendtree.py:1592
+#: ../gramps/plugins/drawreport/descendtree.py:1598
 msgid "Include Page Numbers"
 msgstr "Incloure Números de Pàgina"
 
@@ -20891,32 +20849,32 @@ msgid "Whether to print page numbers on each page."
 msgstr "Si s'han d'imprimir els números de pàgina a cada pàgina."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:851
-#: ../gramps/plugins/drawreport/descendtree.py:1596
+#: ../gramps/plugins/drawreport/descendtree.py:1602
 msgid "Scale tree to fit"
 msgstr "Escala l'arbre perquè hi càpiga"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:852
-#: ../gramps/plugins/drawreport/descendtree.py:1597
+#: ../gramps/plugins/drawreport/descendtree.py:1603
 msgid "Do not scale tree"
 msgstr "No escalar l'arbre"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:853
-#: ../gramps/plugins/drawreport/descendtree.py:1598
+#: ../gramps/plugins/drawreport/descendtree.py:1604
 msgid "Scale tree to fit page width only"
 msgstr "Escala l'arbre només fins a l'amplada de la pàgina"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:854
-#: ../gramps/plugins/drawreport/descendtree.py:1599
+#: ../gramps/plugins/drawreport/descendtree.py:1605
 msgid "Scale tree to fit the size of the page"
 msgstr "Escala l'arbre perquè càpiga a la pàgina"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:856
-#: ../gramps/plugins/drawreport/descendtree.py:1601
+#: ../gramps/plugins/drawreport/descendtree.py:1607
 msgid "Whether to scale the tree to fit a specific paper size"
 msgstr "Si s'ha d'escalar l'arbre perquè càpiga en una mida especificada"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:863
-#: ../gramps/plugins/drawreport/descendtree.py:1608
+#: ../gramps/plugins/drawreport/descendtree.py:1614
 msgid ""
 "Resize Page to Fit Tree size\n"
 "\n"
@@ -20927,7 +20885,7 @@ msgstr ""
 "Nota: té prioritat sobre les opcions de la pestanya 'Opcions de Paper'"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:869
-#: ../gramps/plugins/drawreport/descendtree.py:1614
+#: ../gramps/plugins/drawreport/descendtree.py:1620
 msgid ""
 "Whether to resize the page to fit the size \n"
 "of the tree.  Note:  the page will have a \n"
@@ -20962,12 +20920,12 @@ msgstr ""
 " com en amplada"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:889
-#: ../gramps/plugins/drawreport/descendtree.py:1634
+#: ../gramps/plugins/drawreport/descendtree.py:1640
 msgid "Include Blank Pages"
 msgstr "Incloure Pàgines en Blanc"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:890
-#: ../gramps/plugins/drawreport/descendtree.py:1635
+#: ../gramps/plugins/drawreport/descendtree.py:1641
 msgid "Whether to include pages that are blank."
 msgstr "Si també s'han d'incloure pàgines que estiguin en blanc."
 
@@ -20981,13 +20939,13 @@ msgstr "Si també s'han d'incloure pàgines que estiguin en blanc."
 #. ###############################
 #: ../gramps/plugins/drawreport/ancestortree.py:896
 #: ../gramps/plugins/drawreport/calendarreport.py:490
-#: ../gramps/plugins/drawreport/descendtree.py:1639
+#: ../gramps/plugins/drawreport/descendtree.py:1645
 #: ../gramps/plugins/drawreport/fanchart.py:730
 #: ../gramps/plugins/drawreport/statisticschart.py:1074
 #: ../gramps/plugins/drawreport/timeline.py:435
-#: ../gramps/plugins/graph/gvfamilylines.py:169
-#: ../gramps/plugins/graph/gvhourglass.py:402
-#: ../gramps/plugins/graph/gvrelgraph.py:841
+#: ../gramps/plugins/graph/gvfamilylines.py:170
+#: ../gramps/plugins/graph/gvhourglass.py:404
+#: ../gramps/plugins/graph/gvrelgraph.py:844
 #: ../gramps/plugins/textreport/ancestorreport.py:310
 #: ../gramps/plugins/textreport/birthdayreport.py:500
 #: ../gramps/plugins/textreport/descendreport.py:557
@@ -20998,7 +20956,7 @@ msgstr "Si també s'han d'incloure pàgines que estiguin en blanc."
 #: ../gramps/plugins/textreport/kinshipreport.py:382
 #: ../gramps/plugins/textreport/placereport.py:462
 #: ../gramps/plugins/textreport/recordsreport.py:243
-#: ../gramps/plugins/webreport/webcal.py:1709
+#: ../gramps/plugins/webreport/webcal.py:1710
 msgid "Report Options (2)"
 msgstr "Opcions d'Informe (2)"
 
@@ -21053,17 +21011,17 @@ msgid "The display format for the center person"
 msgstr "El format a mostrar per a la persona central"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:941
-#: ../gramps/plugins/drawreport/descendtree.py:1675
+#: ../gramps/plugins/drawreport/descendtree.py:1681
 msgid "Include Marriage box"
 msgstr "Incloure caixa de Matrimoni"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:943
-#: ../gramps/plugins/drawreport/descendtree.py:1677
+#: ../gramps/plugins/drawreport/descendtree.py:1683
 msgid "Whether to include a separate marital box in the report"
 msgstr "Si s'ha d'incloure una caixa separada del matrimoni a l'informe"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:947
-#: ../gramps/plugins/drawreport/descendtree.py:1681
+#: ../gramps/plugins/drawreport/descendtree.py:1687
 msgid ""
 "Marriage\n"
 "Display Format"
@@ -21072,19 +21030,19 @@ msgstr ""
 "de Casaments"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:949
-#: ../gramps/plugins/drawreport/descendtree.py:1683
+#: ../gramps/plugins/drawreport/descendtree.py:1689
 msgid "Display format for the marital box."
 msgstr "Format de visualització per la caixa de matrimoni."
 
 #. #################
 #: ../gramps/plugins/drawreport/ancestortree.py:954
-#: ../gramps/plugins/drawreport/descendtree.py:1688
+#: ../gramps/plugins/drawreport/descendtree.py:1694
 #: ../gramps/plugins/lib/libmetadata.py:104
 msgid "Advanced"
 msgstr "Avançat"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:957
-#: ../gramps/plugins/drawreport/descendtree.py:1691
+#: ../gramps/plugins/drawreport/descendtree.py:1697
 msgid ""
 "Replace Display Format:\n"
 "'Replace this'/' with this'"
@@ -21093,7 +21051,7 @@ msgstr ""
 "'Substitueix això'/'per això'"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:959
-#: ../gramps/plugins/drawreport/descendtree.py:1693
+#: ../gramps/plugins/drawreport/descendtree.py:1699
 msgid ""
 "i.e.\n"
 "United States of America/U.S.A"
@@ -21108,17 +21066,17 @@ msgstr ""
 #. _("Whether to include thumbnails of people."))
 #. menu.add_option(category_name, "includeImages", self.__include_images)
 #: ../gramps/plugins/drawreport/ancestortree.py:969
-#: ../gramps/plugins/drawreport/descendtree.py:1696
+#: ../gramps/plugins/drawreport/descendtree.py:1702
 msgid "Include a note"
 msgstr "Incloure una nota"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:970
-#: ../gramps/plugins/drawreport/descendtree.py:1697
+#: ../gramps/plugins/drawreport/descendtree.py:1703
 msgid "Whether to include a note on the report."
 msgstr "Si s'ha d'incloure una nota a l'informe."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:975
-#: ../gramps/plugins/drawreport/descendtree.py:1702
+#: ../gramps/plugins/drawreport/descendtree.py:1708
 msgid ""
 "Add a note\n"
 "\n"
@@ -21129,12 +21087,12 @@ msgstr ""
 "$T insereix la data d'avui"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:980
-#: ../gramps/plugins/drawreport/descendtree.py:1707
+#: ../gramps/plugins/drawreport/descendtree.py:1713
 msgid "Note Location"
 msgstr "Posició de la Nota"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:983
-#: ../gramps/plugins/drawreport/descendtree.py:1710
+#: ../gramps/plugins/drawreport/descendtree.py:1716
 msgid "Where to place the note."
 msgstr "On col·locar la nota."
 
@@ -21147,13 +21105,13 @@ msgid "Make the inter-box spacing bigger or smaller"
 msgstr "Fer que l'espaiat entre caixes sigui més gran o més petit"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:993
-#: ../gramps/plugins/drawreport/descendtree.py:1719
+#: ../gramps/plugins/drawreport/descendtree.py:1725
 msgid "box shadow scale factor"
 msgstr "factor d'escala de l'ombra de caixa"
 
 #. down to 0
 #: ../gramps/plugins/drawreport/ancestortree.py:995
-#: ../gramps/plugins/drawreport/descendtree.py:1721
+#: ../gramps/plugins/drawreport/descendtree.py:1727
 msgid "Make the box shadow bigger or smaller"
 msgstr "Fer que l'ombra de caixa sigui més gran o més petita"
 
@@ -21170,7 +21128,7 @@ msgid " Generations of empty boxes for unknown ancestors"
 msgstr " Generacions de caixes buides per avantpassats desconeguts"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:1049
-#: ../gramps/plugins/drawreport/descendtree.py:1781
+#: ../gramps/plugins/drawreport/descendtree.py:1787
 #: ../gramps/plugins/drawreport/fanchart.py:771
 #: ../gramps/plugins/drawreport/timeline.py:480
 #: ../gramps/plugins/textreport/alphabeticalindex.py:120
@@ -21191,14 +21149,14 @@ msgid "The basic style used for the text display."
 msgstr "L'estil bàsic que es fa servir per mostrar el text."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:1059
-#: ../gramps/plugins/drawreport/descendtree.py:1801
+#: ../gramps/plugins/drawreport/descendtree.py:1807
 #: ../gramps/plugins/textreport/familygroup.py:890
 #: ../gramps/plugins/textreport/tagreport.py:993
 msgid "The basic style used for the note display."
 msgstr "L'estil bàsic que es fa servir per mostrar les notes."
 
 #: ../gramps/plugins/drawreport/ancestortree.py:1068
-#: ../gramps/plugins/drawreport/descendtree.py:1772
+#: ../gramps/plugins/drawreport/descendtree.py:1778
 #: ../gramps/plugins/drawreport/fanchart.py:761
 #: ../gramps/plugins/drawreport/statisticschart.py:1159
 #: ../gramps/plugins/drawreport/timeline.py:498
@@ -21246,7 +21204,7 @@ msgstr "Donant format als mesos..."
 
 #: ../gramps/plugins/drawreport/calendarreport.py:316
 #: ../gramps/plugins/textreport/birthdayreport.py:270
-#: ../gramps/plugins/webreport/webcal.py:1285
+#: ../gramps/plugins/webreport/webcal.py:1286
 msgid "Reading database..."
 msgstr "Llegint base de dades..."
 
@@ -21289,14 +21247,14 @@ msgstr[1] ""
 " {person}, {nyears}"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:468
-#: ../gramps/plugins/webreport/webcal.py:1673
+#: ../gramps/plugins/webreport/webcal.py:1674
 msgid "Select filter to restrict people that appear on calendar"
 msgstr ""
 "Selecciona un filtre per restringir les persones que apareixen al calendari"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:473
 #: ../gramps/plugins/drawreport/fanchart.py:690
-#: ../gramps/plugins/graph/gvrelgraph.py:808
+#: ../gramps/plugins/graph/gvrelgraph.py:811
 #: ../gramps/plugins/textreport/ancestorreport.py:291
 #: ../gramps/plugins/textreport/descendreport.py:523
 #: ../gramps/plugins/textreport/detancestralreport.py:832
@@ -21336,12 +21294,12 @@ msgstr "Tercera línia de text a sota del calendari"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:501
 #: ../gramps/plugins/textreport/birthdayreport.py:507
-#: ../gramps/plugins/webreport/webcal.py:1729
+#: ../gramps/plugins/webreport/webcal.py:1730
 msgid "Include only living people"
 msgstr "Incloure només persones vives"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:502
-#: ../gramps/plugins/webreport/webcal.py:1730
+#: ../gramps/plugins/webreport/webcal.py:1731
 msgid "Include only living people in the calendar"
 msgstr "Incloure només persones vives al calendari"
 
@@ -21364,7 +21322,7 @@ msgstr "Any de calendari"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:517
 #: ../gramps/plugins/textreport/birthdayreport.py:530
-#: ../gramps/plugins/webreport/webcal.py:1766
+#: ../gramps/plugins/webreport/webcal.py:1767
 msgid "Country for holidays"
 msgstr "País per festes"
 
@@ -21375,52 +21333,52 @@ msgstr "Selecciona el país per veure festes associades"
 
 #. Default selection ????
 #: ../gramps/plugins/drawreport/calendarreport.py:531
-#: ../gramps/plugins/webreport/webcal.py:1784
+#: ../gramps/plugins/webreport/webcal.py:1785
 msgid "First day of week"
 msgstr "Primer dia de la setmana"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:539
-#: ../gramps/plugins/webreport/webcal.py:1787
+#: ../gramps/plugins/webreport/webcal.py:1788
 msgid "Select the first day of the week for the calendar"
 msgstr "Selecciona el primer dia de la setmana per al calendari"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:542
 #: ../gramps/plugins/textreport/birthdayreport.py:544
-#: ../gramps/plugins/webreport/webcal.py:1791
+#: ../gramps/plugins/webreport/webcal.py:1792
 msgid "Birthday surname"
 msgstr "Cognom de naixement"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:545
 #: ../gramps/plugins/textreport/birthdayreport.py:547
-#: ../gramps/plugins/webreport/webcal.py:1792
+#: ../gramps/plugins/webreport/webcal.py:1793
 msgid "Wives use husband's surname (from first family listed)"
 msgstr ""
-"Les esposes fan servir el cognom del seu marit (a partir de la primera "
-"família llistada)"
+"Les esposes fan servir el cognom del seu marit (a partir de la primera"
+" família llistada)"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:548
 #: ../gramps/plugins/textreport/birthdayreport.py:550
-#: ../gramps/plugins/webreport/webcal.py:1794
+#: ../gramps/plugins/webreport/webcal.py:1795
 msgid "Wives use husband's surname (from last family listed)"
 msgstr ""
-"Les esposes fan servir el cognom del seu marit (a partir de l'última família "
-"llistada)"
+"Les esposes fan servir el cognom del seu marit (a partir de l'última família"
+" llistada)"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:549
 #: ../gramps/plugins/textreport/birthdayreport.py:551
-#: ../gramps/plugins/webreport/webcal.py:1796
+#: ../gramps/plugins/webreport/webcal.py:1797
 msgid "Wives use their own surname"
 msgstr "Les esposes fan servir el seu propi cognom"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:550
 #: ../gramps/plugins/textreport/birthdayreport.py:552
-#: ../gramps/plugins/webreport/webcal.py:1797
+#: ../gramps/plugins/webreport/webcal.py:1798
 msgid "Select married women's displayed surname"
 msgstr "Selecciona el cognom que es mostra de les dones casades"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:553
 #: ../gramps/plugins/textreport/birthdayreport.py:555
-#: ../gramps/plugins/webreport/webcal.py:1882
+#: ../gramps/plugins/webreport/webcal.py:1883
 msgid "Include birthdays"
 msgstr "Incloure aniversaris de naixement"
 
@@ -21431,7 +21389,7 @@ msgstr "Si s'han d'incloure els aniversaris de naixement"
 
 #: ../gramps/plugins/drawreport/calendarreport.py:557
 #: ../gramps/plugins/textreport/birthdayreport.py:559
-#: ../gramps/plugins/webreport/webcal.py:1886
+#: ../gramps/plugins/webreport/webcal.py:1887
 msgid "Include anniversaries"
 msgstr "Incloure aniversaris"
 
@@ -21511,102 +21469,102 @@ msgstr "Gràfica de Descendents per a %(father)s i %(mother)s"
 msgid "Descendant Graph"
 msgstr "Diagrama de Descendents"
 
-#: ../gramps/plugins/drawreport/descendtree.py:326
+#: ../gramps/plugins/drawreport/descendtree.py:332
 #, python-format
 msgid "Family Chart for %(person)s"
 msgstr "Gràfica de Família per a %(person)s"
 
-#: ../gramps/plugins/drawreport/descendtree.py:329
+#: ../gramps/plugins/drawreport/descendtree.py:335
 #, python-format
 msgid "Family Chart for %(father1)s and %(mother1)s"
 msgstr "Gràfica de Família per a %(father1)s i %(mother1)s"
 
-#: ../gramps/plugins/drawreport/descendtree.py:355
+#: ../gramps/plugins/drawreport/descendtree.py:361
 #, python-format
 msgid "Cousin Chart for %(names)s"
 msgstr "Gràfica de Cosins per %(names)s"
 
-#: ../gramps/plugins/drawreport/descendtree.py:758
+#: ../gramps/plugins/drawreport/descendtree.py:764
 #, python-format
 msgid "Family %s is not in the Database"
 msgstr "La família %s no és a la Base de Dades"
 
 #. if self.name == "familial_descend_tree":
-#: ../gramps/plugins/drawreport/descendtree.py:1530
-#: ../gramps/plugins/drawreport/descendtree.py:1534
+#: ../gramps/plugins/drawreport/descendtree.py:1536
+#: ../gramps/plugins/drawreport/descendtree.py:1540
 msgid "Report for"
 msgstr "Informe per"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1531
+#: ../gramps/plugins/drawreport/descendtree.py:1537
 msgid "The main person for the report"
 msgstr "La persona principal per a l'informe"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1535
+#: ../gramps/plugins/drawreport/descendtree.py:1541
 msgid "The main family for the report"
 msgstr "La família principal per a l'informe"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1542
+#: ../gramps/plugins/drawreport/descendtree.py:1548
 msgid "Level of Spouses"
 msgstr "Nivell de Cònjuges"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1543
+#: ../gramps/plugins/drawreport/descendtree.py:1549
 msgid "0=no Spouses, 1=include Spouses, 2=include Spouses of the spouse, etc"
 msgstr ""
 "0=sense Cònjuges, 1=incloure Cònjuges, 2=incloure Cònjuges del cònjuge, etc"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1548
+#: ../gramps/plugins/drawreport/descendtree.py:1554
 msgid "Start with the parent(s) of the selected first"
 msgstr "Comenceu amb el(s) pare(s) del seleccionat"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1551
+#: ../gramps/plugins/drawreport/descendtree.py:1557
 msgid "Will show the parents, brother and sisters of the selected person."
 msgstr "Mostrarà els pares, germà i germanes de la persona seleccionada."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1557
+#: ../gramps/plugins/drawreport/descendtree.py:1563
 msgid "Whether to move people up, where possible, resulting in a smaller tree"
 msgstr ""
-"Si s'han de moure les persones cap amunt, on sigui possible, per obtenir un "
-"arbre més petit"
+"Si s'han de moure les persones cap amunt, on sigui possible, per obtenir un"
+" arbre més petit"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1561
+#: ../gramps/plugins/drawreport/descendtree.py:1567
 msgid "Bold direct descendants"
 msgstr "Descendents en línia directa en negreta"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1563
+#: ../gramps/plugins/drawreport/descendtree.py:1569
 msgid ""
 "Whether to bold those people that are direct (not step or half) descendants."
 msgstr ""
-"Si s'han de marcar en negreta les persones que són descendents directes (ni "
-"fillastres ni mig-germans)."
+"Si s'han de marcar en negreta les persones que són descendents directes (ni"
+" fillastres ni mig-germans)."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1568
+#: ../gramps/plugins/drawreport/descendtree.py:1574
 msgid "Indent Spouses"
 msgstr "Indentar Cònjuges"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1569
+#: ../gramps/plugins/drawreport/descendtree.py:1575
 msgid "Whether to indent the spouses in the tree."
 msgstr "Si s'han d'indentar els cònjuges a l'arbre."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1577
-#: ../gramps/plugins/drawreport/descendtree.py:1750
+#: ../gramps/plugins/drawreport/descendtree.py:1583
+#: ../gramps/plugins/drawreport/descendtree.py:1756
 msgid "Descendant Chart for [selected person(s)]"
 msgstr "Gràfica de Descendents per a [persona(es) seleccionada(es)]"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1580
-#: ../gramps/plugins/drawreport/descendtree.py:1754
+#: ../gramps/plugins/drawreport/descendtree.py:1586
+#: ../gramps/plugins/drawreport/descendtree.py:1760
 msgid "Family Chart for [names of chosen family]"
 msgstr "Gràfica de Família per a [noms de la família escollida]"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1583
-#: ../gramps/plugins/drawreport/descendtree.py:1758
+#: ../gramps/plugins/drawreport/descendtree.py:1589
+#: ../gramps/plugins/drawreport/descendtree.py:1764
 msgid "Cousin Chart for [names of children]"
 msgstr "Gràfica de Cosins per [noms dels fills]"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1593
+#: ../gramps/plugins/drawreport/descendtree.py:1599
 msgid "Whether to include page numbers on each page."
 msgstr "Si s'han d'incloure números de pàgina a cada pàgina."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1654
+#: ../gramps/plugins/drawreport/descendtree.py:1660
 msgid ""
 "Descendant\n"
 "Display Format"
@@ -21614,7 +21572,7 @@ msgstr ""
 "Format de Visualització\n"
 "de Descendent"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1658
+#: ../gramps/plugins/drawreport/descendtree.py:1664
 msgid "Display format for a descendant."
 msgstr "Format de visualització per un descendent."
 
@@ -21624,7 +21582,7 @@ msgstr "Format de visualització per un descendent."
 #. True)
 #. diffspouse.set_help(_("Whether spouses can have a different format."))
 #. menu.add_option(category_name, "diffspouse", diffspouse)
-#: ../gramps/plugins/drawreport/descendtree.py:1668
+#: ../gramps/plugins/drawreport/descendtree.py:1674
 msgid ""
 "Spousal\n"
 "Display Format"
@@ -21632,19 +21590,19 @@ msgstr ""
 "Format de Visualització\n"
 "Conjugal"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1672
+#: ../gramps/plugins/drawreport/descendtree.py:1678
 msgid "Display format for a spouse."
 msgstr "Format de visualització per a un cònjuge."
 
-#: ../gramps/plugins/drawreport/descendtree.py:1714
+#: ../gramps/plugins/drawreport/descendtree.py:1720
 msgid "inter-box Y scale factor"
 msgstr "factor d'escala Y entre caixes"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1716
+#: ../gramps/plugins/drawreport/descendtree.py:1722
 msgid "Make the inter-box Y bigger or smaller"
 msgstr "Fer que la Y entre caixes sigui més gran o més petita"
 
-#: ../gramps/plugins/drawreport/descendtree.py:1792
+#: ../gramps/plugins/drawreport/descendtree.py:1798
 msgid "The bold style used for the text display."
 msgstr "L'estil de negreta que es fa servir per mostrar el text."
 
@@ -21720,8 +21678,8 @@ msgstr "Gràfiques estadístiques"
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:198
 msgid "Produces statistical bar and pie charts of the people in the database"
 msgstr ""
-"Crea gràfiques estadístiques de barres i de pastís sobre les persones de la "
-"base de dades"
+"Crea gràfiques estadístiques de barres i de pastís sobre les persones de la"
+" base de dades"
 
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:221
 #: ../gramps/plugins/drawreport/timeline.py:275
@@ -21815,8 +21773,8 @@ msgstr "Utilitza un tipus de lletra per a totes les generacions"
 msgid ""
 "You can customize font and color for each generation in the style editor"
 msgstr ""
-"Podeu personalitzar el tipus de lletra i el color per a cada generació a "
-"l'editor d'estils"
+"Podeu personalitzar el tipus de lletra i el color per a cada generació a"
+" l'editor d'estils"
 
 #: ../gramps/plugins/drawreport/fanchart.py:782
 #, python-format
@@ -21828,7 +21786,7 @@ msgid "Item count"
 msgstr "Recompte d'objectes"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:315
-#: ../gramps/plugins/graph/gvfamilylines.py:85
+#: ../gramps/plugins/graph/gvfamilylines.py:86
 msgid "Both"
 msgstr "Tots dos"
 
@@ -21989,9 +21947,8 @@ msgid "%s born"
 msgstr ""
 
 #: ../gramps/plugins/drawreport/statisticschart.py:803
-#, fuzzy
 msgid "Persons born"
-msgstr "Referència de persona"
+msgstr "Persones nascudes"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:813
 msgid "Collecting data..."
@@ -22022,8 +21979,8 @@ msgstr "Determina quines persones s'inclouen a l'informe."
 #: ../gramps/plugins/textreport/indivcomplete.py:1068
 #: ../gramps/plugins/textreport/recordsreport.py:223
 #: ../gramps/plugins/tool/sortevents.py:173
-#: ../gramps/plugins/webreport/narrativeweb.py:1645
-#: ../gramps/plugins/webreport/webcal.py:1677
+#: ../gramps/plugins/webreport/narrativeweb.py:1649
+#: ../gramps/plugins/webreport/webcal.py:1678
 msgid "Filter Person"
 msgstr "Filtra per Persona"
 
@@ -22090,20 +22047,20 @@ msgstr "Màx. elements per pastís"
 msgid ""
 "With fewer items pie chart and legend will be used instead of a bar chart."
 msgstr ""
-"Amb menys elements es farà servir un gràfic de pastís i la seva llegenda, en "
-"comptes d'un gràfic de barres."
+"Amb menys elements es farà servir un gràfic de pastís i la seva llegenda, en"
+" comptes d'un gràfic de barres."
 
 #: ../gramps/plugins/drawreport/statisticschart.py:1066
-#, fuzzy
 msgid "Include counts of missing information"
-msgstr "Mostrar camps per la informació que falti"
+msgstr "Incloure recomptes de la informació que falti"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:1068
-#, fuzzy
 msgid ""
-"Whether to include counts of the number of people who lack the given "
-"information."
-msgstr "Si s'han d'incloure altres esdeveniments on gent hi ha participat."
+"Whether to include counts of the number of people who lack the given"
+" information."
+msgstr ""
+"Si s'han d'incloure recomptes del nombre de gent que els manca la informació"
+" donada."
 
 #: ../gramps/plugins/drawreport/statisticschart.py:1102
 msgid "Charts 3"
@@ -22171,8 +22128,8 @@ msgstr "Determina quines persones s'inclouen a l'informe"
 #: ../gramps/plugins/drawreport/timeline.py:423
 #: ../gramps/plugins/textreport/recordsreport.py:224
 #: ../gramps/plugins/tool/sortevents.py:174
-#: ../gramps/plugins/webreport/narrativeweb.py:1646
-#: ../gramps/plugins/webreport/webcal.py:1678
+#: ../gramps/plugins/webreport/narrativeweb.py:1650
+#: ../gramps/plugins/webreport/webcal.py:1679
 msgid "The center person for the filter"
 msgstr "La persona central del filtre"
 
@@ -22235,11 +22192,11 @@ msgstr "GE_DCOM"
 #: ../gramps/plugins/export/export.gpr.py:78
 #: ../gramps/plugins/importer/import.gpr.py:55
 msgid ""
-"GEDCOM is used to transfer data between genealogy programs. Most genealogy "
-"software will accept a GEDCOM file as input."
+"GEDCOM is used to transfer data between genealogy programs. Most genealogy"
+" software will accept a GEDCOM file as input."
 msgstr ""
-"GEDCOM es fa servir per transferir dades entre programes de genealogia. La "
-"major part del programari de genealogia accepta fitxers GEDCOM d'entrada."
+"GEDCOM es fa servir per transferir dades entre programes de genealogia. La"
+" major part del programari de genealogia accepta fitxers GEDCOM d'entrada."
 
 #: ../gramps/plugins/export/export.gpr.py:87
 msgid "GEDCOM export options"
@@ -22267,11 +22224,11 @@ msgstr "Paquet Gra_mps XML (arbre genealògic i audiovisuals)"
 
 #: ../gramps/plugins/export/export.gpr.py:121
 msgid ""
-"Gramps package is an archived XML family tree together with the media object "
-"files."
+"Gramps package is an archived XML family tree together with the media object"
+" files."
 msgstr ""
-"Un paquet Gramps és una base de dades XML arxivada juntament amb els fitxers "
-"de medis audiovisuals."
+"Un paquet Gramps és una base de dades XML arxivada juntament amb els fitxers"
+" de medis audiovisuals."
 
 #: ../gramps/plugins/export/export.gpr.py:130
 msgid "Gramps package export options"
@@ -22287,12 +22244,12 @@ msgstr "Gramps _XML (arbre genealògic)"
 
 #: ../gramps/plugins/export/export.gpr.py:143
 msgid ""
-"Gramps XML export is a complete archived XML backup of a Gramps family tree "
-"without the media object files. Suitable for backup purposes."
+"Gramps XML export is a complete archived XML backup of a Gramps family tree"
+" without the media object files. Suitable for backup purposes."
 msgstr ""
-"Una exportació de Gramps XML és una còpia XML d'arxiu completa d'un arbre "
-"genealògic Gramps sense els fitxers audiovisuals. Apropiat per a còpies de "
-"seguretat."
+"Una exportació de Gramps XML és una còpia XML d'arxiu completa d'un arbre"
+" genealògic Gramps sense els fitxers audiovisuals. Apropiat per a còpies de"
+" seguretat."
 
 #: ../gramps/plugins/export/export.gpr.py:153
 msgid "Gramps XML export options"
@@ -22309,8 +22266,8 @@ msgstr "vC_alendar"
 #: ../gramps/plugins/export/export.gpr.py:166
 msgid "vCalendar is used in many calendaring and PIM applications."
 msgstr ""
-"El format vCalendar es fa servir en moltes aplicacions de calendari i gestió "
-"d'informació personal."
+"El format vCalendar es fa servir en moltes aplicacions de calendari i gestió"
+" d'informació personal."
 
 #: ../gramps/plugins/export/export.gpr.py:174
 msgid "vCalendar export options"
@@ -22349,7 +22306,7 @@ msgid "Include children"
 msgstr "Incloure fills"
 
 #: ../gramps/plugins/export/exportcsv.py:139
-#: ../gramps/plugins/graph/gvfamilylines.py:234
+#: ../gramps/plugins/graph/gvfamilylines.py:235
 msgid "Include places"
 msgstr "Incloure llocs"
 
@@ -22454,15 +22411,14 @@ msgid "WWW"
 msgstr "WWW"
 
 #: ../gramps/plugins/export/exportgedcom.py:1431
-#, fuzzy
 msgid "Writing media"
-msgstr "Escrivint notes"
+msgstr "Gravant medis"
 
 #: ../gramps/plugins/export/exportgedcom.py:1605
 msgid "GEDCOM Export failed"
 msgstr "L'Exportació GEDCOM ha fallat"
 
-#: ../gramps/plugins/export/exportgeneweb.py:96
+#: ../gramps/plugins/export/exportgeneweb.py:97
 msgid "No families matched by selected filter"
 msgstr "Cap família no concorda amb el filtre seleccionat"
 
@@ -22476,22 +22432,22 @@ msgstr "Error en escriure %s"
 
 #: ../gramps/plugins/export/exportxml.py:140
 msgid ""
-"The database cannot be saved because you do not have permission to write to "
-"the directory. Please make sure you have write access to the directory and "
-"try again."
+"The database cannot be saved because you do not have permission to write to"
+" the directory. Please make sure you have write access to the directory and"
+" try again."
 msgstr ""
-"La base de dades no es pot desar perquè no té permís d'escriptura sobre el "
-"directori. Si us plau, asseguri's que té accés d'escriptura al directori i "
-"torni-ho a provar."
+"La base de dades no es pot desar perquè no té permís d'escriptura sobre el"
+" directori. Si us plau, asseguri's que té accés d'escriptura al directori i"
+" torni-ho a provar."
 
 #: ../gramps/plugins/export/exportxml.py:156
 msgid ""
-"The database cannot be saved because you do not have permission to write to "
-"the file. Please make sure you have write access to the file and try again."
+"The database cannot be saved because you do not have permission to write to"
+" the file. Please make sure you have write access to the file and try again."
 msgstr ""
-"La base de dades no es pot desar perquè no té permís d'escriptura sobre el "
-"fitxer. Si us plau, asseguri's que té accés d'escriptura al fitxer i torni-"
-"ho a provar."
+"La base de dades no es pot desar perquè no té permís d'escriptura sobre el"
+" fitxer. Si us plau, asseguri's que té accés d'escriptura al fitxer i"
+" torni-ho a provar."
 
 #. GUI setup:
 #: ../gramps/plugins/gramplet/ageondategramplet.py:52
@@ -22500,14 +22456,14 @@ msgstr "Introdueix una data, clica Executa"
 
 #: ../gramps/plugins/gramplet/ageondategramplet.py:60
 msgid ""
-"Enter a valid date (like YYYY-MM-DD) in the entry below and click Run. This "
-"will compute the ages for everyone in your Family Tree on that date. You can "
-"then sort by the age column, and double-click the row to view or edit."
+"Enter a valid date (like YYYY-MM-DD) in the entry below and click Run. This"
+" will compute the ages for everyone in your Family Tree on that date. You can"
+" then sort by the age column, and double-click the row to view or edit."
 msgstr ""
-"Introduïu una data vàlida (com AAAA-MM-DD) a sota, i cliqueu Executar. Això "
-"calcularà les edats de tothom del seu Arbre Genealògic en aquella data. "
-"Després es pot ordenar per la columna d'edat, i fer doble clic a la fila per "
-"veure o editar."
+"Introduïu una data vàlida (com AAAA-MM-DD) a sota, i cliqueu Executar. Això"
+" calcularà les edats de tothom del seu Arbre Genealògic en aquella data."
+" Després es pot ordenar per la columna d'edat, i fer doble clic a la fila per"
+" veure o editar."
 
 #: ../gramps/plugins/gramplet/agestats.py:53
 #: ../gramps/plugins/gramplet/agestats.py:63
@@ -22598,11 +22554,11 @@ msgstr "%(depth)s. %(name)s"
 
 #: ../gramps/plugins/gramplet/attributes.py:52
 msgid ""
-"Double-click on a row to view a quick report showing all people with the "
-"selected attribute."
+"Double-click on a row to view a quick report showing all people with the"
+" selected attribute."
 msgstr ""
-"Feu doble clic en una fila per veure un informe ràpid que mostra totes les "
-"persones que tinguin l'atribut seleccionat."
+"Feu doble clic en una fila per veure un informe ràpid que mostra totes les"
+" persones que tinguin l'atribut seleccionat."
 
 #: ../gramps/plugins/gramplet/attributes.py:56
 #: ../gramps/plugins/lib/libmetadata.py:172
@@ -22638,8 +22594,8 @@ msgstr "<No hi ha Cita>"
 #: ../gramps/plugins/gramplet/coordinates.py:83
 msgid "Right-click on a row to edit the selected event or the related place."
 msgstr ""
-"Clic dret en una fila per editar l'esdeveniment seleccionat o el lloc "
-"relacionat."
+"Clic dret en una fila per editar l'esdeveniment seleccionat o el lloc"
+" relacionat."
 
 #: ../gramps/plugins/gramplet/coordinates.py:94
 #: ../gramps/plugins/textreport/tagreport.py:158
@@ -22698,8 +22654,8 @@ msgstr ""
 #: ../gramps/plugins/gramplet/faqgramplet.py:61
 #, python-format
 msgid ""
-"%(bold_start)s%(gramps_FAQ_html_start)s%(html_middle)sFrequently Asked "
-"Questions%(html_end)s%(bold_end)s\n"
+"%(bold_start)s%(gramps_FAQ_html_start)s%(html_middle)sFrequently Asked"
+" Questions%(html_end)s%(bold_end)s\n"
 "(needs a connection to the internet)\n"
 msgstr ""
 "%(bold_start)s%(gramps_FAQ_html_start)s%(html_middle)sPreguntes més freqüents"
@@ -22713,20 +22669,20 @@ msgstr "Edició de Cònjuges"
 #: ../gramps/plugins/gramplet/faqgramplet.py:71
 #, python-format
 msgid ""
-"  1. %(gramps_FAQ_html_start)s%(faq_section)sHow do I change the order of "
-"spouses?%(html_end)s\n"
+"  1. %(gramps_FAQ_html_start)s%(faq_section)sHow do I change the order of"
+" spouses?%(html_end)s\n"
 msgstr ""
-"  1. %(gramps_FAQ_html_start)s%(faq_section)sCom puc canviar l'ordre dels "
-"cònjugues?%(html_end)s\n"
+"  1. %(gramps_FAQ_html_start)s%(faq_section)sCom puc canviar l'ordre dels"
+" cònjugues?%(html_end)s\n"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:77
 #, python-format
 msgid ""
-"  2. %(gramps_FAQ_html_start)s%(faq_section)sHow do I add an additional "
-"spouse?%(html_end)s\n"
+"  2. %(gramps_FAQ_html_start)s%(faq_section)sHow do I add an additional"
+" spouse?%(html_end)s\n"
 msgstr ""
-"  2. %(gramps_FAQ_html_start)s%(faq_section)sCom puc afegir un cònjugue "
-"addicional?%(html_end)s\n"
+"  2. %(gramps_FAQ_html_start)s%(faq_section)sCom puc afegir un cònjugue"
+" addicional?%(html_end)s\n"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:83
 #, python-format
@@ -22747,17 +22703,17 @@ msgid ""
 "  4. %(gramps_FAQ_html_start)s%(faq_section)sHow do I make backups safely?"
 "%(html_end)s\n"
 msgstr ""
-"  4. %(gramps_FAQ_html_start)s%(faq_section)sCom puc fer còpies de seguretat "
-"de manera segura?%(html_end)s\n"
+"  4. %(gramps_FAQ_html_start)s%(faq_section)sCom puc fer còpies de seguretat"
+" de manera segura?%(html_end)s\n"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:98
 #, python-format
 msgid ""
-"  5. %(gramps_FAQ_html_start)s%(faq_section)sIs it necessary to update "
-"Gramps every time an update is released?%(html_end)s\n"
+"  5. %(gramps_FAQ_html_start)s%(faq_section)sIs it necessary to update Gramps"
+" every time an update is released?%(html_end)s\n"
 msgstr ""
-"  5. %(gramps_FAQ_html_start)s%(faq_section)sCal actualitzar Gramps cada "
-"vegada que surt una nova versió?%(html_end)s\n"
+"  5. %(gramps_FAQ_html_start)s%(faq_section)sCal actualitzar Gramps cada"
+" vegada que surt una nova versió?%(html_end)s\n"
 "\n"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:103
@@ -22767,20 +22723,20 @@ msgstr "Introducció de Dades"
 #: ../gramps/plugins/gramplet/faqgramplet.py:109
 #, python-format
 msgid ""
-"  6. %(gramps_manual_html_start)s%(section)sHow should information about "
-"marriages be entered?%(html_end)s\n"
+"  6. %(gramps_manual_html_start)s%(section)sHow should information about"
+" marriages be entered?%(html_end)s\n"
 msgstr ""
-"  6. %(gramps_manual_html_start)s%(section)sCom hauria d'introduir la "
-"informació dels casaments?%(html_end)s\n"
+"  6. %(gramps_manual_html_start)s%(section)sCom hauria d'introduir la"
+" informació dels casaments?%(html_end)s\n"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:116
 #, python-format
 msgid ""
-"  7. %(gramps_FAQ_html_start)s%(faq_section)sWhat's the difference between a "
-"residence and an address?%(html_end)s\n"
+"  7. %(gramps_FAQ_html_start)s%(faq_section)sWhat's the difference between a"
+" residence and an address?%(html_end)s\n"
 msgstr ""
-"  7. %(gramps_FAQ_html_start)s%(faq_section)sQuina diferència hi ha entre "
-"una residència i una adreça?%(html_end)s\n"
+"  7. %(gramps_FAQ_html_start)s%(faq_section)sQuina diferència hi ha entre una"
+" residència i una adreça?%(html_end)s\n"
 "\n"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:120
@@ -22790,29 +22746,29 @@ msgstr "Fitxers Audiovisuals"
 #: ../gramps/plugins/gramplet/faqgramplet.py:125
 #, python-format
 msgid ""
-"  8. %(gramps_FAQ_html_start)s%(faq_section)sHow do you add a photo of a "
-"person/source/event?%(html_end)s\n"
+"  8. %(gramps_FAQ_html_start)s%(faq_section)sHow do you add a photo of a"
+" person/source/event?%(html_end)s\n"
 msgstr ""
-"  8. %(gramps_FAQ_html_start)s%(faq_section)sCom s'afegeix una foto d'una "
-"persona/font/esdeveniment?%(html_end)s\n"
+"  8. %(gramps_FAQ_html_start)s%(faq_section)sCom s'afegeix una foto d'una"
+" persona/font/esdeveniment?%(html_end)s\n"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:131
 #, python-format
 msgid ""
-"  9. %(gramps_FAQ_html_start)s%(faq_section)sHow do you find unused media "
-"objects?%(html_end)s\n"
+"  9. %(gramps_FAQ_html_start)s%(faq_section)sHow do you find unused media"
+" objects?%(html_end)s\n"
 msgstr ""
-"  9. %(gramps_FAQ_html_start)s%(faq_section)sCom puc trobar objectes de "
-"mitjans audiovisuals no utilitzats?%(html_end)s\n"
+"  9. %(gramps_FAQ_html_start)s%(faq_section)sCom puc trobar objectes de"
+" mitjans audiovisuals no utilitzats?%(html_end)s\n"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:141
 #, python-format
 msgid ""
-" 10. %(gramps_FAQ_html_start)s%(faq_section)sHow can I make a website with "
-"Gramps and my tree?%(html_end)s\n"
+" 10. %(gramps_FAQ_html_start)s%(faq_section)sHow can I make a website with"
+" Gramps and my tree?%(html_end)s\n"
 msgstr ""
-" 10. %(gramps_FAQ_html_start)s%(faq_section)sCom puc fer un lloc web amb "
-"Gramps i el meu arbre?%(html_end)s\n"
+" 10. %(gramps_FAQ_html_start)s%(faq_section)sCom puc fer un lloc web amb"
+" Gramps i el meu arbre?%(html_end)s\n"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:148
 #, python-format
@@ -22823,11 +22779,11 @@ msgstr ""
 #: ../gramps/plugins/gramplet/faqgramplet.py:154
 #, python-format
 msgid ""
-" 12. %(gramps_FAQ_html_start)s%(faq_section)sWhat do I do if I have found a "
-"bug?%(html_end)s\n"
+" 12. %(gramps_FAQ_html_start)s%(faq_section)sWhat do I do if I have found a"
+" bug?%(html_end)s\n"
 msgstr ""
-" 12. %(gramps_FAQ_html_start)s%(faq_section)sQuè puc fer si trobo un error "
-"del programa?%(html_end)s\n"
+" 12. %(gramps_FAQ_html_start)s%(faq_section)sQuè puc fer si trobo un error"
+" del programa?%(html_end)s\n"
 
 #: ../gramps/plugins/gramplet/faqgramplet.py:159
 #, python-format
@@ -22924,8 +22880,8 @@ msgstr "Gramplet que mostra gràfiques de diferents edats"
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:75
 msgid "Gramplet showing calendar and events on specific dates in history"
 msgstr ""
-"Gramplet que mostra el calendari i els esdeveniments en dates específiques "
-"de la història"
+"Gramplet que mostra el calendari i els esdeveniments en dates específiques de"
+" la història"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:87
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:94
@@ -22938,7 +22894,7 @@ msgstr "Gramplet que mostra els descendents de la persona activa"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:104
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:111
-#: ../gramps/plugins/webreport/person.py:1183
+#: ../gramps/plugins/webreport/person.py:1190
 msgid "Ancestors"
 msgstr "Avantpassats"
 
@@ -22950,8 +22906,8 @@ msgstr "Gramplet que mostra els avantpassats de la persona activa"
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:122
 msgid "Gramplet showing active person's direct ancestors as a fanchart"
 msgstr ""
-"Gramplet que mostra els avantpassats directes de la persona activa en forma "
-"de gràfica de ventall"
+"Gramplet que mostra els avantpassats directes de la persona activa en forma"
+" de gràfica de ventall"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:138
 #: ../gramps/plugins/view/fanchartdescview.py:76
@@ -22961,8 +22917,8 @@ msgstr "Diagrama en Ventall de Descendents"
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:139
 msgid "Gramplet showing active person's direct descendants as a fanchart"
 msgstr ""
-"Gramplet que mostra els descendents directes de la persona activa en forma "
-"de diagrama de ventall"
+"Gramplet que mostra els descendents directes de la persona activa en forma de"
+" diagrama de ventall"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:147
 #: ../gramps/plugins/view/view.gpr.py:158
@@ -22976,11 +22932,11 @@ msgstr "Diagrama de ventall en 2-Sentits"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:156
 msgid ""
-"Gramplet showing active person's direct ancestors and descendants as a "
-"fanchart"
+"Gramplet showing active person's direct ancestors and descendants as a"
+" fanchart"
 msgstr ""
-"Gramlet que mostra els avantpassats directes i els descendents de la persona "
-"activa com un diagrama de ventall"
+"Gramlet que mostra els avantpassats directes i els descendents de la persona"
+" activa com un diagrama de ventall"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:164
 #: ../gramps/plugins/view/view.gpr.py:173
@@ -23009,7 +22965,7 @@ msgstr "Gramplet que mostra tots els noms de pila com a núvol de text"
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:205
 #: ../gramps/plugins/view/pedigreeview.py:528
 #: ../gramps/plugins/view/view.gpr.py:127
-#: ../gramps/plugins/webreport/person.py:1352
+#: ../gramps/plugins/webreport/person.py:1359
 msgid "Pedigree"
 msgstr "Pedigrí"
 
@@ -23424,7 +23380,7 @@ msgstr ""
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:967
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:981
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:995
-#: ../gramps/plugins/webreport/basepage.py:2959
+#: ../gramps/plugins/webreport/basepage.py:2982
 #: ../gramps/plugins/webreport/person.py:884
 #: ../gramps/plugins/webreport/thumbnail.py:164
 msgid "References"
@@ -23488,8 +23444,8 @@ msgstr "Referències Audiovisuals"
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:974
 msgid "Gramplet showing the backlink references for a media object"
 msgstr ""
-"Gramplet que mostra les referències dels retroenllaços d'un objecte "
-"audiovisual"
+"Gramplet que mostra les referències dels retroenllaços d'un objecte"
+" audiovisual"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:987
 msgid "Note References"
@@ -23709,7 +23665,7 @@ msgstr "Refresca"
 
 #: ../gramps/plugins/gramplet/leak.py:122
 msgid "Press Refresh to see initial results"
-msgstr ""
+msgstr "Premeu Refresca per veure els resultats inicials"
 
 #: ../gramps/plugins/gramplet/leak.py:158
 #, python-format
@@ -23975,7 +23931,7 @@ msgstr "menys d'1"
 
 #. -------------------------
 #: ../gramps/plugins/gramplet/statsgramplet.py:140
-#: ../gramps/plugins/graph/gvfamilylines.py:276
+#: ../gramps/plugins/graph/gvfamilylines.py:277
 #: ../gramps/plugins/textreport/summary.py:113
 #: ../gramps/plugins/webreport/basepage.py:1526
 #: ../gramps/plugins/webreport/basepage.py:1577
@@ -23999,19 +23955,16 @@ msgid "Individuals with unknown gender"
 msgstr "Individus de gènere desconegut"
 
 #: ../gramps/plugins/gramplet/statsgramplet.py:156
-#, fuzzy
 msgid "Incomplete names"
-msgstr "Noms incomplets: %d"
+msgstr "Noms incomplets"
 
 #: ../gramps/plugins/gramplet/statsgramplet.py:160
-#, fuzzy
 msgid "Individuals missing birth dates"
-msgstr "Individus sense data de naixement: %d"
+msgstr "Individus sense data de naixement"
 
 #: ../gramps/plugins/gramplet/statsgramplet.py:164
-#, fuzzy
 msgid "Disconnected individuals"
-msgstr "Individu desconnectat"
+msgstr "Individus desconnectats"
 
 #: ../gramps/plugins/gramplet/statsgramplet.py:168
 #: ../gramps/plugins/textreport/summary.py:211
@@ -24032,9 +23985,8 @@ msgid "Media Objects"
 msgstr "Objectes Audiovisuals"
 
 #: ../gramps/plugins/gramplet/statsgramplet.py:181
-#, fuzzy
 msgid "Individuals with media objects"
-msgstr "Individus amb objectes de medis: %d"
+msgstr "Individus amb objectes de medis"
 
 #: ../gramps/plugins/gramplet/statsgramplet.py:185
 #: ../gramps/plugins/webreport/statistics.py:139
@@ -24111,7 +24063,7 @@ msgstr "Afegeix una nova nota Per Fer"
 
 #: ../gramps/plugins/gramplet/todo.py:201
 msgid "First select the object to which you want to attach a note"
-msgstr ""
+msgstr "Primer seleccioneu l'objecte al qual voleu associar una nota"
 
 #: ../gramps/plugins/gramplet/todogramplet.py:149
 msgid "Unattached"
@@ -24123,14 +24075,14 @@ msgstr "Intro"
 
 #: ../gramps/plugins/gramplet/welcomegramplet.py:102
 msgid ""
-"Gramps is a software package designed for genealogical research. Although "
-"similar to other genealogical programs, Gramps offers some unique and "
-"powerful features.\n"
+"Gramps is a software package designed for genealogical research. Although"
+" similar to other genealogical programs, Gramps offers some unique and"
+" powerful features.\n"
 "\n"
 msgstr ""
-"Gramps és un paquet de programari dissenyat per la recerca genealògica. "
-"Encara que és semblant a d'altres programes genealògics, Gramps ofereix "
-"algunes funcionalitats úniques i potents.\n"
+"Gramps és un paquet de programari dissenyat per la recerca genealògica."
+" Encara que és semblant a d'altres programes genealògics, Gramps ofereix"
+" algunes funcionalitats úniques i potents.\n"
 
 #: ../gramps/plugins/gramplet/welcomegramplet.py:105
 msgid "Links"
@@ -24162,18 +24114,18 @@ msgstr "Qui fa el Gramps?"
 
 #: ../gramps/plugins/gramplet/welcomegramplet.py:118
 msgid ""
-"Gramps is created by genealogists for genealogists, organized in the Gramps "
-"Project. Gramps is an Open Source Software package, which means you are free "
-"to make copies and distribute it to anyone you like. It's developed and "
-"maintained by a worldwide team of volunteers whose goal is to make Gramps "
-"powerful, yet easy to use.\n"
+"Gramps is created by genealogists for genealogists, organized in the Gramps"
+" Project. Gramps is an Open Source Software package, which means you are free"
+" to make copies and distribute it to anyone you like. It's developed and"
+" maintained by a worldwide team of volunteers whose goal is to make Gramps"
+" powerful, yet easy to use.\n"
 "\n"
 msgstr ""
-"El Gramps el creen genealogistes per a genealogistes, organitzats en el "
-"Projecte Gramps. Gramps és un paquet de programari de Codi Obert,  i això "
-"significa que sou lliures de fer-ne còpies i de distribuir-lo a tothom que "
-"vulgueu. El desenvolupa i el manté un equip mundial de voluntaris l'objectiu "
-"dels quals és fer que Gramps sigui potent, però fàcil d'utilitzar.\n"
+"El Gramps el creen genealogistes per a genealogistes, organitzats en el"
+" Projecte Gramps. Gramps és un paquet de programari de Codi Obert,  i això"
+" significa que sou lliures de fer-ne còpies i de distribuir-lo a tothom que"
+" vulgueu. El desenvolupa i el manté un equip mundial de voluntaris l'objectiu"
+" dels quals és fer que Gramps sigui potent, però fàcil d'utilitzar.\n"
 
 #: ../gramps/plugins/gramplet/welcomegramplet.py:124
 msgid "Getting Started"
@@ -24181,17 +24133,17 @@ msgstr "Com començar"
 
 #: ../gramps/plugins/gramplet/welcomegramplet.py:125
 msgid ""
-"The first thing you must do is to create a new Family Tree. To create a new "
-"Family Tree (sometimes called 'database') select \"Family Trees\" from the "
-"menu, pick \"Manage Family Trees\", press \"New\" and name your Family Tree. "
-"For more details, please read the information at the links above\n"
+"The first thing you must do is to create a new Family Tree. To create a new"
+" Family Tree (sometimes called 'database') select \"Family Trees\" from the"
+" menu, pick \"Manage Family Trees\", press \"New\" and name your Family Tree."
+" For more details, please read the information at the links above\n"
 "\n"
 msgstr ""
-"El primer que heu de fer és crear un nou Arbre Genealògic. Per crear un nou "
-"Arbre Genealògic (anomenat de vegades 'base de dades') seleccioneu \"Arbres "
-"Genealògics\" al menú, trieu \"Gestió d'Arbres Genealògics\", premeu \"Nou\" "
-"i doneu-li un nom al vostre arbre genealògic. Per més, detalls, llegiu si us "
-"plau la informació que donen els enllaços anteriors\n"
+"El primer que heu de fer és crear un nou Arbre Genealògic. Per crear un nou"
+" Arbre Genealògic (anomenat de vegades 'base de dades') seleccioneu \"Arbres"
+" Genealògics\" al menú, trieu \"Gestió d'Arbres Genealògics\", premeu \"Nou\""
+" i doneu-li un nom al vostre arbre genealògic. Per més, detalls, llegiu si us"
+" plau la informació que donen els enllaços anteriors\n"
 "\n"
 
 #: ../gramps/plugins/gramplet/welcomegramplet.py:130
@@ -24200,25 +24152,25 @@ msgstr "Vista de Panell de Control"
 
 #: ../gramps/plugins/gramplet/welcomegramplet.py:131
 msgid ""
-"You are currently reading from the \"Dashboard\" view, where you can add "
-"your own gramplets. You can also add gramplets to any view by adding a "
-"sidebar and/or bottombar, and right-clicking to the right of the tab.\n"
+"You are currently reading from the \"Dashboard\" view, where you can add your"
+" own gramplets. You can also add gramplets to any view by adding a sidebar"
+" and/or bottombar, and right-clicking to the right of the tab.\n"
 "\n"
-"You can click the configuration icon in the toolbar to add additional "
-"columns, while right-click on the background allows to add gramplets. You "
-"can also drag the Properties button to reposition the gramplet on this page, "
-"and detach the gramplet to float above Gramps."
+"You can click the configuration icon in the toolbar to add additional"
+" columns, while right-click on the background allows to add gramplets. You"
+" can also drag the Properties button to reposition the gramplet on this page,"
+" and detach the gramplet to float above Gramps."
 msgstr ""
-"Ara esteu llegint la vista del \"Panell de Control\", on podeu afegir els "
-"vostres propis gramplets. També podeu afegir gramplets a qualsevol vista "
-"afegint una barra lateral i/o inferior, i clicant a la dreta de la "
-"pestanya.\n"
+"Ara esteu llegint la vista del \"Panell de Control\", on podeu afegir els"
+" vostres propis gramplets. També podeu afegir gramplets a qualsevol vista"
+" afegint una barra lateral i/o inferior, i clicant a la dreta de la"
+" pestanya.\n"
 "\n"
-"Podeu clicar la icona de configuració de la barra de tasques per afegir "
-"columnes addicionals, mentre que fer un clic dret al fons us permet d'afegir "
-"gramplets. També podeu arrossegar el botó de Propietats per canviar de lloc "
-"el gramplet dins d'aquesta pàgina, i desenganxar el gramplet perquè floti "
-"sobre Gramps."
+"Podeu clicar la icona de configuració de la barra de tasques per afegir"
+" columnes addicionals, mentre que fer un clic dret al fons us permet d'afegir"
+" gramplets. També podeu arrossegar el botó de Propietats per canviar de lloc"
+" el gramplet dins d'aquesta pàgina, i desenganxar el gramplet perquè floti"
+" sobre Gramps."
 
 #. Minimum number of lines we want to see. Further lines with the same
 #. distance to the main person will be added on top of this.
@@ -24370,7 +24322,7 @@ msgid "Produces an hourglass graph using Graphviz."
 msgstr "Crea un graf en forma de rellotge de sorra amb Graphviz."
 
 #: ../gramps/plugins/graph/graphplugins.gpr.py:81
-#: ../gramps/plugins/graph/gvrelgraph.py:207
+#: ../gramps/plugins/graph/gvrelgraph.py:208
 msgid "Relationship Graph"
 msgstr "Graf de Relacions"
 
@@ -24383,305 +24335,303 @@ msgstr "Produeix grafs de relacions amb Graphviz."
 #. Constant options items
 #.
 #. ------------------------------------------------------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:73
-#: ../gramps/plugins/graph/gvhourglass.py:58
-#: ../gramps/plugins/graph/gvrelgraph.py:72
-msgid "B&W outline"
-msgstr "Contorn en blanc i negre"
-
 #: ../gramps/plugins/graph/gvfamilylines.py:74
 #: ../gramps/plugins/graph/gvhourglass.py:59
 #: ../gramps/plugins/graph/gvrelgraph.py:73
-msgid "Colored outline"
-msgstr "Contorn acolorit"
+msgid "B&W outline"
+msgstr "Contorn en blanc i negre"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:75
 #: ../gramps/plugins/graph/gvhourglass.py:60
 #: ../gramps/plugins/graph/gvrelgraph.py:74
+msgid "Colored outline"
+msgstr "Contorn acolorit"
+
+#: ../gramps/plugins/graph/gvfamilylines.py:76
+#: ../gramps/plugins/graph/gvhourglass.py:61
+#: ../gramps/plugins/graph/gvrelgraph.py:75
 msgid "Color fill"
 msgstr "Omplir de color"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:77
-#: ../gramps/plugins/graph/gvrelgraph.py:76
+#: ../gramps/plugins/graph/gvfamilylines.py:78
+#: ../gramps/plugins/graph/gvrelgraph.py:77
 msgid "Descendants <- Ancestors"
 msgstr "Descendents <- Avantpassats"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:78
-#: ../gramps/plugins/graph/gvrelgraph.py:77
+#: ../gramps/plugins/graph/gvfamilylines.py:79
+#: ../gramps/plugins/graph/gvrelgraph.py:78
 msgid "Descendants -> Ancestors"
 msgstr "Descendents -> Avantpassats"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:79
-#: ../gramps/plugins/graph/gvrelgraph.py:78
+#: ../gramps/plugins/graph/gvfamilylines.py:80
+#: ../gramps/plugins/graph/gvrelgraph.py:79
 msgid "Descendants <-> Ancestors"
 msgstr "Descendents <-> Avantpassats"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:80
-#: ../gramps/plugins/graph/gvrelgraph.py:79
+#: ../gramps/plugins/graph/gvfamilylines.py:81
+#: ../gramps/plugins/graph/gvrelgraph.py:80
 msgid "Descendants - Ancestors"
 msgstr "Descendents - Avantpassats"
 
 #. ---------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:124
+#: ../gramps/plugins/graph/gvfamilylines.py:125
 msgid "Follow parents to determine \"family lines\""
 msgstr "Segueix els progenitors per determinar les \"línies familiars\""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:126
+#: ../gramps/plugins/graph/gvfamilylines.py:127
 msgid ""
-"Parents and their ancestors will be considered when determining \"family "
-"lines\"."
+"Parents and their ancestors will be considered when determining \"family"
+" lines\"."
 msgstr ""
-"Els pares i els seus avantpassats es tindran en consideració en determinar "
-"les \"línies famliars\"."
+"Els pares i els seus avantpassats es tindran en consideració en determinar"
+" les \"línies famliars\"."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:130
+#: ../gramps/plugins/graph/gvfamilylines.py:131
 msgid "Follow children to determine \"family lines\""
 msgstr "Seguir fills per determinar les \"línies familiars\""
 
-#: ../gramps/plugins/graph/gvfamilylines.py:132
+#: ../gramps/plugins/graph/gvfamilylines.py:133
 msgid "Children will be considered when determining \"family lines\"."
 msgstr "Es consideraran els fills per determinar les \"línies familiars\"."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:136
+#: ../gramps/plugins/graph/gvfamilylines.py:137
 msgid "Try to remove extra people and families"
 msgstr "Intentar de treure persones i famílies afegides"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:138
+#: ../gramps/plugins/graph/gvfamilylines.py:139
 msgid ""
-"People and families not directly related to people of interest will be "
-"removed when determining \"family lines\"."
+"People and families not directly related to people of interest will be"
+" removed when determining \"family lines\"."
 msgstr ""
-"Les persones i famílies que no estiguin emparentades directament amb les "
-"persones d'interès s'eliminaran en determinar les \"línies familiars\"."
+"Les persones i famílies que no estiguin emparentades directament amb les"
+" persones d'interès s'eliminaran en determinar les \"línies familiars\"."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:144
-#: ../gramps/plugins/graph/gvhourglass.py:380
-#: ../gramps/plugins/graph/gvrelgraph.py:812
+#: ../gramps/plugins/graph/gvfamilylines.py:145
+#: ../gramps/plugins/graph/gvhourglass.py:382
+#: ../gramps/plugins/graph/gvrelgraph.py:815
 msgid "Arrowhead direction"
 msgstr "Direcció de la fletxa"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:147
-#: ../gramps/plugins/graph/gvhourglass.py:383
-#: ../gramps/plugins/graph/gvrelgraph.py:815
+#: ../gramps/plugins/graph/gvfamilylines.py:148
+#: ../gramps/plugins/graph/gvhourglass.py:385
+#: ../gramps/plugins/graph/gvrelgraph.py:818
 msgid "Choose the direction that the arrows point."
 msgstr "Tria la direcció cap on apunten les fletxes."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:150
-#: ../gramps/plugins/graph/gvhourglass.py:386
-#: ../gramps/plugins/graph/gvrelgraph.py:818
+#: ../gramps/plugins/graph/gvfamilylines.py:151
+#: ../gramps/plugins/graph/gvhourglass.py:388
+#: ../gramps/plugins/graph/gvrelgraph.py:821
 msgid "Graph coloring"
 msgstr "Colorejat del graf"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:153
+#: ../gramps/plugins/graph/gvfamilylines.py:154
 msgid ""
-"Males will be shown with blue, females with red, unless otherwise set above "
-"for filled. If the sex of an individual is unknown it will be shown with "
-"gray."
+"Males will be shown with blue, females with red, unless otherwise set above"
+" for filled. If the sex of an individual is unknown it will be shown with"
+" gray."
 msgstr ""
-"Les homes es mostraran en blau, les dones en vermell, a no ser que es canviï "
-"a l'opció corresponent. Si el sexe d'un individu és desconegut, es mostrarà "
-"en gris."
+"Les homes es mostraran en blau, les dones en vermell, a no ser que es canviï"
+" a l'opció corresponent. Si el sexe d'un individu és desconegut, es mostrarà"
+" en gris."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:159
-#, fuzzy
+#: ../gramps/plugins/graph/gvfamilylines.py:160
 msgid "Rounded corners"
-msgstr "Utilitza cantonades arrodonides"
+msgstr "Cantonades arrodonides"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:162
-#, fuzzy
+#: ../gramps/plugins/graph/gvfamilylines.py:163
 msgid "Use rounded corners e.g. to differentiate between women and men."
-msgstr "Utilitza cantonades arrodonides per distingir entre dones i homes."
+msgstr ""
+"Utilitza cantonades arrodonides, p. ex. per distingir entre dones i homes."
 
 #. --------------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:184
+#: ../gramps/plugins/graph/gvfamilylines.py:185
 msgid "People of Interest"
 msgstr "Persones d'Interès"
 
 #. --------------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:187
+#: ../gramps/plugins/graph/gvfamilylines.py:188
 msgid "People of interest"
 msgstr "Persones d'interès"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:188
+#: ../gramps/plugins/graph/gvfamilylines.py:189
 msgid ""
-"People of interest are used as a starting point when determining \"family "
-"lines\"."
+"People of interest are used as a starting point when determining \"family"
+" lines\"."
 msgstr ""
-"Les persones d'interès es fan servir com a punt de partida per determinar "
-"\"línies familiars\"."
+"Les persones d'interès es fan servir com a punt de partida per determinar"
+" \"línies familiars\"."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:192
+#: ../gramps/plugins/graph/gvfamilylines.py:193
 msgid "Limit the number of ancestors"
 msgstr "Limitar el nombre d'avantpassats"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:194
+#: ../gramps/plugins/graph/gvfamilylines.py:195
 msgid "Whether to limit the number of ancestors."
 msgstr "Si s'ha de limitar el nombre d'avantpassats."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:200
+#: ../gramps/plugins/graph/gvfamilylines.py:201
 msgid "The maximum number of ancestors to include."
 msgstr "El nombre màxim d'avantpassats a incloure."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:204
+#: ../gramps/plugins/graph/gvfamilylines.py:205
 msgid "Limit the number of descendants"
 msgstr "Limitar el nombre de descendents"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:207
+#: ../gramps/plugins/graph/gvfamilylines.py:208
 msgid "Whether to limit the number of descendants."
 msgstr "Si s'ha de limitar el nombre de descendents."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:213
+#: ../gramps/plugins/graph/gvfamilylines.py:214
 msgid "The maximum number of descendants to include."
 msgstr "El nombre màxim de descendents a incloure."
 
 #. --------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:222
+#: ../gramps/plugins/graph/gvfamilylines.py:223
 msgid "Include dates"
 msgstr "Incloure dates"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:223
+#: ../gramps/plugins/graph/gvfamilylines.py:224
 msgid "Whether to include dates for people and families."
 msgstr "Si s'han d'incloure dates per persones i famílies."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:228
+#: ../gramps/plugins/graph/gvfamilylines.py:229
 msgid "Limit dates to years only"
 msgstr "Limitar les dates a només any"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:229
+#: ../gramps/plugins/graph/gvfamilylines.py:230
 msgid ""
-"Prints just dates' year, neither month or day nor date approximation or "
-"interval are shown."
+"Prints just dates' year, neither month or day nor date approximation or"
+" interval are shown."
 msgstr ""
-"Només mostra l'any de la data, no es mostren ni el mes ni el dia ni les "
-"aproximacions o intervals de dates."
+"Només mostra l'any de la data, no es mostren ni el mes ni el dia ni les"
+" aproximacions o intervals de dates."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:235
+#: ../gramps/plugins/graph/gvfamilylines.py:236
 msgid "Whether to include placenames for people and families."
 msgstr "Si s'han d'incloure noms de lloc per persones i famílies."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:239
+#: ../gramps/plugins/graph/gvfamilylines.py:240
 msgid "Include the number of children"
 msgstr "Incloure el nombre de fills"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:241
+#: ../gramps/plugins/graph/gvfamilylines.py:242
 msgid ""
-"Whether to include the number of children for families with more than 1 "
-"child."
+"Whether to include the number of children for families with more than 1 child."
 msgstr ""
-"Si s'ha d'incloure el nombre de fills per a les famílies que en tinguin més "
-"d'un."
+"Si s'ha d'incloure el nombre de fills per a les famílies que en tinguin més"
+" d'un."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:246
-#: ../gramps/plugins/graph/gvrelgraph.py:904
+#: ../gramps/plugins/graph/gvfamilylines.py:247
+#: ../gramps/plugins/graph/gvrelgraph.py:907
 msgid "Include thumbnail images of people"
 msgstr "Incloure imatges en miniatura de les persones"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:249
+#: ../gramps/plugins/graph/gvfamilylines.py:250
 msgid "Whether to include thumbnail images of people."
 msgstr "Si s'han d'incloure imatges en miniatura de les persones."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:254
+#: ../gramps/plugins/graph/gvfamilylines.py:255
 msgid "Thumbnail location"
 msgstr "Ubicació de les imatges en miniatura"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:255
-#: ../gramps/plugins/graph/gvrelgraph.py:911
+#: ../gramps/plugins/graph/gvfamilylines.py:256
+#: ../gramps/plugins/graph/gvrelgraph.py:914
 msgid "Above the name"
 msgstr "Damunt del nom"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:256
-#: ../gramps/plugins/graph/gvrelgraph.py:912
+#: ../gramps/plugins/graph/gvfamilylines.py:257
+#: ../gramps/plugins/graph/gvrelgraph.py:915
 msgid "Beside the name"
 msgstr "Al costat del nom"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:257
-#: ../gramps/plugins/graph/gvrelgraph.py:914
+#: ../gramps/plugins/graph/gvfamilylines.py:258
+#: ../gramps/plugins/graph/gvrelgraph.py:917
 msgid "Where the thumbnail image should appear relative to the name"
 msgstr "On ha de sortir la imatge en miniatura en relació amb el nom"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:261
+#: ../gramps/plugins/graph/gvfamilylines.py:262
 msgid "Thumbnail size"
 msgstr "Mida de la miniatura"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:264
+#: ../gramps/plugins/graph/gvfamilylines.py:265
 msgid "Size of the thumbnail image"
 msgstr "Mida de les imatges miniatura"
 
 #. ----------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:268
+#: ../gramps/plugins/graph/gvfamilylines.py:269
 msgid "Family Colors"
 msgstr "Colors de la Família"
 
 #. ----------------------------
-#: ../gramps/plugins/graph/gvfamilylines.py:271
+#: ../gramps/plugins/graph/gvfamilylines.py:272
 msgid "Family colors"
 msgstr "Colors de la família"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:272
+#: ../gramps/plugins/graph/gvfamilylines.py:273
 msgid "Colors to use for various family lines."
 msgstr "Colors a utilitzar per diverses línies familiars."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:280
-#: ../gramps/plugins/graph/gvhourglass.py:420
-#: ../gramps/plugins/graph/gvrelgraph.py:941
+#: ../gramps/plugins/graph/gvfamilylines.py:281
+#: ../gramps/plugins/graph/gvhourglass.py:422
+#: ../gramps/plugins/graph/gvrelgraph.py:944
 msgid "The color to use to display men."
 msgstr "El color a utilitzar per mostrar els homes."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:284
-#: ../gramps/plugins/graph/gvhourglass.py:424
-#: ../gramps/plugins/graph/gvrelgraph.py:945
+#: ../gramps/plugins/graph/gvfamilylines.py:285
+#: ../gramps/plugins/graph/gvhourglass.py:426
+#: ../gramps/plugins/graph/gvrelgraph.py:948
 msgid "The color to use to display women."
 msgstr "El color a utilitzar per mostrar les dones."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:288
-#: ../gramps/plugins/graph/gvhourglass.py:428
-#: ../gramps/plugins/graph/gvrelgraph.py:950
+#: ../gramps/plugins/graph/gvfamilylines.py:289
+#: ../gramps/plugins/graph/gvhourglass.py:430
+#: ../gramps/plugins/graph/gvrelgraph.py:953
 msgid "The color to use when the gender is unknown."
 msgstr "El color a utilitzar quan es desconegui el gènere."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:293
-#: ../gramps/plugins/graph/gvhourglass.py:433
-#: ../gramps/plugins/graph/gvrelgraph.py:955
+#: ../gramps/plugins/graph/gvfamilylines.py:294
+#: ../gramps/plugins/graph/gvhourglass.py:435
+#: ../gramps/plugins/graph/gvrelgraph.py:958
 msgid "The color to use to display families."
 msgstr "El color a utilitzar per mostrar les famílies."
 
-#: ../gramps/plugins/graph/gvfamilylines.py:405
+#: ../gramps/plugins/graph/gvfamilylines.py:406
 #: ../gramps/plugins/textreport/familygroup.py:680
 #: ../gramps/plugins/textreport/indivcomplete.py:829
 msgid "Empty report"
 msgstr "Informe buit"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:406
+#: ../gramps/plugins/graph/gvfamilylines.py:407
 #: ../gramps/plugins/textreport/familygroup.py:681
 #: ../gramps/plugins/textreport/indivcomplete.py:830
 msgid "You did not specify anybody"
 msgstr "No heu especificat ningú"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:465
+#: ../gramps/plugins/graph/gvfamilylines.py:466
 msgid "Number of people in database:"
 msgstr "Nombre de persones a la base de dades:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:468
+#: ../gramps/plugins/graph/gvfamilylines.py:469
 msgid "Number of people of interest:"
 msgstr "Nombre de persones d'interès:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:471
+#: ../gramps/plugins/graph/gvfamilylines.py:472
 msgid "Number of families in database:"
 msgstr "Nombre de famílies a la base de dades:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:474
+#: ../gramps/plugins/graph/gvfamilylines.py:475
 msgid "Number of families of interest:"
 msgstr "Nombre de famílies d'interès:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:478
+#: ../gramps/plugins/graph/gvfamilylines.py:479
 msgid "Additional people removed:"
 msgstr "Persones addicionals esborrades:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:481
+#: ../gramps/plugins/graph/gvfamilylines.py:482
 msgid "Additional families removed:"
 msgstr "Famílies addicionals esborrades:"
 
-#: ../gramps/plugins/graph/gvfamilylines.py:484
+#: ../gramps/plugins/graph/gvfamilylines.py:485
 msgid "Initial list of people of interest:"
 msgstr "Llista inicial d persones d'interès:"
 
@@ -24708,246 +24658,246 @@ msgstr "mare: %s"
 msgid "child: %s"
 msgstr "fill: %s"
 
-#: ../gramps/plugins/graph/gvhourglass.py:62
+#: ../gramps/plugins/graph/gvhourglass.py:63
 msgid "Center -> Others"
 msgstr "Centre -> Altres"
 
-#: ../gramps/plugins/graph/gvhourglass.py:63
+#: ../gramps/plugins/graph/gvhourglass.py:64
 msgid "Center <- Others"
 msgstr "Centre <- Altres"
 
-#: ../gramps/plugins/graph/gvhourglass.py:64
+#: ../gramps/plugins/graph/gvhourglass.py:65
 msgid "Center <-> Other"
 msgstr "Centre <-> Altre"
 
-#: ../gramps/plugins/graph/gvhourglass.py:65
+#: ../gramps/plugins/graph/gvhourglass.py:66
 msgid "Center - Other"
 msgstr "Centre - Altre"
 
-#: ../gramps/plugins/graph/gvhourglass.py:367
+#: ../gramps/plugins/graph/gvhourglass.py:369
 msgid "The Center person for the graph"
 msgstr "La persona central del graf"
 
-#: ../gramps/plugins/graph/gvhourglass.py:370
+#: ../gramps/plugins/graph/gvhourglass.py:372
 #: ../gramps/plugins/textreport/kinshipreport.py:362
 msgid "Max Descendant Generations"
 msgstr "Màximes Generacions de Descendents"
 
-#: ../gramps/plugins/graph/gvhourglass.py:371
+#: ../gramps/plugins/graph/gvhourglass.py:373
 msgid "The number of generations of descendants to include in the graph"
 msgstr "El nombre de generacions de descendents a incloure al graf"
 
-#: ../gramps/plugins/graph/gvhourglass.py:375
+#: ../gramps/plugins/graph/gvhourglass.py:377
 #: ../gramps/plugins/textreport/kinshipreport.py:366
 msgid "Max Ancestor Generations"
 msgstr "Màximes Generacions d'Avantpassats"
 
-#: ../gramps/plugins/graph/gvhourglass.py:376
+#: ../gramps/plugins/graph/gvhourglass.py:378
 msgid "The number of generations of ancestors to include in the graph"
 msgstr "El nombre de generacions d'avantpassats a incloure al graf"
 
-#: ../gramps/plugins/graph/gvhourglass.py:389
-#: ../gramps/plugins/graph/gvrelgraph.py:821
+#: ../gramps/plugins/graph/gvhourglass.py:391
+#: ../gramps/plugins/graph/gvrelgraph.py:824
 msgid ""
-"Males will be shown with blue, females with red.  If the sex of an "
-"individual is unknown it will be shown with gray."
+"Males will be shown with blue, females with red.  If the sex of an individual"
+" is unknown it will be shown with gray."
 msgstr ""
-"Els homes sortiran en blau, les dones en vermell. Si el sexe d'un individu "
-"és desconegut, sortirà en gris."
+"Els homes sortiran en blau, les dones en vermell. Si el sexe d'un individu és"
+" desconegut, sortirà en gris."
 
 #. see bug report #2180
-#: ../gramps/plugins/graph/gvhourglass.py:394
-#: ../gramps/plugins/graph/gvrelgraph.py:827
+#: ../gramps/plugins/graph/gvhourglass.py:396
+#: ../gramps/plugins/graph/gvrelgraph.py:830
 msgid "Use rounded corners"
 msgstr "Utilitza cantonades arrodonides"
 
-#: ../gramps/plugins/graph/gvhourglass.py:396
-#: ../gramps/plugins/graph/gvrelgraph.py:828
+#: ../gramps/plugins/graph/gvhourglass.py:398
+#: ../gramps/plugins/graph/gvrelgraph.py:831
 msgid "Use rounded corners to differentiate between women and men."
 msgstr "Utilitza cantonades arrodonides per distingir entre dones i homes."
 
 #. ###############################
-#: ../gramps/plugins/graph/gvhourglass.py:416
-#: ../gramps/plugins/graph/gvrelgraph.py:937
+#: ../gramps/plugins/graph/gvhourglass.py:418
+#: ../gramps/plugins/graph/gvrelgraph.py:940
 msgid "Graph Style"
 msgstr "Estil de graf"
 
-#: ../gramps/plugins/graph/gvhourglass.py:436
-#, fuzzy
-msgid "Force Ahnentafel order"
-msgstr "Informe Ahnentafel"
-
 #: ../gramps/plugins/graph/gvhourglass.py:438
-msgid ""
-"Force Sosa / Sosa-Stradonitz / Ahnentafel layout order for all ancestors, so "
-"that fathers are always on the left branch and mothers are on the right "
-"branch."
-msgstr ""
+msgid "Force Ahnentafel order"
+msgstr "Forçar ordre Ahnentafel"
 
-#: ../gramps/plugins/graph/gvhourglass.py:441
-#, fuzzy
-msgid "Ahnentafel number visible"
-msgstr "Informe Ahnentafel"
+#: ../gramps/plugins/graph/gvhourglass.py:440
+msgid ""
+"Force Sosa / Sosa-Stradonitz / Ahnentafel layout order for all ancestors, so"
+" that fathers are always on the left branch and mothers are on the right"
+" branch."
+msgstr ""
+"Força l'ordre Sosa / Sosa-Stradonitz / Ahnentafel en la disposició per a tots"
+" els avantpassats, de manera que els pares sempre siguin a la branca esquerra"
+" i les mares a la dreta."
 
 #: ../gramps/plugins/graph/gvhourglass.py:443
-msgid ""
-"Show Sosa / Sosa-Stradonitz / Ahnentafel number under all others "
-"informations."
-msgstr ""
+msgid "Ahnentafel number visible"
+msgstr "Nombre Ahnentafel visible"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:208
+#: ../gramps/plugins/graph/gvhourglass.py:445
+msgid ""
+"Show Sosa / Sosa-Stradonitz / Ahnentafel number under all others informations."
+msgstr ""
+"Mostra el nombre Sosa / Sosa-Stradonitz / Ahnentafel a sota de totes les"
+" altres informacions."
+
+#: ../gramps/plugins/graph/gvrelgraph.py:209
 #: ../gramps/plugins/textreport/indivcomplete.py:834
 #: ../gramps/plugins/textreport/notelinkreport.py:103
 #: ../gramps/plugins/textreport/placereport.py:160
 msgid "Generating report"
 msgstr "Generant informe"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:803
+#: ../gramps/plugins/graph/gvrelgraph.py:806
 msgid "Determines what people are included in the graph"
 msgstr "Determina quines persones s'inclouen dins del gràfic"
 
 #. see bug report #11112
-#: ../gramps/plugins/graph/gvrelgraph.py:833
-#, fuzzy
+#: ../gramps/plugins/graph/gvrelgraph.py:836
 msgid "Use hexagons"
-msgstr "Utilitza ombrejat"
+msgstr "Utilitzar hexàgons"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:834
-#, fuzzy
+#: ../gramps/plugins/graph/gvrelgraph.py:837
 msgid "Use hexagons to differentiate those of unknown gender."
-msgstr "Utilitza cantonades arrodonides per distingir entre dones i homes."
+msgstr "Utilitzar hexàgons per diferenciar els de gènere desconegut."
 
 #. ###############################
-#: ../gramps/plugins/graph/gvrelgraph.py:862
+#: ../gramps/plugins/graph/gvrelgraph.py:865
 msgid "Dates and/or Places"
 msgstr "Dates i/o Llocs"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:863
+#: ../gramps/plugins/graph/gvrelgraph.py:866
 msgid "Do not include any dates or places"
 msgstr "No incloguis cap data o lloc"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:864
+#: ../gramps/plugins/graph/gvrelgraph.py:867
 msgid "Include (birth, marriage, death) dates, but no places"
 msgstr "Inclou les dates (de naixement, casament i mort), però els llocs no"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:866
+#: ../gramps/plugins/graph/gvrelgraph.py:869
 msgid "Include (birth, marriage, death) dates, and places"
 msgstr "Inclou les dates i llocs (de naixement, casament i mort)"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:868
+#: ../gramps/plugins/graph/gvrelgraph.py:871
 msgid "Include (birth, marriage, death) dates, and places if no dates"
 msgstr ""
-"Inclou les dates (de naixement, casament i mort) i els llocs si no hi ha "
-"dates"
+"Inclou les dates (de naixement, casament i mort) i els llocs si no hi ha dates"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:870
+#: ../gramps/plugins/graph/gvrelgraph.py:873
 msgid "Include (birth, marriage, death) years, but no places"
 msgstr "Inclou els anys (de naixement, casament i mort), però els llocs no"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:872
+#: ../gramps/plugins/graph/gvrelgraph.py:875
 msgid "Include (birth, marriage, death) years, and places"
 msgstr "Inclou els anys i els llocs (de naixement, casament i mort)"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:874
+#: ../gramps/plugins/graph/gvrelgraph.py:877
 msgid "Include (birth, marriage, death) places, but no dates"
 msgstr "Inclou llocs (de naixement, casament i mort), però les dates no"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:876
+#: ../gramps/plugins/graph/gvrelgraph.py:879
 msgid "Include (birth, marriage, death) dates and places on same line"
 msgstr ""
 "Inclou les dates i llocs (de naixement, casament i mort) en la mateixa línia"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:879
+#: ../gramps/plugins/graph/gvrelgraph.py:882
 msgid "Whether to include dates and/or places"
 msgstr "Si s'han d'incloure dates i/o llocs"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:882
-#, fuzzy
+#: ../gramps/plugins/graph/gvrelgraph.py:885
 msgid "Show all family nodes"
-msgstr "Mostra nodes familiars"
+msgstr "Mostra tots els nodes familiars"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:883
+#: ../gramps/plugins/graph/gvrelgraph.py:886
 msgid ""
 "Show family nodes even if the output contains only one member of the family."
 msgstr ""
+"Mostrar els nodes familiars encara que la sortida només contingui un membre"
+" de la família."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:887
+#: ../gramps/plugins/graph/gvrelgraph.py:890
 msgid "Include URLs"
 msgstr "Incloure URLs"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:888
+#: ../gramps/plugins/graph/gvrelgraph.py:891
 msgid ""
-"Include a URL in each graph node so that PDF and imagemap files can be "
-"generated that contain active links to the files generated by the 'Narrated "
-"Web Site' report."
+"Include a URL in each graph node so that PDF and imagemap files can be"
+" generated that contain active links to the files generated by the 'Narrated"
+" Web Site' report."
 msgstr ""
-"Incloure una URL a cada node del graf perquè es puguin generar fitxers PDF i "
-"de mapa d'imatges que continguin enllaços actius als fitxers generats per "
-"l'informe de 'Lloc Web Narrat'."
+"Incloure una URL a cada node del graf perquè es puguin generar fitxers PDF i"
+" de mapa d'imatges que continguin enllaços actius als fitxers generats per"
+" l'informe de 'Lloc Web Narrat'."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:896
+#: ../gramps/plugins/graph/gvrelgraph.py:899
 #: ../gramps/plugins/textreport/birthdayreport.py:568
 #: ../gramps/plugins/textreport/indivcomplete.py:1145
 msgid "Include relationship to center person"
 msgstr "Incloure parentesc amb la persona central"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:897
+#: ../gramps/plugins/graph/gvrelgraph.py:900
 msgid "Whether to show every person's relationship to the center person"
 msgstr "Si s'ha de mostrat el parentesc de cada persona amb la persona central"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:906
+#: ../gramps/plugins/graph/gvrelgraph.py:909
 msgid "Whether to include thumbnails of people."
 msgstr "Si s'han d'incloure imatges en miniatura de les persones."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:910
+#: ../gramps/plugins/graph/gvrelgraph.py:913
 msgid "Thumbnail Location"
 msgstr "Ubicació de les imatges miniatura"
 
 #. occupation = BooleanOption(_("Include occupation"), False)
-#: ../gramps/plugins/graph/gvrelgraph.py:918
+#: ../gramps/plugins/graph/gvrelgraph.py:921
 msgid "Include occupation"
 msgstr "Incloure la feina"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:919
+#: ../gramps/plugins/graph/gvrelgraph.py:922
 msgid "Do not include any occupation"
 msgstr "No incloure cap feina"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:920
+#: ../gramps/plugins/graph/gvrelgraph.py:923
 msgid "Include description of most recent occupation"
 msgstr "Incloure la descripció i la feina més recent"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:922
+#: ../gramps/plugins/graph/gvrelgraph.py:925
 msgid "Include date, description and place of all occupations"
 msgstr "Incloure la data, descripció i lloc de totes les feines"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:924
+#: ../gramps/plugins/graph/gvrelgraph.py:927
 msgid "Whether to include the last occupation"
 msgstr "Si s'ha d'incloure la darrera feina"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:928
+#: ../gramps/plugins/graph/gvrelgraph.py:931
 msgid "Include relationship debugging numbers also"
 msgstr "Incloure també números de depuració del parentesc"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:931
+#: ../gramps/plugins/graph/gvrelgraph.py:934
 msgid ""
 "Whether to include 'Ga' and 'Gb' also, to debug the relationship calculator"
 msgstr ""
 "Si s'ha d'incloure també 'Ga' i 'Gb', per depurar la calculadora de parentesc"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:959
+#: ../gramps/plugins/graph/gvrelgraph.py:962
 msgid "Indicate non-birth relationships with dotted lines"
 msgstr "Indicar parentius diferents del naixement amb línies de punts"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:960
+#: ../gramps/plugins/graph/gvrelgraph.py:963
 msgid "Non-birth relationships will show up as dotted lines in the graph."
 msgstr ""
 "Parentius diferents del naixement sortiran al graf com a línies de punts."
 
-#: ../gramps/plugins/graph/gvrelgraph.py:964
+#: ../gramps/plugins/graph/gvrelgraph.py:967
 msgid "Show family nodes"
 msgstr "Mostra nodes familiars"
 
-#: ../gramps/plugins/graph/gvrelgraph.py:965
+#: ../gramps/plugins/graph/gvrelgraph.py:968
 msgid "Families will show up as ellipses, linked to parents and children."
 msgstr "Les famílies sortiran com a el·lipses, associades amb pares i fills."
 
@@ -24965,11 +24915,11 @@ msgstr "Paquet Gramps (XML portable)"
 
 #: ../gramps/plugins/importer/import.gpr.py:92
 msgid ""
-"Import data from a Gramps package (an archived XML Family Tree together with "
-"the media object files.)"
+"Import data from a Gramps package (an archived XML Family Tree together with"
+" the media object files.)"
 msgstr ""
-"Importa dades d'un paquet Gramps (un Arbre Genealògic XML arxivat juntament "
-"amb els fitxers de medis audiovisuals)."
+"Importa dades d'un paquet Gramps (un Arbre Genealògic XML arxivat juntament"
+" amb els fitxers de medis audiovisuals)."
 
 #: ../gramps/plugins/importer/import.gpr.py:110
 msgid "Gramps XML Family Tree"
@@ -24977,12 +24927,12 @@ msgstr "Arbre Genealògic Gramps XML"
 
 #: ../gramps/plugins/importer/import.gpr.py:111
 msgid ""
-"The Gramps XML format is a text version of a Family Tree. It is read-write "
-"compatible with the present Gramps database format."
+"The Gramps XML format is a text version of a Family Tree. It is read-write"
+" compatible with the present Gramps database format."
 msgstr ""
-"El format Gramps XML és una versió en text d'un Arbre Genealògic. És "
-"compatible a nivell de lectura i escriptura amb el format de base de dades "
-"Gramps actual."
+"El format Gramps XML és una versió en text d'un Arbre Genealògic. És"
+" compatible a nivell de lectura i escriptura amb el format de base de dades"
+" Gramps actual."
 
 #: ../gramps/plugins/importer/import.gpr.py:131
 msgid "Gramps 2.x database"
@@ -25372,15 +25322,15 @@ msgstr "Codificació GEDCOM"
 
 #: ../gramps/plugins/importer/importgedcom.glade:97
 msgid ""
-"This GEDCOM file has identified itself as using ANSEL encoding. Sometimes, "
-"this is in error. If the imported data contains unusual characters, undo the "
-"import, and override the character set by selecting a different encoding "
-"below."
+"This GEDCOM file has identified itself as using ANSEL encoding. Sometimes,"
+" this is in error. If the imported data contains unusual characters, undo the"
+" import, and override the character set by selecting a different encoding"
+" below."
 msgstr ""
-"Aquest fitxer GEDCOM s'identifica amb la codificació ANSEL. De vegades, això "
-"és un error. Si les dades importades contenen caràcters estranys, desfaci la "
-"importació, i forci el joc de caràcters seleccionant una codificació "
-"diferent a sota."
+"Aquest fitxer GEDCOM s'identifica amb la codificació ANSEL. De vegades, això"
+" és un error. Si les dades importades contenen caràcters estranys, desfaci la"
+" importació, i forci el joc de caràcters seleccionant una codificació"
+" diferent a sota."
 
 #: ../gramps/plugins/importer/importgedcom.glade:125
 msgid "Encoding: "
@@ -25513,8 +25463,8 @@ msgstr "No es pot escriure a la carpeta de medis audiovisuals %s"
 msgid ""
 "Media directory %s exists. Delete it first, then restart the import process"
 msgstr ""
-"La carpeta de medis audiovisuals %s ja existeix. Esborri-la primer, i "
-"després torni a començar el procés d'importació"
+"La carpeta de medis audiovisuals %s ja existeix. Esborri-la primer, i després"
+" torni a començar el procés d'importació"
 
 #: ../gramps/plugins/importer/importgpkg.py:90
 #, python-format
@@ -25528,16 +25478,16 @@ msgstr "Camí base per al conjunt de medis audiovisuals"
 #: ../gramps/plugins/importer/importgpkg.py:108
 #, python-format
 msgid ""
-"The base media path of this Family Tree has been set to %s. Consider taking "
-"a simpler path. You can change this in the Preferences, while moving your "
-"media files to the new position, and using the media manager tool, option "
-"'Replace substring in the path' to set correct paths in your media objects."
+"The base media path of this Family Tree has been set to %s. Consider taking a"
+" simpler path. You can change this in the Preferences, while moving your"
+" media files to the new position, and using the media manager tool, option"
+" 'Replace substring in the path' to set correct paths in your media objects."
 msgstr ""
-"El camí base per als medis d'aquest Arbre Genealògic s'ha fixat a %s. "
-"Consideri de triar-ne un de més senzill. Ho pot canviar a les Preferències, "
-"movent al mateix temps els fitxers a la nova ubicació, i fent servir l'eina "
-"Gestor de Medis, amb l'opció 'Substituir subcadenes dins el camí' per fixar "
-"camins correctes cap als medis audiovisuals."
+"El camí base per als medis d'aquest Arbre Genealògic s'ha fixat a %s."
+" Consideri de triar-ne un de més senzill. Ho pot canviar a les Preferències,"
+" movent al mateix temps els fitxers a la nova ubicació, i fent servir l'eina"
+" Gestor de Medis, amb l'opció 'Substituir subcadenes dins el camí' per fixar"
+" camins correctes cap als medis audiovisuals."
 
 #: ../gramps/plugins/importer/importgpkg.py:117
 msgid "Cannot set base media path"
@@ -25548,19 +25498,19 @@ msgstr "No es pot fixar el camí base de medis audiovisuals"
 msgid ""
 "The Family Tree you imported into already has a base media path: "
 "%(orig_path)s. The imported media objects however are relative from the path "
-"%(path)s. You can change the media path in the Preferences or you can "
-"convert the imported files to the existing base media path. You can do that "
-"by moving your media files to the new position, and using the media manager "
-"tool, option 'Replace substring in the path' to set correct paths in your "
-"media objects."
+"%(path)s. You can change the media path in the Preferences or you can convert"
+" the imported files to the existing base media path. You can do that by"
+" moving your media files to the new position, and using the media manager"
+" tool, option 'Replace substring in the path' to set correct paths in your"
+" media objects."
 msgstr ""
-"L'Arbre Genealògic on heu fet la importació ja té un camí base per als medis "
-"audiovisuals: %(orig_path)s. Els audiovisuals que s'han importat, però, són "
-"relatius al camí %(path)s. Podeu modificar el camí base a les Preferències, "
-"o podeu convertir els fitxers importats al camí base de medis existent. Ho "
-"pot fer movent els fitxers a la nova ubicació, i fent servir l'eina Gestor "
-"de Medis, amb l'opció 'Substituir subcadenes dins el camí' per fixar camins "
-"correctes cap als medis audiovisuals."
+"L'Arbre Genealògic on heu fet la importació ja té un camí base per als medis"
+" audiovisuals: %(orig_path)s. Els audiovisuals que s'han importat, però, són"
+" relatius al camí %(path)s. Podeu modificar el camí base a les Preferències,"
+" o podeu convertir els fitxers importats al camí base de medis existent. Ho"
+" pot fer movent els fitxers a la nova ubicació, i fent servir l'eina Gestor"
+" de Medis, amb l'opció 'Substituir subcadenes dins el camí' per fixar camins"
+" correctes cap als medis audiovisuals."
 
 #: ../gramps/plugins/importer/importgrdb.py:61
 #: ../gramps/plugins/importer/importprogen.py:189
@@ -25573,20 +25523,20 @@ msgstr "%s no s'ha pogut obrir"
 #: ../gramps/plugins/importer/importgrdb.py:62
 #, python-format
 msgid ""
-"The Database version is not supported by this version of Gramps.You should "
-"use an old copy of Gramps at version 3.0.x and import your database into "
-"that version. You should then export a copy of your data to Gramps XML "
-"(Family Tree). Then you should upgrade to the latest version of Gramps (for "
-"example this version), create a new empty database and import the Gramps XML "
-"into that version. Please refer to:%(gramps_wiki_migrate_two_to_three_url)s"
+"The Database version is not supported by this version of Gramps.You should"
+" use an old copy of Gramps at version 3.0.x and import your database into"
+" that version. You should then export a copy of your data to Gramps XML"
+" (Family Tree). Then you should upgrade to the latest version of Gramps (for"
+" example this version), create a new empty database and import the Gramps XML"
+" into that version. Please refer to:%(gramps_wiki_migrate_two_to_three_url)s"
 msgstr ""
-"La versió de Base de Dades no està suportada per aquesta versió de Gramps. "
-"Hauríeu d'utilitzar una còpia antiga de Gramps de la versió 3.0.x i importar "
-"la vostra base de dades en aquella. Llavors, hauríeu d'exportar una còpia de "
-"les vostres dades a Gramps XML (Arbre Genealògic). Finalment, hauríeu "
-"d'actualitzar a l'última versió de Gramps (per exemple, aquesta mateixa), "
-"crear una nova base de dades buida i importar el Gramps XML en aquesta "
-"versió. Si us plau, consulteu:%(gramps_wiki_migrate_two_to_three_url)s"
+"La versió de Base de Dades no està suportada per aquesta versió de Gramps."
+" Hauríeu d'utilitzar una còpia antiga de Gramps de la versió 3.0.x i importar"
+" la vostra base de dades en aquella. Llavors, hauríeu d'exportar una còpia de"
+" les vostres dades a Gramps XML (Arbre Genealògic). Finalment, hauríeu"
+" d'actualitzar a l'última versió de Gramps (per exemple, aquesta mateixa),"
+" crear una nova base de dades buida i importar el Gramps XML en aquesta"
+" versió. Si us plau, consulteu:%(gramps_wiki_migrate_two_to_three_url)s"
 
 #: ../gramps/plugins/importer/importprogen.glade:49
 #: ../gramps/plugins/importer/importprogen.glade:70
@@ -25870,11 +25820,11 @@ msgstr "Token >%(token)s< desconegut. línia saltada: %(line)s"
 
 #: ../gramps/plugins/importer/importvcard.py:335
 msgid ""
-"BEGIN property not properly closed by END property, Gramps can't cope with "
-"nested VCards."
+"BEGIN property not properly closed by END property, Gramps can't cope with"
+" nested VCards."
 msgstr ""
-"La propietat BEGIN no s'ha tancat correctament per la propietat END. Gramps "
-"no pot fer front a VCards niades."
+"La propietat BEGIN no s'ha tancat correctament per la propietat END. Gramps"
+" no pot fer front a VCards niades."
 
 #: ../gramps/plugins/importer/importvcard.py:346
 #, python-format
@@ -25883,18 +25833,18 @@ msgstr "La importació de VCards versió %s no està suportada per Gramps."
 
 #: ../gramps/plugins/importer/importvcard.py:366
 msgid ""
-"VCard is malformed missing the compulsory N property, so there is no name; "
-"skip it."
+"VCard is malformed missing the compulsory N property, so there is no name;"
+" skip it."
 msgstr ""
-"La VCard està mal creada, li falta la propietat obligatòria N, així que no "
-"hi ha nom; la salto."
+"La VCard està mal creada, li falta la propietat obligatòria N, així que no hi"
+" ha nom; la salto."
 
 #: ../gramps/plugins/importer/importvcard.py:371
 msgid ""
 "VCard is malformed missing the compulsory FN property, get name from N alone."
 msgstr ""
-"La VCard està mal creada, li falta la propietat obligatòria FN, només posali "
-"un nom de la N."
+"La VCard està mal creada, li falta la propietat obligatòria FN, només posali"
+" un nom de la N."
 
 #: ../gramps/plugins/importer/importvcard.py:375
 msgid "VCard is malformed wrong number of name components."
@@ -25910,11 +25860,11 @@ msgstr ""
 #: ../gramps/plugins/importer/importvcard.py:525
 #, python-brace-format
 msgid ""
-"Date {vcard_snippet} not in appropriate format yyyy-mm-dd, preserving date "
-"as text."
+"Date {vcard_snippet} not in appropriate format yyyy-mm-dd, preserving date as"
+" text."
 msgstr ""
-"La data {vcard_snippet} no té el format apropriat yyyy-mm-dd, es conservarà "
-"la data com un text."
+"La data {vcard_snippet} no té el format apropriat yyyy-mm-dd, es conservarà"
+" la data com un text."
 
 #. feature requests 2356, 1658: avoid genitive form
 #. -------------------------------------------------------------------------
@@ -25945,8 +25895,8 @@ msgstr "Error llegint %s"
 #: ../gramps/plugins/importer/importxml.py:161
 msgid "The file is probably either corrupt or not a valid Gramps database."
 msgstr ""
-"El fitxer és probablement o bé corrupte o no és una base de dades Gramps "
-"vàlida."
+"El fitxer és probablement o bé corrupte o no és una base de dades Gramps"
+" vàlida."
 
 #: ../gramps/plugins/importer/importxml.py:245
 #, python-format
@@ -26114,26 +26064,25 @@ msgstr "No s'ha pogut canviar la carpeta de medis audiovisuals"
 #: ../gramps/plugins/importer/importxml.py:959
 #, python-format
 msgid ""
-"The opened file has media path %s, which conflicts with the media path of "
-"the Family Tree you import into. The original media path has been retained. "
-"Copy the files to a correct directory or change the media path in the "
-"Preferences."
+"The opened file has media path %s, which conflicts with the media path of the"
+" Family Tree you import into. The original media path has been retained. Copy"
+" the files to a correct directory or change the media path in the Preferences."
 msgstr ""
-"El fitxer obert té una carpeta de medis audiovisuals %s, que està en "
-"conflicte amb la carpeta de medis de l'Arbre Genealògic on esteu fent la "
-"importació. S'ha conservat la carpeta de medis original. Copieu els fitxers "
-"al directori correcte o canvieu la carpeta de medis audiovisuals a les "
-"Preferències."
+"El fitxer obert té una carpeta de medis audiovisuals %s, que està en"
+" conflicte amb la carpeta de medis de l'Arbre Genealògic on esteu fent la"
+" importació. S'ha conservat la carpeta de medis original. Copieu els fitxers"
+" al directori correcte o canvieu la carpeta de medis audiovisuals a les"
+" Preferències."
 
 #: ../gramps/plugins/importer/importxml.py:1018
 msgid ""
-"The .gramps file you are importing does not contain information about the "
-"version of Gramps with, which it was produced.\n"
+"The .gramps file you are importing does not contain information about the"
+" version of Gramps with, which it was produced.\n"
 "\n"
 "The file will not be imported."
 msgstr ""
-"El fitxer .gramps que esteu important no conté informació sobre la versió de "
-"Gramps amb què es va crear.\n"
+"El fitxer .gramps que esteu important no conté informació sobre la versió de"
+" Gramps amb què es va crear.\n"
 "\n"
 "El fitxer no s'importarà."
 
@@ -26144,33 +26093,33 @@ msgstr "Al fitxer d'importació li falta la versió de Gramps"
 #: ../gramps/plugins/importer/importxml.py:1023
 #, python-format
 msgid ""
-"The .gramps file you are importing was made by version %(newer)s of Gramps, "
-"while you are running an older version %(older)s. The file will not be "
-"imported. Please upgrade to the latest version of Gramps and try again."
+"The .gramps file you are importing was made by version %(newer)s of Gramps,"
+" while you are running an older version %(older)s. The file will not be"
+" imported. Please upgrade to the latest version of Gramps and try again."
 msgstr ""
-"El fitxer .gramps que està important va ser creat per la versió %(newer)s de "
-"Gramps, mentre que està executant una versió més vella, la %(older)s. El "
-"fitxer no s'importarà. Si us plau instal·li l'última versió de Gramps i "
-"torni-ho a provar."
+"El fitxer .gramps que està important va ser creat per la versió %(newer)s de"
+" Gramps, mentre que està executant una versió més vella, la %(older)s. El"
+" fitxer no s'importarà. Si us plau instal·li l'última versió de Gramps i"
+" torni-ho a provar."
 
 #: ../gramps/plugins/importer/importxml.py:1031
 #, python-format
 msgid ""
-"The .gramps file you are importing was made by version %(oldgramps)s of "
-"Gramps, while you are running a more recent version %(newgramps)s.\n"
+"The .gramps file you are importing was made by version %(oldgramps)s of"
+" Gramps, while you are running a more recent version %(newgramps)s.\n"
 "\n"
-"The file will not be imported. Please use an older version of Gramps that "
-"supports version %(xmlversion)s of the xml.\n"
+"The file will not be imported. Please use an older version of Gramps that"
+" supports version %(xmlversion)s of the xml.\n"
 "See\n"
 "  %(gramps_wiki_xml_url)s\n"
 " for more info."
 msgstr ""
-"El fitxer .gramps que està important va ser creat per la versió "
-"%(oldgramps)s de Gramps, mentre que n'està executant una versió més recent, "
-"la %(newgramps)s.\n"
+"El fitxer .gramps que està important va ser creat per la versió %(oldgramps)s"
+" de Gramps, mentre que n'està executant una versió més recent, la "
+"%(newgramps)s.\n"
 "\n"
-"El fitxer no s'importarà. Si us plau faci servir una versió més antiga de "
-"Gramps que suporti la versió %(xmlversion)s d'xml.\n"
+"El fitxer no s'importarà. Si us plau faci servir una versió més antiga de"
+" Gramps que suporti la versió %(xmlversion)s d'xml.\n"
 "Veure\n"
 "  %(gramps_wiki_xml_url)s\n"
 " per més informació."
@@ -26182,23 +26131,23 @@ msgstr "El fitxer no s'importarà"
 #: ../gramps/plugins/importer/importxml.py:1044
 #, python-format
 msgid ""
-"The .gramps file you are importing was made by version %(oldgramps)s of "
-"Gramps, while you are running a much more recent version %(newgramps)s.\n"
+"The .gramps file you are importing was made by version %(oldgramps)s of"
+" Gramps, while you are running a much more recent version %(newgramps)s.\n"
 "\n"
-"Ensure after import everything is imported correctly. In the event of "
-"problems, please submit a bug and use an older version of Gramps in the "
-"meantime to import this file, which is version %(xmlversion)s of the xml.\n"
+"Ensure after import everything is imported correctly. In the event of"
+" problems, please submit a bug and use an older version of Gramps in the"
+" meantime to import this file, which is version %(xmlversion)s of the xml.\n"
 "See\n"
 "  %(gramps_wiki_xml_url)s\n"
 "for more info."
 msgstr ""
-"El fitxer .gramps que està important va ser creat per la versió "
-"%(oldgramps)s de Gramps, mentre que n'està executant una versió molt més "
-"recent, la %(newgramps)s.\n"
+"El fitxer .gramps que està important va ser creat per la versió %(oldgramps)s"
+" de Gramps, mentre que n'està executant una versió molt més recent, la "
+"%(newgramps)s.\n"
 "\n"
-"Asseguri's després de la importació que tot s'ha importat de forma correcta. "
-"En cas de problemes, si us plau notifiqui l'error i utilitzi una versió més "
-"vella de Gramps mentrestant per importar aquest fitxer, que és de la versió "
+"Asseguri's després de la importació que tot s'ha importat de forma correcta."
+" En cas de problemes, si us plau notifiqui l'error i utilitzi una versió més"
+" vella de Gramps mentrestant per importar aquest fitxer, que és de la versió "
 "%(xmlversion)s de l'xml.\n"
 "Veure\n"
 "  %(gramps_wiki_xml_url)s\n"
@@ -26225,11 +26174,11 @@ msgstr "Qualsevol referència de persona ha de tenir un atribut 'hlink'."
 #: ../gramps/plugins/importer/importxml.py:1758
 #, python-format
 msgid ""
-"Your Family Tree groups name \"%(key)s\" together with \"%(parent)s\", did "
-"not change this grouping to \"%(value)s\"."
+"Your Family Tree groups name \"%(key)s\" together with \"%(parent)s\", did"
+" not change this grouping to \"%(value)s\"."
 msgstr ""
-"El seu Arbre Genealògic ajunta el nom \"%(key)s\" amb \"%(parent)s\", no "
-"s'ha canviat aquesta agrupació a \"%(value)s\"."
+"El seu Arbre Genealògic ajunta el nom \"%(key)s\" amb \"%(parent)s\", no s'ha"
+" canviat aquesta agrupació a \"%(value)s\"."
 
 #: ../gramps/plugins/importer/importxml.py:1761
 msgid "Gramps ignored a name grouping"
@@ -26258,29 +26207,29 @@ msgstr "Comentari del testimoni: %s"
 #: ../gramps/plugins/importer/importxml.py:3235
 #, python-format
 msgid ""
-"Error: family '%(family)s' father '%(father)s' does not refer back to the "
-"family. Reference added."
+"Error: family '%(family)s' father '%(father)s' does not refer back to the"
+" family. Reference added."
 msgstr ""
-"Error: el pare '%(father)s'  de la família '%(family)s' no té la referència "
-"cap a la família. S'ha afegit la referència."
+"Error: el pare '%(father)s'  de la família '%(family)s' no té la referència"
+" cap a la família. S'ha afegit la referència."
 
 #: ../gramps/plugins/importer/importxml.py:3251
 #, python-format
 msgid ""
-"Error: family '%(family)s' mother '%(mother)s' does not refer back to the "
-"family. Reference added."
+"Error: family '%(family)s' mother '%(mother)s' does not refer back to the"
+" family. Reference added."
 msgstr ""
-"Error: la mare '%(mother)s'  de la família '%(family)s' no té la referència "
-"cap a la família. S'ha afegit la referència."
+"Error: la mare '%(mother)s'  de la família '%(family)s' no té la referència"
+" cap a la família. S'ha afegit la referència."
 
 #: ../gramps/plugins/importer/importxml.py:3273
 #, python-format
 msgid ""
-"Error: family '%(family)s' child '%(child)s' does not refer back to the "
-"family. Reference added."
+"Error: family '%(family)s' child '%(child)s' does not refer back to the"
+" family. Reference added."
 msgstr ""
-"Error: el fill '%(child)s'  de la família '%(family)s' no té la referència "
-"cap a la família. S'ha afegit la referència."
+"Error: el fill '%(child)s'  de la família '%(family)s' no té la referència"
+" cap a la família. S'ha afegit la referència."
 
 #: ../gramps/plugins/lib/libcairodoc.py:1398
 #, python-format
@@ -26296,8 +26245,8 @@ msgid "Common Law Marriage"
 msgstr "Casament informal"
 
 #: ../gramps/plugins/lib/libgedcom.py:699
-#: ../gramps/plugins/webreport/narrativeweb.py:1626
-#: ../gramps/plugins/webreport/webcal.py:1661
+#: ../gramps/plugins/webreport/narrativeweb.py:1630
+#: ../gramps/plugins/webreport/webcal.py:1662
 msgid "Destination"
 msgstr "Destí"
 
@@ -26404,31 +26353,31 @@ msgstr "Registres no importats a "
 #: ../gramps/plugins/lib/libgedcom.py:3225
 #, python-format
 msgid ""
-"Error: %(msg)s  '%(gramps_id)s' (input as @%(xref)s@) not in input GEDCOM. "
-"Record synthesised"
+"Error: %(msg)s  '%(gramps_id)s' (input as @%(xref)s@) not in input GEDCOM."
+" Record synthesised"
 msgstr ""
-"Error: %(msg)s  '%(gramps_id)s' (introduït com a @%(xref)s@) no és al GEDCOM "
-"d'entrada. Registre sintetitzat"
+"Error: %(msg)s  '%(gramps_id)s' (introduït com a @%(xref)s@) no és al GEDCOM"
+" d'entrada. Registre sintetitzat"
 
 #: ../gramps/plugins/lib/libgedcom.py:3234
 #, python-format
 msgid ""
-"Error: %(msg)s '%(gramps_id)s' (input as @%(xref)s@) not in input GEDCOM. "
-"Record with typifying attribute 'Unknown' created"
+"Error: %(msg)s '%(gramps_id)s' (input as @%(xref)s@) not in input GEDCOM."
+" Record with typifying attribute 'Unknown' created"
 msgstr ""
-"Error: %(msg)s  '%(gramps_id)s' (introduït com a @%(xref)s@) no és al GEDCOM "
-"d'entrada. S'ha creat un registre amb atribut tipificador 'Desconegut'"
+"Error: %(msg)s  '%(gramps_id)s' (introduït com a @%(xref)s@) no és al GEDCOM"
+" d'entrada. S'ha creat un registre amb atribut tipificador 'Desconegut'"
 
 #: ../gramps/plugins/lib/libgedcom.py:3278
 #, python-format
 msgid ""
-"Error: family '%(family)s' (input as @%(orig_family)s@) person %(person)s "
-"(input as %(orig_person)s) is not a member of the referenced family. Family "
-"reference removed from person"
+"Error: family '%(family)s' (input as @%(orig_family)s@) person %(person)s"
+" (input as %(orig_person)s) is not a member of the referenced family. Family"
+" reference removed from person"
 msgstr ""
-"Error: la persona %(person)s (introduïda com a %(orig_person)s) de la "
-"família '%(family)s' (introduïda com a @%(orig_family)s@) no és un membre de "
-"la família referenciada. S'ha tret la referència de família de la persona"
+"Error: la persona %(person)s (introduïda com a %(orig_person)s) de la família"
+" '%(family)s' (introduïda com a @%(orig_family)s@) no és un membre de la"
+" família referenciada. S'ha tret la referència de família de la persona"
 
 #: ../gramps/plugins/lib/libgedcom.py:3356
 #, python-format
@@ -26623,11 +26572,11 @@ msgstr "Llengua del text GEDCOM"
 #: ../gramps/plugins/lib/libgedcom.py:7459
 #, python-format
 msgid ""
-"Import of GEDCOM file %(filename)s with DEST=%(by)s, could cause errors in "
-"the resulting database!"
+"Import of GEDCOM file %(filename)s with DEST=%(by)s, could cause errors in"
+" the resulting database!"
 msgstr ""
-"La importació del fitxer GEDCOM %(filename)s amb DEST=%(by)s, podria "
-"provocar errors a la base de dades resultant!"
+"La importació del fitxer GEDCOM %(filename)s amb DEST=%(by)s, podria provocar"
+" errors a la base de dades resultant!"
 
 #: ../gramps/plugins/lib/libgedcom.py:7462
 msgid "Look for nameless events."
@@ -26713,11 +26662,11 @@ msgstr "Codi de temple no vàlid"
 
 #: ../gramps/plugins/lib/libgedcom.py:8093
 msgid ""
-"Your GEDCOM file is corrupted. The file appears to be encoded using the "
-"UTF16 character set, but is missing the BOM marker."
+"Your GEDCOM file is corrupted. The file appears to be encoded using the UTF16"
+" character set, but is missing the BOM marker."
 msgstr ""
-"El fitxer GEDCOM està corromput. El fitxer sembla codificat amb el joc de "
-"caràcters UTF16, però li falta el marcador BOM."
+"El fitxer GEDCOM està corromput. El fitxer sembla codificat amb el joc de"
+" caràcters UTF16, però li falta el marcador BOM."
 
 #: ../gramps/plugins/lib/libgedcom.py:8096
 msgid "Your GEDCOM file is empty."
@@ -26887,7 +26836,7 @@ msgid "She was born on %(birth_date)s."
 msgstr "Va néixer el %(birth_date)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:125
-#: ../gramps/plugins/webreport/webcal.py:2091
+#: ../gramps/plugins/webreport/webcal.py:2092
 #, python-format
 msgid "Born %(birth_date)s."
 msgstr "Nascut el %(birth_date)s."
@@ -27040,11 +26989,11 @@ msgstr "%(unknown_gender_name)s va morir el %(death_date)s a %(death_place)s."
 #: ../gramps/plugins/lib/libnarrate.py:192
 #, python-format
 msgid ""
-"%(unknown_gender_name)s died on %(death_date)s in %(death_place)s at the age "
-"of %(age)s."
+"%(unknown_gender_name)s died on %(death_date)s in %(death_place)s at the age"
+" of %(age)s."
 msgstr ""
-"%(unknown_gender_name)s va morir el %(death_date)s a %(death_place)s a "
-"l'edat de %(age)s."
+"%(unknown_gender_name)s va morir el %(death_date)s a %(death_place)s a l'edat"
+" de %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:195
 #, python-format
@@ -27054,8 +27003,7 @@ msgstr "%(male_name)s va morir el %(death_date)s a %(death_place)s."
 #: ../gramps/plugins/lib/libnarrate.py:196
 #, python-format
 msgid ""
-"%(male_name)s died on %(death_date)s in %(death_place)s at the age of "
-"%(age)s."
+"%(male_name)s died on %(death_date)s in %(death_place)s at the age of %(age)s."
 msgstr ""
 "%(male_name)s va morir el %(death_date)s a %(death_place)s a l'edat de "
 "%(age)s."
@@ -27130,8 +27078,8 @@ msgid ""
 "%(unknown_gender_name)s died %(death_date)s in %(death_place)s at the age of "
 "%(age)s."
 msgstr ""
-"%(unknown_gender_name)s va morir %(death_date)s a %(death_place)s a l'edat "
-"de %(age)s."
+"%(unknown_gender_name)s va morir %(death_date)s a %(death_place)s a l'edat de"
+" %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:228
 #, python-format
@@ -27155,8 +27103,7 @@ msgstr "%(female_name)s va morir %(death_date)s a %(death_place)s."
 msgid ""
 "%(female_name)s died %(death_date)s in %(death_place)s at the age of %(age)s."
 msgstr ""
-"%(female_name)s va morir %(death_date)s a %(death_place)s a l'edat de "
-"%(age)s."
+"%(female_name)s va morir %(death_date)s a %(death_place)s a l'edat de %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:237
 #, python-format
@@ -27168,8 +27115,7 @@ msgstr "Aquesta persona va morir %(death_date)s a %(death_place)s."
 msgid ""
 "This person died %(death_date)s in %(death_place)s at the age of %(age)s."
 msgstr ""
-"Aquesta persona va morir %(death_date)s a %(death_place)s a l'edat de "
-"%(age)s."
+"Aquesta persona va morir %(death_date)s a %(death_place)s a l'edat de %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:241
 #, python-format
@@ -27255,7 +27201,7 @@ msgstr "Va morir el %(death_date)s a l'edat de %(age)s."
 #. latin cross for html code
 #: ../gramps/plugins/lib/libnarrate.py:283
 #: ../gramps/plugins/lib/libnarrate.py:316
-#: ../gramps/plugins/webreport/webcal.py:2081
+#: ../gramps/plugins/webreport/webcal.py:2082
 #, python-format
 msgid "Died %(death_date)s."
 msgstr "Mort %(death_date)s."
@@ -27334,11 +27280,11 @@ msgstr "%(unknown_gender_name)s va morir el %(month_year)s a %(death_place)s."
 #: ../gramps/plugins/lib/libnarrate.py:324
 #, python-format
 msgid ""
-"%(unknown_gender_name)s died in %(month_year)s in %(death_place)s at the age "
-"of %(age)s."
+"%(unknown_gender_name)s died in %(month_year)s in %(death_place)s at the age"
+" of %(age)s."
 msgstr ""
-"%(unknown_gender_name)s va morir el %(month_year)s a %(death_place)s a "
-"l'edat de %(age)s."
+"%(unknown_gender_name)s va morir el %(month_year)s a %(death_place)s a l'edat"
+" de %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:327
 #, python-format
@@ -27348,8 +27294,7 @@ msgstr "%(male_name)s va morir el %(month_year)s a %(death_place)s."
 #: ../gramps/plugins/lib/libnarrate.py:328
 #, python-format
 msgid ""
-"%(male_name)s died in %(month_year)s in %(death_place)s at the age of "
-"%(age)s."
+"%(male_name)s died in %(month_year)s in %(death_place)s at the age of %(age)s."
 msgstr ""
 "%(male_name)s va morir el %(month_year)s a %(death_place)s a l'edat de "
 "%(age)s."
@@ -27604,8 +27549,7 @@ msgstr "Va ser enterrat el %(burial_date)s a %(burial_place)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:465
 #, python-format
 msgid ""
-"%(female_name)s was buried on %(burial_date)s in %(burial_place)s"
-"%(endnotes)s."
+"%(female_name)s was buried on %(burial_date)s in %(burial_place)s%(endnotes)s."
 msgstr ""
 "%(female_name)s va ser enterrada el %(burial_date)s a %(burial_place)s"
 "%(endnotes)s."
@@ -27916,8 +27860,7 @@ msgid ""
 "%(male_name)s was baptized on %(baptism_date)s in %(baptism_place)s"
 "%(endnotes)s."
 msgstr ""
-"%(male_name)s fou batejat el %(baptism_date)s a %(baptism_place)s"
-"%(endnotes)s."
+"%(male_name)s fou batejat el %(baptism_date)s a %(baptism_place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:595
 #, python-format
@@ -27950,8 +27893,7 @@ msgstr ""
 #: ../gramps/plugins/lib/libnarrate.py:603
 #, python-format
 msgid ""
-"This person was baptized on %(baptism_date)s in %(baptism_place)s"
-"%(endnotes)s."
+"This person was baptized on %(baptism_date)s in %(baptism_place)s%(endnotes)s."
 msgstr ""
 "Aquesta persona fou batejada el %(baptism_date)s a %(baptism_place)s"
 "%(endnotes)s."
@@ -27999,8 +27941,7 @@ msgstr "Batejat %(baptism_date)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:626
 #, python-format
 msgid ""
-"%(male_name)s was baptized in %(month_year)s in %(baptism_place)s"
-"%(endnotes)s."
+"%(male_name)s was baptized in %(month_year)s in %(baptism_place)s%(endnotes)s."
 msgstr ""
 "%(male_name)s fou batejat el %(month_year)s a %(baptism_place)s%(endnotes)s."
 
@@ -28083,8 +28024,7 @@ msgstr "Batejat %(month_year)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:658
 #, python-format
 msgid ""
-"%(male_name)s was baptized %(modified_date)s in %(baptism_place)s"
-"%(endnotes)s."
+"%(male_name)s was baptized %(modified_date)s in %(baptism_place)s%(endnotes)s."
 msgstr ""
 "%(male_name)s fou batejat %(modified_date)s a %(baptism_place)s%(endnotes)s."
 
@@ -28884,8 +28824,7 @@ msgstr ""
 #: ../gramps/plugins/lib/libnarrate.py:997
 #, python-format
 msgid ""
-"This person also married %(spouse)s on %(full_date)s in %(place)s"
-"%(endnotes)s."
+"This person also married %(spouse)s on %(full_date)s in %(place)s%(endnotes)s."
 msgstr ""
 "Aquesta persona també es va casar amb %(spouse)s el %(full_date)s a %(place)s"
 "%(endnotes)s."
@@ -29026,8 +28965,7 @@ msgstr ""
 #, python-format
 msgid "This person also married %(spouse)s on %(full_date)s%(endnotes)s."
 msgstr ""
-"Aquesta persona també es va casar amb %(spouse)s el %(full_date)s"
-"%(endnotes)s."
+"Aquesta persona també es va casar amb %(spouse)s el %(full_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1044
 #, python-format
@@ -29165,8 +29103,8 @@ msgstr "També es va casar amb %(spouse)s%(endnotes)s."
 #: ../gramps/plugins/lib/libnarrate.py:1098
 #, python-format
 msgid ""
-"This person had an unmarried relationship with %(spouse)s in "
-"%(partial_date)s in %(place)s%(endnotes)s."
+"This person had an unmarried relationship with %(spouse)s in %(partial_date)s"
+" in %(place)s%(endnotes)s."
 msgstr ""
 "Aquesta persona va tenir una relació extramatrimonial amb %(spouse)s el "
 "%(partial_date)s a %(place)s%(endnotes)s."
@@ -29174,8 +29112,8 @@ msgstr ""
 #: ../gramps/plugins/lib/libnarrate.py:1099
 #, python-format
 msgid ""
-"This person had an unmarried relationship with %(spouse)s on %(full_date)s "
-"in %(place)s%(endnotes)s."
+"This person had an unmarried relationship with %(spouse)s on %(full_date)s in"
+" %(place)s%(endnotes)s."
 msgstr ""
 "Aquesta persona va tenir una relació extramatrimonial amb %(spouse)s el "
 "%(full_date)s a %(place)s%(endnotes)s."
@@ -29183,8 +29121,8 @@ msgstr ""
 #: ../gramps/plugins/lib/libnarrate.py:1100
 #, python-format
 msgid ""
-"This person had an unmarried relationship with %(spouse)s %(modified_date)s "
-"in %(place)s%(endnotes)s."
+"This person had an unmarried relationship with %(spouse)s %(modified_date)s"
+" in %(place)s%(endnotes)s."
 msgstr ""
 "Aquesta persona va tenir una relació extramatrimonial amb %(spouse)s "
 "%(modified_date)s a %(place)s%(endnotes)s."
@@ -29257,8 +29195,7 @@ msgstr ""
 #: ../gramps/plugins/lib/libnarrate.py:1137
 #, python-format
 msgid ""
-"Unmarried relationship with %(spouse)s %(full_date)s in %(place)s"
-"%(endnotes)s."
+"Unmarried relationship with %(spouse)s %(full_date)s in %(place)s%(endnotes)s."
 msgstr ""
 "Relació extramatrimonial amb %(spouse)s el %(full_date)s a %(place)s"
 "%(endnotes)s."
@@ -29279,8 +29216,8 @@ msgid ""
 "This person also had an unmarried relationship with %(spouse)s in "
 "%(partial_date)s in %(place)s%(endnotes)s."
 msgstr ""
-"Aquesta persona també va tenir una relació extramatrimonial amb %(spouse)s "
-"el %(partial_date)s a %(place)s%(endnotes)s."
+"Aquesta persona també va tenir una relació extramatrimonial amb %(spouse)s el"
+" %(partial_date)s a %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1122
 #, python-format
@@ -29288,8 +29225,8 @@ msgid ""
 "This person also had an unmarried relationship with %(spouse)s on "
 "%(full_date)s in %(place)s%(endnotes)s."
 msgstr ""
-"Aquesta persona també va tenir una relació extramatrimonial amb %(spouse)s "
-"el %(full_date)s a %(place)s%(endnotes)s."
+"Aquesta persona també va tenir una relació extramatrimonial amb %(spouse)s el"
+" %(full_date)s a %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1123
 #, python-format
@@ -29315,8 +29252,8 @@ msgid ""
 "He also had an unmarried relationship with %(spouse)s on %(full_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"També va tenir una relació extramatrimonial amb %(spouse)s el %(full_date)s "
-"a %(place)s%(endnotes)s."
+"També va tenir una relació extramatrimonial amb %(spouse)s el %(full_date)s a"
+" %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1128
 #, python-format
@@ -29324,14 +29261,14 @@ msgid ""
 "He also had an unmarried relationship with %(spouse)s %(modified_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"També va tenir una relació extramatrimonial amb %(spouse)s %(modified_date)s "
-"a %(place)s%(endnotes)s."
+"També va tenir una relació extramatrimonial amb %(spouse)s %(modified_date)s"
+" a %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1131
 #, python-format
 msgid ""
-"She also had an unmarried relationship with %(spouse)s in %(partial_date)s "
-"in %(place)s%(endnotes)s."
+"She also had an unmarried relationship with %(spouse)s in %(partial_date)s in"
+" %(place)s%(endnotes)s."
 msgstr ""
 "També va tenir una relació extramatrimonial amb %(spouse)s el "
 "%(partial_date)s a %(place)s%(endnotes)s."
@@ -29342,8 +29279,8 @@ msgid ""
 "She also had an unmarried relationship with %(spouse)s on %(full_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"També va tenir una relació extramatrimonial amb %(spouse)s el %(full_date)s "
-"a %(place)s%(endnotes)s."
+"També va tenir una relació extramatrimonial amb %(spouse)s el %(full_date)s a"
+" %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1133
 #, python-format
@@ -29351,8 +29288,8 @@ msgid ""
 "She also had an unmarried relationship with %(spouse)s %(modified_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"També va tenir una relació extramatrimonial amb %(spouse)s %(modified_date)s "
-"a %(place)s%(endnotes)s."
+"També va tenir una relació extramatrimonial amb %(spouse)s %(modified_date)s"
+" a %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1144
 #, python-format
@@ -29393,8 +29330,7 @@ msgstr ""
 #: ../gramps/plugins/lib/libnarrate.py:1150
 #, python-format
 msgid ""
-"He had an unmarried relationship with %(spouse)s on %(full_date)s"
-"%(endnotes)s."
+"He had an unmarried relationship with %(spouse)s on %(full_date)s%(endnotes)s."
 msgstr ""
 "Va tenir una relació extramatrimonial amb %(spouse)s el %(full_date)s"
 "%(endnotes)s."
@@ -29456,8 +29392,8 @@ msgid ""
 "This person also had an unmarried relationship with %(spouse)s in "
 "%(partial_date)s%(endnotes)s."
 msgstr ""
-"Aquesta persona també va tenir una relació extramatrimonial amb %(spouse)s "
-"el %(partial_date)s%(endnotes)s."
+"Aquesta persona també va tenir una relació extramatrimonial amb %(spouse)s el"
+" %(partial_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1168
 #, python-format
@@ -29465,8 +29401,8 @@ msgid ""
 "This person also had an unmarried relationship with %(spouse)s on "
 "%(full_date)s%(endnotes)s."
 msgstr ""
-"Aquesta persona també va tenir una relació extramatrimonial amb %(spouse)s "
-"el %(full_date)s%(endnotes)s."
+"Aquesta persona també va tenir una relació extramatrimonial amb %(spouse)s el"
+" %(full_date)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1169
 #, python-format
@@ -29700,8 +29636,7 @@ msgid ""
 "He had a relationship with %(spouse)s %(modified_date)s in %(place)s"
 "%(endnotes)s."
 msgstr ""
-"Va tenir una relació amb %(spouse)s %(modified_date)s a %(place)s"
-"%(endnotes)s."
+"Va tenir una relació amb %(spouse)s %(modified_date)s a %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1234
 #, python-format
@@ -29726,8 +29661,7 @@ msgid ""
 "She had a relationship with %(spouse)s %(modified_date)s in %(place)s"
 "%(endnotes)s."
 msgstr ""
-"Va tenir una relació amb %(spouse)s %(modified_date)s a %(place)s"
-"%(endnotes)s."
+"Va tenir una relació amb %(spouse)s %(modified_date)s a %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1239
 #, python-format
@@ -29751,8 +29685,8 @@ msgid ""
 "This person also had a relationship with %(spouse)s in %(partial_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"Aquesta persona també va tenir una relació amb %(spouse)s el "
-"%(partial_date)s a %(place)s%(endnotes)s."
+"Aquesta persona també va tenir una relació amb %(spouse)s el %(partial_date)s"
+" a %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1248
 #, python-format
@@ -29769,8 +29703,8 @@ msgid ""
 "This person also had a relationship with %(spouse)s %(modified_date)s in "
 "%(place)s%(endnotes)s."
 msgstr ""
-"Aquesta persona també va tenir una relació amb %(spouse)s %(modified_date)s "
-"a %(place)s%(endnotes)s."
+"Aquesta persona també va tenir una relació amb %(spouse)s %(modified_date)s a"
+" %(place)s%(endnotes)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:1252
 #, python-format
@@ -30215,7 +30149,7 @@ msgstr "_Enrere"
 #: ../gramps/plugins/view/geoperson.py:109
 #: ../gramps/plugins/view/pedigreeview.py:652
 #: ../gramps/plugins/view/pedigreeview.py:693
-#: ../gramps/plugins/view/pedigreeview.py:1647
+#: ../gramps/plugins/view/pedigreeview.py:1648
 #: ../gramps/plugins/view/relview.py:372 ../gramps/plugins/view/relview.py:436
 msgid "_Home"
 msgstr "_Base"
@@ -30317,7 +30251,7 @@ msgstr "Editor de Filtres de Persones"
 
 #: ../gramps/plugins/lib/libpersonview.py:246
 #: ../gramps/plugins/lib/libpersonview.py:355
-#: ../gramps/plugins/view/pedigreeview.py:1657
+#: ../gramps/plugins/view/pedigreeview.py:1658
 msgid "Set _Home Person"
 msgstr "Fixa Persona _Base"
 
@@ -30418,13 +30352,13 @@ msgstr "Esborrar Persona (%s)"
 
 #: ../gramps/plugins/lib/libpersonview.py:535
 msgid ""
-"Exactly two people must be selected to perform a merge. A second person can "
-"be selected by holding down the control key while clicking on the desired "
-"person."
+"Exactly two people must be selected to perform a merge. A second person can"
+" be selected by holding down the control key while clicking on the desired"
+" person."
 msgstr ""
-"Cal seleccionar exactament dues persones per fer una combinació. Es pot "
-"seleccionar la segona persona prement la tecla de control mentre es clica la "
-"persona desitjada."
+"Cal seleccionar exactament dues persones per fer una combinació. Es pot"
+" seleccionar la segona persona prement la tecla de control mentre es clica la"
+" persona desitjada."
 
 #: ../gramps/plugins/lib/libplaceview.py:104
 msgid "Edit the selected place"
@@ -30452,11 +30386,11 @@ msgstr "No s'ha seleccionat cap lloc."
 
 #: ../gramps/plugins/lib/libplaceview.py:239
 msgid ""
-"You need to select a place to be able to view it on a map. Some Map Services "
-"might support multiple selections."
+"You need to select a place to be able to view it on a map. Some Map Services"
+" might support multiple selections."
 msgstr ""
-"Cal seleccionar un lloc per poder-lo veure en un mapa. Alguns Serveis de "
-"Mapes pot ser que permetin seleccions múltiples."
+"Cal seleccionar un lloc per poder-lo veure en un mapa. Alguns Serveis de"
+" Mapes pot ser que permetin seleccions múltiples."
 
 #: ../gramps/plugins/lib/libplaceview.py:323
 msgid "Place Filter Editor"
@@ -30468,11 +30402,11 @@ msgstr "_Localitza amb el Servei de Mapes"
 
 #: ../gramps/plugins/lib/libplaceview.py:466
 msgid ""
-"Attempt to see selected locations with a Map Service (OpenstreetMap, Google "
-"Maps, ...)"
+"Attempt to see selected locations with a Map Service (OpenstreetMap, Google"
+" Maps, ...)"
 msgstr ""
-"Intentar de veure les ubicacions seleccionades amb un Servei de Mapes "
-"(OpenstreetMap, Google Maps, ...)"
+"Intentar de veure les ubicacions seleccionades amb un Servei de Mapes"
+" (OpenstreetMap, Google Maps, ...)"
 
 #: ../gramps/plugins/lib/libplaceview.py:466
 msgid "Select a Map Service"
@@ -30484,11 +30418,11 @@ msgstr "No es pot esborrar el lloc."
 
 #: ../gramps/plugins/lib/libplaceview.py:507
 msgid ""
-"This place is currently referenced by another place. First remove the places "
-"it contains."
+"This place is currently referenced by another place. First remove the places"
+" it contains."
 msgstr ""
-"Aquest lloc està actualment referenciat per un altre lloc. Primer esborra "
-"els llocs que conté."
+"Aquest lloc està actualment referenciat per un altre lloc. Primer esborra els"
+" llocs que conté."
 
 #: ../gramps/plugins/lib/libplaceview.py:548
 #: ../gramps/plugins/lib/libplaceview.py:556
@@ -30497,13 +30431,12 @@ msgstr "No es poden combinar llocs."
 
 #: ../gramps/plugins/lib/libplaceview.py:549
 msgid ""
-"Exactly two places must be selected to perform a merge. A second place can "
-"be selected by holding down the control key while clicking on the desired "
-"place."
+"Exactly two places must be selected to perform a merge. A second place can be"
+" selected by holding down the control key while clicking on the desired place."
 msgstr ""
-"S'han de seleccionar exactament dos llocs per fer una combinació. Es pot "
-"seleccionar el segon lloc mantenint premuda la tecla de control mentre es "
-"clica el lloc desitjat."
+"S'han de seleccionar exactament dos llocs per fer una combinació. Es pot"
+" seleccionar el segon lloc mantenint premuda la tecla de control mentre es"
+" clica el lloc desitjat."
 
 #: ../gramps/plugins/lib/libplaceview.py:557
 msgid "Merging these places would create a cycle in the place hierarchy."
@@ -30576,8 +30509,8 @@ msgstr "Proporciona substitució de variables en línies de visualització."
 msgid ""
 "Provides the base needed for the ancestor and descendant graphical reports."
 msgstr ""
-"Proporciona la base que cal per als informes gràfics d'avantpassats i "
-"descendents."
+"Proporciona la base que cal per als informes gràfics d'avantpassats i"
+" descendents."
 
 #: ../gramps/plugins/lib/libprogen.py:375
 #, python-format
@@ -30915,12 +30848,12 @@ msgstr "On desar les caselles per mode fora de línia."
 
 #: ../gramps/plugins/lib/maps/geography.py:1253
 msgid ""
-"If you have no more space in your file system. You can remove all tiles "
-"placed in the above path.\n"
+"If you have no more space in your file system. You can remove all tiles"
+" placed in the above path.\n"
 "Be careful! If you have no internet, you'll get no map."
 msgstr ""
-"Si no us queda espai al sistema de fitxers, podeu esborrar totes les "
-"caselles ubicades al camí anterior.\n"
+"Si no us queda espai al sistema de fitxers, podeu esborrar totes les caselles"
+" ubicades al camí anterior.\n"
 "Vigileu! Si no teniu internet, no podreu treure el mapa."
 
 #: ../gramps/plugins/lib/maps/geography.py:1258
@@ -31065,7 +30998,7 @@ msgid "Open on maps.google.com"
 msgstr "Obre a maps.google.com"
 
 #: ../gramps/plugins/mapservices/mapservice.gpr.py:71
-#: ../gramps/plugins/webreport/narrativeweb.py:2044
+#: ../gramps/plugins/webreport/narrativeweb.py:2048
 msgid "OpenStreetMap"
 msgstr "OpenStreetMap"
 
@@ -31399,7 +31332,7 @@ msgstr "Persones"
 #: ../gramps/plugins/webreport/basepage.py:1531
 #: ../gramps/plugins/webreport/basepage.py:1583
 #: ../gramps/plugins/webreport/basepage.py:1652
-#: ../gramps/plugins/webreport/person.py:1249
+#: ../gramps/plugins/webreport/person.py:1256
 #: ../gramps/plugins/webreport/source.py:130
 #: ../gramps/plugins/webreport/source.py:227
 msgid "Sources"
@@ -31476,12 +31409,12 @@ msgstr "Línia paterna per %s"
 
 #: ../gramps/plugins/quickview/lineage.py:54
 msgid ""
-"This report shows the father lineage, also called patronymic lineage or Y-"
-"line. People in this lineage all share the same Y-chromosome."
+"This report shows the father lineage, also called patronymic lineage or"
+" Y-line. People in this lineage all share the same Y-chromosome."
 msgstr ""
-"Aquest informe mostra la línia paterna, anomenada també línia patronímica, o "
-"línia-Y. Les persones d'aquesta línia comparteixen totes el mateix cromosoma "
-"Y."
+"Aquest informe mostra la línia paterna, anomenada també línia patronímica, o"
+" línia-Y. Les persones d'aquesta línia comparteixen totes el mateix cromosoma"
+" Y."
 
 #: ../gramps/plugins/quickview/lineage.py:61
 msgid "Name Father"
@@ -31506,12 +31439,12 @@ msgstr "Línia materna per %s"
 
 #: ../gramps/plugins/quickview/lineage.py:85
 msgid ""
-"This report shows the mother lineage, also called matronymic lineage mtDNA "
-"lineage. People in this lineage all share the same Mitochondrial DNA (mtDNA)."
+"This report shows the mother lineage, also called matronymic lineage mtDNA"
+" lineage. People in this lineage all share the same Mitochondrial DNA (mtDNA)."
 msgstr ""
-"Aquest informe mostra la línia materna, anomenada també línia matronímica o "
-"línia ADNm. Les persones d'aquesta línia comparteixen el mateix ADN "
-"mitocondrial (ADNm)."
+"Aquest informe mostra la línia materna, anomenada també línia matronímica o"
+" línia ADNm. Les persones d'aquesta línia comparteixen el mateix ADN"
+" mitocondrial (ADNm)."
 
 #: ../gramps/plugins/quickview/lineage.py:93
 msgid "Name Mother"
@@ -31688,8 +31621,8 @@ msgstr "Mostra les referències d'enllaç per una nota"
 msgid ""
 "Display the repository reference for sources related to the active repository"
 msgstr ""
-"Mostrar la referència al repositori per fonts relacionades amb el repositori "
-"actiu"
+"Mostrar la referència al repositori per fonts relacionades amb el repositori"
+" actiu"
 
 #: ../gramps/plugins/quickview/quickview.gpr.py:272
 msgid "Same Surnames"
@@ -31782,11 +31715,11 @@ msgid "There is {number_of} person with a matching name, or alternate name.\n"
 msgid_plural ""
 "There are {number_of} people with a matching name, or alternate name.\n"
 msgstr[0] ""
-"Hi ha {number_of} persona el nom (o el nom alternatiu) de les quals "
-"concorda.\n"
+"Hi ha {number_of} persona el nom (o el nom alternatiu) de les quals"
+" concorda.\n"
 msgstr[1] ""
-"Hi ha {number_of} persones el nom (o el nom alternatiu) de les quals "
-"concorda.\n"
+"Hi ha {number_of} persones el nom (o el nom alternatiu) de les quals"
+" concorda.\n"
 
 #. display the title
 #: ../gramps/plugins/quickview/samesurnames.py:158
@@ -32523,11 +32456,11 @@ msgstr "Incloure notes de fonts"
 #: ../gramps/plugins/textreport/detdescendantreport.py:1132
 #: ../gramps/plugins/textreport/indivcomplete.py:1116
 msgid ""
-"Whether to include source notes in the Endnotes section. Only works if "
-"Include sources is selected."
+"Whether to include source notes in the Endnotes section. Only works if"
+" Include sources is selected."
 msgstr ""
-"Si s'han d'incloure notes de fonts a la secció de Notes Finals. Només "
-"funciona si s'ha seleccionat Incloure Fonts."
+"Si s'han d'incloure notes de fonts a la secció de Notes Finals. Només"
+" funciona si s'ha seleccionat Incloure Fonts."
 
 #: ../gramps/plugins/textreport/detancestralreport.py:947
 #: ../gramps/plugins/textreport/detdescendantreport.py:1136
@@ -32677,11 +32610,11 @@ msgstr "Incloure senyal de successió ('+') a la llista de fills"
 
 #: ../gramps/plugins/textreport/detdescendantreport.py:1150
 msgid ""
-"Whether to include a sign ('+') before the descendant number in the child-"
-"list to indicate a child has succession."
+"Whether to include a sign ('+') before the descendant number in the"
+" child-list to indicate a child has succession."
 msgstr ""
-"Si s'ha d'incloure un senyal ('+') abans del número de descendent a la "
-"llista de fills per indicar que un fill té successió."
+"Si s'ha d'incloure un senyal ('+') abans del número de descendent a la llista"
+" de fills per indicar que un fill té successió."
 
 #: ../gramps/plugins/textreport/detdescendantreport.py:1155
 msgid "Include path to start-person"
@@ -32689,11 +32622,11 @@ msgstr "Incloure camí fins a la persona inicial"
 
 #: ../gramps/plugins/textreport/detdescendantreport.py:1156
 msgid ""
-"Whether to include the path of descendancy from the start-person to each "
-"descendant."
+"Whether to include the path of descendancy from the start-person to each"
+" descendant."
 msgstr ""
-"Si s'ha d'incloure el camí de descendència des de la persona inicial fins a "
-"cada descendent."
+"Si s'ha d'incloure el camí de descendència des de la persona inicial fins a"
+" cada descendent."
 
 #. feature request 2356: avoid genitive form
 #: ../gramps/plugins/textreport/endoflinereport.py:159
@@ -32827,8 +32760,8 @@ msgstr "Números de generació (només recursiu)"
 #: ../gramps/plugins/textreport/familygroup.py:804
 msgid "Whether to include the generation on each report (recursive only)."
 msgstr ""
-"Si s'ha d'incloure la generació a cada informe (només amb l'opció de "
-"recursió)."
+"Si s'ha d'incloure la generació a cada informe (només amb l'opció de"
+" recursió)."
 
 #: ../gramps/plugins/textreport/familygroup.py:808
 msgid "Print fields for missing information"
@@ -32859,7 +32792,7 @@ msgid "Alternate Parents"
 msgstr "Progenitors alternatius"
 
 #: ../gramps/plugins/textreport/indivcomplete.py:445
-#: ../gramps/plugins/webreport/person.py:1234
+#: ../gramps/plugins/webreport/person.py:1241
 msgid "Associations"
 msgstr "Associacions"
 
@@ -33028,8 +32961,8 @@ msgstr[1] "La generació {number} té {count} individus. {percent}"
 #: ../gramps/plugins/textreport/numberofancestorsreport.py:167
 #, python-format
 msgid ""
-"Total ancestors in generations %(second_generation)d to %(last_generation)d "
-"is %(count)d. %(percent)s"
+"Total ancestors in generations %(second_generation)d to %(last_generation)d"
+" is %(count)d. %(percent)s"
 msgstr ""
 "El total d'avantpassats en les generacions %(second_generation)d a "
 "%(last_generation)d és %(count)d. %(percent)s"
@@ -33128,8 +33061,8 @@ msgstr "Substitueix els noms de pila pel nom habitual"
 #: ../gramps/plugins/textreport/recordsreport.py:236
 msgid "Underline call name in first names / add call name to first name"
 msgstr ""
-"Subratllar el nom habitual dins del nom de pila / afegir nom habitual al nom "
-"de pila"
+"Subratllar el nom habitual dins del nom de pila / afegir nom habitual al nom"
+" de pila"
 
 #: ../gramps/plugins/textreport/recordsreport.py:240
 msgid "Footer text"
@@ -33187,11 +33120,11 @@ msgstr "Mida de l'imatge"
 
 #: ../gramps/plugins/textreport/simplebooktitle.py:158
 msgid ""
-"Size of the image in cm. A value of 0 indicates that the image should be fit "
-"to the page."
+"Size of the image in cm. A value of 0 indicates that the image should be fit"
+" to the page."
 msgstr ""
-"Mida de la imatge en cm. Un valor de 0 indica que la imatge s'ha d'adaptar a "
-"la mida de la pàgina."
+"Mida de la imatge en cm. Un valor de 0 indica que la imatge s'ha d'adaptar a"
+" la mida de la pàgina."
 
 #: ../gramps/plugins/textreport/summary.py:90
 #: ../gramps/plugins/textreport/textplugins.gpr.py:348
@@ -33353,11 +33286,11 @@ msgstr "Produeix un informe en text de final de llinatge"
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:192
 msgid ""
-"Produces a family group report showing information on a set of parents and "
-"their children."
+"Produces a family group report showing information on a set of parents and"
+" their children."
 msgstr ""
-"Crea un informe de grup familiar que mostra informació sobre uns pares i els "
-"seus fills."
+"Crea un informe de grup familiar que mostra informació sobre uns pares i els"
+" seus fills."
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:215
 msgid "Produces a complete report on the selected people"
@@ -33477,11 +33410,11 @@ msgstr "Construint visualització"
 
 #: ../gramps/plugins/tool/changetypes.glade:91
 msgid ""
-"This tool will rename all events of one type to a different type. Once "
-"completed, this cannot be undone by the regular Undo function."
+"This tool will rename all events of one type to a different type. Once"
+" completed, this cannot be undone by the regular Undo function."
 msgstr ""
-"Aquesta eina canviarà el nom de tots els esdeveniments d'un tipus a un tipus "
-"diferent. Quan hagi acabat, això no ho pot desfer la funció de Desfer normal."
+"Aquesta eina canviarà el nom de tots els esdeveniments d'un tipus a un tipus"
+" diferent. Quan hagi acabat, això no ho pot desfer la funció de Desfer normal."
 
 #: ../gramps/plugins/tool/changetypes.glade:112
 msgid "Original event type:"
@@ -33558,12 +33491,12 @@ msgstr "Reconstruint mapes de referències..."
 #: ../gramps/plugins/tool/check.py:298
 #, python-format
 msgid ""
-"Objects referenced by this note were referenced but missing so that is why "
-"they have been created when you ran Check and Repair on %s."
+"Objects referenced by this note were referenced but missing so that is why"
+" they have been created when you ran Check and Repair on %s."
 msgstr ""
-"Els objectes que referenciava aquesta nota estaven referenciats però no hi "
-"eren i per tant s'han creat quan heu executat una acció de Comprovar i "
-"Reparar sobre %s."
+"Els objectes que referenciava aquesta nota estaven referenciats però no hi"
+" eren i per tant s'han creat quan heu executat una acció de Comprovar i"
+" Reparar sobre %s."
 
 #: ../gramps/plugins/tool/check.py:320
 msgid "Looking for invalid name format references"
@@ -33616,8 +33549,8 @@ msgstr ""
 "el referencia la base de dades, però ja no existeix.\n"
 "El fitxer pot haver-se esborrat o mogut a una altra ubicació.\n"
 "Pot decidir treure'n la referència de la base de dades,\n"
-"mantenir-hi la referència al fitxer desaparegut, o seleccionar un altre "
-"fitxer."
+"mantenir-hi la referència al fitxer desaparegut, o seleccionar un altre"
+" fitxer."
 
 #: ../gramps/plugins/tool/check.py:894
 msgid "Looking for empty people records"
@@ -33735,8 +33668,7 @@ msgstr "La base de dades ha passat les comprovacions internes"
 #: ../gramps/plugins/tool/check.py:2419
 msgid "No errors were found: the database has passed internal checks."
 msgstr ""
-"No s'han trobat errors: la base de dades ha passat les comprovacions "
-"internes."
+"No s'han trobat errors: la base de dades ha passat les comprovacions internes."
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2426
@@ -34013,11 +33945,11 @@ msgstr "Voleu començar la prova de dates?"
 
 #: ../gramps/plugins/tool/dateparserdisplaytest.py:68
 msgid ""
-"This test will create many persons and events in the current database. Do "
-"you really want to run this test?"
+"This test will create many persons and events in the current database. Do you"
+" really want to run this test?"
 msgstr ""
-"Aquesta prova crearà moltes persones i esdeveniments a la base de dades "
-"actual. Realment vols executar aquesta prova?"
+"Aquesta prova crearà moltes persones i esdeveniments a la base de dades"
+" actual. Realment vols executar aquesta prova?"
 
 #: ../gramps/plugins/tool/dateparserdisplaytest.py:71
 msgid "Run test"
@@ -34103,11 +34035,11 @@ msgstr "_Filtre:"
 
 #: ../gramps/plugins/tool/eventcmp.glade:239
 msgid ""
-"The event comparison utility uses the filters defined in the Custom Filter "
-"Editor."
+"The event comparison utility uses the filters defined in the Custom Filter"
+" Editor."
 msgstr ""
-"La utilitat de comparació d'esdeveniments fa servir els filtres definits a "
-"l'Editor de Filtres Personalitzats."
+"La utilitat de comparació d'esdeveniments fa servir els filtres definits a"
+" l'Editor de Filtres Personalitzats."
 
 #: ../gramps/plugins/tool/eventcmp.glade:249
 msgid "Custom filter _editor"
@@ -34324,42 +34256,41 @@ msgstr "Selecció"
 #: ../gramps/plugins/tool/mediamanager.py:233
 #, python-format
 msgid ""
-"This tool allows batch operations on media objects stored in Gramps. An "
-"important distinction must be made between a Gramps media object and its "
-"file.\n"
+"This tool allows batch operations on media objects stored in Gramps. An"
+" important distinction must be made between a Gramps media object and its"
+" file.\n"
 "\n"
-"The Gramps media object is a collection of data about the media object file: "
-"its filename and/or path, its description, its ID, notes, source references, "
-"etc. These data %(bold_start)sdo not include the file itself%(bold_end)s.\n"
+"The Gramps media object is a collection of data about the media object file:"
+" its filename and/or path, its description, its ID, notes, source references,"
+" etc. These data %(bold_start)sdo not include the file itself%(bold_end)s.\n"
 "\n"
-"The files containing image, sound, video, etc, exist separately on your hard "
-"drive. These files are not managed by Gramps and are not included in the "
-"Gramps database. The Gramps database only stores the path and file names.\n"
+"The files containing image, sound, video, etc, exist separately on your hard"
+" drive. These files are not managed by Gramps and are not included in the"
+" Gramps database. The Gramps database only stores the path and file names.\n"
 "\n"
-"This tool allows you to only modify the records within your Gramps database. "
-"If you want to move or rename the files then you need to do it on your own, "
-"outside of Gramps. Then you can adjust the paths using this tool so that the "
-"media objects store the correct file locations."
+"This tool allows you to only modify the records within your Gramps database."
+" If you want to move or rename the files then you need to do it on your own,"
+" outside of Gramps. Then you can adjust the paths using this tool so that the"
+" media objects store the correct file locations."
 msgstr ""
-"Aquesta eina permet operacions massives sobre objectes audiovisuals "
-"emmagatzemats a Gramps. Cal fer una distinció important entre un objecte "
-"audiovisual de Gramps i el seu fitxer.\n"
+"Aquesta eina permet operacions massives sobre objectes audiovisuals"
+" emmagatzemats a Gramps. Cal fer una distinció important entre un objecte"
+" audiovisual de Gramps i el seu fitxer.\n"
 "\n"
-"L'objecte audiovisual Gramps és una agrupació de dades sobre el fitxer "
-"audiovisual: el seu nom i/o camí, la seva descripció, el seu Id, notes, "
-"referències al a font, etc. Aquestes dades %(bold_start)sno inclouen el "
-"propi fitxer%(bold_end)s.\n"
+"L'objecte audiovisual Gramps és una agrupació de dades sobre el fitxer"
+" audiovisual: el seu nom i/o camí, la seva descripció, el seu Id, notes,"
+" referències al a font, etc. Aquestes dades %(bold_start)sno inclouen el"
+" propi fitxer%(bold_end)s.\n"
 "\n"
-"Els fitxers que contenen imatges, so, vídeo, etc, existeixen per separat al "
-"disc dur. Aquests fitxers no els gestiona Gramps i no estan inclosos dins de "
-"la base de dades Gramps. La base de dades Gramps només emmagatzema el camí i "
-"els noms de fitxer.\n"
+"Els fitxers que contenen imatges, so, vídeo, etc, existeixen per separat al"
+" disc dur. Aquests fitxers no els gestiona Gramps i no estan inclosos dins de"
+" la base de dades Gramps. La base de dades Gramps només emmagatzema el camí i"
+" els noms de fitxer.\n"
 "\n"
-"Aquesta eina només permet de modificar els registres dins de la base de "
-"dades Gramps. Si vol moure o canviar el nom dels fitxers, ha de fer-ho pel "
-"seu compte, fora de Gramps. Després pot modificar els camins amb aquesta "
-"eina perquè els objectes de medis tinguin les ubicacions correctes de cada "
-"fitxer."
+"Aquesta eina només permet de modificar els registres dins de la base de dades"
+" Gramps. Si vol moure o canviar el nom dels fitxers, ha de fer-ho pel seu"
+" compte, fora de Gramps. Després pot modificar els camins amb aquesta eina"
+" perquè els objectes de medis tinguin les ubicacions correctes de cada fitxer."
 
 #: ../gramps/plugins/tool/mediamanager.py:344
 msgid "Affected path"
@@ -34369,8 +34300,8 @@ msgstr "Camí afectat"
 msgid ""
 "Press Apply to proceed, Cancel to abort, or Back to revisit your options."
 msgstr ""
-"Premi OK per continuar, Cancel·lar per avortar, o Enrere per revisar les "
-"opcions."
+"Premi OK per continuar, Cancel·lar per avortar, o Enrere per revisar les"
+" opcions."
 
 #: ../gramps/plugins/tool/mediamanager.py:389
 msgid "Operation successfully finished"
@@ -34378,11 +34309,11 @@ msgstr "Operació finalitzada satisfactòriament"
 
 #: ../gramps/plugins/tool/mediamanager.py:391
 msgid ""
-"The operation you requested has finished successfully. You may press Close "
-"now to continue."
+"The operation you requested has finished successfully. You may press Close"
+" now to continue."
 msgstr ""
-"L'operació que heu demanat ha acabat satisfactòriament. Pot prémer el botó "
-"de Tancar per continuar."
+"L'operació que heu demanat ha acabat satisfactòriament. Pot prémer el botó de"
+" Tancar per continuar."
 
 #: ../gramps/plugins/tool/mediamanager.py:394
 msgid "Operation failed"
@@ -34390,11 +34321,11 @@ msgstr "L'operació ha fallat"
 
 #: ../gramps/plugins/tool/mediamanager.py:396
 msgid ""
-"There was an error while performing the requested operation. You may try "
-"starting the tool again."
+"There was an error while performing the requested operation. You may try"
+" starting the tool again."
 msgstr ""
-"Hi ha hagut un error en fer l'operació demanada. Pot provar de tornar a "
-"engegar l'eina."
+"Hi ha hagut un error en fer l'operació demanada. Pot provar de tornar a"
+" engegar l'eina."
 
 #: ../gramps/plugins/tool/mediamanager.py:431
 #, python-format
@@ -34413,13 +34344,13 @@ msgstr "_Substitueix subcadenes dins el camí"
 
 #: ../gramps/plugins/tool/mediamanager.py:489
 msgid ""
-"This tool allows replacing specified substring in the path of media objects "
-"with another substring. This can be useful when you move your media files "
-"from one directory to another"
+"This tool allows replacing specified substring in the path of media objects"
+" with another substring. This can be useful when you move your media files"
+" from one directory to another"
 msgstr ""
-"Aquesta eina permet de substituir subcadenes especificades en el camí "
-"d'objectes audiovisuals per una altra subcadena. Això pot ser útil per moure "
-"els fitxer de medis audiovisuals d'un directori cap a un altre"
+"Aquesta eina permet de substituir subcadenes especificades en el camí"
+" d'objectes audiovisuals per una altra subcadena. Això pot ser útil per moure"
+" els fitxer de medis audiovisuals d'un directori cap a un altre"
 
 #: ../gramps/plugins/tool/mediamanager.py:495
 msgid "Replace substring settings"
@@ -34454,13 +34385,13 @@ msgstr "Convertir camins de carpeta de relatiu a _absolut"
 
 #: ../gramps/plugins/tool/mediamanager.py:574
 msgid ""
-"This tool allows converting relative media paths to the absolute ones. It "
-"does this by prepending the base path as given in the Preferences, or if "
-"that is not set, it prepends user's directory."
+"This tool allows converting relative media paths to the absolute ones. It"
+" does this by prepending the base path as given in the Preferences, or if"
+" that is not set, it prepends user's directory."
 msgstr ""
-"Aquesta eina permet de convertir camins relatius de medis audiovisuals en "
-"absoluts. Ho fa prefixant-hi el camí base donat a les Preferències, o, si no "
-"hi està omplert, hi prefixa el directori de l'usuari."
+"Aquesta eina permet de convertir camins relatius de medis audiovisuals en"
+" absoluts. Ho fa prefixant-hi el camí base donat a les Preferències, o, si no"
+" hi està omplert, hi prefixa el directori de l'usuari."
 
 #: ../gramps/plugins/tool/mediamanager.py:607
 msgid "Convert paths from absolute to r_elative"
@@ -34468,16 +34399,16 @@ msgstr "Convertir camins de carpeta d'absolut a r_elatiu"
 
 #: ../gramps/plugins/tool/mediamanager.py:608
 msgid ""
-"This tool allows converting absolute media paths to a relative path. The "
-"relative path is relative viz-a-viz the base path as given in the "
-"Preferences, or if that is not set, user's directory. A relative path allows "
-"to tie the file location to a base path that can change to your needs."
+"This tool allows converting absolute media paths to a relative path. The"
+" relative path is relative viz-a-viz the base path as given in the"
+" Preferences, or if that is not set, user's directory. A relative path allows"
+" to tie the file location to a base path that can change to your needs."
 msgstr ""
-"Aquesta eina permet de convertir camins de medis absoluts en relatius. El "
-"camí relatiu es fa respecte el camí base donat a les Preferències, o si no "
-"està donat, el directori base de l'usuari. Un camí relatiu permet de donar "
-"la posició del fitxer respecte un camí base que pot canviar segons les "
-"pròpies necessitats."
+"Aquesta eina permet de convertir camins de medis absoluts en relatius. El"
+" camí relatiu es fa respecte el camí base donat a les Preferències, o si no"
+" està donat, el directori base de l'usuari. Un camí relatiu permet de donar"
+" la posició del fitxer respecte un camí base que pot canviar segons les"
+" pròpies necessitats."
 
 #: ../gramps/plugins/tool/mediamanager.py:644
 msgid "Add images not included in database"
@@ -34489,11 +34420,11 @@ msgstr "Busca en directoris les imatges no incloses a la base de dades"
 
 #: ../gramps/plugins/tool/mediamanager.py:646
 msgid ""
-"This tool adds images in directories that are referenced by existing images "
-"in the database."
+"This tool adds images in directories that are referenced by existing images"
+" in the database."
 msgstr ""
-"Aquesta eina afegeix imatges en directoris que estan referenciats per les "
-"imatges existents a la base de dades."
+"Aquesta eina afegeix imatges en directoris que estan referenciats per les"
+" imatges existents a la base de dades."
 
 #: ../gramps/plugins/tool/mergecitations.glade:144
 msgid "Don't merge if citation has notes"
@@ -34523,8 +34454,8 @@ msgstr "Combina_cites"
 msgid ""
 "Notes, media objects and data-items of matching citations will be combined."
 msgstr ""
-"Es combinaran les notes, objectes audiovisuals, i elements de dades de les "
-"cites que concordin."
+"Es combinaran les notes, objectes audiovisuals, i elements de dades de les"
+" cites que concordin."
 
 #: ../gramps/plugins/tool/mergecitations.py:164
 msgid "Merge citations tool"
@@ -34661,32 +34592,32 @@ msgstr "_Accepta i tanca"
 
 #: ../gramps/plugins/tool/patchnames.glade:135
 msgid ""
-"Below is a list of the nicknames, titles, prefixes and compound surnames "
-"that Gramps can extract from the Family Tree.\n"
-"If you accept the changes, Gramps will modify the entries that have been "
-"selected.\n"
+"Below is a list of the nicknames, titles, prefixes and compound surnames that"
+" Gramps can extract from the Family Tree.\n"
+"If you accept the changes, Gramps will modify the entries that have been"
+" selected.\n"
 "\n"
 "Compound surnames are shown as lists of [prefix, surname, connector].\n"
-"For example, with the defaults, the name \"de Mascarenhas da Silva e "
-"Lencastre\" shows as:\n"
+"For example, with the defaults, the name \"de Mascarenhas da Silva e"
+" Lencastre\" shows as:\n"
 "       [de, Mascarenhas]-[da, Silva, e]-[,Lencastre]\n"
 "\n"
-"Run this tool several times to correct names that have multiple information "
-"that can be extracted."
+"Run this tool several times to correct names that have multiple information"
+" that can be extracted."
 msgstr ""
-"A sota hi ha una llista dels sobrenoms, títols, prefixos i cognoms compostos "
-"que Gramps pot extreure de l'Arbre Genealògic.\n"
-"Si accepteu els canvis, Gramps modificarà les entrades que s'hagin "
-"seleccionat.\n"
+"A sota hi ha una llista dels sobrenoms, títols, prefixos i cognoms compostos"
+" que Gramps pot extreure de l'Arbre Genealògic.\n"
+"Si accepteu els canvis, Gramps modificarà les entrades que s'hagin"
+" seleccionat.\n"
 "\n"
-"Els cognoms compostos es mostren com a llistes de [prefix, cognom, "
-"connector].\n"
-"Per exemple, amb les opcions predeterminades, el nom \"de Mascarenhas da "
-"Silva e Lencastre\" surt com a:\n"
+"Els cognoms compostos es mostren com a llistes de [prefix, cognom,"
+" connector].\n"
+"Per exemple, amb les opcions predeterminades, el nom \"de Mascarenhas da"
+" Silva e Lencastre\" surt com a:\n"
 "       [de, Mascarenhas]-[da, Silva, e]-[,Lencastre]\n"
 "\n"
-"Executeu aquesta eina unes quantes vegades per corregir els noms que tenen "
-"informació múltiple que es pugui extreure."
+"Executeu aquesta eina unes quantes vegades per corregir els noms que tenen"
+" informació múltiple que es pugui extreure."
 
 #: ../gramps/plugins/tool/patchnames.py:63
 msgid "manual|Extract_Information_from_Names"
@@ -34764,8 +34695,8 @@ msgstr "Estadístiques de gènere reconstruïdes"
 #: ../gramps/plugins/tool/rebuildgenderstat.py:96
 msgid "Gender statistics for name gender guessing have been rebuilt."
 msgstr ""
-"Les estadístiques de gènere per endevinar el gènere amb el nom s'han "
-"reconstruït."
+"Les estadístiques de gènere per endevinar el gènere amb el nom s'han"
+" reconstruït."
 
 #: ../gramps/plugins/tool/rebuildrefmap.py:91
 msgid "Reference maps rebuilt"
@@ -34823,8 +34754,8 @@ msgstr ""
 
 #: ../gramps/plugins/tool/removespaces.py:104
 msgid ""
-"Search leading and/or trailing spaces for persons and places. Search comma "
-"in coordinates fields.\n"
+"Search leading and/or trailing spaces for persons and places. Search comma in"
+" coordinates fields.\n"
 "Double click on a row to edit its content."
 msgstr ""
 
@@ -34991,27 +34922,27 @@ msgid "manual|Reorder_Gramps_ID"
 msgstr "Reordena_Gramps_ID"
 
 #. self.top.set_icon(ICON)
-#: ../gramps/plugins/tool/reorderids.py:218
-#: ../gramps/plugins/tool/reorderids.py:441
-#: ../gramps/plugins/tool/reorderids.py:533
-#: ../gramps/plugins/tool/reorderids.py:616
-#: ../gramps/plugins/tool/reorderids.py:621
+#: ../gramps/plugins/tool/reorderids.py:221
+#: ../gramps/plugins/tool/reorderids.py:444
+#: ../gramps/plugins/tool/reorderids.py:536
+#: ../gramps/plugins/tool/reorderids.py:626
+#: ../gramps/plugins/tool/reorderids.py:631
 #: ../gramps/plugins/tool/tools.gpr.py:375
 msgid "Reorder Gramps IDs"
 msgstr "Reordena IDs de Gramps"
 
-#: ../gramps/plugins/tool/reorderids.py:544
-#: ../gramps/plugins/tool/reorderids.py:549
+#: ../gramps/plugins/tool/reorderids.py:547
+#: ../gramps/plugins/tool/reorderids.py:552
 #, python-format
 msgid "Reorder %s IDs ..."
 msgstr "Reordena %s IDs ..."
 
-#: ../gramps/plugins/tool/reorderids.py:625
+#: ../gramps/plugins/tool/reorderids.py:635
 #, python-format
 msgid "Do you want to replace %s?"
 msgstr "Vols substituir %s?"
 
-#: ../gramps/plugins/tool/reorderids.py:684
+#: ../gramps/plugins/tool/reorderids.py:694
 msgid "Finding and assigning unused IDs."
 msgstr "Cerca i assigna ID's no utilitzades."
 
@@ -35198,8 +35129,8 @@ msgstr "Arreglar Majúscules de Noms de Famílies"
 msgid ""
 "Searches the entire database and attempts to fix capitalization of the names."
 msgstr ""
-"Busca tota la base de dades i intenta d'arreglar les majúscules i minúscules "
-"dels noms."
+"Busca tota la base de dades i intenta d'arreglar les majúscules i minúscules"
+" dels noms."
 
 #: ../gramps/plugins/tool/tools.gpr.py:61
 msgid "Rename Event Types"
@@ -35218,8 +35149,8 @@ msgstr "Comprovar i Reparar la Base de Dades"
 msgid ""
 "Checks the database for integrity problems, fixing the problems that it can"
 msgstr ""
-"Busca problemes d'integritat a la base de dades, solucionant els problemes "
-"que pugui"
+"Busca problemes d'integritat a la base de dades, solucionant els problemes"
+" que pugui"
 
 #: ../gramps/plugins/tool/tools.gpr.py:107
 msgid "Compare Individual Events"
@@ -35227,12 +35158,12 @@ msgstr "Comparar Esdeveniments Individuals"
 
 #: ../gramps/plugins/tool/tools.gpr.py:108
 msgid ""
-"Aids in the analysis of data by allowing the development of custom filters "
-"that can be applied to the database to find similar events"
+"Aids in the analysis of data by allowing the development of custom filters"
+" that can be applied to the database to find similar events"
 msgstr ""
-"Ajuda l'anàlisi de les dades permetent el desenvolupament de filtres "
-"personalitzats que es poden aplicar a la base de dades per localitzar "
-"esdeveniments semblants"
+"Ajuda l'anàlisi de les dades permetent el desenvolupament de filtres"
+" personalitzats que es poden aplicar a la base de dades per localitzar"
+" esdeveniments semblants"
 
 #: ../gramps/plugins/tool/tools.gpr.py:132
 msgid "Extracts event descriptions from the event data"
@@ -35240,11 +35171,11 @@ msgstr "Extreu descripcions de l'esdeveniment a partir de les seves dades"
 
 #: ../gramps/plugins/tool/tools.gpr.py:154
 msgid ""
-"Searches the entire database, looking for individual entries that may "
-"represent the same person."
+"Searches the entire database, looking for individual entries that may"
+" represent the same person."
 msgstr ""
-"Busca tota la base de dades, buscant entrades individuals que puguin "
-"representar la mateixa persona."
+"Busca tota la base de dades, buscant entrades individuals que puguin"
+" representar la mateixa persona."
 
 #: ../gramps/plugins/tool/tools.gpr.py:177
 msgid "Manages batch operations on media files"
@@ -35257,8 +35188,8 @@ msgstr "No Emparentats"
 #: ../gramps/plugins/tool/tools.gpr.py:199
 msgid "Find people who are not in any way related to the selected person"
 msgstr ""
-"Busca les persones que no tenen cap mena de parentesc amb la persona "
-"seleccionada"
+"Busca les persones que no tenen cap mena de parentesc amb la persona"
+" seleccionada"
 
 #: ../gramps/plugins/tool/tools.gpr.py:221
 msgid "Edit Database Owner Information"
@@ -35274,8 +35205,7 @@ msgstr "Extreure Informació dels Noms"
 
 #: ../gramps/plugins/tool/tools.gpr.py:244
 msgid ""
-"Extract titles, prefixes and compound surnames from given name or family "
-"name."
+"Extract titles, prefixes and compound surnames from given name or family name."
 msgstr ""
 "Extreure títols, prefixos i cognoms compostos del nom donat o nom de família."
 
@@ -35302,8 +35232,8 @@ msgstr "Reconstruir Estadístiques de Gènere"
 #: ../gramps/plugins/tool/tools.gpr.py:310
 msgid "Rebuilds gender statistics for name gender guessing..."
 msgstr ""
-"Reconstrueix les estadístiques de gènere per endevinar el gènere a partir "
-"del nom..."
+"Reconstrueix les estadístiques de gènere per endevinar el gènere a partir del"
+" nom..."
 
 #: ../gramps/plugins/tool/tools.gpr.py:332
 msgid "Calculates the relationship between two people"
@@ -35337,11 +35267,11 @@ msgstr "Verifica les dades amb proves definides per l'usuari"
 
 #: ../gramps/plugins/tool/tools.gpr.py:443
 msgid ""
-"Searches the entire database, looking for citations that have the same "
-"Volume/Page, Date and Confidence."
+"Searches the entire database, looking for citations that have the same"
+" Volume/Page, Date and Confidence."
 msgstr ""
-"Busca tota la base de dades, buscant cites que tinguin els mateixos Volum/"
-"Pàgina, Data i Confiança."
+"Busca tota la base de dades, buscant cites que tinguin els mateixos"
+" Volum/Pàgina, Data i Confiança."
 
 #: ../gramps/plugins/tool/tools.gpr.py:466
 msgid "Searches the entire database, looking for a possible loop."
@@ -35350,11 +35280,11 @@ msgstr "Busca tota la base de dades, buscant un possible bucle."
 #: ../gramps/plugins/tool/tools.gpr.py:490
 #, fuzzy
 msgid ""
-"Searches the entire database, looking for trailing or leading spaces for "
-"places and people. Search comma in coordinates fields in places."
+"Searches the entire database, looking for trailing or leading spaces for"
+" places and people. Search comma in coordinates fields in places."
 msgstr ""
-"Busca tota la base de dades, buscant cites que tinguin els mateixos Volum/"
-"Pàgina, Data i Confiança."
+"Busca tota la base de dades, buscant cites que tinguin els mateixos"
+" Volum/Pàgina, Data i Confiança."
 
 #: ../gramps/plugins/tool/toolsdebug.gpr.py:64
 msgid "Dump Gender Statistics"
@@ -35672,15 +35602,15 @@ msgstr "Editor de Filtres de Cita"
 
 #: ../gramps/plugins/view/citationlistview.py:395
 msgid ""
-"This citation cannot be edited at this time. Either the associated citation "
-"is already being edited or another object that is associated with the same "
-"citation is being edited.\n"
+"This citation cannot be edited at this time. Either the associated citation"
+" is already being edited or another object that is associated with the same"
+" citation is being edited.\n"
 "\n"
 "To edit this citation, you need to close the object."
 msgstr ""
-"Aquesta cita no es pot editar en aquest moment. O bé la cita associada ja "
-"s'està editant, o s'està editant un altre objecte que està associat amb la "
-"mateixa cita.\n"
+"Aquesta cita no es pot editar en aquest moment. O bé la cita associada ja"
+" s'està editant, o s'està editant un altre objecte que està associat amb la"
+" mateixa cita.\n"
 "\n"
 "Per editar aquesta cita, cal tancar l'objecte."
 
@@ -35694,23 +35624,23 @@ msgstr "No es poden combinar cites."
 #: ../gramps/plugins/view/citationlistview.py:409
 #: ../gramps/plugins/view/citationtreeview.py:665
 msgid ""
-"Exactly two citations must be selected to perform a merge. A second citation "
-"can be selected by holding down the control key while clicking on the "
-"desired citation."
+"Exactly two citations must be selected to perform a merge. A second citation"
+" can be selected by holding down the control key while clicking on the"
+" desired citation."
 msgstr ""
-"Cal seleccionar exactament dues cites per dur a terme una combinació. Es pot "
-"seleccionar una segona cita prement la tecla de control mentre es clica la "
-"cita desitjada."
+"Cal seleccionar exactament dues cites per dur a terme una combinació. Es pot"
+" seleccionar una segona cita prement la tecla de control mentre es clica la"
+" cita desitjada."
 
 #: ../gramps/plugins/view/citationlistview.py:420
 #: ../gramps/plugins/view/citationtreeview.py:678
 msgid ""
-"The two selected citations must have the same source to perform a merge. If "
-"you want to merge these two citations, then you must merge the sources first."
+"The two selected citations must have the same source to perform a merge. If"
+" you want to merge these two citations, then you must merge the sources first."
 msgstr ""
-"Les dues cites seleccionades han de tenir la mateixa font per dur a terme "
-"una combinació. Si voleu combinar aquestes dues cites, primer heu de "
-"combinar les fonts."
+"Les dues cites seleccionades han de tenir la mateixa font per dur a terme una"
+" combinació. Si voleu combinar aquestes dues cites, primer heu de combinar"
+" les fonts."
 
 #: ../gramps/plugins/view/citationtreeview.py:124
 msgid "Edit the selected citation or source"
@@ -35753,15 +35683,15 @@ msgstr "Expandir tots els Nodes"
 
 #: ../gramps/plugins/view/citationtreeview.py:651
 msgid ""
-"This source cannot be edited at this time. Either the associated Source "
-"object is already being edited, or another citation associated with the same "
-"source is being edited.\n"
+"This source cannot be edited at this time. Either the associated Source"
+" object is already being edited, or another citation associated with the same"
+" source is being edited.\n"
 "\n"
 "To edit this source, you need to close the object."
 msgstr ""
-"Aquesta font no es pot editar en aquest moment. Pot ser que ja s'estigui "
-"editant l'objecte Font associat o que una altra cita que estigui associada "
-"amb la mateixa font s'estigui editant.\n"
+"Aquesta font no es pot editar en aquest moment. Pot ser que ja s'estigui"
+" editant l'objecte Font associat o que una altra cita que estigui associada"
+" amb la mateixa font s'estigui editant.\n"
 "\n"
 "Per editar aquesta font, cal tancar l'objecte."
 
@@ -35771,11 +35701,11 @@ msgstr "No es pot dur a terme la combinació."
 
 #: ../gramps/plugins/view/citationtreeview.py:691
 msgid ""
-"Both objects must be of the same type, either both must be sources, or both "
-"must be citations."
+"Both objects must be of the same type, either both must be sources, or both"
+" must be citations."
 msgstr ""
-"Tots dos objectes han de ser del mateix tipus, o bé tots dos han de ser "
-"fonts, o tots dos han de ser cites."
+"Tots dos objectes han de ser del mateix tipus, o bé tots dos han de ser"
+" fonts, o tots dos han de ser cites."
 
 #: ../gramps/plugins/view/dashboardview.py:51
 #: ../gramps/plugins/view/dashboardview.py:83
@@ -35819,13 +35749,13 @@ msgstr "No es poden combinar objectes d'esdeveniment."
 
 #: ../gramps/plugins/view/eventview.py:444
 msgid ""
-"Exactly two events must be selected to perform a merge. A second object can "
-"be selected by holding down the control key while clicking on the desired "
-"event."
+"Exactly two events must be selected to perform a merge. A second object can"
+" be selected by holding down the control key while clicking on the desired"
+" event."
 msgstr ""
-"Cal seleccionar exactament dos esdeveniments per fer una combinació. Es pot "
-"seleccionar un segon objecte prement la tecla de control mentre es clica "
-"l'esdeveniment desitjat."
+"Cal seleccionar exactament dos esdeveniments per fer una combinació. Es pot"
+" seleccionar un segon objecte prement la tecla de control mentre es clica"
+" l'esdeveniment desitjat."
 
 #: ../gramps/plugins/view/familyview.py:83
 msgid "Marriage Date"
@@ -35874,13 +35804,13 @@ msgstr "No es poden combinar famílies."
 
 #: ../gramps/plugins/view/familyview.py:433
 msgid ""
-"Exactly two families must be selected to perform a merge. A second family "
-"can be selected by holding down the control key while clicking on the "
-"desired family."
+"Exactly two families must be selected to perform a merge. A second family can"
+" be selected by holding down the control key while clicking on the desired"
+" family."
 msgstr ""
-"S'han de seleccionar exactament dues famílies per fer una combinació. Es pot "
-"seleccionar una segona família mantenint premuda la tecla de control mentre "
-"es clica la família desitjada."
+"S'han de seleccionar exactament dues famílies per fer una combinació. Es pot"
+" seleccionar una segona família mantenint premuda la tecla de control mentre"
+" es clica la família desitjada."
 
 #: ../gramps/plugins/view/fanchart2wayview.py:280
 msgid "Max ancestor generations"
@@ -36016,7 +35946,7 @@ msgstr "Mostra l'última pàgina"
 #: ../gramps/plugins/view/fanchart2wayview.py:346
 #: ../gramps/plugins/view/fanchartdescview.py:345
 #: ../gramps/plugins/view/fanchartview.py:437
-#: ../gramps/plugins/view/pedigreeview.py:2128
+#: ../gramps/plugins/view/pedigreeview.py:2129
 #: ../gramps/plugins/view/relview.py:1882
 msgid "Layout"
 msgstr "Col·locació"
@@ -36112,11 +36042,11 @@ msgstr "Heu de triar una persona de referència."
 
 #: ../gramps/plugins/view/geoclose.py:327
 msgid ""
-"Go to the person view and select the people you want to compare. Return to "
-"this view and use the history."
+"Go to the person view and select the people you want to compare. Return to"
+" this view and use the history."
 msgstr ""
-"Aneu a la vista de persona i seleccioneu les persones que voleu comparar. "
-"Torneu a aquesta vista i utilitzeu la història."
+"Aneu a la vista de persona i seleccioneu les persones que voleu comparar."
+" Torneu a aquesta vista i utilitzeu la història."
 
 #: ../gramps/plugins/view/geoclose.py:385
 msgid "Select the person which will be our reference."
@@ -36176,13 +36106,13 @@ msgstr "Seleccionant tots els esdeveniments"
 #: ../gramps/plugins/view/geoevents.py:368
 #, fuzzy
 msgid ""
-"Right click on the map and select 'show all events' to show all known events "
-"with coordinates. You can use the history to navigate on the map. You can "
-"use filtering."
+"Right click on the map and select 'show all events' to show all known events"
+" with coordinates. You can use the history to navigate on the map. You can"
+" use filtering."
 msgstr ""
-"Clic dret al mapa i selecciona 'mostra tots els llocs' per mostrar tots els "
-"llocs coneguts amb coordenades. Pots canviar el color dels marcadors "
-"depenent del tipus de lloc. Pots utilitzar el filtrat."
+"Clic dret al mapa i selecciona 'mostra tots els llocs' per mostrar tots els"
+" llocs coneguts amb coordenades. Pots canviar el color dels marcadors"
+" depenent del tipus de lloc. Pots utilitzar el filtrat."
 
 #: ../gramps/plugins/view/geoevents.py:408
 #: ../gramps/plugins/view/geoevents.py:440
@@ -36241,11 +36171,11 @@ msgstr "Heu de triar una família de referència."
 
 #: ../gramps/plugins/view/geofamclose.py:357
 msgid ""
-"Go to the family view and select the families you want to compare. Return to "
-"this view and use the history."
+"Go to the family view and select the families you want to compare. Return to"
+" this view and use the history."
 msgstr ""
-"Aneu a la vista de família i seleccioneu les famílies que voleu comparar. "
-"Torneu a aquesta vista i utilitzeu la història."
+"Aneu a la vista de família i seleccioneu les famílies que voleu comparar."
+" Torneu a aquesta vista i utilitzeu la història."
 
 #: ../gramps/plugins/view/geofamclose.py:681
 #: ../gramps/plugins/view/geofamily.py:396
@@ -36346,14 +36276,13 @@ msgstr "Tots els llocs coneguts per a una Família"
 #: ../gramps/plugins/view/geography.gpr.py:105
 msgid "A view showing the places visited by one family during all their life."
 msgstr ""
-"Una vista que mostra els llocs visitats per una família al llarg de tota la "
-"seva vida."
+"Una vista que mostra els llocs visitats per una família al llarg de tota la"
+" seva vida."
 
 #: ../gramps/plugins/view/geography.gpr.py:121
 msgid "Every residence or move for a person and any descendants"
 msgstr ""
-"Totes les residències o desplaçaments per a una persona i els seus "
-"descendents"
+"Totes les residències o desplaçaments per a una persona i els seus descendents"
 
 #: ../gramps/plugins/view/geography.gpr.py:123
 msgid ""
@@ -36361,27 +36290,27 @@ msgid ""
 "This is for a person and any descendant.\n"
 "You can see the dates corresponding to the period."
 msgstr ""
-"Una vista que mostra tots els llocs visitats per totes les persones al llarg "
-"de la seva vida.\n"
+"Una vista que mostra tots els llocs visitats per totes les persones al llarg"
+" de la seva vida.\n"
 "Això és per una persona i els seus descendents.\n"
 "Podeu veure les dates que corresponen al període."
 
 #: ../gramps/plugins/view/geography.gpr.py:143
 msgid ""
-"A view showing the places visited by all family's members during their life: "
-"have these two people been able to meet?"
+"A view showing the places visited by all family's members during their life:"
+" have these two people been able to meet?"
 msgstr ""
-"Una vista que permet de veure els llocs visitats per tots els membres d'una "
-"família al llarg de la seva vida: poden haver-se conegut aquestes dues "
-"persones?"
+"Una vista que permet de veure els llocs visitats per tots els membres d'una"
+" família al llarg de la seva vida: poden haver-se conegut aquestes dues"
+" persones?"
 
 #: ../gramps/plugins/view/geography.gpr.py:161
 msgid ""
-"A view showing the places visited by two persons during their life: have "
-"these two people been able to meet?"
+"A view showing the places visited by two persons during their life: have"
+" these two people been able to meet?"
 msgstr ""
-"Una vista que permet de veure els llocs visitats per dues persones al llarg "
-"de la seva vida: poden haver-se conegut aquestes dues persones?"
+"Una vista que permet de veure els llocs visitats per dues persones al llarg"
+" de la seva vida: poden haver-se conegut aquestes dues persones?"
 
 #: ../gramps/plugins/view/geography.gpr.py:178
 msgid "All known Places"
@@ -36481,24 +36410,24 @@ msgstr "Seleccionant tots els llocs"
 
 #: ../gramps/plugins/view/geoplaces.py:432
 msgid ""
-"Right click on the map and select 'show all places' to show all known places "
-"with coordinates. You can change the markers color depending on place type. "
-"You can use filtering."
+"Right click on the map and select 'show all places' to show all known places"
+" with coordinates. You can change the markers color depending on place type."
+" You can use filtering."
 msgstr ""
-"Clic dret al mapa i selecciona 'mostra tots els llocs' per mostrar tots els "
-"llocs coneguts amb coordenades. Pots canviar el color dels marcadors "
-"depenent del tipus de lloc. Pots utilitzar el filtrat."
+"Clic dret al mapa i selecciona 'mostra tots els llocs' per mostrar tots els"
+" llocs coneguts amb coordenades. Pots canviar el color dels marcadors"
+" depenent del tipus de lloc. Pots utilitzar el filtrat."
 
 #: ../gramps/plugins/view/geoplaces.py:447
 msgid ""
-"Right click on the map and select 'show all places' to show all known places "
-"with coordinates. You can use the history to navigate on the map. You can "
-"change the markers color depending on place type. You can use filtering."
+"Right click on the map and select 'show all places' to show all known places"
+" with coordinates. You can use the history to navigate on the map. You can"
+" change the markers color depending on place type. You can use filtering."
 msgstr ""
-"Clic dret al mapa i selecciona 'mostra tots els llocs' per mostrar tots els "
-"llocs coneguts amb coordenades. Pot utilitzar l'historial i navegar sobre el "
-"mapa. Pots canviar el color dels marcadors depenent del tipus de lloc. Pots "
-"utilitzar el filtrat."
+"Clic dret al mapa i selecciona 'mostra tots els llocs' per mostrar tots els"
+" llocs coneguts amb coordenades. Pot utilitzar l'historial i navegar sobre el"
+" mapa. Pots canviar el color dels marcadors depenent del tipus de lloc. Pots"
+" utilitzar el filtrat."
 
 #: ../gramps/plugins/view/geoplaces.py:462
 msgid "The place name in the status bar is disabled."
@@ -36570,13 +36499,13 @@ msgstr "No es poden combinar medis audiovisuals."
 
 #: ../gramps/plugins/view/mediaview.py:484
 msgid ""
-"Exactly two media objects must be selected to perform a merge. A second "
-"object can be selected by holding down the control key while clicking on the "
-"desired object."
+"Exactly two media objects must be selected to perform a merge. A second"
+" object can be selected by holding down the control key while clicking on the"
+" desired object."
 msgstr ""
-"Cal seleccionar exactament dos objectes audiovisuals per dur a terme una "
-"combinació. Es pot seleccionar un segon objecte prement la tecla de control "
-"mentre es clica l'objecte desitjat."
+"Cal seleccionar exactament dos objectes audiovisuals per dur a terme una"
+" combinació. Es pot seleccionar un segon objecte prement la tecla de control"
+" mentre es clica l'objecte desitjat."
 
 #: ../gramps/plugins/view/noteview.py:95
 msgid "Delete the selected note"
@@ -36596,12 +36525,12 @@ msgstr "No es poden combinar notes."
 
 #: ../gramps/plugins/view/noteview.py:358
 msgid ""
-"Exactly two notes must be selected to perform a merge. A second note can be "
-"selected by holding down the control key while clicking on the desired note."
+"Exactly two notes must be selected to perform a merge. A second note can be"
+" selected by holding down the control key while clicking on the desired note."
 msgstr ""
-"Cal seleccionar exactament dues notes per dur a terme una combinació. Es pot "
-"seleccionar una segona nota prement la tecla de control mentre es clica la "
-"nota desitjada."
+"Cal seleccionar exactament dues notes per dur a terme una combinació. Es pot"
+" seleccionar una segona nota prement la tecla de control mentre es clica la"
+" nota desitjada."
 
 #: ../gramps/plugins/view/pedigreeview.py:80
 msgid "short for born|b."
@@ -36627,85 +36556,85 @@ msgstr "ent."
 msgid "short for cremated|crem."
 msgstr "crem."
 
-#: ../gramps/plugins/view/pedigreeview.py:1205
+#: ../gramps/plugins/view/pedigreeview.py:1206
 msgid "Jump to child..."
 msgstr "Salta cap al fill..."
 
-#: ../gramps/plugins/view/pedigreeview.py:1219
+#: ../gramps/plugins/view/pedigreeview.py:1220
 msgid "Jump to father"
 msgstr "Salta cap al pare"
 
-#: ../gramps/plugins/view/pedigreeview.py:1233
+#: ../gramps/plugins/view/pedigreeview.py:1234
 msgid "Jump to mother"
 msgstr "Salta cap a la mare"
 
-#: ../gramps/plugins/view/pedigreeview.py:1601
+#: ../gramps/plugins/view/pedigreeview.py:1602
 msgid "A person was found to be his/her own ancestor."
 msgstr "S'ha trobat que una persona era el seu propi avantpassat."
 
-#: ../gramps/plugins/view/pedigreeview.py:1645
+#: ../gramps/plugins/view/pedigreeview.py:1646
 msgid "Pre_vious"
 msgstr "Pre_vi"
 
-#: ../gramps/plugins/view/pedigreeview.py:1646
+#: ../gramps/plugins/view/pedigreeview.py:1647
 msgid "_Next"
 msgstr "Següe_nt"
 
 #. Mouse scroll direction setting.
-#: ../gramps/plugins/view/pedigreeview.py:1675
+#: ../gramps/plugins/view/pedigreeview.py:1676
 msgid "Mouse scroll direction"
 msgstr "Direcció del desplaçament del ratolí"
 
-#: ../gramps/plugins/view/pedigreeview.py:1679
+#: ../gramps/plugins/view/pedigreeview.py:1680
 msgid "Top <-> Bottom"
 msgstr "Dalt <-> Baix"
 
-#: ../gramps/plugins/view/pedigreeview.py:1686
+#: ../gramps/plugins/view/pedigreeview.py:1687
 msgid "Left <-> Right"
 msgstr "Esquerra <-> Dreta"
 
-#: ../gramps/plugins/view/pedigreeview.py:1903
+#: ../gramps/plugins/view/pedigreeview.py:1904
 #: ../gramps/plugins/view/relview.py:393
 msgid "Add New Parents..."
 msgstr "Afegeix Pares Nous..."
 
-#: ../gramps/plugins/view/pedigreeview.py:2098
+#: ../gramps/plugins/view/pedigreeview.py:2099
 msgid "Show images"
 msgstr "Mostra imatges"
 
-#: ../gramps/plugins/view/pedigreeview.py:2101
+#: ../gramps/plugins/view/pedigreeview.py:2102
 msgid "Show marriage data"
 msgstr "Mostra dades de casaments"
 
-#: ../gramps/plugins/view/pedigreeview.py:2104
+#: ../gramps/plugins/view/pedigreeview.py:2105
 msgid "Show unknown people"
 msgstr "Mostra persones desconegudes"
 
-#: ../gramps/plugins/view/pedigreeview.py:2107
+#: ../gramps/plugins/view/pedigreeview.py:2108
 msgid "Show tags"
 msgstr "Mostra Etiquetes"
 
-#: ../gramps/plugins/view/pedigreeview.py:2110
+#: ../gramps/plugins/view/pedigreeview.py:2111
 msgid "Tree style"
 msgstr "Estil d'arbre"
 
-#: ../gramps/plugins/view/pedigreeview.py:2112
+#: ../gramps/plugins/view/pedigreeview.py:2113
 msgid "Standard"
 msgstr "Estàndard"
 
-#: ../gramps/plugins/view/pedigreeview.py:2113
+#: ../gramps/plugins/view/pedigreeview.py:2114
 msgid "Compact"
 msgstr "Compacte"
 
-#: ../gramps/plugins/view/pedigreeview.py:2114
+#: ../gramps/plugins/view/pedigreeview.py:2115
 msgid "Expanded"
 msgstr "Estès"
 
-#: ../gramps/plugins/view/pedigreeview.py:2117
+#: ../gramps/plugins/view/pedigreeview.py:2118
 msgid "Tree direction"
 msgstr "Direcció de l'arbre"
 
-#: ../gramps/plugins/view/pedigreeview.py:2124
+#: ../gramps/plugins/view/pedigreeview.py:2125
 msgid "Tree size"
 msgstr "Mida d'arbre"
 
@@ -36943,13 +36872,13 @@ msgstr "No es poden combinar repositoris."
 
 #: ../gramps/plugins/view/repoview.py:364
 msgid ""
-"Exactly two repositories must be selected to perform a merge. A second "
-"repository can be selected by holding down the control key while clicking on "
-"the desired repository."
+"Exactly two repositories must be selected to perform a merge. A second"
+" repository can be selected by holding down the control key while clicking on"
+" the desired repository."
 msgstr ""
-"Cal seleccionar exactament dos repositoris per dur a terme una combinació. "
-"Es pot seleccionar un segon repositori prement la tecla de control mentre es "
-"clica el repositori desitjat."
+"Cal seleccionar exactament dos repositoris per dur a terme una combinació. Es"
+" pot seleccionar un segon repositori prement la tecla de control mentre es"
+" clica el repositori desitjat."
 
 #: ../gramps/plugins/view/sourceview.py:99
 msgid "Edit the selected source"
@@ -36973,13 +36902,13 @@ msgstr "No es poden combinar fonts."
 
 #: ../gramps/plugins/view/sourceview.py:349
 msgid ""
-"Exactly two sources must be selected to perform a merge. A second source can "
-"be selected by holding down the control key while clicking on the desired "
-"source."
+"Exactly two sources must be selected to perform a merge. A second source can"
+" be selected by holding down the control key while clicking on the desired"
+" source."
 msgstr ""
-"Cal seleccionar exactament dues fonts per dur a terme una combinació. Es pot "
-"seleccionar la segona font prement la tecla de control mentre es clica la "
-"font desitjada."
+"Cal seleccionar exactament dues fonts per dur a terme una combinació. Es pot"
+" seleccionar la segona font prement la tecla de control mentre es clica la"
+" font desitjada."
 
 #: ../gramps/plugins/view/view.gpr.py:38
 msgid "The view showing all the events"
@@ -37028,8 +36957,8 @@ msgstr "Mostrant els descendents mitjançant una gràfica en ventall"
 #: ../gramps/plugins/view/view.gpr.py:175
 msgid "Showing ascendants and descendants through a fanchart"
 msgstr ""
-"S'estan mostrant els avantpassats i descendents a través del diagrama de "
-"ventall"
+"S'estan mostrant els avantpassats i descendents a través del diagrama de"
+" ventall"
 
 #: ../gramps/plugins/view/view.gpr.py:188
 msgid "Grouped People"
@@ -37038,14 +36967,14 @@ msgstr "Persones Agrupades"
 #: ../gramps/plugins/view/view.gpr.py:189
 msgid "The view showing all people in the Family Tree grouped per family name"
 msgstr ""
-"La vista que mostra totes les persones de l'Arbre Genealògic agrupats per "
-"nom de família"
+"La vista que mostra totes les persones de l'Arbre Genealògic agrupats per nom"
+" de família"
 
 #: ../gramps/plugins/view/view.gpr.py:206
 msgid "The view showing all people in the Family Tree in a flat list"
 msgstr ""
-"La vista que mostra totes les persones de l'Arbre Genealògic en una llista "
-"plana"
+"La vista que mostra totes les persones de l'Arbre Genealògic en una llista"
+" plana"
 
 #: ../gramps/plugins/view/view.gpr.py:222
 msgid "The view showing all the places of the Family Tree"
@@ -37091,15 +37020,15 @@ msgstr "Agenda"
 #. Address Book Page message
 #: ../gramps/plugins/webreport/addressbooklist.py:90
 msgid ""
-"This page contains an index of all the individuals in the database, sorted "
-"by their surname, with one of the following: Address, Residence, or Web "
-"Links. Selecting the person&#8217;s name will take you to their individual "
-"Address Book page."
+"This page contains an index of all the individuals in the database, sorted by"
+" their surname, with one of the following: Address, Residence, or Web Links."
+" Selecting the person&#8217;s name will take you to their individual Address"
+" Book page."
 msgstr ""
-"Aquesta pàgina conté un índex de tots els individus de la base de dades, "
-"ordenats per cognom, amb una de les següents coses: Adreça, Residència, o "
-"Enllaços Web. Seleccionar el nom de la persona el portarà a la pàgina "
-"individual d'aquesta persona a l'Agenda."
+"Aquesta pàgina conté un índex de tots els individus de la base de dades,"
+" ordenats per cognom, amb una de les següents coses: Adreça, Residència, o"
+" Enllaços Web. Seleccionar el nom de la persona el portarà a la pàgina"
+" individual d'aquesta persona a l'Agenda."
 
 #: ../gramps/plugins/webreport/addressbooklist.py:112
 msgid "Full Name"
@@ -37174,7 +37103,7 @@ msgstr "Imatges en miniatura"
 #: ../gramps/plugins/webreport/basepage.py:1535
 #: ../gramps/plugins/webreport/basepage.py:1668
 #: ../gramps/plugins/webreport/download.py:94
-#: ../gramps/plugins/webreport/narrativeweb.py:1906
+#: ../gramps/plugins/webreport/narrativeweb.py:1910
 msgid "Download"
 msgstr "Baixar"
 
@@ -37225,19 +37154,28 @@ msgstr "Parròquia"
 msgid "Locations"
 msgstr "Ubicacions"
 
+#: ../gramps/plugins/webreport/basepage.py:2943
+msgid "circa"
+msgstr ""
+
+#: ../gramps/plugins/webreport/basepage.py:2945
+#, fuzzy
+msgid "around"
+msgstr "Fons"
+
 #: ../gramps/plugins/webreport/download.py:101
 msgid ""
-"This page is for the user/ creator of this Family Tree/ Narrative website to "
-"share a couple of files with you regarding their family.  If there are any "
-"files listed below, clicking on them will allow you to download them. The "
-"download page and files have the same copyright as the remainder of these "
-"web pages."
+"This page is for the user/ creator of this Family Tree/ Narrative website to"
+" share a couple of files with you regarding their family.  If there are any"
+" files listed below, clicking on them will allow you to download them. The"
+" download page and files have the same copyright as the remainder of these"
+" web pages."
 msgstr ""
-"Aquesta pàgina és perquè l'usuari/ creador d'aquest web d'Arbre Genealògic "
-"Explicat comparteixi amb vostè un parell de fitxers sobre la família. Si hi "
-"ha cap fitxer llistat a sota, clicar-hi li permetrà de baixar-los. La pàgina "
-"de baixades i els fitxers tenen els mateixos drets d'autor que la resta "
-"d'aquestes pàgines web."
+"Aquesta pàgina és perquè l'usuari/ creador d'aquest web d'Arbre Genealògic"
+" Explicat comparteixi amb vostè un parell de fitxers sobre la família. Si hi"
+" ha cap fitxer llistat a sota, clicar-hi li permetrà de baixar-los. La pàgina"
+" de baixades i els fitxers tenen els mateixos drets d'autor que la resta"
+" d'aquestes pàgines web."
 
 #: ../gramps/plugins/webreport/download.py:127
 msgid "File Name"
@@ -37255,12 +37193,12 @@ msgstr "S'estan creant les pàgines d'esdeveniment"
 #: ../gramps/plugins/webreport/family.py:108
 #: ../gramps/plugins/webreport/media.py:116
 #: ../gramps/plugins/webreport/media.py:244
-#: ../gramps/plugins/webreport/narrativeweb.py:501
-#: ../gramps/plugins/webreport/narrativeweb.py:1084
-#: ../gramps/plugins/webreport/narrativeweb.py:1142
-#: ../gramps/plugins/webreport/narrativeweb.py:1165
-#: ../gramps/plugins/webreport/narrativeweb.py:1174
-#: ../gramps/plugins/webreport/narrativeweb.py:1217
+#: ../gramps/plugins/webreport/narrativeweb.py:500
+#: ../gramps/plugins/webreport/narrativeweb.py:1088
+#: ../gramps/plugins/webreport/narrativeweb.py:1146
+#: ../gramps/plugins/webreport/narrativeweb.py:1169
+#: ../gramps/plugins/webreport/narrativeweb.py:1178
+#: ../gramps/plugins/webreport/narrativeweb.py:1221
 #: ../gramps/plugins/webreport/person.py:141
 #: ../gramps/plugins/webreport/place.py:117
 #: ../gramps/plugins/webreport/repository.py:102
@@ -37270,13 +37208,13 @@ msgstr "Informe de Web Explicat"
 
 #: ../gramps/plugins/webreport/event.py:148
 msgid ""
-"This page contains an index of all the events in the database, sorted by "
-"their type and date (if one is present). Clicking on an event&#8217;s Gramps "
-"ID will open a page for that event."
+"This page contains an index of all the events in the database, sorted by"
+" their type and date (if one is present). Clicking on an event&#8217;s Gramps"
+" ID will open a page for that event."
 msgstr ""
-"Aquesta pàgina conté un índex de tots els esdeveniments de la base de dades, "
-"ordenats pel seu tipus i data (si n'hi ha). Si es clica a l'Id Gramps d'un "
-"esdeveniment, s'obrirà una pàgina d'aquest esdeveniment."
+"Aquesta pàgina conté un índex de tots els esdeveniments de la base de dades,"
+" ordenats pel seu tipus i data (si n'hi ha). Si es clica a l'Id Gramps d'un"
+" esdeveniment, s'obrirà una pàgina d'aquest esdeveniment."
 
 #: ../gramps/plugins/webreport/event.py:174
 #: ../gramps/plugins/webreport/family.py:186
@@ -37298,20 +37236,24 @@ msgstr "S'estan creant les pàgines de família..."
 #. Families list page message
 #: ../gramps/plugins/webreport/family.py:141
 msgid ""
-"This page contains an index of all the families/ relationships in the "
-"database, sorted by their family name/ surname. Clicking on a person&#8217;s "
-"name will take you to their family/ relationship&#8217;s page."
+"This page contains an index of all the families/ relationships in the"
+" database, sorted by their family name/ surname. Clicking on a person&#8217;s"
+" name will take you to their family/ relationship&#8217;s page."
 msgstr ""
-"Aquesta pàgina conté un índex de totes les famílies/relacions de la base de "
-"dades, ordenades pel seu nom de família/cognom. Si es clica en el nom d'una "
-"persona, s'anirà a la pàgina de la seva família/relació."
+"Aquesta pàgina conté un índex de totes les famílies/relacions de la base de"
+" dades, ordenades pel seu nom de família/cognom. Si es clica en el nom d'una"
+" persona, s'anirà a la pàgina de la seva família/relació."
 
 #: ../gramps/plugins/webreport/family.py:232
 msgid "Families beginning with letter "
 msgstr "Famílies que comencin amb la lletra "
 
+#. Note. We use '/' here because it is a URL, not a OS
+#. dependent pathname need to leave home link alone,
+#. so look for it ...
 #: ../gramps/plugins/webreport/home.py:78
 #: ../gramps/plugins/webreport/webcal.py:576
+#: ../gramps/plugins/webreport/webcal.py:599
 msgid "Home"
 msgstr "Base"
 
@@ -37321,15 +37263,15 @@ msgstr "S'estan creant les pàgines d'objectes audiovisuals"
 
 #: ../gramps/plugins/webreport/media.py:204
 msgid ""
-"This page contains an index of all the media objects in the database, sorted "
-"by their title. Clicking on the title will take you to that media "
-"object&#8217;s page.  If you see media size dimensions above an image, click "
-"on the image to see the full sized version.  "
+"This page contains an index of all the media objects in the database, sorted"
+" by their title. Clicking on the title will take you to that media"
+" object&#8217;s page.  If you see media size dimensions above an image, click"
+" on the image to see the full sized version.  "
 msgstr ""
-"Aquesta pàgina conté un índex de tots els objectes audiovisuals de la base "
-"de dades, ordenats per títol. Si es clica al títol, s'anirà a la pàgina de "
-"l'objecte corresponent. Si veu les dimensions del medi damunt d'una imatge, "
-"cliqui-la per veure'n la versió de mida sencera.  "
+"Aquesta pàgina conté un índex de tots els objectes audiovisuals de la base de"
+" dades, ordenats per títol. Si es clica al títol, s'anirà a la pàgina de"
+" l'objecte corresponent. Si veu les dimensions del medi damunt d'una imatge,"
+" cliqui-la per veure'n la versió de mida sencera.  "
 
 #: ../gramps/plugins/webreport/media.py:228
 msgid "Media | Name"
@@ -37369,314 +37311,314 @@ msgstr "Tipus de Fitxer"
 msgid "Missing media object:"
 msgstr "Falta objecte audiovisual:"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:285
+#: ../gramps/plugins/webreport/narrativeweb.py:284
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
 msgstr "Ni %(current)s ni %(parent)s són directoris"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:294
-#: ../gramps/plugins/webreport/narrativeweb.py:300
-#: ../gramps/plugins/webreport/narrativeweb.py:313
-#: ../gramps/plugins/webreport/narrativeweb.py:319
+#: ../gramps/plugins/webreport/narrativeweb.py:293
+#: ../gramps/plugins/webreport/narrativeweb.py:299
+#: ../gramps/plugins/webreport/narrativeweb.py:312
+#: ../gramps/plugins/webreport/narrativeweb.py:318
 #, python-format
 msgid "Could not create the directory: %s"
 msgstr "No s'ha pogut crear el directori: %s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:326
+#: ../gramps/plugins/webreport/narrativeweb.py:325
 msgid "Invalid file name"
 msgstr "Nom de fitxer no vàlid"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:327
+#: ../gramps/plugins/webreport/narrativeweb.py:326
 msgid "The archive file must be a file, not a directory"
 msgstr "El fitxer d'arxiu ha de ser un fitxer, no un directori"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:463
+#: ../gramps/plugins/webreport/narrativeweb.py:462
 #, python-format
 msgid "ID=%(grampsid)s, path=%(dir)s"
 msgstr "ID=%(grampsid)s, camí=%(dir)s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:468
+#: ../gramps/plugins/webreport/narrativeweb.py:467
 msgid "Missing media objects:"
 msgstr "Objectes audiovisuals que falten:"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:500
+#: ../gramps/plugins/webreport/narrativeweb.py:499
 msgid "Constructing list of other objects..."
 msgstr "Construint llista d'altres objectes..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:745
+#: ../gramps/plugins/webreport/narrativeweb.py:744
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr "Família de %(husband)s i %(spouse)s"
 
 #. Only the name of the husband is known
 #. Only the name of the wife is known
-#: ../gramps/plugins/webreport/narrativeweb.py:751
-#: ../gramps/plugins/webreport/narrativeweb.py:755
+#: ../gramps/plugins/webreport/narrativeweb.py:750
+#: ../gramps/plugins/webreport/narrativeweb.py:754
 #, python-format
 msgid "Family of %s"
 msgstr "Família de %s"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1083
+#: ../gramps/plugins/webreport/narrativeweb.py:1087
 msgid "Creating GENDEX file"
 msgstr "S'està creant el fitxer GENDEX"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1141
+#: ../gramps/plugins/webreport/narrativeweb.py:1145
 msgid "Creating surname pages"
 msgstr "S'estan creant les pàgines de cognoms"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1166
+#: ../gramps/plugins/webreport/narrativeweb.py:1170
 msgid "Creating thumbnail preview page..."
 msgstr "S'està creant la pàgina de previsualització d'imatges en miniatura..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1175
+#: ../gramps/plugins/webreport/narrativeweb.py:1179
 msgid "Creating statistics page..."
 msgstr "S'està creant la pàgina d'estadístiques..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1216
+#: ../gramps/plugins/webreport/narrativeweb.py:1220
 msgid "Creating address book pages ..."
 msgstr "S'estan creant les pàgines d'agenda ..."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1616
+#: ../gramps/plugins/webreport/narrativeweb.py:1620
 msgid "Store web pages in .tar.gz archive"
 msgstr "Desar les pàgines web en un arxiu .tar.gz"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1618
+#: ../gramps/plugins/webreport/narrativeweb.py:1622
 msgid "Whether to store the web pages in an archive file"
 msgstr "Si s'han de desar les pàgines web en un fitxer comprimit"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1629
-#: ../gramps/plugins/webreport/webcal.py:1663
+#: ../gramps/plugins/webreport/narrativeweb.py:1633
+#: ../gramps/plugins/webreport/webcal.py:1664
 msgid "The destination directory for the web files"
 msgstr "El directori destí per als fitxers web"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1635
+#: ../gramps/plugins/webreport/narrativeweb.py:1639
 msgid "My Family Tree"
 msgstr "El Meu Arbre Genealògic"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1635
+#: ../gramps/plugins/webreport/narrativeweb.py:1639
 msgid "Web site title"
 msgstr "Títol de web"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1636
+#: ../gramps/plugins/webreport/narrativeweb.py:1640
 msgid "The title of the web site"
 msgstr "El títol del web"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1641
+#: ../gramps/plugins/webreport/narrativeweb.py:1645
 msgid "Select filter to restrict people that appear on web site"
 msgstr "Selecciona el filtre per restringir les persones que apareixen al web"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1650
+#: ../gramps/plugins/webreport/narrativeweb.py:1654
 #, fuzzy
 msgid "Show the relationship between the current person and the active person"
 msgstr "Mostrar totes les relacions entre persona i la persona base."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1653
+#: ../gramps/plugins/webreport/narrativeweb.py:1657
 #, fuzzy
 msgid ""
-"For each person page, show the relationship between this person and the "
-"active person."
+"For each person page, show the relationship between this person and the"
+" active person."
 msgstr "Mostrar totes les relacions entre persona i la persona base."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1671
+#: ../gramps/plugins/webreport/narrativeweb.py:1675
 msgid "Html options"
 msgstr "Opcions Html"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1674
-#: ../gramps/plugins/webreport/webcal.py:1684
+#: ../gramps/plugins/webreport/narrativeweb.py:1678
+#: ../gramps/plugins/webreport/webcal.py:1685
 msgid "File extension"
 msgstr "Extensió de fitxers"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1677
-#: ../gramps/plugins/webreport/webcal.py:1687
+#: ../gramps/plugins/webreport/narrativeweb.py:1681
+#: ../gramps/plugins/webreport/webcal.py:1688
 msgid "The extension to be used for the web files"
 msgstr "L'extensió que s'ha de fer servir per als fitxers web"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1680
-#: ../gramps/plugins/webreport/webcal.py:1690
+#: ../gramps/plugins/webreport/narrativeweb.py:1684
+#: ../gramps/plugins/webreport/webcal.py:1691
 msgid "Copyright"
 msgstr "Copyright"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1683
-#: ../gramps/plugins/webreport/webcal.py:1693
+#: ../gramps/plugins/webreport/narrativeweb.py:1687
+#: ../gramps/plugins/webreport/webcal.py:1694
 msgid "The copyright to be used for the web files"
 msgstr "El copyright que s'ha de fer servir per als fitxers web"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1692
-#: ../gramps/plugins/webreport/webcal.py:1702
+#: ../gramps/plugins/webreport/narrativeweb.py:1696
+#: ../gramps/plugins/webreport/webcal.py:1703
 msgid "The stylesheet to be used for the web pages"
 msgstr "El full d'estil utilitzat per les pàgines web"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1697
+#: ../gramps/plugins/webreport/narrativeweb.py:1701
 msgid "Horizontal -- Default"
 msgstr "Horitzontal  -- Predeterminat"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1698
+#: ../gramps/plugins/webreport/narrativeweb.py:1702
 msgid "Vertical   -- Left Side"
 msgstr "Vertical   -- Banda esquerra"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1699
+#: ../gramps/plugins/webreport/narrativeweb.py:1703
 msgid "Fade       -- WebKit Browsers Only"
 msgstr "Difuminar     -- Només Navegadors amb Webkit"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1700
-#: ../gramps/plugins/webreport/narrativeweb.py:1714
+#: ../gramps/plugins/webreport/narrativeweb.py:1704
+#: ../gramps/plugins/webreport/narrativeweb.py:1718
 msgid "Drop-Down  -- WebKit Browsers Only"
 msgstr "Llista-Desplegable  -- Només Navegadors amb WebKit"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1702
+#: ../gramps/plugins/webreport/narrativeweb.py:1706
 msgid "Navigation Menu Layout"
 msgstr "Disposició del Menú de Navegació"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1706
+#: ../gramps/plugins/webreport/narrativeweb.py:1710
 msgid "Choose which layout for the Navigation Menus."
 msgstr "Tria quina disposició han de tenir els Menús de Navegació."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1713
+#: ../gramps/plugins/webreport/narrativeweb.py:1717
 msgid "Normal Outline Style"
 msgstr "Estil Normal de Contorn"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1717
+#: ../gramps/plugins/webreport/narrativeweb.py:1721
 msgid "Citation Referents Layout"
 msgstr "Col·locació de les Referències de Cita"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1721
+#: ../gramps/plugins/webreport/narrativeweb.py:1725
 msgid ""
 "Determine the default layout for the Source Page's Citation Referents section"
 msgstr ""
-"Determinar la col·locació predeterminada per a la secció de les Referències "
-"de Cita de la Pàgina Font"
+"Determinar la col·locació predeterminada per a la secció de les Referències"
+" de Cita de la Pàgina Font"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1725
+#: ../gramps/plugins/webreport/narrativeweb.py:1729
 msgid "Include ancestor's tree"
 msgstr "Incloure arbre d'avantpassats"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1726
+#: ../gramps/plugins/webreport/narrativeweb.py:1730
 msgid "Whether to include an ancestor graph on each individual page"
 msgstr "Si s'ha d'incloure un graf d'avantpassats a cada pàgina individual"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1731
+#: ../gramps/plugins/webreport/narrativeweb.py:1735
 msgid "Add previous/next"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1732
+#: ../gramps/plugins/webreport/narrativeweb.py:1736
 msgid "Add previous/next to the navigation bar."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1735
+#: ../gramps/plugins/webreport/narrativeweb.py:1739
 msgid "This is a secure site (https)"
 msgstr "Aquest es un lloc segur (https)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1737
+#: ../gramps/plugins/webreport/narrativeweb.py:1741
 msgid "Whether to use http:// or https://"
 msgstr "Si utilitzar http:// o https://"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1744
+#: ../gramps/plugins/webreport/narrativeweb.py:1748
 #, fuzzy
 msgid "Extra pages"
 msgstr "Extra gran"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1747
+#: ../gramps/plugins/webreport/narrativeweb.py:1751
 #, fuzzy
 msgid "Extra page name"
 msgstr "Extra gran"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1750
+#: ../gramps/plugins/webreport/narrativeweb.py:1754
 msgid "Your extra page name like it is shown in the menubar"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1755
+#: ../gramps/plugins/webreport/narrativeweb.py:1759
 msgid "Your extra page path"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1758
+#: ../gramps/plugins/webreport/narrativeweb.py:1762
 msgid "Your extra page path without extension"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1778
+#: ../gramps/plugins/webreport/narrativeweb.py:1782
 msgid "Sort all children in birth order"
 msgstr "Ordenar tots els fills per ordre de naixement"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1780
+#: ../gramps/plugins/webreport/narrativeweb.py:1784
 msgid "Whether to display children in birth order or in entry order?"
 msgstr ""
-"Si s'han de mostrar els fills per ordre de naixement o per ordre "
-"d'introducció?"
+"Si s'han de mostrar els fills per ordre de naixement o per ordre"
+" d'introducció?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1784
+#: ../gramps/plugins/webreport/narrativeweb.py:1788
 msgid "Do we display coordinates in the places list?"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1786
+#: ../gramps/plugins/webreport/narrativeweb.py:1790
 msgid "Whether to display latitude/longitude in the places list?"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1790
+#: ../gramps/plugins/webreport/narrativeweb.py:1794
 msgid "Sort places references either by date or by name"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1792
+#: ../gramps/plugins/webreport/narrativeweb.py:1796
 msgid "Sort the places references by date or by name. Not set means by date."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1796
+#: ../gramps/plugins/webreport/narrativeweb.py:1800
 msgid "Graph generations"
 msgstr "Generacions del graf"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1797
+#: ../gramps/plugins/webreport/narrativeweb.py:1801
 msgid "The number of generations to include in the ancestor graph"
 msgstr "El nombre de generacions a incloure al graf d'avantpassats"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1803
+#: ../gramps/plugins/webreport/narrativeweb.py:1807
 msgid "Include narrative notes just after name, gender"
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1805
+#: ../gramps/plugins/webreport/narrativeweb.py:1809
 msgid ""
-"Include narrative notes just after name, gender and age at death (default) "
-"or include them just before attributes."
+"Include narrative notes just after name, gender and age at death (default) or"
+" include them just before attributes."
 msgstr ""
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1814
+#: ../gramps/plugins/webreport/narrativeweb.py:1818
 msgid "Page Generation"
 msgstr "Generació de Pàgines"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1817
+#: ../gramps/plugins/webreport/narrativeweb.py:1821
 msgid "Home page note"
 msgstr "Nota de la pàgina inicial"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1818
+#: ../gramps/plugins/webreport/narrativeweb.py:1822
 msgid "A note to be used on the home page"
 msgstr "Una nota per utilitzar a la pàgina inicial"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1821
+#: ../gramps/plugins/webreport/narrativeweb.py:1825
 msgid "Home page image"
 msgstr "Imatge de la pàgina inicial"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1822
+#: ../gramps/plugins/webreport/narrativeweb.py:1826
 msgid "An image to be used on the home page"
 msgstr "Una imatge per utilitzar a la pàgina inicial"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1825
+#: ../gramps/plugins/webreport/narrativeweb.py:1829
 msgid "Introduction note"
 msgstr "Nota introductòria"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1826
+#: ../gramps/plugins/webreport/narrativeweb.py:1830
 msgid "A note to be used as the introduction"
 msgstr "Una nota per utilitzar com a introducció"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1829
+#: ../gramps/plugins/webreport/narrativeweb.py:1833
 msgid "Introduction image"
 msgstr "Imatge introductòria"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1830
+#: ../gramps/plugins/webreport/narrativeweb.py:1834
 msgid "An image to be used as the introduction"
 msgstr "Una imatge per utilitzar com a introducció"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1833
+#: ../gramps/plugins/webreport/narrativeweb.py:1837
 msgid "Publisher contact note"
 msgstr "Nota de contacte amb l'editor"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1834
+#: ../gramps/plugins/webreport/narrativeweb.py:1838
 msgid ""
 "A note to be used as the publisher contact.\n"
 "If no publisher information is given,\n"
@@ -37686,11 +37628,11 @@ msgstr ""
 "Si no es dóna informació sobre l'editor,\n"
 "no es crearà cap pàgina de contacte"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1840
+#: ../gramps/plugins/webreport/narrativeweb.py:1844
 msgid "Publisher contact image"
 msgstr "Imatge de contacte amb l'editor"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1841
+#: ../gramps/plugins/webreport/narrativeweb.py:1845
 msgid ""
 "An image to be used as the publisher contact.\n"
 "If no publisher information is given,\n"
@@ -37700,349 +37642,349 @@ msgstr ""
 "Si no es dóna informació sobre l'editor,\n"
 "no es crearà cap pàgina de contacte"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1847
+#: ../gramps/plugins/webreport/narrativeweb.py:1851
 msgid "HTML user header"
 msgstr "Capçalera HTML d'usuari"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1848
+#: ../gramps/plugins/webreport/narrativeweb.py:1852
 msgid "A note to be used as the page header"
 msgstr "Una nota per utilitzar com a capçalera de pàgina"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1851
+#: ../gramps/plugins/webreport/narrativeweb.py:1855
 msgid "HTML user footer"
 msgstr "Peu de pàgina HTML"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1852
+#: ../gramps/plugins/webreport/narrativeweb.py:1856
 msgid "A note to be used as the page footer"
 msgstr "Una nota per utilitzar com a peu de pàgina"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1859
+#: ../gramps/plugins/webreport/narrativeweb.py:1863
 msgid "Images Generation"
 msgstr "Generació d'imatges"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1862
+#: ../gramps/plugins/webreport/narrativeweb.py:1866
 msgid "Include images and media objects"
 msgstr "Incloure imatges i objectes audiovisuals"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1864
+#: ../gramps/plugins/webreport/narrativeweb.py:1868
 msgid "Whether to include a gallery of media objects"
 msgstr "Si s'ha d'incloure una galeria d'objectes de medis audiovisuals"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1870
+#: ../gramps/plugins/webreport/narrativeweb.py:1874
 msgid "Include unused images and media objects"
 msgstr "Incloure imatges no utilitzades i objectes audiovisuals"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1871
+#: ../gramps/plugins/webreport/narrativeweb.py:1875
 msgid "Whether to include unused or unreferenced media objects"
 msgstr ""
 "Si s'ha d'incloure objectes audiovisuals no utilitzats o no referenciats"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1876
+#: ../gramps/plugins/webreport/narrativeweb.py:1880
 msgid "Create and only use thumbnail- sized images"
 msgstr "Crear i utilitzar només imatges petites de mostra"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1878
+#: ../gramps/plugins/webreport/narrativeweb.py:1882
 msgid ""
-"This option allows you to create only thumbnail images instead of the full-"
-"sized images on the Media Page. This will allow you to have a much smaller "
-"total upload size to your web hosting site."
+"This option allows you to create only thumbnail images instead of the"
+" full-sized images on the Media Page. This will allow you to have a much"
+" smaller total upload size to your web hosting site."
 msgstr ""
-"Aquesta opció us permet de crear només imatges petites de mostra en comptes "
-"de les imatges de mida sencera de la Pàgina de Medis Audiovisuals. Això us "
-"permetrà de tenir una mida de càrrega total molt més petita al vostre web."
+"Aquesta opció us permet de crear només imatges petites de mostra en comptes"
+" de les imatges de mida sencera de la Pàgina de Medis Audiovisuals. Això us"
+" permetrà de tenir una mida de càrrega total molt més petita al vostre web."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1887
+#: ../gramps/plugins/webreport/narrativeweb.py:1891
 msgid "Max width of initial image"
 msgstr "Amplada màxima d'imatge inicial"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1889
+#: ../gramps/plugins/webreport/narrativeweb.py:1893
 msgid ""
-"This allows you to set the maximum width of the image shown on the media "
-"page. Set to 0 for no limit."
+"This allows you to set the maximum width of the image shown on the media"
+" page. Set to 0 for no limit."
 msgstr ""
-"Això li permet de fixar l'amplada màxima de la imatge que es mostra a la "
-"pàgina d'audiovisuals. Deixar a 0 perquè no hi hagi límit."
+"Això li permet de fixar l'amplada màxima de la imatge que es mostra a la"
+" pàgina d'audiovisuals. Deixar a 0 perquè no hi hagi límit."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1894
+#: ../gramps/plugins/webreport/narrativeweb.py:1898
 msgid "Max height of initial image"
 msgstr "Alçada màxima d'imatge inicial"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1896
+#: ../gramps/plugins/webreport/narrativeweb.py:1900
 msgid ""
-"This allows you to set the maximum height of the image shown on the media "
-"page. Set to 0 for no limit."
+"This allows you to set the maximum height of the image shown on the media"
+" page. Set to 0 for no limit."
 msgstr ""
-"Això li permet de fixar l'alçada màxima de la imatge que es mostra a la "
-"pàgina d'audiovisuals. Deixar a 0 perquè no hi hagi límit."
+"Això li permet de fixar l'alçada màxima de la imatge que es mostra a la"
+" pàgina d'audiovisuals. Deixar a 0 perquè no hi hagi límit."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1909
+#: ../gramps/plugins/webreport/narrativeweb.py:1913
 msgid "Include download page"
 msgstr "Incloure pàgina de baixada"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1911
+#: ../gramps/plugins/webreport/narrativeweb.py:1915
 msgid "Whether to include a database download option"
 msgstr "Si s'ha d'incloure una opció per baixar-se la base de dades"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1916
-#: ../gramps/plugins/webreport/narrativeweb.py:1928
+#: ../gramps/plugins/webreport/narrativeweb.py:1920
+#: ../gramps/plugins/webreport/narrativeweb.py:1932
 msgid "Download Filename"
 msgstr "Nom de fitxer de baixada"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1919
-#: ../gramps/plugins/webreport/narrativeweb.py:1931
+#: ../gramps/plugins/webreport/narrativeweb.py:1923
+#: ../gramps/plugins/webreport/narrativeweb.py:1935
 msgid "File to be used for downloading of database"
 msgstr "Fitxer a utilitzar per baixar la base de dades"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1922
-#: ../gramps/plugins/webreport/narrativeweb.py:1934
+#: ../gramps/plugins/webreport/narrativeweb.py:1926
+#: ../gramps/plugins/webreport/narrativeweb.py:1938
 msgid "Description for download"
 msgstr "Descripció per baixada"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1923
+#: ../gramps/plugins/webreport/narrativeweb.py:1927
 msgid "Smith Family Tree"
 msgstr "Arbre genealògic dels Smith"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1924
-#: ../gramps/plugins/webreport/narrativeweb.py:1936
+#: ../gramps/plugins/webreport/narrativeweb.py:1928
+#: ../gramps/plugins/webreport/narrativeweb.py:1940
 msgid "Give a description for this file."
 msgstr "Donar una descripció per aquest fitxer."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1935
+#: ../gramps/plugins/webreport/narrativeweb.py:1939
 msgid "Johnson Family Tree"
 msgstr "Arbre genealògic dels Johnson"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1945
-#: ../gramps/plugins/webreport/webcal.py:1868
+#: ../gramps/plugins/webreport/narrativeweb.py:1949
+#: ../gramps/plugins/webreport/webcal.py:1869
 msgid "Advanced Options"
 msgstr "Opcions Avançades"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1948
-#: ../gramps/plugins/webreport/webcal.py:1870
+#: ../gramps/plugins/webreport/narrativeweb.py:1952
+#: ../gramps/plugins/webreport/webcal.py:1871
 msgid "Character set encoding"
 msgstr "Codificació de caràcters"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1952
-#: ../gramps/plugins/webreport/webcal.py:1874
+#: ../gramps/plugins/webreport/narrativeweb.py:1956
+#: ../gramps/plugins/webreport/webcal.py:1875
 msgid "The encoding to be used for the web files"
 msgstr "La codificació que s'ha de fer servir per als fitxers web"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1956
+#: ../gramps/plugins/webreport/narrativeweb.py:1960
 msgid "Include link to active person on every page"
 msgstr "Incloure enllaç a la persona activa a cada pàgina"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1958
+#: ../gramps/plugins/webreport/narrativeweb.py:1962
 msgid "Include a link to the active person (if they have a webpage)"
 msgstr "Incloure enllaç a la persona activa (si té pàgina web)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1962
+#: ../gramps/plugins/webreport/narrativeweb.py:1966
 msgid "Include a column for birth dates on the index pages"
 msgstr "Incloure una columna per dates de naixement a les pàgines d'índex"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1963
+#: ../gramps/plugins/webreport/narrativeweb.py:1967
 msgid "Whether to include a birth column"
 msgstr "Si s'ha d'incloure una columna de naixements"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1967
+#: ../gramps/plugins/webreport/narrativeweb.py:1971
 msgid "Include a column for death dates on the index pages"
 msgstr "Incloure una columna per dates de defunció a les pàgines d'índex"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1968
+#: ../gramps/plugins/webreport/narrativeweb.py:1972
 msgid "Whether to include a death column"
 msgstr "Si s'ha d'incloure una columna de defuncions"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1971
+#: ../gramps/plugins/webreport/narrativeweb.py:1975
 msgid "Include a column for partners on the index pages"
 msgstr "Incloure una columna per parelles a les pàgines d'índex"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1973
+#: ../gramps/plugins/webreport/narrativeweb.py:1977
 msgid "Whether to include a partners column"
 msgstr "Si s'ha d'incloure una columna de parelles"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1976
+#: ../gramps/plugins/webreport/narrativeweb.py:1980
 msgid "Include a column for parents on the index pages"
 msgstr "Incloure una columna per pares a les pàgines d'índex"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1978
+#: ../gramps/plugins/webreport/narrativeweb.py:1982
 msgid "Whether to include a parents column"
 msgstr "Si s'ha d'incloure una columna de pares"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1982
+#: ../gramps/plugins/webreport/narrativeweb.py:1986
 msgid "Include half and/ or step-siblings on the individual pages"
 msgstr "Incloure germanastres a les pàgines individuals"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1985
+#: ../gramps/plugins/webreport/narrativeweb.py:1989
 msgid ""
 "Whether to include half and/ or step-siblings with the parents and siblings"
 msgstr "Si s'han d'incloure els germanastres amb els pares i els germans"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1996
+#: ../gramps/plugins/webreport/narrativeweb.py:2000
 msgid "Include family pages"
 msgstr "Incloure pàgines de família"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:1997
+#: ../gramps/plugins/webreport/narrativeweb.py:2001
 msgid "Whether or not to include family pages."
 msgstr "Si s'han d'incloure o no pàgines de família."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2000
+#: ../gramps/plugins/webreport/narrativeweb.py:2004
 msgid "Include event pages"
 msgstr "Incloure pàgines d'esdeveniments"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2002
+#: ../gramps/plugins/webreport/narrativeweb.py:2006
 msgid "Add a complete events list and relevant pages or not"
 msgstr ""
 "Afegeix una llista completa d'esdeveniments i les pàgines rellevants o no"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2005
+#: ../gramps/plugins/webreport/narrativeweb.py:2009
 #, fuzzy
 msgid "Include places pages"
 msgstr "Incloure llocs"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2007
+#: ../gramps/plugins/webreport/narrativeweb.py:2011
 #, fuzzy
 msgid "Whether or not to include the places Pages."
 msgstr "Si s'han d'incloure les Pàgines de Repositori o no."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2010
+#: ../gramps/plugins/webreport/narrativeweb.py:2014
 #, fuzzy
 msgid "Include sources pages"
 msgstr "Incloure notes de fonts"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2012
+#: ../gramps/plugins/webreport/narrativeweb.py:2016
 #, fuzzy
 msgid "Whether or not to include the sources Pages."
 msgstr "Si s'han d'incloure les Pàgines de Repositori o no."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2015
+#: ../gramps/plugins/webreport/narrativeweb.py:2019
 msgid "Include repository pages"
 msgstr "Incloure pàgines de repositori"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2017
+#: ../gramps/plugins/webreport/narrativeweb.py:2021
 msgid "Whether or not to include the Repository Pages."
 msgstr "Si s'han d'incloure les Pàgines de Repositori o no."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2021
+#: ../gramps/plugins/webreport/narrativeweb.py:2025
 msgid "Include GENDEX file (/gendex.txt)"
 msgstr "Incloure fitxer GENDEX (/gendex.txt)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2022
+#: ../gramps/plugins/webreport/narrativeweb.py:2026
 msgid "Whether to include a GENDEX file or not"
 msgstr "Si s'ha d'incloure un fitxer GENDEX o no"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2025
+#: ../gramps/plugins/webreport/narrativeweb.py:2029
 msgid "Include address book pages"
 msgstr "Incloure pàgines d'agenda"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2026
+#: ../gramps/plugins/webreport/narrativeweb.py:2030
 msgid ""
-"Whether or not to add Address Book pages,which can include e-mail and "
-"website addresses and personal address/ residence events."
+"Whether or not to add Address Book pages,which can include e-mail and website"
+" addresses and personal address/ residence events."
 msgstr ""
-"Si s'han d'afegir o no pàgines d'Agenda, que poden incloure adreces de "
-"correu i de web o esdeveniments d'adreça personal/residència."
+"Si s'han d'afegir o no pàgines d'Agenda, que poden incloure adreces de correu"
+" i de web o esdeveniments d'adreça personal/residència."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2032
+#: ../gramps/plugins/webreport/narrativeweb.py:2036
 msgid "Include the statistics page"
 msgstr "Incloure la pàgina d'estadístiques"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2033
+#: ../gramps/plugins/webreport/narrativeweb.py:2037
 msgid "Whether or not to add statistics page"
 msgstr "Si s'ha d'incloure o no la pàgina d'estadístiques"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2040
+#: ../gramps/plugins/webreport/narrativeweb.py:2044
 msgid "Place Map Options"
 msgstr "Opcions de Mapa de Llocs"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2045
+#: ../gramps/plugins/webreport/narrativeweb.py:2049
 msgid "Google"
 msgstr "Google"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2046
+#: ../gramps/plugins/webreport/narrativeweb.py:2050
 msgid "Map Service"
 msgstr "Servei de Mapes"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2050
+#: ../gramps/plugins/webreport/narrativeweb.py:2054
 msgid "Choose your choice of map service for creating the Place Map Pages."
 msgstr "Tria el servei de mapes per crear les Pàgines de Mapa de Llocs."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2056
+#: ../gramps/plugins/webreport/narrativeweb.py:2060
 msgid "Include Place map on Place Pages"
 msgstr "Incloure el mapa de Lloc a les Pàgines de Lloc"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2058
+#: ../gramps/plugins/webreport/narrativeweb.py:2062
 msgid ""
-"Whether to include a place map on the Place Pages, where Latitude/ Longitude "
-"are available."
+"Whether to include a place map on the Place Pages, where Latitude/ Longitude"
+" are available."
 msgstr ""
-"Si s'ha d'incloure un mapa de lloc a les Pàgines de Lloc, on hi hagi "
-"Latitud/ Longitud."
+"Si s'ha d'incloure un mapa de lloc a les Pàgines de Lloc, on hi hagi Latitud/"
+" Longitud."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2063
+#: ../gramps/plugins/webreport/narrativeweb.py:2067
 msgid "Include Family Map Pages with all places shown on the map"
 msgstr ""
 "Incloure Pàgines de Mapa de Família amb tots els llocs mostrats al mapa"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2067
+#: ../gramps/plugins/webreport/narrativeweb.py:2071
 msgid ""
-"Whether or not to add an individual page map showing all the places on this "
-"page. This will allow you to see how your family traveled around the country."
+"Whether or not to add an individual page map showing all the places on this"
+" page. This will allow you to see how your family traveled around the country."
 msgstr ""
-"Si s'ha d'afegir o no un mapa en un pàgina individual que mostri tots els "
-"llocs. Això us permetrà de veure com la seva família va viatjar pel país."
+"Si s'ha d'afegir o no un mapa en un pàgina individual que mostri tots els"
+" llocs. Això us permetrà de veure com la seva família va viatjar pel país."
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2075
+#: ../gramps/plugins/webreport/narrativeweb.py:2079
 msgid "Family Links"
 msgstr "Enllaços de Família"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2076
+#: ../gramps/plugins/webreport/narrativeweb.py:2080
 msgid "Drop"
 msgstr "Eliminar"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2077
+#: ../gramps/plugins/webreport/narrativeweb.py:2081
 msgid "Markers"
 msgstr "Marcadors"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2078
+#: ../gramps/plugins/webreport/narrativeweb.py:2082
 msgid "Google/ FamilyMap Option"
 msgstr "Opció per Mapa de Família amb Google"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2083
-msgid ""
-"Select which option that you would like to have for the Google Maps Family "
-"Map pages..."
-msgstr ""
-"Seleccioneu quina opció voldríeu per les pàgines de Mapa de Família amb "
-"Google Maps..."
-
 #: ../gramps/plugins/webreport/narrativeweb.py:2087
+msgid ""
+"Select which option that you would like to have for the Google Maps Family"
+" Map pages..."
+msgstr ""
+"Seleccioneu quina opció voldríeu per les pàgines de Mapa de Família amb"
+" Google Maps..."
+
+#: ../gramps/plugins/webreport/narrativeweb.py:2091
 msgid "Google maps API key"
 msgstr "Clau API Google maps"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2088
+#: ../gramps/plugins/webreport/narrativeweb.py:2092
 msgid "The API key used for the Google maps"
 msgstr "La clau API utilitzada per al Google maps"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2097
+#: ../gramps/plugins/webreport/narrativeweb.py:2101
 msgid "Other inclusion (CMS, Web Calendar, Php)"
 msgstr "Altres inclusions (CMS, Calendari Web, Php)"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2101
+#: ../gramps/plugins/webreport/narrativeweb.py:2105
 msgid "Do we include these pages in a cms web ?"
 msgstr "Voleu incloure aquestes pàgines a la web cms?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2105
-#: ../gramps/plugins/webreport/narrativeweb.py:2122
+#: ../gramps/plugins/webreport/narrativeweb.py:2109
+#: ../gramps/plugins/webreport/narrativeweb.py:2126
 msgid "URI"
 msgstr "URI"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2111
+#: ../gramps/plugins/webreport/narrativeweb.py:2115
 msgid "Where do you place your web site ? default = /NAVWEB"
 msgstr "On vols hostatjar el teu lloc web ? predeterminat = /NAVWEB"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2118
+#: ../gramps/plugins/webreport/narrativeweb.py:2122
 msgid "Do we include the web calendar ?"
 msgstr "Voleu incloure el calendari web ?"
 
-#: ../gramps/plugins/webreport/narrativeweb.py:2128
+#: ../gramps/plugins/webreport/narrativeweb.py:2132
 msgid "Where do you place your web site ? default = /WEBCAL"
 msgstr "On vols hostatjar el teu lloc web ? predeterminat = /WEBCAL"
 
@@ -38053,13 +37995,13 @@ msgstr "S'estan creant les pàgines individuals"
 #. Individual List page message
 #: ../gramps/plugins/webreport/person.py:188
 msgid ""
-"This page contains an index of all the individuals in the database, sorted "
-"by their last names. Selecting the person&#8217;s name will take you to that "
-"person&#8217;s individual page."
+"This page contains an index of all the individuals in the database, sorted by"
+" their last names. Selecting the person&#8217;s name will take you to that"
+" person&#8217;s individual page."
 msgstr ""
-"Aquesta pàgina conté un índex de tots els individus de la base de dades, "
-"ordenats per cognom. Seleccionar el nom de la persona el portarà a la pàgina "
-"individual d'aquesta persona."
+"Aquesta pàgina conté un índex de tots els individus de la base de dades,"
+" ordenats per cognom. Seleccionar el nom de la persona el portarà a la pàgina"
+" individual d'aquesta persona."
 
 #. Name Column
 #: ../gramps/plugins/webreport/person.py:215
@@ -38086,17 +38028,17 @@ msgstr "Seguint %s"
 #. page description
 #: ../gramps/plugins/webreport/person.py:803
 msgid ""
-"This map page represents that person and any descendants with all of their "
-"event/ places. If you place your mouse over the marker it will display the "
-"place name. The markers and the Reference list are sorted in date order (if "
-"any?). Clicking on a place&#8217;s name in the Reference section will take "
-"you to that place&#8217;s page."
+"This map page represents that person and any descendants with all of their"
+" event/ places. If you place your mouse over the marker it will display the"
+" place name. The markers and the Reference list are sorted in date order (if"
+" any?). Clicking on a place&#8217;s name in the Reference section will take"
+" you to that place&#8217;s page."
 msgstr ""
-"Aquesta pàgina de mapa representa la persona i els seus descendents amb tots "
-"els seus esdeveniments i llocs. Si passeu el ratolí per damunt del marcador, "
-"dirà el nom del lloc. Els marcadors i la llista de Referències estan per "
-"ordre temporal (si és que estan per ordre). Clicar al nom d'un lloc a la "
-"secció de Referències us portarà a la pàgina d'aquest lloc."
+"Aquesta pàgina de mapa representa la persona i els seus descendents amb tots"
+" els seus esdeveniments i llocs. Si passeu el ratolí per damunt del marcador,"
+" dirà el nom del lloc. Els marcadors i la llista de Referències estan per"
+" ordre temporal (si és que estan per ordre). Clicar al nom d'un lloc a la"
+" secció de Referències us portarà a la pàgina d'aquest lloc."
 
 #: ../gramps/plugins/webreport/person.py:874
 msgid "Drop Markers"
@@ -38106,39 +38048,39 @@ msgstr "Treure Marcadors"
 msgid "Place Title"
 msgstr "Títol de Lloc"
 
-#: ../gramps/plugins/webreport/person.py:1446
+#: ../gramps/plugins/webreport/person.py:1453
 msgid "Call Name"
 msgstr "Nom Habitual"
 
-#: ../gramps/plugins/webreport/person.py:1464
+#: ../gramps/plugins/webreport/person.py:1471
 msgid "Nick Name"
 msgstr "Sobrenom"
 
-#: ../gramps/plugins/webreport/person.py:1510
+#: ../gramps/plugins/webreport/person.py:1517
 msgid "Age at Death"
 msgstr "Edat en Morir"
 
-#: ../gramps/plugins/webreport/person.py:1640
+#: ../gramps/plugins/webreport/person.py:1647
 msgid "Stepfather"
 msgstr "Padrastre"
 
-#: ../gramps/plugins/webreport/person.py:1653
+#: ../gramps/plugins/webreport/person.py:1660
 msgid "Stepmother"
 msgstr "Madrastra"
 
-#: ../gramps/plugins/webreport/person.py:1681
+#: ../gramps/plugins/webreport/person.py:1688
 msgid "Not siblings"
 msgstr "No germans"
 
-#: ../gramps/plugins/webreport/person.py:1823
+#: ../gramps/plugins/webreport/person.py:1830
 msgid "Relation to the center person"
 msgstr "Parentesc amb la persona principal"
 
-#: ../gramps/plugins/webreport/person.py:1860
+#: ../gramps/plugins/webreport/person.py:1867
 msgid "Relation to main person"
 msgstr "Parentesc amb la persona principal"
 
-#: ../gramps/plugins/webreport/person.py:1864
+#: ../gramps/plugins/webreport/person.py:1871
 msgid "Relation within this family (if not by birth)"
 msgstr "Parentesc dins d'aquesta família (si no és per naixement)"
 
@@ -38149,13 +38091,12 @@ msgstr "S'estan creant les pàgines de lloc"
 #. place list page message
 #: ../gramps/plugins/webreport/place.py:151
 msgid ""
-"This page contains an index of all the places in the database, sorted by "
-"their title. Clicking on a place&#8217;s title will take you to that "
-"place&#8217;s page."
+"This page contains an index of all the places in the database, sorted by"
+" their title. Clicking on a place&#8217;s title will take you to that"
+" place&#8217;s page."
 msgstr ""
-"Aquesta pàgina conté un índex de tots els llocs de la base de dades, "
-"ordenats pel seu títol. Si es clica en un lloc, s'anirà a la pàgina d'aquest "
-"lloc."
+"Aquesta pàgina conté un índex de tots els llocs de la base de dades, ordenats"
+" pel seu títol. Si es clica en un lloc, s'anirà a la pàgina d'aquest lloc."
 
 #: ../gramps/plugins/webreport/place.py:181
 #: ../gramps/plugins/webreport/place.py:193
@@ -38179,13 +38120,13 @@ msgstr "S'estan creant les pàgines de repositori"
 
 #: ../gramps/plugins/webreport/repository.py:147
 msgid ""
-"This page contains an index of all the repositories in the database, sorted "
-"by their title. Clicking on a repositories&#8217;s title will take you to "
-"that repositories&#8217;s page."
+"This page contains an index of all the repositories in the database, sorted"
+" by their title. Clicking on a repositories&#8217;s title will take you to"
+" that repositories&#8217;s page."
 msgstr ""
-"Aquesta pàgina conté un índex de tots els repositoris de la base de dades, "
-"ordenats per títol. Si es clica al títol d'un repositori, s'anirà a la "
-"pàgina d'aquest repositori."
+"Aquesta pàgina conté un índex de tots els repositoris de la base de dades,"
+" ordenats per títol. Si es clica al títol d'un repositori, s'anirà a la"
+" pàgina d'aquest repositori."
 
 #: ../gramps/plugins/webreport/repository.py:165
 msgid "Repository |Name"
@@ -38197,13 +38138,13 @@ msgstr "S'estan creant les pàgines de font"
 
 #: ../gramps/plugins/webreport/source.py:147
 msgid ""
-"This page contains an index of all the sources in the database, sorted by "
-"their title. Clicking on a source&#8217;s title will take you to that "
-"source&#8217;s page."
+"This page contains an index of all the sources in the database, sorted by"
+" their title. Clicking on a source&#8217;s title will take you to that"
+" source&#8217;s page."
 msgstr ""
-"Aquesta pàgina conté un índex de totes les fonts de la base de dades, "
-"ordenades per títol. Si es clica al títol d'una font, s'anirà a la pàgina "
-"d'aquesta font."
+"Aquesta pàgina conté un índex de totes les fonts de la base de dades,"
+" ordenades per títol. Si es clica al títol d'una font, s'anirà a la pàgina"
+" d'aquesta font."
 
 #: ../gramps/plugins/webreport/source.py:166
 msgid "Source Name|Name"
@@ -38225,13 +38166,13 @@ msgstr "Informe de contingut web narratiu per"
 #: ../gramps/plugins/webreport/surname.py:120
 #, python-format
 msgid ""
-"This page contains an index of all the individuals in the database with the "
-"surname of %s. Selecting the person&#8217;s name will take you to that "
-"person&#8217;s individual page."
+"This page contains an index of all the individuals in the database with the"
+" surname of %s. Selecting the person&#8217;s name will take you to that"
+" person&#8217;s individual page."
 msgstr ""
-"Aquesta pàgina conté un índex de tots els individus de la base de dades amb "
-"el cognom %s. Seleccionar el nom de la persona el portarà a la pàgina "
-"individual d'aquesta persona."
+"Aquesta pàgina conté un índex de tots els individus de la base de dades amb"
+" el cognom %s. Seleccionar el nom de la persona el portarà a la pàgina"
+" individual d'aquesta persona."
 
 #: ../gramps/plugins/webreport/surnamelist.py:101
 msgid "Surnames by person count"
@@ -38240,13 +38181,13 @@ msgstr "Cognoms per nombre de persones"
 #. page message
 #: ../gramps/plugins/webreport/surnamelist.py:109
 msgid ""
-"This page contains an index of all the surnames in the database. Selecting a "
-"link will lead to a list of individuals in the database with this same "
-"surname."
+"This page contains an index of all the surnames in the database. Selecting a"
+" link will lead to a list of individuals in the database with this same"
+" surname."
 msgstr ""
-"Aquesta pàgina conté un índex de tots els cognoms de la base de dades. "
-"Seleccionar un enllaç portarà a una llista dels individus de la base de "
-"dades amb aquest mateix cognom."
+"Aquesta pàgina conté un índex de tots els cognoms de la base de dades."
+" Seleccionar un enllaç portarà a una llista dels individus de la base de"
+" dades amb aquest mateix cognom."
 
 #: ../gramps/plugins/webreport/surnamelist.py:155
 msgid "Number of People"
@@ -38259,24 +38200,24 @@ msgstr "Cognoms que comencin amb la lletra %s"
 
 #: ../gramps/plugins/webreport/thumbnail.py:118
 msgid ""
-"This page displays a indexed list of all the media objects in this "
-"database.  It is sorted by media title.  There is an index of all the media "
-"objects in this database.  Clicking on a thumbnail will take you to that "
-"image&#8217;s page."
+"This page displays a indexed list of all the media objects in this database. "
+" It is sorted by media title.  There is an index of all the media objects in"
+" this database.  Clicking on a thumbnail will take you to that image&#8217;s"
+" page."
 msgstr ""
-"Aquesta pàgina mostra una llista indexada de tots els objectes audiovisuals "
-"d'aquesta base de dades. Està  ordenada per títol. Hi ha un índex de tots "
-"els objectes audiovisuals d'aquesta base de dades. Si es clica en una imatge "
-"en miniatura, s'anirà a la pàgina d'aquesta imatge."
+"Aquesta pàgina mostra una llista indexada de tots els objectes audiovisuals"
+" d'aquesta base de dades. Està  ordenada per títol. Hi ha un índex de tots"
+" els objectes audiovisuals d'aquesta base de dades. Si es clica en una imatge"
+" en miniatura, s'anirà a la pàgina d'aquesta imatge."
 
 #. _('translation')
 #. Number of directory levels up to get to self.html_dir / root
 #. Number of directory levels up to get to root
 #. generate progress pass for "Year At A Glance"
 #: ../gramps/plugins/webreport/webcal.py:332
-#: ../gramps/plugins/webreport/webcal.py:975
-#: ../gramps/plugins/webreport/webcal.py:1061
-#: ../gramps/plugins/webreport/webcal.py:1284
+#: ../gramps/plugins/webreport/webcal.py:976
+#: ../gramps/plugins/webreport/webcal.py:1062
+#: ../gramps/plugins/webreport/webcal.py:1285
 msgid "Web Calendar Report"
 msgstr "Informe de Calendari Web"
 
@@ -38302,296 +38243,294 @@ msgstr "Creat per a %(author)s"
 msgid "Year Glance"
 msgstr "Cop d'ull a l'Any"
 
-#: ../gramps/plugins/webreport/webcal.py:623
+#: ../gramps/plugins/webreport/webcal.py:624
 msgid "NarrativeWeb Home"
 msgstr "Pàgina d'Inici del Lloc Web Explicat"
 
-#: ../gramps/plugins/webreport/webcal.py:625
+#: ../gramps/plugins/webreport/webcal.py:626
 msgid "Full year at a Glance"
 msgstr "Any sencer en un cop d'ull"
 
-#: ../gramps/plugins/webreport/webcal.py:976
+#: ../gramps/plugins/webreport/webcal.py:977
 msgid "Formatting months ..."
 msgstr "Donant format als mesos ..."
 
-#: ../gramps/plugins/webreport/webcal.py:1062
+#: ../gramps/plugins/webreport/webcal.py:1063
 msgid "Creating Year At A Glance calendar"
 msgstr "S'està creant el calendari d'Any en un Cop d'Ull"
 
 #. page title
-#: ../gramps/plugins/webreport/webcal.py:1068
+#: ../gramps/plugins/webreport/webcal.py:1069
 #, python-format
 msgid "%(year)d, At A Glance"
 msgstr "%(year)d, en un Cop d'Ull"
 
-#: ../gramps/plugins/webreport/webcal.py:1083
+#: ../gramps/plugins/webreport/webcal.py:1084
 msgid ""
-"This calendar is meant to give you access to all your data at a glance "
-"compressed into one page. Clicking on a date will take you to a page that "
-"shows all the events for that date, if there are any.\n"
+"This calendar is meant to give you access to all your data at a glance"
+" compressed into one page. Clicking on a date will take you to a page that"
+" shows all the events for that date, if there are any.\n"
 msgstr ""
-"Aquest calendari està pensat per donar-li accés a totes les seves dades d'un "
-"cop d'ull comprimit en una sola pàgina. Clicant en una data, anirà a una "
-"pàgina que en mostra tots els esdeveniments, si n'hi ha.\n"
+"Aquest calendari està pensat per donar-li accés a totes les seves dades d'un"
+" cop d'ull comprimit en una sola pàgina. Clicant en una data, anirà a una"
+" pàgina que en mostra tots els esdeveniments, si n'hi ha.\n"
 
 #. page title
-#: ../gramps/plugins/webreport/webcal.py:1137
+#: ../gramps/plugins/webreport/webcal.py:1138
 msgid "One Day Within A Year"
 msgstr "Un Dia en un Any"
 
-#: ../gramps/plugins/webreport/webcal.py:1473
+#: ../gramps/plugins/webreport/webcal.py:1474
 #, python-format
 msgid "%(spouse)s and %(person)s"
 msgstr "%(spouse)s i %(person)s"
 
-#: ../gramps/plugins/webreport/webcal.py:1496
+#: ../gramps/plugins/webreport/webcal.py:1497
 #, python-format
 msgid "Generated by %(gramps_home_html_start)sGramps%(html_end)s on %(date)s"
 msgstr "Generat per %(gramps_home_html_start)sGramps%(html_end)s el %(date)s"
 
-#. page title
-#: ../gramps/plugins/webreport/webcal.py:1601
-#: ../gramps/plugins/webreport/webcal.py:1667
-msgid "My Family Calendar"
-msgstr "Calendari de la Família"
-
-#: ../gramps/plugins/webreport/webcal.py:1667
+#: ../gramps/plugins/webreport/webcal.py:1668
 msgid "Calendar Title"
 msgstr "Títol de Calendari"
 
 #: ../gramps/plugins/webreport/webcal.py:1668
+msgid "My Family Calendar"
+msgstr "Calendari de la Família"
+
+#: ../gramps/plugins/webreport/webcal.py:1669
 msgid "The title of the calendar"
 msgstr "El títol del calendari"
 
-#: ../gramps/plugins/webreport/webcal.py:1699
+#: ../gramps/plugins/webreport/webcal.py:1700
 msgid "StyleSheet"
 msgstr "Full d'Estil"
 
-#: ../gramps/plugins/webreport/webcal.py:1740
+#: ../gramps/plugins/webreport/webcal.py:1741
 msgid "Content Options"
 msgstr "Opcions de Contingut"
 
-#: ../gramps/plugins/webreport/webcal.py:1745
+#: ../gramps/plugins/webreport/webcal.py:1746
 msgid "Create multiple year calendars"
 msgstr "Crear múltiples calendaris d'any"
 
-#: ../gramps/plugins/webreport/webcal.py:1747
+#: ../gramps/plugins/webreport/webcal.py:1748
 msgid "Whether to create Multiple year calendars or not."
 msgstr "Si s'han de crear múltiples calendaris d'any o no."
 
-#: ../gramps/plugins/webreport/webcal.py:1752
+#: ../gramps/plugins/webreport/webcal.py:1753
 msgid "Start Year for the Calendar(s)"
 msgstr "Any d'inici per al(s) calendari(s)"
 
-#: ../gramps/plugins/webreport/webcal.py:1754
+#: ../gramps/plugins/webreport/webcal.py:1755
 msgid "Enter the starting year for the calendars between 1900 - 3000"
 msgstr "Introdueixi l'any d'inici per als calendaris entre 1900 i 3000"
 
-#: ../gramps/plugins/webreport/webcal.py:1758
+#: ../gramps/plugins/webreport/webcal.py:1759
 msgid "End Year for the Calendar(s)"
 msgstr "Any final per al(s) calendari(s)"
 
-#: ../gramps/plugins/webreport/webcal.py:1760
+#: ../gramps/plugins/webreport/webcal.py:1761
 msgid "Enter the ending year for the calendars between 1900 - 3000."
 msgstr "Introdueixi l'any final per als calendaris entre 1900 i 3000."
 
-#: ../gramps/plugins/webreport/webcal.py:1779
+#: ../gramps/plugins/webreport/webcal.py:1780
 msgid "Holidays will be included for the selected country"
 msgstr "S'inclouran les festes per al país seleccionat"
 
-#: ../gramps/plugins/webreport/webcal.py:1802
+#: ../gramps/plugins/webreport/webcal.py:1803
 msgid "Home link"
 msgstr "Enllaç a pàgina principal"
 
-#: ../gramps/plugins/webreport/webcal.py:1803
+#: ../gramps/plugins/webreport/webcal.py:1804
 msgid ""
 "The link to be included to direct the user to the main page of the web site"
 msgstr ""
-"L'enllaç que s'ha d'incloure per dirigir l'usuari a la pàgina principal del "
-"lloc web"
+"L'enllaç que s'ha d'incloure per dirigir l'usuari a la pàgina principal del"
+" lloc web"
 
-#: ../gramps/plugins/webreport/webcal.py:1811
+#: ../gramps/plugins/webreport/webcal.py:1812
 msgid "Jan - Jun Notes"
 msgstr "Notes Gen - Jun"
 
-#: ../gramps/plugins/webreport/webcal.py:1813
+#: ../gramps/plugins/webreport/webcal.py:1814
 msgid "January Note"
 msgstr "Nota Gener"
 
-#: ../gramps/plugins/webreport/webcal.py:1814
+#: ../gramps/plugins/webreport/webcal.py:1815
 msgid "The note for the month of January"
 msgstr "La nota per al mes de gener"
 
-#: ../gramps/plugins/webreport/webcal.py:1817
+#: ../gramps/plugins/webreport/webcal.py:1818
 msgid "February Note"
 msgstr "Nota Febrer"
 
-#: ../gramps/plugins/webreport/webcal.py:1818
+#: ../gramps/plugins/webreport/webcal.py:1819
 msgid "The note for the month of February"
 msgstr "La nota per al mes de febrer"
 
-#: ../gramps/plugins/webreport/webcal.py:1821
+#: ../gramps/plugins/webreport/webcal.py:1822
 msgid "March Note"
 msgstr "Nota Març"
 
-#: ../gramps/plugins/webreport/webcal.py:1822
+#: ../gramps/plugins/webreport/webcal.py:1823
 msgid "The note for the month of March"
 msgstr "La nota per al mes de març"
 
-#: ../gramps/plugins/webreport/webcal.py:1825
+#: ../gramps/plugins/webreport/webcal.py:1826
 msgid "April Note"
 msgstr "Nota Abril"
 
-#: ../gramps/plugins/webreport/webcal.py:1826
+#: ../gramps/plugins/webreport/webcal.py:1827
 msgid "The note for the month of April"
 msgstr "La nota per al mes d'abril"
 
-#: ../gramps/plugins/webreport/webcal.py:1829
+#: ../gramps/plugins/webreport/webcal.py:1830
 msgid "May Note"
 msgstr "Nota Mai"
 
-#: ../gramps/plugins/webreport/webcal.py:1830
+#: ../gramps/plugins/webreport/webcal.py:1831
 msgid "The note for the month of May"
 msgstr "La nota per al mes de maig"
 
-#: ../gramps/plugins/webreport/webcal.py:1833
+#: ../gramps/plugins/webreport/webcal.py:1834
 msgid "June Note"
 msgstr "Nota Juny"
 
-#: ../gramps/plugins/webreport/webcal.py:1834
+#: ../gramps/plugins/webreport/webcal.py:1835
 msgid "The note for the month of June"
 msgstr "La nota per al mes de juny"
 
-#: ../gramps/plugins/webreport/webcal.py:1837
+#: ../gramps/plugins/webreport/webcal.py:1838
 msgid "Jul - Dec Notes"
 msgstr "Notes Jul - Des"
 
-#: ../gramps/plugins/webreport/webcal.py:1839
+#: ../gramps/plugins/webreport/webcal.py:1840
 msgid "July Note"
 msgstr "Nota Juliol"
 
-#: ../gramps/plugins/webreport/webcal.py:1840
+#: ../gramps/plugins/webreport/webcal.py:1841
 msgid "The note for the month of July"
 msgstr "La nota per al mes de juliol"
 
-#: ../gramps/plugins/webreport/webcal.py:1843
+#: ../gramps/plugins/webreport/webcal.py:1844
 msgid "August Note"
 msgstr "Nota Agost"
 
-#: ../gramps/plugins/webreport/webcal.py:1844
+#: ../gramps/plugins/webreport/webcal.py:1845
 msgid "The note for the month of August"
 msgstr "La nota per al mes d'agost"
 
-#: ../gramps/plugins/webreport/webcal.py:1847
+#: ../gramps/plugins/webreport/webcal.py:1848
 msgid "September Note"
 msgstr "Nota Setembre"
 
-#: ../gramps/plugins/webreport/webcal.py:1848
+#: ../gramps/plugins/webreport/webcal.py:1849
 msgid "The note for the month of September"
 msgstr "La nota per al mes de setembre"
 
-#: ../gramps/plugins/webreport/webcal.py:1851
+#: ../gramps/plugins/webreport/webcal.py:1852
 msgid "October Note"
 msgstr "Nota Octubre"
 
-#: ../gramps/plugins/webreport/webcal.py:1852
+#: ../gramps/plugins/webreport/webcal.py:1853
 msgid "The note for the month of October"
 msgstr "La nota per al mes d'octubre"
 
-#: ../gramps/plugins/webreport/webcal.py:1855
+#: ../gramps/plugins/webreport/webcal.py:1856
 msgid "November Note"
 msgstr "Nota Novembre"
 
-#: ../gramps/plugins/webreport/webcal.py:1856
+#: ../gramps/plugins/webreport/webcal.py:1857
 msgid "The note for the month of November"
 msgstr "La nota per al mes de novembre"
 
-#: ../gramps/plugins/webreport/webcal.py:1859
+#: ../gramps/plugins/webreport/webcal.py:1860
 msgid "December Note"
 msgstr "Nota Desembre"
 
-#: ../gramps/plugins/webreport/webcal.py:1860
+#: ../gramps/plugins/webreport/webcal.py:1861
 msgid "The note for the month of December"
 msgstr "La nota per al mes de desembre"
 
-#: ../gramps/plugins/webreport/webcal.py:1877
+#: ../gramps/plugins/webreport/webcal.py:1878
 msgid "Create one day event pages for Year At A Glance calendar"
 msgstr ""
 "Crear pàgines d'esdeveniment d'un dia per al calendari d'Any en un Cop d'Ull"
 
-#: ../gramps/plugins/webreport/webcal.py:1879
+#: ../gramps/plugins/webreport/webcal.py:1880
 msgid "Whether to create one day pages or not"
 msgstr "Si s'han de crear pàgines d'un dia o no"
 
-#: ../gramps/plugins/webreport/webcal.py:1883
+#: ../gramps/plugins/webreport/webcal.py:1884
 msgid "Include birthdays in the calendar"
 msgstr "Incloure aniversaris de naixement al calendari"
 
-#: ../gramps/plugins/webreport/webcal.py:1887
+#: ../gramps/plugins/webreport/webcal.py:1888
 msgid "Include anniversaries in the calendar"
 msgstr "Incloure aniversaris al calendari"
 
-#: ../gramps/plugins/webreport/webcal.py:1890
+#: ../gramps/plugins/webreport/webcal.py:1891
 #, fuzzy
 msgid "Include death dates"
 msgstr "Incloure dates"
 
-#: ../gramps/plugins/webreport/webcal.py:1891
+#: ../gramps/plugins/webreport/webcal.py:1892
 #, fuzzy
 msgid "Include death anniversaries in the calendar"
 msgstr "Incloure aniversaris al calendari"
 
-#: ../gramps/plugins/webreport/webcal.py:1894
+#: ../gramps/plugins/webreport/webcal.py:1895
 msgid "Link to Narrated Web Report"
 msgstr "Enllaçar a l'Informe de Web Explicat"
 
-#: ../gramps/plugins/webreport/webcal.py:1895
+#: ../gramps/plugins/webreport/webcal.py:1896
 msgid "Whether to link data to web report or not"
 msgstr "Si s'han d'enllaçar les dades cap a l'informe web o no"
 
-#: ../gramps/plugins/webreport/webcal.py:1901
+#: ../gramps/plugins/webreport/webcal.py:1902
 msgid "Show data only after year"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1904
+#: ../gramps/plugins/webreport/webcal.py:1905
 msgid ""
-"Show data only after this year. Default is current year -  'maximum age "
-"probably alive' which is defined in the dates preference tab."
+"Show data only after this year. Default is current year -  'maximum age"
+" probably alive' which is defined in the dates preference tab."
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:1912
+#: ../gramps/plugins/webreport/webcal.py:1913
 msgid "Link prefix"
 msgstr "Prefix d'enllaç"
 
-#: ../gramps/plugins/webreport/webcal.py:1913
+#: ../gramps/plugins/webreport/webcal.py:1914
 msgid "A Prefix on the links to take you to Narrated Web Report"
 msgstr "Un prefix als enllaços que et porti a l'Informe de Web Explicat"
 
-#: ../gramps/plugins/webreport/webcal.py:2092
+#: ../gramps/plugins/webreport/webcal.py:2093
 #, python-format
 msgid "%s old"
 msgstr "%s"
 
-#: ../gramps/plugins/webreport/webcal.py:2102
+#: ../gramps/plugins/webreport/webcal.py:2103
 #, python-format
 msgid "%s since death"
 msgstr ""
 
-#: ../gramps/plugins/webreport/webcal.py:2103
+#: ../gramps/plugins/webreport/webcal.py:2104
 #, fuzzy
 msgid "death"
 msgstr "Defunció"
 
-#: ../gramps/plugins/webreport/webcal.py:2110
+#: ../gramps/plugins/webreport/webcal.py:2111
 #, python-format
 msgid "%(couple)s, <em>wedding</em>"
 msgstr "%(couple)s, <em>casament</em>"
 
-#: ../gramps/plugins/webreport/webcal.py:2118
+#: ../gramps/plugins/webreport/webcal.py:2119
 msgid "Until"
 msgstr "Fins"
 
-#: ../gramps/plugins/webreport/webcal.py:2127
+#: ../gramps/plugins/webreport/webcal.py:2128
 #, python-brace-format
 msgid "{couple}, {years} year anniversary"
 msgid_plural "{couple}, {years} year anniversary"
@@ -38662,29 +38601,11 @@ msgstr "Nebraska"
 msgid "No style sheet"
 msgstr "Sense full d'estil"
 
-#~ msgid ""
-#~ "<b>Improving Gramps</b><br/>Users are encouraged to request enhancements "
-#~ "to Gramps. Requesting an enhancement can be done either through the "
-#~ "gramps-users or gramps-devel mailing lists, or by going to http://bugs."
-#~ "gramps-project.org and creating a Feature Request. Filing a Feature "
-#~ "Request is preferred but it can be good to discuss your ideas on the "
-#~ "email lists."
-#~ msgstr ""
-#~ "<b>Millorar Gramps</b><br/>Animem als usuaris que sol·licitin millores a "
-#~ "Gramps. Es pot demanar una millora mitjançant les llistes de correu "
-#~ "gramps-users o gramps-devel, o bé anant a http://bugs.gramps-project.org "
-#~ "i creant una Sol·licitud de Funció. És preferible omplir una Sol·licitud "
-#~ "de Funció (Feature Request), però també pot ser bo de comentar les seves "
-#~ "idees a les llistes de correu."
+#~ msgid "<b>Improving Gramps</b><br/>Users are encouraged to request enhancements to Gramps. Requesting an enhancement can be done either through the gramps-users or gramps-devel mailing lists, or by going to http://bugs.gramps-project.org and creating a Feature Request. Filing a Feature Request is preferred but it can be good to discuss your ideas on the email lists."
+#~ msgstr "<b>Millorar Gramps</b><br/>Animem als usuaris que sol·licitin millores a Gramps. Es pot demanar una millora mitjançant les llistes de correu gramps-users o gramps-devel, o bé anant a http://bugs.gramps-project.org i creant una Sol·licitud de Funció. És preferible omplir una Sol·licitud de Funció (Feature Request), però també pot ser bo de comentar les seves idees a les llistes de correu."
 
-#~ msgid ""
-#~ "<b>Reporting Bugs in Gramps</b><br/>The best way to report a bug in "
-#~ "Gramps is to use the Gramps bug tracking system at http://bugs.gramps-"
-#~ "project.org"
-#~ msgstr ""
-#~ "<b>Informar d'Errors a Gramps</b><br/>La millor manera d'informar d'un "
-#~ "error de programa a Gramps és fer servir el seu sistema de seguiment "
-#~ "d'errors a http://bugs.gramps-project.org"
+#~ msgid "<b>Reporting Bugs in Gramps</b><br/>The best way to report a bug in Gramps is to use the Gramps bug tracking system at http://bugs.gramps-project.org"
+#~ msgstr "<b>Informar d'Errors a Gramps</b><br/>La millor manera d'informar d'un error de programa a Gramps és fer servir el seu sistema de seguiment d'errors a http://bugs.gramps-project.org"
 
 #~ msgid "unmarried|husband"
 #~ msgstr "company"
@@ -38744,9 +38665,7 @@ msgstr "Sense full d'estil"
 #~ msgstr "Contorn Família"
 
 #~ msgid "Use alternate Font handler for GUI and Reports (requires restart)"
-#~ msgstr ""
-#~ "Utilitza un gestor de tipus de lletra alternatiu per a la IGU i els "
-#~ "informes (necesita reiniciar)"
+#~ msgstr "Utilitza un gestor de tipus de lletra alternatiu per a la IGU i els informes (necesita reiniciar)"
 
 #~ msgid "Web Connect"
 #~ msgstr "Connexió Web"
@@ -38766,51 +38685,36 @@ msgstr "Sense full d'estil"
 #~ msgid "Undo History..."
 #~ msgstr "Historial de Modificacions..."
 
-#, python-format
 #~ msgid "Key %s is not bound"
 #~ msgstr "La tecla %s no està associada"
 
 #~ msgid "_Delete Item"
 #~ msgstr "Esborrar _Element"
 
-#, python-format
 #~ msgid "%(title)s..."
 #~ msgstr "%(title)s..."
 
-#~ msgid ""
-#~ "You need to set a 'default person' to go to. Select the People View, "
-#~ "select the person you want as 'Home Person', then confirm your choice via "
-#~ "the menu Edit ->Set Home Person."
-#~ msgstr ""
-#~ "Heu de fixar una 'persona predeterminada' on anar. Seleccioneu la Vista "
-#~ "de Persones, seleccioneu la persona que voleu com a 'Persona Base', i "
-#~ "llavors confirmeu l'elecció amb el menú Edita -> Fixar Persona Base."
+#~ msgid "You need to set a 'default person' to go to. Select the People View, select the person you want as 'Home Person', then confirm your choice via the menu Edit ->Set Home Person."
+#~ msgstr "Heu de fixar una 'persona predeterminada' on anar. Seleccioneu la Vista de Persones, seleccioneu la persona que voleu com a 'Persona Base', i llavors confirmeu l'elecció amb el menú Edita -> Fixar Persona Base."
 
-#, python-format
 #~ msgid "%(genders)s born %(year_from)04d-%(year_to)04d"
 #~ msgstr "%(genders)s nascuts %(year_from)04d-%(year_to)04d"
 
-#, python-format
 #~ msgid "Persons born %(year_from)04d-%(year_to)04d"
 #~ msgstr "Persones nascudes %(year_from)04d-%(year_to)04d"
 
-#, python-format
 #~ msgid "Marriage of %s"
 #~ msgstr "Casament de %s"
 
-#, python-format
 #~ msgid "Birth of %s"
 #~ msgstr "Naixement de %s"
 
-#, python-format
 #~ msgid "Death of %s"
 #~ msgstr "Defunció de %s"
 
-#, python-format
 #~ msgid "Anniversary: %s"
 #~ msgstr "Aniversari: %s"
 
-#, python-format
 #~ msgid "%d. Partner: "
 #~ msgstr "%d. Parella: "
 
@@ -38820,12 +38724,8 @@ msgstr "Sense full d'estil"
 #~ msgid "Loading..."
 #~ msgstr "Carregant..."
 
-#~ msgid ""
-#~ "Attempt to see this location with a Map Service (OpenstreetMap, Google "
-#~ "Maps, ...)"
-#~ msgstr ""
-#~ "Intentar de veure aquesta ubicació amb un Servei de Mapes (Openstreet "
-#~ "Map, Google Maps, ...)"
+#~ msgid "Attempt to see this location with a Map Service (OpenstreetMap, Google Maps, ...)"
+#~ msgstr "Intentar de veure aquesta ubicació amb un Servei de Mapes (Openstreet Map, Google Maps, ...)"
 
 #~ msgid "_Print..."
 #~ msgstr "Im_primeix..."
@@ -38836,7 +38736,6 @@ msgstr "Sense full d'estil"
 #~ msgid "manual|Media_Manager..."
 #~ msgstr "Gestor_audiovisuals..."
 
-#, python-format
 #~ msgid ""
 #~ "Geography functionality will not be available.\n"
 #~ "To build it for Gramps see %(gramps_wiki_build_osmgps_url)s"
@@ -38847,7 +38746,6 @@ msgstr "Sense full d'estil"
 #~ msgid "Open the folder containing the media file"
 #~ msgstr "Obre la carpeta que conté el fitxer audiovisual"
 
-#, python-format
 #~ msgid " (%s) "
 #~ msgstr " (%s) "
 
@@ -38864,25 +38762,16 @@ msgstr "Sense full d'estil"
 #~ msgstr "Dialeg_Nous_Repositoris"
 
 #~ msgid ""
-#~ "Conveys the submitter's quantitative evaluation of the credibility of a "
-#~ "piece of information, based upon its supporting evidence. It is not "
-#~ "intended to eliminate the receiver's need to evaluate the evidence for "
-#~ "themselves.\n"
+#~ "Conveys the submitter's quantitative evaluation of the credibility of a piece of information, based upon its supporting evidence. It is not intended to eliminate the receiver's need to evaluate the evidence for themselves.\n"
 #~ "Very Low =Unreliable evidence or estimated data\n"
-#~ "Low =Questionable reliability of evidence (interviews, census, oral "
-#~ "genealogies, or potential for bias for example, an autobiography)\n"
+#~ "Low =Questionable reliability of evidence (interviews, census, oral genealogies, or potential for bias for example, an autobiography)\n"
 #~ "High =Secondary evidence, data officially recorded sometime after event\n"
-#~ "Very High =Direct and primary evidence used, or by dominance of the "
-#~ "evidence "
+#~ "Very High =Direct and primary evidence used, or by dominance of the evidence "
 #~ msgstr ""
-#~ "Expressa l'avaluació quantitativa de la credibilitat d'una informació, "
-#~ "segons qui l'aporta, basant-se en les proves que la suporten. No és per "
-#~ "eliminar la necessitat del receptor d'avaluar les proves per si mateix.\n"
+#~ "Expressa l'avaluació quantitativa de la credibilitat d'una informació, segons qui l'aporta, basant-se en les proves que la suporten. No és per eliminar la necessitat del receptor d'avaluar les proves per si mateix.\n"
 #~ "Molt Baix =Proves no fiables o dades estimades\n"
-#~ "Baix =Fiabilitat de la prova qüestionable (entrevistes, cens, genealogies "
-#~ "orals, o biaix potencial, per exemple, una autobiografia)\n"
-#~ "Alt =Prova secundària, dades registrades oficialment algun temps després "
-#~ "de l'esdeveniment\n"
+#~ "Baix =Fiabilitat de la prova qüestionable (entrevistes, cens, genealogies orals, o biaix potencial, per exemple, una autobiografia)\n"
+#~ "Alt =Prova secundària, dades registrades oficialment algun temps després de l'esdeveniment\n"
 #~ "Molt Alt =Prova directa i primària, o per evidència aclaparadora "
 
 #~ msgid "Data version"
@@ -38910,8 +38799,7 @@ msgstr "Sense full d'estil"
 #~ msgstr "Limita"
 
 #~ msgid "You wish to convert this database into the new DB-API format?"
-#~ msgstr ""
-#~ "Voldreu convertir aquesta base de dades al nou format de tipus DB-API?"
+#~ msgstr "Voldreu convertir aquesta base de dades al nou format de tipus DB-API?"
 
 #~ msgid "48.21\"S, -18.2412 or -18:9:48.21)"
 #~ msgstr "48.21\"S, -18.2412 o -18:9:48.21)"

--- a/po/fr.po
+++ b/po/fr.po
@@ -37,15 +37,15 @@ msgstr ""
 "Project-Id-Version: 5.0.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-09-10 17:16+0100\n"
-"PO-Revision-Date: 2019-09-10 17:39+0200\n"
-"Last-Translator: Gil da Costa\n"
+"PO-Revision-Date: 2019-12-15 01:17+0100\n"
+"Last-Translator: \n"
 "Language-Team: French <traduc@traduc.org>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 1.8.11\n"
+"X-Generator: Poedit 1.5.4\n"
 
 #: ../data/gramps.appdata.xml.in.h:1
 msgid ""
@@ -1869,7 +1869,8 @@ msgstr "Verrouillé par %s"
 #: ../gramps/plugins/view/geomoves.py:662
 #: ../gramps/plugins/view/geoperson.py:543
 #: ../gramps/plugins/view/geoplaces.py:592
-#: ../gramps/plugins/view/relview.py:597 ../gramps/plugins/view/relview.py:1176
+#: ../gramps/plugins/view/relview.py:597
+#: ../gramps/plugins/view/relview.py:1176
 #: ../gramps/plugins/view/relview.py:1231
 #: ../gramps/plugins/webreport/basepage.py:1838
 #: ../gramps/plugins/webreport/basepage.py:1868
@@ -7069,8 +7070,8 @@ msgstr "Adresse "
 #: ../gramps/plugins/view/citationtreeview.py:97
 #: ../gramps/plugins/view/eventview.py:83
 #: ../gramps/plugins/view/familyview.py:84
-#: ../gramps/plugins/view/mediaview.py:99 ../gramps/plugins/view/noteview.py:82
-#: ../gramps/plugins/view/repoview.py:97
+#: ../gramps/plugins/view/mediaview.py:99
+#: ../gramps/plugins/view/noteview.py:82 ../gramps/plugins/view/repoview.py:97
 #: ../gramps/plugins/view/sourceview.py:87
 msgid "Private"
 msgstr "Privé"
@@ -7113,7 +7114,8 @@ msgstr "Citations"
 #: ../gramps/plugins/quickview/filterbyname.py:137
 #: ../gramps/plugins/textreport/indivcomplete.py:270
 #: ../gramps/plugins/textreport/tagreport.py:488
-#: ../gramps/plugins/view/noteview.py:110 ../gramps/plugins/view/view.gpr.py:97
+#: ../gramps/plugins/view/noteview.py:110
+#: ../gramps/plugins/view/view.gpr.py:97
 #: ../gramps/plugins/view/view.gpr.py:105
 #: ../gramps/plugins/webreport/basepage.py:1264
 #: ../gramps/plugins/webreport/person.py:1248
@@ -7338,7 +7340,8 @@ msgstr "Rang ou état"
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:75
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:67
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:104
-#: ../gramps/gui/glade/rule.glade:931 ../gramps/gui/glade/styleeditor.glade:278
+#: ../gramps/gui/glade/rule.glade:931
+#: ../gramps/gui/glade/styleeditor.glade:278
 #: ../gramps/gui/plug/_windows.py:134 ../gramps/gui/plug/_windows.py:243
 #: ../gramps/gui/plug/_windows.py:622 ../gramps/gui/plug/_windows.py:1107
 #: ../gramps/gui/selectors/selectevent.py:70
@@ -7436,8 +7439,8 @@ msgstr "Référence d'enfant"
 msgid "Handle"
 msgstr "Poignet"
 
-#: ../gramps/gen/lib/childreftype.py:67 ../gramps/gen/plug/docgen/treedoc.py:72
-#: ../gramps/gui/configure.py:87
+#: ../gramps/gen/lib/childreftype.py:67
+#: ../gramps/gen/plug/docgen/treedoc.py:72 ../gramps/gui/configure.py:87
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:201
 #: ../gramps/gui/filters/sidebar/_eventsidebarfilter.py:175
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:209
@@ -7978,7 +7981,8 @@ msgstr "Événements de vie"
 #: ../gramps/gui/configure.py:646
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:59
 #: ../gramps/gui/editors/displaytabs/personeventembedlist.py:52
-#: ../gramps/gui/editors/editfamily.py:561 ../gramps/gui/editors/editlink.py:93
+#: ../gramps/gui/editors/editfamily.py:561
+#: ../gramps/gui/editors/editlink.py:93
 #: ../gramps/gui/editors/filtereditor.py:295
 #: ../gramps/gui/glade/editldsord.glade:267 ../gramps/gui/grampsgui.py:56
 #: ../gramps/plugins/export/exportcsv.py:506
@@ -8565,8 +8569,8 @@ msgstr "Union civile"
 #: ../gramps/plugins/tool/patchnames.py:407
 #: ../gramps/plugins/tool/sortevents.py:55
 #: ../gramps/plugins/view/eventview.py:80
-#: ../gramps/plugins/view/mediaview.py:96 ../gramps/plugins/view/noteview.py:81
-#: ../gramps/plugins/view/repoview.py:87
+#: ../gramps/plugins/view/mediaview.py:96
+#: ../gramps/plugins/view/noteview.py:81 ../gramps/plugins/view/repoview.py:87
 #: ../gramps/plugins/webreport/basepage.py:960
 #: ../gramps/plugins/webreport/basepage.py:1262
 #: ../gramps/plugins/webreport/basepage.py:2139
@@ -8956,7 +8960,8 @@ msgstr "Nom marital (nom de l'époux)"
 #: ../gramps/gen/lib/note.py:109 ../gramps/gen/plug/docgen/graphdoc.py:265
 #: ../gramps/gen/plug/docgen/treedoc.py:199 ../gramps/gui/clipboard.py:375
 #: ../gramps/gui/configure.py:667 ../gramps/gui/editors/editlink.py:95
-#: ../gramps/gui/editors/editmedia.py:98 ../gramps/gui/editors/editmedia.py:181
+#: ../gramps/gui/editors/editmedia.py:98
+#: ../gramps/gui/editors/editmedia.py:181
 #: ../gramps/gui/editors/editmediaref.py:146
 #: ../gramps/gui/editors/filtereditor.py:301
 #: ../gramps/gui/filters/sidebar/_citationsidebarfilter.py:109
@@ -9191,7 +9196,8 @@ msgstr "Index de référence de naissance"
 msgid "Event references"
 msgstr "Références de l'événement"
 
-#: ../gramps/gen/lib/person.py:199 ../gramps/plugins/graph/gvfamilylines.py:292
+#: ../gramps/gen/lib/person.py:199
+#: ../gramps/plugins/graph/gvfamilylines.py:292
 #: ../gramps/plugins/graph/gvhourglass.py:432
 #: ../gramps/plugins/graph/gvrelgraph.py:954
 #: ../gramps/plugins/quickview/filterbyname.py:94
@@ -9469,7 +9475,8 @@ msgstr "Information de publication"
 msgid "Abbreviation"
 msgstr "Abréviation"
 
-#: ../gramps/gen/lib/src.py:127 ../gramps/plugins/quickview/filterbyname.py:106
+#: ../gramps/gen/lib/src.py:127
+#: ../gramps/plugins/quickview/filterbyname.py:106
 #: ../gramps/plugins/quickview/filterbyname.py:131
 #: ../gramps/plugins/textreport/tagreport.py:642
 #: ../gramps/plugins/view/repoview.py:129
@@ -9729,7 +9736,8 @@ msgstr "Fusion de la famille"
 msgid "Merge Media Objects"
 msgstr "Fusion des objets media"
 
-#: ../gramps/gen/merge/mergenotequery.py:58 ../gramps/gui/merge/mergenote.py:66
+#: ../gramps/gen/merge/mergenotequery.py:58
+#: ../gramps/gui/merge/mergenote.py:66
 msgid "Merge Notes"
 msgstr "Fusion des notes"
 
@@ -9842,9 +9850,8 @@ msgid "Sidebar"
 msgstr "Barre latérale"
 
 #: ../gramps/gen/plug/_pluginreg.py:92
-#, fuzzy
 msgid "Rule"
-msgstr "Ajouter une règle"
+msgstr "Règle"
 
 #. add miscellaneous column
 #: ../gramps/gen/plug/_pluginreg.py:528
@@ -10366,9 +10373,8 @@ msgid "Above"
 msgstr "Au-dessus"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:69
-#, fuzzy
 msgid "Below"
-msgstr "En dess_ous :"
+msgstr "En dessous"
 
 # master
 #: ../gramps/gen/plug/docgen/treedoc.py:70
@@ -10419,12 +10425,10 @@ msgid "Tiny"
 msgstr "Tout petit"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:90
-#, fuzzy
 msgid "Script"
-msgstr "PostScript"
+msgstr "Script"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:91
-#, fuzzy
 msgid "Footnote"
 msgstr "Pied de page"
 
@@ -10488,22 +10492,25 @@ msgid ""
 "One dimension of a node, in mm. If the timeflow is up or down then this is "
 "the width, otherwise it is the height."
 msgstr ""
+"Une dimension du nœud, en mm. Si le flux temporel est vers le haut ou vers le "
+"bas, alors il s'agit de la largeur, sinon c'est la hauteur."
 
 #: ../gramps/gen/plug/docgen/treedoc.py:162
-#, fuzzy
 msgid "Level size"
-msgstr "Taille de l'arbre"
+msgstr "Taille du niveau"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:163
 msgid ""
 "One dimension of a node, in mm. If the timeflow is up or down then this is "
 "the height, otherwise it is the width."
 msgstr ""
+"Une dimension du nœud, en mm. Si le flux temporel est vers le haut ou vers le "
+"bas, alors il s'agit de la hauteur, sinon c'est la largeur."
 
 #: ../gramps/gen/plug/docgen/treedoc.py:171
 #, fuzzy
 msgid "Node color."
-msgstr "Couleurs du genre"
+msgstr "Couleurs du nœud."
 
 #. ###############################
 #. #################
@@ -10515,22 +10522,20 @@ msgstr "Options de l'arbre"
 
 #. ###############################
 #: ../gramps/gen/plug/docgen/treedoc.py:178
-#, fuzzy
 msgid "Timeflow"
-msgstr "Heure"
+msgstr "Flux temporel"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:181
 msgid "Direction that the graph will grow over time."
 msgstr "Sens dans lequel le graphique va grandir."
 
 #: ../gramps/gen/plug/docgen/treedoc.py:184
-#, fuzzy
 msgid "Edge style"
-msgstr "Style de l'arbre"
+msgstr "Style des liens"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:187
 msgid "Style of the edges between nodes."
-msgstr ""
+msgstr "Style des liens entre les nœuds."
 
 #: ../gramps/gen/plug/docgen/treedoc.py:190
 msgid "Level distance"
@@ -10591,7 +10596,8 @@ msgstr "Valeurs valides :"
 #.
 #. -------------------------------------------------------------------------
 #: ../gramps/gen/plug/report/_book.py:71 ../gramps/gui/plug/_dialogs.py:59
-#: ../gramps/gui/plug/report/_bookdialog.py:86 ../gramps/gui/viewmanager.py:112
+#: ../gramps/gui/plug/report/_bookdialog.py:86
+#: ../gramps/gui/viewmanager.py:112
 msgid "Unsupported"
 msgstr "Non supportés"
 
@@ -10696,7 +10702,8 @@ msgstr "Références bibliographiques"
 #: ../gramps/plugins/textreport/indivcomplete.py:929
 #: ../gramps/plugins/textreport/indivcomplete.py:930
 #: ../gramps/plugins/view/relview.py:667 ../gramps/plugins/view/relview.py:731
-#: ../gramps/plugins/view/relview.py:784 ../gramps/plugins/view/relview.py:1033
+#: ../gramps/plugins/view/relview.py:784
+#: ../gramps/plugins/view/relview.py:1033
 #: ../gramps/plugins/view/relview.py:1068
 #: ../gramps/plugins/view/relview.py:1554
 #: ../gramps/plugins/view/relview.py:1577
@@ -10893,16 +10900,19 @@ msgstr "Ascendants de %s"
 msgid "People with common ancestor with %s"
 msgstr "Individus ayant un ascendant commun avec %s"
 
-#: ../gramps/gen/plug/report/utils.py:354 ../gramps/gui/plug/_guioptions.py:897
+#: ../gramps/gen/plug/report/utils.py:354
+#: ../gramps/gui/plug/_guioptions.py:897
 msgid "unknown father"
 msgstr "père inconnu"
 
-#: ../gramps/gen/plug/report/utils.py:360 ../gramps/gui/plug/_guioptions.py:903
+#: ../gramps/gen/plug/report/utils.py:360
+#: ../gramps/gui/plug/_guioptions.py:903
 msgid "unknown mother"
 msgstr "mère inconnue"
 
 # trunk
-#: ../gramps/gen/plug/report/utils.py:362 ../gramps/gui/plug/_guioptions.py:905
+#: ../gramps/gen/plug/report/utils.py:362
+#: ../gramps/gui/plug/_guioptions.py:905
 #, python-format
 msgid "%(father_name)s and %(mother_name)s (%(family_id)s)"
 msgstr "%(father_name)s et %(mother_name)s (%(family_id)s)"
@@ -11148,11 +11158,13 @@ msgstr ""
 "Le calculateur de relations familiales n'est pas disponible pour la langue "
 "'%s'. Utilisation du calculateur 'anglais' à la place."
 
-#: ../gramps/gen/utils/alive.py:145 ../gramps/plugins/importer/importcsv.py:202
+#: ../gramps/gen/utils/alive.py:145
+#: ../gramps/plugins/importer/importcsv.py:202
 msgid "death date"
 msgstr "date de décès"
 
-#: ../gramps/gen/utils/alive.py:150 ../gramps/plugins/importer/importcsv.py:178
+#: ../gramps/gen/utils/alive.py:150
+#: ../gramps/plugins/importer/importcsv.py:178
 msgid "birth date"
 msgstr "date de naissance"
 
@@ -11768,83 +11780,75 @@ msgstr "Masculin"
 
 #: ../gramps/gen/utils/symbols.py:63
 msgid "Asexuality, sexless, genderless"
-msgstr ""
+msgstr "Asexuel, sans sexualité, sans genre"
 
 #: ../gramps/gen/utils/symbols.py:64
 msgid "Lesbianism"
-msgstr ""
+msgstr "Saphisme"
 
 #: ../gramps/gen/utils/symbols.py:65
 msgid "Male homosexuality"
-msgstr ""
+msgstr "Homosexualité masculine"
 
 #: ../gramps/gen/utils/symbols.py:66
 msgid "Heterosexuality"
-msgstr ""
+msgstr "Hétérosexualité"
 
 #: ../gramps/gen/utils/symbols.py:67
 msgid "Transgender, hermaphrodite (in entomology)"
-msgstr ""
+msgstr "Transgenre, hermaphrodite (en entomologie)"
 
 #: ../gramps/gen/utils/symbols.py:68
-#, fuzzy
 msgid "Transgender"
-msgstr "genre"
+msgstr "Transgenre"
 
 #: ../gramps/gen/utils/symbols.py:69
 msgid "Neuter"
-msgstr ""
+msgstr "Neutre"
 
 #: ../gramps/gen/utils/symbols.py:71
-#, fuzzy
 msgid "Illegitimate"
-msgstr "estimé(e)"
+msgstr "Illégitime"
 
 #: ../gramps/gen/utils/symbols.py:73
-#, fuzzy
 msgid "Baptism/Christening"
 msgstr "Baptême religieux"
 
 #: ../gramps/gen/utils/symbols.py:74
-#, fuzzy
 msgid "Engaged"
 msgstr "Fiançailles"
 
 #: ../gramps/gen/utils/symbols.py:77
-#, fuzzy
 msgid "Unmarried partnership"
-msgstr "le conjoint"
+msgstr "Concubinage"
 
 #: ../gramps/gen/utils/symbols.py:78
-#, fuzzy
 msgid "Buried"
 msgstr "Inhumation"
 
 #: ../gramps/gen/utils/symbols.py:79
 msgid "Cremated/Funeral urn"
-msgstr ""
+msgstr "Incinéré/urne funéraire"
 
 #: ../gramps/gen/utils/symbols.py:80
-#, fuzzy
 msgid "Killed in action"
-msgstr "Collection"
+msgstr "Mort au combat"
 
 #: ../gramps/gen/utils/symbols.py:81
 msgid "Extinct"
-msgstr ""
+msgstr "Extinction"
 
 # master
 #. The following is used in the global preferences in the display tab.
 #. Name
 #. UNICODE    SUBSTITUTION
 #: ../gramps/gen/utils/symbols.py:106
-#, fuzzy
 msgid "Nothing"
-msgstr "Dans"
+msgstr "Rien"
 
 #: ../gramps/gen/utils/symbols.py:108
 msgid "Skull and crossbones"
-msgstr ""
+msgstr "Tête de mort et os"
 
 #: ../gramps/gen/utils/symbols.py:109
 msgid "Ankh"
@@ -11852,7 +11856,7 @@ msgstr ""
 
 #: ../gramps/gen/utils/symbols.py:110
 msgid "Orthodox cross"
-msgstr ""
+msgstr "Croix orthodoxe"
 
 #: ../gramps/gen/utils/symbols.py:111
 msgid "Chi rho"
@@ -11860,51 +11864,48 @@ msgstr ""
 
 #: ../gramps/gen/utils/symbols.py:112
 msgid "Cross of Lorraine"
-msgstr ""
+msgstr "Croix de Lorraine"
 
 #: ../gramps/gen/utils/symbols.py:113
 msgid "Cross of Jerusalem"
-msgstr ""
+msgstr "Croix de Jérusalem"
 
 # master
 #: ../gramps/gen/utils/symbols.py:114
-#, fuzzy
 msgid "Star and crescent"
-msgstr "Démarrer le test sur la date ?"
+msgstr "Étoile et croissant"
 
 #: ../gramps/gen/utils/symbols.py:115
 msgid "West Syriac cross"
-msgstr ""
+msgstr "Croix syrienne de l'Ouest"
 
 #: ../gramps/gen/utils/symbols.py:116
-#, fuzzy
 msgid "East Syriac cross"
-msgstr "Dernier accès"
+msgstr "Croix syrienne de l'Est"
 
 #: ../gramps/gen/utils/symbols.py:117
 msgid "Heavy Greek cross"
-msgstr ""
+msgstr "Croix grecque"
 
 #: ../gramps/gen/utils/symbols.py:118
 msgid "Latin cross"
-msgstr ""
+msgstr "Croix latine"
 
 #: ../gramps/gen/utils/symbols.py:119
 msgid "Shadowed White Latin cross"
-msgstr ""
+msgstr "Croix latine avec bordure"
 
 #: ../gramps/gen/utils/symbols.py:120
 msgid "Maltese cross"
-msgstr ""
+msgstr "Croix maltèse"
 
 #: ../gramps/gen/utils/symbols.py:121
 msgid "Star of David"
-msgstr ""
+msgstr "Étoile de David"
 
 #: ../gramps/gen/utils/symbols.py:122
-#, fuzzy
 msgid "Dead"
-msgstr "Masculin décédé"
+msgstr "décédé(e)"
 
 #: ../gramps/gen/utils/unknown.py:140
 msgid "Unknown, created to replace a missing note object."
@@ -12241,13 +12242,15 @@ msgstr "%s : "
 
 #: ../gramps/gui/configure.py:575 ../gramps/gui/editors/edittaglist.py:118
 #: ../gramps/gui/glade/addmedia.glade:55
-#: ../gramps/gui/glade/baseselector.glade:56 ../gramps/gui/glade/book.glade:498
-#: ../gramps/gui/glade/clipboard.glade:21 ../gramps/gui/glade/dbman.glade:150
+#: ../gramps/gui/glade/baseselector.glade:56
+#: ../gramps/gui/glade/book.glade:498 ../gramps/gui/glade/clipboard.glade:21
+#: ../gramps/gui/glade/dbman.glade:150
 #: ../gramps/gui/glade/editaddress.glade:55
 #: ../gramps/gui/glade/editattribute.glade:54
 #: ../gramps/gui/glade/editchildref.glade:58
 #: ../gramps/gui/glade/editcitation.glade:27
-#: ../gramps/gui/glade/editdate.glade:53 ../gramps/gui/glade/editevent.glade:58
+#: ../gramps/gui/glade/editdate.glade:53
+#: ../gramps/gui/glade/editevent.glade:58
 #: ../gramps/gui/glade/editeventref.glade:22
 #: ../gramps/gui/glade/editfamily.glade:60
 #: ../gramps/gui/glade/editldsord.glade:75
@@ -12263,7 +12266,8 @@ msgstr "%s : "
 #: ../gramps/gui/glade/editplaceref.glade:22
 #: ../gramps/gui/glade/editreporef.glade:61
 #: ../gramps/gui/glade/editrepository.glade:59
-#: ../gramps/gui/glade/editsource.glade:58 ../gramps/gui/glade/editurl.glade:57
+#: ../gramps/gui/glade/editsource.glade:58
+#: ../gramps/gui/glade/editurl.glade:57
 #: ../gramps/gui/glade/mergecitation.glade:53
 #: ../gramps/gui/glade/mergedata.glade:77
 #: ../gramps/gui/glade/mergedata.glade:278
@@ -12475,7 +12479,7 @@ msgstr "Arrière-plan pour la personne souche"
 #: ../gramps/gui/configure.py:761
 #, python-format
 msgid "<b>%s</b>"
-msgstr ""
+msgstr "<b>%s</b>"
 
 #: ../gramps/gui/configure.py:774
 msgid "Colors"
@@ -12553,8 +12557,8 @@ msgstr "Exemple"
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:129
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:115
 #: ../gramps/gui/editors/editfamily.py:195 ../gramps/gui/grampsgui.py:56
-#: ../gramps/gui/plug/report/_bookdialog.py:665 ../gramps/gui/views/tags.py:458
-#: ../gramps/gui/widgets/fanchart.py:2028
+#: ../gramps/gui/plug/report/_bookdialog.py:665
+#: ../gramps/gui/views/tags.py:458 ../gramps/gui/widgets/fanchart.py:2028
 #: ../gramps/gui/widgets/fanchart.py:2070
 #: ../gramps/plugins/view/pedigreeview.py:1703
 msgid "_Add"
@@ -12569,8 +12573,8 @@ msgstr "_Ajouter"
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:130
 #: ../gramps/gui/editors/displaytabs/webembedlist.py:116
 #: ../gramps/gui/glade/editlink.glade:222 ../gramps/gui/grampsgui.py:56
-#: ../gramps/gui/plug/report/_bookdialog.py:639 ../gramps/gui/views/tags.py:459
-#: ../gramps/gui/widgets/fanchart.py:1817
+#: ../gramps/gui/plug/report/_bookdialog.py:639
+#: ../gramps/gui/views/tags.py:459 ../gramps/gui/widgets/fanchart.py:1817
 #: ../gramps/plugins/view/pedigreeview.py:1738
 #: ../gramps/plugins/view/pedigreeview.py:1966
 msgid "_Edit"
@@ -13085,7 +13089,8 @@ msgstr "Sélectionner un répertoire media"
 #: ../gramps/gui/glade/editattribute.glade:21
 #: ../gramps/gui/glade/editchildref.glade:22
 #: ../gramps/gui/glade/editcitation.glade:42
-#: ../gramps/gui/glade/editdate.glade:69 ../gramps/gui/glade/editevent.glade:21
+#: ../gramps/gui/glade/editdate.glade:69
+#: ../gramps/gui/glade/editevent.glade:21
 #: ../gramps/gui/glade/editeventref.glade:38
 #: ../gramps/gui/glade/editfamily.glade:21
 #: ../gramps/gui/glade/editldsord.glade:39
@@ -13101,7 +13106,8 @@ msgstr "Sélectionner un répertoire media"
 #: ../gramps/gui/glade/editplaceref.glade:39
 #: ../gramps/gui/glade/editreporef.glade:22
 #: ../gramps/gui/glade/editrepository.glade:22
-#: ../gramps/gui/glade/editsource.glade:23 ../gramps/gui/glade/editurl.glade:21
+#: ../gramps/gui/glade/editsource.glade:23
+#: ../gramps/gui/glade/editurl.glade:21
 #: ../gramps/gui/glade/mergecitation.glade:21
 #: ../gramps/gui/glade/mergedata.glade:25
 #: ../gramps/gui/glade/mergedata.glade:246
@@ -13207,7 +13213,7 @@ msgstr "Choisir une police"
 # https://gramps-project.org/bugs/view.php?id=11286
 #: ../gramps/gui/configure.py:2003 ../gramps/gui/configure.py:2108
 msgid "Select default death symbol"
-msgstr "Sélectionner le symbole par défaut de mort"
+msgstr "Sélectionner le symbole par défaut de décès"
 
 # https://gramps-project.org/bugs/view.php?id=11286
 #: ../gramps/gui/configure.py:2012
@@ -13420,13 +13426,15 @@ msgstr "Information sur la base de données"
 # master
 #: ../gramps/gui/dbman.py:121 ../gramps/gui/editors/edittaglist.py:120
 #: ../gramps/gui/glade/addmedia.glade:38
-#: ../gramps/gui/glade/baseselector.glade:40 ../gramps/gui/glade/book.glade:482
-#: ../gramps/gui/glade/book.glade:572 ../gramps/gui/glade/configure.glade:39
-#: ../gramps/gui/glade/dbman.glade:24 ../gramps/gui/glade/editaddress.glade:36
+#: ../gramps/gui/glade/baseselector.glade:40
+#: ../gramps/gui/glade/book.glade:482 ../gramps/gui/glade/book.glade:572
+#: ../gramps/gui/glade/configure.glade:39 ../gramps/gui/glade/dbman.glade:24
+#: ../gramps/gui/glade/editaddress.glade:36
 #: ../gramps/gui/glade/editattribute.glade:37
 #: ../gramps/gui/glade/editchildref.glade:38
 #: ../gramps/gui/glade/editcitation.glade:57
-#: ../gramps/gui/glade/editdate.glade:85 ../gramps/gui/glade/editevent.glade:40
+#: ../gramps/gui/glade/editdate.glade:85
+#: ../gramps/gui/glade/editevent.glade:40
 #: ../gramps/gui/glade/editeventref.glade:54
 #: ../gramps/gui/glade/editfamily.glade:40
 #: ../gramps/gui/glade/editldsord.glade:55
@@ -13442,7 +13450,8 @@ msgstr "Information sur la base de données"
 #: ../gramps/gui/glade/editplaceref.glade:55
 #: ../gramps/gui/glade/editreporef.glade:41
 #: ../gramps/gui/glade/editrepository.glade:40
-#: ../gramps/gui/glade/editsource.glade:40 ../gramps/gui/glade/editurl.glade:37
+#: ../gramps/gui/glade/editsource.glade:40
+#: ../gramps/gui/glade/editurl.glade:37
 #: ../gramps/gui/glade/mergecitation.glade:37
 #: ../gramps/gui/glade/mergedata.glade:262
 #: ../gramps/gui/glade/mergedata.glade:451
@@ -13456,12 +13465,14 @@ msgstr "Information sur la base de données"
 #: ../gramps/gui/glade/mergerepository.glade:37
 #: ../gramps/gui/glade/mergesource.glade:37
 #: ../gramps/gui/glade/reorder.glade:38 ../gramps/gui/glade/rule.glade:333
-#: ../gramps/gui/glade/rule.glade:764 ../gramps/gui/glade/styleeditor.glade:103
+#: ../gramps/gui/glade/rule.glade:764
+#: ../gramps/gui/glade/styleeditor.glade:103
 #: ../gramps/gui/glade/styleeditor.glade:1754
 #: ../gramps/gui/plug/_guioptions.py:80
 #: ../gramps/gui/plug/report/_reportdialog.py:166 ../gramps/gui/utils.py:194
 #: ../gramps/gui/viewmanager.py:1659 ../gramps/gui/views/tags.py:683
-#: ../gramps/plugins/tool/check.py:781 ../gramps/plugins/tool/patchnames.py:118
+#: ../gramps/plugins/tool/check.py:781
+#: ../gramps/plugins/tool/patchnames.py:118
 #: ../gramps/plugins/tool/populatesources.py:91
 #: ../gramps/plugins/tool/testcasegenerator.py:328
 msgid "_OK"
@@ -13986,13 +13997,15 @@ msgstr "_Attributs"
 #: ../gramps/plugins/tool/notrelated.py:127
 #: ../gramps/plugins/tool/patchnames.py:404
 #: ../gramps/plugins/tool/removeunused.py:195
-#: ../gramps/plugins/tool/sortevents.py:56 ../gramps/plugins/tool/verify.py:572
+#: ../gramps/plugins/tool/sortevents.py:56
+#: ../gramps/plugins/tool/verify.py:572
 #: ../gramps/plugins/view/citationlistview.py:99
 #: ../gramps/plugins/view/citationtreeview.py:94
 #: ../gramps/plugins/view/eventview.py:79
 #: ../gramps/plugins/view/familyview.py:79
-#: ../gramps/plugins/view/mediaview.py:95 ../gramps/plugins/view/noteview.py:80
-#: ../gramps/plugins/view/relview.py:731 ../gramps/plugins/view/repoview.py:86
+#: ../gramps/plugins/view/mediaview.py:95
+#: ../gramps/plugins/view/noteview.py:80 ../gramps/plugins/view/relview.py:731
+#: ../gramps/plugins/view/repoview.py:86
 #: ../gramps/plugins/view/sourceview.py:83
 msgid "ID"
 msgstr "ID"
@@ -14060,14 +14073,12 @@ msgid "Move Down"
 msgstr "Déplacer vers le bas"
 
 #: ../gramps/gui/editors/displaytabs/buttontab.py:76
-#, fuzzy
 msgid "Move Left"
-msgstr "Supérieur gauche"
+msgstr "Déplacer à gauche"
 
 #: ../gramps/gui/editors/displaytabs/buttontab.py:77
-#, fuzzy
 msgid "Move right"
-msgstr "Licence"
+msgstr "Déplacer à droite"
 
 # trunk
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:69
@@ -15471,7 +15482,8 @@ msgid "Add Person (%s)"
 msgstr "Ajouter l'individu (%s)"
 
 #: ../gramps/gui/editors/editperson.py:865
-#: ../gramps/plugins/view/relview.py:711 ../gramps/plugins/view/relview.py:1170
+#: ../gramps/plugins/view/relview.py:711
+#: ../gramps/plugins/view/relview.py:1170
 #: ../gramps/plugins/view/relview.py:1225
 #: ../gramps/plugins/view/relview.py:1339
 #: ../gramps/plugins/view/relview.py:1458
@@ -15531,7 +15543,8 @@ msgid "manual|Place_Editor_dialog"
 msgstr "Éditeur de lieu"
 
 #: ../gramps/gui/editors/editplace.py:91
-#: ../gramps/gui/glade/editplace.glade:355 ../gramps/gui/merge/mergeplace.py:55
+#: ../gramps/gui/glade/editplace.glade:355
+#: ../gramps/gui/merge/mergeplace.py:55
 msgid "place|Name:"
 msgstr "Nom du lieu :"
 
@@ -15961,7 +15974,8 @@ msgid "Rule Name"
 msgstr "Nom de la règle"
 
 #: ../gramps/gui/editors/filtereditor.py:772
-#: ../gramps/gui/editors/filtereditor.py:776 ../gramps/gui/glade/rule.glade:914
+#: ../gramps/gui/editors/filtereditor.py:776
+#: ../gramps/gui/glade/rule.glade:914
 msgid "No rule selected"
 msgstr "Aucune règle retenue"
 
@@ -16157,8 +16171,9 @@ msgid "%s does not contain"
 msgstr "%s ne contient pas"
 
 # Substantif (GNOME fr)
-#: ../gramps/gui/filters/_searchbar.py:168 ../gramps/gui/views/listview.py:1198
-#: ../gramps/gui/views/listview.py:1218 ../gramps/plugins/gramplet/leak.py:193
+#: ../gramps/gui/filters/_searchbar.py:168
+#: ../gramps/gui/views/listview.py:1198 ../gramps/gui/views/listview.py:1218
+#: ../gramps/plugins/gramplet/leak.py:193
 #: ../gramps/plugins/gramplet/leak.py:200
 msgid "Updating display..."
 msgstr "Chargement en cours..."
@@ -16579,7 +16594,8 @@ msgstr "Mises en garde gramps"
 #: ../gramps/gui/glade/editplacename.glade:44
 #: ../gramps/gui/glade/editreporef.glade:50
 #: ../gramps/gui/glade/editrepository.glade:48
-#: ../gramps/gui/glade/editsource.glade:46 ../gramps/gui/glade/editurl.glade:46
+#: ../gramps/gui/glade/editsource.glade:46
+#: ../gramps/gui/glade/editurl.glade:46
 msgid "Accept changes and close window"
 msgstr "Accepter les modifications et fermer la fenêtre"
 
@@ -18190,7 +18206,8 @@ msgstr "Note 2 "
 
 # une note
 #: ../gramps/gui/glade/mergenote.glade:278
-#: ../gramps/gui/glade/mergenote.glade:294 ../gramps/gui/views/listview.py:1069
+#: ../gramps/gui/glade/mergenote.glade:294
+#: ../gramps/gui/views/listview.py:1069
 msgid "Format:"
 msgstr "Format :"
 
@@ -18486,7 +18503,8 @@ msgstr "Éditer la règle sélectionnée"
 msgid "Delete the selected rule"
 msgstr "Supprimer la règle sélectionnée"
 
-#: ../gramps/gui/glade/rule.glade:521 ../gramps/gui/glade/styleeditor.glade:419
+#: ../gramps/gui/glade/rule.glade:521
+#: ../gramps/gui/glade/styleeditor.glade:419
 #: ../gramps/plugins/tool/finddupes.glade:132
 #: ../gramps/plugins/tool/mergecitations.glade:132
 #: ../gramps/plugins/tool/sortevents.py:83
@@ -18778,14 +18796,16 @@ msgstr "_Afficher au démarrage"
 #: ../gramps/plugins/view/familyview.py:197
 #: ../gramps/plugins/view/fanchartview.py:144
 #: ../gramps/plugins/view/fanchartview.py:184
-#: ../gramps/plugins/view/geoclose.py:71 ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoclose.py:71
+#: ../gramps/plugins/view/geoclose.py:111
 #: ../gramps/plugins/view/geoevents.py:67
 #: ../gramps/plugins/view/geoevents.py:101
 #: ../gramps/plugins/view/geofamclose.py:69
 #: ../gramps/plugins/view/geofamclose.py:109
 #: ../gramps/plugins/view/geofamily.py:67
 #: ../gramps/plugins/view/geofamily.py:101
-#: ../gramps/plugins/view/geomoves.py:68 ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geomoves.py:68
+#: ../gramps/plugins/view/geomoves.py:108
 #: ../gramps/plugins/view/geoperson.py:69
 #: ../gramps/plugins/view/geoperson.py:109
 #: ../gramps/plugins/view/geoplaces.py:70
@@ -18796,7 +18816,8 @@ msgstr "_Afficher au démarrage"
 #: ../gramps/plugins/view/noteview.py:197
 #: ../gramps/plugins/view/pedigreeview.py:652
 #: ../gramps/plugins/view/pedigreeview.py:693
-#: ../gramps/plugins/view/relview.py:436 ../gramps/plugins/view/repoview.py:167
+#: ../gramps/plugins/view/relview.py:436
+#: ../gramps/plugins/view/repoview.py:167
 #: ../gramps/plugins/view/repoview.py:210
 #: ../gramps/plugins/view/sourceview.py:153
 #: ../gramps/plugins/view/sourceview.py:196
@@ -19450,7 +19471,8 @@ msgstr "Fusionner les individus"
 #: ../gramps/plugins/quickview/all_relations.py:305
 #: ../gramps/plugins/tool/notrelated.py:128
 #: ../gramps/plugins/view/pedigreeview.py:1866
-#: ../gramps/plugins/view/relview.py:667 ../gramps/plugins/view/relview.py:1033
+#: ../gramps/plugins/view/relview.py:667
+#: ../gramps/plugins/view/relview.py:1033
 #: ../gramps/plugins/view/relview.py:1068
 #: ../gramps/plugins/webreport/person.py:232
 #: ../gramps/plugins/webreport/person.py:1845
@@ -20165,9 +20187,8 @@ msgstr "Voir les données hors filtre"
 
 # master
 #: ../gramps/gui/plug/report/_bookdialog.py:92
-#, fuzzy
 msgid "Generate_Book_dialog"
-msgstr "Générer le livre"
+msgstr "Dialogue_génération_du_livre"
 
 #: ../gramps/gui/plug/report/_bookdialog.py:172
 msgid "Available Books"
@@ -20509,9 +20530,8 @@ msgstr "Styles de document"
 
 # manuel wiki
 #: ../gramps/gui/plug/report/_styleeditor.py:108
-#, fuzzy
 msgid "manual|Document_Styles_dialog"
-msgstr "Le dialogue de filtre"
+msgstr "Dialogue_styles_document"
 
 #: ../gramps/gui/plug/report/_styleeditor.py:147
 msgid "New Style"
@@ -20542,9 +20562,8 @@ msgstr "Éditeur de style"
 
 # manuel wiki
 #: ../gramps/gui/plug/report/_styleeditor.py:242
-#, fuzzy
 msgid "manual|Style_editor_dialog"
-msgstr "Éditeur de lieu"
+msgstr "Dialogue_style_éditeur"
 
 #: ../gramps/gui/plug/report/_styleeditor.py:352
 #: ../gramps/gui/plug/report/_styleeditor.py:380
@@ -20692,9 +20711,8 @@ msgstr "Sélectionner un enfant"
 
 # manuel wiki
 #: ../gramps/gui/selectors/selectperson.py:70
-#, fuzzy
 msgid "manual|Select_Person_selector"
-msgstr "Sélectionner un lieu"
+msgstr "Sélectionner_un_individu"
 
 #: ../gramps/gui/selectors/selectplace.py:60
 msgid "Select Place"
@@ -20711,9 +20729,8 @@ msgstr "Sélectionner le dépôt"
 
 # manuel wiki
 #: ../gramps/gui/selectors/selectrepository.py:75
-#, fuzzy
 msgid "manual|Select_Repository_selector"
-msgstr "Sélectionner une mère"
+msgstr "Sélectionner_un_dépôt"
 
 #: ../gramps/gui/selectors/selectsource.py:59
 msgid "Select Source"
@@ -20721,9 +20738,8 @@ msgstr "Sélectionner la source"
 
 # manuel wiki
 #: ../gramps/gui/selectors/selectsource.py:76
-#, fuzzy
 msgid "manual|Select_Source_selector"
-msgstr "Sélectionner une note"
+msgstr "Sélectionner_une_source"
 
 #: ../gramps/gui/spell.py:92
 msgid "Off"
@@ -21063,7 +21079,8 @@ msgstr "Signets"
 #: ../gramps/plugins/view/mediaview.py:253
 #: ../gramps/plugins/view/noteview.py:153
 #: ../gramps/plugins/view/pedigreeview.py:683
-#: ../gramps/plugins/view/relview.py:435 ../gramps/plugins/view/repoview.py:166
+#: ../gramps/plugins/view/relview.py:435
+#: ../gramps/plugins/view/repoview.py:166
 #: ../gramps/plugins/view/sourceview.py:152
 msgid "Organize Bookmarks"
 msgstr "Édition des signets"
@@ -21347,11 +21364,13 @@ msgstr "Élargir la section"
 msgid "Collapse this section"
 msgstr "Compresser la section"
 
-#: ../gramps/gui/widgets/fanchart.py:1825 ../gramps/plugins/view/relview.py:982
+#: ../gramps/gui/widgets/fanchart.py:1825
+#: ../gramps/plugins/view/relview.py:982
 msgid "Edit family"
 msgstr "Éditer la famille"
 
-#: ../gramps/gui/widgets/fanchart.py:1841 ../gramps/plugins/view/relview.py:983
+#: ../gramps/gui/widgets/fanchart.py:1841
+#: ../gramps/plugins/view/relview.py:983
 msgid "Reorder families"
 msgstr "Réorganiser les familles"
 
@@ -21390,9 +21409,8 @@ msgid "Add Child to Family"
 msgstr "Ajouter un enfant à la famille"
 
 #: ../gramps/gui/widgets/grampletbar.py:118
-#, fuzzy
 msgid "Gramplet Bar Menu"
-msgstr "Barre Gramplet"
+msgstr "Menu Gramplet barre"
 
 #: ../gramps/gui/widgets/grampletbar.py:207
 #: ../gramps/gui/widgets/grampletpane.py:1194
@@ -21519,9 +21537,8 @@ msgid "Progress Information"
 msgstr "Information de progression"
 
 #: ../gramps/gui/widgets/reorderfam.py:63
-#, fuzzy
 msgid "manual|Reorder_Relationships_dialog"
-msgstr "Réorganiser les relations"
+msgstr "Dialogue_réorganiser_les_relations"
 
 #: ../gramps/gui/widgets/reorderfam.py:91
 msgid "Reorder Relationships"
@@ -21557,12 +21574,16 @@ msgid ""
 "\n"
 "Command-Click to follow link"
 msgstr ""
+"\n"
+"Cliquez (commande) pour suivre le lien"
 
 #: ../gramps/gui/widgets/styledtexteditor.py:402
 msgid ""
 "\n"
 "Ctrl-Click to follow link"
 msgstr ""
+"\n"
+"Cliquez (Ctrl) pour suivre le lien"
 
 #. spell checker submenu
 #: ../gramps/gui/widgets/styledtexteditor.py:450
@@ -21629,7 +21650,7 @@ msgstr "Base de données _BSDDB"
 # master
 #: ../gramps/plugins/db/bsddb/bsddb.gpr.py:28
 msgid "Berkeley Software Distribution Database Backend"
-msgstr ""
+msgstr "Support Berkeley Software Distribution Database"
 
 # master
 #: ../gramps/plugins/db/bsddb/upgrade.py:410
@@ -21790,14 +21811,16 @@ msgstr "Génère des documents au format texte (.txt)."
 #: ../gramps/plugins/docgen/docgen.gpr.py:55
 #: ../gramps/plugins/view/fanchartview.py:164
 #: ../gramps/plugins/view/fanchartview.py:227
-#: ../gramps/plugins/view/geoclose.py:91 ../gramps/plugins/view/geoclose.py:167
+#: ../gramps/plugins/view/geoclose.py:91
+#: ../gramps/plugins/view/geoclose.py:167
 #: ../gramps/plugins/view/geoevents.py:81
 #: ../gramps/plugins/view/geoevents.py:129
 #: ../gramps/plugins/view/geofamclose.py:89
 #: ../gramps/plugins/view/geofamclose.py:165
 #: ../gramps/plugins/view/geofamily.py:81
 #: ../gramps/plugins/view/geofamily.py:131
-#: ../gramps/plugins/view/geomoves.py:88 ../gramps/plugins/view/geomoves.py:151
+#: ../gramps/plugins/view/geomoves.py:88
+#: ../gramps/plugins/view/geomoves.py:151
 #: ../gramps/plugins/view/geoperson.py:89
 #: ../gramps/plugins/view/geoplaces.py:84
 #: ../gramps/plugins/view/geoplaces.py:134
@@ -23291,10 +23314,11 @@ msgstr "Information individuelle manquante"
 msgid "(Living people: %(option_name)s)"
 msgstr "(Individus vivants : %(option_name)s)"
 
+# individus (genre) nés ..
 #: ../gramps/plugins/drawreport/statisticschart.py:801
 #, python-format
 msgid "%s born"
-msgstr ""
+msgstr "%s né(s)"
 
 # https://gramps-project.org/bugs/view.php?id=11286
 #: ../gramps/plugins/drawreport/statisticschart.py:803
@@ -25094,9 +25118,8 @@ msgid "Gramplet showing the events for all the family"
 msgstr "Gramplet affichant tous les événements pour toute la famille"
 
 #: ../gramps/plugins/gramplet/leak.py:99
-#, fuzzy
 msgid "Referrer"
-msgstr "Référence"
+msgstr "Référent"
 
 #: ../gramps/plugins/gramplet/leak.py:103
 msgid "Uncollected object"
@@ -25108,7 +25131,7 @@ msgstr "Actualiser"
 
 #: ../gramps/plugins/gramplet/leak.py:122
 msgid "Press Refresh to see initial results"
-msgstr ""
+msgstr "Appuyez sur Rafraichir pour voir les résultats initiaux"
 
 #: ../gramps/plugins/gramplet/leak.py:158
 #, python-format
@@ -25126,9 +25149,8 @@ msgid "Uncollected Objects: %s"
 msgstr "Objets non collectés : %s"
 
 #: ../gramps/plugins/gramplet/leak.py:239
-#, fuzzy
 msgid "Reference Error"
-msgstr "Référence"
+msgstr "Erreur de référence"
 
 #: ../gramps/plugins/gramplet/locations.py:81
 msgid "Double-click on a row to edit the selected place."
@@ -25308,9 +25330,9 @@ msgid "Active person: %s"
 msgstr "Individu actif : %s"
 
 #: ../gramps/plugins/gramplet/relativegramplet.py:88
-#, fuzzy, python-format
+#, python-format
 msgid "%(count)d. %(relation)s: "
-msgstr "%(person)s, naissance%(relation)s"
+msgstr "%(count)d. %(relation)s: "
 
 #: ../gramps/plugins/gramplet/relativegramplet.py:94
 #, python-format
@@ -26607,124 +26629,100 @@ msgstr "individu"
 
 # trunk
 #: ../gramps/plugins/importer/importcsv.py:210
-#, fuzzy
 msgid "Occupation description"
-msgstr "Description de la version"
+msgstr "Description de la profession"
 
 #: ../gramps/plugins/importer/importcsv.py:210
-#, fuzzy
 msgid "occupationdescr"
-msgstr "Profession"
+msgstr "professiondescr"
 
 #: ../gramps/plugins/importer/importcsv.py:211
-#, fuzzy
 msgid "Occupation date"
-msgstr "Profession"
+msgstr "Date profession"
 
 #: ../gramps/plugins/importer/importcsv.py:211
-#, fuzzy
 msgid "occupationdate"
-msgstr "Profession"
+msgstr "professiondate"
 
 #: ../gramps/plugins/importer/importcsv.py:212
-#, fuzzy
 msgid "Occupation place"
-msgstr "Profession"
+msgstr "Lieu de la profession"
 
 #: ../gramps/plugins/importer/importcsv.py:212
-#, fuzzy
 msgid "occupationplace"
-msgstr "Profession"
+msgstr "professionlieu"
 
 #: ../gramps/plugins/importer/importcsv.py:213
-#, fuzzy
 msgid "Occupation place id"
-msgstr "Profession"
+msgstr "Id lieu de la profession"
 
 #: ../gramps/plugins/importer/importcsv.py:213
-#, fuzzy
 msgid "occupationplace_id"
-msgstr "Profession"
+msgstr "professionlieu_id"
 
 #: ../gramps/plugins/importer/importcsv.py:214
-#, fuzzy
 msgid "Occupation source"
-msgstr "Profession"
+msgstr "Source de la profession"
 
 #: ../gramps/plugins/importer/importcsv.py:214
-#, fuzzy
 msgid "occupationsource"
-msgstr "Profession"
+msgstr "professionsource"
 
 #: ../gramps/plugins/importer/importcsv.py:216
-#, fuzzy
 msgid "residence date"
-msgstr "Résidence"
+msgstr "date de la résidence"
 
 #: ../gramps/plugins/importer/importcsv.py:216
-#, fuzzy
 msgid "residencedate"
-msgstr "Résidence"
+msgstr "résidencedate"
 
 #: ../gramps/plugins/importer/importcsv.py:217
-#, fuzzy
 msgid "residence place"
-msgstr "Résidence"
+msgstr "lieu de la résidence"
 
 #: ../gramps/plugins/importer/importcsv.py:217
-#, fuzzy
 msgid "residenceplace"
-msgstr "Résidence"
+msgstr "résidencelieu"
 
 #: ../gramps/plugins/importer/importcsv.py:218
-#, fuzzy
 msgid "residence place id"
-msgstr "ID du lieu de décès"
+msgstr "Id lieu de la résidence"
 
 #: ../gramps/plugins/importer/importcsv.py:218
-#, fuzzy
 msgid "residenceplace_id"
-msgstr "Résidence"
+msgstr "résidencelieu_id"
 
 #: ../gramps/plugins/importer/importcsv.py:219
-#, fuzzy
 msgid "residence source"
-msgstr "Inclure les sources"
+msgstr "source résidence"
 
 #: ../gramps/plugins/importer/importcsv.py:219
-#, fuzzy
 msgid "residencesource"
-msgstr "Résidence"
+msgstr "résidencesource"
 
 #: ../gramps/plugins/importer/importcsv.py:221
-#, fuzzy
 msgid "attribute type"
-msgstr "Note sur l'attribut"
+msgstr "type d'attribut"
 
 #: ../gramps/plugins/importer/importcsv.py:221
-#, fuzzy
 msgid "attributetype"
-msgstr "Note sur l'attribut"
+msgstr "attributtype"
 
 #: ../gramps/plugins/importer/importcsv.py:222
-#, fuzzy
 msgid "attribute value"
-msgstr "Note sur l'attribut"
+msgstr "valeur de l'attribut"
 
 #: ../gramps/plugins/importer/importcsv.py:222
-#, fuzzy
 msgid "attributevalue"
-msgstr "Attribut"
+msgstr "attributvalue"
 
 #: ../gramps/plugins/importer/importcsv.py:223
-#, fuzzy
 msgid "attribute source"
-msgstr "Note sur l'attribut"
+msgstr "source de l'attribut"
 
 #: ../gramps/plugins/importer/importcsv.py:223
-#, fuzzy
 msgid "attributesource"
-msgstr "Attributs"
+msgstr "attributsource"
 
 #. ----------------------------------
 #: ../gramps/plugins/importer/importcsv.py:226
@@ -27099,21 +27097,23 @@ msgstr ""
 
 #: ../gramps/plugins/importer/importprogen.glade:49
 #: ../gramps/plugins/importer/importprogen.glade:70
-#, fuzzy
 msgid ""
 "Source reference\n"
 "(out of Settings)"
-msgstr "Note sur la référence de la source"
+msgstr ""
+"Référence de la source\n"
+"(hors configuration)"
 
 #: ../gramps/plugins/importer/importprogen.glade:124
 msgid ""
 "Source reference text\n"
 "(Text & import Filename)."
 msgstr ""
+"Texte de la référence de la source\n"
+"(texte & nom du fichier d'importation)."
 
 #: ../gramps/plugins/importer/importprogen.glade:155
 #: ../gramps/plugins/importer/importprogen.glade:325
-#, fuzzy
 msgid "Attribut"
 msgstr "Attribut"
 
@@ -27122,51 +27122,58 @@ msgid ""
 "Source attribute text\n"
 "(Text, import Filename & (System-)Date)."
 msgstr ""
+"Texte de l'attribut de la source\n"
+"(text, nom de fichier d'importation & date système)."
 
 #: ../gramps/plugins/importer/importprogen.glade:190
 #: ../gramps/plugins/importer/importprogen.glade:207
-#, fuzzy
 msgid "Citation reference."
-msgstr "Références de la citation"
+msgstr "Référence de la citation."
 
 #: ../gramps/plugins/importer/importprogen.glade:274
 msgid ""
 "Citation confidence level\n"
 "(Very low - very high)."
 msgstr ""
+"Niveau de confiance pour la citation\n"
+"(très bas - très haut)."
 
 #: ../gramps/plugins/importer/importprogen.glade:308
 msgid ""
 "Citation volume/page text\n"
 "(Text & (System-)Date)."
 msgstr ""
+"Texte pour le volume/page de la citation\n"
+"(text & date système)."
 
 #: ../gramps/plugins/importer/importprogen.glade:341
 msgid ""
 "Citation attribute text\n"
 "(Text, import Filename & (System-)Date)."
 msgstr ""
+"Texte de l'attribut de la citation\n"
+"(texte, nom de fichier d'importation & date système)."
 
 #: ../gramps/plugins/importer/importprogen.glade:362
-#, fuzzy
 msgid "Import Text"
-msgstr "Import"
+msgstr "Texte d'importation"
 
 #: ../gramps/plugins/importer/importprogen.glade:415
 msgid ""
 "Default Tagtext\n"
 "(out of Settings)."
 msgstr ""
+"Texte de l'étiquette par défaut\n"
+"(hors configuration)."
 
 # master
 #: ../gramps/plugins/importer/importprogen.glade:443
-#, fuzzy
 msgid "Import Filename."
-msgstr "Importation d'un arbre familial"
+msgstr "Nom du fichier d'importation."
 
 #: ../gramps/plugins/importer/importprogen.glade:492
 msgid "Default (System-)Date."
-msgstr ""
+msgstr "Date système par défaut."
 
 #: ../gramps/plugins/importer/importprogen.glade:766
 #: ../gramps/plugins/importer/importprogen.glade:781
@@ -27176,65 +27183,75 @@ msgstr ""
 #: ../gramps/plugins/importer/importprogen.glade:841
 #: ../gramps/plugins/importer/importprogen.glade:856
 msgid "Combined default text + filename + date."
-msgstr ""
+msgstr "Combinaison de texte par défaut + nom de fichier + date."
 
 #: ../gramps/plugins/importer/importprogen.glade:1111
 msgid ""
 "Copy Default Text\n"
 "to all Tag Text'."
 msgstr ""
+"Copier le texte par défaut\n"
+"vers tous les textes des étiquettes'."
 
 #: ../gramps/plugins/importer/importprogen.glade:1130
 msgid ""
 "Copy Default Filename\n"
 "to all sensitive Tag Text'."
 msgstr ""
+"Copier le nom de fichier par défaut\n"
+"vers tous les textes des étiquettes'."
 
 #: ../gramps/plugins/importer/importprogen.glade:1149
 msgid ""
 "Copy Default Date\n"
 "to all sensitive Tag Text'."
 msgstr ""
+"Copier la date par défaut\n"
+"pour tous les texte des étiquettes'."
 
 #: ../gramps/plugins/importer/importprogen.glade:1164
-#, fuzzy
 msgid "  Objects"
-msgstr "Objet"
+msgstr "  Objets"
 
 #: ../gramps/plugins/importer/importprogen.glade:1168
 msgid ""
 "Enable/Disable\n"
 "all object tags."
 msgstr ""
+"Activer/désactiver\n"
+"toutes les étiquettes objet."
 
 #: ../gramps/plugins/importer/importprogen.glade:1198
-#, fuzzy
 msgid "Tag Text"
-msgstr "Texte brut"
+msgstr "Texte de l'étiquette"
 
-# supprimer car efface l'objet
 #: ../gramps/plugins/importer/importprogen.glade:1217
-#, fuzzy
 msgid "Import Objects"
-msgstr "_Supprimer l'objet"
+msgstr "Importation des objets"
 
 #: ../gramps/plugins/importer/importprogen.glade:1241
 msgid ""
 "Enable/Disable\n"
 "Person import."
 msgstr ""
+"Activer/désactiver\n"
+"l'importation de l'individu."
 
 #: ../gramps/plugins/importer/importprogen.glade:1260
 msgid ""
 "Enable/Disable\n"
 "Family import."
 msgstr ""
+"Activer/désactiver\n"
+"l'importation de la famille."
 
 #: ../gramps/plugins/importer/importprogen.glade:1279
 msgid ""
 "Enable/Disable\n"
 "Child import."
 msgstr ""
+"Activer/désactiver\n"
+"l'importation de l'enfant."
 
 #: ../gramps/plugins/importer/importprogen.glade:1330
 msgid ""
@@ -27255,35 +27272,32 @@ msgstr ""
 "comme identifiant Gramps."
 
 #: ../gramps/plugins/importer/importprogen.glade:1369
-#, fuzzy
 msgid "Identifier"
-msgstr "Mode"
+msgstr "Identifiant"
 
-# espace limité ...
-# master
 #: ../gramps/plugins/importer/importprogen.glade:1400
-#, fuzzy
 msgid "Name change"
-msgstr "Dernier changement"
+msgstr "Changement de nom"
 
 #: ../gramps/plugins/importer/importprogen.glade:1461
-#, fuzzy
 msgid "Event date"
 msgstr "Date de l'événement"
 
 #: ../gramps/plugins/importer/importprogen.glade:1476
-#, fuzzy
 msgid ""
 "Store birth date in\n"
 "event description."
-msgstr "Extraire les descriptions de l'événement"
+msgstr ""
+"Stocke la date de naissance dans\n"
+"la description de l'événement."
 
 #: ../gramps/plugins/importer/importprogen.glade:1495
-#, fuzzy
 msgid ""
 "Store death date in\n"
 "event description."
-msgstr "Extraire les descriptions de l'événement"
+msgstr ""
+"Stocke la date de décès dans\n"
+"la description de l'événement."
 
 #: ../gramps/plugins/importer/importprogen.glade:1515
 msgid "Diverse"
@@ -27298,6 +27312,8 @@ msgid ""
 "Store REFN number\n"
 "in event description."
 msgstr ""
+"Stocker le numéro REFN\n"
+"dans la description de l'événement."
 
 #: ../gramps/plugins/importer/importprogen.glade:1548
 #: ../gramps/plugins/importer/importprogen.glade:1595
@@ -27305,47 +27321,48 @@ msgid ""
 "Use death information\n"
 "as death cause event."
 msgstr ""
+"Utiliser l'information de décès\n"
+"comme cause de l'événement décès."
 
 #: ../gramps/plugins/importer/importprogen.glade:1598
-#, fuzzy
 msgid "(-cause)"
-msgstr "Cause"
+msgstr "(- cause)"
 
 #: ../gramps/plugins/importer/importprogen.glade:1610
-#, fuzzy
 msgid "Male surname"
-msgstr "Sélection du nom de famille"
+msgstr "Nom masculin"
 
 #: ../gramps/plugins/importer/importprogen.glade:1614
 msgid ""
 "Change name of male\n"
 "to e.g. wifes name."
 msgstr ""
+"Changer le nom des hommes\n"
+"par exemple, nom des épouses."
 
 #: ../gramps/plugins/importer/importprogen.glade:1629
-#, fuzzy
 msgid "Female surname"
-msgstr "Sélection du nom de famille"
+msgstr "Nom féminin"
 
 #: ../gramps/plugins/importer/importprogen.glade:1633
 msgid ""
 "Change name of female\n"
 "to e.g. husbands name."
 msgstr ""
+"Changer le nom des femmes\n"
+"pour par exemple, le nom des conjoints."
 
 #: ../gramps/plugins/importer/importprogen.glade:1692
-#, fuzzy
 msgid "Option"
-msgstr "Options"
+msgstr "Option"
 
 #: ../gramps/plugins/importer/importprogen.glade:1731
-#, fuzzy
 msgid "_Ok"
-msgstr "Ok"
+msgstr "_Ok"
 
 #: ../gramps/plugins/importer/importprogen.py:62
 msgid "manual|Import_from_another_genealogy_program"
-msgstr ""
+msgstr "Import_from_another_genealogy_program/fr"
 
 # master
 #: ../gramps/plugins/importer/importprogen.py:121
@@ -27362,9 +27379,8 @@ msgstr "Erreur de donnée Pro-Gen"
 # master
 #: ../gramps/plugins/importer/importprogen.py:457
 #: ../gramps/plugins/importer/importprogen.py:465
-#, fuzzy
 msgid "Import Pro-Gen"
-msgstr "Importer depuis Pro-Gen (%s)"
+msgstr "Importer depuis Pro-Gen"
 
 # master
 #: ../gramps/plugins/importer/importvcard.py:228
@@ -31928,9 +31944,11 @@ msgstr "Exporter l'affichage..."
 #: ../gramps/plugins/view/eventview.py:183
 #: ../gramps/plugins/view/familyview.py:142
 #: ../gramps/plugins/view/fanchartview.py:172
-#: ../gramps/plugins/view/geoclose.py:99 ../gramps/plugins/view/geoevents.py:89
+#: ../gramps/plugins/view/geoclose.py:99
+#: ../gramps/plugins/view/geoevents.py:89
 #: ../gramps/plugins/view/geofamclose.py:97
-#: ../gramps/plugins/view/geofamily.py:89 ../gramps/plugins/view/geomoves.py:96
+#: ../gramps/plugins/view/geofamily.py:89
+#: ../gramps/plugins/view/geomoves.py:96
 #: ../gramps/plugins/view/geoperson.py:97
 #: ../gramps/plugins/view/geoplaces.py:92
 #: ../gramps/plugins/view/mediaview.py:242
@@ -31961,14 +31979,16 @@ msgstr "_Ajouter un signet"
 #: ../gramps/plugins/view/familyview.py:279
 #: ../gramps/plugins/view/fanchartview.py:144
 #: ../gramps/plugins/view/fanchartview.py:184
-#: ../gramps/plugins/view/geoclose.py:71 ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoclose.py:71
+#: ../gramps/plugins/view/geoclose.py:111
 #: ../gramps/plugins/view/geoevents.py:67
 #: ../gramps/plugins/view/geoevents.py:101
 #: ../gramps/plugins/view/geofamclose.py:69
 #: ../gramps/plugins/view/geofamclose.py:109
 #: ../gramps/plugins/view/geofamily.py:67
 #: ../gramps/plugins/view/geofamily.py:101
-#: ../gramps/plugins/view/geomoves.py:68 ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geomoves.py:68
+#: ../gramps/plugins/view/geomoves.py:108
 #: ../gramps/plugins/view/geoperson.py:69
 #: ../gramps/plugins/view/geoperson.py:109
 #: ../gramps/plugins/view/geoplaces.py:70
@@ -31981,7 +32001,8 @@ msgstr "_Ajouter un signet"
 #: ../gramps/plugins/view/noteview.py:279
 #: ../gramps/plugins/view/pedigreeview.py:652
 #: ../gramps/plugins/view/pedigreeview.py:693
-#: ../gramps/plugins/view/relview.py:436 ../gramps/plugins/view/repoview.py:167
+#: ../gramps/plugins/view/relview.py:436
+#: ../gramps/plugins/view/repoview.py:167
 #: ../gramps/plugins/view/repoview.py:210
 #: ../gramps/plugins/view/repoview.py:292
 #: ../gramps/plugins/view/sourceview.py:153
@@ -31995,10 +32016,12 @@ msgstr "_Précédent"
 #: ../gramps/plugins/lib/libpersonview.py:355
 #: ../gramps/plugins/view/fanchartview.py:144
 #: ../gramps/plugins/view/fanchartview.py:184
-#: ../gramps/plugins/view/geoclose.py:71 ../gramps/plugins/view/geoclose.py:111
+#: ../gramps/plugins/view/geoclose.py:71
+#: ../gramps/plugins/view/geoclose.py:111
 #: ../gramps/plugins/view/geofamclose.py:69
 #: ../gramps/plugins/view/geofamclose.py:109
-#: ../gramps/plugins/view/geomoves.py:68 ../gramps/plugins/view/geomoves.py:108
+#: ../gramps/plugins/view/geomoves.py:68
+#: ../gramps/plugins/view/geomoves.py:108
 #: ../gramps/plugins/view/geoperson.py:69
 #: ../gramps/plugins/view/geoperson.py:109
 #: ../gramps/plugins/view/pedigreeview.py:652
@@ -32137,7 +32160,8 @@ msgstr "Aller à l'individu par défaut"
 #: ../gramps/plugins/view/mediaview.py:297
 #: ../gramps/plugins/view/noteview.py:197
 #: ../gramps/plugins/view/pedigreeview.py:693
-#: ../gramps/plugins/view/relview.py:436 ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/relview.py:436
+#: ../gramps/plugins/view/repoview.py:210
 #: ../gramps/plugins/view/sourceview.py:196
 msgid "Go to the next object in the history"
 msgstr "Aller à l'objet suivant dans l'historique"
@@ -32159,7 +32183,8 @@ msgstr "Aller à l'objet suivant dans l'historique"
 #: ../gramps/plugins/view/mediaview.py:297
 #: ../gramps/plugins/view/noteview.py:197
 #: ../gramps/plugins/view/pedigreeview.py:693
-#: ../gramps/plugins/view/relview.py:436 ../gramps/plugins/view/repoview.py:210
+#: ../gramps/plugins/view/relview.py:436
+#: ../gramps/plugins/view/repoview.py:210
 #: ../gramps/plugins/view/sourceview.py:196
 msgid "Go to the previous object in the history"
 msgstr "Aller à l'objet précédent dans l'historique"
@@ -32171,8 +32196,9 @@ msgstr "Aller à l'objet précédent dans l'historique"
 #: ../gramps/plugins/view/eventview.py:268
 #: ../gramps/plugins/view/familyview.py:227
 #: ../gramps/plugins/view/mediaview.py:327
-#: ../gramps/plugins/view/noteview.py:227 ../gramps/plugins/view/relview.py:393
-#: ../gramps/plugins/view/relview.py:479 ../gramps/plugins/view/repoview.py:240
+#: ../gramps/plugins/view/noteview.py:227
+#: ../gramps/plugins/view/relview.py:393 ../gramps/plugins/view/relview.py:479
+#: ../gramps/plugins/view/repoview.py:240
 #: ../gramps/plugins/view/sourceview.py:226
 msgid "Edit..."
 msgstr "Éditer..."
@@ -32187,9 +32213,8 @@ msgstr "Éditer..."
 #: ../gramps/plugins/view/noteview.py:279
 #: ../gramps/plugins/view/repoview.py:292
 #: ../gramps/plugins/view/sourceview.py:278
-#, fuzzy
 msgid "Forward"
-msgstr "_Suivant"
+msgstr "Suivant"
 
 # objet sélectionné
 #: ../gramps/plugins/lib/libpersonview.py:454
@@ -32356,11 +32381,8 @@ msgid "Provides the Base needed for the List People views."
 msgstr "Fournit la base nécessaire à la liste dans les vues Individus."
 
 #: ../gramps/plugins/lib/libplugins.gpr.py:247
-#, fuzzy
 msgid "Provides common functionality for Pro-Gen import"
-msgstr ""
-"Fournit une fonctionnalité commune pour l'importation et l'exportation "
-"Gramps XML."
+msgstr "Fournit une fonctionnalité commune pour l'importation depuis Pro-Gen"
 
 #: ../gramps/plugins/lib/libplugins.gpr.py:265
 msgid "Provides the Base needed for the List Place views."
@@ -32384,23 +32406,21 @@ msgstr "Champ « %(fldname)s » non trouvé"
 
 # master
 #: ../gramps/plugins/lib/libprogen.py:491
-#, fuzzy, python-format
+#, python-format
 msgid "Not a (right) DEF file: %(dname)s"
-msgstr "Impossible de trouver le fichier DEF : %(dname)s"
+msgstr "Mauvais fichier DEF : %(dname)s"
 
 # master
 #: ../gramps/plugins/lib/libprogen.py:498
 #: ../gramps/plugins/lib/libprogen.py:732
-#, fuzzy
 msgid "Import from Pro-Gen"
-msgstr "Importer depuis Pro-Gen (%s)"
+msgstr "Importer depuis Pro-Gen"
 
 # Substantif (GNOME fr)
 #. start feedback about import progress (GUI / TXT)
 #: ../gramps/plugins/lib/libprogen.py:498
-#, fuzzy
 msgid "Initializing."
-msgstr "Installation..."
+msgstr "Initialisation."
 
 # master
 #. Raise a error message
@@ -32414,12 +32434,10 @@ msgstr "Importation Pro-Gen"
 
 # master
 #: ../gramps/plugins/lib/libprogen.py:539
-#, fuzzy
 msgid "Saving."
-msgstr "Recherche en cours..."
+msgstr "Enregistrement."
 
 #: ../gramps/plugins/lib/libprogen.py:928
-#, fuzzy
 msgid "Pro-Gen Import"
 msgstr "Importation Pro-Gen"
 
@@ -32431,26 +32449,23 @@ msgid "Date did not match: '%(text)s' (%(msg)s)"
 msgstr "Date non correspondante : « %(text)s » (%(msg)s)"
 
 #: ../gramps/plugins/lib/libprogen.py:1152
-#, fuzzy, python-format
+#, python-format
 msgid "Time: %s"
-msgstr "En vie : %s"
+msgstr "Période : %s"
 
 # Substantif (GNOME fr)
 #. start feedback about import progress (GUI/TXT)
 #: ../gramps/plugins/lib/libprogen.py:1206
-#, fuzzy
 msgid "Importing persons."
-msgstr "Tri des événements individuels..."
+msgstr "Importation des individus."
 
 #: ../gramps/plugins/lib/libprogen.py:1412
-#, fuzzy
 msgid "see address on "
-msgstr "_Adresse Web :"
+msgstr "voir l'adresse sur "
 
 #: ../gramps/plugins/lib/libprogen.py:1415
-#, fuzzy
 msgid "see also address"
-msgstr "_Adresse Web :"
+msgstr "voir également l'adresse"
 
 #: ../gramps/plugins/lib/libprogen.py:1515
 msgid "Death cause"
@@ -32459,9 +32474,8 @@ msgstr "Cause de décès"
 # Substantif (GNOME fr)
 #. start feedback about import progress (GUI/TXT)
 #: ../gramps/plugins/lib/libprogen.py:1584
-#, fuzzy
 msgid "Importing families."
-msgstr "Écriture des familles"
+msgstr "Importation des familles."
 
 #: ../gramps/plugins/lib/libprogen.py:1689
 msgid "Civil union"
@@ -32469,34 +32483,30 @@ msgstr "Union civile"
 
 # master
 #: ../gramps/plugins/lib/libprogen.py:1794
-#, fuzzy
 msgid "Wedding"
-msgstr "Remplissage :"
+msgstr "Marriage"
 
 #: ../gramps/plugins/lib/libprogen.py:1829
 msgid "future"
-msgstr ""
+msgstr "future"
 
 #. We have seen some case insensitivity in DEF files ...
 #. F13: Father
 #. F14: Mother
 #. start feedback about import progress (GUI/TXT)
 #: ../gramps/plugins/lib/libprogen.py:1901
-#, fuzzy
 msgid "Adding children."
-msgstr " (pas d'enfant)"
+msgstr "Ajout d'enfants."
 
 # master
 #: ../gramps/plugins/lib/libprogen.py:1927
-#, fuzzy
 msgid "Cannot find father for I%(person)s (Father=%(father))"
-msgstr "Impossible de trouver le père de I%(person)s (father=%(id)d)"
+msgstr "Impossible de trouver le père de I%(person)s (père = %(father))"
 
 # master
 #: ../gramps/plugins/lib/libprogen.py:1930
-#, fuzzy
 msgid "Cannot find mother for I%(person)s (Mother=%(mother))"
-msgstr "Impossible de trouver la mère de I%(person)s (mother=%(mother)d)"
+msgstr "Impossible de trouver la mère de I%(person)s (père = %(father))"
 
 #: ../gramps/plugins/lib/librecords.py:55
 msgid "Youngest living person"
@@ -32807,12 +32817,17 @@ msgid ""
 "In the following table you may have :\n"
 " - a green row related to a selected place."
 msgstr ""
+"\n"
+"Dans le tableau suivant vous pouvez voir :\n"
+" - une ligne verte liée au lieu sélectionné."
 
 #: ../gramps/plugins/lib/maps/placeselection.py:128
 msgid ""
 "\n"
 " - a red row related to a geocoding result."
 msgstr ""
+"\n"
+" - une ligne rouge liée au résultat du géocodage."
 
 #: ../gramps/plugins/lib/maps/placeselection.py:165
 msgid "The green values in the row correspond to the current place values."
@@ -33868,7 +33883,7 @@ msgstr "Mon rapport d'anniversaire"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:68
 msgid "✝"
-msgstr ""
+msgstr "✝"
 
 #. feature request 2356: avoid genitive form
 #: ../gramps/plugins/textreport/birthdayreport.py:221
@@ -33877,32 +33892,32 @@ msgid "Relationships shown are to %s"
 msgstr "Relations affichées pour %s"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:333
-#, fuzzy, python-format
+#, python-format
 msgid "* %(person)s, birth%(relation)s"
-msgstr "%(person)s, naissance%(relation)s"
+msgstr "* %(person)s, naissance%(relation)s"
 
 # trunk
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/textreport/birthdayreport.py:338
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "* {year}{person}{dead}, {age}{relation}"
 msgid_plural "* {year}{person}{dead}, {age}{relation}"
-msgstr[0] "{person}, {age}{relation}"
-msgstr[1] "{person}, {age}{relation}"
+msgstr[0] "* {year}{person}{dead}, {age}{relation}"
+msgstr[1] "* {year}{person}{dead}, {age}{relation}"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:402
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "⚭ %(spouse)s and\n"
 " %(person)s, wedding"
 msgstr ""
-"Mariage de %(spouse)s\n"
-"et %(person)s"
+"⚭ %(spouse)s et\n"
+" %(person)s, marriage"
 
 # trunk
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/textreport/birthdayreport.py:407
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid ""
 "⚭ {year}{spouse}{deadtxt2} and\n"
 " {person}{deadtxt1}, {nyears}"
@@ -33910,25 +33925,25 @@ msgid_plural ""
 "⚭ {year}{spouse}{deadtxt2} and\n"
 " {person}{deadtxt1}, {nyears}"
 msgstr[0] ""
-"{spouse} et\n"
-" {person}, {nyears}"
+"⚭ {year}{spouse}{deadtxt2} et\n"
+" {person}{deadtxt1}, {nyears}"
 msgstr[1] ""
-"{spouse} et\n"
-" {person}, {nyears}"
+"⚭ {year}{spouse}{deadtxt2} et\n"
+" {person}{deadtxt1}, {nyears}"
 
 # trunk
 #: ../gramps/plugins/textreport/birthdayreport.py:442
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "✝ {person}, death {relation}"
-msgstr "{person}, {age}{relation}"
+msgstr "✝ {person}, décès {relation}"
 
 # trunk
 #: ../gramps/plugins/textreport/birthdayreport.py:444
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "✝ {year}{person}, {age}{relation}"
 msgid_plural "✝ {year}{person}, {age}{relation}"
-msgstr[0] "{person}, {age}{relation}"
-msgstr[1] "{person}, {age}{relation}"
+msgstr[0] "✝ {year}{person}, {age}{relation}"
+msgstr[1] "✝ {year}{person}, {age}{relation}"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:475
 #: ../gramps/plugins/textreport/familygroup.py:716
@@ -33966,7 +33981,7 @@ msgstr "N'inclure que les individus vivants dans le rapport"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:511
 msgid "Dead Symbol"
-msgstr "Symbole de mort"
+msgstr "Symbole de décès"
 
 # https://gramps-project.org/bugs/view.php?id=11286
 #: ../gramps/plugins/textreport/birthdayreport.py:512
@@ -36854,7 +36869,8 @@ msgstr "Tables de références reconstruites"
 msgid "Select a person to determine the relationship"
 msgstr "Sélectionner un individu pour déterminer la parenté"
 
-#: ../gramps/plugins/tool/relcalc.py:67 ../gramps/plugins/tool/tools.gpr.py:331
+#: ../gramps/plugins/tool/relcalc.py:67
+#: ../gramps/plugins/tool/tools.gpr.py:331
 msgid "Relationship Calculator"
 msgstr "Calcul relationnel"
 
@@ -36902,7 +36918,6 @@ msgstr "Nettoyage des données saisies"
 
 # trunk
 #: ../gramps/plugins/tool/removespaces.py:104
-#, fuzzy
 msgid ""
 "Search leading and/or trailing spaces for persons and places. Search comma "
 "in coordinates fields.\n"
@@ -36910,7 +36925,8 @@ msgid ""
 msgstr ""
 "Recherche dans la base de données, des espaces en début et/ou en fin pour "
 "les lieux et les individus. Recherche des virgules dans les champs de "
-"coordonnées des lieux."
+"coordonnées des lieux.\n"
+"Cliquez deux fois sur une ligne pour éditer son contenu."
 
 # Substantif (GNOME fr)
 # master
@@ -37570,7 +37586,8 @@ msgstr "Nom_bre maximal d'années entre enfants"
 msgid "Maximum _span of years for all children"
 msgstr "Étendue ma_ximale d'années du premier au dernier enfant"
 
-#: ../gramps/plugins/tool/verify.glade:984 ../gramps/plugins/tool/verify.py:673
+#: ../gramps/plugins/tool/verify.glade:984
+#: ../gramps/plugins/tool/verify.py:673
 msgid "_Hide marked"
 msgstr "_Cacher les marqués"
 
@@ -37958,14 +37975,13 @@ msgstr "Éditeur de filtre sur l'événement"
 
 # objet sélectionné
 #: ../gramps/plugins/view/eventview.py:385
-#, fuzzy
 msgid "_Delete Event"
-msgstr "Supprimer l'événement (%s)"
+msgstr "_Supprimer l'événement"
 
 #: ../gramps/plugins/view/eventview.py:400
 #, python-brace-format
 msgid "Delete {type} [{gid}]?"
-msgstr ""
+msgstr "Supprimer {type} [{gid}] ?"
 
 #: ../gramps/plugins/view/eventview.py:443
 msgid "Cannot merge event objects."
@@ -38338,15 +38354,14 @@ msgstr "Sélectionnez tous les événements"
 
 # master
 #: ../gramps/plugins/view/geoevents.py:368
-#, fuzzy
 msgid ""
 "Right click on the map and select 'show all events' to show all known events "
 "with coordinates. You can use the history to navigate on the map. You can "
 "use filtering."
 msgstr ""
-"Un clic droit sur la carte puis sélectionnez 'Afficher tous les lieux' pour "
-"obtenir tous les lieux avec coordonnées. Vous pouvez changer la couleur du "
-"marqueur selon le type de lieu. Vous pouvez utiliser le filtrage."
+"Un clic droit sur la carte puis sélectionnez 'Afficher tous les événements' "
+"pour obtenir tous les événements avec coordonnées. Vous pouvez utiliser "
+"l'historique de la carte. Vous pouvez utiliser le filtrage."
 
 #: ../gramps/plugins/view/geoevents.py:408
 #: ../gramps/plugins/view/geoevents.py:440
@@ -38483,6 +38498,14 @@ msgid ""
 "To build it for Gramps see the Wiki (<F1>)\n"
 " and search for 'build from source'"
 msgstr ""
+"La fonction Géographie ne sera pas disponible.\n"
+"Essayez d'installer :\n"
+" gir1.2-osmgpsmap-1.0 (debian, ubuntu, ...)\n"
+" osm-gps-map-gobject-1.0.1 pour fedora, ...\n"
+" typelib-1_0-OsmGpsMap-1_0 pour openSuse\n"
+" ...\n"
+"To build it for Gramps see the Wiki (<F1>)\n"
+" and search for 'build from source'"
 
 #: ../gramps/plugins/view/geography.gpr.py:87
 msgid "All known places for one Person"
@@ -38913,9 +38936,8 @@ msgid "Expand this Entire Group"
 msgstr "Déployer le groupe entier"
 
 #: ../gramps/plugins/view/relview.py:372
-#, fuzzy
 msgid "Organize Bookmarks..."
-msgstr "Édition des signets"
+msgstr "Organisation des signets"
 
 #: ../gramps/plugins/view/relview.py:393
 msgid "Add Existing Parents..."
@@ -39039,19 +39061,19 @@ msgid "Relationship type: %s"
 msgstr "Type de relation : %s"
 
 #: ../gramps/plugins/view/relview.py:1520
-#, fuzzy, python-format
+#, python-format
 msgid "%(event_type)s %(date)s in %(place)s"
-msgstr "%(event_type)s : %(date)s à %(place)s"
+msgstr "%(event_type)s %(date)s à %(place)s"
 
 #: ../gramps/plugins/view/relview.py:1524
-#, fuzzy, python-format
+#, python-format
 msgid "%(event_type)s %(date)s"
-msgstr "%(event_type)s : %(date)s"
+msgstr "%(event_type)s %(date)s"
 
 #: ../gramps/plugins/view/relview.py:1528
-#, fuzzy, python-format
+#, python-format
 msgid "%(event_type)s %(place)s"
-msgstr "%(event_type)s : %(place)s"
+msgstr "%(event_type)s %(place)s"
 
 #: ../gramps/plugins/view/relview.py:1539
 msgid "Broken family detected"
@@ -39860,8 +39882,8 @@ msgid ""
 "Include narrative notes just after name, gender and age at death (default) "
 "or include them just before attributes."
 msgstr ""
-"Inclure les notes narratives après nom, genre et âge au décès (défaut) "
-"ou les inclure tout de suite après les attributs."
+"Inclure les notes narratives après nom, genre et âge au décès (défaut) ou "
+"les inclure tout de suite après les attributs."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1814
 msgid "Page Generation"
@@ -41069,338 +41091,3 @@ msgstr "Aucune feuille de style"
 
 #~ msgid "Web Connect"
 #~ msgstr "Connexion internet"
-
-# manuel wiki
-#~ msgid "manual|Repositories"
-#~ msgstr "Dépôts"
-
-#~ msgid "Open an existing database"
-#~ msgstr "Ouvrir une base de données existante"
-
-# master
-#~ msgid "Close the current database"
-#~ msgstr "Fermer la base de données actuelle"
-
-#~ msgid "Make a Gramps XML backup of the database"
-#~ msgstr "Générer une sauvegarde de la base de données au format Gramps XML"
-
-#~ msgid "Undo History..."
-#~ msgstr "Historique d'annulations..."
-
-#~ msgid "Key %s is not bound"
-#~ msgstr "La clé %s n'est pas définie"
-
-# objet sélectionné
-#~ msgid "_Delete Item"
-#~ msgstr "_Supprimer l'article"
-
-#~ msgid "%(title)s..."
-#~ msgstr "%(title)s..."
-
-# master
-#~ msgid "%(genders)s born %(year_from)04d-%(year_to)04d"
-#~ msgstr "%(genders)s né %(year_from)04d - %(year_to)04d"
-
-# master
-#~ msgid "Persons born %(year_from)04d-%(year_to)04d"
-#~ msgstr "Individus nés entre %(year_from)04d - %(year_to)04d"
-
-#~ msgid "Marriage of %s"
-#~ msgstr "Mariage de %s"
-
-#~ msgid "Birth of %s"
-#~ msgstr "Naissance de %s"
-
-#~ msgid "Death of %s"
-#~ msgstr "Décès de %s"
-
-#~ msgid "Anniversary: %s"
-#~ msgstr "Anniversaire : %s"
-
-#~ msgid "%d. Partner: "
-#~ msgstr "%d. Conjoint : "
-
-#~ msgid "Not a Pro-Gen file"
-#~ msgstr "Pas un fichier Pro-Gen valide"
-
-# Substantif (GNOME fr)
-#~ msgid "Loading..."
-#~ msgstr "En charge..."
-
-#~ msgid ""
-#~ "Attempt to see this location with a Map Service (OpenstreetMap, Google "
-#~ "Maps, ...)"
-#~ msgstr ""
-#~ "Tentative pour localiser cet emplacement avec le service cartographique "
-#~ "(OpenstreetMap, Google Maps, ...)"
-
-#~ msgid "Map Menu"
-#~ msgstr "Menu Carte"
-
-# manuel wiki
-# points de suspension et url ?
-#~ msgid "manual|Media_Manager..."
-#~ msgstr "Gestionnaire de media"
-
-# master
-#~ msgid ""
-#~ "Geography functionality will not be available.\n"
-#~ "To build it for Gramps see %(gramps_wiki_build_osmgps_url)s"
-#~ msgstr ""
-#~ "La fonction Géographie n'est pas disponible.\n"
-#~ "Pour construire ce module, voir %(gramps_wiki_build_osmgps_url)s"
-
-#~ msgid "Open the folder containing the media file"
-#~ msgstr "Ouvrir le répertoire qui contient le medium"
-
-#~ msgid "Suppress Gramps ID"
-#~ msgstr "Supprimer les identifiants Gramps"
-
-#~ msgid "Whether to include the Gramps ID of objects"
-#~ msgstr "Inclure ou non les identifiants Gramps des objets"
-
-#~ msgid "Thumbnail Preview"
-#~ msgstr "Aperçu de la miniature"
-
-# master
-#~ msgid ""
-#~ "\n"
-#~ "Usage: gramps.py [OPTION...]\n"
-#~ "  --load-modules=MODULE1,MODULE2,...     Dynamic modules to load\n"
-#~ "\n"
-#~ "Help options\n"
-#~ "  -?, --help                             Show this help message\n"
-#~ "  --usage                                Display brief usage message\n"
-#~ "\n"
-#~ "Application options\n"
-#~ "  -O, --open=FAMILY_TREE                 Open Family Tree\n"
-#~ "  -C, --create=FAMILY_TREE               Create on open if new Family "
-#~ "Tree\n"
-#~ "  -i, --import=FILENAME                  Import file\n"
-#~ "  -e, --export=FILENAME                  Export file\n"
-#~ "  -r, --remove=FAMILY_TREE_PATTERN       Remove matching Family Tree(s) "
-#~ "(use regular expressions)\n"
-#~ "  -f, --format=FORMAT                    Specify Family Tree format\n"
-#~ "  -a, --action=ACTION                    Specify action\n"
-#~ "  -p, --options=OPTIONS_STRING           Specify options\n"
-#~ "  -d, --debug=LOGGER_NAME                Enable debug logs\n"
-#~ "  -l [FAMILY_TREE_PATTERN...]            List Family Trees\n"
-#~ "  -L [FAMILY_TREE_PATTERN...]            List Family Trees in Detail\n"
-#~ "  -t [FAMILY_TREE_PATTERN...]            List Family Trees, tab "
-#~ "delimited\n"
-#~ "  -u, --force-unlock                     Force unlock of Family Tree\n"
-#~ "  -s, --show                             Show config settings\n"
-#~ "  -c, --config=[config.setting[:value]]  Set config setting(s) and start "
-#~ "Gramps\n"
-#~ "  -y, --yes                              Don't ask to confirm dangerous "
-#~ "actions (non-GUI mode only)\n"
-#~ "  -q, --quiet                            Suppress progress indication "
-#~ "output (non-GUI mode only)\n"
-#~ "  -v, --version                          Show versions\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Utilisation : gramps.py [OPTION...]\n"
-#~ "  --load-modules=MODULE1,MODULE2,...     Modules dynamiques à charger\n"
-#~ "\n"
-#~ "Options d'aide\n"
-#~ "  -?, --help                             Affiche ce message d'aide\n"
-#~ "  --usage                                Affiche une aide à "
-#~ "l'utilisation\n"
-#~ "\n"
-#~ "Options de l'application\n"
-#~ "  -O, --open=ARBRE_FAMILIAL              Ouvre l'arbre familial\n"
-#~ "  -C, --create=ARBRE_FAMILIAL            Créé à l'ouverture si arbre "
-#~ "familial\n"
-#~ "  -i, --import=FICHIER                   Importe un fichier\n"
-#~ "  -e, --export=FICHIER                   Exporte un fichier\n"
-#~ "  -r, --remove=MODELE_ARBRE       Enlever les arbres correspondants "
-#~ "(utilisez les expressions rationnelles)\n"
-#~ "  -f, --format=FORMAT                    Spécifie le format de l'arbre\n"
-#~ "  -a, --action=ACTION                    Spécifie l'action\n"
-#~ "  -p, --options=OPTIONS                  Spécifie les options\n"
-#~ "  -d, --debug=NOM_DE_LOGGER              Active les logs de déboguage\n"
-#~ "  -l  [MODÈLE_ARBRE_FAMILIAL...]                 Liste les arbres "
-#~ "familiaux\n"
-#~ "  -L[MODÈLE_ARBRE_FAMILIAL...]                 Liste les arbres familiaux "
-#~ "en détail\n"
-#~ "  -t [MODÈLE_ARBRE_FAMILIAL...]                Liste les arbres familiaux "
-#~ "dans un format tabulaire (tab)\n"
-#~ "  -u, --force-unlock                     Force le déverrouillage de "
-#~ "l'arbre\n"
-#~ "                                         familial\n"
-#~ "  -s, --show                             Affiche les paramètres de "
-#~ "configuration\n"
-#~ "  -c, --config=[config.setting[:value]]  Définit un ou plusieurs "
-#~ "paramètres de\n"
-#~ "                                         configuration et lance Gramps\n"
-#~ "  -y, --yes                              Ne pas demander de confirmation "
-#~ "pour les actions dangereuses\n"
-#~ "                                              (hors interface graphique)\n"
-#~ "  -q, --quiet                            Supprimer l'indication de "
-#~ "progression pour la sortie\n"
-#~ "                                               (hors interface "
-#~ "graphique)\n"
-#~ "  -v, --version                          Affiche les versions des "
-#~ "bibliothèques\n"
-
-# master
-#~ msgid "Data version"
-#~ msgstr "Version des données"
-
-# trunk
-#~ msgid "Gender Male Alive"
-#~ msgstr "Masculin vivant"
-
-# trunk
-#~ msgid "Border Male Death"
-#~ msgstr "Bordure masculin décédé"
-
-# trunk
-#~ msgid "Gender Female Alive"
-#~ msgstr "Féminin vivante"
-
-# trunk
-#~ msgid "Border Female Death"
-#~ msgstr "Bordure féminin décédée"
-
-# trunk
-#~ msgid "Gender Unknown Alive"
-#~ msgstr "Inconnu vivant"
-
-# trunk
-#~ msgid "Border Unknown Death"
-#~ msgstr "Bordure inconnu décédé"
-
-#~ msgid "Invalid latitude (syntax: 18\\u00b09'"
-#~ msgstr "Latitude invalide (syntaxe : 18\\u00b09'"
-
-#~ msgid "Invalid longitude (syntax: 18\\u00b09'"
-#~ msgstr "Longitude invalide (syntaxe : 18\\u00b09'"
-
-# manuel wiki
-#~ msgid "manual|New_Repositories_dialog"
-#~ msgstr "Nouveau_dépôts"
-
-# trunk
-#~ msgid ""
-#~ "Conveys the submitter's quantitative evaluation of the credibility of a "
-#~ "piece of information, based upon its supporting evidence. It is not "
-#~ "intended to eliminate the receiver's need to evaluate the evidence for "
-#~ "themselves.\n"
-#~ "Very Low =Unreliable evidence or estimated data\n"
-#~ "Low =Questionable reliability of evidence (interviews, census, oral "
-#~ "genealogies, or potential for bias for example, an autobiography)\n"
-#~ "High =Secondary evidence, data officially recorded sometime after event\n"
-#~ "Very High =Direct and primary evidence used, or by dominance of the "
-#~ "evidence "
-#~ msgstr ""
-#~ "Traduit la confiance placée dans la qualité de la source transmise ou la "
-#~ "crédibilité de cette partie d'information, basé sur les preuves. Il ne "
-#~ "vise pas à éliminer les besoins de vérifier les preuves.\n"
-#~ "Très bas = preuve non-liée ou date estimée\n"
-#~ "Bas = preuve qui nécessite une vérification (interview, recensement, "
-#~ "généalogie orale, ou une possibilité par le biais, par exemple, d'une "
-#~ "autobiographie)\n"
-#~ "Haut = preuve secondaire, données officiellement enregistrées parfois "
-#~ "après un événement\n"
-#~ "Très haut = preuve directe et principale, ou qui n'entraîne pas de doute"
-
-# master
-#~ msgid ""
-#~ "Either use the two fields below to enter coordinates(latitude and "
-#~ "longitude),"
-#~ msgstr ""
-#~ "Utilisez soit les deux champs suivants pour entrer les coordonnées "
-#~ "(latitude et longitude),"
-
-# trunk
-#~ msgid "DB-API version"
-#~ msgstr "Version DB-API"
-
-# master
-#~ msgid "Database db version"
-#~ msgstr "Version de la base de données db"
-
-# master
-#~ msgid "DB-_API Database"
-#~ msgstr "Base de données DB-_API"
-
-# master
-#~ msgid "DB-API Database"
-#~ msgstr "Base de données DB-API"
-
-#~ msgid "In-Memory"
-#~ msgstr "En-Mémoire"
-
-# master
-#~ msgid "In-_Memory Database"
-#~ msgstr "Base de données En-_Mémoire"
-
-# master
-#~ msgid "In-Memory Database"
-#~ msgstr "Base de données En-Mémoire"
-
-# master
-#~ msgid ""
-#~ "%(strong1_start)s%(page_number)d%(strong_end)s of %(strong2_start)s"
-#~ "%(total_pages)d%(strong_end)s"
-#~ msgstr ""
-#~ "%(strong1_start)s%(page_number)d%(strong_end)s sur %(strong2_start)s"
-#~ "%(total_pages)d%(strong_end)s"
-
-# trunk
-#~ msgid "Gender Male Death"
-#~ msgstr "Masculin décédé"
-
-# trunk
-#~ msgid "Gender Female Death"
-#~ msgstr "Féminin décédée"
-
-# trunk
-#~ msgid "Gender Unknown Death"
-#~ msgstr "Inconnu décédé"
-
-# master
-#~ msgid "Suppress comma after house number"
-#~ msgstr "Suppression de la virgule après le numéro de l'adresse"
-
-# master
-#~ msgid "-> Hamlet/Village/Town/City"
-#~ msgstr "-> Hameau/Village/Ville"
-
-# master
-#~ msgid "Hamlet/Village/Town/City ->"
-#~ msgstr "Hameau/Village/Ville ->"
-
-# master
-#~ msgid "Restrict"
-#~ msgstr "Restreindre"
-
-# master
-#~ msgid "You wish to convert this database into the new DB-API format?"
-#~ msgstr ""
-#~ "Souhaitez-vous convertir cette base de données vers le nouveau format DB-"
-#~ "API ?"
-
-#~ msgid "48.21\"S, -18.2412 or -18:9:48.21)"
-#~ msgstr "48.21\"S, -18.2412 ou -18:9:48.21)"
-
-#~ msgid "48.21\"E, -18.2412 or -18:9:48.21)"
-#~ msgstr "48.21\"E, -18.2412 ou -18:9:48.21)"
-
-#~ msgid "_PostgreSQL Database"
-#~ msgstr "Base de données _PostgreSQL"
-
-#~ msgid "PostgreSQL Database"
-#~ msgstr "Base de données PostgreSQL"
-
-# master
-#~ msgid "Ancestor"
-#~ msgstr "Ascendant"
-
-# master
-#~ msgid "Descendant"
-#~ msgstr "Descendant"
-
-#~ msgid "Alphabet Menu: %s"
-#~ msgstr "Menu alphabétique : %s"

--- a/po/nb.po
+++ b/po/nb.po
@@ -27070,7 +27070,7 @@ msgstr "Han døde %(death_date)s."
 #: ../gramps/plugins/lib/libnarrate.py:308
 #, python-format
 msgid "He died %(death_date)s at the age of %(age)s."
-msgstr "Han døde døde %(death_date)s, i en alder av %(age)s."
+msgstr "Han døde %(death_date)s, i en alder av %(age)s."
 
 #: ../gramps/plugins/lib/libnarrate.py:311
 #, python-format


### PR DESCRIPTION
Two problems:
* Don't use media regions in some case:
 - If we don't show families
 - If we don't show events

* When a media is processed in the media display section for an event
page, it's remove from the media_list, so when we try to create the
media regions in the media page, the media list is empty and we
can't display the regions.

Fixes #011500