### PR TITLE
Fix month&day for French date format

### DIFF
--- a/gramps/gen/datehandler/_date_fr.py
+++ b/gramps/gen/datehandler/_date_fr.py
@@ -252,9 +252,6 @@ class DateDisplayFR(DateDisplay):
                "MOI Jour, Année",)  # 7
         # this definition must agree with its "_display_gregorian" method
 
-    def right(self, s, amount):
-        return s[-amount:]
-
     def _display_gregorian(self, date_val, **kwargs):
         """
         display gregorian calendar date in different format
@@ -276,8 +273,8 @@ class DateDisplayFR(DateDisplay):
                 if date_val[0] == date_val[1] == 0:
                     value = str(date_val[2])
                 else:
-                    value = self.dhformat.replace('%m', self.right('0'+str(date_val[1]),2))
-                    value = value.replace('%d', self.right('0'+str(date_val[0]),2))
+                    value = self.dhformat.replace('%m', str(date_val[1]).zfill(2))
+                    value = value.replace('%d', str(date_val[0]).zfill(2))
 
                     # base_display :
                     # value = value.replace('%Y', str(abs(date_val[2])))

--- a/gramps/gen/datehandler/_date_fr.py
+++ b/gramps/gen/datehandler/_date_fr.py
@@ -254,7 +254,7 @@ class DateDisplayFR(DateDisplay):
 
     def right(self, s, amount):
         return s[-amount:]
-    
+
     def _display_gregorian(self, date_val, **kwargs):
         """
         display gregorian calendar date in different format

--- a/gramps/gen/datehandler/_date_fr.py
+++ b/gramps/gen/datehandler/_date_fr.py
@@ -5,6 +5,7 @@
 #
 # Copyright (C) 2004-2006  Donald N. Allingham
 # Copyright (C) 2012       Mathieu MD
+# Copyright (C) 2022       Christophe aka khrys63
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/gramps/gen/datehandler/_date_fr.py
+++ b/gramps/gen/datehandler/_date_fr.py
@@ -251,6 +251,9 @@ class DateDisplayFR(DateDisplay):
                "MOI Jour, Année",)  # 7
         # this definition must agree with its "_display_gregorian" method
 
+    def right(self, s, amount):
+        return s[-amount:]
+    
     def _display_gregorian(self, date_val, **kwargs):
         """
         display gregorian calendar date in different format
@@ -272,8 +275,8 @@ class DateDisplayFR(DateDisplay):
                 if date_val[0] == date_val[1] == 0:
                     value = str(date_val[2])
                 else:
-                    value = self.dhformat.replace('%m', str(date_val[1]))
-                    value = value.replace('%d', str(date_val[0]))
+                    value = self.dhformat.replace('%m', self.right('0'+str(date_val[1]),2))
+                    value = value.replace('%d', self.right('0'+str(date_val[0]),2))
 
                     # base_display :
                     # value = value.replace('%Y', str(abs(date_val[2])))


### PR DESCRIPTION
In French, Day & month are on 2 characters
01 for January
01 for the first day of the month