### PR TITLE
Update Navigator to use modern widgets

### DIFF
--- a/gramps/gui/grampsgui.py
+++ b/gramps/gui/grampsgui.py
@@ -215,7 +215,7 @@ UIDEFAULT = (
           <attribute name="label" translatable="yes">F_ull Screen</attribute>
         </item>
       </section>
-      <section id="ViewsInCatagory">
+      <section id="ViewsInCategory">
       </section>
     </submenu>
     <submenu id="m5" groups='RO'>

--- a/gramps/gui/navigator.py
+++ b/gramps/gui/navigator.py
@@ -94,9 +94,6 @@ class Navigator:
         self.top = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
         frame = Gtk.Frame()
-        hbox = Gtk.Box()
-        hbox.show()
-        frame.add(hbox)
         frame.show()
 
         self.select_button = Gtk.ToggleButton()
@@ -112,13 +109,7 @@ class Navigator:
 
         self.select_button.connect("button_press_event", self.__menu_button_pressed)
 
-        # close_button = Gtk.Button()
-        # img = Gtk.Image.new_from_icon_name('window-close', Gtk.IconSize.MENU)
-        # close_button.set_image(img)
-        # close_button.set_relief(Gtk.ReliefStyle.NONE)
-        # close_button.connect('clicked', self.cb_close_clicked)
-        hbox.pack_start(self.select_button, False, True, 0)
-        # hbox.pack_end(close_button, False, True, 0)
+        frame.add(self.select_button)
 
         self.top.pack_end(frame, False, True, 0)
 
@@ -325,13 +316,6 @@ class Navigator:
         if self.active_view is not None:
             self.pages[index][1].view_changed(self.active_cat, self.active_view)
         self.title_label.set_text(self.pages[index][0])
-
-    def cb_close_clicked(self, button):
-        """
-        Called when the sidebar is closed.
-        """
-        uimanager = self.viewmanager.uimanager
-        uimanager.get_action("/MenuBar/ViewMenu/Navigator").activate()
 
 
 # -------------------------------------------------------------------------

--- a/gramps/gui/navigator.py
+++ b/gramps/gui/navigator.py
@@ -45,7 +45,7 @@ from .uimanager import ActionGroup
 # Constants
 #
 # -------------------------------------------------------------------------
-UICATEGORY = """      <section id="ViewsInCatagory">
+UICATEGORY = """      <section id="ViewsInCategory">
         %s
       </section>
     """
@@ -131,7 +131,7 @@ class Navigator:
         """
         menuitem = """
             <item>
-              <attribute name="action">win.ViewInCatagory</attribute>
+              <attribute name="action">win.ViewInCategory</attribute>
               <attribute name="label" translatable="yes">%s</attribute>
               <attribute name="target">%d %d</attribute>
             </item>
@@ -139,7 +139,7 @@ class Navigator:
         baritem = """
             <child>
               <object class="GtkToggleToolButton" id="bar%d">
-                <property name="action-name">win.ViewInCatagory</property>
+                <property name="action-name">win.ViewInCategory</property>
                 <property name="action-target">'%d %d'</property>
                 <property name="icon-name">%s</property>
                 <property name="tooltip_text" translatable="yes">%s</property>
@@ -178,7 +178,7 @@ class Navigator:
                 if view_num < 9:
                     accel = "<PRIMARY><ALT>%d" % ((view_num % 9) + 1)
                     self.viewmanager.uimanager.app.set_accels_for_action(
-                        "win.ViewInCatagory('%d %d')" % (cat_num, view_num), [accel]
+                        "win.ViewInCategory('%d %d')" % (cat_num, view_num), [accel]
                     )
                 uimenuitems += menuitem % (page[0].name, cat_num, view_num)
 
@@ -258,7 +258,7 @@ class Navigator:
 
         if cat_num in self.ui_category:
             action = (
-                "ViewInCatagory",
+                "ViewInCategory",
                 self.cb_view_clicked,
                 "",
                 str(cat_num) + " " + str(view_num),

--- a/mac/gramps.accel
+++ b/mac/gramps.accel
@@ -59,7 +59,7 @@
 # "win.TipOfDay": "",
 # "win.Undo": "<Primary>z",
 # "win.Redo": "<Primary><Shift>z",
-# "win.ViewInCatagory": "",
+# "win.ViewInCategory": "",
 # "win.HomePerson": "<Alt>Home",
 # "win.ExportTab": "",
 # "win.Edit": "<Primary>Return",


### PR DESCRIPTION
A combo box for the page selection tracks the popup menu for you, which simplifies that bit of the code, and also removes the deprecated `GtkMenu` and `GtkArrow`.

A stack instead of a notebook for the pages can be set to non-homogeneous, so there's no need to mess with hiding/showing widgets.

With the available properties (`GtkComboBox:active-id` and `GtkStack:visible-child-name`), we can bind the stack/combo together and not have to implement this ourselves.

Finally, fix a typo in the `ViewsInCategory` action name.

I broke each of these changes into separate commits for easier review.