### PR TITLE
Enable <Enter> key press on date fields in sidebar filters

### DIFF
--- a/gramps/gui/filters/sidebar/_sidebarfilter.py
+++ b/gramps/gui/filters/sidebar/_sidebarfilter.py
@@ -198,7 +198,10 @@ class SidebarFilter(DbGUIElement):
 
     def add_text_entry(self, name, widget, tooltip=None):
         self.add_entry(name, widget)
-        widget.connect("key-press-event", self.key_press)
+        if isinstance(widget, widgets.DateEntry):
+            widget.entry.connect("key-press-event", self.key_press)
+        else:
+            widget.connect("key-press-event", self.key_press)
         if tooltip:
             widget.set_tooltip_text(tooltip)
 


### PR DESCRIPTION
Allow pressing the Return key or keypad Enter key to run the filter in the sidebar filter gramplets.

Fixes [#13607](https://gramps-project.org/bugs/view.php?id=13607).