### PR TITLE
Remove no_magic support; which was not working for dbapi

### DIFF
--- a/gramps/gen/utils/db.py
+++ b/gramps/gen/utils/db.py
@@ -261,14 +261,8 @@ def get_participant_from_event(db, event_handle, all_=False):
     """
     participant = ""
     ellipses = False
-    try:
-        result_list = list(db.find_backlink_handles(event_handle,
-                                 include_classes=['Person', 'Family']))
-    except:
-        # during a magic batch transaction find_backlink_handles tries to
-        # access the reference_map_referenced_map which is closed
-        # under those circumstances.
-        return ''
+    result_list = list(db.find_backlink_handles(
+        event_handle, include_classes=['Person', 'Family']))
 
     #obtain handles without duplicates
     people = set([x[1] for x in result_list if x[0] == 'Person'])

--- a/gramps/gen/utils/unknown.py
+++ b/gramps/gen/utils/unknown.py
@@ -100,16 +100,11 @@ def make_unknown(class_arg, explanation, class_func, commit_func, transaction,
     elif isinstance(obj, Family):
         obj.set_relationship(FamilyRelType.UNKNOWN)
         handle = obj.handle
-        if getattr(argv['db'].transaction, 'no_magic', False):
-            backlinks = argv['db'].find_backlink_handles(
-                    handle, [Person.__name__])
-            for dummy, person_handle in backlinks:
-                person = argv['db'].get_person_from_handle(person_handle)
-                add_personref_to_family(obj, person)
-        else:
-            for person in argv['db'].iter_people():
-                if person._has_handle_reference('Family', handle):
-                    add_personref_to_family(obj, person)
+        backlinks = argv['db'].find_backlink_handles(
+                handle, [Person.__name__])
+        for dummy, person_handle in backlinks:
+            person = argv['db'].get_person_from_handle(person_handle)
+            add_personref_to_family(obj, person)
     elif isinstance(obj, Event):
         if 'type' in argv:
             obj.set_type(argv['type'])

--- a/gramps/plugins/importer/importxml.py
+++ b/gramps/plugins/importer/importxml.py
@@ -916,12 +916,7 @@ class GrampsParser(UpdateCallback):
         :param ifile: must be a file handle that is already open, with position
                       at the start of the file
         """
-        if personcount < 1000:
-            no_magic = True
-        else:
-            no_magic = False
-        with DbTxn(_("Gramps XML import"), self.db, batch=True,
-                   no_magic=no_magic) as self.trans:
+        with DbTxn(_("Gramps XML import"), self.db, batch=True) as self.trans:
             self.set_total(linecount)
 
             self.db.disable_signals()

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -2737,9 +2737,8 @@ class GedcomParser(UpdateCallback):
           0 TRLR                                          {1:1}
 
         """
-        no_magic = self.maxpeople < 1000
-        with DbTxn(_("GEDCOM import"), self.dbase, not use_trans,
-                   no_magic=no_magic) as self.trans:
+        with DbTxn(_("GEDCOM import"), self.dbase,
+                   not use_trans) as self.trans:
 
             self.dbase.disable_signals()
             self.__parse_header_head()

--- a/gramps/plugins/tool/check.py
+++ b/gramps/plugins/tool/check.py
@@ -225,11 +225,6 @@ class Check(tool.BatchTool):
             checker.check_checksum()
             checker.check_media_sourceref()
             checker.check_note_links()
-
-        # for bsddb the check_backlinks doesn't work in 'batch' mode because
-        # the table used for backlinks is closed.
-        with DbTxn(_("Check Backlink Integrity"), self.db,
-                   batch=False) as checker.trans:
             checker.check_backlinks()
 
         # rebuilding reference maps needs to be done outside of a transaction

--- a/gramps/plugins/tool/check.py
+++ b/gramps/plugins/tool/check.py
@@ -2230,6 +2230,7 @@ class CheckIntegrity:
             gid_list.append(gid)
         gid_list = []
         for note in self.db.iter_notes():
+            self.progress.step()
             ogid = gid = note.get_gramps_id()
             if gid in gid_list:
                 gid = self.db.find_next_note_gramps_id()


### PR DESCRIPTION
**History:**
'no_magic' is an optional parameter for the db 'transaction_begin' for example:
        with DbTxn(_("Gramps XML import"), self.db, batch=True,
                   no_magic=no_magic) as self.trans:

It appears to be a legacy of the bsddb, doesn't show up in any documents on the wiki, and is not listed in the gen.db.base.py.

It was an indicator to the bsddb to allow backlinks to be updated on a commit (when set to True) despite operating in a 'batch' transaction, where backlinks are not normally updated until the end of the transaction.

I found a bug where the GEDCOM importer was not properly fixing up the Sqlite db when the GEDCOM file was not consistent.  Turns out that when the importer tried to 'make_unknown' a family, it was doing a find_backlink_handles still within the batch transaction.  It had previously set no_magic to True, which for bsddb allows the backlinks to be updated as part of the batch transaction.

DBAPI seems to have no code to support the no_magic parameter, and always disables the backlink updates during the batch transaction.

So when make_unknown tried to do the backlink search to find the handles to attach to the family, it came up empty, generating an inconsistent Gramps db.

**This PR:**
I decided to remove support for no_magic.  I also decided to allow the backlinks feature (db references table) to work in batch mode.  To make this a bit less of a burden, I optimized the backlink creations during batch a bit by removing operations that were not needed.

The result is that batch mode transactions now process backlink creation during each commit, rather than at the end of the transaction in a mass update.  For operations like imports which do a lot of commits this slows them down slightly, for operations with few commits it is a bit faster;

Operation | original time | time with PR
---- | ---- | ----
Import file example.gramps | 10.1 sec | 10.7 sec
Import file my.ged (1000 persons) | 28.0 sec | 29.3 sec
Check&Repair my db | 47.6 sec | 45.6 sec

**P.S.**  I also noticed an odd pause in the Check & repair progress meter during processing; traced it to a missing progress update.  Separate commit for that.