### PR TITLE
Missing future import for annotations

### DIFF
--- a/gramps/gen/lib/json_utils.py
+++ b/gramps/gen/lib/json_utils.py
@@ -25,6 +25,7 @@
 #
 # ------------------------------------------------------------------------
 
+from __future__ import annotations
 import json
 import orjson
 


### PR DESCRIPTION
This PR adds a missing import from future for annotations since we use a "|" for "or" between types.