### PR TITLE
Use orjson + encoder

### DIFF
--- a/.github/workflows/gramps-ci.yml
+++ b/.github/workflows/gramps-ci.yml
@@ -56,6 +56,7 @@ jobs:
         sudo apt-get install python3-libxml2
         sudo apt-get install zlib1g-dev
         sudo apt-get install python3-setuptools
+        python3 -m pip install orjson
     - name: Install addons
       run: |
         mkdir -p ~/.gramps/gramps60/plugins/

--- a/data/tests/example.gramps
+++ b/data/tests/example.gramps
@@ -18213,7 +18213,7 @@
       <childof hlink="_DLTJQCAPOXEIKSOU3J"/>
       <citationref hlink="_c140d24638d5368e8e4"/>
     </person>
-    <person handle="_0GDKQC54XKSWZKEBWW" change="1185438865" id="I0988">
+    <person handle="_0GDKQC54XKSWZKEBWW" change="1185438865" id="I0988" priv="1">
       <gender>M</gender>
       <name type="Birth Name">
         <first>John</first>

--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -60,7 +60,7 @@ from ..lib import (
     Source,
     Tag,
 )
-from ..lib.serialize import from_dict, BlobSerializer, JSONSerializer
+from ..lib.serialize import BlobSerializer, JSONSerializer
 from ..lib.genderstats import GenderStats
 from ..lib.researcher import Researcher
 from ..types import (
@@ -1409,7 +1409,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             raise HandleError("Handle is empty")
         data = self._get_raw_data(obj_key, handle)
         if data:
-            return self.serializer.data_to_object(obj_class, data)
+            return self.serializer.data_to_object(data, obj_class)
 
         raise HandleError(f"Handle {handle} not found")
 
@@ -1451,39 +1451,39 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
 
     def get_person_from_gramps_id(self, gramps_id) -> Person:
         data = self._get_raw_person_from_id_data(gramps_id)
-        return self.serializer.data_to_object(Person, data)
+        return self.serializer.data_to_object(data, Person)
 
     def get_family_from_gramps_id(self, gramps_id) -> Family:
         data = self._get_raw_family_from_id_data(gramps_id)
-        return self.serializer.data_to_object(Family, data)
+        return self.serializer.data_to_object(data, Family)
 
     def get_citation_from_gramps_id(self, gramps_id) -> Citation:
         data = self._get_raw_citation_from_id_data(gramps_id)
-        return self.serializer.data_to_object(Citation, data)
+        return self.serializer.data_to_object(data, Citation)
 
     def get_source_from_gramps_id(self, gramps_id) -> Source:
         data = self._get_raw_source_from_id_data(gramps_id)
-        return self.serializer.data_to_object(Source, data)
+        return self.serializer.data_to_object(data, Source)
 
     def get_event_from_gramps_id(self, gramps_id) -> Event:
         data = self._get_raw_event_from_id_data(gramps_id)
-        return self.serializer.data_to_object(Event, data)
+        return self.serializer.data_to_object(data, Event)
 
     def get_media_from_gramps_id(self, gramps_id) -> Media:
         data = self._get_raw_media_from_id_data(gramps_id)
-        return self.serializer.data_to_object(Media, data)
+        return self.serializer.data_to_object(data, Media)
 
     def get_place_from_gramps_id(self, gramps_id) -> Place:
         data = self._get_raw_place_from_id_data(gramps_id)
-        return self.serializer.data_to_object(Place, data)
+        return self.serializer.data_to_object(data, Place)
 
     def get_repository_from_gramps_id(self, gramps_id) -> Repository:
         data = self._get_raw_repository_from_id_data(gramps_id)
-        return self.serializer.data_to_object(Repository, data)
+        return self.serializer.data_to_object(data, Repository)
 
     def get_note_from_gramps_id(self, gramps_id) -> Note:
         data = self._get_raw_note_from_id_data(gramps_id)
-        return self.serializer.data_to_object(Note, data)
+        return self.serializer.data_to_object(data, Note)
 
     ################################################################
     #
@@ -1683,8 +1683,8 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         Iterate over items in a class.
         """
         cursor = self._get_table_func(class_.__name__, "cursor_func")
-        for data in cursor():
-            yield self.serializer.data_to_object(class_, data[1])
+        for handle, data in cursor():
+            yield self.serializer.data_to_object(data, class_)
 
     def iter_people(self) -> Generator[Person]:
         """Iterate over Person objects."""
@@ -2000,7 +2000,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         old_data = self._commit_base(person, PERSON_KEY, transaction, change_time)
 
         if old_data:
-            old_person = from_dict(old_data)
+            old_person = self.serializer.data_to_object(old_data)
             # Update gender statistics if necessary
             if old_person.gender != person.gender or (
                 old_person.primary_name.first_name != person.primary_name.first_name

--- a/gramps/gen/db/upgrade.py
+++ b/gramps/gen/db/upgrade.py
@@ -37,7 +37,6 @@ import logging
 # ------------------------------------------------------------------------
 from gramps.cli.clidbman import NAME_FILE
 from gramps.gen.db.dbconst import CLASS_TO_KEY_MAP
-from gramps.gen.lib.serialize import to_dict
 from gramps.gen.lib import EventType, NameOriginType, Tag, MarkerType
 from gramps.gen.utils.file import create_checksum
 from gramps.gen.utils.id import create_id
@@ -56,7 +55,6 @@ from .dbconst import (
 )
 from ..const import GRAMPS_LOCALE as glocale
 from .conversion_tools import convert_21
-from gramps.gen.lib.serialize import to_dict
 
 _ = glocale.translation.gettext
 

--- a/gramps/gen/display/name.py
+++ b/gramps/gen/display/name.py
@@ -75,7 +75,7 @@ from ..const import ARABIC_COMMA, ARABIC_SEMICOLON, GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
 from ..lib.name import Name
 from ..lib.nameorigintype import NameOriginType
-from ..lib.serialize import to_dict
+from ..lib.json_utils import object_to_data
 
 try:
     from ..config import config
@@ -912,7 +912,7 @@ class NameDisplay:
         try:
             s = func(
                 first,
-                [to_dict(surn) for surn in surname_list],
+                [object_to_data(surn) for surn in surname_list],
                 suffix,
                 title,
                 call,

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -39,7 +39,6 @@ from ..lib.repo import Repository
 from ..lib.media import Media
 from ..lib.note import Note
 from ..lib.tag import Tag
-from ..lib.serialize import from_dict
 from ..const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.gettext
@@ -146,7 +145,7 @@ class GenericFilter:
         if id_list is None:
             with self.get_tree_cursor(db) if tree else self.get_cursor(db) as cursor:
                 for handle, data in cursor:
-                    person = from_dict(data)
+                    person = db.serializer.data_to_object(data)
                     if user:
                         user.step_progress()
                     if task(db, person) != self.invert:
@@ -174,7 +173,7 @@ class GenericFilter:
         if id_list is None:
             with self.get_tree_cursor(db) if tree else self.get_cursor(db) as cursor:
                 for handle, data in cursor:
-                    person = from_dict(data)
+                    person = db.serializer.data_to_object(data)
                     if user:
                         user.step_progress()
                     val = all(rule.apply(db, person) for rule in flist)

--- a/gramps/gen/filters/rules/test/person_rules_test.py
+++ b/gramps/gen/filters/rules/test/person_rules_test.py
@@ -1204,9 +1204,8 @@ class BaseTest(unittest.TestCase):
         """
         Test PeoplePrivate rule.
         """
-        # TODO: example.gramps has no people marked private
         rule = PeoplePrivate([])
-        self.assertEqual(self.filter_with_rule(rule), set([]))
+        self.assertEqual(self.filter_with_rule(rule), set(["0GDKQC54XKSWZKEBWW"]))
 
     def test_peoplepublic(self):
         """
@@ -1214,7 +1213,7 @@ class BaseTest(unittest.TestCase):
         """
         rule = PeoplePublic([])
         # too many to list out to test explicitly
-        self.assertEqual(len(self.filter_with_rule(rule)), 2128)
+        self.assertEqual(len(self.filter_with_rule(rule)), 2127)
 
     def test_personwithincompleteevent(self):
         """

--- a/gramps/gen/lib/json_utils.py
+++ b/gramps/gen/lib/json_utils.py
@@ -1,0 +1,219 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2017,2024       Nick Hall
+# Copyright (C) 2024-2025       Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+# ------------------------------------------------------------------------
+#
+# Python modules
+#
+# ------------------------------------------------------------------------
+
+import json
+import orjson
+
+# ------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# ------------------------------------------------------------------------
+
+import gramps.gen.lib as lib
+
+
+NoneType = type(None)
+
+
+class DataDict(dict):
+    """
+    A wrapper around a data dict that also provides an
+    object interface.
+    """
+
+    def __init__(self, data=None):
+        """
+        Wrap a data dict (raw data) or object
+        with an attribute API. If data is an
+        object, we use it to get the attributes.
+        """
+        if isinstance(data, dict):
+            super().__init__(data)
+        else:
+            super().__init__()
+            if data:
+                # Data is actually a Gramps object
+                self.update(object_to_data(data))
+
+    def __str__(self):
+        if "_object" not in self:
+            self["_object"] = data_to_object(self)
+        return str(self["_object"])
+
+    def __getattr__(self, key):
+        if key.startswith("_"):
+            raise AttributeError(
+                "this method cannot be used to access hidden attributes"
+            )
+
+        if "_object" in self:
+            return getattr(self["_object"], key)
+        elif key in self:
+            value = self[key]
+            if isinstance(value, dict):
+                return DataDict(value)
+            elif isinstance(value, list):
+                return DataList(value)
+            else:
+                return value
+        else:
+            self["_object"] = data_to_object(self)
+            return getattr(self["_object"], key)
+
+
+class DataList(list):
+    """
+    A wrapper around a data list.
+    """
+
+    def __getitem__(self, position):
+        value = super().__getitem__(position)
+        if isinstance(value, dict):
+            return DataDict(value)
+        elif isinstance(value, list):
+            return DataList(value)
+        else:
+            return value
+
+
+def remove_object(data):
+    """
+    Remove _object, if any, from dicts.
+    """
+    if isinstance(data, dict):
+        return {
+            key: remove_object(value) for key, value in data.items() if key != "_object"
+        }
+    elif isinstance(data, (list, tuple)):
+        return [remove_object(item) for item in data]
+    else:
+        return data
+
+
+def convert_state_to_object(obj_dict):
+    _class = obj_dict.pop("_class")
+    cls = lib.__dict__[_class]
+    obj = cls.__new__(cls)
+    obj.set_object_state(obj_dict)
+    return obj
+
+
+def convert_object_to_state(obj):
+    return obj.get_object_state()
+
+
+def string_to_data(string: str | bytes) -> DataDict:
+    """
+    Convert a JSON string into its data representation.
+    """
+    return DataDict(orjson.loads(string))
+
+
+def string_to_dict(string: str | bytes) -> dict:
+    """
+    Convert a JSON string into its dict representation.
+    """
+    return orjson.loads(string)
+
+
+def dict_to_string(dict: dict) -> str | bytes:
+    """
+    Convert a dict into its JSON string representation.
+    """
+    return orjson.dumps(dict)
+
+
+def object_to_dict(obj):
+    """
+    Convert any Gramps lib object into a dict representation.
+    """
+    if isinstance(obj, (float, int, str, NoneType)):
+        return obj
+
+    elif isinstance(obj, (list, tuple)):
+        return [object_to_dict(item) for item in obj]
+
+    state = obj.get_object_state()
+    return {k: object_to_dict(v) for k, v in state.items()}
+
+
+def object_to_data(obj):
+    """
+    Convert any Gramps lib object or other value into
+    its dict or list representation or value, respectively.
+    """
+    if isinstance(obj, (float, int, str, NoneType)):
+        return obj
+
+    elif isinstance(obj, (list, tuple)):
+        return DataList([object_to_data(item) for item in obj])
+
+    state = obj.get_object_state()
+    data = {k: object_to_data(v) for k, v in state.items()}
+    # Stash the object in case we need it later:
+    data["_object"] = obj
+    return DataDict(data)
+
+
+def data_to_object(data):
+    """
+    Convert any object dict representation to a Gramps lib object
+    or other value.
+    """
+    if isinstance(data, dict):
+        if "_object" in data:
+            return data["_object"]
+
+        data = {k: data_to_object(v) for k, v in data.items()}
+        return convert_state_to_object(data)
+
+    elif isinstance(data, (list, tuple)):
+        return [data_to_object(item) for item in data]
+
+    return data
+
+
+def object_to_string(obj: object) -> str | bytes:
+    """
+    Convert any Gramps object into a JSON string/bytes.
+    """
+    return orjson.dumps(obj, default=convert_object_to_state)
+
+
+def data_to_string(data: DataDict):
+    """
+    Convert a DataDict into a string.
+    """
+    return orjson.dumps(remove_object(data))
+
+
+def string_to_object(string: str | bytes):
+    """
+    Convert a JSON string/bytes into a Gramps lib object.
+    """
+    return data_to_object(orjson.loads(string))

--- a/gramps/gen/lib/test/datadict_test.py
+++ b/gramps/gen/lib/test/datadict_test.py
@@ -24,7 +24,7 @@
 
 import unittest
 
-from gramps.gen.lib.serialize import DataDict, DataList, to_dict, from_dict
+from gramps.gen.lib.json_utils import DataDict, DataList, object_to_data, data_to_object
 from gramps.gen.lib import (
     Person,
     Family,
@@ -36,22 +36,22 @@ class DataDictTest(unittest.TestCase):
         p = Person()
         d = DataDict(p)
         # Get the object from the dict:
-        self.assertEqual(id(p), id(from_dict(d)))
+        self.assertEqual(id(p), id(data_to_object(d)))
 
-    def test_person_to_dict(self):
+    def test_person_to_data(self):
         p = Person()
-        d = to_dict(p)
+        d = object_to_data(p)
         self.assertFalse(hasattr(d, "_object"))
 
     def test_family(self):
         p = Family()
         d = DataDict(p)
         # Get the object from the dict:
-        self.assertEqual(id(p), id(from_dict(d)))
+        self.assertEqual(id(p), id(data_to_object(d)))
 
-    def test_family_to_dict(self):
+    def test_family_to_data(self):
         p = Family()
-        d = to_dict(p)
+        d = object_to_data(p)
         self.assertFalse(hasattr(d, "_object"))
 
 
@@ -91,13 +91,13 @@ class DataListTest(unittest.TestCase):
         self.assertIsInstance(dl[0], DataList)
         self.assertEqual(dl[0][0], 42)
 
-    def test_dict(self):
+    def test_data(self):
         p = Person()
-        p_dict = to_dict(p)
-        dl = DataList([p_dict])
+        p_data = object_to_data(p)
+        dl = DataList([p_data])
         self.assertIsInstance(dl, DataList)
         self.assertIsInstance(dl[0], DataDict)
-        self.assertEqual(dl[0], p_dict)
+        self.assertEqual(dl[0], p_data)
         self.assertEqual(dl[0].gender, 2)
 
     def test_append_list(self):

--- a/gramps/gen/lib/test/schema_test.py
+++ b/gramps/gen/lib/test/schema_test.py
@@ -41,7 +41,7 @@ from .. import (
     Source,
     Tag,
 )
-from ..serialize import to_json
+from ..json_utils import object_to_dict
 
 TEST_DIR = os.path.abspath(os.path.join(DATA_DIR, "tests"))
 EXAMPLE = os.path.join(TEST_DIR, "example.gramps")
@@ -49,7 +49,7 @@ EXAMPLE = os.path.join(TEST_DIR, "example.gramps")
 
 class BaseTest(unittest.TestCase):
     def _schema_test(self, obj):
-        instance = json.loads(to_json(obj))
+        instance = object_to_dict(obj)
         try:
             jsonschema.validate(instance, self.schema)
         except jsonschema.exceptions.ValidationError:

--- a/gramps/gen/lib/test/serialize_test.py
+++ b/gramps/gen/lib/test/serialize_test.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-""" Unittest for to_json, from_json """
+""" Unittest for object_to_data, data_to_object """
 
 import os
 import unittest
@@ -38,16 +38,19 @@ from .. import (
     Source,
     Tag,
 )
-from ..serialize import from_json, to_json
+from ..json_utils import object_to_data, data_to_object
 
 TEST_DIR = os.path.abspath(os.path.join(DATA_DIR, "tests"))
 EXAMPLE = os.path.join(TEST_DIR, "example.gramps")
 
 
 class BaseCheck:
-    def test_from_json(self):
-        data = to_json(self.object)
-        obj = from_json(data)
+    def test_data_to_object(self):
+        data = object_to_data(self.object)
+        self.assertIs(data.handle, None)
+        self.assertIs(data["handle"], None)
+        obj = data_to_object(data)
+        self.assertEqual(id(self.object), id(obj))
         self.assertEqual(self.object.serialize(), obj.serialize())
 
 
@@ -119,10 +122,10 @@ def generate_cases(obj, data):
     """
     Dynamically generate tests and attach to DatabaseCheck.
     """
-    json_data = to_json(obj)
-    obj2 = from_json(json_data)
 
     def test(self):
+        json_data = object_to_data(obj)
+        obj2 = data_to_object(json_data)
         self.assertEqual(obj.serialize(), obj2.serialize())
 
     name = "test_serialize_%s_%s" % (obj.__class__.__name__, obj.handle)

--- a/gramps/gen/merge/diff.py
+++ b/gramps/gen/merge/diff.py
@@ -25,7 +25,7 @@ This package implements an object difference engine.
 import json
 
 from ..db.utils import import_as_dict
-from ..lib.serialize import to_dict, from_dict
+from ..lib.json_utils import object_to_dict
 from ..const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.gettext
@@ -129,7 +129,9 @@ def diff_dbs(db1, db2, user):
                 if handles1[p1] == handles2[p2]:  # in both
                     item1 = handle_func1(handles1[p1])
                     item2 = handle_func2(handles2[p2])
-                    diff = diff_items(item, to_dict(item1), to_dict(item2))
+                    diff = diff_items(
+                        item, object_to_dict(item1), object_to_dict(item2)
+                    )
                     if diff:
                         diffs += [(item, item1, item2)]
                     # else same!

--- a/gramps/gen/proxy/proxybase.py
+++ b/gramps/gen/proxy/proxybase.py
@@ -48,6 +48,7 @@ from ..lib import (
     Source,
     Tag,
 )
+from ..lib.json_utils import object_to_data
 from ..const import GRAMPS_LOCALE as glocale
 
 
@@ -803,34 +804,34 @@ class ProxyDbBase(DbReadBase):
         return self.db.get_url_types()
 
     def get_raw_person_data(self, handle):
-        return self.get_person_from_handle(handle).serialize()
+        return object_to_data(self.get_person_from_handle(handle))
 
     def get_raw_family_data(self, handle):
-        return self.get_family_from_handle(handle).serialize()
+        return object_to_data(self.get_family_from_handle(handle))
 
     def get_raw_media_data(self, handle):
-        return self.get_media_from_handle(handle).serialize()
+        return object_to_data(self.get_media_from_handle(handle))
 
     def get_raw_place_data(self, handle):
-        return self.get_place_from_handle(handle).serialize()
+        return object_to_data(self.get_place_from_handle(handle))
 
     def get_raw_event_data(self, handle):
-        return self.get_event_from_handle(handle).serialize()
+        return object_to_data(self.get_event_from_handle(handle))
 
     def get_raw_source_data(self, handle):
-        return self.get_source_from_handle(handle).serialize()
+        return object_to_data(self.get_source_from_handle(handle))
 
     def get_raw_citation_data(self, handle):
-        return self.get_citation_from_handle(handle).serialize()
+        return object_to_data(self.get_citation_from_handle(handle))
 
     def get_raw_repository_data(self, handle):
-        return self.get_repository_from_handle(handle).serialize()
+        return object_to_data(self.get_repository_from_handle(handle))
 
     def get_raw_note_data(self, handle):
-        return self.get_note_from_handle(handle).serialize()
+        return object_to_data(self.get_note_from_handle(handle))
 
     def get_raw_tag_data(self, handle):
-        return self.get_tag_from_handle(handle).serialize()
+        return object_to_data(self.get_tag_from_handle(handle))
 
     def has_person_handle(self, handle):
         """

--- a/gramps/gen/proxy/test/proxies_test.py
+++ b/gramps/gen/proxy/test/proxies_test.py
@@ -1,0 +1,188 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2016 Tom Samstag
+# Copyright (C) 2025 Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Unittest that tests person-specific filter rules
+"""
+import unittest
+import os
+
+from ...db.utils import import_as_dict
+from ...const import DATA_DIR
+from ...user import User
+from ...lib.person import Person
+from ...lib.json_utils import remove_object
+
+from ...proxy import PrivateProxyDb, LivingProxyDb
+
+TEST_DIR = os.path.abspath(os.path.join(DATA_DIR, "tests"))
+EXAMPLE = os.path.join(TEST_DIR, "example.gramps")
+
+
+class PrivateProxyTest(unittest.TestCase):
+    """
+    Person rule tests.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Import example database.
+        """
+        cls.db = PrivateProxyDb(import_as_dict(EXAMPLE, User()))
+
+    def assertDataEquals(self, data1, data2):
+        self.assertIsInstance(data1, dict)
+        self.assertIsInstance(data2, dict)
+        self.assertEquals(
+            remove_object(data1),
+            remove_object(data2),
+        )
+
+    def test_person_count(self):
+        count = self.db.get_number_of_people()
+        # One private person:
+        self.assertEqual(count, 2127)
+        # No proxy:
+        count = self.db.basedb.get_number_of_people()
+        self.assertEqual(count, 2128)
+
+    def test_private_person_data(self):
+        # A private person:
+        handle = "0GDKQC54XKSWZKEBWW"
+        data = self.db.get_raw_person_data(handle)
+        self.assertIs(data, None)
+        # But they are visible without proxy:
+        data = self.db.basedb.get_raw_person_data(handle)
+        self.assertIsNot(data, None)
+
+    def test_not_private_person_data(self):
+        # A non-private person:
+        handle = "0FWJQCLYEP736P3YZK"
+        data = self.db.get_raw_person_data(handle)
+        self.assertIsNot(data, None)
+        self.assertIsInstance(data, dict)
+        self.assertEquals(data.handle, handle)
+        # Should be same:
+        data_orig = self.db.basedb.get_raw_person_data(handle)
+        self.assertDataEquals(data, data_orig)
+
+    def test_private_person(self):
+        # A private person:
+        handle = "0GDKQC54XKSWZKEBWW"
+        person = self.db.get_person_from_handle(handle)
+        self.assertIs(person, None)
+        # But they are visible without proxy:
+        person = self.db.basedb.get_person_from_handle(handle)
+        self.assertIsNot(person, None)
+
+    def test_not_private_person(self):
+        # A non-private person:
+        handle = "0FWJQCLYEP736P3YZK"
+        person = self.db.get_person_from_handle(handle)
+        self.assertIsNot(person, None)
+        self.assertIsInstance(person, Person)
+        person_orig = self.db.basedb.get_person_from_handle(handle)
+        # Same person:
+        self.assertEquals(person.gramps_id, person_orig.gramps_id)
+
+    def test_person_with_private_data(self):
+        # A person with private data:
+        handle = "GNUJQCL9MD64AM56OH"
+        person = self.db.get_person_from_handle(handle)
+        self.assertTrue(len(person.attribute_list) == 2)
+        # Unfiltered person has three attributes
+        person = self.db.basedb.get_person_from_handle(handle)
+        self.assertTrue(len(person.attribute_list) == 3)
+
+
+class LivingProxyTest(unittest.TestCase):
+    """
+    Person rule tests.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Import example database.
+        """
+        cls.db = LivingProxyDb(
+            import_as_dict(EXAMPLE, User()),
+            mode=LivingProxyDb.MODE_EXCLUDE_ALL,
+            current_year=2006,
+            years_after_death=10,
+        )
+
+    def test_person_count(self):
+        count = self.db.get_number_of_people()
+        self.assertEqual(count, 1245)
+
+    def test_live_person_data(self):
+        handle = "004KQCGYT27EEPQHK"
+        data = self.db.get_raw_person_data(handle)
+        self.assertIsInstance(data, dict)
+        self.assertEquals(data.primary_name.first_name, "Martha")
+
+    def test_dead_person_data(self):
+        handle = "66TJQC6CC7ZWL9YZ64"
+        data = self.db.get_raw_person_data(handle)
+        self.assertIs(data, None)
+
+    def test_live_person(self):
+        handle = "004KQCGYT27EEPQHK"
+        person = self.db.get_person_from_handle(handle)
+        self.assertIsInstance(person, Person)
+
+    def test_dead_person(self):
+        handle = "66TJQC6CC7ZWL9YZ64"
+        person = self.db.get_person_from_handle(handle)
+        self.assertIs(person, None)
+
+
+class LivingPrivateProxyTest(unittest.TestCase):
+    """
+    Person rule tests.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Import example database.
+        """
+        cls.db = LivingProxyDb(
+            PrivateProxyDb(import_as_dict(EXAMPLE, User())),
+            mode=LivingProxyDb.MODE_EXCLUDE_ALL,
+            current_year=2006,
+            years_after_death=10,
+        )
+
+    def test_person_count(self):
+        count = self.db.get_number_of_people()
+        self.assertEqual(count, 1244)
+
+    def test_private_person(self):
+        # A private person:
+        handle = "0GDKQC54XKSWZKEBWW"
+        person = self.db.get_person_from_handle(handle)
+        self.assertIs(person, None)
+        # But they are visible without proxy:
+        person = self.db.basedb.get_person_from_handle(handle)
+        self.assertIsNot(person, None)

--- a/gramps/gui/editors/editsecondary.py
+++ b/gramps/gui/editors/editsecondary.py
@@ -28,7 +28,6 @@
 from ..managedwindow import ManagedWindow
 from ..display import display_help
 from gramps.gen.config import config
-from gramps.gen.lib.serialize import to_dict, from_dict
 from ..dbguielement import DbGUIElement
 
 
@@ -37,7 +36,7 @@ class EditSecondary(ManagedWindow, DbGUIElement):
         """Create an edit window.  Associates a person with the window."""
 
         self.obj = obj
-        self.old_obj = to_dict(obj)
+        self.old_obj = state.db.serializer.object_to_data(obj)
         self.dbstate = state
         self.uistate = uistate
         self.db = state.db
@@ -138,7 +137,7 @@ class EditSecondary(ManagedWindow, DbGUIElement):
         """
         Undo the edits that happened on this secondary object
         """
-        self.obj = from_dict(self.old_obj)
+        self.obj = self.db.serializer.data_to_object(self.old_obj)
         self.close(obj)
 
     def close(self, *obj):

--- a/gramps/gui/views/treemodels/citationbasemodel.py
+++ b/gramps/gui/views/treemodels/citationbasemodel.py
@@ -45,7 +45,7 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 from gramps.gen.datehandler import format_time, get_date, get_date_valid
 from gramps.gen.lib import Citation
-from gramps.gen.lib.serialize import from_dict
+from gramps.gen.lib.json_utils import data_to_object
 from gramps.gen.utils.string import conf_strings
 from gramps.gen.config import config
 
@@ -62,7 +62,7 @@ class CitationBaseModel:
 
     def citation_date(self, data):
         if data.date:
-            citation = from_dict(data)
+            citation = data_to_object(data)
             date_str = get_date(citation)
             if date_str != "":
                 retval = escape(date_str)
@@ -77,7 +77,7 @@ class CitationBaseModel:
 
     def citation_sort_date(self, data):
         if data.date:
-            citation = from_dict(data)
+            citation = data_to_object(data)
             retval = "%09d" % citation.get_date_object().get_sort_value()
             if not get_date_valid(citation):
                 return INVALID_DATE_FORMAT % retval

--- a/gramps/gui/views/treemodels/eventmodel.py
+++ b/gramps/gui/views/treemodels/eventmodel.py
@@ -43,7 +43,7 @@ from gi.repository import Gtk
 # -------------------------------------------------------------------------
 from gramps.gen.datehandler import format_time, get_date, get_date_valid
 from gramps.gen.lib import Event, EventType
-from gramps.gen.lib.serialize import from_dict
+from gramps.gen.lib.json_utils import data_to_object
 from gramps.gen.utils.db import get_participant_from_event
 from gramps.gen.display.place import displayer as place_displayer
 from gramps.gen.config import config
@@ -137,7 +137,7 @@ class EventModel(FlatBaseModel):
         if data.place:
             cached, value = self.get_cached_value(data.handle, "PLACE")
             if not cached:
-                event = from_dict(data)
+                event = data_to_object(data)
                 value = place_displayer.display_event(self.db, event)
                 self.set_cached_value(data.handle, "PLACE", value)
             return value
@@ -152,7 +152,7 @@ class EventModel(FlatBaseModel):
 
     def column_date(self, data):
         if data.date:
-            event = from_dict(data)
+            event = data_to_object(data)
             date_str = get_date(event)
             if date_str != "":
                 retval = escape(date_str)
@@ -166,7 +166,7 @@ class EventModel(FlatBaseModel):
 
     def sort_date(self, data):
         if data.date:
-            event = from_dict(data)
+            event = data_to_object(data)
             retval = "%09d" % event.get_date_object().get_sort_value()
             if not get_date_valid(event):
                 return INVALID_DATE_FORMAT % retval

--- a/gramps/gui/views/treemodels/mediamodel.py
+++ b/gramps/gui/views/treemodels/mediamodel.py
@@ -46,7 +46,7 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 from gramps.gen.datehandler import displayer, format_time
 from gramps.gen.lib import Date, Media
-from gramps.gen.lib.serialize import from_dict
+from gramps.gen.lib.json_utils import data_to_object
 from .flatbasemodel import FlatBaseModel
 
 
@@ -135,12 +135,12 @@ class MediaModel(FlatBaseModel):
 
     def column_date(self, data):
         if data.date:
-            date = from_dict(data.date)
+            date = data_to_object(data.date)
             return displayer.display(date)
         return ""
 
     def sort_date(self, data):
-        obj = from_dict(data)
+        obj = data_to_object(data)
         d = obj.get_date_object()
         if d:
             return "%09d" % d.get_sort_value()

--- a/gramps/gui/views/treemodels/peoplemodel.py
+++ b/gramps/gui/views/treemodels/peoplemodel.py
@@ -67,7 +67,7 @@ from gramps.gen.lib import (
     ChildRefType,
     NoteType,
 )
-from gramps.gen.lib.serialize import from_dict
+from gramps.gen.lib.json_utils import data_to_object
 from gramps.gen.display.name import displayer as name_displayer
 from gramps.gen.display.place import displayer as place_displayer
 from gramps.gen.datehandler import format_time, get_date, get_date_valid
@@ -239,7 +239,7 @@ class PeopleBaseModel(BaseModel):
         if index != -1:
             try:
                 local = data.event_ref_list[index]
-                b = from_dict(local)
+                b = data_to_object(local)
                 birth = self.db.get_event_from_handle(b.ref)
                 if sort_mode:
                     retval = "%09d" % birth.get_date_object().get_sort_value()
@@ -255,7 +255,7 @@ class PeopleBaseModel(BaseModel):
                 return ""
 
         for event_ref in data.event_ref_list:
-            er = from_dict(event_ref)
+            er = data_to_object(event_ref)
             event = self.db.get_event_from_handle(er.ref)
             etype = event.get_type()
             date_str = get_date(event)
@@ -296,7 +296,7 @@ class PeopleBaseModel(BaseModel):
         if index != -1:
             try:
                 local = data.event_ref_list[index]
-                ref = from_dict(local)
+                ref = data_to_object(local)
                 event = self.db.get_event_from_handle(ref.ref)
                 if sort_mode:
                     retval = "%09d" % event.get_date_object().get_sort_value()
@@ -312,7 +312,7 @@ class PeopleBaseModel(BaseModel):
                 return ""
 
         for event_ref in data.event_ref_list:
-            er = from_dict(event_ref)
+            er = data_to_object(event_ref)
             event = self.db.get_event_from_handle(er.ref)
             etype = event.get_type()
             date_str = get_date(event)
@@ -341,7 +341,7 @@ class PeopleBaseModel(BaseModel):
             if index != -1:
                 try:
                     local = data.event_ref_list[index]
-                    br = from_dict(local)
+                    br = data_to_object(local)
                     event = self.db.get_event_from_handle(br.ref)
                     if event:
                         place_title = place_displayer.display_event(self.db, event)
@@ -355,7 +355,7 @@ class PeopleBaseModel(BaseModel):
                     return value
 
             for event_ref in data.event_ref_list:
-                er = from_dict(event_ref)
+                er = data_to_object(event_ref)
                 event = self.db.get_event_from_handle(er.ref)
                 etype = event.get_type()
                 if etype.is_birth_fallback() and er.get_role() == EventRoleType.PRIMARY:
@@ -378,7 +378,7 @@ class PeopleBaseModel(BaseModel):
             if index != -1:
                 try:
                     local = data.event_ref_list[index]
-                    dr = from_dict(local)
+                    dr = data_to_object(local)
                     event = self.db.get_event_from_handle(dr.ref)
                     if event:
                         place_title = place_displayer.display_event(self.db, event)
@@ -392,7 +392,7 @@ class PeopleBaseModel(BaseModel):
                     return value
 
             for event_ref in data.event_ref_list:
-                er = from_dict(event_ref)
+                er = data_to_object(event_ref)
                 event = self.db.get_event_from_handle(er.ref)
                 etype = event.get_type()
                 if etype.is_death_fallback() and er.get_role() == EventRoleType.PRIMARY:

--- a/gramps/gui/views/treemodels/placemodel.py
+++ b/gramps/gui/views/treemodels/placemodel.py
@@ -47,7 +47,7 @@ from gi.repository import Gtk
 #
 # -------------------------------------------------------------------------
 from gramps.gen.lib import Place, PlaceType
-from gramps.gen.lib.serialize import from_dict
+from gramps.gen.lib.json_utils import data_to_object
 from gramps.gen.datehandler import format_time
 from gramps.gen.utils.place import conv_lat_lon, coord_formats
 from gramps.gen.display.place import displayer as place_displayer
@@ -127,7 +127,7 @@ class PlaceBaseModel:
         handle = data.handle
         cached, value = self.get_cached_value(handle, "PLACE")
         if not cached:
-            place = from_dict(data)
+            place = data_to_object(data)
             value = place_displayer.display(self.db, place)
             self.set_cached_value(handle, "PLACE", value)
         return value

--- a/gramps/gui/views/treemodels/repomodel.py
+++ b/gramps/gui/views/treemodels/repomodel.py
@@ -41,7 +41,7 @@ from gi.repository import Gtk
 #
 # -------------------------------------------------------------------------
 from gramps.gen.lib import Address, RepositoryType, Url, UrlType
-from gramps.gen.lib.serialize import from_dict
+from gramps.gen.lib.json_utils import data_to_object
 from gramps.gen.datehandler import format_time
 from .flatbasemodel import FlatBaseModel
 from gramps.gen.const import GRAMPS_LOCALE as glocale
@@ -142,7 +142,7 @@ class RepositoryModel(FlatBaseModel):
     def column_city(self, data):
         try:
             if data.address_list:
-                addr = from_dict(data.address_list[0])
+                addr = data_to_object(data.address_list[0])
                 return addr.get_city()
         except:
             pass
@@ -151,7 +151,7 @@ class RepositoryModel(FlatBaseModel):
     def column_street(self, data):
         try:
             if data.address_list:
-                addr = from_dict(data.address_list[0])
+                addr = data_to_object(data.address_list[0])
                 return addr.get_street()
         except:
             pass
@@ -160,7 +160,7 @@ class RepositoryModel(FlatBaseModel):
     def column_locality(self, data):
         try:
             if data.address_list:
-                addr = from_dict(data.address_list[0])
+                addr = data_to_object(data.address_list[0])
                 return addr.get_locality()
         except:
             pass
@@ -169,7 +169,7 @@ class RepositoryModel(FlatBaseModel):
     def column_state(self, data):
         try:
             if data.address_list:
-                addr = from_dict(data.address_list[0])
+                addr = data_to_object(data.address_list[0])
                 return addr.get_state()
         except:
             pass
@@ -178,7 +178,7 @@ class RepositoryModel(FlatBaseModel):
     def column_country(self, data):
         try:
             if data.address_list:
-                addr = from_dict(data.address_list[0])
+                addr = data_to_object(data.address_list[0])
                 return addr.get_country()
         except:
             pass
@@ -187,7 +187,7 @@ class RepositoryModel(FlatBaseModel):
     def column_postal_code(self, data):
         try:
             if data.address_list:
-                addr = from_dict(data.address_list[0])
+                addr = data_to_object(data.address_list[0])
                 return addr.get_postal_code()
         except:
             pass
@@ -196,7 +196,7 @@ class RepositoryModel(FlatBaseModel):
     def column_phone(self, data):
         try:
             if data.address_list:
-                addr = from_dict(data.address_list[0])
+                addr = data_to_object(data.address_list[0])
                 return addr.get_phone()
         except:
             pass
@@ -205,7 +205,7 @@ class RepositoryModel(FlatBaseModel):
     def column_email(self, data):
         if data.urls:
             for url_data in data.urls:
-                url = from_dict(url_data)
+                url = data_to_object(url_data)
                 if url.get_type() == UrlType.EMAIL:
                     return url.path
         return ""
@@ -213,7 +213,7 @@ class RepositoryModel(FlatBaseModel):
     def column_search_url(self, data):
         if data.urls:
             for url_data in data.urls:
-                url = from_dict(url_data)
+                url = data_to_object(url_data)
                 if url.get_type() == UrlType.WEB_SEARCH:
                     return url.path
         return ""
@@ -221,7 +221,7 @@ class RepositoryModel(FlatBaseModel):
     def column_home_url(self, data):
         if data.urls:
             for url_data in data.urls:
-                url = from_dict(url_data)
+                url = data_to_object(url_data)
                 if url.get_type() == UrlType.WEB_HOME:
                     return url.path
         return ""

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -61,7 +61,6 @@ from gramps.gen.lib import (
     Source,
     Tag,
 )
-from gramps.gen.lib.serialize import from_dict, to_dict
 from gramps.gen.lib.genderstats import GenderStats
 from gramps.gen.updatecallback import UpdateCallback
 
@@ -684,9 +683,21 @@ class DBAPI(DbGeneric):
         self._update_backlinks(obj, trans)
         if not trans.batch:
             if old_data:
-                trans.add(obj_key, TXNUPD, obj.handle, old_data, to_dict(obj))
+                trans.add(
+                    obj_key,
+                    TXNUPD,
+                    obj.handle,
+                    old_data,
+                    self.serializer.object_to_data(obj),
+                )
             else:
-                trans.add(obj_key, TXNADD, obj.handle, None, to_dict(obj))
+                trans.add(
+                    obj_key,
+                    TXNADD,
+                    obj.handle,
+                    None,
+                    self.serializer.object_to_data(obj),
+                )
 
         return old_data
 
@@ -928,7 +939,7 @@ class DBAPI(DbGeneric):
             logging.info("Rebuilding %s reference map", class_func.__name__)
             with cursor_func() as cursor:
                 for _, val in cursor:
-                    obj = self.serializer.data_to_object(class_func, val)
+                    obj = self.serializer.data_to_object(val, class_func)
                     references = set(obj.get_referenced_handles_recursively())
                     # handle addition of new references
                     for ref_class_name, ref_handle in references:
@@ -1091,7 +1102,7 @@ class DBAPI(DbGeneric):
                     f"INSERT INTO {table} (handle, {self.serializer.data_field}) VALUES (?, ?)",
                     [handle, self.serializer.data_to_string(data)],
                 )
-            obj = from_dict(data)
+            obj = self.serializer.data_to_object(data)
             self._update_secondary_values(obj)
 
     def get_surname_list(self):

--- a/gramps/plugins/gramplet/sessionloggramplet.py
+++ b/gramps/plugins/gramplet/sessionloggramplet.py
@@ -30,7 +30,7 @@ import time
 # ------------------------------------------------------------------------
 
 from gramps.gen.lib import Person, Family
-from gramps.gen.lib.serialize import from_dict
+from gramps.gen.lib.json_utils import data_to_object
 from gramps.gen.db import PERSON_KEY, FAMILY_KEY, TXNDEL
 from gramps.gen.plug import Gramplet
 from gramps.gen.display.name import displayer as name_displayer
@@ -129,7 +129,7 @@ class LogGramplet(Gramplet):
                                 and trans_type == TXNDEL
                                 and hndl == handle
                             ):
