### PR TITLE
Update Info.plist for Gramps 6.0

### DIFF
--- a/mac/Info.plist
+++ b/mac/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleExecutable</key>
     <string>Gramps</string>
     <key>CFBundleGetInfoString</key>
-    <string>Gramps-5.2.4-1, (C) 1997-2025 The Gramps Team http://www.gramps-project.org</string>
+    <string>Gramps-6.0.0-beta1-1, (C) 1997-2025 The Gramps Team http://www.gramps-project.org</string>
     <key>CFBundleIconFile</key>
     <string>gramps.icns</string>
     <key>CFBundleIdentifier</key>
@@ -17,15 +17,15 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>Gramps-5.2.4-1</string>
+    <string>Gramps-6.0.0-beta1-1</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleVersion</key>
-    <string>Gramps-5.2.4-1</string>
+    <string>Gramps-6.0.0-beta1-1</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright 1997 - 2025 The Gramps Team, GNU General Public License.</string>
     <key>LSMinimumSystemVersion</key>
-    <string>10.13</string>
+    <string>11.0</string>
     <key>GtkOSXLaunchScriptFile</key>
     <string>gramps_launcher.py</string>
     <key>NSHighResolutionCapable</key>


### PR DESCRIPTION
The important change is that macOS 11.0 (Big Sur) is now the minimum required for both Intel and Apple Silicon Macs.
Only 11.0 and later work on Apple Silicon. The version before 11.0, 10.15, is now over 5 years old and a new major release is a good time to sunset it.