### PR TITLE
Geography View: Fix number of arguments in add_bookmark method

### DIFF
--- a/gramps/plugins/lib/maps/geography.py
+++ b/gramps/plugins/lib/maps/geography.py
@@ -193,11 +193,12 @@ class GeoGraphyView(OsmGps, NavigationView):
         """
         self.build_tree()
 
-    def add_bookmark(self, menu):
+    def add_bookmark(self, menu, handle):
         """
         Add the place to the bookmark
         """
         dummy_menu = menu
+        dummy_hdle = handle
         mlist = self.selected_handles()
         if mlist:
             self.bookmarks.add(mlist[0])


### PR DESCRIPTION
GeoGraphyView.add_bookmark() takes 2 positional arguments but 3 were given

Fixes [#12718](https://gramps-project.org/bugs/view.php?id=12718)