### PR TITLE
Recognize event reference citations in editor event tabs

### DIFF
--- a/gramps/gui/editors/displaytabs/eventrefmodel.py
+++ b/gramps/gui/editors/displaytabs/eventrefmodel.py
@@ -170,7 +170,7 @@ class EventRefModel(Gtk.TreeStore):
             self.column_age(event),
             self.column_sort_age(event),
             eventref.get_privacy(),
-            event.has_citations(),
+            event.has_citations() or eventref.has_citations(),
         ]
 
     def colweight(self, index):


### PR DESCRIPTION
Bug [#13401](https://gramps-project.org/bugs/view.php?id=13401)

Have the S/C icon in the event embedlist display for a  S/C either on the event or in the event's ref section