### PR TITLE
Add new Indonesian translation

### DIFF
--- a/gramps/gen/utils/grampslocale.py
+++ b/gramps/gen/utils/grampslocale.py
@@ -87,6 +87,7 @@ _LOCALE_NAMES = {
     'he': ('Hebrew_Israel', '1255', _("Hebrew")),
     'hr': ('Croatian_Croatia', '1250', _("Croatian")),
     'hu': ('Hungarian_Hungary', '1250', _("Hungarian")),
+    'id': ('Indonesian', '1057', _("Indonesian")),
     'is': ('Icelandic', '1252', _("Icelandic")),
     'it': ('Italian_Italy', '1252', _("Italian")),
     'ja': ('Japanese_Japan', '932', _("Japanese")),


### PR DESCRIPTION
I have already added an Indonesian translation on Weblate in response to a request.  We can merge this once the translation has been started.

@jralls @prculley How do I find the correct locale code for Indonesian?  Should it be "Indonesian" or "Indonesian_Indonesia"?
