### PR TITLE
Fix Date sortval bug and corresponding unit test

### DIFF
--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -1765,15 +1765,7 @@ class Date:
         self.calendar = calendar
         self.dateval = value
         self.set_new_year(newyear)
-        year, month, day = self._zero_adjust_ymd(
-            value[Date._POS_YR], value[Date._POS_MON], value[Date._POS_DAY]
-        )
-
-        if year == month == day == 0:
-            self.sortval = 0
-        else:
-            func = Date._calendar_convert[calendar]
-            self.sortval = func(year, month, day)
+        self._calc_sort_value()
 
         if self.get_slash() and self.get_calendar() != Date.CAL_JULIAN:
             self.set_calendar(Date.CAL_JULIAN)
@@ -1848,14 +1840,19 @@ class Date:
         """
         Calculate the numerical sort value associated with the date.
         """
-        year, month, day = self._zero_adjust_ymd(
-            self.dateval[Date._POS_YR],
-            self.dateval[Date._POS_MON],
-            self.dateval[Date._POS_DAY],
-        )
-        if year == month == 0 and day == 0:
+        if (
+            self.dateval[Date._POS_YR]
+            == self.dateval[Date._POS_MON]
+            == self.dateval[Date._POS_DAY]
+            == 0
+        ):
             self.sortval = 0
         else:
+            year, month, day = self._zero_adjust_ymd(
+                self.dateval[Date._POS_YR],
+                self.dateval[Date._POS_MON],
+                self.dateval[Date._POS_DAY],
+            )
             func = Date._calendar_convert[self.calendar]
             self.sortval = func(year, month, day)
 

--- a/gramps/gen/lib/test/date_test.py
+++ b/gramps/gen/lib/test/date_test.py
@@ -1055,11 +1055,11 @@ class AgeTest(BaseDateTest):
             "2000",
             "40 years",
         ),
-        ("", "1760", "greater than 110 years"),
-        ("", "1960", "greater than 110 years"),
-        ("", "2020", "greater than 110 years"),
-        ("", "3020", "greater than 110 years"),
-        ("2000", "", "(1999 years)"),
+        ("", "1760", "unknown"),
+        ("", "1960", "unknown"),
+        ("", "2020", "unknown"),
+        ("", "3020", "unknown"),
+        ("2000", "", "unknown"),
     ]
 
     def convert_to_date(self, d):

--- a/gramps/gen/lib/test/date_test.py
+++ b/gramps/gen/lib/test/date_test.py
@@ -414,7 +414,7 @@ ENGLISH_DATE_HANDLER = _dd.__class__ == DateDisplayEn
 
 @unittest.skipUnless(
     ENGLISH_DATE_HANDLER,
-    "This test of Date() matching logic can only run in English locale.",
+    "This test of Date() matching logic can only run in US-English locale.",
 )
 class MatchDateTest(BaseDateTest):
     """
@@ -635,7 +635,7 @@ class SpanTest(BaseDateTest):
 # -------------------------------------------------------------------------
 @unittest.skipUnless(
     ENGLISH_DATE_HANDLER,
-    "This test of Date() matching logic can only run in English locale.",
+    "This test of Date() matching logic can only run in US-English locale.",
 )
 class DateComparisonTest(BaseDateTest):
     """
@@ -1010,7 +1010,7 @@ class DateComparisonTest(BaseDateTest):
 # -------------------------------------------------------------------------
 @unittest.skipUnless(
     ENGLISH_DATE_HANDLER,
-    "This test of Date() matching logic can only run in English locale.",
+    "This test of Date() matching logic can only run in US-English locale.",
 )
 class AgeTest(BaseDateTest):
     """


### PR DESCRIPTION
Three commits, to fix the sortval bug and corresponding unit test.  These need to go together to allow tests to pass.
The 3rd component is a trivial improvement to warning message when date unit tests are skipped.