### PR TITLE
Always filter the collation order, don't uselessly store it.

### DIFF
--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -364,12 +364,9 @@ class DBAPI(DbGeneric):
         :type locale: A GrampsLocale object.
         """
         if sort_handles:
-            if locale != glocale:
-                self.dbapi.check_collation(locale)
-
             self.dbapi.execute('SELECT handle FROM person '
                                'ORDER BY surname '
-                               'COLLATE "%s"' % locale.get_collation())
+                               'COLLATE "%s"' % self.dbapi.check_collation(locale))
         else:
             self.dbapi.execute("SELECT handle FROM person")
         rows = self.dbapi.fetchall()
@@ -386,9 +383,6 @@ class DBAPI(DbGeneric):
         :type locale: A GrampsLocale object.
         """
         if sort_handles:
-            if locale != glocale:
-                self.dbapi.check_collation(locale)
-
             sql = ('SELECT family.handle ' +
                    'FROM family ' +
                    'LEFT JOIN person AS father ' +
@@ -403,7 +397,7 @@ class DBAPI(DbGeneric):
                    'THEN mother.given_name ' +
                    'ELSE father.given_name ' +
                    'END) ' +
-                   'COLLATE "%s"' % locale.get_collation())
+                   'COLLATE "%s"' % self.dbapi.check_collation(locale))
             self.dbapi.execute(sql)
         else:
             self.dbapi.execute("SELECT handle FROM family")
@@ -430,12 +424,9 @@ class DBAPI(DbGeneric):
         :type locale: A GrampsLocale object.
         """
         if sort_handles:
-            if locale != glocale:
-                self.dbapi.check_collation(locale)
-
             self.dbapi.execute('SELECT handle FROM citation '
                                'ORDER BY page '
-                               'COLLATE "%s"' % locale.get_collation())
+                               'COLLATE "%s"' % self.dbapi.check_collation(locale))
         else:
             self.dbapi.execute("SELECT handle FROM citation")
         rows = self.dbapi.fetchall()
@@ -452,12 +443,9 @@ class DBAPI(DbGeneric):
         :type locale: A GrampsLocale object.
         """
         if sort_handles:
-            if locale != glocale:
-                self.dbapi.check_collation(locale)
-
             self.dbapi.execute('SELECT handle FROM source '
                                'ORDER BY title '
-                               'COLLATE "%s"' % locale.get_collation())
+                               'COLLATE "%s"' % self.dbapi.check_collation(locale))
         else:
             self.dbapi.execute("SELECT handle from source")
         rows = self.dbapi.fetchall()
@@ -474,12 +462,9 @@ class DBAPI(DbGeneric):
         :type locale: A GrampsLocale object.
         """
         if sort_handles:
-            if locale != glocale:
-                self.dbapi.check_collation(locale)
-
             self.dbapi.execute('SELECT handle FROM place '
                                'ORDER BY title '
-                               'COLLATE "%s"' % locale.get_collation())
+                               'COLLATE "%s"' % self.dbapi.check_collation(locale))
         else:
             self.dbapi.execute("SELECT handle FROM place")
         rows = self.dbapi.fetchall()
@@ -505,12 +490,9 @@ class DBAPI(DbGeneric):
         :type locale: A GrampsLocale object.
         """
         if sort_handles:
-            if locale != glocale:
-                self.dbapi.check_collation(locale)
-
             self.dbapi.execute('SELECT handle FROM media '
                                'ORDER BY desc '
-                               'COLLATE "%s"' % locale.get_collation())
+                               'COLLATE "%s"' % self.dbapi.check_collation(locale))
         else:
             self.dbapi.execute("SELECT handle FROM media")
         rows = self.dbapi.fetchall()
@@ -536,12 +518,9 @@ class DBAPI(DbGeneric):
         :type locale: A GrampsLocale object.
         """
         if sort_handles:
-            if locale != glocale:
-                self.dbapi.check_collation(locale)
-
             self.dbapi.execute('SELECT handle FROM tag '
                                'ORDER BY name '
-                               'COLLATE "%s"' % locale.get_collation())
+                               'COLLATE "%s"' % self.dbapi.check_collation(locale))
         else:
             self.dbapi.execute("SELECT handle FROM tag")
         rows = self.dbapi.fetchall()

--- a/gramps/plugins/db/dbapi/sqlite.py
+++ b/gramps/plugins/db/dbapi/sqlite.py
@@ -117,6 +117,8 @@ class Connection:
         collation = locale.get_collation().translate(self.__tmap)
         if collation not in self.__collations:
             self.__connection.create_collation(collation, locale.strcoll)
+            self.__collations.append(collation)
+        return collation
 
     def execute(self, *args, **kwargs):
         """


### PR DESCRIPTION
PySQLite3 chokes on collations that include the @ character used by
ICU so filter every query that passes a collation to convert it along
with '-', '.', '=', and ';' to '_'.

Don't bother saving an array of collations that isn't used anywhere.

Fixes https://gramps-project.org/bugs/view.php?id=12343.

@prculley, @Nick-Hall I'd like to get this into 5.1.4.