### PR TITLE
Grampstype set

### DIFF
--- a/gramps/gen/lib/grampstype.py
+++ b/gramps/gen/lib/grampstype.py
@@ -151,6 +151,16 @@ class GrampsType(metaclass=GrampsTypeMeta):
         else:
             self.__string = ""
 
+    def __set_dict(self, value):
+        "Set the value/string properties from a dict."
+        val, strg = self._DEFAULT, ""
+        if value:
+            val = value["value"]
+            if len(value) > 1 and val == self._CUSTOM:
+                strg = value["string"]
+        self.__value = val
+        self.__string = strg
+
     def __set_tuple(self, value):
         "Set the value/string properties from a tuple."
         val, strg = self._DEFAULT, ""
@@ -184,7 +194,9 @@ class GrampsType(metaclass=GrampsTypeMeta):
 
     def set(self, value):
         "Set the value/string properties from the passed in value."
-        if isinstance(value, tuple):
+        if isinstance(value, dict):
+            self.__set_dict(value)
+        elif isinstance(value, tuple):
             self.__set_tuple(value)
         elif isinstance(value, int):
             self.__set_int(value)

--- a/gramps/gen/lib/grampstype.py
+++ b/gramps/gen/lib/grampstype.py
@@ -244,7 +244,7 @@ class GrampsType(metaclass=GrampsTypeMeta):
         if string == cls._CUSTOM:
             return string
         else:
-            return cls._I2SMAP.get(value, cls.UNKNOWN)
+            return cls._I2SMAP.get(value, _UNKNOWN)
 
     @classmethod
     def get_str(cls, dict):

--- a/gramps/gen/lib/grampstype.py
+++ b/gramps/gen/lib/grampstype.py
@@ -240,6 +240,17 @@ class GrampsType(metaclass=GrampsTypeMeta):
         return (self.__value, self.__string)
 
     @classmethod
+    def __get_str(cls, value, string):
+        if string == cls._CUSTOM:
+            return string
+        else:
+            return cls._I2SMAP.get(value, cls.UNKNOWN)
+
+    @classmethod
+    def get_str(cls, dict):
+        return cls.__get_str(dict["value"], dict["string"])
+
+    @classmethod
     def get_schema(cls):
         """
         Returns the JSON Schema for this class.
@@ -265,9 +276,7 @@ class GrampsType(metaclass=GrampsTypeMeta):
         return self
 
     def __str__(self):
-        if self.__value == self._CUSTOM:
-            return self.__string
-        return self._I2SMAP.get(self.__value, _UNKNOWN)
+        return type(self).__get_str(self.__value, self.__string)
 
     def __int__(self):
         return self.__value

--- a/gramps/gen/lib/grampstype.py
+++ b/gramps/gen/lib/grampstype.py
@@ -247,8 +247,8 @@ class GrampsType(metaclass=GrampsTypeMeta):
             return cls._I2SMAP.get(value, _UNKNOWN)
 
     @classmethod
-    def get_str(cls, dict):
-        return cls.__get_str(dict["value"], dict["string"])
+    def get_str(cls, data):
+        return cls.__get_str(data.value, data.string)
 
     @classmethod
     def get_schema(cls):

--- a/gramps/gen/lib/grampstype.py
+++ b/gramps/gen/lib/grampstype.py
@@ -151,7 +151,7 @@ class GrampsType(metaclass=GrampsTypeMeta):
         else:
             self.__string = ""
 
-    def __set_dict(self, value):
+    def set_dict(self, value):
         "Set the value/string properties from a dict."
         val, strg = self._DEFAULT, ""
         if value:
@@ -161,7 +161,7 @@ class GrampsType(metaclass=GrampsTypeMeta):
         self.__value = val
         self.__string = strg
 
-    def __set_tuple(self, value):
+    def set_tuple(self, value):
         "Set the value/string properties from a tuple."
         val, strg = self._DEFAULT, ""
         if value:
@@ -171,12 +171,12 @@ class GrampsType(metaclass=GrampsTypeMeta):
         self.__value = val
         self.__string = strg
 
-    def __set_int(self, value):
+    def set_int(self, value):
         "Set the value/string properties from an integer."
         self.__value = value
         self.__string = ""
 
-    def __set_instance(self, value):
+    def set_instance(self, value):
         "Set the value/string properties from another grampstype."
         self.__value = value.value
         if self.__value == self._CUSTOM:
@@ -184,7 +184,7 @@ class GrampsType(metaclass=GrampsTypeMeta):
         else:
             self.__string = ""
 
-    def __set_str(self, value):
+    def set_str(self, value):
         "Set the value/string properties from a string."
         self.__value = self._S2IMAP.get(value, self._CUSTOM)
         if self.__value == self._CUSTOM:
@@ -195,15 +195,15 @@ class GrampsType(metaclass=GrampsTypeMeta):
     def set(self, value):
         "Set the value/string properties from the passed in value."
         if isinstance(value, dict):
-            self.__set_dict(value)
+            self.set_dict(value)
         elif isinstance(value, tuple):
-            self.__set_tuple(value)
+            self.set_tuple(value)
         elif isinstance(value, int):
-            self.__set_int(value)
+            self.set_int(value)
         elif isinstance(value, self.__class__):
-            self.__set_instance(value)
+            self.set_instance(value)
         elif isinstance(value, str):
-            self.__set_str(value)
+            self.set_str(value)
         else:
             self.__value = self._DEFAULT
             self.__string = ""
@@ -343,5 +343,5 @@ class GrampsType(metaclass=GrampsTypeMeta):
     def __ne__(self, value):
         return not self.__eq__(value)
 
-    value = property(__int__, __set_int, None, "Returns or sets integer value")
-    string = property(__str__, __set_str, None, "Returns or sets string value")
+    value = property(__int__, set_int, None, "Returns or sets integer value")
+    string = property(__str__, set_str, None, "Returns or sets string value")

--- a/gramps/gen/lib/grampstype.py
+++ b/gramps/gen/lib/grampstype.py
@@ -241,7 +241,7 @@ class GrampsType(metaclass=GrampsTypeMeta):
 
     @classmethod
     def __get_str(cls, value, string):
-        if string == cls._CUSTOM:
+        if value == cls._CUSTOM:
             return string
         else:
             return cls._I2SMAP.get(value, _UNKNOWN)

--- a/gramps/gui/views/treemodels/eventmodel.py
+++ b/gramps/gui/views/treemodels/eventmodel.py
@@ -145,7 +145,7 @@ class EventModel(FlatBaseModel):
             return ""
 
     def column_type(self, data):
-        return EventType.get_str(data["type"])
+        return EventType.get_str(data.type)
 
     def column_id(self, data):
         return data["gramps_id"]

--- a/gramps/gui/views/treemodels/eventmodel.py
+++ b/gramps/gui/views/treemodels/eventmodel.py
@@ -145,7 +145,7 @@ class EventModel(FlatBaseModel):
             return ""
 
     def column_type(self, data):
-        return str(EventType(data["type"]))
+        return EventType.get_str(data["type"])
 
     def column_id(self, data):
         return data["gramps_id"]

--- a/gramps/gui/views/treemodels/familymodel.py
+++ b/gramps/gui/views/treemodels/familymodel.py
@@ -165,7 +165,7 @@ class FamilyModel(FlatBaseModel):
         return value
 
     def column_type(self, data):
-        return data["type"]["string"]
+        return FamilyRelType.get_str(data["type"])
 
     def column_marriage(self, data):
         handle = data["handle"]

--- a/gramps/gui/views/treemodels/familymodel.py
+++ b/gramps/gui/views/treemodels/familymodel.py
@@ -165,7 +165,7 @@ class FamilyModel(FlatBaseModel):
         return value
 
     def column_type(self, data):
-        return FamilyRelType.get_str(data["type"])
+        return FamilyRelType.get_str(data.type)
 
     def column_marriage(self, data):
         handle = data["handle"]

--- a/gramps/gui/views/treemodels/notemodel.py
+++ b/gramps/gui/views/treemodels/notemodel.py
@@ -118,7 +118,7 @@ class NoteModel(FlatBaseModel):
 
     def column_type(self, data):
         """Return the type of the Note in readable format."""
-        return NoteType.get_str(data["type"])
+        return NoteType.get_str(data.type)
 
     def column_preview(self, data):
         """Return a shortend version of the Note's text."""

