### PR TITLE
Fix AttributeError in editor surname tab

### DIFF
--- a/gramps/gui/editors/displaytabs/surnametab.py
+++ b/gramps/gui/editors/displaytabs/surnametab.py
@@ -98,6 +98,7 @@ class SurnameTab(EmbeddedList):
         self.curr_col = -1
         self.curr_cellr = None
         self.curr_celle = None
+        self.curr_path = None
 
         EmbeddedList.__init__(
             self,


### PR DESCRIPTION
Fixes [#13322](https://gramps-project.org/bugs/view.php?id=13322)

When using arrow up/down keys, curr_path isn't set, so when attempting to delete the surname, an AttributeError exception is thrown. This is avoided by initalizing curr_path.