### PR TITLE
Always return str from to_string methods

### DIFF
--- a/gramps/gen/lib/json_utils.py
+++ b/gramps/gen/lib/json_utils.py
@@ -161,11 +161,11 @@ def string_to_dict(string: str | bytes) -> dict:
     return orjson.loads(string)
 
 
-def dict_to_string(dict: dict) -> str | bytes:
+def dict_to_string(dict: dict) -> str:
     """
     Convert a dict into its JSON string representation.
     """
-    return orjson.dumps(dict)
+    return orjson.dumps(dict).decode()
 
 
 def object_to_dict(obj):
@@ -218,18 +218,18 @@ def data_to_object(data):
     return data
 
 
-def object_to_string(obj: object) -> str | bytes:
+def object_to_string(obj: object) -> str:
     """
     Convert any Gramps object into a JSON string/bytes.
     """
-    return orjson.dumps(obj, default=convert_object_to_state)
+    return orjson.dumps(obj, default=convert_object_to_state).decode()
 
 
-def data_to_string(data: DataDict):
+def data_to_string(data: DataDict) -> str:
     """
     Convert a DataDict into a string.
     """
-    return orjson.dumps(remove_object(data))
+    return orjson.dumps(remove_object(data)).decode()
 
 
 def string_to_object(string: str | bytes):


### PR DESCRIPTION
This PR changes the JSON serialization methods such that all `to_string` methods actually return strings and not bytes. While it turns out that Python SQLite3 converts the byte strings correctly to strings before storing them in the JSON column, pscopg2 for instance doesn't do that. This breaks compatibility of Gramps 6.0 with PostgreSQL, unless awkward workaraounds are introduced.

Related: https://github.com/gramps-project/addons-source/pull/639#issuecomment-2686053136