### PR TITLE
Fix GEDCOM import/export DATE/TIME creep by UTC offset.

### DIFF
--- a/gramps/plugins/export/exportgedcom.py
+++ b/gramps/plugins/export/exportgedcom.py
@@ -1123,7 +1123,7 @@ class GedcomWriter(UpdateCallback):
             +1 <<NOTE_STRUCTURE>>          # not used
         """
         self._writeln(level, 'CHAN')
-        time_val = time.gmtime(timeval)
+        time_val = time.localtime(timeval)
         self._writeln(level + 1, 'DATE', '%d %s %d' % (
             time_val[2], libgedcom.MONTH[time_val[1]], time_val[0]))
         self._writeln(level + 2, 'TIME', '%02d:%02d:%02d' % (


### PR DESCRIPTION
Fixes [#11849](https://gramps-project.org/bugs/view.php?id=11849)

## Description

Importing a GEDCOM file and then exporting it propagates a UTC/local time offset error.

[libgedcom.py](https://github.com/gramps-project/gramps/blob/master/gramps/plugins/lib/libgedcom.py#L7834) uses [time.mktime()](https://docs.python.org/3/library/time.html#time.mktime) which converts a time tuple in **local time** to seconds on import of a GEDCOM file.

[exportgedcom.py](https://github.com/gramps-project/gramps/blob/master/gramps/plugins/export/exportgedcom.py#L1126) uses [time.gmtime()](https://docs.python.org/3/library/time.html#time.gmtime) to convert that same time on export, thereby introducing the time creep by the UTC-local offset.

The fix is to use [time.localtime()](https://docs.python.org/3/library/time.html#time.localtime) on export.

An alternative would be to make sure to import in UTC. This would require using something like [calendar.timegm()](https://docs.python.org/3/library/calendar.html#calendar.timegm) since the `time` library is missing this function.

Unfortunately the GEDCOM spec forgot about time zones so there's no "right" way to do this. Gramps uses localtime() elsewhere in the 'HEAD', so sticking to local time seems like the best approach.



