### PR TITLE
Split the indexes of people, families, events, places and sources in the narrative web.

### DIFF
--- a/data/css/Web_Basic-Ash.css
+++ b/data/css/Web_Basic-Ash.css
@@ -192,6 +192,12 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #CCC;
     border-bottom: solid 1px black;
 }
+div#ltr.nav ul.ltr li.CurrentSection, div#rtl.nav ul.rtl li.CurrentSection,
+div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
+    font-weight: bold;
+    font-style: italic;
+    background-color: #CCC;
+}
 div#nav ul li.CurrentSection a {
     position: relative;
     top: 1px;

--- a/data/css/Web_Basic-Ash.css
+++ b/data/css/Web_Basic-Ash.css
@@ -192,7 +192,7 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #CCC;
     border-bottom: solid 1px black;
 }
-div#ltr.nav ul.ltr li.CurrentSection, div#rtl.nav ul.rtl li.CurrentSection,
+div#ltr.pnav ul.ltr li.CurrentSection, div#rtl.pnav ul.rtl li.CurrentSection,
 div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
     font-weight: bold;
     font-style: italic;
@@ -210,6 +210,8 @@ div#nav ul li.CurrentSection a {
 }
 div#nav li.lang {
     font-family: sans-serif;
+    font-size: smaller;
+    font-weight: bold;
 }
 div#nav li.lang:hover > ul {
     visibility: visible;

--- a/data/css/Web_Basic-Blue.css
+++ b/data/css/Web_Basic-Blue.css
@@ -283,6 +283,12 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #CCC;
     border-bottom: solid 1px black;
 }
+div#ltr.nav ul.ltr li.CurrentSection, div#rtl.nav ul.rtl li.CurrentSection,
+div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
+    font-weight: bold;
+    font-style: italic;
+    background-color: #CCC;
+}
 div#nav ul li.CurrentSection a {
     position: relative;
     top: 1px;

--- a/data/css/Web_Basic-Blue.css
+++ b/data/css/Web_Basic-Blue.css
@@ -283,7 +283,7 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #CCC;
     border-bottom: solid 1px black;
 }
-div#ltr.nav ul.ltr li.CurrentSection, div#rtl.nav ul.rtl li.CurrentSection,
+div#ltr.pnav ul.ltr li.CurrentSection, div#rtl.pnav ul.rtl li.CurrentSection,
 div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
     font-weight: bold;
     font-style: italic;
@@ -300,7 +300,7 @@ div#nav ul li.CurrentSection a {
     background-color: #903;
 }
 div#nav li.lang {
-    font-size: 12px;
+    font-size: smaller;
     font-weight: bold;
     padding-top: .5em;
 }

--- a/data/css/Web_Basic-Cypress.css
+++ b/data/css/Web_Basic-Cypress.css
@@ -200,6 +200,12 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #9DBF9D;
     border-bottom: solid 1px black;
 }
+div#ltr.nav ul.ltr li.CurrentSection, div#rtl.nav ul.rtl li.CurrentSection,
+div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
+    font-weight: bold;
+    font-style: italic;
+    background-color: #9DBF9D;
+}
 div#nav ul li.CurrentSection a {
     position: relative;
     top: 1px;

--- a/data/css/Web_Basic-Cypress.css
+++ b/data/css/Web_Basic-Cypress.css
@@ -200,7 +200,7 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #9DBF9D;
     border-bottom: solid 1px black;
 }
-div#ltr.nav ul.ltr li.CurrentSection, div#rtl.nav ul.rtl li.CurrentSection,
+div#ltr.pnav ul.ltr li.CurrentSection, div#rtl.pnav ul.rtl li.CurrentSection,
 div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
     font-weight: bold;
     font-style: italic;

--- a/data/css/Web_Basic-Lilac.css
+++ b/data/css/Web_Basic-Lilac.css
@@ -195,7 +195,7 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #B4B4CB;
     border-bottom: solid 1px black;
 }
-div#ltr.nav ul.ltr li.CurrentSection, div#rtl.nav ul.rtl li.CurrentSection,
+div#ltr.pnav ul.ltr li.CurrentSection, div#rtl.pnav ul.rtl li.CurrentSection,
 div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
     font-weight: bold;
     font-style: italic;

--- a/data/css/Web_Basic-Lilac.css
+++ b/data/css/Web_Basic-Lilac.css
@@ -195,6 +195,12 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #B4B4CB;
     border-bottom: solid 1px black;
 }
+div#ltr.nav ul.ltr li.CurrentSection, div#rtl.nav ul.rtl li.CurrentSection,
+div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
+    font-weight: bold;
+    font-style: italic;
+    background-color: #B4B4CB;
+}
 div#nav ul li.CurrentSection a {
     position: relative;
     top: 1px;

--- a/data/css/Web_Basic-Peach.css
+++ b/data/css/Web_Basic-Peach.css
@@ -195,7 +195,7 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #FFC35E;
     border-bottom: solid 1px #36220B;
 }
-div#ltr.nav ul.ltr li.CurrentSection, div#rtl.nav ul.rtl li.CurrentSection,
+div#ltr.pnav ul.ltr li.CurrentSection, div#rtl.pnav ul.rtl li.CurrentSection,
 div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
     font-weight: bold;
     font-style: italic;

--- a/data/css/Web_Basic-Peach.css
+++ b/data/css/Web_Basic-Peach.css
@@ -195,6 +195,12 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #FFC35E;
     border-bottom: solid 1px #36220B;
 }
+div#ltr.nav ul.ltr li.CurrentSection, div#rtl.nav ul.rtl li.CurrentSection,
+div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
+    font-weight: bold;
+    font-style: italic;
+    background-color: #FFC35E;
+}
 div#nav ul li.CurrentSection a {
     position: relative;
     top: 1px;

--- a/data/css/Web_Basic-Spruce.css
+++ b/data/css/Web_Basic-Spruce.css
@@ -196,7 +196,7 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #BFD0EA;
     border-bottom: solid 1px black;
 }
-div#ltr.nav ul.ltr li.CurrentSection, div#rtl.nav ul.rtl li.CurrentSection,
+div#ltr.pnav ul.ltr li.CurrentSection, div#rtl.pnav ul.rtl li.CurrentSection,
 div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
     font-weight: bold;
     font-style: italic;

--- a/data/css/Web_Basic-Spruce.css
+++ b/data/css/Web_Basic-Spruce.css
@@ -196,6 +196,12 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #BFD0EA;
     border-bottom: solid 1px black;
 }
+div#ltr.nav ul.ltr li.CurrentSection, div#rtl.nav ul.rtl li.CurrentSection,
+div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
+    font-weight: bold;
+    font-style: italic;
+    background-color: #BFD0EA;
+}
 div#nav ul li.CurrentSection a {
     position: relative;
     top: 1px;

--- a/data/css/Web_Mainz.css
+++ b/data/css/Web_Mainz.css
@@ -193,6 +193,12 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     text-decoration: none;
     background-color: #FFFFE7;
 }
+div#ltr.nav ul.ltr li.CurrentSection, div#rtl.nav ul.rtl li.CurrentSection,
+div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
+    font-weight: bold;
+    font-style: italic;
+    border-color: #7D5925;
+}
 div#nav ul li.CurrentSection a, #subnavigation ul li.CurrentSection a {
     font-weight: bold;
     font-style: italic;

--- a/data/css/Web_Mainz.css
+++ b/data/css/Web_Mainz.css
@@ -193,7 +193,7 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     text-decoration: none;
     background-color: #FFFFE7;
 }
-div#ltr.nav ul.ltr li.CurrentSection, div#rtl.nav ul.rtl li.CurrentSection,
+div#ltr.pnav ul.ltr li.CurrentSection, div#rtl.pnav ul.rtl li.CurrentSection,
 div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
     font-weight: bold;
     font-style: italic;
@@ -212,6 +212,7 @@ div#nav ul li.CurrentSection a, #subnavigation ul li.CurrentSection a {
 }
 div#nav li.lang {
     font-size: smaller;
+    font-weight: bold;
     padding-top: 2px;
     padding-bottom: 1px;
 }

--- a/data/css/Web_Nebraska.css
+++ b/data/css/Web_Nebraska.css
@@ -287,6 +287,12 @@ div#alphanav ul li a:hover, div#nav ul li a:hover, div#subnavigation ul li a:hov
     background-color: #000;
     color: #FFF;
 }
+div#ltr.nav ul.ltr li.CurrentSection, div#rtl.nav ul.rtl li.CurrentSection,
+div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
+    font-weight: bold;
+    font-style: italic;
+    background-color: #F2F6EE;
+}
 div#nav ul li.CurrentSection a, div#subnavigation ul li.CurrentSection a {
     padding: 4px 2px 3px 2px;
     border-right: solid 1px #542;

--- a/data/css/Web_Nebraska.css
+++ b/data/css/Web_Nebraska.css
@@ -287,7 +287,7 @@ div#alphanav ul li a:hover, div#nav ul li a:hover, div#subnavigation ul li a:hov
     background-color: #000;
     color: #FFF;
 }
-div#ltr.nav ul.ltr li.CurrentSection, div#rtl.nav ul.rtl li.CurrentSection,
+div#ltr.pnav ul.ltr li.CurrentSection, div#rtl.pnav ul.rtl li.CurrentSection,
 div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
     font-weight: bold;
     font-style: italic;
@@ -310,6 +310,7 @@ div#nav li.lang {
     position: relative;
     padding-top: 3px;
     padding-left: 8px;
+    font-size: smaller;
     font: bold .7em sans;
 }
 div#nav li.lang:hover > ul {

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,6 @@
+{% extends '!layout.html' %}
+
+{% block footer %}
+        <!-- https://gramps.discourse.group/t/how-can-useful-snippets-be-proposed-for-the-sphinx-developer-docs/5740/4 : add to "&#169; Copyright 2001-2019, The Gramps Project. Created using <a href="http://sphinx-doc.org/">Sphinx</a> 2.0.1." -->
+        &bull; <a href="https://www.gramps-project.org/wiki/index.php/Category:Developers/Reference">Become a Contributor.</a>
+{% endblock %}

--- a/gramps/gen/datehandler/_datedisplay.py
+++ b/gramps/gen/datehandler/_datedisplay.py
@@ -82,11 +82,11 @@ class DateDisplay:
         # Translators: Full month name, day, year
         _T_("Month Day, Year"),
         # Translators: Abbreviated month name, day, year
-        _T_("MON DAY, YEAR"),
+        _T_("Mon Day, Year"),
         # Translators: Day, full month name, year
         _T_("Day Month Year"),
         # Translators: Day, abbreviated month name, year
-        _T_("DAY MON YEAR"),
+        _T_("Day Mon Year"),
     )
     """
     .. note:: Will be overridden if a locale-specific date displayer exists.

--- a/gramps/gen/db/conversion_tools/__init__.py
+++ b/gramps/gen/db/conversion_tools/__init__.py
@@ -1,0 +1,21 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2024 Doug Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+from .conversion_21 import convert_21

--- a/gramps/gen/db/conversion_tools/conversion_21.py
+++ b/gramps/gen/db/conversion_tools/conversion_21.py
@@ -1,0 +1,493 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2024 Doug Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+
+def convert_21(classname, array):
+    if classname == "Person":
+        return convert_person(array)
+    elif classname == "Family":
+        return convert_family(array)
+    elif classname == "Event":
+        return convert_event(array)
+    elif classname == "Place":
+        return convert_place(array)
+    elif classname == "Repository":
+        return convert_repository(array)
+    elif classname == "Source":
+        return convert_source(array)
+    elif classname == "Citation":
+        return convert_citation(array)
+    elif classname == "Media":
+        return convert_media(array)
+    elif classname == "Note":
+        return convert_note(array)
+    elif classname == "Tag":
+        return convert_tag(array)
+    else:
+        raise Exception("unknown class: %s" % classname)
+
+
+def convert_researcher(researcher):
+    # This can be a problem if the Researcher class
+    # changes!
+    return {
+        "_class": "Researcher",
+        "street": researcher.street,
+        "city": researcher.city,
+        "county": researcher.county,
+        "state": researcher.state,
+        "country": researcher.country,
+        "postal": researcher.postal,
+        "phone": researcher.phone,
+        "locality": researcher.locality,
+        "name": researcher.name,
+        "addr": researcher.addr,
+        "email": researcher.email,
+    }
+
+
+def convert_person(array):
+    return {
+        "_class": "Person",
+        "handle": array[0],
+        "gramps_id": array[1],
+        "gender": array[2],
+        "primary_name": convert_name(array[3]),
+        "alternate_names": [convert_name(name) for name in array[4]],
+        "death_ref_index": array[5],
+        "birth_ref_index": array[6],
+        "event_ref_list": [convert_event_ref(ref) for ref in array[7]],
+        "family_list": array[8],
+        "parent_family_list": array[9],
+        "media_list": [convert_media_ref(ref) for ref in array[10]],
+        "address_list": [convert_address(address) for address in array[11]],
+        "attribute_list": [convert_attribute("Attribute", attr) for attr in array[12]],
+        "urls": [convert_url(url) for url in array[13]],
+        "lds_ord_list": [convert_ord(ord) for ord in array[14]],
+        "citation_list": array[15],  # handles
+        "note_list": array[16],  # handles
+        "change": array[17],
+        "tag_list": array[18],  # handles
+        "private": array[19],
+        "person_ref_list": [convert_person_ref(ref) for ref in array[20]],
+    }
+
+
+def convert_person_ref(array):
+    return {
+        "_class": "PersonRef",
+        "private": array[0],
+        "citation_list": array[1],  # handles
+        "note_list": array[2],  # handles
+        "ref": array[3],
+        "rel": array[4],
+    }
+
+
+def convert_ord(array):
+    return {
+        "_class": "LdsOrd",
+        "citation_list": array[0],  # handles
+        "note_list": array[1],  # handles
+        "date": convert_date(array[2]),
+        "type": array[3],  # string
+        "place": array[4],
+        "famc": array[5],
+        "temple": array[6],
+        "status": array[7],
+        "private": array[8],
+    }
+
+
+def convert_url(array):
+    return {
+        "_class": "Url",
+        "private": array[0],
+        "path": array[1],
+        "desc": array[2],
+        "type": convert_type("UrlType", array[3]),
+    }
+
+
+def convert_address(array):
+    return {
+        "_class": "Address",
+        "private": array[0],
+        "citation_list": array[1],  # handles
+        "note_list": array[2],  # handles
+        "date": convert_date(array[3]),
+        "street": array[4][0],
+        "locality": array[4][1],
+        "city": array[4][2],
+        "county": array[4][3],
+        "state": array[4][4],
+        "country": array[4][5],
+        "postal": array[4][6],
+        "phone": array[4][7],
+    }
+
+
+def convert_media_ref(array):
+    return {
+        "_class": "MediaRef",
+        "private": array[0],
+        "citation_list": array[1],  # handles
+        "note_list": array[2],  # handles
+        "attribute_list": [convert_attribute("Attribute", attr) for attr in array[3]],
+        "ref": array[4],
+        "rect": list(array[5]) if array[5] is not None else None,
+    }
+
+
+def convert_event_ref(array):
+    return {
+        "_class": "EventRef",
+        "private": array[0],
+        "citation_list": array[1],  # handles
+        "note_list": array[2],  # handles
+        "attribute_list": [convert_attribute("Attribute", attr) for attr in array[3]],
+        "ref": array[4],
+        "role": convert_type("EventRoleType", array[5]),
+    }
+
+
+def convert_attribute(classname, array):
+    if classname == "SrcAttribute":
+        return {
+            "_class": classname,
+            "private": array[0],
+            "type": convert_type("SrcAttributeType", array[1]),
+            "value": array[2],
+        }
+    else:
+        return {
+            "_class": classname,
+            "private": array[0],
+            "citation_list": array[1],  # handles
+            "note_list": array[2],  # handles
+            "type": convert_type("AttributeType", array[3]),
+            "value": array[4],
+        }
+
+
+def convert_name(array):
+    return {
+        "_class": "Name",
+        "private": array[0],
+        "citation_list": array[1],
+        "note_list": array[2],  # handles
+        "date": convert_date(array[3]),
+        "first_name": array[4],
+        "surname_list": [convert_surname(name) for name in array[5]],
+        "suffix": array[6],
+        "title": array[7],
+        "type": convert_type("NameType", array[8]),
+        "group_as": array[9],
+        "sort_as": array[10],
+        "display_as": array[11],
+        "call": array[12],
+        "nick": array[13],
+        "famnick": array[14],
+    }
+
+
+def convert_surname(array):
+    return {
+        "_class": "Surname",
+        "surname": array[0],
+        "prefix": array[1],
+        "primary": array[2],
+        "origintype": convert_type("NameOriginType", array[3]),
+        "connector": array[4],
+    }
+
+
+def convert_date(array):
+    if array is None:
+        return {
+            "_class": "Date",
+            "calendar": 0,
+            "modifier": 0,
+            "quality": 0,
+            "dateval": [0, 0, 0, False],
+            "text": "",
+            "sortval": 0,
+            "newyear": 0,
+            "format": None,
+        }
+    else:
+        return {
+            "_class": "Date",
+            "calendar": array[0],
+            "modifier": array[1],
+            "quality": array[2],
+            "dateval": list(array[3]),
+            "text": array[4],
+            "sortval": array[5],
+            "newyear": array[6],
+            "format": None,
+        }
+
+
+def convert_stt(array):
+    return {
+        "_class": "StyledTextTag",
+        "name": convert_type("StyledTextTagType", array[0]),
+        "value": array[1],
+        "ranges": [list(r) for r in array[2]],
+    }
+
+
+def convert_type(classname, array):
+    return {
+        "_class": classname,
+        "value": array[0],
+        "string": array[1],
+    }
+
+
+def convert_family(array):
+    return {
+        "_class": "Family",
+        "handle": array[0],
+        "gramps_id": array[1],
+        "father_handle": array[2],
+        "mother_handle": array[3],
+        "child_ref_list": [convert_child_ref(ref) for ref in array[4]],
+        "type": convert_type("FamilyRelType", array[5]),
+        "event_ref_list": [convert_event_ref(ref) for ref in array[6]],
+        "media_list": [convert_media_ref(ref) for ref in array[7]],
+        "attribute_list": [convert_attribute("Attribute", attr) for attr in array[8]],
+        "lds_ord_list": [convert_ord(ord) for ord in array[9]],
+        "citation_list": array[10],  # handles
+        "note_list": array[11],  # handles
+        "change": array[12],
+        "tag_list": array[13],
+        "private": array[14],
+        "complete": 0,
+    }
+
+
+def convert_child_ref(array):
+    return {
+        "_class": "ChildRef",
+        "private": array[0],
+        "citation_list": array[1],
+        "note_list": array[2],
+        "ref": array[3],
+        "frel": convert_type("ChildRefType", array[4]),
+        "mrel": convert_type("ChildRefType", array[5]),
+    }
+
+
+def convert_event(array):
+    return {
+        "_class": "Event",
+        "handle": array[0],
+        "gramps_id": array[1],
+        "type": convert_type("EventType", array[2]),
+        "date": convert_date(array[3]),
+        "description": array[4],
+        "place": array[5],
+        "citation_list": array[6],
+        "note_list": array[7],
+        "media_list": [convert_media_ref(ref) for ref in array[8]],
+        "attribute_list": [convert_attribute("Attribute", attr) for attr in array[9]],
+        "change": array[10],
+        "tag_list": array[11],
+        "private": array[12],
+    }
+
+
+def convert_place(array):
+    return {
+        "_class": "Place",
+        "handle": array[0],
+        "gramps_id": array[1],
+        "title": array[2],
+        "long": array[3],
+        "lat": array[4],
+        "placeref_list": [convert_place_ref(ref) for ref in array[5]],
+        "name": convert_place_name(array[6]),
+        "alt_names": [convert_place_name(name) for name in array[7]],
+        "place_type": convert_type("PlaceType", array[8]),
+        "code": array[9],
+        "alt_loc": [convert_location(loc) for loc in array[10]],
+        "urls": [convert_url(url) for url in array[11]],
+        "media_list": [convert_media_ref(ref) for ref in array[12]],
+        "citation_list": array[13],
+        "note_list": array[14],
+        "change": array[15],
+        "tag_list": array[16],
+        "private": array[17],
+    }
+
+
+def convert_location(array):
+    return {
+        "_class": "Location",
+        "street": array[0][0],
+        "locality": array[0][1],
+        "city": array[0][2],
+        "county": array[0][3],
+        "state": array[0][4],
+        "country": array[0][5],
+        "postal": array[0][6],
+        "phone": array[0][7],
+        "parish": array[1],
+    }
+
+
+def convert_place_ref(array):
+    return {
+        "_class": "PlaceRef",
+        "ref": array[0],
+        "date": convert_date(array[1]),
+    }
+
+
+def convert_place_name(array):
+    return {
+        "_class": "PlaceName",
+        "value": array[0],
+        "date": convert_date(array[1]),
+        "lang": array[2],
+    }
+
+
+def convert_repository(array):
+    return {
+        "_class": "Repository",
+        "handle": array[0],
+        "gramps_id": array[1],
+        "type": convert_type("RepositoryType", array[2]),
+        "name": array[3],
+        "note_list": array[4],
+        "address_list": [convert_address(addr) for addr in array[5]],
+        "urls": [convert_url(url) for url in array[6]],
+        "change": array[7],
+        "tag_list": array[8],
+        "private": array[9],
+    }
+
+
+def convert_source(array):
+    return {
+        "_class": "Source",
+        "handle": array[0],
+        "gramps_id": array[1],
+        "title": array[2],
+        "author": array[3],
+        "pubinfo": array[4],
+        "note_list": array[5],
+        "media_list": [convert_media_ref(ref) for ref in array[6]],
+        "abbrev": array[7],
+        "change": array[8],
+        "attribute_list": [
+            convert_attribute("SrcAttribute", attr) for attr in array[9]
+        ],
+        "reporef_list": [convert_repo_ref(ref) for ref in array[10]],
+        "tag_list": array[11],
+        "private": array[12],
+    }
+
+
+def convert_repo_ref(array):
+    return {
+        "_class": "RepoRef",
+        "note_list": array[0],
+        "ref": array[1],
+        "call_number": array[2],
+        "media_type": convert_type("SourceMediaType", array[3]),
+        "private": array[4],
+    }
+
+
+def convert_citation(array):
+    return {
+        "_class": "Citation",
+        "handle": array[0],
+        "gramps_id": array[1],
+        "date": convert_date(array[2]),
+        "page": array[3],
+        "confidence": array[4],
+        "source_handle": array[5],
+        "note_list": array[6],
+        "media_list": [convert_media_ref(ref) for ref in array[7]],
+        "attribute_list": [
+            convert_attribute("SrcAttribute", attr) for attr in array[8]
+        ],
+        "change": array[9],
+        "tag_list": array[10],
+        "private": array[11],
+    }
+
+
+def convert_media(array):
+    return {
+        "_class": "Media",
+        "handle": array[0],
+        "gramps_id": array[1],
+        "path": array[2],
+        "mime": array[3],
+        "desc": array[4],
+        "checksum": array[5],
+        "attribute_list": [convert_attribute("Attribute", attr) for attr in array[6]],
+        "citation_list": array[7],
+        "note_list": array[8],
+        "change": array[9],
+        "date": convert_date(array[10]),
+        "tag_list": array[11],
+        "private": array[12],
+        "thumb": None,
+    }
+
+
+def convert_note(array):
+    return {
+        "_class": "Note",
+        "handle": array[0],
+        "gramps_id": array[1],
+        "text": convert_styledtext(array[2]),
+        "format": array[3],
+        "type": convert_type("NoteType", array[4]),
+        "change": array[5],
+        "tag_list": array[6],
+        "private": array[7],
+    }
+
+
+def convert_styledtext(array):
+    return {
+        "_class": "StyledText",
+        "string": array[0],
+        "tags": [convert_stt(stt) for stt in array[1]],
+    }
+
+
+def convert_tag(array):
+    return {
+        "_class": "Tag",
+        "handle": array[0],
+        "name": array[1],
+        "color": array[2],
+        "priority": array[3],
+        "change": array[4],
+    }

--- a/gramps/gen/display/name.py
+++ b/gramps/gen/display/name.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2004-2007  Donald N. Allingham
 # Copyright (C) 2010       Brian G. Matherly
 # Copyright (C) 2014       Paul Franklin
+# Copyright (C) 2024       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -72,6 +73,7 @@ from ..const import ARABIC_COMMA, ARABIC_SEMICOLON, GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
 from ..lib.name import Name
 from ..lib.nameorigintype import NameOriginType
+from ..lib.serialize import to_dict
 
 try:
     from ..config import config
@@ -86,25 +88,8 @@ except ImportError:
 # Constants
 #
 # -------------------------------------------------------------------------
-_FIRSTNAME = 4
-_SURNAME_LIST = 5
-_SUFFIX = 6
-_TITLE = 7
-_TYPE = 8
-_GROUP = 9
-_SORT = 10
-_DISPLAY = 11
-_CALL = 12
-_NICK = 13
-_FAMNICK = 14
-_SURNAME_IN_LIST = 0
-_PREFIX_IN_LIST = 1
-_PRIMARY_IN_LIST = 2
-_TYPE_IN_LIST = 3
-_CONNECTOR_IN_LIST = 4
 _ORIGINPATRO = NameOriginType.PATRONYMIC
 _ORIGINMATRO = NameOriginType.MATRONYMIC
-
 _ACT = True
 _INA = False
 
@@ -170,7 +155,7 @@ def _raw_primary_surname(raw_surn_data_list):
     global PAT_AS_SURN
     nrsur = len(raw_surn_data_list)
     for raw_surn_data in raw_surn_data_list:
-        if raw_surn_data[_PRIMARY_IN_LIST]:
+        if raw_surn_data["primary"]:
             # if there are multiple surnames, return the primary. If there
             # is only one surname, then primary has little meaning, and we
             # assume a pa/matronymic should not be given as primary as it
@@ -179,8 +164,8 @@ def _raw_primary_surname(raw_surn_data_list):
                 not PAT_AS_SURN
                 and nrsur == 1
                 and (
-                    raw_surn_data[_TYPE_IN_LIST][0] == _ORIGINPATRO
-                    or raw_surn_data[_TYPE_IN_LIST][0] == _ORIGINMATRO
+                    raw_surn_data["origintype"]["string"] == _ORIGINPATRO
+                    or raw_surn_data["origintype"]["string"] == _ORIGINMATRO
                 )
             ):
                 return ""
@@ -194,18 +179,18 @@ def _raw_primary_surname_only(raw_surn_data_list):
     global PAT_AS_SURN
     nrsur = len(raw_surn_data_list)
     for raw_surn_data in raw_surn_data_list:
-        if raw_surn_data[_PRIMARY_IN_LIST]:
+        if raw_surn_data["primary"]:
             if (
                 not PAT_AS_SURN
                 and nrsur == 1
                 and (
-                    raw_surn_data[_TYPE_IN_LIST][0] == _ORIGINPATRO
-                    or raw_surn_data[_TYPE_IN_LIST][0] == _ORIGINMATRO
+                    raw_surn_data["origintype"]["string"] == _ORIGINPATRO
+                    or raw_surn_data["origintype"]["string"] == _ORIGINMATRO
                 )
             ):
                 return ""
             else:
-                return raw_surn_data[_SURNAME_IN_LIST]
+                return raw_surn_data["surname"]
     return ""
 
 
@@ -214,18 +199,18 @@ def _raw_primary_prefix_only(raw_surn_data_list):
     global PAT_AS_SURN
     nrsur = len(raw_surn_data_list)
     for raw_surn_data in raw_surn_data_list:
-        if raw_surn_data[_PRIMARY_IN_LIST]:
+        if raw_surn_data["primary"]:
             if (
                 not PAT_AS_SURN
                 and nrsur == 1
                 and (
-                    raw_surn_data[_TYPE_IN_LIST][0] == _ORIGINPATRO
-                    or raw_surn_data[_TYPE_IN_LIST][0] == _ORIGINMATRO
+                    raw_surn_data["origintype"]["string"] == _ORIGINPATRO
+                    or raw_surn_data["origintype"]["string"] == _ORIGINMATRO
                 )
             ):
                 return ""
             else:
-                return raw_surn_data[_PREFIX_IN_LIST]
+                return raw_surn_data["prefix"]
     return ""
 
 
@@ -234,18 +219,18 @@ def _raw_primary_conn_only(raw_surn_data_list):
     global PAT_AS_SURN
     nrsur = len(raw_surn_data_list)
     for raw_surn_data in raw_surn_data_list:
-        if raw_surn_data[_PRIMARY_IN_LIST]:
+        if raw_surn_data["primary"]:
             if (
                 not PAT_AS_SURN
                 and nrsur == 1
                 and (
-                    raw_surn_data[_TYPE_IN_LIST][0] == _ORIGINPATRO
-                    or raw_surn_data[_TYPE_IN_LIST][0] == _ORIGINMATRO
+                    raw_surn_data["origintype"]["string"] == _ORIGINPATRO
+                    or raw_surn_data["origintype"]["string"] == _ORIGINMATRO
                 )
             ):
                 return ""
             else:
-                return raw_surn_data[_CONNECTOR_IN_LIST]
+                return raw_surn_data["connector"]
     return ""
 
 
@@ -253,8 +238,8 @@ def _raw_patro_surname(raw_surn_data_list):
     """method for the 'y' symbol: patronymic surname"""
     for raw_surn_data in raw_surn_data_list:
         if (
-            raw_surn_data[_TYPE_IN_LIST][0] == _ORIGINPATRO
-            or raw_surn_data[_TYPE_IN_LIST][0] == _ORIGINMATRO
+            raw_surn_data["origintype"]["string"] == _ORIGINPATRO
+            or raw_surn_data["origintype"]["string"] == _ORIGINMATRO
         ):
             return __format_raw_surname(raw_surn_data).strip()
     return ""
@@ -264,10 +249,10 @@ def _raw_patro_surname_only(raw_surn_data_list):
     """method for the '1y' symbol: patronymic surname only"""
     for raw_surn_data in raw_surn_data_list:
         if (
-            raw_surn_data[_TYPE_IN_LIST][0] == _ORIGINPATRO
-            or raw_surn_data[_TYPE_IN_LIST][0] == _ORIGINMATRO
+            raw_surn_data["origintype"]["string"] == _ORIGINPATRO
+            or raw_surn_data["origintype"]["string"] == _ORIGINMATRO
         ):
-            result = "%s" % (raw_surn_data[_SURNAME_IN_LIST])
+            result = "%s" % (raw_surn_data["surname"])
             return " ".join(result.split())
     return ""
 
@@ -276,10 +261,10 @@ def _raw_patro_prefix_only(raw_surn_data_list):
     """method for the '0y' symbol: patronymic prefix only"""
     for raw_surn_data in raw_surn_data_list:
         if (
-            raw_surn_data[_TYPE_IN_LIST][0] == _ORIGINPATRO
-            or raw_surn_data[_TYPE_IN_LIST][0] == _ORIGINMATRO
+            raw_surn_data["origintype"]["string"] == _ORIGINPATRO
+            or raw_surn_data["origintype"]["string"] == _ORIGINMATRO
         ):
-            result = "%s" % (raw_surn_data[_PREFIX_IN_LIST])
+            result = "%s" % (raw_surn_data["prefix"])
             return " ".join(result.split())
     return ""
 
@@ -288,10 +273,10 @@ def _raw_patro_conn_only(raw_surn_data_list):
     """method for the '2y' symbol: patronymic conn only"""
     for raw_surn_data in raw_surn_data_list:
         if (
-            raw_surn_data[_TYPE_IN_LIST][0] == _ORIGINPATRO
-            or raw_surn_data[_TYPE_IN_LIST][0] == _ORIGINMATRO
+            raw_surn_data["origintype"]["string"] == _ORIGINPATRO
+            or raw_surn_data["origintype"]["string"] == _ORIGINMATRO
         ):
-            result = "%s" % (raw_surn_data[_CONNECTOR_IN_LIST])
+            result = "%s" % (raw_surn_data["connector"])
             return " ".join(result.split())
     return ""
 
@@ -303,9 +288,9 @@ def _raw_nonpatro_surname(raw_surn_data_list):
     result = ""
     for raw_surn_data in raw_surn_data_list:
         if (
-            (not raw_surn_data[_PRIMARY_IN_LIST])
-            and raw_surn_data[_TYPE_IN_LIST][0] != _ORIGINPATRO
-            and raw_surn_data[_TYPE_IN_LIST][0] != _ORIGINMATRO
+            (not raw_surn_data["primary"])
+            and raw_surn_data["origintype"]["string"] != _ORIGINPATRO
+            and raw_surn_data["origintype"]["string"] != _ORIGINMATRO
         ):
             result += __format_raw_surname(raw_surn_data)
     return result.strip()
@@ -315,7 +300,7 @@ def _raw_nonprimary_surname(raw_surn_data_list):
     """method for the 'r' symbol: nonprimary surnames"""
     result = ""
     for raw_surn_data in raw_surn_data_list:
-        if not raw_surn_data[_PRIMARY_IN_LIST]:
+        if not raw_surn_data["primary"]:
             result += __format_raw_surname(raw_surn_data)
     return result.strip()
 
@@ -324,7 +309,7 @@ def _raw_prefix_surname(raw_surn_data_list):
     """method for the 'p' symbol: all prefixes"""
     result = ""
     for raw_surn_data in raw_surn_data_list:
-        result += "%s " % (raw_surn_data[_PREFIX_IN_LIST])
+        result += "%s " % (raw_surn_data["prefix"])
     return " ".join(result.split()).strip()
 
 
@@ -332,7 +317,7 @@ def _raw_single_surname(raw_surn_data_list):
     """method for the 'q' symbol: surnames without prefix and connectors"""
     result = ""
     for raw_surn_data in raw_surn_data_list:
-        result += "%s " % (raw_surn_data[_SURNAME_IN_LIST])
+        result += "%s " % (raw_surn_data["surname"])
     return " ".join(result.split()).strip()
 
 
@@ -359,14 +344,14 @@ def __format_raw_surname(raw_surn_data):
 
     If the connector is a hyphen, don't pad it with spaces.
     """
-    result = raw_surn_data[_PREFIX_IN_LIST]
+    result = raw_surn_data["prefix"]
     if result:
         result += " "
-    result += raw_surn_data[_SURNAME_IN_LIST]
-    if result and raw_surn_data[_CONNECTOR_IN_LIST] != "-":
-        result += " %s " % raw_surn_data[_CONNECTOR_IN_LIST]
+    result += raw_surn_data["surname"]
+    if result and raw_surn_data["connector"] != "-":
+        result += " %s " % raw_surn_data["connector"]
     else:
-        result += raw_surn_data[_CONNECTOR_IN_LIST]
+        result += raw_surn_data["connector"]
     return result
 
 
@@ -460,22 +445,22 @@ class NameDisplay:
 
     def _raw_lnfn(self, raw_data):
         result = self.LNFN_STR % (
-            _raw_full_surname(raw_data[_SURNAME_LIST]),
-            raw_data[_FIRSTNAME],
-            raw_data[_SUFFIX],
+            _raw_full_surname(raw_data["surname_list"]),
+            raw_data["first_name"],
+            raw_data["suffix"],
         )
         return " ".join(result.split())
 
     def _raw_fnln(self, raw_data):
         result = "%s %s %s" % (
-            raw_data[_FIRSTNAME],
-            _raw_full_surname(raw_data[_SURNAME_LIST]),
-            raw_data[_SUFFIX],
+            raw_data["first_name"],
+            _raw_full_surname(raw_data["surname_list"]),
+            raw_data["suffix"],
         )
         return " ".join(result.split())
 
     def _raw_fn(self, raw_data):
-        result = raw_data[_FIRSTNAME]
+        result = raw_data["first_name"]
         return " ".join(result.split())
 
     def clear_custom_formats(self):
@@ -616,9 +601,9 @@ class NameDisplay:
         The new function is of the form::
 
         def fn(raw_data):
-            return "%s %s %s" % (raw_data[_TITLE],
-                   raw_data[_FIRSTNAME],
-                   raw_data[_SUFFIX])
+            return "%s %s %s" % (raw_data["title"],
+                   raw_data["first_name"],
+                   raw_data["suffix"])
 
         Specific symbols for parts of a name are defined (keywords given):
         't' : title = title
@@ -650,88 +635,88 @@ class NameDisplay:
         # called to fill in each format flag.
         # Dictionary is "code": ("expression", "keyword", "i18n-keyword")
         d = {
-            "t": ("raw_data[_TITLE]", "title", _("title", "Person")),
-            "f": ("raw_data[_FIRSTNAME]", "given", _("given")),
+            "t": ("raw_data['title']", "title", _("title", "Person")),
+            "f": ("raw_data['first_name']", "given", _("given")),
             "l": (
-                "_raw_full_surname(raw_data[_SURNAME_LIST])",
+                "_raw_full_surname(raw_data['surname_list'])",
                 "surname",
                 _("surname"),
             ),
-            "s": ("raw_data[_SUFFIX]", "suffix", _("suffix")),
-            "c": ("raw_data[_CALL]", "call", _("call", "Name")),
+            "s": ("raw_data['suffix']", "suffix", _("suffix")),
+            "c": ("raw_data['call']", "call", _("call", "Name")),
             "x": (
-                "(raw_data[_NICK] or raw_data[_CALL] or raw_data[_FIRSTNAME].split(' ')[0])",
+                "(raw_data['nick'] or raw_data['call'] or raw_data['first_name'].split(' ')[0])",
                 "common",
                 _("common", "Name"),
             ),
             "i": (
                 "''.join([word[0] +'.' for word in ('. ' +"
-                + " raw_data[_FIRSTNAME]).split()][1:])",
+                + " raw_data['first_name']).split()][1:])",
                 "initials",
                 _("initials"),
             ),
             "m": (
-                "_raw_primary_surname(raw_data[_SURNAME_LIST])",
+                "_raw_primary_surname(raw_data['surname_list'])",
                 "primary",
                 _("primary", "Name"),
             ),
             "0m": (
-                "_raw_primary_prefix_only(raw_data[_SURNAME_LIST])",
+                "_raw_primary_prefix_only(raw_data['surname_list'])",
                 "primary[pre]",
                 _("primary[pre]"),
             ),
             "1m": (
-                "_raw_primary_surname_only(raw_data[_SURNAME_LIST])",
+                "_raw_primary_surname_only(raw_data['surname_list'])",
                 "primary[sur]",
                 _("primary[sur]"),
             ),
             "2m": (
-                "_raw_primary_conn_only(raw_data[_SURNAME_LIST])",
+                "_raw_primary_conn_only(raw_data['surname_list'])",
                 "primary[con]",
                 _("primary[con]"),
             ),
             "y": (
-                "_raw_patro_surname(raw_data[_SURNAME_LIST])",
+                "_raw_patro_surname(raw_data['surname_list'])",
                 "patronymic",
                 _("patronymic"),
             ),
             "0y": (
-                "_raw_patro_prefix_only(raw_data[_SURNAME_LIST])",
+                "_raw_patro_prefix_only(raw_data['surname_list'])",
                 "patronymic[pre]",
                 _("patronymic[pre]"),
             ),
             "1y": (
-                "_raw_patro_surname_only(raw_data[_SURNAME_LIST])",
+                "_raw_patro_surname_only(raw_data['surname_list'])",
                 "patronymic[sur]",
                 _("patronymic[sur]"),
             ),
             "2y": (
-                "_raw_patro_conn_only(raw_data[_SURNAME_LIST])",
+                "_raw_patro_conn_only(raw_data['surname_list'])",
                 "patronymic[con]",
                 _("patronymic[con]"),
             ),
             "o": (
-                "_raw_nonpatro_surname(raw_data[_SURNAME_LIST])",
+                "_raw_nonpatro_surname(raw_data['surname_list'])",
                 "notpatronymic",
                 _("notpatronymic"),
             ),
             "r": (
-                "_raw_nonprimary_surname(raw_data[_SURNAME_LIST])",
+                "_raw_nonprimary_surname(raw_data['surname_list'])",
                 "rest",
                 _("rest", "Remaining names"),
             ),
             "p": (
-                "_raw_prefix_surname(raw_data[_SURNAME_LIST])",
+                "_raw_prefix_surname(raw_data['surname_list'])",
                 "prefix",
                 _("prefix"),
             ),
             "q": (
-                "_raw_single_surname(raw_data[_SURNAME_LIST])",
+                "_raw_single_surname(raw_data['surname_list'])",
                 "rawsurnames",
                 _("rawsurnames"),
             ),
-            "n": ("raw_data[_NICK]", "nickname", _("nickname")),
-            "g": ("raw_data[_FAMNICK]", "familynick", _("familynick")),
+            "n": ("raw_data['nick']", "nickname", _("nickname")),
+            "g": ("raw_data['famnick']", "familynick", _("familynick")),
         }
         args = "raw_data"
         return self._make_fn(format_str, d, args)
@@ -925,7 +910,7 @@ class NameDisplay:
         try:
             s = func(
                 first,
-                [surn.serialize() for surn in surname_list],
+                [to_dict(surn) for surn in surname_list],
                 suffix,
                 title,
                 call,
@@ -1016,7 +1001,7 @@ class NameDisplay:
         :returns: Returns the :class:`~.name.Name` string representation
         :rtype: str
         """
-        num = self._is_format_valid(raw_data[_SORT])
+        num = self._is_format_valid(raw_data["sort_as"])
         return self.name_formats[num][_F_RAWFN](raw_data)
 
     def display(self, person):
@@ -1096,7 +1081,7 @@ class NameDisplay:
         :returns: Returns the :class:`~.name.Name` string representation
         :rtype: str
         """
-        num = self._is_format_valid(raw_data[_DISPLAY])
+        num = self._is_format_valid(raw_data["display_as"])
         return self.name_formats[num][_F_RAWFN](raw_data)
 
     def display_given(self, person):
@@ -1145,18 +1130,18 @@ class NameDisplay:
         :returns: Returns the groupname string representation
         :rtype: str
         """
-        if pn[_GROUP]:
-            return pn[_GROUP]
-        name = pn[_GROUP]
+        if pn["group_as"]:
+            return pn["group_as"]
+        name = pn["group_as"]
         if not name:
             # if we have no primary surname, perhaps we have a
             # patronymic/matronynic name ?
-            srnme = pn[_ORIGINPATRO]
+            srnme = pn["surname_list"]
             surname = []
             for _surname in srnme:
                 if (
-                    _surname[_TYPE_IN_LIST][0] == _ORIGINPATRO
-                    or _surname[_TYPE_IN_LIST][0] == _ORIGINMATRO
+                    _surname["origintype"]["string"] == _ORIGINPATRO
+                    or _surname["origintype"]["string"] == _ORIGINMATRO
                 ):
                     # Yes, we have one.
                     surname = [_surname]
@@ -1166,7 +1151,7 @@ class NameDisplay:
                 name = db.get_name_group_mapping(name1)
         if not name:
             name = db.get_name_group_mapping(
-                _raw_primary_surname_only(pn[_SURNAME_LIST])
+                _raw_primary_surname_only(pn["surname_list"])
             )
         return name
 

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -3,7 +3,7 @@
 #
 # Copyright (C) 2002-2006  Donald N. Allingham
 # Copyright (C) 2011       Tim G L Lyons
-# Copyright (C) 2012       Doug Blank <doug.blank@gmail.com>
+# Copyright (C) 2012,2024  Doug Blank <doug.blank@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -39,6 +39,7 @@ from ..lib.repo import Repository
 from ..lib.media import Media
 from ..lib.note import Note
 from ..lib.tag import Tag
+from ..lib.serialize import from_dict
 from ..const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.gettext
@@ -145,8 +146,7 @@ class GenericFilter:
         if id_list is None:
             with self.get_tree_cursor(db) if tree else self.get_cursor(db) as cursor:
                 for handle, data in cursor:
-                    person = self.make_obj()
-                    person.unserialize(data)
+                    person = from_dict(data)
                     if user:
                         user.step_progress()
                     if task(db, person) != self.invert:
@@ -174,8 +174,7 @@ class GenericFilter:
         if id_list is None:
             with self.get_tree_cursor(db) if tree else self.get_cursor(db) as cursor:
                 for handle, data in cursor:
-                    person = self.make_obj()
-                    person.unserialize(data)
+                    person = from_dict(data)
                     if user:
                         user.step_progress()
                     val = all(rule.apply(db, person) for rule in flist)

--- a/gramps/gen/lib/address.py
+++ b/gramps/gen/lib/address.py
@@ -117,10 +117,7 @@ class Address(
                     "title": _("Notes"),
                     "items": {"type": "string", "maxLength": 50},
                 },
-                "date": {
-                    "oneOf": [{"type": "null"}, Date.get_schema()],
-                    "title": _("Date"),
-                },
+                "date": Date.get_schema(),
                 "street": {"type": "string", "title": _("Street")},
                 "locality": {"type": "string", "title": _("Locality")},
                 "city": {"type": "string", "title": _("City")},

--- a/gramps/gen/lib/baseobj.py
+++ b/gramps/gen/lib/baseobj.py
@@ -2,6 +2,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2000-2006  Donald N. Allingham
+# Copyright (C) 2024       Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -56,6 +57,48 @@ class BaseObject(metaclass=ABCMeta):
         """
         Convert a serialized tuple of data to an object.
         """
+
+    def get_object_state(self):
+        """
+        Get the current object state as a dictionary.
+
+        By default this returns the public attributes of the instance.  This
+        method can be overridden if the class requires other attributes or
+        properties to be saved.
+
+        This method is called to provide the information required to serialize
+        the object.  If None is returned then the object will be represented as
+        null in JSON.
+
+        :returns: Returns a dictionary of attributes that represent the state
+                  of the object or None.
+        :rtype: dict
+        """
+        attr_dict = dict(
+            (key, value)
+            for key, value in self.__dict__.items()
+            if not key.startswith("_")
+        )
+        attr_dict["_class"] = self.__class__.__name__
+        return attr_dict
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        By default this sets the state of the object assuming that all items in
+        the dictionary map to public attributes.  This method can be overridden
+        to set the state using custom functionality.  For performance reasons
+        it is useful to set a property without calling its setter function.  As
+        JSON provides no distinction between tuples and lists, this method can
+        also be use to convert lists into tuples where required.
+
+        :param attr_dict: A dictionary of attributes that represent the state of
+                          the object.
+        :type attr_dict: dict
+        """
+        self.__dict__.update(attr_dict)
 
     def matches_string(self, pattern, case_sensitive=False):
         """

--- a/gramps/gen/lib/baseobj.py
+++ b/gramps/gen/lib/baseobj.py
@@ -67,11 +67,10 @@ class BaseObject(metaclass=ABCMeta):
         properties to be saved.
 
         This method is called to provide the information required to serialize
-        the object.  If None is returned then the object will be represented as
-        null in JSON.
+        the object.
 
         :returns: Returns a dictionary of attributes that represent the state
-                  of the object or None.
+                  of the object.
         :rtype: dict
         """
         attr_dict = dict(

--- a/gramps/gen/lib/citation.py
+++ b/gramps/gen/lib/citation.py
@@ -113,10 +113,7 @@ class Citation(
                     "title": _("Handle"),
                 },
                 "gramps_id": {"type": "string", "title": _("Gramps ID")},
-                "date": {
-                    "oneOf": [{"type": "null"}, Date.get_schema()],
-                    "title": _("Date"),
-                },
+                "date": Date.get_schema(),
                 "page": {"type": "string", "title": _("Page")},
                 "confidence": {
                     "type": "integer",

--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -38,6 +38,7 @@ import time
 # Gramps modules
 #
 # ------------------------------------------------------------------------
+from .baseobj import BaseObject
 from ..config import config
 from ..const import GRAMPS_LOCALE as glocale
 from ..errors import DateError
@@ -563,7 +564,7 @@ class Span:
 # Date
 #
 # -------------------------------------------------------------------------
-class Date:
+class Date(BaseObject):
     """
     The core date handling class for Gramps.
 

--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -1,11 +1,11 @@
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2000-2007  Donald N. Allingham
-# Copyright (C) 2009-2013  Douglas S. Blank
-# Copyright (C) 2013       Paul Franklin
-# Copyright (C) 2013-2014  Vassilii Khachaturov
-# Copyright (C) 2017,2024  Nick Hall
+# Copyright (C) 2000-2007       Donald N. Allingham
+# Copyright (C) 2009-2013,2024  Douglas S. Blank
+# Copyright (C) 2013            Paul Franklin
+# Copyright (C) 2013-2014       Vassilii Khachaturov
+# Copyright (C) 2017,2024       Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -602,6 +602,7 @@ class Date(BaseObject):
 
     EMPTY = (0, 0, 0, False)
 
+    # These are positions in JSON dateval:
     _POS_DAY = 0
     _POS_MON = 1
     _POS_YR = 2

--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2009-2013  Douglas S. Blank
 # Copyright (C) 2013       Paul Franklin
 # Copyright (C) 2013-2014  Vassilii Khachaturov
-# Copyright (C) 2017       Nick Hall
+# Copyright (C) 2017,2024  Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -749,6 +749,28 @@ class Date(BaseObject):
         else:
             raise DateError("Invalid date to unserialize")
         return self
+
+    def get_object_state(self):
+        """
+        Get the current object state as a dictionary.
+
+        We override this method to represent an empty date as null in JSON.
+        """
+        if self.is_empty() and not self.text:
+            return None
+        else:
+            return super().get_object_state()
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to convert `dateval` into a tuple.
+        """
+        if "dateval" in attr_dict:
+            attr_dict["dateval"] = tuple(attr_dict["dateval"])
+        super().set_object_state(attr_dict)
 
     @classmethod
     def get_schema(cls):

--- a/gramps/gen/lib/date.py
+++ b/gramps/gen/lib/date.py
@@ -750,17 +750,6 @@ class Date(BaseObject):
             raise DateError("Invalid date to unserialize")
         return self
 
-    def get_object_state(self):
-        """
-        Get the current object state as a dictionary.
-
-        We override this method to represent an empty date as null in JSON.
-        """
-        if self.is_empty() and not self.text:
-            return None
-        else:
-            return super().get_object_state()
-
     def set_object_state(self, attr_dict):
         """
         Set the current object state using information provided in the given

--- a/gramps/gen/lib/event.py
+++ b/gramps/gen/lib/event.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2000-2007  Donald N. Allingham
 # Copyright (C) 2010       Michiel D. Nauta
 # Copyright (C) 2011       Tim G L Lyons
-# Copyright (C) 2017       Nick Hall
+# Copyright (C) 2017,2024  Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -135,6 +135,28 @@ class Event(
             TagBase.serialize(self),
             self.private,
         )
+
+    def get_object_state(self):
+        """
+        Get the current object state as a dictionary.
+
+        We override this method to handle the `type` and `description` properties.
+        """
+        attr_dict = super().get_object_state()
+        attr_dict["type"] = self.__type
+        attr_dict["description"] = self.__description
+        return attr_dict
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to handle the `type` and `description` properties.
+        """
+        self.__type = attr_dict.pop("type")
+        self.__description = attr_dict.pop("description")
+        super().set_object_state(attr_dict)
 
     @classmethod
     def get_schema(cls):

--- a/gramps/gen/lib/event.py
+++ b/gramps/gen/lib/event.py
@@ -183,10 +183,7 @@ class Event(
                 },
                 "gramps_id": {"type": "string", "title": _("Gramps ID")},
                 "type": EventType.get_schema(),
-                "date": {
-                    "oneOf": [{"type": "null"}, Date.get_schema()],
-                    "title": _("Date"),
-                },
+                "date": Date.get_schema(),
                 "description": {"type": "string", "title": _("Description")},
                 "place": {
                     "type": ["string", "null"],

--- a/gramps/gen/lib/eventref.py
+++ b/gramps/gen/lib/eventref.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2010       Michiel D. Nauta
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Doug Blank <doug.blank@gmail.com>
-# Copyright (C) 2017       Nick Hall
+# Copyright (C) 2017,2024  Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -85,6 +85,26 @@ class EventRef(
             RefBase.serialize(self),
             self.__role.serialize(),
         )
+
+    def get_object_state(self):
+        """
+        Get the current object state as a dictionary.
+
+        We override this method to handle the `role` property.
+        """
+        attr_dict = super().get_object_state()
+        attr_dict["role"] = self.__role
+        return attr_dict
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to handle the `role` property.
+        """
+        self.__role = attr_dict.pop("role")
+        super().set_object_state(attr_dict)
 
     @classmethod
     def get_schema(cls):

--- a/gramps/gen/lib/grampstype.py
+++ b/gramps/gen/lib/grampstype.py
@@ -2,7 +2,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2000-2007  Donald N. Allingham
-# Copyright (C) 2017       Nick Hall
+# Copyright (C) 2017,2024  Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -136,6 +136,30 @@ class GrampsType(metaclass=GrampsTypeMeta):
         if value is not None:
             self.set(value)
 
+    def get_object_state(self):
+        """
+        Get the current object state as a dictionary.
+
+        We override this method to handle the `value` and `string` properties.
+        """
+        attr_dict = {"_class": self.__class__.__name__}
+        attr_dict["value"] = self.__value
+        attr_dict["string"] = self.__string
+        return attr_dict
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to handle the `value` and `string` properties.
+        """
+        self.__value = attr_dict["value"]
+        if self.__value == self._CUSTOM:
+            self.__string = attr_dict["string"]
+        else:
+            self.__string = ""
+
     def __set_tuple(self, value):
         "Set the value/string properties from a tuple."
         val, strg = self._DEFAULT, ""
@@ -225,7 +249,8 @@ class GrampsType(metaclass=GrampsTypeMeta):
             "title": _("Type"),
             "properties": {
                 "_class": {"enum": [cls.__name__]},
-                "string": {"type": "string", "title": _("Type")},
+                "string": {"type": "string", "title": _("Custom type")},
+                "value": {"type": "integer", "title": _("Type code")},
             },
         }
 

--- a/gramps/gen/lib/grampstype.py
+++ b/gramps/gen/lib/grampstype.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2000-2007  Donald N. Allingham
 # Copyright (C) 2017,2024  Nick Hall
+# Copyright (C) 2024       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -87,22 +88,12 @@ class GrampsType(metaclass=GrampsTypeMeta):
       List of indices to ignore (obsolete/retired entries).
       (gramps policy is never to delete type values, or reuse the name (TOKEN)
       of any specific type value)
-    :cvar POS_<x>: (int)
-      Position of <x> attribute in the serialized format of
-      an instance.
-
-    .. warning:: The POS_<x> class variables reflect the serialized object,
-                 they have to be updated in case the data structure or the
-                 :meth:`serialize` method changes!
-
     :cvar _CUSTOM:  (int) a custom type object
     :cvar _DEFAULT: (int) the default type, used on creation
 
     :attribute value: (int) Returns or sets integer value
     :attribute string: (str) Returns or sets string value
     """
-
-    (POS_VALUE, POS_STRING) = list(range(2))
 
     _CUSTOM = 0
     _DEFAULT = 0

--- a/gramps/gen/lib/ldsord.py
+++ b/gramps/gen/lib/ldsord.py
@@ -196,10 +196,7 @@ class LdsOrd(SecondaryObject, CitationBase, NoteBase, DateBase, PlaceBase, Priva
                     "title": _("Notes"),
                     "items": {"type": "string", "maxLength": 50},
                 },
-                "date": {
-                    "oneOf": [{"type": "null"}, Date.get_schema()],
-                    "title": _("Date"),
-                },
+                "date": Date.get_schema(),
                 "type": {"type": "integer", "title": _("Type")},
                 "place": {"type": "string", "title": _("Place")},
                 "famc": {"type": ["null", "string"], "title": _("Family")},

--- a/gramps/gen/lib/media.py
+++ b/gramps/gen/lib/media.py
@@ -169,10 +169,7 @@ class Media(CitationBase, NoteBase, DateBase, AttributeBase, PrimaryObject):
                     "title": _("Notes"),
                 },
                 "change": {"type": "integer", "title": _("Last changed")},
-                "date": {
-                    "oneOf": [{"type": "null"}, Date.get_schema()],
-                    "title": _("Date"),
-                },
+                "date": Date.get_schema(),
                 "tag_list": {
                     "type": "array",
                     "items": {"type": "string", "maxLength": 50},

--- a/gramps/gen/lib/mediaref.py
+++ b/gramps/gen/lib/mediaref.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2010       Michiel D. Nauta
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2013       Doug Blank <doug.blank@gmail.com>
-# Copyright (C) 2017       Nick Hall
+# Copyright (C) 2017,2024  Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -150,6 +150,18 @@ class MediaRef(
         AttributeBase.unserialize(self, attribute_list)
         RefBase.unserialize(self, ref)
         return self
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to convert `rect` into a tuple.
+        """
+        rect = attr_dict["rect"]
+        if rect is not None:
+            attr_dict["rect"] = tuple(rect)
+        super().set_object_state(attr_dict)
 
     def get_text_data_child_list(self):
         """

--- a/gramps/gen/lib/name.py
+++ b/gramps/gen/lib/name.py
@@ -177,10 +177,7 @@ class Name(SecondaryObject, PrivacyBase, SurnameBase, CitationBase, NoteBase, Da
                     "items": {"type": "string", "maxLength": 50},
                     "title": _("Notes"),
                 },
-                "date": {
-                    "oneOf": [{"type": "null"}, Date.get_schema()],
-                    "title": _("Date"),
-                },
+                "date": Date.get_schema(),
                 "first_name": {"type": "string", "title": _("Given name")},
                 "surname_list": {
                     "type": "array",

--- a/gramps/gen/lib/note.py
+++ b/gramps/gen/lib/note.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2000-2007  Donald N. Allingham
 # Copyright (C) 2010       Michiel D. Nauta
 # Copyright (C) 2010,2017  Nick Hall
+# Copyright (C) 2024       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -62,26 +63,9 @@ class Note(BasicPrimaryObject):
 
     :cvar FLOWED: indicates flowed format
     :cvar FORMATTED: indicates formatted format (respecting whitespace needed)
-    :cvar POS_<x>: (int) Position of <x> attribute in the serialized format of
-        an instance.
-
-    .. warning:: The POS_<x> class variables reflect the serialized object,
-                 they have to be updated in case the data structure or the
-                 :meth:`serialize` method changes!
     """
 
     (FLOWED, FORMATTED) = list(range(2))
-
-    (
-        POS_HANDLE,
-        POS_ID,
-        POS_TEXT,
-        POS_FORMAT,
-        POS_TYPE,
-        POS_CHANGE,
-        POS_TAGS,
-        POS_PRIVATE,
-    ) = list(range(8))
 
     def __init__(self, text=""):
         """Create a new Note object, initializing from the passed string."""

--- a/gramps/gen/lib/person.py
+++ b/gramps/gen/lib/person.py
@@ -1,10 +1,10 @@
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2000-2007  Donald N. Allingham
-# Copyright (C) 2010       Michiel D. Nauta
-# Copyright (C) 2010,2017  Nick Hall
-# Copyright (C) 2011       Tim G L Lyons
+# Copyright (C) 2000-2007       Donald N. Allingham
+# Copyright (C) 2010            Michiel D. Nauta
+# Copyright (C) 2010,2017,2024  Nick Hall
+# Copyright (C) 2011            Tim G L Lyons
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -321,6 +321,26 @@ class Person(
         NoteBase.unserialize(self, note_list)
         TagBase.unserialize(self, tag_list)
         return self
+
+    def get_object_state(self):
+        """
+        Get the current object state as a dictionary.
+
+        We override this method to handle the `gender` property.
+        """
+        attr_dict = super().get_object_state()
+        attr_dict["gender"] = self.__gender
+        return attr_dict
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to handle the `gender` property.
+        """
+        self.__gender = attr_dict.pop("gender")
+        super().set_object_state(attr_dict)
 
     def _has_handle_reference(self, classname, handle):
         """

--- a/gramps/gen/lib/placename.py
+++ b/gramps/gen/lib/placename.py
@@ -96,10 +96,7 @@ class PlaceName(SecondaryObject, DateBase):
             "properties": {
                 "_class": {"enum": [cls.__name__]},
                 "value": {"type": "string", "title": _("Text")},
-                "date": {
-                    "oneOf": [{"type": "null"}, Date.get_schema()],
-                    "title": _("Date"),
-                },
+                "date": Date.get_schema(),
                 "lang": {"type": "string", "title": _("Language")},
             },
         }

--- a/gramps/gen/lib/placeref.py
+++ b/gramps/gen/lib/placeref.py
@@ -93,10 +93,7 @@ class PlaceRef(RefBase, DateBase, SecondaryObject):
                     "title": _("Handle"),
                     "maxLength": 50,
                 },
-                "date": {
-                    "oneOf": [{"type": "null"}, Date.get_schema()],
-                    "title": _("Date"),
-                },
+                "date": Date.get_schema(),
             },
         }
 

--- a/gramps/gen/lib/researcher.py
+++ b/gramps/gen/lib/researcher.py
@@ -147,3 +147,44 @@ class Researcher(LocationBase):
             if getattr(self, attr) != "":
                 return False
         return True
+
+    def get_object_state(self):
+        """
+        Get the current object state as a dictionary.
+
+        By default this returns the public attributes of the instance.  This
+        method can be overridden if the class requires other attributes or
+        properties to be saved.
+
+        This method is called to provide the information required to serialize
+        the object.
+
+        :returns: Returns a dictionary of attributes that represent the state
+                  of the object.
+        :rtype: dict
+        """
+        attr_dict = dict(
+            (key, value)
+            for key, value in self.__dict__.items()
+            if not key.startswith("_")
+        )
+        attr_dict["_class"] = self.__class__.__name__
+        return attr_dict
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        By default this sets the state of the object assuming that all items in
+        the dictionary map to public attributes.  This method can be overridden
+        to set the state using custom functionality.  For performance reasons
+        it is useful to set a property without calling its setter function.  As
+        JSON provides no distinction between tuples and lists, this method can
+        also be use to convert lists into tuples where required.
+
+        :param attr_dict: A dictionary of attributes that represent the state of
+                          the object.
+        :type attr_dict: dict
+        """
+        self.__dict__.update(attr_dict)

--- a/gramps/gen/lib/serialize.py
+++ b/gramps/gen/lib/serialize.py
@@ -1,7 +1,7 @@
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2017       Nick Hall
+# Copyright (C) 2017,2024       Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -37,36 +37,16 @@ import json
 import gramps.gen.lib as lib
 
 
-def __default(obj):
-    obj_dict = {"_class": obj.__class__.__name__}
-    if isinstance(obj, lib.GrampsType):
-        obj_dict["string"] = getattr(obj, "string")
-    if isinstance(obj, lib.Date):
-        if obj.is_empty() and not obj.text:
-            return None
-    for key, value in obj.__dict__.items():
-        if not key.startswith("_"):
-            obj_dict[key] = value
-    for key, value in obj.__class__.__dict__.items():
-        if isinstance(value, property):
-            if key != "year":
-                obj_dict[key] = getattr(obj, key)
-    return obj_dict
-
-
 def __object_hook(obj_dict):
-    obj = getattr(lib, obj_dict["_class"])()
-    for key, value in obj_dict.items():
-        if key != "_class":
-            if key in ("dateval", "rect") and value is not None:
-                value = tuple(value)
-            if key == "ranges":
-                value = [tuple(item) for item in value]
-            setattr(obj, key, value)
-    if obj_dict["_class"] == "Date":
-        if obj.is_empty() and not obj.text:
-            return None
+    _class = obj_dict.pop("_class")
+    cls = lib.__dict__[_class]
+    obj = cls.__new__(cls)
+    obj.set_object_state(obj_dict)
     return obj
+
+
+def __default(obj):
+    return obj.get_object_state()
 
 
 def to_json(obj):

--- a/gramps/gen/lib/serialize.py
+++ b/gramps/gen/lib/serialize.py
@@ -2,6 +2,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2017,2024       Nick Hall
+# Copyright (C) 2024            Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,6 +29,8 @@ Serialization utilities for Gramps.
 #
 # ------------------------------------------------------------------------
 import json
+import pickle
+import logging
 
 # ------------------------------------------------------------------------
 #
@@ -35,6 +38,8 @@ import json
 #
 # ------------------------------------------------------------------------
 import gramps.gen.lib as lib
+
+LOG = logging.getLogger(".serialize")
 
 
 def __object_hook(obj_dict):
@@ -71,3 +76,147 @@ def from_json(data):
     :rtype: object
     """
     return json.loads(data, object_hook=__object_hook)
+
+
+def to_dict(obj):
+    """
+    Convert a Gramps object into a struct.
+
+    :param obj: The object to be serialized.
+    :type obj: object
+    :returns: A dictionary.
+    :rtype: dict
+    """
+    return json.loads(to_json(obj))
+
+
+def from_dict(dict):
+    """
+    Convert a dictionary into a Gramps object.
+
+    :param dict: The dictionary to be unserialized.
+    :type dict: dict
+    :returns: A Gramps object.
+    :rtype: object
+    """
+    return from_json(json.dumps(dict))
+
+
+class BlobSerializer:
+    """
+    Serializer for blob data
+
+    In this serializer, data is a nested array,
+    and string is pickled bytes.
+    """
+
+    data_field = "blob_data"
+    metadata_field = "value"
+
+    @staticmethod
+    def data_to_object(obj_class, data):
+        LOG.debug("blob, data_to_object: %s(%r)", obj_class, data[0] if data else data)
+        return obj_class.create(data)
+
+    @staticmethod
+    def string_to_object(obj_class, bytes):
+        LOG.debug("blob, string_to_object: %r...", bytes[:35])
+        return obj_class.create(pickle.loads(bytes))
+
+    @staticmethod
+    def string_to_data(bytes):
+        LOG.debug("blob, string_to_object: %r...", bytes[:35])
+        return pickle.loads(bytes)
+
+    @staticmethod
+    def object_to_string(obj):
+        LOG.debug("blob, object_to_string: %s...", obj)
+        return pickle.dumps(obj.serialize())
+
+    @staticmethod
+    def data_to_string(data):
+        LOG.debug("blob, data_to_string: %s...", data[0] if data else data)
+        return pickle.dumps(data)
+
+    @staticmethod
+    def metadata_to_object(blob):
+        return pickle.loads(blob)
+
+    @staticmethod
+    def object_to_metadata(value):
+        return pickle.dumps(value)
+
+
+class JSONSerializer:
+    """
+    Serializer for JSON data.
+
+    In this serializer, data is a dict,
+    and string is a JSON string.
+    """
+
+    data_field = "json_data"
+    metadata_field = "json_data"
+
+    @staticmethod
+    def data_to_object(obj_class, data):
+        LOG.debug(
+            "json, data_to_object: {'_class': %r, ...}",
+            data["_class"] if (data and "_class" in data) else data,
+        )
+        return from_dict(data)
+
+    @staticmethod
+    def string_to_object(obj_class, string):
+        LOG.debug("json, string_to_object: %r...", string[:65])
+        return from_json(string)
+
+    @staticmethod
+    def string_to_data(string):
+        LOG.debug("json, string_to_data: %r...", string[:65])
+        return json.loads(string)
+
+    @staticmethod
+    def object_to_string(obj):
+        LOG.debug("json, object_to_string: %s...", obj)
+        return to_json(obj)
+
+    @staticmethod
+    def data_to_string(data):
+        LOG.debug(
+            "json, data_to_string: {'_class': %r, ...}",
+            data["_class"] if (data and "_class" in data) else data,
+        )
+        return json.dumps(data)
+
+    @staticmethod
+    def metadata_to_object(string):
+        doc = json.loads(string)
+        type_name = doc["type"]
+        if type_name in ("int", "str", "list"):
+            return doc["value"]
+        elif type_name == "set":
+            return set(doc["value"])
+        elif type_name == "tuple":
+            return tuple(doc["value"])
+        elif type_name == "dict":
+            return doc["value"]
+        elif type_name == "Researcher":
+            return from_dict(doc["value"])
+        else:
+            return doc["value"]
+
+    @staticmethod
+    def object_to_metadata(value):
+        type_name = type(value).__name__
+        if type_name in ("set", "tuple"):
+            value = list(value)
+        elif type_name == "Researcher":
+            value = to_dict(value)
+        elif type_name not in ("int", "str", "list"):
+            value = json.loads(to_json(value))
+        data = {
+            "type": type_name,
+            "value": value,
+        }
+        return json.dumps(data)

--- a/gramps/gen/lib/styledtext.py
+++ b/gramps/gen/lib/styledtext.py
@@ -35,6 +35,7 @@ from copy import copy
 #
 # -------------------------------------------------------------------------
 from ..const import GRAMPS_LOCALE as glocale
+from .baseobj import BaseObject
 from .styledtexttag import StyledTextTag
 
 _ = glocale.translation.gettext
@@ -45,7 +46,7 @@ _ = glocale.translation.gettext
 # StyledText
 #
 # -------------------------------------------------------------------------
-class StyledText:
+class StyledText(BaseObject):
     """Helper class to enable character based text formatting.
 
     :py:class:`StyledText` is a wrapper class binding the clear text string and

--- a/gramps/gen/lib/styledtext.py
+++ b/gramps/gen/lib/styledtext.py
@@ -3,7 +3,7 @@
 #
 # Copyright (C) 2008       Zsolt Foldvari
 # Copyright (C) 2013       Doug Blank <doug.blank@gmail.com>
-# Copyright (C) 2017       Nick Hall
+# Copyright (C) 2017,2024  Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -101,6 +101,27 @@ class StyledText(BaseObject):
             self._tags = tags
         else:
             self._tags = []
+
+    def get_object_state(self):
+        """
+        Get the current object state as a dictionary.
+
+        We override this method to handle the `tags` and `string` properties.
+        """
+        attr_dict = {"_class": self.__class__.__name__}
+        attr_dict["tags"] = self._tags
+        attr_dict["string"] = self._string
+        return attr_dict
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to handle the `tags` and `string` properties.
+        """
+        self._tags = attr_dict["tags"]
+        self._string = attr_dict["string"]
 
     # special methods
 

--- a/gramps/gen/lib/styledtext.py
+++ b/gramps/gen/lib/styledtext.py
@@ -2,7 +2,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2008       Zsolt Foldvari
-# Copyright (C) 2013       Doug Blank <doug.blank@gmail.com>
+# Copyright (C) 2013,2024  Doug Blank <doug.blank@gmail.com>
 # Copyright (C) 2017,2024  Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
@@ -68,15 +68,6 @@ class StyledText(BaseObject):
     :ivar tags: (list of :py:class:`.StyledTextTag`) Text tags holding
                 formatting information for the string.
 
-    :cvar POS_TEXT: Position of *string* attribute in the serialized format of
-                    an instance.
-    :cvar POS_TAGS: (int) Position of *tags* attribute in the serialized format
-                    of an instance.
-
-    .. warning:: The POS_<x> class variables reflect the serialized object,
-      they have to be updated in case the data structure or the
-      :py:meth:`serialize` method changes!
-
     .. note::
      1. There is no sanity check of tags in :py:meth:`__init__`, because when a
         :py:class:`StyledText` is displayed it is passed to a
@@ -90,8 +81,6 @@ class StyledText(BaseObject):
      3. Warning: Some of these operations modify the source tag ranges in place
         so if you intend to use a source tag more than once, copy it for use.
     """
-
-    (POS_TEXT, POS_TAGS) = list(range(2))
 
     def __init__(self, text="", tags=None):
         """Setup initial instance variable values."""

--- a/gramps/gen/lib/styledtexttag.py
+++ b/gramps/gen/lib/styledtexttag.py
@@ -28,6 +28,7 @@
 #
 # -------------------------------------------------------------------------
 from ..const import GRAMPS_LOCALE as glocale
+from .baseobj import BaseObject
 from .styledtexttagtype import StyledTextTagType
 
 _ = glocale.translation.gettext
@@ -38,7 +39,7 @@ _ = glocale.translation.gettext
 # StyledTextTag
 #
 # -------------------------------------------------------------------------
-class StyledTextTag:
+class StyledTextTag(BaseObject):
     """Hold formatting information for :py:class:`.StyledText`.
 
     :py:class:`StyledTextTag` is a container class, it's attributes are

--- a/gramps/gen/lib/styledtexttag.py
+++ b/gramps/gen/lib/styledtexttag.py
@@ -1,9 +1,9 @@
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2008  Zsolt Foldvari
-# Copyright (C) 2013  Doug Blank <doug.blank@gmail.com>
-# Copyright (C) 2017  Nick Hall
+# Copyright (C) 2008       Zsolt Foldvari
+# Copyright (C) 2013       Doug Blank <doug.blank@gmail.com>
+# Copyright (C) 2017,2024  Nick Hall
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -69,6 +69,16 @@ class StyledTextTag(BaseObject):
         else:
             # Current use of StyledTextTag is such that a shallow copy suffices.
             self.ranges = ranges
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to convert the elements of `ranges` into tuples.
+        """
+        attr_dict["ranges"] = [tuple(item) for item in attr_dict["ranges"]]
+        super().set_object_state(attr_dict)
 
     def serialize(self):
         """Convert the object to a serialized tuple of data.

--- a/gramps/gen/lib/tag.py
+++ b/gramps/gen/lib/tag.py
@@ -1,8 +1,8 @@
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2010,2017 Nick Hall
-# Copyright (C) 2013      Doug Blank <doug.blank@gmail.com>
+# Copyright (C) 2010,2017,2024  Nick Hall
+# Copyright (C) 2013            Doug Blank <doug.blank@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -107,6 +107,32 @@ class Tag(TableObject):
             self.change,
         ) = data
         return self
+
+    def get_object_state(self):
+        """
+        Get the current object state as a dictionary.
+
+        We override this method to handle the `name`, `color` and `priority`
+        properties.
+        """
+        attr_dict = super().get_object_state()
+        attr_dict["name"] = self.__name
+        attr_dict["color"] = self.__color
+        attr_dict["priority"] = self.__priority
+        return attr_dict
+
+    def set_object_state(self, attr_dict):
+        """
+        Set the current object state using information provided in the given
+        dictionary.
+
+        We override this method to handle the `name`, `color` and `priority`
+        properties.
+        """
+        self.__name = attr_dict.pop("name")
+        self.__color = attr_dict.pop("color")
+        self.__priority = attr_dict.pop("priority")
+        super().set_object_state(attr_dict)
 
     @classmethod
     def get_schema(cls):

--- a/gramps/gen/lib/test/serialize_test.py
+++ b/gramps/gen/lib/test/serialize_test.py
@@ -50,11 +50,6 @@ class BaseCheck:
         obj = from_json(data)
         self.assertEqual(self.object.serialize(), obj.serialize())
 
-    def test_from_empty_json(self):
-        data = '{"_class": "%s"}' % self.cls.__name__
-        obj = from_json(data)
-        self.assertEqual(self.object.serialize(), obj.serialize())
-
 
 class PersonCheck(unittest.TestCase, BaseCheck):
     def setUp(self):

--- a/gramps/gen/lib/test/serialize_test.py
+++ b/gramps/gen/lib/test/serialize_test.py
@@ -129,7 +129,7 @@ def generate_case(obj):
     setattr(DatabaseCheck, name, test)
     ####
     # def test2(self):
-    #    self.assertEqual(obj.serialize(), from_struct(struct).serialize())
+    #    self.assertEqual(obj.serialize(), from_dict(struct).serialize())
     # name = "test_create_%s_%s" % (obj.__class__.__name__, obj.handle)
     # setattr(DatabaseCheck, name, test2)
 

--- a/gramps/gen/merge/diff.py
+++ b/gramps/gen/merge/diff.py
@@ -1,7 +1,7 @@
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2012       Doug Blank <doug.blank@gmail.com>
+# Copyright (C) 2012,2024  Doug Blank <doug.blank@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -25,17 +25,10 @@ This package implements an object difference engine.
 import json
 
 from ..db.utils import import_as_dict
-from ..lib.serialize import to_json
+from ..lib.serialize import to_dict, from_dict
 from ..const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.gettext
-
-
-def to_struct(obj):
-    """
-    Convert an object into a struct.
-    """
-    return json.loads(to_json(obj))
 
 
 def diff_dates(json1, json2):
@@ -136,7 +129,7 @@ def diff_dbs(db1, db2, user):
                 if handles1[p1] == handles2[p2]:  # in both
                     item1 = handle_func1(handles1[p1])
                     item2 = handle_func2(handles2[p2])
-                    diff = diff_items(item, to_struct(item1), to_struct(item2))
+                    diff = diff_items(item, to_dict(item1), to_dict(item2))
                     if diff:
                         diffs += [(item, item1, item2)]
                     # else same!

--- a/gramps/gen/plug/_pluginreg.py
+++ b/gramps/gen/plug/_pluginreg.py
@@ -535,73 +535,98 @@ class PluginData:
         # THUMBNAILER attr
         self._thumbnailer = None
 
-    def _set_id(self, plugin_id):
-        self._id = plugin_id
-
-    def _get_id(self):
+    @property
+    def id(self):
         return self._id
 
-    def _set_name(self, name):
-        self._name = name
+    @id.setter
+    def id(self, plugin_id):
+        self._id = plugin_id
 
-    def _get_name(self):
+    @property
+    def name(self):
         return self._name
 
-    def _set_name_accell(self, name):
-        self._name_accell = name
+    @name.setter
+    def name(self, name):
+        self._name = name
 
-    def _get_name_accell(self):
+    @property
+    def name_accell(self):
         if self._name_accell is None:
             return self._name
         return self._name_accell
 
-    def _set_description(self, description):
-        self._description = description
+    @name_accell.setter
+    def name_accell(self, name):
+        self._name_accell = name
 
-    def _get_description(self):
+    @property
+    def description(self):
         return self._description
 
-    def _set_version(self, plugin_version):
-        self._version = plugin_version
+    @description.setter
+    def description(self, description):
+        self._description = description
 
-    def _get_version(self):
+    @property
+    def version(self):
         return self._version
 
-    def _set_gramps_target_version(self, target_version):
-        self._gramps_target_version = target_version
+    @version.setter
+    def version(self, plugin_version):
+        self._version = plugin_version
 
-    def _get_gramps_target_version(self):
+    @property
+    def gramps_target_version(self):
         return self._gramps_target_version
 
-    def _set_status(self, status):
+    @gramps_target_version.setter
+    def gramps_target_version(self, target_version):
+        self._gramps_target_version = target_version
+
+    @property
+    def status(self):
+        return self._status
+
+    @status.setter
+    def status(self, status):
         if status not in STATUS:
             raise ValueError(f"plugin status cannot be {status}")
         self._status = status
 
-    def _get_status(self):
-        return self._status
+    @property
+    def audience(self):
+        return self._audience
 
-    def _set_audience(self, audience):
+    @audience.setter
+    def audience(self, audience):
         if audience not in AUDIENCE:
             raise ValueError(f"plugin audience cannot be {audience}")
         self._audience = audience
 
-    def _get_audience(self):
-        return self._audience
-
-    def _set_fname(self, fname):
-        self._fname = fname
-
-    def _get_fname(self):
+    @property
+    def fname(self):
         return self._fname
 
-    def _set_fpath(self, fpath):
-        self._fpath = fpath
+    @fname.setter
+    def fname(self, fname):
+        self._fname = fname
 
-    def _get_fpath(self):
+    @property
+    def fpath(self):
         return self._fpath
 
-    def _set_ptype(self, ptype):
+    @fpath.setter
+    def fpath(self, fpath):
+        self._fpath = fpath
+
+    @property
+    def ptype(self):
+        return self._ptype
+
+    @ptype.setter
+    def ptype(self, ptype):
         if ptype not in PTYPE:
             raise ValueError(f"Plugin type cannot be {ptype}")
         if self._ptype is not None:
@@ -618,144 +643,141 @@ class PluginData:
         # if self._ptype == DOCGEN:
         #    self._load_on_reg = True
 
-    def _get_ptype(self):
-        return self._ptype
+    @property
+    def authors(self):
+        return self._authors
 
-    def _set_authors(self, authors):
+    @authors.setter
+    def authors(self, authors):
         if not authors or not isinstance(authors, list):
             return
         self._authors = authors
 
-    def _get_authors(self):
-        return self._authors
+    @property
+    def authors_email(self):
+        return self._authors_email
 
-    def _set_authors_email(self, authors_email):
+    @authors_email.setter
+    def authors_email(self, authors_email):
         if not authors_email or not isinstance(authors_email, list):
             return
         self._authors_email = authors_email
 
-    def _get_authors_email(self):
-        return self._authors_email
+    @property
+    def maintainers(self):
+        return self._maintainers
 
-    def _set_maintainers(self, maintainers):
+    @maintainers.setter
+    def maintainers(self, maintainers):
         if not maintainers or not isinstance(maintainers, list):
             return
         self._maintainers = maintainers
 
-    def _get_maintainers(self):
-        return self._maintainers
+    @property
+    def maintainers_email(self):
+        return self._maintainers_email
 
-    def _set_maintainers_email(self, maintainers_email):
+    @maintainers_email.setter
+    def maintainers_email(self, maintainers_email):
         if not maintainers_email or not isinstance(maintainers_email, list):
             return
         self._maintainers_email = maintainers_email
 
-    def _get_maintainers_email(self):
-        return self._maintainers_email
+    @property
+    def supported(self):
+        return self._supported
 
-    def _set_supported(self, supported):
+    @supported.setter
+    def supported(self, supported):
         if not isinstance(supported, bool):
             raise ValueError("Plugin must have supported=True or False")
         self._supported = supported
 
-    def _get_supported(self):
-        return self._supported
+    @property
+    def load_on_reg(self):
+        return self._load_on_reg
 
-    def _set_load_on_reg(self, load_on_reg):
+    @load_on_reg.setter
+    def load_on_reg(self, load_on_reg):
         if not isinstance(load_on_reg, bool):
             raise ValueError("Plugin must have load_on_reg=True or False")
         self._load_on_reg = load_on_reg
 
-    def _get_load_on_reg(self):
-        return self._load_on_reg
-
-    def _get_icons(self):
+    @property
+    def icons(self):
         return self._icons
 
-    def _set_icons(self, icons):
+    @icons.setter
+    def icons(self, icons):
         if not isinstance(icons, list):
             raise ValueError("Plugin must have icons as a list")
         self._icons = icons
 
-    def _get_icondir(self):
+    @property
+    def icondir(self):
         return self._icondir
 
-    def _set_icondir(self, icondir):
+    @icondir.setter
+    def icondir(self, icondir):
         self._icondir = icondir
 
-    def _get_depends_on(self):
+    @property
+    def depends_on(self):
         return self._depends_on
 
-    def _set_depends_on(self, depends):
+    @depends_on.setter
+    def depends_on(self, depends):
         if not isinstance(depends, list):
             raise ValueError("Plugin must have depends_on as a list")
         self._depends_on = depends
 
-    def _get_requires_mod(self):
+    @property
+    def requires_mod(self):
         return self._requires_mod
 
-    def _set_requires_mod(self, requires):
+    @requires_mod.setter
+    def requires_mod(self, requires):
         if not isinstance(requires, list):
             raise ValueError("Plugin must have requires_mod as a list")
         self._requires_mod = requires
 
-    def _get_requires_gi(self):
+    @property
+    def requires_gi(self):
         return self._requires_gi
 
-    def _set_requires_gi(self, requires):
+    @requires_gi.setter
+    def requires_gi(self, requires):
         if not isinstance(requires, list):
             raise ValueError("Plugin must have requires_gi as a list")
         self._requires_gi = requires
 
-    def _get_requires_exe(self):
+    @property
+    def requires_exe(self):
         return self._requires_exe
 
-    def _set_requires_exe(self, requires):
+    @requires_exe.setter
+    def requires_exe(self, requires):
         if not isinstance(requires, list):
             raise ValueError("Plugin must have requires_exe as a list")
         self._requires_exe = requires
 
-    def _get_include_in_listing(self):
+    @property
+    def include_in_listing(self):
         return self._include_in_listing
 
-    def _set_include_in_listing(self, include):
+    @include_in_listing.setter
+    def include_in_listing(self, include):
         if not isinstance(include, bool):
             raise ValueError("Plugin must have include_in_listing as a bool")
         self._include_in_listing = include
 
-    def _set_help_url(self, help_url):
-        self._help_url = help_url
-
-    def _get_help_url(self):
+    @property
+    def help_url(self):
         return self._help_url
 
-    id = property(_get_id, _set_id)
-    name = property(_get_name, _set_name)
-    name_accell = property(_get_name_accell, _set_name_accell)
-    description = property(_get_description, _set_description)
-    version = property(_get_version, _set_version)
-    gramps_target_version = property(
-        _get_gramps_target_version, _set_gramps_target_version
-    )
-    status = property(_get_status, _set_status)
-    audience = property(_get_audience, _set_audience)
-    fname = property(_get_fname, _set_fname)
-    fpath = property(_get_fpath, _set_fpath)
-    ptype = property(_get_ptype, _set_ptype)
-    authors = property(_get_authors, _set_authors)
-    authors_email = property(_get_authors_email, _set_authors_email)
-    maintainers = property(_get_maintainers, _set_maintainers)
-    maintainers_email = property(_get_maintainers_email, _set_maintainers_email)
-    supported = property(_get_supported, _set_supported)
-    load_on_reg = property(_get_load_on_reg, _set_load_on_reg)
-    icons = property(_get_icons, _set_icons)
-    icondir = property(_get_icondir, _set_icondir)
-    depends_on = property(_get_depends_on, _set_depends_on)
-    requires_mod = property(_get_requires_mod, _set_requires_mod)
-    requires_gi = property(_get_requires_gi, _set_requires_gi)
-    requires_exe = property(_get_requires_exe, _set_requires_exe)
-    include_in_listing = property(_get_include_in_listing, _set_include_in_listing)
-    help_url = property(_get_help_url, _set_help_url)
+    @help_url.setter
+    def help_url(self, help_url):
+        self._help_url = help_url
 
     def statustext(self):
         """
@@ -766,45 +788,55 @@ class PluginData:
     # type specific plugin attributes
 
     # RELCALC attributes
-    def _set_relcalcclass(self, relcalcclass):
+    @property
+    def relcalcclass(self):
+        return self._relcalcclass
+
+    @relcalcclass.setter
+    def relcalcclass(self, relcalcclass):
         if self._ptype != RELCALC:
             raise ValueError("relcalcclass may only be set for RELCALC plugins")
         self._relcalcclass = relcalcclass
 
-    def _get_relcalcclass(self):
-        return self._relcalcclass
+    @property
+    def lang_list(self):
+        return self._lang_list
 
-    def _set_lang_list(self, lang_list):
+    @lang_list.setter
+    def lang_list(self, lang_list):
         if self._ptype != RELCALC:
             raise ValueError("relcalcclass may only be set for RELCALC plugins")
         self._lang_list = lang_list
 
-    def _get_lang_list(self):
-        return self._lang_list
-
-    relcalcclass = property(_get_relcalcclass, _set_relcalcclass)
-    lang_list = property(_get_lang_list, _set_lang_list)
-
     # REPORT attributes
-    def _set_require_active(self, require_active):
+    @property
+    def require_active(self):
+        return self._require_active
+
+    @require_active.setter
+    def require_active(self, require_active):
         if self._ptype != REPORT:
             raise ValueError("require_active may only be set for REPORT plugins")
         if not isinstance(require_active, bool):
             raise ValueError("Report must have require_active=True or False")
         self._require_active = require_active
 
-    def _get_require_active(self):
-        return self._require_active
+    @property
+    def reportclass(self):
+        return self._reportclass
 
-    def _set_reportclass(self, reportclass):
+    @reportclass.setter
+    def reportclass(self, reportclass):
         if self._ptype != REPORT:
             raise ValueError("reportclass may only be set for REPORT plugins")
         self._reportclass = reportclass
 
-    def _get_reportclass(self):
-        return self._reportclass
+    @property
+    def report_modes(self):
+        return self._report_modes
 
-    def _set_report_modes(self, report_modes):
+    @report_modes.setter
+    def report_modes(self, report_modes):
         if self._ptype != REPORT:
             raise ValueError("report_modes may only be set for REPORT plugins")
         if not isinstance(report_modes, list):
@@ -813,11 +845,13 @@ class PluginData:
         if not self._report_modes:
             raise ValueError("report_modes not a valid list of modes")
 
-    def _get_report_modes(self):
-        return self._report_modes
-
     # REPORT or TOOL or QUICKREPORT or GENERAL attributes
-    def _set_category(self, category):
+    @property
+    def category(self):
+        return self._category
+
+    @category.setter
+    def category(self, category):
         if self._ptype not in [REPORT, TOOL, QUICKREPORT, VIEW, GENERAL]:
             raise ValueError(
                 "category may only be set for "
@@ -825,30 +859,36 @@ class PluginData:
             )
         self._category = category
 
-    def _get_category(self):
-        return self._category
-
     # REPORT OR TOOL attributes
-    def _set_optionclass(self, optionclass):
+    @property
+    def optionclass(self):
+        return self._optionclass
+
+    @optionclass.setter
+    def optionclass(self, optionclass):
         if self._ptype not in [REPORT, TOOL, DOCGEN]:
             raise ValueError(
                 "optionclass may only be set for REPORT/TOOL/DOCGEN plugins"
             )
         self._optionclass = optionclass
 
-    def _get_optionclass(self):
-        return self._optionclass
-
     # TOOL attributes
-    def _set_toolclass(self, toolclass):
+    @property
+    def toolclass(self):
+        return self._toolclass
+
+    @toolclass.setter
+    def toolclass(self, toolclass):
         if self._ptype != TOOL:
             raise ValueError("toolclass may only be set for TOOL plugins")
         self._toolclass = toolclass
 
-    def _get_toolclass(self):
-        return self._toolclass
+    @property
+    def tool_modes(self):
+        return self._tool_modes
 
-    def _set_tool_modes(self, tool_modes):
+    @tool_modes.setter
+    def tool_modes(self, tool_modes):
         if self._ptype != TOOL:
             raise ValueError("tool_modes may only be set for TOOL plugins")
         if not isinstance(tool_modes, list):
@@ -857,166 +897,172 @@ class PluginData:
         if not self._tool_modes:
             raise ValueError("tool_modes not a valid list of modes")
 
-    def _get_tool_modes(self):
-        return self._tool_modes
-
-    require_active = property(_get_require_active, _set_require_active)
-    reportclass = property(_get_reportclass, _set_reportclass)
-    report_modes = property(_get_report_modes, _set_report_modes)
-    category = property(_get_category, _set_category)
-    optionclass = property(_get_optionclass, _set_optionclass)
-    toolclass = property(_get_toolclass, _set_toolclass)
-    tool_modes = property(_get_tool_modes, _set_tool_modes)
-
     # DOCGEN attributes
-    def _set_paper(self, paper):
+    @property
+    def paper(self):
+        return self._paper
+
+    @paper.setter
+    def paper(self, paper):
         if self._ptype != DOCGEN:
             raise ValueError("paper may only be set for DOCGEN plugins")
         if not isinstance(paper, bool):
             raise ValueError("Plugin must have paper=True or False")
         self._paper = paper
 
-    def _get_paper(self):
-        return self._paper
+    @property
+    def style(self):
+        return self._style
 
-    def _set_style(self, style):
+    @style.setter
+    def style(self, style):
         if self._ptype != DOCGEN:
             raise ValueError("style may only be set for DOCGEN plugins")
         if not isinstance(style, bool):
             raise ValueError("Plugin must have style=True or False")
         self._style = style
 
-    def _get_style(self):
-        return self._style
+    @property
+    def extension(self):
+        return self._extension
 
-    def _set_extension(self, extension):
+    @extension.setter
+    def extension(self, extension):
         if self._ptype not in [DOCGEN, EXPORT, IMPORT]:
             raise ValueError(
                 "extension may only be set for DOCGEN/EXPORT/IMPORT plugins"
             )
         self._extension = extension
 
-    def _get_extension(self):
-        return self._extension
-
-    paper = property(_get_paper, _set_paper)
-    style = property(_get_style, _set_style)
-    extension = property(_get_extension, _set_extension)
-
     # QUICKREPORT attributes
-    def _set_runfunc(self, runfunc):
+    @property
+    def runfunc(self):
+        return self._runfunc
+
+    @runfunc.setter
+    def runfunc(self, runfunc):
         if self._ptype != QUICKREPORT:
             raise ValueError("runfunc may only be set for QUICKREPORT plugins")
         self._runfunc = runfunc
 
-    def _get_runfunc(self):
-        return self._runfunc
-
-    runfunc = property(_get_runfunc, _set_runfunc)
-
     # MAPSERVICE attributes
-    def _set_mapservice(self, mapservice):
+    @property
+    def mapservice(self):
+        return self._mapservice
+
+    @mapservice.setter
+    def mapservice(self, mapservice):
         if self._ptype != MAPSERVICE:
             raise ValueError("mapservice may only be set for MAPSERVICE plugins")
         self._mapservice = mapservice
 
-    def _get_mapservice(self):
-        return self._mapservice
-
-    mapservice = property(_get_mapservice, _set_mapservice)
-
     # EXPORT attributes
-    def _set_export_function(self, export_function):
+    @property
+    def export_function(self):
+        return self._export_function
+
+    @export_function.setter
+    def export_function(self, export_function):
         if self._ptype != EXPORT:
             raise ValueError("export_function may only be set for EXPORT plugins")
         self._export_function = export_function
 
-    def _get_export_function(self):
-        return self._export_function
+    @property
+    def export_options(self):
+        return self._export_options
 
-    def _set_export_options(self, export_options):
+    @export_options.setter
+    def export_options(self, export_options):
         if self._ptype != EXPORT:
             raise ValueError("export_options may only be set for EXPORT plugins")
         self._export_options = export_options
 
-    def _get_export_options(self):
-        return self._export_options
+    @property
+    def export_options_title(self):
+        return self._export_options_title
 
-    def _set_export_options_title(self, export_options_title):
+    @export_options_title.setter
+    def export_options_title(self, export_options_title):
         if self._ptype != EXPORT:
             raise ValueError("export_options_title may only be set for EXPORT plugins")
         self._export_options_title = export_options_title
 
-    def _get_export_options_title(self):
-        return self._export_options_title
-
-    export_function = property(_get_export_function, _set_export_function)
-    export_options = property(_get_export_options, _set_export_options)
-    export_options_title = property(
-        _get_export_options_title, _set_export_options_title
-    )
-
     # IMPORT attributes
-    def _set_import_function(self, import_function):
+    @property
+    def import_function(self):
+        return self._import_function
+
+    @import_function.setter
+    def import_function(self, import_function):
         if self._ptype != IMPORT:
             raise ValueError("import_function may only be set for IMPORT plugins")
         self._import_function = import_function
 
-    def _get_import_function(self):
-        return self._import_function
-
-    import_function = property(_get_import_function, _set_import_function)
-
     # GRAMPLET attributes
-    def _set_gramplet(self, gramplet):
+    @property
+    def gramplet(self):
+        return self._gramplet
+
+    @gramplet.setter
+    def gramplet(self, gramplet):
         if self._ptype != GRAMPLET:
             raise ValueError("gramplet may only be set for GRAMPLET plugins")
         self._gramplet = gramplet
 
-    def _get_gramplet(self):
-        return self._gramplet
+    @property
+    def height(self):
+        return self._height
 
-    def _set_height(self, height):
+    @height.setter
+    def height(self, height):
         if self._ptype != GRAMPLET:
             raise ValueError("height may only be set for GRAMPLET plugins")
         if not isinstance(height, int):
             raise ValueError("Plugin must have height an integer")
         self._height = height
 
-    def _get_height(self):
-        return self._height
+    @property
+    def detached_height(self):
+        return self._detached_height
 
-    def _set_detached_height(self, detached_height):
+    @detached_height.setter
+    def detached_height(self, detached_height):
         if self._ptype != GRAMPLET:
             raise ValueError("detached_height may only be set for GRAMPLET plugins")
         if not isinstance(detached_height, int):
             raise ValueError("Plugin must have detached_height an integer")
         self._detached_height = detached_height
 
-    def _get_detached_height(self):
-        return self._detached_height
+    @property
+    def detached_width(self):
+        return self._detached_width
 
-    def _set_detached_width(self, detached_width):
+    @detached_width.setter
+    def detached_width(self, detached_width):
         if self._ptype != GRAMPLET:
             raise ValueError("detached_width may only be set for GRAMPLET plugins")
         if not isinstance(detached_width, int):
             raise ValueError("Plugin must have detached_width an integer")
         self._detached_width = detached_width
 
-    def _get_detached_width(self):
-        return self._detached_width
+    @property
+    def expand(self):
+        return self._expand
 
-    def _set_expand(self, expand):
+    @expand.setter
+    def expand(self, expand):
         if self._ptype != GRAMPLET:
             raise ValueError("expand may only be set for GRAMPLET plugins")
         if not isinstance(expand, bool):
             raise ValueError("Plugin must have expand as a bool")
         self._expand = expand
 
-    def _get_expand(self):
-        return self._expand
+    @property
+    def gramplet_title(self):
+        return self._gramplet_title
 
-    def _set_gramplet_title(self, gramplet_title):
+    @gramplet_title.setter
+    def gramplet_title(self, gramplet_title):
         if self._ptype != GRAMPLET:
             raise ValueError("gramplet_title may only be set for GRAMPLET plugins")
         if not isinstance(gramplet_title, str):
@@ -1026,165 +1072,163 @@ class PluginData:
             )
         self._gramplet_title = gramplet_title
 
-    def _get_gramplet_title(self):
-        return self._gramplet_title
+    @property
+    def navtypes(self):
+        return self._navtypes
 
-    def _set_navtypes(self, navtypes):
+    @navtypes.setter
+    def navtypes(self, navtypes):
         if self._ptype != GRAMPLET:
             raise ValueError("navtypes may only be set for GRAMPLET plugins")
         self._navtypes = navtypes
 
-    def _get_navtypes(self):
-        return self._navtypes
+    @property
+    def orientation(self):
+        return self._orientation
 
-    def _set_orientation(self, orientation):
+    @orientation.setter
+    def orientation(self, orientation):
         if self._ptype != GRAMPLET:
             raise ValueError("orientation may only be set for GRAMPLET plugins")
         self._orientation = orientation
 
-    def _get_orientation(self):
-        return self._orientation
+    @property
+    def viewclass(self):
+        return self._viewclass
 
-    gramplet = property(_get_gramplet, _set_gramplet)
-    height = property(_get_height, _set_height)
-    detached_height = property(_get_detached_height, _set_detached_height)
-    detached_width = property(_get_detached_width, _set_detached_width)
-    expand = property(_get_expand, _set_expand)
-    gramplet_title = property(_get_gramplet_title, _set_gramplet_title)
-    navtypes = property(_get_navtypes, _set_navtypes)
-    orientation = property(_get_orientation, _set_orientation)
-
-    def _set_viewclass(self, viewclass):
+    @viewclass.setter
+    def viewclass(self, viewclass):
         if self._ptype != VIEW:
             raise ValueError("viewclass may only be set for VIEW plugins")
         self._viewclass = viewclass
 
-    def _get_viewclass(self):
-        return self._viewclass
+    @property
+    def stock_category_icon(self):
+        return self._stock_category_icon
 
-    def _set_stock_category_icon(self, stock_category_icon):
+    @stock_category_icon.setter
+    def stock_category_icon(self, stock_category_icon):
         if self._ptype != VIEW:
             raise ValueError("stock_category_icon may only be set for VIEW plugins")
         self._stock_category_icon = stock_category_icon
 
-    def _get_stock_category_icon(self):
-        return self._stock_category_icon
+    @property
+    def stock_icon(self):
+        return self._stock_icon
 
-    def _set_stock_icon(self, stock_icon):
+    @stock_icon.setter
+    def stock_icon(self, stock_icon):
         if self._ptype != VIEW:
             raise ValueError("stock_icon may only be set for VIEW plugins")
         self._stock_icon = stock_icon
 
-    def _get_stock_icon(self):
-        return self._stock_icon
-
-    viewclass = property(_get_viewclass, _set_viewclass)
-    stock_category_icon = property(_get_stock_category_icon, _set_stock_category_icon)
-    stock_icon = property(_get_stock_icon, _set_stock_icon)
-
     # SIDEBAR attributes
-    def _set_sidebarclass(self, sidebarclass):
+    @property
+    def sidebarclass(self):
+        return self._sidebarclass
+
+    @sidebarclass.setter
+    def sidebarclass(self, sidebarclass):
         if self._ptype != SIDEBAR:
             raise ValueError("sidebarclass may only be set for SIDEBAR plugins")
         self._sidebarclass = sidebarclass
 
-    def _get_sidebarclass(self):
-        return self._sidebarclass
+    @property
+    def menu_label(self):
+        return self._menu_label
 
-    def _set_menu_label(self, menu_label):
+    @menu_label.setter
+    def menu_label(self, menu_label):
         if self._ptype != SIDEBAR:
             raise ValueError("menu_label may only be set for SIDEBAR plugins")
         self._menu_label = menu_label
 
-    def _get_menu_label(self):
-        return self._menu_label
-
-    sidebarclass = property(_get_sidebarclass, _set_sidebarclass)
-    menu_label = property(_get_menu_label, _set_menu_label)
-
     # VIEW, SIDEBAR and THUMBNAILER attributes
-    def _set_order(self, order):
+    @property
+    def order(self):
+        return self._order
+
+    @order.setter
+    def order(self, order):
         if self._ptype not in [VIEW, SIDEBAR, THUMBNAILER]:
             raise ValueError(
                 "order may only be set for VIEW/SIDEBAR/THUMBNAILER plugins"
             )
         self._order = order
 
-    def _get_order(self):
-        return self._order
-
-    order = property(_get_order, _set_order)
-
     # DATABASE attributes
-    def _set_databaseclass(self, databaseclass):
+    @property
+    def databaseclass(self):
+        return self._databaseclass
+
+    @databaseclass.setter
+    def databaseclass(self, databaseclass):
         if self._ptype != DATABASE:
             raise ValueError("databaseclass may only be set for DATABASE plugins")
         self._databaseclass = databaseclass
 
-    def _get_databaseclass(self):
-        return self._databaseclass
+    @property
+    def reset_system(self):
+        return self._reset_system
 
-    def _set_reset_system(self, reset_system):
+    @reset_system.setter
+    def reset_system(self, reset_system):
         if self._ptype != DATABASE:
             raise ValueError("reset_system may only be set for DATABASE plugins")
         self._reset_system = reset_system
 
-    def _get_reset_system(self):
-        return self._reset_system
-
-    databaseclass = property(_get_databaseclass, _set_databaseclass)
-    reset_system = property(_get_reset_system, _set_reset_system)
-
     # GENERAL attr
-    def _set_data(self, data):
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, data):
         if self._ptype != GENERAL:
             raise ValueError("data may only be set for GENERAL plugins")
         self._data = data
 
-    def _get_data(self):
-        return self._data
+    @property
+    def process(self):
+        return self._process
 
-    def _set_process(self, process):
+    @process.setter
+    def process(self, process):
         if self._ptype != GENERAL:
             raise ValueError("process may only be set for GENERAL plugins")
         self._process = process
 
-    def _get_process(self):
-        return self._process
-
-    data = property(_get_data, _set_data)
-    process = property(_get_process, _set_process)
-
     # RULE attr
-    def _set_ruleclass(self, data):
+    @property
+    def ruleclass(self):
+        return self._ruleclass
+
+    @ruleclass.setter
+    def ruleclass(self, data):
         if self._ptype != RULE:
             raise ValueError("ruleclass may only be set for RULE plugins")
         self._ruleclass = data
 
-    def _get_ruleclass(self):
-        return self._ruleclass
+    @property
+    def namespace(self):
+        return self._namespace
 
-    def _set_namespace(self, data):
+    @namespace.setter
+    def namespace(self, data):
         if self._ptype != RULE:
             raise ValueError("namespace may only be set for RULE plugins")
         self._namespace = data
 
-    def _get_namespace(self):
-        return self._namespace
-
-    ruleclass = property(_get_ruleclass, _set_ruleclass)
-    namespace = property(_get_namespace, _set_namespace)
-
     # THUMBNAILER attr
-    def _set_thumbnailer(self, data):
+    @property
+    def thumbnailer(self):
+        return self._thumbnailer
+
+    @thumbnailer.setter
+    def thumbnailer(self, data):
         if self._ptype != THUMBNAILER:
             raise ValueError("thumbnailer may only be set for THUMBNAILER plugins")
         self._thumbnailer = data
-
-    def _get_thumbnailer(self):
-        return self._thumbnailer
-
-    thumbnailer = property(_get_thumbnailer, _set_thumbnailer)
 
 
 def newplugin():

--- a/gramps/gen/plug/utils.py
+++ b/gramps/gen/plug/utils.py
@@ -333,12 +333,7 @@ def load_addon_file(path, callback=None):
     """
     import tarfile
 
-    if (
-        path.startswith("http://")
-        or path.startswith("https://")
-        or path.startswith("ftp://")
-        or path.startswith("file://")
-    ):
+    if path.startswith(("http://", "https://", "ftp://", "file://")):
         try:
             fptr = urlopen_maybe_no_check_cert(path)
         except:
@@ -361,9 +356,9 @@ def load_addon_file(path, callback=None):
         return False
     fptr.close()
     # file_obj is either Zipfile or TarFile
-    if path.endswith(".zip") or path.endswith(".ZIP"):
+    if path.endswith((".zip", ".ZIP")):
         file_obj = Zipfile(buffer)
-    elif path.endswith(".tar.gz") or path.endswith(".tgz"):
+    elif path.endswith((".tar.gz", ".tgz")):
         try:
             file_obj = tarfile.open(None, fileobj=buffer)
         except:

--- a/gramps/gen/utils/grampslocale.py
+++ b/gramps/gen/utils/grampslocale.py
@@ -526,7 +526,7 @@ class GrampsLocale:
                 translator.lang = lang
                 return translator
 
-            if lang.startswith("en") or lang.startswith("C"):
+            if lang.startswith(("en", "C")):
                 translator = GrampsNullTranslations()
                 translator.lang = "en"
                 return translator

--- a/gramps/gen/utils/resourcepath.py
+++ b/gramps/gen/utils/resourcepath.py
@@ -74,7 +74,7 @@ class ResourcePath:
         package_path = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "..", "..", "..")
         )
-        installed = not os.path.exists(os.path.join(package_path, ".git"))
+        installed = not os.path.exists(os.path.join(package_path, "MANIFEST.in"))
         if installed:
             test_path = os.path.join("gramps", "authors.xml")
         else:

--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -471,12 +471,10 @@ def show_settings():
     try:
         import sqlite3
 
-        sqlite3_py_version_str = sqlite3.version
         sqlite3_version_str = sqlite3.sqlite_version
         sqlite3_location_str = sqlite3.__file__
     except:
         sqlite3_version_str = "not found"
-        sqlite3_py_version_str = "not found"
         sqlite3_location_str = "not found"
 
     try:
@@ -591,7 +589,6 @@ def show_settings():
     print("     location    : %s" % bsddb_location_str)
     print(" sqlite3   :")
     print("     version     : %s" % sqlite3_version_str)
-    print("     py version  : %s" % sqlite3_py_version_str)
     print("     location    : %s" % sqlite3_location_str)
     print("")
 

--- a/gramps/gui/aboutdialog.py
+++ b/gramps/gui/aboutdialog.py
@@ -92,10 +92,8 @@ except:
 try:
     import sqlite3
 
-    sqlite3_py_version_str = sqlite3.version
     sqlite3_version_str = sqlite3.sqlite_version
 except:
-    sqlite3_py_version_str = "not found"
     sqlite3_version_str = "not found"
 
 
@@ -154,11 +152,7 @@ class GrampsAboutDialog(Gtk.AboutDialog):
         if hasattr(os, "uname"):
             distro = "\n" + _("Distribution: %s") % ellipses(os.uname()[2])
 
-        sqlite = (
-            "sqlite"
-            + COLON
-            + " %s (%s)\n" % (sqlite3_version_str, sqlite3_py_version_str)
-        )
+        sqlite = f"sqlite{COLON} {sqlite3_version_str}\n"
 
         return (
             "\n\n"

--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -525,8 +525,9 @@ class ConfigureDialog(ManagedWindow):
             hexval = colors[scheme]
         else:
             hexval = colors
-        color = Gdk.color_parse(hexval)
-        entry = Gtk.ColorButton(color=color)
+        rgba = Gdk.RGBA()
+        rgba.parse(hexval)
+        entry = Gtk.ColorButton.new_with_rgba(rgba)
         color_hex_label = BasicLabel(hexval)
         color_hex_label.set_hexpand(True)
         entry.connect("notify::color", self.update_color, constant, color_hex_label)

--- a/gramps/gui/editors/displaytabs/addrembedlist.py
+++ b/gramps/gui/editors/displaytabs/addrembedlist.py
@@ -97,7 +97,7 @@ class AddrEmbedList(EmbeddedList):
 
     def get_icon_name(self):
         """
-        Return the stock-id icon name associated with the display tab
+        Return the icon name associated with the display tab
         """
         return "gramps-address"
 

--- a/gramps/gui/editors/displaytabs/citationembedlist.py
+++ b/gramps/gui/editors/displaytabs/citationembedlist.py
@@ -124,7 +124,7 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
 
     def get_icon_name(self):
         """
-        Return the stock-id icon name associated with the display tab
+        Return the icon name associated with the display tab
         """
         return "gramps-source"
 

--- a/gramps/gui/editors/displaytabs/notetab.py
+++ b/gramps/gui/editors/displaytabs/notetab.py
@@ -213,7 +213,7 @@ class NoteTab(EmbeddedList, DbGUIElement):
 
     def get_icon_name(self):
         """
-        Return the stock-id icon name associated with the display tab
+        Return the icon name associated with the display tab
         """
         return "gramps-notes"
 

--- a/gramps/gui/editors/editsecondary.py
+++ b/gramps/gui/editors/editsecondary.py
@@ -2,7 +2,8 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2000-2006  Donald N. Allingham
-#               2009       Gary Burton
+# Copyright (C) 2009       Gary Burton
+# Copyright (C) 2024       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,6 +28,7 @@
 from ..managedwindow import ManagedWindow
 from ..display import display_help
 from gramps.gen.config import config
+from gramps.gen.lib.serialize import to_dict, from_dict
 from ..dbguielement import DbGUIElement
 
 
@@ -35,7 +37,7 @@ class EditSecondary(ManagedWindow, DbGUIElement):
         """Create an edit window.  Associates a person with the window."""
 
         self.obj = obj
-        self.old_obj = obj.serialize()
+        self.old_obj = to_dict(obj)
         self.dbstate = state
         self.uistate = uistate
         self.db = state.db
@@ -136,7 +138,7 @@ class EditSecondary(ManagedWindow, DbGUIElement):
         """
         Undo the edits that happened on this secondary object
         """
-        self.obj.unserialize(self.old_obj)
+        self.obj = from_dict(self.old_obj)
         self.close(obj)
 
     def close(self, *obj):

--- a/gramps/gui/glade.py
+++ b/gramps/gui/glade.py
@@ -173,44 +173,36 @@ class Glade(Gtk.Builder):
                     else:
                         self.__toplevel = None
 
-    def __get_filename(self):
+    @property
+    def filename(self):
         """
-        __get_filename: return filename of glade file
+        filename: return filename of glade file
         :rtype:   string
         :returns:  filename of glade file
         """
         return self.__filename
 
-    filename = property(__get_filename)
-
-    def __get_dirname(self):
+    @property
+    def dirname(self):
         """
-        __get_dirname: return directory where glade file found
+        dirname: return directory where glade file found
         :rtype:   string
         :returns:  directory where glade file found
         """
         return self.__dirname
 
-    dirname = property(__get_dirname)
-
-    def __get_toplevel(self):
+    @property
+    def toplevel(self):
         """
-        __get_toplevel: return toplevel object
+        toplevel: return toplevel object
         :rtype:   object
         :returns:  toplevel object
         """
         return self.__toplevel
 
-    def __set_toplevel(self, toplevel):
-        """
-        __set_toplevel: set toplevel object
-
-        :type  toplevel: string
-        :param toplevel: The name of the toplevel object to use
-        """
+    @toplevel.setter
+    def toplevel(self, toplevel):
         self.__toplevel = self.get_object(toplevel)
-
-    toplevel = property(__get_toplevel, __set_toplevel)
 
     def get_child_object(self, value, toplevel=None):
         """

--- a/gramps/gui/glade/addmedia.glade
+++ b/gramps/gui/glade/addmedia.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="button81">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -36,7 +35,6 @@
             <child>
               <object class="GtkButton" id="button79">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -53,7 +51,6 @@
             <child>
               <object class="GtkButton" id="button103">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -212,7 +209,6 @@
                 <child>
                   <object class="GtkCheckButton" id="relpath">
                     <property name="label" translatable="yes">Convert to a relative path</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>

--- a/gramps/gui/glade/baseselector.glade
+++ b/gramps/gui/glade/baseselector.glade
@@ -23,7 +23,6 @@
             <child>
               <object class="GtkButton" id="cancelbutton1">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -39,7 +38,6 @@
             <child>
               <object class="GtkButton" id="okbutton1">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -55,7 +53,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -120,7 +117,6 @@
             <child>
               <object class="GtkCheckButton" id="showall">
                 <property name="label" translatable="yes">Show all</property>
-                <property name="use-action-appearance">False</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="no-show-all">True</property>

--- a/gramps/gui/glade/baseselector.glade
+++ b/gramps/gui/glade/baseselector.glade
@@ -126,7 +126,6 @@
                 <property name="no-show-all">True</property>
                 <property name="halign">center</property>
                 <property name="use-underline">True</property>
-                <property name="xalign">0.5</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>

--- a/gramps/gui/glade/book.glade
+++ b/gramps/gui/glade/book.glade
@@ -151,8 +151,8 @@
                   <object class="GtkLabel" id="title">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">12</property>
-                    <property name="margin-right">12</property>
+                    <property name="margin-start">12</property>
+                    <property name="margin-end">12</property>
                     <property name="margin-top">12</property>
                     <property name="margin-bottom">12</property>
                   </object>
@@ -174,8 +174,8 @@
                           <object class="GtkLabel" id="name_label">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="margin-left">12</property>
-                            <property name="margin-right">12</property>
+                            <property name="margin-start">12</property>
+                            <property name="margin-end">12</property>
                             <property name="label" translatable="yes">Book _name:</property>
                             <property name="use-underline">True</property>
                             <property name="mnemonic-widget">name_entry</property>
@@ -320,7 +320,7 @@
                   <object class="GtkGrid" id="table1">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">12</property>
+                    <property name="margin-start">12</property>
                     <child>
                       <object class="GtkLabel" id="avail_label">
                         <property name="visible">True</property>
@@ -391,7 +391,7 @@
                   <object class="GtkGrid" id="table2">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">12</property>
+                    <property name="margin-start">12</property>
                     <child>
                       <object class="GtkLabel" id="book_label">
                         <property name="visible">True</property>

--- a/gramps/gui/glade/clipboard.glade
+++ b/gramps/gui/glade/clipboard.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="helpbutton1">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -37,7 +36,6 @@
             <child>
               <object class="GtkButton" id="btn_clear_all">
                 <property name="label" translatable="yes">Clear _All</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -53,7 +51,6 @@
             <child>
               <object class="GtkButton" id="btn_clear">
                 <property name="label" translatable="yes">_Clear</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -70,7 +67,6 @@
             <child>
               <object class="GtkButton" id="btn_close">
                 <property name="label" translatable="yes">_Close</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/gui/glade/configure.glade
+++ b/gramps/gui/glade/configure.glade
@@ -134,8 +134,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">12</property>
-                        <property name="margin-right">12</property>
+                        <property name="margin-start">12</property>
+                        <property name="margin-end">12</property>
                         <property name="margin-top">6</property>
                         <property name="margin-bottom">6</property>
                         <property name="label" translatable="yes">The following conventions are used:

--- a/gramps/gui/glade/configure.glade
+++ b/gramps/gui/glade/configure.glade
@@ -21,7 +21,6 @@
             <child>
               <object class="GtkButton" id="cancelbutton2">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -37,7 +36,6 @@
             <child>
               <object class="GtkButton" id="okbutton2">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/gui/glade/dbman.glade
+++ b/gramps/gui/glade/dbman.glade
@@ -234,7 +234,7 @@
               <object class="GtkButtonBox" id="vbuttonbox2">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">12</property>
+                <property name="margin-start">12</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <property name="layout-style">start</property>

--- a/gramps/gui/glade/dbman.glade
+++ b/gramps/gui/glade/dbman.glade
@@ -22,7 +22,6 @@
             <child>
               <object class="GtkButton" id="okbutton3">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -132,7 +131,6 @@
             <child>
               <object class="GtkButton" id="cancel_btn">
                 <property name="label" translatable="yes">_Close Window</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -148,7 +146,6 @@
             <child>
               <object class="GtkButton" id="connect_btn">
                 <property name="label" translatable="yes">_Load Family Tree</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -164,7 +161,6 @@
             <child>
               <object class="GtkButton" id="help_btn">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -241,7 +237,6 @@
                 <child>
                   <object class="GtkButton" id="new_btn">
                     <property name="label" translatable="yes">_New</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>
@@ -272,7 +267,6 @@
                 <child>
                   <object class="GtkButton" id="remove_btn">
                     <property name="label" translatable="yes">_Delete</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>
@@ -288,7 +282,6 @@
                 <child>
                   <object class="GtkButton" id="rename_btn">
                     <property name="label" translatable="yes">_Rename</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>
@@ -304,7 +297,6 @@
                 <child>
                   <object class="GtkButton" id="close_btn">
                     <property name="label" translatable="yes">Close</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>
@@ -320,7 +312,6 @@
                 <child>
                   <object class="GtkButton" id="convert_btn">
                     <property name="label" translatable="yes">Con_vert</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>
@@ -336,7 +327,6 @@
                 <child>
                   <object class="GtkButton" id="repair_btn">
                     <property name="label" translatable="yes">Re_pair</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>
@@ -352,7 +342,6 @@
                 <child>
                   <object class="GtkButton" id="rcs_btn">
                     <property name="label" translatable="yes">_Archive</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>

--- a/gramps/gui/glade/dialog.glade
+++ b/gramps/gui/glade/dialog.glade
@@ -194,8 +194,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="use-markup">True</property>
                 <property name="wrap">True</property>
               </object>
@@ -344,8 +344,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="margin-top">24</property>
                 <property name="margin-bottom">24</property>
                 <property name="hexpand">True</property>
@@ -377,8 +377,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="hexpand">True</property>
                 <property name="use-markup">True</property>
                 <property name="wrap">True</property>
@@ -517,8 +517,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="margin-top">24</property>
                 <property name="margin-bottom">24</property>
                 <property name="hexpand">True</property>
@@ -550,8 +550,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="hexpand">True</property>
                 <property name="use-markup">True</property>
                 <property name="wrap">True</property>
@@ -667,8 +667,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="margin-top">12</property>
                 <property name="margin-bottom">12</property>
                 <property name="hexpand">True</property>
@@ -699,8 +699,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="hexpand">True</property>
                 <property name="use-markup">True</property>
                 <property name="wrap">True</property>
@@ -848,8 +848,8 @@
                   <object class="GtkLabel" id="qd_label2">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">6</property>
-                    <property name="margin-right">6</property>
+                    <property name="margin-start">6</property>
+                    <property name="margin-end">6</property>
                     <property name="margin-top">6</property>
                     <property name="margin-bottom">6</property>
                     <property name="label" translatable="yes">label</property>
@@ -964,8 +964,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="label" translatable="yes">label</property>
                 <property name="use-markup">True</property>
                 <property name="wrap">True</property>
@@ -994,8 +994,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="use-markup">True</property>
                 <property name="wrap">True</property>
               </object>

--- a/gramps/gui/glade/editattribute.glade
+++ b/gramps/gui/glade/editattribute.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -52,7 +50,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -131,7 +128,6 @@
                 </child>
                 <child>
                   <object class="GtkToggleButton" id="private">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/gui/glade/editchildref.glade
+++ b/gramps/gui/glade/editchildref.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -36,7 +35,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -56,7 +54,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -158,7 +155,6 @@
                 </child>
                 <child>
                   <object class="GtkToggleButton" id="private">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -222,7 +218,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="edit">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/gui/glade/editdate.glade
+++ b/gramps/gui/glade/editdate.glade
@@ -38,8 +38,8 @@
       <object class="GtkBox" id="vbox86">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="margin-left">12</property>
-        <property name="margin-right">12</property>
+        <property name="margin-start">12</property>
+        <property name="margin-end">12</property>
         <property name="vexpand">True</property>
         <property name="orientation">vertical</property>
         <property name="spacing">6</property>
@@ -136,7 +136,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">6</property>
+                        <property name="margin-start">6</property>
                         <property name="label" translatable="yes">Calenda_r:</property>
                         <property name="use-underline">True</property>
                         <property name="mnemonic-widget">calendar_box</property>
@@ -257,8 +257,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">6</property>
-                        <property name="margin-right">6</property>
+                        <property name="margin-start">6</property>
+                        <property name="margin-end">6</property>
                         <property name="label" translatable="yes">Q_uality</property>
                         <property name="use-underline">True</property>
                         <property name="mnemonic-widget">quality_box</property>
@@ -276,7 +276,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="events"/>
-                        <property name="margin-left">12</property>
+                        <property name="margin-start">12</property>
                         <property name="hexpand">True</property>
                       </object>
                       <packing>
@@ -289,8 +289,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">6</property>
-                        <property name="margin-right">6</property>
+                        <property name="margin-start">6</property>
+                        <property name="margin-end">6</property>
                         <property name="label" translatable="yes">_Type</property>
                         <property name="use-underline">True</property>
                         <property name="mnemonic-widget">type_box</property>
@@ -307,7 +307,7 @@
                       <object class="GtkComboBoxText" id="type_box">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">12</property>
+                        <property name="margin-start">12</property>
                         <property name="hexpand">True</property>
                       </object>
                       <packing>
@@ -320,8 +320,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">6</property>
-                        <property name="margin-right">6</property>
+                        <property name="margin-start">6</property>
+                        <property name="margin-end">6</property>
                         <property name="label" translatable="yes">Date</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
@@ -375,7 +375,7 @@
                       <object class="GtkSpinButton" id="start_day">
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
-                        <property name="margin-left">12</property>
+                        <property name="margin-start">12</property>
                         <property name="hexpand">True</property>
                         <property name="adjustment">adjustment1</property>
                         <property name="climb-rate">1</property>
@@ -416,8 +416,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">6</property>
-                        <property name="margin-right">6</property>
+                        <property name="margin-start">6</property>
+                        <property name="margin-end">6</property>
                         <property name="label" translatable="yes">Second date</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
@@ -471,7 +471,7 @@
                       <object class="GtkSpinButton" id="stop_day">
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
-                        <property name="margin-left">12</property>
+                        <property name="margin-start">12</property>
                         <property name="hexpand">True</property>
                         <property name="adjustment">adjustment3</property>
                         <property name="climb-rate">1</property>
@@ -559,7 +559,7 @@
                       <object class="GtkLabel" id="label415">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">6</property>
+                        <property name="margin-start">6</property>
                         <property name="label" translatable="yes">Te_xt comment:</property>
                         <property name="use-underline">True</property>
                         <property name="mnemonic-widget">date_text_entry</property>

--- a/gramps/gui/glade/editdate.glade
+++ b/gramps/gui/glade/editdate.glade
@@ -51,7 +51,6 @@
             <child>
               <object class="GtkButton" id="button174">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -67,7 +66,6 @@
             <child>
               <object class="GtkButton" id="button175">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -83,7 +81,6 @@
             <child>
               <object class="GtkButton" id="ok_button">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -193,7 +190,6 @@
                     <child>
                       <object class="GtkCheckButton" id="dualdated">
                         <property name="label" translatable="yes">Dua_l dated</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>

--- a/gramps/gui/glade/editevent.glade
+++ b/gramps/gui/glade/editevent.glade
@@ -415,7 +415,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
-                        <property name="margin-right">1</property>
+                        <property name="margin-end">1</property>
                         <property name="image-position">right</property>
                       </object>
                       <packing>

--- a/gramps/gui/glade/editeventref.glade
+++ b/gramps/gui/glade/editeventref.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -36,7 +35,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -52,7 +50,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -128,7 +125,6 @@
                 </child>
                 <child>
                   <object class="GtkToggleButton" id="eer_ref_priv">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -338,7 +334,6 @@
                         </child>
                         <child>
                           <object class="GtkButton" id="share_place">
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">True</property>
@@ -364,7 +359,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="add_del_place">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -383,7 +377,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="eer_date_stat">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -419,7 +412,6 @@
                     </child>
                     <child>
                       <object class="GtkToggleButton" id="eer_ev_priv">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>

--- a/gramps/gui/glade/editeventref.glade
+++ b/gramps/gui/glade/editeventref.glade
@@ -78,8 +78,8 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="halign">start</property>
-            <property name="margin-left">6</property>
-            <property name="margin-right">6</property>
+            <property name="margin-start">6</property>
+            <property name="margin-end">6</property>
             <property name="margin-top">3</property>
             <property name="margin-bottom">3</property>
             <property name="label" translatable="yes">Reference information</property>
@@ -509,7 +509,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
-                        <property name="margin-right">1</property>
+                        <property name="margin-end">1</property>
                         <property name="image-position">right</property>
                       </object>
                       <packing>

--- a/gramps/gui/glade/editfamily.glade
+++ b/gramps/gui/glade/editfamily.glade
@@ -115,7 +115,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin-left">6</property>
+                                <property name="margin-start">6</property>
                                 <property name="label" translatable="yes">Name:</property>
                               </object>
                               <packing>
@@ -128,7 +128,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin-left">6</property>
+                                <property name="margin-start">6</property>
                                 <property name="label" translatable="yes">Birth:</property>
                               </object>
                               <packing>
@@ -141,7 +141,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin-left">6</property>
+                                <property name="margin-start">6</property>
                                 <property name="label" translatable="yes">Death:</property>
                               </object>
                               <packing>
@@ -382,7 +382,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin-left">6</property>
+                                <property name="margin-start">6</property>
                                 <property name="label" translatable="yes">Name:</property>
                               </object>
                               <packing>
@@ -395,7 +395,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin-left">6</property>
+                                <property name="margin-start">6</property>
                                 <property name="label" translatable="yes">Birth:</property>
                               </object>
                               <packing>
@@ -408,7 +408,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin-left">6</property>
+                                <property name="margin-start">6</property>
                                 <property name="label" translatable="yes">Death:</property>
                               </object>
                               <packing>
@@ -693,7 +693,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">6</property>
+                        <property name="margin-start">6</property>
                         <property name="label" translatable="yes">_ID:</property>
                         <property name="use-underline">True</property>
                         <property name="mnemonic-widget">gid</property>
@@ -756,7 +756,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">6</property>
+                        <property name="margin-start">6</property>
                         <property name="label" translatable="yes">_Tags:</property>
                         <property name="use-underline">True</property>
                         <property name="mnemonic-widget">tag_button</property>

--- a/gramps/gui/glade/editfamily.glade
+++ b/gramps/gui/glade/editfamily.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -38,7 +37,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -58,7 +56,6 @@
             <child>
               <object class="GtkButton" id="button119">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -171,7 +168,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="fbutton_index">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -203,7 +199,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="fbutton_add">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -234,7 +229,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="fbutton_del">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -265,7 +259,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="fbutton_edit">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -462,7 +455,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="mbutton_index">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -493,7 +485,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="mbutton_add">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -524,7 +515,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkToggleButton" id="private">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -555,7 +545,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="mbutton_del">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -586,7 +575,6 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="mbutton_edit">
-                                    <property name="use-action-appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">True</property>
@@ -784,7 +772,6 @@
                         </child>
                         <child>
                           <object class="GtkButton" id="tag_button">
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">True</property>

--- a/gramps/gui/glade/editldsord.glade
+++ b/gramps/gui/glade/editldsord.glade
@@ -37,7 +37,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -53,7 +52,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -73,7 +71,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -139,7 +136,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="date_stat">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -243,7 +239,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="parents_select">
-                    <property name="use-action-appearance">False</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
                     <property name="tooltip-text" translatable="yes">Select Family</property>
@@ -333,7 +328,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="share_place">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -359,7 +353,6 @@
                 </child>
                 <child>
                   <object class="GtkToggleButton" id="private">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -391,7 +384,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="add_del_place">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/gui/glade/editlink.glade
+++ b/gramps/gui/glade/editlink.glade
@@ -190,7 +190,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">12</property>
+                        <property name="margin-start">12</property>
                         <property name="hexpand">True</property>
                       </object>
                     </child>

--- a/gramps/gui/glade/editlink.glade
+++ b/gramps/gui/glade/editlink.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="button125">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -36,7 +35,6 @@
             <child>
               <object class="GtkButton" id="button124">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -56,7 +54,6 @@
             <child>
               <object class="GtkButton" id="button130">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -150,7 +147,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="button1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -207,7 +203,6 @@
                 <child>
                   <object class="GtkButton" id="new">
                     <property name="label" translatable="yes">_New</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -221,7 +216,6 @@
                 <child>
                   <object class="GtkButton" id="edit">
                     <property name="label" translatable="yes">_Edit</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/gui/glade/editlocation.glade
+++ b/gramps/gui/glade/editlocation.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="button119">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="button118">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -52,7 +50,6 @@
             <child>
               <object class="GtkButton" id="button128">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/gui/glade/editmedia.glade
+++ b/gramps/gui/glade/editmedia.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="button91">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -36,7 +35,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -53,7 +51,6 @@
             <child>
               <object class="GtkButton" id="button102">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -228,7 +225,6 @@ Gramps does not store the media internally, it only stores the path! Set the 'Re
                 </child>
                 <child>
                   <object class="GtkButton" id="date_edit">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -264,7 +260,6 @@ Gramps does not store the media internally, it only stores the path! Set the 'Re
                 </child>
                 <child>
                   <object class="GtkButton" id="file_select">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -311,7 +306,6 @@ Gramps does not store the media internally, it only stores the path! Set the 'Re
                 </child>
                 <child>
                   <object class="GtkToggleButton" id="private">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -385,7 +379,6 @@ Gramps does not store the media internally, it only stores the path! Set the 'Re
                     </child>
                     <child>
                       <object class="GtkButton" id="tag_button">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>

--- a/gramps/gui/glade/editname.glade
+++ b/gramps/gui/glade/editname.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="button119">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -38,7 +37,6 @@
             <child>
               <object class="GtkButton" id="button118">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -57,7 +55,6 @@
             <child>
               <object class="GtkButton" id="button131">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -132,7 +129,6 @@
                     </child>
                     <child>
                       <object class="GtkToggleButton" id="priv">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -574,7 +570,6 @@ Here you can make sure this person is sorted according to a custom name format (
                     </child>
                     <child>
                       <object class="GtkButton" id="date_stat">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -634,7 +629,6 @@ You will be asked if you want to group this person only, or all people with this
                         <child>
                           <object class="GtkCheckButton" id="group_over">
                             <property name="label" translatable="yes">O_verride</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/editname.glade
+++ b/gramps/gui/glade/editname.glade
@@ -97,8 +97,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">4</property>
-                        <property name="margin-right">4</property>
+                        <property name="margin-start">4</property>
+                        <property name="margin-end">4</property>
                         <property name="label" translatable="yes">_Type:</property>
                         <property name="use-underline">True</property>
                         <property name="justify">center</property>
@@ -182,7 +182,7 @@
                       <object class="GtkGrid" id="table2">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">12</property>
+                        <property name="margin-start">12</property>
                         <property name="row-spacing">6</property>
                         <property name="column-spacing">6</property>
                         <child>
@@ -373,8 +373,8 @@
                       <object class="GtkBox" id="vbox1">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">12</property>
-                        <property name="margin-right">12</property>
+                        <property name="margin-start">12</property>
+                        <property name="margin-end">12</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkBox" id="hboxmultsurnames">

--- a/gramps/gui/glade/editnote.glade
+++ b/gramps/gui/glade/editnote.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -189,7 +186,6 @@
                     <child>
                       <object class="GtkCheckButton" id="format">
                         <property name="label" translatable="yes">_Preformatted</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -210,7 +206,6 @@ Use monospace font to keep preformatting.</property>
                     </child>
                     <child>
                       <object class="GtkToggleButton" id="private">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -272,7 +267,6 @@ Use monospace font to keep preformatting.</property>
                         </child>
                         <child>
                           <object class="GtkButton" id="tag_button">
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">True</property>

--- a/gramps/gui/glade/editperson.glade
+++ b/gramps/gui/glade/editperson.glade
@@ -128,8 +128,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">3</property>
-                        <property name="margin-right">3</property>
+                        <property name="margin-start">3</property>
+                        <property name="margin-end">3</property>
                         <property name="margin-top">3</property>
                         <property name="margin-bottom">3</property>
                         <property name="label" translatable="yes">_Given:</property>
@@ -191,8 +191,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">3</property>
-                        <property name="margin-right">3</property>
+                        <property name="margin-start">3</property>
+                        <property name="margin-end">3</property>
                         <property name="margin-top">3</property>
                         <property name="margin-bottom">3</property>
                         <property name="label" translatable="yes">T_itle:</property>
@@ -241,8 +241,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">3</property>
-                        <property name="margin-right">3</property>
+                        <property name="margin-start">3</property>
+                        <property name="margin-end">3</property>
                         <property name="label" translatable="yes">_Nick:</property>
                         <property name="use-underline">True</property>
                         <property name="mnemonic-widget">nickname</property>
@@ -444,8 +444,8 @@ Indicate that the surname consists of different parts. Every surname has its own
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">6</property>
-                            <property name="margin-right">6</property>
+                            <property name="margin-start">6</property>
+                            <property name="margin-end">6</property>
                             <property name="margin-top">3</property>
                             <property name="margin-bottom">3</property>
                             <property name="label" translatable="yes">_Surname:</property>
@@ -581,8 +581,8 @@ Indicate that the surname consists of different parts. Every surname has its own
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">6</property>
-                            <property name="margin-right">6</property>
+                            <property name="margin-start">6</property>
+                            <property name="margin-end">6</property>
                             <property name="label" translatable="yes">G_ender:</property>
                             <property name="use-underline">True</property>
                             <property name="mnemonic-widget">gender</property>
@@ -646,8 +646,8 @@ Indicate that the surname consists of different parts. Every surname has its own
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">6</property>
-                            <property name="margin-right">6</property>
+                            <property name="margin-start">6</property>
+                            <property name="margin-end">6</property>
                             <property name="label" translatable="yes">_Tags:</property>
                             <property name="use-underline">True</property>
                             <property name="mnemonic-widget">tag_button</property>
@@ -721,8 +721,8 @@ Indicate that the surname consists of different parts. Every surname has its own
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">3</property>
-                        <property name="margin-right">3</property>
+                        <property name="margin-start">3</property>
+                        <property name="margin-end">3</property>
                         <property name="margin-top">3</property>
                         <property name="margin-bottom">3</property>
                         <property name="label" translatable="yes">_Type:</property>
@@ -740,8 +740,8 @@ Indicate that the surname consists of different parts. Every surname has its own
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">3</property>
-                        <property name="margin-right">3</property>
+                        <property name="margin-start">3</property>
+                        <property name="margin-end">3</property>
                         <property name="margin-top">3</property>
                         <property name="margin-bottom">3</property>
                         <property name="hexpand">True</property>

--- a/gramps/gui/glade/editperson.glade
+++ b/gramps/gui/glade/editperson.glade
@@ -43,7 +43,6 @@
             <child>
               <object class="GtkButton" id="button15">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -62,7 +61,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -80,7 +78,6 @@
             <child>
               <object class="GtkButton" id="button134">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -349,7 +346,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="multsurnamebtn">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -393,7 +389,6 @@ Indicate that the surname consists of different parts. Every surname has its own
                         </child>
                         <child>
                           <object class="GtkToggleButton" id="private">
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">True</property>
@@ -505,7 +500,6 @@ Indicate that the surname consists of different parts. Every surname has its own
                     </child>
                     <child>
                       <object class="GtkButton" id="editnamebtn">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -671,7 +665,6 @@ Indicate that the surname consists of different parts. Every surname has its own
                         </child>
                         <child>
                           <object class="GtkButton" id="tag_button">
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">True</property>

--- a/gramps/gui/glade/editpersonref.glade
+++ b/gramps/gui/glade/editpersonref.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -55,7 +53,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -156,7 +153,6 @@ Note: Use Events instead for relations connected to specific time frames or occa
                 </child>
                 <child>
                   <object class="GtkButton" id="select">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -190,7 +186,6 @@ Note: Use Events instead for relations connected to specific time frames or occa
                 </child>
                 <child>
                   <object class="GtkToggleButton" id="private">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -222,7 +217,6 @@ Note: Use Events instead for relations connected to specific time frames or occa
                 </child>
                 <child>
                   <object class="GtkButton" id="add_del">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/gui/glade/editplaceref.glade
+++ b/gramps/gui/glade/editplaceref.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -37,7 +36,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -53,7 +51,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/gui/glade/editplaceref.glade
+++ b/gramps/gui/glade/editplaceref.glade
@@ -79,8 +79,8 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="halign">start</property>
-            <property name="margin-left">6</property>
-            <property name="margin-right">6</property>
+            <property name="margin-start">6</property>
+            <property name="margin-end">6</property>
             <property name="margin-top">3</property>
             <property name="margin-bottom">3</property>
             <property name="label" translatable="yes">Reference information</property>

--- a/gramps/gui/glade/editreporef.glade
+++ b/gramps/gui/glade/editreporef.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -39,7 +38,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -59,7 +57,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -172,7 +169,6 @@
                     </child>
                     <child>
                       <object class="GtkToggleButton" id="private_ref">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
@@ -391,7 +387,6 @@
                             </child>
                             <child>
                               <object class="GtkToggleButton" id="private">
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">True</property>

--- a/gramps/gui/glade/editreporef.glade
+++ b/gramps/gui/glade/editreporef.glade
@@ -90,8 +90,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="margin-top">3</property>
                 <property name="margin-bottom">3</property>
                 <property name="label" translatable="yes">Reference information</property>

--- a/gramps/gui/glade/editurl.glade
+++ b/gramps/gui/glade/editurl.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="button125">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="button124">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -55,7 +53,6 @@
             <child>
               <object class="GtkButton" id="button130">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -135,7 +132,6 @@
                 </child>
                 <child>
                   <object class="GtkToggleButton" id="priv">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -199,7 +195,6 @@
                 <child>
                   <object class="GtkButton" id="jump">
                     <property name="label" translatable="yes">_Jump to</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/gui/glade/grampletpane.glade
+++ b/gramps/gui/glade/grampletpane.glade
@@ -54,7 +54,6 @@
                 <property name="can-focus">False</property>
                 <child>
                   <object class="GtkButton" id="gvproperties">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -87,7 +86,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="gvstate">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -120,7 +118,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="gvclose">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -154,7 +151,6 @@
                 <child>
                   <object class="GtkButton" id="gvtitle">
                     <property name="label" translatable="yes">Gramplet</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/gui/glade/mergecitation.glade
+++ b/gramps/gui/glade/mergecitation.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="citation_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="citation_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="citation_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -110,7 +107,6 @@ primary data for the merged citation.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -133,7 +129,6 @@ primary data for the merged citation.</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -211,7 +206,6 @@ primary data for the merged citation.</property>
                         <child>
                           <object class="GtkRadioButton" id="page_btn1">
                             <property name="label" translatable="yes">Volume/Page:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -227,7 +221,6 @@ primary data for the merged citation.</property>
                         <child>
                           <object class="GtkRadioButton" id="page_btn2">
                             <property name="label" translatable="yes">Volume/Page:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -244,7 +237,6 @@ primary data for the merged citation.</property>
                         <child>
                           <object class="GtkRadioButton" id="date_btn1">
                             <property name="label" translatable="yes">Date:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -260,7 +252,6 @@ primary data for the merged citation.</property>
                         <child>
                           <object class="GtkRadioButton" id="date_btn2">
                             <property name="label" translatable="yes">Date:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -277,7 +268,6 @@ primary data for the merged citation.</property>
                         <child>
                           <object class="GtkRadioButton" id="confidence_btn1">
                             <property name="label" translatable="yes">Confidence:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -293,7 +283,6 @@ primary data for the merged citation.</property>
                         <child>
                           <object class="GtkRadioButton" id="confidence_btn2">
                             <property name="label" translatable="yes">Confidence:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -310,7 +299,6 @@ primary data for the merged citation.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn1">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -326,7 +314,6 @@ primary data for the merged citation.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn2">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/mergedata.glade
+++ b/gramps/gui/glade/mergedata.glade
@@ -23,7 +23,6 @@
             <child>
               <object class="GtkButton" id="merge_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -40,7 +39,6 @@
             <child>
               <object class="GtkButton" id="edit">
                 <property name="label" translatable="yes">Merge and _edit</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">True</property>
@@ -58,7 +56,6 @@
             <child>
               <object class="GtkButton" id="close">
                 <property name="label" translatable="yes">_Merge and close</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -75,7 +72,6 @@
             <child>
               <object class="GtkButton" id="merge_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -172,7 +168,6 @@
                 <child>
                   <object class="GtkRadioButton" id="select2">
                     <property name="label" translatable="yes">Select</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -188,7 +183,6 @@
                 <child>
                   <object class="GtkRadioButton" id="select1">
                     <property name="label" translatable="yes">Select</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -260,7 +254,6 @@
             <child>
               <object class="GtkButton" id="button15">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -276,7 +269,6 @@
             <child>
               <object class="GtkButton" id="button16">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -292,7 +284,6 @@
             <child>
               <object class="GtkButton" id="people_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -378,7 +369,6 @@
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="person1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -394,7 +384,6 @@
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="person2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -464,7 +453,6 @@
             <child>
               <object class="GtkButton" id="place_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -481,7 +469,6 @@
             <child>
               <object class="GtkButton" id="place_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -498,7 +485,6 @@
             <child>
               <object class="GtkButton" id="place_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -607,7 +593,6 @@
                 <child>
                   <object class="GtkRadioButton" id="place1">
                     <property name="label" translatable="yes">Place 1</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -624,7 +609,6 @@
                 <child>
                   <object class="GtkRadioButton" id="place2">
                     <property name="label" translatable="yes">Place 2</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -641,7 +625,6 @@
                 <child>
                   <object class="GtkRadioButton" id="place3">
                     <property name="label" translatable="yes">Other</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -709,7 +692,6 @@
             <child>
               <object class="GtkButton" id="source_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -725,7 +707,6 @@
             <child>
               <object class="GtkButton" id="source_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -741,7 +722,6 @@
             <child>
               <object class="GtkButton" id="source_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -803,7 +783,6 @@
             <child>
               <object class="GtkRadioButton" id="title_btn1">
                 <property name="label" translatable="yes">Title:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -819,7 +798,6 @@
             <child>
               <object class="GtkRadioButton" id="title_btn2">
                 <property name="label" translatable="yes">Title:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -836,7 +814,6 @@
             <child>
               <object class="GtkRadioButton" id="author_btn1">
                 <property name="label" translatable="yes">Author:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -852,7 +829,6 @@
             <child>
               <object class="GtkRadioButton" id="radiobutton4">
                 <property name="label" translatable="yes">Author:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -869,7 +845,6 @@
             <child>
               <object class="GtkRadioButton" id="abbrev_btn1">
                 <property name="label" translatable="yes">Abbreviation:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -885,7 +860,6 @@
             <child>
               <object class="GtkRadioButton" id="abbrev_btn2">
                 <property name="label" translatable="yes">Abbreviation:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -902,7 +876,6 @@
             <child>
               <object class="GtkRadioButton" id="pub_btn1">
                 <property name="label" translatable="yes">Publication:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -918,7 +891,6 @@
             <child>
               <object class="GtkRadioButton" id="pub_btn2">
                 <property name="label" translatable="yes">Publication:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -935,7 +907,6 @@
             <child>
               <object class="GtkRadioButton" id="gramps_btn1">
                 <property name="label" translatable="yes">Gramps ID:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
@@ -951,7 +922,6 @@
             <child>
               <object class="GtkRadioButton" id="gramps_btn2">
                 <property name="label" translatable="yes">Gramps ID:</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>

--- a/gramps/gui/glade/mergeevent.glade
+++ b/gramps/gui/glade/mergeevent.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="event_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="event_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="event_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -110,7 +107,6 @@ primary data for the merged event.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -133,7 +129,6 @@ primary data for the merged event.</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -211,7 +206,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="type_btn1">
                             <property name="label" translatable="yes">Type:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -227,7 +221,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="type_btn2">
                             <property name="label" translatable="yes">Type:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -244,7 +237,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="date_btn1">
                             <property name="label" translatable="yes">Date:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -260,7 +252,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="date_btn2">
                             <property name="label" translatable="yes">Date:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -277,7 +268,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="place_btn1">
                             <property name="label" translatable="yes">Place:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -293,7 +283,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="place_btn2">
                             <property name="label" translatable="yes">Place:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -310,7 +299,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="desc_btn1">
                             <property name="label" translatable="yes">Description:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -326,7 +314,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="desc_btn2">
                             <property name="label" translatable="yes">Description:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -343,7 +330,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn1">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -359,7 +345,6 @@ primary data for the merged event.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn2">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/mergefamily.glade
+++ b/gramps/gui/glade/mergefamily.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="family_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="family_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="family_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -111,7 +108,6 @@ primary data for the merged family.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -135,7 +131,6 @@ primary data for the merged family.</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -186,7 +181,6 @@ primary data for the merged family.</property>
                         <child>
                           <object class="GtkRadioButton" id="father_btn1">
                             <property name="label" translatable="yes">Father:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -202,7 +196,6 @@ primary data for the merged family.</property>
                         <child>
                           <object class="GtkRadioButton" id="father_btn2">
                             <property name="label" translatable="yes">Father:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -219,7 +212,6 @@ primary data for the merged family.</property>
                         <child>
                           <object class="GtkRadioButton" id="mother_btn1">
                             <property name="label" translatable="yes">Mother:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -235,7 +227,6 @@ primary data for the merged family.</property>
                         <child>
                           <object class="GtkRadioButton" id="mother_btn2">
                             <property name="label" translatable="yes">Mother:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -252,7 +243,6 @@ primary data for the merged family.</property>
                         <child>
                           <object class="GtkRadioButton" id="rel_btn1">
                             <property name="label" translatable="yes">Relationship:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -268,7 +258,6 @@ primary data for the merged family.</property>
                         <child>
                           <object class="GtkRadioButton" id="rel_btn2">
                             <property name="label" translatable="yes">Relationship:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -285,7 +274,6 @@ primary data for the merged family.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn1">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -301,7 +289,6 @@ primary data for the merged family.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn2">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/mergemedia.glade
+++ b/gramps/gui/glade/mergemedia.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="object_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="object_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="object_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -110,7 +107,6 @@ primary data for the merged object.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -133,7 +129,6 @@ primary data for the merged object.</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -211,7 +206,6 @@ primary data for the merged object.</property>
                         <child>
                           <object class="GtkRadioButton" id="desc_btn1">
                             <property name="label" translatable="yes">Title:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -227,7 +221,6 @@ primary data for the merged object.</property>
                         <child>
                           <object class="GtkRadioButton" id="desc_btn2">
                             <property name="label" translatable="yes">Title:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -244,7 +237,6 @@ primary data for the merged object.</property>
                         <child>
                           <object class="GtkRadioButton" id="path_btn1">
                             <property name="label" translatable="yes">Path:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -260,7 +252,6 @@ primary data for the merged object.</property>
                         <child>
                           <object class="GtkRadioButton" id="path_btn2">
                             <property name="label" translatable="yes">Path:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -277,7 +268,6 @@ primary data for the merged object.</property>
                         <child>
                           <object class="GtkRadioButton" id="date_btn1">
                             <property name="label" translatable="yes">Date:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -293,7 +283,6 @@ primary data for the merged object.</property>
                         <child>
                           <object class="GtkRadioButton" id="date_btn2">
                             <property name="label" translatable="yes">Date:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -310,7 +299,6 @@ primary data for the merged object.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn1">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -326,7 +314,6 @@ primary data for the merged object.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn2">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/mergenote.glade
+++ b/gramps/gui/glade/mergenote.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="note_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="note_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="note_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -110,7 +107,6 @@ primary data for the merged note.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -133,7 +129,6 @@ primary data for the merged note.</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -211,7 +206,6 @@ primary data for the merged note.</property>
                         <child>
                           <object class="GtkRadioButton" id="text_btn1">
                             <property name="label" translatable="yes">Text:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -227,7 +221,6 @@ primary data for the merged note.</property>
                         <child>
                           <object class="GtkRadioButton" id="text_btn2">
                             <property name="label" translatable="yes">Text:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -244,7 +237,6 @@ primary data for the merged note.</property>
                         <child>
                           <object class="GtkRadioButton" id="type_btn1">
                             <property name="label" translatable="yes">Type:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -260,7 +252,6 @@ primary data for the merged note.</property>
                         <child>
                           <object class="GtkRadioButton" id="type_btn2">
                             <property name="label" translatable="yes">Type:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -277,7 +268,6 @@ primary data for the merged note.</property>
                         <child>
                           <object class="GtkRadioButton" id="format_btn1">
                             <property name="label" translatable="yes">Format:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -293,7 +283,6 @@ primary data for the merged note.</property>
                         <child>
                           <object class="GtkRadioButton" id="format_btn2">
                             <property name="label" translatable="yes">Format:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -310,7 +299,6 @@ primary data for the merged note.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn1">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -326,7 +314,6 @@ primary data for the merged note.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn2">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/mergeperson.glade
+++ b/gramps/gui/glade/mergeperson.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="person_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="person_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="person_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -116,7 +113,6 @@ primary data for the merged person.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -141,7 +137,6 @@ primary data for the merged person.</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -221,7 +216,6 @@ primary data for the merged person.</property>
                         <child>
                           <object class="GtkRadioButton" id="name_btn1">
                             <property name="label" translatable="yes">Name:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -237,7 +231,6 @@ primary data for the merged person.</property>
                         <child>
                           <object class="GtkRadioButton" id="name_btn2">
                             <property name="label" translatable="yes">Name:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -254,7 +247,6 @@ primary data for the merged person.</property>
                         <child>
                           <object class="GtkRadioButton" id="gender_btn1">
                             <property name="label" translatable="yes">Gender:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -270,7 +262,6 @@ primary data for the merged person.</property>
                         <child>
                           <object class="GtkRadioButton" id="gender_btn2">
                             <property name="label" translatable="yes">Gender:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -287,7 +278,6 @@ primary data for the merged person.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn1">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -303,7 +293,6 @@ primary data for the merged person.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn2">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/mergerepository.glade
+++ b/gramps/gui/glade/mergerepository.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="repository_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="repository_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="repository_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -110,7 +107,6 @@ primary data for the merged repository.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -133,7 +129,6 @@ primary data for the merged repository.</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -211,7 +206,6 @@ primary data for the merged repository.</property>
                         <child>
                           <object class="GtkRadioButton" id="name_btn1">
                             <property name="label" translatable="yes" context="repo">Name:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -227,7 +221,6 @@ primary data for the merged repository.</property>
                         <child>
                           <object class="GtkRadioButton" id="name_btn2">
                             <property name="label" translatable="yes" context="repo">Name:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -244,7 +237,6 @@ primary data for the merged repository.</property>
                         <child>
                           <object class="GtkRadioButton" id="type_btn1">
                             <property name="label" translatable="yes">Type:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -260,7 +252,6 @@ primary data for the merged repository.</property>
                         <child>
                           <object class="GtkRadioButton" id="type_btn2">
                             <property name="label" translatable="yes">Type:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -277,7 +268,6 @@ primary data for the merged repository.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn1">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -293,7 +283,6 @@ primary data for the merged repository.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn2">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/mergesource.glade
+++ b/gramps/gui/glade/mergesource.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="source_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="source_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="source_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -110,7 +107,6 @@ primary data for the merged source.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn1">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -133,7 +129,6 @@ primary data for the merged source.</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="handle_btn2">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -211,7 +206,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="title_btn1">
                             <property name="label" translatable="yes">Title:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -227,7 +221,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="title_btn2">
                             <property name="label" translatable="yes">Title:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -244,7 +237,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="author_btn1">
                             <property name="label" translatable="yes">Author:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -260,7 +252,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="author_btn2">
                             <property name="label" translatable="yes">Author:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -277,7 +268,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="abbrev_btn1">
                             <property name="label" translatable="yes">Abbreviation:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -293,7 +283,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="abbrev_btn2">
                             <property name="label" translatable="yes">Abbreviation:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -310,7 +299,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="pub_btn1">
                             <property name="label" translatable="yes">Publication:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -326,7 +314,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="pub_btn2">
                             <property name="label" translatable="yes">Publication:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -343,7 +330,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn1">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -359,7 +345,6 @@ primary data for the merged source.</property>
                         <child>
                           <object class="GtkRadioButton" id="gramps_btn2">
                             <property name="label" translatable="yes">Gramps ID:</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/papermenu.glade
+++ b/gramps/gui/glade/papermenu.glade
@@ -35,7 +35,7 @@
               <object class="GtkGrid" id="format_grid">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">12</property>
+                <property name="margin-start">12</property>
                 <property name="border-width">6</property>
                 <property name="row-spacing">6</property>
                 <property name="column-spacing">6</property>
@@ -192,7 +192,7 @@
               <object class="GtkGrid" id="table3">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">12</property>
+                <property name="margin-start">12</property>
                 <property name="border-width">6</property>
                 <property name="row-spacing">6</property>
                 <property name="column-spacing">6</property>

--- a/gramps/gui/glade/papermenu.glade
+++ b/gramps/gui/glade/papermenu.glade
@@ -377,7 +377,6 @@
             <child>
               <object class="GtkCheckButton" id="metric">
                 <property name="label" translatable="yes">Metric</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>

--- a/gramps/gui/glade/plugins.glade
+++ b/gramps/gui/glade/plugins.glade
@@ -105,8 +105,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">10</property>
-                        <property name="margin-right">10</property>
+                        <property name="margin-start">10</property>
+                        <property name="margin-end">10</property>
                         <property name="margin-top">10</property>
                         <property name="margin-bottom">10</property>
                         <property name="use-markup">True</property>
@@ -132,8 +132,8 @@
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
                     <property name="valign">start</property>
-                    <property name="margin-left">10</property>
-                    <property name="margin-right">10</property>
+                    <property name="margin-start">10</property>
+                    <property name="margin-end">10</property>
                     <property name="margin-top">20</property>
                     <property name="margin-bottom">20</property>
                     <property name="label" translatable="yes">Select a report from those available on the left.</property>
@@ -154,8 +154,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">end</property>
-                        <property name="margin-left">6</property>
-                        <property name="margin-right">6</property>
+                        <property name="margin-start">6</property>
+                        <property name="margin-end">6</property>
                         <property name="margin-top">3</property>
                         <property name="margin-bottom">3</property>
                         <property name="label" translatable="yes">Status:</property>
@@ -171,8 +171,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">5</property>
-                        <property name="margin-right">5</property>
+                        <property name="margin-start">5</property>
+                        <property name="margin-end">5</property>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
@@ -184,8 +184,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">end</property>
-                        <property name="margin-left">6</property>
-                        <property name="margin-right">6</property>
+                        <property name="margin-start">6</property>
+                        <property name="margin-end">6</property>
                         <property name="margin-top">3</property>
                         <property name="margin-bottom">3</property>
                         <property name="label" translatable="yes">Author:</property>
@@ -200,8 +200,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">end</property>
-                        <property name="margin-left">6</property>
-                        <property name="margin-right">6</property>
+                        <property name="margin-start">6</property>
+                        <property name="margin-end">6</property>
                         <property name="margin-top">3</property>
                         <property name="margin-bottom">3</property>
                         <property name="label" translatable="yes">Author's email:</property>
@@ -216,8 +216,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">5</property>
-                        <property name="margin-right">5</property>
+                        <property name="margin-start">5</property>
+                        <property name="margin-end">5</property>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
@@ -229,8 +229,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">5</property>
-                        <property name="margin-right">5</property>
+                        <property name="margin-start">5</property>
+                        <property name="margin-end">5</property>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>

--- a/gramps/gui/glade/plugins.glade
+++ b/gramps/gui/glade/plugins.glade
@@ -20,7 +20,6 @@
             <child>
               <object class="GtkButton" id="button108">
                 <property name="label" translatable="yes">_Close</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -36,7 +35,6 @@
             </child>
             <child>
               <object class="GtkButton" id="apply">
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/gui/glade/reorder.glade
+++ b/gramps/gui/glade/reorder.glade
@@ -172,7 +172,7 @@
               <object class="GtkScrolledWindow" id="scrolledwindow86">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
-                <property name="margin-left">6</property>
+                <property name="margin-start">6</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
                 <property name="shadow-type">in</property>
@@ -210,7 +210,7 @@
               <object class="GtkScrolledWindow" id="scrolledwindow87">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
-                <property name="margin-left">6</property>
+                <property name="margin-start">6</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
                 <property name="shadow-type">in</property>

--- a/gramps/gui/glade/reorder.glade
+++ b/gramps/gui/glade/reorder.glade
@@ -19,7 +19,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -35,7 +34,6 @@
             <child>
               <object class="GtkButton" id="ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -51,7 +49,6 @@
             <child>
               <object class="GtkButton" id="help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -101,7 +98,6 @@
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkButton" id="pup">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -131,7 +127,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="pdown">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -236,7 +231,6 @@
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkButton" id="fup">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -266,7 +260,6 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="fdown">
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/gui/glade/rule.glade
+++ b/gramps/gui/glade/rule.glade
@@ -915,7 +915,6 @@
                         <property name="label" translatable="yes">No rule selected</property>
                         <property name="wrap">True</property>
                         <property name="width-chars">40</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -951,7 +950,6 @@
                         <property name="label" translatable="yes">No description</property>
                         <property name="wrap">True</property>
                         <property name="width-chars">40</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/gramps/gui/glade/rule.glade
+++ b/gramps/gui/glade/rule.glade
@@ -22,7 +22,6 @@
             <child>
               <object class="GtkButton" id="filter_list_close">
                 <property name="label" translatable="yes">_Close</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -39,7 +38,6 @@
             <child>
               <object class="GtkButton" id="filter_list_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -114,7 +112,6 @@
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkButton" id="filter_list_add">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="can-default">True</property>
@@ -137,7 +134,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="filter_list_edit">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
                         <property name="can-focus">True</property>
@@ -161,7 +157,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="filter_list_clone">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
                         <property name="can-focus">True</property>
@@ -185,7 +180,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="filter_list_test">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -207,7 +201,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="filter_list_delete">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
                         <property name="can-focus">True</property>
@@ -314,7 +307,6 @@
             <child>
               <object class="GtkButton" id="definition_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -331,7 +323,6 @@
             <child>
               <object class="GtkButton" id="definition_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">True</property>
@@ -349,7 +340,6 @@
             <child>
               <object class="GtkButton" id="definition_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -406,7 +396,6 @@
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkButton" id="definition_add">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="can-default">True</property>
@@ -439,7 +428,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="definition_edit">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
                         <property name="can-focus">True</property>
@@ -473,7 +461,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="definition_delete">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="sensitive">False</property>
                         <property name="can-focus">True</property>
@@ -602,7 +589,6 @@
                 <child>
                   <object class="GtkCheckButton" id="logical_not">
                     <property name="label" translatable="yes">Return values that do no_t match the filter rules</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -746,7 +732,6 @@
             <child>
               <object class="GtkButton" id="rule_editor_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -763,7 +748,6 @@
             <child>
               <object class="GtkButton" id="rule_editor_ok">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -780,7 +764,6 @@
             <child>
               <object class="GtkButton" id="rule_editor_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -1021,7 +1004,6 @@
             <child>
               <object class="GtkButton" id="test_close">
                 <property name="label" translatable="yes">_Close</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/gui/glade/rule.glade
+++ b/gramps/gui/glade/rule.glade
@@ -251,8 +251,8 @@
               <object class="GtkLabel" id="label30">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="label" translatable="yes">Note: changes take effect only after this window is closed</property>
                 <attributes>
                   <attribute name="style" value="italic"/>
@@ -564,8 +564,8 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
-                    <property name="margin-left">6</property>
-                    <property name="margin-right">6</property>
+                    <property name="margin-start">6</property>
+                    <property name="margin-end">6</property>
                     <property name="label" translatable="yes">Co_mment:</property>
                     <property name="use-underline">True</property>
                     <property name="mnemonic-widget">comment</property>
@@ -579,7 +579,7 @@
                   <object class="GtkScrolledWindow" id="scrolledwindow1">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">6</property>
+                    <property name="margin-start">6</property>
                     <property name="shadow-type">in</property>
                     <child>
                       <object class="PersistentTreeView" id="rule_list">
@@ -607,7 +607,7 @@
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="halign">center</property>
-                    <property name="margin-left">6</property>
+                    <property name="margin-start">6</property>
                     <property name="use-underline">True</property>
                     <property name="draw-indicator">True</property>
                   </object>
@@ -621,7 +621,7 @@
                   <object class="GtkComboBox" id="rule_apply">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">6</property>
+                    <property name="margin-start">6</property>
                     <property name="model">model1</property>
                     <child>
                       <object class="GtkCellRendererText" id="renderer1"/>
@@ -652,8 +652,8 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
-                    <property name="margin-left">6</property>
-                    <property name="margin-right">6</property>
+                    <property name="margin-start">6</property>
+                    <property name="margin-end">6</property>
                     <property name="label" translatable="yes">_Name:</property>
                     <property name="use-underline">True</property>
                     <property name="mnemonic-widget">filter_name</property>
@@ -910,8 +910,8 @@
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="valign">start</property>
-                        <property name="margin-left">12</property>
-                        <property name="margin-right">12</property>
+                        <property name="margin-start">12</property>
+                        <property name="margin-end">12</property>
                         <property name="label" translatable="yes">No rule selected</property>
                         <property name="wrap">True</property>
                         <property name="width-chars">40</property>
@@ -946,8 +946,8 @@
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="valign">start</property>
-                        <property name="margin-left">12</property>
-                        <property name="margin-right">12</property>
+                        <property name="margin-start">12</property>
+                        <property name="margin-end">12</property>
                         <property name="label" translatable="yes">No description</property>
                         <property name="wrap">True</property>
                         <property name="width-chars">40</property>

--- a/gramps/gui/glade/styleeditor.glade
+++ b/gramps/gui/glade/styleeditor.glade
@@ -84,7 +84,6 @@
             <child>
               <object class="GtkButton" id="button8">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -101,7 +100,6 @@
             <child>
               <object class="GtkButton" id="button7">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -314,7 +312,6 @@
                         <child>
                           <object class="GtkRadioButton" id="roman">
                             <property name="label" translatable="yes">_Roman (Times, serif)</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -331,7 +328,6 @@
                         <child>
                           <object class="GtkRadioButton" id="swiss">
                             <property name="label" translatable="yes">_Swiss (Arial, Helvetica, sans-serif)</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -431,7 +427,6 @@
                         <child>
                           <object class="GtkCheckButton" id="bold">
                             <property name="label" translatable="yes">_Bold</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -448,7 +443,6 @@
                         <child>
                           <object class="GtkCheckButton" id="italic">
                             <property name="label" translatable="yes">_Italic</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -465,7 +459,6 @@
                         <child>
                           <object class="GtkCheckButton" id="underline">
                             <property name="label" translatable="yes">_Underline</property>
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -493,7 +486,6 @@
                         </child>
                         <child>
                           <object class="GtkColorButton" id="color">
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -954,7 +946,6 @@
                         </child>
                         <child>
                           <object class="GtkColorButton" id="bgcolor">
-                            <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -973,7 +964,6 @@
                             <child>
                               <object class="GtkRadioButton" id="lalign">
                                 <property name="label" translatable="yes">_Left</property>
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
@@ -991,7 +981,6 @@
                             <child>
                               <object class="GtkRadioButton" id="ralign">
                                 <property name="label" translatable="yes">_Right</property>
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
@@ -1009,7 +998,6 @@
                             <child>
                               <object class="GtkRadioButton" id="jalign">
                                 <property name="label" translatable="yes">J_ustify</property>
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
@@ -1027,7 +1015,6 @@
                             <child>
                               <object class="GtkRadioButton" id="calign">
                                 <property name="label" translatable="yes">Cen_ter</property>
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
@@ -1057,7 +1044,6 @@
                             <child>
                               <object class="GtkCheckButton" id="lborder">
                                 <property name="label" translatable="yes">Le_ft</property>
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
@@ -1075,7 +1061,6 @@
                             <child>
                               <object class="GtkCheckButton" id="rborder">
                                 <property name="label" translatable="yes">Righ_t</property>
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
@@ -1092,7 +1077,6 @@
                             <child>
                               <object class="GtkCheckButton" id="tborder">
                                 <property name="label" translatable="yes">_Top</property>
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
@@ -1109,7 +1093,6 @@
                             <child>
                               <object class="GtkCheckButton" id="bborder">
                                 <property name="label" translatable="yes">_Bottom</property>
-                                <property name="use-action-appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
@@ -1785,7 +1768,6 @@
             <child>
               <object class="GtkButton" id="button2">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -1802,7 +1784,6 @@
             <child>
               <object class="GtkButton" id="button1">
                 <property name="label" translatable="yes">_OK</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -1898,7 +1879,6 @@
                     <property name="layout-style">start</property>
                     <child>
                       <object class="GtkButton" id="button3">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -1930,7 +1910,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="button4">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -1962,7 +1941,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="button5">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>

--- a/gramps/gui/glade/styleeditor.glade
+++ b/gramps/gui/glade/styleeditor.glade
@@ -149,8 +149,8 @@
               <object class="GtkLabel" id="title1">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
-                <property name="margin-right">5</property>
+                <property name="margin-start">5</property>
+                <property name="margin-end">5</property>
                 <property name="margin-top">5</property>
                 <property name="margin-bottom">5</property>
                 <property name="use-markup">True</property>
@@ -319,7 +319,7 @@
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
                           </object>
@@ -336,7 +336,7 @@
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
                             <property name="group">roman</property>
@@ -368,7 +368,7 @@
                           <object class="GtkSpinButton" id="size">
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="adjustment">adjustment7</property>
                             <property name="climb-rate">1</property>
                             <property name="numeric">True</property>
@@ -436,7 +436,7 @@
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
                           </object>
@@ -453,7 +453,7 @@
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
                           </object>
@@ -470,7 +470,7 @@
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="use-underline">True</property>
                             <property name="draw-indicator">True</property>
                           </object>
@@ -497,7 +497,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
@@ -634,7 +634,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">First li_ne:</property>
                             <property name="use-underline">True</property>
                             <property name="justify">center</property>
@@ -689,7 +689,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">R_ight:</property>
                             <property name="use-underline">True</property>
                             <property name="justify">center</property>
@@ -705,7 +705,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">L_eft:</property>
                             <property name="use-underline">True</property>
                             <property name="justify">center</property>
@@ -740,7 +740,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">Abo_ve:</property>
                             <property name="use-underline">True</property>
                             <property name="justify">center</property>
@@ -756,7 +756,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">Belo_w:</property>
                             <property name="use-underline">True</property>
                             <property name="justify">center</property>
@@ -887,7 +887,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">_Padding:</property>
                             <property name="use-underline">True</property>
                             <property name="justify">center</property>
@@ -958,7 +958,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
@@ -978,7 +978,7 @@
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
                                 <property name="halign">center</property>
-                                <property name="margin-left">12</property>
+                                <property name="margin-start">12</property>
                                 <property name="use-underline">True</property>
                                 <property name="draw-indicator">True</property>
                               </object>
@@ -1062,7 +1062,7 @@
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
                                 <property name="halign">center</property>
-                                <property name="margin-left">12</property>
+                                <property name="margin-start">12</property>
                                 <property name="use-underline">True</property>
                                 <property name="draw-indicator">True</property>
                               </object>
@@ -1224,7 +1224,7 @@
                           <object class="GtkBox" id="column_widths">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <placeholder/>
@@ -1239,7 +1239,7 @@
                           <object class="GtkSpinButton" id="table_width">
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="shadow-type">etched-out</property>
                             <property name="adjustment">adjustment8</property>
                             <property name="numeric">True</property>
@@ -1348,7 +1348,7 @@
                           <object class="GtkLabel" id="label29">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">Padding:</property>
                           </object>
                           <packing>
@@ -1379,7 +1379,7 @@
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin-left">12</property>
+                                <property name="margin-start">12</property>
                                 <property name="draw-indicator">True</property>
                               </object>
                               <packing>
@@ -1514,7 +1514,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">Style:</property>
                           </object>
                           <packing>
@@ -1527,7 +1527,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">Width:</property>
                           </object>
                           <packing>
@@ -1540,7 +1540,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">Line:</property>
                           </object>
                           <packing>
@@ -1553,7 +1553,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">Fill:</property>
                           </object>
                           <packing>
@@ -1667,7 +1667,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-left">12</property>
+                            <property name="margin-start">12</property>
                             <property name="label" translatable="yes">Spacing:</property>
                           </object>
                           <packing>

--- a/gramps/gui/glade/styleeditor.glade
+++ b/gramps/gui/glade/styleeditor.glade
@@ -118,11 +118,11 @@
             </child>
             <child>
               <object class="GtkButton" id="help_btn">
-                <property name="label">gtk-help</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_btn_style_clicked" swapped="no"/>
               </object>
               <packing>
@@ -1819,11 +1819,11 @@
             </child>
             <child>
               <object class="GtkButton" id="help_btn_styles">
-                <property name="label">gtk-help</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_btn_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gramps/gui/glade/tipofday.glade
+++ b/gramps/gui/glade/tipofday.glade
@@ -60,8 +60,8 @@
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
                 <property name="valign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="margin-top">6</property>
                 <property name="margin-bottom">6</property>
                 <property name="hexpand">True</property>

--- a/gramps/gui/glade/updateaddons.glade
+++ b/gramps/gui/glade/updateaddons.glade
@@ -23,7 +23,6 @@
             <child>
               <object class="GtkButton" id="cancel">
                 <property name="label" translatable="yes">_Close</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
@@ -39,7 +38,6 @@
             <child>
               <object class="GtkButton" id="apply">
                 <property name="label" translatable="yes">Install Selected _Addons</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
@@ -103,7 +101,6 @@
                 <child>
                   <object class="GtkButton" id="select_all">
                     <property name="label" translatable="yes">_Select All</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
@@ -118,7 +115,6 @@
                 <child>
                   <object class="GtkButton" id="select_none">
                     <property name="label" translatable="yes">Select _None</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>

--- a/gramps/gui/logger/_errorreportassistant.py
+++ b/gramps/gui/logger/_errorreportassistant.py
@@ -48,11 +48,9 @@ except:
 try:
     import sqlite3
 
-    sqlite3_py_version_str = sqlite3.version
     sqlite3_version_str = sqlite3.sqlite_version
 except:
     sqlite3_version_str = "not found"
-    sqlite3_py_version_str = "not found"
 
 # -------------------------------------------------------------------------
 #
@@ -195,10 +193,7 @@ class ErrorReportAssistant(ManagedWindow, Gtk.Assistant):
         if hasattr(os, "uname"):
             distribution = "Distribution: %s\n" % os.uname()[2]
 
-        sqlite = "sqlite version: %s (%s) \n" % (
-            sqlite3_version_str,
-            sqlite3_py_version_str,
-        )
+        sqlite = f"sqlite version: {sqlite3_version_str} \n"
 
         return (
             "Gramps version: %s \n"

--- a/gramps/gui/plug/_windows.py
+++ b/gramps/gui/plug/_windows.py
@@ -1254,7 +1254,7 @@ class PluginStatus(ManagedWindow):
         pm.set_pass(total=len(lines), header=_("Reading gramps-project.org..."))
         for line in lines:
             pm.step()
-            if line.startswith("|-") or line.startswith("|}"):
+            if line.startswith(("|-", "|}")):
                 if row != []:
                     rows.append(row)
                 state = "row"
@@ -1308,12 +1308,7 @@ class PluginStatus(ManagedWindow):
                 url = download[1:-1]
                 if " " in url:
                     url, text = url.split(" ", 1)
-            if (
-                url.endswith(".zip")
-                or url.endswith(".ZIP")
-                or url.endswith(".tar.gz")
-                or url.endswith(".tgz")
-            ):
+            if url.endswith((".zip", ".ZIP", ".tar.gz", ".tgz")):
                 # Then this is ok:
                 self.addon_model.append(
                     row=[

--- a/gramps/gui/plug/_windows.py
+++ b/gramps/gui/plug/_windows.py
@@ -460,6 +460,7 @@ class AddonManager(ManagedWindow):
         hbox.pack_start(self.status_combo, False, False, 0)
 
         clear = Gtk.Button.new_from_icon_name("edit-clear", Gtk.IconSize.BUTTON)
+        clear.set_tooltip_text(_("Reset addon filters to defaults"))
         clear.connect("clicked", self.__clear_filters)
         hbox.pack_start(clear, False, False, 0)
 
@@ -699,10 +700,15 @@ class AddonManager(ManagedWindow):
 
         hbox = Gtk.Box()
         add_btn = SimpleButton("list-add", self.__add_project)
+        add_btn.set_tooltip_text(_("Insert a project"))
         del_btn = SimpleButton("list-remove", self.__remove_project)
+        del_btn.set_tooltip_text(_("Remove the selected project"))
         up_btn = SimpleButton("go-up", self.__move_up)
+        up_btn.set_tooltip_text(_("Move project upwards in the list"))
         down_btn = SimpleButton("go-down", self.__move_down)
+        down_btn.set_tooltip_text(_("Move project downwards in the list"))
         restore_btn = SimpleButton("document-revert", self.__restore_defaults)
+        restore_btn.set_tooltip_text(_("Revert to the project defaults"))
         self.buttons = [add_btn, del_btn, up_btn, down_btn, restore_btn]
         for button in self.buttons:
             hbox.pack_start(button, False, False, 0)
@@ -740,6 +746,9 @@ class AddonManager(ManagedWindow):
         row = 1
         install = Gtk.CheckButton()
         install.set_label(_("Allow Gramps to install required Python modules"))
+        install.set_tooltip_text(
+            _("Where possible, try to install any missing prerequisite Python modules")
+        )
         active = config.get("behavior.addons-allow-install")
         install.set_active(active)
         install.connect("toggled", self.install_changed)

--- a/gramps/gui/plug/_windows.py
+++ b/gramps/gui/plug/_windows.py
@@ -1507,7 +1507,7 @@ class PluginStatus(ManagedWindow):
                 )
 
         success_list = sorted(
-            self.__pmgr.get_success_list(), key=lambda x: (x[0], x[2]._get_name())
+            self.__pmgr.get_success_list(), key=lambda x: (x[0], x[2].name)
         )
         for i in success_list:
             # i = (filename, module, pdata)

--- a/gramps/gui/plug/quick/_quicktable.py
+++ b/gramps/gui/plug/quick/_quicktable.py
@@ -1,8 +1,8 @@
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2008  Donald N. Allingham
-# Copyright (C) 2009  Douglas S. Blank
+# Copyright (C) 2008       Donald N. Allingham
+# Copyright (C) 2009,2024  Douglas S. Blank
 # Copyright (C) 2011       Tim G L Lyons
 #
 # This program is free software; you can redistribute it and/or modify
@@ -471,7 +471,7 @@ class QuickTable(SimpleTable):
                 model.append(
                     row=([count] + list(rowdata) + [col[count] for col in sort_data])
                 )
-            except KeyError as msg:
+            except (IndexError, KeyError) as msg:
                 print(msg)
                 if sort_data:
                     print(

--- a/gramps/gui/plug/report/_styleeditor.py
+++ b/gramps/gui/plug/report/_styleeditor.py
@@ -309,7 +309,7 @@ class StyleEditor(ManagedWindow):
         for widget_name in ("color", "bgcolor", "line_color", "fill_color"):
             color = self.top.get_object(widget_name)
             label = self.top.get_object(widget_name + "_code")
-            color.connect("notify::color", self.color_changed, label)
+            color.connect("notify::rgba", self.rgba_changed, label)
 
         self.top.get_object("style_name").set_text(name)
 
@@ -395,10 +395,10 @@ class StyleEditor(ManagedWindow):
         self.top.get_object("line_style").set_active(g.get_line_style())
         self.top.get_object("line_width").set_value(g.get_line_width())
 
-        self.line_color = rgb2color(g.get_color())
-        self.top.get_object("line_color").set_color(self.line_color)
-        self.fill_color = rgb2color(g.get_fill_color())
-        self.top.get_object("fill_color").set_color(self.fill_color)
+        line_color = tuple2rgba(g.get_color())
+        self.top.get_object("line_color").set_rgba(line_color)
+        fill_color = tuple2rgba(g.get_fill_color())
+        self.top.get_object("fill_color").set_rgba(fill_color)
 
         self.top.get_object("shadow").set_active(g.get_shadow())
         self.top.get_object("shadow_space").set_value(g.get_shadow_space())
@@ -497,17 +497,17 @@ class StyleEditor(ManagedWindow):
         self.top.get_object("rborder").set_active(p.get_right_border())
         self.top.get_object("bborder").set_active(p.get_bottom_border())
 
-        color = rgb2color(font.get_color())
-        self.top.get_object("color").set_color(color)
-        bg_color = rgb2color(p.get_background_color())
-        self.top.get_object("bgcolor").set_color(bg_color)
+        color = tuple2rgba(font.get_color())
+        self.top.get_object("color").set_rgba(color)
+        bg_color = tuple2rgba(p.get_background_color())
+        self.top.get_object("bgcolor").set_rgba(bg_color)
 
-    def color_changed(self, color, name, label):
+    def rgba_changed(self, color, name, label):
         """
         Called to set the color code when a color is changed.
         """
-        rgb = color2rgb(color.get_color())
-        label.set_text("#%02X%02X%02X" % color2rgb(color.get_color()))
+        rgb = rgba2tuple(color.get_rgba())
+        label.set_text("#%02X%02X%02X" % rgb)
 
     def save(self):
         """
@@ -529,10 +529,10 @@ class StyleEditor(ManagedWindow):
         g = self.current_style
         g.set_line_style(self.top.get_object("line_style").get_active())
         g.set_line_width(self.top.get_object("line_width").get_value())
-        line_color = self.top.get_object("line_color").get_color()
-        g.set_color(color2rgb(line_color))
-        fill_color = self.top.get_object("fill_color").get_color()
-        g.set_fill_color(color2rgb(fill_color))
+        line_color = self.top.get_object("line_color").get_rgba()
+        g.set_color(rgba2tuple(line_color))
+        fill_color = self.top.get_object("fill_color").get_rgba()
+        g.set_fill_color(rgba2tuple(fill_color))
         shadow = self.top.get_object("shadow").get_active()
         shadow_space = self.top.get_object("shadow_space").get_value()
         g.set_shadow(shadow, shadow_space)
@@ -599,10 +599,10 @@ class StyleEditor(ManagedWindow):
         p.set_right_border(self.top.get_object("rborder").get_active())
         p.set_bottom_border(self.top.get_object("bborder").get_active())
 
-        color = self.top.get_object("color").get_color()
-        font.set_color(color2rgb(color))
-        bg_color = self.top.get_object("bgcolor").get_color()
-        p.set_background_color(color2rgb(bg_color))
+        color = self.top.get_object("color").get_rgba()
+        font.set_color(rgba2tuple(color))
+        bg_color = self.top.get_object("bgcolor").get_rgba()
+        p.set_background_color(rgba2tuple(bg_color))
 
         self.style.add_paragraph_style(self.current_name, self.current_style)
 
@@ -635,18 +635,22 @@ class StyleEditor(ManagedWindow):
         self.draw()
 
 
-def rgb2color(rgb):
+def tuple2rgba(rgb):
     """
-    Convert a tuple containing RGB values into a Gdk Color.
+    Convert a tuple containing 8-bit RGB values into a Gdk.RGBA.
     """
-    return Gdk.Color(rgb[0] << 8, rgb[1] << 8, rgb[2] << 8)
+    rgba = Gdk.RGBA()
+    rgba.red = rgb[0] / 0xFF
+    rgba.green = rgb[1] / 0xFF
+    rgba.blue = rgb[2] / 0xFF
+    return rgba
 
 
-def color2rgb(color):
+def rgba2tuple(rgba):
     """
-    Convert a Gdk Color into a tuple containing RGB values.
+    Convert a Gdk.RGBA into a tuple containing 8-bit RGB values.
     """
-    return (color.red >> 8, color.green >> 8, color.blue >> 8)
+    return (int(rgba.red * 0xFF), int(rgba.green * 0xFF), int(rgba.blue * 0xFF))
 
 
 def dummy_callback(obj):

--- a/gramps/gui/uimanager.py
+++ b/gramps/gui/uimanager.py
@@ -290,7 +290,7 @@ class UIManager:
                 el_id = update.attrib["id"]
                 # find the parent of the id'd element in original xml
                 parent = self.et_xml.find(".//*[@id='%s'].." % el_id)
-                if parent:
+                if parent is not None:
                     # we found it, now delete original, inset updated
                     for indx in range(len(parent)):
                         if parent[indx].get("id") == el_id:
@@ -330,7 +330,7 @@ class UIManager:
             el_id = update.attrib["id"]
             # find parent of id'd element
             element = self.et_xml.find(".//*[@id='%s']" % el_id)
-            if element:  # element may have already been deleted
+            if element is not None:  # element may have already been deleted
                 for dummy in range(len(element)):
                     del element[0]
         # results = ET.tostring(self.et_xml, encoding="unicode")

--- a/gramps/gui/views/treemodels/citationbasemodel.py
+++ b/gramps/gui/views/treemodels/citationbasemodel.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2000-2006  Donald N. Allingham
 # Copyright (C) 2011       Tim G L Lyons, Nick Hall
+# Copyright (C) 2024       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -44,36 +45,9 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 from gramps.gen.datehandler import format_time, get_date, get_date_valid
 from gramps.gen.lib import Citation
+from gramps.gen.lib.serialize import from_dict
 from gramps.gen.utils.string import conf_strings
 from gramps.gen.config import config
-
-# -------------------------------------------------------------------------
-#
-# COLUMN constants
-#
-# -------------------------------------------------------------------------
-# These are the column numbers in the serialize/unserialize interfaces in
-# the Citation object
-COLUMN_HANDLE = 0
-COLUMN_ID = 1
-COLUMN_DATE = 2
-COLUMN_PAGE = 3
-COLUMN_CONFIDENCE = 4
-COLUMN_SOURCE = 5
-COLUMN_CHANGE = 9
-COLUMN_TAGS = 10
-COLUMN_PRIV = 11
-
-# Data for the Source object
-COLUMN2_HANDLE = 0
-COLUMN2_ID = 1
-COLUMN2_TITLE = 2
-COLUMN2_AUTHOR = 3
-COLUMN2_PUBINFO = 4
-COLUMN2_ABBREV = 7
-COLUMN2_CHANGE = 8
-COLUMN2_TAGS = 11
-COLUMN2_PRIV = 12
 
 INVALID_DATE_FORMAT = config.get("preferences.invalid-date-format")
 
@@ -87,12 +61,14 @@ class CitationBaseModel:
     # Fields access when 'data' is a Citation
 
     def citation_date(self, data):
-        if data[COLUMN_DATE]:
-            citation = Citation()
-            citation.unserialize(data)
+        if data["date"]:
+            citation = from_dict(data)
             date_str = get_date(citation)
             if date_str != "":
                 retval = escape(date_str)
+            else:
+                retval = ""
+
             if not get_date_valid(citation):
                 return INVALID_DATE_FORMAT % retval
             else:
@@ -100,9 +76,8 @@ class CitationBaseModel:
         return ""
 
     def citation_sort_date(self, data):
-        if data[COLUMN_DATE]:
-            citation = Citation()
-            citation.unserialize(data)
+        if data["date"]:
+            citation = from_dict(data)
             retval = "%09d" % citation.get_date_object().get_sort_value()
             if not get_date_valid(citation):
                 return INVALID_DATE_FORMAT % retval
@@ -111,21 +86,21 @@ class CitationBaseModel:
         return ""
 
     def citation_id(self, data):
-        return data[COLUMN_ID]
+        return data["gramps_id"]
 
     def citation_page(self, data):
-        return data[COLUMN_PAGE]
+        return data["page"]
 
     def citation_sort_confidence(self, data):
-        if data[COLUMN_CONFIDENCE]:
-            return str(data[COLUMN_CONFIDENCE])
+        if data["confidence"]:
+            return str(data["confidence"])
         return ""
 
     def citation_confidence(self, data):
-        return _(conf_strings[data[COLUMN_CONFIDENCE]])
+        return _(conf_strings[data["confidence"]])
 
     def citation_private(self, data):
-        if data[COLUMN_PRIV]:
+        if data["private"]:
             return "gramps-lock"
         else:
             # There is a problem returning None here.
@@ -135,7 +110,7 @@ class CitationBaseModel:
         """
         Return the sorted list of tags.
         """
-        tag_list = list(map(self.get_tag_name, data[COLUMN_TAGS]))
+        tag_list = list(map(self.get_tag_name, data["tag_list"]))
         # TODO for Arabic, should the next line's comma be translated?
         return ", ".join(sorted(tag_list, key=glocale.sort_key))
 
@@ -143,12 +118,12 @@ class CitationBaseModel:
         """
         Return the tag color.
         """
-        tag_handle = data[0]
+        tag_handle = data["handle"]
         cached, tag_color = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
             tag_color = ""
             tag_priority = None
-            for handle in data[COLUMN_TAGS]:
+            for handle in data["tag_list"]:
                 tag = self.db.get_tag_from_handle(handle)
                 this_priority = tag.get_priority()
                 if tag_priority is None or this_priority < tag_priority:
@@ -158,16 +133,16 @@ class CitationBaseModel:
         return tag_color
 
     def citation_change(self, data):
-        return format_time(data[COLUMN_CHANGE])
+        return format_time(data["change"])
 
     def citation_sort_change(self, data):
-        return "%012x" % data[COLUMN_CHANGE]
+        return "%012x" % data["change"]
 
     def citation_source(self, data):
-        return data[COLUMN_SOURCE]
+        return data["source_handle"]
 
     def citation_src_title(self, data):
-        source_handle = data[COLUMN_SOURCE]
+        source_handle = data["source_handle"]
         cached, value = self.get_cached_value(source_handle, "SRC_TITLE")
         if not cached:
             try:
@@ -179,7 +154,7 @@ class CitationBaseModel:
         return value
 
     def citation_src_id(self, data):
-        source_handle = data[COLUMN_SOURCE]
+        source_handle = data["source_handle"]
         cached, value = self.get_cached_value(source_handle, "SRC_ID")
         if not cached:
             try:
@@ -191,7 +166,7 @@ class CitationBaseModel:
         return value
 
     def citation_src_auth(self, data):
-        source_handle = data[COLUMN_SOURCE]
+        source_handle = data["source_handle"]
         cached, value = self.get_cached_value(source_handle, "SRC_AUTH")
         if not cached:
             try:
@@ -203,7 +178,7 @@ class CitationBaseModel:
         return value
 
     def citation_src_abbr(self, data):
-        source_handle = data[COLUMN_SOURCE]
+        source_handle = data["source_handle"]
         cached, value = self.get_cached_value(source_handle, "SRC_ABBR")
         if not cached:
             try:
@@ -215,7 +190,7 @@ class CitationBaseModel:
         return value
 
     def citation_src_pinfo(self, data):
-        source_handle = data[COLUMN_SOURCE]
+        source_handle = data["source_handle"]
         cached, value = self.get_cached_value(source_handle, "SRC_PINFO")
         if not cached:
             try:
@@ -227,7 +202,7 @@ class CitationBaseModel:
         return value
 
     def citation_src_private(self, data):
-        source_handle = data[COLUMN_SOURCE]
+        source_handle = data["source_handle"]
         cached, value = self.get_cached_value(source_handle, "SRC_PRIVATE")
         if not cached:
             try:
@@ -243,7 +218,7 @@ class CitationBaseModel:
         return value
 
     def citation_src_tags(self, data):
-        source_handle = data[COLUMN_SOURCE]
+        source_handle = data["source_handle"]
         cached, value = self.get_cached_value(source_handle, "SRC_TAGS")
         if not cached:
             try:
@@ -257,7 +232,7 @@ class CitationBaseModel:
         return value
 
     def citation_src_chan(self, data):
-        source_handle = data[COLUMN_SOURCE]
+        source_handle = data["source_handle"]
         cached, value = self.get_cached_value(source_handle, "SRC_CHAN")
         if not cached:
             try:
@@ -269,7 +244,7 @@ class CitationBaseModel:
         return value
 
     def citation_src_sort_change(self, data):
-        source_handle = data[COLUMN_SOURCE]
+        source_handle = data["source_handle"]
         cached, value = self.get_cached_value(source_handle, "SRC_CHAN")
         if not cached:
             try:
@@ -283,22 +258,22 @@ class CitationBaseModel:
     # Fields access when 'data' is a Source
 
     def source_src_title(self, data):
-        return data[COLUMN2_TITLE]
+        return data["title"]
 
     def source_src_id(self, data):
-        return data[COLUMN2_ID]
+        return data["gramps_id"]
 
     def source_src_auth(self, data):
-        return data[COLUMN2_AUTHOR]
+        return data["author"]
 
     def source_src_abbr(self, data):
-        return data[COLUMN2_ABBREV]
+        return data["abbrev"]
 
     def source_src_pinfo(self, data):
-        return data[COLUMN2_PUBINFO]
+        return data["pubinfo"]
 
     def source_src_private(self, data):
-        if data[COLUMN2_PRIV]:
+        if data["private"]:
             return "gramps-lock"
         else:
             # There is a problem returning None here.
@@ -308,7 +283,7 @@ class CitationBaseModel:
         """
         Return the sorted list of tags.
         """
-        tag_list = list(map(self.get_tag_name, data[COLUMN2_TAGS]))
+        tag_list = list(map(self.get_tag_name, data["tag_list"]))
         # TODO for Arabic, should the next line's comma be translated?
         return ", ".join(sorted(tag_list, key=glocale.sort_key))
 
@@ -316,12 +291,12 @@ class CitationBaseModel:
         """
         Return the tag color.
         """
-        tag_handle = data[0]
+        tag_handle = data["handle"]
         cached, tag_color = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
             tag_color = ""
             tag_priority = None
-            for handle in data[COLUMN2_TAGS]:
+            for handle in data["tag_list"]:
                 tag = self.db.get_tag_from_handle(handle)
                 this_priority = tag.get_priority()
                 if tag_priority is None or this_priority < tag_priority:
@@ -331,10 +306,10 @@ class CitationBaseModel:
         return tag_color
 
     def source_src_chan(self, data):
-        return format_time(data[COLUMN2_CHANGE])
+        return format_time(data["change"])
 
     def source_sort2_change(self, data):
-        return "%012x" % data[COLUMN2_CHANGE]
+        return "%012x" % data["change"]
 
     def dummy_sort_key(self, data):
         # dummy sort key for columns that don't have data

--- a/gramps/gui/views/treemodels/citationtreemodel.py
+++ b/gramps/gui/views/treemodels/citationtreemodel.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2000-2006  Donald N. Allingham
 # Copyright (C) 2011       Tim G L Lyons, Nick Hall
+# Copyright (C) 2024       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -211,17 +212,23 @@ class CitationTreeModel(CitationBaseModel, TreeBaseModel):
         # add the citation as a child of the source. Otherwise we add the source
         # first (because citations don't have any meaning without the associated
         # source)
-        if self._get_node(data[5]):
+        if self._get_node(data["source_handle"]):
             #             parent   child   sortkey   handle
-            self.add_node(data[5], handle, sort_key, handle, secondary=True)
+            self.add_node(
+                data["source_handle"], handle, sort_key, handle, secondary=True
+            )
         else:
             # add the source node first
-            source_sort_key = self.sort_func(self.map(data[5]))
+            source_sort_key = self.sort_func(self.map(data["source_handle"]))
             #            parent child    sortkey          handle
-            self.add_node(None, data[5], source_sort_key, data[5])
+            self.add_node(
+                None, data["source_handle"], source_sort_key, data["source_handle"]
+            )
 
             #            parent    child   sortkey   handle
-            self.add_node(data[5], handle, sort_key, handle, secondary=True)
+            self.add_node(
+                data["source_handle"], handle, sort_key, handle, secondary=True
+            )
 
     def on_get_n_columns(self):
         return len(self.fmap) + 1

--- a/gramps/gui/views/treemodels/eventmodel.py
+++ b/gramps/gui/views/treemodels/eventmodel.py
@@ -2,6 +2,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2000-2006  Donald N. Allingham
+# Copyright (C) 2024       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -42,26 +43,12 @@ from gi.repository import Gtk
 # -------------------------------------------------------------------------
 from gramps.gen.datehandler import format_time, get_date, get_date_valid
 from gramps.gen.lib import Event, EventType
+from gramps.gen.lib.serialize import from_dict
 from gramps.gen.utils.db import get_participant_from_event
 from gramps.gen.display.place import displayer as place_displayer
 from gramps.gen.config import config
 from .flatbasemodel import FlatBaseModel
 from gramps.gen.const import GRAMPS_LOCALE as glocale
-
-# -------------------------------------------------------------------------
-#
-# Positions in raw data structure
-#
-# -------------------------------------------------------------------------
-COLUMN_HANDLE = 0
-COLUMN_ID = 1
-COLUMN_TYPE = 2
-COLUMN_DATE = 3
-COLUMN_DESCRIPTION = 4
-COLUMN_PLACE = 5
-COLUMN_CHANGE = 10
-COLUMN_TAGS = 11
-COLUMN_PRIV = 12
 
 INVALID_DATE_FORMAT = config.get("preferences.invalid-date-format")
 
@@ -134,40 +121,38 @@ class EventModel(FlatBaseModel):
         return len(self.fmap) + 1
 
     def column_description(self, data):
-        return data[COLUMN_DESCRIPTION]
+        return data["description"]
 
     def column_participant(self, data):
-        handle = data[0]
+        handle = data["handle"]
         cached, value = self.get_cached_value(handle, "PARTICIPANT")
         if not cached:
             value = get_participant_from_event(
-                self.db, data[COLUMN_HANDLE], all_=True
+                self.db, data["handle"], all_=True
             )  # all participants
             self.set_cached_value(handle, "PARTICIPANT", value)
         return value
 
     def column_place(self, data):
-        if data[COLUMN_PLACE]:
-            cached, value = self.get_cached_value(data[0], "PLACE")
+        if data["place"]:
+            cached, value = self.get_cached_value(data["handle"], "PLACE")
             if not cached:
-                event = Event()
-                event.unserialize(data)
+                event = from_dict(data)
                 value = place_displayer.display_event(self.db, event)
-                self.set_cached_value(data[0], "PLACE", value)
+                self.set_cached_value(data["handle"], "PLACE", value)
             return value
         else:
             return ""
 
     def column_type(self, data):
-        return str(EventType(data[COLUMN_TYPE]))
+        return str(EventType(data["type"]))
 
     def column_id(self, data):
-        return data[COLUMN_ID]
+        return data["gramps_id"]
 
     def column_date(self, data):
-        if data[COLUMN_DATE]:
-            event = Event()
-            event.unserialize(data)
+        if data["date"]:
+            event = from_dict(data)
             date_str = get_date(event)
             if date_str != "":
                 retval = escape(date_str)
@@ -180,9 +165,8 @@ class EventModel(FlatBaseModel):
         return ""
 
     def sort_date(self, data):
-        if data[COLUMN_DATE]:
-            event = Event()
-            event.unserialize(data)
+        if data["date"]:
+            event = from_dict(data)
             retval = "%09d" % event.get_date_object().get_sort_value()
             if not get_date_valid(event):
                 return INVALID_DATE_FORMAT % retval
@@ -192,17 +176,17 @@ class EventModel(FlatBaseModel):
         return ""
 
     def column_private(self, data):
-        if data[COLUMN_PRIV]:
+        if data["private"]:
             return "gramps-lock"
         else:
             # There is a problem returning None here.
             return ""
 
     def sort_change(self, data):
-        return "%012x" % data[COLUMN_CHANGE]
+        return "%012x" % data["change"]
 
     def column_change(self, data):
-        return format_time(data[COLUMN_CHANGE])
+        return format_time(data["change"])
 
     def get_tag_name(self, tag_handle):
         """
@@ -219,12 +203,12 @@ class EventModel(FlatBaseModel):
         """
         Return the tag color.
         """
-        tag_handle = data[0]
+        tag_handle = data["handle"]
         cached, tag_color = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
             tag_color = ""
             tag_priority = None
-            for handle in data[COLUMN_TAGS]:
+            for handle in data["tag_list"]:
                 tag = self.db.get_tag_from_handle(handle)
                 this_priority = tag.get_priority()
                 if tag_priority is None or this_priority < tag_priority:
@@ -237,6 +221,6 @@ class EventModel(FlatBaseModel):
         """
         Return the sorted list of tags.
         """
-        tag_list = list(map(self.get_tag_name, data[COLUMN_TAGS]))
+        tag_list = list(map(self.get_tag_name, data["tag_list"]))
         # TODO for Arabic, should the next line's comma be translated?
         return ", ".join(sorted(tag_list, key=glocale.sort_key))

--- a/gramps/gui/views/treemodels/familymodel.py
+++ b/gramps/gui/views/treemodels/familymodel.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2000-2007  Donald N. Allingham
 # Copyright (C) 2010       Nick Hall
+# Copyright (C) 2024       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -116,11 +117,11 @@ class FamilyModel(FlatBaseModel):
         return len(self.fmap) + 1
 
     def column_father(self, data):
-        handle = data[0]
+        handle = data["handle"]
         cached, value = self.get_cached_value(handle, "FATHER")
         if not cached:
-            if data[2]:
-                person = self.db.get_person_from_handle(data[2])
+            if data["father_handle"]:
+                person = self.db.get_person_from_handle(data["father_handle"])
                 value = name_displayer.display_name(person.primary_name)
             else:
                 value = ""
@@ -128,11 +129,11 @@ class FamilyModel(FlatBaseModel):
         return value
 
     def sort_father(self, data):
-        handle = data[0]
+        handle = data["handle"]
         cached, value = self.get_cached_value(handle, "SORT_FATHER")
         if not cached:
-            if data[2]:
-                person = self.db.get_person_from_handle(data[2])
+            if data["father_handle"]:
+                person = self.db.get_person_from_handle(data["father_handle"])
                 value = name_displayer.sorted_name(person.primary_name)
             else:
                 value = ""
@@ -140,11 +141,11 @@ class FamilyModel(FlatBaseModel):
         return value
 
     def column_mother(self, data):
-        handle = data[0]
+        handle = data["handle"]
         cached, value = self.get_cached_value(handle, "MOTHER")
         if not cached:
-            if data[3]:
-                person = self.db.get_person_from_handle(data[3])
+            if data["mother_handle"]:
+                person = self.db.get_person_from_handle(data["mother_handle"])
                 value = name_displayer.display_name(person.primary_name)
             else:
                 value = ""
@@ -152,11 +153,11 @@ class FamilyModel(FlatBaseModel):
         return value
 
     def sort_mother(self, data):
-        handle = data[0]
+        handle = data["handle"]
         cached, value = self.get_cached_value(handle, "SORT_MOTHER")
         if not cached:
-            if data[3]:
-                person = self.db.get_person_from_handle(data[3])
+            if data["mother_handle"]:
+                person = self.db.get_person_from_handle(data["mother_handle"])
                 value = name_displayer.sorted_name(person.primary_name)
             else:
                 value = ""
@@ -164,15 +165,15 @@ class FamilyModel(FlatBaseModel):
         return value
 
     def column_type(self, data):
-        return str(FamilyRelType(data[5]))
+        return data["type"]["string"]
 
     def column_marriage(self, data):
-        handle = data[0]
+        handle = data["handle"]
         cached, value = self.get_cached_value(handle, "MARRIAGE")
         if not cached:
-            family = self.db.get_family_from_handle(data[0])
+            family = self.db.get_family_from_handle(data["handle"])
             event = get_marriage_or_fallback(self.db, family, "<i>%s</i>")
-            if event:
+            if event and event.date:
                 if event.date.format:
                     value = event.date.format % displayer.display(event.date)
                 elif not get_date_valid(event):
@@ -185,10 +186,10 @@ class FamilyModel(FlatBaseModel):
         return value
 
     def sort_marriage(self, data):
-        handle = data[0]
+        handle = data["handle"]
         cached, value = self.get_cached_value(handle, "SORT_MARRIAGE")
         if not cached:
-            family = self.db.get_family_from_handle(data[0])
+            family = self.db.get_family_from_handle(data["handle"])
             event = get_marriage_or_fallback(self.db, family)
             if event:
                 value = "%09d" % event.date.get_sort_value()
@@ -198,20 +199,20 @@ class FamilyModel(FlatBaseModel):
         return value
 
     def column_id(self, data):
-        return data[1]
+        return data["gramps_id"]
 
     def column_private(self, data):
-        if data[14]:
+        if data["private"]:
             return "gramps-lock"
         else:
             # There is a problem returning None here.
             return ""
 
     def sort_change(self, data):
-        return "%012x" % data[12]
+        return "%012x" % data["change"]
 
     def column_change(self, data):
-        return format_time(data[12])
+        return format_time(data["change"])
 
     def get_tag_name(self, tag_handle):
         """
@@ -227,12 +228,12 @@ class FamilyModel(FlatBaseModel):
         """
         Return the tag color.
         """
-        tag_handle = data[0]
+        tag_handle = data["handle"]
         cached, tag_color = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
             tag_color = ""
             tag_priority = None
-            for handle in data[13]:
+            for handle in data["tag_list"]:
                 tag = self.db.get_tag_from_handle(handle)
                 this_priority = tag.get_priority()
                 if tag_priority is None or this_priority < tag_priority:
@@ -245,6 +246,6 @@ class FamilyModel(FlatBaseModel):
         """
         Return the sorted list of tags.
         """
-        tag_list = list(map(self.get_tag_name, data[13]))
+        tag_list = list(map(self.get_tag_name, data["tag_list"]))
         # TODO for Arabic, should the next line's comma be translated?
         return ", ".join(sorted(tag_list, key=glocale.sort_key))

--- a/gramps/gui/views/treemodels/mediamodel.py
+++ b/gramps/gui/views/treemodels/mediamodel.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2000-2006  Donald N. Allingham
 # Copyright (C) 2010       Nick Hall
+# Copyright (C) 2024       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -45,6 +46,7 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 from gramps.gen.datehandler import displayer, format_time
 from gramps.gen.lib import Date, Media
+from gramps.gen.lib.serialize import from_dict
 from .flatbasemodel import FlatBaseModel
 
 
@@ -109,37 +111,36 @@ class MediaModel(FlatBaseModel):
         """
         Return the color column.
         """
+        # For model.get_value() arg
         return 8
 
     def on_get_n_columns(self):
         return len(self.fmap) + 1
 
     def column_description(self, data):
-        return data[4]
+        return data["desc"]
 
     def column_path(self, data):
-        return data[2]
+        return data["path"]
 
     def column_mime(self, data):
-        mime = data[3]
+        mime = data["mime"]
         if mime:
             return mime
         else:
             return _("Note")
 
     def column_id(self, data):
-        return data[1]
+        return data["gramps_id"]
 
     def column_date(self, data):
-        if data[10]:
-            date = Date()
-            date.unserialize(data[10])
+        if data["date"]:
+            date = from_dict(data["date"])
             return displayer.display(date)
         return ""
 
     def sort_date(self, data):
-        obj = Media()
-        obj.unserialize(data)
+        obj = from_dict(data)
         d = obj.get_date_object()
         if d:
             return "%09d" % d.get_sort_value()
@@ -147,20 +148,20 @@ class MediaModel(FlatBaseModel):
             return ""
 
     def column_handle(self, data):
-        return str(data[0])
+        return str(data["handle"])
 
     def column_private(self, data):
-        if data[12]:
+        if data["private"]:
             return "gramps-lock"
         else:
             # There is a problem returning None here.
             return ""
 
     def sort_change(self, data):
-        return "%012x" % data[9]
+        return "%012x" % data["change"]
 
     def column_change(self, data):
-        return format_time(data[9])
+        return format_time(data["change"])
 
     def column_tooltip(self, data):
         return "Media tooltip"
@@ -179,12 +180,12 @@ class MediaModel(FlatBaseModel):
         """
         Return the tag color.
         """
-        tag_handle = data[0]
+        tag_handle = data["handle"]
         cached, tag_color = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
             tag_color = ""
             tag_priority = None
-            for handle in data[11]:
+            for handle in data["tag_list"]:
                 tag = self.db.get_tag_from_handle(handle)
                 this_priority = tag.get_priority()
                 if tag_priority is None or this_priority < tag_priority:
@@ -197,6 +198,6 @@ class MediaModel(FlatBaseModel):
         """
         Return the sorted list of tags.
         """
-        tag_list = list(map(self.get_tag_name, data[11]))
+        tag_list = list(map(self.get_tag_name, data["tag_list"]))
         # TODO for Arabic, should the next line's comma be translated?
         return ", ".join(sorted(tag_list, key=glocale.sort_key))

--- a/gramps/gui/views/treemodels/notemodel.py
+++ b/gramps/gui/views/treemodels/notemodel.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2000-2007  Donald N. Allingham
 # Copyright (C) 2010       Nick Hall
+# Copyright (C) 2024       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -104,6 +105,7 @@ class NoteModel(FlatBaseModel):
         """
         Return the color column.
         """
+        # This is for model.get_value() arg
         return 6
 
     def on_get_n_columns(self):
@@ -112,17 +114,17 @@ class NoteModel(FlatBaseModel):
 
     def column_id(self, data):
         """Return the id of the Note."""
-        return data[Note.POS_ID]
+        return data["gramps_id"]
 
     def column_type(self, data):
         """Return the type of the Note in readable format."""
         temp = NoteType()
-        temp.set(data[Note.POS_TYPE])
+        temp.set(data["type"])
         return str(temp)
 
     def column_preview(self, data):
         """Return a shortend version of the Note's text."""
-        note = data[Note.POS_TEXT][StyledText.POS_TEXT]
+        note = data["text"]["string"]
         note = " ".join(note.split())
         if len(note) > 80:
             return note[:80] + "..."
@@ -130,17 +132,17 @@ class NoteModel(FlatBaseModel):
             return note
 
     def column_private(self, data):
-        if data[Note.POS_PRIVATE]:
+        if data["private"]:
             return "gramps-lock"
         else:
             # There is a problem returning None here.
             return ""
 
     def sort_change(self, data):
-        return "%012x" % data[Note.POS_CHANGE]
+        return "%012x" % data["change"]
 
     def column_change(self, data):
-        return format_time(data[Note.POS_CHANGE])
+        return format_time(data["change"])
 
     def get_tag_name(self, tag_handle):
         """
@@ -156,12 +158,12 @@ class NoteModel(FlatBaseModel):
         """
         Return the tag color.
         """
-        tag_handle = data[0]
+        tag_handle = data["handle"]
         cached, value = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
             tag_color = ""
             tag_priority = None
-            for handle in data[Note.POS_TAGS]:
+            for handle in data["tag_list"]:
                 tag = self.db.get_tag_from_handle(handle)
                 if tag:
                     this_priority = tag.get_priority()
@@ -176,6 +178,6 @@ class NoteModel(FlatBaseModel):
         """
         Return the sorted list of tags.
         """
-        tag_list = list(map(self.get_tag_name, data[Note.POS_TAGS]))
+        tag_list = list(map(self.get_tag_name, data["tag_list"]))
         # TODO for Arabic, should the next line's comma be translated?
         return ", ".join(sorted(tag_list, key=glocale.sort_key))

--- a/gramps/gui/views/treemodels/placemodel.py
+++ b/gramps/gui/views/treemodels/placemodel.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2009-2010  Nick Hall
 # Copyright (C) 2009       Benny Malengier
 # Copyright (C) 2010       Gary Burton
+# Copyright (C) 2024       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -46,6 +47,7 @@ from gi.repository import Gtk
 #
 # -------------------------------------------------------------------------
 from gramps.gen.lib import Place, PlaceType
+from gramps.gen.lib.serialize import from_dict
 from gramps.gen.datehandler import format_time
 from gramps.gen.utils.place import conv_lat_lon, coord_formats
 from gramps.gen.display.place import displayer as place_displayer
@@ -115,86 +117,95 @@ class PlaceBaseModel:
         """
         Return the color column.
         """
+        # This is a model.get_value() arg
         return 10
 
     def on_get_n_columns(self):
         return len(self.fmap) + 1
 
     def column_title(self, data):
-        handle = data[0]
+        handle = data["handle"]
         cached, value = self.get_cached_value(handle, "PLACE")
         if not cached:
-            place = Place()
-            place.unserialize(data)
+            place = from_dict(data)
             value = place_displayer.display(self.db, place)
             self.set_cached_value(handle, "PLACE", value)
         return value
 
     def column_name(self, data):
         """Return the primary name"""
-        return data[6][0]
+        return data["name"]["value"]
 
     def search_name(self, data):
         """The search name includes all alt names to enable finding by alt name"""
-        return ",".join([data[6][0]] + [name[0] for name in data[7]])
+        return ",".join(
+            [data["name"]["value"]] + [name["value"] for name in data["alt_name"]]
+        )
 
     def column_longitude(self, data):
-        if not data[3]:
+        if not data["long"]:
             return ""
         value = conv_lat_lon(
-            "0", data[3], format=coord_formats[config.get("preferences.coord-format")]
+            "0",
+            data["long"],
+            format=coord_formats[config.get("preferences.coord-format")],
         )[1]
         if not value:
             return _("Error in format")
         return ("\u202d" + value + "\u202e") if glocale.rtl_locale else value
 
     def column_latitude(self, data):
-        if not data[4]:
+        if not data["lat"]:
             return ""
         value = conv_lat_lon(
-            data[4], "0", format=coord_formats[config.get("preferences.coord-format")]
+            data["lat"],
+            "0",
+            format=coord_formats[config.get("preferences.coord-format")],
         )[0]
         if not value:
             return _("Error in format")
         return ("\u202d" + value + "\u202e") if glocale.rtl_locale else value
 
     def sort_longitude(self, data):
-        if not data[3]:
+        if not data["long"]:
             return ""
-        value = conv_lat_lon("0", data[3], format="ISO-DMS") if data[3] else ""
+        value = (
+            conv_lat_lon("0", data["long"], format="ISO-DMS") if data["long"] else ""
+        )
         if not value:
             return _("Error in format")
         return value
 
     def sort_latitude(self, data):
-        if not data[4]:
+        if not data["lat"]:
             return ""
-        value = conv_lat_lon(data[4], "0", format="ISO-DMS") if data[4] else ""
+        value = conv_lat_lon(data["lat"], "0", format="ISO-DMS") if data["lat"] else ""
         if not value:
             return _("Error in format")
         return value
 
     def column_id(self, data):
-        return data[1]
+        return data["gramps_id"]
 
     def column_type(self, data):
-        return str(PlaceType(data[8]))
+        pt = from_dict(data["place_type"])
+        return str(pt)
 
     def column_code(self, data):
-        return data[9]
+        return data["code"]
 
     def column_private(self, data):
-        if data[17]:
+        if data["private"]:
             return "gramps-lock"
         else:
             # There is a problem returning None here.
             return ""
 
     def sort_change(self, data):
-        return "%012x" % data[15]
+        return "%012x" % data["change"]
 
     def column_change(self, data):
-        return format_time(data[15])
+        return format_time(data["change"])
 
     def get_tag_name(self, tag_handle):
         """
@@ -210,12 +221,12 @@ class PlaceBaseModel:
         """
         Return the tag color.
         """
-        tag_handle = data[0]
+        tag_handle = data["handle"]
         cached, value = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
             tag_color = ""
             tag_priority = None
-            for handle in data[16]:
+            for handle in data["tag_list"]:
                 tag = self.db.get_tag_from_handle(handle)
                 if tag:
                     this_priority = tag.get_priority()
@@ -230,7 +241,7 @@ class PlaceBaseModel:
         """
         Return the sorted list of tags.
         """
-        tag_list = list(map(self.get_tag_name, data[16]))
+        tag_list = list(map(self.get_tag_name, data["tag_list"]))
         # TODO for Arabic, should the next line's comma be translated?
         return ", ".join(sorted(tag_list, key=glocale.sort_key))
 
@@ -351,8 +362,8 @@ class PlaceTreeModel(PlaceBaseModel, TreeBaseModel):
         data        The object data.
         """
         sort_key = self.sort_func(data)
-        if len(data[5]) > 0:
-            parent = data[5][0][0]
+        if len(data["placeref_list"]) > 0:
+            parent = data["placeref_list"][0]["ref"]
         else:
             parent = None
 

--- a/gramps/gui/views/treemodels/repomodel.py
+++ b/gramps/gui/views/treemodels/repomodel.py
@@ -2,6 +2,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2000-2006  Donald N. Allingham
+# Copyright (C) 2024       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -40,6 +41,7 @@ from gi.repository import Gtk
 #
 # -------------------------------------------------------------------------
 from gramps.gen.lib import Address, RepositoryType, Url, UrlType
+from gramps.gen.lib.serialize import from_dict
 from gramps.gen.datehandler import format_time
 from .flatbasemodel import FlatBaseModel
 from gramps.gen.const import GRAMPS_LOCALE as glocale
@@ -122,25 +124,25 @@ class RepositoryModel(FlatBaseModel):
         """
         Return the color column.
         """
+        # For model.get_value() arg
         return 15
 
     def on_get_n_columns(self):
         return len(self.fmap) + 1
 
     def column_id(self, data):
-        return data[1]
+        return data["gramps_id"]
 
     def column_type(self, data):
-        return str(RepositoryType(data[2]))
+        return str(RepositoryType(data["type"]))
 
     def column_name(self, data):
-        return data[3]
+        return data["name"]
 
     def column_city(self, data):
         try:
-            if data[5]:
-                addr = Address()
-                addr.unserialize(data[5][0])
+            if data["address_list"]:
+                addr = from_dict(data["address_list"][0])
                 return addr.get_city()
         except:
             pass
@@ -148,9 +150,8 @@ class RepositoryModel(FlatBaseModel):
 
     def column_street(self, data):
         try:
-            if data[5]:
-                addr = Address()
-                addr.unserialize(data[5][0])
+            if data["address_list"]:
+                addr = from_dict(data["address_list"][0])
                 return addr.get_street()
         except:
             pass
@@ -158,9 +159,8 @@ class RepositoryModel(FlatBaseModel):
 
     def column_locality(self, data):
         try:
-            if data[5]:
-                addr = Address()
-                addr.unserialize(data[5][0])
+            if data["address_list"]:
+                addr = from_dict(data["address_list"][0])
                 return addr.get_locality()
         except:
             pass
@@ -168,9 +168,8 @@ class RepositoryModel(FlatBaseModel):
 
     def column_state(self, data):
         try:
-            if data[5]:
-                addr = Address()
-                addr.unserialize(data[5][0])
+            if data["address_list"]:
+                addr = from_dict(data["address_list"][0])
                 return addr.get_state()
         except:
             pass
@@ -178,9 +177,8 @@ class RepositoryModel(FlatBaseModel):
 
     def column_country(self, data):
         try:
-            if data[5]:
-                addr = Address()
-                addr.unserialize(data[5][0])
+            if data["address_list"]:
+                addr = from_dict(data["address_list"][0])
                 return addr.get_country()
         except:
             pass
@@ -188,9 +186,8 @@ class RepositoryModel(FlatBaseModel):
 
     def column_postal_code(self, data):
         try:
-            if data[5]:
-                addr = Address()
-                addr.unserialize(data[5][0])
+            if data["address_list"]:
+                addr = from_dict(data["address_list"][0])
                 return addr.get_postal_code()
         except:
             pass
@@ -198,53 +195,49 @@ class RepositoryModel(FlatBaseModel):
 
     def column_phone(self, data):
         try:
-            if data[5]:
-                addr = Address()
-                addr.unserialize(data[5][0])
+            if data["address_list"]:
+                addr = from_dict(data["address_list"][0])
                 return addr.get_phone()
         except:
             pass
         return ""
 
     def column_email(self, data):
-        if data[6]:
-            for i in data[6]:
-                url = Url()
-                url.unserialize(i)
+        if data["urls"]:
+            for url_data in data["urls"]:
+                url = from_dict(url_data)
                 if url.get_type() == UrlType.EMAIL:
                     return url.path
         return ""
 
     def column_search_url(self, data):
-        if data[6]:
-            for i in data[6]:
-                url = Url()
-                url.unserialize(i)
+        if data["urls"]:
+            for url_data in data["urls"]:
+                url = from_dict(url_data)
                 if url.get_type() == UrlType.WEB_SEARCH:
                     return url.path
         return ""
 
     def column_home_url(self, data):
-        if data[6]:
-            for i in data[6]:
-                url = Url()
-                url.unserialize(i)
+        if data["urls"]:
+            for url_data in data["urls"]:
+                url = from_dict(url_data)
                 if url.get_type() == UrlType.WEB_HOME:
                     return url.path
         return ""
 
     def column_private(self, data):
-        if data[9]:
+        if data["private"]:
             return "gramps-lock"
         else:
             # There is a problem returning None here.
             return ""
 
     def sort_change(self, data):
-        return "%012x" % data[7]
+        return "%012x" % data["change"]
 
     def column_change(self, data):
-        return format_time(data[7])
+        return format_time(data["change"])
 
     def get_tag_name(self, tag_handle):
         """
@@ -261,12 +254,12 @@ class RepositoryModel(FlatBaseModel):
         """
         Return the tag color.
         """
-        tag_handle = data[0]
+        tag_handle = data["handle"]
         cached, tag_color = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
             tag_color = ""
             tag_priority = None
-            for handle in data[8]:
+            for handle in data["tag_list"]:
                 tag = self.db.get_tag_from_handle(handle)
                 this_priority = tag.get_priority()
                 if tag_priority is None or this_priority < tag_priority:
@@ -279,6 +272,6 @@ class RepositoryModel(FlatBaseModel):
         """
         Return the sorted list of tags.
         """
-        tag_list = list(map(self.get_tag_name, data[8]))
+        tag_list = list(map(self.get_tag_name, data["tag_list"]))
         # TODO for Arabic, should the next line's comma be translated?
         return ", ".join(sorted(tag_list, key=glocale.sort_key))

--- a/gramps/gui/views/treemodels/sourcemodel.py
+++ b/gramps/gui/views/treemodels/sourcemodel.py
@@ -2,6 +2,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2000-2006  Donald N. Allingham
+# Copyright (C) 2024       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -103,38 +104,39 @@ class SourceModel(FlatBaseModel):
         """
         Return the color column.
         """
+        # This is for model.get_value() arg
         return 8
 
     def on_get_n_columns(self):
         return len(self.fmap) + 1
 
     def column_title(self, data):
-        return data[2].replace("\n", " ")
+        return data["title"].replace("\n", " ")
 
     def column_author(self, data):
-        return data[3]
+        return data["author"]
 
     def column_abbrev(self, data):
-        return data[7]
+        return data["abbrev"]
 
     def column_id(self, data):
-        return data[1]
+        return data["gramps_id"]
 
     def column_pubinfo(self, data):
-        return data[4]
+        return data["pubinfo"]
 
     def column_private(self, data):
-        if data[12]:
+        if data["private"]:
             return "gramps-lock"
         else:
             # There is a problem returning None here.
             return ""
 
     def column_change(self, data):
-        return format_time(data[8])
+        return format_time(data["change"])
 
     def sort_change(self, data):
-        return "%012x" % data[8]
+        return "%012x" % data["change"]
 
     def get_tag_name(self, tag_handle):
         """
@@ -150,12 +152,12 @@ class SourceModel(FlatBaseModel):
         """
         Return the tag color.
         """
-        tag_handle = data[0]
+        tag_handle = data["handle"]
         cached, value = self.get_cached_value(tag_handle, "TAG_COLOR")
         if not cached:
             tag_color = ""
             tag_priority = None
-            for handle in data[11]:
+            for handle in data["tag_list"]:
                 tag = self.db.get_tag_from_handle(handle)
                 if tag:
                     this_priority = tag.get_priority()
@@ -170,6 +172,6 @@ class SourceModel(FlatBaseModel):
         """
         Return the sorted list of tags.
         """
-        tag_list = list(map(self.get_tag_name, data[11]))
+        tag_list = list(map(self.get_tag_name, data["tag_list"]))
         # TODO for Arabic, should the next line's comma be translated?
         return ", ".join(sorted(tag_list, key=glocale.sort_key))

--- a/gramps/plugins/db/bsddb/bsddb.py
+++ b/gramps/plugins/db/bsddb/bsddb.py
@@ -2,7 +2,8 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2020 Paul Culley <paulr2787@gmail.com>
-# Copyright (C) 2020  Nick Hall
+# Copyright (C) 2020 Nick Hall
+# Copyright (C) 2024 Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -108,8 +109,11 @@ class DbBsddb(SQLite):
             username=username,
             password=password,
         )
+        # Default new DBAPI uses "json" serializer
+        # So, we force read/write in blobs:
+        self.set_serializer("blob")
 
-        # now read in the bsddb and copy to dpapi
+        # now read in the bsddb and copy to dbapi
         schema_vers = None
         total = 0
         tables = (
@@ -149,14 +153,9 @@ class DbBsddb(SQLite):
         self.set_total(total)
         # copy data from each dbmap to sqlite table
         for old_t, new_t, dbmap in table_list:
-            self._txn_begin()
-            if new_t == "metadata":
-                sql = "REPLACE INTO metadata (setting, value) VALUES " "(?, ?)"
-            else:
-                sql = "INSERT INTO %s (handle, blob_data) VALUES " "(?, ?)" % new_t
-
             for key in dbmap.keys():
                 self.update()
+                # Try to unpickle data saved before db version 19:
                 data = pickle.loads(dbmap[key], encoding="utf-8")
 
                 if new_t == "metadata":
@@ -171,7 +170,10 @@ class DbBsddb(SQLite):
                             new_data = (addr, data[1], data[2], data[3])
                         else:
                             new_data = data
+
+                        # Version 19 Researcher format is an Object!
                         data = Researcher().unserialize(new_data)
+
                     elif key == b"name_formats":
                         # upgrade formats if they were saved in the old way
                         for format_ix in range(len(data)):
@@ -215,7 +217,15 @@ class DbBsddb(SQLite):
                         # These are list, but need to be set
                         data = set(data)
 
-                self.dbapi.execute(sql, [key.decode("utf-8"), pickle.dumps(data)])
+                    self._set_metadata(key.decode("utf-8"), data)
+                else:
+                    # Not metadata, but gramps object
+                    self._txn_begin()
+                    self.dbapi(
+                        f"INSERT INTO {new_t} (handle, blob_data) VALUES " "(?, ?)",
+                        [key.decode("utf-8"), pickle.dumps(data)],
+                    )
+                    self._txn_commit()
 
             # get schema version from file if not in metadata
             if new_t == "metadata" and schema_vers is None:
@@ -226,8 +236,8 @@ class DbBsddb(SQLite):
                 else:
                     schema_vers = 0
                 # and put schema version into metadata
-                self.dbapi.execute(sql, ["version", schema_vers])
-            self._txn_commit()
+                self._set_metadata("version", schema_vers)
+
             dbmap.close()
             if new_t == "metadata" and schema_vers < _MINVERSION:
                 raise DbVersionError(schema_vers, _MINVERSION, _DBVERSION)

--- a/gramps/plugins/db/dbapi/sqlite.py
+++ b/gramps/plugins/db/dbapi/sqlite.py
@@ -65,7 +65,6 @@ class SQLite(DBAPI):
         summary.update(
             {
                 _("Database version"): sqlite3.sqlite_version,
-                _("Database module version"): sqlite3.version,
                 _("Database module location"): sqlite3.__file__,
             }
         )

--- a/gramps/plugins/db/dbapi/sqlite.py
+++ b/gramps/plugins/db/dbapi/sqlite.py
@@ -191,6 +191,24 @@ class Connection:
         )
         return self.fetchone()[0] != 0
 
+    def column_exists(self, table, column):
+        """
+        Test whether the specified SQL column exists in the specified table.
+
+        :param table: table name to check.
+        :type table: str
+        :param column: column name to check.
+        :type column: str
+        :returns: True if the column exists, False otherwise.
+        :rtype: bool
+        """
+        self.execute(
+            "SELECT COUNT(*) "
+            f"FROM pragma_table_info('{table}') "
+            f"WHERE name = '{column}'"
+        )
+        return self.fetchone()[0] != 0
+
     def close(self):
         """
         Close the current database.

--- a/gramps/plugins/docgen/gtkprint.glade
+++ b/gramps/plugins/docgen/gtkprint.glade
@@ -130,7 +130,6 @@
             </child>
             <child>
               <object class="GtkToolItem" id="toolitem1">
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <child>

--- a/gramps/plugins/docgen/gtkprint.glade
+++ b/gramps/plugins/docgen/gtkprint.glade
@@ -22,11 +22,11 @@
             <property name="toolbar-style">icons</property>
             <child>
               <object class="GtkToolButton" id="quit">
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Quit</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Closes print preview window</property>
-                <property name="stock-id">gtk-quit</property>
                 <signal name="clicked" handler="on_quit_clicked" swapped="no"/>
               </object>
               <packing>
@@ -36,11 +36,11 @@
             </child>
             <child>
               <object class="GtkToolButton" id="print">
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Print</property>
+                <property name="use-underline">1</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Prints the current file</property>
-                <property name="stock-id">gtk-print</property>
                 <signal name="clicked" handler="on_print_clicked" swapped="no"/>
               </object>
               <packing>
@@ -60,13 +60,12 @@
             </child>
             <child>
               <object class="GtkToolButton" id="first">
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_First</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Shows the first page</property>
-                <property name="is-important">True</property>
-                <property name="stock-id">gtk-goto-first</property>
                 <signal name="clicked" handler="on_first_clicked" swapped="no"/>
               </object>
               <packing>
@@ -76,13 +75,12 @@
             </child>
             <child>
               <object class="GtkToolButton" id="prev">
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Back</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Shows previous page</property>
-                <property name="is-important">True</property>
-                <property name="stock-id">gtk-go-back</property>
                 <signal name="clicked" handler="on_prev_clicked" swapped="no"/>
               </object>
               <packing>
@@ -92,13 +90,12 @@
             </child>
             <child>
               <object class="GtkToolButton" id="next">
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Forward</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Shows the next page</property>
-                <property name="is-important">True</property>
-                <property name="stock-id">gtk-go-forward</property>
                 <signal name="clicked" handler="on_next_clicked" swapped="no"/>
               </object>
               <packing>
@@ -108,13 +105,12 @@
             </child>
             <child>
               <object class="GtkToolButton" id="last">
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Last</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Shows the last page</property>
-                <property name="is-important">True</property>
-                <property name="stock-id">gtk-goto-last</property>
                 <signal name="clicked" handler="on_last_clicked" swapped="no"/>
               </object>
               <packing>
@@ -189,7 +185,7 @@
             </child>
             <child>
               <object class="GtkToggleToolButton" id="zoom_fit_width">
-                <property name="use-action-appearance">False</property>
+                <property name="icon-name">gramps-zoom-fit-width</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Zooms to fit the page width</property>
@@ -203,11 +199,10 @@
             </child>
             <child>
               <object class="GtkToggleToolButton" id="zoom_best_fit">
-                <property name="use-action-appearance">False</property>
+                <property name="icon-name">gramps-zoom-best-fit</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Zooms to fit the whole page</property>
-                <property name="stock-id">gtk-zoom-fit</property>
                 <signal name="toggled" handler="on_zoom_best_fit_toggled" swapped="no"/>
               </object>
               <packing>
@@ -217,11 +212,10 @@
             </child>
             <child>
               <object class="GtkToolButton" id="zoom_in">
-                <property name="use-action-appearance">False</property>
+                <property name="icon-name">gramps-zoom-in</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Zooms the page in</property>
-                <property name="stock-id">gtk-zoom-in</property>
                 <signal name="clicked" handler="on_zoom_in_clicked" swapped="no"/>
               </object>
               <packing>
@@ -231,11 +225,10 @@
             </child>
             <child>
               <object class="GtkToolButton" id="zoom_out">
-                <property name="use-action-appearance">False</property>
+                <property name="icon-name">gramps-zoom-out</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Zooms the page out</property>
-                <property name="stock-id">gtk-zoom-out</property>
                 <signal name="clicked" handler="on_zoom_out_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gramps/plugins/docgen/gtkprint.py
+++ b/gramps/plugins/docgen/gtkprint.py
@@ -211,13 +211,9 @@ class PrintPreview:
         self._pages_entry = glade_xml.get_object("entry")
         self._pages_label = glade_xml.get_object("label")
         self._zoom_fit_width_button = glade_xml.get_object("zoom_fit_width")
-        self._zoom_fit_width_button.set_stock_id("gramps-zoom-fit-width")
         self._zoom_best_fit_button = glade_xml.get_object("zoom_best_fit")
-        self._zoom_best_fit_button.set_stock_id("gramps-zoom-best-fit")
         self._zoom_in_button = glade_xml.get_object("zoom_in")
-        self._zoom_in_button.set_stock_id("gramps-zoom-in")
         self._zoom_out_button = glade_xml.get_object("zoom_out")
-        self._zoom_out_button.set_stock_id("gramps-zoom-out")
 
         # connect the signals
         glade_xml.connect_signals(self)

--- a/gramps/plugins/gramplet/eval.py
+++ b/gramps/plugins/gramplet/eval.py
@@ -28,7 +28,7 @@ Provide a python evaluation window
 # standard python modules
 #
 # ------------------------------------------------------------------------
-import sys
+import contextlib
 from io import StringIO
 import traceback
 
@@ -110,20 +110,15 @@ class PythonEvaluation(Gramplet):
             )
         )
 
-        oldout = sys.stdout
-        olderr = sys.stderr
         outtext = StringIO()
         errtext = StringIO()
-        sys.stdout = outtext
-        sys.stderr = errtext
-        try:
-            exec(text)
-        except:
-            traceback.print_exc()
+        with contextlib.redirect_stdout(outtext), contextlib.redirect_stderr(errtext):
+            try:
+                exec(text)
+            except:
+                traceback.print_exc()
         self.dbuf.set_text(outtext.getvalue())
         self.error.set_text(errtext.getvalue())
-        sys.stdout = oldout
-        sys.stderr = olderr
 
     def clear_clicked(self, obj):
         self.dbuf.set_text("")

--- a/gramps/plugins/gramplet/sessionloggramplet.py
+++ b/gramps/plugins/gramplet/sessionloggramplet.py
@@ -1,6 +1,6 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2007-2009  Douglas S. Blank <doug.blank@gmail.com>
+# Copyright (C) 2007-2009,2024  Douglas S. Blank <doug.blank@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -30,6 +30,7 @@ import time
 # ------------------------------------------------------------------------
 
 from gramps.gen.lib import Person, Family
+from gramps.gen.lib.serialize import from_dict
 from gramps.gen.db import PERSON_KEY, FAMILY_KEY, TXNDEL
 from gramps.gen.plug import Gramplet
 from gramps.gen.display.name import displayer as name_displayer
@@ -128,8 +129,7 @@ class LogGramplet(Gramplet):
                                 and trans_type == TXNDEL
                                 and hndl == handle
                             ):
-                                person = Person()
-                                person.unserialize(old_data)
+                                person = from_dict(old_data)
                                 name = name_displayer.display(person)
                                 break
                 elif ltype == "Family":
@@ -150,8 +150,7 @@ class LogGramplet(Gramplet):
                                 and trans_type == TXNDEL
                                 and hndl == handle
                             ):
-                                family = Family()
-                                family.unserialize(old_data)
+                                family = from_dict(old_data)
                                 name = family_name(family, self.dbstate.db, name)
                                 break
                 self.append_text(name)

--- a/gramps/plugins/importer/importgedcom.glade
+++ b/gramps/plugins/importer/importgedcom.glade
@@ -43,13 +43,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="okbutton1">
-                <property name="label">gtk-ok</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_OK</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/gramps/plugins/importer/importgedcom.glade
+++ b/gramps/plugins/importer/importgedcom.glade
@@ -90,8 +90,8 @@
               <object class="GtkLabel" id="label18">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="margin-top">6</property>
                 <property name="margin-bottom">6</property>
                 <property name="label" translatable="yes">This GEDCOM file has identified itself as using ANSEL encoding. Sometimes, this is in error. If the imported data contains unusual characters, undo the import, and override the character set by selecting a different encoding below.</property>

--- a/gramps/plugins/importer/importprogen.glade
+++ b/gramps/plugins/importer/importprogen.glade
@@ -156,8 +156,8 @@
                       <object class="GtkImage" id="imp_source_priv_img">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">5</property>
-                        <property name="margin-right">5</property>
+                        <property name="margin-start">5</property>
+                        <property name="margin-end">5</property>
                         <property name="icon-name">dialog-password</property>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="imp_source_priv_img-atkobject">
@@ -280,8 +280,8 @@
                       <object class="GtkImage" id="imp_citation_priv_img">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">5</property>
-                        <property name="margin-right">5</property>
+                        <property name="margin-start">5</property>
+                        <property name="margin-end">5</property>
                         <property name="icon-name">dialog-password</property>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="imp_citation_priv_img-atkobject">
@@ -306,7 +306,7 @@
                   <object class="GtkLabel" id="imp_citation_conf_lbl">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-right">2</property>
+                    <property name="margin-end">2</property>
                     <property name="label" translatable="yes">Confidence</property>
                   </object>
                   <packing>
@@ -438,8 +438,8 @@
                         <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="valign">center</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">2</property>
                         <property name="label" translatable="yes">Text</property>
                       </object>
                       <packing>
@@ -454,7 +454,7 @@
                         <property name="can-focus">True</property>
                         <property name="tooltip-text" translatable="yes">Default Tagtext
 (out of Settings).</property>
-                        <property name="margin-right">4</property>
+                        <property name="margin-end">4</property>
                         <property name="hexpand">True</property>
                       </object>
                       <packing>
@@ -467,7 +467,7 @@
                       <object class="GtkLabel" id="tag_default_fname_lbl">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-end">2</property>
                         <property name="label" translatable="yes">File</property>
                       </object>
                       <packing>
@@ -481,7 +481,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="tooltip-text" translatable="yes">Import Filename.</property>
-                        <property name="margin-right">4</property>
+                        <property name="margin-end">4</property>
                         <property name="width-chars">13</property>
                       </object>
                       <packing>
@@ -494,7 +494,7 @@
                       <object class="GtkLabel" id="tag_default_date_lbl">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-end">2</property>
                         <property name="label" translatable="yes">Date</property>
                       </object>
                       <packing>
@@ -752,7 +752,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-end">2</property>
                         <property name="label" translatable="yes">Citation</property>
                       </object>
                       <packing>
@@ -1194,7 +1194,7 @@ all object tags.</property>
                   <object class="GtkGrid" id="primobj_grid">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">4</property>
+                    <property name="margin-start">4</property>
                     <property name="resize-mode">queue</property>
                     <property name="column-spacing">4</property>
                     <child>
@@ -1296,7 +1296,7 @@ Child import.</property>
                   <object class="GtkGrid" id="option_grid">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">4</property>
+                    <property name="margin-start">4</property>
                     <property name="resize-mode">queue</property>
                     <property name="column-spacing">4</property>
                     <child>
@@ -1351,8 +1351,8 @@ Identifier as Gramps ID.</property>
                       <object class="GtkSeparator" id="opt_sep11">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">8</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">8</property>
                         <property name="orientation">vertical</property>
                       </object>
                       <packing>
@@ -1379,8 +1379,8 @@ Identifier as Gramps ID.</property>
                       <object class="GtkSeparator" id="opt_sep21">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">8</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">8</property>
                         <property name="orientation">vertical</property>
                       </object>
                       <packing>
@@ -1392,8 +1392,8 @@ Identifier as Gramps ID.</property>
                       <object class="GtkSeparator" id="opt_sep22">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">8</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">8</property>
                         <property name="orientation">vertical</property>
                       </object>
                       <packing>
@@ -1405,8 +1405,8 @@ Identifier as Gramps ID.</property>
                       <object class="GtkSeparator" id="opt_sep23">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">8</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">8</property>
                         <property name="orientation">vertical</property>
                       </object>
                       <packing>
@@ -1515,8 +1515,8 @@ as cause of death event.</property>
                       <object class="GtkSeparator" id="opt_sep32">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">8</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">8</property>
                         <property name="orientation">vertical</property>
                       </object>
                       <packing>
@@ -1528,8 +1528,8 @@ as cause of death event.</property>
                       <object class="GtkSeparator" id="opt_sep31">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">8</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">8</property>
                         <property name="orientation">vertical</property>
                       </object>
                       <packing>
@@ -1591,8 +1591,8 @@ to e.g. husbands name.</property>
                       <object class="GtkSeparator" id="opt_sep13">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">8</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">8</property>
                         <property name="orientation">vertical</property>
                       </object>
                       <packing>
@@ -1604,8 +1604,8 @@ to e.g. husbands name.</property>
                       <object class="GtkSeparator" id="opt_sep12">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-left">8</property>
-                        <property name="margin-right">8</property>
+                        <property name="margin-start">8</property>
+                        <property name="margin-end">8</property>
                         <property name="orientation">vertical</property>
                       </object>
                       <packing>

--- a/gramps/plugins/importer/importprogen.glade
+++ b/gramps/plugins/importer/importprogen.glade
@@ -26,7 +26,6 @@
             <child>
               <object class="GtkButton" id="import_cancel">
                 <property name="label" translatable="yes">_Cancel</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="is-focus">True</property>
@@ -43,7 +42,6 @@
             <child>
               <object class="GtkButton" id="import_ok">
                 <property name="label" translatable="yes">_Ok</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="is-focus">True</property>
@@ -61,7 +59,6 @@
             <child>
               <object class="GtkButton" id="import_help">
                 <property name="label" translatable="yes">_Help</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -516,7 +513,6 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="tag_default_date_btn">
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>

--- a/gramps/plugins/importer/importprogen.glade
+++ b/gramps/plugins/importer/importprogen.glade
@@ -136,7 +136,6 @@
 (out of Settings)</property>
                     <property name="halign">start</property>
                     <property name="resize-mode">queue</property>
-                    <property name="xalign">0</property>
                     <property name="draw-indicator">True</property>
                     <signal name="toggled" handler="on_source_button_toggled" swapped="no"/>
                   </object>
@@ -244,7 +243,6 @@
                     <property name="receives-default">False</property>
                     <property name="tooltip-text" translatable="yes">Citation reference.</property>
                     <property name="halign">start</property>
-                    <property name="xalign">0</property>
                     <property name="draw-indicator">True</property>
                     <signal name="toggled" handler="on_citation_button_toggled" swapped="no"/>
                   </object>
@@ -587,7 +585,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
                       </object>
@@ -602,7 +599,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
                       </object>
@@ -617,7 +613,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
                       </object>
@@ -632,7 +627,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
                       </object>
@@ -647,7 +641,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
                       </object>
@@ -662,7 +655,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
                       </object>
@@ -677,7 +669,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
                       </object>
@@ -869,7 +860,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_fname_button_toggled" swapped="no"/>
                       </object>
@@ -884,7 +874,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_fname_button_toggled" swapped="no"/>
                       </object>
@@ -899,7 +888,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_fname_button_toggled" swapped="no"/>
                       </object>
@@ -914,7 +902,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_fname_button_toggled" swapped="no"/>
                       </object>
@@ -929,7 +916,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_fname_button_toggled" swapped="no"/>
                       </object>
@@ -944,7 +930,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_fname_button_toggled" swapped="no"/>
                       </object>
@@ -959,7 +944,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_fname_button_toggled" swapped="no"/>
                       </object>
@@ -974,7 +958,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_date_button_toggled" swapped="no"/>
                       </object>
@@ -989,7 +972,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_date_button_toggled" swapped="no"/>
                       </object>
@@ -1004,7 +986,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_date_button_toggled" swapped="no"/>
                       </object>
@@ -1019,7 +1000,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_date_button_toggled" swapped="no"/>
                       </object>
@@ -1034,7 +1014,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_date_button_toggled" swapped="no"/>
                       </object>
@@ -1049,7 +1028,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_date_button_toggled" swapped="no"/>
                       </object>
@@ -1064,7 +1042,6 @@
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">center</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_date_button_toggled" swapped="no"/>
                       </object>
@@ -1205,7 +1182,7 @@ all object tags.</property>
                         <property name="receives-default">False</property>
                         <property name="tooltip-text" translatable="yes">Enable/Disable
 Person import.</property>
-                        <property name="xalign">0</property>
+                        <property name="halign">start</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_primobj_button_toggled" swapped="no"/>
                       </object>
@@ -1222,7 +1199,7 @@ Person import.</property>
                         <property name="receives-default">False</property>
                         <property name="tooltip-text" translatable="yes">Enable/Disable
 Family import.</property>
-                        <property name="xalign">0</property>
+                        <property name="halign">start</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_primobj_button_toggled" swapped="no"/>
                       </object>
@@ -1239,7 +1216,7 @@ Family import.</property>
                         <property name="receives-default">False</property>
                         <property name="tooltip-text" translatable="yes">Enable/Disable
 Child import.</property>
-                        <property name="xalign">0</property>
+                        <property name="halign">start</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_primobj_button_toggled" swapped="no"/>
                       </object>
@@ -1308,7 +1285,6 @@ Child import.</property>
                         <property name="tooltip-text" translatable="yes">Use original Person
 Identifier as Gramps ID.</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -1325,7 +1301,6 @@ Identifier as Gramps ID.</property>
                         <property name="tooltip-text" translatable="yes">Use original Family
 Identifier as Gramps ID.</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -1438,7 +1413,6 @@ Identifier as Gramps ID.</property>
                         <property name="tooltip-text" translatable="yes">Store birth date in
 event description.</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -1456,7 +1430,6 @@ event description.</property>
                         <property name="tooltip-text" translatable="yes">Store death date in
 event description.</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -1487,7 +1460,6 @@ event description.</property>
                         <property name="tooltip-text" translatable="yes">Store REFN number
 in event description.</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -1503,7 +1475,6 @@ in event description.</property>
                         <property name="tooltip-text" translatable="yes">Use death information
 as cause of death event.</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -1561,7 +1532,7 @@ as cause of death event.</property>
                         <property name="receives-default">False</property>
                         <property name="tooltip-text" translatable="yes">Change name of male
 to e.g. wifes name.</property>
-                        <property name="xalign">0</property>
+                        <property name="halign">start</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_surname_button_toggled" swapped="no"/>
                       </object>
@@ -1578,7 +1549,7 @@ to e.g. wifes name.</property>
                         <property name="receives-default">False</property>
                         <property name="tooltip-text" translatable="yes">Change name of female
 to e.g. husbands name.</property>
-                        <property name="xalign">0</property>
+                        <property name="halign">start</property>
                         <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="on_surname_button_toggled" swapped="no"/>
                       </object>

--- a/gramps/plugins/importer/importvcard.py
+++ b/gramps/plugins/importer/importvcard.py
@@ -525,11 +525,11 @@ class VCardParser:
                     else:
                         addr.set_street(strng)
 
-            addr.add_street = add_street
+            addr._add_street = add_street
             set_func = [
-                "add_street",
-                "add_street",
-                "add_street",
+                "_add_street",
+                "_add_street",
+                "_add_street",
                 "set_city",
                 "set_state",
                 "set_postal_code",

--- a/gramps/plugins/importer/importxml.py
+++ b/gramps/plugins/importer/importxml.py
@@ -3,7 +3,7 @@
 #
 # Copyright (C) 2000-2007  Donald N. Allingham
 # Copyright (C) 200?-2013  Benny Malengier
-# Copyright (C) 2009       Douglas S. Blank
+# Copyright (C) 2009,2024  Douglas S. Blank
 # Copyright (C) 2010-2011  Nick Hall
 # Copyright (C) 2011       Michiel D. Nauta
 # Copyright (C) 2011       Tim G L Lyons
@@ -91,6 +91,7 @@ from gramps.gen.lib import (
     Tag,
     Url,
 )
+from gramps.gen.lib.serialize import from_dict
 from gramps.gen.db import DbTxn
 
 # from gramps.gen.db.write import CLASS_TO_KEY_MAP
@@ -839,7 +840,8 @@ class GrampsParser(UpdateCallback):
                     "tag": self.db.get_raw_tag_data,
                 }[target]
                 raw = get_raw_obj_data(handle)
-                prim_obj.unserialize(raw)
+                temp_obj = from_dict(raw)
+                prim_obj.set_object_state(temp_obj.get_object_state())
                 self.import_handles[orig_handle][target][INSTANTIATED] = True
             return handle
         elif handle in self.import_handles:
@@ -1000,7 +1002,8 @@ class GrampsParser(UpdateCallback):
         handle = id2handle_map.get(gramps_id)
         if handle:
             raw = get_raw_obj_data(handle)
-            prim_obj.unserialize(raw)
+            temp_obj = from_dict(raw)
+            prim_obj.set_object_state(temp_obj.get_object_state())
         else:
             handle = create_id()
             while has_handle_func(handle):

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -6,6 +6,7 @@
 # Copyright (C) 2010       Nick Hall
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2016       Paul R. Culley
+# Copyright (C) 2024       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -157,6 +158,7 @@ from gramps.gen.lib import (
     PlaceRef,
     PlaceName,
 )
+from gramps.gen.lib.serialize import from_dict, to_dict
 from gramps.gen.db import DbTxn
 from gramps.gen.updatecallback import UpdateCallback
 from gramps.gen.utils.file import media_path
@@ -2163,7 +2165,7 @@ class GedcomParser(UpdateCallback):
     __TRUNC_MSG = _(
         "Your GEDCOM file is corrupted. " "It appears to have been truncated."
     )
-    _EMPTY_LOC = Location().serialize()
+    _EMPTY_LOC = to_dict(Location())
 
     SyntaxError = "Syntax Error"
     BadFile = "Not a GEDCOM file"
@@ -3185,11 +3187,11 @@ class GedcomParser(UpdateCallback):
         already used (is in the db), we return the item in the db. Otherwise,
         we create a new person, assign the handle and Gramps ID.
         """
-        person = Person()
         intid = self.gid2id.get(gramps_id)
         if self.dbase.has_person_handle(intid):
-            person.unserialize(self.dbase.get_raw_person_data(intid))
+            person = from_dict(self.dbase.get_raw_person_data(intid))
         else:
+            person = Person()
             intid = self.__find_from_handle(gramps_id, self.gid2id)
             person.set_handle(intid)
             person.set_gramps_id(gramps_id)
@@ -3201,16 +3203,16 @@ class GedcomParser(UpdateCallback):
         already used (is in the db), we return the item in the db. Otherwise,
         we create a new family, assign the handle and Gramps ID.
         """
-        family = Family()
-        # Add a counter for reordering the children later:
-        family.child_ref_count = 0
         intid = self.fid2id.get(gramps_id)
         if self.dbase.has_family_handle(intid):
-            family.unserialize(self.dbase.get_raw_family_data(intid))
+            family = from_dict(self.dbase.get_raw_family_data(intid))
         else:
+            family = Family()
             intid = self.__find_from_handle(gramps_id, self.fid2id)
             family.set_handle(intid)
             family.set_gramps_id(gramps_id)
+        # Add a counter for reordering the children later:
+        family._child_ref_count = 0
         return family
 
     def __find_or_create_media(self, gramps_id):
@@ -3219,11 +3221,11 @@ class GedcomParser(UpdateCallback):
         already used (is in the db), we return the item in the db. Otherwise,
         we create a new media object, assign the handle and Gramps ID.
         """
-        obj = Media()
         intid = self.oid2id.get(gramps_id)
         if self.dbase.has_media_handle(intid):
-            obj.unserialize(self.dbase.get_raw_media_data(intid))
+            obj = from_dict(self.dbase.get_raw_media_data(intid))
         else:
+            obj = Media()
             intid = self.__find_from_handle(gramps_id, self.oid2id)
             obj.set_handle(intid)
             obj.set_gramps_id(gramps_id)
@@ -3237,11 +3239,11 @@ class GedcomParser(UpdateCallback):
         db. Otherwise, we create a new source, assign the handle and Gramps ID.
 
         """
-        obj = Source()
         intid = self.sid2id.get(gramps_id)
         if self.dbase.has_source_handle(intid):
-            obj.unserialize(self.dbase.get_raw_source_data(intid))
+            obj = from_dict(self.dbase.get_raw_source_data(intid))
         else:
+            obj = Source()
             intid = self.__find_from_handle(gramps_id, self.sid2id)
             obj.set_handle(intid)
             obj.set_gramps_id(gramps_id)
@@ -3256,11 +3258,11 @@ class GedcomParser(UpdateCallback):
         Some GEDCOM "flavors" destroy the specification, and declare the
         repository inline instead of in a object.
         """
-        repository = Repository()
         intid = self.rid2id.get(gramps_id)
         if self.dbase.has_repository_handle(intid):
-            repository.unserialize(self.dbase.get_raw_repository_data(intid))
+            repository = from_dict(self.dbase.get_raw_repository_data(intid))
         else:
+            repository = Repository()
             intid = self.__find_from_handle(gramps_id, self.rid2id)
             repository.set_handle(intid)
             repository.set_gramps_id(gramps_id)
@@ -3274,7 +3276,6 @@ class GedcomParser(UpdateCallback):
         If no Gramps ID is passed in, we not only make a Note with GID, we
         commit it.
         """
-        note = Note()
         if not gramps_id:
             need_commit = True
             gramps_id = self.dbase.find_next_note_gramps_id()
@@ -3283,8 +3284,9 @@ class GedcomParser(UpdateCallback):
 
         intid = self.nid2id.get(gramps_id)
         if self.dbase.has_note_handle(intid):
-            note.unserialize(self.dbase.get_raw_note_data(intid))
+            note = from_dict(self.dbase.get_raw_note_data(intid))
         else:
+            note = Note()
             intid = self.__find_from_handle(gramps_id, self.nid2id)
             note.set_handle(intid)
             note.set_gramps_id(gramps_id)
@@ -3302,7 +3304,7 @@ class GedcomParser(UpdateCallback):
         """
         if location is None:
             return True
-        elif location.serialize() == self._EMPTY_LOC:
+        elif to_dict(location) == self._EMPTY_LOC:
             return True
         elif location.is_empty():
             return True
@@ -5646,8 +5648,8 @@ class GedcomParser(UpdateCallback):
         order given in the FAM section.
         """
         family.child_ref_list.remove(child_ref)
-        family.child_ref_list.insert(family.child_ref_count, child_ref)
-        family.child_ref_count += 1
+        family.child_ref_list.insert(family._child_ref_count, child_ref)
+        family._child_ref_count += 1
 
     def __family_slgs(self, line, state):
         """

--- a/gramps/plugins/lib/libgedcom.py
+++ b/gramps/plugins/lib/libgedcom.py
@@ -1006,10 +1006,8 @@ class Lexer:
                     line_value = line[2].lstrip()
                     # Ignore meaningless @IDENT@ on CONT or CONC line
                     # as noted at http://www.tamurajones.net/IdentCONT.xhtml
-                    if line_value.lstrip().startswith(
-                        "CONT "
-                    ) or line_value.lstrip().startswith("CONC "):
-                        line = line_value.lstrip().partition(" ")
+                    if line_value.startswith(("CONT ", "CONC ")):
+                        line = line_value.partition(" ")
                         tag = line[0]
                         line_value = line[2]
                 else:
@@ -4009,7 +4007,7 @@ class GedcomParser(UpdateCallback):
                 self.__check_msgs(_("Top Level"), state, None)
             elif key in ("SOUR", "SOURCE"):
                 self.__parse_source(line.token_text, 1)
-            elif line.data.startswith("SOUR ") or line.data.startswith("SOURCE "):
+            elif line.data.startswith(("SOUR ", "SOURCE ")):
                 # A source formatted in a single line, for example:
                 # 0 @S62@ SOUR This is the title of the source
                 source = self.__find_or_create_source(self.sid_map[line.data])

--- a/gramps/plugins/lib/libhtml.py
+++ b/gramps/plugins/lib/libhtml.py
@@ -520,9 +520,10 @@ class Html(list):
             self[0:0] = [doctype]
 
     #
-    def __gettag(self):
+    @property
+    def tag(self):
         """
-        Returns HTML tag for this object
+        The HTML tag for this object.
 
         :rtype:   string
         :returns: HTML tag
@@ -530,13 +531,8 @@ class Html(list):
         return self[0].split()[0].strip("< >")
 
     #
-    def __settag(self, newtag):
-        """
-        Sets a new HTML tag for this object
-
-        :type  name: string
-        :param name: new HTML tag
-        """
+    @tag.setter
+    def tag(self, newtag):
         curtag = self.tag
 
         # Replace closing tag, if any
@@ -548,12 +544,11 @@ class Html(list):
 
         self[0] = self[0].replace("<" + curtag, "<" + newtag)
 
-    tag = property(__gettag, __settag)
-
     #
-    def __getattr(self):
+    @property
+    def attr(self):
         """
-        Returns HTML attributes for this object
+        The HTML attributes for this object.
 
         :rtype:   string
         :returns: HTML attributes
@@ -562,13 +557,8 @@ class Html(list):
         return attr[1] if len(attr) > 1 else ""
 
     #
-    def __setattr(self, value):
-        """
-        Sets new HTML attributes for this object
-
-        :type  name: string
-        :param name: new HTML attributes
-        """
+    @attr.setter
+    def attr(self, value):
         beg = len(self.tag) + 1
 
         # See if self-closed or normal
@@ -577,10 +567,8 @@ class Html(list):
         self[0] = self[0][:beg] + " " + value + self[0][end:]
 
     #
-    def __delattr(self):
-        """
-        Removes HTML attributes for this object
-        """
+    @attr.deleter
+    def attr(self):
         self[0] = (
             "<"
             + self.tag
@@ -590,12 +578,10 @@ class Html(list):
         )
 
     #
-    attr = property(__getattr, __setattr, __delattr)
-
-    #
-    def __getinside(self):
+    @property
+    def inside(self):
         """
-        Returns list of items between opening and closing tags
+        The list of items between opening and closing tags.
 
         :rtype:   list
         :returns: list of items between opening and closing HTML tags
@@ -603,13 +589,8 @@ class Html(list):
         return self[1:-1]
 
     #
-    def __setinside(self, value):
-        """
-        Sets new contents between opening and closing tags
-
-        :type  name: list
-        :param name: new HTML contents
-        """
+    @inside.setter
+    def inside(self, value):
         if len(self) < 2:
             raise AttributeError("No closing tag. Cannot set inside value")
         if (
@@ -621,14 +602,10 @@ class Html(list):
         self[1:-1] = value
 
     #
-    def __delinside(self):
-        """
-        Removes contents between opening and closing tag
-        """
+    @inside.deleter
+    def inside(self):
         if len(self) > 2:
             self[:] = self[:1] + self[-1:]
-
-    inside = property(__getinside, __setinside, __delinside)
 
     #
     def __enter__(self):

--- a/gramps/plugins/lib/libmixin.py
+++ b/gramps/plugins/lib/libmixin.py
@@ -2,6 +2,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2000-2007  Donald N. Allingham
+# Copyright (C) 2024       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -38,6 +39,7 @@ from gramps.gen.lib import (
     Note,
     Tag,
 )
+from gramps.gen.lib.serialize import from_dict
 
 
 # ------------------------------------------------------------------------------
@@ -77,7 +79,7 @@ class DbMixin:
         new = True
         raw = get_raw_obj_data(handle)
         if raw is not None:
-            obj.unserialize(raw)
+            obj = from_dict(raw)
             # references create object with id None before object is really made
             if obj.gramps_id is not None:
                 new = False
@@ -103,7 +105,7 @@ class DbMixin:
         handle = str(handle)
         raw = get_raw_obj_data(handle)
         if raw is not None:
-            obj.unserialize(raw)
+            obj = from_dict(raw)
             return obj, False
         else:
             obj.set_handle(handle)

--- a/gramps/plugins/lib/libprogen.py
+++ b/gramps/plugins/lib/libprogen.py
@@ -855,16 +855,16 @@ class ProgenParser(UpdateCallback):
         """
         # If the ID is already used (= is in the database), return the item in
         # DB. Otherwise, create a new person, assign the handle and Gramps ID.
-        person = Person()
         intid = self.gid2id.get(progen_id)
         if self.dbase.has_person_handle(intid):
-            person.unserialize(self.dbase.get_raw_person_data(intid))
+            person = self.dbase.get_person_from_gramps_id(intid)
         else:
             # create a new Person
             gramps_id = self.dbase.id2user_format("I%06d" % progen_id)
             if self.dbase.has_person_gramps_id(gramps_id):
                 gramps_id = self.dbase.find_next_person_gramps_id()
             intid = self.__find_from_handle(progen_id, self.gid2id)
+            person = Person()
             person.set_handle(intid)
             person.set_gramps_id(gramps_id)
 
@@ -877,16 +877,16 @@ class ProgenParser(UpdateCallback):
         """
         Finds or creates a Family based on the Pro-Gen ID.
         """
-        family = Family()
         intid = self.fid2id.get(progen_id)
         if self.dbase.has_family_handle(intid):
-            family.unserialize(self.dbase.get_raw_family_data(intid))
+            family = self.dbase.get_family_from_gramps_id(intid)
         else:
             # create a new Family
             gramps_id = self.dbase.fid2user_format("F%04d" % progen_id)
             if self.dbase.has_family_gramps_id(gramps_id):
                 gramps_id = self.dbase.find_next_family_gramps_id()
             intid = self.__find_from_handle(progen_id, self.fid2id)
+            family = Family()
             family.set_handle(intid)
             family.set_gramps_id(gramps_id)
 

--- a/gramps/plugins/lib/maps/datelayer.py
+++ b/gramps/plugins/lib/maps/datelayer.py
@@ -123,13 +123,9 @@ class DateLayer(GObject.GObject, osmgpsmap.MapLayer):
             self.font, cairo.FONT_SLANT_NORMAL, cairo.FONT_WEIGHT_NORMAL
         )
         ctx.set_font_size(int(self.size))
-        color = Gdk.color_parse(self.color)
-        ctx.set_source_rgba(
-            float(color.red / 65535.0),
-            float(color.green / 65535.0),
-            float(color.blue / 65535.0),
-            0.6,
-        )  # transparency
+        rgba = Gdk.RGBA()
+        rgba.parse(self.color)
+        ctx.set_source_rgba(rgba.red, rgba.green, rgba.blue, 0.6)
         coord_x = 10
         coord_y = 15 + 2 * int(self.size)  # Display the oldest date
         ctx.move_to(coord_x, coord_y)

--- a/gramps/plugins/lib/maps/kmllayer.py
+++ b/gramps/plugins/lib/maps/kmllayer.py
@@ -114,8 +114,10 @@ class KmlLayer(GObject.GObject, osmgpsmap.MapLayer):
         """
         Draw all the surfaces and paths
         """
-        color1 = Gdk.color_parse("red")
-        color2 = Gdk.color_parse("blue")
+        color1 = Gdk.RGBA()
+        color1.parse("red")
+        color2 = Gdk.RGBA()
+        color2.parse("blue")
         for polygons in self.polygons:
             for polygon in polygons:
                 (dummy_name, ptype, dummy_color, dummy_transparency, points) = polygon
@@ -126,12 +128,7 @@ class KmlLayer(GObject.GObject, osmgpsmap.MapLayer):
                     map_points.append((coord_x, coord_y))
                 first = True
                 ctx.save()
-                ctx.set_source_rgba(
-                    float(color2.red / 65535.0),
-                    float(color2.green / 65535.0),
-                    float(color2.blue / 65535.0),
-                    0.3,
-                )  # transparency
+                ctx.set_source_rgba(color2.red, color2.green, color2.blue, 0.3)
                 ctx.set_line_cap(cairo.LINE_CAP_ROUND)
                 ctx.set_line_join(cairo.LINE_JOIN_ROUND)
                 ctx.set_line_width(3)
@@ -162,12 +159,7 @@ class KmlLayer(GObject.GObject, osmgpsmap.MapLayer):
                     map_points.append((coord_x, coord_y))
                 first = True
                 ctx.save()
-                ctx.set_source_rgba(
-                    float(color1.red / 65535.0),
-                    float(color1.green / 65535.0),
-                    float(color1.blue / 65535.0),
-                    0.5,
-                )  # transparency
+                ctx.set_source_rgba(color1.red, color1.green, color1.blue, 0.5)
                 ctx.set_line_width(5)
                 ctx.set_operator(cairo.OPERATOR_ATOP)
                 for idx_pt in range(0, len(map_points)):

--- a/gramps/plugins/lib/maps/lifewaylayer.py
+++ b/gramps/plugins/lib/maps/lifewaylayer.py
@@ -95,16 +95,22 @@ class LifeWayLayer(GObject.GObject, osmgpsmap.MapLayer):
         radius is the size of the track.
         """
         if isinstance(color, str):
-            color = Gdk.color_parse(color)
-        self.lifeways_ref.append((points, color, radius))
+            rgba = Gdk.RGBA()
+            rgba.parse(color)
+        else:
+            rgba = color
+        self.lifeways_ref.append((points, rgba, radius))
 
     def add_way(self, points, color):
         """
         Add a track or life way.
         """
         if isinstance(color, str):
-            color = Gdk.color_parse(color)
-        self.lifeways.append((points, color))
+            rgba = Gdk.RGBA()
+            rgba.parse(color)
+        else:
+            rgba = color
+        self.lifeways.append((points, rgba))
 
     def do_draw(self, gpsmap, ctx):
         """
@@ -114,13 +120,8 @@ class LifeWayLayer(GObject.GObject, osmgpsmap.MapLayer):
             ctx.set_line_cap(cairo.LINE_CAP_ROUND)
             ctx.set_line_join(cairo.LINE_JOIN_ROUND)
             ctx.set_line_width(3)
-            color = lifeway[1]
-            ctx.set_source_rgba(
-                float(color.red / 65535.0),
-                float(color.green / 65535.0),
-                float(color.blue / 65535.0),
-                0.1,
-            )  # transparency
+            rgba = lifeway[1]
+            ctx.set_source_rgba(rgba.red, rgba.green, rgba.blue, 0.1)
             rds = float(lifeway[2])
             for point in lifeway[0]:
                 conv_pt1 = osmgpsmap.MapPoint.new_degrees(point[0], point[1])
@@ -154,12 +155,8 @@ class LifeWayLayer(GObject.GObject, osmgpsmap.MapLayer):
                 conv_pt = osmgpsmap.MapPoint.new_degrees(point[0], point[1])
                 coord_x, coord_y = gpsmap.convert_geographic_to_screen(conv_pt)
                 map_points.append((coord_x, coord_y))
-            color = lifeway[1]
-            ctx.set_source_rgb(
-                float(color.red / 65535.0),
-                float(color.green / 65535.0),
-                float(color.blue / 65535.0),
-            )
+            rgba = lifeway[1]
+            ctx.set_source_rgb(rgba.red, rgba.green, rgba.blue)
             first = True
             for idx_pt in range(0, len(map_points)):
                 if first:

--- a/gramps/plugins/lib/maps/markerlayer.py
+++ b/gramps/plugins/lib/maps/markerlayer.py
@@ -191,11 +191,12 @@ GObject.type_register(MarkerLayer)
 def draw_marker(ctx, x01, y01, size, color):
     width = 48.0 * size
     height = width / 2
-    color = Gdk.color_parse(color)
+    rgba = Gdk.RGBA()
+    rgba.parse(color)
     fill_color = (
-        color.red / 65535.0,
-        color.green / 65535.0,
-        color.blue / 65535.0,
+        rgba.red,
+        rgba.green,
+        rgba.blue,
         1.0,  # transparency
     )
     stroke_color = (1.0, 0.0, 0.0, 0.5)

--- a/gramps/plugins/lib/maps/messagelayer.py
+++ b/gramps/plugins/lib/maps/messagelayer.py
@@ -123,13 +123,9 @@ class MessageLayer(GObject.GObject, osmgpsmap.MapLayer):
         # font = Pango.FontDescription(font_size)
         descr = Pango.font_description_from_string(self.font)
         descr.set_size(self.size * Pango.SCALE)
-        color = Gdk.color_parse(self.color)
-        ctx.set_source_rgba(
-            float(color.red / 65535.0),
-            float(color.green / 65535.0),
-            float(color.blue / 65535.0),
-            0.9,
-        )  # transparency
+        rgba = Gdk.RGBA()
+        rgba.parse(self.color)
+        ctx.set_source_rgba(rgba.red, rgba.green, rgba.blue, 0.9)
         d_width = gpsmap.get_allocation().width
         d_width -= 100
         ctx.restore()

--- a/gramps/plugins/test/imports_test.py
+++ b/gramps/plugins/test/imports_test.py
@@ -36,7 +36,7 @@ from gramps.gen.utils.config import config
 
 config.set("preferences.date-format", 0)
 from gramps.gen.db.utils import import_as_dict
-from gramps.gen.merge.diff import diff_dbs, to_struct
+from gramps.gen.merge.diff import diff_dbs, to_dict
 from gramps.gen.simple import SimpleAccess
 from gramps.gen.utils.id import set_det_id
 from gramps.gen.user import User
@@ -89,7 +89,7 @@ class TestImports(unittest.TestCase):
         if diffs:
             for diff in diffs:
                 obj_type, item1, item2 = diff
-                msg = self._report_diff(obj_type, to_struct(item1), to_struct(item2))
+                msg = self._report_diff(obj_type, to_dict(item1), to_dict(item2))
                 if msg != "":
                     if hasattr(item1, "gramps_id"):
                         self.msg += "%s: %s  handle=%s\n" % (

--- a/gramps/plugins/test/tools_test.py
+++ b/gramps/plugins/test/tools_test.py
@@ -149,11 +149,9 @@ class ToolControl(unittest.TestCase):
         self.assertTrue(check_res(out, err, expect, do_out=True))
         out, err = call("-O", TREE_NAME, "-y", "-a", "tool", "-p", "name=check")
         expect = [
-            "7 broken child/family links were fixed",
-            "4 broken spouse/family links were fixed",
             "1 place alternate name fixed",
-            "10 media objects were referenced, but not found",
-            "References to 10 missing media objects were kept",
+            "9 media objects were referenced, but not found",
+            "References to 9 missing media objects were kept",
             "3 events were referenced, but not found",
             "1 invalid birth event name was fixed",
             "1 invalid death event name was fixed",
@@ -161,13 +159,13 @@ class ToolControl(unittest.TestCase):
             "16 citations were referenced, but not found",
             "19 sources were referenced, but not found",
             "9 Duplicated Gramps IDs fixed",
-            "7 empty objects removed",
+            "9 empty objects removed:",
             "1 person objects",
             "1 family objects",
             "1 event objects",
             "1 source objects",
-            "0 media objects",
-            "0 place objects",
+            "1 media objects",
+            "1 place objects",
             "1 repository objects",
             "1 note objects",
         ]

--- a/gramps/plugins/textreport/kinshipreport.py
+++ b/gramps/plugins/textreport/kinshipreport.py
@@ -6,6 +6,7 @@
 # Contribution  2009 by   Reinhard Mueller <reinhard.mueller@bytewise.at>
 # Copyright (C) 2010      Jakim Friant
 # Copyright (C) 2013-2014 Paul Franklin
+# Copyright (C) 2024      Brian McCullough
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -81,6 +82,7 @@ class KinshipReport(Report):
 
         maxdescend    - Maximum generations of descendants to include.
         maxascend     - Maximum generations of ancestors to include.
+        incids        - Whether to show Gramps IDs.
         incspouses    - Whether to include spouses.
         inccousins    - Whether to include cousins.
         incaunts      - Whether to include aunts/uncles/nephews/nieces.
@@ -104,6 +106,8 @@ class KinshipReport(Report):
 
         self.max_descend = menu.get_option_by_name("maxdescend").get_value()
         self.max_ascend = menu.get_option_by_name("maxascend").get_value()
+        self.inc_ids = True
+        self.inc_ids = menu.get_option_by_name("incids").get_value()
         self.inc_spouses = menu.get_option_by_name("incspouses").get_value()
         self.inc_cousins = menu.get_option_by_name("inccousins").get_value()
         self.inc_aunts = menu.get_option_by_name("incaunts").get_value()
@@ -314,6 +318,8 @@ class KinshipReport(Report):
         person = self.database.get_person_from_handle(person_handle)
 
         name = self._name_display.display(person)
+        if self.inc_ids:
+            name = person.get_gramps_id() + ": " + name
         mark = utils.get_person_mark(self.database, person)
         birth_date = ""
         birth = get_birth_or_fallback(self.database, person)
@@ -375,6 +381,10 @@ class KinshipOptions(MenuReportOptions):
         maxascend = NumberOption(_("Max Ancestor Generations"), 2, 1, 50)
         maxascend.set_help(_("The maximum number of ancestor generations"))
         menu.add_option(category_name, "maxascend", maxascend)
+
+        incids = BooleanOption(_("Show Gramps ID"), False)
+        incids.set_help(_("Whether to show Gramps ID"))
+        menu.add_option(category_name, "incids", incids)
 
         incspouses = BooleanOption(_("Include spouses"), True)
         incspouses.set_help(_("Whether to include spouses"))

--- a/gramps/plugins/tool/changenames.glade
+++ b/gramps/plugins/tool/changenames.glade
@@ -69,13 +69,12 @@ Select the names you wish Gramps to convert. </property>
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="help">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>
@@ -86,13 +85,12 @@ Select the names you wish Gramps to convert. </property>
             </child>
             <child>
               <object class="GtkButton" id="button6">
-                <property name="label">gtk-cancel</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Cancel</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="changenames" swapped="yes"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/changenames.glade
+++ b/gramps/plugins/tool/changenames.glade
@@ -102,7 +102,6 @@ Select the names you wish Gramps to convert. </property>
             <child>
               <object class="GtkButton" id="button5">
                 <property name="label" translatable="yes">_Accept changes and close</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/plugins/tool/changetypes.glade
+++ b/gramps/plugins/tool/changetypes.glade
@@ -19,13 +19,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button5">
-                <property name="label">gtk-cancel</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Cancel</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_close_clicked" object="changetypes" swapped="yes"/>
               </object>
               <packing>
@@ -36,13 +35,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button3">
-                <property name="label">gtk-ok</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_OK</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_apply_clicked" object="changetypes" swapped="yes"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/changetypes.glade
+++ b/gramps/plugins/tool/changetypes.glade
@@ -83,8 +83,8 @@
               <object class="GtkLabel" id="label4">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">12</property>
-                <property name="margin-right">12</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
                 <property name="margin-top">12</property>
                 <property name="margin-bottom">12</property>
                 <property name="label" translatable="yes">This tool will rename all events of one type to a different type. Once completed, this cannot be undone by the regular Undo function.</property>

--- a/gramps/plugins/tool/check.glade
+++ b/gramps/plugins/tool/check.glade
@@ -18,13 +18,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="close">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="check" swapped="yes"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/eventcmp.glade
+++ b/gramps/plugins/tool/eventcmp.glade
@@ -243,8 +243,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">end</property>
-                <property name="margin-left">5</property>
-                <property name="margin-right">5</property>
+                <property name="margin-start">5</property>
+                <property name="margin-end">5</property>
                 <property name="label" translatable="yes">_Filter:</property>
                 <property name="use-underline">True</property>
                 <property name="justify">center</property>

--- a/gramps/plugins/tool/eventcmp.glade
+++ b/gramps/plugins/tool/eventcmp.glade
@@ -18,13 +18,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button21">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="eventcmp" swapped="yes"/>
               </object>
               <packing>
@@ -35,13 +34,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button19">
-                <property name="label">gtk-save-as</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">Save _As</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_write_table" object="eventcmp" swapped="yes"/>
               </object>
               <packing>
@@ -52,13 +50,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button30">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>
@@ -173,13 +170,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button27">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="filters" swapped="yes"/>
               </object>
               <packing>
@@ -190,13 +186,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button26">
-                <property name="label">gtk-apply</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Apply</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_apply_clicked" object="filters" swapped="yes"/>
               </object>
               <packing>
@@ -207,13 +202,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button29">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/eventcmp.glade
+++ b/gramps/plugins/tool/eventcmp.glade
@@ -264,7 +264,6 @@
             <child>
               <object class="GtkButton" id="button28">
                 <property name="label" translatable="yes">Custom filter _editor</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>

--- a/gramps/plugins/tool/finddupes.glade
+++ b/gramps/plugins/tool/finddupes.glade
@@ -148,7 +148,7 @@
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="halign">center</property>
-                    <property name="margin-left">12</property>
+                    <property name="margin-start">12</property>
                     <property name="hexpand">True</property>
                     <property name="use-underline">True</property>
                     <property name="xalign">0.5</property>
@@ -164,7 +164,7 @@
                   <object class="GtkComboBox" id="menu">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">12</property>
+                    <property name="margin-start">12</property>
                     <property name="hexpand">True</property>
                     <property name="model">liststore1</property>
                     <child>

--- a/gramps/plugins/tool/finddupes.glade
+++ b/gramps/plugins/tool/finddupes.glade
@@ -25,13 +25,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button12">
-                <property name="label">gtk-cancel</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Cancel</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="finddupes" swapped="yes"/>
               </object>
               <packing>
@@ -42,13 +41,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button10">
-                <property name="label">gtk-ok</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_OK</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_merge_ok_clicked" object="finddupes" swapped="yes"/>
               </object>
               <packing>
@@ -59,13 +57,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button14">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>
@@ -243,13 +240,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button9">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="mergelist" swapped="yes"/>
               </object>
               <packing>
@@ -277,13 +273,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button13">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_show_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/finddupes.glade
+++ b/gramps/plugins/tool/finddupes.glade
@@ -151,7 +151,6 @@
                     <property name="margin-start">12</property>
                     <property name="hexpand">True</property>
                     <property name="use-underline">True</property>
-                    <property name="xalign">0.5</property>
                     <property name="active">True</property>
                     <property name="draw-indicator">True</property>
                   </object>

--- a/gramps/plugins/tool/finddupes.glade
+++ b/gramps/plugins/tool/finddupes.glade
@@ -140,7 +140,6 @@
                 <child>
                   <object class="GtkCheckButton" id="soundex">
                     <property name="label" translatable="yes">Use soundex codes</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -257,7 +256,6 @@
             <child>
               <object class="GtkButton" id="button7">
                 <property name="label" translatable="yes">Co_mpare</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/plugins/tool/findloop.glade
+++ b/gramps/plugins/tool/findloop.glade
@@ -20,13 +20,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="close">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" swapped="yes"/>
               </object>
               <packing>
@@ -37,13 +36,12 @@
             </child>
             <child>
               <object class="GtkButton" id="helpbutton1">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/mediamanager.py
+++ b/gramps/plugins/tool/mediamanager.py
@@ -6,6 +6,7 @@
 # Copyright (C) 2008       Brian G. Matherly
 # Copyright (C) 2010       Jakim Friant
 # Copyright (C) 2012       Nick Hall
+# Copyright (C) 2024       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -50,6 +51,7 @@ from gi.repository import GdkPixbuf
 from gramps.gen.const import URL_MANUAL_PAGE, ICON, SPLASH
 from gramps.gui.display import display_help
 from gramps.gen.lib import Media
+from gramps.gen.lib.serialize import from_dict
 from gramps.gen.db import DbTxn
 from gramps.gen.updatecallback import UpdateCallback
 from gramps.gui.plug import tool
@@ -568,8 +570,7 @@ class PathChange(BatchOp):
         self.set_total(self.db.get_number_of_media())
         with self.db.get_media_cursor() as cursor:
             for handle, data in cursor:
-                obj = Media()
-                obj.unserialize(data)
+                obj = from_dict(data)
                 if obj.get_path().find(from_text) != -1:
                     self.handle_list.append(handle)
                     self.path_list.append(obj.path)
@@ -608,8 +609,7 @@ class Convert2Abs(BatchOp):
         self.set_total(self.db.get_number_of_media())
         with self.db.get_media_cursor() as cursor:
             for handle, data in cursor:
-                obj = Media()
-                obj.unserialize(data)
+                obj = from_dict(data)
                 if not os.path.isabs(obj.path):
                     self.handle_list.append(handle)
                     self.path_list.append(obj.path)
@@ -647,8 +647,7 @@ class Convert2Rel(BatchOp):
         self.set_total(self.db.get_number_of_media())
         with self.db.get_media_cursor() as cursor:
             for handle, data in cursor:
-                obj = Media()
-                obj.unserialize(data)
+                obj = from_dict(data)
                 if os.path.isabs(obj.path):
                     self.handle_list.append(handle)
                     self.path_list.append(obj.path)
@@ -689,8 +688,7 @@ class ImagesNotIncluded(BatchOp):
         self.set_total(self.db.get_number_of_media())
         with self.db.get_media_cursor() as cursor:
             for handle, data in cursor:
-                obj = Media()
-                obj.unserialize(data)
+                obj = from_dict(data)
                 self.handle_list.append(handle)
                 full_path = media_path_full(self.db, obj.path)
                 self.path_list.append(full_path)

--- a/gramps/plugins/tool/mergecitations.glade
+++ b/gramps/plugins/tool/mergecitations.glade
@@ -140,7 +140,6 @@
                 <child>
                   <object class="GtkCheckButton" id="notes">
                     <property name="label" translatable="yes">Don't merge if citation has notes</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>

--- a/gramps/plugins/tool/mergecitations.glade
+++ b/gramps/plugins/tool/mergecitations.glade
@@ -148,7 +148,7 @@
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="halign">center</property>
-                    <property name="margin-left">12</property>
+                    <property name="margin-start">12</property>
                     <property name="hexpand">True</property>
                     <property name="use-underline">True</property>
                     <property name="xalign">0.5</property>
@@ -164,7 +164,7 @@
                   <object class="GtkComboBox" id="menu">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-left">12</property>
+                    <property name="margin-start">12</property>
                     <property name="hexpand">True</property>
                     <property name="model">liststore1</property>
                     <child>

--- a/gramps/plugins/tool/mergecitations.glade
+++ b/gramps/plugins/tool/mergecitations.glade
@@ -151,7 +151,6 @@
                     <property name="margin-start">12</property>
                     <property name="hexpand">True</property>
                     <property name="use-underline">True</property>
-                    <property name="xalign">0.5</property>
                     <property name="active">True</property>
                     <property name="draw-indicator">True</property>
                   </object>

--- a/gramps/plugins/tool/mergecitations.glade
+++ b/gramps/plugins/tool/mergecitations.glade
@@ -25,13 +25,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button12">
-                <property name="label">gtk-cancel</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Cancel</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="mergecitations" swapped="yes"/>
               </object>
               <packing>
@@ -42,13 +41,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button10">
-                <property name="label">gtk-ok</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_OK</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_merge_ok_clicked" object="mergecitations" swapped="yes"/>
               </object>
               <packing>
@@ -59,13 +57,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button14">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/notrelated.glade
+++ b/gramps/plugins/tool/notrelated.glade
@@ -18,13 +18,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="close">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="notrelated" swapped="yes"/>
               </object>
               <packing>
@@ -35,13 +34,12 @@
             </child>
             <child>
               <object class="GtkButton" id="help">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>
@@ -140,12 +138,11 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="tagapply">
-                    <property name="label">gtk-apply</property>
-                    <property name="use-action-appearance">False</property>
+                    <property name="label" translatable="1">_Apply</property>
+                    <property name="use-underline">1</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
-                    <property name="use-stock">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/gramps/plugins/tool/ownereditor.glade
+++ b/gramps/plugins/tool/ownereditor.glade
@@ -18,13 +18,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="cancel_button">
-                <property name="label">gtk-cancel</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Cancel</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_cancel_button_clicked" swapped="no"/>
               </object>
               <packing>
@@ -35,13 +34,12 @@
             </child>
             <child>
               <object class="GtkButton" id="ok_button">
-                <property name="label">gtk-ok</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_OK</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_ok_button_clicked" swapped="no"/>
               </object>
               <packing>
@@ -52,13 +50,12 @@
             </child>
             <child>
               <object class="GtkButton" id="help_button">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_button_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/patchnames.glade
+++ b/gramps/plugins/tool/patchnames.glade
@@ -50,7 +50,6 @@
             </child>
             <child>
               <object class="GtkButton" id="button5">
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>

--- a/gramps/plugins/tool/patchnames.glade
+++ b/gramps/plugins/tool/patchnames.glade
@@ -18,13 +18,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="helpbutton1">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>
@@ -35,13 +34,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button6">
-                <property name="label">gtk-cancel</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Cancel</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="patchnames" swapped="yes"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/rebuildgenderstat.py
+++ b/gramps/plugins/tool/rebuildgenderstat.py
@@ -2,6 +2,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2012       Benny Malengier
+# Copyright (C) 2024       Doug Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -55,16 +56,13 @@ from gramps.gui.plug import tool
 from gramps.gui.dialog import OkDialog
 from gramps.gen.updatecallback import UpdateCallback
 from gramps.gen.lib import Name
+from gramps.gen.lib.serialize import from_dict
 
 # -------------------------------------------------------------------------
 #
 # runTool
 #
 # -------------------------------------------------------------------------
-
-COLUMN_GENDER = 2
-COLUMN_NAME = 3
-COLUMN_ALTNAMES = 4
 
 
 class RebuildGenderStat(tool.Tool, UpdateCallback):
@@ -114,13 +112,13 @@ class RebuildGenderStat(tool.Tool, UpdateCallback):
             # loop over database and store the sort field, and the handle, and
             # allow for a third iter
             for key, data in cursor:
-                rawprimname = data[COLUMN_NAME]
-                rawaltnames = data[COLUMN_ALTNAMES]
-                primary_name = Name().unserialize(rawprimname).get_first_name()
+                rawprimname = data["primary_name"]
+                rawaltnames = data["alternate_names"]
+                primary_name = from_dict(rawprimname).get_first_name()
                 alternate_names = [
-                    Name().unserialize(name).get_first_name() for name in rawaltnames
+                    from_dict(name).get_first_name() for name in rawaltnames
                 ]
-                self.db.genderStats.count_name(primary_name, data[COLUMN_GENDER])
+                self.db.genderStats.count_name(primary_name, data["gender"])
 
 
 # ------------------------------------------------------------------------

--- a/gramps/plugins/tool/relcalc.glade
+++ b/gramps/plugins/tool/relcalc.glade
@@ -19,13 +19,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button5">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -35,11 +34,11 @@
             </child>
             <child>
               <object class="GtkButton" id="help_btn">
-                <property name="label">gtk-help</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>

--- a/gramps/plugins/tool/removespaces.glade
+++ b/gramps/plugins/tool/removespaces.glade
@@ -74,7 +74,6 @@
                 <property name="height-request">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="double-buffered">False</property>
                 <property name="justify">center</property>
                 <property name="ellipsize">start</property>
               </object>

--- a/gramps/plugins/tool/removespaces.glade
+++ b/gramps/plugins/tool/removespaces.glade
@@ -20,14 +20,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="close">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
-                <property name="image-position">right</property>
-                <property name="always-show-image">True</property>
                 <signal name="clicked" handler="destroy_passed_object" swapped="yes"/>
               </object>
               <packing>
@@ -39,13 +37,12 @@
             </child>
             <child>
               <object class="GtkButton" id="helpbutton1">
-                <property name="label">gtk-help</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
-                <property name="always-show-image">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gramps/plugins/tool/removeunused.glade
+++ b/gramps/plugins/tool/removeunused.glade
@@ -88,7 +88,6 @@
                     <child>
                       <object class="GtkCheckButton" id="events_box">
                         <property name="label" translatable="yes">Search for events</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -105,7 +104,6 @@
                     <child>
                       <object class="GtkCheckButton" id="sources_box">
                         <property name="label" translatable="yes">Search for sources</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -137,7 +135,6 @@
                     <child>
                       <object class="GtkCheckButton" id="places_box">
                         <property name="label" translatable="yes">Search for places</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -154,7 +151,6 @@
                     <child>
                       <object class="GtkCheckButton" id="media_box">
                         <property name="label" translatable="yes">Search for media</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -171,7 +167,6 @@
                     <child>
                       <object class="GtkCheckButton" id="repos_box">
                         <property name="label" translatable="yes">Search for repositories</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -188,7 +183,6 @@
                     <child>
                       <object class="GtkCheckButton" id="notes_box">
                         <property name="label" translatable="yes">Search for notes</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -276,7 +270,6 @@
                 <child>
                   <object class="GtkButton" id="mark_button">
                     <property name="label" translatable="yes">_Mark all</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>
@@ -292,7 +285,6 @@
                 <child>
                   <object class="GtkButton" id="unmark_button">
                     <property name="label" translatable="yes">_Unmark all</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>
@@ -308,7 +300,6 @@
                 <child>
                   <object class="GtkButton" id="invert_button">
                     <property name="label" translatable="yes">In_vert marks</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="can-default">True</property>

--- a/gramps/plugins/tool/removeunused.glade
+++ b/gramps/plugins/tool/removeunused.glade
@@ -96,7 +96,6 @@
                         <property name="receives-default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0.5</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -114,7 +113,6 @@
                         <property name="receives-default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0.5</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -129,7 +127,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
-                        <property name="xalign">0</property>
+                        <property name="halign">start</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -147,7 +145,6 @@
                         <property name="receives-default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0.5</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -165,7 +162,6 @@
                         <property name="receives-default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0.5</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -183,7 +179,6 @@
                         <property name="receives-default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0.5</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>
@@ -201,7 +196,6 @@
                         <property name="receives-default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
-                        <property name="xalign">0.5</property>
                         <property name="draw-indicator">True</property>
                       </object>
                       <packing>

--- a/gramps/plugins/tool/removeunused.glade
+++ b/gramps/plugins/tool/removeunused.glade
@@ -17,13 +17,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="remove_button">
-                <property name="label">gtk-delete</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Delete</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_remove_button_clicked" swapped="no"/>
               </object>
               <packing>
@@ -34,13 +33,12 @@
             </child>
             <child>
               <object class="GtkButton" id="closebutton1">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" swapped="no"/>
               </object>
               <packing>
@@ -218,13 +216,12 @@
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <child>
                       <object class="GtkButton" id="find_button">
-                        <property name="label">gtk-find</property>
-                        <property name="use-action-appearance">False</property>
+                        <property name="label" translatable="1">_Find</property>
+                        <property name="use-underline">1</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="use-stock">True</property>
                         <signal name="clicked" handler="on_find_button_clicked" swapped="no"/>
                       </object>
                       <packing>

--- a/gramps/plugins/tool/reorderids.glade
+++ b/gramps/plugins/tool/reorderids.glade
@@ -178,14 +178,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="reorder_cancel">
-                <property name="label">gtk-cancel</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Cancel</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="is-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-underline">True</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_cancel_button_clicked" swapped="no"/>
               </object>
               <packing>
@@ -196,14 +194,12 @@
             </child>
             <child>
               <object class="GtkButton" id="reorder_ok">
-                <property name="label">gtk-ok</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_OK</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-underline">True</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_ok_button_clicked" swapped="no"/>
               </object>
               <packing>
@@ -214,14 +210,12 @@
             </child>
             <child>
               <object class="GtkButton" id="reorder_help">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-underline">True</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_button_clicked" swapped="no"/>
               </object>
               <packing>
@@ -876,7 +870,6 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="resize-mode">queue</property>
                 <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
@@ -1456,7 +1449,6 @@
                 <property name="focus-on-click">False</property>
                 <property name="receives-default">True</property>
                 <property name="tooltip-text" translatable="yes">Enable ID reordering with Start / Step sequence.</property>
-                <property name="resize-mode">immediate</property>
                 <property name="relief">none</property>
                 <signal name="clicked" handler="on_change_button_clicked" swapped="no"/>
               </object>

--- a/gramps/plugins/tool/reorderids.glade
+++ b/gramps/plugins/tool/reorderids.glade
@@ -122,7 +122,6 @@
                 <property name="tooltip-text" translatable="yes">If you check this button, your next answer will apply to the rest of the selected items</property>
                 <property name="halign">center</property>
                 <property name="use-underline">True</property>
-                <property name="xalign">0.5</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -878,7 +877,7 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="resize-mode">queue</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -893,7 +892,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -908,7 +907,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -923,7 +922,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -938,7 +937,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -953,7 +952,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -968,7 +967,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -983,7 +982,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -998,7 +997,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="xalign">0</property>
+                <property name="halign">start</property>
                 <property name="active">True</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_object_button_toggled" swapped="no"/>
@@ -1141,7 +1140,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1156,7 +1154,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1171,7 +1168,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1186,7 +1182,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1201,7 +1196,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1216,7 +1210,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1231,7 +1224,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1246,7 +1238,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1261,7 +1252,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
               </object>
               <packing>
@@ -1275,7 +1265,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>
@@ -1290,7 +1279,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>
@@ -1305,7 +1293,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>
@@ -1320,7 +1307,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>
@@ -1335,7 +1321,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>
@@ -1350,7 +1335,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>
@@ -1365,7 +1349,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>
@@ -1380,7 +1363,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>
@@ -1395,7 +1377,6 @@
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="halign">center</property>
-                <property name="xalign">0</property>
                 <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="on_change_button_toggled" swapped="no"/>
               </object>

--- a/gramps/plugins/tool/reorderids.glade
+++ b/gramps/plugins/tool/reorderids.glade
@@ -69,8 +69,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="margin-top">24</property>
                 <property name="margin-bottom">24</property>
                 <property name="hexpand">True</property>
@@ -102,8 +102,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-left">6</property>
-                <property name="margin-right">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
                 <property name="hexpand">True</property>
                 <property name="use-markup">True</property>
                 <property name="wrap">True</property>

--- a/gramps/plugins/tool/verify.glade
+++ b/gramps/plugins/tool/verify.glade
@@ -107,13 +107,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="helpbutton1">
-                <property name="label">gtk-help</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">Help</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_help_clicked" swapped="no"/>
               </object>
               <packing>
@@ -124,13 +123,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button5">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="destroy_passed_object" object="verify" swapped="yes"/>
               </object>
               <packing>
@@ -852,13 +850,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="closebutton1">
-                <property name="label">gtk-close</property>
-                <property name="use-action-appearance">False</property>
+                <property name="label" translatable="1">_Close</property>
+                <property name="use-underline">1</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/gramps/plugins/tool/verify.glade
+++ b/gramps/plugins/tool/verify.glade
@@ -140,7 +140,6 @@
             <child>
               <object class="GtkButton" id="button4">
                 <property name="label" translatable="yes">_Run</property>
-                <property name="use-action-appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
@@ -358,7 +357,6 @@
                     <child>
                       <object class="GtkCheckButton" id="estimate_age">
                         <property name="label" translatable="yes">_Estimate missing or inexact dates</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -375,7 +373,6 @@
                     <child>
                       <object class="GtkCheckButton" id="invdate">
                         <property name="label" translatable="yes">_Identify invalid dates</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -979,7 +976,6 @@
                     <child>
                       <object class="GtkButton" id="mark_all">
                         <property name="label" translatable="yes">_Mark all</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="can-default">True</property>
@@ -995,7 +991,6 @@
                     <child>
                       <object class="GtkButton" id="unmark_all">
                         <property name="label" translatable="yes">_Unmark all</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="can-default">True</property>
@@ -1011,7 +1006,6 @@
                     <child>
                       <object class="GtkButton" id="invert_all">
                         <property name="label" translatable="yes">In_vert marks</property>
-                        <property name="use-action-appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="can-default">True</property>
@@ -1034,7 +1028,6 @@
                 <child>
                   <object class="GtkToggleButton" id="hide_button">
                     <property name="label" translatable="yes">_Hide marked</property>
-                    <property name="use-action-appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>

--- a/gramps/plugins/tool/verify.glade
+++ b/gramps/plugins/tool/verify.glade
@@ -450,8 +450,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">2</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-start">2</property>
+                        <property name="margin-end">2</property>
                         <property name="margin-top">2</property>
                         <property name="margin-bottom">2</property>
                         <property name="hexpand">True</property>
@@ -469,8 +469,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">2</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-start">2</property>
+                        <property name="margin-end">2</property>
                         <property name="margin-top">2</property>
                         <property name="margin-bottom">2</property>
                         <property name="hexpand">True</property>
@@ -488,8 +488,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">2</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-start">2</property>
+                        <property name="margin-end">2</property>
                         <property name="margin-top">2</property>
                         <property name="margin-bottom">2</property>
                         <property name="hexpand">True</property>
@@ -580,8 +580,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">2</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-start">2</property>
+                        <property name="margin-end">2</property>
                         <property name="margin-top">2</property>
                         <property name="margin-bottom">2</property>
                         <property name="hexpand">True</property>
@@ -599,8 +599,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">2</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-start">2</property>
+                        <property name="margin-end">2</property>
                         <property name="margin-top">2</property>
                         <property name="margin-bottom">2</property>
                         <property name="hexpand">True</property>
@@ -618,8 +618,8 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-left">2</property>
-                        <property name="margin-right">2</property>
+                        <property name="margin-start">2</property>
+                        <property name="margin-end">2</property>
                         <property name="margin-top">2</property>
                         <property name="margin-bottom">2</property>
                         <property name="hexpand">True</property>

--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -2749,15 +2749,13 @@ class BasePage:
 
                     # Web Site address
                     elif _type == UrlType.WEB_HOME:
-                        if not (
-                            uri.startswith("http://") or uri.startswith("https://")
-                        ):
+                        if not uri.startswith(("http://", "https://")):
                             url = self.secure_mode
                             uri = url + "%(website)s" % {"website": uri}
 
                     # FTP server address
                     elif _type == UrlType.WEB_FTP:
-                        if not (uri.startswith("ftp://") or uri.startswith("ftps://")):
+                        if not uri.startswith(("ftp://", "ftps://")):
                             uri = "ftp://%(ftpsite)s" % {"ftpsite": uri}
 
                     descr = Html("p", html_escape(descr)) + (

--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -45,6 +45,7 @@ Classe:
 # ------------------------------------------------
 from functools import partial
 import os
+import calendar
 import copy
 import datetime
 from decimal import getcontext
@@ -250,7 +251,25 @@ class BasePage:
         """Used to sort events by date."""
         event = self.r_db.get_event_from_handle(handle.ref)
         date = event.get_date_object()
+        # we need to remove abt, bef, aft, ...
         if date.get_year() > 0:
+            if len(str(date).split(" ")) > 1:
+                modif = str(date).split(" ")[0]
+                year = date.get_year()
+                month = date.get_month()
+                if year == 0:
+                    year = datetime.date.today().year
+                if month == 0:
+                    month = 1
+                day = date.get_day()
+                if day == 0:
+                    day = 1
+                ddd = datetime.date(year, month, day)
+                if modif == "bef":
+                    ddd = ddd - datetime.timedelta(days=1)
+                elif modif == "aft":
+                    ddd = ddd + datetime.timedelta(days=1)
+                date = Date(ddd.year, ddd.month, ddd.day)
             return date
         else:
             # if we have no date, we'll put the event at the
@@ -906,8 +925,7 @@ class BasePage:
         trow += Html("td", srcrefs, class_="ColumnSources", rowspan=2)
 
         # get event notes
-        notelist = event_ref.get_note_list()
-        notelist.extend(event.get_note_list()[:])  # we don't want to modify
+        notelist = event.get_note_list()
         # cached original
         htmllist = self.dump_notes(notelist, Event)
 

--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -48,6 +48,7 @@ import os
 import copy
 import datetime
 from decimal import getcontext
+from unicodedata import normalize
 
 # ------------------------------------------------
 # Set up logging
@@ -259,7 +260,7 @@ class BasePage:
     def sort_on_name_and_grampsid(self, handle):
         """Used to sort on name and gramps ID."""
         person = self.r_db.get_person_from_handle(handle)
-        name = _nd.display(person)
+        name = normalize('NFD', _nd.display(person))
         return (name, person.get_gramps_id())
 
     def sort_on_given_and_birth(self, handle):
@@ -2013,6 +2014,8 @@ class BasePage:
                                 lang_txt = html_escape(self._(language))
                                 n_lang = languages[language]
                                 nfname = self.report.cur_fname
+                                if "event" in nfname:
+                                    nfname = "".join(("events", self.ext))
                                 if "cal" in nfname:
                                     (dummy_field, dummy_sep, field2) = nfname.partition(
                                         "cal/"
@@ -3332,13 +3335,13 @@ class BasePage:
             parent_place = self.r_db.get_place_from_handle(obj.ref)
             if parent_place:
                 place_name = parent_place.get_name().get_value()
-            return place_name
+            return normalize('NFD', place_name)
 
         def sort_by_encl(obj):
             """
             Sort by encloses
             """
-            return obj[0]
+            return normalize('NFD', obj[0])
 
         for placeref in sorted(place.get_placeref_list(), key=sort_by_enclosed_by):
             parent_place = self.r_db.get_place_from_handle(placeref.ref)

--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -260,7 +260,7 @@ class BasePage:
     def sort_on_name_and_grampsid(self, handle):
         """Used to sort on name and gramps ID."""
         person = self.r_db.get_person_from_handle(handle)
-        name = normalize('NFD', _nd.display(person))
+        name = normalize("NFD", _nd.display(person))
         return (name, person.get_gramps_id())
 
     def sort_on_given_and_birth(self, handle):
@@ -3335,13 +3335,13 @@ class BasePage:
             parent_place = self.r_db.get_place_from_handle(obj.ref)
             if parent_place:
                 place_name = parent_place.get_name().get_value()
-            return normalize('NFD', place_name)
+            return normalize("NFD", place_name)
 
         def sort_by_encl(obj):
             """
             Sort by encloses
             """
-            return normalize('NFD', obj[0])
+            return normalize("NFD", obj[0])
 
         for placeref in sorted(place.get_placeref_list(), key=sort_by_enclosed_by):
             parent_place = self.r_db.get_place_from_handle(placeref.ref)

--- a/gramps/plugins/webreport/calendar.py
+++ b/gramps/plugins/webreport/calendar.py
@@ -280,7 +280,7 @@ class CalendarPage(BasePage):
                         url_fname = url_fname.lower()
                     url = url_fname
                     add_subdirs = False
-                    if not (url.startswith("http:") or url.startswith("/")):
+                    if not url.startswith(("http:", "/")):
                         add_subdirs = not _has_webpage_extension(url)
 
                     # whether to add subdirs or not???

--- a/gramps/plugins/webreport/calendar.py
+++ b/gramps/plugins/webreport/calendar.py
@@ -57,7 +57,7 @@ from gramps.gen.display.name import displayer as _nd
 
 import gramps.plugins.lib.libholiday as libholiday
 from gramps.plugins.webreport.basepage import BasePage
-from gramps.plugins.webreport.common import do_we_have_holidays, _WEB_EXT
+from gramps.plugins.webreport.common import do_we_have_holidays, _has_webpage_extension
 from gramps.plugins.lib.libhtml import Html  # , xml_lang
 from gramps.gui.pluginmanager import GuiPluginManager
 
@@ -281,7 +281,7 @@ class CalendarPage(BasePage):
                     url = url_fname
                     add_subdirs = False
                     if not (url.startswith("http:") or url.startswith("/")):
-                        add_subdirs = not any(url.endswith(ext) for ext in _WEB_EXT)
+                        add_subdirs = not _has_webpage_extension(url)
 
                     # whether to add subdirs or not???
                     if add_subdirs:
@@ -1346,15 +1346,6 @@ def get_first_day_of_month(year, month):
 
     current_ord = current_date.toordinal() - monthinfo[0].count(0)
     return current_date, current_ord, monthinfo
-
-
-def _has_webpage_extension(url):
-    """
-    determine if a filename has an extension or not...
-
-    url = filename to be checked
-    """
-    return any(url.endswith(ext) for ext in _WEB_EXT)
 
 
 def get_day_list(event_date, holiday_list, bday_anniv_list, rlocale=glocale):

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -79,7 +79,7 @@ LOG = logging.getLogger(".NarrativeWeb")
 # define clear blank line for proper styling
 FULLCLEAR = Html("div", class_="fullclear", inline=True)
 # define all possible web page filename extensions
-_WEB_EXT = [".html", ".htm", ".shtml", ".php", ".cgi"]
+_WEB_EXT = (".html", ".htm", ".shtml", ".php", ".cgi")
 # used to select secured web site or not
 HTTP = "http://"
 HTTPS = "https://"
@@ -823,7 +823,7 @@ def _has_webpage_extension(url):
 
     @param: url -- filename to be checked
     """
-    return any(url.endswith(ext) for ext in _WEB_EXT)
+    return url.endswith(_WEB_EXT)
 
 
 def add_birthdate(dbase, ppl_handle_list, rlocale):

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -646,7 +646,6 @@ if HAVE_ALPHABETICINDEX:
                     used_scripts.append(script)
                     super().addLabels(loc)
 
-
 else:
     AlphabeticIndex = localAlphabeticIndex
 

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -760,7 +760,7 @@ def partial_navigation(partial_index, rlocale=glocale, rtl=False, only=True, new
 
             while index < num_pages:
                 name, handle = partial_index[index]
-                title_txt = "Go to:"
+                title_txt = "Go to: "
                 title_str = rlocale.translation.sgettext(title_txt) + name
                 check_cs = False
                 if new_page:
@@ -776,9 +776,9 @@ def partial_navigation(partial_index, rlocale=glocale, rtl=False, only=True, new
                     temp_cs = 'class = "CurrentSection"'
                     check_cs = temp_cs if check_cs else False
                     if index == 0:
-                        hyper = Html("a", name + " => ", title=title_str, href="%s" % new_index + extension)
+                        hyper = Html("a", name + " \u27a1 ", title=title_str, href="%s" % new_index + extension)
                     else:
-                        hyper = Html("a", name + " => ", title=title_str, href="%s" % new_index + "_%d" % index + extension)
+                        hyper = Html("a", name + " \u27a1 ", title=title_str, href="%s" % new_index + "_%d" % index + extension)
                 else:
                     hyper = Html("a", name, title=title_str, href="#%s" % "link")
                 if check_cs:

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -777,7 +777,7 @@ def partial_navigation(
     num_of_rows = 1
 
     # begin alphabet navigation division
-    with Html("div", id=rtl, class_="nav") as partialnavigation:
+    with Html("div", id=rtl, class_="pnav") as partialnavigation:
         index = 0
         for dummy_row in range(num_of_rows):
             unordered = Html("ul", class_=rtl)

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -651,7 +651,7 @@ else:
 
 
 def alphabet_navigation(
-    sorted_alpha_index, rlocale=glocale, rtl=False, only=True, new_page=False, ext=None
+    sorted_alpha_index, rlocale=glocale, current=None, rtl=False, only=True, new_page=False, ext=None
 ):
     """
     Will create the alphabet navigation bar for classes IndividualListPage,
@@ -659,6 +659,7 @@ def alphabet_navigation(
 
     @param: index_list -- a dictionary of either letters or words
     @param: rlocale    -- The locale to use
+    @param: current    -- The current page
     @param: rtl        -- Do we use rtl language ?
     @param: only       -- Used only for alphabet letters
     @param: new_page   -- Used to have multiple index pages
@@ -711,31 +712,35 @@ def alphabet_navigation(
                     else:
                         url = "/".join((pathl, "events" + extension))
                     hyper = Html("a", filel, title=title_str, href=url)
-                    if new_page == url:
-                        check_cs = True
-                    temp_cs = 'class = "CurrentSection"'
-                    check_cs = temp_cs if check_cs else False
                     if cols != 0:
+                        next_name = new_index + str(cols)
                         hyper = Html(
                             "a",
                             menu_item,
                             title=title_str,
-                            href="%s" % new_index + str(cols) + extension,
+                            href="%s" % next_name + extension,
                         )
                     else:
+                        next_name = new_index
                         hyper = Html(
                             "a",
                             menu_item,
                             title=title_str,
                             href="%s" % new_index + extension,
                         )
+                    # if "_" in current:
+                    current = current.split("_")[0]
+                    if current == next_name:
+                        check_cs = True
+                    temp_cs = 'class = "CurrentSection"'
+                    check_cs = temp_cs if check_cs else False
                 else:
                     hyper = Html("a", menu_item, title=title_str, href="#%s" % link)
                 if check_cs:
-                    Html("li", hyper, attr=check_cs, inline=True)
+                    next_elem = Html("li", hyper, attr=check_cs, inline=True)
                 else:
-                    Html("li", hyper, inline=True)
-                unordered.extend(Html("li", hyper, inline=True))
+                    next_elem = Html("li", hyper, inline=True)
+                unordered.extend(next_elem)
 
                 index += 1
                 cols += 1
@@ -747,15 +752,15 @@ def alphabet_navigation(
 
 
 def partial_navigation(
-    partial_index, rlocale=glocale, rtl=False, only=True, new_page=False, ext=None
+    partial_index, rlocale=glocale, current=None, rtl=False, new_page=False, ext=None
 ):
     """
     Will create the partial navigation bar for big indexes
 
     @param: partial_index -- a dictionary of (name, handle)
     @param: rlocale       -- The locale to use
+    @param: current       -- The current page
     @param: rtl           -- Do we use rtl language ?
-    @param: only          -- Used only for alphabet letters
     @param: new_page      -- Used to have multiple index pages
     @param: ext           -- The default extension when new_page is used
     """
@@ -767,13 +772,12 @@ def partial_navigation(
     num_of_rows = 1
 
     # begin alphabet navigation division
-    with Html("div", id=rtl, class_="pnav") as partialnavigation:
+    with Html("div", id=rtl, class_="nav") as partialnavigation:
         index = 0
         for dummy_row in range(num_of_rows):
             unordered = Html("ul", class_=rtl)
 
             while index < num_pages:
-                # print("p_index :", partial_index[index])
                 handle, name = partial_index[index]
                 title_txt = "Go to: "
                 title_str = rlocale.translation.sgettext(title_txt) + name
@@ -782,15 +786,12 @@ def partial_navigation(
                     if index == 0:
                         new_index = new_page
                     else:
-                        new_index = new_page[:-1]  # + str(index)
+                        new_index = new_page[:-1]
                     new_index, extension = os.path.splitext(new_page)
                     if extension == "":
                         extension = ext
-                    if new_page == new_index:
-                        check_cs = True
-                    temp_cs = 'class = "CurrentSection"'
-                    check_cs = temp_cs if check_cs else False
                     if index == 0:
+                        next_name = new_index
                         hyper = Html(
                             "a",
                             name + " \u27a1 ",
@@ -798,19 +799,24 @@ def partial_navigation(
                             href="%s" % new_index + extension,
                         )
                     else:
+                        next_name = new_index + "_%d" % index
                         hyper = Html(
                             "a",
                             name + " \u27a1 ",
                             title=title_str,
                             href="%s" % new_index + "_%d" % index + extension,
                         )
+                    if current == next_name:
+                        check_cs = True
+                    temp_cs = 'class = "CurrentSection"'
+                    check_cs = temp_cs if check_cs else False
                 else:
                     hyper = Html("a", name, title=title_str, href="#%s" % "link")
                 if check_cs:
-                    Html("li", hyper, attr=check_cs, inline=True)
+                    next_elem = Html("li", hyper, attr=check_cs, inline=True)
                 else:
-                    Html("li", hyper, inline=True)
-                unordered.extend(Html("li", hyper, inline=True))
+                    next_elem = Html("li", hyper, inline=True)
+                unordered.extend(next_elem)
 
                 index += 1
             num_of_rows -= 1

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -651,7 +651,13 @@ else:
 
 
 def alphabet_navigation(
-    sorted_alpha_index, rlocale=glocale, current=None, rtl=False, only=True, new_page=False, ext=None
+    sorted_alpha_index,
+    rlocale=glocale,
+    current=None,
+    rtl=False,
+    only=True,
+    new_page=False,
+    ext=None
 ):
     """
     Will create the alphabet navigation bar for classes IndividualListPage,
@@ -728,7 +734,6 @@ def alphabet_navigation(
                             title=title_str,
                             href="%s" % new_index + extension,
                         )
-                    # if "_" in current:
                     current = current.split("_")[0]
                     if current == next_name:
                         check_cs = True
@@ -1070,7 +1075,8 @@ def create_indexes_pages(
     max_rows = int(max_rows / row_count) * row_count
     page = 0
     for letter, hdle_list in handle_list:
-        hdle_list.sort(key=lambda x: locale.sort_key(x[1]))
+        if not "events" in name:
+            hdle_list.sort(key=lambda x: locale.sort_key(x[1]))
         if len(hdle_list) <= row_count:
             function(
                 report,

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -646,11 +646,14 @@ if HAVE_ALPHABETICINDEX:
                     used_scripts.append(script)
                     super().addLabels(loc)
 
+
 else:
     AlphabeticIndex = localAlphabeticIndex
 
 
-def alphabet_navigation(sorted_alpha_index, rlocale=glocale, rtl=False, only=True, new_page=False, ext=None):
+def alphabet_navigation(
+    sorted_alpha_index, rlocale=glocale, rtl=False, only=True, new_page=False, ext=None
+):
     """
     Will create the alphabet navigation bar for classes IndividualListPage,
     SurnameListPage, PlaceListPage, and EventList
@@ -714,9 +717,19 @@ def alphabet_navigation(sorted_alpha_index, rlocale=glocale, rtl=False, only=Tru
                     temp_cs = 'class = "CurrentSection"'
                     check_cs = temp_cs if check_cs else False
                     if cols != 0:
-                        hyper = Html("a", menu_item, title=title_str, href="%s" % new_index + str(cols) + extension)
+                        hyper = Html(
+                            "a",
+                            menu_item,
+                            title=title_str,
+                            href="%s" % new_index + str(cols) + extension,
+                        )
                     else:
-                        hyper = Html("a", menu_item, title=title_str, href="%s" % new_index + extension)
+                        hyper = Html(
+                            "a",
+                            menu_item,
+                            title=title_str,
+                            href="%s" % new_index + extension,
+                        )
                 else:
                     hyper = Html("a", menu_item, title=title_str, href="#%s" % link)
                 if check_cs:
@@ -734,7 +747,9 @@ def alphabet_navigation(sorted_alpha_index, rlocale=glocale, rtl=False, only=Tru
     return alphabetnavigation
 
 
-def partial_navigation(partial_index, rlocale=glocale, rtl=False, only=True, new_page=False, ext=None):
+def partial_navigation(
+    partial_index, rlocale=glocale, rtl=False, only=True, new_page=False, ext=None
+):
     """
     Will create the partial navigation bar for big indexes
 
@@ -776,9 +791,19 @@ def partial_navigation(partial_index, rlocale=glocale, rtl=False, only=True, new
                     temp_cs = 'class = "CurrentSection"'
                     check_cs = temp_cs if check_cs else False
                     if index == 0:
-                        hyper = Html("a", name + " \u27a1 ", title=title_str, href="%s" % new_index + extension)
+                        hyper = Html(
+                            "a",
+                            name + " \u27a1 ",
+                            title=title_str,
+                            href="%s" % new_index + extension,
+                        )
                     else:
-                        hyper = Html("a", name + " \u27a1 ", title=title_str, href="%s" % new_index + "_%d" % index + extension)
+                        hyper = Html(
+                            "a",
+                            name + " \u27a1 ",
+                            title=title_str,
+                            href="%s" % new_index + "_%d" % index + extension,
+                        )
                 else:
                     hyper = Html("a", name, title=title_str, href="#%s" % "link")
                 if check_cs:

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -1045,8 +1045,9 @@ def html_escape(text):
     return text
 
 
-def create_indexes_pages(report, name, index_list, function, handle_list, max_rows,
-                         locale=None):
+def create_indexes_pages(
+    report, name, index_list, function, handle_list, max_rows, locale=None
+):
     """
     This is used to create indexes depending on a row limit.
 
@@ -1060,13 +1061,10 @@ def create_indexes_pages(report, name, index_list, function, handle_list, max_ro
     """
     row_count = report.options["splitindex"]
     max_rows += row_count  # For the last incomplete page
-    max_rows = (
-        int(max_rows / row_count) * row_count
-    )
+    max_rows = int(max_rows / row_count) * row_count
     page = 0
     for letter, hdle_list in handle_list:
         hdle_list.sort(key=lambda x: locale.sort_key(x[1]))
-        # current = [(letter, hdle_list)]
         if len(hdle_list) <= row_count:
             function(
                 report,
@@ -1094,7 +1092,6 @@ def create_indexes_pages(report, name, index_list, function, handle_list, max_ro
                     if nbh > len(hdle_list):
                         break
                     phdle_list.append(hdle_list[nbh])
-                # plist = [(letter, phdle_list)]
                 if sub_page != 0:
                     subp = "_%d" % sub_page
                 else:

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -657,7 +657,7 @@ def alphabet_navigation(
     rtl=False,
     only=True,
     new_page=False,
-    ext=None
+    ext=None,
 ):
     """
     Will create the alphabet navigation bar for classes IndividualListPage,

--- a/gramps/plugins/webreport/event.py
+++ b/gramps/plugins/webreport/event.py
@@ -282,7 +282,8 @@ class EventPages(BasePage):
 
             # Output the navigation
             alpha_nav = alphabet_navigation(
-                index_list, self.rlocale, rtl=self.dir, new_page="events", ext=self.ext
+                index_list, self.rlocale, rtl=self.dir, new_page="events", ext=self.ext,
+                current=part_name,
             )
             if alpha_nav:
                 eventlist += alpha_nav
@@ -292,6 +293,7 @@ class EventPages(BasePage):
                 partial_nav = partial_navigation(
                     partial_list,
                     self.rlocale,
+                    current=part_name,
                     rtl=self.dir,
                     ext=self.ext,
                     new_page=nav_name,

--- a/gramps/plugins/webreport/event.py
+++ b/gramps/plugins/webreport/event.py
@@ -440,13 +440,15 @@ class EventPages(BasePage):
                 extended_handle_list[bletter].append((hdle[0], hdle[2]))
         extended_handle_list = list(extended_handle_list.items())
         max_rows = max_letter_rows[bletter]
-        create_indexes_pages(report,
-                             "events",
-                             index_list,
-                             self.part_eventlistpage,
-                             extended_handle_list,
-                             max_rows,
-                             locale=self.rlocale)
+        create_indexes_pages(
+            report,
+            "events",
+            index_list,
+            self.part_eventlistpage,
+            extended_handle_list,
+            max_rows,
+            locale=self.rlocale,
+        )
 
     def _geteventdate(self, event):
         """

--- a/gramps/plugins/webreport/event.py
+++ b/gramps/plugins/webreport/event.py
@@ -428,7 +428,7 @@ class EventPages(BasePage):
         events_handle_list.sort(key=lambda x: self.rlocale.sort_key(x[0]))
         extended_handle_list = defaultdict(list)
         row_count = report.options["splitindex"]
-        for (bletter, hdlel) in events_handle_list:
+        for bletter, hdlel in events_handle_list:
             bletter = (
                 unicodedata.normalize("NFKD", bletter)[0]
                 if len(bletter) > 0
@@ -441,7 +441,7 @@ class EventPages(BasePage):
         extended_handle_list = list(extended_handle_list.items())
         max_rows = 0
         page = 0
-        for (bletter, hdle_list) in extended_handle_list:
+        for bletter, hdle_list in extended_handle_list:
             max_rows = max_letter_rows[bletter]
             max_rows += row_count  # For the last incomplete page
             max_rows = (

--- a/gramps/plugins/webreport/event.py
+++ b/gramps/plugins/webreport/event.py
@@ -282,8 +282,12 @@ class EventPages(BasePage):
 
             # Output the navigation
             alpha_nav = alphabet_navigation(
-                index_list, self.rlocale, rtl=self.dir, new_page="events", ext=self.ext,
+                index_list,
+                self.rlocale,
                 current=part_name,
+                rtl=self.dir,
+                new_page="events",
+                ext=self.ext,
             )
             if alpha_nav:
                 eventlist += alpha_nav

--- a/gramps/plugins/webreport/family.py
+++ b/gramps/plugins/webreport/family.py
@@ -272,6 +272,7 @@ class FamilyPages(BasePage):
             alpha_nav = alphabet_navigation(
                 index_list,
                 self.rlocale,
+                current=part_name,
                 rtl=self.dir,
                 new_page="families",
                 ext=self.ext,
@@ -284,6 +285,7 @@ class FamilyPages(BasePage):
                 partial_nav = partial_navigation(
                     partial_list,
                     self.rlocale,
+                    current=part_name,
                     rtl=self.dir,
                     ext=self.ext,
                     new_page=nav_name,

--- a/gramps/plugins/webreport/family.py
+++ b/gramps/plugins/webreport/family.py
@@ -171,9 +171,7 @@ class FamilyPages(BasePage):
             # Update the ColumnRowLabel cell
             trow.attr = 'class="BeginLetter BeginFamily"'
             ttle = self._("Families beginning with " "letter ")
-            tcell += Html(
-                "a", letter, name=letter, title=ttle + letter
-            )
+            tcell += Html("a", letter, name=letter, title=ttle + letter)
             #  and create the populated ColumnPartner for the person
             tcell = Html("td", class_="ColumnPartner")
             tcell += self.new_person_link(person_handle, uplink=self.uplink)
@@ -436,13 +434,15 @@ class FamilyPages(BasePage):
                 extended_handle_list[bletter].append((hdle, fname))
         extended_handle_list = list(extended_handle_list.items())
         max_rows = max_letter_rows[bletter]
-        create_indexes_pages(report,
-                             "families",
-                             index_list,
-                             self.part_familylistpage,
-                             extended_handle_list,
-                             max_rows,
-                             locale=self.rlocale)
+        create_indexes_pages(
+            report,
+            "families",
+            index_list,
+            self.part_familylistpage,
+            extended_handle_list,
+            max_rows,
+            locale=self.rlocale,
+        )
 
     def familypage(self, report, the_lang, the_title, family_handle):
         """

--- a/gramps/plugins/webreport/family.py
+++ b/gramps/plugins/webreport/family.py
@@ -420,7 +420,7 @@ class FamilyPages(BasePage):
         row_count = report.options["splitindex"]
         max_letter_rows = defaultdict(int)
         index_list = []
-        for (bletter, hdlel) in surname_handle_list.items():
+        for bletter, hdlel in surname_handle_list.items():
             bletter = (
                 unicodedata.normalize("NFKD", bletter)[0]
                 if len(bletter) > 0
@@ -440,7 +440,7 @@ class FamilyPages(BasePage):
             int(max_rows / report.options["splitindex"]) * report.options["splitindex"]
         )
         page = 0
-        for (bletter, hdle_list) in extended_handle_list:
+        for bletter, hdle_list in extended_handle_list:
             current = [(bletter, hdle_list)]
             if len(hdle_list) <= row_count:
                 name = "families"

--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -2210,6 +2210,12 @@ class NavWebOptions(MenuReportOptions):
         self.__toggle.set_help(_("Check it if you want to open/close" " a section"))
         addopt("toggle", self.__toggle)
 
+        self.__splitindex = NumberOption(_("Max. rows in an index"), 500, 10, 2000)
+        self.__splitindex.set_help(
+            _("The maximum number of rows to include in an index page")
+        )
+        addopt("splitindex", self.__splitindex)
+
     def __add_more_pages(self, menu):
         """
         Add more extra pages to the report

--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -548,7 +548,8 @@ class NavWebReport(Report):
                 self.tab["Event"].display_pages(the_lang, the_title)
 
             # build classes PlaceListPage and PlacePage
-            self.tab["Place"].display_pages(the_lang, the_title)
+            if self.inc_places:
+                self.tab["Place"].display_pages(the_lang, the_title)
 
             # build classes RepositoryListPage and RepositoryPage
             if self.inc_repository:
@@ -567,7 +568,8 @@ class NavWebReport(Report):
                 self.addressbook_pages(self.obj_dict[Person])
 
             # build classes SourceListPage and SourcePage
-            self.tab["Source"].display_pages(the_lang, the_title)
+            if self.inc_sources:
+                self.tab["Source"].display_pages(the_lang, the_title)
 
             # build calendar for the current year
             if self.usecal:

--- a/gramps/plugins/webreport/person.py
+++ b/gramps/plugins/webreport/person.py
@@ -466,7 +466,11 @@ class PersonPages(BasePage):
                 for person_handle in sorted(
                     handle_list, key=self.sort_on_name_and_grampsid
                 ):
-                    (date, first_surname, first_individual,) = self.__output_person(
+                    (
+                        date,
+                        first_surname,
+                        first_individual,
+                    ) = self.__output_person(
                         date,
                         tbody,
                         letter,
@@ -526,11 +530,7 @@ class PersonPages(BasePage):
                 letter = index.bucketLabel
                 if letter not in index_list:
                     index_list.append(letter)
-                bletter = (
-                    normalize("NFKD", letter)[0]
-                    if len(letter) > 0
-                    else letter
-                )
+                bletter = normalize("NFKD", letter)[0] if len(letter) > 0 else letter
                 while index.nextRecord():
                     handle_list = index.recordData
                     if handle_list:
@@ -546,12 +546,8 @@ class PersonPages(BasePage):
         surname_handle_list.sort(key=lambda x: self.rlocale.sort_key(x[0]))
         extended_handle_list = defaultdict(list)
         row_count = report.options["splitindex"]
-        for (bletter, hdlel) in surname_handle_list:
-            bletter = (
-                normalize("NFKD", bletter)[0]
-                if len(bletter) > 0
-                else bletter
-            )
+        for bletter, hdlel in surname_handle_list:
+            bletter = normalize("NFKD", bletter)[0] if len(bletter) > 0 else bletter
             bletter = bletter[0] if len(bletter) > 0 else bletter
             bletter = bletter.upper() if bletter.isalpha() else "…"
             for hdle in hdlel:
@@ -563,7 +559,7 @@ class PersonPages(BasePage):
             int(max_rows / report.options["splitindex"]) * report.options["splitindex"]
         )
         page = 0
-        for (bletter, hdle_list) in extended_handle_list:
+        for bletter, hdle_list in extended_handle_list:
             current = [(bletter, hdle_list)]
             if len(hdle_list) <= row_count:
                 name = "individuals"

--- a/gramps/plugins/webreport/person.py
+++ b/gramps/plugins/webreport/person.py
@@ -223,7 +223,10 @@ class PersonPages(BasePage):
                 "with letter %(letter)s" % {"surname": surname, "letter": bucket_letter}
             )
             tcell += Html(
-                "a", html_escape(bucket_letter), name=bucket_letter, title=ttle,
+                "a",
+                html_escape(bucket_letter),
+                name=bucket_letter,
+                title=ttle,
             )
         elif first_individual:
             first_individual = False
@@ -458,7 +461,11 @@ class PersonPages(BasePage):
                     surnamed = surname.upper()
                 else:
                     surnamed = surname
-                (date, first_surname, first_individual,) = self.__output_person(
+                (
+                    date,
+                    first_surname,
+                    first_individual,
+                ) = self.__output_person(
                     date,
                     tbody,
                     letter,

--- a/gramps/plugins/webreport/person.py
+++ b/gramps/plugins/webreport/person.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-#!/usr/bin/env python
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
@@ -45,6 +44,7 @@ Classe:
 from collections import defaultdict
 from operator import itemgetter
 from decimal import Decimal, getcontext
+from unicodedata import normalize
 import logging
 
 # ------------------------------------------------
@@ -57,7 +57,6 @@ from gramps.gen.lib import (
     Name,
     Person,
     EventRoleType,
-    Family,
     Event,
     EventType,
 )
@@ -81,6 +80,7 @@ from gramps.gen.relationship import get_relationship_calculator
 from gramps.plugins.webreport.basepage import BasePage
 from gramps.plugins.webreport.common import (
     alphabet_navigation,
+    partial_navigation,
     add_birthdate,
     FULLCLEAR,
     _find_birth_date,
@@ -339,30 +339,33 @@ class PersonPages(BasePage):
             trow += Html("td", class_="ColumnParents", inline=samerow) + tcell
         return (date, first_surname, first_individual)
 
-    def individuallistpage(self, report, the_lang, the_title, ppl_handle_list):
+    def part_individuallistpage(
+        self,
+        report,
+        index_list,
+        name,
+        letter,
+        surname_handle_list,
+        part=None,
+        subp=None,
+        deb=None,
+        partial_list=None,
+    ):
         """
-        Creates an individual page
-
-        @param: report          -- The instance of the main report class
-                                   for this report
-        @param: the_lang        -- The lang to process
-        @param: the_title       -- The title page related to the language
-        @param: ppl_handle_list -- The list of people for whom we need
-                                   to create a page.
+        Creates a partial of individual index
         """
-        BasePage.__init__(self, report, the_lang, the_title)
-
-        # plugin variables for this module
-        showbirth = report.options["showbirth"]
-        showdeath = report.options["showdeath"]
-        showpartner = report.options["showpartner"]
-        showparents = report.options["showparents"]
-
-        output_file, sio = self.report.create_file("individuals")
+        nav_name = part_name = name
+        if part != 0 and subp != 0:
+            part_name += str(part)
+            nav_name = part_name
+        if subp and subp != 0:
+            part_name += subp
+        output_file, sio = self.report.create_file(part_name)
         result = self.write_header(self._("Individuals"))
         indlistpage, dummy_head, dummy_body, outerwrapper = result
         date = 0
 
+        # for each bucket, output the surnames in that bucket
         # begin Individuals division
         with Html("div", class_="content", id="Individuals") as individuallist:
             outerwrapper += individuallist
@@ -377,31 +380,30 @@ class PersonPages(BasePage):
             )
             individuallist += Html("p", msg, id="description")
 
-            # add alphabet navigation
-            # Assemble all the handles for each surname into a dictionary
-            # We don't call sort_people because we don't care about sorting
-            # individuals, only surnames
-            surname_handle_dict = defaultdict(list)
-            for person_handle in ppl_handle_list:
-                person = self.r_db.get_person_from_handle(person_handle)
-                surname = get_surname_from_person(self.r_db, person)
-                surname_handle_dict[surname].append(person_handle)
-
-            # Assemble the alphabeticIndex
-            index = AlphabeticIndex(self.rlocale)
-            for surname, handle_list in surname_handle_dict.items():
-                index.addRecord(surname, handle_list)
-
-            # Extract the buckets from the index
-            index_list = []
-            index.resetBucketIterator()
-            while index.nextBucket():
-                if index.bucketRecordCount != 0:
-                    index_list.append(index.bucketLabel)
-            # Output the navigation
-            alpha_nav = alphabet_navigation(index_list, self.rlocale, rtl=self.dir)
+            alpha_nav = alphabet_navigation(
+                index_list,
+                self.rlocale,
+                rtl=self.dir,
+                new_page="individuals",
+                ext=self.ext,
+            )
             if alpha_nav is not None:
                 individuallist += alpha_nav
+
+            if part is not None:
+                # We need to create a new navigation tab for partial page index.
+                partial_nav = partial_navigation(
+                    partial_list,
+                    self.rlocale,
+                    rtl=self.dir,
+                    ext=self.ext,
+                    new_page=nav_name,
+                )
+                if partial_nav is not None:
+                    individuallist += Html(
+                        "div", style="clear: both;"
+                    )  # This to align the next div to the left.
+                    individuallist += partial_nav
 
             # begin table and table head
             with Html(
@@ -420,22 +422,22 @@ class PersonPages(BasePage):
                 )
                 trow += Html("th", self._("Name"), class_="ColumnName", inline=True)
 
-                if showbirth:
+                if report.options["showbirth"]:
                     trow += Html(
                         "th", self._("Birth"), class_="ColumnDate", inline=True
                     )
 
-                if showdeath:
+                if report.options["showdeath"]:
                     trow += Html(
                         "th", self._("Death"), class_="ColumnDate", inline=True
                     )
 
-                if showpartner:
+                if report.options["showpartner"]:
                     trow += Html(
                         "th", self._("Partner"), class_="ColumnPartner", inline=True
                     )
 
-                if showparents:
+                if report.options["showparents"]:
                     trow += Html(
                         "th", self._("Parents"), class_="ColumnParents", inline=True
                     )
@@ -443,68 +445,42 @@ class PersonPages(BasePage):
             tbody = Html("tbody")
             table += tbody
 
-            # for each bucket, output the surnames in that bucket
-            index.resetBucketIterator()
-            output = []
-            dup_index = 0
-            while index.nextBucket():
-                if index.bucketRecordCount != 0:
-                    surname_handle_dict = defaultdict(list)
-                    bucket_letter = index.bucketLabel
-                    bucket_link = bucket_letter
-                    if bucket_letter in output:
-                        bucket_link = "%s (%i)" % (bucket_letter, dup_index)
-                        dup_index += 1
-                    output.append(bucket_letter)
-                    while index.nextRecord():
-                        surname = index.recordName
-                        handle_list = index.recordData
-                        for handle in handle_list:
-                            surname_handle_dict[surname].append(handle)
-                    surname_handle_list = list(surname_handle_dict.items())
-                    # sort by surname
-                    surname_handle_list.sort(key=lambda x: self.rlocale.sort_key(x[0]))
+            name_format = self.report.options["name_format"]
+            nme_format = _nd.name_formats[name_format][1]
+            for surname, handle_list in surname_handle_list:
+                if not surname or surname.isspace():
+                    surname = self._("<absent>")
 
-                    name_format = self.report.options["name_format"]
-                    nme_format = _nd.name_formats[name_format][1]
-                    for surname, handle_list in surname_handle_list:
-                        if not surname or surname.isspace():
-                            surname = self._("<absent>")
-
-                        # In case the user choose a format name like "*SURNAME*"
-                        # We must display this field in upper case. So we use
-                        # the english format of format_name to find if this is
-                        # the case. name_format =
-                        # self.report.options['name_format'] nme_format =
-                        # _nd.name_formats[name_format][1]
-                        if "SURNAME" in nme_format:
-                            surnamed = surname.upper()
-                        else:
-                            surnamed = surname
-                        first_surname = True
-                        first_individual = True
-                        for person_handle in sorted(
-                            handle_list, key=self.sort_on_name_and_grampsid
-                        ):
-                            (
-                                date,
-                                first_surname,
-                                first_individual,
-                            ) = self.__output_person(
-                                date,
-                                tbody,
-                                bucket_letter,
-                                bucket_link,
-                                showbirth,
-                                showdeath,
-                                showpartner,
-                                showparents,
-                                surname,
-                                surnamed,
-                                first_surname,
-                                first_individual,
-                                person_handle,
-                            )
+                # In case the user choose a format name like "*SURNAME*"
+                # We must display this field in upper case. So we use
+                # the english format of format_name to find if this is
+                # the case. name_format =
+                # self.report.options['name_format'] nme_format =
+                # _nd.name_formats[name_format][1]
+                if "SURNAME" in nme_format:
+                    surnamed = surname.upper()
+                else:
+                    surnamed = surname
+                first_surname = True
+                first_individual = True
+                for person_handle in sorted(
+                    handle_list, key=self.sort_on_name_and_grampsid
+                ):
+                    (date, first_surname, first_individual,) = self.__output_person(
+                        date,
+                        tbody,
+                        letter,
+                        letter,  # bucket_link,
+                        report.options["showbirth"],
+                        report.options["showdeath"],
+                        report.options["showpartner"],
+                        report.options["showparents"],
+                        surname,
+                        surnamed,
+                        first_surname,
+                        first_individual,
+                        person_handle,
+                    )
 
         # create clear line for proper styling
         # create footer section
@@ -514,6 +490,142 @@ class PersonPages(BasePage):
         # send page out for processing
         # and close the file
         self.xhtml_writer(indlistpage, output_file, sio, date)
+
+    def individuallistpage(self, report, the_lang, the_title, ppl_handle_list):
+        """
+        Creates an individual page
+
+        @param: report          -- The instance of the main report class
+                                   for this report
+        @param: the_lang        -- The lang to process
+        @param: the_title       -- The title page related to the language
+        @param: ppl_handle_list -- The list of people for whom we need
+                                   to create a page.
+        """
+        BasePage.__init__(self, report, the_lang, the_title)
+
+        surname_handle_dict = defaultdict(list)
+        surname_handle_list = []
+        for person_handle in ppl_handle_list:
+            person = self.r_db.get_person_from_handle(person_handle)
+            surname = get_surname_from_person(self.r_db, person)
+            surname_handle_dict[surname].append(person_handle)
+        # Assemble the alphabeticIndex
+        index = AlphabeticIndex(self.rlocale)
+        for surname, handle_list in surname_handle_dict.items():
+            index.addRecord(surname, handle_list)
+        index_list = []
+        surname_handle_dict = defaultdict(list)
+        max_letter_rows = defaultdict(int)
+        row_count = report.options["splitindex"]
+        # Extract the buckets from the index
+        index.resetBucketIterator()
+        page = 0
+        while index.nextBucket():
+            if index.bucketRecordCount != 0:
+                letter = index.bucketLabel
+                if letter not in index_list:
+                    index_list.append(letter)
+                bletter = (
+                    normalize("NFKD", letter)[0]
+                    if len(letter) > 0
+                    else letter
+                )
+                while index.nextRecord():
+                    handle_list = index.recordData
+                    if handle_list:
+                        for handle in handle_list:
+                            surname_handle_dict[bletter].append(handle)
+                        if bletter in max_letter_rows:
+                            max_letter_rows[bletter] += len(handle_list)
+                        else:
+                            max_letter_rows[bletter] = len(handle_list)
+
+        surname_handle_list = list(surname_handle_dict.items())
+        # sort by surname
+        surname_handle_list.sort(key=lambda x: self.rlocale.sort_key(x[0]))
+        extended_handle_list = defaultdict(list)
+        row_count = report.options["splitindex"]
+        for (bletter, hdlel) in surname_handle_list:
+            bletter = (
+                normalize("NFKD", bletter)[0]
+                if len(bletter) > 0
+                else bletter
+            )
+            bletter = bletter[0] if len(bletter) > 0 else bletter
+            bletter = bletter.upper() if bletter.isalpha() else "…"
+            for hdle in hdlel:
+                extended_handle_list[bletter].append(hdle)
+        extended_handle_list = list(extended_handle_list.items())
+        max_rows = max_letter_rows[bletter]
+        max_rows += row_count  # For the last incomplete page
+        max_rows = (
+            int(max_rows / report.options["splitindex"]) * report.options["splitindex"]
+        )
+        page = 0
+        for (bletter, hdle_list) in extended_handle_list:
+            current = [(bletter, hdle_list)]
+            if len(hdle_list) <= row_count:
+                name = "individuals"
+                self.part_individuallistpage(
+                    report,
+                    index_list,
+                    name,
+                    bletter,
+                    current,
+                    part=page,
+                    deb=max_letter_rows[letter],
+                )
+            else:
+                nname = ""
+                partial_list = []
+                hdle1_list = []
+                name_format = self.report.options["name_format"]
+                for handle in hdle_list:
+                    person = self.r_db.get_person_from_handle(handle)
+                    primary_name = person.get_primary_name()
+                    nname = Name(primary_name)
+                    nname.set_display_as(name_format)
+                    fname = _nd.display_name(nname)
+                    hdle1_list.append((fname, handle))
+                hdle1_list.sort(key=lambda x: self.rlocale.sort_key(x[0]))
+                for idx in range(0, int(len(hdle1_list) / row_count) + 1, 1):
+                    handle = hdle1_list[idx * row_count]
+                    partial_list.append(hdle1_list[idx * row_count])
+                sub_page = 0
+                part = 0
+                start = 0
+                while start < len(hdle1_list):
+                    phdle_list = []
+                    for nbh in range(len(hdle1_list)):
+                        if nbh < start:
+                            continue
+                        if nbh >= start + row_count:
+                            break
+                        if nbh > len(hdle1_list):
+                            break
+                        phdle_list.append(hdle1_list[nbh][1])
+                    plist = [(bletter, phdle_list)]
+                    name = "individuals"
+                    if sub_page != 0:
+                        subp = "_%d" % sub_page
+                    else:
+                        subp = None
+                    self.part_individuallistpage(
+                        report,
+                        index_list,
+                        name,
+                        bletter,
+                        plist,
+                        part=page,
+                        subp=subp,
+                        deb=max_letter_rows[bletter],
+                        partial_list=partial_list,
+                    )
+                    part += 1
+                    start += row_count
+                    sub_page += 1
+            page += 1
 
     #################################################
     #

--- a/gramps/plugins/webreport/person.py
+++ b/gramps/plugins/webreport/person.py
@@ -381,6 +381,7 @@ class PersonPages(BasePage):
             alpha_nav = alphabet_navigation(
                 index_list,
                 self.rlocale,
+                current=part_name,
                 rtl=self.dir,
                 new_page="individuals",
                 ext=self.ext,
@@ -393,6 +394,7 @@ class PersonPages(BasePage):
                 partial_nav = partial_navigation(
                     partial_list,
                     self.rlocale,
+                    current=part_name,
                     rtl=self.dir,
                     ext=self.ext,
                     new_page=nav_name,

--- a/gramps/plugins/webreport/place.py
+++ b/gramps/plugins/webreport/place.py
@@ -299,8 +299,12 @@ class PlacePages(BasePage):
 
             # Output the navigation
             alpha_nav = alphabet_navigation(
-                index_list, self.rlocale, rtl=self.dir, new_page="places", ext=self.ext,
+                index_list,
+                self.rlocale,
                 current=part_name,
+                rtl=self.dir,
+                new_page="places",
+                ext=self.ext,
             )
             if alpha_nav:
                 placelist += alpha_nav

--- a/gramps/plugins/webreport/place.py
+++ b/gramps/plugins/webreport/place.py
@@ -269,7 +269,6 @@ class PlacePages(BasePage):
         subp=None,
         partial_list=None,
     ):
-
         """
         Create a part of a place index
         """

--- a/gramps/plugins/webreport/place.py
+++ b/gramps/plugins/webreport/place.py
@@ -299,7 +299,8 @@ class PlacePages(BasePage):
 
             # Output the navigation
             alpha_nav = alphabet_navigation(
-                index_list, self.rlocale, rtl=self.dir, new_page="places", ext=self.ext
+                index_list, self.rlocale, rtl=self.dir, new_page="places", ext=self.ext,
+                current=part_name,
             )
             if alpha_nav:
                 placelist += alpha_nav
@@ -309,6 +310,7 @@ class PlacePages(BasePage):
                 partial_nav = partial_navigation(
                     partial_list,
                     self.rlocale,
+                    current=part_name,
                     rtl=self.dir,
                     ext=self.ext,
                     new_page=nav_name,

--- a/gramps/plugins/webreport/place.py
+++ b/gramps/plugins/webreport/place.py
@@ -441,13 +441,15 @@ class PlacePages(BasePage):
 
         places_list = list(places_dict.items())
         max_rows = max_letter_rows[bletter]
-        create_indexes_pages(report,
-                             "places",
-                             index_list,
-                             self.part_placelistpage,
-                             places_list,
-                             max_rows,
-                             locale=self.rlocale)
+        create_indexes_pages(
+            report,
+            "places",
+            index_list,
+            self.part_placelistpage,
+            places_list,
+            max_rows,
+            locale=self.rlocale,
+        )
 
     def placepage(self, report, the_lang, the_title, place_handle, place_name):
         """

--- a/gramps/plugins/webreport/place.py
+++ b/gramps/plugins/webreport/place.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-#!/usr/bin/env python
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
@@ -43,6 +42,7 @@ Classe:
 # ------------------------------------------------
 from collections import defaultdict
 from decimal import getcontext
+import unicodedata
 import logging
 
 # ------------------------------------------------
@@ -63,6 +63,7 @@ from gramps.gen.display.place import displayer as _pd
 from gramps.plugins.webreport.basepage import BasePage
 from gramps.plugins.webreport.common import (
     alphabet_navigation,
+    partial_navigation,
     GOOGLE_MAPS,
     FULLCLEAR,
     MARKER_PATH,
@@ -208,7 +209,6 @@ class PlacePages(BasePage):
                 plc_title = ", ".join(pname.split(",")[:3])
             elif nbrs == 6:
                 plc_title = ", ".join(pname.split(",")[:4])
-            main_location = get_main_location(self.r_db, place)
             if not plc_title or plc_title == " ":
                 letter = "&nbsp;"
             trow = Html("tr")
@@ -258,21 +258,32 @@ class PlacePages(BasePage):
                     tcell2 += "&nbsp;"
         return (ldatec, first_place)
 
-    def placelistpage(self, report, the_lang, the_title):
-        """
-        Create a place index
+    def part_placelistpage(
+        self,
+        report,
+        index_list,
+        name,
+        letter,
+        places_handle_list,
+        part=None,
+        subp=None,
+        partial_list=None,
+    ):
 
-        @param: report        -- The instance of the main report class
-                                 for this report
-        @param: the_lang      -- The lang to process
-        @param: the_title     -- The title page related to the language
         """
-        BasePage.__init__(self, report, the_lang, the_title)
-
-        output_file, sio = self.report.create_file("places")
+        Create a part of a place index
+        """
+        nav_name = part_name = name
+        if part != 0 and subp != 0:
+            part_name += str(part)
+            nav_name = part_name
+        if subp and subp != 0:
+            part_name += subp
+        output_file, sio = self.report.create_file(part_name)
         result = self.write_header(self._("Places"))
         placelistpage, dummy_head, dummy_body, outerwrapper = result
         ldatec = 0
+        first_place = True
 
         # begin places division
         with Html("div", class_="content", id="Places") as placelist:
@@ -287,24 +298,27 @@ class PlacePages(BasePage):
             )
             placelist += Html("p", msg, id="description")
 
-            # begin alphabet navigation
-            # Assemble all the places
-            index = AlphabeticIndex(self.rlocale)
-            # self.report.obj_dict[PlaceName] is a dict with key place_name and
-            # values (place_fname, place_name, place.gramps_id, event)
-            for place_name, value in self.report.obj_dict[PlaceName].items():
-                index.addRecord(place_name, value)
-
-            # Extract the buckets from the index
-            index_list = []
-            index.resetBucketIterator()
-            while index.nextBucket():
-                if index.bucketRecordCount != 0:
-                    index_list.append(index.bucketLabel)
             # Output the navigation
-            alpha_nav = alphabet_navigation(index_list, self.rlocale, rtl=self.dir)
+            alpha_nav = alphabet_navigation(
+                index_list, self.rlocale, rtl=self.dir, new_page="places", ext=self.ext
+            )
             if alpha_nav:
                 placelist += alpha_nav
+
+            if part is not None:
+                # We need to create a new navigation tab for partial page index.
+                partial_nav = partial_navigation(
+                    partial_list,
+                    self.rlocale,
+                    rtl=self.dir,
+                    ext=self.ext,
+                    new_page=nav_name,
+                )
+                if partial_nav is not None:
+                    placelist += Html(
+                        "div", style="clear: both;"
+                    )  # This to align the next div to the left.
+                    placelist += partial_nav
 
             # begin places table and table head
             with Html(
@@ -343,66 +357,36 @@ class PlacePages(BasePage):
                     )
 
                 # begin table body
-                tbody = Html("tbody")
-                table += tbody
-
-                # For each bucket, output the places in that bucket
-                index.resetBucketIterator()
-                output = []
-                dup_index = 0
-                while index.nextBucket():
-                    if index.bucketRecordCount != 0:
-                        bucket_letter = index.bucketLabel
-                        bucket_link = bucket_letter
-                        if bucket_letter in output:
-                            bucket_link = "%s (%i)" % (bucket_letter, dup_index)
-                            dup_index += 1
-                        output.append(bucket_letter)
-                        # Assemble all the places in this bucket into a dict for
-                        # sorting
-                        place_dict = dict()
-                        while index.nextRecord():
-                            place_name = index.recordName
-                            value = index.recordData
-                            place_dict[place_name] = value
-
-                        handle_list = sort_places(self.r_db, place_dict, self.rlocale)
-                        first_place = True
-                        for pname, place_handle in handle_list:
-                            if not pname:
-                                continue
-                            val = self.report.obj_dict[PlaceName][pname]
-                            nbelem = len(val)
-                            if val and nbelem > 3:
-                                if isinstance(place_handle, tuple):
-                                    place = self.r_db.get_place_from_handle(
-                                        place_handle[0]
-                                    )
-                                else:
-                                    place = self.r_db.get_place_from_handle(
-                                        place_handle
-                                    )
-                                main_location = get_main_location(self.r_db, place)
-                                sname = main_location.get(PlaceType.STATE, "")
-                                cname = main_location.get(PlaceType.COUNTRY, "")
-                            elif nbelem == 3:
-                                cname = val[3]
-                                sname = val[2]
-                            else:
-                                val = [""]
-                                cname = ""
-                                sname = ""
-                            (ldatec, first_place) = self.__output_place(
-                                ldatec,
-                                trow,
-                                first_place,
-                                pname,
-                                sname,
-                                cname,
-                                val[0],
-                                bucket_letter,
-                                bucket_link,
-                            )
+                letter, phandle_list = places_handle_list[0]
+                for pname, place_handle in phandle_list:
+                    val = self.report.obj_dict[PlaceName][pname]
+                    nbelem = len(val)
+                    if val and nbelem > 3:
+                        if isinstance(place_handle, tuple):
+                            place = self.r_db.get_place_from_handle(place_handle[0])
+                        else:
+                            place = self.r_db.get_place_from_handle(place_handle)
+                        main_location = get_main_location(self.r_db, place)
+                        sname = main_location.get(PlaceType.STATE, "")
+                        cname = main_location.get(PlaceType.COUNTRY, "")
+                    elif nbelem == 3:
+                        cname = val[3]
+                        sname = val[2]
+                    else:
+                        val = [""]
+                        cname = ""
+                        sname = ""
+                    (ldatec, first_place) = self.__output_place(
+                        ldatec,
+                        trow,
+                        first_place,
+                        pname,
+                        sname,
+                        cname,
+                        val[0],
+                        letter,
+                        letter,
+                    )
 
         # add clearline for proper styling
         # add footer section
@@ -412,6 +396,98 @@ class PlacePages(BasePage):
         # send page out for processing
         # and close the file
         self.xhtml_writer(placelistpage, output_file, sio, ldatec)
+
+    def placelistpage(self, report, the_lang, the_title):
+        """
+        Create a place index
+
+        @param: report        -- The instance of the main report class
+                                 for this report
+        @param: the_lang      -- The lang to process
+        @param: the_title     -- The title page related to the language
+        """
+        BasePage.__init__(self, report, the_lang, the_title)
+
+        # begin alphabet navigation
+        index = AlphabeticIndex(self.rlocale)
+        # self.report.obj_dict[PlaceName] is a dict with key place_name and
+        # values (place_fname, place_name, place.gramps_id, event)
+        for place_name, value in self.report.obj_dict[PlaceName].items():
+            index.addRecord(place_name, value)
+
+        # Extract the buckets from the index
+        index_list = []
+        places_list = defaultdict(list)
+        index.resetBucketIterator()
+        while index.nextBucket():
+            if index.bucketRecordCount != 0:
+                letter = index.bucketLabel
+                if letter not in index_list:
+                    index_list.append(letter)
+                bletter = (
+                    unicodedata.normalize("NFKD", letter)[0]
+                    if len(letter) > 0
+                    else letter
+                )
+                # Assemble all the places in this bucket into a dict for sorting
+                place_dict = dict()
+                while index.nextRecord():
+                    place_name = index.recordName
+                    value = index.recordData
+                    place_dict[place_name] = value
+                handle_list = sort_places(self.r_db, place_dict, self.rlocale)
+                places_list[bletter] = handle_list
+
+        row_count = report.options["splitindex"]
+        handle_list = list(places_list)
+        page = 0
+        for letter in places_list:
+            handle_list = places_list[letter]
+            current = [(letter, handle_list)]
+            if len(handle_list) <= row_count:
+                name = "places"
+                self.part_placelistpage(
+                    report, index_list, name, letter, current, part=page
+                )
+            else:
+                # For each bucket, output the places in that bucket
+                partial_list = []
+                # hdle1_list.sort(key=lambda x: self.rlocale.sort_key(x[0]))
+                for idx in range(0, int(len(handle_list) / row_count) + 1, 1):
+                    partial_list.append(handle_list[idx * row_count])
+                sub_page = 0
+                part = 0
+                start = 0
+                while start < len(handle_list):
+                    phdle_list = []
+                    for nbh in range(len(handle_list)):
+                        if nbh < start:
+                            continue
+                        if nbh >= start + row_count:
+                            break
+                        if nbh > len(handle_list):
+                            break
+                        phdle_list.append(handle_list[nbh])
+                    plist = [(letter, phdle_list)]
+                    name = "places"
+                    if sub_page != 0:
+                        subp = "_%d" % sub_page
+                    else:
+                        subp = None
+                    self.part_placelistpage(
+                        report,
+                        index_list,
+                        name,
+                        letter,
+                        plist,
+                        part=page,
+                        subp=subp,
+                        partial_list=partial_list,
+                    )
+                    part += 1
+                    start += row_count
+                    sub_page += 1
+            page += 1
 
     def placepage(self, report, the_lang, the_title, place_handle, place_name):
         """
@@ -430,9 +506,7 @@ class PlacePages(BasePage):
         BasePage.__init__(self, report, the_lang, the_title, place.get_gramps_id())
         self.bibli = Bibliography()
         ldatec = place.get_change_time()
-        apname = _pd.display(self.r_db, place, fmt=0)
 
-        # if place_name:  # != apname: # store only the primary named page
         output_file, sio = self.report.create_file(place_handle, "plc")
         self.uplink = True
         self.page_title = place_name

--- a/gramps/plugins/webreport/source.py
+++ b/gramps/plugins/webreport/source.py
@@ -167,6 +167,7 @@ class SourcePages(BasePage):
             alpha_nav = alphabet_navigation(
                 index_list,
                 self.rlocale,
+                current=part_name,
                 rtl=self.dir,
                 new_page="sources",
                 ext=self.ext,
@@ -179,6 +180,7 @@ class SourcePages(BasePage):
                 partial_nav = partial_navigation(
                     partial_list,
                     self.rlocale,
+                    current=part_name,
                     rtl=self.dir,
                     ext=self.ext,
                     new_page=nav_name,

--- a/gramps/plugins/webreport/source.py
+++ b/gramps/plugins/webreport/source.py
@@ -318,13 +318,15 @@ class SourcePages(BasePage):
                 extended_handle_list[bletter].append((hdle))
         extended_handle_list = list(extended_handle_list.items())
         max_rows = max_letter_rows[bletter]
-        create_indexes_pages(report,
-                             "sources",
-                             index_list,
-                             self.part_sourcelistpage,
-                             extended_handle_list,
-                             max_rows,
-                             locale=self.rlocale)
+        create_indexes_pages(
+            report,
+            "sources",
+            index_list,
+            self.part_sourcelistpage,
+            extended_handle_list,
+            max_rows,
+            locale=self.rlocale,
+        )
 
     def sourcepage(self, report, the_lang, the_title, source_handle):
         """

--- a/gramps/plugins/webreport/webcal.py
+++ b/gramps/plugins/webreport/webcal.py
@@ -98,7 +98,7 @@ _LOG = logging.getLogger(".WebPage")
 FULLCLEAR = Html("div", class_="fullclear", inline=True)
 
 # Web page filename extensions
-_WEB_EXT = [".html", ".htm", ".shtml", ".php", ".php3", ".cgi"]
+_WEB_EXT = (".html", ".htm", ".shtml", ".php", ".php3", ".cgi")
 
 # Calendar stylesheet names
 _CALENDARSCREEN = "calendar-screen.css"
@@ -710,7 +710,7 @@ return false;
                     url = url_fname
                     add_subdirs = False
                     if not (url.startswith("http:") or url.startswith("/")):
-                        add_subdirs = not any(url.endswith(ext) for ext in _WEB_EXT)
+                        add_subdirs = not _has_webpage_extension(url)
 
                     # whether to add subdirs or not???
                     if add_subdirs:
@@ -2238,7 +2238,7 @@ def _has_webpage_extension(url):
 
     url = filename to be checked
     """
-    return any(url.endswith(ext) for ext in _WEB_EXT)
+    return url.endswith(_WEB_EXT)
 
 
 def get_day_list(event_date, holiday_list, bday_anniv_list, rlocale=glocale):

--- a/gramps/plugins/webreport/webcal.py
+++ b/gramps/plugins/webreport/webcal.py
@@ -709,7 +709,7 @@ return false;
                         url_fname = url_fname.lower()
                     url = url_fname
                     add_subdirs = False
-                    if not (url.startswith("http:") or url.startswith("/")):
+                    if not url.startswith(("http:", "/")):
                         add_subdirs = not _has_webpage_extension(url)
 
                     # whether to add subdirs or not???

--- a/gramps/test/test_util.py
+++ b/gramps/test/test_util.py
@@ -174,7 +174,7 @@ def delete_tree(dir):
     sdir = os.path.abspath(dir)
     here = _caller_dir() + os.path.sep
     tmp = tempfile.gettempdir() + os.path.sep
-    if not (sdir.startswith(here) or sdir.startswith(tmp)):
+    if not sdir.startswith((here, tmp)):
         raise TestError("%r is not a subdir of here (%r) or %r" % (dir, here, tmp))
     shutil.rmtree(sdir)
 

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -84,6 +84,11 @@ gramps/gen/db/txn.py
 gramps/gen/db/undoredo.py
 gramps/gen/db/utils.py
 #
+# gen.db.conversion_tools package
+#
+gramps/gen/db/conversion_tools/__init__.py
+gramps/gen/db/conversion_tools/conversion_21.py
+#
 # gen.display package
 #
 gramps/gen/display/__init__.py

--- a/po/update_po.py
+++ b/po/update_po.py
@@ -312,7 +312,7 @@ def create_filesfile():
 
         for filename in os.listdir(dirpath):
             name = os.path.split(filename)[1]
-            if name.endswith(".py") or name.endswith(".glade"):
+            if name.endswith((".py", ".glade")):
                 full_filename = os.path.join(dirpath, filename)
                 # Skip the file if in POTFILES.skip
                 if full_filename[lentopdir:] in notinfiles:
@@ -430,13 +430,13 @@ def xml_fragments():
             tokens = tokenize(fp.readline)
             in_string = False
             for _token, _text, _start, _end, _line in tokens:
-                if _text.startswith('"""') or _text.startswith("'''"):
+                if _text.startswith(('"""', "'''")):
                     _text = _text[3:]
-                elif _text.startswith('"') or _text.startswith("'"):
+                elif _text.startswith(('"', "'")):
                     _text = _text[1:]
-                if _text.endswith('"""') or _text.endswith("'''"):
+                if _text.endswith(('"""', "'''")):
                     _text = _text[:-3]
-                elif _text.endswith('"') or _text.endswith("'"):
+                elif _text.endswith(('"', "'")):
                     _text = _text[:-1]
                 if _token == STRING and not in_string:
                     in_string = True

--- a/setup.py
+++ b/setup.py
@@ -262,6 +262,7 @@ package_core = [
     "gramps.gen",
     "gramps.gen.datehandler",
     "gramps.gen.db",
+    "gramps.gen.db.conversion_tools",
     "gramps.gen.display",
     "gramps.gen.filters",
     "gramps.gen.filters.rules",

--- a/test/blob_to_json_test.py
+++ b/test/blob_to_json_test.py
@@ -1,0 +1,41 @@
+from gramps.gen.db.utils import open_database
+from gramps.gen.lib.serialize import to_dict, from_dict
+from gramps.gen.db.conversion_tools import convert_21
+
+# 1. Prepare: create a database named "Example" in version 20
+#    containing the blob data
+
+# 2. Open the database in latest Gramps to convert the database
+#    to version 21
+
+db = open_database("Example")
+
+# This is a version 21 database
+
+# But we tell it to use the blob data:
+
+db.set_serializer("blob")
+
+for table_name in db._get_table_func():
+    print("Testing %s..." % table_name)
+    get_array_from_handle = db._get_table_func(table_name, "raw_func")
+    iter_objects = db._get_table_func(table_name, "iter_func")
+
+    for obj in iter_objects():
+        # We convert the object into the JSON dicts:
+        json_data = to_dict(obj)
+
+        # We get the blob array:
+        array = get_array_from_handle(obj.handle)
+
+        # We convert the array to JSON dict using the
+        # conversion code to convert array directly to
+        # dict
+
+        convert_data = convert_21(table_name, array)
+
+        # Now we make sure they are identical in types
+        # and values:
+        assert convert_data == json_data
+
+db.close()


### PR DESCRIPTION
When we have large databases, the current indexes are too big
We have now 1 page for each letter.

We can limit the size of the page in rows per page in the html tab of the report.
The values are between 10 and 2000. The default is 500.
If we have more than this limit, we create a secondary index for the associated letter.