### PR TITLE
Replace deprecated makeSuite with TestLoader().loadTestsFromTestCase

### DIFF
--- a/test/GrampsLogger/ErrorReportAssistant_Test.py
+++ b/test/GrampsLogger/ErrorReportAssistant_Test.py
@@ -68,7 +68,7 @@ class ErrorReportAssistantTest(TestCaseBase):
 
 
 def testSuite():
-    suite = unittest.makeSuite(ErrorReportAssistantTest, "test")
+    suite = unittest.TestLoader().loadTestsFromTestCase(ErrorReportAssistantTest)
     return suite
 
 

--- a/test/GrampsLogger/GtkHandler_Test.py
+++ b/test/GrampsLogger/GtkHandler_Test.py
@@ -55,7 +55,7 @@ class GtkHandlerTest(unittest.TestCase):
         l.addHandler(gtkh)
 
         l.info("An info message")
-        l.warn("A warn message")
+        l.warning("A warn message")
         l.debug("A debug message")
         log_message = "Debug message"
 

--- a/test/GrampsLogger/GtkHandler_Test.py
+++ b/test/GrampsLogger/GtkHandler_Test.py
@@ -71,7 +71,7 @@ class GtkHandlerTest(unittest.TestCase):
 
 
 def testSuite():
-    suite = unittest.makeSuite(GtkHandlerTest, "test")
+    suite = unittest.TestLoader().loadTestsFromTestCase(GtkHandlerTest)
     return suite
 
 


### PR DESCRIPTION
[`unittest.makeSuite` is removed in Python 3.13.](https://docs.python.org/3.13/whatsnew/3.13.html#unittest)

While at it also replace deprecated 'warn' method with 'warning'.