### PR TITLE
Fix Python 3.12 deprecation warnings

### DIFF
--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -471,12 +471,10 @@ def show_settings():
     try:
         import sqlite3
 
-        sqlite3_py_version_str = sqlite3.version
         sqlite3_version_str = sqlite3.sqlite_version
         sqlite3_location_str = sqlite3.__file__
     except:
         sqlite3_version_str = "not found"
-        sqlite3_py_version_str = "not found"
         sqlite3_location_str = "not found"
 
     try:
@@ -591,7 +589,6 @@ def show_settings():
     print("     location    : %s" % bsddb_location_str)
     print(" sqlite3   :")
     print("     version     : %s" % sqlite3_version_str)
-    print("     py version  : %s" % sqlite3_py_version_str)
     print("     location    : %s" % sqlite3_location_str)
     print("")
 

--- a/gramps/gui/aboutdialog.py
+++ b/gramps/gui/aboutdialog.py
@@ -92,10 +92,8 @@ except:
 try:
     import sqlite3
 
-    sqlite3_py_version_str = sqlite3.version
     sqlite3_version_str = sqlite3.sqlite_version
 except:
-    sqlite3_py_version_str = "not found"
     sqlite3_version_str = "not found"
 
 
@@ -154,11 +152,7 @@ class GrampsAboutDialog(Gtk.AboutDialog):
         if hasattr(os, "uname"):
             distro = "\n" + _("Distribution: %s") % ellipses(os.uname()[2])
 
-        sqlite = (
-            "sqlite"
-            + COLON
-            + " %s (%s)\n" % (sqlite3_version_str, sqlite3_py_version_str)
-        )
+        sqlite = f"sqlite{COLON} {sqlite3_version_str}\n"
 
         return (
             "\n\n"

--- a/gramps/gui/logger/_errorreportassistant.py
+++ b/gramps/gui/logger/_errorreportassistant.py
@@ -48,11 +48,9 @@ except:
 try:
     import sqlite3
 
-    sqlite3_py_version_str = sqlite3.version
     sqlite3_version_str = sqlite3.sqlite_version
 except:
     sqlite3_version_str = "not found"
-    sqlite3_py_version_str = "not found"
 
 # -------------------------------------------------------------------------
 #
@@ -195,10 +193,7 @@ class ErrorReportAssistant(ManagedWindow, Gtk.Assistant):
         if hasattr(os, "uname"):
             distribution = "Distribution: %s\n" % os.uname()[2]
 
-        sqlite = "sqlite version: %s (%s) \n" % (
-            sqlite3_version_str,
-            sqlite3_py_version_str,
-        )
+        sqlite = f"sqlite version: {sqlite3_version_str} \n"
 
         return (
             "Gramps version: %s \n"

--- a/gramps/gui/uimanager.py
+++ b/gramps/gui/uimanager.py
@@ -290,7 +290,7 @@ class UIManager:
                 el_id = update.attrib["id"]
                 # find the parent of the id'd element in original xml
                 parent = self.et_xml.find(".//*[@id='%s'].." % el_id)
-                if parent:
+                if parent is not None:
                     # we found it, now delete original, inset updated
                     for indx in range(len(parent)):
                         if parent[indx].get("id") == el_id:
@@ -330,7 +330,7 @@ class UIManager:
             el_id = update.attrib["id"]
             # find parent of id'd element
             element = self.et_xml.find(".//*[@id='%s']" % el_id)
-            if element:  # element may have already been deleted
+            if element is not None:  # element may have already been deleted
                 for dummy in range(len(element)):
                     del element[0]
         # results = ET.tostring(self.et_xml, encoding="unicode")

--- a/gramps/plugins/db/dbapi/sqlite.py
+++ b/gramps/plugins/db/dbapi/sqlite.py
@@ -65,7 +65,6 @@ class SQLite(DBAPI):
         summary.update(
             {
                 _("Database version"): sqlite3.sqlite_version,
-                _("Database module version"): sqlite3.version,
                 _("Database module location"): sqlite3.__file__,
             }
         )


### PR DESCRIPTION
[`sqlite3.version`](https://docs.python.org/3/library/sqlite3.html#sqlite3.version) and [truth testing on an XML `Element`](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.remove) are now deprecated.