### PR TITLE
DbLoader: Fix call to 'file' function, which doesn't exist in Python3

### DIFF
--- a/gramps/gui/dbloader.py
+++ b/gramps/gui/dbloader.py
@@ -532,7 +532,7 @@ class GrampsImportFileDialog(ManagedWindow):
                 return True
         else:
             try:
-                f = file(filename,'w')
+                f = open(filename, 'w')
                 f.close()
                 os.remove(filename)
             except IOError:


### PR DESCRIPTION
User posted a bug report on Discourse https://gramps.discourse.group/t/can-not-open-gpkg/1117
In a rarely encountered error path, we still had the Python2 'file' function.