### PR TITLE
Allow Gramps' core to be imported without requiring GObject

### DIFF
--- a/gramps/gen/const.py
+++ b/gramps/gen/const.py
@@ -39,8 +39,6 @@ import logging
 
 LOG = logging.getLogger(".")
 
-from gi.repository import GLib
-
 # -------------------------------------------------------------------------
 #
 # Gramps modules
@@ -97,46 +95,55 @@ APP_VCARD = ["text/x-vcard", "text/x-vcalendar"]
 # Determine the user data and user configuration directories.
 #
 # -------------------------------------------------------------------------
-if "GRAMPSHOME" in os.environ:
-    USER_HOME = get_env_var("GRAMPSHOME")
+if "GRAMPSHOME_ISOLATED" in os.environ:
+    USER_HOME = get_env_var("GRAMPSHOME_ISOLATED")
     USER_DATA = os.path.join(USER_HOME, "gramps")
-    USER_CONFIG = USER_DATA
-elif "USERPROFILE" in os.environ:
-    USER_HOME = get_env_var("USERPROFILE")
-    if "APPDATA" in os.environ:
-        USER_DATA = os.path.join(get_env_var("APPDATA"), "gramps")
-    else:
-        USER_DATA = os.path.join(USER_HOME, "AppData", "Roaming", "gramps")
-    USER_CONFIG = USER_DATA
-    # Migrate data from AppData\Local to AppData\Roaming on Windows.
-    OLD_HOME = os.path.join(USER_HOME, "AppData", "Local", "gramps")
-    if os.path.exists(OLD_HOME):
-        if os.path.exists(USER_DATA):
-            LOG.warning("Two Gramps application data directories exist.")
-        else:
-            shutil.move(OLD_HOME, USER_DATA)
+    USER_CONFIG = os.path.join(USER_DATA, "config")
+    USER_CACHE = os.path.join(USER_DATA, "cache")
+    USER_PICTURES = os.path.join(USER_DATA, "pictures")
 else:
-    USER_HOME = get_env_var("HOME")
-    USER_DATA = os.path.join(GLib.get_user_data_dir(), "gramps")
-    USER_CONFIG = os.path.join(GLib.get_user_config_dir(), "gramps")
-    # Copy the database directory into the XDG directory.
-    OLD_HOME = os.path.join(USER_HOME, ".gramps")
-    if os.path.exists(OLD_HOME):
-        if os.path.exists(USER_DATA) or os.path.exists(USER_CONFIG):
-            LOG.warning("Two Gramps application data directories exist.")
+    from gi.repository import GLib
+
+    if "GRAMPSHOME" in os.environ:
+        USER_HOME = get_env_var("GRAMPSHOME")
+        USER_DATA = os.path.join(USER_HOME, "gramps")
+        USER_CONFIG = USER_DATA
+    elif "USERPROFILE" in os.environ:
+        USER_HOME = get_env_var("USERPROFILE")
+        if "APPDATA" in os.environ:
+            USER_DATA = os.path.join(get_env_var("APPDATA"), "gramps")
         else:
-            db_dir = os.path.join(OLD_HOME, "grampsdb")
-            if os.path.exists(db_dir):
-                shutil.copytree(db_dir, os.path.join(USER_DATA, "grampsdb"))
+            USER_DATA = os.path.join(USER_HOME, "AppData", "Roaming", "gramps")
+        USER_CONFIG = USER_DATA
+        # Migrate data from AppData\Local to AppData\Roaming on Windows.
+        OLD_HOME = os.path.join(USER_HOME, "AppData", "Local", "gramps")
+        if os.path.exists(OLD_HOME):
+            if os.path.exists(USER_DATA):
+                LOG.warning("Two Gramps application data directories exist.")
+            else:
+                shutil.move(OLD_HOME, USER_DATA)
+    else:
+        USER_HOME = get_env_var("HOME")
+        USER_DATA = os.path.join(GLib.get_user_data_dir(), "gramps")
+        USER_CONFIG = os.path.join(GLib.get_user_config_dir(), "gramps")
+        # Copy the database directory into the XDG directory.
+        OLD_HOME = os.path.join(USER_HOME, ".gramps")
+        if os.path.exists(OLD_HOME):
+            if os.path.exists(USER_DATA) or os.path.exists(USER_CONFIG):
+                LOG.warning("Two Gramps application data directories exist.")
+            else:
+                db_dir = os.path.join(OLD_HOME, "grampsdb")
+                if os.path.exists(db_dir):
+                    shutil.copytree(db_dir, os.path.join(USER_DATA, "grampsdb"))
 
-USER_CACHE = os.path.join(GLib.get_user_cache_dir(), "gramps")
+    USER_CACHE = os.path.join(GLib.get_user_cache_dir(), "gramps")
 
-if "SAFEMODE" in os.environ:
-    USER_CONFIG = get_env_var("SAFEMODE")
+    if "SAFEMODE" in os.environ:
+        USER_CONFIG = get_env_var("SAFEMODE")
 
-USER_PICTURES = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PICTURES)
-if not USER_PICTURES:
-    USER_PICTURES = USER_DATA
+    USER_PICTURES = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PICTURES)
+    if not USER_PICTURES:
+        USER_PICTURES = USER_DATA
 
 VERSION_DIR_NAME = "gramps%s%s" % (VERSION_TUPLE[0], VERSION_TUPLE[1])
 VERSION_DIR = os.path.join(USER_CONFIG, VERSION_DIR_NAME)

--- a/gramps/gen/utils/requirements.py
+++ b/gramps/gen/utils/requirements.py
@@ -27,13 +27,6 @@ from importlib.util import find_spec
 
 # -------------------------------------------------------------------------
 #
-# GTK modules
-#
-# -------------------------------------------------------------------------
-import gi
-
-# -------------------------------------------------------------------------
-#
 # Gramps modules
 #
 # -------------------------------------------------------------------------
@@ -89,6 +82,8 @@ class Requirements:
         """
         Test to see if a particular version of a module is available.
         """
+        import gi
+
         try:
             gi.require_version(module, version)
             return True


### PR DESCRIPTION
This is a first stab at making Gramps more easily usable (or at all) in a stand-alone fashion, without requiring third-party system packages to be installed manually. It also aims to be backwards-compatible, hence the addition of checks rather than a refactoring.

I tested this using https://github.com/bartfeenstra/betty/blob/gramps-api/test.py (which itself uses my own relatively extensive Gramps family tree export) and other than a warning for one of the plugins, this works fine and my code can successfully load the family tree:
```
ERROR: Failed reading plugin registration geography.gpr.py
Traceback (most recent call last):
  File "/home/bart/code/bartfeenstra/betty/venv13/lib/python3.13/site-packages/gramps/gen/plug/_pluginreg.py", line 1428, in scan_dir
    exec(
    ~~~~^
        compile(stream, filename, "exec"),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        make_environment(_=local_gettext),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        {"uistate": uistate},
        ^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "geography.gpr.py", line 33, in <module>
ModuleNotFoundError: No module named 'gi'

WARNING:._manager:Plugin error (from 'importprogen'): No module named 'gi'
```