### PR TITLE
Update build_deb.yml for Ubuntu 24.04 deb

### DIFF
--- a/.github/workflows/build_deb.yml
+++ b/.github/workflows/build_deb.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
 
 
     steps:


### PR DESCRIPTION
Ubuntu 20.04 goes end of life April 2025 so we should update to include 24.04 