### PR TITLE
New debian release - update changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gramps (5.1.2-1) unstable; urgency=medium
+
+  * New release
+
+ -- Ross Gammon <rossgammon@debian.org>  Sat, 11 Jan 2020 19:07:08 +0100
+
 gramps (5.1.1-1) unstable; urgency=medium
 
   * New release


### PR DESCRIPTION
Update Debian files for 5.1.2 release. Only the changelog needed updating this time.