### PR TITLE
Fix exportvcalendar error is "is not" with a literal (Python 3.8 issue)

### DIFF
--- a/gramps/plugins/export/exportvcalendar.py
+++ b/gramps/plugins/export/exportvcalendar.py
@@ -202,7 +202,7 @@ class CalendarWriter:
         date = event.get_date_object()
         place_handle = event.get_place_handle()
         date_string = self.format_date(date, 1)
-        if date_string is not "":
+        if date_string != "":
             # self.writeln("")
             self.writeln("BEGIN:VEVENT")
             time_s = time.gmtime(event.change)


### PR DESCRIPTION
Fixes #12000