### PR TITLE
Use XDG pictures directory as the default media path

### DIFF
--- a/gramps/gen/const.py
+++ b/gramps/gen/const.py
@@ -125,6 +125,10 @@ else:
     USER_CONFIG = os.path.join(GLib.get_user_config_dir(), 'gramps')
     USER_CACHE = os.path.join(GLib.get_user_cache_dir(), 'gramps')
 
+USER_PICTURES = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PICTURES)
+if not USER_PICTURES:
+    USER_PICTURES = HOME_DIR
+
 VERSION_DIR_NAME = "gramps%s%s" % (VERSION_TUPLE[0], VERSION_TUPLE[1])
 VERSION_DIR = os.path.join(USER_CONFIG, VERSION_DIR_NAME)
 USER_DATA_VERSION = os.path.join(USER_DATA, VERSION_DIR_NAME)

--- a/gramps/gen/utils/file.py
+++ b/gramps/gen/utils/file.py
@@ -43,7 +43,7 @@ LOG = logging.getLogger(".gen.utils.file")
 #
 #-------------------------------------------------------------------------
 from ..constfunc import win, mac, get_env_var
-from ..const import USER_HOME, ENV, GRAMPS_LOCALE as glocale
+from ..const import USER_HOME, USER_PICTURES, ENV, GRAMPS_LOCALE as glocale
 
 #-------------------------------------------------------------------------
 #
@@ -182,9 +182,9 @@ def expand_media_path(mpath, db):
      - Convert to absolute path
      - Convert slashes and case (on Windows)
     """
-    # Use home dir if no media_path specified
+    # Use XDG pictures diectory if no media_path specified
     if mpath is None:
-        mpath = os.path.abspath(USER_HOME)
+        mpath = os.path.abspath(USER_PICTURES)
     # Expand environment variables
     mpath = expand_path(mpath, False)
     # Relative mediapath are considered as relative to the database

--- a/gramps/gen/utils/test/file_test.py
+++ b/gramps/gen/utils/test/file_test.py
@@ -39,7 +39,7 @@ import unittest
 # Gramps modules
 #
 #-------------------------------------------------------------------------
-from ...const import USER_HOME, USER_PLUGINS, VERSION
+from ...const import USER_HOME, USER_PICTURES, USER_PLUGINS, VERSION
 from ...utils.file import media_path
 from ...db.utils import make_database
 
@@ -66,7 +66,7 @@ class FileTest(unittest.TestCase):
 
             # Test without db.mediapath set
             self.assertEqual(media_path(db), os.path.normcase(os.path.normpath(
-                os.path.abspath(USER_HOME))))
+                os.path.abspath(USER_PICTURES))))
             self.assertTrue(os.path.exists(media_path(db)))
 
             # Test with absolute db.mediapath


### PR DESCRIPTION
If the "Base path for relative media paths" is left empty then use the XDG pictures directory as the default rather than the home directory.

This is a better default for our Flatpak distribution.

Fixes [#12217](https://gramps-project.org/bugs/view.php?id=12217).