### PR TITLE
New indexes for big databases in the narrative web report

### DIFF
--- a/data/css/Web_Basic-Ash.css
+++ b/data/css/Web_Basic-Ash.css
@@ -192,6 +192,12 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #CCC;
     border-bottom: solid 1px black;
 }
+div#ltr.pnav ul.ltr li.CurrentSection, div#rtl.pnav ul.rtl li.CurrentSection,
+div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
+    font-weight: bold;
+    font-style: italic;
+    background-color: #CCC;
+}
 div#nav ul li.CurrentSection a {
     position: relative;
     top: 1px;

--- a/data/css/Web_Basic-Blue.css
+++ b/data/css/Web_Basic-Blue.css
@@ -283,6 +283,12 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #CCC;
     border-bottom: solid 1px black;
 }
+div#ltr.pnav ul.ltr li.CurrentSection, div#rtl.pnav ul.rtl li.CurrentSection,
+div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
+    font-weight: bold;
+    font-style: italic;
+    background-color: #CCC;
+}
 div#nav ul li.CurrentSection a {
     position: relative;
     top: 1px;

--- a/data/css/Web_Basic-Cypress.css
+++ b/data/css/Web_Basic-Cypress.css
@@ -201,6 +201,12 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #9DBF9D;
     border-bottom: solid 1px black;
 }
+div#ltr.pnav ul.ltr li.CurrentSection, div#rtl.pnav ul.rtl li.CurrentSection,
+div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
+    font-weight: bold;
+    font-style: italic;
+    background-color: #9DBF9D;
+}
 div#nav ul li.CurrentSection a {
     position: relative;
     top: 1px;

--- a/data/css/Web_Basic-Lilac.css
+++ b/data/css/Web_Basic-Lilac.css
@@ -195,6 +195,12 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #B4B4CB;
     border-bottom: solid 1px black;
 }
+div#ltr.pnav ul.ltr li.CurrentSection, div#rtl.pnav ul.rtl li.CurrentSection,
+div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
+    font-weight: bold;
+    font-style: italic;
+    background-color: #B4B4CB;
+}
 div#nav ul li.CurrentSection a {
     position: relative;
     top: 1px;

--- a/data/css/Web_Basic-Peach.css
+++ b/data/css/Web_Basic-Peach.css
@@ -195,6 +195,12 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #FFC35E;
     border-bottom: solid 1px #36220B;
 }
+div#ltr.pnav ul.ltr li.CurrentSection, div#rtl.pnav ul.rtl li.CurrentSection,
+div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
+    font-weight: bold;
+    font-style: italic;
+    background-color: #FFC35E;
+}
 div#nav ul li.CurrentSection a {
     position: relative;
     top: 1px;

--- a/data/css/Web_Basic-Spruce.css
+++ b/data/css/Web_Basic-Spruce.css
@@ -195,6 +195,12 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     background-color: #BFD0EA;
     border-bottom: solid 1px black;
 }
+div#ltr.pnav ul.ltr li.CurrentSection, div#rtl.pnav ul.rtl li.CurrentSection,
+div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
+    font-weight: bold;
+    font-style: italic;
+    background-color: #BFD0EA;
+}
 div#nav ul li.CurrentSection a {
     position: relative;
     top: 1px;

--- a/data/css/Web_Mainz.css
+++ b/data/css/Web_Mainz.css
@@ -197,6 +197,12 @@ div#nav ul li a:hover, #subnavigation ul li a:hover {
     text-decoration: none;
     background-color: #FFFFE7;
 }
+div#ltr.pnav ul.ltr li.CurrentSection, div#rtl.pnav ul.rtl li.CurrentSection,
+div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
+    font-weight: bold;
+    font-style: italic;
+    border-color: #7D5925;
+}
 div#nav ul li.CurrentSection a, #subnavigation ul li.CurrentSection a {
     font-weight: bold;
     font-style: italic;
@@ -213,6 +219,7 @@ div#nav li.lang ul.lang li {
 }
 div#nav li.lang {
     font-size: smaller;
+    font-weight: bold;
     padding-top: 2px;
     padding-bottom: 1px;
 }

--- a/data/css/Web_Nebraska.css
+++ b/data/css/Web_Nebraska.css
@@ -285,6 +285,12 @@ div#alphanav ul li a:hover, div#nav ul li a:hover, div#subnavigation ul li a:hov
     background-color: #000;
     color: #FFF;
 }
+div#ltr.pnav ul.ltr li.CurrentSection, div#rtl.pnav ul.rtl li.CurrentSection,
+div#ltr ul.ltr li.CurrentSection, div#rtl ul.rtl li.CurrentSection {
+    font-weight: bold;
+    font-style: italic;
+    background-color: #F2F6EE;
+}
 div#nav ul li.CurrentSection a, div#subnavigation ul li.CurrentSection a {
     padding: 4px 2px 3px 2px;
     border-right: solid 1px #542;
