### PR TITLE
Avoid signal warning during editor clean up

### DIFF
--- a/gramps/gui/editors/displaytabs/gallerytab.py
+++ b/gramps/gui/editors/displaytabs/gallerytab.py
@@ -215,7 +215,7 @@ class GalleryTab(ButtonTab, DbGUIElement):
         self.iconlist.set_selection_mode(Gtk.SelectionMode.SINGLE)
 
         # connect the signals
-        self.__id_connect_sel = self.iconlist.connect('selection-changed', self._selection_changed)
+        self.iconlist.connect('selection-changed', self._selection_changed)
         self.iconlist.connect('button_press_event', self.double_click)
         self.iconlist.connect('key_press_event', self.key_pressed)
         self._connect_icon_model()
@@ -608,5 +608,4 @@ class GalleryTab(ButtonTab, DbGUIElement):
         return self.get_data().index(obj)
 
     def clean_up(self):
-        self.iconlist.disconnect(self.__id_connect_sel)
         super(ButtonTab, self).clean_up()


### PR DESCRIPTION
The signal no longer exists to disconnect from at this point.