### PR TITLE
Fix References Gramplet for inadequate updates when other objects change

### DIFF
--- a/gramps/plugins/gramplet/backlinks.py
+++ b/gramps/plugins/gramplet/backlinks.py
@@ -92,13 +92,17 @@ class Backlinks(Gramplet):
 
         edit_object(self.dbstate, self.uistate, objclass, handle)
 
+    def db_changed(self):
+        for item in ['person', 'family', 'source', 'citation', 'event',
+                     'media', 'place', 'repository', 'note']:
+            self.connect(self.dbstate.db, '%s-delete' % item, self.update)
+            self.connect(self.dbstate.db, '%s-add' % item, self.update)
+            self.connect(self.dbstate.db, '%s-update' % item, self.update)
+
 class PersonBacklinks(Backlinks):
     """
     Displays the back references for a person.
     """
-    def db_changed(self):
-        self.connect(self.dbstate.db, 'person-update', self.update)
-
     def active_changed(self, handle):
         self.update()
 
@@ -119,7 +123,7 @@ class EventBacklinks(Backlinks):
     Displays the back references for an event.
     """
     def db_changed(self):
-        self.connect(self.dbstate.db, 'event-update', self.update)
+        super().db_changed()
         self.connect_signal('Event', self.update)
 
     def update_has_data(self):
@@ -139,7 +143,7 @@ class FamilyBacklinks(Backlinks):
     Displays the back references for a family.
     """
     def db_changed(self):
-        self.connect(self.dbstate.db, 'family-update', self.update)
+        super().db_changed()
         self.connect_signal('Family', self.update)
 
     def update_has_data(self):
@@ -159,7 +163,7 @@ class PlaceBacklinks(Backlinks):
     Displays the back references for a place.
     """
     def db_changed(self):
-        self.connect(self.dbstate.db, 'place-update', self.update)
+        super().db_changed()
         self.connect_signal('Place', self.update)
 
     def update_has_data(self):
@@ -179,7 +183,7 @@ class SourceBacklinks(Backlinks):
     Displays the back references for a source,.
     """
     def db_changed(self):
-        self.connect(self.dbstate.db, 'source-update', self.update)
+        super().db_changed()
         self.connect_signal('Source', self.update)
 
     def update_has_data(self):
@@ -199,7 +203,7 @@ class CitationBacklinks(Backlinks):
     Displays the back references for a Citation,.
     """
     def db_changed(self):
-        self.connect(self.dbstate.db, 'citation-update', self.update)
+        super().db_changed()
         self.connect_signal('Citation', self.update)
 
     def update_has_data(self):
@@ -219,7 +223,7 @@ class RepositoryBacklinks(Backlinks):
     Displays the back references for a repository.
     """
     def db_changed(self):
-        self.connect(self.dbstate.db, 'repository-update', self.update)
+        super().db_changed()
         self.connect_signal('Repository', self.update)
 
     def update_has_data(self):
@@ -239,7 +243,7 @@ class MediaBacklinks(Backlinks):
     Displays the back references for a media object.
     """
     def db_changed(self):
-        self.connect(self.dbstate.db, 'media-update', self.update)
+        super().db_changed()
         self.connect_signal('Media', self.update)
 
     def update_has_data(self):
@@ -259,7 +263,7 @@ class NoteBacklinks(Backlinks):
     Displays the back references for a note.
     """
     def db_changed(self):
-        self.connect(self.dbstate.db, 'note-update', self.update)
+        super().db_changed()
         self.connect_signal('Note', self.update)
 
     def update_has_data(self):


### PR DESCRIPTION
Fixes #12248

The original bug reports an exception from the backlinks gramplet when editing a backlink following a merge.  The root cause was the Gramplet not updating the references list when an object was deleted; thus trying to edit the object generated the HandleError exception.

On further investigation, I saw that the References were mostly not getting updated when new objects were added with a reference, or most other objects were edited with a new reference.

This should fix these issues.