### PR TITLE
Add option to hide ages for events after death

### DIFF
--- a/gramps/gen/config.py
+++ b/gramps/gen/config.py
@@ -282,6 +282,7 @@ register('preferences.last-view', '')
 register('preferences.last-views', [])
 register('preferences.family-relation-type', 3) # UNKNOWN
 register('preferences.age-display-precision', 1)
+register('preferences.age-after-death', True)
 
 register('colors.scheme', 0)
 register('colors.male-alive', ['#b8cee6', '#1f344a'])

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -1344,6 +1344,12 @@ class GrampsPreferences(ConfigureDialog):
         grid.attach(obox, 2, row, 2, 1)
 
         row += 1
+        # Display ages for events after death
+        self.add_checkbox(
+            grid, _("Display ages for events after death *"),
+            row, 'preferences.age-after-death', start=2, stop=3)
+
+        row += 1
         # Calendar format on report:
         obox = Gtk.ComboBoxText()
         list(map(obox.append_text, Date.ui_calendar_names))

--- a/gramps/gui/editors/displaytabs/eventrefmodel.py
+++ b/gramps/gui/editors/displaytabs/eventrefmodel.py
@@ -60,6 +60,7 @@ from gramps.gen.proxy.cache import CacheProxyDb
 #-------------------------------------------------------------------------
 invalid_date_format = config.get('preferences.invalid-date-format')
 age_precision = config.get('preferences.age-display-precision')
+age_after_death = config.get('preferences.age-after-death')
 
 #-------------------------------------------------------------------------
 #
@@ -101,6 +102,7 @@ class EventRefModel(Gtk.TreeStore):
         @param kwargs: A dictionary of additional settings/values.
         """
         self.start_date = kwargs.get("start_date", None)
+        self.end_date = kwargs.get("end_date", None)
         typeobjs = (x[1] for x in self.COLS)
         Gtk.TreeStore.__init__(self, *typeobjs)
         self.db = CacheProxyDb(db)
@@ -181,6 +183,8 @@ class EventRefModel(Gtk.TreeStore):
             if (date == self.start_date and date.modifier == Date.MOD_NONE
                     and not (event.get_type().is_death_fallback() or
                              event.get_type() == EventType.DEATH)):
+                return ""
+            elif self.end_date and self.end_date < date and not age_after_death:
                 return ""
             else:
                 return (date - self.start_date).format(precision=age_precision)

--- a/gramps/gui/editors/editperson.py
+++ b/gramps/gui/editors/editperson.py
@@ -53,7 +53,7 @@ _ = glocale.translation.sgettext
 from gramps.gen.utils.file import media_path_full
 from gramps.gen.utils.thumbnails import get_thumbnail_image
 from ..utils import is_right_click, open_file_with_default_application
-from gramps.gen.utils.db import get_birth_or_fallback
+from gramps.gen.utils.db import get_birth_or_fallback, get_death_or_fallback
 from gramps.gen.lib import NoteType, Person, Surname
 from gramps.gen.db import DbTxn
 from .. import widgets
@@ -447,6 +447,14 @@ class EditPerson(EditPrimary):
         event = get_birth_or_fallback(self.dbstate.db, self.obj)
         return event.get_date_object() if event else None
 
+    def get_end_date(self):
+        """
+        Get the end date for a person, usually a death date, or
+        something close to death.
+        """
+        event = get_death_or_fallback(self.dbstate.db, self.obj)
+        return event.get_date_object() if event else None
+
     def _create_tabbed_pages(self):
         """
         Create the notebook tabs and insert them into the main window.
@@ -459,7 +467,8 @@ class EditPerson(EditPrimary):
             self.uistate,
             self.track,
             self.obj,
-            start_date=self.get_start_date())
+            start_date=self.get_start_date(),
+            end_date=self.get_end_date())
 
         self._add_tab(notebook, self.event_list)
         self.track_ref_for_deletion("event_list")


### PR DESCRIPTION
This PR adds the option to hide the age in the person editor for events after death.

Read the [Calculating age for burials](https://gramps.discourse.group/t/calculating-age-for-burials) topic for further details.