### PR TITLE
Crash with empty ADDR in narrative web

### DIFF
--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -1031,7 +1031,7 @@ class NavWebReport(Report):
                 name = ""
         if config.get("preferences.place-auto"):
             place_name = _pd.display_event(self._db, event, fmt=0)
-            if event:
+            if event and place_name:
                 cplace_name = place_name.split()[-1]
                 if len(place_name.split()) > 1:
                     splace_name = place_name.split()[-2]


### PR DESCRIPTION
Fixes [#13479](https://gramps-project.org/bugs/view.php?id=13479)

The output from Family Tree Maker does not contain the address that was entered. 