### PR TITLE
[PedigreeView] fix font color in boxes (bug 11799)

### DIFF
--- a/gramps/gui/test/utils_test.py
+++ b/gramps/gui/test/utils_test.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+""" Unittest for utils.py """
+
+import unittest
+from ..utils import get_contrast_color
+
+
+class Test_get_contrast_color(unittest.TestCase):
+    def setUp(self):
+        self.black = (0, 0, 0)
+        self.white = (1, 1, 1)
+
+    def test_contrast_black_returns_white(self):
+        contrast_color = get_contrast_color(self.black)
+        self.assertEqual(contrast_color, self.white,
+                         "Contrasting color for black did not return white")
+
+    def test_contrast_white_returns_black(self):
+        contrast_color = get_contrast_color(self.white)
+        self.assertEqual(contrast_color, self.black,
+                         "Contrasting color for white did not return black")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gramps/gui/utils.py
+++ b/gramps/gui/utils.py
@@ -545,6 +545,15 @@ def rgb_to_hex(rgb):
         rgbint = (int(rgb[0] * 255), int(rgb[1] * 255), int(rgb[2] * 255))
         return '#%02x%02x%02x' % rgbint
 
+def get_contrast_color(color):
+    """
+    Choose contrast text color (white or black) for provided background.
+    """
+    yiq = (color[0]*299)+(color[1]*587)+(color[2]*114)
+    if (yiq < 500):
+        return (1, 1, 1)  # 'white'
+    return (0, 0, 0)      # 'black'
+
 def get_link_color(context):
     """
     Find the link color for the current theme.

--- a/gramps/plugins/view/pedigreeview.py
+++ b/gramps/plugins/view/pedigreeview.py
@@ -65,7 +65,8 @@ from gramps.gen.config import config
 from gramps.gui.views.bookmarks import PersonBookmarks
 from gramps.gen.const import CUSTOM_FILTERS, URL_MANUAL_PAGE, URL_WIKISTRING
 from gramps.gui.dialog import RunDatabaseRepair, ErrorDialog
-from gramps.gui.utils import color_graph_box, hex_to_rgb_float, is_right_click
+from gramps.gui.utils import (color_graph_box, hex_to_rgb_float,
+                              is_right_click, get_contrast_color)
 from gramps.gen.constfunc import lin
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
@@ -337,7 +338,8 @@ class PersonBoxWidgetCairo(_PersonWidgetBase):
 
         # text
         context.move_to(5, 4)
-        context.set_source_rgb(0, 0, 0)
+        fg_color = get_contrast_color(self.bgcolor)
+        context.set_source_rgb(*fg_color[:3])
         PangoCairo.show_layout(context, self.textlayout)
         context.restore()
         context.get_target().flush()


### PR DESCRIPTION
Detect contrast color for text depending on background color (see [wiki](https://en.wikipedia.org/wiki/YIQ)).
Fixes [11799](https://gramps-project.org/bugs/view.php?id=11799)