### PR TITLE
WIP: AIO build updates

### DIFF
--- a/aio/README.md
+++ b/aio/README.md
@@ -1,25 +1,30 @@
-The files in this directory are used to build the Windows AIO (All In One) installer.
+The files in this directory are used to build the Gramps Windows AIO (All In One) installer.
 
 To build AIO for the master branch :
 
-1. install msys2
-* download msys2 from <https://www.msys2.org/> .
-* install with default options. 
-* run "MSYS2 MINGW64"
-* upgrade system : ` pacman -Syuu --noconfirm `  (twice if first run close msys2).
+1. Install MSYS2
+    * Download MSYS2 from <https://www.msys2.org/> .
+    * Install with default options. 
+    * Run "MSYS2 MINGW64"
+    * Upgrade system : ` pacman -Syuu --noconfirm `  (twice if first run close msys2).
 
-2. download sources from github :
-
+2. Install Git, if not already installed
 ```
 pacman -S git --noconfirm
+```
+
+3. Download Gramps sources from github :
+
+```
 git clone https://github.com/gramps-project/gramps.git
 ```
 
-3. build AIO :
+4. Build AIO :
 
 ```
 cd gramps/aio
 ./build.sh
 ```
+To capture the full output of the build, use `./build.sh >& build_log.txt`
 
-result is in gramps/aio/mingw64/src
+Resulting AIO installer is in gramps/aio/mingw64/src/GrampsAIO-[appversion]-[appbuild]-[hash]_win64.exe

--- a/aio/build.sh
+++ b/aio/build.sh
@@ -5,10 +5,12 @@
 # install prerequisites
 ## prerequisites in msys packages
 pacman -S --needed --noconfirm mingw-w64-x86_64-python mingw-w64-x86_64-python-pip mingw-w64-x86_64-gexiv2 mingw-w64-x86_64-ghostscript mingw-w64-x86_64-python-cairo mingw-w64-x86_64-python-gobject mingw-w64-x86_64-python-icu mingw-w64-x86_64-iso-codes mingw-w64-x86_64-hunspell mingw-w64-x86_64-enchant perl-XML-Parser intltool mingw-w64-x86_64-python-lxml mingw-w64-x86_64-python-jsonschema mingw-w64-x86_64-gspell mingw-w64-x86_64-geocode-glib mingw-w64-x86_64-python-pillow git mingw-w64-x86_64-graphviz mingw-w64-x86_64-goocanvas mingw-w64-x86_64-osm-gps-map base-devel subversion mingw-w64-x86_64-python-graphviz mingw-w64-x86_64-osm-gps-map mingw-w64-x86_64-nsis mingw-w64-x86_64-python-requests mingw-w64-x86_64-adwaita-icon-theme mingw-w64-x86_64-python-networkx mingw-w64-x86_64-python-psycopg2 upx mingw-w64-x86_64-python-packaging unzip mingw-w64-x86_64-python-nose mingw-w64-x86_64-python-wheel
+pacman -S --needed --noconfirm mingw-w64-x86_64-python-build
+pacman -S --needed --noconfirm mingw-w64-x86_64-python-cx-freeze
+pacman -S --needed --noconfirm mingw-w64-x86_64-python-distlib
+pacman -S --needed --noconfirm mingw-w64-x86_64-python-lief
+pacman -S --needed --noconfirm mingw-w64-x86_64-python-setuptools
 pacman -S --needed --noconfirm mingw-w64-x86_64-toolchain
-
-wget --no-verbose -N https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-python-cx-freeze-6.15.9-1-any.pkg.tar.zst
-pacman -U --needed --noconfirm mingw-w64-x86_64-python-cx-freeze-6.15.9-1-any.pkg.tar.zst
 
 wget --no-verbose -N https://github.com/bpisoj/MINGW-packages/releases/download/v5.0/mingw-w64-x86_64-db-6.0.30-1-any.pkg.tar.xz
 pacman -U --needed --noconfirm mingw-w64-x86_64-db-6.0.30-1-any.pkg.tar.xz
@@ -71,7 +73,7 @@ popd
 mkdir -p /mingw64/share/enchant/voikko
 pushd /mingw64/share/enchant/voikko
 wget --no-verbose -N https://www.puimula.org/htp/testing/voikko-snapshot-v5/dict.zip
-unzip -o dict.zip
+unzip -q -o dict.zip
 rm dict.zip
 popd
 
@@ -79,12 +81,12 @@ popd
 #cd D:/a/gramps/gramps/aio
 
 ## create a directory structure for icons
-mkdir /mingw64/share/icons/gnome
-mkdir /mingw64/share/icons/gnome/48x48
-mkdir /mingw64/share/icons/gnome/48x48/mimetypes
-mkdir /mingw64/share/icons/gnome/scalable
-mkdir /mingw64/share/icons/gnome/scalable/mimetypes
-mkdir /mingw64/share/icons/gnome/scalable/places
+mkdir -p /mingw64/share/icons/gnome
+mkdir -p /mingw64/share/icons/gnome/48x48
+mkdir -p /mingw64/share/icons/gnome/48x48/mimetypes
+mkdir -p /mingw64/share/icons/gnome/scalable
+mkdir -p /mingw64/share/icons/gnome/scalable/mimetypes
+mkdir -p /mingw64/share/icons/gnome/scalable/places
 
 # Change to the gramps root directory
 cd ..
@@ -107,7 +109,7 @@ rm -rf dist aio/dist
 python setup.py bdist_wheel
 appbuild="r$(git rev-list --count HEAD)-$(git rev-parse --short HEAD)"
 appversion=$(grep "^VERSION_TUPLE" gramps/version.py|sed 's/.*(//;s/, */\./g;s/).*//')
-unzip -d aio/dist dist/*.whl
+unzip -q -d aio/dist dist/*.whl
 cd aio
 
 # create nsis script

--- a/aio/setup.py
+++ b/aio/setup.py
@@ -97,7 +97,6 @@ EXCLUDES = [
     "PyQt5.QtGui",
     "pyside" "PyQt5.QtWidgets",
     "sip",
-    "lib2to3",
     "PIL.ImageQt",
     "pip",
     "distlib",
@@ -108,7 +107,7 @@ REPLACE_PATHS = [
 ]
 MISSING_DLL = [
     "libgtk-3-0.dll",
-    "libgspell-1-2.dll",
+    "libgspell-1-3.dll",
     "libgexiv2-2.dll",
     "libgoocanvas-3.0-9.dll",
     "libosmgpsmap-1.0-1.dll",
@@ -132,10 +131,6 @@ MISSING_DLL = [
 BIN_EXCLUDES = ["Qt5Core.dll", "gdiplus.dll", "gdiplus"]
 
 from os.path import dirname, basename
-import lib2to3
-
-lib23_path = dirname(lib2to3.__file__)
-INCLUDE_FILES.append((lib23_path, "lib/lib2to3"))
 import pip
 
 libpip_path = dirname(pip.__file__)


### PR DESCRIPTION
1. Changes required due to updating MSYS2 environment (e.g. gspell version, cx-freeze etc.)
2. Remove references to lib2to3 (deprecated)
3. Reduce log output from build.sh so errors and warnings are easier to spot
4. Cleanup README

This is **not ready to merge**, because the AIO build doesn't complete without warnings/errors. For now I've marked it as a draft PR so others can continue working on it until the changes are complete.

FYI @ennoborg 