### PR TITLE
Set new media as active

### DIFF
--- a/gramps/gui/editors/editmedia.py
+++ b/gramps/gui/editors/editmedia.py
@@ -326,6 +326,7 @@ class EditMedia(EditPrimary):
             with DbTxn(_("Add Media Object (%s)") % self.obj.get_description(),
                        self.db) as trans:
                 self.db.add_media(self.obj, trans)
+            self.uistate.set_active(self.obj.handle, "Media")
         else:
             if self.data_has_changed():
                 with DbTxn(_("Edit Media Object (%s)") % self.obj.get_description(),

--- a/gramps/plugins/view/mediaview.py
+++ b/gramps/plugins/view/mediaview.py
@@ -169,7 +169,10 @@ class MediaView(ListView):
         """
         if not sel_data:
             return
+
         files = sel_data.get_uris()
+        photo = None
+
         for file in files:
             protocol, site, mfile, j, k, l = urlparse(file)
             if protocol == "file":
@@ -191,6 +194,10 @@ class MediaView(ListView):
                 photo.set_description(root)
                 with DbTxn(_("Drag Media Object"), self.dbstate.db) as trans:
                     self.dbstate.db.add_media(photo, trans)
+
+        if photo:
+            self.uistate.set_active(photo.handle, "Media")
+
         widget.emit_stop_by_name('drag_data_received')
 
     def define_actions(self):


### PR DESCRIPTION
When new media is added either by drag & drop or using the "add media" button it now becomes the active media.

This seems like the only sensible behavior to me since you otherwise can't even tell that drag & drop did anything and it also makes it much easier to further modify the media, e.g. using the photo tagging add-on. 