### PR TITLE
geofamily crashes if a family has no father

### DIFF
--- a/gramps/plugins/view/geofamily.py
+++ b/gramps/plugins/view/geofamily.py
@@ -370,8 +370,9 @@ class GeoFamily(GeoGraphyView):
                           _("Family places for %s") % self.family_label(family))
         person = None
         if family:
-            person = dbstate.db.get_person_from_handle(
-                                                     family.get_father_handle())
+            handle = family.get_father_handle()
+            if handle:
+                person = dbstate.db.get_person_from_handle(handle)
         else:
             return
         family_id = family.gramps_id


### PR DESCRIPTION
Fixes #012237

See: [discourse #1300](https://gramps.discourse.group/t/geography-view-all-known-places-for-a-family-bug/1300)