### PR TITLE
Narweb: incorrect place index if alternate names

### DIFF
--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -839,6 +839,9 @@ class NavWebReport(Report):
                 name = ""
         if config.get('preferences.place-auto'):
             place_name = _pd.display_event(self._db, event)
+            rplace_name = _pd.display(self._db, place)
+            if place_name != rplace_name:
+                place_name = rplace_name
         else:
             place_name = place.get_title()
         if event:


### PR DESCRIPTION
In the narrative web, the first phase is to select all places.
For each object, if we have a place, we memorize that depending on date.
When we create the place pages, we start from these information in the place table. At this moment, we have no date. So the sort by primary names gives an incorrect index list and the place names are incorrect.

If the primary name is different, from the found name, that means it's an alternate name.
In this case, we set the place name to the primary name in place of the alternate name.

Fixes #11645