### PR TITLE
Set initial focus in EditPlaceRef dialog

### DIFF
--- a/gramps/gui/editors/editplaceref.py
+++ b/gramps/gui/editors/editplaceref.py
@@ -91,6 +91,9 @@ class EditPlaceRef(EditReference):
             self.dbstate, self.uistate, self.track, _("_General"), tblref
         )
 
+    def _post_init(self):
+        self.name.grab_focus()
+
     def _connect_signals(self):
         self.define_cancel_button(self.top.get_object("cancel"))
         self.ok_button = self.top.get_object("ok")


### PR DESCRIPTION
Currently, in the Place Reference Editor dialog `EditPlaceRef`, the default focus is set to the the top tab control, "General" tab. Given that there is only a single tab, this is not useful. The first action that all users have to do is to move the focus.
With this change, the default focus is set to the name control of the place, allowing the user to immediately start typing \ editing the place name. The Name field was chosen as I felt it was more likely to be edited than the Date field.

![image](https://github.com/user-attachments/assets/102b9e72-dfad-4d07-a924-44fd1febcf8e)
