### PR TITLE
Use preferred name instead of default name in name editor

### DIFF
--- a/gramps/gui/editors/displaytabs/nameembedlist.py
+++ b/gramps/gui/editors/displaytabs/nameembedlist.py
@@ -130,7 +130,7 @@ class NameEmbedList(GroupEmbeddedList):
                 (True, _("_Add"), self.add_button_clicked),
                 (False, _("_Edit"), self.edit_button_clicked),
                 (True, _("_Remove"), self.del_button_clicked),
-                (True, _("Set as default name"), self.name_button_clicked),
+                (True, _("Set as Preferred name"), self.name_button_clicked),
             ]
         else:
             return [


### PR DESCRIPTION
make "Alternative names" Context menu match "Preferred name" GUI label in Names tab of Person Editor

https://gramps-project.org/bugs/view.php?id=13256