### PR TITLE
Fix 12945: Track all tab settings separately

### DIFF
--- a/gramps/gui/editors/displaytabs/addrembedlist.py
+++ b/gramps/gui/editors/displaytabs/addrembedlist.py
@@ -82,7 +82,7 @@ class AddrEmbedList(EmbeddedList):
         (_("Private"), 9, 30, ICON_COL, -1, "gramps-lock"),
     ]
 
-    def __init__(self, dbstate, uistate, track, data):
+    def __init__(self, dbstate, uistate, track, data, config_key):
         self.data = data
         EmbeddedList.__init__(
             self,
@@ -91,6 +91,7 @@ class AddrEmbedList(EmbeddedList):
             track,
             _("_Addresses"),
             AddressModel,
+            config_key,
             move_buttons=True,
         )
 
@@ -170,6 +171,3 @@ class AddrEmbedList(EmbeddedList):
         Called to update the screen when the address changes
         """
         self.rebuild()
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/attrembedlist.py
+++ b/gramps/gui/editors/displaytabs/attrembedlist.py
@@ -66,7 +66,7 @@ class AttrEmbedList(EmbeddedList):
         (_("Private"), 3, 30, ICON_COL, -1, "gramps-lock"),
     ]
 
-    def __init__(self, dbstate, uistate, track, data):
+    def __init__(self, dbstate, uistate, track, data, config_key):
         """
         Initialize the displaytab. The dbstate and uistate is needed
         track is the list of parent windows
@@ -81,6 +81,7 @@ class AttrEmbedList(EmbeddedList):
             track,
             _("_Attributes"),
             AttrModel,
+            config_key,
             move_buttons=True,
         )
 
@@ -144,6 +145,3 @@ class AttrEmbedList(EmbeddedList):
     def edit_callback(self, name):
         self.changed = True
         self.rebuild()
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/backreflist.py
+++ b/gramps/gui/editors/displaytabs/backreflist.py
@@ -62,9 +62,13 @@ class BackRefList(EmbeddedList):
         (_("Name"), 2, 250, TEXT_COL, -1, None),
     ]
 
-    def __init__(self, dbstate, uistate, track, obj, refmodel, callback=None):
+    def __init__(
+        self, dbstate, uistate, track, obj, refmodel, config_key, callback=None
+    ):
         self.obj = obj
-        EmbeddedList.__init__(self, dbstate, uistate, track, _("_References"), refmodel)
+        EmbeddedList.__init__(
+            self, dbstate, uistate, track, _("_References"), refmodel, config_key
+        )
         self._callback = callback
         self.connectid = self.model.connect("row-inserted", self.update_label)
         self.db_connect = []
@@ -153,6 +157,3 @@ class BackRefList(EmbeddedList):
     def edit_button_clicked(self, obj):
         (reftype, ref) = self.find_node()
         edit_object(self.dbstate, self.uistate, reftype, ref)
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/citationbackreflist.py
+++ b/gramps/gui/editors/displaytabs/citationbackreflist.py
@@ -29,9 +29,16 @@ from .backreflist import BackRefList
 
 
 class CitationBackRefList(BackRefList):
-    def __init__(self, dbstate, uistate, track, obj, callback=None):
+    def __init__(self, dbstate, uistate, track, obj, config_key, callback=None):
         BackRefList.__init__(
-            self, dbstate, uistate, track, obj, BackRefModel, callback=callback
+            self,
+            dbstate,
+            uistate,
+            track,
+            obj,
+            BackRefModel,
+            config_key,
+            callback=callback,
         )
 
     def get_icon_name(self):

--- a/gramps/gui/editors/displaytabs/citationembedlist.py
+++ b/gramps/gui/editors/displaytabs/citationembedlist.py
@@ -90,7 +90,7 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
         (_("Sorted date"), 8, 80, TEXT_COL, -1, None),
     ]
 
-    def __init__(self, dbstate, uistate, track, data, callertitle=None):
+    def __init__(self, dbstate, uistate, track, data, config_key, callertitle=None):
         self.data = data
         self.callertitle = callertitle
         EmbeddedList.__init__(
@@ -100,6 +100,7 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
             track,
             _("_Source Citations"),
             CitationRefModel,
+            config_key,
             share_button=True,
             move_buttons=True,
         )
@@ -345,6 +346,3 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
                     )
             else:
                 raise ValueError("selection must be either source or citation")
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/embeddedlist.py
+++ b/gramps/gui/editors/displaytabs/embeddedlist.py
@@ -85,6 +85,7 @@ class EmbeddedList(ButtonTab):
         track,
         name,
         build_model,
+        config_key,
         share_button=False,
         move_buttons=False,
         jump_button=False,
@@ -93,6 +94,8 @@ class EmbeddedList(ButtonTab):
         """
         Create a new list, using the passed build_model to populate the list.
         """
