### PR TITLE
Fix printing of Books

### DIFF
--- a/gramps/gui/plug/report/_bookdialog.py
+++ b/gramps/gui/plug/report/_bookdialog.py
@@ -1029,7 +1029,7 @@ class BookDialog(DocReportDialog):
         selected_style = StyleSheet()
 
         pstyle = self.paper_frame.get_paper_style()
-        self.doc = self.format(None, pstyle)
+        self.doc = self.format(None, pstyle, uistate=self.uistate)
 
         for item in self.book.get_item_list():
             item.option_class.set_document(self.doc)


### PR DESCRIPTION
As noted in the original issue, PR#372 changed `GtkPrint` to try to parent its window via `self.uistate`, set in its constructor.

In `DocReportDialog.make_document`, the `uistate` argument is passed to the format class, but `BookDialog` overrides that method and is missing that argument, causing the `GtkPrint.uistate` to remain `None`. This allowed the 'Print...' option to work in plain Reports, but not Books.

Fixes [#12804](https://gramps-project.org/bugs/view.php?id=12804).