### PR TITLE
Bug: Use cx-freeze 7.2.8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ docs/_build/
 # Gramps AIO build artifacts
 aio/grampsaio64.nsi
 aio/mingw-w64-x86_64-db-*.pkg.tar.xz
+aio/mingw-w64-x86_64-python-cx-freeze-*.pkg.tar.zst
 aio/mingw64
 gramps.egg-info
 

--- a/aio/build.sh
+++ b/aio/build.sh
@@ -4,6 +4,9 @@
 #
 # install prerequisites
 ## prerequisites in msys packages
+pacman -Syy
+pacman -Syyu --noconfirm
+
 pacman -S --needed --noconfirm \
     base-devel \
     git \
@@ -49,6 +52,9 @@ pacman -S --needed --noconfirm \
 
 wget --no-verbose -N https://github.com/bpisoj/MINGW-packages/releases/download/v5.0/mingw-w64-x86_64-db-6.0.30-1-any.pkg.tar.xz
 pacman -U --needed --noconfirm mingw-w64-x86_64-db-6.0.30-1-any.pkg.tar.xz
+
+wget --no-verbose -N https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-python-cx-freeze-7.2.8-1-any.pkg.tar.zst
+pacman -U --needed --noconfirm mingw-w64-x86_64-python-cx-freeze-7.2.8-1-any.pkg.tar.zst
 
 ## create a python virtual environment so that we have a clean starting point
 pythonvenv=$TMP/grampspythonenv


### PR DESCRIPTION
The latest cx-freeze version 7.2.9.[1|2] result in two DLLs being located in the wrong directory.

1. force use of cx-freeze 7.2.8.1 which works correctly
2. update pacman databases as part of the build to ensure local builds match runners

Fixes bug [0013602](https://gramps-project.org/bugs/view.php?id=13602)