### PR TITLE
Update ukrainian translation

### DIFF
--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: gramps\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-10-17 11:43+1100\n"
-"PO-Revision-Date: 2019-11-02 16:47+0200\n"
+"PO-Revision-Date: 2020-01-11 14:53+0100\n"
 "Last-Translator: Fedir Zinchuk <fedikw@gmail.com>\n"
 "Language-Team: Ukrainian <fedikw@gmail.com>\n"
 "Language: uk\n"
@@ -1305,7 +1305,6 @@ msgid "Unknown action: %s."
 msgstr "Невідома дія: %s."
 
 #: ../gramps/cli/argparser.py:56
-#, fuzzy
 msgid ""
 "\n"
 "Usage: gramps.py [OPTION...]\n"
@@ -1387,6 +1386,18 @@ msgstr ""
 "  -q, --quiet                            Не виводити індикацію прогресу "
 "(лише режим без GUI)\n"
 "  -v, --version                          Показати версію\n"
+"  -S, --safe                             Запустити Gramps у \"безпечному "
+"режимі\"\n"
+"                                         (тимчасово використовувати "
+"налаштування за замовчуванням)\n"
+"  -D, --default=[APXFE]                  Скинути налаштування до "
+"стандартних;\n"
+"                 A - Очистити додатки\n"
+"                 P - Очистити налаштування\n"
+"                 X - Очистити книги, звіти та налаштування інструментів за "
+"замовчуванням\n"
+"                 F - Очистити фільтри\n"
+"                 E - Встановите все за замовчуванням або очистити\n"
 "\n"
 
 #: ../gramps/cli/argparser.py:95
@@ -1448,7 +1459,7 @@ msgid ""
 "Syntax may be different for other shells and for Windows.\n"
 msgstr ""
 "\n"
-"Приклад використання GRAMPS з командного рядка\n"
+"Приклад використання Gramps з командного рядка\n"
 "\n"
 "1. Щоб імпортувати чотири бази даних (з визначенням формату за "
 "розширенням),\n"
@@ -3809,11 +3820,11 @@ msgstr "Без опису"
 #. more references to a filter than expected
 #: ../gramps/gen/filters/rules/_rule.py:94
 msgid "The filter definition contains a loop."
-msgstr ""
+msgstr "Визначення фільтра містить цикл."
 
 #: ../gramps/gen/filters/rules/_rule.py:95
 msgid "One rule references another which eventually references the first."
-msgstr ""
+msgstr "Одне правило посилається на інше, яке зрештою посилається на перше."
 
 #: ../gramps/gen/filters/rules/citation/_allcitations.py:45
 msgid "Every citation"
@@ -3908,7 +3919,7 @@ msgstr "Вибирати цитати з вказаною кількістю п�
 
 #: ../gramps/gen/filters/rules/citation/_hasnotematchingsubstringof.py:43
 msgid "Citations having notes containing <substring>"
-msgstr "Цитати, примітки яких містять <текст>"
+msgstr "Цитати, примітки яких містять <частину рядка>"
 
 #: ../gramps/gen/filters/rules/citation/_hasnotematchingsubstringof.py:44
 msgid "Matches citations whose notes contain text matching a substring"
@@ -4088,7 +4099,7 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/citation/_regexpsourceidof.py:48
 msgid "Citations with Source Id containing <text>"
-msgstr "Цитати з Джерелом Id  які містять <текст>"
+msgstr "Цитати з Джерелом Id які містять <текст>"
 
 #: ../gramps/gen/filters/rules/citation/_regexpsourceidof.py:49
 msgid ""
@@ -4234,7 +4245,7 @@ msgstr "Вибирати події з вказаною кількістю пр�
 
 #: ../gramps/gen/filters/rules/event/_hasnotematchingsubstringof.py:42
 msgid "Events having notes containing <substring>"
-msgstr "Події, примітки яких містять <текст>"
+msgstr "Події, примітки яких містять <частину рядка>"
 
 #: ../gramps/gen/filters/rules/event/_hasnotematchingsubstringof.py:43
 msgid "Matches events whose notes contain text matching a substring"
@@ -4323,6 +4334,8 @@ msgid ""
 "Matches events that occurred at places that match the specified place filter "
 "name"
 msgstr ""
+"Вибирає події, що відбулися в місцях, які відповідають вказаному фільтру "
+"місць"
 
 #: ../gramps/gen/filters/rules/event/_matchessourceconfidence.py:45
 msgid "Events with at least one direct source >= <confidence level>"
@@ -4513,7 +4526,7 @@ msgstr "Вибирати сім'ї з вказаною кількістю при
 
 #: ../gramps/gen/filters/rules/family/_hasnotematchingsubstringof.py:42
 msgid "Families having notes containing <substring>"
-msgstr "Сім’ї, примітки яких містять <текст>"
+msgstr "Сім’ї, примітки яких містять <частину рядка>"
 
 #: ../gramps/gen/filters/rules/family/_hasnotematchingsubstringof.py:43
 msgid "Matches families whose notes contain text matching a substring"
@@ -4638,7 +4651,7 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/family/_motherhasidof.py:46
 msgid "Families having mother with Id containing <text>"
-msgstr ""
+msgstr "Сім’ї, де Id матері містить <текст>"
 
 #: ../gramps/gen/filters/rules/family/_motherhasidof.py:47
 msgid "Matches families whose mother has a specified Gramps ID"
@@ -4798,7 +4811,7 @@ msgstr "Вибирає медіа об’єкти з вказаними пара
 
 #: ../gramps/gen/filters/rules/media/_hasnotematchingsubstringof.py:42
 msgid "Media objects having notes containing <substring>"
-msgstr "Медіа об'єкти з примітками, що містять <рядок>"
+msgstr "Медіа об'єкти з примітками, що містять <частину рядка>"
 
 #: ../gramps/gen/filters/rules/media/_hasnotematchingsubstringof.py:43
 msgid "Matches media objects whose notes contain text matching a substring"
@@ -4968,7 +4981,7 @@ msgstr "Вибирає примітки, вміст яких підпадає п
 
 #: ../gramps/gen/filters/rules/note/_matchessubstringof.py:44
 msgid "Notes containing <substring>"
-msgstr "Примітки, що містять запис <substring>"
+msgstr "Примітки, що містять запис <частини рядка>"
 
 #: ../gramps/gen/filters/rules/note/_matchessubstringof.py:45
 msgid "Matches notes that contain text which matches a substring"
@@ -5328,7 +5341,7 @@ msgstr "Вибирати осіб з вказаною кількістю при�
 
 #: ../gramps/gen/filters/rules/person/_hasnotematchingsubstringof.py:42
 msgid "People having notes containing <substring>"
-msgstr "Особи з примітками, які містять <запис>"
+msgstr "Особи з примітками, які містять <частину рядка>"
 
 #: ../gramps/gen/filters/rules/person/_hasnotematchingsubstringof.py:43
 msgid "Matches people whose notes contain text matching a substring"
@@ -5397,6 +5410,8 @@ msgid ""
 "Soundex Match of people with a specified name. First name, Surname, Call "
 "name, and Nickname are searched in primary and alternate names."
 msgstr ""
+"Soundex вибірка людей із вказаним іменем. Ім'я, прізвище, ім'я в побуті та "
+"псевдонім шукаються в основних та альтернативних іменах."
 
 #: ../gramps/gen/filters/rules/person/_hassourcecount.py:45
 msgid "People with <count> sources"
@@ -5429,7 +5444,7 @@ msgstr "Враховувати регістр:"
 
 #: ../gramps/gen/filters/rules/person/_hastextmatchingsubstringof.py:48
 msgid "People with records containing <substring>"
-msgstr "Особи, які містять <запис>"
+msgstr "Особи, які містять <частину рядка>"
 
 #: ../gramps/gen/filters/rules/person/_hastextmatchingsubstringof.py:49
 msgid "Matches people whose records contain text matching a substring"
@@ -6093,11 +6108,11 @@ msgstr ""
 
 #: ../gramps/gen/filters/rules/place/_isenclosedby.py:49
 msgid "Places enclosed by another place"
-msgstr "Місця, розташовані поруч іншого місця"
+msgstr "Місця, що належать іншому місці"
 
 #: ../gramps/gen/filters/rules/place/_isenclosedby.py:50
 msgid "Matches a place enclosed by a particular place"
-msgstr ""
+msgstr "Вибирає місця, що належать до певного місця"
 
 #: ../gramps/gen/filters/rules/place/_matcheseventfilter.py:50
 msgid "Places of events matching the <event filter>"
@@ -6157,13 +6172,15 @@ msgstr "Вибирає місця на вказаній відстані до і
 
 #: ../gramps/gen/filters/rules/place/_withinarea.py:83
 msgid "Cannot use the filter 'within area'"
-msgstr ""
+msgstr "Неможливо використовувати фільтр 'у межах області'"
 
 #: ../gramps/gen/filters/rules/place/_withinarea.py:84
 msgid ""
 "The place you selected contains bad coordinates. Please, run the tool 'clean "
 "input data'"
 msgstr ""
+"Вибране місце містить погані координати. Будь ласка, запустіть інструмент "
+"'очистити вхідні дані'"
 
 #: ../gramps/gen/filters/rules/repository/_allrepos.py:44
 msgid "Every repository"
@@ -6195,7 +6212,7 @@ msgstr "Вибирає сховище із вказаним Gramps ID"
 
 #: ../gramps/gen/filters/rules/repository/_hasnotematchingsubstringof.py:42
 msgid "Repositories having notes containing <substring>"
-msgstr "Сховища, примітки яких містять <текст>"
+msgstr "Сховища, примітки яких містять <частину рядка>"
 
 #: ../gramps/gen/filters/rules/repository/_hasnotematchingsubstringof.py:43
 msgid "Matches repositories whose notes contain text matching a substring"
@@ -6329,7 +6346,7 @@ msgstr "Вибирає джерела з вказаною кількістю п�
 
 #: ../gramps/gen/filters/rules/source/_hasnotematchingsubstringof.py:42
 msgid "Sources having notes containing <substring>"
-msgstr "Джерела, примітки яких містять <текст>"
+msgstr "Джерела, примітки яких містять <частину рядка>"
 
 #: ../gramps/gen/filters/rules/source/_hasnotematchingsubstringof.py:43
 msgid "Matches sources whose notes contain text matching a substring"
@@ -6843,7 +6860,7 @@ msgstr "Відносини дитини"
 #: ../gramps/gen/lib/reporef.py:104 ../gramps/gen/lib/src.py:102
 #: ../gramps/gen/lib/tag.py:120
 msgid "Handle"
-msgstr ""
+msgstr "Нагода"
 
 #: ../gramps/gen/lib/childreftype.py:67 ../gramps/gen/plug/docgen/treedoc.py:72
 #: ../gramps/gui/configure.py:87
@@ -7973,7 +7990,7 @@ msgstr "<без статусу>"
 
 #: ../gramps/gen/lib/ldsord.py:104
 msgid "Born in Covenant"
-msgstr ""
+msgstr "Народився за угодою"
 
 #: ../gramps/gen/lib/ldsord.py:105
 msgid "Canceled"
@@ -8002,7 +8019,7 @@ msgstr "Виконано"
 
 #: ../gramps/gen/lib/ldsord.py:109
 msgid "Do not seal"
-msgstr ""
+msgstr "Не блокувати"
 
 #: ../gramps/gen/lib/ldsord.py:110
 msgid "Infant"
@@ -8018,7 +8035,7 @@ msgstr "Кваліфіковано"
 
 #: ../gramps/gen/lib/ldsord.py:113
 msgid "Do not seal/Cancel"
-msgstr ""
+msgstr "Не блокувати/Відмінити"
 
 #: ../gramps/gen/lib/ldsord.py:114
 msgid "Stillborn"
@@ -8528,7 +8545,7 @@ msgstr "Альтернативні імена"
 
 #: ../gramps/gen/lib/person.py:190
 msgid "Death reference index"
-msgstr ""
+msgstr "Індекс посилання на смерть"
 
 #: ../gramps/gen/lib/person.py:192
 msgid "Birth reference index"
@@ -9154,9 +9171,8 @@ msgid "Sidebar"
 msgstr "Бічна панель"
 
 #: ../gramps/gen/plug/_pluginreg.py:92
-#, fuzzy
 msgid "Rule"
-msgstr "Додати правило"
+msgstr "Правило"
 
 #. add miscellaneous column
 #: ../gramps/gen/plug/_pluginreg.py:528
@@ -9460,14 +9476,12 @@ msgid "How the lines between objects will be drawn."
 msgstr "Як буде намальовано лінії між об'єктами."
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:193
-#, fuzzy
 msgid "Alternate line attachment"
-msgstr "Альтернативні імена"
+msgstr ""
 
 #: ../gramps/gen/plug/docgen/graphdoc.py:194
-#, fuzzy
 msgid "Whether lines attach to nodes differently"
-msgstr "Чи додавати посилання на веб-звіт"
+msgstr "Чи по-різному додаються лінії до вузлів"
 
 #. ###############################
 #: ../gramps/gen/plug/docgen/graphdoc.py:210
