### PR TITLE
Save column sizes before a rebuild

### DIFF
--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -328,6 +328,8 @@ class ListView(NavigationView):
         self.uistate.viewmanager.tags.tag_disable()
 
     def build_tree(self, force_sidebar=False, preserve_col=True):
+        if self.list.get_columns()[0].get_width() > 0:
+            self.list.save_column_info(self.list)
         if self.active:
             cput0 = perf_counter()
             if not self.search_bar.is_visible():

--- a/gramps/gui/widgets/persistenttreeview.py
+++ b/gramps/gui/widgets/persistenttreeview.py
@@ -115,7 +115,7 @@ class PersistentTreeView(Gtk.TreeView):
                     # Don't resize the icons
                     size = 2
                 else:
-                    size = int(column.get_width() / char_width) + 1
+                    size = column.get_width() / char_width
                     size = 2 if size < 2 else size
                 newsize.append(size)
             nbc += 1


### PR DESCRIPTION
To prevent overriding the defaults, don't save sizes before the initial build.

Save column sizes as floats rather than integers. This prevents seeing a slight column resize after a rebuild.

Fixes [#12943](https://gramps-project.org/bugs/view.php?id=12943).