### PR TITLE
Disable rounding glyph positions in cairo document generator

### DIFF
--- a/gramps/plugins/docgen/cairodoc.py
+++ b/gramps/plugins/docgen/cairodoc.py
@@ -110,6 +110,7 @@ class CairoDocgen(libcairodoc.CairoDoc):
                 fontmap = PangoCairo.font_map_new()
                 fontmap.set_resolution(DPI)
                 pango_context = fontmap.create_context()
+                pango_context.set_round_glyph_positions(False)
                 options = cairo.FontOptions()
                 options.set_hint_metrics(cairo.HINT_METRICS_OFF)
                 if is_quartz():


### PR DESCRIPTION
According to [Pango documentation](https://docs.gtk.org/Pango/method.Context.set_round_glyph_positions.html), rounding glyph positions makes Pango render glyphs so that their positions are integral in device units. This is useful for rendering text on the screen, however it does not make sense for documents.

Moreover, with this option enabled, letter spacing can be weird for some font sizes. It is especially noticeable for sizes like 3-4 pt, some artifacts also appear at bigger sizes. Rendering large PDF report on small page can produce quite ugly output. 

Here is Ancestor Tree PDF report with 3pt text size and rounding enabled.
![s1](https://github.com/gramps-project/gramps/assets/18007501/619d8919-b25f-4e9d-b230-ab2936192569)

Here is the same output with rounding disabled.
![s2](https://github.com/gramps-project/gramps/assets/18007501/27e22037-3c02-4381-94d7-a4a3bdfe6770)

That's why I suggest disabling rounding glyph positions in Docgen.