@@ -9693,11 +9707,11 @@ msgstr "Заокруглено"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:83
 msgid "Swing"
-msgstr ""
+msgstr "Розмах"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:84
 msgid "Mesh"
-msgstr ""
+msgstr "Сітка"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:89
 msgid "Tiny"
@@ -9770,6 +9784,8 @@ msgid ""
 "One dimension of a node, in mm. If the timeflow is up or down then this is "
 "the width, otherwise it is the height."
 msgstr ""
+"Один розмір вузла, в мм. Якщо час рухається вгору або вниз, то це ширина, "
+"інакше - висота."
 
 #: ../gramps/gen/plug/docgen/treedoc.py:162
 msgid "Level size"
@@ -9780,6 +9796,8 @@ msgid ""
 "One dimension of a node, in mm. If the timeflow is up or down then this is "
 "the height, otherwise it is the width."
 msgstr ""
+"Один розмір вузла, в мм. Якщо час рухаєится вгору або вниз, то це висота, "
+"інакше - ширина."
 
 #: ../gramps/gen/plug/docgen/treedoc.py:171
 msgid "Node color."
@@ -11023,44 +11041,39 @@ msgid "Illegitimate"
 msgstr "Незаконний"
 
 #: ../gramps/gen/utils/symbols.py:73
-#, fuzzy
 msgid "Baptism/Christening"
 msgstr "Хрещення (малям)"
 
 #: ../gramps/gen/utils/symbols.py:74
-#, fuzzy
 msgid "Engaged"
-msgstr "Заручини"
+msgstr "Заручені"
 
 #: ../gramps/gen/utils/symbols.py:77
 msgid "Unmarried partnership"
 msgstr "Нешлюбне партнерство"
 
 #: ../gramps/gen/utils/symbols.py:78
-#, fuzzy
 msgid "Buried"
-msgstr "Поховання"
+msgstr "Поховані"
 
 #: ../gramps/gen/utils/symbols.py:79
 msgid "Cremated/Funeral urn"
 msgstr "Кремовано / Похоронна урна"
 
 #: ../gramps/gen/utils/symbols.py:80
-#, fuzzy
 msgid "Killed in action"
-msgstr "Колекція"
+msgstr "Убиті в бою"
 
 #: ../gramps/gen/utils/symbols.py:81
 msgid "Extinct"
-msgstr ""
+msgstr "Вимерлі"
 
 #. The following is used in the global preferences in the display tab.
 #. Name
 #. UNICODE    SUBSTITUTION
 #: ../gramps/gen/utils/symbols.py:106
-#, fuzzy
 msgid "Nothing"
-msgstr "У межах"
+msgstr "Нічого"
 
 #: ../gramps/gen/utils/symbols.py:108
 msgid "Skull and crossbones"
@@ -11095,36 +11108,32 @@ msgid "West Syriac cross"
 msgstr "Сирійська хрест"
 
 #: ../gramps/gen/utils/symbols.py:116
-#, fuzzy
 msgid "East Syriac cross"
-msgstr "Останній доступ"
+msgstr "Східносирійський хрест"
 
 #: ../gramps/gen/utils/symbols.py:117
 msgid "Heavy Greek cross"
 msgstr "Грецький хрест"
 
 #: ../gramps/gen/utils/symbols.py:118
-#, fuzzy
 msgid "Latin cross"
-msgstr "Латинська"
+msgstr "Латинський хрест"
 
 #: ../gramps/gen/utils/symbols.py:119
 msgid "Shadowed White Latin cross"
 msgstr "Затінений білий латинський хрест"
 
 #: ../gramps/gen/utils/symbols.py:120
-#, fuzzy
 msgid "Maltese cross"
-msgstr "Мальтійська"
+msgstr "Мальтійський хрест"
 
 #: ../gramps/gen/utils/symbols.py:121
 msgid "Star of David"
 msgstr "Зірка Давида"
 
 #: ../gramps/gen/utils/symbols.py:122
-#, fuzzy
 msgid "Dead"
-msgstr "Чоловік, помер"
+msgstr "Померлий"
 
 #: ../gramps/gen/utils/unknown.py:140
 msgid "Unknown, created to replace a missing note object."
@@ -11482,18 +11491,16 @@ msgid "_Help"
 msgstr "_Допомога"
 
 #: ../gramps/gui/configure.py:597
-#, fuzzy
 msgid "Researcher information"
-msgstr "Інформація про посилання"
+msgstr "Інформація для дослідників"
 
 #: ../gramps/gui/configure.py:602
-#, fuzzy
 msgid ""
 "Enter information about yourself so people can contact you when you "
 "distribute your Family Tree"
 msgstr ""
-"Вкажіть інформацію про себе, щоб особи могли зав'язатися з Вами, коли Ви "
-"поширите Сімейне Дерево"
+"Введіть інформацію про себе, щоб люди могли зв’язатися з вами, коли ви "
+"розповсюджуєте своє сімейне дерево"
 
 #: ../gramps/gui/configure.py:617
 #: ../gramps/gui/editors/displaytabs/addrembedlist.py:75
@@ -11515,9 +11522,8 @@ msgid "Researcher"
 msgstr "Дослідник"
 
 #: ../gramps/gui/configure.py:638
-#, fuzzy
 msgid "Gramps ID format settings"
-msgstr "Хибний формат імені %s"
+msgstr "Налаштування формату Gramps ID"
 
 #: ../gramps/gui/configure.py:658 ../gramps/gui/editors/editperson.py:641
 #: ../gramps/gui/widgets/photo.py:87
@@ -11529,9 +11535,8 @@ msgid "ID Formats"
 msgstr "Формат ID"
 
 #: ../gramps/gui/configure.py:677
-#, fuzzy
 msgid "Colors used for boxes in the graphical views"
-msgstr "Вкажіть кольори, що будуть використані для блоків діаграми"
+msgstr "Кольори, що використовуються для блоків у графічному вигляду"
 
 #: ../gramps/gui/configure.py:683
 msgid "Light colors"
@@ -11554,100 +11559,83 @@ msgid "Restore colors for current theme to default."
 msgstr "Скинути кольори поточної теми до стандартних."
 
 #: ../gramps/gui/configure.py:701
-#, fuzzy
 msgid "Colors for Male persons"
-msgstr "Колір для дублікатів"
+msgstr "Колір осіб жіночої статі"
 
 #: ../gramps/gui/configure.py:702
 msgid "Colors for Female persons"
 msgstr "Колір осіб жіночої статі"
 
 #: ../gramps/gui/configure.py:703
-#, fuzzy
 msgid "Colors for Unknown persons"
-msgstr "(невідома особа)"
+msgstr "Колір осіб невідомої статі"
 
 #: ../gramps/gui/configure.py:704
-#, fuzzy
 msgid "Colors for Family nodes"
-msgstr "Показати сімейні вузли"
+msgstr "Кольори для сімейних вузлів"
 
 #: ../gramps/gui/configure.py:705
-#, fuzzy
 msgid "Other colors"
-msgstr "Кольори статі"
+msgstr "Інші кольори"
 
 #: ../gramps/gui/configure.py:707
-#, fuzzy
 msgid "Background for Alive"
-msgstr "Колір фону"
+msgstr "Колір фону для живих"
 
 #: ../gramps/gui/configure.py:708
-#, fuzzy
 msgid "Background for Dead"
-msgstr "Колір фону"
+msgstr "Колір фону для померлих"
 
 #: ../gramps/gui/configure.py:709
-#, fuzzy
 msgid "Border for Alive"
-msgstr "Рамка, чоловіча, живий"
+msgstr "Рамка для живих"
 
 #: ../gramps/gui/configure.py:710
-#, fuzzy
 msgid "Border for Dead"
-msgstr "Рамка, Чоловік помер"
+msgstr "Рамка для померлих"
 
 #. for family
 #: ../gramps/gui/configure.py:730
-#, fuzzy
 msgid "Default background"
-msgstr "Особа за замовчуванням"
+msgstr "Фон за замовчуванням"
 
 #: ../gramps/gui/configure.py:731
-#, fuzzy
 msgid "Background for Married"
-msgstr "Колір фону"
+msgstr "Колір фону для заміжніх"
 
 #: ../gramps/gui/configure.py:732
-#, fuzzy
 msgid "Background for Unmarried"
-msgstr "Колір фону"
+msgstr "Колір фону для незаміжніх"
 
 #: ../gramps/gui/configure.py:734
-#, fuzzy
 msgid "Background for Civil union"
-msgstr "Колір фону"
+msgstr "Колір фону для громадянського союзу"
 
 #: ../gramps/gui/configure.py:736
-#, fuzzy
 msgid "Background for Unknown"
-msgstr "%dU"
+msgstr "Колір фону для невідомих"
 
 #: ../gramps/gui/configure.py:737
-#, fuzzy
 msgid "Background for Divorced"
-msgstr "Колір фону"
+msgstr "Колір фону для розлучених"
 
 #: ../gramps/gui/configure.py:738
-#, fuzzy
 msgid "Default border"
-msgstr "Особа за замовчуванням"
+msgstr "Рамка за замовчуванням"
 
 #: ../gramps/gui/configure.py:739
-#, fuzzy
 msgid "Border for Divorced"
-msgstr "Рамка, Розлучена сім'я"
+msgstr "Рамка для розлучених"
 
 #. for other
 #: ../gramps/gui/configure.py:742
-#, fuzzy
 msgid "Background for Home Person"
-msgstr "Відношення до базової особи"
+msgstr "Колір фону для базової особи"
 
 #: ../gramps/gui/configure.py:761
-#, fuzzy, python-format
+#, python-format
 msgid "<b>%s</b>"
-msgstr "<b>Чоловіки</b>"
+msgstr "<b>%s</b>"
 
 #: ../gramps/gui/configure.py:774
 msgid "Colors"
@@ -11751,9 +11739,8 @@ msgid "_Remove"
 msgstr "_Вилучити"
 
 #: ../gramps/gui/configure.py:1153
-#, fuzzy
 msgid "Appearance and format settings"
-msgstr "Хибний формат імені %s"
+msgstr "Налаштування зовнішності та формату"
 
 #: ../gramps/gui/configure.py:1198 ../gramps/gui/configure.py:1237
 #: ../gramps/gui/editors/displaytabs/buttontab.py:71
@@ -11773,9 +11760,8 @@ msgid "Consider single pa/matronymic as surname"
 msgstr "Розглядати по-батькові/по-матері як прізвище"
 
 #: ../gramps/gui/configure.py:1240
-#, fuzzy
 msgid "Place format (auto place title)"
-msgstr "Місця, що збігаються з назвою"
+msgstr "Формат місця (автоматична назва місця)"
 
 #: ../gramps/gui/configure.py:1243
 msgid "Enables automatic place title generation using specifed format."
@@ -11833,11 +11819,12 @@ msgid "Show text label beside Navigator buttons (requires restart)"
 msgstr "Показувати текст поруч з кнопками навігації (потрібен перезапуск)"
 
 #: ../gramps/gui/configure.py:1342
-#, fuzzy
 msgid ""
 "Show or hide text beside Navigator buttons (People, Families, Events...).\n"
 "Requires Gramps restart to apply."
-msgstr "Показувати текст поруч з кнопками навігації (потрібен перезапуск)"
+msgstr ""
+"Показувати текст поруч з кнопками навігації (Люди, Родини, Події ...).\n"
+"Потрібен перезапуск Gramps, щоб застосувати."
 
 #: ../gramps/gui/configure.py:1348
 msgid "Show close button in gramplet bar tabs"
@@ -11973,6 +11960,8 @@ msgid ""
 "Specifed tag will be added on import.\n"
 "Clear to set default value."
 msgstr ""
+"Вказаний тег буде доданий при імпорті.\n"
+"Очистіть, щоб встановити значення за замовчуванням."
 
 #: ../gramps/gui/configure.py:1580
 msgid "Enable spelling checker"
@@ -11993,16 +11982,15 @@ msgstr "Показувати підказку дня"
 
 #: ../gramps/gui/configure.py:1597
 msgid "Show useful information about using Gramps on startup."
-msgstr ""
+msgstr "Показати корисну інформацію про використання Gramps при запуску."
 
 #: ../gramps/gui/configure.py:1600
 msgid "Remember last view displayed"
 msgstr "Запам'ятовувати останню відкриту вкладку"
 
 #: ../gramps/gui/configure.py:1602
-#, fuzzy
 msgid "Remember last view displayed and open it next time."
-msgstr "Запам'ятовувати останню відкриту вкладку"
+msgstr "Запам’ятовувати останній вигляд і відкривати його наступного разу."
 
 #: ../gramps/gui/configure.py:1605
 msgid "Max generations for relationships"
@@ -12014,7 +12002,7 @@ msgstr "Базовий каталог для медіа"
 
 #: ../gramps/gui/configure.py:1617
 msgid "Third party addons management"
-msgstr ""
+msgstr "Управління аддоном сторонніх організацій"
 
 #: ../gramps/gui/configure.py:1626
 msgid "Once a month"
