### PR TITLE
Disable pylintrc no-else-return check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -50,7 +50,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=suppressed-message,useless-suppression
+disable=suppressed-message,useless-suppression,no-else-return
 
 
 [REPORTS]


### PR DESCRIPTION
As explicit is better than implicit disabled no-else-return refactoring check.