### PR TITLE
Center the progress bar in the main window status bar

### DIFF
--- a/gramps/gui/widgets/statusbar.py
+++ b/gramps/gui/widgets/statusbar.py
@@ -58,6 +58,7 @@ class Statusbar(Gtk.Box):
         self.set_border_width(2)
 
         self.__progress = Gtk.ProgressBar()
+        self.__progress.set_valign(Gtk.Align.CENTER)
         self.__progress.set_size_request(100, -1)
         self.__progress.hide()
 


### PR DESCRIPTION
Fixes [#13630](https://gramps-project.org/bugs/view.php?id=13630).