### PR TITLE
Show other roles for an event in the narrative web report

### DIFF
--- a/gramps/gen/utils/db.py
+++ b/gramps/gen/utils/db.py
@@ -664,6 +664,32 @@ def get_source_and_citation_referents(source_handle, db):
     return the_lists
 
 
+def get_event_person_referents(event_handle, db):
+    """
+    Find persons that refer to the event object.
+
+    This function finds all primary objects that refer
+    to the given event handle in a given database.
+    """
+    _primaries = ("Person",)
+
+    lists = get_referents(event_handle, db, _primaries)
+    return [x for xs in lists for x in xs]
+
+
+def get_event_family_referents(event_handle, db):
+    """
+    Find families that refer to the event object.
+
+    This function finds all primary objects that refer
+    to the given event handle in a given database.
+    """
+    _primaries = ("Family",)
+
+    lists = get_referents(event_handle, db, _primaries)
+    return [x for xs in lists for x in xs]
+
+
 def get_media_referents(media_handle, db):
     """
     Find objects that refer the media object.

--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -215,6 +215,9 @@ class NavWebReport(Report):
         # create an event pages or not?
         self.inc_events = self.options["inc_events"]
 
+        # Include other roles to an event?
+        self.inc_other_roles = self.options["inc_other_roles"]
+
         # create places pages or not?
         self.inc_places = self.options["inc_places"]
 
@@ -2554,6 +2557,10 @@ class NavWebOptions(MenuReportOptions):
         inc_events = BooleanOption(_("Include event pages"), False)
         inc_events.set_help(_("Add a complete events list and relevant pages or not"))
         addopt("inc_events", inc_events)
+
+        inc_other_roles = BooleanOption(_("Include other roles"), False)
+        inc_other_roles.set_help(_("Include persons with other roles to an event"))
+        addopt("inc_other_roles", inc_other_roles)
 
         inc_places = BooleanOption(_("Include place pages"), False)
         inc_places.set_help(_("Whether or not to include the place pages."))


### PR DESCRIPTION
Include an option to the Narrative Web Page generator to also include other roles for an event.

A person can have multiple events. The events where the person is the primary person, are normally shown in the report. With the additional option "Include other roles" enabled (default disabled), the report will also show the persons that also have some role in that event.

The result looks like this:
![image](https://github.com/gramps-project/gramps/assets/11874759/84394b11-2153-42cf-9bd1-a059d80f209b)
