### PR TITLE
sort Confidence col in Source Citations tabs

### DIFF
--- a/gramps/gui/editors/displaytabs/citationembedlist.py
+++ b/gramps/gui/editors/displaytabs/citationembedlist.py
@@ -63,7 +63,7 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
     Derives from the EmbeddedList class.
     """
 
-    _HANDLE_COL = 9  # Column number from CitationRefModel
+    _HANDLE_COL = 10  # Column number from CitationRefModel
     _DND_TYPE = DdTargets.CITATION_LINK
     _DND_EXTRA = DdTargets.SOURCE_LINK
 
@@ -83,11 +83,12 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
         (_("Author"), 1, 200, TEXT_COL, -1, None),
         (_("Date"), 8, 180, MARKUP_COL, -1, None),
         (_("Publisher"), 3, 200, TEXT_COL, -1, None),
-        (_("Confidence Level"), 4, 120, TEXT_COL, -1, None),
+        (_("Confidence"), 9, 120, MARKUP_COL, -1, None),
         (_("Page"), 5, 100, TEXT_COL, -1, None),
         (_("ID"), 6, 80, TEXT_COL, -1, None),
         (_("Private"), 7, 30, ICON_COL, -1, "gramps-lock"),
         (_("Sorted date"), 8, 80, TEXT_COL, -1, None),
+        (_("Sorted confidence"), 9, 120, TEXT_COL, -1, None),
     ]
 
     def __init__(self, dbstate, uistate, track, data, config_key, callertitle=None):

--- a/gramps/gui/editors/displaytabs/citationrefmodel.py
+++ b/gramps/gui/editors/displaytabs/citationrefmodel.py
@@ -39,7 +39,9 @@ _ = glocale.translation.gettext
 # -------------------------------------------------------------------------
 class CitationRefModel(Gtk.ListStore):
     def __init__(self, citation_list, db):
-        Gtk.ListStore.__init__(self, str, str, str, str, str, str, str, bool, str, str)
+        Gtk.ListStore.__init__(
+            self, str, str, str, str, str, str, str, bool, str, int, str
+        )
         self.db = db
         dbgsfh = self.db.get_source_from_handle
         for handle in citation_list:
@@ -57,6 +59,7 @@ class CitationRefModel(Gtk.ListStore):
                     citation.gramps_id,
                     citation.get_privacy(),
                     self.column_sort_date(citation),
+                    self.column_sort_confidence(citation),
                     handle,
                 ]
             )
@@ -74,3 +77,7 @@ class CitationRefModel(Gtk.ListStore):
             return "%09d" % date.get_sort_value()
         else:
             return ""
+
+    def column_sort_confidence(self, citation):
+        confidence = citation.get_confidence_level()
+        return confidence


### PR DESCRIPTION
The "Confidence level" is sorted by confidence label instead of the internal value.

The "Confidence level" text is too wide and replaced by "Confidence".

Fixes [#13036](https://gramps-project.org/bugs/view.php?id=13036).