@@ -302,6 +308,9 @@ div#nav li.lang {
     position: relative;
     font-size: smaller;
     font-weight: bold;
+    padding-top: 3px;
+    padding-left: 8px;
+    font-size: smaller;
 }
 div#nav li.lang:hover > ul {
     visibility: visible;

--- a/gramps/plugins/webreport/family.py
+++ b/gramps/plugins/webreport/family.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-#!/usr/bin/env python
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
@@ -43,6 +42,7 @@ Classe:
 # ------------------------------------------------
 from collections import defaultdict, OrderedDict
 from decimal import getcontext
+import unicodedata
 import logging
 
 # ------------------------------------------------
@@ -60,6 +60,8 @@ from gramps.plugins.webreport.basepage import BasePage
 from gramps.gen.display.name import displayer as _nd
 from gramps.plugins.webreport.common import (
     alphabet_navigation,
+    partial_navigation,
+    create_indexes_pages,
     html_escape,
     FULLCLEAR,
     AlphabeticIndex,
@@ -134,7 +136,6 @@ class FamilyPages(BasePage):
         person_handle,
         tbody,
         letter,
-        bucket_link,
         first_person,
         first_family,
     ):
@@ -170,9 +171,7 @@ class FamilyPages(BasePage):
             # Update the ColumnRowLabel cell
             trow.attr = 'class="BeginLetter BeginFamily"'
             ttle = self._("Families beginning with " "letter ")
-            tcell += Html(
-                "a", letter, name=letter, title=ttle + letter, id_=bucket_link
-            )
+            tcell += Html("a", letter, name=letter, title=ttle + letter)
             #  and create the populated ColumnPartner for the person
             tcell = Html("td", class_="ColumnPartner")
             tcell += self.new_person_link(person_handle, uplink=self.uplink)
@@ -228,19 +227,27 @@ class FamilyPages(BasePage):
         first_family = False
         return (ldatec, first_person, first_family)
 
-    def familylistpage(self, report, the_lang, the_title, fam_list):
+    def part_familylistpage(
+        self,
+        report,
+        index_list,
+        name,
+        letter,
+        family_handle_list,
+        part=None,
+        subp=None,
+        partial_list=None,
+    ):
         """
-        Create a family index
-
-        @param: report    -- The instance of the main report class for
-                             this report
-        @param: the_lang  -- The lang to process
-        @param: the_title -- The title page related to the language
-        @param: fam_list  -- The handle for the place to add
+        Create a partial family index
         """
-        BasePage.__init__(self, report, the_lang, the_title)
-
-        output_file, sio = self.report.create_file("families")
+        nav_name = part_name = name
+        if part != 0 and subp != 0:
+            part_name += str(part)
+            nav_name = part_name
+        if subp and subp != 0:
+            part_name += subp
+        output_file, sio = self.report.create_file(part_name)
         result = self.write_header(self._("Families"))
         familieslistpage, dummy_head, dummy_body, outerwrapper = result
         ldatec = 0
@@ -260,42 +267,34 @@ class FamilyPages(BasePage):
             )
             relationlist += Html("p", msg, id="description")
 
-            # go through all the families, and construct a dictionary of all the
-            # people and the families they are involved in. Note that the people
-            # in the list may be involved in OTHER families, that are not listed
-            # because they are not in the original family list.
-            pers_fam_dict = defaultdict(list)
-            for family_handle in fam_list:
-                family = self.r_db.get_family_from_handle(family_handle)
-                if family:
-                    if family.get_change_time() > ldatec:
-                        ldatec = family.get_change_time()
-                    husband_handle = family.get_father_handle()
-                    spouse_handle = family.get_mother_handle()
-                    if husband_handle:
-                        pers_fam_dict[husband_handle].append(family)
-                    if spouse_handle:
-                        pers_fam_dict[spouse_handle].append(family)
-
-            # Assemble all the people, we no longer care about their families
-            index = AlphabeticIndex(self.rlocale)
-            for person_handle, dummy_family in pers_fam_dict.items():
-                person = self.r_db.get_person_from_handle(person_handle)
-                surname = get_surname_from_person(self.r_db, person)
-                index.addRecord(surname, person_handle)
-
-            # Extract the buckets from the index
-            index_list = []
-            index.resetBucketIterator()
-            while index.nextBucket():
-                if index.bucketRecordCount != 0:
-                    index_list.append(index.bucketLabel)
-
             # Output the navigation
             # add alphabet navigation
-            alpha_nav = alphabet_navigation(index_list, self.rlocale, rtl=self.dir)
+            alpha_nav = alphabet_navigation(
+                index_list,
+                self.rlocale,
+                current=part_name,
+                rtl=self.dir,
+                new_page="families",
+                ext=self.ext,
+            )
             if alpha_nav:
                 relationlist += alpha_nav
