### PR TITLE
Avoid application crash on invalid user input

### DIFF
--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -2873,9 +2873,17 @@ class BasePage: # pylint: disable=C1001
                 if self.reference_sort:
                     role = ""
                 elif role[1:2] == ':':
+                    # format of role is role_type:ISO date string
+                    if role.count(':') > 1:
+                        print("Invalid date :", role[2:], " for individual with ID:", gid,
+                              ". Please, use the 'verify the data' tool to correct this.")
+                        cal, role = role.split(':', 1)
+                    else:
+                        cal, role = role.split(':')
+
                     # cal is the original calendar
-                    cal, role = role.split(':')
-                    # conver ISO date to Date for translation.
+
+                    # convert ISO date to Date for translation.
                     # all modifiers are in english, so convert them
                     # to the local language
                     if len(role.split(' - ')) > 1:


### PR DESCRIPTION
This is a fix for bug [0012658](https://gramps-project.org/bugs/view.php?id=12658). If the user inputs an invalid date this
change keeps the application from crashing when such a date is found.