### PR TITLE
Fix the Tag.is_empty() method

### DIFF
--- a/gramps/gen/lib/tag.py
+++ b/gramps/gen/lib/tag.py
@@ -133,7 +133,7 @@ class Tag(TableObject):
         :returns: True if the Tag is empty
         :rtype: bool
         """
-        return self.__name != ""
+        return not self.__name
 
     def are_equal(self, other):
         """


### PR DESCRIPTION
The `Tag.is_empty()` method was returning the inverse of the expected value.

Fixes [#12579](https://gramps-project.org/bugs/view.php?id=12579).