### PR TITLE
Fix Place.get_text_data_child_list

### DIFF
--- a/gramps/gen/lib/place.py
+++ b/gramps/gen/lib/place.py
@@ -228,7 +228,7 @@ class Place(CitationBase, NoteBase, MediaBase, UrlBase, PrimaryObject):
         """
 
         ret = (self.media_list + self.alt_loc + self.urls +
-               self.name.get_text_data_child_list() + self.alt_names)
+               [self.name] + self.alt_names)
         return ret
 
     def get_citation_child_list(self):


### PR DESCRIPTION
As found in https://github.com/gramps-project/gramps-webapi/issues/245, there is bug in the `Place` object's `get_text_data_child_list` method. This method is supposed to return a "list of child objects that may carry textual data". In the case of `Place`, this is most importantly its `name` and `alt_names` (while the now deprecated `title` is already returned as part of `get_text_data_list` as it's not an object itself. While `alt_names` is added correctly to the returned list, for `name` not the object is added but it's own `get_text_data_list`, which is a list of strings.
