### PR TITLE
Fix translated tip of the day entries with quote characters

### DIFF
--- a/gramps/gui/tipofday.py
+++ b/gramps/gui/tipofday.py
@@ -104,7 +104,6 @@ class TipOfDay(ManagedWindow):
         # Must be first
         text = text.replace(" > ", " &gt; ")
         # Replace standalone > char
-        text = text.replace('"', "&quot;")  # quotes
         return text
 
     def next_tip_cb(self, dummy=None):


### PR DESCRIPTION
When extracting strings from the `tips.xml` file, xgettext removes the escape sequence for the quote character (&quot;) so we don't need to add it back  before we obtain the translated string.

Fixes [#12325](https://gramps-project.org/bugs/view.php?id=12325).