### PR TITLE
Refactor JSON serialisation

### DIFF
--- a/gramps/gen/lib/baseobj.py
+++ b/gramps/gen/lib/baseobj.py
@@ -2,6 +2,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2000-2006  Donald N. Allingham
+# Copyright (C) 2024       Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -56,6 +57,48 @@ class BaseObject(metaclass=ABCMeta):
         """
         Convert a serialized tuple of data to an object.
         """
+
+    def get_object_state(self):
+        """
+        Get the current object state as a dictionary.
+
+        By default this returns the public attributes of the instance.  This
+        method can be overridden if the class requires other attributes or
+        properties to be saved.
+
+        This method is called to provide the information required to serialize
+        the object.  If None is returned then the object will be represented as
+        null in JSON.
+
+        :returns: Returns a dictionary of attributes that represent the state
+                  of the object or None.
+        :rtype: dict
+        """
+        attr_dict = dict(
+            (key, value)
+            for key, value in self.__dict__.items()
+            if not key.startswith("_")
+        )
+        attr_dict["_class"] = self.__class__.__name__
+        return attr_dict
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        By default this sets the state of the object assuming that all items in
+        the dictionary map to public attributes.  This method can be overridden
+        to set the state using custom functionality.  For performance reasons
+        it is useful to set a property without calling its setter function.  As
+        JSON provides no distinction between tuples and lists, this method can
+        also be use to convert lists into tuples where required.
+
+        :param attr_dict: A dictionary of attributes that represent the state of
+                          the object.
+        :type attr_dict: dict
+        """
+        self.__dict__.update(attr_dict)
 
     def matches_string(self, pattern, case_sensitive=False):
         """

--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -38,6 +38,7 @@ import time
 # Gramps modules
 #
 # ------------------------------------------------------------------------
+from .baseobj import BaseObject
 from ..config import config
 from ..const import GRAMPS_LOCALE as glocale
 from ..errors import DateError
@@ -563,7 +564,7 @@ class Span:
 # Date
 #
 # -------------------------------------------------------------------------
-class Date:
+class Date(BaseObject):
     """
     The core date handling class for Gramps.
 

--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2009-2013  Douglas S. Blank
 # Copyright (C) 2013       Paul Franklin
 # Copyright (C) 2013-2014  Vassilii Khachaturov
-# Copyright (C) 2017       Nick Hall
+# Copyright (C) 2017,2024  Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -749,6 +749,28 @@ class Date(BaseObject):
         else:
             raise DateError("Invalid date to unserialize")
         return self
+
+    def get_object_state(self):
+        """
+        Get the current object state as a dictionary.
+
+        We override this method to represent an empty date as null in JSON.
+        """
+        if self.is_empty() and not self.text:
+            return None
+        else:
+            return super().get_object_state()
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to convert `dateval` into a tuple.
+        """
+        if "dateval" in attr_dict:
+            attr_dict["dateval"] = tuple(attr_dict["dateval"])
+        super().set_object_state(attr_dict)
 
     @classmethod
     def get_schema(cls):

--- a/gramps/gen/lib/event.py
+++ b/gramps/gen/lib/event.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2000-2007  Donald N. Allingham
 # Copyright (C) 2010       Michiel D. Nauta
 # Copyright (C) 2011       Tim G L Lyons
-# Copyright (C) 2017       Nick Hall
+# Copyright (C) 2017,2024  Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -135,6 +135,28 @@ class Event(
             TagBase.serialize(self),
             self.private,
         )
