### PR TITLE
Add gramps_id to repository & note text data lists

### DIFF
--- a/gramps/gen/lib/note.py
+++ b/gramps/gen/lib/note.py
@@ -151,7 +151,7 @@ class Note(BasicPrimaryObject):
         :returns: The list of all textual attributes of the object.
         :rtype: list
         """
-        return [str(self.text)]
+        return [str(self.text), self.gramps_id]
 
     def get_referenced_handles(self):
         """

--- a/gramps/gen/lib/repo.py
+++ b/gramps/gen/lib/repo.py
@@ -138,7 +138,7 @@ class Repository(NoteBase, AddressBase, UrlBase, IndirectCitationBase,
         :returns: Returns the list of all textual attributes of the object.
         :rtype: list
         """
-        return [self.name, str(self.type)]
+        return [self.name, str(self.type), self.gramps_id]
 
     def get_text_data_child_list(self):
         """


### PR DESCRIPTION
This is a very small change: it adds the `gramps_id` to the return value of the `get_text_data_list` methods of the `Repository` and `Note` classes. This is to keep consistency with all other base classes that include their Gramps ID in this list:

See e.g.:

https://github.com/gramps-project/gramps/blob/1a99f9f7a04abb8d1d4dc4e77590c83340c9016a/gramps/gen/lib/person.py#L436
https://github.com/gramps-project/gramps/blob/1a99f9f7a04abb8d1d4dc4e77590c83340c9016a/gramps/gen/lib/event.py#L251
https://github.com/gramps-project/gramps/blob/1a99f9f7a04abb8d1d4dc4e77590c83340c9016a/gramps/gen/lib/place.py#L220

This turned up because of an [issue](https://github.com/gramps-project/web-api/issues/110) in the Web API.