### PR TITLE
Rename "Help" button to "Wiki" in plugins dialog

### DIFF
--- a/gramps/gui/glade/plugins.glade
+++ b/gramps/gui/glade/plugins.glade
@@ -19,7 +19,7 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="help">
-                <property name="label" translatable="yes">_Help</property>
+                <property name="label" translatable="yes">_Wiki</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>


### PR DESCRIPTION
Fixes [#13625](https://gramps-project.org/bugs/view.php?id=13625).