### PR TITLE
Fix Family Tree Manager drop error on Windows

### DIFF
--- a/gramps/gui/dbman.py
+++ b/gramps/gui/dbman.py
@@ -1013,7 +1013,7 @@ class DbManager(CLIDbManager, ManagedWindow):
         """
         Handle the reception of drag data
         """
-        drag_value = selection.get_data().decode()
+        drag_value = selection.get_data().decode().strip(' \r\n\x00')
         fname = None
         type = None
         title = None


### PR DESCRIPTION
Fixes #10734

On Windows an attempt to drag/drop a file onto the Family Tree Manager failed because it contained a terminating null byte.  I suspect this is a Gtk issue, but it is easy to fix in Gramps.