### PR TITLE
Add __main__.py

### DIFF
--- a/gramps/__main__.py
+++ b/gramps/__main__.py
@@ -1,0 +1,31 @@
+#! /usr/bin/env python3
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2012       Benny Malengier
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+#
+
+"""This is a stub to start Gramps.
+
+It is provided to be able to start gramps as `python3 -m gramps`,
+e.g. in a virtual environment.
+"""
+
+import gramps.grampsapp as app
+
+if __name__ == "__main__":
+    app.main()

--- a/gramps/cli/argparser.py
+++ b/gramps/cli/argparser.py
@@ -54,7 +54,7 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 
 _HELP = _("""
-Usage: gramps.py [OPTION...]
+Usage: gramps [OPTION...]
   --load-modules=MODULE1,MODULE2,...     Dynamic modules to load
 
 Help options

--- a/gramps/cli/test/cli_test.py
+++ b/gramps/cli/test/cli_test.py
@@ -94,6 +94,25 @@ class Test(unittest.TestCase):
         g = re.search("INDI", content)
         self.assertTrue(g, "found 'INDI' in output file")
 
+    def test2_exec_cli_m(self):
+        """Test the `python -m gramps` way to run the CLI."""
+        ifile = min1r
+        ofile = out_ged
+        gcmd = [sys.executable, "-m", "gramps", "-i", ifile, "-e", ofile]
+        process = subprocess.Popen(gcmd,
+                                   stdin=subprocess.PIPE,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
+        result_str, err_str = process.communicate()
+        self.assertEqual(process.returncode, 0,
+                         "executed CLI command %r" % gcmd)
+        # simple validation o output
+        self.assertTrue(os.path.isfile(ofile), "output file created")
+        with open(ofile) as f:
+            content = f.read()
+        g = re.search("INDI", content)
+        self.assertTrue(g, "found 'INDI' in output file")
+
     # this verifies that files in the temporary "import dir"
     # get cleaned before (and after) running a CLI
     # (eg cleanout stale files from prior crash-runs)

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -8,6 +8,7 @@ setup.py
 # gramps
 #
 gramps/__init__.py
+gramps/__main__.py
 gramps/version.py
 #
 # cli


### PR DESCRIPTION
Another very simple PR which adds a single file: `gramps/__main__.py`, which is nothing but a copy of `Gramps.py` or `scripts/gramps` (apart from the `if` statement).

Rationale: it allows to start Gramps (the GUI or the CLI) on any system alternatively with `python3 -m gramps` instead of `gramps`. This has a small benefit if the `gramps` script does not happen to be in the `PATH` for some reason. But the main motivation for this PR is to be able to start Gramps without problems when installed in a virtual environment, e.g. with pip (cf. #1114). Using the `-m` notation avoids any ambiguities which Python interpreter is used to run the GUI/CLI. 