+
+    def get_object_state(self):
+        """
+        Get the current object state as a dictionary.
+
+        We override this method to handle the `type` and `description` properties.
+        """
+        attr_dict = super().get_object_state()
+        attr_dict["type"] = self.__type
+        attr_dict["description"] = self.__description
+        return attr_dict
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to handle the `type` and `description` properties.
+        """
+        self.__type = attr_dict.pop("type")
+        self.__description = attr_dict.pop("description")
+        super().set_object_state(attr_dict)
 
     @classmethod
     def get_schema(cls):

--- a/gramps/gen/lib/eventref.py
+++ b/gramps/gen/lib/eventref.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2010       Michiel D. Nauta
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Doug Blank <doug.blank@gmail.com>
-# Copyright (C) 2017       Nick Hall
+# Copyright (C) 2017,2024  Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -85,6 +85,26 @@ class EventRef(
             RefBase.serialize(self),
             self.__role.serialize(),
         )
+
+    def get_object_state(self):
+        """
+        Get the current object state as a dictionary.
+
+        We override this method to handle the `role` property.
+        """
+        attr_dict = super().get_object_state()
+        attr_dict["role"] = self.__role
+        return attr_dict
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to handle the `role` property.
+        """
+        self.__role = attr_dict.pop("role")
+        super().set_object_state(attr_dict)
 
     @classmethod
     def get_schema(cls):

--- a/gramps/gen/lib/grampstype.py
+++ b/gramps/gen/lib/grampstype.py
@@ -2,7 +2,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2000-2007  Donald N. Allingham
-# Copyright (C) 2017       Nick Hall
+# Copyright (C) 2017,2024  Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -136,6 +136,30 @@ class GrampsType(metaclass=GrampsTypeMeta):
         if value is not None:
             self.set(value)
 
