### PR TITLE
Restore AIO console executable's icon

### DIFF
--- a/aio/setup.py
+++ b/aio/setup.py
@@ -190,7 +190,7 @@ EXECUTABLES = [
         "grampsaioc.py",
         base="Console",
         target_name="gramps.exe",
-        icon="gramps.ico",
+        icon="grampsc.ico",
         copyright=COPYRIGHT,
     ),
     cx_Freeze.Executable(


### PR DESCRIPTION
Fixes [0013402](https://gramps-project.org/bugs/view.php?id=13402)

Starting with Gramps 5.2.0 and the new AIO installer build scripts, the icon for GrampsAIO-console app changed from the one that has the console badge to one without, i.e. the icons for both Gramps and Gramps-console are the same. This commit restores the icon for the console badge, making it distinguishable once again.