### PR TITLE
Fixes #11744, #12626, #12629, #12963 delete surname

### DIFF
--- a/gramps/gui/editors/displaytabs/surnametab.py
+++ b/gramps/gui/editors/displaytabs/surnametab.py
@@ -248,8 +248,11 @@ class SurnameTab(EmbeddedList):
         """
         Delete button is clicked. Remove from the model
         """
-        (model, node) = self.selection.get_selected()
+        (_model, node) = self.selection.get_selected()
         if node:
+            path = self.model.get_path(node).to_string()
+            if path == self.curr_path:
+                self.curr_path = None
             self.model.remove(node)
             self.update()
 
@@ -260,6 +263,7 @@ class SurnameTab(EmbeddedList):
         self.curr_col = colnr
         self.curr_cellr = cellr
         self.curr_celle = celle
+        self.curr_path = path
 
     def on_edit_start_cmb(self, cellr, celle, path, colnr):
         """
@@ -291,6 +295,8 @@ class SurnameTab(EmbeddedList):
         Edit is happening. The model is updated and the surname objects updated.
         colnr must be the column in the model.
         """
+        if self.curr_path == None:
+            return
         node = self.model.get_iter(path)
         text = new_text.translate(INVISIBLE).strip()
         self.model.set_value(node, colnr, text)


### PR DESCRIPTION
These bugs occur when deleting one of multiple surnames under specific movements of users cursor and order of actions.
See [~0063983](https://gramps-project.org/bugs/view.php?id=12629#c63983) for a good description of at least one way to get this bug.

What is happening is that the cell renderer thinks it is in the middle of an edit operation, when the delete for that row of cells comes long.  The row disappears, and then the cell gets a signal to end editing and store results in the row that no longer exists.
Most of the time the user will cause a focus out signal that causes the edit to end before he tries to delete the row and everything works.

To fix I store the 'path' for the row when a cell edit starts, and then, on delete, check if  the path matches the row under edit.  If so, I invalidate the stored path.  When the end edit signal comes along, I check that the path is still valid before attempting to update the model, if it is not, we skip it as the row is gone anyway.