### PR TITLE
Improve the backlinks (References) gramplets

### DIFF
--- a/gramps/gui/clipboard.py
+++ b/gramps/gui/clipboard.py
@@ -81,25 +81,32 @@ clipdb = None  # current db to avoid different transient dbs during db change
 
 theme = Gtk.IconTheme.get_default()
 LINK_PIC = theme.load_icon("stock_link", 16, 0)
+OBJ2ICON = {
+    "media": "gramps-media",
+    "note": "gramps-notes",
+    "person": "gramps-person",
+    "place": "gramps-place",
+    "address": "gramps-address",
+    "attribute": "gramps-attribute",
+    "event": "gramps-event",
+    "family": "gramps-family",
+    "location": "geo-place-link",
+    "media": "gramps-media",
+    "name": "geo-show-person",
+    "repository": "gramps-repository",
+    "source": "gramps-source",
+    "citation": "gramps-citation",
+    "text": "gramps-font",
+    "url": "gramps-geo",
+}
+
+
+def obj2icon(target):
+    return OBJ2ICON[target] if target in OBJ2ICON else None
+
+
 ICONS = {}
-for name, icon in (
-    ("media", "gramps-media"),
-    ("note", "gramps-notes"),
-    ("person", "gramps-person"),
-    ("place", "gramps-place"),
-    ("address", "gramps-address"),
-    ("attribute", "gramps-attribute"),
-    ("event", "gramps-event"),
-    ("family", "gramps-family"),
-    ("location", "geo-place-link"),
-    ("media", "gramps-media"),
-    ("name", "geo-show-person"),
-    ("repository", "gramps-repository"),
-    ("source", "gramps-source"),
-    ("citation", "gramps-citation"),
-    ("text", "gramps-font"),
-    ("url", "gramps-geo"),
-):
+for name, icon in OBJ2ICON.items():
     ICONS[name] = theme.load_icon(icon, 16, 0)
 
 
@@ -1257,7 +1264,7 @@ class ClipboardListView:
                 _ob._dbname = dbname
 
             # If this was a ClipPersonLink with a list for a handle, we don't
-            # want it.  Can happen in People Treeview with attemp to drag last
+            # want it.  Can happen in People Treeview with attempt to drag last
             # name group.
             if isinstance(_ob, ClipHandleWrapper) and isinstance(_ob._handle, list):
                 return None

--- a/gramps/gui/listmodel.py
+++ b/gramps/gui/listmodel.py
@@ -77,6 +77,7 @@ class ListModel:
     mode:           Selection mode for TreeView.  See Gtk documentation.
     list_mode:      "list" or "tree"
     right_click:    Function called when the user right-clicks on a row.
+    middle_click:   Function called when the user middle-clicks on a row.
     """
 
     def __init__(
@@ -88,6 +89,7 @@ class ListModel:
         mode=Gtk.SelectionMode.SINGLE,
         list_mode="list",
         right_click=None,
+        middle_click=None,
     ):
         self.tree = tree
         self.tree.set_fixed_height_mode(True)
@@ -97,6 +99,7 @@ class ListModel:
         self.list_mode = list_mode  # "list", or "tree"
         self.double_click = None
         self.right_click = None
+        self.middle_click = None
 
         for info in dlist:
             col_type = TEXT
@@ -134,11 +137,13 @@ class ListModel:
 
         if select_func:
             self.selection.connect("changed", select_func)
-        if event_func or right_click:
+        if event_func or middle_click or right_click:
             if event_func:
                 self.double_click = event_func
             if right_click:
                 self.right_click = right_click
+            if middle_click:
+                self.middle_click = middle_click
             self.tree.connect("button-press-event", self.__button_press)
 
     def __build_image_column(self, cnum, name, renderer, column):
@@ -508,6 +513,10 @@ class ListModel:
         elif is_right_click(event):
             if self.right_click:
                 self.right_click(obj, event)
+                return True
+        elif event.type == Gdk.EventType.BUTTON_PRESS and event.button == 2:
+            if self.middle_click:
+                self.middle_click(obj, event)
                 return True
         return False
 

--- a/gramps/plugins/gramplet/backlinks.py
+++ b/gramps/plugins/gramplet/backlinks.py
@@ -1,7 +1,8 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2011 Nick Hall
+# Copyright (C) 2011       Nick Hall
 # Copyright (C) 2011       Tim G L Lyons
+# Copyright (C) 2024-2025  Steve Youngs
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,16 +21,26 @@
 
 # -------------------------------------------------------------------------
 #
+# python
+#
+# -------------------------------------------------------------------------
+import pickle
+
+# -------------------------------------------------------------------------
+#
 # Gtk modules
 #
 # -------------------------------------------------------------------------
-from gi.repository import Gtk
+from gi.repository import Gdk, Gtk
 
 # -------------------------------------------------------------------------
 #
 # Gramps modules
 #
 # -------------------------------------------------------------------------
+from gramps.gui.clipboard import obj2icon, obj2target
+from gramps.gui.ddtargets import DdTargets
+from gramps.gen.lib.datebase import DateBase
 from gramps.gui.listmodel import ListModel
 from gramps.gen.utils.db import navigation_label
 from gramps.gen.plug import Gramplet
@@ -45,9 +56,24 @@ class Backlinks(Gramplet):
     Displays the back references for an object.
     """
 
