### PR TITLE
Fixes #12970, Multiple Surname tab doesn't save column settings

### DIFF
--- a/gramps/gui/editors/displaytabs/surnametab.py
+++ b/gramps/gui/editors/displaytabs/surnametab.py
@@ -91,12 +91,14 @@ class SurnameTab(EmbeddedList):
         name,
         on_change=None,
         top_label="<b>%s</b>" % _("Multiple Surnames"),
+        surname_override = None
     ):
         self.obj = name
         self.on_change = on_change
         self.curr_col = -1
         self.curr_cellr = None
         self.curr_celle = None
+        self.surname_override = surname_override
 
         EmbeddedList.__init__(
             self,
@@ -433,4 +435,6 @@ class SurnameTab(EmbeddedList):
         return True
 
     def get_config_name(self):
+        if self.surname_override:
+            return self.surname_override
         return __name__

--- a/gramps/gui/editors/editperson.py
+++ b/gramps/gui/editors/editperson.py
@@ -479,6 +479,7 @@ class EditPerson(EditPrimary):
             self.track,
             self.obj.get_primary_name(),
             on_change=self._changed_name,
+            surname_override = "pers_surnnametab"
         )
 
     def get_start_date(self):


### PR DESCRIPTION
Fixes [#12970](https://gramps-project.org/bugs/view.php?id=12970)  Multiple Surname tab doesn't save its column settings.

The problem appears to be that when editing a person there are actually two SurnameTab instances active at the same time. One is started by the EditPerson, and a second is started by EditName. Attempting to change the EditName surname columns works as long as the enclosing EditPerson dialog doesn't close. If you close the EditPerson, its copy of SurnameTab overrides the config settings for the EditName instance.

Fixed by providing a different name for the EditPerson version of the SurnameTab, so the config settings of the two instances don't collide.

Note, a better fix might be to save the config settings as the user adjusts them, and not when the PersistentTreeView closes.  This would mean that in this particular case both SurnameTab instances would end up with the same settings.  It would also work if a user had multiple dialogs of the same type open (like EditPerson) and made changes in one dialog only to lose them when the second closed.  But it would be a lot harder and more pervasive to code up.