### PR TITLE
Prevent debug plugin loading for Gramps AIO

### DIFF
--- a/gramps/gen/plug/_pluginreg.py
+++ b/gramps/gen/plug/_pluginreg.py
@@ -49,6 +49,9 @@ import logging
 
 LOG = logging.getLogger("._manager")
 
+# Fix DEBUG for AIO built with cx_Freeze
+DEBUG = __debug__ and not hasattr(sys, "frozen")
+
 # -------------------------------------------------------------------------
 #
 # PluginData
@@ -1319,7 +1322,7 @@ class PluginRegister:
                 "This class is a singleton. " "Use the get_instance() method"
             )
         self.stable_only = True
-        if __debug__:
+        if DEBUG:
             self.stable_only = False
         self.__plugindata = []
         self.__id_to_pdata = {}
@@ -1406,7 +1409,7 @@ class PluginRegister:
             # check if:
             #  1. plugin exists, if not remove, otherwise set module name
             #  2. plugin not stable, if stable_only=True, remove
-            #  3. TOOL_DEBUG only if __debug__ True
+            #  3. TOOL_DEBUG only if DEBUG True
             rmlist = []
             ind = lenpd - 1
             for plugin in self.__plugindata[lenpd:]:
@@ -1434,11 +1437,7 @@ class PluginRegister:
                 if plugin.status == UNSTABLE and self.stable_only:
                     rmlist.append(ind)
                     continue
-                if (
-                    plugin.ptype == TOOL
-                    and plugin.category == TOOL_DEBUG
-                    and not __debug__
-                ):
+                if plugin.ptype == TOOL and plugin.category == TOOL_DEBUG and not DEBUG:
                     rmlist.append(ind)
                     continue
                 if plugin.fname is None:


### PR DESCRIPTION
The new AIO build, using cx_freeze, leads to a release version that loads debug plugins. This can be prevented by checking for 'frozen' code. This fix also changes appbuild to a simple number, to stay consistent with normal release policies.

The changed code still allows loading of debug plugins on Linux, where it can be suppressed in the usual way, by specifying the Python optimize parameter (-O)

Note: The \__debug__ constant is checked in more places than the changed _pluginreg.py. Those other files were not changed.