+        self.config_key = config_key
+
         ButtonTab.__init__(
             self,
             dbstate,
@@ -565,7 +568,7 @@ class EmbeddedList(ButtonTab):
 
     def get_config_name(self):
         """used to associate the selector config name to the PersistentTreeView"""
-        assert False, "Must be defined in the subclass"
+        return self.config_key
 
     def icon_func(self, column, renderer, model, iter_, col_num):
         """

--- a/gramps/gui/editors/displaytabs/eventattrembedlist.py
+++ b/gramps/gui/editors/displaytabs/eventattrembedlist.py
@@ -32,8 +32,8 @@ from .attrembedlist import AttrEmbedList
 #
 # -------------------------------------------------------------------------
 class EventAttrEmbedList(AttrEmbedList):
-    def __init__(self, dbstate, uistate, track, data):
-        AttrEmbedList.__init__(self, dbstate, uistate, track, data)
+    def __init__(self, dbstate, uistate, track, data, config_key):
+        AttrEmbedList.__init__(self, dbstate, uistate, track, data, config_key)
 
     def get_editor(self):
         from .. import EditAttribute
@@ -42,6 +42,3 @@ class EventAttrEmbedList(AttrEmbedList):
 
     def get_user_values(self):
         return self.dbstate.db.get_event_attribute_types()
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/eventbackreflist.py
+++ b/gramps/gui/editors/displaytabs/eventbackreflist.py
@@ -28,8 +28,10 @@ from .backreflist import BackRefList
 
 
 class EventBackRefList(BackRefList):
-    def __init__(self, dbstate, uistate, track, obj, callback=None):
-        BackRefList.__init__(self, dbstate, uistate, track, obj, BackRefModel, callback)
+    def __init__(self, dbstate, uistate, track, obj, config_key, callback=None):
+        BackRefList.__init__(
+            self, dbstate, uistate, track, obj, BackRefModel, config_key, callback
+        )
 
     def get_icon_name(self):
         return "gramps-event"

--- a/gramps/gui/editors/displaytabs/eventembedlist.py
+++ b/gramps/gui/editors/displaytabs/eventembedlist.py
@@ -111,7 +111,14 @@ class EventEmbedList(DbGUIElement, GroupEmbeddedList):
     ]
 
     def __init__(
-        self, dbstate, uistate, track, obj, build_model=EventRefModel, **kwargs
+        self,
+        dbstate,
+        uistate,
+        track,
+        obj,
+        config_key,
+        build_model=EventRefModel,
+        **kwargs
     ):
         self.obj = obj
         self._groups = []
@@ -124,6 +131,7 @@ class EventEmbedList(DbGUIElement, GroupEmbeddedList):
             track,
             _("_Events"),
             build_model,
+            config_key,
             share_button=True,
             move_buttons=True,
             **kwargs,
@@ -484,6 +492,3 @@ class EventEmbedList(DbGUIElement, GroupEmbeddedList):
         self.tree.expand_all()
         if prebuildpath is not None:
             self.selection.select_path(prebuildpath)
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/familyattrembedlist.py
+++ b/gramps/gui/editors/displaytabs/familyattrembedlist.py
@@ -32,8 +32,8 @@ from .attrembedlist import AttrEmbedList
 #
 # -------------------------------------------------------------------------
 class FamilyAttrEmbedList(AttrEmbedList):
-    def __init__(self, dbstate, uistate, track, data):
-        AttrEmbedList.__init__(self, dbstate, uistate, track, data)
+    def __init__(self, dbstate, uistate, track, data, config_key):
+        AttrEmbedList.__init__(self, dbstate, uistate, track, data, config_key)
 
     def get_editor(self):
         from .. import EditAttribute
@@ -42,6 +42,3 @@ class FamilyAttrEmbedList(AttrEmbedList):
 
     def get_user_values(self):
         return self.dbstate.db.get_family_attribute_types()
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/familyldsembedlist.py
+++ b/gramps/gui/editors/displaytabs/familyldsembedlist.py
@@ -58,8 +58,8 @@ class FamilyLdsEmbedList(LdsEmbedList):
         (_("Private"), 6, 30, ICON_COL, -1, "gramps-lock"),
     ]
 
-    def __init__(self, dbstate, uistate, track, data):
-        LdsEmbedList.__init__(self, dbstate, uistate, track, data)
+    def __init__(self, dbstate, uistate, track, data, config_key):
+        LdsEmbedList.__init__(self, dbstate, uistate, track, data, config_key)
 
     def get_editor(self):
         from .. import EditFamilyLdsOrd
@@ -70,6 +70,3 @@ class FamilyLdsEmbedList(LdsEmbedList):
         lds = LdsOrd()
         lds.set_type(LdsOrd.SEAL_TO_SPOUSE)
         return lds
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/groupembeddedlist.py
+++ b/gramps/gui/editors/displaytabs/groupembeddedlist.py
@@ -68,6 +68,7 @@ class GroupEmbeddedList(EmbeddedList):
         track,
         name,
         build_model,
+        config_key,
         share_button=False,
         move_buttons=False,
         jump_button=False,
@@ -84,6 +85,7 @@ class GroupEmbeddedList(EmbeddedList):
             track,
             name,
             build_model,
+            config_key,
             share_button,
             move_buttons,
             jump_button,
@@ -421,6 +423,3 @@ class GroupEmbeddedList(EmbeddedList):
                 self._move_down(pos, ref[1])
         elif ref and ref[1] is None:
             self._move_down_group(ref[0])
-
-    def get_config_name(self):
-        assert False, "Must be defined in the subclass"

--- a/gramps/gui/editors/displaytabs/ldsembedlist.py
+++ b/gramps/gui/editors/displaytabs/ldsembedlist.py
@@ -68,10 +68,17 @@ class LdsEmbedList(EmbeddedList):
         (_("Private"), 6, 30, ICON_COL, -1, "gramps-lock"),
     ]
 
-    def __init__(self, dbstate, uistate, track, data):
+    def __init__(self, dbstate, uistate, track, data, config_key):
         self.data = data
         EmbeddedList.__init__(
-            self, dbstate, uistate, track, _("_LDS"), LdsModel, move_buttons=True
+            self,
+            dbstate,
+            uistate,
+            track,
+            _("_LDS"),
+            LdsModel,
+            config_key,
+            move_buttons=True,
         )
 
     def get_editor(self):
@@ -118,6 +125,3 @@ class LdsEmbedList(EmbeddedList):
 
     def edit_callback(self, name):
         self.rebuild()
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/locationembedlist.py
+++ b/gramps/gui/editors/displaytabs/locationembedlist.py
@@ -60,7 +60,7 @@ class LocationEmbedList(EmbeddedList):
         (_("Country"), 5, 75, TEXT_COL, -1, None),
     ]
 
-    def __init__(self, dbstate, uistate, track, data):
+    def __init__(self, dbstate, uistate, track, data, config_key):
         self.data = data
         EmbeddedList.__init__(
             self,
@@ -69,6 +69,7 @@ class LocationEmbedList(EmbeddedList):
             track,
             _("Alternate _Locations"),
             LocationModel,
+            config_key,
             move_buttons=True,
         )
 
@@ -107,6 +108,3 @@ class LocationEmbedList(EmbeddedList):
 
     def edit_callback(self, name):
         self.rebuild()
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/mediaattrembedlist.py
+++ b/gramps/gui/editors/displaytabs/mediaattrembedlist.py
@@ -32,8 +32,8 @@ from .attrembedlist import AttrEmbedList
 #
 # -------------------------------------------------------------------------
 class MediaAttrEmbedList(AttrEmbedList):
-    def __init__(self, dbstate, uistate, track, data):
-        AttrEmbedList.__init__(self, dbstate, uistate, track, data)
+    def __init__(self, dbstate, uistate, track, data, config_key):
+        AttrEmbedList.__init__(self, dbstate, uistate, track, data, config_key)
 
     def get_editor(self):
         from .. import EditAttribute
@@ -42,6 +42,3 @@ class MediaAttrEmbedList(AttrEmbedList):
 
     def get_user_values(self):
         return self.dbstate.db.get_media_attribute_types()
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/mediabackreflist.py
+++ b/gramps/gui/editors/displaytabs/mediabackreflist.py
@@ -28,9 +28,16 @@ from .backreflist import BackRefList
 
 
 class MediaBackRefList(BackRefList):
-    def __init__(self, dbstate, uistate, track, obj, callback=None):
+    def __init__(self, dbstate, uistate, track, obj, config_key, callback=None):
         BackRefList.__init__(
-            self, dbstate, uistate, track, obj, BackRefModel, callback=callback
+            self,
+            dbstate,
+            uistate,
+            track,
+            obj,
+            BackRefModel,
+            config_key,
+            callback=callback,
         )
 
     def get_icon_name(self):

--- a/gramps/gui/editors/displaytabs/nameembedlist.py
+++ b/gramps/gui/editors/displaytabs/nameembedlist.py
@@ -81,7 +81,7 @@ class NameEmbedList(GroupEmbeddedList):
         (_("Private"), NameModel.COL_PRIVATE[0], 30, ICON_COL, -1, "gramps-lock"),
     ]
 
-    def __init__(self, dbstate, uistate, track, data, person, callback):
+    def __init__(self, dbstate, uistate, track, data, person, config_key, callback):
         """callback is the function to call when preferred name changes
         on the namelist"""
         self.data = data
@@ -89,7 +89,14 @@ class NameEmbedList(GroupEmbeddedList):
         self.callback = callback
 
         GroupEmbeddedList.__init__(
-            self, dbstate, uistate, track, _("_Names"), NameModel, move_buttons=True
+            self,
+            dbstate,
+            uistate,
+            track,
+            _("_Names"),
+            NameModel,
+            config_key,
+            move_buttons=True,
         )
         self.tree.expand_all()
 
@@ -232,6 +239,3 @@ class NameEmbedList(GroupEmbeddedList):
         self.tree.expand_all()
         if prebuildpath is not None:
             self.selection.select_path(prebuildpath)
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/notebackreflist.py
+++ b/gramps/gui/editors/displaytabs/notebackreflist.py
@@ -29,9 +29,16 @@ from .backreflist import BackRefList
 
 
 class NoteBackRefList(BackRefList):
-    def __init__(self, dbstate, uistate, track, obj, callback=None):
+    def __init__(self, dbstate, uistate, track, obj, config_key, callback=None):
         BackRefList.__init__(
-            self, dbstate, uistate, track, obj, BackRefModel, callback=callback
+            self,
+            dbstate,
+            uistate,
+            track,
+            obj,
+            BackRefModel,
+            config_key,
+            callback=callback,
         )
 
     def get_icon_name(self):

--- a/gramps/gui/editors/displaytabs/notetab.py
+++ b/gramps/gui/editors/displaytabs/notetab.py
@@ -81,7 +81,16 @@ class NoteTab(EmbeddedList, DbGUIElement):
         (_("Private"), 2, 30, ICON_COL, -1, "gramps-lock"),
     ]
 
-    def __init__(self, dbstate, uistate, track, data, callertitle=None, notetype=None):
+    def __init__(
+        self,
+        dbstate,
+        uistate,
+        track,
+        data,
+        config_key,
+        callertitle=None,
+        notetype=None,
+    ):
         self.data = data
         self.callertitle = callertitle
         self.notetype = notetype
@@ -92,6 +101,7 @@ class NoteTab(EmbeddedList, DbGUIElement):
             track,
             _("_Notes"),
             NoteModel,
+            config_key,
             share_button=True,
             move_buttons=True,
         )
@@ -231,6 +241,3 @@ class NoteTab(EmbeddedList, DbGUIElement):
             if handle in self.data:
                 self.rebuild()
                 break
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/personbackreflist.py
+++ b/gramps/gui/editors/displaytabs/personbackreflist.py
@@ -28,9 +28,16 @@ from .backreflist import BackRefList
 
 
 class PersonBackRefList(BackRefList):
-    def __init__(self, dbstate, uistate, track, obj, callback=None):
+    def __init__(self, dbstate, uistate, track, obj, config_key, callback=None):
         BackRefList.__init__(
-            self, dbstate, uistate, track, obj, BackRefModel, callback=callback
+            self,
+            dbstate,
+            uistate,
+            track,
+            obj,
+            BackRefModel,
+            config_key,
+            callback=callback,
         )
 
     def get_icon_name(self):

--- a/gramps/gui/editors/displaytabs/personeventembedlist.py
+++ b/gramps/gui/editors/displaytabs/personeventembedlist.py
@@ -62,10 +62,19 @@ class PersonEventEmbedList(EventEmbedList):
         "down": _("Move the selected event downwards or change family order"),
     }
 
-    def __init__(self, dbstate, uistate, track, obj, **kwargs):
+    def __init__(
+        self,
+        dbstate,
+        uistate,
+        track,
+        obj,
+        config_key,
+        build_model=EventRefModel,
+        **kwargs
+    ):
         self.dbstate = dbstate
         EventEmbedList.__init__(
-            self, dbstate, uistate, track, obj, build_model=EventRefModel, **kwargs
+            self, dbstate, uistate, track, obj, config_key, build_model, **kwargs
         )
 
     def get_data(self):
@@ -193,6 +202,3 @@ class PersonEventEmbedList(EventEmbedList):
         path = (index + 2,)
         self.tree.get_selection().select_path(path)
         GLib.idle_add(self.tree.scroll_to_cell, path)
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/personrefembedlist.py
+++ b/gramps/gui/editors/displaytabs/personrefembedlist.py
@@ -70,7 +70,7 @@ class PersonRefEmbedList(DbGUIElement, EmbeddedList):
         (_("Private"), 4, 30, ICON_COL, -1, "gramps-lock"),
     ]
 
-    def __init__(self, dbstate, uistate, track, data):
+    def __init__(self, dbstate, uistate, track, data, config_key):
         self.data = data
         DbGUIElement.__init__(self, dbstate.db)
         EmbeddedList.__init__(
@@ -80,6 +80,7 @@ class PersonRefEmbedList(DbGUIElement, EmbeddedList):
             track,
             _("_Associations"),
             PersonRefModel,
+            config_key,
             move_buttons=True,
         )
 
@@ -208,6 +209,3 @@ class PersonRefEmbedList(DbGUIElement, EmbeddedList):
             )
         except WindowActiveError:
             pass
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/placebackreflist.py
+++ b/gramps/gui/editors/displaytabs/placebackreflist.py
@@ -28,9 +28,16 @@ from .backreflist import BackRefList
 
 
 class PlaceBackRefList(BackRefList):
-    def __init__(self, dbstate, uistate, track, obj, callback=None):
+    def __init__(self, dbstate, uistate, track, obj, config_key, callback=None):
         BackRefList.__init__(
-            self, dbstate, uistate, track, obj, BackRefModel, callback=callback
+            self,
+            dbstate,
+            uistate,
+            track,
+            obj,
+            BackRefModel,
+            config_key,
+            callback=callback,
         )
 
     def get_icon_name(self):

--- a/gramps/gui/editors/displaytabs/placenameembedlist.py
+++ b/gramps/gui/editors/displaytabs/placenameembedlist.py
@@ -66,7 +66,7 @@ class PlaceNameEmbedList(EmbeddedList):
         (_("Language"), 2, 100, TEXT_COL, -1, None),
     ]
 
-    def __init__(self, dbstate, uistate, track, data):
+    def __init__(self, dbstate, uistate, track, data, config_key):
         self.data = data
         EmbeddedList.__init__(
             self,
@@ -75,6 +75,7 @@ class PlaceNameEmbedList(EmbeddedList):
             track,
             _("Alternative Names"),
             PlaceNameModel,
+            config_key,
             move_buttons=True,
         )
 
@@ -127,6 +128,3 @@ class PlaceNameEmbedList(EmbeddedList):
         Called to update the screen when the place name changes.
         """
         self.rebuild()
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/placerefembedlist.py
+++ b/gramps/gui/editors/displaytabs/placerefembedlist.py
@@ -63,7 +63,7 @@ class PlaceRefEmbedList(DbGUIElement, EmbeddedList):
         (_("Date"), 3, 150, TEXT_COL, -1, None),
     ]
 
