### PR TITLE
New Citations not included on the Narrative Web - Re: Add citations to event references

### DIFF
--- a/gramps/gen/proxy/private.py
+++ b/gramps/gen/proxy/private.py
@@ -830,6 +830,7 @@ def sanitize_event_ref(db, event_ref):
 
     new_ref.set_reference_handle(event_ref.get_reference_handle())
     new_ref.set_role(event_ref.get_role())
+    copy_citation_ref_list(db, event_ref, new_ref)
     copy_notes(db, event_ref, new_ref)
     copy_attributes(db, event_ref, new_ref)
 

--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -896,8 +896,12 @@ class BasePage:
 
         trow2 = Html("tr")
         # get event source references
-        srcrefs = self.get_citation_links(event.get_citation_list() +
-                                          event_ref.get_citation_list()) or "&nbsp;"
+        srcrefs = (
+            self.get_citation_links(
+                event.get_citation_list() + event_ref.get_citation_list()
+            )
+            or "&nbsp;"
+        )
         trow += Html("td", srcrefs, class_="ColumnSources", rowspan=2)
 
         # get event notes
@@ -912,13 +916,18 @@ class BasePage:
         # cached original
         attrlist.extend(event_ref.get_attribute_list())
         for attr in attrlist:
-            htmllist.extend(
-                Html(
-                    "p",
-                    self._("%(str1)s: %(str2)s")
-                    % {"str1": Html("b", attr.get_type()), "str2": attr.get_value()},
-                )
+            attrrefs = self.get_citation_links(attr.get_citation_list())
+            attrdesc = self._("%(str1)s: %(str2)s") % {
+                "str1": Html("b", attr.get_type()),
+                "str2": attr.get_value(),
+            }
+            attr_row = (
+                Html("tr")
+                + Html("td", "&nbsp")
+                + Html("td", attrdesc, colspan=3)
+                + Html("td", attrrefs)
             )
+            htmllist.extend(attr_row)
 
             # also output notes attached to the attributes
             notelist = attr.get_note_list()

--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -896,7 +896,8 @@ class BasePage:
 
         trow2 = Html("tr")
         # get event source references
-        srcrefs = self.get_citation_links(event.get_citation_list()) or "&nbsp;"
+        srcrefs = self.get_citation_links(event.get_citation_list() +
+                                          event_ref.get_citation_list()) or "&nbsp;"
         trow += Html("td", srcrefs, class_="ColumnSources", rowspan=2)
 
         # get event notes

--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -723,6 +723,8 @@ class NavWebReport(Report):
 
                         for citation_handle in event.get_citation_list():
                             self._add_citation(citation_handle, Person, person_handle)
+                        for citation_handle in evt_ref.get_citation_list():
+                            self._add_citation(citation_handle, Person, person_handle)
 
             ############### Families section ##############
             # Tell the families tab to display this individuals families
@@ -750,6 +752,10 @@ class NavWebReport(Report):
                                             place_handle, Person, person_handle, event
                                         )
                                     for cite_hdl in event.get_citation_list():
+                                        self._add_citation(
+                                            cite_hdl, Person, person_handle
+                                        )
+                                    for cite_hdl in evt_ref.get_citation_list():
                                         self._add_citation(
                                             cite_hdl, Person, person_handle
                                         )

--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -725,6 +725,9 @@ class NavWebReport(Report):
                             self._add_citation(citation_handle, Person, person_handle)
                         for citation_handle in evt_ref.get_citation_list():
                             self._add_citation(citation_handle, Person, person_handle)
+                        for attr in evt_ref.get_attribute_list():
+                            for citation_handle in attr.get_citation_list():
+                                self._add_citation(citation_handle, Event, evt_ref.ref)
 
             ############### Families section ##############
             # Tell the families tab to display this individuals families


### PR DESCRIPTION
Fixes [#13046](https://gramps-project.org/bugs/view.php?id=13046).

This PR contains a fix for an old CacheProxyDb bug
The event ref attributes have no citations. I added them.