### PR TITLE
Render reports with styled notes containing subscript and strikethrough

### DIFF
--- a/gramps/gen/plug/docbackend/cairobackend.py
+++ b/gramps/gen/plug/docbackend/cairobackend.py
@@ -79,6 +79,8 @@ class CairoBackend(DocBackend):
         DocBackend.FONTCOLOR,
         DocBackend.HIGHLIGHT,
         DocBackend.SUPERSCRIPT,
+        DocBackend.STRIKETHROUGH,
+        DocBackend.SUBSCRIPT,
     ]
 
     STYLETAG_MARKUP = {
@@ -86,6 +88,8 @@ class CairoBackend(DocBackend):
         DocBackend.ITALIC: ("<i>", "</i>"),
         DocBackend.UNDERLINE: ("<u>", "</u>"),
         DocBackend.SUPERSCRIPT: ("<sup>", "</sup>"),
+        DocBackend.STRIKETHROUGH: ("<s>", "</s>"),
+        DocBackend.SUBSCRIPT: ("<sub>", "</sub>"),
     }
 
     ESCAPE_FUNC = lambda x: escape

--- a/gramps/gen/plug/docbackend/docbackend.py
+++ b/gramps/gen/plug/docbackend/docbackend.py
@@ -95,6 +95,8 @@ class DocBackend:
     HIGHLIGHT = 6
     SUPERSCRIPT = 7
     LINK = 8
+    STRIKETHROUGH = 9
+    SUBSCRIPT = 10
 
     SUPPORTED_MARKUP = []
 
@@ -111,6 +113,8 @@ class DocBackend:
         UNDERLINE: ("", ""),
         SUPERSCRIPT: ("", ""),
         LINK: ("", ""),
+        STRIKETHROUGH: ("", ""),
+        SUBSCRIPT: ("", ""),
     }
 
     def __init__(self, filename=None):
@@ -200,7 +204,6 @@ class DocBackend:
     def find_tag_by_stag(self, s_tag):
         """
         :param s_tag: object: assumed styledtexttag
-        :param s_tagvalue: None/int/str: value associated with the tag
 
         A styled tag is type with a value. Every styled tag must be converted
         to the tags used in the corresponding markup for the backend,
@@ -222,6 +225,8 @@ class DocBackend:
             self.STYLETYPE_MAP[tagtype.HIGHLIGHT] = self.HIGHLIGHT
             self.STYLETYPE_MAP[tagtype.SUPERSCRIPT] = self.SUPERSCRIPT
             self.STYLETYPE_MAP[tagtype.LINK] = self.LINK
+            self.STYLETYPE_MAP[tagtype.STRIKETHROUGH] = self.STRIKETHROUGH
+            self.STYLETYPE_MAP[tagtype.SUBSCRIPT] = self.SUBSCRIPT
 
         if s_tag.name == tagtype.LINK:
             return self.format_link(s_tag.value)

--- a/gramps/plugins/docgen/latexdoc.py
+++ b/gramps/plugins/docgen/latexdoc.py
@@ -112,6 +112,7 @@ _LATEX_TEMPLATE = """%
 \\usepackage{ifthen}% For table width calculations
 \\usepackage{ragged2e}% For left aligning with hyphenation
 \\usepackage{wrapfig}% wrap pictures in text
+\\usepackage[normalem]{ulem}% For strikeout
 %
 % Depending on your LaTeX installation, the margins may be too
 % narrow.  This can be corrected by uncommenting the following
@@ -601,6 +602,8 @@ class LaTeXBackend(DocBackend):
         DocBackend.FONTSIZE,
         DocBackend.FONTFACE,
         DocBackend.SUPERSCRIPT,
+        DocBackend.SUBSCRIPT,
+        DocBackend.STRIKETHROUGH,
     ]
 
     STYLETAG_MARKUP = {
@@ -608,6 +611,8 @@ class LaTeXBackend(DocBackend):
         DocBackend.ITALIC: ("\\textit{", "}"),
         DocBackend.UNDERLINE: ("\\underline{", "}"),
         DocBackend.SUPERSCRIPT: ("\\textsuperscript{", "}"),
+        DocBackend.SUBSCRIPT: ("\\textsubscript{", "}"),
+        DocBackend.STRIKETHROUGH: ("\\sout{", "}"),
     }
 
     ESCAPE_FUNC = lambda x: latexescape

