### PR TITLE
Allow older gramps versions to see (not crash) db schema 21

### DIFF
--- a/gramps/gen/db/upgrade.py
+++ b/gramps/gen/db/upgrade.py
@@ -110,6 +110,11 @@ def gramps_upgrade_21(self):
 
     self.set_serializer("json")
     self._set_metadata("version", 21, use_txn=False)
+    # Set the blob metadata "version" so that old version of gramps
+    # will know what version it is
+    self.set_serializer("blob")
+    self._set_metadata("version", 21, use_txn=False)
+    self.set_serializer("json")
     self._txn_commit()
     # Bump up database version. Separate transaction to save metadata.
 

--- a/gramps/gen/lib/serialize.py
+++ b/gramps/gen/lib/serialize.py
@@ -60,6 +60,7 @@ class BlobSerializer:
     and string is pickled bytes.
     """
 
+    name = "blob"
     data_field = "blob_data"
     metadata_field = "value"
 
@@ -112,6 +113,7 @@ class JSONSerializer:
     and string is a JSON string.
     """
 
+    name = "json"
     data_field = "json_data"
     metadata_field = "json_data"
 


### PR DESCRIPTION
Older versions of Gramps cannot see the new db format (21) but just crashes.

This PR:

1. adds a `value` column of type `BLOB` to metadata 
2. always writes metadata to both blob and json

Fixes [#13633](https://gramps-project.org/bugs/view.php?id=13633)
