### PR TITLE
Add xdg-utils to no longer needed list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ Prerequistes required for the following Addons to work:
 
 No longer needed:
 -----------------
+* Since Gramps 5.2:
+   **xdg-utils**
+
 * Since Gramps 4.2:
    **gir-webkit**
 


### PR DESCRIPTION
The dependency was removed in PR #1077.