### PR TITLE
GEDCOM export, add _UID when not present

### DIFF
--- a/data/tests/exp_sample_ged_uid.ged
+++ b/data/tests/exp_sample_ged_uid.ged
@@ -1,0 +1,1502 @@
+0 HEAD
+1 SOUR Gramps
+2 VERS 5.1.2
+2 NAME Gramps
+1 DATE 31 DEC 1969
+2 TIME 18:00:00
+1 SUBM @SUBM@
+1 FILE C:\Users\prc\AppData\Roaming\gramps\temp\exp_sample_ged_uid.ged
+1 COPR Copyright (c) 1969 Alex Roitman,,,.
+1 GEDC
+2 VERS 5.5.1
+2 FORM LINEAGE-LINKED
+1 CHAR UTF-8
+1 LANG English
+0 @SUBM@ SUBM
+1 NAME Alex Roitman,,,
+1 ADDR Not Provided
+2 ADR1 Not Provided
+1 PHON 666-555-4444
+1 EMAIL an_email@@gmail.com
+0 @I0000@ INDI
+1 NAME Anna /Hansdotter/
+2 GIVN Anna
+2 SURN Hansdotter
+2 NICK Annanana
+1 NAME Anna Nana /Hansdotter/
+2 TYPE aka
+2 GIVN Anna Nana
+2 SURN Hansdotter
+1 SEX F
+1 BIRT
+2 TYPE Birth of Anna Hansdotter
+2 DATE 2 OCT 1864
+2 PLAC Löderup, Malmöhus Län, Sweden
+1 DEAT
+2 TYPE Death of Anna Hansdotter
+2 DATE 29 SEP 1945
+2 PLAC Sparks, Washoe Co., NV
+1 _UID CD072CD85594AA6B62E6E2820442027A44DC
+1 FAMS @F0003@
+1 ASSO @I0038@
+2 RELA Friend
+2 NOTE @N0015@
+1 NOTE @N0014@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0001@ INDI
+1 NAME Keith Lloyd /Smith/
+2 GIVN Keith Lloyd
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 TYPE Birth of Keith Lloyd Smith
+2 DATE 11 AUG 1966
+2 PLAC San Francisco, San Francisco Co., CA
+1 _UID 13167AE8762833817386264879627CC15C06
+1 FAMC @F0008@
+2 PEDI birth
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0002@ INDI
+1 NAME Amber Marie /Smith/
+2 GIVN Amber Marie
+2 SURN Smith
+1 SEX F
+1 BIRT
+2 TYPE Birth of Amber Marie Smith
+2 DATE 12 APR 1998
+2 PLAC Hayward, Alameda Co., CA
+1 CHR
+2 TYPE Christening of Amber Marie Smith
+2 DATE 26 APR 1998
+2 PLAC Community Presbyterian Church, Danville, CA
+2 ADDR
+3 ADR2 Community Presbyterian Church, Danville, CA
+1 _UID 0B59F4E6D9D4654FFB40D6BA2A9219AFEE6B
+1 FAMC @F0013@
+2 PEDI birth
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0003@ INDI
+1 NAME Magnes /Smith/
+2 GIVN Magnes
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 TYPE Birth of Magnes Smith
+2 DATE 6 OCT 1858
+2 PLAC Simrishamn, Kristianstad Län, Sweden
+1 DEAT
+2 TYPE Death of Magnes Smith
+2 DATE 20 FEB 1910
+2 PLAC Rønne, Bornholm, Denmark
+1 _UID F48DC719A2E2256FBC17BBE906501D7ADD7D
+1 FAMC @F0002@
+2 PEDI birth
+1 FAMS @F0011@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0004@ INDI
+1 NAME Ingeman /Smith/
+2 GIVN Ingeman
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 TYPE Birth of Ingeman Smith
+2 DATE 29 JAN 1826
+2 PLAC Gladsax, Kristianstad Län, Sweden
+1 _UID C39FAF42A83C98032A371BDEE833D7DEFC7A
+1 FAMC @F0000@
+2 PEDI birth
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0005@ INDI
+1 NAME Mason Michael /Smith/
+2 GIVN Mason Michael
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 TYPE Birth of Mason Michael Smith
+2 DATE 26 JUN 1996
+2 PLAC Hayward, Alameda Co., CA
+1 CHR
+2 TYPE Christening of Mason Michael Smith
+2 DATE 10 JUL 1996
+2 PLAC Community Presbyterian Church, Danville, CA
+2 ADDR
+3 ADR2 Community Presbyterian Church, Danville, CA
+1 _UID 4F624891D2B7B0F74422AE728B32CEEEB9E7
+1 FAMC @F0013@
+2 PEDI birth
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0006@ INDI
+1 NAME Edwin /Willard/
+2 GIVN Edwin
+2 SURN Willard
+1 SEX M
+1 BIRT
+2 TYPE Birth of Edwin Willard
+2 DATE ABT 1886
+1 _UID 1137EB1BB7D91F8D7D35E1B46A16258C0279
+1 FAMS @F0004@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0007@ INDI
+1 NAME Ingar /Smith/
+2 GIVN Ingar
+2 SURN Smith
+1 SEX F
+1 BIRT
+2 TYPE Birth of Ingar Smith
+2 DATE AFT 1823
+2 PLAC Gladsax, Kristianstad Län, Sweden
+1 _UID C106508A77126E9605CDEA71A5E18862CBD5
+1 FAMC @F0000@
+2 PEDI birth
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0008@ INDI
+1 NAME Hjalmar /Smith/
+2 GIVN Hjalmar
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 TYPE Birth of Hjalmar Smith
+2 DATE 7 APR 1895
+2 PLAC Rønne, Bornholm, Denmark
+1 DEAT
+2 TYPE Death of Hjalmar Smith
+2 DATE 26 JUN 1975
+2 PLAC Reno, Washoe Co., NV
+1 BAPM
+2 TYPE Baptism of Hjalmar Smith
+2 DATE 3 JUN 1895
+2 PLAC Rønne Bornholm, Denmark
+1 EVEN
+2 TYPE Immi
+2 DATE 14 NOV 1912
+2 PLAC Copenhagen, Denmark
+1 _UID 72DD5D93CC08534AB581CD2F77D41AA8EF7C
+1 FAMC @F0003@
+2 PEDI birth
+1 FAMS @F0006@
+1 NOTE @N0003@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0009@ INDI
+1 NAME Emil /Smith/
+2 GIVN Emil
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 TYPE Birth of Emil Smith
+2 DATE 27 SEP 1860
+2 PLAC Simrishamn, Kristianstad Län, Sweden
+1 _UID 7CEFFD79B854F2C1EB0574E0C8B262ECACAE
+1 FAMC @F0002@
+2 PEDI birth
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0010@ INDI
+1 NAME Hans Peter /Smith/
+2 GIVN Hans Peter
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 TYPE Birth of Hans Peter Smith
+2 DATE 17 APR 1904
+2 PLAC Rønne, Bornholm, Denmark
+2 SOUR @S0002@
+3 PAGE 22 6
+3 DATA
+4 DATE 5 MAY 1955
+4 TEXT A citation Note Source text
+3 NOTE @N0018@
+3 EVEN Citation Event?
+4 ROLE The Event type Role
+1 DEAT
+2 TYPE Death of Hans Peter Smith
+2 DATE 29 JAN 1977
+2 PLAC San Francisco, San Francisco Co., CA
+1 BURI
+2 TYPE In cemetary
+2 DATE 5 FEB 1977
+2 PLAC San Francisco, San Francisco Co., CA
+2 SOUR @S0004@
+3 QUAY 2
+3 DATA
+4 DATE 22 JUL 1977
+1 _UID 2879ABD725E6C6CF93E977D974CA23F3E3E2
+1 FAMC @F0003@
+2 PEDI birth
+1 FAMS @F0009@
+1 FAMS @F0014@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0011@ INDI
+1 NAME Hanna /Smith/
+2 GIVN Hanna
+2 SURN Smith
+1 SEX F
+1 BIRT
+2 TYPE Birth of Hanna Smith
+2 DATE 29 JAN 1821
+2 PLAC Gladsax, Kristianstad Län, Sweden
+1 _UID 72E46694811A58735A5A17CB706516154C30
+1 FAMC @F0000@
+2 PEDI birth
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0012@ INDI
+1 NAME Herman Julius /Nielsen/
+2 GIVN Herman Julius
+2 SURN Nielsen
+1 SEX M
+1 BIRT
+2 TYPE Birth of Herman Julius Nielsen
+2 DATE 31 AUG 1889
+2 PLAC Rønne, Bornholm, Denmark
+1 DEAT
+2 TYPE Death of Herman Julius Nielsen
+2 DATE 1945
+1 _UID 865ADF9C075651A1020157D82D95373E1315
+1 FAMS @F0005@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0013@ INDI
+1 NAME Evelyn /Michaels/
+2 GIVN Evelyn
+2 SURN Michaels
+1 SEX F
+1 BIRT
+2 TYPE Birth of Evelyn Michaels
+2 DATE ABT 1897
+1 _UID B2E042BB141A703838CA69CBDD16215504C1
+1 FAMS @F0007@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0014@ INDI
+1 NAME Marjorie Lee /Smith/
+2 GIVN Marjorie Lee
+2 SURN Smith
+1 SEX F
+1 BIRT
+2 TYPE Birth of Marjorie Lee Smith
+2 DATE 4 NOV 1934
+2 PLAC Reno, Washoe Co., NV
+1 _UID 43AEDFD0068B9AB2EC163BAEE899D506C488
+1 FAMC @F0006@
+2 PEDI birth
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0015@ INDI
+1 NAME Gus /Smith/
+2 GIVN Gus
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 TYPE Birth of Gus Smith
+2 DATE 11 SEP 1897
+2 PLAC Rønne, Bornholm, Denmark
+1 DEAT
+2 TYPE Death of Gus Smith
+2 DATE 21 OCT 1963
+2 PLAC San Francisco, San Francisco Co., CA
+1 _UID B05A8FA21FA77193D54C2664A12303FB720A
+1 FAMC @F0003@
+2 PEDI birth
+1 FAMS @F0007@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0016@ INDI
+1 NAME Jennifer /Anderson/
+2 GIVN Jennifer
+2 SURN Anderson
+1 SEX F
+1 BIRT
+2 TYPE Birth of Jennifer Anderson
+2 DATE 5 NOV 1907
+2 PLAC Rønne, Bornholm, Denmark
+1 DEAT
+2 TYPE Death of Jennifer Anderson
+2 DATE 29 MAY 1985
+2 PLAC San Francisco, San Francisco Co., CA
+1 _UID 77F88905FA97B71F9BBAFDCC221C8A428C33
+1 FAMS @F0014@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0017@ INDI
+1 NAME Lillie Harriet /Jones/
+2 GIVN Lillie Harriet
+2 SURN Jones
+1 SEX F
+1 BIRT
+2 TYPE Birth of Lillie Harriet Jones
+2 DATE 2 MAY 1910
+2 PLAC Rønne, Bornholm, Denmark
+1 DEAT
+2 TYPE Death of Lillie Harriet Jones
+2 DATE 26 JUN 1990
+1 _UID 7944883898EC9CA598DDAC596550292EC891
+1 FAMS @F0009@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0018@ INDI
+1 NAME John Hjalmar /Smith/
+2 GIVN John Hjalmar
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 TYPE Birth of John Hjalmar Smith
+2 DATE 30 JAN 1932
+2 PLAC San Francisco, San Francisco Co., CA
+1 _UID 6E52EE8081FAFCFC2EFB0833CB064ABBDBB9
+1 FAMC @F0006@
+2 PEDI birth
+1 FAMS @F0012@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0019@ INDI
+1 NAME Eric Lloyd /Smith/
+2 GIVN Eric Lloyd
+2 SURN Smith
+2 NPFX Dr.
+1 SEX M
+1 BIRT
+2 TYPE Birth of Eric Lloyd Smith
+2 DATE 28 AUG 1963
+2 PLAC San Francisco, San Francisco Co., CA
+1 ADOP Y
+2 FAMC @F0008@
+3 ADOP BOTH
+1 _UID 122C32AC608F1BAD11BF6DD8AF0B2D400FF2
+1 FAMC @F0008@
+2 PEDI adopted
+1 FAMS @F0010@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0020@ INDI
+1 NAME Carl Emil /Smith/
+2 GIVN Carl Emil
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 TYPE Birth of Carl Emil Smith
+2 DATE 20 DEC 1899
+2 PLAC Rønne, Bornholm, Denmark
+1 DEAT
+2 TYPE Death of Carl Emil Smith
+2 DATE 28 JAN 1959
+2 PLAC Reno, Washoe Co., NV
+2 CAUS Bad breath
+1 _UID 59F8C02CE74A6E5B831F3D40CA062F03588F
+1 FAMC @F0003@
+2 PEDI birth
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0021@ INDI
+1 NAME Hjalmar /Smith/
+2 GIVN Hjalmar
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 TYPE Birth of Hjalmar Smith
+2 DATE 31 JAN 1893
+2 PLAC Rønne, Bornholm, Denmark
+1 DEAT
+2 TYPE Death of Hjalmar Smith
+2 DATE 25 SEP 1894
+2 PLAC Rønne, Bornholm, Denmark
+1 _UID 9BD1D7BD93F5E747D74800F464E4FE9EAD84
+1 FAMC @F0003@
+2 PEDI birth
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0022@ INDI
+1 NAME Martin /Smith/
+2 GIVN Martin
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 TYPE Birth of Martin Smith
+2 DATE 19 NOV 1830
+2 PLAC Gladsax, Kristianstad Län, Sweden
+1 DEAT
+2 TYPE Death of Martin Smith
+2 DATE BET 1899 AND 1905
+2 PLAC Sweden
+1 BAPM
+2 TYPE Baptism of Martin Smith
+2 DATE 23 NOV 1830
+2 PLAC Gladsax, Kristianstad Län, Sweden
+1 _UID 6FD432B785FB9CA675599B55515D4A3DE1E4
+1 FAMC @F0000@
+2 PEDI birth
+1 FAMS @F0002@
+1 NOTE @N0002@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0023@ INDI
+1 NAME Astrid Shermanna Augusta /Smith/
+2 GIVN Astrid Shermanna Augusta
+2 SURN Smith
+1 SEX F
+1 BIRT
+2 TYPE Birth of Astrid Shermanna Augusta Smith
+2 DATE 31 JAN 1889
+2 PLAC Rønne, Bornholm, Denmark
+1 DEAT
+2 TYPE Death of Astrid Shermanna Augusta Smith
+2 DATE 21 DEC 1963
+2 PLAC San Francisco, San Francisco Co., CA
+1 _UID 6F9B2CA3AD89166AEFC0F90BE399027232DB
+1 FAMC @F0003@
+2 PEDI birth
+1 FAMS @F0005@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0024@ INDI
+1 NAME Gustaf /Smith/ Sr.
+2 GIVN Gustaf
+2 SURN Smith
+2 NSFX Sr.
+1 SEX M
+1 BIRT
+2 TYPE Birth of Gustaf Smith, Sr.
+2 DATE 28 NOV 1862
+2 PLAC Grostorp, Kristianstad Län, Sweden
+1 DEAT
+2 TYPE Death of Gustaf Smith, Sr.
+2 DATE BEF 23 JUL 1930
+2 PLAC Sparks, Washoe Co., NV
+1 EVEN
+2 TYPE Immi
+2 DATE 21 MAY 1908
+2 PLAC Copenhagen, Denmark
+1 CHR
+2 TYPE Christening of Gustaf Smith, Sr.
+2 DATE 7 DEC 1862
+2 PLAC Gladsax, Kristianstad Län, Sweden
+1 _UID B4255E283F7367C160A445E24FF89C7EC5A9
+1 FAMC @F0002@
+2 PEDI birth
+1 FAMS @F0003@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0025@ INDI
+1 NAME Marta /Ericsdotter/
+2 GIVN Marta
+2 SURN Ericsdotter
+1 SEX F
+1 BIRT
+2 TYPE Birth of Marta Ericsdotter
+2 DATE ABT 1775
+2 PLAC Sweden
+1 _UID E53F8677DD6CFACF2DEEBDB93655A0FCEB73
+1 FAMS @F0001@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0026@ INDI
+1 NAME Kirsti Marie /Smith/
+2 GIVN Kirsti Marie
+2 SURN Smith
+1 SEX F
+1 BIRT
+2 TYPE Birth of Kirsti Marie Smith
+2 DATE 15 DEC 1886
+2 PLAC Rønne, Bornholm, Denmark
+1 DEAT
+2 TYPE Death of Kirsti Marie Smith
+2 DATE 18 JUL 1966
+2 PLAC San Francisco, San Francisco Co., CA
+1 _UID CB28B3AD2BFCF050748DA9361565081935CE
+1 FAMC @F0003@
+2 PEDI birth
+1 FAMS @F0004@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0027@ INDI
+1 NAME Ingeman /Smith/
+2 GIVN Ingeman
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 TYPE Birth of Ingeman Smith
+2 DATE ABT 1770
+2 PLAC Sweden
+1 _UID 5C4236A6EDC6A7DFBFF87FFA1B71A5192DB9
+1 FAMS @F0001@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0028@ INDI
+1 NAME Anna /Streiffert/
+2 GIVN Anna
+2 SURN Streiffert
+1 SEX F
+1 BIRT
+2 TYPE Birth of Anna Streiffert
+2 DATE 23 SEP 1860
+2 PLAC Hoya/Jona/Hoia, Sweden
+1 DEAT
+2 TYPE Death of Anna Streiffert
+2 DATE 2 FEB 1927
+2 PLAC Rønne, Bornholm, Denmark
+1 _UID BC0DD31414E5D6CA271582DC7677D85800B6
+1 FAMS @F0011@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0029@ INDI
+1 NAME Craig Peter /Smith/
+2 GIVN Craig Peter
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 TYPE Birth of Craig Peter Smith
+2 DATE AFT 1966
+2 PLAC San Francisco, San Francisco Co., CA
+1 CENS
+2 TYPE Census of Craig Peter Smith
+2 NOTE @N0000@
+1 _UID FD7732DF8249C1048EE8680AFFCD55AECCE6
+1 FAMC @F0008@
+2 PEDI birth
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0030@ INDI
+1 NAME Janice Ann /Adams/
+2 GIVN Janice Ann
+2 SURN Adams
+1 SEX F
+1 BIRT
+2 TYPE Birth of Janice Ann Adams
+2 DATE 26 AUG 1965
+2 PLAC Fremont, Alameda Co., CA
+1 OCCU Retail Manager
+1 _DEG
+2 TYPE Business Management
+2 DATE 1988
+1 _UID D466F08ED8FD4DF287CBC5A7220318E7AE61
+1 FAMS @F0013@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0031@ INDI
+1 NAME Marjorie /Ohman/
+2 GIVN Marjorie
+2 SURN Ohman
+1 SEX F
+1 BIRT
+2 TYPE Birth of Marjorie Ohman
+2 DATE 3 JUN 1903
+2 PLAC Denver, Denver Co., CO, Denver Co., Colorado, USA
+3 MAP
+4 LATI N39.7392
+4 LONG W104.9903
+2 ADDR
+3 CITY Denver, Denver Co., CO
+3 STAE Colorado
+3 CTRY USA
+1 DEAT
+2 TYPE Death of Marjorie Ohman
+2 DATE 22 JUN 1980
+2 PLAC Reno, Washoe Co., NV
+1 _UID 3B4BE0A368B3B5897945353577DB4D96BF9F
+1 FAMS @F0006@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0032@ INDI
+1 NAME Darcy /Horne/
+2 GIVN Darcy
+2 SURN Horne
+1 SEX F
+1 BIRT
+2 TYPE Birth of Darcy Horne
+2 DATE 2 JUL 1966
+2 PLAC Sacramento, Sacramento Co., CA
+2 ADDR
+3 CITY Sacramento, Sacramento Co., CA
+1 _UID 5F1447026574A92685405A554DBE24CAD1ED
+1 FAMS @F0010@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0033@ INDI
+1 NAME Lloyd /Smith/
+2 GIVN Lloyd
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 TYPE Birth of Lloyd Smith
+2 DATE 13 MAR 1935
+2 PLAC San Francisco, San Francisco Co., CA
+1 ADOP Y
+2 FAMC @F0009@
+3 ADOP HUSB
+1 _UID 1C94EFB7F295DB9EC7468C0AC7C3F2299EB2
+1 FAMC @F0009@
+2 _FREL Adopted
+2 _MREL Foster
+1 FAMS @F0008@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0034@ INDI
+1 NAME Alice Paula /Perkins/
+2 GIVN Alice Paula
+2 SURN Perkins
+1 SEX F
+1 BIRT
+2 TYPE Birth of Alice Paula Perkins
+2 DATE 22 NOV 1933
+2 PLAC Sparks, Washoe Co., NV
+1 _UID B7B11E4A8F77698CBDB81C4B6F875A0C032C
+1 FAMS @F0012@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0035@ INDI
+1 NAME Lars Peter /Smith/
+2 GIVN Lars Peter
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 TYPE Birth of Lars Peter Smith
+2 DATE 16 SEP 1991
+2 PLAC Santa Rosa, Sonoma Co., CA
+1 ADOP Y
+2 FAMC @F0010@
+3 ADOP BOTH
+1 _UID E6112412FCEE195400322B6A15C89DE8AD79
+1 FAMC @F0010@
+2 PEDI adopted
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0036@ INDI
+1 NAME Elna /Jefferson/
+2 GIVN Elna
+2 SURN Jefferson
+1 SEX F
+1 BIRT
+2 TYPE Birth of Elna Jefferson
+2 DATE 14 SEP 1800
+2 PLAC Gladsax, Kristianstad Län, Sweden
+1 DEAT
+2 TYPE Death of Elna Jefferson
+2 PLAC Sweden
+1 CHR
+2 TYPE Christening of Elna Jefferson
+2 DATE 16 SEP 1800
+2 PLAC Gladsax, Kristianstad Län, Sweden
+1 _UID 695E58791E8DF957186AA57A4CAD18B3F847
+1 FAMS @F0000@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0037@ INDI
+1 NAME Edwin Michael /Smith/
+2 GIVN Edwin Michael
+2 SURN Smith
+2 SOUR @S0001@
+1 SEX M
+1 BIRT
+2 TYPE Birth of Edwin Michael Smith
+2 DATE 24 MAY 1961
+2 PLAC San Jose, Santa Clara Co., CA
+2 SOUR @S0003@
+1 OCCU Software Engineer
+2 AGE 23
+2 NOTE @N0001@
+1 EDUC Education of Edwin Michael Smith
+2 DATE BET 1979 AND 1984
+2 PLAC UC Berkeley
+1 _DEG
+2 TYPE B.S.E.E.
+2 DATE 1984
+1 _UID 4A6B316DDC85494D5E62F7E465BA70EB5F1B
+1 FAMC @F0012@
+2 PEDI birth
+1 FAMS @F0013@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0038@ INDI
+1 NAME Kerstina /Hansdotter/
+2 GIVN Kerstina
+2 SURN Hansdotter
+1 SEX F
+1 BIRT
+2 TYPE Birth of Kerstina Hansdotter
+2 DATE 29 NOV 1832
+2 PLAC Smestorp, Kristianstad Län, Sweden
+1 DEAT
+2 TYPE Death of Kerstina Hansdotter
+2 DATE BEF 1908
+2 PLAC Sweden
+1 _UID FC8A8DA3A1E7AC15CE73F7BF05EEA70F9F16
+1 FAMS @F0002@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0039@ INDI
+1 NAME Martin /Smith/
+2 GIVN Martin
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 TYPE Birth of Martin Smith
+2 DATE BET 1794 AND 1796
+2 PLAC Tommarp, Kristianstad Län, Sweden
+1 DEAT
+2 TYPE Death of Martin Smith
+2 PLAC Sweden
+1 _UID 1C860202A66DDD84E9C5E6AD35394C6C8180
+1 FAMC @F0001@
+2 PEDI birth
+1 FAMS @F0000@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0040@ INDI
+1 NAME Marjorie Alice /Smith/
+2 GIVN Marjorie Alice
+2 SURN Smith
+1 SEX F
+1 BIRT
+2 TYPE Birth of Marjorie Alice Smith
+2 DATE 5 FEB 1960
+2 PLAC San Jose, Santa Clara Co., CA
+1 _UID 62F84A5E3309F0C64380646EEBFDC75B9339
+1 FAMC @F0012@
+2 PEDI birth
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0041@ INDI
+1 NAME Janis Elaine /Green/
+2 GIVN Janis Elaine
+2 SURN Green
+1 SEX F
+1 BIRT
+2 TYPE Birth of Janis Elaine Green
+2 DATE 2 DEC 1935
+1 _UID 578BB6B355B14AAD99E7701E9349E06577CB
+1 FAMS @F0008@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0042@ INDI
+1 NAME 雪 /Ke 柯/
+2 GIVN 雪
+2 SURN Ke 柯
+1 NAME Frank /Neilsen/
+2 TYPE aka
+2 GIVN Frank
+2 SURN Neilsen
+1 SEX M
+1 ADOP Y
+2 FAMC @F0005@
+3 ADOP BOTH
+1 _UID F07C7725202AAE32EDB3C66074D9BD26284F
+1 FAMC @F0005@
+2 PEDI adopted
+1 OBJE @O0000@
+1 NOTE @N0007@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0043@ INDI
+1 NAME ピーター /リチミシキスイミ/
+2 GIVN ピーター
+2 SURN リチミシキスイミ
+1 SEX M
+1 _UID 592EA5FBC8DB0FAE99830138036425E64E67
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0044@ INDI
+1 NAME The /Tester/
+2 GIVN The
+2 SURN Tester
+2 NICK Testy
+1 SEX M
+1 BIRT
+2 DATE 29 DEC 1954
+2 PLAC 123 High St, Cleveland, Cuyahoga, Ohio, USA
+2 ADDR 123 High St
+3 ADR1 123 High St
+3 CITY Cleveland
+3 STAE Ohio
+3 POST 44140
+3 CTRY USA
+2 PHON 440-871-3400
+2 PHON 800-871-3400
+2 EMAIL thetester@@gmail.com
+2 FAX 440-123-4567
+2 WWW http://thetester.com
+1 EVEN A very bad day
+2 TYPE LossOfMojo
+2 DATE 7 JUL 1973
+1 EVEN
+2 TYPE GainOfMojo
+2 DATE 10 JUL 1973
+1 _UID CE3470D1FB23BFC83C28A3D78E173C953CF3
+1 BAPL
+2 DATE 2 JAN 1955
+2 STAT INFANT
+1 FAMC @F0008@
+2 PEDI birth
+1 FAMS @F0016@
+1 SOUR @S0005@
+1 RESI
+2 DATE 27 OCT 2017
+2 ADDR
+3 CONT test village
+3 CONT Akron
+3 CONT OH
+3 CONT 44177
+3 CONT Cuyahoga
+3 ADR2 test village
+3 CITY Akron
+3 STAE OH
+3 POST 44177
+3 CTRY Cuyahoga
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0045@ INDI
+1 NAME Mrs /Tester/
+2 TYPE married
+2 GIVN Mrs
+2 SURN Tester
+1 SEX F
+1 RESI
+2 DATE 30 DEC 1954
+2 PLAC 123 Main St., Winslow, PA, 12345
+2 PHON 440-871-3401
+2 EMAIL mrstester@@gmail.com
+2 FAX 440-321-4568
+2 WWW http://mrstester.com
+2 NOTE @N0011@
+1 _UID 702E9BCEF727170A8F8A9F394EDC660AD1DA
+1 FAMS @F0016@
+1 SOUR @S0005@
+1 RESI
+2 ADDR 123 Main St.
+3 CONT Winslow
+3 CONT PA
+3 CONT 12345
+3 ADR1 123 Main St.
+3 CITY Winslow
+3 STAE PA
+3 POST 12345
+1 PHON 440-871-3401
+1 PHON 800-871-3401
+1 EMAIL mrstester@@gmail.com
+1 FAX 440-321-4568
+1 WWW http://mrstester.com
+1 NOTE @N0010@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0046@ INDI
+1 NAME Tom /Von Tester y tested/
+2 GIVN Tom
+2 SPFX Von
+2 SURN Tester y, tested
+2 NICK TesterNickname
+1 SEX M
+1 RESI
+2 DATE FROM 1 JAN 1964 TO 3 MAR 1970
+2 PLAC Denver, Denver Co., CO, Denver Co., Colorado, USA
+3 MAP
+4 LATI N39.7392
+4 LONG W104.9903
+2 ADDR
+3 CITY Denver, Denver Co., CO
+3 STAE Colorado
+3 CTRY USA
+2 PHON 440-871-3402
+2 EMAIL tomtester@@gmail.com
+2 FAX 440-321-4569
+2 WWW http://tomtester.com
+1 RESI
+2 DATE I think 1970 to 1971
+2 PLAC San Francisco, San Francisco Co., CA
+1 _UID 1C6A0DD85C19F5A77F0EF6F7F4A847815A40
+1 SLGC
+2 DATE EST ABT 1999
+2 FAMC @F0016@
+2 TEMP DENVE
+2 PLAC Denver, Denver Co., CO, Denver Co., Colorado, USA
+3 MAP
+4 LATI N39.7392
+4 LONG W104.9903
+2 ADDR
+3 CITY Denver, Denver Co., CO
+3 STAE Colorado
+3 CTRY USA
+1 FAMC @F0016@
+2 PEDI birth
+1 SOUR @S0005@
+2 DATA
+3 TEXT A citation Note Source text
+1 OBJE
+2 FORM URL
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0047@ INDI
+1 NAME Fake /von Person/ I
+2 GIVN Fake
+2 SPFX von
+2 SURN Person
+2 NSFX I
+2 NPFX Fake person
+2 NICK Fake
+1 BIRT
+2 DATE 1954
+3 TIME 12:45 am
+2 PLAC Fremont, Alameda Co., CA
+2 AGNC A hosptial
+2 HUSB
+3 AGE 47
+2 WIFE
+3 AGE 16
+1 DEAT Y
+1 OCCU
+2 DATE 1972
+1 BURI
+2 TYPE Buried in a Cemetary
+2 DATE 1 JAN 2017
+1 RETI Y
+1 ADOP Y
+2 FAMC @F0016@
+3 ADOP HUSB
+1 IDNO ID99999
+1 RFN RFN8888
+1 RESN
+1 FACT 99
+2 TYPE Age
+1 FACT a hospital
+2 TYPE Agency
+1 DSCR A fake description
+1 _UID 23299F80894EE992DC8A93FDBB1F39BF854E
+1 BAPL
+2 DATE 7 JUN 1960
+2 TEMP DENVE
+2 PLAC Denver, Denver Co., CO, Denver Co., Colorado, USA
+3 MAP
+4 LATI N39.7392
+4 LONG W104.9903
+2 ADDR
+3 CITY Denver, Denver Co., CO
+3 STAE Colorado
+3 CTRY USA
+2 STAT QUALIFIED
+1 FAMC @F0016@
+2 _FREL Adopted
+2 _MREL Step
+1 RESI
+2 DATE 1954
+2 ADDR 8888 Cliff Dr
+3 CONT Bay Village
+3 CONT Ohio
+3 CONT 44140
+3 CONT Cuyahoga
+3 ADR1 8888 Cliff Dr
+3 CITY Bay Village
+3 STAE Ohio
+3 POST 44140
+3 CTRY Cuyahoga
+2 PHON 440-871-3400
+1 OBJE
+2 FORM URL
+2 TITL A test FTP URL
+2 FILE ftp://whoknows.org
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0048@ INDI
+1 NAME Mary /Tester/
+2 GIVN Mary
+2 SURN Tester
+1 SEX F
+1 ADOP Y
+2 FAMC @F0016@
+3 ADOP WIFE
+1 _UID 4A49C334C6C83E99CF8D1D9621A04DCCD89B
+1 FAMC @F0016@
+2 _FREL birth
+2 _MREL Adopted
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0049@ INDI
+1 NAME Martha /Tester/
+2 TYPE Unknown
+2 GIVN Martha
+2 SURN Tester
+1 SEX F
+1 _UID EA83952E5B4024411187CC10E15121DCD364
+1 FAMC @F0016@
+2 PEDI foster
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0050@ INDI
+1 NAME John /Tester/
+2 TYPE aka
+2 GIVN John
+2 SURN Tester
+1 SEX M
+1 _UID AB7B7768A39E5ECFB830F00FD1189820FBE7
+1 FAMC @F0016@
+2 PEDI stepchild
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @I0051@ INDI
+1 NAME Mark /Tester/
+2 GIVN Mark
+2 SURN Tester
+1 SEX M
+1 _UID 38FE76D4B6F53209E044F96A8EAE99B779DD
+1 FAMC @F0016@
+2 PEDI Sponsored
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @F0000@ FAM
+1 HUSB @I0039@
+1 WIFE @I0036@
+1 MARR
+2 TYPE Marriage of Martin Smith and Elna Jefferson
+2 DATE ABT 1816
+2 PLAC Gladsax, Kristianstad Län, Sweden
+1 _UID 79C298FCE77B4069F3039D9C54A8FD626463
+1 CHIL @I0011@
+1 CHIL @I0007@
+1 CHIL @I0004@
+1 CHIL @I0022@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @F0001@ FAM
+1 HUSB @I0027@
+1 WIFE @I0025@
+1 MARR
+2 TYPE Marriage of Ingeman Smith and Marta Ericsdotter
+2 DATE ABT 1790
+2 PLAC Sweden
+1 _UID 67590A0C8409C0265BF40D9E997845A13A17
+1 CHIL @I0039@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @F0002@ FAM
+1 HUSB @I0022@
+1 WIFE @I0038@
+1 MARR
+2 TYPE Marriage of Martin Smith and Kerstina Hansdotter
+2 DATE ABT 1856
+1 _UID 9E3BBF582597857D37589BE194D83D9F0127
+1 CHIL @I0003@
+1 CHIL @I0009@
+1 CHIL @I0024@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @F0003@ FAM
+1 HUSB @I0024@
+1 WIFE @I0000@
+1 MARR
+2 TYPE Marriage of Gustaf Smith, Sr. and Anna Hansdotter
+2 DATE 27 NOV 1885
+2 PLAC Rønne, Bornholm, Denmark
+1 _UID AFA16AE934A0A1CC92996CCF71A86A30FDD8
+1 CHIL @I0026@
+1 CHIL @I0023@
+1 CHIL @I0021@
+1 CHIL @I0008@
+1 CHIL @I0015@
+1 CHIL @I0020@
+1 CHIL @I0010@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @F0004@ FAM
+1 HUSB @I0006@
+1 WIFE @I0026@
+1 MARR
+2 TYPE Marriage of Edwin Willard and Kirsti Marie Smith
+2 DATE ABT 1910
+1 _UID 45A138C814F8CF71C499B1C18CB299744CC4
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @F0005@ FAM
+1 HUSB @I0012@
+1 WIFE @I0023@
+1 MARR
+2 TYPE Marriage of Herman Julius Nielsen and Astrid Shermanna Augusta Smith
+2 DATE 30 NOV 1912
+2 PLAC Rønne, Bornholm, Denmark
+1 _UID 389A2DEFF250757C8A9DACE6C96C4A379029
+1 CHIL @I0042@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @F0006@ FAM
+1 HUSB @I0008@
+1 WIFE @I0031@
+1 MARR
+2 TYPE Marriage of Hjalmar Smith and Marjorie Ohman
+2 DATE 31 OCT 1927
+2 PLAC Reno, Washoe Co., NV
+1 _UID 94B90A1DE139E690F6E641ECF09F8DEF18E9
+1 CHIL @I0018@
+1 CHIL @I0014@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @F0007@ FAM
+1 HUSB @I0015@
+1 WIFE @I0013@
+1 MARR
+2 TYPE Marriage of Gus Smith and Evelyn Michaels
+2 DATE ABT 1920
+1 _UID 2376676A35E465191EFC18C675265C7262EB
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @F0008@ FAM
+1 HUSB @I0033@
+1 WIFE @I0041@
+1 MARR
+2 TYPE Marriage of Lloyd Smith and Janis Elaine Green
+2 DATE 10 AUG 1958
+2 PLAC San Francisco, San Francisco Co., CA
+1 _UID C818B9AF8EE0B6070B8655F63B90F8B8CA9E
+1 CHIL @I0019@
+1 CHIL @I0001@
+1 CHIL @I0029@
+1 CHIL @I0044@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @F0009@ FAM
+1 HUSB @I0010@
+1 WIFE @I0017@
+1 _UID 1B1A1B14AA1C0112D7488507DA830E59ACE3
+1 CHIL @I0033@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @F0010@ FAM
+1 HUSB @I0019@
+1 WIFE @I0032@
+1 MARR
+2 TYPE Marriage of Eric Lloyd Smith and Darcy Horne
+2 DATE 12 JUL 1986
+2 PLAC Woodland, Yolo Co., CA
+1 _UID 03446DF95E6CAAD18729B8E4860C3E3543D8
+1 CHIL @I0035@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @F0011@ FAM
+1 HUSB @I0003@
+1 WIFE @I0028@
+1 MARR
+2 TYPE Marriage of Magnes Smith and Anna Streiffert
+2 DATE 24 AUG 1884
+2 PLAC Rønne, Bornholm, Denmark
+1 _UID 03D9D6018F55D79AD1EEF2DB35B0DE2F869F
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @F0012@ FAM
+1 HUSB @I0018@
+1 WIFE @I0034@
+1 MARR
+2 TYPE Marriage of John Hjalmar Smith and Alice Paula Perkins
+2 DATE 4 JUN 1954
+2 PLAC Sparks, Washoe Co., NV
+2 SOUR @S0000@
+1 _UID A0A8C51CCE438CF5C70352216ECE6DF79879
+1 CHIL @I0040@
+1 CHIL @I0037@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @F0013@ FAM
+1 HUSB @I0037@
+1 WIFE @I0030@
+1 MARR
+2 TYPE Marriage of Edwin Michael Smith and Janice Ann Adams
+2 DATE 27 MAY 1995
+2 PLAC San Ramon, Conta Costa Co., CA
+1 ENGA
+2 TYPE Engagement of Edwin Michael Smith and Janice Ann Adams
+2 DATE 5 OCT 1994
+2 PLAC San Francisco, San Francisco Co., CA
+1 _UID 80C0BB5C11EEE94A385FCBA2BD1632FE90BD
+1 CHIL @I0005@
+1 CHIL @I0002@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @F0014@ FAM
+1 HUSB @I0010@
+1 WIFE @I0016@
+1 _UID 9D8BB294EE070A28A60CCEE5ACFA17F2A905
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @F0016@ FAM
+1 HUSB @I0044@
+1 WIFE @I0045@
+1 SLGS
+2 DATE 22 FEB 2000
+2 TEMP DENVE
+2 PLAC Community Presbyterian Church, Danville, CA
+2 ADDR
+3 ADR2 Community Presbyterian Church, Danville, CA
+2 STAT CLEARED
+1 MARR
+2 HUSB
+3 AGE 45
+2 WIFE
+3 AGE 15
+1 ENGA
+2 TYPE They were engaged
+1 EVEN Married by a clown in the buff
+2 TYPE Alternate Marriage
+1 EVEN
+2 TYPE Alternate Marriage
+1 NCHI 4
+1 RFN RFN3333
+1 FACT 7532951
+2 TYPE License Number
+1 FACT
+2 TYPE Unknown
+1 _UID DA85ECCD3EAD2A3EAF663EC16AE0824A95F6
+1 CHIL @I0046@
+1 CHIL @I0047@
+1 CHIL @I0048@
+1 CHIL @I0049@
+1 CHIL @I0050@
+1 CHIL @I0051@
+1 CHAN
+2 DATE 1 JAN 1970
+3 TIME 00:00:00
+0 @S0000@ SOUR
+1 TITL Marriage Certificae
+1 REPO @R0002@
+2 CALN what-321-ever
+3 MEDI Photo
+1 NOTE @N0004@
+1 CHAN
+2 DATE 21 DEC 2007
+3 TIME 07:35:26
+0 @S0001@ SOUR
+1 TITL Birth Certificate
+1 CHAN
+2 DATE 21 DEC 2007
+3 TIME 07:35:26
+0 @S0002@ SOUR
+1 TITL Birth Records
+1 CHAN
+2 DATE 21 DEC 2007
+3 TIME 07:35:26
+0 @S0003@ SOUR
+1 TITL Birth, Death and Marriage Records
+1 REPO @R0002@
+2 CALN CA-123-LL-456_Num/ber
+3 MEDI Film
+1 NOTE @N0005@
+1 CHAN
+2 DATE 21 DEC 2007
+3 TIME 07:35:26
+0 @S0004@ SOUR
+1 TITL findagrave.com
+1 CHAN
+2 DATE 4 JUN 2016
+3 TIME 21:28:36
+0 @S0005@ SOUR
+1 TITL Import from imp_FTM_LINK.ged
+1 REPO @R0000@
+1 REPO @R0001@
+1 CHAN
+2 DATE 29 AUG 2016
+3 TIME 19:51:48
+0 @S0006@ SOUR
+1 TITL Ohio Births, 1958-2002
+1 REPO @R0004@
+1 CHAN
+2 DATE 29 AUG 2016
+3 TIME 19:51:48
+0 @S0007@ SOUR
+1 AUTH The tester
+1 PUBL Published when the test was written
+1 ABBR TST
+1 REPO @R0006@
+1 CHAN
+2 DATE 29 OCT 2016
+3 TIME 16:20:39
+0 @R0000@ REPO
+1 NAME Business that produced the product: Ancestry.com
+1 ADDR 360 W 4800 N, Provo, UT 84604
+2 ADR1 360 W 4800 N, Provo, UT 84604
+1 PHON (801) 705-7000
+1 FAX (801) 705-7001
+1 EMAIL help@@ancestry.com
+1 WWW http://www.ancestry.com
+0 @R0001@ REPO
+1 NAME SUBM (Submitter): (@@SUBM@@) The Subm /Tester/
+1 ADDR 123 Main St.
+2 CONT Winslow
+2 CONT PA
+2 CONT 12345
+2 ADR1 123 Main St.
+2 CITY Winslow
+2 STAE PA
+2 POST 12345
+1 PHON 440-871-3401
+1 EMAIL mrstester@@gmail.com
+1 FAX 440-321-4568
+1 WWW http://mrstester.com
+1 NOTE @N0009@
+0 @R0002@ REPO
+1 NAME New York Public Library
+1 ADDR 5th Ave at 42 street
+2 CONT New York
+2 CONT New York
+2 CONT 11111
+2 CONT USA
+2 ADR1 5th Ave at 42 street
+2 CITY New York
+2 STAE New York
+2 POST 11111
+2 CTRY USA
+0 @R0003@ REPO
+1 NAME Aunt Martha's Attic
+1 ADDR 123 Main St
+2 CONT Someville
+2 CONT ST
+2 CONT USA
+2 ADR1 123 Main St
+2 CITY Someville
+2 STAE ST
+2 CTRY USA
+1 WWW http://library.gramps-project.org
+1 NOTE @N0006@
+0 @R0004@ REPO
+1 NAME Testers Repository
+1 ADDR 123 High St., OSF village, CA, USA
+2 ADR1 123 High St., OSF village, CA, USA
+1 PHON 988-765-4321
+1 EMAIL tester_repo@@osf.com
+1 FAX 987-654-3210
+1 WWW http://www.tester_repo.com
+1 NOTE @N0012@
+1 NOTE @N0013@
+0 @R0005@ REPO
+0 @R0006@ REPO
+0 @N0000@ NOTE Witness name: John Doe
+1 CONT Witness comment: This is a simple test.
+0 @N0001@ NOTE Witness name: No Name
+0 @N0002@ NOTE BIOGRAPHY
+1 CONT Martin was listed as being a Husman, (owning a house as opposed to a far
+1 CONC m) in the house records of Gladsax.
+0 @N0003@ NOTE BIOGRAPHY
+1 CONT 
+1 CONT Hjalmar sailed from Copenhagen, Denmark on the OSCAR II, 14 November 191
+1 CONC 2 arriving in New York 27 November 1912. He was seventeen years old. O
+1 CONC n the ship passenger list his trade was listed as a Blacksmith.  He cam
+1 CONC e to Reno, Nevada and lived with his sister Marie for a time before sett
+1 CONC ling in Sparks. He worked for Southern Pacific Railroad as a car inspect
+1 CONC or for a time, then went to work for Standard Oil
+1 CONT Company. He enlisted in the army at Sparks 7 December 1917 and served a
+1 CONC s a Corporal in the Medical Corp until his discharge 12 August 1919 at t
+1 CONC he Presidio in San Francisco, California. Both he and Marjorie are burie
+1 CONC d in the Masonic Memorial Gardens Mausoleum in Reno, he the 30th June 19
+1 CONC 75, and she the 25th of June 1980.
+0 @N0004@ NOTE But Aunt Martha still keeps the original!
+0 @N0005@ NOTE The repository reference from the source is important
+0 @N0006@ NOTE Some note on the repo
+0 @N0007@ NOTE Some Unicode Characters: ࣶǼЀج⿄㑝㵋圛墉幵聟聦𐅉🚶🛈
+1 CONT Some Bold Unicode Characters: ࣶǼЀج⿄㑝㵋圛墉幵聟聦𐅉🚶🛈
+1 CONT Some Italic Unicode Characters: ࣶǼЀج⿄㑝㵋圛墉幵聟聦𐅉🚶🛈
+1 CONT Some Unicode Characters: ࣶǼЀج⿄㑝㵋圛墉幵聟聦𐅉🚶🛈
+1 CONT Some Bold Unicode Characters: ࣶǼЀج⿄㑝㵋圛墉幵聟聦𐅉🚶🛈
+1 CONT Some Italic Unicode Characters: ࣶǼЀج⿄㑝㵋圛墉幵聟聦𐅉🚶🛈
+0 @N0008@ NOTE Records not imported into HEAD (header):
+1 CONT 
+1 CONT Only one phone number supported                                     Lin
+1 CONC e     9: 3 PHON (800) 705-7000
+0 @N0009@ NOTE Records not imported into SUBM (Submitter): (@@SUBM@@) The Subm /Te
+1 CONC ster/:
+1 CONT 
+1 CONT Only one phone number supported                                     Lin
+1 CONC e    29: 1 PHON 800-871-3401
+0 @N0010@ NOTE Address with PHON,FAX,EMAIL,WWW. attached directly to person is no
+1 CONC t legal Gedcom, but allowed here.
+0 @N0011@ NOTE Address as event is legal, with PHON,FAX,EMAIL,WWW
+0 @N0012@ NOTE The repository record
+0 @N0013@ NOTE Records not imported into REPO (repository) Gramps ID R0002:
+1 CONT 
+1 CONT Only one phone number supported                                     Lin
+1 CONC e    87: 1 PHON 800-765-4321
+0 @N0014@ NOTE ******************************************************************8
+1 CONC 90123456789
+1 CONT ******************************************************************89 123
+1 CONC 456789
+0 @N0015@ NOTE This should show up under the ASSO tag in Gedcom
+0 @N0016@ NOTE ??? What is RESN???
+0 @N0017@ NOTE A citation Note Source text
+0 @N0018@ NOTE Another Citation Note
+0 @N0019@ NOTE A bad photo for sure
+0 @O0000@ OBJE
+1 FILE d:\users\prc\documents\gramps\data\tests\O0.jpg
+2 FORM jpg
+2 TITL Michael O'Toole 2015-11
+1 NOTE @N0019@
+1 CHAN
+2 DATE 29 OCT 2016
+3 TIME 15:23:37
+0 TRLR

