### PR TITLE
Birthday on February 29 only taken into account every 4 years

### DIFF
--- a/gramps/gen/config.py
+++ b/gramps/gen/config.py
@@ -243,6 +243,7 @@ register('paths.quick-backup-filename',
 register('preferences.quick-backup-include-mode', False)
 register('preferences.date-format', 0)
 register('preferences.calendar-format-report', 0)
+register('preferences.february-29', False)  # False: 02/28; True: 03/01
 register('preferences.cprefix', 'C%04d')
 register('preferences.default-source', False)
 register('preferences.tag-on-import', False)

--- a/gramps/gen/config.py
+++ b/gramps/gen/config.py
@@ -158,6 +158,9 @@ register('behavior.welcome', 100)
 register('behavior.web-search-url', 'http://google.com/#&q=%(text)s')
 register('behavior.addons-url', "https://raw.githubusercontent.com/gramps-project/addons/master/gramps52")
 
+register('csv.dialect', 'excel')
+register('csv.delimiter', 0)  # 0 means comma
+
 register('database.backend', 'sqlite')
 register('database.compress-backup', True)
 register('database.backup-path', USER_HOME)

--- a/gramps/gen/const.py
+++ b/gramps/gen/const.py
@@ -376,3 +376,5 @@ EXPANDED = 2
 
 TYPE_BOX_NORMAL = 0
 TYPE_BOX_FAMILY = 1
+
+CSV_DELIMITERS = [',', ':', ';', '|', '\\t']

--- a/gramps/gen/utils/docgen/csvtab.py
+++ b/gramps/gen/utils/docgen/csvtab.py
@@ -30,8 +30,14 @@ import csv
 # gramps modules
 #
 #-------------------------------------------------------------------------
+from gramps.gen.const import CSV_DELIMITERS
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.config import config
 from .tabbeddoc import *
 from ...constfunc import win
+
+_ = glocale.translation.gettext
+
 
 class CSVTab(TabbedDoc):
 
@@ -51,7 +57,18 @@ class CSVTab(TabbedDoc):
 
         self.f = open(self.filename, "w",
                       encoding='utf_8_sig' if win() else 'utf_8')
-        self.writer = csv.writer(self.f)
+        my_dialect = config.get('csv.dialect')
+        delimiter = config.get('csv.delimiter')
+        for item in range(len(CSV_DELIMITERS)):
+            if item == delimiter:
+                if len(CSV_DELIMITERS[item]) == 1:
+                    my_delimiter = CSV_DELIMITERS[item]
+                else:
+                    my_delimiter = "\t"
+        if my_dialect == _("custom"):
+            self.writer = csv.writer(self.f, delimiter=my_delimiter)
+        else:
+            self.writer = csv.writer(self.f, dialect=my_dialect)
 
     def close(self):
         assert(self.f)

--- a/gramps/gen/utils/docgen/csvtab.py
+++ b/gramps/gen/utils/docgen/csvtab.py
@@ -65,7 +65,7 @@ class CSVTab(TabbedDoc):
                     my_delimiter = CSV_DELIMITERS[item]
                 else:
                     my_delimiter = "\t"
-        if my_dialect == _("custom"):
+        if my_dialect == _("Custom"):
             self.writer = csv.writer(self.f, delimiter=my_delimiter)
         else:
             self.writer = csv.writer(self.f, dialect=my_dialect)

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -1224,6 +1224,15 @@ class GrampsPreferences(ConfigureDialog):
         grid.attach(obox, 1, row, 2, 1)
 
         row += 1
+        # Birthday on february 29
+        active = config.get('preferences.february-29')
+        self.add_checkbox(
+            grid, _('Birthday on february 29 for non leap years'),
+            row, 'preferences.february-29', start=0, stop=2,
+            tooltip=_("For non leap year, the birthday is displayed in"
+                      " february 28 or march 1 (if checked) in calendars"))
+
+        row += 1
         # Place format:
         self.pformat = Gtk.ComboBox()
         renderer = Gtk.CellRendererText()

--- a/gramps/gui/csvdialect.py
+++ b/gramps/gui/csvdialect.py
@@ -1,0 +1,151 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2021-      Serge Noiraud
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# gui/columnorder.py
+
+"""
+Handle the csv format when exporting views
+"""
+
+# -------------------------------------------------------------------------
+#
+# python modules
+#
+# -------------------------------------------------------------------------
+import logging
+import csv
+
+# -------------------------------------------------------------------------
+#
+# GTK modules
+#
+# -------------------------------------------------------------------------
+from gi.repository import Gtk
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+#  -------------------------------------------------------------------------
+from gramps.gen.config import config
+from gramps.gen.const import CSV_DELIMITERS
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+
+_ = glocale.translation.gettext
+
+# -------------------------------------------------------------------------
+#
+# set up logging
+#
+# -------------------------------------------------------------------------
+__LOG = logging.getLogger(".CsvDialect")
+
+
+class CsvDialect(Gtk.Box):
+    """
+    Use a custom format for csv export views
+    """
+
+    def __init__(self):
+        """
+        Used to set the csv dialect.
+        We add the possibility to add a custom model where we
+        can change the delimiter.
+        """
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL)
+        hbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+
+        hbox.set_spacing(10)
+        hbox.pack_start(Gtk.Label(label=_('Choose your dialect')), False,
+                        False, 0)
+        comment = Gtk.Label(label=_('Changes are immediate.\n'
+                                    'This is used when exporting views'
+                                    ' in CSV format.'))
+        comment.set_justify(Gtk.Justification.LEFT)
+        hbox.pack_start(comment, False, False, 0)
+        hbox.pack_start(Gtk.Label(label=' '), False, True, 0)
+
+        self.pack_start(hbox, True, True, 0)
+
+        self.dialect = config.get('csv.dialect')
+        self.delimiter = config.get('csv.delimiter')
+
+        self.dialects = csv.list_dialects()
+        self.dialects.append(_("custom"))
+        self.buttons = []
+        button = None
+        self.entry = Gtk.ComboBox()
+
+        for dialect in self.dialects:
+            title = dialect
+            button = Gtk.RadioButton.new_with_mnemonic_from_widget(button,
+                                                                   title)
+            button.connect("toggled", self.on_toggled, self.entry)
+            self.buttons.append(button)
+            hbox.pack_start(button, False, True, 0)
+            if dialect == self.dialect:
+                button.set_active(True)
+
+        lwidget = Gtk.Label(label=_("Delimiter:"))
+        hbox.pack_start(lwidget, False, False, 0)
+
+        store = Gtk.ListStore(int, str)
+        idx = 0
+        for item in CSV_DELIMITERS:
+            store.append((idx, item))
+            idx += 1
+        self.entry.set_model(store)
+        cell = Gtk.CellRendererText()
+        self.entry.pack_start(cell, True)
+        self.entry.add_attribute(cell, 'text', 1)
+        for item in range(len(CSV_DELIMITERS)):
+            if item == self.delimiter:
+                self.entry.set_active(item)
+        self.entry.set_hexpand(False)
+        self.entry.connect('changed', self.on_changed)
+        hbox.pack_start(self.entry, False, True, 0)
+        if self.dialect == "custom":
+            self.entry.set_sensitive(True)
+        else:
+            self.entry.set_sensitive(False)
+
+    def on_changed(self, obj):
+        """
+        called when a button state change
+        save is immediate
+        """
+        sep_iter = obj.get_active_iter()
+
+        if sep_iter is not None:
+            model = obj.get_model()
+            sep = model[sep_iter][0]
+            config.set('csv.delimiter', sep)
+
+    def on_toggled(self, obj, entry):
+        """
+        called when a button state change
+        save is immediate
+        """
+        if obj.get_active():
+            button = obj.get_label()
+            config.set('csv.dialect', button)
+            if button == "custom":
+                entry.set_sensitive(True)
+            else:
+                entry.set_sensitive(False)

