### PR TITLE
Fix exact search filters in selector dialogs

### DIFF
--- a/gramps/gui/selectors/baseselector.py
+++ b/gramps/gui/selectors/baseselector.py
@@ -305,7 +305,7 @@ class BaseSelector(ManagedWindow):
         Builds the default filters and add them to the filter bar.
         """
         cols = [
-            (pair[3], pair[1], pair[0] in self.exact_search())
+            (pair[3], pair[1], pair[1] in self.exact_search())
             for pair in self.column_order()
             if pair[0]
         ]


### PR DESCRIPTION
Some filters require an exact search, "is", rather than "contains". If the column number in pair[1] is in the values returned by the exact_search method then an exact search is required.