### PR TITLE
HtmlDoc.add_media: unique filename for cropped images

### DIFF
--- a/gramps/plugins/docgen/htmldoc.py
+++ b/gramps/plugins/docgen/htmldoc.py
@@ -556,7 +556,10 @@ class HtmlDoc(BaseDoc, TextDoc):
         """
         self._empty = 0
         size = int(max(w_cm, h_cm) * float(150.0/2.54))
-        refname = "is%s" % os.path.basename(name)
+        if crop:
+            refname = "is-%d-%d-%d-%d-%s" % (crop[0], crop[1], crop[2], crop[3], os.path.basename(name))
+        else:
+            refname = "is%s" % os.path.basename(name)
 
         imdir = self._backend.datadirfull()
 


### PR DESCRIPTION
The reports det_ancestor_report and det_descendant_report can include the photos with incphotos=True. This works for simple photos, but in case one photo contains multiple persons, then only the last person is shown.

A crop region is defined for every person on a photo. The photo is croped and saved to disk. The problem is that the photo is always saved using only the original filename. That means that all the croped files will overwrite the previous croped file.

This PR will give every croped file a unique filename so that the don't overwrite each other.