### PR TITLE
Change default confidence level in citation filter

### DIFF
--- a/gramps/gui/filters/sidebar/_citationsidebarfilter.py
+++ b/gramps/gui/filters/sidebar/_citationsidebarfilter.py
@@ -142,7 +142,7 @@ class CitationSidebarFilter(SidebarFilter):
         self.filter_id.set_text("")
         self.filter_page.set_text("")
         self.filter_date.set_text("")
-        self.filter_conf.set_active(Citation.CONF_NORMAL)
+        self.filter_conf.set_active(Citation.CONF_VERY_LOW)
         self.filter_note.set_text("")
         self.tag.set_active(0)
         self.generic.set_active(0)


### PR DESCRIPTION
change default in Citation filter for Confidence from "Normal" to "Very Low" so that nothing is excluded by default.

https://gramps-project.org/bugs/view.php?id=11797
missed line for  PR Update citation.py #1700