### PR TITLE
New tools for media manager

### DIFF
--- a/gramps/plugins/tool/mediamanager.py
+++ b/gramps/plugins/tool/mediamanager.py
@@ -32,6 +32,11 @@
 #
 #------------------------------------------------------------------------
 import os
+import datetime
+import threading
+import time
+import queue
+import re
 
 #------------------------------------------------------------------------
 #
@@ -41,6 +46,11 @@ import os
 from gi.repository import Gtk
 from gi.repository import GObject
 from gi.repository import GdkPixbuf
+import gi
+gi.require_version('GExiv2', '0.10')
+from gi.repository import GExiv2
+gi.require_version('GLib', '2.0')
+from gi.repository import GLib
 
 #------------------------------------------------------------------------
 #
@@ -49,7 +59,7 @@ from gi.repository import GdkPixbuf
 #------------------------------------------------------------------------
 from gramps.gen.const import URL_MANUAL_PAGE, ICON, SPLASH
 from gramps.gui.display import display_help
-from gramps.gen.lib import Media
+from gramps.gen.lib import Media, Date
 from gramps.gen.db import DbTxn
 from gramps.gen.updatecallback import UpdateCallback
 from gramps.gui.plug import tool
@@ -66,6 +76,7 @@ from gramps.gui.managedwindow import ManagedWindow
 #-------------------------------------------------------------------------
 WIKI_HELP_PAGE = '%s_-_Tools' % URL_MANUAL_PAGE
 WIKI_HELP_SEC = _('manual|Media_Manager')
+
 
 #-------------------------------------------------------------------------
 #
@@ -172,6 +183,8 @@ class MediaMan(ManagedWindow, tool.Tool):
             Convert2Abs,
             Convert2Rel,
             ImagesNotIncluded,
+            FixPathSeparator,
+            AddDateInformation,
             ]
 
         for batch_class in batches_to_use:
