### PR TITLE
Find possible duplicate people enhancements

### DIFF
--- a/gramps/plugins/tool/finddupes.py
+++ b/gramps/plugins/tool/finddupes.py
@@ -60,10 +60,11 @@ _val2label = {
     0.25 : _("Low"),
     1.0  : _("Medium"),
     2.0  : _("High"),
-    }
+}
 
 WIKI_HELP_PAGE = '%s_-_Tools' % URL_MANUAL_PAGE
 WIKI_HELP_SEC = _('manual|Find_Possible_Duplicate_People')
+
 
 #-------------------------------------------------------------------------
 #
@@ -79,6 +80,7 @@ def is_initial(name):
     else:
         return name[0] == name[0].upper()
 
+
 #-------------------------------------------------------------------------
 #
 # The Actual tool.
@@ -90,8 +92,7 @@ class DuplicatePeopleTool(tool.Tool, ManagedWindow):
         uistate = user.uistate
 
         tool.Tool.__init__(self, dbstate, options_class, name)
-        ManagedWindow.__init__(self, uistate, [],
-                                             self.__class__)
+        ManagedWindow.__init__(self, uistate, [], self.__class__)
         self.dbstate = dbstate
         self.uistate = uistate
         self.map = {}
@@ -135,14 +136,14 @@ class DuplicatePeopleTool(tool.Tool, ManagedWindow):
             "on_help_clicked"       : self.on_help_clicked,
             "on_delete_merge_event" : self.close,
             "on_delete_event"       : self.close,
-            })
+        })
 
         self.show()
 
-    def build_menu_names(self, obj):
-        return (_("Tool settings"),_("Find Duplicates tool"))
+    def build_menu_names(self, _obj):
+        return (_("Tool settings"), _("Find Duplicates tool"))
 
-    def on_help_clicked(self, obj):
+    def on_help_clicked(self, _obj):
         """Display the relevant portion of Gramps manual"""
 
         display_help(WIKI_HELP_PAGE , WIKI_HELP_SEC)
@@ -155,8 +156,8 @@ class DuplicatePeopleTool(tool.Tool, ManagedWindow):
         f1_id = p1.get_main_parents_family_handle()
         if f1_id:
             f1 = self.db.get_family_from_handle(f1_id)
-            self.ancestors_of(f1.get_father_handle(),id_list)
-            self.ancestors_of(f1.get_mother_handle(),id_list)
+            self.ancestors_of(f1.get_father_handle(), id_list)
+            self.ancestors_of(f1.get_mother_handle(), id_list)
 
     def on_merge_ok_clicked(self, obj):
         threshold = self.menu.get_model()[self.menu.get_active()][1]
@@ -319,12 +320,12 @@ class DuplicatePeopleTool(tool.Tool, ManagedWindow):
         chance += value
 
         ancestors = []
-        self.ancestors_of(p1.get_handle(),ancestors)
+        self.ancestors_of(p1.get_handle(), ancestors)
         if p2.get_handle() in ancestors:
             return -1
 
         ancestors = []
-        self.ancestors_of(p2.get_handle(),ancestors)
+        self.ancestors_of(p2.get_handle(), ancestors)
         if p1.get_handle() in ancestors:
             return -1
 
@@ -345,7 +346,7 @@ class DuplicatePeopleTool(tool.Tool, ManagedWindow):
             else:
                 dad2 = None
 
-            value = self.name_match(dad1,dad2)
+            value = self.name_match(dad1, dad2)
 
             if value == -1:
                 return -1
@@ -363,7 +364,7 @@ class DuplicatePeopleTool(tool.Tool, ManagedWindow):
             else:
                 mom2 = None
 
-            value = self.name_match(mom1,mom2)
+            value = self.name_match(mom1, mom2)
             if value == -1:
                 return -1
 
@@ -374,31 +375,31 @@ class DuplicatePeopleTool(tool.Tool, ManagedWindow):
             for f2_id in p2.get_family_handle_list():
                 f2 = self.db.get_family_from_handle(f2_id)
                 if p1.get_gender() == Person.FEMALE:
-                    father1_id = f1.get_father_handle()
-                    father2_id = f2.get_father_handle()
-                    if father1_id and father2_id:
-                        if father1_id == father2_id:
+                    father1_h = f1.get_father_handle()
+                    father2_h = f2.get_father_handle()
+                    if father1_h and father2_h:
+                        if father1_h == father2_h:
                             chance += 1
                         else:
-                            father1 = self.db.get_person_from_handle(father1_id)
-                            father2 = self.db.get_person_from_handle(father2_id)
+                            father1 = self.db.get_person_from_handle(father1_h)
+                            father2 = self.db.get_person_from_handle(father2_h)
                             fname1 = get_name_obj(father1)
                             fname2 = get_name_obj(father2)
-                            value = self.name_match(fname1,fname2)
+                            value = self.name_match(fname1, fname2)
                             if value != -1:
                                 chance += value
                 else:
