### PR TITLE
enable "file:///" URI paths for addons location

### DIFF
--- a/gramps/gen/plug/utils.py
+++ b/gramps/gen/plug/utils.py
@@ -215,12 +215,12 @@ def available_updates():
                 LOG.warning("Failed to open addon metadata for {lang} {url}: {err}".
                         format(lang=lang, url=URL, err=err))
                 fp = None
-        if fp and fp.getcode() == 200: # ok
+        if fp and (fp.getcode() == 200 or fp.file):
             break
 
     pmgr = BasePluginManager.get_instance()
     addon_update_list = []
-    if fp and fp.getcode() == 200:
+    if fp and (fp.getcode() == 200 or fp.file):
         lines = list(fp.readlines())
         count = 0
         for line in lines:
@@ -282,7 +282,8 @@ def load_addon_file(path, callback=None):
     import tarfile
     if (path.startswith("http://") or
         path.startswith("https://") or
-        path.startswith("ftp://")):
+        path.startswith("ftp://") or
+        path.startswith("file://")):
         try:
             fp = urlopen_maybe_no_check_cert(path)
         except:
@@ -291,7 +292,7 @@ def load_addon_file(path, callback=None):
             return False
     else:
         try:
-            fp = open(path)
+            fp = open(path, 'rb')
         except:
             if callback:
                 callback(_("Unable to open '%s'") % path)


### PR DESCRIPTION
I failed to open addons from a local folder. I didn't see a reason why a locally built addons folder should not be opened. I failed to do this with the current master. Did I miss a way to do this?

To change this I tried to use file:/// paths, which pass the first checks. I had to check if only a file was found (which doesn't have a return code).
Then opening fails when trying to open the file with open(), because it starts with file:///. So I removed that.
Additionally It always failed to open the addon tgz. I had to switch to "read binary" -> "rb". Did this ever work without 'rb' using python 3?

So for me now this works to load addons:
![grafik](https://user-images.githubusercontent.com/37930020/80922684-01df5d00-8d7f-11ea-960c-704c9404d56e.png)
