### PR TITLE
Fix progress bar freeze due to changes in Gtk

### DIFF
--- a/gramps/gui/dbloader.py
+++ b/gramps/gui/dbloader.py
@@ -548,7 +548,6 @@ class GrampsImportFileDialog(ManagedWindow):
         self.import_info = None
         self._begin_progress()
         self.uistate.set_sensitive(False)
-        self.uistate.viewmanager.enable_menu(False)
 
         try:
             #an importer can return an object with info, object.info_text()
@@ -569,7 +568,6 @@ class GrampsImportFileDialog(ManagedWindow):
         except Exception:
             _LOG.error("Failed to import database.", exc_info=True)
         self.uistate.set_sensitive(True)
-        self.uistate.viewmanager.enable_menu(True)
         self._end_progress()
 
     def build_menu_names(self, obj): # this is meaningless since it's modal

--- a/gramps/gui/displaystate.py
+++ b/gramps/gui/displaystate.py
@@ -520,7 +520,10 @@ class DisplayState(Callback):
             history.push(handle)
 
     def set_sensitive(self, state):
-        self.window.set_sensitive(state)
+        tbar = self.uimanager.get_widget('ToolBar')
+        tbar.set_sensitive(state)
+        self.viewmanager.hpane.set_sensitive(state)
+        self.uimanager.enable_all_actions(state)
 
     def db_changed(self, db):
         db.connect('long-op-start', self.progress_monitor.add_op)

--- a/gramps/gui/uimanager.py
+++ b/gramps/gui/uimanager.py
@@ -496,6 +496,16 @@ class UIManager():
         """
         return group.act_group.lookup_action(actionname)
 
+    def enable_all_actions(self, state):
+        for group in self.action_groups:
+            if group.act_group:
+                for item in group.actionlist:
+                    action = group.act_group.lookup_action(item[ACTION_NAME])
+                    if action:
+                        # We check in case the group has not been inserted into
+                        # UIManager yet
+                        action.set_enabled(group.sensitive if state else False)
+
     def dump_all_accels(self):
         ''' A function used diagnostically to see what accels are present.
         This will only dump the current accel set, if other non-open windows

--- a/gramps/gui/utils.py
+++ b/gramps/gui/utils.py
@@ -450,7 +450,7 @@ def open_file_with_default_application(path, uistate):
     GLib.timeout_add_seconds(1, poll_external, (proc, errstrings, uistate))
     return
 
-def process_pending_events(max_count=10):
+def process_pending_events(max_count=20):
     """
     Process pending events, but don't get into an infinite loop.
     """

--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -273,13 +273,13 @@ class ViewManager(CLIManager):
                 Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.MOD1_MASK)
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.window.add(vbox)
-        hpane = Gtk.Paned()
+        self.hpane = Gtk.Paned()
         self.ebox = Gtk.EventBox()
 
         self.navigator = Navigator(self)
         self.ebox.add(self.navigator.get_top())
-        hpane.pack1(self.ebox, False, False)
-        hpane.show()
+        self.hpane.pack1(self.ebox, False, False)
+        self.hpane.show()
 
         self.notebook = Gtk.Notebook()
         self.notebook.set_scrollable(True)
@@ -288,13 +288,13 @@ class ViewManager(CLIManager):
         self.__init_lists()
         self.__build_ui_manager()
 
-        hpane.add2(self.notebook)
+        self.hpane.add2(self.notebook)
         toolbar = self.uimanager.get_widget('ToolBar')
         self.statusbar = Statusbar()
         self.statusbar.show()
         vbox.pack_end(self.statusbar, False, True, 0)
         vbox.pack_start(toolbar, False, True, 0)
-        vbox.pack_end(hpane, True, True, 0)
+        vbox.pack_end(self.hpane, True, True, 0)
         vbox.show()
 
         self.uistate = DisplayState(self.window, self.statusbar,
@@ -1060,51 +1060,6 @@ class ViewManager(CLIManager):
         self.uimanager.update_menu()
         config.set('paths.recent-file', '')
         config.save()
-
-    def enable_menu(self, enable):
-        """ Enable/disable the menues.  Used by the dbloader for import to
-        prevent other operations during import.  Needed because simpler methods
-        don't work under Gnome with application menus at top of screen (instead
-        of Gramps window).
-        Note: enable must be set to False on first call.
-        """
-        if not enable:
-            self.action_st = (
-                self.uimanager.get_actions_sensitive(self.actiongroup),
-                self.uimanager.get_actions_sensitive(self.readonlygroup),
-                self.uimanager.get_actions_sensitive(self.undoactions),
-                self.uimanager.get_actions_sensitive(self.redoactions),
-                self.uimanager.get_actions_sensitive(self.fileactions),
-                self.uimanager.get_actions_sensitive(self.toolactions),
-                self.uimanager.get_actions_sensitive(self.reportactions),
-                self.uimanager.get_actions_sensitive(
-                    self.recent_manager.action_group))
-            self.uimanager.set_actions_sensitive(self.actiongroup, enable)
-            self.uimanager.set_actions_sensitive(self.readonlygroup, enable)
-            self.uimanager.set_actions_sensitive(self.undoactions, enable)
-            self.uimanager.set_actions_sensitive(self.redoactions, enable)
-            self.uimanager.set_actions_sensitive(self.fileactions, enable)
-            self.uimanager.set_actions_sensitive(self.toolactions, enable)
-            self.uimanager.set_actions_sensitive(self.reportactions, enable)
-            self.uimanager.set_actions_sensitive(
-                self.recent_manager.action_group, enable)
-        else:
-            self.uimanager.set_actions_sensitive(
-                self.actiongroup, self.action_st[0])
-            self.uimanager.set_actions_sensitive(
-                self.readonlygroup, self.action_st[1])
-            self.uimanager.set_actions_sensitive(
-                self.undoactions, self.action_st[2])
-            self.uimanager.set_actions_sensitive(
-                self.redoactions, self.action_st[3])
-            self.uimanager.set_actions_sensitive(
-                self.fileactions, self.action_st[4])
-            self.uimanager.set_actions_sensitive(
-                self.toolactions, self.action_st[5])
-            self.uimanager.set_actions_sensitive(
-                self.reportactions, self.action_st[6])
-            self.uimanager.set_actions_sensitive(
-                self.recent_manager.action_group, self.action_st[7])
 
     def __change_undo_label(self, label, update_menu=True):
         """


### PR DESCRIPTION
Fixes #11642

A bit of history: https://github.com/gramps-project/gramps/pull/584 was implemented to deal with crashes during import when a user tried to do something.  It worked by setting the whole Gramps main window insensitive and separately disabling most of the menus.

Recent changes in Gtk have caused the main window progress bar to freeze.  I tracked this down to the setting of the main window insensitive.  Don't know why this would stop progress updates, but...  I posted a bug on the Gtk about this but got no response.  At the moment, this is only affecting the most recent of distros, but I expect more will see this soon.

This is a workaround.  instead of making the whole window insensitive, I just made most of it, excluding the status bar and (out of my control) the menu bar.  I also observed that some of the menus (that were now overall sensitive) were still active.  So I created a more comprehensive menu disable using the uimanager, which in turn uses the action groups to disable the individual actions.

And finally, I observed that sometimes, during autobackup, the progress bar would stutter or freeze.  I tracked this down to a small loop count in the process_pending_events routine.  Apparently Gtk or Gramps has, under some conditions, more events than in the past.  So I increased the count.