### PR TITLE
Fix accessing an attribute in a DataDict

### DIFF
--- a/gramps/gen/filters/rules/person/_hasnameof.py
+++ b/gramps/gen/filters/rules/person/_hasnameof.py
@@ -106,7 +106,7 @@ class HasNameOf(Rule):
             return False
         if self.list[8] and not self.match_substring(8, surn.connector):
             return False
-        if int(surn.origintype) == NameOriginType.PATRONYMIC:
+        if int(surn.origintype.value) == NameOriginType.PATRONYMIC:
             if self.list[9] and not self.match_substring(9, surn.surname):
                 return False
         return True

--- a/gramps/gen/filters/rules/person/_hassoundexname.py
+++ b/gramps/gen/filters/rules/person/_hassoundexname.py
@@ -109,7 +109,7 @@ class HasSoundexName(Rule):
         """
         if soundex(str(surname.get_surname())) == self.soundex:
             return True
-        if int(surname.origintype) == NameOriginType.PATRONYMIC:
+        if int(surname.origintype.value) == NameOriginType.PATRONYMIC:
             if soundex(str(surname.surname)) == self.soundex:
                 return True
         return False

--- a/gramps/gen/lib/json_utils.py
+++ b/gramps/gen/lib/json_utils.py
@@ -72,9 +72,7 @@ class DataDict(dict):
                 "this method cannot be used to access hidden attributes"
             )
 
-        if "_object" in self:
-            return getattr(self["_object"], key)
-        elif key in self:
+        if key in self:
             value = self[key]
             if isinstance(value, dict):
                 return DataDict(value)
@@ -83,7 +81,10 @@ class DataDict(dict):
             else:
                 return value
         else:
+            # Some method or attribute not available
+            # otherwise. Cache it:
             self["_object"] = data_to_object(self)
+            # And return the attr from the object:
             return getattr(self["_object"], key)
 
 


### PR DESCRIPTION
This PR fixes a bug in accessing an attr in a DataDict.

Previously, `person_data.handle` (where person_data is a DataDict) would return the attribute from the "_object" if it existed. This is fine for any non-data values (like strings). But for other items (like a Name), it would return the Object (Name) rather than a DataDict of the Name. This might be not noticed if you continued to access attr, but Object["other_attr"] would crash.

Now, it properly returns a DataDict for all attributes, except those that only exist on the object (such as methods).