### PR TITLE
citations gramplet: add date, page, confidence

### DIFF
--- a/gramps/gui/editors/displaytabs/citationembedlist.py
+++ b/gramps/gui/editors/displaytabs/citationembedlist.py
@@ -77,13 +77,13 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
     #index = column in model. Value =
     #  (name, sortcol in model, width, markup/text, weigth_col
     _column_names = [
-        (_('Title'), 0, 150, TEXT_COL, -1, None),
-        (_('Author'), 1, 150, TEXT_COL, -1, None),
-        (_('Date'), 2, 150, TEXT_COL, -1, None),
-        (_('Publisher'), 3, 150, TEXT_COL, -1, None),
-        (_('Confidence Level'), 4, 100, TEXT_COL, -1, None),
-        (_('Page'), 5, 80, TEXT_COL, -1, None),
-        (_('ID'), 6, 75, TEXT_COL, -1, None),
+        (_('Title'), 0, 350, TEXT_COL, -1, None),
+        (_('Author'), 1, 200, TEXT_COL, -1, None),
+        (_('Date'), 2, 180, TEXT_COL, -1, None),
+        (_('Publisher'), 3, 200, TEXT_COL, -1, None),
+        (_('Confidence Level'), 4, 120, TEXT_COL, -1, None),
+        (_('Page'), 5, 100, TEXT_COL, -1, None),
+        (_('ID'), 6, 80, TEXT_COL, -1, None),
         (_('Private'), 7, 30, ICON_COL, -1, 'gramps-lock')
     ]
 
@@ -124,7 +124,7 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
         """
         Return the column order of the columns in the display tab.
         """
-        return ((1, 7), (1, 0), (1, 1), (1, 2), (1, 3), (1, 4), (1, 5), (1, 6))
+        return ((1, 0), (1, 1), (1, 5), (1, 2), (1, 3), (1, 6), (1, 4), (1, 7))
 
     def add_button_clicked(self, obj):
         """

--- a/gramps/gui/editors/displaytabs/citationembedlist.py
+++ b/gramps/gui/editors/displaytabs/citationembedlist.py
@@ -61,7 +61,7 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
     Derives from the EmbeddedList class.
     """
 
-    _HANDLE_COL = 8  # Column number from CitationRefModel
+    _HANDLE_COL = 9  # Column number from CitationRefModel
     _DND_TYPE = DdTargets.CITATION_LINK
     _DND_EXTRA = DdTargets.SOURCE_LINK
 

--- a/gramps/gui/editors/displaytabs/citationembedlist.py
+++ b/gramps/gui/editors/displaytabs/citationembedlist.py
@@ -25,14 +25,13 @@
 #
 #-------------------------------------------------------------------------
 import logging
-LOG = logging.getLogger(".citation")
 
 #-------------------------------------------------------------------------
 #
 # GTK/Gnome modules
 #
 #-------------------------------------------------------------------------
-from gi.repository import GObject, GLib
+from gi.repository import GLib
 
 #-------------------------------------------------------------------------
 #
@@ -40,17 +39,16 @@ from gi.repository import GObject, GLib
 #
 #-------------------------------------------------------------------------
 from gramps.gen.const import GRAMPS_LOCALE as glocale
-_ = glocale.translation.gettext
 from gramps.gen.errors import WindowActiveError
 from gramps.gen.lib import Citation, Source
-from gramps.gen.utils.string import conf_strings
-from gramps.gen.datehandler._dateutils import get_date
 from ...dbguielement import DbGUIElement
 from ...selectors import SelectorFactory
 from .citationrefmodel import CitationRefModel
 from .embeddedlist import EmbeddedList, TEXT_COL, MARKUP_COL, ICON_COL
 from ...ddtargets import DdTargets
 
+LOG = logging.getLogger(".citation")
+_ = glocale.translation.gettext
 #-------------------------------------------------------------------------
 #
 # CitationEmbedList
@@ -105,9 +103,9 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
         #citation: citation-rebuild closes the editors, so no need to connect
         # to it
         self.callman.register_callbacks(
-           {'citation-delete': self.citation_delete,
-            'citation-update': self.citation_update,
-           })
+            {'citation-delete': self.citation_delete,
+             'citation-update': self.citation_update,
+            })
         self.callman.connect_all(keys=['citation'])
 
     def get_icon_name(self):
@@ -160,15 +158,15 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
         SelectCitation = SelectorFactory('Citation')
 
         sel = SelectCitation(self.dbstate, self.uistate, self.track)
-        object = sel.run()
-        LOG.debug("selected object: %s" % object)
+        objct = sel.run()
+        LOG.debug("selected object: %s" % objct)
         # the object returned should either be a Source or a Citation
