### PR TITLE
Fix IndexError that sometimes occurs when changing view

### DIFF
--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -786,7 +786,12 @@ class ViewManager(CLIManager):
             self.__create_page(page_def[0], page_def[1])
 
         self.notebook.set_current_page(page_num)
-        return self.pages[page_num]
+        try:
+            return self.pages[page_num]
+        except IndexError:
+            # The following is to avoid 'IndexError: list index out of range'
+            # Should solve bug 12636
+            return self.pages[0]
 
     def get_category(self, cat_name):
         """
@@ -880,7 +885,12 @@ class ViewManager(CLIManager):
         """
         self.__disconnect_previous_page()
 
-        self.active_page = self.pages[page_num]
+        # The following is to avoid 'IndexError: list index out of range'
+        # Bugs: 12304, 12429, 12623, 12695
+        try:
+            self.active_page = self.pages[page_num]
+        except IndexError:
+            self.active_page = self.pages[0]
         self.__connect_active_page(page_num)
         self.active_page.set_active()
         while Gtk.events_pending():


### PR DESCRIPTION
This occours when restarting gramps.
This should solve bugs:
[#12636](https://gramps-project.org/bugs/view.php?id=12636), [#12304](https://gramps-project.org/bugs/view.php?id=12304), [#12429](https://gramps-project.org/bugs/view.php?id=12429), [#12623](https://gramps-project.org/bugs/view.php?id=12623), [#12695](https://gramps-project.org/bugs/view.php?id=12695)

Fixes #012636, #012304, #012429, #012623, #012695