### PR TITLE
Add a translation context to a couple of name origin types

### DIFF
--- a/gramps/gen/lib/nameorigintype.py
+++ b/gramps/gen/lib/nameorigintype.py
@@ -89,8 +89,8 @@ class NameOriginType(GrampsType):
         (PSEUDONYM, _("Pseudonym"), "Pseudonym"),
         (PATRILINEAL, _("Patrilineal"), "Patrilineal"),
         (MATRILINEAL, _("Matrilineal"), "Matrilineal"),
-        (OCCUPATION, _("Occupation"), "Occupation"),
-        (LOCATION, _("Location"), "Location"),
+        (OCCUPATION, _("Occupation", "Surname"), "Occupation"),
+        (LOCATION, _("Location", "Surname"), "Location"),
     ]
 
     def __init__(self, value=None):


### PR DESCRIPTION
Add the translation context "Surname" to the name origin types "Occupation" and "Location".

This change was requested by a Weblate translator.