### PR TITLE
Replace inspect.stack() with inspect.currentframe()

### DIFF
--- a/gramps/gen/db/dummydb.py
+++ b/gramps/gen/db/dummydb.py
@@ -52,7 +52,6 @@ methods should be changed to generate exceptions. Possibly by globally changing
 #
 #-------------------------------------------------------------------------
 import logging
-import os
 import inspect
 from abc import ABCMeta
 from types import FunctionType

--- a/gramps/gen/db/dummydb.py
+++ b/gramps/gen/db/dummydb.py
@@ -160,10 +160,12 @@ def wrapper(method):
         """
         class_name = args[0].__class__.__name__
         func_name = method.__name__
-        caller_frame = inspect.stack()[1]
+        frame = inspect.currentframe()
+        c_frame = frame.f_back
+        c_code = c_frame.f_code
         LOG.debug('calling %s.%s()... from file %s, line %s in %s',
-                  class_name, func_name, os.path.split(caller_frame[1])[1],
-                  caller_frame[2], caller_frame[3])
+                  class_name, func_name, c_code.co_filename, c_frame.f_lineno,
+                  c_code.co_name)
         return method(*args, **keywargs)
     return wrapped
 

--- a/gramps/gen/db/txn.py
+++ b/gramps/gen/db/txn.py
@@ -78,15 +78,13 @@ class DbTxn(defaultdict):
 
         elapsed_time = time.time() - self.start_time
         if __debug__:
-            caller_frame = inspect.stack()[1]
+            frame = inspect.currentframe()
+            c_frame = frame.f_back
+            c_code = c_frame.f_code
             _LOG.debug("    **** DbTxn %s exited. Called from file %s, "
-                       "line %s, in %s **** %.2f seconds" %
-                       ((hex(id(self)),)+
-                        (os.path.split(caller_frame[1])[1],)+
-                        tuple(caller_frame[i] for i in range(2, 4))+
-                        (elapsed_time,)
-                       )
-                      )
+                       "line %s, in %s **** %.2f seconds",
+                       hex(id(self)), c_code.co_filename, c_frame.f_lineno,
+                       c_code.co_name, elapsed_time)
 
         return False
 

--- a/gramps/gen/db/utils.py
+++ b/gramps/gen/db/utils.py
@@ -70,12 +70,14 @@ def make_database(plugin_id):
             database = getattr(mod, pdata.databaseclass)
             db = database()
             import inspect
-            caller_frame = inspect.stack()[1]
+            frame = inspect.currentframe()
+            c_frame = frame.f_back
+            c_code = c_frame.f_code
             _LOG.debug("Database class instance created Class:%s instance:%s. "
-                       "Called from File %s, line %s, in %s"
-                       % ((db.__class__.__name__, hex(id(db)))
-                          + (os.path.split(caller_frame[1])[1],)
-                          + tuple(caller_frame[i] for i in range(2, 4))))
+                       "Called from File %s, line %s, in %s",
+                       db.__class__.__name__, hex(id(db)), c_code.co_filename,
+                       c_frame.f_lineno, c_code.co_name)
+
             return db
         else:
             raise Exception("can't load database backend: '%s'" % plugin_id)

--- a/gramps/gen/dbstate.py
+++ b/gramps/gen/dbstate.py
@@ -29,7 +29,6 @@ Provide the database state class
 #
 #------------------------------------------------------------------------
 import sys
-import os
 import logging
 import inspect
 

--- a/gramps/gen/dbstate.py
+++ b/gramps/gen/dbstate.py
@@ -88,10 +88,12 @@ class DbState(Callback):
         """
         class_name = self.__class__.__name__
         func_name = "is_open"
-        caller_frame = inspect.stack()[1]
+        frame = inspect.currentframe()
+        c_frame = frame.f_back
+        c_code = c_frame.f_code
         _LOG.debug('calling %s.%s()... from file %s, line %s in %s',
-                  class_name, func_name, os.path.split(caller_frame[1])[1],
-                  caller_frame[2], caller_frame[3])
+                   class_name, func_name, c_code.co_filename, c_frame.f_lineno,
+                   c_code.co_name)
         return (self.db is not None) and self.db.is_open()
 
     def change_database(self, database):

--- a/gramps/gen/filters/rules/test/person_rules_test.py
+++ b/gramps/gen/filters/rules/test/person_rules_test.py
@@ -99,7 +99,8 @@ class BaseTest(unittest.TestCase):
         stime = perf_counter()
         results = filter_.apply(self.db)
         if __debug__:
-            rulename = inspect.stack()[1][3]
+            frame = inspect.currentframe()
+            rulename = frame.f_back.f_code.co_name
             print("%s: %.2f\n" % (rulename, perf_counter() - stime))
         return set(results)
 

--- a/gramps/gen/utils/callback.py
+++ b/gramps/gen/utils/callback.py
@@ -324,12 +324,16 @@ class Callback:
             return
 
         # Check signal exists
