### PR TITLE
[Language: Russian] Maintenance/gramps51

### DIFF
--- a/po/ru.po
+++ b/po/ru.po
@@ -5301,7 +5301,7 @@ msgstr "В быту:"
 
 #: ../gramps/gen/filters/rules/person/_hasnameof.py:51
 msgid "Nick Name:"
-msgstr "Клич/Прозвище:"
+msgstr "Прозвище:"
 
 #: ../gramps/gen/filters/rules/person/_hasnameof.py:52
 msgid "Prefix:"
@@ -24116,7 +24116,7 @@ msgstr "неизвестен тип отношений"
 
 #: ../gramps/plugins/gramplet/whatsnext.py:469
 msgid "family not complete"
-msgstr "семья не полноценна"
+msgstr "нехватка данных о семье"
 
 #: ../gramps/plugins/gramplet/whatsnext.py:484
 msgid "date unknown"
@@ -24571,10 +24571,9 @@ msgstr ""
 msgid "Graph Style"
 msgstr "Стиль графа"
 
-# !!!FIXME!!!
 #: ../gramps/plugins/graph/gvhourglass.py:438
 msgid "Force Ahnentafel order"
-msgstr "Принудить сортировку по древу"
+msgstr "Принудительная сортировка по древу"
 
 #: ../gramps/plugins/graph/gvhourglass.py:440
 msgid ""
@@ -24585,7 +24584,7 @@ msgstr ""
 
 #: ../gramps/plugins/graph/gvhourglass.py:443
 msgid "Ahnentafel number visible"
-msgstr "Показывать колено"
+msgstr "Показывать счёт поколений"
 
 #: ../gramps/plugins/graph/gvhourglass.py:445
 msgid ""
@@ -37289,7 +37288,7 @@ msgstr "Авторские права, которые будут использ�
 #: ../gramps/plugins/webreport/narrativeweb.py:1696
 #: ../gramps/plugins/webreport/webcal.py:1703
 msgid "The stylesheet to be used for the web pages"
-msgstr "Таблица видов для страницы"
+msgstr "Таблица стилей для страницы"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1701
 msgid "Horizontal -- Default"
@@ -38154,7 +38153,7 @@ msgstr "Первый год календаря"
 
 #: ../gramps/plugins/webreport/webcal.py:1755
 msgid "Enter the starting year for the calendars between 1900 - 3000"
-msgstr "оВведите первый год календаря, он должен быть между 1900 - 3000"
+msgstr "Введите первый год календаря, он должен быть между 1900 - 3000"
 
 #: ../gramps/plugins/webreport/webcal.py:1759
 msgid "End Year for the Calendar(s)"
@@ -38372,7 +38371,7 @@ msgstr "Создаёт страницы (HTML) для отдельных лиц 
 
 #: ../gramps/plugins/webreport/webplugins.gpr.py:59
 msgid "Produces web (HTML) calendars."
-msgstr "Создаёт сетовые календари (HTML)."
+msgstr "Создаёт сетевые календари (HTML)."
 
 #: ../gramps/plugins/webstuff/webstuff.gpr.py:36
 msgid "Webstuff"

--- a/po/ru.po
+++ b/po/ru.po
@@ -5297,7 +5297,7 @@ msgstr "Суффикс:"
 
 #: ../gramps/gen/filters/rules/person/_hasnameof.py:50
 msgid "Call Name:"
-msgstr "Мирское имя:"
+msgstr "В быту:"
 
 #: ../gramps/gen/filters/rules/person/_hasnameof.py:51
 msgid "Nick Name:"
@@ -15338,7 +15338,7 @@ msgstr ""
 "  <b>%t</b> - Титул            <b>%T</b> - ТИТУЛ\n"
 "  <b>%p</b> - Префикс          <b>%P</b> - ПРЕФИКС\n"
 "  <b>%s</b> - Суффикс          <b>%S</b> - СУФФИКС\n"
-"  <b>%c</b> - Бытовое, мирское имя <b>%C</b> - БЫТОВОЕ ИМЯ\n"
+"  <b>%c</b> - Бытовое имя      <b>%C</b> - БЫТОВОЕ ИМЯ\n"
 "  <b>%y</b> - Отчество         <b>%Y</b> - ОТЧЕСТВО</tt>"
 
 #: ../gramps/gui/glade/configure.glade:155
@@ -16238,7 +16238,7 @@ msgstr "Суффи_кс:"
 
 #: ../gramps/gui/glade/editname.glade:235
 msgid "C_all Name:"
-msgstr "Мирское имя:"
+msgstr "В быту:"
 
 #: ../gramps/gui/glade/editname.glade:250
 #: ../gramps/gui/glade/editperson.glade:150
@@ -16257,9 +16257,9 @@ msgid ""
 "some reports."
 msgstr ""
 "Часть личного имени человека, которая обычно употребляется в обиходе. "
-"Отображение на красном фоне означает, что указанное мирское, бытовое имя не является "
-"частью перечисленных личных имён, и поэтому не будет подчёркнуто в некоторых "
-"отчётах."
+"Отображение на красном фоне означает, что указанное мирское, бытовое имя "
+"не является частью перечисленных личных имён, и поэтому не будет "
+"подчёркнуто в некоторых отчётах."
 
 #: ../gramps/gui/glade/editname.glade:291
 #: ../gramps/gui/glade/editperson.glade:211
@@ -24834,7 +24834,7 @@ msgstr "имя"
 
 #: ../gramps/plugins/importer/importcsv.py:165
 msgid "call"
-msgstr "мирское имя"
+msgstr "бытовое имя"
 
 #: ../gramps/plugins/importer/importcsv.py:166
 msgid "Person or Place|title"
@@ -32209,7 +32209,7 @@ msgstr "Пропускать ли повторяющихся предков."
 #: ../gramps/plugins/textreport/detancestralreport.py:894
 #: ../gramps/plugins/textreport/detdescendantreport.py:1079
 msgid "Use callname for common name"
-msgstr "Использовать мирское имя по умолчанию"
+msgstr "Использовать бытовое имя по умолчанию"
 
 #: ../gramps/plugins/textreport/detancestralreport.py:895
 #: ../gramps/plugins/textreport/detdescendantreport.py:1080
@@ -37886,7 +37886,7 @@ msgstr "Название места"
 
 #: ../gramps/plugins/webreport/person.py:1453
 msgid "Call Name"
-msgstr "Мирское имя"
+msgstr "Бытовое имя"
 
 #: ../gramps/plugins/webreport/person.py:1471
 msgid "Nick Name"

--- a/po/ru.po
+++ b/po/ru.po
@@ -11,6 +11,7 @@
 # Vassilii Khachaturov <vassilii@tarunz.org>, 2011-2014.
 # Egor Reentov <egor.gramps@gmail.com>, 2011-2013.
 # Ivan Komaritsyn <vantu5z@mail.ru>, 2015-2020.
+# Roman <https://gramps-project.org/wiki/index.php/User:Roman>, 2020
 #
 msgid ""
 msgstr ""
