### PR TITLE
Implement the GEDCOM tag "_RUFNAME"

### DIFF
--- a/data/tests/exp_sample.gramps
+++ b/data/tests/exp_sample.gramps
@@ -774,6 +774,7 @@
       <name type="Birth Name">
         <first>Amber Marie</first>
         <surname>Smith</surname>
+        <call>Marie</call>
       </name>
       <eventref hlink="_0000003100000031" role="Primary"/>
       <eventref hlink="_0000003300000033" role="Primary"/>

--- a/data/tests/exp_sample.vcf
+++ b/data/tests/exp_sample.vcf
@@ -122,7 +122,7 @@ BEGIN:VCARD
 VERSION:3.0
 PRODID:-//Gramps//NONSGML Gramps 5.0.0-alpha1//EN
 FN:Amber Marie Smith
-N:Smith;Amber;Marie;;
+N:Smith;Marie;Amber;;
 SORT-STRING:Smith                    Amber Marie                   
 X-GENDER:Female
 BDAY:1998-04-12

--- a/data/tests/exp_sample_ged.ged
+++ b/data/tests/exp_sample_ged.ged
@@ -65,6 +65,7 @@
 2 TYPE birth
 2 GIVN Amber Marie
 2 SURN Smith
+2 _RUFNAME Marie
 1 SEX F
 1 BIRT
 2 TYPE Birth of Amber Marie Smith
@@ -984,6 +985,7 @@
 2 GIVN Fake
 2 SPFX von
 2 SURN Person
+2 _RUFNAME Person
 2 NSFX I
 2 NPFX Fake person
 2 NICK Fake

--- a/gramps/plugins/export/exportgedcom.py
+++ b/gramps/plugins/export/exportgedcom.py
@@ -1304,6 +1304,7 @@ class GedcomWriter(UpdateCallback):
         suffix = name.get_suffix()
         title = name.get_title()
         nick = name.get_nick_name()
+        call = name.get_call_name()
         if nick.strip() == '':
             nick = attr_nick
 
@@ -1323,6 +1324,8 @@ class GedcomWriter(UpdateCallback):
             self._writeln(2, 'SPFX', surprefix)
         if surname:
             self._writeln(2, 'SURN', surname)
+        if call:
+            self._writeln(2, '_RUFNAME', call)
         if name.get_suffix():
             self._writeln(2, 'NSFX', suffix)
         if name.get_title():

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -276,6 +276,7 @@ TOKEN__JUST = 135
 TOKEN__TEXT = 136
 TOKEN__DATE = 137
 TOKEN__APID = 138
+TOKEN__CALLNAME = 139
 
 TOKENS = {
     "_ADPN"           : TOKEN__ADPN,
@@ -316,6 +317,7 @@ TOKENS = {
     "_PRIMARY"        : TOKEN__PRIMARY,
     "_PRIV"           : TOKEN__PRIV,
     "_PUBLISHER"      : TOKEN_IGNORE,
+    "_RUFNAME"        : TOKEN__CALLNAME,
     "_SCBK"           : TOKEN_IGNORE,
     "_SCHEMA"         : TOKEN__SCHEMA,
     "_SSHOW"          : TOKEN_IGNORE,
@@ -2091,6 +2093,8 @@ class GedcomParser(UpdateCallback):
             TOKEN_GIVN   : self.__name_givn,
             # NICK <NAME_PIECE_NICKNAME> {0:1}
             TOKEN_NICK   : self.__name_nick,
+            # _RUFNAME <NAME_PIECE_CALLNAME> {0:1}
+            TOKEN__CALLNAME: self.__name_call,
             # +1 SPFX <NAME_PIECE_SURNAME_PREFIX {0:1}
             TOKEN_SPFX   : self.__name_spfx,
             # +1 SURN <NAME_PIECE_SURNAME> {0:1}
@@ -4422,6 +4426,19 @@ class GedcomParser(UpdateCallback):
         @type state: CurrentState
         """
         state.name.set_nick_name(line.data.strip())
+        self.__skip_subordinate_levels(state.level + 1, state)
+
+    def __name_call(self, line, state):
+        """
+        This parses the inofficial _RUFNAME tag that indicates which part
+        of a person's given name is commonly used to address them.
+
+        @param line: The current line in GedLine format
+        @type line: GedLine
+        @param state: The current state
+        @type state: CurrentState
+        """
+        state.name.set_call_name(line.data.strip())
         self.__skip_subordinate_levels(state.level + 1, state)
 
     def __name_aka(self, line, state):


### PR DESCRIPTION
RUFNAME is the German word for "call name", i.e. the part of the given name commonly used to address somebody. Some official documents mark it as such.

The GEDCOM standards 5.5.1 and 5.5.5 mention this tag.