+        frame = inspect.currentframe()
+        c_frame = frame.f_back
+        c_code = c_frame.f_code
+        frame_info = (c_code.co_filename, c_frame.f_lineno, c_code.co_name)
         if signal_name not in self.__signal_map:
             self._warn("Attempt to emit to unknown signal: %s\n"
                        "         from: file: %s\n"
                        "               line: %d\n"
                        "               func: %s\n"
-                       % ((str(signal_name), ) + inspect.stack()[1][1:4]))
+                       % ((str(signal_name), ) + frame_info))
             return
 
         # check that the signal is not already being emitted. This prevents
@@ -340,7 +344,7 @@ class Callback:
                        "        from: file: %s\n"
                        "              line: %d\n"
                        "              func: %s\n"
-                       % ((str(signal_name), ) + inspect.stack()[1][1:4]))
+                       % ((str(signal_name), ) + frame_info))
             return
 
         try:
@@ -358,7 +362,7 @@ class Callback:
                            "         from: file: %s\n"
                            "               line: %d\n"
                            "               func: %s\n"
-                           % ((str(signal_name), ) + inspect.stack()[1][1:4]))
+                           % ((str(signal_name), ) + frame_info))
                 return
 
             # type check arguments
@@ -369,7 +373,7 @@ class Callback:
                            "         from: file: %s\n"
                            "               line: %d\n"
                            "               func: %s\n"
-                           % ((str(signal_name), ) + inspect.stack()[1][1:4]))
+                           % ((str(signal_name), ) + frame_info))
                 return
 
             if len(args) > 0:
@@ -379,7 +383,7 @@ class Callback:
                                "         from: file: %s\n"
                                "               line: %d\n"
                                "               func: %s\n"
-                               % ((str(signal_name), ) + inspect.stack()[1][1:4]))
+                               % ((str(signal_name), ) + frame_info))
                     return
 
                 if arg_types is not None:
@@ -391,7 +395,7 @@ class Callback:
                                        "               line: %d\n"
                                        "               func: %s\n"
                                        "    arg passed was: %s, type of arg passed %s,  type should be: %s\n"
-                                       % ((str(signal_name), ) + inspect.stack()[1][1:4] +\
+                                       % ((str(signal_name), ) + frame_info +\
                                           (args[i], repr(type(args[i])), repr(arg_types[i]))))
                             return
             if signal_name in self.__callback_map:

--- a/gramps/plugins/db/bsddb/bsddbtxn.py
+++ b/gramps/plugins/db/bsddb/bsddbtxn.py
@@ -73,14 +73,13 @@ class BSDDBTxn:
         """
         # Conditional on __debug__ because all that frame stuff may be slow
         if __debug__:
-            caller_frame = inspect.stack()[1]
+            frame = inspect.currentframe()
+            c_frame = frame.f_back
+            c_code = c_frame.f_code
             _LOG.debug("        BSDDBTxn %s instantiated. Called from file %s,"
-                       " line %s, in %s" %
-                       ((hex(id(self)),)+
-                        (os.path.split(caller_frame[1])[1],)+
-                        (tuple(caller_frame[i] for i in range(2, 4)))
-                       )
-                      )
+                       " line %s, in %s", hex(id(self)), c_code.co_filename,
+                       c_frame.f_lineno, c_code.co_name)
+
         self.env = env
         self.db = db
         self.txn = None

--- a/gramps/plugins/db/bsddb/bsddbtxn.py
+++ b/gramps/plugins/db/bsddb/bsddbtxn.py
@@ -29,7 +29,6 @@ BSDDBTxn class: Wrapper for BSDDB transaction-oriented methods
 #-------------------------------------------------------------------------
 import logging
 import inspect
-import os
 
 #-------------------------------------------------------------------------
 #

--- a/mac/gramps.bundle
+++ b/mac/gramps.bundle
@@ -41,7 +41,7 @@
   </binary>
 
   <binary recurse="True">
-    ${prefix}/lib/python3.6/*.so
+    ${prefix}/lib/python3.8/*.so
   </binary>
 
   <binary>
@@ -144,19 +144,19 @@
   <!-- We have to pull in the python modules, which are mixed python
        and loadable modules.  -->
   <data recurse="True">
-    ${prefix}/lib/python3.6/*.py
+    ${prefix}/lib/python3.8/*.py
   </data>
 
   <data>
-    ${prefix}/lib/python3.6/config-3.6m-darwin/
+    ${prefix}/lib/python3.8/config-3.8-darwin/
   </data>
 
   <data>
-    ${prefix}/lib/python3.6/site-packages/gramps/gen/utils/resource-path
+    ${prefix}/lib/python3.8/site-packages/gramps/gen/utils/resource-path
   </data>
 
   <data>
-    ${prefix}/include/python3.6m/pyconfig.h
+    ${prefix}/include/python3.8/pyconfig.h
   </data>
 
 
@@ -173,7 +173,7 @@
   </data>
 
   <data recurse="True">
-    ${prefix}/lib/python3.6/site-packages/gramps/*.glade
+    ${prefix}/lib/python3.8/site-packages/gramps/*.glade
   </data>
 
   <data>


### PR DESCRIPTION
Fixes [#11874](https://gramps-project.org/bugs/view.php?id=11874)

Works around a [Python bug](https://bugs.python.org/issue12920) that causes every
call to `inspect.trace()` to fail because `__main__` is always the
starting point.