@@ -643,7 +644,7 @@ msgid ""
 msgstr ""
 "<b>Редактирование отношения «родители/дети»</b><br/> Вы можете уточнять "
 "отношения между детьми и родителями двойным щелчком мыши на ребёнке в "
-"редакторе семей. Возможные значения: Рождение, Приёмный, Пасынок, и т.д."
+"редакторе семей. Возможные значения: Рождение, Усыновление, Пасынок, и т.д."
 
 #: ../data/tips.xml.in.h:28
 msgid ""
@@ -1823,7 +1824,7 @@ msgstr "Заблокировано %s"
 #: ../gramps/plugins/webreport/basepage.py:2217
 #: ../gramps/plugins/webreport/basepage.py:2389
 msgid "Unknown"
-msgstr "Неизвестно"
+msgstr "Прочее"
 
 #: ../gramps/cli/grampscli.py:86
 #, python-format
@@ -4201,7 +4202,7 @@ msgstr "Выбирает события с указанным значением
 #: ../gramps/gui/editors/filtereditor.py:104
 #: ../gramps/gui/editors/filtereditor.py:543
 msgid "Event type:"
-msgstr "Тип события:"
+msgstr "Событие:"
 
 #: ../gramps/gen/filters/rules/event/_hasdata.py:47
 #: ../gramps/gen/filters/rules/family/_hasevent.py:49
@@ -5296,11 +5297,11 @@ msgstr "Суффикс:"
 
 #: ../gramps/gen/filters/rules/person/_hasnameof.py:50
 msgid "Call Name:"
-msgstr "Имя в быту:"
+msgstr "Мирское имя:"
 
 #: ../gramps/gen/filters/rules/person/_hasnameof.py:51
 msgid "Nick Name:"
-msgstr "Прозвище:"
+msgstr "Клич/Прозвище:"
 
 #: ../gramps/gen/filters/rules/person/_hasnameof.py:52
 msgid "Prefix:"
@@ -6805,7 +6806,7 @@ msgstr "Значение"
 #: ../gramps/plugins/textreport/indivcomplete.py:74
 #: ../gramps/plugins/view/geoplaces.py:595
 msgid "Custom"
-msgstr "Другой"
+msgstr "Дополнительное"
 
 #: ../gramps/gen/lib/attrtype.py:65
 msgid "Caste"
@@ -6886,7 +6887,7 @@ msgstr "Возраст матери"
 
 #: ../gramps/gen/lib/attrtype.py:77 ../gramps/gen/lib/eventroletype.py:60
 msgid "Witness"
-msgstr "Свидетель"
+msgstr "Свидетеля"
 
 #: ../gramps/gen/lib/attrtype.py:78
 msgid "Time"
@@ -6897,7 +6898,7 @@ msgstr "Время"
 #: ../gramps/gen/plug/docgen/treedoc.py:451
 #: ../gramps/plugins/gramplet/persondetails.py:163
 msgid "Occupation"
-msgstr "Профессия"
+msgstr "Деятельность"
 
 #: ../gramps/gen/lib/childref.py:105 ../gramps/gui/editors/editchildref.py:190
 msgid "Child Reference"
@@ -6950,7 +6951,7 @@ msgstr "Рождение"
 
 #: ../gramps/gen/lib/childreftype.py:69 ../gramps/gen/lib/eventtype.py:164
 msgid "Adopted"
-msgstr "Приёмный"
+msgstr "Усыновление"
 
 #: ../gramps/gen/lib/childreftype.py:70
 msgid "Stepchild"
@@ -7143,7 +7144,7 @@ msgstr "Метки"
 #: ../gramps/plugins/view/relview.py:791
 #: ../gramps/plugins/webreport/person.py:431
 msgid "unknown"
-msgstr "неизвестно"
+msgstr "неизвестен"
 
 #: ../gramps/gen/lib/date.py:281
 #, python-format
@@ -7390,36 +7391,36 @@ msgstr "Атрибуты"
 
 #: ../gramps/gen/lib/eventroletype.py:54
 msgid "Role|Primary"
-msgstr "Главная"
+msgstr "Основная"
 
 # LDS
 #: ../gramps/gen/lib/eventroletype.py:55
 msgid "Clergy"
-msgstr "Религиозный персонал"
+msgstr "Религиозного персонала"
 
 #: ../gramps/gen/lib/eventroletype.py:56
 msgid "Celebrant"
-msgstr "Именинник"
+msgstr "Именинника"
 
 #: ../gramps/gen/lib/eventroletype.py:57
 msgid "Aide"
-msgstr "Помощник"
+msgstr "Помощника"
 
 #: ../gramps/gen/lib/eventroletype.py:58
 msgid "Bride"
-msgstr "Невеста"
+msgstr "Невесты"
 
 #: ../gramps/gen/lib/eventroletype.py:59
 msgid "Groom"
-msgstr "Жених"
+msgstr "Жениха"
 
 #: ../gramps/gen/lib/eventroletype.py:61
 msgid "Role|Family"
-msgstr "Член семьи"
+msgstr "Члена семьи"
 
 #: ../gramps/gen/lib/eventroletype.py:62
 msgid "Informant"
-msgstr "Податель заявления"
+msgstr "Подателя заявления"
 
 #: ../gramps/gen/lib/eventtype.py:137
 msgid "Life Events"
@@ -7462,7 +7463,7 @@ msgstr "Религия"
 
 #: ../gramps/gen/lib/eventtype.py:145
 msgid "Vocational"
-msgstr "Род занятий"
+msgstr "Занятие"
 
 #: ../gramps/gen/lib/eventtype.py:147
 msgid "Academic"
@@ -7483,14 +7484,14 @@ msgstr "Правовое"
 #: ../gramps/plugins/webreport/addressbooklist.py:114
 #: ../gramps/plugins/webreport/basepage.py:2802
 msgid "Residence"
-msgstr "Место жительства"
+msgstr "Проживание"
 
 #: ../gramps/gen/lib/eventtype.py:155 ../gramps/gui/glade/mergedata.glade:523
 #: ../gramps/gui/glade/mergedata.glade:610
 #: ../gramps/plugins/lib/maps/placeselection.py:152
 #: ../gramps/plugins/lib/maps/placeselection.py:203
 msgid "Other"
-msgstr "Другое"
+msgstr "Иное"
 
 #: ../gramps/gen/lib/eventtype.py:166 ../gramps/gui/merge/mergeperson.py:194
 #: ../gramps/plugins/export/exportvcalendar.py:160
@@ -7950,11 +7951,11 @@ msgstr "Процедура СПД"
 #: ../gramps/gen/lib/familyreltype.py:47
 #: ../gramps/plugins/webreport/webcal.py:2115
 msgid "Married"
-msgstr "Женаты"
+msgstr "Супружество"
 
 #: ../gramps/gen/lib/familyreltype.py:48
 msgid "Unmarried"
-msgstr "Не женаты"
+msgstr "Вне брака"
 
 #: ../gramps/gen/lib/familyreltype.py:49
 msgid "Civil Union"