--- a/gramps/gui/csvdialect.py
+++ b/gramps/gui/csvdialect.py
@@ -87,7 +87,7 @@ class CsvDialect(Gtk.Box):
         self.delimiter = config.get('csv.delimiter')
 
         self.dialects = csv.list_dialects()
-        self.dialects.append(_("custom"))
+        self.dialects.append(_("Custom"))
         self.buttons = []
         button = None
         self.entry = Gtk.ComboBox()
@@ -120,7 +120,7 @@ class CsvDialect(Gtk.Box):
         self.entry.set_hexpand(False)
         self.entry.connect('changed', self.on_changed)
         hbox.pack_start(self.entry, False, True, 0)
-        if self.dialect == "custom":
+        if self.dialect == _("Custom"):
             self.entry.set_sensitive(True)
         else:
             self.entry.set_sensitive(False)
@@ -145,7 +145,7 @@ class CsvDialect(Gtk.Box):
         if obj.get_active():
             button = obj.get_label()
             config.set('csv.dialect', button)
-            if button == "custom":
+            if button == _("Custom"):
                 entry.set_sensitive(True)
             else:
                 entry.set_sensitive(False)

--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -58,6 +58,7 @@ from .pageview import PageView
 from .navigationview import NavigationView
 from ..uimanager import ActionGroup
 from ..columnorder import ColumnOrder
