### PR TITLE
Relationship Graph; Add option for 'offset parents', replacing/expanding 'use subgraph'

### DIFF
--- a/gramps/gen/plug/docgen/graphdoc.py
+++ b/gramps/gen/plug/docgen/graphdoc.py
@@ -258,13 +258,6 @@ class GVOptions:
                            "between columns."))
         menu.add_option(category, "ranksep", ranksep)
 
-        use_subgraphs = BooleanOption(_('Use subgraphs'), True)
-        use_subgraphs.set_help(_("Subgraphs can help Graphviz position "
-                                 "spouses together, but with non-trivial "
-                                 "graphs will result in longer lines and "
-                                 "larger graphs."))
-        menu.add_option(category, "usesubgraphs", use_subgraphs)
-
         ################################
         category = _("Note")
         ################################
@@ -450,7 +443,6 @@ class GVDocBase(BaseDoc, GVDoc):
         self.ranksep = get_option('ranksep').get_value()
         self.ratio = get_option('ratio').get_value()
         self.vpages = get_option('v_pages').get_value()
-        self.usesubgraphs = get_option('usesubgraphs').get_value()
         self.spline = get_option('spline').get_value()
         self.node_ports = get_option('node_ports').get_value()
 

--- a/gramps/plugins/graph/gvfamilylines.py
+++ b/gramps/plugins/graph/gvfamilylines.py
@@ -181,6 +181,13 @@ class FamilyLinesOptions(MenuReportOptions):
 
         stdoptions.add_date_format_option(menu, category_name, locale_opt)
 
+        use_subgraphs = BooleanOption(_('Use subgraphs'), True)
+        use_subgraphs.set_help(_("Subgraphs can help Graphviz position "
+                                 "spouses together, but with non-trivial "
+                                 "graphs will result in longer lines and "
+                                 "larger graphs."))
+        add_option("usesubgraphs", use_subgraphs)
+
         # --------------------------------
         add_option = partial(menu.add_option, _('People of Interest'))
         # --------------------------------

--- a/gramps/plugins/graph/gvrelgraph.py
+++ b/gramps/plugins/graph/gvrelgraph.py
@@ -497,7 +497,8 @@ class RelGraphReport(Report):
             self.doc.start_subgraph(fam_id)
             f_handle = fam.get_father_handle()
             m_handle = fam.get_mother_handle()
-            if f_handle and m_handle:
+            if(self.use_subgraphs == 2 and f_handle in self.persons and
+               m_handle in self.persons):
                 father = self._db.get_person_from_handle(f_handle)
                 mother = self._db.get_person_from_handle(m_handle)
                 fcount = 0
@@ -968,6 +969,22 @@ class RelGraphOptions(MenuReportOptions):
         showfamily.set_help(_("Families will show up as ellipses, linked "
                               "to parents and children."))
         add_option("showfamily", showfamily)
+
+        use_subgraphs = EnumeratedListOption(_('Parent grouping'), 0)
+        use_subgraphs.add_item(0, _('Normal'))
+        use_subgraphs.add_item(1, _('Parents together'))
+        use_subgraphs.add_item(2, _('Parents offset'))
+        use_subgraphs.set_help(_(
+            "In the 'Normal' setting parents will be located to keep most "
+            "lines short.\n"
+            "The 'Parents together' setting can help position "
+            "spouses next to each other, but with non-trivial graphs will "
+            "result in longer lines and larger graphs.\n"
+            "The Parents offset setting will also try to put spouses near "
+            "each other, however they will be offset from each other.  This "
+            "will tend to make graphs with many people in a generation more "
+            "square."))
+        add_option("usesubgraphs", use_subgraphs)
 
     def __update_filters(self):
         """


### PR DESCRIPTION
The relationship graph was changed in https://github.com/gramps-project/gramps/pull/733 to make it ‘more compact’ and ‘beautiful’ according to the author.  I don't care for it and several others have filed bug reports and complained about it.
https://gramps.discourse.group/t/spouses-misplaced-on-relationship-graph/299/4
https://gramps-project.org/bugs/view.php?id=11550
https://gramps-project.org/bugs/view.php?id=11494
https://sourceforge.net/p/gramps/mailman/gramps-users/thread/CABN8Op8RGCcDV90o9kZsiMASLU0-HiPZHxb4rP3WJP%3DC1UvDkA%40mail.gmail.com/#msg36977242

This PR makes that change an option.  The original 'Use subgraphs' option has been removed from the GraphViz Options tab.  There is now a 3-way choice ('normal', 'Parents together', 'Parents offset') in the 'Graph Style' tab.  It also fixes the user bug mentioned in the sourceforge thread.

Because the original 'Use subgraphs' option was removed from the GraphViz Options tab, the Family Lines graph was also slightly affected.  I put the 'Use subgraphs' option back into the 'Report Options (2)' tab for that report.