@@ -12100,6 +12088,7 @@ msgstr "оновлення"
 #: ../gramps/gui/configure.py:1729
 msgid "Family tree database settings and Backup management"
 msgstr ""
+"Налаштування бази даних сімейного дерева та управління резервними копіями"
 
 #: ../gramps/gui/configure.py:1735
 msgid "Database backend"
@@ -12126,6 +12115,8 @@ msgid ""
 "Don't open dialog to choose family tree to load on startup, just load last "
 "used."
 msgstr ""
+"Не відкривати діалогове вікно, щоб вибрати сімейне дерево для завантаження "
+"при запуску, завжди завантажувати останнє використане"
 
 #: ../gramps/gui/configure.py:1766
 msgid "Backup path"
@@ -12138,6 +12129,8 @@ msgstr "Резервування при виході"
 #: ../gramps/gui/configure.py:1773
 msgid "Backup Your family tree on exit to Backup path specified above."
 msgstr ""
+"Резервне копіювання вашого родинного дерева при виході за адресою резервного "
+"копіювання, зазначеною вище."
 
 #: ../gramps/gui/configure.py:1779
 msgid "Every 15 minutes"
@@ -12235,16 +12228,24 @@ msgid ""
 "If you select the \"use symbols\" checkbox, Gramps will use the selected "
 "font if it exists."
 msgstr ""
+"Ця вкладка дає можливість використовувати один шрифт, який здатний "
+"відображати всі генеалогічні символи\n"
+"\n"
+"Якщо встановити прапорець \"використовувати символи\", Gramps "
+"використовуватиме вибраний шрифт, якщо він існує."
 
 #: ../gramps/gui/configure.py:1952
 msgid ""
 "This can be useful if you want to add phonetic in a note to show how to "
 "pronounce a name or if you mix multiple languages like greek and russian."
 msgstr ""
+"Це може бути корисно, якщо ви хочете додати фонетику в примітці, щоб "
+"показати, як вимовляти ім’я, або якщо ви змішуєте кілька мов, як грецька та "
+"російська."
 
 #: ../gramps/gui/configure.py:1959
 msgid "Use symbols"
-msgstr ""
+msgstr "Використовуйте символи"
 
 #: ../gramps/gui/configure.py:1964
 msgid ""
@@ -12252,12 +12253,17 @@ msgid ""
 "before you can continue (10 minutes or more). \n"
 "If you cancel the process, nothing will be changed."
 msgstr ""
+"Будьте уважні, якщо натиснути кнопку \"Спробуйте знайти\", це може зайняти "
+"деякий час, перш ніж ви зможете продовжити (10 хвилин і більше).\n"
+"Якщо ви скасуєте процес, нічого не зміниться."
 
 #: ../gramps/gui/configure.py:1974
 msgid ""
 "You have already run the tool to search for genealogy fonts.\n"
 "Run it again only if you added fonts on your system."
 msgstr ""
+"Ви вже запустили інструмент для пошуку генеалогічних шрифтів.\n"
+"Запустіть його ще раз, лише якщо ви додали шрифти в свою систему."
 
 #: ../gramps/gui/configure.py:1979
 msgid "Try to find"
@@ -12268,38 +12274,40 @@ msgid "Choose font"
 msgstr "Оберіть шрифт"
 
 #: ../gramps/gui/configure.py:2003 ../gramps/gui/configure.py:2108
-#, fuzzy
 msgid "Select default death symbol"
-msgstr "Встановити як ім'я за замовчуванням"
+msgstr "Виберіть символ смерті за замовчуванням"
 
 #: ../gramps/gui/configure.py:2012
-#, fuzzy
 msgid "Genealogical Symbols"
-msgstr "Генеалогічна система"
+msgstr "Генеалогічні символи"
 
 #: ../gramps/gui/configure.py:2021
 msgid "Cannot look for genealogical fonts"
-msgstr ""
+msgstr "Неможливо шукати генеалогічні шрифти"
 
 #: ../gramps/gui/configure.py:2022
 msgid ""
 "I am not able to select genealogical fonts. Please, install the module "
 "fontconfig for python 3."
 msgstr ""
+"Я не в змозі відібрати генеалогічні шрифти. Будь ласка, встановіть модуль "
+"fontconfig для python 3."
 
 #: ../gramps/gui/configure.py:2039
 msgid "Checking available genealogical fonts"
-msgstr ""
+msgstr "Перевірка доступних генеалогічних шрифтів"
 
 #: ../gramps/gui/configure.py:2043
 msgid "Looking for all fonts with genealogical symbols."
-msgstr ""
+msgstr "Шукаємо всі шрифти з генеалогічними символами."
 
 #: ../gramps/gui/configure.py:2116
 msgid ""
 "You have no font with genealogical symbols on your system. Gramps will not "
 "be able to use symbols."
 msgstr ""
+"У вас немає шрифту з генеалогічними символами у вашій системі. Gramps не "
+"зможе використовувати ці символи."
 
 #: ../gramps/gui/configure.py:2154
 msgid "What you will see"
@@ -12443,7 +12451,7 @@ msgstr ""
 #: ../gramps/gui/dbman.py:97
 #, python-format
 msgid "%s_-_Manage_Family_Trees"
-msgstr ""
+msgstr "%s_-_Керування_сімейними_деревами"
 
 #: ../gramps/gui/dbman.py:98
 msgid "Family_Trees_manager_window"
@@ -13064,14 +13072,12 @@ msgid "Move Down"
 msgstr "Вниз"
 
 #: ../gramps/gui/editors/displaytabs/buttontab.py:76
-#, fuzzy
 msgid "Move Left"
-msgstr "Вгорі ліворуч"
+msgstr "Перемістити вліво"
 
 #: ../gramps/gui/editors/displaytabs/buttontab.py:77
-#, fuzzy
 msgid "Move right"
-msgstr "Авторське право"
+msgstr "Перемістити вправо"
 
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:69
 msgid "Create and add a new citation and new source"
@@ -13469,15 +13475,15 @@ msgstr "Альтернативні імена"
 #: ../gramps/plugins/webreport/basepage.py:2696
 #: ../gramps/plugins/webreport/basepage.py:2714
 msgid "Enclosed By"
-msgstr ""
+msgstr "Належить"
 
 #: ../gramps/gui/editors/displaytabs/placerefembedlist.py:189
 msgid "Place cycle detected"
-msgstr ""
+msgstr "Виявлено цикл місць"
 
 #: ../gramps/gui/editors/displaytabs/placerefembedlist.py:190
 msgid "The place you are adding is already enclosed by this place"
-msgstr "Місце яке ви додаєте вже поруч до цього місця"
+msgstr "Місце яке ви додаєте вже належить до цього місця"
 
 #: ../gramps/gui/editors/displaytabs/repoembedlist.py:55
 msgid "Create and add a new repository"
@@ -14802,7 +14808,7 @@ msgstr "Також сімейні події, в яких особа є в ст�
 
 #: ../gramps/gui/editors/filtereditor.py:575
 msgid "Only include primary participants"
-msgstr ""
+msgstr "Включити лише первинних учасників"
 
 #: ../gramps/gui/editors/filtereditor.py:591
 #: ../gramps/gui/widgets/placewithin.py:73
@@ -15649,7 +15655,6 @@ msgstr ""
 "інвентарній книзі народжень. "
 
 #: ../gramps/gui/glade/editcitation.glade:201
-#, fuzzy
 msgid ""
 "Conveys the submitter's quantitative evaluation of the credibility of a "
 "piece of information, based upon its supporting evidence. It is not intended "
@@ -15667,7 +15672,7 @@ msgstr ""
 "Низька =Достовірність доказів під питанням (антерв'ю, перепис населення, "
 "усний переказ, потенційно суб'єктивна думка, (напр. автобіграфія)\n"
 "Висока =Вторинні докази, дані офіційно зафіксовані після події\n"
-"Дуже Висока =Прямі і первинні докази "
+"Дуже Висока =Прямі та первинні докази, або за домінуванням доказів."
 
 #: ../gramps/gui/glade/editcitation.glade:226
 #: ../gramps/gui/glade/editevent.glade:312
@@ -15783,7 +15788,7 @@ msgid ""
 "the tool 'Extract Event Description'."
 msgstr ""
 "Опис події. Залиште пустим, якщо бажаєте автоматично згенерувати з допомогою "
-"інструменту \"Видобути Опис події\"."
+"інструменту 'Видобути Опис події'."
 
 #: ../gramps/gui/glade/editevent.glade:194
 #: ../gramps/gui/glade/editeventref.glade:270
@@ -15802,7 +15807,7 @@ msgstr "Селектор"
 
 #: ../gramps/gui/glade/editevent.glade:292
 msgid "What type of event this is. Eg 'Burial', 'Graduation', ... ."
-msgstr "Якого типу ця подія. \"Поховання\", \"Випуск\",..."
+msgstr "Якого типу ця подія. 'Поховання', 'Випуск',..."
 
 #: ../gramps/gui/glade/editevent.glade:326
 msgid ""
@@ -15900,7 +15905,7 @@ msgid ""
 "The relationship type, eg 'Married' or 'Unmarried'. Use Events for more "
 "details."
 msgstr ""
-"Тип відносин, напр. \"Одружені\" або \"Розлучені\". Використовуйте події для "
+"Тип відносин, напр. 'Одружені' або 'Розлучені'. Використовуйте події для "
 "детальнішої інформації."
 
 #: ../gramps/gui/glade/editfamily.glade:733
@@ -16553,6 +16558,8 @@ msgid ""
 "<b>Note:</b> Any changes in the enclosing place information will be "
 "reflected in the place itself, for places that it encloses."
 msgstr ""
+"<b>Примітка:</b> Будь-які зміни в інформації про місце, що додається, "
+"відображатимуться в самому місці, у місцях які віно охоплює."
 
 #: ../gramps/gui/glade/editreporef.glade:127
 msgid "_Media Type:"
@@ -17736,7 +17743,7 @@ msgstr "Помилка при розборі аргументів"
 
 #: ../gramps/gui/grampsgui.py:678
 msgid "Gramps terminated because of no DISPLAY"
-msgstr ""
+msgstr "Gramps припиняється через відсутність DISPLAY"
 
 #: ../gramps/gui/grampsgui.py:701 ../gramps/gui/grampsgui.py:775
 msgid ""
@@ -18076,6 +18083,10 @@ msgid ""
 "handle.  We recommend that you go to Relationships view and see if "
 "additional manual merging of families is necessary."
 msgstr ""
+"Особи об'єднані.\n"
+"Однак сім'ї для цього злиття були надто складними, щоб впоратися "
+"автоматично. Ми рекомендуємо перейти до перегляду відносин і побачити, чи "
+"потрібно додаткове ручне об’єднання сімей."
 
 #: ../gramps/gui/merge/mergeplace.py:53
 msgid "manual|Merge_Places"
@@ -18697,9 +18708,8 @@ msgid "See data not in Filter"
 msgstr "Переглянути дані, що не потрапили під фільтр"
 
 #: ../gramps/gui/plug/report/_bookdialog.py:92
-#, fuzzy
 msgid "Generate_Book_dialog"
-msgstr "Генерувати книгу"
+msgstr ""
 
 #: ../gramps/gui/plug/report/_bookdialog.py:172
 msgid "Available Books"
@@ -19392,7 +19402,7 @@ msgstr "Лише читання"
 
 #: ../gramps/gui/viewmanager.py:1023
 msgid "Gramps had a problem the last time it was run."
-msgstr ""
+msgstr "У Gramps була проблема в останній раз, коли вон був запущений."
 
 #: ../gramps/gui/viewmanager.py:1024
 msgid "Would you like to run the Check and Repair tool?"
@@ -19852,12 +19862,11 @@ msgstr "Додати особу"
 #: ../gramps/gui/widgets/fanchart.py:2182
 #: ../gramps/plugins/view/relview.py:1734
 msgid "Add Child to Family"
-msgstr "додати дитину до сім'ї"
+msgstr "Додати дитину до сім'ї"
 
 #: ../gramps/gui/widgets/grampletbar.py:118
-#, fuzzy
 msgid "Gramplet Bar Menu"
-msgstr "Ґрамплети"
+msgstr ""
 
 #: ../gramps/gui/widgets/grampletbar.py:207
 #: ../gramps/gui/widgets/grampletpane.py:1194
@@ -19974,6 +19983,8 @@ msgid ""
 "Matches places within a given distance of the active place. You have no "
 "active place."
 msgstr ""
+"Відповідає місцям на певній відстані від активного місця. У вас немає "
+"активного місця."
 
 #: ../gramps/gui/widgets/progressdialog.py:298
 msgid "Progress Information"
@@ -20373,7 +20384,7 @@ msgstr "Не можу створити jpeg версію зображення %(
 
 #: ../gramps/plugins/docgen/latexdoc.py:1240
 msgid "PIL (Python Imaging Library) not loaded."
-msgstr ""
+msgstr "PIL (Python Imaging Library) не завантажується."
 
 #: ../gramps/plugins/docgen/latexdoc.py:1241
 msgid ""
@@ -20381,6 +20392,9 @@ msgid ""
 "available. Use your package manager to install python-imaging or python-"
 "pillow or python3-pillow"
 msgstr ""