+    def get_object_state(self):
+        """
+        Get the current object state as a dictionary.
+
+        We override this method to handle the `value` and `string` properties.
+        """
+        attr_dict = {"_class": self.__class__.__name__}
+        attr_dict["value"] = self.__value
+        attr_dict["string"] = self.__string
+        return attr_dict
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to handle the `value` and `string` properties.
+        """
+        self.__value = attr_dict["value"]
+        if self.__value == self._CUSTOM:
+            self.__string = attr_dict["string"]
+        else:
+            self.__string = ""
+
     def __set_tuple(self, value):
         "Set the value/string properties from a tuple."
         val, strg = self._DEFAULT, ""
@@ -225,7 +249,8 @@ class GrampsType(metaclass=GrampsTypeMeta):
             "title": _("Type"),
             "properties": {
                 "_class": {"enum": [cls.__name__]},
-                "string": {"type": "string", "title": _("Type")},
+                "string": {"type": "string", "title": _("Custom type")},
+                "value": {"type": "integer", "title": _("Type code")},
             },
         }
 

--- a/gramps/gen/lib/mediaref.py
+++ b/gramps/gen/lib/mediaref.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2010       Michiel D. Nauta
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Doug Blank <doug.blank@gmail.com>
-# Copyright (C) 2017       Nick Hall
+# Copyright (C) 2017,2024  Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -150,6 +150,18 @@ class MediaRef(
         AttributeBase.unserialize(self, attribute_list)
         RefBase.unserialize(self, ref)
         return self
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to convert `rect` into a tuple.
+        """
+        rect = attr_dict["rect"]
+        if rect is not None:
+            attr_dict["rect"] = tuple(rect)
+        super().set_object_state(attr_dict)
 
     def get_text_data_child_list(self):
         """

--- a/gramps/gen/lib/person.py
+++ b/gramps/gen/lib/person.py
@@ -1,10 +1,10 @@
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2000-2007  Donald N. Allingham
-# Copyright (C) 2010       Michiel D. Nauta
-# Copyright (C) 2010,2017  Nick Hall
-# Copyright (C) 2011       Tim G L Lyons
+# Copyright (C) 2000-2007       Donald N. Allingham
+# Copyright (C) 2010            Michiel D. Nauta
+# Copyright (C) 2010,2017,2024  Nick Hall
+# Copyright (C) 2011            Tim G L Lyons
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -321,6 +321,26 @@ class Person(
         NoteBase.unserialize(self, note_list)
         TagBase.unserialize(self, tag_list)
         return self
+
+    def get_object_state(self):
+        """
+        Get the current object state as a dictionary.
+
+        We override this method to handle the `gender` property.
+        """
+        attr_dict = super().get_object_state()
+        attr_dict["gender"] = self.__gender
+        return attr_dict
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to handle the `gender` property.
+        """
+        self.__gender = attr_dict.pop("gender")
+        super().set_object_state(attr_dict)
 
     def _has_handle_reference(self, classname, handle):
         """

--- a/gramps/gen/lib/serialize.py
+++ b/gramps/gen/lib/serialize.py
@@ -1,7 +1,7 @@
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2017       Nick Hall
+# Copyright (C) 2017,2024       Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -37,36 +37,16 @@ import json
 import gramps.gen.lib as lib
 
 
-def __default(obj):
-    obj_dict = {"_class": obj.__class__.__name__}
-    if isinstance(obj, lib.GrampsType):
-        obj_dict["string"] = getattr(obj, "string")
-    if isinstance(obj, lib.Date):
-        if obj.is_empty() and not obj.text:
-            return None
-    for key, value in obj.__dict__.items():
-        if not key.startswith("_"):
-            obj_dict[key] = value
-    for key, value in obj.__class__.__dict__.items():
-        if isinstance(value, property):
-            if key != "year":
-                obj_dict[key] = getattr(obj, key)
-    return obj_dict
-
-
 def __object_hook(obj_dict):
-    obj = getattr(lib, obj_dict["_class"])()
-    for key, value in obj_dict.items():
-        if key != "_class":
-            if key in ("dateval", "rect") and value is not None:
-                value = tuple(value)
-            if key == "ranges":
-                value = [tuple(item) for item in value]
-            setattr(obj, key, value)
-    if obj_dict["_class"] == "Date":
-        if obj.is_empty() and not obj.text:
-            return None
+    _class = obj_dict.pop("_class")
+    cls = lib.__dict__[_class]
+    obj = cls.__new__(cls)
+    obj.set_object_state(obj_dict)
     return obj
+
+
+def __default(obj):
+    return obj.get_object_state()
 
 
 def to_json(obj):

--- a/gramps/gen/lib/styledtext.py
+++ b/gramps/gen/lib/styledtext.py
@@ -35,6 +35,7 @@ from copy import copy
 #
 # -------------------------------------------------------------------------
 from ..const import GRAMPS_LOCALE as glocale
+from .baseobj import BaseObject
 from .styledtexttag import StyledTextTag
 
 _ = glocale.translation.gettext
@@ -45,7 +46,7 @@ _ = glocale.translation.gettext
 # StyledText
 #
 # -------------------------------------------------------------------------
-class StyledText:
+class StyledText(BaseObject):
     """Helper class to enable character based text formatting.
 
     :py:class:`StyledText` is a wrapper class binding the clear text string and

--- a/gramps/gen/lib/styledtext.py
+++ b/gramps/gen/lib/styledtext.py
@@ -3,7 +3,7 @@
 #
 # Copyright (C) 2008       Zsolt Foldvari
 # Copyright (C) 2013       Doug Blank <doug.blank@gmail.com>
-# Copyright (C) 2017       Nick Hall
+# Copyright (C) 2017,2024  Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -101,6 +101,27 @@ class StyledText(BaseObject):
             self._tags = tags
         else:
             self._tags = []
