### PR TITLE
Clean up some Gdk deprecations

### DIFF
--- a/gramps/gen/utils/image.py
+++ b/gramps/gen/utils/image.py
@@ -150,10 +150,12 @@ def image_dpi(source):
     try:
         from gi.repository import Gdk
 
-        s = Gdk.Display.get_default().get_default_screen()
+        mon = Gdk.Display.get_default().get_primary_monitor()
+        mon_geom = mon.get_geometry()
+        scale = mon.get_scale_factor() * MM_PER_INCH
         dpi = (
-            s.get_width() * MM_PER_INCH / s.get_width_mm(),
-            s.get_height() * MM_PER_INCH / s.get_height_mm(),
+            mon_geom.width * scale / mon.get_width_mm(),
+            mon_geom.height * scale / mon.get_height_mm(),
         )
     except:
         dpi = (96.0, 96.0)  # LibOO 3.6 assumes this if image contains no DPI info

--- a/gramps/gui/displaystate.py
+++ b/gramps/gui/displaystate.py
@@ -70,6 +70,7 @@ from gramps.gen.errors import HandleError
 from .widgets.progressdialog import ProgressMonitor, GtkProgressDialog
 from .dialog import ErrorDialog, WarningDialog
 from .uimanager import ActionGroup
+from .utils import get_display_size
 from ..version import VERSION_QUALIFIER, DEV_VERSION
 from gramps.gen.const import VERSION
 
@@ -550,13 +551,15 @@ class DisplayState(Callback):
         """
         Return the width of the current screen.
         """
-        return self.window.get_screen().get_width()
+        width, _height = get_display_size(self.window)
+        return width
 
     def screen_height(self):
         """
         Return the height of the current screen.
         """
-        return self.window.get_screen().get_height()
+        _width, height = get_display_size(self.window)
+        return height
 
     def clear_history(self):
         """

--- a/gramps/gui/logger/_errorview.py
+++ b/gramps/gui/logger/_errorview.py
@@ -36,6 +36,7 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
 from ._errorreportassistant import ErrorReportAssistant
 from ..display import display_help
+from ..utils import get_display_size
 from ..managedwindow import ManagedWindow
 
 # -------------------------------------------------------------------------
@@ -124,9 +125,7 @@ class ErrorView(ManagedWindow):
             if win.is_toplevel() and win.is_visible():
                 self.parent_window = win  # for ManagedWindow
         if self.parent_window is None:  # but it is on some screen
-            self.parent_window = self.top.get_screen()
-            self.p_width = self.top.get_screen().get_width()
-            self.p_height = self.top.get_screen().get_height()
+            self.p_width, self.p_height = get_display_size(self.top)
             self.top.set_position(Gtk.WindowPosition.CENTER)
             self.top.set_urgency_hint(True)
             self.top.set_keep_above(True)

--- a/gramps/gui/managedwindow.py
+++ b/gramps/gui/managedwindow.py
@@ -58,6 +58,7 @@ from gramps.gen.errors import WindowActiveError
 from gramps.gen.config import config
 from gramps.gen.constfunc import is_quartz
 from .uimanager import ActionGroup, valid_action_name
+from .utils import get_display_size
 from .glade import Glade
 
 # -------------------------------------------------------------------------
@@ -645,9 +646,7 @@ class ManagedWindow:
             vert_position = config.get(self.vert_position_key)
             # make sure some of left side shows on screen
             # for part time multi monitor setups
-            screen = Gtk.Window().get_screen()
-            s_width = screen.get_width()
-            s_height = screen.get_height()
+            s_width, s_height = get_display_size(self.window)
             if horiz_position > s_width - 50 or vert_position > s_height - 50:
                 (p_width, p_height) = self.parent_window.get_size()
                 (p_horiz, p_vert) = self.parent_window.get_position()

--- a/gramps/gui/utils.py
+++ b/gramps/gui/utils.py
@@ -719,6 +719,40 @@ def get_link_color(context):
     return rgb_to_hex((col.red, col.green, col.blue))
 
 
+def get_display_size(widget):
+    """
+    Get current display size for the ``Gdk.Display`` which has a top level window
+    associated with this widget. This function can only be called after the
+    widget has been added to a widget hierarchy with a ``Gtk.Window`` at the top.
+    Replaces ``screen.get_width()`` and ``screen.get_height()``.
+
+    :param widget: A Gtk widget
+    :type widget: ``Gtk.Widget``
+
+    :return: width, height
+    :rtype: tuple (int, int)
+
+    .. rubric:: Example::
+
+        widget = Gtk.Window()
+        width, height = get_display_size(display)
+    """
+    try:
+        display = widget.get_display()
+    except:
+        display = Gdk.Display.get_default()
+    mon_geoms = [
+        display.get_monitor(i).get_geometry() for i in range(display.get_n_monitors())
+    ]
+
+    x0 = min(rect.x for rect in mon_geoms)
+    y0 = min(rect.y for rect in mon_geoms)
+    x1 = max(rect.x + rect.width for rect in mon_geoms)
+    y1 = max(rect.y + rect.height for rect in mon_geoms)
+
+    return x1 - x0, y1 - y0
+
+
 def edit_object(dbstate, uistate, reftype, ref):
     """
     Invokes the appropriate editor for an object type and given handle.
