### PR TITLE
macOS: Use File Logging instead of stderr Logging when there's no terminal

### DIFF
--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -127,15 +127,32 @@ if win():
         elif not os.path.isdir(HOME_DIR):
             os.makedirs(HOME_DIR)
         sys.stdout = sys.stderr = open(logfile, "w", encoding='utf-8')
-stderrh = logging.StreamHandler(sys.stderr)
-stderrh.setFormatter(form)
-stderrh.setLevel(logging.DEBUG)
+# macOS sets stderr to /dev/null when running without a terminal,
+# e.g. if Gramps.app is lauched by double-clicking on it in
+# finder. Write to a file instead.
+if mac() and not sys.stdin.isatty():
+    from tempfile import gettempdir
 
-# Setup the base level logger, this one gets
-# everything.
-l = logging.getLogger()
-l.setLevel(logging.WARNING)
-l.addHandler(stderrh)
+    log_file_name = 'gramps-' + str(os.getpid()) + '.log'
+    log_file_path = os.path.join(gettempdir(), log_file_name)
+    log_file_handler = logging.FileHandler(log_file_path, mode='a',
+                                           encoding='utf-8')
+    log_file_handler.setFormatter(form)
+    log_file_handler.setLevel(logging.DEBUG)
+
+    logger = logging.getLogger()
+    logger.setLevel(logging.WARNING)
+    logger.addHandler(log_file_handler)
+else:
+    stderrh = logging.StreamHandler(sys.stderr)
+    stderrh.setFormatter(form)
+    stderrh.setLevel(logging.DEBUG)
+
+    # Setup the base level logger, this one gets
+    # everything.
+    l = logging.getLogger()
+    l.setLevel(logging.WARNING)
+    l.addHandler(stderrh)
 
 
 def exc_hook(err_type, value, t_b):

--- a/gramps/gui/uimanager.py
+++ b/gramps/gui/uimanager.py
@@ -134,6 +134,8 @@ class UIManager():
         self.et_xml = ET.fromstring(initial_xml)
         self.builder = None
         self.toolbar = None
+        self.old_toolbar = None  # holds previous toolbar until Gtk is idle
+        self.old_toolbar_items = None
         self.action_groups = []  # current list of action groups
         self.show_groups = []  # groups to show at the moment
         self.accel_dict = {}  # used to store accel overrides from file
@@ -242,6 +244,11 @@ class UIManager():
         # the following updates the toolbar from the new builder
         toolbar_parent = toolbar.get_parent()
         tb_show = toolbar.get_visible()
+        if not self.old_toolbar:
+            self.old_toolbar = toolbar
+            self.old_toolbar_items = toolbar.get_children()
+        else:
+            print("Problem: multiple Toolbar updates before idle")
         toolbar_parent.remove(toolbar)
         toolbar = self.builder.get_object("ToolBar")  # new toolbar
         if config.get('interface.toolbar-text'):
@@ -251,7 +258,17 @@ class UIManager():
             toolbar.show_all()
         else:
             toolbar.hide()
+        GLib.idle_add(self.delete_old_toolbar)
         #print('*** Update ui')
+
+    def delete_old_toolbar(self):
+        """ This is used to finish removal of the old toolbar after Gtk is
+        idle.  To avoid an issue with the toolbar being removed before all
+        references were removed.
+        """
+        self.old_toolbar = None
+        self.old_toolbar_items = None
+        return False
 
     def add_ui_from_string(self, changexml):
         """ This performs a merge operation on the xml elements that have


### PR DESCRIPTION
When an app like Gramps is launched using LaunchServices on macOS there is no stderr to log to so any log messages are lost if Gramps quits unexpectedly in a way that the GUI Error handler doesn't catch. In those cases where it's Python quitting rather than a low-level crash there isn't a crash report either, leaving no clue about what went wrong.

This change sets up a FileHandler default log handler instead of the StreamHandler one when running on macOS when there's no attached tty and associated stderr.
