### PR TITLE
No longer state that Gramps will close in the backup message

### DIFF
--- a/gramps/gui/viewmanager.py
+++ b/gramps/gui/viewmanager.py
@@ -1283,10 +1283,7 @@ class ViewManager(CLIManager):
             and self.dbstate.db.has_changed > self.prev_has_changed
         ):
             self.prev_has_changed = self.dbstate.db.has_changed
-            message = _(
-                "Please wait for backup in progress.\n"
-                "Gramps will close when complete."
-            )
+            message = _("Please wait for backup to complete.")
             message = '<span size="larger" weight="bold">%s</span>' % message
             pgr_title = _("Autobackup...")
             popup = Popup(pgr_title, message, parent=self.window)
@@ -1904,10 +1901,7 @@ class QuickBackup(ManagedWindow):  # TODO move this class into its own module
             position = self.window.get_position()  # crock
             window.hide()
             self.window.move(position[0], position[1])
-            message = _(
-                "Please wait for backup in progress.\n"
-                "Gramps will close when complete."
-            )
+            message = _("Please wait for backup to complete.")
             message = '<span size="larger" weight="bold">%s</span>' % message
             pgr_title = _("Making backup...")
             popup = Popup(pgr_title, message, parent=self.window)


### PR DESCRIPTION
An autobackup could be a periodic backup rather than a backup on exit.

Fixes [#12984](https://gramps-project.org/bugs/view.php?id=12984).