### PR TITLE
Fix exactsearch filters

### DIFF
--- a/gramps/gui/selectors/baseselector.py
+++ b/gramps/gui/selectors/baseselector.py
@@ -315,8 +315,9 @@ class BaseSelector(ManagedWindow):
         """
         Builds the selection people see in the Selector
         """
+        # any search_bar filter takes precedence over self.filter
         search_bar_filter = self.search_bar.get_value()
-        if (not self.filter[1]) or (search_bar_filter[1]):
+        if search_bar_filter[1]:
             filter_info = (
                 0,
                 search_bar_filter,

--- a/gramps/gui/selectors/baseselector.py
+++ b/gramps/gui/selectors/baseselector.py
@@ -315,8 +315,9 @@ class BaseSelector(ManagedWindow):
         """
         Builds the selection people see in the Selector
         """
-        if not self.filter[1]:
-            filter_info = (False, self.search_bar.get_value(), False)
+        search_bar_filter = self.search_bar.get_value()
+        if (not self.filter[1]) or (search_bar_filter[1]):
+            filter_info = (0, search_bar_filter, search_bar_filter[0] in self.exact_search())
         else:
             filter_info = self.filter
         if self.model:

--- a/gramps/gui/selectors/baseselector.py
+++ b/gramps/gui/selectors/baseselector.py
@@ -317,7 +317,11 @@ class BaseSelector(ManagedWindow):
         """
         search_bar_filter = self.search_bar.get_value()
         if (not self.filter[1]) or (search_bar_filter[1]):
-            filter_info = (0, search_bar_filter, search_bar_filter[0] in self.exact_search())
+            filter_info = (
+                0,
+                search_bar_filter,
+                search_bar_filter[0] in self.exact_search(),
+            )
         else:
             filter_info = self.filter
         if self.model:

--- a/gramps/gui/selectors/baseselector.py
+++ b/gramps/gui/selectors/baseselector.py
@@ -305,7 +305,7 @@ class BaseSelector(ManagedWindow):
         Builds the default filters and add them to the filter bar.
         """
         cols = [
-            (pair[3], pair[1], pair[0] in self.exact_search())
+            (pair[3], pair[1], pair[1] in self.exact_search())
             for pair in self.column_order()
             if pair[0]
         ]


### PR DESCRIPTION
Some filters require exact search, "is", rather than "contains". This detail is given in the second value of the tuple, pair[1].
Correct the code so that it uses pair[1]