### PR TITLE
Remove rounding when formatting a span

### DIFF
--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -429,11 +429,6 @@ class Span:
                               ).format(number_of=diff_tuple[0])
             detail += 1
         if self.precision == detail:
-            if diff_tuple[1] >= 6: # round up years
-                # Translators: leave all/any {...} untranslated
-                retval = ngettext("{number_of} year", "{number_of} years",
-                                  diff_tuple[0] + 1
-                                 ).format(number_of=diff_tuple[0] + 1)
             return retval
         if diff_tuple[1] != 0:
             if retval != "":


### PR DESCRIPTION
Removes the +1 when the Age precision is set to 1 (Years) and the month is >= 6

Bug [#12422](https://gramps-project.org/bugs/view.php?id=12422)