### PR TITLE
Added support for open spans.

### DIFF
--- a/gramps/gen/datehandler/_date_ar.py
+++ b/gramps/gen/datehandler/_date_ar.py
@@ -23,29 +23,29 @@
 Arabic-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 from ..const import ARABIC_COMMA
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Arabic parser class
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserAR(DateParser):
     """
     Convert a text string into a Date object. If the date cannot be
@@ -54,117 +54,183 @@ class DateParserAR(DateParser):
 
     # modifiers before the date
     modifier_to_int = {
-        'قبل' : Date.MOD_BEFORE,
-        'قبل'    : Date.MOD_BEFORE,
-        'قبل.'   : Date.MOD_BEFORE,
-        'بعد'  : Date.MOD_AFTER,
-        'بعد'    : Date.MOD_AFTER,
-        'بعد.'   : Date.MOD_AFTER,
-        'حوالي'  : Date.MOD_ABOUT,
-        'حوالي.'   : Date.MOD_ABOUT,
-        'حوالي'    : Date.MOD_ABOUT,
-        'حوالي'  : Date.MOD_ABOUT,
-        'حوالي.'     : Date.MOD_ABOUT,
-        'حوالي' : Date.MOD_ABOUT,
-        }
+        "قبل": Date.MOD_BEFORE,
+        "قبل": Date.MOD_BEFORE,
+        "قبل.": Date.MOD_BEFORE,
+        "بعد": Date.MOD_AFTER,
+        "بعد": Date.MOD_AFTER,
+        "بعد.": Date.MOD_AFTER,
+        "حوالي": Date.MOD_ABOUT,
+        "حوالي.": Date.MOD_ABOUT,
+        "حوالي": Date.MOD_ABOUT,
+        "حوالي": Date.MOD_ABOUT,
+        "حوالي.": Date.MOD_ABOUT,
+        "حوالي": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     islamic_to_int = {
-        "محرّم"           : 1,  "محرّم الحرام"  : 1,
-        "صفر"              : 2,  "ربيع الأول"      : 3,
-        "ربيع 1"             : 3,  "ربيع الأخير"      : 4,
-        "ربيع الثاني"     : 4,  "ربيع الثاني"    : 4,
-        "ربيع الثاني"     : 4,  "ربيع الثاني"    : 4,
-        "ربيع 2"           : 4,  "جمادى الأولى"       : 5,
-        "جمادى الأول"   : 5,  "جمادى 1"          : 5,
-        "جمادى الثانية"     : 6,  "جمادى الأخير"   : 6,
-        "جمادى الثاني"  : 6,  "جمادى 2"         : 5,
-        "رجب"              : 7,  "شعبان"            : 8,
-        "شعبان"           : 8,  "رمضان"            : 9,
-        "رمضان"           : 9,  "شوال"            : 10,
-        "ذو القعدة"        : 11, "ذو القعدة"          : 11,
-        "ذو القعدة"      : 11, "ذو الحجة"        : 12,
-        "ذو الحجة"          : 12, "ذو الحجة"      : 12,
-        }
+        "محرّم": 1,
+        "محرّم الحرام": 1,
+        "صفر": 2,
+        "ربيع الأول": 3,
+        "ربيع 1": 3,
+        "ربيع الأخير": 4,
+        "ربيع الثاني": 4,
+        "ربيع الثاني": 4,
+        "ربيع الثاني": 4,
+        "ربيع الثاني": 4,
+        "ربيع 2": 4,
+        "جمادى الأولى": 5,
+        "جمادى الأول": 5,
+        "جمادى 1": 5,
+        "جمادى الثانية": 6,
+        "جمادى الأخير": 6,
+        "جمادى الثاني": 6,
+        "جمادى 2": 5,
+        "رجب": 7,
+        "شعبان": 8,
+        "شعبان": 8,
+        "رمضان": 9,
+        "رمضان": 9,
+        "شوال": 10,
+        "ذو القعدة": 11,
+        "ذو القعدة": 11,
+        "ذو القعدة": 11,
+        "ذو الحجة": 12,
+        "ذو الحجة": 12,
+        "ذو الحجة": 12,
+    }
 
-    bce = ["قبل الميلاد", "قبل الميلاد", "قبل الميلاد", "قبل الميلاد", "قبل الميلاد", "قبل الميلاد" ]
+    bce = [
+        "قبل الميلاد",
+        "قبل الميلاد",
+        "قبل الميلاد",
+        "قبل الميلاد",
+        "قبل الميلاد",
+        "قبل الميلاد",
+    ]
 
     calendar_to_int = {
-        'غريغوري'        : Date.CAL_GREGORIAN,
-        'غريغوري'                : Date.CAL_GREGORIAN,
-        'يوليوسي'           : Date.CAL_JULIAN,
-        'يوليوسي'                : Date.CAL_JULIAN,
-        'عبري'           : Date.CAL_HEBREW,
-        'عبري'                : Date.CAL_HEBREW,
-        'إسلامي'          : Date.CAL_ISLAMIC,
-        'إسلامي'                : Date.CAL_ISLAMIC,
-        'فرنسي'           : Date.CAL_FRENCH,
-        'فرنسي جمهوري': Date.CAL_FRENCH,
-        'فرنسي'                : Date.CAL_FRENCH,
-        'فارسي'          : Date.CAL_PERSIAN,
-        'فارسي'                : Date.CAL_PERSIAN,
-        'سويدي'          : Date.CAL_SWEDISH,
-        'سويدي'                : Date.CAL_SWEDISH,
-        }
+        "غريغوري": Date.CAL_GREGORIAN,
+        "غريغوري": Date.CAL_GREGORIAN,
+        "يوليوسي": Date.CAL_JULIAN,
+        "يوليوسي": Date.CAL_JULIAN,
+        "عبري": Date.CAL_HEBREW,
+        "عبري": Date.CAL_HEBREW,
+        "إسلامي": Date.CAL_ISLAMIC,
+        "إسلامي": Date.CAL_ISLAMIC,
+        "فرنسي": Date.CAL_FRENCH,
+        "فرنسي جمهوري": Date.CAL_FRENCH,
+        "فرنسي": Date.CAL_FRENCH,
+        "فارسي": Date.CAL_PERSIAN,
+        "فارسي": Date.CAL_PERSIAN,
+        "سويدي": Date.CAL_SWEDISH,
+        "سويدي": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        'متوقع'  : Date.QUAL_ESTIMATED,
-        'متوقع.'       : Date.QUAL_ESTIMATED,
-        'متوقع'        : Date.QUAL_ESTIMATED,
-        'محسوب.'      : Date.QUAL_CALCULATED,
-        'محسوب'       : Date.QUAL_CALCULATED,
-        'محسوب' : Date.QUAL_CALCULATED,
-        }
+        "متوقع": Date.QUAL_ESTIMATED,
+        "متوقع.": Date.QUAL_ESTIMATED,
+        "متوقع": Date.QUAL_ESTIMATED,
+        "محسوب.": Date.QUAL_CALCULATED,
+        "محسوب": Date.QUAL_CALCULATED,
+        "محسوب": Date.QUAL_CALCULATED,
+    }
 
     def init_strings(self):
         """
         This method compiles regular expression strings for matching dates.
         """
         DateParser.init_strings(self)
-        _span_1 = ['من']
-        _span_2 = ['إلى']
-        _range_1 = ['بين']
-        _range_2 = ['و']
+        _span_1 = ["من"]
+        _span_2 = ["إلى"]
+        _range_1 = ["بين"]
+        _range_2 = ["و"]
         self._span = re.compile(
-            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-            ('|'.join(_span_1), '|'.join(_span_2)), re.IGNORECASE)
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_span_1), "|".join(_span_2)),
+            re.IGNORECASE,
+        )
         self._range = re.compile(
-            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-            ('|'.join(_range_1), '|'.join(_range_2)), re.IGNORECASE)
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_range_1), "|".join(_range_2)),
+            re.IGNORECASE,
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Arabic display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayAR(DateDisplay):
     """
     Arabic language date display class.
     """
-    # this is used to display the 12 gregorian months
-    long_months = ( "", "كانون الثاني", "شباط", "آذار", "نيسان", "أيار",
-                    "حزيران", "تموز", "آب", "أيلول", "تشرين الأول",
-                    "تشرين الثاني", "كانون الأول" )
 
-    short_months = ( "", "كانون2", "شباط", "آذار", "نيسان", "أيار", "حزيران",
-                     "تموز", "آب", "أيلول", "تشرين1", "تشرين2", "كانون1" )
+    # this is used to display the 12 gregorian months
+    long_months = (
+        "",
+        "كانون الثاني",
+        "شباط",
+        "آذار",
+        "نيسان",
+        "أيار",
+        "حزيران",
+        "تموز",
+        "آب",
+        "أيلول",
+        "تشرين الأول",
+        "تشرين الثاني",
+        "كانون الأول",
+    )
+
+    short_months = (
+        "",
+        "كانون2",
+        "شباط",
+        "آذار",
+        "نيسان",
+        "أيار",
+        "حزيران",
+        "تموز",
+        "آب",
+        "أيلول",
+        "تشرين1",
+        "تشرين2",
+        "كانون1",
+    )
 
     islamic = (
-        "", "محرّم", "صفر", "ربيع الأول", "ربيع الثاني",
-        "جمادى الأولى", "جمادى الثانية", "رجب", "شعبان",
-        "رمضان", "شوال", "ذو القعدة", "ذو الحجة"
-        )
+        "",
+        "محرّم",
+        "صفر",
+        "ربيع الأول",
+        "ربيع الثاني",
+        "جمادى الأولى",
+        "جمادى الثانية",
+        "رجب",
+        "شعبان",
+        "رمضان",
+        "شوال",
+        "ذو القعدة",
+        "ذو الحجة",
+    )
 
     formats = (
-        "YYYY-MM-DD (قياسي)", "عددي", "شهر يوم, سنة",
-        "شهر يوم, سنة", "يوم شهر سنة", "يوم شهر سنة"
-        )
-        # this must agree with DateDisplayEn's "formats" definition
-        # (since no locale-specific _display_gregorian exists, here)
+        "YYYY-MM-DD (قياسي)",
+        "عددي",
+        "شهر يوم, سنة",
+        "شهر يوم, سنة",
+        "يوم شهر سنة",
+        "يوم شهر سنة",
+    )
+    # this must agree with DateDisplayEn's "formats" definition
+    # (since no locale-specific _display_gregorian exists, here)
 
-    calendar = (
-        "", "يوليوسي", "عبري", "فرنسي",
-        "فارسي", "إسلامي", "سويدي"
-        )
+    calendar = ("", "يوليوسي", "عبري", "فرنسي", "فارسي", "إسلامي", "سويدي")
 
     _mod_str = ("", "قبل ", "بعد ", "حوالي ", "", "", "")
 
@@ -192,12 +258,12 @@ class DateDisplayAR(DateDisplay):
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'من', d1, 'إلى', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "من", d1, "إلى", d2, scal)
         elif mod == Date.MOD_RANGE:
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'بين', d1, 'و', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "بين", d1, "و", d2, scal)
         else:
             text = self.display_cal[date.get_calendar()](start)
             scal = self.format_extras(cal, newyear)
@@ -208,27 +274,30 @@ class DateDisplayAR(DateDisplay):
         numerical -- for Arabic dates
         """
         value = DateDisplay.dd_dformat01(self, date_val)
-        return value.replace(',', ARABIC_COMMA)
+        return value.replace(",", ARABIC_COMMA)
 
     def dd_dformat02(self, date_val, inflect, long_months):
         """
         month_name day, year -- for Arabic dates
         """
         value = DateDisplay.dd_dformat02(self, date_val, inflect, long_months)
-        return value.replace(',', ARABIC_COMMA)
+        return value.replace(",", ARABIC_COMMA)
 
     def dd_dformat03(self, date_val, inflect, short_months):
         """
         month_abbreviation day, year -- for Arabic dates
         """
         value = DateDisplay.dd_dformat03(self, date_val, inflect, short_months)
-        return value.replace(',', ARABIC_COMMA)
+        return value.replace(",", ARABIC_COMMA)
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('ar_EG', 'ar_AR', 'ar', 'Arabic', 'arabic', ('%d %b, %Y',)),
-    DateParserAR, DateDisplayAR)
+    ("ar_EG", "ar_AR", "ar", "Arabic", "arabic", ("%d %b, %Y",)),
+    DateParserAR,
+    DateDisplayAR,
+)

--- a/gramps/gen/datehandler/_date_bg.py
+++ b/gramps/gen/datehandler/_date_bg.py
@@ -23,172 +23,202 @@
 Bulgarian-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Bulgarian parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserBG(DateParser):
 
     modifier_to_int = {
-        'преди'          : Date.MOD_BEFORE,
-        'пр.'            : Date.MOD_BEFORE,
-        'пр'             : Date.MOD_BEFORE,
-        'след'           : Date.MOD_AFTER,
-        'сл.'            : Date.MOD_AFTER,
-        'сл'             : Date.MOD_AFTER,
-        'ок'             : Date.MOD_ABOUT,
-        'ок.'            : Date.MOD_ABOUT,
-        'около'          : Date.MOD_ABOUT,
-        'примерно'       : Date.MOD_ABOUT,
-        'прим'           : Date.MOD_ABOUT,
-        'прим.'          : Date.MOD_ABOUT,
-        'приблизително'  : Date.MOD_ABOUT,
-        'приб.'          : Date.MOD_ABOUT,
-        'прибл.'         : Date.MOD_ABOUT,
-        'приб'           : Date.MOD_ABOUT,
-        'прибл'          : Date.MOD_ABOUT,
-        }
+        "преди": Date.MOD_BEFORE,
+        "пр.": Date.MOD_BEFORE,
+        "пр": Date.MOD_BEFORE,
+        "след": Date.MOD_AFTER,
+        "сл.": Date.MOD_AFTER,
+        "сл": Date.MOD_AFTER,
+        "ок": Date.MOD_ABOUT,
+        "ок.": Date.MOD_ABOUT,
+        "около": Date.MOD_ABOUT,
+        "примерно": Date.MOD_ABOUT,
+        "прим": Date.MOD_ABOUT,
+        "прим.": Date.MOD_ABOUT,
+        "приблизително": Date.MOD_ABOUT,
+        "приб.": Date.MOD_ABOUT,
+        "прибл.": Date.MOD_ABOUT,
+        "приб": Date.MOD_ABOUT,
+        "прибл": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     calendar_to_int = {
-        'григориански'          : Date.CAL_GREGORIAN,
-        'г'                     : Date.CAL_GREGORIAN,
-        'юлиански'              : Date.CAL_JULIAN,
-        'ю'                     : Date.CAL_JULIAN,
-        'еврейски'              : Date.CAL_HEBREW,
-        'е'                     : Date.CAL_HEBREW,
-        'ислямски'              : Date.CAL_ISLAMIC,
-        'и'                     : Date.CAL_ISLAMIC,
-        'френски републикански' : Date.CAL_FRENCH,
-        'републикански'         : Date.CAL_FRENCH,
-        'фр.реп.'               : Date.CAL_FRENCH,
-        'р'                     : Date.CAL_FRENCH,
-        'френски'               : Date.CAL_FRENCH,
-        'фр.'                   : Date.CAL_FRENCH,
-        'персийски'             : Date.CAL_PERSIAN,
-        'п'                     : Date.CAL_PERSIAN,
-        }
+        "григориански": Date.CAL_GREGORIAN,
+        "г": Date.CAL_GREGORIAN,
+        "юлиански": Date.CAL_JULIAN,
+        "ю": Date.CAL_JULIAN,
+        "еврейски": Date.CAL_HEBREW,
+        "е": Date.CAL_HEBREW,
+        "ислямски": Date.CAL_ISLAMIC,
+        "и": Date.CAL_ISLAMIC,
+        "френски републикански": Date.CAL_FRENCH,
+        "републикански": Date.CAL_FRENCH,
+        "фр.реп.": Date.CAL_FRENCH,
+        "р": Date.CAL_FRENCH,
+        "френски": Date.CAL_FRENCH,
+        "фр.": Date.CAL_FRENCH,
+        "персийски": Date.CAL_PERSIAN,
+        "п": Date.CAL_PERSIAN,
+    }
 
     quality_to_int = {
-        'приблизително'  : Date.QUAL_ESTIMATED,
-        'прибл.'         : Date.QUAL_ESTIMATED,
-        'изчислено'      : Date.QUAL_CALCULATED,
-        'изчисл.'        : Date.QUAL_CALCULATED,
-        'изч.'           : Date.QUAL_CALCULATED,
-        }
+        "приблизително": Date.QUAL_ESTIMATED,
+        "прибл.": Date.QUAL_ESTIMATED,
+        "изчислено": Date.QUAL_CALCULATED,
+        "изчисл.": Date.QUAL_CALCULATED,
+        "изч.": Date.QUAL_CALCULATED,
+    }
 
     hebrew_to_int = {
-        "тишрей":1,
-        "мархешван":2,
-        "кислев":3,
-        "тевет":4,
-        "шват":5,
-        "адар":6,
-        "адар бет":7,
-        "нисан":8,
-        "ияр":9,
-        "сиван":10,
-        "тамуз":11,
-        "ав":12,
-        "eлул":13,
+        "тишрей": 1,
+        "мархешван": 2,
+        "кислев": 3,
+        "тевет": 4,
+        "шват": 5,
+        "адар": 6,
+        "адар бет": 7,
+        "нисан": 8,
+        "ияр": 9,
+        "сиван": 10,
+        "тамуз": 11,
+        "ав": 12,
+        "eлул": 13,
     }
 
     islamic_to_int = {
-        "мухаррам":1,
-        "саффар":2,
-        "рабиу-л-ауал":3,
-        "рабиу-с-сани":4,
-        "джумадал-уля":5,
-        "джумада-с-сания":6,
-        "раджаб":7,
-        "шаабан":8,
-        "рамадан":9,
-        "шауал":10,
-        "зу-л-кида":11,
-        "зул-л-хиджа":12,
-        }
+        "мухаррам": 1,
+        "саффар": 2,
+        "рабиу-л-ауал": 3,
+        "рабиу-с-сани": 4,
+        "джумадал-уля": 5,
+        "джумада-с-сания": 6,
+        "раджаб": 7,
+        "шаабан": 8,
+        "рамадан": 9,
+        "шауал": 10,
+        "зу-л-кида": 11,
+        "зул-л-хиджа": 12,
+    }
 
     persian_to_int = {
-        "фарвардин":1,
-        "урдбихищ":2,
-        "хурдад":3,
-        "тир":4,
-        "мурдад":5,
-        "шахривар":6,
-        "михр":7,
-        "абан":8,
-        "азар":9,
-        "дай":10,
-        "бахман":11,
-        "исфаидармуз":12,
-        }
+        "фарвардин": 1,
+        "урдбихищ": 2,
+        "хурдад": 3,
+        "тир": 4,
+        "мурдад": 5,
+        "шахривар": 6,
+        "михр": 7,
+        "абан": 8,
+        "азар": 9,
+        "дай": 10,
+        "бахман": 11,
+        "исфаидармуз": 12,
+    }
 
     french_to_int = {
-        "вандемер":1,
-        "брюмер":2,
-        "фример":3,
-        "нивоз":4,
-        "плювиоз":5,
-        "вантоз":6,
-        "жерминал":7,
-        "флореал":8,
-        "прериал":9,
-        "месидор":10,
-        "термидор":11,
-        "фрюктидор":12,
-        "допълнителен":13,
-        }
+        "вандемер": 1,
+        "брюмер": 2,
+        "фример": 3,
+        "нивоз": 4,
+        "плювиоз": 5,
+        "вантоз": 6,
+        "жерминал": 7,
+        "флореал": 8,
+        "прериал": 9,
+        "месидор": 10,
+        "термидор": 11,
+        "фрюктидор": 12,
+        "допълнителен": 13,
+    }
 
-    bce = [
-        'преди Христа', 'пр. Хр.', 'пр.Хр.'
-        ] + DateParser.bce
+    bce = ["преди Христа", "пр. Хр.", "пр.Хр."] + DateParser.bce
 
     def init_strings(self):
         DateParser.init_strings(self)
-        _span_1 = ['от']
-        _span_2 = ['до']
-        _range_1 = ['между']
-        _range_2 = ['и']
+        _span_1 = ["от"]
+        _span_2 = ["до"]
+        _range_1 = ["между"]
+        _range_2 = ["и"]
         self._span = re.compile(
-            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-            ('|'.join(_span_1), '|'.join(_span_2)), re.IGNORECASE)
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_span_1), "|".join(_span_2)),
+            re.IGNORECASE,
+        )
         self._range = re.compile(
-            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-            ('|'.join(_range_1), '|'.join(_range_2)), re.IGNORECASE)
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_range_1), "|".join(_range_2)),
+            re.IGNORECASE,
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Bulgarian displayer
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayBG(DateDisplay):
     """
     Bulgarian language date display class.
     """
-    long_months = ( "", "януари", "февруари", "март", "април", "май",
-                    "юни", "юли", "август", "септември", "октомври",
-                    "ноември", "декември" )
 
-    short_months = ( "", "яну", "февр", "март", "апр", "май", "юни",
-                     "юли", "авг", "септ", "окт", "ное", "дек" )
+    long_months = (
+        "",
+        "януари",
+        "февруари",
+        "март",
+        "април",
+        "май",
+        "юни",
+        "юли",
+        "август",
+        "септември",
+        "октомври",
+        "ноември",
+        "декември",
+    )
 
+    short_months = (
+        "",
+        "яну",
+        "февр",
+        "март",
+        "апр",
+        "май",
+        "юни",
+        "юли",
+        "авг",
+        "септ",
+        "окт",
+        "ное",
+        "дек",
+    )
 
     calendar = (
         "",
@@ -197,8 +227,8 @@ class DateDisplayBG(DateDisplay):
         "републикански",
         "персийски",
         "ислямски",
-        "шведски"
-        )
+        "шведски",
+    )
 
     _mod_str = ("", "преди ", "след ", "около ", "", "", "")
 
@@ -207,12 +237,18 @@ class DateDisplayBG(DateDisplay):
     _bce_str = "%s пр. Хр."
 
     formats = (
-        "ГГГГ-ММ-ДД (ISO)", "Числов", "Месец Ден, Година", "Мес. Ден, Година", "Ден Месец Година", "Ден Мес. Година"
-        )
-        # this must agree with DateDisplayEn's "formats" definition
-        # (since no locale-specific _display_gregorian exists, here)
+        "ГГГГ-ММ-ДД (ISO)",
+        "Числов",
+        "Месец Ден, Година",
+        "Мес. Ден, Година",
+        "Ден Месец Година",
+        "Ден Мес. Година",
+    )
+    # this must agree with DateDisplayEn's "formats" definition
+    # (since no locale-specific _display_gregorian exists, here)
 
-    hebrew = ( "",
+    hebrew = (
+        "",
         "Тишрей",
         "Мархешван",
         "Кислев",
@@ -226,9 +262,10 @@ class DateDisplayBG(DateDisplay):
         "Тамуз",
         "Ав",
         "Елул",
-        )
+    )
 
-    islamic = ( "",
+    islamic = (
+        "",
         "Мухаррам",
         "Саффар",
         "Рабиу-л-ауал",
@@ -241,9 +278,10 @@ class DateDisplayBG(DateDisplay):
         "Шауал",
         "Зу-л-кида",
         "Зул-л-хиджа",
-        )
+    )
 
-    persian = ( "",
+    persian = (
+        "",
         "Фарвардин",
         "Урдбихищ",
         "Хурдад",
@@ -256,9 +294,10 @@ class DateDisplayBG(DateDisplay):
         "Дай",
         "Бахман",
         "Исфаидармуз",
-        )
+    )
 
-    french = ( "",
+    french = (
+        "",
         "Вандемер",
         "Брюмер",
         "Фример",
@@ -271,8 +310,8 @@ class DateDisplayBG(DateDisplay):
         "Мессидор",
         "Термидор",
         "Фрюктидор",
-        "Допълнителен"
-        )
+        "Допълнителен",
+    )
 
     def display(self, date):
         """
@@ -294,12 +333,12 @@ class DateDisplayBG(DateDisplay):
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'от', d1, 'до', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "от", d1, "до", d2, scal)
         elif mod == Date.MOD_RANGE:
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'между', d1, 'и', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "между", d1, "и", d2, scal)
         else:
             text = self.display_cal[date.get_calendar()](start)
             scal = self.format_extras(cal, newyear)
@@ -315,21 +354,24 @@ class DateDisplayBG(DateDisplay):
             if date_val[0] == date_val[1] == 0:
                 return str(date_val[2])
             else:
-                value = self.dhformat.replace('%m', str(date_val[1]))
+                value = self.dhformat.replace("%m", str(date_val[1]))
                 # some locales have %b for the month, e.g. ar_EG, is_IS, nb_NO
-                value = value.replace('%b', str(date_val[1]))
-                if date_val[0] == 0: # ignore the zero day and its delimiter
-                    i_day = value.find('%e') # Bulgarian uses %e and not %d
-                    value = value.replace(value[i_day:i_day+3], '')
-                value = value.replace('%e', str(date_val[0]))
-                value = value.replace('%Y', str(abs(date_val[2])))
-                return value.replace('-', '/')
+                value = value.replace("%b", str(date_val[1]))
+                if date_val[0] == 0:  # ignore the zero day and its delimiter
+                    i_day = value.find("%e")  # Bulgarian uses %e and not %d
+                    value = value.replace(value[i_day : i_day + 3], "")
+                value = value.replace("%e", str(date_val[0]))
+                value = value.replace("%Y", str(abs(date_val[2])))
+                return value.replace("-", "/")
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('bg_BG', 'bg', 'bulgarian', 'Bulgarian', ('%e.%m.%Y',)),
-    DateParserBG, DateDisplayBG)
+    ("bg_BG", "bg", "bulgarian", "Bulgarian", ("%e.%m.%Y",)),
+    DateParserBG,
+    DateDisplayBG,
+)

--- a/gramps/gen/datehandler/_date_ca.py
+++ b/gramps/gen/datehandler/_date_ca.py
@@ -25,137 +25,170 @@
 Catalan-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Catalan parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserCA(DateParser):
 
     modifier_to_int = {
-        'abans de'     : Date.MOD_BEFORE,
-        'abans'        : Date.MOD_BEFORE,
-        'ab.'          : Date.MOD_BEFORE,
-        'després de'   : Date.MOD_AFTER,
-        'després'      : Date.MOD_AFTER,
-        'desp.'        : Date.MOD_AFTER,
-        'desp'         : Date.MOD_AFTER,
-        'aprox.'       : Date.MOD_ABOUT,
-        'aprox'        : Date.MOD_ABOUT,
-        'circa'        : Date.MOD_ABOUT,
-        'ca.'          : Date.MOD_ABOUT,
-        'ca'           : Date.MOD_ABOUT,
-        'c.'           : Date.MOD_ABOUT,
-        'cap a'        : Date.MOD_ABOUT,
-        'al voltant'   : Date.MOD_ABOUT,
-        'al voltant de': Date.MOD_ABOUT,
-        }
+        "abans de": Date.MOD_BEFORE,
+        "abans": Date.MOD_BEFORE,
+        "ab.": Date.MOD_BEFORE,
+        "després de": Date.MOD_AFTER,
+        "després": Date.MOD_AFTER,
+        "desp.": Date.MOD_AFTER,
+        "desp": Date.MOD_AFTER,
+        "aprox.": Date.MOD_ABOUT,
+        "aprox": Date.MOD_ABOUT,
+        "circa": Date.MOD_ABOUT,
+        "ca.": Date.MOD_ABOUT,
+        "ca": Date.MOD_ABOUT,
+        "c.": Date.MOD_ABOUT,
+        "cap a": Date.MOD_ABOUT,
+        "al voltant": Date.MOD_ABOUT,
+        "al voltant de": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     calendar_to_int = {
-        'gregorià'     : Date.CAL_GREGORIAN,
-        'g'            : Date.CAL_GREGORIAN,
-        'julià'        : Date.CAL_JULIAN,
-        'j'            : Date.CAL_JULIAN,
-        'hebreu'       : Date.CAL_HEBREW,
-        'h'            : Date.CAL_HEBREW,
-        'islàmic'      : Date.CAL_ISLAMIC,
-        'i'            : Date.CAL_ISLAMIC,
-        'revolucionari': Date.CAL_FRENCH,
-        'r'            : Date.CAL_FRENCH,
-        'persa'        : Date.CAL_PERSIAN,
-        'p'            : Date.CAL_PERSIAN,
-        'swedish'      : Date.CAL_SWEDISH,
-        's'            : Date.CAL_SWEDISH,
-        }
+        "gregorià": Date.CAL_GREGORIAN,
+        "g": Date.CAL_GREGORIAN,
+        "julià": Date.CAL_JULIAN,
+        "j": Date.CAL_JULIAN,
+        "hebreu": Date.CAL_HEBREW,
+        "h": Date.CAL_HEBREW,
+        "islàmic": Date.CAL_ISLAMIC,
+        "i": Date.CAL_ISLAMIC,
+        "revolucionari": Date.CAL_FRENCH,
+        "r": Date.CAL_FRENCH,
+        "persa": Date.CAL_PERSIAN,
+        "p": Date.CAL_PERSIAN,
+        "swedish": Date.CAL_SWEDISH,
+        "s": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        'estimat'   : Date.QUAL_ESTIMATED,
-        'est.'      : Date.QUAL_ESTIMATED,
-        'est'       : Date.QUAL_ESTIMATED,
-        'calc.'     : Date.QUAL_CALCULATED,
-        'calc'      : Date.QUAL_CALCULATED,
-        'calculat'  : Date.QUAL_CALCULATED,
-        }
+        "estimat": Date.QUAL_ESTIMATED,
+        "est.": Date.QUAL_ESTIMATED,
+        "est": Date.QUAL_ESTIMATED,
+        "calc.": Date.QUAL_CALCULATED,
+        "calc": Date.QUAL_CALCULATED,
+        "calculat": Date.QUAL_CALCULATED,
+    }
 
     def init_strings(self):
         DateParser.init_strings(self)
-        _span_1 = ['des de']
-        _span_2 = ['fins a']
-        _range_1 = ['entre', r'ent\.', 'ent']
-        _range_2 = ['i']
+        _span_1 = ["des de"]
+        _span_2 = ["fins a"]
+        _range_1 = ["entre", r"ent\.", "ent"]
+        _range_2 = ["i"]
         self._span = re.compile(
-            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-            ('|'.join(_span_1), '|'.join(_span_2)), re.IGNORECASE)
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_span_1), "|".join(_span_2)),
+            re.IGNORECASE,
+        )
         self._range = re.compile(
-            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-            ('|'.join(_range_1), '|'.join(_range_2)), re.IGNORECASE)
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_range_1), "|".join(_range_2)),
+            re.IGNORECASE,
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Catalan display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayCA(DateDisplay):
     """
     Catalan language date display class.
     """
-    long_months = ( "", "Gener", "Febrer", "Març", "Abril", "Maig",
-                    "Juny", "Juliol", "Agost", "Setembre", "Octubre",
-                    "Novembre", "Desembre" )
 
-    short_months = ( "", "Gen", "Feb", "Mar", "Abr", "Mai", "Jun",
-                     "Jul", "Ago", "Set", "Oct", "Nov", "Des" )
+    long_months = (
+        "",
+        "Gener",
+        "Febrer",
+        "Març",
+        "Abril",
+        "Maig",
+        "Juny",
+        "Juliol",
+        "Agost",
+        "Setembre",
+        "Octubre",
+        "Novembre",
+        "Desembre",
+    )
 
-    calendar = (
-        "", "Julià", "Hebreu",
-        "Revolucionari", "Persa", "Islàmic",
-        "Suec"
-        )
+    short_months = (
+        "",
+        "Gen",
+        "Feb",
+        "Mar",
+        "Abr",
+        "Mai",
+        "Jun",
+        "Jul",
+        "Ago",
+        "Set",
+        "Oct",
+        "Nov",
+        "Des",
+    )
+
+    calendar = ("", "Julià", "Hebreu", "Revolucionari", "Persa", "Islàmic", "Suec")
 
     _mod_str = ("", "abans de ", "després de ", "cap a ", "", "", "")
 
     _qual_str = ("", "estimat ", "calculat ")
 
     french = (
-        '',
+        "",
         "Vendemiari",
-        'Brumari',
-        'Frimari',
+        "Brumari",
+        "Frimari",
         "Nivós",
         "Pluviós",
         "Ventós",
-        'Germinal',
+        "Germinal",
         "Floreal",
-        'Pradial',
-        'Messidor',
-        'Termidor',
-        'Fructidor',
-        'Extra',
-        )
+        "Pradial",
+        "Messidor",
+        "Termidor",
+        "Fructidor",
+        "Extra",
+    )
 
     formats = (
-        "AAAA-MM-DD (ISO)", "Numèrica", "Mes Dia, Any",
-        "MES Dia, Any", "Dia Mes, Any", "Dia MES, Any"
-        )
-        # this must agree with DateDisplayEn's "formats" definition
-        # (since no locale-specific _display_gregorian exists, here)
+        "AAAA-MM-DD (ISO)",
+        "Numèrica",
+        "Mes Dia, Any",
+        "MES Dia, Any",
+        "Dia Mes, Any",
+        "Dia MES, Any",
+    )
+    # this must agree with DateDisplayEn's "formats" definition
+    # (since no locale-specific _display_gregorian exists, here)
 
     def display(self, date):
         """
@@ -177,23 +210,25 @@ class DateDisplayCA(DateDisplay):
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'des de', d1, 'fins a', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "des de", d1, "fins a", d2, scal)
         elif mod == Date.MOD_RANGE:
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'entre', d1, 'i', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "entre", d1, "i", d2, scal)
         else:
             text = self.display_cal[date.get_calendar()](start)
             scal = self.format_extras(cal, newyear)
             return "%s%s%s%s" % (qual_str, self._mod_str[mod], text, scal)
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('ca_ES', 'ca', 'català', 'Catalan',
-     'ca_FR', 'ca_AD', 'ca_IT', ('%d/%m/%Y',)),
-    DateParserCA, DateDisplayCA)
+    ("ca_ES", "ca", "català", "Catalan", "ca_FR", "ca_AD", "ca_IT", ("%d/%m/%Y",)),
+    DateParserCA,
+    DateDisplayCA,
+)

--- a/gramps/gen/datehandler/_date_cs.py
+++ b/gramps/gen/datehandler/_date_cs.py
@@ -23,72 +23,80 @@
 Czech-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Czech parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserCZ(DateParser):
     """
     Converts a text string into a Date object
     """
 
     modifier_to_int = {
-        'před': Date.MOD_BEFORE,
-        'kolem': Date.MOD_ABOUT,
-        'po': Date.MOD_AFTER,
+        "před": Date.MOD_BEFORE,
+        "kolem": Date.MOD_ABOUT,
+        "po": Date.MOD_AFTER,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
     }
 
     quality_to_int = {
-        'přibližně'  : Date.QUAL_ESTIMATED,
-        'odhadem'    : Date.QUAL_ESTIMATED,
-        'odh.'       : Date.QUAL_ESTIMATED,
-        'vypočteno'  : Date.QUAL_CALCULATED,
-        'vypočtené'  : Date.QUAL_CALCULATED,
-        'vyp.'       : Date.QUAL_CALCULATED,
+        "přibližně": Date.QUAL_ESTIMATED,
+        "odhadem": Date.QUAL_ESTIMATED,
+        "odh.": Date.QUAL_ESTIMATED,
+        "vypočteno": Date.QUAL_CALCULATED,
+        "vypočtené": Date.QUAL_CALCULATED,
+        "vyp.": Date.QUAL_CALCULATED,
     }
 
-    bce = ["před naším letopočtem", "před Kristem",
-           "př. n. l.", "př. Kr."] + DateParser.bce
+    bce = [
+        "před naším letopočtem",
+        "před Kristem",
+        "př. n. l.",
+        "př. Kr.",
+    ] + DateParser.bce
 
     def dhformat_changed(self):
-        """ Allow overriding so a subclass can modify it """
+        """Allow overriding so a subclass can modify it"""
         # bug 9739 grampslocale.py gets '%-d.%-m.%Y' -- makes it be '%/d.%/m.%Y'
-        self.dhformat = self.dhformat.replace('/', '') # so counteract that
+        self.dhformat = self.dhformat.replace("/", "")  # so counteract that
 
     def init_strings(self):
         DateParser.init_strings(self)
-        self._text2 = re.compile(r'(\d+)?\.?\s+?%s\.?\s*((\d+)(/\d+)?)?\s*$'
-                                 % self._mon_str, re.IGNORECASE)
+        self._text2 = re.compile(
+            r"(\d+)?\.?\s+?%s\.?\s*((\d+)(/\d+)?)?\s*$" % self._mon_str, re.IGNORECASE
+        )
         self._span = re.compile(
-            r"(od)\s+(?P<start>.+)\s+(do)\s+(?P<stop>.+)",
-            re.IGNORECASE)
+            r"(od)\s+(?P<start>.+)\s+(do)\s+(?P<stop>.+)", re.IGNORECASE
+        )
         self._range = re.compile(
-            r"(mezi)\s+(?P<start>.+)\s+(a)\s+(?P<stop>.+)",
-            re.IGNORECASE)
+            r"(mezi)\s+(?P<start>.+)\s+(a)\s+(?P<stop>.+)", re.IGNORECASE
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Czech display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayCZ(DateDisplay):
     """
     Czech language date display class.
@@ -97,17 +105,17 @@ class DateDisplayCZ(DateDisplay):
     display = DateDisplay.display_formatted
 
     def formats_changed(self):
-        """ Allow overriding so a subclass can modify """
+        """Allow overriding so a subclass can modify"""
 
         # bug 9537 grampslocale.py gets '%-d.%-m.%Y' -- makes it be '%/d.%/m.%Y'
-        self.dhformat = self.dhformat.replace('/', '') # so counteract that
+        self.dhformat = self.dhformat.replace("/", "")  # so counteract that
 
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ("cs_CZ", "cs", "CS", "Czech", ('%-d.%-m.%Y',)),
-    DateParserCZ, DateDisplayCZ)
+    ("cs_CZ", "cs", "CS", "Czech", ("%-d.%-m.%Y",)), DateParserCZ, DateDisplayCZ
+)

--- a/gramps/gen/datehandler/_date_da.py
+++ b/gramps/gen/datehandler/_date_da.py
@@ -23,28 +23,28 @@
 Danish-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Danish parser class
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserDa(DateParser):
     """
     Convert a text string into a Date object, expecting a date
@@ -54,65 +54,94 @@ class DateParserDa(DateParser):
 
     # modifiers before the date
     modifier_to_int = {
-        'før'    : Date.MOD_BEFORE,
-        'inden'  : Date.MOD_BEFORE,
-        'efter'   : Date.MOD_AFTER,
-        'omkring' : Date.MOD_ABOUT,
-        'ca.'     : Date.MOD_ABOUT
-        }
+        "før": Date.MOD_BEFORE,
+        "inden": Date.MOD_BEFORE,
+        "efter": Date.MOD_AFTER,
+        "omkring": Date.MOD_ABOUT,
+        "ca.": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     bce = ["f Kr"]
 
     calendar_to_int = {
-        'gregoriansk   '      : Date.CAL_GREGORIAN,
-        'g'                   : Date.CAL_GREGORIAN,
-        'juliansk tidsregning': Date.CAL_JULIAN,
-        'juliansk'            : Date.CAL_JULIAN,
-        'j'                   : Date.CAL_JULIAN,
-        'hebraisk'            : Date.CAL_HEBREW,
-        'h'                   : Date.CAL_HEBREW,
-        'islamisk'            : Date.CAL_ISLAMIC,
-        'muslimsk'            : Date.CAL_ISLAMIC,
-        'i'                   : Date.CAL_ISLAMIC,
-        'fransk'              : Date.CAL_FRENCH,
-        'fransk republikansk' : Date.CAL_FRENCH,
-        'f'                   : Date.CAL_FRENCH,
-        'persisk'             : Date.CAL_PERSIAN,
-        'p'                   : Date.CAL_PERSIAN,
-        'svensk'              : Date.CAL_SWEDISH,
-        's'                   : Date.CAL_SWEDISH,
-        }
+        "gregoriansk   ": Date.CAL_GREGORIAN,
+        "g": Date.CAL_GREGORIAN,
+        "juliansk tidsregning": Date.CAL_JULIAN,
+        "juliansk": Date.CAL_JULIAN,
+        "j": Date.CAL_JULIAN,
+        "hebraisk": Date.CAL_HEBREW,
+        "h": Date.CAL_HEBREW,
+        "islamisk": Date.CAL_ISLAMIC,
+        "muslimsk": Date.CAL_ISLAMIC,
+        "i": Date.CAL_ISLAMIC,
+        "fransk": Date.CAL_FRENCH,
+        "fransk republikansk": Date.CAL_FRENCH,
+        "f": Date.CAL_FRENCH,
+        "persisk": Date.CAL_PERSIAN,
+        "p": Date.CAL_PERSIAN,
+        "svensk": Date.CAL_SWEDISH,
+        "s": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        'estimeret' : Date.QUAL_ESTIMATED,
-        'anslået'   : Date.QUAL_ESTIMATED,
-        'beregnet'   : Date.QUAL_CALCULATED,
-        }
+        "estimeret": Date.QUAL_ESTIMATED,
+        "anslået": Date.QUAL_ESTIMATED,
+        "beregnet": Date.QUAL_CALCULATED,
+    }
 
     def init_strings(self):
         DateParser.init_strings(self)
         self._span = re.compile(
-            r"(fra)?\s*(?P<start>.+)\s*(til|--|–)\s*(?P<stop>.+)",
-            re.IGNORECASE)
+            r"(fra)?\s*(?P<start>.+)\s*(til|--|–)\s*(?P<stop>.+)", re.IGNORECASE
+        )
         self._range = re.compile(
-            r"(mellem)\s+(?P<start>.+)\s+og\s+(?P<stop>.+)", re.IGNORECASE)
+            r"(mellem)\s+(?P<start>.+)\s+og\s+(?P<stop>.+)", re.IGNORECASE
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Danish display class
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayDa(DateDisplay):
     """
     Danish language date display class.
     """
 
-    long_months = ( "", "januar", "februar", "marts", "april", "maj",
-                    "juni", "juli", "august", "september", "oktober",
-                    "november", "december" )
+    long_months = (
+        "",
+        "januar",
+        "februar",
+        "marts",
+        "april",
+        "maj",
+        "juni",
+        "juli",
+        "august",
+        "september",
+        "oktober",
+        "november",
+        "december",
+    )
 
-    short_months = ( "", "jan", "feb", "mar", "apr", "maj", "jun",
-                     "jul", "aug", "sep", "okt", "nov", "dec" )
+    short_months = (
+        "",
+        "jan",
+        "feb",
+        "mar",
+        "apr",
+        "maj",
+        "jun",
+        "jul",
+        "aug",
+        "sep",
+        "okt",
+        "nov",
+        "dec",
+    )
 
     formats = (
         "ÅÅÅÅ-MM-DD (ISO)",
@@ -121,9 +150,9 @@ class DateDisplayDa(DateDisplay):
         "Md Dag År",
         "Dag måned år",
         "Dag md År",
-        )
-        # this must agree with DateDisplayEn's "formats" definition
-        # (since no locale-specific _display_gregorian exists, here)
+    )
+    # this must agree with DateDisplayEn's "formats" definition
+    # (since no locale-specific _display_gregorian exists, here)
 
     calendar = (
         "",
@@ -132,8 +161,8 @@ class DateDisplayDa(DateDisplay):
         "fransk republikansk",
         "persisk",
         "islamisk",
-        "svensk"
-        )
+        "svensk",
+    )
 
     _mod_str = ("", "før ", "efter ", "ca. ", "", "", "")
 
@@ -166,19 +195,18 @@ class DateDisplayDa(DateDisplay):
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%smellem %s og %s%s" % (qual_str, d1, d2,
-                                              scal)
+            return "%smellem %s og %s%s" % (qual_str, d1, d2, scal)
         else:
             text = self.display_cal[date.get_calendar()](start)
             scal = self.format_extras(cal, newyear)
-            return "%s%s%s%s" % (qual_str, self._mod_str[mod],
-                                 text, scal)
+            return "%s%s%s%s" % (qual_str, self._mod_str[mod], text, scal)
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('da_DK', 'da', 'dansk', 'Danish', ('%d-%m-%Y',)),
-    DateParserDa, DateDisplayDa)
+    ("da_DK", "da", "dansk", "Danish", ("%d-%m-%Y",)), DateParserDa, DateDisplayDa
+)

--- a/gramps/gen/datehandler/_date_de.py
+++ b/gramps/gen/datehandler/_date_de.py
@@ -23,28 +23,28 @@
 German-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # German parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserDE(DateParser):
 
     month_to_int = DateParser.month_to_int
@@ -208,72 +208,90 @@ class DateParserDE(DateParser):
     month_to_int["wendeling"] = 11
 
     modifier_to_int = {
-        'vor'    : Date.MOD_BEFORE,
-        'nach'   : Date.MOD_AFTER,
-        'gegen'  : Date.MOD_ABOUT,
-        'um'     : Date.MOD_ABOUT,
-        'etwa'   : Date.MOD_ABOUT,
-        'circa'  : Date.MOD_ABOUT,
-        'ca.'  : Date.MOD_ABOUT,
-        }
+        "vor": Date.MOD_BEFORE,
+        "nach": Date.MOD_AFTER,
+        "gegen": Date.MOD_ABOUT,
+        "um": Date.MOD_ABOUT,
+        "etwa": Date.MOD_ABOUT,
+        "circa": Date.MOD_ABOUT,
+        "ca.": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     calendar_to_int = {
-        'gregorianisch'  : Date.CAL_GREGORIAN,
-        'greg.'          : Date.CAL_GREGORIAN,
-        'julianisch'     : Date.CAL_JULIAN,
-        'jul.'           : Date.CAL_JULIAN,
-        'hebräisch'      : Date.CAL_HEBREW,
-        'hebr.'          : Date.CAL_HEBREW,
-        'islamisch'      : Date.CAL_ISLAMIC,
-        'isl.'           : Date.CAL_ISLAMIC,
-        'französisch republikanisch': Date.CAL_FRENCH,
-        'franz.'         : Date.CAL_FRENCH,
-        'persisch'       : Date.CAL_PERSIAN,
-        'schwedisch'     : Date.CAL_SWEDISH,
-        's'              : Date.CAL_SWEDISH,
-        }
+        "gregorianisch": Date.CAL_GREGORIAN,
+        "greg.": Date.CAL_GREGORIAN,
+        "julianisch": Date.CAL_JULIAN,
+        "jul.": Date.CAL_JULIAN,
+        "hebräisch": Date.CAL_HEBREW,
+        "hebr.": Date.CAL_HEBREW,
+        "islamisch": Date.CAL_ISLAMIC,
+        "isl.": Date.CAL_ISLAMIC,
+        "französisch republikanisch": Date.CAL_FRENCH,
+        "franz.": Date.CAL_FRENCH,
+        "persisch": Date.CAL_PERSIAN,
+        "schwedisch": Date.CAL_SWEDISH,
+        "s": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        'geschätzt' : Date.QUAL_ESTIMATED,
-        'gesch.'    : Date.QUAL_ESTIMATED,
-        'errechnet' : Date.QUAL_CALCULATED,
-        'berechnet' : Date.QUAL_CALCULATED,
-        'ber.'      : Date.QUAL_CALCULATED,
-        }
+        "geschätzt": Date.QUAL_ESTIMATED,
+        "gesch.": Date.QUAL_ESTIMATED,
+        "errechnet": Date.QUAL_CALCULATED,
+        "berechnet": Date.QUAL_CALCULATED,
+        "ber.": Date.QUAL_CALCULATED,
+    }
 
-    bce = ["vor unserer Zeitrechnung", "vor unserer Zeit",
-           "vor der Zeitrechnung", "vor der Zeit",
-           "v. u. Z.", "v. d. Z.", "v.u.Z.", "v.d.Z.",
-           "vor Christi Geburt", "vor Christus", "v. Chr."] + DateParser.bce
+    bce = [
+        "vor unserer Zeitrechnung",
+        "vor unserer Zeit",
+        "vor der Zeitrechnung",
+        "vor der Zeit",
+        "v. u. Z.",
+        "v. d. Z.",
+        "v.u.Z.",
+        "v.d.Z.",
+        "vor Christi Geburt",
+        "vor Christus",
+        "v. Chr.",
+    ] + DateParser.bce
 
     def init_strings(self):
         DateParser.init_strings(self)
         self._span = re.compile(
-            r"(von|vom)\s+(?P<start>.+)\s+(bis)\s+(?P<stop>.+)", re.IGNORECASE)
+            r"(von|vom)\s+(?P<start>.+)\s+(bis)\s+(?P<stop>.+)", re.IGNORECASE
+        )
         self._range = re.compile(
-            r"zwischen\s+(?P<start>.+)\s+und\s+(?P<stop>.+)", re.IGNORECASE)
+            r"zwischen\s+(?P<start>.+)\s+und\s+(?P<stop>.+)", re.IGNORECASE
+        )
         self._text2 = re.compile(
-            r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?' % self._mon_str,
-            re.IGNORECASE)
+            r"(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?" % self._mon_str, re.IGNORECASE
+        )
         self._jtext2 = re.compile(
-            r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?' % self._jmon_str,
-            re.IGNORECASE)
+            r"(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?" % self._jmon_str, re.IGNORECASE
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # German display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayDE(DateDisplay):
     """
     German language date display class.
     """
 
     calendar = (
-        "", "julianisch", "hebräisch",
-        "französisch republikanisch", "persisch", "islamisch",
-        "schwedisch"
-        )
+        "",
+        "julianisch",
+        "hebräisch",
+        "französisch republikanisch",
+        "persisch",
+        "islamisch",
+        "schwedisch",
+    )
 
     _mod_str = ("", "vor ", "nach ", "etwa ", "", "", "")
 
@@ -282,11 +300,15 @@ class DateDisplayDE(DateDisplay):
     _bce_str = "%s v. u. Z."
 
     formats = (
-        "JJJJ-MM-DD (ISO)", "Numerisch", "Monat Tag Jahr",
-        "MONAT Tag Jahr", "Tag. Monat Jahr", "Tag. MONAT Jahr",
-        "Numerisch mit führenden Nullen"
-        )
-        # this definition must agree with its "_display_gregorian" method
+        "JJJJ-MM-DD (ISO)",
+        "Numerisch",
+        "Monat Tag Jahr",
+        "MONAT Tag Jahr",
+        "Tag. Monat Jahr",
+        "Tag. MONAT Jahr",
+        "Numerisch mit führenden Nullen",
+    )
+    # this definition must agree with its "_display_gregorian" method
 
     def _display_gregorian(self, date_val, **kwargs):
         """
@@ -304,9 +326,9 @@ class DateDisplayDE(DateDisplay):
                 if date_val[0] == date_val[1] == 0:
                     value = str(date_val[2])
                 else:
-                    value = self.dhformat.replace('%m', str(date_val[1]))
-                    value = value.replace('%d', str(date_val[0]))
-                    value = value.replace('%Y', str(date_val[2]))
+                    value = self.dhformat.replace("%m", str(date_val[1]))
+                    value = value.replace("%d", str(date_val[0]))
+                    value = value.replace("%Y", str(date_val[2]))
         elif self.format == 2:
             # month_name day, year
             if date_val[0] == 0:
@@ -315,8 +337,7 @@ class DateDisplayDE(DateDisplay):
                 else:
                     value = "%s %s" % (self.long_months[date_val[1]], year)
             else:
-                value = "%s %d, %s" % (self.long_months[date_val[1]],
-                                       date_val[0], year)
+                value = "%s %d, %s" % (self.long_months[date_val[1]], date_val[0], year)
         elif self.format == 3:
             # month_abbreviation day, year
             if date_val[0] == 0:
@@ -325,8 +346,11 @@ class DateDisplayDE(DateDisplay):
                 else:
                     value = "%s %s" % (self.short_months[date_val[1]], year)
             else:
-                value = "%s %d, %s" % (self.short_months[date_val[1]],
-                                       date_val[0], year)
+                value = "%s %d, %s" % (
+                    self.short_months[date_val[1]],
+                    date_val[0],
+                    year,
+                )
         elif self.format == 4:
             # day. month_name year
             if date_val[0] == 0:
@@ -335,8 +359,7 @@ class DateDisplayDE(DateDisplay):
                 else:
                     value = "%s %s" % (self.long_months[date_val[1]], year)
             else:
-                value = "%d. %s %s" % (date_val[0],
-                                       self.long_months[date_val[1]], year)
+                value = "%d. %s %s" % (date_val[0], self.long_months[date_val[1]], year)
         elif self.format == 6:
             # day.month_number.year with leading zeros
             if date_val[3]:
@@ -345,10 +368,9 @@ class DateDisplayDE(DateDisplay):
                 if date_val[0] == date_val[1] == 0:
                     value = str(date_val[2])
                 else:
-                    value = self.dhformat.replace('%m', str(date_val[1])
-                                                  .zfill(2))
-                    value = value.replace('%d', str(date_val[0]).zfill(2))
-                    value = value.replace('%Y', str(date_val[2]))
+                    value = self.dhformat.replace("%m", str(date_val[1]).zfill(2))
+                    value = value.replace("%d", str(date_val[0]).zfill(2))
+                    value = value.replace("%Y", str(date_val[2]))
         else:
             # day. month_abbreviation year
             if date_val[0] == 0:
@@ -357,8 +379,11 @@ class DateDisplayDE(DateDisplay):
                 else:
                     value = "%s %s" % (self.short_months[date_val[1]], year)
             else:
-                value = "%d. %s %s" % (date_val[0],
-                                       self.short_months[date_val[1]], year)
+                value = "%d. %s %s" % (
+                    date_val[0],
+                    self.short_months[date_val[1]],
+                    year,
+                )
         if date_val[2] < 0:
             return self._bce_str % value
         else:
@@ -384,7 +409,7 @@ class DateDisplayDE(DateDisplay):
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'von', d1, 'bis', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "von", d1, "bis", d2, scal)
         elif mod == Date.MOD_RANGE:
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
@@ -395,13 +420,25 @@ class DateDisplayDE(DateDisplay):
             scal = self.format_extras(cal, newyear)
             return "%s%s%s%s" % (qual_str, self._mod_str[mod], text, scal)
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('de_DE', 'german', 'German', 'de_CH',
-     'de_LI', 'de_LU', 'de_BE', 'de', ('%d.%m.%Y',)),
-    DateParserDE, DateDisplayDE)
-register_datehandler( ('de_AT', ('%d.%m.%Y',)), DateParserDE, DateDisplayDE)
+    (
+        "de_DE",
+        "german",
+        "German",
+        "de_CH",
+        "de_LI",
+        "de_LU",
+        "de_BE",
+        "de",
+        ("%d.%m.%Y",),
+    ),
+    DateParserDE,
+    DateDisplayDE,
+)
+register_datehandler(("de_AT", ("%d.%m.%Y",)), DateParserDE, DateDisplayDE)

--- a/gramps/gen/datehandler/_date_el.py
+++ b/gramps/gen/datehandler/_date_el.py
@@ -24,28 +24,28 @@
 Greek-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Greek parser class
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserEL(DateParser):
     """
     Convert a text string into a Date object. If the date cannot be
@@ -54,94 +54,126 @@ class DateParserEL(DateParser):
 
     # modifiers before the date
     modifier_to_int = {
-        'προ του'      : Date.MOD_BEFORE,
-        'πριν το'      : Date.MOD_BEFORE,
-        'πριν από τις' : Date.MOD_BEFORE,
-        'πριν από την' : Date.MOD_BEFORE,
-        'πριν από το'  : Date.MOD_BEFORE,
-        'πριν από τον' : Date.MOD_BEFORE,
-        'προ'          : Date.MOD_BEFORE,
-        'πρ.'          : Date.MOD_BEFORE,
-        'μετά το'      : Date.MOD_AFTER,
-        'μετά από τις' : Date.MOD_AFTER,
-        'μετά από την' : Date.MOD_AFTER,
-        'μετά από το'  : Date.MOD_AFTER,
-        'μετά από τον' : Date.MOD_AFTER,
-        'μετά'         : Date.MOD_AFTER,
-        'μετ.'         : Date.MOD_AFTER,
-        'γύρω στο'     : Date.MOD_ABOUT,
-        'γύρω στον'    : Date.MOD_ABOUT,
-        'γύρω στις'    : Date.MOD_ABOUT,
-        'περίπου το'   : Date.MOD_ABOUT,
-        'περ.'         : Date.MOD_ABOUT,
-        'γυρ.'         : Date.MOD_ABOUT,
-        '~'            : Date.MOD_ABOUT,
-        }
+        "προ του": Date.MOD_BEFORE,
+        "πριν το": Date.MOD_BEFORE,
+        "πριν από τις": Date.MOD_BEFORE,
+        "πριν από την": Date.MOD_BEFORE,
+        "πριν από το": Date.MOD_BEFORE,
+        "πριν από τον": Date.MOD_BEFORE,
+        "προ": Date.MOD_BEFORE,
+        "πρ.": Date.MOD_BEFORE,
+        "μετά το": Date.MOD_AFTER,
+        "μετά από τις": Date.MOD_AFTER,
+        "μετά από την": Date.MOD_AFTER,
+        "μετά από το": Date.MOD_AFTER,
+        "μετά από τον": Date.MOD_AFTER,
+        "μετά": Date.MOD_AFTER,
+        "μετ.": Date.MOD_AFTER,
+        "γύρω στο": Date.MOD_ABOUT,
+        "γύρω στον": Date.MOD_ABOUT,
+        "γύρω στις": Date.MOD_ABOUT,
+        "περίπου το": Date.MOD_ABOUT,
+        "περ.": Date.MOD_ABOUT,
+        "γυρ.": Date.MOD_ABOUT,
+        "~": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
-    bce = ["π.Χ.", "π.Κ.Χ.", "π.Κ.Ε.", "π.Χ" ]
+    bce = ["π.Χ.", "π.Κ.Χ.", "π.Κ.Ε.", "π.Χ"]
 
     calendar_to_int = {
-        'γρηγοριανό'          : Date.CAL_GREGORIAN,
-        'γ'                   : Date.CAL_GREGORIAN,
-        'ιουλιανό'            : Date.CAL_JULIAN,
-        'ι'                   : Date.CAL_JULIAN,
-        'εβραϊκό'             : Date.CAL_HEBREW,
-        'ε'                   : Date.CAL_HEBREW,
-        'ισλαμικό'            : Date.CAL_ISLAMIC,
-        'ισλ'                 : Date.CAL_ISLAMIC,
-        'γαλλικό'             : Date.CAL_FRENCH,
-        'γαλλικής δημοκρατίας': Date.CAL_FRENCH,
-        'γ'                   : Date.CAL_FRENCH,
-        'περσικό'             : Date.CAL_PERSIAN,
-        'π'                   : Date.CAL_PERSIAN,
-        'σουηδικό'            : Date.CAL_SWEDISH,
-        'σ'                   : Date.CAL_SWEDISH,
-        }
+        "γρηγοριανό": Date.CAL_GREGORIAN,
+        "γ": Date.CAL_GREGORIAN,
+        "ιουλιανό": Date.CAL_JULIAN,
+        "ι": Date.CAL_JULIAN,
+        "εβραϊκό": Date.CAL_HEBREW,
+        "ε": Date.CAL_HEBREW,
+        "ισλαμικό": Date.CAL_ISLAMIC,
+        "ισλ": Date.CAL_ISLAMIC,
+        "γαλλικό": Date.CAL_FRENCH,
+        "γαλλικής δημοκρατίας": Date.CAL_FRENCH,
+        "γ": Date.CAL_FRENCH,
+        "περσικό": Date.CAL_PERSIAN,
+        "π": Date.CAL_PERSIAN,
+        "σουηδικό": Date.CAL_SWEDISH,
+        "σ": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        'κατʼ εκτίμηση' : Date.QUAL_ESTIMATED,
-        'εκτιμώμενη'    : Date.QUAL_ESTIMATED,
-        'εκτ.'          : Date.QUAL_ESTIMATED,
-        'εκτ'           : Date.QUAL_ESTIMATED,
-        'υπολογ'        : Date.QUAL_CALCULATED,
-        'υπολογ.'       : Date.QUAL_CALCULATED,
-        'υπολογισμένη'  : Date.QUAL_CALCULATED,
-        'με υπολογισμό' : Date.QUAL_CALCULATED,
-        }
+        "κατʼ εκτίμηση": Date.QUAL_ESTIMATED,
+        "εκτιμώμενη": Date.QUAL_ESTIMATED,
+        "εκτ.": Date.QUAL_ESTIMATED,
+        "εκτ": Date.QUAL_ESTIMATED,
+        "υπολογ": Date.QUAL_CALCULATED,
+        "υπολογ.": Date.QUAL_CALCULATED,
+        "υπολογισμένη": Date.QUAL_CALCULATED,
+        "με υπολογισμό": Date.QUAL_CALCULATED,
+    }
 
     def init_strings(self):
         """
         This method compiles regular expression strings for matching dates.
         """
         DateParser.init_strings(self)
-        _span_1 = ['από']
-        _span_2 = ['έως']
-        _range_1 = ['μετ', r'μετ\.', 'μεταξύ']
-        _range_2 = ['και']
+        _span_1 = ["από"]
+        _span_2 = ["έως"]
+        _range_1 = ["μετ", r"μετ\.", "μεταξύ"]
+        _range_2 = ["και"]
         self._span = re.compile(
-            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-            ('|'.join(_span_1), '|'.join(_span_2)), re.IGNORECASE)
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_span_1), "|".join(_span_2)),
+            re.IGNORECASE,
+        )
         self._range = re.compile(
-            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-            ('|'.join(_range_1), '|'.join(_range_2)), re.IGNORECASE)
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_range_1), "|".join(_range_2)),
+            re.IGNORECASE,
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Greek display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayEL(DateDisplay):
     """
     Greek language date display class.
     """
-    # this is used to display the 12 gregorian months
-    long_months = ( "", "Ιανουάριος", "Φεβρουάριος", "Μάρτιος",
-                    "Απρίλιος", "Μάιος", "Ιούνιος",
-                    "Ιούλιος", "Αύγουστος", "Σεπτέμβριος",
-                    "Οκτώβριος", "Νοέμβριος", "Δεκέμβριος" )
 
-    short_months = ( "", "Ιαν", "Φεβ", "Μαρ", "Απρ", "Μάι", "Ιουν",
-                     "Ιουλ", "Αύγ", "Σεπ", "Οκτ", "Νοε", "Δεκ" )
+    # this is used to display the 12 gregorian months
+    long_months = (
+        "",
+        "Ιανουάριος",
+        "Φεβρουάριος",
+        "Μάρτιος",
+        "Απρίλιος",
+        "Μάιος",
+        "Ιούνιος",
+        "Ιούλιος",
+        "Αύγουστος",
+        "Σεπτέμβριος",
+        "Οκτώβριος",
+        "Νοέμβριος",
+        "Δεκέμβριος",
+    )
+
+    short_months = (
+        "",
+        "Ιαν",
+        "Φεβ",
+        "Μαρ",
+        "Απρ",
+        "Μάι",
+        "Ιουν",
+        "Ιουλ",
+        "Αύγ",
+        "Σεπ",
+        "Οκτ",
+        "Νοε",
+        "Δεκ",
+    )
 
     _mod_str = ("", "προ του ", "μετά το ", "γύρω στο ", "", "", "")
 
@@ -150,10 +182,13 @@ class DateDisplayEL(DateDisplay):
     _bce_str = "%s π.Χ."
 
     formats = (
-        "ΕΕΕΕ-ΜΜ-ΗΗ (ISO)", "ΗΗ-ΜΜ-ΕΕΕΕ", "ΗΗ/ΜΜ/ΕΕΕΕ",
-        "ΗΗ Μήνας ΕΕΕΕ", "ΗΗ Μήν ΕΕΕΕ"
-        )
-        # this definition must agree with its "_display_gregorian" method
+        "ΕΕΕΕ-ΜΜ-ΗΗ (ISO)",
+        "ΗΗ-ΜΜ-ΕΕΕΕ",
+        "ΗΗ/ΜΜ/ΕΕΕΕ",
+        "ΗΗ Μήνας ΕΕΕΕ",
+        "ΗΗ Μήν ΕΕΕΕ",
+    )
+    # this definition must agree with its "_display_gregorian" method
 
     def _display_gregorian(self, date_val, **kwargs):
         """
@@ -189,8 +224,7 @@ class DateDisplayEL(DateDisplay):
                 else:
                     value = "%s %s" % (self.long_months[date_val[1]], year)
             else:
-                value = "%d %s %s" % (date_val[0],
-                                      self.long_months[date_val[1]], year)
+                value = "%d %s %s" % (date_val[0], self.long_months[date_val[1]], year)
         else:
             # day month_abbreviation year
             if date_val[0] == 0:
@@ -199,8 +233,7 @@ class DateDisplayEL(DateDisplay):
                 else:
                     value = "%s %s" % (self.short_months[date_val[1]], year)
             else:
-                value = "%d %s %s" % (date_val[0],
-                                      self.short_months[date_val[1]], year)
+                value = "%d %s %s" % (date_val[0], self.short_months[date_val[1]], year)
         if date_val[2] < 0:
             return self._bce_str % value
         else:
@@ -226,22 +259,25 @@ class DateDisplayEL(DateDisplay):
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'από', d1, 'έως', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "από", d1, "έως", d2, scal)
         elif mod == Date.MOD_RANGE:
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'μεταξύ', d1, 'και', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "μεταξύ", d1, "και", d2, scal)
         else:
             text = self.display_cal[date.get_calendar()](start)
             scal = self.format_extras(cal, newyear)
             return "%s%s%s%s" % (qual_str, self._mod_str[mod], text, scal)
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('el_GR', 'el_CY', 'el', 'Greek', 'greek', ('%d/%m/%Y',)),
-    DateParserEL, DateDisplayEL)
+    ("el_GR", "el_CY", "el", "Greek", "greek", ("%d/%m/%Y",)),
+    DateParserEL,
+    DateDisplayEL,
+)

--- a/gramps/gen/datehandler/_date_es.py
+++ b/gramps/gen/datehandler/_date_es.py
@@ -23,102 +23,105 @@
 Spanish-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Spanish parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserES(DateParser):
 
     modifier_to_int = {
-        'antes de'   : Date.MOD_BEFORE,
-        'antes'      : Date.MOD_BEFORE,
-        'ant.'       : Date.MOD_BEFORE,
-        'ant'        : Date.MOD_BEFORE,
-        'después de' : Date.MOD_AFTER,
-        'después'    : Date.MOD_AFTER,
-        'desp.'      : Date.MOD_AFTER,
-        'desp'       : Date.MOD_AFTER,
-        'aprox.'     : Date.MOD_ABOUT,
-        'aprox'      : Date.MOD_ABOUT,
-        'apr.'       : Date.MOD_ABOUT,
-        'apr'        : Date.MOD_ABOUT,
-        'circa'      : Date.MOD_ABOUT,
-        'ca.'        : Date.MOD_ABOUT,
-        'ca'         : Date.MOD_ABOUT,
-        'c.'         : Date.MOD_ABOUT,
-        'hacia'      : Date.MOD_ABOUT,
-        }
+        "antes de": Date.MOD_BEFORE,
+        "antes": Date.MOD_BEFORE,
+        "ant.": Date.MOD_BEFORE,
+        "ant": Date.MOD_BEFORE,
+        "después de": Date.MOD_AFTER,
+        "después": Date.MOD_AFTER,
+        "desp.": Date.MOD_AFTER,
+        "desp": Date.MOD_AFTER,
+        "aprox.": Date.MOD_ABOUT,
+        "aprox": Date.MOD_ABOUT,
+        "apr.": Date.MOD_ABOUT,
+        "apr": Date.MOD_ABOUT,
+        "circa": Date.MOD_ABOUT,
+        "ca.": Date.MOD_ABOUT,
+        "ca": Date.MOD_ABOUT,
+        "c.": Date.MOD_ABOUT,
+        "hacia": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     calendar_to_int = {
-        'gregoriano'     : Date.CAL_GREGORIAN,
-        'g'              : Date.CAL_GREGORIAN,
-        'juliano'        : Date.CAL_JULIAN,
-        'j'              : Date.CAL_JULIAN,
-        'hebreo'         : Date.CAL_HEBREW,
-        'h'              : Date.CAL_HEBREW,
-        'islámico'       : Date.CAL_ISLAMIC,
-        'i'              : Date.CAL_ISLAMIC,
-        'revolucionario' : Date.CAL_FRENCH,
-        'r'              : Date.CAL_FRENCH,
-        'persa'          : Date.CAL_PERSIAN,
-        'p'              : Date.CAL_PERSIAN,
-        'swedish'        : Date.CAL_SWEDISH,
-        's'              : Date.CAL_SWEDISH,
-        }
+        "gregoriano": Date.CAL_GREGORIAN,
+        "g": Date.CAL_GREGORIAN,
+        "juliano": Date.CAL_JULIAN,
+        "j": Date.CAL_JULIAN,
+        "hebreo": Date.CAL_HEBREW,
+        "h": Date.CAL_HEBREW,
+        "islámico": Date.CAL_ISLAMIC,
+        "i": Date.CAL_ISLAMIC,
+        "revolucionario": Date.CAL_FRENCH,
+        "r": Date.CAL_FRENCH,
+        "persa": Date.CAL_PERSIAN,
+        "p": Date.CAL_PERSIAN,
+        "swedish": Date.CAL_SWEDISH,
+        "s": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        'estimado'   : Date.QUAL_ESTIMATED,
-        'est.'       : Date.QUAL_ESTIMATED,
-        'est'        : Date.QUAL_ESTIMATED,
-        'calc.'      : Date.QUAL_CALCULATED,
-        'calc'       : Date.QUAL_CALCULATED,
-        'calculado'  : Date.QUAL_CALCULATED,
-        }
+        "estimado": Date.QUAL_ESTIMATED,
+        "est.": Date.QUAL_ESTIMATED,
+        "est": Date.QUAL_ESTIMATED,
+        "calc.": Date.QUAL_CALCULATED,
+        "calc": Date.QUAL_CALCULATED,
+        "calculado": Date.QUAL_CALCULATED,
+    }
 
     def init_strings(self):
         DateParser.init_strings(self)
-        _span_1 = ['de']
-        _span_2 = ['a']
-        _range_1 = ['entre', r'ent\.', 'ent']
-        _range_2 = ['y']
+        _span_1 = ["de"]
+        _span_2 = ["a"]
+        _range_1 = ["entre", r"ent\.", "ent"]
+        _range_2 = ["y"]
         self._span = re.compile(
-            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-            ('|'.join(_span_1), '|'.join(_span_2)), re.IGNORECASE)
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_span_1), "|".join(_span_2)),
+            re.IGNORECASE,
+        )
         self._range = re.compile(
-            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-            ('|'.join(_range_1), '|'.join(_range_2)), re.IGNORECASE)
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_range_1), "|".join(_range_2)),
+            re.IGNORECASE,
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Spanish display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayES(DateDisplay):
     """
     Spanish language date display class.
     """
-    # TODO: Translate these month strings:
-    long_months = ( "", "enero", "febrero", "marzo", "abril", "mayo",
-                    "junio", "julio", "agosto", "septiembre", "octubre",
-                    "noviembre", "diciembre" )
 
     short_months = ( "", "ene", "feb", "mar", "abr", "may",
                      "jun", "jul", "ago", "sep", "oct", "nov",
@@ -135,11 +138,15 @@ class DateDisplayES(DateDisplay):
     _qual_str = ("", "estimado ", "calculado ")
 
     formats = (
-        "AAAA-MM-DD (ISO)", "Numérica", "Mes Día, Año",
-        "MES Día, Año", "Día Mes, Año", "Día MES, Año"
-        )
-        # this must agree with DateDisplayEn's "formats" definition
-        # (since no locale-specific _display_gregorian exists, here)
+        "AAAA-MM-DD (ISO)",
+        "Numérica",
+        "Mes Día, Año",
+        "MES Día, Año",
+        "Día Mes, Año",
+        "Día MES, Año",
+    )
+    # this must agree with DateDisplayEn's "formats" definition
+    # (since no locale-specific _display_gregorian exists, here)
 
     def display(self, date):
         """
@@ -161,22 +168,23 @@ class DateDisplayES(DateDisplay):
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'de', d1, 'a', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "de", d1, "a", d2, scal)
         elif mod == Date.MOD_RANGE:
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'entre', d1, 'y', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "entre", d1, "y", d2, scal)
         else:
             text = self.display_cal[date.get_calendar()](start)
             scal = self.format_extras(cal, newyear)
             return "%s%s%s%s" % (qual_str, self._mod_str[mod], text, scal)
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('es_ES', 'es', 'spanish', 'Spanish', ('%d/%m/%Y',)),
-    DateParserES, DateDisplayES)
+    ("es_ES", "es", "spanish", "Spanish", ("%d/%m/%Y",)), DateParserES, DateDisplayES
+)

--- a/gramps/gen/datehandler/_date_fi.py
+++ b/gramps/gen/datehandler/_date_fi.py
@@ -23,31 +23,31 @@
 Finnish-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Finnish parser
 #
 # This handles only dates where days and months are given as numeric, as:
 # - That's how they are normally used in Finland
 # - Parsing Finnish is much more complicated than English
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserFI(DateParser):
 
     # NOTE: these need to be in lower case because the "key" comparison
@@ -58,76 +58,79 @@ class DateParserFI(DateParser):
         # examples:
         # - ennen 1.1.2005
         # - noin 1.1.2005
-        'ennen'   : Date.MOD_BEFORE,
-        'e.'      : Date.MOD_BEFORE,
-        'noin'    : Date.MOD_ABOUT,
-        'n.'      : Date.MOD_ABOUT,
-        }
+        "ennen": Date.MOD_BEFORE,
+        "e.": Date.MOD_BEFORE,
+        "noin": Date.MOD_ABOUT,
+        "n.": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
     modifier_after_to_int = {
         # examples:
         # - 1.1.2005 jälkeen
-        'jälkeen' : Date.MOD_AFTER,
-        'j.'      : Date.MOD_AFTER,
-        }
+        "jälkeen": Date.MOD_AFTER,
+        "j.": Date.MOD_AFTER,
+    }
 
     bce = ["ekr.", "ekr"]
 
     calendar_to_int = {
-        'gregoriaaninen'  : Date.CAL_GREGORIAN,
-        'greg.'           : Date.CAL_GREGORIAN,
-        'juliaaninen'     : Date.CAL_JULIAN,
-        'jul.'            : Date.CAL_JULIAN,
-        'heprealainen'    : Date.CAL_HEBREW,
-        'hepr.'           : Date.CAL_HEBREW,
-        'islamilainen'    : Date.CAL_ISLAMIC,
-        'isl.'            : Date.CAL_ISLAMIC,
-        'ranskan vallankumouksen aikainen': Date.CAL_FRENCH,
-        'ranskan v.'      : Date.CAL_FRENCH,
-        'persialainen'    : Date.CAL_PERSIAN,
-        'pers.'           : Date.CAL_PERSIAN,
-        'svensk'          : Date.CAL_SWEDISH,
-        's'               : Date.CAL_SWEDISH,
-        }
+        "gregoriaaninen": Date.CAL_GREGORIAN,
+        "greg.": Date.CAL_GREGORIAN,
+        "juliaaninen": Date.CAL_JULIAN,
+        "jul.": Date.CAL_JULIAN,
+        "heprealainen": Date.CAL_HEBREW,
+        "hepr.": Date.CAL_HEBREW,
+        "islamilainen": Date.CAL_ISLAMIC,
+        "isl.": Date.CAL_ISLAMIC,
+        "ranskan vallankumouksen aikainen": Date.CAL_FRENCH,
+        "ranskan v.": Date.CAL_FRENCH,
+        "persialainen": Date.CAL_PERSIAN,
+        "pers.": Date.CAL_PERSIAN,
+        "svensk": Date.CAL_SWEDISH,
+        "s": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        'arviolta'   : Date.QUAL_ESTIMATED,
-        'arv.'       : Date.QUAL_ESTIMATED,
-        'laskettuna' : Date.QUAL_CALCULATED,
-        'lask.'      : Date.QUAL_CALCULATED,
-        }
+        "arviolta": Date.QUAL_ESTIMATED,
+        "arv.": Date.QUAL_ESTIMATED,
+        "laskettuna": Date.QUAL_CALCULATED,
+        "lask.": Date.QUAL_CALCULATED,
+    }
 
     def init_strings(self):
         DateParser.init_strings(self)
-        self._text2 = re.compile(r'(\d+)?\.?\s+?%s\.?\s*((\d+)(/\d+)?)?\s*$'
-                                 % self._mon_str, re.IGNORECASE)
-        self._span = re.compile(r"(?P<start>.+)\s+(-)\s+(?P<stop>.+)",
-                                re.IGNORECASE)
+        self._text2 = re.compile(
+            r"(\d+)?\.?\s+?%s\.?\s*((\d+)(/\d+)?)?\s*$" % self._mon_str, re.IGNORECASE
+        )
+        self._span = re.compile(r"(?P<start>.+)\s+(-)\s+(?P<stop>.+)", re.IGNORECASE)
         self._range = re.compile(
-            r"(vuosien\s*)?(?P<start>.+)\s+ja\s+(?P<stop>.+)\s+välillä",
-            re.IGNORECASE)
+            r"(vuosien\s*)?(?P<start>.+)\s+ja\s+(?P<stop>.+)\s+välillä", re.IGNORECASE
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Finnish display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayFI(DateDisplay):
     """
     Finnish language date display class.
     """
+
     _bce_str = "%s ekr."
 
     formats = (
         "VVVV-KK-PP (ISO)",
         "PP.KK.VVVV",
-        "Päivä Kuukausi Vuosi" # Day, full month name, year
-        )
-        # this definition must agree with its "_display_calendar" method
+        "Päivä Kuukausi Vuosi",  # Day, full month name, year
+    )
+    # this definition must agree with its "_display_calendar" method
 
     display = DateDisplay.display_formatted
 
-    def _display_calendar(self, date_val, long_months, short_months = None,
-                          inflect=""):
+    def _display_calendar(self, date_val, long_months, short_months=None, inflect=""):
         # this must agree with its locale-specific "formats" definition
 
         if short_months is None:
@@ -159,25 +162,26 @@ class DateDisplayFI(DateDisplay):
                 return year
             else:
                 if inflect:
-                    return self.format_long_month_year(date_val[1], year,
-                                                       inflect, long_months)
+                    return self.format_long_month_year(
+                        date_val[1], year, inflect, long_months
+                    )
                 else:
                     return "{long_month.f[IN]} {year}".format(
-                             long_month = long_months[date_val[1]],
-                             year = year)
+                        long_month=long_months[date_val[1]], year=year
+                    )
         else:
-            if not hasattr(long_months[date_val[1]], 'f'): # not a Lexeme
-                return self.dd_dformat01(date_val) # maybe the month is zero
+            if not hasattr(long_months[date_val[1]], "f"):  # not a Lexeme
+                return self.dd_dformat01(date_val)  # maybe the month is zero
             return "{day:d}. {long_month.f[P]} {year}".format(
-                     day = date_val[0],
-                     long_month = long_months[date_val[1]],
-                     year = year)
+                day=date_val[0], long_month=long_months[date_val[1]], year=year
+            )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('fi_FI', 'fi', 'finnish', 'Finnish', ('%d.%m.%Y',)),
-    DateParserFI, DateDisplayFI)
+    ("fi_FI", "fi", "finnish", "Finnish", ("%d.%m.%Y",)), DateParserFI, DateDisplayFI
+)

--- a/gramps/gen/datehandler/_date_fr.py
+++ b/gramps/gen/datehandler/_date_fr.py
@@ -25,29 +25,29 @@
 French-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # French parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserFR(DateParser):
     """
     Convert a text string into a Date object. If the date cannot be
@@ -57,39 +57,45 @@ class DateParserFR(DateParser):
     month_to_int = DateParser.month_to_int
 
     modifier_to_int = {
-        'avant'    : Date.MOD_BEFORE,
-        'av.'      : Date.MOD_BEFORE,
-        #u'av'     : Date.MOD_BEFORE, # Broke Hebrew "Av" month name
-        #u'<'      : Date.MOD_BEFORE, # Worrying about XML/HTML parsing
-        'après'    : Date.MOD_AFTER,
-        'ap.'      : Date.MOD_AFTER,
-        'ap'       : Date.MOD_AFTER,
-        #u'>'      : Date.MOD_AFTER, # Worrying about XML/HTML parsing
-        'environ'  : Date.MOD_ABOUT,
-        'env.'     : Date.MOD_ABOUT,
-        'env'      : Date.MOD_ABOUT,
-        'circa'    : Date.MOD_ABOUT,
-        'ca.'      : Date.MOD_ABOUT,
-        'ca'       : Date.MOD_ABOUT,
-        'c.'       : Date.MOD_ABOUT,
-        'vers'     : Date.MOD_ABOUT,
-        '~'        : Date.MOD_ABOUT,
-        }
+        "avant": Date.MOD_BEFORE,
+        "av.": Date.MOD_BEFORE,
+        # u'av'     : Date.MOD_BEFORE, # Broke Hebrew "Av" month name
+        # u'<'      : Date.MOD_BEFORE, # Worrying about XML/HTML parsing
+        "après": Date.MOD_AFTER,
+        "ap.": Date.MOD_AFTER,
+        "ap": Date.MOD_AFTER,
+        # u'>'      : Date.MOD_AFTER, # Worrying about XML/HTML parsing
+        "environ": Date.MOD_ABOUT,
+        "env.": Date.MOD_ABOUT,
+        "env": Date.MOD_ABOUT,
+        "circa": Date.MOD_ABOUT,
+        "ca.": Date.MOD_ABOUT,
+        "ca": Date.MOD_ABOUT,
+        "c.": Date.MOD_ABOUT,
+        "vers": Date.MOD_ABOUT,
+        "~": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     quality_to_int = {
-        'estimée': Date.QUAL_ESTIMATED,
-        'est.'   : Date.QUAL_ESTIMATED,
-        'est'    : Date.QUAL_ESTIMATED,
-        'calculée': Date.QUAL_CALCULATED,
-        'calc.'   : Date.QUAL_CALCULATED,
-        'calc'    : Date.QUAL_CALCULATED,
-        'comptée' : Date.QUAL_CALCULATED,
-        'compt.'  : Date.QUAL_CALCULATED,
-        'compt'   : Date.QUAL_CALCULATED,
-        }
+        "estimée": Date.QUAL_ESTIMATED,
+        "est.": Date.QUAL_ESTIMATED,
+        "est": Date.QUAL_ESTIMATED,
+        "calculée": Date.QUAL_CALCULATED,
+        "calc.": Date.QUAL_CALCULATED,
+        "calc": Date.QUAL_CALCULATED,
+        "comptée": Date.QUAL_CALCULATED,
+        "compt.": Date.QUAL_CALCULATED,
+        "compt": Date.QUAL_CALCULATED,
+    }
 
-    bce = ["avant le calendrier", "avant notre ère", "avant JC",
-           "avant J.C"] + DateParser.bce
+    bce = [
+        "avant le calendrier",
+        "avant notre ère",
+        "avant JC",
+        "avant J.C",
+    ] + DateParser.bce
 
     def init_strings(self):
         """
@@ -104,126 +110,139 @@ class DateParserFR(DateParser):
         """
         DateParser.init_strings(self)
 
-        DateParser.calendar_to_int.update({
-            'révolutionnaire'  : Date.CAL_FRENCH,
-            'r'                : Date.CAL_FRENCH,
-            'perse'            : Date.CAL_PERSIAN,
-        })
+        DateParser.calendar_to_int.update(
+            {
+                "révolutionnaire": Date.CAL_FRENCH,
+                "r": Date.CAL_FRENCH,
+                "perse": Date.CAL_PERSIAN,
+            }
+        )
 
-        DateParser.month_to_int.update({
-            "januaris"    : 1,
-            "januarii"    : 1,
-            "januarius"   : 1,
-            "janer"       : 1,
-            "jänner"      : 1,
-            "jenner"      : 1,
-            "hartmonat"   : 1,
-            "hartung"     : 1,
-            "horn"        : 1,
-            "eismond"     : 1,
-            "februaris"   : 2,
-            "februarii"   : 2,
-            "februarius"  : 2,
-            "hornig"      : 2,
-            "hornung"     : 2,
-            "wintermonat" : 2,
-            "taumond"     : 2,
-            "narrenmond"  : 2,
-            "martii"      : 3,
-            "martius"     : 3,
-            "lenzing"     : 3,
-            "aprilis"     : 4,
-            "ostermond"   : 4,
-            "maius"       : 5,
-            "maii"        : 5,
-            "maien"       : 5,
-            "bluviose"    : 5,
-            "wonnemond"   : 5,
-            "wiesenmonat" : 5,
-            "junius"      : 6,
-            "junii"       : 6,
-            "vendose"     : 6,
-            "brachet"     : 6,
-            "julius"      : 7,
-            "julii"       : 7,
-            "heuet"       : 7,
-            "heuert"      : 7,
-            "augustus"    : 8,
-            "augusti"     : 8,
-            "ernting"     : 8,
-            "septembris"  : 9,
-            "7bre"        : 9,
-            "7bris"       : 9,
-            "september"   : 9,
-            "scheidling"  : 9,
-            "october"     : 10,
-            "octobris"    : 10,
-            "8bre"        : 10,
-            "8bris"       : 10,
-            "gilbhard"    : 10,
-            "november"    : 11,
-            "novembris"   : 11,
-            "9bre"        : 11,
-            "9bris"       : 11,
-            "nebelmonat"  : 11,
-            "nebelung"    : 11,
-            "december"    : 12,
-            "decembris"   : 12,
-            "10bre"       : 12,
-            "10bris"      : 12,
-            "xbre"        : 12,
-            "xbris"       : 12,
-            "julmond"     : 12,
-            "christmond"  : 12,
-        })
+        DateParser.month_to_int.update(
+            {
+                "januaris": 1,
+                "januarii": 1,
+                "januarius": 1,
+                "janer": 1,
+                "jänner": 1,
+                "jenner": 1,
+                "hartmonat": 1,
+                "hartung": 1,
+                "horn": 1,
+                "eismond": 1,
+                "februaris": 2,
+                "februarii": 2,
+                "februarius": 2,
+                "hornig": 2,
+                "hornung": 2,
+                "wintermonat": 2,
+                "taumond": 2,
+                "narrenmond": 2,
+                "martii": 3,
+                "martius": 3,
+                "lenzing": 3,
+                "aprilis": 4,
+                "ostermond": 4,
+                "maius": 5,
+                "maii": 5,
+                "maien": 5,
+                "bluviose": 5,
+                "wonnemond": 5,
+                "wiesenmonat": 5,
+                "junius": 6,
+                "junii": 6,
+                "vendose": 6,
+                "brachet": 6,
+                "julius": 7,
+                "julii": 7,
+                "heuet": 7,
+                "heuert": 7,
+                "augustus": 8,
+                "augusti": 8,
+                "ernting": 8,
+                "septembris": 9,
+                "7bre": 9,
+                "7bris": 9,
+                "september": 9,
+                "scheidling": 9,
+                "october": 10,
+                "octobris": 10,
+                "8bre": 10,
+                "8bris": 10,
+                "gilbhard": 10,
+                "november": 11,
+                "novembris": 11,
+                "9bre": 11,
+                "9bris": 11,
+                "nebelmonat": 11,
+                "nebelung": 11,
+                "december": 12,
+                "decembris": 12,
+                "10bre": 12,
+                "10bris": 12,
+                "xbre": 12,
+                "xbris": 12,
+                "julmond": 12,
+                "christmond": 12,
+            }
+        )
 
         # This self._numeric is different from the base
         # avoid bug gregorian / french calendar conversion (+/-10 days)
 
         self._numeric = re.compile(r"((\d+)[/\. ])?\s*((\d+)[/\.])?\s*(\d+)\s*$")
-        self._span = re.compile(r"(de)\s+(?P<start>.+)\s+(à)\s+(?P<stop>.+)",
-                                re.IGNORECASE)
-        self._range = re.compile(r"(entre|ent\.|ent)\s+(?P<start>.+)\s+(et)\s+(?P<stop>.+)",
-                                 re.IGNORECASE)
+        self._span = re.compile(
+            r"(de)\s+(?P<start>.+)\s+(à)\s+(?P<stop>.+)", re.IGNORECASE
+        )
+        self._range = re.compile(
+            r"(entre|ent\.|ent)\s+(?P<start>.+)\s+(et)\s+(?P<stop>.+)", re.IGNORECASE
+        )
 
         # This self._text are different from the base
         # by adding ".?" after the first date and removing "\s*$" at the end
 
-        #gregorian and julian
+        # gregorian and julian
 
-        self._text2 = re.compile(r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?' %
-                                 self._mon_str, re.IGNORECASE)
+        self._text2 = re.compile(
+            r"(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?" % self._mon_str, re.IGNORECASE
+        )
 
-        #hebrew
+        # hebrew
 
-        self._jtext2 = re.compile(r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?' %
-                                  self._jmon_str, re.IGNORECASE)
+        self._jtext2 = re.compile(
+            r"(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?" % self._jmon_str, re.IGNORECASE
+        )
 
-        #french
+        # french
 
-        self._ftext2 = re.compile(r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?' %
-                                  self._fmon_str, re.IGNORECASE)
+        self._ftext2 = re.compile(
+            r"(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?" % self._fmon_str, re.IGNORECASE
+        )
 
-        #persian
+        # persian
 
-        self._ptext2 = re.compile(r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?' %
-                                  self._pmon_str, re.IGNORECASE)
+        self._ptext2 = re.compile(
+            r"(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?" % self._pmon_str, re.IGNORECASE
+        )
 
-        #islamic
+        # islamic
 
-        self._itext2 = re.compile(r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?' %
-                                  self._imon_str, re.IGNORECASE)
+        self._itext2 = re.compile(
+            r"(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?" % self._imon_str, re.IGNORECASE
+        )
 
-        #swedish
+        # swedish
 
-        self._stext2 = re.compile(r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?' %
-                                  self._smon_str, re.IGNORECASE)
+        self._stext2 = re.compile(
+            r"(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?" % self._smon_str, re.IGNORECASE
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # French display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayFR(DateDisplay):
     """
     French language date display class.
@@ -232,23 +251,25 @@ class DateDisplayFR(DateDisplay):
     _bce_str = "%s avant le calendrier"
 
     def formats_changed(self):
-        """ Allow overriding so a subclass can modify """
+        """Allow overriding so a subclass can modify"""
 
         # Replace the previous "Numérique" by a string which
         # do have an explicit meaning: "System default (format)"
         example = self.dhformat
-        example = example.replace('%d', "J")
-        example = example.replace('%m', "M")
-        example = example.replace('%Y', "A")
+        example = example.replace("%d", "J")
+        example = example.replace("%m", "M")
+        example = example.replace("%Y", "A")
 
-        self.formats = ("AAAA-MM-JJ (ISO)",  # 0
-               "Défaut système (" + example + ")",        # 1
-               "Jour Mois Année",   # 2
-               "Jour MOI Année",    # 3
-               "Jour. Mois Année",  # 4
-               "Jour. MOI Année",   # 5
-               "Mois Jour, Année",  # 6
-               "MOI Jour, Année",)  # 7
+        self.formats = (
+            "AAAA-MM-JJ (ISO)",  # 0
+            "Défaut système (" + example + ")",  # 1
+            "Jour Mois Année",  # 2
+            "Jour MOI Année",  # 3
+            "Jour. Mois Année",  # 4
+            "Jour. MOI Année",  # 5
+            "Mois Jour, Année",  # 6
+            "MOI Jour, Année",
+        )  # 7
         # this definition must agree with its "_display_gregorian" method
 
     def _display_gregorian(self, date_val, **kwargs):
@@ -272,14 +293,14 @@ class DateDisplayFR(DateDisplay):
                 if date_val[0] == date_val[1] == 0:
                     value = str(date_val[2])
                 else:
-                    value = self.dhformat.replace('%m', str(date_val[1]))
-                    value = value.replace('%d', str(date_val[0]))
+                    value = self.dhformat.replace("%m", str(date_val[1]))
+                    value = value.replace("%d", str(date_val[0]))
 
                     # base_display :
                     # value = value.replace('%Y', str(abs(date_val[2])))
                     # value = value.replace('-', '/')
 
-                    value = value.replace('%Y', str(date_val[2]))
+                    value = value.replace("%Y", str(date_val[2]))
         elif self.format == 2:
 
             # day month_name year
@@ -291,8 +312,7 @@ class DateDisplayFR(DateDisplay):
                     value = "%s %s" % (self.long_months[date_val[1]], year)
             else:
 
-                value = "%d %s %s" % (date_val[0],
-                                      self.long_months[date_val[1]], year)
+                value = "%d %s %s" % (date_val[0], self.long_months[date_val[1]], year)
         elif self.format == 3:
 
             # day month_abbreviation year
@@ -304,8 +324,7 @@ class DateDisplayFR(DateDisplay):
                     value = "%s %s" % (self.short_months[date_val[1]], year)
             else:
 
-                value = "%d %s %s" % (date_val[0],
-                                      self.short_months[date_val[1]], year)
+                value = "%d %s %s" % (date_val[0], self.short_months[date_val[1]], year)
         elif self.format == 4:
 
             # day. month_name year
@@ -321,9 +340,7 @@ class DateDisplayFR(DateDisplay):
                 # value = "%d %s %s" % (date_val[0],
                 #                       self.long_months[date_val[1]], year)
 
-                value = "%d. %s %s" % (date_val[0],
-                                       self.long_months[date_val[1]],
-                                       year)
+                value = "%d. %s %s" % (date_val[0], self.long_months[date_val[1]], year)
         elif self.format == 5:
 
             # day. month_abbreviation year
@@ -339,8 +356,11 @@ class DateDisplayFR(DateDisplay):
                 # value = "%d %s %s" % (date_val[0],
                 #                       self.short_months[date_val[1]], year)
 
-                value = "%d. %s %s" % (date_val[0],
-                                       self.short_months[date_val[1]], year)
+                value = "%d. %s %s" % (
+                    date_val[0],
+                    self.short_months[date_val[1]],
+                    year,
+                )
         elif self.format == 6:
 
             # month_name day, year
@@ -351,8 +371,7 @@ class DateDisplayFR(DateDisplay):
                 else:
                     value = "%s %s" % (self.long_months[date_val[1]], year)
             else:
-                value = "%s %d, %s" % (self.long_months[date_val[1]],
-                                       date_val[0], year)
+                value = "%s %d, %s" % (self.long_months[date_val[1]], date_val[0], year)
         elif self.format == 7:
 
             # month_abbreviation day, year
@@ -363,8 +382,11 @@ class DateDisplayFR(DateDisplay):
                 else:
                     value = "%s %s" % (self.short_months[date_val[1]], year)
             else:
-                value = "%s %d, %s" % (self.short_months[date_val[1]],
-                                       date_val[0], year)
+                value = "%s %d, %s" % (
+                    self.short_months[date_val[1]],
+                    date_val[0],
+                    year,
+                )
         else:
             return self.display_iso(date_val)
 
@@ -375,13 +397,15 @@ class DateDisplayFR(DateDisplay):
 
     display = DateDisplay.display_formatted
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 
 register_datehandler(
-    ('fr_FR', 'fr', 'french', 'French', 'fr_CA',
-     'fr_BE', 'fr_CH', ('%d/%m/%Y',)),
-    DateParserFR, DateDisplayFR)
+    ("fr_FR", "fr", "french", "French", "fr_CA", "fr_BE", "fr_CH", ("%d/%m/%Y",)),
+    DateParserFR,
+    DateDisplayFR,
+)

--- a/gramps/gen/datehandler/_date_hr.py
+++ b/gramps/gen/datehandler/_date_hr.py
@@ -28,50 +28,51 @@
 Croatian-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Croatian parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserHR(DateParser):
     modifier_to_int = {
-        'prije'   : Date.MOD_BEFORE,
-        'pr. '    : Date.MOD_BEFORE,
-        'poslije' : Date.MOD_AFTER,
-        'po. '    : Date.MOD_AFTER,
-        'nakon'   : Date.MOD_AFTER,
-        'na. '    : Date.MOD_AFTER,
-        'oko'     : Date.MOD_ABOUT,
-        'okolo'   : Date.MOD_ABOUT,
-        'ok. '    : Date.MOD_ABOUT,
-        }
+        "prije": Date.MOD_BEFORE,
+        "pr. ": Date.MOD_BEFORE,
+        "poslije": Date.MOD_AFTER,
+        "po. ": Date.MOD_AFTER,
+        "nakon": Date.MOD_AFTER,
+        "na. ": Date.MOD_AFTER,
+        "oko": Date.MOD_ABOUT,
+        "okolo": Date.MOD_ABOUT,
+        "ok. ": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     quality_to_int = {
-        'približno' : Date.QUAL_ESTIMATED,
-        'prb.'      : Date.QUAL_ESTIMATED,
-        'izračunato'  : Date.QUAL_CALCULATED,
-        'izr.'       : Date.QUAL_CALCULATED,
-        }
+        "približno": Date.QUAL_ESTIMATED,
+        "prb.": Date.QUAL_ESTIMATED,
+        "izračunato": Date.QUAL_CALCULATED,
+        "izr.": Date.QUAL_CALCULATED,
+    }
 
-    bce = ["prije nove ere", "prije Krista",
-           "p.n.e."] + DateParser.bce
+    bce = ["prije nove ere", "prije Krista", "p.n.e."] + DateParser.bce
 
     def init_strings(self):
         """
@@ -80,71 +81,86 @@ class DateParserHR(DateParser):
         DateParser.init_strings(self)
 
         # match 'Day. MONTH year.' format with or without dots
-        self._text2 = re.compile(r'(\d+)?\.?\s*?%s\.?\s*((\d+)(/\d+)?)?\s*\.?$'
-                                 % self._mon_str, re.IGNORECASE)
+        self._text2 = re.compile(
+            r"(\d+)?\.?\s*?%s\.?\s*((\d+)(/\d+)?)?\s*\.?$" % self._mon_str,
+            re.IGNORECASE,
+        )
 
         # match Day.Month.Year.
-        self._numeric = re.compile(
-                            r"((\d+)[/\. ])?\s*((\d+)[/\.])?\s*(\d+)\.?$")
+        self._numeric = re.compile(r"((\d+)[/\. ])?\s*((\d+)[/\.])?\s*(\d+)\.?$")
 
-        self._jtext2 = re.compile(r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?'
-                                  % self._jmon_str, re.IGNORECASE)
+        self._jtext2 = re.compile(
+            r"(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?" % self._jmon_str, re.IGNORECASE
+        )
 
-        _span_1 = ['od']
-        _span_2 = ['do']
-        _range_1 = ['između']
-        _range_2 = ['i']
-        self._span = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
-                                % ('|'.join(_span_1), '|'.join(_span_2)),
-                                re.IGNORECASE)
-        self._range = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
-                                 % ('|'.join(_range_1), '|'.join(_range_2)),
-                                 re.IGNORECASE)
+        _span_1 = ["od"]
+        _span_2 = ["do"]
+        _range_1 = ["između"]
+        _range_2 = ["i"]
+        self._span = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_span_1), "|".join(_span_2)),
+            re.IGNORECASE,
+        )
+        self._range = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_range_1), "|".join(_range_2)),
+            re.IGNORECASE,
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Croatian display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayHR(DateDisplay):
     """
     Croatian language date display class.
     """
-     # TODO fix BUG 7064: non-Gregorian calendars wrongly use BCE notation for negative dates
+
+    # TODO fix BUG 7064: non-Gregorian calendars wrongly use BCE notation for negative dates
     # not refactoring _bce_str into base class because it'll be gone under #7064
     _bce_str = "%s p.n.e."
 
     display = DateDisplay.display_formatted
 
     def format_short_month_year(self, month, year, inflect, short_months):
-        """ Allow a subclass to modify the year, e.g. add a period """
-        if not hasattr(short_months[1], 'f'): # not a Lexeme: no inflection
+        """Allow a subclass to modify the year, e.g. add a period"""
+        if not hasattr(short_months[1], "f"):  # not a Lexeme: no inflection
             return "{short_month} {year}.".format(
-                     short_month = short_months[month], year = year)
+                short_month=short_months[month], year=year
+            )
         return self.FORMATS_short_month_year[inflect].format(
-                     short_month = short_months[month], year = year)
+            short_month=short_months[month], year=year
+        )
 
     def _get_localized_year(self, year):
-        """ Allow a subclass to modify the year, e.g. add a period """
-        return year + '.'
+        """Allow a subclass to modify the year, e.g. add a period"""
+        return year + "."
 
     # FIXME probably there should be a Croatian-specific "formats" (and this
     # ("American comma") format (and dd_dformat03 too) should be eliminated)
     def dd_dformat02(self, date_val, inflect, long_months):
-        """ month_name day, year """
-        return DateDisplay.dd_dformat02(
-            self, date_val, inflect, long_months).replace(' .', '')
+        """month_name day, year"""
+        return DateDisplay.dd_dformat02(self, date_val, inflect, long_months).replace(
+            " .", ""
+        )
 
     def dd_dformat04(self, date_val, inflect, long_months):
-        """ day month_name year """
-        return DateDisplay.dd_dformat04(
-            self, date_val, inflect, long_months).replace(' .', '')
+        """day month_name year"""
+        return DateDisplay.dd_dformat04(self, date_val, inflect, long_months).replace(
+            " .", ""
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('hr_HR', 'hr', 'HR', 'croatian', 'Croatian', 'hrvatski', ('%d. %m. %Y.',)),
-    DateParserHR, DateDisplayHR)
+    ("hr_HR", "hr", "HR", "croatian", "Croatian", "hrvatski", ("%d. %m. %Y.",)),
+    DateParserHR,
+    DateDisplayHR,
+)

--- a/gramps/gen/datehandler/_date_hu.py
+++ b/gramps/gen/datehandler/_date_hu.py
@@ -24,226 +24,233 @@
 Hungarian-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Hungarian parser
 #
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserHU(DateParser):
-
 
     month_to_int = DateParser.month_to_int
 
-    month_to_int["-"]=0   #to make the Zero month to work
+    month_to_int["-"] = 0  # to make the Zero month to work
 
     month_to_int["január"] = 1
     month_to_int["jan"] = 1
     month_to_int["jan."] = 1
     month_to_int["I"] = 1
-#    month_to_int["i"] = 1
+    #    month_to_int["i"] = 1
 
     month_to_int["február"] = 2
     month_to_int["feb"] = 2
     month_to_int["feb."] = 2
     month_to_int["II"] = 2
-#    month_to_int["ii"] = 2
+    #    month_to_int["ii"] = 2
 
     month_to_int["március"] = 3
     month_to_int["márc"] = 3
     month_to_int["márc."] = 3
     month_to_int["III"] = 3
-#    month_to_int["iii"] = 3
+    #    month_to_int["iii"] = 3
 
     month_to_int["április"] = 4
     month_to_int["ápr"] = 4
     month_to_int["ápr."] = 4
     month_to_int["IV"] = 4
-#    month_to_int["iv"] = 4
+    #    month_to_int["iv"] = 4
 
     month_to_int["május"] = 5
     month_to_int["máj"] = 5
     month_to_int["máj."] = 5
     month_to_int["V"] = 5
-#    month_to_int["v"] = 5
+    #    month_to_int["v"] = 5
 
     month_to_int["június"] = 6
     month_to_int["jún"] = 6
     month_to_int["jún."] = 6
     month_to_int["VI"] = 6
-#    month_to_int["vi"] = 6
+    #    month_to_int["vi"] = 6
 
     month_to_int["július"] = 7
     month_to_int["júl"] = 7
     month_to_int["júl."] = 7
     month_to_int["VII"] = 7
-#    month_to_int["vii"] = 7
+    #    month_to_int["vii"] = 7
 
     month_to_int["augusztus"] = 8
     month_to_int["aug"] = 8
     month_to_int["aug."] = 8
     month_to_int["VIII"] = 8
-#    month_to_int["viii"] = 8
+    #    month_to_int["viii"] = 8
 
     month_to_int["szeptember"] = 9
     month_to_int["szept"] = 9
     month_to_int["szept."] = 9
     month_to_int["IX"] = 9
-#    month_to_int["ix"] = 9
+    #    month_to_int["ix"] = 9
 
     month_to_int["október"] = 10
     month_to_int["okt"] = 10
     month_to_int["okt."] = 10
     month_to_int["X"] = 10
-#    month_to_int["x"] = 10
+    #    month_to_int["x"] = 10
 
     month_to_int["november"] = 11
     month_to_int["nov"] = 11
     month_to_int["nov."] = 11
     month_to_int["XI"] = 11
-#    month_to_int["xi"] = 11
+    #    month_to_int["xi"] = 11
 
     month_to_int["december"] = 12
     month_to_int["dec"] = 12
     month_to_int["dec."] = 12
     month_to_int["XII"] = 12
-#    month_to_int["xii"] = 12
+    #    month_to_int["xii"] = 12
 
-
-#-----------------------------------------------------------------------
-#
-#  Alternative and latin names - not verified
-#
-#-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    #
+    #  Alternative and latin names - not verified
+    #
+    # -----------------------------------------------------------------------
     # Other common latin names
 
-#    month_to_int["januaris"] = 01
-#    month_to_int["januarii"] = 01
-#    month_to_int["januarius"] = 01
-#    month_to_int["februaris"] = 02
-#    month_to_int["februarii"] = 02
-#    month_to_int["februarius"] = 02
-#    month_to_int["martii"] = 03
-#    month_to_int["martius"] = 03
-#    month_to_int["aprilis"] = 04
-#    month_to_int["maius"] = 05
-#    month_to_int["maii"] = 05
-#    month_to_int["junius"] = 06
-#    month_to_int["junii"] = 06
-#    month_to_int["julius"] = 07
-#    month_to_int["julii"] = 07
-#    month_to_int["augustus"] = 08
-#    month_to_int["augusti"] = 08
-#    month_to_int["septembris"] = 09
-#    month_to_int["7bris"] = 09
-#    month_to_int["september"] = 09
-#    month_to_int["october"] = 10
-#    month_to_int["octobris"] = 10
-#    month_to_int["8bris"] = 10
-#    month_to_int["novembris"] = 11
-#    month_to_int["9bris"] = 11
-#    month_to_int["november"] = 11
-#    month_to_int["decembris"] = 12
-#    month_to_int["10bris"] = 12
-#    month_to_int["xbris"] = 12
-#    month_to_int["december"] = 12
+    #    month_to_int["januaris"] = 01
+    #    month_to_int["januarii"] = 01
+    #    month_to_int["januarius"] = 01
+    #    month_to_int["februaris"] = 02
+    #    month_to_int["februarii"] = 02
+    #    month_to_int["februarius"] = 02
+    #    month_to_int["martii"] = 03
+    #    month_to_int["martius"] = 03
+    #    month_to_int["aprilis"] = 04
+    #    month_to_int["maius"] = 05
+    #    month_to_int["maii"] = 05
+    #    month_to_int["junius"] = 06
+    #    month_to_int["junii"] = 06
+    #    month_to_int["julius"] = 07
+    #    month_to_int["julii"] = 07
+    #    month_to_int["augustus"] = 08
+    #    month_to_int["augusti"] = 08
+    #    month_to_int["septembris"] = 09
+    #    month_to_int["7bris"] = 09
+    #    month_to_int["september"] = 09
+    #    month_to_int["october"] = 10
+    #    month_to_int["octobris"] = 10
+    #    month_to_int["8bris"] = 10
+    #    month_to_int["novembris"] = 11
+    #    month_to_int["9bris"] = 11
+    #    month_to_int["november"] = 11
+    #    month_to_int["decembris"] = 12
+    #    month_to_int["10bris"] = 12
+    #    month_to_int["xbris"] = 12
+    #    month_to_int["december"] = 12
 
     # old Hungarian names
 
-#    month_to_int["Boldogasszony hava"] = 01
-#    month_to_int["Fergeteg hava"] = 01
-#    month_to_int["Böjtelő hava"] = 02
-#    month_to_int["Jégbontó hava"] = 02
-#    month_to_int["Böjtmás hava"] = 03
-#    month_to_int["Kikelet hava"] = 03
-#    month_to_int["Szent György hava"] = 04
-#    month_to_int["Szelek hava"] = 04
-#    month_to_int["Pünkösd hava"] = 05
-#    month_to_int["Ígéret hava"] = 05
-#    month_to_int["Szent Iván hava"] = 06
-#    month_to_int["Napisten hava"] = 06
-#    month_to_int["Szent Jakab hava"] = 07
-#    month_to_int["Áldás hava"] = 07
-#    month_to_int["Kisasszony hava"] = 08
-#    month_to_int["Újkenyér hava"] = 08
-#    month_to_int["Szent Mihály hava"] = 09
-#    month_to_int["Földanya hava"] = 09
-#    month_to_int["Mindszent hava"] = 10
-#    month_to_int["Magvető hava"] = 10
-#    month_to_int["Szent András hava"] = 11
-#    month_to_int["Enyészet hava"] = 11
-#    month_to_int["Karácsony hava"] = 12
-#    month_to_int["Álom hava"] = 12
+    #    month_to_int["Boldogasszony hava"] = 01
+    #    month_to_int["Fergeteg hava"] = 01
+    #    month_to_int["Böjtelő hava"] = 02
+    #    month_to_int["Jégbontó hava"] = 02
+    #    month_to_int["Böjtmás hava"] = 03
+    #    month_to_int["Kikelet hava"] = 03
+    #    month_to_int["Szent György hava"] = 04
+    #    month_to_int["Szelek hava"] = 04
+    #    month_to_int["Pünkösd hava"] = 05
+    #    month_to_int["Ígéret hava"] = 05
+    #    month_to_int["Szent Iván hava"] = 06
+    #    month_to_int["Napisten hava"] = 06
+    #    month_to_int["Szent Jakab hava"] = 07
+    #    month_to_int["Áldás hava"] = 07
+    #    month_to_int["Kisasszony hava"] = 08
+    #    month_to_int["Újkenyér hava"] = 08
+    #    month_to_int["Szent Mihály hava"] = 09
+    #    month_to_int["Földanya hava"] = 09
+    #    month_to_int["Mindszent hava"] = 10
+    #    month_to_int["Magvető hava"] = 10
+    #    month_to_int["Szent András hava"] = 11
+    #    month_to_int["Enyészet hava"] = 11
+    #    month_to_int["Karácsony hava"] = 12
+    #    month_to_int["Álom hava"] = 12
 
     modifier_to_int = {
-        'előtt'      : Date.MOD_BEFORE,
-        'körül'      : Date.MOD_ABOUT,
-        'után'       : Date.MOD_AFTER,
-        }
+        "előtt": Date.MOD_BEFORE,
+        "körül": Date.MOD_ABOUT,
+        "után": Date.MOD_AFTER,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     quality_to_int = {
-        'becsült'       : Date.QUAL_ESTIMATED,
-        'hozzávetőleg'  : Date.QUAL_ESTIMATED,
-        'becs.'         : Date.QUAL_ESTIMATED,
-        'számított'     : Date.QUAL_CALCULATED,
-        'körülbelül'    : Date.QUAL_ESTIMATED,
-        'számolt'       : Date.QUAL_CALCULATED,
-        'szám.'         : Date.QUAL_CALCULATED,
-        }
+        "becsült": Date.QUAL_ESTIMATED,
+        "hozzávetőleg": Date.QUAL_ESTIMATED,
+        "becs.": Date.QUAL_ESTIMATED,
+        "számított": Date.QUAL_CALCULATED,
+        "körülbelül": Date.QUAL_ESTIMATED,
+        "számolt": Date.QUAL_CALCULATED,
+        "szám.": Date.QUAL_CALCULATED,
+    }
 
-    bce = ["időszámításunk előtt", "időszámítás előtt", "i. e.",
-           "Krisztus előtt", "Krisztus előtti", "Kr. e."] + DateParser.bce
-
+    bce = [
+        "időszámításunk előtt",
+        "időszámítás előtt",
+        "i. e.",
+        "Krisztus előtt",
+        "Krisztus előtti",
+        "Kr. e.",
+    ] + DateParser.bce
 
     calendar_to_int = {
-        'Gergely'              : Date.CAL_GREGORIAN,
-        'Julián'               : Date.CAL_JULIAN,
-        'julián'               : Date.CAL_JULIAN,
-        'héber'                : Date.CAL_HEBREW,
-        'iszlám'               : Date.CAL_ISLAMIC,
-        'francia köztársasági' : Date.CAL_FRENCH,
-        'perzsa'               : Date.CAL_PERSIAN,
-        'svéd'                 : Date.CAL_SWEDISH,
-        }
-
+        "Gergely": Date.CAL_GREGORIAN,
+        "Julián": Date.CAL_JULIAN,
+        "julián": Date.CAL_JULIAN,
+        "héber": Date.CAL_HEBREW,
+        "iszlám": Date.CAL_ISLAMIC,
+        "francia köztársasági": Date.CAL_FRENCH,
+        "perzsa": Date.CAL_PERSIAN,
+        "svéd": Date.CAL_SWEDISH,
+    }
 
     def init_strings(self):
         # Compiles regular expression strings for matching dates
         DateParser.init_strings(self)
 
-        self._numeric = re.compile(
-            r"((\d+)[/\.])?\s*((\d+)[/\.])?\s*(\d+)[/\. ]?$")
+        self._numeric = re.compile(r"((\d+)[/\.])?\s*((\d+)[/\.])?\s*(\d+)[/\. ]?$")
         # this next RE has the (possibly-slashed) year at the string's start
-        self._text2 = re.compile(r'((\d+)(/\d+)?\.)?\s+?%s\.?\s*(\d+\.)?\s*$'
-                                 % self._mon_str, re.IGNORECASE)
-        _span_1 = [r'-tó\(ő\)l', '-tól', '-től']
-        _span_2 = ['-ig']
-        _range_1 = ['és']
-        _range_2 = ['között']
-        self._span = re.compile(r"(?P<start>.+)(%s)\s+(?P<stop>.+)(%s)" %
-                                ('|'.join(_span_1), '|'.join(_span_2)),
-                                re.IGNORECASE)
-        self._range = re.compile(r"(?P<start>.+)\s+(%s)\s+(?P<stop>.+)\s+(%s)"
-                                 % ('|'.join(_range_1), '|'.join(_range_2)),
-                                 re.IGNORECASE)
-
+        self._text2 = re.compile(
+            r"((\d+)(/\d+)?\.)?\s+?%s\.?\s*(\d+\.)?\s*$" % self._mon_str, re.IGNORECASE
+        )
+        _span_1 = [r"-tó\(ő\)l", "-tól", "-től"]
+        _span_2 = ["-ig"]
+        _range_1 = ["és"]
+        _range_2 = ["között"]
+        self._span = re.compile(
+            r"(?P<start>.+)(%s)\s+(?P<stop>.+)(%s)"
+            % ("|".join(_span_1), "|".join(_span_2)),
+            re.IGNORECASE,
+        )
+        self._range = re.compile(
+            r"(?P<start>.+)\s+(%s)\s+(?P<stop>.+)\s+(%s)"
+            % ("|".join(_range_1), "|".join(_range_2)),
+            re.IGNORECASE,
+        )
 
     def _get_int(self, val):
         """
@@ -253,13 +260,14 @@ class DateParserHU(DateParser):
         if val is None:
             return 0
         else:
-            return int(val.replace('.', ''))
+            return int(val.replace(".", ""))
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Hungarian display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayHU(DateDisplay):
     """
     Hungarian language date display class.
@@ -267,24 +275,34 @@ class DateDisplayHU(DateDisplay):
 
     _bce_str = "i. e. %s"
 
-    roman_months=(
-                  "-.", "I.", "II.", "III.", "IV.", "V.", "VI.",
-                  "VII.", "VIII.", "IX.", "X.", "XI.", "XII."
-                 )
+    roman_months = (
+        "-.",
+        "I.",
+        "II.",
+        "III.",
+        "IV.",
+        "V.",
+        "VI.",
+        "VII.",
+        "VIII.",
+        "IX.",
+        "X.",
+        "XI.",
+        "XII.",
+    )
 
     formats = (
-        "ÉÉÉÉ-HH-NN (ISO)",                              # 0
-        "Alapértelmezett éééé. hh. nn.",                 # 1
-        "Év hónap nap", # year, full month name, day     # 2
-        "Év hó nap",    #year, short month name, day     # 3
-        "Év római h.sz. nap"   #year, Roman number, day  # 4
-        )
-        # this definition must agree with its "_display_calendar" method
+        "ÉÉÉÉ-HH-NN (ISO)",  # 0
+        "Alapértelmezett éééé. hh. nn.",  # 1
+        "Év hónap nap",  # year, full month name, day     # 2
+        "Év hó nap",  # year, short month name, day     # 3
+        "Év római h.sz. nap",  # year, Roman number, day  # 4
+    )
+    # this definition must agree with its "_display_calendar" method
 
     display = DateDisplay.display_formatted
 
-    def _display_calendar(self, date_val, long_months, short_months = None,
-                          inflect=""):
+    def _display_calendar(self, date_val, long_months, short_months=None, inflect=""):
         # this must agree with its locale-specific "formats" definition
 
         year = self._slash_year(date_val[2], date_val[3])
@@ -301,55 +319,84 @@ class DateDisplayHU(DateDisplay):
             if date_val[3]:
                 return self.display_iso(date_val)
             else:
-                if date_val[0]==0:          #No day
-                    if date_val[1]==0:      #No month -> year
-                        value="%s" % year
+                if date_val[0] == 0:  # No day
+                    if date_val[1] == 0:  # No month -> year
+                        value = "%s" % year
                     else:
-                         value="%s. %02d." % (year, date_val[1])    #If no day -> year, month
+                        value = "%s. %02d." % (
+                            year,
+                            date_val[1],
+                        )  # If no day -> year, month
                 else:
-                    value="%s. %02d. %02d." % (year, date_val[1], date_val[0])
+                    value = "%s. %02d. %02d." % (year, date_val[1], date_val[0])
 
         elif self.format == 2:
             # year, full month name, day
 
-            if date_val[0]==0:
-                if date_val[1]==0:
-                    value="%s" % year
+            if date_val[0] == 0:
+                if date_val[1] == 0:
+                    value = "%s" % year
                 else:
-                     value="%s. %s" % (year, self.long_months[date_val[1]]) #If no day -> year, month
+                    value = "%s. %s" % (
+                        year,
+                        self.long_months[date_val[1]],
+                    )  # If no day -> year, month
             else:
-                 if date_val[1]==0:
-                     value="%s. %s %02d." % (year, '-', date_val[0])   #To indicate somehow if the month is missing
-                 else:
-                      value="%s. %s %02d." % (year, self.long_months[date_val[1]], date_val[0])
-
+                if date_val[1] == 0:
+                    value = "%s. %s %02d." % (
+                        year,
+                        "-",
+                        date_val[0],
+                    )  # To indicate somehow if the month is missing
+                else:
+                    value = "%s. %s %02d." % (
+                        year,
+                        self.long_months[date_val[1]],
+                        date_val[0],
+                    )
 
         elif self.format == 3:
-            #year, short month name, day
+            # year, short month name, day
 
-            if date_val[0]==0:
-                if date_val[1]==0:
-                    value="%s" % year
+            if date_val[0] == 0:
+                if date_val[1] == 0:
+                    value = "%s" % year
                 else:
-                    value="%s. %s" % (year, self.short_months[date_val[1]]) #If no day -> year, month
+                    value = "%s. %s" % (
+                        year,
+                        self.short_months[date_val[1]],
+                    )  # If no day -> year, month
             else:
-                 if date_val[1]==0:
-                     value="%s. %s %02d." % (year, '-.', date_val[0])   #To indicate somehow if the month is missing
-                 else:
-                     value="%s. %s %02d." % (year, self.short_months[date_val[1]], date_val[0])
-
+                if date_val[1] == 0:
+                    value = "%s. %s %02d." % (
+                        year,
+                        "-.",
+                        date_val[0],
+                    )  # To indicate somehow if the month is missing
+                else:
+                    value = "%s. %s %02d." % (
+                        year,
+                        self.short_months[date_val[1]],
+                        date_val[0],
+                    )
 
         elif self.format == 4:
-            #year, Roman number, day
+            # year, Roman number, day
 
-            if date_val[0]==0:
-                if date_val[1]==0:
-                    value="%s" % year
+            if date_val[0] == 0:
+                if date_val[1] == 0:
+                    value = "%s" % year
                 else:
-                     value="%s. %s" % (year, self.roman_months[date_val[1]]) #If no day -> year, month
+                    value = "%s. %s" % (
+                        year,
+                        self.roman_months[date_val[1]],
+                    )  # If no day -> year, month
             else:
-                value="%s. %s %02d." % (year, self.roman_months[date_val[1]], date_val[0])
-
+                value = "%s. %s %02d." % (
+                    year,
+                    self.roman_months[date_val[1]],
+                    date_val[0],
+                )
 
         else:
             # day month_name year
@@ -361,11 +408,14 @@ class DateDisplayHU(DateDisplay):
         else:
             return value
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('hu_HU', 'hu', 'hungarian', 'Hungarian', 'magyar', ('%Y-%m-%d',)),
-    DateParserHU, DateDisplayHU)
+    ("hu_HU", "hu", "hungarian", "Hungarian", "magyar", ("%Y-%m-%d",)),
+    DateParserHU,
+    DateDisplayHU,
+)

--- a/gramps/gen/datehandler/_date_is.py
+++ b/gramps/gen/datehandler/_date_is.py
@@ -24,29 +24,29 @@
 Icelandic-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 import datetime
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Icelandic parser class
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserIs(DateParser):
     """
     Convert a text string into a Date object, expecting a date
@@ -56,39 +56,41 @@ class DateParserIs(DateParser):
 
     # modifiers before the date
     modifier_to_int = {
-        'fyrir'    : Date.MOD_BEFORE,
-        'á undan'  : Date.MOD_BEFORE,
-        'eftir'   : Date.MOD_AFTER,
-        'í kringum' : Date.MOD_ABOUT,
-        'uþb'      : Date.MOD_ABOUT,
-        'um'       : Date.MOD_ABOUT,
-        }
+        "fyrir": Date.MOD_BEFORE,
+        "á undan": Date.MOD_BEFORE,
+        "eftir": Date.MOD_AFTER,
+        "í kringum": Date.MOD_ABOUT,
+        "uþb": Date.MOD_ABOUT,
+        "um": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     bce = ["f Kr"]
 
     calendar_to_int = {
-        'gregoríanskt   '      : Date.CAL_GREGORIAN,
-        'g'                   : Date.CAL_GREGORIAN,
-        'júlíanskt'            : Date.CAL_JULIAN,
-        'j'                   : Date.CAL_JULIAN,
-        'hebreskt'            : Date.CAL_HEBREW,
-        'h'                   : Date.CAL_HEBREW,
-        'íslamskt'            : Date.CAL_ISLAMIC,
-        'múslimskt'            : Date.CAL_ISLAMIC,
-        'i'                   : Date.CAL_ISLAMIC,
-        'franskt'              : Date.CAL_FRENCH,
-        'franska lýðveldisins' : Date.CAL_FRENCH,
-        'f'                   : Date.CAL_FRENCH,
-        'persneskt'             : Date.CAL_PERSIAN,
-        'p'                   : Date.CAL_PERSIAN,
-        'sænskt'              : Date.CAL_SWEDISH,
-        's'                   : Date.CAL_SWEDISH,
-        }
+        "gregoríanskt   ": Date.CAL_GREGORIAN,
+        "g": Date.CAL_GREGORIAN,
+        "júlíanskt": Date.CAL_JULIAN,
+        "j": Date.CAL_JULIAN,
+        "hebreskt": Date.CAL_HEBREW,
+        "h": Date.CAL_HEBREW,
+        "íslamskt": Date.CAL_ISLAMIC,
+        "múslimskt": Date.CAL_ISLAMIC,
+        "i": Date.CAL_ISLAMIC,
+        "franskt": Date.CAL_FRENCH,
+        "franska lýðveldisins": Date.CAL_FRENCH,
+        "f": Date.CAL_FRENCH,
+        "persneskt": Date.CAL_PERSIAN,
+        "p": Date.CAL_PERSIAN,
+        "sænskt": Date.CAL_SWEDISH,
+        "s": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        'áætlað' : Date.QUAL_ESTIMATED,
-        'reiknað'   : Date.QUAL_CALCULATED,
-        }
+        "áætlað": Date.QUAL_ESTIMATED,
+        "reiknað": Date.QUAL_CALCULATED,
+    }
 
     def dhformat_changed(self):
         self._dhformat_parse = re.compile(r".*%(\S).*%(\S).*%(\S).*%(\S).*")
@@ -97,34 +99,63 @@ class DateParserIs(DateParser):
         DateParser.init_strings(self)
 
         # match 'day. month year' format
-        self._text2 = re.compile(r'(\d+)?\.?\s*?%s\.?\s*((\d+)(/\d+)?)?\s*$'
-                                 % self._mon_str, re.IGNORECASE)
+        self._text2 = re.compile(
+            r"(\d+)?\.?\s*?%s\.?\s*((\d+)(/\d+)?)?\s*$" % self._mon_str, re.IGNORECASE
+        )
         # match 'short-day day.month year' format
-        short_day_str = '(' + '|'.join(self._ds.short_days[1:]) + ')'
-        self._numeric = re.compile(r"%s\s*((\d+)[\.]\s*)?((\d+)\s*)?(\d+)\s*$"
-                                   % short_day_str, re.IGNORECASE)
+        short_day_str = "(" + "|".join(self._ds.short_days[1:]) + ")"
+        self._numeric = re.compile(
+            r"%s\s*((\d+)[\.]\s*)?((\d+)\s*)?(\d+)\s*$" % short_day_str, re.IGNORECASE
+        )
         self._span = re.compile(
-            r"(frá)?\s*(?P<start>.+)\s*(til|--|–)\s*(?P<stop>.+)",
-            re.IGNORECASE)
+            r"(frá)?\s*(?P<start>.+)\s*(til|--|–)\s*(?P<stop>.+)", re.IGNORECASE
+        )
         self._range = re.compile(
-            r"(milli)\s+(?P<start>.+)\s+og\s+(?P<stop>.+)", re.IGNORECASE)
+            r"(milli)\s+(?P<start>.+)\s+og\s+(?P<stop>.+)", re.IGNORECASE
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Icelandic display class
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayIs(DateDisplay):
     """
     Icelandic language date display class.
     """
 
-    long_months = ( "", "janúar", "febrúar", "mars", "apríl", "maí",
-                    "júní", "júlí", "ágúst", "september", "október",
-                    "nóvember", "desember" )
+    long_months = (
+        "",
+        "janúar",
+        "febrúar",
+        "mars",
+        "apríl",
+        "maí",
+        "júní",
+        "júlí",
+        "ágúst",
+        "september",
+        "október",
+        "nóvember",
+        "desember",
+    )
 
-    short_months = ( "", "jan", "feb", "mar", "apr", "maí", "jún",
-                     "júl", "ágú", "sep", "okt", "nóv", "des" )
+    short_months = (
+        "",
+        "jan",
+        "feb",
+        "mar",
+        "apr",
+        "maí",
+        "jún",
+        "júl",
+        "ágú",
+        "sep",
+        "okt",
+        "nóv",
+        "des",
+    )
 
     formats = (
         "ÁÁÁÁ-MM-DD (ISO)",
@@ -133,9 +164,9 @@ class DateDisplayIs(DateDisplay):
         "Mán Dag Ár",
         "Dagur mánuður ár",
         "Dag Mán Ár",
-        )
-        # this must agree with DateDisplayEn's "formats" definition
-        # (since no locale-specific _display_gregorian exists, here)
+    )
+    # this must agree with DateDisplayEn's "formats" definition
+    # (since no locale-specific _display_gregorian exists, here)
 
     calendar = (
         "",
@@ -144,8 +175,8 @@ class DateDisplayIs(DateDisplay):
         "franska lýðveldisins",
         "persneskt",
         "íslamskt",
-        "sænskt"
-        )
+        "sænskt",
+    )
 
     _mod_str = ("", "fyrir ", "eftir ", "uþb ", "", "", "")
 
@@ -178,19 +209,20 @@ class DateDisplayIs(DateDisplay):
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%smilli %s og %s%s" % (qual_str, d1, d2,
-                                              scal)
+            return "%smilli %s og %s%s" % (qual_str, d1, d2, scal)
         else:
             text = self.display_cal[date.get_calendar()](start)
             scal = self.format_extras(cal, newyear)
-            return "%s%s%s%s" % (qual_str, self._mod_str[mod],
-                                 text, scal)
+            return "%s%s%s%s" % (qual_str, self._mod_str[mod], text, scal)
 
     def _get_weekday(self, date_val):
-        if (date_val[0] == 0 or date_val[1] == 0 # no day or no month or both
-                or date_val[2] > datetime.MAXYEAR): # bug 10815
-            return ''
-        w_day = datetime.date(date_val[2], date_val[1], date_val[0]) # y, m, d
+        if (
+            date_val[0] == 0
+            or date_val[1] == 0  # no day or no month or both
+            or date_val[2] > datetime.MAXYEAR
+        ):  # bug 10815
+            return ""
+        w_day = datetime.date(date_val[2], date_val[1], date_val[0])  # y, m, d
         return self.short_days[((w_day.weekday() + 1) % 7) + 1]
 
     def dd_dformat01(self, date_val):
@@ -203,23 +235,26 @@ class DateDisplayIs(DateDisplay):
             if date_val[0] == date_val[1] == 0:
                 return str(date_val[2])
             else:
-                value = self.dhformat.replace('%m', str(date_val[1]))
+                value = self.dhformat.replace("%m", str(date_val[1]))
                 # some locales have %b for the month, e.g. ar_EG, is_IS, nb_NO
-                value = value.replace('%b', str(date_val[1]))
+                value = value.replace("%b", str(date_val[1]))
                 # some locales have %a for the abbreviated day, e.g. is_IS
-                value = value.replace('%a', self._get_weekday(date_val))
-                if date_val[0] == 0: # ignore the zero day and its delimiter
-                    i_day = value.find('%e') # Icelandic uses %e and not %d
-                    value = value.replace(value[i_day:i_day+3], '')
-                value = value.replace('%e', str(date_val[0]))
-                value = value.replace('%Y', str(abs(date_val[2])))
-                return value.replace('-', '/')
+                value = value.replace("%a", self._get_weekday(date_val))
+                if date_val[0] == 0:  # ignore the zero day and its delimiter
+                    i_day = value.find("%e")  # Icelandic uses %e and not %d
+                    value = value.replace(value[i_day : i_day + 3], "")
+                value = value.replace("%e", str(date_val[0]))
+                value = value.replace("%Y", str(abs(date_val[2])))
+                return value.replace("-", "/")
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('is_IS', 'is', 'íslenskt', 'Icelandic', ('%a %e.%b %Y',)),
-    DateParserIs, DateDisplayIs)
+    ("is_IS", "is", "íslenskt", "Icelandic", ("%a %e.%b %Y",)),
+    DateParserIs,
+    DateDisplayIs,
+)

--- a/gramps/gen/datehandler/_date_it.py
+++ b/gramps/gen/datehandler/_date_it.py
@@ -25,133 +25,174 @@
 Italian-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Italian parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserIT(DateParser):
 
     modifier_to_int = {
-        'prima del'            : Date.MOD_BEFORE,
-        'prima'                : Date.MOD_BEFORE,
-        'dopo del'             : Date.MOD_AFTER,
-        'dopo'                 : Date.MOD_AFTER,
-        'approssimativamente'  : Date.MOD_ABOUT,
-        'apross.'              : Date.MOD_ABOUT,
-        'apross'               : Date.MOD_ABOUT,
-        'circa il'             : Date.MOD_ABOUT,
-        'circa'                : Date.MOD_ABOUT,
-        'ca.'                  : Date.MOD_ABOUT,
-        'ca'                   : Date.MOD_ABOUT,
-        'c.'                   : Date.MOD_ABOUT,
-        }
+        "prima del": Date.MOD_BEFORE,
+        "prima": Date.MOD_BEFORE,
+        "dopo del": Date.MOD_AFTER,
+        "dopo": Date.MOD_AFTER,
+        "approssimativamente": Date.MOD_ABOUT,
+        "apross.": Date.MOD_ABOUT,
+        "apross": Date.MOD_ABOUT,
+        "circa il": Date.MOD_ABOUT,
+        "circa": Date.MOD_ABOUT,
+        "ca.": Date.MOD_ABOUT,
+        "ca": Date.MOD_ABOUT,
+        "c.": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     calendar_to_int = {
-        'gregoriano'    : Date.CAL_GREGORIAN,
-        'g'             : Date.CAL_GREGORIAN,
-        'giuliano'      : Date.CAL_JULIAN,
-        'j'             : Date.CAL_JULIAN,
-        'ebraico'       : Date.CAL_HEBREW,
-        'e'             : Date.CAL_HEBREW,
-        'islamico'      : Date.CAL_ISLAMIC,
-        'i'             : Date.CAL_ISLAMIC,
-        'rivoluzionario': Date.CAL_FRENCH,
-        'r'             : Date.CAL_FRENCH,
-        'persiano'      : Date.CAL_PERSIAN,
-        'p'             : Date.CAL_PERSIAN,
-        'svedese'      : Date.CAL_SWEDISH,
-        's'            : Date.CAL_SWEDISH,
-        }
+        "gregoriano": Date.CAL_GREGORIAN,
+        "g": Date.CAL_GREGORIAN,
+        "giuliano": Date.CAL_JULIAN,
+        "j": Date.CAL_JULIAN,
+        "ebraico": Date.CAL_HEBREW,
+        "e": Date.CAL_HEBREW,
+        "islamico": Date.CAL_ISLAMIC,
+        "i": Date.CAL_ISLAMIC,
+        "rivoluzionario": Date.CAL_FRENCH,
+        "r": Date.CAL_FRENCH,
+        "persiano": Date.CAL_PERSIAN,
+        "p": Date.CAL_PERSIAN,
+        "svedese": Date.CAL_SWEDISH,
+        "s": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        'stimata'   : Date.QUAL_ESTIMATED,
-        'st.'       : Date.QUAL_ESTIMATED,
-        'st'        : Date.QUAL_ESTIMATED,
-        'calcolata' : Date.QUAL_CALCULATED,
-        'calc.'     : Date.QUAL_CALCULATED,
-        'calc'      : Date.QUAL_CALCULATED,
-        }
+        "stimata": Date.QUAL_ESTIMATED,
+        "st.": Date.QUAL_ESTIMATED,
+        "st": Date.QUAL_ESTIMATED,
+        "calcolata": Date.QUAL_CALCULATED,
+        "calc.": Date.QUAL_CALCULATED,
+        "calc": Date.QUAL_CALCULATED,
+    }
 
     def init_strings(self):
         DateParser.init_strings(self)
-        _span_1 = ['dal', 'da']
-        _span_2 = ['al', 'a']
-        _range_1 = ['tra', 'fra']
-        _range_2 = ['e']
-        self._span = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                ('|'.join(_span_1), '|'.join(_span_2)),
-                                 re.IGNORECASE)
+        _span_1 = ["dal", "da"]
+        _span_2 = ["al", "a"]
+        _range_1 = ["tra", "fra"]
+        _range_2 = ["e"]
+        self._span = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_span_1), "|".join(_span_2)),
+            re.IGNORECASE,
+        )
         self._range = re.compile(
-            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-            ('|'.join(_range_1), '|'.join(_range_2)), re.IGNORECASE)
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_range_1), "|".join(_range_2)),
+            re.IGNORECASE,
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Italian display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayIT(DateDisplay):
     """
     Italian language date display class.
     """
-    long_months = ( "", "gennaio", "febbraio", "marzo", "aprile",
-                    "maggio", "giugno", "luglio", "agosto", "settembre",
-                    "ottobre", "novembre", "dicembre" )
 
-    short_months = ( "", "gen", "feb", "mar", "apr", "mag", "giu",
-                     "lug", "ago", "set", "ott", "nov", "dic" )
+    long_months = (
+        "",
+        "gennaio",
+        "febbraio",
+        "marzo",
+        "aprile",
+        "maggio",
+        "giugno",
+        "luglio",
+        "agosto",
+        "settembre",
+        "ottobre",
+        "novembre",
+        "dicembre",
+    )
+
+    short_months = (
+        "",
+        "gen",
+        "feb",
+        "mar",
+        "apr",
+        "mag",
+        "giu",
+        "lug",
+        "ago",
+        "set",
+        "ott",
+        "nov",
+        "dic",
+    )
 
     calendar = (
-        "", "Giuliano", "Ebraico",
-        "Rivoluzionario", "Persiano", "Islamico",
-        "Svedese"
-        )
+        "",
+        "Giuliano",
+        "Ebraico",
+        "Rivoluzionario",
+        "Persiano",
+        "Islamico",
+        "Svedese",
+    )
 
     _mod_str = ("", "prima del ", "dopo del ", "circa il ", "", "", "")
 
     _qual_str = ("", "stimata ", "calcolata ")
 
     french = (
-        '',
-        'vendemmiaio',
-        'brumaio',
-        'frimaio',
-        'nevoso',
-        'piovoso',
-        'ventoso',
-        'germile',
-        'fiorile',
-        'pratile',
-        'messidoro',
-        'termidoro',
-        'fruttidoro',
-        'extra',
-        )
+        "",
+        "vendemmiaio",
+        "brumaio",
+        "frimaio",
+        "nevoso",
+        "piovoso",
+        "ventoso",
+        "germile",
+        "fiorile",
+        "pratile",
+        "messidoro",
+        "termidoro",
+        "fruttidoro",
+        "extra",
+    )
 
     formats = (
-        "AAAA-MM-DD (ISO)", "Numerico", "Mese Giorno Anno",
-        "MES Giorno, Anno", "Giorno Mese Anno", "Giorno MES Anno"
-        )
-        # this must agree with DateDisplayEn's "formats" definition
-        # (since no locale-specific _display_gregorian exists, here)
+        "AAAA-MM-DD (ISO)",
+        "Numerico",
+        "Mese Giorno Anno",
+        "MES Giorno, Anno",
+        "Giorno Mese Anno",
+        "Giorno MES Anno",
+    )
+    # this must agree with DateDisplayEn's "formats" definition
+    # (since no locale-specific _display_gregorian exists, here)
 
     def display(self, date):
         """
@@ -173,22 +214,25 @@ class DateDisplayIT(DateDisplay):
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'dal', d1, 'al', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "dal", d1, "al", d2, scal)
         elif mod == Date.MOD_RANGE:
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'tra', d1, 'e', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "tra", d1, "e", d2, scal)
         else:
             text = self.display_cal[date.get_calendar()](start)
             scal = self.format_extras(cal, newyear)
             return "%s%s%s%s" % (qual_str, self._mod_str[mod], text, scal)
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('it_IT', 'it', 'italian', 'Italian', 'it_CH', ('%d/%m/%Y',)),
-    DateParserIT, DateDisplayIT)
+    ("it_IT", "it", "italian", "Italian", "it_CH", ("%d/%m/%Y",)),
+    DateParserIT,
+    DateDisplayIT,
+)

--- a/gramps/gen/datehandler/_date_ja.py
+++ b/gramps/gen/datehandler/_date_ja.py
@@ -24,30 +24,30 @@
 Japanese-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Japanese parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserJA(DateParser):
     """
     Convert a text string into a Date object. If the date cannot be
@@ -56,21 +56,23 @@ class DateParserJA(DateParser):
 
     # modifiers after the date
     modifier_after_to_int = {
-        '以前' : Date.MOD_BEFORE,
-        '以降' : Date.MOD_AFTER,
-        '頃'   : Date.MOD_ABOUT,
-        'ごろ' : Date.MOD_ABOUT,
-        }
+        "以前": Date.MOD_BEFORE,
+        "以降": Date.MOD_AFTER,
+        "頃": Date.MOD_ABOUT,
+        "ごろ": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     month_to_int = DateParser.month_to_int
 
     quality_to_int = {
-        'およそ'    : Date.QUAL_ESTIMATED,
-        'ごろ'      : Date.QUAL_ESTIMATED,
-        '位'      : Date.QUAL_ESTIMATED,
-        'の見積り'  : Date.QUAL_ESTIMATED,
-        '計算上'  : Date.QUAL_CALCULATED,
-        }
+        "およそ": Date.QUAL_ESTIMATED,
+        "ごろ": Date.QUAL_ESTIMATED,
+        "位": Date.QUAL_ESTIMATED,
+        "の見積り": Date.QUAL_ESTIMATED,
+        "計算上": Date.QUAL_CALCULATED,
+    }
 
     bce = ["紀元前", "BC"] + DateParser.bce
 
@@ -80,130 +82,138 @@ class DateParserJA(DateParser):
         """
         DateParser.init_strings(self)
 
-        DateParser.calendar_to_int.update({
-            'グレゴリオ暦' : Date.CAL_GREGORIAN,
-            'g'            : Date.CAL_GREGORIAN,
-            'ユリウス暦' : Date.CAL_JULIAN,
-            'j'          : Date.CAL_JULIAN,
-            'ユダヤ暦' : Date.CAL_HEBREW,
-            'h'        : Date.CAL_HEBREW,
-            'ヒジュラ暦' : Date.CAL_ISLAMIC,
-            'i'          : Date.CAL_ISLAMIC,
-            'フランス革命暦' : Date.CAL_FRENCH,
-            '共和暦'         : Date.CAL_FRENCH,
-            'f'              : Date.CAL_FRENCH,
-            'イラン暦' : Date.CAL_PERSIAN,
-            'p'        : Date.CAL_PERSIAN,
-            'スウェーデン暦' : Date.CAL_SWEDISH,
-            's'              : Date.CAL_SWEDISH,
-        })
+        DateParser.calendar_to_int.update(
+            {
+                "グレゴリオ暦": Date.CAL_GREGORIAN,
+                "g": Date.CAL_GREGORIAN,
+                "ユリウス暦": Date.CAL_JULIAN,
+                "j": Date.CAL_JULIAN,
+                "ユダヤ暦": Date.CAL_HEBREW,
+                "h": Date.CAL_HEBREW,
+                "ヒジュラ暦": Date.CAL_ISLAMIC,
+                "i": Date.CAL_ISLAMIC,
+                "フランス革命暦": Date.CAL_FRENCH,
+                "共和暦": Date.CAL_FRENCH,
+                "f": Date.CAL_FRENCH,
+                "イラン暦": Date.CAL_PERSIAN,
+                "p": Date.CAL_PERSIAN,
+                "スウェーデン暦": Date.CAL_SWEDISH,
+                "s": Date.CAL_SWEDISH,
+            }
+        )
 
-        DateParser.month_to_int.update({
-            "一月"      : 1,
-            "ichigatsu" : 1,
-            "睦月"      : 1,
-            "mutsuki"   : 1,
-            "二月"       : 2,
-            "nigatsu"    : 2,
-            "如月"       : 2,
-            "kisaragi"   : 2,
-            "衣更着"     : 2,
-            "kinusaragi" : 2,
-            "三月"     : 3,
-            "sangatsu" : 3,
-            "弥生"     : 3,
-            "yayoi"    : 3,
-            "四月"     : 4,
-            "shigatsu" : 4,
-            "卯月"     : 4,
-            "uzuki"    : 4,
-            "五月"       : 5,
-            "gogatsu"    : 5,
-            "皐月"       : 5,
-            "satsuki"    : 5,
-            "早苗月"     : 5,
-            "sanaetsuki" : 5,
-            "六月"      : 6,
-            "rokugatsu" : 6,
-            "水無月"    : 6,
-            "minazuki"  : 6,
-            "七月"        : 7,
-            "shichigatsu" : 7,
-            "文月"        : 7,
-            "fumizuki"    : 7,
-            "八月"       : 8,
-            "hachigatsu" : 8,
-            "葉月"       : 8,
-            "hazuki"     : 8,
-            "九月"      : 9,
-            "kugatsu"   : 9,
-            "長月"      : 9,
-            "nagatsuki" : 9,
-            "十月"        : 10,
-            "jugatsu"     : 10,
-            "jūgatsu"     : 10,
-            "juugatsu"    : 10,
-            "神無月"      : 10,
-            "kannazuki"   : 10,
-            "kaminazuki"  : 10,
-            "神有月"      : 10,
-            "神在月"      : 10,
-            "kamiarizuki" : 10,
-            "十一月"       : 11,
-            "juichigatsu"  : 11,
-            "jūichigatsu"  : 11,
-            "juuichigatsu" : 11,
-            "霜月"         : 11,
-            "shimotsuki"   : 11,
-            "十二月"     : 12,
-            "junigatsu"  : 12,
-            "jūnigatsu"  : 12,
-            "juunigatsu" : 12,
-            "師走"       : 12,
-            "shiwasu"    : 12,
-        })
+        DateParser.month_to_int.update(
+            {
+                "一月": 1,
+                "ichigatsu": 1,
+                "睦月": 1,
+                "mutsuki": 1,
+                "二月": 2,
+                "nigatsu": 2,
+                "如月": 2,
+                "kisaragi": 2,
+                "衣更着": 2,
+                "kinusaragi": 2,
+                "三月": 3,
+                "sangatsu": 3,
+                "弥生": 3,
+                "yayoi": 3,
+                "四月": 4,
+                "shigatsu": 4,
+                "卯月": 4,
+                "uzuki": 4,
+                "五月": 5,
+                "gogatsu": 5,
+                "皐月": 5,
+                "satsuki": 5,
+                "早苗月": 5,
+                "sanaetsuki": 5,
+                "六月": 6,
+                "rokugatsu": 6,
+                "水無月": 6,
+                "minazuki": 6,
+                "七月": 7,
+                "shichigatsu": 7,
+                "文月": 7,
+                "fumizuki": 7,
+                "八月": 8,
+                "hachigatsu": 8,
+                "葉月": 8,
+                "hazuki": 8,
+                "九月": 9,
+                "kugatsu": 9,
+                "長月": 9,
+                "nagatsuki": 9,
+                "十月": 10,
+                "jugatsu": 10,
+                "jūgatsu": 10,
+                "juugatsu": 10,
+                "神無月": 10,
+                "kannazuki": 10,
+                "kaminazuki": 10,
+                "神有月": 10,
+                "神在月": 10,
+                "kamiarizuki": 10,
+                "十一月": 11,
+                "juichigatsu": 11,
+                "jūichigatsu": 11,
+                "juuichigatsu": 11,
+                "霜月": 11,
+                "shimotsuki": 11,
+                "十二月": 12,
+                "junigatsu": 12,
+                "jūnigatsu": 12,
+                "juunigatsu": 12,
+                "師走": 12,
+                "shiwasu": 12,
+            }
+        )
 
-        _span_1 = ['から', '~', '〜']
-        _span_2 = ['まで']
-        _range_1 = ['から', 'と', '~', '〜']
-        _range_2 = ['までの間', 'の間']
-        self._span = re.compile(r"(?P<start>.+)(%s)(?P<stop>.+)(%s)" %
-                                ('|'.join(_span_1), '|'.join(_span_2)),
-                                re.IGNORECASE)
-        self._range = re.compile(r"(?P<start>.+)(%s)(?P<stop>.+)(%s)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2)),
-                                 re.IGNORECASE)
+        _span_1 = ["から", "~", "〜"]
+        _span_2 = ["まで"]
+        _range_1 = ["から", "と", "~", "〜"]
+        _range_2 = ["までの間", "の間"]
+        self._span = re.compile(
+            r"(?P<start>.+)(%s)(?P<stop>.+)(%s)"
+            % ("|".join(_span_1), "|".join(_span_2)),
+            re.IGNORECASE,
+        )
+        self._range = re.compile(
+            r"(?P<start>.+)(%s)(?P<stop>.+)(%s)"
+            % ("|".join(_range_1), "|".join(_range_2)),
+            re.IGNORECASE,
+        )
         self._numeric = re.compile(r"((\d+)年\s*)?((\d+)月\s*)?(\d+)?日?\s*$")
-        self._cal = re.compile(r"(.*?)\s*\(%s\)\s*(.*)" % self._cal_str,
-                               re.IGNORECASE)
-        self._qual = re.compile(r"(.*?)\s*%s\s*(.*)" % self._qual_str,
-                                re.IGNORECASE)
+        self._cal = re.compile(r"(.*?)\s*\(%s\)\s*(.*)" % self._cal_str, re.IGNORECASE)
+        self._qual = re.compile(r"(.*?)\s*%s\s*(.*)" % self._qual_str, re.IGNORECASE)
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Japanese display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayJA(DateDisplay):
     """
     Japanese language date display class.
     """
 
     def formats_changed(self):
-        """ Allow overriding so a subclass can modify """
+        """Allow overriding so a subclass can modify"""
 
         # Specify what is actually the "System Default".
         example = self.dhformat
-        example = example.replace('%d', "31")
-        example = example.replace('%m', "12")
-        example = example.replace('%Y', "1999")
+        example = example.replace("%d", "31")
+        example = example.replace("%m", "12")
+        example = example.replace("%Y", "1999")
 
         # This definition must agree with its "_display_gregorian" method
-        self. formats = ("YYYY-MM-DD (ISO)", # 0
-                "システムデフォールト (" + example + ")", # 1
-                "1999年12月31日",   # 2
-                "1999年十二月31日", # 3
-                )
+        self.formats = (
+            "YYYY-MM-DD (ISO)",  # 0
+            "システムデフォールト (" + example + ")",  # 1
+            "1999年12月31日",  # 2
+            "1999年十二月31日",  # 3
+        )
 
     def _display_gregorian(self, date_val, **kwargs):
         """
@@ -223,12 +233,12 @@ class DateDisplayJA(DateDisplay):
                 if date_val[0] == date_val[1] == 0:
                     value = str(date_val[2])
                 else:
-                    value = self.dhformat.replace('%m', str(date_val[1]))
-                    if date_val[0] == 0: # ignore the zero day and its delimiter
-                        i_day = value.find('%d')
-                        value = value.replace(value[i_day:i_day+3], '')
-                    value = value.replace('%d', str(date_val[0]))
-                    value = value.replace('%Y', str(date_val[2]))
+                    value = self.dhformat.replace("%m", str(date_val[1]))
+                    if date_val[0] == 0:  # ignore the zero day and its delimiter
+                        i_day = value.find("%d")
+                        value = value.replace(value[i_day : i_day + 3], "")
+                    value = value.replace("%d", str(date_val[0]))
+                    value = value.replace("%Y", str(date_val[2]))
 
         elif self.format == 2:
             # 1999年12月31日
@@ -236,12 +246,9 @@ class DateDisplayJA(DateDisplay):
                 if date_val[1] == 0:
                     value = "%s年" % year
                 else:
-                    value = "%s年%s" % (year,
-                                        self.short_months[date_val[1]])
+                    value = "%s年%s" % (year, self.short_months[date_val[1]])
             else:
-                value = "%s年%s%s日" % (year,
-                                        self.short_months[date_val[1]],
-                                        date_val[0])
+                value = "%s年%s%s日" % (year, self.short_months[date_val[1]], date_val[0])
 
         elif self.format == 3:
             # 1999年十二月31日
@@ -249,12 +256,9 @@ class DateDisplayJA(DateDisplay):
                 if date_val[1] == 0:
                     value = "%s年" % year
                 else:
-                    value = "%s年%s" % (year,
-                                        self.long_months[date_val[1]])
+                    value = "%s年%s" % (year, self.long_months[date_val[1]])
             else:
-                value = "%s年%s%s日" % (year,
-                                        self.long_months[date_val[1]],
-                                        date_val[0])
+                value = "%s年%s%s日" % (year, self.long_months[date_val[1]], date_val[0])
 
         else:
             return self.display_iso(date_val)
@@ -266,12 +270,13 @@ class DateDisplayJA(DateDisplay):
 
     display = DateDisplay.display_formatted
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 
 register_datehandler(
-    ('ja_JP', 'ja', 'japanese', 'Japanese', ('%Y年%m月%d日',)),
-    DateParserJA, DateDisplayJA)
+    ("ja_JP", "ja", "japanese", "Japanese", ("%Y年%m月%d日",)), DateParserJA, DateDisplayJA
+)

--- a/gramps/gen/datehandler/_date_lt.py
+++ b/gramps/gen/datehandler/_date_lt.py
@@ -23,28 +23,28 @@
 Lithuanian-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Lithuanian parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserLT(DateParser):
     """
     Convert a text string into a Date object. If the date cannot be
@@ -101,92 +101,137 @@ class DateParserLT(DateParser):
     month_to_int["gruod"] = 12
 
     modifier_to_int = {
-        'prieš'    : Date.MOD_BEFORE,
-        'po' : Date.MOD_AFTER,
-        'apie' : Date.MOD_ABOUT,
-        }
+        "prieš": Date.MOD_BEFORE,
+        "po": Date.MOD_AFTER,
+        "apie": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     calendar_to_int = {
-        'grigaliaus'   : Date.CAL_GREGORIAN,
-        'g'                 : Date.CAL_GREGORIAN,
-        'julijaus'            : Date.CAL_JULIAN,
-        'j'                 : Date.CAL_JULIAN,
-        'hebrajų'         : Date.CAL_HEBREW,
-        'h'         : Date.CAL_HEBREW,
-        'islamo'         : Date.CAL_ISLAMIC,
-        'i'                 : Date.CAL_ISLAMIC,
-        'prancūzų respublikos': Date.CAL_FRENCH,
-        'r'                 : Date.CAL_FRENCH,
-        'persų'             : Date.CAL_PERSIAN,
-        'p'             : Date.CAL_PERSIAN,
-        'švedų'      : Date.CAL_SWEDISH,
-        's'            : Date.CAL_SWEDISH,
-        }
+        "grigaliaus": Date.CAL_GREGORIAN,
+        "g": Date.CAL_GREGORIAN,
+        "julijaus": Date.CAL_JULIAN,
+        "j": Date.CAL_JULIAN,
+        "hebrajų": Date.CAL_HEBREW,
+        "h": Date.CAL_HEBREW,
+        "islamo": Date.CAL_ISLAMIC,
+        "i": Date.CAL_ISLAMIC,
+        "prancūzų respublikos": Date.CAL_FRENCH,
+        "r": Date.CAL_FRENCH,
+        "persų": Date.CAL_PERSIAN,
+        "p": Date.CAL_PERSIAN,
+        "švedų": Date.CAL_SWEDISH,
+        "s": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        'apytikriai'  : Date.QUAL_ESTIMATED,
-        'apskaičiuota'      : Date.QUAL_CALCULATED,
-        }
+        "apytikriai": Date.QUAL_ESTIMATED,
+        "apskaičiuota": Date.QUAL_CALCULATED,
+    }
 
     def init_strings(self):
         DateParser.init_strings(self)
         # this next RE has the (possibly-slashed) year at the string's start
         self._text2 = re.compile(
-            r'((\d+)(/\d+)?)?\s+?m\.\s+%s\s*(\d+)?\s*d?\.?$'
-            % self._mon_str, re.IGNORECASE)
-        _span_1 = ['nuo']
-        _span_2 = ['iki']
-        _range_1 = ['tarp']
-        _range_2 = ['ir']
-        self._span = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                ('|'.join(_span_1), '|'.join(_span_2)),
-                                re.IGNORECASE)
+            r"((\d+)(/\d+)?)?\s+?m\.\s+%s\s*(\d+)?\s*d?\.?$" % self._mon_str,
+            re.IGNORECASE,
+        )
+        _span_1 = ["nuo"]
+        _span_2 = ["iki"]
+        _range_1 = ["tarp"]
+        _range_2 = ["ir"]
+        self._span = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_span_1), "|".join(_span_2)),
+            re.IGNORECASE,
+        )
         self._range = re.compile(
-            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-            ('|'.join(_range_1), '|'.join(_range_2)), re.IGNORECASE)
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_range_1), "|".join(_range_2)),
+            re.IGNORECASE,
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Lithuanian displayer
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayLT(DateDisplay):
     """
     Lithuanian language date display class.
     """
 
-    long_months = ( "", "sausio", "vasario", "kovo", "balandžio", "gegužės",
-                    "birželio", "liepos", "rugpjūčio", "rugsėjo", "spalio",
-                    "lapkričio", "gruodžio" )
+    long_months = (
+        "",
+        "sausio",
+        "vasario",
+        "kovo",
+        "balandžio",
+        "gegužės",
+        "birželio",
+        "liepos",
+        "rugpjūčio",
+        "rugsėjo",
+        "spalio",
+        "lapkričio",
+        "gruodžio",
+    )
 
-    long_months_vardininkas = ( "", "sausis", "vasaris", "kovas", "balandis", "gegužė",
-                    "birželis", "liepa", "rugpjūtis", "rugsėjis", "spalis",
-                    "lapkritis", "gruodis" )
+    long_months_vardininkas = (
+        "",
+        "sausis",
+        "vasaris",
+        "kovas",
+        "balandis",
+        "gegužė",
+        "birželis",
+        "liepa",
+        "rugpjūtis",
+        "rugsėjis",
+        "spalis",
+        "lapkritis",
+        "gruodis",
+    )
 
-    short_months = ( "", "Sau", "Vas", "Kov", "Bal", "Geg", "Bir",
-                     "Lie", "Rgp", "Rgs", "Spa", "Lap", "Grd" )
+    short_months = (
+        "",
+        "Sau",
+        "Vas",
+        "Kov",
+        "Bal",
+        "Geg",
+        "Bir",
+        "Lie",
+        "Rgp",
+        "Rgs",
+        "Spa",
+        "Lap",
+        "Grd",
+    )
 
     calendar = (
-        "", "julijaus",
+        "",
+        "julijaus",
         "hebrajų",
         "prancūzų respublikos",
         "persų",
         "islamo",
-        "švedų"
-        )
+        "švedų",
+    )
 
-    _mod_str = ("",
-        "prieš ",
-        "po ",
-        "apie ",
-        "", "", "")
+    _mod_str = ("", "prieš ", "po ", "apie ", "", "", "")
 
     _qual_str = ("", "apytikriai ", "apskaičiuota ")
 
     formats = (
-        "mmmm-MM-DD (ISO)", "mmmm.MM.DD",
-        "mmmm m. mėnesio diena d.", "Mėn diena, metai")
-        # this definition must agree with its "_display_gregorian" method
+        "mmmm-MM-DD (ISO)",
+        "mmmm.MM.DD",
+        "mmmm m. mėnesio diena d.",
+        "Mėn diena, metai",
+    )
+    # this definition must agree with its "_display_gregorian" method
 
     def _display_gregorian(self, date_val, **kwargs):
         """
@@ -206,11 +251,16 @@ class DateDisplayLT(DateDisplay):
                 if date_val[1] == 0:
                     value = year
                 else:
-                    value = "%s m. %s" % (year, self.long_months_vardininkas[date_val[1]])
+                    value = "%s m. %s" % (
+                        year,
+                        self.long_months_vardininkas[date_val[1]],
+                    )
             else:
-                value = "%s m. %s %d d." % (year,
-                                            self.long_months[date_val[1]],
-                                            date_val[0])
+                value = "%s m. %s %d d." % (
+                    year,
+                    self.long_months[date_val[1]],
+                    date_val[0],
+                )
         elif self.format == 3:
             # month_abbreviation day, year
             if date_val[0] == 0:
@@ -219,8 +269,11 @@ class DateDisplayLT(DateDisplay):
                 else:
                     value = "%s %s" % (self.short_months[date_val[1]], year)
             else:
-                value = "%s %d, %s" % (self.short_months[date_val[1]],
-                                       date_val[0], year)
+                value = "%s %d, %s" % (
+                    self.short_months[date_val[1]],
+                    date_val[0],
+                    year,
+                )
         if date_val[2] < 0:
             return self._bce_str % value
         else:
@@ -246,25 +299,25 @@ class DateDisplayLT(DateDisplay):
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'nuo', d1, 'iki',
-                                        d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "nuo", d1, "iki", d2, scal)
         elif mod == Date.MOD_RANGE:
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'tarp', d1, 'ir',
-                                        d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "tarp", d1, "ir", d2, scal)
         else:
             text = self.display_cal[date.get_calendar()](start)
             scal = self.format_extras(cal, newyear)
-            return "%s%s%s%s" % (qual_str, self._mod_str[mod], text,
-                                 scal)
+            return "%s%s%s%s" % (qual_str, self._mod_str[mod], text, scal)
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('lt_LT', 'lt', 'lithuanian', 'Lithuanian', ('%Y.%m.%d',)),
-    DateParserLT, DateDisplayLT)
+    ("lt_LT", "lt", "lithuanian", "Lithuanian", ("%Y.%m.%d",)),
+    DateParserLT,
+    DateDisplayLT,
+)

--- a/gramps/gen/datehandler/_date_nb.py
+++ b/gramps/gen/datehandler/_date_nb.py
@@ -23,28 +23,28 @@
 Norwegian-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Norwegian parser class
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserNb(DateParser):
     """
     Convert a text string into a Date object, expecting a date
@@ -54,66 +54,94 @@ class DateParserNb(DateParser):
 
     # modifiers before the date
     modifier_to_int = {
-        'før'    : Date.MOD_BEFORE,
-        'innen'  : Date.MOD_BEFORE,
-        'etter'   : Date.MOD_AFTER,
-        'omkring' : Date.MOD_ABOUT,
-        'omtrent' : Date.MOD_ABOUT,
-        'ca'      : Date.MOD_ABOUT
-        }
+        "før": Date.MOD_BEFORE,
+        "innen": Date.MOD_BEFORE,
+        "etter": Date.MOD_AFTER,
+        "omkring": Date.MOD_ABOUT,
+        "omtrent": Date.MOD_ABOUT,
+        "ca": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     bce = ["f Kr"]
 
     calendar_to_int = {
-        'gregoriansk   '      : Date.CAL_GREGORIAN,
-        'g'                   : Date.CAL_GREGORIAN,
-        'juliansk'            : Date.CAL_JULIAN,
-        'j'                   : Date.CAL_JULIAN,
-        'hebraisk'            : Date.CAL_HEBREW,
-        'h'                   : Date.CAL_HEBREW,
-        'islamisk'            : Date.CAL_ISLAMIC,
-        'muslimsk'            : Date.CAL_ISLAMIC,
-        'i'                   : Date.CAL_ISLAMIC,
-        'fransk'              : Date.CAL_FRENCH,
-        'fransk republikansk' : Date.CAL_FRENCH,
-        'f'                   : Date.CAL_FRENCH,
-        'persisk'             : Date.CAL_PERSIAN,
-        'p'                   : Date.CAL_PERSIAN,
-        'svensk'              : Date.CAL_SWEDISH,
-        's'                   : Date.CAL_SWEDISH,
-        }
+        "gregoriansk   ": Date.CAL_GREGORIAN,
+        "g": Date.CAL_GREGORIAN,
+        "juliansk": Date.CAL_JULIAN,
+        "j": Date.CAL_JULIAN,
+        "hebraisk": Date.CAL_HEBREW,
+        "h": Date.CAL_HEBREW,
+        "islamisk": Date.CAL_ISLAMIC,
+        "muslimsk": Date.CAL_ISLAMIC,
+        "i": Date.CAL_ISLAMIC,
+        "fransk": Date.CAL_FRENCH,
+        "fransk republikansk": Date.CAL_FRENCH,
+        "f": Date.CAL_FRENCH,
+        "persisk": Date.CAL_PERSIAN,
+        "p": Date.CAL_PERSIAN,
+        "svensk": Date.CAL_SWEDISH,
+        "s": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        'estimert' : Date.QUAL_ESTIMATED,
-        'beregnet'   : Date.QUAL_CALCULATED,
-        }
+        "estimert": Date.QUAL_ESTIMATED,
+        "beregnet": Date.QUAL_CALCULATED,
+    }
 
     def init_strings(self):
         DateParser.init_strings(self)
-        self._numeric = re.compile(
-            r"((\d+)[/\.\s]\s*)?((\d+)[/\.\-\s]\s*)?(\d+)\s*$")
+        self._numeric = re.compile(r"((\d+)[/\.\s]\s*)?((\d+)[/\.\-\s]\s*)?(\d+)\s*$")
         self._span = re.compile(
-            r"(fra)?\s*(?P<start>.+)\s*(til|--|–)\s*(?P<stop>.+)",
-            re.IGNORECASE)
+            r"(fra)?\s*(?P<start>.+)\s*(til|--|–)\s*(?P<stop>.+)", re.IGNORECASE
+        )
         self._range = re.compile(
-            r"(mellom)\s+(?P<start>.+)\s+og\s+(?P<stop>.+)", re.IGNORECASE)
+            r"(mellom)\s+(?P<start>.+)\s+og\s+(?P<stop>.+)", re.IGNORECASE
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Norwegian display class
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayNb(DateDisplay):
     """
     Norwegian language date display class.
     """
 
-    long_months = ( "", "januar", "februar", "mars", "april", "mai",
-                    "juni", "juli", "august", "september", "oktober",
-                    "november", "desember" )
+    long_months = (
+        "",
+        "januar",
+        "februar",
+        "mars",
+        "april",
+        "mai",
+        "juni",
+        "juli",
+        "august",
+        "september",
+        "oktober",
+        "november",
+        "desember",
+    )
 
-    short_months = ( "", "jan", "feb", "mar", "apr", "mai", "jun",
-                     "jul", "aug", "sep", "okt", "nov", "des" )
+    short_months = (
+        "",
+        "jan",
+        "feb",
+        "mar",
+        "apr",
+        "mai",
+        "jun",
+        "jul",
+        "aug",
+        "sep",
+        "okt",
+        "nov",
+        "des",
+    )
 
     formats = (
         "ÅÅÅÅ-MM-DD (ISO)",
@@ -122,9 +150,9 @@ class DateDisplayNb(DateDisplay):
         "Mån Dag År",
         "Dag måned år",
         "Dag Mån År",
-        )
-        # this must agree with DateDisplayEn's "formats" definition
-        # (since no locale-specific _display_gregorian exists, here)
+    )
+    # this must agree with DateDisplayEn's "formats" definition
+    # (since no locale-specific _display_gregorian exists, here)
 
     calendar = (
         "",
@@ -133,8 +161,8 @@ class DateDisplayNb(DateDisplay):
         "fransk republikansk",
         "persisk",
         "islamisk",
-        "svensk"
-        )
+        "svensk",
+    )
 
     _mod_str = ("", "før ", "etter ", "ca ", "", "", "")
 
@@ -167,23 +195,24 @@ class DateDisplayNb(DateDisplay):
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%smellom %s og %s%s" % (qual_str, d1, d2,
-                                              scal)
+            return "%smellom %s og %s%s" % (qual_str, d1, d2, scal)
         else:
             text = self.display_cal[date.get_calendar()](start)
             scal = self.format_extras(cal, newyear)
-            return "%s%s%s%s" % (qual_str, self._mod_str[mod],
-                                 text, scal)
+            return "%s%s%s%s" % (qual_str, self._mod_str[mod], text, scal)
 
     def dd_dformat01(self, date_val):
-        """ numerical -- for Norwegian dates """
+        """numerical -- for Norwegian dates"""
         return DateDisplay.dd_dformat01(self, date_val).lstrip()
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('nb_NO', 'nb', 'nn_NO', 'nn', 'norsk', 'Norwegian', ('%d. %b %Y',)),
-    DateParserNb, DateDisplayNb)
+    ("nb_NO", "nb", "nn_NO", "nn", "norsk", "Norwegian", ("%d. %b %Y",)),
+    DateParserNb,
+    DateDisplayNb,
+)

--- a/gramps/gen/datehandler/_date_nl.py
+++ b/gramps/gen/datehandler/_date_nl.py
@@ -29,28 +29,28 @@
 Dutch-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Dutch parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserNL(DateParser):
 
     month_to_int = DateParser.month_to_int
@@ -63,7 +63,7 @@ class DateParserNL(DateParser):
     month_to_int["feber"] = 2
     month_to_int["februaris"] = 2
     month_to_int["merz"] = 3
-    #make sure on all distro mrt and maa are accepted
+    # make sure on all distro mrt and maa are accepted
     month_to_int["maa"] = 3
     month_to_int["mrt"] = 3
     month_to_int["aprilis"] = 4
@@ -83,74 +83,112 @@ class DateParserNL(DateParser):
     month_to_int["xbris"] = 12
 
     modifier_to_int = {
-        'voor'       : Date.MOD_BEFORE,
-        'na'         : Date.MOD_AFTER,
-        'ca.'        : Date.MOD_ABOUT,
-        'circa'      : Date.MOD_ABOUT,
-        'om'         : Date.MOD_ABOUT,
-        'omstreeks'  : Date.MOD_ABOUT,
-        'ongeveer'   : Date.MOD_ABOUT,
-        'rond'       : Date.MOD_ABOUT,
-        'tegen'      : Date.MOD_ABOUT,
-        }
+        "voor": Date.MOD_BEFORE,
+        "na": Date.MOD_AFTER,
+        "ca.": Date.MOD_ABOUT,
+        "circa": Date.MOD_ABOUT,
+        "om": Date.MOD_ABOUT,
+        "omstreeks": Date.MOD_ABOUT,
+        "ongeveer": Date.MOD_ABOUT,
+        "rond": Date.MOD_ABOUT,
+        "tegen": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     calendar_to_int = {
-        'gregoriaans'         : Date.CAL_GREGORIAN,
-        'greg.'               : Date.CAL_GREGORIAN,
-        'juliaans'            : Date.CAL_JULIAN,
-        'jul.'                : Date.CAL_JULIAN,
-        'hebreeuws'           : Date.CAL_HEBREW,
-        'hebr.'               : Date.CAL_HEBREW,
-        'islamitisch'         : Date.CAL_ISLAMIC,
-        'isl.'                : Date.CAL_ISLAMIC,
-        'frans republiekeins' : Date.CAL_FRENCH,
-        'fran.'               : Date.CAL_FRENCH,
-        'persisch'            : Date.CAL_PERSIAN,
-        'zweeds'              : Date.CAL_SWEDISH,
-        'z'                   : Date.CAL_SWEDISH,
-        }
+        "gregoriaans": Date.CAL_GREGORIAN,
+        "greg.": Date.CAL_GREGORIAN,
+        "juliaans": Date.CAL_JULIAN,
+        "jul.": Date.CAL_JULIAN,
+        "hebreeuws": Date.CAL_HEBREW,
+        "hebr.": Date.CAL_HEBREW,
+        "islamitisch": Date.CAL_ISLAMIC,
+        "isl.": Date.CAL_ISLAMIC,
+        "frans republiekeins": Date.CAL_FRENCH,
+        "fran.": Date.CAL_FRENCH,
+        "persisch": Date.CAL_PERSIAN,
+        "zweeds": Date.CAL_SWEDISH,
+        "z": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        'geschat'   : Date.QUAL_ESTIMATED,
-        'gesch.'    : Date.QUAL_ESTIMATED,
-        'berekend'  : Date.QUAL_CALCULATED,
-        'ber.'      : Date.QUAL_CALCULATED,
-        }
+        "geschat": Date.QUAL_ESTIMATED,
+        "gesch.": Date.QUAL_ESTIMATED,
+        "berekend": Date.QUAL_CALCULATED,
+        "ber.": Date.QUAL_CALCULATED,
+    }
 
     bce = ["voor onze tijdrekening", "voor Christus", "v. Chr."] + DateParser.bce
 
     def init_strings(self):
         DateParser.init_strings(self)
         self._span = re.compile(
-            r"(van)\s+(?P<start>.+)\s+(tot)\s+(?P<stop>.+)", re.IGNORECASE)
-        self._range = re.compile(r"tussen\s+(?P<start>.+)\s+en\s+(?P<stop>.+)",
-                                 re.IGNORECASE)
-        self._text2 = re.compile(r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?'
-                                 % self._mon_str, re.IGNORECASE)
-        self._jtext2 = re.compile(r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?'
-                                  % self._jmon_str, re.IGNORECASE)
+            r"(van)\s+(?P<start>.+)\s+(tot)\s+(?P<stop>.+)", re.IGNORECASE
+        )
+        self._range = re.compile(
+            r"tussen\s+(?P<start>.+)\s+en\s+(?P<stop>.+)", re.IGNORECASE
+        )
+        self._text2 = re.compile(
+            r"(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?" % self._mon_str, re.IGNORECASE
+        )
+        self._jtext2 = re.compile(
+            r"(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?" % self._jmon_str, re.IGNORECASE
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Dutch display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayNL(DateDisplay):
     """
     Dutch language date display class.
     """
-    # TODO: Translate these month strings:
-    long_months = ( "", "januari", "februari", "maart", "april", "mei",
-                    "juni", "juli", "augustus", "september", "oktober",
-                    "november", "december" )
 
-    short_months = ( "", "jan", "feb", "mrt", "apr", "mei", "jun",
-                     "jul", "aug", "sep", "okt", "nov", "dec" )
+    # TODO: Translate these month strings:
+    long_months = (
+        "",
+        "januari",
+        "februari",
+        "maart",
+        "april",
+        "mei",
+        "juni",
+        "juli",
+        "augustus",
+        "september",
+        "oktober",
+        "november",
+        "december",
+    )
+
+    short_months = (
+        "",
+        "jan",
+        "feb",
+        "mrt",
+        "apr",
+        "mei",
+        "jun",
+        "jul",
+        "aug",
+        "sep",
+        "okt",
+        "nov",
+        "dec",
+    )
 
     calendar = (
-        "", "juliaans", "hebreeuws",
-        "frans republikeins", "persisch", "islamitisch",
-        "zweeds" )
+        "",
+        "juliaans",
+        "hebreeuws",
+        "frans republikeins",
+        "persisch",
+        "islamitisch",
+        "zweeds",
+    )
 
     _mod_str = ("", "voor ", "na ", "omstreeks ", "", "", "")
 
@@ -159,10 +197,14 @@ class DateDisplayNL(DateDisplay):
     _bce_str = "%s v. Chr."
 
     formats = (
-        "JJJJ-MM-DD (ISO)", "Numeriek DD/MM/JJJJ", "Maand Dag, Jaar",
-        "Mnd. Dag Jaar", "Dag Maand Jaar", "Dag Mnd. Jaar"
-        )
-        # this definition must agree with its "_display_gregorian" method
+        "JJJJ-MM-DD (ISO)",
+        "Numeriek DD/MM/JJJJ",
+        "Maand Dag, Jaar",
+        "Mnd. Dag Jaar",
+        "Dag Maand Jaar",
+        "Dag Mnd. Jaar",
+    )
+    # this definition must agree with its "_display_gregorian" method
 
     def _display_gregorian(self, date_val, **kwargs):
         """
@@ -180,10 +222,10 @@ class DateDisplayNL(DateDisplay):
                 if date_val[0] == date_val[1] == 0:
                     value = str(date_val[2])
                 else:
-                    value = self.dhformat.replace('%m', str(date_val[1]))
-                    value = value.replace('%d', str(date_val[0]))
-                    value = value.replace('%Y', str(abs(date_val[2])))
-                    value = value.replace('-', '/')
+                    value = self.dhformat.replace("%m", str(date_val[1]))
+                    value = value.replace("%d", str(date_val[0]))
+                    value = value.replace("%Y", str(abs(date_val[2])))
+                    value = value.replace("-", "/")
         elif self.format == 2:
             # month_name day, year
             if date_val[0] == 0:
@@ -192,8 +234,7 @@ class DateDisplayNL(DateDisplay):
                 else:
                     value = "%s %s" % (self.long_months[date_val[1]], year)
             else:
-                value = "%s %d, %s" % (self.long_months[date_val[1]],
-                                       date_val[0], year)
+                value = "%s %d, %s" % (self.long_months[date_val[1]], date_val[0], year)
         elif self.format == 3:
             # month_abbreviation day, year
             if date_val[0] == 0:
@@ -202,8 +243,11 @@ class DateDisplayNL(DateDisplay):
                 else:
                     value = "%s %s" % (self.short_months[date_val[1]], year)
             else:
-                value = "%s %d, %s" % (self.short_months[date_val[1]],
-                                       date_val[0], year)
+                value = "%s %d, %s" % (
+                    self.short_months[date_val[1]],
+                    date_val[0],
+                    year,
+                )
         elif self.format == 4:
             # day month_name year
             if date_val[0] == 0:
@@ -212,8 +256,7 @@ class DateDisplayNL(DateDisplay):
                 else:
                     value = "%s %s" % (self.long_months[date_val[1]], year)
             else:
-                value = "%d %s %s" % (date_val[0],
-                                      self.long_months[date_val[1]], year)
+                value = "%d %s %s" % (date_val[0], self.long_months[date_val[1]], year)
         else:
             # day month_abbreviation year
             if date_val[0] == 0:
@@ -222,8 +265,7 @@ class DateDisplayNL(DateDisplay):
                 else:
                     value = "%s %s" % (self.short_months[date_val[1]], year)
             else:
-                value = "%d %s %s" % (date_val[0],
-                                      self.short_months[date_val[1]], year)
+                value = "%d %s %s" % (date_val[0], self.short_months[date_val[1]], year)
         if date_val[2] < 0:
             return self._bce_str % value
         else:
@@ -249,25 +291,25 @@ class DateDisplayNL(DateDisplay):
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'van', d1,
-                                        'tot', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "van", d1, "tot", d2, scal)
         elif mod == Date.MOD_RANGE:
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%stussen %s en %s%s" % (qual_str, d1, d2,
-                                            scal)
+            return "%stussen %s en %s%s" % (qual_str, d1, d2, scal)
         else:
             text = self.display_cal[date.get_calendar()](start)
             scal = self.format_extras(cal, newyear)
-            return "%s%s%s%s" % (qual_str, self._mod_str[mod], text,
-                                 scal)
+            return "%s%s%s%s" % (qual_str, self._mod_str[mod], text, scal)
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('nl_NL', 'dutch', 'Dutch', 'nl_BE', 'nl', ('%d-%m-%Y',)),
-    DateParserNL, DateDisplayNL)
+    ("nl_NL", "dutch", "Dutch", "nl_BE", "nl", ("%d-%m-%Y",)),
+    DateParserNL,
+    DateDisplayNL,
+)

--- a/gramps/gen/datehandler/_date_pl.py
+++ b/gramps/gen/datehandler/_date_pl.py
@@ -26,28 +26,28 @@
 Polish-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Polish parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserPL(DateParser):
 
     month_to_int = DateParser.month_to_int
@@ -112,83 +112,117 @@ class DateParserPL(DateParser):
     month_to_int["paz"] = 10
 
     modifier_to_int = {
-        'przed'    : Date.MOD_BEFORE,
-        'po'   : Date.MOD_AFTER,
-        'około'  : Date.MOD_ABOUT,
-        'ok.'     : Date.MOD_ABOUT,
-        'circa'  : Date.MOD_ABOUT,
-        'ca.'  : Date.MOD_ABOUT,
+        "przed": Date.MOD_BEFORE,
+        "po": Date.MOD_AFTER,
+        "około": Date.MOD_ABOUT,
+        "ok.": Date.MOD_ABOUT,
+        "circa": Date.MOD_ABOUT,
+        "ca.": Date.MOD_ABOUT,
         # Alternative forms: misspellings sometimes used in emails
-        'okolo'  : Date.MOD_ABOUT,
-        'ok'     : Date.MOD_ABOUT,
-        }
+        "okolo": Date.MOD_ABOUT,
+        "ok": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     calendar_to_int = {
-        'gregoriański'   : Date.CAL_GREGORIAN,
-        'greg.'          : Date.CAL_GREGORIAN,
-        'juliański'      : Date.CAL_JULIAN,
-        'jul.'           : Date.CAL_JULIAN,
-        'hebrajski'      : Date.CAL_HEBREW,
-        'hebr.'          : Date.CAL_HEBREW,
-        'islamski'       : Date.CAL_ISLAMIC,
-        'isl.'           : Date.CAL_ISLAMIC,
-        'francuski republikański': Date.CAL_FRENCH,
-        'franc.'         : Date.CAL_FRENCH,
-        'perski'         : Date.CAL_PERSIAN,
-        'szwedzki'       : Date.CAL_SWEDISH,
-        's'              : Date.CAL_SWEDISH,
-    # Alternative forms: nouns without polish accent letters
-    # (misspellings sometimes used in emails)
-        'gregorianski'   : Date.CAL_GREGORIAN,
-        'julianski'      : Date.CAL_JULIAN,
-        'francuski republikanski': Date.CAL_FRENCH,
-        }
+        "gregoriański": Date.CAL_GREGORIAN,
+        "greg.": Date.CAL_GREGORIAN,
+        "juliański": Date.CAL_JULIAN,
+        "jul.": Date.CAL_JULIAN,
+        "hebrajski": Date.CAL_HEBREW,
+        "hebr.": Date.CAL_HEBREW,
+        "islamski": Date.CAL_ISLAMIC,
+        "isl.": Date.CAL_ISLAMIC,
+        "francuski republikański": Date.CAL_FRENCH,
+        "franc.": Date.CAL_FRENCH,
+        "perski": Date.CAL_PERSIAN,
+        "szwedzki": Date.CAL_SWEDISH,
+        "s": Date.CAL_SWEDISH,
+        # Alternative forms: nouns without polish accent letters
+        # (misspellings sometimes used in emails)
+        "gregorianski": Date.CAL_GREGORIAN,
+        "julianski": Date.CAL_JULIAN,
+        "francuski republikanski": Date.CAL_FRENCH,
+    }
 
     quality_to_int = {
-        'szacowany'  : Date.QUAL_ESTIMATED,
-        'szac.'      : Date.QUAL_ESTIMATED,
-        'obliczony'  : Date.QUAL_CALCULATED,
-        'obl.'       : Date.QUAL_CALCULATED,
-        }
+        "szacowany": Date.QUAL_ESTIMATED,
+        "szac.": Date.QUAL_ESTIMATED,
+        "obliczony": Date.QUAL_CALCULATED,
+        "obl.": Date.QUAL_CALCULATED,
+    }
 
-    bce = ["przed naszą erą", "przed Chrystusem",
-           "p.n.e."] + DateParser.bce
+    bce = ["przed naszą erą", "przed Chrystusem", "p.n.e."] + DateParser.bce
 
     def init_strings(self):
         DateParser.init_strings(self)
         self._span = re.compile(
-            r"(od)\s+(?P<start>.+)\s+(do)\s+(?P<stop>.+)", re.IGNORECASE)
+            r"(od)\s+(?P<start>.+)\s+(do)\s+(?P<stop>.+)", re.IGNORECASE
+        )
         # Also handle a common mistakes
         self._range = re.compile(
-            r"((?:po)?mi(?:ę|e)dzy)\s+(?P<start>.+)\s+(a)\s+(?P<stop>.+)",
-            re.IGNORECASE)
-        self._text2 = re.compile(r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?'
-                                 % self._mon_str, re.IGNORECASE)
-        self._jtext2 = re.compile(r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?'
-                                  % self._jmon_str, re.IGNORECASE)
+            r"((?:po)?mi(?:ę|e)dzy)\s+(?P<start>.+)\s+(a)\s+(?P<stop>.+)", re.IGNORECASE
+        )
+        self._text2 = re.compile(
+            r"(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?" % self._mon_str, re.IGNORECASE
+        )
+        self._jtext2 = re.compile(
+            r"(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?" % self._jmon_str, re.IGNORECASE
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Polish display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayPL(DateDisplay):
     """
     Polish language date display class.
     """
 
-    long_months = ( "", "Styczeń", "Luty", "Marzec", "Kwiecień", "Maj",
-                    "Czerwiec", "Lipiec", "Sierpień", "Wrzesień", "Październik",
-                    "Listopad", "Grudzień" )
+    long_months = (
+        "",
+        "Styczeń",
+        "Luty",
+        "Marzec",
+        "Kwiecień",
+        "Maj",
+        "Czerwiec",
+        "Lipiec",
+        "Sierpień",
+        "Wrzesień",
+        "Październik",
+        "Listopad",
+        "Grudzień",
+    )
 
-    short_months = ( "", "Sty", "Lut", "Mar", "Kwi", "Maj", "Cze",
-                     "Lip", "Sie", "Wrz", "Paź", "Lis", "Gru" )
+    short_months = (
+        "",
+        "Sty",
+        "Lut",
+        "Mar",
+        "Kwi",
+        "Maj",
+        "Cze",
+        "Lip",
+        "Sie",
+        "Wrz",
+        "Paź",
+        "Lis",
+        "Gru",
+    )
 
     calendar = (
-        "", "juliański", "hebrajski",
-        "francuski republikański", "perski", "islamski",
-        "swedish"
-        )
+        "",
+        "juliański",
+        "hebrajski",
+        "francuski republikański",
+        "perski",
+        "islamski",
+        "swedish",
+    )
 
     _mod_str = ("", "przed ", "po ", "ok. ", "", "", "")
 
@@ -197,10 +231,14 @@ class DateDisplayPL(DateDisplay):
     _bce_str = "%s p.n.e."
 
     formats = (
-        "RRRR-MM-DD (ISO)", "Numeryczny", "Miesiąc Dzień, Rok",
-        "Miesiąc.Dzień.Rok", "Dzień Miesiąc Rok", "Dzień MieRzym Rok"
-        )
-        # this definition must agree with its "_display_gregorian" method
+        "RRRR-MM-DD (ISO)",
+        "Numeryczny",
+        "Miesiąc Dzień, Rok",
+        "Miesiąc.Dzień.Rok",
+        "Dzień Miesiąc Rok",
+        "Dzień MieRzym Rok",
+    )
+    # this definition must agree with its "_display_gregorian" method
 
     roman_months = (
         "",
@@ -215,8 +253,8 @@ class DateDisplayPL(DateDisplay):
         "IX",
         "X",
         "XI",
-        "XII"
-        )
+        "XII",
+    )
 
     def _display_gregorian(self, date_val, **kwargs):
         """
@@ -234,9 +272,9 @@ class DateDisplayPL(DateDisplay):
                 if date_val[0] == date_val[1] == 0:
                     value = str(date_val[2])
                 else:
-                    value = self.dhformat.replace('%d', str(date_val[0]))
-                    value = value.replace('%m', str(date_val[1]))
-                    value = value.replace('%Y', str(date_val[2]))
+                    value = self.dhformat.replace("%d", str(date_val[0]))
+                    value = value.replace("%m", str(date_val[1]))
+                    value = value.replace("%Y", str(date_val[2]))
         elif self.format == 2:
             # month_name day, year
             if date_val[0] == 0:
@@ -245,8 +283,7 @@ class DateDisplayPL(DateDisplay):
                 else:
                     value = "%s %s" % (self.long_months[date_val[1]], year)
             else:
-                value = "%s %d, %s" % (self.long_months[date_val[1]],
-                                       date_val[0], year)
+                value = "%s %d, %s" % (self.long_months[date_val[1]], date_val[0], year)
         elif self.format == 3:
             # month_number. day. year
             if date_val[0] == 0:
@@ -264,8 +301,7 @@ class DateDisplayPL(DateDisplay):
                 else:
                     value = "%s %s" % (self.long_months[date_val[1]], year)
             else:
-                value = "%d %s %s" % (date_val[0],
-                                      self.long_months[date_val[1]], year)
+                value = "%d %s %s" % (date_val[0], self.long_months[date_val[1]], year)
         else:
             # day Roman_number_month year
             if date_val[0] == 0:
@@ -274,8 +310,7 @@ class DateDisplayPL(DateDisplay):
                 else:
                     value = "%s %s" % (self.roman_months[date_val[1]], year)
             else:
-                value = "%d %s %s" % (date_val[0],
-                                      self.roman_months[date_val[1]], year)
+                value = "%d %s %s" % (date_val[0], self.roman_months[date_val[1]], year)
         if date_val[2] < 0:
             return self._bce_str % value
         else:
@@ -301,25 +336,25 @@ class DateDisplayPL(DateDisplay):
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'od', d1, 'do', d2,
-                                        scal)
+            return "%s%s %s %s %s%s" % (qual_str, "od", d1, "do", d2, scal)
         elif mod == Date.MOD_RANGE:
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'między', d1, 'a', d2,
-                                        scal)
+            return "%s%s %s %s %s%s" % (qual_str, "między", d1, "a", d2, scal)
         else:
             text = self.display_cal[date.get_calendar()](start)
             scal = self.format_extras(cal, newyear)
-            return "%s%s%s%s" % (qual_str, self._mod_str[mod], text,
-                                 scal)
+            return "%s%s%s%s" % (qual_str, self._mod_str[mod], text, scal)
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('pl_PL', 'polish', 'Polish_Poland', 'pl', ('%d.%m.%Y',)),
-    DateParserPL, DateDisplayPL)
+    ("pl_PL", "polish", "Polish_Poland", "pl", ("%d.%m.%Y",)),
+    DateParserPL,
+    DateDisplayPL,
+)

--- a/gramps/gen/datehandler/_date_pt.py
+++ b/gramps/gen/datehandler/_date_pt.py
@@ -25,128 +25,161 @@
 Portuguese-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Portuguese parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserPT(DateParser):
 
     modifier_to_int = {
-        'antes de'     : Date.MOD_BEFORE,
-        'antes'        : Date.MOD_BEFORE,
-        'ant.'         : Date.MOD_BEFORE,
-        'ant'          : Date.MOD_BEFORE,
-        'até'          : Date.MOD_BEFORE,
-        'depois de'    : Date.MOD_AFTER,
-        'depois'       : Date.MOD_AFTER,
-        'dep.'         : Date.MOD_AFTER,
-        'dep'          : Date.MOD_AFTER,
-        'aprox.'       : Date.MOD_ABOUT,
-        'aprox'        : Date.MOD_ABOUT,
-        'apr.'         : Date.MOD_ABOUT,
-        'apr'          : Date.MOD_ABOUT,
-        'cerca de'     : Date.MOD_ABOUT,
-        'ca.'          : Date.MOD_ABOUT,
-        'ca'           : Date.MOD_ABOUT,
-        'c.'           : Date.MOD_ABOUT,
-        'por volta de' : Date.MOD_ABOUT,
-        'por volta'    : Date.MOD_ABOUT,
-        'pvd.'         : Date.MOD_ABOUT,
-        }
+        "antes de": Date.MOD_BEFORE,
+        "antes": Date.MOD_BEFORE,
+        "ant.": Date.MOD_BEFORE,
+        "ant": Date.MOD_BEFORE,
+        "até": Date.MOD_BEFORE,
+        "depois de": Date.MOD_AFTER,
+        "depois": Date.MOD_AFTER,
+        "dep.": Date.MOD_AFTER,
+        "dep": Date.MOD_AFTER,
+        "aprox.": Date.MOD_ABOUT,
+        "aprox": Date.MOD_ABOUT,
+        "apr.": Date.MOD_ABOUT,
+        "apr": Date.MOD_ABOUT,
+        "cerca de": Date.MOD_ABOUT,
+        "ca.": Date.MOD_ABOUT,
+        "ca": Date.MOD_ABOUT,
+        "c.": Date.MOD_ABOUT,
+        "por volta de": Date.MOD_ABOUT,
+        "por volta": Date.MOD_ABOUT,
+        "pvd.": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     calendar_to_int = {
-        'gregoriano'            : Date.CAL_GREGORIAN,
-        'g'                     : Date.CAL_GREGORIAN,
-        'juliano'               : Date.CAL_JULIAN,
-        'j'                     : Date.CAL_JULIAN,
-        'hebreu'                : Date.CAL_HEBREW,
-        'h'                     : Date.CAL_HEBREW,
-        'islâmico'              : Date.CAL_ISLAMIC,
-        'i'                     : Date.CAL_ISLAMIC,
-        'revolucionário'        : Date.CAL_FRENCH,
-        'r'                     : Date.CAL_FRENCH,
-        'persa'                 : Date.CAL_PERSIAN,
-        'p'                     : Date.CAL_PERSIAN,
-        'swedish'               : Date.CAL_SWEDISH,
-        's'                     : Date.CAL_SWEDISH,
-        }
+        "gregoriano": Date.CAL_GREGORIAN,
+        "g": Date.CAL_GREGORIAN,
+        "juliano": Date.CAL_JULIAN,
+        "j": Date.CAL_JULIAN,
+        "hebreu": Date.CAL_HEBREW,
+        "h": Date.CAL_HEBREW,
+        "islâmico": Date.CAL_ISLAMIC,
+        "i": Date.CAL_ISLAMIC,
+        "revolucionário": Date.CAL_FRENCH,
+        "r": Date.CAL_FRENCH,
+        "persa": Date.CAL_PERSIAN,
+        "p": Date.CAL_PERSIAN,
+        "swedish": Date.CAL_SWEDISH,
+        "s": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        'estimado'   : Date.QUAL_ESTIMATED,
-        'estimada'   : Date.QUAL_ESTIMATED,
-        'est.'       : Date.QUAL_ESTIMATED,
-        'est'        : Date.QUAL_ESTIMATED,
-        'calc.'      : Date.QUAL_CALCULATED,
-        'calc'       : Date.QUAL_CALCULATED,
-        'calculado'  : Date.QUAL_CALCULATED,
-        'calculada'  : Date.QUAL_CALCULATED,
-        }
+        "estimado": Date.QUAL_ESTIMATED,
+        "estimada": Date.QUAL_ESTIMATED,
+        "est.": Date.QUAL_ESTIMATED,
+        "est": Date.QUAL_ESTIMATED,
+        "calc.": Date.QUAL_CALCULATED,
+        "calc": Date.QUAL_CALCULATED,
+        "calculado": Date.QUAL_CALCULATED,
+        "calculada": Date.QUAL_CALCULATED,
+    }
 
     def init_strings(self):
         DateParser.init_strings(self)
-        _span_1 = ['de']
-        _span_2 = ['a']
-        _range_1 = ['entre', r'ent\.', 'ent']
-        _range_2 = ['e']
-        self._span = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
-                                % ('|'.join(_span_1), '|'.join(_span_2)),
-                                re.IGNORECASE)
-        self._range = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
-                                 % ('|'.join(_range_1), '|'.join(_range_2)),
-                                 re.IGNORECASE)
+        _span_1 = ["de"]
+        _span_2 = ["a"]
+        _range_1 = ["entre", r"ent\.", "ent"]
+        _range_2 = ["e"]
+        self._span = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_span_1), "|".join(_span_2)),
+            re.IGNORECASE,
+        )
+        self._range = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_range_1), "|".join(_range_2)),
+            re.IGNORECASE,
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Portuguese display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayPT(DateDisplay):
     """
     Portuguese language date display class.
     """
-    long_months = ( "", "Janeiro", "Fevereiro", "Março", "Abril", "Maio",
-                    "Junho", "Julho", "Agosto", "Setembro", "Outubro",
-                    "Novembro", "Dezembro" )
 
-    short_months = ( "", "Jan", "Fev", "Mar", "Abr", "Mai", "Jun",
-                     "Jul", "Ago", "Set", "Out", "Nov", "Dez" )
+    long_months = (
+        "",
+        "Janeiro",
+        "Fevereiro",
+        "Março",
+        "Abril",
+        "Maio",
+        "Junho",
+        "Julho",
+        "Agosto",
+        "Setembro",
+        "Outubro",
+        "Novembro",
+        "Dezembro",
+    )
 
-    calendar = (
-        "", "Juliano", "Hebreu",
-        "Revolucionário", "Persa", "Islâmico",
-        "Sueco"
-        )
+    short_months = (
+        "",
+        "Jan",
+        "Fev",
+        "Mar",
+        "Abr",
+        "Mai",
+        "Jun",
+        "Jul",
+        "Ago",
+        "Set",
+        "Out",
+        "Nov",
+        "Dez",
+    )
 
-    _mod_str = ("","antes de ","depois de ","por volta de ","","","")
+    calendar = ("", "Juliano", "Hebreu", "Revolucionário", "Persa", "Islâmico", "Sueco")
 
-    _qual_str = ("","estimado ","calculado ")
+    _mod_str = ("", "antes de ", "depois de ", "por volta de ", "", "", "")
+
+    _qual_str = ("", "estimado ", "calculado ")
 
     formats = (
-        "AAAA-MM-DD (ISO)", "Numérica", "Mês Dia, Ano",
-        "MÊS Dia, Ano", "Dia Mês, Ano", "Dia MÊS, Ano"
-        )
-        # this must agree with DateDisplayEn's "formats" definition
-        # (since no locale-specific _display_gregorian exists, here)
+        "AAAA-MM-DD (ISO)",
+        "Numérica",
+        "Mês Dia, Ano",
+        "MÊS Dia, Ano",
+        "Dia Mês, Ano",
+        "Dia MÊS, Ano",
+    )
+    # this must agree with DateDisplayEn's "formats" definition
+    # (since no locale-specific _display_gregorian exists, here)
 
-    def display(self,date):
+    def display(self, date):
         """
         Return a text string representing the date.
         """
@@ -166,23 +199,33 @@ class DateDisplayPT(DateDisplay):
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'de', d1, 'a', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "de", d1, "a", d2, scal)
         elif mod == Date.MOD_RANGE:
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'entre', d1, 'e', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "entre", d1, "e", d2, scal)
         else:
             text = self.display_cal[date.get_calendar()](start)
             scal = self.format_extras(cal, newyear)
             return "%s%s%s%s" % (qual_str, self._mod_str[mod], text, scal)
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('pt_PT', 'pt_PT.UTF-8', 'pt_BR', 'pt_BR.UTF-8',
-     'pt' 'portuguese', 'Portuguese', ('%d-%m-%Y',)),
-    DateParserPT, DateDisplayPT)
+    (
+        "pt_PT",
+        "pt_PT.UTF-8",
+        "pt_BR",
+        "pt_BR.UTF-8",
+        "pt" "portuguese",
+        "Portuguese",
+        ("%d-%m-%Y",),
+    ),
+    DateParserPT,
+    DateDisplayPT,
+)

--- a/gramps/gen/datehandler/_date_ru.py
+++ b/gramps/gen/datehandler/_date_ru.py
@@ -23,91 +23,97 @@
 Russian-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Russian parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserRU(DateParser):
     modifier_to_int = {
-        'перед'    : Date.MOD_BEFORE,
-        'по'    : Date.MOD_BEFORE,
-        'до'    : Date.MOD_BEFORE,
-        'после' : Date.MOD_AFTER,
-        'п.'    : Date.MOD_AFTER,
-        'п'    : Date.MOD_AFTER,
-        'с'     : Date.MOD_AFTER,
-        'ок' : Date.MOD_ABOUT,
-        'ок.'   : Date.MOD_ABOUT,
-        'около'    : Date.MOD_ABOUT,
-        'примерно'  : Date.MOD_ABOUT,
-        'прим'     : Date.MOD_ABOUT,
-        'прим.'     : Date.MOD_ABOUT,
-        'приблизительно'  : Date.MOD_ABOUT,
-        'приб.'  : Date.MOD_ABOUT,
-        'прибл.'  : Date.MOD_ABOUT,
-        'приб'  : Date.MOD_ABOUT,
-        'прибл'  : Date.MOD_ABOUT,
-        }
-
+        "перед": Date.MOD_BEFORE,
+        "по": Date.MOD_BEFORE,
+        "до": Date.MOD_BEFORE,
+        "после": Date.MOD_AFTER,
+        "п.": Date.MOD_AFTER,
+        "п": Date.MOD_AFTER,
+        "с": Date.MOD_AFTER,
+        "ок": Date.MOD_ABOUT,
+        "ок.": Date.MOD_ABOUT,
+        "около": Date.MOD_ABOUT,
+        "примерно": Date.MOD_ABOUT,
+        "прим": Date.MOD_ABOUT,
+        "прим.": Date.MOD_ABOUT,
+        "приблизительно": Date.MOD_ABOUT,
+        "приб.": Date.MOD_ABOUT,
+        "прибл.": Date.MOD_ABOUT,
+        "приб": Date.MOD_ABOUT,
+        "прибл": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     quality_to_int = {
-        'оценено'  : Date.QUAL_ESTIMATED,
-        'оцен.'       : Date.QUAL_ESTIMATED,
-        'оц.'        : Date.QUAL_ESTIMATED,
-        'оцен'       : Date.QUAL_ESTIMATED,
-        'оц'        : Date.QUAL_ESTIMATED,
-        'вычислено'      : Date.QUAL_CALCULATED,
-        'вычисл.'       : Date.QUAL_CALCULATED,
-        'выч.' : Date.QUAL_CALCULATED,
-        'вычисл'       : Date.QUAL_CALCULATED,
-        'выч' : Date.QUAL_CALCULATED,
-        }
+        "оценено": Date.QUAL_ESTIMATED,
+        "оцен.": Date.QUAL_ESTIMATED,
+        "оц.": Date.QUAL_ESTIMATED,
+        "оцен": Date.QUAL_ESTIMATED,
+        "оц": Date.QUAL_ESTIMATED,
+        "вычислено": Date.QUAL_CALCULATED,
+        "вычисл.": Date.QUAL_CALCULATED,
+        "выч.": Date.QUAL_CALCULATED,
+        "вычисл": Date.QUAL_CALCULATED,
+        "выч": Date.QUAL_CALCULATED,
+    }
 
-    bce = [
-        'до нашей эры', 'до н. э.', 'до н.э.',
-        'до н э', 'до нэ'] + DateParser.bce
+    bce = ["до нашей эры", "до н. э.", "до н.э.", "до н э", "до нэ"] + DateParser.bce
 
     def init_strings(self):
         DateParser.init_strings(self)
-        DateParser.calendar_to_int.update({
-            'персидский'    : Date.CAL_PERSIAN,
-            'п'             : Date.CAL_PERSIAN,
-        })
-        _span_1 = ['с', 'от']
-        #_span_2 = ['по', 'до'] # <-- clashes with bce parsing :-(
-        _span_2 = ['по']
-        _range_1 = ['между', r'меж\.', 'меж']
-        _range_2 = ['и']
-        self._span = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
-                                % ('|'.join(_span_1), '|'.join(_span_2)),
-                                re.IGNORECASE)
-        self._range = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
-                                 % ('|'.join(_range_1), '|'.join(_range_2)),
-                                 re.IGNORECASE)
+        DateParser.calendar_to_int.update(
+            {
+                "персидский": Date.CAL_PERSIAN,
+                "п": Date.CAL_PERSIAN,
+            }
+        )
+        _span_1 = ["с", "от"]
+        # _span_2 = ['по', 'до'] # <-- clashes with bce parsing :-(
+        _span_2 = ["по"]
+        _range_1 = ["между", r"меж\.", "меж"]
+        _range_2 = ["и"]
+        self._span = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_span_1), "|".join(_span_2)),
+            re.IGNORECASE,
+        )
+        self._range = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_range_1), "|".join(_range_2)),
+            re.IGNORECASE,
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Russian displayer
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayRU(DateDisplay):
     """
     Russian language date display class.
@@ -128,20 +134,19 @@ class DateDisplayRU(DateDisplay):
             if date_val[1] == 0:
                 return year
             else:
-                return self.format_long_month_year(date_val[1], year,
-                                                   inflect, long_months)
-        elif date_val[1] == 0: # month is zero but day is not (see 8477)
+                return self.format_long_month_year(
+                    date_val[1], year, inflect, long_months
+                )
+        elif date_val[1] == 0:  # month is zero but day is not (see 8477)
             return self.display_iso(date_val)
-        elif not hasattr(long_months[date_val[1]], 'f'): # not a Lexeme
+        elif not hasattr(long_months[date_val[1]], "f"):  # not a Lexeme
             return "{day:d} {long_month} {year}".format(
-                     day = date_val[0],
-                     long_month = long_months[date_val[1]],
-                     year = year)
+                day=date_val[0], long_month=long_months[date_val[1]], year=year
+            )
         else:
             return "{day:d} {long_month.f[Р]} {year}".format(
-                     day = date_val[0],
-                     long_month = long_months[date_val[1]],
-                     year = year)
+                day=date_val[0], long_month=long_months[date_val[1]], year=year
+            )
 
     def dd_dformat05(self, date_val, inflect, short_months):
         """
@@ -152,26 +157,26 @@ class DateDisplayRU(DateDisplay):
             if date_val[1] == 0:
                 return year
             else:
-                return self.format_short_month_year(date_val[1], year,
-                                                    inflect, short_months)
-        elif date_val[1] == 0: # month is zero but day is not (see 8477)
+                return self.format_short_month_year(
+                    date_val[1], year, inflect, short_months
+                )
+        elif date_val[1] == 0:  # month is zero but day is not (see 8477)
             return self.display_iso(date_val)
-        elif not hasattr(short_months[date_val[1]], 'f'): # not a Lexeme
+        elif not hasattr(short_months[date_val[1]], "f"):  # not a Lexeme
             return "{day:d} {short_month} {year}".format(
-                     day = date_val[0],
-                     short_month = short_months[date_val[1]],
-                     year = year)
+                day=date_val[0], short_month=short_months[date_val[1]], year=year
+            )
         else:
             return "{day:d} {short_month.f[Р]} {year}".format(
-                     day = date_val[0],
-                     short_month = short_months[date_val[1]],
-                     year = year)
+                day=date_val[0], short_month=short_months[date_val[1]], year=year
+            )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('ru_RU', 'ru', 'russian', 'Russian', ('%d.%m.%Y',)),
-    DateParserRU, DateDisplayRU)
+    ("ru_RU", "ru", "russian", "Russian", ("%d.%m.%Y",)), DateParserRU, DateDisplayRU
+)

--- a/gramps/gen/datehandler/_date_sk.py
+++ b/gramps/gen/datehandler/_date_sk.py
@@ -23,108 +23,149 @@
 Slovak-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Slovak parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserSK(DateParser):
 
     modifier_to_int = {
-        'pred'   : Date.MOD_BEFORE,
-        'do'     : Date.MOD_BEFORE,
-        'po'     : Date.MOD_AFTER,
-        'asi'    : Date.MOD_ABOUT,
-        'okolo'  : Date.MOD_ABOUT,
-        'pribl.' : Date.MOD_ABOUT,
-        }
+        "pred": Date.MOD_BEFORE,
+        "do": Date.MOD_BEFORE,
+        "po": Date.MOD_AFTER,
+        "asi": Date.MOD_ABOUT,
+        "okolo": Date.MOD_ABOUT,
+        "pribl.": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     calendar_to_int = {
-        'gregoriánsky'  : Date.CAL_GREGORIAN,
-        'g'             : Date.CAL_GREGORIAN,
-        'juliánsky'     : Date.CAL_JULIAN,
-        'j'             : Date.CAL_JULIAN,
-        'hebrejský'     : Date.CAL_HEBREW,
-        'h'             : Date.CAL_HEBREW,
-        'islamský'      : Date.CAL_ISLAMIC,
-        'i'             : Date.CAL_ISLAMIC,
-        'republikánsky' : Date.CAL_FRENCH,
-        'r'             : Date.CAL_FRENCH,
-        'perzský'       : Date.CAL_PERSIAN,
-        'p'             : Date.CAL_PERSIAN,
-        'švédsky'      : Date.CAL_SWEDISH,
-        's'            : Date.CAL_SWEDISH,
-        }
+        "gregoriánsky": Date.CAL_GREGORIAN,
+        "g": Date.CAL_GREGORIAN,
+        "juliánsky": Date.CAL_JULIAN,
+        "j": Date.CAL_JULIAN,
+        "hebrejský": Date.CAL_HEBREW,
+        "h": Date.CAL_HEBREW,
+        "islamský": Date.CAL_ISLAMIC,
+        "i": Date.CAL_ISLAMIC,
+        "republikánsky": Date.CAL_FRENCH,
+        "r": Date.CAL_FRENCH,
+        "perzský": Date.CAL_PERSIAN,
+        "p": Date.CAL_PERSIAN,
+        "švédsky": Date.CAL_SWEDISH,
+        "s": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        'odhadovaný' : Date.QUAL_ESTIMATED,
-        'odh.'       : Date.QUAL_ESTIMATED,
-        'vypočítaný' : Date.QUAL_CALCULATED,
-        'vyp.'       : Date.QUAL_CALCULATED,
-        }
+        "odhadovaný": Date.QUAL_ESTIMATED,
+        "odh.": Date.QUAL_ESTIMATED,
+        "vypočítaný": Date.QUAL_CALCULATED,
+        "vyp.": Date.QUAL_CALCULATED,
+    }
 
     def init_strings(self):
         DateParser.init_strings(self)
-        _span_1 = ['od']
-        _span_2 = ['do']
-        _range_1 = ['medzi']
-        _range_2 = ['a']
-        self._span = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
-                                % ('|'.join(_span_1), '|'.join(_span_2)),
-                                re.IGNORECASE)
-        self._range = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
-                                 % ('|'.join(_range_1), '|'.join(_range_2)),
-                                 re.IGNORECASE)
+        _span_1 = ["od"]
+        _span_2 = ["do"]
+        _range_1 = ["medzi"]
+        _range_2 = ["a"]
+        self._span = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_span_1), "|".join(_span_2)),
+            re.IGNORECASE,
+        )
+        self._range = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_range_1), "|".join(_range_2)),
+            re.IGNORECASE,
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Slovak display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplaySK(DateDisplay):
     """
     Slovak language date display class.
     """
-    long_months = ( "", "január", "február", "marec", "apríl", "máj",
-                    "jún", "júl", "august", "september", "október",
-                    "november", "december" )
 
-    short_months = ( "", "jan", "feb", "mar", "apr", "máj", "jún",
-                     "júl", "aug", "sep", "okt", "nov", "dec" )
+    long_months = (
+        "",
+        "január",
+        "február",
+        "marec",
+        "apríl",
+        "máj",
+        "jún",
+        "júl",
+        "august",
+        "september",
+        "október",
+        "november",
+        "december",
+    )
+
+    short_months = (
+        "",
+        "jan",
+        "feb",
+        "mar",
+        "apr",
+        "máj",
+        "jún",
+        "júl",
+        "aug",
+        "sep",
+        "okt",
+        "nov",
+        "dec",
+    )
 
     calendar = (
-        "", "juliánsky", "hebrejský",
-        "republikánsky", "perzský", "islamský",
-        "švédsky"
-        )
+        "",
+        "juliánsky",
+        "hebrejský",
+        "republikánsky",
+        "perzský",
+        "islamský",
+        "švédsky",
+    )
 
     _mod_str = ("", "pred ", "po ", "okolo ", "", "", "")
 
     _qual_str = ("", "odh. ", "vyp. ")
 
     formats = (
-        "RRRR-MM-DD (ISO)", "numerický", "Mesiac Deň, Rok",
-        "MES Deň, Rok", "Deň, Mesiac, Rok", "Deň MES Rok"
-        )
-        # this must agree with DateDisplayEn's "formats" definition
-        # (since no locale-specific _display_gregorian exists, here)
+        "RRRR-MM-DD (ISO)",
+        "numerický",
+        "Mesiac Deň, Rok",
+        "MES Deň, Rok",
+        "Deň, Mesiac, Rok",
+        "Deň MES Rok",
+    )
+    # this must agree with DateDisplayEn's "formats" definition
+    # (since no locale-specific _display_gregorian exists, here)
 
     def display(self, date):
         """
@@ -146,25 +187,23 @@ class DateDisplaySK(DateDisplay):
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'od', d1,
-                                        'do', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "od", d1, "do", d2, scal)
         elif mod == Date.MOD_RANGE:
             d1 = self.display_cal[cal](start)
             d2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, 'medzi',
-                                        d1, 'a', d2, scal)
+            return "%s%s %s %s %s%s" % (qual_str, "medzi", d1, "a", d2, scal)
         else:
             text = self.display_cal[date.get_calendar()](start)
             scal = self.format_extras(cal, newyear)
-            return "%s%s%s%s" % (qual_str, self._mod_str[mod],
-                                 text, scal)
+            return "%s%s%s%s" % (qual_str, self._mod_str[mod], text, scal)
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('sk_SK', 'sk', 'SK', 'Slovak', ('%d.%m.%Y',)),
-    DateParserSK, DateDisplaySK)
+    ("sk_SK", "sk", "SK", "Slovak", ("%d.%m.%Y",)), DateParserSK, DateDisplaySK
+)

--- a/gramps/gen/datehandler/_date_sl.py
+++ b/gramps/gen/datehandler/_date_sl.py
@@ -25,61 +25,69 @@
 Slovenian-specific classes for parsing and displaying dates - new framework.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Slovenian parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserSL(DateParser):
     """
     Converts a text string into a Date object
     """
 
     modifier_to_int = {
-        'pred'   : Date.MOD_BEFORE,
-        'pr.'    : Date.MOD_BEFORE,
-        'po'     : Date.MOD_AFTER,
-        'okoli'  : Date.MOD_ABOUT,
-        'okrog'  : Date.MOD_ABOUT,
-        'okr.'   : Date.MOD_ABOUT,
-        'ok.'    : Date.MOD_ABOUT,
-        'cca.'   : Date.MOD_ABOUT,
-        'cca'    : Date.MOD_ABOUT,
-        'circa'  : Date.MOD_ABOUT,
-        'ca.'    : Date.MOD_ABOUT,
-        'približno' : Date.MOD_ABOUT,
-        'pribl.' : Date.MOD_ABOUT,
-        '~'      : Date.MOD_ABOUT,
-        }
+        "pred": Date.MOD_BEFORE,
+        "pr.": Date.MOD_BEFORE,
+        "po": Date.MOD_AFTER,
+        "okoli": Date.MOD_ABOUT,
+        "okrog": Date.MOD_ABOUT,
+        "okr.": Date.MOD_ABOUT,
+        "ok.": Date.MOD_ABOUT,
+        "cca.": Date.MOD_ABOUT,
+        "cca": Date.MOD_ABOUT,
+        "circa": Date.MOD_ABOUT,
+        "ca.": Date.MOD_ABOUT,
+        "približno": Date.MOD_ABOUT,
+        "pribl.": Date.MOD_ABOUT,
+        "~": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     quality_to_int = {
-        'ocenjeno'   : Date.QUAL_ESTIMATED,
-        'oc.'        : Date.QUAL_ESTIMATED,
-        'po oceni'   : Date.QUAL_ESTIMATED,
-        'izračunano' : Date.QUAL_CALCULATED,
-        'izrač.'     : Date.QUAL_CALCULATED,
-        'po izračunu': Date.QUAL_CALCULATED,
-        }
+        "ocenjeno": Date.QUAL_ESTIMATED,
+        "oc.": Date.QUAL_ESTIMATED,
+        "po oceni": Date.QUAL_ESTIMATED,
+        "izračunano": Date.QUAL_CALCULATED,
+        "izrač.": Date.QUAL_CALCULATED,
+        "po izračunu": Date.QUAL_CALCULATED,
+    }
 
-    bce = ["pred našim štetjem", "pred Kristusom",
-           "p.n.š.", "p. n. š.", "pr.Kr.", "pr. Kr."] + DateParser.bce
+    bce = [
+        "pred našim štetjem",
+        "pred Kristusom",
+        "p.n.š.",
+        "p. n. š.",
+        "pr.Kr.",
+        "pr. Kr.",
+    ] + DateParser.bce
 
     def init_strings(self):
         """
@@ -88,40 +96,48 @@ class DateParserSL(DateParser):
 
         DateParser.init_strings(self)
         # match 'Day. MONTH year.' format with or without dots
-        self._text2 = re.compile(r'(\d+)?\.?\s*?%s\.?\s*((\d+)(/\d+)?)?\s*\.?$'
-                                 % self._mon_str, re.IGNORECASE)
+        self._text2 = re.compile(
+            r"(\d+)?\.?\s*?%s\.?\s*((\d+)(/\d+)?)?\s*\.?$" % self._mon_str,
+            re.IGNORECASE,
+        )
         # match Day.Month.Year.
-        self._numeric = re.compile(
-            r"((\d+)[/\.-])?\s*((\d+)[/\.-])?\s*(\d+)\.?$")
+        self._numeric = re.compile(r"((\d+)[/\.-])?\s*((\d+)[/\.-])?\s*(\d+)\.?$")
 
-        self._span = re.compile(r"od\s+(?P<start>.+)\s+do\s+(?P<stop>.+)",
-                                re.IGNORECASE)
+        self._span = re.compile(
+            r"od\s+(?P<start>.+)\s+do\s+(?P<stop>.+)", re.IGNORECASE
+        )
         self._range = re.compile(
-            r"med\s+(?P<start>.+)\s+in\s+(?P<stop>.+)", re.IGNORECASE)
-        self._jtext2 = re.compile(r'(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?'
-                                  % self._jmon_str, re.IGNORECASE)
+            r"med\s+(?P<start>.+)\s+in\s+(?P<stop>.+)", re.IGNORECASE
+        )
+        self._jtext2 = re.compile(
+            r"(\d+)?.?\s+?%s\s*((\d+)(/\d+)?)?" % self._jmon_str, re.IGNORECASE
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Slovenian display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplaySL(DateDisplay):
     """
     Slovenian language date display class.
     """
+
     # TODO fix BUG 7064: non-Gregorian calendars wrongly use BCE notation for negative dates
     # not refactoring _bce_str into base class because it'll be gone under #7064
     _bce_str = "%s pr.Kr."
 
     display = DateDisplay.display_formatted
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ("sl_SI", "sl", "SL",
-     "slovenščina", "slovenian", "Slovenian", ('%d. %m. %Y',)),
-    DateParserSL, DateDisplaySL)
+    ("sl_SI", "sl", "SL", "slovenščina", "slovenian", "Slovenian", ("%d. %m. %Y",)),
+    DateParserSL,
+    DateDisplaySL,
+)

--- a/gramps/gen/datehandler/_date_sr.py
+++ b/gramps/gen/datehandler/_date_sr.py
@@ -26,32 +26,33 @@
 Serbian-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Serbian parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserSR(DateParser):
     """
     Converts a text string into a Date object
     """
+
     month_to_int = DateParser.month_to_int
 
     month_to_int["januar"] = 1
@@ -145,64 +146,68 @@ class DateParserSR(DateParser):
     month_to_int["xii"] = 12
 
     modifier_to_int = {
-        'pre'    : Date.MOD_BEFORE,
-        'posle'  : Date.MOD_AFTER,
-        'oko'    : Date.MOD_ABOUT,
-        'cca'    : Date.MOD_ABOUT,
-
-        'пре'    : Date.MOD_BEFORE,
-        'после'  : Date.MOD_AFTER,
-        'око'    : Date.MOD_ABOUT,
-        }
+        "pre": Date.MOD_BEFORE,
+        "posle": Date.MOD_AFTER,
+        "oko": Date.MOD_ABOUT,
+        "cca": Date.MOD_ABOUT,
+        "пре": Date.MOD_BEFORE,
+        "после": Date.MOD_AFTER,
+        "око": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     calendar_to_int = {
-        'gregorijanski'  : Date.CAL_GREGORIAN,
-        'greg.'          : Date.CAL_GREGORIAN,
-        'julijanski'     : Date.CAL_JULIAN,
-        'jul.'           : Date.CAL_JULIAN,
-        'hebrejski'      : Date.CAL_HEBREW,
-        'hebr.'          : Date.CAL_HEBREW,
-        'islamski'       : Date.CAL_ISLAMIC,
-        'isl.'           : Date.CAL_ISLAMIC,
-        'francuski republikanski': Date.CAL_FRENCH,
-        'franc.'         : Date.CAL_FRENCH,
-        'persijski'      : Date.CAL_PERSIAN,
-        'pers. '         : Date.CAL_PERSIAN,
-        'švedski'        : Date.CAL_SWEDISH,
-        'šv.'            : Date.CAL_SWEDISH,
-
-        'грегоријански'  : Date.CAL_GREGORIAN,
-        'грег.'          : Date.CAL_GREGORIAN,
-        'јулијански'     : Date.CAL_JULIAN,
-        'јул.'           : Date.CAL_JULIAN,
-        'хебрејски'      : Date.CAL_HEBREW,
-        'хебр.'          : Date.CAL_HEBREW,
-        'исламски'       : Date.CAL_ISLAMIC,
-        'исл.'           : Date.CAL_ISLAMIC,
-        'француски републикански': Date.CAL_FRENCH,
-        'франц.'         : Date.CAL_FRENCH,
-        'персијски'      : Date.CAL_PERSIAN,
-        'перс. '         : Date.CAL_PERSIAN,
-        'шведски'        : Date.CAL_SWEDISH,
-        'шв'             : Date.CAL_SWEDISH,
-        }
+        "gregorijanski": Date.CAL_GREGORIAN,
+        "greg.": Date.CAL_GREGORIAN,
+        "julijanski": Date.CAL_JULIAN,
+        "jul.": Date.CAL_JULIAN,
+        "hebrejski": Date.CAL_HEBREW,
+        "hebr.": Date.CAL_HEBREW,
+        "islamski": Date.CAL_ISLAMIC,
+        "isl.": Date.CAL_ISLAMIC,
+        "francuski republikanski": Date.CAL_FRENCH,
+        "franc.": Date.CAL_FRENCH,
+        "persijski": Date.CAL_PERSIAN,
+        "pers. ": Date.CAL_PERSIAN,
+        "švedski": Date.CAL_SWEDISH,
+        "šv.": Date.CAL_SWEDISH,
+        "грегоријански": Date.CAL_GREGORIAN,
+        "грег.": Date.CAL_GREGORIAN,
+        "јулијански": Date.CAL_JULIAN,
+        "јул.": Date.CAL_JULIAN,
+        "хебрејски": Date.CAL_HEBREW,
+        "хебр.": Date.CAL_HEBREW,
+        "исламски": Date.CAL_ISLAMIC,
+        "исл.": Date.CAL_ISLAMIC,
+        "француски републикански": Date.CAL_FRENCH,
+        "франц.": Date.CAL_FRENCH,
+        "персијски": Date.CAL_PERSIAN,
+        "перс. ": Date.CAL_PERSIAN,
+        "шведски": Date.CAL_SWEDISH,
+        "шв": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        'procenjeno' : Date.QUAL_ESTIMATED,
-        'pro.'       : Date.QUAL_ESTIMATED,
-        'izračunato' : Date.QUAL_CALCULATED,
-        'izr.'       : Date.QUAL_CALCULATED,
+        "procenjeno": Date.QUAL_ESTIMATED,
+        "pro.": Date.QUAL_ESTIMATED,
+        "izračunato": Date.QUAL_CALCULATED,
+        "izr.": Date.QUAL_CALCULATED,
+        "процењено": Date.QUAL_ESTIMATED,
+        "про.": Date.QUAL_ESTIMATED,
+        "приближно": Date.QUAL_ESTIMATED,
+        "израчунато": Date.QUAL_CALCULATED,
+        "изр.": Date.QUAL_CALCULATED,
+        "прорачунато": Date.QUAL_CALCULATED,
+    }
 
-        'процењено'  : Date.QUAL_ESTIMATED,
-        'про.'       : Date.QUAL_ESTIMATED,
-        'приближно'  : Date.QUAL_ESTIMATED,
-        'израчунато' : Date.QUAL_CALCULATED,
-        'изр.'       : Date.QUAL_CALCULATED,
-        'прорачунато': Date.QUAL_CALCULATED,
-        }
-
-    bce = ["пре нове ере", "пре Христа", "п.н.е."
-           "pre nove ere", "pre Hrista", "p.n.e."] + DateParser.bce
+    bce = [
+        "пре нове ере",
+        "пре Христа",
+        "п.н.е." "pre nove ere",
+        "pre Hrista",
+        "p.n.e.",
+    ] + DateParser.bce
 
     def init_strings(self):
         """
@@ -210,38 +215,54 @@ class DateParserSR(DateParser):
         """
         DateParser.init_strings(self)
         # match 'Day. MONTH year.' format with or without dots
-        self._text2 = re.compile(r'(\d+)?\.?\s*?%s\s*((\d+)(/\d+)?)?\.?\s*$'
-                                 % self._mon_str, re.IGNORECASE)
+        self._text2 = re.compile(
+            r"(\d+)?\.?\s*?%s\s*((\d+)(/\d+)?)?\.?\s*$" % self._mon_str, re.IGNORECASE
+        )
 
         # match Day.Month.Year.
-        self._numeric = re.compile(
-            r"((\d+)[/\. ])?\s*((\d+)[/\.])?\s*(\d+)\.?$")
+        self._numeric = re.compile(r"((\d+)[/\. ])?\s*((\d+)[/\.])?\s*(\d+)\.?$")
 
-        _span_1 = ['od', 'од', 'из']
-        _span_2 = ['do', 'до']
-        _range_1 = ['između', 'између']
-        _range_2 = ['i', 'и']
-        self._span = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
-                                % ('|'.join(_span_1), '|'.join(_span_2)),
-                                re.IGNORECASE)
-        self._range = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
-                                 % ('|'.join(_range_1), '|'.join(_range_2)),
-                                 re.IGNORECASE)
+        _span_1 = ["od", "од", "из"]
+        _span_2 = ["do", "до"]
+        _range_1 = ["između", "између"]
+        _range_2 = ["i", "и"]
+        self._span = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_span_1), "|".join(_span_2)),
+            re.IGNORECASE,
+        )
+        self._range = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_range_1), "|".join(_range_2)),
+            re.IGNORECASE,
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Serbian display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplaySR_Base(DateDisplay):
     """
     Serbian (base) date display class
     """
 
     roman_months = (
-        "", "I", "II", "III", "IV", "V", "VI",
-        "VII", "VIII", "IX", "X", "XI", "XII"
-        )
+        "",
+        "I",
+        "II",
+        "III",
+        "IV",
+        "V",
+        "VI",
+        "VII",
+        "VIII",
+        "IX",
+        "X",
+        "XI",
+        "XII",
+    )
 
     def _display_gregorian(self, date_val, **kwargs):
         """
@@ -259,11 +280,11 @@ class DateDisplaySR_Base(DateDisplay):
                 if date_val[0] == 0 and date_val[1] == 0:
                     value = str(date_val[2])
                 else:
-                    value = self.dhformat.replace('%m', str(date_val[1]))
-                    value = value.replace('%d', str(date_val[0]))
-                    value = value.replace('%Y', str(abs(date_val[2])))
-                    #some locale magic already provides the right separator
-                    #value = value.replace('/', '.')
+                    value = self.dhformat.replace("%m", str(date_val[1]))
+                    value = value.replace("%d", str(date_val[0]))
+                    value = value.replace("%Y", str(abs(date_val[2])))
+                    # some locale magic already provides the right separator
+                    # value = value.replace('/', '.')
         elif self.format == 2:
             # day. month_abbreviation year.
             if date_val[0] == 0:
@@ -272,8 +293,11 @@ class DateDisplaySR_Base(DateDisplay):
                 else:
                     value = "%s %s." % (self.short_months[date_val[1]], year)
             else:
-                value = "%d. %s %s." % (date_val[0],
-                                        self.short_months[date_val[1]], year)
+                value = "%d. %s %s." % (
+                    date_val[0],
+                    self.short_months[date_val[1]],
+                    year,
+                )
         elif self.format == 3:
             # day. month_name year.
             if date_val[0] == 0:
@@ -282,8 +306,11 @@ class DateDisplaySR_Base(DateDisplay):
                 else:
                     value = "%s %s." % (self.long_months[date_val[1]], year)
             else:
-                value = "%d. %s %s." % (date_val[0],
-                                        self.long_months[date_val[1]], year)
+                value = "%d. %s %s." % (
+                    date_val[0],
+                    self.long_months[date_val[1]],
+                    year,
+                )
         else:
             # day. Roman_number_month year.
             if date_val[0] == 0:
@@ -292,8 +319,11 @@ class DateDisplaySR_Base(DateDisplay):
                 else:
                     value = "%s %s." % (self.roman_months[date_val[1]], year)
             else:
-                value = "%d. %s %s." % (date_val[0],
-                                        self.roman_months[date_val[1]], year)
+                value = "%d. %s %s." % (
+                    date_val[0],
+                    self.roman_months[date_val[1]],
+                    year,
+                )
         if date_val[2] < 0:
             return self._bce_str % value
         else:
@@ -323,41 +353,64 @@ class DateDisplaySR_Base(DateDisplay):
             d_1 = self.display_cal[cal](start)
             d_2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, span1, d_1, span2, d_2,
-                                                            scal)
+            return "%s%s %s %s %s%s" % (qual_str, span1, d_1, span2, d_2, scal)
         elif mod == Date.MOD_RANGE:
             d_1 = self.display_cal[cal](start)
             d_2 = self.display_cal[cal](date.get_stop_date())
             scal = self.format_extras(cal, newyear)
-            return "%s%s %s %s %s%s" % (qual_str, range1, d_1, range2, d_2,
-                                                            scal)
+            return "%s%s %s %s %s%s" % (qual_str, range1, d_1, range2, d_2, scal)
         else:
             text = self.display_cal[date.get_calendar()](start)
             scal = self.format_extras(cal, newyear)
-            return "%s%s%s%s" % (qual_str, self._mod_str[mod], text,
-                                                scal)
+            return "%s%s%s%s" % (qual_str, self._mod_str[mod], text, scal)
+
 
 class DateDisplaySR_Latin(DateDisplaySR_Base):
     """
     Serbian (Latin) date display class
     """
 
-    long_months = ("",
-        "januara", "februara", "marta", "aprila",
-        "maja", "juna", "jula", "avgusta",
-        "septembra", "oktobra", "novembra", "decembra"
-        )
+    long_months = (
+        "",
+        "januara",
+        "februara",
+        "marta",
+        "aprila",
+        "maja",
+        "juna",
+        "jula",
+        "avgusta",
+        "septembra",
+        "oktobra",
+        "novembra",
+        "decembra",
+    )
 
-    short_months = ("",
-        "jan", "feb", "mar", "apr", "maj", "jun",
-        "jul", "avg", "sep", "okt", "nov", "dec"
-        )
+    short_months = (
+        "",
+        "jan",
+        "feb",
+        "mar",
+        "apr",
+        "maj",
+        "jun",
+        "jul",
+        "avg",
+        "sep",
+        "okt",
+        "nov",
+        "dec",
+    )
 
     calendar = (
-        "", "julijanski", "hebrejski",
-        "francuski republikanski", "persijski", "islamski",
-        "švedski"
-        )
+        "",
+        "julijanski",
+        "hebrejski",
+        "francuski republikanski",
+        "persijski",
+        "islamski",
+        "švedski",
+    )
 
     _mod_str = ("", "pre ", "posle ", "oko ", "", "", "")
 
@@ -370,36 +423,62 @@ class DateDisplaySR_Latin(DateDisplaySR_Base):
         "Numerički (DD.MM.GGGG.)",
         "D. MMM GGGG.",
         "D. Mesec GGGG.",
-        "D. Rb GGGG."
-        )
-        # this definition must agree with its "_display_gregorian" method
+        "D. Rb GGGG.",
+    )
+    # this definition must agree with its "_display_gregorian" method
 
-    _span1 = 'od'
-    _span2 = 'do'
-    _range1 = 'između'
-    _range2 = 'i'
+    _span1 = "od"
+    _span2 = "do"
+    _range1 = "između"
+    _range2 = "i"
+
 
 class DateDisplaySR_Cyrillic(DateDisplaySR_Base):
     """
     Serbian (Cyrillic) date display class
     """
 
-    long_months = ("",
-        "Јануар", "Фебруар", "Март", "Април",
-        "Мај", "Јуне", "Јули", "Аугуст",
-        "Септембар", "Оцтобер", "Новембер", "Децембар"
-        )
+    long_months = (
+        "",
+        "Јануар",
+        "Фебруар",
+        "Март",
+        "Април",
+        "Мај",
+        "Јуне",
+        "Јули",
+        "Аугуст",
+        "Септембар",
+        "Оцтобер",
+        "Новембер",
+        "Децембар",
+    )
 
-    short_months = ("",
-        "Јан", "Феб", "Мар", "Апр", "Мај", "Јун",
-        "Јул", "Авг", "Сеп", "Окт", "Нов", "Дец"
-        )
+    short_months = (
+        "",
+        "Јан",
+        "Феб",
+        "Мар",
+        "Апр",
+        "Мај",
+        "Јун",
+        "Јул",
+        "Авг",
+        "Сеп",
+        "Окт",
+        "Нов",
+        "Дец",
+    )
 
     calendar = (
-        "", "Јулиан", "хебрејски",
-        "француски републиканац", "Персиан", "исламски",
-        "шведски"
-        )
+        "",
+        "Јулиан",
+        "хебрејски",
+        "француски републиканац",
+        "Персиан",
+        "исламски",
+        "шведски",
+    )
 
     _mod_str = ("", "пре ", "после ", "око ", "", "", "")
 
@@ -412,25 +491,45 @@ class DateDisplaySR_Cyrillic(DateDisplaySR_Base):
         "Нумеричка (ДД.ММ.ГГГГ.)",
         "Д. МММ ГГГГ.",
         "Д. Месец ГГГГ.",
-        "Д. Rb ГГГГ."
-        )
-        # this definition must agree with its "_display_gregorian" method
+        "Д. Rb ГГГГ.",
+    )
+    # this definition must agree with its "_display_gregorian" method
 
-    _span1 = 'из'
-    _span2 = 'до'
-    _range1 = 'између'
-    _range2 = 'и'
+    _span1 = "из"
+    _span2 = "до"
+    _range1 = "између"
+    _range2 = "и"
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('sr_RS.utf8@latin', 'srpski', 'Srpski',
-     'sr_Latn', 'sr_Latn_RS', 'sr_RS@latin', ('%d.%m.%Y.',)),
-    DateParserSR, DateDisplaySR_Latin)
+    (
+        "sr_RS.utf8@latin",
+        "srpski",
+        "Srpski",
+        "sr_Latn",
+        "sr_Latn_RS",
+        "sr_RS@latin",
+        ("%d.%m.%Y.",),
+    ),
+    DateParserSR,
+    DateDisplaySR_Latin,
+)
 register_datehandler(
-    ('sr_RS', 'sr', 'sr_Cyrl', 'sr_Cyrl_RS',
-     'српски', 'Српски', 'serbian', ('%d.%m.%Y.',)),
-    DateParserSR, DateDisplaySR_Cyrillic)
+    (
+        "sr_RS",
+        "sr",
+        "sr_Cyrl",
+        "sr_Cyrl_RS",
+        "српски",
+        "Српски",
+        "serbian",
+        ("%d.%m.%Y.",),
+    ),
+    DateParserSR,
+    DateDisplaySR_Cyrillic,
+)

--- a/gramps/gen/datehandler/_date_sv.py
+++ b/gramps/gen/datehandler/_date_sv.py
@@ -23,28 +23,28 @@
 Swedish-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Swedish parser class
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserSv(DateParser):
     """
     Convert a text string into a Date object, expecting a date
@@ -54,63 +54,67 @@ class DateParserSv(DateParser):
 
     # modifiers before the date
     modifier_to_int = {
-        'före'    : Date.MOD_BEFORE,
-        'innan'   : Date.MOD_BEFORE,
-        'efter'   : Date.MOD_AFTER,
-        'omkring' : Date.MOD_ABOUT,
-        'ca'      : Date.MOD_ABOUT,
-        'c:a'     : Date.MOD_ABOUT
-        }
+        "före": Date.MOD_BEFORE,
+        "innan": Date.MOD_BEFORE,
+        "efter": Date.MOD_AFTER,
+        "omkring": Date.MOD_ABOUT,
+        "ca": Date.MOD_ABOUT,
+        "c:a": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     bce = ["f Kr"]
 
     calendar_to_int = {
-        'gregoriansk   '      : Date.CAL_GREGORIAN,
-        'g'                   : Date.CAL_GREGORIAN,
-        'juliansk'            : Date.CAL_JULIAN,
-        'j'                   : Date.CAL_JULIAN,
-        'hebreisk'            : Date.CAL_HEBREW,
-        'h'                   : Date.CAL_HEBREW,
-        'islamisk'            : Date.CAL_ISLAMIC,
-        'muslimsk'            : Date.CAL_ISLAMIC,
-        'i'                   : Date.CAL_ISLAMIC,
-        'fransk'              : Date.CAL_FRENCH,
-        'fransk republikansk' : Date.CAL_FRENCH,
-        'f'                   : Date.CAL_FRENCH,
-        'persisk'             : Date.CAL_PERSIAN,
-        'p'                   : Date.CAL_PERSIAN,
-        'svensk'              : Date.CAL_SWEDISH,
-        's'                   : Date.CAL_SWEDISH,
-        }
+        "gregoriansk   ": Date.CAL_GREGORIAN,
+        "g": Date.CAL_GREGORIAN,
+        "juliansk": Date.CAL_JULIAN,
+        "j": Date.CAL_JULIAN,
+        "hebreisk": Date.CAL_HEBREW,
+        "h": Date.CAL_HEBREW,
+        "islamisk": Date.CAL_ISLAMIC,
+        "muslimsk": Date.CAL_ISLAMIC,
+        "i": Date.CAL_ISLAMIC,
+        "fransk": Date.CAL_FRENCH,
+        "fransk republikansk": Date.CAL_FRENCH,
+        "f": Date.CAL_FRENCH,
+        "persisk": Date.CAL_PERSIAN,
+        "p": Date.CAL_PERSIAN,
+        "svensk": Date.CAL_SWEDISH,
+        "s": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        'uppskattat' : Date.QUAL_ESTIMATED,
-        'uppskattad' : Date.QUAL_ESTIMATED,
-        'bedömt'     : Date.QUAL_ESTIMATED,
-        'bedömd'     : Date.QUAL_ESTIMATED,
-        'beräknat'   : Date.QUAL_CALCULATED,
-        'beräknad'   : Date.QUAL_CALCULATED,
-        }
+        "uppskattat": Date.QUAL_ESTIMATED,
+        "uppskattad": Date.QUAL_ESTIMATED,
+        "bedömt": Date.QUAL_ESTIMATED,
+        "bedömd": Date.QUAL_ESTIMATED,
+        "beräknat": Date.QUAL_CALCULATED,
+        "beräknad": Date.QUAL_CALCULATED,
+    }
 
     def init_strings(self):
-        """ Define, in Swedish, span and range regular expressions"""
+        """Define, in Swedish, span and range regular expressions"""
         DateParser.init_strings(self)
         self._numeric = re.compile(r"((\d+)/)?\s*((\d+)/)?\s*(\d+)[/ ]?$")
         # this next RE has the (possibly-slashed) year at the string's start
-        self._text2 = re.compile(r'((\d+)(/\d+)?)?\s+?%s\s*(\d+)?\s*$'
-                                 % self._mon_str, re.IGNORECASE)
+        self._text2 = re.compile(
+            r"((\d+)(/\d+)?)?\s+?%s\s*(\d+)?\s*$" % self._mon_str, re.IGNORECASE
+        )
         self._span = re.compile(
-            r"(från)?\s*(?P<start>.+)\s*(till|--|–)\s*(?P<stop>.+)",
-            re.IGNORECASE)
+            r"(från)?\s*(?P<start>.+)\s*(till|--|–)\s*(?P<stop>.+)", re.IGNORECASE
+        )
         self._range = re.compile(
-            r"(mellan)\s+(?P<start>.+)\s+och\s+(?P<stop>.+)",
-            re.IGNORECASE)
+            r"(mellan)\s+(?P<start>.+)\s+och\s+(?P<stop>.+)", re.IGNORECASE
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Swedish display class
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplaySv(DateDisplay):
     """
     Swedish language date display class.
@@ -123,11 +127,10 @@ class DateDisplaySv(DateDisplay):
         "År/mån/dag",
         "År månad dag",
         "År mån dag",
-        )
-        # this definition must agree with its "_display_calendar" method
+    )
+    # this definition must agree with its "_display_calendar" method
 
-    def _display_calendar(self, date_val, long_months, short_months = None,
-                          inflect=""):
+    def _display_calendar(self, date_val, long_months, short_months=None, inflect=""):
         # this must agree with its locale-specific "formats" definition
 
         if short_months is None:
@@ -160,7 +163,7 @@ class DateDisplaySv(DateDisplay):
                 return year
             else:
                 return "%s %s" % (year, long_months[date_val[1]])
-        elif date_val[1] == 0: # month is zero but day is not (see 8477)
+        elif date_val[1] == 0:  # month is zero but day is not (see 8477)
             return self.display_iso(date_val)
         else:
             return "%s %s %s" % (year, long_months[date_val[1]], date_val[0])
@@ -173,18 +176,21 @@ class DateDisplaySv(DateDisplay):
                 return year
             else:
                 return "%s %s" % (year, short_months[date_val[1]])
-        elif date_val[1] == 0: # month is zero but day is not (see 8477)
+        elif date_val[1] == 0:  # month is zero but day is not (see 8477)
             return self.display_iso(date_val)
         else:
             return "%s %s %s" % (year, short_months[date_val[1]], date_val[0])
 
     display = DateDisplay.display_formatted
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('sv_SE', 'sv_SE.UTF-8', 'sv', 'Swedish', ('%Y-%m-%d',)),
-    DateParserSv, DateDisplaySv)
+    ("sv_SE", "sv_SE.UTF-8", "sv", "Swedish", ("%Y-%m-%d",)),
+    DateParserSv,
+    DateDisplaySv,
+)

--- a/gramps/gen/datehandler/_date_uk.py
+++ b/gramps/gen/datehandler/_date_uk.py
@@ -24,29 +24,29 @@
 Ukrainian-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Ukrainian parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserUK(DateParser):
     """
     Convert a text string into a :class:`.Date` object. If the date cannot be
@@ -55,41 +55,42 @@ class DateParserUK(DateParser):
 
     # modifiers before the date
     modifier_to_int = {
-        'перед'    : Date.MOD_BEFORE,
-        'до'       : Date.MOD_BEFORE,
-        'раніше'   : Date.MOD_BEFORE,
-
-        'після'    : Date.MOD_AFTER,
-        'п.'       : Date.MOD_AFTER,
-        'за'       : Date.MOD_AFTER,
-
-        'приблизно': Date.MOD_ABOUT,
-        'прибл.'   : Date.MOD_ABOUT,
-        'приб.'    : Date.MOD_ABOUT,
-        'близько'  : Date.MOD_ABOUT,
-        'бл.'      : Date.MOD_ABOUT,
-        'біля'     : Date.MOD_ABOUT,
-        }
+        "перед": Date.MOD_BEFORE,
+        "до": Date.MOD_BEFORE,
+        "раніше": Date.MOD_BEFORE,
+        "після": Date.MOD_AFTER,
+        "п.": Date.MOD_AFTER,
+        "за": Date.MOD_AFTER,
+        "приблизно": Date.MOD_ABOUT,
+        "прибл.": Date.MOD_ABOUT,
+        "приб.": Date.MOD_ABOUT,
+        "близько": Date.MOD_ABOUT,
+        "бл.": Date.MOD_ABOUT,
+        "біля": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     quality_to_int = {
-        'за оцінкою'  : Date.QUAL_ESTIMATED,
-        'за оц.'      : Date.QUAL_ESTIMATED,
-        'оцінено'     : Date.QUAL_ESTIMATED,
-        'орієнтовно'  : Date.QUAL_ESTIMATED,
-        'приблизно'   : Date.QUAL_ESTIMATED,
-        'прибл.'      : Date.QUAL_ESTIMATED,
-
-        'підраховано' : Date.QUAL_CALCULATED,
-        'підрах.'     : Date.QUAL_CALCULATED,
-        'розраховано' : Date.QUAL_CALCULATED,
-        'розрахунково' : Date.QUAL_CALCULATED,
-        'розрах.'     : Date.QUAL_CALCULATED,
-        }
+        "за оцінкою": Date.QUAL_ESTIMATED,
+        "за оц.": Date.QUAL_ESTIMATED,
+        "оцінено": Date.QUAL_ESTIMATED,
+        "орієнтовно": Date.QUAL_ESTIMATED,
+        "приблизно": Date.QUAL_ESTIMATED,
+        "прибл.": Date.QUAL_ESTIMATED,
+        "підраховано": Date.QUAL_CALCULATED,
+        "підрах.": Date.QUAL_CALCULATED,
+        "розраховано": Date.QUAL_CALCULATED,
+        "розрахунково": Date.QUAL_CALCULATED,
+        "розрах.": Date.QUAL_CALCULATED,
+    }
 
     bce = [
-        'до нашої ери', 'до н. е.', 'до н.е.',
-        'до народження Христа'
-        ] + DateParser.bce
+        "до нашої ери",
+        "до н. е.",
+        "до н.е.",
+        "до народження Христа",
+    ] + DateParser.bce
 
     def init_strings(self):
         """
@@ -99,30 +100,37 @@ class DateParserUK(DateParser):
         """
         DateParser.init_strings(self)
 
-        DateParser.hebrew_to_int.update({
-            'мархешван': 2,
-            'ве адар'  : 7,
-            'адар бет' : 7,
-            'авів'     : 8,
-        })
+        DateParser.hebrew_to_int.update(
+            {
+                "мархешван": 2,
+                "ве адар": 7,
+                "адар бет": 7,
+                "авів": 8,
+            }
+        )
 
-        _span_1 = ['з', 'від']
+        _span_1 = ["з", "від"]
         # b.c.e. pattern also have "до" so skip "до н."
-        _span_2 = ['по', r'до(?!\s+н)']
-        _range_1 = ['між']
-        _range_2 = ['і', 'та']
-        self._span = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)" %
-                                ('|'.join(_span_1), '|'.join(_span_2)),
-                                re.IGNORECASE)
-        self._range = re.compile(r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
-                                 % ('|'.join(_range_1), '|'.join(_range_2)),
-                                 re.IGNORECASE)
+        _span_2 = ["по", r"до(?!\s+н)"]
+        _range_1 = ["між"]
+        _range_2 = ["і", "та"]
+        self._span = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_span_1), "|".join(_span_2)),
+            re.IGNORECASE,
+        )
+        self._range = re.compile(
+            r"(%s)\s+(?P<start>.+)\s+(%s)\s+(?P<stop>.+)"
+            % ("|".join(_range_1), "|".join(_range_2)),
+            re.IGNORECASE,
+        )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Ukrainian displayer
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayUK(DateDisplay):
     """
     Ukrainian language date display class.
@@ -133,11 +141,13 @@ class DateDisplayUK(DateDisplay):
     display = DateDisplay.display_formatted
 
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 register_datehandler(
-    ('uk_UA', 'uk', 'ukrainian', 'Ukrainian', ('%d.%m.%Y',)),
-    DateParserUK, DateDisplayUK)
+    ("uk_UA", "uk", "ukrainian", "Ukrainian", ("%d.%m.%Y",)),
+    DateParserUK,
+    DateDisplayUK,
+)

--- a/gramps/gen/datehandler/_date_zh_CN.py
+++ b/gramps/gen/datehandler/_date_zh_CN.py
@@ -24,29 +24,29 @@
 Simplified-Chinese-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Simplified-Chinese parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserZH_CN(DateParser):
     """
     Convert a text string into a Date object. If the date cannot be
@@ -55,10 +55,12 @@ class DateParserZH_CN(DateParser):
 
     # modifiers before the date
     modifier_to_int = {
-        '以前'   : Date.MOD_BEFORE,
-        '以后'   : Date.MOD_AFTER,
-        '大约'   : Date.MOD_ABOUT,
-        }
+        "以前": Date.MOD_BEFORE,
+        "以后": Date.MOD_AFTER,
+        "大约": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     month_to_int = DateParser.month_to_int
 
@@ -91,26 +93,26 @@ class DateParserZH_CN(DateParser):
     month_to_int["jiǎ rùn yùe"] = 13
 
     calendar_to_int = {
-        '阳历'             : Date.CAL_GREGORIAN,
-        'g'                : Date.CAL_GREGORIAN,
-        '儒略历'           : Date.CAL_JULIAN,
-        'j'                : Date.CAL_JULIAN,
-        '希伯来历'         : Date.CAL_HEBREW,
-        'h'                : Date.CAL_HEBREW,
-        '伊斯兰历'         : Date.CAL_ISLAMIC,
-        'i'                : Date.CAL_ISLAMIC,
-        '法国共和历'       : Date.CAL_FRENCH,
-        'f'                : Date.CAL_FRENCH,
-        '伊郎历'           : Date.CAL_PERSIAN,
-        'p'                : Date.CAL_PERSIAN,
-        '瑞典历'           : Date.CAL_SWEDISH,
-        's'                : Date.CAL_SWEDISH,
-        }
+        "阳历": Date.CAL_GREGORIAN,
+        "g": Date.CAL_GREGORIAN,
+        "儒略历": Date.CAL_JULIAN,
+        "j": Date.CAL_JULIAN,
+        "希伯来历": Date.CAL_HEBREW,
+        "h": Date.CAL_HEBREW,
+        "伊斯兰历": Date.CAL_ISLAMIC,
+        "i": Date.CAL_ISLAMIC,
+        "法国共和历": Date.CAL_FRENCH,
+        "f": Date.CAL_FRENCH,
+        "伊郎历": Date.CAL_PERSIAN,
+        "p": Date.CAL_PERSIAN,
+        "瑞典历": Date.CAL_SWEDISH,
+        "s": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        '据估计'     : Date.QUAL_ESTIMATED,
-        '据计算'     : Date.QUAL_CALCULATED,
-        }
+        "据估计": Date.QUAL_ESTIMATED,
+        "据计算": Date.QUAL_CALCULATED,
+    }
 
     # FIXME translate these English strings into simplified-Chinese ones
     bce = ["before calendar", "negative year"] + DateParser.bce
@@ -120,41 +122,46 @@ class DateParserZH_CN(DateParser):
         This method compiles regular expression strings for matching dates.
         """
         DateParser.init_strings(self)
-        _span_1 = ['自']
-        _span_2 = ['至']
-        _range_1 = ['介于']
-        _range_2 = ['与']
-        _range_3 = ['之间']
-        self._span = re.compile(r"(%s)\s*(?P<start>.+)\s*(%s)\s*(?P<stop>.+)" %
-                                ('|'.join(_span_1), '|'.join(_span_2)),
-                                re.IGNORECASE)
-        self._range = re.compile(r"(%s)\s*(?P<start>.+)\s*(%s)\s*(?P<stop>.+)\s*(%s)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2), '|'.join(_range_3)),
-                                 re.IGNORECASE)
+        _span_1 = ["自"]
+        _span_2 = ["至"]
+        _range_1 = ["介于"]
+        _range_2 = ["与"]
+        _range_3 = ["之间"]
+        self._span = re.compile(
+            r"(%s)\s*(?P<start>.+)\s*(%s)\s*(?P<stop>.+)"
+            % ("|".join(_span_1), "|".join(_span_2)),
+            re.IGNORECASE,
+        )
+        self._range = re.compile(
+            r"(%s)\s*(?P<start>.+)\s*(%s)\s*(?P<stop>.+)\s*(%s)"
+            % ("|".join(_range_1), "|".join(_range_2), "|".join(_range_3)),
+            re.IGNORECASE,
+        )
         self._numeric = re.compile(r"((\d+)年\s*)?((\d+)月\s*)?(\d+)?日?\s*$")
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Simplified-Chinese display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayZH_CN(DateDisplay):
     """
     Simplified-Chinese language date display class.
     """
 
     formats = (
-        "年年年年-月月-日日 (ISO)",  "数字格式",
-        )
-        # this definition must agree with its "_display_calendar" method
+        "年年年年-月月-日日 (ISO)",
+        "数字格式",
+    )
+    # this definition must agree with its "_display_calendar" method
 
     # FIXME translate these English strings into simplified-Chinese ones
     _bce_str = "%s B.C.E."
 
     display = DateDisplay.display_formatted
 
-    def _display_calendar(self, date_val, long_months, short_months = None,
-                          inflect=""):
+    def _display_calendar(self, date_val, long_months, short_months=None, inflect=""):
         # this must agree with its locale-specific "formats" definition
 
         if short_months is None:
@@ -173,12 +180,15 @@ class DateDisplayZH_CN(DateDisplay):
         else:
             return value
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 
 register_datehandler(
-    ('zh_CN', 'zh_SG', 'zh', 'chinese', 'Chinese', ('%Y年%m月%d日',)),
-    DateParserZH_CN, DateDisplayZH_CN)
+    ("zh_CN", "zh_SG", "zh", "chinese", "Chinese", ("%Y年%m月%d日",)),
+    DateParserZH_CN,
+    DateDisplayZH_CN,
+)

--- a/gramps/gen/datehandler/_date_zh_TW.py
+++ b/gramps/gen/datehandler/_date_zh_TW.py
@@ -24,29 +24,29 @@
 Traditional-Chinese-specific classes for parsing and displaying dates.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 
 from ..lib.date import Date
 from ._dateparser import DateParser
 from ._datedisplay import DateDisplay
 from ._datehandler import register_datehandler
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Traditional-Chinese parser
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParserZH_TW(DateParser):
     """
     Convert a text string into a Date object. If the date cannot be
@@ -55,10 +55,12 @@ class DateParserZH_TW(DateParser):
 
     # modifiers before the date
     modifier_to_int = {
-        '以前'   : Date.MOD_BEFORE,
-        '以後'   : Date.MOD_AFTER,
-        '大約'   : Date.MOD_ABOUT,
-        }
+        "以前": Date.MOD_BEFORE,
+        "以後": Date.MOD_AFTER,
+        "大約": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
 
     month_to_int = DateParser.month_to_int
 
@@ -91,26 +93,26 @@ class DateParserZH_TW(DateParser):
     month_to_int["jiǎ rùn yùe"] = 13
 
     calendar_to_int = {
-        '陽曆'             : Date.CAL_GREGORIAN,
-        'g'                : Date.CAL_GREGORIAN,
-        '儒略曆'           : Date.CAL_JULIAN,
-        'j'                : Date.CAL_JULIAN,
-        '希伯來歷'         : Date.CAL_HEBREW,
-        'h'                : Date.CAL_HEBREW,
-        '伊斯蘭曆'         : Date.CAL_ISLAMIC,
-        'i'                : Date.CAL_ISLAMIC,
-        '法國共和歷'       : Date.CAL_FRENCH,
-        'f'                : Date.CAL_FRENCH,
-        '伊郎歷'           : Date.CAL_PERSIAN,
-        'p'                : Date.CAL_PERSIAN,
-        '瑞典歷'           : Date.CAL_SWEDISH,
-        's'                : Date.CAL_SWEDISH,
-        }
+        "陽曆": Date.CAL_GREGORIAN,
+        "g": Date.CAL_GREGORIAN,
+        "儒略曆": Date.CAL_JULIAN,
+        "j": Date.CAL_JULIAN,
+        "希伯來歷": Date.CAL_HEBREW,
+        "h": Date.CAL_HEBREW,
+        "伊斯蘭曆": Date.CAL_ISLAMIC,
+        "i": Date.CAL_ISLAMIC,
+        "法國共和歷": Date.CAL_FRENCH,
+        "f": Date.CAL_FRENCH,
+        "伊郎歷": Date.CAL_PERSIAN,
+        "p": Date.CAL_PERSIAN,
+        "瑞典歷": Date.CAL_SWEDISH,
+        "s": Date.CAL_SWEDISH,
+    }
 
     quality_to_int = {
-        '據估計'     : Date.QUAL_ESTIMATED,
-        '據計算'     : Date.QUAL_CALCULATED,
-        }
+        "據估計": Date.QUAL_ESTIMATED,
+        "據計算": Date.QUAL_CALCULATED,
+    }
 
     # FIXME translate these English strings into traditional-Chinese ones
     bce = ["before calendar", "negative year"] + DateParser.bce
@@ -120,41 +122,46 @@ class DateParserZH_TW(DateParser):
         This method compiles regular expression strings for matching dates.
         """
         DateParser.init_strings(self)
-        _span_1 = ['自']
-        _span_2 = ['至']
-        _range_1 = ['介於']
-        _range_2 = ['與']
-        _range_3 = ['之間']
-        self._span = re.compile(r"(%s)\s*(?P<start>.+)\s*(%s)\s*(?P<stop>.+)" %
-                                ('|'.join(_span_1), '|'.join(_span_2)),
-                                re.IGNORECASE)
-        self._range = re.compile(r"(%s)\s*(?P<start>.+)\s*(%s)\s*(?P<stop>.+)\s*(%s)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2), '|'.join(_range_3)),
-                                 re.IGNORECASE)
+        _span_1 = ["自"]
+        _span_2 = ["至"]
+        _range_1 = ["介於"]
+        _range_2 = ["與"]
+        _range_3 = ["之間"]
+        self._span = re.compile(
+            r"(%s)\s*(?P<start>.+)\s*(%s)\s*(?P<stop>.+)"
+            % ("|".join(_span_1), "|".join(_span_2)),
+            re.IGNORECASE,
+        )
+        self._range = re.compile(
+            r"(%s)\s*(?P<start>.+)\s*(%s)\s*(?P<stop>.+)\s*(%s)"
+            % ("|".join(_range_1), "|".join(_range_2), "|".join(_range_3)),
+            re.IGNORECASE,
+        )
         self._numeric = re.compile(r"((\d+)年\s*)?((\d+)月\s*)?(\d+)?日?\s*$")
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Traditional-Chinese display
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplayZH_TW(DateDisplay):
     """
     Traditional-Chinese language date display class.
     """
 
     formats = (
-        "年年年年-月月-日日 (ISO)",  "數字格式",
-        )
-        # this definition must agree with its "_display_calendar" method
+        "年年年年-月月-日日 (ISO)",
+        "數字格式",
+    )
+    # this definition must agree with its "_display_calendar" method
 
     # FIXME translate these English strings into traditional-Chinese ones
     _bce_str = "%s B.C.E."
 
     display = DateDisplay.display_formatted
 
-    def _display_calendar(self, date_val, long_months, short_months = None,
-                          inflect=""):
+    def _display_calendar(self, date_val, long_months, short_months=None, inflect=""):
         # this must agree with its locale-specific "formats" definition
 
         if short_months is None:
@@ -173,12 +180,13 @@ class DateDisplayZH_TW(DateDisplay):
         else:
             return value
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Register classes
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 
 register_datehandler(
-    ('zh_TW', 'zh_HK', ('西元%Y年%m月%d日',)),
-    DateParserZH_TW, DateDisplayZH_TW)
+    ("zh_TW", "zh_HK", ("西元%Y年%m月%d日",)), DateParserZH_TW, DateDisplayZH_TW
+)

--- a/gramps/gen/datehandler/_datedisplay.py
+++ b/gramps/gen/datehandler/_datedisplay.py
@@ -26,40 +26,42 @@ U.S English date display class. Should serve as the base class for all
 localized tasks.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import datetime
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # set up logging
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import logging
+
 log = logging.getLogger(".DateDisplay")
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date
 from ..const import GRAMPS_LOCALE as glocale
 from ..utils.grampslocale import GrampsLocale
 from ._datestrings import DateStrings
 
 # _T_ is a gramps-defined keyword -- see po/update_po.py and po/genpot.sh
-def _T_(value, context=''): # enable deferred translations
+def _T_(value, context=""):  # enable deferred translations
     return "%s\x04%s" % (context, value) if context else value
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # DateDisplay
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateDisplay:
     """
     Base date display class.
@@ -69,7 +71,6 @@ class DateDisplay:
         # format 0 - must always be ISO
         # Translators: Numeric year, month, day
         _T_("YYYY-MM-DD (ISO)"),
-
         # format # 1 - must always be locale-preferred numerical format
         # such as YY.MM.DD, MM-DD-YY, or whatever your locale prefers.
         # This should be the format that is used under the locale by
@@ -77,19 +78,15 @@ class DateDisplay:
         # Translators: You may translate this as "Numerical",
         # "System preferred", or similar.
         _T_("Numerical", "date format"),
-
         # Translators: Full month name, day, year
         _T_("Month Day, Year"),
-
         # Translators: Abbreviated month name, day, year
         _T_("MON DAY, YEAR"),
-
         # Translators: Day, full month name, year
         _T_("Day Month Year"),
-
         # Translators: Day, abbreviated month name, year
-        _T_("DAY MON YEAR")
-        )
+        _T_("DAY MON YEAR"),
+    )
     """
     .. note:: Will be overridden if a locale-specific date displayer exists.
 
@@ -110,19 +107,20 @@ class DateDisplay:
         :param blocale: allow translation of dates and date formats
         :type blocale: a :class:`.GrampsLocale` instance
         """
-        from ._datehandler import locale_tformat # circular import if above
+        from ._datehandler import locale_tformat  # circular import if above
+
         if blocale:
             self._locale = blocale
-        elif not hasattr(self, '_locale'):
+        elif not hasattr(self, "_locale"):
             self._locale = glocale
         if self._locale.calendar in locale_tformat:
-            self.dhformat = locale_tformat[self._locale.calendar] # date format
+            self.dhformat = locale_tformat[self._locale.calendar]  # date format
         else:
-            self.dhformat = locale_tformat['en_GB'] # something is required
-        self.formats_changed() # allow overriding so a subclass can modify
+            self.dhformat = locale_tformat["en_GB"]  # something is required
+        self.formats_changed()  # allow overriding so a subclass can modify
         self._ds = DateStrings(self._locale)
         calendar = list(self._ds.calendar)
-        calendar[Date.CAL_GREGORIAN] = "" # that string only used in parsing,
+        calendar[Date.CAL_GREGORIAN] = ""  # that string only used in parsing,
         # gregorian cal name shouldn't be output!
         self.calendar = tuple(calendar)
         self.short_months = self._ds.short_months
@@ -138,11 +136,12 @@ class DateDisplay:
             self._display_french,
             self._display_persian,
             self._display_islamic,
-            self._display_swedish]
+            self._display_swedish,
+        ]
         self._mod_str = self._ds.modifiers
         self._qual_str = self._ds.qualifiers
         self.long_days = self._ds.long_days
-        self.short_days = self._ds.short_days # Icelandic needs this
+        self.short_days = self._ds.short_days  # Icelandic needs this
 
         if format is None:
             self.format = 0
@@ -151,179 +150,159 @@ class DateDisplay:
 
         self._ = _ = self._locale.translation.sgettext
         self.FORMATS_long_month_year = {
-# Inflection control due to modifier.
-# Protocol: DateDisplayXX passes a key to the dictionary in the
-# parameter ``inflect`` to ``_display_calendar``.
-# The modifier passed is not necessarily the one printed, it's just
-# a representative that induces the same inflection control.
-# For example, in Russian "before May", "after May", and "about May"
-# all require genitive form for May, whereas no modifier (just "May 1234")
-# require nominative, so DateDisplayRU.display will pass "before"
-# in all 3 cases, collapsing the 3 modifiers into 1.
-#
-# Another example in Russian is that "between April 1234 and June 1235"
-# requires the same inflection for both April and June, so just "between"
-# is used by DateDisplayRU.display, collapsing two more modifiers into 1.
-#
-# If inflect is not specified, then it means that the modifier doesn't have
-# grammatical control over the format, and so the format can be
-# localized in a context-free way.
-# The translator is responsible for:
-# 1) proper collapse of modifier classes
-# 2) translating the formats that are selected in runtime
-# 3) ignoring the other formats in .po (it does no harm to translate them,
-# it's just a lot of extra work)
-#
-# To prevent POT pollution, not all possibilities are populated here yet.
-# To be amended as the actual localized handlers use it.
-#
-# Not moving to DateStrings, as this is part of display code only,
-# coupled tightly with the formats used in this file.
-                ""
-                : _("{long_month} {year}"),
-
-                "from"
-                # first date in a span
-                # Translators: If "from <Month>" needs a special inflection
-                # in your language, translate to "{long_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{long_month} {year}", "from"),
-
-                "to"
-                # second date in a span
-                # Translators: If "to <Month>" needs a special inflection
-                # in your language, translate to "{long_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{long_month} {year}", "to"),
-
-                "between"
-                # first date in a range
-                # Translators: If "between <Month>" needs a special inflection
-                # in your language, translate to "{long_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{long_month} {year}", "between"),
-
-                "and"
-                # second date in a range
-                # Translators: If "and <Month>" needs a special inflection
-                # in your language, translate to "{long_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{long_month} {year}", "and"),
-
-                "before"
-                # Translators: If "before <Month>" needs a special inflection
-                # in your language, translate to "{long_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{long_month} {year}", "before"),
-
-                "after"
-                # Translators: If "after <Month>" needs a special inflection
-                # in your language, translate to "{long_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{long_month} {year}", "after"),
-
-                "about"
-                # Translators: If "about <Month>" needs a special inflection
-                # in your language, translate to "{long_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{long_month} {year}", "about"),
-
-                "estimated"
-                # Translators: If "estimated <Month>" needs a special inflection
-                # in your language, translate to "{long_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{long_month} {year}", "estimated"),
-
-                "calculated"
-                # Translators: If "calculated <Month>" needs a special inflection
-                # in your language, translate to "{long_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{long_month} {year}", "calculated"),
+            # Inflection control due to modifier.
+            # Protocol: DateDisplayXX passes a key to the dictionary in the
+            # parameter ``inflect`` to ``_display_calendar``.
+            # The modifier passed is not necessarily the one printed, it's just
+            # a representative that induces the same inflection control.
+            # For example, in Russian "before May", "after May", and "about May"
+            # all require genitive form for May, whereas no modifier (just "May 1234")
+            # require nominative, so DateDisplayRU.display will pass "before"
+            # in all 3 cases, collapsing the 3 modifiers into 1.
+            #
+            # Another example in Russian is that "between April 1234 and June 1235"
+            # requires the same inflection for both April and June, so just "between"
+            # is used by DateDisplayRU.display, collapsing two more modifiers into 1.
+            #
+            # If inflect is not specified, then it means that the modifier doesn't have
+            # grammatical control over the format, and so the format can be
+            # localized in a context-free way.
+            # The translator is responsible for:
+            # 1) proper collapse of modifier classes
+            # 2) translating the formats that are selected in runtime
+            # 3) ignoring the other formats in .po (it does no harm to translate them,
+            # it's just a lot of extra work)
+            #
+            # To prevent POT pollution, not all possibilities are populated here yet.
+            # To be amended as the actual localized handlers use it.
+            #
+            # Not moving to DateStrings, as this is part of display code only,
+            # coupled tightly with the formats used in this file.
+            "": _("{long_month} {year}"),
+            "from"
+            # first date in a span
+            # Translators: If "from <Month>" needs a special inflection
+            # in your language, translate to "{long_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{long_month} {year}", "from"),
+            "to"
+            # second date in a span
+            # Translators: If "to <Month>" needs a special inflection
+            # in your language, translate to "{long_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{long_month} {year}", "to"),
+            "between"
+            # first date in a range
+            # Translators: If "between <Month>" needs a special inflection
+            # in your language, translate to "{long_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{long_month} {year}", "between"),
+            "and"
+            # second date in a range
+            # Translators: If "and <Month>" needs a special inflection
+            # in your language, translate to "{long_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{long_month} {year}", "and"),
+            "before"
+            # Translators: If "before <Month>" needs a special inflection
+            # in your language, translate to "{long_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{long_month} {year}", "before"),
+            "after"
+            # Translators: If "after <Month>" needs a special inflection
+            # in your language, translate to "{long_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{long_month} {year}", "after"),
+            "about"
+            # Translators: If "about <Month>" needs a special inflection
+            # in your language, translate to "{long_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{long_month} {year}", "about"),
+            "estimated"
+            # Translators: If "estimated <Month>" needs a special inflection
+            # in your language, translate to "{long_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{long_month} {year}", "estimated"),
+            "calculated"
+            # Translators: If "calculated <Month>" needs a special inflection
+            # in your language, translate to "{long_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{long_month} {year}", "calculated"),
         }
 
         self.FORMATS_short_month_year = {
-                ""
-                : _("{short_month} {year}"),
-
-                "from"
-                # first date in a span
-                # Translators: If "from <Month>" needs a special inflection
-                # in your language, translate to "{short_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{short_month} {year}", "from"),
-
-                "to"
-                # second date in a span
-                # Translators: If "to <Month>" needs a special inflection
-                # in your language, translate to "{short_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{short_month} {year}", "to"),
-
-                "between"
-                # first date in a range
-                # Translators: If "between <Month>" needs a special inflection
-                # in your language, translate to "{short_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{short_month} {year}", "between"),
-
-                "and"
-                # second date in a range
-                # Translators: If "and <Month>" needs a special inflection
-                # in your language, translate to "{short_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{short_month} {year}", "and"),
-
-                "before"
-                # Translators: If "before <Month>" needs a special inflection
-                # in your language, translate to "{short_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{short_month} {year}", "before"),
-
-                "after"
-                # Translators: If "after <Month>" needs a special inflection
-                # in your language, translate to "{short_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{short_month} {year}", "after"),
-
-                "about"
-                # Translators: If "about <Month>" needs a special inflection
-                # in your language, translate to "{short_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{short_month} {year}", "about"),
-
-                "estimated"
-                # Translators: If "estimated <Month>" needs a special inflection
-                # in your language, translate to "{short_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{short_month} {year}", "estimated"),
-
-                "calculated"
-                # Translators: If "calculated <Month>" needs a special inflection
-                # in your language, translate to "{short_month.f[X]} {year}"
-                # (where X is one of the month-name inflections you defined)
-                # else leave it untranslated
-                : _("{short_month} {year}", "calculated"),
+            "": _("{short_month} {year}"),
+            "from"
+            # first date in a span
+            # Translators: If "from <Month>" needs a special inflection
+            # in your language, translate to "{short_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{short_month} {year}", "from"),
+            "to"
+            # second date in a span
+            # Translators: If "to <Month>" needs a special inflection
+            # in your language, translate to "{short_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{short_month} {year}", "to"),
+            "between"
+            # first date in a range
+            # Translators: If "between <Month>" needs a special inflection
+            # in your language, translate to "{short_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{short_month} {year}", "between"),
+            "and"
+            # second date in a range
+            # Translators: If "and <Month>" needs a special inflection
+            # in your language, translate to "{short_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{short_month} {year}", "and"),
+            "before"
+            # Translators: If "before <Month>" needs a special inflection
+            # in your language, translate to "{short_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{short_month} {year}", "before"),
+            "after"
+            # Translators: If "after <Month>" needs a special inflection
+            # in your language, translate to "{short_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{short_month} {year}", "after"),
+            "about"
+            # Translators: If "about <Month>" needs a special inflection
+            # in your language, translate to "{short_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{short_month} {year}", "about"),
+            "estimated"
+            # Translators: If "estimated <Month>" needs a special inflection
+            # in your language, translate to "{short_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{short_month} {year}", "estimated"),
+            "calculated"
+            # Translators: If "calculated <Month>" needs a special inflection
+            # in your language, translate to "{short_month.f[X]} {year}"
+            # (where X is one of the month-name inflections you defined)
+            # else leave it untranslated
+            : _("{short_month} {year}", "calculated"),
         }
 
     def formats_changed(self):
-        """ Allow overriding so a subclass can modify """
+        """Allow overriding so a subclass can modify"""
         pass
 
     def set_format(self, format):
@@ -386,15 +365,15 @@ class DateDisplay:
 
     def _slash_year(self, val, slash):
         if val < 0:
-            val = - val
+            val = -val
 
         if slash:
-            if (val-1) % 100 == 99:
-                year = "%d/%d" % (val - 1, (val%1000))
-            elif (val-1) % 10 == 9:
-                year = "%d/%d" % (val - 1, (val%100))
+            if (val - 1) % 100 == 99:
+                year = "%d/%d" % (val - 1, (val % 1000))
+            elif (val - 1) % 10 == 9:
+                year = "%d/%d" % (val - 1, (val % 100))
             else:
-                year = "%d/%d" % (val - 1, (val%10))
+                year = "%d/%d" % (val - 1, (val % 10))
         else:
             year = "%d" % (val)
 
@@ -425,22 +404,28 @@ class DateDisplay:
         cal = date.get_calendar()
         qual_str = self._qual_str[date.get_quality()]
         scal = self.format_extras(cal, date.get_new_year())
-        d1 = self.display_cal[cal](date.get_start_date(),
+        d1 = self.display_cal[cal](
+            date.get_start_date(),
             # Translators: If there is no special inflection for
             # "from <Month>" in your language, DON'T translate this.
             # Otherwise, translate to "from" in ENGLISH!!! ENGLISH!!!
-                                   inflect=self._("", "from-date"))
-        d2 = self.display_cal[cal](date.get_stop_date(),
+            inflect=self._("", "from-date"),
+        )
+        d2 = self.display_cal[cal](
+            date.get_stop_date(),
             # Translators: If there is no special inflection for
             # "to <Month>" in your language, DON'T translate this.
             # Otherwise, translate to "to" in ENGLISH!!! ENGLISH!!!
-                                   inflect=self._("", "to-date"))
-        return self._("{date_quality}from {date_start} to {date_stop}"
-                      "{nonstd_calendar_and_ny}").format(
-                            date_quality=qual_str,
-                            date_start=d1,
-                            date_stop=d2,
-                            nonstd_calendar_and_ny=scal)
+            inflect=self._("", "to-date"),
+        )
+        return self._(
+            "{date_quality}from {date_start} to {date_stop}" "{nonstd_calendar_and_ny}"
+        ).format(
+            date_quality=qual_str,
+            date_start=d1,
+            date_stop=d2,
+            nonstd_calendar_and_ny=scal,
+        )
 
     def dd_range(self, date):
         """
@@ -450,22 +435,29 @@ class DateDisplay:
         cal = date.get_calendar()
         qual_str = self._qual_str[date.get_quality()]
         scal = self.format_extras(cal, date.get_new_year())
-        d1 = self.display_cal[cal](date.get_start_date(),
+        d1 = self.display_cal[cal](
+            date.get_start_date(),
             # Translators: If there is no special inflection for
             # "between <Month>" in your language, DON'T translate this.
             # Otherwise, translate to "between" in ENGLISH!!! ENGLISH!!!
-                                   inflect=self._("", "between-date"))
-        d2 = self.display_cal[cal](date.get_stop_date(),
+            inflect=self._("", "between-date"),
+        )
+        d2 = self.display_cal[cal](
+            date.get_stop_date(),
             # Translators: If there is no special inflection for
             # "and <Month>" in your language, DON'T translate this.
             # Otherwise, translate to "and" in ENGLISH!!! ENGLISH!!!
-                                   inflect=self._("", "and-date"))
-        return self._("{date_quality}between {date_start} and {date_stop}"
-                      "{nonstd_calendar_and_ny}").format(
-                            date_quality=qual_str,
-                            date_start=d1,
-                            date_stop=d2,
-                            nonstd_calendar_and_ny=scal)
+            inflect=self._("", "and-date"),
+        )
+        return self._(
+            "{date_quality}between {date_start} and {date_stop}"
+            "{nonstd_calendar_and_ny}"
+        ).format(
+            date_quality=qual_str,
+            date_start=d1,
+            date_stop=d2,
+            nonstd_calendar_and_ny=scal,
+        )
 
     def display_formatted(self, date):
         """
@@ -499,6 +491,16 @@ class DateDisplay:
                 # "after <Month>" in your language, DON'T translate this.
                 # Otherwise, translate to "after" in ENGLISH!!! ENGLISH!!!
                 date_type = _("", "after-date")
+            elif mod == Date.MOD_FROM:
+                # Translators: If there is no special inflection for
+                # "after <Month>" in your language, DON'T translate this.
+                # Otherwise, translate to "after" in ENGLISH!!! ENGLISH!!!
+                date_type = _("", "from-date")
+            elif mod == Date.MOD_TO:
+                # Translators: If there is no special inflection for
+                # "after <Month>" in your language, DON'T translate this.
+                # Otherwise, translate to "after" in ENGLISH!!! ENGLISH!!!
+                date_type = _("", "to-date")
             elif mod == Date.MOD_ABOUT:
                 # Translators: If there is no special inflection for
                 # "about <Month>" in your language, DON'T translate this.
@@ -528,70 +530,89 @@ class DateDisplay:
             modifier = self._mod_str[mod]
             # some languages have a modifier after the date (e.g. Finnish)
             # (if so, they are specified in DateParser.modifier_after_to_int)
-            if modifier.startswith(' '):
+            if modifier.startswith(" "):
                 text += modifier
-                modifier = ''
+                modifier = ""
             scal = self.format_extras(cal, newyear)
-            return _("{date_quality}{noncompound_modifier}{date}"
-                     "{nonstd_calendar_and_ny}").format(
-                         date_quality=qual_str,
-                         noncompound_modifier=modifier,
-                         date=text,
-                         nonstd_calendar_and_ny=scal)
+            return _(
+                "{date_quality}{noncompound_modifier}{date}" "{nonstd_calendar_and_ny}"
+            ).format(
+                date_quality=qual_str,
+                noncompound_modifier=modifier,
+                date=text,
+                nonstd_calendar_and_ny=scal,
+            )
 
     def _display_gregorian(self, date_val, **kwargs):
-        return self._display_calendar(date_val, self.long_months,
-                self.short_months, **kwargs)
+        return self._display_calendar(
+            date_val, self.long_months, self.short_months, **kwargs
+        )
 
     # Julian and Swedish date display is the same as Gregorian
     _display_julian = _display_swedish = _display_gregorian
 
     def format_long_month_year(self, month, year, inflect, long_months):
-        if not hasattr(long_months[1], 'f'): # not a Lexeme: no inflection
+        if not hasattr(long_months[1], "f"):  # not a Lexeme: no inflection
             return "{long_month} {year}".format(
-                     long_month = long_months[month], year = year)
+                long_month=long_months[month], year=year
+            )
         return self.FORMATS_long_month_year[inflect].format(
-                     long_month = long_months[month], year = year)
+            long_month=long_months[month], year=year
+        )
 
     def format_short_month_year(self, month, year, inflect, short_months):
-        if not hasattr(short_months[1], 'f'): # not a Lexeme: no inflection
+        if not hasattr(short_months[1], "f"):  # not a Lexeme: no inflection
             return "{short_month} {year}".format(
-                     short_month = short_months[month], year = year)
+                short_month=short_months[month], year=year
+            )
         return self.FORMATS_short_month_year[inflect].format(
-                     short_month = short_months[month], year = year)
+            short_month=short_months[month], year=year
+        )
 
     def format_long_month(self, month, inflect, long_months):
-        if not hasattr(long_months[1], 'f'): # not a Lexeme: no inflection
-            return "{long_month}".format(long_month = long_months[month])
-        return self.FORMATS_long_month_year[inflect].format(
-                     long_month = long_months[month], year = '').rstrip()
+        if not hasattr(long_months[1], "f"):  # not a Lexeme: no inflection
+            return "{long_month}".format(long_month=long_months[month])
+        return (
+            self.FORMATS_long_month_year[inflect]
+            .format(long_month=long_months[month], year="")
+            .rstrip()
+        )
 
     def format_short_month(self, month, inflect, short_months):
-        if not hasattr(short_months[1], 'f'): # not a Lexeme: no inflection
-            return "{short_month}".format(short_month = short_months[month])
-        return self.FORMATS_short_month_year[inflect].format(
-                     short_month = short_months[month], year = '').rstrip()
+        if not hasattr(short_months[1], "f"):  # not a Lexeme: no inflection
+            return "{short_month}".format(short_month=short_months[month])
+        return (
+            self.FORMATS_short_month_year[inflect]
+            .format(short_month=short_months[month], year="")
+            .rstrip()
+        )
 
     def _get_short_weekday(self, date_val):
-        if (date_val[0] == 0 or date_val[1] == 0 # no day or no month or both
-                or date_val[1] == 13 # Hebrew has 13 months
-                or date_val[2] > datetime.MAXYEAR # bug 10815
-                or date_val[2] < 0): # B.C.E. date
-            return ''
-        w_day = datetime.date(date_val[2], date_val[1], date_val[0]) # y, m, d
+        if (
+            date_val[0] == 0
+            or date_val[1] == 0  # no day or no month or both
+            or date_val[1] == 13  # Hebrew has 13 months
+            or date_val[2] > datetime.MAXYEAR  # bug 10815
+            or date_val[2] < 0
+        ):  # B.C.E. date
+            return ""
+        w_day = datetime.date(date_val[2], date_val[1], date_val[0])  # y, m, d
         return self.short_days[((w_day.weekday() + 1) % 7) + 1]
 
     def _get_long_weekday(self, date_val):
-        if (date_val[0] == 0 or date_val[1] == 0 # no day or no month or both
-                or date_val[1] == 13 # Hebrew has 13 months
-                or date_val[2] > datetime.MAXYEAR # bug 10815
-                or date_val[2] < 0): # B.C.E. date
-            return ''
-        w_day = datetime.date(date_val[2], date_val[1], date_val[0]) # y, m, d
+        if (
+            date_val[0] == 0
+            or date_val[1] == 0  # no day or no month or both
+            or date_val[1] == 13  # Hebrew has 13 months
+            or date_val[2] > datetime.MAXYEAR  # bug 10815
+            or date_val[2] < 0
+        ):  # B.C.E. date
+            return ""
+        w_day = datetime.date(date_val[2], date_val[1], date_val[0])  # y, m, d
         return self.long_days[((w_day.weekday() + 1) % 7) + 1]
 
     def _get_localized_year(self, year):
-        """ Allow a subclass to modify the year, e.g. add a period """
+        """Allow a subclass to modify the year, e.g. add a period"""
         return year
 
     def dd_dformat01(self, date_val):
@@ -607,30 +628,28 @@ class DateDisplay:
             if date_val[0] == date_val[1] == 0:
                 return self._get_localized_year(str(date_val[2]))
             else:
-                value = self.dhformat.replace('%m', str(date_val[1]))
-                if '%b' in value or '%B' in value:
+                value = self.dhformat.replace("%m", str(date_val[1]))
+                if "%b" in value or "%B" in value:
                     # some locales have %b for the month (ar_EG, is_IS, nb_NO)
                     # so it would be "Jan" but as it's "numeric" make it "1"
-                    value = value.replace('%b', str(date_val[1]))
+                    value = value.replace("%b", str(date_val[1]))
                     # some locales have %B for the month, e.g. ta_IN
                     # so it would be "January" but as it's "numeric" make it 1
-                    value = value.replace('%B', str(date_val[1]))
-                if '%a' in value or '%A' in value:
+                    value = value.replace("%B", str(date_val[1]))
+                if "%a" in value or "%A" in value:
                     # some locales have %a for the abbreviated day, e.g. is_IS
-                    value = value.replace('%a',
-                                          self._get_short_weekday(date_val))
+                    value = value.replace("%a", self._get_short_weekday(date_val))
                     # some locales have %A for the long/full day, e.g. ta_IN
-                    value = value.replace('%A',
-                                          self._get_long_weekday(date_val))
-                if date_val[0] == 0: # ignore the zero day and its delimiter
-                    i_day = value.find('%d')
-                    if len(value) == i_day + 2: # delimiter is left of the day
-                        value = value.replace(value[i_day-1:i_day+2], '')
-                    else: # delimiter is to the right of the day
-                        value = value.replace(value[i_day:i_day+3], '')
-                value = value.replace('%d', str(date_val[0]))
-                value = value.replace('%Y', str(abs(date_val[2])))
-                return value.replace('-', '/')
+                    value = value.replace("%A", self._get_long_weekday(date_val))
+                if date_val[0] == 0:  # ignore the zero day and its delimiter
+                    i_day = value.find("%d")
+                    if len(value) == i_day + 2:  # delimiter is left of the day
+                        value = value.replace(value[i_day - 1 : i_day + 2], "")
+                    else:  # delimiter is to the right of the day
+                        value = value.replace(value[i_day : i_day + 3], "")
+                value = value.replace("%d", str(date_val[0]))
+                value = value.replace("%Y", str(abs(date_val[2])))
+                return value.replace("-", "/")
 
     def dd_dformat02(self, date_val, inflect, long_months):
         """
@@ -645,18 +664,18 @@ class DateDisplay:
             if date_val[1] == 0:
                 return self._get_localized_year(year)
             else:
-                return self.format_long_month_year(date_val[1], year,
-                                                   inflect, long_months)
-        elif date_val[1] == 0: # month is zero but day is not (see 8477)
+                return self.format_long_month_year(
+                    date_val[1], year, inflect, long_months
+                )
+        elif date_val[1] == 0:  # month is zero but day is not (see 8477)
             return self.display_iso(date_val)
         else:
             # Translators: this month is ALREADY inflected: ignore it
             return _("{long_month} {day:d}, {year}").format(
-                       long_month = self.format_long_month(date_val[1],
-                                                           inflect,
-                                                           long_months),
-                       day = date_val[0],
-                       year = year)
+                long_month=self.format_long_month(date_val[1], inflect, long_months),
+                day=date_val[0],
+                year=year,
+            )
 
     def dd_dformat03(self, date_val, inflect, short_months):
         """
@@ -671,18 +690,18 @@ class DateDisplay:
             if date_val[1] == 0:
                 return self._get_localized_year(year)
             else:
-                return self.format_short_month_year(date_val[1], year,
-                                                    inflect, short_months)
-        elif date_val[1] == 0: # month is zero but day is not (see 8477)
+                return self.format_short_month_year(
+                    date_val[1], year, inflect, short_months
+                )
+        elif date_val[1] == 0:  # month is zero but day is not (see 8477)
             return self.display_iso(date_val)
         else:
             # Translators: this month is ALREADY inflected: ignore it
             return _("{short_month} {day:d}, {year}").format(
-                       short_month = self.format_short_month(date_val[1],
-                                                             inflect,
-                                                             short_months),
-                       day = date_val[0],
-                       year = year)
+                short_month=self.format_short_month(date_val[1], inflect, short_months),
+                day=date_val[0],
+                year=year,
+            )
 
     def dd_dformat04(self, date_val, inflect, long_months):
         """
@@ -697,18 +716,18 @@ class DateDisplay:
             if date_val[1] == 0:
                 return self._get_localized_year(year)
             else:
-                return self.format_long_month_year(date_val[1], year,
-                                                   inflect, long_months)
-        elif date_val[1] == 0: # month is zero but day is not (see 8477)
+                return self.format_long_month_year(
+                    date_val[1], year, inflect, long_months
+                )
+        elif date_val[1] == 0:  # month is zero but day is not (see 8477)
             return self.display_iso(date_val)
         else:
             # Translators: this month is ALREADY inflected: ignore it
             return _("{day:d} {long_month} {year}").format(
-                       day = date_val[0],
-                       long_month = self.format_long_month(date_val[1],
-                                                           inflect,
-                                                           long_months),
-                       year = year)
+                day=date_val[0],
+                long_month=self.format_long_month(date_val[1], inflect, long_months),
+                year=year,
+            )
 
     def dd_dformat05(self, date_val, inflect, short_months):
         """
@@ -723,21 +742,20 @@ class DateDisplay:
             if date_val[1] == 0:
                 return self._get_localized_year(year)
             else:
-                return self.format_short_month_year(date_val[1], year,
-                                                    inflect, short_months)
-        elif date_val[1] == 0: # month is zero but day is not (see 8477)
+                return self.format_short_month_year(
+                    date_val[1], year, inflect, short_months
+                )
+        elif date_val[1] == 0:  # month is zero but day is not (see 8477)
             return self.display_iso(date_val)
         else:
             # Translators: this month is ALREADY inflected: ignore it
             return _("{day:d} {short_month} {year}").format(
-                       day = date_val[0],
-                       short_month = self.format_short_month(date_val[1],
-                                                             inflect,
-                                                             short_months),
-                       year = year)
+                day=date_val[0],
+                short_month=self.format_short_month(date_val[1], inflect, short_months),
+                year=year,
+            )
 
-    def _display_calendar(self, date_val, long_months, short_months = None,
-                          inflect=""):
+    def _display_calendar(self, date_val, long_months, short_months=None, inflect=""):
         """
         this must agree with DateDisplayEn's "formats" definition
         (it may be overridden if a locale-specific date displayer exists)
@@ -772,7 +790,6 @@ class DateDisplay:
         else:
             return value
 
-
     def _display_french(self, date_val, **kwargs):
         return self._display_calendar(date_val, self.french, **kwargs)
 
@@ -785,14 +802,18 @@ class DateDisplay:
     def _display_islamic(self, date_val, **kwargs):
         return self._display_calendar(date_val, self.islamic, **kwargs)
 
+
 class DateDisplayEn(DateDisplay):
     """
     English language date display class.
     """
+
     display = DateDisplay.display_formatted
+
 
 class DateDisplayGB(DateDisplay):
     """
     British-English language date display class (its format is different).
     """
+
     display = DateDisplay.display_formatted

--- a/gramps/gen/datehandler/_dateparser.py
+++ b/gramps/gen/datehandler/_dateparser.py
@@ -26,42 +26,44 @@ Date parsing class. Serves as the base class for any localized
 date parsing class. The default base class provides parsing for English.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 import calendar
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # set up logging
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import logging
+
 log = logging.getLogger(".DateParser")
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ..lib.date import Date, DateError, Today
 from ..const import GRAMPS_LOCALE as glocale
 from ..utils.grampslocale import GrampsLocale
 from ._datestrings import DateStrings
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Top-level module functions
 #
-#-------------------------------------------------------------------------
-_max_days = [ 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 ]
-_leap_days = [ 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 ]
+# -------------------------------------------------------------------------
+_max_days = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+_leap_days = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
 
 def gregorian_valid(date_tuple):
-    """ Checks if date_tuple is a valid date in Gregorian Calendar  """
+    """Checks if date_tuple is a valid date in Gregorian Calendar"""
     day = date_tuple[0]
     month = date_tuple[1]
     valid = True
@@ -69,16 +71,17 @@ def gregorian_valid(date_tuple):
         if month > 12:
             valid = False
         elif calendar.isleap(date_tuple[2]):
-            if day > _leap_days[month-1]:
+            if day > _leap_days[month - 1]:
                 valid = False
-        elif day > _max_days[month-1]:
+        elif day > _max_days[month - 1]:
             valid = False
     except:
         valid = False
     return valid
 
+
 def julian_valid(date_tuple):
-    """ Checks if date_tuple is a valid date in Julian Calendar """
+    """Checks if date_tuple is a valid date in Julian Calendar"""
     day = date_tuple[0]
     month = date_tuple[1]
     valid = True
@@ -87,20 +90,21 @@ def julian_valid(date_tuple):
             valid = False
         elif (date_tuple[2]) % 4 == 0:
             # julian always have leapyear every 4 year
-            if day > _leap_days[month-1]:
+            if day > _leap_days[month - 1]:
                 valid = False
-        elif day > _max_days[month-1]:
+        elif day > _max_days[month - 1]:
             valid = False
     except:
         valid = False
     return valid
 
+
 def swedish_valid(date_tuple):
-    """ Checks if date_tuple is a valid date in Swedish Calendar """
+    """Checks if date_tuple is a valid date in Swedish Calendar"""
     valid_J = julian_valid(date_tuple)
     date_tuple = (date_tuple[2], date_tuple[1], date_tuple[0])
     # Swedish calendar starts as Julian 1700-03-01 and ends 1712-03-01 as Julian
-    if date_tuple >= (1700, 2, 29) and  date_tuple < (1712, 3, 1):
+    if date_tuple >= (1700, 2, 29) and date_tuple < (1712, 3, 1):
         if date_tuple == (1712, 2, 30):  # extra day was inserted 1712, not valid Julian
             return True
         if valid_J:
@@ -112,13 +116,15 @@ def swedish_valid(date_tuple):
     else:
         return False
 
+
 def french_valid(date_tuple):
-    """ Checks if date_tuple is a valid date in French Calendar """
+    """Checks if date_tuple is a valid date in French Calendar"""
     valid = True
     # year 1 starts on 22.9.1792
     if date_tuple[2] < 1:
         valid = False
     return valid
+
 
 def _build_prefix_table(month_to_int, month_variants):
     """
@@ -126,12 +132,12 @@ def _build_prefix_table(month_to_int, month_variants):
     with all the prefixes found in month_variants.
     """
 
-    month_variants = list(month_variants) # drain the generator, if any
+    month_variants = list(month_variants)  # drain the generator, if any
     month_to_int_new = {}
 
     # Populate with full names first, w/o prefixes
     log.debug("Mapping full names...")
-    for i in range(0,len(month_variants)):
+    for i in range(0, len(month_variants)):
         for month in month_variants[i]:
             m = month.lower()
             log.debug("Mapping {} -> {}".format(m, i))
@@ -142,7 +148,7 @@ def _build_prefix_table(month_to_int, month_variants):
     months_sorted = list(month_to_int_new.keys())
     months_sorted.sort(key=len, reverse=True)
     for m in months_sorted:
-        for prefixlen in reversed(range(1,len(m))):
+        for prefixlen in reversed(range(1, len(m))):
             mp = m[:prefixlen]
             if mp.strip() != mp:
                 continue
@@ -152,6 +158,7 @@ def _build_prefix_table(month_to_int, month_variants):
                 i = month_to_int[m]
                 log.debug("Mapping {} -> {}".format(mp, i))
                 month_to_int[mp] = i
+
 
 def _generate_variants(months):
     """
@@ -179,15 +186,16 @@ def _generate_variants(months):
                 # plain string, not a lexeme with inflections...
                 # Maybe a '|'-separated list of alternatives, maybe empty,
                 # maybe a single string. Suppress empty strings!
-                mv = (s for s in m.split('|') if s)
+                mv = (s for s in m.split("|") if s)
             v.extend(mv)
-        yield(list(set(v)))
+        yield (list(set(v)))
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # DateParser class
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateParser:
     """
     Convert a text string into a :class:`.Date` object. If the date cannot be
@@ -197,12 +205,21 @@ class DateParser:
     _dhformat_parse = re.compile(r".*%(\S).*%(\S).*%(\S).*")
 
     # RFC-2822 only uses capitalized English abbreviated names, no locales.
-    _rfc_days = ('Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat')
+    _rfc_days = ("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")
     _rfc_mons_to_int = {
-        'Jan' : 1,  'Feb' : 2,  'Mar' : 3,  'Apr' : 4,
-        'May' : 5,  'Jun' : 6,  'Jul' : 7,  'Aug' : 8,
-        'Sep' : 9,  'Oct' : 10, 'Nov' : 11, 'Dec' : 12,
-        }
+        "Jan": 1,
+        "Feb": 2,
+        "Mar": 3,
+        "Apr": 4,
+        "May": 5,
+        "Jun": 6,
+        "Jul": 7,
+        "Aug": 8,
+        "Sep": 9,
+        "Oct": 10,
+        "Nov": 11,
+        "Dec": 12,
+    }
 
     # seeded with __init_prefix_tables
     swedish_to_int = month_to_int = {}
@@ -214,99 +231,150 @@ class DateParser:
     # modifiers before the date
     # (overridden if a locale-specific date parser exists)
     modifier_to_int = {
-        'before' : Date.MOD_BEFORE, 'bef'    : Date.MOD_BEFORE,
-        'bef.'   : Date.MOD_BEFORE, 'after'  : Date.MOD_AFTER,
-        'aft'    : Date.MOD_AFTER,  'aft.'   : Date.MOD_AFTER,
-        'about'  : Date.MOD_ABOUT,  'abt.'   : Date.MOD_ABOUT,
-        'abt'    : Date.MOD_ABOUT,  'circa'  : Date.MOD_ABOUT,
-        'c.'     : Date.MOD_ABOUT,  'around' : Date.MOD_ABOUT,
-        }
+        "before": Date.MOD_BEFORE,
+        "bef": Date.MOD_BEFORE,
+        "bef.": Date.MOD_BEFORE,
+        "after": Date.MOD_AFTER,
+        "aft": Date.MOD_AFTER,
+        "aft.": Date.MOD_AFTER,
+        "about": Date.MOD_ABOUT,
+        "abt.": Date.MOD_ABOUT,
+        "abt": Date.MOD_ABOUT,
+        "circa": Date.MOD_ABOUT,
+        "c.": Date.MOD_ABOUT,
+        "around": Date.MOD_ABOUT,
+        "from": Date.MOD_FROM,
+        "to": Date.MOD_TO,
+    }
     # in some languages some of above listed modifiers are after the date,
     # in that case the subclass should put them into this dictionary instead
     modifier_after_to_int = {}
 
     hebrew_to_int = {
-        "tishri"  : 1,   "heshvan" : 2,   "kislev"  : 3,
-        "tevet"   : 4,   "shevat"  : 5,   "adari"   : 6,
-        "adarii"  : 7,   "nisan"   : 8,   "iyyar"   : 9,
-        "sivan"   : 10,  "tammuz"  : 11,  "av"      : 12,
-        "elul"    : 13,
-        #alternative spelling
-        "cheshvan": 2,   "adar sheni":  7, "iyar"    : 9,
-        #GEDCOM months
-        "tsh" : 1, "csh": 5, "ksl": 3, "tvt": 4, "shv": 5, "adr": 6,
-        "ads" : 7, "nsn": 8, "iyr": 9, "svn":10, "tmz":11, "aav":12,
-        "ell":13,
-        }
+        "tishri": 1,
+        "heshvan": 2,
+        "kislev": 3,
+        "tevet": 4,
+        "shevat": 5,
+        "adari": 6,
+        "adarii": 7,
+        "nisan": 8,
+        "iyyar": 9,
+        "sivan": 10,
+        "tammuz": 11,
+        "av": 12,
+        "elul": 13,
+        # alternative spelling
+        "cheshvan": 2,
+        "adar sheni": 7,
+        "iyar": 9,
+        # GEDCOM months
+        "tsh": 1,
+        "csh": 5,
+        "ksl": 3,
+        "tvt": 4,
+        "shv": 5,
+        "adr": 6,
+        "ads": 7,
+        "nsn": 8,
+        "iyr": 9,
+        "svn": 10,
+        "tmz": 11,
+        "aav": 12,
+        "ell": 13,
+    }
 
     french_to_int = {
-# the long ones are seeded with __init_prefix_tables
-        #GEDCOM months
-        'vend'    : 1,    'brum' : 2,
-        'frim'    : 3,    'nivo' : 4,
-        'pluv'    : 5,    'vent' : 6,
-        'germ'    : 7,    'flor' : 8,
-        'prai'    : 9,    'mess' : 10,
-        'ther'    : 11,   'fruc' : 12,
-        'comp'    : 13,
-        }
+        # the long ones are seeded with __init_prefix_tables
+        # GEDCOM months
+        "vend": 1,
+        "brum": 2,
+        "frim": 3,
+        "nivo": 4,
+        "pluv": 5,
+        "vent": 6,
+        "germ": 7,
+        "flor": 8,
+        "prai": 9,
+        "mess": 10,
+        "ther": 11,
+        "fruc": 12,
+        "comp": 13,
+    }
 
     islamic_to_int = {
-# some are already seeded with __init_prefix_tables,
-# but it is a pain to separate them out from the variants...
-        "muharram"           : 1,  "muharram ul haram"  : 1,
-        "safar"              : 2,  "rabi`al-awwal"      : 3,
-        "rabi'l"             : 3,  "rabi`ul-akhir"      : 4,
-        "rabi`ath-thani"     : 4,  "rabi` ath-thani"    : 4,
-        "rabi`al-thaany"     : 4,  "rabi` al-thaany"    : 4,
-        "rabi' ii"           : 4,  "jumada l-ula"       : 5,
-        "jumaada-ul-awwal"   : 5,  "jumaada i"          : 5,
-        "jumada t-tania"     : 6,  "jumaada-ul-akhir"   : 6,
-        "jumaada al-thaany"  : 6,  "jumaada ii"         : 5,
-        "rajab"              : 7,  "sha`ban"            : 8,
-        "sha`aban"           : 8,  "ramadan"            : 9,
-        "ramadhan"           : 9,  "shawwal"            : 10,
-        "dhu l-qa`da"        : 11, "dhu qadah"          : 11,
-        "thw al-qi`dah"      : 11, "dhu l-hijja"        : 12,
-        "dhu hijja"          : 12, "thw al-hijjah"      : 12,
-        }
+        # some are already seeded with __init_prefix_tables,
+        # but it is a pain to separate them out from the variants...
+        "muharram": 1,
+        "muharram ul haram": 1,
+        "safar": 2,
+        "rabi`al-awwal": 3,
+        "rabi'l": 3,
+        "rabi`ul-akhir": 4,
+        "rabi`ath-thani": 4,
+        "rabi` ath-thani": 4,
+        "rabi`al-thaany": 4,
+        "rabi` al-thaany": 4,
+        "rabi' ii": 4,
+        "jumada l-ula": 5,
+        "jumaada-ul-awwal": 5,
+        "jumaada i": 5,
+        "jumada t-tania": 6,
+        "jumaada-ul-akhir": 6,
+        "jumaada al-thaany": 6,
+        "jumaada ii": 5,
+        "rajab": 7,
+        "sha`ban": 8,
+        "sha`aban": 8,
+        "ramadan": 9,
+        "ramadhan": 9,
+        "shawwal": 10,
+        "dhu l-qa`da": 11,
+        "dhu qadah": 11,
+        "thw al-qi`dah": 11,
+        "dhu l-hijja": 12,
+        "dhu hijja": 12,
+        "thw al-hijjah": 12,
+    }
 
     # seeded with __init_prefix_tables
-    persian_to_int = { }
+    persian_to_int = {}
 
-    bce = ["B.C.E.", "B.C.E", "BCE", "B.C.", "B.C", "BC" ]
+    bce = ["B.C.E.", "B.C.E", "BCE", "B.C.", "B.C", "BC"]
     # (overridden if a locale-specific date parser exists)
 
     # seeded with __init_prefix_tables
-    calendar_to_int = {
-        }
-        # (probably overridden if a locale-specific date parser exists)
+    calendar_to_int = {}
+    # (probably overridden if a locale-specific date parser exists)
 
     newyear_to_int = {
-        "jan1":  Date.NEWYEAR_JAN1,
-        "mar1":  Date.NEWYEAR_MAR1,
+        "jan1": Date.NEWYEAR_JAN1,
+        "mar1": Date.NEWYEAR_MAR1,
         "mar25": Date.NEWYEAR_MAR25,
-        "sep1" : Date.NEWYEAR_SEP1,
-        }
+        "sep1": Date.NEWYEAR_SEP1,
+    }
 
     quality_to_int = {
-        'estimated'  : Date.QUAL_ESTIMATED,
-        'est.'       : Date.QUAL_ESTIMATED,
-        'est'        : Date.QUAL_ESTIMATED,
-        'calc.'      : Date.QUAL_CALCULATED,
-        'calc'       : Date.QUAL_CALCULATED,
-        'calculated' : Date.QUAL_CALCULATED,
-        }
-        # (overridden if a locale-specific date parser exists)
+        "estimated": Date.QUAL_ESTIMATED,
+        "est.": Date.QUAL_ESTIMATED,
+        "est": Date.QUAL_ESTIMATED,
+        "calc.": Date.QUAL_CALCULATED,
+        "calc": Date.QUAL_CALCULATED,
+        "calculated": Date.QUAL_CALCULATED,
+    }
+    # (overridden if a locale-specific date parser exists)
 
-    today = ["$T",]
-        # Override with a list of *synonyms* for "today" in your language.
-        # Note: the word "today" itself will already be pulled in from your translation DB,
-        # see init_strings, so there is no need to override this if you have no aliases
-        # for "today".
-        # We also secretly support "$T" like in some reports.
+    today = [
+        "$T",
+    ]
+    # Override with a list of *synonyms* for "today" in your language.
+    # Note: the word "today" itself will already be pulled in from your translation DB,
+    # see init_strings, so there is no need to override this if you have no aliases
+    # for "today".
+    # We also secretly support "$T" like in some reports.
 
     _langs = set()
+
     def __init_prefix_tables(self):
         ds = self._ds = DateStrings(self._locale)
         lang = self._locale.lang
@@ -316,56 +384,69 @@ class DateParser:
         else:
             DateParser._langs.add(lang)
         log.debug("Begin building parser prefix tables for {}".format(lang))
-        _build_prefix_table(DateParser.month_to_int,
+        _build_prefix_table(
+            DateParser.month_to_int,
             _generate_variants(
-                    zip(ds.long_months, ds.short_months,
-                        ds.swedish_SV, ds.alt_long_months)))
-        _build_prefix_table(DateParser.hebrew_to_int,
-            _generate_variants(zip(ds.hebrew)))
-        _build_prefix_table(DateParser.french_to_int,
-            _generate_variants(zip(ds.french)))
-        _build_prefix_table(DateParser.islamic_to_int,
-            _generate_variants(zip(ds.islamic)))
-        _build_prefix_table(DateParser.persian_to_int,
-            _generate_variants(zip(ds.persian)))
-        _build_prefix_table(DateParser.calendar_to_int,
-                _generate_variants(zip(ds.calendar)))
+                zip(ds.long_months, ds.short_months, ds.swedish_SV, ds.alt_long_months)
+            ),
+        )
+        _build_prefix_table(
+            DateParser.hebrew_to_int, _generate_variants(zip(ds.hebrew))
+        )
+        _build_prefix_table(
+            DateParser.french_to_int, _generate_variants(zip(ds.french))
+        )
+        _build_prefix_table(
+            DateParser.islamic_to_int, _generate_variants(zip(ds.islamic))
+        )
+        _build_prefix_table(
+            DateParser.persian_to_int, _generate_variants(zip(ds.persian))
+        )
+        _build_prefix_table(
+            DateParser.calendar_to_int, _generate_variants(zip(ds.calendar))
+        )
 
     def __init__(self, plocale=None):
         """
         :param plocale: allow correct date format to be loaded and parsed
         :type plocale: a :class:`.GrampsLocale` instance
         """
-        from ._datehandler import locale_tformat # circular import if above
+        from ._datehandler import locale_tformat  # circular import if above
+
         if plocale:
             self._locale = plocale
-        elif not hasattr(self, '_locale'):
+        elif not hasattr(self, "_locale"):
             self._locale = glocale
         if self._locale.calendar in locale_tformat:
-            self.dhformat = locale_tformat[self._locale.calendar] # date format
+            self.dhformat = locale_tformat[self._locale.calendar]  # date format
         else:
-            self.dhformat = locale_tformat['en_GB'] # something is required
-        self.dhformat_changed() # Allow overriding so a subclass can modify it
+            self.dhformat = locale_tformat["en_GB"]  # something is required
+        self.dhformat_changed()  # Allow overriding so a subclass can modify it
         self.init_strings()
         self.parser = {
-            Date.CAL_GREGORIAN : self._parse_gregorian,
-            Date.CAL_JULIAN    : self._parse_julian,
-            Date.CAL_FRENCH    : self._parse_french,
-            Date.CAL_PERSIAN   : self._parse_persian,
-            Date.CAL_HEBREW    : self._parse_hebrew,
-            Date.CAL_ISLAMIC   : self._parse_islamic,
-            Date.CAL_SWEDISH   : self._parse_swedish,
-            }
+            Date.CAL_GREGORIAN: self._parse_gregorian,
+            Date.CAL_JULIAN: self._parse_julian,
+            Date.CAL_FRENCH: self._parse_french,
+            Date.CAL_PERSIAN: self._parse_persian,
+            Date.CAL_HEBREW: self._parse_hebrew,
+            Date.CAL_ISLAMIC: self._parse_islamic,
+            Date.CAL_SWEDISH: self._parse_swedish,
+        }
 
         match = self._dhformat_parse.match(self.dhformat.lower())
         if match:
-            self._ddmy = match.groups() == ('a', 'e', 'b', 'y') # Icelandic
-            self.dmy = (match.groups() == ('d', 'm', 'y') or
-                        match.groups() == ('e', 'm', 'y') or # Bulgarian
-                        match.groups() == ('d', 'b', 'y') or
-                        match.groups() == ('a', 'e', 'b', 'y'))
-            self.ymd = (match.groups() == ('y', 'm', 'd') or \
-                       match.groups() == ('y', 'b', 'd'))
+            self._ddmy = match.groups() == ("a", "e", "b", "y")  # Icelandic
+            self.dmy = (
+                match.groups() == ("d", "m", "y")
+                or match.groups() == ("e", "m", "y")
+                or match.groups() == ("d", "b", "y")  # Bulgarian
+                or match.groups() == ("a", "e", "b", "y")
+            )
+            self.ymd = match.groups() == ("y", "m", "d") or match.groups() == (
+                "y",
+                "b",
+                "d",
+            )
             # note ('m','d','y') is valid -- in which case both will be False
         else:
             self.dmy = True
@@ -373,7 +454,7 @@ class DateParser:
             self._ddmy = False
 
     def dhformat_changed(self):
-        """ Allow overriding so a subclass can modify it """
+        """Allow overriding so a subclass can modify it"""
         pass
 
     def re_longest_first(self, keys):
@@ -383,7 +464,7 @@ class DateParser:
         are quoted.
         """
         keys.sort(key=len, reverse=True)
-        return '(' + '|'.join([re.escape(key) for key in keys]) + ')'
+        return "(" + "|".join([re.escape(key) for key in keys]) + ")"
 
     def init_strings(self):
         """
@@ -401,14 +482,15 @@ class DateParser:
         _ = self._locale.translation.gettext
         self.__init_prefix_tables()
 
-        self._rfc_mon_str = '(' + '|'.join(list(self._rfc_mons_to_int.keys())) + ')'
-        self._rfc_day_str = '(' + '|'.join(self._rfc_days) + ')'
+        self._rfc_mon_str = "(" + "|".join(list(self._rfc_mons_to_int.keys())) + ")"
+        self._rfc_day_str = "(" + "|".join(self._rfc_days) + ")"
 
         self._bce_str = self.re_longest_first(self.bce)
         self._qual_str = self.re_longest_first(list(self.quality_to_int.keys()))
         self._mod_str = self.re_longest_first(list(self.modifier_to_int.keys()))
         self._mod_after_str = self.re_longest_first(
-            list(self.modifier_after_to_int.keys()))
+            list(self.modifier_after_to_int.keys())
+        )
 
         self._mon_str = self.re_longest_first(list(self.month_to_int.keys()))
         self._jmon_str = self.re_longest_first(list(self.hebrew_to_int.keys()))
@@ -419,43 +501,48 @@ class DateParser:
         self._cal_str = self.re_longest_first(list(self.calendar_to_int.keys()))
         self._ny_str = self.re_longest_first(list(self.newyear_to_int.keys()))
 
-        self._today_str = self.re_longest_first(self.today + [_("today"),])
+        self._today_str = self.re_longest_first(
+            self.today
+            + [
+                _("today"),
+            ]
+        )
 
         # bce, calendar type and quality may be either at the end or at
         # the beginning of the given date string, therefore they will
         # be parsed from the middle and will be in match.group(2).
         self._bce_re = re.compile(r"(.*)\s+%s( ?.*)" % self._bce_str)
 
-        self._cal = re.compile(r"(.*)\s+\(%s\)( ?.*)" % self._cal_str,
-                               re.IGNORECASE)
-        self._calny = re.compile(r"(.*)\s+\(%s,\s*%s\)( ?.*)" %
-                                 (self._cal_str, self._ny_str), re.IGNORECASE)
+        self._cal = re.compile(r"(.*)\s+\(%s\)( ?.*)" % self._cal_str, re.IGNORECASE)
+        self._calny = re.compile(
+            r"(.*)\s+\(%s,\s*%s\)( ?.*)" % (self._cal_str, self._ny_str), re.IGNORECASE
+        )
         self._calny_iso = re.compile(
-            r"(.*)\s+\(%s,\s*(\d{1,2}-\d{1,2})\)( ?.*)" % self._cal_str,
-            re.IGNORECASE)
+            r"(.*)\s+\(%s,\s*(\d{1,2}-\d{1,2})\)( ?.*)" % self._cal_str, re.IGNORECASE
+        )
 
-        self._ny = re.compile(r"(.*)\s+\(%s\)( ?.*)" % self._ny_str,
-                              re.IGNORECASE)
+        self._ny = re.compile(r"(.*)\s+\(%s\)( ?.*)" % self._ny_str, re.IGNORECASE)
         self._ny_iso = re.compile(r"(.*)\s+\((\d{1,2}-\d{1,2})\)( ?.*)")
 
-        self._qual = re.compile(r"(.* ?)%s\s+(.+)" % self._qual_str,
-                                re.IGNORECASE)
+        self._qual = re.compile(r"(.* ?)%s\s+(.+)" % self._qual_str, re.IGNORECASE)
 
-        self._span = re.compile(r"(from)\s+(?P<start>.+)\s+to\s+(?P<stop>.+)",
-                                re.IGNORECASE)
+        self._span = re.compile(
+            r"(from)\s+(?P<start>.+)\s+to\s+(?P<stop>.+)", re.IGNORECASE
+        )
         self._range = re.compile(
-            r"(bet|bet.|between)\s+(?P<start>.+)\s+and\s+(?P<stop>.+)",
-            re.IGNORECASE)
+            r"(bet|bet.|between)\s+(?P<start>.+)\s+and\s+(?P<stop>.+)", re.IGNORECASE
+        )
         self._quarter = re.compile(
-            r"[qQ](?P<quarter>[1-4])\s+(?P<year>.+)",
-            re.IGNORECASE)
-        self._modifier = re.compile(r'%s\s+(.*)' % self._mod_str,
-                                    re.IGNORECASE)
-        self._modifier_after = re.compile(r'(.*)\s+%s' % self._mod_after_str,
-                                          re.IGNORECASE)
-        self._abt2 = re.compile('<(.*)>', re.IGNORECASE)
-        self._text = re.compile(r'%s\.?(\s+\d+)?\s*,?\s+((\d+)(/\d+)?)?\s*$'
-                                % self._mon_str, re.IGNORECASE)
+            r"[qQ](?P<quarter>[1-4])\s+(?P<year>.+)", re.IGNORECASE
+        )
+        self._modifier = re.compile(r"%s\s+(.*)" % self._mod_str, re.IGNORECASE)
+        self._modifier_after = re.compile(
+            r"(.*)\s+%s" % self._mod_after_str, re.IGNORECASE
+        )
+        self._abt2 = re.compile("<(.*)>", re.IGNORECASE)
+        self._text = re.compile(
+            r"%s\.?(\s+\d+)?\s*,?\s+((\d+)(/\d+)?)?\s*$" % self._mon_str, re.IGNORECASE
+        )
         # this next RE has the (possibly-slashed) year at the string's end
         self._text2 = re.compile(r'(\d+)?\s+?%s\.?\s*((\d+)(/\d+)?)?\s*$'
                                  % self._mon_str, re.IGNORECASE)
@@ -484,12 +571,13 @@ class DateParser:
         self._iso = re.compile(r"(\d+)(/(\d+))?-(\d+)(-(\d+))?\s*$")
         self._isotimestamp = re.compile(
             r"^\s*?(\d{4})([01]\d)([0123]\d)(?:(?:[012]\d[0-5]\d[0-5]\d)|"
-            r"(?:\s+[012]\d:[0-5]\d(?::[0-5]\d)?))?\s*?$")
+            r"(?:\s+[012]\d:[0-5]\d(?::[0-5]\d)?))?\s*?$"
+        )
         self._rfc = re.compile(
             r"(%s,)?\s+(\d|\d\d)\s+%s\s+(\d+)\s+\d\d:\d\d(:\d\d)?\s+"
-            r"(\+|-)\d\d\d\d" % (self._rfc_day_str, self._rfc_mon_str))
-        self._today = re.compile(r"^\s*%s\s*$" % self._today_str,
-                                 re.IGNORECASE)
+            r"(\+|-)\d\d\d\d" % (self._rfc_day_str, self._rfc_mon_str)
+        )
+        self._today = re.compile(r"^\s*%s\s*$" % self._today_str, re.IGNORECASE)
 
     def _get_int(self, val):
         """
@@ -502,37 +590,41 @@ class DateParser:
             return int(val)
 
     def _parse_hebrew(self, text):
-        return self._parse_calendar(text, self._jtext, self._jtext2,
-                                    self.hebrew_to_int)
+        return self._parse_calendar(text, self._jtext, self._jtext2, self.hebrew_to_int)
 
     def _parse_islamic(self, text):
-        return self._parse_calendar(text, self._itext, self._itext2,
-                                    self.islamic_to_int)
+        return self._parse_calendar(
+            text, self._itext, self._itext2, self.islamic_to_int
+        )
 
     def _parse_persian(self, text):
-        return self._parse_calendar(text, self._ptext, self._ptext2,
-                                    self.persian_to_int)
+        return self._parse_calendar(
+            text, self._ptext, self._ptext2, self.persian_to_int
+        )
 
     def _parse_french(self, text):
-        return self._parse_calendar(text, self._ftext, self._ftext2,
-                                    self.french_to_int, french_valid)
+        return self._parse_calendar(
+            text, self._ftext, self._ftext2, self.french_to_int, french_valid
+        )
 
     def _parse_gregorian(self, text):
-        return self._parse_calendar(text, self._text, self._text2,
-                                    self.month_to_int, gregorian_valid)
+        return self._parse_calendar(
+            text, self._text, self._text2, self.month_to_int, gregorian_valid
+        )
 
     def _parse_julian(self, text):
-        return self._parse_calendar(text, self._text, self._text2,
-                                    self.month_to_int, julian_valid)
+        return self._parse_calendar(
+            text, self._text, self._text2, self.month_to_int, julian_valid
+        )
 
     def _parse_swedish(self, text):
-        return self._parse_calendar(text, self._stext, self._stext2,
-                                    self.swedish_to_int,swedish_valid)
-
+        return self._parse_calendar(
+            text, self._stext, self._stext2, self.swedish_to_int, swedish_valid
+        )
 
     def _parse_calendar(self, text, regex1, regex2, mmap, check=None):
         match = regex1.match(text.lower())
-        if match: # user typed in 'month-name day year' or 'month-name year'
+        if match:  # user typed in 'month-name day year' or 'month-name year'
             groups = match.groups()
             if groups[0] is None:
                 m = 0
@@ -546,20 +638,20 @@ class DateParser:
             else:
                 d = self._get_int(groups[1])
                 if groups[4] is not None:
-                    y = int(groups[3]) + 1 # fullyear + 1
-                    s = True # slash year
-                else: # regular year
+                    y = int(groups[3]) + 1  # fullyear + 1
+                    s = True  # slash year
+                else:  # regular year
                     y = int(groups[3])
                     s = False
             value = (d, m, y, s)
-            if s and julian_valid(value): # slash year
+            if s and julian_valid(value):  # slash year
                 pass
             elif check and not check((d, m, y)):
                 value = Date.EMPTY
             return value
 
         match = regex2.match(text.lower())
-        if match: # user typed in day month-name year or year month-name day
+        if match:  # user typed in day month-name year or year month-name day
             groups = match.groups()
             if self.ymd:
                 if groups[3] is None:
@@ -572,9 +664,9 @@ class DateParser:
                     s = False
                 else:
                     if groups[2] is not None:
-                        y = int(groups[1]) + 1 # fullyear + 1
-                        s = True # slash year
-                    else: # regular year
+                        y = int(groups[1]) + 1  # fullyear + 1
+                        s = True  # slash year
+                    else:  # regular year
                         y = int(groups[1])
                         s = False
             else:
@@ -588,9 +680,9 @@ class DateParser:
                     s = False
                 else:
                     if groups[4] is not None:
-                        y = int(groups[3]) + 1 # fullyear + 1
-                        s = True # slash year
-                    else: # regular year
+                        y = int(groups[3]) + 1  # fullyear + 1
+                        s = True  # slash year
+                    else:  # regular year
                         y = int(groups[3])
                         s = False
             value = (d, m, y, s)
@@ -632,7 +724,7 @@ class DateParser:
             m = self._get_int(groups[3])
             d = self._get_int(groups[5])
             if groups[2] and julian_valid((d, m, y + 1)):
-                return (d, m, y + 1, True) # slash year
+                return (d, m, y + 1, True)  # slash year
             if check is None or check((d, m, y)):
                 return (d, m, y, False)
             return Date.EMPTY
@@ -666,8 +758,8 @@ class DateParser:
             groups = match.groups()
             if groups == (None, None, None, None, None):
                 return Date.EMPTY
-            if self._ddmy: # Icelandic
-                groups = groups[1:] # ignore the day of the week at the start
+            if self._ddmy:  # Icelandic
+                groups = groups[1:]  # ignore the day of the week at the start
             if self.ymd:
                 # '1789' and ymd: incomplete date
                 if groups[1] is None:
@@ -682,7 +774,7 @@ class DateParser:
                     y = self._get_int(groups[1])
                     m = self._get_int(groups[3])
                     d = self._get_int(groups[4])
-                if m > 12: # maybe a slash year, not a month (1722/3 is March)
+                if m > 12:  # maybe a slash year, not a month (1722/3 is March)
                     if y % 100 == 99:
                         modyear = (y + 1) % 1000
                     elif y % 10 == 9:
@@ -690,7 +782,7 @@ class DateParser:
                     else:
                         modyear = (y + 1) % 10
                     if m == modyear:
-                        return (0, 0, y + 1, True) # slash year
+                        return (0, 0, y + 1, True)  # slash year
             else:
                 y = self._get_int(groups[4])
                 if self.dmy:
@@ -703,7 +795,7 @@ class DateParser:
                 else:
                     m = self._get_int(groups[1])
                     d = self._get_int(groups[3])
-                if m > 12: # maybe a slash year, not a month
+                if m > 12:  # maybe a slash year, not a month
                     if m % 100 == 99:
                         modyear = (m + 1) % 1000
                     elif m % 10 == 9:
@@ -711,7 +803,7 @@ class DateParser:
                     else:
                         modyear = (m + 1) % 10
                     if y == modyear:
-                        return (0, 0, m + 1, True) # slash year
+                        return (0, 0, m + 1, True)  # slash year
             value = (d, m, y, False)
             if check and not check((d, m, y)):
                 value = Date.EMPTY
@@ -795,14 +887,14 @@ class DateParser:
         match = self._span.match(text)
         if match:
             text_parser = self.parser[cal]
-            (text1, bc1) = self.match_bce(match.group('start'))
+            (text1, bc1) = self.match_bce(match.group("start"))
             start = self._parse_subdate(text1, text_parser, cal)
             if start == Date.EMPTY and text1 != "":
                 return 0
             if bc1:
                 start = self.invert_year(start)
 
-            (text2, bc2) = self.match_bce(match.group('stop'))
+            (text2, bc2) = self.match_bce(match.group("stop"))
             stop = self._parse_subdate(text2, text_parser, cal)
             if stop == Date.EMPTY and text2 != "":
                 return 0
@@ -822,14 +914,14 @@ class DateParser:
         match = self._range.match(text)
         if match:
             text_parser = self.parser[cal]
-            (text1, bc1) = self.match_bce(match.group('start'))
+            (text1, bc1) = self.match_bce(match.group("start"))
             start = self._parse_subdate(text1, text_parser, cal)
             if start == Date.EMPTY and text1 != "":
                 return 0
             if bc1:
                 start = self.invert_year(start)
 
-            (text2, bc2) = self.match_bce(match.group('stop'))
+            (text2, bc2) = self.match_bce(match.group("stop"))
             stop = self._parse_subdate(text2, text_parser, cal)
             if stop == Date.EMPTY and text2 != "":
                 return 0
@@ -848,20 +940,33 @@ class DateParser:
         """
         match = self._quarter.match(text)
         if match:
-            quarter = self._get_int(match.group('quarter'))
+            quarter = self._get_int(match.group("quarter"))
 
             text_parser = self.parser[cal]
-            (text, bc) = self.match_bce(match.group('year'))
+            (text, bc) = self.match_bce(match.group("year"))
             start = self._parse_subdate(text, text_parser, cal)
-            if (start == Date.EMPTY and text != "") or (start[0] != 0) or (start[1] != 0): # reject dates where the day or month have been set
+            if (
+                (start == Date.EMPTY and text != "")
+                or (start[0] != 0)
+                or (start[1] != 0)
+            ):  # reject dates where the day or month have been set
                 return 0
             if bc:
                 start = self.invert_year(start)
 
             stop_month = quarter * 3
-            stop_day = _max_days[stop_month - 1] # no need to worry about leap years since no quarter ends in February
+            stop_day = _max_days[
+                stop_month - 1
+            ]  # no need to worry about leap years since no quarter ends in February
 
-            date.set(qual, Date.MOD_RANGE, cal, (1, stop_month - 2, start[2], start[3]) + (stop_day, stop_month, start[2], start[3]), newyear=ny)
+            date.set(
+                qual,
+                Date.MOD_RANGE,
+                cal,
+                (1, stop_month - 2, start[2], start[3])
+                + (stop_day, stop_month, start[2], start[3]),
+                newyear=ny,
+            )
             return 1
         return 0
 
@@ -874,7 +979,7 @@ class DateParser:
         match = self._bce_re.match(text)
         bc = False
         if match:
-        # bce is in the match.group(2)
+            # bce is in the match.group(2)
             try:
                 text = match.group(1) + match.group(3)
             except:
@@ -908,8 +1013,7 @@ class DateParser:
             if match:
                 grps = match.groups()
                 start = self._parse_subdate(grps[0], self.parser[cal], cal)
-                mod = self.modifier_after_to_int.get(grps[1].lower(),
-                                                     Date.MOD_NONE)
+                mod = self.modifier_after_to_int.get(grps[1].lower(), Date.MOD_NONE)
                 if start == Date.EMPTY:
                     date.set_modifier(Date.MOD_TEXTONLY)
                     date.set_text_value(text)
@@ -937,7 +1041,7 @@ class DateParser:
         """
         Parses the text and sets the date according to the parsing.
         """
-        text = text.strip() # otherwise spaces can make it a bad date
+        text = text.strip()  # otherwise spaces can make it a bad date
         date.set_text_value(text)
         qual = Date.QUAL_NONE
         cal = Date.CAL_GREGORIAN
@@ -969,7 +1073,9 @@ class DateParser:
             return
 
         if bc:
-            date.set(qual, Date.MOD_NONE, cal, self.invert_year(subdate), newyear=newyear)
+            date.set(
+                qual, Date.MOD_NONE, cal, self.invert_year(subdate), newyear=newyear
+            )
         else:
             date.set(qual, Date.MOD_NONE, cal, subdate, newyear=newyear)
 

--- a/gramps/gen/datehandler/_datestrings.py
+++ b/gramps/gen/datehandler/_datestrings.py
@@ -38,19 +38,20 @@ strings as needed. Then remove the strings from your language's
 :class:`DateParserXX` and :class:`DateHandlerXX` classes.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # set up logging
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import logging
+
 log = logging.getLogger(".DateStrings")
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # DateStrings
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateStrings:
     """
     String tables for :class:`.DateDisplay` and :class:`.DateParser`.
@@ -61,17 +62,26 @@ class DateStrings:
     # Display of these months uses the regular long_months.
     # TODO should we pack these into alt_long_months instead?
     swedish_SV = (
-        "", "Januari", "Februari", "Mars",
-        "April", "Maj", "Juni",
-        "Juli", "Augusti", "September",
-        "Oktober", "November", "December"
-        )
-
+        "",
+        "Januari",
+        "Februari",
+        "Mars",
+        "April",
+        "Maj",
+        "Juni",
+        "Juli",
+        "Augusti",
+        "September",
+        "Oktober",
+        "November",
+        "December",
+    )
 
     def __init__(self, locale):
         _ = locale.translation.lexgettext
 
-        self.long_months = ( "",
+        self.long_months = (
+            "",
             # Translators: see
             # http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
             # to learn how to select proper inflection to be used in your localized
@@ -89,7 +99,8 @@ class DateStrings:
             _("November", "localized lexeme inflections"),
             _("December", "localized lexeme inflections") )
 
-        self.short_months = ( "",
+        self.short_months = (
+            "",
             # Translators: see
             # http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
             # to learn how to select proper inflection to be used in your localized
@@ -108,7 +119,8 @@ class DateStrings:
             _("Dec", "localized lexeme inflections - short month form") )
 
         _ = locale.translation.sgettext
-        self.alt_long_months = ( "",
+        self.alt_long_months = (
+            "",
             # Translators: see
             # http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
             # to learn how to add proper alternatives to be recognized in your localized
@@ -127,14 +139,15 @@ class DateStrings:
             _("", "alternative month names for December") )
 
         self.calendar = (
-# Must appear in the order indexed by Date.CAL_... numeric constants
-                _("Gregorian", "calendar"),
-                _("Julian", "calendar"),
-                _("Hebrew", "calendar"),
-                _("French Republican", "calendar"),
-                _("Persian", "calendar"),
-                _("Islamic", "calendar"),
-                _("Swedish", "calendar") )
+            # Must appear in the order indexed by Date.CAL_... numeric constants
+            _("Gregorian", "calendar"),
+            _("Julian", "calendar"),
+            _("Hebrew", "calendar"),
+            _("French Republican", "calendar"),
+            _("Persian", "calendar"),
+            _("Islamic", "calendar"),
+            _("Swedish", "calendar"),
+        )
         _ = locale.translation.lexgettext
 
         self.hebrew = (
@@ -155,8 +168,8 @@ class DateStrings:
             _("Sivan", "Hebrew month lexeme"),
             _("Tammuz", "Hebrew month lexeme"),
             _("Av", "Hebrew month lexeme"),
-            _("Elul", "Hebrew month lexeme")
-            )
+            _("Elul", "Hebrew month lexeme"),
+        )
 
         self.french = (
             "",
@@ -177,7 +190,7 @@ class DateStrings:
             _("Thermidor", "French month lexeme"),
             _("Fructidor", "French month lexeme"),
             _("Extra", "French month lexeme"),
-            )
+        )
 
         self.islamic = (
             "",
@@ -197,7 +210,7 @@ class DateStrings:
             _("Shawwal", "Islamic month lexeme"),
             _("Dhu l-Qa`da", "Islamic month lexeme"),
             _("Dhu l-Hijja", "Islamic month lexeme"),
-            )
+        )
 
         self.persian = (
             "",
@@ -217,76 +230,98 @@ class DateStrings:
             _("Dey", "Persian month lexeme"),
             _("Bahman", "Persian month lexeme"),
             _("Esfand", "Persian month lexeme"),
-            )
+        )
 
-        self.modifiers = ("",
-                # Translators: if the modifier is after the date
-                # put the space ahead of the word instead of after it
-                _("before ", "date modifier"),
-                # Translators: if the modifier is after the date
-                # put the space ahead of the word instead of after it
-                _("after ", "date modifier"),
-                # Translators: if the modifier is after the date
-                # put the space ahead of the word instead of after it
-                _("about ", "date modifier"),
-                "", "", "")
+        self.modifiers = (
+            "",
+            # Translators: if the modifier is after the date
+            # put the space ahead of the word instead of after it
+            _("before ", "date modifier"),
+            # Translators: if the modifier is after the date
+            # put the space ahead of the word instead of after it
+            _("after ", "date modifier"),
+            # Translators: if the modifier is after the date
+            # put the space ahead of the word instead of after it
+            _("about ", "date modifier"),
+            "",
+            "",
+            "",
+            # Translators: if the modifier is after the date
+            # put the space ahead of the word instead of after it
+            _("from ", "date modifier"),
+            # Translators: if the modifier is after the date
+            # put the space ahead of the word instead of after it
+            _("to ", "date modifier"),
+        )
 
-        self.qualifiers = ("",
-                _("estimated ", "date quality"),
-                _("calculated ", "date quality"),
-                )
+        self.qualifiers = (
+            "",
+            _("estimated ", "date quality"),
+            _("calculated ", "date quality"),
+        )
 
         # 6753: localized day names. Eventually should sprout into
         # a per-calendar type thing instead.
-        self.long_days = ("",
-                _("Sunday"),
-                _("Monday"),
-                _("Tuesday"),
-                _("Wednesday"),
-                _("Thursday"),
-                _("Friday"),
-                _("Saturday"),
-            )
+        self.long_days = (
+            "",
+            _("Sunday"),
+            _("Monday"),
+            _("Tuesday"),
+            _("Wednesday"),
+            _("Thursday"),
+            _("Friday"),
+            _("Saturday"),
+        )
 
-        self.short_days = ("", # Icelandic needs them
+        self.short_days = (
+            "",  # Icelandic needs them
             _("Sun"),
             _("Mon"),
             _("Tue"),
             _("Wed"),
             _("Thu"),
             _("Fri"),
-            _("Sat"))
+            _("Sat"),
+        )
+
 
 # set GRAMPS_RESOURCES then: python3 -m gramps.gen.datehandler._datestrings
-if __name__ == '__main__':
+if __name__ == "__main__":
     import sys
     from ..utils.grampslocale import GrampsLocale
     from ..const import GRAMPS_LOCALE as glocale
-    from ._grampslocale import (_deprecated_long_months as old_long,
-            _deprecated_short_months as old_short,
-            _deprecated_short_days as old_short_days, # Icelandic needs them
-            _deprecated_long_days as old_days)
+    from ._grampslocale import (
+        _deprecated_long_months as old_long,
+        _deprecated_short_months as old_short,
+        _deprecated_short_days as old_short_days,  # Icelandic needs them
+        _deprecated_long_days as old_days,
+    )
     from ._datedisplay import DateDisplay
     import gettext
+
     lang = glocale.lang
     lang_short = lang[:2]
-    available_langs = glocale.languages # get the cached list
+    available_langs = glocale.languages  # get the cached list
     if glocale.check_available_translations(lang) is None:
-        print ("Translation for current language {lang} not available.\n"
-                "Available translations: {list}.\n"
-                "Does po/{lang_short}*.po exist in gramps source tree?!\n"
-                "Please set your LANG / LC_ALL environment to something else...\n".format(
-                    lang=lang, list=available_langs, lang_short=lang_short),
-                file=sys.stderr)
+        print(
+            "Translation for current language {lang} not available.\n"
+            "Available translations: {list}.\n"
+            "Does po/{lang_short}*.po exist in gramps source tree?!\n"
+            "Please set your LANG / LC_ALL environment to something else...\n".format(
+                lang=lang, list=available_langs, lang_short=lang_short
+            ),
+            file=sys.stderr,
+        )
         sys.exit(1)
 
-    print ("# Generating snippets for {}*.po\n"
-            "# Available languages: {}".format(
-                    lang_short, available_langs))
-    glocale = GrampsLocale(languages=(lang)) # in __main__
+    print(
+        "# Generating snippets for {}*.po\n"
+        "# Available languages: {}".format(lang_short, available_langs)
+    )
+    glocale = GrampsLocale(languages=(lang))  # in __main__
     dd = glocale.date_displayer
     ds = dd._ds
-    glocale_EN = GrampsLocale(languages=('en')) # in __main__
+    glocale_EN = GrampsLocale(languages=("en"))  # in __main__
     ds_EN = DateStrings(glocale_EN)
 
     filename = __file__
@@ -297,35 +332,43 @@ if __name__ == '__main__':
         localized_months = old_long
 
     def print_po_snippet(en_loc_old_lists, context):
-        for m,localized,old in zip(*en_loc_old_lists):
+        for m, localized, old in zip(*en_loc_old_lists):
             if m == "":
                 continue
             if m == localized:
                 localized = old
-            print ('#: {file}:{line}\n'
-                   'msgid "{context}{en_month}"\n'
-                   'msgstr "{localized_month}"\n'.format(
-                       context = context,
-                       file = filename,
-                       line = print_po_snippet.line,
-                       en_month = m,
-                       localized_month = localized))
+            print(
+                "#: {file}:{line}\n"
+                'msgid "{context}{en_month}"\n'
+                'msgstr "{localized_month}"\n'.format(
+                    context=context,
+                    file=filename,
+                    line=print_po_snippet.line,
+                    en_month=m,
+                    localized_month=localized,
+                )
+            )
             print_po_snippet.line += 1
+
     print_po_snippet.line = 10000
 
     try:
         localized_months = dd.__class__.long_months
     except AttributeError:
         localized_months = old_long
-    print_po_snippet((ds_EN.long_months, localized_months, old_long),
-            "localized lexeme inflections||")
+    print_po_snippet(
+        (ds_EN.long_months, localized_months, old_long),
+        "localized lexeme inflections||",
+    )
 
     try:
         localized_months = dd.__class__.short_months
     except AttributeError:
         localized_months = old_short
-    print_po_snippet((ds_EN.short_months, localized_months, old_short),
-            "localized lexeme inflections - short month form||")
+    print_po_snippet(
+        (ds_EN.short_months, localized_months, old_short),
+        "localized lexeme inflections - short month form||",
+    )
 
     print_po_snippet((ds_EN.long_days, old_days, old_days), "")
 
@@ -333,42 +376,36 @@ if __name__ == '__main__':
 
     try:
         loc = dd.__class__.hebrew
-        print_po_snippet((ds_EN.hebrew, loc, loc),
-                "Hebrew month lexeme|")
+        print_po_snippet((ds_EN.hebrew, loc, loc), "Hebrew month lexeme|")
     except AttributeError:
         pass
 
     try:
         loc = dd.__class__.french
-        print_po_snippet((ds_EN.french, loc, loc),
-                "French month lexeme|")
+        print_po_snippet((ds_EN.french, loc, loc), "French month lexeme|")
     except AttributeError:
         pass
 
     try:
         loc = dd.__class__.islamic
-        print_po_snippet((ds_EN.islamic, loc, loc),
-                "Islamic month lexeme|")
+        print_po_snippet((ds_EN.islamic, loc, loc), "Islamic month lexeme|")
     except AttributeError:
         pass
 
     try:
         loc = dd.__class__.persian
-        print_po_snippet((ds_EN.persian, loc, loc),
-                "Persian month lexeme|")
+        print_po_snippet((ds_EN.persian, loc, loc), "Persian month lexeme|")
     except AttributeError:
         pass
 
     try:
         loc = dd.__class__._mod_str
-        print_po_snippet((ds_EN.modifiers, loc, loc),
-                "date modifier|")
+        print_po_snippet((ds_EN.modifiers, loc, loc), "date modifier|")
     except AttributeError:
         pass
 
     try:
         loc = dd.__class__._qual_str
-        print_po_snippet((ds_EN.qualifiers, loc, loc),
-                "date quality|")
+        print_po_snippet((ds_EN.qualifiers, loc, loc), "date quality|")
     except AttributeError:
         pass

--- a/gramps/gen/datehandler/test/datehandler_test.py
+++ b/gramps/gen/datehandler/test/datehandler_test.py
@@ -29,44 +29,46 @@ Validate localized date parser and displayer.
 Based on the Check Localized Date Displayer and Parser tool.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # standard python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import unittest
 
 import sys
-if '-v' in sys.argv or '--verbose' in sys.argv:
+
+if "-v" in sys.argv or "--verbose" in sys.argv:
     import logging
-    logging.getLogger('').addHandler(logging.StreamHandler())
+
+    logging.getLogger("").addHandler(logging.StreamHandler())
     log = logging.getLogger(".Date")
     log.setLevel(logging.DEBUG)
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ...config import config
 from ...lib import Date, DateError
 from ...utils.grampslocale import GrampsLocale, _LOCALE_NAMES
 from .. import LANG_TO_PARSER
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 #
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class DateHandlerTest(unittest.TestCase):
-
     def setUp(self):
-        config.set('preferences.date-format', 0)
+        config.set("preferences.date-format", 0)
 
     def __base_test_all_languages(self, dates):
 
-        languages = [lang for lang in LANG_TO_PARSER.keys()
-                          if lang in _LOCALE_NAMES.keys()]
+        languages = [
+            lang for lang in LANG_TO_PARSER.keys() if lang in _LOCALE_NAMES.keys()
+        ]
         for language in languages:
             with self.subTest(lang=language):
                 self.__test_language(language, dates)
@@ -80,28 +82,43 @@ class DateHandlerTest(unittest.TestCase):
             datestr = displayer.display(test_date)
             new_date = parser.parse(datestr)
             with self.subTest(date=datestr):
-                self.assertTrue(test_date.is_equal(new_date),
-                                "{} -> {}\n{} -> {}".format(
-                                    test_date, new_date,
-                                    test_date.__dict__, new_date.__dict__))
+                self.assertTrue(
+                    test_date.is_equal(new_date),
+                    "{} -> {}\n{} -> {}".format(
+                        test_date, new_date, test_date.__dict__, new_date.__dict__
+                    ),
+                )
 
     def test_simple(self):
 
         dates = []
         for calendar in (Date.CAL_GREGORIAN, Date.CAL_JULIAN):
-            for newyear in (Date.NEWYEAR_JAN1, Date.NEWYEAR_MAR25, (5,5)):
-                for quality in (Date.QUAL_NONE, Date.QUAL_ESTIMATED,
-                                Date.QUAL_CALCULATED):
-                    for modifier in (Date.MOD_NONE, Date.MOD_BEFORE,
-                                     Date.MOD_AFTER, Date.MOD_ABOUT):
-                        for slash1 in (False,True):
+            for newyear in (Date.NEWYEAR_JAN1, Date.NEWYEAR_MAR25, (5, 5)):
+                for quality in (
+                    Date.QUAL_NONE,
+                    Date.QUAL_ESTIMATED,
+                    Date.QUAL_CALCULATED,
+                ):
+                    for modifier in (
+                        Date.MOD_NONE,
+                        Date.MOD_BEFORE,
+                        Date.MOD_AFTER,
+                        Date.MOD_ABOUT,
+                        Date.MOD_FROM,
+                        Date.MOD_TO,
+                    ):
+                        for slash1 in (False, True):
                             for month in (2, 6, 12):
                                 for day in (5, 27):
                                     d = Date()
-                                    d.set(quality, modifier, calendar,
-                                          (day, month, 1789, slash1),
-                                          "Text comment",
-                                          newyear)
+                                    d.set(
+                                        quality,
+                                        modifier,
+                                        calendar,
+                                        (day, month, 1789, slash1),
+                                        "Text comment",
+                                        newyear,
+                                    )
                                     dates.append(d)
         self.__base_test_all_languages(dates)
 
@@ -109,36 +126,83 @@ class DateHandlerTest(unittest.TestCase):
 
         dates = []
         calendar = Date.CAL_GREGORIAN
-        for quality in (Date.QUAL_NONE, Date.QUAL_ESTIMATED,
-                        Date.QUAL_CALCULATED):
+        for quality in (Date.QUAL_NONE, Date.QUAL_ESTIMATED, Date.QUAL_CALCULATED):
             for modifier in (Date.MOD_RANGE, Date.MOD_SPAN):
                 for slash1 in (False, True):
                     for slash2 in (False, True):
                         for month in (2, 6, 12):
                             for day in (5, 27):
                                 d = Date()
-                                d.set(quality, modifier, calendar,
-                                      (day, month, 1789, slash1,
-                                       day, month, 1876, slash2),
-                                      "Text comment")
+                                d.set(
+                                    quality,
+                                    modifier,
+                                    calendar,
+                                    (
+                                        day,
+                                        month,
+                                        1789,
+                                        slash1,
+                                        day,
+                                        month,
+                                        1876,
+                                        slash2,
+                                    ),
+                                    "Text comment",
+                                )
                                 dates.append(d)
                                 d = Date()
-                                d.set(quality, modifier, calendar,
-                                      (day, month, 1789, slash1,
-                                       day, 13-month, 1876, slash2),
-                                      "Text comment")
+                                d.set(
+                                    quality,
+                                    modifier,
+                                    calendar,
+                                    (
+                                        day,
+                                        month,
+                                        1789,
+                                        slash1,
+                                        day,
+                                        13 - month,
+                                        1876,
+                                        slash2,
+                                    ),
+                                    "Text comment",
+                                )
                                 dates.append(d)
                                 d = Date()
-                                d.set(quality, modifier, calendar,
-                                      (day, month, 1789, slash1,
-                                       32-day, month, 1876, slash2),
-                                      "Text comment")
+                                d.set(
+                                    quality,
+                                    modifier,
+                                    calendar,
+                                    (
+                                        day,
+                                        month,
+                                        1789,
+                                        slash1,
+                                        32 - day,
+                                        month,
+                                        1876,
+                                        slash2,
+                                    ),
+                                    "Text comment",
+                                )
                                 dates.append(d)
                                 d = Date()
-                                d.set(quality, modifier, calendar,
-                                      (day, month, 1789, slash1,
-                                       32-day, 13-month, 1876, slash2),
-                                      "Text comment")
+                                d.set(
+                                    quality,
+                                    modifier,
+                                    calendar,
+                                    (
+                                        day,
+                                        month,
+                                        1789,
+                                        slash1,
+                                        32 - day,
+                                        13 - month,
+                                        1876,
+                                        slash2,
+                                    ),
+                                    "Text comment",
+                                )
                                 dates.append(d)
         self.__base_test_all_languages(dates)
 
@@ -147,11 +211,11 @@ class DateHandlerTest(unittest.TestCase):
         dates = []
         calendar = Date.CAL_GREGORIAN
         modifier = Date.MOD_TEXTONLY
-        for quality in (Date.QUAL_NONE, Date.QUAL_ESTIMATED,
-                        Date.QUAL_CALCULATED):
+        for quality in (Date.QUAL_NONE, Date.QUAL_ESTIMATED, Date.QUAL_CALCULATED):
             test_date = Date()
-            test_date.set(quality, modifier, calendar, Date.EMPTY,
-                          "This is a textual date")
+            test_date.set(
+                quality, modifier, calendar, Date.EMPTY, "This is a textual date"
+            )
             dates.append(test_date)
         self.__base_test_all_languages(dates)
 
@@ -160,46 +224,83 @@ class DateHandlerTest(unittest.TestCase):
         for l in range(1, len(dateval)):
             d = Date()
             with self.assertRaises(DateError):
-                d.set(Date.QUAL_NONE, Date.MOD_NONE, Date.CAL_GREGORIAN,
-                      dateval[:l], "Text comment")
+                d.set(
+                    Date.QUAL_NONE,
+                    Date.MOD_NONE,
+                    Date.CAL_GREGORIAN,
+                    dateval[:l],
+                    "Text comment",
+                )
 
     def test_too_few_span_arguments(self):
         dateval = (4, 7, 1789, False, 5, 8, 1876, False)
         for l in range(1, len(dateval)):
             d = Date()
             with self.assertRaises(DateError):
-                d.set(Date.QUAL_NONE, Date.MOD_SPAN, Date.CAL_GREGORIAN,
-                      dateval[:l], "Text comment")
+                d.set(
+                    Date.QUAL_NONE,
+                    Date.MOD_SPAN,
+                    Date.CAL_GREGORIAN,
+                    dateval[:l],
+                    "Text comment",
+                )
 
     def test_invalid_day(self):
         d = Date()
         with self.assertRaises(DateError):
-            d.set(Date.QUAL_NONE, Date.MOD_NONE, Date.CAL_GREGORIAN,
-                  (44, 7, 1789,False), "Text comment")
+            d.set(
+                Date.QUAL_NONE,
+                Date.MOD_NONE,
+                Date.CAL_GREGORIAN,
+                (44, 7, 1789, False),
+                "Text comment",
+            )
 
     def test_invalid_month(self):
         d = Date()
         with self.assertRaises(DateError):
-            d.set(Date.QUAL_NONE,Date.MOD_NONE, Date.CAL_GREGORIAN,
-                  (4, 77, 1789, False), "Text comment")
+            d.set(
+                Date.QUAL_NONE,
+                Date.MOD_NONE,
+                Date.CAL_GREGORIAN,
+                (4, 77, 1789, False),
+                "Text comment",
+            )
 
     def test_invalid_month_with_ny(self):
         d = Date()
         with self.assertRaises(DateError):
-            d.set(Date.QUAL_NONE,Date.MOD_NONE, Date.CAL_GREGORIAN,
-                  (4, 77, 1789, False), "Text comment", newyear=2)
+            d.set(
+                Date.QUAL_NONE,
+                Date.MOD_NONE,
+                Date.CAL_GREGORIAN,
+                (4, 77, 1789, False),
+                "Text comment",
+                newyear=2,
+            )
 
     def test_invalid_span_day(self):
         d = Date()
         with self.assertRaises(DateError):
-            d.set(Date.QUAL_NONE, Date.MOD_SPAN, Date.CAL_GREGORIAN,
-                  (4, 7, 1789, False, 55, 8, 1876, False), "Text comment")
+            d.set(
+                Date.QUAL_NONE,
+                Date.MOD_SPAN,
+                Date.CAL_GREGORIAN,
+                (4, 7, 1789, False, 55, 8, 1876, False),
+                "Text comment",
+            )
 
     def test_invalid_span_month(self):
         d = Date()
         with self.assertRaises(DateError):
-            d.set(Date.QUAL_NONE, Date.MOD_SPAN, Date.CAL_GREGORIAN,
-                  (4, 7, 1789, False, 5, 88, 1876, False), "Text comment")
+            d.set(
+                Date.QUAL_NONE,
+                Date.MOD_SPAN,
+                Date.CAL_GREGORIAN,
+                (4, 7, 1789, False, 5, 88, 1876, False),
+                "Text comment",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -24,36 +24,49 @@
 
 """Support for dates."""
 
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 #
 # Set up logging
 #
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 import logging
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gnome/GTK modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 
 
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#------------------------------------------------------------------------
-from .gcalendar import (gregorian_sdn, julian_sdn, hebrew_sdn,
-                        french_sdn, persian_sdn, islamic_sdn, swedish_sdn,
-                        gregorian_ymd, julian_ymd, hebrew_ymd,
-                        french_ymd, persian_ymd, islamic_ymd,
-                        swedish_ymd)
+# ------------------------------------------------------------------------
+from .gcalendar import (
+    gregorian_sdn,
+    julian_sdn,
+    hebrew_sdn,
+    french_sdn,
+    persian_sdn,
+    islamic_sdn,
+    swedish_sdn,
+    gregorian_ymd,
+    julian_ymd,
+    hebrew_ymd,
+    french_ymd,
+    persian_ymd,
+    islamic_ymd,
+    swedish_ymd,
+)
 from ..config import config
 from ..errors import DateError
 from ..const import GRAMPS_LOCALE as glocale
+
 _ = glocale.translation.sgettext
 
 LOG = logging.getLogger(".Date")
+
 
 class Span:
     """
@@ -64,12 +77,14 @@ class Span:
     minmax = (min days, max days)
 
     """
-    BEFORE = config.get('behavior.date-before-range')
-    AFTER = config.get('behavior.date-after-range')
-    ABOUT = config.get('behavior.date-about-range')
-    ALIVE = config.get('behavior.max-age-prob-alive')
+
+    BEFORE = config.get("behavior.date-before-range")
+    AFTER = config.get("behavior.date-after-range")
+    ABOUT = config.get("behavior.date-about-range")
+    ALIVE = config.get("behavior.max-age-prob-alive")
+
     def __init__(self, date1, date2):
-        self.valid = (date1.sortval != 0 and date2.sortval != 0)
+        self.valid = date1.sortval != 0 and date2.sortval != 0
         self.date1 = date1
         self.date2 = date2
         self.sort = (-9999, -9999)
@@ -86,15 +101,15 @@ class Span:
             if self.date2.calendar != Date.CAL_GREGORIAN:
                 self.date2 = self.date2.to_calendar("gregorian")
             if self.date1.get_modifier() == Date.MOD_NONE:
-                if   self.date2.get_modifier() == Date.MOD_NONE:
+                if self.date2.get_modifier() == Date.MOD_NONE:
                     val = self.date1.sortval - self.date2.sortval
                     self.sort = (val, 0)
                     self.minmax = (val, val)
-                elif self.date2.get_modifier() == Date.MOD_BEFORE:
+                elif self.date2.get_modifier() in [Date.MOD_BEFORE, Date.MOD_TO]:
                     val = self.date1.sortval - self.date2.sortval
                     self.sort = (val, -Span.BEFORE)
                     self.minmax = (val - Span.BEFORE, val)
-                elif self.date2.get_modifier() == Date.MOD_AFTER:
+                elif self.date2.get_modifier() in [Date.MOD_AFTER, Date.MOD_FROM]:
                     val = self.date1.sortval - self.date2.sortval
                     self.sort = (val, Span.AFTER)
                     self.minmax = (val, val + Span.AFTER)
@@ -107,19 +122,19 @@ class Span:
                     start = Date(*start)
                     stop = Date(*stop)
                     val1 = self.date1.sortval - stop.sortval  # min
-                    val2 = self.date1.sortval - start.sortval # max
+                    val2 = self.date1.sortval - start.sortval  # max
                     self.sort = (val1, val2 - val1)
                     self.minmax = (val1, val2)
             elif self.date1.get_modifier() == Date.MOD_BEFORE:
-                if   self.date2.get_modifier() == Date.MOD_NONE:
+                if self.date2.get_modifier() == Date.MOD_NONE:
                     val = self.date1.sortval - self.date2.sortval
                     self.sort = (val, 0)
                     self.minmax = (0, val)
-                elif self.date2.get_modifier() == Date.MOD_BEFORE:
+                elif self.date2.get_modifier() in [Date.MOD_BEFORE, Date.MOD_TO]:
                     val = self.date1.sortval - self.date2.sortval
                     self.sort = (val, -Span.BEFORE)
                     self.minmax = (val, val + Span.BEFORE)
-                elif self.date2.get_modifier() == Date.MOD_AFTER:
+                elif self.date2.get_modifier() in [Date.MOD_AFTER, Date.MOD_FROM]:
                     val = self.date1.sortval - self.date2.sortval
                     self.sort = (val, -Span.AFTER)
                     self.minmax = (0, val)
@@ -136,11 +151,11 @@ class Span:
                     val = self.date1.sortval - self.date2.sortval
                     self.sort = (val, Span.AFTER)
                     self.minmax = (val, val + Span.AFTER)
-                elif self.date2.get_modifier() == Date.MOD_BEFORE:
+                elif self.date2.get_modifier() in [Date.MOD_BEFORE, Date.MOD_TO]:
                     val = self.date1.sortval - self.date2.sortval
                     self.sort = (val, Span.AFTER)
                     self.minmax = (val - Span.BEFORE, val + Span.AFTER)
-                elif self.date2.get_modifier() == Date.MOD_AFTER:
+                elif self.date2.get_modifier() in [Date.MOD_AFTER, Date.MOD_FROM]:
                     val = self.date1.sortval - self.date2.sortval
                     self.sort = (val, Span.AFTER)
                     self.minmax = (val, val + Span.AFTER)
@@ -157,11 +172,11 @@ class Span:
                     val = self.date1.sortval - self.date2.sortval
                     self.sort = (val, -Span.ABOUT)
                     self.minmax = (val - Span.ABOUT, val + Span.ABOUT)
-                elif self.date2.get_modifier() == Date.MOD_BEFORE:
+                elif self.date2.get_modifier() in [Date.MOD_BEFORE, Date.MOD_TO]:
                     val = self.date1.sortval - self.date2.sortval
                     self.sort = (val, -Span.BEFORE)
                     self.minmax = (val - Span.BEFORE, val + Span.ABOUT)
-                elif self.date2.get_modifier() == Date.MOD_AFTER:
+                elif self.date2.get_modifier() in [Date.MOD_AFTER, Date.MOD_FROM]:
                     val = self.date1.sortval - self.date2.sortval
                     self.sort = (val, Span.AFTER)
                     self.minmax = (val - Span.ABOUT, val + Span.ABOUT)
@@ -178,15 +193,15 @@ class Span:
                     start, stop = self.date1.get_start_stop_range()
                     start = Date(*start)
                     stop = Date(*stop)
-                    val1 = start.sortval - self.date2.sortval # min
-                    val2 = stop.sortval - self.date2.sortval # max
+                    val1 = start.sortval - self.date2.sortval  # min
+                    val2 = stop.sortval - self.date2.sortval  # max
                     self.sort = (val1, val2 - val1)
                     self.minmax = (val1, val2)
-                elif self.date2.get_modifier() == Date.MOD_BEFORE:
+                elif self.date2.get_modifier() in [Date.MOD_BEFORE, Date.MOD_TO]:
                     val = self.date1.sortval - self.date2.sortval
                     self.sort = (val, Span.BEFORE)
                     self.minmax = (val - Span.BEFORE, val + Span.BEFORE)
-                elif self.date2.get_modifier() == Date.MOD_AFTER:
+                elif self.date2.get_modifier() in [Date.MOD_AFTER, Date.MOD_FROM]:
                     val = self.date1.sortval - self.date2.sortval
                     self.sort = (val, -Span.AFTER)
                     self.minmax = (val - Span.AFTER, val + Span.AFTER)
@@ -202,7 +217,7 @@ class Span:
                     stop1 = Date(*stop1)
                     stop2 = Date(*stop2)
                     val1 = start1.sortval - stop2.sortval  # min
-                    val2 = stop1.sortval - start2.sortval # max
+                    val2 = stop1.sortval - start2.sortval  # max
                     self.sort = (val1, val2 - val1)
                     self.minmax = (val1, val2)
 
@@ -225,20 +240,20 @@ class Span:
         else:
             return self.sort[0] + self.sort[1]
 
-##    def __cmp__(self, other):
-##        """
-##        DEPRECATED - not available in python 3
-##
-##        Comparing two Spans for SORTING purposes.
-##        Use cmp(abs(int(span1)), abs(int(span2))) for comparing
-##        actual spans of times, as spans have directionality
-##        as indicated by negative values.
-##        """
-##        raise NotImplementedError
-##        if other is None:
-##            return cmp(int(self), -9999)
-##        else:
-##            return cmp(int(self), int(other))
+    ##    def __cmp__(self, other):
+    ##        """
+    ##        DEPRECATED - not available in python 3
+    ##
+    ##        Comparing two Spans for SORTING purposes.
+    ##        Use cmp(abs(int(span1)), abs(int(span2))) for comparing
+    ##        actual spans of times, as spans have directionality
+    ##        as indicated by negative values.
+    ##        """
+    ##        raise NotImplementedError
+    ##        if other is None:
+    ##            return cmp(int(self), -9999)
+    ##        else:
+    ##            return cmp(int(self), int(other))
 
     def as_age(self):
         """
@@ -275,8 +290,9 @@ class Span:
         # FIXME all this concatenation will fail for RTL languages -- really??
         if self.valid:
             fdate12 = self._format(self._diff(self.date1, self.date2), dlocale)
-            fdate12p1 = self._format(self._diff(self.date1, self.date2),
-                                     dlocale).format(precision=1)
+            fdate12p1 = self._format(
+                self._diff(self.date1, self.date2), dlocale
+            ).format(precision=1)
             if as_age and self._diff(self.date1, self.date2)[0] > Span.ALIVE:
                 _repr = trans_text("greater than %s years") % Span.ALIVE
             elif self.date1.get_modifier() == Date.MOD_NONE:
@@ -292,14 +308,17 @@ class Span:
                     start, stop = self.date2.get_start_stop_range()
                     start = Date(*start)
                     stop = Date(*stop)
-                    _repr = (trans_text("between") + " " +
-                             self._format(self._diff(self.date1, stop),
-                                          dlocale) + " " +
-                             trans_text("and") + " " +
-                             self._format(self._diff(self.date1, start),
-                                          dlocale))
+                    _repr = (
+                        trans_text("between")
+                        + " "
+                        + self._format(self._diff(self.date1, stop), dlocale)
+                        + " "
+                        + trans_text("and")
+                        + " "
+                        + self._format(self._diff(self.date1, start), dlocale)
+                    )
             elif self.date1.get_modifier() == Date.MOD_BEFORE:
-                if   self.date2.get_modifier() == Date.MOD_NONE:
+                if self.date2.get_modifier() == Date.MOD_NONE:
                     _repr = trans_text("less than") + " " + fdate12
                 elif self.date2.get_modifier() == Date.MOD_BEFORE:
                     _repr = self._format((-1, -1, -1))
@@ -310,7 +329,7 @@ class Span:
                 elif self.date2.is_compound():
                     _repr = trans_text("less than") + " " + fdate12
             elif self.date1.get_modifier() == Date.MOD_AFTER:
-                if   self.date2.get_modifier() == Date.MOD_NONE:
+                if self.date2.get_modifier() == Date.MOD_NONE:
                     _repr = trans_text("more than") + " " + fdate12
                 elif self.date2.get_modifier() == Date.MOD_BEFORE:
                     _repr = trans_text("more than") + " " + fdate12
@@ -321,7 +340,7 @@ class Span:
                 elif self.date2.is_compound():
                     _repr = trans_text("more than") + " " + fdate12
             elif self.date1.get_modifier() == Date.MOD_ABOUT:
-                if   self.date2.get_modifier() == Date.MOD_NONE:
+                if self.date2.get_modifier() == Date.MOD_NONE:
                     _repr = trans_text("about", "age") + " " + fdate12p1
                 elif self.date2.get_modifier() == Date.MOD_BEFORE:
                     _repr = trans_text("more than about") + " " + fdate12p1
@@ -332,16 +351,19 @@ class Span:
                 elif self.date2.is_compound():
                     _repr = trans_text("about", "age") + " " + fdate12p1
             elif self.date1.is_compound():
-                if   self.date2.get_modifier() == Date.MOD_NONE:
+                if self.date2.get_modifier() == Date.MOD_NONE:
                     start, stop = self.date1.get_start_stop_range()
                     start = Date(*start)
                     stop = Date(*stop)
-                    _repr = (trans_text("between") + " " +
-                             self._format(self._diff(start, self.date2),
-                                          dlocale) + " " +
-                             trans_text("and") + " " +
-                             self._format(self._diff(stop, self.date2),
-                                          dlocale))
+                    _repr = (
+                        trans_text("between")
+                        + " "
+                        + self._format(self._diff(start, self.date2), dlocale)
+                        + " "
+                        + trans_text("and")
+                        + " "
+                        + self._format(self._diff(stop, self.date2), dlocale)
+                    )
                 elif self.date2.get_modifier() == Date.MOD_BEFORE:
                     _repr = trans_text("more than") + " " + fdate12
                 elif self.date2.get_modifier() == Date.MOD_AFTER:
@@ -355,14 +377,19 @@ class Span:
                     start2 = Date(*start2)
                     stop1 = Date(*stop1)
                     stop2 = Date(*stop2)
-                    _repr = (trans_text("between") + " " +
-                             self._format(self._diff(start1, stop2), dlocale) +
-                             " " + trans_text("and") + " " +
-                             self._format(self._diff(stop1, start2), dlocale))
-        if _repr.find('-') == -1: # we don't have a negative value to return.
+                    _repr = (
+                        trans_text("between")
+                        + " "
+                        + self._format(self._diff(start1, stop2), dlocale)
+                        + " "
+                        + trans_text("and")
+                        + " "
+                        + self._format(self._diff(stop1, start2), dlocale)
+                    )
+        if _repr.find("-") == -1:  # we don't have a negative value to return.
             return _repr
         else:
-            return '(' + _repr.replace('-', '') + ')'
+            return "(" + _repr.replace("-", "") + ")"
 
     def __eq__(self, other):
         """
@@ -415,7 +442,7 @@ class Span:
         :param dlocale: allow deferred translation of strings
         :type dlocale: a :class:`.GrampsLocale` instance
         """
-        ngettext = dlocale.translation.ngettext # to see "nearby" comments
+        ngettext = dlocale.translation.ngettext  # to see "nearby" comments
         # trans_text is a defined keyword (see po/update_po.py, po/genpot.sh)
         trans_text = dlocale.translation.sgettext
         if diff_tuple == (-1, -1, -1):
@@ -424,25 +451,25 @@ class Span:
         detail = 0
         if diff_tuple[0] != 0:
             # Translators: leave all/any {...} untranslated
-            retval += ngettext("{number_of} year", "{number_of} years",
-                               diff_tuple[0]
-                              ).format(number_of=diff_tuple[0])
+            retval += ngettext(
+                "{number_of} year", "{number_of} years", diff_tuple[0]
+            ).format(number_of=diff_tuple[0])
             detail += 1
         if self.precision == detail:
-            if diff_tuple[1] >= 6: # round up years
+            if diff_tuple[1] >= 6:  # round up years
                 # Translators: leave all/any {...} untranslated
-                retval = ngettext("{number_of} year", "{number_of} years",
-                                  diff_tuple[0] + 1
-                                 ).format(number_of=diff_tuple[0] + 1)
+                retval = ngettext(
+                    "{number_of} year", "{number_of} years", diff_tuple[0] + 1
+                ).format(number_of=diff_tuple[0] + 1)
             return retval
         if diff_tuple[1] != 0:
             if retval != "":
                 # Translators: needed for Arabic, ignore otherwise
                 retval += trans_text(", ")
             # Translators: leave all/any {...} untranslated
-            retval += ngettext("{number_of} month", "{number_of} months",
-                               diff_tuple[1]
-                              ).format(number_of=diff_tuple[1])
+            retval += ngettext(
+                "{number_of} month", "{number_of} months", diff_tuple[1]
+            ).format(number_of=diff_tuple[1])
             detail += 1
         if self.precision == detail:
             return retval
@@ -451,9 +478,9 @@ class Span:
                 # Translators: needed for Arabic, ignore otherwise
                 retval += trans_text(", ")
             # Translators: leave all/any {...} untranslated
-            retval += ngettext("{number_of} day", "{number_of} days",
-                               diff_tuple[2]
-                              ).format(number_of=diff_tuple[2])
+            retval += ngettext(
+                "{number_of} day", "{number_of} days", diff_tuple[2]
+            ).format(number_of=diff_tuple[2])
             detail += 1
         if self.precision == detail:
             return retval
@@ -487,7 +514,7 @@ class Span:
         # months:
         if ymd2[1] > ymd1[1]:
             ymd1[0] -= 1  # from years
-            ymd1[1] += 12 # to months
+            ymd1[1] += 12  # to months
         days = ymd1[2] - ymd2[2]
         months = ymd1[1] - ymd2[1]
         years = ymd1[0] - ymd2[0]
@@ -501,7 +528,7 @@ class Span:
         # Check transitivity:
         if date1.is_full() and date2.is_full():
             edate = date1 - (years, months, days)
-            if edate < date2: # too small, strictly less than
+            if edate < date2:  # too small, strictly less than
                 diff = 0
                 while edate << date2 and diff < 60:
                     diff += 1
@@ -528,17 +555,19 @@ class Span:
         else:
             return (years, months, days)
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Date class
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class Date:
     """
     The core date handling class for Gramps.
 
     Supports partial dates, compound dates and alternate calendars.
     """
+
     MOD_NONE = 0  # CODE
     MOD_BEFORE = 1
     MOD_AFTER = 2
@@ -546,13 +575,15 @@ class Date:
     MOD_RANGE = 4
     MOD_SPAN = 5
     MOD_TEXTONLY = 6
+    MOD_FROM = 7
+    MOD_TO = 8
 
-    QUAL_NONE = 0 # BITWISE
+    QUAL_NONE = 0  # BITWISE
     QUAL_ESTIMATED = 1
     QUAL_CALCULATED = 2
-    #QUAL_INTERPRETED = 4 unused in source!!
+    # QUAL_INTERPRETED = 4 unused in source!!
 
-    CAL_GREGORIAN = 0 # CODE
+    CAL_GREGORIAN = 0  # CODE
     CAL_JULIAN = 1
     CAL_HEBREW = 2
     CAL_FRENCH = 3
@@ -561,7 +592,7 @@ class Date:
     CAL_SWEDISH = 6
     CALENDARS = range(7)
 
-    NEWYEAR_JAN1 = 0 # CODE
+    NEWYEAR_JAN1 = 0  # CODE
     NEWYEAR_MAR1 = 1
     NEWYEAR_MAR25 = 2
     NEWYEAR_SEP1 = 3
@@ -585,7 +616,7 @@ class Date:
         persian_sdn,
         islamic_sdn,
         swedish_sdn,
-        ]
+    ]
 
     _calendar_change = [
         gregorian_ymd,
@@ -595,24 +626,27 @@ class Date:
         persian_ymd,
         islamic_ymd,
         swedish_ymd,
-        ]
+    ]
 
-    calendar_names = ["Gregorian",
-                      "Julian",
-                      "Hebrew",
-                      "French Republican",
-                      "Persian",
-                      "Islamic",
-                      "Swedish"]
+    calendar_names = [
+        "Gregorian",
+        "Julian",
+        "Hebrew",
+        "French Republican",
+        "Persian",
+        "Islamic",
+        "Swedish",
+    ]
 
-
-    ui_calendar_names = [_("Gregorian", "calendar"),
-                         _("Julian", "calendar"),
-                         _("Hebrew", "calendar"),
-                         _("French Republican", "calendar"),
-                         _("Persian", "calendar"),
-                         _("Islamic", "calendar"),
-                         _("Swedish", "calendar")]
+    ui_calendar_names = [
+        _("Gregorian", "calendar"),
+        _("Julian", "calendar"),
+        _("Hebrew", "calendar"),
+        _("French Republican", "calendar"),
+        _("Persian", "calendar"),
+        _("Islamic", "calendar"),
+        _("Swedish", "calendar"),
+    ]
 
     def __init__(self, *source):
         """
@@ -629,7 +663,7 @@ class Date:
         elif len(source) == 2:
             source = (source[0], source[1], 0)
         elif len(source) == 3:
-            pass # source is ok
+            pass  # source is ok
         else:
             raise AttributeError("invalid args to Date: %s" % source)
         self.format = None
@@ -665,28 +699,48 @@ class Date:
         Convert to a series of tuples for data storage.
         """
         if no_text_date:
-            text = ''
+            text = ""
         else:
             text = self.text
 
-        return (self.calendar, self.modifier, self.quality,
-                self.dateval, text, self.sortval, self.newyear)
+        return (
+            self.calendar,
+            self.modifier,
+            self.quality,
+            self.dateval,
+            text,
+            self.sortval,
+            self.newyear,
+        )
 
     def unserialize(self, data):
         """
         Load from the format created by serialize.
         """
-        #FIXME: work around 3.1.0 error:
-        #2792: Dates in sourcereferences in person_ref_list not upgraded
-        #Added 2009/03/09
+        # FIXME: work around 3.1.0 error:
+        # 2792: Dates in sourcereferences in person_ref_list not upgraded
+        # Added 2009/03/09
         if len(data) == 7:
             # This is correct:
-            (self.calendar, self.modifier, self.quality,
-             self.dateval, self.text, self.sortval, self.newyear) = data
+            (
+                self.calendar,
+                self.modifier,
+                self.quality,
+                self.dateval,
+                self.text,
+                self.sortval,
+                self.newyear,
+            ) = data
         elif len(data) == 6:
             # This is necessary to fix 3.1.0 bug:
-            (self.calendar, self.modifier, self.quality,
-             self.dateval, self.text, self.sortval) = data
+            (
+                self.calendar,
+                self.modifier,
+                self.quality,
+                self.dateval,
+                self.text,
+                self.sortval,
+            ) = data
             self.newyear = 0
             # Remove all except if-part after 3.1.1
         else:
@@ -706,22 +760,18 @@ class Date:
             "title": _("Date"),
             "properties": {
                 "_class": {"enum": [cls.__name__]},
-                "calendar": {"type": "integer",
-                             "title": _("Calendar")},
-                "modifier": {"type": "integer",
-                             "title": _("Modifier")},
-                "quality": {"type": "integer",
-                            "title": _("Quality")},
-                "dateval": {"type": "array",
-                            "title": _("Values"),
-                            "items": {"type": ["integer", "boolean"]}},
-                "text": {"type": "string",
-                         "title": _("Text")},
-                "sortval": {"type": "integer",
-                            "title": _("Sort value")},
-                "newyear": {"type": "integer",
-                            "title": _("New year begins")}
-            }
+                "calendar": {"type": "integer", "title": _("Calendar")},
+                "modifier": {"type": "integer", "title": _("Modifier")},
+                "quality": {"type": "integer", "title": _("Quality")},
+                "dateval": {
+                    "type": "array",
+                    "title": _("Values"),
+                    "items": {"type": ["integer", "boolean"]},
+                },
+                "text": {"type": "string", "title": _("Text")},
+                "sortval": {"type": "integer", "title": _("Sort value")},
+                "newyear": {"type": "integer", "title": _("New year begins")},
+            },
         }
 
     def copy(self, source):
@@ -737,21 +787,21 @@ class Date:
         self.sortval = source.sortval
         self.newyear = source.newyear
 
-##   PYTHON 3 no __cmp__
-##    def __cmp__(self, other):
-##        """
-##        Compare two dates.
-##
-##        Comparison function. Allows the usage of equality tests.
-##        This allows you do run statements like 'date1 <= date2'
-##        """
-##        if isinstance(other, Date):
-##            return cmp(self.sortval, other.sortval)
-##        else:
-##            return -1
+    ##   PYTHON 3 no __cmp__
+    ##    def __cmp__(self, other):
+    ##        """
+    ##        Compare two dates.
+    ##
+    ##        Comparison function. Allows the usage of equality tests.
+    ##        This allows you do run statements like 'date1 <= date2'
+    ##        """
+    ##        if isinstance(other, Date):
+    ##            return cmp(self.sortval, other.sortval)
+    ##        else:
+    ##            return -1
 
     # Can't use this (as is) as this breaks comparing dates to None
-    #def __eq__(self, other):
+    # def __eq__(self, other):
     #    return self.sortval == other.sortval
 
     def __eq__(self, other):
@@ -761,7 +811,7 @@ class Date:
         if isinstance(other, Date):
             return self.sortval == other.sortval
         else:
-            #indicate this is not supported
+            # indicate this is not supported
             return False
 
     def __ne__(self, other):
@@ -771,7 +821,7 @@ class Date:
         if isinstance(other, Date):
             return self.sortval != other.sortval
         else:
-            #indicate this is not supported
+            # indicate this is not supported
             return True
 
     def __le__(self, other):
@@ -782,7 +832,7 @@ class Date:
         if isinstance(other, Date):
             return self.sortval <= other.sortval
         else:
-            #indicate this is not supported
+            # indicate this is not supported
             return NotImplemented
 
     def __ge__(self, other):
@@ -793,7 +843,7 @@ class Date:
         if isinstance(other, Date):
             return self.sortval >= other.sortval
         else:
-            #indicate this is not supported
+            # indicate this is not supported
             return NotImplemented
 
     def __add__(self, other):
@@ -817,11 +867,11 @@ class Date:
         """
         Date arithmetic: Date() - years, Date - (y,m,d), or Date() - Date().
         """
-        if isinstance(other, int):                # Date - value -> Date
+        if isinstance(other, int):  # Date - value -> Date
             return self.copy_offset_ymd(-other)
-        elif isinstance(other, (tuple, list)):    # Date - (y, m, d) -> Date
+        elif isinstance(other, (tuple, list)):  # Date - (y, m, d) -> Date
             return self.copy_offset_ymd(*[-i for i in other])
-        elif isinstance(other, type(self)):       # Date1 - Date2 -> tuple
+        elif isinstance(other, type(self)):  # Date1 - Date2 -> tuple
             return Span(self, other)
         else:
             raise AttributeError("unknown date sub type: %s " % type(other))
@@ -864,14 +914,15 @@ class Date:
         Needed, because the __cmp__ only looks at the sorting value, and
         ignores the modifiers/comments.
         """
-        if self.modifier == other.modifier \
-               and self.modifier == Date.MOD_TEXTONLY:
+        if self.modifier == other.modifier and self.modifier == Date.MOD_TEXTONLY:
             value = self.text == other.text
         else:
-            value = (self.calendar == other.calendar and
-                     self.modifier == other.modifier and
-                     self.quality == other.quality and
-                     self.dateval == other.dateval)
+            value = (
+                self.calendar == other.calendar
+                and self.modifier == other.modifier
+                and self.quality == other.quality
+                and self.dateval == other.dateval
+            )
         return value
 
     def get_start_stop_range(self):
@@ -894,8 +945,12 @@ class Date:
 
             Slash date is already taken care of.
             """
-            return (dateval[Date._POS_YR], dateval[Date._POS_MON],
-                    dateval[Date._POS_DAY])
+            return (
+                dateval[Date._POS_YR],
+                dateval[Date._POS_MON],
+                dateval[Date._POS_DAY],
+            )
+
         def date_offset(dateval, offset):
             """
             Local function to do date arithmetic: add the offset, return
@@ -906,7 +961,7 @@ class Date:
             return new_date.offset(offset)
 
         datecopy = Date(self)
-        #we do all calculation in Gregorian calendar
+        # we do all calculation in Gregorian calendar
         datecopy.convert_calendar(Date.CAL_GREGORIAN)
 
         start = yr_mon_day(datecopy.get_start_date())
@@ -916,7 +971,7 @@ class Date:
             stop = start
 
         stopmax = list(stop)
-        if stopmax[0] == 0: # then use start_year, if one
+        if stopmax[0] == 0:  # then use start_year, if one
             stopmax[0] = start[Date._POS_YR]
         if stopmax[1] == 0:
             stopmax[1] = 12
@@ -928,17 +983,18 @@ class Date:
         if startmin[2] == 0:
             startmin[2] = 1
         # if BEFORE, AFTER, or ABOUT/EST, adjust:
-        if self.modifier == Date.MOD_BEFORE:
-            stopmax = date_offset(startmin, -1)
-            fdiff = config.get('behavior.date-before-range')
+        if self.modifier in [Date.MOD_BEFORE, Date.MOD_TO]:
+            if self.modifier == Date.MOD_BEFORE:
+                stopmax = date_offset(startmin, -1)
+            fdiff = config.get("behavior.date-before-range")
             startmin = (stopmax[0] - fdiff, stopmax[1], stopmax[2])
-        elif self.modifier == Date.MOD_AFTER:
-            startmin = date_offset(stopmax, 1)
-            fdiff = config.get('behavior.date-after-range')
+        elif self.modifier in [Date.MOD_AFTER, Date.MOD_FROM]:
+            if self.modifier == Date.MOD_AFTER:
+                startmin = date_offset(stopmax, 1)
+            fdiff = config.get("behavior.date-after-range")
             stopmax = (startmin[0] + fdiff, startmin[1], startmin[2])
-        elif (self.modifier == Date.MOD_ABOUT or
-              self.quality == Date.QUAL_ESTIMATED):
-            fdiff = config.get('behavior.date-about-range')
+        elif self.modifier == Date.MOD_ABOUT or self.quality == Date.QUAL_ESTIMATED:
+            fdiff = config.get("behavior.date-about-range")
             startmin = (startmin[0] - fdiff, startmin[1], startmin[2])
             stopmax = (stopmax[0] + fdiff, stopmax[1], stopmax[2])
         # return tuples not lists, for comparisons
@@ -951,9 +1007,9 @@ class Date:
         """
         if other_date.modifier == Date.MOD_NONE:
             return other_date.sortval == self.sortval
-        elif other_date.modifier == Date.MOD_BEFORE:
+        elif other_date.modifier in [Date.MOD_BEFORE, Date.MOD_TO]:
             return other_date.sortval > self.sortval
-        elif other_date.modifier == Date.MOD_AFTER:
+        elif other_date.modifier in [Date.MOD_AFTER, Date.MOD_FROM]:
             return other_date.sortval < self.sortval
         elif other_date.is_compound():
             start, stop = other_date.get_start_stop_range()
@@ -977,13 +1033,17 @@ class Date:
         ==========  =======================================================
         =,==        True if any part of other_date matches any part of self
         <           True if any part of other_date < any part of self
+        <=          True if any part of other_date <= any part of self
         <<          True if all parts of other_date < all parts of self
         >           True if any part of other_date > any part of self
+        >=          True if any part of other_date >= any part of self
         >>          True if all parts of other_date > all parts of self
         ==========  =======================================================
         """
-        if (other_date.modifier == Date.MOD_TEXTONLY or
-                self.modifier == Date.MOD_TEXTONLY):
+        if (
+            other_date.modifier == Date.MOD_TEXTONLY
+            or self.modifier == Date.MOD_TEXTONLY
+        ):
             if comparison == "=":
                 return self.text.upper().find(other_date.text.upper()) != -1
             elif comparison == "==":
@@ -999,14 +1059,15 @@ class Date:
 
         if comparison == "=":
             # If some overlap then match is True, otherwise False.
-            return ((self_start <= other_start <= self_stop) or
-                    (self_start <= other_stop <= self_stop) or
-                    (other_start <= self_start <= other_stop) or
-                    (other_start <= self_stop <= other_stop))
+            return (
+                (self_start <= other_start <= self_stop)
+                or (self_start <= other_stop <= self_stop)
+                or (other_start <= self_start <= other_stop)
+                or (other_start <= self_stop <= other_stop)
+            )
         elif comparison == "==":
             # If they match exactly on start and stop
-            return ((self_start == other_start) and
-                    (other_stop == other_stop))
+            return (self_start == other_start) and (other_stop == other_stop)
         elif comparison == "<":
             # If any < any
             return self_start < other_stop
@@ -1026,8 +1087,7 @@ class Date:
             # If all > all
             return self_start > other_stop
         else:
-            raise AttributeError("invalid match comparison operator: '%s'" %
-                                 comparison)
+            raise AttributeError("invalid match comparison operator: '%s'" % comparison)
 
     def __str__(self):
         """
@@ -1049,6 +1109,10 @@ class Date:
             pref = "bef "
         elif self.modifier == Date.MOD_AFTER:
             pref = "aft "
+        elif self.modifier == Date.MOD_FROM:
+            pref = "from "
+        elif self.modifier == Date.MOD_TO:
+            pref = "to "
         elif self.modifier == Date.MOD_ABOUT:
             pref = "abt "
         else:
@@ -1074,16 +1138,23 @@ class Date:
                 self.dateval[Date._POS_YR] - 1,
                 (self.dateval[Date._POS_YR]) % 10,
                 self.dateval[Date._POS_MON],
-                self.dateval[Date._POS_DAY])
+                self.dateval[Date._POS_DAY],
+            )
         elif self.is_compound():
             val = "%04d-%02d-%02d - %04d-%02d-%02d" % (
-                self.dateval[Date._POS_YR], self.dateval[Date._POS_MON],
-                self.dateval[Date._POS_DAY], self.dateval[Date._POS_RYR],
-                self.dateval[Date._POS_RMON], self.dateval[Date._POS_RDAY])
+                self.dateval[Date._POS_YR],
+                self.dateval[Date._POS_MON],
+                self.dateval[Date._POS_DAY],
+                self.dateval[Date._POS_RYR],
+                self.dateval[Date._POS_RMON],
+                self.dateval[Date._POS_RDAY],
+            )
         else:
             val = "%04d-%02d-%02d" % (
-                self.dateval[Date._POS_YR], self.dateval[Date._POS_MON],
-                self.dateval[Date._POS_DAY])
+                self.dateval[Date._POS_YR],
+                self.dateval[Date._POS_MON],
+                self.dateval[Date._POS_DAY],
+            )
         return "%s%s%s%s" % (qual, pref, val, cal)
 
     def newyear_to_str(self):
@@ -1156,6 +1227,8 @@ class Date:
         MOD_AFTER     after
         MOD_ABOUT     about
         MOD_RANGE     date range
+        MOD_FROM      open ended date span
+        MOD_TO        open ended date span
         MOD_SPAN      date span
         MOD_TEXTONLY  text only
         ============  =====================
@@ -1166,9 +1239,17 @@ class Date:
         """
         Set the modifier for the date.
         """
-        if val not in (Date.MOD_NONE, Date.MOD_BEFORE, Date.MOD_AFTER,
-                       Date.MOD_ABOUT, Date.MOD_RANGE, Date.MOD_SPAN,
-                       Date.MOD_TEXTONLY):
+        if val not in (
+            Date.MOD_NONE,
+            Date.MOD_BEFORE,
+            Date.MOD_AFTER,
+            Date.MOD_ABOUT,
+            Date.MOD_RANGE,
+            Date.MOD_FROM,
+            Date.MOD_TO,
+            Date.MOD_SPAN,
+            Date.MOD_TEXTONLY,
+        ):
             raise DateError("Invalid modifier")
         self.modifier = val
 
@@ -1190,8 +1271,7 @@ class Date:
         """
         Set the quality selected for the date.
         """
-        if val not in (Date.QUAL_NONE, Date.QUAL_ESTIMATED,
-                       Date.QUAL_CALCULATED):
+        if val not in (Date.QUAL_NONE, Date.QUAL_ESTIMATED, Date.QUAL_CALCULATED):
             raise DateError("Invalid quality")
         self.quality = val
 
@@ -1340,8 +1420,9 @@ class Date:
         if self.is_compound() and remove_stop_date is None:
             raise DateError("Required parameter remove_stop_date not set!")
 
-        self.__set_yr_mon_day(year, month, day,
-                              Date._POS_YR, Date._POS_MON, Date._POS_DAY)
+        self.__set_yr_mon_day(
+            year, month, day, Date._POS_YR, Date._POS_MON, Date._POS_DAY
+        )
         self._calc_sort_value()
         if remove_stop_date and self.is_compound():
             self.set2_yr_mon_day(year, month, day)
@@ -1356,11 +1437,11 @@ class Date:
         a compound date (range or span).
         """
         self._assert_compound()
-        self.__set_yr_mon_day(year, month, day,
-                              Date._POS_RYR, Date._POS_RMON, Date._POS_RDAY)
+        self.__set_yr_mon_day(
+            year, month, day, Date._POS_RYR, Date._POS_RMON, Date._POS_RDAY
+        )
 
-    def __set_yr_mon_day_offset(self, year, month, day,
-                                pos_yr, pos_mon, pos_day):
+    def __set_yr_mon_day_offset(self, year, month, day, pos_yr, pos_mon, pos_day):
         dlist = list(self.dateval)
         if dlist[pos_yr]:
             dlist[pos_yr] += year
@@ -1374,13 +1455,13 @@ class Date:
             else:
                 dlist[pos_mon] = month
         # Fix if month out of bounds:
-        if month != 0: # only check if changed
-            if dlist[pos_mon] == 0: # subtraction
+        if month != 0:  # only check if changed
+            if dlist[pos_mon] == 0:  # subtraction
                 dlist[pos_mon] = 12
                 dlist[pos_yr] -= 1
-            elif dlist[pos_mon] < 0: # subtraction
+            elif dlist[pos_mon] < 0:  # subtraction
                 dlist[pos_yr] -= int((-dlist[pos_mon]) // 12) + 1
-                dlist[pos_mon] = (dlist[pos_mon] % 12)
+                dlist[pos_mon] = dlist[pos_mon] % 12
             elif dlist[pos_mon] > 12 or dlist[pos_mon] < 1:
                 dlist[pos_yr] += int(dlist[pos_mon] // 12)
                 dlist[pos_mon] = dlist[pos_mon] % 12
@@ -1392,8 +1473,9 @@ class Date:
         """
         Offset the date by the given year, month, and day values.
         """
-        if self.__set_yr_mon_day_offset(year, month, day, Date._POS_YR,
-                                        Date._POS_MON, Date._POS_DAY):
+        if self.__set_yr_mon_day_offset(
+            year, month, day, Date._POS_YR, Date._POS_MON, Date._POS_DAY
+        ):
             self.set_yr_mon_day(*self.offset(day), remove_stop_date=False)
         if self.is_compound():
             self.set2_yr_mon_day_offset(year, month, day)
@@ -1404,8 +1486,9 @@ class Date:
         of a compound date (range or span).
         """
         self._assert_compound()
-        if self.__set_yr_mon_day_offset(year, month, day, Date._POS_RYR,
-                                        Date._POS_RMON, Date._POS_RDAY):
+        if self.__set_yr_mon_day_offset(
+            year, month, day, Date._POS_RYR, Date._POS_RMON, Date._POS_RDAY
+        ):
             stop = Date(self.get_stop_ymd())
             self.set2_yr_mon_day(*stop.offset(day))
 
@@ -1440,7 +1523,7 @@ class Date:
         """
         Set the year value.
         """
-        self.dateval = self.dateval[0:2] + (year, ) + self.dateval[3:]
+        self.dateval = self.dateval[0:2] + (year,) + self.dateval[3:]
         self._calc_sort_value()
 
     def get_year_valid(self):
@@ -1560,7 +1643,7 @@ class Date:
         """
         nyear = self.get_new_year()
         year_delta = 0
-        if nyear: # new year offset?
+        if nyear:  # new year offset?
             if nyear == Date.NEWYEAR_MAR1:
                 split = (3, 1)
             elif nyear == Date.NEWYEAR_MAR25:
@@ -1573,15 +1656,23 @@ class Date:
                 split = (0, 0)
             if (self.get_month(), self.get_day()) >= split and split != (0, 0):
                 year_delta = -1
-                new_date = Date(self.get_year() + year_delta, self.get_month(),
-                                self.get_day())
+                new_date = Date(
+                    self.get_year() + year_delta, self.get_month(), self.get_day()
+                )
                 new_date.set_calendar(self.calendar)
                 new_date.recalc_sort_value()
                 self.sortval = new_date.sortval
         return year_delta
 
-    def set(self, quality=None, modifier=None, calendar=None,
-            value=None, text=None, newyear=0):
+    def set(
+        self,
+        quality=None,
+        modifier=None,
+        calendar=None,
+        value=None,
+        text=None,
+        newyear=0,
+    ):
         """
         Set the date to the specified value.
 
@@ -1618,25 +1709,45 @@ class Date:
         if value is None:
             value = self.dateval
 
-        if modifier in (Date.MOD_NONE, Date.MOD_BEFORE,
-                        Date.MOD_AFTER, Date.MOD_ABOUT) and len(value) < 4:
+        if (
+            modifier
+            in (
+                Date.MOD_NONE,
+                Date.MOD_BEFORE,
+                Date.MOD_AFTER,
+                Date.MOD_ABOUT,
+                Date.MOD_FROM,
+                Date.MOD_TO,
+            )
+            and len(value) < 4
+        ):
             raise DateError("Invalid value. Should be: (DD, MM, YY, slash)")
         if modifier in (Date.MOD_RANGE, Date.MOD_SPAN) and len(value) < 8:
-            raise DateError("Invalid value. Should be: (DD, MM, "
-                            "YY, slash1, DD, MM, YY, slash2)")
-        if modifier not in (Date.MOD_NONE, Date.MOD_BEFORE, Date.MOD_AFTER,
-                            Date.MOD_ABOUT, Date.MOD_RANGE, Date.MOD_SPAN,
-                            Date.MOD_TEXTONLY):
+            raise DateError(
+                "Invalid value. Should be: (DD, MM, " "YY, slash1, DD, MM, YY, slash2)"
+            )
+        if modifier not in (
+            Date.MOD_NONE,
+            Date.MOD_BEFORE,
+            Date.MOD_AFTER,
+            Date.MOD_ABOUT,
+            Date.MOD_RANGE,
+            Date.MOD_FROM,
+            Date.MOD_TO,
+            Date.MOD_SPAN,
+            Date.MOD_TEXTONLY,
+        ):
             raise DateError("Invalid modifier")
-        if quality not in (Date.QUAL_NONE, Date.QUAL_ESTIMATED,
-                           Date.QUAL_CALCULATED):
+        if quality not in (Date.QUAL_NONE, Date.QUAL_ESTIMATED, Date.QUAL_CALCULATED):
             raise DateError("Invalid quality")
         if calendar not in Date.CALENDARS:
             raise DateError("Invalid calendar")
         if newyear != 0 and calendar_has_fixed_newyear(calendar):
             raise DateError(
                 "May not adjust newyear to {ny} for calendar {cal}".format(
-                    ny=newyear, cal=calendar))
+                    ny=newyear, cal=calendar
+                )
+            )
 
         self.quality = quality
         self.modifier = modifier
@@ -1644,9 +1755,8 @@ class Date:
         self.dateval = value
         self.set_new_year(newyear)
         year, month, day = self._zero_adjust_ymd(
-            value[Date._POS_YR],
-            value[Date._POS_MON],
-            value[Date._POS_DAY])
+            value[Date._POS_YR], value[Date._POS_MON], value[Date._POS_DAY]
+        )
 
         if year == month == day == 0:
             self.sortval = 0
@@ -1683,32 +1793,37 @@ class Date:
                 try:
                     self.__compare(sanity.dateval, value, year_delta)
                 except DateError as err:
-                    LOG.debug("Sanity check failed - self: {}, sanity: {}".
-                              format(self.__dict__, sanity.__dict__))
+                    LOG.debug(
+                        "Sanity check failed - self: {}, sanity: {}".format(
+                            self.__dict__, sanity.__dict__
+                        )
+                    )
                     err.date = self
                     raise
 
     def __compare(self, sanity, value, year_delta):
         ziplist = zip(sanity, value)
         # Loop over all values present, whether compound or not
-        for day, month, year, slash in zip(*[iter(ziplist)]*4):
+        for day, month, year, slash in zip(*[iter(ziplist)] * 4):
             # each of d,m,y,sl is a pair from dateval and value, to compare
             adjusted, original = slash
             if adjusted != original:
-                raise DateError("Invalid date value {}".
-                                format(value))
+                raise DateError("Invalid date value {}".format(value))
 
             for adjusted, original in day, month:
-                if adjusted != original and not(original == 0 and
-                                                adjusted == 1):
-                    raise DateError("Invalid day/month {} passed in value {}".
-                                    format(original, value))
+                if adjusted != original and not (original == 0 and adjusted == 1):
+                    raise DateError(
+                        "Invalid day/month {} passed in value {}".format(
+                            original, value
+                        )
+                    )
 
             adjusted, original = year
             adjusted -= year_delta
-            if adjusted != original and not(original == 0 and adjusted == 1):
-                raise DateError("Invalid year {} passed in value {}".
-                                format(original, value))
+            if adjusted != original and not (original == 0 and adjusted == 1):
+                raise DateError(
+                    "Invalid year {} passed in value {}".format(original, value)
+                )
 
     def recalc_sort_value(self):
         """
@@ -1725,7 +1840,8 @@ class Date:
         year, month, day = self._zero_adjust_ymd(
             self.dateval[Date._POS_YR],
             self.dateval[Date._POS_MON],
-            self.dateval[Date._POS_DAY])
+            self.dateval[Date._POS_DAY],
+        )
         if year == month == 0 and day == 0:
             self.sortval = 0
         else:
@@ -1736,20 +1852,22 @@ class Date:
         """
         Convert the date from the current calendar to the specified calendar.
         """
-        if (known_valid  # if not known valid, round-trip convert anyway
-                and calendar == self.calendar
-                and self.newyear == Date.NEWYEAR_JAN1):
+        if (
+            known_valid  # if not known valid, round-trip convert anyway
+            and calendar == self.calendar
+            and self.newyear == Date.NEWYEAR_JAN1
+        ):
             return
         (year, month, day) = Date._calendar_change[calendar](self.sortval)
         if self.is_compound():
             ryear, rmonth, rday = self._zero_adjust_ymd(
                 self.dateval[Date._POS_RYR],
                 self.dateval[Date._POS_RMON],
-                self.dateval[Date._POS_RDAY])
+                self.dateval[Date._POS_RDAY],
+            )
             sdn = Date._calendar_convert[self.calendar](ryear, rmonth, rday)
             (nyear, nmonth, nday) = Date._calendar_change[calendar](sdn)
-            self.dateval = (day, month, year, False,
-                            nday, nmonth, nyear, False)
+            self.dateval = (day, month, year, False, nday, nmonth, nyear, False)
         else:
             self.dateval = (day, month, year, False)
         self.calendar = calendar
@@ -1773,16 +1891,17 @@ class Date:
         """
         Return True if the date contains no information (empty text).
         """
-        return not((self.modifier == Date.MOD_TEXTONLY and self.text)
-               or self.get_start_date() != Date.EMPTY
-                or self.get_stop_date() != Date.EMPTY)
+        return not (
+            (self.modifier == Date.MOD_TEXTONLY and self.text)
+            or self.get_start_date() != Date.EMPTY
+            or self.get_stop_date() != Date.EMPTY
+        )
 
     def is_compound(self):
         """
         Return True if the date is a date range or a date span.
         """
-        return self.modifier == Date.MOD_RANGE \
-               or self.modifier == Date.MOD_SPAN
+        return self.modifier == Date.MOD_RANGE or self.modifier == Date.MOD_SPAN
 
     def is_regular(self):
         """
@@ -1792,18 +1911,19 @@ class Date:
         a range or a span, not estimated/calculated, not about/before/after
         date, and having year, month, and day all non-zero.
         """
-        return self.modifier == Date.MOD_NONE \
-               and self.quality == Date.QUAL_NONE \
-               and self.get_year_valid() and self.get_month_valid() \
-               and self.get_day_valid()
+        return (
+            self.modifier == Date.MOD_NONE
+            and self.quality == Date.QUAL_NONE
+            and self.get_year_valid()
+            and self.get_month_valid()
+            and self.get_day_valid()
+        )
 
     def is_full(self):
         """
         Return True if the date is fully specified.
         """
-        return (self.get_year_valid() and
-                self.get_month_valid() and
-                self.get_day_valid())
+        return self.get_year_valid() and self.get_month_valid() and self.get_day_valid()
 
     def get_ymd(self):
         """
@@ -1816,8 +1936,7 @@ class Date:
         Return (day, month, year, [slash]).
         """
         if get_slash:
-            return (self.get_day(), self.get_month(), self.get_year(),
-                    self.get_slash())
+            return (self.get_day(), self.get_month(), self.get_year(), self.get_slash())
         else:
             return (self.get_day(), self.get_month(), self.get_year())
 
@@ -1826,8 +1945,7 @@ class Date:
         Return (year, month, day) of the stop date, or all-zeros if it's not
         defined.
         """
-        return (self.get_stop_year(), self.get_stop_month(),
-                self.get_stop_day())
+        return (self.get_stop_year(), self.get_stop_month(), self.get_stop_day())
 
     def offset(self, value):
         """
@@ -1839,8 +1957,7 @@ class Date:
         """
         Return (year, month, day) of this date +- value.
         """
-        return Date(Date._calendar_change[Date.CAL_GREGORIAN](self.sortval +
-                                                              value))
+        return Date(Date._calendar_change[Date.CAL_GREGORIAN](self.sortval + value))
 
     def lookup_calendar(self, calendar):
         """
@@ -1853,8 +1970,7 @@ class Date:
         Lookup date quality keyword, even if translated.
         """
         qualities = ["none", "estimated", "calculated"]
-        ui_qualities = [_("none", "date-quality"),
-                        _("estimated"), _("calculated")]
+        ui_qualities = [_("none", "date-quality"), _("estimated"), _("calculated")]
         if quality.lower() in qualities:
             return qualities.index(quality.lower())
         elif quality.lower() in ui_qualities:
@@ -1866,11 +1982,28 @@ class Date:
         """
         Lookup date modifier keyword, even if translated.
         """
-        mods = ["none", "before", "after", "about",
-                "range", "span", "textonly"]
-        ui_mods = [_("none", "date-modifier"),
-                   _("before"), _("after"), _("about"),
-                   _("range"), _("span"), _("textonly")]
+        mods = [
+            "none",
+            "before",
+            "after",
+            "about",
+            "range",
+            "from",
+            "to",
+            "span",
+            "textonly",
+        ]
+        ui_mods = [
+            _("none", "date-modifier"),
+            _("before"),
+            _("after"),
+            _("about"),
+            _("range"),
+            _("from"),
+            _("to"),
+            _("span"),
+            _("textonly"),
+        ]
         if modifier.lower() in mods:
             return mods.index(modifier.lower())
         elif modifier.lower() in ui_mods:
@@ -1933,14 +2066,17 @@ class Date:
 
     year = property(get_year, set_year)
 
+
 def Today():
     """
     Returns a Date object set to the current date.
     """
     import time
+
     current_date = Date()
     current_date.set_yr_mon_day(*time.localtime(time.time())[0:3])
     return current_date
+
 
 def NextYear():
     """
@@ -1948,11 +2084,12 @@ def NextYear():
     """
     return Today() + 1
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # Date Functions
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 
 
 def lookup_calendar(calendar):
@@ -1962,8 +2099,10 @@ def lookup_calendar(calendar):
     >>> lookup_calendar("hebrew")
     2
     """
-    if calendar is None: return Date.CAL_GREGORIAN
-    if isinstance(calendar, int): return calendar
+    if calendar is None:
+        return Date.CAL_GREGORIAN
+    if isinstance(calendar, int):
+        return calendar
     for pos, calendar_name in enumerate(Date.calendar_names):
         if calendar.lower() == calendar_name.lower():
             return pos
@@ -1972,12 +2111,14 @@ def lookup_calendar(calendar):
             return pos
     raise AttributeError("invalid calendar: '%s'" % calendar)
 
+
 def gregorian(date):
     """Convert given date to gregorian. Doesn't modify the original object."""
     if date.get_calendar() != Date.CAL_GREGORIAN:
         date = Date(date)
         date.convert_calendar(Date.CAL_GREGORIAN)
     return date
+
 
 def calendar_has_fixed_newyear(cal):
     """Does the given calendar have a fixed new year, or may it be reset?"""

--- a/gramps/gen/lib/test/date_test.py
+++ b/gramps/gen/lib/test/date_test.py
@@ -21,18 +21,18 @@
 
 """ Unittest for testing dates """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Standard python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import unittest
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from ...config import config
 from ...datehandler import get_date_formats, set_format
 from ...datehandler import parser as _dp
@@ -47,21 +47,34 @@ testset = "basic test"
 dates = []
 calendar = Date.CAL_GREGORIAN
 for quality in (Date.QUAL_NONE, Date.QUAL_ESTIMATED, Date.QUAL_CALCULATED):
-    for modifier in (Date.MOD_NONE, Date.MOD_BEFORE, Date.MOD_AFTER, Date.MOD_ABOUT):
-        for month in range(1,13):
+    for modifier in (
+        Date.MOD_NONE,
+        Date.MOD_BEFORE,
+        Date.MOD_AFTER,
+        Date.MOD_ABOUT,
+        Date.MOD_FROM,
+        Date.MOD_TO,
+    ):
+        for month in range(1, 13):
             d = Date()
-            d.set(quality,modifier,calendar,(4,month,1789,False),"Text comment")
-            dates.append( d)
+            d.set(quality, modifier, calendar, (4, month, 1789, False), "Text comment")
+            dates.append(d)
     for modifier in (Date.MOD_RANGE, Date.MOD_SPAN):
-        for month1 in range(1,13):
-            for month2 in range(1,13):
+        for month1 in range(1, 13):
+            for month2 in range(1, 13):
                 d = Date()
-                d.set(quality,modifier,calendar,(4,month1,1789,False,5,month2,1876,False),"Text comment")
-                dates.append( d)
+                d.set(
+                    quality,
+                    modifier,
+                    calendar,
+                    (4, month1, 1789, False, 5, month2, 1876, False),
+                    "Text comment",
+                )
+                dates.append(d)
     modifier = Date.MOD_TEXTONLY
     d = Date()
-    d.set(quality,modifier,calendar,Date.EMPTY,"This is a textual date")
-    dates.append( d)
+    d.set(quality, modifier, calendar, Date.EMPTY, "This is a textual date")
+    dates.append(d)
 date_tests[testset] = dates
 
 # incomplete dates (day or month missing)
@@ -69,38 +82,93 @@ testset = "partial date"
 dates = []
 calendar = Date.CAL_GREGORIAN
 for quality in (Date.QUAL_NONE, Date.QUAL_ESTIMATED, Date.QUAL_CALCULATED):
-    for modifier in (Date.MOD_NONE, Date.MOD_BEFORE, Date.MOD_AFTER, Date.MOD_ABOUT):
+    for modifier in (
+        Date.MOD_NONE,
+        Date.MOD_BEFORE,
+        Date.MOD_AFTER,
+        Date.MOD_ABOUT,
+        Date.MOD_FROM,
+        Date.MOD_TO,
+    ):
         d = Date()
-        d.set(quality,modifier,calendar,(0,11,1789,False),"Text comment")
-        dates.append( d)
+        d.set(quality, modifier, calendar, (0, 11, 1789, False), "Text comment")
+        dates.append(d)
         d = Date()
-        d.set(quality,modifier,calendar,(0,0,1789,False),"Text comment")
-        dates.append( d)
+        d.set(quality, modifier, calendar, (0, 0, 1789, False), "Text comment")
+        dates.append(d)
     for modifier in (Date.MOD_RANGE, Date.MOD_SPAN):
         d = Date()
-        d.set(quality,modifier,calendar,(4,10,1789,False,0,11,1876,False),"Text comment")
-        dates.append( d)
+        d.set(
+            quality,
+            modifier,
+            calendar,
+            (4, 10, 1789, False, 0, 11, 1876, False),
+            "Text comment",
+        )
+        dates.append(d)
         d = Date()
-        d.set(quality,modifier,calendar,(4,10,1789,False,0,0,1876,False),"Text comment")
-        dates.append( d)
+        d.set(
+            quality,
+            modifier,
+            calendar,
+            (4, 10, 1789, False, 0, 0, 1876, False),
+            "Text comment",
+        )
+        dates.append(d)
         d = Date()
-        d.set(quality,modifier,calendar,(0,10,1789,False,5,11,1876,False),"Text comment")
-        dates.append( d)
+        d.set(
+            quality,
+            modifier,
+            calendar,
+            (0, 10, 1789, False, 5, 11, 1876, False),
+            "Text comment",
+        )
+        dates.append(d)
         d = Date()
-        d.set(quality,modifier,calendar,(0,10,1789,False,0,11,1876,False),"Text comment")
-        dates.append( d)
+        d.set(
+            quality,
+            modifier,
+            calendar,
+            (0, 10, 1789, False, 0, 11, 1876, False),
+            "Text comment",
+        )
+        dates.append(d)
         d = Date()
-        d.set(quality,modifier,calendar,(0,10,1789,False,0,0,1876,False),"Text comment")
-        dates.append( d)
+        d.set(
+            quality,
+            modifier,
+            calendar,
+            (0, 10, 1789, False, 0, 0, 1876, False),
+            "Text comment",
+        )
+        dates.append(d)
         d = Date()
-        d.set(quality,modifier,calendar,(0,0,1789,False,5,11,1876,False),"Text comment")
-        dates.append( d)
+        d.set(
+            quality,
+            modifier,
+            calendar,
+            (0, 0, 1789, False, 5, 11, 1876, False),
+            "Text comment",
+        )
+        dates.append(d)
         d = Date()
-        d.set(quality,modifier,calendar,(0,0,1789,False,0,11,1876,False),"Text comment")
-        dates.append( d)
+        d.set(
+            quality,
+            modifier,
+            calendar,
+            (0, 0, 1789, False, 0, 11, 1876, False),
+            "Text comment",
+        )
+        dates.append(d)
         d = Date()
-        d.set(quality,modifier,calendar,(0,0,1789,False,0,0,1876,False),"Text comment")
-        dates.append( d)
+        d.set(
+            quality,
+            modifier,
+            calendar,
+            (0, 0, 1789, False, 0, 0, 1876, False),
+            "Text comment",
+        )
+        dates.append(d)
 date_tests[testset] = dates
 
 # slash-dates
@@ -108,21 +176,46 @@ testset = "slash-dates"
 dates = []
 calendar = Date.CAL_GREGORIAN
 for quality in (Date.QUAL_NONE, Date.QUAL_ESTIMATED, Date.QUAL_CALCULATED):
-    for modifier in (Date.MOD_NONE, Date.MOD_BEFORE, Date.MOD_AFTER, Date.MOD_ABOUT):
+    for modifier in (
+        Date.MOD_NONE,
+        Date.MOD_BEFORE,
+        Date.MOD_AFTER,
+        Date.MOD_ABOUT,
+        Date.MOD_FROM,
+        Date.MOD_TO,
+    ):
         # normal date
         d = Date()
-        d.set(quality,modifier,calendar,(4,11,1789,True),"Text comment")
-        dates.append( d)
+        d.set(quality, modifier, calendar, (4, 11, 1789, True), "Text comment")
+        dates.append(d)
     for modifier in (Date.MOD_RANGE, Date.MOD_SPAN):
         d = Date()
-        d.set(quality,modifier,calendar,(4,11,1789,True,5,10,1876,False),"Text comment")
-        dates.append( d)
+        d.set(
+            quality,
+            modifier,
+            calendar,
+            (4, 11, 1789, True, 5, 10, 1876, False),
+            "Text comment",
+        )
+        dates.append(d)
         d = Date()
-        d.set(quality,modifier,calendar,(4,11,1789,False,5,10,1876,True),"Text comment")
-        dates.append( d)
+        d.set(
+            quality,
+            modifier,
+            calendar,
+            (4, 11, 1789, False, 5, 10, 1876, True),
+            "Text comment",
+        )
+        dates.append(d)
         d = Date()
-        d.set(quality,modifier,calendar,(4,11,1789,True,5,10,1876,True),"Text comment")
-        dates.append( d)
+        d.set(
+            quality,
+            modifier,
+            calendar,
+            (4, 11, 1789, True, 5, 10, 1876, True),
+            "Text comment",
+        )
+        dates.append(d)
 date_tests[testset] = dates
 
 # BCE
@@ -130,74 +223,116 @@ testset = "B. C. E."
 dates = []
 calendar = Date.CAL_GREGORIAN
 for quality in (Date.QUAL_NONE, Date.QUAL_ESTIMATED, Date.QUAL_CALCULATED):
-    for modifier in (Date.MOD_NONE, Date.MOD_BEFORE, Date.MOD_AFTER, Date.MOD_ABOUT):
+    for modifier in (
+        Date.MOD_NONE,
+        Date.MOD_BEFORE,
+        Date.MOD_AFTER,
+        Date.MOD_ABOUT,
+        Date.MOD_FROM,
+        Date.MOD_TO,
+    ):
         # normal date
         d = Date()
-        d.set(quality,modifier,calendar,(4,11,-90,False),"Text comment")
-        dates.append( d)
+        d.set(quality, modifier, calendar, (4, 11, -90, False), "Text comment")
+        dates.append(d)
     for modifier in (Date.MOD_RANGE, Date.MOD_SPAN):
         d = Date()
-        d.set(quality,modifier,calendar,(5,10,-90,False,4,11,-90,False),"Text comment")
-        dates.append( d)
-        d = Date()
+        d.set(
+            quality,
+            modifier,
+            calendar,
+            (5, 10, -90, False, 4, 11, -90, False),
+            "Text comment",
+        )
+        dates.append(d)
 date_tests[testset] = dates
 
 # test for all other different calendars
 testset = "Non-gregorian"
 dates = []
-for calendar in (Date.CAL_JULIAN,
-                 Date.CAL_HEBREW,
-                 Date.CAL_ISLAMIC,
-                 Date.CAL_FRENCH,
-                 Date.CAL_PERSIAN,
-                 ):
+for calendar in (
+    Date.CAL_JULIAN,
+    Date.CAL_HEBREW,
+    Date.CAL_ISLAMIC,
+    Date.CAL_FRENCH,
+    Date.CAL_PERSIAN,
+):
     for quality in (Date.QUAL_NONE, Date.QUAL_ESTIMATED, Date.QUAL_CALCULATED):
-        for modifier in (Date.MOD_NONE, Date.MOD_BEFORE, Date.MOD_AFTER, Date.MOD_ABOUT):
+        for modifier in (
+            Date.MOD_NONE,
+            Date.MOD_BEFORE,
+            Date.MOD_AFTER,
+            Date.MOD_ABOUT,
+            Date.MOD_FROM,
+            Date.MOD_TO,
+        ):
             d = Date()
-            d.set(quality,modifier,calendar,(4,11,1789,False),"Text comment")
-            dates.append( d)
+            d.set(quality, modifier, calendar, (4, 11, 1789, False), "Text comment")
+            dates.append(d)
         for modifier in (Date.MOD_RANGE, Date.MOD_SPAN):
             d = Date()
-            d.set(quality,modifier,calendar,(4,10,1789,False,5,11,1876,False),"Text comment")
-            dates.append( d)
+            d.set(
+                quality,
+                modifier,
+                calendar,
+                (4, 10, 1789, False, 5, 11, 1876, False),
+                "Text comment",
+            )
+            dates.append(d)
 
 # CAL_SWEDISH    - Swedish calendar 1700-03-01 -> 1712-02-30!
 class Context:
     def __init__(self, retval):
         self.retval = retval
+
     def __enter__(self):
         return self.retval
+
     def __exit__(self, *args, **kwargs):
         pass
 
+
 with Context(Date.CAL_SWEDISH) as calendar:
     for quality in (Date.QUAL_NONE, Date.QUAL_ESTIMATED, Date.QUAL_CALCULATED):
-        for modifier in (Date.MOD_NONE, Date.MOD_BEFORE, Date.MOD_AFTER, Date.MOD_ABOUT):
+        for modifier in (
+            Date.MOD_NONE,
+            Date.MOD_BEFORE,
+            Date.MOD_AFTER,
+            Date.MOD_ABOUT,
+            Date.MOD_FROM,
+            Date.MOD_TO,
+        ):
             d = Date()
-            d.set(quality,modifier,calendar,(4,11,1700,False),"Text comment")
-            dates.append( d)
+            d.set(quality, modifier, calendar, (4, 11, 1700, False), "Text comment")
+            dates.append(d)
         for modifier in (Date.MOD_RANGE, Date.MOD_SPAN):
             d = Date()
-            d.set(quality,modifier,calendar,(4,10,1701,False,
-                                             5,11,1702,False),"Text comment")
-            dates.append( d)
+            d.set(
+                quality,
+                modifier,
+                calendar,
+                (4, 10, 1701, False, 5, 11, 1702, False),
+                "Text comment",
+            )
+            dates.append(d)
 
 quality = Date.QUAL_NONE
 modifier = Date.MOD_NONE
-for calendar in (Date.CAL_JULIAN,
-                 Date.CAL_ISLAMIC,
-                 Date.CAL_PERSIAN,
-                 ):
-    for month in range(1,13):
+for calendar in (
+    Date.CAL_JULIAN,
+    Date.CAL_ISLAMIC,
+    Date.CAL_PERSIAN,
+):
+    for month in range(1, 13):
         d = Date()
-        d.set(quality,modifier,calendar,(4,month,1789,False),"Text comment")
-        dates.append( d)
+        d.set(quality, modifier, calendar, (4, month, 1789, False), "Text comment")
+        dates.append(d)
 
 for calendar in (Date.CAL_HEBREW, Date.CAL_FRENCH):
-    for month in range(1,14):
+    for month in range(1, 14):
         d = Date()
-        d.set(quality,modifier,calendar,(4,month,1789,False),"Text comment")
-        dates.append( d)
+        d.set(quality, modifier, calendar, (4, month, 1789, False), "Text comment")
+        dates.append(d)
 
 date_tests[testset] = dates
 
@@ -205,35 +340,37 @@ swedish_dates = []
 # CAL_SWEDISH    - Swedish calendar 1700-03-01 -> 1712-02-30!
 with Context(Date.CAL_SWEDISH) as calendar:
     for year in range(1701, 1712):
-        for month in range(1,13):
+        for month in range(1, 13):
             d = Date()
-            d.set(quality,modifier,calendar,(4,month,year,False),"Text comment")
-            swedish_dates.append( d)
+            d.set(quality, modifier, calendar, (4, month, year, False), "Text comment")
+            swedish_dates.append(d)
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # BaseDateTest
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class BaseDateTest(unittest.TestCase):
     """
     Base class for all date tests.
     """
+
     def setUp(self):
-        config.set('behavior.date-before-range', 9999)
-        config.set('behavior.date-after-range', 9999)
-        config.set('behavior.date-about-range', 10)
+        config.set("behavior.date-before-range", 9999)
+        config.set("behavior.date-after-range", 9999)
+        config.set("behavior.date-about-range", 10)
 
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # ParserDateTest
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class ParserDateTest(BaseDateTest):
     """
     Date displayer and parser tests.
     """
+
     def do_case(self, testset):
         for index, date_format in enumerate(get_date_formats()):
             set_format(index)
@@ -241,12 +378,13 @@ class ParserDateTest(BaseDateTest):
             for dateval in date_tests[testset]:
                 datestr = _dd.display(dateval)
                 ndate = _dp.parse(datestr)
-                self.assertTrue(dateval.is_equal(ndate),
-                                "dateval fails is_equal in format %d:\n"
-                                "   '%s' != '%s'\n"
-                                "   '%s' != '%s'\n" %
-                                (index, dateval, ndate,
-                                 dateval.__dict__, ndate.__dict__))
+                self.assertTrue(
+                    dateval.is_equal(ndate),
+                    "dateval fails is_equal in format %d:\n"
+                    "   '%s' != '%s'\n"
+                    "   '%s' != '%s'\n"
+                    % (index, dateval, ndate, dateval.__dict__, ndate.__dict__),
+                )
 
     def test_basic(self):
         self.do_case("basic test")
@@ -264,103 +402,117 @@ class ParserDateTest(BaseDateTest):
         self.do_case("Non-gregorian")
 
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # MatchDateTest
 #
-#-------------------------------------------------------------------------
-ENGLISH_DATE_HANDLER = (_dd.__class__ == DateDisplayEn)
-@unittest.skipUnless(ENGLISH_DATE_HANDLER,
-        "This test of Date() matching logic can only run in English locale.")
+# -------------------------------------------------------------------------
+ENGLISH_DATE_HANDLER = _dd.__class__ == DateDisplayEn
+
+
+@unittest.skipUnless(
+    ENGLISH_DATE_HANDLER,
+    "This test of Date() matching logic can only run in English locale.",
+)
 class MatchDateTest(BaseDateTest):
     """
     Date match tests.
     """
-    tests = [("before 1960", "before 1961", True),
-             ("before 1960", "before 1960", True),
-             ("before 1961", "before 1961", True),
-             ("jan 1, 1960", "jan 1, 1960", True),
-             ("dec 31, 1959", "dec 31, 1959", True),
-             ("before 1960", "jan 1, 1960", False),
-             ("before 1960", "dec 31, 1959", True),
-             ("abt 1960", "1960", True),
-             ("abt 1960", "before 1960", True),
-             ("1960", "1960", True),
-             ("1960", "after 1960", False),
-             ("1960", "before 1960", False),
-             ("abt 1960", "abt 1960", True),
-             ("before 1960", "after 1960", False),
-             ("after jan 1, 1900", "jan 2, 1900", True),
-             ("abt jan 1, 1900", "jan 1, 1900", True),
-             ("from 1950 to 1955", "1950", True),
-             ("from 1950 to 1955", "1951", True),
-             ("from 1950 to 1955", "1952", True),
-             ("from 1950 to 1955", "1953", True),
-             ("from 1950 to 1955", "1954", True),
-             ("from 1950 to 1955", "1955", True),
-             ("from 1950 to 1955", "1956", False),
-             ("from 1950 to 1955", "dec 31, 1955", True),
-             ("from 1950 to 1955", "jan 1, 1955", True),
-             ("from 1950 to 1955", "dec 31, 1949", False),
-             ("from 1950 to 1955", "jan 1, 1956", False),
-             ("after jul 4, 1980", "jul 4, 1980", False),
-             ("after jul 4, 1980", "before jul 4, 1980", False),
-             ("after jul 4, 1980", "about jul 4, 1980", True),
-             ("after jul 4, 1980", "after jul 4, 1980", True),
-             ("between 1750 and 1752", "1750", True),
-             ("between 1750 and 1752", "about 1750", True),
-             ("between 1750 and 1752", "between 1749 and 1750", True),
-             ("between 1750 and 1752", "1749", False),
-             ("invalid date", "invalid date", True),
-             ("invalid date", "invalid", False, True),
-             ("invalid date 1", "invalid date 2", False),
-             ("abt jan 1, 2000", "dec 31, 1999", True),
-             ("jan 1, 2000", "dec 31, 1999", False),
-             ("aft jan 1, 2000", "dec 31, 1999", False),
-             ("after jan 1, 2000", "after dec 31, 1999", True),
-             ("after dec 31, 1999", "after jan 1, 2000", True),
-             ("1 31, 2000", "jan 1, 2000", False),
-             ("dec 31, 1999", "jan 1, 2000", False),
-             ("jan 1, 2000", "before dec 31, 1999", False),
-             ("aft jan 1, 2000", "before dec 31, 1999", False),
-             ("before jan 1, 2000", "after dec 31, 1999", False),
-             ("jan 1, 2000/1", "jan 1, 2000", False),
-             ("jan 1, 2000/1", "jan 1, 2001", False),
-             ("jan 1, 2000/1", "jan 1, 2000/1", True),
-             ("jan 1, 2000/1", "jan 14, 2001", True),
-             ("jan 1, 2000/1", "jan 1, 2001 (julian)", True),
-             ("about 1984", "about 2005", False),
-             ("about 1990", "about 2005", True),
-             ("about 2007", "about 2006", True),
-             ("about 1995", "after 2000", True),
-             ("about 1995", "after 2005", False),
-             ("about 2007", "about 2003", True),
-             ("before 2007", "2000", True),
-             # offsets
-             # different calendar, same date
-             ("1800-8-3", "15 Thermidor 8 (French Republican)", True),
-             ("after 1800-8-3", "before 15 Thermidor 8 (French Republican)", False),
-             ("ab cd", "54 ab cd 2000", True, False),
-             ("1700-02-29 (Julian)", "1700-03-01 (Swedish)", True),
-             ("1706-12-31 (Julian)", "1707-01-01 (Swedish)", True),
-             ("1712-02-28 (Julian)", "1712-02-29 (Swedish)", True),
-             ("1712-02-29 (Julian)", "1712-02-30 (Swedish)", True),
-             # See bug# 7100
-             ("1233-12-01", "1234-12-01 (Mar25)", True),
-             ("1234-01-04", "1234-01-04 (Mar25)", True),
-             # See bug# 7158
-# Some issues passing Travis close to midnight; not sure why:
-#             ("today", Today(), True),
-#             ("today (Hebrew)", Today(), True),
-             ("today", "today", True),
-             (Today(), Today(), True),
-             # See bug# 7197
-             ("1788-03-27", "1789-03-27 (Mar25)", True),
-             ("1788-03-27 (Julian)", "1789-03-27 (Julian, Mar25)", True),
-             ]
+
+    tests = [
+        ("before 1960", "before 1961", True),
+        ("before 1960", "before 1960", True),
+        ("before 1961", "before 1961", True),
+        ("jan 1, 1960", "jan 1, 1960", True),
+        ("dec 31, 1959", "dec 31, 1959", True),
+        ("before 1960", "jan 1, 1960", False),
+        ("before 1960", "dec 31, 1959", True),
+        ("abt 1960", "1960", True),
+        ("abt 1960", "before 1960", True),
+        ("1960", "1960", True),
+        ("1960", "after 1960", False),
+        ("1960", "before 1960", False),
+        ("abt 1960", "abt 1960", True),
+        ("before 1960", "after 1960", False),
+        ("after jan 1, 1900", "jan 2, 1900", True),
+        ("abt jan 1, 1900", "jan 1, 1900", True),
+        ("from 1950 to 1955", "1950", True),
+        ("from 1950 to 1955", "1951", True),
+        ("from 1950 to 1955", "1952", True),
+        ("from 1950 to 1955", "1953", True),
+        ("from 1950 to 1955", "1954", True),
+        ("from 1950 to 1955", "1955", True),
+        ("from 1950 to 1955", "1956", False),
+        ("from 1950 to 1955", "dec 31, 1955", True),
+        ("from 1950 to 1955", "jan 1, 1955", True),
+        ("from 1950 to 1955", "dec 31, 1949", False),
+        ("from 1950 to 1955", "jan 1, 1956", False),
+        ("from 1950", "1940", False),
+        ("from 1950", "2000", True),
+        ("from 1950", "jan 1, 1950", True),
+        ("from 1950", "dec 31, 1949", False),
+        ("to 1950", "1940", True),
+        ("to 1950", "2000", False),
+        ("to 1950", "dec 31, 1950", True),
+        ("to 1950", "jan 1, 1951", False),
+        ("after jul 4, 1980", "jul 4, 1980", False),
+        ("after jul 4, 1980", "before jul 4, 1980", False),
+        ("after jul 4, 1980", "about jul 4, 1980", True),
+        ("after jul 4, 1980", "after jul 4, 1980", True),
+        ("between 1750 and 1752", "1750", True),
+        ("between 1750 and 1752", "about 1750", True),
+        ("between 1750 and 1752", "between 1749 and 1750", True),
+        ("between 1750 and 1752", "1749", False),
+        ("invalid date", "invalid date", True),
+        ("invalid date", "invalid", False, True),
+        ("invalid date 1", "invalid date 2", False),
+        ("abt jan 1, 2000", "dec 31, 1999", True),
+        ("jan 1, 2000", "dec 31, 1999", False),
+        ("aft jan 1, 2000", "dec 31, 1999", False),
+        ("after jan 1, 2000", "after dec 31, 1999", True),
+        ("after dec 31, 1999", "after jan 1, 2000", True),
+        ("1 31, 2000", "jan 1, 2000", False),
+        ("dec 31, 1999", "jan 1, 2000", False),
+        ("jan 1, 2000", "before dec 31, 1999", False),
+        ("aft jan 1, 2000", "before dec 31, 1999", False),
+        ("before jan 1, 2000", "after dec 31, 1999", False),
+        ("jan 1, 2000/1", "jan 1, 2000", False),
+        ("jan 1, 2000/1", "jan 1, 2001", False),
+        ("jan 1, 2000/1", "jan 1, 2000/1", True),
+        ("jan 1, 2000/1", "jan 14, 2001", True),
+        ("jan 1, 2000/1", "jan 1, 2001 (julian)", True),
+        ("about 1984", "about 2005", False),
+        ("about 1990", "about 2005", True),
+        ("about 2007", "about 2006", True),
+        ("about 1995", "after 2000", True),
+        ("about 1995", "after 2005", False),
+        ("about 2007", "about 2003", True),
+        ("before 2007", "2000", True),
+        # offsets
+        # different calendar, same date
+        ("1800-8-3", "15 Thermidor 8 (French Republican)", True),
+        ("after 1800-8-3", "before 15 Thermidor 8 (French Republican)", False),
+        ("ab cd", "54 ab cd 2000", True, False),
+        ("1700-02-29 (Julian)", "1700-03-01 (Swedish)", True),
+        ("1706-12-31 (Julian)", "1707-01-01 (Swedish)", True),
+        ("1712-02-28 (Julian)", "1712-02-29 (Swedish)", True),
+        ("1712-02-29 (Julian)", "1712-02-30 (Swedish)", True),
+        # See bug# 7100
+        ("1233-12-01", "1234-12-01 (Mar25)", True),
+        ("1234-01-04", "1234-01-04 (Mar25)", True),
+        # See bug# 7158
+        # Some issues passing Travis close to midnight; not sure why:
+        #             ("today", Today(), True),
+        #             ("today (Hebrew)", Today(), True),
+        ("today", "today", True),
+        (Today(), Today(), True),
+        # See bug# 7197
+        ("1788-03-27", "1789-03-27 (Mar25)", True),
+        ("1788-03-27 (Julian)", "1789-03-27 (Julian, Mar25)", True),
+    ]
 
     def convert_to_date(self, d):
-        return d if isinstance(d,Date) else _dp.parse(d)
+        return d if isinstance(d, Date) else _dp.parse(d)
 
     def do_case(self, d1, d2, expected1, expected2=None):
         """
@@ -376,27 +528,33 @@ class MatchDateTest(BaseDateTest):
         date1 = self.convert_to_date(d1)
         date2 = self.convert_to_date(d2)
         result = date2.match(date1)
-        self.assertEqual(result, expected,
-                         "'{}' {} '{}'\n({} vs {})".format(
-                             d1,
-                             ("did not match" if expected else "matched"),
-                             d2,
-                             date1.__dict__, date2.__dict__))
+        self.assertEqual(
+            result,
+            expected,
+            "'{}' {} '{}'\n({} vs {})".format(
+                d1,
+                ("did not match" if expected else "matched"),
+                d2,
+                date1.__dict__,
+                date2.__dict__,
+            ),
+        )
 
     def test_match(self):
         for testdata in self.tests:
             self.do_case(*testdata)
 
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # ArithmeticDateTest
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class ArithmeticDateTest(BaseDateTest):
     """
     Date arithmetic tests.
     """
+
     tests = [
         # Date +/- int/tuple -> Date
         ("Date(2008, 1, 1) - 1", "Date(2007, 1, 1)"),
@@ -411,7 +569,7 @@ class ArithmeticDateTest(BaseDateTest):
         ("Date(2008, 1, 1) + (0, 0, 32)", "Date(2008, 2, 2)"),
         ("Date(2008, 2, 1) + (0, 0, 32)", "Date(2008, 3, 4)"),
         ("Date(2000) - (0, 1, 0)", "Date(1999, 12, 1)"),
-        ("Date(2000) + (0, 1, 0)", "Date(2000, 1, 0)"), # Ok?
+        ("Date(2000) + (0, 1, 0)", "Date(2000, 1, 0)"),  # Ok?
         ("Date(2000, 1, 1) - (0, 1, 0)", "Date(1999, 12, 1)"),
         ("Date(2000, 1, 1) - 1", "Date(1999, 1, 1)"),
         ("Date(2000) - 1", "Date(1999)"),
@@ -423,28 +581,33 @@ class ArithmeticDateTest(BaseDateTest):
         ("(Date(2000,1,1) - Date(1999,12,1)).tuple()", "(0, 1, 0)"),
         ("(Date(2007, 12, 23) - Date(1963, 12, 4)).tuple()", "(44, 0, 19)"),
         ("(Date(1963, 12, 4) - Date(2007, 12, 23)).tuple()", "(-44, 0, -19)"),
-        ]
+    ]
 
     def test_evaluate(self):
         for exp1, exp2 in self.tests:
             val1 = eval(exp1)
             val2 = eval(exp2)
-            self.assertEqual(val1, val2,
-                        "'%s' should be '%s' but was '%s'" % (exp1, val2, val1))
+            self.assertEqual(
+                val1, val2, "'%s' should be '%s' but was '%s'" % (exp1, val2, val1)
+            )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # SpanTest
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class SpanTest(BaseDateTest):
     """
     Test spans.
     """
-    tests = [((2000, 1, 31), (2000, 1, 1), 30),
-             ((1799, 11, 19), (8, 2, 18, Date.CAL_FRENCH), 10),
-             ((8, 2, 18, Date.CAL_FRENCH), (1799, 11, 4), 5),
-             ((8, 2, 18, Date.CAL_FRENCH), (3, 2, 9, Date.CAL_FRENCH), 1836)]
+
+    tests = [
+        ((2000, 1, 31), (2000, 1, 1), 30),
+        ((1799, 11, 19), (8, 2, 18, Date.CAL_FRENCH), 10),
+        ((8, 2, 18, Date.CAL_FRENCH), (1799, 11, 4), 5),
+        ((8, 2, 18, Date.CAL_FRENCH), (3, 2, 9, Date.CAL_FRENCH), 1836),
+    ]
 
     def test_evaluate(self):
         for value1, value2, duration in self.tests:
@@ -462,146 +625,613 @@ class SpanTest(BaseDateTest):
         date.set_yr_mon_day(value[0], value[1], value[2])
         return date
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
+#
+# DateComparisonTest
+#
+# -------------------------------------------------------------------------
+@unittest.skipUnless(
+    ENGLISH_DATE_HANDLER,
+    "This test of Date() matching logic can only run in English locale.",
+)
+class DateComparisonTest(BaseDateTest):
+    """
+    Date comparison tests.
+    """
+
+    tests = [
+        ("1960", "=", "1960", True),
+        ("1960", "=", "1961", False),
+        ("1960", "!=", "1960", False),
+        ("1960", "!=", "1961", True),
+        ("1960", "==", "1960", True),
+        ("1960", "==", "1961", False),
+        ("1960", "<", "1959", False),
+        ("1960", "<", "1960", True),
+        ("1960", "<", "1961", True),
+        ("1960", ">", "1959", True),
+        ("1960", ">", "1960", True),
+        ("1960", ">", "1961", False),
+        ("1960", "<<", "1959", False),
+        ("1960", "<<", "1960", False),
+        ("1960", "<<", "1961", True),
+        ("1960", ">>", "1959", True),
+        ("1960", ">>", "1960", False),
+        ("1960", ">>", "1961", False),
+        ("1960", "<=", "1959", False),
+        ("1960", "<=", "1960", True),
+        ("1960", "<=", "1961", True),
+        ("1960", ">=", "1959", True),
+        ("1960", ">=", "1960", True),
+        ("1960", ">=", "1961", False),
+        ("1960-01-01", "=", "1960-01-01", True),
+        ("1960-01-01", "=", "1960-01-02", False),
+        ("1960-01-01", "!=", "1960-01-01", False),
+        ("1960-01-01", "!=", "1960-01-02", True),
+        ("1960-01-01", "==", "1960-01-01", True),
+        ("1960-01-01", "==", "1960-01-02", False),
+        ("1960-01-01", "<", "1959-12-31", False),
+        ("1960-01-01", "<", "1960-01-01", False),
+        ("1960-01-01", "<", "1960-01-02", True),
+        ("1960-01-01", ">", "1959-12-31", True),
+        ("1960-01-01", ">", "1960-01-01", False),
+        ("1960-01-01", ">", "1960-01-02", False),
+        ("1960-01-01", "<<", "1959-12-31", False),
+        ("1960-01-01", "<<", "1960-01-01", False),
+        ("1960-01-01", "<<", "1960-01-02", True),
+        ("1960-01-01", ">>", "1959-12-31", True),
+        ("1960-01-01", ">>", "1960-01-01", False),
+        ("1960-01-01", ">>", "1960-01-02", False),
+        ("before 1960-01-01", "=", "1959-12-31", True),
+        ("before 1960-01-01", "=", "1960-01-01", False),
+        ("about 1960-01-01", "=", "1959-12-31", True),
+        ("about 1960-01-01", "=", "1960-01-01", True),
+        ("about 1960-01-01", "=", "1960-01-02", True),
+        ("after 1960-01-01", "=", "1960-01-01", False),
+        ("after 1960-01-01", "=", "1960-01-02", True),
+        ("between 1960-01-01 and 1960-01-03", "=", "1959-12-31", False),
+        ("between 1960-01-01 and 1960-01-03", "=", "1960-01-01", True),
+        ("between 1960-01-01 and 1960-01-03", "=", "1960-01-02", True),
+        ("between 1960-01-01 and 1960-01-03", "=", "1960-01-02", True),
+        ("between 1960-01-01 and 1960-01-03", "=", "1960-01-04", False),
+        ("before 1960-01-01", "==", "1959-12-31", False),  # !
+        ("before 1960-01-01", "==", "1960-01-01", True),  # !
+        ("before 1960-01-01", "==", "1960-01-02", False),  # !
+        ("about 1960-01-01", "==", "1959-12-31", False),  # !
+        ("about 1960-01-01", "==", "1960-01-01", True),
+        ("about 1960-01-01", "==", "1960-01-02", False),  # !
+        ("after 1960-01-01", "==", "1960-01-01", True),  # !
+        ("after 1960-01-01", "==", "1960-01-02", False),  # !
+        ("between 1960-01-01 and 1960-01-03", "==", "1959-12-31", False),
+        ("between 1960-01-01 and 1960-01-03", "==", "1960-01-01", True),
+        ("between 1960-01-01 and 1960-01-03", "==", "1960-01-02", False),
+        ("between 1960-01-01 and 1960-01-03", "==", "1960-01-02", False),
+        ("between 1960-01-01 and 1960-01-03", "==", "1960-01-04", False),
+        (
+            "4713-01-01 B.C. (Julian)",
+            "=",
+            "to 1960",
+            False,
+        ),  # Corner case, logically True.
+        ("4713-01-02 B.C. (Julian)", "=", "to 1960", True),
+        ("4713-01-02 B.C. (Julian)", "<", "to 1960", True),
+        ("4713-01-02 B.C. (Julian)", "<=", "to 1960", True),
+        ("4713-01-02 B.C. (Julian)", "<<", "to 1960", False),
+        ("from 1960", "=", "from 1960", True),
+        ("from 1960", "=", "from 1961", True),
+        ("from 1960", "!=", "from 1960", False),
+        ("from 1960", "!=", "from 1961", True),
+        ("from 1960", "==", "from 1960", True),
+        ("from 1960", "==", "from 1961", False),
+        ("from 1960", "<", "from 1959", True),
+        ("from 1960", "<", "from 1960", True),
+        ("from 1960", "<", "from 1961", True),
+        ("from 1960", ">", "from 1959", True),
+        ("from 1960", ">", "from 1960", True),
+        ("from 1960", ">", "from 1961", True),
+        ("from 1960", "<<", "from 1959", False),
+        ("from 1960", "<<", "from 1960", False),
+        ("from 1960", "<<", "from 1961", False),
+        ("from 1960", ">>", "from 1959", False),
+        ("from 1960", ">>", "from 1960", False),
+        ("from 1960", ">>", "from 1961", False),
+        ("from 1960", "<=", "from 1959", False),
+        ("from 1960", "<=", "from 1960", True),
+        ("from 1960", "<=", "from 1961", True),
+        ("from 1960", ">=", "from 1959", True),
+        ("from 1960", ">=", "from 1960", True),
+        ("from 1960", ">=", "from 1961", False),
+        ("from 1960", "=", "to 1959", False),
+        ("from 1960", "=", "to 1960", True),
+        ("from 1960", "=", "to 1961", True),
+        ("from 1960", "!=", "to 1959", True),
+        ("from 1960", "!=", "to 1960", False),
+        ("from 1960", "!=", "to 1961", True),
+        ("from 1960", "==", "to 1959", False),
+        ("from 1960", "==", "to 1960", True),
+        ("from 1960", "==", "to 1961", False),
+        ("from 1960", "<", "to 1959", False),
+        ("from 1960", "<", "to 1960", True),
+        ("from 1960", "<", "to 1961", True),
+        ("from 1960", ">", "to 1959", True),
+        ("from 1960", ">", "to 1960", True),
+        ("from 1960", ">", "to 1961", True),
+        ("from 1960", "<<", "to 1959", False),
+        ("from 1960", "<<", "to 1960", False),
+        ("from 1960", "<<", "to 1961", False),
+        ("from 1960", ">>", "to 1959", True),
+        ("from 1960", ">>", "to 1960", False),
+        ("from 1960", ">>", "to 1961", False),
+        ("from 1960", "<=", "to 1959", False),
+        ("from 1960", "<=", "to 1960", True),
+        ("from 1960", "<=", "to 1961", True),
+        ("from 1960", ">=", "to 1959", True),
+        ("from 1960", ">=", "to 1960", True),
+        ("from 1960", ">=", "to 1961", False),
+        ("to 1960", "=", "from 1959", True),
+        ("to 1960", "=", "from 1960", True),
+        ("to 1960", "=", "from 1961", False),
+        ("to 1960", "!=", "from 1959", True),
+        ("to 1960", "!=", "from 1960", False),
+        ("to 1960", "!=", "from 1961", True),
+        ("to 1960", "==", "from 1959", False),
+        ("to 1960", "==", "from 1960", True),
+        ("to 1960", "==", "from 1961", False),
+        ("to 1960", "<", "from 1959", True),
+        ("to 1960", "<", "from 1960", True),
+        ("to 1960", "<", "from 1961", True),
+        ("to 1960", ">", "from 1959", True),
+        ("to 1960", ">", "from 1960", True),
+        ("to 1960", ">", "from 1961", False),
+        ("to 1960", "<<", "from 1959", False),
+        ("to 1960", "<<", "from 1960", False),
+        ("to 1960", "<<", "from 1961", True),
+        ("to 1960", ">>", "from 1959", False),
+        ("to 1960", ">>", "from 1960", False),
+        ("to 1960", ">>", "from 1961", False),
+        ("to 1960", "<=", "from 1959", False),
+        ("to 1960", "<=", "from 1960", True),
+        ("to 1960", "<=", "from 1961", True),
+        ("to 1960", ">=", "from 1959", True),
+        ("to 1960", ">=", "from 1960", True),
+        ("to 1960", ">=", "from 1961", False),
+        ("to 1960", "=", "to 1959", True),
+        ("to 1960", "=", "to 1960", True),
+        ("to 1960", "=", "to 1961", True),
+        ("to 1960", "!=", "to 1959", True),
+        ("to 1960", "!=", "to 1960", False),
+        ("to 1960", "!=", "to 1961", True),
+        ("to 1960", "==", "to 1959", False),
+        ("to 1960", "==", "to 1960", True),
+        ("to 1960", "==", "to 1961", False),
+        ("to 1960", "<", "to 1959", True),
+        ("to 1960", "<", "to 1960", True),
+        ("to 1960", "<", "to 1961", True),
+        ("to 1960", ">", "to 1959", True),
+        ("to 1960", ">", "to 1960", True),
+        ("to 1960", ">", "to 1961", True),
+        ("to 1960", "<<", "to 1959", False),
+        ("to 1960", "<<", "to 1960", False),
+        ("to 1960", "<<", "to 1961", False),
+        ("to 1960", ">>", "to 1959", False),
+        ("to 1960", ">>", "to 1960", False),
+        ("to 1960", ">>", "to 1961", False),
+        ("to 1960", "<=", "to 1959", False),
+        ("to 1960", "<=", "to 1960", True),
+        ("to 1960", "<=", "to 1961", True),
+        ("to 1960", ">=", "to 1959", True),
+        ("to 1960", ">=", "to 1960", True),
+        ("to 1960", ">=", "to 1961", False),
+        ("from 1960 to 1961", "=", "from 1958 to 1959", False),
+        ("from 1960 to 1961", "=", "from 1959 to 1960", True),
+        ("from 1960 to 1961", "=", "from 1960 to 1961", True),
+        ("from 1960 to 1961", "=", "from 1961 to 1962", True),
+        ("from 1960 to 1961", "=", "from 1962 to 1963", False),
+        ("from 1960 to 1961", "!=", "from 1958 to 1959", True),
+        ("from 1960 to 1961", "!=", "from 1959 to 1960", True),
+        ("from 1960 to 1961", "!=", "from 1960 to 1961", False),
+        ("from 1960 to 1961", "!=", "from 1961 to 1962", True),
+        ("from 1960 to 1961", "!=", "from 1962 to 1963", True),
+        ("from 1960 to 1961", "==", "from 1959 to 1960", False),
+        ("from 1960 to 1961", "==", "from 1960 to 1961", True),
+        ("from 1960 to 1961", "==", "from 1961 to 1962", False),
+        ("from 1960 to 1961", "<", "from 1958 to 1959", False),
+        ("from 1960 to 1961", "<", "from 1959 to 1960", True),
+        ("from 1960 to 1961", "<", "from 1960 to 1961", True),
+        ("from 1960 to 1961", "<", "from 1961 to 1962", True),
+        ("from 1960 to 1961", "<", "from 1962 to 1963", True),
+        ("from 1960 to 1961", ">", "from 1958 to 1959", True),
+        ("from 1960 to 1961", ">", "from 1959 to 1960", True),
+        ("from 1960 to 1961", ">", "from 1960 to 1961", True),
+        ("from 1960 to 1961", ">", "from 1961 to 1962", True),
+        ("from 1960 to 1961", ">", "from 1962 to 1963", False),
+        ("from 1960 to 1961", "<<", "from 1958 to 1959", False),
+        ("from 1960 to 1961", "<<", "from 1959 to 1960", False),
+        ("from 1960 to 1961", "<<", "from 1960 to 1961", False),
+        ("from 1960 to 1961", "<<", "from 1961 to 1962", False),
+        ("from 1960 to 1961", "<<", "from 1962 to 1963", True),
+        ("from 1960 to 1961", ">>", "from 1958 to 1959", True),
+        ("from 1960 to 1961", ">>", "from 1959 to 1960", False),
+        ("from 1960 to 1961", ">>", "from 1960 to 1961", False),
+        ("from 1960 to 1961", ">>", "from 1961 to 1962", False),
+        ("from 1960 to 1961", ">>", "from 1962 to 1963", False),
+        ("from 1960 to 1961", "<=", "from 1958 to 1959", False),
+        ("from 1960 to 1961", "<=", "from 1959 to 1960", False),
+        ("from 1960 to 1961", "<=", "from 1960 to 1961", True),
+        ("from 1960 to 1961", "<=", "from 1961 to 1962", True),
+        ("from 1960 to 1961", "<=", "from 1962 to 1963", True),
+        ("from 1960 to 1961", ">=", "from 1958 to 1959", True),
+        ("from 1960 to 1961", ">=", "from 1959 to 1960", True),
+        ("from 1960 to 1961", ">=", "from 1960 to 1961", True),
+        ("from 1960 to 1961", ">=", "from 1961 to 1962", False),
+        ("from 1960 to 1961", ">=", "from 1962 to 1963", False),
+        ("from 1960-01-01 to 1961-01-01", "=", "from 1958-01-01 to 1959-12-31", False),
+        ("from 1960-01-01 to 1961-01-01", "=", "from 1958-01-01 to 1960-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", "=", "from 1958-01-01 to 1961-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", "=", "from 1958-01-01 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", "=", "from 1960-01-01 to 1960-12-31", True),
+        ("from 1960-01-01 to 1961-01-01", "=", "from 1960-01-01 to 1961-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", "=", "from 1960-01-01 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", "=", "from 1960-12-31 to 1961-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", "=", "from 1960-12-31 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", "=", "from 1961-01-01 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", "=", "from 1961-01-02 to 1961-01-03", False),
+        ("from 1960-01-01 to 1961-01-01", "!=", "from 1958-01-01 to 1959-12-31", True),
+        ("from 1960-01-01 to 1961-01-01", "!=", "from 1958-01-01 to 1960-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", "!=", "from 1958-01-01 to 1961-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", "!=", "from 1958-01-01 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", "!=", "from 1960-01-01 to 1960-12-31", False),
+        ("from 1960-01-01 to 1961-01-01", "!=", "from 1960-01-01 to 1961-01-01", False),
+        ("from 1960-01-01 to 1961-01-01", "!=", "from 1960-01-01 to 1961-01-02", False),
+        ("from 1960-01-01 to 1961-01-01", "!=", "from 1960-12-31 to 1961-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", "!=", "from 1960-12-31 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", "!=", "from 1961-01-01 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", "!=", "from 1961-01-02 to 1961-01-03", True),
+        ("from 1960-01-01 to 1961-01-01", "==", "from 1958-01-01 to 1959-12-31", False),
+        ("from 1960-01-01 to 1961-01-01", "==", "from 1958-01-01 to 1960-01-01", False),
+        ("from 1960-01-01 to 1961-01-01", "==", "from 1958-01-01 to 1961-01-01", False),
+        ("from 1960-01-01 to 1961-01-01", "==", "from 1958-01-01 to 1961-01-02", False),
+        ("from 1960-01-01 to 1961-01-01", "==", "from 1960-01-01 to 1960-12-31", True),
+        ("from 1960-01-01 to 1961-01-01", "==", "from 1960-01-01 to 1961-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", "==", "from 1960-01-01 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", "==", "from 1960-12-31 to 1961-01-01", False),
+        ("from 1960-01-01 to 1961-01-01", "==", "from 1960-12-31 to 1961-01-02", False),
+        ("from 1960-01-01 to 1961-01-01", "==", "from 1961-01-01 to 1961-01-02", False),
+        ("from 1960-01-01 to 1961-01-01", "==", "from 1961-01-02 to 1961-01-03", False),
+        ("from 1960-01-01 to 1961-01-01", "<", "from 1958-01-01 to 1959-12-31", False),
+        ("from 1960-01-01 to 1961-01-01", "<", "from 1958-01-01 to 1960-01-01", False),
+        ("from 1960-01-01 to 1961-01-01", "<", "from 1958-01-01 to 1961-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", "<", "from 1958-01-01 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", "<", "from 1960-01-01 to 1960-12-31", True),
+        ("from 1960-01-01 to 1961-01-01", "<", "from 1960-01-01 to 1961-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", "<", "from 1960-01-01 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", "<", "from 1960-12-31 to 1961-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", "<", "from 1960-12-31 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", "<", "from 1961-01-01 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", "<", "from 1961-01-02 to 1961-01-03", True),
+        ("from 1960-01-01 to 1961-01-01", ">", "from 1958-01-01 to 1959-12-31", True),
+        ("from 1960-01-01 to 1961-01-01", ">", "from 1958-01-01 to 1960-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", ">", "from 1958-01-01 to 1961-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", ">", "from 1958-01-01 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", ">", "from 1960-01-01 to 1960-12-31", True),
+        ("from 1960-01-01 to 1961-01-01", ">", "from 1960-01-01 to 1961-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", ">", "from 1960-01-01 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", ">", "from 1960-12-31 to 1961-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", ">", "from 1960-12-31 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", ">", "from 1961-01-01 to 1961-01-02", False),
+        ("from 1960-01-01 to 1961-01-01", ">", "from 1961-01-02 to 1961-01-03", False),
+        ("from 1960-01-01 to 1961-01-01", "<<", "from 1958-01-01 to 1959-12-31", False),
+        ("from 1960-01-01 to 1961-01-01", "<<", "from 1958-01-01 to 1960-01-01", False),
+        ("from 1960-01-01 to 1961-01-01", "<<", "from 1958-01-01 to 1961-01-01", False),
+        ("from 1960-01-01 to 1961-01-01", "<<", "from 1958-01-01 to 1961-01-02", False),
+        ("from 1960-01-01 to 1961-01-01", "<<", "from 1960-01-01 to 1960-12-31", False),
+        ("from 1960-01-01 to 1961-01-01", "<<", "from 1960-01-01 to 1961-01-01", False),
+        ("from 1960-01-01 to 1961-01-01", "<<", "from 1960-01-01 to 1961-01-02", False),
+        ("from 1960-01-01 to 1961-01-01", "<<", "from 1960-12-31 to 1961-01-01", False),
+        ("from 1960-01-01 to 1961-01-01", "<<", "from 1960-12-31 to 1961-01-02", False),
+        ("from 1960-01-01 to 1961-01-01", "<<", "from 1961-01-01 to 1961-01-02", False),
+        ("from 1960-01-01 to 1961-01-01", "<<", "from 1961-01-02 to 1961-01-03", True),
+        ("from 1960-01-01 to 1961-01-01", ">>", "from 1958-01-01 to 1959-12-31", True),
+        ("from 1960-01-01 to 1961-01-01", ">>", "from 1958-01-01 to 1960-01-01", False),
+        ("from 1960-01-01 to 1961-01-01", ">>", "from 1958-01-01 to 1961-01-01", False),
+        ("from 1960-01-01 to 1961-01-01", ">>", "from 1958-01-01 to 1961-01-02", False),
+        ("from 1960-01-01 to 1961-01-01", ">>", "from 1960-01-01 to 1960-12-31", False),
+        ("from 1960-01-01 to 1961-01-01", ">>", "from 1960-01-01 to 1961-01-01", False),
+        ("from 1960-01-01 to 1961-01-01", ">>", "from 1960-01-01 to 1961-01-02", False),
+        ("from 1960-01-01 to 1961-01-01", ">>", "from 1960-12-31 to 1961-01-01", False),
+        ("from 1960-01-01 to 1961-01-01", ">>", "from 1960-12-31 to 1961-01-02", False),
+        ("from 1960-01-01 to 1961-01-01", ">>", "from 1961-01-01 to 1961-01-02", False),
+        ("from 1960-01-01 to 1961-01-01", ">>", "from 1961-01-02 to 1961-01-03", False),
+        ("from 1960-01-01 to 1961-01-01", "<=", "from 1958-01-01 to 1959-12-31", False),
+        ("from 1960-01-01 to 1961-01-01", "<=", "from 1958-01-01 to 1960-01-01", False),
+        ("from 1960-01-01 to 1961-01-01", "<=", "from 1958-01-01 to 1961-01-01", False),
+        ("from 1960-01-01 to 1961-01-01", "<=", "from 1958-01-01 to 1961-01-02", False),
+        ("from 1960-01-01 to 1961-01-01", "<=", "from 1960-01-01 to 1960-12-31", True),
+        ("from 1960-01-01 to 1961-01-01", "<=", "from 1960-01-01 to 1961-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", "<=", "from 1960-01-01 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", "<=", "from 1960-12-31 to 1961-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", "<=", "from 1960-12-31 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", "<=", "from 1961-01-01 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", "<=", "from 1961-01-02 to 1961-01-03", True),
+        ("from 1960-01-01 to 1961-01-01", ">=", "from 1958-01-01 to 1959-12-31", True),
+        ("from 1960-01-01 to 1961-01-01", ">=", "from 1958-01-01 to 1960-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", ">=", "from 1958-01-01 to 1961-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", ">=", "from 1958-01-01 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", ">=", "from 1960-01-01 to 1960-12-31", True),
+        ("from 1960-01-01 to 1961-01-01", ">=", "from 1960-01-01 to 1961-01-01", True),
+        ("from 1960-01-01 to 1961-01-01", ">=", "from 1960-01-01 to 1961-01-02", True),
+        ("from 1960-01-01 to 1961-01-01", ">=", "from 1960-12-31 to 1961-01-01", False),
+        ("from 1960-01-01 to 1961-01-01", ">=", "from 1960-12-31 to 1961-01-02", False),
+        ("from 1960-01-01 to 1961-01-01", ">=", "from 1961-01-01 to 1961-01-02", False),
+        ("from 1960-01-01 to 1961-01-01", ">=", "from 1961-01-02 to 1961-01-03", False),
+    ]
+
+    def convert_to_date(self, d):
+        return d if isinstance(d, Date) else _dp.parse(d)
+
+    def do_case(self, d1, op, d2, expected):
+        """
+        Compare two Gramps dates.
+        """
+        failstr = d1 + " " + op + " " + d2 + " should be {}".format(expected)
+        date1 = self.convert_to_date(d1)
+        date2 = self.convert_to_date(d2)
+        if op == "=":
+            self.assertEqual(date1.match(date2), expected, failstr)
+        elif op == "!=":
+            self.assertEqual(date1 != date2, expected, failstr)
+        elif op == "==":
+            self.assertEqual(date1 == date2, expected, failstr)
+        elif op == "<":
+            self.assertEqual(date1 < date2, expected, failstr)
+        elif op == "<<":
+            self.assertEqual(date1 << date2, expected, failstr)
+        elif op == ">":
+            self.assertEqual(date1 > date2, expected, failstr)
+        elif op == ">>":
+            self.assertEqual(date1 >> date2, expected, failstr)
+        elif op == "<=":
+            self.assertEqual(date1 <= date2, expected, failstr)
+        elif op == ">=":
+            self.assertEqual(date1 >= date2, expected, failstr)
+
+    def test_comparison(self):
+        for testdata in self.tests:
+            self.do_case(*testdata)
+
+
+# -------------------------------------------------------------------------
+#
+# AgeTest
+#
+# -------------------------------------------------------------------------
+@unittest.skipUnless(
+    ENGLISH_DATE_HANDLER,
+    "This test of Date() matching logic can only run in English locale.",
+)
+class AgeTest(BaseDateTest):
+    """
+    Age tests.
+    """
+
+    tests = [
+        ("1960", "1960", "0 days"),  # Logically (less than 1 year)
+        (
+            "1960-01",
+            "1960-01",
+            "0 days",
+        ),  # Logically (less than 1 month)
+        (
+            "1960-01",
+            "1960-02",
+            "1 month",
+        ),  # Logically (between 1 month and 1 month, 27|28) days)
+        ("1960-01-01", "1960-01-02", "1 day"),
+        ("1960-01-01", "1960-01-31", "30 days"),
+        ("after 1960-01-01", "1960-01-31", "less than 29 days"),
+        ("1960-01-01", "1960-02-02", "1 month, 1 day"),
+        ("1960-01-01", "1961-02-02", "1 year, 1 month"),
+        ("1960-01-01", "1965-01-01", "5 years"),
+        (
+            "1960-01-01",
+            "1965-02-02",
+            "5 years, 1 month",
+        ),
+        (
+            "about 1960-01-01",
+            "before 1965-02-02",
+            "less than about 5 years, 1 month",
+        ),
+        (
+            "about 1960-01-01",
+            "after 1965-02-02",
+            "more than about 5 years, 1 month",
+        ),
+        (
+            "1960",
+            "2000",
+            "40 years",
+        ),
+        ("", "1760", "greater than 110 years"),
+        ("", "1960", "greater than 110 years"),
+        ("", "2020", "greater than 110 years"),
+        ("", "3020", "greater than 110 years"),
+        ("2000", "", "(1999 years)"),
+    ]
+
+    def convert_to_date(self, d):
+        return d if isinstance(d, Date) else _dp.parse(d)
+
+    def do_case(self, d1, d2, exp_age):
+        span = Span(self.convert_to_date(d2), self.convert_to_date(d1))
+        age = span.as_age()
+        failstr = (
+            "Birth at "
+            + d1
+            + ", death at "
+            + d2
+            + " gives age "
+            + age
+            + ". Should be {}".format(exp_age)
+        )
+        self.assertEqual(age, exp_age, failstr)
+
+    def test_age(self):
+        for testdata in self.tests:
+            self.do_case(*testdata)
+
+
+# -------------------------------------------------------------------------
 #
 # SwedishDateTest
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class SwedishDateTest(BaseDateTest):
     """
     Swedish calendar tests.
     """
+
     def test_swedish(self):
         for date in swedish_dates:
-            self.assertEqual(date.sortval,
-                             date.to_calendar('gregorian').sortval)
+            self.assertEqual(date.sortval, date.to_calendar("gregorian").sortval)
+
 
 class Test_set2(BaseDateTest):
     """
     Test the Date.set2_... setters -- the ones to manipulate the 2nd date
     of a compound date
     """
+
     def setUp(self):
         self.date = d = Date()
-        d.set(modifier=Date.MOD_RANGE,
-                #d  m  y    sl--d  m  y    sl
-          value=(1, 1, 2000, 0, 1, 1, 2010, 0))
+        d.set(
+            modifier=Date.MOD_RANGE,
+            # d  m  y    sl--d  m  y    sl
+            value=(1, 1, 2000, 0, 1, 1, 2010, 0),
+        )
 
     def testStartStopSanity(self):
-        start,stop = self.date.get_start_stop_range()
+        start, stop = self.date.get_start_stop_range()
         self.assertEqual(start, (2000, 1, 1))
         self.assertEqual(stop, (2010, 1, 1))
 
     def test_set2_ymd_overrides_stop_date(self):
         self.date.set2_yr_mon_day(2013, 2, 2)
-        start,stop = self.date.get_start_stop_range()
+        start, stop = self.date.get_start_stop_range()
         self.assertEqual(start, (2000, 1, 1))
         self.assertEqual(stop, (2013, 2, 2))
 
     def test_set_ymd_overrides_both_dates(self):
-        self.date.set_yr_mon_day(2013, 2, 2, remove_stop_date = True)
-        start,stop = self.date.get_start_stop_range()
+        self.date.set_yr_mon_day(2013, 2, 2, remove_stop_date=True)
+        start, stop = self.date.get_start_stop_range()
         self.assertEqual(start, stop)
         self.assertEqual(stop, (2013, 2, 2))
 
     def test_set_ymd_offset_updates_both_ends(self):
         self.date.set_yr_mon_day_offset(+2, +2, +2)
-        start,stop = self.date.get_start_stop_range()
+        start, stop = self.date.get_start_stop_range()
         self.assertEqual(start, (2002, 3, 3))
         self.assertEqual(stop, (2012, 3, 3))
 
     def test_set2_ymd_offset_updates_stop_date(self):
         self.date.set2_yr_mon_day_offset(+7, +5, +5)
-        start,stop = self.date.get_start_stop_range()
+        start, stop = self.date.get_start_stop_range()
         self.assertEqual(start, (2000, 1, 1))
         self.assertEqual(stop, (2017, 6, 6))
 
     def test_copy_offset_ymd_preserves_orig(self):
         copied = self.date.copy_offset_ymd(year=-1)
         self.testStartStopSanity()
-        start,stop = copied.get_start_stop_range()
+        start, stop = copied.get_start_stop_range()
         self.assertEqual(start, (1999, 1, 1))
         self.assertEqual(stop, (2009, 1, 1))
 
     def test_copy_ymd_preserves_orig(self):
-        copied = self.date.copy_ymd(year=1000, month=10, day=10,
-                remove_stop_date=True)
+        copied = self.date.copy_ymd(year=1000, month=10, day=10, remove_stop_date=True)
         self.testStartStopSanity()
-        start,stop = copied.get_start_stop_range()
+        start, stop = copied.get_start_stop_range()
         self.assertEqual(start, (1000, 10, 10))
         self.assertEqual(stop, (1000, 10, 10))
 
     def _test_set2_function_raises_error_unless_compound(self, function):
-        for mod in (Date.MOD_NONE, Date.MOD_BEFORE, Date.MOD_AFTER,
-                       Date.MOD_ABOUT,
-                       Date.MOD_TEXTONLY):
+        for mod in (
+            Date.MOD_NONE,
+            Date.MOD_BEFORE,
+            Date.MOD_AFTER,
+            Date.MOD_ABOUT,
+            Date.MOD_TEXTONLY,
+        ):
             self.date.set_modifier(mod)
             try:
                 function(self.date)
-                self.assertTrue(False,
-                        "Modifier: {}, dateval: {} - exception expected!".format(
-                            mod, self.date.dateval))
+                self.assertTrue(
+                    False,
+                    "Modifier: {}, dateval: {} - exception expected!".format(
+                        mod, self.date.dateval
+                    ),
+                )
             except DateError:
                 pass
 
     def test_set2_ymd_raises_error_unless_compound(self):
         self._test_set2_function_raises_error_unless_compound(
-                lambda date: date.set2_yr_mon_day(2013, 2, 2))
+            lambda date: date.set2_yr_mon_day(2013, 2, 2)
+        )
 
     def test_set2_ymd_offset_raises_error_unless_compound(self):
         self._test_set2_function_raises_error_unless_compound(
-                lambda date: date.set2_yr_mon_day_offset(year=-1))
+            lambda date: date.set2_yr_mon_day_offset(year=-1)
+        )
+
 
 class Test_set_newyear(BaseDateTest):
     def test_raises_error_iff_calendar_has_fixed_newyear(self):
         for cal in Date.CALENDARS:
-            d = Date(1111,2,3)
+            d = Date(1111, 2, 3)
             should_raise = calendar_has_fixed_newyear(cal)
-            message = "{name} {cal}".format(
-                    name = Date.calendar_names[cal],
-                    cal = cal)
+            message = "{name} {cal}".format(name=Date.calendar_names[cal], cal=cal)
             try:
                 d.set(calendar=cal, newyear=2)
                 self.assertFalse(should_raise, message)
             except DateError:
                 self.assertTrue(should_raise, message)
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # EmptyDateTest
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class EmptyDateTest(BaseDateTest):
     """
     Tests for empty dates.
     """
+
     def test_empty(self):
         d = Date()
         self.assertTrue(d.is_empty())
 
     def test_text_only_empty(self):
         d = Date()
-        d.set(text='First of Jan',
-              modifier=Date.MOD_TEXTONLY)
+        d.set(text="First of Jan", modifier=Date.MOD_TEXTONLY)
         self.assertFalse(d.is_empty())
 
     def test_single_empty(self):
         d = Date()
-        d.set(value=(1, 1, 1900, False),
-              modifier=Date.MOD_NONE)
+        d.set(value=(1, 1, 1900, False), modifier=Date.MOD_NONE)
         self.assertFalse(d.is_empty())
 
     def test_range_empty(self):
         d = Date()
-        d.set(value=(1, 1, 1900, False, 1, 1, 1910, False),
-              modifier=Date.MOD_RANGE)
+        d.set(value=(1, 1, 1900, False, 1, 1, 1910, False), modifier=Date.MOD_RANGE)
         self.assertFalse(d.is_empty())
 
     def test_span_empty(self):
         d = Date()
-        d.set(value=(1, 1, 1900, False, 1, 1, 1910, False),
-              modifier=Date.MOD_SPAN)
+        d.set(value=(1, 1, 1900, False, 1, 1, 1910, False), modifier=Date.MOD_SPAN)
         self.assertFalse(d.is_empty())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/gramps/gui/editors/editdate.py
+++ b/gramps/gui/editors/editdate.py
@@ -31,32 +31,32 @@ The DateEditor provides a dialog in which the date can be
 unambiguously built using UI controls such as menus and spin buttons.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # set up logging
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import logging
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # GNOME modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from gi.repository import Gtk
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.config import config
 from gramps.gen.lib.date import Date, DateError, calendar_has_fixed_newyear
@@ -68,42 +68,47 @@ from ..glade import Glade
 
 LOG = logging.getLogger(".EditDate")
 _ = glocale.translation.sgettext
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Constants
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 MOD_TEXT = (
-    (Date.MOD_NONE, _('Regular')),
-    (Date.MOD_BEFORE, _('Before')),
-    (Date.MOD_AFTER, _('After')),
-    (Date.MOD_ABOUT, _('About')),
-    (Date.MOD_RANGE, _('Range')),
-    (Date.MOD_SPAN, _('Span')),
-    (Date.MOD_TEXTONLY, _('Text only')))
+    (Date.MOD_NONE, _("Regular")),
+    (Date.MOD_BEFORE, _("Before")),
+    (Date.MOD_AFTER, _("After")),
+    (Date.MOD_ABOUT, _("About")),
+    (Date.MOD_RANGE, _("Range")),
+    (Date.MOD_FROM, _("From")),
+    (Date.MOD_TO, _("To")),
+    (Date.MOD_SPAN, _("Span")),
+    (Date.MOD_TEXTONLY, _("Text only")),
+)
 
 QUAL_TEXT = (
-    (Date.QUAL_NONE, _('Regular')),
-    (Date.QUAL_ESTIMATED, _('Estimated')),
-    (Date.QUAL_CALCULATED, _('Calculated')))
+    (Date.QUAL_NONE, _("Regular")),
+    (Date.QUAL_ESTIMATED, _("Estimated")),
+    (Date.QUAL_CALCULATED, _("Calculated")),
+)
 
 CAL_TO_MONTHS_NAMES = {
-    Date.CAL_GREGORIAN  : displayer.short_months,
-    Date.CAL_JULIAN     : displayer.short_months,
-    Date.CAL_HEBREW     : displayer.hebrew,
-    Date.CAL_FRENCH     : displayer.french,
-    Date.CAL_PERSIAN    : displayer.persian,
-    Date.CAL_ISLAMIC    : displayer.islamic,
-    Date.CAL_SWEDISH    : displayer.swedish}
+    Date.CAL_GREGORIAN: displayer.short_months,
+    Date.CAL_JULIAN: displayer.short_months,
+    Date.CAL_HEBREW: displayer.hebrew,
+    Date.CAL_FRENCH: displayer.french,
+    Date.CAL_PERSIAN: displayer.persian,
+    Date.CAL_ISLAMIC: displayer.islamic,
+    Date.CAL_SWEDISH: displayer.swedish,
+}
 
 WIKI_HELP_PAGE = URL_MANUAL_SECT1
-WIKI_HELP_SEC = _('Editing_dates', 'manual')
+WIKI_HELP_SEC = _("Editing_dates", "manual")
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # EditDate
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class EditDate(ManagedWindow):
     """
     Dialog allowing to build the date precisely, to correct possible
@@ -122,40 +127,39 @@ class EditDate(ManagedWindow):
         self.top = Glade()
 
         self.set_window(
-            self.top.toplevel,
-            self.top.get_object('title'),
-            _('Date selection'))
-        self.setup_configs('interface.editdate', 620, 320)
+            self.top.toplevel, self.top.get_object("title"), _("Date selection")
+        )
+        self.setup_configs("interface.editdate", 620, 320)
 
-        self.statusbar = self.top.get_object('statusbar')
-        self.ok_button = self.top.get_object('ok_button')
-        self.calendar_box = self.top.get_object('calendar_box')
+        self.statusbar = self.top.get_object("statusbar")
+        self.ok_button = self.top.get_object("ok_button")
+        self.calendar_box = self.top.get_object("calendar_box")
         for name in Date.ui_calendar_names:
             self.calendar_box.get_model().append([name])
 
-        self.new_year = self.top.get_object('newyear')
+        self.new_year = self.top.get_object("newyear")
         self.new_year.set_text(self.date.newyear_to_str())
 
         cal = self.date.get_calendar()
         self.calendar_box.set_active(cal)
         self.align_newyear_ui_with_calendar(cal)
-        self.calendar_box.connect('changed', self.switch_calendar)
+        self.calendar_box.connect("changed", self.switch_calendar)
 
-        self.quality_box = self.top.get_object('quality_box')
+        self.quality_box = self.top.get_object("quality_box")
         for item_number, item in enumerate(QUAL_TEXT):
             self.quality_box.append_text(item[1])
             if self.date.get_quality() == item[0]:
                 self.quality_box.set_active(item_number)
 
-        self.type_box = self.top.get_object('type_box')
+        self.type_box = self.top.get_object("type_box")
         for item_number, item in enumerate(MOD_TEXT):
             self.type_box.append_text(item[1])
             if self.date.get_modifier() == item[0]:
                 self.type_box.set_active(item_number)
-        self.type_box.connect('changed', self.switch_type)
+        self.type_box.connect("changed", self.switch_type)
 
-        self.start_month_box = self.top.get_object('start_month_box')
-        self.stop_month_box = self.top.get_object('stop_month_box')
+        self.start_month_box = self.top.get_object("start_month_box")
+        self.stop_month_box = self.top.get_object("stop_month_box")
         month_names = CAL_TO_MONTHS_NAMES[self.date.get_calendar()]
         for name in month_names:
             self.start_month_box.append_text(name)
@@ -163,17 +167,17 @@ class EditDate(ManagedWindow):
         self.start_month_box.set_active(self.date.get_month())
         self.stop_month_box.set_active(self.date.get_stop_month())
 
-        self.start_day = self.top.get_object('start_day')
+        self.start_day = self.top.get_object("start_day")
         self.start_day.set_value(self.date.get_day())
-        self.start_year = self.top.get_object('start_year')
+        self.start_year = self.top.get_object("start_year")
         self.start_year.set_value(self.date.get_year())
 
-        self.stop_day = self.top.get_object('stop_day')
+        self.stop_day = self.top.get_object("stop_day")
         self.stop_day.set_value(self.date.get_stop_day())
-        self.stop_year = self.top.get_object('stop_year')
+        self.stop_year = self.top.get_object("stop_year")
         self.stop_year.set_value(self.date.get_stop_year())
 
-        self.dual_dated = self.top.get_object('dualdated')
+        self.dual_dated = self.top.get_object("dualdated")
 
         # Disable second date controls if not compound date
         if not self.date.is_compound():
@@ -191,16 +195,16 @@ class EditDate(ManagedWindow):
             self.dual_dated.set_sensitive(0)
             self.new_year.set_sensitive(0)
 
-        self.text_entry = self.top.get_object('date_text_entry')
+        self.text_entry = self.top.get_object("date_text_entry")
         self.text_entry.set_text(self.date.get_text())
 
         if self.date.get_slash():
             self.dual_dated.set_active(1)
             self.calendar_box.set_sensitive(0)
             self.calendar_box.set_active(Date.CAL_JULIAN)
-        self.dual_dated.connect('toggled', self.switch_dual_dated)
+        self.dual_dated.connect("toggled", self.switch_dual_dated)
 
-        cal = config.get('preferences.calendar-format-input')
+        cal = config.get("preferences.calendar-format-input")
         self.calendar_box.set_active(cal)
 
         # The dialog is modal -- since dates don't have names, we don't
@@ -211,7 +215,7 @@ class EditDate(ManagedWindow):
 
         for obj in self.top.get_objects():
             if obj != self.ok_button:
-                for signal in ['changed', 'value-changed']:
+                for signal in ["changed", "value-changed"]:
                     try:
                         obj.connect_after(signal, self.revalidate)
                     except TypeError:
@@ -245,20 +249,27 @@ class EditDate(ManagedWindow):
         If anything changed, revalidate the date and
         enable/disable the "OK" button based on the result.
         """
-        (the_quality, the_modifier, the_calendar, the_value,
-         the_text, the_newyear) = self.build_date_from_ui()
-        LOG.debug("revalidate: {0} changed, value: {1}".format(
-            obj, the_value))
+        (
+            the_quality,
+            the_modifier,
+            the_calendar,
+            the_value,
+            the_text,
+            the_newyear,
+        ) = self.build_date_from_ui()
+        LOG.debug("revalidate: {0} changed, value: {1}".format(obj, the_value))
         dat = Date(self.date)
         if not self.ok_button.get_sensitive():
             self.statusbar.pop(1)
         try:
-            dat.set(quality=the_quality,
-                    modifier=the_modifier,
-                    calendar=the_calendar,
-                    value=the_value,
-                    text=the_text,
-                    newyear=the_newyear)
+            dat.set(
+                quality=the_quality,
+                modifier=the_modifier,
+                calendar=the_calendar,
+                value=the_value,
+                text=the_text,
+                newyear=the_newyear,
+            )
             # didn't throw yet?
             self.validated_date = dat
             LOG.debug("validated_date set to: {0}".format(dat.__dict__))
@@ -270,10 +281,12 @@ class EditDate(ManagedWindow):
             self.calendar_box.set_sensitive(0)
             curmode = MOD_TEXT[self.type_box.get_active()][1]
             txtmode = MOD_TEXT[-1][1]
-            self.statusbar.push(1,
-                                _("Correct the date or switch from `{cur_mode}'"
-                                  " to `{text_mode}'").format(
-                                      cur_mode=curmode, text_mode=txtmode))
+            self.statusbar.push(
+                1,
+                _(
+                    "Correct the date or switch from `{cur_mode}'" " to `{text_mode}'"
+                ).format(cur_mode=curmode, text_mode=txtmode),
+            )
             return False
 
     def build_menu_names(self, obj):
@@ -297,8 +310,14 @@ class EditDate(ManagedWindow):
         text = self.text_entry.get_text()
 
         if modifier == Date.MOD_TEXTONLY:
-            return (Date.QUAL_NONE, Date.MOD_TEXTONLY, Date.CAL_GREGORIAN,
-                    Date.EMPTY, text, Date.NEWYEAR_JAN1)
+            return (
+                Date.QUAL_NONE,
+                Date.MOD_TEXTONLY,
+                Date.CAL_GREGORIAN,
+                Date.EMPTY,
+                text,
+                Date.NEWYEAR_JAN1,
+            )
 
         quality = QUAL_TEXT[self.quality_box.get_active()][0]
 
@@ -311,13 +330,15 @@ class EditDate(ManagedWindow):
                 self.stop_day.get_value_as_int(),
                 self.stop_month_box.get_active(),
                 self.stop_year.get_value_as_int(),
-                self.dual_dated.get_active())
+                self.dual_dated.get_active(),
+            )
         else:
             value = (
                 self.start_day.get_value_as_int(),
                 self.start_month_box.get_active(),
                 self.start_year.get_value_as_int(),
-                self.dual_dated.get_active())
+                self.dual_dated.get_active(),
+            )
         calendar = self.calendar_box.get_active()
         newyear = Date.newyear_to_code(self.new_year.get_text())
         return (quality, modifier, calendar, value, text, newyear)
@@ -366,7 +387,7 @@ class EditDate(ManagedWindow):
         if calendar_has_fixed_newyear(cal):
             LOG.debug("new year disabled for cal {0}".format(cal))
             self.new_year.set_sensitive(0)
-            self.new_year.set_text('')
+            self.new_year.set_text("")
         else:
             LOG.debug("new year enabled for cal {0}".format(cal))
             self.new_year.set_sensitive(1)
@@ -379,20 +400,29 @@ class EditDate(ManagedWindow):
 
         old_cal = self.date.get_calendar()
         new_cal = self.calendar_box.get_active()
-        LOG.debug(">>>switch_calendar: {0} changed, {1} -> {2}".format(
-            obj, old_cal, new_cal))
+        LOG.debug(
+            ">>>switch_calendar: {0} changed, {1} -> {2}".format(obj, old_cal, new_cal)
+        )
 
         self.align_newyear_ui_with_calendar(new_cal)
 
-        (the_quality, the_modifier, dummy_the_calendar,
-         the_value, the_text, the_newyear) = self.build_date_from_ui()
+        (
+            the_quality,
+            the_modifier,
+            dummy_the_calendar,
+            the_value,
+            the_text,
+            the_newyear,
+        ) = self.build_date_from_ui()
         try:
-            self.date.set(quality=the_quality,
-                          modifier=the_modifier,
-                          calendar=old_cal,
-                          value=the_value,
-                          text=the_text,
-                          newyear=the_newyear)
+            self.date.set(
+                quality=the_quality,
+                modifier=the_modifier,
+                calendar=old_cal,
+                value=the_value,
+                text=the_text,
+                newyear=the_newyear,
+            )
         except DateError:
             pass
         else:
@@ -412,5 +442,6 @@ class EditDate(ManagedWindow):
         self.stop_day.set_value(self.date.get_stop_day())
         self.stop_month_box.set_active(self.date.get_stop_month())
         self.stop_year.set_value(self.date.get_stop_year())
-        LOG.debug("<<<switch_calendar: {0} changed, {1} -> {2}".format(
-            obj, old_cal, new_cal))
+        LOG.debug(
+            "<<<switch_calendar: {0} changed, {1} -> {2}".format(obj, old_cal, new_cal)
+        )

--- a/gramps/plugins/export/exportgeneweb.py
+++ b/gramps/plugins/export/exportgeneweb.py
@@ -24,28 +24,30 @@
 
 "Export to GeneWeb."
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Standard Python Modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import os
 
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 #
 # Set up logging
 #
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 import logging
 from collections import abc
+
 log = logging.getLogger(".WriteGeneWeb")
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+
 _ = glocale.translation.gettext
 from gramps.gen.lib import Date, Event, EventType, FamilyRelType, Person
 from gramps.gui.plug.export import WriterOptionBox
@@ -53,6 +55,7 @@ from gramps.gen.utils.alive import probably_alive
 from gramps.gui.glade import Glade
 from gramps.gen.config import config
 from gramps.gen.display.place import displayer as _pd
+
 
 class GeneWebWriter:
     def __init__(self, database, filename, user, option_box=None):
@@ -78,17 +81,17 @@ class GeneWebWriter:
 
     def update_real(self):
         self.count += 1
-        newval = int(100*self.count/self.total)
+        newval = int(100 * self.count / self.total)
         if newval != self.oldval:
             self.user.callback(newval)
             self.oldval = newval
 
     def writeln(self, text):
-        self.g.write(self.iso8859('%s\n' % (text)))
+        self.g.write(self.iso8859("%s\n" % (text)))
 
     def export_data(self):
 
-        self.dirname = os.path.dirname (self.filename)
+        self.dirname = os.path.dirname(self.filename)
         try:
             with open(self.filename, "wb") as self.g:
                 self.flist = self.db.get_family_handles()
@@ -123,29 +126,31 @@ class GeneWebWriter:
                 mother_handle = family.get_mother_handle()
                 if mother_handle:
                     mother = self.db.get_person_from_handle(mother_handle)
-                    self.writeln("fam %s %s+%s %s %s" %
-                            (self.get_ref_name(father),
+                    self.writeln(
+                        "fam %s %s+%s %s %s"
+                        % (
+                            self.get_ref_name(father),
                             self.get_full_person_info_fam(father),
                             self.get_wedding_data(family),
                             self.get_ref_name(mother),
-                            self.get_full_person_info_fam(mother)
-                            )
-                         )
-                    self.write_witness( family)
-                    self.write_sources( family.get_citation_list())
-                    self.write_children( family, father)
-                    self.write_notes( family, father, mother)
-                    if True: # FIXME: not (self.restrict and self.exclnotes):
+                            self.get_full_person_info_fam(mother),
+                        )
+                    )
+                    self.write_witness(family)
+                    self.write_sources(family.get_citation_list())
+                    self.write_children(family, father)
+                    self.write_notes(family, father, mother)
+                    if True:  # FIXME: not (self.restrict and self.exclnotes):
                         notelist = family.get_note_list()
                         note = ""
                         for notehandle in notelist:
                             noteobj = self.db.get_note_from_handle(notehandle)
                             note += noteobj.get() + " "
                         if note and note != "":
-                            note = note.replace('\n\r',' ')
-                            note = note.replace('\r\n',' ')
-                            note = note.replace('\n',' ')
-                            note = note.replace('\r',' ')
+                            note = note.replace("\n\r", " ")
+                            note = note.replace("\r\n", " ")
+                            note = note.replace("\n", " ")
+                            note = note.replace("\r", " ")
                             self.writeln("comm %s" % note)
 
     def write_witness(self, family):
@@ -162,24 +167,25 @@ class GeneWebWriter:
                 if w_list:
                     for witness in w_list:
                         if witness and witness.type == Event.ID:
-                            person = self.db.get_person_from_handle(
-                                                        witness.get_value())
+                            person = self.db.get_person_from_handle(witness.get_value())
                             if person:
                                 gender = ""
                                 if person.get_gender() == Person.MALE:
                                     gender = "h"
                                 elif person.get_gender() == Person.FEMALE:
                                     gender = "f"
-                                self.writeln("wit %s %s %s" %
-                                        (gender,
+                                self.writeln(
+                                    "wit %s %s %s"
+                                    % (
+                                        gender,
                                         self.get_ref_name(person),
-                                        self.get_full_person_info_fam(person)
-                                        )
+                                        self.get_full_person_info_fam(person),
                                     )
+                                )
 
-    def write_sources(self,reflist):
+    def write_sources(self, reflist):
         # FIXME
-        #if self.restrict and self.exclnotes:
+        # if self.restrict and self.exclnotes:
         #    return
 
         if reflist:
@@ -188,11 +194,9 @@ class GeneWebWriter:
                 src_handle = citation.get_reference_handle()
                 source = self.db.get_source_from_handle(src_handle)
                 if source:
-                    self.writeln( "src %s" %
-                        (self.rem_spaces(source.get_title()))
-                        )
+                    self.writeln("src %s" % (self.rem_spaces(source.get_title())))
 
-    def write_children(self,family, father):
+    def write_children(self, family, father):
         father_lastname = father.get_primary_name().get_surname()
         child_ref_list = family.get_child_ref_list()
         if child_ref_list:
@@ -205,17 +209,19 @@ class GeneWebWriter:
                         gender = "h"
                     elif child.get_gender() == Person.FEMALE:
                         gender = "f"
-                    self.writeln("- %s %s %s" %
-                            (gender,
+                    self.writeln(
+                        "- %s %s %s"
+                        % (
+                            gender,
                             self.get_child_ref_name(child, father_lastname),
-                            self.get_full_person_info_child(child)
-                            )
-                         )
+                            self.get_full_person_info_child(child),
+                        )
+                    )
             self.writeln("end")
 
-    def write_notes(self,family, father, mother):
+    def write_notes(self, family, father, mother):
         # FIXME:
-        #if self.restrict and self.exclnotes:
+        # if self.restrict and self.exclnotes:
         #    return
 
         self.write_note_of_person(father)
@@ -227,19 +233,20 @@ class GeneWebWriter:
                 if child:
                     self.write_note_of_person(child)
         # FIXME: witnesses do not exist in events anymore
-##         event_ref_list = family.get_event_ref_list()
-##         for event_ref in event_ref_list:
-##             event = self.db.get_event_from_handle(event_ref.ref)
-##             if int(event.get_type()) == EventType.MARRIAGE:
-##                 w_list = event.get_witness_list()
-##                 if w_list:
-##                     for witness in w_list:
-##                         if witness and witness.type == Event.ID:
-##                             person = self.db.get_person_from_handle(witness.get_value())
-##                             if person:
-##                                 self.write_note_of_person(person)
 
-    def write_note_of_person(self,person):
+    ##         event_ref_list = family.get_event_ref_list()
+    ##         for event_ref in event_ref_list:
+    ##             event = self.db.get_event_from_handle(event_ref.ref)
+    ##             if int(event.get_type()) == EventType.MARRIAGE:
+    ##                 w_list = event.get_witness_list()
+    ##                 if w_list:
+    ##                     for witness in w_list:
+    ##                         if witness and witness.type == Event.ID:
+    ##                             person = self.db.get_person_from_handle(witness.get_value())
+    ##                             if person:
+    ##                                 self.write_note_of_person(person)
+
+    def write_note_of_person(self, person):
         if self.persons_notes_done.count(person.get_handle()) == 0:
             self.persons_notes_done.append(person.get_handle())
 
@@ -259,7 +266,7 @@ class GeneWebWriter:
 
     def get_full_person_info(self, person):
         # FIXME:
-        #if self.restrict:
+        # if self.restrict:
         #    return "0 "
 
         retval = ""
@@ -270,12 +277,12 @@ class GeneWebWriter:
         if birth_ref:
             birth = self.db.get_event_from_handle(birth_ref.ref)
             if birth:
-                b_date = self.format_date( birth.get_date_object())
+                b_date = self.format_date(birth.get_date_object())
                 place_handle = birth.get_place_handle()
                 if place_handle:
                     b_place = _pd.display_event(self.db, birth)
 
-        if probably_alive(person,self.db):
+        if probably_alive(person, self.db):
             d_date = ""
         else:
             d_date = "0"
@@ -284,7 +291,7 @@ class GeneWebWriter:
         if death_ref:
             death = self.db.get_event_from_handle(death_ref.ref)
             if death:
-                d_date = self.format_date( death.get_date_object())
+                d_date = self.format_date(death.get_date_object())
                 place_handle = death.get_place_handle()
                 if place_handle:
                     d_place = _pd.display_event(self.db, death)
@@ -316,7 +323,6 @@ class GeneWebWriter:
                 retval = self.get_full_person_info(person)
         return retval
 
-
     def get_full_person_info_child(self, person):
         """Output full person data for a child, if not printed somewhere else."""
         retval = ""
@@ -325,36 +331,36 @@ class GeneWebWriter:
             retval = self.get_full_person_info(person)
         return retval
 
-    def rem_spaces(self,str):
-        return str.replace(' ','_')
+    def rem_spaces(self, str):
+        return str.replace(" ", "_")
 
-    def get_ref_name(self,person):
-        #missing_surname = config.get("preferences.no-surname-text")
-        surname = self.rem_spaces( person.get_primary_name().get_surname())
-        #firstname = config.get('preferences.private-given-text')
-        #if not (probably_alive(person,self.db) and \
+    def get_ref_name(self, person):
+        # missing_surname = config.get("preferences.no-surname-text")
+        surname = self.rem_spaces(person.get_primary_name().get_surname())
+        # firstname = config.get('preferences.private-given-text')
+        # if not (probably_alive(person,self.db) and \
         #  self.restrict and self.living):
-        firstname = self.rem_spaces( person.get_primary_name().get_first_name())
+        firstname = self.rem_spaces(person.get_primary_name().get_first_name())
         if person.get_handle() not in self.person_ids:
             self.person_ids[person.get_handle()] = len(self.person_ids)
-        return "%s %s.%d" % (surname, firstname,
-                             self.person_ids[person.get_handle()])
+        return "%s %s.%d" % (surname, firstname, self.person_ids[person.get_handle()])
 
-    def get_child_ref_name(self,person,father_lastname):
-        #missing_first_name = config.get("preferences.no-given-text")
-        surname = self.rem_spaces( person.get_primary_name().get_surname())
-        #firstname = config.get('preferences.private-given-text')
-        #if not (probably_alive(person,self.db) and \
+    def get_child_ref_name(self, person, father_lastname):
+        # missing_first_name = config.get("preferences.no-given-text")
+        surname = self.rem_spaces(person.get_primary_name().get_surname())
+        # firstname = config.get('preferences.private-given-text')
+        # if not (probably_alive(person,self.db) and \
         #  self.restrict and self.living):
-        firstname = self.rem_spaces( person.get_primary_name().get_first_name())
+        firstname = self.rem_spaces(person.get_primary_name().get_first_name())
         if person.get_handle() not in self.person_ids:
             self.person_ids[person.get_handle()] = len(self.person_ids)
         ret = "%s.%d" % (firstname, self.person_ids[person.get_handle()])
-        if surname != father_lastname: ret += " " + surname
+        if surname != father_lastname:
+            ret += " " + surname
         return ret
 
-    def get_wedding_data(self,family):
-        ret = "";
+    def get_wedding_data(self, family):
+        ret = ""
         event_ref_list = family.get_event_ref_list()
         m_date = ""
         m_place = ""
@@ -370,40 +376,46 @@ class GeneWebWriter:
             event = self.db.get_event_from_handle(event_ref.ref)
             if event.get_type() == EventType.MARRIAGE:
                 married = 1
-                m_date = self.format_date( event.get_date_object())
+                m_date = self.format_date(event.get_date_object())
                 place_handle = event.get_place_handle()
                 if place_handle:
                     m_place = _pd.display_event(self.db, event)
-                m_source = self.get_primary_source( event.get_citation_list())
+                m_source = self.get_primary_source(event.get_citation_list())
             if event.get_type() == EventType.ENGAGEMENT:
                 engaged = 1
-                eng_date = self.format_date( event.get_date_object())
+                eng_date = self.format_date(event.get_date_object())
                 place_handle = event.get_place_handle()
                 if place_handle:
                     eng_place = _pd.display_event(self.db, event)
-                eng_source = self.get_primary_source( event.get_citation_list())
+                eng_source = self.get_primary_source(event.get_citation_list())
             if event.get_type() == EventType.DIVORCE:
                 divorced = 1
-                div_date = self.format_date( event.get_date_object())
+                div_date = self.format_date(event.get_date_object())
         if married == 1:
             if m_date != "":
                 ret = ret + m_date
             if m_place != "" and m_source != "":
-                ret = ret + " #mp %s #ms %s" % (self.rem_spaces( m_place), self.rem_spaces( m_source))
+                ret = ret + " #mp %s #ms %s" % (
+                    self.rem_spaces(m_place),
+                    self.rem_spaces(m_source),
+                )
             if m_place != "" and m_source == "":
-                ret = ret + " #mp %s" % self.rem_spaces( m_place)
+                ret = ret + " #mp %s" % self.rem_spaces(m_place)
             if m_source != "" and m_place == "":
-                ret = ret + " #ms %s" % self.rem_spaces( m_source)
+                ret = ret + " #ms %s" % self.rem_spaces(m_source)
         elif engaged == 1:
             """Geneweb only supports either Marriage or engagement"""
             if eng_date != "":
                 ret = ret + eng_date
             if m_place != "" and m_source != "":
-                ret = ret + " #mp %s #ms %s" % (self.rem_spaces( m_place), self.rem_spaces( m_source))
+                ret = ret + " #mp %s #ms %s" % (
+                    self.rem_spaces(m_place),
+                    self.rem_spaces(m_source),
+                )
             if eng_place != "" and m_source == "":
-                ret = ret + " #mp %s" % self.rem_spaces( m_place)
+                ret = ret + " #mp %s" % self.rem_spaces(m_place)
             if eng_source != "" and m_place == "":
-                ret = ret + " #ms %s" % self.rem_spaces( m_source)
+                ret = ret + " #ms %s" % self.rem_spaces(m_source)
         else:
             if family.get_relationship() != FamilyRelType.MARRIED:
                 """Not married or engaged"""
@@ -411,13 +423,13 @@ class GeneWebWriter:
 
         if divorced == 1:
             if div_date != "":
-                ret = ret + " -%s" %div_date
+                ret = ret + " -%s" % div_date
             else:
                 ret = ret + " -0"
 
         return ret
 
-    def get_primary_source(self,reflist):
+    def get_primary_source(self, reflist):
         ret = ""
         if reflist:
             for handle in reflist:
@@ -453,15 +465,14 @@ class GeneWebWriter:
         if year > 0:
             if month > 0:
                 if day > 0:
-                    retval = "%s%s/%s/%s%s" % (mode_prefix,day,month,year,cal_type)
+                    retval = "%s%s/%s/%s%s" % (mode_prefix, day, month, year, cal_type)
                 else:
-                    retval = "%s%s/%s%s" % (mode_prefix,month,year,cal_type)
+                    retval = "%s%s/%s%s" % (mode_prefix, month, year, cal_type)
             else:
-                retval = "%s%s%s" % (mode_prefix,year,cal_type)
+                retval = "%s%s%s" % (mode_prefix, year, cal_type)
         return retval
 
-
-    def format_date(self,date):
+    def format_date(self, date):
         retval = ""
         if date.get_modifier() == Date.MOD_TEXTONLY:
             retval = "0(%s)" % self.rem_spaces(date.get_text())
@@ -470,20 +481,30 @@ class GeneWebWriter:
             cal = cal = date.get_calendar()
             if mod == Date.MOD_SPAN or mod == Date.MOD_RANGE:
                 retval = "%s..%s" % (
-                    self.format_single_date(date.get_start_date(), cal,mod),
-                    self.format_single_date(date.get_stop_date(),cal,mod))
+                    self.format_single_date(date.get_start_date(), cal, mod),
+                    self.format_single_date(date.get_stop_date(), cal, mod),
+                )
+            elif mod == Date.MOD_FROM:
+                retval = "%s..0" % (
+                    self.format_single_date(date.get_start_date(), cal, mod)
+                )
+            elif mod == Date.MOD_TO:
+                retval = "0..%s" % (
+                    self.format_single_date(date.get_start_date(), cal, mod)
+                )
             else:
-                retval = self.format_single_date(date.get_start_date(),cal,mod)
+                retval = self.format_single_date(date.get_start_date(), cal, mod)
         return retval
 
-    def iso8859(self,s):
-        return s.encode('iso-8859-1','xmlcharrefreplace')
+    def iso8859(self, s):
+        return s.encode("iso-8859-1", "xmlcharrefreplace")
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 #
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 def exportData(database, filename, user, option_box=None):
     gw = GeneWebWriter(database, filename, user, option_box)
     return gw.export_data()

--- a/gramps/plugins/export/exportvcalendar.py
+++ b/gramps/plugins/export/exportvcalendar.py
@@ -23,30 +23,32 @@
 
 "Export Events to vCalendar."
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Standard Python Modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import os
 import sys
 import time
 
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 #
 # Set up logging
 #
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 import logging
 from collections import abc
+
 log = logging.getLogger(".ExportVCal")
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+
 _ = glocale.translation.gettext
 from gramps.gui.plug.export import WriterOptionBox
 from gramps.gen.utils.db import family_name
@@ -91,14 +93,13 @@ class CalendarWriter:
             self.oldval = newval
 
     def writeln(self, text):
-        self.g.write('%s\n' % text)
+        self.g.write("%s\n" % text)
 
     def export_data(self, filename):
 
         self.dirname = os.path.dirname(filename)
         try:
-            with open(filename, "w", encoding='utf8',
-                      newline='\r\n') as self.g:
+            with open(filename, "w", encoding="utf8", newline="\r\n") as self.g:
                 self.writeln("BEGIN:VCALENDAR")
                 self.writeln("PRODID:-//GNU//Gramps//EN")
                 self.writeln("VERSION:2.0")
@@ -134,8 +135,7 @@ class CalendarWriter:
                 event = self.db.get_event_from_handle(event_ref.ref)
                 if event and event.get_type() == EventType.MARRIAGE:
                     # feature requests 2356, 1657: avoid genitive form
-                    text = "%s - %s" % (family_name(family, self.db),
-                                        _("Marriage"))
+                    text = "%s - %s" % (family_name(family, self.db), _("Marriage"))
                     self.write_vevent(text, event)
 
     def write_person(self, person_handle):
@@ -146,18 +146,18 @@ class CalendarWriter:
                 birth = self.db.get_event_from_handle(birth_ref.ref)
                 if birth:
                     # feature requests 2356, 1657: avoid genitive form
-                    self.write_vevent("%s - %s" %
-                                      (name_displayer.display(person),
-                                       _("Birth")), birth)
+                    self.write_vevent(
+                        "%s - %s" % (name_displayer.display(person), _("Birth")), birth
+                    )
 
             death_ref = person.get_death_ref()
             if death_ref:
                 death = self.db.get_event_from_handle(death_ref.ref)
                 if death:
                     # feature requests 2356, 1657: avoid genitive form
-                    self.write_vevent("%s - %s" %
-                                      (name_displayer.display(person),
-                                       _("Death")), death)
+                    self.write_vevent(
+                        "%s - %s" % (name_displayer.display(person), _("Death")), death
+                    )
 
     def format_single_date(self, subdate, thisyear, cal):
         retval = ""
@@ -183,19 +183,24 @@ class CalendarWriter:
             mod = date.get_modifier()
             cal = cal = date.get_calendar()
             if mod == Date.MOD_SPAN or mod == Date.MOD_RANGE:
-                start = self.format_single_date(date.get_start_date(),
-                                                thisyear, cal)
-                end = self.format_single_date(date.get_stop_date(),
-                                              thisyear, cal)
+                start = self.format_single_date(date.get_start_date(), thisyear, cal)
+                end = self.format_single_date(date.get_stop_date(), thisyear, cal)
                 if start and end:
-                    retval = "DTSTART:%sT000001\nDTEND:%sT235959" % (start,
-                                                                     end)
-            elif mod == Date.MOD_NONE:
-                start = self.format_single_date(date.get_start_date(),
-                                                thisyear, cal)
+                    retval = "DTSTART:%sT000001\nDTEND:%sT235959" % (start, end)
+            elif mod == Date.MOD_FROM:
+                start = self.format_single_date(date.get_start_date(), thisyear, cal)
                 if start:
-                    retval = "DTSTART:%sT000001\nDTEND:%sT235959" % (start,
-                                                                     start)
+                    retval = "DTSTART:%sT000001" % (start)
+
+            elif mod == Date.MOD_TO:
+                end = self.format_single_date(date.get_start_date(), thisyear, cal)
+                if end:
+                    retval = "DTEND:%sT235959" % (end)
+
+            elif mod == Date.MOD_NONE:
+                start = self.format_single_date(date.get_start_date(), thisyear, cal)
+                if start:
+                    retval = "DTSTART:%sT000001\nDTEND:%sT235959" % (start, start)
         return retval
 
     def write_vevent(self, event_text, event):
@@ -217,18 +222,19 @@ class CalendarWriter:
             self.writeln(date_string)
             self.writeln("END:VEVENT")
 
+
 # -------------------------------------------------------------------------
 
 
 def fold(txt):
-    """ Limit line length to 75 octets (per RFC 5545) """
+    """Limit line length to 75 octets (per RFC 5545)"""
     l_len = 0
-    text = ''
+    text = ""
     for char in txt:
-        c_len = len(char.encode('utf8'))
+        c_len = len(char.encode("utf8"))
         if c_len + l_len > 75:
             l_len = 1
-            text += '\n ' + char
+            text += "\n " + char
         else:
             l_len += c_len
             text += char

--- a/gramps/plugins/export/exportvcard.py
+++ b/gramps/plugins/export/exportvcard.py
@@ -24,29 +24,31 @@
 
 "Export Persons to vCard (RFC 2426)."
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Standard Python Modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import sys
 from textwrap import TextWrapper
 
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 #
 # Set up logging
 #
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 import logging
 from collections import abc
+
 log = logging.getLogger(".ExportVCard")
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+
 _ = glocale.translation.gettext
 from gramps.gen.const import PROGRAM_NAME
 from gramps.version import VERSION
@@ -57,11 +59,11 @@ from gramps.gen.lib.eventtype import EventType
 from gramps.gen.display.name import displayer as _nd
 from gramps.gen.plug.utils import OpenFileOrStdout
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Support Functions
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 def exportData(database, filename, user, option_box=None):
     """Function called by Gramps to export data on persons in VCard format."""
     cardw = VCardWriter(database, filename, option_box, user)
@@ -76,17 +78,19 @@ def exportData(database, filename, user, option_box=None):
         return False
     return True
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # VCardWriter class
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class VCardWriter:
     """Class to create a file with data in VCard format."""
-    LINELENGTH = 73 # unclear if the 75 chars of spec includes \r\n.
-    ESCAPE_CHAR = '\\'
-    TOBE_ESCAPED = ['\\', ',', ';'] # order is important
-    LINE_CONTINUATION = [' ', '\t']
+
+    LINELENGTH = 73  # unclear if the 75 chars of spec includes \r\n.
+    ESCAPE_CHAR = "\\"
+    TOBE_ESCAPED = ["\\", ",", ";"]  # order is important
+    LINE_CONTINUATION = [" ", "\t"]
 
     @staticmethod
     def esc(data):
@@ -100,8 +104,10 @@ class VCardWriter:
         elif type(data) == type(()):
             return tuple(map(VCardWriter.esc, data))
         else:
-            raise TypeError("VCard escaping is not implemented for "
-                              "data type %s." % str(type(data)))
+            raise TypeError(
+                "VCard escaping is not implemented for "
+                "data type %s." % str(type(data))
+            )
 
     def __init__(self, database, filename, option_box=None, user=None):
         self.db = database
@@ -118,11 +124,13 @@ class VCardWriter:
             self.option_box.parse_options()
             self.db = option_box.get_filtered_database(self.db)
 
-        self.txtwrp = TextWrapper(width=self.LINELENGTH,
-                                  expand_tabs=False,
-                                  replace_whitespace=False,
-                                  drop_whitespace=False,
-                                  subsequent_indent=self.LINE_CONTINUATION[0])
+        self.txtwrp = TextWrapper(
+            width=self.LINELENGTH,
+            expand_tabs=False,
+            replace_whitespace=False,
+            drop_whitespace=False,
+            subsequent_indent=self.LINE_CONTINUATION[0],
+        )
         self.count = 0
         self.total = 0
 
@@ -133,7 +141,7 @@ class VCardWriter:
     def update_real(self):
         """Report progress."""
         self.count += 1
-        newval = int(100*self.count/self.total)
+        newval = int(100 * self.count / self.total)
         if newval != self.oldval:
             self.user.callback(newval)
             self.oldval = newval
@@ -144,13 +152,15 @@ class VCardWriter:
 
         Can't cope with nested VCards, section 2.4.2 of RFC 2426.
         """
-        self.filehandle.write('%s\r\n' % '\r\n'.join(
-            [line for line in self.txtwrp.wrap(text)]))
+        self.filehandle.write(
+            "%s\r\n" % "\r\n".join([line for line in self.txtwrp.wrap(text)])
+        )
 
     def export_data(self):
         """Open the file and loop over everyone too write their VCards."""
-        with OpenFileOrStdout(self.filename, encoding='utf-8',
-                              errors='strict', newline='') as self.filehandle:
+        with OpenFileOrStdout(
+            self.filename, encoding="utf-8", errors="strict", newline=""
+        ) as self.filehandle:
             if self.filehandle:
                 self.count = 0
                 self.oldval = 0
@@ -181,8 +191,7 @@ class VCardWriter:
         """Write the opening lines of a VCard."""
         self.writeln("BEGIN:VCARD")
         self.writeln("VERSION:3.0")
-        self.writeln("PRODID:-//Gramps//NONSGML %s %s//EN" %
-                     (PROGRAM_NAME, VERSION))
+        self.writeln("PRODID:-//Gramps//NONSGML %s %s//EN" % (PROGRAM_NAME, VERSION))
 
     def write_footer(self):
         """Write the closing lines of a VCard."""
@@ -199,20 +208,32 @@ class VCardWriter:
 
     def write_name(self, prname):
         """Write the compulsory N property of a VCard."""
-        family_name = ''
-        given_name = ''
-        additional_names = ''
-        hon_prefix = ''
-        suffix = ''
+        family_name = ""
+        given_name = ""
+        additional_names = ""
+        hon_prefix = ""
+        suffix = ""
 
         primary_surname = prname.get_primary_surname()
         surname_list = prname.get_surname_list()
         if not surname_list[0].get_primary():
             surname_list.remove(primary_surname)
             surname_list.insert(0, primary_surname)
-        family_name = ','.join(self.esc([("%s %s %s" % (surname.get_prefix(),
-            surname.get_surname(), surname.get_connector())).strip()
-            for surname in surname_list]))
+        family_name = ",".join(
+            self.esc(
+                [
+                    (
+                        "%s %s %s"
+                        % (
+                            surname.get_prefix(),
+                            surname.get_surname(),
+                            surname.get_connector(),
+                        )
+                    ).strip()
+                    for surname in surname_list
+                ]
+            )
+        )
 
         call_name = prname.get_call_name()
         if call_name:
@@ -220,23 +241,25 @@ class VCardWriter:
             additional_name_list = prname.get_first_name().split()
             if call_name in additional_name_list:
                 additional_name_list.remove(call_name)
-            additional_names = ','.join(self.esc(additional_name_list))
+            additional_names = ",".join(self.esc(additional_name_list))
         else:
             name_list = prname.get_first_name().split()
             if len(name_list) > 0:
                 given_name = self.esc(name_list[0])
                 if len(name_list) > 1:
-                    additional_names = ','.join(self.esc(name_list[1:]))
+                    additional_names = ",".join(self.esc(name_list[1:]))
         # Alternate names are ignored because names just don't add up:
         # if one name is Jean and an alternate is Paul then you can't
         # conclude the Jean Paul is also an alternate name of that person.
 
         # Assume all titles/suffixes that apply are present in primary name.
-        hon_prefix = ','.join(self.esc(prname.get_title().split()))
-        suffix = ','.join(self.esc(prname.get_suffix().split()))
+        hon_prefix = ",".join(self.esc(prname.get_title().split()))
+        suffix = ",".join(self.esc(prname.get_suffix().split()))
 
-        self.writeln("N:%s;%s;%s;%s;%s" % (family_name, given_name,
-                     additional_names, hon_prefix, suffix))
+        self.writeln(
+            "N:%s;%s;%s;%s;%s"
+            % (family_name, given_name, additional_names, hon_prefix, suffix)
+        )
 
     def write_sortstring(self, prname):
         """Write the SORT-STRING property of a VCard."""
@@ -245,19 +268,20 @@ class VCardWriter:
 
     def write_nicknames(self, person, prname):
         """Write the NICKNAME property of a VCard."""
-        nicknames = [x.get_nick_name() for x in person.get_alternate_names()
-                     if x.get_nick_name()]
+        nicknames = [
+            x.get_nick_name() for x in person.get_alternate_names() if x.get_nick_name()
+        ]
         if prname.get_nick_name():
             nicknames.insert(0, prname.get_nick_name())
         if len(nicknames) > 0:
-            self.writeln("NICKNAME:%s" % (','.join(self.esc(nicknames))))
+            self.writeln("NICKNAME:%s" % (",".join(self.esc(nicknames))))
 
     def write_gender(self, person):
         """Write the X-GENDER property of a VCard (X- dropped in 4.0, we're at 3.0)."""
         gender = person.get_gender()
-        gender_value = ''
+        gender_value = ""
         if gender == Person.MALE:
-            gender_value = 'Male'
+            gender_value = "Male"
         elif gender == Person.FEMALE:
             gender_value = 'Female'
         elif gender == Person.OTHER:
@@ -274,10 +298,14 @@ class VCardWriter:
             if birth:
                 b_date = birth.get_date_object()
                 mod = b_date.get_modifier()
-                if (mod != Date.MOD_TEXTONLY and
-                    not b_date.is_empty() and
-                    not mod == Date.MOD_SPAN and
-                    not mod == Date.MOD_RANGE):
+                if (
+                    mod != Date.MOD_TEXTONLY
+                    and not b_date.is_empty()
+                    and not mod == Date.MOD_SPAN
+                    and not mod == Date.MOD_FROM
+                    and not mod == Date.MOD_TO
+                    and not mod == Date.MOD_RANGE
+                ):
                     (day, month, year, slash) = b_date.get_start_date()
                     if day > 0 and month > 0 and year > 0:
                         self.writeln("BDAY:%s-%02d-%02d" % (year, month, day))
@@ -294,8 +322,10 @@ class VCardWriter:
             zipcode = address.get_postal_code()
             country = address.get_country()
             if street or city or state or zipcode or country:
-                self.writeln("ADR:%s;%s;%s;%s;%s;%s;%s" % self.esc(
-                    (postbox, ext, street, city, state, zipcode, country)))
+                self.writeln(
+                    "ADR:%s;%s;%s;%s;%s;%s;%s"
+                    % self.esc((postbox, ext, street, city, state, zipcode, country))
+                )
 
             phone = address.get_phone()
             if phone:
@@ -308,8 +338,8 @@ class VCardWriter:
             href = url.get_path()
             if href:
                 if url.get_type() == UrlType(UrlType.EMAIL):
-                    if href.startswith('mailto:'):
-                        href = href[len('mailto:'):]
+                    if href.startswith("mailto:"):
+                        href = href[len("mailto:") :]
                     self.writeln("EMAIL:%s" % self.esc(href))
                 else:
                     self.writeln("URL:%s" % self.esc(href))
@@ -321,12 +351,13 @@ class VCardWriter:
         Use the most recent occupation event.
         """
         event_refs = person.get_primary_event_ref_list()
-        events = [event for event in
-                    [self.db.get_event_from_handle(ref.ref) for ref in event_refs]
-                    if event.get_type() == EventType(EventType.OCCUPATION)]
+        events = [
+            event
+            for event in [self.db.get_event_from_handle(ref.ref) for ref in event_refs]
+            if event.get_type() == EventType(EventType.OCCUPATION)
+        ]
         if len(events) > 0:
             events.sort(key=lambda x: x.get_date_object())
             occupation = events[-1].get_description()
             if occupation:
                 self.writeln("ROLE:%s" % occupation)
-

--- a/gramps/plugins/export/exportxml.py
+++ b/gramps/plugins/export/exportxml.py
@@ -30,31 +30,33 @@ Contains the interface to allow a database to get written using
 Gramps' XML file format.
 """
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Standard python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import time
 import shutil
 import os
 import codecs
 from xml.sax.saxutils import escape
 
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 #
 # Set up logging
 #
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 import logging
+
 LOG = logging.getLogger(".WriteXML")
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+
 _ = glocale.translation.gettext
 from gramps.gen.const import URL_HOMEPAGE
 from gramps.gen.lib import Date, Person
@@ -65,40 +67,49 @@ from gramps.gen.constfunc import win
 from gramps.gui.plug.export import WriterOptionBox, WriterOptionBoxWithCompression
 import gramps.plugins.lib.libgrampsxml as libgrampsxml
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Attempt to load the GZIP library. Some version of python do not seem
 # to be compiled with this available.
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 try:
     import gzip
+
     _gzip_ok = 1
 except:
     _gzip_ok = 0
 
 # table for skipping control chars from XML except 09, 0A, 0D
-strip_dict = dict.fromkeys(list(range(9))+list(range(11,13))+list(range(14, 32)))
+strip_dict = dict.fromkeys(list(range(9)) + list(range(11, 13)) + list(range(14, 32)))
+
 
 def escxml(d):
-    return escape(d,
-                  {'"' : '&quot;',
-                   '<' : '&lt;',
-                   '>' : '&gt;',
-                   }) if d else ""
+    return (
+        escape(
+            d,
+            {
+                '"': "&quot;",
+                "<": "&lt;",
+                ">": "&gt;",
+            },
+        )
+        if d
+        else ""
+    )
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 #
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class GrampsXmlWriter(UpdateCallback):
     """
     Writes a database to the XML file.
     """
 
-    def __init__(self, db, strip_photos=0, compress=1, version="unknown",
-                 user=None):
+    def __init__(self, db, strip_photos=0, compress=1, version="unknown", user=None):
         """
         Initialize, but does not write, an XML file.
 
@@ -124,8 +135,9 @@ class GrampsXmlWriter(UpdateCallback):
         """
         Write the database to the specified file.
         """
-        if filename == '-':
+        if filename == "-":
             import sys
+
             try:
                 g = sys.stdout.buffer
             except:
@@ -136,48 +148,58 @@ class GrampsXmlWriter(UpdateCallback):
             if os.path.isdir(base):
                 if not os.access(base, os.W_OK) or not os.access(base, os.R_OK):
                     raise DbWriteFailure(
-                            _('Failure writing %s') % filename,
-                            _("The database cannot be saved because you do "
+                        _("Failure writing %s") % filename,
+                        _(
+                            "The database cannot be saved because you do "
                             "not have permission to write to the directory. "
                             "Please make sure you have write access to the "
-                                "directory and try again."))
+                            "directory and try again."
+                        ),
+                    )
                     return 0
             else:
-                raise DbWriteFailure(_('No directory'),
-                                     _('There is no directory %s.\n\n'
-                                       'Please select another directory '
-                                       'or create it.') % base )
+                raise DbWriteFailure(
+                    _("No directory"),
+                    _(
+                        "There is no directory %s.\n\n"
+                        "Please select another directory "
+                        "or create it."
+                    )
+                    % base,
+                )
                 return 0
 
             if os.path.exists(filename):
                 if not os.access(filename, os.W_OK):
                     raise DbWriteFailure(
-                            _('Failure writing %s') % filename,
-                            _("The database cannot be saved because you do "
+                        _("Failure writing %s") % filename,
+                        _(
+                            "The database cannot be saved because you do "
                             "not have permission to write to the file. "
                             "Please make sure you have write access to the "
-                            "file and try again."))
+                            "file and try again."
+                        ),
+                    )
                     return 0
 
             self.fileroot = os.path.dirname(filename)
             try:
                 if self.compress and _gzip_ok:
                     try:
-                        g = gzip.open(filename,"wb")
+                        g = gzip.open(filename, "wb")
                     except:
-                        g = open(filename,"wb")
+                        g = open(filename, "wb")
                 else:
-                    g = open(filename,"wb")
+                    g = open(filename, "wb")
             except IOError as msg:
                 LOG.warning(str(msg))
-                raise DbWriteFailure(_('Failure writing %s') % filename,
-                                        str(msg))
+                raise DbWriteFailure(_("Failure writing %s") % filename, str(msg))
                 return 0
 
         self.g = codecs.getwriter("utf8")(g)
 
         self.write_xml_data()
-        if filename != '-':
+        if filename != "-":
             g.close()
         return 1
 
@@ -216,35 +238,50 @@ class GrampsXmlWriter(UpdateCallback):
         note_len = self.db.get_number_of_notes()
         tag_len = self.db.get_number_of_tags()
 
-        total_steps = (person_len + family_len + event_len + citation_len +
-                       source_len + place_len + repo_len + obj_len + note_len +
-                       tag_len
-                      )
+        total_steps = (
+            person_len
+            + family_len
+            + event_len
+            + citation_len
+            + source_len
+            + place_len
+            + repo_len
+            + obj_len
+            + note_len
+            + tag_len
+        )
 
         self.set_total(total_steps)
 
         self.g.write('<?xml version="1.0" encoding="UTF-8"?>\n')
-        self.g.write('<!DOCTYPE database '
-                     'PUBLIC "-//Gramps//DTD Gramps XML %s//EN"\n'
-                     '"%sxml/%s/grampsxml.dtd">\n'
-                     % (libgrampsxml.GRAMPS_XML_VERSION, URL_HOMEPAGE,
-                        libgrampsxml.GRAMPS_XML_VERSION))
-        self.g.write('<database xmlns="%sxml/%s/">\n'
-                     % (URL_HOMEPAGE, libgrampsxml.GRAMPS_XML_VERSION))
+        self.g.write(
+            "<!DOCTYPE database "
+            'PUBLIC "-//Gramps//DTD Gramps XML %s//EN"\n'
+            '"%sxml/%s/grampsxml.dtd">\n'
+            % (
+                libgrampsxml.GRAMPS_XML_VERSION,
+                URL_HOMEPAGE,
+                libgrampsxml.GRAMPS_XML_VERSION,
+            )
+        )
+        self.g.write(
+            '<database xmlns="%sxml/%s/">\n'
+            % (URL_HOMEPAGE, libgrampsxml.GRAMPS_XML_VERSION)
+        )
         self.g.write("  <header>\n")
-        self.g.write('    <created date="%04d-%02d-%02d\"' % date[:3])
-        self.g.write(" version=\"" + self.version + "\"")
+        self.g.write('    <created date="%04d-%02d-%02d"' % date[:3])
+        self.g.write(' version="' + self.version + '"')
         self.g.write("/>\n")
         self.g.write("    <researcher>\n")
-        self.write_line("resname", owner.get_name(),3)
-        self.write_line("resaddr", owner.get_address(),3)
-        self.write_line("reslocality", owner.get_locality(),3)
-        self.write_line("rescity", owner.get_city(),3)
-        self.write_line("resstate", owner.get_state(),3)
-        self.write_line("rescountry", owner.get_country(),3)
-        self.write_line("respostal", owner.get_postal_code(),3)
-        self.write_line("resphone", owner.get_phone(),3)
-        self.write_line("resemail", owner.get_email(),3)
+        self.write_line("resname", owner.get_name(), 3)
+        self.write_line("resaddr", owner.get_address(), 3)
+        self.write_line("reslocality", owner.get_locality(), 3)
+        self.write_line("rescity", owner.get_city(), 3)
+        self.write_line("resstate", owner.get_state(), 3)
+        self.write_line("rescountry", owner.get_country(), 3)
+        self.write_line("respostal", owner.get_postal_code(), 3)
+        self.write_line("resphone", owner.get_phone(), 3)
+        self.write_line("resemail", owner.get_email(), 3)
         self.g.write("    </researcher>\n")
         self.write_metadata()
         self.g.write("  </header>\n")
@@ -269,7 +306,7 @@ class GrampsXmlWriter(UpdateCallback):
             for handle in sorted(self.db.get_event_handles()):
                 event = self.db.get_event_from_handle(handle)
                 if event:
-                    self.write_event(event,2)
+                    self.write_event(event, 2)
                 self.update()
             self.g.write("  </events>\n")
 
@@ -278,7 +315,7 @@ class GrampsXmlWriter(UpdateCallback):
             person = self.db.get_default_person()
             if person:
                 self.g.write(' home="_%s"' % person.handle)
-            self.g.write('>\n')
+            self.g.write(">\n")
 
             for handle in sorted(self.db.get_person_handles()):
                 person = self.db.get_person_from_handle(handle)
@@ -292,7 +329,7 @@ class GrampsXmlWriter(UpdateCallback):
             for handle in sorted(self.db.iter_family_handles()):
                 family = self.db.get_family_from_handle(handle)
                 if family:
-                    self.write_family(family,2)
+                    self.write_family(family, 2)
                 self.update()
             self.g.write("  </families>\n")
 
@@ -301,7 +338,7 @@ class GrampsXmlWriter(UpdateCallback):
             for handle in sorted(self.db.get_citation_handles()):
                 citation = self.db.get_citation_from_handle(handle)
                 if citation:
-                    self.write_citation(citation,2)
+                    self.write_citation(citation, 2)
                 self.update()
             self.g.write("  </citations>\n")
 
@@ -310,7 +347,7 @@ class GrampsXmlWriter(UpdateCallback):
             for handle in sorted(self.db.get_source_handles()):
                 source = self.db.get_source_from_handle(handle)
                 if source:
-                    self.write_source(source,2)
+                    self.write_source(source, 2)
                 self.update()
             self.g.write("  </sources>\n")
 
@@ -320,7 +357,7 @@ class GrampsXmlWriter(UpdateCallback):
                 # try:
                 place = self.db.get_place_from_handle(key)
                 if place:
-                    self.write_place_obj(place,2)
+                    self.write_place_obj(place, 2)
                 self.update()
             self.g.write("  </places>\n")
 
@@ -329,7 +366,7 @@ class GrampsXmlWriter(UpdateCallback):
             for handle in sorted(self.db.get_media_handles()):
                 obj = self.db.get_media_from_handle(handle)
                 if obj:
-                    self.write_object(obj,2)
+                    self.write_object(obj, 2)
                 self.update()
             self.g.write("  </objects>\n")
 
@@ -338,7 +375,7 @@ class GrampsXmlWriter(UpdateCallback):
             for key in sorted(self.db.get_repository_handles()):
                 repo = self.db.get_repository_from_handle(key)
                 if repo:
-                    self.write_repository(repo,2)
+                    self.write_repository(repo, 2)
                 self.update()
             self.g.write("  </repositories>\n")
 
@@ -357,13 +394,12 @@ class GrampsXmlWriter(UpdateCallback):
 
         self.g.write("</database>\n")
 
-#        self.status.end()
-#        self.status = None
+    #        self.status.end()
+    #        self.status = None
 
     def write_metadata(self):
-        """ Method to write out metadata of the database
-        """
-        mediapath= self.db.get_mediapath()
+        """Method to write out metadata of the database"""
+        mediapath = self.db.get_mediapath()
         if mediapath is not None:
             self.write_line("mediapath", mediapath, 2)
 
@@ -375,8 +411,10 @@ class GrampsXmlWriter(UpdateCallback):
             self.g.write("  <namemaps>\n")
             for key in group_map:
                 value = self.db.get_name_group_mapping(key)
-                self.g.write('    <map type="group_as" key="%s" value="%s"/>\n'
-                             % (self.fix(key), self.fix(value)))
+                self.g.write(
+                    '    <map type="group_as" key="%s" value="%s"/>\n'
+                    % (self.fix(key), self.fix(value))
+                )
             self.g.write("  </namemaps>\n")
 
     def write_bookmarks(self):
@@ -390,52 +428,53 @@ class GrampsXmlWriter(UpdateCallback):
         bm_obj_len = len(self.db.media_bookmarks.get())
         bm_note_len = len(self.db.note_bookmarks.get())
 
-        bm_len = (bm_person_len + bm_family_len + bm_event_len +
-                  bm_source_len + bm_place_len + bm_repo_len +
-                  bm_citation_len + bm_obj_len + bm_note_len
-                  )
+        bm_len = (
+            bm_person_len
+            + bm_family_len
+            + bm_event_len
+            + bm_source_len
+            + bm_place_len
+            + bm_repo_len
+            + bm_citation_len
+            + bm_obj_len
+            + bm_note_len
+        )
 
         if bm_len > 0:
             self.g.write("  <bookmarks>\n")
 
             for handle in self.db.get_bookmarks().get():
-                self.g.write('    <bookmark target="person" hlink="_%s"/>\n'
-                             % handle )
+                self.g.write('    <bookmark target="person" hlink="_%s"/>\n' % handle)
             for handle in self.db.get_family_bookmarks().get():
-                self.g.write('    <bookmark target="family" hlink="_%s"/>\n'
-                             % handle )
+                self.g.write('    <bookmark target="family" hlink="_%s"/>\n' % handle)
             for handle in self.db.get_event_bookmarks().get():
-                self.g.write('    <bookmark target="event" hlink="_%s"/>\n'
-                             % handle )
+                self.g.write('    <bookmark target="event" hlink="_%s"/>\n' % handle)
             for handle in self.db.get_source_bookmarks().get():
-                self.g.write('    <bookmark target="source" hlink="_%s"/>\n'
-                             % handle )
+                self.g.write('    <bookmark target="source" hlink="_%s"/>\n' % handle)
             for handle in self.db.get_citation_bookmarks().get():
-                self.g.write('    <bookmark target="citation" hlink="_%s"/>\n'
-                             % handle )
+                self.g.write('    <bookmark target="citation" hlink="_%s"/>\n' % handle)
             for handle in self.db.get_place_bookmarks().get():
-                self.g.write('    <bookmark target="place" hlink="_%s"/>\n'
-                             % handle )
+                self.g.write('    <bookmark target="place" hlink="_%s"/>\n' % handle)
             for handle in self.db.get_media_bookmarks().get():
-                self.g.write('    <bookmark target="media" hlink="_%s"/>\n'
-                             % handle )
+                self.g.write('    <bookmark target="media" hlink="_%s"/>\n' % handle)
             for handle in self.db.get_repo_bookmarks().get():
-                self.g.write('    <bookmark target="repository" hlink="_%s"/>\n'
-                             % handle )
+                self.g.write(
+                    '    <bookmark target="repository" hlink="_%s"/>\n' % handle
+                )
             for handle in self.db.get_note_bookmarks().get():
-                self.g.write('    <bookmark target="note" hlink="_%s"/>\n'
-                             % handle )
+                self.g.write('    <bookmark target="note" hlink="_%s"/>\n' % handle)
 
             self.g.write("  </bookmarks>\n")
 
     def write_name_formats(self):
         if len(self.db.name_formats) > 0:
             self.g.write("  <name-formats>\n")
-            for number, name,fmt_str,active in self.db.name_formats:
-                self.g.write('%s<format number="%d" name="%s" '
-                             'fmt_str="%s" active="%d"/>\n'
-                             % ('    ', number,
-                                escxml(name), escxml(fmt_str), int(active)) )
+            for number, name, fmt_str, active in self.db.name_formats:
+                self.g.write(
+                    '%s<format number="%d" name="%s" '
+                    'fmt_str="%s" active="%d"/>\n'
+                    % ("    ", number, escxml(name), escxml(fmt_str), int(active))
+                )
             self.g.write("  </name-formats>\n")
 
     def write_tag(self, tag, index=2):
@@ -445,26 +484,26 @@ class GrampsXmlWriter(UpdateCallback):
         if not tag:
             return
 
-        self.write_table_tag('tag', tag, index, close=False)
+        self.write_table_tag("tag", tag, index, close=False)
         self.g.write(' name="%s"' % escxml(tag.get_name()))
         self.g.write(' color="%s"' % tag.get_color())
         self.g.write(' priority="%d"' % tag.get_priority())
-        self.g.write('/>\n')
+        self.g.write("/>\n")
 
     def fix(self, line):
         l = str(line)
         l = l.strip().translate(strip_dict)
         return escxml(l)
 
-    def write_note_list(self, note_list,indent=0):
+    def write_note_list(self, note_list, indent=0):
         for handle in note_list:
-            self.write_ref("noteref", handle,indent)
+            self.write_ref("noteref", handle, indent)
 
     def write_note(self, note, index=2):
         if not note:
             return
 
-        self.write_primary_tag('note', note, index, close=False)
+        self.write_primary_tag("note", note, index, close=False)
 
         ntype = escxml(note.get_type().xml_str())
         format = note.get_format()
@@ -475,273 +514,304 @@ class GrampsXmlWriter(UpdateCallback):
         self.g.write(' type="%s"' % ntype)
         if format != note.FLOWED:
             self.g.write(' format="%d"' % format)
-        self.g.write('>\n')
+        self.g.write(">\n")
 
-        self.write_text('text', text, index + 1)
+        self.write_text("text", text, index + 1)
 
         if styles:
             self.write_styles(styles, index + 1)
 
         for tag_handle in note.get_tag_list():
-            self.write_ref("tagref", tag_handle, index+1)
+            self.write_ref("tagref", tag_handle, index + 1)
 
-        self.g.write('  ' * index + '</note>\n')
+        self.g.write("  " * index + "</note>\n")
 
     def write_styles(self, styles, index=3):
         for style in styles:
             name = style.name.xml_str()
             value = style.value
 
-            self.g.write('  ' * index + '<style name="%s"' % name)
+            self.g.write("  " * index + '<style name="%s"' % name)
             if value:
                 self.g.write(' value="%s"' % escxml(str(value)))
-            self.g.write('>\n')
+            self.g.write(">\n")
 
             for (start, end) in style.ranges:
-                self.g.write(('  ' * (index + 1)) +
-                             '<range start="%d" end="%d"/>\n' % (start, end))
+                self.g.write(
+                    ("  " * (index + 1))
+                    + '<range start="%d" end="%d"/>\n' % (start, end)
+                )
 
-            self.g.write('  ' * index + '</style>\n')
+            self.g.write("  " * index + "</style>\n")
 
     def write_text(self, val, text, indent=0):
         if not text:
             return
 
         if indent:
-            self.g.write('  ' * indent)
+            self.g.write("  " * indent)
 
-        self.g.write('<%s>' % val)
+        self.g.write("<%s>" % val)
         self.g.write(escxml(str(text).translate(strip_dict)))
         self.g.write("</%s>\n" % val)
 
-    def write_person(self,person,index=1):
-        sp = "  "*index
-        self.write_primary_tag("person",person,index)
+    def write_person(self, person, index=1):
+        sp = "  " * index
+        self.write_primary_tag("person", person, index)
         if person.get_gender() == Person.MALE:
-            self.write_line("gender","M",index+1)
+            self.write_line("gender", "M", index + 1)
         elif person.get_gender() == Person.FEMALE:
             self.write_line("gender","F",index+1)
         elif person.get_gender() == Person.OTHER:
             self.write_line("gender","X",index+1)
         else:
-            self.write_line("gender","U",index+1)
-        self.dump_name(person.get_primary_name(),False,index+1)
+            self.write_line("gender", "U", index + 1)
+        self.dump_name(person.get_primary_name(), False, index + 1)
         for name in person.get_alternate_names():
-            self.dump_name(name,True,index+1)
+            self.dump_name(name, True, index + 1)
 
-        #self.dump_event_ref(person.get_birth_ref(),index+1)
-        #self.dump_event_ref(person.get_death_ref(),index+1)
+        # self.dump_event_ref(person.get_birth_ref(),index+1)
+        # self.dump_event_ref(person.get_death_ref(),index+1)
         for event_ref in person.get_event_ref_list():
-            self.dump_event_ref(event_ref,index+1)
+            self.dump_event_ref(event_ref, index + 1)
 
         for lds_ord in person.lds_ord_list:
-            self.dump_ordinance(lds_ord,index+1)
+            self.dump_ordinance(lds_ord, index + 1)
 
-        self.write_media_list(person.get_media_list(),index+1)
+        self.write_media_list(person.get_media_list(), index + 1)
 
-        self.write_address_list(person,index+1)
+        self.write_address_list(person, index + 1)
         self.write_attribute_list(person.get_attribute_list())
-        self.write_url_list(person.get_url_list(),index+1)
+        self.write_url_list(person.get_url_list(), index + 1)
 
         for family_handle in person.get_parent_family_handle_list():
-            self.write_ref("childof",family_handle,index+1)
+            self.write_ref("childof", family_handle, index + 1)
 
         for family_handle in person.get_family_handle_list():
-            self.write_ref("parentin",family_handle,index+1)
+            self.write_ref("parentin", family_handle, index + 1)
 
         for person_ref in person.get_person_ref_list():
-            self.dump_person_ref(person_ref,index+1)
+            self.dump_person_ref(person_ref, index + 1)
 
-        self.write_note_list(person.get_note_list(),index+1)
+        self.write_note_list(person.get_note_list(), index + 1)
 
         for citation_handle in person.get_citation_list():
-            self.write_ref("citationref", citation_handle, index+1)
+            self.write_ref("citationref", citation_handle, index + 1)
 
         for tag_handle in person.get_tag_list():
-            self.write_ref("tagref", tag_handle, index+1)
+            self.write_ref("tagref", tag_handle, index + 1)
 
         self.g.write("%s</person>\n" % sp)
 
-    def write_family(self,family,index=1):
-        sp = "  "*index
-        self.write_family_handle(family,index)
+    def write_family(self, family, index=1):
+        sp = "  " * index
+        self.write_family_handle(family, index)
         fhandle = family.get_father_handle()
         mhandle = family.get_mother_handle()
         if fhandle:
-            self.write_ref("father",fhandle,index+1)
+            self.write_ref("father", fhandle, index + 1)
         if mhandle:
-            self.write_ref("mother",mhandle,index+1)
+            self.write_ref("mother", mhandle, index + 1)
         for event_ref in family.get_event_ref_list():
-            self.dump_event_ref(event_ref,3)
+            self.dump_event_ref(event_ref, 3)
         for lds_ord in family.lds_ord_list:
-            self.dump_ordinance(lds_ord,index+1)
+            self.dump_ordinance(lds_ord, index + 1)
 
-        self.write_media_list(family.get_media_list(),index+1)
+        self.write_media_list(family.get_media_list(), index + 1)
 
         for child_ref in family.get_child_ref_list():
-            self.dump_child_ref(child_ref,index+1)
+            self.dump_child_ref(child_ref, index + 1)
         self.write_attribute_list(family.get_attribute_list())
-        self.write_note_list(family.get_note_list(),index+1)
+        self.write_note_list(family.get_note_list(), index + 1)
         for citation_handle in family.get_citation_list():
-            self.write_ref("citationref", citation_handle, index+1)
+            self.write_ref("citationref", citation_handle, index + 1)
 
         for tag_handle in family.get_tag_list():
-            self.write_ref("tagref", tag_handle, index+1)
+            self.write_ref("tagref", tag_handle, index + 1)
 
         self.g.write("%s</family>\n" % sp)
 
     def write_citation(self, citation, index=1):
         sp = "  " * index
         self.write_primary_tag("citation", citation, index)
-        self.write_date(citation.get_date_object(), index+1)
-        self.write_line("page", citation.get_page(), index+1)
-        self.write_line_always("confidence",
-                               citation.get_confidence_level(), index+1)
-        self.write_note_list(citation.get_note_list(), index+1)
-        self.write_media_list(citation.get_media_list(), index+1)
-        self.write_srcattribute_list(citation.get_attribute_list(), index+1)
-        self.write_ref("sourceref", citation.get_reference_handle(), index+1)
+        self.write_date(citation.get_date_object(), index + 1)
+        self.write_line("page", citation.get_page(), index + 1)
+        self.write_line_always("confidence", citation.get_confidence_level(), index + 1)
+        self.write_note_list(citation.get_note_list(), index + 1)
+        self.write_media_list(citation.get_media_list(), index + 1)
+        self.write_srcattribute_list(citation.get_attribute_list(), index + 1)
+        self.write_ref("sourceref", citation.get_reference_handle(), index + 1)
 
         for tag_handle in citation.get_tag_list():
-            self.write_ref("tagref", tag_handle, index+1)
+            self.write_ref("tagref", tag_handle, index + 1)
 
         self.g.write("%s</citation>\n" % sp)
 
     def write_source(self, source, index=1):
-        sp = "  "*index
+        sp = "  " * index
         self.write_primary_tag("source", source, index)
-        self.write_force_line("stitle", source.get_title(), index+1)
-        self.write_line("sauthor", source.get_author(), index+1)
-        self.write_line("spubinfo", source.get_publication_info(), index+1)
-        self.write_line("sabbrev", source.get_abbreviation(), index+1)
-        self.write_note_list(source.get_note_list(), index+1)
-        self.write_media_list(source.get_media_list(), index+1)
-        self.write_srcattribute_list(source.get_attribute_list(), index+1)
-        self.write_reporef_list(source.get_reporef_list(), index+1)
+        self.write_force_line("stitle", source.get_title(), index + 1)
+        self.write_line("sauthor", source.get_author(), index + 1)
+        self.write_line("spubinfo", source.get_publication_info(), index + 1)
+        self.write_line("sabbrev", source.get_abbreviation(), index + 1)
+        self.write_note_list(source.get_note_list(), index + 1)
+        self.write_media_list(source.get_media_list(), index + 1)
+        self.write_srcattribute_list(source.get_attribute_list(), index + 1)
+        self.write_reporef_list(source.get_reporef_list(), index + 1)
 
         for tag_handle in source.get_tag_list():
-            self.write_ref("tagref", tag_handle, index+1)
+            self.write_ref("tagref", tag_handle, index + 1)
 
         self.g.write("%s</source>\n" % sp)
 
-    def write_repository(self,repo,index=1):
-        sp = "  "*index
-        self.write_primary_tag("repository",repo,index)
-        #name
-        self.write_line('rname',repo.name,index+1)
+    def write_repository(self, repo, index=1):
+        sp = "  " * index
+        self.write_primary_tag("repository", repo, index)
+        # name
+        self.write_line("rname", repo.name, index + 1)
         rtype = repo.type.xml_str()
         if rtype:
-            self.write_line('type',rtype,index+1)
-        #address list
-        self.write_address_list(repo,index+1)
+            self.write_line("type", rtype, index + 1)
+        # address list
+        self.write_address_list(repo, index + 1)
         # url list
-        self.write_url_list(repo.get_url_list(),index+1)
-        self.write_note_list(repo.get_note_list(),index+1)
+        self.write_url_list(repo.get_url_list(), index + 1)
+        self.write_note_list(repo.get_note_list(), index + 1)
 
         for tag_handle in repo.get_tag_list():
-            self.write_ref("tagref", tag_handle, index+1)
+            self.write_ref("tagref", tag_handle, index + 1)
 
         self.g.write("%s</repository>\n" % sp)
 
-    def write_address_list(self, obj,index=1):
+    def write_address_list(self, obj, index=1):
         if len(obj.get_address_list()) == 0:
             return
-        sp = "  "*index
+        sp = "  " * index
         for address in obj.get_address_list():
-            self.g.write('%s<address%s>\n' % (sp,conf_priv(address)))
-            self.write_date(address.get_date_object(),index+1)
-            self.write_line("street",address.get_street(),index+1)
-            self.write_line("locality",address.get_locality(),index+1)
-            self.write_line("city",address.get_city(),index+1)
-            self.write_line("county",address.get_county(),index+1)
-            self.write_line("state",address.get_state(),index+1)
-            self.write_line("country",address.get_country(),index+1)
-            self.write_line("postal",address.get_postal_code(),index+1)
-            self.write_line("phone",address.get_phone(),index+1)
-            self.write_note_list(address.get_note_list(),index+1)
+            self.g.write("%s<address%s>\n" % (sp, conf_priv(address)))
+            self.write_date(address.get_date_object(), index + 1)
+            self.write_line("street", address.get_street(), index + 1)
+            self.write_line("locality", address.get_locality(), index + 1)
+            self.write_line("city", address.get_city(), index + 1)
+            self.write_line("county", address.get_county(), index + 1)
+            self.write_line("state", address.get_state(), index + 1)
+            self.write_line("country", address.get_country(), index + 1)
+            self.write_line("postal", address.get_postal_code(), index + 1)
+            self.write_line("phone", address.get_phone(), index + 1)
+            self.write_note_list(address.get_note_list(), index + 1)
             for citation_handle in address.get_citation_list():
-                self.write_ref("citationref", citation_handle, index+1)
-            self.g.write('%s</address>\n' % sp)
+                self.write_ref("citationref", citation_handle, index + 1)
+            self.g.write("%s</address>\n" % sp)
 
-    def dump_person_ref(self,personref,index=1):
+    def dump_person_ref(self, personref, index=1):
         if not personref or not personref.ref:
             return
-        sp = "  "*index
+        sp = "  " * index
         priv_text = conf_priv(personref)
         rel_text = ' rel="%s"' % escxml(personref.get_relation())
 
         citation_list = personref.get_citation_list()
         nreflist = personref.get_note_list()
-        if (len(citation_list) + len(nreflist) == 0):
-            self.write_ref('personref',personref.ref,index,close=True,
-                           extra_text=priv_text+rel_text)
+        if len(citation_list) + len(nreflist) == 0:
+            self.write_ref(
+                "personref",
+                personref.ref,
+                index,
+                close=True,
+                extra_text=priv_text + rel_text,
+            )
         else:
-            self.write_ref('personref',personref.ref,index,close=False,
-                           extra_text=priv_text+rel_text)
+            self.write_ref(
+                "personref",
+                personref.ref,
+                index,
+                close=False,
+                extra_text=priv_text + rel_text,
+            )
             for citation_handle in citation_list:
-                self.write_ref("citationref", citation_handle, index+1)
+                self.write_ref("citationref", citation_handle, index + 1)
 
-            self.write_note_list(nreflist,index+1)
-            self.g.write('%s</personref>\n' % sp)
+            self.write_note_list(nreflist, index + 1)
+            self.g.write("%s</personref>\n" % sp)
 
-    def dump_child_ref(self,childref,index=1):
+    def dump_child_ref(self, childref, index=1):
         if not childref or not childref.ref:
             return
-        sp = "  "*index
+        sp = "  " * index
         priv_text = conf_priv(childref)
         if childref.frel.is_default():
-            frel_text = ''
+            frel_text = ""
         else:
             frel_text = ' frel="%s"' % escxml(childref.frel.xml_str())
         if childref.mrel.is_default():
-            mrel_text = ''
+            mrel_text = ""
         else:
             mrel_text = ' mrel="%s"' % escxml(childref.mrel.xml_str())
         citation_list = childref.get_citation_list()
         nreflist = childref.get_note_list()
-        if (len(citation_list)+len(nreflist) == 0):
-            self.write_ref('childref',childref.ref,index,close=True,
-                           extra_text=priv_text+mrel_text+frel_text)
+        if len(citation_list) + len(nreflist) == 0:
+            self.write_ref(
+                "childref",
+                childref.ref,
+                index,
+                close=True,
+                extra_text=priv_text + mrel_text + frel_text,
+            )
         else:
-            self.write_ref('childref',childref.ref,index,close=False,
-                           extra_text=priv_text+mrel_text+frel_text)
+            self.write_ref(
+                "childref",
+                childref.ref,
+                index,
+                close=False,
+                extra_text=priv_text + mrel_text + frel_text,
+            )
             for citation_handle in citation_list:
-                self.write_ref("citationref", citation_handle, index+1)
-            self.write_note_list(nreflist,index+1)
-            self.g.write('%s</childref>\n' % sp)
+                self.write_ref("citationref", citation_handle, index + 1)
+            self.write_note_list(nreflist, index + 1)
+            self.g.write("%s</childref>\n" % sp)
 
-    def dump_event_ref(self,eventref,index=1):
+    def dump_event_ref(self, eventref, index=1):
         if not eventref or not eventref.ref:
             return
-        sp = "  "*index
+        sp = "  " * index
         priv_text = conf_priv(eventref)
         role = escxml(eventref.role.xml_str())
         if role:
             role_text = ' role="%s"' % role
         else:
-            role_text = ''
+            role_text = ""
 
         attribute_list = eventref.get_attribute_list()
         note_list = eventref.get_note_list()
-        if (len(attribute_list) + len(note_list) == 0):
-            self.write_ref('eventref',eventref.ref,index,
-                           close=True,extra_text=priv_text+role_text)
+        if len(attribute_list) + len(note_list) == 0:
+            self.write_ref(
+                "eventref",
+                eventref.ref,
+                index,
+                close=True,
+                extra_text=priv_text + role_text,
+            )
         else:
-            self.write_ref('eventref',eventref.ref,index,
-                           close=False,extra_text=priv_text+role_text)
-            self.write_attribute_list(attribute_list,index+1)
-            self.write_note_list(note_list,index+1)
-            self.g.write('%s</eventref>\n' % sp)
+            self.write_ref(
+                "eventref",
+                eventref.ref,
+                index,
+                close=False,
+                extra_text=priv_text + role_text,
+            )
+            self.write_attribute_list(attribute_list, index + 1)
+            self.write_note_list(note_list, index + 1)
+            self.g.write("%s</eventref>\n" % sp)
 
     def dump_place_ref(self, placeref, index=1):
         sp = "  " * index
         date = placeref.get_date_object()
         if date.is_empty():
-            self.write_ref('placeref', placeref.ref, index, close=True)
+            self.write_ref("placeref", placeref.ref, index, close=True)
         else:
-            self.write_ref('placeref', placeref.ref, index, close=False)
-            self.write_date(date, index+1)
-            self.g.write('%s</placeref>\n' % sp)
+            self.write_ref("placeref", placeref.ref, index, close=False)
+            self.write_date(date, index + 1)
+            self.g.write("%s</placeref>\n" % sp)
 
     def dump_place_name(self, place_name, index=1):
         sp = "  " * index
@@ -752,71 +822,73 @@ class GrampsXmlWriter(UpdateCallback):
         if lang:
             self.g.write(' lang="%s"' % self.fix(lang))
         if date.is_empty():
-            self.g.write('/>\n')
+            self.g.write("/>\n")
         else:
-            self.g.write('>\n')
-            self.write_date(date, index+1)
-            self.g.write('%s</pname>\n' % sp)
+            self.g.write(">\n")
+            self.write_date(date, index + 1)
+            self.g.write("%s</pname>\n" % sp)
 
-    def write_event(self,event,index=1):
+    def write_event(self, event, index=1):
         if not event:
             return
 
-        self.write_primary_tag("event",event,2)
+        self.write_primary_tag("event", event, 2)
 
         sp = "  " * index
         etype = event.get_type().xml_str()
-        self.g.write('  %s<type>%s</type>\n' % (sp,self.fix(etype)) )
-        self.write_date(event.get_date_object(),index+1)
-        self.write_ref("place",event.get_place_handle(),index+1)
-        self.write_line("description",event.get_description(),index+1)
-        self.write_attribute_list(event.get_attribute_list(),index+1)
-        self.write_note_list(event.get_note_list(),index+1)
+        self.g.write("  %s<type>%s</type>\n" % (sp, self.fix(etype)))
+        self.write_date(event.get_date_object(), index + 1)
+        self.write_ref("place", event.get_place_handle(), index + 1)
+        self.write_line("description", event.get_description(), index + 1)
+        self.write_attribute_list(event.get_attribute_list(), index + 1)
+        self.write_note_list(event.get_note_list(), index + 1)
 
         for citation_handle in event.get_citation_list():
-            self.write_ref("citationref", citation_handle, index+1)
-        self.write_media_list(event.get_media_list(),index+1)
+            self.write_ref("citationref", citation_handle, index + 1)
+        self.write_media_list(event.get_media_list(), index + 1)
 
         for tag_handle in event.get_tag_list():
-            self.write_ref("tagref", tag_handle, index+1)
+            self.write_ref("tagref", tag_handle, index + 1)
 
         self.g.write("%s</event>\n" % sp)
 
-    def dump_ordinance(self, ord,index=1):
+    def dump_ordinance(self, ord, index=1):
 
         name = ord.type2xml()
 
         sp = "  " * index
-        sp2 = "  " * (index+1)
+        sp2 = "  " * (index + 1)
 
         priv = conf_priv(ord)
-        self.g.write('%s<lds_ord type="%s"%s>\n' % (sp, name,priv))
+        self.g.write('%s<lds_ord type="%s"%s>\n' % (sp, name, priv))
         dateobj = ord.get_date_object()
         if dateobj and not dateobj.is_empty():
-            self.write_date(dateobj,index+1)
+            self.write_date(dateobj, index + 1)
         if ord.get_temple():
-            self.g.write('%s<temple val="%s"/>\n'
-                         % (sp2,self.fix(ord.get_temple())))
-        self.write_ref("place", ord.get_place_handle(),index+1)
+            self.g.write('%s<temple val="%s"/>\n' % (sp2, self.fix(ord.get_temple())))
+        self.write_ref("place", ord.get_place_handle(), index + 1)
         if ord.get_status() != 0:
             self.g.write('%s<status val="%s"/>\n' % (sp2, ord.status2xml()))
         if ord.get_family_handle():
-            self.g.write('%s<sealed_to hlink="%s"/>\n' %
-                         (sp2,"_"+ord.get_family_handle()))
-        self.write_note_list(ord.get_note_list(),index+1)
+            self.g.write(
+                '%s<sealed_to hlink="%s"/>\n' % (sp2, "_" + ord.get_family_handle())
+            )
+        self.write_note_list(ord.get_note_list(), index + 1)
         for citation_handle in ord.get_citation_list():
-            self.write_ref("citationref", citation_handle, index+1)
-        self.g.write('%s</lds_ord>\n' % sp)
+            self.write_ref("citationref", citation_handle, index + 1)
+        self.g.write("%s</lds_ord>\n" % sp)
 
-    def write_ref(self,tagname, handle,index=1,close=True,extra_text=''):
+    def write_ref(self, tagname, handle, index=1, close=True, extra_text=""):
         if handle:
             if close:
                 close_tag = "/"
             else:
                 close_tag = ""
-            sp = "  "*index
-            self.g.write('%s<%s hlink="_%s"%s%s>\n'
-                         % (sp,tagname, handle,extra_text,close_tag))
+            sp = "  " * index
+            self.g.write(
+                '%s<%s hlink="_%s"%s%s>\n'
+                % (sp, tagname, handle, extra_text, close_tag)
+            )
 
     def write_primary_tag(self, tagname, obj, index=1, close=True):
         """
@@ -830,7 +902,7 @@ class GrampsXmlWriter(UpdateCallback):
         self.write_table_tag(tagname, obj, index, False)
         self.g.write(id_text + priv_text)
         if close:
-            self.g.write('>\n')
+            self.g.write(">\n")
 
     def write_table_tag(self, tagname, obj, index=1, close=True):
         """
@@ -840,24 +912,24 @@ class GrampsXmlWriter(UpdateCallback):
             return
         sp = "  " * index
         try:
-            change_text = ' change="%d"' %  obj.get_change_time()
+            change_text = ' change="%d"' % obj.get_change_time()
         except:
-            change_text = ' change="%d"' %  0
+            change_text = ' change="%d"' % 0
 
         handle_text = ' handle="_%s"' % obj.get_handle()
 
-        obj_text = '%s<%s' % (sp, tagname)
+        obj_text = "%s<%s" % (sp, tagname)
         self.g.write(obj_text + handle_text + change_text)
         if close:
-            self.g.write('>\n')
+            self.g.write(">\n")
 
-    def write_family_handle(self,family,index=1):
-        sp = "  "*index
-        self.write_primary_tag('family',family,index)
+    def write_family_handle(self, family, index=1):
+        sp = "  " * index
+        self.write_primary_tag("family", family, index)
         if family:
             rel = escxml(family.get_relationship().xml_str())
             if rel != "":
-                self.g.write('  %s<rel type="%s"/>\n' % (sp,rel) )
+                self.g.write('  %s<rel type="%s"/>\n' % (sp, rel))
 
     def write_surname(self, surname, indent=1):
         """
@@ -868,7 +940,7 @@ class GrampsXmlWriter(UpdateCallback):
         nam = surname.get_surname()
         der = surname.get_origintype().xml_str()
         pri = surname.get_primary()
-        self.g.write('%s<surname' % ('  '*indent))
+        self.g.write("%s<surname" % ("  " * indent))
         if pre:
             self.g.write(' prefix="%s"' % escxml(pre))
         if not pri:
@@ -878,28 +950,29 @@ class GrampsXmlWriter(UpdateCallback):
         if der:
             self.g.write(' derivation="%s"' % escxml(der))
 
-        self.g.write('>%s</surname>\n' % self.fix(nam))
+        self.g.write(">%s</surname>\n" % self.fix(nam))
 
-    def write_line(self,tagname,value,indent=1):
+    def write_line(self, tagname, value, indent=1):
         if value:
-            self.g.write('%s<%s>%s</%s>\n' %
-                         ('  '*indent,tagname,self.fix(value),tagname))
+            self.g.write(
+                "%s<%s>%s</%s>\n" % ("  " * indent, tagname, self.fix(value), tagname)
+            )
 
-    def write_line_nofix(self,tagname,value,indent=1):
+    def write_line_nofix(self, tagname, value, indent=1):
         """Writes a line, but does not escape characters.
-            Use this instead of write_line if the value is already fixed,
-            this avoids &amp; becoming &amp;amp;
+        Use this instead of write_line if the value is already fixed,
+        this avoids &amp; becoming &amp;amp;
         """
         if value:
-            self.g.write('%s<%s>%s</%s>\n' %
-                         ('  '*indent, tagname, value, tagname))
+            self.g.write("%s<%s>%s</%s>\n" % ("  " * indent, tagname, value, tagname))
 
-    def write_line_always(self,tagname,value,indent=1):
+    def write_line_always(self, tagname, value, indent=1):
         """Writes a line, always, even with a zero value."""
-        self.g.write('%s<%s>%s</%s>\n' %
-                     ('  '*indent,tagname,self.fix(value),tagname))
+        self.g.write(
+            "%s<%s>%s</%s>\n" % ("  " * indent, tagname, self.fix(value), tagname)
+        )
 
-    def get_iso_date(self,date):
+    def get_iso_date(self, date):
         if date[2] == 0:
             y = "????"
         else:
@@ -913,24 +986,24 @@ class GrampsXmlWriter(UpdateCallback):
         else:
             m = "-%02d" % (date[1])
         if date[0] == 0:
-            d = ''
+            d = ""
         else:
             d = "-%02d" % date[0]
-        ret = "%s%s%s" % (y,m,d)
+        ret = "%s%s%s" % (y, m, d)
         # If the result does not contain anything beyond dashes
         # and question marks then it's as good as empty
-        if ret.replace('-','').replace('?','') == '':
-            ret = ''
+        if ret.replace("-", "").replace("?", "") == "":
+            ret = ""
         return ret
 
-    def write_date(self,date,indent=1):
-        sp = '  '*indent
+    def write_date(self, date, indent=1):
+        sp = "  " * indent
 
-        cal= date.get_calendar()
+        cal = date.get_calendar()
         if cal != Date.CAL_GREGORIAN:
             calstr = ' cformat="%s"' % Date.calendar_names[cal]
         else:
-            calstr = ''
+            calstr = ""
 
         qual = date.get_quality()
         if qual == Date.QUAL_ESTIMATED:
@@ -944,28 +1017,38 @@ class GrampsXmlWriter(UpdateCallback):
         if dualdated:
             dualdated_str = ' dualdated="1"'
         else:
-            dualdated_str = ''
+            dualdated_str = ""
 
         newyear = date.newyear_to_str()
         if newyear:
             newyear_str = ' newyear="%s"' % newyear
         else:
-            newyear_str = ''
+            newyear_str = ""
 
         mode = date.get_modifier()
 
         if date.is_compound():
             if mode == Date.MOD_RANGE:
-                tagname = 'daterange'
+                tagname = "daterange"
             else:
-                tagname = 'datespan'
+                tagname = "datespan"
 
             d1 = self.get_iso_date(date.get_start_date())
             d2 = self.get_iso_date(date.get_stop_date())
             if d1 != "" or d2 != "":
-                self.g.write('%s<%s start="%s" stop="%s"%s%s%s%s/>\n'
-                             % (sp,tagname,d1,d2,qual_str,calstr,
-                                dualdated_str, newyear_str))
+                self.g.write(
+                    '%s<%s start="%s" stop="%s"%s%s%s%s/>\n'
+                    % (
+                        sp,
+                        tagname,
+                        d1,
+                        d2,
+                        qual_str,
+                        calstr,
+                        dualdated_str,
+                        newyear_str,
+                    )
+                )
         elif mode != Date.MOD_TEXTONLY:
             date_str = self.get_iso_date(date.get_start_date())
             if date_str == "":
@@ -977,29 +1060,35 @@ class GrampsXmlWriter(UpdateCallback):
                 mode_str = ' type="after"'
             elif mode == Date.MOD_ABOUT:
                 mode_str = ' type="about"'
+            elif mode == Date.MOD_FROM:
+                mode_str = ' type="from"'
+            elif mode == Date.MOD_TO:
+                mode_str = ' type="to"'
             else:
                 mode_str = ""
 
-            self.g.write('%s<dateval val="%s"%s%s%s%s%s/>\n'
-                         % (sp, date_str, mode_str, qual_str,
-                            calstr, dualdated_str, newyear_str))
+            self.g.write(
+                '%s<dateval val="%s"%s%s%s%s%s/>\n'
+                % (sp, date_str, mode_str, qual_str, calstr, dualdated_str, newyear_str)
+            )
         else:
-            self.g.write('%s<datestr val="%s"/>\n'
-                         %(sp,self.fix(date.get_text())))
+            self.g.write('%s<datestr val="%s"/>\n' % (sp, self.fix(date.get_text())))
 
-    def write_force_line(self,label,value,indent=1):
+    def write_force_line(self, label, value, indent=1):
         if value is not None:
-            self.g.write('%s<%s>%s</%s>\n' % ('  '*indent,label,self.fix(value),label))
+            self.g.write(
+                "%s<%s>%s</%s>\n" % ("  " * indent, label, self.fix(value), label)
+            )
 
-    def dump_name(self, name,alternative=False,index=1):
-        sp = "  "*index
+    def dump_name(self, name, alternative=False, index=1):
+        sp = "  " * index
         name_type = name.get_type().xml_str()
         # bug 9242
         if len(name.get_first_name().splitlines()) != 1:
             firstname = "".join(name.get_first_name().splitlines())
         else:
             firstname = name.get_first_name()
-        self.g.write('%s<name' % sp)
+        self.g.write("%s<name" % sp)
         if alternative:
             self.g.write(' alt="1"')
         if name_type:
@@ -1010,31 +1099,31 @@ class GrampsXmlWriter(UpdateCallback):
             self.g.write(' sort="%d"' % name.get_sort_as())
         if name.get_display_as() != 0:
             self.g.write(' display="%d"' % name.get_display_as())
-        self.g.write('>\n')
-        self.write_line("first", firstname, index+1)
-        self.write_line("call", name.get_call_name(), index+1)
+        self.g.write(">\n")
+        self.write_line("first", firstname, index + 1)
+        self.write_line("call", name.get_call_name(), index + 1)
         for surname in name.get_surname_list():
-            self.write_surname(surname,index+1)
-        self.write_line("suffix", name.get_suffix(), index+1)
-        self.write_line("title", name.get_title(), index+1)
-        self.write_line("nick", name.get_nick_name(), index+1)
-        self.write_line("familynick", name.get_family_nick_name(), index+1)
-        self.write_line("group", name.get_group_as(), index+1)
+            self.write_surname(surname, index + 1)
+        self.write_line("suffix", name.get_suffix(), index + 1)
+        self.write_line("title", name.get_title(), index + 1)
+        self.write_line("nick", name.get_nick_name(), index + 1)
+        self.write_line("familynick", name.get_family_nick_name(), index + 1)
+        self.write_line("group", name.get_group_as(), index + 1)
         if name.date:
-            self.write_date(name.date,4)
-        self.write_note_list(name.get_note_list(),index+1)
+            self.write_date(name.date, 4)
+        self.write_note_list(name.get_note_list(), index + 1)
         for citation_handle in name.get_citation_list():
-            self.write_ref("citationref", citation_handle, index+1)
+            self.write_ref("citationref", citation_handle, index + 1)
 
-        self.g.write('%s</name>\n' % sp)
+        self.g.write("%s</name>\n" % sp)
 
-    def append_value(self, orig,val):
+    def append_value(self, orig, val):
         if orig:
-            return "%s, %s" % (orig,val)
+            return "%s, %s" % (orig, val)
         else:
             return val
 
-    def build_place_title(self,loc):
+    def build_place_title(self, loc):
         "Builds a title from a location"
         street = self.fix(loc.get_street())
         locality = self.fix(loc.get_locality())
@@ -1062,7 +1151,7 @@ class GrampsXmlWriter(UpdateCallback):
             value = self.append_value(value, country)
         return value
 
-    def dump_location(self,loc):
+    def dump_location(self, loc):
         "Writes the location information to the output file"
         if loc.is_empty():
             return
@@ -1076,7 +1165,7 @@ class GrampsXmlWriter(UpdateCallback):
         zip_code = self.fix(loc.get_postal_code())
         phone = self.fix(loc.get_phone())
 
-        self.g.write('      <location')
+        self.g.write("      <location")
         if street:
             self.g.write(' street="%s"' % street)
         if locality:
@@ -1095,80 +1184,91 @@ class GrampsXmlWriter(UpdateCallback):
             self.g.write(' postal="%s"' % zip_code)
         if phone:
             self.g.write(' phone="%s"' % phone)
-        self.g.write('/>\n')
+        self.g.write("/>\n")
 
     def write_attribute_list(self, list, indent=3):
-        sp = '  ' * indent
+        sp = "  " * indent
         for attr in list:
-            self.g.write('%s<attribute%s type="%s" value="%s"' %
-                         (sp,conf_priv(attr),escxml(attr.get_type().xml_str()),
-                         self.fix(attr.get_value()))
-                         )
+            self.g.write(
+                '%s<attribute%s type="%s" value="%s"'
+                % (
+                    sp,
+                    conf_priv(attr),
+                    escxml(attr.get_type().xml_str()),
+                    self.fix(attr.get_value()),
+                )
+            )
             citation_list = attr.get_citation_list()
             nlist = attr.get_note_list()
-            if (len(nlist)+len(citation_list)) == 0:
-                self.g.write('/>\n')
+            if (len(nlist) + len(citation_list)) == 0:
+                self.g.write("/>\n")
             else:
-                self.g.write('>\n')
+                self.g.write(">\n")
                 for citation_handle in citation_list:
-                    self.write_ref("citationref", citation_handle, indent+1)
-                self.write_note_list(attr.get_note_list(),indent+1)
-                self.g.write('%s</attribute>\n' % sp)
+                    self.write_ref("citationref", citation_handle, indent + 1)
+                self.write_note_list(attr.get_note_list(), indent + 1)
+                self.g.write("%s</attribute>\n" % sp)
 
     def write_srcattribute_list(self, list, indent=3):
-        sp = '  ' * indent
+        sp = "  " * indent
         for srcattr in list:
-            self.g.write('%s<srcattribute%s type="%s" value="%s"' %
-                         (sp, conf_priv(srcattr), escxml(srcattr.get_type().xml_str()),
-                         self.fix(srcattr.get_value()))
-                         )
-            self.g.write('/>\n')
+            self.g.write(
+                '%s<srcattribute%s type="%s" value="%s"'
+                % (
+                    sp,
+                    conf_priv(srcattr),
+                    escxml(srcattr.get_type().xml_str()),
+                    self.fix(srcattr.get_value()),
+                )
+            )
+            self.g.write("/>\n")
 
-    def write_media_list(self,list,indent=3):
-        sp = '  '*indent
+    def write_media_list(self, list, indent=3):
+        sp = "  " * indent
         for photo in list:
             mobj_id = photo.get_reference_handle()
-            self.g.write('%s<objref hlink="%s"' % (sp,"_"+mobj_id))
+            self.g.write('%s<objref hlink="%s"' % (sp, "_" + mobj_id))
             if photo.get_privacy():
                 self.g.write(' priv="1"')
             proplist = photo.get_attribute_list()
             citation_list = photo.get_citation_list()
             nreflist = photo.get_note_list()
             rect = photo.get_rectangle()
-            if rect is not None :
+            if rect is not None:
                 corner1_x = rect[0]
                 corner1_y = rect[1]
                 corner2_x = rect[2]
                 corner2_y = rect[3]
-                if corner1_x is None : corner1_x = 0
-                if corner1_y is None : corner1_y = 0
-                if corner2_x is None : corner2_x = 100
-                if corner2_y is None : corner2_y = 100
-                #don't output not set rectangle
-                if (corner1_x == corner1_y == corner2_x == corner2_y == 0 or
-                   corner1_x == corner1_y == 0 and
-                   corner2_x == corner2_y == 100):
+                if corner1_x is None:
+                    corner1_x = 0
+                if corner1_y is None:
+                    corner1_y = 0
+                if corner2_x is None:
+                    corner2_x = 100
+                if corner2_y is None:
+                    corner2_y = 100
+                # don't output not set rectangle
+                if (
+                    corner1_x == corner1_y == corner2_x == corner2_y == 0
+                    or corner1_x == corner1_y == 0
+                    and corner2_x == corner2_y == 100
+                ):
                     rect = None
-            if (len(proplist) + len(nreflist) + len(citation_list) == 0 and
-                rect is None):
+            if len(proplist) + len(nreflist) + len(citation_list) == 0 and rect is None:
                 self.g.write("/>\n")
             else:
                 self.g.write(">\n")
-                if rect is not None :
-                    self.g.write(' %s<region corner1_x="%d" corner1_y="%d" '
-                                 'corner2_x="%d" corner2_y="%d"/>\n' % (
-                                    sp,
-                                    corner1_x,
-                                    corner1_y,
-                                    corner2_x,
-                                    corner2_y
-                                    )
-                                )
-                self.write_attribute_list(proplist,indent+1)
+                if rect is not None:
+                    self.g.write(
+                        ' %s<region corner1_x="%d" corner1_y="%d" '
+                        'corner2_x="%d" corner2_y="%d"/>\n'
+                        % (sp, corner1_x, corner1_y, corner2_x, corner2_y)
+                    )
+                self.write_attribute_list(proplist, indent + 1)
                 for citation_handle in citation_list:
-                    self.write_ref("citationref", citation_handle, indent+1)
-                self.write_note_list(nreflist, indent+1)
-                self.g.write('%s</objref>\n' % sp)
+                    self.write_ref("citationref", citation_handle, indent + 1)
+                self.write_note_list(nreflist, indent + 1)
+                self.g.write("%s</objref>\n" % sp)
 
     def write_reporef_list(self, rrlist, index=1):
         for reporef in rrlist:
@@ -1178,10 +1278,10 @@ class GrampsXmlWriter(UpdateCallback):
             if reporef.get_privacy():
                 priv_text = ' priv="1"'
             else:
-                priv_text = ''
+                priv_text = ""
 
             if reporef.call_number == "":
-                callno_text = ''
+                callno_text = ""
             else:
                 callno_text = ' callno="%s"' % escxml(reporef.call_number)
 
@@ -1189,76 +1289,81 @@ class GrampsXmlWriter(UpdateCallback):
             if mtype:
                 type_text = ' medium="%s"' % escxml(mtype)
             else:
-                type_text = ''
+                type_text = ""
 
             note_list = reporef.get_note_list()
-            if  len(note_list) == 0:
-                self.write_ref('reporef', reporef.ref, index, close=True,
-                               extra_text=priv_text+callno_text+type_text)
+            if len(note_list) == 0:
+                self.write_ref(
+                    "reporef",
+                    reporef.ref,
+                    index,
+                    close=True,
+                    extra_text=priv_text + callno_text + type_text,
+                )
             else:
-                self.write_ref('reporef', reporef.ref, index, close=False,
-                               extra_text=priv_text+callno_text+type_text)
-                self.write_note_list(note_list, index+1)
-                sp = "  "*index
-                self.g.write('%s</reporef>\n' % sp)
+                self.write_ref(
+                    "reporef",
+                    reporef.ref,
+                    index,
+                    close=False,
+                    extra_text=priv_text + callno_text + type_text,
+                )
+                self.write_note_list(note_list, index + 1)
+                sp = "  " * index
+                self.g.write("%s</reporef>\n" % sp)
 
     def write_url_list(self, list, index=1):
-        sp = "  "*index
+        sp = "  " * index
         for url in list:
             url_type = url.get_type().xml_str()
             if url_type:
                 type_text = ' type="%s"' % escxml(url_type)
             else:
-                type_text = ''
+                type_text = ""
             priv_text = conf_priv(url)
             if url.get_description() != "":
-                desc_text = ' description="%s"' % self.fix(
-                    url.get_description())
+                desc_text = ' description="%s"' % self.fix(url.get_description())
             else:
-                desc_text = ''
+                desc_text = ""
             path_text = '  href="%s"' % self.fix(url.get_path())
-            self.g.write('%s<url%s%s%s%s/>\n' % (
-                            sp,
-                            priv_text,
-                            path_text,
-                            type_text,
-                            desc_text
-                            )
-                        )
+            self.g.write(
+                "%s<url%s%s%s%s/>\n" % (sp, priv_text, path_text, type_text, desc_text)
+            )
 
     def write_place_obj(self, place, index=1):
         self.write_primary_tag("placeobj", place, index, close=False)
         ptype = self.fix(place.get_type().xml_str())
         self.g.write(' type="%s"' % ptype)
-        self.g.write('>\n')
+        self.g.write(">\n")
 
         title = self.fix(place.get_title())
         code = self.fix(place.get_code())
-        self.write_line_nofix("ptitle", title, index+1)
-        self.write_line_nofix("code", code, index+1)
+        self.write_line_nofix("ptitle", title, index + 1)
+        self.write_line_nofix("code", code, index + 1)
 
-        self.dump_place_name(place.get_name(), index+1)
+        self.dump_place_name(place.get_name(), index + 1)
         for pname in place.get_alternative_names():
-            self.dump_place_name(pname, index+1)
+            self.dump_place_name(pname, index + 1)
 
         longitude = self.fix(place.get_longitude())
         lat = self.fix(place.get_latitude())
         if longitude or lat:
-            self.g.write('%s<coord long="%s" lat="%s"/>\n'
-                         % ("  "*(index+1), longitude, lat))
+            self.g.write(
+                '%s<coord long="%s" lat="%s"/>\n' % ("  " * (index + 1), longitude, lat)
+            )
         for placeref in place.get_placeref_list():
-            self.dump_place_ref(placeref, index+1)
+            self.dump_place_ref(placeref, index + 1)
         list(map(self.dump_location, place.get_alternate_locations()))
-        self.write_media_list(place.get_media_list(), index+1)
+        self.write_media_list(place.get_media_list(), index + 1)
         self.write_url_list(place.get_url_list())
-        self.write_note_list(place.get_note_list(), index+1)
+        self.write_note_list(place.get_note_list(), index + 1)
         for citation_handle in place.get_citation_list():
-            self.write_ref("citationref", citation_handle, index+1)
+            self.write_ref("citationref", citation_handle, index + 1)
 
         for tag_handle in place.get_tag_list():
-            self.write_ref("tagref", tag_handle, index+1)
+            self.write_ref("tagref", tag_handle, index + 1)
 
-        self.g.write("%s</placeobj>\n" % ("  "*index))
+        self.g.write("%s</placeobj>\n" % ("  " * index))
 
     def write_object(self, obj, index=1):
         self.write_primary_tag("object", obj, index)
@@ -1269,43 +1374,51 @@ class GrampsXmlWriter(UpdateCallback):
         if desc:
             desc_text = ' description="%s"' % self.fix(desc)
         else:
-            desc_text = ''
+            desc_text = ""
         checksum = obj.get_checksum()
         if checksum:
             checksum_text = ' checksum="%s"' % checksum
         else:
-            checksum_text = ''
+            checksum_text = ""
         if self.strip_photos == 1:
             path = os.path.basename(path)
-        elif self.strip_photos == 2 and (len(path)>0 and os.path.isabs(path)):
+        elif self.strip_photos == 2 and (len(path) > 0 and os.path.isabs(path)):
             drive, path = os.path.splitdrive(path)
             path = path[1:]
         if win():
             # Always export path with \ replaced with /. Otherwise import
             # from Windows to Linux of gpkg's path to images does not work.
-            path = path.replace('\\','/')
-        self.g.write('%s<file src="%s" mime="%s"%s%s/>\n'
-                     % ("  "*(index+1), self.fix(path), self.fix(mime_type),
-                        checksum_text, desc_text))
+            path = path.replace("\\", "/")
+        self.g.write(
+            '%s<file src="%s" mime="%s"%s%s/>\n'
+            % (
+                "  " * (index + 1),
+                self.fix(path),
+                self.fix(mime_type),
+                checksum_text,
+                desc_text,
+            )
+        )
         self.write_attribute_list(obj.get_attribute_list())
-        self.write_note_list(obj.get_note_list(), index+1)
+        self.write_note_list(obj.get_note_list(), index + 1)
         dval = obj.get_date_object()
         if not dval.is_empty():
-            self.write_date(dval, index+1)
+            self.write_date(dval, index + 1)
         for citation_handle in obj.get_citation_list():
-            self.write_ref("citationref", citation_handle, index+1)
+            self.write_ref("citationref", citation_handle, index + 1)
 
         for tag_handle in obj.get_tag_list():
-            self.write_ref("tagref", tag_handle, index+1)
+            self.write_ref("tagref", tag_handle, index + 1)
 
-        self.g.write("%s</object>\n" % ("  "*index))
+        self.g.write("%s</object>\n" % ("  " * index))
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 #
 #
-#-------------------------------------------------------------------------
-def sortById(first,second):
+# -------------------------------------------------------------------------
+def sortById(first, second):
     fid = first.get_gramps_id()
     sid = second.get_gramps_id()
 
@@ -1314,22 +1427,24 @@ def sortById(first,second):
     else:
         return fid != sid
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 #
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 def conf_priv(obj):
     if obj.get_privacy() != 0:
         return ' priv="%d"' % obj.get_privacy()
     else:
-        return ''
+        return ""
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # export_data
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 def export_data(database, filename, user, option_box=None):
     """
     Call the XML writer with the syntax expected by the export plugin.
@@ -1351,26 +1466,26 @@ def export_data(database, filename, user, option_box=None):
     g = XmlWriter(database, user, 0, compress)
     return g.write(filename)
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #
 # XmlWriter
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class XmlWriter(GrampsXmlWriter):
     """
     Writes a database to the XML file.
     """
 
     def __init__(self, dbase, user, strip_photos, compress=1):
-        GrampsXmlWriter.__init__(
-            self, dbase, strip_photos, compress, VERSION, user)
+        GrampsXmlWriter.__init__(self, dbase, strip_photos, compress, VERSION, user)
         self.user = user
 
     def write(self, filename):
         """
         Write the database to the specified file.
         """
-        ret = 0 #False
+        ret = 0  # False
         try:
             ret = GrampsXmlWriter.write(self, filename)
         except DbWriteFailure as msg:

--- a/gramps/plugins/importer/importgeneweb.py
+++ b/gramps/plugins/importer/importgeneweb.py
@@ -22,31 +22,33 @@
 
 "Import from GeneWeb"
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # standard python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import re
 import time
 
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 #
 # Set up logging
 #
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 import logging
+
 LOG = logging.getLogger(".ImportGeneWeb")
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.utils.libformatting import ImportInfo
+
 _ = glocale.translation.gettext
-ngettext = glocale.translation.ngettext # else "nearby" comments are ignored
+ngettext = glocale.translation.ngettext  # else "nearby" comments are ignored
 from gramps.gen.errors import GedcomError, GrampsImportError
 from gramps.gen.lib import (Attribute, AttributeType, ChildRef, Citation,
         Date, DateError, Event, EventRef, EventRoleType, EventType,
@@ -56,123 +58,127 @@ from gramps.gen.db import DbTxn
 from html.entities import name2codepoint
 
 _date_parse = re.compile(
-    r'([kmes~?<>]+)?([0-9/]+)([J|H|F])?(\.\.)?([0-9/]+)?([J|H|F])?')
-_text_parse = re.compile(r'0\((.*)\)')
+    r"([kmes~?<>]+)?([0-9/]+)([J|H|F])?(\.\.)?([0-9/]+)?([J|H|F])?"
+)
+_text_parse = re.compile(r"0\((.*)\)")
 
 _mod_map = {
-    '>' : Date.MOD_AFTER,
-    '<' : Date.MOD_BEFORE,
-    '~' : Date.MOD_ABOUT,
-    }
+    ">": Date.MOD_AFTER,
+    "<": Date.MOD_BEFORE,
+    "~": Date.MOD_ABOUT,
+}
 
 _cal_map = {
-    'J' : Date.CAL_JULIAN,
-    'H' : Date.CAL_HEBREW,
-    'F' : Date.CAL_FRENCH,
-    }
+    "J": Date.CAL_JULIAN,
+    "H": Date.CAL_HEBREW,
+    "F": Date.CAL_FRENCH,
+}
 
 pevents_map = {
-    "#birt" : EventType.BIRTH, #Epers_Birth
-    "#bapt" : EventType.BAPTISM, #Epers_Baptism
-    "#deat" : EventType.DEATH, #Epers_Death
-    "#buri" : EventType.BURIAL, #Epers_Burial
-    "#crem" : EventType.CREMATION,
-    "#acco" : EventType((EventType.CUSTOM, _('Accomplishment'))) ,
-    "#acqu" : EventType((EventType.CUSTOM, _('Acquisition'))),
-    "#adhe" : EventType((EventType.CUSTOM, _('Adhesion'))),
-    "#awar" : EventType((EventType.CUSTOM, _('Award'))),
-    "#bapl" : LdsOrd.BAPTISM, #Epers_BaptismLDS
-    "#barm" : EventType.BAR_MITZVAH, #Epers_BarMitzvah
-    "#basm" : EventType.BAS_MITZVAH, #Epers_BatMitzvah
-    "#bles" : EventType.BLESS, #Epers_Benediction
-    "#cens" : EventType.CENSUS,
-    "#chgn" : EventType((EventType.CUSTOM, _('Change Name'))),
-    "#circ" : EventType((EventType.CUSTOM, _('Circumcision'))),
-    "#conf" : EventType.CONFIRMATION, #Epers_Confirmation
-    "#conl" : LdsOrd.CONFIRMATION, #Epers_ConfirmationLDS
-    "#degr" : EventType.DEGREE,
-    "#demm" : EventType((EventType.CUSTOM, _('Military Demobilisation'))),
-    "#dist" : EventType((EventType.CUSTOM, _('Award'))),
-    "#dotl" : LdsOrd.ENDOWMENT, #Epers_DotationLDS
-    "#educ" : EventType.EDUCATION, #Epers_Education
-    "#elec" : EventType.ELECTED, #Epers_Election
-    "#emig" : EventType.EMIGRATION,
-    "#endl" : EventType((EventType.CUSTOM, _('Dotation'))),
-    "#exco" : EventType((EventType.CUSTOM, _('Excommunication'))),
-    "#fcom" : EventType.FIRST_COMMUN,
-    "#flkl" : EventType((EventType.CUSTOM, _('LDS Family Link'))),
-    "#fune" : EventType((EventType.CUSTOM, _('Funeral'))),
-    "#grad" : EventType.GRADUATION,
-    "#hosp" : EventType((EventType.CUSTOM, _('Hospitalisation'))),
-    "#illn" : EventType((EventType.CUSTOM, _('Illness'))),
-    "#immi" : EventType.IMMIGRATION,
-    "#lpas" : EventType((EventType.CUSTOM, _('List Passenger'))),
-    "#mdis" : EventType((EventType.CUSTOM, _('Military Distinction'))),
-    "#mobm" : EventType((EventType.CUSTOM, _('Militaty Mobilisation'))),
-    "#mpro" : EventType((EventType.CUSTOM, _('Military Promotion'))),
-    "#mser" : EventType.MILITARY_SERV, #Epers_MilitaryService
-    "#natu" : EventType.NATURALIZATION, #Epers_Naturalisation
-    "#occu" : EventType.OCCUPATION, #Epers_Occupation
-    "#ordn" : EventType.ORDINATION, #Epers_Ordination
-    "#prop" : EventType.PROPERTY, #Epers_Property
-    "#resi" : EventType.RESIDENCE, #Epers_Residence
-    "#reti" : EventType.RETIREMENT,
-    "#slgc" : EventType((EventType.CUSTOM, _('LDS Seal to child'))), #Epers_ScellentChildLDS
-    "#slgp" : LdsOrd.SEAL_TO_PARENTS, #Epers_ScellentParentLDS
-    "#slgs" : LdsOrd.SEAL_TO_SPOUSE,
-    "#vteb" : EventType((EventType.CUSTOM, _('Sold property'))), #Epers_VenteBien
-    "#will" : EventType.WILL, #Epers_Will
-                     }
+    "#birt": EventType.BIRTH,  # Epers_Birth
+    "#bapt": EventType.BAPTISM,  # Epers_Baptism
+    "#deat": EventType.DEATH,  # Epers_Death
+    "#buri": EventType.BURIAL,  # Epers_Burial
+    "#crem": EventType.CREMATION,
+    "#acco": EventType((EventType.CUSTOM, _("Accomplishment"))),
+    "#acqu": EventType((EventType.CUSTOM, _("Acquisition"))),
+    "#adhe": EventType((EventType.CUSTOM, _("Adhesion"))),
+    "#awar": EventType((EventType.CUSTOM, _("Award"))),
+    "#bapl": LdsOrd.BAPTISM,  # Epers_BaptismLDS
+    "#barm": EventType.BAR_MITZVAH,  # Epers_BarMitzvah
+    "#basm": EventType.BAS_MITZVAH,  # Epers_BatMitzvah
+    "#bles": EventType.BLESS,  # Epers_Benediction
+    "#cens": EventType.CENSUS,
+    "#chgn": EventType((EventType.CUSTOM, _("Change Name"))),
+    "#circ": EventType((EventType.CUSTOM, _("Circumcision"))),
+    "#conf": EventType.CONFIRMATION,  # Epers_Confirmation
+    "#conl": LdsOrd.CONFIRMATION,  # Epers_ConfirmationLDS
+    "#degr": EventType.DEGREE,
+    "#demm": EventType((EventType.CUSTOM, _("Military Demobilisation"))),
+    "#dist": EventType((EventType.CUSTOM, _("Award"))),
+    "#dotl": LdsOrd.ENDOWMENT,  # Epers_DotationLDS
+    "#educ": EventType.EDUCATION,  # Epers_Education
+    "#elec": EventType.ELECTED,  # Epers_Election
+    "#emig": EventType.EMIGRATION,
+    "#endl": EventType((EventType.CUSTOM, _("Dotation"))),
+    "#exco": EventType((EventType.CUSTOM, _("Excommunication"))),
+    "#fcom": EventType.FIRST_COMMUN,
+    "#flkl": EventType((EventType.CUSTOM, _("LDS Family Link"))),
+    "#fune": EventType((EventType.CUSTOM, _("Funeral"))),
+    "#grad": EventType.GRADUATION,
+    "#hosp": EventType((EventType.CUSTOM, _("Hospitalisation"))),
+    "#illn": EventType((EventType.CUSTOM, _("Illness"))),
+    "#immi": EventType.IMMIGRATION,
+    "#lpas": EventType((EventType.CUSTOM, _("List Passenger"))),
+    "#mdis": EventType((EventType.CUSTOM, _("Military Distinction"))),
+    "#mobm": EventType((EventType.CUSTOM, _("Militaty Mobilisation"))),
+    "#mpro": EventType((EventType.CUSTOM, _("Military Promotion"))),
+    "#mser": EventType.MILITARY_SERV,  # Epers_MilitaryService
+    "#natu": EventType.NATURALIZATION,  # Epers_Naturalisation
+    "#occu": EventType.OCCUPATION,  # Epers_Occupation
+    "#ordn": EventType.ORDINATION,  # Epers_Ordination
+    "#prop": EventType.PROPERTY,  # Epers_Property
+    "#resi": EventType.RESIDENCE,  # Epers_Residence
+    "#reti": EventType.RETIREMENT,
+    "#slgc": EventType(
+        (EventType.CUSTOM, _("LDS Seal to child"))
+    ),  # Epers_ScellentChildLDS
+    "#slgp": LdsOrd.SEAL_TO_PARENTS,  # Epers_ScellentParentLDS
+    "#slgs": LdsOrd.SEAL_TO_SPOUSE,
+    "#vteb": EventType((EventType.CUSTOM, _("Sold property"))),  # Epers_VenteBien
+    "#will": EventType.WILL,  # Epers_Will
+}
 
 fevents_map = {
-    "#marr" : EventType.MARRIAGE, #Efam_Marriage
-    "#nmar" : EventType.NUM_MARRIAGES,
-    "#nmen" : EventType((EventType.CUSTOM, _('No mention'))), #Efam_NoMention
-    "#enga" : EventType.ENGAGEMENT, #Efam_Engage
-    "#div"  : EventType.DIVORCE,
-    "#sep"  : EventType((EventType.CUSTOM, _('Separated'))), #Efam_Separated
-    "#anul" : EventType.ANNULMENT, #Efam_Annulation
-    "#marb" : EventType.MARR_BANNS, #Efam_MarriageBann
-    "#marc" : EventType.MARR_CONTR, #Efam_MarriageContract)
-    "#marl" : EventType.MARR_LIC, #Efam_MarriageLicense)
-    "#resi" : EventType.RESIDENCE, #Efam_Residence)
-                  }
+    "#marr": EventType.MARRIAGE,  # Efam_Marriage
+    "#nmar": EventType.NUM_MARRIAGES,
+    "#nmen": EventType((EventType.CUSTOM, _("No mention"))),  # Efam_NoMention
+    "#enga": EventType.ENGAGEMENT,  # Efam_Engage
+    "#div": EventType.DIVORCE,
+    "#sep": EventType((EventType.CUSTOM, _("Separated"))),  # Efam_Separated
+    "#anul": EventType.ANNULMENT,  # Efam_Annulation
+    "#marb": EventType.MARR_BANNS,  # Efam_MarriageBann
+    "#marc": EventType.MARR_CONTR,  # Efam_MarriageContract)
+    "#marl": EventType.MARR_LIC,  # Efam_MarriageLicense)
+    "#resi": EventType.RESIDENCE,  # Efam_Residence)
+}
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 #
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 def importData(database, filename, user):
 
     global callback
 
     try:
-        g = GeneWebParser(database,filename)
+        g = GeneWebParser(database, filename)
     except IOError as msg:
-        user.notify_error(_("%s could not be opened\n") % filename,str(msg))
+        user.notify_error(_("%s could not be opened\n") % filename, str(msg))
         return
 
     try:
         status = g.parse_geneweb_file()
     except IOError as msg:
         errmsg = _("%s could not be opened\n") % filename
-        user.notify_error(errmsg,str(msg))
+        user.notify_error(errmsg, str(msg))
         return
     return ImportInfo({_("Results"): _("done")})
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 # For a description of the file format see
 # http://cristal.inria.fr/~ddr/GeneWeb/en/gwformat.htm
 # https://github.com/geneanet/geneweb/issues/315
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class GeneWebParser:
     def __init__(self, dbase, file):
         self.db = dbase
-        if file: # Unit tests can create the parser w/o underlying file
+        if file:  # Unit tests can create the parser w/o underlying file
             self.f = open(file, "rUb")
             self.filename = file
-            self.encoding = 'iso-8859-1'
+            self.encoding = "iso-8859-1"
             self.gwplus = False
 
     def get_next_line(self):
@@ -180,7 +186,7 @@ class GeneWebParser:
         line = self.f.readline()
 
         try:
-            line = line.decode('utf-8')
+            line = line.decode("utf-8")
         except GrampsImportError as err:
             self.errmsg(str(err))
 
@@ -222,58 +228,62 @@ class GeneWebParser:
 
                     fields = line.split(" ")
 
-                    LOG.debug("LINE: %s" %line)
+                    LOG.debug("LINE: %s" % line)
 
                     if fields[0] == "gwplus":
                         self.gwplus = True
-                        self.encoding = 'utf-8'
+                        self.encoding = "utf-8"
                     elif fields[0] == "encoding:":
                         self.encoding = fields[1]
                     elif fields[0] == "fam":
                         self.current_mode = "fam"
-                        self.read_family_line(line,fields)
+                        self.read_family_line(line, fields)
                     elif fields[0] == "rel":
                         self.current_mode = "rel"
-                        self.read_relationship_person(line,fields)
+                        self.read_relationship_person(line, fields)
                     elif fields[0] == "src":
-                        self.read_source_line(line,fields)
+                        self.read_source_line(line, fields)
                     elif fields[0] in ("wit", "wit:"):
-                        self.read_witness_line(line,fields)
+                        self.read_witness_line(line, fields)
                     elif fields[0] == "cbp":
-                        self.read_children_birthplace_line(line,fields)
+                        self.read_children_birthplace_line(line, fields)
                     elif fields[0] == "csrc":
-                        self.read_children_source_line(line,fields)
+                        self.read_children_source_line(line, fields)
                     elif fields[0] == "beg" and self.current_mode == "fam":
                         self.read_children_lines()
                     elif fields[0] == "beg" and self.current_mode == "rel":
                         self.read_relation_lines()
                     elif fields[0] == "comm":
-                        self.read_family_comment(line,fields)
+                        self.read_family_comment(line, fields)
                     elif fields[0] == "notes":
-                        self.read_person_notes_lines(line,fields)
+                        self.read_person_notes_lines(line, fields)
                     elif fields[0] == "fevt" and self.current_mode == "fam":
-                        #self.read_fevent_line(self.get_next_line())
+                        # self.read_fevent_line(self.get_next_line())
                         pass
                     elif fields[0] == "pevt":
-                        #self.read_pevent_line(self.get_next_line(), fields)
+                        # self.read_pevent_line(self.get_next_line(), fields)
                         pass
                     elif fields[0] == "notes-db":
-                        self.read_database_notes_lines(line,fields)
+                        self.read_database_notes_lines(line, fields)
                     elif fields[0] == "pages-ext" or "wizard-note":
                         pass
                     elif fields[0] == "end":
                         self.current_mode = None
                     else:
-                        LOG.warning("parse_geneweb_file(): Token >%s< unknown. line %d skipped: %s" %
-                                 (fields[0],self.lineno,line))
+                        LOG.warning(
+                            "parse_geneweb_file(): Token >%s< unknown. line %d skipped: %s"
+                            % (fields[0], self.lineno, line)
+                        )
             except GedcomError as err:
                 self.errmsg(str(err))
 
             t = time.time() - t
             # Translators: leave all/any {...} untranslated
-            msg = ngettext('Import Complete: {number_of} second',
-                           'Import Complete: {number_of} seconds', t
-                          ).format(number_of=t)
+            msg = ngettext(
+                "Import Complete: {number_of} second",
+                "Import Complete: {number_of} seconds",
+                t,
+            ).format(number_of=t)
 
         self.db.enable_signals()
         self.db.request_rebuild()
@@ -283,38 +293,38 @@ class GeneWebParser:
         LOG.debug("Individuals: %d" % len(self.ikeys))
         return None
 
-    def read_family_line(self,line,fields):
+    def read_family_line(self, line, fields):
         self.current_husband_handle = None
         self.current_child_birthplace_handle = None
         self.current_child_source_handle = None
         self.current_family = Family()
-        self.db.add_family(self.current_family,self.trans)
-        #self.db.commit_family(self.current_family,self.trans)
+        self.db.add_family(self.current_family, self.trans)
+        # self.db.commit_family(self.current_family,self.trans)
         self.fkeys.append(self.current_family.get_handle())
-        idx = 1;
+        idx = 1
 
         LOG.debug("\nHusband:")
-        (idx, husband) = self.parse_person(fields,idx,Person.MALE,None)
+        (idx, husband) = self.parse_person(fields, idx, Person.MALE, None)
         if husband:
             self.current_husband_handle = husband.get_handle()
             self.current_family.set_father_handle(husband.get_handle())
-            self.db.commit_family(self.current_family,self.trans)
+            self.db.commit_family(self.current_family, self.trans)
             husband.add_family_handle(self.current_family.get_handle())
-            self.db.commit_person(husband,self.trans)
+            self.db.commit_person(husband, self.trans)
         LOG.debug("Marriage:")
-        idx = self.parse_marriage(fields,idx)
+        idx = self.parse_marriage(fields, idx)
         LOG.debug("Wife:")
-        (idx,wife) = self.parse_person(fields,idx,Person.FEMALE,None)
+        (idx, wife) = self.parse_person(fields, idx, Person.FEMALE, None)
         if wife:
             self.current_family.set_mother_handle(wife.get_handle())
-            self.db.commit_family(self.current_family,self.trans)
+            self.db.commit_family(self.current_family, self.trans)
             wife.add_family_handle(self.current_family.get_handle())
-            self.db.commit_person(wife,self.trans)
+            self.db.commit_person(wife, self.trans)
         return None
 
-    def read_relationship_person(self,line,fields):
+    def read_relationship_person(self, line, fields):
         LOG.debug(r"\Relationships:")
-        (idx,person) = self.parse_person(fields,1,Person.UNKNOWN,None)
+        (idx, person) = self.parse_person(fields, 1, Person.UNKNOWN, None)
         if person:
             self.current_relationship_person_handle = person.get_handle()
 
@@ -322,7 +332,9 @@ class GeneWebParser:
         if not self.current_relationship_person_handle:
             LOG.warning("Unknown person for relationship in line %d!" % self.lineno)
             return None
-        rel_person = self.db.get_person_from_handle(self.current_relationship_person_handle)
+        rel_person = self.db.get_person_from_handle(
+            self.current_relationship_person_handle
+        )
         while 1:
             line = self.get_next_line()
             if line is None or line == "end":
@@ -334,16 +346,16 @@ class GeneWebParser:
             line_re = re.compile("^- ([^:]+): (.*)$")
             matches = line_re.match(line)
             if matches:
-                #split related person into fields
+                # split related person into fields
                 fields = matches.groups()[1].split(" ")
                 if fields:
-                    (idx,asso_p) = self.parse_person(fields,0,Person.UNKNOWN,None)
+                    (idx, asso_p) = self.parse_person(fields, 0, Person.UNKNOWN, None)
                     pref = PersonRef()
                     pref.set_relation(matches.groups()[0])
                     LOG.warning("TODO: Handle association types properly")
                     pref.set_reference_handle(asso_p.get_handle())
                     rel_person.add_person_ref(pref)
-                    self.db.commit_person(rel_person,self.trans)
+                    self.db.commit_person(rel_person, self.trans)
                 else:
                     LOG.warning("Invalid name of person in line %d" % self.lineno)
             else:
@@ -352,31 +364,31 @@ class GeneWebParser:
         self.current_mode = None
         return None
 
-    def read_source_line(self,line,fields):
+    def read_source_line(self, line, fields):
         if not self.current_family:
             LOG.warning("Unknown family of child in line %d!" % self.lineno)
             return None
         source = self.get_or_create_source(self.decode(fields[1]))
         self.current_family.add_citation(source.get_handle())
-        self.db.commit_family(self.current_family,self.trans)
+        self.db.commit_family(self.current_family, self.trans)
         return None
 
-    def read_witness_line(self,line,fields):
+    def read_witness_line(self, line, fields):
         LOG.debug("Witness:")
         if fields[1] == "m:":
-            (idx,wit_p) = self.parse_person(fields,2,Person.MALE,None)
+            (idx, wit_p) = self.parse_person(fields, 2, Person.MALE, None)
         elif fields[1] == "f:":
-            (idx,wit_p) = self.parse_person(fields,2,Person.FEMALE,None)
+            (idx, wit_p) = self.parse_person(fields, 2, Person.FEMALE, None)
         else:
-            (idx,wit_p) = self.parse_person(fields,1,None,None)
+            (idx, wit_p) = self.parse_person(fields, 1, None, None)
         if wit_p:
             mev = None
             # search marriage event
             for evr in self.current_family.get_event_ref_list():
                 ev = self.db.get_event_from_handle(evr.get_reference_handle())
                 if ev.get_type() == EventType.MARRIAGE:
-                    mev = ev # found.
-            if not mev: # No marriage event found create a new one
+                    mev = ev  # found.
+            if not mev:  # No marriage event found create a new one
                 mev = self.create_event(EventType.MARRIAGE, None, None, None, None)
                 mar_ref = EventRef()
                 mar_ref.set_reference_handle(mev.get_handle())
@@ -385,7 +397,7 @@ class GeneWebParser:
             wit_ref.set_role(EventRoleType(EventRoleType.WITNESS))
             wit_ref.set_reference_handle(mev.get_handle())
             wit_p.add_event_ref(wit_ref)
-            self.db.commit_person(wit_p,self.trans)
+            self.db.commit_person(wit_p, self.trans)
         return None
 
     def read_children_lines(self):
@@ -410,18 +422,24 @@ class GeneWebParser:
                 LOG.debug("Child:")
                 child = None
                 if fields[1] == "h":
-                    (idx,child) = self.parse_person(fields,2,Person.MALE,father_surname)
+                    (idx, child) = self.parse_person(
+                        fields, 2, Person.MALE, father_surname
+                    )
                 elif fields[1] == "f":
-                    (idx,child) = self.parse_person(fields,2,Person.FEMALE,father_surname)
+                    (idx, child) = self.parse_person(
+                        fields, 2, Person.FEMALE, father_surname
+                    )
                 else:
-                    (idx,child) = self.parse_person(fields,1,Person.UNKNOWN,father_surname)
+                    (idx, child) = self.parse_person(
+                        fields, 1, Person.UNKNOWN, father_surname
+                    )
 
                 if child:
                     childref = ChildRef()
                     childref.set_reference_handle(child.get_handle())
-                    self.current_family.add_child_ref( childref)
-                    self.db.commit_family(self.current_family,self.trans)
-                    child.add_parent_family_handle( self.current_family.get_handle())
+                    self.current_family.add_child_ref(childref)
+                    self.db.commit_family(self.current_family, self.trans)
+                    child.add_parent_family_handle(self.current_family.get_handle())
                     if self.current_child_birthplace_handle:
                         birth = None
                         birth_ref = child.get_birth_ref()
@@ -433,36 +451,35 @@ class GeneWebParser:
                             birth_ref.set_reference_handle(birth.get_handle())
                             child.set_birth_ref(birth_ref)
                         birth.set_place_handle(self.current_child_birthplace_handle)
-                        self.db.commit_event(birth,self.trans)
+                        self.db.commit_event(birth, self.trans)
                     if self.current_child_source_handle:
                         child.add_citation(self.current_child_source_handle)
-                    self.db.commit_person(child,self.trans)
+                    self.db.commit_person(child, self.trans)
             else:
                 break
         self.current_mode = None
         return None
 
-
-    def read_children_birthplace_line(self,line,fields):
+    def read_children_birthplace_line(self, line, fields):
         cbp = self.get_or_create_place(self.decode(fields[1]))
         if cbp:
             self.current_child_birthplace_handle = cbp.get_handle()
         return None
 
-    def read_children_source_line(self,line,fields):
+    def read_children_source_line(self, line, fields):
         csrc = self.get_or_create_source(self.decode(fields[1]))
         self.current_child_source_handle = csrc.handle
         return None
 
-    def read_family_comment(self,line,fields):
+    def read_family_comment(self, line, fields):
         if not self.current_family:
             LOG.warning("Unknown family of child in line %d!" % self.lineno)
             return None
         n = Note()
         n.set(line)
-        self.db.add_note(n,self.trans)
+        self.db.add_note(n, self.trans)
         self.current_family.add_note(n.handle)
-        self.db.commit_family(self.current_family,self.trans)
+        self.db.commit_family(self.current_family, self.trans)
         return None
 
     def _read_notes_lines(self, note_tag):
@@ -485,21 +502,21 @@ class GeneWebParser:
         if note_txt:
             n = Note()
             n.set(note_txt)
-            self.db.add_note(n,self.trans)
+            self.db.add_note(n, self.trans)
             return n.handle
         return None
 
-    def read_person_notes_lines(self,line,fields):
-        (idx,person) = self.parse_person(fields,1,None,None)
-        note_handle = self._read_notes_lines( fields[0])
+    def read_person_notes_lines(self, line, fields):
+        (idx, person) = self.parse_person(fields, 1, None, None)
+        note_handle = self._read_notes_lines(fields[0])
         if note_handle:
             person.add_note(note_handle)
-            self.db.commit_person(person,self.trans)
+            self.db.commit_person(person, self.trans)
 
-    def read_database_notes_lines(self,line,fields):
-        note_handle = self._read_notes_lines( fields[0])
+    def read_database_notes_lines(self, line, fields):
+        note_handle = self._read_notes_lines(fields[0])
 
-    def parse_marriage(self,fields,idx):
+    def parse_marriage(self, fields, idx):
         mariageDataRe = re.compile("^[+#-0-9].*$")
 
         mar_date = None
@@ -513,12 +530,14 @@ class GeneWebParser:
         engaged = 0
 
         # skip to marriage date in case person contained unmatches tokens
-        #Alex: this failed when fields[idx] was an empty line. Fixed.
-        #while idx < len(fields) and not fields[idx][0] == "+":
+        # Alex: this failed when fields[idx] was an empty line. Fixed.
+        # while idx < len(fields) and not fields[idx][0] == "+":
         while idx < len(fields) and not (fields[idx] and fields[idx][0] == "+"):
             if fields[idx]:
-                LOG.warning(("parse_marriage(): Unknown field: " +
-                          "'%s' in line %d!") % (fields[idx], self.lineno))
+                LOG.warning(
+                    ("parse_marriage(): Unknown field: " + "'%s' in line %d!")
+                    % (fields[idx], self.lineno)
+                )
             idx += 1
 
         while idx < len(fields) and mariageDataRe.match(fields[idx]):
@@ -553,48 +572,47 @@ class GeneWebParser:
                 LOG.debug(" Are engaged.")
                 engaged = 1
             else:
-                LOG.warning(("parse_marriage(): Unknown field " +
-                          "'%s'for mariage in line %d!") % (field, self.lineno))
+                LOG.warning(
+                    ("parse_marriage(): Unknown field " + "'%s'for mariage in line %d!")
+                    % (field, self.lineno)
+                )
 
         if mar_date or mar_place or mar_source:
             mar = self.create_event(
-                EventType.MARRIAGE, None, mar_date, mar_place, mar_source)
+                EventType.MARRIAGE, None, mar_date, mar_place, mar_source
+            )
             mar_ref = EventRef()
             mar_ref.set_reference_handle(mar.get_handle())
             mar_ref.set_role(EventRoleType.FAMILY)
             self.current_family.add_event_ref(mar_ref)
-            self.current_family.set_relationship(
-                FamilyRelType(FamilyRelType.MARRIED))
+            self.current_family.set_relationship(FamilyRelType(FamilyRelType.MARRIED))
 
         if div_date:
-            div = self.create_event(
-                EventType.DIVORCE, None, div_date, None, None)
+            div = self.create_event(EventType.DIVORCE, None, div_date, None, None)
             div_ref = EventRef()
             div_ref.set_reference_handle(div.get_handle())
             div_ref.set_role(EventRoleType.FAMILY)
             self.current_family.add_event_ref(div_ref)
 
         if sep_date or engaged:
-            sep = self.create_event(
-                EventType.ENGAGEMENT, None, sep_date, None, None)
+            sep = self.create_event(EventType.ENGAGEMENT, None, sep_date, None, None)
             sep_ref = EventRef()
             sep_ref.set_reference_handle(sep.get_handle())
             sep_ref.set_role(EventRoleType.FAMILY)
             self.current_family.add_event_ref(sep_ref)
 
         if not married:
-            self.current_family.set_relationship(
-                FamilyRelType(FamilyRelType.UNMARRIED))
+            self.current_family.set_relationship(FamilyRelType(FamilyRelType.UNMARRIED))
 
-        self.db.commit_family(self.current_family,self.trans)
+        self.db.commit_family(self.current_family, self.trans)
         return idx
 
-    def parse_person(self,fields,idx,gender,father_surname):
+    def parse_person(self, fields, idx, gender, father_surname):
 
         if not father_surname:
             if not idx < len(fields):
                 LOG.warning("Missing surname of person in line %d!" % self.lineno)
-                surname =""
+                surname = ""
             else:
                 surname = self.decode(fields[idx])
             idx += 1
@@ -614,16 +632,16 @@ class GeneWebParser:
                 idx += 1
 
         LOG.debug("Person: %s %s" % (firstname, surname))
-        person = self.get_or_create_person(firstname,surname)
+        person = self.get_or_create_person(firstname, surname)
         name = Name()
-        name.set_type( NameType(NameType.BIRTH))
+        name.set_type(NameType(NameType.BIRTH))
         name.set_first_name(firstname)
         surname_obj = name.get_primary_surname()
         surname_obj.set_surname(surname)
         person.set_primary_name(name)
         if person.get_gender() == Person.UNKNOWN and gender is not None:
             person.set_gender(gender)
-        self.db.commit_person(person,self.trans)
+        self.db.commit_person(person, self.trans)
         personDataRe = re.compile(r"^[kmes0-9<>~#\[({!].*$")
         dateRe = re.compile("^[kmes0-9~<>?]+.*$")
 
@@ -656,13 +674,13 @@ class GeneWebParser:
         while idx < len(fields) and personDataRe.match(fields[idx]):
             field = fields[idx]
             idx += 1
-            if field.startswith('('):
+            if field.startswith("("):
                 LOG.debug("Public Name: %s" % field)
                 public_name = self.decode(field[1:-1])
-            elif field.startswith('{'):
+            elif field.startswith("{"):
                 LOG.debug("Firstsname Alias: %s" % field)
                 firstname_aliases.append(self.decode(field[1:-1]))
-            elif field.startswith('['):
+            elif field.startswith("["):
                 LOG.debug("Title: %s" % field)
                 titleparts = self.decode(field[1:-1]).split(":")
                 tname = ttitle = tplace = tstart = tend = tnth = None
@@ -676,101 +694,99 @@ class GeneWebParser:
                     tnth = titleparts[5]
                 except IndexError:  # not all parts are written all the time
                     pass
-                if tnth:    # Append title numer to title
+                if tnth:  # Append title numer to title
                     # TODO for Arabic, should the next comma be translated?
                     ttitle += ", " + tnth
-                title = self.create_event(
-                           EventType.NOB_TITLE, ttitle, tstart, tplace)
+                title = self.create_event(EventType.NOB_TITLE, ttitle, tstart, tplace)
                 # TODO: Geneweb has a start date and an end date, and therefore
                 # supports stuff like: FROM about 1955 TO between 1998 and 1999
                 # gramps only supports one single date or range.
                 if tname and tname != "*":
                     n = Note()
                     n.set(tname)
-                    self.db.add_note(n,self.trans)
-                    title.add_note( n.handle)
+                    self.db.add_note(n, self.trans)
+                    title.add_note(n.handle)
                 title_ref = EventRef()
                 title_ref.set_reference_handle(title.get_handle())
                 person.add_event_ref(title_ref)
-            elif field == '#nick' and idx < len(fields):
+            elif field == "#nick" and idx < len(fields):
                 LOG.debug("Nick Name: %s" % fields[idx])
                 nick_names.append(self.decode(fields[idx]))
                 idx += 1
-            elif field == '#occu' and idx < len(fields):
+            elif field == "#occu" and idx < len(fields):
                 LOG.debug("Occupation: %s" % fields[idx])
-                occu = self.create_event(
-                        EventType.OCCUPATION, self.decode(fields[idx]))
+                occu = self.create_event(EventType.OCCUPATION, self.decode(fields[idx]))
                 occu_ref = EventRef()
                 occu_ref.set_reference_handle(occu.get_handle())
                 person.add_event_ref(occu_ref)
                 idx += 1
-            elif field == '#alias' and idx < len(fields):
+            elif field == "#alias" and idx < len(fields):
                 LOG.debug("Name Alias: %s" % fields[idx])
                 name_aliases.append(self.decode(fields[idx]))
                 idx += 1
-            elif field == '#salias' and idx < len(fields):
+            elif field == "#salias" and idx < len(fields):
                 LOG.debug("Surname Alias: %s" % fields[idx])
                 surname_aliases.append(self.decode(fields[idx]))
                 idx += 1
-            elif field == '#image' and idx < len(fields):
+            elif field == "#image" and idx < len(fields):
                 LOG.debug("Image: %s" % fields[idx])
                 idx += 1
-            elif field == '#src' and idx < len(fields):
+            elif field == "#src" and idx < len(fields):
                 LOG.debug("Source: %s" % fields[idx])
                 source = self.get_or_create_source(self.decode(fields[idx]))
                 idx += 1
-            elif field == '#bs' and idx < len(fields):
+            elif field == "#bs" and idx < len(fields):
                 LOG.debug("Birth Source: %s" % fields[idx])
                 birth_source = self.get_or_create_source(self.decode(fields[idx]))
                 idx += 1
-            elif field[0] == '!':
+            elif field[0] == "!":
                 LOG.debug("Baptize at: %s" % field[1:])
                 bapt_date = self.parse_date(self.decode(field[1:]))
-            elif field == '#bp' and idx < len(fields):
+            elif field == "#bp" and idx < len(fields):
                 LOG.debug("Birth Place: %s" % fields[idx])
                 birth_place = self.get_or_create_place(self.decode(fields[idx]))
                 idx += 1
-            elif field == '#pp' and idx < len(fields):
+            elif field == "#pp" and idx < len(fields):
                 LOG.debug("Baptize Place: %s" % fields[idx])
                 bapt_place = self.get_or_create_place(self.decode(fields[idx]))
                 idx += 1
-            elif field == '#ps' and idx < len(fields):
+            elif field == "#ps" and idx < len(fields):
                 LOG.debug("Baptize Source: %s" % fields[idx])
                 bapt_source = self.get_or_create_source(self.decode(fields[idx]))
                 idx += 1
-            elif field == '#dp' and idx < len(fields):
+            elif field == "#dp" and idx < len(fields):
                 LOG.debug("Death Place: %s" % fields[idx])
                 death_place = self.get_or_create_place(self.decode(fields[idx]))
                 idx += 1
-            elif field == '#ds' and idx < len(fields):
+            elif field == "#ds" and idx < len(fields):
                 LOG.debug("Death Source: %s" % fields[idx])
                 death_source = self.get_or_create_source(self.decode(fields[idx]))
                 idx += 1
-            elif field == '#buri' and idx < len(fields):
-                if fields[idx][0]!='#': # bug in GeneWeb: empty #buri fields
+            elif field == "#buri" and idx < len(fields):
+                if fields[idx][0] != "#":  # bug in GeneWeb: empty #buri fields
                     LOG.debug("Burial Date: %s" % fields[idx])
                     bur_date = self.parse_date(self.decode(fields[idx]))
                     idx += 1
-            elif field == '#crem' and idx < len(fields):
+            elif field == "#crem" and idx < len(fields):
                 LOG.debug("Cremention Date: %s" % fields[idx])
                 crem_date = self.parse_date(self.decode(fields[idx]))
                 idx += 1
-            elif field == '#rp' and idx < len(fields):
+            elif field == "#rp" and idx < len(fields):
                 LOG.debug("Burial Place: %s" % fields[idx])
                 bur_place = self.get_or_create_place(self.decode(fields[idx]))
                 idx += 1
-            elif field == '#rs' and idx < len(fields):
+            elif field == "#rs" and idx < len(fields):
                 LOG.debug("Burial Source: %s" % fields[idx])
                 bur_source = self.get_or_create_source(self.decode(fields[idx]))
                 idx += 1
-            elif field == '#apubl':
+            elif field == "#apubl":
                 LOG.debug("This is a public record")
-            elif field == '#apriv':
+            elif field == "#apriv":
                 LOG.debug("This is a private record")
                 person.set_privacy(True)
-            elif field == '#h':
+            elif field == "#h":
                 LOG.debug("This is a restricted record")
-                #TODO: Gramps does currently not feature this level
+                # TODO: Gramps does currently not feature this level
                 person.set_privacy(True)
             elif dateRe.match(field):
                 if not birth_parsed:
@@ -790,10 +806,12 @@ class GeneWebParser:
                         death_cause = "Executed"
                     elif field.startswith("d"):
                         death_cause = "Disappeared"
-                    #TODO: Set special death types more properly
+                    # TODO: Set special death types more properly
             else:
-                LOG.warning(("parse_person(): Unknown field " +
-                          "'%s' for person in line %d!") % (field, self.lineno))
+                LOG.warning(
+                    ("parse_person(): Unknown field " + "'%s' for person in line %d!")
+                    % (field, self.lineno)
+                )
 
         if public_name:
             name = person.get_primary_name()
@@ -843,43 +861,53 @@ class GeneWebParser:
             person.add_citation(source.get_handle())
 
         if birth_date or birth_place or birth_source:
-            birth = self.create_event(EventType.BIRTH, None, birth_date, birth_place, birth_source)
+            birth = self.create_event(
+                EventType.BIRTH, None, birth_date, birth_place, birth_source
+            )
             birth_ref = EventRef()
-            birth_ref.set_reference_handle( birth.get_handle())
-            person.set_birth_ref( birth_ref)
+            birth_ref.set_reference_handle(birth.get_handle())
+            person.set_birth_ref(birth_ref)
 
         if bapt_date or bapt_place or bapt_source:
-            babt = self.create_event(EventType.BAPTISM, None, bapt_date, bapt_place, bapt_source)
+            babt = self.create_event(
+                EventType.BAPTISM, None, bapt_date, bapt_place, bapt_source
+            )
             babt_ref = EventRef()
-            babt_ref.set_reference_handle( babt.get_handle())
-            person.add_event_ref( babt_ref)
+            babt_ref.set_reference_handle(babt.get_handle())
+            person.add_event_ref(babt_ref)
 
         if death_date or death_place or death_source or death_cause:
-            death = self.create_event(EventType.DEATH, None, death_date, death_place, death_source)
+            death = self.create_event(
+                EventType.DEATH, None, death_date, death_place, death_source
+            )
             if death_cause:
                 death.set_description(death_cause)
-                self.db.commit_event(death,self.trans)
+                self.db.commit_event(death, self.trans)
             death_ref = EventRef()
-            death_ref.set_reference_handle( death.get_handle())
-            person.set_death_ref( death_ref)
+            death_ref.set_reference_handle(death.get_handle())
+            person.set_death_ref(death_ref)
 
         if bur_date:
-            bur = self.create_event(EventType.BURIAL, None, bur_date, bur_place, bur_source)
+            bur = self.create_event(
+                EventType.BURIAL, None, bur_date, bur_place, bur_source
+            )
             bur_ref = EventRef()
-            bur_ref.set_reference_handle( bur.get_handle())
-            person.add_event_ref( bur_ref)
+            bur_ref.set_reference_handle(bur.get_handle())
+            person.add_event_ref(bur_ref)
 
         if crem_date:
-            crem = self.create_event(EventType.CREMATION, None, crem_date, bur_place, bur_source)
+            crem = self.create_event(
+                EventType.CREMATION, None, crem_date, bur_place, bur_source
+            )
             crem_ref = EventRef()
-            crem_ref.set_reference_handle( crem.get_handle())
+            crem_ref.set_reference_handle(crem.get_handle())
             person.add_event_ref(crem_ref)
 
-        self.db.commit_person(person,self.trans)
+        self.db.commit_person(person, self.trans)
 
-        return (idx,person)
+        return (idx, person)
 
-    def parse_date(self,field):
+    def parse_date(self, field):
         if field == "0":
             return None
         date = Date()
@@ -893,40 +921,59 @@ class GeneWebParser:
         matches = _date_parse.match(field)
         if matches:
             groups = matches.groups()
-            mod = _mod_map.get(groups[0],Date.MOD_NONE)
+            mod = _mod_map.get(groups[0], Date.MOD_NONE)
             if groups[3] == "..":
-                mod = Date.MOD_SPAN
-                cal2 = _cal_map.get(groups[5],Date.CAL_GREGORIAN)
-                sub2 = self.sub_date(groups[4])
+                if groups[4] == "0":
+                    mod = Date.MOD_FROM
+                    cal1 = _cal_map.get(groups[2], Date.CAL_GREGORIAN)
+                    sub1 = self.sub_date(groups[1])
+                    sub2 = (0, 0, 0)
+                elif groups[1] == "0":
+                    mod = Date.MOD_TO
+                    cal1 = _cal_map.get(groups[5], Date.CAL_GREGORIAN)
+                    sub1 = self.sub_date(groups[4])
+                    sub2 = (0, 0, 0)
+                else:
+                    mod = Date.MOD_SPAN
+                    cal1 = _cal_map.get(groups[2], Date.CAL_GREGORIAN)
+                    cal2 = _cal_map.get(groups[5], Date.CAL_GREGORIAN)
+                    sub1 = self.sub_date(groups[1])
+                    sub2 = self.sub_date(groups[4])
             else:
-                sub2 = (0,0,0)
-            cal1 = _cal_map.get(groups[2],Date.CAL_GREGORIAN)
-            sub1 = self.sub_date(groups[1])
+                cal1 = _cal_map.get(groups[2], Date.CAL_GREGORIAN)
+                sub1 = self.sub_date(groups[1])
+                sub2 = (0, 0, 0)
             try:
-                date.set(Date.QUAL_NONE,mod, cal1,
-                         (sub1[0],sub1[1],sub1[2],0,sub2[0],sub2[1],sub2[2],0))
+                date.set(
+                    Date.QUAL_NONE,
+                    mod,
+                    cal1,
+                    (sub1[0], sub1[1], sub1[2], 0, sub2[0], sub2[1], sub2[2], 0),
+                )
             except DateError as e:
                 # Translators: leave the {date} and {gw_snippet} untranslated
                 # in the format string, but you may re-order them if needed.
-                LOG.warning(_(
-                    "Invalid date {date} in {gw_snippet}, "
-                    "preserving date as text."
-                    ).format(date=e.date.__dict__, gw_snippet=field))
+                LOG.warning(
+                    _(
+                        "Invalid date {date} in {gw_snippet}, "
+                        "preserving date as text."
+                    ).format(date=e.date.__dict__, gw_snippet=field)
+                )
                 date.set(modifier=Date.MOD_TEXTONLY, text=field)
             return date
         else:
             return None
 
-    def sub_date(self,data):
-        vals = data.split('/')
+    def sub_date(self, data):
+        vals = data.split("/")
         if len(vals) == 1:
-            return (0,0,int(vals[0]))
+            return (0, 0, int(vals[0]))
         elif len(vals) == 2:
-            return (0,int(vals[0]),int(vals[1]))
+            return (0, int(vals[0]), int(vals[1]))
         else:
-            return (int(vals[0]),int(vals[1]),int(vals[2]))
+            return (int(vals[0]), int(vals[1]), int(vals[2]))
 
-    def create_event(self,type,desc=None,date=None,place=None,source=None):
+    def create_event(self, type, desc=None, date=None, place=None, source=None):
         event = Event()
         if type:
             event.set_type(EventType(type))
@@ -938,23 +985,23 @@ class GeneWebParser:
             event.set_place_handle(place.get_handle())
         if source:
             event.add_citation(source.get_handle())
-        self.db.add_event(event,self.trans)
-        self.db.commit_event(event,self.trans)
+        self.db.add_event(event, self.trans)
+        self.db.commit_event(event, self.trans)
         return event
 
-    def get_or_create_person(self,firstname,lastname):
+    def get_or_create_person(self, firstname, lastname):
         person = None
-        mykey = firstname+lastname
+        mykey = firstname + lastname
         if mykey in self.ikeys and firstname != "?" and lastname != "?":
             person = self.db.get_person_from_handle(self.ikeys[mykey])
         else:
             person = Person()
-            self.db.add_person(person,self.trans)
-            self.db.commit_person(person,self.trans)
+            self.db.add_person(person, self.trans)
+            self.db.commit_person(person, self.trans)
             self.ikeys[mykey] = person.get_handle()
         return person
 
-    def get_or_create_place(self,place_name):
+    def get_or_create_place(self, place_name):
         place = None
         if place_name in self.pkeys:
             place = self.db.get_place_from_handle(self.pkeys[place_name])
@@ -962,20 +1009,20 @@ class GeneWebParser:
             place = Place()
             place.name = PlaceName(value=place_name)
             place.set_title(place_name)
-            self.db.add_place(place,self.trans)
-            self.db.commit_place(place,self.trans)
+            self.db.add_place(place, self.trans)
+            self.db.commit_place(place, self.trans)
             self.pkeys[place_name] = place.get_handle()
         return place
 
-    def get_or_create_source(self,source_name):
+    def get_or_create_source(self, source_name):
         source = None
         if source_name in self.skeys:
             source = self.db.get_source_from_handle(self.skeys[source_name])
         else:
             source = Source()
             source.set_title(source_name)
-            self.db.add_source(source,self.trans)
-            self.db.commit_source(source,self.trans)
+            self.db.add_source(source, self.trans)
+            self.db.commit_source(source, self.trans)
             self.skeys[source_name] = source.get_handle()
         citation = Citation()
         citation.set_reference_handle(source.get_handle())
@@ -986,16 +1033,16 @@ class GeneWebParser:
     def read_fevent_line(self, event):
 
         if fevents_map.get(event[0:5]) == None:
-            return #need to fix custom event types not in the map
+            return  # need to fix custom event types not in the map
 
         fev = None
         # get events for the current family
         for evr in self.current_family.get_event_ref_list():
             ev = self.db.get_event_from_handle(evr.get_reference_handle())
             if ev.get_type() == fevents_map.get(event[0:5]):
-                fev = ev # found. Need to also check EventRef role
+                fev = ev  # found. Need to also check EventRef role
                 return
-            if not fev: # No event found create a new one
+            if not fev:  # No event found create a new one
                 if evr.get_role() != EventRoleType(EventRoleType.FAMILY):
                     continue
                 else:
@@ -1009,7 +1056,7 @@ class GeneWebParser:
                 continue
             else:
                 self.current_mode = None
-                #self.db.commit_family(self.current_family,self.trans)
+                # self.db.commit_family(self.current_family,self.trans)
                 break
 
     def read_pevent_line(self, event, fields):
@@ -1021,29 +1068,29 @@ class GeneWebParser:
         # check key on {ikey}
         except:
             self.person = "(TO_CHECK: %s)" % fields[1:]
-            #GrampsImportError()
+            # GrampsImportError()
 
         lastname = fields[1]
         firstname = fields[2]
         self.current_person = self.get_or_create_person(firstname, lastname)
 
-        #name = Name()
-        #name.set_type(NameType(NameType.BIRTH))
-        #name.set_first_name(firstname)
-        #surname_obj = name.get_primary_surname()
-        #surname_obj.set_surname(surname)
-        #self.current_person.set_primary_name(name)
+        # name = Name()
+        # name.set_type(NameType(NameType.BIRTH))
+        # name.set_first_name(firstname)
+        # surname_obj = name.get_primary_surname()
+        # surname_obj.set_surname(surname)
+        # self.current_person.set_primary_name(name)
 
         if pevents_map.get(event[0:5]) == None:
-            return #need to fix custom event types not in the map
+            return  # need to fix custom event types not in the map
 
         self.current_event = None
         # get events for the current person
         for evr in self.current_person.get_event_ref_list():
             ev = self.db.get_event_from_handle(evr.get_reference_handle())
             if ev.get_type() == pevents_map.get(event[0:5]):
-                self.current_event = ev # found. Need to also check EventRef role
-            if not self.current_event: # No event found create a new one
+                self.current_event = ev  # found. Need to also check EventRef role
+            if not self.current_event:  # No event found create a new one
                 self.current_event = self.new_gwplus_pevent(event)
         while True:
             line = self.get_next_line()
@@ -1058,10 +1105,10 @@ class GeneWebParser:
                     self.current_event.add_note(n.handle)
                     self.db.commit_event(self.current_event, self.trans)
                 else:
-                    print('note', n.handle)
+                    print("note", n.handle)
             else:
                 self.current_mode = None
-                #self.db.commit_person(self.current_person,self.trans)
+                # self.db.commit_person(self.current_person,self.trans)
                 break
 
     def new_gwplus_fevent(self, line):
@@ -1081,15 +1128,15 @@ class GeneWebParser:
             if part == "#s":
                 source = self.get_or_create_source(self.decode(data[idx]))
         self.current_event = self.create_event(type, None, None, None, None)
-        print('new event', self.current_event.handle)
+        print("new event", self.current_event.handle)
         if date:
             print(date)
             self.current_event.set_date_object(date)
         if place:
-            print('place', place.handle)
+            print("place", place.handle)
             self.current_event.set_place_handle(place.get_handle())
         if source:
-            print('source', source.handle)
+            print("source", source.handle)
             self.current_event.add_citation(source.get_handle())
         self.db.commit_event(self.current_event, self.trans)
         nev_ref = EventRef()
@@ -1115,15 +1162,15 @@ class GeneWebParser:
             if part == "#s":
                 source = self.get_or_create_source(self.decode(data[idx]))
         self.current_event = self.create_event(type, None, None, None, None)
-        print('new event', self.current_event.handle)
+        print("new event", self.current_event.handle)
         if date:
             print(date)
             self.current_event.set_date_object(date)
         if place:
-            print('place', place.handle)
+            print("place", place.handle)
             self.current_event.set_place_handle(place.get_handle())
         if source:
-            print('source', source.handle)
+            print("source", source.handle)
             self.current_event.add_citation(source.get_handle())
         self.db.commit_event(self.current_event, self.trans)
         nev_ref = EventRef()
@@ -1132,21 +1179,21 @@ class GeneWebParser:
         self.db.commit_person(self.current_person, self.trans)
         return self.current_event
 
-    def decode(self,s):
-        s = s.replace('_',' ')
-        charref_re = re.compile('(&#)(x?)([0-9a-zA-Z]+)(;)')
+    def decode(self, s):
+        s = s.replace("_", " ")
+        charref_re = re.compile("(&#)(x?)([0-9a-zA-Z]+)(;)")
         for match in charref_re.finditer(s):
             try:
                 if match.group(2):  # HEX
-                    nchar = chr(int(match.group(3),16))
-                else:   # Decimal
+                    nchar = chr(int(match.group(3), 16))
+                else:  # Decimal
                     nchar = chr(int(match.group(3)))
                 s = s.replace(match.group(0), nchar)
             except UnicodeDecodeError:
                 pass
 
         # replace named entities
-        entref_re = re.compile('(&)([a-zA-Z]+)(;)')
+        entref_re = re.compile("(&)([a-zA-Z]+)(;)")
         for match in entref_re.finditer(s):
             try:
                 if match.group(2) in name2codepoint:
@@ -1155,7 +1202,7 @@ class GeneWebParser:
             except UnicodeDecodeError:
                 pass
 
-        return(s)
+        return s
 
     def debug(self, txt):
         LOG.debug(txt)


### PR DESCRIPTION
I chose to add separate phrases in gramps.pot rather than make complicated patterns in DateParser, and as I thought it be more safe, being unsure if the open span phrases always are sub phrases of the closed span phrase. See line 1949 and line 1954 in gramps.pot.

Changed the date comparison operators '==', '!=', '<', and '>' to use match instead of sortval in case any of the dates is a span, and added a '!=' comparison in match. Checked that the change does not break the display order of events in gramps itself and the webreport.
 
Besides date.py, _datedisplay.py, and _dateparser.py, the change affected all _date__XX.py and XX.po files.
_date_ja.py also failed to match calendar names as the re.compile truncated the match at 200 characters, so I added match_calendar.

I also had to make a small change to uk.po due to a clash for 'before date' and 'from date'.

Changed DateHandlerTest to run tests for a static list of languages and to not stop at first failure.
Doing this required changes in the DateParser to accept date strings as output by DateDisplay. Thus I added the _qual_match_str, _mod_match_str, and _cal_match_str.

Most languages passes the test, but some failes due to lacking _date_XX.py files in combination with that DateParser does not adapt to the target language (as DateDisplay does), and thus expects dates in 'en' language.
Some of the languages that lacks _date_XX.py should possibly fail, but as they passes they are included among the tested languages.

Added a DateComparisonTest to date_test.py. Doing that was what made me change the comparison operators as described above, as I thought that the sortval based comparisons for spans where a bit awkward, especially for a span open to the left, i.e. 'to *date*'. Some tests, not related to spans, have an outcome that is likely wrong. Those are anyway included in the test.