+    __obj2target = {
+        "Person": DdTargets.PERSON_LINK,
+        "Family": DdTargets.FAMILY_LINK,
+        "Event": DdTargets.EVENT,
+        "Citation": DdTargets.CITATION_LINK,
+        "Source": DdTargets.SOURCE_LINK,
+        "Place": DdTargets.PLACE_LINK,
+        "Repository": DdTargets.REPO_LINK,
+        "Media": DdTargets.MEDIAOBJ,
+        "Note": DdTargets.NOTE_LINK,
+    }
+
+    def __init__(self, classname, gui, nav_group=0):
+        self.__classname = classname  # must be set before calling super().__init__
+        super().__init__(gui, nav_group)
+
     def init(self):
         self.date_column = None
-        self.evts = False
         self.gui.WIDGET = self.build_gui()
         self.gui.get_container_widget().remove(self.gui.textview)
         self.gui.get_container_widget().add(self.gui.WIDGET)
@@ -58,50 +84,101 @@ class Backlinks(Gramplet):
         Build the GUI interface.
         """
         self.top = Gtk.TreeView()
+        self.top.get_selection().connect("changed", self.selection_changed)
+        self.top.connect_after("drag-begin", self.drag_begin)
+        self.top.connect("drag_data_get", self.drag_data_get)
+
         titles = [
             (_("Type"), 1, 100),
             (_("Name"), 2, 100),
             (_("Date"), 4, 200),
-            ("sd", 4, 120),  # sorted date column
+            ("date_sort_value", 4, 1),  # hidden column
             ("", 5, 1),  # hidden column for the handle
             ("", 6, 1),  # hidden column for non-localized object type
         ]
-        self.model = ListModel(self.top, titles, event_func=self.cb_double_click)
+        self.model = ListModel(
+            self.top,
+            titles,
+            event_func=self.cb_double_click,
+            middle_click=self.cb_middle_click,
+            right_click=self.cb_right_click,
+        )
+
         self.date_column = self.top.get_column(2)
-        self.sdate = self.top.get_column(3)
-        self.top.get_column(1).set_expand(True)  # The name use the max
+        self.date_column.set_visible(False)
+        self.date_column.set_sort_column_id(3)
+        self.top.get_column(1).set_expand(
+            True
+        )  # Expand the Name column as far as possible
+        self.top.get_column(3).set_visible(
+            False
+        )  # always hide the date_sort_value column
         # possible size
         return self.top
+
+    def selection_changed(self, selection):
+        """
+        Called when the selection is changed in the TreeView.
+        """
+        target = None
+        (model, iter_) = selection.get_selected()
+        if iter_:
+            objclass = model.get_value(iter_, 5)
+            target = self.__obj2target.get(objclass)
+
+        if target:
+            self.top.drag_source_set(
+                Gdk.ModifierType.BUTTON1_MASK, [target.target()], Gdk.DragAction.COPY
+            )
+        else:
+            self.top.drag_source_unset()
+
+    def drag_begin(self, widget, drag_context):
+        """
+        We want to show the icon during drag instead of the long row entry
+        """
+        (model, iter_) = self.top.get_selection().get_selected()
+        if not iter_:
+            return
+
+        objclass = model.get_value(iter_, 5)
+        Gtk.drag_set_icon_name(drag_context, obj2icon(objclass.lower()), 0, 0)
+
+    def drag_data_get(self, widget, context, sel_data, info, time):
+        # get the selected object, returning if nothing is selected
+        (model, iter_) = self.top.get_selection().get_selected()
+        if not iter_:
+            return
+
+        (objclass, handle) = (model.get_value(iter_, 5), model.get_value(iter_, 4))
+
+        target = obj2target(objclass)
+        data = (target.name(), id(self), handle, 0)
+
+        sel_data.set(target, 8, pickle.dumps(data))
 
     def display_backlinks(self, active_handle):
         """
         Display the back references for an object.
         """
-        self.evts = False
-        sdcolumn = None
+        have_dates = False  # True if any of the objects we are displaying are instances of DateBase
         for classname, handle in self.dbstate.db.find_backlink_handles(active_handle):
             name = navigation_label(self.dbstate.db, classname, handle)[0]
-            sdcolumn = self.top.get_column(3)
-            dcolumn = self.top.get_column(2)
-            if classname == "Event":
-                obj = self.dbstate.db.get_event_from_handle(handle)
+            obj = self.dbstate.db.method("get_%s_from_handle", classname)(handle)
+            if isinstance(obj, DateBase):
                 o_date = obj.get_date_object()
                 date = displayer.display(o_date)
-                sdate = "%09d" % o_date.get_sort_value()
-                sdcolumn.set_sort_column_id(3)
-                dcolumn.set_sort_column_id(3)
-                self.evts = True
+                date_sort_value = "%09d" % o_date.get_sort_value()
+                have_dates = True
             else:
-                sdcolumn.set_sort_column_id(1)
-                date = sdate = ""
-            self.model.add((_(classname), name, date, sdate, handle, classname))
-        if self.evts:
-            self.date_column.set_visible(True)
-            sdcolumn.set_visible(False)
-        else:
-            self.date_column.set_visible(False)
-            if sdcolumn:
-                sdcolumn.set_visible(False)
+                date = date_sort_value = ""
+            self.model.add(
+                (_(classname), name, date, date_sort_value, handle, classname)
+            )
+
+        self.date_column.set_visible(
+            have_dates
+        )  # only show the Date column if there are some values
         self.set_has_data(self.model.count > 0)
 
     def get_has_data(self, active_handle):
@@ -126,6 +203,46 @@ class Backlinks(Gramplet):
 
         edit_object(self.dbstate, self.uistate, objclass, handle)
 
+    def cb_middle_click(self, treeview, event):
+        """
+        Handle middle click on view.
+        """
+        (model, iter_) = treeview.get_selection().get_selected()
+        if not iter_:
+            return
+
+        (objclass, handle) = (model.get_value(iter_, 5), model.get_value(iter_, 4))
+        self.uistate.set_active(handle, objclass)
+
+    def cb_right_click(self, treeview, event):
+        """
+        Handle right click on view.
+        """
+        (model, iter_) = self.top.get_selection().get_selected()
+        if not iter_:
+            return  # nothing selected, so do not display the context menu
+
+        (objclass, handle) = (model.get_value(iter_, 5), model.get_value(iter_, 4))
+
+        self.__store_menu = Gtk.Menu()  # need to keep reference or menu disappears
+        menu = self.__store_menu
+
+        item = Gtk.MenuItem.new_with_mnemonic(_("_Edit"))
+        item.connect(
+            "activate",
+            lambda obj: edit_object(self.dbstate, self.uistate, objclass, handle),
+        )
+        item.show()
+        menu.append(item)
+
+        item = Gtk.MenuItem.new_with_mnemonic(_("_Make Active %s") % objclass)
+        item.connect("activate", lambda obj: self.uistate.set_active(handle, objclass))
+        item.show()
+        menu.append(item)
+
+        menu.popup_at_pointer(event)
+        return True
+
     def db_changed(self):
         for item in [
             "person",
@@ -141,6 +258,25 @@ class Backlinks(Gramplet):
             self.connect(self.dbstate.db, "%s-delete" % item, self.update)
             self.connect(self.dbstate.db, "%s-add" % item, self.update)
             self.connect(self.dbstate.db, "%s-update" % item, self.update)
+        if self.__classname != "Person":
+            # the Gramplet super class already connects to changes in
+            # active person and calls active_changed
+            self.connect_signal(self.__classname, self.update)
+
+    def active_changed(self, handle):
+        self.update()
+
+    def update_has_data(self):
+        active_handle = self.get_active(self.__classname)
+        self.set_has_data(self.get_has_data(active_handle))
+
+    def main(self):
+        active_handle = self.get_active(self.__classname)
+        self.model.clear()
+        if active_handle:
+            self.display_backlinks(active_handle)
+        else:
+            self.set_has_data(False)
 
 
 class PersonBacklinks(Backlinks):
@@ -148,20 +284,8 @@ class PersonBacklinks(Backlinks):
     Displays the back references for a person.
     """
 