+
+            if part is not None:
+                # We need to create a new navigation tab for partial page index.
+                partial_nav = partial_navigation(
+                    partial_list,
+                    self.rlocale,
+                    current=part_name,
+                    rtl=self.dir,
+                    ext=self.ext,
+                    new_page=nav_name,
+                )
+                if partial_nav is not None:
+                    relationlist += Html(
+                        "div", style="clear: both;"
+                    )  # This to align the next div to the left.
+                    relationlist += partial_nav
 
             # begin families table and table head
             with Html("table", class_="infolist relationships " + self.dir) as table:
@@ -322,60 +321,27 @@ class FamilyPages(BasePage):
                 tbody = Html("tbody")
                 table += tbody
 
-                # for each bucket, output the people and their families in that
-                # bucket
-                index.resetBucketIterator()
-                output = []
-                dup_index = 0
-                while index.nextBucket():
-                    if index.bucketRecordCount != 0:
-                        bucket_letter = index.bucketLabel
-                        bucket_link = bucket_letter
-                        if bucket_letter in output:
-                            bucket_link = "%s (%i)" % (bucket_letter, dup_index)
-                            dup_index += 1
-                        output.append(bucket_letter)
-                        # Assemble a dict of all the people in this bucket.
-                        surname_ppl_handle_dict = OrderedDict()
-                        while index.nextRecord():
-                            # The records are returned sorted by recordName,
-                            # which is surname. we need to retain that order but
-                            # in addition sort by the rest of the name
-                            person_surname = index.recordName
-                            person_handle = index.recordData
-                            if person_surname in surname_ppl_handle_dict.keys():
-                                surname_ppl_handle_dict[person_surname].append(
-                                    person_handle
-                                )
-                            else:
-                                surname_ppl_handle_dict[person_surname] = [
-                                    person_handle
-                                ]
-                        first_person = True
-                        for surname, handle_list in surname_ppl_handle_dict.items():
-                            # get person from sorted database list
-                            for person_handle in sorted(
-                                handle_list, key=self.sort_on_name_and_grampsid
-                            ):
-                                person = self.r_db.get_person_from_handle(person_handle)
-                                if person:
-                                    family_list = person.get_family_handle_list()
-                                    first_family = True
-                                    for family_handle in family_list:
-                                        (
-                                            ldatec,
-                                            first_person,
-                                            first_family,
-                                        ) = self.__output_family(
-                                            ldatec,
-                                            family_handle,
-                                            person_handle,
-                                            tbody,
-                                            bucket_letter,
-                                            bucket_link,
-                                            first_person,
-                                            first_family,
-                                        )
+                first_person = True
+                # family_handle_list = family_handle_list[0][1]
+                for person_handle, surname in family_handle_list:
+                    person = self.r_db.get_person_from_handle(person_handle)
+                    if person:
+                        family_list = person.get_family_handle_list()
+                        first_family = True
+                        for family_handle in family_list:
+                            (
+                                ldatec,
+                                first_person,
+                                first_family,
+                            ) = self.__output_family(
+                                ldatec,
+                                family_handle,
+                                person_handle,
+                                tbody,
+                                letter,
+                                first_person,
+                                first_family,
+                            )
 
         # add clearline for proper styling
         # add footer section
@@ -385,6 +351,100 @@ class FamilyPages(BasePage):
         # send page out for processing
         # and close the file
         self.xhtml_writer(familieslistpage, output_file, sio, ldatec)