@@ -8148,15 +8149,13 @@ msgstr "Статус"
 #: ../gramps/gen/lib/location.py:87 ../gramps/gen/lib/nameorigintype.py:86
 #: ../gramps/gui/clipboard.py:318 ../gramps/gui/plug/_windows.py:627
 msgid "Location"
-msgstr "Расположение"
+msgstr "Местность"
 
 #: ../gramps/gen/lib/location.py:107 ../gramps/gen/lib/placetype.py:69
 #: ../gramps/plugins/view/geoplaces.py:646
 msgid "Parish"
 msgstr "Приход"
 
-# Заполнено?
-# !!!FIXME!!!
 #: ../gramps/gen/lib/markertype.py:53
 #: ../gramps/gui/logger/_errorreportassistant.py:693
 msgid "Complete"
@@ -8342,15 +8341,15 @@ msgstr "%(first)s %(surname)s, %(suffix)s"
 
 #: ../gramps/gen/lib/nameorigintype.py:76
 msgid "Surname|Inherited"
-msgstr "Унаследованное"
+msgstr "Унаследование, по завещанию"
 
 #: ../gramps/gen/lib/nameorigintype.py:77
 msgid "Surname|Given"
-msgstr "Фамилия (по рождении)"
+msgstr "Фамилия, по рождению"
 
 #: ../gramps/gen/lib/nameorigintype.py:78
 msgid "Surname|Taken"
-msgstr "Фамилия (принятая)"
+msgstr "Фамилия, по принятию"
 
 #: ../gramps/gen/lib/nameorigintype.py:79 ../gramps/gen/utils/keyword.py:65
 #: ../gramps/gui/configure.py:857
@@ -8359,11 +8358,11 @@ msgstr "Отчество"
 
 #: ../gramps/gen/lib/nameorigintype.py:80
 msgid "Matronymic"
-msgstr "Матроним"
+msgstr "Матчество"
 
 #: ../gramps/gen/lib/nameorigintype.py:81
 msgid "Surname|Feudal"
-msgstr "Феодальное"
+msgstr "Акколада, по посвящению"
 
 #: ../gramps/gen/lib/nameorigintype.py:82
 msgid "Pseudonym"
@@ -8371,11 +8370,11 @@ msgstr "Псевдоним"
 
 #: ../gramps/gen/lib/nameorigintype.py:83
 msgid "Patrilineal"
-msgstr "Происхождение по мужской линии"
+msgstr "Происхождение, по мужской линии"
 
 #: ../gramps/gen/lib/nameorigintype.py:84
 msgid "Matrilineal"
-msgstr "Происхождение по женской линии"
+msgstr "Происхождение, по женской линии"
 
 #: ../gramps/gen/lib/nametype.py:48
 msgid "Also Known As"
@@ -8383,11 +8382,11 @@ msgstr "Он(а) же"
 
 #: ../gramps/gen/lib/nametype.py:49
 msgid "Birth Name"
-msgstr "Фамилия при рождении"
+msgstr "Имя по рождению"
 
 #: ../gramps/gen/lib/nametype.py:50
 msgid "Married Name"
-msgstr "Фамилия в браке"
+msgstr "Имя по браку"
 
 #. ###############################
 #. 3
@@ -8654,7 +8653,7 @@ msgstr "Адреса"
 
 #: ../gramps/gen/lib/person.py:215
 msgid "Urls"
-msgstr "Веб-ссылки"
+msgstr "Ссылки URL"
 
 #: ../gramps/gen/lib/person.py:237
 msgid "Person references"
@@ -8757,7 +8756,7 @@ msgstr "Соседство"
 
 #: ../gramps/gen/lib/placetype.py:76 ../gramps/plugins/view/geoplaces.py:643
 msgid "District"
-msgstr "Округ"
+msgstr "Округ/Край"
 
 #: ../gramps/gen/lib/placetype.py:77 ../gramps/plugins/view/geoplaces.py:607
 msgid "Borough"
@@ -8838,7 +8837,7 @@ msgstr "Альбом"
 
 #: ../gramps/gen/lib/repotype.py:59
 msgid "Web site"
-msgstr "Веб сайт"
+msgstr "Сетевая страничка"
 
 #: ../gramps/gen/lib/repotype.py:60
 msgid "Bookstore"
@@ -9065,19 +9064,19 @@ msgstr "Приоритет"
 
 #: ../gramps/gen/lib/url.py:88 ../gramps/gui/clipboard.py:418
 msgid "Url"
-msgstr "Веб-адрес"
+msgstr "Ссылка URL"
 
 #: ../gramps/gen/lib/urltype.py:49
 msgid "E-mail"
-msgstr "Эл. почта"
+msgstr "Электронная почта"
 
 #: ../gramps/gen/lib/urltype.py:50
 msgid "Web Home"
-msgstr "Домашняя страница в сети"
+msgstr "Страница в сети"
 
 #: ../gramps/gen/lib/urltype.py:51
 msgid "Web Search"
-msgstr "Поиск в сети"
+msgstr "Статья в интернете"
 
 #: ../gramps/gen/lib/urltype.py:52
 msgid "FTP"
@@ -9187,7 +9186,6 @@ msgstr "Стабильный"
 msgid "Unstable"
 msgstr "Нестабильный"
 
-# !!!FIXME!!!
 #: ../gramps/gen/plug/_pluginreg.py:80
 msgid "Quickreport"
 msgstr "Быстрый отчёт"
@@ -9760,7 +9758,7 @@ msgstr "Вверх (↑)"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:78
 msgid "Right (→)"
-msgstr "Вправо"
+msgstr "Вправо (→)"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:79
 msgid "Left (←)"
@@ -9803,7 +9801,7 @@ msgstr "Небольшой"
 #: ../gramps/plugins/graph/gvfamilylines.py:263
 #: ../gramps/plugins/importer/importprogen.py:488
 msgid "Normal"
-msgstr "Нормальный"
+msgstr "Нормальная"
 
 #: ../gramps/gen/plug/docgen/treedoc.py:94
 #: ../gramps/plugins/graph/gvfamilylines.py:264
@@ -9870,7 +9868,7 @@ msgstr ""
 
 #: ../gramps/gen/plug/docgen/treedoc.py:171
 msgid "Node color."
-msgstr "Цвет блока"
+msgstr "Цвет узла."
 
 #. ###############################
 #. #################
@@ -9987,7 +9985,7 @@ msgstr "Графики"
 msgid "Trees"
 msgstr "Древа"
 
-# !!!FIXME!!!
+# !!!FIXME!!! изображение?
 #: ../gramps/gen/plug/report/_constants.py:55
 msgid "Graphics"
 msgstr "Графика"
@@ -11274,7 +11272,7 @@ msgstr ""
 
 #: ../gramps/gui/aboutdialog.py:111
 msgid "Gramps Homepage"
-msgstr "Домашняя страница Gramps"
+msgstr "Страница Gramps"
 
 #: ../gramps/gui/aboutdialog.py:117
 msgid "Contributions by"
@@ -11458,17 +11456,17 @@ msgstr ""
 "фамилии (с префиксом и связками)\n"
 "  <b>Титул</b>       - звание: «Др.», «Св.», ...    <b>Суффикс</b>     - "
 "например, «Мл.» или «III»\n"