--- a/gramps/gui/views/treemodels/notemodel.py
+++ b/gramps/gui/views/treemodels/notemodel.py
@@ -118,9 +118,7 @@ class NoteModel(FlatBaseModel):
 
     def column_type(self, data):
         """Return the type of the Note in readable format."""
-        temp = NoteType()
-        temp.set(data["type"])
-        return str(temp)
+        return NoteType.get_str(data["type"])
 
     def column_preview(self, data):
         """Return a shortend version of the Note's text."""

--- a/gramps/gui/views/treemodels/placemodel.py
+++ b/gramps/gui/views/treemodels/placemodel.py
@@ -188,7 +188,7 @@ class PlaceBaseModel:
         return data["gramps_id"]
 
     def column_type(self, data):
-        return PlaceType.get_str(data["place_type"])
+        return PlaceType.get_str(data.place_type)
 
     def column_code(self, data):
         return data["code"]

--- a/gramps/gui/views/treemodels/placemodel.py
+++ b/gramps/gui/views/treemodels/placemodel.py
@@ -188,8 +188,7 @@ class PlaceBaseModel:
         return data["gramps_id"]
 
     def column_type(self, data):
-        pt = from_dict(data["place_type"])
-        return str(pt)
+        return PlaceType.get_str(data["place_type"])
 
     def column_code(self, data):
         return data["code"]

--- a/gramps/gui/views/treemodels/repomodel.py
+++ b/gramps/gui/views/treemodels/repomodel.py
@@ -134,7 +134,7 @@ class RepositoryModel(FlatBaseModel):
         return data["gramps_id"]
 
     def column_type(self, data):
-        return str(RepositoryType(data["type"]))
+        return RepositoryType.get_str(data["type"])
 
     def column_name(self, data):
         return data["name"]

--- a/gramps/gui/views/treemodels/repomodel.py
+++ b/gramps/gui/views/treemodels/repomodel.py
@@ -134,7 +134,7 @@ class RepositoryModel(FlatBaseModel):
         return data["gramps_id"]
 
     def column_type(self, data):
-        return RepositoryType.get_str(data["type"])
+        return RepositoryType.get_str(data.type)
 
     def column_name(self, data):
         return data["name"]


### PR DESCRIPTION
Make the `GrampsType.__set` methods public

Based on a comment by @dsblank in [PR #1825](https://github.com/gramps-project/gramps/pull/1825#discussion_r1895209505) 
This PR builds on PR #1825

No attempt has been made to convert calling code. That could be tackled if there is agreement on the approach. 

CC @Nick-Hall for comment on the approach