### PR TITLE
Hide navigation bar selector when only one sidebar plugin is loaded

### DIFF
--- a/gramps/gui/navigator.py
+++ b/gramps/gui/navigator.py
@@ -95,7 +95,7 @@ class Navigator:
         self.top.show()
 
         self.select_button = Gtk.ComboBoxText()
-        self.select_button.show()
+        self.select_button.hide()
         self.top.pack_end(self.select_button, False, True, 0)
 
         self.stack = Gtk.Stack(homogeneous=False)


### PR DESCRIPTION
Fixes [#13640](https://gramps-project.org/bugs/view.php?id=13640).