### PR TITLE
Add a new primary surname substitution keyword option

### DIFF
--- a/gramps/gen/lib/surnamebase.py
+++ b/gramps/gen/lib/surnamebase.py
@@ -197,6 +197,18 @@ class SurnameBase:
                                                      'second': fsurn}
         return totalsurn.strip()
 
+    def get_primary(self):
+        """
+        Return a fully formatted primary surname
+        """
+        primary = self.get_primary_surname()
+        partsurn = primary.get_surname()
+        if primary.get_prefix():
+            fsurn = _('%(first)s %(second)s') % {'first': primary.get_prefix(),
+                                                 'second': partsurn}
+        else:
+            fsurn = partsurn
+        return fsurn.strip()
 
     def get_upper_surname(self):
         """Return a fully formatted surname capitalized"""

--- a/gramps/plugins/lib/libsubstkeyword.py
+++ b/gramps/plugins/lib/libsubstkeyword.py
@@ -177,7 +177,7 @@ class NameFormat(GenericFormat):
             return (name.get_call_name() or
                     name.get_first_name().split(' ')[0])
 
-        code = "tfcnxslg"
+        code = "tfcnxslgp"
         upper = code.upper()
         function = [name.get_title,            # t
                     name.get_first_name,       # f
@@ -186,7 +186,8 @@ class NameFormat(GenericFormat):
                     common,                    # x
                     name.get_suffix,           # s
                     name.get_surname,          # l
-                    name.get_family_nick_name  # g
+                    name.get_family_nick_name, # g
+                    name.get_primary           # p
                    ]
 
         return self.generic_format(name, code, upper, function)


### PR DESCRIPTION
Adds a new "p" option to display the primary surname with prefix if present as part of a name format.

For example:  $n(f p)

to display a name as a first name with primary surname only.