### PR TITLE
Fix some Glade deprecations

### DIFF
--- a/gramps/gui/editors/displaytabs/addrembedlist.py
+++ b/gramps/gui/editors/displaytabs/addrembedlist.py
@@ -97,7 +97,7 @@ class AddrEmbedList(EmbeddedList):
 
     def get_icon_name(self):
         """
-        Return the stock-id icon name associated with the display tab
+        Return the icon name associated with the display tab
         """
         return "gramps-address"
 

--- a/gramps/gui/editors/displaytabs/citationembedlist.py
+++ b/gramps/gui/editors/displaytabs/citationembedlist.py
@@ -124,7 +124,7 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
 
     def get_icon_name(self):
         """
-        Return the stock-id icon name associated with the display tab
+        Return the icon name associated with the display tab
         """
         return "gramps-source"
 

--- a/gramps/gui/editors/displaytabs/notetab.py
+++ b/gramps/gui/editors/displaytabs/notetab.py
@@ -213,7 +213,7 @@ class NoteTab(EmbeddedList, DbGUIElement):
 
     def get_icon_name(self):
         """
-        Return the stock-id icon name associated with the display tab
+        Return the icon name associated with the display tab
         """
         return "gramps-notes"
 

--- a/gramps/gui/glade/addmedia.glade
+++ b/gramps/gui/glade/addmedia.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="button81">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -36,7 +35,6 @@
             <child>
               <object class="GtkButton" id="button79">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -53,7 +51,6 @@
             <child>
               <object class="GtkButton" id="button103">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -212,7 +209,6 @@
                 <child>
                   <object class="GtkCheckButton" id="relpath">
                     <property name="label" translatable="yes">Convert to a relative path</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>

--- a/gramps/gui/glade/baseselector.glade
+++ b/gramps/gui/glade/baseselector.glade
@@ -23,7 +23,6 @@
             <child>
               <object class="GtkButton" id="cancelbutton1">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -39,7 +38,6 @@
             <child>
               <object class="GtkButton" id="okbutton1">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -55,7 +53,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -120,7 +117,6 @@
             <child>
               <object class="GtkCheckButton" id="showall">
                 <property name="label" translatable="yes">Show all</property>
-                <property name="use-action-appearance">False</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="no-show-all">True</property>

--- a/gramps/gui/glade/baseselector.glade
+++ b/gramps/gui/glade/baseselector.glade
@@ -126,7 +126,6 @@
                 <property name="no-show-all">True</property>
                 <property name="halign">center</property>
                 <property name="use-underline">True</property>
-                <property name="xalign">0.5</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>

--- a/gramps/gui/glade/book.glade
+++ b/gramps/gui/glade/book.glade
@@ -151,8 +151,8 @@
                   <object class="GtkLabel" id="title">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">12</property>
-                    <property name="margin-right">12</property>
+                    <property name="margin-start">12</property>
+                    <property name="margin-end">12</property>
                     <property name="margin-top">12</property>
                     <property name="margin-bottom">12</property>
                   </object>
@@ -174,8 +174,8 @@
                           <object class="GtkLabel" id="name_label">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="margin-left">12</property>
-                            <property name="margin-right">12</property>
+                            <property name="margin-start">12</property>
+                            <property name="margin-end">12</property>
                             <property name="label" translatable="yes">Book _name:</property>
                             <property name="use-underline">True</property>
                             <property name="mnemonic-widget">name_entry</property>
@@ -320,7 +320,7 @@
                   <object class="GtkGrid" id="table1">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">12</property>
+                    <property name="margin-start">12</property>
                     <child>
                       <object class="GtkLabel" id="avail_label">
                         <property name="visible">True</property>
@@ -391,7 +391,7 @@
                   <object class="GtkGrid" id="table2">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">12</property>
+                    <property name="margin-start">12</property>
                     <child>
                       <object class="GtkLabel" id="book_label">
                         <property name="visible">True</property>

--- a/gramps/gui/glade/clipboard.glade
+++ b/gramps/gui/glade/clipboard.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="helpbutton1">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -37,7 +36,6 @@
             <child>
               <object class="GtkButton" id="btn_clear_all">
                 <property name="label" translatable="yes">Clear _All</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -53,7 +51,6 @@
             <child>
               <object class="GtkButton" id="btn_clear">
                 <property name="label" translatable="yes">_Clear</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -70,7 +67,6 @@
             <child>
               <object class="GtkButton" id="btn_close">
                 <property name="label" translatable="yes">_Close</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/gui/glade/configure.glade
+++ b/gramps/gui/glade/configure.glade
@@ -134,8 +134,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">12</property>
-                        <property name="margin-right">12</property>
+                        <property name="margin-start">12</property>
+                        <property name="margin-end">12</property>
                         <property name="margin-top">6</property>
                         <property name="margin-bottom">6</property>
                         <property name="label" translatable="yes">The following conventions are used:

--- a/gramps/gui/glade/configure.glade
+++ b/gramps/gui/glade/configure.glade
@@ -21,7 +21,6 @@
             <child>
               <object class="GtkButton" id="cancelbutton2">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -37,7 +36,6 @@
             <child>
               <object class="GtkButton" id="okbutton2">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/gui/glade/dbman.glade
+++ b/gramps/gui/glade/dbman.glade
@@ -234,7 +234,7 @@
               <object class="GtkButtonBox" id="vbuttonbox2">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">12</property>
+                <property name="margin-start">12</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <property name="layout-style">start</property>

--- a/gramps/gui/glade/dbman.glade
+++ b/gramps/gui/glade/dbman.glade
@@ -22,7 +22,6 @@
             <child>
               <object class="GtkButton" id="okbutton3">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -132,7 +131,6 @@
             <child>
               <object class="GtkButton" id="cancel_btn">
                 <property name="label" translatable="yes">_Close Window</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -148,7 +146,6 @@
             <child>
               <object class="GtkButton" id="connect_btn">
                 <property name="label" translatable="yes">_Load Family Tree</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -164,7 +161,6 @@
             <child>
               <object class="GtkButton" id="help_btn">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -241,7 +237,6 @@
                 <child>
                   <object class="GtkButton" id="new_btn">
                     <property name="label" translatable="yes">_New</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>
@@ -272,7 +267,6 @@
                 <child>
                   <object class="GtkButton" id="remove_btn">
                     <property name="label" translatable="yes">_Delete</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>
@@ -288,7 +282,6 @@
                 <child>
                   <object class="GtkButton" id="rename_btn">
                     <property name="label" translatable="yes">_Rename</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>
@@ -304,7 +297,6 @@
                 <child>
                   <object class="GtkButton" id="close_btn">
                     <property name="label" translatable="yes">Close</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>
@@ -320,7 +312,6 @@
                 <child>
                   <object class="GtkButton" id="convert_btn">
                     <property name="label" translatable="yes">Con_vert</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>
@@ -336,7 +327,6 @@
                 <child>
                   <object class="GtkButton" id="repair_btn">
                     <property name="label" translatable="yes">Re_pair</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>
@@ -352,7 +342,6 @@
                 <child>
                   <object class="GtkButton" id="rcs_btn">
                     <property name="label" translatable="yes">_Archive</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>

--- a/gramps/gui/glade/dialog.glade
+++ b/gramps/gui/glade/dialog.glade
@@ -194,8 +194,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="use-markup">True</property>
                 <property name="wrap">True</property>
               </object>
@@ -344,8 +344,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="margin-top">24</property>
                 <property name="margin-bottom">24</property>
                 <property name="hexpand">True</property>
@@ -377,8 +377,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="hexpand">True</property>
                 <property name="use-markup">True</property>
                 <property name="wrap">True</property>
@@ -517,8 +517,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="margin-top">24</property>
                 <property name="margin-bottom">24</property>
                 <property name="hexpand">True</property>
@@ -550,8 +550,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="hexpand">True</property>
                 <property name="use-markup">True</property>
                 <property name="wrap">True</property>
@@ -667,8 +667,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="margin-top">12</property>
                 <property name="margin-bottom">12</property>
                 <property name="hexpand">True</property>
@@ -699,8 +699,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="hexpand">True</property>
                 <property name="use-markup">True</property>
                 <property name="wrap">True</property>
@@ -848,8 +848,8 @@
                   <object class="GtkLabel" id="qd_label2">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">6</property>
-                    <property name="margin-right">6</property>
+                    <property name="margin-start">6</property>
+                    <property name="margin-end">6</property>
                     <property name="margin-top">6</property>
                     <property name="margin-bottom">6</property>
                     <property name="label" translatable="yes">label</property>
@@ -964,8 +964,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="label" translatable="yes">label</property>
                 <property name="use-markup">True</property>
                 <property name="wrap">True</property>
@@ -994,8 +994,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="use-markup">True</property>
                 <property name="wrap">True</property>
               </object>

--- a/gramps/gui/glade/editattribute.glade
+++ b/gramps/gui/glade/editattribute.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -52,7 +50,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -131,7 +128,6 @@
                 </child>
                 <child>
                   <object class="GtkToggleButton" id="private">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/gui/glade/editchildref.glade
+++ b/gramps/gui/glade/editchildref.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -36,7 +35,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -56,7 +54,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -158,7 +155,6 @@
                 </child>
                 <child>
                   <object class="GtkToggleButton" id="private">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -222,7 +218,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="edit">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/gui/glade/editdate.glade
+++ b/gramps/gui/glade/editdate.glade
@@ -38,8 +38,8 @@
       <object class="GtkBox" id="vbox86">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="margin-left">12</property>
-        <property name="margin-right">12</property>
+        <property name="margin-start">12</property>
+        <property name="margin-end">12</property>
         <property name="vexpand">True</property>
         <property name="orientation">vertical</property>
         <property name="spacing">6</property>
@@ -136,7 +136,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">6</property>
+                        <property name="margin-start">6</property>
                         <property name="label" translatable="yes">Calenda_r:</property>
                         <property name="use-underline">True</property>
                         <property name="mnemonic-widget">calendar_box</property>
@@ -257,8 +257,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">6</property>
-                        <property name="margin-right">6</property>
+                        <property name="margin-start">6</property>
+                        <property name="margin-end">6</property>
                         <property name="label" translatable="yes">Q_uality</property>
                         <property name="use-underline">True</property>
                         <property name="mnemonic-widget">quality_box</property>
@@ -276,7 +276,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="events"/>
-                        <property name="margin-left">12</property>
+                        <property name="margin-start">12</property>
                         <property name="hexpand">True</property>
                       </object>
                       <packing>
@@ -289,8 +289,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">6</property>
-                        <property name="margin-right">6</property>
+                        <property name="margin-start">6</property>
+                        <property name="margin-end">6</property>
                         <property name="label" translatable="yes">_Type</property>
                         <property name="use-underline">True</property>
                         <property name="mnemonic-widget">type_box</property>
@@ -307,7 +307,7 @@
                       <object class="GtkComboBoxText" id="type_box">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">12</property>
+                        <property name="margin-start">12</property>
                         <property name="hexpand">True</property>
                       </object>
                       <packing>
@@ -320,8 +320,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">6</property>
-                        <property name="margin-right">6</property>
+                        <property name="margin-start">6</property>
+                        <property name="margin-end">6</property>
                         <property name="label" translatable="yes">Date</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
@@ -375,7 +375,7 @@
                       <object class="GtkSpinButton" id="start_day">
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
-                        <property name="margin-left">12</property>
+                        <property name="margin-start">12</property>
                         <property name="hexpand">True</property>
                         <property name="adjustment">adjustment1</property>
                         <property name="climb-rate">1</property>
@@ -416,8 +416,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">6</property>
-                        <property name="margin-right">6</property>
+                        <property name="margin-start">6</property>
+                        <property name="margin-end">6</property>
                         <property name="label" translatable="yes">Second date</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
