### PR TITLE
Add round trip Ancestry.com _APID tag support

### DIFF
--- a/gramps/plugins/export/exportgedcom.py
+++ b/gramps/plugins/export/exportgedcom.py
@@ -999,6 +999,11 @@ class GedcomWriter(UpdateCallback):
             self._note_references(source.get_note_list(), 1)
             self._change(source.get_change_time(), 1)
 
+            for srcattr in source.get_attribute_list():
+                if str(srcattr.type) == "_APID":
+                    self._writeln(1, "_APID", srcattr.value)
+                    break
+
     def _notes(self):
         """
         Write out the list of notes, sorting by Gramps ID.
@@ -1407,6 +1412,11 @@ class GedcomWriter(UpdateCallback):
                 if str(srcattr.type) == "EVEN:ROLE":
                     self._writeln(level + 2, "ROLE", srcattr.value)
                     break
+
+        for srcattr in citation.get_attribute_list():
+            if str(srcattr.type) == "_APID":
+                self._writeln(level + 1, "_APID", srcattr.value)
+                break
 
     def _photo(self, photo, level):
         """

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -275,6 +275,7 @@ TOKEN__PRIM = 134
 TOKEN__JUST = 135
 TOKEN__TEXT = 136
 TOKEN__DATE = 137
+TOKEN__APID = 138
 
 TOKENS = {
     "_ADPN"           : TOKEN__ADPN,
@@ -282,6 +283,7 @@ TOKENS = {
     "_AKAN"           : TOKEN__AKA,
     "_ALIA"           : TOKEN_ALIA,
     "_ANCES_ORDRE"    : TOKEN_IGNORE,
+    "_APID"           : TOKEN__APID,    # Ancestry.com database and page id
     "_CAT"            : TOKEN_IGNORE,
     "_CHUR"           : TOKEN_IGNORE,
     "_COMM"           : TOKEN__COMM,
@@ -2304,6 +2306,7 @@ class GedcomParser(UpdateCallback):
             TOKEN_TEXT   : self.__citation_data_text,
             TOKEN__LINK  : self.__citation_link,
             TOKEN__JUST  : self.__citation__just,
+            TOKEN__APID  : self.__citation__apid,
         }
         self.func_list.append(self.citation_parse_tbl)
 
@@ -2452,6 +2455,7 @@ class GedcomParser(UpdateCallback):
             # not legal, but Ultimate Family Tree does this
             TOKEN_DATE   : self.__ignore,
             TOKEN_IGNORE : self.__ignore,
+            TOKEN__APID  : self.__source_attr,
         }
         self.func_list.append(self.source_func)
 
@@ -6376,6 +6380,17 @@ class GedcomParser(UpdateCallback):
         note.set_type(_("Citation Justification"))
         self.dbase.add_note(note, self.trans)
         state.citation.add_note(note.get_handle())
+
+    def __citation__apid(self, line, state):
+        """
+        Not legal GEDCOM - added to support Ancestry.com, converts the
+        _APID tag to an attribute. This tag identifies the location of
+        the cited page in the relevant Ancestry.com database.
+        """
+        sattr = SrcAttribute()
+        sattr.set_type("_APID")
+        sattr.set_value(line.data)
+        state.citation.add_attribute(sattr)
 
     def __citation_data_note(self, line, state):
         self.__parse_note(line, state.citation, state)


### PR DESCRIPTION
This PR addresses feature request [#9925](https://gramps-project.org/bugs/view.php?id=9925).  

It adds support for saving the _APID tags used by Ancestry.com as attributes on citation and source objects during a Gedcom import and then including them in a Gedcom export. Note for citations these identify the specific item in the database being cited, for sources they merely identify the database. 

Tested an import of a raw Gedcom with 159097 _APID tags. On export 159089 were present.  A test upload to Ancestry.com worked as expected.  The 8 unaccounted for appear to have been missed due to unrelated structural parsing errors I did not take the time to investigate in detail.