### PR TITLE
Update Debian folder for Gramps 5.1.4 release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+gramps (5.1.4-1) unstable; urgency=medium
+
+  * New release
+  * Add new copyrights
+  * Update watch file
+  * Patch probably alive test to fix FTBFS
+
+ -- Ross Gammon <rossgammon@debian.org>  Sun, 15 Aug 2021 18:31:56 +0200
+
 gramps (5.1.3-1) focal; urgency=medium
 
   * New release

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Name: Gramps
 Source: https://gramps-project.org
 
 Files: *
-Copyright: 2000-2007, 2020 Alex Roitman
+Copyright: 2000-2007, Alex Roitman
            2000-2002, Bruce J. DeGrasse
            2000-2008, Donald N. Allingham
            2000-2007, Martin Hawlisch
@@ -92,6 +92,8 @@ Copyright: 2000-2007, 2020 Alex Roitman
            2018, Robin van der Vliet
            2018, Theo van Rijn
            2019, Matthias Kemmer
+           2020, Jan Sparreboom
+           2021, Mirko Leonhaeuser
 License: GPL-2+
 
 Files: debian/*

--- a/debian/patches/fix-probably_alive_test.patch
+++ b/debian/patches/fix-probably_alive_test.patch
@@ -1,0 +1,22 @@
+Description: Fix probably alive test
+ The probably alive funtion was fixed just prior to the Gramps 5.1.4
+ release. It appears the relevant unit test was not updated to match.
+ The relevant commit:
+ https://github.com/gramps-project/gramps/commit/a685b96f700dcfc6b953413cb3adc8be61d87438
+Author: Ross Gammon <rossgammon@debian.org>
+Forwarded: no
+Applied-Upstream: no
+Last-Update: 2021-08-09
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/gramps/gen/filters/rules/test/person_rules_test.py
++++ b/gramps/gen/filters/rules/test/person_rules_test.py
+@@ -347,7 +347,7 @@
+         """
+         rule = ProbablyAlive(['1900'])
+         res = self.filter_with_rule(rule)
+-        self.assertEqual(len(res), 766)
++        self.assertEqual(len(res), 733)
+ 
+     def test_RegExpName(self):
+         """

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+fix-probably_alive_test.patch

--- a/debian/watch
+++ b/debian/watch
@@ -1,8 +1,6 @@
-version=3
-
+version=4
 opts=\
-dversionmangle=s/(\~|\+)(debian|dfsg|ds|deb)(\.\d+)?$//,\
-filenamemangle=s/.+\/v?(\d\S*)\.tar\.gz/$1\.tar\.gz/,\
+filenamemangle=s/.+\/v?(\d\S+)\.tar\.gz/gramps-project-$1\.tar\.gz/,\
 repacksuffix=~dfsg \
 https://github.com/gramps-project/gramps/tags \
-.*/archive/v?([\d\.]+).tar.gz
+.*/v?(\d\S+)\.tar\.gz


### PR DESCRIPTION
Sorry about the delay due to holidays. Deb file has been uploaded.
I had to create a patch to get the tests to pass so the build did not fail. I will do a PR separately for that.