+
+    def familylistpage(self, report, the_lang, the_title, fam_list):
+        """
+        Create a family index
+
+        @param: report    -- The instance of the main report class for
+                             this report
+        @param: the_lang  -- The lang to process
+        @param: the_title -- The title page related to the language
+        @param: fam_list  -- The handle for the place to add
+        """
+        BasePage.__init__(self, report, the_lang, the_title)
+        ldatec = 0
+
+        pers_fam_dict = defaultdict(list)
+        for family_handle in fam_list:
+            family = self.r_db.get_family_from_handle(family_handle)
+            if family:
+                if family.get_change_time() > ldatec:
+                    ldatec = family.get_change_time()
+                husband_handle = family.get_father_handle()
+                spouse_handle = family.get_mother_handle()
+                if husband_handle:
+                    pers_fam_dict[husband_handle].append(family)
+                if spouse_handle:
+                    pers_fam_dict[spouse_handle].append(family)
+
+        # Assemble all the people, we no longer care about their families
+        index = AlphabeticIndex(self.rlocale)
+        for person_handle, dummy_family in pers_fam_dict.items():
+            person = self.r_db.get_person_from_handle(person_handle)
+            surname = get_surname_from_person(self.r_db, person)
+            index.addRecord(surname, person_handle)
+
+        # Extract the buckets from the index
+        index_list = []
+        index.resetBucketIterator()
+        # for each bucket, output the people and their families in that
+        # bucket
+        surname_ppl_handle_dict = OrderedDict()
+        while index.nextBucket():
+            if index.bucketRecordCount != 0:
+                letter = index.bucketLabel
+                # Assemble a dict of all the people in this bucket.
+                bletter = (
+                    unicodedata.normalize("NFKD", letter)[0]
+                    if len(letter) > 0
+                    else letter
+                )
+                while index.nextRecord():
+                    # The records are returned sorted by recordName,
+                    # which is surname. we need to retain that order but
+                    # in addition sort by the rest of the name
+                    person_surname = index.recordName
+                    person_handle = index.recordData
+                    if person_surname in surname_ppl_handle_dict.keys():
+                        surname_ppl_handle_dict[person_surname].append(person_handle)
+                    else:
+                        surname_ppl_handle_dict[person_surname] = [person_handle]
+        # sort by surname
+        surname_handle_list = surname_ppl_handle_dict
+        extended_handle_list = defaultdict(list)
+        name_format = self.report.options["name_format"]
+        max_letter_rows = defaultdict(int)
+        index_list = []
+        for bletter, hdlel in surname_handle_list.items():
+            bletter = (
+                unicodedata.normalize("NFKD", bletter)[0]
+                if len(bletter) > 0
+                else bletter
+            )
+            bletter = bletter[0] if len(bletter) > 0 else bletter
+            bletter = bletter.upper() if bletter.isalpha() else "…"
+            if bletter not in index_list:
+                index_list.append(bletter)
+            max_letter_rows[bletter] = len(hdlel)
+            for hdle in hdlel:
+                person = self.r_db.get_person_from_handle(hdle)
+                primary_name = person.get_primary_name()
+                nname = Name(primary_name)
+                nname.set_display_as(name_format)
+                fname = _nd.display_name(nname)
+                extended_handle_list[bletter].append((hdle, fname))
+        extended_handle_list = list(extended_handle_list.items())
+        max_rows = max_letter_rows[bletter]
+        create_indexes_pages(
+            report,
+            "families",
+            index_list,
+            self.part_familylistpage,
+            extended_handle_list,
+            max_rows,
+            locale=self.rlocale,
+        )
 
     def familypage(self, report, the_lang, the_title, family_handle):
         """

--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -551,7 +551,8 @@ class NavWebReport(Report):
                 self.tab["Event"].display_pages(the_lang, the_title)
 
             # build classes PlaceListPage and PlacePage
-            self.tab["Place"].display_pages(the_lang, the_title)
+            if self.inc_places:
+                self.tab["Place"].display_pages(the_lang, the_title)
 
             # build classes RepositoryListPage and RepositoryPage
             if self.inc_repository:
@@ -570,7 +571,8 @@ class NavWebReport(Report):
                 self.addressbook_pages(self.obj_dict[Person])
 
             # build classes SourceListPage and SourcePage
-            self.tab["Source"].display_pages(the_lang, the_title)
+            if self.inc_sources:
+                self.tab["Source"].display_pages(the_lang, the_title)
 
             # build calendar for the current year
             if self.usecal:
@@ -2221,6 +2223,12 @@ class NavWebOptions(MenuReportOptions):
         self.__toggle = BooleanOption(_("Toggle sections"), False)
         self.__toggle.set_help(_("Check it if you want to open/close" " a section"))
         addopt("toggle", self.__toggle)
+
+        self.__splitindex = NumberOption(_("Max. rows in an index"), 500, 10, 2000)
+        self.__splitindex.set_help(
+            _("The maximum number of rows to include in an index page")
+        )
+        addopt("splitindex", self.__splitindex)
 
     def __add_more_pages(self, menu):
         """

--- a/gramps/plugins/webreport/person.py
+++ b/gramps/plugins/webreport/person.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-#!/usr/bin/env python
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
@@ -45,6 +44,7 @@ Classe:
 from collections import defaultdict
 from operator import itemgetter
 from decimal import Decimal, getcontext
+from unicodedata import normalize
 import logging
 
 # ------------------------------------------------
@@ -57,7 +57,6 @@ from gramps.gen.lib import (
     Name,
     Person,
     EventRoleType,
-    Family,
     Event,
     EventType,
 )
@@ -81,6 +80,8 @@ from gramps.gen.relationship import get_relationship_calculator
 from gramps.plugins.webreport.basepage import BasePage
 from gramps.plugins.webreport.common import (
     alphabet_navigation,
+    partial_navigation,
+    create_indexes_pages,
     add_birthdate,
     FULLCLEAR,
     _find_birth_date,
@@ -192,7 +193,6 @@ class PersonPages(BasePage):
         date,
         tbody,
         bucket_letter,
-        bucket_link,
         showbirth,
         showdeath,
         showpartner,
@@ -224,9 +224,8 @@ class PersonPages(BasePage):
             )
             tcell += Html(
                 "a",
-                html_escape(surnamed),
+                html_escape(bucket_letter),
                 name=bucket_letter,
-                id_=bucket_link,
                 title=ttle,
             )
         elif first_individual:
