### PR TITLE
Add uistate to tree views filter initialization

### DIFF
--- a/gramps/gui/views/treemodels/treebasemodel.py
+++ b/gramps/gui/views/treemodels/treebasemodel.py
@@ -587,7 +587,8 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
         if dfilter:
             cdb = CacheProxyDb(self.db)
             for handle in dfilter.apply(cdb, tree=True,
-                                        user=User(parent=self.uistate.window)):
+                                        user=User(parent=self.uistate.window,
+                                                  uistate=self.uistate)):
                 status_ppl.heartbeat()
                 data = data_map(handle)
                 add_func(handle, data)


### PR DESCRIPTION
Fixes #11657

When trying to develop a new filter that allows access to the current view 'active' person etc. it was discovered that this doesn't work for tree views.

It turns out that when sidebar filters are processed a new gui 'User' class was used, and it did not include the current uistate.