-"  <b>Обиходное</b>   - имя в быту                   <b>Прозвище</b>\n"
+"  <b>Обиходное</b>   - бытовое или мирское имя   <b>Прозвище</b>\n"
 "  <b>Инициалы</b>    - начальные буквы имён         <b>Разговорное</b> - "
 "прозвище, или одно из имен\n"
 "  <b>Главное, Главное[пр], или …[фам] …[св]</b> - полностью главная фамилия, "
 "префикс, только фамилия, связка\n"
 "  <b>Отчество, Отчество[пр], или …[им] …[св]</b> - аналогично Главное… для "
-"отчества или матронима\n"
+"отчества или матчиства\n"
 "  <b>Семпрозвище</b> - семейное прозвище            <b>Неглавные</b>   - "
 "фамилии без главной+отчества\n"
 "  <b>Префикс</b>     - приставки («де», «ван», ...) <b>Безотчества</b> - "
-"фамилии без отчества/матронима\n"
+"фамилии без отчества/матчиства\n"
 "  <b>Списокфо</b>    - фамилии и отчества (без префиксов и связок)\n"
 "</tt>\n"
 "Укажите ключевое слово ЗАГЛАВНЫМИ БУКВАМИ, чтобы соответствующие данные\n"
@@ -11587,7 +11585,7 @@ msgstr "Индекс/Почтовый код"
 #: ../gramps/gui/configure.py:628 ../gramps/gui/plug/_windows.py:625
 #: ../gramps/plugins/view/repoview.py:95
 msgid "Email"
-msgstr "Эл. почта"
+msgstr "Электронная почта"
 
 #: ../gramps/gui/configure.py:629
 msgid "Researcher"
@@ -11830,7 +11828,7 @@ msgstr "Редактировать"
 
 #: ../gramps/gui/configure.py:1208
 msgid "Consider single pa/matronymic as surname"
-msgstr "Использовать одиночное отчество/матроним как фамилию"
+msgstr "Использовать одиночное отчество/матчиство как фамилию"
 
 #: ../gramps/gui/configure.py:1240
 msgid "Place format (auto place title)"
@@ -11864,10 +11862,9 @@ msgstr "Календарь в отчётах"
 msgid "Surname guessing"
 msgstr "Угадывание фамилий"
 
-# !!!FIXME!!!
 #: ../gramps/gui/configure.py:1308
 msgid "Default family relationship"
-msgstr "Семейное отношение по умолчанию"
+msgstr "Межличностное отношения по умолчанию"
 
 #: ../gramps/gui/configure.py:1315
 msgid "Height multiple surname box (pixels)"
@@ -12600,11 +12597,11 @@ msgstr "Семейные древа"
 
 #: ../gramps/gui/dbman.py:381
 msgid "Family Tree name"
-msgstr "Название семейного древа"
+msgstr "Семейное древо"
 
 #: ../gramps/gui/dbman.py:401
 msgid "Database Type"
-msgstr "Тип базы данных"
+msgstr "База данных"
 
 #: ../gramps/gui/dbman.py:508
 #, python-format
@@ -13184,7 +13181,7 @@ msgstr "Переместить выделенную цитату ниже"
 
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:91
 msgid "_Source Citations"
-msgstr "Цитаты источника"
+msgstr "Цитаты"
 
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:171
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:182
@@ -13874,7 +13871,7 @@ msgstr "Сохранение события невозможно. ID уже су
 
 #: ../gramps/gui/editors/editevent.py:264
 msgid "The event type cannot be empty"
-msgstr "Тип события не может быть пустым"
+msgstr "События не может быть безымянным"
 
 #: ../gramps/gui/editors/editevent.py:270
 #, python-format
@@ -15246,10 +15243,9 @@ msgstr "_Название книги:"
 msgid "Clear the book"
 msgstr "Очистить книгу"
 
-# !!!FIXME!!!
 #: ../gramps/gui/glade/book.glade:112
 msgid "Save current set of configured selections"
-msgstr "Сохранить текущий набор настроек"
+msgstr "Сохранить настройки"
 
 #: ../gramps/gui/glade/book.glade:135
 msgid "Open previously created book"
@@ -15342,7 +15338,7 @@ msgstr ""
 "  <b>%t</b> - Титул            <b>%T</b> - ТИТУЛ\n"
 "  <b>%p</b> - Префикс          <b>%P</b> - ПРЕФИКС\n"
 "  <b>%s</b> - Суффикс          <b>%S</b> - СУФФИКС\n"
-"  <b>%c</b> - Имя в быту         <b>%C</b> - ИМЯ В БЫТУ\n"
+"  <b>%c</b> - Бытовое, мирское имя <b>%C</b> - БЫТОВОЕ ИМЯ\n"
 "  <b>%y</b> - Отчество         <b>%Y</b> - ОТЧЕСТВО</tt>"
 
 #: ../gramps/gui/glade/configure.glade:155
@@ -15379,7 +15375,7 @@ msgstr "_Создать"
 
 #: ../gramps/gui/glade/dbman.glade:251
 msgid "_Info"
-msgstr "_Информация"
+msgstr "_Подробнее"
 
 #: ../gramps/gui/glade/dbman.glade:282
 msgid "_Rename"
@@ -16083,7 +16079,7 @@ msgid ""
 "Bundesland."
 msgstr ""
 "Второй уровень подразделения местоположения. Например, в С.Ш.А. это штат, в "
-"России - республика или автономный округ."
+"России - республика, автономный округ или бывшие уезды."
 
 #: ../gramps/gui/glade/editlocation.glade:234
 msgid "The country where the place is."
@@ -16242,7 +16238,7 @@ msgstr "Суффи_кс:"
 
 #: ../gramps/gui/glade/editname.glade:235
 msgid "C_all Name:"
-msgstr "Имя в быту:"
+msgstr "Мирское имя:"
 
 #: ../gramps/gui/glade/editname.glade:250
 #: ../gramps/gui/glade/editperson.glade:150
@@ -16261,7 +16257,7 @@ msgid ""
 "some reports."
 msgstr ""
 "Часть личного имени человека, которая обычно употребляется в обиходе. "
-"Отображение на красном фоне означает, что указанное имя в быту не является "
+"Отображение на красном фоне означает, что указанное мирское, бытовое имя не является "
 "частью перечисленных личных имён, и поэтому не будет подчёркнуто в некоторых "
 "отчётах."
 
@@ -16511,7 +16507,7 @@ msgstr "Выбор лица, которое имеет связь с редак�
 msgid ""
 "Either use the two fields below to enter coordinates (latitude and "
 "longitude),"
-msgstr "Введите в поля ниже координаты (широта и долгота),"
+msgstr "Введите координаты в поле ниже (широта и долгота),"
 
 #: ../gramps/gui/glade/editplace.glade:120
 msgid "L_atitude:"
@@ -16741,7 +16737,7 @@ msgstr "Уникальный номер для идентификации ист
 
 #: ../gramps/gui/glade/editurl.glade:96
 msgid "_Web address:"