-    def active_changed(self, handle):
-        self.update()
-
-    def update_has_data(self):
-        active_handle = self.get_active("Person")
-        self.set_has_data(self.get_has_data(active_handle))
-
-    def main(self):
-        active_handle = self.get_active("Person")
-        self.model.clear()
-        if active_handle:
-            self.display_backlinks(active_handle)
-        else:
-            self.set_has_data(False)
+    def __init__(self, gui, nav_group=0):
+        super().__init__("Person", gui, nav_group)
 
 
 class EventBacklinks(Backlinks):
@@ -169,21 +293,8 @@ class EventBacklinks(Backlinks):
     Displays the back references for an event.
     """
 
-    def db_changed(self):
-        super().db_changed()
-        self.connect_signal("Event", self.update)
-
-    def update_has_data(self):
-        active_handle = self.get_active("Event")
-        self.set_has_data(self.get_has_data(active_handle))
-
-    def main(self):
-        active_handle = self.get_active("Event")
-        self.model.clear()
-        if active_handle:
-            self.display_backlinks(active_handle)
-        else:
-            self.set_has_data(False)
+    def __init__(self, gui, nav_group=0):
+        super().__init__("Event", gui, nav_group)
 
 
 class FamilyBacklinks(Backlinks):
@@ -191,21 +302,8 @@ class FamilyBacklinks(Backlinks):
     Displays the back references for a family.
     """
 
