### PR TITLE
Geography: add a popup for a bad tiles path

### DIFF
--- a/gramps/plugins/lib/maps/osmgps.py
+++ b/gramps/plugins/lib/maps/osmgps.py
@@ -64,6 +64,7 @@ _ = glocale.translation.sgettext
 from gramps.gen.config import config
 from gramps.gui.dialog import ErrorDialog
 from gramps.gen.constfunc import get_env_var
+from gramps.gen.const import VERSION_DIR
 
 #-------------------------------------------------------------------------
 #
@@ -138,7 +139,19 @@ class OsmGps:
                 ErrorDialog(_("Can't create "
                               "tiles cache directory %s") % cache_path,
                             parent=self.uistate.window)
-                return self.vbox
+                gini = os.path.join(VERSION_DIR, 'gramps.ini')
+                ErrorDialog(_("You must verify and change the tiles cache"
+                              "\n..."
+                              "\n[geography]"
+                              "\n..."
+                              "\npath='bad/path'"
+                              "\n..."
+                              "\nin the gramps.ini file :\n%s"
+                              "\n\nBefore to change the gramps.ini file, "
+                              "you need to close gramps"
+                              "\n\nThe next errors will be normal") % gini,
+                            parent=self.uistate.window)
+                return None
 
         self.change_map(None, config.get("geography.map_service"))
         return self.vbox


### PR DESCRIPTION
For some reason, the home directory may change. In this case, the tile cache directory becomes incorrect. We already have a popup for that. To make sure the user understands the problem, I added a new pop-up where I show how to fix the problem.

Fixes #11629