### PR TITLE
Change the output of ADDR tags in the Gedcom export

### DIFF
--- a/data/tests/exp_sample_ged.ged
+++ b/data/tests/exp_sample_ged.ged
@@ -75,8 +75,6 @@
 2 TYPE Christening of Amber Marie Smith
 2 DATE 26 APR 1998
 2 PLAC Community Presbyterian Church, Danville, CA
-2 ADDR
-3 ADR2 Community Presbyterian Church, Danville, CA
 1 FAMC @F0013@
 2 PEDI birth
 1 CHAN
@@ -131,8 +129,6 @@
 2 TYPE Christening of Mason Michael Smith
 2 DATE 10 JUL 1996
 2 PLAC Community Presbyterian Church, Danville, CA
-2 ADDR
-3 ADR2 Community Presbyterian Church, Danville, CA
 1 FAMC @F0013@
 2 PEDI birth
 1 CHAN
@@ -626,10 +622,6 @@
 3 MAP
 4 LATI N39.7392
 4 LONG W104.9903
-2 ADDR
-3 CITY Denver, Denver Co., CO
-3 STAE Colorado
-3 CTRY USA
 1 DEAT
 2 TYPE Death of Marjorie Ohman
 2 DATE 22 JUN 1980
@@ -648,8 +640,6 @@
 2 TYPE Birth of Darcy Horne
 2 DATE 2 JUL 1966
 2 PLAC Sacramento, Sacramento Co., CA
-2 ADDR
-3 CITY Sacramento, Sacramento Co., CA
 1 FAMS @F0010@
 1 CHAN
 2 DATE 21 DEC 2007
@@ -858,12 +848,6 @@
 1 BIRT
 2 DATE 29 DEC 1954
 2 PLAC 123 High St, Cleveland, Cuyahoga, Ohio, USA
-2 ADDR 123 High St
-3 ADR1 123 High St
-3 CITY Cleveland
-3 STAE Ohio
-3 POST 44140
-3 CTRY USA
 2 PHON 440-871-3400
 2 PHON 800-871-3400
 2 EMAIL thetester@@gmail.com
@@ -884,8 +868,7 @@
 1 SOUR @S0005@
 1 RESI
 2 DATE 27 OCT 2017
-2 ADDR
-3 CONT test village
+2 ADDR test village
 3 CONT Akron
 3 CONT OH
 3 CONT 44177
@@ -946,10 +929,6 @@
 3 MAP
 4 LATI N39.7392
 4 LONG W104.9903
-2 ADDR
-3 CITY Denver, Denver Co., CO
-3 STAE Colorado
-3 CTRY USA
 2 PHON 440-871-3402
 2 EMAIL tomtester@@gmail.com
 2 FAX 440-321-4569
@@ -965,10 +944,6 @@
 3 MAP
 4 LATI N39.7392
 4 LONG W104.9903
-2 ADDR
-3 CITY Denver, Denver Co., CO
-3 STAE Colorado
-3 CTRY USA
 1 FAMC @F0016@
 2 PEDI birth
 1 SOUR @S0005@
@@ -1023,10 +998,6 @@
 3 MAP
 4 LATI N39.7392
 4 LONG W104.9903
-2 ADDR
-3 CITY Denver, Denver Co., CO
-3 STAE Colorado
-3 CTRY USA
 2 STAT QUALIFIED
 1 FAMC @F0016@
 2 _FREL Adopted
@@ -1278,8 +1249,6 @@
 2 DATE 22 FEB 2000
 2 TEMP DENVE
 2 PLAC Community Presbyterian Church, Danville, CA
-2 ADDR
-3 ADR2 Community Presbyterian Church, Danville, CA
 2 STAT CLEARED
 1 MARR
 2 HUSB

--- a/gramps/gen/lib/locationbase.py
+++ b/gramps/gen/lib/locationbase.py
@@ -107,6 +107,25 @@ class LocationBase:
             self.phone,
         ]
 
+    def get_address_lines(self):
+        """
+        Return a list of non-empty address lines for the Location suitable for
+        producing a formatted address.
+
+        :returns: A list of address lines for the Location.
+        :rtype: list
+        """
+        addr_lines = [
+            self.street,
+            self.locality,
+            self.city,
+            self.county,
+            self.state,
+            self.postal,
+            self.country,
+        ]
+        return [line for line in addr_lines if line]
+
     def set_street(self, val):
         """Set the street portion of the Location."""
         self.street = val

--- a/gramps/plugins/export/exportgedcom.py
+++ b/gramps/plugins/export/exportgedcom.py
@@ -1598,33 +1598,6 @@ class GedcomWriter(UpdateCallback):
             self._writeln(level + 1, "MAP")
             self._writeln(level + 2, "LATI", latitude)
             self._writeln(level + 2, "LONG", longitude)
-
-        # The Gedcom standard shows that an optional address structure can
-        # be written out in the event detail.
-        # http://homepages.rootsweb.com/~pmcbride/gedcom/55gcch2.htm#EVENT_DETAIL
-        location = get_main_location(self.dbase, place)
-        street = location.get(PlaceType.STREET)
-        locality = location.get(PlaceType.LOCALITY)
-        city = location.get(PlaceType.CITY)
-        state = location.get(PlaceType.STATE)
-        country = location.get(PlaceType.COUNTRY)
-        postal_code = place.get_code()
-
-        if street or locality or city or state or postal_code or country:
-            self._writeln(level, "ADDR", street)
-            if street:
-                self._writeln(level + 1, "ADR1", street)
-            if locality:
-                self._writeln(level + 1, "ADR2", locality)
-            if city:
-                self._writeln(level + 1, "CITY", city)
-            if state:
-                self._writeln(level + 1, "STAE", state)
-            if postal_code:
-                self._writeln(level + 1, "POST", postal_code)
-            if country:
-                self._writeln(level + 1, "CTRY", country)
-
         self._note_references(place.get_note_list(), level + 1)
 
     def __write_addr(self, level, addr):
@@ -1652,25 +1625,11 @@ class GedcomWriter(UpdateCallback):
         @param addr: The location or address
         @type addr: [a super-type of] LocationBase
         """
-        if (
-            addr.get_street()
-            or addr.get_locality()
-            or addr.get_city()
-            or addr.get_state()
-            or addr.get_postal_code()
-            or addr.get_country()
-        ):
-            self._writeln(level, "ADDR", addr.get_street())
-            if addr.get_locality():
-                self._writeln(level + 1, "CONT", addr.get_locality())
-            if addr.get_city():
-                self._writeln(level + 1, "CONT", addr.get_city())
-            if addr.get_state():
-                self._writeln(level + 1, "CONT", addr.get_state())
-            if addr.get_postal_code():
-                self._writeln(level + 1, "CONT", addr.get_postal_code())
-            if addr.get_country():
-                self._writeln(level + 1, "CONT", addr.get_country())
+        addr_lines = addr.get_address_lines()
+        if addr_lines:
+            self._writeln(level, "ADDR", addr_lines[0])
+            for line in addr_lines[1:]:
+                self._writeln(level + 1, "CONT", line)
 
             if addr.get_street():
                 self._writeln(level + 1, "ADR1", addr.get_street())


### PR DESCRIPTION
* Only output the ADDR structure for addresses, not places.
* Remove empty lines from the ADDR structure.

Replaces PR #1619.
