### PR TITLE
Correct parameter type hints to accept <object> | None

### DIFF
--- a/gramps/gen/filters/rules/family/_isancestorof.py
+++ b/gramps/gen/filters/rules/family/_isancestorof.py
@@ -71,7 +71,7 @@ class IsAncestorOf(Rule):
     def apply_to_one(self, db: Database, family: Family) -> bool:
         return family.handle in self.selected_handles
 
-    def init_list(self, db: Database, family: Family, first: bool):
+    def init_list(self, db: Database, family: Family | None, first: bool) -> None:
         """
         Initialise family handle list.
         """

--- a/gramps/gen/filters/rules/family/_isdescendantof.py
+++ b/gramps/gen/filters/rules/family/_isdescendantof.py
@@ -71,7 +71,7 @@ class IsDescendantOf(Rule):
     def apply_to_one(self, db: Database, family: Family) -> bool:
         return family.handle in self.selected_handles
 
-    def init_list(self, db: Database, family: Family, first: bool) -> None:
+    def init_list(self, db: Database, family: Family | None, first: bool) -> None:
         """
         Initialise family handle list.
         """

--- a/gramps/gen/filters/rules/person/_deeprelationshippathbetween.py
+++ b/gramps/gen/filters/rules/person/_deeprelationshippathbetween.py
@@ -91,7 +91,7 @@ def get_person_family_people(
 
 
 def find_deep_relations(
-    db: Database, user, person: Person, target_people: List[str]
+    db: Database, user, person: Person | None, target_people: List[str]
 ) -> Set[str]:
     """This explores all possible paths between a person and one or more
     targets.  The algorithm processes paths in a breadth first wave, one

--- a/gramps/gen/filters/rules/person/_isancestorof.py
+++ b/gramps/gen/filters/rules/person/_isancestorof.py
@@ -78,7 +78,9 @@ class IsAncestorOf(Rule):
     def apply_to_one(self, db: Database, person: Person) -> bool:
         return person.handle in self.selected_handles
 
-    def init_ancestor_list(self, db: Database, person: Person, first: bool) -> None:
+    def init_ancestor_list(
+        self, db: Database, person: Person | None, first: bool
+    ) -> None:
         if not person:
             return
         if person.handle in self.selected_handles:

--- a/gramps/gen/filters/rules/person/_isdescendantfamilyof.py
+++ b/gramps/gen/filters/rules/person/_isdescendantfamilyof.py
@@ -88,7 +88,7 @@ class IsDescendantFamilyOf(Rule):
     def apply_to_one(self, db: Database, person: Person) -> bool:
         return person.handle in self.selected_handles
 
-    def add_matches(self, person: Person):
+    def add_matches(self, person: Person | None):
         if not person:
             return
 

--- a/gramps/gen/filters/rules/person/_isdescendantof.py
+++ b/gramps/gen/filters/rules/person/_isdescendantof.py
@@ -78,7 +78,7 @@ class IsDescendantOf(Rule):
     def apply_to_one(self, db: Database, person: Person) -> bool:
         return person.handle in self.selected_handles
 
-    def init_list(self, person: Person, first: bool):
+    def init_list(self, person: Person | None, first: bool) -> None:
         if not person or person.handle in self.selected_handles:
             # if we have been here before, skip
             return

--- a/gramps/gen/filters/rules/person/_islessthannthgenerationdescendantof.py
+++ b/gramps/gen/filters/rules/person/_islessthannthgenerationdescendantof.py
@@ -77,7 +77,7 @@ class IsLessThanNthGenerationDescendantOf(Rule):
     def apply_to_one(self, db: Database, person: Person) -> bool:
         return person.handle in self.selected_handles
 
-    def init_list(self, person: Person, gen: int):
+    def init_list(self, person: Person | None, gen: int):
         if not person or person.handle in self.selected_handles:
             # if we have been here before, skip
             return

--- a/gramps/gen/filters/rules/person/_isrelatedwith.py
+++ b/gramps/gen/filters/rules/person/_isrelatedwith.py
@@ -74,9 +74,9 @@ class IsRelatedWith(Rule):
     def apply_to_one(self, db: Database, person: Person) -> bool:
         return person.handle in self.selected_handles
 
-    def add_relative(self, start: Person):
+    def add_relative(self, start: Person | None):
         """Non-recursive function that scans relatives and add them to self.selected_handles"""
-        if not (start):
+        if not start:
             return
 
         queue: List[Person] = [start]


### PR DESCRIPTION
The type hints on these methods do not currently accept None.
None can be passed in and is handled correctly within the method.
Correct the type hint accordingly.