### PR TITLE
Emit a "plugins-reloaded" signal when a new addon is installed

### DIFF
--- a/gramps/gui/plug/_windows.py
+++ b/gramps/gui/plug/_windows.py
@@ -558,6 +558,7 @@ class AddonManager(ManagedWindow):
         )
         pdata = self.__preg.get_plugin(addon_id)
         self.__pmgr.load_plugin(pdata)
+        self.__pmgr.emit("plugins-reloaded")
 
     def build_menu_names(self, obj):
         return (self.title, self.title)


### PR DESCRIPTION
This ensures that the user interface will be updated to include the new addon.

Fixes [#13021](https://gramps-project.org/bugs/view.php?id=13021).