### PR TITLE
Replace GtkArrow with GtkImage and symbolic icons

### DIFF
--- a/gramps/gui/widgets/expandcollapsearrow.py
+++ b/gramps/gui/widgets/expandcollapsearrow.py
@@ -87,13 +87,13 @@ class ExpandCollapseArrow(Gtk.EventBox):
         """
         Gtk.EventBox.__init__(self)
         if collapsed:
-            self.arrow = Gtk.Arrow(
-                arrow_type=Gtk.ArrowType.RIGHT, shadow_type=Gtk.ShadowType.OUT
+            self.arrow = Gtk.Image.new_from_icon_name(
+                "pan-end-symbolic", Gtk.IconSize.BUTTON
             )
             self.set_tooltip_text(_("Expand this section"))
         else:
-            self.arrow = Gtk.Arrow(
-                arrow_type=Gtk.ArrowType.DOWN, shadow_type=Gtk.ShadowType.OUT
+            self.arrow = Gtk.Image.new_from_icon_name(
+                "pan-down-symbolic", Gtk.IconSize.BUTTON
             )
             self.set_tooltip_text(_("Collapse this section"))
         self.add(self.arrow)

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -975,8 +975,8 @@ class RelationshipView(NavigationView):
                     False, self.expand_collapse_press, (person, family.handle)
                 )
         else:
-            arrow = Gtk.Arrow(
-                arrow_type=Gtk.ArrowType.RIGHT, shadow_type=Gtk.ShadowType.OUT
+            arrow = Gtk.Image.new_from_icon_name(
+                "pan-end-symbolic", Gtk.IconSize.BUTTON
             )
         hbox.pack_start(arrow, False, True, 0)
         hbox.pack_start(label, True, True, 0)


### PR DESCRIPTION
The former was deprecated in GTK 3.14, and removed in GTK4.