### PR TITLE
Fix the addon translator language for core translations

### DIFF
--- a/gramps/gen/utils/grampslocale.py
+++ b/gramps/gen/utils/grampslocale.py
@@ -677,7 +677,7 @@ class GrampsLocale:
 
         Assumes path/filename = path/locale/LANG/LC_MESSAGES/addon.mo.
         """
-        gramps_translator = self._get_translation()
+        gramps_translator = self._get_translation(languages=languages)
 
         path = self.localedir
         if filename:


### PR DESCRIPTION
Pass the languages list to the core translator. This gives better translations when creating the addon listings.

Fixes [#13221](https://gramps-project.org/bugs/view.php?id=13221).