### PR TITLE
Add support for CITE plugins

### DIFF
--- a/gramps/gen/config.py
+++ b/gramps/gen/config.py
@@ -289,6 +289,7 @@ register('preferences.last-views', [])
 register('preferences.family-relation-type', 3) # UNKNOWN
 register('preferences.age-display-precision', 1)
 register('preferences.age-after-death', True)
+register('preferences.cite-plugin', 'cite-default')
 
 register('colors.scheme', 0)
 register('colors.male-alive', ['#b8cee6', '#1f344a'])

--- a/gramps/gen/plug/_manager.py
+++ b/gramps/gen/plug/_manager.py
@@ -458,6 +458,11 @@ class BasePluginManager:
         """
         return self.__pgr.thumbnailer_plugins()
 
+    def get_reg_cite(self):
+        """ Return list of registered cite plugins.
+        """
+        return self.__pgr.cite_plugins()
+
     def get_external_opt_dict(self):
         """ Return the dictionary of external options. """
         return self.__external_opt_dict

--- a/gramps/gen/plug/_pluginreg.py
+++ b/gramps/gen/plug/_pluginreg.py
@@ -90,9 +90,10 @@ SIDEBAR = 11
 DATABASE = 12
 RULE = 13
 THUMBNAILER = 14
+CITE = 15
 PTYPE = [REPORT, QUICKREPORT, TOOL, IMPORT, EXPORT, DOCGEN, GENERAL,
          MAPSERVICE, VIEW, RELCALC, GRAMPLET, SIDEBAR, DATABASE, RULE,
-         THUMBNAILER]
+         THUMBNAILER, CITE]
 PTYPE_STR = {
         REPORT: _('Report') ,
         QUICKREPORT: _('Quickreport'),
@@ -109,6 +110,7 @@ PTYPE_STR = {
         DATABASE: _('Database'),
         RULE: _('Rule'),
         THUMBNAILER: _('Thumbnailer'),
+        CITE: _('Citation formatter'),
         }
 
 #possible report categories
@@ -1201,6 +1203,7 @@ def make_environment(**kwargs):
         'GRAMPLET': GRAMPLET,
         'SIDEBAR': SIDEBAR,
         'THUMBNAILER': THUMBNAILER,
+        'CITE': CITE,
         'CATEGORY_TEXT': CATEGORY_TEXT,
         'CATEGORY_DRAW': CATEGORY_DRAW,
         'CATEGORY_CODE': CATEGORY_CODE,
@@ -1528,6 +1531,12 @@ class PluginRegister:
         Return a list of :class:`PluginData` that are of type THUMBNAILER
         """
         return self.type_plugins(THUMBNAILER)
+
+    def cite_plugins(self):
+        """
+        Return a list of :class:`PluginData` that are of type CITE
+        """
+        return self.type_plugins(CITE)
 
     def filter_load_on_reg(self):
         """

--- a/gramps/gen/plug/utils.py
+++ b/gramps/gen/plug/utils.py
@@ -454,3 +454,24 @@ class OpenFileOrStdin:
         if self.filename != '-':
             self.filehandle.close()
         return False
+
+#-------------------------------------------------------------------------
+#
+# get_cite function
+#
+#-------------------------------------------------------------------------
+def get_cite():
+    """
+    Function that returns the active cite plugin.
+    """
+    plugman = BasePluginManager.get_instance()
+    for pdata in plugman.get_reg_cite():
+        if pdata.id != config.get('preferences.cite-plugin'):
+            continue
+        module = plugman.load_plugin(pdata)
+        if not module:
+            print("Error loading formatter '%s': skipping content"
+                  % pdata.name)
+            continue
+        cite = getattr(module, 'Formatter')()
+        return cite

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -1421,6 +1421,12 @@ class GrampsPreferences(ConfigureDialog):
         grid.attach(obox, 2, row, 2, 1)
 
         row += 1
+        lwidget = BasicLabel(_("%s: ") % _('Citation formatter'))
+        grid.attach(lwidget, 1, row, 1, 1)
+        obox = self.__create_cite_combo()
+        grid.attach(obox, 2, row, 2, 1)
+
+        row += 1
         label = self.add_text(
             grid, _("\nInput Options"), row,
             line_wrap=True, bold=True, start=0, stop=3)
@@ -1796,6 +1802,15 @@ class GrampsPreferences(ConfigureDialog):
             else:
                 widget.set_sensitive(True)
 
+    def cite_changed(self, obj):
+        """
+        Update Database Backend.
+        """
+        the_list = obj.get_model()
+        the_iter = obj.get_active_iter()
+        cite_choice = the_list.get_value(the_iter, 2)
+        config.set('preferences.cite-plugin', cite_choice)
+
     def add_famtree_panel(self, configdialog):
         """
         Config tab for family tree, backup and Media path settings.
@@ -1965,6 +1980,33 @@ class GrampsPreferences(ConfigureDialog):
         # set the default value as active in the combo
         obox.set_active(active)
         obox.connect('changed', self.database_backend_changed)
+        return obox
+
+    def __create_cite_combo(self):
+        """
+        Create cite selection widget.
+        """
+        backend_plugins = self.uistate.viewmanager._pmgr.get_reg_cite()
+        obox = Gtk.ComboBox()
+        cell = Gtk.CellRendererText()
+        obox.pack_start(cell, True)
+        obox.add_attribute(cell, 'text', 1)
+        # Build model:
+        model = Gtk.ListStore(GObject.TYPE_INT,
+                              GObject.TYPE_STRING,
+                              GObject.TYPE_STRING)
+        count = 0
+        active = 0
+        default = config.get('preferences.cite-plugin')
+        for plugin in sorted(backend_plugins, key=lambda plugin: plugin.name):
+            if plugin.id == default:
+                active = count
+            model.append(row=[count, plugin.name, plugin.id])
+            count += 1
+        obox.set_model(model)
+        # set the default value as active in the combo
+        obox.set_active(active)
+        obox.connect('changed', self.cite_changed)
         return obox
 
     def set_mediapath(self, *obj):

