### PR TITLE
Remove Duplicate Definition of Database

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -2783,6 +2783,3 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             self.serializer = BlobSerializer
         elif serializer_name == "json":
             self.serializer = JSONSerializer
-
-
-Database = DbGeneric

--- a/gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py
+++ b/gramps/gen/filters/rules/person/_isdescendantfamilyoffiltermatch.py
@@ -37,7 +37,7 @@ _ = glocale.translation.gettext
 from ._isdescendantfamilyof import IsDescendantFamilyOf
 from ._matchesfilter import MatchesFilter
 from ....types import PersonHandle
-from ....db.generic import Database
+from ....db import Database
 
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
There are currently two definitions of Database
1. [`gb/generic.py`](https://github.com/gramps-project/gramps/blob/309e086e782b8e5afffe9448518acfae501f26ca/gramps/gen/db/generic.py#L2788)
2. [`db/__init__.py`](https://github.com/gramps-project/gramps/blob/309e086e782b8e5afffe9448518acfae501f26ca/gramps/gen/db/__init__.py#L75)

When using Database as a type hint, pylance reports [Variable not allowed in type expression](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportInvalidTypeForm)

The second definition appears to create a variable called `Database` rather than a type. I'm interested in the reasoning if anyone can explain.

Remove the definition from `generic.py` so that Database is a type