### PR TITLE
Skip time-consuming calls when debug logging is disabled

### DIFF
--- a/gramps/gen/db/dummydb.py
+++ b/gramps/gen/db/dummydb.py
@@ -157,7 +157,7 @@ def wrapper(method):
         This 'wrapped' method logs the original function that was called, and
         where it was called from.
         """
-        if __debug__:
+        if __debug__ and LOG.isEnabledFor(logging.DEBUG):
             class_name = args[0].__class__.__name__
             func_name = method.__name__
             frame = inspect.currentframe()

--- a/gramps/gen/db/dummydb.py
+++ b/gramps/gen/db/dummydb.py
@@ -157,15 +157,16 @@ def wrapper(method):
         This 'wrapped' method logs the original function that was called, and
         where it was called from.
         """
-        class_name = args[0].__class__.__name__
-        func_name = method.__name__
-        frame = inspect.currentframe()
-        c_frame = frame.f_back
-        c_code = c_frame.f_code
-        LOG.debug('calling %s.%s()... from file %s, line %s in %s',
-                  class_name, func_name, c_code.co_filename, c_frame.f_lineno,
-                  c_code.co_name)
-        return method(*args, **keywargs)
+        if __debug__:
+            class_name = args[0].__class__.__name__
+            func_name = method.__name__
+            frame = inspect.currentframe()
+            c_frame = frame.f_back
+            c_code = c_frame.f_code
+            LOG.debug('calling %s.%s()... from file %s, line %s in %s',
+                      class_name, func_name, c_code.co_filename,
+                      c_frame.f_lineno, c_code.co_name)
+            return method(*args, **keywargs)
     return wrapped
 
 

--- a/gramps/gen/db/txn.py
+++ b/gramps/gen/db/txn.py
@@ -77,7 +77,7 @@ class DbTxn(defaultdict):
             self.db.transaction_abort(self)
 
         elapsed_time = time.time() - self.start_time
-        if __debug__:
+        if __debug__ and _LOG.isEnabledFor(logging.DEBUG):
             frame = inspect.currentframe()
             c_frame = frame.f_back
             c_code = c_frame.f_code
@@ -122,7 +122,7 @@ class DbTxn(defaultdict):
         """
 
         # Conditional on __debug__ because all that frame stuff may be slow
-        if __debug__:
+        if __debug__ and _LOG.isEnabledFor(logging.DEBUG):
             caller_frame = inspect.stack()[1]
             # If the call comes from gramps.gen.db.generic.DbGenericTxn.__init__
             # then it is just a dummy redirect, so we need to go back another

--- a/gramps/gen/db/utils.py
+++ b/gramps/gen/db/utils.py
@@ -71,7 +71,7 @@ def make_database(plugin_id):
         if mod:
             database = getattr(mod, pdata.databaseclass)
             db = database()
-            if __debug__:
+            if __debug__ and _LOG.isEnabledFor(logging.DEBUG):
                 import inspect
                 frame = inspect.currentframe()
                 c_frame = frame.f_back

--- a/gramps/gen/db/utils.py
+++ b/gramps/gen/db/utils.py
@@ -71,15 +71,15 @@ def make_database(plugin_id):
         if mod:
             database = getattr(mod, pdata.databaseclass)
             db = database()
-            import inspect
-            frame = inspect.currentframe()
-            c_frame = frame.f_back
-            c_code = c_frame.f_code
-            _LOG.debug("Database class instance created Class:%s instance:%s. "
-                       "Called from File %s, line %s, in %s",
-                       db.__class__.__name__, hex(id(db)), c_code.co_filename,
-                       c_frame.f_lineno, c_code.co_name)
-
+            if __debug__:
+                import inspect
+                frame = inspect.currentframe()
+                c_frame = frame.f_back
+                c_code = c_frame.f_code
+                _LOG.debug("Database class instance created Class:%s instance:%s. "
+                           "Called from File %s, line %s, in %s",
+                           db.__class__.__name__, hex(id(db)), c_code.co_filename,
+                           c_frame.f_lineno, c_code.co_name)
             return db
         else:
             raise Exception("can't load database backend: '%s'" % plugin_id)

--- a/gramps/gen/dbstate.py
+++ b/gramps/gen/dbstate.py
@@ -85,14 +85,15 @@ class DbState(Callback):
         This replaces tests on DbState.open, DbState.db, DbState.db.is_open()
         and DbState.db.db_is_open all of which are deprecated.
         """
-        class_name = self.__class__.__name__
-        func_name = "is_open"
-        frame = inspect.currentframe()
-        c_frame = frame.f_back
-        c_code = c_frame.f_code
-        _LOG.debug('calling %s.%s()... from file %s, line %s in %s',
-                   class_name, func_name, c_code.co_filename, c_frame.f_lineno,
-                   c_code.co_name)
+        if __debug__:
+            class_name = self.__class__.__name__
+            func_name = "is_open"
+            frame = inspect.currentframe()
+            c_frame = frame.f_back
+            c_code = c_frame.f_code
+            _LOG.debug('calling %s.%s()... from file %s, line %s in %s',
+                       class_name, func_name, c_code.co_filename,
+                       c_frame.f_lineno, c_code.co_name)
         return (self.db is not None) and self.db.is_open()
 
     def change_database(self, database):

--- a/gramps/gen/dbstate.py
+++ b/gramps/gen/dbstate.py
@@ -85,7 +85,7 @@ class DbState(Callback):
         This replaces tests on DbState.open, DbState.db, DbState.db.is_open()
         and DbState.db.db_is_open all of which are deprecated.
         """
-        if __debug__:
+        if __debug__ and _LOG.isEnabledFor(logging.DEBUG):
             class_name = self.__class__.__name__
             func_name = "is_open"
             frame = inspect.currentframe()


### PR DESCRIPTION
Profiling the performance of some of the code in [web-api](https://github.com/gramps-project/web-api), I noticed that in some calls, more than 90% of the time was spent evaluating `inspect.stack` merely for the purpose of debug logging.

In fact, this is appreciated in part of the codebase by wrapping this call inside `if __debug__`:

https://github.com/gramps-project/gramps/blob/976edfbf1d7f7fc0d1bd26019d8a3121364be549/gramps/gen/db/txn.py#L126-L128

But there were also some cases where this was missing. So my first commit 9df8d56  adds the `if __debug__` in the remaining places.

However, this is not the whole story. Gramps uses `python -O` in the executable script to disable all the `if __debug__` blocks and this is certainly a great idea. But when using Gramps as a library - as is done for web-api - this does not work as we cannot rely on flags being set on the Python interpreter by whatever code imports our library, and `__debug__` is `True` by default.

Fortunately, there is a very simple way to remedy this without changing anything about how things work at the moment. Namely, `logging` has a well-defined way how to skip calls that are only necessary for a logging output that is not shown anyway: `isEnabledFor`, [see the logging docs](https://docs.python.org/3/howto/logging.html#optimization).

So my second commit 6c75218 replaces all occurrences of `if __debug__:` where `inspect.stack` is called by

```python
if __debug__ and _LOG.isEnabledFor(logging.DEBUG):
    ...
    _LOG.debug(...)
``` 

What will this do?

- For a normal Gramps user installation, `__debug__` is false (thanks to `-O`) and the second part of the `if` statement will never be executed - no change!
- For code using `gramps.gen` as a library and *not* using `-O`, it will now depend on the log level set by that code: if it's set to `DEBUG`, the block will be executed. If it's set to a higher level, it will be skipped entirely.

This way, we can speed up some endpoints in web-api by a factor of 10 and even make Gramps itself a little bit faster (by adding the missing `__debug__` statements).