### PR TITLE
Change http:// to https:// in Tip of the Day file

### DIFF
--- a/data/tips.xml
+++ b/data/tips.xml
@@ -93,7 +93,7 @@
 
 <tip number="50"><b>Reporting Bugs in Gramps</b><br/>The best way to report a bug in Gramps is to use the Gramps bug tracking system at https://gramps-project.org/bugs/.</tip>
 
-<tip number="51"><b>The Gramps Homepage</b><br/>The Gramps homepage is at http://gramps-project.org/.</tip>
+<tip number="51"><b>The Gramps Homepage</b><br/>The Gramps homepage is at https://gramps-project.org/.</tip>
 
 <tip number="53"><b>Privacy in Gramps</b><br/>Gramps helps you to keep personal information secure by allowing you to mark information as private. Data marked as private can be excluded from reports and data exports. Look for the padlock which toggles records between private and public.</tip>
 
@@ -123,7 +123,7 @@
 
 <tip number="71"><b>Open Source Software</b><br/>The Free/Libre and Open Source Software (FLOSS) development model means Gramps can be extended by any programmer since all of the source code is freely available under its license. So it's not just about free beer, it's also about freedom to study and change the tool. For more about Open Source software lookup the Free Software Foundation and the Open Source Initiative.</tip>
 
-<tip number="72"><b>The Gramps Software License</b><br/>You are free to use and share Gramps with others. Gramps is freely distributable under the GNU General Public License, see http://www.gnu.org/licenses/licenses.html#GPL to read about the rights and restrictions of this license.</tip>
+<tip number="72"><b>The Gramps Software License</b><br/>You are free to use and share Gramps with others. Gramps is freely distributable under the GNU General Public License, see https://www.gnu.org/licenses/licenses.html#GPL to read about the rights and restrictions of this license.</tip>
 
 <tip number="73"><b>Gramps for Gnome or KDE?</b><br/>For Linux users Gramps works with whichever desktop environment you prefer. As long as the required GTK libraries are installed it will run fine.</tip>
 


### PR DESCRIPTION
Reported as a source string [comment](https://hosted.weblate.org/translate/gramps-project/gramps/en/?checksum=b90cbe9de5be9c41) on Weblate.