### PR TITLE
Faster Multiple Person Delete

### DIFF
--- a/gramps/gui/dialog.py
+++ b/gramps/gui/dialog.py
@@ -440,7 +440,7 @@ class MissingMediaDialog:
 class MultiSelectDialog:
     def __init__(self, msg1_func, msg2_func, items, lookup,
                  cancel_func=None, no_func=None, yes_func=None,
-                 parent=None):
+                 multi_yes_func=None, parent=None):
         """
         """
         self.xml = Glade(toplevel='multiselectdialog')
@@ -489,6 +489,10 @@ class MultiSelectDialog:
                     response = self.top.run()
 
                 if check_button.get_active():
+                    # run the multiple yes if 'do remainder' is checked
+                    if multi_yes_func and response == 3:
+                        multi_yes_func(items)
+                        break
                     default_action = response
             else:
                 response = default_action


### PR DESCRIPTION
There have been several comments/complaints by users that Gramps takes a long time to do multiple deletes.  This PR starts down the path of speeding this up so users won't have to learn how to export/import to reduce their dbs.

For the moment this only speeds up the deletion of multiple persons when "Use this answer for the rest of the items" is checked.  If this turns out to be popular, I can look into extending this PR to other types of objects.

No changes to the GUI interface.  The delete is undo able, as a single undo.

Tested on example.gramps, by deleting all persons by selecting all in Flat person view (<ctrl>a), and using the delete icon.  Original code 21.5 minutes, with PR, 4 seconds.

Found on additional issue when deleting a very large tree; the status bar had an update set 5 seconds after the last message push.  When this went off before the deletions was complete, a HandleError occurred as the GUI had not yet been updated with the deleted objects.  Fixed in separate commit.