### PR TITLE
Move comments away from translated strings

### DIFF
--- a/gramps/cli/arghandler.py
+++ b/gramps/cli/arghandler.py
@@ -432,9 +432,9 @@ class ArgHandler:
             summary_list = self.dbman.family_tree_summary(self.database_names)
             if not summary_list:
                 return
+            line_list = [_("Family Tree")]
             # We have to construct the line elements together, to avoid
             # insertion of blank spaces when print on the same line is used
-            line_list = [_("Family Tree")]
             for key in sorted(summary_list[0]):
                 if key != _("Family Tree"):
                     line_list += [key]

--- a/gramps/cli/clidbman.py
+++ b/gramps/cli/clidbman.py
@@ -66,9 +66,9 @@ _LOG = logging.getLogger(DBLOGNAME)
 # constants
 #
 #-------------------------------------------------------------------------
-DEFAULT_TITLE = _("Family Tree")
 NAME_FILE = "name.txt"
 META_NAME = "meta_data.db"
+DEFAULT_TITLE = _("Family Tree")
 UNAVAILABLE = _('Unavailable')
 
 #-------------------------------------------------------------------------

--- a/po/gramps.pot
+++ b/po/gramps.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-15 18:47+0100\n"
+"POT-Creation-Date: 2021-05-23 22:45+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -868,16 +868,9 @@ msgstr ""
 msgid "Gramps Family Trees:"
 msgstr ""
 
-#. We have to construct the line elements together, to avoid
-#. insertion of blank spaces when print on the same line is used
-#. -------------------------------------------------------------------------
-#.
-#. constants
-#.
-#. -------------------------------------------------------------------------
-#: ../gramps/cli/arghandler.py:437 ../gramps/cli/arghandler.py:439
+#: ../gramps/cli/arghandler.py:435 ../gramps/cli/arghandler.py:439
 #: ../gramps/cli/arghandler.py:444 ../gramps/cli/arghandler.py:445
-#: ../gramps/cli/arghandler.py:447 ../gramps/cli/clidbman.py:69
+#: ../gramps/cli/arghandler.py:447 ../gramps/cli/clidbman.py:71
 #: ../gramps/cli/clidbman.py:169 ../gramps/cli/clidbman.py:197
 #: ../gramps/gui/clipboard.py:916 ../gramps/gui/configure.py:1793
 msgid "Family Tree"
@@ -7637,7 +7630,7 @@ msgstr ""
 #: ../gramps/gui/selectors/selectperson.py:90
 #: ../gramps/gui/selectors/selectplace.py:67
 #: ../gramps/gui/views/bookmarks.py:281 ../gramps/gui/views/tags.py:473
-#: ../gramps/gui/views/treemodels/peoplemodel.py:611
+#: ../gramps/gui/views/treemodels/peoplemodel.py:614
 #: ../gramps/plugins/export/exportcsv.py:286
 #: ../gramps/plugins/gramplet/ancestor.py:63
 #: ../gramps/plugins/gramplet/backlinks.py:59
@@ -12606,7 +12599,7 @@ msgid "Move the selected name downwards"
 msgstr ""
 
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:77
-#: ../gramps/gui/views/treemodels/peoplemodel.py:611
+#: ../gramps/gui/views/treemodels/peoplemodel.py:614
 msgid "Group As"
 msgstr ""
 


### PR DESCRIPTION
This will remove comments not relevant to translators from the
POT file.