### PR TITLE
Update welcomegramplet.py - add margin

### DIFF
--- a/gramps/plugins/gramplet/welcomegramplet.py
+++ b/gramps/plugins/gramplet/welcomegramplet.py
@@ -102,6 +102,8 @@ class WelcomeGramplet(Gramplet):
         self.texteditor = StyledTextEditor()
         self.texteditor.set_editable(False)
         self.texteditor.set_wrap_mode(Gtk.WrapMode.WORD)
+        self.texteditor.set_left_margin(6)
+        self.texteditor.set_right_margin(6)
         scrolledwindow.add(self.texteditor)
 
         self.display_text()


### PR DESCRIPTION
add some white space between the left/right text box borders and the text glyphs

see
https://gramps.discourse.group/t/what-can-i-do-to-help-fix-unpadded-text-gramplets/2293/2