### PR TITLE
Narrated Website Google Maps Output JS Warning

### DIFF
--- a/gramps/plugins/webreport/person.py
+++ b/gramps/plugins/webreport/person.py
@@ -705,9 +705,9 @@ class PersonPages(BasePage):
 
         # add MapService specific javascript code
         if self.mapservice == "Google":
-            src_js = GOOGLE_MAPS + "api/js?sensor=false"
+            src_js = GOOGLE_MAPS + "api/js"
             if self.googlemapkey:
-                src_js += "&key=" + self.googlemapkey
+                src_js += "?key=" + self.googlemapkey
             head += Html("script", type="text/javascript",
                          src=src_js, inline=True)
         else:

--- a/gramps/plugins/webreport/place.py
+++ b/gramps/plugins/webreport/place.py
@@ -367,10 +367,10 @@ class PlacePages(BasePage):
                                  media="screen", rel="stylesheet")
 
                     # add MapService specific javascript code
-                    src_js = GOOGLE_MAPS + "api/js?sensor=false"
+                    src_js = GOOGLE_MAPS + "api/js"
                     if self.mapservice == "Google":
                         if self.googlemapkey:
-                            src_js += "&key=" + self.googlemapkey
+                            src_js += "?key=" + self.googlemapkey
                         head += Html("script", type="text/javascript",
                                      src=src_js, inline=True)
                     else:


### PR DESCRIPTION
SensorNotRequired:
The sensor parameter is no longer required for the Maps JavaScript API.
It won't prevent the Maps JavaScript API from working correctly, but we
recommend that you remove the sensor parameter from the script element.

Fixes #011654