### PR TITLE
Try to fix exceptions on ManagedWindow close

### DIFF
--- a/gramps/gui/managedwindow.py
+++ b/gramps/gui/managedwindow.py
@@ -32,6 +32,14 @@ the create/deletion of dialog windows.
 import os
 from io import StringIO
 import html
+import logging
+
+#-------------------------------------------------------------------------
+#
+# Set up logging
+#
+#-------------------------------------------------------------------------
+_LOG = logging.getLogger(".")
 #-------------------------------------------------------------------------
 #
 # GNOME/GTK
@@ -575,6 +583,9 @@ class ManagedWindow:
 
         Takes care of closing children and removing itself from menu.
         """
+        if hasattr(self, 'opened') and not self.opened:
+            _LOG.warning("Tried to close a ManagedWindow more than once.")
+            return  # in case close somehow gets called again
         self.opened = False
         self._save_position(save_config=False)  # the next line will save it
         self._save_size()


### PR DESCRIPTION
Issues #10252, #10642, #10821, #11163, #11440, #11476, #11482, #11508

This one has been annoying me for quite a while.  What all these bugs have in common is that they happen during a ManagedWindow.close.  And that they are not easily repeatable.  In fact I have never been able to repeat any of these despite a lot of trying.  The bug submitters also indicate that they happen intermittently.

There are two basic stack dumps in the list of bugs, when I analyzed each, the only way I can think of that the error can occur is if somehow the ManagedWindow.close has gotten called more than once, so that the code gets exceptions trying to do something that has already been done.

So assuming that this is indeed what is happening, I have added a test to the close code to see if it has already been done, if so skip it.  I have tested this and it seems to have no effect on normal close, stacked window close etc.  But if my analysis is correct, it should stop the exceptions.