### PR TITLE
Prevent hyperlink tagging being added as an undo action

### DIFF
--- a/gramps/gui/widgets/undoablestyledbuffer.py
+++ b/gramps/gui/widgets/undoablestyledbuffer.py
@@ -112,6 +112,8 @@ class UndoableStyledBuffer(StyledTextBuffer):
             self.not_undoable_action = oldflag
 
     def on_tag_insert_undoable(self, buffer, tag, start, end):
+        if tag.get_property("name") == "hyperlink":
+            return
         if not self.undo_in_progress:
             self._empty_redo_stack()
         if self.not_undoable_action:


### PR DESCRIPTION
When the mouse hovers over a link in the note editor it is highlighted. This was stacked as an undoable action and as a result clicking the undo button sometimes had no noticeable effect.

Fixes [#13267](https://gramps-project.org/bugs/view.php?id=13267).