### PR TITLE
Fix GEDCOM import for bad source title when sources precede references.

### DIFF
--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -7776,7 +7776,8 @@ class GedcomParser(UpdateCallback):
             # have got deleted by Chack and repair because the record is empty.
             # If we find the source record, the title is overwritten in
             # __source_title.
-            src.set_title(line.data)
+            if not src.title:
+                src.set_title(line.data)
         self.dbase.commit_source(src, self.trans)
         self.__parse_source_reference(citation, level, src.handle, state)
         citation.set_reference_handle(src.handle)


### PR DESCRIPTION
Fixes #11610

A user provided a GEDCOM file where the sources were early in the file, before their references.  The usual practice for GEDCOM files is to put the level 0 records in this order (from the GEDCOM specification):
```
n <<FAM_RECORD>>
|
n <<INDIVIDUAL_RECORD>>
|
n <<MULTIMEDIA_RECORD>>
|
n <<NOTE_RECORD>>
|
n <<REPOSITORY_RECORD>>
|
n <<SOURCE_RECORD>>
|
n <<SUBMITTER_RECORD>>

```
Our importer seems to have assumed the usual order, so did the wrong thing when out of the usual order.  The is PR fixes the particular issue with the source title; I did not exhaustively test to see if other order dependent issues might be lurking.