### PR TITLE
Narweb: image size limit doesn't match tooltip

### DIFF
--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -1891,7 +1891,7 @@ class NavWebOptions(MenuReportOptions):
             _("Max width of initial image"), _DEFAULT_MAX_IMG_WIDTH, 0, 2000)
         self.__maxinitialimagewidth.set_help(
             _("This allows you to set the maximum width "
-              "of the image shown on the media page. Set to 0 for no limit."))
+              "of the image shown on the media page."))
         addopt("maxinitialimagewidth", self.__maxinitialimagewidth)
 
         self.__maxinitialimageheight = NumberOption(


### PR DESCRIPTION
Fixes #011536

Note: I only modified the width tooltip limit.
To avoid merge problem, I didn't modify the height tooltip limit which will disapear in 5.2 as this limit is unused.