### PR TITLE
Gramps version output now reports OS rather than Platform

### DIFF
--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -29,8 +29,8 @@
 # -------------------------------------------------------------------------
 import sys
 import os
+import platform
 import signal
-
 import logging
 
 LOG = logging.getLogger(".")
@@ -534,7 +534,7 @@ def show_settings():
     print("Gramps Settings:")
     print("----------------")
     print(" gramps    : %s" % gramps_str)
-    print(" o.s.      : %s" % sys.platform)
+    print(" o.s.      : %s" % platform.system())
     if kernel:
         print(" kernel    : %s" % kernel)
     print("")


### PR DESCRIPTION
Fixes [#12285](https://gramps-project.org/bugs/view.php?id=12285)

Currently `gramps -v` reports the platform instead of O.S. which is confusing to users. Now Gramps will report the operating system name. Reference: [platform.system()](https://docs.python.org/3/library/platform.html#platform.system). There's a difference in capitalization between platform and system, so `linux` is reported as `Linux` and likewise for Darwin.

Current:
```
Gramps Settings:
----------------
gramps    : AIO64-5.2.2-r1-f905d14
o.s.      : win32

```
With this change:
```
Gramps Settings:
----------------
gramps    : AIO64-5.2.2-r1-f905d14
o.s.      : Windows
```