### PR TITLE
Ignore AIO artifacts in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,12 @@ dist/
 # Gramps
 docs/_build/
 
+# Gramps AIO build artifacts
+aio/grampsaio64.nsi
+aio/mingw-w64-x86_64-db-*.pkg.tar.xz
+aio/mingw64
+gramps.egg-info
+
 # Editing
 tags
 *.swp


### PR DESCRIPTION
Several artifacts are generated (or downloaded) when building the AIO bundle, which have been added to .gitignore since they don't need to be tracked with git.