### PR TITLE
Make `gramps.gen.lib.primaryobj` typed

### DIFF
--- a/.github/workflows/gramps-ci.yml
+++ b/.github/workflows/gramps-ci.yml
@@ -54,6 +54,7 @@ jobs:
         sudo apt-get install libxml2-utils
         sudo apt-get install python3-lxml
         sudo apt-get install python3-libxml2
+        sudo apt-get install python3-typing-extensions
         sudo apt-get install zlib1g-dev
         sudo apt-get install python3-setuptools
         python3 -m pip install orjson

--- a/gramps/gen/lib/citation.py
+++ b/gramps/gen/lib/citation.py
@@ -31,6 +31,9 @@ Citation object for Gramps.
 #
 # -------------------------------------------------------------------------
 import logging
+from collections.abc import Collection
+
+from typing_extensions import override
 
 # -------------------------------------------------------------------------
 #
@@ -197,19 +200,8 @@ class Citation(
         SrcAttributeBase.unserialize(self, srcattr_list)
         return self
 
-    def _has_handle_reference(self, classname, handle):
-        """
-        Return True if the object has reference to a given handle of given
-        primary object type.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param handle: The handle to be checked.
-        :type handle: str
-        :returns: Returns whether the object has reference to this handle of
-                  this object type.
-        :rtype: bool
-        """
+    @override
+    def _has_handle_reference(self, classname: str, handle: str) -> bool:
         if classname == "Note":
             return handle in [ref.ref for ref in self.note_list]
         if classname == "Media":
@@ -218,29 +210,17 @@ class Citation(
             return handle == self.get_reference_handle()
         return False
 
-    def _remove_handle_references(self, classname, handle_list):
-        """
-        Remove all references in this object to object handles in the list.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param handle_list: The list of handles to be removed.
-        :type handle_list: str
-        """
+    @override
+    def _remove_handle_references(
+        self, classname: str, handle_list: Collection[str]
+    ) -> None:
         if classname == "Source" and self.get_reference_handle() in handle_list:
             self.set_reference_handle(None)
 
-    def _replace_handle_reference(self, classname, old_handle, new_handle):
-        """
-        Replace all references to old handle with those to the new handle.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param old_handle: The handle to be replaced.
-        :type old_handle: str
-        :param new_handle: The handle to replace the old one with.
-        :type new_handle: str
-        """
+    @override
+    def _replace_handle_reference(
+        self, classname: str, old_handle: str, new_handle: str
+    ) -> None:
         if classname == "Source" and self.get_reference_handle() == old_handle:
             self.set_reference_handle(new_handle)
 

--- a/gramps/gen/lib/event.py
+++ b/gramps/gen/lib/event.py
@@ -31,6 +31,9 @@ Event object for Gramps.
 #
 # -------------------------------------------------------------------------
 import logging
+from collections.abc import Collection
+
+from typing_extensions import override
 
 # -------------------------------------------------------------------------
 #
@@ -255,46 +258,23 @@ class Event(
         TagBase.unserialize(self, tag_list)
         return self
 
-    def _has_handle_reference(self, classname, handle):
-        """
-        Return True if the object has reference to a given handle of given
-        primary object type.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param handle: The handle to be checked.
-        :type handle: str
-        :returns: Returns whether the object has reference to this handle of
-                  this object type.
-        :rtype: bool
-        """
+    @override
+    def _has_handle_reference(self, classname: str, handle: str) -> bool:
         if classname == "Place":
             return self.place == handle
         return False
 
-    def _remove_handle_references(self, classname, handle_list):
-        """
-        Remove all references in this object to object handles in the list.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param handle_list: The list of handles to be removed.
-        :type handle_list: str
-        """
+    @override
+    def _remove_handle_references(
+        self, classname: str, handle_list: Collection[str]
+    ) -> None:
         if classname == "Place" and self.place in handle_list:
             self.place = ""
 
-    def _replace_handle_reference(self, classname, old_handle, new_handle):
-        """
-        Replace all references to old handle with those to the new handle.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param old_handle: The handle to be replaced.
-        :type old_handle: str
-        :param new_handle: The handle to replace the old one with.
-        :type new_handle: str
-        """
+    @override
+    def _replace_handle_reference(
+        self, classname: str, old_handle: str, new_handle: str
+    ) -> None:
         if classname == "Place" and self.place == old_handle:
             self.place = new_handle
 

--- a/gramps/gen/lib/eventbase.py
+++ b/gramps/gen/lib/eventbase.py
@@ -23,6 +23,7 @@
 """
 EventBase class for Gramps.
 """
+from collections.abc import Collection
 
 # -------------------------------------------------------------------------
 #
@@ -135,13 +136,12 @@ class EventBase:
         """
         return event_handle in [event_ref.ref for event_ref in self.event_ref_list]
 
-    def _remove_event_references(self, handle_list):
+    def _remove_event_references(self, handle_list: Collection[str]):
         """
         Remove any references to the given event handles from the instance's
         :class:`~.eventref.EventRef` list.
 
         :param handle_list: List of valid event handles to remove
-        :type handle_list: list
         """
         new_list = [
             event_ref

--- a/gramps/gen/lib/family.py
+++ b/gramps/gen/lib/family.py
@@ -31,6 +31,8 @@ Family object for Gramps.
 #
 # -------------------------------------------------------------------------
 import logging
+from collections.abc import Collection
+from typing_extensions import override
 
 # -------------------------------------------------------------------------
 #
@@ -254,19 +256,8 @@ class Family(
         TagBase.unserialize(self, tag_list)
         return self
 
-    def _has_handle_reference(self, classname, handle):
-        """
-        Return True if the object has reference to a given handle of given
-        primary object type.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param handle: The handle to be checked.
-        :type handle: str
-        :returns: Returns whether the object has reference to this handle of
-                  this object type.
-        :rtype: bool
-        """
+    @override
+    def _has_handle_reference(self, classname: str, handle: str) -> bool:
         if classname == "Event":
             return self._has_event_reference(handle)
         if classname == "Person":
@@ -278,15 +269,10 @@ class Family(
             return handle in [x.place for x in self.lds_ord_list]
         return False
 
-    def _remove_handle_references(self, classname, handle_list):
-        """
-        Remove all references in this object to object handles in the list.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param handle_list: The list of handles to be removed.
-        :type handle_list: str
-        """
+    @override
+    def _remove_handle_references(
+        self, classname: str, handle_list: Collection[str]
+    ) -> None:
         if classname == "Event":
             self._remove_event_references(handle_list)
         elif classname == "Person":
@@ -303,17 +289,10 @@ class Family(
                 if lds_ord.place in handle_list:
                     lds_ord.place = None
 
-    def _replace_handle_reference(self, classname, old_handle, new_handle):
-        """
-        Replace all references to old handle with those to the new handle.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param old_handle: The handle to be replaced.
-        :type old_handle: str
-        :param new_handle: The handle to replace the old one with.
-        :type new_handle: str
-        """
+    @override
+    def _replace_handle_reference(
+        self, classname: str, old_handle: str, new_handle: str
+    ) -> None:
         if classname == "Event":
             self._replace_event_references(old_handle, new_handle)
         elif classname == "Person":

--- a/gramps/gen/lib/note.py
+++ b/gramps/gen/lib/note.py
@@ -24,6 +24,9 @@
 """
 Note class for Gramps.
 """
+from collections.abc import Collection
+
+from typing_extensions import override
 
 # -------------------------------------------------------------------------
 #
@@ -172,22 +175,8 @@ class Note(BasicPrimaryObject):
         reflist.extend(self.get_referenced_tag_handles())
         return reflist
 
-    def has_handle_reference(self, classname, handle):
-        """
-        Return True if the object has reference to a given handle of given
-        primary object type.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param handle: The handle to be checked.
-        :type handle: str
-
-        :returns:
-          Returns whether the object has reference to this handle of
-          this object type.
-
-        :rtype: bool
-        """
+    @override
+    def has_handle_reference(self, classname: str, handle: str) -> bool:
         for dom, obj, prop, hndl in self.get_links():
             if (
                 dom == "gramps"
@@ -198,18 +187,10 @@ class Note(BasicPrimaryObject):
                 return True
         return False
 
-    def remove_handle_references(self, classname, handle_list):
-        """
-        Remove all references in this object to object handles in the list.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param handle_list: The list of handles to be removed.
-        :type handle_list: str
-
-        If the link is in the styled text, we just remove the style for that
-        link.
-        """
+    @override
+    def remove_handle_references(
+        self, classname: str, handle_list: Collection[str]
+    ) -> None:
         tags = []
         for styledtext_tag in self.text.get_tags():
             if (
@@ -222,17 +203,10 @@ class Note(BasicPrimaryObject):
             tags.append(styledtext_tag)
         self.text.set_tags(tags)
 
-    def replace_handle_reference(self, classname, old_handle, new_handle):
-        """
-        Replace all references to old handle with those to the new handle.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param old_handle: The handle to be replaced.
-        :type old_handle: str
-        :param new_handle: The handle to replace the old one with.
-        :type new_handle: str
-        """
+    @override
+    def replace_handle_reference(
+        self, classname: str, old_handle: str, new_handle: str
+    ) -> None:
         for styledtext_tag in self.text.get_tags():
             if (
                 styledtext_tag.name == StyledTextTagType.LINK

--- a/gramps/gen/lib/person.py
+++ b/gramps/gen/lib/person.py
@@ -24,6 +24,8 @@
 """
 Person object for Gramps.
 """
+from collections.abc import Collection
+from typing_extensions import override
 
 # -------------------------------------------------------------------------
 #
@@ -342,19 +344,8 @@ class Person(
         self.__gender = attr_dict.pop("gender")
         super().set_object_state(attr_dict)
 
-    def _has_handle_reference(self, classname, handle):
-        """
-        Return True if the object has reference to a given handle of given
-        primary object type.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param handle: The handle to be checked.
-        :type handle: str
-        :returns: Returns whether the object has reference to this handle of
-                  this object type.
-        :rtype: bool
-        """
+    @override
+    def _has_handle_reference(self, classname: str, handle: str) -> bool:
         if classname == "Event":
             return self._has_event_reference(handle)
         if classname == "Person":
@@ -370,7 +361,10 @@ class Person(
             return any(ordinance.place == handle for ordinance in self.lds_ord_list)
         return False
 
-    def _remove_handle_references(self, classname, handle_list):
+    @override
+    def _remove_handle_references(
+        self, classname: str, handle_list: Collection[str]
+    ) -> None:
         if classname == "Event":
             # Keep a copy of the birth and death references
             birth_ref = self.get_birth_ref()
@@ -422,7 +416,10 @@ class Person(
                 if ordinance.place in handle_list:
                     ordinance.place = None
 
-    def _replace_handle_reference(self, classname, old_handle, new_handle):
+    @override
+    def _replace_handle_reference(
+        self, classname: str, old_handle: str, new_handle: str
+    ) -> None:
         if classname == "Event":
             refs_list = [ref.ref for ref in self.event_ref_list]
             new_ref = None

--- a/gramps/gen/lib/place.py
+++ b/gramps/gen/lib/place.py
@@ -33,6 +33,8 @@ Place object for Gramps.
 # -------------------------------------------------------------------------
 from __future__ import annotations
 
+from typing_extensions import override
+
 # -------------------------------------------------------------------------
 #
 # Gramps modules
@@ -497,36 +499,18 @@ class Place(CitationBase, NoteBase, MediaBase, UrlBase, PrimaryObject):
             else:
                 self.placeref_list.append(addendum)
 
-    def _has_handle_reference(self, classname, handle):
-        """
-        Return True if the object has reference to a given handle of given
-        primary object type.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param handle: The handle to be checked.
-        :type handle: str
-        :returns: Returns whether the object has reference to this handle of
-                this object type.
-        :rtype: bool
-        """
+    @override
+    def _has_handle_reference(self, classname: str, handle: str) -> bool:
         if classname == "Place":
             for placeref in self.placeref_list:
                 if placeref.ref == handle:
                     return True
         return False
 
-    def _replace_handle_reference(self, classname, old_handle, new_handle):
-        """
-        Replace all references to old handle with those to the new handle.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param old_handle: The handle to be replaced.
-        :type old_handle: str
-        :param new_handle: The handle to replace the old one with.
-        :type new_handle: str
-        """
+    @override
+    def _replace_handle_reference(
+        self, classname: str, old_handle: str, new_handle: str
+    ) -> None:
         if classname == "Place":
             for placeref in self.placeref_list:
                 if placeref.ref == old_handle:

--- a/gramps/gen/lib/primaryobj.py
+++ b/gramps/gen/lib/primaryobj.py
@@ -22,13 +22,14 @@
 """
 Basic Primary Object class for Gramps.
 """
+from collections.abc import Collection
 
 # -------------------------------------------------------------------------
 #
 # Python modules
 #
 # -------------------------------------------------------------------------
-from abc import abstractmethod
+from typing_extensions import override, Self
 
 # -------------------------------------------------------------------------
 #
@@ -61,7 +62,7 @@ class BasicPrimaryObject(TableObject, PrivacyBase, TagBase):
     ID is the user visible version.
     """
 
-    def __init__(self, source=None):
+    def __init__(self, source: Self | None = None):
         """
         Initialize a PrimaryObject.
 
@@ -70,87 +71,64 @@ class BasicPrimaryObject(TableObject, PrivacyBase, TagBase):
         of the source object.
 
         :param source: Object used to initialize the new object
-        :type source: PrimaryObject
         """
         TableObject.__init__(self, source)
         PrivacyBase.__init__(self, source)
         TagBase.__init__(self)
-        if source:
-            self.gramps_id = source.gramps_id
-        else:
-            self.gramps_id = None
+        self.gramps_id = source.get_gramps_id() if source else ""
 
-    @abstractmethod
-    def serialize(self):
-        """
-        Convert the object to a serialized tuple of data.
-        """
-
-    @abstractmethod
-    def unserialize(self, data):
-        """
-        Convert a serialized tuple of data to an object.
-        """
-
-    def set_gramps_id(self, gramps_id):
+    def set_gramps_id(self, gramps_id: str) -> None:
         """
         Set the Gramps ID for the primary object.
 
         :param gramps_id: Gramps ID
-        :type gramps_id: str
         """
         self.gramps_id = gramps_id
 
-    def get_gramps_id(self):
+    def get_gramps_id(self) -> str:
         """
         Return the Gramps ID for the primary object.
 
         :returns: Gramps ID associated with the object
-        :rtype: str
         """
         return self.gramps_id
 
-    def has_handle_reference(self, classname, handle):
+    def has_handle_reference(self, classname: str, handle: str) -> bool:
         """
         Return True if the object has reference to a given handle of given
         primary object type.
 
         :param classname: The name of the primary object class.
-        :type classname: str
         :param handle: The handle to be checked.
-        :type handle: str
 
         :returns:
           Returns whether the object has reference to this handle of
           this object type.
-
-        :rtype: bool
         """
         return False
 
-    def remove_handle_references(self, classname, handle_list):
+    def remove_handle_references(
+        self, classname: str, handle_list: Collection[str]
+    ) -> None:
         """
         Remove all references in this object to object handles in the list.
 
         :param classname: The name of the primary object class.
-        :type classname: str
         :param handle_list: The list of handles to be removed.
-        :type handle_list: str
         """
 
-    def replace_handle_reference(self, classname, old_handle, new_handle):
+    def replace_handle_reference(
+        self, classname: str, old_handle: str, new_handle: str
+    ) -> None:
         """
         Replace all references to old handle with those to the new handle.
 
         :param classname: The name of the primary object class.
-        :type classname: str
         :param old_handle: The handle to be replaced.
-        :type old_handle: str
         :param new_handle: The handle to replace the old one with.
-        :type new_handle: str
         """
 
-    def has_citation_reference(self, handle):
+    def has_citation_reference(self, handle: str) -> bool:
         """
         Indicate if the object has a citation references.
 
@@ -159,7 +137,7 @@ class BasicPrimaryObject(TableObject, PrivacyBase, TagBase):
         """
         return False
 
-    def has_media_reference(self, handle):
+    def has_media_reference(self, handle: str) -> bool:
         """
         Indicate if the object has a media references.
 
@@ -168,7 +146,7 @@ class BasicPrimaryObject(TableObject, PrivacyBase, TagBase):
         """
         return False
 
-    def remove_citation_references(self, handle_list):
+    def remove_citation_references(self, handle_list: Collection[str]) -> None:
         """
         Remove the specified citation references from the object.
 
@@ -176,7 +154,7 @@ class BasicPrimaryObject(TableObject, PrivacyBase, TagBase):
         override this if they provide citation references.
         """
 
-    def remove_media_references(self, handle_list):
+    def remove_media_references(self, handle_list: Collection[str]) -> None:
         """
         Remove the specified media references from the object.
 
@@ -184,7 +162,7 @@ class BasicPrimaryObject(TableObject, PrivacyBase, TagBase):
         override this if they provide media references.
         """
 
-    def remove_note_references(self, handle_list):
+    def remove_note_references(self, handle_list: Collection[str]) -> None:
         """
         Remove the specified note references from the object.
 
@@ -192,13 +170,13 @@ class BasicPrimaryObject(TableObject, PrivacyBase, TagBase):
         override this if they provide note references.
         """
 
-    def replace_citation_references(self, old_handle, new_handle):
+    def replace_citation_references(self, old_handle: str, new_handle: str) -> None:
         """
         Replace all references to the old citation handle with those to the new
         citation handle.
         """
 
-    def replace_media_references(self, old_handle, new_handle):
+    def replace_media_references(self, old_handle: str, new_handle: str) -> None:
         """
         Replace all references to the old media handle with those to the new
         media handle.
@@ -221,7 +199,7 @@ class PrimaryObject(BasicPrimaryObject):
     ID is the user visible version.
     """
 
-    def __init__(self, source=None):
+    def __init__(self, source: Self | None = None):
         """
         Initialize a PrimaryObject.
 
@@ -230,50 +208,21 @@ class PrimaryObject(BasicPrimaryObject):
         of the source object.
 
         :param source: Object used to initialize the new object
-        :type source: PrimaryObject
         """
         BasicPrimaryObject.__init__(self, source)
 
-    @abstractmethod
-    def serialize(self):
-        """
-        Convert the object to a serialized tuple of data.
-        """
-
-    @abstractmethod
-    def unserialize(self, data):
-        """
-        Convert a serialized tuple of data to an object.
-        """
-
-    def has_handle_reference(self, classname, handle):
-        """
-        Return True if the object has reference to a given handle of given
-        primary object type.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param handle: The handle to be checked.
-        :type handle: str
-        :returns: Returns whether the object has reference to this handle
-                  of this object type.
-        :rtype: bool
-        """
+    @override
+    def has_handle_reference(self, classname: str, handle: str) -> bool:
         if classname == "Citation" and isinstance(self, CitationBase):
             return self.has_citation_reference(handle)
         if classname == "Media" and isinstance(self, MediaBase):
             return self.has_media_reference(handle)
         return self._has_handle_reference(classname, handle)
 
-    def remove_handle_references(self, classname, handle_list):
-        """
-        Remove all references in this object to object handles in the list.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param handle_list: The list of handles to be removed.
-        :type handle_list: str
-        """
+    @override
+    def remove_handle_references(
+        self, classname: str, handle_list: Collection[str]
+    ) -> None:
         if classname == "Citation" and isinstance(self, CitationBase):
             self.remove_citation_references(handle_list)
         elif classname == "Media" and isinstance(self, MediaBase):
@@ -283,17 +232,10 @@ class PrimaryObject(BasicPrimaryObject):
         else:
             self._remove_handle_references(classname, handle_list)
 
-    def replace_handle_reference(self, classname, old_handle, new_handle):
-        """
-        Replace all references to old handle with those to the new handle.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param old_handle: The handle to be replaced.
-        :type old_handle: str
-        :param new_handle: The handle to replace the old one with.
-        :type new_handle: str
-        """
+    @override
+    def replace_handle_reference(
+        self, classname: str, old_handle: str, new_handle: str
+    ) -> None:
         if classname == "Citation" and isinstance(self, CitationBase):
             self.replace_citation_references(old_handle, new_handle)
         elif classname == "Media" and isinstance(self, MediaBase):
@@ -301,18 +243,24 @@ class PrimaryObject(BasicPrimaryObject):
         else:
             self._replace_handle_reference(classname, old_handle, new_handle)
 
-    def _has_handle_reference(self, classname, handle):
+    def _has_handle_reference(self, classname: str, handle: str) -> bool:
         """
         Return True if the handle is referenced by the object.
         """
         return False
 
-    def _remove_handle_references(self, classname, handle_list):
+    def _remove_handle_references(
+        self, classname: str, handle_list: Collection[str]
+    ) -> None:
         """
         Remove the handle references from the object.
         """
+        pass
 
-    def _replace_handle_reference(self, classname, old_handle, new_handle):
+    def _replace_handle_reference(
+        self, classname: str, old_handle: str, new_handle: str
+    ) -> None:
         """
         Replace the handle reference with the new reference.
         """
+        pass

--- a/gramps/gen/lib/src.py
+++ b/gramps/gen/lib/src.py
@@ -25,6 +25,9 @@
 """
 Source object for Gramps.
 """
+from collections.abc import Collection
+
+from typing_extensions import override
 
 # -------------------------------------------------------------------------
 #
@@ -173,47 +176,24 @@ class Source(
         self.reporef_list = [RepoRef().unserialize(item) for item in reporef_list]
         return self
 
-    def _has_handle_reference(self, classname, handle):
-        """
-        Return True if the object has reference to a given handle of given
-        primary object type.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param handle: The handle to be checked.
-        :type handle: str
-        :returns: Returns whether the object has reference to this handle of
-                  this object type.
-        :rtype: bool
-        """
+    @override
+    def _has_handle_reference(self, classname: str, handle: str) -> bool:
         if classname == "Repository":
             return handle in [ref.ref for ref in self.reporef_list]
         return False
 
-    def _remove_handle_references(self, classname, handle_list):
-        """
-        Remove all references in this object to object handles in the list.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param handle_list: The list of handles to be removed.
-        :type handle_list: str
-        """
+    @override
+    def _remove_handle_references(
+        self, classname: str, handle_list: Collection[str]
+    ) -> None:
         if classname == "Repository":
             new_list = [ref for ref in self.reporef_list if ref.ref not in handle_list]
             self.reporef_list = new_list
 
-    def _replace_handle_reference(self, classname, old_handle, new_handle):
-        """
-        Replace all references to old handle with those to the new handle.
-
-        :param classname: The name of the primary object class.
-        :type classname: str
-        :param old_handle: The handle to be replaced.
-        :type old_handle: str
-        :param new_handle: The handle to replace the old one with.
-        :type new_handle: str
-        """
+    @override
+    def _replace_handle_reference(
+        self, classname: str, old_handle: str, new_handle: str
+    ) -> None:
         if classname == "Repository":
             handle_list = [ref.ref for ref in self.reporef_list]
             while old_handle in handle_list:


### PR DESCRIPTION
This PR:
- Adds type hints to everything in `gramps.gen.lib.primaryobj`, as well as any methods overridden in subclasses
- Uses `typing.override` to help mypy ensure subclasses override methods correctly, and for them to inherit the parents' docstrings (hence the large number of removals).