### PR TITLE
Fix StyledText so serialize will match for style list order changes

### DIFF
--- a/gramps/gen/lib/styledtext.py
+++ b/gramps/gen/lib/styledtext.py
@@ -299,6 +299,7 @@ class StyledText:
         """
         if self._tags:
             the_tags = [tag.serialize() for tag in self._tags]
+            the_tags.sort()
         else:
             the_tags = []
 

--- a/gramps/gen/lib/test/styledtext_test.py
+++ b/gramps/gen/lib/test/styledtext_test.py
@@ -64,11 +64,11 @@ class Test1(unittest.TestCase):
         C = self.C.join([self.A, self.S, deepcopy(self.B)])
         C = C.replace('X', StyledText('_', [self.T3]))
         _C = ('123_456\ncleartext\nabc_def',
-              [((1, ''), 'v1', [(0, 2), (2, 3)]),
-               ((0, ''), 'v3', [(3, 4)]),
+              [((0, ''), 'v3', [(3, 4)]),
+               ((0, ''), 'v3', [(21, 22)]),
+               ((1, ''), 'v1', [(0, 2), (2, 3)]),
                ((1, ''), 'v1', [(4, 6)]),
                ((2, ''), 'v2', [(19, 21), (18, 21)]),
-               ((0, ''), 'v3', [(21, 22)]),
                ((2, ''), 'v2', [(22, 23), (22, 25)])])
         self.assertEqual(C.serialize(), _C)
 


### PR DESCRIPTION
Fixes [#11529](https://gramps-project.org/bugs/view.php?id=11529)

A minor bug; if a note has a lot of styled text (several different types) it can fail the EditNote (EditPrimary) check for data_has_changed, even though the data has not in fact been changed.

This is due to the fact that the SyledTextBuffer code puts our StyledText into the Gtk model and then pulls it back out.  The StyledText tag list gets recreated in the process, from data in the buffer, put into a dict and eventually back into the tag list.  Since the dict ordering (and possibly the Gtk returned tag ordering) was not guaranteed the returned tag list is often different in order than when it was first saved in the db.

When EditPrimary test for data changes in data_has_changed, it uses the object.serialize() to standardize the original and updated objects for comparison.  The sometimes reordered tag list doesn't match in this test.

I considered several ways to fix this, but because the db and XML files contain tag lists in various orders, I decided the best way was simply to sort the tag list as it is serialized.  The order of the tag list makes no difference to the actual functionality.