@@ -200,6 +213,7 @@ class MediaMan(ManagedWindow, tool.Tool):
         """
         self.uistate.set_busy_cursor(False)
         self.uistate.progress.hide()
+
 
 #------------------------------------------------------------------------
 #
@@ -398,6 +412,7 @@ class ConclusionPage(Gtk.Box):
         self.label.set_text(conclusion_text)
         self.assistant.set_page_title(self, conclusion_title)
 
+
 #------------------------------------------------------------------------
 #
 # These are the actuall sub-tools (batch-ops) for use from Assistant
@@ -480,6 +495,7 @@ class BatchOp(UpdateCallback):
     def _prepare(self):
         print("This method needs to be written.")
         print("Preparing BatchOp tool... done.")
+
 
 #------------------------------------------------------------------------
 # Simple op to replace substrings in the paths
@@ -566,6 +582,7 @@ class PathChange(BatchOp):
             self.update()
         return True
 
+
 #------------------------------------------------------------------------
 #An op to convert relative paths to absolute
 #------------------------------------------------------------------------
@@ -599,6 +616,7 @@ class Convert2Abs(BatchOp):
             self.db.commit_media(obj, self.trans)
             self.update()
         return True
+
 
 #------------------------------------------------------------------------
 #An op to convert absolute paths to relative
@@ -636,6 +654,7 @@ class Convert2Rel(BatchOp):
             self.db.commit_media(obj, self.trans)
             self.update()
         return True
+
 
 #------------------------------------------------------------------------
 #An op to look for images that may have been forgotten.
@@ -702,6 +721,387 @@ class ImagesNotIncluded(BatchOp):
                             self.db.add_media(obj, self.trans)
             self.update()
         return True
+
+
+# ------------------------------------------------------------------------
+# An op to convert slashes in media paths
+# ------------------------------------------------------------------------
+class FixPathSeparator(BatchOp):
+    title = _('Change the path separator - i.e. "/" to "\\" or vice versa')
+    description = _("This tool allows converting the media path "
+                    "separators. The operating system usually has "
+                    "a default separator. For Windows this is a "
+                    "backslash '\\', for Linux it is forward slash '/'. "
+                    "Importing data or switching the operating system "
+                    "can cause inconsistencies. ")
+    if os.name == 'nt' and os.path.sep == '/':
+        description += _("\nYou working on windows but the default "
+                         "separator is forward slash '/'. This suggests "
+                         "you are using a cross compiled Python executable. ")
+
+    separators = ['/', '\\']
+    cb_items = ['Posix separator /', 'Windows separator \\']
+
+    def _prepare(self):
+        selected_separator = self.separators[
+            self.separator_combobox.get_active()]
+        other_separator = self.separators[
+            (self.separator_combobox.get_active() + 1) % 2]
+        self.set_total(self.db.get_number_of_media())
+        with self.db.get_media_cursor() as cursor:
+            for handle, data in cursor:
+                obj = Media()
+                obj.unserialize(data)
+                new_path = os.path.normpath(obj.path).replace(
+                    other_separator, selected_separator)
+                if obj.path != new_path:
+                    self.handle_list.append(handle)
+                    self.path_list.append(obj.path)
+                self.update()
+        self.reset()
+
+    def build_config(self):
+        title = _("Select path separator")
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        box.set_spacing(12)
+
+        grid = Gtk.Grid()
+        grid.set_row_spacing(6)
+        grid.set_column_spacing(6)
+
+        label = Gtk.Label(label=_('Please select the new path separator:'))
+        grid.attach(label, 0, 0, 1, 1)
+
+        cell = Gtk.CellRendererText()
+        self.separator_combobox = Gtk.ComboBox()
+        self.separator_combobox.pack_start(cell, True)
+        self.separator_combobox.add_attribute(cell, 'text', 0)
+        model = Gtk.ListStore(str)
+        for i, conf_value in enumerate(self.cb_items):
+            model.append((conf_value,))
+        self.separator_combobox.set_model(model)
+        self.separator_combobox.set_active(1 if os.name == 'nt' else 0)
+
+        grid.attach(self.separator_combobox, 0, 1, 1, 1)
+
+        box.add(grid)
+
+        return (title, box)
+
+    def _run(self):
+        if not self.prepared:
+            self.prepare()
+        self.set_total(len(self.handle_list))
+        selected_separator = self.separators[
+            self.separator_combobox.get_active()]
+        other_separator = self.separators[(
+            self.separator_combobox.get_active() + 1) % 2]
+        for handle in self.handle_list:
+            obj = self.db.get_media_from_handle(handle)
+            new_path = os.path.normpath(obj.path).replace(
+                other_separator, selected_separator)
+            if new_path != obj.path:
+                obj.set_path(new_path)
+                self.db.commit_media(obj, self.trans)
+                self.update()
+        return True
+
+
+# ------------------------------------------------------------------------
+# An op to add date information to media
+# ------------------------------------------------------------------------
+class AddDateInformationWorker(threading.Thread):
+
+    def __init__(self, media_data):
+        threading.Thread.__init__(self, name='Media Manager Worker')
+        self.media_data = media_data
+
+        # abort work and stop this thread asap
+        self.event_stop_thread = threading.Event()
+        # abort work and restart
+        self.event_update_list = threading.Event()
+        # work is done
+        self.event_update_done = threading.Event()
+
+        self.com_queue = queue.Queue()
+        # regex string
+        self.regex_string = None
+        # overwrite existing dates
+        self.overwrite = None
+        # prefer exif tag
+        self.prefer_exif = None
+        # format string to generate date from regex groups
+        self.regex_format = None
+
+    def run(self):
+        while not self.event_stop_thread.isSet():
+            time.sleep(0.01)
+            if self.event_update_list.isSet():
+                # clear list
+                self.event_update_list.clear()
+                self.event_update_done.clear()
+                self.com_queue.put(('clear',))
+
+                try:
+                    # compile regex
+                    regex_string = self.regex_string
+                    regex = re.compile(regex_string)
+                except re.error as e:
+                    self.com_queue.put(
+                        ('add', ('', f'Regex error: {e}')))
+                else:
+                    self._handle_media_data(regex,
+                                            self.regex_format,
+                                            self.prefer_exif,
+                                            self.overwrite)
+
+    def _handle_media_data(self, regex, regex_format, prefer_exif, overwrite):
+        for handle, data in self.media_data.items():
+            # time.sleep(0.05)
+            obj = Media()
+            obj.unserialize(data)
+            try:
+                year = obj.get_date_object().get_year()
+                if year == 0 or overwrite:
+                    filename = os.path.abspath(obj.path)
+                    match = regex.match(filename)
+                    if match:
+                        date_string = None
+                        is_jpeg = os.path.splitext(filename.upper())[
+                            1] in ['.JPG', '.JPEG']
+                        if prefer_exif and is_jpeg and os.path.isfile(filename):
+                            date_string = self._get_date_from_exif(filename)
+                        if date_string is None:
+                            found_keys = match.groupdict()
+                            try:
+                                date_string = regex_format.format(**found_keys)
+                            except KeyError as e:
+                                filename = (f'The parameter "{e}" was not '
+                                            f'found in regex for file {filename}')
+                                date_string = ''
+                            except Exception as e:
+                                filename = f'"{e}" for file {filename}'
+                                date_string = ''
+
+                        if date_string is not None:
+                            self.com_queue.put(
+                                ('add', (date_string, filename, handle)))
+            except Exception:
+                # ignore errors
+                pass
+            if self.event_update_list.isSet():
+                break
+        self.event_update_done.set()
+
+    def _get_date_from_exif(self, full_path):
+        """
+        Read date from the exif tag.
+        """
+
+        if not os.path.exists(full_path):
+            return False
+
+        date_string = False
+        with open(full_path, 'rb') as fd:
+            try:
+                buf = fd.read()
+                metadata = GExiv2.Metadata()
+                metadata.open_buf(buf)
+
+                if 'Exif.Photo.DateTimeOriginal' not in metadata.get_tags():
+                    date_string = None
+                else:
+                    exif_date_string = metadata.get_tag_string(
+                        'Exif.Photo.DateTimeOriginal')
+                    dt = datetime.datetime.strptime(
+                        exif_date_string, '%Y:%m:%d %H:%M:%S')
+                    gramps_date = Date(dt.year, dt.month, dt.day)
+                    date_string = glocale.get_date(gramps_date)
+            except Exception:
+                pass
+        return date_string
+
+    def update_list(self):
+        self.event_update_list.set()
+
+    def stop(self):
+        """Stop method, sets the event to terminate the thread's main loop"""
+        self.event_stop_thread.set()
+
+
+class AddDateInformation(BatchOp):
+    title = _('Add date information')
+    description = _("This tool enables the user to add the date information "
+                    "to media. If you path to the file or the filename "
+                    "includes the year/date information, then this tool "
+                    "can parse it and set the database accordingly. "
+                    "If an exif tag of a photo is available then this "
+                    "information can be used aswell.")
+    worker_thread = None
+
+    def __init__(self, db, callback):
+        BatchOp.__init__(self, db, callback)
+        # storage for db entries
+        self.media_data = {}
+        # start worker thread and wait until it is running
+        self.worker_thread = AddDateInformationWorker(self.media_data)
+        if not self.worker_thread.is_alive():
+            self.worker_thread.start()
+            while not self.worker_thread.is_alive():
+                time.sleep(0.01)
+
+    def _prepare(self):
+        if self.worker_thread:
+            # should be wait_for and a dialog to ask the user
+            # whether the thread shall be stopped
+            self.worker_thread.event_update_done.wait()
+        self.reset()
+        self.set_total(len(self.my_handle_list))
+        for date_string, filename, handle in self.my_handle_list:
+            if date_string:
+                self.path_list.append(filename)
+            self.update()
+        self.reset()
+
+    def __del__(self):
+        # also kill the thread if this batchop is deleted
+        self.worker_thread.stop()
+        self.worker_thread.join()
+
+    def check_queue(self):
+        """
+        handle queue of new list update commands
+
+        Returns:
+            bool: keep alive
+        """
+        if self.worker_thread.is_alive():
+            try:
+                while not self.worker_thread.com_queue.empty():
+                    update_command = self.worker_thread.com_queue.get()
+                    # handle the command
+                    GLib.idle_add(self.handle_queue_item, update_command)
+            except queue.Empty:
+                pass
+            # to keep timeout running
+            return True
+        else:
+            # to end timeout
+            return False
+
+    def handle_queue_item(self, update):
+        """
+        handle an item from the update command queue
+
+        Args:
+            update (tuple): update command and arguments
+        """
+        if update[0] == 'clear':
+            self.path_model_date.clear()
+            self.my_handle_list.clear()
+        elif update[0] == 'add':
+            self.path_model_date.append(row=(update[1][0], update[1][1]))
+            self.my_handle_list.append(update[1])
+
+    def build_config(self):
+        self.path_model_date = Gtk.ListStore(
+            GObject.TYPE_STRING, GObject.TYPE_STRING)
+        title = _("Configure date detection")
+
+        # read data from database, to enable access from other thread
+        self.media_data.clear()
+        self.my_handle_list = []
+        with self.db.get_media_cursor() as cursor:
+            for handle, data in cursor:
+                self.media_data[handle] = data
+
+        vbox = Gtk.Box(homogeneous=False, orientation=Gtk.Orientation.VERTICAL)
+
+        label = Gtk.Label(label=_(
+            'Please define a regular expression to filter media files:'))
+        vbox.pack_start(label, False, False, 0)
+        label = Gtk.Label()
+        label.set_markup(
+            _('(see <a href="https://docs.python.org/3/library/re.html">'
+              'https://docs.python.org/3/library/re.html</a>)'))
+        vbox.pack_start(label, False, False, 0)
+
+        self.regex_entry = Gtk.Entry()
+        self.regex_entry.set_hexpand(True)
+        vbox.pack_start(self.regex_entry, False, False, 0)
+        self.regex_entry.set_text(r".*\\(?P<year>\d{4})[\w_\(\)_ ]*\.jpg")
+        self.regex_entry.connect('changed', self.update_list)
+
+        self.checkbox_exif = Gtk.CheckButton(
+            label=_("Prefer to use exif tag, where possible"))
+        self.checkbox_exif.set_active(True)
+        self.checkbox_exif.connect('clicked', self.update_list)
+        vbox.pack_start(self.checkbox_exif, False, False, 0)
+
+        label = Gtk.Label(label=_('Please define the date format:'))
+        vbox.pack_start(label, False, False, 0)
+
+        self.regex_format = Gtk.Entry()
+        self.regex_format.set_hexpand(True)
+        vbox.pack_start(self.regex_format, False, False, 0)
+        self.regex_format.set_text("{year}")
+        self.regex_format.connect('changed', self.update_list)
+
+        self.checkbox_overwrite = Gtk.CheckButton(
+            label=_("Overwrite existing dates"))
+        self.checkbox_overwrite.connect('clicked', self.update_list)
+        vbox.pack_start(self.checkbox_overwrite, False, False, 0)
+
+        scrolled_window = Gtk.ScrolledWindow()
+        scrolled_window.set_policy(
+            Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scrolled_window.set_shadow_type(Gtk.ShadowType.IN)
+        tree = Gtk.TreeView()
+        tree.set_model(self.path_model_date)
+        tree_view_column2 = Gtk.TreeViewColumn(_('Date'),
+                                               Gtk.CellRendererText(), text=0)
+        tree_view_column2.set_sort_column_id(0)
+        tree.append_column(tree_view_column2)
+        tree_view_column = Gtk.TreeViewColumn(_('Found files'),
+                                              Gtk.CellRendererText(), text=1)
+        tree_view_column.set_sort_column_id(1)
+        tree.append_column(tree_view_column)
+        scrolled_window.add(tree)
+        vbox.pack_start(scrolled_window, True, True, 0)
+
+        self.update_list(None)
+        GLib.timeout_add(100, self.check_queue)
+
+        return (title, vbox)
+
+    def update_list(self, _button):
+        """
+        send new settings to the thread and restart work
+        """
+        self.worker_thread.prefer_exif = self.checkbox_exif.get_active()
+        self.worker_thread.overwrite = self.checkbox_overwrite.get_active()
+        self.worker_thread.regex_format = self.regex_format.get_text()
+        self.worker_thread.regex_string = self.regex_entry.get_text()
+        self.worker_thread.update_list()
+
+    def _run(self):
+        if not self.prepared:
+            self.prepare()
+        self.set_total(len(self.my_handle_list))
+        for date_string, filename, handle in self.my_handle_list:
+            if date_string:
+                obj = self.db.get_media_from_handle(handle)
+                try:
+                    date = glocale.date_parser.parse(date_string)
+                    date_object = obj.get_date_object()
+                    date_object.set_yr_mon_day(*date.get_ymd())
+                    self.db.commit_media(obj, self.trans)
+                except Exception:
+                    pass
+            self.update()
+        return True
+
 
 #------------------------------------------------------------------------
 #

--- a/gramps/plugins/tool/mediamanager.py
+++ b/gramps/plugins/tool/mediamanager.py
@@ -945,7 +945,7 @@ class AddDateInformationWorker(threading.Thread):
 class AddDateInformation(BatchOp):
     title = _('Add date information')
     description = _("This tool enables the user to add the date information "
-                    "to media. If you path to the file or the filename "
+                    "to media. If the path of the file or the filename "
                     "includes the year/date information, then this tool "
                     "can parse it and set the database accordingly. "
                     "If an exif tag of a photo is available then this "


### PR DESCRIPTION
I wrote two tools for the media manager:
1. **Fix path separator**
  This tool can be used to align the path separator of media files
2. **Add date information to media**
  This tool can parse a date from a filename or path, or use the exif data to set the date information.

**More info about path separator:**
I had an issue with wrong separators or mixed separators on windows. Usually windows uses backslash, but msys2/mingw uses forward slash (https://github.com/msys2/MSYS2-packages/issues/1591). I.e. in some dialogs in gramps (such as adding an image in the person editor gallery) the paths were added with backslash, in others with forward slash (e.g. basically everything handled with os.path...).
This tool can set the separator to a user defined value.
![grafik](https://user-images.githubusercontent.com/37930020/81509367-69128980-930a-11ea-880c-6b4ea814e377.png)
![grafik](https://user-images.githubusercontent.com/37930020/81509378-7b8cc300-930a-11ea-94e8-8197cead8dbe.png)


**More info about date detection**
I needed dates assigned to photos for https://github.com/gramps-project/addons-source/pull/335.
![grafik](https://user-images.githubusercontent.com/37930020/81509509-7ed47e80-930b-11ea-920c-6bd030d02a24.png)
In the configuration view you can try out different regular expression to detect the date based on the filename / path name. It is also possible to read the exif information (Exif.Photo.DateTimeOriginal). Optionally already set data can be overwritten. The default regular expression searches for a four-digit year at the beginning of the filename.
![grafik](https://user-images.githubusercontent.com/37930020/81509546-ac212c80-930b-11ea-9e38-3744b1ddc4ee.png)
The list on the bottom is continuously updated and shows the resulting dates for different files.
![grafik](https://user-images.githubusercontent.com/37930020/81509603-10dc8700-930c-11ea-80ad-79a77b60ee72.png)

**General remark on threading**
I also implemented a thread to handle the continuous evaluation of user input. However, it turned out that the database cannot be accessed easily from other threads. The thread now only communicates via a queue of native python types. The thread now lives after opening the tool window, is deleted when opening a new one.
After implementing this, I realized that there are not too many thread implementations in gramps. Is there a specific reason for that?
