### PR TITLE
Fix fan charts on HiDPI screens

### DIFF
--- a/gramps/gui/widgets/fanchart2way.py
+++ b/gramps/gui/widgets/fanchart2way.py
@@ -463,7 +463,11 @@ class FanChart2WayWidget(FanChartWidget, FanChartDescWidget):
             self.set_size_request(max(size_w, size_w_a), max(size_h, size_h_a))
             size_w = self.get_allocated_width()
             size_h = self.get_allocated_height()
-            self.surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, size_w, size_h)
+            scale_factor = self.get_scale_factor()
+            self.surface = cairo.ImageSurface(
+                cairo.FORMAT_ARGB32, size_w * scale_factor, size_h * scale_factor
+            )
+            self.surface.set_device_scale(scale_factor, scale_factor)
             ctx = cairo.Context(self.surface)
             self.center_xy = self.center_xy_from_delta()
             ctx.translate(*self.center_xy)

--- a/gramps/gui/widgets/fanchartdesc.py
+++ b/gramps/gui/widgets/fanchartdesc.py
@@ -491,7 +491,11 @@ class FanChartDescWidget(FanChartBaseWidget):
             self.set_size_request(max(size_w, size_w_a), max(size_h, size_h_a))
             size_w = self.get_allocated_width()
             size_h = self.get_allocated_height()
-            self.surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, size_w, size_h)
+            scale_factor = self.get_scale_factor()
+            self.surface = cairo.ImageSurface(
+                cairo.FORMAT_ARGB32, size_w * scale_factor, size_h * scale_factor
+            )
+            self.surface.set_device_scale(scale_factor, scale_factor)
             ctx = cairo.Context(self.surface)
             self.center_xy = self.center_xy_from_delta()
             ctx.translate(*self.center_xy)


### PR DESCRIPTION
Most DrawingArea-based widgets are fine, but the fan charts use a backing image surface that is blitted when needed. On HiDPI displays, this image surface is normal size, and thus everything ends up blurry when scaled up.

Instead the backing surface should be scaled to match the display, and also re-created if the display scale changes (e.g., if display settings change, or the window is moved between displays with different settings.)

I suppose this could possibly be backported to maintenance branches as well.