### PR TITLE
Fix error when changing the style of misspelt words

### DIFF
--- a/gramps/gui/widgets/styledtextbuffer.py
+++ b/gramps/gui/widgets/styledtextbuffer.py
@@ -492,7 +492,7 @@ class StyledTextBuffer(UndoableBuffer):
         start, end = self._get_selection()
         tags = self._get_tag_from_range(start.get_offset(), end.get_offset())
         for tag_name, tag_data in tags.items():
-            if tag_name.startswith(str(style)):
+            if tag_name is not None and tag_name.startswith(str(style)):
                 for start, end in tag_data:
                     self.remove_tag_by_name(
                         tag_name,


### PR DESCRIPTION
In the note editor, changing the style of text failing the spell check caused an error.  The style tag used by the spell checker to indicate spelling errors has no tag name.

Fixes [#13282](https://gramps-project.org/bugs/view.php?id=13282).