### PR TITLE
Clarified terminology for father/mother lineage description

### DIFF
--- a/gramps/plugins/quickview/lineage.py
+++ b/gramps/plugins/quickview/lineage.py
@@ -89,7 +89,7 @@ def run_mother(database, document, person):
     sd.paragraph(
         _(
             ""
-            "This report shows the mother lineage, also called matronymic lineage "
+            "This report shows the mother lineage, also called the matrilineal lineage "
             "mtDNA lineage."
             " People in this lineage all share the same Mitochondrial DNA (mtDNA)."
         )

--- a/gramps/plugins/quickview/lineage.py
+++ b/gramps/plugins/quickview/lineage.py
@@ -55,9 +55,9 @@ def run_father(database, document, person):
     sd.paragraph(
         _(
             ""
-            "This report shows the father lineage, also called patronymic lineage"
+            "This report shows the father lineage, also called the patrilineal lineage"
             " or Y-line."
-            " People in this lineage all share the same Y-chromosome."
+            " People in this lineage all share the same Y-chromosomes."
         )
     )
     sd.paragraph("")


### PR DESCRIPTION
- Changed "patronymic lineage" to "patrilineal lineage" for accuracy.