### PR TITLE
Use orjson, if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ to your language:
 
 The following packages are **STRONGLY RECOMMENDED** to be installed:
 --------------------------------------------------------------------
+*  [**orjson**](https://pypi.org/project/orjson/)
+
+  A fast JSON library for Python. Used to increase the performance of Gramps.
+  The package name is usually orjson, python-orjson or python3-orjson.
+
 *  [**osmgpsmap**](https://nzjrs.github.io/osm-gps-map/)
 
  Used to show maps in the [Geography Category](https://gramps-project.org/wiki/index.php?title=Gramps_5.1_Wiki_Manual_-_Categories#Geography_Category).

--- a/aio/build.sh
+++ b/aio/build.sh
@@ -41,6 +41,7 @@ pacman -S --needed --noconfirm \
     mingw-w64-x86_64-python-requests \
     mingw-w64-x86_64-python-setuptools \
     mingw-w64-x86_64-python-wheel \
+    mingw-w64-x86_64-rust \
     mingw-w64-x86_64-toolchain \
     perl-XML-Parser \
     subversion \
@@ -57,7 +58,7 @@ source $pythonvenv/bin/activate
 
 ## prerequisites in pip packages
 python -m pip install --upgrade pip
-pip install --upgrade pygraphviz pydot pydotplus requests asyncio
+pip install --upgrade asyncio orjson pydot pydotplus pygraphviz requests
 
 ## download dictionaries
 mkdir -p /mingw64/share/enchant/hunspell

--- a/aio/setup.py
+++ b/aio/setup.py
@@ -88,6 +88,7 @@ PACKAGES = [
     "pydotplus",
     "pygraphviz",
     "pydot",
+    "orjson",
 ]
 EXCLUDES = [
     "tkinter",

--- a/gramps/gen/lib/serialize.py
+++ b/gramps/gen/lib/serialize.py
@@ -32,14 +32,26 @@ import json
 import pickle
 import logging
 
+LOG = logging.getLogger(".serialize")
+
+try:
+    import orjson
+
+    json_dumps = orjson.dumps
+    json_loads = orjson.loads
+except ImportError:
+    LOG.warning(
+        "The Python package 'orjson' is not installed; performance may be degraded."
+    )
+    json_dumps = json.dumps
+    json_loads = json.loads
+
 # ------------------------------------------------------------------------
 #
 # Gramps modules
 #
 # ------------------------------------------------------------------------
 import gramps.gen.lib as lib
-
-LOG = logging.getLogger(".serialize")
 
 
 class DataDict(dict):
@@ -237,7 +249,7 @@ class JSONSerializer:
     @staticmethod
     def string_to_data(string):
         LOG.debug("json, string_to_data: %r...", string[:65])
-        return DataDict(json.loads(string))
+        return DataDict(json_loads(string))
 
     @staticmethod
     def object_to_string(obj):
@@ -250,7 +262,7 @@ class JSONSerializer:
             "json, data_to_string: {'_class': %r, ...}",
             data["_class"] if (data and "_class" in data) else data,
         )
-        return json.dumps(data)
+        return json_dumps(data)
 
     @staticmethod
     def metadata_to_object(string):

--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -312,6 +312,17 @@ def show_settings():
         pangocairo_str = _("not found")
 
     try:
+        import orjson
+
+        try:
+            orjson_str = orjson.__version__
+        except:  # any failure to 'get' the version
+            orjson_str = "unknown version"
+
+    except ImportError:
+        orjson_str = "not found"
+
+    try:
         from gi import Repository
 
         repository = Repository.get_default()
@@ -548,6 +559,7 @@ def show_settings():
     print("")
     print("Recommended:")
     print("------------")
+    print(" orjson    : %s" % orjson_str)
     print(" osmgpsmap : %s" % osmgpsmap_str)
     print(" Graphviz  : %s" % dotversion_str)
     print(" Ghostscr. : %s" % gsversion_str)

--- a/gramps/gui/aboutdialog.py
+++ b/gramps/gui/aboutdialog.py
@@ -96,6 +96,17 @@ try:
 except:
     sqlite3_version_str = "not found"
 
+try:
+    import orjson
+
+    try:
+        orjson_str = orjson.__version__
+    except:  # any failure to 'get' the version
+        orjson_str = "unknown version"
+
+except ImportError:
+    orjson_str = "not found"
+
 
 # -------------------------------------------------------------------------
 #
@@ -166,6 +177,9 @@ class GrampsAboutDialog(Gtk.AboutDialog):
             + COLON
             + " %s \n"
             + sqlite
+            + "orjson"
+            + COLON
+            + " %s\n"
             + "LANG"
             + COLON
             + " %s\n"
@@ -175,6 +189,7 @@ class GrampsAboutDialog(Gtk.AboutDialog):
             ellipses(str(VERSION)),
             ellipses(platform.python_version()),
             BSDDB_STR,
+            orjson_str,
             ellipses(get_env_var("LANG", "")),
             ellipses(platform.system()),
         )

--- a/gramps/gui/logger/_errorreportassistant.py
+++ b/gramps/gui/logger/_errorreportassistant.py
@@ -52,6 +52,17 @@ try:
 except:
     sqlite3_version_str = "not found"
 
+try:
+    import orjson
+
+    try:
+        orjson_str = orjson.__version__
+    except:  # any failure to 'get' the version
+        orjson_str = "unknown version"
+
+except ImportError:
+    orjson_str = "not found"
+
 # -------------------------------------------------------------------------
 #
 # Gramps modules
@@ -200,6 +211,7 @@ class ErrorReportAssistant(ManagedWindow, Gtk.Assistant):
             "Python version: %s \n"
             "BSDDB version: %s \n"
             "%s"
+            "orjson version: %s\n"
             "LANG: %s\n"
             "OS: %s\n"
             "%s\n"
@@ -211,6 +223,7 @@ class ErrorReportAssistant(ManagedWindow, Gtk.Assistant):
                 platform.python_version(),
                 BSDDB_STR,
                 sqlite,
+                orjson_str,
                 get_env_var("LANG", ""),
                 platform.system(),
                 distribution,

--- a/mac/gramps.modules
+++ b/mac/gramps.modules
@@ -12,13 +12,13 @@
   <repository type="tarball" name="oracle"
 	      href="http://download.oracle.com/"/>
   <repository type="tarball" name="pymodules"
-	      href="https://pypi.python.org/packages/"/>
+	      href="https://files.pythonhosted.org/packages/"/>
   <repository type="git" name="github" href="https://github.com/"/>
   <repository type="tarball" name="github-tarball" href="https://github.com/"/>
   <repository type="tarball" name="exiv2.org"
 	      href="http://www.exiv2.org/releases/"/>
   <repository type="tarball" name="pythonware"
-	      href="http://effbot.org/downloads/"/>
+              href="http://effbot.org/downloads/"/>
 
   <include href="https://gitlab.gnome.org/GNOME/gtk-osx/raw/master/modulesets-stable/gtk-osx.modules"/>
   <!--include href="/Users/john/Development/GTK-OSX/gtk-osx-build/modulesets-stable/gtk-osx.modules"/-->
@@ -56,6 +56,13 @@
       <dep package="gobject-introspection"/>
     </dependencies>
   </meson>
+
+  <pip id="orjson">
+    <branch module="ae/f9/5dea21763eeff8c1590076918a446ea3d6140743e0e36f58f369928ed0f4/orjson-3.10.15.tar.gz"
+            version="3.10.15"
+            repo="pymodules"
+            />
+  </pip>
 
   <meson id="geocode-glib" mesonargs="-Denable-gtk-doc=false">
     <branch module="geocode-glib/3.26/geocode-glib-3.26.2.tar.xz"
@@ -186,6 +193,7 @@
       <dep package="graphviz"/>
       <dep package="gexiv2"/>
       <dep package="gtk-mac-integration-python"/>
+      <dep package="orjson"/>
       <dep package="pycairo"/>
       <dep package="pygobject3"/>
       <dep package='pyicu'/>


### PR DESCRIPTION
This PR uses the orjson fast loads/dumps for two specific places:

1. converting from string to data (dict)
2. converting data (dict) to string

It cannot be used in other places as it does not support object creation.

Using orjson has a large increase in performance where it can be used, namely in places that use `db.get_raw_OBJECT_data()` and `db._iter_raw_OBJECT_data()`. Those have already been used throughout the Gramps codebase.

Test code for performance:

```python
>>> from gramps.gen.db.utils import open_database
>>> db = open_database("Example")

>>> %%timeit
>>> count = 0
>>> for person in db._iter_raw_person_data():
...     count += 1

>>> db.close()
```

Scenario | Time in millseconds
-------- | --------------:
PR       | 43.7
PR + orjson installed         | 18.8

