### PR TITLE
Allow entering place latlong without space

### DIFF
--- a/gramps/gui/editors/editplace.py
+++ b/gramps/gui/editors/editplace.py
@@ -187,9 +187,13 @@ class EditPlace(EditPrimary):
 
     def set_latlongitude(self, value):
         try:
-            coma = value.index(', ')
-            longitude = value[coma+2:].strip().replace(',','.')
-            latitude = value[:coma].strip().replace(',','.')
+            parts = value.index(', ')
+            if len(parts) == 2:
+                longitude = parts[0].strip().replace(',', '.')
+                latitude = parts[1].strip().replace(',', '.')
+            else:
+                longitude, latitude = value.split(',')
+
             self.longitude.set_text(longitude)
             self.latitude.set_text(latitude)
             self.top.get_object("lat_entry").validate(force=True)

--- a/gramps/gui/editors/editplaceref.py
+++ b/gramps/gui/editors/editplaceref.py
@@ -181,9 +181,13 @@ class EditPlaceRef(EditReference):
 
     def set_latlongitude(self, value):
         try:
-            coma = value.index(', ')
-            longitude = value[coma+2:].strip().replace(',','.')
-            latitude = value[:coma].strip().replace(',','.')
+            parts = value.index(', ')
+            if len(parts) == 2:
+                longitude = parts[0].strip().replace(',', '.')
+                latitude = parts[1].strip().replace(',', '.')
+            else:
+                longitude, latitude = value.split(',')
+
             self.longitude.set_text(longitude)
             self.latitude.set_text(latitude)
             self.top.get_object("lat_entry").validate(force=True)


### PR DESCRIPTION
When pasting latitude/longitude combinations from Google Maps URLs they don't have a space after the comma and use a dot as decimal separator.

To avoid issues we first still check for `, ` and split there if possible but otherwise try to just split at a comma. If the split doesn't produce exactly two values the unpacking will raise an exception and abort as before.