### PR TITLE
Use Ubuntu 22.04 for CI

### DIFF
--- a/.github/workflows/gramps-ci.yml
+++ b/.github/workflows/gramps-ci.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
         sudo apt-get install python3-jsonschema
         sudo apt-get install libxml2-utils
         sudo apt-get install python3-lxml
-        sudo apt-get install python-libxml2
+        sudo apt-get install python3-libxml2
         sudo apt-get install zlib1g-dev
         sudo apt-get install python3-setuptools
     - name: Install addons


### PR DESCRIPTION
In https://github.com/gramps-project/gramps/pull/1858, I realized the CI currently runs on Ubuntu 20.04, which uses Python 3.8, that we are not supporting anymore. This PR switches conservatively to 22.04 LTS, which uses Python 3.10. One package had to be removed as well to make it run, but I believe this is anyway an old Python 2 leftover.