### PR TITLE
Fixed a filter/rule that bypasses proxies

### DIFF
--- a/gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py
@@ -69,7 +69,9 @@ class IsDescendantFamilyOfFilterMatch(IsDescendantFamilyOf):
                 _("Retrieving all sub-filter matches"),
                 db.get_number_of_people(),
             )
-        for handle, person in db._iter_raw_person_data():
+        # Must use db.iter_people() rather that db._iter_raw_person_data()
+        # because of proxies:
+        for person in db.iter_people():
             if user:
                 user.step_progress()
             if self.matchfilt.apply_to_one(db, person):


### PR DESCRIPTION
This PR changes `db._iter_raw_person_data()` to `db.iter_people()` because proxies don't protect data on that method.