-    def __init__(self, dbstate, uistate, track, data, handle, callback):
+    def __init__(self, dbstate, uistate, track, data, config_key, handle, callback):
         self.data = data
         self.handle = handle
         self.callback = callback
@@ -75,6 +75,7 @@ class PlaceRefEmbedList(DbGUIElement, EmbeddedList):
             track,
             _("Enclosed By"),
             PlaceRefModel,
+            config_key,
             share_button=True,
             move_buttons=True,
         )
@@ -231,6 +232,3 @@ class PlaceRefEmbedList(DbGUIElement, EmbeddedList):
             )
         except WindowActiveError:
             pass
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/repoembedlist.py
+++ b/gramps/gui/editors/displaytabs/repoembedlist.py
@@ -71,7 +71,7 @@ class RepoEmbedList(EmbeddedList, DbGUIElement):
         (_("Private"), 4, 30, ICON_COL, -1, "gramps-lock"),
     ]
 
-    def __init__(self, dbstate, uistate, track, obj):
+    def __init__(self, dbstate, uistate, track, obj, config_key):
         self.obj = obj
         EmbeddedList.__init__(
             self,
@@ -80,6 +80,7 @@ class RepoEmbedList(EmbeddedList, DbGUIElement):
             track,
             _("_Repositories"),
             RepoRefModel,
+            config_key,
             share_button=True,
             move_buttons=True,
         )
@@ -229,6 +230,3 @@ class RepoEmbedList(EmbeddedList, DbGUIElement):
             if handle in ref_handles:
                 self.rebuild()
                 break
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/sourcebackreflist.py
+++ b/gramps/gui/editors/displaytabs/sourcebackreflist.py
@@ -29,9 +29,16 @@ from .backreflist import BackRefList
 
 
 class SourceBackRefList(BackRefList):
-    def __init__(self, dbstate, uistate, track, obj, callback=None):
+    def __init__(self, dbstate, uistate, track, obj, config_key, callback=None):
         BackRefList.__init__(
-            self, dbstate, uistate, track, obj, BackRefModel, callback=callback
+            self,
+            dbstate,
+            uistate,
+            track,
+            obj,
+            BackRefModel,
+            config_key,
+            callback=callback,
         )
 
     def get_icon_name(self):

