### PR TITLE
Teach GrampsType.set() to work with a dict

### DIFF
--- a/gramps/gen/lib/grampstype.py
+++ b/gramps/gen/lib/grampstype.py
@@ -151,6 +151,10 @@ class GrampsType(metaclass=GrampsTypeMeta):
         else:
             self.__string = ""
 
+    def __set_dict(self, value):
+        "Set the value/string properties from a dict."
+        self.__set_tuple((value["value"], value["string"]))
+
     def __set_tuple(self, value):
         "Set the value/string properties from a tuple."
         val, strg = self._DEFAULT, ""
@@ -184,7 +188,9 @@ class GrampsType(metaclass=GrampsTypeMeta):
 
     def set(self, value):
         "Set the value/string properties from the passed in value."
-        if isinstance(value, tuple):
+        if isinstance(value, dict):
+            self.__set_dict(value)
+        elif isinstance(value, tuple):
             self.__set_tuple(value)
         elif isinstance(value, int):
             self.__set_int(value)
@@ -228,6 +234,25 @@ class GrampsType(metaclass=GrampsTypeMeta):
         return (self.__value, self.__string)
 
     @classmethod
+    def __get_str(cls, value, string):
+        if value == cls._CUSTOM:
+            return string
+        else:
+            return cls._I2SMAP.get(value, _UNKNOWN)
+
+    @classmethod
+    def get_str(cls, data):
+        """
+        Return the translated string corresponding to the type.
+
+        :param data: A dict representation of the type.
+        :type data: dict
+        :returns: The translated string corresponding to the type.
+        :rtype: str
+        """
+        return cls.__get_str(data.value, data.string)
+
+    @classmethod
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -253,9 +278,7 @@ class GrampsType(metaclass=GrampsTypeMeta):
         return self
 
     def __str__(self):
-        if self.__value == self._CUSTOM:
-            return self.__string
-        return self._I2SMAP.get(self.__value, _UNKNOWN)
+        return type(self).__get_str(self.__value, self.__string)
 
     def __int__(self):
         return self.__value

--- a/gramps/gui/views/treemodels/eventmodel.py
+++ b/gramps/gui/views/treemodels/eventmodel.py
@@ -145,7 +145,7 @@ class EventModel(FlatBaseModel):
             return ""
 
     def column_type(self, data):
-        return str(EventType(data["type"]))
+        return EventType.get_str(data.type)
 
     def column_id(self, data):
         return data["gramps_id"]

--- a/gramps/gui/views/treemodels/familymodel.py
+++ b/gramps/gui/views/treemodels/familymodel.py
@@ -165,7 +165,7 @@ class FamilyModel(FlatBaseModel):
         return value
 
     def column_type(self, data):
-        return data["type"]["string"]
+        return FamilyRelType.get_str(data.type)
 
     def column_marriage(self, data):
         handle = data["handle"]

--- a/gramps/gui/views/treemodels/notemodel.py
+++ b/gramps/gui/views/treemodels/notemodel.py
@@ -118,9 +118,7 @@ class NoteModel(FlatBaseModel):
 
     def column_type(self, data):
         """Return the type of the Note in readable format."""
-        temp = NoteType()
-        temp.set(data["type"])
-        return str(temp)
+        return NoteType.get_str(data.type)
 
     def column_preview(self, data):
         """Return a shortend version of the Note's text."""

--- a/gramps/gui/views/treemodels/placemodel.py
+++ b/gramps/gui/views/treemodels/placemodel.py
@@ -188,8 +188,7 @@ class PlaceBaseModel:
         return data["gramps_id"]
 
     def column_type(self, data):
-        pt = from_dict(data["place_type"])
-        return str(pt)
+        return PlaceType.get_str(data.place_type)
 
     def column_code(self, data):
         return data["code"]

--- a/gramps/gui/views/treemodels/repomodel.py
+++ b/gramps/gui/views/treemodels/repomodel.py
@@ -134,7 +134,7 @@ class RepositoryModel(FlatBaseModel):
         return data["gramps_id"]
 
     def column_type(self, data):
-        return str(RepositoryType(data["type"]))
+        return RepositoryType.get_str(data.type)
 
     def column_name(self, data):
         return data["name"]


### PR DESCRIPTION
Teach GrampsType.set() how to work when value is of `dict` type
This fixes a bug introduced by PR #1786 

To reproduce:
1. create a new, empty, tree
2. switch to event view
3. create a new event, changing the event type to Death
4. observe that the event type is shown as `Birth` in the event view
