### PR TITLE
Make cleanup optional after an AIO build

### DIFF
--- a/.github/workflows/windows-aio.yml
+++ b/.github/workflows/windows-aio.yml
@@ -19,7 +19,14 @@
 
 name: Windows AIO
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      cleanup:
+        description: 'Cleanup python environment on completion?'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   build:
@@ -38,7 +45,7 @@ jobs:
     - name: Build
       run: |
         cd aio
-        ./build.sh
+        ./build.sh ${{ inputs.cleanup }}
     - uses: actions/upload-artifact@v4
       with:
         name: GrampsAIO

--- a/aio/README.md
+++ b/aio/README.md
@@ -27,4 +27,8 @@ cd gramps/aio
 ```
 To capture the full output of the build, use `./build.sh >& build_log.txt`
 
-Resulting AIO installer is in gramps/aio/mingw64/src/GrampsAIO-[appversion]-[appbuild]-[hash]_win64.exe
+The resulting AIO installer is in `gramps/aio/mingw64/src/GrampsAIO-[appversion]-[appbuild]-[hash]_win64.exe`
+
+The python virtual environment created during build (`c:\msys64\tmp\grampspythonenv\bin\python.exe` by default) can then be configured in Visual Studio Code and used to debug etc.
+
+To delete the python virtual environment at the end of the build, call ```./build.sh true```. This can be useful when testing the build script.

--- a/aio/build.sh
+++ b/aio/build.sh
@@ -157,7 +157,10 @@ makensis grampsaio64.nsi
 # result is in mingw64/src
 
 # deactivate and delete the python virtual environment
-deactivate
-rm -rf $pythonvenv
+if [ "$1" = "true" ]; then
+    echo "post build cleanup"
+    deactivate
+    rm -rf $pythonvenv
+fi
 
 exit 0


### PR DESCRIPTION
If the first argument passed to build.sh is "true", cleanup the python virtual environment at the end of the script.

For local development it is useful to keep the python virtual environment after the workflow completes.
For cloud runners, there is no need to cleanup as a new runner is provisioned for each workflow run
For locally testing build scripts it is helpful to cleanup the virtual environment. Since this is the less common scenario, default to not cleaning the environment.

For Windows developers it's then a case of install MSYS2, clone gramps sources, `cd aio; ./build.sh`
The leftover python virtual env (`c:\msys64\tmp\grampspythonenv\bin\python.exe` by default) can then be configured in Visual Studio Code and used to debug etc.
