### PR TITLE
Skip some tests requiring an English locale on non-English systems

### DIFF
--- a/gramps/gen/filters/rules/test/event_rules_test.py
+++ b/gramps/gen/filters/rules/test/event_rules_test.py
@@ -39,6 +39,12 @@ TEST_DIR = os.path.abspath(os.path.join(DATA_DIR, "tests"))
 EXAMPLE = os.path.join(TEST_DIR, "example.gramps")
 GenericEventFilter = GenericFilterFactory('Event')
 
+def skipIfNotEnglish(obj):
+    from ....utils.grampslocale import GrampsLocale
+    if not GrampsLocale().language[0].startswith("en"):
+        obj.skipTest("skipping test for non-English language %s" % (GrampsLocale().language,))
+
+
 class BaseTest(unittest.TestCase):
     """
     Event rule tests.
@@ -171,6 +177,7 @@ class BaseTest(unittest.TestCase):
         """
         Test HasData rule.
         """
+        skipIfNotEnglish(self)
         rule = HasData(['Burial', 'before 1800', 'USA', ''])
         self.assertEqual(self.filter_with_rule(rule), set([
             'a5af0ed4211095487d2', 'a5af0ed36793c1d3e05',

--- a/gramps/gen/filters/rules/test/family_rules_test.py
+++ b/gramps/gen/filters/rules/test/family_rules_test.py
@@ -41,6 +41,11 @@ TEST_DIR = os.path.abspath(os.path.join(DATA_DIR, "tests"))
 EXAMPLE = os.path.join(TEST_DIR, "example.gramps")
 GenericFamilyFilter = GenericFilterFactory('Family')
 
+def skipIfNotEnglish(obj):
+    from ....utils.grampslocale import GrampsLocale
+    if not GrampsLocale().language[0].startswith("en"):
+        obj.skipTest("skipping test for non-English language %s" % (GrampsLocale().language,))
+
 class BaseTest(unittest.TestCase):
     """
     Family rule tests.
@@ -176,6 +181,7 @@ class BaseTest(unittest.TestCase):
         """
         Test HasEvent rule.
         """
+        skipIfNotEnglish(self)
         rule = HasEvent(['Marriage', 'before 1900', 'USA', '', 'Garner'])
         self.assertEqual(self.filter_with_rule(rule), set([
             'KSFKQCP4V0YXGM1LR9', '8ZFKQC3FRSHACOJBOU', '3XFKQCE7QUDJ99AVNV',

--- a/gramps/gen/filters/rules/test/person_rules_test.py
+++ b/gramps/gen/filters/rules/test/person_rules_test.py
@@ -59,6 +59,11 @@ from ..person import (
 TEST_DIR = os.path.abspath(os.path.join(DATA_DIR, "tests"))
 EXAMPLE = os.path.join(TEST_DIR, "example.gramps")
 
+def skipIfNotEnglish(obj):
+    from ....utils.grampslocale import GrampsLocale
+    if not GrampsLocale().language[0].startswith("en"):
+        obj.skipTest("skipping test for non-English language %s" % (GrampsLocale().language,))
+
 class BaseTest(unittest.TestCase):
     """
     Person rule tests.
@@ -238,6 +243,7 @@ class BaseTest(unittest.TestCase):
         """
         Test rule.
         """
+        skipIfNotEnglish(self)
         rule = HasBirth(['between 1600 and 1700', 'akron', ''])
         res = self.filter_with_rule(rule)
         self.assertEqual(len(res), 2)
@@ -246,6 +252,7 @@ class BaseTest(unittest.TestCase):
         """
         Test HasDeath rule.
         """
+        skipIfNotEnglish(self)
         rule = HasDeath(['between 1600 and 1700', 'ashtabula', ''])
         res = self.filter_with_rule(rule)
         self.assertEqual(len(res), 2)
@@ -254,6 +261,7 @@ class BaseTest(unittest.TestCase):
         """
         Test rule.
         """
+        skipIfNotEnglish(self)
         rule = HasEvent(['Birth', 'between 1600 and 1700', 'akron',
                          '', '', 1])
         res = self.filter_with_rule(rule)
@@ -271,6 +279,7 @@ class BaseTest(unittest.TestCase):
         """
         Test rule.
         """
+        skipIfNotEnglish(self)
         rule = HasFamilyEvent(['Marriage', 'after 1900', 'craw', ''])
         res = self.filter_with_rule(rule)
         self.assertEqual(len(res), 4)


### PR DESCRIPTION
Closes: https://gramps-project.org/bugs/view.php?id=12578

(the full reasoning is explained in the bugreport)

The check whether the tests should be skipped is a bit simplistic:

~~~python3
from ....utils.grampslocale import GrampsLocale
if not GrampsLocale().language[0].startswith("en"):
    self.skipTest("skipping test for non-English language %s" % (GrampsLocale().language,))
~~~

possible improvements:
- catch `IndexError`
- what if `GrampsLocale().language` contains multiple languages? is it sufficient if *any* of them is English? all? just the first?