### PR TITLE
In familysidebarfilter, search on each part of name

### DIFF
--- a/gramps/gui/filters/sidebar/_familysidebarfilter.py
+++ b/gramps/gui/filters/sidebar/_familysidebarfilter.py
@@ -163,16 +163,43 @@ class FamilySidebarFilter(SidebarFilter):
                 generic_filter.add_rule(rule)
 
             if father:
-                rule = RegExpFatherName([father], use_regex=regex)
-                generic_filter.add_rule(rule)
+                # if the name is not empty, split the name in multiple part if
+                # we don't use regexp. if the regexp is used, don't split the
+                # field
+                if not regex:
+                    name_parts = father.split(sep=" ")
+                    for name_part in name_parts:
+                        rule = RegExpFatherName([name_part], use_regex=regex)
+                        generic_filter.add_rule(rule)
+                else:
+                    rule = RegExpFatherName([father], use_regex=regex)
+                    generic_filter.add_rule(rule)
 
             if mother:
-                rule = RegExpMotherName([mother], use_regex=regex)
-                generic_filter.add_rule(rule)
+                # if the name is not empty, split the name in multiple part if
+                # we don't use regexp. if the regexp is used, don't split the
+                # field
+                if not regex:
+                    name_parts = mother.split(sep=" ")
+                    for name_part in name_parts:
+                        rule = RegExpMotherName([name_part], use_regex=regex)
+                        generic_filter.add_rule(rule)
+                else:
+                    rule = RegExpMotherName([mother], use_regex=regex)
+                    generic_filter.add_rule(rule)
 
             if child:
-                rule = RegExpChildName([child], use_regex=regex)
-                generic_filter.add_rule(rule)
+                # if the name is not empty, split the name in multiple part if
+                # we don't use regexp. if the regexp is used, don't split the
+                # field
+                if not regex:
+                    name_parts = child.split(sep=" ")
+                    for name_part in name_parts:
+                        rule = RegExpChildName([name_part], use_regex=regex)
+                        generic_filter.add_rule(rule)
+                else:
+                    rule = RegExpChildName([child], use_regex=regex)
+                    generic_filter.add_rule(rule)
 
             if etype:
                 rule = HasEvent([etype, '', '', '', ''], use_regex=regex)


### PR DESCRIPTION
Instead of requiring that the entire search string matches a single
one of the Person's names, the function will require that each word
in the search string matches any of the Person's name fields.

Fixes #12023

This same enhancement was done to person sidebar in https://github.com/gramps-project/gramps/commit/dd9ddab84920538cf475b3bd700a7a1288f30043 several years ago.