### PR TITLE
Allow filter rules to access Family filters

### DIFF
--- a/gramps/gui/editors/filtereditor.py
+++ b/gramps/gui/editors/filtereditor.py
@@ -530,6 +530,8 @@ class EditRule(ManagedWindow):
                 # filters of another namespace, name may be same as caller!
                 elif v == _('Person filter name:'):
                     t = MyFilters(self.filterdb.get_filters('Person'))
+                elif v == _('Family filter name:'):
+                    t = MyFilters(self.filterdb.get_filters('Family'))
                 elif v == _('Event filter name:'):
                     t = MyFilters(self.filterdb.get_filters('Event'))
                 elif v == _('Source filter name:'):


### PR DESCRIPTION
Some addons have recently been created which add to the filter rules.  One area that was not 'clean' was to add rules that included matching Family Filters.  This was difficult because the filtereditor never included the "Family filter name:" as a potential rule parameter.

This PR corrects this.