-                                person = from_dict(old_data)
+                                person = data_to_object(old_data)
                                 name = name_displayer.display(person)
                                 break
                 elif ltype == "Family":
@@ -150,7 +150,7 @@ class LogGramplet(Gramplet):
                                 and trans_type == TXNDEL
                                 and hndl == handle
                             ):
-                                family = from_dict(old_data)
+                                family = data_to_object(old_data)
                                 name = family_name(family, self.dbstate.db, name)
                                 break
                 self.append_text(name)

--- a/gramps/plugins/importer/importxml.py
+++ b/gramps/plugins/importer/importxml.py
@@ -91,7 +91,7 @@ from gramps.gen.lib import (
     Tag,
     Url,
 )
-from gramps.gen.lib.serialize import from_dict
+from gramps.gen.lib.json_utils import data_to_object
 from gramps.gen.db import DbTxn
 
 # from gramps.gen.db.write import CLASS_TO_KEY_MAP
@@ -840,7 +840,7 @@ class GrampsParser(UpdateCallback):
                     "tag": self.db.get_raw_tag_data,
                 }[target]
                 raw = get_raw_obj_data(handle)
-                temp_obj = from_dict(raw)
+                temp_obj = data_to_object(raw)
                 prim_obj.set_object_state(temp_obj.get_object_state())
                 self.import_handles[orig_handle][target][INSTANTIATED] = True
             return handle
