### PR TITLE
EditPrimary Windows: Always Call _do_close Before callback

### DIFF
--- a/gramps/gui/editors/editcitation.py
+++ b/gramps/gui/editors/editcitation.py
@@ -341,9 +341,9 @@ class EditCitation(EditPrimary):
                         self.obj.set_gramps_id(self.db.find_next_citation_gramps_id())
                     self.db.commit_citation(self.obj, trans)
 
+        self._do_close()
         if self.callback:
             self.callback(self.obj.get_handle())
-        self._do_close()
 
     def data_has_changed(self):
         """

--- a/gramps/gui/editors/editevent.py
+++ b/gramps/gui/editors/editevent.py
@@ -278,9 +278,9 @@ class EditEvent(EditPrimary):
                         self.obj.set_gramps_id(self.db.find_next_event_gramps_id())
                     self.db.commit_event(self.obj, trans)
 
+        self._do_close()
         if self.callback:
             self.callback(self.obj)
-        self._do_close()
 
     def data_has_changed(self):
         """

--- a/gramps/gui/editors/editmedia.py
+++ b/gramps/gui/editors/editmedia.py
@@ -334,9 +334,9 @@ class EditMedia(EditPrimary):
                         self.obj.set_gramps_id(self.db.find_next_media_gramps_id())
                     self.db.commit_media(self.obj, trans)
 
+        self._do_close()
         if self.callback:
             self.callback(self.obj)
-        self._do_close()
 
     def data_has_changed(self):
         """

--- a/gramps/gui/editors/editnote.py
+++ b/gramps/gui/editors/editnote.py
@@ -346,9 +346,9 @@ class EditNote(EditPrimary):
                         self.obj.set_gramps_id(self.db.find_next_note_gramps_id())
                     self.db.commit_note(self.obj, trans)
 
+        self._do_close()
         if self.callback:
             self.callback(self.obj.get_handle())
-        self._do_close()
 
 class DeleteNoteQuery:
     def __init__(self, dbstate, uistate, note, the_lists):

--- a/gramps/gui/editors/editrepository.py
+++ b/gramps/gui/editors/editrepository.py
@@ -65,7 +65,7 @@ class EditRepository(EditPrimary):
 
         EditPrimary.__init__(self, dbstate, uistate, track, repository,
                              dbstate.db.get_repository_from_handle,
-                             dbstate.db.get_repository_from_gramps_id)
+                             dbstate.db.get_repository_from_gramps_id, callback)
 
     def empty_object(self):
         return Repository()
@@ -208,6 +208,8 @@ class EditRepository(EditPrimary):
                     self.db.commit_repository(self.obj, trans)
 
         self._do_close()
+        if self.callback:
+            self.callback(self.obj)
 
 class DeleteRepositoryQuery:
     def __init__(self, dbstate, uistate, repository, sources):


### PR DESCRIPTION
There are several types of window derived from EditPrimary, all of which take an optional callback to be called after saving the object. They differ in that

- EditRepository does not initalise self.callback and does not attempt to.
- EditFamily, EditPerson, EditPlace and EditSource close their GUI elements before calling the callback
- EditCitation, EditEvent, EditMedia and EditNote call the callback before closing their GUI elements

This PR ensures that all types of EditPrimary consistently close their GUI elements before calling the callback. This allows the callback to have certainty, for example if it wishes to updates its own GUI elements. This capability is used in PR267 of the addons-source repo.

A separate PR, #986, updates EditEvent to initialise self.callback.