### PR TITLE
Fixed empty ADDR in Gedcom export

### DIFF
--- a/data/tests/exp_sample_ged.ged
+++ b/data/tests/exp_sample_ged.ged
@@ -75,8 +75,6 @@
 2 TYPE Christening of Amber Marie Smith
 2 DATE 26 APR 1998
 2 PLAC Community Presbyterian Church, Danville, CA
-2 ADDR
-3 ADR2 Community Presbyterian Church, Danville, CA
 1 FAMC @F0013@
 2 PEDI birth
 1 CHAN
@@ -131,8 +129,6 @@
 2 TYPE Christening of Mason Michael Smith
 2 DATE 10 JUL 1996
 2 PLAC Community Presbyterian Church, Danville, CA
-2 ADDR
-3 ADR2 Community Presbyterian Church, Danville, CA
 1 FAMC @F0013@
 2 PEDI birth
 1 CHAN
@@ -626,10 +622,6 @@
 3 MAP
 4 LATI N39.7392
 4 LONG W104.9903
-2 ADDR
-3 CITY Denver, Denver Co., CO
-3 STAE Colorado
-3 CTRY USA
 1 DEAT
 2 TYPE Death of Marjorie Ohman
 2 DATE 22 JUN 1980
@@ -648,8 +640,6 @@
 2 TYPE Birth of Darcy Horne
 2 DATE 2 JUL 1966
 2 PLAC Sacramento, Sacramento Co., CA
-2 ADDR
-3 CITY Sacramento, Sacramento Co., CA
 1 FAMS @F0010@
 1 CHAN
 2 DATE 21 DEC 2007
@@ -884,17 +874,6 @@
 1 SOUR @S0005@
 1 RESI
 2 DATE 27 OCT 2017
-2 ADDR
-3 CONT test village
-3 CONT Akron
-3 CONT OH
-3 CONT 44177
-3 CONT Cuyahoga
-3 ADR2 test village
-3 CITY Akron
-3 STAE OH
-3 POST 44177
-3 CTRY Cuyahoga
 1 CHAN
 2 DATE 29 OCT 2016
 3 TIME 16:40:40
@@ -946,10 +925,6 @@
 3 MAP
 4 LATI N39.7392
 4 LONG W104.9903
-2 ADDR
-3 CITY Denver, Denver Co., CO
-3 STAE Colorado
-3 CTRY USA
 2 PHON 440-871-3402
 2 EMAIL tomtester@@gmail.com
 2 FAX 440-321-4569
@@ -965,10 +940,6 @@
 3 MAP
 4 LATI N39.7392
 4 LONG W104.9903
-2 ADDR
-3 CITY Denver, Denver Co., CO
-3 STAE Colorado
-3 CTRY USA
 1 FAMC @F0016@
 2 PEDI birth
 1 SOUR @S0005@
@@ -1023,10 +994,6 @@
 3 MAP
 4 LATI N39.7392
 4 LONG W104.9903
-2 ADDR
-3 CITY Denver, Denver Co., CO
-3 STAE Colorado
-3 CTRY USA
 2 STAT QUALIFIED
 1 FAMC @F0016@
 2 _FREL Adopted
@@ -1278,8 +1245,6 @@
 2 DATE 22 FEB 2000
 2 TEMP DENVE
 2 PLAC Community Presbyterian Church, Danville, CA
-2 ADDR
-3 ADR2 Community Presbyterian Church, Danville, CA
 2 STAT CLEARED
 1 MARR
 2 HUSB

--- a/gramps/plugins/export/exportgedcom.py
+++ b/gramps/plugins/export/exportgedcom.py
@@ -1610,7 +1610,7 @@ class GedcomWriter(UpdateCallback):
         country = location.get(PlaceType.COUNTRY)
         postal_code = place.get_code()
 
-        if street or locality or city or state or postal_code or country:
+        if street:
             self._writeln(level, "ADDR", street)
             if street:
                 self._writeln(level + 1, "ADR1", street)
@@ -1652,14 +1652,7 @@ class GedcomWriter(UpdateCallback):
         @param addr: The location or address
         @type addr: [a super-type of] LocationBase
         """
-        if (
-            addr.get_street()
-            or addr.get_locality()
-            or addr.get_city()
-            or addr.get_state()
-            or addr.get_postal_code()
-            or addr.get_country()
-        ):
+        if addr.get_street():
             self._writeln(level, "ADDR", addr.get_street())
             if addr.get_locality():
                 self._writeln(level + 1, "CONT", addr.get_locality())
@@ -1672,8 +1665,7 @@ class GedcomWriter(UpdateCallback):
             if addr.get_country():
                 self._writeln(level + 1, "CONT", addr.get_country())
 
-            if addr.get_street():
-                self._writeln(level + 1, "ADR1", addr.get_street())
+            self._writeln(level + 1, "ADR1", addr.get_street())
             if addr.get_locality():
                 self._writeln(level + 1, "ADR2", addr.get_locality())
             if addr.get_city():


### PR DESCRIPTION
The Gedcom specs don't allow ADDR to be empty. Gramps however, does create ADDR lines, even if there is no street. I fixed that.