### PR TITLE
unittest both with and without orjson

### DIFF
--- a/.github/workflows/gramps-ci.yml
+++ b/.github/workflows/gramps-ci.yml
@@ -74,3 +74,5 @@ jobs:
       run: |
         export GDK_BACKEND=-
         python3 setup.py test
+        python3 -m pip install orjson
+        python3 setup.py test


### PR DESCRIPTION
orjson is highly recommend, but not mandatory, so test both scenarios

This PR is so that we can discuss if we \ how we want to unit test with orjson
Originated from an observation in #1875. See [this](https://github.com/gramps-project/gramps/pull/1875#issuecomment-2614312272) comment.