### PR TITLE
Fix crash sorting on columns in Selectors with TreeModels

### DIFF
--- a/gramps/gui/selectors/baseselector.py
+++ b/gramps/gui/selectors/baseselector.py
@@ -325,7 +325,6 @@ class BaseSelector(ManagedWindow):
                 self.sortorder = Gtk.SortType.ASCENDING
             else:
                 self.sortorder = Gtk.SortType.DESCENDING
-            self.model.reverse_order()
         self.build_tree()
 
         return True


### PR DESCRIPTION
Fixes #11750

When changing the sort in the TreeModel of a Selector, (PersonTreeModel as example) we would sometimes get an exception.  Other times the selected person would change to a different part of the tree.

The problem was that the code was first reversing the model, then getting a TreeSelection iter in the build_tree code, and then replacing the model in an effort to reset the selection to the original person.  But the model reversing caused the iter to become invalid, so some times it found a valid (but wrong) node handle, and sometimes the iter did not get a valid node at all, causing the exception.

It appears that a prior fix had caused the model to be rebuilt every time a column sort was done anyway; so the model reverse was wasted.  By eliminating this, the code appears to work correctly in my tests.