### PR TITLE
Use event attribute types in the event reference editor

### DIFF
--- a/gramps/gui/editors/editeventref.py
+++ b/gramps/gui/editors/editeventref.py
@@ -38,7 +38,7 @@ from gramps.gen.lib import EventType, NoteType
 from gramps.gen.db import DbTxn
 from ..glade import Glade
 from .displaytabs import (CitationEmbedList, NoteTab, GalleryTab,
-                         EventBackRefList, AttrEmbedList)
+                         EventBackRefList, EventAttrEmbedList)
 from ..widgets import (PrivacyButton, MonitoredEntry,
                      MonitoredDate, MonitoredDataType, MonitoredTagList)
 from .editreference import RefTab, EditReference
@@ -209,10 +209,10 @@ class EditEventRef(EditReference):
         self._add_tab(notebook, self.srcref_list)
         self.track_ref_for_deletion("srcref_list")
 
-        self.attr_list = AttrEmbedList(self.dbstate,
-                                       self.uistate,
-                                       self.track,
-                                       self.source.get_attribute_list())
+        self.attr_list = EventAttrEmbedList(self.dbstate,
+                                            self.uistate,
+                                            self.track,
+                                            self.source.get_attribute_list())
         self._add_tab(notebook, self.attr_list)
         self.track_ref_for_deletion("attr_list")
 
@@ -247,10 +247,11 @@ class EditEventRef(EditReference):
         self._add_tab(notebook, self.backref_tab)
         self.track_ref_for_deletion("backref_tab")
 
-        self.attr_ref_list = AttrEmbedList(self.dbstate,
-                                           self.uistate,
-                                           self.track,
-                                           self.source_ref.get_attribute_list())
+        self.attr_ref_list = EventAttrEmbedList(
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.source_ref.get_attribute_list())
         self._add_tab(notebook_ref, self.attr_ref_list)
         self.track_ref_for_deletion("attr_ref_list")
 


### PR DESCRIPTION
In the event reference editor, custom event attribute types should be used rather than the default person attribute types.

Fixes bug [#11576](https://gramps-project.org/bugs/view.php?id=11576).