### PR TITLE
 Changed layout of places and dates in familylines plugin 

### DIFF
--- a/gramps/plugins/graph/gvfamilylines.py
+++ b/gramps/plugins/graph/gvfamilylines.py
@@ -68,6 +68,8 @@ from gramps.gen.plug.menu import (
     SurnameColorOption,
 )
 from gramps.gen.utils.db import get_birth_or_fallback, get_death_or_fallback
+from gramps.gen.config import config
+from gramps.gen.utils.symbols import Symbols
 from gramps.gen.proxy import CacheProxyDb
 from gramps.gen.errors import ReportError
 from gramps.gen.display.place import displayer as _pd
@@ -854,6 +856,12 @@ class FamilyLinesReport(Report):
         if self._incimages:
             use_html_output = True
 
+        # get birth and death symbols
+        symbols = Symbols()
+        death_idx = config.get("utf8.death-symbol")
+        death_symbol = symbols.get_death_symbol_for_char(death_idx)
+        birth_symbol = symbols.get_symbol_for_string(symbols.SYMBOL_BIRTH)
+
         # loop through all the people we need to output
         for handle in sorted(self._people):  # enable a diff
             person = self._db.get_person_from_handle(handle)
@@ -953,22 +961,20 @@ class FamilyLinesReport(Report):
             elif self.includeid == 2:  # own line
                 label += "%s(%s)" % (line_delimiter, p_id)
 
-            if birth_str or death_str:
-                label += "%s(" % line_delimiter
+            if birth_str or birthplace:
+                label += "%s%s " % (line_delimiter, birth_symbol)
                 if birth_str:
                     label += "%s" % birth_str
-                label += " – "
-                if death_str:
-                    label += "%s" % death_str
-                label += ")"
-            if birthplace or deathplace:
-                if birthplace == deathplace:
-                    deathplace = None  # no need to print the same name twice
-                label += "%s" % line_delimiter
+                if birth_str and birthplace:
+                    label += " - "
                 if birthplace:
                     label += "%s" % birthplace
-                if birthplace and deathplace:
-                    label += " / "
+            if death_str or deathplace:
+                label += "%s%s " % (line_delimiter, death_symbol)
+                if death_str:
+                    label += "%s" % death_str
+                if death_str and deathplace:
+                    label += " - "
                 if deathplace:
                     label += "%s" % deathplace
 


### PR DESCRIPTION
[#10699](https://gramps-project.org/bugs/view.php?id=10699); [#7788](https://gramps-project.org/bugs/view.php?id=7788l)
In the current layout of the familylines plugin, there is no possibility to differ between birthplace and deathplace when there is only one defined. This changes the layout to looks much sleeker and helps to differ between the place types.