### PR TITLE
Crash in narrative web if invalid latitude/longitude

### DIFF
--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -2878,6 +2878,16 @@ class BasePage:
             tbody += trow
 
         data = place.get_latitude()
+        v_lat, v_lon = conv_lat_lon(data, "0.0", "D.D8")
+        if not v_lat:
+            data += self._(":")
+            # We use the same message as in:
+            # gramps/gui/editors/editplace.py
+            # gramps/gui/editors/editplaceref.py
+            data += self._("Invalid latitude\n(syntax: 18\\u00b09'48.21\"S,"
+                           " -18.2412 or -18:9:48.21)")
+            # We need to convert "\\u00b0" to "&deg;" for html
+            data = data.replace("\\u00b0", "&deg;")
         if data != "":
             trow = Html('tr') + (
                 Html("td", self._("Latitude"), class_="ColumnAttribute",
@@ -2886,6 +2896,16 @@ class BasePage:
             )
             tbody += trow
         data = place.get_longitude()
+        v_lat, v_lon = conv_lat_lon("0.0", data, "D.D8")
+        if not v_lon:
+            data += self._(":")
+            # We use the same message as in:
+            # gramps/gui/editors/editplace.py
+            # gramps/gui/editors/editplaceref.py
+            data += self._("Invalid longitude\n(syntax: 18\\u00b09'48.21\"E,"
+                           " -18.2412 or -18:9:48.21)")
+            # We need to convert "\\u00b0" to "&deg;" for html
+            data = data.replace("\\u00b0", "&deg;")
         if data != "":
             trow = Html('tr') + (
                 Html("td", self._("Longitude"), class_="ColumnAttribute",

--- a/gramps/plugins/webreport/place.py
+++ b/gramps/plugins/webreport/place.py
@@ -523,11 +523,10 @@ class PlacePages(BasePage):
                                 if photo_hdle in self.report.obj_dict[Media]:
                                     tracelife += str(imglnk)
                                 break # We show only the first image
-                    scripts = Html()
-                    if self.mapservice == "Google":
-                        with Html("script", type="text/javascript",
-                                  indent=False) as jsc:
-                            scripts += jsc
+                    with Html("script", type="text/javascript",
+                              indent=False) as jsc:
+                        if self.mapservice == "Google":
+                            # scripts += jsc
                             # Google adds Latitude/ Longitude to its maps...
                             plce = placetitle.replace("'", "\\'")
                             jsc += MARKER_PATH % marker_path
@@ -537,18 +536,14 @@ class PlacePages(BasePage):
                                                 1, tracelife]],
                                               latitude, longitude,
                                               10)
-                    elif self.mapservice == "OpenStreetMap":
-                        with Html("script", type="text/javascript") as jsc:
-                            scripts += jsc
+                        elif self.mapservice == "OpenStreetMap":
                             jsc += MARKER_PATH % marker_path
                             jsc += OSM_MARKERS % ([[float(longitude),
                                                     float(latitude),
                                                     placetitle, tracelife]],
                                                   longitude, latitude, 10)
                             jsc += OPENLAYER
-                    else: # STAMEN
-                        with Html("script", type="text/javascript") as jsc:
-                            scripts += jsc
+                        else: # STAMEN
                             jsc += MARKER_PATH % marker_path
                             jsc += STAMEN_MARKERS % ([[float(longitude),
                                                        float(latitude),
@@ -556,7 +551,7 @@ class PlacePages(BasePage):
                                                      self.stamenopts,
                                                      longitude, latitude, 10)
                             jsc += OPENLAYER
-                    placedetail += scripts
+                    placedetail += jsc
 
         # add clearline for proper styling
         # add footer section

--- a/gramps/plugins/webreport/place.py
+++ b/gramps/plugins/webreport/place.py
@@ -495,11 +495,14 @@ class PlacePages(BasePage):
 
             # Begin inline javascript code because jsc is a
             # docstring, it does NOT have to be properly indented
+            latitude, longitude = conv_lat_lon(place.get_latitude(),
+                                               place.get_longitude(),
+                                               "D.D8")
+            if not (latitude and longitude):
+                # We have incorrect longitude and/or latitude for this place.
+                latitude = longitude = 0.0
             if self.placemappages:
                 if place and (place.lat and place.long):
-                    latitude, longitude = conv_lat_lon(place.get_latitude(),
-                                                       place.get_longitude(),
-                                                       "D.D8")
                     tracelife = " "
                     if self.create_media and media_list:
                         for fmedia in media_list:


### PR DESCRIPTION
We add a message after the latitude/longitude to show the value and the syntax.
For translators, I used the same message as in editplace.py and editplaceref.py, so no need to translate new strings.

Fixes [#12565](https://gramps-project.org/bugs/view.php?id=12565)