### PR TITLE
Fix some Python syntax errors that appear in v3.8.x

### DIFF
--- a/gramps/gen/plug/_manager.py
+++ b/gramps/gen/plug/_manager.py
@@ -83,7 +83,7 @@ class BasePluginManager:
 
     def __init__(self):
         """ This function should only be run once by get_instance() """
-        if BasePluginManager.__instance is not 1:
+        if BasePluginManager.__instance != 1:
             raise Exception("This class is a singleton. "
                             "Use the get_instance() method")
 

--- a/gramps/gen/plug/_pluginreg.py
+++ b/gramps/gen/plug/_pluginreg.py
@@ -1135,7 +1135,7 @@ class PluginRegister:
 
     def __init__(self):
         """ This function should only be run once by get_instance() """
-        if PluginRegister.__instance is not 1:
+        if PluginRegister.__instance != 1:
             raise Exception("This class is a singleton. "
                             "Use the get_instance() method")
         self.stable_only = True

--- a/gramps/gui/pluginmanager.py
+++ b/gramps/gui/pluginmanager.py
@@ -71,7 +71,7 @@ class GuiPluginManager(Callback):
 
     def __init__(self):
         """ This function should only be run once by get_instance() """
-        if GuiPluginManager.__instance is not 1:
+        if GuiPluginManager.__instance != 1:
             raise Exception("This class is a singleton. "
                             "Use the get_instance() method")
 

--- a/gramps/plugins/lib/maps/messagelayer.py
+++ b/gramps/plugins/lib/maps/messagelayer.py
@@ -113,7 +113,7 @@ class MessageLayer(GObject.GObject, osmgpsmap.MapLayer):
         """
         Add a message
         """
-        self.message += "\n%s" % message if self.message is not "" else message
+        self.message += "\n%s" % message if self.message else message
 
     def do_draw(self, gpsmap, ctx):
         """


### PR DESCRIPTION
Fixes #11641

The 'is not 1' expression works with cpython since the cpython implementation has already created small integers as an optimization and doesn't have to create them as it does other objects. And they are used whenever needed. This is not true for all python implementations, so Python 3.8.x decided to add this warning.