### PR TITLE
Update database method names

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -2739,3 +2739,45 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             self.serializer = BlobSerializer
         elif serializer_name == "json":
             self.serializer = JSONSerializer
+
+    # New names for methods:
+
+    get_person = get_person_from_handle
+    get_family = get_family_from_handle
+    get_source = get_source_from_handle
+    get_citation = get_citation_from_handle
+    get_event = get_event_from_handle
+    get_media = get_media_from_handle
+    get_place = get_place_from_handle
+    get_repository = get_repository_from_handle
+    get_note = get_note_from_handle
+
+    get_person_data = get_raw_person_data
+    get_family_data = get_raw_family_data
+    get_source_data = get_raw_source_data
+    get_citation_data = get_raw_citation_data
+    get_event_data = get_raw_event_data
+    get_media_data = get_raw_media_data
+    get_place_data = get_raw_place_data
+    get_repository_data = get_raw_repository_data
+    get_note_data = get_raw_note_data
+
+    get_person_from_id = get_person_from_gramps_id
+    get_family_from_id = get_family_from_gramps_id
+    get_source_from_id = get_source_from_gramps_id
+    get_citation_from_id = get_citation_from_gramps_id
+    get_event_from_id = get_event_from_gramps_id
+    get_media_from_id = get_media_from_gramps_id
+    get_place_from_id = get_place_from_gramps_id
+    get_repository_from_id = get_repository_from_gramps_id
+    get_note_from_id = get_note_from_gramps_id
+
+    get_person_data_from_id = _get_raw_person_from_id_data
+    get_family_data_from_id = _get_raw_family_from_id_data
+    get_source_data_from_id = _get_raw_source_from_id_data
+    get_citation_data_from_id = _get_raw_citation_from_id_data
+    get_event_data_from_id = _get_raw_event_from_id_data
+    get_media_data_from_id = _get_raw_media_from_id_data
+    get_place_data_from_id = _get_raw_place_from_id_data
+    get_repository_data_from_id = _get_raw_repository_from_id_data
+    get_note_data_from_id = _get_raw_note_from_id_data

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -64,6 +64,7 @@ from ..lib.researcher import Researcher
 from ..updatecallback import UpdateCallback
 from ..utils.callback import Callback
 from ..utils.id import create_id