-msgstr "_Web адрес:"
+msgstr "_Веб адрес:"
 
 #: ../gramps/gui/glade/editurl.glade:111
 msgid "_Description:"
@@ -17158,7 +17154,7 @@ msgstr "Статус:"
 
 #: ../gramps/gui/glade/plugins.glade:206
 msgid "Author's email:"
-msgstr "Эл. почта автора:"
+msgstr "Электронная почта автора:"
 
 #: ../gramps/gui/glade/reorder.glade:87
 msgid "Parent relationships"
@@ -17582,7 +17578,7 @@ msgstr "Полно_экранный режим"
 
 #: ../gramps/gui/grampsgui.py:56
 msgid "Gramps _Home Page"
-msgstr "_Домашняя страница Gramps"
+msgstr "_Страница Gramps"
 
 #: ../gramps/gui/grampsgui.py:56
 msgid "Gramps _Mailing Lists"
@@ -17707,7 +17703,7 @@ msgstr "_Руководство пользователя"
 
 #: ../gramps/gui/grampsgui.py:56
 msgid "_View"
-msgstr "_Вид"
+msgstr "_Облик"
 
 #: ../gramps/gui/grampsgui.py:56
 msgid "_Windows"
@@ -18173,7 +18169,7 @@ msgstr "Супруги"
 #: ../gramps/plugins/textreport/familygroup.py:570
 #: ../gramps/plugins/view/relview.py:1580
 msgid "Spouse"
-msgstr "Супруг(а)"
+msgstr "Супруг(-а)"
 
 #: ../gramps/gui/merge/mergeperson.py:264
 msgid "No spouses or children found"
@@ -18986,7 +18982,7 @@ msgstr "Горизонтальная"
 
 #: ../gramps/gui/plug/report/_papermenu.py:215
 msgid "inch|in."
-msgstr "''"
+msgstr "дюйм."
 
 #: ../gramps/gui/plug/report/_reportdialog.py:143
 msgid "Configuration"
@@ -18996,7 +18992,7 @@ msgstr "Конфигурация"
 #: ../gramps/gui/plug/report/_styleeditor.py:115
 #: ../gramps/gui/plug/report/_styleeditor.py:270
 msgid "Style"
-msgstr "Стиль"
+msgstr "Вид"
 
 #. better to 'Show siblings of\nthe center person
 #. Spouse_disp = EnumeratedListOption(_("Show spouses of\nthe center "
@@ -21721,7 +21717,7 @@ msgstr "Возраст смерти"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:379
 msgid "Event type"
-msgstr "Тип события"
+msgstr "Cобытие"
 
 #: ../gramps/plugins/drawreport/statisticschart.py:393
 msgid "(Preferred) title missing"
@@ -21741,8 +21737,6 @@ msgstr "Отсутствует (главная) фамилия"
 msgid "Gender unknown"
 msgstr "Пол неизвестен"
 
-# Предположение
-# !!!FIXME!!!
 #. localized year
 #. inadequate information
 #: ../gramps/plugins/drawreport/statisticschart.py:431
@@ -22253,7 +22247,7 @@ msgstr "Запись хранилищ"
 #: ../gramps/plugins/export/exportgedcom.py:1166
 #: ../gramps/plugins/lib/libgedcom.py:5945
 msgid "EMAIL"
-msgstr "Эл. почта"
+msgstr "Электронная почта"
 
 #: ../gramps/plugins/export/exportgedcom.py:1168
 #: ../gramps/plugins/lib/libgedcom.py:5957
@@ -23491,10 +23485,9 @@ msgstr "Показывает события для всей семьи"
 msgid "Referrer"
 msgstr ""
 
-# !!!FIXME!!!
 #: ../gramps/plugins/gramplet/leak.py:103
 msgid "Uncollected object"
-msgstr "Неуничтоженный объект"
+msgstr "Необработаный объект"
 
 #: ../gramps/plugins/gramplet/leak.py:112
 msgid "Refresh"
@@ -23514,11 +23507,10 @@ msgstr "Ссылается на объект %d"
 msgid "%d refers to"
 msgstr "%d ссылается на этот объект"
 
-# !!!FIXME!!!
 #: ../gramps/plugins/gramplet/leak.py:198
 #, python-format
 msgid "Uncollected Objects: %s"
-msgstr "Неуничтоженные объекты: %s"
+msgstr "Необработаные объекты: %s"
 
 #: ../gramps/plugins/gramplet/leak.py:239
 msgid "Reference Error"
@@ -24123,11 +24115,9 @@ msgstr "отсутствует свадебное событие"
 msgid "relation type unknown"
 msgstr "неизвестен тип отношений"
 
-# Заполнено?
-# !!!FIXME!!!
 #: ../gramps/plugins/gramplet/whatsnext.py:469
 msgid "family not complete"
-msgstr "семья не полная"
+msgstr "семья не полноценна"
 
 #: ../gramps/plugins/gramplet/whatsnext.py:484
 msgid "date unknown"
@@ -24585,7 +24575,7 @@ msgstr "Стиль графа"
 # !!!FIXME!!!
 #: ../gramps/plugins/graph/gvhourglass.py:438
 msgid "Force Ahnentafel order"
-msgstr ""
+msgstr "Принудить сортировку по древу"
 
 #: ../gramps/plugins/graph/gvhourglass.py:440
 msgid ""
@@ -24594,10 +24584,9 @@ msgid ""
 "branch."
 msgstr ""
 
-# !!!FIXME!!!
 #: ../gramps/plugins/graph/gvhourglass.py:443
 msgid "Ahnentafel number visible"
-msgstr ""
+msgstr "Показывать колено"
 
 #: ../gramps/plugins/graph/gvhourglass.py:445
 msgid ""
@@ -24712,23 +24701,23 @@ msgstr "Размещение изображения"
 #. occupation = BooleanOption(_("Include occupation"), False)
 #: ../gramps/plugins/graph/gvrelgraph.py:921
 msgid "Include occupation"
-msgstr "Включить данные о профессии"
+msgstr "Включить данные о деятельности"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:922
 msgid "Do not include any occupation"
-msgstr "Не включать данные о профессии"
+msgstr "Не включать данные о деятельности"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:923
 msgid "Include description of most recent occupation"
-msgstr "Включать описание профессии"
+msgstr "Включать описание деятельности"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:925
 msgid "Include date, description and place of all occupations"
-msgstr "Включать даты, описания и места всех профессий"
+msgstr "Включать даты, описания и места всех деятельностей"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:927
 msgid "Whether to include the last occupation"
-msgstr "Включать ли последнюю профессию"
+msgstr "Включать ли последнюю деятельность"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:931
 msgid "Include relationship debugging numbers also"
@@ -24845,7 +24834,7 @@ msgstr "имя"
 
 #: ../gramps/plugins/importer/importcsv.py:165
 msgid "call"
-msgstr "имя в быту"
+msgstr "мирское имя"
 
 #: ../gramps/plugins/importer/importcsv.py:166
 msgid "Person or Place|title"
