### PR TITLE
"Age on date": correct misleading description of GUI element placement

### DIFF
--- a/gramps/plugins/gramplet/ageondategramplet.py
+++ b/gramps/plugins/gramplet/ageondategramplet.py
@@ -64,7 +64,7 @@ class AgeOnDateGramplet(Gramplet):
         buffer.set_text(
             _(
                 "Enter a valid date (like YYYY-MM-DD) in the"
-                " entry below and click Run. This will compute"
+                " entry text box and click Run. This will compute"
                 " the ages for everyone in your Family Tree on"
                 " that date. You can then sort by the age column,"
                 " and double-click the row to view or edit."


### PR DESCRIPTION
Text prompt said "in the entry below" but the text box was actually above. (At least, it was above on Fedora).

change to generic "in the text box"