### PR TITLE
Fix wrong order for lat/lon in set_latlongitude

### DIFF
--- a/gramps/gui/editors/editplace.py
+++ b/gramps/gui/editors/editplace.py
@@ -189,10 +189,10 @@ class EditPlace(EditPrimary):
         try:
             parts = value.index(', ')
             if len(parts) == 2:
-                longitude = parts[0].strip().replace(',', '.')
-                latitude = parts[1].strip().replace(',', '.')
+                latitude = parts[0].strip().replace(',', '.')
+                longitude = parts[1].strip().replace(',', '.')
             else:
-                longitude, latitude = value.split(',')
+                latitude, longitude = value.split(',')
 
             self.longitude.set_text(longitude)
             self.latitude.set_text(latitude)

--- a/gramps/gui/editors/editplaceref.py
+++ b/gramps/gui/editors/editplaceref.py
@@ -183,10 +183,10 @@ class EditPlaceRef(EditReference):
         try:
             parts = value.index(', ')
             if len(parts) == 2:
-                longitude = parts[0].strip().replace(',', '.')
-                latitude = parts[1].strip().replace(',', '.')
+                latitude = parts[0].strip().replace(',', '.')
+                longitude = parts[1].strip().replace(',', '.')
             else:
-                longitude, latitude = value.split(',')
+                latitude, longitude = value.split(',')
 
             self.longitude.set_text(longitude)
             self.latitude.set_text(latitude)


### PR DESCRIPTION
Bug was introduced in pull request !1278

Before the fix this resulted in this:

![image](https://user-images.githubusercontent.com/1447163/147589734-a896c54b-2320-476e-a490-a74f8b9ed4b4.png)