### PR TITLE
Check for Windows executables in addon requirements

### DIFF
--- a/gramps/gen/utils/requirements.py
+++ b/gramps/gen/utils/requirements.py
@@ -86,7 +86,7 @@ class Requirements:
         """
         if executable in self.exe_list:
             return True
-        if search_for(executable):
+        if search_for(executable) or search_for(executable + ".exe"):
             self.exe_list.append(executable)
             return True
         else:


### PR DESCRIPTION
When checking addon requirements we also need to look for Windows executables with the .exe extension.

Fixes [#12954](https://gramps-project.org/bugs/view.php?id=12954).