### PR TITLE
Calendar gramplet: add the name of the days.

### DIFF
--- a/gramps/plugins/gramplet/calendargramplet.py
+++ b/gramps/plugins/gramplet/calendargramplet.py
@@ -50,6 +50,7 @@ class CalendarGramplet(Gramplet):
         self.gui.calendar.connect('day-selected-double-click',
                                   self.double_click)
         self.gui.calendar.set_display_options(
+            Gtk.CalendarDisplayOptions.SHOW_DAY_NAMES |
             Gtk.CalendarDisplayOptions.SHOW_HEADING)
         self.gui.get_container_widget().remove(self.gui.textview)
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)


### PR DESCRIPTION
The first day is define according on the LANG

https://gramps.discourse.group/t/built-in-calendar-gramplet/2080

Fixes [#12515](https://gramps-project.org/bugs/view.php?id=12515)