### PR TITLE
Remove unused Subversion keyword substitutions

### DIFF
--- a/data/css/Web_Basic-Blue.css
+++ b/data/css/Web_Basic-Blue.css
@@ -20,8 +20,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# $Id: Web_Basic-Blue.css 15540 2010-06-07 16:32:00Z robhealey1 $
-#
+
 *************************************************
 GRAMPS Cascading Style Sheet
 Style Name: Basic Blue Stylesheet

--- a/data/css/Web_Vertical-Menus.css
+++ b/data/css/Web_Vertical-Menus.css
@@ -25,8 +25,6 @@ GRAMPS Cascading Style Sheet
 Style Name: Web_Navigation-Vertical.css Stylesheet
 *******************************************************************************
 
-# $Id: Web_Navigation-Vertical.css 15241 2010-04-19 11:07:00Z robhealey1 $
-
  Body Element
 ----------------------------------------------------- */
 body {

--- a/data/css/ancestortree.css
+++ b/data/css/ancestortree.css
@@ -18,8 +18,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# $Id: $
-#
+
 *******************************************************************************
 GRAMPS Cascading Style Sheet
 Style Name: Combined Ancestor Tree Style Sheet

--- a/gramps/gen/datehandler/_date_hr.py
+++ b/gramps/gen/datehandler/_date_hr.py
@@ -18,8 +18,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# $Id: _date_hr.py 22672 2013-07-13 18:01:08Z paul-franklin $
-#
 
 # Croatian version 2008 by Josip
 # Croatian version 2018 by Milo

--- a/gramps/gui/navigator.py
+++ b/gramps/gui/navigator.py
@@ -17,7 +17,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# $Id: navigator.py 20492 2012-10-02 21:08:19Z nick-h $
 
 """
 A module that provides pluggable sidebars.  These provide an interface to

--- a/gramps/plugins/sidebar/dropdownsidebar.py
+++ b/gramps/plugins/sidebar/dropdownsidebar.py
@@ -21,7 +21,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# $Id: categorysidebar.py 20634 2012-11-07 17:53:14Z bmcage $
 
 # -------------------------------------------------------------------------
 #

--- a/gramps/plugins/sidebar/expandersidebar.py
+++ b/gramps/plugins/sidebar/expandersidebar.py
@@ -21,7 +21,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# $Id: categorysidebar.py 20634 2012-11-07 17:53:14Z bmcage $
 
 # -------------------------------------------------------------------------
 #

--- a/po/ca.po
+++ b/po/ca.po
@@ -1,5 +1,4 @@
 # Catalan translation for Gramps
-# $Id: ca.po 22700 2013-07-21 06:57:33Z vassilii $
 # This file is distributed under the same license as the Gramps package.
 # translation of ca.po to Català
 # TRADUCCIÓ AL CATALÀ DE GRAMPS

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,5 +1,4 @@
 # Polish translation for Gramps
-# $Id: pl.po 22700 2013-07-21 06:57:33Z vassilii $
 # This file is distributed under the same license as the Gramps package.
 # Copyright (C) 2002-2003, 2006, 2007 Free Software Foundation, Inc.
 #


### PR DESCRIPTION
These are not used with Git and are clearly outdated, as these files have all been touched since the indicated dates.