### PR TITLE
Add mypy configuration

### DIFF
--- a/.github/workflows/gramps-ci.yml
+++ b/.github/workflows/gramps-ci.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Run mypy static type checker
       run: |
         python3 -m pip install mypy
-        mypy gramps test --ignore-missing-imports --exclude '.*gpr\.py$'
+        mypy
     - name: Run unit test suite
       run: |
         export GDK_BACKEND=-

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,45 @@
+[mypy]
+files = ./gramps, ./test
+exclude = .*gpr\.py$
+
+[mypy-berkeleydb.*]
+ignore_missing_imports = True
+
+[mypy-bsddb3.*]
+ignore_missing_imports = True
+
+[mypy-cairo.*]
+ignore_missing_imports = True
+
+[mypy-gi.*]
+ignore_missing_imports = True
+
+[mypy-guitest.*]
+ignore_missing_imports = True
+
+[mypy-icu.*]
+ignore_missing_imports = True
+
+[mypy-imagesize.*]
+ignore_missing_imports = True
+
+[mypy-jsonschema.*]
+ignore_missing_imports = True
+
+[mypy-lxml.*]
+ignore_missing_imports = True
+
+[mypy-orjson.*]
+ignore_missing_imports = True
+
+[mypy-PIL.*]
+ignore_missing_imports = True
+
+[mypy-pycountry.*]
+ignore_missing_imports = True
+
+[mypy-PyICU.*]
+ignore_missing_imports = True
+
+[mypy-sets.*]
+ignore_missing_imports = True


### PR DESCRIPTION
This adds centralized mypy configuration so one just has to run `mypy` to get the same results as the CI builds. Instead of blindly ignoring any untyped imports, this explicitly ignores those that are known to be missing, so future errors are not suppressed silently.

This file also serves as a starting point to gradually make the mypy rules stricter, for instance per file or directory (so the codebase can be converted gradually).

As to the `@todo`s: we'd ideally install a few more Python packages (containing typing stubs for third part packages) that are not available through APT. Can we instead manage dependencies through a single, centralized source, and install them with pip?