### PR TITLE
Fix corrupted NOTE tag in Gedcom export

### DIFF
--- a/gramps/plugins/export/exportgedcom.py
+++ b/gramps/plugins/export/exportgedcom.py
@@ -160,10 +160,9 @@ def breakup(txt, limit):
     data = []
     while len(txt) > limit:
         # look for non-space pair to break between
-        # do not break within a UTF-8 byte sequence, i. e. first char >127
+        # fix issue #0012709 by removing Python2 code obsoleted by Python3
         idx = limit
-        while (idx > 0 and (txt[idx - 1].isspace() or txt[idx].isspace() or
-                            ord(txt[idx - 1]) > 127)):
+        while (idx > 0 and (txt[idx - 1].isspace() or txt[idx].isspace())):
             idx -= 1
         if idx == 0:
             #no words to break on, just break at limit anyway


### PR DESCRIPTION
fix issue [#12709](https://gramps-project.org/bugs/view.php?id=12709) by removing Python2 code obsoleted by Python3, which was corrupting GEDCOM export of Gramps Notes text that includes multi-byte utf-8 characters.

in exportgedcom.py, function "breakup", there is code to break up long strings of characters,
the idea is to keep lines exported to GEDCOM shorter than about 80 characters, forcing the remaining text on to "CONC" continuation lines.
When doing this, the code trys to protect all white space by ensuring that a printable character starts and ends the wrapped/broken line.

(Since Gramps NOTES may be formatted using white space, it is important to prevent leading/trailing white space from
being discarded by any program importing the GEDCOM file, hence the need for a leading and trailing printable character)

Issue #12709 finds that long strings of Ukrainian (multi-byte utf-8) characters cause invalid GEDCOM NOTE tags to be emitted.
This happens because the current code will not break between white space characters OR if the 1st of two adjoining characters is multi-byte utf-8 character.

This results in skipping past all the characters in the Gramps NOTE text and breaking within the text of the GEDCOM "NOTE" tag itself. GEDCOM import programs will detect the wrapped/broken GEDCOM NOTE tag as an invalid line.

In the example below, the "В" character is not the ASCII letter B, it is a 2 byte character (0xd0, 0xb2) the lower case version of Ukrainian "В" (0xd0, 0x92)

a Gramps NOTE containing  only:
"вввввввввввввввввввввввввввввввввввввввввввввввввввввввввввввввв1 ій"

Text actually passed to the "breakup" function:
" NOTE вввввввввввввввввввввввввввввввввввввввввввввввввввввввввввввввв1 ій "

Produces GEDCOM:
0 @N000001@ <b>NOT</b>
1 CONC <b>E</b> вввввввввввввввввввввввввввввввввввввввввввввввввввввввввввввввв1 ій


The correct GEDCOM after the patch given below:
0 @N000001@ NOTE вввввввввввввввввввввввввввввввввввввввввввввввввввввввввввввввв1 і
1 CONC й

The Gramps code that breaks up the line, is using Python 2 code that is supposed to prevent multi-byte utf-8 characters being separated across lines in the GEDCOM file.

That Python 2 approach wont work in Python 3, as the string data type was redefined. In Python 2 it is a string of bytes,
in Python 3 it is a string of code points meaning that each index-able thing in the string may be 1 to 4 bytes long.
The Python 2 code thinks it is looking the 1st byte of a 2 byte character, but is actually looking at the entire next character.

Actually the Python 3 code no longer has to worry about the bytes of a utf-8 character being separated, it is handled by Python.

Since Gramps no longer supports Python 2 the simple solution is to just remove the vestigial code.

In Python 3, text strings are indexed as characters, it is not necessary to interpret the individual bytes of a multi-byte utf-8 characters.

For Gramps 5.1.5, on Windows, you can edit file "C:\Program Files\GrampsAIO64-5.1.5\gramps\plugins\export\exportgedcom.py"

Current code at line 165 in exportgedcom.py on 51 branch:
        while (idx > 0 and (txt[idx - 1].isspace() or txt[idx].isspace() **or
                        ord(txt[idx - 1]) > 127**)):

Corrected code:
        while (idx > 0 and (txt[idx - 1].isspace() or txt[idx].isspace())):

The same code change should work in 5.2, but the line numbers are a little different.