### PR TITLE
Harmonize _datedisplay.py Date Format label capitalization

### DIFF
--- a/gramps/gen/datehandler/_datedisplay.py
+++ b/gramps/gen/datehandler/_datedisplay.py
@@ -82,11 +82,11 @@ class DateDisplay:
         # Translators: Full month name, day, year
         _T_("Month Day, Year"),
         # Translators: Abbreviated month name, day, year
-        _T_("MON DAY, YEAR"),
+        _T_("Mon Day, Year"),
         # Translators: Day, full month name, year
         _T_("Day Month Year"),
         # Translators: Day, abbreviated month name, year
-        _T_("DAY MON YEAR"),
+        _T_("Day Mon Year"),
     )
     """
     .. note:: Will be overridden if a locale-specific date displayer exists.


### PR DESCRIPTION
2 (of 6) Date Formats had labels in all UPPER CASE when the format does not force upper case. Harmonize with the other Mixed/Camel case labels.

see reasoning in Discourse forum thread:
 https://gramps.discourse.group/t/featuring-gramps-features-is-it-really-a-genealogy-program-for-all/1322/6 