### PR TITLE
Fix negative Span when dates are not Gregorian

### DIFF
--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -77,14 +77,14 @@ class Span:
         self.precision = 2
         self.negative = False
         if self.valid:
-            if self.date1.calendar != Date.CAL_GREGORIAN:
-                self.date1 = self.date1.to_calendar("gregorian")
-            if self.date2.calendar != Date.CAL_GREGORIAN:
-                self.date2 = self.date2.to_calendar("gregorian")
             if self.date1.sortval < self.date2.sortval:
                 self.date1 = date2
                 self.date2 = date1
                 self.negative = True
+            if self.date1.calendar != Date.CAL_GREGORIAN:
+                self.date1 = self.date1.to_calendar("gregorian")
+            if self.date2.calendar != Date.CAL_GREGORIAN:
+                self.date2 = self.date2.to_calendar("gregorian")
             if self.date1.get_modifier() == Date.MOD_NONE:
                 if   self.date2.get_modifier() == Date.MOD_NONE:
                     val = self.date1.sortval - self.date2.sortval

--- a/gramps/gen/lib/test/date_test.py
+++ b/gramps/gen/lib/test/date_test.py
@@ -38,7 +38,7 @@ from ...datehandler import get_date_formats, set_format
 from ...datehandler import parser as _dp
 from ...datehandler import displayer as _dd
 from ...datehandler._datedisplay import DateDisplayEn
-from ...lib.date import Date, DateError, Today, calendar_has_fixed_newyear
+from ...lib.date import Date, DateError, Today, calendar_has_fixed_newyear, Span
 
 date_tests = {}
 
@@ -431,6 +431,36 @@ class ArithmeticDateTest(BaseDateTest):
             val2 = eval(exp2)
             self.assertEqual(val1, val2,
                         "'%s' should be '%s' but was '%s'" % (exp1, val2, val1))
+
+#-------------------------------------------------------------------------
+#
+# SpanTest
+#
+#-------------------------------------------------------------------------
+class SpanTest(BaseDateTest):
+    """
+    Test spans.
+    """
+    tests = [((2000, 1, 31), (2000, 1, 1), 30),
+             ((1799, 11, 19), (8, 2, 18, Date.CAL_FRENCH), 10),
+             ((8, 2, 18, Date.CAL_FRENCH), (1799, 11, 4), 5),
+             ((8, 2, 18, Date.CAL_FRENCH), (3, 2, 9, Date.CAL_FRENCH), 1836)]
+
+    def test_evaluate(self):
+        for value1, value2, duration in self.tests:
+            date1 = self._get_date(value1)
+            date2 = self._get_date(value2)
+            span1 = Span(date1, date2)
+            self.assertEqual(int(span1), duration)
+            span2 = Span(date2, date1)
+            self.assertEqual(int(span2), -duration)
+
+    def _get_date(self, value):
+        date = Date()
+        if len(value) == 4:
+            date.set_calendar(value[3])
+        date.set_yr_mon_day(value[0], value[1], value[2])
+        return date
 
 #-------------------------------------------------------------------------
 #


### PR DESCRIPTION
A replacement fix for PR #1322.

Fixes [#12525](https://gramps-project.org/bugs/view.php?id=12525).