### PR TITLE
Fix RemoveUnused tool for crash caused by PyGObject problem

### DIFF
--- a/gramps/plugins/tool/removeunused.py
+++ b/gramps/plugins/tool/removeunused.py
@@ -172,7 +172,11 @@ class RemoveUnused(tool.Tool, ManagedWindow, UpdateCallback):
                                         GObject.TYPE_STRING,
                                         GObject.TYPE_STRING,
                                         GObject.TYPE_STRING)
-        self.sort_model = self.real_model.sort_new_with_model()
+        # a short term Gtk introspection means we need to try both ways:
+        if hasattr(self.real_model, "sort_new_with_model"):
+            self.sort_model = self.real_model.sort_new_with_model()
+        else:
+            self.sort_model = Gtk.TreeModelSort.new_with_model(self.real_model)
         self.warn_tree.set_model(self.sort_model)
 
         self.renderer = Gtk.CellRendererText()


### PR DESCRIPTION
Fixes #11634  AttributeError: 'ListStore' object has no attribute 'sort_new_with_model'

PyGObject 3.26.1 (and possibly earlier) has mistakenly removed the original function in trying to fix something else.  It appears that it will be fixed again in a newer release, but for now we need to try both ways of creating a child model.