### PR TITLE
Improve AIO build script to run without modifications

### DIFF
--- a/aio/build.sh
+++ b/aio/build.sh
@@ -1,10 +1,14 @@
+#!/usr/bin/env bash
+#
+# Assumption: script is executed from the 'aio' directory
+#
 # install prerequisites
 ## prerequisites in msys packages
 pacman -S --needed --noconfirm mingw-w64-x86_64-python mingw-w64-x86_64-python-pip mingw-w64-x86_64-gexiv2 mingw-w64-x86_64-ghostscript mingw-w64-x86_64-python-cairo mingw-w64-x86_64-python-gobject mingw-w64-x86_64-python-icu mingw-w64-x86_64-iso-codes mingw-w64-x86_64-hunspell mingw-w64-x86_64-enchant perl-XML-Parser intltool mingw-w64-x86_64-python-lxml mingw-w64-x86_64-python-jsonschema mingw-w64-x86_64-gspell mingw-w64-x86_64-geocode-glib mingw-w64-x86_64-python-pillow git mingw-w64-x86_64-graphviz mingw-w64-x86_64-goocanvas mingw-w64-x86_64-osm-gps-map base-devel subversion mingw-w64-x86_64-python-graphviz mingw-w64-x86_64-osm-gps-map mingw-w64-x86_64-nsis mingw-w64-x86_64-python-cx-freeze  mingw-w64-x86_64-python-requests mingw-w64-x86_64-adwaita-icon-theme mingw-w64-x86_64-python-networkx mingw-w64-x86_64-python-psycopg2 upx mingw-w64-x86_64-python-packaging unzip mingw-w64-x86_64-python-nose mingw-w64-x86_64-python-wheel
 pacman -S --needed --noconfirm mingw-w64-x86_64-toolchain
 
-wget https://github.com/bpisoj/MINGW-packages/releases/download/v5.0/mingw-w64-x86_64-db-6.0.30-1-any.pkg.tar.xz
-pacman -U --noconfirm mingw-w64-x86_64-db-6.0.30-1-any.pkg.tar.xz
+wget -N https://github.com/bpisoj/MINGW-packages/releases/download/v5.0/mingw-w64-x86_64-db-6.0.30-1-any.pkg.tar.xz
+pacman -U --needed --noconfirm mingw-w64-x86_64-db-6.0.30-1-any.pkg.tar.xz
 
 pacman -S --needed --noconfirm  mingw-w64-x86_64-python-bsddb3
 
@@ -13,8 +17,8 @@ python -m pip install --upgrade pip
 pip install --upgrade pydot pydotplus requests asyncio pygraphviz
 
 ## download dictionaries
-mkdir /mingw64/share/enchant/hunspell
-cd /mingw64/share/enchant/hunspell
+mkdir -p /mingw64/share/enchant/hunspell
+pushd /mingw64/share/enchant/hunspell
 rootdir=https://raw.githubusercontent.com/wooorm/dictionaries/main/dictionaries/
 dicts=(
     bg:bg_BG
@@ -58,14 +62,17 @@ for dict in "${dicts[@]}"; do
     wget ${rootdir}${dir}/index.dic
     mv index.dic ${lang}.dic
 done
+popd
 
-mkdir /mingw64/share/enchant/voikko
-cd /mingw64/share/enchant/voikko
-wget https://www.puimula.org/htp/testing/voikko-snapshot-v5/dict.zip
-unzip dict.zip
+mkdir -p /mingw64/share/enchant/voikko
+pushd /mingw64/share/enchant/voikko
+wget -N https://www.puimula.org/htp/testing/voikko-snapshot-v5/dict.zip
+unzip -o dict.zip
 rm dict.zip
+popd
 
-cd D:/a/gramps/gramps/aio
+# Assumption: script is executed from the 'aio' directory!
+#cd D:/a/gramps/gramps/aio
 
 ## create a directory structure for icons
 mkdir /mingw64/share/icons/gnome
@@ -75,6 +82,7 @@ mkdir /mingw64/share/icons/gnome/scalable
 mkdir /mingw64/share/icons/gnome/scalable/mimetypes
 mkdir /mingw64/share/icons/gnome/scalable/places
 
+# Change to the gramps root directory
 cd ..
 cp images/gramps.png /mingw64/share/icons
 cd images/hicolor/48x48/mimetypes
@@ -107,3 +115,4 @@ cd mingw64/src
 makensis grampsaio64.nsi
 # result is in mingw64/src
 
+exit 0


### PR DESCRIPTION
When used locally, the build script required modification before first use to set the full path to the local aio directory. With this change, by invoking the script from the aio directory, that local modification is no longer necessary. Internally the script uses pushd/popd to return to the aio directory.

Second change is to use the `-N` option in wget to avoid downloading a file if the timestamp hasn't changed on the server. This should reduce build time on second and subsequent builds if the source package hasn't changed. It also resolves a lurking error where an updated file on the server would not be used because wget appends a counter to the file names whereas the script was always extracting based on the original filename.

Third change is to avoid the script from asking for interactive input on second and subsequent runs when attempting to unzip dict.zip by passing the `-o` to unzip to allow overwrites.