### PR TITLE
add workflow for .deb build.

### DIFF
--- a/.github/workflows/build_deb.yml
+++ b/.github/workflows/build_deb.yml
@@ -1,0 +1,97 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2021       Nick Hall
+# Copyright (C) 2024       Jean Michault
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+name: Build Debian packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      build-number:
+        description: 'Build number'
+        type: string
+        default: '1'
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
+
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install gir1.2-pango-1.0
+        sudo apt-get install gir1.2-gtk-3.0
+        sudo apt-get install xdg-utils
+        sudo apt-get install librsvg2-common
+        sudo apt-get install libglib2.0-dev
+        sudo apt-get install intltool
+        sudo apt-get install python3-gi
+        sudo apt-get install python3-cairo
+        sudo apt-get install python3-gi-cairo
+        sudo apt-get install python3-bsddb3
+        sudo apt-get install python3-dev
+        sudo apt-get install python3-nose
+        sudo apt-get install python3-mock
+        sudo apt-get install python3-icu
+        sudo apt-get install python3-coverage
+        sudo apt-get install python3-jsonschema
+        sudo apt-get install libxml2-utils
+        sudo apt-get install python3-lxml
+        sudo apt-get install python3-libxml2
+        sudo apt-get install zlib1g-dev
+        sudo apt-get install python3-setuptools
+        sudo apt-get install devscripts debhelper dh-python python3-all python3-nose-exclude
+    - name: Build deb package
+      run: |
+        python3 setup.py egg_info
+        VERSION=$(grep "^Version:" gramps.egg-info/PKG-INFO|sed 's/Version: *//')
+        if grep -q '^DEV_VERSION\s*=\s*True' gramps/version.py; then
+          appbuild=$(git rev-parse --short $GITHUB_SHA)
+        else
+          appbuild=${{ inputs.build-number }}
+        fi
+        # create entry in debian/changelog, if needed :
+        if ! grep "^gramps ($VERSION" debian/changelog ; then
+          DEBFULLNAME="Gramps Project" DEBEMAIL="noreply@gramps-project.org" debchange -D UNRELEASED -v "$VERSION"-"$appbuild" "New release"
+        fi
+        python3 setup.py sdist
+        cd dist
+        tar zxf gramps-"$VERSION".tar.gz
+        mv gramps-"$VERSION".tar.gz gramps_"$VERSION".orig.tar.gz
+        cd gramps-"$VERSION"
+        # to allow resourcepath detection :
+        mkdir .git
+        # to make mediapath test successful :
+        mkdir -p build/.gramps
+        export LANG=en_US.utf8
+        debuild --no-sign
+        cd /home/runner/work/gramps/gramps/dist
+        mv gramps_${VERSION}-${appbuild}_all.deb gramps_${VERSION}-${appbuild}_all.${{ matrix.os }}.deb
+    - uses: actions/upload-artifact@v4
+      with:
+        name: Gramps_deb_${{ matrix.os }}
+        path: /home/runner/work/gramps/gramps/dist/*.deb
+        retention-days: 7

--- a/debian/rules
+++ b/debian/rules
@@ -4,13 +4,14 @@
 #export DH_VERBOSE=1
 #export DH_OPTIONS=-v
 export PYBUILD_NAME=gramps
-export PYBUILD_INSTALL_ARGS_python3=--resourcepath=/usr/share --force
+export PYBUILD_INSTALL_ARGS_python3=
 
 %:
 	dh $@ --with python3 --buildsystem=pybuild
 
 # Override auto test to enable nose tests
 override_dh_auto_test:
+	mkdir -p $(CURDIR)/build/.gramps; \
 	HOME=$(CURDIR)/build \
 	nosetests3 -vv \
 	--exclude=TestcaseGenerator \


### PR DESCRIPTION
little changes in debian/rules to allow build.

And workflow to build .deb package for ubuntu 20.04 and ubuntu latest (actually 22.04 for github).