### PR TITLE
Remove the default toolbar style option and replace it with "Both"

### DIFF
--- a/gramps/gui/configure.py
+++ b/gramps/gui/configure.py
@@ -2121,10 +2121,9 @@ class GrampsPreferences(ConfigureDialog):
         # Toolbar styles:
         obox = Gtk.ComboBoxText()
         formats = [
-            _("Use default preference"),
+            _("Both text and icons"),
             _("Text only"),
             _("Icons only"),
-            _("Both text and icons"),
         ]
         list(map(obox.append_text, formats))
         active = config.get("interface.toolbar-style")

--- a/gramps/gui/uimanager.py
+++ b/gramps/gui/uimanager.py
@@ -262,12 +262,12 @@ class UIManager:
         toolbar_parent.remove(toolbar)
         toolbar = self.builder.get_object("ToolBar")  # new toolbar
         toolbar_style = config.get("interface.toolbar-style")
-        if toolbar_style == 1:
-            toolbar.set_style(Gtk.ToolbarStyle.TEXT)
-        elif toolbar_style == 2:
-            toolbar.set_style(Gtk.ToolbarStyle.ICONS)
-        elif toolbar_style == 3:
+        if toolbar_style == 0:
             toolbar.set_style(Gtk.ToolbarStyle.BOTH)
+        elif toolbar_style == 1:
+            toolbar.set_style(Gtk.ToolbarStyle.TEXT)
+        else:
+            toolbar.set_style(Gtk.ToolbarStyle.ICONS)
         toolbar_parent.pack_start(toolbar, False, True, 0)
         if tb_show:
             toolbar.show_all()


### PR DESCRIPTION
The "Use default preference" option has been removed because it was confusing users. Using a system desktop default also doesn't make much sense since the Toolbar widget has been removed in Gtk4.

The default of "Both text and icons" is intended to be helpful for new users.