### PR TITLE
Fix command line progress output

### DIFF
--- a/gramps/cli/test/user_test.py
+++ b/gramps/cli/test/user_test.py
@@ -173,6 +173,26 @@ class TestUser_progress(unittest.TestCase):
             self.user.step_progress()
         self.user.end_progress()
 
+    def test_progress_percent(self):
+        self.user.begin_progress("Foo", "Bar", 20)
+        self.user._fileout.write.assert_called_with("Bar")
+        for i in range(20):
+            self.user.step_progress()
+            pct = (i + 1) * 5
+            self.user._fileout.write.assert_called_with("\r{:3d}% ".format(pct))
+        self.user.end_progress()
+        self.user._fileout.write.assert_called_with("\n")
+
+    def test_progress_spinner(self):
+        self.user.begin_progress("Foo", "Bar", 0)
+        self.user._fileout.write.assert_called_with("Bar")
+        for i in range(5):
+            self.user.step_progress()
+            spn = user._SPINNER[(i + 1) % 4]
+            self.user._fileout.write.assert_called_with("\r  {}  ".format(spn))
+        self.user.end_progress()
+        self.user._fileout.write.assert_called_with("\n")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/gramps/cli/user.py
+++ b/gramps/cli/user.py
@@ -96,31 +96,35 @@ class User(user.UserBase):
         :type steps: int
         :returns: none
         """
-        self._fileout.write(message)
         self.steps = steps
         self.current_step = 0
-        if self.steps == 0:
-            self._fileout.write(_SPINNER[self.current_step])
-        else:
-            self._fileout.write("00%")
+        self.display_progress()
+        self._fileout.write(message)
 
     def step_progress(self):
         """
         Advance the progress meter.
         """
         self.current_step += 1
-        if self.steps == 0:
-            self.current_step %= 4
-            self._fileout.write("\r  %s  " % _SPINNER[self.current_step])
-        else:
-            percent = int((float(self.current_step) / self.steps) * 100)
-            self._fileout.write("\r%02d%%" % percent)
+        self.display_progress()
 
     def end_progress(self):
         """
         Stop showing the progress indicator to the user.
         """
-        self._fileout.write("\r100%\n")
+        self.display_progress(end=True)
+
+    def display_progress(self, end=False):
+        if end:
+            self.steps = self.current_step = 1
+        if self.steps == 0:
+            self.current_step %= 4
+            self._fileout.write("\r  %s  " % _SPINNER[self.current_step])
+        else:
+            percent = int((float(self.current_step) / self.steps) * 100)
+            self._fileout.write("\r%3d%% " % percent)
+        if end:
+            self._fileout.write("\n")
 
     def prompt(
         self,


### PR DESCRIPTION
During CLI invocation (e.g.: gramps --action=report ...) a progress is shown on stdout. This progress consists of a procent value and some text. The text is however partly overwriten whenever the percent value is updated.

This PR fixes it in a way that the percent value and text are correctly alligned.