### PR TITLE
Remove the Trove classifier "Natural Language :: German(Austrian)"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -487,7 +487,6 @@ setup(
         "Natural Language :: Finnish",
         "Natural Language :: French",
         "Natural Language :: German",
-        "Natural Language :: German (Austrian)",
         "Natural Language :: Greek",
         "Natural Language :: Hebrew",
         "Natural Language :: Hungarian",


### PR DESCRIPTION
This is not valid in PyPI.
See: https://pypi.org/classifiers