### PR TITLE
Fix report dialog error when no active person selected

### DIFF
--- a/gramps/gui/plug/_dialogs.py
+++ b/gramps/gui/plug/_dialogs.py
@@ -260,11 +260,10 @@ class PluginDialog(ManagedWindow):
             return
 
         if pdata.ptype == REPORT:
-            active_handle = self.uistate.get_active("Person")
             report(
                 self.state,
                 self.uistate,
-                self.state.db.get_person_from_handle(active_handle),
+                self.uistate.get_active("Person"),
                 getattr(mod, pdata.reportclass),
                 getattr(mod, pdata.optionclass),
                 pdata.name,


### PR DESCRIPTION
Running a report from the reports dialog with no active person selected caused an error.

Fixes [#13020](https://gramps-project.org/bugs/view.php?id=13020).