### PR TITLE
Bug10853m

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -537,7 +537,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         self.transaction = None
         self.abort_possible = False
         self._bm_changes = 0
-        self.has_changed = False
+        self.has_changed = 0  # Also gives commits since startup
         self.surname_list = []
         self.genderStats = GenderStats() # can pass in loaded stats as dict
         self.owner = Researcher()

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -1779,7 +1779,9 @@ class GrampsPreferences(ConfigureDialog):
         formats = [_("Never"),
                    _("Every 15 minutes"),
                    _("Every 30 minutes"),
-                   _("Every hour")]
+                   _("Every hour"),
+                   _("Every 12 hours"),
+                   _("Every day")]
         list(map(obox.append_text, formats))
         active = config.get('database.autobackup')
         obox.set_active(active)

--- a/gramps/gui/displaystate.py
+++ b/gramps/gui/displaystate.py
@@ -458,6 +458,10 @@ class DisplayState(Callback):
             minutes = 30
         elif interval == 3:
             minutes = 60
+        elif interval == 4:
+            minutes = 720
+        elif interval == 5:
+            minutes = 1440
         if interval > 0:
             self.backup_timer = GLib.timeout_add_seconds(
                 minutes*60, self.__emit_autobackup)

--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -184,6 +184,7 @@ class ViewManager(CLIManager):
         self.view_changing = False
         self.autobackup_time = time.time()  # time of start or last autobackup
         self.delay_timer = None  # autobackup delay timer for after wakeup
+        self.prev_has_changed = 0  # db commit count at autobackup time
 
         self.show_navigator = config.get('interface.view')
         self.show_toolbar = config.get('interface.toolbar-on')
@@ -1209,7 +1210,10 @@ class ViewManager(CLIManager):
             self.autobackup_time = now
             return
         self.autobackup_time = now
-        if self.dbstate.db.is_open() and self.dbstate.db.has_changed:
+        # Only backup if more commits since last time
+        if(self.dbstate.db.is_open() and
+           self.dbstate.db.has_changed > self.prev_has_changed):
+            self.prev_has_changed = self.dbstate.db.has_changed
             self.uistate.set_busy_cursor(True)
             self.uistate.progress.show()
             self.uistate.push_message(self.dbstate, _("Autobackup..."))

--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -56,6 +56,7 @@ LOG = logging.getLogger(".")
 #-------------------------------------------------------------------------
 from gi.repository import Gtk
 from gi.repository import Gdk
+from gi.repository import GLib
 
 #-------------------------------------------------------------------------
 #
@@ -181,6 +182,8 @@ class ViewManager(CLIManager):
         self.views = None
         self.current_views = [] # The current view in each category
         self.view_changing = False
+        self.autobackup_time = time.time()  # time of start or last autobackup
+        self.delay_timer = None  # autobackup delay timer for after wakeup
 
         self.show_navigator = config.get('interface.view')
         self.show_toolbar = config.get('interface.toolbar-on')
@@ -1183,6 +1186,29 @@ class ViewManager(CLIManager):
         """
         Backup the current family tree.
         """
+        if self.delay_timer is not None:
+            GLib.source_remove(self.delay_timer)
+            self.delay_timer = None
+        interval = config.get('database.autobackup')
+        if interval == 1:
+            seconds = 900.  # 15min *60
+        elif interval == 2:
+            seconds = 1800.  # 30min *60
+        elif interval == 3:
+            seconds = 3600.  # 60min *60
+        elif interval == 4:
+            seconds = 43200.  # (12 hours) 720min *60
+        elif interval == 5:
+            seconds = 86400.  # (24 hours) 1440min *60
+        now = time.time()
+        if interval and now > self.autobackup_time + seconds + 300.:
+            # we have been delayed by more than 5 minutes
+            # so we have probably been awakened from sleep/hibernate
+            # we should delay a bit more to let the system settle
+            self.delay_timer = GLib.timeout_add_seconds(300, self.autobackup)
+            self.autobackup_time = now
+            return
+        self.autobackup_time = now
         if self.dbstate.db.is_open() and self.dbstate.db.has_changed:
             self.uistate.set_busy_cursor(True)
             self.uistate.progress.show()

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -276,7 +276,7 @@ class DBAPI(DbGeneric):
         self.undodb.commit(txn, msg)
         self._after_commit(txn)
         txn.clear()
-        self.has_changed = True
+        self.has_changed += 1  # Also gives commits since startup
 
     def transaction_abort(self, txn):
         """


### PR DESCRIPTION
Several users with very large trees note that auto-backups can make Gramps unresponsive, particularly noticeable when resuming a system from sleep.  Because a sleeping system has usually gone beyond the backup time limit, an auto-backup is triggered as soon as the system wakes.  This is also when the system is also busy doing other maintenance tasks.

This PR checks for the a longer time than expected since last backup when the  auto-backup timer fires.  If a significantly longer time has elapsed (indicating probable sleep), we add a further delay before starting the auto-backup.

A second commit makes a change to the code that detects if anything has been done, requiring an auto-backup.  Originally the auto-backup would go if any commit had occurred since Gramps opened the db.  With this change, we monitor the number of commits since Gramps opened the db; if no new commits have occurred since the last auto-backup, we skip it.  This will stop backups when the db is just open for reference without changes.

There have been requests for longer intervals; this PR includes a 12 and 24 hour interval.  Which was taken from another https://github.com/gramps-project/gramps/pull/1094 and included to make sure this would work with that other PR if it was accepted.