### PR TITLE
Fix display of gramplet help URLs that start with "https://"

### DIFF
--- a/gramps/gui/widgets/grampletbar.py
+++ b/gramps/gui/widgets/grampletbar.py
@@ -746,7 +746,7 @@ class DetachedWindow(ManagedWindow):
         elif response == Gtk.ResponseType.HELP:
             # translated name:
             if self.gramplet.help_url:
-                if self.gramplet.help_url.startswith("http://"):
+                if self.gramplet.help_url.startswith(("http://", "https://")):
                     display_url(self.gramplet.help_url)
                 else:
                     display_help(self.gramplet.help_url)

--- a/gramps/gui/widgets/grampletpane.py
+++ b/gramps/gui/widgets/grampletpane.py
@@ -288,7 +288,7 @@ class GrampletWindow(ManagedWindow):
         elif response == Gtk.ResponseType.HELP:
             # translated name:
             if self.gramplet.help_url:
-                if self.gramplet.help_url.startswith("http://"):
+                if self.gramplet.help_url.startswith(("http://", "https://")):
                     display_url(self.gramplet.help_url)
                 else:
                     display_help(self.gramplet.help_url)


### PR DESCRIPTION
A help_url starting with either "http://" or "https://" should be used as the full url to be displayed in the browser.

Fixes [#13039](https://gramps-project.org/bugs/view.php?id=13039).