### PR TITLE
EditEvent callback

### DIFF
--- a/gramps/gui/editors/editevent.py
+++ b/gramps/gui/editors/editevent.py
@@ -74,7 +74,7 @@ class EditEvent(EditPrimary):
 
         EditPrimary.__init__(self, dbstate, uistate, track,
                              event, dbstate.db.get_event_from_handle,
-                             dbstate.db.get_event_from_gramps_id)
+                             dbstate.db.get_event_from_gramps_id, callback)
 
         self._init_event()
 


### PR DESCRIPTION
In line with other editor windows, EditEvent.__init__ accepts a callback parameter. Unlike other editor windows, EditEvent does not pass the callback parameter into EditPrimary.__init__, leaving self.callback=None in all cases. This PR fixes this such that self.callback = callback, as expected.

Justification
Editor window callback functions form an integral part of Form addon [PR267](https://github.com/gramps-project/addons-source/pull/267). In PR267, the callback is used to perform additional operations, if the user OK'd the editor window. 
Making the editor windows behave in a consisent way, allows consistent coding in PR267, in addition to making EditEvent behave as a casual observer would expect. 
For a concrete example, look at PR267, [actionutils.py](https://github.com/gramps-project/addons-source/pull/267/files#diff-5a30656ef3ce96d579ad4e3fe5e0c12bR102), `add_event` and the symmmetry with `commit_person` that can be achieved if this PR is merged.

Note
I have not comprehensively reviewed other editor window classes for the same problem. I have observed that EditRepository has a similar problem. A fix is not included in this PR as I have no immediate need to use EditRepository. I am prepared to review all editor window classes for this problem, if felt necessary.