--- a/gramps/plugins/cite/cite.gpr.py
+++ b/gramps/plugins/cite/cite.gpr.py
@@ -1,0 +1,43 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2022       Nick Hall
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+
+_ = glocale.translation.gettext
+
+MODULE_VERSION = "5.2"
+
+#------------------------------------------------------------------------
+#
+# Default citation formatters for Gramps
+#
+#------------------------------------------------------------------------
+
+register(
+    CITE,
+    id="cite-default",
+    name=_("Default"),
+    description=_("Default citation formatter"),
+    version="1.0",
+    gramps_target_version=MODULE_VERSION,
+    status=STABLE,
+    fname="default.py",
+    authors=["The Gramps project"],
+    authors_email=["http://gramps-project.org"],
+)

--- a/gramps/plugins/cite/default.py
+++ b/gramps/plugins/cite/default.py
@@ -1,0 +1,129 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2022       Nick Hall
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+A ciation formatter that implements the current functionality.
+"""
+
+#-------------------------------------------------------------------------
+#
+# Standard python modules
+#
+#-------------------------------------------------------------------------
+import logging
+
+#-------------------------------------------------------------------------
+#
+# GTK/Gnome modules
+#
+#-------------------------------------------------------------------------
+
+#-------------------------------------------------------------------------
+#
+# Gramps modules
+#
+#-------------------------------------------------------------------------
+from gramps.gen.lib import Citation
+from gramps.gen.utils.string import conf_strings
+
+#-------------------------------------------------------------------------
+#
+# Constants
+#
+#-------------------------------------------------------------------------
+LOG = logging.getLogger(".cite")
+
+
+class Formatter():
+
+    def __init__(self):
+        pass
+
+    def format(self, bibliography, db, elocale):
+
+        result = []
+        for citation in bibliography.get_citation_list():
+            source = db.get_source_from_handle(citation.get_source_handle())
+            src = _format_source_text(source, elocale)
+
+            refs = []
+            for key, ref in citation.get_ref_list():
+                ref = _format_ref_text(ref, key, elocale)
+                refs.append([key, ref])
+
+            result.append([src, refs])
+
+        return result
+
+def _format_source_text(source, elocale):
+    if not source: return ""
+
+    trans_text = elocale.translation.gettext
+    # trans_text is a defined keyword (see po/update_po.py, po/genpot.sh)
+
+    src_txt = ""
+
+    if source.get_author():
+        src_txt += source.get_author()
+
+    if source.get_title():
+        if src_txt:
+            # Translators: needed for Arabic, ignore otherwise
+            src_txt += trans_text(', ')
+        # Translators: used in French+Russian, ignore otherwise
+        src_txt += trans_text('"%s"') % source.get_title()
+
+    if source.get_publication_info():
+        if src_txt:
+            # Translators: needed for Arabic, ignore otherwise
+            src_txt += trans_text(', ')
+        src_txt += source.get_publication_info()
+
+    if source.get_abbreviation():
+        if src_txt:
+            # Translators: needed for Arabic, ignore otherwise
+            src_txt += trans_text(', ')
+        src_txt += "(%s)" % source.get_abbreviation()
+
+    return src_txt
+
+def _format_ref_text(ref, key, elocale):
+    if not ref: return ""
+
+    ref_txt = ""
+
+    datepresent = False
+    date = ref.get_date_object()
+    if date is not None and not date.is_empty():
+        datepresent = True
+    if datepresent:
+        if ref.get_page():
+            ref_txt = "%s - %s" % (ref.get_page(), elocale.get_date(date))
+        else:
+            ref_txt = elocale.get_date(date)
+    else:
+        ref_txt = ref.get_page()
+
+    # Print only confidence level if it is not Normal
+    if ref.get_confidence_level() != Citation.CONF_NORMAL:
+        ref_txt += " [" + elocale.translation.gettext(
+                              conf_strings[ref.get_confidence_level()]) + "]"
+
+    return ref_txt

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -578,6 +578,8 @@ gramps/gui/widgets/reorderfam.py
 gramps/gui/widgets/styledtextbuffer.py
 gramps/gui/widgets/styledtexteditor.py
 gramps/gui/widgets/validatedmaskedentry.py
+gramps/plugins/cite/cite.gpr.py
+gramps/plugins/cite/default.py
 gramps/plugins/db/bsddb/bsddb.gpr.py
 gramps/plugins/db/dbapi/sqlite.gpr.py
 gramps/plugins/db/dbapi/sqlite.py

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -457,6 +457,10 @@ gramps/gui/widgets/validatedcomboentry.py
 #
 gramps/plugins/__init__.py
 #
+# plugins/cite directory
+#
+gramps/plugins/cite/__init__.py
+#
 # plugins/db/bsddb directory
 #
 gramps/plugins/db/bsddb/__init__.py


### PR DESCRIPTION
Experimental code to allow citations in reports to be formatted using plugins.

The "Default" plugin just implements the current functionality.

The idea is to investigate improvements such as templates or external formatting.  CSL formatting using [citeproc-py](https://github.com/brechtm/citeproc-py) is one idea.