### PR TITLE
Skip test3b_delete_tree_constraint iff $HOME is a subdirectory of /tmp

### DIFF
--- a/gramps/test/test/test_util_test.py
+++ b/gramps/test/test/test_util_test.py
@@ -175,6 +175,10 @@ class Test3(U.TestCase):
 
     def test3b_delete_tree_constraint(self):
         if self.home:
+            sep = os.path.sep
+            tmp = tempfile.gettempdir() + sep
+            if ((self.home + sep).startswith(tmp)):
+                self.skipTest("skipping delete_tree_constraint test")
             err = None
             try:
                 tu.delete_tree(self.home_junk)


### PR DESCRIPTION
Closes: https://gramps-project.org/bugs/view.php?id=12577

(the full reasoning is explained in the bugreport)