### PR TITLE
Allow setting DB read-only in CLI DB handler

### DIFF
--- a/gramps/cli/grampscli.py
+++ b/gramps/cli/grampscli.py
@@ -47,7 +47,7 @@ LOG = logging.getLogger(".grampscli")
 from gramps.gen.display.name import displayer as name_displayer
 from gramps.gen.config import config
 from gramps.gen.const import PLUGINS_DIR, USER_PLUGINS
-from gramps.gen.db.dbconst import DBBACKEND
+from gramps.gen.db.dbconst import DBBACKEND, DBMODE_R, DBMODE_W
 from gramps.gen.db.utils import make_database
 from gramps.gen.errors import DbError
 from gramps.gen.dbstate import DbState
@@ -128,7 +128,7 @@ class CLIDbLoader:
         """
         pass
 
-    def read_file(self, filename, username, password, mode=None):
+    def read_file(self, filename, username, password, mode=DBMODE_W):
         """
         This method takes care of changing database, and loading the data.
         In 3.0 we only allow reading of real databases of filetype
@@ -143,17 +143,11 @@ class CLIDbLoader:
         should enable signals, as well as finish up with other UI goodies.
         """
 
-        if mode is None:
-            if os.path.exists(filename):
-                if not os.access(filename, os.W_OK):
-                    mode = "r"
-                    self._warn(_('Read only database'),
-                               _('You do not have write access '
-                                 'to the selected file.'))
-                else:
-                    mode = "w"
-            else:
-                mode = 'w'
+        if os.path.exists(filename) and not os.access(filename, os.W_OK):
+            mode = DBMODE_R
+            self._warn(_('Read only database'),
+                       _('You do not have write access '
+                         'to the selected file.'))
 
         dbid_path = os.path.join(filename, DBBACKEND)
         if os.path.isfile(dbid_path):

--- a/gramps/cli/grampscli.py
+++ b/gramps/cli/grampscli.py
@@ -148,8 +148,8 @@ class CLIDbLoader:
                 if not os.access(filename, os.W_OK):
                     mode = "r"
                     self._warn(_('Read only database'),
-                            _('You do not have write access '
-                                'to the selected file.'))
+                               _('You do not have write access '
+                                 'to the selected file.'))
                 else:
                     mode = "w"
             else:
@@ -225,7 +225,9 @@ class CLIManager:
         print(_('ERROR: %s') % errormessage, file=sys.stderr)
         sys.exit(1)
 
-    def _read_recent_file(self, filename, username=None, password=None, mode=None):
+    def _read_recent_file(
+            self, filename, username=None, password=None, mode=None
+        ):
         """
         Called when a file needs to be loaded
         """

--- a/gramps/cli/grampscli.py
+++ b/gramps/cli/grampscli.py
@@ -128,7 +128,7 @@ class CLIDbLoader:
         """
         pass
 
-    def read_file(self, filename, username, password):
+    def read_file(self, filename, username, password, mode=None):
         """
         This method takes care of changing database, and loading the data.
         In 3.0 we only allow reading of real databases of filetype
@@ -143,16 +143,17 @@ class CLIDbLoader:
         should enable signals, as well as finish up with other UI goodies.
         """
 
-        if os.path.exists(filename):
-            if not os.access(filename, os.W_OK):
-                mode = "r"
-                self._warn(_('Read only database'),
-                           _('You do not have write access '
-                             'to the selected file.'))
+        if mode is None:
+            if os.path.exists(filename):
+                if not os.access(filename, os.W_OK):
+                    mode = "r"
+                    self._warn(_('Read only database'),
+                            _('You do not have write access '
+                                'to the selected file.'))
+                else:
+                    mode = "w"
             else:
-                mode = "w"
-        else:
-            mode = 'w'
+                mode = 'w'
 
         dbid_path = os.path.join(filename, DBBACKEND)
         if os.path.isfile(dbid_path):
@@ -211,11 +212,11 @@ class CLIManager:
         self._pmgr = BasePluginManager.get_instance()
         self.user = user
 
-    def open_activate(self, path, username=None, password=None):
+    def open_activate(self, path, username=None, password=None, mode=None):
         """
         Open and make a family tree active
         """
-        self._read_recent_file(path, username, password)
+        self._read_recent_file(path, username, password, mode=mode)
 
     def _errordialog(self, title, errormessage):
         """
@@ -224,7 +225,7 @@ class CLIManager:
         print(_('ERROR: %s') % errormessage, file=sys.stderr)
         sys.exit(1)
 
-    def _read_recent_file(self, filename, username=None, password=None):
+    def _read_recent_file(self, filename, username=None, password=None, mode=None):
         """
         Called when a file needs to be loaded
         """
@@ -245,7 +246,7 @@ class CLIManager:
                   "that the database is not in use."))
             return
 
-        if self.db_loader.read_file(filename, username, password):
+        if self.db_loader.read_file(filename, username, password, mode=mode):
             # Attempt to figure out the database title
             path = os.path.join(filename, "name.txt")
             try:


### PR DESCRIPTION
This is a very simple change that adds a keyword argument `mode` to the methods `CLIDbLoader.read_file` and `CLIManager.open_activate`. At the moment, whether the database is open in readonly mode by the CLI is determined only by whether the directory is writable or not. However, there might be use cases where the DB should be opened in readonly mode even if it could be writable in principle. In particular, opening it in readonly mode avoids writing a lock file, so that multiple such calls could be run in parallel.

My specific use case is the use of the CLI DB handler for the [web API](https://github.com/gramps-project/web-api): while in principle the use of the database by a web server is completely analogous to the CLI, so the class can be used directly, there is one difference: for read-only operations, it is preferable to allow simultaneous read access, which requires *not* writing a lock file. With this (very minor) change, this is achieved by simply using `open_activate(..., mode="r")`.

In the future, this could in principle even be used to add a `--readonly` switch to the CLI to allow batch operations without locking the DB.

But for the moment, merging this would tremendously simplify work on the web API without having to monkey-patch classes :wink: 