### PR TITLE
Upgade from BSDDB to SQLITE

### DIFF
--- a/gramps/gen/db/exceptions.py
+++ b/gramps/gen/db/exceptions.py
@@ -360,6 +360,35 @@ class DbConnectionError(Exception):
                     'message': self.msg,
                     'settings_file': self.settings_file}
 
+
+class DbSupportedError(Exception):
+    """
+    Error used to report that a database is no longer supported.
+    """
+    def __init__(self, msg):
+        Exception.__init__(self)
+        self.msg = msg
+
+    def __str__(self):
+        return _('The Family Tree you are trying to load is in the %(dbtype)s '
+                 'database, which is no longer supported.\nTherefore you '
+                 'cannot load this Family Tree without upgrading.\n\n'
+                 'If you upgrade then you won\'t be able to use the previous '
+                 'version of Gramps, even if you subsequently '
+                 '%(wiki_manual_backup_html_start)sbackup%(html_end)s or '
+                 '%(wiki_manual_export_html_start)sexport%(html_end)s '
+                 'your upgraded Family Tree.\n\n'
+                 'You are strongly advised to backup your Family Tree.\n\n'
+                 'If you have not already made a backup of your Family Tree, '
+                 'then you should start your previous version of Gramps and '
+                 '%(wiki_backup_html_start)smake a backup%(html_end)s '
+                 'of your Family Tree.') % {
+                     'dbtype' : self.msg,
+                     'wiki_manual_backup_html_start' : URL_BACKUP2_START ,
+                     'wiki_manual_export_html_start' : URL_EXPORT_START ,
+                     'wiki_backup_html_start' : URL_BACKUP1_START ,
+                     'html_end'    : '</a>'}
+
 if __name__ == "__main__":
     """
     Call this from the CLI (in order to find the imported modules):

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -47,6 +47,7 @@ from . import (DbReadBase, DbWriteBase, DbUndo, DBLOGNAME, DBUNDOFN,
                REPOSITORY_KEY, NOTE_KEY, TAG_KEY, TXNADD, TXNUPD, TXNDEL,
                KEY_TO_NAME_MAP, DBMODE_R, DBMODE_W)
 from .utils import write_lock_file, clear_lock_file
+from .exceptions import DbVersionError, DbUpgradeRequiredError
 from ..errors import HandleError
 from ..utils.callback import Callback
 from ..updatecallback import UpdateCallback
@@ -311,7 +312,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
 
     __callback_map = {}
 
-    VERSION = (18, 0, 0)
+    VERSION = (20, 0, 0)
 
     def __init__(self, directory=None):
         DbReadBase.__init__(self)
@@ -658,6 +659,21 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         self.nmap_index = self._get_metadata('nmap_index', 0)
 
         self.db_is_open = True
+
+        # Check on db version to see if we need upgrade or too new
+        dbversion = int(self._get_metadata('version', default='0'))
+        if dbversion > self.VERSION[0]:
+            self.close()
+            raise DbVersionError(dbversion, 18, self.VERSION[0])
+
+        if not self.readonly and dbversion < self.VERSION[0]:
+            LOG.debug("Schema upgrade required from %s to %s",
+                      dbversion, self.VERSION[0])
+            if force_schema_upgrade:
+                self._gramps_upgrade(dbversion, directory, callback)
+            else:
+                self.close()
+                raise DbUpgradeRequiredError(dbversion, self.VERSION[0])
 
     def _close(self):
         """
