### PR TITLE
Localization: const.py

### DIFF
--- a/gramps/gen/const.py
+++ b/gramps/gen/const.py
@@ -262,7 +262,7 @@ NO_GIVEN = "(%s)" % _("none", "given-name")
 ARABIC_COMMA = "،"
 ARABIC_SEMICOLON = "؛"
 DOCGEN_OPTIONS = 'Docgen Options'
-COLON = _(':') # Translators: needed for French, ignore otherwise
+COLON = _(': ') # translators: for RTL needed ' :', for French needed ' : ', for other language ': '
 
 #-------------------------------------------------------------------------
 #


### PR DESCRIPTION
Sign 'COLON' can translated for RTL, French and other languages.
Combination ':' + " " can resolve problems, e.g. this: https://github.com/gramps-project/gramps/pull/1223#discussion_r638147788
For work with COLON need change all 'STRING:' to 
`_('STRING{colon}').format(colon=COLON)`

I add whitespace after colon and change comment only.