### PR TITLE
Fix bottombar always showing after restart, even when not wanted

### DIFF
--- a/gramps/gui/views/pageview.py
+++ b/gramps/gui/views/pageview.py
@@ -166,7 +166,7 @@ class PageView(DbGUIElement, metaclass=ABCMeta):
         self.widget.set_name('view')
         self.vpane.pack1(self.widget, resize=True, shrink=False)
         self.vpane.pack2(self.bottombar, resize=False, shrink=True)
-        self.vpane.show_all()
+        self.vpane.show()
         self._config.register('vpane.slider-position', -1)
         self.vpane.set_position(self._config.get('vpane.slider-position'))
 


### PR DESCRIPTION
Fixes #12338

Side effect of https://github.com/gramps-project/gramps/commit/912e5556e2775356c0803c38fcc3a5779af933a6
Seems I used a show_all() where it should have been just show().