### PR TITLE
Clean up `exec` and `globals`

### DIFF
--- a/gramps/gen/display/name.py
+++ b/gramps/gen/display/name.py
@@ -749,7 +749,7 @@ class NameDisplay:
 
         The new function is of the form::
 
-        def fn(first, raw_surname_list, suffix, title, call,):
+        def fn(first, raw_surname_list, suffix, title, call, nick, famnick):
             return "%s %s" % (first,suffix)
 
         Specific symbols for parts of a name are defined (keywords given):
@@ -1172,8 +1172,7 @@ class NameDisplay:
 
     def _make_fn(self, format_str, d, args):
         """
-        Create the name display function and handles dependent
-        punctuation.
+        Create the name display function and handles dependent punctuation.
         """
         # d is a dict: dict[code] = (expr, word, translated word)
 
@@ -1281,18 +1280,17 @@ def fn(%s):
             ",".join(param),
         )
         try:
-            exec(s) in globals(), locals()
-            return locals()["fn"]
-        except:
+            result = {}
+            exec(s, globals(), result)
+            return result["fn"]
+        except SyntaxError:
             LOG.error(
-                "\n"
-                + "Wrong name format string %s" % new_fmt
-                + "\n"
-                + ("ERROR, Edit Name format in Preferences->Display to correct")
-                + "\n"
-                + _("Wrong name format string %s") % new_fmt
-                + "\n"
-                + ("ERROR, Edit Name format in Preferences->Display to correct")
+                "Wrong name format string %s\n"
+                "ERROR, Edit Name format in Preferences->Display to correct\n"
+                + _("Wrong name format string %s")
+                + "\nERROR, Edit Name format in Preferences->Display to correct",
+                new_fmt,
+                new_fmt,
             )
 
             def errfn(*arg):

--- a/gramps/gen/plug/utils.py
+++ b/gramps/gen/plug/utils.py
@@ -80,29 +80,37 @@ def version_str_to_tup(sversion, positions):
     return tup[:positions]
 
 
-class newplugin:
+class FakeRegistrar:
     """
-    Fake newplugin.
+    Fakes ``register`` and ``newplugin``.
     """
 
     def __init__(self):
-        globals()["register_results"].append({})
+        self.results = []
 
-    def __setattr__(self, attr, value):
-        globals()["register_results"][-1][attr] = value
+    @property
+    def newplugin(self):
+        class _newplugin:
+            """
+            Fake newplugin.
+            """
 
+            def __init__(inner_self):
+                self.results.append({})
 
-def register(ptype, **kwargs):
-    """
-    Fake registration. Side-effect sets register_results to kwargs.
-    """
-    retval = {"ptype": ptype}
-    retval.update(kwargs)
-    # Get the results back to calling function
-    if "register_results" in globals():
-        globals()["register_results"].append(retval)
-    else:
-        globals()["register_results"] = [retval]
+            def __setattr__(inner_self, attr, value):
+                self.results[-1][attr] = value
+
+        return _newplugin
+
+    def register(self, ptype, **kwargs):
+        """
+        Fake registration. Side-effect sets results to kwargs.
+        """
+        retval = {"ptype": ptype}
+        retval.update(kwargs)
+        # Get the results back to calling function
+        self.results.append(retval)
 
 
 class Zipfile:
@@ -380,12 +388,13 @@ def load_addon_file(path, callback=None):
         if callback:
             callback((_("Examining '%s'...") % gpr_file) + "\n")
         contents = file_obj.extractfile(gpr_file).read()
+        registrar = FakeRegistrar()
         # Put a fake register and _ function in environment:
         env = make_environment(
-            register=register, newplugin=newplugin, _=lambda text: text
+            register=registrar.register,
+            newplugin=registrar.newplugin,
+            _=lambda text: text,
         )
-        # clear out the result variable:
-        globals()["register_results"] = []
         # evaluate the contents:
         try:
             exec(contents, env)
@@ -395,7 +404,7 @@ def load_addon_file(path, callback=None):
                 callback("   " + msg + "\n" + str(exp))
             continue
         # There can be multiple addons per gpr file:
-        for results in globals()["register_results"]:
+        for results in registrar.results:
             gramps_target_version = results.get("gramps_target_version", None)
             id = results.get("id", None)
             if gramps_target_version:

--- a/gramps/plugins/test/db_undo_and_signals_test.py
+++ b/gramps/plugins/test/db_undo_and_signals_test.py
@@ -449,17 +449,9 @@ class DbTestClassBase(object):
         self.assertEqual(cm_padd_key, None, msg="Callback Manager disconnect cb check")
 
 
-params = [("SQLite", "sqlite")]
+class TestSQLite(DbTestClassBase, unittest.TestCase):
+    param = "sqlite"
 
