### PR TITLE
Narweb: incorrect place index if alternate names

### DIFF
--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -2631,9 +2631,6 @@ class BasePage: # pylint: disable=C1001
         @param: place -- Place object from the database
         @param: table -- Table from Placedetail
         """
-        if place in self.report.visited:
-            return None
-        self.report.visited.append(place)
         # add table body
         tbody = Html("tbody")
         table += tbody
@@ -3101,7 +3098,7 @@ class BasePage: # pylint: disable=C1001
 
         @param: output_file  -- Open file that is being written to
         @param: htmlinstance -- Web page created with libhtml
-                                src/plugins/lib/libhtml.py
+                                gramps/plugins/lib/libhtml.py
         """
         htmlinstance.write(partial(print, file=output_file))
 

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -421,14 +421,14 @@ def sort_people(dbase, handle_list, rlocale=glocale):
 
     return sorted_lists
 
-def sort_places(dbase, handle_list, handle_places, rlocale=glocale):
+def sort_places(dbase, handle_list, rlocale=glocale):
     """
     will sort the database places
     """
     pname_sub = defaultdict(list)
 
     for place_name in handle_list.keys():
-        (hdle, pname, ig_id, event) = handle_list[place_name]
+        (hdle, pname, dummy_id, event) = handle_list[place_name]
         place = dbase.get_place_from_handle(hdle)
         pname = _pd.display(dbase, place)
         apname = _pd.display_event(dbase, event)

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -421,18 +421,21 @@ def sort_people(dbase, handle_list, rlocale=glocale):
 
     return sorted_lists
 
-def sort_places(dbase, handle_list, rlocale=glocale):
+def sort_places(dbase, handle_list, handle_places, rlocale=glocale):
     """
-    will sort the database place
+    will sort the database places
     """
     pname_sub = defaultdict(list)
-    sortnames = {}
 
-    for place_handle in handle_list:
-        place = dbase.get_place_from_handle(place_handle)
+    for place_name in handle_list.keys():
+        (hdle, pname, ig_id, event) = handle_list[place_name]
+        place = dbase.get_place_from_handle(hdle)
         pname = _pd.display(dbase, place)
-        sortnames[place_handle] = pname
-        pname_sub[pname].append(place_handle)
+        apname = _pd.display_event(dbase, event)
+
+        pname_sub[pname].append(hdle)
+        if pname != apname:
+            pname_sub[apname].append(hdle)
 
     sorted_lists = []
     temp_list = sorted(pname_sub, key=rlocale.sort_key)
@@ -440,10 +443,7 @@ def sort_places(dbase, handle_list, rlocale=glocale):
     for name in temp_list:
         if isinstance(name, bytes):
             name = name.decode('utf-8')
-        slist = sorted(((sortnames[x], x) for x in pname_sub[name]),
-                       key=lambda x: rlocale.sort_key(x[0]))
-        for entry in slist:
-            sorted_lists.append(entry)
+        sorted_lists.append((name, pname_sub[name][0]))
 
     return sorted_lists
 

