### PR TITLE
Fix GrampsType for comparison bug with empty string as one value

### DIFF
--- a/gramps/gen/lib/grampstype.py
+++ b/gramps/gen/lib/grampstype.py
@@ -288,10 +288,12 @@ class GrampsType(object, metaclass=GrampsTypeMeta):
             else:
                 return self.__value == value[0]
         else:
-            if value.value == self._CUSTOM:
+            if value.value == self._CUSTOM and self.__value == self._CUSTOM:
                 return self.__string == value.string
-            else:
+            elif value.value != self._CUSTOM and self.__value != self._CUSTOM:
                 return self.__value == value.value
+            else:
+                return False
 
     def __ne__(self, value):
         return not self.__eq__(value)


### PR DESCRIPTION
#11563
A user noted that if trying to add a blank Attribute with the attribute tool, that the first Attribute in any persons list was overwritten.

It turns out that the problem was in GrampsType, in doing the equality comparison between two GrampsType instances, where one was custom with an empty string and the other was not custom.  The original code assumed that if the second value was custom, both must be, and so compared the string values.  Unfortunately, the string value of non-custom values is always an empty string.