### PR TITLE
Use the preferred calendar for new dates only in the date editor

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -39,7 +39,7 @@ To build and install, whether from a tarball or git repo:
    python3 setup.py build
    sudo python3 setup.py install
 
-You can avoid using sudo for the install step by specifying a prefix to which you have write priviledge. The default is /usr/local, which is usually owned by root. You can learn of more options with
+You can avoid using sudo for the install step by specifying a prefix to which you have write privilege. The default is /usr/local, which is usually owned by root. You can learn of more options with
    python3 setup.py --help
 
 One can use Gramps from the command line without installing it by

--- a/gramps/gui/editors/editdate.py
+++ b/gramps/gui/editors/editdate.py
@@ -205,8 +205,10 @@ class EditDate(ManagedWindow):
             self.calendar_box.set_active(Date.CAL_JULIAN)
         self.dual_dated.connect("toggled", self.switch_dual_dated)
 
-        cal = config.get("preferences.calendar-format-input")
-        self.calendar_box.set_active(cal)
+        # Use the calendar from user preferences for new dates only.
+        if self.date.is_empty():
+            cal = config.get("preferences.calendar-format-input")
+            self.calendar_box.set_active(cal)
 
         # The dialog is modal -- since dates don't have names, we don't
         # want to have several open dialogs, since then the user will


### PR DESCRIPTION
See https://gramps-project.org/bugs/view.php?id=13403#c67233 

This commit introduced a bug
https://github.com/gramps-project/gramps/commit/42b71b23d6b3e163197bcc3b8d580b469447917e#diff-403f8698a9cc1199c93a43229eaeaed780e54ddae595e4fa5942eee5bb88d084

- I'm not familiar with all the supported calendars, and if the `newyear` for, e.g. Hebrew, needs to be adjusted.  The domain owner's feedback is needed.
- Text parsing logic to generate a date looks funky.  It parses an empty string replacing the previous data object while assuming defaults. It looks suspicious.