--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -63,7 +63,7 @@ from decimal import getcontext
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.lib import (EventType, Name,
                             Person,
-                            Family, Event, Place, Source,
+                            Family, Event, Place, PlaceName, Source,
                             Citation, Media, Repository, Note, Tag)
 from gramps.gen.plug.menu import (PersonOption, NumberOption, StringOption,
                                   BooleanOption, EnumeratedListOption,
@@ -524,7 +524,7 @@ class NavWebReport(Report):
         and the handle for the object that refers to the 'key' object.
         """
         _obj_class_list = (Person, Family, Event, Place, Source, Citation,
-                           Media, Repository, Note, Tag)
+                           Media, Repository, Note, Tag, PlaceName)
 
         # setup a dictionary of the required structure
         self.obj_dict = defaultdict(lambda: defaultdict(set))
@@ -881,8 +881,10 @@ class NavWebReport(Report):
                 name = ""
         if config.get('preferences.place-auto'):
             place_name = _pd.display_event(self._db, event)
+            pplace_name = _pd.display(self._db, place)
         else:
             place_name = place.get_title()
+            pplace_name = place_name
         if event:
             if self.reference_sort:
                 role_or_date = name
@@ -899,6 +901,11 @@ class NavWebReport(Report):
                                            False) + self.ext
         self.obj_dict[Place][place_handle] = (place_fname, place_name,
                                               place.gramps_id, event)
+        self.obj_dict[PlaceName][place_name] = (place_handle, place_name,
+                                                place.gramps_id, event)
+        if place_name != pplace_name:
+            self.obj_dict[PlaceName][pplace_name] = (place_handle, pplace_name,
+                                                     place.gramps_id, event)
         self.bkref_dict[Place][place_handle].add((bkref_class, bkref_handle,
                                                   role_or_date
                                                  ))

--- a/gramps/plugins/webreport/place.py
+++ b/gramps/plugins/webreport/place.py
@@ -62,7 +62,7 @@ from gramps.gen.display.place import displayer as _pd
 from gramps.plugins.webreport.basepage import BasePage
 from gramps.plugins.webreport.common import (first_letter,
                                              alphabet_navigation, GOOGLE_MAPS,
-                                             primary_difference, _KEYPLACE,
+                                             primary_difference,
                                              get_index_letter, FULLCLEAR,
                                              MARKER_PATH, OPENLAYER,
                                              OSM_MARKERS, STAMEN_MARKERS,
@@ -128,17 +128,15 @@ class PlacePages(BasePage):
                 index += 1
                 self.placepage(self.report, title, p_handle[0], place_name)
             step()
-            self.placelistpage(self.report, title,
-                               self.report.obj_dict[Place].keys())
+            self.placelistpage(self.report, title)
 
-    def placelistpage(self, report, title, place_handles):
+    def placelistpage(self, report, title):
         """
         Create a place index
 
         @param: report        -- The instance of the main report class for
                                  this report
         @param: title         -- Is the title of the web page
-        @param: place_handles -- The handle for the place to add
         """
         BasePage.__init__(self, report, title)
 
@@ -203,7 +201,6 @@ class PlacePages(BasePage):
 
                 handle_list = sort_places(self.r_db,
                                           self.report.obj_dict[PlaceName],
-                                          self.report.obj_dict[Place],
                                           self.rlocale)
                 first = True
 
@@ -297,7 +294,7 @@ class PlacePages(BasePage):
         """
         place = report.database.get_place_from_handle(place_handle)
         if not place:
-            return
+            return None
         BasePage.__init__(self, report, title, place.get_gramps_id())
         self.bibli = Bibliography()
         ldatec = place.get_change_time()
@@ -489,11 +486,10 @@ class PlacePages(BasePage):
         # and close the file
         if place_name == apname: # store only the primary named page
             if place in self.report.visited: # only the first time
-                self.report.close_file(output_file, sio, date)
+                self.report.close_file(output_file, sio, None)
                 return None
             self.report.visited.append(place)
             self.xhtml_writer(placepage, output_file, sio, ldatec)
-
 
 def get_first_letters(place_list, rlocale=glocale):
     """
@@ -521,4 +517,3 @@ def get_first_letters(place_list, rlocale=glocale):
 
     # return menu set letters for alphabet_navigation
     return index_list
-

--- a/gramps/plugins/webreport/place.py
+++ b/gramps/plugins/webreport/place.py
@@ -49,17 +49,18 @@ import logging
 # Gramps module
 #------------------------------------------------
 from gramps.gen.const import GRAMPS_LOCALE as glocale
-from gramps.gen.lib import (PlaceType, Place)
+from gramps.gen.lib import (PlaceType, Place, PlaceName)
 from gramps.gen.plug.report import Bibliography
 from gramps.plugins.lib.libhtml import Html
 from gramps.gen.utils.place import conv_lat_lon
 from gramps.gen.utils.location import get_main_location
+from gramps.gen.display.place import displayer as _pd
 
 #------------------------------------------------
 # specific narrative web import
 #------------------------------------------------
 from gramps.plugins.webreport.basepage import BasePage
-from gramps.plugins.webreport.common import (get_first_letters, first_letter,
+from gramps.plugins.webreport.common import (first_letter,
                                              alphabet_navigation, GOOGLE_MAPS,
                                              primary_difference, _KEYPLACE,
                                              get_index_letter, FULLCLEAR,
@@ -121,10 +122,11 @@ class PlacePages(BasePage):
                                   len(self.report.obj_dict[Place]) + 1
                                  ) as step:
             index = 1
-            for place_handle in self.report.obj_dict[Place]:
+            for place_name in self.report.obj_dict[PlaceName].keys():
                 step()
+                p_handle = self.report.obj_dict[PlaceName][place_name]
                 index += 1
-                self.placepage(self.report, title, place_handle)
+                self.placepage(self.report, title, p_handle[0], place_name)
             step()
             self.placelistpage(self.report, title,
                                self.report.obj_dict[Place].keys())
@@ -158,8 +160,8 @@ class PlacePages(BasePage):
             placelist += Html("p", msg, id="description")
 
             # begin alphabet navigation
-            index_list = get_first_letters(self.r_db, place_handles,
-                                           _KEYPLACE, rlocale=self.rlocale)
+            pkeys = self.report.obj_dict[PlaceName].keys()
+            index_list = get_first_letters(pkeys, rlocale=self.rlocale)
             alpha_nav = alphabet_navigation(index_list, self.rlocale)
             if alpha_nav is not None:
                 placelist += alpha_nav
@@ -199,7 +201,9 @@ class PlacePages(BasePage):
                         ]
                     )
 
-                handle_list = sort_places(self.r_db, place_handles,
+                handle_list = sort_places(self.r_db,
+                                          self.report.obj_dict[PlaceName],
+                                          self.report.obj_dict[Place],
                                           self.rlocale)
                 first = True
 
@@ -207,12 +211,12 @@ class PlacePages(BasePage):
                 tbody = Html("tbody")
                 table += tbody
 
-                for (dummy_pname, place_handle) in handle_list:
+                for (pname, place_handle) in handle_list:
                     place = self.r_db.get_place_from_handle(place_handle)
                     if place:
                         if place.get_change_time() > ldatec:
                             ldatec = place.get_change_time()
-                        plc_title = self.report.obj_dict[Place][place_handle][1]
+                        plc_title = pname
                         main_location = get_main_location(self.r_db, place)
 
                         if plc_title and plc_title != " ":
@@ -282,7 +286,7 @@ class PlacePages(BasePage):
         # and close the file
         self.xhtml_writer(placelistpage, output_file, sio, ldatec)
 
-    def placepage(self, report, title, place_handle):
+    def placepage(self, report, title, place_handle, place_name):
         """
         Create a place page
 
@@ -296,10 +300,11 @@ class PlacePages(BasePage):
             return
         BasePage.__init__(self, report, title, place.get_gramps_id())
         self.bibli = Bibliography()
-        place_name = self.report.obj_dict[Place][place_handle][1]
         ldatec = place.get_change_time()
+        apname = _pd.display(self.r_db, place)
 
-        output_file, sio = self.report.create_file(place_handle, "plc")
+        if place_name == apname: # store only the primary named page
+            output_file, sio = self.report.create_file(place_handle, "plc")
         self.uplink = True
         self.page_title = place_name
         (placepage, head, dummy_body,
@@ -482,4 +487,38 @@ class PlacePages(BasePage):
 
         # send page out for processing
         # and close the file
-        self.xhtml_writer(placepage, output_file, sio, ldatec)
+        if place_name == apname: # store only the primary named page
+            if place in self.report.visited: # only the first time
+                self.report.close_file(output_file, sio, date)
+                return None
+            self.report.visited.append(place)
+            self.xhtml_writer(placepage, output_file, sio, ldatec)
+
+
+def get_first_letters(place_list, rlocale=glocale):
+    """
+    get the first letters of the place name list
+
+    @param: handle_list -- The place name list
+
+    The first letter (or letters if there is a contraction) are extracted from
+    """
+    index_list = []
+    for place in place_list:
+        ltr = first_letter(place)
+        index_list.append(ltr)
+
+    # Now remove letters where there is not a primary difference
+    index_list.sort(key=rlocale.sort_key)
+    first = True
+    prev_index = None
+    for nkey in index_list[:]:   #iterate over a slice copy of the list
+        if first or primary_difference(prev_index, nkey, rlocale):
+            first = False
+            prev_index = nkey
+        else:
+            index_list.remove(nkey)
+
+    # return menu set letters for alphabet_navigation
+    return index_list
+


### PR DESCRIPTION
The places page index doesn't show the alternate names used.

In the narrative web, the first phase is to select all places.
For each object, if we have a place, we memorize that depending on date.
When we create the place pages, we start from these information in the place
table. At this moment, we have no date.
So the sort by primary names gives an incorrect index list and the alternate
place names are missing.

Fixes #11645