### PR TITLE
Fix Dashboard Gramplets to update during db close when not shown

### DIFF
--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -875,9 +875,6 @@ class ViewManager(CLIManager):
         """
         Perform necessary actions when a page is changed.
         """
-        if not self.dbstate.is_open():
-            return
-
         self.__disconnect_previous_page()
 
         self.active_page = self.pages[page_num]


### PR DESCRIPTION
Fixes #11632

If a db is closed while another view than dashboard is shown, the dashboard gramplets don't get updated to show the closed db.  Seems that most other views (not dashboard) have been fixed up by adding special db_close code in their gramplets.  But I am not certain that all of them have fixed.  I decided to provide a general fix, rather than trying to fix all the dashboard gramplets.

An early attempt to deal with closed db had simply disabled updates for views when changing to a view with the db closed.  Given the many other fixes for closed db, I am pretty sure this is no longer necessary.  So I removed the test, allowing all views (including dashboard) to be updated (when dirty) when the view is activated.

I tested all the views with both open and (recently) closed db and they seem to work correctly. 