### PR TITLE
Add more date handler tests

### DIFF
--- a/gramps/gen/datehandler/_date_cs.py
+++ b/gramps/gen/datehandler/_date_cs.py
@@ -50,6 +50,12 @@ class DateParserCZ(DateParser):
     Converts a text string into a Date object
     """
 
+    modifier_to_int = {
+        'před': Date.MOD_BEFORE,
+        'kolem': Date.MOD_ABOUT,
+        'po': Date.MOD_AFTER,
+    }
+
     quality_to_int = {
         'přibližně'  : Date.QUAL_ESTIMATED,
         'odhadem'    : Date.QUAL_ESTIMATED,

--- a/gramps/gen/datehandler/_date_da.py
+++ b/gramps/gen/datehandler/_date_da.py
@@ -66,6 +66,7 @@ class DateParserDa(DateParser):
     calendar_to_int = {
         'gregoriansk   '      : Date.CAL_GREGORIAN,
         'g'                   : Date.CAL_GREGORIAN,
+        'juliansk tidsregning': Date.CAL_JULIAN,
         'juliansk'            : Date.CAL_JULIAN,
         'j'                   : Date.CAL_JULIAN,
         'hebraisk'            : Date.CAL_HEBREW,
@@ -84,6 +85,7 @@ class DateParserDa(DateParser):
 
     quality_to_int = {
         'estimeret' : Date.QUAL_ESTIMATED,
+        'anslået'   : Date.QUAL_ESTIMATED,
         'beregnet'   : Date.QUAL_CALCULATED,
         }
 

--- a/gramps/gen/datehandler/_date_hu.py
+++ b/gramps/gen/datehandler/_date_hu.py
@@ -192,7 +192,7 @@ class DateParserHU(DateParser):
 #    month_to_int["Karácsony hava"] = 12
 #    month_to_int["Álom hava"] = 12
 
-    modifier_after_to_int={
+    modifier_to_int = {
         'előtt'      : Date.MOD_BEFORE,
         'körül'      : Date.MOD_ABOUT,
         'után'       : Date.MOD_AFTER,
@@ -215,6 +215,7 @@ class DateParserHU(DateParser):
     calendar_to_int = {
         'Gergely'              : Date.CAL_GREGORIAN,
         'Julián'               : Date.CAL_JULIAN,
+        'julián'               : Date.CAL_JULIAN,
         'héber'                : Date.CAL_HEBREW,
         'iszlám'               : Date.CAL_ISLAMIC,
         'francia köztársasági' : Date.CAL_FRENCH,

--- a/gramps/gen/datehandler/_date_is.py
+++ b/gramps/gen/datehandler/_date_is.py
@@ -60,7 +60,8 @@ class DateParserIs(DateParser):
         'á undan'  : Date.MOD_BEFORE,
         'eftir'   : Date.MOD_AFTER,
         'í kringum' : Date.MOD_ABOUT,
-        'uþb'      : Date.MOD_ABOUT
+        'uþb'      : Date.MOD_ABOUT,
+        'um'       : Date.MOD_ABOUT,
         }
 
     bce = ["f Kr"]

--- a/gramps/gen/datehandler/_date_ja.py
+++ b/gramps/gen/datehandler/_date_ja.py
@@ -54,8 +54,8 @@ class DateParserJA(DateParser):
     converted, the text string is assigned.
     """
 
-    # modifiers before the date
-    modifier_to_int = {
+    # modifiers after the date
+    modifier_after_to_int = {
         '以前' : Date.MOD_BEFORE,
         '以降' : Date.MOD_AFTER,
         '頃'   : Date.MOD_ABOUT,
@@ -68,6 +68,7 @@ class DateParserJA(DateParser):
         'およそ'    : Date.QUAL_ESTIMATED,
         'ごろ'      : Date.QUAL_ESTIMATED,
         '位'      : Date.QUAL_ESTIMATED,
+        'の見積り'  : Date.QUAL_ESTIMATED,
         '計算上'  : Date.QUAL_CALCULATED,
         }
 
@@ -163,16 +164,20 @@ class DateParserJA(DateParser):
         })
 
         _span_1 = ['から', '~', '〜']
-        _span_2 = ['まで', '']
+        _span_2 = ['まで']
         _range_1 = ['から', 'と', '~', '〜']
         _range_2 = ['までの間', 'の間']