+from ..csvdialect import CsvDialect
 from gramps.gen.config import config
 from gramps.gen.errors import WindowActiveError, FilterError, HandleError
 from ..filters import SearchBar
@@ -1271,4 +1272,6 @@ class ListView(NavigationView):
                                             self.get_column_widths(),
                                             self.set_column_order,
                                             tree=not flat)
-        return [columnpage]
+        def csvdialect(configdialog):
+            return _('CSV Dialect'), CsvDialect()
+        return [columnpage, csvdialect]

--- a/gramps/plugins/drawreport/calendarreport.py
+++ b/gramps/plugins/drawreport/calendarreport.py
@@ -27,6 +27,7 @@
 from functools import partial
 import datetime
 import time
+import calendar
 
 #------------------------------------------------------------------------
 #
@@ -38,6 +39,7 @@ _ = glocale.translation.gettext
 from gramps.gen.const import URL_HOMEPAGE
 from gramps.gen.display.name import displayer as _nd
 from gramps.gen.errors import ReportError
+from gramps.gen.config import config
 from gramps.gen.plug.docgen import (FontStyle, ParagraphStyle, GraphicsStyle,
                                     FONT_SERIF, PARA_ALIGN_CENTER,
                                     PARA_ALIGN_LEFT, PARA_ALIGN_RIGHT,
@@ -54,7 +56,7 @@ from gramps.gen.utils.alive import probably_alive
 from gramps.gen.datehandler import displayer as date_displayer
 from gramps.gen.lib import (Date, EventRoleType, EventType, Name, NameType,
                             Person, Surname)
-from gramps.gen.lib.date import gregorian
+from gramps.gen.lib.date import (gregorian, Today)
 
 import gramps.plugins.lib.libholiday as libholiday
 from gramps.plugins.lib.libholiday import g2iso
@@ -333,6 +335,16 @@ class Calendar(Report):
                     day = birth_date.get_day()
 
                     prob_alive_date = Date(self.year, month, day)
+
+                    # if birth on february, 29, we must choose
+                    # the birthday in case of non-leap year
+                    if (not calendar.isleap(Today().get_year()) and
+                            month == 2 and day == 29):
+                        if config.get('preferences.february-29'):
+                            month = 3
+                            day = 1
+                        else:
+                            day = 28
 
                     nyears = self.year - year
                     # add some things to handle maiden name:

--- a/gramps/plugins/export/export.gpr.py
+++ b/gramps/plugins/export/export.gpr.py
@@ -33,7 +33,9 @@ plg = newplugin()
 plg.id = 'ex_csv'
 plg.name = _("Comma Separated Values Spreadsheet (CSV)")
 plg.name_accell = _("Comma _Separated Values Spreadsheet (CSV)")
-plg.description = _("CSV is a common spreadsheet format.")
+plg.description = _("CSV is a common spreadsheet format."
+                    "\nYou can change this behavior in the 'Configure active"
+                    " view' of any list-based view")
 plg.version = '1.0'
 plg.gramps_target_version = MODULE_VERSION
 plg.status = STABLE

--- a/gramps/plugins/export/exportcsv.py
+++ b/gramps/plugins/export/exportcsv.py
@@ -266,7 +266,7 @@ class CSVWriter:
                         my_delimiter = CSV_DELIMITERS[item]
                     else:
                         my_delimiter = "\t"
-            if my_dialect == _("custom"):
+            if my_dialect == _("Custom"):
                 self.g = csv.writer(self.fp, delimiter=my_delimiter)
             else:
                 self.g = csv.writer(self.fp, dialect=my_dialect)

--- a/gramps/plugins/export/exportcsv.py
+++ b/gramps/plugins/export/exportcsv.py
@@ -51,6 +51,8 @@ LOG = logging.getLogger(".ExportCSV")
 # Gramps modules
 #
 #-------------------------------------------------------------------------
+from gramps.gen.const import CSV_DELIMITERS
+from gramps.gen.config import config
 from gramps.gen.lib import EventType, Person
 from gramps.gen.lib.eventroletype import EventRoleType
 from gramps.gui.plug.export import WriterOptionBox
@@ -256,7 +258,18 @@ class CSVWriter:
             self.fp = open(self.filename, "w",
                            encoding='utf_8_sig' if win() else 'utf_8',
                            newline='')
-            self.g = csv.writer(self.fp)
+            my_dialect = config.get('csv.dialect')
+            delimiter = config.get('csv.delimiter')
+            for item in range(len(CSV_DELIMITERS)):
+                if item == delimiter:
+                    if len(CSV_DELIMITERS[item]) == 1:
+                        my_delimiter = CSV_DELIMITERS[item]
+                    else:
+                        my_delimiter = "\t"
+            if my_dialect == _("custom"):
+                self.g = csv.writer(self.fp, delimiter=my_delimiter)
+            else:
+                self.g = csv.writer(self.fp, dialect=my_dialect)
         except IOError as msg:
             msg2 = _("Could not create %s") % self.filename
             self.user.notify_error(msg2,str(msg))

--- a/gramps/plugins/importer/importcsv.py
+++ b/gramps/plugins/importer/importcsv.py
@@ -47,6 +47,7 @@ LOG = logging.getLogger(".ImportCSV")
 # Gramps modules
 #
 #-------------------------------------------------------------------------
+from gramps.gen.const import CSV_DELIMITERS
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
 ngettext = glocale.translation.ngettext # else "nearby" comments are ignored
@@ -269,8 +270,22 @@ class CSVParser:
 
     def read_csv(self, filehandle):
         "Read the data from the file and return it as a list."
+        my_dialect = config.get('csv.dialect')
+        delimiter = config.get('csv.delimiter')
+        for item in range(len(CSV_DELIMITERS)):
+            if item == delimiter:
+                if len(CSV_DELIMITERS[item]) == 1:
+                    my_delimiter = CSV_DELIMITERS[item]
+                else:
+                    my_delimiter = "\t"
         try:
-            data = [[r.strip() for r in row] for row in csv.reader(filehandle)]
+            if my_dialect == _("custom"):
+                data = [[r.strip() for r in row]
+                        for row in csv.reader(filehandle,
+                                              delimiter=my_delimiter)]
+            else:
+                data = [[r.strip() for r in row]
+                        for row in csv.reader(filehandle, dialect=my_dialect)]
         except csv.Error as err:
             self.user.notify_error(_('format error: line %(line)d: %(zero)s') % {
                         'line' : csv.reader.line_num, 'zero' : err } )

--- a/gramps/plugins/importer/importcsv.py
+++ b/gramps/plugins/importer/importcsv.py
@@ -279,7 +279,7 @@ class CSVParser:
                 else:
                     my_delimiter = "\t"
         try:
-            if my_dialect == _("custom"):
+            if my_dialect == _("Custom"):
                 data = [[r.strip() for r in row]
                         for row in csv.reader(filehandle,
                                               delimiter=my_delimiter)]

--- a/gramps/plugins/textreport/birthdayreport.py
+++ b/gramps/plugins/textreport/birthdayreport.py
@@ -27,6 +27,7 @@
 #
 #------------------------------------------------------------------------
 import datetime, time
+import calendar
 
 #------------------------------------------------------------------------
 #
@@ -37,8 +38,9 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 from gramps.gen.const import URL_HOMEPAGE
 from gramps.gen.errors import ReportError
+from gramps.gen.config import config
 from gramps.gen.lib import NameType, EventType, Name, Date, Person, Surname
-from gramps.gen.lib.date import gregorian
+from gramps.gen.lib.date import (gregorian, Today)
 from gramps.gen.relationship import get_relationship_calculator
 from gramps.gen.plug.docgen import (FontStyle, ParagraphStyle, GraphicsStyle,
                                     FONT_SERIF, PARA_ALIGN_RIGHT,
@@ -285,6 +287,16 @@ class BirthdayReport(Report):
                     day = birth_date.get_day()
 
                     prob_alive_date = Date(self.year, month, day)
+
+                    # if birth on february, 29, we must choose
+                    # the birthday in case of non-leap year
+                    if (not calendar.isleap(Today().get_year()) and
+                            month == 2 and day == 29):
+                        if config.get('preferences.february-29'):
+                            month = 3
+                            day = 1
+                        else:
+                            day = 28
 
                     nyears = self.year - year
                     # add some things to handle maiden name:

--- a/gramps/plugins/webreport/calendar.py
+++ b/gramps/plugins/webreport/calendar.py
@@ -969,6 +969,16 @@ class CalendarPage(BasePage):
                     # month and birth day
                     prob_alive_date = Date(this_year, month, day)
 
+                    # if birth on february, 29, we must choose
+                    # the birthday in case of non-leap year
+                    if (not calendar.isleap(Today().get_year()) and
+                            month == 2 and day == 29):
+                        if config.get('preferences.february-29'):
+                            month = 3
+                            day = 1
+                        else:
+                            day = 28
+
                     # add some things to handle maiden name:
                     father_surname = None # husband, actually
                     if person.gender == Person.FEMALE:

--- a/gramps/plugins/webreport/webcal.py
+++ b/gramps/plugins/webreport/webcal.py
@@ -1371,6 +1371,16 @@ return false;
                     # month and birth day
                     prob_alive_date = Date(this_year, month, day)
 
+                    # if birth on february, 29, we must choose
+                    # the birthday in case of non-leap year
+                    if (not calendar.isleap(Today().get_year()) and
+                            month == 2 and day == 29):
+                        if config.get('preferences.february-29'):
+                            month = 3
+                            day = 1
+                        else:
+                            day = 28
+
                     # add some things to handle maiden name:
                     father_surname = None # husband, actually
                     if person.gender == Person.FEMALE:


### PR DESCRIPTION
Fixes #012511
    
Birthday on February 29th only taken into account every 4 years
in the calendars
    
Added an option in the preferences display tab
If checked, we display the birthday on march 1 for non-leap years
If not checked, we display the birthday on february 28 for non-leap years
When we have a leap year, display the date on february 29
