### PR TITLE
Regression: Exception in Redo

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -183,7 +183,7 @@ class DbGenericUndo(DbUndo):
         try:
             self.db._txn_begin()
             for record_id in subitems:
-                (key, trans_type, handle, _, new_data) = pickle.loads(
+                (key, trans_type, handle, __, new_data) = pickle.loads(
                     self.undodb[record_id]
                 )
 


### PR DESCRIPTION
CC @dsblank as the error message implicates DataDict
Update: the error is _not_ related to DataDict but an earlier pylint related change

Steps to reproduce using master
1. create a new db
2. add a new person. Enter given name. Gender Unknown
3. From the Person view, select the person and click Delete
4. Ctrl+Z to undelete the person
6. Ctrl+Shift+Z to redo the person deletion
An exception will be thrown

```
2025-01-13 21:55:17.007: ERROR: grampsapp.py: line 188: Unhandled exception
Traceback (most recent call last):
  File "C:\msys64\home\steve\gramps\gramps\gui\undohistory.py", line 181, in _response
    self._move(nsteps or 1)
  File "C:\msys64\home\steve\gramps\gramps\gui\undohistory.py", line 218, in _move
    func(False)
  File "C:\msys64\home\steve\gramps\gramps\gen\db\generic.py", line 2611, in redo
    return self.undodb.redo(update_history)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\msys64\home\steve\gramps\gramps\gen\db\undoredo.py", line 157, in redo
    return self._redo(update_history)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\msys64\home\steve\gramps\gramps\gen\db\generic.py", line 203, in _redo
    db.undo_callback(_("_Undo %s") % transaction.get_description())
                     ^^^^^^^^^^^^^
TypeError: 'DataDict' object is not callable
```

I've not worked out what's going wrong, hence the post to record my findings. 
From the debugger, it's almost as if `_("_Undo %s")` is creating a DataDict
changing the code to `glocale.translation.gettext("_Undo %s")` works.