### PR TITLE
Enhancements to Selector Dialogs

### DIFF
--- a/gramps/gui/editors/displaytabs/gallerytab.py
+++ b/gramps/gui/editors/displaytabs/gallerytab.py
@@ -345,24 +345,38 @@ class GalleryTab(ButtonTab, DbGUIElement):
         """
         SelectObject = SelectorFactory("Media")
 
-        sel = SelectObject(self.dbstate, self.uistate, self.track)
-        src = sel.run()
-        if src:
-            sref = MediaRef()
-            try:
-                from .. import EditMediaRef
+        sel = SelectObject(
+            self.dbstate, self.uistate, self.track, allow_multiple_selection=True
+        )
+        handles = sel.run()
+        if handles:
+            if len(handles) > 1:
+                for src in handles:
+                    media_ref = MediaRef()
+                    media_ref.set_reference_handle(src)
+                    self.add_callback(media_ref, src)
+            else:
+                for src in handles:
+                    sref = MediaRef()
+                    try:
+                        from .. import EditMediaRef
 
-                EditMediaRef(
-                    self.dbstate, self.uistate, self.track, src, sref, self.add_callback
-                )
-            except WindowActiveError:
-                from ...dialog import WarningDialog
+                        EditMediaRef(
+                            self.dbstate,
+                            self.uistate,
+                            self.track,
+                            src,
+                            sref,
+                            self.add_callback,
+                        )
+                    except WindowActiveError:
+                        from ...dialog import WarningDialog
 
-                WarningDialog(
-                    _("Cannot share this reference"),
-                    self.__blocked_text(),
-                    parent=self.uistate.window,
-                )
+                        WarningDialog(
+                            _("Cannot share this reference"),
+                            self.__blocked_text(),
+                            parent=self.uistate.window,
+                        )
 
     def del_button_clicked(self, obj):
         ref = self.get_selected()

--- a/gramps/gui/selectors/baseselector.py
+++ b/gramps/gui/selectors/baseselector.py
@@ -248,9 +248,11 @@ class BaseSelector(ManagedWindow):
         Defines the columns to show in the selector. Must be defined in the
         subclasses.
         :returns: a list of tuples with four entries. The four entries should
-                be 0: column header string, 1: column width,
-                2: TEXT, MARKUP or IMAGE, 3: column in the model that must be
-                used.
+                be:
+                0: column header string,
+                1: column width,
+                2: TEXT, MARKUP or IMAGE,
+                3: column in the model that must be used.
         """
         raise NotImplementedError
 

--- a/gramps/gui/selectors/selectobject.py
+++ b/gramps/gui/selectors/selectobject.py
@@ -34,7 +34,9 @@ import gc
 # GTK+
 #
 # -------------------------------------------------------------------------
-from gi.repository import Gtk
+from gi.repository import GdkPixbuf, Gtk
+from gi.repository import GObject
+from gi.repository import Pango
 
 # -------------------------------------------------------------------------
 #
