### PR TITLE
Safe mode working on Windows

### DIFF
--- a/gramps/gen/const.py
+++ b/gramps/gen/const.py
@@ -101,10 +101,11 @@ elif "USERPROFILE" in os.environ:
     USER_HOME = get_env_var("USERPROFILE")
     HOME_DIR = os.path.join(GLib.get_user_config_dir(), "gramps")
     if not os.path.exists(HOME_DIR):
-        if "APPDATA" in os.environ:
-            HOME_DIR = os.path.join(get_env_var("APPDATA"), "gramps")
-        else:
-            HOME_DIR = os.path.join(USER_HOME, "gramps")
+        homedir = get_env_var("APPDATA") if "APPDATA" in os.environ else USER_HOME
+        homedir = os.path.join(homedir, "gramps")
+        dbpath = os.path.join(homedir, "grampsdb")
+        if os.path.isdir(dbpath) and os.listdir(dbpath):
+            HOME_DIR = homedir
 else:
     USER_HOME = get_env_var("HOME")
     HOME_DIR = os.path.join(USER_HOME, ".gramps")

--- a/gramps/gen/const.py
+++ b/gramps/gen/const.py
@@ -99,10 +99,12 @@ if "GRAMPSHOME" in os.environ:
     HOME_DIR = os.path.join(USER_HOME, "gramps")
 elif "USERPROFILE" in os.environ:
     USER_HOME = get_env_var("USERPROFILE")
-    if "APPDATA" in os.environ:
-        HOME_DIR = os.path.join(get_env_var("APPDATA"), "gramps")
-    else:
-        HOME_DIR = os.path.join(USER_HOME, "gramps")
+    HOME_DIR = os.path.join(GLib.get_user_config_dir(), "gramps")
+    if not os.path.exists(HOME_DIR):
+        if "APPDATA" in os.environ:
+            HOME_DIR = os.path.join(get_env_var("APPDATA"), "gramps")
+        else:
+            HOME_DIR = os.path.join(USER_HOME, "gramps")
 else:
     USER_HOME = get_env_var("HOME")
     HOME_DIR = os.path.join(USER_HOME, ".gramps")


### PR DESCRIPTION
Safe mode which was broken with Gramps 5.2.0-5.2.2 on Windows, has been fixed with this commit. Fixes [#13300](https://gramps-project.org/bugs/view.php?id=13300)

Existing code was looking for user configuration in APPDATA, but with the move to XDG-based directory layout (bug 8025), this is no longer correct (see [doc](https://docs.gtk.org/glib/func.get_user_data_dir.html)). With the fix code looks for the new layout first, and then APPDATA.

The modified code is probably executed only on Windows, but it would be good to get confirmation for Linux and MacOS.

- [X] Testing on Windows with Gramps 5.2.2 only, and side-by-side with Gramps 5.1.6.
- [ ] Testing on Linux, if affected
- [ ] Testing on MacOS, if affected

Test to verify that [safe mode](https://gramps-project.org/wiki/index.php/Gramps_5.2_Wiki_Manual_-_Command_Line#Safe_mode) functions as described, i.e. starting from a user's customized environment, verify that existing family trees are available in safe mode but settings and configuration are not.

NOTE: This also fixes [#13261](https://gramps-project.org/bugs/view.php?id=13261) which documents another way in which this bug manifests. However, this is bug is closer to the root cause and easier to test.