### PR TITLE
Allow web-accessible file references in media objects

### DIFF
--- a/gramps/gen/const.py
+++ b/gramps/gen/const.py
@@ -288,6 +288,7 @@ THUMBSCALE = 96.0
 THUMBSCALE_LARGE = 180.0
 SIZE_NORMAL = 0
 SIZE_LARGE = 1
+REMOTE_MIME = "application/http"
 XMLFILE = "data.gramps"
 NO_SURNAME = "(%s)" % _("none", "surname")
 NO_GIVEN = "(%s)" % _("none", "given-name")

--- a/gramps/gen/mime/_pythonmime.py
+++ b/gramps/gen/mime/_pythonmime.py
@@ -20,7 +20,7 @@
 # gen/mime/_pythonmime.py
 
 import mimetypes
-from ..const import GRAMPS_LOCALE as glocale
+from ..const import GRAMPS_LOCALE as glocale, REMOTE_MIME
 
 _ = glocale.translation.gettext
 
@@ -34,6 +34,7 @@ _type_map = {
     "image/png": "PNG image",
     "application/pdf": "PDF document",
     "text/rtf": "Rich Text File",
+    REMOTE_MIME: "External web page",
 }
 
 mimetypes.add_type("application/x-gramps", ".grdb")
@@ -54,6 +55,8 @@ def get_description(mime_type):
 
 def get_type(filename):
     """Return the mime type of the specified file"""
+    if filename.startswith(("http://", "https://")):
+        return REMOTE_MIME
     value = mimetypes.guess_type(filename)
     if value and value[0]:
         return value[0]

--- a/gramps/gen/utils/file.py
+++ b/gramps/gen/utils/file.py
@@ -213,6 +213,8 @@ def media_path_full(db, filename):
     Given a database and a filename of a media, return the media filename
     is full form, eg 'graves/tomb.png' becomes '/home/me/genea/graves/tomb.png
     """
+    if filename.startswith(("http://", "https://")):
+        return filename
     if os.path.isabs(filename):
         return filename
     mpath = media_path(db)

--- a/gramps/gen/utils/thumbnails.py
+++ b/gramps/gen/utils/thumbnails.py
@@ -60,6 +60,7 @@ from gramps.gen.const import (
     THUMB_NORMAL,
     SIZE_NORMAL,
     SIZE_LARGE,
+    REMOTE_MIME,
 )
 from gramps.gen.mime import get_type
 from gramps.gen.plug import BasePluginManager, START, Thumbnailer
@@ -257,7 +258,13 @@ def get_thumbnail_path(src_file, mtype=None, rectangle=None, size=SIZE_NORMAL):
     :rtype: GdkPixbuf.Pixbuf
     """
     filename = __build_thumb_path(src_file, rectangle, size)
-    if not os.path.isfile(src_file):
+    if src_file.startswith(("http://", "https://")):
+        mtype = REMOTE_MIME
+        if not os.path.isfile(filename):
+            if not __create_thumbnail_image(src_file, mtype, rectangle, size):
+                return os.path.join(IMAGE_DIR, "gramps-url.png")
+        return os.path.abspath(filename)
+    elif not os.path.isfile(src_file):
         return os.path.join(IMAGE_DIR, "image-missing.png")
     else:
         if (not os.path.isfile(filename)) or (

--- a/gramps/gui/display.py
+++ b/gramps/gui/display.py
@@ -37,7 +37,6 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.const import URL_MANUAL_PAGE, URL_WIKISTRING
 from gramps.gen.constfunc import is_quartz, mac
 from gramps.gen.config import config
-from .utils import open_file_with_default_application as run_file
 
 # list of manuals on wiki, map locale code to wiki extension, add language codes
 # completely, or first part, so pt_BR if Brazilian portugeze wiki manual, and

--- a/gramps/gui/editors/editmedia.py
+++ b/gramps/gui/editors/editmedia.py
@@ -61,7 +61,7 @@ from .displaytabs import (
 from .addmedia import AddMedia
 from ..dialog import ErrorDialog
 from ..glade import Glade
-from gramps.gen.const import URL_MANUAL_SECT2
+from gramps.gen.const import URL_MANUAL_SECT2, REMOTE_MIME
 
 # -------------------------------------------------------------------------
 #
@@ -182,6 +182,11 @@ class EditMedia(EditPrimary):
         self.draw_preview()
 
     def determine_mime(self):
+        if self.file_path.get_text().startswith(("https://", "http://")):
+            self.obj.set_mime_type(REMOTE_MIME)
+            self.mimetext.set_text("External Web page")
+            return
+
         descr = get_description(self.obj.get_mime_type())
         if descr:
             self.mimetext.set_text(descr)
@@ -345,7 +350,7 @@ class EditMedia(EditPrimary):
 
         path = self.file_path.get_text()
         full_path = media_path_full(self.db, path)
-        if os.path.isfile(full_path):
+        if os.path.isfile(full_path) or path.startswith(("http://", "https://")):
             self.determine_mime()
         else:
             msg1 = _("There is no media matching the current path value!")

--- a/gramps/gui/editors/editmediaref.py
+++ b/gramps/gui/editors/editmediaref.py
@@ -48,7 +48,7 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.sgettext
 from ..utils import open_file_with_default_application
-from gramps.gen.const import THUMBSCALE
+from gramps.gen.const import THUMBSCALE, REMOTE_MIME
 from gramps.gen.mime import get_description, get_type
 from gramps.gen.utils.thumbnails import get_thumbnail_image, find_mime_type_pixbuf
 from gramps.gen.utils.file import media_path_full, find_file, create_checksum
@@ -142,6 +142,11 @@ class EditMediaRef(EditReference):
         self.select.connect("clicked", self.select_file)
 
     def determine_mime(self):
+        if self.file_path.get_text().startswith(("https://", "http://")):
+            self.source.set_mime_type(REMOTE_MIME)
+            self.mimetext.set_text("External Web page")
+            return
+
         descr = get_description(self.source.get_mime_type())
         if descr:
             self.mimetext.set_text(descr)
@@ -167,7 +172,7 @@ class EditMediaRef(EditReference):
         the path.
         """
         mtype = self.source.get_mime_type()
-        if mtype:
+        if mtype and mtype != REMOTE_MIME:
             fullpath = media_path_full(self.db, self.source.get_path())
             pb = get_thumbnail_image(fullpath, mtype)
             self.pixmap.set_from_pixbuf(pb)

--- a/gramps/gui/utils.py
+++ b/gramps/gui/utils.py
@@ -63,6 +63,7 @@ from gramps.gen.constfunc import has_display, is_quartz, mac, win
 from gramps.gen.config import config
 from gramps.gen.plug.utils import available_updates
 from gramps.gen.errors import WindowActiveError
+from .display import display_url
 
 # -------------------------------------------------------------------------
 #
@@ -492,6 +493,9 @@ def open_file_with_default_application(path, uistate):
     :type file_path: string
     :return: nothing
     """
+    if path.startswith(("http://", "https://")):
+        display_url(path)
+        return
 
     norm_path = os.path.normpath(path)
     if not os.path.exists(norm_path):


### PR DESCRIPTION
Gedcom 7.0 allows an URL with scheme ftp, http, or https in the FILE tag.

See:

https://gedcom.io/specifications/FamilySearchGEDCOMv7.html#FILE