+"Виробництво зображень jpg із зображень, що не є jpg, у документах LaTeX буде "
+"недоступним. Використовуйте менеджер пакунків, щоб встановити python-imaging "
+"або python-pillow або python3-pillow"
 
 #: ../gramps/plugins/docgen/odfdoc.py:1182
 #, python-format
@@ -20856,7 +20870,7 @@ msgstr "Одне покоління в пустому блоці, для нев�
 
 #: ../gramps/plugins/drawreport/ancestortree.py:1032
 msgid " Generations of empty boxes for unknown ancestors"
-msgstr "Пусті блоки поколінь для невідомих предків"
+msgstr " Пусті блоки поколінь для невідомих предків"
 
 #: ../gramps/plugins/drawreport/ancestortree.py:1049
 #: ../gramps/plugins/drawreport/descendtree.py:1787
@@ -21668,9 +21682,8 @@ msgid "%s born"
 msgstr "%s народження"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:803
-#, fuzzy
 msgid "Persons born"
-msgstr "Лінк на особину"
+msgstr "Особи народжені"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:813
 msgid "Collecting data..."
@@ -21772,16 +21785,16 @@ msgstr ""
 "кругову діаграму і пояснення."
 
 #: ../gramps/plugins/drawreport/statisticschart.py:1066
-#, fuzzy
 msgid "Include counts of missing information"
-msgstr "Друкувати поля для відсутньої інформації"
+msgstr "Включати лічильники відсутньої інформації"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:1068
-#, fuzzy
 msgid ""
 "Whether to include counts of the number of people who lack the given "
 "information."
-msgstr "Чи включити інші події, в яких взяли участь особи."
+msgstr ""
+"Чи слід включати підрахунки кількості людей, яким не вистачає даної "
+"інформації."
 
 #: ../gramps/plugins/drawreport/statisticschart.py:1102
 msgid "Charts 3"
@@ -22033,12 +22046,12 @@ msgstr "Переклад заголовків"
 
 #: ../gramps/plugins/export/exportcsv.py:288
 msgid "Enclosed_by"
-msgstr ""
+msgstr "Додано_до"
 
 #: ../gramps/plugins/export/exportcsv.py:340
 #, python-brace-format
 msgid "CSV export doesn't support non-primary surnames, {count} dropped"
-msgstr ""
+msgstr "Експорт CSV не підтримує прізвища, що не є первинними, {count} випадає"
 
 #: ../gramps/plugins/export/exportcsv.py:357
 msgid "Birth source"
@@ -22127,9 +22140,8 @@ msgid "WWW"
 msgstr "WWW"
 
 #: ../gramps/plugins/export/exportgedcom.py:1431
-#, fuzzy
 msgid "Writing media"
-msgstr "Запис приміток"
+msgstr "Запис медіа"
 
 #: ../gramps/plugins/export/exportgedcom.py:1605
 msgid "GEDCOM Export failed"
@@ -22648,7 +22660,7 @@ msgstr ""
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:164
 #: ../gramps/plugins/view/view.gpr.py:173
 msgid "2-Way Fan"
-msgstr ""
+msgstr "Двосторонне віяло"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:172
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:178
@@ -23316,25 +23328,25 @@ msgstr "Ґрамплет генерую коди SoundEx"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1294
 msgid "Place Enclosed By"
-msgstr ""
+msgstr "Місце належить до"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1295
 msgid "Gramplet showing the places enclosed by the active place"
-msgstr "Ґрамплет показує місця поруч з активним місцем"
+msgstr "Ґрамплет показує місця що належать до активного місця"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1308
 #: ../gramps/plugins/webreport/basepage.py:2673
 #: ../gramps/plugins/webreport/basepage.py:2736
 msgid "Place Encloses"
-msgstr ""
+msgstr "Місце охоплює"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1309
 msgid "Gramplet showing the places that the active place encloses"
-msgstr "Ґрамплет показує місця поруч з якими знаходиться активне місце"
+msgstr "Ґрамплет показує місця які охоплює активне місце"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1316
 msgid "Encloses"
-msgstr ""
+msgstr "Охоплює"
 
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:1322
 msgid "Geography coordinates for Person Events"
@@ -23354,9 +23366,8 @@ msgid "Gramplet showing the events for all the family"
 msgstr "Ґрамплет показує події для всієї родини"
 
 #: ../gramps/plugins/gramplet/leak.py:99
-#, fuzzy
 msgid "Referrer"
-msgstr "Посилання"
+msgstr "Довідник"
 
 #: ../gramps/plugins/gramplet/leak.py:103
 msgid "Uncollected object"
@@ -23386,9 +23397,8 @@ msgid "Uncollected Objects: %s"
 msgstr "Облишені Об'єкти: %s"
 
 #: ../gramps/plugins/gramplet/leak.py:239
-#, fuzzy
 msgid "Reference Error"
-msgstr "Посилання"
+msgstr "Помилка посилання"
 
 #: ../gramps/plugins/gramplet/locations.py:81
 msgid "Double-click on a row to edit the selected place."
@@ -24139,12 +24149,10 @@ msgstr ""
 "сірий колір."
 
 #: ../gramps/plugins/graph/gvfamilylines.py:160
-#, fuzzy
 msgid "Rounded corners"
-msgstr "Використовувати заокруглення кутків"
+msgstr "Закруглені кути"
 
 #: ../gramps/plugins/graph/gvfamilylines.py:163
-#, fuzzy
 msgid "Use rounded corners e.g. to differentiate between women and men."
 msgstr ""
 "Використовувати заокруглення кутків для показу різниці між чоловіком та "
@@ -24430,9 +24438,8 @@ msgid "Graph Style"
 msgstr "Стиль діаграми"
 
 #: ../gramps/plugins/graph/gvhourglass.py:438
-#, fuzzy
 msgid "Force Ahnentafel order"
-msgstr "Звіт Предки (Ahnentafel)"
+msgstr ""
 
 #: ../gramps/plugins/graph/gvhourglass.py:440
 msgid ""
@@ -24442,15 +24449,16 @@ msgid ""
 msgstr ""
 
 #: ../gramps/plugins/graph/gvhourglass.py:443
-#, fuzzy
 msgid "Ahnentafel number visible"
-msgstr "Звіт Предки (Ahnentafel)"
+msgstr ""
 
 #: ../gramps/plugins/graph/gvhourglass.py:445
 msgid ""
 "Show Sosa / Sosa-Stradonitz / Ahnentafel number under all others "
 "informations."
 msgstr ""
+"Показати номер Sosa / Sosa-Stradonitz / Ahnentafel під усіма іншими "
+"відомостями."
 
 #: ../gramps/plugins/graph/gvrelgraph.py:209
 #: ../gramps/plugins/textreport/indivcomplete.py:834
@@ -24465,16 +24473,12 @@ msgstr "Визначає яких осіб показувати на діагр�
 
 #. see bug report #11112
 #: ../gramps/plugins/graph/gvrelgraph.py:836
-#, fuzzy
 msgid "Use hexagons"
-msgstr "Використати затінення"
+msgstr "Використовуйте шестикутники"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:837
-#, fuzzy
 msgid "Use hexagons to differentiate those of unknown gender."
-msgstr ""
-"Використовувати заокруглення кутків для показу різниці між чоловіком та "
-"жінкою."
+msgstr "Використовуйте шестикутники для розмежування осіб невідомої статі."
 
 #. ###############################
 #: ../gramps/plugins/graph/gvrelgraph.py:865
@@ -24518,14 +24522,14 @@ msgid "Whether to include dates and/or places"
 msgstr "Чи включати дати та/або місця"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:885
-#, fuzzy
 msgid "Show all family nodes"
-msgstr "Показати сімейні вузли"
+msgstr "Показати всі сімейні вузли"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:886
 msgid ""
 "Show family nodes even if the output contains only one member of the family."
 msgstr ""
+"Показати сімейні вузли, навіть якщо вихід містить лише одного члена родини."
 
 #: ../gramps/plugins/graph/gvrelgraph.py:890
 msgid "Include URLs"
@@ -24538,7 +24542,7 @@ msgid ""
 "Web Site' report."
 msgstr ""
 "Включити URL до кожної вершини графіка так, щоб створений PDF та imagemap "
-"містив посилання на файли створені звітом \"Вебсайт Розповідь\"."
+"містив посилання на файли створені звітом 'Вебсайт Розповідь'."
 
 #: ../gramps/plugins/graph/gvrelgraph.py:899
 #: ../gramps/plugins/textreport/birthdayreport.py:568
@@ -24573,7 +24577,7 @@ msgstr "Показати опис останнього заняття (проф�
 
 #: ../gramps/plugins/graph/gvrelgraph.py:925
 msgid "Include date, description and place of all occupations"
-msgstr ""
+msgstr "Включити дату, опис та місце всіх професій"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:927
 msgid "Whether to include the last occupation"
@@ -24781,45 +24785,40 @@ msgid "person"
 msgstr "особа"
 
 #: ../gramps/plugins/importer/importcsv.py:210
-#, fuzzy
 msgid "Occupation description"
-msgstr "Опис версії"
+msgstr "Опис професії"
 
 #: ../gramps/plugins/importer/importcsv.py:210
 msgid "occupationdescr"
 msgstr ""
 
 #: ../gramps/plugins/importer/importcsv.py:211
-#, fuzzy
 msgid "Occupation date"
-msgstr "Професія"
+msgstr "Дата праці"
 
 #: ../gramps/plugins/importer/importcsv.py:211
 msgid "occupationdate"
 msgstr ""
 
 #: ../gramps/plugins/importer/importcsv.py:212
-#, fuzzy
 msgid "Occupation place"
-msgstr "Професія"
+msgstr "Місце праці"
 
 #: ../gramps/plugins/importer/importcsv.py:212
 msgid "occupationplace"
 msgstr ""
 
 #: ../gramps/plugins/importer/importcsv.py:213
-#, fuzzy
 msgid "Occupation place id"
-msgstr "Професія"
+msgstr "Ідентифікатор місця праці"
 
 #: ../gramps/plugins/importer/importcsv.py:213
 msgid "occupationplace_id"
 msgstr ""
 
 #: ../gramps/plugins/importer/importcsv.py:214
-#, fuzzy
 msgid "Occupation source"
-msgstr "Професія"
+msgstr "Джерело професії"
 
 #: ../gramps/plugins/importer/importcsv.py:214
 msgid "occupationsource"
@@ -24827,7 +24826,7 @@ msgstr ""
 
 #: ../gramps/plugins/importer/importcsv.py:216
 msgid "residence date"
-msgstr ""
+msgstr "дата проживання"
 
 #: ../gramps/plugins/importer/importcsv.py:216
 msgid "residencedate"
@@ -24835,16 +24834,15 @@ msgstr ""
 
 #: ../gramps/plugins/importer/importcsv.py:217
 msgid "residence place"
-msgstr ""
+msgstr "місце проживання"
 
 #: ../gramps/plugins/importer/importcsv.py:217
 msgid "residenceplace"
 msgstr ""
 
 #: ../gramps/plugins/importer/importcsv.py:218
-#, fuzzy
 msgid "residence place id"
-msgstr "місце смерті ID"
+msgstr "ідентифікатор місця проживання"
 
 #: ../gramps/plugins/importer/importcsv.py:218
 msgid "residenceplace_id"
@@ -24852,7 +24850,7 @@ msgstr ""
 
 #: ../gramps/plugins/importer/importcsv.py:219
 msgid "residence source"
-msgstr ""
+msgstr "джерело проживання"
 
 #: ../gramps/plugins/importer/importcsv.py:219
 msgid "residencesource"
@@ -24860,7 +24858,7 @@ msgstr ""
 
 #: ../gramps/plugins/importer/importcsv.py:221
 msgid "attribute type"
-msgstr ""
+msgstr "тип атрибута"
 
 #: ../gramps/plugins/importer/importcsv.py:221
 msgid "attributetype"
@@ -24868,7 +24866,7 @@ msgstr ""
 
 #: ../gramps/plugins/importer/importcsv.py:222
 msgid "attribute value"
-msgstr ""
+msgstr "значення атрибута"
 
 #: ../gramps/plugins/importer/importcsv.py:222
 msgid "attributevalue"
@@ -24876,7 +24874,7 @@ msgstr ""
 
 #: ../gramps/plugins/importer/importcsv.py:223
 msgid "attribute source"
-msgstr ""
+msgstr "джерело атрибута"
 
 #: ../gramps/plugins/importer/importcsv.py:223
 msgid "attributesource"
@@ -24948,7 +24946,7 @@ msgstr "код"
 
 #: ../gramps/plugins/importer/importcsv.py:244
 msgid "enclosed by"
-msgstr ""
+msgstr "належить до"
 
 #: ../gramps/plugins/importer/importcsv.py:245
 msgid "enclosed_by"
@@ -25171,7 +25169,7 @@ msgstr ""
 "Базовий шлях для цього Сімейного Дерева було встановлено як %s. Краще "
 "використати простіший шлях. Ви можете змінити його в налаштуваннях, потім "
 "перемістити файли до нового місця, та, використовуючи інструмент керування "