@@ -339,30 +338,32 @@ class PersonPages(BasePage):
             trow += Html("td", class_="ColumnParents", inline=samerow) + tcell
         return (date, first_surname, first_individual)
 
-    def individuallistpage(self, report, the_lang, the_title, ppl_handle_list):
+    def part_individuallistpage(
+        self,
+        report,
+        index_list,
+        name,
+        letter,
+        surname_handle_list,
+        part=None,
+        subp=None,
+        partial_list=None,
+    ):
         """
-        Creates an individual page
-
-        @param: report          -- The instance of the main report class
-                                   for this report
-        @param: the_lang        -- The lang to process
-        @param: the_title       -- The title page related to the language
-        @param: ppl_handle_list -- The list of people for whom we need
-                                   to create a page.
+        Creates a partial of individual index
         """
-        BasePage.__init__(self, report, the_lang, the_title)
-
-        # plugin variables for this module
-        showbirth = report.options["showbirth"]
-        showdeath = report.options["showdeath"]
-        showpartner = report.options["showpartner"]
-        showparents = report.options["showparents"]
-
-        output_file, sio = self.report.create_file("individuals")
+        nav_name = part_name = name
+        if part != 0 and subp != 0:
+            part_name += str(part)
+            nav_name = part_name
+        if subp and subp != 0:
+            part_name += subp
+        output_file, sio = self.report.create_file(part_name)
         result = self.write_header(self._("Individuals"))
         indlistpage, dummy_head, dummy_body, outerwrapper = result
         date = 0
 
+        # for each bucket, output the surnames in that bucket
         # begin Individuals division
         with Html("div", class_="content", id="Individuals") as individuallist:
             outerwrapper += individuallist
@@ -377,31 +378,32 @@ class PersonPages(BasePage):
             )
             individuallist += Html("p", msg, id="description")
 
-            # add alphabet navigation
-            # Assemble all the handles for each surname into a dictionary
-            # We don't call sort_people because we don't care about sorting
-            # individuals, only surnames
-            surname_handle_dict = defaultdict(list)
-            for person_handle in ppl_handle_list:
-                person = self.r_db.get_person_from_handle(person_handle)
-                surname = get_surname_from_person(self.r_db, person)
-                surname_handle_dict[surname].append(person_handle)
-
-            # Assemble the alphabeticIndex
-            index = AlphabeticIndex(self.rlocale)
-            for surname, handle_list in surname_handle_dict.items():
-                index.addRecord(surname, handle_list)
-
-            # Extract the buckets from the index
-            index_list = []
-            index.resetBucketIterator()
-            while index.nextBucket():
-                if index.bucketRecordCount != 0:
-                    index_list.append(index.bucketLabel)
-            # Output the navigation
-            alpha_nav = alphabet_navigation(index_list, self.rlocale, rtl=self.dir)
+            alpha_nav = alphabet_navigation(
+                index_list,
+                self.rlocale,
+                current=part_name,
+                rtl=self.dir,
+                new_page="individuals",
+                ext=self.ext,
+            )
             if alpha_nav is not None:
                 individuallist += alpha_nav
+
+            if part is not None:
+                # We need to create a new navigation tab for partial page index.
+                partial_nav = partial_navigation(
+                    partial_list,
+                    self.rlocale,
+                    current=part_name,
+                    rtl=self.dir,
+                    ext=self.ext,
+                    new_page=nav_name,
+                )
+                if partial_nav is not None:
+                    individuallist += Html(
+                        "div", style="clear: both;"
+                    )  # This to align the next div to the left.
+                    individuallist += partial_nav
 
             # begin table and table head
             with Html(
@@ -420,22 +422,22 @@ class PersonPages(BasePage):
                 )
                 trow += Html("th", self._("Name"), class_="ColumnName", inline=True)
 
-                if showbirth:
+                if report.options["showbirth"]:
                     trow += Html(
                         "th", self._("Birth"), class_="ColumnDate", inline=True
                     )
 
-                if showdeath:
+                if report.options["showdeath"]:
                     trow += Html(
                         "th", self._("Death"), class_="ColumnDate", inline=True
                     )
 
-                if showpartner:
+                if report.options["showpartner"]:
                     trow += Html(
                         "th", self._("Partner"), class_="ColumnPartner", inline=True
                     )
 
-                if showparents:
+                if report.options["showparents"]:
                     trow += Html(
                         "th", self._("Parents"), class_="ColumnParents", inline=True
                     )
@@ -443,68 +445,42 @@ class PersonPages(BasePage):
             tbody = Html("tbody")
             table += tbody
 
