### PR TITLE
Use "Translator" tag when extracting comments for translators

### DIFF
--- a/gramps/cli/arghandler.py
+++ b/gramps/cli/arghandler.py
@@ -445,7 +445,7 @@ class ArgHandler:
                 line_list = [(_('"%s"') % summary[_("Family Tree")])]
                 for item in sorted(summary):
                     if item != _("Family Tree"):
-                        # translators: used in French+Russian, ignore otherwise
+                        # Translators: used in French+Russian, ignore otherwise
                         line_list += [(_('"%s"') % summary[item])]
                 print("\t".join(line_list))
             return

--- a/gramps/cli/argparser.py
+++ b/gramps/cli/argparser.py
@@ -383,7 +383,7 @@ class ArgParser:
                                 converter = get_type_converter(setting_value)
                                 new_value = converter(new_value)
                             config.set(cfg_name, new_value)
-                            # translators: indent "New" to match "Current"
+                            # Translators: indent "New" to match "Current"
                             print(_("    New Gramps config setting: "
                                     "%(name)s:%(value)s"
                                    ) % {'name'  : cfg_name,

--- a/gramps/cli/clidbman.py
+++ b/gramps/cli/clidbman.py
@@ -197,7 +197,7 @@ class CLIDbManager:
                 print(_('Family Tree "%s":') % summary[_("Family Tree")])
                 for item in sorted(summary):
                     if item != "Family Tree":
-                        # translators: needed for French, ignore otherwise
+                        # Translators: needed for French, ignore otherwise
                         print('   ' + _("%(str1)s: %(str2)s"
                                        ) % {'str1' : item,
                                             'str2' : summary[item]})

--- a/gramps/cli/plug/__init__.py
+++ b/gramps/cli/plug/__init__.py
@@ -412,7 +412,7 @@ class CommandLineReport:
                         father = self.database.get_person_from_handle(fhandle)
                         if father:
                             fname = name_displayer.display(father)
-                    # translators: needed for French, Hebrew and Arabic
+                    # Translators: needed for French, Hebrew and Arabic
                     text = _("%(id)s:\t%(father)s, %(mother)s"
                             ) % {'id': family.get_gramps_id(),
                                  'father': fname, 'mother': mname}

--- a/gramps/gen/const.py
+++ b/gramps/gen/const.py
@@ -262,7 +262,7 @@ NO_GIVEN = "(%s)" % _("none", "given-name")
 ARABIC_COMMA = "،"
 ARABIC_SEMICOLON = "؛"
 DOCGEN_OPTIONS = 'Docgen Options'
-COLON = _(':') # translators: needed for French, ignore otherwise
+COLON = _(':') # Translators: needed for French, ignore otherwise
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_datedisplay.py
+++ b/gramps/gen/datehandler/_datedisplay.py
@@ -67,25 +67,27 @@ class DateDisplay:
 
     formats = (
         # format 0 - must always be ISO
+        # Translators: Numeric year, month, day
         _T_("YYYY-MM-DD (ISO)"),
 
         # format # 1 - must always be locale-preferred numerical format
         # such as YY.MM.DD, MM-DD-YY, or whatever your locale prefers.
         # This should be the format that is used under the locale by
         # strftime() for '%x'.
-        # You may translate this as "Numerical", "System preferred", or similar.
+        # Translators: You may translate this as "Numerical",
+        # "System preferred", or similar.
         _T_("Numerical", "date format"),
 
-        # Full month name, day, year
+        # Translators: Full month name, day, year
         _T_("Month Day, Year"),
 
-        # Abbreviated month name, day, year
+        # Translators: Abbreviated month name, day, year
         _T_("MON DAY, YEAR"),
 
-        # Day, full month name, year
+        # Translators: Day, full month name, year
         _T_("Day Month Year"),
 
-        # Day, abbreviated month name, year
+        # Translators: Day, abbreviated month name, year
         _T_("DAY MON YEAR")
         )
     """
@@ -182,67 +184,67 @@ class DateDisplay:
 
                 "from"
                 # first date in a span
-                # If "from <Month>" needs a special inflection in your
-                # language, translate this to "{long_month.f[X]} {year}"
+                # Translators: If "from <Month>" needs a special inflection
+                # in your language, translate to "{long_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{long_month} {year}", "from"),
 
                 "to"
                 # second date in a span
-                # If "to <Month>" needs a special inflection in your
-                # language, translate this to "{long_month.f[X]} {year}"
+                # Translators: If "to <Month>" needs a special inflection
+                # in your language, translate to "{long_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{long_month} {year}", "to"),
 
                 "between"
                 # first date in a range
-                # If "between <Month>" needs a special inflection in your
-                # language, translate this to "{long_month.f[X]} {year}"
+                # Translators: If "between <Month>" needs a special inflection
+                # in your language, translate to "{long_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{long_month} {year}", "between"),
 
                 "and"
                 # second date in a range
-                # If "and <Month>" needs a special inflection in your
-                # language, translate this to "{long_month.f[X]} {year}"
+                # Translators: If "and <Month>" needs a special inflection
+                # in your language, translate to "{long_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{long_month} {year}", "and"),
 
                 "before"
-                # If "before <Month>" needs a special inflection in your
-                # language, translate this to "{long_month.f[X]} {year}"
+                # Translators: If "before <Month>" needs a special inflection
+                # in your language, translate to "{long_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{long_month} {year}", "before"),
 
                 "after"
-                # If "after <Month>" needs a special inflection in your
-                # language, translate this to "{long_month.f[X]} {year}"
+                # Translators: If "after <Month>" needs a special inflection
+                # in your language, translate to "{long_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{long_month} {year}", "after"),
 
                 "about"
-                # If "about <Month>" needs a special inflection in your
-                # language, translate this to "{long_month.f[X]} {year}"
+                # Translators: If "about <Month>" needs a special inflection
+                # in your language, translate to "{long_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{long_month} {year}", "about"),
 
                 "estimated"
-                # If "estimated <Month>" needs a special inflection in your
-                # language, translate this to "{long_month.f[X]} {year}"
+                # Translators: If "estimated <Month>" needs a special inflection
+                # in your language, translate to "{long_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{long_month} {year}", "estimated"),
 
                 "calculated"
-                # If "calculated <Month>" needs a special inflection in your
-                # language, translate this to "{long_month.f[X]} {year}"
+                # Translators: If "calculated <Month>" needs a special inflection
+                # in your language, translate to "{long_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{long_month} {year}", "calculated"),
@@ -254,67 +256,67 @@ class DateDisplay:
 
                 "from"
                 # first date in a span
-                # If "from <Month>" needs a special inflection in your
-                # language, translate this to "{short_month.f[X]} {year}"
+                # Translators: If "from <Month>" needs a special inflection
+                # in your language, translate to "{short_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{short_month} {year}", "from"),
 
                 "to"
                 # second date in a span
-                # If "to <Month>" needs a special inflection in your
-                # language, translate this to "{short_month.f[X]} {year}"
+                # Translators: If "to <Month>" needs a special inflection
+                # in your language, translate to "{short_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{short_month} {year}", "to"),
 
                 "between"
                 # first date in a range
-                # If "between <Month>" needs a special inflection in your
-                # language, translate this to "{short_month.f[X]} {year}"
+                # Translators: If "between <Month>" needs a special inflection
+                # in your language, translate to "{short_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{short_month} {year}", "between"),
 
                 "and"
                 # second date in a range
-                # If "and <Month>" needs a special inflection in your
-                # language, translate this to "{short_month.f[X]} {year}"
+                # Translators: If "and <Month>" needs a special inflection
+                # in your language, translate to "{short_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{short_month} {year}", "and"),
 
                 "before"
-                # If "before <Month>" needs a special inflection in your
-                # language, translate this to "{short_month.f[X]} {year}"
+                # Translators: If "before <Month>" needs a special inflection
+                # in your language, translate to "{short_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{short_month} {year}", "before"),
 
                 "after"
-                # If "after <Month>" needs a special inflection in your
-                # language, translate this to "{short_month.f[X]} {year}"
+                # Translators: If "after <Month>" needs a special inflection
+                # in your language, translate to "{short_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{short_month} {year}", "after"),
 
                 "about"
-                # If "about <Month>" needs a special inflection in your
-                # language, translate this to "{short_month.f[X]} {year}"
+                # Translators: If "about <Month>" needs a special inflection
+                # in your language, translate to "{short_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{short_month} {year}", "about"),
 
                 "estimated"
-                # If "estimated <Month>" needs a special inflection in your
-                # language, translate this to "{short_month.f[X]} {year}"
+                # Translators: If "estimated <Month>" needs a special inflection
+                # in your language, translate to "{short_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{short_month} {year}", "estimated"),
 
                 "calculated"
-                # If "calculated <Month>" needs a special inflection in your
-                # language, translate this to "{short_month.f[X]} {year}"
+                # Translators: If "calculated <Month>" needs a special inflection
+                # in your language, translate to "{short_month.f[X]} {year}"
                 # (where X is one of the month-name inflections you defined)
                 # else leave it untranslated
                 : _("{short_month} {year}", "calculated"),
@@ -421,14 +423,14 @@ class DateDisplay:
         qual_str = self._qual_str[date.get_quality()]
         scal = self.format_extras(cal, date.get_new_year())
         d1 = self.display_cal[cal](date.get_start_date(),
-            # If there is no special inflection for "from <Month>"
-            # in your language, DON'T translate this string.  Otherwise,
-            # "translate" this to "from" in ENGLISH!!! ENGLISH!!!
+            # Translators: If there is no special inflection for
+            # "from <Month>" in your language, DON'T translate this.
+            # Otherwise, translate to "from" in ENGLISH!!! ENGLISH!!!
                                    inflect=self._("", "from-date"))
         d2 = self.display_cal[cal](date.get_stop_date(),
-            # If there is no special inflection for "to <Month>"
-            # in your language, DON'T translate this string.  Otherwise,
-            # "translate" this to "to" in ENGLISH!!! ENGLISH!!!
+            # Translators: If there is no special inflection for
+            # "to <Month>" in your language, DON'T translate this.
+            # Otherwise, translate to "to" in ENGLISH!!! ENGLISH!!!
                                    inflect=self._("", "to-date"))
         return self._("{date_quality}from {date_start} to {date_stop}"
                       "{nonstd_calendar_and_ny}").format(
@@ -446,14 +448,14 @@ class DateDisplay:
         qual_str = self._qual_str[date.get_quality()]
         scal = self.format_extras(cal, date.get_new_year())
         d1 = self.display_cal[cal](date.get_start_date(),
-            # If there is no special inflection for "between <Month>"
-            # in your language, DON'T translate this string.  Otherwise,
-            # "translate" this to "between" in ENGLISH!!! ENGLISH!!!
+            # Translators: If there is no special inflection for
+            # "between <Month>" in your language, DON'T translate this.
+            # Otherwise, translate to "between" in ENGLISH!!! ENGLISH!!!
                                    inflect=self._("", "between-date"))
         d2 = self.display_cal[cal](date.get_stop_date(),
-            # If there is no special inflection for "and <Month>"
-            # in your language, DON'T translate this string.  Otherwise,
-            # "translate" this to "and" in ENGLISH!!! ENGLISH!!!
+            # Translators: If there is no special inflection for
+            # "and <Month>" in your language, DON'T translate this.
+            # Otherwise, translate to "and" in ENGLISH!!! ENGLISH!!!
                                    inflect=self._("", "and-date"))
         return self._("{date_quality}between {date_start} and {date_stop}"
                       "{nonstd_calendar_and_ny}").format(
@@ -485,29 +487,29 @@ class DateDisplay:
             return self.dd_range(date)
         else:
             if mod == Date.MOD_BEFORE:
-                # If there is no special inflection for "before <Month>"
-                # in your language, DON'T translate this string.  Otherwise,
-                # "translate" this to "before" in ENGLISH!!! ENGLISH!!!
+                # Translators: If there is no special inflection for
+                # "before <Month>" in your language, DON'T translate this.
+                # Otherwise, translate to "before" in ENGLISH!!! ENGLISH!!!
                 date_type = _("", "before-date")
             elif mod == Date.MOD_AFTER:
-                # If there is no special inflection for "after <Month>"
-                # in your language, DON'T translate this string.  Otherwise,
-                # "translate" this to "after" in ENGLISH!!! ENGLISH!!!
+                # Translators: If there is no special inflection for
+                # "after <Month>" in your language, DON'T translate this.
+                # Otherwise, translate to "after" in ENGLISH!!! ENGLISH!!!
                 date_type = _("", "after-date")
             elif mod == Date.MOD_ABOUT:
-                # If there is no special inflection for "about <Month>"
-                # in your language, DON'T translate this string.  Otherwise,
-                # "translate" this to "about" in ENGLISH!!! ENGLISH!!!
+                # Translators: If there is no special inflection for
+                # "about <Month>" in your language, DON'T translate this.
+                # Otherwise, translate to "about" in ENGLISH!!! ENGLISH!!!
                 date_type = _("", "about-date")
             elif qual == Date.QUAL_ESTIMATED:
-                # If there is no special inflection for "estimated <Month>"
-                # in your language, DON'T translate this string.  Otherwise,
-                # "translate" this to "estimated" in ENGLISH!!! ENGLISH!!!
+                # Translators: If there is no special inflection for
+                # "estimated <Month>" in your language, DON'T translate this.
+                # Otherwise, translate to "estimated" in ENGLISH!!! ENGLISH!!!
                 date_type = _("", "estimated-date")
             elif qual == Date.QUAL_CALCULATED:
-                # If there is no special inflection for "calculated <Month>"
-                # in your language, DON'T translate this string.  Otherwise,
-                # "translate" this to "calculated" in ENGLISH!!! ENGLISH!!!
+                # Translators: If there is no special inflection for
+                # "calculated <Month>" in your language, DON'T translate this.
+                # Otherwise, translate to "calculated" in ENGLISH!!! ENGLISH!!!
                 date_type = _("", "calculated-date")
             else:
                 date_type = ""
@@ -761,7 +763,8 @@ class DateDisplay:
             # day month_abbreviation year
             value = self.dd_dformat05(date_val, inflect, short_months)
         if date_val[2] < 0:
-            # TODO fix BUG 7064: non-Gregorian calendars wrongly use BCE notation for negative dates
+            # TODO fix BUG 7064: non-Gregorian calendars wrongly use BCE notation
+            # for negative dates
             return self._bce_str % value
         else:
             return value

--- a/gramps/gen/datehandler/_datedisplay.py
+++ b/gramps/gen/datehandler/_datedisplay.py
@@ -645,7 +645,7 @@ class DateDisplay:
         elif date_val[1] == 0: # month is zero but day is not (see 8477)
             return self.display_iso(date_val)
         else:
-            # TRANSLATORS: this month is ALREADY inflected: ignore it
+            # Translators: this month is ALREADY inflected: ignore it
             return _("{long_month} {day:d}, {year}").format(
                        long_month = self.format_long_month(date_val[1],
                                                            inflect,
@@ -671,7 +671,7 @@ class DateDisplay:
         elif date_val[1] == 0: # month is zero but day is not (see 8477)
             return self.display_iso(date_val)
         else:
-            # TRANSLATORS: this month is ALREADY inflected: ignore it
+            # Translators: this month is ALREADY inflected: ignore it
             return _("{short_month} {day:d}, {year}").format(
                        short_month = self.format_short_month(date_val[1],
                                                              inflect,
@@ -697,7 +697,7 @@ class DateDisplay:
         elif date_val[1] == 0: # month is zero but day is not (see 8477)
             return self.display_iso(date_val)
         else:
-            # TRANSLATORS: this month is ALREADY inflected: ignore it
+            # Translators: this month is ALREADY inflected: ignore it
             return _("{day:d} {long_month} {year}").format(
                        day = date_val[0],
                        long_month = self.format_long_month(date_val[1],
@@ -723,7 +723,7 @@ class DateDisplay:
         elif date_val[1] == 0: # month is zero but day is not (see 8477)
             return self.display_iso(date_val)
         else:
-            # TRANSLATORS: this month is ALREADY inflected: ignore it
+            # Translators: this month is ALREADY inflected: ignore it
             return _("{day:d} {short_month} {year}").format(
                        day = date_val[0],
                        short_month = self.format_short_month(date_val[1],

--- a/gramps/gen/datehandler/_datestrings.py
+++ b/gramps/gen/datehandler/_datestrings.py
@@ -72,7 +72,7 @@ class DateStrings:
         _ = locale.translation.lexgettext
 
         self.long_months = ( "",
-            # TRANSLATORS: see
+            # Translators: see
             # http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
             # to learn how to select proper inflection to be used in your localized
             # DateDisplayer code!
@@ -90,7 +90,7 @@ class DateStrings:
             _("|December", "localized lexeme inflections") )
 
         self.short_months = ( "",
-            # TRANSLATORS: see
+            # Translators: see
             # http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
             # to learn how to select proper inflection to be used in your localized
             # DateDisplayer code!
@@ -109,7 +109,7 @@ class DateStrings:
 
         _ = locale.translation.sgettext
         self.alt_long_months = ( "",
-            # TRANSLATORS: see
+            # Translators: see
             # http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
             # to learn how to add proper alternatives to be recognized in your localized
             # DateParser code!
@@ -139,7 +139,7 @@ class DateStrings:
 
         self.hebrew = (
             "",
-            # TRANSLATORS: see
+            # Translators: see
             # http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
             # to learn how to select proper inflection to be used in your localized
             # DateDisplayer code!
@@ -160,7 +160,7 @@ class DateStrings:
 
         self.french = (
             "",
-            # TRANSLATORS: see
+            # Translators: see
             # http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
             # to learn how to select proper inflection to be used in your localized
             # DateDisplayer code!
@@ -181,7 +181,7 @@ class DateStrings:
 
         self.islamic = (
             "",
-            # TRANSLATORS: see
+            # Translators: see
             # http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
             # to learn how to select proper inflection to be used in your localized
             # DateDisplayer code!
@@ -201,7 +201,7 @@ class DateStrings:
 
         self.persian = (
             "",
-            # TRANSLATORS: see
+            # Translators: see
             # http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
             # to learn how to select proper inflection to be used in your localized
             # DateDisplayer code!
@@ -220,13 +220,13 @@ class DateStrings:
             )
 
         self.modifiers = ("",
-                # TRANSLATORS: if the modifier is after the date
+                # Translators: if the modifier is after the date
                 # put the space ahead of the word instead of after it
                 _("before ", "date modifier"),
-                # TRANSLATORS: if the modifier is after the date
+                # Translators: if the modifier is after the date
                 # put the space ahead of the word instead of after it
                 _("after ", "date modifier"),
-                # TRANSLATORS: if the modifier is after the date
+                # Translators: if the modifier is after the date
                 # put the space ahead of the word instead of after it
                 _("about ", "date modifier"),
                 "", "", "")

--- a/gramps/gen/display/name.py
+++ b/gramps/gen/display/name.py
@@ -345,7 +345,7 @@ class NameDisplay:
         global WITH_GRAMPS_CONFIG
         global PAT_AS_SURN
 
-        # translators: needed for Arabic, ignore otherwise
+        # Translators: needed for Arabic, ignore otherwise
         COMMAGLYPH = xlocale.translation.gettext(',')
 
         self.STANDARD_FORMATS = [
@@ -358,7 +358,7 @@ class NameDisplay:
             (Name.FNLN,  _("Given Surname Suffix"),
                          '%f %l %s', _ACT),
             # primary name primconnector other, given pa/matronynic suffix, primprefix
-            # translators: long string, have a look at Preferences dialog
+            # Translators: long string, have a look at Preferences dialog
             (Name.LNFNP, _("Main Surnames, Given Patronymic Suffix Prefix"),
                          '%1m %2m %o' + COMMAGLYPH + ' %f %1y %s %0m', _ACT),
             # DEPRECATED FORMATS

--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -423,23 +423,23 @@ class Span:
         retval = ""
         detail = 0
         if diff_tuple[0] != 0:
-            # translators: leave all/any {...} untranslated
+            # Translators: leave all/any {...} untranslated
             retval += ngettext("{number_of} year", "{number_of} years",
                                diff_tuple[0]
                               ).format(number_of=diff_tuple[0])
             detail += 1
         if self.precision == detail:
             if diff_tuple[1] >= 6: # round up years
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 retval = ngettext("{number_of} year", "{number_of} years",
                                   diff_tuple[0] + 1
                                  ).format(number_of=diff_tuple[0] + 1)
             return retval
         if diff_tuple[1] != 0:
             if retval != "":
-                # translators: needed for Arabic, ignore otherwise
+                # Translators: needed for Arabic, ignore otherwise
                 retval += trans_text(", ")
-            # translators: leave all/any {...} untranslated
+            # Translators: leave all/any {...} untranslated
             retval += ngettext("{number_of} month", "{number_of} months",
                                diff_tuple[1]
                               ).format(number_of=diff_tuple[1])
@@ -448,9 +448,9 @@ class Span:
             return retval
         if diff_tuple[2] != 0:
             if retval != "":
-                # translators: needed for Arabic, ignore otherwise
+                # Translators: needed for Arabic, ignore otherwise
                 retval += trans_text(", ")
-            # translators: leave all/any {...} untranslated
+            # Translators: leave all/any {...} untranslated
             retval += ngettext("{number_of} day", "{number_of} days",
                                diff_tuple[2]
                               ).format(number_of=diff_tuple[2])

--- a/gramps/gen/lib/name.py
+++ b/gramps/gen/lib/name.py
@@ -457,11 +457,11 @@ class Name(SecondaryObject, PrivacyBase, SurnameBase, CitationBase, NoteBase,
         first = self.first_name
         surname = self.get_surname()
         if self.suffix:
-            # translators: needed for Arabic, ignore otherwise
+            # Translators: needed for Arabic, ignore otherwise
             return _("%(surname)s, %(first)s %(suffix)s"
                     ) % {'surname':surname, 'first':first, 'suffix':self.suffix}
         else:
-            # translators: needed for Arabic, ignore otherwise
+            # Translators: needed for Arabic, ignore otherwise
             return _("%(str1)s, %(str2)s") % {'str1':surname, 'str2':first}
 
     def get_upper_name(self):
@@ -472,11 +472,11 @@ class Name(SecondaryObject, PrivacyBase, SurnameBase, CitationBase, NoteBase,
         first = self.first_name
         surname = self.get_surname().upper()
         if self.suffix:
-            # translators: needed for Arabic, ignore otherwise
+            # Translators: needed for Arabic, ignore otherwise
             return _("%(surname)s, %(first)s %(suffix)s"
                     ) % {'surname':surname, 'first':first, 'suffix':self.suffix}
         else:
-            # translators: needed for Arabic, ignore otherwise
+            # Translators: needed for Arabic, ignore otherwise
             return _("%(str1)s, %(str2)s") % {'str1':surname, 'str2':first}
 
     def get_regular_name(self):
@@ -489,7 +489,7 @@ class Name(SecondaryObject, PrivacyBase, SurnameBase, CitationBase, NoteBase,
         if self.suffix == "":
             return "%s %s" % (first, surname)
         else:
-            # translators: needed for Arabic, ignore otherwise
+            # Translators: needed for Arabic, ignore otherwise
             return _("%(first)s %(surname)s, %(suffix)s"
                     ) % {'surname':surname, 'first':first, 'suffix':self.suffix}
 

--- a/gramps/gen/plug/report/endnotes.py
+++ b/gramps/gen/plug/report/endnotes.py
@@ -114,7 +114,7 @@ def cite_source(bibliography, database, obj, elocale=glocale):
         first = True
         for ref in slist:
             if not first:
-                # translators: needed for Arabic, ignore otherwise
+                # Translators: needed for Arabic, ignore otherwise
                 txt += trans_text(', ')
             first = False
             citation = database.get_citation_from_handle(ref)
@@ -171,7 +171,7 @@ def write_endnotes(bibliography, database, doc, printnotes=False, links=False,
                          'Endnotes-Source-Notes', links)
 
         for key, ref in citation.get_ref_list():
-            # translators: needed for French, ignore otherwise
+            # Translators: needed for French, ignore otherwise
             doc.start_paragraph('Endnotes-Ref', trans_text('%s:') % key)
             doc.write_text(_format_ref_text(ref, key, elocale), links=links)
             doc.end_paragraph()
@@ -193,20 +193,20 @@ def _format_source_text(source, elocale):
 
     if source.get_title():
         if src_txt:
-            # translators: needed for Arabic, ignore otherwise
+            # Translators: needed for Arabic, ignore otherwise
             src_txt += trans_text(', ')
-        # translators: used in French+Russian, ignore otherwise
+        # Translators: used in French+Russian, ignore otherwise
         src_txt += trans_text('"%s"') % source.get_title()
 
     if source.get_publication_info():
         if src_txt:
-            # translators: needed for Arabic, ignore otherwise
+            # Translators: needed for Arabic, ignore otherwise
             src_txt += trans_text(', ')
         src_txt += source.get_publication_info()
 
     if source.get_abbreviation():
         if src_txt:
-            # translators: needed for Arabic, ignore otherwise
+            # Translators: needed for Arabic, ignore otherwise
             src_txt += trans_text(', ')
         src_txt += "(%s)" % source.get_abbreviation()
 

--- a/gramps/gen/plug/report/utils.py
+++ b/gramps/gen/plug/report/utils.py
@@ -252,7 +252,7 @@ def get_address_str(addr):
             if addr_str == "":
                 addr_str = info
             else:
-                # translators: needed for Arabic, ignore otherwise
+                # Translators: needed for Arabic, ignore otherwise
                 addr_str = _("%(str1)s, %(str2)s"
                             ) % {'str1' : addr_str, 'str2' : info}
     return addr_str

--- a/gramps/gui/aboutdialog.py
+++ b/gramps/gui/aboutdialog.py
@@ -116,7 +116,7 @@ class GrampsAboutDialog(Gtk.AboutDialog):
         if len(contributors) > 0:
             self.add_credit_section(_('Contributions by'), contributors)
 
-        # TRANSLATORS: Translate this to your name in your native language
+        # Translators: Translate this to your name in your native language
         self.set_translator_credits(_("translator-credits"))
 
         self.set_documenters(DOCUMENTERS)

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -410,7 +410,7 @@ class ConfigureDialog(ManagedWindow):
         if not callback:
             callback = self.update_entry
         if label:
-            lwidget = BasicLabel(_("%s: ") % label)  # translators: for French
+            lwidget = BasicLabel(_("%s: ") % label)  # Translators: for French
         entry = Gtk.Entry()
         if localized_config:
             entry.set_text(config.get(constant))

--- a/gramps/gui/editors/editfamily.py
+++ b/gramps/gui/editors/editfamily.py
@@ -991,14 +991,14 @@ class EditFamily(EditPrimary):
             if birth:
                 #if event changes it view needs to update
                 self.callman.register_handles({'event': [birth.get_handle()]})
-                # translators: needed for French, ignore otherwise
+                # Translators: needed for French, ignore otherwise
                 birth_label.set_label(_("%s:") % birth.get_type())
 
             death = get_death_or_fallback(db, person)
             if death:
                 #if event changes it view needs to update
                 self.callman.register_handles({'event': [death.get_handle()]})
-                # translators: needed for French, ignore otherwise
+                # Translators: needed for French, ignore otherwise
                 death_label.set_label(_("%s:") % death.get_type())
 
             btn_edit.set_tooltip_text(_('Edit %s') % name)

--- a/gramps/gui/editors/editplace.py
+++ b/gramps/gui/editors/editplace.py
@@ -209,12 +209,12 @@ class EditPlace(EditPrimary):
     def _validate_coordinate(self, widget, text, typedeg):
         if (typedeg == 'lat') and not conv_lat_lon(text, "0", "ISO-D"):
             return ValidationError(
-                # translators: translate the "S" too (and the "or" of course)
+                # Translators: translate the "S" too (and the "or" of course)
                 _('Invalid latitude\n(syntax: '
                   '18\u00b09\'48.21"S, -18.2412 or -18:9:48.21)'))
         elif (typedeg == 'lon') and not conv_lat_lon("0", text, "ISO-D"):
             return ValidationError(
-                # translators: translate the "E" too (and the "or" of course)
+                # Translators: translate the "E" too (and the "or" of course)
                 _('Invalid longitude\n(syntax: '
                   '18\u00b09\'48.21"E, -18.2412 or -18:9:48.21)'))
 

--- a/gramps/gui/editors/editplaceref.py
+++ b/gramps/gui/editors/editplaceref.py
@@ -203,12 +203,12 @@ class EditPlaceRef(EditReference):
     def _validate_coordinate(self, widget, text, typedeg):
         if (typedeg == 'lat') and not conv_lat_lon(text, "0", "ISO-D"):
             return ValidationError(
-                # translators: translate the "S" too (and the "or" of course)
+                # Translators: translate the "S" too (and the "or" of course)
                 _('Invalid latitude\n(syntax: '
                   '18\u00b09\'48.21"S, -18.2412 or -18:9:48.21)'))
         elif (typedeg == 'lon') and not conv_lat_lon("0", text, "ISO-D"):
             return ValidationError(
-                # translators: translate the "E" too (and the "or" of course)
+                # Translators: translate the "E" too (and the "or" of course)
                 _('Invalid longitude\n(syntax: '
                   '18\u00b09\'48.21"E, -18.2412 or -18:9:48.21)'))
 

--- a/gramps/gui/merge/mergeperson.py
+++ b/gramps/gui/merge/mergeperson.py
@@ -58,7 +58,7 @@ WIKI_HELP_PAGE = URL_MANUAL_SECT3
 WIKI_HELP_SEC = _("Merge_People", "manual")
 _GLADE_FILE = "mergeperson.glade"
 
-# translators: needed for French, ignore otherwise
+# Translators: needed for French, ignore otherwise
 KEYVAL = _("%(key)s:\t%(value)s")
 
 sex = ( _("female"), _("male"), _("unknown") )
@@ -214,7 +214,7 @@ class MergePerson(ManagedWindow):
                     self.add(tobj, normal,
                              KEYVAL % {'key': name, 'value': ev_info})
                 else:
-                    self.add(tobj, normal, # translators: needed for French
+                    self.add(tobj, normal, # Translators: needed for French
                              "%(name)s (%(role)s):\t%(info)s"
                                  % {'name': name, 'role': role,
                                     'info': ev_info})

--- a/gramps/gui/plug/_windows.py
+++ b/gramps/gui/plug/_windows.py
@@ -1117,7 +1117,7 @@ class UpdateAddons(ManagedWindow):
         last_category = None
         for (status,plugin_url,plugin_dict) in addon_update_list:
             count = get_count(addon_update_list, plugin_dict["t"])
-            # translators: needed for French, ignore otherwise
+            # Translators: needed for French, ignore otherwise
             category = _("%(str1)s: %(str2)s") % {'str1' : status,
                                                   'str2' : _(plugin_dict["t"])}
             if last_category != category:
@@ -1220,7 +1220,7 @@ class UpdateAddons(ManagedWindow):
         if count:
             self.rescan = True
             OkDialog(_("Done downloading and installing addons"),
-                     # translators: leave all/any {...} untranslated
+                     # Translators: leave all/any {...} untranslated
                      "%s %s" % (ngettext("{number_of} addon was installed.",
                                          "{number_of} addons were installed.",
                                          count).format(number_of=count),

--- a/gramps/gui/plug/export/_exportoptions.py
+++ b/gramps/gui/plug/export/_exportoptions.py
@@ -163,7 +163,7 @@ class WriterOptionBox:
         label = Gtk.Label(label=_("Unfiltered Family Tree:"))
         full_database_row.pack_start(label, True, True, 0)
         people_count = len(self.dbstate.db.get_person_handles())
-        # translators: leave all/any {...} untranslated
+        # Translators: leave all/any {...} untranslated
         button = Gtk.Button(label=ngettext("{number_of} Person",
                                            "{number_of} People", people_count
                                            ).format(number_of=people_count))
@@ -270,7 +270,7 @@ class WriterOptionBox:
         # Make a box and put the option in it:
         from gi.repository import Gtk
         from ...widgets import SimpleButton
-        # translators: leave all/any {...} untranslated
+        # Translators: leave all/any {...} untranslated
         button = Gtk.Button(label=ngettext("{number_of} Person",
                                            "{number_of} People", 0
                                            ).format(number_of=0))
@@ -578,7 +578,7 @@ class WriterOptionBox:
                 self.preview_proxy_button[proxy_name].set_sensitive(1)
                 people_count = len(dbase.get_person_handles())
                 self.preview_proxy_button[proxy_name].set_label(
-                    # translators: leave all/any {...} untranslated
+                    # Translators: leave all/any {...} untranslated
                     ngettext("{number_of} Person",
                              "{number_of} People", people_count
                             ).format(number_of=people_count) )

--- a/gramps/gui/plug/report/_reportdialog.py
+++ b/gramps/gui/plug/report/_reportdialog.py
@@ -373,7 +373,7 @@ class ReportDialog(ManagedWindow):
         for (text, widget) in self.widgets:
             widget.set_hexpand(True)
             if text:
-                # translators: needed for French, ignore otherwise
+                # Translators: needed for French, ignore otherwise
                 text_widget = Gtk.Label(label=_("%s:") % text)
                 text_widget.set_halign(Gtk.Align.START)
                 grid.attach(text_widget, 1, row, 1, 1)

--- a/gramps/plugins/drawreport/calendarreport.py
+++ b/gramps/plugins/drawreport/calendarreport.py
@@ -361,7 +361,7 @@ class Calendar(Report):
                             text = self._('%(person)s, birth') % {
                                                 'person' : short_name }
                         else:
-                            # translators: leave all/any {...} untranslated
+                            # Translators: leave all/any {...} untranslated
                             text = ngettext('{person}, {age}',
                                             '{person}, {age}',
                                             nyears).format(person=short_name,
@@ -423,7 +423,7 @@ class Calendar(Report):
                                                         'person' : short_name,
                                                         }
                                             else:
-                                                # translators: leave all/any {...} untranslated
+                                                # Translators: leave all/any {...} untranslated
                                                 text = ngettext("{spouse} and\n {person}, {nyears}",
                                                                 "{spouse} and\n {person}, {nyears}",
                                                                 nyears).format(spouse=spouse_name, person=short_name, nyears=nyears)

--- a/gramps/plugins/drawreport/descendtree.py
+++ b/gramps/plugins/drawreport/descendtree.py
@@ -354,7 +354,7 @@ class TitleC(DescendantTitleBase):
                 for kid in family.get_child_ref_list()]
 
         #ok we have the children.  Make a title off of them
-        # translators: needed for Arabic, ignore otherwise
+        # Translators: needed for Arabic, ignore otherwise
         cousin_names = self._(', ').join(self._get_names(kids, self._nd))
 
         self.text = self._(

--- a/gramps/plugins/gramplet/pedigreegramplet.py
+++ b/gramps/plugins/gramplet/pedigreegramplet.py
@@ -268,7 +268,7 @@ class PedigreeGramplet(Gramplet):
                           tooltip=_("Double-click to see people in generation %d") % g)
                 percent = glocale.format('%.2f', float(count)/2**(g-1) * 100) + percent_sign
                 self.append_text(
-                    # translators: leave all/any {...} untranslated
+                    # Translators: leave all/any {...} untranslated
                     ngettext(" has {count_person} of {max_count_person} "
                              "individuals ({percent} complete)\n",
                              " has {count_person} of {max_count_person} "
@@ -279,7 +279,7 @@ class PedigreeGramplet(Gramplet):
         self.link(_("All generations"), 'PersonList', all,
                   tooltip=_("Double-click to see all generations"))
         self.append_text(
-            # translators: leave all/any {...} untranslated
+            # Translators: leave all/any {...} untranslated
             ngettext(" have {number_of} individual\n",
                      " have {number_of} individuals\n", len(all)
                     ).format(number_of=len(all)))

--- a/gramps/plugins/gramplet/persondetails.py
+++ b/gramps/plugins/gramplet/persondetails.py
@@ -234,7 +234,7 @@ class PersonDetails(Gramplet):
             if attr.get_type() == attr_key:
                 values.append(attr.get_value())
         if values:
-            # translators: needed for Arabic, ignore otherwise
+            # Translators: needed for Arabic, ignore otherwise
             self.add_row(attr_key, _(', ').join(values))
 
     def display_type(self, active_person, event_type):

--- a/gramps/plugins/gramplet/sessionloggramplet.py
+++ b/gramps/plugins/gramplet/sessionloggramplet.py
@@ -86,7 +86,7 @@ class LogGramplet(Gramplet):
                 continue
             self.last_log = (ltype, action, handle)
             self.timestamp()
-            # translators: needed for French, ignore otherwise
+            # Translators: needed for French, ignore otherwise
             self.append_text(_("%s: ") % _(action))
             if action == 'Deleted':
                 transaction = self.dbstate.db.transaction

--- a/gramps/plugins/gramplet/whatsnext.py
+++ b/gramps/plugins/gramplet/whatsnext.py
@@ -490,7 +490,7 @@ class WhatNextGramplet(Gramplet):
             missingbits.append(_("place unknown"))
 
         if missingbits:
-            # translators: needed for French, ignore otherwise
+            # Translators: needed for French, ignore otherwise
             return [_("%(str1)s: %(str2)s"
                      ) % {'str1' : event.get_type(),
                           'str2' : _(", ").join(missingbits)}] # Arabic OK

--- a/gramps/plugins/graph/gvfamilylines.py
+++ b/gramps/plugins/graph/gvfamilylines.py
@@ -487,7 +487,7 @@ class FamilyLinesReport(Report):
             person = self._db.get_person_from_handle(handle)
             gid = person.get_gramps_id()
             name = person.get_primary_name().get_regular_name()
-            # Translators: needed for Arabic, ignore othewise
+            # Translators: needed for Arabic, ignore otherwise
             id_n = self._("%(str1)s, %(str2)s") % {'str1':gid, 'str2':name}
             self.doc.add_comment('# -> ' + id_n)
 

--- a/gramps/plugins/graph/gvfamilylines.py
+++ b/gramps/plugins/graph/gvfamilylines.py
@@ -487,7 +487,7 @@ class FamilyLinesReport(Report):
             person = self._db.get_person_from_handle(handle)
             gid = person.get_gramps_id()
             name = person.get_primary_name().get_regular_name()
-            # translators: needed for Arabic, ignore othewise
+            # Translators: needed for Arabic, ignore othewise
             id_n = self._("%(str1)s, %(str2)s") % {'str1':gid, 'str2':name}
             self.doc.add_comment('# -> ' + id_n)
 
@@ -978,7 +978,7 @@ class FamilyLinesReport(Report):
             if self._incchildcount:
                 child_count = len(family.get_child_ref_list())
                 if child_count >= 1:
-                    # translators: leave all/any {...} untranslated
+                    # Translators: leave all/any {...} untranslated
                     children_str = ngettext("{number_of} child",
                                             "{number_of} children", child_count
                                            ).format(number_of=child_count)

--- a/gramps/plugins/importer/importcsv.py
+++ b/gramps/plugins/importer/importcsv.py
@@ -370,7 +370,7 @@ class CSVParser:
             self.db.enable_signals()
             self.db.request_rebuild()
             tym = time.time() - tym
-            # translators: leave all/any {...} untranslated
+            # Translators: leave all/any {...} untranslated
             msg = ngettext('Import Complete: {number_of} second',
                            'Import Complete: {number_of} seconds', tym
                           ).format(number_of=tym)

--- a/gramps/plugins/importer/importgeneweb.py
+++ b/gramps/plugins/importer/importgeneweb.py
@@ -270,7 +270,7 @@ class GeneWebParser:
                 self.errmsg(str(err))
 
             t = time.time() - t
-            # translators: leave all/any {...} untranslated
+            # Translators: leave all/any {...} untranslated
             msg = ngettext('Import Complete: {number_of} second',
                            'Import Complete: {number_of} seconds', t
                           ).format(number_of=t)
@@ -906,7 +906,7 @@ class GeneWebParser:
                 date.set(Date.QUAL_NONE,mod, cal1,
                          (sub1[0],sub1[1],sub1[2],0,sub2[0],sub2[1],sub2[2],0))
             except DateError as e:
-                # TRANSLATORS: leave the {date} and {gw_snippet} untranslated
+                # Translators: leave the {date} and {gw_snippet} untranslated
                 # in the format string, but you may re-order them if needed.
                 LOG.warning(_(
                     "Invalid date {date} in {gw_snippet}, "

--- a/gramps/plugins/importer/importvcard.py
+++ b/gramps/plugins/importer/importvcard.py
@@ -245,7 +245,7 @@ class VCardParser:
         self.database.enable_signals()
         self.database.request_rebuild()
         tym = time.time() - tym
-        # translators: leave all/any {...} untranslated
+        # Translators: leave all/any {...} untranslated
         msg = ngettext('Import Complete: {number_of} second',
                        'Import Complete: {number_of} seconds', tym
                       ).format(number_of=tym)
@@ -511,7 +511,7 @@ class VCardParser:
             try:
                 date.set(value=(d, m, y, False))
             except DateError:
-                # TRANSLATORS: leave the {vcard_snippet} untranslated
+                # Translators: leave the {vcard_snippet} untranslated
                 # in the format string, but you may re-order it if needed.
                 self.__add_msg(_(
                     "Invalid date in BDAY {vcard_snippet}, "
@@ -520,7 +520,7 @@ class VCardParser:
                 date.set(modifier=Date.MOD_TEXTONLY, text=data)
         else:
             if date_str:
-                # TRANSLATORS: leave the {vcard_snippet} untranslated.
+                # Translators: leave the {vcard_snippet} untranslated.
                 self.__add_msg(_(
                     "Date {vcard_snippet} not in appropriate format "
                     "yyyy-mm-dd, preserving date as text."

--- a/gramps/plugins/importer/importxml.py
+++ b/gramps/plugins/importer/importxml.py
@@ -2523,7 +2523,7 @@ class GrampsParser(UpdateCallback):
             attrs = " ".join(
                 ['{}="{}"'.format(k,escape(v, entities={'"' : "&quot;"}))
                     for k,v in xml_attrs.items()]))
-        # TRANSLATORS: leave the {date} and {xml} untranslated in the format string,
+        # Translators: leave the {date} and {xml} untranslated in the format string,
         # but you may re-order them if needed.
         LOG.warning(_("Invalid date {date} in XML {xml}, preserving XML as text"
             ).format(date=date_error.date.__dict__, xml=xml))

--- a/gramps/plugins/lib/librecords.py
+++ b/gramps/plugins/lib/librecords.py
@@ -513,7 +513,7 @@ def _get_styled(name, callname, placeholder=False,
         elif callname == CALLNAME_UNDERLINE_ADD:
             if n.call not in n.first_name:
                 # Add call name to first name.
-                # translators: used in French+Russian, ignore otherwise
+                # Translators: used in French+Russian, ignore otherwise
                 n.first_name = trans_text('"%(callname)s" (%(firstname)s)') % {
                                              'callname':  n.call,
                                              'firstname': n.first_name }

--- a/gramps/plugins/lib/libtreebase.py
+++ b/gramps/plugins/lib/libtreebase.py
@@ -703,7 +703,7 @@ class PageNumberBox(BoxBase):
 
     def __calc_position(self, page):
         """ calculate where I am to print on the page(s) """
-        # translators: needed for Arabic, ignore otherwise
+        # Translators: needed for Arabic, ignore otherwise
         self.text = "(%d" + self._(',') + "%d)"
 
         style_sheet = self.doc.get_style_sheet()

--- a/gramps/plugins/quickview/filterbyname.py
+++ b/gramps/plugins/quickview/filterbyname.py
@@ -416,7 +416,7 @@ def run(database, document, filter_name, *args, **kwargs):
 
     else:
         raise AttributeError("invalid filter name: '%s'" % filter_name)
-    # translators: leave all/any {...} untranslated
+    # Translators: leave all/any {...} untranslated
     sdoc.paragraph(ngettext("Filter matched {number_of} record.",
                             "Filter matched {number_of} records.", matches
                            ).format(number_of=matches) )

--- a/gramps/plugins/quickview/samesurnames.py
+++ b/gramps/plugins/quickview/samesurnames.py
@@ -131,7 +131,7 @@ def run(database, document, person):
 
     document.has_data = matches > 0
     sdoc.paragraph(
-        # translators: leave all/any {...} untranslated
+        # Translators: leave all/any {...} untranslated
         ngettext("There is {number_of} person "
                      "with a matching name, or alternate name.\n",
                  "There are {number_of} people "
@@ -176,7 +176,7 @@ def run_given(database, document, person):
 
     document.has_data = matches > 0
     sdoc.paragraph(
-        # translators: leave all/any {...} untranslated
+        # Translators: leave all/any {...} untranslated
         ngettext("There is {number_of} person "
                      "with a matching name, or alternate name.\n",
                  "There are {number_of} people "

--- a/gramps/plugins/textreport/birthdayreport.py
+++ b/gramps/plugins/textreport/birthdayreport.py
@@ -334,7 +334,7 @@ class BirthdayReport(Report):
                                 'person'   : short_name,
                                 'relation' : comment}
                         else:
-                            # translators: leave all/any {...} untranslated
+                            # Translators: leave all/any {...} untranslated
                             text = ngettext('* {year}{person}{dead}, {age}{relation}',
                                             '* {year}{person}{dead}, {age}{relation}',
                                             nyears).format(year=yeartxt,
@@ -403,7 +403,7 @@ class BirthdayReport(Report):
                                                          'spouse' : spouse_name,
                                                          'person' : short_name}
                                             else:
-                                                # translators: leave all/any {...} untranslated
+                                                # Translators: leave all/any {...} untranslated
                                                 text = ngettext("⚭ {year}{spouse}{deadtxt2} and\n {person}{deadtxt1}, {nyears}",
                                                                 "⚭ {year}{spouse}{deadtxt2} and\n {person}{deadtxt1}, {nyears}",
                                                                 nyears).format(year=yeartxt, spouse=spouse_name, deadtxt2=deadtxt2, person=short_name, deadtxt1=deadtxt1, nyears=nyears)

--- a/gramps/plugins/textreport/detancestralreport.py
+++ b/gramps/plugins/textreport/detancestralreport.py
@@ -413,7 +413,7 @@ class DetAncestorReport(Report):
                     date = addr.get_date_object().get_year()
 
                 if date:
-                    # translators: needed for Arabic, ignore otherwise
+                    # Translators: needed for Arabic, ignore otherwise
                     self.doc.write_text(self._('%s, ') % date)
                 self.doc.write_text(text)
                 self.doc.write_text_citation(self.endnotes(addr))
@@ -426,7 +426,7 @@ class DetAncestorReport(Report):
             for attr in attrs:
                 self.doc.start_paragraph('DAR-MoreDetails')
                 attr_name = attr.get_type().type2base()
-                # translators: needed for French, ignore otherwise
+                # Translators: needed for French, ignore otherwise
                 text = self._("%(type)s: %(value)s%(endnotes)s"
                              ) % {'type'     : self._(attr_name),
                                   'value'    : attr.get_value(),
@@ -450,7 +450,7 @@ class DetAncestorReport(Report):
 
         self.doc.start_paragraph('DAR-MoreDetails')
         if date and place:
-            # translators: needed for Arabic, ignore otherwise
+            # Translators: needed for Arabic, ignore otherwise
             text += self._('%(str1)s, %(str2)s'
                           ) % {'str1' : date, 'str2' : place}
         elif date:
@@ -471,7 +471,7 @@ class DetAncestorReport(Report):
         event_name = self._(self._get_type(event.get_type()))
         role = event_ref.get_role()
         if role in (EventRoleType.PRIMARY, EventRoleType.FAMILY):
-            # translators: needed for French, ignore otherwise
+            # Translators: needed for French, ignore otherwise
             text = self._('%(str1)s: %(str2)s'
                          ) % {'str1' : event_name, 'str2' : text}
         else:
@@ -491,10 +491,10 @@ class DetAncestorReport(Report):
             attr_list.extend(event_ref.get_attribute_list())
             for attr in attr_list:
                 if text:
-                    # translators: needed for Arabic, ignore otherwise
+                    # Translators: needed for Arabic, ignore otherwise
                     text += self._("; ")
                 attr_name = attr.get_type().type2base()
-                # translators: needed for French, ignore otherwise
+                # Translators: needed for French, ignore otherwise
                 text += self._("%(type)s: %(value)s%(endnotes)s"
                               ) % {'type'     : self._(attr_name),
                                    'value'    : attr.get_value(),

--- a/gramps/plugins/textreport/detdescendantreport.py
+++ b/gramps/plugins/textreport/detdescendantreport.py
@@ -411,7 +411,7 @@ class DetDescendantReport(Report):
             if index == 1:
                 self.doc.write_text(name + "-" + str(index) + ") ")
             else:
-                # translators: needed for Arabic, ignore otherwise
+                # Translators: needed for Arabic, ignore otherwise
                 self.doc.write_text(name + "-" + str(index) + self._("; "))
             index -= 1
 
@@ -483,7 +483,7 @@ class DetDescendantReport(Report):
         self.doc.start_paragraph('DDR-MoreDetails')
         event_name = self._get_type(event.get_type())
         if date and place:
-            # translators: needed for Arabic, ignore otherwise
+            # Translators: needed for Arabic, ignore otherwise
             text += self._('%(str1)s, %(str2)s'
                           ) % {'str1' : date, 'str2' : place}
         elif date:
@@ -501,7 +501,7 @@ class DetDescendantReport(Report):
         if text:
             text += ". "
 
-        # translators: needed for French, ignore otherwise
+        # Translators: needed for French, ignore otherwise
         text = self._('%(str1)s: %(str2)s'
                      ) % {'str1' : self._(event_name),
                           'str2' : text}
@@ -514,10 +514,10 @@ class DetDescendantReport(Report):
             attr_list.extend(event_ref.get_attribute_list())
             for attr in attr_list:
                 if text:
-                    # translators: needed for Arabic, ignore otherwise
+                    # Translators: needed for Arabic, ignore otherwise
                     text += self._("; ")
                 attr_name = attr.get_type().type2base()
-                # translators: needed for French, ignore otherwise
+                # Translators: needed for French, ignore otherwise
                 text += self._("%(type)s: %(value)s%(endnotes)s"
                               ) % {'type'     : self._(attr_name),
                                    'value'    : attr.get_value(),
@@ -935,7 +935,7 @@ class DetDescendantReport(Report):
 
                 self.doc.write_text(self._('Address: '))
                 if date:
-                    # translators: needed for Arabic, ignore otherwise
+                    # Translators: needed for Arabic, ignore otherwise
                     self.doc.write_text(self._('%s, ') % date)
                 self.doc.write_text(text)
                 self.doc.write_text_citation(self.endnotes(addr))
@@ -954,7 +954,7 @@ class DetDescendantReport(Report):
             for attr in attrs:
                 self.doc.start_paragraph('DDR-MoreDetails')
                 attr_name = attr.get_type().type2base()
-                # translators: needed for French, ignore otherwise
+                # Translators: needed for French, ignore otherwise
                 text = self._("%(type)s: %(value)s%(endnotes)s"
                              ) % {'type'     : self._(attr_name),
                                   'value'    : attr.get_value(),

--- a/gramps/plugins/textreport/familygroup.py
+++ b/gramps/plugins/textreport/familygroup.py
@@ -133,10 +133,10 @@ class FamilyGroup(Report):
             if self.include_attrs:
                 for attr in event.get_attribute_list():
                     if descr:
-                        # translators: needed for Arabic, ignore otherwise
+                        # Translators: needed for Arabic, ignore otherwise
                         descr += self._("; ")
                     attr_type = self._get_type(attr.get_type())
-                    # translators: needed for French, ignore otherwise
+                    # Translators: needed for French, ignore otherwise
                     descr += self._("%(str1)s: %(str2)s"
                                    ) % {'str1' : self._(attr_type),
                                         'str2' : attr.get_value()}
@@ -302,7 +302,7 @@ class FamilyGroup(Report):
         self.doc.start_cell('FGR-ParentHead', 3)
         self.doc.start_paragraph('FGR-ParentName')
         mark = utils.get_person_mark(self.db, person)
-        # translators: needed for French, ignore otherwise
+        # Translators: needed for French, ignore otherwise
         self.doc.write_text(self._("%(str1)s: %(str2)s"
                                   ) % {'str1' : title,
                                        'str2' : name},
@@ -406,7 +406,7 @@ class FamilyGroup(Report):
             header = self._("Marriage")
             if self.gramps_ids:
                 header += " (%s)" % family.get_gramps_id()
-            # translators: needed for French, ignore otherwise
+            # Translators: needed for French, ignore otherwise
             self.doc.write_text(self._("%s:") % header)
             self.doc.end_paragraph()
             self.doc.end_cell()

--- a/gramps/plugins/textreport/indivcomplete.py
+++ b/gramps/plugins/textreport/indivcomplete.py
@@ -199,7 +199,7 @@ class IndivCompleteReport(Report):
             column_1 = self._(self._get_type(event.get_type()))
             if role not in (EventRoleType.PRIMARY, EventRoleType.FAMILY):
                 column_1 = column_1 + ' (' + self._(role.xml_str()) + ')'
-            # translators: needed for Arabic, ignore otherwise
+            # Translators: needed for Arabic, ignore otherwise
             # make sure it's translated, so it can be used below, in "combine"
             ignore = _('%(str1)s, %(str2)s') % {'str1' : '', 'str2' : ''}
             column_2 = self.combine('%(str1)s, %(str2)s', '%s',
@@ -207,7 +207,7 @@ class IndivCompleteReport(Report):
         else:
             # Groups with a single type (remove event type from first column)
             column_1 = date
-            # translators: needed for Arabic, ignore otherwise
+            # Translators: needed for Arabic, ignore otherwise
             # make sure it's translated, so it can be used below, in "combine"
             ignore = _('%(str1)s, %(str2)s') % {'str1' : '', 'str2' : ''}
             column_2 = self.combine('%(str1)s, %(str2)s', '%s',
@@ -919,7 +919,7 @@ class IndivCompleteReport(Report):
                     p_style = 'IDS-PersonTable' # this is tested for, also
                 else:
                     self._user.warn(_("Could not add photo to page"),
-                                    # translators: for French, else ignore
+                                    # Translators: for French, else ignore
                                     _("%(str1)s: %(str2)s"
                                      ) % {'str1' : image_filename,
                                           'str2' : _('File does not exist')})
@@ -927,7 +927,7 @@ class IndivCompleteReport(Report):
         self.doc.start_table('person', p_style)
         self.doc.start_row()
 
-        # translators: needed for French, ignore otherwise
+        # Translators: needed for French, ignore otherwise
         ignore = self._("%s:")
         self.doc.start_cell('IDS-NormalCell')
         self.write_paragraph(self._("%s:") % self._("Name"))
@@ -959,7 +959,7 @@ class IndivCompleteReport(Report):
             else:
                 for attr in attr_list:
                     attr_type = attr.get_type().type2base()
-                    # translators: needed for French, ignore otherwise
+                    # Translators: needed for French, ignore otherwise
                     text = self._("%(str1)s: %(str2)s"
                                  ) % {'str1' : self._(attr_type),
                                       'str2' : attr.get_value()}
@@ -1020,7 +1020,7 @@ class IndivCompleteReport(Report):
         if not txt:
             return prior
         if prior:
-            # translators: needed for Arabic, ignore otherwise
+            # Translators: needed for Arabic, ignore otherwise
             txt = self._('%(str1)s, %(str2)s') % {'str1':prior, 'str2':txt}
         return txt
 
@@ -1030,7 +1030,7 @@ class IndivCompleteReport(Report):
             return
         for attr in attr_list:
             attr_type = attr.get_type().type2base()
-            # translators: needed for French, ignore otherwise
+            # Translators: needed for French, ignore otherwise
             text = self._("%(str1)s: %(str2)s"
                          ) % {'str1' : self._(attr_type),
                               'str2' : attr.get_value()}

--- a/gramps/plugins/textreport/indivcomplete.py
+++ b/gramps/plugins/textreport/indivcomplete.py
@@ -247,7 +247,7 @@ class IndivCompleteReport(Report):
         self.doc.start_row()
         self.write_cell(label)
         if parent_name:
-            # for example (a stepfather): John Smith, relationship: Step
+            # Translators: e.g. (a stepfather): John Smith, relationship: Step
             text = self._('%(parent-name)s, relationship: %(rel-type)s'
                          ) % {'parent-name' : parent_name,
                               'rel-type'    : self._(rel_type)}

--- a/gramps/plugins/textreport/numberofancestorsreport.py
+++ b/gramps/plugins/textreport/numberofancestorsreport.py
@@ -120,7 +120,7 @@ class NumberOfAncestorsReport(Report):
 
                 # TC # English return something like:
                 # Generation 3 has 2 individuals. (50.00%)
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 text = ngettext(
                     "Generation {number} has {count} individual. {percent}",
                     "Generation {number} has {count} individuals. {percent}",

--- a/gramps/plugins/textreport/placereport.py
+++ b/gramps/plugins/textreport/placereport.py
@@ -181,7 +181,7 @@ class PlaceReport(Report):
 
         place_details = [self._("Gramps ID: %s ") % place.get_gramps_id()]
         for level in get_location_list(self._db, place):
-            # translators: needed for French, ignore otherwise
+            # Translators: needed for French, ignore otherwise
             place_details.append(self._("%(str1)s: %(str2)s"
                                        ) % {'str1': self._(level[1].xml_str()),
                                             'str2': level[0]})
@@ -191,7 +191,7 @@ class PlaceReport(Report):
         if len(all_names) > 1 or __debug__:
             for place_name in all_names:
                 if place_names != '':
-                    # translators: needed for Arabic, ignore otherwise
+                    # Translators: needed for Arabic, ignore otherwise
                     place_names += self._(", ")
                 place_names += '%s' % place_name.get_value()
                 if place_name.get_language() != '' or __debug__:

--- a/gramps/plugins/tool/changetypes.py
+++ b/gramps/plugins/tool/changetypes.py
@@ -133,7 +133,7 @@ class ChangeTypes(tool.BatchTool, ManagedWindow):
         if modified == 0:
             msg = _("No event record was modified.")
         else:
-            # translators: leave all/any {...} untranslated
+            # Translators: leave all/any {...} untranslated
             msg = ngettext("{number_of} event record was modified.",
                            "{number_of} event records were modified.", modified
                           ).format(number_of=modified)

--- a/gramps/plugins/tool/check.py
+++ b/gramps/plugins/tool/check.py
@@ -2458,7 +2458,7 @@ class CheckIntegrity:
 
         if blink > 0:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} broken child/family link was fixed\n",
                          "{quantity} broken child/family links were fixed\n",
                          blink).format(quantity=blink)
@@ -2484,7 +2484,7 @@ class CheckIntegrity:
 
         if plink > 0:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} broken spouse/family link was fixed\n",
                          "{quantity} broken spouse/family links were fixed\n",
                          plink).format(quantity=plink)
@@ -2510,7 +2510,7 @@ class CheckIntegrity:
 
         if slink > 0:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} duplicate "
                          "spouse/family link was found\n",
                          "{quantity} duplicate "
@@ -2538,7 +2538,7 @@ class CheckIntegrity:
 
         if efam:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} family "
                          "with no parents or children found, removed.\n",
                          "{quantity} families "
@@ -2550,7 +2550,7 @@ class CheckIntegrity:
 
         if rel:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} corrupted family relationship fixed\n",
                          "{quantity} corrupted family relationships fixed\n",
                          rel).format(quantity=rel)
@@ -2558,7 +2558,7 @@ class CheckIntegrity:
 
         if self.place_errors:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} place alternate name fixed\n",
                          "{quantity} place alternate names fixed\n",
                          self.place_errors).format(quantity=self.place_errors)
@@ -2566,7 +2566,7 @@ class CheckIntegrity:
 
         if person_references:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext(
                     "{quantity} person was referenced but not found\n",
                     "{quantity} persons were referenced, but not found\n",
@@ -2575,7 +2575,7 @@ class CheckIntegrity:
 
         if family_references:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} family was "
                          "referenced but not found\n",
                          "{quantity} families were "
@@ -2585,7 +2585,7 @@ class CheckIntegrity:
 
         if invalid_dates:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} date was corrected\n",
                          "{quantity} dates were corrected\n",
                          invalid_dates).format(quantity=invalid_dates)
@@ -2593,7 +2593,7 @@ class CheckIntegrity:
 
         if repo_references:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext(
                     "{quantity} repository was "
                     "referenced but not found\n",
@@ -2604,7 +2604,7 @@ class CheckIntegrity:
 
         if photos:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} media object was "
                          "referenced but not found\n",
                          "{quantity} media objects were "
@@ -2614,7 +2614,7 @@ class CheckIntegrity:
 
         if bad_photos:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext(
                     "Reference to {quantity} missing media object was kept\n",
                     "References to {quantity} missing media objects were kept\n",
@@ -2623,7 +2623,7 @@ class CheckIntegrity:
 
         if replaced_photos:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} missing media object was replaced\n",
                          "{quantity} missing media objects were replaced\n",
                          replaced_photos).format(quantity=replaced_photos)
@@ -2631,7 +2631,7 @@ class CheckIntegrity:
 
         if removed_photos:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} missing media object was removed\n",
                          "{quantity} missing media objects were removed\n",
                          removed_photos).format(quantity=removed_photos)
@@ -2639,7 +2639,7 @@ class CheckIntegrity:
 
         if event_invalid:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} event was referenced but not found\n",
                          "{quantity} events were referenced, but not found\n",
                          event_invalid).format(quantity=event_invalid)
@@ -2647,7 +2647,7 @@ class CheckIntegrity:
 
         if birth_invalid:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} invalid birth event name was fixed\n",
                          "{quantity} invalid birth event names were fixed\n",
                          birth_invalid).format(quantity=birth_invalid)
@@ -2655,7 +2655,7 @@ class CheckIntegrity:
 
         if death_invalid:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} invalid death event name was fixed\n",
                          "{quantity} invalid death event names were fixed\n",
                          death_invalid).format(quantity=death_invalid)
@@ -2663,7 +2663,7 @@ class CheckIntegrity:
 
         if place_references:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} place was referenced but not found\n",
                          "{quantity} places were referenced, but not found\n",
                          place_references).format(quantity=place_references)
@@ -2671,7 +2671,7 @@ class CheckIntegrity:
 
         if citation_references:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext(
                     "{quantity} citation was referenced but not found\n",
                     "{quantity} citations were referenced, but not found\n",
@@ -2681,7 +2681,7 @@ class CheckIntegrity:
 
         if source_references:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext(
                     "{quantity} source was referenced but not found\n",
                     "{quantity} sources were referenced, but not found\n",
@@ -2690,7 +2690,7 @@ class CheckIntegrity:
 
         if media_references:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext(
                     "{quantity} media object was referenced but not found\n",
                     "{quantity} media objects were referenced,"
@@ -2700,7 +2700,7 @@ class CheckIntegrity:
 
         if note_references:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} note object was "
                          "referenced but not found\n",
                          "{quantity} note objects were "
@@ -2710,7 +2710,7 @@ class CheckIntegrity:
 
         if tag_references:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} tag object was "
                          "referenced but not found\n",
                          "{quantity} tag objects were "
@@ -2720,7 +2720,7 @@ class CheckIntegrity:
 
         if tag_references:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} tag object was "
                          "referenced but not found\n",
                          "{quantity} tag objects were "
@@ -2730,7 +2730,7 @@ class CheckIntegrity:
 
         if name_format:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} invalid name format "
                          "reference was removed\n",
                          "{quantity} invalid name format "
@@ -2740,7 +2740,7 @@ class CheckIntegrity:
 
         if replaced_sourcerefs:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext(
                     "{quantity} invalid source citation was fixed\n",
                     "{quantity} invalid source citations were fixed\n",
@@ -2750,7 +2750,7 @@ class CheckIntegrity:
 
         if dup_gramps_ids > 0:
             self.text.write(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("{quantity} Duplicated Gramps ID fixed\n",
                          "{quantity} Duplicated Gramps IDs fixed\n",
                          dup_gramps_ids).format(quantity=dup_gramps_ids)

--- a/gramps/plugins/tool/eventnames.py
+++ b/gramps/plugins/tool/eventnames.py
@@ -116,7 +116,7 @@ class EventNames(tool.BatchTool):
         else:
             parent_window = None
         if self.change == True:
-            # translators: leave all/any {...} untranslated
+            # Translators: leave all/any {...} untranslated
             message = ngettext("{quantity} event description has been added",
                                "{quantity} event descriptions have been added",
                                counter).format(quantity=counter)

--- a/gramps/plugins/tool/mergecitations.py
+++ b/gramps/plugins/tool/mergecitations.py
@@ -231,7 +231,7 @@ class MergeCitations(tool.BatchTool,ManagedWindow):
         db.request_rebuild()
         self.progress.close()
         OkDialog(_("Number of merges done"),
-                 # translators: leave all/any {...} untranslated
+                 # Translators: leave all/any {...} untranslated
                  ngettext("{number_of} citation merged",
                           "{number_of} citations merged", num_merges
                          ).format(number_of=num_merges),

--- a/gramps/plugins/tool/notrelated.py
+++ b/gramps/plugins/tool/notrelated.py
@@ -257,7 +257,7 @@ class NotRelated(tool.ActivePersonTool, ManagedWindow):
                 progress = ProgressMeter(self.title, _('Starting'),
                                          parent=self.window)
                 progress.set_pass(
-                    # translators: leave all/any {...} untranslated
+                    # Translators: leave all/any {...} untranslated
                     #TRANS: no singular form needed, as rows is always > 1
                     ngettext("Setting tag for {number_of} person",
                              "Setting tag for {number_of} people",
@@ -300,7 +300,7 @@ class NotRelated(tool.ActivePersonTool, ManagedWindow):
     def findRelatedPeople(self):
 
         self.progress.set_pass(
-            # translators: leave all/any {...} untranslated
+            # Translators: leave all/any {...} untranslated
             #TRANS: No singular form is needed.
             ngettext("Finding relationships between {number_of} person",
                      "Finding relationships between {number_of} people",
@@ -381,7 +381,7 @@ class NotRelated(tool.ActivePersonTool, ManagedWindow):
             # we have at least 1 "unrelated" person to find
 
             self.progress.set_pass(
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 ngettext("Looking for {number_of} person",
                          "Looking for {number_of} people",
                          self.numberOfUnrelatedPeople
@@ -409,7 +409,7 @@ class NotRelated(tool.ActivePersonTool, ManagedWindow):
     def populateModel(self):
 
         self.progress.set_pass(
-            # translators: leave all/any {...} untranslated
+            # Translators: leave all/any {...} untranslated
             ngettext("Looking up the name of {number_of} person",
                      "Looking up the names of {number_of} people",
                      self.numberOfUnrelatedPeople

--- a/gramps/plugins/tool/verify.py
+++ b/gramps/plugins/tool/verify.py
@@ -314,7 +314,7 @@ class Verify(tool.Tool, ManagedWindow, UpdateCallback):
             severity_str = 'W'
         elif severity == Rule.ERROR:
             severity_str = 'E'
-        # translators: needed for French+Arabic, ignore otherwise
+        # Translators: needed for French+Arabic, ignore otherwise
         print(_("%(severity)s: %(msg)s, %(type)s: %(gid)s, %(name)s"
                ) % {'severity' : severity_str, 'msg' : msg, 'type' : the_type,
                     'gid' : gramps_id, 'name' : name})

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -1040,7 +1040,7 @@ class RelationshipView(NavigationView):
             else:
                 count = 0
             if count > 1 :
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 childmsg = ngettext(" ({number_of} sibling)",
                                     " ({number_of} siblings)", count
                                    ).format(number_of=count)
@@ -1095,7 +1095,7 @@ class RelationshipView(NavigationView):
                     else:
                         count = 0
                     if count > 1 :
-                        # translators: leave all/any {...} untranslated
+                        # Translators: leave all/any {...} untranslated
                         childmsg = ngettext(" ({number_of} sibling)",
                                             " ({number_of} siblings)", count
                                            ).format(number_of=count)
@@ -1560,7 +1560,7 @@ class RelationshipView(NavigationView):
             else:
                 count = 0
             if count >= 1 :
-                # translators: leave all/any {...} untranslated
+                # Translators: leave all/any {...} untranslated
                 childmsg = ngettext(" ({number_of} child)",
                                     " ({number_of} children)", count
                                    ).format(number_of=count)
@@ -1606,7 +1606,7 @@ class RelationshipView(NavigationView):
                 else:
                     count = 0
                 if count >= 1 :
-                    # translators: leave all/any {...} untranslated
+                    # Translators: leave all/any {...} untranslated
                     childmsg = ngettext(" ({number_of} child)",
                                         " ({number_of} children)", count
                                        ).format(number_of=count)

--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -197,7 +197,7 @@ class BasePage:
         else:
             self.rlocale = report.set_locale(report.options['trans'])
         self._ = self.rlocale.translation.sgettext
-        self.colon = self._(':') # translators: needed for French, else ignore
+        self.colon = self._(':') # Translators: needed for French, else ignore
 
         if report.options['securesite']:
             self.secure_mode = HTTPS

--- a/gramps/plugins/webreport/calendar.py
+++ b/gramps/plugins/webreport/calendar.py
@@ -1359,7 +1359,7 @@ def get_day_list(event_date, holiday_list, bday_anniv_list, rlocale=glocale):
                 age = ", <font size='+1' ><b>%s</b></font> <em>%s (%s)" % (
                     death_symbol, mess, age_at_death)
             else:
-                # TRANSLATORS: expands to smth like "12 years old",
+                # Translators: expands to smth like "12 years old",
                 # where "12 years" is already localized to your language
                 age = ', <em>'
                 date_y = date.get_year()
@@ -1397,7 +1397,7 @@ def get_day_list(event_date, holiday_list, bday_anniv_list, rlocale=glocale):
                         txt_str += "</em>"
                 else:
                     age = '<em>%s' % nyears
-                    # translators: leave all/any {...} untranslated
+                    # Translators: leave all/any {...} untranslated
                     ngettext = rlocale.translation.ngettext
                     txt_str = ngettext("{couple}, {years} year anniversary",
                                        "{couple}, {years} year anniversary",

--- a/gramps/plugins/webreport/webcal.py
+++ b/gramps/plugins/webreport/webcal.py
@@ -2177,7 +2177,7 @@ def get_day_list(event_date, holiday_list, bday_anniv_list, rlocale=glocale):
                 age = ", <font size='+1' ><b>%s</b></font> <em>%s (%s)" % (
                     death_symbol, mess, age_at_death)
             else:
-                # TRANSLATORS: expands to smth like "12 years old",
+                # Translators: expands to smth like "12 years old",
                 # where "12 years" is already localized to your language
                 age = ', <em>'
                 date_y = date.get_year()
@@ -2215,7 +2215,7 @@ def get_day_list(event_date, holiday_list, bday_anniv_list, rlocale=glocale):
                         txt_str += "</em>"
                 else:
                     age = '<em>%s' % nyears
-                    # translators: leave all/any {...} untranslated
+                    # Translators: leave all/any {...} untranslated
                     ngettext = rlocale.translation.ngettext
                     txt_str = ngettext("{couple}, {years} year anniversary",
                                        "{couple}, {years} year anniversary",

--- a/gramps/plugins/webstuff/webstuff.py
+++ b/gramps/plugins/webstuff/webstuff.py
@@ -57,31 +57,31 @@ def load_on_reg(dbstate, uistate, plugin):
         # "default" is used as default
 
         # default style sheet in the options
-        # Basic Ash style sheet
+        # Translators: Basic Ash style sheet
         ["Basic-Ash", 1, _("Basic-Ash"),
          path_css('Web_Basic-Ash.css'), None, [], []],
 
-        # Basic Blue style sheet with navigation menus
+        # Translators: Basic Blue style sheet with navigation menus
         ["Basic-Blue", 1, _("Basic-Blue"),
          path_css('Web_Basic-Blue.css'), None, [], []],
 
-        # Basic Cypress style sheet
+        # Translators: Basic Cypress style sheet
         ["Basic-Cypress", 1, _("Basic-Cypress"),
          path_css('Web_Basic-Cypress.css'), None, [], []],
 
-        # basic Lilac style sheet
+        # Translators: Basic Lilac style sheet
         ["Basic-Lilac", 1, _("Basic-Lilac"),
          path_css('Web_Basic-Lilac.css'), None, [], []],
 
-        # basic Peach style sheet
+        # Translators: Basic Peach style sheet
         ["Basic-Peach", 1, _("Basic-Peach"),
          path_css('Web_Basic-Peach.css'), None, [], []],
 
-        # basic Spruce style sheet
+        # Translators: Basic Spruce style sheet
         ["Basic-Spruce", 1, _("Basic-Spruce"),
          path_css('Web_Basic-Spruce.css'), None, [], []],
 
-        # Mainz style sheet with its images
+        # Translators: Mainz style sheet with its images
         ["Mainz", 1, _("Mainz"),
          path_css('Web_Mainz.css'), None,
          [path_img("Web_Mainz_Bkgd.png"),
@@ -89,11 +89,11 @@ def load_on_reg(dbstate, uistate, plugin):
           path_img("Web_Mainz_Mid.png"),
           path_img("Web_Mainz_MidLight.png")], []],
 
-        # Nebraska style sheet
+        # Translators: Nebraska style sheet
         ["Nebraska", 1, _("Nebraska"),
          path_css('Web_Nebraska.css'), None, [], []],
 
-        # Visually Impaired style sheet with its navigation menus
+        # Translators: Visually Impaired style sheet with its navigation menus
         ["Visually Impaired", 1, _("Visually Impaired"),
          path_css('Web_Visually.css'), "narrative-menus.css", [], []],
 

--- a/po/gramps.pot
+++ b/po/gramps.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-24 23:01+0100\n"
+"POT-Creation-Date: 2021-06-01 14:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -247,28 +247,27 @@ msgstr ""
 msgid "Russia"
 msgstr ""
 
-#: ../data/holidays.xml:400
+#: ../data/holidays.xml:403
 msgid "Serbia"
 msgstr ""
 
-#: ../data/holidays.xml:415
+#: ../data/holidays.xml:418
 msgid "Serbia (Latin)"
 msgstr ""
 
-#: ../data/holidays.xml:430
+#: ../data/holidays.xml:433
 msgid "Slovakia"
 msgstr ""
 
-#. Make upper case of translated country so string search works later
-#: ../data/holidays.xml:447 ../gramps/plugins/mapservices/eniroswedenmap.py:47
+#: ../data/holidays.xml:450 ../gramps/plugins/mapservices/eniroswedenmap.py:47
 msgid "Sweden"
 msgstr ""
 
-#: ../data/holidays.xml:474
+#: ../data/holidays.xml:477
 msgid "Ukraine"
 msgstr ""
 
-#: ../data/holidays.xml:501
+#: ../data/holidays.xml:504
 msgid "United States of America"
 msgstr ""
 
@@ -876,7 +875,7 @@ msgstr ""
 msgid "Family Tree"
 msgstr ""
 
-#. translators: used in French+Russian, ignore otherwise
+#. Translators: used in French+Russian, ignore otherwise
 #: ../gramps/cli/arghandler.py:445 ../gramps/cli/arghandler.py:449
 #, python-format
 msgid "\"%s\""
@@ -944,7 +943,6 @@ msgstr ""
 msgid "Ignoring invalid options string."
 msgstr ""
 
-#. name exists, but is not in the list of valid report names
 #: ../gramps/cli/arghandler.py:637
 msgid "Unknown report name."
 msgstr ""
@@ -1133,12 +1131,11 @@ msgstr ""
 msgid "Current Gramps config setting: %(name)s:%(value)s"
 msgstr ""
 
-#. does a user want the default config value?
 #: ../gramps/cli/argparser.py:380
 msgid "DEFAULT"
 msgstr ""
 
-#. translators: indent "New" to match "Current"
+#. Translators: indent "New" to match "Current"
 #: ../gramps/cli/argparser.py:387
 #, python-format
 msgid "    New Gramps config setting: %(name)s:%(value)s"
@@ -1196,9 +1193,9 @@ msgstr ""
 msgid "Family Tree \"%s\":"
 msgstr ""
 
-#. translators: needed for French, ignore otherwise
-#. translators: for French, else ignore
-#. translators: needed for French, ignore otherwise
+#. Translators: needed for French, ignore otherwise
+#. Translators: for French, else ignore
+#. Translators: needed for French, ignore otherwise
 #: ../gramps/cli/clidbman.py:201 ../gramps/gen/plug/report/utils.py:159
 #: ../gramps/gui/editors/editattribute.py:135
 #: ../gramps/gui/editors/editname.py:310 ../gramps/gui/plug/_windows.py:685
@@ -1230,7 +1227,6 @@ msgstr ""
 msgid "Import finished..."
 msgstr ""
 
-#. Create a new database
 #: ../gramps/cli/clidbman.py:366 ../gramps/plugins/importer/importcsv.py:362
 msgid "Importing data..."
 msgstr ""
@@ -1271,24 +1267,11 @@ msgstr ""
 msgid "Never"
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/cli/clidbman.py:551
 #, python-format
 msgid "Locked by %s"
 msgstr ""
 
-#. allow deferred translation of attribute UI strings
-#. Pro-Gen has a text field for the date.
-#. It can be anything (it should be dd-mm-yyyy), but we have seen:
-#. yyyy
-#. mm-yyyy
-#. before yyyy
-#. dd=mm-yyyy  (typo I guess)
-#. 00-00-yyyy
-#. oo-oo-yyyy
-#. dd-mm-00 (does this mean we do not know about the year?)
-#. Function tries to parse the text and create a proper Gramps Date()
-#. object. If all else fails create a MOD_TEXTONLY Date() object.
 #: ../gramps/cli/clidbman.py:553 ../gramps/gen/lib/attrtype.py:63
 #: ../gramps/gen/lib/childreftype.py:73 ../gramps/gen/lib/eventroletype.py:52
 #: ../gramps/gen/lib/eventtype.py:162 ../gramps/gen/lib/familyreltype.py:50
@@ -1429,7 +1412,6 @@ msgid ""
 "use."
 msgstr ""
 
-#. already errors encountered. Show first one on terminal and exit
 #: ../gramps/cli/grampscli.py:322
 #, python-format
 msgid "Error encountered: %s"
@@ -1520,7 +1502,7 @@ msgstr ""
 msgid "CSS filename to use, html format only"
 msgstr ""
 
-#. translators: needed for French, Hebrew and Arabic
+#. Translators: needed for French, Hebrew and Arabic
 #: ../gramps/cli/plug/__init__.py:416
 #, python-format
 msgid "%(id)s:\t%(father)s, %(mother)s"
@@ -1535,8 +1517,7 @@ msgstr ""
 msgid "   Valid options are:"
 msgstr ""
 
-#. ok we have the children.  Make a title off of them
-#. translators: needed for Arabic, ignore otherwise
+#. Translators: needed for Arabic, ignore otherwise
 #: ../gramps/cli/plug/__init__.py:463 ../gramps/cli/plug/__init__.py:553
 #: ../gramps/plugins/drawreport/descendtree.py:358
 #: ../gramps/plugins/drawreport/fanchart.py:364
@@ -1591,7 +1572,6 @@ msgstr ""
 msgid "   Available values are:"
 msgstr ""
 
-#. there was a show option given, but the option is invalid
 #: ../gramps/cli/plug/__init__.py:652
 #, python-format
 msgid ""
@@ -1647,8 +1627,7 @@ msgstr ""
 msgid "Private Record"
 msgstr ""
 
-#. enable a simple CLI test to see if the datestrings exist
-#. TRANSLATORS: see
+#. Translators: see
 #. http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
 #. to learn how to select proper inflection to be used in your localized
 #. DateDisplayer code!
@@ -1694,347 +1673,336 @@ msgstr ""
 msgid "Date displayer for '%s' not available, using default"
 msgstr ""
 
-#. format 0 - must always be ISO
-#: ../gramps/gen/datehandler/_datedisplay.py:70
+#. Translators: Numeric year, month, day
+#: ../gramps/gen/datehandler/_datedisplay.py:71
 msgid "YYYY-MM-DD (ISO)"
 msgstr ""
 
-#. format # 1 - must always be locale-preferred numerical format
-#. such as YY.MM.DD, MM-DD-YY, or whatever your locale prefers.
-#. This should be the format that is used under the locale by
-#. strftime() for '%x'.
-#. You may translate this as "Numerical", "System preferred", or similar.
-#: ../gramps/gen/datehandler/_datedisplay.py:77
+#. Translators: You may translate this as "Numerical",
+#. "System preferred", or similar.
+#: ../gramps/gen/datehandler/_datedisplay.py:79
 msgctxt "date format"
 msgid "Numerical"
 msgstr ""
 
-#. Full month name, day, year
-#: ../gramps/gen/datehandler/_datedisplay.py:80
+#. Translators: Full month name, day, year
+#: ../gramps/gen/datehandler/_datedisplay.py:82
 msgid "Month Day, Year"
 msgstr ""
 
-#. Abbreviated month name, day, year
-#: ../gramps/gen/datehandler/_datedisplay.py:83
+#. Translators: Abbreviated month name, day, year
+#: ../gramps/gen/datehandler/_datedisplay.py:85
 msgid "MON DAY, YEAR"
 msgstr ""
 
-#. Day, full month name, year
-#: ../gramps/gen/datehandler/_datedisplay.py:86
+#. Translators: Day, full month name, year
+#: ../gramps/gen/datehandler/_datedisplay.py:88
 msgid "Day Month Year"
 msgstr ""
 
-#. Day, abbreviated month name, year
-#: ../gramps/gen/datehandler/_datedisplay.py:89
+#. Translators: Day, abbreviated month name, year
+#: ../gramps/gen/datehandler/_datedisplay.py:91
 msgid "DAY MON YEAR"
 msgstr ""
 
-#: ../gramps/gen/datehandler/_datedisplay.py:181
+#: ../gramps/gen/datehandler/_datedisplay.py:183
 #, python-brace-format
 msgid "{long_month} {year}"
 msgstr ""
 
-#. first date in a span
-#. If "from <Month>" needs a special inflection in your
-#. language, translate this to "{long_month.f[X]} {year}"
+#. Translators: If "from <Month>" needs a special inflection
+#. in your language, translate to "{long_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:189
+#: ../gramps/gen/datehandler/_datedisplay.py:191
 #, python-brace-format
 msgctxt "from"
 msgid "{long_month} {year}"
 msgstr ""
 
-#. second date in a span
-#. If "to <Month>" needs a special inflection in your
-#. language, translate this to "{long_month.f[X]} {year}"
+#. Translators: If "to <Month>" needs a special inflection
+#. in your language, translate to "{long_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:197
+#: ../gramps/gen/datehandler/_datedisplay.py:199
 #, python-brace-format
 msgctxt "to"
 msgid "{long_month} {year}"
 msgstr ""
 
-#. first date in a range
-#. If "between <Month>" needs a special inflection in your
-#. language, translate this to "{long_month.f[X]} {year}"
+#. Translators: If "between <Month>" needs a special inflection
+#. in your language, translate to "{long_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:205
+#: ../gramps/gen/datehandler/_datedisplay.py:207
 #, python-brace-format
 msgctxt "between"
 msgid "{long_month} {year}"
 msgstr ""
 
-#. second date in a range
-#. If "and <Month>" needs a special inflection in your
-#. language, translate this to "{long_month.f[X]} {year}"
+#. Translators: If "and <Month>" needs a special inflection
+#. in your language, translate to "{long_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:213
+#: ../gramps/gen/datehandler/_datedisplay.py:215
 #, python-brace-format
 msgctxt "and"
 msgid "{long_month} {year}"
 msgstr ""
 
-#. If "before <Month>" needs a special inflection in your
-#. language, translate this to "{long_month.f[X]} {year}"
+#. Translators: If "before <Month>" needs a special inflection
+#. in your language, translate to "{long_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:220
+#: ../gramps/gen/datehandler/_datedisplay.py:222
 #, python-brace-format
 msgctxt "before"
 msgid "{long_month} {year}"
 msgstr ""
 
-#. If "after <Month>" needs a special inflection in your
-#. language, translate this to "{long_month.f[X]} {year}"
+#. Translators: If "after <Month>" needs a special inflection
+#. in your language, translate to "{long_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:227
+#: ../gramps/gen/datehandler/_datedisplay.py:229
 #, python-brace-format
 msgctxt "after"
 msgid "{long_month} {year}"
 msgstr ""
 
-#. If "about <Month>" needs a special inflection in your
-#. language, translate this to "{long_month.f[X]} {year}"
+#. Translators: If "about <Month>" needs a special inflection
+#. in your language, translate to "{long_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:234
+#: ../gramps/gen/datehandler/_datedisplay.py:236
 #, python-brace-format
 msgctxt "about"
 msgid "{long_month} {year}"
 msgstr ""
 
-#. If "estimated <Month>" needs a special inflection in your
-#. language, translate this to "{long_month.f[X]} {year}"
+#. Translators: If "estimated <Month>" needs a special inflection
+#. in your language, translate to "{long_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:241
+#: ../gramps/gen/datehandler/_datedisplay.py:243
 #, python-brace-format
 msgctxt "estimated"
 msgid "{long_month} {year}"
 msgstr ""
 
-#. If "calculated <Month>" needs a special inflection in your
-#. language, translate this to "{long_month.f[X]} {year}"
+#. Translators: If "calculated <Month>" needs a special inflection
+#. in your language, translate to "{long_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:248
+#: ../gramps/gen/datehandler/_datedisplay.py:250
 #, python-brace-format
 msgctxt "calculated"
 msgid "{long_month} {year}"
 msgstr ""
 
-#: ../gramps/gen/datehandler/_datedisplay.py:253
+#: ../gramps/gen/datehandler/_datedisplay.py:255
 #, python-brace-format
 msgid "{short_month} {year}"
 msgstr ""
 
-#. first date in a span
-#. If "from <Month>" needs a special inflection in your
-#. language, translate this to "{short_month.f[X]} {year}"
+#. Translators: If "from <Month>" needs a special inflection
+#. in your language, translate to "{short_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:261
+#: ../gramps/gen/datehandler/_datedisplay.py:263
 #, python-brace-format
 msgctxt "from"
 msgid "{short_month} {year}"
 msgstr ""
 
-#. second date in a span
-#. If "to <Month>" needs a special inflection in your
-#. language, translate this to "{short_month.f[X]} {year}"
+#. Translators: If "to <Month>" needs a special inflection
+#. in your language, translate to "{short_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:269
+#: ../gramps/gen/datehandler/_datedisplay.py:271
 #, python-brace-format
 msgctxt "to"
 msgid "{short_month} {year}"
 msgstr ""
 
-#. first date in a range
-#. If "between <Month>" needs a special inflection in your
-#. language, translate this to "{short_month.f[X]} {year}"
+#. Translators: If "between <Month>" needs a special inflection
+#. in your language, translate to "{short_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:277
+#: ../gramps/gen/datehandler/_datedisplay.py:279
 #, python-brace-format
 msgctxt "between"
 msgid "{short_month} {year}"
 msgstr ""
 
-#. second date in a range
-#. If "and <Month>" needs a special inflection in your
-#. language, translate this to "{short_month.f[X]} {year}"
+#. Translators: If "and <Month>" needs a special inflection
+#. in your language, translate to "{short_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:285
+#: ../gramps/gen/datehandler/_datedisplay.py:287
 #, python-brace-format
 msgctxt "and"
 msgid "{short_month} {year}"
 msgstr ""
 
-#. If "before <Month>" needs a special inflection in your
-#. language, translate this to "{short_month.f[X]} {year}"
+#. Translators: If "before <Month>" needs a special inflection
+#. in your language, translate to "{short_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:292
+#: ../gramps/gen/datehandler/_datedisplay.py:294
 #, python-brace-format
 msgctxt "before"
 msgid "{short_month} {year}"
 msgstr ""
 
-#. If "after <Month>" needs a special inflection in your
-#. language, translate this to "{short_month.f[X]} {year}"
+#. Translators: If "after <Month>" needs a special inflection
+#. in your language, translate to "{short_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:299
+#: ../gramps/gen/datehandler/_datedisplay.py:301
 #, python-brace-format
 msgctxt "after"
 msgid "{short_month} {year}"
 msgstr ""
 
-#. If "about <Month>" needs a special inflection in your
-#. language, translate this to "{short_month.f[X]} {year}"
+#. Translators: If "about <Month>" needs a special inflection
+#. in your language, translate to "{short_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:306
+#: ../gramps/gen/datehandler/_datedisplay.py:308
 #, python-brace-format
 msgctxt "about"
 msgid "{short_month} {year}"
 msgstr ""
 
-#. If "estimated <Month>" needs a special inflection in your
-#. language, translate this to "{short_month.f[X]} {year}"
+#. Translators: If "estimated <Month>" needs a special inflection
+#. in your language, translate to "{short_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:313
+#: ../gramps/gen/datehandler/_datedisplay.py:315
 #, python-brace-format
 msgctxt "estimated"
 msgid "{short_month} {year}"
 msgstr ""
 
-#. If "calculated <Month>" needs a special inflection in your
-#. language, translate this to "{short_month.f[X]} {year}"
+#. Translators: If "calculated <Month>" needs a special inflection
+#. in your language, translate to "{short_month.f[X]} {year}"
 #. (where X is one of the month-name inflections you defined)
 #. else leave it untranslated
-#: ../gramps/gen/datehandler/_datedisplay.py:320
+#: ../gramps/gen/datehandler/_datedisplay.py:322
 #, python-brace-format
 msgctxt "calculated"
 msgid "{short_month} {year}"
 msgstr ""
 
-#. If there is no special inflection for "from <Month>"
-#. in your language, DON'T translate this string.  Otherwise,
-#. "translate" this to "from" in ENGLISH!!! ENGLISH!!!
-#: ../gramps/gen/datehandler/_datedisplay.py:427
+#. Translators: If there is no special inflection for
+#. "from <Month>" in your language, DON'T translate this.
+#. Otherwise, translate to "from" in ENGLISH!!! ENGLISH!!!
+#: ../gramps/gen/datehandler/_datedisplay.py:429
 msgctxt "from-date"
 msgid ""
 msgstr ""
 
-#. If there is no special inflection for "to <Month>"
-#. in your language, DON'T translate this string.  Otherwise,
-#. "translate" this to "to" in ENGLISH!!! ENGLISH!!!
-#: ../gramps/gen/datehandler/_datedisplay.py:432
+#. Translators: If there is no special inflection for
+#. "to <Month>" in your language, DON'T translate this.
+#. Otherwise, translate to "to" in ENGLISH!!! ENGLISH!!!
+#: ../gramps/gen/datehandler/_datedisplay.py:434
 msgctxt "to-date"
 msgid ""
 msgstr ""
 
-#: ../gramps/gen/datehandler/_datedisplay.py:433
+#: ../gramps/gen/datehandler/_datedisplay.py:435
 #, python-brace-format
 msgid "{date_quality}from {date_start} to {date_stop}{nonstd_calendar_and_ny}"
 msgstr ""
 
-#. If there is no special inflection for "between <Month>"
-#. in your language, DON'T translate this string.  Otherwise,
-#. "translate" this to "between" in ENGLISH!!! ENGLISH!!!
-#: ../gramps/gen/datehandler/_datedisplay.py:452
+#. Translators: If there is no special inflection for
+#. "between <Month>" in your language, DON'T translate this.
+#. Otherwise, translate to "between" in ENGLISH!!! ENGLISH!!!
+#: ../gramps/gen/datehandler/_datedisplay.py:454
 msgctxt "between-date"
 msgid ""
 msgstr ""
 
-#. If there is no special inflection for "and <Month>"
-#. in your language, DON'T translate this string.  Otherwise,
-#. "translate" this to "and" in ENGLISH!!! ENGLISH!!!
-#: ../gramps/gen/datehandler/_datedisplay.py:457
+#. Translators: If there is no special inflection for
+#. "and <Month>" in your language, DON'T translate this.
+#. Otherwise, translate to "and" in ENGLISH!!! ENGLISH!!!
+#: ../gramps/gen/datehandler/_datedisplay.py:459
 msgctxt "and-date"
 msgid ""
 msgstr ""
 
-#: ../gramps/gen/datehandler/_datedisplay.py:458
+#: ../gramps/gen/datehandler/_datedisplay.py:460
 #, python-brace-format
 msgid ""
 "{date_quality}between {date_start} and {date_stop}{nonstd_calendar_and_ny}"
 msgstr ""
 
-#. If there is no special inflection for "before <Month>"
-#. in your language, DON'T translate this string.  Otherwise,
-#. "translate" this to "before" in ENGLISH!!! ENGLISH!!!
-#: ../gramps/gen/datehandler/_datedisplay.py:491
+#. Translators: If there is no special inflection for
+#. "before <Month>" in your language, DON'T translate this.
+#. Otherwise, translate to "before" in ENGLISH!!! ENGLISH!!!
+#: ../gramps/gen/datehandler/_datedisplay.py:493
 msgctxt "before-date"
 msgid ""
 msgstr ""
 
-#. If there is no special inflection for "after <Month>"
-#. in your language, DON'T translate this string.  Otherwise,
-#. "translate" this to "after" in ENGLISH!!! ENGLISH!!!
-#: ../gramps/gen/datehandler/_datedisplay.py:496
+#. Translators: If there is no special inflection for
+#. "after <Month>" in your language, DON'T translate this.
+#. Otherwise, translate to "after" in ENGLISH!!! ENGLISH!!!
+#: ../gramps/gen/datehandler/_datedisplay.py:498
 msgctxt "after-date"
 msgid ""
 msgstr ""
 
-#. If there is no special inflection for "about <Month>"
-#. in your language, DON'T translate this string.  Otherwise,
-#. "translate" this to "about" in ENGLISH!!! ENGLISH!!!
-#: ../gramps/gen/datehandler/_datedisplay.py:501
+#. Translators: If there is no special inflection for
+#. "about <Month>" in your language, DON'T translate this.
+#. Otherwise, translate to "about" in ENGLISH!!! ENGLISH!!!
+#: ../gramps/gen/datehandler/_datedisplay.py:503
 msgctxt "about-date"
 msgid ""
 msgstr ""
 
-#. If there is no special inflection for "estimated <Month>"
-#. in your language, DON'T translate this string.  Otherwise,
-#. "translate" this to "estimated" in ENGLISH!!! ENGLISH!!!
-#: ../gramps/gen/datehandler/_datedisplay.py:506
+#. Translators: If there is no special inflection for
+#. "estimated <Month>" in your language, DON'T translate this.
+#. Otherwise, translate to "estimated" in ENGLISH!!! ENGLISH!!!
+#: ../gramps/gen/datehandler/_datedisplay.py:508
 msgctxt "estimated-date"
 msgid ""
 msgstr ""
 
-#. If there is no special inflection for "calculated <Month>"
-#. in your language, DON'T translate this string.  Otherwise,
-#. "translate" this to "calculated" in ENGLISH!!! ENGLISH!!!
-#: ../gramps/gen/datehandler/_datedisplay.py:511
+#. Translators: If there is no special inflection for
+#. "calculated <Month>" in your language, DON'T translate this.
+#. Otherwise, translate to "calculated" in ENGLISH!!! ENGLISH!!!
+#: ../gramps/gen/datehandler/_datedisplay.py:513
 msgctxt "calculated-date"
 msgid ""
 msgstr ""
 
-#: ../gramps/gen/datehandler/_datedisplay.py:530
+#: ../gramps/gen/datehandler/_datedisplay.py:532
 #, python-brace-format
 msgid "{date_quality}{noncompound_modifier}{date}{nonstd_calendar_and_ny}"
 msgstr ""
 
-#. TRANSLATORS: this month is ALREADY inflected: ignore it
-#: ../gramps/gen/datehandler/_datedisplay.py:649
+#. Translators: this month is ALREADY inflected: ignore it
+#: ../gramps/gen/datehandler/_datedisplay.py:651
 #, python-brace-format
 msgid "{long_month} {day:d}, {year}"
 msgstr ""
 
-#. TRANSLATORS: this month is ALREADY inflected: ignore it
-#: ../gramps/gen/datehandler/_datedisplay.py:675
+#. Translators: this month is ALREADY inflected: ignore it
+#: ../gramps/gen/datehandler/_datedisplay.py:677
 #, python-brace-format
 msgid "{short_month} {day:d}, {year}"
 msgstr ""
 
-#. TRANSLATORS: this month is ALREADY inflected: ignore it
-#: ../gramps/gen/datehandler/_datedisplay.py:701
+#. Translators: this month is ALREADY inflected: ignore it
+#: ../gramps/gen/datehandler/_datedisplay.py:703
 #, python-brace-format
 msgid "{day:d} {long_month} {year}"
 msgstr ""
 
-#. TRANSLATORS: this month is ALREADY inflected: ignore it
-#: ../gramps/gen/datehandler/_datedisplay.py:727
+#. Translators: this month is ALREADY inflected: ignore it
+#: ../gramps/gen/datehandler/_datedisplay.py:729
 #, python-brace-format
 msgid "{day:d} {short_month} {year}"
 msgstr ""
@@ -2098,7 +2066,7 @@ msgctxt "localized lexeme inflections"
 msgid "|December"
 msgstr ""
 
-#. TRANSLATORS: see
+#. Translators: see
 #. http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
 #. to learn how to select proper inflection to be used in your localized
 #. DateDisplayer code!
@@ -2162,7 +2130,7 @@ msgctxt "localized lexeme inflections - short month form"
 msgid "|Dec"
 msgstr ""
 
-#. TRANSLATORS: see
+#. Translators: see
 #. http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
 #. to learn how to add proper alternatives to be recognized in your localized
 #. DateParser code!
@@ -2226,7 +2194,6 @@ msgctxt "alternative month names for December"
 msgid "|"
 msgstr ""
 
-#. Must appear in the order indexed by Date.CAL_... numeric constants
 #: ../gramps/gen/datehandler/_datestrings.py:131 ../gramps/gen/lib/date.py:609
 msgctxt "calendar"
 msgid "Gregorian"
@@ -2262,7 +2229,7 @@ msgctxt "calendar"
 msgid "Swedish"
 msgstr ""
 
-#. TRANSLATORS: see
+#. Translators: see
 #. http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
 #. to learn how to select proper inflection to be used in your localized
 #. DateDisplayer code!
@@ -2331,7 +2298,7 @@ msgctxt "Hebrew month lexeme"
 msgid "Elul"
 msgstr ""
 
-#. TRANSLATORS: see
+#. Translators: see
 #. http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
 #. to learn how to select proper inflection to be used in your localized
 #. DateDisplayer code!
@@ -2400,7 +2367,7 @@ msgctxt "French month lexeme"
 msgid "Extra"
 msgstr ""
 
-#. TRANSLATORS: see
+#. Translators: see
 #. http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
 #. to learn how to select proper inflection to be used in your localized
 #. DateDisplayer code!
@@ -2464,7 +2431,7 @@ msgctxt "Islamic month lexeme"
 msgid "Dhu l-Hijja"
 msgstr ""
 
-#. TRANSLATORS: see
+#. Translators: see
 #. http://gramps-project.org/wiki/index.php?title=Translating_Gramps#Translating_dates
 #. to learn how to select proper inflection to be used in your localized
 #. DateDisplayer code!
@@ -2528,21 +2495,21 @@ msgctxt "Persian month lexeme"
 msgid "Esfand"
 msgstr ""
 
-#. TRANSLATORS: if the modifier is after the date
+#. Translators: if the modifier is after the date
 #. put the space ahead of the word instead of after it
 #: ../gramps/gen/datehandler/_datestrings.py:225
 msgctxt "date modifier"
 msgid "before "
 msgstr ""
 
-#. TRANSLATORS: if the modifier is after the date
+#. Translators: if the modifier is after the date
 #. put the space ahead of the word instead of after it
 #: ../gramps/gen/datehandler/_datestrings.py:228
 msgctxt "date modifier"
 msgid "after "
 msgstr ""
 
-#. TRANSLATORS: if the modifier is after the date
+#. Translators: if the modifier is after the date
 #. put the space ahead of the word instead of after it
 #: ../gramps/gen/datehandler/_datestrings.py:231
 msgctxt "date modifier"
@@ -2587,7 +2554,6 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
-#. Icelandic needs them
 #: ../gramps/gen/datehandler/_datestrings.py:252
 msgid "Sun"
 msgstr ""
@@ -2838,7 +2804,7 @@ msgstr ""
 msgid "Upgrade Statistics"
 msgstr ""
 
-#. translators: needed for Arabic, ignore otherwise
+#. Translators: needed for Arabic, ignore otherwise
 #: ../gramps/gen/display/name.py:349 ../gramps/plugins/lib/libtreebase.py:707
 msgid ","
 msgstr ""
@@ -2868,13 +2834,11 @@ msgstr ""
 msgid "Given Surname Suffix"
 msgstr ""
 
-#. primary name primconnector other, given pa/matronynic suffix, primprefix
-#. translators: long string, have a look at Preferences dialog
+#. Translators: long string, have a look at Preferences dialog
 #: ../gramps/gen/display/name.py:362
 msgid "Main Surnames, Given Patronymic Suffix Prefix"
 msgstr ""
 
-#. DEPRECATED FORMATS
 #: ../gramps/gen/display/name.py:365
 msgid "Patronymic, Given"
 msgstr ""
@@ -2889,7 +2853,6 @@ msgstr ""
 msgid "given"
 msgstr ""
 
-#. 2=double underline
 #: ../gramps/gen/display/name.py:606 ../gramps/gen/display/name.py:706
 #: ../gramps/plugins/importer/importcsv.py:162
 #: ../gramps/plugins/tool/removespaces.py:144
@@ -2990,11 +2953,6 @@ msgstr ""
 msgid "Error in '%s' file: cannot load."
 msgstr ""
 
-#. -------------------------------------------------------------------------
-#.
-#. Private Constants
-#.
-#. -------------------------------------------------------------------------
 #: ../gramps/gen/display/place.py:74 ../gramps/gen/plug/docgen/treedoc.py:63
 msgid "Full"
 msgstr ""
@@ -3023,10 +2981,6 @@ msgstr ""
 msgid "Applying ..."
 msgstr ""
 
-#. #########################
-#. ###############################
-#. #########################
-#. ###############################
 #: ../gramps/gen/filters/_genericfilter.py:143
 #: ../gramps/gen/filters/_genericfilter.py:174
 #: ../gramps/gui/editors/filtereditor.py:1121
@@ -3350,7 +3304,6 @@ msgstr ""
 msgid "No description"
 msgstr ""
 
-#. more references to a filter than expected
 #: ../gramps/gen/filters/rules/_rule.py:94
 msgid "The filter definition contains a loop."
 msgstr ""
@@ -3839,7 +3792,6 @@ msgstr ""
 msgid "Include Family events:"
 msgstr ""
 
-#. filters of another namespace, name may be same as caller!
 #: ../gramps/gen/filters/rules/event/_matchespersonfilter.py:50
 #: ../gramps/gui/editors/filtereditor.py:531
 msgid "Person filter name:"
@@ -5150,8 +5102,6 @@ msgid ""
 "generations away"
 msgstr ""
 
-#. -------------------------
-#. ###############################
 #: ../gramps/gen/filters/rules/person/_ismale.py:45
 #: ../gramps/plugins/gramplet/statsgramplet.py:146
 #: ../gramps/plugins/graph/gvfamilylines.py:280
@@ -5934,7 +5884,6 @@ msgstr ""
 msgid "Matches sources that are indicated as private"
 msgstr ""
 
-#. We encounter a PLAC, having previously encountered an ADDR
 #: ../gramps/gen/lib/address.py:97 ../gramps/gui/clipboard.py:298
 #: ../gramps/gui/configure.py:610 ../gramps/gui/editors/editaddress.py:167
 #: ../gramps/gui/filters/sidebar/_reposidebarfilter.py:106
@@ -6052,9 +6001,6 @@ msgstr ""
 msgid "Notes"
 msgstr ""
 
-#. wrap it all up and return to its callers
-#. position 0 = translatable label, position 1 = column class
-#. position 2 = data
 #: ../gramps/gen/lib/address.py:111 ../gramps/gen/lib/citation.py:106
 #: ../gramps/gen/lib/date.py:706 ../gramps/gen/lib/event.py:146
 #: ../gramps/gen/lib/ldsord.py:182 ../gramps/gen/lib/media.py:163
@@ -6255,7 +6201,6 @@ msgstr ""
 msgid "Caste"
 msgstr ""
 
-#. 2 name (version)
 #: ../gramps/gen/lib/attrtype.py:66 ../gramps/gen/lib/event.py:148
 #: ../gramps/gen/lib/media.py:147 ../gramps/gen/lib/url.py:96
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:75
@@ -6408,7 +6353,6 @@ msgstr ""
 msgid "Foster"
 msgstr ""
 
-#. 8
 #: ../gramps/gen/lib/citation.py:97 ../gramps/gen/lib/notetype.py:79
 #: ../gramps/gui/clipboard.py:468 ../gramps/gui/configure.py:655
 #: ../gramps/gui/editors/editcitation.py:119
@@ -6476,7 +6420,6 @@ msgstr ""
 msgid "Confidence"
 msgstr ""
 
-#. 7
 #: ../gramps/gen/lib/citation.py:115 ../gramps/gen/lib/src.py:97
 #: ../gramps/gui/clipboard.py:761 ../gramps/gui/configure.py:652
 #: ../gramps/gui/editors/displaytabs/nameembedlist.py:78
@@ -6500,8 +6443,6 @@ msgstr ""
 msgid "Source"
 msgstr ""
 
-#. 2
-#. add media column
 #: ../gramps/gen/lib/citation.py:122 ../gramps/gen/lib/event.py:162
 #: ../gramps/gen/lib/event.py:165 ../gramps/gen/lib/family.py:168
 #: ../gramps/gen/lib/media.py:134 ../gramps/gen/lib/person.py:206
@@ -6584,9 +6525,7 @@ msgctxt "age"
 msgid "about"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
-#. round up years
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/gen/lib/date.py:427 ../gramps/gen/lib/date.py:434
 #, python-brace-format
 msgid "{number_of} year"
@@ -6594,7 +6533,7 @@ msgid_plural "{number_of} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/gen/lib/date.py:443
 #, python-brace-format
 msgid "{number_of} month"
@@ -6602,7 +6541,7 @@ msgid_plural "{number_of} months"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/gen/lib/date.py:454
 #, python-brace-format
 msgid "{number_of} day"
@@ -6693,7 +6632,6 @@ msgstr ""
 msgid "textonly"
 msgstr ""
 
-#. 0 this order range above
 #: ../gramps/gen/lib/event.py:136 ../gramps/gen/lib/eventref.py:109
 #: ../gramps/gui/clipboard.py:335 ../gramps/gui/configure.py:661
 #: ../gramps/gui/editors/editlink.py:92
@@ -6712,7 +6650,6 @@ msgstr ""
 msgid "Event"
 msgstr ""
 
-#. 5
 #: ../gramps/gen/lib/event.py:151 ../gramps/gen/lib/ldsord.py:186
 #: ../gramps/gen/lib/place.py:134 ../gramps/gui/clipboard.py:355
 #: ../gramps/gui/configure.py:649
@@ -6813,9 +6750,6 @@ msgstr ""
 msgid "Life Events"
 msgstr ""
 
-#. _FAMNAME = _("With %(namepartner)s (%(famid)s)")
-#. 1
-#. get the family events
 #: ../gramps/gen/lib/eventtype.py:139 ../gramps/gen/lib/family.py:145
 #: ../gramps/gen/lib/ldsord.py:188 ../gramps/gui/clipboard.py:739
 #: ../gramps/gui/configure.py:646
@@ -7060,12 +6994,6 @@ msgstr ""
 msgid "Alternate Marriage"
 msgstr ""
 
-#. cm2pt = utils.cm2pt
-#. ------------------------------------------------------------------------
-#.
-#. Constants
-#.
-#. ------------------------------------------------------------------------
 #: ../gramps/gen/lib/eventtype.py:211
 #: ../gramps/plugins/drawreport/ancestortree.py:60
 #: ../gramps/plugins/drawreport/descendtree.py:57
@@ -7302,9 +7230,6 @@ msgctxt "Annulment abbreviation"
 msgid "annul."
 msgstr ""
 
-#. The parent may not be birth father in ths family, because it
-#. may be a step family. However, it will be odd to display the
-#. parent as anything other than "Father"
 #: ../gramps/gen/lib/family.py:155
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:60
 #: ../gramps/gui/filters/sidebar/_familysidebarfilter.py:122
@@ -7349,7 +7274,6 @@ msgstr ""
 msgid "Mother"
 msgstr ""
 
-#. Go over children and build their menu
 #: ../gramps/gen/lib/family.py:161 ../gramps/gui/widgets/fanchart.py:1957
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:855
 #: ../gramps/plugins/gramplet/gramplet.gpr.py:869
@@ -7395,8 +7319,6 @@ msgstr ""
 msgid "Civil Union"
 msgstr ""
 
-#. Create the tree columns
-#. 0 selected?
 #: ../gramps/gen/lib/grampstype.py:221 ../gramps/gen/lib/grampstype.py:225
 #: ../gramps/gen/lib/ldsord.py:184 ../gramps/gui/clipboard.py:907
 #: ../gramps/gui/editors/displaytabs/attrembedlist.py:62
@@ -7554,8 +7476,6 @@ msgstr ""
 msgid "Temple"
 msgstr ""
 
-#. icon_column = Gtk.TreeViewColumn(_('Status'), render,
-#. icon_name=ICON_COL)
 #: ../gramps/gen/lib/ldsord.py:192 ../gramps/gui/dbman.py:394
 #: ../gramps/gui/editors/displaytabs/familyldsembedlist.py:53
 #: ../gramps/gui/editors/displaytabs/ldsembedlist.py:63
@@ -7604,11 +7524,6 @@ msgstr ""
 msgid "Region"
 msgstr ""
 
-#. 1 new gramplet
-#. Priority
-#. Handle
-#. Add column with object name
-#. Name Column
 #: ../gramps/gen/lib/name.py:143 ../gramps/gen/lib/repo.py:96
 #: ../gramps/gen/lib/tag.py:122 ../gramps/gui/clipboard.py:562
 #: ../gramps/gui/configure.py:608
@@ -7711,7 +7626,6 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#. show surname and first name
 #: ../gramps/gen/lib/name.py:169 ../gramps/plugins/webreport/person.py:224
 msgid "Group as"
 msgstr ""
@@ -7736,18 +7650,16 @@ msgstr ""
 msgid "Family nick name"
 msgstr ""
 
-#. translators: needed for Arabic, ignore otherwise
+#. Translators: needed for Arabic, ignore otherwise
 #: ../gramps/gen/lib/name.py:461 ../gramps/gen/lib/name.py:476
 #, python-format
 msgid "%(surname)s, %(first)s %(suffix)s"
 msgstr ""
 
-#. translators: needed for Arabic, ignore otherwise
-#. translators: needed for Arabic, ignore othewise
-#. translators: needed for Arabic, ignore otherwise
-#. translators: needed for Arabic, ignore otherwise
+#. Translators: needed for Arabic, ignore otherwise
+#. Translators: needed for Arabic, ignore otherwise
 #. make sure it's translated, so it can be used below, in "combine"
-#. translators: needed for Arabic, ignore otherwise
+#. Translators: needed for Arabic, ignore otherwise
 #: ../gramps/gen/lib/name.py:465 ../gramps/gen/lib/name.py:480
 #: ../gramps/gen/plug/report/utils.py:256
 #: ../gramps/plugins/graph/gvfamilylines.py:491
@@ -7760,7 +7672,7 @@ msgstr ""
 msgid "%(str1)s, %(str2)s"
 msgstr ""
 
-#. translators: needed for Arabic, ignore otherwise
+#. Translators: needed for Arabic, ignore otherwise
 #: ../gramps/gen/lib/name.py:493
 #, python-format
 msgid "%(first)s %(surname)s, %(suffix)s"
@@ -7819,8 +7731,6 @@ msgstr ""
 msgid "Married Name"
 msgstr ""
 
-#. ###############################
-#. 3
 #: ../gramps/gen/lib/note.py:109 ../gramps/gen/plug/docgen/graphdoc.py:265
 #: ../gramps/gen/plug/docgen/treedoc.py:199 ../gramps/gui/clipboard.py:375
 #: ../gramps/gui/configure.py:667 ../gramps/gui/editors/editlink.py:95
@@ -7981,13 +7891,6 @@ msgstr ""
 msgid "Child Reference Note"
 msgstr ""
 
-#. 4
-#. ------------------------------------------------------------------------
-#.
-#. References
-#.
-#. ------------------------------------------------------------------------
-#. functions for the actual quickreports
 #: ../gramps/gen/lib/person.py:173 ../gramps/gui/clipboard.py:719
 #: ../gramps/gui/configure.py:643 ../gramps/gui/editors/editlink.py:96
 #: ../gramps/gui/editors/filtereditor.py:294
@@ -8232,7 +8135,6 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
-#. 6
 #: ../gramps/gen/lib/repo.py:86 ../gramps/gui/clipboard.py:781
 #: ../gramps/gui/configure.py:664 ../gramps/gui/editors/editlink.py:98
 #: ../gramps/gui/editors/editrepository.py:77
@@ -8589,12 +8491,6 @@ msgstr ""
 msgid "Merge Source"
 msgstr ""
 
-#. -------------------------------------------------------------------------
-#.
-#. Short hand function to return either the person's name, or an empty
-#. string if the person is None
-#.
-#. -------------------------------------------------------------------------
 #: ../gramps/gen/mime/_pythonmime.py:50 ../gramps/gen/mime/_pythonmime.py:58
 #: ../gramps/gen/mime/_winmime.py:57 ../gramps/gen/utils/db.py:523
 #: ../gramps/gui/editors/editperson.py:343
@@ -8615,11 +8511,6 @@ msgstr ""
 msgid "Gramplet %s caused an error"
 msgstr ""
 
-#. -------------------------------------------------------------------------
-#.
-#. Constants
-#.
-#. -------------------------------------------------------------------------
 #: ../gramps/gen/plug/_manager.py:62
 msgid "No description was provided"
 msgstr ""
@@ -8694,7 +8585,6 @@ msgstr ""
 msgid "Rule"
 msgstr ""
 
-#. add miscellaneous column
 #: ../gramps/gen/plug/_pluginreg.py:528
 #: ../gramps/plugins/gramplet/faqgramplet.py:135
 #: ../gramps/plugins/importer/importprogen.glade:1306
@@ -8749,7 +8639,6 @@ msgstr ""
 msgid "File %s already open, close it first."
 msgstr ""
 
-#. Export shouldn't bring Gramps down.
 #: ../gramps/gen/plug/docbackend/docbackend.py:147
 #: ../gramps/gen/plug/docbackend/docbackend.py:150
 #: ../gramps/gen/utils/docgen/odstab.py:340
@@ -8791,11 +8680,6 @@ msgstr ""
 msgid "Could not create %s"
 msgstr ""
 
-#. -------------------------------------------------------------------------
-#.
-#. Private Constants
-#.
-#. -------------------------------------------------------------------------
 #: ../gramps/gen/plug/docgen/graphdoc.py:68
 #: ../gramps/gen/plug/docgen/treedoc.py:67
 #: ../gramps/gen/plug/docgen/treedoc.py:73
@@ -8904,12 +8788,10 @@ msgstr ""
 msgid "Orthogonal"
 msgstr ""
 
-#. ###############################
 #: ../gramps/gen/plug/docgen/graphdoc.py:141
 msgid "Graphviz Layout"
 msgstr ""
 
-#. ###############################
 #: ../gramps/gen/plug/docgen/graphdoc.py:143
 #: ../gramps/gui/widgets/styledtexteditor.py:78
 msgid "Font family"
@@ -8986,12 +8868,10 @@ msgstr ""
 msgid "Whether lines attach to nodes differently"
 msgstr ""
 
-#. ###############################
 #: ../gramps/gen/plug/docgen/graphdoc.py:210
 msgid "Graphviz Options"
 msgstr ""
 
-#. ###############################
 #: ../gramps/gen/plug/docgen/graphdoc.py:213
 msgid "Aspect ratio"
 msgstr ""
@@ -9056,7 +8936,6 @@ msgid ""
 "graphs will result in longer lines and larger graphs."
 msgstr ""
 
-#. ###############################
 #: ../gramps/gen/plug/docgen/graphdoc.py:268
 msgid "Note to add to the graph"
 msgstr ""
@@ -9238,12 +9117,10 @@ msgstr ""
 msgid "Extra huge"
 msgstr ""
 
-#. ###############################
 #: ../gramps/gen/plug/docgen/treedoc.py:141
 msgid "Node Options"
 msgstr ""
 
-#. ###############################
 #: ../gramps/gen/plug/docgen/treedoc.py:144
 msgid "Node detail"
 msgstr ""
@@ -9280,15 +9157,12 @@ msgstr ""
 msgid "Node color."
 msgstr ""
 
-#. ###############################
-#. #################
 #: ../gramps/gen/plug/docgen/treedoc.py:175
 #: ../gramps/plugins/drawreport/ancestortree.py:799
 #: ../gramps/plugins/drawreport/descendtree.py:1533
 msgid "Tree Options"
 msgstr ""
 
-#. ###############################
 #: ../gramps/gen/plug/docgen/treedoc.py:178
 msgid "Timeflow"
 msgstr ""
@@ -9316,7 +9190,6 @@ msgid ""
 "this corresponds to spacing between columns."
 msgstr ""
 
-#. ###############################
 #: ../gramps/gen/plug/docgen/treedoc.py:202
 msgid "Note to add to the tree"
 msgstr ""
@@ -9351,16 +9224,6 @@ msgstr ""
 msgid "Valid values: "
 msgstr ""
 
-#. ------------------------------------------------------------------------
-#.
-#. Private Constants
-#.
-#. ------------------------------------------------------------------------
-#. -------------------------------------------------------------------------
-#.
-#. Constants
-#.
-#. -------------------------------------------------------------------------
 #: ../gramps/gen/plug/report/_book.py:71 ../gramps/gui/plug/_dialogs.py:59
 #: ../gramps/gui/plug/report/_bookdialog.py:86 ../gramps/gui/viewmanager.py:113
 msgid "Unsupported"
@@ -9482,7 +9345,6 @@ msgctxt "'living people'"
 msgid "Not included"
 msgstr ""
 
-#. for deferred translation
 #: ../gramps/gen/plug/report/stdoptions.py:203
 msgid "How to handle living people"
 msgstr ""
@@ -9508,11 +9370,6 @@ msgstr ""
 msgid "Do not include"
 msgstr ""
 
-#. --------------------
-#. ###############################
-#. What to include
-#. #########################
-#. ###############################
 #: ../gramps/gen/plug/report/stdoptions.py:334
 #: ../gramps/gen/plug/report/stdoptions.py:363
 #: ../gramps/gui/viewmanager.py:1753
@@ -9568,7 +9425,6 @@ msgstr ""
 msgid "Could not add photo to page"
 msgstr ""
 
-#. Do this in case of command line options query (show=filter)
 #: ../gramps/gen/plug/report/utils.py:288
 msgid "PERSON"
 msgstr ""
@@ -9580,7 +9436,6 @@ msgstr ""
 msgid "Entire Database"
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/gen/plug/report/utils.py:300
 #: ../gramps/gui/plug/export/_exportoptions.py:460
 #: ../gramps/plugins/textreport/descendreport.py:488
@@ -9588,7 +9443,6 @@ msgstr ""
 msgid "Descendants of %s"
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/gen/plug/report/utils.py:304
 #: ../gramps/gen/plug/report/utils.py:381
 #: ../gramps/gui/plug/export/_exportoptions.py:465
@@ -9596,7 +9450,6 @@ msgstr ""
 msgid "Descendant Families of %s"
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/gen/plug/report/utils.py:308
 #: ../gramps/gui/plug/export/_exportoptions.py:470
 #, python-format
@@ -9622,12 +9475,10 @@ msgstr ""
 msgid "%(father_name)s and %(mother_name)s (%(family_id)s)"
 msgstr ""
 
-#. Do this in case of command line options query (show=filter)
 #: ../gramps/gen/plug/report/utils.py:368
 msgid "FAMILY"
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/gen/plug/report/utils.py:385
 #, python-format
 msgid "Ancestor Families of %s"
@@ -9921,7 +9772,6 @@ msgstr ""
 msgid "Database error: loop in %s's ancestors"
 msgstr ""
 
-#. no evidence, must consider alive
 #: ../gramps/gen/utils/alive.py:507
 msgid "no evidence"
 msgstr ""
@@ -9964,7 +9814,6 @@ msgstr ""
 msgid "Breton"
 msgstr ""
 
-#. Windows has no translation for Breton
 #: ../gramps/gen/utils/grampslocale.py:74
 msgid "Catalan"
 msgstr ""
@@ -9997,7 +9846,6 @@ msgstr ""
 msgid "Esperanto"
 msgstr ""
 
-#. Windows has no translation for Esperanto
 #: ../gramps/gen/utils/grampslocale.py:82
 msgid "Spanish"
 msgstr ""
@@ -10014,7 +9862,6 @@ msgstr ""
 msgid "Gaelic"
 msgstr ""
 
-#. Windows has no translation for Gaelic
 #: ../gramps/gen/utils/grampslocale.py:86
 msgid "Hebrew"
 msgstr ""
@@ -10047,7 +9894,6 @@ msgstr ""
 msgid "Macedonian"
 msgstr ""
 
-#. Windows has no translation for Macedonian
 #: ../gramps/gen/utils/grampslocale.py:94
 msgid "Norwegian Bokmal"
 msgstr ""
@@ -10104,7 +9950,6 @@ msgstr ""
 msgid "Tamil"
 msgstr ""
 
-#. Windows has no codepage for Tamil
 #: ../gramps/gen/utils/grampslocale.py:108
 msgid "Turkish"
 msgstr ""
@@ -10239,7 +10084,6 @@ msgstr ""
 msgid "PRIMARY"
 msgstr ""
 
-#. name, sort, width, modelcol
 #: ../gramps/gen/utils/keyword.py:61
 #: ../gramps/gui/editors/displaytabs/surnametab.py:82
 msgctxt "Name"
@@ -10425,7 +10269,6 @@ msgid ""
 "abandoning changes."
 msgstr ""
 
-#. Name                     UNICODE       SUBSTITUTION
 #: ../gramps/gen/utils/symbols.py:61
 #: ../gramps/plugins/graph/gvfamilylines.py:84
 #: ../gramps/plugins/textreport/indivcomplete.py:944
@@ -10504,9 +10347,6 @@ msgstr ""
 msgid "Extinct"
 msgstr ""
 
-#. The following is used in the global preferences in the display tab.
-#. Name
-#. UNICODE    SUBSTITUTION
 #: ../gramps/gen/utils/symbols.py:106
 msgid "Nothing"
 msgstr ""
@@ -10575,7 +10415,6 @@ msgstr ""
 msgid "Unknown, created to replace a missing note object."
 msgstr ""
 
-#. primitive static variable
 #: ../gramps/gen/utils/unknown.py:150
 #, python-format
 msgid "Unknown, was missing %(time)s (%(count)d)"
@@ -10630,7 +10469,7 @@ msgstr ""
 msgid "Contributions by"
 msgstr ""
 
-#. TRANSLATORS: Translate this to your name in your native language
+#. Translators: Translate this to your name in your native language
 #: ../gramps/gui/aboutdialog.py:120
 msgid "translator-credits"
 msgstr ""
@@ -10688,8 +10527,6 @@ msgstr ""
 msgid "Clipboard"
 msgstr ""
 
-#. Now add more items to popup menu, if available
-#. See details (edit, etc):
 #: ../gramps/gui/clipboard.py:1493 ../gramps/gui/plug/quick/_quicktable.py:141
 #, python-format
 msgctxt "the object"
@@ -10725,7 +10562,6 @@ msgstr ""
 msgid "_Apply"
 msgstr ""
 
-#. #################
 #: ../gramps/gui/columnorder.py:128 ../gramps/gui/configure.py:1354
 #: ../gramps/plugins/drawreport/ancestortree.py:916
 #: ../gramps/plugins/drawreport/descendtree.py:1658
@@ -10753,7 +10589,6 @@ msgstr ""
 msgid "Display Name Editor"
 msgstr ""
 
-#. self.window.connect('response', self.close)
 #: ../gramps/gui/configure.py:116 ../gramps/gui/configure.py:189
 #: ../gramps/gui/dialog.py:261 ../gramps/gui/dialog.py:307
 #: ../gramps/gui/dialog.py:333 ../gramps/gui/glade/book.glade:466
@@ -10816,8 +10651,7 @@ msgstr ""
 msgid "Invalid or incomplete format definition."
 msgstr ""
 
-#. label for the combo
-#. translators: needed for French, ignore otherwise
+#. Translators: needed for French, ignore otherwise
 #: ../gramps/gui/configure.py:386 ../gramps/gui/configure.py:413
 #: ../gramps/gui/configure.py:435 ../gramps/gui/configure.py:451
 #: ../gramps/gui/configure.py:482 ../gramps/gui/configure.py:519
@@ -10986,7 +10820,6 @@ msgstr ""
 msgid "Border for Dead"
 msgstr ""
 
-#. for family
 #: ../gramps/gui/configure.py:730
 msgid "Default background"
 msgstr ""
@@ -11019,7 +10852,6 @@ msgstr ""
 msgid "Border for Divorced"
 msgstr ""
 
-#. for other
 #: ../gramps/gui/configure.py:742
 msgid "Background for Home Person"
 msgstr ""
@@ -11082,8 +10914,6 @@ msgstr ""
 msgid "Example"
 msgstr ""
 
-#. show an add button
-#. we now construct an add menu
 #: ../gramps/gui/configure.py:1054
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:147
 #: ../gramps/gui/editors/displaytabs/embeddedlist.py:154
@@ -11441,8 +11271,6 @@ msgstr ""
 msgid "' and '"
 msgstr ""
 
-#. List of translated strings used here
-#. Dead code for l10n
 #: ../gramps/gui/configure.py:1701
 msgid "new"
 msgstr ""
@@ -12260,7 +12088,6 @@ msgstr ""
 msgid "_Attributes"
 msgstr ""
 
-#. Add column with object gramps_id
 #: ../gramps/gui/editors/displaytabs/backreflist.py:60
 #: ../gramps/gui/editors/displaytabs/citationembedlist.py:86
 #: ../gramps/gui/editors/displaytabs/eventembedlist.py:79
@@ -12615,11 +12442,6 @@ msgstr ""
 msgid "Set as default name"
 msgstr ""
 
-#. -------------------------------------------------------------------------
-#.
-#. NameModel
-#.
-#. -------------------------------------------------------------------------
 #: ../gramps/gui/editors/displaytabs/namemodel.py:56
 #: ../gramps/gui/plug/_guioptions.py:1259 ../gramps/gui/viewmanager.py:1030
 #: ../gramps/gui/views/tags.py:561
@@ -12681,7 +12503,6 @@ msgstr ""
 msgid "_Notes"
 msgstr ""
 
-#. add personal column
 #: ../gramps/gui/editors/displaytabs/personeventembedlist.py:50
 #: ../gramps/plugins/webreport/basepage.py:1967
 msgid "Personal"
@@ -13331,15 +13152,7 @@ msgid ""
 "editing of this window, and select the existing family"
 msgstr ""
 
-#. translators: needed for French, ignore otherwise
-#. Styles Frame
-#. translators: needed for French, ignore otherwise
-#. Save Frame
-#. translators: needed for French, ignore otherwise
-#. Gramps ID
-#. don't show rest
-#. show "> Family: ..." and nothing else
-#. show "V Family: ..." and the rest
+#. Translators: needed for French, ignore otherwise
 #: ../gramps/gui/editors/editfamily.py:995
 #: ../gramps/gui/editors/editfamily.py:1002
 #: ../gramps/gui/plug/report/_docreportdialog.py:186
@@ -13808,7 +13621,7 @@ msgstr ""
 msgid "New Place"
 msgstr ""
 
-#. translators: translate the "S" too (and the "or" of course)
+#. Translators: translate the "S" too (and the "or" of course)
 #: ../gramps/gui/editors/editplace.py:213
 #: ../gramps/gui/editors/editplaceref.py:207
 msgid ""
@@ -13816,7 +13629,7 @@ msgid ""
 "(syntax: 18\\u00b09'48.21\"S, -18.2412 or -18:9:48.21)"
 msgstr ""
 
-#. translators: translate the "E" too (and the "or" of course)
+#. Translators: translate the "E" too (and the "or" of course)
 #: ../gramps/gui/editors/editplace.py:218
 #: ../gramps/gui/editors/editplaceref.py:212
 msgid ""
@@ -15977,7 +15790,6 @@ msgstr ""
 msgid "_Merge and close"
 msgstr ""
 
-#. name, click?, width, toggle
 #: ../gramps/gui/glade/mergedata.glade:173
 #: ../gramps/gui/glade/mergedata.glade:189 ../gramps/gui/plug/_windows.py:1103
 #: ../gramps/plugins/tool/changenames.py:196
@@ -17104,7 +16916,7 @@ msgctxt "manual"
 msgid "Merge_People"
 msgstr ""
 
-#. translators: needed for French, ignore otherwise
+#. Translators: needed for French, ignore otherwise
 #: ../gramps/gui/merge/mergeperson.py:62
 #, python-format
 msgid "%(key)s:\t%(value)s"
@@ -17114,7 +16926,6 @@ msgstr ""
 msgid "Merge People"
 msgstr ""
 
-#. Go over parents and build their menu
 #: ../gramps/gui/merge/mergeperson.py:224
 #: ../gramps/gui/widgets/fanchart.py:1994
 #: ../gramps/plugins/quickview/all_relations.py:305
@@ -17138,7 +16949,6 @@ msgstr ""
 msgid "No parents found"
 msgstr ""
 
-#. Go over spouses and build their menu
 #: ../gramps/gui/merge/mergeperson.py:238
 #: ../gramps/gui/widgets/fanchart.py:1857
 #: ../gramps/plugins/textreport/kinshipreport.py:133
@@ -17160,7 +16970,6 @@ msgstr ""
 msgid "No spouses or children found"
 msgstr ""
 
-#. Add column with the warning text
 #: ../gramps/gui/merge/mergeperson.py:341 ../gramps/plugins/tool/verify.py:568
 msgid "Warning"
 msgstr ""
@@ -17296,12 +17105,10 @@ msgstr ""
 msgid "Info"
 msgstr ""
 
-#. id_col
 #: ../gramps/gui/plug/_windows.py:147 ../gramps/gui/plug/_windows.py:201
 msgid "Hide/Unhide"
 msgstr ""
 
-#. id_col
 #: ../gramps/gui/plug/_windows.py:155 ../gramps/gui/plug/_windows.py:210
 msgid "Load"
 msgstr ""
@@ -17328,7 +17135,6 @@ msgstr ""
 msgid "Loaded Plugins"
 msgstr ""
 
-#. self.addon_list.connect('button-press-event', self.button_press)
 #: ../gramps/gui/plug/_windows.py:235
 msgid "Addon Name"
 msgstr ""
@@ -17349,8 +17155,6 @@ msgstr ""
 msgid "Refresh Addon List"
 msgstr ""
 
-#. Only show the "Reload" button when in debug mode
-#. (without -O on the command line)
 #: ../gramps/gui/plug/_windows.py:289
 msgid "Reload"
 msgstr ""
@@ -17453,7 +17257,7 @@ msgstr ""
 msgid "Done downloading and installing addons"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/gui/plug/_windows.py:1224
 #, python-brace-format
 msgid "{number_of} addon was installed."
@@ -17469,7 +17273,6 @@ msgstr ""
 msgid "No addons were installed."
 msgstr ""
 
-#. set up ManagedWindow
 #: ../gramps/gui/plug/export/_exportassistant.py:119
 msgid "Export Assistant"
 msgstr ""
@@ -17542,7 +17345,6 @@ msgid ""
 "not alter the copy you have just made. "
 msgstr ""
 
-#. add test, what is dir
 #: ../gramps/gui/plug/export/_exportassistant.py:512
 #, python-format
 msgid "Filename: %s"
@@ -17597,7 +17399,7 @@ msgstr ""
 msgid "Unfiltered Family Tree:"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/gui/plug/export/_exportoptions.py:167
 #: ../gramps/gui/plug/export/_exportoptions.py:274
 #: ../gramps/gui/plug/export/_exportoptions.py:582
@@ -17640,7 +17442,6 @@ msgstr ""
 msgid "Click to see preview after note filter"
 msgstr ""
 
-#. Frame 3:
 #: ../gramps/gui/plug/export/_exportoptions.py:319
 msgid "Privacy Filter"
 msgstr ""
@@ -17649,7 +17450,6 @@ msgstr ""
 msgid "Click to see preview after privacy filter"
 msgstr ""
 
-#. Frame 4:
 #: ../gramps/gui/plug/export/_exportoptions.py:330
 msgid "Living Filter"
 msgstr ""
@@ -17927,24 +17727,6 @@ msgstr ""
 msgid "Style"
 msgstr ""
 
-#. better to 'Show siblings of\nthe center person
-#. Spouse_disp = EnumeratedListOption(_("Show spouses of\nthe center "
-#. "person"), 0)
-#. Spouse_disp.add_item(0, _("No.  Do not show Spouses"))
-#. Spouse_disp.add_item(1, _("Yes, and use the Main Display Format"))
-#. Spouse_disp.add_item(2, _("Yes, and use the Secondary "
-#. "Display Format"))
-#. Spouse_disp.set_help(_("Show spouses of the center person?"))
-#. menu.add_option(category_name, "Spouse_disp", Spouse_disp)
-#. #################
-#. #########################
-#. #################
-#. ###############################
-#. ---------------------
-#. ###############################
-#. Report Options
-#. #########################
-#. ###############################
 #: ../gramps/gui/plug/report/_reportdialog.py:366
 #: ../gramps/plugins/drawreport/ancestortree.py:843
 #: ../gramps/plugins/drawreport/calendarreport.py:462
@@ -17977,7 +17759,6 @@ msgstr ""
 msgid "Report Options"
 msgstr ""
 
-#. need any labels at top:
 #: ../gramps/gui/plug/report/_reportdialog.py:457
 msgid "Document Options"
 msgstr ""
@@ -18075,7 +17856,6 @@ msgstr ""
 msgid "Error saving stylesheet"
 msgstr ""
 
-#. How to handle missing information
 #: ../gramps/gui/plug/report/_styleeditor.py:174
 #: ../gramps/gui/plug/report/_styleeditor.py:188
 #: ../gramps/plugins/textreport/detancestralreport.py:960
@@ -18301,12 +18081,6 @@ msgstr ""
 msgid "_Redo"
 msgstr ""
 
-#. self.tree.append_column(
-#. Gtk.TreeViewColumn(_('Original time'), self.renderer,
-#. text=0, foreground=2, background=3))
-#. self.tree.append_column(
-#. Gtk.TreeViewColumn(_('Action'), self.renderer,
-#. text=1, foreground=2, background=3))
 #: ../gramps/gui/undohistory.py:113
 msgid "Original time"
 msgstr ""
@@ -18376,7 +18150,6 @@ msgstr ""
 msgid "No Family Tree"
 msgstr ""
 
-#. registering plugins
 #: ../gramps/gui/viewmanager.py:561
 msgid "Registering plugins..."
 msgstr ""
@@ -18534,7 +18307,6 @@ msgctxt "manual"
 msgid "Bookmarks"
 msgstr ""
 
-#. this is meaningless while it's modal
 #: ../gramps/gui/views/bookmarks.py:265 ../gramps/gui/views/bookmarks.py:275
 #: ../gramps/gui/views/bookmarks.py:371
 #: ../gramps/plugins/lib/libpersonview.py:205
@@ -18693,7 +18465,6 @@ msgstr ""
 msgid "Configure %s View"
 msgstr ""
 
-#. top widget at the top
 #: ../gramps/gui/views/pageview.py:613
 #, python-format
 msgid "View %(name)s: %(msg)s"
@@ -18846,7 +18617,6 @@ msgstr ""
 msgid "_Copy"
 msgstr ""
 
-#. Go over siblings and build their menu
 #: ../gramps/gui/widgets/fanchart.py:1891
 #: ../gramps/plugins/quickview/quickview.gpr.py:319
 #: ../gramps/plugins/view/pedigreeview.py:1805
@@ -18854,7 +18624,6 @@ msgstr ""
 msgid "Siblings"
 msgstr ""
 
-#. Go over parents and build their menu
 #: ../gramps/gui/widgets/fanchart.py:2037
 #: ../gramps/plugins/view/pedigreeview.py:1932
 msgid "Related"
@@ -18923,12 +18692,10 @@ msgid ""
 "action cannot be undone."
 msgstr ""
 
-#. default tooltip
 #: ../gramps/gui/widgets/grampletpane.py:816
 msgid "Drag Properties Button to move and click it for setup"
 msgstr ""
 
-#. build the GUI:
 #: ../gramps/gui/widgets/grampletpane.py:1017
 msgid "Right click to add gramplets"
 msgstr ""
@@ -18982,7 +18749,6 @@ msgstr ""
 msgid "Make Active Media"
 msgstr ""
 
-#. initial tooltip when no place already selected.
 #: ../gramps/gui/widgets/placewithin.py:63
 msgid ""
 "Matches places within a given distance of the active place. You have no "
@@ -19039,7 +18805,6 @@ msgid ""
 "Ctrl-Click to follow link"
 msgstr ""
 
-#. spell checker submenu
 #: ../gramps/gui/widgets/styledtexteditor.py:450
 msgid "Spellcheck"
 msgstr ""
@@ -19085,7 +18850,6 @@ msgstr ""
 msgid "This field is mandatory"
 msgstr ""
 
-#. used on AgeOnDateGramplet
 #: ../gramps/gui/widgets/validatedmaskedentry.py:1236
 #, python-format
 msgid "'%s' is not a valid date value"
@@ -19347,12 +19111,10 @@ msgstr ""
 msgid "The color, if any, of the SVG background"
 msgstr ""
 
-#. we want no text, but need a text for the TOC in a book!
 #: ../gramps/plugins/drawreport/ancestortree.py:115
 msgid "Ancestor Graph"
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/drawreport/ancestortree.py:133
 #, python-format
 msgid "Ancestor Graph for %s"
@@ -19555,14 +19317,6 @@ msgstr ""
 msgid "Whether to include pages that are blank."
 msgstr ""
 
-#. #################
-#. #########################
-#. #################
-#. ###############################
-#. ---------------------
-#. ###############################
-#. #########################
-#. ###############################
 #: ../gramps/plugins/drawreport/ancestortree.py:903
 #: ../gramps/plugins/drawreport/calendarreport.py:490
 #: ../gramps/plugins/drawreport/descendtree.py:1645
@@ -19596,12 +19350,6 @@ msgstr ""
 msgid "Display format for the fathers box."
 msgstr ""
 
-#. Will add when libsubstkeyword supports it.
-#. missing = EnumeratedListOption(_("Replace missing\nplaces\\dates #. with"), 0)
-#. missing.add_item(0, _("Does not display anything"))
-#. missing.add_item(1, _("Displays '_____'"))
-#. missing.set_help(_("What will print when information is not known"))
-#. menu.add_option(category_name, "miss_val", missing)
 #: ../gramps/plugins/drawreport/ancestortree.py:933
 msgid ""
 "Mother\n"
@@ -19652,7 +19400,6 @@ msgstr ""
 msgid "Display format for the marital box."
 msgstr ""
 
-#. #################
 #: ../gramps/plugins/drawreport/ancestortree.py:961
 #: ../gramps/plugins/drawreport/descendtree.py:1694
 #: ../gramps/plugins/lib/libmetadata.py:104
@@ -19673,13 +19420,6 @@ msgid ""
 "United States of America/U.S.A."
 msgstr ""
 
-#. TODO this code is never used and so I conclude it is for future use
-#. self.__include_images = BooleanOption(
-#. _('Include thumbnail images of people'), False)
-#. self.__include_images.set_help(
-#. _("Whether to include thumbnails of people."))
-#. menu.add_option(category_name, "includeImages",
-#. self.__include_images)
 #: ../gramps/plugins/drawreport/ancestortree.py:977
 #: ../gramps/plugins/drawreport/descendtree.py:1702
 msgid "Include a note"
@@ -19721,7 +19461,6 @@ msgstr ""
 msgid "box shadow scale factor"
 msgstr ""
 
-#. down to 0
 #: ../gramps/plugins/drawreport/ancestortree.py:1003
 #: ../gramps/plugins/drawreport/descendtree.py:1727
 msgid "Make the box shadow bigger or smaller"
@@ -19801,8 +19540,6 @@ msgstr ""
 msgid "Produced with Gramps"
 msgstr ""
 
-#. generate the report:
-#. to see "nearby" comments
 #: ../gramps/plugins/drawreport/calendarreport.py:199
 #: ../gramps/plugins/drawreport/calendarreport.py:225
 #: ../gramps/plugins/drawreport/calendarreport.py:315
@@ -19825,7 +19562,7 @@ msgstr ""
 msgid "%(person)s, birth"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/drawreport/calendarreport.py:365
 #, python-brace-format
 msgid "{person}, {age}"
@@ -19840,7 +19577,7 @@ msgid ""
 " %(person)s, wedding"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/drawreport/calendarreport.py:427
 #, python-brace-format
 msgid ""
@@ -19910,9 +19647,6 @@ msgstr ""
 msgid "Include only living people in the calendar"
 msgstr ""
 
-#. #########################
-#. Content options
-#. Content
 #: ../gramps/plugins/drawreport/calendarreport.py:508
 #: ../gramps/plugins/textreport/birthdayreport.py:523
 #: ../gramps/plugins/textreport/detancestralreport.py:873
@@ -19921,7 +19655,6 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#. #########################
 #: ../gramps/plugins/drawreport/calendarreport.py:512
 #: ../gramps/plugins/drawreport/calendarreport.py:514
 msgid "Year of calendar"
@@ -19938,7 +19671,6 @@ msgstr ""
 msgid "Select the country to see associated holidays"
 msgstr ""
 
-#. Default selection ????
 #: ../gramps/plugins/drawreport/calendarreport.py:531
 #: ../gramps/plugins/webreport/narrativeweb.py:2809
 #: ../gramps/plugins/webreport/webcal.py:1867
@@ -20050,13 +19782,11 @@ msgstr ""
 msgid "Descendant Chart for %(person)s and %(father1)s, %(mother1)s"
 msgstr ""
 
-#. Should be 2 items in names list
 #: ../gramps/plugins/drawreport/descendtree.py:165
 #, python-format
 msgid "Descendant Chart for %(person)s, %(father1)s and %(mother1)s"
 msgstr ""
 
-#. Should be 2 items in both names and names2 lists
 #: ../gramps/plugins/drawreport/descendtree.py:172
 #, python-format
 msgid ""
@@ -20068,13 +19798,11 @@ msgstr ""
 msgid "Descendant Chart for %(person)s"
 msgstr ""
 
-#. Should be two items in names list
 #: ../gramps/plugins/drawreport/descendtree.py:184
 #, python-format
 msgid "Descendant Chart for %(father)s and %(mother)s"
 msgstr ""
 
-#. we want no text, but need a text for the TOC in a book!
 #: ../gramps/plugins/drawreport/descendtree.py:213
 msgid "Descendant Graph"
 msgstr ""
@@ -20099,7 +19827,6 @@ msgstr ""
 msgid "Family %s is not in the Database"
 msgstr ""
 
-#. if self.name == "familial_descend_tree":
 #: ../gramps/plugins/drawreport/descendtree.py:1536
 #: ../gramps/plugins/drawreport/descendtree.py:1540
 msgid "Report for"
@@ -20179,12 +19906,6 @@ msgstr ""
 msgid "Display format for a descendant."
 msgstr ""
 
-#. bug 4767
-#. diffspouse = BooleanOption(
-#. _("Use separate display format for spouses"),
-#. True)
-#. diffspouse.set_help(_("Whether spouses can have a different format."))
-#. menu.add_option(category_name, "diffspouse", diffspouse)
 #: ../gramps/plugins/drawreport/descendtree.py:1674
 msgid ""
 "Spousal\n"
@@ -20287,7 +20008,6 @@ msgstr ""
 msgid "Produces fan charts"
 msgstr ""
 
-#. extract requested items from the database and count them
 #: ../gramps/plugins/drawreport/drawplugins.gpr.py:197
 #: ../gramps/plugins/drawreport/statisticschart.py:812
 #: ../gramps/plugins/drawreport/statisticschart.py:822
@@ -20309,7 +20029,6 @@ msgstr ""
 msgid "Produces a timeline chart."
 msgstr ""
 
-#. choose  one line or two lines translation according to the width
 #: ../gramps/plugins/drawreport/fanchart.py:256
 #, python-format
 msgid "%(generations)d Generation Fan Chart for %(person)s"
@@ -20491,7 +20210,6 @@ msgstr ""
 msgid "(Preferred) title missing"
 msgstr ""
 
-#. the list of keys that represent "missing" information
 #: ../gramps/plugins/drawreport/statisticschart.py:402
 #: ../gramps/plugins/drawreport/statisticschart.py:928
 msgid "(Preferred) forename missing"
@@ -20505,8 +20223,6 @@ msgstr ""
 msgid "Gender unknown"
 msgstr ""
 
-#. localized year
-#. inadequate information
 #: ../gramps/plugins/drawreport/statisticschart.py:431
 #: ../gramps/plugins/drawreport/statisticschart.py:451
 #: ../gramps/plugins/drawreport/statisticschart.py:558
@@ -20704,7 +20420,6 @@ msgctxt "sorted by"
 msgid "Name"
 msgstr ""
 
-#. Sort the people as requested
 #: ../gramps/plugins/drawreport/timeline.py:157
 #: ../gramps/plugins/drawreport/timeline.py:169
 #: ../gramps/plugins/drawreport/timeline.py:338
@@ -20719,7 +20434,6 @@ msgstr ""
 msgid "Calculating timeline..."
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/drawreport/timeline.py:277
 #, python-format
 msgid "Sorted by %s"
@@ -21050,7 +20764,6 @@ msgid ""
 "the file. Please make sure you have write access to the file and try again."
 msgstr ""
 
-#. GUI setup:
 #: ../gramps/plugins/gramplet/ageondategramplet.py:52
 msgid "Enter a date, click Run"
 msgstr ""
@@ -21374,7 +21087,6 @@ msgstr ""
 msgid "Double-click given name for details"
 msgstr ""
 
-#. will be overwritten in load
 #: ../gramps/plugins/gramplet/givennamegramplet.py:55
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:50
 #: ../gramps/plugins/gramplet/recordsgramplet.py:43
@@ -22306,7 +22018,6 @@ msgstr ""
 msgid " has 1 of 1 individual (%(percent)s complete)\n"
 msgstr ""
 
-#. Create the Generation title, set an index marker
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:267
 #: ../gramps/plugins/textreport/ancestorreport.py:218
 #: ../gramps/plugins/textreport/detancestralreport.py:228
@@ -22321,7 +22032,7 @@ msgstr ""
 msgid "Double-click to see people in generation %d"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:272
 #, python-brace-format
 msgid ""
@@ -22339,7 +22050,7 @@ msgstr ""
 msgid "Double-click to see all generations"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/gramplet/pedigreegramplet.py:283
 #, python-brace-format
 msgid " have {number_of} individual\n"
@@ -22357,7 +22068,6 @@ msgstr ""
 msgid "%(date)s."
 msgstr ""
 
-#. Add types:
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:71
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:107
 #: ../gramps/plugins/gramplet/quickviewgramplet.py:129
@@ -22430,7 +22140,6 @@ msgstr ""
 msgid "Opened data base -----------\n"
 msgstr ""
 
-#. List of translated strings used here (translated in self.log ).
 #: ../gramps/plugins/gramplet/sessionloggramplet.py:59
 msgid "Added"
 msgstr ""
@@ -22461,7 +22170,6 @@ msgstr ""
 msgid "less than 1"
 msgstr ""
 
-#. -------------------------
 #: ../gramps/plugins/gramplet/statsgramplet.py:140
 #: ../gramps/plugins/graph/gvfamilylines.py:277
 #: ../gramps/plugins/textreport/summary.py:113
@@ -22681,40 +22389,26 @@ msgid ""
 "and detach the gramplet to float above Gramps."
 msgstr ""
 
-#. Minimum number of lines we want to see. Further lines with the same
-#. distance to the main person will be added on top of this.
 #: ../gramps/plugins/gramplet/whatsnext.py:57
 msgid "Minimum number of items to display"
 msgstr ""
 
-#. How many generations of descendants to process before we go up to the
-#. next level of ancestors.
 #: ../gramps/plugins/gramplet/whatsnext.py:63
 msgid "Descendant generations per ancestor generation"
 msgstr ""
 
-#. After an ancestor was processed, how many extra rounds to delay until
-#. the descendants of this ancestor are processed.
 #: ../gramps/plugins/gramplet/whatsnext.py:69
 msgid "Delay before descendants of an ancestor is processed"
 msgstr ""
 
-#. Tag to use to indicate that this person has no further marriages, if
-#. the person is not tagged, warn about this at the time the marriages
-#. for the person are processed.
 #: ../gramps/plugins/gramplet/whatsnext.py:76
 msgid "Tag to indicate that a person is complete"
 msgstr ""
 
-#. Tag to use to indicate that there are no further children in this
-#. family, if this family is not tagged, warn about this at the time the
-#. children of this family are processed.
 #: ../gramps/plugins/gramplet/whatsnext.py:83
 msgid "Tag to indicate that a family is complete"
 msgstr ""
 
-#. Tag to use to specify people and families to ignore. In his way,
-#. hopeless cases can be marked separately and don't clutter up the list.
 #: ../gramps/plugins/gramplet/whatsnext.py:89
 msgid "Tag to indicate that a person or family should be ignored"
 msgstr ""
@@ -22839,11 +22533,6 @@ msgstr ""
 msgid "Produces relationship graphs using Graphviz."
 msgstr ""
 
-#. ------------------------------------------------------------------------
-#.
-#. Constant options items
-#.
-#. ------------------------------------------------------------------------
 #: ../gramps/plugins/graph/gvfamilylines.py:74
 #: ../gramps/plugins/graph/gvhourglass.py:59
 #: ../gramps/plugins/graph/gvrelgraph.py:73
@@ -22882,7 +22571,6 @@ msgstr ""
 msgid "Descendants - Ancestors"
 msgstr ""
 
-#. ---------------------
 #: ../gramps/plugins/graph/gvfamilylines.py:125
 msgid "Follow parents to determine \"family lines\""
 msgstr ""
@@ -22944,12 +22632,10 @@ msgstr ""
 msgid "Use rounded corners e.g. to differentiate between women and men."
 msgstr ""
 
-#. --------------------------------
 #: ../gramps/plugins/graph/gvfamilylines.py:185
 msgid "People of Interest"
 msgstr ""
 
-#. --------------------------------
 #: ../gramps/plugins/graph/gvfamilylines.py:188
 msgid "People of interest"
 msgstr ""
@@ -22984,7 +22670,6 @@ msgstr ""
 msgid "The maximum number of descendants to include."
 msgstr ""
 
-#. --------------------
 #: ../gramps/plugins/graph/gvfamilylines.py:223
 msgid "Include dates"
 msgstr ""
@@ -23053,12 +22738,10 @@ msgstr ""
 msgid "Size of the thumbnail image"
 msgstr ""
 
-#. ----------------------------
 #: ../gramps/plugins/graph/gvfamilylines.py:269
 msgid "Family Colors"
 msgstr ""
 
-#. ----------------------------
 #: ../gramps/plugins/graph/gvfamilylines.py:272
 msgid "Family colors"
 msgstr ""
@@ -23131,7 +22814,7 @@ msgstr ""
 msgid "Initial list of people of interest:"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/graph/gvfamilylines.py:982
 #, python-brace-format
 msgid "{number_of} child"
@@ -23199,7 +22882,6 @@ msgid ""
 "individual is unknown it will be shown with gray."
 msgstr ""
 
-#. see bug report #2180
 #: ../gramps/plugins/graph/gvhourglass.py:396
 #: ../gramps/plugins/graph/gvrelgraph.py:830
 msgid "Use rounded corners"
@@ -23210,7 +22892,6 @@ msgstr ""
 msgid "Use rounded corners to differentiate between women and men."
 msgstr ""
 
-#. ###############################
 #: ../gramps/plugins/graph/gvhourglass.py:418
 #: ../gramps/plugins/graph/gvrelgraph.py:940
 msgid "Graph Style"
@@ -23248,7 +22929,6 @@ msgstr ""
 msgid "Determines what people are included in the graph"
 msgstr ""
 
-#. see bug report #11112
 #: ../gramps/plugins/graph/gvrelgraph.py:836
 msgid "Use hexagons"
 msgstr ""
@@ -23257,7 +22937,6 @@ msgstr ""
 msgid "Use hexagons to differentiate those of unknown gender."
 msgstr ""
 
-#. ###############################
 #: ../gramps/plugins/graph/gvrelgraph.py:865
 msgid "Dates and/or Places"
 msgstr ""
@@ -23336,7 +23015,6 @@ msgstr ""
 msgid "Thumbnail Location"
 msgstr ""
 
-#. occupation = BooleanOption(_("Include occupation"), False)
 #: ../gramps/plugins/graph/gvrelgraph.py:921
 msgid "Include occupation"
 msgstr ""
@@ -23445,10 +23123,6 @@ msgstr ""
 msgid "%s could not be opened\n"
 msgstr ""
 
-#. # a "GEDCOM import report" happens in GedcomParser so this is not needed:
-#. # (but the imports_test.py unittest currently requires it, so here it is)
-#. # a "VCARD import report" happens in VCardParser so this is not needed:
-#. # (but the imports_test.py unittest currently requires it, so here it is)
 #: ../gramps/plugins/importer/importcsv.py:129
 #: ../gramps/plugins/importer/importgedcom.py:154
 #: ../gramps/plugins/importer/importgeneweb.py:162
@@ -23654,12 +23328,10 @@ msgstr ""
 msgid "attributesource"
 msgstr ""
 
-#. ----------------------------------
 #: ../gramps/plugins/importer/importcsv.py:229
 msgid "child"
 msgstr ""
 
-#. ----------------------------------
 #: ../gramps/plugins/importer/importcsv.py:232
 msgid "mother"
 msgstr ""
@@ -23700,7 +23372,6 @@ msgstr ""
 msgid "place id"
 msgstr ""
 
-#. 2=double underline
 #: ../gramps/plugins/importer/importcsv.py:242
 #: ../gramps/plugins/tool/removespaces.py:190
 msgid "name"
@@ -23710,13 +23381,11 @@ msgstr ""
 msgid "type"
 msgstr ""
 
-#. 2=double underline
 #: ../gramps/plugins/importer/importcsv.py:244
 #: ../gramps/plugins/tool/removespaces.py:194
 msgid "latitude"
 msgstr ""
 
-#. 2=double underline
 #: ../gramps/plugins/importer/importcsv.py:245
 #: ../gramps/plugins/tool/removespaces.py:198
 msgid "longitude"
@@ -23751,7 +23420,7 @@ msgstr ""
 msgid "CSV import"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/importer/importcsv.py:374
 #: ../gramps/plugins/importer/importgeneweb.py:274
 #: ../gramps/plugins/importer/importvcard.py:249
@@ -23921,8 +23590,6 @@ msgstr ""
 msgid "Media directory %s is not writable"
 msgstr ""
 
-#. mediadir exists and writable -- User could have valuable stuff in
-#. it, have him remove it!
 #: ../gramps/plugins/importer/importgpkg.py:81
 #, python-format
 msgid ""
@@ -24282,20 +23949,12 @@ msgid ""
 "as text."
 msgstr ""
 
-#. feature requests 2356, 1658: avoid genitive form
-#. -------------------------------------------------------------------------
-#.
-#. Support functions
-#.
-#. -------------------------------------------------------------------------
-#. feature requests 2356, 1658: avoid genitive form
 #: ../gramps/plugins/importer/importxml.py:103
 #: ../gramps/plugins/tool/eventnames.py:137
 #, python-format
 msgid "%(event_name)s of %(family)s"
 msgstr ""
 
-#. feature requests 2356, 1658: avoid genitive form
 #: ../gramps/plugins/importer/importxml.py:105
 #: ../gramps/plugins/tool/eventnames.py:139
 #, python-format
@@ -24439,7 +24098,6 @@ msgid ""
 "Objects that are candidates to be merged:\n"
 msgstr ""
 
-#. there is no old style XML
 #: ../gramps/plugins/importer/importxml.py:809
 #: ../gramps/plugins/importer/importxml.py:1294
 #: ../gramps/plugins/importer/importxml.py:1566
@@ -24556,7 +24214,7 @@ msgstr ""
 msgid "Any note reference must have a 'hlink' attribute."
 msgstr ""
 
-#. TRANSLATORS: leave the {date} and {xml} untranslated in the format string,
+#. Translators: leave the {date} and {xml} untranslated in the format string,
 #. but you may re-order them if needed.
 #: ../gramps/plugins/importer/importxml.py:2528
 #, python-brace-format
@@ -24653,7 +24311,6 @@ msgstr ""
 msgid "Separation"
 msgstr ""
 
-#. Applies to Families
 #: ../gramps/plugins/lib/libgedcom.py:714
 msgid "Weight"
 msgstr ""
@@ -24662,7 +24319,6 @@ msgstr ""
 msgid "Line ignored "
 msgstr ""
 
-#. e.g. Illegal character (oxAB) (0xCB)... 1 NOTE xyz?pqr?lmn
 #: ../gramps/plugins/lib/libgedcom.py:1540
 #, python-format
 msgid "Illegal character%s"
@@ -24742,9 +24398,6 @@ msgid ""
 "referenced by note %(unknown)s.\n"
 msgstr ""
 
-#. message means that the element %s was ignored, but
-#. expressed the wrong way round because the message is
-#. truncated for output
 #: ../gramps/plugins/lib/libgedcom.py:3431
 #, python-format
 msgid "ADDR element ignored '%s'"
@@ -24809,18 +24462,14 @@ msgstr ""
 msgid "Multiple FILE in a single OBJE ignored"
 msgstr ""
 
-#. We have previously found a PLAC
 #: ../gramps/plugins/lib/libgedcom.py:5659
 msgid "A second PLAC ignored"
 msgstr ""
 
-#. For RootsMagic etc. Place Details e.g. address, hospital, ...
 #: ../gramps/plugins/lib/libgedcom.py:5798
 msgid "Detail"
 msgstr ""
 
-#. We have perviously found an ADDR, or have populated
-#. location from PLAC title
 #: ../gramps/plugins/lib/libgedcom.py:5811
 msgid "Location already populated; ADDR ignored"
 msgstr ""
@@ -24838,7 +24487,6 @@ msgstr ""
 msgid "REFN ignored"
 msgstr ""
 
-#. SOURce with the given gramps_id had no title
 #: ../gramps/plugins/lib/libgedcom.py:6503
 #, python-format
 msgid "No title - ID %s"
@@ -24901,7 +24549,6 @@ msgstr ""
 msgid "Publication date of source data"
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/lib/libgedcom.py:7386
 #, python-format
 msgid "Import from %s"
@@ -24942,8 +24589,6 @@ msgstr ""
 msgid "GEDCOM version"
 msgstr ""
 
-#. Allow Lineage-Linked etc. though it should be in
-#. uppercase  (Note: Gramps is not a validator! prc)
 #: ../gramps/plugins/lib/libgedcom.py:7521
 msgid "GEDCOM FORM should be in uppercase"
 msgstr ""
@@ -24998,8 +24643,6 @@ msgstr ""
 msgid "Submission: Ordinance process flag"
 msgstr ""
 
-#. Okay we have no clue which temple this is.
-#. We should tell the user and store it anyway.
 #: ../gramps/plugins/lib/libgedcom.py:7999
 msgid "Invalid temple code"
 msgstr ""
@@ -25014,8 +24657,6 @@ msgstr ""
 msgid "Your GEDCOM file is empty."
 msgstr ""
 
-#. First is used as default selection.
-#. As seen on the internet, ISO-xxx are listed as capital letters
 #: ../gramps/plugins/lib/libhtmlconst.py:51
 msgid "Unicode UTF-8 (recommended)"
 msgstr ""
@@ -25024,8 +24665,6 @@ msgstr ""
 msgid "Standard copyright"
 msgstr ""
 
-#. This must match _CC
-#. translators, long strings, have a look at Web report dialogs
 #: ../gramps/plugins/lib/libhtmlconst.py:111
 msgid "Creative Commons - By attribution"
 msgstr ""
@@ -28580,12 +28219,10 @@ msgstr ""
 msgid "Import from Pro-Gen"
 msgstr ""
 
-#. start feedback about import progress (GUI / TXT)
 #: ../gramps/plugins/lib/libprogen.py:498
 msgid "Initializing."
 msgstr ""
 
-#. Raise a error message
 #: ../gramps/plugins/lib/libprogen.py:515
 msgid "Not a supported Pro-Gen import file language"
 msgstr ""
@@ -28602,7 +28239,6 @@ msgstr ""
 msgid "Pro-Gen Import"
 msgstr ""
 
-#. Hmmm. Just use the plain text.
 #: ../gramps/plugins/lib/libprogen.py:1138
 #, python-format
 msgid "Date did not match: '%(text)s' (%(msg)s)"
@@ -28613,7 +28249,6 @@ msgstr ""
 msgid "Time: %s"
 msgstr ""
 
-#. start feedback about import progress (GUI/TXT)
 #: ../gramps/plugins/lib/libprogen.py:1207
 msgid "Importing persons."
 msgstr ""
@@ -28630,7 +28265,6 @@ msgstr ""
 msgid "Death cause"
 msgstr ""
 
-#. start feedback about import progress (GUI/TXT)
 #: ../gramps/plugins/lib/libprogen.py:1586
 msgid "Importing families."
 msgstr ""
@@ -28647,10 +28281,6 @@ msgstr ""
 msgid "future"
 msgstr ""
 
-#. We have seen some case insensitivity in DEF files ...
-#. F13: Father
-#. F14: Mother
-#. start feedback about import progress (GUI/TXT)
 #: ../gramps/plugins/lib/libprogen.py:1903
 msgid "Adding children."
 msgstr ""
@@ -28973,7 +28603,6 @@ msgstr ""
 msgid "The green values in the row correspond to the current place values."
 msgstr ""
 
-#. if we found no place, we must create a default place.
 #: ../gramps/plugins/lib/maps/placeselection.py:223
 msgid "New place with empty fields"
 msgstr ""
@@ -28995,12 +28624,10 @@ msgstr ""
 msgid "Denmark"
 msgstr ""
 
-#. TODO for Arabic, should the next line's comma be translated?
 #: ../gramps/plugins/mapservices/eniroswedenmap.py:81
 msgid " parish"
 msgstr ""
 
-#. TODO for Arabic, should the next line's comma be translated?
 #: ../gramps/plugins/mapservices/eniroswedenmap.py:87
 msgid " state"
 msgstr ""
@@ -29083,8 +28710,6 @@ msgid ""
 "Living matches: %(alive)d, Deceased matches: %(dead)d\n"
 msgstr ""
 
-#. display the results
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/quickview/all_events.py:57
 #, python-format
 msgid "Sorted events of %s"
@@ -29118,7 +28743,6 @@ msgstr ""
 msgid "Not found"
 msgstr ""
 
-#. display the results
 #: ../gramps/plugins/quickview/all_events.py:103
 #, python-format
 msgid ""
@@ -29215,7 +28839,6 @@ msgstr ""
 msgid "There are %d people with a matching attribute name.\n"
 msgstr ""
 
-#. else "nearby" comments are ignored
 #: ../gramps/plugins/quickview/filterbyname.py:41
 msgctxt "Filtering_on"
 msgid "all"
@@ -29467,7 +29090,7 @@ msgstr ""
 msgid "Size in bytes"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/quickview/filterbyname.py:420
 #, python-brace-format
 msgid "Filter matched {number_of} record."
@@ -29475,8 +29098,6 @@ msgid_plural "Filter matched {number_of} records."
 msgstr[0] ""
 msgstr[1] ""
 
-#. display the results
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/quickview/lineage.py:52
 #, python-format
 msgid "Father lineage for %s"
@@ -29502,8 +29123,6 @@ msgstr ""
 msgid "Direct line male descendants"
 msgstr ""
 
-#. display the results
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/quickview/lineage.py:83
 #, python-format
 msgid "Mother lineage for %s"
@@ -29538,7 +29157,6 @@ msgstr ""
 msgid "Unknown gender"
 msgstr ""
 
-#. display the title
 #: ../gramps/plugins/quickview/linkreferences.py:43
 msgid "Link References for this note"
 msgstr ""
@@ -29565,7 +29183,6 @@ msgstr ""
 msgid "No link references for this note"
 msgstr ""
 
-#. display the title
 #: ../gramps/plugins/quickview/onthisday.py:77
 #, python-format
 msgid "Events of %(date)s"
@@ -29714,7 +29331,6 @@ msgstr ""
 msgid "Display a person's siblings."
 msgstr ""
 
-#. display the title
 #: ../gramps/plugins/quickview/references.py:68
 #, python-format
 msgid "References for this %s"
@@ -29766,13 +29382,12 @@ msgstr ""
 msgid "Matches people with firstname missing"
 msgstr ""
 
-#. display the title
 #: ../gramps/plugins/quickview/samesurnames.py:113
 #, python-format
 msgid "People sharing the surname '%s'"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/quickview/samesurnames.py:135
 #: ../gramps/plugins/quickview/samesurnames.py:180
 #, python-brace-format
@@ -29782,14 +29397,11 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#. display the title
 #: ../gramps/plugins/quickview/samesurnames.py:158
 #, python-format
 msgid "People with the given name '%s'"
 msgstr ""
 
-#. display the title
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/quickview/siblings.py:46
 #, python-format
 msgid "Siblings of %s"
@@ -29960,7 +29572,6 @@ msgstr ""
 msgid "Entire Book"
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/textreport/ancestorreport.py:197
 #, python-format
 msgid "Ahnentafel Report for %s"
@@ -30001,7 +29612,6 @@ msgstr ""
 msgid "✝"
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/textreport/birthdayreport.py:221
 #, python-format
 msgid "Relationships shown are to %s"
@@ -30012,7 +29622,7 @@ msgstr ""
 msgid "* %(person)s, birth%(relation)s"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/textreport/birthdayreport.py:338
 #, python-brace-format
 msgid "* {year}{person}{dead}, {age}{relation}"
@@ -30027,7 +29637,7 @@ msgid ""
 " %(person)s, wedding"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/textreport/birthdayreport.py:407
 #, python-brace-format
 msgid ""
@@ -30253,7 +29863,6 @@ msgstr ""
 msgid "The style used for the spouse level %d display."
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/textreport/detancestralreport.py:216
 #, python-format
 msgid "Ancestral Report for %s"
@@ -30273,14 +29882,13 @@ msgstr ""
 msgid "%(name)s is the same person as [%(id_str)s]."
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/textreport/detancestralreport.py:361
 #: ../gramps/plugins/textreport/detdescendantreport.py:881
 #, python-format
 msgid "Notes for %s"
 msgstr ""
 
-#. translators: needed for French, ignore otherwise
+#. Translators: needed for French, ignore otherwise
 #: ../gramps/plugins/textreport/detancestralreport.py:379
 #: ../gramps/plugins/textreport/detancestralreport.py:430
 #: ../gramps/plugins/textreport/detancestralreport.py:498
@@ -30297,7 +29905,7 @@ msgstr ""
 msgid "Address: "
 msgstr ""
 
-#. translators: needed for Arabic, ignore otherwise
+#. Translators: needed for Arabic, ignore otherwise
 #: ../gramps/plugins/textreport/detancestralreport.py:417
 #: ../gramps/plugins/textreport/detdescendantreport.py:939
 #, python-format
@@ -30309,7 +29917,7 @@ msgstr ""
 msgid "%(event_role)s at %(event_name)s of %(primary_person)s: %(event_text)s"
 msgstr ""
 
-#. translators: needed for Arabic, ignore otherwise
+#. Translators: needed for Arabic, ignore otherwise
 #: ../gramps/plugins/textreport/detancestralreport.py:495
 #: ../gramps/plugins/textreport/detdescendantreport.py:415
 #: ../gramps/plugins/textreport/detdescendantreport.py:518
@@ -30465,8 +30073,6 @@ msgstr ""
 msgid "Whether to include images."
 msgstr ""
 
-#. #########################
-#. ###############################
 #: ../gramps/plugins/textreport/detancestralreport.py:931
 #: ../gramps/plugins/textreport/detdescendantreport.py:1120
 #: ../gramps/plugins/textreport/familygroup.py:782
@@ -30597,7 +30203,6 @@ msgstr ""
 msgid "The style used for details."
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/textreport/detdescendantreport.py:342
 #, python-format
 msgid "Descendant Report for %(person_name)s"
@@ -30670,13 +30275,11 @@ msgid ""
 "descendant."
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/textreport/endoflinereport.py:159
 #, python-format
 msgid "End of Line Report for %s"
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/textreport/endoflinereport.py:166
 #, python-format
 msgid "All the ancestors of %s who are missing a parent"
@@ -30733,7 +30336,6 @@ msgstr ""
 msgid "Create reports for all descendants of this family."
 msgstr ""
 
-#. #########################
 #: ../gramps/plugins/textreport/familygroup.py:755
 msgid "Parent Marriage"
 msgstr ""
@@ -30818,13 +30420,12 @@ msgstr ""
 msgid "The style used for the parent's name"
 msgstr ""
 
-#. make sure it's translated, so it can be used below, in "combine"
 #: ../gramps/plugins/textreport/indivcomplete.py:193
 #, python-format
 msgid "%(str1)s in %(str2)s. "
 msgstr ""
 
-#. for example (a stepfather): John Smith, relationship: Step
+#. Translators: e.g. (a stepfather): John Smith, relationship: Step
 #: ../gramps/plugins/textreport/indivcomplete.py:251
 #, python-format
 msgid "%(parent-name)s, relationship: %(rel-type)s"
@@ -30871,7 +30472,6 @@ msgid ""
 "Report'"
 msgstr ""
 
-#. ###############################
 #: ../gramps/plugins/textreport/indivcomplete.py:1116
 msgid "Include Notes"
 msgstr ""
@@ -30908,12 +30508,10 @@ msgstr ""
 msgid "Whether to include Census Events."
 msgstr ""
 
-#. ###############################
 #: ../gramps/plugins/textreport/indivcomplete.py:1162
 msgid "Sections"
 msgstr ""
 
-#. ###############################
 #: ../gramps/plugins/textreport/indivcomplete.py:1165
 msgid "Event groups"
 msgstr ""
@@ -30941,7 +30539,6 @@ msgstr ""
 msgid "The style used for image descriptions."
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/textreport/kinshipreport.py:125
 #, python-format
 msgid "Kinship Report for %s"
@@ -30996,7 +30593,6 @@ msgstr ""
 msgid "Failed"
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/textreport/numberofancestorsreport.py:104
 #, python-format
 msgid "Number of Ancestors for %s"
@@ -31009,8 +30605,6 @@ msgid_plural "Generation {number} has {count} individuals. {percent}"
 msgstr[0] ""
 msgstr[1] ""
 
-#. TC # English return something like:
-#. Total ancestors in generations 2 to 3 is 4. (66.67%)
 #: ../gramps/plugins/textreport/numberofancestorsreport.py:167
 #, python-format
 msgid ""
@@ -31018,8 +30612,6 @@ msgid ""
 "is %(count)d. %(percent)s"
 msgstr ""
 
-#. Write the title line. Set in INDEX marker so that this section will be
-#. identified as a major category if this is included in a Book report.
 #: ../gramps/plugins/textreport/placereport.py:128
 #: ../gramps/plugins/textreport/placereport.py:142
 #: ../gramps/plugins/textreport/placereport.py:159
@@ -31262,7 +30854,6 @@ msgstr ""
 msgid "You must first create a tag before running this report."
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/textreport/tagreport.py:116
 #, python-format
 msgid "Tag Report for %s Items"
@@ -31479,7 +31070,7 @@ msgstr ""
 msgid "No event record was modified."
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/changetypes.py:137
 #, python-brace-format
 msgid "{number_of} event record was modified."
@@ -31508,8 +31099,6 @@ msgstr ""
 msgid "Check Integrity"
 msgstr ""
 
-#. for bsddb the check_backlinks doesn't work in 'batch' mode because
-#. the table used for backlinks is closed.
 #: ../gramps/plugins/tool/check.py:231
 msgid "Check Backlink Integrity"
 msgstr ""
@@ -31622,10 +31211,6 @@ msgstr ""
 msgid "Looking for event problems"
 msgstr ""
 
-#. Now we go through our backlinks and the dbs table comparing them
-#. check that each real reference has a backlink in the db table
-#. Now we go through the db table and make checks against ours
-#. Check for db backlinks that don't have a reference object at all
 #: ../gramps/plugins/tool/check.py:1242 ../gramps/plugins/tool/check.py:1271
 #: ../gramps/plugins/tool/check.py:1296
 msgid "Looking for backlink reference problems"
@@ -31695,7 +31280,7 @@ msgstr ""
 msgid "No errors were found: the database has passed internal checks."
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2462
 #, python-brace-format
 msgid "{quantity} broken child/family link was fixed\n"
@@ -31712,7 +31297,7 @@ msgstr ""
 msgid "%(person)s was removed from the family of %(family)s\n"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2488
 #, python-brace-format
 msgid "{quantity} broken spouse/family link was fixed\n"
@@ -31729,7 +31314,7 @@ msgstr ""
 msgid "%(person)s was restored to the family of %(family)s\n"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2514
 #, python-brace-format
 msgid "{quantity} duplicate spouse/family link was found\n"
@@ -31737,7 +31322,7 @@ msgid_plural "{quantity} duplicate spouse/family links were found\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2542
 #, python-brace-format
 msgid "{quantity} family with no parents or children found, removed.\n"
@@ -31746,7 +31331,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2554
 #, python-brace-format
 msgid "{quantity} corrupted family relationship fixed\n"
@@ -31754,7 +31339,7 @@ msgid_plural "{quantity} corrupted family relationships fixed\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2562
 #, python-brace-format
 msgid "{quantity} place alternate name fixed\n"
@@ -31769,7 +31354,7 @@ msgid_plural "{quantity} persons were referenced, but not found\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2579
 #, python-brace-format
 msgid "{quantity} family was referenced but not found\n"
@@ -31777,7 +31362,7 @@ msgid_plural "{quantity} families were referenced, but not found\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2589
 #, python-brace-format
 msgid "{quantity} date was corrected\n"
@@ -31792,7 +31377,7 @@ msgid_plural "{quantity} repositories were referenced, but not found\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2608 ../gramps/plugins/tool/check.py:2695
 #, python-brace-format
 msgid "{quantity} media object was referenced but not found\n"
@@ -31803,11 +31388,11 @@ msgstr[1] ""
 #: ../gramps/plugins/tool/check.py:2619
 #, python-brace-format
 msgid "Reference to {quantity} missing media object was kept\n"
-msgid_plural "References to {quantity} media objects were kept\n"
+msgid_plural "References to {quantity} missing media objects were kept\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2627
 #, python-brace-format
 msgid "{quantity} missing media object was replaced\n"
@@ -31815,7 +31400,7 @@ msgid_plural "{quantity} missing media objects were replaced\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2635
 #, python-brace-format
 msgid "{quantity} missing media object was removed\n"
@@ -31823,7 +31408,7 @@ msgid_plural "{quantity} missing media objects were removed\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2643
 #, python-brace-format
 msgid "{quantity} event was referenced but not found\n"
@@ -31831,7 +31416,7 @@ msgid_plural "{quantity} events were referenced, but not found\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2651
 #, python-brace-format
 msgid "{quantity} invalid birth event name was fixed\n"
@@ -31839,7 +31424,7 @@ msgid_plural "{quantity} invalid birth event names were fixed\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2659
 #, python-brace-format
 msgid "{quantity} invalid death event name was fixed\n"
@@ -31847,7 +31432,7 @@ msgid_plural "{quantity} invalid death event names were fixed\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2667
 #, python-brace-format
 msgid "{quantity} place was referenced but not found\n"
@@ -31869,7 +31454,7 @@ msgid_plural "{quantity} sources were referenced, but not found\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2704
 #, python-brace-format
 msgid "{quantity} note object was referenced but not found\n"
@@ -31877,7 +31462,7 @@ msgid_plural "{quantity} note objects were referenced, but not found\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2714 ../gramps/plugins/tool/check.py:2724
 #, python-brace-format
 msgid "{quantity} tag object was referenced but not found\n"
@@ -31885,7 +31470,7 @@ msgid_plural "{quantity} tag objects were referenced, but not found\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2734
 #, python-brace-format
 msgid "{quantity} invalid name format reference was removed\n"
@@ -31900,7 +31485,7 @@ msgid_plural "{quantity} invalid source citations were fixed\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/check.py:2754
 #, python-brace-format
 msgid "{quantity} Duplicated Gramps ID fixed\n"
@@ -31969,57 +31554,10 @@ msgstr ""
 msgid "Generating dates"
 msgstr ""
 
-#. test invalid dates
-#. dateval = (4,7,1789,False,5,8,1876,False)
-#. for l in range(1,len(dateval)):
-#. d = Date()
-#. try:
-#. d.set(Date.QUAL_NONE,Date.MOD_NONE,
-#. Date.CAL_GREGORIAN,dateval[:l],"Text comment")
-#. dates.append( d)
-#. except DateError, e:
-#. d.set_as_text("Date identified value correctly as invalid.\n%s" % e)
-#. dates.append( d)
-#. except:
-#. d = Date()
-#. d.set_as_text("Date.set Exception %s" % ("".join(traceback.format_exception(*sys.exc_info())),))
-#. dates.append( d)
-#. for l in range(1,len(dateval)):
-#. d = Date()
-#. try:
-#. d.set(Date.QUAL_NONE,Date.MOD_SPAN,Date.CAL_GREGORIAN,dateval[:l],"Text comment")
-#. dates.append( d)
-#. except DateError, e:
-#. d.set_as_text("Date identified value correctly as invalid.\n%s" % e)
-#. dates.append( d)
-#. except:
-#. d = Date()
-#. d.set_as_text("Date.set Exception %s" % ("".join(traceback.format_exception(*sys.exc_info())),))
-#. dates.append( d)
-#. self.progress.step()
-#. d = Date()
-#. d.set(Date.QUAL_NONE,Date.MOD_NONE,
-#. Date.CAL_GREGORIAN,(44,7,1789,False),"Text comment")
-#. dates.append( d)
-#. d = Date()
-#. d.set(Date.QUAL_NONE,Date.MOD_NONE,
-#. Date.CAL_GREGORIAN,(4,77,1789,False),"Text comment")
-#. dates.append( d)
-#. d = Date()
-#. d.set(Date.QUAL_NONE,Date.MOD_SPAN,
-#. Date.CAL_GREGORIAN,
-#. (4,7,1789,False,55,8,1876,False),"Text comment")
-#. dates.append( d)
-#. d = Date()
-#. d.set(Date.QUAL_NONE,Date.MOD_SPAN,
-#. Date.CAL_GREGORIAN,
-#. (4,7,1789,False,5,88,1876,False),"Text comment")
-#. dates.append( d)
 #: ../gramps/plugins/tool/dateparserdisplaytest.py:181
 msgid "Date Test Plugin"
 msgstr ""
 
-#. create pass and fail tags
 #: ../gramps/plugins/tool/dateparserdisplaytest.py:187
 msgid "Pass"
 msgstr ""
@@ -32087,7 +31625,6 @@ msgstr ""
 msgid "%(event_name)s Date"
 msgstr ""
 
-#. This won't be shown in a tree
 #: ../gramps/plugins/tool/eventcmp.py:259
 #, python-format
 msgid "%(event_name)s Place"
@@ -32114,7 +31651,7 @@ msgstr ""
 msgid "Extract Event Description"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/eventnames.py:120
 #, python-brace-format
 msgid "{quantity} event description has been added"
@@ -32221,7 +31758,6 @@ msgstr ""
 msgid "Find database loop"
 msgstr ""
 
-#. start the progress indicator
 #: ../gramps/plugins/tool/findloop.py:93
 #: ../gramps/plugins/tool/notrelated.py:112
 #: ../gramps/plugins/tool/notrelated.py:257
@@ -32433,7 +31969,7 @@ msgstr ""
 msgid "Number of merges done"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/mergecitations.py:235
 #, python-brace-format
 msgid "{number_of} citation merged"
@@ -32459,13 +31995,12 @@ msgstr ""
 msgid "NotRelated"
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/tool/notrelated.py:173
 #, python-format
 msgid "Everyone in the database is related to %s"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #. TRANS: no singular form needed, as rows is always > 1
 #: ../gramps/plugins/tool/notrelated.py:262
 #, python-brace-format
@@ -32474,7 +32009,7 @@ msgid_plural "Setting tag for {number_of} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #. TRANS: No singular form is needed.
 #: ../gramps/plugins/tool/notrelated.py:305
 #, python-brace-format
@@ -32483,7 +32018,7 @@ msgid_plural "Finding relationships between {number_of} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/notrelated.py:385
 #, python-brace-format
 msgid "Looking for {number_of} person"
@@ -32491,7 +32026,7 @@ msgid_plural "Looking for {number_of} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/tool/notrelated.py:413
 #, python-brace-format
 msgid "Looking up the name of {number_of} person"
@@ -32716,17 +32251,14 @@ msgstr ""
 msgid "handle"
 msgstr ""
 
-#. 2=double underline
 #: ../gramps/plugins/tool/removespaces.py:140
 msgid "firstname"
 msgstr ""
 
-#. 2=double underline
 #: ../gramps/plugins/tool/removespaces.py:148
 msgid "alternate name"
 msgstr ""
 
-#. 2=double underline
 #: ../gramps/plugins/tool/removespaces.py:152
 msgid "group as"
 msgstr ""
@@ -32808,8 +32340,6 @@ msgstr ""
 msgid "Unused Objects"
 msgstr ""
 
-#. Add mark column
-#. Add ignore column
 #: ../gramps/plugins/tool/removeunused.py:188
 #: ../gramps/plugins/tool/verify.py:557
 msgid "Mark"
@@ -32886,7 +32416,6 @@ msgctxt "manual"
 msgid "Reorder_Gramps_ID"
 msgstr ""
 
-#. self.top.set_icon(ICON)
 #: ../gramps/plugins/tool/reorderids.py:221
 #: ../gramps/plugins/tool/reorderids.py:444
 #: ../gramps/plugins/tool/reorderids.py:536
@@ -33014,40 +32543,6 @@ msgstr ""
 msgid "Generating families"
 msgstr ""
 
-#. Create a family, that links to father and mother, but father does not
-#. link back
-#. Create a family, that misses the link to the father
-#. Create a family, that misses the link to the mother
-#. Create a family, that links to father and mother, but mother does not
-#. link back
-#. person2 = self.db.get_person_from_handle(person2_h)
-#. person2.add_family_handle(fam_h)
-#. self.db.commit_person(person2, self.trans)
-#. Create two married people of same sex.
-#. This is NOT detected as an error by plugins/tool/Check.py
-#. Create a family, that contains an invalid handle to for the father
-#. Create a family, that contains an invalid handle to for the mother
-#. person2 = self.db.get_person_from_handle(person2_h)
-#. person2.add_family_handle(fam_h)
-#. self.db.commit_person(person2, self.trans)
-#. Creates a family where the child does not link back to the family
-#. child = self.db.get_person_from_handle(child_h)
-#. person2.add_parent_family_handle(fam_h)
-#. self.db.commit_person(child, self.trans)
-#. Creates a family where the child is not linked, but the child links
-#. to the family
-#. Creates a family where the child is one of the parents
-#. Creates a couple that refer to a family that does not exist in the
-#. database.
-#. Creates a person having a non existing birth event handle set
-#. Creates a person having a non existing death event handle set
-#. Creates a person having a non existing event handle set
-#. Creates a person with a birth event having an empty type
-#. Creates a person with a death event having an empty type
-#. Creates a person with an event having an empty type
-#. This is NOT detected as an error by plugins/tool/Check.py
-#. Creates a person with a birth event pointing to nonexisting place
-#. Creates a person with an event pointing to nonexisting place
 #: ../gramps/plugins/tool/testcasegenerator.py:470
 #: ../gramps/plugins/tool/testcasegenerator.py:506
 #: ../gramps/plugins/tool/testcasegenerator.py:555
@@ -33313,7 +32808,7 @@ msgstr ""
 msgid "Data Verify tool"
 msgstr ""
 
-#. translators: needed for French+Arabic, ignore otherwise
+#. Translators: needed for French+Arabic, ignore otherwise
 #: ../gramps/plugins/tool/verify.py:318
 #, python-format
 msgid "%(severity)s: %(msg)s, %(type)s: %(gid)s, %(name)s"
@@ -33796,7 +33291,6 @@ msgstr ""
 msgid "Add global background colored gradient"
 msgstr ""
 
-#. colors, stored as hex values
 #: ../gramps/plugins/view/fanchart2wayview.py:317
 #: ../gramps/plugins/view/fanchartdescview.py:309
 #: ../gramps/plugins/view/fanchartview.py:406
@@ -33814,7 +33308,6 @@ msgstr ""
 msgid "Color for duplicates"
 msgstr ""
 
-#. algo for the fan angle distribution
 #: ../gramps/plugins/view/fanchart2wayview.py:324
 #: ../gramps/plugins/view/fanchartdescview.py:323
 msgid "Fan chart distribution"
@@ -33830,29 +33323,22 @@ msgstr ""
 msgid "Size proportional to number of descendants"
 msgstr ""
 
-#. show names one two line
 #: ../gramps/plugins/view/fanchart2wayview.py:335
 #: ../gramps/plugins/view/fanchartdescview.py:334
 #: ../gramps/plugins/view/fanchartview.py:418
 msgid "Show names on two lines"
 msgstr ""
 
-#. Flip names
 #: ../gramps/plugins/view/fanchart2wayview.py:339
 #: ../gramps/plugins/view/fanchartdescview.py:338
 #: ../gramps/plugins/view/fanchartview.py:422
 msgid "Flip name on the left of the fan"
 msgstr ""
 
-#. Show gramps id
 #: ../gramps/plugins/view/fanchart2wayview.py:343
 msgid "Show the gramps id"
 msgstr ""
 
-#. options we don't show on the dialog
-#. #configdialog.add_checkbox(table,
-#. #        _('Allow radial text'),
-#. #        ??, 'interface.fanview-radialtext')
 #: ../gramps/plugins/view/fanchart2wayview.py:346
 #: ../gramps/plugins/view/fanchartdescview.py:345
 #: ../gramps/plugins/view/fanchartview.py:437
@@ -33867,7 +33353,6 @@ msgstr ""
 msgid "No preview available"
 msgstr ""
 
-#. form of the fan
 #: ../gramps/plugins/view/fanchartdescview.py:316
 #: ../gramps/plugins/view/fanchartview.py:411
 msgid "Fan chart type"
@@ -33888,8 +33373,6 @@ msgstr ""
 msgid "Quadrant"
 msgstr ""
 
-#. show gramps_id
-#. Show the gramps_id
 #: ../gramps/plugins/view/fanchartdescview.py:342
 #: ../gramps/plugins/view/fanchartview.py:430
 msgid "Show gramps id"
@@ -33899,7 +33382,6 @@ msgstr ""
 msgid "Print or save the Fan Chart View"
 msgstr ""
 
-#. options users should not change:
 #: ../gramps/plugins/view/fanchartview.py:426
 msgid "Show children ring"
 msgstr ""
@@ -34442,7 +33924,6 @@ msgstr ""
 msgid "_Next"
 msgstr ""
 
-#. Mouse scroll direction setting.
 #: ../gramps/plugins/view/pedigreeview.py:1681
 msgid "Mouse scroll direction"
 msgstr ""
@@ -34595,7 +34076,7 @@ msgstr ""
 msgid "Remove person as parent in this family"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/view/relview.py:1044
 #: ../gramps/plugins/view/relview.py:1099
 #, python-brace-format
@@ -34673,7 +34154,7 @@ msgstr ""
 msgid "Please run the Check and Repair Database tool"
 msgstr ""
 
-#. translators: leave all/any {...} untranslated
+#. Translators: leave all/any {...} untranslated
 #: ../gramps/plugins/view/relview.py:1564
 #: ../gramps/plugins/view/relview.py:1610
 #, python-brace-format
@@ -34860,7 +34341,6 @@ msgstr ""
 msgid "A view displaying citations and sources in a tree format."
 msgstr ""
 
-#. Add xml, doctype, meta and stylesheets
 #: ../gramps/plugins/webreport/addressbook.py:89
 #: ../gramps/plugins/webreport/addressbooklist.py:82
 #: ../gramps/plugins/webreport/basepage.py:1748
@@ -34869,7 +34349,6 @@ msgstr ""
 msgid "Address Book"
 msgstr ""
 
-#. Address Book Page message
 #: ../gramps/plugins/webreport/addressbooklist.py:91
 msgid ""
 "This page contains an index of all the individuals in the database, sorted "
@@ -34920,16 +34399,13 @@ msgstr ""
 msgid "%(http_break)sCreated for %(subject_url)s"
 msgstr ""
 
-#. Begin Navigation Menu--
-#. is the style sheet either Basic-Blue or Visually Impaired,
-#. and menu layout is Drop Down?
-#. Basic Blue style sheet with navigation menus
+#. Translators: Basic Blue style sheet with navigation menus
 #: ../gramps/plugins/webreport/basepage.py:1680
 #: ../gramps/plugins/webstuff/webstuff.py:65
 msgid "Basic-Blue"
 msgstr ""
 
-#. Visually Impaired style sheet with its navigation menus
+#. Translators: Visually Impaired style sheet with its navigation menus
 #: ../gramps/plugins/webreport/basepage.py:1681
 #: ../gramps/plugins/webstuff/webstuff.py:97
 msgid "Visually Impaired"
@@ -34958,7 +34434,6 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#. add contact column
 #: ../gramps/plugins/webreport/basepage.py:1750
 #: ../gramps/plugins/webreport/basepage.py:1947
 #: ../gramps/plugins/webreport/basepage.py:1984
@@ -35049,8 +34524,6 @@ msgstr ""
 msgid "MD5"
 msgstr ""
 
-#. We have several files to download
-#. but all file names are empty
 #: ../gramps/plugins/webreport/download.py:178
 msgid "No file to download"
 msgstr ""
@@ -35083,7 +34556,6 @@ msgstr ""
 msgid "Creating family pages..."
 msgstr ""
 
-#. Families list page message
 #: ../gramps/plugins/webreport/family.py:148
 msgid ""
 "This page contains an index of all the families/ relationships in the "
@@ -35144,7 +34616,6 @@ msgid ""
 "%(total_pages)d%(strong_end)s"
 msgstr ""
 
-#. missing media error message
 #: ../gramps/plugins/webreport/media.py:427
 msgid "The file has been moved or deleted."
 msgstr ""
@@ -35196,8 +34667,6 @@ msgstr ""
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr ""
 
-#. Only the name of the husband is known
-#. Only the name of the wife is known
 #: ../gramps/plugins/webreport/narrativeweb.py:845
 #: ../gramps/plugins/webreport/narrativeweb.py:849
 #, python-format
@@ -35526,8 +34995,6 @@ msgstr ""
 msgid "A note to be used as the page footer"
 msgstr ""
 
-#. This option will be available only if you select ".php" in the
-#. "File extension" from the "Html" tab
 #: ../gramps/plugins/webreport/narrativeweb.py:2212
 msgid "PHP user session"
 msgstr ""
@@ -36014,7 +35481,6 @@ msgstr ""
 msgid "Creating individual pages"
 msgstr ""
 
-#. Individual List page message
 #: ../gramps/plugins/webreport/person.py:199
 msgid ""
 "This page contains an index of all the individuals in the database, sorted "
@@ -36039,7 +35505,6 @@ msgstr ""
 msgid "Tracking %s"
 msgstr ""
 
-#. page description
 #: ../gramps/plugins/webreport/person.py:922
 msgid ""
 "This map page represents that person and any descendants with all of their "
@@ -36097,7 +35562,6 @@ msgstr ""
 msgid "Creating place pages"
 msgstr ""
 
-#. place list page message
 #: ../gramps/plugins/webreport/place.py:161
 msgid ""
 "This page contains an index of all the places in the database, sorted by "
@@ -36116,12 +35580,10 @@ msgstr ""
 msgid "Places beginning with letter %s"
 msgstr ""
 
-#. section title
 #: ../gramps/plugins/webreport/place.py:407
 msgid "Place Map"
 msgstr ""
 
-#. set progress bar pass for Repositories
 #: ../gramps/plugins/webreport/repository.py:105
 msgid "Creating repository pages"
 msgstr ""
@@ -36166,7 +35628,6 @@ msgstr ""
 msgid "Narrative web content report for"
 msgstr ""
 
-#. feature request 2356: avoid genitive form
 #: ../gramps/plugins/webreport/surname.py:121
 #, python-format
 msgid ""
@@ -36179,7 +35640,6 @@ msgstr ""
 msgid "Surnames by person count"
 msgstr ""
 
-#. page message
 #: ../gramps/plugins/webreport/surnamelist.py:110
 msgid ""
 "This page contains an index of all the surnames in the database. Selecting a "
@@ -36216,19 +35676,11 @@ msgid ""
 "%(days)d days and for a maximum of %(nb)d objects per object type."
 msgstr ""
 
-#. An optional link to a home page
-#. Note. We use '/' here because it is a URL, not a OS
-#. dependent pathname need to leave home link alone,
-#. so look for it ...
 #: ../gramps/plugins/webreport/webcal.py:193
 #: ../gramps/plugins/webreport/webcal.py:649
 msgid "NarrativeWeb Home"
 msgstr ""
 
-#. _('translation')
-#. Number of directory levels up to get to self.html_dir / root
-#. Number of directory levels up to get to root
-#. generate progress pass for "Year At A Glance"
 #: ../gramps/plugins/webreport/webcal.py:336
 #: ../gramps/plugins/webreport/webcal.py:1030
 #: ../gramps/plugins/webreport/webcal.py:1115
@@ -36241,7 +35693,6 @@ msgstr ""
 msgid "Calculating Holidays for year %04d"
 msgstr ""
 
-#. Add a link for year_glance() if requested
 #: ../gramps/plugins/webreport/webcal.py:631
 #: ../gramps/plugins/webreport/webcal.py:674
 msgid "Full year at a Glance"
@@ -36255,7 +35706,6 @@ msgstr ""
 msgid "Creating Year At A Glance calendar"
 msgstr ""
 
-#. page title
 #: ../gramps/plugins/webreport/webcal.py:1122
 #, python-format
 msgid "%(year)d, At A Glance"
@@ -36268,7 +35718,6 @@ msgid ""
 "shows all the events for that date, if there are any.\n"
 msgstr ""
 
-#. page title
 #: ../gramps/plugins/webreport/webcal.py:1191
 msgid "One Day Within A Year"
 msgstr ""
@@ -36493,46 +35942,41 @@ msgstr ""
 msgid "Provides a collection of resources for the web"
 msgstr ""
 
-#. id, user selectable?, translated_name, option name, fullpath,
-#. navigation target name, images, javascript
-#. "default" is used as default
-#. default style sheet in the options
-#. Basic Ash style sheet
+#. Translators: Basic Ash style sheet
 #: ../gramps/plugins/webstuff/webstuff.py:61
 msgid "Basic-Ash"
 msgstr ""
 
-#. Basic Cypress style sheet
+#. Translators: Basic Cypress style sheet
 #: ../gramps/plugins/webstuff/webstuff.py:69
 msgid "Basic-Cypress"
 msgstr ""
 
-#. basic Lilac style sheet
+#. Translators: Basic Lilac style sheet
 #: ../gramps/plugins/webstuff/webstuff.py:73
 msgid "Basic-Lilac"
 msgstr ""
 
-#. basic Peach style sheet
+#. Translators: Basic Peach style sheet
 #: ../gramps/plugins/webstuff/webstuff.py:77
 msgid "Basic-Peach"
 msgstr ""
 
-#. basic Spruce style sheet
+#. Translators: Basic Spruce style sheet
 #: ../gramps/plugins/webstuff/webstuff.py:81
 msgid "Basic-Spruce"
 msgstr ""
 
-#. Mainz style sheet with its images
+#. Translators: Mainz style sheet with its images
 #: ../gramps/plugins/webstuff/webstuff.py:85
 msgid "Mainz"
 msgstr ""
 
-#. Nebraska style sheet
+#. Translators: Nebraska style sheet
 #: ../gramps/plugins/webstuff/webstuff.py:93
 msgid "Nebraska"
 msgstr ""
 
-#. no style sheet option
 #: ../gramps/plugins/webstuff/webstuff.py:144
 msgid "No style sheet"
 msgstr ""

--- a/po/update_po.py
+++ b/po/update_po.py
@@ -423,8 +423,9 @@ def retrieve():
     listing('python.txt', ['.py', '.py.in'])
 
     # additional keywords must always be kept in sync with those in genpot.sh
-    os.system('''%(xgettext)s -F -c -j --directory=./ -d gramps '''
-              '''-L Python -o gramps.pot --files-from=python.txt '''
+    os.system('''%(xgettext)s -F --add-comments=Translators -j '''
+              '''--directory=./ -d gramps -L Python '''
+              '''-o gramps.pot --files-from=python.txt '''
               '''--debug --keyword=_ --keyword=ngettext '''
               '''--keyword=_T_ --keyword=trans_text:1,2c '''
               '''--keyword=_:1,2c --keyword=_T_:1,2c '''
@@ -437,8 +438,8 @@ def retrieve():
     # C format header (.h extension)
     for h in headers():
         print ('xgettext for %s' % h)
-        os.system('''%(xgettext)s -F --add-comments -j -o gramps.pot '''
-                  '''--keyword=N_ --from-code=UTF-8 %(head)s'''
+        os.system('''%(xgettext)s -F --add-comments=Translators -j '''
+                  '''-o gramps.pot --keyword=N_ --from-code=UTF-8 %(head)s'''
                   % {'xgettext': xgettextCmd, 'head': h}
                   )
     clean()


### PR DESCRIPTION
Previously all comments before a translated string were extracted.  This change prevents translators from seeing unnecessary or misleading  comments.

Changed the old tags "translator" and "TRANSLATOR" to "Translator".

Added some new tags to comments intended for translators.