### PR TITLE
Update citation.py

### DIFF
--- a/gramps/gen/lib/citation.py
+++ b/gramps/gen/lib/citation.py
@@ -81,7 +81,7 @@ class Citation(
         DateBase.__init__(self)  #  2
         self.source_handle = None  #  5
         self.page = ""  #  3
-        self.confidence = Citation.CONF_NORMAL  #  4
+        self.confidence = Citation.CONF_VERY_LOW  #  4
         SrcAttributeBase.__init__(self)  #  8
 
     @classmethod


### PR DESCRIPTION
change default in Citation filter for Confidence from "Normal" to "Very Low" so that nothing is excluded by default.

https://gramps-project.org/bugs/view.php?id=11797