### PR TITLE
Remove non-existent old attribute personal for an event

### DIFF
--- a/gramps/plugins/importer/importxml.py
+++ b/gramps/plugins/importer/importxml.py
@@ -1306,10 +1306,8 @@ class GrampsParser(UpdateCallback):
             return
 
         if self.family:
-            event.personal = False
             self.family.add_event_ref(self.eventref)
         elif self.person:
-            event.personal = True
             if (event.type == EventType.BIRTH) \
                    and (self.eventref.role == EventRoleType.PRIMARY) \
                    and (self.person.get_birth_ref() is None):


### PR DESCRIPTION
As discussed on the gramps mailing-list this attribute is obsolete
https://sourceforge.net/p/gramps/mailman/message/37013965/