### PR TITLE
Change repository "Title" to "Name" in the source editor

### DIFF
--- a/gramps/gui/editors/displaytabs/repoembedlist.py
+++ b/gramps/gui/editors/displaytabs/repoembedlist.py
@@ -65,7 +65,7 @@ class RepoEmbedList(EmbeddedList, DbGUIElement):
     #  (name, sortcol in model, width, markup/text, weigth_col
     _column_names = [
         (_("ID"), 0, 75, TEXT_COL, -1, None),
-        (_("Title"), 1, 200, TEXT_COL, -1, None),
+        (_("Name"), 1, 200, TEXT_COL, -1, None),
         (_("Call Number"), 2, 125, TEXT_COL, -1, None),
         (_("Type"), 3, 100, TEXT_COL, -1, None),
         (_("Private"), 4, 30, ICON_COL, -1, "gramps-lock"),


### PR DESCRIPTION
Make column label "Title" in Source editor's Repositories tab match "Name" used in Repositories view and Repository object editor.

fixes [0013258](https://gramps-project.org/bugs/view.php?id=13258): Column "Title" in Edit Source dialog's Repository tabs is a mismatch for "Name" in the Repository object editor