-            # for each bucket, output the surnames in that bucket
-            index.resetBucketIterator()
-            output = []
-            dup_index = 0
-            while index.nextBucket():
-                if index.bucketRecordCount != 0:
-                    surname_handle_dict = defaultdict(list)
-                    bucket_letter = index.bucketLabel
-                    bucket_link = bucket_letter
-                    if bucket_letter in output:
-                        bucket_link = "%s (%i)" % (bucket_letter, dup_index)
-                        dup_index += 1
-                    output.append(bucket_letter)
-                    while index.nextRecord():
-                        surname = index.recordName
-                        handle_list = index.recordData
-                        for handle in handle_list:
-                            surname_handle_dict[surname].append(handle)
-                    surname_handle_list = list(surname_handle_dict.items())
-                    # sort by surname
-                    surname_handle_list.sort(key=lambda x: self.rlocale.sort_key(x[0]))
+            name_format = self.report.options["name_format"]
+            nme_format = _nd.name_formats[name_format][1]
+            first_surname = True
+            first_individual = True
+            for handle, surname in surname_handle_list:
+                if not surname or surname.isspace():
+                    surname = self._("<absent>")
 
-                    name_format = self.report.options["name_format"]
-                    nme_format = _nd.name_formats[name_format][1]
-                    for surname, handle_list in surname_handle_list:
-                        if not surname or surname.isspace():
-                            surname = self._("<absent>")
-
-                        # In case the user choose a format name like "*SURNAME*"
-                        # We must display this field in upper case. So we use
-                        # the english format of format_name to find if this is
-                        # the case. name_format =
-                        # self.report.options['name_format'] nme_format =
-                        # _nd.name_formats[name_format][1]
-                        if "SURNAME" in nme_format:
-                            surnamed = surname.upper()
-                        else:
-                            surnamed = surname
-                        first_surname = True
-                        first_individual = True
-                        for person_handle in sorted(
-                            handle_list, key=self.sort_on_name_and_grampsid
-                        ):
-                            (
-                                date,
-                                first_surname,
-                                first_individual,
-                            ) = self.__output_person(
-                                date,
-                                tbody,
-                                bucket_letter,
-                                bucket_link,
-                                showbirth,
-                                showdeath,
-                                showpartner,
-                                showparents,
-                                surname,
-                                surnamed,
-                                first_surname,
-                                first_individual,
-                                person_handle,
-                            )
+                # In case the user choose a format name like "*SURNAME*"
+                # We must display this field in upper case. So we use
+                # the english format of format_name to find if this is
+                # the case. name_format =
+                # self.report.options['name_format'] nme_format =
+                # _nd.name_formats[name_format][1]
+                if "SURNAME" in nme_format:
+                    surnamed = surname.upper()
+                else:
+                    surnamed = surname
+                (
+                    date,
+                    first_surname,
+                    first_individual,
+                ) = self.__output_person(
+                    date,
+                    tbody,
+                    letter,
+                    report.options["showbirth"],
+                    report.options["showdeath"],
+                    report.options["showpartner"],
+                    report.options["showparents"],
+                    surname,
+                    surnamed,
+                    first_surname,
+                    first_individual,
+                    handle[0],
+                )
 
         # create clear line for proper styling
         # create footer section
@@ -514,6 +490,80 @@ class PersonPages(BasePage):
         # send page out for processing
         # and close the file
         self.xhtml_writer(indlistpage, output_file, sio, date)
