### PR TITLE
mypy: Simplify HasSourceOfBase.prepare()

### DIFF
--- a/gramps/gen/filters/rules/_hassourceofbase.py
+++ b/gramps/gen/filters/rules/_hassourceofbase.py
@@ -59,16 +59,12 @@ class HasSourceOfBase(Rule):
     description = "Matches objects who have a particular source"
 
     def prepare(self, db: Database, user):
-        if self.list[0] == "":
+        self.nosource = self.list[0] == ""
+        if self.nosource:
             self.source_handle = None
-            self.nosource = True
-            return
-
-        self.nosource = False
-        try:
-            self.source_handle = db.get_source_from_gramps_id(self.list[0]).handle
-        except:
-            self.source_handle = None
+        else:
+            source = db.get_source_from_gramps_id(self.list[0])
+            self.source_handle = source.handle if source else None
 
     def apply_to_one(self, db: Database, object: CitationBase) -> bool:
         if not self.source_handle:


### PR DESCRIPTION
mypy complains about the current code
`gramps/gen/filters/rules/_hassourceofbase.py:69: error: Item "None" of "Source | None" has no attribute "handle"  [union-attr]`
so refactor and simplify to fix.

Exceptions are for exceptional behaviour. db.get_source_from_gramps_id returning None is not exceptional, so just handle it.