### PR TITLE
Fix a French Typo

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -2974,7 +2974,7 @@ msgstr "Hébraïque"
 #: ../gramps/gen/datehandler/_datestrings.py:134 ../gramps/gen/lib/date.py:612
 msgctxt "calendar"
 msgid "French Republican"
-msgstr "Républicain français"
+msgstr "Républicain"
 
 # trunk
 #: ../gramps/gen/datehandler/_datestrings.py:135 ../gramps/gen/lib/date.py:613


### PR DESCRIPTION
Hi 

In France a calendar was created and implemented during the French Revolution.
Named :
- in French : Calendrier républicain
- in English : French Republican calendar

In each language we don't need the words "Calendrier" or "Calendar".
And in French we dont need lthe word "Français" present in the last typo.

https://fr.wikipedia.org/wiki/Calendrier_r%C3%A9publicain
https://en.wikipedia.org/wiki/French_Republican_calendar

This PR remove the unnecessary word "français"