-        self._span = re.compile(r"(?P<start>.+)(%s)(?P<stop>\d+)(%s)" %
+        self._span = re.compile(r"(?P<start>.+)(%s)(?P<stop>.+)(%s)" %
                                 ('|'.join(_span_1), '|'.join(_span_2)),
                                 re.IGNORECASE)
         self._range = re.compile(r"(?P<start>.+)(%s)(?P<stop>.+)(%s)" %
                                  ('|'.join(_range_1), '|'.join(_range_2)),
                                  re.IGNORECASE)
         self._numeric = re.compile(r"((\d+)年\s*)?((\d+)月\s*)?(\d+)?日?\s*$")
+        self._cal = re.compile(r"(.*?)\s*\(%s\)\s*(.*)" % self._cal_str,
+                               re.IGNORECASE)
+        self._qual = re.compile(r"(.*?)\s*%s\s*(.*)" % self._qual_str,
+                                re.IGNORECASE)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/gen/datehandler/_date_pt.py
+++ b/gramps/gen/datehandler/_date_pt.py
@@ -91,11 +91,13 @@ class DateParserPT(DateParser):
 
     quality_to_int = {
         'estimado'   : Date.QUAL_ESTIMATED,
+        'estimada'   : Date.QUAL_ESTIMATED,
         'est.'       : Date.QUAL_ESTIMATED,
         'est'        : Date.QUAL_ESTIMATED,
         'calc.'      : Date.QUAL_CALCULATED,
         'calc'       : Date.QUAL_CALCULATED,
         'calculado'  : Date.QUAL_CALCULATED,
+        'calculada'  : Date.QUAL_CALCULATED,
         }
 
     def init_strings(self):

--- a/gramps/gen/datehandler/_date_sr.py
+++ b/gramps/gen/datehandler/_date_sr.py
@@ -195,8 +195,10 @@ class DateParserSR(DateParser):
 
         'процењено'  : Date.QUAL_ESTIMATED,
         'про.'       : Date.QUAL_ESTIMATED,
+        'приближно'  : Date.QUAL_ESTIMATED,
         'израчунато' : Date.QUAL_CALCULATED,
         'изр.'       : Date.QUAL_CALCULATED,
+        'прорачунато': Date.QUAL_CALCULATED,
         }
 
     bce = ["пре нове ере", "пре Христа", "п.н.е."
@@ -215,7 +217,7 @@ class DateParserSR(DateParser):
         self._numeric = re.compile(
             r"((\d+)[/\. ])?\s*((\d+)[/\.])?\s*(\d+)\.?$")
 
-        _span_1 = ['od', 'од']
+        _span_1 = ['od', 'од', 'из']
         _span_2 = ['do', 'до']
         _range_1 = ['između', 'између']
         _range_2 = ['i', 'и']

--- a/gramps/gen/datehandler/_date_zh_CN.py
+++ b/gramps/gen/datehandler/_date_zh_CN.py
@@ -124,11 +124,12 @@ class DateParserZH_CN(DateParser):
         _span_2 = ['至']
         _range_1 = ['介于']
         _range_2 = ['与']
-        self._span = re.compile(r"(%s)(?P<start>.+)(%s)(?P<stop>\d+)" %
+        _range_3 = ['之间']
+        self._span = re.compile(r"(%s)\s*(?P<start>.+)\s*(%s)\s*(?P<stop>.+)" %
                                 ('|'.join(_span_1), '|'.join(_span_2)),
                                 re.IGNORECASE)
-        self._range = re.compile(r"(%s)(?P<start>.+)(%s)(?P<stop>\d+)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2)),
+        self._range = re.compile(r"(%s)\s*(?P<start>.+)\s*(%s)\s*(?P<stop>.+)\s*(%s)" %
+                                 ('|'.join(_range_1), '|'.join(_range_2), '|'.join(_range_3)),
                                  re.IGNORECASE)
         self._numeric = re.compile(r"((\d+)年\s*)?((\d+)月\s*)?(\d+)?日?\s*$")
 

--- a/gramps/gen/datehandler/_date_zh_TW.py
+++ b/gramps/gen/datehandler/_date_zh_TW.py
@@ -124,11 +124,12 @@ class DateParserZH_TW(DateParser):
         _span_2 = ['至']
         _range_1 = ['介於']
         _range_2 = ['與']
-        self._span = re.compile(r"(%s)(?P<start>.+)(%s)(?P<stop>\d+)" %
+        _range_3 = ['之間']
+        self._span = re.compile(r"(%s)\s*(?P<start>.+)\s*(%s)\s*(?P<stop>.+)" %
                                 ('|'.join(_span_1), '|'.join(_span_2)),
                                 re.IGNORECASE)
-        self._range = re.compile(r"(%s)(?P<start>.+)(%s)(?P<stop>\d+)" %
-                                 ('|'.join(_range_1), '|'.join(_range_2)),
+        self._range = re.compile(r"(%s)\s*(?P<start>.+)\s*(%s)\s*(?P<stop>.+)\s*(%s)" %
+                                 ('|'.join(_range_1), '|'.join(_range_2), '|'.join(_range_3)),
                                  re.IGNORECASE)
         self._numeric = re.compile(r"((\d+)年\s*)?((\d+)月\s*)?(\d+)?日?\s*$")
 

--- a/gramps/gen/datehandler/_dateparser.py
+++ b/gramps/gen/datehandler/_dateparser.py
@@ -308,13 +308,13 @@ class DateParser:
 
     _langs = set()
     def __init_prefix_tables(self):
+        ds = self._ds = DateStrings(self._locale)
         lang = self._locale.lang
         if lang in DateParser._langs:
             log.debug("Prefix tables for {} already built".format(lang))
             return
         else:
             DateParser._langs.add(lang)
-        ds = self._ds = DateStrings(self._locale)
         log.debug("Begin building parser prefix tables for {}".format(lang))
         _build_prefix_table(DateParser.month_to_int,
             _generate_variants(


### PR DESCRIPTION
Add tests for all languages with a custom date handler.

Fix date handlers for round trip.   Parsers should be able to parse the output from the displayer.

Split off from PR #1124.