### PR TITLE
Add substitution key for maiden name

### DIFF
--- a/gramps/gen/lib/person.py
+++ b/gramps/gen/lib/person.py
@@ -40,6 +40,7 @@ from .ldsordbase import LdsOrdBase
 from .urlbase import UrlBase
 from .tagbase import TagBase
 from .name import Name
+from .nametype import NameType
 from .eventref import EventRef
 from .personref import PersonRef
 from .attrtype import AttributeType
@@ -634,6 +635,18 @@ class Person(CitationBase, NoteBase, AttributeBase, MediaBase,
             if int(attr.type) == AttributeType.NICKNAME:
                 return attr.get_value()
         return ''
+
+    def get_maiden_name(self):
+        married_name = None
+        birth_name = None
+        for name in [self.get_primary_name()] + self.get_alternate_names():
+            if name.get_type() == NameType.BIRTH and name.get_surname():
+                birth_name   = name.get_surname()
+            elif name.get_type() == NameType.MARRIED and name.get_surname():
+                married_name = name.get_surname()
+        if birth_name and married_name and birth_name != married_name:
+            return birth_name
+        return None
 
     def set_gender(self, gender):
         """

--- a/gramps/plugins/lib/libsubstkeyword.py
+++ b/gramps/plugins/lib/libsubstkeyword.py
@@ -186,7 +186,7 @@ class NameFormat(GenericFormat):
                     common,                    # x
                     name.get_suffix,           # s
                     name.get_surname,          # l
-                    name.get_family_nick_name, # g
+                    name.get_family_nick_name  # g
                    ]
 
         return self.generic_format(name, code, upper, function)
@@ -823,7 +823,7 @@ class VariableParse:
     def is_a(self):
         """ check """
         return self._in.this == "$" and self._in.next is not None and \
-                              "näsijbBdDmMvVauetTpPG".find(self._in.next) != -1
+                              "nhsijbBdDmMvVauetTpPG".find(self._in.next) != -1
 
     def get_event_by_type(self, marriage, e_type):
         """ get an event from a type """
@@ -946,7 +946,8 @@ class VariableParse:
         if next_char == "n":
             #Person's name
             return self.__parse_name(self.friend.person, attrib_parse)
-        elif next_char == "ä":
+
+        elif next_char == "h":
             if self.empty_item(self.friend.person):
                 return
 #            print(self.friend.person.get_maiden_name())

--- a/gramps/plugins/lib/libsubstkeyword.py
+++ b/gramps/plugins/lib/libsubstkeyword.py
@@ -186,7 +186,7 @@ class NameFormat(GenericFormat):
                     common,                    # x
                     name.get_suffix,           # s
                     name.get_surname,          # l
-                    name.get_family_nick_name  # g
+                    name.get_family_nick_name, # g
                    ]
 
         return self.generic_format(name, code, upper, function)
@@ -823,7 +823,7 @@ class VariableParse:
     def is_a(self):
         """ check """
         return self._in.this == "$" and self._in.next is not None and \
-                              "nsijbBdDmMvVauetTpPG".find(self._in.next) != -1
+                              "näsijbBdDmMvVauetTpPG".find(self._in.next) != -1
 
     def get_event_by_type(self, marriage, e_type):
         """ get an event from a type """
@@ -946,6 +946,12 @@ class VariableParse:
         if next_char == "n":
             #Person's name
             return self.__parse_name(self.friend.person, attrib_parse)
+        elif next_char == "ä":
+            if self.empty_item(self.friend.person):
+                return
+#            print(self.friend.person.get_maiden_name())
+            return self.friend.person.get_maiden_name()
+
         elif next_char == "s":
             #Souses name
             return self.__parse_name(self.friend.spouse, attrib_parse)


### PR DESCRIPTION
### Why
I wanted to add both the married name as well as the maiden name to our family tree. For this I'm using a new substitution key `h`, which tries to find out a person's maiden name (`h` was chosen at random because it was still free, I'm open to other suggestions).

### Example
For example one could use the pattern `$n {born "$n(h)" }`

For a person who has a preferred surname which is different from their birth surname this results in:
- Mary Foo born Bar

For a person who did not adopt a new surname, `h` remains empty. This results in:
- Mary Bar

### How
The approach for this is:
1. Search for birth names and married names
2. If there's both a birth name and a married name AND they differ: Return the birth day
```python
    def get_maiden_name(self):
        married_name = None
        birth_name = None
        for name in [self.get_primary_name()] + self.get_alternate_names():
            if name.get_type() == NameType.BIRTH and name.get_surname():
                birth_name   = name.get_surname()
            elif name.get_type() == NameType.MARRIED and name.get_surname():
                married_name = name.get_surname()
        if birth_name and married_name and birth_name != married_name:
            return birth_name
        return None
```

### Caveats
The pattern only woks when the preferred name is the married name (if the preferred name is the birth name it would result in "Mary Bar born Bar"). I was thinking about an additional substitution key to find out the married name, but this is more complicated because there can be multiple married names. I guess one could search for the most recent?