@@ -26085,7 +26074,7 @@ msgstr "Причина смерти"
 
 #: ../gramps/plugins/lib/libgedcom.py:702
 msgid "Employment"
-msgstr "Профессия"
+msgstr "Деятельность"
 
 #: ../gramps/plugins/lib/libgedcom.py:704
 msgid "Eye Color"
@@ -30925,7 +30914,7 @@ msgstr "Место события"
 #: ../gramps/plugins/quickview/all_events.py:124
 #: ../gramps/plugins/webreport/person.py:900
 msgid "Event Type"
-msgstr "Тип события"
+msgstr "Событие"
 
 #: ../gramps/plugins/quickview/all_events.py:70
 #: ../gramps/plugins/quickview/all_events.py:120
@@ -31156,10 +31145,9 @@ msgstr "по размеру документа"
 msgid "Filtering_on|list of people"
 msgstr "список людей"
 
-# !!!FIXME!!!
 #: ../gramps/plugins/quickview/filterbyname.py:85
 msgid "Summary counts of current selection"
-msgstr "Суммарное количество в текущем выделении"
+msgstr "Суммарное количество текущего выбора"
 
 #: ../gramps/plugins/quickview/filterbyname.py:87
 msgid "Right-click row (or press ENTER) to see selected items."
@@ -32152,7 +32140,7 @@ msgstr "Подробности про %(mother_name)s и %(father_name)s:"
 #: ../gramps/plugins/textreport/detdescendantreport.py:614
 #, python-format
 msgid "Spouse: %s"
-msgstr "Супруг(а): %s"
+msgstr "Супруг(-а): %s"
 
 #: ../gramps/plugins/textreport/detancestralreport.py:749
 #: ../gramps/plugins/textreport/detdescendantreport.py:618
@@ -32221,7 +32209,7 @@ msgstr "Пропускать ли повторяющихся предков."
 #: ../gramps/plugins/textreport/detancestralreport.py:894
 #: ../gramps/plugins/textreport/detdescendantreport.py:1079
 msgid "Use callname for common name"
-msgstr "Использовать имя в быту как обычное имя"
+msgstr "Использовать мирское имя по умолчанию"
 
 #: ../gramps/plugins/textreport/detancestralreport.py:895
 #: ../gramps/plugins/textreport/detdescendantreport.py:1080
@@ -32930,11 +32918,10 @@ msgstr "Подчеркнуть прозвище в имени / добавить
 msgid "Footer text"
 msgstr "Нижний колонтитул"
 
-# !!!FIXME!!!
 #: ../gramps/plugins/textreport/recordsreport.py:345
 #: ../gramps/plugins/textreport/simplebooktitle.py:191
 msgid "The style used for the footer."
-msgstr "Стиль нижней строки."
+msgstr "Вид нижней строки."
 
 #: ../gramps/plugins/textreport/simplebooktitle.py:136
 msgid "Title of the Book"
@@ -32965,7 +32952,6 @@ msgstr "Подзаголовок книги."
 msgid "Copyright %(year)d %(name)s"
 msgstr "© %(year)d %(name)s"
 
-# !!!FIXME!!!
 #: ../gramps/plugins/textreport/simplebooktitle.py:148
 msgid "Footer"
 msgstr "Нижняя строка"
@@ -33102,7 +33088,6 @@ msgstr "Информация о публикации"
 msgid "The tag to use for the report"
 msgstr "Метка для построения отчёта"
 
-# !!!FIXME!!!
 #: ../gramps/plugins/textreport/textplugins.gpr.py:37
 msgid "Ahnentafel Report"
 msgstr "Таблица предков"
@@ -33544,16 +33529,14 @@ msgstr[0] "{quantity} нарушенная связь ребёнок/семья 
 msgstr[1] "{quantity} нарушенные связи ребёнок/семья были исправлены\n"
 msgstr[2] "{quantity} нарушенных связей ребёнок/семья было исправлено\n"
 
-# !!!FIXME!!!
 #: ../gramps/plugins/tool/check.py:2434
 msgid "Non existing child"
-msgstr "Несуществующий ребёнок"
+msgstr "Отсутствующий ребёнок"
 
-# !!!FIXME!!!
 #: ../gramps/plugins/tool/check.py:2445
 #, python-format
 msgid "%(person)s was removed from the family of %(family)s\n"
-msgstr "%(person)s был(а) удален(а) из семьи %(family)s\n"
+msgstr "%(person)s удален(а) из семьи %(family)s\n"
 
 #. translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2452
@@ -34456,7 +34439,7 @@ msgstr "Телефон:"
 
 #: ../gramps/plugins/tool/ownereditor.glade:248
 msgid "_Email:"
-msgstr "Эл. почта:"
+msgstr "Электронная почта:"
 
 #: ../gramps/plugins/tool/ownereditor.glade:383
 msgid "Right-click to copy from/to Researcher Preferences"
@@ -36896,7 +36879,7 @@ msgstr "Полное имя"
 #: ../gramps/plugins/webreport/addressbooklist.py:115
 #: ../gramps/plugins/webreport/basepage.py:2079
 msgid "Web Links"
-msgstr "Веб-ссылки"
+msgstr "Ссылки"
 
 #. add section title
 #: ../gramps/plugins/webreport/basepage.py:369
@@ -36978,7 +36961,7 @@ msgstr "Контакт"
 #: ../gramps/plugins/webreport/basepage.py:1540
 #: ../gramps/plugins/webreport/webplugins.gpr.py:58
 msgid "Web Calendar"
-msgstr "Веб-календарь"
+msgstr "Сетвой календарь"
 
 #: ../gramps/plugins/webreport/basepage.py:1612
 #: ../gramps/plugins/webreport/media.py:399
@@ -37030,8 +37013,8 @@ msgid ""
 "download page and files have the same copyright as the remainder of these "
 "web pages."
 msgstr ""
-"Эта страница предназначена для того, чтобы пользователь -- создатель этого "
-"веб-сайта с семейным древом и рассказами о нём -- мог поделиться с вами "
+"Эта страница предназначена для того, чтобы пользователь -- создатель этой "
+"странички с семейным древом и рассказами о нём -- мог поделиться с вами "
 "файлами, имеющими отношение к его семье. Если ниже имеется список файлов, "
 "выбор ссылки на каждом из них позволяет загрузить соответствующий файл. Как "
 "данная страница для загрузки, так и файлы, опубликованные на ней, "
@@ -37262,7 +37245,7 @@ msgstr "Название сайта"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1640
 msgid "The title of the web site"
-msgstr "Название этого веб-сайта"
+msgstr "Название странички"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1645
 msgid "Select filter to restrict people that appear on web site"
@@ -37302,12 +37285,12 @@ msgstr "Авторское право"
 #: ../gramps/plugins/webreport/narrativeweb.py:1687
 #: ../gramps/plugins/webreport/webcal.py:1694
 msgid "The copyright to be used for the web files"
-msgstr "Авторские права, которые будут использоваться для веб-страниц"
+msgstr "Авторские права, которые будут использоваться для странички"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1696
 #: ../gramps/plugins/webreport/webcal.py:1703
 msgid "The stylesheet to be used for the web pages"
