### PR TITLE
Fix sizing of shared information in the reference editors

### DIFF
--- a/gramps/gui/editors/editreference.py
+++ b/gramps/gui/editors/editreference.py
@@ -128,6 +128,17 @@ class EditReference(ManagedWindow, DbGUIElement):
 
     def define_expander(self, expander):
         expander.set_expanded(True)
+        expander.connect("activate", self.__on_expand)
+
+    def __on_expand(self, expander):
+        """
+        Sets the packing of the expander widget to depend on whether or not
+        it is expanded.
+        """
+        state = not expander.get_expanded()
+        parent = expander.get_parent()
+        parent.set_child_packing(expander, state, state, 0, Gtk.PackType.START)
+        expander.set_vexpand(state)
 
     def _post_init(self):
         """

--- a/gramps/gui/glade/editeventref.glade
+++ b/gramps/gui/glade/editeventref.glade
@@ -99,6 +99,7 @@
           <object class="GtkNotebook" id="notebook_ref">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
+            <property name="vexpand">True</property>
             <property name="border_width">6</property>
             <child>
               <object class="GtkGrid" id="table64">
@@ -207,6 +208,7 @@
               <object class="GtkNotebook" id="notebook">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="vexpand">True</property>
                 <property name="show_border">False</property>
                 <child>
                   <object class="GtkGrid" id="table62">

--- a/gramps/gui/glade/editplaceref.glade
+++ b/gramps/gui/glade/editplaceref.glade
@@ -100,6 +100,7 @@
           <object class="GtkNotebook" id="notebook_ref">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
+            <property name="vexpand">True</property>
             <property name="border_width">6</property>
             <child>
               <object class="GtkGrid" id="table64">
@@ -185,6 +186,7 @@
               <object class="GtkNotebook" id="notebook">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="vexpand">True</property>
                 <property name="show_border">False</property>
                 <child>
                   <object class="GtkGrid" id="table62">

--- a/gramps/gui/glade/editreporef.glade
+++ b/gramps/gui/glade/editreporef.glade
@@ -111,6 +111,7 @@
               <object class="GtkNotebook" id="notebook_ref">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="vexpand">True</property>
                 <property name="border_width">6</property>
                 <child>
                   <object class="GtkGrid" id="table70">


### PR DESCRIPTION
Sets the packing of the expander widget to depend on whether or not it is expanded.

Fixes [#13030](https://gramps-project.org/bugs/view.php?id=13030).