+from ..utils.logging import log_once_per_level
 from . import (
     CITATION_KEY,
     DBLOGNAME,
@@ -2742,42 +2743,389 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
 
     # New names for methods:
 
-    get_person = get_person_from_handle
-    get_family = get_family_from_handle
-    get_source = get_source_from_handle
-    get_citation = get_citation_from_handle
-    get_event = get_event_from_handle
-    get_media = get_media_from_handle
-    get_place = get_place_from_handle
-    get_repository = get_repository_from_handle
-    get_note = get_note_from_handle
+    def get_person_from_handle(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_person_from_handle has been deprecated; please use db.get_person",
+        )
+        return self.get_person(*args, **kwargs)
 
-    get_person_data = get_raw_person_data
-    get_family_data = get_raw_family_data
-    get_source_data = get_raw_source_data
-    get_citation_data = get_raw_citation_data
-    get_event_data = get_raw_event_data
-    get_media_data = get_raw_media_data
-    get_place_data = get_raw_place_data
-    get_repository_data = get_raw_repository_data
-    get_note_data = get_raw_note_data
+    def get_family_from_handle(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_family_from_handle has been deprecated; please use db.get_family",
+        )
+        return self.get_family(*args, **kwargs)
 
-    get_person_from_id = get_person_from_gramps_id
-    get_family_from_id = get_family_from_gramps_id
-    get_source_from_id = get_source_from_gramps_id
-    get_citation_from_id = get_citation_from_gramps_id
-    get_event_from_id = get_event_from_gramps_id
-    get_media_from_id = get_media_from_gramps_id
-    get_place_from_id = get_place_from_gramps_id
-    get_repository_from_id = get_repository_from_gramps_id
-    get_note_from_id = get_note_from_gramps_id
+    def get_source_from_handle(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_source_from_handle has been deprecated; please use db.get_source",
+        )
+        return self.get_source(*args, **kwargs)
 
-    get_person_data_from_id = _get_raw_person_from_id_data
-    get_family_data_from_id = _get_raw_family_from_id_data
-    get_source_data_from_id = _get_raw_source_from_id_data
-    get_citation_data_from_id = _get_raw_citation_from_id_data
-    get_event_data_from_id = _get_raw_event_from_id_data
-    get_media_data_from_id = _get_raw_media_from_id_data
-    get_place_data_from_id = _get_raw_place_from_id_data
-    get_repository_data_from_id = _get_raw_repository_from_id_data
-    get_note_data_from_id = _get_raw_note_from_id_data
+    def get_citation_from_handle(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_citation_from_handle has been deprecated; please use db.get_citation",
+        )
+        return self.get_citation(*args, **kwargs)
+
+    def get_event_from_handle(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_event_from_handle has been deprecated; please use db.get_event",
+        )
+        return self.get_event(*args, **kwargs)
+
+    def get_media_from_handle(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_media_from_handle has been deprecated; please use db.get_media",
+        )
+        return self.get_media(self, *args, **kwargs)
+
+    def get_place_from_handle(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_place_from_handle has been deprecated; please use db.get_place",
+        )
+        return self.get_place(self, *args, **kwargs)
+
+    def get_repository_from_handle(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_repository_from_handle has been deprecated; please use db.get_repository",
+        )
+        return self.get_repository(self, *args, **kwargs)
+
+    def get_note_from_handle(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_note_from_handle has been deprecated; please use db.get_note",
+        )
+        return self.get_note(self, *args, **kwargs)
+
+    def get_raw_person_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_raw_person_data has been deprecated; please use db.get_person_data",
+        )
+        return self.get_person_data(self, *args, **kwargs)
+
+    def get_raw_family_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_raw_family_data has been deprecated; please use db.get_family_data",
+        )
+        return self.get_family_data(self, *args, **kwargs)
+
+    def get_raw_source_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_raw_source_data has been deprecated; please use db.get_source_data",
+        )
+        return self.get_source_data(self, *args, **kwargs)
+
+    def get_raw_citation_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_raw_citation_data has been deprecated; please use db.get_citation_data",
+        )
+        return self.get_citation_data(self, *args, **kwargs)
+
+    def get_raw_event_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_raw_event_data has been deprecated; please use db.get_event_data",
+        )
+        return self.get_event_data(self, *args, **kwargs)
+
+    def get_raw_media_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_raw_media_data has been deprecated; please use db.get_media_data",
+        )
+        return self.get_media_data(self, *args, **kwargs)
+
+    def get_raw_place_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_raw_place_data has been deprecated; please use db.get_place_data",
+        )
+        return self.get_place_data(self, *args, **kwargs)
+
+    def get_raw_repository_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_raw_repository_data has been deprecated; please use db.get_repository_data",
+        )
+        return self.get_repository_data(self, *args, **kwargs)
+
+    def get_raw_note_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_raw_note_data has been deprecated; please use db.get_note_data",
+        )
+        return self.get_note_data(self, *args, **kwargs)
+
+    def get_person_from_gramps_id(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_person_from_gramps_id has been deprecated; please use db.get_person_from_id",
+        )
+        return self.get_person_from_id(self, *args, **kwargs)
+
+    def get_family_from_gramps_id(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_family_from_gramps_id has been deprecated; please use db.get_family_from_id",
+        )
+        return self.get_family_from_id(self, *args, **kwargs)
+
+    def get_source_from_gramps_id(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_source_from_gramps_id has been deprecated; please use db.get_source_from_id",
+        )
+        return self.get_source_from_id(self, *args, **kwargs)
+
+    def get_citation_from_gramps_id(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_citation_from_gramps_id has been deprecated; please use db.get_citation_from_id",
+        )
+        return self.get_citation_from_id(self, *args, **kwargs)
+
+    def get_event_from_gramps_id(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_event_from_gramps_id has been deprecated; please use db.get_event_from_id",
+        )
+        return self.get_event_from_id(self, *args, **kwargs)
+
+    def get_media_from_gramps_id(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_media_from_gramps_id has been deprecated; please use db.get_media_from_id",
+        )
+        return self.get_media_from_id(self, *args, **kwargs)
+
+    def get_place_from_gramps_id(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_place_from_gramps_id has been deprecated; please use db.get_place_from_id",
+        )
+        return self.get_place_from_id(self, *args, **kwargs)
+
+    def get_repository_from_gramps_id(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_repository_from_gramps_id has been deprecated; please use db.get_repository_from_id",
+        )
+        return self.get_repository_from_id(self, *args, **kwargs)
+
+    def get_note_from_gramps_id(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.get_note_from_gramps_id has been deprecated; please use db.get_note_from_id",
+        )
+        return self.get_note_from_id(self, *args, **kwargs)
+
+    def _get_raw_person_from_id_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._get_raw_person_from_id_data has been deprecated; please use db.get_person_data_from_id",
+        )
+        return self.get_person_data_from_id(self, *args, **kwargs)
+
+    def _get_raw_family_from_id_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._get_raw_family_from_id_data has been deprecated; please use db.get_family_data_from_id",
+        )
+        return self.get_family_data_from_id(self, *args, **kwargs)
+
+    def _get_raw_source_from_id_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._get_raw_source_from_id_data has been deprecated; please use db.get_source_data_from_id",
+        )
+        return self.get_source_data_from_id(self, *args, **kwargs)
+
+    def _get_raw_citation_from_id_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._get_raw_citation_from_id_data has been deprecated; please use db.get_citation_data_from_id",
+        )
+        return self.get_citation_data_from_id(self, *args, **kwargs)
+
+    def _get_raw_event_from_id_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._get_raw_event_from_id_data has been deprecated; please use db.get_event_data_from_id",
+        )
+        return self.get_event_data_from_id(self, *args, **kwargs)
+
+    def _get_raw_media_from_id_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._get_raw_media_from_id_data has been deprecated; please use db.get_media_data_from_id",
+        )
+        return self.get_media_data_from_id(self, *args, **kwargs)
+
+    def _get_raw_place_from_id_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._get_raw_place_from_id_data has been deprecated; please use db.get_place_data_from_id",
+        )
+        return self.get_place_data_from_id(self, *args, **kwargs)
+
+    def _get_raw_repository_from_id_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._get_raw_repository_from_id_data has been deprecated; please use db.get_repository_data_from_id",
+        )
+        return self.get_repository_data_from_id(self, *args, **kwargs)
+
+    def _get_raw_note_from_id_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._get_raw_note_from_id_data has been deprecated; please use db.get_note_data_from_id",
+        )
+        return self.get_note_data_from_id(self, *args, **kwargs)
+
+    def _iter_raw_person_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._iter_raw_person_data has been deprecated; please use db.iter_person_data",
+        )
+        return self.iter_person_data(self, *args, **kwargs)
+
+    def _iter_raw_family_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._iter_raw_family_data has been deprecated; please use db.iter_family_data",
+        )
+        return self.iter_family_data(self, *args, **kwargs)
+
+    def _iter_raw_event_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._iter_raw_event_data has been deprecated; please use db.iter_event_data",
+        )
+        return self.iter_event_data(self, *args, **kwargs)
+
+    def _iter_raw_place_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._iter_raw_place_data has been deprecated; please use db.iter_place_data",
+        )
+        return self.iter_place_data(self, *args, **kwargs)
+
+    def _iter_raw_repository_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._iter_raw_repository_data has been deprecated; please use db.iter_repository_data",
+        )
+        return self.iter_repository_data(self, *args, **kwargs)
+
+    def _iter_raw_source_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._iter_raw_source_data has been deprecated; please use db.iter_source_data",
+        )
+        return self.iter_source_data(self, *args, **kwargs)
+
+    def _iter_raw_citation_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._iter_raw_citation_data has been deprecated; please use db.iter_citation_data",
+        )
+        return self.iter_citation_data(self, *args, **kwargs)
+
+    def _iter_raw_media_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._iter_raw_media_data has been deprecated; please use db.iter_media_data",
+        )
+        return self.iter_media_data(self, *args, **kwargs)
+
+    def _iter_raw_note_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._iter_raw_note_data has been deprecated; please use db.iter_note_data",
+        )
+        return self.iter_note_data(self, *args, **kwargs)
+
+    def _iter_raw_tag_data(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db._iter_raw_tag_data has been deprecated; please use db.iter_tag_data",
+        )
+        return self.iter_tag_data(self, *args, **kwargs)
+
+    def iter_citations(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.iter_citations has been deprecated; please use db.iter_citation",
+        )
+        return self.iter_citation(self, *args, **kwargs)
+
+    def iter_events(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO, "db.iter_events has been deprecated; please use db.iter_event"
+        )
+        return self.iter_event(self, *args, **kwargs)
+
+    def iter_families(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.iter_families has been deprecated; please use db.iter_family",
+        )
+        return self.iter_family(self, *args, **kwargs)
+
+    def iter_media(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO, "db.iter_media has been deprecated; please use db.iter_media"
+        )
+        return self.iter_media(self, *args, **kwargs)
+
+    def iter_notes(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO, "db.iter_notes has been deprecated; please use db.iter_note"
+        )
+        return self.iter_note(self, *args, **kwargs)
+
+    def iter_people(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.iter_people has been deprecated; please use db.iter_person",
+        )
+        return self.iter_person(self, *args, **kwargs)
+
+    def iter_places(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO, "db.iter_places has been deprecated; please use db.iter_place"
+        )
+        return self.iter_place(self, *args, **kwargs)
+
+    def iter_repositories(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.iter_repositories has been deprecated; please use db.iter_repository",
+        )
+        return self.iter_repository(self, *args, **kwargs)
+
+    def iter_sources(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO,
+            "db.iter_sources has been deprecated; please use db.iter_source",
+        )
+        return self.iter_source(self, *args, **kwargs)
+
+    def iter_tags(self, *args, **kwargs):
+        log_once_at_level(
+            logging.INFO, "db.iter_tags has been deprecated; please use db.iter_tag"
+        )
+        return self.iter_tag(self, *args, **kwargs)