@@ -1002,7 +1002,7 @@ class GrampsParser(UpdateCallback):
         handle = id2handle_map.get(gramps_id)
         if handle:
             raw = get_raw_obj_data(handle)
-            temp_obj = from_dict(raw)
+            temp_obj = data_to_object(raw)
             prim_obj.set_object_state(temp_obj.get_object_state())
         else:
             handle = create_id()

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -158,7 +158,7 @@ from gramps.gen.lib import (
     PlaceRef,
     PlaceName,
 )
-from gramps.gen.lib.serialize import from_dict, to_dict
+from gramps.gen.lib.json_utils import data_to_object, object_to_dict
 from gramps.gen.db import DbTxn
 from gramps.gen.updatecallback import UpdateCallback
 from gramps.gen.utils.file import media_path
@@ -2163,7 +2163,7 @@ class GedcomParser(UpdateCallback):
     __TRUNC_MSG = _(
         "Your GEDCOM file is corrupted. " "It appears to have been truncated."
     )
-    _EMPTY_LOC = to_dict(Location())
+    _EMPTY_LOC = object_to_dict(Location())
 
     SyntaxError = "Syntax Error"
     BadFile = "Not a GEDCOM file"
@@ -3187,7 +3187,7 @@ class GedcomParser(UpdateCallback):
         """
         intid = self.gid2id.get(gramps_id)
         if self.dbase.has_person_handle(intid):
-            person = from_dict(self.dbase.get_raw_person_data(intid))
+            person = data_to_object(self.dbase.get_raw_person_data(intid))
         else:
             person = Person()
             intid = self.__find_from_handle(gramps_id, self.gid2id)
@@ -3203,7 +3203,7 @@ class GedcomParser(UpdateCallback):
         """
         intid = self.fid2id.get(gramps_id)
         if self.dbase.has_family_handle(intid):