-"медіа, виконати операцію \"Замінити підрядок в шляху\", щоб вказати вірний "
+"медіа, виконати операцію 'Замінити підрядок в шляху', щоб вказати вірний "
 "шлях до Ваших медіа об’єктів."
 
 #: ../gramps/plugins/importer/importgpkg.py:117
@@ -25224,21 +25222,23 @@ msgstr ""
 
 #: ../gramps/plugins/importer/importprogen.glade:49
 #: ../gramps/plugins/importer/importprogen.glade:70
-#, fuzzy
 msgid ""
 "Source reference\n"
 "(out of Settings)"
-msgstr "Примітка до посилання на джерело"
+msgstr ""
+"Посилання на джерело\n"
+"(поза налаштуваннями)"
 
 #: ../gramps/plugins/importer/importprogen.glade:124
 msgid ""
 "Source reference text\n"
 "(Text & import Filename)."
 msgstr ""
+"Довідковий текст джерела\n"
+"(Текст та назва файлу при імпорті)."
 
 #: ../gramps/plugins/importer/importprogen.glade:155
 #: ../gramps/plugins/importer/importprogen.glade:325
-#, fuzzy
 msgid "Attribut"
 msgstr "Атрибут"
 
@@ -25247,6 +25247,8 @@ msgid ""
 "Source attribute text\n"
 "(Text, import Filename & (System-)Date)."
 msgstr ""
+"Текст атрибута джерела\n"
+"(Текст, назва файлу при імпорті та (системна) дата)."
 
 #: ../gramps/plugins/importer/importprogen.glade:190
 #: ../gramps/plugins/importer/importprogen.glade:207
@@ -25258,29 +25260,36 @@ msgid ""
 "Citation confidence level\n"
 "(Very low - very high)."
 msgstr ""
+"Рівень довіри цитування\n"
+"(Дуже низький - дуже високий)."
 
 #: ../gramps/plugins/importer/importprogen.glade:308
 msgid ""
 "Citation volume/page text\n"
 "(Text & (System-)Date)."
 msgstr ""
+"Обсяг цитування/текст сторінки\n"
+"(Текст та (системна) дата)."
 
 #: ../gramps/plugins/importer/importprogen.glade:341
 msgid ""
 "Citation attribute text\n"
 "(Text, import Filename & (System-)Date)."
 msgstr ""
+"Текст атрибуту цитування\n"
+"(Текст, назва файлу при імпорті та (системна) дата)."
 
 #: ../gramps/plugins/importer/importprogen.glade:362
-#, fuzzy
 msgid "Import Text"
-msgstr "Імпортер"
+msgstr "Імпорт тексту"
 
 #: ../gramps/plugins/importer/importprogen.glade:415
 msgid ""
 "Default Tagtext\n"
 "(out of Settings)."
 msgstr ""
+"Тегтекст за замовчуванням\n"
+"(поза налаштуваннями)."
 
 #: ../gramps/plugins/importer/importprogen.glade:443
 msgid "Import Filename."
@@ -25288,7 +25297,7 @@ msgstr "Імпорт файлу"
 
 #: ../gramps/plugins/importer/importprogen.glade:492
 msgid "Default (System-)Date."
-msgstr ""
+msgstr "Дата за замовчуванням (системна)."
 
 #: ../gramps/plugins/importer/importprogen.glade:766
 #: ../gramps/plugins/importer/importprogen.glade:781
@@ -25298,88 +25307,101 @@ msgstr ""
 #: ../gramps/plugins/importer/importprogen.glade:841
 #: ../gramps/plugins/importer/importprogen.glade:856
 msgid "Combined default text + filename + date."
-msgstr ""
+msgstr "Комбінований текст за замовчуванням + назва файлу + дата."
 
 #: ../gramps/plugins/importer/importprogen.glade:1111
 msgid ""
 "Copy Default Text\n"
 "to all Tag Text'."
 msgstr ""
+"Скопіюйте текст за замовчуванням\n"
+"до тексту всіх міток '."
 
 #: ../gramps/plugins/importer/importprogen.glade:1130
 msgid ""
 "Copy Default Filename\n"
 "to all sensitive Tag Text'."
 msgstr ""
+"Скопіюйте ім'я файлу за замовчуванням\n"
+"до всього чутливого тексту міток."
 
 #: ../gramps/plugins/importer/importprogen.glade:1149
 msgid ""
 "Copy Default Date\n"
 "to all sensitive Tag Text'."
 msgstr ""
+"Скопіюйте дату за замовчуванням\n"
+"до всього чутливого тексту міток."
 
 #: ../gramps/plugins/importer/importprogen.glade:1164
 msgid "  Objects"
-msgstr "Об'єкти"
+msgstr " Об'єкти"
 
 #: ../gramps/plugins/importer/importprogen.glade:1168
 msgid ""
 "Enable/Disable\n"
 "all object tags."
 msgstr ""
+"Увімкнути/вимкнути\n"
+"всі мітки об'єктів"
 
 #: ../gramps/plugins/importer/importprogen.glade:1198
-#, fuzzy
 msgid "Tag Text"
-msgstr "Звичайний текст"
+msgstr "Текст мітки"
 
 #: ../gramps/plugins/importer/importprogen.glade:1217
-#, fuzzy
 msgid "Import Objects"
-msgstr "_Вилучити об'єкт"
+msgstr "Об'єкти імпорту"
 
 #: ../gramps/plugins/importer/importprogen.glade:1241
 msgid ""
 "Enable/Disable\n"
 "Person import."
 msgstr ""
+"Увімкнути/вимкнути\n"
+"імпорт людей."
 
 #: ../gramps/plugins/importer/importprogen.glade:1260
 msgid ""
 "Enable/Disable\n"
 "Family import."
 msgstr ""
+"Увімкнути/вимкнути\n"
+"імпорт сімей."
 
 #: ../gramps/plugins/importer/importprogen.glade:1279
 msgid ""
 "Enable/Disable\n"
 "Child import."
 msgstr ""
+"Увімкнути/вимкнути\n"
+"імпорт дітей."
 
 #: ../gramps/plugins/importer/importprogen.glade:1330
 msgid ""
 "Use original Person\n"
 "Identifier as Gramps ID."
 msgstr ""
+"Використовуйте оригінальний ідентифікатор \n"
+"особи як Gramps ID."
 
 #: ../gramps/plugins/importer/importprogen.glade:1349
 msgid ""
 "Use original Family\n"
 "Identifier as Gramps ID."
 msgstr ""
+"Використовуйте оригінальний ідентифікатор \n"
+"сім'ї як Gramps ID."
 
 #: ../gramps/plugins/importer/importprogen.glade:1369
-#, fuzzy
 msgid "Identifier"
-msgstr "Модифікатор"
+msgstr "Ідентифікатор"
 
 #: ../gramps/plugins/importer/importprogen.glade:1400
-#, fuzzy
 msgid "Name change"
-msgstr "Востаннє змінено"
+msgstr "Зміна імені"
 
 #: ../gramps/plugins/importer/importprogen.glade:1461
-#, fuzzy
 msgid "Event date"
 msgstr "Дата події"
 
@@ -25401,17 +25423,19 @@ msgstr ""
 
 #: ../gramps/plugins/importer/importprogen.glade:1515
 msgid "Diverse"
-msgstr ""
+msgstr "Різноманітний"
 
 #: ../gramps/plugins/importer/importprogen.glade:1526
 msgid "REFN"
-msgstr ""
+msgstr "REFN"
 
 #: ../gramps/plugins/importer/importprogen.glade:1530
 msgid ""
 "Store REFN number\n"
 "in event description."
 msgstr ""
+"Зберігати REFN номер в\n"
+"опис події"
 
 #: ../gramps/plugins/importer/importprogen.glade:1548
 #: ../gramps/plugins/importer/importprogen.glade:1595
@@ -25419,42 +25443,44 @@ msgid ""
 "Use death information\n"
 "as death cause event."
 msgstr ""
+"Використовуйте інформацію про смерть\n"
+"в якості причини події смерті."
 
 #: ../gramps/plugins/importer/importprogen.glade:1598
 msgid "(-cause)"
 msgstr "(-причина)"
 
 #: ../gramps/plugins/importer/importprogen.glade:1610
-#, fuzzy
 msgid "Male surname"
-msgstr "Оберіть прізвище"
+msgstr "Прізвище чоловіка"
 
 #: ../gramps/plugins/importer/importprogen.glade:1614
 msgid ""
 "Change name of male\n"
 "to e.g. wifes name."
 msgstr ""
+"Зміна імені чоловіка\n"
+"на, наприклад, ім'я жінки."
 
 #: ../gramps/plugins/importer/importprogen.glade:1629
-#, fuzzy
 msgid "Female surname"
-msgstr "Оберіть прізвище"
+msgstr "Прізвище жінки"
 
 #: ../gramps/plugins/importer/importprogen.glade:1633
 msgid ""
 "Change name of female\n"
 "to e.g. husbands name."
 msgstr ""
+"Зміна імені жінки\n"
+"на, наприклад, ім'я чоловіка."
 
 #: ../gramps/plugins/importer/importprogen.glade:1692
-#, fuzzy
 msgid "Option"
-msgstr "Параметри"
+msgstr "Вибір"
 
 #: ../gramps/plugins/importer/importprogen.glade:1731
-#, fuzzy
 msgid "_Ok"
-msgstr "Так"
+msgstr "_Добре"
 
 #: ../gramps/plugins/importer/importprogen.py:62
 msgid "manual|Import_from_another_genealogy_program"
@@ -25473,9 +25499,8 @@ msgstr "Помилка даних Pro-Gen"
 
 #: ../gramps/plugins/importer/importprogen.py:457
 #: ../gramps/plugins/importer/importprogen.py:465
-#, fuzzy
 msgid "Import Pro-Gen"
-msgstr "Імпорт з Pro-Gen  (%s)"
+msgstr "Імпорт Pro-Gen"
 
 #: ../gramps/plugins/importer/importvcard.py:228
 #, python-format
@@ -25498,13 +25523,15 @@ msgstr "VCARD звіт імпорту: %s помилок виявлено\n"
 #: ../gramps/plugins/importer/importvcard.py:321
 #, python-format
 msgid "Token >%(token)s< unknown. line skipped: %(line)s"
-msgstr ""
+msgstr "Токен >%(token)s< невідомо. Рядок пропущено: %(line)s"
 
 #: ../gramps/plugins/importer/importvcard.py:335
 msgid ""
 "BEGIN property not properly closed by END property, Gramps can't cope with "
 "nested VCards."
 msgstr ""
+"Властивість BEGIN неправильно закрита властивістю END, Gramps не може "
+"впоратися із вкладеними картками VC."
 
 #: ../gramps/plugins/importer/importvcard.py:346
 #, python-format
@@ -25680,6 +25707,13 @@ msgid ""
 "number in parentheses. Where possible these\n"
 "'Unkown' objects are referenced by note %(unknown)s.\n"
 msgstr ""
+"\n"
+"Імпортований файл не був все-вмісний.\n"
+"Дря виправлення цього було створено %(new)d нових об'єктів, та\n"
+"їхнім типологічним атрибутом було вибрано 'Unknown'.\n"
+"Розбивка на категорію зображена символом\n"
+"число в дужках. Де можливо,\n"
+"на об'єкти 'Unknown' створено посилання в примітці %(unknown)s.\n"
 
 #: ../gramps/plugins/importer/importxml.py:310
 msgid ""
@@ -25934,7 +25968,7 @@ msgstr "Висота"
 
 #: ../gramps/plugins/lib/libgedcom.py:707
 msgid "Initiatory (LDS)"
-msgstr ""
+msgstr "Ініціатива (LDS)"
 
 #: ../gramps/plugins/lib/libgedcom.py:708
 msgid "Military ID"
@@ -25942,11 +25976,11 @@ msgstr "ІД військової служби"
 
 #: ../gramps/plugins/lib/libgedcom.py:709
 msgid "Mission (LDS)"
-msgstr ""
+msgstr "Місія (LDS)"
 
 #: ../gramps/plugins/lib/libgedcom.py:710
 msgid "Namesake"
-msgstr ""
+msgstr "Тезка"
 
 #: ../gramps/plugins/lib/libgedcom.py:711
 msgid "Ordinance"
@@ -26072,7 +26106,7 @@ msgstr ""
 
 #: ../gramps/plugins/lib/libgedcom.py:3480
 msgid "(Submitter):"
-msgstr ""
+msgstr "(Відправник):"
 
 #: ../gramps/plugins/lib/libgedcom.py:3504
 #: ../gramps/plugins/lib/libgedcom.py:7318
@@ -26097,7 +26131,7 @@ msgstr "INDI (особа) Gramps ID %s"
 
 #: ../gramps/plugins/lib/libgedcom.py:3793
 msgid "Empty Alias <NAME PERSONAL> ignored"
-msgstr ""
+msgstr "Порожній псевдонім <ІМ'Я ОСОБА> ігнорується"
 
 #: ../gramps/plugins/lib/libgedcom.py:5024
 #, python-format
