### PR TITLE
Replace deprecated imp by importlib

### DIFF
--- a/gramps/gen/plug/_manager.py
+++ b/gramps/gen/plug/_manager.py
@@ -372,13 +372,9 @@ class BasePluginManager:
         Reloads modules that might not be in the path.
         """
         try:
-            import imp
-            fp, pathname, description = imp.find_module(pdata.mod_name, [pdata.fpath])
-            try:
-                module = imp.load_module(pdata.mod_name, fp, pathname,description)
-            finally:
-                if fp:
-                    fp.close()
+            spec = importlib.util.find_spec(pdata.mod_name, [pdata.fpath])
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
         except:
             if pdata.mod_name in sys.modules:
                 del sys.modules[pdata.mod_name]

--- a/gramps/plugins/importer/importgedcom.py
+++ b/gramps/plugins/importer/importgedcom.py
@@ -47,8 +47,8 @@ from gramps.gen.utils.libformatting import ImportInfo
 # a quick turnround, without having to restart Gramps.
 module = __import__("gramps.plugins.lib.libgedcom",
                     fromlist=["gramps.plugins.lib"])   # why o why ?? as above!
-import imp
-imp.reload(module)
+import importlib
+importlib.reload(module)
 
 from gramps.gen.config import config
 


### PR DESCRIPTION
`imp` is deprecated and will be removed in Python 3.12, to be released this year.

The code I added will work with Python 3.4 and up, which is enough four Gramps 5.1 and up.

Could also be cherry-picked into the 5.1 maintenance branch.