### PR TITLE
Fix fallback for the `image_size` utility function

### DIFF
--- a/gramps/gen/utils/image.py
+++ b/gramps/gen/utils/image.py
@@ -186,8 +186,9 @@ def image_size(source):
         import imagesize
 
         return imagesize.get(source)
-    except (ImportError, FileNotFoundError):
-        # python-imagesize is not installed or the file does not exist.
+    except (ImportError, FileNotFoundError, ValueError):
+        # python-imagesize is not installed, the file does not exist, or
+        # the size cannot be determined by imagesize.
         # So Trying to get image size with Gdk.
         try:
             img = GdkPixbuf.Pixbuf.new_from_file(source)


### PR DESCRIPTION
When I tried to create a WebReport ("Reports" → "Web Pages" → "Narrated Web Site") there were several errors preventing the report. These issues came from various SVG images (usually flags and coats of arms), because `imagesize` was not able to determine the image size.

Changes:
- If `imagesize` is installed, but fails to determine the image size, use the existing GDK fallback.

See also:
- [Bug #13310](https://gramps-project.org/bugs/view.php?id=13310)
- [Related imagesize bug: "cannot read a svg file"](https://github.com/shibukawa/imagesize_py/issues/59)
- [Example SVG image](https://upload.wikimedia.org/wikipedia/commons/0/0f/DEU_Krefeld_COA.svg) that does not work.
  - `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" … viewBox="0 0 1110 1210">`  (note the missing `width` and `height` attributes)