### PR TITLE
Update the INSTALL file

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -37,10 +37,10 @@ To install all needed dependencies you can use (in Ubuntu):
 
 To build and install, whether from a tarball or git repo:
    python3 setup.py build
-   sudo python3 setup.py install
+   sudo pip3 install .
 
 You can avoid using sudo for the install step by specifying a prefix to which you have write privilege. The default is /usr/local, which is usually owned by root. You can learn of more options with
-   python3 setup.py --help
+   pip3 install --help
 
 One can use Gramps from the command line without installing it by
 setting the following environment variables, but that won't provide
@@ -53,13 +53,17 @@ See below for ways to invoke Gramps.
 
 Typical install directories in linux (Ubuntu) are:
   * /usr/local/bin                                  : the Gramps executable
-  * /usr/local/lib/python3.5/dist-packages/gramps/  : the Gramps python module
+  * /usr/local/lib/python3.10/dist-packages/gramps/ : the Gramps python module
   * /usr/local/share/doc/gramps                     : documentation, also example .gramps and .gedcom
-  * /usr/local/share/icons/gnome                    : our icons
+  * /usr/local/share/gramps                         : data files
+  * /usr/local/share/gramps/images                  : our images
+  * /usr/local/share/gramps/css                     : css files
+  * /usr/local/share/icons/hicolor                  : application icons
   * /usr/local/share/locale/xx/LC_MESSAGES          : xx language code, translation
   * /usr/local/share/man/xx/man1                    : xx language code, man file
-  * /usr/local/share/mime
-  * /usr/local/share/mime-info                      : mime info so Gramps opens files automatically
+  * /usr/local/share/applications                   : desktop entry
+  * /usr/local/share/mime/packages                  : mime info so Gramps opens files automatically
+  * /usr/local/share/metainfo                       : application metadata
 
 Running Gramps
 --------------
@@ -89,10 +93,10 @@ from the source directory.
 Custom directory installation
 -------------------------------------
 If you would like to install Gramps without being root, or in an
-alternative location on Windows, supply the --root argument to setup.py
+alternative location on Windows, supply the --root argument to pip3 install
 
 For example:
-   python3 setup.py install --root ~/test
+   pip3 install . --root ~/test
 
 Packager's issues
 ------------------
@@ -100,9 +104,3 @@ There is a MANIFEST.in file to indicate the work needed.
 To create a source distribution run:
 
    python3 setup.py sdist
-
-If Gramps is built outside of the source tree in a temporary location (e.g. when
-packaging for a distribution), the --resourcepath option can be used to specify
-the path to the installed location of the Gramps resources (e.g. /usr/share):
-
-   python3 setup.py install --resourcepath=/usr/share


### PR DESCRIPTION
* Change install from `setup.py` to `pip`.
* Update typical installation locations.
* Remove the `--resourcepath` option which no longer exists.

Issue [#13717](https://gramps-project.org/bugs/view.php?id=13717).