### PR TITLE
Update openstreetmap.py

### DIFF
--- a/gramps/plugins/mapservices/openstreetmap.py
+++ b/gramps/plugins/mapservices/openstreetmap.py
@@ -62,6 +62,7 @@ class OpensStreetMapService(MapService):
             return
 
         titledescr = place_displayer.display(self.database, place)
+        titledescr = titledescr.replace(".", "")
         self.url = "http://nominatim.openstreetmap.org/" "search?q=%s" % "+".join(
             titledescr.split()
         )


### PR DESCRIPTION
OpenStreetMap's Nomiatim does not like abbreviations in place like "U.S.A." or "p.E.I."; Prince Edward Island.

The added line strips periods "." from the place name before sending it out to the URL

Bug report https://gramps-project.org/bugs/view.php?id=13085