### PR TITLE
Fix write_lock_file exception when USERNAME is missing

### DIFF
--- a/gramps/gen/db/utils.py
+++ b/gramps/gen/db/utils.py
@@ -42,6 +42,8 @@ from ..const import PLUGINS_DIR, USER_PLUGINS
 from ..constfunc import win, get_env_var
 from ..config import config
 from .dbconst import DBLOGNAME, DBLOCKFN, DBBACKEND
+from ..const import GRAMPS_LOCALE as glocale
+_ = glocale.translation.gettext
 
 #-------------------------------------------------------------------------
 #
@@ -211,8 +213,8 @@ def write_lock_file(name):
         if win():
             user = get_env_var('USERNAME')
             host = get_env_var('USERDOMAIN')
-            if host is None:
-                host = ""
+            if not user:
+                user = _("Unknown")
         else:
             host = os.uname()[1]
             # An ugly workaround for os.getlogin() issue with Konsole


### PR DESCRIPTION
Fixes #12150

On Windows machines, the user profile can sometimes be damaged or otherwise unreadable.  When this occurs, Windows will create a temporary profile, however, it doesn't include the USERNAME and USERDOMAIN environment variables.  When this occurs, the Gramps user is unable to write the lock file because the original code doesn't deal with this situation.

This fixes that issue.