@@ -26123,12 +26157,12 @@ msgstr "Тип медіа"
 #: ../gramps/plugins/lib/libgedcom.py:5519
 #: ../gramps/plugins/lib/libgedcom.py:6793
 msgid "Multiple FILE in a single OBJE ignored"
-msgstr ""
+msgstr "Кілька FILE в одному OBJE ігнорується"
 
 #. We have previously found a PLAC
 #: ../gramps/plugins/lib/libgedcom.py:5658
 msgid "A second PLAC ignored"
-msgstr ""
+msgstr "Другий PLAC ігнорується"
 
 #. For RootsMagic etc. Place Details e.g. address, hospital, ...
 #: ../gramps/plugins/lib/libgedcom.py:5797
@@ -26139,7 +26173,7 @@ msgstr "Детально"
 #. location from PLAC title
 #: ../gramps/plugins/lib/libgedcom.py:5810
 msgid "Location already populated; ADDR ignored"
-msgstr ""
+msgstr "Місцезнаходження вже заселене; ADDR ігнорується"
 
 #: ../gramps/plugins/lib/libgedcom.py:6211
 #: ../gramps/plugins/lib/libgedcom.py:7099
@@ -26268,7 +26302,7 @@ msgstr ""
 
 #: ../gramps/plugins/lib/libgedcom.py:7523
 msgid "GEDCOM FORM not supported"
-msgstr ""
+msgstr "Версія GEDCOM FORM не підтримується"
 
 #: ../gramps/plugins/lib/libgedcom.py:7526
 msgid "GEDCOM form"
@@ -30004,9 +30038,8 @@ msgstr "Редагувати..."
 #: ../gramps/plugins/view/noteview.py:279
 #: ../gramps/plugins/view/repoview.py:292
 #: ../gramps/plugins/view/sourceview.py:278
-#, fuzzy
 msgid "Forward"
-msgstr "_Вперед"
+msgstr "Вперед"
 
 #: ../gramps/plugins/lib/libpersonview.py:454
 msgid "_Delete Person"
@@ -30090,6 +30123,8 @@ msgid ""
 "This place is currently referenced by another place. First remove the places "
 "it contains."
 msgstr ""
+"На це місце зараз посилається інше місце. Спочатку видаліть місця, які воно "
+"оточує."
 
 #: ../gramps/plugins/lib/libplaceview.py:548
 #: ../gramps/plugins/lib/libplaceview.py:556
@@ -30107,7 +30142,7 @@ msgstr ""
 
 #: ../gramps/plugins/lib/libplaceview.py:557
 msgid "Merging these places would create a cycle in the place hierarchy."
-msgstr ""
+msgstr "Об’єднання цих місць створило б цикл в ієрархії місць."
 
 #: ../gramps/plugins/lib/libplugins.gpr.py:35
 msgid "Provides a library for using Cairo to generate documents."
@@ -30119,7 +30154,7 @@ msgstr "Надає функціонал для роботи з GEDCOM"
 
 #: ../gramps/plugins/lib/libplugins.gpr.py:71
 msgid "Provides recursive routines for reports"
-msgstr ""
+msgstr "Надає рекурсивні процедури для звітів"
 
 #: ../gramps/plugins/lib/libplugins.gpr.py:88
 msgid "Provides common functionality for Gramps XML import/export."
@@ -30181,38 +30216,34 @@ msgid "Field '%(fldname)s' not found"
 msgstr "Поле '%(fldname)s' не знайдено"
 
 #: ../gramps/plugins/lib/libprogen.py:491
-#, fuzzy, python-format
+#, python-format
 msgid "Not a (right) DEF file: %(dname)s"
-msgstr "Не можу знайти DEF файл: %(dname)s"
+msgstr "Не (справний) DEF файл: %(dname)s"
 
 #: ../gramps/plugins/lib/libprogen.py:498
 #: ../gramps/plugins/lib/libprogen.py:732
-#, fuzzy
 msgid "Import from Pro-Gen"
-msgstr "Імпорт з Pro-Gen  (%s)"
+msgstr "Імпорт з Pro-Gen"
 
 #. start feedback about import progress (GUI / TXT)
 #: ../gramps/plugins/lib/libprogen.py:498
-#, fuzzy
 msgid "Initializing."
-msgstr "Встановлюю..."
+msgstr "Ініціалізація."
 
 #. Raise a error message
 #: ../gramps/plugins/lib/libprogen.py:515
 msgid "Not a supported Pro-Gen import file language"
-msgstr ""
+msgstr "Мова Pro-Gen файлу імпорту не підтримується"
 
 #: ../gramps/plugins/lib/libprogen.py:531
 msgid "Pro-Gen import"
 msgstr "Імпорт з Pro-Gen"
 
 #: ../gramps/plugins/lib/libprogen.py:539
-#, fuzzy
 msgid "Saving."
-msgstr "Пошук..."
+msgstr "Збереження."
 
 #: ../gramps/plugins/lib/libprogen.py:928
-#, fuzzy
 msgid "Pro-Gen Import"
 msgstr "Імпорт з Pro-Gen"
 
@@ -30223,15 +30254,14 @@ msgid "Date did not match: '%(text)s' (%(msg)s)"
 msgstr "Дати не співпадають: '%(text)s' (%(msg)s)"
 
 #: ../gramps/plugins/lib/libprogen.py:1152
-#, fuzzy, python-format
+#, python-format
 msgid "Time: %s"
-msgstr "Живий(а): %s"
+msgstr "Час: %s"
 
 #. start feedback about import progress (GUI/TXT)
 #: ../gramps/plugins/lib/libprogen.py:1206
-#, fuzzy
 msgid "Importing persons."
-msgstr "Сортування особистих подій..."
+msgstr "Імпорт осіб."
 
 #: ../gramps/plugins/lib/libprogen.py:1412
 msgid "see address on "
@@ -30251,7 +30281,6 @@ msgid "Importing families."
 msgstr "Імпортую сім'ї."
 
 #: ../gramps/plugins/lib/libprogen.py:1689
-#, fuzzy
 msgid "Civil union"
 msgstr "Цивільний союз"
 
@@ -30261,7 +30290,7 @@ msgstr "Весілля"
 
 #: ../gramps/plugins/lib/libprogen.py:1829
 msgid "future"
-msgstr ""
+msgstr "майбутнє"
 
 #. We have seen some case insensitivity in DEF files ...
 #. F13: Father
@@ -30272,14 +30301,12 @@ msgid "Adding children."
 msgstr "Додаю дітей."
 
 #: ../gramps/plugins/lib/libprogen.py:1927
-#, fuzzy
 msgid "Cannot find father for I%(person)s (Father=%(father))"
-msgstr "Не можу знайти батька для I%(person)s (батько=%(id)d)"
+msgstr "Не можу знайти батька для I%(person)s (Батько=%(father))"
 
 #: ../gramps/plugins/lib/libprogen.py:1930
-#, fuzzy
 msgid "Cannot find mother for I%(person)s (Mother=%(mother))"
-msgstr "Не можу знайти маму для I%(person)s (мама=%(mother)d)"
+msgstr "Не можу знайти мати для I%(person)s (Мати=%(father))"
 
 #: ../gramps/plugins/lib/librecords.py:55
 msgid "Youngest living person"
@@ -30436,7 +30463,7 @@ msgstr "Замінити '%(map)s' з =>"
 #: ../gramps/plugins/lib/maps/geography.py:418
 #, python-format
 msgid "Reload all visible tiles for '%(map)s'."
-msgstr ""
+msgstr "Перезавантажте всі видимі плитки для '%(map)s'."
 
 #: ../gramps/plugins/lib/maps/geography.py:427
 #, python-format
@@ -30527,6 +30554,9 @@ msgid ""
 "Either we choose the + and - from the keypad if we select this,\n"
 "or we use the characters from the keyboard."
 msgstr ""
+"Використовуйте клавіатуру для швидких клавіш:\n"
+"Або ми виберемо + та - з клавіатури, якщо виберемо це,\n"
+"або ми використовуємо символи з клавіатури."
 
 #: ../gramps/plugins/lib/maps/geography.py:1271
 msgid "The map"
@@ -30566,12 +30596,17 @@ msgid ""
 "In the following table you may have :\n"
 " - a green row related to a selected place."
 msgstr ""
+"\n"
+"У наступній таблиці ви можете мати:\n"
+" - зелений рядок, пов’язаний з обраним місцем."
 
 #: ../gramps/plugins/lib/maps/placeselection.py:128
 msgid ""
 "\n"
 " - a red row related to a geocoding result."
 msgstr ""
+"\n"
+"- червоний рядок, пов'язаний з результатом геокодування."
 
 #: ../gramps/plugins/lib/maps/placeselection.py:165
 msgid "The green values in the row correspond to the current place values."
@@ -30584,12 +30619,12 @@ msgstr "Нове місце з порожніми полями"
 
 #: ../gramps/plugins/lib/maps/placeselection.py:298
 msgid "you have a wrong latitude for:"
-msgstr ""
+msgstr "у вас неправильна широта для:"
 
 #: ../gramps/plugins/lib/maps/placeselection.py:300
 #: ../gramps/plugins/lib/maps/placeselection.py:310
 msgid "Please, correct this before linking"
-msgstr ""
+msgstr "Будь ласка, виправте це перед посиланням"
 
 #: ../gramps/plugins/lib/maps/placeselection.py:308
 msgid "you have a wrong longitude for:"
@@ -31510,15 +31545,15 @@ msgstr "Категорія"
 
 #: ../gramps/plugins/sidebar/sidebar.gpr.py:48
 msgid "Drop-down Sidebar"
-msgstr ""
+msgstr "Бічна панель, що випадає"
 
 #: ../gramps/plugins/sidebar/sidebar.gpr.py:49
 msgid "Selection of categories and views from drop-down lists"
-msgstr ""
+msgstr "Вибір категорій та представлень зі спадних списків"
 
 #: ../gramps/plugins/sidebar/sidebar.gpr.py:57
 msgid "Drop-Down"
-msgstr ""
+msgstr "Випадаючий"
 
 #: ../gramps/plugins/sidebar/sidebar.gpr.py:63
 msgid "Expander Sidebar"
@@ -31526,7 +31561,7 @@ msgstr "Розширювач бічної панелі"
 
 #: ../gramps/plugins/sidebar/sidebar.gpr.py:64
 msgid "Selection of views from lists with expanders"
-msgstr ""
+msgstr "Вибір переглядів зі списків із розширювачами"
 
 #: ../gramps/plugins/sidebar/sidebar.gpr.py:72
 msgid "Expander"
@@ -31594,21 +31629,21 @@ msgid "Relationships shown are to %s"
 msgstr "Відносини показані до %s"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:333
-#, fuzzy, python-format
+#, python-format
 msgid "* %(person)s, birth%(relation)s"
-msgstr "%(person)s, народження%(relation)s"
+msgstr "* %(person)s, народження %(relation)s"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/textreport/birthdayreport.py:338
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "* {year}{person}{dead}, {age}{relation}"
 msgid_plural "* {year}{person}{dead}, {age}{relation}"
-msgstr[0] "{person}, {age}{relation}"
-msgstr[1] "{person}, {age}{relation}"
-msgstr[2] "{person}, {age}{relation}"
+msgstr[0] "* {year}{person}{dead}, {age}{relation}"
+msgstr[1] "* {year}{person}{dead}, {age}{relation}"
+msgstr[2] "* {year}{person}{dead}, {age}{relation}"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:402
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "⚭ %(spouse)s and\n"
 " %(person)s, wedding"
@@ -31618,7 +31653,7 @@ msgstr ""
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/textreport/birthdayreport.py:407
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid ""
 "⚭ {year}{spouse}{deadtxt2} and\n"
 " {person}{deadtxt1}, {nyears}"
@@ -31626,27 +31661,27 @@ msgid_plural ""
 "⚭ {year}{spouse}{deadtxt2} and\n"
 " {person}{deadtxt1}, {nyears}"
 msgstr[0] ""
-"{spouse} та\n"
-" {person}, {nyears}"
+"⚭ {year}{spouse}{deadtxt2} та\n"
+" {person}{deadtxt1}, {nyears}"
 msgstr[1] ""
-"{spouse} та\n"
-" {person}, {nyears}"
+"⚭ {year}{spouse}{deadtxt2} та\n"
+" {person}{deadtxt1}, {nyears}"
 msgstr[2] ""
-"{spouse} та\n"
-" {person}, {nyears}"
+"⚭ {year}{spouse}{deadtxt2} та\n"
+" {person}{deadtxt1}, {nyears}"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:442
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "✝ {person}, death {relation}"
-msgstr "{person}, {age}{relation}"
+msgstr "✝ {person}, смерть {relation}"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:444
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "✝ {year}{person}, {age}{relation}"
 msgid_plural "✝ {year}{person}, {age}{relation}"
-msgstr[0] "{person}, {age}{relation}"
-msgstr[1] "{person}, {age}{relation}"
-msgstr[2] "{person}, {age}{relation}"
+msgstr[0] "✝ {year}{person}, {age}{relation}"
+msgstr[1] "✝ {year}{person}, {age}{relation}"
+msgstr[2] "✝ {year}{person}, {age}{relation}"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:475
 #: ../gramps/plugins/textreport/familygroup.py:716
