### PR TITLE
Fix Statusbar progress being shown before use

### DIFF
--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -291,12 +291,13 @@ class ViewManager(CLIManager):
 
         self.hpane.add2(self.notebook)
         toolbar = self.uimanager.get_widget('ToolBar')
+        toolbar.show_all()
         self.statusbar = Statusbar()
         self.statusbar.show()
         vbox.pack_end(self.statusbar, False, True, 0)
         vbox.pack_start(toolbar, False, True, 0)
         vbox.pack_end(self.hpane, True, True, 0)
-        vbox.show_all()
+        vbox.show()
 
         self.uistate = DisplayState(self.window, self.statusbar,
                                     self.uimanager, self)


### PR DESCRIPTION
Fixes #12373

The status bar progress indicator shows up after Gramps startup and hangs around until user does something that updates it.
Another side effect of my attempt to fix the pane creep https://github.com/gramps-project/gramps/pull/1122.

This time I only do show_all on the toolbar...