@@ -889,7 +923,7 @@ def match_primary_mask(test_mask, addl_mask=0):
     GdkModifierIntent.PRIMARY_ACCELERATOR and addl_mask, False
     otherwise.
     """
-    keymap = Gdk.Keymap.get_default()
+    keymap = Gdk.Keymap.get_for_display(Gdk.Display.get_default())
     primary = keymap.get_modifier_mask(Gdk.ModifierIntent.PRIMARY_ACCELERATOR)
     return (test_mask & (primary | addl_mask)) == (primary | addl_mask)
 
@@ -900,6 +934,6 @@ def no_match_primary_mask(test_mask, addl_mask=0):
     GdkModifierIntent.PRIMARY_ACCELERATOR or addl_mask, True
     otherwise.
     """
-    keymap = Gdk.Keymap.get_default()
+    keymap = Gdk.Keymap.get_for_display(Gdk.Display.get_default())
     primary = keymap.get_modifier_mask(Gdk.ModifierIntent.PRIMARY_ACCELERATOR)
     return (test_mask & (primary | addl_mask)) == 0

--- a/gramps/gui/widgets/interactivesearchbox.py
+++ b/gramps/gui/widgets/interactivesearchbox.py
@@ -44,7 +44,7 @@ from gi.repository import Gtk, Gdk, GLib
 # Gramps modules
 #
 # -------------------------------------------------------------------------
-from ..utils import match_primary_mask
+from ..utils import match_primary_mask, get_display_size
 
 # -------------------------------------------------------------------------
 #
@@ -91,8 +91,8 @@ class InteractiveSearchBox:
         popup_menu_id = self._search_entry.connect("popup-menu", lambda x: True)
 
         # Move the entry off screen
-        screen = self._treeview.get_screen()
-        self._search_window.move(screen.get_width() + 1, screen.get_height() + 1)
+        width, height = get_display_size(self._treeview)
+        self._search_window.move(width + 1, height + 1)
         self._search_window.show()
 
         # Send the event to the window.  If the preedit_changed signal is
@@ -135,17 +135,14 @@ class InteractiveSearchBox:
 
     def ensure_interactive_directory(self):
         toplevel = self._treeview.get_toplevel()
-        screen = self._treeview.get_screen()
         if self._search_window:
             if toplevel.has_group():
                 toplevel.get_group().add_window(self._search_window)
             elif self._search_window.has_group():
                 self._search_window.get_group().remove_window(self._search_window)
-            self._search_window.set_screen(screen)
             return
 
         self._search_window = Gtk.Window(type=Gtk.WindowType.POPUP)
-        self._search_window.set_screen(screen)
         if toplevel.has_group():
             toplevel.get_group().add_window(self._search_window)
         self._search_window.set_type_hint(Gdk.WindowTypeHint.UTILITY)
@@ -420,10 +417,7 @@ class InteractiveSearchBox:
 
     def _position_func(self, userdata=None):
         tree_window = self._treeview.get_window()
-        screen = self._treeview.get_screen()
-
-        monitor_num = screen.get_monitor_at_window(tree_window)
-        monitor = screen.get_monitor_workarea(monitor_num)
+        s_width, s_height = get_display_size(tree_window)
 
         self._search_window.realize()
         ret, tree_x, tree_y = tree_window.get_origin()
@@ -431,15 +425,15 @@ class InteractiveSearchBox:
         tree_height = tree_window.get_height()
         _, requisition = self._search_window.get_preferred_size()
 
-        if tree_x + tree_width > screen.get_width():
-            x = screen.get_width() - requisition.width
+        if tree_x + tree_width > s_width:
+            x = s_width - requisition.width
         elif tree_x + tree_width - requisition.width < 0:
             x = 0
         else:
             x = tree_x + tree_width - requisition.width
 
-        if tree_y + tree_height + requisition.height > screen.get_height():
-            y = screen.get_height() - requisition.height
+        if tree_y + tree_height + requisition.height > s_height:
+            y = s_height - requisition.height
         elif tree_y + tree_height < 0:  # isn't really possible ...
             y = 0
         else:

--- a/gramps/gui/widgets/undoableentry.py
+++ b/gramps/gui/widgets/undoableentry.py
@@ -131,7 +131,7 @@ class UndoableEntry(Gtk.Entry, Gtk.Editable):
         Handle formatting undo/redo key press.
 
         """
-        keymap = Gdk.Keymap.get_default()
+        keymap = Gdk.Keymap.get_for_display(Gdk.Display.get_default())
         primary = keymap.get_modifier_mask(Gdk.ModifierIntent.PRIMARY_ACCELERATOR)
         if (
             (Gdk.keyval_name(event.keyval) == "Z")


### PR DESCRIPTION
In particular: Gdk.Screen.get_width() and height deprecated as of 3.22 (new code works as of 3.22)
Gdk.Keymap.get_default() deprecated as of 3.22 (new code works as of 2.2)

Should be OK since we now have Gtk 3.24 as minimum version.
