### PR TITLE
Fix error in Fast*Filter

### DIFF
--- a/gramps/gui/editors/editfamily.py
+++ b/gramps/gui/editors/editfamily.py
@@ -417,8 +417,8 @@ class FastMaleFilter:
         self.db = db
 
     def match(self, handle, db):
-        value = self.db.get_raw_person_data(handle)
-        return value.gender == Person.MALE
+        data = self.db.get_raw_person_data(handle)
+        return data.gender == Person.MALE
 
 
 class FastFemaleFilter:
@@ -426,8 +426,8 @@ class FastFemaleFilter:
         self.db = db
 
     def match(self, handle, db):
-        value = self.db.get_raw_person_data(handle)
-        return value.gender == Person.FEMALE
+        data = self.db.get_raw_person_data(handle)
+        return data.gender == Person.FEMALE
 
 
 # -------------------------------------------------------------------------

--- a/gramps/gui/editors/editfamily.py
+++ b/gramps/gui/editors/editfamily.py
@@ -418,7 +418,7 @@ class FastMaleFilter:
 
     def match(self, handle, db):
         value = self.db.get_raw_person_data(handle)
-        return value[2] == Person.MALE
+        return value.gender == Person.MALE
 
 
 class FastFemaleFilter:
@@ -427,7 +427,7 @@ class FastFemaleFilter:
 
     def match(self, handle, db):
         value = self.db.get_raw_person_data(handle)
-        return value[2] == Person.FEMALE
+        return value.gender == Person.FEMALE
 
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
`get_raw_person_data` now returns a DataDict.
Update `FastMaleFilter.match()` and `FastFemaleFilter.match()` accordingly to avoid a runtime error

Steps to reproduce the problem:
1. start a new tree
2. add a family
3. in the EditFamily dialog, click the select button to choose the Father

The following error is displayed:
```
 File "C:\msys64\home\steve\gramps\gramps\gui\editors\editfamily.py", line 421, in match
    return value[2] == Person.MALE
           ~~~~~^^^
KeyError: 2
```