### PR TITLE
Use imagesize rather than magic

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ The following packages are **STRONGLY RECOMMENDED** to be installed:
 
   Used by Graphviz reports to help create PDF files.
 
+* **python-imagesize**
+
+ Provides better image processing performance. If this module is not available,
+ we continue to use Gdk. This provides a real improvement when we need to
+ process many big images.
+
 The following packages are optional:
 ------------------------------------
 * **gspell**
@@ -120,24 +126,6 @@ The following packages are optional:
 
  Python bindings of fontconfig are required for displaying
  genealogical symbols
-
-* **magic**
-
- Python magic bindings required to have better performances with image
- processing.
- If this module is not available, we continue to use Gdk.
- This avoid to load the image in memory. This is a real improvement
- when we have many big images.
- Used in odfdoc, rtfdoc and webreport and tested with png, gif, jpeg, bmp, tiff
- #
- #            file size     with magic  without (Gdk)   ratio
- # example 1 :     256k        0.00080        0.00575       7
- # example 2 :      21M        0.00171        0.55860     326
-
- Debian, Ubuntu, ... : python3-magic
- Fedora, Redhat, ... : python3-magic
- openSUSE            : python-magic
- ArchLinux           : python-magic
 
 Optional packages required by Third-party Addons
 ------------------------------------------------

--- a/gramps/gen/utils/image.py
+++ b/gramps/gen/utils/image.py
@@ -182,31 +182,12 @@ def image_size(source):
     from gi.repository import GLib
 
     try:
-        import re
-        import magic
+        # For performance reasons, we'll try to get image size from imagesize.
+        import imagesize
 
-        # For performance reasons, we'll try to get image size from magic.
-        # This avoid to load the image in memory. This is a real improvement
-        # when we have many big images.
-        # Used in odfdoc, rtfdoc and webreport and tested with png, gif, jpeg,
-        # bmp, tiff
-        #
-        #            file size     with magic  without (Gdk)   ratio
-        # example 1 :     256k        0.00080        0.00575       7
-        # example 2 :      21M        0.00171        0.55860     326
-        img = magic.from_file(source)
-        found = img.find("TIFF")
-        if found == 0:
-            width = re.search("width=(\d+)", img).groups()
-            height = re.search("height=(\d+)", img).groups()
-            return (int(width[0]), int(height[0]))
-        found = img.find("precision")
-        if found > 0:
-            img = img[found:]
-        size = re.search("(\d+)\s*x\s*(\d+)", img).groups()
-        return (int(size[0]), int(size[1]))
+        return imagesize.get(source)
     except (ImportError, FileNotFoundError):
-        # python-magic is not installed or the file does not exist.
+        # python-imagesize is not installed or the file does not exist.
         # So Trying to get image size with Gdk.
         try:
             img = GdkPixbuf.Pixbuf.new_from_file(source)


### PR DESCRIPTION
Using python-imagesize rather than python-magic would seem to be a better choice when finding the size of an image.