### PR TITLE
Changing -f gramps-xml to -f gramps (Issue ID 0009723)

### DIFF
--- a/data/man/en.rst
+++ b/data/man/en.rst
@@ -221,7 +221,7 @@ To explicitly specify the formats in the above example, append filenames with
 appropriate **-f** options::
 
     gramps -i file1.ged -f gedcom -i file2.tgz -f gramps-pkg \
-    -i ~/db3.gramps -f gramps-xml -i file4.wft -f wft -a check
+    -i ~/db3.gramps -f gramps -i file4.wft -f wft -a check
 
 To record the database resulting from all imports, supply a **-e** flag (use
 **-f** if the filename does not allow gramps to guess the format)::

--- a/gramps/cli/argparser.py
+++ b/gramps/cli/argparser.py
@@ -113,7 +113,7 @@ and then check the resulting database for errors, one may type:
 gramps -i file1.ged -i file2.gpkg -i ~/db3.gramps -i file4.wft -a tool -p name=check.
 
 2. To explicitly specify the formats in the above example, append filenames with appropriate -f options:
-gramps -i file1.ged -f gedcom -i file2.gpkg -f gramps-pkg -i ~/db3.gramps -f gramps-xml -i file4.wft -f wft -a tool -p name=check.
+gramps -i file1.ged -f gedcom -i file2.gpkg -f gramps-pkg -i ~/db3.gramps -f gramps -i file4.wft -f wft -a tool -p name=check.
 
 3. To record the database resulting from all imports, supply -e flag
 (use -f if the filename does not allow Gramps to guess the format):
@@ -138,7 +138,7 @@ To find out details of a particular option, use show=option_name , e.g. name=tim
 To learn about available report names, use name=show string.
 
 9. To convert a Family Tree on the fly to a .gramps xml file:
-gramps -O 'Family Tree 1' -e output.gramps -f gramps-xml
+gramps -O 'Family Tree 1' -e output.gramps -f gramps
 
 10. To generate a web site into an other locale (in german):
 LANGUAGE=de_DE; LANG=de_DE.UTF-8 gramps -O 'Family Tree 1' -a report -p name=navwebpage,target=/../de


### PR DESCRIPTION
Found instances of command line -f prompts for gramps-xml when it should be gramps

This is a do-over for my first pull request (https://github.com/gramps-project/gramps/pull/1630) which I goofed up by using master. It also incorporates changes from @hgohel to update another file and retain the references to Gramps XML. This only applies to the command line prompts now. 

Fixes bug [#9723](https://gramps-project.org/bugs/view.php?id=9723).