### PR TITLE
Need to set locale.textdomain under linux

### DIFF
--- a/gramps/gen/utils/grampslocale.py
+++ b/gramps/gen/utils/grampslocale.py
@@ -525,7 +525,7 @@ class GrampsLocale:
         # with locale instead of gettext. Win32 doesn't support bindtextdomain.
         if self.localedir:
             if not sys.platform == 'win32':
-                # bug12278, _build_popup_ui() under linux
+                # bug12278, _build_popup_ui() under linux and macOS
                 locale.textdomain(self.localedomain)
                 locale.bindtextdomain(self.localedomain, self.localedir)
             else:

--- a/gramps/gen/utils/grampslocale.py
+++ b/gramps/gen/utils/grampslocale.py
@@ -525,6 +525,8 @@ class GrampsLocale:
         # with locale instead of gettext. Win32 doesn't support bindtextdomain.
         if self.localedir:
             if not sys.platform == 'win32':
+                # bug12278, _build_popup_ui() under linux
+                locale.textdomain(self.localedomain)
                 locale.bindtextdomain(self.localedomain, self.localedir)
             else:
                 self._win_bindtextdomain(self.localedomain.encode('utf-8'),


### PR DESCRIPTION
_build_popup_ui() ignores translated strings without locale.textdomain set.