--- a/gramps/gen/config.py
+++ b/gramps/gen/config.py
@@ -174,7 +174,8 @@ register('export.proxy-order',
           ["person", 0],
           ["note", 0],
           ["reference", 0]]
-        )
+         )
+register('export.include-uid', True)
 
 register('geography.center-lon', 0.0)
 register('geography.lock', False)

--- a/gramps/plugins/export/export.gpr.py
+++ b/gramps/plugins/export/export.gpr.py
@@ -83,7 +83,7 @@ plg.status = STABLE
 plg.fname = 'exportgedcom.py'
 plg.ptype = EXPORT
 plg.export_function = 'export_data'
-plg.export_options = 'WriterOptionBox'
+plg.export_options = 'GedcomWriterOptionBox'
 plg.export_options_title = _('GEDCOM export options')
 plg.extension = "ged"
 

--- a/gramps/plugins/test/exports_test.py
+++ b/gramps/plugins/test/exports_test.py
@@ -42,6 +42,13 @@ def mock_localtime(*args):
     return strptime("25 Dec 1999", "%d %b %Y")
 
 
+def mock_time(*args):
+    """
+    Mock up a dummy to replace the varying 'time string results'
+    """
+    return 0.0
+
+
 def call(*args):
     """ Call Gramps to perform the action with out and err captured """
     #print("call:", args)
