### PR TITLE
fix: Typo alt_name -> alt_names

### DIFF
--- a/gramps/gui/views/treemodels/placemodel.py
+++ b/gramps/gui/views/treemodels/placemodel.py
@@ -138,9 +138,11 @@ class PlaceBaseModel:
 
     def search_name(self, data):
         """The search name includes all alt names to enable finding by alt name"""
-        return ",".join(
-            [data["name"]["value"]] + [name["value"] for name in data["alt_name"]]
-        )
+        if "alt_name" in data:
+            return ",".join(
+                [data["name"]["value"]] + [name["value"] for name in data["alt_name"]]
+            )
+        return data["name"]["value"]
 
     def column_longitude(self, data):
         if not data["long"]:


### PR DESCRIPTION
When editing a place the application can crash if the alt_name is not set.

Steps to reproduce:

1. Create a person
2. Add a new event (Birth for example)
3. Assign a new place
4. Go to Places tab
5. Right click > Edit the existing location
6. Click Share
7. The application will crash with an error similar to below

```
2025-01-15 12:24:43.096: ERROR: grampsapp.py: line 188: Unhandled exception
Traceback (most recent call last):
  File "/home/coldkick/code/Gramps/gramps/gui/editors/displaytabs/placerefembedlist.py", line 168, in share_button_clicked
    sel = SelectPlace(
        self.dbstate, self.uistate, self.track, skip=self.get_skip_list(self.handle)
    )
  File "/home/coldkick/code/Gramps/gramps/gui/selectors/baseselector.py", line 149, in __init__
    self.build_tree()
    ~~~~~~~~~~~~~~~^^
  File "/home/coldkick/code/Gramps/gramps/gui/selectors/baseselector.py", line 312, in build_tree
    self.model = self.get_model_class()(
                 ~~~~~~~~~~~~~~~~~~~~~~^
        self.db,
        ^^^^^^^^
    ...<5 lines>...
        search=filter_info,
        ^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/coldkick/code/Gramps/gramps/gui/views/treemodels/placemodel.py", line 322, in __init__
    TreeBaseModel.__init__(
    ~~~~~~~~~~~~~~~~~~~~~~^
        self,
        ^^^^^
    ...<8 lines>...
        group_can_have_handle=True,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/coldkick/code/Gramps/gramps/gui/views/treemodels/treebasemodel.py", line 368, in __init__
    self.rebuild_data(self.current_filter, skip=skip)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/coldkick/code/Gramps/gramps/gui/views/treemodels/treebasemodel.py", line 526, in rebuild_data
    self._build_data(self.current_filter, None, skip)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/coldkick/code/Gramps/gramps/gui/views/treemodels/treebasemodel.py", line 550, in _rebuild_search
    self.__rebuild_search(dfilter, skip, items, self.gen_cursor, self.add_row)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/coldkick/code/Gramps/gramps/gui/views/treemodels/treebasemodel.py", line 577, in __rebuild_search
    handle in skip or (dfilter and not dfilter.match(handle, self.db))
                                       ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/coldkick/code/Gramps/gramps/gen/filters/_searchfilter.py", line 33, in match
    return self.invert ^ (self.func(handle).upper().find(self.text) != -1)
                          ~~~~~~~~~^^^^^^^^
  File "/home/coldkick/code/Gramps/gramps/gui/views/treemodels/treebasemodel.py", line 472, in <lambda>
    func = lambda x: self._get_value(x, col, secondary=False) or ""
                     ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/coldkick/code/Gramps/gramps/gui/views/treemodels/treebasemodel.py", line 991, in _get_value
    value = self.fmap[col](data)
  File "/home/coldkick/code/Gramps/gramps/gui/views/treemodels/placemodel.py", line 142, in search_name
    [data["name"]["value"]] + [name["value"] for name in data["alt_name"]]
                                                         ~~~~^^^^^^^^^^^^
KeyError: 'alt_name'
```


An alternative solution would be to ensure the alt_name field always exists, but it is unclear to me why it doesn't exist in this usage pattern, and this protection would ensure it doesn't break in the same way again in the future.