### PR TITLE
Fix the match method in the GenericFilter class

### DIFF
--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -80,7 +80,7 @@ class GenericFilter:
         """
         Return True or False depending on whether the handle matches the filter.
         """
-        obj = self.get_object(handle)
+        obj = self.get_object(db, handle)
         return self.apply_to_one(db, obj)
 
     def is_empty(self):


### PR DESCRIPTION
This was causing problems when using the filter sidebar in the place tree view.  A filtered place was being displayed as "????" if an enclosing place was removed or added back again.

Fixes [#13606](https://gramps-project.org/bugs/view.php?id=13606).