+
+    def get_object_state(self):
+        """
+        Get the current object state as a dictionary.
+
+        We override this method to handle the `tags` and `string` properties.
+        """
+        attr_dict = {"_class": self.__class__.__name__}
+        attr_dict["tags"] = self._tags
+        attr_dict["string"] = self._string
+        return attr_dict
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to handle the `tags` and `string` properties.
+        """
+        self._tags = attr_dict["tags"]
+        self._string = attr_dict["string"]
 
     # special methods
 

--- a/gramps/gen/lib/styledtexttag.py
+++ b/gramps/gen/lib/styledtexttag.py
@@ -28,6 +28,7 @@
 #
 # -------------------------------------------------------------------------
 from ..const import GRAMPS_LOCALE as glocale
+from .baseobj import BaseObject
 from .styledtexttagtype import StyledTextTagType
 
 _ = glocale.translation.gettext
@@ -38,7 +39,7 @@ _ = glocale.translation.gettext
 # StyledTextTag
 #
 # -------------------------------------------------------------------------
-class StyledTextTag:
+class StyledTextTag(BaseObject):
     """Hold formatting information for :py:class:`.StyledText`.
 
     :py:class:`StyledTextTag` is a container class, it's attributes are

--- a/gramps/gen/lib/styledtexttag.py
+++ b/gramps/gen/lib/styledtexttag.py
@@ -1,9 +1,9 @@
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2008  Zsolt Foldvari
-# Copyright (C) 2013  Doug Blank <doug.blank@gmail.com>
-# Copyright (C) 2017  Nick Hall
+# Copyright (C) 2008       Zsolt Foldvari
+# Copyright (C) 2013       Doug Blank <doug.blank@gmail.com>
+# Copyright (C) 2017,2024  Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -69,6 +69,16 @@ class StyledTextTag(BaseObject):
         else:
             # Current use of StyledTextTag is such that a shallow copy suffices.
             self.ranges = ranges
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to convert the elements of `ranges` into tuples.
+        """
+        attr_dict["ranges"] = [tuple(item) for item in attr_dict["ranges"]]
+        super().set_object_state(attr_dict)
 
     def serialize(self):
         """Convert the object to a serialized tuple of data.

--- a/gramps/gen/lib/tag.py
+++ b/gramps/gen/lib/tag.py
@@ -1,8 +1,8 @@
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2010,2017 Nick Hall
-# Copyright (C) 2013      Doug Blank <doug.blank@gmail.com>
+# Copyright (C) 2010,2017,2024  Nick Hall
+# Copyright (C) 2013            Doug Blank <doug.blank@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -107,6 +107,32 @@ class Tag(TableObject):
             self.change,
         ) = data
         return self
+
+    def get_object_state(self):
+        """
+        Get the current object state as a dictionary.
+
+        We override this method to handle the `name`, `color` and `priority`
+        properties.
+        """
+        attr_dict = super().get_object_state()
+        attr_dict["name"] = self.__name
+        attr_dict["color"] = self.__color
+        attr_dict["priority"] = self.__priority
+        return attr_dict
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to handle the `name`, `color` and `priority`
+        properties.
+        """
+        self.__name = attr_dict.pop("name")
+        self.__color = attr_dict.pop("color")
+        self.__priority = attr_dict.pop("priority")
+        super().set_object_state(attr_dict)
 
     @classmethod
     def get_schema(cls):

--- a/gramps/gen/lib/test/serialize_test.py
+++ b/gramps/gen/lib/test/serialize_test.py
@@ -50,11 +50,6 @@ class BaseCheck:
         obj = from_json(data)
         self.assertEqual(self.object.serialize(), obj.serialize())
 
-    def test_from_empty_json(self):
-        data = '{"_class": "%s"}' % self.cls.__name__
-        obj = from_json(data)
-        self.assertEqual(self.object.serialize(), obj.serialize())
-
 
 class PersonCheck(unittest.TestCase, BaseCheck):
     def setUp(self):


### PR DESCRIPTION
Simplify the JSON serialisation by creating methods to get and set the state of an object.

The method names `get_attrs` and `set_attrs` are not ideal and will probably need changing.

There is some copy and paste of these methods from the `BaseObject` into the `Date` object.  Why are `GrampsType`, `Date`, `StyledText` and `StyledTextTag` not derived from `BaseObject`?

TODO:  Look at removing the checks for empty dates from the `to_json` and `from_json` functions.