### PR TITLE
Fix GEDCOM export of compound dates estimated/calculated modifers

### DIFF
--- a/data/tests/exp_sample_ged.ged
+++ b/data/tests/exp_sample_ged.ged
@@ -1,12 +1,12 @@
 0 HEAD
 1 SOUR Gramps
-2 VERS 5.0.2
+2 VERS 5.1.2
 2 NAME Gramps
-1 DATE 4 AUG 2019
-2 TIME 15:26:44
+1 DATE 7 JAN 2020
+2 TIME 13:39:43
 1 SUBM @SUBM@
 1 FILE C:\Users\prc\AppData\Roaming\gramps\temp\exp_sample_ged.ged
-1 COPR Copyright (c) 2019 Alex Roitman,,,.
+1 COPR Copyright (c) 2020 Alex Roitman,,,.
 1 GEDC
 2 VERS 5.5.1
 2 FORM LINEAGE-LINKED
@@ -911,7 +911,7 @@
 2 DATE I think 1970 to 1971
 2 PLAC San Francisco, San Francisco Co., CA
 1 SLGC
-2 DATE EST ABT 1999
+2 DATE ABT 1999
 2 FAMC @F0016@
 2 TEMP DENVE
 2 PLAC Denver, Denver Co., CO, Denver Co., Colorado, USA
@@ -1424,7 +1424,7 @@
 0 @N0018@ NOTE Another Citation Note
 0 @N0019@ NOTE A bad photo for sure
 0 @O0000@ OBJE
-1 FILE c:\users\prc\workspace\grampsm\main\data\tests\O0.jpg
+1 FILE d:\users\prc\documents\gramps\data\tests\O0.jpg
 2 FORM jpg
 2 TITL Michael O'Toole 2015-11
 1 NOTE @N0019@

--- a/gramps/plugins/export/exportgedcom.py
+++ b/gramps/plugins/export/exportgedcom.py
@@ -1250,20 +1250,14 @@ class GedcomWriter(UpdateCallback):
         if start != Date.EMPTY:
             cal = date.get_calendar()
             mod = date.get_modifier()
-            quality = date.get_quality()
-            if quality in libgedcom.DATE_QUALITY:
-                qual_text = libgedcom.DATE_QUALITY[quality] + " "
-            else:
-                qual_text = ""
+            quality = None if mod else date.get_quality()
             if mod == Date.MOD_SPAN:
-                val = "%sFROM %s TO %s" % (
-                    qual_text,
+                val = "FROM %s TO %s" % (
                     libgedcom.make_gedcom_date(start, cal, mod, None),
                     libgedcom.make_gedcom_date(date.get_stop_date(),
                                                cal, mod, None))
             elif mod == Date.MOD_RANGE:
-                val = "%sBET %s AND %s" % (
-                    qual_text,
+                val = "BET %s AND %s" % (
                     libgedcom.make_gedcom_date(start, cal, mod, None),
                     libgedcom.make_gedcom_date(date.get_stop_date(),
                                                cal, mod, None))


### PR DESCRIPTION
Current Gramps allows the estimated/calculated prefix (EST/CAL) to be added to GEDCOM export for all the other modifier options (before after range span text about).  This is illegal GEDCOM.

```
DATE_VALUE:=
[
<DATE> |
<DATE_PERIOD> |
<DATE_RANGE>|
<DATE_APPROXIMATED> |
INT + space + <DATE> + space + (<DATE_PHRASE>) |
(<DATE_PHRASE>)
]
DATE_APPROXIMATED:=
[
ABT + space + <DATE> |
CAL + space + <DATE> |
EST + space + <DATE>
]
```

See bug [#11513](https://gramps-project.org/bugs/view.php?id=11513).