### PR TITLE
Fix context menu in all family events quick view screen

### DIFF
--- a/gramps/plugins/quickview/all_events.py
+++ b/gramps/plugins/quickview/all_events.py
@@ -81,7 +81,7 @@ def run_fam(database, document, family):
     stab = QuickTable(sdb)
 
     # get the family events
-    event_list = [(_("Family"), x) for x in sdb.events(family)]
+    event_list = [(family, x) for x in sdb.events(family)]
 
     # get the events of father and mother
     # fathername = sdb.first_name(sdb.father(family))


### PR DESCRIPTION
Fixes [#12759](https://gramps-project.org/bugs/view.php?id=12759).

Replaces the string "family" with the actually family object, allowing Quick view menu to display functional "see the family details" option instead of previous non-functional "see see details details" option.  This also displays the name of the couple instead of just the word "family", while also allowing drag and drop to the clipboard. 