### PR TITLE
Package Gramps 5.2.3 for macOS.

### DIFF
--- a/mac/Info.plist
+++ b/mac/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleExecutable</key>
     <string>Gramps</string>
     <key>CFBundleGetInfoString</key>
-    <string>Gramps-5.2.2-1, (C) 1997-2024 The Gramps Team http://www.gramps-project.org</string>
+    <string>Gramps-5.2.3-1, (C) 1997-2024 The Gramps Team http://www.gramps-project.org</string>
     <key>CFBundleIconFile</key>
     <string>gramps.icns</string>
     <key>CFBundleIdentifier</key>
@@ -17,11 +17,11 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>Gramps-5.2.2-1</string>
+    <string>Gramps-5.2.3-1</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleVersion</key>
-    <string>Gramps-5.2.2-1</string>
+    <string>Gramps-5.2.3-1</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright 1997 - 2024 The Gramps Team, GNU General Public License.</string>
     <key>LSMinimumSystemVersion</key>

--- a/mac/gramps.modules
+++ b/mac/gramps.modules
@@ -32,9 +32,9 @@
     </dependencies>
   </distutils>
  <distutils id="gramps" supports-non-srcdir-builds="no">
-    <branch module="gramps-project/gramps/archive/v5.2.2.tar.gz"
-	    repo="github-tarball" version="5.2.2"
-            checkoutdir="gramps-gramps-5.2.2" />
+    <branch module="gramps-project/gramps/archive/v5.2.3.tar.gz"
+	    repo="github-tarball" version="5.2.3"
+            checkoutdir="gramps-gramps-5.2.3" />
     <dependencies>
       <dep package="meta-gramps-modules"/>
     </dependencies>


### PR DESCRIPTION
@Nick-Hall Please squash this into the Gramps-5.2.3 release that you mentioned in gramps-devel last weekend.