### PR TITLE
Add gen.db.conversion_tools from PR #1786

### DIFF
--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -84,6 +84,11 @@ gramps/gen/db/txn.py
 gramps/gen/db/undoredo.py
 gramps/gen/db/utils.py
 #
+# gen.db.conversion_tools package
+#
+gramps/gen/db/conversion_tools/__init__.py
+gramps/gen/db/conversion_tools/conversion_21.py
+#
 # gen.display package
 #
 gramps/gen/display/__init__.py

--- a/setup.py
+++ b/setup.py
@@ -262,6 +262,7 @@ package_core = [
     "gramps.gen",
     "gramps.gen.datehandler",
     "gramps.gen.db",
+    "gramps.gen.db.conversion_tools",
     "gramps.gen.display",
     "gramps.gen.filters",
     "gramps.gen.filters.rules",


### PR DESCRIPTION
The `gen.db.conversion_tools` package is missing from `setup.py` and its files from `po/POTFILES.skip`.