-for name, param in params:
-    cls_name = "TestMyTestClass_%s" % (name,)
-    globals()[cls_name] = type(
-        cls_name,
-        (DbTestClassBase, unittest.TestCase),
-        {
-            "param": param,
-        },
-    )
 
 if __name__ == "__main__":
     unittest.main()

--- a/gramps/plugins/tool/removeunused.py
+++ b/gramps/plugins/tool/removeunused.py
@@ -383,12 +383,11 @@ class RemoveUnused(tool.Tool, ManagedWindow, UpdateCallback):
             self.call_editor(the_type, handle)
 
     def call_editor(self, the_type, handle):
+        import gramps.gui.editors
+
+        obj = self.tables[the_type]["get_func"](handle)
+        editor = getattr(gramps.gui.editors, self.tables[the_type]["editor"])
         try:
-            obj = self.tables[the_type]["get_func"](handle)
-            editor_str = "from gramps.gui.editors import %s as editor" % (
-                self.tables[the_type]["editor"]
-            )
-            exec(editor_str, globals())
             editor(self.dbstate, self.uistate, [], obj)
         except WindowActiveError:
             pass

--- a/gramps/plugins/tool/verify.py
+++ b/gramps/plugins/tool/verify.py
@@ -34,7 +34,6 @@ options are defined (and read in) is not done the way it would be now.
 
 # pylint: disable=not-callable
 # pylint: disable=no-self-use
-# pylint: disable=undefined-variable
 
 # ------------------------------------------------------------------------
 #
@@ -411,7 +410,7 @@ def get_n_children(db, person):
 class Verify(tool.Tool, ManagedWindow, UpdateCallback):
     """
     A plugin to verify the data against user-adjusted tests.
-    This is the research tool, not the low-level data ingerity check.
+    This is the research tool, not the low-level data integrity check.
     """
 
     def __init__(self, dbstate, user, options_class, name, callback=None):
@@ -547,7 +546,9 @@ class Verify(tool.Tool, ManagedWindow, UpdateCallback):
         yngmar,
         oldmar,
         oldmom,
+        olddad,
         yngmom,
+        yngdad,
         cbspan,
         cspace,
         estimate_age,
@@ -638,10 +639,7 @@ class Verify(tool.Tool, ManagedWindow, UpdateCallback):
         if n_families <= _family_cache_size:
             preload_family_cache(self.db)
 
-        for option, value in self.options.handler.options_dict.items():
-            exec("%s = %s" % (option, value), globals())
-            # TODO my pylint doesn't seem to understand these variables really
-            # are defined here, so I have disabled the undefined-variable error
+        options_dict = self.options.handler.options_dict
 
         if self.v_r:
             self.v_r.real_model.clear()
@@ -659,27 +657,29 @@ class Verify(tool.Tool, ManagedWindow, UpdateCallback):
                     self.process_family(
                         cli,
                         verify_family,
-                        hwdif,
-                        yngmar,
-                        oldmar,
-                        oldmom,
-                        yngmom,
-                        cbspan,
-                        cspace,
-                        estimate_age,
+                        options_dict["hwdif"],
+                        options_dict["yngmar"],
+                        options_dict["oldmar"],
+                        options_dict["oldmom"],
+                        options_dict["olddad"],
+                        options_dict["yngmom"],
+                        options_dict["yngdad"],
+                        options_dict["cbspan"],
+                        options_dict["cspace"],
+                        options_dict["estimate_age"],
                     )
                     family_handles.remove(family_handle)
 
             self.process_person(
                 cli,
                 verify_person,
-                oldage,
-                wedder,
-                oldunm,
-                mxchilddad,
-                mxchildmom,
-                invdate,
-                estimate_age,
+                options_dict["oldage"],
+                options_dict["wedder"],
+                options_dict["oldunm"],
+                options_dict["mxchilddad"],
+                options_dict["mxchildmom"],
+                options_dict["invdate"],
+                options_dict["estimate_age"],
             )
 
         # Family-based rules - for any left over families (families without any spouses)
@@ -689,14 +689,16 @@ class Verify(tool.Tool, ManagedWindow, UpdateCallback):
             self.process_family(
                 cli,
                 verify_family,
-                hwdif,
-                yngmar,
-                oldmar,
-                oldmom,
-                yngmom,
-                cbspan,
-                cspace,
-                estimate_age,
+                options_dict["hwdif"],
+                options_dict["yngmar"],
+                options_dict["oldmar"],
+                options_dict["oldmom"],
+                options_dict["olddad"],
+                options_dict["yngmom"],
+                options_dict["yngdad"],
+                options_dict["cbspan"],
+                options_dict["cspace"],
+                options_dict["estimate_age"],
             )
 
         clear_cache()


### PR DESCRIPTION
Using `exec` and `globals` can sometimes obscure what code is doing.

The last commit also fixes bug [#13347](https://gramps-project.org/bugs/view.php?id=13347).