### PR TITLE
Add a name parameter to the get_person_mark utility

### DIFF
--- a/gramps/gen/plug/report/utils.py
+++ b/gramps/gen/plug/report/utils.py
@@ -218,7 +218,7 @@ def find_marriage(database, family):
 # Indexing function
 #
 # -------------------------------------------------------------------------
-def get_person_mark(dbase, person):
+def get_person_mark(dbase, person, name=None):
     """
     Return a IndexMark that can be used to index a person in a report
 
@@ -228,7 +228,8 @@ def get_person_mark(dbase, person):
     if not person:
         return None
 
-    name = person.get_primary_name().get_name()
+    if name is None:
+        name = person.get_primary_name().get_name()
     birth = " "
     death = " "
     key = ""

--- a/gramps/plugins/textreport/detancestralreport.py
+++ b/gramps/plugins/textreport/detancestralreport.py
@@ -315,7 +315,7 @@ class DetAncestorReport(Report):
         name = self._nd.display(person)
         if not name:
             name = self._("Unknown")
-        mark = utils.get_person_mark(self._db, person)
+        mark = utils.get_person_mark(self._db, person, name)
 
         self.doc.start_bold()
         self.doc.write_text(name, mark)
@@ -559,14 +559,14 @@ class DetAncestorReport(Report):
             if mother_handle:
                 mother = self._db.get_person_from_handle(mother_handle)
                 mother_name = self._nd.display_name(mother.get_primary_name())
-                mother_mark = utils.get_person_mark(self._db, mother)
+                mother_mark = utils.get_person_mark(self._db, mother, mother_name)
             else:
                 mother_name = ""
                 mother_mark = ""
             if father_handle:
                 father = self._db.get_person_from_handle(father_handle)
                 father_name = self._nd.display_name(father.get_primary_name())
-                father_mark = utils.get_person_mark(self._db, father)
+                father_mark = utils.get_person_mark(self._db, father, father_name)
             else:
                 father_name = ""
                 father_mark = ""
@@ -589,7 +589,8 @@ class DetAncestorReport(Report):
             spouse_handle = utils.find_spouse(person, family)
             if spouse_handle:
                 spouse = self._db.get_person_from_handle(spouse_handle)
-                spouse_mark = utils.get_person_mark(self._db, spouse)
+                spouse_name = self._nd.display_name(spouse.get_primary_name())
+                spouse_mark = utils.get_person_mark(self._db, spouse, spouse_name)
             else:
                 spouse_mark = None
 
@@ -642,7 +643,7 @@ class DetAncestorReport(Report):
             child_name = self._nd.display(child)
             if not child_name:
                 child_name = self._("Unknown")
-            child_mark = utils.get_person_mark(self._db, child)
+            child_mark = utils.get_person_mark(self._db, child, child_name)
 
             if self.childref and self.prev_gen_handles.get(child_handle):
                 value = int(self.prev_gen_handles.get(child_handle))


### PR DESCRIPTION
This allows an alphabetical index entry for a person to use the selected name format.  Previously a "Surname, Given Suffix" format was always used.

Fixes [#13155](https://gramps-project.org/bugs/view.php?id=13155).

A quick _grep_ reveals that about a dozen reports are affected.

Another possible solution would be to pass a name displayer to the `get_person_mark` utility rather than a name.  This needs further investigation.  I don't have time right now.