@@ -87,22 +89,51 @@ class SelectObject(BaseSelector):
         Perform local initialisation for this class
         """
         self.setup_configs("interface.media-sel", 600, 450)
-        self.preview = Gtk.Image()
-        self.preview.set_size_request(int(THUMBSCALE), int(THUMBSCALE))
+
+        # insert a ScrolledWindow containing an IconView to display thumbnails
+        # of the selected media
+
+        # pixels to pad the image
+        padding = 6
+
+        self.iconmodel = Gtk.ListStore(GdkPixbuf.Pixbuf, GObject.TYPE_STRING, object)
+        self.iconlist = Gtk.IconView()
+        self.track_ref_for_deletion("iconlist")
+        self.iconlist.set_pixbuf_column(0)
+        self.iconlist.set_item_width(int(THUMBSCALE) + padding * 2)
+
+        text_renderer = Gtk.CellRendererText()
+        text_renderer.set_property("wrap-mode", Pango.WrapMode.WORD_CHAR)
+        text_renderer.set_property("wrap-width", THUMBSCALE)
+        text_renderer.set_property("alignment", Pango.Alignment.CENTER)
+        self.iconlist.pack_end(text_renderer, True)
+        self.iconlist.add_attribute(text_renderer, "text", 1)
+
+        self.iconlist.set_margin(padding)
+        self.iconlist.set_column_spacing(padding)
+        self.iconlist.set_model(self.iconmodel)
+
+        # create the scrolled window
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scroll.set_min_content_height(int(THUMBSCALE) + padding * 2)
+        scroll.add(self.iconlist)
+
         vbox = self.glade.get_object("select_person_vbox")
-        vbox.pack_start(self.preview, False, True, 0)
-        vbox.reorder_child(self.preview, 1)
-        self.preview.show()
+        vbox.pack_start(scroll, False, True, 0)
+        vbox.reorder_child(scroll, 1)
+        scroll.show()
         self.selection.connect("changed", self._row_change)
 
     def _row_change(self, obj):
+        self.iconmodel.clear()
+
         id_list = self.get_selected_ids()
-        if not (id_list and id_list[0]):
-            return
-        handle = id_list[0]
-        obj = self.get_from_handle_func()(handle)
-        pix = get_thumbnail_image(media_path_full(self.db, obj.get_path()))
-        self.preview.set_from_pixbuf(pix)
+        for handle in self.get_selected_ids():
+            if handle:
+                obj = self.get_from_handle_func()(handle)
+                pix = get_thumbnail_image(media_path_full(self.db, obj.get_path()))
+                self.iconmodel.append(row=(pix, obj.get_description(), obj))
         gc.collect()
 
     def get_config_name(self):

--- a/gramps/gui/selectors/selectobject.py
+++ b/gramps/gui/selectors/selectobject.py
@@ -79,6 +79,7 @@ class SelectObject(BaseSelector):
             (_("ID"), 75, BaseSelector.TEXT, 1),
             (_("Type"), 75, BaseSelector.TEXT, 2),
             (_("Last Change"), 150, BaseSelector.TEXT, 7),
+            (_("Path"), 150, BaseSelector.TEXT, 3),
         ]
 
     def _local_init(self):

--- a/gramps/gui/widgets/multitreeview.py
+++ b/gramps/gui/widgets/multitreeview.py
@@ -25,6 +25,7 @@ An override to allow easy multiselections.
 from gi.repository import Gdk
 from gi.repository import Gtk
 from ..utils import no_match_primary_mask
+from . import PersistentTreeView
 
 # -------------------------------------------------------------------------
 #
@@ -33,14 +34,13 @@ from ..utils import no_match_primary_mask
 # -------------------------------------------------------------------------
 
 
-# TODO GTK3: Is this not duplicate of the class in clipboard py ?? We should reuse pieces
-class MultiTreeView(Gtk.TreeView):
+class MultiTreeView(PersistentTreeView):
     """
     TreeView that captures mouse events to make drag and drop work properly
     """
 
-    def __init__(self):
-        Gtk.TreeView.__init__(self)
+    def __init__(self, uistate=None, config_name=None):
+        super().__init__(uistate, config_name)
         self.connect("button_press_event", self.on_button_press)
         self.connect("button_release_event", self.on_button_release)
         self.connect("drag-end", self.on_drag_end)


### PR DESCRIPTION
A set of enhancements to the selector dialogs:
1. Add a Path column to the Select Media Object dialog (`SelectObject`)
See image 2 below
2. Add the standard search bar to the Select Person dialog (`SelectPerson`)
See image 1 below
3. Add (optional) support for multiple selection in the `BaseSelector` class
This includes unifying the two different `MultiTreeView` classes in gramps
4. Add (optional) support for multiple selection to the Select Media Object dialog
The existing single thumbnail is replaced with a `ScrolledWindow` containing an `IconView`
See image 2 below
5. Use multiple selection when sharing media in the `GalleryTab`

If this PR is accepted, a follow on PR can add support for multiple selection to other selector dialogs. Examples could include: sharing multiple children to a family, sharing multiple events to a person

Currently, where only a single media object can be selected, the Edit Media Ref dialog is shown immediately after selection. The media ref is only added to the primary object when OK is selected from the Edit Media Ref dialog. This PR preserves this behaviour if the user only selects a single object. If _multiple_ media objects are selected by the user, the media refs are immediately created and added. No Edit Media Ref dialogs are shown. The user can manually edit the media ref, using existing GalleryTab functionality (e.g. double click the thumbnail) as required. This avoids a poor user experience of multiple Edit Media Ref dialogs appearing all at once, or in a sequence. It also mirrors the behaviour of drag and drop of multiple files on to the gallery tab.

**Image 1**
![image](https://github.com/user-attachments/assets/6284e53d-bef7-41d6-8dac-045124e06d46)
**Image 2**
![image](https://github.com/user-attachments/assets/41436913-0554-4db9-8bce-d72e91209e04)