-            family = from_dict(self.dbase.get_raw_family_data(intid))
+            family = data_to_object(self.dbase.get_raw_family_data(intid))
         else:
             family = Family()
             intid = self.__find_from_handle(gramps_id, self.fid2id)
@@ -3221,7 +3221,7 @@ class GedcomParser(UpdateCallback):
         """
         intid = self.oid2id.get(gramps_id)
         if self.dbase.has_media_handle(intid):
-            obj = from_dict(self.dbase.get_raw_media_data(intid))
+            obj = data_to_object(self.dbase.get_raw_media_data(intid))
         else:
             obj = Media()
             intid = self.__find_from_handle(gramps_id, self.oid2id)
@@ -3239,7 +3239,7 @@ class GedcomParser(UpdateCallback):
         """
         intid = self.sid2id.get(gramps_id)
         if self.dbase.has_source_handle(intid):
-            obj = from_dict(self.dbase.get_raw_source_data(intid))
+            obj = data_to_object(self.dbase.get_raw_source_data(intid))
         else:
             obj = Source()
             intid = self.__find_from_handle(gramps_id, self.sid2id)
@@ -3258,7 +3258,7 @@ class GedcomParser(UpdateCallback):
         """
         intid = self.rid2id.get(gramps_id)
         if self.dbase.has_repository_handle(intid):
-            repository = from_dict(self.dbase.get_raw_repository_data(intid))
+            repository = data_to_object(self.dbase.get_raw_repository_data(intid))
         else:
             repository = Repository()
             intid = self.__find_from_handle(gramps_id, self.rid2id)
@@ -3282,7 +3282,7 @@ class GedcomParser(UpdateCallback):
 
         intid = self.nid2id.get(gramps_id)
         if self.dbase.has_note_handle(intid):
-            note = from_dict(self.dbase.get_raw_note_data(intid))
+            note = data_to_object(self.dbase.get_raw_note_data(intid))
         else:
             note = Note()
             intid = self.__find_from_handle(gramps_id, self.nid2id)
@@ -3302,7 +3302,7 @@ class GedcomParser(UpdateCallback):
         """
         if location is None:
             return True
