### PR TITLE
Safe mode working with Gramps 5.2 on Windows

### DIFF
--- a/gramps/gen/const.py
+++ b/gramps/gen/const.py
@@ -100,10 +100,13 @@ if "GRAMPSHOME" in os.environ:
     HOME_DIR = os.path.join(USER_HOME, "gramps")
 elif "USERPROFILE" in os.environ:
     USER_HOME = get_env_var("USERPROFILE")
-    if "APPDATA" in os.environ:
-        HOME_DIR = os.path.join(get_env_var("APPDATA"), "gramps")
-    else:
-        HOME_DIR = os.path.join(USER_HOME, "gramps")
+    HOME_DIR = os.path.join(GLib.get_user_config_dir(), "gramps")
+    if not os.path.exists(HOME_DIR):
+        homedir = get_env_var("APPDATA") if "APPDATA" in os.environ else USER_HOME
+        homedir = os.path.join(homedir, "gramps")
+        dbpath = os.path.join(homedir, "grampsdb")
+        if os.path.isdir(dbpath) and os.listdir(dbpath):
+            HOME_DIR = homedir
 else:
     USER_HOME = get_env_var("HOME")
     HOME_DIR = os.path.join(USER_HOME, ".gramps")


### PR DESCRIPTION
Fixes [#13300](https://gramps-project.org/bugs/view.php?id=13300)

Safe mode which was broken with Gramps 5.2.0-5.2.4 on Windows, has been fixed with commit.

Previously code was looking for user configuration in APPDATA, but with the move to XDG-based directory layout (bug [8025](https://gramps-project.org/bugs/view.php?id=8025)), this was no longer correct.

Per Nick Hall's review comment: Use the old directory structure if new structure is not present *and* the old location isn't empty (i.e. upgrade scenario from pre-5.2 Gramps), otherwise, use the new XDG-based directory layout (i.e. new install scenario of Gramps 5.2+).

TESTING
Test to verify that [safe mode](https://gramps-project.org/wiki/index.php/Gramps_5.2_Wiki_Manual_-_Command_Line#Safe_mode) functions as described, i.e. starting from a user's customized environment, verify that existing family trees are available in safe mode but settings and configuration are not.

NOTE: This also fixes [#13261](https://gramps-project.org/bugs/view.php?id=13261) which documents another way in which this bug manifests. However, this is bug is closer to the root cause and easier to test.

For previous discussion of this change, see PR #1726