### PR TITLE
Allow Gramps to run from an extracted source distribution

### DIFF
--- a/gramps/gen/utils/resourcepath.py
+++ b/gramps/gen/utils/resourcepath.py
@@ -74,7 +74,7 @@ class ResourcePath:
         package_path = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "..", "..", "..")
         )
-        installed = not os.path.exists(os.path.join(package_path, ".git"))
+        installed = not os.path.exists(os.path.join(package_path, "MANIFEST.in"))
         if installed:
             test_path = os.path.join("gramps", "authors.xml")
         else:


### PR DESCRIPTION
When trying to run gramps directly from sources extracted from tar.gz file, gramps don't run : 

```
$ python3 Gramps.py
ResourcePath.ERROR: Unable to determine resource path
```
This is because gramps is testing for the existence of the ".git" folder, which does not exist in the sources extracted from the tar.gz file.

I suggest testing for the existence of the "data" folder, which exists both in the sources obtained by "git clone" and those extracted from tar.gz.