### PR TITLE
Speed up Place Reference Editor and Listview for enclose place

### DIFF
--- a/gramps/gui/editors/editeventref.py
+++ b/gramps/gui/editors/editeventref.py
@@ -66,6 +66,7 @@ class EditEventRef(EditReference):
     def __init__(self, state, uistate, track, event, event_ref, update):
         EditReference.__init__(self, state, uistate, track, event, event_ref,
                                update)
+        self.original = event.serialize()
         self._init_event()
 
     def _local_init(self):
@@ -268,8 +269,10 @@ class EditEventRef(EditReference):
     def ok_clicked(self, obj):
 
         if self.source.handle:
-            with DbTxn(_("Modify Event"), self.db) as trans:
-                self.commit_event(self.source,trans)
+            # only commit if it has changed
+            if self.source.serialize() != self.original:
+                with DbTxn(_("Modify Event"), self.db) as trans:
+                    self.commit_event(self.source, trans)
         else:
             if self.check_for_duplicate_id('Event'):
                 return

--- a/gramps/gui/editors/editmediaref.py
+++ b/gramps/gui/editors/editmediaref.py
@@ -83,7 +83,9 @@ class EditMediaRef(EditReference):
         if not self.source.get_handle():
             #show the addmedia dialog immediately, with track of parent.
             AddMedia(state, self.uistate, self.track, self.source,
-                           self._update_addmedia)
+                     self._update_addmedia)
+        else:
+            self.original = self.source.serialize()
 
     def _local_init(self):
 
@@ -518,9 +520,11 @@ class EditMediaRef(EditReference):
 
         #first save primary object
         if self.source.handle:
-            with DbTxn(_("Edit Media Object (%s)") %
-                       self.source.get_description(), self.db) as trans:
-                self.db.commit_media(self.source, trans)
+            # only commit if it has changed
+            if self.source.serialize() != self.original:
+                with DbTxn(_("Edit Media Object (%s)") %
+                           self.source.get_description(), self.db) as trans:
+                    self.db.commit_media(self.source, trans)
         else:
             if self.check_for_duplicate_id('Media'):
                 return

--- a/gramps/gui/editors/editplaceref.py
+++ b/gramps/gui/editors/editplaceref.py
@@ -51,6 +51,7 @@ class EditPlaceRef(EditReference):
     def __init__(self, state, uistate, track, place, place_ref, update):
         EditReference.__init__(self, state, uistate, track, place, place_ref,
                                update)
+        self.original = place.serialize()
 
     def _local_init(self):
 
@@ -312,8 +313,10 @@ class EditPlaceRef(EditReference):
             return
 
         if self.source.handle:
-            with DbTxn(_("Modify Place"), self.db) as trans:
-                self.db.commit_place(self.source, trans)
+            # only commit if it has changed
+            if self.source.serialize() != self.original:
+                with DbTxn(_("Modify Place"), self.db) as trans:
+                    self.db.commit_place(self.source, trans)
         else:
             if self.check_for_duplicate_id('Place'):
                 return

--- a/gramps/gui/editors/editreporef.py
+++ b/gramps/gui/editors/editreporef.py
@@ -51,6 +51,7 @@ class EditRepoRef(EditReference):
 
         EditReference.__init__(self, state, uistate, track, source,
                                source_ref, update)
+        self.original = source.serialize()
 
     def _local_init(self):
 
@@ -189,8 +190,10 @@ class EditRepoRef(EditReference):
     def ok_clicked(self, obj):
 
         if self.source.handle:
-            with DbTxn(_("Modify Repository"), self.db) as trans:
-                self.db.commit_repository(self.source,trans)
+            # only commit if it has changed
+            if self.source.serialize() != self.original:
+                with DbTxn(_("Modify Repository"), self.db) as trans:
+                    self.db.commit_repository(self.source, trans)
         else:
             if self.check_for_duplicate_id('Repository'):
                 return

--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -846,6 +846,9 @@ class ListView(NavigationView):
             for cl_name, handle in self.dbstate.db.find_backlink_handles(hndl):
                 if cl_name == nav_type:
                     upd_list.append(handle)
+                    if len(upd_list) > 20:
+                        self.dirty = True
+                        return
                 if (cl_name == 'Place' or cl_name == 'Event' and
                         nav_type == 'Person'):
                     queue.append(handle)


### PR DESCRIPTION
Fixes [#11531](https://gramps-project.org/bugs/view.php?id=11531)

Bug submitter noted that enclosing a place was taking a very long time (minutes in some cases), if the place being added in the PlaceRef (enclosing place) already had a lot of references/subordinate places.

There were two issues that added to the time:

I note that the adding a PlaceRef to a place with the editor should really only trigger a modify-place signal when the actual place is modified, which would normally be seldom when adding an already present place as the enclosing place. If we fix this, the specific case would finish almost instantly.

If the actual enclosing place does get edited sending the modify-place signal (or as the code is now always sending it), we end up looking at all the references attached to the newly enclosing places, and sending view row updates to the other views (Events, Families, People). If there are a lot of these (in bug submitters case 1/2 of a very large tree) this can take a LONG time to execute. If we were to just mark the view dirty, we would skip this step. Of course then the view would have to be redrawn when the user next looked at it. But that is a LOT faster than thousands of row_updates.

I decided to fix both problems in this PR.  Only commit the enclosing place if it actually changed in the PlaceRefEditor, and to mark non-active views dirty if more than a few (20) handles to update.  So for smaller updates, the non-active view still gets row updates (as it does now), but when lots of changes are forthcoming, we mark dirty, and the (Person, Family, Event) view has to be rebuilt when next made active.