### PR TITLE
Strip whitespace from media path in media editor

### DIFF
--- a/gramps/gui/editors/editmedia.py
+++ b/gramps/gui/editors/editmedia.py
@@ -363,7 +363,7 @@ class EditMedia(EditPrimary):
             self.ok_button.set_sensitive(True)
             return
 
-        self.obj.set_path(path)
+        self.obj.set_path(path.strip())
 
         if not self.obj.handle:
             with DbTxn(


### PR DESCRIPTION
Similar to #1991 we should insure no trailing spaces are saved in a URL manually entered in the path field in the media editor.