### PR TITLE
Fix error when installing an addon that will not be registered

### DIFF
--- a/gramps/gui/plug/_windows.py
+++ b/gramps/gui/plug/_windows.py
@@ -557,6 +557,13 @@ class AddonManager(ManagedWindow):
             USER_PLUGINS, self.dbstate, self.uistate, load_on_reg=True
         )
         pdata = self.__preg.get_plugin(addon_id)
+        if pdata is None:
+            OkDialog(
+                _("Addon Registration Failed"),
+                _("The addon will be unavailable in your current configuration."),
+                parent=self.window,
+            )
+            return
         self.__pmgr.load_plugin(pdata)
         self.__pmgr.emit("plugins-reloaded")
 


### PR DESCRIPTION
Some addons are removed from the plugin registration lists. These include addons that don't meet their prerequisite requirements and also developer tools and unstable addons when not running in developer mode.

In the current design we don't store the installation status of these addons, so this fix just presents an error dialog to the user.

A better long-term solution would be to register the addons, but flag them as inactive.  This way we could easily detect if that they were installed and disable the install button.

Fixes [#13233](https://gramps-project.org/bugs/view.php?id=13233).