### PR TITLE
Fix bug in editors that occurred when source icons were added

### DIFF
--- a/gramps/gui/editors/displaytabs/srcattrembedlist.py
+++ b/gramps/gui/editors/displaytabs/srcattrembedlist.py
@@ -35,7 +35,7 @@ from gi.repository import GObject, GLib
 from gramps.gen.lib import SrcAttribute
 from gramps.gen.errors import WindowActiveError
 from ...ddtargets import DdTargets
-from .attrmodel import AttrModel
+from .srcattrmodel import SrcAttrModel
 from .embeddedlist import (EmbeddedList, TEXT_COL, MARKUP_COL, ICON_COL,
                            TEXT_EDIT_COL)
 
@@ -74,7 +74,7 @@ class SrcAttrEmbedList(EmbeddedList):
         """
         self.data = data
         EmbeddedList.__init__(self, dbstate, uistate, track, _('_Attributes'),
-                              AttrModel, move_buttons=True)
+                              SrcAttrModel, move_buttons=True)
 
     def get_editor(self):
         from .. import EditSrcAttribute

--- a/gramps/gui/editors/displaytabs/srcattrmodel.py
+++ b/gramps/gui/editors/displaytabs/srcattrmodel.py
@@ -33,19 +33,18 @@ from gi.repository import Gtk
 
 #-------------------------------------------------------------------------
 #
-# AttrModel
+# SrcAttrModel
 #
 #-------------------------------------------------------------------------
-class AttrModel(Gtk.ListStore):
+class SrcAttrModel(Gtk.ListStore):
 
     def __init__(self, attr_list, db):
-        Gtk.ListStore.__init__(self, str, str, bool, bool, object)
+        Gtk.ListStore.__init__(self, str, str, bool, object)
         self.db = db
         for attr in attr_list:
             self.append(row=[
                 str(attr.get_type()),
                 attr.get_value(),
-                attr.has_citations(),
                 attr.get_privacy(),
                 attr,
                 ])

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -343,6 +343,7 @@ gramps/gui/editors/displaytabs/placenamemodel.py
 gramps/gui/editors/displaytabs/placerefmodel.py
 gramps/gui/editors/displaytabs/reporefmodel.py
 gramps/gui/editors/displaytabs/sourcebackreflist.py
+gramps/gui/editors/displaytabs/srcattrmodel.py
 gramps/gui/editors/displaytabs/surnamemodel.py
 gramps/gui/editors/displaytabs/webmodel.py
 #


### PR DESCRIPTION
Source attributes do not have citations which means that they cannot share the same attribute model.