-        if object:
-            if isinstance(object, Source):
+        if objct:
+            if isinstance(objct, Source):
                 try:
                     from .. import EditCitation
                     EditCitation(self.dbstate, self.uistate, self.track,
-                                 Citation(), object,
+                                 Citation(), objct,
                                  callback=self.add_callback,
                                  callertitle=self.callertitle)
                 except WindowActiveError:
@@ -176,11 +174,11 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
                     WarningDialog(_("Cannot share this reference"),
                                   self.__blocked_text(),
                                   parent=self.uistate.window)
-            elif isinstance(object, Citation):
+            elif isinstance(objct, Citation):
                 try:
                     from .. import EditCitation
                     EditCitation(self.dbstate, self.uistate, self.track,
-                                 object, callback=self.add_callback,
+                                 objct, callback=self.add_callback,
                                  callertitle=self.callertitle)
                 except WindowActiveError:
                     from ...dialog import WarningDialog
@@ -195,10 +193,10 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
         Return the common text used when citation cannot be edited
         """
         return _("This citation cannot be created at this time. "
-                    "Either the associated Source object is already being "
-                    "edited, or another citation associated with the same "
-                    "source is being edited.\n\nTo edit this "
-                    "citation, you need to close the object.")
+                 "Either the associated Source object is already being "
+                 "edited, or another citation associated with the same "
+                 "source is being edited.\n\nTo edit this "
+                 "citation, you need to close the object.")
 
     def edit_button_clicked(self, obj):
         """
@@ -215,7 +213,7 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
             try:
                 from .. import EditCitation
                 EditCitation(self.dbstate, self.uistate, self.track, citation,
-                             callertitle = self.callertitle)
+                             callertitle=self.callertitle)
             except WindowActiveError:
                 pass
 
@@ -227,7 +225,7 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
             so this method need not do this
         """
         rebuild = False
-        for handle in del_citation_handle_list :
+        for handle in del_citation_handle_list:
             while self.data.count(handle) > 0:
                 self.data.remove(handle)
                 rebuild = True
@@ -239,7 +237,7 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
         Outside of this tab citation objects have been updated. Check if tab
         and object must be updated.
         """
-        for handle in upd_citation_handle_list :
+        for handle in upd_citation_handle_list:
             if handle in self.data:
                 self.rebuild()
                 break
@@ -249,12 +247,12 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
         A CITATION_LINK has been dragged
         """
         if handle:
-            object = self.dbstate.db.get_citation_from_handle(handle)
-            if isinstance(object, Citation):
+            objct = self.dbstate.db.get_citation_from_handle(handle)
+            if isinstance(objct, Citation):
                 try:
                     from .. import EditCitation
                     EditCitation(self.dbstate, self.uistate, self.track,
-                                 object, callback=self.add_callback,
+                                 objct, callback=self.add_callback,
                                  callertitle=self.callertitle)
                 except WindowActiveError:
                     from ...dialog import WarningDialog
@@ -269,12 +267,12 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
         A SOURCE_LINK object has been dragged
         """
         if handle:
-            object = self.dbstate.db.get_source_from_handle(handle)
-            if isinstance(object, Source):
+            objct = self.dbstate.db.get_source_from_handle(handle)
+            if isinstance(objct, Source):
                 try:
                     from .. import EditCitation
                     EditCitation(self.dbstate, self.uistate, self.track,
-                                 Citation(), object,
+                                 Citation(), objct,
                                  callback=self.add_callback,
                                  callertitle=self.callertitle)
                 except WindowActiveError:

--- a/gramps/gui/editors/displaytabs/citationembedlist.py
+++ b/gramps/gui/editors/displaytabs/citationembedlist.py
@@ -79,12 +79,13 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
     _column_names = [
         (_('Title'), 0, 350, TEXT_COL, -1, None),
         (_('Author'), 1, 200, TEXT_COL, -1, None),
-        (_('Date'), 2, 180, TEXT_COL, -1, None),
+        (_('Date'), 8, 180, MARKUP_COL, -1, None),
         (_('Publisher'), 3, 200, TEXT_COL, -1, None),
         (_('Confidence Level'), 4, 120, TEXT_COL, -1, None),
         (_('Page'), 5, 100, TEXT_COL, -1, None),
         (_('ID'), 6, 80, TEXT_COL, -1, None),
-        (_('Private'), 7, 30, ICON_COL, -1, 'gramps-lock')
+        (_('Private'), 7, 30, ICON_COL, -1, 'gramps-lock'),
+        (_('Sorted date'), 8, 80, TEXT_COL, -1, None)
     ]
 
     def __init__(self, dbstate, uistate, track, data, callertitle=None):

