### PR TITLE
Add URL to citation data form Ancestry ged

### DIFF
--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -2940,6 +2940,7 @@ class GedcomParser(UpdateCallback):
             TOKEN_TEXT: self.__citation_data_text,
             TOKEN_RNOTE: self.__citation_data_note,
             TOKEN_NOTE: self.__citation_data_note,
+            TOKEN_WWW: self.__citation_data_text, # Not legal GEDCOM, used by Ancestry
         }
         self.func_list.append(self.citation_data_tbl)
 


### PR DESCRIPTION
“Other sources” with url attached in Ancestry.com generate a invalid ged. Solution to handle "Tag WWW is not allowed under DATA" and save it as NoteType.SOURCE_TEXT.