### PR TITLE
Add Media filter rule 'HasMedia' to list of media rules for editor

### DIFF
--- a/gramps/gen/filters/rules/media/__init__.py
+++ b/gramps/gen/filters/rules/media/__init__.py
@@ -51,6 +51,7 @@ editor_rule_list = [
     MediaPrivate,
     MatchesFilter,
     MatchesSourceConfidence,
+    HasMedia,
     HasAttribute,
     ChangedSince,
     HasTag,


### PR DESCRIPTION
Fixes #12212

It looks like the rule was inadvertently left off the media filter editor list.