--- a/gramps/gui/editors/displaytabs/citationembedlist.py
+++ b/gramps/gui/editors/displaytabs/citationembedlist.py
@@ -43,6 +43,8 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 from gramps.gen.errors import WindowActiveError
 from gramps.gen.lib import Citation, Source
+from gramps.gen.utils.string import conf_strings
+from gramps.gen.datehandler._dateutils import get_date
 from ...dbguielement import DbGUIElement
 from ...selectors import SelectorFactory
 from .citationrefmodel import CitationRefModel
@@ -61,7 +63,7 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
     Derives from the EmbeddedList class.
     """
 
-    _HANDLE_COL = 5  # Column number from CitationRefModel
+    _HANDLE_COL = 8  # Column number from CitationRefModel
     _DND_TYPE = DdTargets.CITATION_LINK
     _DND_EXTRA = DdTargets.SOURCE_LINK
 
@@ -77,11 +79,14 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
     #index = column in model. Value =
     #  (name, sortcol in model, width, markup/text, weigth_col
     _column_names = [
-        (_('Title'),   0, 200, TEXT_COL, -1, None),
-        (_('Author'),  1, 125, TEXT_COL, -1, None),
-        (_('Page'),    2, 100, TEXT_COL, -1, None),
-        (_('ID'),      3,  75, TEXT_COL, -1, None),
-        (_('Private'), 4,  30, ICON_COL, -1, 'gramps-lock')
+        (_('Title'), 0, 150, TEXT_COL, -1, None),
+        (_('Author'), 1, 150, TEXT_COL, -1, None),
+        (_('Date'), 2, 150, TEXT_COL, -1, None),
+        (_('Publisher'), 3, 150, TEXT_COL, -1, None),
+        (_('Confidence Level'), 4, 100, TEXT_COL, -1, None),
+        (_('Page'), 5, 80, TEXT_COL, -1, None),
+        (_('ID'), 6, 75, TEXT_COL, -1, None),
+        (_('Private'), 7, 30, ICON_COL, -1, 'gramps-lock')
     ]
 
     def __init__(self, dbstate, uistate, track, data, callertitle=None):
@@ -121,7 +126,7 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
         """
         Return the column order of the columns in the display tab.
         """
-        return ((1, 4), (1, 0), (1, 1), (1, 2), (1, 3))
+        return ((1, 7), (1, 0), (1, 1), (1, 2), (1, 3), (1, 4), (1, 5), (1, 6))
 
     def add_button_clicked(self, obj):
         """

--- a/gramps/gui/editors/displaytabs/citationrefmodel.py
+++ b/gramps/gui/editors/displaytabs/citationrefmodel.py
@@ -25,6 +25,10 @@
 #
 #-------------------------------------------------------------------------
 from gi.repository import Gtk
+from gramps.gen.utils.string import conf_strings
+from gramps.gen.datehandler._dateutils import get_date
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+_ = glocale.translation.gettext
 
 #-------------------------------------------------------------------------
 #
@@ -34,11 +38,16 @@ from gi.repository import Gtk
 class CitationRefModel(Gtk.ListStore):
 
     def __init__(self, citation_list, db):
-        Gtk.ListStore.__init__(self, str, str, str, str, bool, str)
+        Gtk.ListStore.__init__(self, str, str, str, str, str, str, str,
+                               bool, str)
         self.db = db
+        dbgsfh = self.db.get_source_from_handle
         for handle in citation_list:
             citation = self.db.get_citation_from_handle(handle)