@@ -226,12 +233,14 @@ class ExportControl(unittest.TestCase):
         if msg:
             self.fail(tst_file + ': ' + msg)
 
+    @patch('gramps.plugins.export.exportgedcom.time.time', mock_time)
     def test_ged(self):
         """ Run a Gedcom export test """
         config.set('preferences.place-auto', True)
         config.set('database.backend', 'bsddb')
+        config.set('export.include-uid', True)
         src_file = 'exp_sample.gramps'
-        tst_file = 'exp_sample_ged.ged'
+        tst_file = 'exp_sample_ged_uid.ged'
         msg = do_it(src_file, tst_file, gedfilt)
         if msg:
             self.fail(tst_file + ': ' + msg)
@@ -240,6 +249,7 @@ class ExportControl(unittest.TestCase):
         """ Run a Gedcom export test """
         config.set('preferences.place-auto', True)
         config.set('database.backend', 'sqlite')
+        config.set('export.include-uid', False)
         src_file = 'exp_sample.gramps'
         tst_file = 'exp_sample_ged.ged'
         msg = do_it(src_file, tst_file, gedfilt)


### PR DESCRIPTION
Many programs read and understand the _UID tag on INDI and FAM GEDCOM files.  This tag allows the program to positively identify a person or family when merging.  Gramps has been able to import these tags and add them as attributes.  A recent PR https://github.com/gramps-project/gramps/pull/1000 takes advantage of this in our own Find Possible duplicate people tool.

This extends our own export to attach these tags, when the user selects the option on GEDCOM export.
The _UID records are added to the GEDCOM file, and the matching _UID attribute is added to any Persons or Families that do not already have the attribute in the db so that future GEDCOM imports of derived trees can use the Find Possible duplicate people tool to assist merging.

The addition can be Undone after the GEDCOM export if desired.