### PR TITLE
The space used as an empty column heading does not need translation

### DIFF
--- a/gramps/plugins/lib/libmetadata.py
+++ b/gramps/plugins/lib/libmetadata.py
@@ -227,7 +227,7 @@ class MetadataView(Gtk.TreeView):
         titles = [
             (_("Namespace"), 0, 150),
             (_("Label"), 1, 150),
-            (_(" "), NOSORT, 60, COL_IMAGE),
+            (" ", NOSORT, 60, COL_IMAGE),
             (_("Value"), NOSORT, 325),
         ]
 


### PR DESCRIPTION
This change was requested by a Weblate translator.