### PR TITLE
Fix place title when place names use open spans

### DIFF
--- a/gramps/gen/utils/location.py
+++ b/gramps/gen/utils/location.py
@@ -70,13 +70,13 @@ def __get_latest_date(place):
     latest_date = None
     for place_name in place.get_all_names():
         date = place_name.get_date_object()
-        if date.is_empty() or date.modifier == Date.MOD_AFTER:
+        if date.is_empty() or date.modifier in (Date.MOD_FROM, Date.MOD_AFTER):
             return Today()
         else:
             if date.is_compound():
                 date1, date2 = date.get_start_stop_range()
                 date = Date(*date2)
-            if date.modifier == Date.MOD_BEFORE:
+            if date.modifier in (Date.MOD_TO, Date.MOD_BEFORE):
                 date = date - 1
             if latest_date is None or date > latest_date:
                 latest_date = date


### PR DESCRIPTION
The function to determine the latest date for a place had not been updated for open spans resulting in "?" being incorrectly displayed as the place title.

Fixes [#13222](https://gramps-project.org/bugs/view.php?id=13222).