### PR TITLE
Enable Web Connection menu in all list views

### DIFF
--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -69,7 +69,6 @@ from ..widgets.menuitem import add_menuitem
 from gramps.gen.const import CUSTOM_FILTERS
 from gramps.gen.utils.debug import profile
 from gramps.gen.utils.string import data_recover_msg
-from gramps.gen.plug import CATEGORY_QR_PERSON
 from ..dialog import QuestionDialog, QuestionDialog3, ErrorDialog, MultiSelectDialog
 from ..editors import FilterEditor
 from ..ddtargets import DdTargets
@@ -1066,7 +1065,7 @@ class ListView(NavigationView):
                     self.at_popup_menu.append(qr_ui)
 
             # Web Connects
-            if self.QR_CATEGORY == CATEGORY_QR_PERSON:
+            if self.QR_CATEGORY > -1:
                 (web_ui, web_actions) = create_web_connect_menu(
                     self.dbstate,
                     self.uistate,

--- a/gramps/plugins/lib/libplaceview.py
+++ b/gramps/plugins/lib/libplaceview.py
@@ -477,6 +477,8 @@ class PlaceBaseView(ListView):
       <section>
         <placeholder id='QuickReport'>
         </placeholder>
+        <placeholder id='WebConnect'>
+        </placeholder>
       </section>
       <section>
         <item>

--- a/gramps/plugins/view/citationlistview.py
+++ b/gramps/plugins/view/citationlistview.py
@@ -365,6 +365,8 @@ class CitationListView(ListView):
       <section>
         <placeholder id='QuickReport'>
         </placeholder>
+        <placeholder id='WebConnect'>
+        </placeholder>
       </section>
     </menu>
 """

--- a/gramps/plugins/view/citationtreeview.py
+++ b/gramps/plugins/view/citationtreeview.py
@@ -552,6 +552,8 @@ class CitationTreeView(LibSourceView, ListView):
       <section>
         <placeholder id='QuickReport'>
         </placeholder>
+        <placeholder id='WebConnect'>
+        </placeholder>
       </section>
     </menu>
 """

--- a/gramps/plugins/view/eventview.py
+++ b/gramps/plugins/view/eventview.py
@@ -378,6 +378,8 @@ class EventView(ListView):
       <section>
         <placeholder id='QuickReport'>
         </placeholder>
+        <placeholder id='WebConnect'>
+        </placeholder>
       </section>
     </menu>
 """

--- a/gramps/plugins/view/familyview.py
+++ b/gramps/plugins/view/familyview.py
@@ -347,6 +347,8 @@ class FamilyView(ListView):
       <section>
         <placeholder id='QuickReport'>
         </placeholder>
+        <placeholder id='WebConnect'>
+        </placeholder>
       </section>
     </menu>
 """

--- a/gramps/plugins/view/mediaview.py
+++ b/gramps/plugins/view/mediaview.py
@@ -467,6 +467,8 @@ class MediaView(ListView):
       <section>
         <placeholder id='QuickReport'>
         </placeholder>
+        <placeholder id='WebConnect'>
+        </placeholder>
       </section>
       <section>
         <placeholder id='AfterTools'>

--- a/gramps/plugins/view/noteview.py
+++ b/gramps/plugins/view/noteview.py
@@ -323,6 +323,8 @@ class NoteView(ListView):
       <section>
         <placeholder id='QuickReport'>
         </placeholder>
+        <placeholder id='WebConnect'>
+        </placeholder>
       </section>
     </menu>
     """

--- a/gramps/plugins/view/repoview.py
+++ b/gramps/plugins/view/repoview.py
@@ -360,6 +360,8 @@ class RepositoryView(ListView):
       <section>
         <placeholder id='QuickReport'>
         </placeholder>
+        <placeholder id='WebConnect'>
+        </placeholder>
       </section>
     </menu>
     """

--- a/gramps/plugins/view/sourceview.py
+++ b/gramps/plugins/view/sourceview.py
@@ -332,6 +332,8 @@ class SourceView(LibSourceView, ListView):
       <section>
         <placeholder id='QuickReport'>
         </placeholder>
+        <placeholder id='WebConnect'>
+        </placeholder>
       </section>
     </menu>
     """


### PR DESCRIPTION
At present the Web Connection menu is restricted to the person list views.  Removing this restriction would allow further development of the Web Connection functionality in addons.

This type of change would not normally be allowed in a maintenance branch, but since the change is small we could possibly consider it in this case.