@@ -31679,23 +31714,20 @@ msgid "Include only living people in the report"
 msgstr "Включати до звіту лише осіб, що досі живі"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:511
-#, fuzzy
 msgid "Dead Symbol"
-msgstr "Мертва мама"
+msgstr "Символ смерті"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:512
-#, fuzzy
 msgid "This will show after name to indicate that person is dead"
-msgstr "Мітка, яка означає, що дослідження особи закінчено"
+msgstr "Це буде відображено після імені, щоб вказати, що людина померла"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:519
 msgid "Show event year"
 msgstr "Показати рік події"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:520
-#, fuzzy
 msgid "Prints the year the event took place in the report"
-msgstr "Визначити яких осіб буде додано до звіту"
+msgstr "Друкує рік коли відбуляся подія в звіту"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:525
 #: ../gramps/plugins/textreport/birthdayreport.py:527
@@ -31703,14 +31735,12 @@ msgid "Year of report"
 msgstr "Річний звіт"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:563
-#, fuzzy
 msgid "Include death anniversaries"
-msgstr "Включати річниці"
+msgstr "Включати річниці смерті"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:564
-#, fuzzy
 msgid "Whether to include anniversaries of death"
-msgstr "Чи додавати річниці"
+msgstr "Чи включати річниці смерті"
 
 #: ../gramps/plugins/textreport/birthdayreport.py:570
 #: ../gramps/plugins/textreport/indivcomplete.py:1147
@@ -31947,11 +31977,11 @@ msgstr "Відносини з: %s"
 
 #: ../gramps/plugins/textreport/detancestralreport.py:835
 msgid "Sosa-Stradonitz number"
-msgstr ""
+msgstr "Номер Sosa-Stradonitz"
 
 #: ../gramps/plugins/textreport/detancestralreport.py:837
 msgid "The Sosa-Stradonitz number of the central person."
-msgstr ""
+msgstr "Номер Sosa-Stradonitz центральної особи."
 
 #: ../gramps/plugins/textreport/detancestralreport.py:851
 #: ../gramps/plugins/textreport/detdescendantreport.py:1040
@@ -32996,7 +33026,7 @@ msgstr ""
 
 #: ../gramps/plugins/textreport/textplugins.gpr.py:438
 msgid "Shows status of links in notes"
-msgstr ""
+msgstr "Показувати стан посилань у нотатках"
 
 #: ../gramps/plugins/tool/changenames.glade:34
 msgid ""
@@ -33893,9 +33923,8 @@ msgid "Media Manager"
 msgstr "Керування Медіа"
 
 #: ../gramps/plugins/tool/mediamanager.py:91
-#, fuzzy
 msgid "Help"
-msgstr "_Допомога"
+msgstr "Допомога"
 
 #: ../gramps/plugins/tool/mediamanager.py:101
 #: ../gramps/plugins/webreport/basepage.py:1523
@@ -34196,11 +34225,11 @@ msgstr[2] "Пошук імен {number_of} осіб"
 
 #: ../gramps/plugins/tool/ownereditor.glade:10
 msgid "Copy from DB to Preferences"
-msgstr ""
+msgstr "Копіювати з БД до налаштувань"
 
 #: ../gramps/plugins/tool/ownereditor.glade:23
 msgid "Copy from Preferences to DB"
-msgstr ""
+msgstr "Копіювати з налаштувань у БД"
 
 #: ../gramps/plugins/tool/ownereditor.glade:164
 msgid "_Street:"
@@ -34229,6 +34258,8 @@ msgstr "_Ел.пошта:"
 #: ../gramps/plugins/tool/ownereditor.glade:383
 msgid "Right-click to copy from/to Researcher Preferences"
 msgstr ""
+"Клацніть правою кнопкою миші, щоб скопіювати з/до Налаштування для "
+"дослідників"
 
 #: ../gramps/plugins/tool/ownereditor.py:56
 msgid "manual|Edit_Database_Owner_Information"
@@ -34401,7 +34432,7 @@ msgstr ""
 #: ../gramps/plugins/tool/removespaces.py:87
 #: ../gramps/plugins/tool/tools.gpr.py:489
 msgid "Clean input data"
-msgstr ""
+msgstr "Очистити вхідні дані"
 
 #: ../gramps/plugins/tool/removespaces.py:104
 msgid ""
@@ -34409,22 +34440,23 @@ msgid ""
 "in coordinates fields.\n"
 "Double click on a row to edit its content."
 msgstr ""
+"Шукайте провідні та/або проміжні місця для осіб та місць. Шукати кому в "
+"полях координат.\n"
+"Двічі клацніть на рядку, щоб відредагувати її вміст."
 
 #: ../gramps/plugins/tool/removespaces.py:113
-#, fuzzy
 msgid "Looking for possible fields with leading or trailing spaces"
-msgstr "Пошук можливого циклу (замикання) для кожної особи"
+msgstr "Шукаєте можливі поля з провідними або кінцевими пробілами"
 
 #: ../gramps/plugins/tool/removespaces.py:130
 #: ../gramps/plugins/tool/removespaces.py:179
 msgid "handle"
-msgstr ""
+msgstr "нагода"
 
 #. 2=double underline
 #: ../gramps/plugins/tool/removespaces.py:135
-#, fuzzy
 msgid "firstname"
-msgstr "ім'я невідоме"
+msgstr "ім'я"
 
 #. 2=double underline
 #: ../gramps/plugins/tool/removespaces.py:143
@@ -34501,13 +34533,15 @@ msgstr "Вилучити об'єкти, що не використовуютьс
 
 #: ../gramps/plugins/tool/reorderids.glade:1406
 msgid "Enable ID reordering."
-msgstr ""
+msgstr "Увімкнути перепорядкування ідентифікаторів."
 
 #: ../gramps/plugins/tool/reorderids.glade:1420
 msgid ""
 "List next ID available\n"
 "(maynot be continuous)."
 msgstr ""
+"Перерахувати наступні доступні ID\n"
+"(може бути безперервним)."
 
 #: ../gramps/plugins/tool/reorderids.glade:1424
 msgid "  Actual"
@@ -34523,7 +34557,7 @@ msgstr " Кількість"
 
 #: ../gramps/plugins/tool/reorderids.glade:1452
 msgid "Actual / Upcoming ID format."
-msgstr ""
+msgstr "Фактичний / майбутній формат ID."
 
 #: ../gramps/plugins/tool/reorderids.glade:1465
 msgid "Change"
@@ -34534,6 +34568,8 @@ msgid ""
 "Enable ID reordering\n"
 "with Start / Step sequence."
 msgstr ""
+"Увімкнути перепорядкування ідентифікаторів\n"
+"із \"Початок/Крок\" послідовністю."
 
 #: ../gramps/plugins/tool/reorderids.glade:1483
 msgid "Start"
@@ -34549,7 +34585,7 @@ msgstr "Крок"
 
 #: ../gramps/plugins/tool/reorderids.glade:1506
 msgid "Reorder ID step width."
-msgstr ""
+msgstr "Ширина кроку переупорядкування ID."
 
 #: ../gramps/plugins/tool/reorderids.glade:1518
 msgid "Keep"
@@ -34639,25 +34675,27 @@ msgstr ""
 #: ../gramps/plugins/tool/testcasegenerator.py:274
 #: ../gramps/plugins/tool/testcasegenerator.py:280
 msgid "Generate testcases"
-msgstr ""
+msgstr "Створити тестові приклади"
 
 #: ../gramps/plugins/tool/testcasegenerator.py:285
 msgid ""
 "Generate low level database errors\n"
 "Correction needs database reload"
 msgstr ""
+"Створити помилки бази даних низького рівня\n"
+"Виправлення потребує перезавантаження бази даних"
 
 #: ../gramps/plugins/tool/testcasegenerator.py:290
 msgid "Generate database errors"
-msgstr ""
+msgstr "Створити помилки бази даних"
 
 #: ../gramps/plugins/tool/testcasegenerator.py:294
 msgid "Generate dummy data"
-msgstr ""
+msgstr "Створити фіктивні дані"
 
 #: ../gramps/plugins/tool/testcasegenerator.py:299
 msgid "Generate long names"
-msgstr ""
+msgstr "Створити довгі імена"
 
 #: ../gramps/plugins/tool/testcasegenerator.py:304
 msgid "Add special characters"
@@ -34676,12 +34714,14 @@ msgid ""
 "Number of people to generate\n"
 "(Number is approximate because families are generated)"
 msgstr ""
+"Кількість людей для генерації\n"
+"(Кількість приблизна, оскільки створюються сім'ї)"
 
 #: ../gramps/plugins/tool/testcasegenerator.py:377
 #: ../gramps/plugins/tool/testcasegenerator.py:387
 #: ../gramps/plugins/tool/testcasegenerator.py:393
 msgid "Generating testcases"
-msgstr ""
+msgstr "Створення тестових прикладів"
 
 #: ../gramps/plugins/tool/testcasegenerator.py:378
 msgid "Generating low level database errors"
@@ -34761,7 +34801,7 @@ msgstr "Генерую сім'ї"
 #: ../gramps/plugins/tool/testcasegenerator.py:1685
 #, python-format
 msgid "Testcase generator step %d"
-msgstr ""
+msgstr "Крок генератора тестових шаблонів %d"
 
 #: ../gramps/plugins/tool/tools.gpr.py:38
 msgid "Fix Capitalization of Family Names"
@@ -34908,13 +34948,12 @@ msgid "Searches the entire database, looking for a possible loop."
 msgstr "Пошук по всій базі даних, шукаючи можливий цикл (замикання)."
 
 #: ../gramps/plugins/tool/tools.gpr.py:490
-#, fuzzy
 msgid ""
 "Searches the entire database, looking for trailing or leading spaces for "
 "places and people. Search comma in coordinates fields in places."
 msgstr ""
-"Перешуковує базу даних на наявність цитат, що мають ті ж том/сторінку, дату "
-"та достовірність."
+"Перешуковує базу даних шукаючи провідні або проміжні місця для осіб та "
+"місць. Шукати кому в полях координат."
 
 #: ../gramps/plugins/tool/toolsdebug.gpr.py:64
 msgid "Dump Gender Statistics"
@@ -35156,19 +35195,16 @@ msgid "Old age but no death"
 msgstr "Старшого віку, проте відсутня дата смерті"
 
 #: ../gramps/plugins/tool/verify.py:1802
-#, fuzzy
 msgid "Birth equals death"
-msgstr "Дата народження"
+msgstr "Народження дорівнює смерті"
 
 #: ../gramps/plugins/tool/verify.py:1820
-#, fuzzy
 msgid "Birth equals marriage"
-msgstr "Найкоротший шлюб в минулому"
+msgstr "Народження дорівнює шлюбу"
 
 #: ../gramps/plugins/tool/verify.py:1838
-#, fuzzy
 msgid "Death equals marriage"
-msgstr "Пізній шлюб"
+msgstr "Смерть дорівнює шлюбу"
 
 #: ../gramps/plugins/view/citationlistview.py:105
 msgid "Source: Title"
@@ -35358,14 +35394,13 @@ msgid "Event Filter Editor"
 msgstr "Редактор фільтру подій"
 
 #: ../gramps/plugins/view/eventview.py:385
-#, fuzzy
 msgid "_Delete Event"
-msgstr "Видалити подію (%s)"
+msgstr "_Видалити подію"
 
 #: ../gramps/plugins/view/eventview.py:400
 #, python-brace-format
 msgid "Delete {type} [{gid}]?"
-msgstr ""
+msgstr "Видалити {type} [{gid}]?"
 
 #: ../gramps/plugins/view/eventview.py:443
 msgid "Cannot merge event objects."
@@ -35504,7 +35539,7 @@ msgstr "Тло"
 
 #: ../gramps/plugins/view/fanchart2wayview.py:313
 msgid "Add global background colored gradient"
-msgstr ""
+msgstr "Додати глобальний кольоровий градієнт фону"
 
 #. colors, stored as hex values
 #: ../gramps/plugins/view/fanchart2wayview.py:317
@@ -35537,9 +35572,8 @@ msgstr "Однорідний розподіл дітей"
 
 #: ../gramps/plugins/view/fanchart2wayview.py:329
 #: ../gramps/plugins/view/fanchartdescview.py:328
-#, fuzzy
 msgid "Size proportional to number of descendants"
-msgstr "Розмір пропорційний до кількості нащадків"
+msgstr "Розмір пропорційний кількості нащадків"
 
 #. show names one two line
 #: ../gramps/plugins/view/fanchart2wayview.py:335
@@ -35557,9 +35591,8 @@ msgstr ""
 
 #. Show gramps id
 #: ../gramps/plugins/view/fanchart2wayview.py:343
-#, fuzzy
 msgid "Show the gramps id"
-msgstr "Показати останню сторінку"
+msgstr "Показати Gramps ID"
 
 #. options we don't show on the dialog
 #. #configdialog.add_checkbox(table,
