### PR TITLE
XDG MIME types improvements

### DIFF
--- a/data/org.gramps_project.Gramps.xml.in
+++ b/data/org.gramps_project.Gramps.xml.in
@@ -6,16 +6,6 @@
     <comment>Gramps database</comment>
     <glob pattern="*.grdb"/>
   </mime-type>
-  <mime-type type="application/x-gedcom">
-    <comment>GEDCOM</comment>
-    <glob pattern="*.ged"/>
-    <glob pattern="*.gedcom"/>
-    <glob pattern="*.GED"/>
-    <glob pattern="*.GEDCOM"/>
-    <magic priority="80">
-      <match type="string" value="0 HEAD" offset="0:1"/>
-    </magic>
-  </mime-type>
   <mime-type type="application/x-gramps-package">
     <comment>Gramps package</comment>
     <glob pattern="*.gpkg"/>

--- a/data/org.gramps_project.Gramps.xml.in
+++ b/data/org.gramps_project.Gramps.xml.in
@@ -21,7 +21,6 @@
   <mime-type type="application/x-geneweb">
     <comment>GeneWeb source file</comment>
     <glob pattern="*.gw"/>
-    <glob pattern="*.GW"/>
     <magic priority="80">
       <match type="string" value="fam " offset="0:64"/>
     </magic>


### PR DESCRIPTION
- drop `application/x-gedcom`: `shared-mime-info` ships one since v0.17 (released in 2006)
- drop the uppercase glob pattern in `application/x-geneweb`, as the pattern matching is case-insensitive by default

See the specific commit messages for longer explanations.