### PR TITLE
Fix XML export when 'Group-as" name contains XML invalid chars

### DIFF
--- a/gramps/plugins/export/exportxml.py
+++ b/gramps/plugins/export/exportxml.py
@@ -376,7 +376,7 @@ class GrampsXmlWriter(UpdateCallback):
             for key in group_map:
                 value = self.db.get_name_group_mapping(key)
                 self.g.write('    <map type="group_as" key="%s" value="%s"/>\n'
-                             % (self.fix(key), value))
+                             % (self.fix(key), self.fix(value)))
             self.g.write("  </namemaps>\n")
 
     def write_bookmarks(self):


### PR DESCRIPTION
Fixes #11834