+
+    def individuallistpage(self, report, the_lang, the_title, ppl_handle_list):
+        """
+        Creates an individual page
+
+        @param: report          -- The instance of the main report class
+                                   for this report
+        @param: the_lang        -- The lang to process
+        @param: the_title       -- The title page related to the language
+        @param: ppl_handle_list -- The list of people for whom we need
+                                   to create a page.
+        """
+        BasePage.__init__(self, report, the_lang, the_title)
+
+        surname_handle_dict = defaultdict(list)
+        surname_handle_list = []
+        for person_handle in ppl_handle_list:
+            person = self.r_db.get_person_from_handle(person_handle)
+            surname = get_surname_from_person(self.r_db, person)
+            surname_handle_dict[surname].append(person_handle)
+        # Assemble the alphabeticIndex
+        index = AlphabeticIndex(self.rlocale)
+        for surname, handle_list in surname_handle_dict.items():
+            index.addRecord(surname, handle_list)
+        index_list = []
+        surname_handle_dict = defaultdict(list)
+        max_letter_rows = defaultdict(int)
+        # Extract the buckets from the index
+        index.resetBucketIterator()
+        while index.nextBucket():
+            if index.bucketRecordCount != 0:
+                letter = index.bucketLabel
+                if letter not in index_list:
+                    index_list.append(letter)
+                bletter = normalize("NFKD", letter)[0] if len(letter) > 0 else letter
+                while index.nextRecord():
+                    handle_list = index.recordData
+                    if handle_list:
+                        for handle in handle_list:
+                            surname_handle_dict[bletter].append(
+                                (handle, index.recordName)
+                            )
+                        if bletter in max_letter_rows:
+                            max_letter_rows[bletter] += len(handle_list)
+                        else:
+                            max_letter_rows[bletter] = len(handle_list)
+
+        surname_handle_list = list(surname_handle_dict.items())
+        # sort by surname
+        surname_handle_list.sort(key=lambda x: self.rlocale.sort_key(x[0]))
+        extended_handle_list = defaultdict(list)
+        name_format = self.report.options["name_format"]
+        for bletter, hdlel in surname_handle_list:
+            bletter = normalize("NFKD", bletter)[0] if len(bletter) > 0 else bletter
+            bletter = bletter[0] if len(bletter) > 0 else bletter
+            bletter = bletter.upper() if bletter.isalpha() else "…"
+            for hdle in hdlel:
+                person = self.r_db.get_person_from_handle(hdle[0])
+                primary_name = person.get_primary_name()
+                nname = Name(primary_name)
+                nname.set_display_as(name_format)
+                fname = _nd.display_name(nname)
+                extended_handle_list[bletter].append((hdle, fname))
+        extended_handle_list = list(extended_handle_list.items())
+        max_rows = max_letter_rows[bletter]
+        create_indexes_pages(
+            report,
+            "individuals",
+            index_list,
+            self.part_individuallistpage,
+            extended_handle_list,
+            max_rows,
+            locale=self.rlocale,
+        )
 
     #################################################
     #

--- a/gramps/plugins/webreport/source.py
+++ b/gramps/plugins/webreport/source.py
@@ -43,6 +43,7 @@ Classe:
 # ------------------------------------------------
 from collections import defaultdict
 from decimal import getcontext
+from unicodedata import normalize
 import logging
 
 # ------------------------------------------------
@@ -56,7 +57,14 @@ from gramps.plugins.lib.libhtml import Html
 # specific narrative web import
 # ------------------------------------------------
 from gramps.plugins.webreport.basepage import BasePage
-from gramps.plugins.webreport.common import FULLCLEAR, html_escape
+from gramps.plugins.webreport.common import (
+    FULLCLEAR,
+    html_escape,
+    alphabet_navigation,
+    partial_navigation,
+    create_indexes_pages,
+    AlphabeticIndex,
+)
 
 _ = glocale.translation.sgettext
 LOG = logging.getLogger(".NarrativeWeb.source")
@@ -119,38 +127,34 @@ class SourcePages(BasePage):
                 index += 1
                 self.sourcepage(self.report, the_lang, the_title, source_handle)
 
-    def sourcelistpage(self, report, the_lang, the_title, source_handles):
+    def part_sourcelistpage(
+        self,
+        report,
+        index_list,
+        name,
+        letter,
+        source_handle_list,
+        part=None,
+        subp=None,
+        partial_list=None,
+    ):
         """
-        Generate and output the Sources index page.
-
-        @param: report         -- The instance of the main report class for
-                                  this report
-        @param: the_lang       -- The lang to process
-        @param: the_title      -- The title page related to the language
-        @param: source_handles -- A list of the handles of the sources to be
-                                  displayed
+        Generate a partial Sources index page.
         """
-        BasePage.__init__(self, report, the_lang, the_title)
-
-        source_dict = {}
-
-        output_file, sio = self.report.create_file("sources")
+        nav_name = part_name = name
+        if part != 0 and subp != 0:
+            part_name += str(part)
+            nav_name = part_name
+        if subp and subp != 0:
+            part_name += subp
+        output_file, sio = self.report.create_file(part_name)
         result = self.write_header(self._("Sources"))
         sourcelistpage, dummy_head, dummy_body, outerwrapper = result
+        date = 0
 
         # begin source list division
         with Html("div", class_="content", id="Sources") as sourceslist:
             outerwrapper += sourceslist
-
-            # Sort the sources
-            for handle in source_handles:
-                source = self.r_db.get_source_from_handle(handle)
-                if source is not None:
-                    key = source.get_title() + source.get_author()
-                    key += str(source.get_gramps_id())
-                    source_dict[key] = (source, handle)
-
-            keys = sorted(source_dict, key=self.rlocale.sort_key)
 
             msg = self._(
                 "This page contains an index of all the sources "
@@ -159,6 +163,33 @@ class SourcePages(BasePage):
                 "title will take you to that source&#8217;s page."
             )
             sourceslist += Html("p", msg, id="description")
