### PR TITLE
Solve InterpolationSyntaxError if "%" in a string

### DIFF
--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -1239,6 +1239,12 @@ class GrampletPane(Gtk.ScrolledWindow):
                                     else:
                                         cnt = 0
                                         for item in base_opts["data"]:
+                                            # If we have a "%" in a string,
+                                            # escape it by writing "%%"
+                                            # to avoid InterpolationSyntaxError
+                                            # in python configparser module.
+                                            if isinstance(item, str):
+                                                item = item.replace("%", "%%")
                                             fp.write("data[%d]=%s\n" % (cnt, item))
                                             cnt += 1
                                 else:


### PR DESCRIPTION
The grampletpane module save data in a config file for all the gramplets added in the dashboard.
The python configparser module doesn't like if we have a "%" character in a string.
    
Fixes #012423