### PR TITLE
Fix exception when finding relationship to home person

### DIFF
--- a/gramps/plugins/quickview/all_relations.py
+++ b/gramps/plugins/quickview/all_relations.py
@@ -380,7 +380,7 @@ class AllRelReport:
                     for val in fam[1:]:
                         # TODO for Arabic, should the next comma be translated?
                         famstr += ", " + str(val + 1)
-                else:
+                elif fam is not None:
                     famstr = str(fam + 1)
                 sdoc.paragraph(_FMT_DET2 % (" ", par_str, birth_str, famstr))
                 counter = ""


### PR DESCRIPTION
Fixes [#13495](https://gramps-project.org/bugs/view.php?id=13495)

Proposed bug fix to catch the unhandled exception by testing for None. However, it's not a guaranteed fix because no data was provided to test the bug.

Question remains what is the family tree that leads to the exception? Is it a valid case? Should it be handled in a way that isn't being done now? If it isn't valid, is it being captured by check and repair database?