### PR TITLE
Fix Genealogy Tree reports for crash in CLI

### DIFF
--- a/gramps/cli/plug/__init__.py
+++ b/gramps/cli/plug/__init__.py
@@ -519,8 +519,8 @@ class CommandLineReport:
                         self.format = tree_format["class"]
             if self.format is None:
                 # Pick the first one as the default.
-                self.format = tree_format.FORMATS[0]["class"]
-                _chosen_format = tree_format.FORMATS[0]["type"]
+                self.format = treedoc.FORMATS[0]["class"]
+                _chosen_format = treedoc.FORMATS[0]["type"]
         else:
             self.format = None
         if _chosen_format and _format_str:

--- a/gramps/gen/plug/menu/_enumeratedlist.py
+++ b/gramps/gen/plug/menu/_enumeratedlist.py
@@ -62,6 +62,7 @@ class EnumeratedListOption(Option):
         :type value: int
         :return: nothing
         """
+        self.ini_value = value
         Option.__init__(self, label, value)
         self.__items = []
         self.__xml_items = []
@@ -138,6 +139,8 @@ class EnumeratedListOption(Option):
         """
         if value in (v for v, d in self.__items):
             Option.set_value(self, value)
+        elif value == self.ini_value:
+            return
         else:
             logging.warning(_("Value '%(val)s' not found for option '%(opt)s'") %
                              {'val' : str(value), 'opt' : self.get_label()})


### PR DESCRIPTION
Fixes #11621

Typo in file caused crash in CLI mode for Genealogy Tree

The second commit avoids some warning messages where the EnnumeratedListOption can sometimes have list elements different than the default initial value (seems to occur for empty string as initial value).  This depends on the usage of the option.  I decided that if an the initial value for the option was considered ok, then when it appears as a value it is ok, even if it is not in the current list.