### PR TITLE
Allow gramplets to have an orientation dependent layout

### DIFF
--- a/gramps/gen/plug/_gramplet.py
+++ b/gramps/gen/plug/_gramplet.py
@@ -484,3 +484,13 @@ class Gramplet:
         By default, assume that the gramplet has data.
         """
         self.set_has_data(True)
+
+    def set_orientation(self, orientation):
+        """
+        Called when the gramplet orientation changes. A gramplet may override
+        this if it has a preferred horizontal and vertical layout.
+
+        :param orientation: A Gtk.Orientation (VERTCIAL or HORIZONTAL)
+        :type orientation: int
+        """
+        pass

--- a/gramps/gui/views/pageview.py
+++ b/gramps/gui/views/pageview.py
@@ -150,10 +150,12 @@ class PageView(DbGUIElement, metaclass=ABCMeta):
         defaults = self.get_default_gramplets()
         self.sidebar = GrampletBar(self.dbstate, self.uistate, self,
                                    self.ident + "_sidebar",
-                                   defaults[0])
+                                   defaults[0],
+                                   Gtk.Orientation.VERTICAL)
         self.bottombar = GrampletBar(self.dbstate, self.uistate, self,
                                      self.ident + "_bottombar",
-                                     defaults[1])
+                                     defaults[1],
+                                     Gtk.Orientation.HORIZONTAL)
         hpane = Gtk.Paned()
         self.vpane = Gtk.Paned(orientation=Gtk.Orientation.VERTICAL)
         hpane.pack1(self.vpane, resize=True, shrink=False)

--- a/gramps/gui/widgets/grampletbar.py
+++ b/gramps/gui/widgets/grampletbar.py
@@ -90,7 +90,8 @@ class GrampletBar(Gtk.Notebook):
     """
     A class which defines the graphical representation of the GrampletBar.
     """
-    def __init__(self, dbstate, uistate, pageview, configfile, defaults):
+    def __init__(self, dbstate, uistate, pageview, configfile, defaults,
+                 orientation=Gtk.Orientation.VERTICAL):
         Gtk.Notebook.__init__(self)
 
         self.dbstate = dbstate
@@ -98,6 +99,7 @@ class GrampletBar(Gtk.Notebook):
         self.pageview = pageview
         self.configfile = os.path.join(VERSION_DIR, "%s.ini" % configfile)
         self.defaults = defaults
+        self.orientation = orientation
         self.detached_gramplets = []
         self.empty = False
         self.close_buttons = []
@@ -433,6 +435,8 @@ class GrampletBar(Gtk.Notebook):
         Called when a new page is added to the GrampletBar.
         """
         gramplet = self.get_nth_page(new_page)
+        if isinstance(gramplet, TabGramplet):
+            gramplet.set_orientation(self.orientation)
         if self.empty:
             if isinstance(gramplet, TabGramplet):
                 self.empty = False
@@ -633,6 +637,12 @@ class TabGramplet(Gtk.ScrolledWindow, GuiGramplet):
         Return the top level container widget.
         """
         return self
+
+    def set_orientation(self, orientation):
+        """
+        Called when the gramplet orientation changes.
+        """
+        self.pui.set_orientation(orientation)
 
 #-------------------------------------------------------------------------
 #

--- a/gramps/plugins/gramplet/gallery.py
+++ b/gramps/plugins/gramplet/gallery.py
@@ -52,6 +52,12 @@ class Gallery(Gramplet):
         self.top = Gtk.Box(spacing=3)
         return self.top
 
+    def set_orientation(self, orientation):
+        """
+        Called when the gramplet orientation changes.
+        """
+        self.top.set_orientation(orientation)
+
     def clear_images(self):
         """
         Remove all images from the Gramplet.


### PR DESCRIPTION
Implement this for the gallery gramplets.

To test drag a gallery gramplet between the bottombar and sidebar.

Replaces PR #1001.