-            src = self.db.get_source_from_handle(citation.get_reference_handle())
-            self.append(row=[src.title, src.author, citation.page,
+            src = dbgsfh(citation.get_reference_handle())
+            confidence = citation.get_confidence_level()
+            self.append(row=[src.title, src.author, get_date(citation),
+                             src.get_publication_info(),
+                             _(conf_strings[confidence]), citation.page,
                              citation.gramps_id, citation.get_privacy(),
                              handle, ])

--- a/gramps/gui/editors/displaytabs/citationrefmodel.py
+++ b/gramps/gui/editors/displaytabs/citationrefmodel.py
@@ -26,7 +26,7 @@
 #-------------------------------------------------------------------------
 from gi.repository import Gtk
 from gramps.gen.utils.string import conf_strings
-from gramps.gen.datehandler._dateutils import get_date
+from gramps.gen.datehandler import (get_date, get_date_valid)
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 
@@ -39,15 +39,31 @@ class CitationRefModel(Gtk.ListStore):
 
     def __init__(self, citation_list, db):
         Gtk.ListStore.__init__(self, str, str, str, str, str, str, str,
-                               bool, str)
+                               bool, str, str)
         self.db = db
         dbgsfh = self.db.get_source_from_handle
         for handle in citation_list:
             citation = self.db.get_citation_from_handle(handle)
             src = dbgsfh(citation.get_reference_handle())
             confidence = citation.get_confidence_level()
-            self.append(row=[src.title, src.author, get_date(citation),
+            self.append(row=[src.title, src.author,
+                             self.column_date(citation),
                              src.get_publication_info(),
                              _(conf_strings[confidence]), citation.page,
                              citation.gramps_id, citation.get_privacy(),
+                             self.column_sort_date(citation),
                              handle, ])
+
+    def column_date(self, citation):
+        retval = get_date(citation)
+        if not get_date_valid(citation):
+            return invalid_date_format % escape(retval)
+        else:
+            return retval
+
+    def column_sort_date(self, citation):
+        date = citation.get_date_object()
+        if date:
+            return "%09d" % date.get_sort_value()
+        else:
+            return ""

--- a/gramps/plugins/gramplet/citations.py
+++ b/gramps/plugins/gramplet/citations.py
@@ -41,14 +41,16 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 
 class Citations(Gramplet, DbGUIElement):
+    """
+    Displays the citations for an object.
+    """
 
     def __init__(self, gui, nav_group=0):
         Gramplet.__init__(self, gui, nav_group)
         DbGUIElement.__init__(self, self.dbstate.db)
+        self.model = None
+        self.source_nodes = {}
 
-    """
-    Displays the citations for an object.
-    """
     def init(self):
         self.gui.WIDGET = self.build_gui()
         self.gui.get_container_widget().remove(self.gui.textview)

--- a/gramps/plugins/gramplet/citations.py
+++ b/gramps/plugins/gramplet/citations.py
@@ -33,6 +33,8 @@ from gi.repository import Gtk
 from gramps.gui.editors import EditSource, EditCitation
 from gramps.gui.listmodel import ListModel, NOSORT
 from gramps.gen.plug import Gramplet
+from gramps.gen.utils.string import conf_strings
+from gramps.gen.datehandler._dateutils import get_date
 from gramps.gui.dbguielement import DbGUIElement
 from gramps.gen.errors import WindowActiveError
 from gramps.gen.const import GRAMPS_LOCALE as glocale
@@ -80,9 +82,11 @@ class Citations(Gramplet, DbGUIElement):
         self.set_tooltip(tip)
         top = Gtk.TreeView()
         titles = [('', NOSORT, 50,),
-                  (_('Source/Citation'), 1, 350),
-                  (_('Author'), 2, 200),
-                  (_('Publisher'), 3, 150)]
+                  (_('Source/Date'), 1, 350),
+                  (_('Volume/Page'), 2, 150),
+                  (_('Confidence Level'), 3, 150),
+                  (_('Author'), 4, 200),
+                  (_('Publisher'), 5, 150)]
         self.model = ListModel(top, titles, list_mode="tree",
                                event_func=self.invoke_editor)
         return top
@@ -159,18 +163,21 @@ class Citations(Gramplet, DbGUIElement):
         citation = self.dbstate.db.get_citation_from_handle(citation_handle)
         page = citation.get_page()
         if not page:
-            page = _('<No Citation>')
+            page = _('<No Volume/Page>')
         source_handle = citation.get_reference_handle()
         source = self.dbstate.db.get_source_from_handle(source_handle)
         title = source.get_title()
         author = source.get_author()
         publisher = source.get_publication_info()
+        confidence = citation.get_confidence_level()
 
         if source_handle not in self.source_nodes:
-            node = self.model.add([source_handle, title, author, publisher])
+            node = self.model.add([source_handle, title, '', '',
+                                   author, publisher])
             self.source_nodes[source_handle] = node
 
-        self.model.add([citation_handle, page, '', ''],
+        self.model.add([citation_handle, get_date(citation), page,
+                        _(conf_strings[confidence]), '', ''],
                        node=self.source_nodes[source_handle])
 
     def check_citations(self, obj):

--- a/gramps/plugins/gramplet/citations.py
+++ b/gramps/plugins/gramplet/citations.py
@@ -48,7 +48,6 @@ class Citations(Gramplet, DbGUIElement):
     def __init__(self, gui, nav_group=0):
         Gramplet.__init__(self, gui, nav_group)
         DbGUIElement.__init__(self, self.dbstate.db)
-        self.model = None
         self.source_nodes = {}
 
     def init(self):


### PR DESCRIPTION
Fixes #09224
discourse: https://gramps.discourse.group/t/enhanced-citations-gramplet/983

This add date, page and confidence to the citation gramplet.
In addition, I modified all citation tabs for people, family, place, ...
I added the date, the publisher and confidence
For that, I also modify:
gramps/gui/editors/displaytabs/citationembedlist.py
gramps/gui/editors/displaytabs/citationrefmodel.py