-msgstr "Таблица стилей для веб-страниц"
+msgstr "Таблица видов для страницы"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1701
 msgid "Horizontal -- Default"
@@ -37525,25 +37508,21 @@ msgstr "Заметка для использования в качестве н�
 msgid "Images Generation"
 msgstr "Создание изображений"
 
-# !!!FIXME!!!
 #: ../gramps/plugins/webreport/narrativeweb.py:1866
 msgid "Include images and media objects"
-msgstr "Включать изображения и документы"
+msgstr "Включить изображения и документы в отчёт"
 
-# !!!FIXME!!!
 #: ../gramps/plugins/webreport/narrativeweb.py:1868
 msgid "Whether to include a gallery of media objects"
-msgstr "Включать ли галерею документов"
+msgstr "Включить галерею документов в отчёт"
 
-# !!!FIXME!!!
 #: ../gramps/plugins/webreport/narrativeweb.py:1874
 msgid "Include unused images and media objects"
-msgstr "Включать неиспользуемые изображения и документы"
+msgstr "Включить неиспользуемые изображения и документы в отчёт"
 
-# !!!FIXME!!!
 #: ../gramps/plugins/webreport/narrativeweb.py:1875
 msgid "Whether to include unused or unreferenced media objects"
-msgstr "Включать ли неиспользуемые документы"
+msgstr "Включить незатронутые и неиспользуемые документы в отчёт"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1880
 msgid "Create and only use thumbnail- sized images"
@@ -37907,7 +37886,7 @@ msgstr "Название места"
 
 #: ../gramps/plugins/webreport/person.py:1453
 msgid "Call Name"
-msgstr "Имя в быту"
+msgstr "Мирское имя"
 
 #: ../gramps/plugins/webreport/person.py:1471
 msgid "Nick Name"
@@ -38070,7 +38049,7 @@ msgstr ""
 #: ../gramps/plugins/webreport/webcal.py:1062
 #: ../gramps/plugins/webreport/webcal.py:1285
 msgid "Web Calendar Report"
-msgstr "Отчёт «Веб-календарь»"
+msgstr "Отчёт «Сетевой календарь»"
 
 #: ../gramps/plugins/webreport/webcal.py:333
 #, python-format
@@ -38176,7 +38155,7 @@ msgstr "Первый год календаря"
 
 #: ../gramps/plugins/webreport/webcal.py:1755
 msgid "Enter the starting year for the calendars between 1900 - 3000"
-msgstr "Введите первый год календаря, он должен быть между 1900 - 3000"
+msgstr "оВведите первый год календаря, он должен быть между 1900 - 3000"
 
 #: ../gramps/plugins/webreport/webcal.py:1759
 msgid "End Year for the Calendar(s)"
@@ -38390,19 +38369,19 @@ msgstr "Повествовательный сайт"
 
 #: ../gramps/plugins/webreport/webplugins.gpr.py:35
 msgid "Produces web (HTML) pages for individuals, or a set of individuals"
-msgstr "Создаёт веб-страницы (HTML) для отдельных лиц или их групп"
+msgstr "Создаёт страницы (HTML) для отдельных лиц или их групп"
 
 #: ../gramps/plugins/webreport/webplugins.gpr.py:59
 msgid "Produces web (HTML) calendars."
-msgstr "Создаёт веб-календари (HTML)."
+msgstr "Создаёт сетовые календари (HTML)."
 
 #: ../gramps/plugins/webstuff/webstuff.gpr.py:36
 msgid "Webstuff"
-msgstr "Веб-инструменты"
+msgstr "Сетевые-инструменты"
 
 #: ../gramps/plugins/webstuff/webstuff.gpr.py:37
 msgid "Provides a collection of resources for the web"
-msgstr "Предоставляет набор инструментов для Веб"
+msgstr "Предоставляет набор инструментов для сети"
 
 #. id, user selectable?, translated_name, option name, fullpath,
 #. navigation target name, images, javascript
@@ -38802,7 +38781,7 @@ msgstr "Без стилевого листа"
 #~ msgid ""
 #~ "Either use the two fields below to enter coordinates(latitude and "
 #~ "longitude),"
-#~ msgstr "Введите в поля ниже координаты (широта и долгота),"
+#~ msgstr "Введите координаты в поле ниже (широта и долгота),"
 
 #~ msgid "11"
 #~ msgstr "11"
@@ -38890,7 +38869,7 @@ msgstr "Без стилевого листа"
 #~ msgstr "Ис_точник"
 
 #~ msgid "_Citation"
-#~ msgstr "_Цитата"
+#~ msgstr "_Цитату"
 
 #~ msgid "Repositor_y"
 #~ msgstr "_Хранилище"
@@ -39593,10 +39572,8 @@ msgstr "Без стилевого листа"
 #~ msgid "Collection (Short)"
 #~ msgstr "Коллекция (сокр.)"
 
-# Заполнено?
-# !!!FIXME!!!
 #~ msgid "Compiler"
-#~ msgstr "Составитель"
+#~ msgstr "Компилятор"
 
 #~ msgid "Creation date (Short)"
 #~ msgstr "Дата создания (сокр.)"
@@ -39650,10 +39627,10 @@ msgstr "Без стилевого листа"
 #~ msgstr "Том"
 
 #~ msgid "Website"
-#~ msgstr "Веб сайт"
+#~ msgstr "Страничка в сети"
 
 #~ msgid "Website (Short)"
-#~ msgstr "Веб сайт (сокр.)"
+#~ msgstr "Сокращённая страничка в сети"
 
 #~ msgid "Year"
 #~ msgstr "Год"
@@ -39888,9 +39865,8 @@ msgstr "Без стилевого листа"
 #~ msgid "Python Evaluation"
 #~ msgstr "Исполнение операций Python"
 
-# !!!FIXME!!!
 #~ msgid "Uncollected Objects"
-#~ msgstr "Неуничтоженные объекты"
+#~ msgstr "Необработаные объекты"
 
 #~ msgid "Include private records"
 #~ msgstr "Включать приватные записи"
@@ -40164,9 +40140,8 @@ msgstr "Без стилевого листа"
 #~ msgid "Error Window"
 #~ msgstr "Окно ошибок"
 
-# !!!FIXME!!!
 #~ msgid "Uncollected Objects Tool"
-#~ msgstr "Неуничтоженные Объекты"
+#~ msgstr "Инструмент необработаных объектов"
 
 #~ msgid "Close Window"
 #~ msgstr "Закрыть окно"
@@ -40387,7 +40362,7 @@ msgstr "Без стилевого листа"
 #~ msgstr "Телефон:"
 
 #~ msgid "Email:"
-#~ msgstr "Эл. почта:"
+#~ msgstr "Электронная почта:"
 
 #~ msgid "Select Save File"
 #~ msgstr "Выберите файл для сохранения"
@@ -40817,9 +40792,8 @@ msgstr "Без стилевого листа"
 #~ msgid "<b>Available Gramps Updates for Addons</b>"
 #~ msgstr "<b>Доступные обновления для дополнений</b>"
 
