### PR TITLE
Add .venv environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ ehthumbs.db
 
 # Glade temp files
 *~
+
+# Python metadata
+.venv*/
+


### PR DESCRIPTION
Make virtual Python environments a supported developer/builder environment.

Usage:

## Windows
```pwsh
git  clone  https://github.com/gramps-project/gramps
py -0
py -3.10 -m venv .venv --prompt gramps310
source .venv/scripts/Activate.ps1
```

## Linux/macOS
```bash
git clone https://github.com/gramps-project/gramps
python3 -m venv  .venv --prompt gramps310
source .venv/bin/activate
```

