### PR TITLE
Revert "Enclose tree report image path and file name in braces"

### DIFF
--- a/gramps/gen/plug/docgen/treedoc.py
+++ b/gramps/gen/plug/docgen/treedoc.py
@@ -460,8 +460,7 @@ class TreeDocBase(BaseDoc, TreeDoc):
             if os.path.isfile(path):
                 if win():
                     path = path.replace('\\', '/')
-                self.write(level+1, 'image = {{%s}%s},\n' %
-                           os.path.splitext(path))
+                self.write(level+1, 'image = {%s},\n' % path)
                 break # first image only
         self.write(level, '}\n')
 


### PR DESCRIPTION
Fixes #0012437 by reverting commit 75921ceaf40f3ced597d99c43794b98f81e49957 due to reports of regression where processing of the generated TeX file fails due to bad path specificiation for image files.

Change was originally introduced as a bug fix for #0010495. Bugs #0012437 and #0012697 reported the regression and confirmed that reverting the change fixes the regression.

This fix has been tested with tree reports on Windows 10 with Gramps 5.1.5 AIO using gramps sample tree. Verified that images in the generated TeX file were processed with pdflualatex without errors and shown in the resulting PDF.

**Needs testing on Linux and MacOS.**
FYI @azrdev @Nick-Hall 

My hunch is that improved handling of spaces in file paths in LaTeX since the original problem was reported in 2018 may have resolved the problem. Reference: [LaTeX News Issue 30, October 2019](https://www.latex-project.org/news/latex2e-news/ltnews30.pdf):

> Improving file name handling in pdfTEX
> A related change is that file names used as part of \input, \includegraphics, etc., commands can now contain any Unicode characters allowed by the file system in use, including spaces.

