### PR TITLE
Enable window tracking for ConfigureDialog

### DIFF
--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -161,13 +161,15 @@ class ConfigureDialog(ManagedWindow):
     On save, a config file on which the dialog works, is saved to disk, and
     a callback called.
     """
-    def __init__(self, uistate, dbstate, configure_page_funcs, configobj,
-                 configmanager,
+    def __init__(self, uistate, dbstate, track,
+                 configure_page_funcs, configobj, configmanager,
                  dialogtitle=_("Preferences"), on_close=None):
         """
         Set up a configuration dialog
         :param uistate: a DisplayState instance
         :param dbstate: a DbState instance
+        :param track: {list of parent windows, [] if the main Gramps window
+                       is the parent}
         :param configure_page_funcs: a list of function that return a tuple
             (str, Gtk.Widget). The string is used as label for the
             configuration page, and the widget as the content of the
@@ -184,7 +186,7 @@ class ConfigureDialog(ManagedWindow):
         """
         self.dbstate = dbstate
         self.__config = configmanager
-        ManagedWindow.__init__(self, uistate, [], configobj)
+        ManagedWindow.__init__(self, uistate, track, configobj)
         self.set_window(Gtk.Dialog(title=dialogtitle), None, dialogtitle, None)
         self.window.add_button(_('_Close'), Gtk.ResponseType.CLOSE)
         self.panel = Gtk.Notebook()
@@ -571,7 +573,7 @@ class GrampsPreferences(ConfigureDialog):
             self.add_warnings_panel,
             self.add_researcher_panel,
             )
-        ConfigureDialog.__init__(self, uistate, dbstate, page_funcs,
+        ConfigureDialog.__init__(self, uistate, dbstate, [], page_funcs,
                                  GrampsPreferences, config,
                                  on_close=update_constants)
         help_btn = self.window.add_button(_('_Help'), Gtk.ResponseType.HELP)

--- a/gramps/gui/views/pageview.py
+++ b/gramps/gui/views/pageview.py
@@ -583,7 +583,7 @@ class PageView(DbGUIElement, metaclass=ABCMeta):
             config_funcs += self.bottombar.get_config_funcs()
 
         try:
-            ViewConfigureDialog(self.uistate, self.dbstate,
+            ViewConfigureDialog(self.uistate, self.dbstate, [],
                             config_funcs,
                             self, self._config, dialogtitle=title,
                             ident=_("%(cat)s - %(view)s") %
@@ -596,17 +596,22 @@ class ViewConfigureDialog(ConfigureDialog):
     """
     All views can have their own configuration dialog
     """
-    def __init__(self, uistate, dbstate, configure_page_funcs, configobj,
-                 configmanager,
-                 dialogtitle=_("Preferences"), on_close=None, ident=''):
-        self.ident = ident
-        ConfigureDialog.__init__(self, uistate, dbstate, configure_page_funcs,
+    def __init__(self, uistate, dbstate, track,
+                 configure_page_funcs, configobj, configmanager,
+                 dialogtitle=_("Preferences"), on_close=None, ident='',
+                 can_branch=False):
+        if can_branch:
+            self.view_title = (dialogtitle, dialogtitle)
+        else:
+            self.view_title = (_('Configure %s View') % ident, None)
+        ConfigureDialog.__init__(self, uistate, dbstate, track,
+                                 configure_page_funcs,
                                  configobj, configmanager,
                                  dialogtitle=dialogtitle, on_close=on_close)
         self.setup_configs('interface.viewconfiguredialog', 420, 500)
 
     def build_menu_names(self, obj):
-        return (_('Configure %s View') % self.ident, None)
+        return self.view_title
 
 class DummyPage(PageView):
     """


### PR DESCRIPTION
This PR modifies the ConfigureDialog and ViewConfigureDialog classes to allow window tracking data to be passed in and adds a parm to ViewConfigureDialog to enable use as a branch rather than leaf.

I required these modifications for the view I have been experimenting with and am currently keeping separate modified copies of these two classes which it would be best not to do.