### PR TITLE
Fix upgrades from bsddb

### DIFF
--- a/gramps/gen/db/upgrade.py
+++ b/gramps/gen/db/upgrade.py
@@ -78,6 +78,20 @@ def gramps_upgrade_21(self):
 
     self._txn_begin()
     self.upgrade_table_for_json_data("metadata")
+    # the *map_keys are not in some older versions of the db so we will initialize
+    # them here; needed in blobs if someone tries to downgrade the db so we don't
+    # crash before the warning is generated.
+    self.set_serializer("blob")
+    self._set_metadata("cmap_index", self.cmap_index, use_txn=False)
+    self._set_metadata("smap_index", self.smap_index, use_txn=False)
+    self._set_metadata("emap_index", self.emap_index, use_txn=False)
+    self._set_metadata("pmap_index", self.pmap_index, use_txn=False)
+    self._set_metadata("fmap_index", self.fmap_index, use_txn=False)
+    self._set_metadata("lmap_index", self.lmap_index, use_txn=False)
+    self._set_metadata("omap_index", self.omap_index, use_txn=False)
+    self._set_metadata("rmap_index", self.rmap_index, use_txn=False)
+    self._set_metadata("nmap_index", self.nmap_index, use_txn=False)
+
     keys = self._get_metadata_keys()
     for key in keys:
         self.set_serializer("blob")
@@ -107,7 +121,10 @@ def gramps_upgrade_21(self):
             # has "handle", "_class", and uses json.dumps()
             self._commit_raw(json_data, key)
             self.update()
+        self._drop_column(table_name, "blob_data")
 
+    self.set_serializer("blob")
+    self._set_metadata("version", 21, use_txn=False)  # keep blob version up to date
     self.set_serializer("json")
     self._set_metadata("version", 21, use_txn=False)
     self._txn_commit()

--- a/gramps/plugins/db/dbapi/dbapi.py
+++ b/gramps/plugins/db/dbapi/dbapi.py
@@ -107,11 +107,17 @@ class DBAPI(DbGeneric):
         """
         return self.dbapi.table_exists("person")
 
-    def _create_schema(self):
+    def _create_schema(self, json_data):
         """
         Create and update schema.
         """
         self.dbapi.begin()
+        if json_data:
+            col_data = "json_data TEXT"
+            meta_col_data = "json_data TEXT, value BLOB"
+        else:
+            col_data = "blob_data BLOB"
+            meta_col_data = "value BLOB"
 
         # make sure schema is up to date:
         self.dbapi.execute(
@@ -120,42 +126,42 @@ class DBAPI(DbGeneric):
             "handle VARCHAR(50) PRIMARY KEY NOT NULL, "
             "given_name TEXT, "
             "surname TEXT, "
-            "json_data TEXT"
+            f"{col_data}"
             ")"
         )
         self.dbapi.execute(
             "CREATE TABLE family "
             "("
             "handle VARCHAR(50) PRIMARY KEY NOT NULL, "
-            "json_data TEXT"
+            f"{col_data}"
             ")"
         )
         self.dbapi.execute(
             "CREATE TABLE source "
             "("
             "handle VARCHAR(50) PRIMARY KEY NOT NULL, "
-            "json_data TEXT"
+            f"{col_data}"
             ")"
         )
         self.dbapi.execute(
             "CREATE TABLE citation "
             "("
             "handle VARCHAR(50) PRIMARY KEY NOT NULL, "
-            "json_data TEXT"
+            f"{col_data}"
             ")"
         )
         self.dbapi.execute(
             "CREATE TABLE event "
             "("
             "handle VARCHAR(50) PRIMARY KEY NOT NULL, "
-            "json_data TEXT"
+            f"{col_data}"
             ")"
         )
         self.dbapi.execute(
             "CREATE TABLE media "
             "("
             "handle VARCHAR(50) PRIMARY KEY NOT NULL, "
-            "json_data TEXT"
+            f"{col_data}"
             ")"
         )
         self.dbapi.execute(
@@ -163,28 +169,28 @@ class DBAPI(DbGeneric):
             "("
             "handle VARCHAR(50) PRIMARY KEY NOT NULL, "
             "enclosed_by VARCHAR(50), "
-            "json_data TEXT"
+            f"{col_data}"
             ")"
         )
         self.dbapi.execute(
             "CREATE TABLE repository "
             "("
             "handle VARCHAR(50) PRIMARY KEY NOT NULL, "
-            "json_data TEXT"
+            f"{col_data}"
             ")"
         )
         self.dbapi.execute(
             "CREATE TABLE note "
             "("
             "handle VARCHAR(50) PRIMARY KEY NOT NULL, "
-            "json_data TEXT"
+            f"{col_data}"
             ")"
         )
         self.dbapi.execute(
             "CREATE TABLE tag "
             "("
             "handle VARCHAR(50) PRIMARY KEY NOT NULL, "
-            "json_data TEXT"
+            f"{col_data}"
             ")"
         )
         # Secondary:
@@ -208,7 +214,7 @@ class DBAPI(DbGeneric):
             "CREATE TABLE metadata "
             "("
             "setting VARCHAR(50) PRIMARY KEY NOT NULL, "
-            "json_data TEXT"
+            f"{meta_col_data}"
             ")"
         )
         self.dbapi.execute(
@@ -245,6 +251,14 @@ class DBAPI(DbGeneric):
         self.dbapi.execute("CREATE INDEX reference_obj_handle ON reference(obj_handle)")
 
         self.dbapi.commit()
+
+    def _drop_column(self, table_name, column_name):
+        """
+        Used to remove a column of data which we don't need anymore.
+        Must be used within a tranaction
+        If db doesn't support, nothing happens
+        """
+        self.dbapi.drop_column(table_name, column_name)
 
     def _close(self):
         self.dbapi.close()

--- a/gramps/plugins/db/dbapi/sqlite.py
+++ b/gramps/plugins/db/dbapi/sqlite.py
@@ -208,6 +208,12 @@ class Connection:
         )
         return self.fetchone()[0] != 0
 
+    def drop_column(self, table_name, column_name):
+        # DROP COLUMN is available with Sqlite v 3.35.0, released 2021-03-12
+        db_ver = sqlite3.sqlite_version.split(".")
+        if int(db_ver[0]) == 3 and int(db_ver[1]) >= 35:
+            self.execute(f"ALTER TABLE {table_name} DROP COLUMN {column_name};")
+
     def close(self):
         """
         Close the current database.


### PR DESCRIPTION
My take on how to do upgrades.

Plan is to make bsddb upgrades go through two steps.
  1) create an sqlite db containing nothing but blobs and then copy data into it.  Which is different than previous PRs.  This makes the resulting db look like gramps v5.x dbs.
  2) this next step does upgrades just like from any more sqlite db with blobs.

This mostly worked, but found a few other issues along the way.

I also wanted to allow older 5.2.x (at least) dbs to be able to open a current db well enough to report a downgrade error.  This required keeping the metadata blobs in the db, and making sure that they were initialized well enough to get the version with the older code.

I've tested with dbs from several older versions of Gramps, an made a PR that can repeat these tests which I will post shortly.  I've also tested less extensively the downgrade, by trying to read a Gramps 6.0 db with 5.2.4.  This also worked, no matter the source of the db, upgrade or new.

As usual there may be cases I missed, so more testing is appreciated.