### PR TITLE
replace file() -> open()

### DIFF
--- a/gramps/gen/plug/utils.py
+++ b/gramps/gen/plug/utils.py
@@ -116,7 +116,7 @@ class Zipfile:
                 os.mkdir(fullname)
         for name in self.get_files(names):
             fullname = os.path.join(path, name)
-            outfile = file(fullname, 'wb')
+            outfile = open(fullname, 'wb')
             outfile.write(self.zip_obj.read(name))
             outfile.close()
 

--- a/gramps/gen/plug/utils.py
+++ b/gramps/gen/plug/utils.py
@@ -116,9 +116,8 @@ class Zipfile:
                 os.mkdir(fullname)
         for name in self.get_files(names):
             fullname = os.path.join(path, name)
-            outfile = open(fullname, 'wb')
-            outfile.write(self.zip_obj.read(name))
-            outfile.close()
+            with open(fullname, 'wb') as outfile:
+                outfile.write(self.zip_obj.read(name))
 
     def extractfile(self, name):
         """

--- a/gramps/gui/dbloader.py
+++ b/gramps/gui/dbloader.py
@@ -463,7 +463,7 @@ class GrampsImportFileDialog(ManagedWindow):
                 return True
         else:
             try:
-                f = file(filename,'w')
+                f = open(filename,'w')
                 f.close()
                 os.remove(filename)
             except IOError:


### PR DESCRIPTION
This seems to be Python 2. But even there it is not recommended:
> When opening a file, it’s preferable to use open() instead of invoking this constructor directly. file is more suited to type testing (for example, writing isinstance(f, file)).

https://docs.python.org/2/library/functions.html?highlight=file#file

There is another one in [./gramps/gui/dbloader.py](https://github.com/gramps-project/gramps/blob/47a83a82d74b713558d4717ccbb07a82c484796c/gramps/gui/dbloader.py#L466).
