### PR TITLE
Fix schema upgrade errors

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -832,7 +832,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             if force_schema_upgrade:
                 self._gramps_upgrade(dbversion, directory, callback)
             else:
-                self.close()
+                self.close(update=False)
                 raise DbUpgradeRequiredError(dbversion, self.VERSION[0])
 
     def _create_undo_manager(self):


### PR DESCRIPTION
Version metadata was prematurely stored, preventing subsequent upgrade steps from working.  Db ended up with blobs instead of json.

This is what happens when I just make sure db upgrades and opens, but never switch to an interesting view.

Fixes [#13674](https://gramps-project.org/bugs/view.php?id=13674).