### PR TITLE
Report simpler Python version string in About and Error dialogs

### DIFF
--- a/gramps/gui/aboutdialog.py
+++ b/gramps/gui/aboutdialog.py
@@ -179,7 +179,7 @@ class GrampsAboutDialog(Gtk.AboutDialog):
             + distro
         ) % (
             ellipses(str(VERSION)),
-            ellipses(str(sys.version).replace("\n", "")),
+            ellipses(platform.python_version()),
             BSDDB_STR,
             ellipses(get_env_var("LANG", "")),
             ellipses(platform.system()),

--- a/gramps/gui/logger/_errorreportassistant.py
+++ b/gramps/gui/logger/_errorreportassistant.py
@@ -213,7 +213,7 @@ class ErrorReportAssistant(ManagedWindow, Gtk.Assistant):
             "cairo version  : %s"
             % (
                 str(VERSION),
-                str(sys.version).replace("\n", ""),
+                platform.python_version(),
                 BSDDB_STR,
                 sqlite,
                 get_env_var("LANG", ""),


### PR DESCRIPTION
A gramps user reported on the discourse forum ([thread](https://gramps.discourse.group/t/help-about-showing-system-details/4534)) that information in the about box was truncated, and he could not expand the box to view the rest of the text.

A look at the text in question suggested a simple change: the truncated string is intended to be the Python version which is typically major.minor.patch version, but the text being displayed is the output of sys.version() which includes additional information including build number and compiler used. For the About box this isn't necessarily useful, so this PR replaces that call with platform.python_version() which returns just the version and resolves the truncated string issue. The same change is also made in the error report dialog for consistency.

An unrelated change is also included in this PR: after building the AIO bundle locally several artifacts are generated (or downloaded) to the source folder, which have been added to .gitignore to avoid tracking with git.

Here's what the Python strings look like with the change:

![gramps52-about-box-python-ver-short](https://github.com/gramps-project/gramps/assets/1551217/1043410e-5ee0-4ae6-ab49-1a15b7dd6381)
![gramps52-errorreport-python-ver-short](https://github.com/gramps-project/gramps/assets/1551217/43913542-e67b-4838-8ea0-2f8330a326d5)

FYI @emyoulation 