### PR TITLE
Fix Windows GUI mode startup for crash with some languages

### DIFF
--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -126,7 +126,7 @@ if win():
             pass  # ok
         elif not os.path.isdir(HOME_DIR):
             os.makedirs(HOME_DIR)
-        sys.stdout = sys.stderr = open(logfile, "w")
+        sys.stdout = sys.stderr = open(logfile, "w", encoding='utf-8')
 stderrh = logging.StreamHandler(sys.stderr)
 stderrh.setFormatter(form)
 stderrh.setLevel(logging.DEBUG)


### PR DESCRIPTION
Fixes: #11612. #11490, #11518, #9179, #9201, #9266
The symptom was a crash on startup when running under some (but not all) languages.  And it was occurring in a print statement, a UnicodeEncodeError with the system code page, often cp1252.

This one was difficult to debug because it wouldn't occur under debug, so I could not see exactly what was happening in my debugger.  It only seemed to appear when running in the AIO and started with the no-console shortcut.  Initially I thought that this was some kind of Windows/Python issue because in that mode, stdout normally goes nowhere (NUL device).

But it turned out to be the gramps51.log file; created only when running under Windows without a console.  It was opened with the wrong encoding.