### PR TITLE
The example filename in the welcome gramplet should not be translated

### DIFF
--- a/gramps/plugins/gramplet/welcomegramplet.py
+++ b/gramps/plugins/gramplet/welcomegramplet.py
@@ -265,7 +265,7 @@ class WelcomeGramplet(Gramplet):
                 " the Gramps program.\n\n"
             )
         )
-        welcome += linkst(_("Example.gramps"), wiki("Example.gramps")) + "\n\n"
+        welcome += linkst("Example.gramps", wiki("Example.gramps")) + "\n\n"
 
         self.texteditor.set_text(welcome)
 


### PR DESCRIPTION
This change was requested by a Weblate translator.