### PR TITLE
Fix to allow ancestor_too_old() tests to be done

### DIFF
--- a/gramps/gen/utils/alive.py
+++ b/gramps/gen/utils/alive.py
@@ -615,6 +615,7 @@ class ProbablyAlive:
 
             return (None, None, "", None)
 
+        self.pset = set()
         try:
             # If there are ancestors that would be too old in the current year
             # then assume our person must be dead too.


### PR DESCRIPTION
When calling probably_alive, the previous code did not clear the self.pset list between running descendant test and ancestor test, so the ancestor test code assumed all persons had already been checked and was never executed.

This bug and fix is easier to evaluate if patch for bug [#13431](https://gramps-project.org/bugs/view.php?id=13431) has been applied - that is just to improve debug output.