### PR TITLE
Fix unicode conversion bug when upgrading from schema 16 to 17

### DIFF
--- a/gramps/gen/db/upgrade.py
+++ b/gramps/gen/db/upgrade.py
@@ -317,7 +317,9 @@ def gramps_upgrade_17(self):
             n -= 1
 
         if parent_handle is not None:
-            placeref_list = [(parent_handle.decode("utf-8"), None)]
+            if isinstance(parent_handle, bytes):
+                parent_handle = parent_handle.decode("utf-8")
+            placeref_list = [(parent_handle, None)]
         else:
             placeref_list = []
 
@@ -487,7 +489,9 @@ def add_place(self, name, level, parent, title):
     gid = self.place_prefix % self.max_id
     placetype = (7 - level, "")
     if parent is not None:
-        placeref_list = [(parent.decode("utf-8"), None)]
+        if isinstance(parent, bytes):
+            parent = parent.decode("utf-8")
+        placeref_list = [(parent, None)]
     else:
         placeref_list = []
     place = (


### PR DESCRIPTION
Fixing a string behavior error (py2->py3 change) that prevented me from upgrading a very old database file