### PR TITLE
Avoid empty media section in narrative web report

### DIFF
--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -2582,11 +2582,10 @@ class BasePage:
                 if lightboxes_1:
                     toggle += lightboxes_1
                     toggle += lightboxes_2
-                    if lightbox < len(photolist):
-                        toggle += Html(
-                            "h3", self._("Other media: videos, pdfs..."), inline=True
-                        )
-                if medias:
+                if medias.inside:
+                    toggle += Html(
+                        "h3", self._("Other media: videos, pdfs..."), inline=True
+                    )
                     toggle += medias
 
             # add fullclear for proper styling


### PR DESCRIPTION
When creating a WebReport ("Reports" → "Web Pages" → "Narrated Web Site") all pages for individuals with any photos or any other media entry include a "Other media: videos, pdfs..." even if there are only images, which are not in this section.
Example:
```
<div id="toggle_media" style="display:block">
  <div class="MediaRow">…</div>
  <div class="ModalClass" id="MediaModal">…</div>
  <h3>Other media: videos, pdfs...</h3>
    <div id="medias">
    </div>
</div>
```

Changes:
- Don't show "Other media: videos, pdfs..." section if there are no non-image media entries.