### PR TITLE
Add option that allows to use the name of the individual as title.

### DIFF
--- a/gramps/plugins/textreport/indivcomplete.py
+++ b/gramps/plugins/textreport/indivcomplete.py
@@ -141,6 +141,8 @@ class IndivCompleteReport(Report):
 
         self.sort = menu.get_option_by_name('sort').get_value()
 
+        self.name_is_title = menu.get_option_by_name('name_is_title').get_value()
+
         self.use_attrs = menu.get_option_by_name('incl_attrs').get_value()
         self.use_census = menu.get_option_by_name('incl_census').get_value()
         self.use_gramps_id = menu.get_option_by_name('inc_id').get_value()
@@ -853,16 +855,20 @@ class IndivCompleteReport(Report):
         self.bibli = Bibliography(
             Bibliography.MODE_DATE|Bibliography.MODE_PAGE)
 
-        title1 = self._("Complete Individual Report")
-        text2 = self._name_display.display(self.person)
+        if self.name_is_title:
+            title1 = self._name_display.display(self.person)
+        else:
+            title1 = self._("Complete Individual Report")
+            text2 = self._name_display.display(self.person)
+            mark2 = IndexMark(text2, INDEX_TYPE_TOC, 2)
         mark1 = IndexMark(title1, INDEX_TYPE_TOC, 1)
-        mark2 = IndexMark(text2, INDEX_TYPE_TOC, 2)
         self.doc.start_paragraph("IDS-Title")
         self.doc.write_text(title1, mark1)
         self.doc.end_paragraph()
-        self.doc.start_paragraph("IDS-Title")
-        self.doc.write_text(text2, mark2)
-        self.doc.end_paragraph()
+        if not self.name_is_title:
+            self.doc.start_paragraph("IDS-Title")
+            self.doc.write_text(text2, mark2)
+            self.doc.end_paragraph()
 
         self.doc.start_paragraph("IDS-Normal")
         self.doc.end_paragraph()
@@ -1078,6 +1084,11 @@ class IndivCompleteOptions(MenuReportOptions):
         pageben.set_help(
             _("Whether to start a new page before the end notes."))
         menu.add_option(category_name, "pageben", pageben)
+
+        name_is_title = BooleanOption(_("Use name of person as title"), False)
+        name_is_title.set_help(_("Whether the title should be the name of the "
+                                 "person, or 'Complete Individual Report'"))
+        menu.add_option(category_name, "name_is_title", name_is_title)
 
         ################################
         category_name = _("Report Options (2)")

--- a/gramps/plugins/textreport/indivcomplete.py
+++ b/gramps/plugins/textreport/indivcomplete.py
@@ -141,7 +141,7 @@ class IndivCompleteReport(Report):
 
         self.sort = menu.get_option_by_name('sort').get_value()
 
-        self.name_is_title = menu.get_option_by_name('name_is_title').get_value()
+        self.name_is_title = menu.get_option_by_name('name_title').get_value()
 
         self.use_attrs = menu.get_option_by_name('incl_attrs').get_value()
         self.use_census = menu.get_option_by_name('incl_census').get_value()
@@ -1088,7 +1088,7 @@ class IndivCompleteOptions(MenuReportOptions):
         name_is_title = BooleanOption(_("Use name of person as title"), False)
         name_is_title.set_help(_("Whether the title should be the name of the "
                                  "person, or 'Complete Individual Report'"))
-        menu.add_option(category_name, "name_is_title", name_is_title)
+        menu.add_option(category_name, "name_title", name_is_title)
 
         ################################
         category_name = _("Report Options (2)")


### PR DESCRIPTION
The Complete Individual Report uses as first title 'Complete Individual Report' and as second title the name of the person. When printing the report for many persons, every page starts with these two titles.
This patch adds an option to use the name of the person as first title and omit the title 'Complete Individual Report'.