@@ -35604,9 +35637,8 @@ msgstr "Квадрант"
 #. Show the gramps_id
 #: ../gramps/plugins/view/fanchartdescview.py:342
 #: ../gramps/plugins/view/fanchartview.py:430
-#, fuzzy
 msgid "Show gramps id"
-msgstr "Gramps id"
+msgstr "Показати Gramps id"
 
 #: ../gramps/plugins/view/fanchartview.py:227
 msgid "Print or save the Fan Chart View"
@@ -35685,7 +35717,7 @@ msgstr "%(eventtype)s : %(name)s"
 
 #: ../gramps/plugins/view/geoclose.py:642
 msgid "Choose and bookmark the new reference person"
-msgstr ""
+msgstr "Виберіть і додайте закладку до нового посилання на особу"
 
 #: ../gramps/plugins/view/geoclose.py:665
 msgid ""
@@ -35731,6 +35763,9 @@ msgid ""
 "with coordinates. You can use the history to navigate on the map. You can "
 "use filtering."
 msgstr ""
+"Клацніть правою кнопкою миші на карті та виберіть 'показати всі події', "
+"щоб показати всі відомі події з координатами. Ви можете використовувати "
+"історію для навігації по карті. Можна використовувати фільтрування."
 
 #: ../gramps/plugins/view/geoevents.py:408
 #: ../gramps/plugins/view/geoevents.py:440
@@ -35821,7 +35856,7 @@ msgstr "Особа : %(id)s %(name)s не має сім'ї."
 
 #: ../gramps/plugins/view/geofamclose.py:831
 msgid "Choose and bookmark the new reference family"
-msgstr ""
+msgstr "Виберіть і додайте закладку до нового посилання на сім'ю"
 
 #: ../gramps/plugins/view/geofamclose.py:854
 msgid ""
@@ -35867,6 +35902,14 @@ msgid ""
 "To build it for Gramps see the Wiki (<F1>)\n"
 " and search for 'build from source'"
 msgstr ""
+"Функціонал географії не буде доступний.\n"
+"Спробуйте встановити:\n"
+" gir1.2-osmgpsmap-1.0 (debian, ubuntu, ...)\n"
+" osm-gps-map-gobject-1.0.1 для fedora, ...\n"
+" typelib-1_0-OsmGpsMap-1_0 для openSuse\n"
+" ...\n"
+"Щоб побудувати його для Gramps, перегляньте Wiki (<F1>)\n"
+" і шукайте 'build from source'"
 
 #: ../gramps/plugins/view/geography.gpr.py:87
 msgid "All known places for one Person"
@@ -36027,6 +36070,9 @@ msgid ""
 "with coordinates. You can change the markers color depending on place type. "
 "You can use filtering."
 msgstr ""
+"Клацніть правою кнопкою миші на карті та виберіть 'показати всі місця', "
+"щоб показати всі відомі місця з координатами. Ви можете змінювати колір "
+"маркерів залежно від типу місця. Можна використовувати фільтрування."
 
 #: ../gramps/plugins/view/geoplaces.py:447
 msgid ""
@@ -36034,6 +36080,10 @@ msgid ""
 "with coordinates. You can use the history to navigate on the map. You can "
 "change the markers color depending on place type. You can use filtering."
 msgstr ""
+"Клацніть правою кнопкою миші на карті та виберіть 'показати всі місця', "
+"щоб показати всі відомі місця з координатами. Ви можете використовувати "
+"історію для навігації по карті. Ви можете змінювати колір маркерів залежно "
+"від типу місця. Можна використовувати фільтрування."
 
 #: ../gramps/plugins/view/geoplaces.py:462
 msgid "The place name in the status bar is disabled."
@@ -36070,9 +36120,8 @@ msgid "Show all places"
 msgstr "Показати всі місця"
 
 #: ../gramps/plugins/view/geoplaces.py:659
-#, fuzzy
 msgid "Custom places name"
-msgstr "Повна назва місця"
+msgstr "Спеціальна назва місця"
 
 #: ../gramps/plugins/view/geoplaces.py:668
 msgid "The places marker color"
@@ -36389,19 +36438,19 @@ msgid "Relationship type: %s"
 msgstr "Тип відносин: %s"
 
 #: ../gramps/plugins/view/relview.py:1520
-#, fuzzy, python-format
+#, python-format
 msgid "%(event_type)s %(date)s in %(place)s"
-msgstr "%(event_type)s: %(date)s в %(place)s"
+msgstr "%(event_type)s %(date)s в %(place)s"
 
 #: ../gramps/plugins/view/relview.py:1524
-#, fuzzy, python-format
+#, python-format
 msgid "%(event_type)s %(date)s"
-msgstr "%(event_type)s: %(date)s"
+msgstr "%(event_type)s %(date)s"
 
 #: ../gramps/plugins/view/relview.py:1528
-#, fuzzy, python-format
+#, python-format
 msgid "%(event_type)s %(place)s"
-msgstr "%(event_type)s: %(place)s"
+msgstr "%(event_type)s %(place)s"
 
 #: ../gramps/plugins/view/relview.py:1539
 msgid "Broken family detected"
@@ -36751,7 +36800,7 @@ msgstr "Розташування"
 
 #: ../gramps/plugins/webreport/basepage.py:2943
 msgid "circa"
-msgstr ""
+msgstr "близько"
 
 #: ../gramps/plugins/webreport/basepage.py:2945
 msgid "around"
@@ -37003,11 +37052,12 @@ msgid "Show the relationship between the current person and the active person"
 msgstr "Показує відносини між поточною та активною особою"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1657
-#, fuzzy
 msgid ""
 "For each person page, show the relationship between this person and the "
 "active person."
-msgstr "Показує всі відносини між поточною та базовою особою."
+msgstr ""
+"На кожній сторінці особи, показвати всі відносини між поточною та базовою "
+"особою."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1675
 msgid "Html options"
@@ -37087,13 +37137,12 @@ msgid "Whether to include an ancestor graph on each individual page"
 msgstr "Чи включати діаграму предків на кожну особисту сторінку"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1735
-#, fuzzy
 msgid "Add previous/next"
-msgstr "Додати Подружжя"
+msgstr "Додати попередній/наступний"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1736
 msgid "Add previous/next to the navigation bar."
-msgstr ""
+msgstr "Додати попередній/наступний в панелі навігації."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1739
 msgid "This is a secure site (https)"
@@ -37104,14 +37153,12 @@ msgid "Whether to use http:// or https://"
 msgstr "Використовувати  http:// або https://"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1748
-#, fuzzy
 msgid "Extra pages"
-msgstr "Екстра великий"
+msgstr "Додаткові сторінки"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1751
-#, fuzzy
 msgid "Extra page name"
-msgstr "Екстра великий"
+msgstr "Додаткова назва сторінки"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1754
 msgid "Your extra page name like it is shown in the menubar"
@@ -37136,19 +37183,21 @@ msgstr ""
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1788
 msgid "Do we display coordinates in the places list?"
-msgstr ""
+msgstr "Чи відображаємо координати у списку місць?"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1790
 msgid "Whether to display latitude/longitude in the places list?"
-msgstr ""
+msgstr "Чи відображати широту / довготу в списку місць?"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1794
 msgid "Sort places references either by date or by name"
-msgstr ""
+msgstr "Сортуйте посилання на місця або за датою, або за назвою"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1796
 msgid "Sort the places references by date or by name. Not set means by date."
 msgstr ""
+"Сортуйте посилання на місця за датою чи назвою. Не встановити засоби за "
+"датою."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1800
 msgid "Graph generations"
@@ -37160,13 +37209,15 @@ msgstr "Кількість поколінь для включення до гр�
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1807
 msgid "Include narrative notes just after name, gender"
-msgstr ""
+msgstr "Включайте розповідні замітки безпосередньо після імені, статі"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1809
 msgid ""
 "Include narrative notes just after name, gender and age at death (default) "
 "or include them just before attributes."
 msgstr ""
+"Включайте розповідні замітки безпосередньо після імені, статі та віку при "
+"смерті (за замовчуванням) або включайте їх безпосередньо перед атрибутами."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1818
 msgid "Page Generation"
@@ -37423,24 +37474,20 @@ msgid "Add a complete events list and relevant pages or not"
 msgstr "Чи додавати повний список подій та сторінки для кожної події"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:2009
-#, fuzzy
 msgid "Include places pages"
-msgstr "Включати місця"
+msgstr "Включати сторінки місць"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:2011
-#, fuzzy
 msgid "Whether or not to include the places Pages."
-msgstr "Чи потрібно додавати сторінки сховищ."
+msgstr "Чи потрібно додавати місця сторінок."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:2014
-#, fuzzy
 msgid "Include sources pages"
-msgstr "Включити примітки до джерел"
+msgstr "Включити сторінки джерел"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:2016
-#, fuzzy
 msgid "Whether or not to include the sources Pages."
-msgstr "Чи потрібно додавати сторінки сховищ."
+msgstr "Чи потрібно додавати джерела сторінок."
 
 #: ../gramps/plugins/webreport/narrativeweb.py:2019
 msgid "Include repository pages"
@@ -37555,7 +37602,7 @@ msgstr "Інші включення (CMS, Web Calendar, Php)"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:2105
 msgid "Do we include these pages in a cms web ?"
-msgstr ""
+msgstr "Чи включаємо ми ці сторінки до cms сайту?"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:2109
 #: ../gramps/plugins/webreport/narrativeweb.py:2126
@@ -38046,14 +38093,12 @@ msgid "Include anniversaries in the calendar"
 msgstr "Включати річниці в календар"
 
 #: ../gramps/plugins/webreport/webcal.py:1891
-#, fuzzy
 msgid "Include death dates"
-msgstr "Включати дати"
+msgstr "Включати дати смерті"
 
 #: ../gramps/plugins/webreport/webcal.py:1892
-#, fuzzy
 msgid "Include death anniversaries in the calendar"
-msgstr "Включати річниці в календар"
+msgstr "Включати річниці смерті в календар"
 
 #: ../gramps/plugins/webreport/webcal.py:1895
 msgid "Link to Narrated Web Report"
@@ -38065,13 +38110,16 @@ msgstr "Чи додавати посилання на веб-звіт"
 
 #: ../gramps/plugins/webreport/webcal.py:1902
 msgid "Show data only after year"
-msgstr ""
+msgstr "Показуйте дані лише через рік"
 
 #: ../gramps/plugins/webreport/webcal.py:1905
 msgid ""
 "Show data only after this year. Default is current year -  'maximum age "
 "probably alive' which is defined in the dates preference tab."
 msgstr ""
+"Показати дані лише після цього року. За замовчуванням - поточний рік - "
+"'максимальний вік, ймовірно, живий', який визначено на вкладці "
+"'Налаштування дати'."
 
 #: ../gramps/plugins/webreport/webcal.py:1913
 msgid "Link prefix"
@@ -38462,6 +38510,7 @@ msgstr "Без таблиці стилів"
 #~ "Цей фільтр зараз використовується в якості базового для інших фільтрів. "
 #~ "Його видалення спричинить видалення залежних від нього фільтрів."
 
+#, fuzzy
 #~ msgid ""
 #~ "Conveys the submitter's quantitative evaluation of the credibility of a "
 #~ "piece of information, based upon its supporting evidence. It is not "
@@ -38480,7 +38529,7 @@ msgstr "Без таблиці стилів"
 #~ "Низька =Достовірність доказів під питанням (антерв'ю, перепис населення, "
 #~ "усний переказ, потенційно суб'єктивна думка, (напр. автобіграфія)\n"
 #~ "Висока =Вторинні докази, дані офіційно зафіксовані після події\n"
-#~ "Дуже Висока =Прямі і первинні докази "
+#~ "Дуже Висока =Прямі та первинні докази, або за домінуванням доказів."
 
 #~ msgid ""
 #~ "Either use the two fields below to enter coordinates(latitude and "
@@ -40205,8 +40254,9 @@ msgstr "Без таблиці стилів"
 #~ msgid "<b>Description</b>"
 #~ msgstr "<b>Опис</b>"
 
+#, fuzzy
 #~ msgid "<b>Values</b>"
-#~ msgstr "<b>Значення</b>"
+#~ msgstr "<b>Сім'ї</b>"
 
 #~ msgid "<b>Size</b>"
 #~ msgstr "<b>Розмір</b>"


### PR DESCRIPTION
Hi,

I have updated translation to the Ukrainian language.

Unfortunately, some terms are ambiguous and to translate them better I need more context. I didn't find an easy way to use an updated translation file with Gramps (and I don't want to build it from sources). Maybe I will take a look after the next version is released and improve the translation.

Also some terms I can't understand how to properly translate them, e.g.:
* `manual|Merge_Families`, I do not understand how they used, do we need to translate them in the same way, like `manual|Об'єднати_родини`?
* `occupationplace`, we already have `Occupation place` and `occupation place` why do we need third term, how is it used and how we need to translate it?

Also with some terms, like `Ahnentafel` I'm not familiar. I left these strings not translated. May be someone with more experience in genealogy can do that later.

Best regards,
Oleh
