### PR TITLE
Fix libplaceview to avoid exception when mapservice is no longer present

### DIFF
--- a/gramps/plugins/lib/libplaceview.py
+++ b/gramps/plugins/lib/libplaceview.py
@@ -206,8 +206,10 @@ class PlaceBaseView(ListView):
         """
         if action:
             action.set_state(value)
-        self.mapservice = mapkey = value.get_string()
-        config.set('interface.mapservice', mapkey)
+            self.mapservice = value.get_string()
+        else:
+            self.mapservice = value
+        config.set('interface.mapservice', self.mapservice)
         config.save()
         _ui = self.__create_maps_menu_actions()
         self.uimanager.add_ui_from_string(_ui)


### PR DESCRIPTION
Fixes #12263

When a previously configured mapservice addon is removed, the Places view code tries to revert to an installed plugin/addon.  This is an unusual situation, and contains a bug.

The bug appears to be that when called from the code that detects a missing addon, the set_mapservice(self, action, value) "value" is a string, where when called from the Gtk code (the normal path), it is a "Variant".  We need a test for this case in the set_mapservice code, so it can use the string.