### PR TITLE
Fix gramps example media source

### DIFF
--- a/example/gramps/example.gramps
+++ b/example/gramps/example.gramps
@@ -7,7 +7,7 @@
     <researcher>
       <resname>Alex Roitman,,,</resname>
     </researcher>
-    <mediapath>{GRAMPS_RESOURCES}/doc/gramps/example/gramps</mediapath>
+    <mediapath>{GRAMPS_RESOURCES}/example/gramps</mediapath>
   </header>
   <name-formats>
     <format number="-1" name="SURNAME, Given (Common)" fmt_str="SURNAME, given (common)" active="1"/>


### PR DESCRIPTION
Apparently, the media path has changed relative to {GRAMPS_RESOURCES}.