--- a/gramps/gen/utils/logging.py
+++ b/gramps/gen/utils/logging.py
@@ -1,0 +1,60 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025       Doug Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Logging utilities
+"""
+
+import logging
+from typing import Any, Set
+
+LOGGER = logging.getLogger(".")
+LOG_ONCE_CACHE: Set[str] = set()
+
+
+def log_once_at_level(
+    logging_level: int, message: str, *args: Any, **kwargs: Any
+) -> None:
+    """
+    Log the given message once at the given level then at the DEBUG
+    level on further calls.
+
+    This is a global setting, removed with
+    remove_log_once_at_level(MESSAGE)
+    """
+    global LOG_ONCE_CACHE
+
+    if message not in LOG_ONCE_CACHE:
+        LOG_ONCE_CACHE.add(message)
+        LOGGER.log(logging_level, message, *args, **kwargs)
+    else:
+        LOGGER.debug(message, *args, **kwargs)
+
+
+def remove_log_once_at_level(message: str) -> None:
+    """
+    Clears the specified message from the global
+    log-once-per-session cache, enabling it to be logged at the
+    original level again when ``log_once_at_level()`` is subsequently
+    called.
+    """
+    global LOG_ONCE_CACHE
+
+    LOG_ONCE_CACHE.discard(message)


### PR DESCRIPTION
Now that the `raw` data is actually useful, and the data is hardly "raw", it would make sense to update the method names for all of the get_object methods to make them more consistent.

This PR allows aliases for the common getters and iters. If this idea is accepted, I would also update the code base, and provide deprecation messages on the older forms.

Suggestions:

First, some of the methods (`get_raw_person_data`) have an implied `from_handle`. We can remove all `from_handle` from most method names for consistency and usability:

NOTE: **new names on left, current names on right**

```python
    get_person = get_person_from_handle
    get_family = get_family_from_handle
    get_source = get_source_from_handle
    get_citation = get_citation_from_handle
    get_event = get_event_from_handle
    get_media = get_media_from_handle
    get_place = get_place_from_handle
    get_repository = get_repository_from_handle
    get_note = get_note_from_handle
```

Then, we don't need both `raw` and `data`, and is nicely parallel with the above:

```python
    get_person_data = get_raw_person_data
    get_family_data = get_raw_family_data
    get_source_data = get_raw_source_data
    get_citation_data = get_raw_citation_data
    get_event_data = get_raw_event_data
    get_media_data = get_raw_media_data
    get_place_data = get_raw_place_data
    get_repository_data = get_raw_repository_data
    get_note_data = get_raw_note_data
```

We only have one id, so we don't need to explicitly say that it is `gramps`:

```python
    get_person_from_id = get_person_from_gramps_id
    get_family_from_id = get_family_from_gramps_id
    get_source_from_id = get_source_from_gramps_id
    get_citation_from_id = get_citation_from_gramps_id
    get_event_from_id = get_event_from_gramps_id
    get_media_from_id = get_media_from_gramps_id
    get_place_from_id = get_place_from_gramps_id
    get_repository_from_id = get_repository_from_gramps_id
    get_note_from_id = get_note_from_gramps_id
```

<s>These methods are inexplicably private, and using the above rules, suggest</s>:

**NOT USED**: should be deleted.

```python
    _get_raw_person_from_id_data
    _get_raw_family_from_id_data
    _get_raw_source_from_id_data
    _get_raw_citation_from_id_data
    _get_raw_event_from_id_data
    _get_raw_media_from_id_data
    _get_raw_place_from_id_data
    _get_raw_repository_from_id_data
    _get_raw_note_from_id_data
```

Updated with iter-method suggested changes:

```
    iter_person_data = _iter_raw_person_data
    iter_family_data = _iter_raw_family_data
    iter_event_data = _iter_raw_event_data
    iter_place_data = _iter_raw_place_data
    iter_repository_data = _iter_raw_repository_data
    iter_source_data = _iter_raw_source_data
    iter_citation_data = _iter_raw_citation_data
    iter_media_data = _iter_raw_media_data
    iter_note_data = _iter_raw_note_data
    iter_tag_data = _iter_raw_tag_data
```

Changes from plural to singular:

```
    iter_citation = iter_citations
    iter_event = iter_events
    iter_family = iter_families
    iter_media = iter_media
    iter_note = iter_notes
    iter_people = iter_people
    iter_place = iter_places
    iter_repository = iter_repositories
    iter_source = iter_sources
    iter_tag = iter_tags

```

And these would stay the same:

```
    iter_citation_handles
    iter_event_handles
    iter_family_handles
    iter_media_handles
    iter_note_handles
    iter_person_handles
    iter_place_handles
    iter_repository_handles
    iter_source_handles
    iter_tag_handles
```