### PR TITLE
Add a new name displayer to provide brief given names

### DIFF
--- a/gramps/gen/display/name.py
+++ b/gramps/gen/display/name.py
@@ -30,6 +30,7 @@ Specific symbols for parts of a name are defined:
     ======  ===============================================================
     't'     title
     'f'     given (first names)
+    'b'     brief given name (first name plus initials)
     'l'     full surname (lastname)
     'c'     callname
     'x'     nick name, call, or otherwise first first name (common name)
@@ -628,6 +629,7 @@ class NameDisplay:
         Specific symbols for parts of a name are defined (keywords given):
         't' : title = title
         'f' : given = given (first names)
+        'b' : brief = given name (first name plus initials)
         'l' : surname = full surname (lastname)
         'c' : call = callname
         'x' : common = nick name, call, otherwise first first name (common name)
@@ -657,6 +659,11 @@ class NameDisplay:
         d = {
             "t": ("raw_data[_TITLE]", "title", _("title", "Person")),
             "f": ("raw_data[_FIRSTNAME]", "given", _("given")),
+            "b": ("raw_data[_FIRSTNAME].split(' ')[0] + ' ' + " +
+                "''.join([word[0] +'.' for word in ('. ' +" +
+                " raw_data[_FIRSTNAME]).split()][2:])",
+                "brief",
+                _("brief")),
             "l": (
                 "_raw_full_surname(raw_data[_SURNAME_LIST])",
                 "surname",
@@ -760,6 +767,7 @@ class NameDisplay:
         Specific symbols for parts of a name are defined (keywords given):
         't' : title = title
         'f' : given = given (first names)
+        'b' : brief = given name (first name plus initials)
         'l' : surname = full surname (lastname)
         'c' : call = callname
         'x' : common = nick name, call, or otherwise first first name (common name)
@@ -788,6 +796,10 @@ class NameDisplay:
         d = {
             "t": ("title", "title", _("title", "Person")),
             "f": ("first", "given", _("given")),
+            "b": ("first.split(' ')[0] + ' ' + ''.join([word[0] +'.' " +
+                "for word in ('. ' + first).split()][2:])",
+                "brief",
+                _("brief")),
             "l": ("_raw_full_surname(raw_surname_list)", "surname", _("surname")),
             "s": ("suffix", "suffix", _("suffix")),
             "c": ("call", "call", _("call", "Name")),
@@ -900,6 +912,7 @@ class NameDisplay:
         The following substitutions are made:
         '%t' : title
         '%f' : given (first names)
+        '%b' : brief given name (first name plus initials)
         '%l' : full surname (lastname)
         '%c' : callname
         '%x' : nick name, call, or otherwise first first name (common name)

--- a/gramps/gen/display/name.py
+++ b/gramps/gen/display/name.py
@@ -360,6 +360,21 @@ def _raw_single_surname(raw_surn_data_list):
     return " ".join(result.split()).strip()
 
 
+def _raw_brief_given(firstname, call):
+    """method for the 'b' symbol: brief given names
+    The first given name is presented in full with the rest initialed.
+    If provided the call name is presented in full instead of the first given name
+    """
+    given_names = firstname.split(" ")
+    full_name = call or given_names[0]
+    try:
+        new_name = [n[0] + "." if n != full_name else full_name for n in given_names]
+    except IndexError:
+        new_name = ""
+
+    return " ".join(new_name)
+
+
 def cleanup_name(namestring):
     """Remove too long white space due to missing name parts,
     so "a   b" becomes "a b" and "a , b" becomes "a, b"
@@ -654,16 +669,16 @@ class NameDisplay:
         """
 
         # we need the names of each of the variables or methods that are
-        # called to fill in each format flag.
+        # cailed to fill in each format flag.
         # Dictionary is "code": ("expression", "keyword", "i18n-keyword")
         d = {
             "t": ("raw_data[_TITLE]", "title", _("title", "Person")),
             "f": ("raw_data[_FIRSTNAME]", "given", _("given")),
-            "b": ("raw_data[_FIRSTNAME].split(' ')[0] + ' ' + " +
-                "''.join([word[0] +'.' for word in ('. ' +" +
-                " raw_data[_FIRSTNAME]).split()][2:])",
+            "b": (
+                "_raw_brief_given(raw_data[_FIRSTNAME], raw_data[_CALL])",
                 "brief",
-                _("brief")),
+                _("brief"),
+            ),
             "l": (
                 "_raw_full_surname(raw_data[_SURNAME_LIST])",
                 "surname",
@@ -796,10 +811,11 @@ class NameDisplay:
         d = {
             "t": ("title", "title", _("title", "Person")),
             "f": ("first", "given", _("given")),
-            "b": ("first.split(' ')[0] + ' ' + ''.join([word[0] +'.' " +
-                "for word in ('. ' + first).split()][2:])",
+            "b": (
+                "_raw_brief_given(first, call)",
                 "brief",
-                _("brief")),
+                _("brief"),
+            ),
             "l": ("_raw_full_surname(raw_surname_list)", "surname", _("surname")),
             "s": ("suffix", "suffix", _("suffix")),
             "c": ("call", "call", _("call", "Name")),

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -133,7 +133,7 @@ class DisplayNameEditor(ManagedWindow):
   <b>Title</b>   - title (Dr., Mrs.)           <b>Suffix</b>   - suffix (Jr., Sr.)
   <b>Call</b>    - call name                   <b>Nickname</b> - nick name
   <b>Initials</b>- first letters of given      <b>Common</b>   - nick name, call, or first of given
-  <b>Prefix</b>  - all prefixes (von, de)
+  <b>Prefix</b>  - all prefixes (von, de)      <b>Brief</b>    - first given name and rest initialed
 Surnames:
   <b>Rest</b>      - non primary surnames    <b>Notpatronymic</b>- all surnames, except pa/matronymic &amp; primary
   <b>Familynick</b>- family nick name        <b>Rawsurnames</b>  - surnames (no prefixes and connectors)

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -133,7 +133,7 @@ class DisplayNameEditor(ManagedWindow):
   <b>Title</b>   - title (Dr., Mrs.)           <b>Suffix</b>   - suffix (Jr., Sr.)
   <b>Call</b>    - call name                   <b>Nickname</b> - nick name
   <b>Initials</b>- first letters of given      <b>Common</b>   - nick name, call, or first of given
-  <b>Prefix</b>  - all prefixes (von, de)      <b>Brief</b>    - first given name and rest initialed
+  <b>Prefix</b>  - all prefixes (von, de)      <b>Brief</b>    - call name or first given name and rest initialed
 Surnames:
   <b>Rest</b>      - non primary surnames    <b>Notpatronymic</b>- all surnames, except pa/matronymic &amp; primary
   <b>Familynick</b>- family nick name        <b>Rawsurnames</b>  - surnames (no prefixes and connectors)


### PR DESCRIPTION
Family trees and charts become rather wide when displaying families with lots of children which each have multiple given names. Gramps already has a name displayer which initials all given names and this can be used to make charts more compact, but initialing all given names makes it more difficult to identify each person.
This PR adds a new name displayer for given names which shows the first given name in full, which aids identification, and for brevity any subsequent given names are shown initialed. For example, "Mary Ann Elizabeth Smith" would have her second and third given names initialed and her name would appear as "Mary A. E. Smith".
