### PR TITLE
OsmGpsMap-CRITICAL: Map source setup called twice

### DIFF
--- a/gramps/plugins/lib/maps/geography.py
+++ b/gramps/plugins/lib/maps/geography.py
@@ -289,9 +289,6 @@ class GeoGraphyView(OsmGps, NavigationView):
         if self.active:
             self.bookmarks.redraw()
         self.build_tree()
-        if self.osm:
-            self.osm.grab_focus()
-            self.set_crosshair(config.get("geography.show_cross"))
 
     def can_configure(self):
         """

--- a/gramps/plugins/lib/maps/osmgps.py
+++ b/gramps/plugins/lib/maps/osmgps.py
@@ -182,14 +182,11 @@ class OsmGps:
             self.osm = DummyMapNoGpsPoint()
         else:
             if http_proxy:
-                self.osm = osmgpsmap.Map(tile_cache=tiles_path,
-                                         proxy_uri=http_proxy,
-                                         map_source=constants.MAP_TYPE[
-                                                                      map_type])
+                self.osm = osmgpsmap.Map(proxy_uri=http_proxy)
             else:
-                self.osm = osmgpsmap.Map(tile_cache=tiles_path,
-                                         map_source=constants.MAP_TYPE[
-                                                                      map_type])
+                self.osm = osmgpsmap.Map()
+            self.osm.set_property("tile_cache", tiles_path)
+            self.osm.set_property("map_source", constants.MAP_TYPE[map_type])
         self.osm.props.tile_cache = osmgpsmap.MAP_CACHE_AUTO
         current_map = osmgpsmap.MapOsd(show_dpad=False, show_zoom=True)
         self.end_selection = None

--- a/gramps/plugins/view/geoclose.py
+++ b/gramps/plugins/view/geoclose.py
@@ -246,6 +246,14 @@ class GeoClose(GeoGraphyView):
         self.add_item = None
         self.newmenu = None
         self.config_meeting_slider = None
+        self.dbstate.connect('database-changed', self.reset_change_db)
+
+    def reset_change_db(self, dummy_dbase):
+        """
+        Used to reset the family reference
+        """
+        self.refperson = None
+
 
     def get_title(self):
         """

--- a/gramps/plugins/view/geofamclose.py
+++ b/gramps/plugins/view/geofamclose.py
@@ -243,6 +243,13 @@ class GeoFamClose(GeoGraphyView):
         self.cal = config.get('preferences.calendar-format-report')
         self.no_show_places_in_status_bar = False
         self.config_meeting_slider = None
+        self.dbstate.connect('database-changed', self.reset_change_db)
+
+    def reset_change_db(self, dummy_dbase):
+        """
+        Used to reset the family reference
+        """
+        self.reffamily = None
 
     def get_title(self):
         """


### PR DESCRIPTION
This message is relative to the osm-gps-map library after some changes.