@@ -471,7 +471,7 @@
                       <object class="GtkSpinButton" id="stop_day">
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
-                        <property name="margin-left">12</property>
+                        <property name="margin-start">12</property>
                         <property name="hexpand">True</property>
                         <property name="adjustment">adjustment3</property>
                         <property name="climb-rate">1</property>
@@ -559,7 +559,7 @@
                       <object class="GtkLabel" id="label415">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">6</property>
+                        <property name="margin-start">6</property>
                         <property name="label" translatable="yes">Te_xt comment:</property>
                         <property name="use-underline">True</property>
                         <property name="mnemonic-widget">date_text_entry</property>

--- a/gramps/gui/glade/editdate.glade
+++ b/gramps/gui/glade/editdate.glade
@@ -51,7 +51,6 @@
             <child>
               <object class="GtkButton" id="button174">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -67,7 +66,6 @@
             <child>
               <object class="GtkButton" id="button175">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -83,7 +81,6 @@
             <child>
               <object class="GtkButton" id="ok_button">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -193,7 +190,6 @@
                     <child>
                       <object class="GtkCheckButton" id="dualdated">
                         <property name="label" translatable="yes">Dua_l dated</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>

--- a/gramps/gui/glade/editevent.glade
+++ b/gramps/gui/glade/editevent.glade
@@ -415,7 +415,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
-                        <property name="margin-right">1</property>
+                        <property name="margin-end">1</property>
                         <property name="image-position">right</property>
                       </object>
                       <packing>

--- a/gramps/gui/glade/editeventref.glade
+++ b/gramps/gui/glade/editeventref.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -36,7 +35,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -52,7 +50,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -128,7 +125,6 @@
                 </child>
                 <child>
                   <object class="GtkToggleButton" id="eer_ref_priv">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -338,7 +334,6 @@
                         </child>
                         <child>
                           <object class="GtkButton" id="share_place">
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">True</property>
@@ -364,7 +359,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="add_del_place">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -383,7 +377,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="eer_date_stat">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -419,7 +412,6 @@
                     </child>
                     <child>
                       <object class="GtkToggleButton" id="eer_ev_priv">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>

--- a/gramps/gui/glade/editeventref.glade
+++ b/gramps/gui/glade/editeventref.glade
@@ -78,8 +78,8 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="halign">start</property>
-            <property name="margin-left">6</property>
-            <property name="margin-right">6</property>
+            <property name="margin-start">6</property>
+            <property name="margin-end">6</property>
             <property name="margin-top">3</property>
             <property name="margin-bottom">3</property>
             <property name="label" translatable="yes">Reference information</property>
@@ -509,7 +509,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
-                        <property name="margin-right">1</property>
+                        <property name="margin-end">1</property>
                         <property name="image-position">right</property>
                       </object>
                       <packing>

--- a/gramps/gui/glade/editfamily.glade
+++ b/gramps/gui/glade/editfamily.glade
@@ -115,7 +115,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin-left">6</property>
+                                <property name="margin-start">6</property>
                                 <property name="label" translatable="yes">Name:</property>
                               </object>
                               <packing>
@@ -128,7 +128,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin-left">6</property>
+                                <property name="margin-start">6</property>
                                 <property name="label" translatable="yes">Birth:</property>
                               </object>
                               <packing>
@@ -141,7 +141,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin-left">6</property>
+                                <property name="margin-start">6</property>
                                 <property name="label" translatable="yes">Death:</property>
                               </object>
                               <packing>
@@ -382,7 +382,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin-left">6</property>
+                                <property name="margin-start">6</property>
                                 <property name="label" translatable="yes">Name:</property>
                               </object>
                               <packing>
@@ -395,7 +395,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin-left">6</property>
+                                <property name="margin-start">6</property>
                                 <property name="label" translatable="yes">Birth:</property>
                               </object>
                               <packing>
@@ -408,7 +408,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin-left">6</property>
+                                <property name="margin-start">6</property>
                                 <property name="label" translatable="yes">Death:</property>
                               </object>
                               <packing>
@@ -693,7 +693,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">6</property>
+                        <property name="margin-start">6</property>
                         <property name="label" translatable="yes">_ID:</property>
                         <property name="use-underline">True</property>
                         <property name="mnemonic-widget">gid</property>
@@ -756,7 +756,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">6</property>
+                        <property name="margin-start">6</property>
                         <property name="label" translatable="yes">_Tags:</property>
                         <property name="use-underline">True</property>
                         <property name="mnemonic-widget">tag_button</property>

--- a/gramps/gui/glade/editfamily.glade
+++ b/gramps/gui/glade/editfamily.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -38,7 +37,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -58,7 +56,6 @@
             <child>
               <object class="GtkButton" id="button119">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -171,7 +168,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="fbutton_index">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -203,7 +199,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="fbutton_add">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -234,7 +229,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="fbutton_del">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -265,7 +259,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="fbutton_edit">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -462,7 +455,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="mbutton_index">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -493,7 +485,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="mbutton_add">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -524,7 +515,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkToggleButton" id="private">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -555,7 +545,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="mbutton_del">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -586,7 +575,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="mbutton_edit">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -784,7 +772,6 @@
                         </child>
                         <child>
                           <object class="GtkButton" id="tag_button">
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">True</property>

--- a/gramps/gui/glade/editldsord.glade
+++ b/gramps/gui/glade/editldsord.glade
@@ -37,7 +37,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -53,7 +52,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -73,7 +71,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -139,7 +136,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="date_stat">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -243,7 +239,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="parents_select">
-                    <property name="use-action-appearance">False</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
                     <property name="tooltip-text" translatable="yes">Select Family</property>
@@ -333,7 +328,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="share_place">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -359,7 +353,6 @@
                 </child>
                 <child>
                   <object class="GtkToggleButton" id="private">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -391,7 +384,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="add_del_place">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/gui/glade/editlink.glade
+++ b/gramps/gui/glade/editlink.glade
@@ -190,7 +190,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">12</property>
+                        <property name="margin-start">12</property>
                         <property name="hexpand">True</property>
                       </object>
                     </child>

--- a/gramps/gui/glade/editlink.glade
+++ b/gramps/gui/glade/editlink.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="button125">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -36,7 +35,6 @@
             <child>
               <object class="GtkButton" id="button124">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -56,7 +54,6 @@
             <child>
               <object class="GtkButton" id="button130">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -150,7 +147,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="button1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -207,7 +203,6 @@
                 <child>
                   <object class="GtkButton" id="new">
                     <property name="label" translatable="yes">_New</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -221,7 +216,6 @@
                 <child>
                   <object class="GtkButton" id="edit">
                     <property name="label" translatable="yes">_Edit</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/gui/glade/editlocation.glade
+++ b/gramps/gui/glade/editlocation.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="button119">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="button118">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -52,7 +50,6 @@
             <child>
               <object class="GtkButton" id="button128">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/gui/glade/editmedia.glade
+++ b/gramps/gui/glade/editmedia.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="button91">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -36,7 +35,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -53,7 +51,6 @@
             <child>
               <object class="GtkButton" id="button102">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -228,7 +225,6 @@ Gramps does not store the media internally, it only stores the path! Set the 'Re
                 </child>
                 <child>
                   <object class="GtkButton" id="date_edit">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -264,7 +260,6 @@ Gramps does not store the media internally, it only stores the path! Set the 'Re
                 </child>
                 <child>
                   <object class="GtkButton" id="file_select">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -311,7 +306,6 @@ Gramps does not store the media internally, it only stores the path! Set the 'Re
                 </child>
                 <child>
                   <object class="GtkToggleButton" id="private">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -385,7 +379,6 @@ Gramps does not store the media internally, it only stores the path! Set the 'Re
                     </child>
                     <child>
                       <object class="GtkButton" id="tag_button">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>

