### PR TITLE
Improve EditLink's usability: Preselect the active objects for each type

### DIFF
--- a/gramps/gui/editors/editlink.py
+++ b/gramps/gui/editors/editlink.py
@@ -208,17 +208,28 @@ class EditLink(ManagedWindow):
                                    (object_class, prop, value))
 
     def _on_type_changed(self, widget):
-        self.selected.set_text("")
         if self.uri_list.get_active() == WEB:
             self.url_link.set_sensitive(True)
             self.pick_item.set_sensitive(False)
             self.new_button.set_sensitive(False)
             self.edit_button.set_sensitive(False)
+            self.selected.set_text("")
+            self.url_link.set_text("https://")
         else:
             self.url_link.set_sensitive(False)
             self.pick_item.set_sensitive(True)
             self.new_button.set_sensitive(True)
             self.edit_button.set_sensitive(True)
+            object_class = OBJECT_MAP[self.uri_list.get_active()]
+            handle = self.uistate.get_active(object_class)
+            if handle:
+                self.selected.set_text(self.display_link(
+                    object_class, "handle", handle))
+                self.url_link.set_text("gramps://%s/handle/%s" %
+                                       (object_class, handle))
+            else:
+                self.selected.set_text("")
+                self.url_link.set_text("")
 
     def get_uri(self):
         if self.uri_list.get_active() == WEB:

--- a/gramps/gui/widgets/styledtexteditor.py
+++ b/gramps/gui/widgets/styledtexteditor.py
@@ -903,6 +903,7 @@ def uri_dialog(self, uri, callback):
                 handle = obj.uistate.get_active(object_class)
                 if handle:
                     uri = "gramps://%s/handle/%s" % (object_class, handle)
+                    break
         EditLink(obj.dbstate, obj.uistate, obj.track, uri, callback)
 
 


### PR DESCRIPTION
Background story: In my private family tree I transcribe quite a lot of documents. And in these transcriptions notes I usually want to link people that are mentioned there. Often this is easy, because I usually want to link the active person, which is often preselected, or a person from the same family, which is close to the active person in the list. Unfortunately, quite often it's cumbersome to select the correct person, because the dialog starts not with a person, but with a place. Then I have to change the type to "Person" and find the right person starting from scratch.

This patch makes Gramps gives "Person" the highest priority, and not "Media" as it used to be. And if the user changes the type, Gramps selects the active of that type. This should make it easier to link people and other types.

(Note: This behaviour could be improved even further if Gramps would use the default type according to the currently active category/view.)