### PR TITLE
Specify the obj_class when calling data_to_object

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -2012,7 +2012,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
         old_data = self._commit_base(person, PERSON_KEY, transaction, change_time)
 
         if old_data:
-            old_person = self.serializer.data_to_object(old_data)
+            old_person = self.serializer.data_to_object(old_data, Person)
             # Update gender statistics if necessary
             if old_person.gender != person.gender or (
                 old_person.primary_name.first_name != person.primary_name.first_name

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -1102,7 +1102,7 @@ class DBAPI(DbGeneric):
                     f"INSERT INTO {table} (handle, {self.serializer.data_field}) VALUES (?, ?)",
                     [handle, self.serializer.data_to_string(data)],
                 )
-            obj = self.serializer.data_to_object(data)
+            obj = self.serializer.data_to_object(data, cls)
             self._update_secondary_values(obj)
 
     def get_surname_list(self):


### PR DESCRIPTION
Make sure the `obj_class` argument is always supplied when calling `data_to_object`

For `JSONSerializer` the `obj_class` parameter defaults to `None`
For `BlobSerializer` there is no default

Found by mypy