### PR TITLE
Simplify logic for setting data, config and cache directories

### DIFF
--- a/.github/workflows/gramps-ci.yml
+++ b/.github/workflows/gramps-ci.yml
@@ -59,11 +59,11 @@ jobs:
         python3 -m pip install orjson
     - name: Install addons
       run: |
-        mkdir -p ~/.gramps/gramps60/plugins/
+        mkdir -p ~/.local/share/gramps/gramps60/plugins/
         wget https://github.com/gramps-project/addons/raw/master/gramps60/download/CliMerge.addon.tgz
-        tar -C ~/.gramps/gramps60/plugins -xzf CliMerge.addon.tgz
+        tar -C ~/.local/share/gramps/gramps60/plugins/ -xzf CliMerge.addon.tgz
         wget https://github.com/gramps-project/addons/raw/master/gramps60/download/ExportRaw.addon.tgz
-        tar -C ~/.gramps/gramps60/plugins -xzf ExportRaw.addon.tgz
+        tar -C ~/.local/share/gramps/gramps60/plugins/ -xzf ExportRaw.addon.tgz
     - name: Build
       run: |
         python3 setup.py build

--- a/gramps/gen/config.py
+++ b/gramps/gen/config.py
@@ -391,11 +391,24 @@ register("utf8.killed-symbol", "x")
 if __debug__:  # enable a simple CLI test to see if the datestrings exist
     register("test.january", _("January", "localized lexeme inflections"))
 
+
 # ---------------------------------------------------------------
 #
 # Upgrade Conversions go here.
 #
 # ---------------------------------------------------------------
+def load_previous(ini_file):
+    """
+    Attempt to load a `gramps.ini` file from an earlier version.
+    Return True if the file exists.
+    """
+    if os.path.exists(ini_file):
+        logging.info("Importing old config file '%s'...", ini_file)
+        CONFIGMAN.load(ini_file)
+        logging.info("Done importing old config file '%s'", ini_file)
+        return True
+    return False
+
 
 # If we have not already upgraded to this version,
 # we can tell by seeing if there is a key file for this version:
@@ -410,6 +423,7 @@ if not os.path.exists(CONFIGMAN.filename):
     # check previous version of gramps:
     fullpath, filename = os.path.split(CONFIGMAN.filename)
     fullpath, previous = os.path.split(fullpath)
+    oldpath = os.path.join(USER_HOME, ".gramps")
     match = re.match(r"gramps(\d*)", previous)
     if match:
         # cycle back looking for previous versions of gramps
@@ -422,11 +436,11 @@ if not os.path.exists(CONFIGMAN.filename):
             # Perhaps addings specific list of versions to check
             # -----------------------------------------
             digits = str(int(match.groups()[0]) - i)
-            previous_grampsini = os.path.join(fullpath, "gramps" + digits, filename)
-            if os.path.exists(previous_grampsini):
-                logging.info("Importing old config file '%s'...", previous_grampsini)
-                CONFIGMAN.load(previous_grampsini)
-                logging.info("Done importing old config file '%s'", previous_grampsini)
+            grampsini = os.path.join(fullpath, "gramps" + digits, filename)
+            if load_previous(grampsini):
+                break
+            grampsini = os.path.join(oldpath, "gramps" + digits, filename)
+            if load_previous(grampsini):
                 break
 
 # ---------------------------------------------------------------

--- a/gramps/gen/const.py
+++ b/gramps/gen/const.py
@@ -90,47 +90,33 @@ APP_VCARD = ["text/x-vcard", "text/x-vcalendar"]
 
 # -------------------------------------------------------------------------
 #
-# Determine the home directory. According to Wikipedia, most UNIX like
-# systems use HOME. I'm assuming that this would apply to OS X as well.
-# Windows apparently uses USERPROFILE
+# Determine the user data and user configuration directories.
 #
 # -------------------------------------------------------------------------
 if "GRAMPSHOME" in os.environ:
     USER_HOME = get_env_var("GRAMPSHOME")
-    HOME_DIR = os.path.join(USER_HOME, "gramps")
+    USER_DATA = os.path.join(USER_HOME, "gramps")
+    USER_CONFIG = USER_DATA
 elif "USERPROFILE" in os.environ:
     USER_HOME = get_env_var("USERPROFILE")
-    HOME_DIR = os.path.join(GLib.get_user_config_dir(), "gramps")
-    if not os.path.exists(HOME_DIR):
-        homedir = get_env_var("APPDATA") if "APPDATA" in os.environ else USER_HOME
-        homedir = os.path.join(homedir, "gramps")
-        dbpath = os.path.join(homedir, "grampsdb")
-        if os.path.isdir(dbpath) and os.listdir(dbpath):
-            HOME_DIR = homedir
+    if "APPDATA" in os.environ:
+        USER_DATA = os.path.join(get_env_var("APPDATA"), "gramps")
+    else:
+        USER_DATA = os.path.join(USER_HOME, "AppData", "Roaming", "gramps")
+    USER_CONFIG = USER_DATA
 else:
     USER_HOME = get_env_var("HOME")
