### PR TITLE
Fix error in Birthday and Anniversary report

### DIFF
--- a/gramps/plugins/textreport/birthdayreport.py
+++ b/gramps/plugins/textreport/birthdayreport.py
@@ -271,6 +271,7 @@ class BirthdayReport(Report):
             for person_handle in people:
                 step()
                 person = self.database.get_person_from_handle(person_handle)
+                short_name = self.get_name(person)
                 birth_ref = person.get_birth_ref()
                 birth_date = None
                 if birth_ref:


### PR DESCRIPTION
Fixes an error triggered when the first person_handle in the list
has a death event, but no birth event (get_birth_ref() == None)
and does not have family relationships (spouse_handle == None).
These conditions lead to the local variable short_name not being
declared before it comes time to process death events.

Fixes #11766