### PR TITLE
Add support for ISO 639-3 part 3 standard language code

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ The following packages are optional:
  Python bindings of fontconfig are required for displaying
  genealogical symbols
 
+* [**pycountry**](https://pypi.org/project/pycountry/)
+
+ Used to validate ISO language codes.
+
 
 Optional packages required by Third-party Addons
 ------------------------------------------------

--- a/aio/build.sh
+++ b/aio/build.sh
@@ -33,6 +33,7 @@ pacman -S --needed --noconfirm \
     mingw-w64-x86_64-python-pillow \
     mingw-w64-x86_64-python-pip \
     mingw-w64-x86_64-python-psycopg2 \
+    mingw-w64-x86_64-python-pycountry \
     mingw-w64-x86_64-python-requests \
     mingw-w64-x86_64-python-wheel \
     perl-XML-Parser \

--- a/gramps/gui/editors/editplacename.py
+++ b/gramps/gui/editors/editplacename.py
@@ -41,6 +41,28 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
 from gramps.gen.const import URL_MANUAL_SECT2
 
+try:
+    import pycountry
+
+    def validate_iso(text):
+        """
+        Validate 2 and 3 digit ISO language codes.
+        """
+        if pycountry.languages.get(alpha_2=text):
+            return True
+        if pycountry.languages.get(alpha_3=text):
+            return True
+        return False
+
+except ModuleNotFoundError:
+
+    def validate_iso(_):
+        """
+        Dummy ISO language code validation.  Always return True.
+        """
+        return True
+
+
 # -------------------------------------------------------------------------
 #
 # Constants
@@ -48,193 +70,6 @@ from gramps.gen.const import URL_MANUAL_SECT2
 # -------------------------------------------------------------------------
 WIKI_HELP_PAGE = URL_MANUAL_SECT2
 WIKI_HELP_SEC = _("Place_Name_Editor_dialog", "manual")
-
-ISO_CODES = (
-    "aa",
-    "ab",
-    "ae",
-    "af",
-    "ak",
-    "am",
-    "an",
-    "ar",
-    "as",
-    "av",
-    "ay",
-    "az",
-    "ba",
-    "be",
-    "bg",
-    "bh",
-    "bi",
-    "bm",
-    "bn",
-    "bo",
-    "br",
-    "bs",
-    "ca",
-    "ce",
-    "ch",
-    "co",
-    "cr",
-    "cs",
-    "cu",
-    "cv",
-    "cy",
-    "da",
-    "de",
-    "dv",
-    "dz",
-    "ee",
-    "el",
-    "en",
-    "eo",
-    "es",
-    "et",
-    "eu",
-    "fa",
-    "ff",
-    "fi",
-    "fj",
-    "fo",
-    "fr",
-    "fy",
-    "ga",
-    "gd",
-    "gl",
-    "gn",
-    "gu",
-    "gv",
-    "ha",
-    "he",
-    "hi",
-    "ho",
-    "hr",
-    "ht",
-    "hu",
-    "hy",
-    "hz",
-    "ia",
-    "id",
-    "ie",
-    "ig",
-    "ii",
-    "ik",
-    "io",
-    "is",
-    "it",
-    "iu",
-    "ja",
-    "jv",
-    "ka",
-    "kg",
-    "ki",
-    "kj",
-    "kk",
-    "kl",
-    "km",
-    "kn",
-    "ko",
-    "kr",
-    "ks",
-    "ku",
-    "kv",
-    "kw",
-    "ky",
-    "la",
-    "lb",
-    "lg",
-    "li",
-    "ln",
-    "lo",
-    "lt",
-    "lu",
-    "lv",
-    "mg",
-    "mh",
-    "mi",
-    "mk",
-    "ml",
-    "mn",
-    "mr",
-    "ms",
-    "mt",
-    "my",
-    "na",
-    "nb",
-    "nd",
-    "ne",
-    "ng",
-    "nl",
-    "nn",
-    "no",
-    "nr",
-    "nv",
-    "ny",
-    "oc",
-    "oj",
-    "om",
-    "or",
-    "os",
-    "pa",
-    "pi",
-    "pl",
-    "ps",
-    "pt",
-    "qu",
-    "rm",
-    "rn",
-    "ro",
-    "ru",
-    "rw",
-    "sa",
-    "sc",
-    "sd",
-    "se",
-    "sg",
-    "si",
-    "sk",
-    "sl",
-    "sm",
-    "sn",
-    "so",
-    "sq",
-    "sr",
-    "ss",
-    "st",
-    "su",
-    "sv",
-    "sw",
-    "ta",
-    "te",
-    "tg",
-    "th",
-    "ti",
-    "tk",
-    "tl",
-    "tn",
-    "to",
-    "tr",
-    "ts",
-    "tt",
-    "tw",
-    "ty",
-    "ug",
-    "uk",
-    "ur",
-    "uz",
-    "ve",
-    "vi",
-    "vo",
-    "wa",
-    "wo",
-    "xh",
-    "yi",
-    "yo",
-    "za",
-    "zh",
-    "zu",
-)
 
 
 # -------------------------------------------------------------------------
@@ -287,7 +122,7 @@ class EditPlaceName(EditSecondary):
         self.top.get_object("language").validate(force=True)
 
     def _validate_iso_code(self, widget, text):
-        if text not in ISO_CODES:
+        if not validate_iso(text):
             return ValidationError(_("Invalid ISO code"))
 
     def _connect_signals(self):


### PR DESCRIPTION
The commit adds pycountry as an extra optional dependency.

Fixes [#12772](https://gramps-project.org/bugs/view.php?id=12772).

Replaces PR #1595.