-    def db_changed(self):
-        super().db_changed()
-        self.connect_signal("Family", self.update)
-
-    def update_has_data(self):
-        active_handle = self.get_active("Family")
-        self.set_has_data(self.get_has_data(active_handle))
-
-    def main(self):
-        active_handle = self.get_active("Family")
-        self.model.clear()
-        if active_handle:
-            self.display_backlinks(active_handle)
-        else:
-            self.set_has_data(False)
+    def __init__(self, gui, nav_group=0):
+        super().__init__("Family", gui, nav_group)
 
 
 class PlaceBacklinks(Backlinks):
@@ -213,65 +311,26 @@ class PlaceBacklinks(Backlinks):
     Displays the back references for a place.
     """
 
-    def db_changed(self):
-        super().db_changed()
-        self.connect_signal("Place", self.update)
-
-    def update_has_data(self):
-        active_handle = self.get_active("Place")
-        self.set_has_data(self.get_has_data(active_handle))
-
-    def main(self):
-        active_handle = self.get_active("Place")
-        self.model.clear()
-        if active_handle:
-            self.display_backlinks(active_handle)
-        else:
-            self.set_has_data(False)
+    def __init__(self, gui, nav_group=0):
+        super().__init__("Place", gui, nav_group)
 
 
 class SourceBacklinks(Backlinks):
     """
