### PR TITLE
Remove check that path exists in the media path unit test

### DIFF
--- a/gramps/gen/utils/test/file_test.py
+++ b/gramps/gen/utils/test/file_test.py
@@ -70,7 +70,6 @@ class FileTest(unittest.TestCase):
                 media_path(db),
                 os.path.normcase(os.path.normpath(os.path.abspath(USER_PICTURES))),
             )
-            self.assertTrue(os.path.exists(media_path(db)))
 
             # Test with absolute db.mediapath
             db.set_mediapath(os.path.abspath(USER_HOME) + "/test_abs")


### PR DESCRIPTION
The existence of the media path is the responsibility of the user and the unit test should not fail if it is missing.

Fixes [#13305](https://gramps-project.org/bugs/view.php?id=13305).