### PR TITLE
Fix crash when printing notes during endnote creation

### DIFF
--- a/gramps/gen/plug/report/endnotes.py
+++ b/gramps/gen/plug/report/endnotes.py
@@ -169,16 +169,17 @@ def write_endnotes(
         cindex += 1
 
         doc.start_paragraph("Endnotes-Source", "%d." % cindex)
-        doc.write_text(citation[0], links=links)
+        source, text = citation[0]
+        doc.write_text(text, links=links)
         doc.end_paragraph()
 
         if printnotes:
             _print_notes(source, database, doc, "Endnotes-Source-Notes", links)
 
-        for key, ref in citation[1]:
+        for ref, key, text in citation[1]:
             # Translators: needed for French, ignore otherwise
             doc.start_paragraph("Endnotes-Ref", trans_text("%s:") % key)
-            doc.write_text(ref, links=links)
+            doc.write_text(key, links=links)
             doc.end_paragraph()
 
             if printnotes:

--- a/gramps/plugins/cite/default.py
+++ b/gramps/plugins/cite/default.py
@@ -63,10 +63,10 @@ class Formatter:
 
             refs = []
             for key, ref in citation.get_ref_list():
-                ref = _format_ref_text(ref, key, elocale)
-                refs.append([key, ref])
+                text = _format_ref_text(ref, key, elocale)
+                refs.append([ref, key, text])
 
-            result.append([src, refs])
+            result.append([[source, src], refs])
 
         return result
 


### PR DESCRIPTION
Fixes [#12983](https://gramps-project.org/bugs/view.php?id=12983).