-        elif to_dict(location) == self._EMPTY_LOC:
+        elif object_to_dict(location) == self._EMPTY_LOC:
             return True
         elif location.is_empty():
             return True

--- a/gramps/plugins/lib/libmixin.py
+++ b/gramps/plugins/lib/libmixin.py
@@ -39,7 +39,7 @@ from gramps.gen.lib import (
     Note,
     Tag,
 )
-from gramps.gen.lib.serialize import from_dict
+from gramps.gen.lib.json_utils import data_to_object
 
 
 # ------------------------------------------------------------------------------
@@ -79,7 +79,7 @@ class DbMixin:
         new = True
         raw = get_raw_obj_data(handle)
         if raw is not None:
-            obj = from_dict(raw)
+            obj = data_to_object(raw)
             # references create object with id None before object is really made
             if obj.gramps_id is not None:
                 new = False
@@ -105,7 +105,7 @@ class DbMixin:
         handle = str(handle)
         raw = get_raw_obj_data(handle)
         if raw is not None:
-            obj = from_dict(raw)
+            obj = data_to_object(raw)
             return obj, False
         else:
             obj.set_handle(handle)

--- a/gramps/plugins/test/imports_test.py
+++ b/gramps/plugins/test/imports_test.py
@@ -36,7 +36,8 @@ from gramps.gen.utils.config import config
 
 config.set("preferences.date-format", 0)
 from gramps.gen.db.utils import import_as_dict
