### PR TITLE
Fix man page updates

### DIFF
--- a/data/man/en.rst
+++ b/data/man/en.rst
@@ -221,7 +221,7 @@ To explicitly specify the formats in the above example, append filenames with
 appropriate **-f** options::
 
     gramps -i file1.ged -f gedcom -i file2.tgz -f gramps-pkg \
-    -i ~/db3.gramps -f gramps -i file4.wft -f wft -a check
+    -i ~/db3.gramps -f gramps-xml -i file4.wft -f wft -a check
 
 To record the database resulting from all imports, supply a **-e** flag (use
 **-f** if the filename does not allow gramps to guess the format)::
@@ -285,15 +285,15 @@ FILES
 AUTHORS
 #######
 
-Donald Allingham <don@gramps-project.org>
-https://www.gramps-project.org/
+Donald Allingham <`don@gramps-project.org`>
+`https://www.gramps-project.org/`
 
 This man page was originally written by:
-Brandon L. Griffith <brandon@debian.org>
+Brandon L. Griffith <`brandon@debian.org`>
 for inclusion in the Debian GNU/Linux system.
 
 This man page is currently maintained by:
-Gramps project <xxx@gramps-project.org>
+Gramps project <`xxx@gramps-project.org`>
 
 #############
 DOCUMENTATION
@@ -303,5 +303,5 @@ The user documentation is available through a web browser in the form of the
 Gramps Manual.
 
 The developer documentation can be found on the
-https://www.gramps-project.org/wiki/index.php/Portal:Developers
+`https://www.gramps-project.org/wiki/index.php/Portal:Developers`
 portal.

--- a/data/man/update_man.py
+++ b/data/man/update_man.py
@@ -52,7 +52,7 @@ SPHINXBUILD = "sphinx-build"
 if sys.platform == "win32":
     pythonCmd = os.path.join(sys.prefix, "bin", "python.exe")
     sphinxCmd = os.path.join(sys.prefix, "bin", "sphinx-build.exe")
-elif sys.platform in ["linux2", "darwin", "cygwin"]:
+elif sys.platform in ["linux", "linux2", "darwin", "cygwin"]:
     pythonCmd = os.path.join(sys.prefix, "bin", "python")
     sphinxCmd = SPHINXBUILD
 else:
@@ -74,7 +74,7 @@ def tests():
 
     try:
         print("\n=================='Sphinx-build'=============================\n")
-        os.system("""%(program)s""" % {"program": sphinxCmd})
+        os.system("""%(program)s --version""" % {"program": sphinxCmd})
     except:
         print("Please, install sphinx")
 
@@ -193,11 +193,11 @@ def man():
     from docutils.writers import manpage
     """
 
-    os.system("""rst2man en.rst gramps.1""")
+    os.system("""rst2man en.rst gramps.1.in""")
 
     for lang in LANGUAGES:
         os.system(
-            """rst2man %(lang)s/%(lang)s.rst -l %(lang)s %(lang)s/gramps.1"""
+            """rst2man %(lang)s/%(lang)s.rst -l %(lang)s %(lang)s/gramps.1.in"""
             % {"lang": lang}
         )
 


### PR DESCRIPTION
* Fix `update_man.py` script.
* Change man page output from `gramps.1` to `gramps.1.in`.
* Update `en.rst` to generate latest man page.

This will generate an English man page that is very similar to the existing page.