-# !!!FIXME!!!
 #~ msgid "<b>Uncollected Objects</b>"
-#~ msgstr "<b>Неуничтоженные объекты</b>"
+#~ msgstr "<b>Необработаные объекты</b>"
 
 #~ msgid "- default -"
 #~ msgstr "- по умолчанию -"

--- a/po/ru.po
+++ b/po/ru.po
@@ -18991,7 +18991,7 @@ msgstr "Конфигурация"
 #: ../gramps/gui/plug/report/_styleeditor.py:115
 #: ../gramps/gui/plug/report/_styleeditor.py:270
 msgid "Style"
-msgstr "Слиль"
+msgstr "Стиль"
 
 #. better to 'Show siblings of\nthe center person
 #. Spouse_disp = EnumeratedListOption(_("Show spouses of\nthe center "
@@ -23486,7 +23486,7 @@ msgstr ""
 
 #: ../gramps/plugins/gramplet/leak.py:103
 msgid "Uncollected object"
-msgstr "Необработаный объект"
+msgstr "Необработанный объект"
 
 #: ../gramps/plugins/gramplet/leak.py:112
 msgid "Refresh"
@@ -23509,7 +23509,7 @@ msgstr "%d ссылается на этот объект"
 #: ../gramps/plugins/gramplet/leak.py:198
 #, python-format
 msgid "Uncollected Objects: %s"
-msgstr "Необработаные объекты: %s"
+msgstr "Необработанные объекты: %s"
 
 #: ../gramps/plugins/gramplet/leak.py:239
 msgid "Reference Error"
@@ -24711,11 +24711,11 @@ msgstr "Включать описание деятельности"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:925
 msgid "Include date, description and place of all occupations"
-msgstr "Включать даты, описания и места всех деятельностей"
+msgstr "Включать даты, описания и места всех видов деятельности"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:927
 msgid "Whether to include the last occupation"
-msgstr "Включать ли последнюю деятельность"
+msgstr "Включать ли последний вид деятельности"
 
 #: ../gramps/plugins/graph/gvrelgraph.py:931
 msgid "Include relationship debugging numbers also"
@@ -36959,7 +36959,7 @@ msgstr "Контакт"
 #: ../gramps/plugins/webreport/basepage.py:1540
 #: ../gramps/plugins/webreport/webplugins.gpr.py:58
 msgid "Web Calendar"
-msgstr "Сетвой календарь"
+msgstr "Сетевой календарь"
 
 #: ../gramps/plugins/webreport/basepage.py:1612
 #: ../gramps/plugins/webreport/media.py:399

--- a/po/ru.po
+++ b/po/ru.po
@@ -9985,10 +9985,9 @@ msgstr "Графики"
 msgid "Trees"
 msgstr "Древа"
 
-# !!!FIXME!!! изображение?
 #: ../gramps/gen/plug/report/_constants.py:55
 msgid "Graphics"
-msgstr "Графика"
+msgstr "Диаграмма"
 
 #: ../gramps/gen/plug/report/endnotes.py:61
 #: ../gramps/plugins/textreport/ancestorreport.py:376
@@ -11462,11 +11461,11 @@ msgstr ""
 "  <b>Главное, Главное[пр], или …[фам] …[св]</b> - полностью главная фамилия, "
 "префикс, только фамилия, связка\n"
 "  <b>Отчество, Отчество[пр], или …[им] …[св]</b> - аналогично Главное… для "
-"отчества или матчиства\n"
+"отчества или матчества\n"
 "  <b>Семпрозвище</b> - семейное прозвище            <b>Неглавные</b>   - "
 "фамилии без главной+отчества\n"
 "  <b>Префикс</b>     - приставки («де», «ван», ...) <b>Безотчества</b> - "
-"фамилии без отчества/матчиства\n"
+"фамилии без отчества/матчества\n"
 "  <b>Списокфо</b>    - фамилии и отчества (без префиксов и связок)\n"
 "</tt>\n"
 "Укажите ключевое слово ЗАГЛАВНЫМИ БУКВАМИ, чтобы соответствующие данные\n"
@@ -11828,7 +11827,7 @@ msgstr "Редактировать"
 
 #: ../gramps/gui/configure.py:1208
 msgid "Consider single pa/matronymic as surname"
-msgstr "Использовать одиночное отчество/матчиство как фамилию"
+msgstr "Использовать одиночное отчество/матчество как фамилию"
 
 #: ../gramps/gui/configure.py:1240
 msgid "Place format (auto place title)"
@@ -11864,7 +11863,7 @@ msgstr "Угадывание фамилий"
 
 #: ../gramps/gui/configure.py:1308
 msgid "Default family relationship"
-msgstr "Межличностное отношения по умолчанию"
+msgstr "Межличностное отношение по умолчанию"
 
 #: ../gramps/gui/configure.py:1315
 msgid "Height multiple surname box (pixels)"
@@ -13871,7 +13870,7 @@ msgstr "Сохранение события невозможно. ID уже су
 
 #: ../gramps/gui/editors/editevent.py:264
 msgid "The event type cannot be empty"
-msgstr "События не может быть безымянным"
+msgstr "Событие не может быть безымянным"
 
 #: ../gramps/gui/editors/editevent.py:270
 #, python-format
@@ -17703,7 +17702,7 @@ msgstr "_Руководство пользователя"
 
 #: ../gramps/gui/grampsgui.py:56
 msgid "_View"
-msgstr "_Облик"
+msgstr "_Вид"
 
 #: ../gramps/gui/grampsgui.py:56
 msgid "_Windows"
@@ -18992,7 +18991,7 @@ msgstr "Конфигурация"
 #: ../gramps/gui/plug/report/_styleeditor.py:115
 #: ../gramps/gui/plug/report/_styleeditor.py:270
 msgid "Style"
-msgstr "Вид"
+msgstr "Слиль"
 
 #. better to 'Show siblings of\nthe center person
 #. Spouse_disp = EnumeratedListOption(_("Show spouses of\nthe center "
@@ -37241,7 +37240,7 @@ msgstr "Моё семейное древо"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1639
 msgid "Web site title"
-msgstr "Название сайта"
+msgstr "Название странички"
 
 #: ../gramps/plugins/webreport/narrativeweb.py:1640
 msgid "The title of the web site"


### PR DESCRIPTION
Новый перевод для неких случаев, но улучшающие понимание и выглядит более уместно. Также применены русские переводы слов, которые использовали до того англицизмы.

На своём компе употребляю с версией "Мирское имя" вместо "Имя в быту" - так как оно имеет название ... но думая что бытовое имя тоже довольно неплохо описывает его.

Updated Russian language.
Fixed some not logical, incorrect or misleading translations.
Also there are some minor issues left according the following:

- gender-> unknown -> not same as unknown at its own
- add-> family -> not same as drop-down entry family in events
- add-> citation -> not same as in type: citation
- spouse in tabs: -> male / female differentiation
- add-> note: -> not same as drop-down entry & titles


**Commit needs review, as it may conflict - i'd edit BOLT texts**