-from gramps.gen.merge.diff import diff_dbs, to_dict
+from gramps.gen.merge.diff import diff_dbs
+from gramps.gen.lib.json_utils import object_to_dict
 from gramps.gen.simple import SimpleAccess
 from gramps.gen.utils.id import set_det_id
 from gramps.gen.user import User
@@ -99,7 +100,9 @@ class TestImports(unittest.TestCase):
         if diffs:
             for diff in diffs:
                 obj_type, item1, item2 = diff
-                msg = self._report_diff(obj_type, to_dict(item1), to_dict(item2))
+                msg = self._report_diff(
+                    obj_type, object_to_dict(item1), object_to_dict(item2)
+                )
                 if msg != "":
                     if hasattr(item1, "gramps_id"):
                         self.msg += "%s: %s  handle=%s\n" % (

--- a/gramps/plugins/tool/check.py
+++ b/gramps/plugins/tool/check.py
@@ -76,7 +76,7 @@ from gramps.gen.lib import (
     StyledTextTagType,
     Tag,
 )
-from gramps.gen.lib.serialize import to_dict
+from gramps.gen.lib.json_utils import object_to_dict
 from gramps.gen.db import DbTxn, CLASS_TO_KEY_MAP
 from gramps.gen.config import config
 from gramps.gen.utils.id import create_id
@@ -909,15 +909,15 @@ class CheckIntegrity:
             logging.info("    OK: no missing photos found")
 
     def cleanup_empty_objects(self):
-        empty_person_data = to_dict(Person())
-        empty_family_data = to_dict(Family())
-        empty_event_data = to_dict(Event())
-        empty_source_data = to_dict(Source())
-        empty_citation_data = to_dict(Citation())
-        empty_place_data = to_dict(Place())
-        empty_media_data = to_dict(Media())
-        empty_repos_data = to_dict(Repository())
-        empty_note_data = to_dict(Note())
+        empty_person_data = object_to_dict(Person())
+        empty_family_data = object_to_dict(Family())
+        empty_event_data = object_to_dict(Event())
+        empty_source_data = object_to_dict(Source())
+        empty_citation_data = object_to_dict(Citation())
+        empty_place_data = object_to_dict(Place())
+        empty_media_data = object_to_dict(Media())
+        empty_repos_data = object_to_dict(Repository())
+        empty_note_data = object_to_dict(Note())
 
         _db = self.db
 

--- a/gramps/plugins/tool/mediamanager.py
+++ b/gramps/plugins/tool/mediamanager.py
@@ -51,7 +51,8 @@ from gi.repository import GdkPixbuf
 from gramps.gen.const import URL_MANUAL_PAGE, ICON, SPLASH
 from gramps.gui.display import display_help
 from gramps.gen.lib import Media
-from gramps.gen.lib.serialize import from_dict
+
+from gramps.gen.lib.json_utils import data_to_object
 from gramps.gen.db import DbTxn
 from gramps.gen.updatecallback import UpdateCallback
 from gramps.gui.plug import tool
@@ -570,7 +571,7 @@ class PathChange(BatchOp):
         self.set_total(self.db.get_number_of_media())
         with self.db.get_media_cursor() as cursor:
             for handle, data in cursor:
-                obj = from_dict(data)
+                obj = data_to_object(data)
                 if obj.get_path().find(from_text) != -1:
                     self.handle_list.append(handle)
                     self.path_list.append(obj.path)
@@ -609,7 +610,7 @@ class Convert2Abs(BatchOp):
         self.set_total(self.db.get_number_of_media())
         with self.db.get_media_cursor() as cursor:
             for handle, data in cursor:
-                obj = from_dict(data)
+                obj = data_to_opject(data)
                 if not os.path.isabs(obj.path):
                     self.handle_list.append(handle)
                     self.path_list.append(obj.path)
@@ -647,7 +648,7 @@ class Convert2Rel(BatchOp):
         self.set_total(self.db.get_number_of_media())
         with self.db.get_media_cursor() as cursor:
             for handle, data in cursor:
-                obj = from_dict(data)
+                obj = data_to_object(data)
                 if os.path.isabs(obj.path):
                     self.handle_list.append(handle)
                     self.path_list.append(obj.path)
@@ -688,7 +689,7 @@ class ImagesNotIncluded(BatchOp):
         self.set_total(self.db.get_number_of_media())
         with self.db.get_media_cursor() as cursor:
             for handle, data in cursor:
-                obj = from_dict(data)
+                obj = data_to_object(data)
                 self.handle_list.append(handle)
                 full_path = media_path_full(self.db, obj.path)
                 self.path_list.append(full_path)

--- a/gramps/plugins/tool/rebuildgenderstat.py
+++ b/gramps/plugins/tool/rebuildgenderstat.py
@@ -56,7 +56,7 @@ from gramps.gui.plug import tool
 from gramps.gui.dialog import OkDialog
 from gramps.gen.updatecallback import UpdateCallback
 from gramps.gen.lib import Name
-from gramps.gen.lib.serialize import from_dict
+from gramps.gen.lib.json_utils import data_to_object
 
 # -------------------------------------------------------------------------
 #
@@ -114,9 +114,9 @@ class RebuildGenderStat(tool.Tool, UpdateCallback):
             for key, data in cursor:
                 rawprimname = data["primary_name"]
                 rawaltnames = data["alternate_names"]
-                primary_name = from_dict(rawprimname).get_first_name()
+                primary_name = data_to_object(rawprimname).get_first_name()
                 alternate_names = [
-                    from_dict(name).get_first_name() for name in rawaltnames
+                    data_to_object(name).get_first_name() for name in rawaltnames
                 ]
                 self.db.genderStats.count_name(primary_name, data["gender"])
 

--- a/gramps/plugins/tool/removeunused.py
+++ b/gramps/plugins/tool/removeunused.py
@@ -89,7 +89,7 @@ class RemoveUnused(tool.Tool, ManagedWindow, UpdateCallback):
                 "get_text": self.get_event_text,
                 "editor": "EditEvent",
                 "icon": "gramps-event",
-                "name_ix": 4,
+                "name_ix": "description",
             },
             "sources": {
                 "get_func": self.db.get_source_from_handle,
@@ -97,7 +97,7 @@ class RemoveUnused(tool.Tool, ManagedWindow, UpdateCallback):
                 "get_text": None,
                 "editor": "EditSource",
                 "icon": "gramps-source",
-                "name_ix": 2,
+                "name_ix": "title",
             },
             "citations": {
                 "get_func": self.db.get_citation_from_handle,
@@ -105,7 +105,7 @@ class RemoveUnused(tool.Tool, ManagedWindow, UpdateCallback):
                 "get_text": None,
                 "editor": "EditCitation",
                 "icon": "gramps-citation",
-                "name_ix": 3,
+                "name_ix": "page",
             },
             "places": {
                 "get_func": self.db.get_place_from_handle,
@@ -113,7 +113,7 @@ class RemoveUnused(tool.Tool, ManagedWindow, UpdateCallback):
                 "get_text": self.get_place_text,
                 "editor": "EditPlace",
                 "icon": "gramps-place",
-                "name_ix": 2,
+                "name_ix": "title",
             },
             "media": {
                 "get_func": self.db.get_media_from_handle,
@@ -121,7 +121,7 @@ class RemoveUnused(tool.Tool, ManagedWindow, UpdateCallback):
                 "get_text": None,
                 "editor": "EditMedia",
                 "icon": "gramps-media",
-                "name_ix": 4,
+                "name_ix": "desc",
             },
             "repos": {
                 "get_func": self.db.get_repository_from_handle,
@@ -129,7 +129,7 @@ class RemoveUnused(tool.Tool, ManagedWindow, UpdateCallback):
                 "get_text": None,
                 "editor": "EditRepository",
                 "icon": "gramps-repository",
-                "name_ix": 3,
+                "name_ix": "name",
             },
             "notes": {
                 "get_func": self.db.get_note_from_handle,
@@ -137,7 +137,7 @@ class RemoveUnused(tool.Tool, ManagedWindow, UpdateCallback):
                 "get_text": self.get_note_text,
                 "editor": "EditNote",
                 "icon": "gramps-notes",
-                "name_ix": 2,
+                "name_ix": "text",
             },
         }
 
