### PR TITLE
Fix first name format for genealogytree docgen

### DIFF
--- a/gramps/gui/plug/report/_treereportdialog.py
+++ b/gramps/gui/plug/report/_treereportdialog.py
@@ -55,6 +55,53 @@ class TreeReportDialog(GraphReportDialog):
         """
         return treedoc.TreeOptions()
 
+    def doc_type_changed(self, obj):
+        """
+        This routine is called when the user selects a new file
+        format for the report.  It adjusts the various dialog sections
+        to reflect the appropriate values for the currently selected
+        file format.  For example, a HTML document doesn't need any
+        paper size/orientation options, but it does need a template
+        file.  Those changes are made here.
+        """
+        GraphReportDialog.doc_type_changed(self, obj)
+
+        output_format_str = obj.get_clname()
+        if output_format_str in ['graph']:
+            #Node Options
+            self._goptions.detail.set_available(False)
+            self._goptions.marriage.set_available(False)
+            self._goptions.nodesize.set_available(False)
+            self._goptions.levelsize.set_available(False)
+            self._goptions.nodecolor.set_available(False)
+
+            #Tree Options
+            self._goptions.timeflow.set_available(False)
+            self._goptions.edges.set_available(False)
+            self._goptions.leveldist.set_available(False)
+
+            #Note
+            self._goptions.note.set_available(False)
+            self._goptions.noteloc.set_available(False)
+            self._goptions.notesize.set_available(False)
+        else:
+            #Node Options
+            self._goptions.detail.set_available(True)
+            self._goptions.marriage.set_available(True)
+            self._goptions.nodesize.set_available(True)
+            self._goptions.levelsize.set_available(True)
+            self._goptions.nodecolor.set_available(True)
+
+            #Tree Options
+            self._goptions.timeflow.set_available(True)
+            self._goptions.edges.set_available(True)
+            self._goptions.leveldist.set_available(True)
+
+            #Note
+            self._goptions.note.set_available(True)
+            self._goptions.noteloc.set_available(True)
+            self._goptions.notesize.set_available(True)
+
 #-------------------------------------------------------------------------------
 #
 # TreeFormatComboBox


### PR DESCRIPTION
If no "call" name, first name should be inside `pref{}` per [genealogytree docs](https://ctan.math.illinois.edu/macros/latex/contrib/genealogytree/genealogytree.pdf)

Also removed spaces between `\pref{}` and `\surn{}` blocks, because Genealogytree appears to render the spaces  if present