### PR TITLE
Various fixes to user-visible strings

### DIFF
--- a/gramps/gui/glade/editcitation.glade
+++ b/gramps/gui/glade/editcitation.glade
@@ -178,7 +178,7 @@
               <object class="ValidatableMaskedEntry" id="date_entry">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="tooltip_text" translatable="yes">The date of the entry in the source you are referencing, e.g. the date a house was visited during a census, or the date an entry was made in a birth log/registry. </property>
+                <property name="tooltip_text" translatable="yes">The date of the entry in the source you are referencing, e.g. the date a house was visited during a census, or the date an entry was made in a birth log/registry.</property>
                 <property name="hexpand">True</property>
                 <property name="invisible_char">•</property>
                 <property name="primary_icon_activatable">False</property>

--- a/gramps/gui/glade/editmedia.glade
+++ b/gramps/gui/glade/editmedia.glade
@@ -203,7 +203,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="tooltip_text" translatable="yes">Path of the media object on your computer.
-Gramps does not store the media internally, it only stores the path! Set the 'Relative Path' in the Preferences to avoid retyping the common base directory where all your media is stored. The 'Media Manager' tool can help managing paths of a collection of media objects. </property>
+Gramps does not store the media internally, it only stores the path! Set the 'Relative Path' in the Preferences to avoid retyping the common base directory where all your media is stored. The 'Media Manager' tool can help managing paths of a collection of media objects.</property>
                     <property name="hexpand">True</property>
                     <property name="invisible_char">●</property>
                   </object>

--- a/gramps/gui/glade/editname.glade
+++ b/gramps/gui/glade/editname.glade
@@ -330,7 +330,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">Given Name(s) </property>
+                        <property name="label" translatable="yes">Given Name(s)</property>
                         <attributes>
                           <attribute name="style" value="italic"/>
                         </attributes>

--- a/gramps/gui/glade/editplace.glade
+++ b/gramps/gui/glade/editplace.glade
@@ -235,7 +235,7 @@ You can set these values via the Geography View by searching the place, or via a
                       <object class="ValidatableMaskedEntry" id="latlon_entry">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="tooltip_text" translatable="yes">Field used to paste info from a web page like google, openstreetmap, ... </property>
+                        <property name="tooltip_text" translatable="yes">Field used to paste info from a web page like Google, OpenStreetMap...</property>
                         <property name="hexpand">True</property>
                         <property name="invisible_char">●</property>
                       </object>

--- a/gramps/gui/glade/editplaceref.glade
+++ b/gramps/gui/glade/editplaceref.glade
@@ -373,7 +373,7 @@
                           <object class="ValidatableMaskedEntry" id="latlon_entry">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="tooltip_text" translatable="yes">Field used to paste info from a web page like google, openstreetmap, ... </property>
+                            <property name="tooltip_text" translatable="yes">Field used to paste info from a web page like Google, OpenStreetMap...</property>
                             <property name="hexpand">True</property>
                             <property name="invisible_char">●</property>
                           </object>

--- a/gramps/plugins/drawreport/ancestortree.py
+++ b/gramps/plugins/drawreport/ancestortree.py
@@ -963,7 +963,7 @@ class AncestorTreeOptions(MenuReportOptions):
         repldisp = TextOption(
             _("Replace Display Format:\n'Replace this'/' with this'"),
             [])
-        repldisp.set_help(_("i.e.\nUnited States of America/U.S.A"))
+        repldisp.set_help(_("i.e.\nUnited States of America/U.S.A."))
         menu.add_option(category_name, "replace_list", repldisp)
 
         # TODO this code is never used and so I conclude it is for future use

--- a/gramps/plugins/drawreport/descendtree.py
+++ b/gramps/plugins/drawreport/descendtree.py
@@ -1696,7 +1696,7 @@ class DescendTreeOptions(MenuReportOptions):
         repldisp = TextOption(
             _("Replace Display Format:\n'Replace this'/' with this'"),
             [])
-        repldisp.set_help(_("i.e.\nUnited States of America/U.S.A"))
+        repldisp.set_help(_("i.e.\nUnited States of America/U.S.A."))
         menu.add_option(category_name, "replace_list", repldisp)
 
         self.usenote = BooleanOption(_('Include a note'), False)

--- a/gramps/plugins/importer/importgedcom.glade
+++ b/gramps/plugins/importer/importgedcom.glade
@@ -15,7 +15,7 @@
         <col id="0" translatable="yes">ANSEL</col>
       </row>
       <row>
-        <col id="0" translatable="yes">ANSI (iso-8859-1)</col>
+        <col id="0" translatable="yes">ANSI (ISO-8859-1)</col>
       </row>
       <row>
         <col id="0" translatable="yes">ASCII</col>

--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -2129,13 +2129,13 @@ class NavWebOptions(MenuReportOptions):
         birthorder = BooleanOption(
             _('Sort all children in birth order'), False)
         birthorder.set_help(
-            _('Whether to display children in birth order or in entry order?'))
+            _('Whether to display children in birth order or in entry order.'))
         addopt("birthorder", birthorder)
 
         coordinates = BooleanOption(
             _('Do we display coordinates in the places list?'), False)
         coordinates.set_help(
-            _('Whether to display latitude/longitude in the places list?'))
+            _('Whether to display latitude/longitude in the places list.'))
         addopt("coordinates", coordinates)
 
         reference_sort = BooleanOption(
@@ -2200,7 +2200,7 @@ class NavWebOptions(MenuReportOptions):
 
         headernote = NoteOption(_('HTML user header'))
         headernote.set_help(_("A note to be used as the page header"
-                              " or a php code to insert."))
+                              " or a PHP code to insert."))
         addopt("headernote", headernote)
 
         footernote = NoteOption(_('HTML user footer'))


### PR DESCRIPTION
The change includes various fixes:
- removal of trailing whitespaces;
- consistent usage of the final dot (instead of a question mark);
- fix a few acronyms (uppercase when needed, correct spelling).