### PR TITLE
Update AIO minimum Windows version requirement to 8.1 64-bit

### DIFF
--- a/aio/grampsaio64.nsi.template
+++ b/aio/grampsaio64.nsi.template
@@ -718,8 +718,8 @@ Function .onInit
     Quit
   ${EndIf}
 
-  ${If} ${AtMostWinXP}
-    MessageBox MB_OK "Windows Vista and above required"
+  ${If} ${AtMostWin8}
+    MessageBox MB_OK "Windows 8.1 and above required"
     Quit
   ${EndIf}
   ;StrCpy $LANGUAGE ${LANG_FRENCH}


### PR DESCRIPTION
The MSYS2 build environment [dropped support](https://www.msys2.org/news/#2023-01-15-dropping-support-for-windows-7-and-80
) for Windows 7 and 8.0 on 15th Jan 2023.

See the MSYS2 [supported versions](https://www.msys2.org/docs/windows_support/).