### PR TITLE
Add extra checks when changing a parent in the family editor

### DIFF
--- a/gramps/gui/editors/editfamily.py
+++ b/gramps/gui/editors/editfamily.py
@@ -1150,11 +1150,11 @@ class EditFamily(EditPrimary):
         if orig_handle != new_handle:
             if orig_handle:
                 person = self.db.get_person_from_handle(orig_handle)
-                person.family_list.remove(self.obj.handle)
+                person.remove_family_handle(self.obj.handle)
                 self.db.commit_person(person, trans)
             if new_handle:
                 person = self.db.get_person_from_handle(new_handle)
-                person.family_list.append(self.obj.handle)
+                person.add_family_handle(self.obj.handle)
                 self.db.commit_person(person, trans)
 
     def on_drag_fatherdata_received(self, widget, context, x, y, sel_data, info, time):


### PR DESCRIPTION
Using the `add_family_handle` and `remove_family_handle` methods of a `Person` safeguards against the family having already been added or removed.  This can happen in unusal circumstances, such as a person being both a parent and child in a family.

Fixes [#13642](https://gramps-project.org/bugs/view.php?id=13642).