### PR TITLE
Fix probably alive test

### DIFF
--- a/gramps/gen/filters/rules/test/person_rules_test.py
+++ b/gramps/gen/filters/rules/test/person_rules_test.py
@@ -347,7 +347,7 @@ class BaseTest(unittest.TestCase):
         """
         rule = ProbablyAlive(['1900'])
         res = self.filter_with_rule(rule)
-        self.assertEqual(len(res), 766)
+        self.assertEqual(len(res), 733)
 
     def test_RegExpName(self):
         """


### PR DESCRIPTION
The probably alive funtion was fixed just prior to the Gramps 5.1.4
release. It appears the relevant unit test was not updated to match.
The relevant commit:
https://github.com/gramps-project/gramps/commit/a685b96f700dcfc6b953413cb3adc8be61d87438

The failing unit test caused the build for the Debian package to fail.