### PR TITLE
NarrativeWeb should show patronymic in individuals

### DIFF
--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -2393,9 +2393,6 @@ class BasePage: # pylint: disable=C1001
             # not necessarily mean that a page has been generated
             (link, name, gid) = result
 
-        if name_style == _NAME_STYLE_FIRST and person:
-            name = _get_short_name(person.get_gender(),
-                                   person.get_primary_name())
         name = html_escape(name)
         # construct the result
         if not self.noid and gid != "":

--- a/gramps/plugins/webreport/person.py
+++ b/gramps/plugins/webreport/person.py
@@ -70,7 +70,7 @@ from gramps.gen.proxy import LivingProxyDb
 from gramps.plugins.webreport.basepage import BasePage
 from gramps.plugins.webreport.common import (get_first_letters, _KEYPERSON,
                                              alphabet_navigation, sort_people,
-                                             _NAME_STYLE_FIRST, first_letter,
+                                             first_letter,
                                              get_index_letter, add_birthdate,
                                              primary_difference, FULLCLEAR,
                                              _find_birth_date, _find_death_date,
@@ -210,9 +210,9 @@ class PersonPages(BasePage):
                 thead += trow
 
                 # show surname and first name
-                trow += Html("th", self._("Surname"), class_="ColumnSurname",
+                trow += Html("th", self._("Group as"), class_="ColumnSurname",
                              inline=True)
-                trow += Html("th", self._("Given Name"), class_="ColumnName",
+                trow += Html("th", self._("Name"), class_="ColumnName",
                              inline=True)
 
                 if showbirth:
@@ -294,8 +294,7 @@ class PersonPages(BasePage):
                         tcell += "&nbsp;"
 
                     # firstname column
-                    link = self.new_person_link(person_handle, person=person,
-                                                name_style=_NAME_STYLE_FIRST)
+                    link = self.new_person_link(person_handle, person=person)
                     trow += Html("td", link, class_="ColumnName")
 
                     # birth column

--- a/gramps/plugins/webreport/surname.py
+++ b/gramps/plugins/webreport/surname.py
@@ -56,7 +56,7 @@ from gramps.plugins.lib.libhtml import Html
 # specific narrative web import
 #------------------------------------------------
 from gramps.plugins.webreport.basepage import BasePage
-from gramps.plugins.webreport.common import (name_to_md5, _NAME_STYLE_FIRST,
+from gramps.plugins.webreport.common import (name_to_md5,
                                              _find_birth_date, _find_death_date,
                                              FULLCLEAR, html_escape)
 
@@ -134,7 +134,7 @@ class SurnamePage(BasePage):
                 thead += trow
 
                 # Name Column
-                trow += Html("th", self._("Given Name"), class_="ColumnName",
+                trow += Html("th", self._("Name"), class_="ColumnName",
                              inline=True)
 
                 if showbirth:
@@ -170,8 +170,7 @@ class SurnamePage(BasePage):
 
                     # firstname column
                     link = self.new_person_link(person_handle, uplink=True,
-                                                person=person,
-                                                name_style=_NAME_STYLE_FIRST)
+                                                person=person)
                     trow += Html("td", link, class_="ColumnName")
 
                     # birth column


### PR DESCRIPTION
In the individuals and in surnames pages, we should show the complete name
like defined in the display tab from the narrative web configuration.

Fixes #04404