--- a/gramps/gui/glade/editname.glade
+++ b/gramps/gui/glade/editname.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="button119">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -38,7 +37,6 @@
             <child>
               <object class="GtkButton" id="button118">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -57,7 +55,6 @@
             <child>
               <object class="GtkButton" id="button131">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -132,7 +129,6 @@
                     </child>
                     <child>
                       <object class="GtkToggleButton" id="priv">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -574,7 +570,6 @@ Here you can make sure this person is sorted according to a custom name format (
                     </child>
                     <child>
                       <object class="GtkButton" id="date_stat">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -634,7 +629,6 @@ You will be asked if you want to group this person only, or all people with this
                         <child>
                           <object class="GtkCheckButton" id="group_over">
                             <property name="label" translatable="yes">O_verride</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/editname.glade
+++ b/gramps/gui/glade/editname.glade
@@ -97,8 +97,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">4</property>
-                        <property name="margin-right">4</property>
+                        <property name="margin-start">4</property>
+                        <property name="margin-end">4</property>
                         <property name="label" translatable="yes">_Type:</property>
                         <property name="use-underline">True</property>
                         <property name="justify">center</property>
@@ -182,7 +182,7 @@
                       <object class="GtkGrid" id="table2">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">12</property>
+                        <property name="margin-start">12</property>
                         <property name="row-spacing">6</property>
                         <property name="column-spacing">6</property>
                         <child>
@@ -373,8 +373,8 @@
                       <object class="GtkBox" id="vbox1">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">12</property>
-                        <property name="margin-right">12</property>
+                        <property name="margin-start">12</property>
+                        <property name="margin-end">12</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkBox" id="hboxmultsurnames">

--- a/gramps/gui/glade/editnote.glade
+++ b/gramps/gui/glade/editnote.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -189,7 +186,6 @@
                     <child>
                       <object class="GtkCheckButton" id="format">
                         <property name="label" translatable="yes">_Preformatted</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -210,7 +206,6 @@ Use monospace font to keep preformatting.</property>
                     </child>
                     <child>
                       <object class="GtkToggleButton" id="private">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -272,7 +267,6 @@ Use monospace font to keep preformatting.</property>
                         </child>
                         <child>
                           <object class="GtkButton" id="tag_button">
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">True</property>

--- a/gramps/gui/glade/editperson.glade
+++ b/gramps/gui/glade/editperson.glade
@@ -128,8 +128,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">3</property>
-                        <property name="margin-right">3</property>
+                        <property name="margin-start">3</property>
+                        <property name="margin-end">3</property>
                         <property name="margin-top">3</property>
                         <property name="margin-bottom">3</property>
                         <property name="label" translatable="yes">_Given:</property>
@@ -191,8 +191,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">3</property>
-                        <property name="margin-right">3</property>
+                        <property name="margin-start">3</property>
+                        <property name="margin-end">3</property>
                         <property name="margin-top">3</property>
                         <property name="margin-bottom">3</property>
                         <property name="label" translatable="yes">T_itle:</property>
@@ -241,8 +241,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">3</property>
-                        <property name="margin-right">3</property>
+                        <property name="margin-start">3</property>
+                        <property name="margin-end">3</property>
                         <property name="label" translatable="yes">_Nick:</property>
                         <property name="use-underline">True</property>
                         <property name="mnemonic-widget">nickname</property>
@@ -444,8 +444,8 @@ Indicate that the surname consists of different parts. Every surname has its own
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">6</property>
-                            <property name="margin-right">6</property>
+                            <property name="margin-start">6</property>
+                            <property name="margin-end">6</property>
                             <property name="margin-top">3</property>
                             <property name="margin-bottom">3</property>
                             <property name="label" translatable="yes">_Surname:</property>
@@ -581,8 +581,8 @@ Indicate that the surname consists of different parts. Every surname has its own
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">6</property>
-                            <property name="margin-right">6</property>
+                            <property name="margin-start">6</property>
+                            <property name="margin-end">6</property>
                             <property name="label" translatable="yes">G_ender:</property>
                             <property name="use-underline">True</property>
                             <property name="mnemonic-widget">gender</property>
@@ -646,8 +646,8 @@ Indicate that the surname consists of different parts. Every surname has its own
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">6</property>
-                            <property name="margin-right">6</property>
+                            <property name="margin-start">6</property>
+                            <property name="margin-end">6</property>
                             <property name="label" translatable="yes">_Tags:</property>
                             <property name="use-underline">True</property>
                             <property name="mnemonic-widget">tag_button</property>
@@ -721,8 +721,8 @@ Indicate that the surname consists of different parts. Every surname has its own
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">3</property>
-                        <property name="margin-right">3</property>
+                        <property name="margin-start">3</property>
+                        <property name="margin-end">3</property>
                         <property name="margin-top">3</property>
                         <property name="margin-bottom">3</property>
                         <property name="label" translatable="yes">_Type:</property>
@@ -740,8 +740,8 @@ Indicate that the surname consists of different parts. Every surname has its own
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">3</property>
-                        <property name="margin-right">3</property>
+                        <property name="margin-start">3</property>
+                        <property name="margin-end">3</property>
                         <property name="margin-top">3</property>
                         <property name="margin-bottom">3</property>
                         <property name="hexpand">True</property>

--- a/gramps/gui/glade/editperson.glade
+++ b/gramps/gui/glade/editperson.glade
@@ -43,7 +43,6 @@
             <child>
               <object class="GtkButton" id="button15">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -62,7 +61,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -80,7 +78,6 @@
             <child>
               <object class="GtkButton" id="button134">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -349,7 +346,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="multsurnamebtn">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -393,7 +389,6 @@ Indicate that the surname consists of different parts. Every surname has its own
                         </child>
                         <child>
                           <object class="GtkToggleButton" id="private">
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">True</property>
@@ -505,7 +500,6 @@ Indicate that the surname consists of different parts. Every surname has its own
                     </child>
                     <child>
                       <object class="GtkButton" id="editnamebtn">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -671,7 +665,6 @@ Indicate that the surname consists of different parts. Every surname has its own
                         </child>
                         <child>
                           <object class="GtkButton" id="tag_button">
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">True</property>

--- a/gramps/gui/glade/editpersonref.glade
+++ b/gramps/gui/glade/editpersonref.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -55,7 +53,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -156,7 +153,6 @@ Note: Use Events instead for relations connected to specific time frames or occa
                 </child>
                 <child>
                   <object class="GtkButton" id="select">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -190,7 +186,6 @@ Note: Use Events instead for relations connected to specific time frames or occa
                 </child>
                 <child>
                   <object class="GtkToggleButton" id="private">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -222,7 +217,6 @@ Note: Use Events instead for relations connected to specific time frames or occa
                 </child>
                 <child>
                   <object class="GtkButton" id="add_del">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/gui/glade/editplaceref.glade
+++ b/gramps/gui/glade/editplaceref.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -37,7 +36,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -53,7 +51,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/gui/glade/editplaceref.glade
+++ b/gramps/gui/glade/editplaceref.glade
@@ -79,8 +79,8 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="halign">start</property>
-            <property name="margin-left">6</property>
-            <property name="margin-right">6</property>
+            <property name="margin-start">6</property>
+            <property name="margin-end">6</property>
             <property name="margin-top">3</property>
             <property name="margin-bottom">3</property>
             <property name="label" translatable="yes">Reference information</property>

--- a/gramps/gui/glade/editreporef.glade
+++ b/gramps/gui/glade/editreporef.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -39,7 +38,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -59,7 +57,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -172,7 +169,6 @@
                     </child>
                     <child>
                       <object class="GtkToggleButton" id="private_ref">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -391,7 +387,6 @@
                             </child>
                             <child>
                               <object class="GtkToggleButton" id="private">
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">True</property>

--- a/gramps/gui/glade/editreporef.glade
+++ b/gramps/gui/glade/editreporef.glade
@@ -90,8 +90,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="margin-top">3</property>
                 <property name="margin-bottom">3</property>
                 <property name="label" translatable="yes">Reference information</property>

--- a/gramps/gui/glade/editurl.glade
+++ b/gramps/gui/glade/editurl.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="button125">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="button124">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -55,7 +53,6 @@
             <child>
               <object class="GtkButton" id="button130">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -135,7 +132,6 @@
                 </child>
                 <child>
                   <object class="GtkToggleButton" id="priv">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -199,7 +195,6 @@
                 <child>
                   <object class="GtkButton" id="jump">
                     <property name="label" translatable="yes">_Jump to</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/gui/glade/grampletpane.glade
+++ b/gramps/gui/glade/grampletpane.glade
@@ -54,7 +54,6 @@
                 <property name="can-focus">False</property>
                 <child>
                   <object class="GtkButton" id="gvproperties">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -87,7 +86,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="gvstate">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -120,7 +118,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="gvclose">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -154,7 +151,6 @@
                 <child>
                   <object class="GtkButton" id="gvtitle">
                     <property name="label" translatable="yes">Gramplet</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/gui/glade/mergecitation.glade
+++ b/gramps/gui/glade/mergecitation.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="citation_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="citation_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="citation_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -110,7 +107,6 @@ primary data for the merged citation.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -133,7 +129,6 @@ primary data for the merged citation.</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -211,7 +206,6 @@ primary data for the merged citation.</property>
                         <child>
                           <object class="GtkRadioButton" id="page_btn1">
                             <property name="label" translatable="yes">Volume/Page:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -227,7 +221,6 @@ primary data for the merged citation.</property>
                         <child>
                           <object class="GtkRadioButton" id="page_btn2">
                             <property name="label" translatable="yes">Volume/Page:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -244,7 +237,6 @@ primary data for the merged citation.</property>
                         <child>
                           <object class="GtkRadioButton" id="date_btn1">
                             <property name="label" translatable="yes">Date:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -260,7 +252,6 @@ primary data for the merged citation.</property>
                         <child>
                           <object class="GtkRadioButton" id="date_btn2">
                             <property name="label" translatable="yes">Date:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -277,7 +268,6 @@ primary data for the merged citation.</property>
                         <child>
                           <object class="GtkRadioButton" id="confidence_btn1">
                             <property name="label" translatable="yes">Confidence:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -293,7 +283,6 @@ primary data for the merged citation.</property>
                         <child>
                           <object class="GtkRadioButton" id="confidence_btn2">
                             <property name="label" translatable="yes">Confidence:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -310,7 +299,6 @@ primary data for the merged citation.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn1">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -326,7 +314,6 @@ primary data for the merged citation.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn2">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/mergedata.glade
+++ b/gramps/gui/glade/mergedata.glade
@@ -23,7 +23,6 @@
             <child>
               <object class="GtkButton" id="merge_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -40,7 +39,6 @@
             <child>
               <object class="GtkButton" id="edit">
                 <property name="label" translatable="yes">Merge and _edit</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">True</property>
@@ -58,7 +56,6 @@
             <child>
               <object class="GtkButton" id="close">
                 <property name="label" translatable="yes">_Merge and close</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -75,7 +72,6 @@
             <child>
               <object class="GtkButton" id="merge_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -172,7 +168,6 @@
                 <child>
                   <object class="GtkRadioButton" id="select2">
                     <property name="label" translatable="yes">Select</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -188,7 +183,6 @@
                 <child>
                   <object class="GtkRadioButton" id="select1">
                     <property name="label" translatable="yes">Select</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -260,7 +254,6 @@
             <child>
               <object class="GtkButton" id="button15">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -276,7 +269,6 @@
             <child>
               <object class="GtkButton" id="button16">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -292,7 +284,6 @@
             <child>
               <object class="GtkButton" id="people_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -378,7 +369,6 @@
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="person1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -394,7 +384,6 @@
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="person2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -464,7 +453,6 @@
             <child>
               <object class="GtkButton" id="place_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -481,7 +469,6 @@
             <child>
               <object class="GtkButton" id="place_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -498,7 +485,6 @@
             <child>
               <object class="GtkButton" id="place_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -607,7 +593,6 @@
                 <child>
                   <object class="GtkRadioButton" id="place1">
                     <property name="label" translatable="yes">Place 1</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -624,7 +609,6 @@
                 <child>
                   <object class="GtkRadioButton" id="place2">
                     <property name="label" translatable="yes">Place 2</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -641,7 +625,6 @@
                 <child>
                   <object class="GtkRadioButton" id="place3">
                     <property name="label" translatable="yes">Other</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -709,7 +692,6 @@
             <child>
               <object class="GtkButton" id="source_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -725,7 +707,6 @@
             <child>
               <object class="GtkButton" id="source_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -741,7 +722,6 @@
             <child>
               <object class="GtkButton" id="source_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -803,7 +783,6 @@
             <child>
               <object class="GtkRadioButton" id="title_btn1">
                 <property name="label" translatable="yes">Title:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -819,7 +798,6 @@
             <child>
               <object class="GtkRadioButton" id="title_btn2">
                 <property name="label" translatable="yes">Title:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -836,7 +814,6 @@
             <child>
               <object class="GtkRadioButton" id="author_btn1">
                 <property name="label" translatable="yes">Author:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -852,7 +829,6 @@
             <child>
               <object class="GtkRadioButton" id="radiobutton4">
                 <property name="label" translatable="yes">Author:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -869,7 +845,6 @@
             <child>
               <object class="GtkRadioButton" id="abbrev_btn1">
                 <property name="label" translatable="yes">Abbreviation:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -885,7 +860,6 @@
             <child>
               <object class="GtkRadioButton" id="abbrev_btn2">
                 <property name="label" translatable="yes">Abbreviation:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -902,7 +876,6 @@
             <child>
               <object class="GtkRadioButton" id="pub_btn1">
                 <property name="label" translatable="yes">Publication:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -918,7 +891,6 @@
             <child>
               <object class="GtkRadioButton" id="pub_btn2">
                 <property name="label" translatable="yes">Publication:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -935,7 +907,6 @@
             <child>
               <object class="GtkRadioButton" id="gramps_btn1">
                 <property name="label" translatable="yes">Gramps ID:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -951,7 +922,6 @@
             <child>
               <object class="GtkRadioButton" id="gramps_btn2">
                 <property name="label" translatable="yes">Gramps ID:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>

--- a/gramps/gui/glade/mergeevent.glade
+++ b/gramps/gui/glade/mergeevent.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="event_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="event_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="event_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -110,7 +107,6 @@ primary data for the merged event.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -133,7 +129,6 @@ primary data for the merged event.</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -211,7 +206,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="type_btn1">
                             <property name="label" translatable="yes">Type:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -227,7 +221,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="type_btn2">
                             <property name="label" translatable="yes">Type:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -244,7 +237,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="date_btn1">
                             <property name="label" translatable="yes">Date:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -260,7 +252,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="date_btn2">
                             <property name="label" translatable="yes">Date:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -277,7 +268,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="place_btn1">
                             <property name="label" translatable="yes">Place:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -293,7 +283,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="place_btn2">
                             <property name="label" translatable="yes">Place:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -310,7 +299,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="desc_btn1">
                             <property name="label" translatable="yes">Description:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -326,7 +314,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="desc_btn2">
                             <property name="label" translatable="yes">Description:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -343,7 +330,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn1">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -359,7 +345,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn2">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/mergefamily.glade
+++ b/gramps/gui/glade/mergefamily.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="family_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="family_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="family_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -111,7 +108,6 @@ primary data for the merged family.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -135,7 +131,6 @@ primary data for the merged family.</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -186,7 +181,6 @@ primary data for the merged family.</property>
                         <child>
                           <object class="GtkRadioButton" id="father_btn1">
                             <property name="label" translatable="yes">Father:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -202,7 +196,6 @@ primary data for the merged family.</property>
                         <child>
                           <object class="GtkRadioButton" id="father_btn2">
                             <property name="label" translatable="yes">Father:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -219,7 +212,6 @@ primary data for the merged family.</property>
                         <child>
                           <object class="GtkRadioButton" id="mother_btn1">
                             <property name="label" translatable="yes">Mother:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -235,7 +227,6 @@ primary data for the merged family.</property>
                         <child>
                           <object class="GtkRadioButton" id="mother_btn2">
                             <property name="label" translatable="yes">Mother:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -252,7 +243,6 @@ primary data for the merged family.</property>
                         <child>
                           <object class="GtkRadioButton" id="rel_btn1">
                             <property name="label" translatable="yes">Relationship:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -268,7 +258,6 @@ primary data for the merged family.</property>
                         <child>
                           <object class="GtkRadioButton" id="rel_btn2">
                             <property name="label" translatable="yes">Relationship:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -285,7 +274,6 @@ primary data for the merged family.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn1">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -301,7 +289,6 @@ primary data for the merged family.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn2">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/mergemedia.glade
+++ b/gramps/gui/glade/mergemedia.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="object_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="object_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="object_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -110,7 +107,6 @@ primary data for the merged object.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -133,7 +129,6 @@ primary data for the merged object.</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -211,7 +206,6 @@ primary data for the merged object.</property>
                         <child>
                           <object class="GtkRadioButton" id="desc_btn1">
                             <property name="label" translatable="yes">Title:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -227,7 +221,6 @@ primary data for the merged object.</property>
                         <child>
                           <object class="GtkRadioButton" id="desc_btn2">
                             <property name="label" translatable="yes">Title:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -244,7 +237,6 @@ primary data for the merged object.</property>
                         <child>
                           <object class="GtkRadioButton" id="path_btn1">
                             <property name="label" translatable="yes">Path:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -260,7 +252,6 @@ primary data for the merged object.</property>
                         <child>
                           <object class="GtkRadioButton" id="path_btn2">
                             <property name="label" translatable="yes">Path:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -277,7 +268,6 @@ primary data for the merged object.</property>
                         <child>
                           <object class="GtkRadioButton" id="date_btn1">
                             <property name="label" translatable="yes">Date:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -293,7 +283,6 @@ primary data for the merged object.</property>
                         <child>
                           <object class="GtkRadioButton" id="date_btn2">
                             <property name="label" translatable="yes">Date:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -310,7 +299,6 @@ primary data for the merged object.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn1">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -326,7 +314,6 @@ primary data for the merged object.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn2">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/mergenote.glade
+++ b/gramps/gui/glade/mergenote.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="note_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="note_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="note_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -110,7 +107,6 @@ primary data for the merged note.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -133,7 +129,6 @@ primary data for the merged note.</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -211,7 +206,6 @@ primary data for the merged note.</property>
                         <child>
                           <object class="GtkRadioButton" id="text_btn1">
                             <property name="label" translatable="yes">Text:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -227,7 +221,6 @@ primary data for the merged note.</property>
                         <child>
                           <object class="GtkRadioButton" id="text_btn2">
                             <property name="label" translatable="yes">Text:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -244,7 +237,6 @@ primary data for the merged note.</property>
                         <child>
                           <object class="GtkRadioButton" id="type_btn1">
                             <property name="label" translatable="yes">Type:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -260,7 +252,6 @@ primary data for the merged note.</property>
                         <child>
                           <object class="GtkRadioButton" id="type_btn2">
                             <property name="label" translatable="yes">Type:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -277,7 +268,6 @@ primary data for the merged note.</property>
                         <child>
                           <object class="GtkRadioButton" id="format_btn1">
                             <property name="label" translatable="yes">Format:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -293,7 +283,6 @@ primary data for the merged note.</property>
                         <child>
                           <object class="GtkRadioButton" id="format_btn2">
                             <property name="label" translatable="yes">Format:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -310,7 +299,6 @@ primary data for the merged note.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn1">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -326,7 +314,6 @@ primary data for the merged note.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn2">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/mergeperson.glade
+++ b/gramps/gui/glade/mergeperson.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="person_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="person_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="person_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -116,7 +113,6 @@ primary data for the merged person.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -141,7 +137,6 @@ primary data for the merged person.</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -221,7 +216,6 @@ primary data for the merged person.</property>
                         <child>
                           <object class="GtkRadioButton" id="name_btn1">
                             <property name="label" translatable="yes">Name:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -237,7 +231,6 @@ primary data for the merged person.</property>
                         <child>
                           <object class="GtkRadioButton" id="name_btn2">
                             <property name="label" translatable="yes">Name:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -254,7 +247,6 @@ primary data for the merged person.</property>
                         <child>
                           <object class="GtkRadioButton" id="gender_btn1">
                             <property name="label" translatable="yes">Gender:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -270,7 +262,6 @@ primary data for the merged person.</property>
                         <child>
                           <object class="GtkRadioButton" id="gender_btn2">
                             <property name="label" translatable="yes">Gender:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -287,7 +278,6 @@ primary data for the merged person.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn1">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -303,7 +293,6 @@ primary data for the merged person.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn2">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/mergerepository.glade
+++ b/gramps/gui/glade/mergerepository.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="repository_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="repository_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="repository_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -110,7 +107,6 @@ primary data for the merged repository.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -133,7 +129,6 @@ primary data for the merged repository.</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -211,7 +206,6 @@ primary data for the merged repository.</property>
                         <child>
                           <object class="GtkRadioButton" id="name_btn1">
                             <property name="label" translatable="yes" context="repo">Name:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -227,7 +221,6 @@ primary data for the merged repository.</property>
                         <child>
                           <object class="GtkRadioButton" id="name_btn2">
                             <property name="label" translatable="yes" context="repo">Name:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -244,7 +237,6 @@ primary data for the merged repository.</property>
                         <child>
                           <object class="GtkRadioButton" id="type_btn1">
                             <property name="label" translatable="yes">Type:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -260,7 +252,6 @@ primary data for the merged repository.</property>
                         <child>
                           <object class="GtkRadioButton" id="type_btn2">
                             <property name="label" translatable="yes">Type:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -277,7 +268,6 @@ primary data for the merged repository.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn1">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -293,7 +283,6 @@ primary data for the merged repository.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn2">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/mergesource.glade
+++ b/gramps/gui/glade/mergesource.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="source_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="source_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="source_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -110,7 +107,6 @@ primary data for the merged source.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -133,7 +129,6 @@ primary data for the merged source.</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -211,7 +206,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="title_btn1">
                             <property name="label" translatable="yes">Title:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -227,7 +221,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="title_btn2">
                             <property name="label" translatable="yes">Title:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -244,7 +237,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="author_btn1">
                             <property name="label" translatable="yes">Author:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -260,7 +252,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="author_btn2">
                             <property name="label" translatable="yes">Author:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -277,7 +268,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="abbrev_btn1">
                             <property name="label" translatable="yes">Abbreviation:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -293,7 +283,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="abbrev_btn2">
                             <property name="label" translatable="yes">Abbreviation:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -310,7 +299,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="pub_btn1">
                             <property name="label" translatable="yes">Publication:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -326,7 +314,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="pub_btn2">
                             <property name="label" translatable="yes">Publication:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -343,7 +330,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn1">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -359,7 +345,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn2">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/papermenu.glade
+++ b/gramps/gui/glade/papermenu.glade
@@ -35,7 +35,7 @@
               <object class="GtkGrid" id="format_grid">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">12</property>
+                <property name="margin-start">12</property>
                 <property name="border-width">6</property>
                 <property name="row-spacing">6</property>
                 <property name="column-spacing">6</property>
@@ -192,7 +192,7 @@
               <object class="GtkGrid" id="table3">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">12</property>
+                <property name="margin-start">12</property>
                 <property name="border-width">6</property>
                 <property name="row-spacing">6</property>
                 <property name="column-spacing">6</property>

--- a/gramps/gui/glade/papermenu.glade
+++ b/gramps/gui/glade/papermenu.glade
@@ -377,7 +377,6 @@
             <child>
               <object class="GtkCheckButton" id="metric">
                 <property name="label" translatable="yes">Metric</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>

--- a/gramps/gui/glade/plugins.glade
+++ b/gramps/gui/glade/plugins.glade
@@ -105,8 +105,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">10</property>
-                        <property name="margin-right">10</property>
+                        <property name="margin-start">10</property>
+                        <property name="margin-end">10</property>
                         <property name="margin-top">10</property>
                         <property name="margin-bottom">10</property>
                         <property name="use-markup">True</property>
@@ -132,8 +132,8 @@
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
                     <property name="valign">start</property>
-                    <property name="margin-left">10</property>
-                    <property name="margin-right">10</property>
+                    <property name="margin-start">10</property>
+                    <property name="margin-end">10</property>
                     <property name="margin-top">20</property>
                     <property name="margin-bottom">20</property>
                     <property name="label" translatable="yes">Select a report from those available on the left.</property>
@@ -154,8 +154,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">end</property>
-                        <property name="margin-left">6</property>
-                        <property name="margin-right">6</property>
+                        <property name="margin-start">6</property>
+                        <property name="margin-end">6</property>
                         <property name="margin-top">3</property>
                         <property name="margin-bottom">3</property>
                         <property name="label" translatable="yes">Status:</property>
@@ -171,8 +171,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">5</property>
-                        <property name="margin-right">5</property>
+                        <property name="margin-start">5</property>
+                        <property name="margin-end">5</property>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
@@ -184,8 +184,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">end</property>
-                        <property name="margin-left">6</property>
-                        <property name="margin-right">6</property>
+                        <property name="margin-start">6</property>
+                        <property name="margin-end">6</property>
                         <property name="margin-top">3</property>
                         <property name="margin-bottom">3</property>
                         <property name="label" translatable="yes">Author:</property>
@@ -200,8 +200,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">end</property>
-                        <property name="margin-left">6</property>
-                        <property name="margin-right">6</property>
+                        <property name="margin-start">6</property>
+                        <property name="margin-end">6</property>
                         <property name="margin-top">3</property>
                         <property name="margin-bottom">3</property>
                         <property name="label" translatable="yes">Author's email:</property>
@@ -216,8 +216,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">5</property>
-                        <property name="margin-right">5</property>
+                        <property name="margin-start">5</property>
+                        <property name="margin-end">5</property>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
@@ -229,8 +229,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">5</property>
-                        <property name="margin-right">5</property>
+                        <property name="margin-start">5</property>
+                        <property name="margin-end">5</property>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>

--- a/gramps/gui/glade/plugins.glade
+++ b/gramps/gui/glade/plugins.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="button108">
                 <property name="label" translatable="yes">_Close</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -36,7 +35,6 @@
             </child>
             <child>
               <object class="GtkButton" id="apply">
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/gui/glade/reorder.glade
+++ b/gramps/gui/glade/reorder.glade
@@ -172,7 +172,7 @@
               <object class="GtkScrolledWindow" id="scrolledwindow86">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
-                <property name="margin-left">6</property>
+                <property name="margin-start">6</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
                 <property name="shadow-type">in</property>
@@ -210,7 +210,7 @@
               <object class="GtkScrolledWindow" id="scrolledwindow87">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
-                <property name="margin-left">6</property>
+                <property name="margin-start">6</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
                 <property name="shadow-type">in</property>

--- a/gramps/gui/glade/reorder.glade
+++ b/gramps/gui/glade/reorder.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -101,7 +98,6 @@
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkButton" id="pup">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -131,7 +127,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="pdown">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -236,7 +231,6 @@
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkButton" id="fup">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -266,7 +260,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="fdown">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/gui/glade/rule.glade
+++ b/gramps/gui/glade/rule.glade
@@ -915,7 +915,6 @@
                         <property name="label" translatable="yes">No rule selected</property>
                         <property name="wrap">True</property>
                         <property name="width-chars">40</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -951,7 +950,6 @@
                         <property name="label" translatable="yes">No description</property>
                         <property name="wrap">True</property>
                         <property name="width-chars">40</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/gramps/gui/glade/rule.glade
+++ b/gramps/gui/glade/rule.glade
@@ -22,7 +22,6 @@
             <child>
               <object class="GtkButton" id="filter_list_close">
                 <property name="label" translatable="yes">_Close</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -39,7 +38,6 @@
             <child>
               <object class="GtkButton" id="filter_list_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -114,7 +112,6 @@
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkButton" id="filter_list_add">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="can-default">True</property>
@@ -137,7 +134,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="filter_list_edit">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
                         <property name="can-focus">True</property>
@@ -161,7 +157,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="filter_list_clone">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
                         <property name="can-focus">True</property>
@@ -185,7 +180,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="filter_list_test">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -207,7 +201,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="filter_list_delete">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
                         <property name="can-focus">True</property>
@@ -314,7 +307,6 @@
             <child>
               <object class="GtkButton" id="definition_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -331,7 +323,6 @@
             <child>
               <object class="GtkButton" id="definition_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">True</property>
@@ -349,7 +340,6 @@
             <child>
               <object class="GtkButton" id="definition_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -406,7 +396,6 @@
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkButton" id="definition_add">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="can-default">True</property>
@@ -439,7 +428,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="definition_edit">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
                         <property name="can-focus">True</property>
@@ -473,7 +461,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="definition_delete">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
                         <property name="can-focus">True</property>
@@ -602,7 +589,6 @@
                 <child>
                   <object class="GtkCheckButton" id="logical_not">
                     <property name="label" translatable="yes">Return values that do no_t match the filter rules</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -746,7 +732,6 @@
             <child>
               <object class="GtkButton" id="rule_editor_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -763,7 +748,6 @@
             <child>
               <object class="GtkButton" id="rule_editor_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -780,7 +764,6 @@
             <child>
               <object class="GtkButton" id="rule_editor_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -1021,7 +1004,6 @@
             <child>
               <object class="GtkButton" id="test_close">
                 <property name="label" translatable="yes">_Close</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/gui/glade/rule.glade
+++ b/gramps/gui/glade/rule.glade
@@ -251,8 +251,8 @@
               <object class="GtkLabel" id="label30">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="label" translatable="yes">Note: changes take effect only after this window is closed</property>
                 <attributes>
                   <attribute name="style" value="italic"/>
@@ -564,8 +564,8 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
-                    <property name="margin-left">6</property>
-                    <property name="margin-right">6</property>
+                    <property name="margin-start">6</property>
+                    <property name="margin-end">6</property>
                     <property name="label" translatable="yes">Co_mment:</property>
                     <property name="use-underline">True</property>
                     <property name="mnemonic-widget">comment</property>
@@ -579,7 +579,7 @@
                   <object class="GtkScrolledWindow" id="scrolledwindow1">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">6</property>
+                    <property name="margin-start">6</property>
                     <property name="shadow-type">in</property>
                     <child>
                       <object class="PersistentTreeView" id="rule_list">
@@ -607,7 +607,7 @@
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="halign">center</property>
-                    <property name="margin-left">6</property>
+                    <property name="margin-start">6</property>
                     <property name="use-underline">True</property>
                     <property name="draw-indicator">True</property>
                   </object>
@@ -621,7 +621,7 @@
                   <object class="GtkComboBox" id="rule_apply">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">6</property>
+                    <property name="margin-start">6</property>
                     <property name="model">model1</property>
                     <child>
                       <object class="GtkCellRendererText" id="renderer1"/>
@@ -652,8 +652,8 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
-                    <property name="margin-left">6</property>
-                    <property name="margin-right">6</property>
+                    <property name="margin-start">6</property>
+                    <property name="margin-end">6</property>
                     <property name="label" translatable="yes">_Name:</property>
                     <property name="use-underline">True</property>
                     <property name="mnemonic-widget">filter_name</property>
@@ -910,8 +910,8 @@
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="valign">start</property>
-                        <property name="margin-left">12</property>
-                        <property name="margin-right">12</property>
+                        <property name="margin-start">12</property>
+                        <property name="margin-end">12</property>
                         <property name="label" translatable="yes">No rule selected</property>
                         <property name="wrap">True</property>
                         <property name="width-chars">40</property>
@@ -946,8 +946,8 @@
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="valign">start</property>
-                        <property name="margin-left">12</property>
-                        <property name="margin-right">12</property>
+                        <property name="margin-start">12</property>
+                        <property name="margin-end">12</property>
                         <property name="label" translatable="yes">No description</property>
                         <property name="wrap">True</property>
                         <property name="width-chars">40</property>

--- a/gramps/gui/glade/styleeditor.glade
+++ b/gramps/gui/glade/styleeditor.glade
@@ -84,7 +84,6 @@
             <child>
               <object class="GtkButton" id="button8">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -101,7 +100,6 @@
             <child>
               <object class="GtkButton" id="button7">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -314,7 +312,6 @@
                         <child>
                           <object class="GtkRadioButton" id="roman">
                             <property name="label" translatable="yes">_Roman (Times, serif)</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -331,7 +328,6 @@
                         <child>
                           <object class="GtkRadioButton" id="swiss">
                             <property name="label" translatable="yes">_Swiss (Arial, Helvetica, sans-serif)</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -431,7 +427,6 @@
                         <child>
                           <object class="GtkCheckButton" id="bold">
                             <property name="label" translatable="yes">_Bold</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -448,7 +443,6 @@
                         <child>
                           <object class="GtkCheckButton" id="italic">
                             <property name="label" translatable="yes">_Italic</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -465,7 +459,6 @@
                         <child>
                           <object class="GtkCheckButton" id="underline">
                             <property name="label" translatable="yes">_Underline</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -493,7 +486,6 @@
                         </child>
                         <child>
                           <object class="GtkColorButton" id="color">
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -954,7 +946,6 @@
                         </child>
                         <child>
                           <object class="GtkColorButton" id="bgcolor">
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -973,7 +964,6 @@
                             <child>
                               <object class="GtkRadioButton" id="lalign">
                                 <property name="label" translatable="yes">_Left</property>
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
@@ -991,7 +981,6 @@
                             <child>
                               <object class="GtkRadioButton" id="ralign">
                                 <property name="label" translatable="yes">_Right</property>
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
@@ -1009,7 +998,6 @@
                             <child>
                               <object class="GtkRadioButton" id="jalign">
                                 <property name="label" translatable="yes">J_ustify</property>
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
@@ -1027,7 +1015,6 @@
                             <child>
                               <object class="GtkRadioButton" id="calign">
                                 <property name="label" translatable="yes">Cen_ter</property>
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
@@ -1057,7 +1044,6 @@
                             <child>
                               <object class="GtkCheckButton" id="lborder">
                                 <property name="label" translatable="yes">Le_ft</property>
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
@@ -1075,7 +1061,6 @@
                             <child>
                               <object class="GtkCheckButton" id="rborder">
                                 <property name="label" translatable="yes">Righ_t</property>
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
@@ -1092,7 +1077,6 @@
                             <child>
                               <object class="GtkCheckButton" id="tborder">
                                 <property name="label" translatable="yes">_Top</property>
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
@@ -1109,7 +1093,6 @@
                             <child>
                               <object class="GtkCheckButton" id="bborder">
                                 <property name="label" translatable="yes">_Bottom</property>
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
@@ -1785,7 +1768,6 @@
             <child>
               <object class="GtkButton" id="button2">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -1802,7 +1784,6 @@
             <child>
               <object class="GtkButton" id="button1">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -1898,7 +1879,6 @@
                     <property name="layout-style">start</property>
                     <child>
                       <object class="GtkButton" id="button3">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -1930,7 +1910,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="button4">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -1962,7 +1941,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="button5">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>

--- a/gramps/gui/glade/styleeditor.glade
+++ b/gramps/gui/glade/styleeditor.glade
@@ -149,8 +149,8 @@
               <object class="GtkLabel" id="title1">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
-                <property name="margin-right">5</property>
+                <property name="margin-start">5</property>
+                <property name="margin-end">5</property>
                 <property name="margin-top">5</property>
                 <property name="margin-bottom">5</property>
                 <property name="use-markup">True</property>
@@ -319,7 +319,7 @@
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
                           </object>
@@ -336,7 +336,7 @@
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
                             <property name="group">roman</property>
@@ -368,7 +368,7 @@
                           <object class="GtkSpinButton" id="size">
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="adjustment">adjustment7</property>
                             <property name="climb-rate">1</property>
                             <property name="numeric">True</property>
@@ -436,7 +436,7 @@
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
                           </object>
@@ -453,7 +453,7 @@
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
                           </object>
@@ -470,7 +470,7 @@
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
                           </object>
@@ -497,7 +497,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
@@ -634,7 +634,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">First li_ne:</property>
                             <property name="use-underline">True</property>
                             <property name="justify">center</property>
@@ -689,7 +689,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">R_ight:</property>
                             <property name="use-underline">True</property>
                             <property name="justify">center</property>
@@ -705,7 +705,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">L_eft:</property>
                             <property name="use-underline">True</property>
                             <property name="justify">center</property>
@@ -740,7 +740,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">Abo_ve:</property>
                             <property name="use-underline">True</property>
                             <property name="justify">center</property>
@@ -756,7 +756,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">Belo_w:</property>
                             <property name="use-underline">True</property>
                             <property name="justify">center</property>
@@ -887,7 +887,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">_Padding:</property>
                             <property name="use-underline">True</property>
                             <property name="justify">center</property>
@@ -958,7 +958,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
@@ -978,7 +978,7 @@
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
                                 <property name="halign">center</property>
-                                <property name="margin-left">12</property>
+                                <property name="margin-start">12</property>
                                 <property name="use-underline">True</property>
                                 <property name="draw-indicator">True</property>
                               </object>
@@ -1062,7 +1062,7 @@
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
                                 <property name="halign">center</property>
-                                <property name="margin-left">12</property>
+                                <property name="margin-start">12</property>
                                 <property name="use-underline">True</property>
                                 <property name="draw-indicator">True</property>
                               </object>
@@ -1224,7 +1224,7 @@
                           <object class="GtkBox" id="column_widths">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <placeholder/>
@@ -1239,7 +1239,7 @@
                           <object class="GtkSpinButton" id="table_width">
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="shadow-type">etched-out</property>
                             <property name="adjustment">adjustment8</property>
                             <property name="numeric">True</property>
@@ -1348,7 +1348,7 @@
                           <object class="GtkLabel" id="label29">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">Padding:</property>
                           </object>
                           <packing>
@@ -1379,7 +1379,7 @@
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin-left">12</property>
+                                <property name="margin-start">12</property>
                                 <property name="draw-indicator">True</property>
                               </object>
                               <packing>
@@ -1514,7 +1514,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">Style:</property>
                           </object>
                           <packing>
@@ -1527,7 +1527,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">Width:</property>
                           </object>
                           <packing>
@@ -1540,7 +1540,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">Line:</property>
                           </object>
                           <packing>
@@ -1553,7 +1553,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">Fill:</property>
                           </object>
                           <packing>
@@ -1667,7 +1667,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">Spacing:</property>
                           </object>
                           <packing>

--- a/gramps/gui/glade/styleeditor.glade
+++ b/gramps/gui/glade/styleeditor.glade
@@ -118,11 +118,11 @@
             </child>
             <child>
               <object class="GtkButton" id="help_btn">
-                <property name="label">gtk-help</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_btn_style_clicked" swapped="no"/>
               </object>
               <packing>
@@ -1819,11 +1819,11 @@
             </child>
             <child>
               <object class="GtkButton" id="help_btn_styles">
-                <property name="label">gtk-help</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_btn_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gramps/gui/glade/tipofday.glade
+++ b/gramps/gui/glade/tipofday.glade
@@ -60,8 +60,8 @@
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
                 <property name="valign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="margin-top">6</property>
                 <property name="margin-bottom">6</property>
                 <property name="hexpand">True</property>

--- a/gramps/gui/glade/updateaddons.glade
+++ b/gramps/gui/glade/updateaddons.glade
@@ -23,7 +23,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Close</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
@@ -39,7 +38,6 @@
             <child>
               <object class="GtkButton" id="apply">
                 <property name="label" translatable="yes">Install Selected _Addons</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
@@ -103,7 +101,6 @@
                 <child>
                   <object class="GtkButton" id="select_all">
                     <property name="label" translatable="yes">_Select All</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -118,7 +115,6 @@
                 <child>
                   <object class="GtkButton" id="select_none">
                     <property name="label" translatable="yes">Select _None</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/plugins/docgen/gtkprint.glade
+++ b/gramps/plugins/docgen/gtkprint.glade
@@ -130,7 +130,6 @@
             </child>
             <child>
               <object class="GtkToolItem" id="toolitem1">
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <child>

--- a/gramps/plugins/docgen/gtkprint.glade
+++ b/gramps/plugins/docgen/gtkprint.glade
@@ -22,11 +22,11 @@
             <property name="toolbar-style">icons</property>
             <child>
               <object class="GtkToolButton" id="quit">
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Quit</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Closes print preview window</property>
-                <property name="stock-id">gtk-quit</property>
                 <signal name="clicked" handler="on_quit_clicked" swapped="no"/>
               </object>
               <packing>
@@ -36,11 +36,11 @@
             </child>
             <child>
               <object class="GtkToolButton" id="print">
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Print</property>
+                <property name="use-underline">1</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Prints the current file</property>
-                <property name="stock-id">gtk-print</property>
                 <signal name="clicked" handler="on_print_clicked" swapped="no"/>
               </object>
               <packing>
@@ -60,13 +60,12 @@
             </child>
             <child>
               <object class="GtkToolButton" id="first">
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_First</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Shows the first page</property>
-                <property name="is-important">True</property>
-                <property name="stock-id">gtk-goto-first</property>
                 <signal name="clicked" handler="on_first_clicked" swapped="no"/>
               </object>
               <packing>
@@ -76,13 +75,12 @@
             </child>
             <child>
               <object class="GtkToolButton" id="prev">
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Back</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Shows previous page</property>
-                <property name="is-important">True</property>
-                <property name="stock-id">gtk-go-back</property>
                 <signal name="clicked" handler="on_prev_clicked" swapped="no"/>
               </object>
               <packing>
@@ -92,13 +90,12 @@
             </child>
             <child>
               <object class="GtkToolButton" id="next">
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Forward</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Shows the next page</property>
-                <property name="is-important">True</property>
-                <property name="stock-id">gtk-go-forward</property>
                 <signal name="clicked" handler="on_next_clicked" swapped="no"/>
               </object>
               <packing>
@@ -108,13 +105,12 @@
             </child>
             <child>
               <object class="GtkToolButton" id="last">
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Last</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Shows the last page</property>
-                <property name="is-important">True</property>
-                <property name="stock-id">gtk-goto-last</property>
                 <signal name="clicked" handler="on_last_clicked" swapped="no"/>
               </object>
               <packing>
@@ -189,7 +185,7 @@
             </child>
             <child>
               <object class="GtkToggleToolButton" id="zoom_fit_width">
-                <property name="use-action-appearance">False</property>
+                <property name="icon-name">gramps-zoom-fit-width</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Zooms to fit the page width</property>
@@ -203,11 +199,10 @@
             </child>
             <child>
               <object class="GtkToggleToolButton" id="zoom_best_fit">
-                <property name="use-action-appearance">False</property>
+                <property name="icon-name">gramps-zoom-best-fit</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Zooms to fit the whole page</property>
-                <property name="stock-id">gtk-zoom-fit</property>
                 <signal name="toggled" handler="on_zoom_best_fit_toggled" swapped="no"/>
               </object>
               <packing>
@@ -217,11 +212,10 @@
             </child>
             <child>
               <object class="GtkToolButton" id="zoom_in">
-                <property name="use-action-appearance">False</property>
+                <property name="icon-name">gramps-zoom-in</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Zooms the page in</property>
-                <property name="stock-id">gtk-zoom-in</property>
                 <signal name="clicked" handler="on_zoom_in_clicked" swapped="no"/>
               </object>
               <packing>
@@ -231,11 +225,10 @@
             </child>
             <child>
               <object class="GtkToolButton" id="zoom_out">
-                <property name="use-action-appearance">False</property>
+                <property name="icon-name">gramps-zoom-out</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Zooms the page out</property>
-                <property name="stock-id">gtk-zoom-out</property>
                 <signal name="clicked" handler="on_zoom_out_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gramps/plugins/docgen/gtkprint.py
+++ b/gramps/plugins/docgen/gtkprint.py
@@ -211,13 +211,9 @@ class PrintPreview:
         self._pages_entry = glade_xml.get_object("entry")
         self._pages_label = glade_xml.get_object("label")
         self._zoom_fit_width_button = glade_xml.get_object("zoom_fit_width")
-        self._zoom_fit_width_button.set_stock_id("gramps-zoom-fit-width")
         self._zoom_best_fit_button = glade_xml.get_object("zoom_best_fit")
-        self._zoom_best_fit_button.set_stock_id("gramps-zoom-best-fit")
         self._zoom_in_button = glade_xml.get_object("zoom_in")
-        self._zoom_in_button.set_stock_id("gramps-zoom-in")
         self._zoom_out_button = glade_xml.get_object("zoom_out")
-        self._zoom_out_button.set_stock_id("gramps-zoom-out")
 
         # connect the signals
         glade_xml.connect_signals(self)

--- a/gramps/plugins/importer/importgedcom.glade
+++ b/gramps/plugins/importer/importgedcom.glade
@@ -43,13 +43,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="okbutton1">
-                <property name="label">gtk-ok</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_OK</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/gramps/plugins/importer/importgedcom.glade
+++ b/gramps/plugins/importer/importgedcom.glade
@@ -90,8 +90,8 @@
               <object class="GtkLabel" id="label18">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="margin-top">6</property>
                 <property name="margin-bottom">6</property>
                 <property name="label" translatable="yes">This GEDCOM file has identified itself as using ANSEL encoding. Sometimes, this is in error. If the imported data contains unusual characters, undo the import, and override the character set by selecting a different encoding below.</property>

--- a/gramps/plugins/importer/importprogen.glade
+++ b/gramps/plugins/importer/importprogen.glade
@@ -156,8 +156,8 @@
                       <object class="GtkImage" id="imp_source_priv_img">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">5</property>
-                        <property name="margin-right">5</property>
+                        <property name="margin-start">5</property>
+                        <property name="margin-end">5</property>
                         <property name="icon-name">dialog-password</property>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="imp_source_priv_img-atkobject">
@@ -280,8 +280,8 @@
                       <object class="GtkImage" id="imp_citation_priv_img">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">5</property>
-                        <property name="margin-right">5</property>
+                        <property name="margin-start">5</property>
+                        <property name="margin-end">5</property>
                         <property name="icon-name">dialog-password</property>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="imp_citation_priv_img-atkobject">
@@ -306,7 +306,7 @@
                   <object class="GtkLabel" id="imp_citation_conf_lbl">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-right">2</property>
+                    <property name="margin-end">2</property>
                     <property name="label" translatable="yes">Confidence</property>
                   </object>
                   <packing>
@@ -438,8 +438,8 @@
                         <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="valign">center</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">2</property>
                         <property name="label" translatable="yes">Text</property>
                       </object>
                       <packing>
@@ -454,7 +454,7 @@
                         <property name="can-focus">True</property>
                         <property name="tooltip-text" translatable="yes">Default Tagtext
 (out of Settings).</property>
-                        <property name="margin-right">4</property>
+                        <property name="margin-end">4</property>
                         <property name="hexpand">True</property>
                       </object>
                       <packing>
@@ -467,7 +467,7 @@
                       <object class="GtkLabel" id="tag_default_fname_lbl">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-end">2</property>
                         <property name="label" translatable="yes">File</property>
                       </object>
                       <packing>
@@ -481,7 +481,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="tooltip-text" translatable="yes">Import Filename.</property>
-                        <property name="margin-right">4</property>
+                        <property name="margin-end">4</property>
                         <property name="width-chars">13</property>
                       </object>
                       <packing>
@@ -494,7 +494,7 @@
                       <object class="GtkLabel" id="tag_default_date_lbl">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-end">2</property>
                         <property name="label" translatable="yes">Date</property>
                       </object>
                       <packing>
@@ -752,7 +752,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-end">2</property>
                         <property name="label" translatable="yes">Citation</property>
                       </object>
                       <packing>
@@ -1194,7 +1194,7 @@ all object tags.</property>
                   <object class="GtkGrid" id="primobj_grid">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">4</property>
+                    <property name="margin-start">4</property>
                     <property name="resize-mode">queue</property>
                     <property name="column-spacing">4</property>
                     <child>
@@ -1296,7 +1296,7 @@ Child import.</property>
                   <object class="GtkGrid" id="option_grid">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">4</property>
+                    <property name="margin-start">4</property>
                     <property name="resize-mode">queue</property>
                     <property name="column-spacing">4</property>
                     <child>
@@ -1351,8 +1351,8 @@ Identifier as Gramps ID.</property>
                       <object class="GtkSeparator" id="opt_sep11">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">8</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">8</property>
                         <property name="orientation">vertical</property>
                       </object>
                       <packing>
@@ -1379,8 +1379,8 @@ Identifier as Gramps ID.</property>
                       <object class="GtkSeparator" id="opt_sep21">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">8</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">8</property>
                         <property name="orientation">vertical</property>
                       </object>
                       <packing>
@@ -1392,8 +1392,8 @@ Identifier as Gramps ID.</property>
                       <object class="GtkSeparator" id="opt_sep22">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">8</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">8</property>
                         <property name="orientation">vertical</property>
                       </object>
                       <packing>
@@ -1405,8 +1405,8 @@ Identifier as Gramps ID.</property>
                       <object class="GtkSeparator" id="opt_sep23">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">8</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">8</property>
                         <property name="orientation">vertical</property>
                       </object>
                       <packing>
@@ -1515,8 +1515,8 @@ as cause of death event.</property>
                       <object class="GtkSeparator" id="opt_sep32">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">8</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">8</property>
                         <property name="orientation">vertical</property>
                       </object>
                       <packing>
@@ -1528,8 +1528,8 @@ as cause of death event.</property>
                       <object class="GtkSeparator" id="opt_sep31">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">8</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">8</property>
                         <property name="orientation">vertical</property>
                       </object>
                       <packing>
@@ -1591,8 +1591,8 @@ to e.g. husbands name.</property>
                       <object class="GtkSeparator" id="opt_sep13">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">8</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">8</property>
                         <property name="orientation">vertical</property>
                       </object>
                       <packing>
@@ -1604,8 +1604,8 @@ to e.g. husbands name.</property>
                       <object class="GtkSeparator" id="opt_sep12">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">8</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">8</property>
                         <property name="orientation">vertical</property>
                       </object>
                       <packing>

--- a/gramps/plugins/importer/importprogen.glade
+++ b/gramps/plugins/importer/importprogen.glade
@@ -26,7 +26,6 @@
             <child>
               <object class="GtkButton" id="import_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="is-focus">True</property>
@@ -43,7 +42,6 @@
             <child>
               <object class="GtkButton" id="import_ok">
                 <property name="label" translatable="yes">_Ok</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="is-focus">True</property>
@@ -61,7 +59,6 @@
             <child>
               <object class="GtkButton" id="import_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -516,7 +513,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="tag_default_date_btn">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>

--- a/gramps/plugins/importer/importprogen.glade
+++ b/gramps/plugins/importer/importprogen.glade
@@ -136,7 +136,6 @@
 (out of Settings)</property>
                     <property name="halign">start</property>
                     <property name="resize-mode">queue</property>
-                    <property name="xalign">0</property>
                     <property name="draw-indicator">True</property>
                     <signal name="toggled" handler="on_source_button_toggled" swapped="no"/>
                   </object>
@@ -244,7 +243,6 @@
                     <property name="receives-default">False</property>
                     <property name="tooltip-text" translatable="yes">Citation reference.</property>
                     <property name="halign">start</property>
-                    <property name="xalign">0</property>
                     <property name="draw-indicator">True</property>
                     <signal name="toggled" handler="on_citation_button_toggled" swapped="no"/>
                   </object>
@@ -587,7 +585,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
                       </object>
@@ -602,7 +599,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
                       </object>
@@ -617,7 +613,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
                       </object>
@@ -632,7 +627,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
                       </object>
@@ -647,7 +641,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
                       </object>
@@ -662,7 +655,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
                       </object>
@@ -677,7 +669,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
                       </object>
@@ -869,7 +860,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_fname_button_toggled" swapped="no"/>
                       </object>
@@ -884,7 +874,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_fname_button_toggled" swapped="no"/>
                       </object>
@@ -899,7 +888,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_fname_button_toggled" swapped="no"/>
                       </object>
@@ -914,7 +902,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_fname_button_toggled" swapped="no"/>
                       </object>
@@ -929,7 +916,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_fname_button_toggled" swapped="no"/>
                       </object>
@@ -944,7 +930,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_fname_button_toggled" swapped="no"/>
                       </object>
@@ -959,7 +944,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_fname_button_toggled" swapped="no"/>
                       </object>
@@ -974,7 +958,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_date_button_toggled" swapped="no"/>
                       </object>
@@ -989,7 +972,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_date_button_toggled" swapped="no"/>
                       </object>
@@ -1004,7 +986,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_date_button_toggled" swapped="no"/>
                       </object>
@@ -1019,7 +1000,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_date_button_toggled" swapped="no"/>
                       </object>
@@ -1034,7 +1014,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_date_button_toggled" swapped="no"/>
                       </object>
@@ -1049,7 +1028,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_date_button_toggled" swapped="no"/>
                       </object>
@@ -1064,7 +1042,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_date_button_toggled" swapped="no"/>
                       </object>
@@ -1205,7 +1182,7 @@ all object tags.</property>
                         <property name="receives-default">False</property>
                         <property name="tooltip-text" translatable="yes">Enable/Disable
 Person import.</property>
-                        <property name="xalign">0</property>
+                        <property name="halign">start</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_primobj_button_toggled" swapped="no"/>
                       </object>
@@ -1222,7 +1199,7 @@ Person import.</property>
                         <property name="receives-default">False</property>
                         <property name="tooltip-text" translatable="yes">Enable/Disable
 Family import.</property>
-                        <property name="xalign">0</property>
+                        <property name="halign">start</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_primobj_button_toggled" swapped="no"/>
                       </object>
@@ -1239,7 +1216,7 @@ Family import.</property>
                         <property name="receives-default">False</property>
                         <property name="tooltip-text" translatable="yes">Enable/Disable
 Child import.</property>
-                        <property name="xalign">0</property>
+                        <property name="halign">start</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_primobj_button_toggled" swapped="no"/>
                       </object>
@@ -1308,7 +1285,6 @@ Child import.</property>
                         <property name="tooltip-text" translatable="yes">Use original Person
 Identifier as Gramps ID.</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -1325,7 +1301,6 @@ Identifier as Gramps ID.</property>
                         <property name="tooltip-text" translatable="yes">Use original Family
 Identifier as Gramps ID.</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -1438,7 +1413,6 @@ Identifier as Gramps ID.</property>
                         <property name="tooltip-text" translatable="yes">Store birth date in
 event description.</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -1456,7 +1430,6 @@ event description.</property>
                         <property name="tooltip-text" translatable="yes">Store death date in
 event description.</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -1487,7 +1460,6 @@ event description.</property>
                         <property name="tooltip-text" translatable="yes">Store REFN number
 in event description.</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -1503,7 +1475,6 @@ in event description.</property>
                         <property name="tooltip-text" translatable="yes">Use death information
 as cause of death event.</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -1561,7 +1532,7 @@ as cause of death event.</property>
                         <property name="receives-default">False</property>
                         <property name="tooltip-text" translatable="yes">Change name of male
 to e.g. wifes name.</property>
-                        <property name="xalign">0</property>
+                        <property name="halign">start</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_surname_button_toggled" swapped="no"/>
                       </object>
@@ -1578,7 +1549,7 @@ to e.g. wifes name.</property>
                         <property name="receives-default">False</property>
                         <property name="tooltip-text" translatable="yes">Change name of female
 to e.g. husbands name.</property>
-                        <property name="xalign">0</property>
+                        <property name="halign">start</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_surname_button_toggled" swapped="no"/>
                       </object>

--- a/gramps/plugins/tool/changenames.glade
+++ b/gramps/plugins/tool/changenames.glade
@@ -69,13 +69,12 @@ Select the names you wish Gramps to convert. </property>
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="help">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>
@@ -86,13 +85,12 @@ Select the names you wish Gramps to convert. </property>
             </child>
             <child>
               <object class="GtkButton" id="button6">
-                <property name="label">gtk-cancel</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Cancel</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="changenames" swapped="yes"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/changenames.glade
+++ b/gramps/plugins/tool/changenames.glade
@@ -102,7 +102,6 @@ Select the names you wish Gramps to convert. </property>
             <child>
               <object class="GtkButton" id="button5">
                 <property name="label" translatable="yes">_Accept changes and close</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/plugins/tool/changetypes.glade
+++ b/gramps/plugins/tool/changetypes.glade
@@ -19,13 +19,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button5">
-                <property name="label">gtk-cancel</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Cancel</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_close_clicked" object="changetypes" swapped="yes"/>
               </object>
               <packing>
@@ -36,13 +35,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button3">
-                <property name="label">gtk-ok</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_OK</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_apply_clicked" object="changetypes" swapped="yes"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/changetypes.glade
+++ b/gramps/plugins/tool/changetypes.glade
@@ -83,8 +83,8 @@
               <object class="GtkLabel" id="label4">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">12</property>
-                <property name="margin-right">12</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
                 <property name="margin-top">12</property>
                 <property name="margin-bottom">12</property>
                 <property name="label" translatable="yes">This tool will rename all events of one type to a different type. Once completed, this cannot be undone by the regular Undo function.</property>

--- a/gramps/plugins/tool/check.glade
+++ b/gramps/plugins/tool/check.glade
@@ -18,13 +18,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="close">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="check" swapped="yes"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/eventcmp.glade
+++ b/gramps/plugins/tool/eventcmp.glade
@@ -243,8 +243,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">end</property>
-                <property name="margin-left">5</property>
-                <property name="margin-right">5</property>
+                <property name="margin-start">5</property>
+                <property name="margin-end">5</property>
                 <property name="label" translatable="yes">_Filter:</property>
                 <property name="use-underline">True</property>
                 <property name="justify">center</property>

--- a/gramps/plugins/tool/eventcmp.glade
+++ b/gramps/plugins/tool/eventcmp.glade
@@ -18,13 +18,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button21">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="eventcmp" swapped="yes"/>
               </object>
               <packing>
@@ -35,13 +34,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button19">
-                <property name="label">gtk-save-as</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">Save _As</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_write_table" object="eventcmp" swapped="yes"/>
               </object>
               <packing>
@@ -52,13 +50,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button30">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>
@@ -173,13 +170,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button27">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="filters" swapped="yes"/>
               </object>
               <packing>
@@ -190,13 +186,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button26">
-                <property name="label">gtk-apply</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Apply</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_apply_clicked" object="filters" swapped="yes"/>
               </object>
               <packing>
@@ -207,13 +202,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button29">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/eventcmp.glade
+++ b/gramps/plugins/tool/eventcmp.glade
@@ -264,7 +264,6 @@
             <child>
               <object class="GtkButton" id="button28">
                 <property name="label" translatable="yes">Custom filter _editor</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>

--- a/gramps/plugins/tool/finddupes.glade
+++ b/gramps/plugins/tool/finddupes.glade
@@ -148,7 +148,7 @@
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="halign">center</property>
-                    <property name="margin-left">12</property>
+                    <property name="margin-start">12</property>
                     <property name="hexpand">True</property>
                     <property name="use-underline">True</property>
                     <property name="xalign">0.5</property>
@@ -164,7 +164,7 @@
                   <object class="GtkComboBox" id="menu">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">12</property>
+                    <property name="margin-start">12</property>
                     <property name="hexpand">True</property>
                     <property name="model">liststore1</property>
                     <child>

--- a/gramps/plugins/tool/finddupes.glade
+++ b/gramps/plugins/tool/finddupes.glade
@@ -25,13 +25,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button12">
-                <property name="label">gtk-cancel</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Cancel</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="finddupes" swapped="yes"/>
               </object>
               <packing>
@@ -42,13 +41,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button10">
-                <property name="label">gtk-ok</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_OK</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_merge_ok_clicked" object="finddupes" swapped="yes"/>
               </object>
               <packing>
@@ -59,13 +57,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button14">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>
@@ -243,13 +240,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button9">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="mergelist" swapped="yes"/>
               </object>
               <packing>
@@ -277,13 +273,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button13">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_show_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/finddupes.glade
+++ b/gramps/plugins/tool/finddupes.glade
@@ -151,7 +151,6 @@
                     <property name="margin-start">12</property>
                     <property name="hexpand">True</property>
                     <property name="use-underline">True</property>
-                    <property name="xalign">0.5</property>
                     <property name="active">True</property>
                     <property name="draw-indicator">True</property>
                   </object>

--- a/gramps/plugins/tool/finddupes.glade
+++ b/gramps/plugins/tool/finddupes.glade
@@ -140,7 +140,6 @@
                 <child>
                   <object class="GtkCheckButton" id="soundex">
                     <property name="label" translatable="yes">Use soundex codes</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -257,7 +256,6 @@
             <child>
               <object class="GtkButton" id="button7">
                 <property name="label" translatable="yes">Co_mpare</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/plugins/tool/findloop.glade
+++ b/gramps/plugins/tool/findloop.glade
@@ -20,13 +20,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="close">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" swapped="yes"/>
               </object>
               <packing>
@@ -37,13 +36,12 @@
             </child>
             <child>
               <object class="GtkButton" id="helpbutton1">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/mergecitations.glade
+++ b/gramps/plugins/tool/mergecitations.glade
@@ -140,7 +140,6 @@
                 <child>
                   <object class="GtkCheckButton" id="notes">
                     <property name="label" translatable="yes">Don't merge if citation has notes</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>

--- a/gramps/plugins/tool/mergecitations.glade
+++ b/gramps/plugins/tool/mergecitations.glade
@@ -148,7 +148,7 @@
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="halign">center</property>
-                    <property name="margin-left">12</property>
+                    <property name="margin-start">12</property>
                     <property name="hexpand">True</property>
                     <property name="use-underline">True</property>
                     <property name="xalign">0.5</property>
@@ -164,7 +164,7 @@
                   <object class="GtkComboBox" id="menu">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">12</property>
+                    <property name="margin-start">12</property>
                     <property name="hexpand">True</property>
                     <property name="model">liststore1</property>
                     <child>

--- a/gramps/plugins/tool/mergecitations.glade
+++ b/gramps/plugins/tool/mergecitations.glade
@@ -151,7 +151,6 @@
                     <property name="margin-start">12</property>
                     <property name="hexpand">True</property>
                     <property name="use-underline">True</property>
-                    <property name="xalign">0.5</property>
                     <property name="active">True</property>
                     <property name="draw-indicator">True</property>
                   </object>

--- a/gramps/plugins/tool/mergecitations.glade
+++ b/gramps/plugins/tool/mergecitations.glade
@@ -25,13 +25,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button12">
-                <property name="label">gtk-cancel</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Cancel</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="mergecitations" swapped="yes"/>
               </object>
               <packing>
@@ -42,13 +41,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button10">
-                <property name="label">gtk-ok</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_OK</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_merge_ok_clicked" object="mergecitations" swapped="yes"/>
               </object>
               <packing>
@@ -59,13 +57,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button14">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/notrelated.glade
+++ b/gramps/plugins/tool/notrelated.glade
@@ -18,13 +18,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="close">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="notrelated" swapped="yes"/>
               </object>
               <packing>
@@ -35,13 +34,12 @@
             </child>
             <child>
               <object class="GtkButton" id="help">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>
@@ -140,12 +138,11 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="tagapply">
-                    <property name="label">gtk-apply</property>
-                    <property name="use-action-appearance">False</property>
+                    <property name="label" translatable="1">_Apply</property>
+                    <property name="use-underline">1</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
-                    <property name="use-stock">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/gramps/plugins/tool/ownereditor.glade
+++ b/gramps/plugins/tool/ownereditor.glade
@@ -18,13 +18,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="cancel_button">
-                <property name="label">gtk-cancel</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Cancel</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_cancel_button_clicked" swapped="no"/>
               </object>
               <packing>
@@ -35,13 +34,12 @@
             </child>
             <child>
               <object class="GtkButton" id="ok_button">
-                <property name="label">gtk-ok</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_OK</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_ok_button_clicked" swapped="no"/>
               </object>
               <packing>
@@ -52,13 +50,12 @@
             </child>
             <child>
               <object class="GtkButton" id="help_button">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_button_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/patchnames.glade
+++ b/gramps/plugins/tool/patchnames.glade
@@ -50,7 +50,6 @@
             </child>
             <child>
               <object class="GtkButton" id="button5">
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/plugins/tool/patchnames.glade
+++ b/gramps/plugins/tool/patchnames.glade
@@ -18,13 +18,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="helpbutton1">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>
@@ -35,13 +34,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button6">
-                <property name="label">gtk-cancel</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Cancel</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="patchnames" swapped="yes"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/relcalc.glade
+++ b/gramps/plugins/tool/relcalc.glade
@@ -19,13 +19,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button5">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -35,11 +34,11 @@
             </child>
             <child>
               <object class="GtkButton" id="help_btn">
-                <property name="label">gtk-help</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>

--- a/gramps/plugins/tool/removespaces.glade
+++ b/gramps/plugins/tool/removespaces.glade
@@ -74,7 +74,6 @@
                 <property name="height-request">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="double-buffered">False</property>
                 <property name="justify">center</property>
                 <property name="ellipsize">start</property>
               </object>

--- a/gramps/plugins/tool/removespaces.glade
+++ b/gramps/plugins/tool/removespaces.glade
@@ -20,14 +20,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="close">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
-                <property name="image-position">right</property>
-                <property name="always-show-image">True</property>
                 <signal name="clicked" handler="destroy_passed_object" swapped="yes"/>
               </object>
               <packing>
@@ -39,13 +37,12 @@
             </child>
             <child>
               <object class="GtkButton" id="helpbutton1">
-                <property name="label">gtk-help</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
-                <property name="always-show-image">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/removeunused.glade
+++ b/gramps/plugins/tool/removeunused.glade
@@ -88,7 +88,6 @@
                     <child>
                       <object class="GtkCheckButton" id="events_box">
                         <property name="label" translatable="yes">Search for events</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -105,7 +104,6 @@
                     <child>
                       <object class="GtkCheckButton" id="sources_box">
                         <property name="label" translatable="yes">Search for sources</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -137,7 +135,6 @@
                     <child>
                       <object class="GtkCheckButton" id="places_box">
                         <property name="label" translatable="yes">Search for places</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -154,7 +151,6 @@
                     <child>
                       <object class="GtkCheckButton" id="media_box">
                         <property name="label" translatable="yes">Search for media</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -171,7 +167,6 @@
                     <child>
                       <object class="GtkCheckButton" id="repos_box">
                         <property name="label" translatable="yes">Search for repositories</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -188,7 +183,6 @@
                     <child>
                       <object class="GtkCheckButton" id="notes_box">
                         <property name="label" translatable="yes">Search for notes</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -276,7 +270,6 @@
                 <child>
                   <object class="GtkButton" id="mark_button">
                     <property name="label" translatable="yes">_Mark all</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>
@@ -292,7 +285,6 @@
                 <child>
                   <object class="GtkButton" id="unmark_button">
                     <property name="label" translatable="yes">_Unmark all</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>
@@ -308,7 +300,6 @@
                 <child>
                   <object class="GtkButton" id="invert_button">
                     <property name="label" translatable="yes">In_vert marks</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>

--- a/gramps/plugins/tool/removeunused.glade
+++ b/gramps/plugins/tool/removeunused.glade
@@ -96,7 +96,6 @@
                         <property name="receives-default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0.5</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -114,7 +113,6 @@
                         <property name="receives-default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0.5</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -129,7 +127,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
-                        <property name="xalign">0</property>
+                        <property name="halign">start</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -147,7 +145,6 @@
                         <property name="receives-default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0.5</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -165,7 +162,6 @@
                         <property name="receives-default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0.5</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -183,7 +179,6 @@
                         <property name="receives-default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0.5</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -201,7 +196,6 @@
                         <property name="receives-default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0.5</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>

--- a/gramps/plugins/tool/removeunused.glade
+++ b/gramps/plugins/tool/removeunused.glade
@@ -17,13 +17,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="remove_button">
-                <property name="label">gtk-delete</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Delete</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_remove_button_clicked" swapped="no"/>
               </object>
               <packing>
@@ -34,13 +33,12 @@
             </child>
             <child>
               <object class="GtkButton" id="closebutton1">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" swapped="no"/>
               </object>
               <packing>
@@ -218,13 +216,12 @@
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <child>
                       <object class="GtkButton" id="find_button">
-                        <property name="label">gtk-find</property>
-                        <property name="use-action-appearance">False</property>
+                        <property name="label" translatable="1">_Find</property>
+                        <property name="use-underline">1</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="use-stock">True</property>
                         <signal name="clicked" handler="on_find_button_clicked" swapped="no"/>
                       </object>
                       <packing>

--- a/gramps/plugins/tool/reorderids.glade
+++ b/gramps/plugins/tool/reorderids.glade
@@ -178,14 +178,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="reorder_cancel">
-                <property name="label">gtk-cancel</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Cancel</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="is-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-underline">True</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_cancel_button_clicked" swapped="no"/>
               </object>
               <packing>
@@ -196,14 +194,12 @@
             </child>
             <child>
               <object class="GtkButton" id="reorder_ok">
-                <property name="label">gtk-ok</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_OK</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-underline">True</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_ok_button_clicked" swapped="no"/>
               </object>
               <packing>
@@ -214,14 +210,12 @@
             </child>
             <child>
               <object class="GtkButton" id="reorder_help">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-underline">True</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_button_clicked" swapped="no"/>
               </object>
               <packing>
@@ -876,7 +870,6 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="resize-mode">queue</property>
                 <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
@@ -1456,7 +1449,6 @@
                 <property name="focus-on-click">False</property>
                 <property name="receives-default">True</property>
                 <property name="tooltip-text" translatable="yes">Enable ID reordering with Start / Step sequence.</property>
-                <property name="resize-mode">immediate</property>
                 <property name="relief">none</property>
                 <signal name="clicked" handler="on_change_button_clicked" swapped="no"/>
               </object>

--- a/gramps/plugins/tool/reorderids.glade
+++ b/gramps/plugins/tool/reorderids.glade
@@ -122,7 +122,6 @@
                 <property name="tooltip-text" translatable="yes">If you check this button, your next answer will apply to the rest of the selected items</property>
                 <property name="halign">center</property>
                 <property name="use-underline">True</property>
-                <property name="xalign">0.5</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -878,7 +877,7 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="resize-mode">queue</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -893,7 +892,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -908,7 +907,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -923,7 +922,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -938,7 +937,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -953,7 +952,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -968,7 +967,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -983,7 +982,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -998,7 +997,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -1141,7 +1140,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1156,7 +1154,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1171,7 +1168,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1186,7 +1182,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1201,7 +1196,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1216,7 +1210,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1231,7 +1224,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1246,7 +1238,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1261,7 +1252,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1275,7 +1265,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>
@@ -1290,7 +1279,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>
@@ -1305,7 +1293,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>
@@ -1320,7 +1307,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>
@@ -1335,7 +1321,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>
@@ -1350,7 +1335,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>
@@ -1365,7 +1349,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>
@@ -1380,7 +1363,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>
@@ -1395,7 +1377,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>

--- a/gramps/plugins/tool/reorderids.glade
+++ b/gramps/plugins/tool/reorderids.glade
@@ -69,8 +69,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="margin-top">24</property>
                 <property name="margin-bottom">24</property>
                 <property name="hexpand">True</property>
@@ -102,8 +102,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="hexpand">True</property>
                 <property name="use-markup">True</property>
                 <property name="wrap">True</property>

--- a/gramps/plugins/tool/verify.glade
+++ b/gramps/plugins/tool/verify.glade
@@ -107,13 +107,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="helpbutton1">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>
@@ -124,13 +123,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button5">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="verify" swapped="yes"/>
               </object>
               <packing>
@@ -852,13 +850,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="closebutton1">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/gramps/plugins/tool/verify.glade
+++ b/gramps/plugins/tool/verify.glade
@@ -140,7 +140,6 @@
             <child>
               <object class="GtkButton" id="button4">
                 <property name="label" translatable="yes">_Run</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -358,7 +357,6 @@
                     <child>
                       <object class="GtkCheckButton" id="estimate_age">
                         <property name="label" translatable="yes">_Estimate missing or inexact dates</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -375,7 +373,6 @@
                     <child>
                       <object class="GtkCheckButton" id="invdate">
                         <property name="label" translatable="yes">_Identify invalid dates</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -979,7 +976,6 @@
                     <child>
                       <object class="GtkButton" id="mark_all">
                         <property name="label" translatable="yes">_Mark all</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="can-default">True</property>
@@ -995,7 +991,6 @@
                     <child>
                       <object class="GtkButton" id="unmark_all">
                         <property name="label" translatable="yes">_Unmark all</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="can-default">True</property>
@@ -1011,7 +1006,6 @@
                     <child>
                       <object class="GtkButton" id="invert_all">
                         <property name="label" translatable="yes">In_vert marks</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="can-default">True</property>
@@ -1034,7 +1028,6 @@
                 <child>
                   <object class="GtkToggleButton" id="hide_button">
                     <property name="label" translatable="yes">_Hide marked</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>

--- a/gramps/plugins/tool/verify.glade
+++ b/gramps/plugins/tool/verify.glade
@@ -450,8 +450,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">2</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-start">2</property>
+                        <property name="margin-end">2</property>
                         <property name="margin-top">2</property>
                         <property name="margin-bottom">2</property>
                         <property name="hexpand">True</property>
@@ -469,8 +469,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">2</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-start">2</property>
+                        <property name="margin-end">2</property>
                         <property name="margin-top">2</property>
                         <property name="margin-bottom">2</property>
                         <property name="hexpand">True</property>
@@ -488,8 +488,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">2</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-start">2</property>
+                        <property name="margin-end">2</property>
                         <property name="margin-top">2</property>
                         <property name="margin-bottom">2</property>
                         <property name="hexpand">True</property>
@@ -580,8 +580,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">2</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-start">2</property>
+                        <property name="margin-end">2</property>
                         <property name="margin-top">2</property>
                         <property name="margin-bottom">2</property>
                         <property name="hexpand">True</property>
@@ -599,8 +599,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">2</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-start">2</property>
+                        <property name="margin-end">2</property>
                         <property name="margin-top">2</property>
                         <property name="margin-bottom">2</property>
                         <property name="hexpand">True</property>
@@ -618,8 +618,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">2</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-start">2</property>
+                        <property name="margin-end">2</property>
                         <property name="margin-top">2</property>
                         <property name="margin-bottom">2</property>
                         <property name="hexpand">True</property>


### PR DESCRIPTION
`margin-{left,right}` have been replaced by `margin-{start,end}`, and `xalign` with `halign`. In some cases, both were specified, so I deleted the deprecated one.