### PR TITLE
Fix PDF generation failure with LaTeX-based reports

### DIFF
--- a/gramps/gen/plug/docgen/treedoc.py
+++ b/gramps/gen/plug/docgen/treedoc.py
@@ -131,6 +131,7 @@ _NOTESIZE = [
 
 if win():
     _LATEX_FOUND = search_for("lualatex.exe")
+    CREATE_NO_WINDOW = 0x8000000
 else:
     _LATEX_FOUND = search_for("lualatex")
 
@@ -803,8 +804,18 @@ class TreePdfDoc(TreeDocBase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             basename = os.path.basename(self._filename)
-            args = ["lualatex", "-output-directory", tmpdir, "-jobname", basename[:-4]]
-            proc = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+            args = ["lualatex", "--jobname", basename[:-4]]
+            if win():
+                proc = Popen(
+                    args,
+                    stdin=PIPE,
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    cwd=tmpdir,
+                    creationflags=CREATE_NO_WINDOW,
+                )
+            else:
+                proc = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE, cwd=tmpdir)
             proc.communicate(input=self._tex.getvalue().encode("utf-8"))
 
             temp_output_file = os.path.join(tmpdir, basename)


### PR DESCRIPTION
With this change generating PDFs from LaTeX-based reports such as sandclock and other tree reports is fixed.

Gramps set the output directory for lualatex to a temporary directory which directs all output from lualatex to that directory. Lualatex looks for a format file when it runs, and if one does not exist it will create one and save it to the output directory. However, this temporary directory is not searched by lualatex, so it fails to locate the format file when attempting to generate the PDF file, leading to the failure reported in the bug report.

The solution used by this PR is to avoid setting the output directory. This lets lualatex choose destination for the format file to one that is searched for by lualatex. However, a side-effect of this is that the PDF was then being sent to the directory Gramps was launched from which isn't suitable. To resolve this, we use the cwd argument that Popen accepts, and set that to the temporary directory so that the report files are generated in the expected location.

Finally, when Gramps was not launched with a console, PDF generation was launching a window and closing it which was not necessary, so the creation flag CREATE_NO_WINDOW was added to Popen, which avoids that.

Fixes #[10696](https://gramps-project.org/bugs/view.php?id=10696)

Testing required on all platforms:
1. Install Sandclock tree addon
2. Generate Trees > Sandclock Tree report in PDF format (usually requires a large paper size setting in landscape mode)
3. PDF should generate without errors


- [X] Windows 11, Windows 10
- [X] Linux Mint 21.3 (thanks to @ennoborg)
- [ ] MacOS