### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,69 +60,6 @@ addons:
 # https://github.com/deanmalmgren/textract/issues/19
     - zlib1g-dev
 
-before_install:
-
-install:
-# The working directory is set to /home/travis/build/gramps-project/gramps
-# by the automatic git checkout.
-
-# Download Sean Ross-Ross's Pure Python module containing a framework to
-# manipulate and analyze python ast�s and bytecode. This is loaded to
-# /home/travis/build/gramps-project/gramps/meta
-# FIXME: This should be loaded from the release directory at
-# https://pypi.python.org/pypi/meta
- - git clone -b master https://github.com/srossross/meta
-
-# Build Gramps package. This seems to copy everything to
-# /home/travis/build/scripts-3.3
- - python setup.py build
-
-before_script:
-# Create the Gramps database directory.
- - mkdir -p ~/.gramps/grampsdb/
-# set PYTHONPATH so the directly installed module (meta) is picked up from
-# /home/travis/build/gramps-project/gramps/meta
- - export PYTHONPATH=meta
-# set module exclusions. --exclude=TestUser because of older version of mock
-# without configure_mock
- - export EXCLUDE="--exclude=TestcaseGenerator"
-#   --exclude=merge_ref_test"
-# set GRAMPS_RESOURCES for locale, data,image and documentation
- - export GRAMPS_RESOURCES=.
-# Install addons
- - mkdir -p ~/.gramps/gramps52/plugins/
- - wget https://github.com/gramps-project/addons/raw/master/gramps52/download/CliMerge.addon.tgz
- - tar -C ~/.gramps/gramps52/plugins -xzf CliMerge.addon.tgz
- - wget https://github.com/gramps-project/addons/raw/master/gramps52/download/ExportRaw.addon.tgz
- - tar -C ~/.gramps/gramps52/plugins -xzf ExportRaw.addon.tgz
-
-script:
-# Ignore the virtualenv entirely. Use nosetests3, python3 (3.4.0) and coverage
-# from /usr/bin. Use libraries from /usr/lib/python3.4,
-# /usr/local/lib/python3.4/dist-packages and /usr/lib/python3/dist-packages
- - nosetests3 --nologcapture --with-coverage --cover-package=gramps $EXCLUDE
-   gramps
-# FIXME: This should have run from the current directory, rather than from
-# gramps, because there is some test code in that directory.
-
-# give an error for any trailing whitespace
- - if git --no-pager grep --color -n --full-name '[ 	]$' -- \*.py; then
-     echo "ERROR - Trailing whitespace found in source file(s)";
-     exit 1;
-   fi
-
-after_success:
-# apt-get installs python3-coverage, but codecov only invokes coverage, so make
-# a link
- - sudo ln /usr/bin/python3-coverage /usr/bin/coverage
-
-# We have to use the bash script because the apt-get coverage does not install
-# codecov. If we used pip to install codecov, it would run inside the
-# virtualenv, and that doesn't work. Change the path to ensure that codecov
-# picks up coverage from /usr/bin, rather than from
-# /home/travis/virtualenv/python3.3.6/bin/
- - PATH=/usr/bin:$PATH bash <(curl -s https://codecov.io/bash)
-
 stages:
   - test
   # Only execute deployment stage on tagged commits, and from our repository
@@ -136,6 +73,69 @@ env:
 
 jobs:
   include:
+    - stage: test
+      name: Run unit tests
+      install:
+      # The working directory is set to /home/travis/build/gramps-project/gramps
+      # by the automatic git checkout.
+
+      # Download Sean Ross-Ross's Pure Python module containing a framework to
+      # manipulate and analyze python ast�s and bytecode. This is loaded to
+      # /home/travis/build/gramps-project/gramps/meta
+      # FIXME: This should be loaded from the release directory at
+      # https://pypi.python.org/pypi/meta
+      - git clone -b master https://github.com/srossross/meta
+
+      # Build Gramps package. This seems to copy everything to
+      # /home/travis/build/scripts-3.3
+      - python setup.py build
+
+      before_script:
+      # Create the Gramps database directory.
+      - mkdir -p ~/.gramps/grampsdb/
+      # set PYTHONPATH so the directly installed module (meta) is picked up from
+      # /home/travis/build/gramps-project/gramps/meta
+      - export PYTHONPATH=meta
+      # set module exclusions. --exclude=TestUser because of older version of mock
+      # without configure_mock
+      - export EXCLUDE="--exclude=TestcaseGenerator"
+      #   --exclude=merge_ref_test"
+      # set GRAMPS_RESOURCES for locale, data,image and documentation
+      - export GRAMPS_RESOURCES=.
+      # Install addons
+      - mkdir -p ~/.gramps/gramps52/plugins/
+      - wget https://github.com/gramps-project/addons/raw/master/gramps52/download/CliMerge.addon.tgz
+      - tar -C ~/.gramps/gramps52/plugins -xzf CliMerge.addon.tgz
+      - wget https://github.com/gramps-project/addons/raw/master/gramps52/download/ExportRaw.addon.tgz
+      - tar -C ~/.gramps/gramps52/plugins -xzf ExportRaw.addon.tgz
+
+      script:
+      # Ignore the virtualenv entirely. Use nosetests3, python3 (3.4.0) and coverage
+      # from /usr/bin. Use libraries from /usr/lib/python3.4,
+      # /usr/local/lib/python3.4/dist-packages and /usr/lib/python3/dist-packages
+      - nosetests3 --nologcapture --with-coverage --cover-package=gramps $EXCLUDE
+        gramps
+      # FIXME: This should have run from the current directory, rather than from
+      # gramps, because there is some test code in that directory.
+
+      # give an error for any trailing whitespace
+      - if git --no-pager grep --color -n --full-name '[ 	]$' -- \*.py; then
+          echo "ERROR - Trailing whitespace found in source file(s)";
+          exit 1;
+        fi
+
+      after_success:
+      # apt-get installs python3-coverage, but codecov only invokes coverage, so make
+      # a link
+      - sudo ln /usr/bin/python3-coverage /usr/bin/coverage
+
+      # We have to use the bash script because the apt-get coverage does not install
+      # codecov. If we used pip to install codecov, it would run inside the
+      # virtualenv, and that doesn't work. Change the path to ensure that codecov
+      # picks up coverage from /usr/bin, rather than from
+      # /home/travis/virtualenv/python3.3.6/bin/
+      - PATH=/usr/bin:$PATH bash <(curl -s https://codecov.io/bash)
+
     # Deploy source distribution
     - stage: deploy
       name: Deploy source distribution and wheel


### PR DESCRIPTION
The recent addition of PyPI autodeploy from Travis on tagging accidentally disabled the unit test build. This commit fixes this issue.

See: https://github.com/gramps-project/gramps/pull/1114#issuecomment-696436837
