### PR TITLE
Add SQLite undo log

### DIFF
--- a/gramps/gen/db/undoredo.py
+++ b/gramps/gen/db/undoredo.py
@@ -125,6 +125,10 @@ class DbUndo(metaclass=ABCMeta):
         txn.set_description(msg)
         txn.timestamp = time.time()
         self.undoq.append(txn)
+        self._after_commit(txn)
+
+    def _after_commit(self, transaction):
+        """Post-transaction commit processing."""
 
     def undo(self, update_history=True):
         """


### PR DESCRIPTION
Triggered by the discussion in https://github.com/gramps-project/gramps-webapi/issues/320, I implemented an SQLite-based undo log by simply modifying the existing methods of `gramps.gen.db.DbGenericUndo`. That way, no other parts of the codebase need to be modified as the interface of the class stays the same.

Some more details:

### Existing implementation

An instance of `DbGenericUndo` has the properties `undoq` (of type `collections.deque`), `redoq` and `undodb` (of type list). When a transaction is commited to the database, the transaction object (`DbTxn`) is appended to `undoq` and the commits (1 or more) are appended to the `undodb` list.

When a transaction is undone, the transaction is moved from the `undoq` to the `redoq` and the commits (identified by two integers `first` and `last` in the transaction) are applied inversely and in opposite order to the database.

When a transaction is redone, it is moved again from the `redoq` to the `undoq` and the commits in `undodb` are applied again in the original order.

### New implementation

The steps outlined above are not modified, but the `undodb` list is removed and the list-like interface of `DbGenericUndo` is instead implemented by a SQLite table in a new database `undo.db` (the constant for this filename was already present in the API of the class, but unused, so it looks like this was already foreseen).

Instead of just a single table of commits, there are actually three tables to allow storing the history from multiple "sessions" (opening and closing the application). It is implemented in a way that even simultaneous sessions would record their transactions and commits in a consistent way. This would be relevant e.g. for Web API, where each HTTP request opens a new "session".

The first table is called "sessions" and just adds an ID and a timestamp for each new session. It only adds a row if the session edits the database (if transactions/commits are done).

![grafik](https://user-images.githubusercontent.com/10965193/231125554-93f9e2d6-bc3d-4584-8786-36fad4357363.png)

The second table is called "transactions" and contains one row for every transaction. This is essentially the data stored in `undoq`, but persisted to the database, with one important addition: it also adds a row for any undo/redo transaction. This allows to fully reconsstruct the edit history of the database, except in the case of batch transactions like the GEDCOM import below, which is not linked to any traceable commits (`first` and `last` are `NULL`):

![grafik](https://user-images.githubusercontent.com/10965193/231126417-11d5f413-b40f-412b-9284-2292420a1f9c.png)

Finally, the actual commit data that was previously held by `undodb` is in the `commits` table. It is partially expanded out into columns to potentially allow filtering etc., but the interface of the class is still exactly the same as before. I also added an as yet empty JSON column to potentially replace the `old_data`/`new_data` BLOBs by a JSON patch object in the future (as suggested by @Nick-Hall) without the need to change the database schema.

![grafik](https://user-images.githubusercontent.com/10965193/231128538-82f0814c-124f-4fde-9c64-6dfd7358e9fc.png)


### Final comments

This change does not yet enable the user to undo actions performed in a previous session of Gramps desktop, but this could be added in a future PR with relatively small changes. (Basically, it just requires loading part of the `transactions` table into `undoq` on startup.)

There is also no mechanism to truncate or VACUUM the undo.db, so it will keep growing; however, it can be safely deleted anytime for a fresh start.