### PR TITLE
Speed up Event displaytab and gramplet

### DIFF
--- a/gramps/gui/editors/displaytabs/eventrefmodel.py
+++ b/gramps/gui/editors/displaytabs/eventrefmodel.py
@@ -51,6 +51,7 @@ from gramps.gen.datehandler import get_date, get_date_valid
 from gramps.gen.config import config
 from gramps.gen.utils.db import get_participant_from_event
 from gramps.gen.display.place import displayer as place_displayer
+from gramps.gen.proxy.cache import CacheProxyDb
 
 #-------------------------------------------------------------------------
 #
@@ -101,7 +102,7 @@ class EventRefModel(Gtk.TreeStore):
         self.start_date = kwargs.get("start_date", None)
         typeobjs = (x[1] for x in self.COLS)
         Gtk.TreeStore.__init__(self, *typeobjs)
-        self.db = db
+        self.db = CacheProxyDb(db)
         self.groups = groups
         for index, group in enumerate(event_list):
             parentiter = self.append(None, row=self.row_group(index, group))

--- a/gramps/plugins/gramplet/events.py
+++ b/gramps/plugins/gramplet/events.py
@@ -41,6 +41,7 @@ from gramps.gen.utils.db import (get_participant_from_event,
                                  get_marriage_or_fallback)
 from gramps.gen.errors import WindowActiveError
 from gramps.gen.config import config
+from gramps.gen.proxy.cache import CacheProxyDb
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 
@@ -51,6 +52,7 @@ class Events(Gramplet, DbGUIElement):
     def __init__(self, gui, nav_group=0):
         Gramplet.__init__(self, gui, nav_group)
         DbGUIElement.__init__(self, self.dbstate.db)
+        self.db = None
 
     """
     Displays the events for a person or family.
@@ -99,14 +101,14 @@ class Events(Gramplet, DbGUIElement):
         Add an event to the model.
         """
         self.callman.register_handles({'event': [event_ref.ref]})
-        event = self.dbstate.db.get_event_from_handle(event_ref.ref)
+        event = self.db.get_event_from_handle(event_ref.ref)
         event_date = get_date(event)
         event_sort = '%012d' % event.get_date_object().get_sort_value()
         person_age = self.column_age(event)
         person_age_sort = self.column_sort_age(event)
-        place = place_displayer.display_event(self.dbstate.db, event)
+        place = place_displayer.display_event(self.db, event)
 
-        participants = get_participant_from_event(self.dbstate.db,
+        participants = get_participant_from_event(self.db,
                                                   event_ref.ref)
 
         self.model.add((event.get_handle(),
@@ -191,24 +193,26 @@ class PersonEvents(Events):
     def main(self): # return false finishes
         active_handle = self.get_active('Person')
 
+        self.db = CacheProxyDb(self.dbstate.db)
         self.model.clear()
         self.callman.unregister_all()
         if active_handle:
             self.display_person(active_handle)
         else:
             self.set_has_data(False)
+        self.db = None
 
     def display_person(self, active_handle):
         """
         Display the events for the active person.
         """
-        active_person = self.dbstate.db.get_person_from_handle(active_handle)
+        active_person = self.db.get_person_from_handle(active_handle)
         if active_person:
             self.cached_start_date = self.get_start_date()
             for event_ref in active_person.get_event_ref_list():
                 self.add_event_ref(event_ref)
             for family_handle in active_person.get_family_handle_list():
-                family = self.dbstate.db.get_family_from_handle(family_handle)
+                family = self.db.get_family_from_handle(family_handle)
                 self.display_family(family, active_person)
         else:
             self.cached_start_date = None
@@ -220,7 +224,7 @@ class PersonEvents(Events):
         """
         spouse_handle = find_spouse(active_person, family)
         if spouse_handle:
-            spouse = self.dbstate.db.get_person_from_handle(spouse_handle)
+            spouse = self.db.get_person_from_handle(spouse_handle)
         else:
             spouse = None
         if family:
@@ -233,8 +237,8 @@ class PersonEvents(Events):
         something close to birth.
         """
         active_handle = self.get_active('Person')
-        active = self.dbstate.db.get_person_from_handle(active_handle)
-        event = get_birth_or_fallback(self.dbstate.db, active)
+        active = self.db.get_person_from_handle(active_handle)
+        event = get_birth_or_fallback(self.db, active)
         return event.get_date_object() if event else None
 
 class FamilyEvents(Events):
@@ -264,18 +268,20 @@ class FamilyEvents(Events):
     def main(self): # return false finishes
         active_handle = self.get_active('Family')
 
+        self.db = CacheProxyDb(self.dbstate.db)
         self.model.clear()
         self.callman.unregister_all()
         if active_handle:
             self.display_family(active_handle)
         else:
             self.set_has_data(False)
+        self.db = None
 
     def display_family(self, active_handle):
         """
         Display the events for the active family.
         """
-        active_family = self.dbstate.db.get_family_from_handle(active_handle)
+        active_family = self.db.get_family_from_handle(active_handle)
         self.cached_start_date = self.get_start_date()
         for event_ref in active_family.get_event_ref_list():
             self.add_event_ref(event_ref)
@@ -287,7 +293,7 @@ class FamilyEvents(Events):
         something close to marriage.
         """
         active_handle = self.get_active('Family')
-        active = self.dbstate.db.get_family_from_handle(active_handle)
-        event = get_marriage_or_fallback(self.dbstate.db, active)
+        active = self.db.get_family_from_handle(active_handle)
+        event = get_marriage_or_fallback(self.db, active)
         return event.get_date_object() if event else None
 


### PR DESCRIPTION
Based on a comment by Jerome in #1003, about a db that had a lot of events attached to a single person being slow, I developed this fix.  A test Gedcom file from https://gramps-project.org/bugs/view.php?id=8466 was used for testing.

The problem was in the EventRefModel used in the Event Display Tab on persons and families.  A very similar problem was in the Events Gramplet used on the person and Family views.  If you happened to have both active at the time you updated an eventref or an event from the eventref, the slowdown was quite noticeable (about 10 sec for me).

In each case we were having a significant chunk of code being executed 2*event_refs**2, so things slowed down a lot when a lot of event refs were present.  I could not think of a way to completely eliminate this n**2 slowdown, but I found a way to reduce the largest part back to just scale by n.

The method was to add a cache on the db, only used during the building of the view.  The cache is discarded after the view is built, so keeping it coherent is not an issue.

In my debugger, with the changes present, it still takes about 2 sec to get everything updated, but that is a bit better than 10 sec.