### PR TITLE
The latest version of openlayers doesn't work

### DIFF
--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -61,6 +61,7 @@ from decimal import getcontext
 # Gramps module
 #------------------------------------------------
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.const import VERSION_DIR
 from gramps.gen.lib import (EventType, Name,
                             Person,
                             Family, Event, Place, PlaceName, Source,
@@ -2501,17 +2502,20 @@ class NavWebOptions(MenuReportOptions):
             config.register(openlayers, last_ok_version)
         openlayers = 'external_modules.openlayers_version'
         olv = config.get(openlayers)
+        inipath = os.path.join(VERSION_DIR, 'gramps.ini')
         olv = [
-            (_("in gramps.ini (%s)" % olv), olv),
-            (_("latest"), "latest"),
-            (_("last working version (%s)" % last_ok_version), last_ok_version)]
+            (_("in %(inipth)s (%(val)s)" % {'inipth': inipath,
+                                            'val': olv}), olv),
+            (_("latest"), "latest")]
         self.__olv = EnumeratedListOption(_("openlayers version to use"),
                                           olv[0][1])
         for trans, opt in olv:
             self.__olv.add_item(opt, trans)
         self.__olv.set_help(
-            _("You should use this option only if you "
-              "can't see the map in openstreetmap..."
+            _("You should use this option only if you can't see "
+              "the maps in your website for OpenStreetMap or Stamen maps"
+              "\nYou can change the value in the specified file."
+              " The option name to modify is openlayers_version."
               "\nSee OLDER VERSIONS in https://openlayers.org/"))
         addopt("ol_version", self.__olv)
 

--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -1876,6 +1876,7 @@ class NavWebOptions(MenuReportOptions):
         self.__stamenopts = None
         self.__googleopts = None
         self.__googlemapkey = None
+        self.__olv = None
         self.__ancestortree = None
         self.__css = None
         self.__gallery = None
@@ -2494,6 +2495,26 @@ class NavWebOptions(MenuReportOptions):
 
         self.__placemap_options()
 
+        openlayers = 'external_modules.openlayers_version'
+        last_ok_version = "v6.15.1"
+        if not config.is_set(openlayers):
+            config.register(openlayers, last_ok_version)
+        openlayers = 'external_modules.openlayers_version'
+        olv = config.get(openlayers)
+        olv = [
+            (_("in gramps.ini (%s)" % olv), olv),
+            (_("latest"), "latest"),
+            (_("last working version (%s)" % last_ok_version), last_ok_version)]
+        self.__olv = EnumeratedListOption(_("openlayers version to use"),
+                                          olv[0][1])
+        for trans, opt in olv:
+            self.__olv.add_item(opt, trans)
+        self.__olv.set_help(
+            _("You should use this option only if you "
+              "can't see the map in openstreetmap..."
+              "\nSee OLDER VERSIONS in https://openlayers.org/"))
+        addopt("ol_version", self.__olv)
+
     def __add_others_options(self, menu):
         """
         Options for the cms tab, web calendar inclusion, PHP ...
@@ -2790,8 +2811,12 @@ class NavWebOptions(MenuReportOptions):
 
         if family_active and mapservice_opts == "Google":
             self.__googleopts.set_available(True)
+            if self.__olv:
+                self.__olv.set_available(False)
         else:
             self.__googleopts.set_available(False)
+            if self.__olv:
+                self.__olv.set_available(True)
 
         if (place_active or family_active) and mapservice_opts == "Google":
             self.__googlemapkey.set_available(True)

--- a/gramps/plugins/webreport/person.py
+++ b/gramps/plugins/webreport/person.py
@@ -835,10 +835,11 @@ class PersonPages(BasePage):
             src_js += "ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"
             head += Html("script", type="text/javascript",
                          src=src_js, inline=True)
-            src_js = "https://openlayers.org/en/latest/build/ol.js"
+            olv = self.report.options['ol_version']
+            src_js = "https://openlayers.org/en/%s/build/ol.js" % olv
             head += Html("script", type="text/javascript",
                          src=src_js, inline=True)
-            url = "https://openlayers.org/en/latest/css/ol.css"
+            url = "https://openlayers.org/en/%s/css/ol.css" % olv
             head += Html("link", href=url, type="text/css",
                          rel="stylesheet")
 

--- a/gramps/plugins/webreport/person.py
+++ b/gramps/plugins/webreport/person.py
@@ -836,10 +836,24 @@ class PersonPages(BasePage):
             head += Html("script", type="text/javascript",
                          src=src_js, inline=True)
             olv = self.report.options['ol_version']
-            src_js = "https://openlayers.org/en/%s/build/ol.js" % olv
+            build = "legacy"
+            if olv < "v7.0.0":
+                build = "build"
+            if olv == "latest":
+                build = "legacy"
+            src_js = ("https://openlayers.org/en/"
+                      "%(ver)s/%(bld)s/ol.js") % {"ver" : olv,
+                                                  "bld": build}
             head += Html("script", type="text/javascript",
                          src=src_js, inline=True)
-            url = "https://openlayers.org/en/%s/css/ol.css" % olv
+            css = "legacy"
+            if olv < "v7.0.0":
+                css = "css"
+            if olv == "latest":
+                css = "legacy"
+            url = ("https://openlayers.org/en/"
+                   "%(ver)s/%(css)s/ol.css") % {"ver" : olv,
+                                                "css": css}
             head += Html("link", href=url, type="text/css",
                          rel="stylesheet")
 

--- a/gramps/plugins/webreport/place.py
+++ b/gramps/plugins/webreport/place.py
@@ -447,10 +447,11 @@ class PlacePages(BasePage):
                                    "jquery.min.js")
                         head += Html("script", type="text/javascript",
                                      src=src_js, inline=True)
-                        src_js = "https://openlayers.org/en/latest/build/ol.js"
+                        olv = self.report.options['ol_version']
+                        src_js = "https://openlayers.org/en/%s/build/ol.js" % olv
                         head += Html("script", type="text/javascript",
                                      src=src_js, inline=True)
-                        url = "https://openlayers.org/en/latest/css/ol.css"
+                        url = "https://openlayers.org/en/%s/css/ol.css" % olv
                         head += Html("link", href=url, type="text/css",
                                      rel="stylesheet")
 

--- a/gramps/plugins/webreport/place.py
+++ b/gramps/plugins/webreport/place.py
@@ -448,10 +448,24 @@ class PlacePages(BasePage):
                         head += Html("script", type="text/javascript",
                                      src=src_js, inline=True)
                         olv = self.report.options['ol_version']
-                        src_js = "https://openlayers.org/en/%s/build/ol.js" % olv
+                        build = "legacy"
+                        if olv < "v7.0.0":
+                            build = "build"
+                        if olv == "latest":
+                            build = "legacy"
+                        src_js = ("https://openlayers.org/en/"
+                                  "%(ver)s/%(bld)s/ol.js") % {"ver" : olv,
+                                                              "bld": build}
                         head += Html("script", type="text/javascript",
                                      src=src_js, inline=True)
-                        url = "https://openlayers.org/en/%s/css/ol.css" % olv
+                        css = "legacy"
+                        if olv < "v7.0.0":
+                            css = "css"
+                        if olv == "latest":
+                            css = "legacy"
+                        url = ("https://openlayers.org/en/"
+                               "%(ver)s/%(css)s/ol.css") % {"ver" : olv,
+                                                           "css": css}
                         head += Html("link", href=url, type="text/css",
                                      rel="stylesheet")
 


### PR DESCRIPTION
Every years, openlayers change its "latest" version.
If this no longer works in the browser we need to change "latest"
by another version.
v6.15.1 is the latest working version and is available several years.
If this no longer the case for this version, we need to change this version
in the gramps.ini file.

The section will be:
...
[external_modules]
;;openlayers_version=‘v6.15.1’
…

You'll need to remove the two commas before openlayers_version and
change v6.15.1 to the working version.
Available versions are provided in the OLDER SECTION of https://openlayers.org/

Fixes #012680