### PR TITLE
Addon Manager Requirements mark symbols on Mac

### DIFF
--- a/gramps/gen/utils/requirements.py
+++ b/gramps/gen/utils/requirements.py
@@ -182,4 +182,4 @@ def tick_cross(value):
     """
     Return a tick for True or a cross for False
     """
-    return "\u2714" if value else "\u2718"
+    return "\N{CHECK MARK}" if value else "\N{CROSS MARK}"

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -2742,7 +2742,7 @@ class GrampsPreferences(ConfigureDialog):
         self.set_substitution_symbol("utf8.engaged-symbol", "o")
         self.set_substitution_symbol("utf8.divorce-symbol", "o|o")
         self.set_substitution_symbol("utf8.partner-symbol", "o-o")
-        self.set_substitution_symbol("utf8.dead-symbol", "✝")
+        self.set_substitution_symbol("utf8.dead-symbol", "+")
         self.set_substitution_symbol("utf8.buried-symbol", "[]")
         self.set_substitution_symbol("utf8.cremated-symbol", "⚱")
         self.set_substitution_symbol("utf8.killed-symbol", "x")


### PR DESCRIPTION
Change the cross mark and check mark symbols used in the Addon Manager Requirements screen to be valid characters on Mac.

Addresses bug [#13194](https://gramps-project.org/bugs/view.php?id=13194).