### PR TITLE
Fix addon prerequisites install

### DIFF
--- a/gramps/gen/const.py
+++ b/gramps/gen/const.py
@@ -157,6 +157,10 @@ USER_DIRLIST = (
     USER_CSS,
 )
 
+LIB_PATH = os.path.join(USER_PLUGINS, "lib")
+if LIB_PATH not in sys.path:
+    sys.path.append(LIB_PATH)
+
 
 # -------------------------------------------------------------------------
 #


### PR DESCRIPTION
This fixes up the addons prerequisites install, reverting to the earlier idea of using pip.  It is based on Nick's code for putting the installed modules into the user space.