### PR TITLE
Allow custom undo managers in database plugins

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -626,11 +626,11 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
 
         self._set_save_path(directory)
 
-        if self._directory:
+        if self._directory and self._directory != ":memory:":
             self.undolog = os.path.join(self._directory, DBUNDOFN)
         else:
             self.undolog = None
-        self.undodb = DbGenericUndo(self, self.undolog)
+        self.undodb = self._create_undo_manager()
         self.undodb.open()
 
         # Other items to load
@@ -664,6 +664,12 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             else:
                 self.close()
                 raise DbUpgradeRequiredError(dbversion, self.VERSION[0])
+
+    def _create_undo_manager(self):
+        """
+        Create the undo manager.
+        """
+        return DbGenericUndo(self, self.undolog)
 
     def _close(self):
         """

--- a/gramps/gen/db/undoredo.py
+++ b/gramps/gen/db/undoredo.py
@@ -125,6 +125,13 @@ class DbUndo(metaclass=ABCMeta):
         txn.set_description(msg)
         txn.timestamp = time.time()
         self.undoq.append(txn)
+        self._after_commit(txn)
+
+    def _after_commit(self, transaction):
+        """
+        Post-transaction commit processing.
+        """
+        pass
 
     def undo(self, update_history=True):
         """


### PR DESCRIPTION
Add a _create_undo_manager method in DbGeneric which can be overridden to supply a custom undo manager rather than the default DbGenericUndo.