### PR TITLE
Completing pip installability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,3 +122,25 @@ after_success:
 # picks up coverage from /usr/bin, rather than from
 # /home/travis/virtualenv/python3.3.6/bin/
  - PATH=/usr/bin:$PATH bash <(curl -s https://codecov.io/bash)
+
+stages:
+  - test
+  # Only execute deployment stage on tagged commits, and from our repository
+  # (e.g. not PRs).
+  - name: deploy
+    if: tag IS PRESENT AND repo = gramps-project/gramps
+
+env:
+  global:
+    - TWINE_USERNAME=__token__
+
+jobs:
+  include:
+    # Deploy source distribution
+    - stage: deploy
+      name: Deploy source distribution and wheel
+      install: skip
+      script: python3 setup.py sdist bdist_wheel
+      after_success: |
+        python3 -m pip install twine
+        python3 -m twine upload --repository testpypi --skip-existing dist/*

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ if sys.version_info < (3, 2):
     raise SystemExit("Gramps requires Python 3.2 or later.")
 
 from distutils import log
-from distutils.core import setup, Command
+from setuptools import setup
+from distutils.core import Command
 from distutils.util import convert_path, newer
 from distutils.command.build import build as _build
 import os
@@ -400,6 +401,13 @@ setup(name = 'gramps',
       cmdclass = {'build': build, 'test': test},
       packages = packages,
       package_data = {'gramps': package_data},
+      extras_require={
+          "bsddb": ["bsddb3"],
+          "image": ["Pillow"],
+          "i18n": ["PyICU"],
+          "GUI":  ["PyGObject", "pycairo"],
+          "testing": ["jsonschema", "mock", "lxml"],
+      },
       data_files = data_files,
       scripts = ['scripts/gramps'],
       classifiers = [


### PR DESCRIPTION
Based on the changes by @Nick-Hall in #1106, this PR will make Gramps (the Python library) installable via `pip` and will push the source distribution and a platform-independent wheel to PyPI automatically for tagged commits.

For clarification, this won't be a supported installation method for the desktop application, but will be very useful for things like a [web API](https://github.com/gramps-project/web-api).

In detail:

- It replaces `disutils.setup` by `setuptools.setup` in `setup.py` to provide the `bdist_wheel` command
- It adds `extras_require` to be able to install extra Python requirements
- It adds an automatic deploy stage to the Travis CI configuration. In order to work, this needs defining a PyPI deploy token as Travis environment variable (I'll be happy to assist there. I tried it successfuly on TestPyPI.)

After deployment, the Gramps Python library can be installed, e.g. in a venv, like this:

```
python3 -m pip install gramps
```

Some extras require non-Python dependencies. For instance, for locale support, on Ubuntu one would need
```
sudo apt install build-essential libicu-dev
python3 -m pip install gramps[i18n]
```