@@ -2229,6 +2245,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         """
         return list(self.place_types)
 
+
     ################################################################
     #
     # get_*_bookmarks methods
@@ -2463,3 +2480,35 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             enclosed_by = placeref.ref
             break
         return enclosed_by
+
+    def _gramps_upgrade(self, version, directory, callback=None):
+        """
+        Here we do the calls for stepwise schema upgrades.
+        We assume that we need to rebuild secondary and reference maps.
+        """
+        UpdateCallback.__init__(self, callback)
+
+        start = time.time()
+
+        from .upgrade import make_zip_backup, gramps_upgrade_20
+
+        LOG.debug("Make backup prior to schema upgrade")
+        make_zip_backup(self, directory)
+
+        if version < 20:
+            gramps_upgrade_20(self)
+
+        self.rebuild_secondary()
+        self.reindex_reference_map(self.update)
+        self.reset()
+
+        self.set_schema_version(self.VERSION[0])
+        LOG.debug("Upgrade time: %d seconds" % int(time.time() - start))
+
+    def get_schema_version(self):
+        """ Return current schema version as an int"""
+        return int(self._get_metadata('version', default='0'))
+
+    def set_schema_version(self, value):
+        """ set the current schema version """
+        self._set_metadata('version', str(value))

--- a/gramps/gen/db/upgrade.py
+++ b/gramps/gen/db/upgrade.py
@@ -1,0 +1,192 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2019-2016 Gramps Development Team
+# Copyright (C) 2019      Paul Culley
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+""" Generic upgrade module for dbapi dbs """
+#------------------------------------------------------------------------
+#
+# Python Modules
+#
+#------------------------------------------------------------------------
+import os
+import time
+import logging
+#------------------------------------------------------------------------
+#
+# Gramps Modules
+#
+#------------------------------------------------------------------------
+from gramps.cli.clidbman import NAME_FILE, find_next_db_dir
+from gramps.gui.dialog import GrampsLoginDialog
+from gramps.gen.config import config
+from . import DbTxn
+from .dbconst import (PERSON_KEY, FAMILY_KEY, EVENT_KEY, MEDIA_KEY, PLACE_KEY,
+                      REPOSITORY_KEY, SOURCE_KEY, KEY_TO_NAME_MAP, DBBACKEND)
+from .exceptions import DbConnectionError
+from .utils import make_database
+from ..const import GRAMPS_LOCALE as glocale
+_ = glocale.translation.gettext
+
+LOG = logging.getLogger(".upgrade")
+
+
+def convert_db(old_db, dirname, uistate):
+    """
+    Convert a db from its current type to a new format determined by the
+    config setting.  This is done by creating a new db in its own directory,
+    copying all data objects as serialized data, copying metadata.
+    Then both dbs are closed, the original db files are erased, and the new
+    db files are moved to the original db directory.
+
+    If the new db needs a password, the dialog is started to get it.
+
+    Returns the dbid of the new db, as well as username, password if any.
+    """
+    # make a directory for new upgraded db
+    old_db_name = os.path.join(dirname, NAME_FILE)
+    new_path = find_next_db_dir()
+    os.mkdir(new_path)
+    # store dbid in new dir
+    dbid = config.get('database.backend')
+    backend_path = os.path.join(new_path, DBBACKEND)
+    with open(backend_path, "w", encoding='utf8') as backend_file:
+        backend_file.write(dbid)
+    # make and load the new db
+    new_db = make_database(dbid)
+    username = password = None
+    if new_db.requires_login():
+        login = GrampsLoginDialog(uistate)
+        credentials = login.run()
+        if credentials is None:
+            raise DbConnectionError(_("No credentials."))
+        username, password = credentials
+    new_db.load(new_path, uistate.pulse_progressbar, 'w',
+                False, False,  # force_schema_upgrade, force_bsddb_upgrade
+                False, False,  # force_bsddb_downgrade, force_python_upgrade
+                username=username, password=password)
+    total = 0
+    for _obj_key, obj_name in KEY_TO_NAME_MAP.items():
+        data_map = getattr(old_db, obj_name + "_map", None)
+        if not data_map:
+            continue
+        total += len(data_map)
+    old_db.set_total(total)
+    with DbTxn('upgraded', new_db, batch=True) as trans:
+        for obj_key, obj_name in KEY_TO_NAME_MAP.items():
+            data_map = getattr(old_db, obj_name + "_map", None)
+            if not data_map:
+                continue
+            for handle in data_map.keys():
+                obj = data_map[handle]
+                new_db._commit_raw(obj, obj_key, trans)
+                old_db.update()
+    # copy metadata from old_db to new db
+    new_db.set_schema_version(old_db.get_schema_version())
+    new_db.name_formats = old_db.name_formats
+    new_db.owner = old_db.owner
+    new_db.bookmarks = old_db.bookmarks
+    new_db.family_bookmarks = old_db.family_bookmarks
+    new_db.event_bookmarks = old_db.event_bookmarks
+    new_db.source_bookmarks = old_db.source_bookmarks
+    new_db.citation_bookmarks = old_db.citation_bookmarks
+    new_db.repo_bookmarks = old_db.repo_bookmarks
+    new_db.media_bookmarks = old_db.media_bookmarks
+    new_db.place_bookmarks = old_db.place_bookmarks
+    new_db.note_bookmarks = old_db.note_bookmarks
+
+    # Custom type values
+    new_db.event_names = old_db.event_names
+    new_db.family_attributes = old_db.family_attributes
+    new_db.individual_attributes = old_db.individual_attributes
+    new_db.source_attributes = old_db.source_attributes
+    new_db.marker_names = old_db.marker_names
+    new_db.child_ref_types = old_db.child_ref_types
+    new_db.family_rel_types = old_db.family_rel_types
+    new_db.event_role_names = old_db.event_role_names
+    new_db.name_types = old_db.name_types
+    new_db.origin_types = old_db.origin_types
+    new_db.repository_types = old_db.repository_types
+    new_db.note_types = old_db.note_types
+    new_db.source_media_types = old_db.source_media_types
+    new_db.url_types = old_db.url_types
+    new_db.media_attributes = old_db.media_attributes
+    new_db.event_attributes = old_db.event_attributes
+    new_db.place_types = old_db.place_types
+
+    # surname list
+    new_db.surname_list = old_db.surname_list
+
+    old_db.close()
+    new_db.close()
+    # copy tree name to new dir
+    db_name = os.path.join(new_path, NAME_FILE)
+    with open(old_db_name, "r", encoding='utf8') as _file:
+        name = _file.read().strip()
+    with open(db_name, "w", encoding='utf8') as _file:
+        _file.write(name)
+    # remove files from old dir
+    for filename in os.listdir(dirname):
+        file_path = os.path.join(dirname, filename)
+        try:
+            os.unlink(file_path)
+        except Exception as e:
+            LOG.error('Failed to delete %s. Reason: %s' % (file_path, e))
+    # copy new db files to old dir
+    for filename in os.listdir(new_path):
+        old_file_path = os.path.join(new_path, filename)
+        file_path = os.path.join(dirname, filename)
+        try:
+            os.replace(old_file_path, file_path)
+        except Exception as e:
+            LOG.error('Failed to move %s. Reason: %s' % (old_file_path, e))
+    os.rmdir(new_path)
+    return (dbid, username, password)
+
+
+def gramps_upgrade_20(self):
+    """
+    Generic update.
+    """
+
+
+def make_zip_backup(self, dirname):
+    """
+    This backs up the db files so an upgrade can be (manually) undone.
+    """
+    import zipfile
+    # In Windows reserved characters is "<>:"/\|?*"
+    reserved_char = r':,<>"/\|?* '
+    replace_char = "-__________"
+    title = self.get_dbname()
+    trans = title.maketrans(reserved_char, replace_char)
+    title = title.translate(trans)
+
+    if not os.access(dirname, os.W_OK):
+        LOG.warning("Can't write technical DB backup for %s", title)
+        return
+    (grampsdb_path, db_code) = os.path.split(dirname)
+    dotgramps_path = os.path.dirname(grampsdb_path)
+    zipname = title + time.strftime("_%Y-%m-%d_%H-%M-%S") + ".zip"
+    zippath = os.path.join(dotgramps_path, zipname)
+    with zipfile.ZipFile(zippath, 'w') as myzip:
+        for filename in os.listdir(dirname):
+            pathname = os.path.join(dirname, filename)
+            myzip.write(pathname, os.path.join(db_code, filename))
+    LOG.warning("If upgrade and loading the Family Tree works, you can "
+                "delete the zip file at %s", zippath)

--- a/gramps/gui/dialog.py
+++ b/gramps/gui/dialog.py
@@ -48,6 +48,7 @@ _ = glocale.translation.gettext
 from gramps.gen.const import ICON, URL_BUGHOME
 from gramps.gen.config import config
 from gramps.gen.constfunc import is_quartz
+from gramps.gui.managedwindow import ManagedWindow
 from .glade import Glade
 from .display import display_url
 
@@ -547,6 +548,51 @@ class MessageHideDialog:
     def update_checkbox(self, obj, constant):
         config.set(constant, obj.get_active())
         config.save()
+
+
+class GrampsLoginDialog(ManagedWindow):
+
+    def __init__(self, uistate):
+        """
+        A login dialog to obtain credentials to connect to a database
+        """
+        self.title = _("Login")
+        ManagedWindow.__init__(self, uistate, [], self.__class__, modal=True)
+
+        dialog = Gtk.Dialog(transient_for=uistate.window)
+        grid = Gtk.Grid()
+        grid.set_border_width(6)
+        grid.set_row_spacing(6)
+        grid.set_column_spacing(6)
+        label = Gtk.Label(label=_('Username: '))
+        grid.attach(label, 0, 0, 1, 1)
+        self.username = Gtk.Entry()
+        self.username.set_hexpand(True)
+        grid.attach(self.username, 1, 0, 1, 1)
+        label = Gtk.Label(label=_('Password: '))
+        grid.attach(label, 0, 1, 1, 1)
+        self.password = Gtk.Entry()
+        self.password.set_hexpand(True)
+        self.password.set_visibility(False)
+        self.password.set_input_purpose(Gtk.InputPurpose.PASSWORD)
+        grid.attach(self.password, 1, 1, 1, 1)
+        dialog.vbox.pack_start(grid, True, True, 0)
+        dialog.add_buttons(_('_Cancel'), Gtk.ResponseType.CANCEL,
+                           _('Login'), Gtk.ResponseType.OK)
+        self.set_window(dialog, None, self.title)
+
+    def run(self):
+        self.show()
+        response = self.window.run()
+        username = self.username.get_text()
+        password = self.password.get_text()
+        if response == Gtk.ResponseType.CANCEL:
+            self.close()
+            return None
+        elif response == Gtk.ResponseType.OK:
+            self.close()
+            return (username, password)
+
 
 ## Testing function of some of these dialogs
 def main(args):


### PR DESCRIPTION
This is the initial attempt at an upgrade, assuming we will not be using BSDDB anymore.  It seems to work, but I know we have more to do.  It should be able to convert any bsddb tree that current 5.1.x can open.

One thing I did, is to modify the dbloader code so that we don't get several sequential popups asking if it is ok to upgrade.  I did not like the user aspects, and was a bit concerned that with only a partial bsddb open process, we would leave the db in an unstable state if the user did not accept all the upgrade prompts.  So with my changes, the only time a user can get two prompts is if his bsddb library version is older than the version last used to create the tree.  Then he gets the 'downgrade' warning.

ToDo:
* make sure CLI read of BSDDB db either works, or fails nicely
* Strip out most bsddb code from API etc.  Everything not needed for upgrade.
* Maybe reduce the number of zip backups made; could be 4 I think, if upgrading a very old bsddb
* Fix up config database.backend setting to exclude bsddb (in preferences and in case was set in ini file)
* Make sure we don't default to bsddb anywhere (cli db create?)
* Look into callbacks during upgrade process, no sign of progress on GUI, and numbers seem to be all over the place.
* Fix up other PRs (UID, GEPS045 Place enhancements) to use this if accepted.