### PR TITLE
Inherit month names from base class

### DIFF
--- a/gramps/gen/datehandler/_date_de.py
+++ b/gramps/gen/datehandler/_date_de.py
@@ -269,13 +269,6 @@ class DateDisplayDE(DateDisplay):
     German language date display class.
     """
 
-    long_months = (  "", "Januar", "Februar", "März", "April", "Mai",
-                    "Juni", "Juli", "August", "September", "Oktober",
-                    "November", "Dezember" )
-
-    short_months = ( "", "Jan", "Feb", "Mär", "Apr", "Mai", "Jun",
-                     "Jul", "Aug", "Sep", "Okt", "Nov", "Dez" )
-
     calendar = (
         "", "julianisch", "hebräisch",
         "französisch republikanisch", "persisch", "islamisch",


### PR DESCRIPTION
This should allow the German date handler to work with Austrian month names.