### PR TITLE
Installing 5.1.x after 5.2.x will no longer override config/data locations

### DIFF
--- a/gramps/gen/const.py
+++ b/gramps/gen/const.py
@@ -114,15 +114,16 @@ if "SAFEMODE" in os.environ:
         USER_HOME = get_env_var("HOME")
     HOME_DIR = get_env_var("SAFEMODE")
 
-
-if os.path.exists(HOME_DIR) or "GRAMPSHOME" in os.environ or "SAFEMODE" in os.environ:
+USER_DATA = os.path.join(GLib.get_user_data_dir(), "gramps")
+USER_CONFIG = os.path.join(GLib.get_user_config_dir(), "gramps")
+USER_CACHE = os.path.join(GLib.get_user_cache_dir(), "gramps")
+if os.path.exists(USER_DATA) and os.path.exists(USER_CONFIG):
+    # Use existing XDG-based directory layout
+    pass
+elif os.path.exists(HOME_DIR) or "GRAMPSHOME" in os.environ or "SAFEMODE" in os.environ:
     USER_DATA = HOME_DIR
     USER_CONFIG = HOME_DIR
     USER_CACHE = HOME_DIR
-else:
-    USER_DATA = os.path.join(GLib.get_user_data_dir(), "gramps")
-    USER_CONFIG = os.path.join(GLib.get_user_config_dir(), "gramps")
-    USER_CACHE = os.path.join(GLib.get_user_cache_dir(), "gramps")
 
 USER_PICTURES = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PICTURES)
 if not USER_PICTURES:


### PR DESCRIPTION
Fix [#13261](https://gramps-project.org/bugs/view.php?id=13261)

In an existing 5.2.x installation with XDG directory layout for data/config/cache, installing 5.1.x later would create a second config folder in the legacy layout, overriding the existing config.

This change makes it so that an existing configuration for 5.2.x will be given preference over the 5.1.x config. If there isn't one, previous logic will continue to be used.

Testing passed on Windows
1. Gramps 5.2.2 only
2. Gramps 5.2.2 followed by Gramps 5.1.6
3. Gramps 5.1.6 followed by Gramps 5.2.2
* Create family trees in each version of Gramps and ensure that they are available when that version is launched.
* Ensure that if 5.1.x is installed before 5.2.x, config is imported.

- [X] Testing on Windows
- [x] Testing on Linux
- [X] Testing on MacOS 
- [ ] Testing with GRAMPSHOME and SAFEMODE (cli?).

Thanks!