--- a/gramps/gui/editors/displaytabs/srcattrembedlist.py
+++ b/gramps/gui/editors/displaytabs/srcattrembedlist.py
@@ -65,7 +65,7 @@ class SrcAttrEmbedList(EmbeddedList):
         (_("Private"), 2, 30, ICON_COL, -1, "gramps-lock"),
     ]
 
-    def __init__(self, dbstate, uistate, track, data):
+    def __init__(self, dbstate, uistate, track, data, config_key):
         """
         Initialize the displaytab. The dbstate and uistate is needed
         track is the list of parent windows
@@ -80,6 +80,7 @@ class SrcAttrEmbedList(EmbeddedList):
             track,
             _("_Attributes"),
             SrcAttrModel,
+            config_key,
             move_buttons=True,
         )
 
@@ -180,6 +181,3 @@ class SrcAttrEmbedList(EmbeddedList):
     def edit_callback(self, name):
         self.changed = True
         self.rebuild()
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/surnametab.py
+++ b/gramps/gui/editors/displaytabs/surnametab.py
@@ -89,6 +89,7 @@ class SurnameTab(EmbeddedList):
         uistate,
         track,
         name,
+        config_key,
         on_change=None,
         top_label="<b>%s</b>" % _("Multiple Surnames"),
     ):
@@ -105,6 +106,7 @@ class SurnameTab(EmbeddedList):
             track,
             _("Family Surnames"),
             SurnameModel,
+            config_key,
             move_buttons=True,
             top_label=top_label,
         )
@@ -437,6 +439,3 @@ class SurnameTab(EmbeddedList):
                     self.curr_celle.editing_done()
                     return
         return True
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/displaytabs/webembedlist.py
+++ b/gramps/gui/editors/displaytabs/webembedlist.py
@@ -69,7 +69,7 @@ class WebEmbedList(EmbeddedList):
         (_("Private"), 3, 30, ICON_COL, -1, "gramps-lock"),
     ]
 
-    def __init__(self, dbstate, uistate, track, data):
+    def __init__(self, dbstate, uistate, track, data, config_key):
         self.data = data
         EmbeddedList.__init__(
             self,
@@ -78,6 +78,7 @@ class WebEmbedList(EmbeddedList):
             track,
             _("_Internet"),
             WebModel,
+            config_key,
             move_buttons=True,
             jump_button=True,
         )
@@ -135,6 +136,3 @@ class WebEmbedList(EmbeddedList):
         url = self.get_selected()
         if url.get_path():
             display_url(url.get_path())
-
-    def get_config_name(self):
-        return __name__

--- a/gramps/gui/editors/editaddress.py
+++ b/gramps/gui/editors/editaddress.py
@@ -172,7 +172,11 @@ class EditAddress(EditSecondary):
         notebook = Gtk.Notebook()
 
         self.srcref_list = CitationEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_citation_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_citation_list(),
+            "address_editor_citations",
         )
         self._add_tab(notebook, self.srcref_list)
         self.track_ref_for_deletion("srcref_list")
@@ -182,6 +186,7 @@ class EditAddress(EditSecondary):
             self.uistate,
             self.track,
             self.obj.get_note_list(),
+            "address_editor_notes",
             notetype=NoteType.ADDRESS,
         )
         self._add_tab(notebook, self.note_tab)

--- a/gramps/gui/editors/editattribute.py
+++ b/gramps/gui/editors/editattribute.py
@@ -218,7 +218,11 @@ class EditAttribute(EditAttributeRoot):
     def _create_tabbed_pages(self):
         notebook = Gtk.Notebook()
         self.srcref_list = CitationEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_citation_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_citation_list(),
+            "attribute_editor_citations",
         )
         self._add_tab(notebook, self.srcref_list)
         self.track_ref_for_deletion("srcref_list")
@@ -228,6 +232,7 @@ class EditAttribute(EditAttributeRoot):
             self.uistate,
             self.track,
             self.obj.get_note_list(),
+            "attribute_editor_notes",
             notetype=NoteType.ATTRIBUTE,
         )
         self._add_tab(notebook, self.note_tab)

--- a/gramps/gui/editors/editchildref.py
+++ b/gramps/gui/editors/editchildref.py
@@ -171,7 +171,11 @@ class EditChildRef(EditSecondary):
         notebook = Gtk.Notebook()
 
         self.srcref_list = CitationEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_citation_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_citation_list(),
+            "childref_editor_citations",
         )
         self._add_tab(notebook, self.srcref_list)
         self.track_ref_for_deletion("srcref_list")
@@ -181,6 +185,7 @@ class EditChildRef(EditSecondary):
             self.uistate,
             self.track,
             self.obj.get_note_list(),
+            "childref_editor_notes",
             notetype=NoteType.CHILDREF,
         )
         self._add_tab(notebook, self.note_tab)

--- a/gramps/gui/editors/editcitation.py
+++ b/gramps/gui/editors/editcitation.py
@@ -271,6 +271,7 @@ class EditCitation(EditPrimary):
             self.uistate,
             self.track,
             self.obj.get_note_list(),
+            "citation_editor_notes",
             self.get_menu_title(),
             notetype=NoteType.CITATION,
         )
@@ -278,13 +279,20 @@ class EditCitation(EditPrimary):
         self.track_ref_for_deletion("note_tab")
 
         self.gallery_tab = GalleryTab(
-            self.dbstate, self.uistate, self.track, self.obj.get_media_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_media_list(),
         )
         self._add_tab(notebook, self.gallery_tab)
         self.track_ref_for_deletion("gallery_tab")
 
         self.attr_tab = SrcAttrEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_attribute_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_attribute_list(),
+            "citation_editor_attributes",
         )
         self._add_tab(notebook, self.attr_tab)
         self.track_ref_for_deletion("attr_tab")
@@ -294,6 +302,7 @@ class EditCitation(EditPrimary):
             self.uistate,
             self.track,
             self.db.find_backlink_handles(self.obj.handle),
+            "citation_editor_references",
         )
         self._add_tab(notebook, self.citationref_list)
         self.track_ref_for_deletion("citationref_list")

--- a/gramps/gui/editors/editevent.py
+++ b/gramps/gui/editors/editevent.py
@@ -219,6 +219,7 @@ class EditEvent(EditPrimary):
             self.uistate,
             self.track,
             self.obj.get_citation_list(),
+            "event_editor_citations",
             self.get_menu_title(),
         )
         self._add_tab(notebook, self.citation_list)
@@ -228,23 +229,35 @@ class EditEvent(EditPrimary):
             self.uistate,
             self.track,
             self.obj.get_note_list(),
+            "event_editor_notes",
             notetype=NoteType.EVENT,
         )
         self._add_tab(notebook, self.note_list)
 
         self.gallery_list = GalleryTab(
-            self.dbstate, self.uistate, self.track, self.obj.get_media_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_media_list(),
         )
         self._add_tab(notebook, self.gallery_list)
 
         self.attr_list = EventAttrEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_attribute_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_attribute_list(),
+            "event_editor_attributes",
         )
         self._add_tab(notebook, self.attr_list)
 
         handle_list = self.dbstate.db.find_backlink_handles(self.obj.handle)
         self.backref_list = EventBackRefList(
-            self.dbstate, self.uistate, self.track, handle_list
+            self.dbstate,
+            self.uistate,
+            self.track,
+            handle_list,
+            "event_editor_references",
         )
         self._add_tab(notebook, self.backref_list)
 

--- a/gramps/gui/editors/editeventref.py
+++ b/gramps/gui/editors/editeventref.py
@@ -225,25 +225,41 @@ class EditEventRef(EditReference):
         self.track_ref_for_deletion("reftab")
 
         self.srcref_list = CitationEmbedList(
-            self.dbstate, self.uistate, self.track, self.source.get_citation_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.source.get_citation_list(),
+            "eventref_editor_shared_citations",
         )
         self._add_tab(notebook, self.srcref_list)
         self.track_ref_for_deletion("srcref_list")
 
         self.srcref_ref_list = CitationEmbedList(
-            self.dbstate, self.uistate, self.track, self.source_ref.get_citation_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.source_ref.get_citation_list(),
+            "eventref_editor_ref_citations",
         )
         self._add_tab(notebook_ref, self.srcref_ref_list)
         self.track_ref_for_deletion("srcref_ref_list")
 
         self.attr_list = EventAttrEmbedList(
-            self.dbstate, self.uistate, self.track, self.source.get_attribute_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.source.get_attribute_list(),
+            "eventref_editor_shared_attributes",
         )
         self._add_tab(notebook, self.attr_list)
         self.track_ref_for_deletion("attr_list")
 
         self.attr_ref_list = EventAttrEmbedList(
-            self.dbstate, self.uistate, self.track, self.source_ref.get_attribute_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.source_ref.get_attribute_list(),
+            "eventref_editor_ref_attributes",
         )
         self._add_tab(notebook_ref, self.attr_ref_list)
         self.track_ref_for_deletion("attr_ref_list")
@@ -253,6 +269,7 @@ class EditEventRef(EditReference):
             self.uistate,
             self.track,
             self.source.get_note_list(),
+            "eventref_editor_shared_notes",
             notetype=NoteType.EVENT,
         )
         self._add_tab(notebook, self.note_tab)
@@ -263,13 +280,17 @@ class EditEventRef(EditReference):
             self.uistate,
             self.track,
             self.source_ref.get_note_list(),
+            "eventref_editor_ref_notes",
             notetype=NoteType.EVENTREF,
         )
         self._add_tab(notebook_ref, self.note_ref_tab)
         self.track_ref_for_deletion("note_ref_tab")
 
         self.gallery_tab = GalleryTab(
-            self.dbstate, self.uistate, self.track, self.source.get_media_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.source.get_media_list(),
         )
         self._add_tab(notebook, self.gallery_tab)
         self.track_ref_for_deletion("gallery_tab")
@@ -279,6 +300,7 @@ class EditEventRef(EditReference):
             self.uistate,
             self.track,
             self.db.find_backlink_handles(self.source.handle),
+            "eventref_editor_references",
             self.enable_warnbox,
         )
         self._add_tab(notebook, self.backref_tab)

--- a/gramps/gui/editors/editfamily.py
+++ b/gramps/gui/editors/editfamily.py
@@ -151,7 +151,7 @@ class ChildEmbedList(DbGUIElement, EmbeddedList):
         (_("Private"), 14, 30, ICON_COL, -1, "gramps-lock"),
     ]
 
-    def __init__(self, dbstate, uistate, track, family):
+    def __init__(self, dbstate, uistate, track, family, config_key):
         """
         Create the object, storing the passed family value
         """
@@ -164,6 +164,7 @@ class ChildEmbedList(DbGUIElement, EmbeddedList):
             track,
             _("Chil_dren"),
             ChildModel,
+            config_key,
             share_button=True,
             move_buttons=True,
         )
@@ -409,9 +410,6 @@ class ChildEmbedList(DbGUIElement, EmbeddedList):
             return name
         else:
             return name
-
-    def get_config_name(self):
-        return __name__
 
 
 class FastMaleFilter:
@@ -823,7 +821,7 @@ class EditFamily(EditPrimary):
         notebook = Gtk.Notebook()
 
         self.child_list = ChildEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj
+            self.dbstate, self.uistate, self.track, self.obj, "family_editor_childrefs"
         )
         self.child_tab = self._add_tab(notebook, self.child_list)
         self.track_ref_for_deletion("child_list")
@@ -834,6 +832,7 @@ class EditFamily(EditPrimary):
             self.uistate,
             self.track,
             self.obj,
+            "family_editor_events",
             start_date=self.get_start_date(),
         )
 
@@ -845,13 +844,18 @@ class EditFamily(EditPrimary):
             self.uistate,
             self.track,
             self.obj.get_citation_list(),
+            "family_editor_citations",
             self.get_menu_title(),
         )
         self._add_tab(notebook, self.citation_list)
         self.track_ref_for_deletion("citation_list")
 
         self.attr_list = FamilyAttrEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_attribute_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_attribute_list(),
+            "family_editor_attributes",
         )
         self._add_tab(notebook, self.attr_list)
         self.track_ref_for_deletion("attr_list")
@@ -861,6 +865,7 @@ class EditFamily(EditPrimary):
             self.uistate,
             self.track,
             self.obj.get_note_list(),
+            "family_editor_notes",
             self.get_menu_title(),
             notetype=NoteType.FAMILY,
         )
@@ -868,13 +873,20 @@ class EditFamily(EditPrimary):
         self.track_ref_for_deletion("note_tab")
 
         self.gallery_tab = GalleryTab(
-            self.dbstate, self.uistate, self.track, self.obj.get_media_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_media_list(),
         )
         self._add_tab(notebook, self.gallery_tab)
         self.track_ref_for_deletion("gallery_tab")
 
         self.lds_embed = FamilyLdsEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_lds_ord_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_lds_ord_list(),
+            "family_editor_ldsord",
         )
         if not (config.get("interface.hide-lds") and self.lds_embed.is_empty()):
             self._add_tab(notebook, self.lds_embed)
@@ -1396,9 +1408,6 @@ class EditFamily(EditPrimary):
                         name.set_surname_list([surnames[-1]])
                         return name
         return name
-
-    def get_config_name(self):
-        return __name__
 
 
 def button_activated(event, mouse_button):

--- a/gramps/gui/editors/editldsord.py
+++ b/gramps/gui/editors/editldsord.py
@@ -268,7 +268,11 @@ class EditLdsOrd(EditSecondary):
     def _create_tabbed_pages(self):
         notebook = Gtk.Notebook()
         self.citation_list = CitationEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_citation_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_citation_list(),
+            "ldsord_editor_citations",
         )
         self._add_tab(notebook, self.citation_list)
         self.track_ref_for_deletion("citation_list")
@@ -278,6 +282,7 @@ class EditLdsOrd(EditSecondary):
             self.uistate,
             self.track,
             self.obj.get_note_list(),
+            "ldsord_editor_notes",
             notetype=NoteType.LDS,
         )
         self._add_tab(notebook, self.note_tab)
@@ -453,7 +458,11 @@ class EditFamilyLdsOrd(EditSecondary):
     def _create_tabbed_pages(self):
         notebook = Gtk.Notebook()
         self.srcref_list = CitationEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_citation_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_citation_list(),
+            "ldsord_editor_citations",
         )
         self._add_tab(notebook, self.srcref_list)
         self.track_ref_for_deletion("srcref_list")
@@ -463,6 +472,7 @@ class EditFamilyLdsOrd(EditSecondary):
             self.uistate,
             self.track,
             self.obj.get_note_list(),
+            "ldsord_editor_notes",
             notetype=NoteType.LDS,
         )
         self._add_tab(notebook, self.note_tab)

--- a/gramps/gui/editors/editmedia.py
+++ b/gramps/gui/editors/editmedia.py
@@ -228,13 +228,18 @@ class EditMedia(EditPrimary):
             self.uistate,
             self.track,
             self.obj.get_citation_list(),
+            "media_editor_citations",
             self.get_menu_title(),
         )
         self._add_tab(notebook, self.citation_tab)
         self.track_ref_for_deletion("citation_tab")
 
         self.attr_tab = MediaAttrEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_attribute_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_attribute_list(),
+            "media_editor_attributes",
         )
         self._add_tab(notebook, self.attr_tab)
         self.track_ref_for_deletion("attr_tab")
@@ -244,6 +249,7 @@ class EditMedia(EditPrimary):
             self.uistate,
             self.track,
             self.obj.get_note_list(),
+            "media_editor_notes",
             notetype=NoteType.MEDIA,
         )
         self._add_tab(notebook, self.note_tab)
@@ -254,6 +260,7 @@ class EditMedia(EditPrimary):
             self.uistate,
             self.track,
             self.db.find_backlink_handles(self.obj.handle),
+            "media_editor_references",
         )
         self.backref_list = self._add_tab(notebook, self.backref_tab)
         self.track_ref_for_deletion("backref_tab")

--- a/gramps/gui/editors/editmediaref.py
+++ b/gramps/gui/editors/editmediaref.py
@@ -494,13 +494,21 @@ class EditMediaRef(EditReference):
         self._add_tab(notebook_ref, self.reftab)
 
         self.srcref_list = CitationEmbedList(
-            self.dbstate, self.uistate, self.track, self.source_ref.get_citation_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.source_ref.get_citation_list(),
+            "mediaref_editor_ref_citations",
         )
         self._add_tab(notebook_ref, self.srcref_list)
         self.track_ref_for_deletion("srcref_list")
 
         self.attr_list = MediaAttrEmbedList(
-            self.dbstate, self.uistate, self.track, self.source_ref.get_attribute_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.source_ref.get_attribute_list(),
+            "mediaref_editor_ref_attributes",
         )
         self._add_tab(notebook_ref, self.attr_list)
         self.track_ref_for_deletion("attr_list")
@@ -510,6 +518,7 @@ class EditMediaRef(EditReference):
             self.uistate,
             self.track,
             self.db.find_backlink_handles(self.source.handle),
+            "mediaref_editor_shared_references",
             self.enable_warnbox,
         )
         self._add_tab(notebook_src, self.backref_list)
@@ -520,19 +529,28 @@ class EditMediaRef(EditReference):
             self.uistate,
             self.track,
             self.source_ref.get_note_list(),
+            "mediaref_editor_ref_notes",
             notetype=NoteType.MEDIAREF,
         )
         self._add_tab(notebook_ref, self.note_ref_tab)
         self.track_ref_for_deletion("note_ref_tab")
 
         self.src_srcref_list = CitationEmbedList(
-            self.dbstate, self.uistate, self.track, self.source.get_citation_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.source.get_citation_list(),
+            "mediaref_editor_shared_citations",
         )
         self._add_tab(notebook_src, self.src_srcref_list)
         self.track_ref_for_deletion("src_srcref_list")
 
         self.src_attr_list = MediaAttrEmbedList(
-            self.dbstate, self.uistate, self.track, self.source.get_attribute_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.source.get_attribute_list(),
+            "mediaref_editor_shared_attributes",
         )
         self._add_tab(notebook_src, self.src_attr_list)
         self.track_ref_for_deletion("src_attr_list")
@@ -542,6 +560,7 @@ class EditMediaRef(EditReference):
             self.uistate,
             self.track,
             self.source.get_note_list(),
+            "mediaref_editor_shared_notes",
             notetype=NoteType.MEDIA,
         )
         self._add_tab(notebook_src, self.src_note_ref_tab)

--- a/gramps/gui/editors/editname.py
+++ b/gramps/gui/editors/editname.py
@@ -129,7 +129,12 @@ class EditName(EditSecondary):
         hbox_surn.set_size_request(-1, int(config.get("interface.surname-box-height")))
         hbox_surn.pack_start(
             SurnameTab(
-                self.dbstate, self.uistate, self.track, self.obj, top_label=None
+                self.dbstate,
+                self.uistate,
+                self.track,
+                self.obj,
+                "name_editor_surnames",
+                top_label=None,
             ),
             True,
             True,
@@ -300,7 +305,11 @@ class EditName(EditSecondary):
         self.track_ref_for_deletion("gennam")
 
         self.srcref_list = CitationEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_citation_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_citation_list(),
+            "name_editor_citations",
         )
         self._add_tab(notebook, self.srcref_list)
         self.track_ref_for_deletion("srcref_list")
@@ -310,6 +319,7 @@ class EditName(EditSecondary):
             self.uistate,
             self.track,
             self.obj.get_note_list(),
+            "name_editor_notes",
             notetype=NoteType.PERSONNAME,
         )
         self._add_tab(notebook, self.note_tab)

--- a/gramps/gui/editors/editnote.py
+++ b/gramps/gui/editors/editnote.py
@@ -282,7 +282,9 @@ class EditNote(EditPrimary):
         self._add_tab(notebook, self.ntab)
 
         handles = self.dbstate.db.find_backlink_handles(self.obj.handle)
-        self.rlist = NoteBackRefList(self.dbstate, self.uistate, self.track, handles)
+        self.rlist = NoteBackRefList(
+            self.dbstate, self.uistate, self.track, handles, "note_editor_references"
+        )
         self.backref_tab = self._add_tab(notebook, self.rlist)
         self.track_ref_for_deletion("rlist")
         self.track_ref_for_deletion("backref_tab")

--- a/gramps/gui/editors/editperson.py
+++ b/gramps/gui/editors/editperson.py
@@ -478,6 +478,7 @@ class EditPerson(EditPrimary):
             self.uistate,
             self.track,
             self.obj.get_primary_name(),
+            "person_editor_surnames",
             on_change=self._changed_name,
         )
 
@@ -509,6 +510,7 @@ class EditPerson(EditPrimary):
             self.uistate,
             self.track,
             self.obj,
+            "person_editor_events",
             start_date=self.get_start_date(),
             end_date=self.get_end_date(),
         )
@@ -522,6 +524,7 @@ class EditPerson(EditPrimary):
             self.track,
             self.obj.get_alternate_names(),
             self.obj,
+            "person_editor_names",
             self.name_callback,
         )
         self._add_tab(notebook, self.name_list)
@@ -532,19 +535,28 @@ class EditPerson(EditPrimary):
             self.uistate,
             self.track,
             self.obj.get_citation_list(),
+            "person_editor_citations",
             self.get_menu_title(),
         )
         self._add_tab(notebook, self.srcref_list)
         self.track_ref_for_deletion("srcref_list")
 
         self.attr_list = AttrEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_attribute_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_attribute_list(),
+            "person_editor_attributes",
         )
         self._add_tab(notebook, self.attr_list)
         self.track_ref_for_deletion("attr_list")
 
         self.addr_list = AddrEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_address_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_address_list(),
+            "person_editor_addresses",
         )
         self._add_tab(notebook, self.addr_list)
         self.track_ref_for_deletion("addr_list")
@@ -554,6 +566,7 @@ class EditPerson(EditPrimary):
             self.uistate,
             self.track,
             self.obj.get_note_list(),
+            "person_editor_notes",
             self.get_menu_title(),
             notetype=NoteType.PERSON,
         )
@@ -571,19 +584,31 @@ class EditPerson(EditPrimary):
         self.track_ref_for_deletion("gallery_tab")
 
         self.web_list = WebEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_url_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_url_list(),
+            "person_editor_internet",
         )
         self._add_tab(notebook, self.web_list)
         self.track_ref_for_deletion("web_list")
 
         self.person_ref_list = PersonRefEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_person_ref_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_person_ref_list(),
+            "person_editor_associations",
         )
         self._add_tab(notebook, self.person_ref_list)
         self.track_ref_for_deletion("person_ref_list")
 
         self.lds_list = LdsEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_lds_ord_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_lds_ord_list(),
+            "person_editor_ldsord",
         )
         if not (config.get("interface.hide-lds") and self.lds_list.is_empty()):
             self._add_tab(notebook, self.lds_list)
@@ -594,6 +619,7 @@ class EditPerson(EditPrimary):
             self.uistate,
             self.track,
             self.db.find_backlink_handles(self.obj.handle),
+            "person_editor_references",
         )
         self._add_tab(notebook, self.backref_tab)
         self.track_ref_for_deletion("backref_tab")
@@ -1036,6 +1062,7 @@ class EditPerson(EditPrimary):
             self.uistate,
             self.track,
             self.obj.get_primary_name(),
+            "person_editor_surnames",
             on_change=self._changed_name,
         )
         self.multsurnfr.set_size_request(

--- a/gramps/gui/editors/editpersonref.py
+++ b/gramps/gui/editors/editpersonref.py
@@ -156,7 +156,11 @@ class EditPersonRef(EditSecondary):
         notebook = Gtk.Notebook()
 
         self.srcref_list = CitationEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_citation_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_citation_list(),
+            "personref_editor_ref_citations",
         )
         self._add_tab(notebook, self.srcref_list)
         self.track_ref_for_deletion("srcref_list")
@@ -166,6 +170,7 @@ class EditPersonRef(EditSecondary):
             self.uistate,
             self.track,
             self.obj.get_note_list(),
+            "personref_editor_ref_notes",
             notetype=NoteType.ASSOCIATION,
         )
         self._add_tab(notebook, self.note_tab)

--- a/gramps/gui/editors/editplace.py
+++ b/gramps/gui/editors/editplace.py
@@ -301,6 +301,7 @@ class EditPlace(EditPrimary):
             self.uistate,
             self.track,
             self.obj.get_placeref_list(),
+            "place_editor_placerefs",
             self.obj.handle,
             self.update_title,
         )
@@ -308,14 +309,22 @@ class EditPlace(EditPrimary):
         self.track_ref_for_deletion("placeref_list")
 
         self.alt_name_list = PlaceNameEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.alt_names
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.alt_names,
+            "place_editor_altnames",
         )
         self._add_tab(notebook, self.alt_name_list)
         self.track_ref_for_deletion("alt_name_list")
 
         if len(self.obj.alt_loc) > 0:
             self.loc_list = LocationEmbedList(
-                self.dbstate, self.uistate, self.track, self.obj.alt_loc
+                self.dbstate,
+                self.uistate,
+                self.track,
+                self.obj.alt_loc,
+                "place_editor_locations",
             )
             self._add_tab(notebook, self.loc_list)
             self.track_ref_for_deletion("loc_list")
@@ -325,6 +334,7 @@ class EditPlace(EditPrimary):
             self.uistate,
             self.track,
             self.obj.get_citation_list(),
+            "place_editor_citations",
             self.get_menu_title(),
         )
         self._add_tab(notebook, self.citation_list)
@@ -335,6 +345,7 @@ class EditPlace(EditPrimary):
             self.uistate,
             self.track,
             self.obj.get_note_list(),
+            "place_editor_notes",
             self.get_menu_title(),
             notetype=NoteType.PLACE,
         )
@@ -342,13 +353,20 @@ class EditPlace(EditPrimary):
         self.track_ref_for_deletion("note_tab")
 
         self.gallery_tab = GalleryTab(
-            self.dbstate, self.uistate, self.track, self.obj.get_media_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_media_list(),
         )
         self._add_tab(notebook, self.gallery_tab)
         self.track_ref_for_deletion("gallery_tab")
 
         self.web_list = WebEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_url_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_url_list(),
+            "place_editor_internet",
         )
         self._add_tab(notebook, self.web_list)
         self.track_ref_for_deletion("web_list")
@@ -358,6 +376,7 @@ class EditPlace(EditPrimary):
             self.uistate,
             self.track,
             self.db.find_backlink_handles(self.obj.handle),
+            "place_editor_references",
         )
         self.backref_tab = self._add_tab(notebook, self.backref_list)
         self.track_ref_for_deletion("backref_list")

--- a/gramps/gui/editors/editplaceref.py
+++ b/gramps/gui/editors/editplaceref.py
@@ -275,6 +275,7 @@ class EditPlaceRef(EditReference):
             self.uistate,
             self.track,
             self.source.get_placeref_list(),
+            "placeref_editor_placerefs",
             self.source.handle,
             self.update_title,
         )
@@ -282,20 +283,32 @@ class EditPlaceRef(EditReference):
         self.track_ref_for_deletion("placeref_list")
 
         self.alt_name_list = PlaceNameEmbedList(
-            self.dbstate, self.uistate, self.track, self.source.alt_names
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.source.alt_names,
+            "placeref_editor_altnames",
         )
         self._add_tab(notebook, self.alt_name_list)
         self.track_ref_for_deletion("alt_name_list")
 
         if len(self.source.alt_loc) > 0:
             self.loc_list = LocationEmbedList(
-                self.dbstate, self.uistate, self.track, self.source.alt_loc
+                self.dbstate,
+                self.uistate,
+                self.track,
+                self.source.alt_loc,
+                "placeref_editor_locations",
             )
             self._add_tab(notebook, self.loc_list)
             self.track_ref_for_deletion("loc_list")
 
         self.citation_list = CitationEmbedList(
-            self.dbstate, self.uistate, self.track, self.source.get_citation_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.source.get_citation_list(),
+            "placeref_editor_citations",
         )
         self._add_tab(notebook, self.citation_list)
         self.track_ref_for_deletion("citation_list")
@@ -305,19 +318,27 @@ class EditPlaceRef(EditReference):
             self.uistate,
             self.track,
             self.source.get_note_list(),
+            "placeref_editor_notes",
             notetype=NoteType.PLACE,
         )
         self._add_tab(notebook, self.note_tab)
         self.track_ref_for_deletion("note_tab")
 
         self.gallery_tab = GalleryTab(
-            self.dbstate, self.uistate, self.track, self.source.get_media_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.source.get_media_list(),
         )
         self._add_tab(notebook, self.gallery_tab)
         self.track_ref_for_deletion("gallery_tab")
 
         self.web_list = WebEmbedList(
-            self.dbstate, self.uistate, self.track, self.source.get_url_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.source.get_url_list(),
+            "placeref_editor_internet",
         )
         self._add_tab(notebook, self.web_list)
         self.track_ref_for_deletion("web_list")
@@ -327,6 +348,7 @@ class EditPlaceRef(EditReference):
             self.uistate,
             self.track,
             self.db.find_backlink_handles(self.source.handle),
+            "placeref_editor_references",
         )
         self.backref_tab = self._add_tab(notebook, self.backref_list)
         self.track_ref_for_deletion("backref_list")

--- a/gramps/gui/editors/editreporef.py
+++ b/gramps/gui/editors/editreporef.py
@@ -156,6 +156,7 @@ class EditRepoRef(EditReference):
             self.uistate,
             self.track,
             self.source.get_note_list(),
+            "reporef_editor_shared_notes",
             notetype=NoteType.REPO,
         )
         self._add_tab(notebook_src, self.note_tab)
@@ -166,19 +167,28 @@ class EditRepoRef(EditReference):
             self.uistate,
             self.track,
             self.source_ref.get_note_list(),
+            "reporef_editor_ref_notes",
             notetype=NoteType.REPOREF,
         )
         self._add_tab(notebook_ref, self.comment_tab)
         self.track_ref_for_deletion("comment_tab")
 
         self.address_tab = AddrEmbedList(
-            self.dbstate, self.uistate, self.track, self.source.get_address_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.source.get_address_list(),
+            "reporef_editor_shared_address",
         )
         self._add_tab(notebook_src, self.address_tab)
         self.track_ref_for_deletion("address_tab")
 
         self.web_list = WebEmbedList(
-            self.dbstate, self.uistate, self.track, self.source.get_url_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.source.get_url_list(),
+            "reporef_editor_shared_internet",
         )
         self._add_tab(notebook_src, self.web_list)
         self.track_ref_for_deletion("web_list")
@@ -188,6 +198,7 @@ class EditRepoRef(EditReference):
             self.uistate,
             self.track,
             self.db.find_backlink_handles(self.source.handle),
+            "reporef_editor_shared_references",
             self.enable_warnbox,
         )
         self._add_tab(notebook_src, self.backref_tab)

--- a/gramps/gui/editors/editrepository.py
+++ b/gramps/gui/editors/editrepository.py
@@ -138,13 +138,21 @@ class EditRepository(EditPrimary):
         notebook = Gtk.Notebook()
 
         self.addr_tab = AddrEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_address_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_address_list(),
+            "repository_editor_addresses",
         )
         self._add_tab(notebook, self.addr_tab)
         self.track_ref_for_deletion("addr_tab")
 
         self.url_tab = WebEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_url_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_url_list(),
+            "repository_editor_internet",
         )
         self._add_tab(notebook, self.url_tab)
         self.track_ref_for_deletion("url_tab")
@@ -154,6 +162,7 @@ class EditRepository(EditPrimary):
             self.uistate,
             self.track,
             self.obj.get_note_list(),
+            "repository_editor_notes",
             self.get_menu_title(),
             notetype=NoteType.REPO,
         )
@@ -165,6 +174,7 @@ class EditRepository(EditPrimary):
             self.uistate,
             self.track,
             self.db.find_backlink_handles(self.obj.handle),
+            "repository_editor_references",
         )
         self.backref_list = self._add_tab(notebook, self.backref_tab)
         self.track_ref_for_deletion("backref_tab")

--- a/gramps/gui/editors/editsource.py
+++ b/gramps/gui/editors/editsource.py
@@ -182,6 +182,7 @@ class EditSource(EditPrimary):
             self.uistate,
             self.track,
             self.obj.get_note_list(),
+            "source_editor_notes",
             self.get_menu_title(),
             NoteType.SOURCE,
         )
@@ -189,19 +190,30 @@ class EditSource(EditPrimary):
         self.track_ref_for_deletion("note_tab")
 
         self.gallery_tab = GalleryTab(
-            self.dbstate, self.uistate, self.track, self.obj.get_media_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_media_list(),
         )
         self._add_tab(notebook, self.gallery_tab)
         self.track_ref_for_deletion("gallery_tab")
 
         self.attr_tab = SrcAttrEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_attribute_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_attribute_list(),
+            "source_editor_attributes",
         )
         self._add_tab(notebook, self.attr_tab)
         self.track_ref_for_deletion("attr_tab")
 
         self.repo_tab = RepoEmbedList(
-            self.dbstate, self.uistate, self.track, self.obj.get_reporef_list()
+            self.dbstate,
+            self.uistate,
+            self.track,
+            self.obj.get_reporef_list(),
+            "source_editor_repositories",
         )
         self._add_tab(notebook, self.repo_tab)
         self.track_ref_for_deletion("repo_tab")
@@ -211,6 +223,7 @@ class EditSource(EditPrimary):
             self.uistate,
             self.track,
             self.db.find_backlink_handles(self.obj.handle),
+            "source_editor_references",
         )
         self.backref_tab = self._add_tab(notebook, self.backref_list)
         self.track_ref_for_deletion("backref_tab")


### PR DESCRIPTION
Addresses issue 12945 by adding a mandatory config_key to all embedded list tabs and the note tab and updates editors to set keys specific to the editor so column changes persist on a per tab per editor basis. 

```
address_editor_citations=[2, 16, 17, 9, 15, 17, 7]
address_editor_notes=[2, 6]
childref_editor_citations=[2, 29, 17, 9, 15, 17, 7]
childref_editor_notes=[2, 9]
citation_editor_attributes=[2, 10]
citation_editor_notes=[2, 6]
citation_editor_references=[9, 7]
event_editor_attributes=[2, 2, 14]
event_editor_citations=[2, 21, 17, 9, 15, 17, 7]
event_editor_notes=[2, 9]
event_editor_references=[9, 15]
eventref_editor_ref_attributes=[2, 2, 8]
eventref_editor_ref_citations=[2, 8, 17, 9, 15, 17, 7]
eventref_editor_ref_notes=[2, 9]
eventref_editor_references=[6, 13]
eventref_editor_shared_attributes=[2, 2, 21]
eventref_editor_shared_citations=[2, 37, 17, 9, 15, 17, 7]
eventref_editor_shared_notes=[2, 5]
family_editor_attributes=[2, 2, 21]
family_editor_childrefs=[2, 2, 3, 5, 21, 7, 9, 9]
family_editor_citations=[2, 29, 17, 9, 15, 17, 7]
family_editor_events=[10, 20, 13, 20, 20, 2, 2, 7, 5]
family_editor_ldsord=[2, 2, 13, 13, 7, 17]
family_editor_notes=[2, 9]
ldsord_editor_citations=[2, 22, 17, 9, 15, 17, 7]
ldsord_editor_notes=[2, 16]
media_editor_attributes=[2, 2, 21]
media_editor_citations=[2, 29, 17, 9, 15, 17, 7]
media_editor_notes=[2, 9]
media_editor_references=[9, 7]
mediaref_editor_ref_attributes=[2, 2, 14]
mediaref_editor_ref_citations=[2, 16, 17, 9, 15, 17, 7]
mediaref_editor_ref_notes=[2, 13]
mediaref_editor_shared_attributes=[2, 2, 21]
mediaref_editor_shared_citations=[2, 29, 17, 9, 15, 17, 7]
mediaref_editor_shared_notes=[2, 9]
mediaref_editor_shared_references=[9, 7]
name_editor_citations=[2, 22, 17, 9, 15, 17, 7]
name_editor_notes=[2, 15]
name_editor_surnames=[23, 23, 9, 13]
note_editor_references=[9, 10]
person_editor_addresses=[2, 2, 13, 19, 9, 9, 9, 7, 7]
person_editor_associations=[2, 2, 21, 9]
person_editor_attributes=[2, 2, 18]
person_editor_citations=[2, 29, 17, 9, 15, 17, 7]
person_editor_events=[10, 20, 13, 20, 20, 2, 2, 7, 5]
person_editor_internet=[2, 9, 25]
person_editor_ldsord=[2, 2, 13, 8, 7, 17]
person_editor_names=[21, 2, 2, 9, 9]
person_editor_notes=[2, 9]
person_editor_references=[9, 11]
person_editor_surnames=[2, 77, 2, 13]
personref_editor_ref_citations=[2, 22, 17, 9, 15, 17, 7]
personref_editor_ref_notes=[2, 7]
place_editor_altnames=[11, 21]
place_editor_citations=[2, 16, 17, 9, 15, 17, 7]
place_editor_internet=[2, 9, 11]
place_editor_notes=[2, 20]
place_editor_placerefs=[7, 21, 9]
place_editor_references=[9, 11]
placeref_editor_altnames=[15, 21]
placeref_editor_citations=[2, 18, 17, 9, 15, 17, 7]
placeref_editor_internet=[2, 9, 8]
placeref_editor_notes=[2, 9]
placeref_editor_placerefs=[17, 21, 9]
placeref_editor_references=[9, 18]
reporef_editor_ref_notes=[2, 6]
reporef_editor_shared_address=[2, 2, 13, 19, 9, 9, 9, 7, 7]
reporef_editor_shared_internet=[2, 9, 17]
reporef_editor_shared_notes=[2, 13]
reporef_editor_shared_references=[9, 9]
repository_editor_addresses=[2, 2, 13, 19, 9, 9, 9, 7, 7]
repository_editor_internet=[2, 9, 17]
repository_editor_notes=[2, 9]
repository_editor_references=[9, 7]
source_editor_attributes=[2, 17]
source_editor_notes=[2, 9]
source_editor_references=[9, 7]
source_editor_repositories=[2, 7, 17, 11]
```