### PR TITLE
Fix CSV export of view to only put single CR character.

### DIFF
--- a/gramps/gen/utils/docgen/csvtab.py
+++ b/gramps/gen/utils/docgen/csvtab.py
@@ -49,7 +49,7 @@ class CSVTab(TabbedDoc):
         else:
             self.filename = filename
 
-        self.f = open(self.filename, "w",
+        self.f = open(self.filename, "w", newline='',
                       encoding='utf_8_sig' if win() else 'utf_8')
         self.writer = csv.writer(self.f)
 


### PR DESCRIPTION
Fixes #12158

CSV writer was not opened properly resulting in CR, CR, LF for each line...