### PR TITLE
Set default column size in list views

### DIFF
--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -283,8 +283,7 @@ class ListView(NavigationView):
             column.set_resizable(True)
             column.set_clickable(True)
             column.set_sizing(Gtk.TreeViewColumnSizing.FIXED)
-            # removed since we have a PersistentTreeView
-            # column.set_fixed_width(pair[2])
+            column.set_fixed_width(pair[2])
 
             self.columns.append(column)
             self.list.append_column(column)


### PR DESCRIPTION
Need to set the column size in list views so that the PersistentTreeView has sensible defaults.

Fixes [#12944](https://gramps-project.org/bugs/view.php?id=12944).