### PR TITLE
Fix Locations Gramplet (Enclosed by) to properly displaycertain nested places.

### DIFF
--- a/gramps/plugins/gramplet/locations.py
+++ b/gramps/plugins/gramplet/locations.py
@@ -300,6 +300,8 @@ class DateRange:
         """
         start = None
         stop = None
+        if date.is_empty():
+            return (None, None)
         if date.modifier == Date.MOD_NONE:
             start = date.sortval
             stop = date.sortval


### PR DESCRIPTION
when the smallest place has undated enclosure and larger places are dated.

Issue [#11691](https://gramps-project.org/bugs/view.php?id=11691)

User noted that the "enclosed by" Gramplet was not fully showing enclosing places in certain cases.  It turns out that if an enclosed place has an 'empty' date on the PlaceRef, and the places that enclose it have more comprehensive dates on their PlaceRefs, then the 'intersect' method in the Gramplet doesn't work correctly.  That code expects the DateRange code to have 'None' values for start and stop if either of those values is not set.  Unfortunately the __get_sortvals code doesn't properly set these values for an empty date, if sets the start/stop values to zero instead.