-    Displays the back references for a source,.
+    Displays the back references for a source.
     """
 
-    def db_changed(self):
-        super().db_changed()
-        self.connect_signal("Source", self.update)
-
-    def update_has_data(self):
-        active_handle = self.get_active("Source")
-        self.set_has_data(self.get_has_data(active_handle))
-
-    def main(self):
-        active_handle = self.get_active("Source")
-        self.model.clear()
-        if active_handle:
-            self.display_backlinks(active_handle)
-        else:
-            self.set_has_data(False)
+    def __init__(self, gui, nav_group=0):
+        super().__init__("Source", gui, nav_group)
 
 
 class CitationBacklinks(Backlinks):
     """
-    Displays the back references for a Citation,.
+    Displays the back references for a Citation.
     """
 
-    def db_changed(self):
-        super().db_changed()
-        self.connect_signal("Citation", self.update)
-
-    def update_has_data(self):
-        active_handle = self.get_active("Citation")
-        self.set_has_data(self.get_has_data(active_handle))
-
-    def main(self):
-        active_handle = self.get_active("Citation")
-        self.model.clear()
-        if active_handle:
-            self.display_backlinks(active_handle)
-        else:
-            self.set_has_data(False)
+    def __init__(self, gui, nav_group=0):
+        super().__init__("Citation", gui, nav_group)
 
 
 class RepositoryBacklinks(Backlinks):
@@ -279,21 +338,8 @@ class RepositoryBacklinks(Backlinks):
     Displays the back references for a repository.
     """
 
-    def db_changed(self):
-        super().db_changed()
-        self.connect_signal("Repository", self.update)
-
-    def update_has_data(self):
-        active_handle = self.get_active("Repository")
-        self.set_has_data(self.get_has_data(active_handle))
-
-    def main(self):
-        active_handle = self.get_active("Repository")
-        self.model.clear()
-        if active_handle:
-            self.display_backlinks(active_handle)
-        else:
-            self.set_has_data(False)
+    def __init__(self, gui, nav_group=0):
+        super().__init__("Repository", gui, nav_group)
 
 
 class MediaBacklinks(Backlinks):
@@ -301,21 +347,8 @@ class MediaBacklinks(Backlinks):
     Displays the back references for a media object.
     """
 
-    def db_changed(self):
-        super().db_changed()
-        self.connect_signal("Media", self.update)
-
-    def update_has_data(self):
-        active_handle = self.get_active("Media")
-        self.set_has_data(self.get_has_data(active_handle))
-
-    def main(self):
-        active_handle = self.get_active("Media")
-        self.model.clear()
-        if active_handle:
-            self.display_backlinks(active_handle)
-        else:
-            self.set_has_data(False)
+    def __init__(self, gui, nav_group=0):
+        super().__init__("Media", gui, nav_group)
 
 
 class NoteBacklinks(Backlinks):
@@ -323,18 +356,5 @@ class NoteBacklinks(Backlinks):
     Displays the back references for a note.
     """
 
-    def db_changed(self):
-        super().db_changed()
-        self.connect_signal("Note", self.update)
-
-    def update_has_data(self):
-        active_handle = self.get_active("Note")
-        self.set_has_data(self.get_has_data(active_handle))
-
-    def main(self):
-        active_handle = self.get_active("Note")
-        self.model.clear()
-        if active_handle:
-            self.display_backlinks(active_handle)
-        else:
-            self.set_has_data(False)
+    def __init__(self, gui, nav_group=0):
+        super().__init__("Note", gui, nav_group)


### PR DESCRIPTION
The backlinks gramplet (called References in the UI) is great for finding linked objects. It also allows direct editing of the object by double clicking. However, if you want to make the linked object the active object, you have to go to the relevant object-type view (e.g. Families), and re-find the object.
This enhancement allows the active object to be set directly from the References gramplet. This is currently a two-step process

1. select the row
![image](https://github.com/user-attachments/assets/7d4af57e-fcf2-423d-986f-6deb81207a8a)

2. press the middle mouse button (anywhere within the gramplet)
The selected object will be made the active object of that type.
In the above example, Family F0403 will be made the active family.
It works for all object types, not just families
![image](https://github.com/user-attachments/assets/75ce1684-a542-4110-8549-477ac50a67c1)


