### PR TITLE
Select json data from database

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -91,7 +91,6 @@ from . import (
 from .bookmarks import DbBookmarks
 from .exceptions import DbUpgradeRequiredError, DbVersionError
 from .utils import clear_lock_file, write_lock_file
-from .select_utils import select
 
 _ = glocale.translation.gettext
 
@@ -2741,13 +2740,31 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
 
     def select(self, table, selections=None, where=None, sort_by=None):
         """
-        Generic function that can handle jsonpath items in a list.
+        Generic implementation of select, with where and sort_by clauses.
 
-        table - name of table
-        selections -
-            Example: ("gender", "primary_name.suname_list[0].surname", ...)
-        sort_by - "gender"
-        where - ("and", ("handle", "=", "abc64564346"),
-                        ("gramps_id", "=", ""))
+        :param table: Name of table
+        :type table: str
+        :param selections: List of json-paths
+        :type selections: List[str] or tuple(str)
+        :param where: A single where-expression (see below)
+        :type where: tuple or list
+        :param sort_by: A list of expressions to sort on
+        :type where: tuple or list
+        :returns: Returns selected items from select rows, from iterator
+        :rtype: dict
+
+        Examples:
+
+        Get the gender and surname of all males, sort by gramps_id:
+        ```
+        db.select(
+            "person",
+            ["$.gender", "$.primary_name.surname_list[0].surname"],
+            where=["$.gender", "=", Person.MALE],
+            sort_by=["$.gramps_id"],
+        )
+        ```
         """
+        from gramps.gen.db.select_utils import select
+
         yield from select(self, table, selections, where, sort_by)

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -2738,7 +2738,8 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         elif serializer_name == "json":
             self.serializer = JSONSerializer
 
-    def select(self, table, selections=None, where=None, sort_by=None):
+    def select(self, table, selections=None, where=None, sort_by=None,
+               page=0, page_size=25):
         """
         Generic implementation of select, with where and sort_by clauses.
 
@@ -2748,8 +2749,10 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         :type selections: List[str] or tuple(str)
         :param where: A single where-expression (see below)
         :type where: tuple or list
-        :param sort_by: A list of expressions to sort on
-        :type where: tuple or list
+        :param page: The page number to return (zero-based)
+        :type page: int
+        :param page_size: The size of a page in rows; None means ignore
+        :type page: int or None
         :returns: Returns selected items from select rows, from iterator
         :rtype: dict
 
@@ -2764,7 +2767,21 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             sort_by=["$.gramps_id"],
         )
         ```
+        Notes:
+
+        Although the Python jsonpath_ng library may support more
+        variations than SQL (or other implementations) you should
+        not use them to ensure that your code will run with all
+        backends.
+
+        The where expressions only support the following operators:
+            "=", "!=", "<", "<=", ">", ">=", "in", "not in", "like"
+
+        The `like` operator supports "%" (zero or more characters)
+        and "_" (one character) regular expression matches.
         """
         from gramps.gen.db.select_utils import select
 
-        yield from select(self, table, selections, where, sort_by)
+        yield from select(
+            self, table, selections, where, sort_by, page, page_size
+        )

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -2739,7 +2739,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             self.serializer = JSONSerializer
 
     def select(
-        self, table, selections=None, where=None, sort_by=None, page=0, page_size=25
+        self, table, selections=None, where=None, sort_by=None, page=0, page_size=None
     ):
         """
         Generic implementation of select, with where and sort_by clauses.

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -2738,8 +2738,9 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         elif serializer_name == "json":
             self.serializer = JSONSerializer
 
-    def select(self, table, selections=None, where=None, sort_by=None,
-               page=0, page_size=25):
+    def select(
+        self, table, selections=None, where=None, sort_by=None, page=0, page_size=25
+    ):
         """
         Generic implementation of select, with where and sort_by clauses.
 
@@ -2782,6 +2783,4 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         """
         from gramps.gen.db.select_utils import select
 
-        yield from select(
-            self, table, selections, where, sort_by, page, page_size
-        )
+        yield from select(self, table, selections, where, sort_by, page, page_size)

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -91,6 +91,7 @@ from . import (
 from .bookmarks import DbBookmarks
 from .exceptions import DbUpgradeRequiredError, DbVersionError
 from .utils import clear_lock_file, write_lock_file
+from .select_utils import select
 
 _ = glocale.translation.gettext
 
@@ -2737,3 +2738,16 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             self.serializer = BlobSerializer
         elif serializer_name == "json":
             self.serializer = JSONSerializer
+
+    def select(self, table, selections=None, where=None, sort_by=None):
+        """
+        Generic function that can handle jsonpath items in a list.
+
+        table - name of table
+        selections -
+            Example: ("gender", "primary_name.suname_list[0].surname", ...)
+        sort_by - "gender"
+        where - ("and", ("handle", "=", "abc64564346"),
+                        ("gramps_id", "=", ""))
+        """
+        yield from select(self, table, selections, where, sort_by)

--- a/gramps/gen/db/select_utils.py
+++ b/gramps/gen/db/select_utils.py
@@ -56,7 +56,9 @@ def select(db, table, selections, where, sort_by, page, page_size):
             yield row
     else:
         results = list(select_items(db, table, ["$"], where))
-        for count, row in enumerate(sorted(results, key=lambda item: sort_function(item, sort_by))):
+        for count, row in enumerate(
+            sorted(results, key=lambda item: sort_function(item, sort_by))
+        ):
             if count < offset:
                 continue
             if count > (offset + limit):

--- a/gramps/gen/db/select_utils.py
+++ b/gramps/gen/db/select_utils.py
@@ -1,0 +1,225 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2024 Doug Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Support functions for Generic DB select functionality
+"""
+
+import jsonpath_ng
+
+PARSE_CACHE = {}
+
+
+def select(db, table, selections, where, sort_by):
+    """
+    Top-level function for select functions.
+
+    Args:
+        db: database instance
+        table: the table name
+        selections: list of json paths
+        where: a where expression (see below)
+        sort_by: list of json_paths to sort by
+    """
+    selections = selections if selections else ["$"]
+    if sort_by is None:
+        yield from select_items(db, table, selections, where)
+    else:
+        results = list(select_items(db, table, ["$"], where))
+        for row in sorted(results, key=lambda item: sort_function(item, sort_by)):
+            yield get_items(row, selections)
+
+
+def select_items(db, table, selections, where):
+    """
+    Select items with optional where expr.
+
+    Note that we apply the where, then select the items.
+    """
+    for row in select_where(db, table, where):
+        results = get_items(row, selections)
+        yield results
+
+
+def select_where(db, table, where):
+    """
+    Select items in the table where an expression
+    is True.
+
+    We don't always want to scan the entire database
+    if we don't have to. So we chech for all exact
+    matches on what we can select on directly using
+    handle and gramps_id lookup methods.
+    """
+    if where:
+        indexed_expressions = []
+        get_indexed_fields(where, indexed_expressions)
+        if indexed_expressions:
+            handles_returned = []
+            for indexed in indexed_expressions:
+                index_field, compare, index_value = indexed
+                if index_field == "$.gramps_id":
+                    func_name = "raw_id_func"
+                elif index_field == "$.handle":
+                    func_name = "raw_func"
+                else:
+                    raise Exception("index must be handle or gramps_id")
+
+                row = db._get_table_func(table.title(), func_name)(index_value)
+                if match_where(row, where):
+                    # Don't return the same row more than once:
+                    if row["handle"] not in handles_returned:
+                        handles_returned.append(row["handle"])
+                        yield row
+            return
+
+    # Otherwise, we have to scan the whole table:
+    iter_func = db._get_table_func(table.title(), "cursor_func")
+    for row in iter_func():
+        if where:
+            if match_where(row[1], where):
+                yield row[1]
+        else:
+            yield row[1]
+
+
+def sort_function(item, sort_by):
+    """
+    Given a list of json paths, return a
+    tuple of associated values for sorting.
+    """
+    results = get_items(item, sort_by)
+    return tuple(results.values())
+
+
+def get_items(row, selections):
+    """
+    Given a list of json paths, get the
+    items from the row.
+    """
+    results = {}
+    for json_path in selections:
+        if json_path == "$":
+            results = row
+        else:
+            match = match_json_path(json_path, row)
+            if match:
+                results[json_path[2:]] = match[0].value
+    return results
+
+
+def match_json_path(json_path, row):
+    """
+    Return the matching json_path item if the given
+    json_path matches.
+    """
+    if json_path not in PARSE_CACHE:
+        PARSE_CACHE[json_path] = jsonpath_ng.parse(json_path)
+    jsonpath_expr = PARSE_CACHE[json_path]
+    match = jsonpath_expr.find(row)
+    return match
+
+def eval_expr(expr, data):
+    if isinstance(expr, str) and expr.startswith("$"):
+        match = match_json_path(expr, data)
+        if match:
+            return match[0].value
+        else:
+            return None
+
+    return expr
+
+
+def match_where(data, where):
+    """
+    Assumes all comparisons are using JSONpath
+    ("gender", "=", value)
+    """
+    if len(where) == 3:
+        lhs = eval_expr(where[0], data)
+        op = where[1].lower()
+        rhs = eval_expr(where[2], data)
+        return compare_where(lhs, op, rhs)
+    elif where[0].lower() == "and":
+        for expr in where[1]:
+            result = match_where(data, expr)
+            if not result:
+                return False
+        return True
+    elif where[0].lower() == "or":
+        for expr in where[1]:
+            result = match_where(data, expr)
+            if result:
+                return True
+        return False
+    else:
+        raise Exception("Malformed where expression: %r" % where)
+
+
+def compare_where(lhs, op, rhs):
+    """
+    Evaluate the where expression.
+    """
+    if op == "=":
+        return lhs == rhs
+    elif op == "!=":
+        return lhs != rhs
+    elif op == "<":
+        return lhs < rhs
+    elif op == ">":
+        return lhs > rhs
+    elif op == "in":
+        return lhs in rhs
+    elif op == "not in":
+        return lhs not in rhs
+    else:
+        raise Exception("Operator %r is not supported" % op)
+
+
+def get_indexed_fields(where, indexes):
+    """
+    Recursive function that accumpulates matches
+    in the mutable `indexes` list.
+
+    A match is an expression that compares "$.handle"
+    or "$.gramps_id" equal to a value.
+
+    where - a tuple expression, "or" or "and"
+    indexes - pass in a list
+
+    Example where clauses:
+
+    There are 4 cases to consider:
+    ```
+    ("$.gramps_id", "=", "I0043")
+    ("$.handle", "=", "abc23652")
+    ("and", (...))
+    ("or", (...))
+    ```
+    """
+    if len(where) == 3:
+        # A comparison expression
+        if where[0] in ["$.gramps_id", "$.handle"] and where[1] == "=":
+            indexes += [where]
+    else:
+        # Must be ("and", exprs) or ("or", exprs)
+        # Recurse on all expressions
+        for expr in where[1]:
+            get_indexed_fields(expr, indexes)

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -1224,8 +1224,13 @@ class DBAPI(DbGeneric):
                 return expressions_str
 
     def select(
-            self, table, selections=None, where=None, sort_by=None,
-            page=0, page_size=25,
+        self,
+        table,
+        selections=None,
+        where=None,
+        sort_by=None,
+        page=0,
+        page_size=25,
     ):
         """This is a DB-API implementation of the DbGeneric.select()
         method.
@@ -1270,10 +1275,14 @@ class DBAPI(DbGeneric):
 
         """
         selections = selections if selections else ["$"]
-        select_clause = ", ".join([self._convert_expr_to_sql(item) for item in selections])
+        select_clause = ", ".join(
+            [self._convert_expr_to_sql(item) for item in selections]
+        )
         where_clause = self._convert_where_expr_to_sql(where) if where else ""
         sort_by = sort_by if sort_by else []
-        sort_by_clause = ", ".join([self._convert_expr_to_sql(item) for item in sort_by])
+        sort_by_clause = ", ".join(
+            [self._convert_expr_to_sql(item) for item in sort_by]
+        )
         if page_size is None:
             offset_limit_clause = ""
         else:

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -1210,19 +1210,16 @@ class DBAPI(DbGeneric):
         This method can be overloaded for different SQL
         syntaxes.
         """
-        if len(where) == 3:
+        if where[1].lower() in ["and", "or"]:
+            lhs = self._convert_where_expr_to_sql(where[0])
+            cond = where[1]
+            rhs = self._convert_where_expr_to_sql(where[2])
+            return "(%s %s %s)" % (lhs, cond, rhs)
+        else:
             lhs = self._convert_expr_to_sql(where[0])
             op = where[1]
             rhs = self._convert_expr_to_sql(where[2])
             return "(%s %s %s)" % (lhs, op, rhs)
-        else:
-            cond = where[0]
-            expressions = [self._convert_where_expr_to_sql(expr) for expr in where[1]]
-            expressions_str = (" " + cond + " ").join(expressions)
-            if len(expressions) > 1:
-                return "(%s)" % expressions_str
-            else:
-                return expressions_str
 
     def select(
         self,

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -1295,7 +1295,7 @@ class DBAPI(DbGeneric):
 
         self.dbapi.execute(
             f"select {select_clause} from {table}{where_clause}{sort_by_clause}{offset_limit_clause};",
-            values
+            values,
         )
         for row in self.dbapi.fetchall():
             if "$" in selections:


### PR DESCRIPTION
This PR adds a generic method for querying the database. It has a pure-python implementation (in case some database backend cannot implement it, or for testing, but not designed for real use) and a DB-API implementation. The pure-python version could be removed from this PR.

## Motivation

As we create an optimized filter API, we will need to create methods for querying the data using the power of the underlying database (such as SQL, or MongoDB). Some of these methods will require "business logic" methods that require JOINS or other more complicated queries.

However, a large number of queries are simple and can be implemented by simply querying the JSON data in a table.

## Example

There are many examples in the 274 filter rules. Here is one that is used often: `_hastag.py`. This is used to determine if an object contains a tag.

```python
    def apply(self, db, obj):
        """
        Apply the rule.  Return True for a match.
        """
        if self.tag_handle is None:
            return False
        return self.tag_handle in obj.get_tag_list()
```

Currently, it is designed to examine every object to see if the tag_handle is in the tag_list.

However, that can be re-written as:

```python
    def prepare(self, db, user):
        self.tag_handle = None
        tag = db.get_tag_from_name(self.list[0])
        if tag is not None:
            self.tag_handle = tag.get_handle()
            results = db.select(self.table, ["$.handle"], ("$.tag_list", "LIKE", f'%"{self.tag_handle}"%'))
            self.map = set([row["handle"] for row in list(results)])
        else:
            self.map = set()

    def apply_to_one(self, db, data):
        return data["handle"] in self.map
```

The key line is:

```python
db.select(self.table, ["$.handle"], ("$.tag_list", "LIKE", f'%"{self.tag_handle}"%'))
```

## Decision

The choice is:

1. Write specific methods for each of these simple selects
2. Add a single method, `db.select()`, that will prevent having to write dozens of one-line methods

We need to make this decision before touching the 274 rules for the filter refactor/optimize PR.