### PR TITLE
Check events of type CENSUS as well as OCCUPATION when looking for occupations

### DIFF
--- a/gramps/plugins/graph/gvrelgraph.py
+++ b/gramps/plugins/graph/gvrelgraph.py
@@ -749,7 +749,8 @@ class RelGraphReport(Report):
                 for event in [
                     self._db.get_event_from_handle(ref.ref) for ref in event_refs
                 ]
-                if event.get_type() == EventType(EventType.OCCUPATION)
+                if (event.get_type() == EventType(EventType.OCCUPATION))
+                or (event.get_type() == EventType(EventType.CENSUS))
             ]
             if len(events) > 0:
                 events.sort(key=lambda x: x.get_date_object())


### PR DESCRIPTION
At present, when an "Include occupation" option is selected, only events of type OCCUPATION are searched. This mod includes events of type CENSUS as well, which usually include occupation information too.

An alternative, far more complex, approach would be to create another option set for "Include census", independent of the "Include occupation" option. However, for most people, this 2 line mod would probably suffice. (Actually, it would have been just a one line mod, but I've just spent 15 minutes going round in circles working out what's wrong with my code formatting style, only to find my one line needs to be split across two with no trailing spaces:-) )
