### PR TITLE
Display "[Missing surname]" for blank surname in peopletreemodel

### DIFF
--- a/gramps/gui/views/treemodels/peoplemodel.py
+++ b/gramps/gui/views/treemodels/peoplemodel.py
@@ -84,6 +84,7 @@ COLUMN_TAGS = 18
 COLUMN_PRIV = 19
 
 invalid_date_format = config.get('preferences.invalid-date-format')
+no_surname = config.get("preferences.no-surname-text")
 
 #-------------------------------------------------------------------------
 #
@@ -614,7 +615,7 @@ class PersonTreeModel(PeopleBaseModel, TreeBaseModel):
         return [_('Group As'), _('Name')]
 
     def column_header(self, node):
-        return node.name
+        return node.name if node.name else no_surname
 
     def add_row(self, handle, data):
         """


### PR DESCRIPTION
Persons where no surname was entered or the surname was entered into a wrong field, only an arrow is shown in the treeview person selector. This could confuse newbies, therefore a simple discription `[Missing surname]` would be helpful.

The problem came up in [#12333](https://gramps-project.org/bugs/view.php?id=12333)


Edit: Use `[Missing surname]` from preferences.no-surname-text instead of `[No surname]`