### PR TITLE
Add new note type of "Analysis"

### DIFF
--- a/gramps/gen/lib/notetype.py
+++ b/gramps/gen/lib/notetype.py
@@ -65,6 +65,7 @@ class NoteType(GrampsType):
     TODO = 25
     # indicate a note used as link in another note
     LINK = 26
+    ANALYSIS = 27
 
     _CUSTOM = CUSTOM
     _DEFAULT = GENERAL
@@ -74,6 +75,7 @@ class NoteType(GrampsType):
         (CUSTOM, _("Custom"), "Custom"),
         (GENERAL, _("General"), "General"),
         (RESEARCH, _("Research"), "Research"),
+        (ANALYSIS, _("Analysis"), "Analysis"),
         (TRANSCRIPT, _("Transcript"), "Transcript"),
         (SOURCE_TEXT, _("Source text"), "Source text"),
         (CITATION, _('Citation'), "Citation"),


### PR DESCRIPTION
This is intended to be used for notes that contain all types of analysis conducted by the researcher. Examples include proof arguments and the analysis of evidence.

Replaces PR #1417.