-    HOME_DIR = os.path.join(USER_HOME, ".gramps")
-ORIG_HOME_DIR = HOME_DIR
-if "SAFEMODE" in os.environ:
-    if "USERPROFILE" in os.environ:
-        USER_HOME = get_env_var("USERPROFILE")
-    else:
-        USER_HOME = get_env_var("HOME")
-    HOME_DIR = get_env_var("SAFEMODE")
-
-
-if os.path.exists(HOME_DIR) or "GRAMPSHOME" in os.environ or "SAFEMODE" in os.environ:
-    USER_DATA = HOME_DIR
-    USER_CONFIG = HOME_DIR
-    USER_CACHE = HOME_DIR
-else:
     USER_DATA = os.path.join(GLib.get_user_data_dir(), "gramps")
     USER_CONFIG = os.path.join(GLib.get_user_config_dir(), "gramps")
-    USER_CACHE = os.path.join(GLib.get_user_cache_dir(), "gramps")
+
+USER_CACHE = os.path.join(GLib.get_user_cache_dir(), "gramps")
+
+if "SAFEMODE" in os.environ:
+    USER_CONFIG = get_env_var("SAFEMODE")
 
 USER_PICTURES = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PICTURES)
 if not USER_PICTURES:
-    USER_PICTURES = HOME_DIR
+    USER_PICTURES = USER_DATA
 
 VERSION_DIR_NAME = "gramps%s%s" % (VERSION_TUPLE[0], VERSION_TUPLE[1])
 VERSION_DIR = os.path.join(USER_CONFIG, VERSION_DIR_NAME)

--- a/gramps/grampsapp.py
+++ b/gramps/grampsapp.py
@@ -51,7 +51,7 @@ if "-S" in sys.argv or "--safe" in sys.argv:
 # Gramps modules
 #
 # -------------------------------------------------------------------------
-from .gen.const import APP_GRAMPS, USER_DIRLIST, USER_DATA, ORIG_HOME_DIR
+from .gen.const import APP_GRAMPS, USER_DIRLIST, USER_DATA
 from .gen.constfunc import mac
 from .version import VERSION_TUPLE
 from .gen.constfunc import win, get_env_var
@@ -653,11 +653,6 @@ def run():
 
     argv_copy = sys.argv[:]
     argpars = ArgParser(argv_copy)
-
-    # if in safe mode we should point the db dir back to the original dir.
-    # It is ok to import config here, 'Defaults' command had its chance...
-    if "SAFEMODE" in os.environ:
-        config.set("database.path", os.path.join(ORIG_HOME_DIR, "grampsdb"))
 
     # On windows the fontconfig handler is a better choice
     if win() and ("PANGOCAIRO_BACKEND" not in os.environ):

--- a/gramps/plugins/test/imports_test.py
+++ b/gramps/plugins/test/imports_test.py
@@ -46,7 +46,7 @@ from gramps.gen.lib.json_utils import object_to_dict
 from gramps.gen.simple import SimpleAccess
 from gramps.gen.utils.id import set_det_id
 from gramps.gen.user import User
-from gramps.gen.const import HOME_DIR, DATA_DIR
+from gramps.gen.const import USER_DATA, DATA_DIR
 from gramps.test.test_util import capture
 from gramps.plugins.export.exportxml import XmlWriter
 from gramps.gen.db.dbconst import DBBACKEND
@@ -65,7 +65,7 @@ from gramps.gen.db.exceptions import (
 # the following defines where to find the test import and result files
 TEST_DIR = os.path.abspath(os.path.join(DATA_DIR, "tests"))
 # the following defines where to find test error diffs and import result XML files
-TEMP_DIR = os.path.join(HOME_DIR, "temp")
+TEMP_DIR = os.path.join(USER_DATA, "temp")
 if not os.path.isdir(TEMP_DIR):
     os.makedirs(TEMP_DIR)
 


### PR DESCRIPTION
This PR is illustrates a simplification of the logic for setting the data, config and cache directories.

* The old `$HOME/.gramps` location for Linux is removed in favour of the newer XDG specification.
* For Windows `$APPDATA` is used with a fallback to `$USERPROFILE/AppData/Roaming`.

The old locations can still be used by setting the `$GRAMPSHOME` variable.

If we decide to adopt this approach then we should consider migrating existing data.

Fixes [#13261](https://gramps-project.org/bugs/view.php?id=13261), [#13300](https://gramps-project.org/bugs/view.php?id=13300), [#13686](https://gramps-project.org/bugs/view.php?id=13686).