--- a/gramps/plugins/docgen/odfdoc.py
+++ b/gramps/plugins/docgen/odfdoc.py
@@ -285,6 +285,18 @@ _AUTOMATIC_STYLES = """\
         style:text-position="super 58%"/>
 </style:style>
 
+<style:style style:name="GSub"
+    style:family="text">
+    <style:text-properties
+        style:text-position="sub 58%"/>
+</style:style>
+
+<style:style style:name="GStrikethrough"
+    style:family="text">
+    <style:text-properties
+        style:text-line-through-style="solid"/>
+</style:style>
+
 <style:style style:name="GRAMPS-preformat"
     style:family="text">
     <style:text-properties

--- a/gramps/plugins/lib/libhtmlbackend.py
+++ b/gramps/plugins/lib/libhtmlbackend.py
@@ -182,6 +182,8 @@ class HtmlBackend(DocBackend):
         DocBackend.HIGHLIGHT,
         DocBackend.SUPERSCRIPT,
         DocBackend.LINK,
+        DocBackend.STRIKETHROUGH,
+        DocBackend.SUBSCRIPT,
     ]
 
     STYLETAG_MARKUP = {
@@ -189,6 +191,8 @@ class HtmlBackend(DocBackend):
         DocBackend.ITALIC: ("<em>", "</em>"),
         DocBackend.UNDERLINE: ('<span style="text-decoration:underline;">', "</span>"),
         DocBackend.SUPERSCRIPT: ("<sup>", "</sup>"),
+        DocBackend.STRIKETHROUGH: ("<s>", "</s>"),
+        DocBackend.SUBSCRIPT: ("<sub>", "</sub>"),
     }
 
     ESCAPE_FUNC = lambda self: escape

--- a/gramps/plugins/lib/libodfbackend.py
+++ b/gramps/plugins/lib/libodfbackend.py
@@ -89,6 +89,8 @@ class OdfBackend(DocBackend):
         DocBackend.HIGHLIGHT,
         DocBackend.SUPERSCRIPT,
         DocBackend.LINK,
+        DocBackend.SUBSCRIPT,
+        DocBackend.STRIKETHROUGH,
     ]
 
     STYLETAG_MARKUP = {
@@ -100,6 +102,14 @@ class OdfBackend(DocBackend):
         ),
         DocBackend.SUPERSCRIPT: (
             '<text:span text:style-name="GSuper">',
+            "</text:span>",
+        ),
+        DocBackend.SUBSCRIPT: (
+            '<text:span text:style-name="GSub">',
+            "</text:span>",
+        ),
+        DocBackend.STRIKETHROUGH: (
+            '<text:span text:style-name="GStrikethrough">',
             "</text:span>",
         ),
     }


### PR DESCRIPTION
Fixes #[13417](https://gramps-project.org/bugs/view.php?id=13417)

With this change all reports should be able to render styled notes using subscript or strikethrough without throwing exceptions.

1. Add support for subscript and strikethough in DocBackend.
2. Implement support for subscript and strikethrough in:
- CairoBackend
- LatexBackend
Use package ulem for strikethrough support. ulem overrides rendering of emphasis, so specified normalel option to maintain the default.
~A bug in `str_inc` was being triggered during my testing. I used AI to fix the code and it seems to work. I haven't investigated whether this will change anything, but the code seems to work. Looking for review on the code change, ways to test, or other comments~
**Update:** AI generated code reverted as it is explicitly forbidden by Gramps contribution rules. Bug #13418 filed to track this issue separately as it is not the target of the bug being addressed by PR.
- HTMLBackend
- ODFBackend
Add two new styles GSub and GStrikethrough to support subscript and strikethrough formatting, and implemented the two in odfdoc.py

Testing
1. Create a note that includes subscript and strikethrough, and attach to a person
2. Run any report which would include that note. Example: Complete Individual Report for that person
3. Render report in all formats and verify that (1) no exceptions are thrown and (2) output is rendered appropriately for the format. For Text and RTF, these styles will not have any effect, other formats including PDF, HTML, LaTeX, ODT, PS you will see the style applied.

Todo

1. Add methods similar to start[end]_superscript for subscript and strikethrough in each of the Doc classes so that plugins and addons can use the same functionality. **For compatibility, this should be introduced in 5.3 so plugins can specify Gramps version required.**
2. Add similar API for italics since no API is available for that today. See thread on discourse: https://gramps.discourse.group/t/reports-normal-italic-and-bold-within-a-paragraph/5106/5