-                    mother1_id = f1.get_mother_handle()
-                    mother2_id = f2.get_mother_handle()
-                    if mother1_id and mother2_id:
-                        if mother1_id == mother2_id:
+                    mother1_h = f1.get_mother_handle()
+                    mother2_h = f2.get_mother_handle()
+                    if mother1_h and mother2_h:
+                        if mother1_h == mother2_h:
                             chance += 1
                         else:
-                            mother1 = self.db.get_person_from_handle(mother1_id)
-                            mother2 = self.db.get_person_from_handle(mother2_id)
+                            mother1 = self.db.get_person_from_handle(mother1_h)
+                            mother2 = self.db.get_person_from_handle(mother2_h)
                             mname1 = get_name_obj(mother1)
                             mname2 = get_name_obj(mother2)
-                            value = self.name_match(mname1,mname2)
+                            value = self.name_match(mname1, mname2)
                             if value != -1:
                                 chance += value
         return chance
@@ -406,7 +407,7 @@ class DuplicatePeopleTool(tool.Tool, ManagedWindow):
     def name_compare(self, s1, s2):
         if self.use_soundex:
             try:
-                return compare(s1,s2)
+                return compare(s1, s2)
             except UnicodeEncodeError:
                 return s1 == s2
         else:
@@ -419,7 +420,7 @@ class DuplicatePeopleTool(tool.Tool, ManagedWindow):
             return 1
 
         if date1.is_compound() or date2.is_compound():
-            return self.range_compare(date1,date2)
+            return self.range_compare(date1, date2)
 
         if date1.get_year() == date2.get_year():
             if date1.get_month() == date2.get_month():
@@ -437,10 +438,10 @@ class DuplicatePeopleTool(tool.Tool, ManagedWindow):
         stop_date_1 = date1.get_stop_date()[0:3]
         stop_date_2 = date2.get_stop_date()[0:3]
         if date1.is_compound() and date2.is_compound():
-            if (start_date_2 <= start_date_1 <= stop_date_2 or
-                start_date_1 <= start_date_2 <= stop_date_1 or
-                start_date_2 <= stop_date_1 <= stop_date_2 or
-                start_date_1 <= stop_date_2 <= stop_date_1):
+            if(start_date_2 <= start_date_1 <= stop_date_2 or
+               start_date_1 <= start_date_2 <= stop_date_1 or
+               start_date_2 <= stop_date_1 <= stop_date_2 or
+               start_date_1 <= stop_date_2 <= stop_date_1):
                 return 0.5
             else:
                 return -1
@@ -465,7 +466,7 @@ class DuplicatePeopleTool(tool.Tool, ManagedWindow):
         srn2 = get_surnames(name1)
         sfx2 = name1.get_suffix()
 
-        if not self.name_compare(srn1,srn2):
+        if not self.name_compare(srn1, srn2):
             return -1
         if sfx1 != sfx2:
             if sfx1 != "" and sfx2 != "":
@@ -478,9 +479,9 @@ class DuplicatePeopleTool(tool.Tool, ManagedWindow):
             list2 = name1.get_first_name().split()
 
             if len(list1) < len(list2):
-                return self.list_reduce(list1,list2)
+                return self.list_reduce(list1, list2)
             else:
-                return self.list_reduce(list2,list1)
+                return self.list_reduce(list2, list1)
 
     def place_match(self, p1_id, p2_id):
         if p1_id == p2_id:
@@ -503,8 +504,8 @@ class DuplicatePeopleTool(tool.Tool, ManagedWindow):
         if name1 == name2:
             return 1
 
-        list1 = name1.replace(","," ").split()
-        list2 = name2.replace(","," ").split()
+        list1 = name1.replace(",", " ").split()
+        list2 = name2.replace(",", " ").split()
 
         value = 0
         for name in list1:
@@ -513,7 +514,7 @@ class DuplicatePeopleTool(tool.Tool, ManagedWindow):
                     value += 0.5
                 elif name[0] == name2[0] and self.name_compare(name, name2):
                     value += 0.25
-        return min(value,1) if value else -1
+        return min(value, 1) if value else -1
 
     def list_reduce(self, list1, list2):
         value = 0
@@ -527,7 +528,7 @@ class DuplicatePeopleTool(tool.Tool, ManagedWindow):
                     value += 0.5
                 elif name[0] == name2[0] and self.name_compare(name, name2):
                     value += 0.25