@@ -399,7 +399,7 @@ class RemoveUnused(tool.Tool, ManagedWindow, UpdateCallback):
 
     def add_results(self, results):
         (the_type, handle, data) = results
-        gramps_id = data[1]
+        gramps_id = data.gramps_id
 
         # if we have a function that will return to us some type
         # of text summary, then we should use it; otherwise we'll

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -166,6 +166,7 @@ gramps/gen/lib/datebase.py
 gramps/gen/lib/eventbase.py
 gramps/gen/lib/gcalendar.py
 gramps/gen/lib/genderstats.py
+gramps/gen/lib/json_utils.py
 gramps/gen/lib/ldsordbase.py
 gramps/gen/lib/locationbase.py
 gramps/gen/lib/mediabase.py
@@ -262,6 +263,11 @@ gramps/gen/proxy/filter.py
 gramps/gen/proxy/living.py
 gramps/gen/proxy/proxybase.py
 gramps/gen/proxy/referencedbyselection.py
+#
+# gen.proxy.test
+#
+gramps/gen/proxy/test/__init__.py
+gramps/gen/proxy/test/proxies_test.py
 #
 # gen.simple
 #

--- a/test/blob_to_json_test.py
+++ b/test/blob_to_json_test.py
@@ -1,5 +1,4 @@
 from gramps.gen.db.utils import open_database
-from gramps.gen.lib.serialize import to_dict, from_dict
 from gramps.gen.db.conversion_tools import convert_21
 
 # 1. Prepare: create a database named "Example" in version 20
@@ -23,7 +22,7 @@ for table_name in db._get_table_func():
 
     for obj in iter_objects():
         # We convert the object into the JSON dicts:
-        json_data = to_dict(obj)
+        json_data = db.serializer.object_to_data(obj)
 
         # We get the blob array:
         array = get_array_from_handle(obj.handle)


### PR DESCRIPTION
This PR uses orjson with a hand-coded encoder/decoder everywhere, and assumes orjson is installed.

Tests shows that this is 60% faster than master for `db.iter_people()` on a 40k person table.