### PR TITLE
Remove xdg-utils dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ The following three packages with GObject Introspection bindings (the gi package
 * **pangocairo** - Allows you to use Pango with Cairo http://www.pango.org/
 
 * **librsvg2** - (SVG icon view) a library to render SVG files using cairo. http://live.gnome.org/LibRsvg
-* **xdg-utils** - Desktop integration utilities from freedesktop.org
 * **bsddb3** - Python bindings for Oracle Berkeley DB https://pypi.python.org/pypi/bsddb3/
 * **sqlite3** - Python bindings for SQLite Database library
 

--- a/debian/control
+++ b/debian/control
@@ -34,7 +34,6 @@ Depends:
  python3-gi (>= 3.12.0),
  python3-gi-cairo,
  python3-bsddb3,
- xdg-utils,
  ${misc:Depends},
  ${python3:Depends}
 Recommends:


### PR DESCRIPTION
This is for opening files in external programs, not location of cache/user data.

It simplifies the code and gets rid a a dependency.  We would have to test it on Linux, Mac and Windows.