### PR TITLE
Check that view exists before calling post_create method

### DIFF
--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -842,7 +842,8 @@ class ViewManager(CLIManager):
         hbox.add(Gtk.Label(label=pdata.name))
         hbox.show_all()
         page_num = self.notebook.append_page(page.get_display(), hbox)
-        self.active_page.post_create()
+        if self.active_page:
+            self.active_page.post_create()
         if not self.file_loaded:
             self.uimanager.set_actions_visible(self.actiongroup, False)
             self.uimanager.set_actions_visible(self.readonlygroup, False)


### PR DESCRIPTION
Avoids 'NoneType' object has no attribute 'post_create' error.

Fixes [#12638](https://gramps-project.org/bugs/view.php?id=12638).

This patch can be applied on 5.1 or 5.2