### PR TITLE
Fix EditEventRef, EditPlaceRef, EditMediaRef, EditRepoRef for improperly saving objects in their object lists.

### DIFF
--- a/gramps/gui/editors/editeventref.py
+++ b/gramps/gui/editors/editeventref.py
@@ -26,7 +26,7 @@
 # Python modules
 #
 #-------------------------------------------------------------------------
-
+from copy import deepcopy
 #-------------------------------------------------------------------------
 #
 # gramps modules
@@ -66,7 +66,7 @@ class EditEventRef(EditReference):
     def __init__(self, state, uistate, track, event, event_ref, update):
         EditReference.__init__(self, state, uistate, track, event, event_ref,
                                update)
-        self.original = event.serialize()
+        self.original = deepcopy(event.serialize())
         self._init_event()
 
     def _local_init(self):

--- a/gramps/gui/editors/editmediaref.py
+++ b/gramps/gui/editors/editmediaref.py
@@ -29,6 +29,7 @@
 #
 #-------------------------------------------------------------------------
 import os
+from copy import deepcopy
 
 #-------------------------------------------------------------------------
 #
@@ -85,7 +86,7 @@ class EditMediaRef(EditReference):
             AddMedia(state, self.uistate, self.track, self.source,
                      self._update_addmedia)
         else:
-            self.original = self.source.serialize()
+            self.original = deepcopy(self.source.serialize())
 
     def _local_init(self):
 

--- a/gramps/gui/editors/editplaceref.py
+++ b/gramps/gui/editors/editplaceref.py
@@ -18,7 +18,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-
+from copy import deepcopy
 #-------------------------------------------------------------------------
 #
 # Gramps modules
@@ -51,7 +51,7 @@ class EditPlaceRef(EditReference):
     def __init__(self, state, uistate, track, place, place_ref, update):
         EditReference.__init__(self, state, uistate, track, place, place_ref,
                                update)
-        self.original = place.serialize()
+        self.original = deepcopy(place.serialize())
 
     def _local_init(self):
 

--- a/gramps/gui/editors/editreporef.py
+++ b/gramps/gui/editors/editreporef.py
@@ -24,7 +24,7 @@
 # Python modules
 #
 #-------------------------------------------------------------------------
-
+from copy import deepcopy
 #-------------------------------------------------------------------------
 #
 # gramps modules
@@ -51,7 +51,7 @@ class EditRepoRef(EditReference):
 
         EditReference.__init__(self, state, uistate, track, source,
                                source_ref, update)
-        self.original = source.serialize()
+        self.original = deepcopy(source.serialize())
 
     def _local_init(self):
 


### PR DESCRIPTION
Fixes #11917, #11933
A recent change added code to check for changes to the base object (Event) when updating the EventRef.  It did this by comparing the serialized object prior to edit to the serialized object post edit.  Users noted that the Event was not getting updated as it should when changes to citations or notes occurred (additions, deletions, order).

When we serialize the event, and it gets to the part of the code in event.serialize that does a CitationBase.serialize() that code just returns a reference to the Event.citiation_list. When you edit the Citation list by adding a Citation, the list (which is still referenced in the serialized Event) is just updated. So self.original appears to have changed.

So serializing an object is not quite enough to preserve its state when you are editing the object's lists.

This fixes the problem by making a full copy (including the lists) of the original, prior to editing.