### PR TITLE
Retarget Python Eval audience, status, help_url

### DIFF
--- a/gramps/plugins/gramplet/gramplet.gpr.py
+++ b/gramps/plugins/gramplet/gramplet.gpr.py
@@ -1452,12 +1452,13 @@ register(
     description="Gramplet allowing the evaluation of python code",
     version="1.0.0",
     gramps_target_version=MODULE_VERSION,
-    status=UNSTABLE,
+    audience=EXPERT,
+    status=STABLE,
     fname="eval.py",
     height=200,
     gramplet="PythonEvaluation",
     gramplet_title="Python Evaluation",
-    help_url=DEBUG_HELP,
+    help_url="https://gramps-project.org/wiki/index.php/Gramps_5.2_Wiki_Manual_-_Gramplets#Python_Evaluation",
 )
 
 register(


### PR DESCRIPTION
Everyone > Expert
Unstable > Stable
generic debug to specific section (5.2 specific version URL. How can this adapt to 5.3?)

fulfill 2nd half of  	0013422: Change "Audience" registrations of plug-ins to 5.2 "Expert"
https://gramps-project.org/bugs/view.php?id=13422