+
+            alpha_nav = alphabet_navigation(
+                index_list,
+                self.rlocale,
+                current=part_name,
+                rtl=self.dir,
+                new_page="sources",
+                ext=self.ext,
+            )
+            if alpha_nav is not None:
+                sourceslist += alpha_nav
+
+            if part is not None:
+                # We need to create a new navigation tab for partial page index.
+                partial_nav = partial_navigation(
+                    partial_list,
+                    self.rlocale,
+                    current=part_name,
+                    rtl=self.dir,
+                    ext=self.ext,
+                    new_page=nav_name,
+                )
+                if partial_nav is not None:
+                    sourceslist += Html(
+                        "div", style="clear: both;"
+                    )  # This to align the next div to the left.
+                    sourceslist += partial_nav
 
             # begin sourcelist table and table head
             with Html(
@@ -186,12 +217,20 @@ class SourcePages(BasePage):
                 tbody = Html("tbody")
                 table += tbody
 
-                for index, key in enumerate(keys):
-                    source, source_handle = source_dict[key]
+                first_row = True
+                for source_idx in source_handle_list:
+                    source_handle, title = source_idx
+                    source = self.r_db.get_source_from_handle(source_handle)
 
-                    trow = Html("tr") + (
-                        Html("td", index + 1, class_="ColumnRowLabel", inline=True)
-                    )
+                    if first_row:
+                        first_row = False
+                        trow = Html("tr") + (
+                            Html("td", letter, class_="ColumnRowLabel", inline=True)
+                        )
+                    else:
+                        trow = Html("tr") + (
+                            Html("td", "&nbsp;", class_="ColumnRowLabel", inline=True)
+                        )
                     tbody += trow
                     trow.extend(
                         Html(
@@ -215,12 +254,81 @@ class SourcePages(BasePage):
 
         # add clearline for proper styling
         # add footer section
-        footer = self.write_footer(None)
+        footer = self.write_footer(date)
         outerwrapper += (FULLCLEAR, footer)
 
         # send page out for processing
         # and close the file
         self.xhtml_writer(sourcelistpage, output_file, sio, 0)
+
+    def sourcelistpage(self, report, the_lang, the_title, source_handles):
+        """
+        Generate and output the Sources index page.
+
+        @param: report         -- The instance of the main report class for
+                                  this report
+        @param: the_lang       -- The lang to process
+        @param: the_title      -- The title page related to the language
+        @param: source_handles -- A list of the handles of the sources to be
+                                  displayed
+        """
+        BasePage.__init__(self, report, the_lang, the_title)
+
+        source_dict = {}
+        # Sort the sources
+        for handle in source_handles:
+            source = self.r_db.get_source_from_handle(handle)
+            if source is not None:
+                key = source.get_title()  # + source.get_author()
+                source_dict[key] = (key, handle)
+
+        # Assemble the alphabeticIndex
+        index = AlphabeticIndex(self.rlocale)
+        for key, handle_list in source_dict.items():
+            index.addRecord(key, handle_list)
+        index_list = []
+        source_handle_dict = defaultdict(list)
+        max_letter_rows = defaultdict(int)
+        # Extract the buckets from the index
+        index.resetBucketIterator()
+        while index.nextBucket():
+            if index.bucketRecordCount != 0:
+                letter = index.bucketLabel
+                if letter not in index_list:
+                    index_list.append(letter)
+                bletter = normalize("NFKD", letter)[0] if len(letter) > 0 else letter
+                while index.nextRecord():
+                    handle_list = index.recordData
+                    if handle_list:
+                        source_handle_dict[bletter].append(
+                            (handle_list[1], handle_list[0])
+                        )
+                        if bletter in max_letter_rows:
+                            max_letter_rows[bletter] += len(handle_list[1])
+                        else:
+                            max_letter_rows[bletter] = len(handle_list[1])
+
+        source_handle_list = list(source_handle_dict.items())
+        # sort by source
+        source_handle_list.sort(key=lambda x: self.rlocale.sort_key(x[0]))
+        extended_handle_list = defaultdict(list)
+        for bletter, hdlel in source_handle_list:
+            bletter = normalize("NFKD", bletter)[0] if len(bletter) > 0 else bletter
+            bletter = bletter[0] if len(bletter) > 0 else bletter
+            bletter = bletter.upper() if bletter.isalpha() else "…"
+            for hdle in hdlel:
+                extended_handle_list[bletter].append((hdle))
+        extended_handle_list = list(extended_handle_list.items())
+        max_rows = max_letter_rows[bletter]
+        create_indexes_pages(
+            report,
+            "sources",
+            index_list,
+            self.part_sourcelistpage,
+            extended_handle_list,
+            max_rows,
+            locale=self.rlocale,
+        )
 
     def sourcepage(self, report, the_lang, the_title, source_handle):
         """


### PR DESCRIPTION
When we have large databases, the current indexes are too big
We have now 1 page for each letter.

We can limit the size of the page in rows per page in the html tab of the report.
The values are between 10 and 2000. The default is 500.
If we have more than this limit, we create a secondary index for the associated letter.
