### PR TITLE
Fix Tag report for places that have a hierarchy.

### DIFF
--- a/gramps/plugins/textreport/tagreport.py
+++ b/gramps/plugins/textreport/tagreport.py
@@ -441,7 +441,8 @@ class TagReport(Report):
 
         for place_handle in place_list:
             place = self.database.get_place_from_handle(place_handle)
-            place_title = _pd.display(self.database, place, self.place_format)
+            place_title = _pd.display(self.database, place, None,
+                                      self.place_format)
 
             self.doc.start_row()
 


### PR DESCRIPTION
Fixes #12124
The calling parameters are missing the  'date' field.  