-        return min(value,1) if value else -1
+        return min(value, 1) if value else -1
 
     def __dummy(self, obj):
         """dummy callback, needed because a shared glade file is used for
@@ -539,7 +540,7 @@ class DuplicatePeopleTool(tool.Tool, ManagedWindow):
 class DuplicatePeopleToolMatches(ManagedWindow):
 
     def __init__(self, dbstate, uistate, track, the_list, the_map, callback):
-        ManagedWindow.__init__(self,uistate,track,self.__class__)
+        ManagedWindow.__init__(self, uistate, track, self.__class__)
 
         self.dellist = set()
         self.list = the_list
@@ -566,25 +567,24 @@ class DuplicatePeopleToolMatches(ManagedWindow):
             "on_help_clicked"       : self.__dummy,
             "on_delete_merge_event" : self.__dummy,
             "on_delete_event"       : self.__dummy,
-            })
+        })
         self.db.connect("person-delete", self.person_delete)
 
-        mtitles = [
-                (_('Rating'),3,75),
-                (_('First Person'),1,200),
-                (_('Second Person'),2,200),
-                ('',-1,0)
-                ]
-        self.list = ListModel(self.mlist,mtitles,
+        mtitles = [(_('Rating'), 3, 75),
+                   (_('First Person'), 1, 200),
+                   (_('Second Person'), 2, 200),
+                   ('', -1, 0)
+                   ]
+        self.list = ListModel(self.mlist, mtitles,
                               event_func=self.on_do_merge_clicked)
 
         self.redraw()
         self.show()
 
-    def build_menu_names(self, obj):
+    def build_menu_names(self, _obj):
         return (_("Merge candidates"), _("Merge persons"))
 
-    def on_help_clicked(self, obj):
+    def on_help_clicked(self, _obj):
         """Display the relevant portion of Gramps manual"""
 
         display_help(WIKI_HELP_PAGE , WIKI_HELP_SEC)
@@ -612,12 +612,12 @@ class DuplicatePeopleToolMatches(ManagedWindow):
             pn2 = name_displayer.display(p2)
             self.list.add([c1, pn1, pn2,c2],(p1key,p2key))
 
-    def on_do_merge_clicked(self, obj):
-        store,iter = self.list.selection.get_selected()
-        if not iter:
+    def on_do_merge_clicked(self, _obj):
+        _store, iter_ = self.list.selection.get_selected()
+        if not iter_:
             return
 
-        (self.p1,self.p2) = self.list.get_object(iter)
+        (self.p1, self.p2) = self.list.get_object(iter_)
         MergePerson(self.dbstate, self.uistate, self.track, self.p1, self.p2,
                     self.on_update, True)
 
@@ -630,7 +630,7 @@ class DuplicatePeopleToolMatches(ManagedWindow):
         self.update()
         self.redraw()
 
-    def update_and_destroy(self, obj):
+    def update_and_destroy(self, _obj):
         self.update(1)
         self.close()
 
@@ -654,7 +654,8 @@ class DuplicatePeopleToolMatches(ManagedWindow):
 def name_of(p):
     if not p:
         return ""
-    return "%s (%s)" % (name_displayer.display(p),p.get_handle())
+    return "%s (%s)" % (name_displayer.display(p), p.get_handle())
+
 
 def get_name_obj(person):
     if person:
@@ -662,9 +663,11 @@ def get_name_obj(person):
     else:
         return None
 
+
 def get_surnames(name):
     """Construct a full surname of the surnames"""
     return ' '.join([surn.get_surname() for surn in name.get_surname_list()])
+
 
 #------------------------------------------------------------------------
 #
@@ -676,8 +679,8 @@ class DuplicatePeopleToolOptions(tool.ToolOptions):
     Defines options and provides handling interface.
     """
 
-    def __init__(self, name,person_id=None):
-        tool.ToolOptions.__init__(self, name,person_id)
+    def __init__(self, name, person_id=None):
+        tool.ToolOptions.__init__(self, name, person_id)
 
         # Options specific for this report
         self.options_dict = {
@@ -685,9 +688,9 @@ class DuplicatePeopleToolOptions(tool.ToolOptions):
             'threshold' : 0.25,
         }
         self.options_help = {
-            'soundex'   : ("=0/1","Whether to use SoundEx codes",
-                           ["Do not use SoundEx","Use SoundEx"],
+            'soundex'   : ("=0/1", "Whether to use SoundEx codes",
+                           ["Do not use SoundEx", "Use SoundEx"],
                            True),
-            'threshold' : ("=num","Threshold for tolerance",
+            'threshold' : ("=num", "Threshold for tolerance",
                            "Floating point number")
-            }
+        }


### PR DESCRIPTION
When attempting to merge in a GEDCOM that contained _UID for the people, with a tree that already had some of the same people, I noted that our 'Find Possible Duplicate People' was ignoring the _UID entries.  The tree also happened to have a set of actual duplicates which I could not get to show up.

P.S. our GEDCOM importer stores _UID entries as attributes on Persons or Families.

On investigation, I saw that the tool did not display all possible duplicates for a single person, only the one it thought had the highest score.  And it did not look at _UID attributes at all.

This PR contains three commits, a pylint, the patch to allow all duplicate pairs to show up, and a second patch to allow matching _UID attributes on persons to give the highest score (10).