### PR TITLE
Narrative web: Solves some problems

### DIFF
--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -881,7 +881,7 @@ class BasePage:
         found = any(data[3] == place_handle and data[4] == event_date
                     for data in place_lat_long)
         if not found:
-            placetitle = _pd.display(self.r_db, place)
+            placetitle = _pd.display(self.r_db, place, fmt=0)
             latitude = place.get_latitude()
             longitude = place.get_longitude()
             if latitude and longitude:
@@ -1012,7 +1012,8 @@ class BasePage:
 
         place_hyper = None
         if place:
-            place_name = _pd.display(self.r_db, place, evt.get_date_object())
+            place_name = _pd.display(self.r_db, place,
+                                     evt.get_date_object(), fmt=0)
             place_hyper = self.place_link(place_handle, place_name,
                                           uplink=uplink)
 
@@ -1076,7 +1077,7 @@ class BasePage:
                 if place_handle:
                     place = self.r_db.get_place_from_handle(place_handle)
                     if place:
-                        place_title = _pd.display(self.r_db, place)
+                        place_title = _pd.display(self.r_db, place, fmt=0)
                         place_hyper = self.place_link(
                             place_handle, place_title,
                             place.get_gramps_id(), uplink=True)
@@ -2165,7 +2166,7 @@ class BasePage:
                                                             "evt", True)
             elif classname == "Place":
                 _obj = self.r_db.get_place_from_handle(newhandle)
-                _name = _pd.display(self.r_db, _obj)
+                _name = _pd.display(self.r_db, _obj, fmt=0)
                 if not _name:
                     _name = self._("Unknown")
                 _linkurl = self.report.build_url_fname_html(newhandle,

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -513,14 +513,18 @@ def sort_places(dbase, handle_list, rlocale=glocale):
     pname_sub = defaultdict(list)
 
     for place_name in handle_list.keys():
-        (hdle, pname, dummy_id, event) = handle_list[place_name]
+        cname = sname = None
+        if len(handle_list[place_name]) == 4:
+            (hdle, pname, dummy_id, event) = handle_list[place_name]
+        else:
+            (hdle, pname, cname,
+             sname, dummy_id, event) = handle_list[place_name]
         place = dbase.get_place_from_handle(hdle)
-        pname = _pd.display(dbase, place)
-        apname = _pd.display_event(dbase, event)
+        pname = _pd.display(dbase, place, fmt=0)
+        apname = _pd.display_event(dbase, event, fmt=0)
 
         pname_sub[pname].append(hdle)
-        if pname != apname:
-            pname_sub[apname].append(hdle)
+        pname_sub[apname].append((hdle, pname, cname, sname))
 
     sorted_lists = []
     temp_list = sorted(pname_sub, key=rlocale.sort_key)

--- a/gramps/plugins/webreport/family.py
+++ b/gramps/plugins/webreport/family.py
@@ -441,6 +441,7 @@ class FamilyPages(BasePage):
                 relationshipdetail += families
 
             # display additional images as gallery
+            if self.create_media:
                 addgallery = self.disp_add_img_as_gallery(media_list, family)
                 if addgallery:
                     relationshipdetail += addgallery

--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -939,11 +939,20 @@ class NavWebReport(Report):
             else:
                 name = ""
         if config.get('preferences.place-auto'):
-            place_name = _pd.display_event(self._db, event)
-            pplace_name = _pd.display(self._db, place)
+            place_name = _pd.display_event(self._db, event, fmt=0)
+            if event:
+                cplace_name = place_name.split()[-1]
+                if len(place_name.split()) > 1:
+                    splace_name = place_name.split()[-2]
+                else:
+                    splace_name = cplace_name
+            else:
+                cplace_name = None
+                splace_name = None
         else:
             place_name = place.get_title()
-            pplace_name = place_name
+            cplace_name = place_name
+            splace_name = place_name
         if event:
             if self.reference_sort:
                 role_or_date = name
@@ -961,10 +970,8 @@ class NavWebReport(Report):
         self.obj_dict[Place][place_handle] = (place_fname, place_name,
                                               place.gramps_id, event)
         self.obj_dict[PlaceName][place_name] = (place_handle, place_name,
+                                                splace_name, cplace_name,
                                                 place.gramps_id, event)
-        if place_name != pplace_name:
-            self.obj_dict[PlaceName][pplace_name] = (place_handle, pplace_name,
-                                                     place.gramps_id, event)
         self.bkref_dict[Place][place_handle].add((bkref_class, bkref_handle,
                                                   role_or_date
                                                  ))

--- a/gramps/plugins/webreport/person.py
+++ b/gramps/plugins/webreport/person.py
@@ -1703,14 +1703,14 @@ class PersonPages(BasePage):
                     birth = self.r_db.get_event_from_handle(birth_ref.ref)
                     if birth:
                         birth_date = birth.get_date_object()
-                        p_birth = _pd.display_event(self.r_db, birth)
+                        p_birth = _pd.display_event(self.r_db, birth, fmt=0)
 
                 death_ref = self.person.get_death_ref()
                 p_death = ""
                 if death_ref:
                     death = self.r_db.get_event_from_handle(death_ref.ref)
                     if death:
-                        p_death = _pd.display_event(self.r_db, death)
+                        p_death = _pd.display_event(self.r_db, death, fmt=0)
 
                 death_date = _find_death_date(self.r_db, self.person)
                 if birth_date and birth_date is not Date.EMPTY:


### PR DESCRIPTION
Fixes [#12821](https://gramps-project.org/bugs/view.php?id=12821)

Force place name to be "Full" names.
Force the country field to be the last field of the place name Force the State/province to be the penultimate field of the place name

We use place names that stop in the country, but if we have place names such as: city, province, country, continent, planet with the continent and planet as custom place type, the State/Province field will be the name of the place continent... (should never happen, but...)