### PR TITLE
Convert 'Tip of the Day' window to Gtk.Template

### DIFF
--- a/gramps/gui/glade/tipofday.glade
+++ b/gramps/gui/glade/tipofday.glade
@@ -2,7 +2,7 @@
 <!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
-  <object class="GtkWindow" id="tipofday">
+  <template class="TipOfDay" parent="GtkWindow">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
     <property name="hexpand">True</property>
@@ -11,13 +11,13 @@
     <property name="title">window1</property>
     <property name="gravity">center</property>
     <child>
-      <object class="GtkBox" id="vbox126">
+      <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child>
           <!-- n-columns=3 n-rows=3 -->
-          <object class="GtkGrid" id="grid1">
+          <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="valign">start</property>
@@ -103,18 +103,19 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" id="hbuttonbox47">
+          <object class="GtkButtonBox">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="layout-style">end</property>
             <child>
-              <object class="GtkButton" id="next">
+              <object class="GtkButton">
                 <property name="label" translatable="yes">_Forward</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">True</property>
                 <property name="use-underline">True</property>
+                <signal name="clicked" handler="next_tip_cb"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -123,13 +124,14 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="close">
+              <object class="GtkButton">
                 <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">True</property>
                 <property name="use-underline">True</property>
+                <signal name="clicked" handler="close_cb"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -146,5 +148,5 @@
         </child>
       </object>
     </child>
-  </object>
+  </template>
 </interface>


### PR DESCRIPTION
I don't really understand the reason for the `Glade` class, but here's an example of using PyGObject's `Gtk.Template` integration instead on the simplest window.