### PR TITLE
Skip TestImports if en_US locale is not available on build host

### DIFF
--- a/gramps/plugins/test/imports_test.py
+++ b/gramps/plugins/test/imports_test.py
@@ -53,12 +53,6 @@ TEST_DIR = os.path.abspath(os.path.join(DATA_DIR, "tests"))
 #  Local Functions
 # ------------------------------------------------------------------
 
-# These tests assume a US date and time format.
-try:
-    locale.setlocale(locale.LC_ALL, "en_US.utf8")
-except locale.Error:  # seems to fail on Windows system for some reason
-    locale.setlocale(locale.LC_ALL, "English_United States")
-
 
 def mock_time(*args):
     """
@@ -74,6 +68,22 @@ def mock_localtime(*args):
     return strptime("25 Dec 1999", "%d %b %Y")
 
 
+# These tests assume a US date and time format.
+# If the locale is not available on the
+# build host, skip these tests.
+en_US_locale_available = False
+try:
+    locale.setlocale(locale.LC_ALL, "en_US.utf8")
+    en_US_locale_available = True
+except locale.Error:  # seems to fail on Windows system for some reason
+    try:
+        locale.setlocale(locale.LC_ALL, "English_United States")
+        en_US_locale_available = True
+    except locale.Error:
+        pass
+
+
+@unittest.skipUnless(en_US_locale_available, "en_US locale is not avaiable")
 class TestImports(unittest.TestCase):
     """The test class cases will be dynamically created at import time from
     files to be tested.  The following defs are used by the test cases


### PR DESCRIPTION
This PR does not error out if the en_US locale is not available, but skips those tests instead.

This should fix  https://gramps-project.org/bugs/view.php?id=13079