### PR TITLE
Fix crash when displaying settings in context menu popup

### DIFF
--- a/gramps/plugins/view/pedigreeview.py
+++ b/gramps/plugins/view/pedigreeview.py
@@ -1828,7 +1828,6 @@ class PedigreeView(NavigationView):
         menu.append(item)
 
         # Help menu entry
-        menu.append(item)
         item = Gtk.MenuItem(label=_("About Pedigree View"))
         item.connect("activate", self.on_help_clicked)
         item.show()


### PR DESCRIPTION
A separator menu item was being added twice.

Fixes [#13029](https://gramps-project.org/bugs/view.php?id=13029).