### PR TITLE
Fix German date handler for reports

### DIFF
--- a/gramps/gen/datehandler/_date_de.py
+++ b/gramps/gen/datehandler/_date_de.py
@@ -215,6 +215,7 @@ class DateParserDE(DateParser):
         "etwa": Date.MOD_ABOUT,
         "circa": Date.MOD_ABOUT,
         "ca.": Date.MOD_ABOUT,
+        "ab": Date.MOD_FROM,
         "von": Date.MOD_FROM,
         "bis": Date.MOD_TO,
     }

--- a/gramps/gen/datehandler/_date_de.py
+++ b/gramps/gen/datehandler/_date_de.py
@@ -441,4 +441,14 @@ register_datehandler(
     DateParserDE,
     DateDisplayDE,
 )
-register_datehandler(("de_AT", ("%d.%m.%Y",)), DateParserDE, DateDisplayDE)
+
+
+class DateParserDE_AT(DateParserDE):
+    pass
+
+
+class DateDisplayDE_AT(DateDisplayDE):
+    pass
+
+
+register_datehandler(("de_AT", ("%d.%m.%Y",)), DateParserDE_AT, DateDisplayDE_AT)


### PR DESCRIPTION
Date displayers have an associated locale which can cause problems if more then one locale uses the same handler.

A similar fix may be needed for pt_PT and pt_BR and also zh_TW and zh_HK which also share handlers.

Fixes [#13312](https://gramps-project.org/bugs/view.php?id=13312).