### PR TITLE
Allow Multiple Selection from People, Event and Note Selectors

### DIFF
--- a/gramps/gui/editors/displaytabs/citationembedlist.py
+++ b/gramps/gui/editors/displaytabs/citationembedlist.py
@@ -185,33 +185,35 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
         objct = sel.run()
         LOG.debug("selected object: %s" % objct)
         # the object returned should either be a Source or a Citation
-        if objct:
+        if objct is not None:
             if not isinstance(objct, (Source, Citation)):
                 raise ValueError(
-                    f"selection must be either source or citation, got {type(objct)}"
+                    _("Selection must be either a source or a citation, got %s")
+                    % type(objct)
                 )
-            source = objct if isinstance(objct, Source) else None
-            citation = objct if isinstance(objct, Citation) else Citation()
-            try:
-                from .. import EditCitation
+            if isinstance(objct, Citation):
+                self.add_callback(objct.handle)
+            else:  # objct is a Source
+                try:
+                    from .. import EditCitation
 
-                EditCitation(
-                    self.dbstate,
-                    self.uistate,
-                    self.track,
-                    citation,
-                    source,
-                    callback=self.add_callback,
-                    callertitle=self.callertitle,
-                )
-            except WindowActiveError:
-                from ...dialog import WarningDialog
+                    EditCitation(
+                        self.dbstate,
+                        self.uistate,
+                        self.track,
+                        Citation(),
+                        objct,
+                        callback=self.add_callback,
+                        callertitle=self.callertitle,
+                    )
+                except WindowActiveError:
+                    from ...dialog import WarningDialog
 
-                WarningDialog(
-                    _("Cannot share this reference"),
-                    self.__blocked_text(),
-                    parent=self.uistate.window,
-                )
+                    WarningDialog(
+                        _("Cannot share this reference"),
+                        self.__blocked_text(),
+                        parent=self.uistate.window,
+                    )
 
     def __blocked_text(self):
         """

--- a/gramps/gui/editors/displaytabs/citationembedlist.py
+++ b/gramps/gui/editors/displaytabs/citationembedlist.py
@@ -177,8 +177,8 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
     def share_button_clicked(self, obj):
         SelectCitation = SelectorFactory("Citation")
 
-        # do not allow multiple selection, as it is not clear what behaviour should follow if the user
-        # selects multiple sources
+        # Multiple selection disabled: unclear UX for mixed Source/Citation selections
+        # and for multiple sources. Single selection prevents confusion.
         sel = SelectCitation(
             self.dbstate, self.uistate, self.track, allow_multiple_selection=False
         )

--- a/gramps/gui/editors/displaytabs/citationembedlist.py
+++ b/gramps/gui/editors/displaytabs/citationembedlist.py
@@ -177,11 +177,19 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
     def share_button_clicked(self, obj):
         SelectCitation = SelectorFactory("Citation")
 
-        sel = SelectCitation(self.dbstate, self.uistate, self.track)
+        # do not allow multiple selection, as it is not clear what behaviour should follow if the user
+        # selects multiple sources
+        sel = SelectCitation(
+            self.dbstate, self.uistate, self.track, allow_multiple_selection=False
+        )
         objct = sel.run()
         LOG.debug("selected object: %s" % objct)
         # the object returned should either be a Source or a Citation
         if objct:
+            if not isinstance(objct, (Source, Citation)):
+                raise ValueError(
+                    f"selection must be either source or citation, got {type(objct)}"
+                )
             source = objct if isinstance(objct, Source) else None
             citation = objct if isinstance(objct, Citation) else Citation()
             try:

--- a/gramps/gui/editors/displaytabs/citationembedlist.py
+++ b/gramps/gui/editors/displaytabs/citationembedlist.py
@@ -182,31 +182,28 @@ class CitationEmbedList(EmbeddedList, DbGUIElement):
         LOG.debug("selected object: %s" % objct)
         # the object returned should either be a Source or a Citation
         if objct:
-            if isinstance(objct, Source):
-                try:
-                    from .. import EditCitation
+            source = objct if isinstance(objct, Source) else None
+            citation = objct if isinstance(objct, Citation) else Citation()
+            try:
+                from .. import EditCitation
 
-                    EditCitation(
-                        self.dbstate,
-                        self.uistate,
-                        self.track,
-                        Citation(),
-                        objct,
-                        callback=self.add_callback,
-                        callertitle=self.callertitle,
-                    )
-                except WindowActiveError:
-                    from ...dialog import WarningDialog
+                EditCitation(
+                    self.dbstate,
+                    self.uistate,
+                    self.track,
+                    citation,
+                    source,
+                    callback=self.add_callback,
+                    callertitle=self.callertitle,
+                )
+            except WindowActiveError:
+                from ...dialog import WarningDialog
 
-                    WarningDialog(
-                        _("Cannot share this reference"),
-                        self.__blocked_text(),
-                        parent=self.uistate.window,
-                    )
-            elif isinstance(objct, Citation):
-                self.add_callback(objct.handle)
-            else:
-                raise ValueError("selection must be either source or citation")
+                WarningDialog(
+                    _("Cannot share this reference"),
+                    self.__blocked_text(),
+                    parent=self.uistate.window,
+                )
 
     def __blocked_text(self):
         """

--- a/gramps/gui/editors/displaytabs/eventembedlist.py
+++ b/gramps/gui/editors/displaytabs/eventembedlist.py
@@ -303,12 +303,7 @@ class EventEmbedList(DbGUIElement, GroupEmbeddedList):
         )
         events = sel.run()
         if events:
-            if len(events) > 1:
-                for event in events:
-                    ref = EventRef()
-                    ref.set_role(self.default_role())
-                    self.object_added(ref, event)
-            else:
+            if len(events) == 1:
                 try:
                     ref = EventRef()
                     ref.set_role(self.default_role())
@@ -328,6 +323,11 @@ class EventEmbedList(DbGUIElement, GroupEmbeddedList):
                         self.__blocked_text(),
                         parent=self.uistate.window,
                     )
+            else:
+                for event in events:
+                    ref = EventRef()
+                    ref.set_role(self.default_role())
+                    self.object_added(ref, event)
 
     def edit_button_clicked(self, obj):
         ref = self.get_selected()

--- a/gramps/gui/editors/displaytabs/eventembedlist.py
+++ b/gramps/gui/editors/displaytabs/eventembedlist.py
@@ -298,28 +298,36 @@ class EventEmbedList(DbGUIElement, GroupEmbeddedList):
     def share_button_clicked(self, obj):
         SelectEvent = SelectorFactory("Event")
 
-        sel = SelectEvent(self.dbstate, self.uistate, self.track)
-        event = sel.run()
-        if event:
-            try:
-                ref = EventRef()
-                ref.set_role(self.default_role())
-                self.get_ref_editor()(
-                    self.dbstate,
-                    self.uistate,
-                    self.track,
-                    event,
-                    ref,
-                    self.object_added,
-                )
-            except WindowActiveError:
-                from ...dialog import WarningDialog
+        sel = SelectEvent(
+            self.dbstate, self.uistate, self.track, allow_multiple_selection=True
+        )
+        events = sel.run()
+        if events:
+            if len(events) > 1:
+                for event in events:
+                    ref = EventRef()
+                    ref.set_role(self.default_role())
+                    self.object_added(ref, event)
+            else:
+                try:
+                    ref = EventRef()
+                    ref.set_role(self.default_role())
+                    self.get_ref_editor()(
+                        self.dbstate,
+                        self.uistate,
+                        self.track,
+                        events[0],
+                        ref,
+                        self.object_added,
+                    )
+                except WindowActiveError:
+                    from ...dialog import WarningDialog
 
-                WarningDialog(
-                    _("Cannot share this reference"),
-                    self.__blocked_text(),
-                    parent=self.uistate.window,
-                )
+                    WarningDialog(
+                        _("Cannot share this reference"),
+                        self.__blocked_text(),
+                        parent=self.uistate.window,
+                    )
 
     def edit_button_clicked(self, obj):
         ref = self.get_selected()

--- a/gramps/gui/editors/displaytabs/notetab.py
+++ b/gramps/gui/editors/displaytabs/notetab.py
@@ -212,10 +212,13 @@ class NoteTab(EmbeddedList, DbGUIElement):
     def share_button_clicked(self, obj):
         SelectNote = SelectorFactory("Note")
 
-        sel = SelectNote(self.dbstate, self.uistate, self.track)
-        note = sel.run()
-        if note:
-            self.add_callback(note)
+        sel = SelectNote(
+            self.dbstate, self.uistate, self.track, allow_multiple_selection=True
+        )
+        notes = sel.run()
+        if notes:
+            for note in notes:
+                self.add_callback(note)
 
     def get_icon_name(self):
         """

--- a/gramps/gui/editors/editfamily.py
+++ b/gramps/gui/editors/editfamily.py
@@ -298,19 +298,27 @@ class ChildEmbedList(DbGUIElement, EmbeddedList):
         skip_list.extend(x.ref for x in self.family.get_child_ref_list())
 
         sel = SelectPerson(
-            self.dbstate, self.uistate, self.track, _("Select Child"), skip=skip_list
+            self.dbstate,
+            self.uistate,
+            self.track,
+            _("Select Child"),
+            skip=skip_list,
+            allow_multiple_selection=True,
         )
-        person = sel.run()
+        people = sel.run()
 
-        if person:
-            ref = ChildRef()
-            ref.ref = person.get_handle()
-            self.family.add_child_ref(ref)
-            self.rebuild()
-            GLib.idle_add(
-                self.tree.scroll_to_cell, len(self.family.get_child_ref_list()) - 1
-            )
-            self.call_edit_childref(ref)
+        if people:
+            for person in people:
+                ref = ChildRef()
+                ref.ref = person.get_handle()
+                self.family.add_child_ref(ref)
+                self.rebuild()
+                GLib.idle_add(
+                    self.tree.scroll_to_cell,
+                    len(self.family.get_child_ref_list()) - len(people),
+                )
+                if len(people) == 1:
+                    self.call_edit_childref(ref)
 
     def run(self, skip):
         skip_list = [_f for _f in skip if _f]

--- a/gramps/gui/editors/editfamily.py
+++ b/gramps/gui/editors/editfamily.py
@@ -309,6 +309,7 @@ class ChildEmbedList(DbGUIElement, EmbeddedList):
 
         if people:
             # add the child references to the family
+            first_new_index = len(self.family.get_child_ref_list())
             for person in people:
                 ref = ChildRef()
                 ref.ref = person.get_handle()
@@ -317,7 +318,7 @@ class ChildEmbedList(DbGUIElement, EmbeddedList):
             # scroll to the first added child
             GLib.idle_add(
                 self.tree.scroll_to_cell,
-                len(self.family.get_child_ref_list()) - len(people),
+                first_new_index,
             )
             if len(people) == 1:
                 self.call_edit_childref(self.family.get_child_ref_list()[-1])

--- a/gramps/gui/editors/editfamily.py
+++ b/gramps/gui/editors/editfamily.py
@@ -308,17 +308,19 @@ class ChildEmbedList(DbGUIElement, EmbeddedList):
         people = sel.run()
 
         if people:
+            # add the child references to the family
             for person in people:
                 ref = ChildRef()
                 ref.ref = person.get_handle()
                 self.family.add_child_ref(ref)
-                self.rebuild()
-                GLib.idle_add(
-                    self.tree.scroll_to_cell,
-                    len(self.family.get_child_ref_list()) - len(people),
-                )
-                if len(people) == 1:
-                    self.call_edit_childref(ref)
+            self.rebuild()
+            # scroll to the first added child
+            GLib.idle_add(
+                self.tree.scroll_to_cell,
+                len(self.family.get_child_ref_list()) - len(people),
+            )
+            if len(people) == 1:
+                self.call_edit_childref(self.family.get_child_ref_list()[-1])
 
     def run(self, skip):
         skip_list = [_f for _f in skip if _f]

--- a/gramps/gui/editors/editfamily.py
+++ b/gramps/gui/editors/editfamily.py
@@ -310,6 +310,7 @@ class ChildEmbedList(DbGUIElement, EmbeddedList):
         if people:
             # add the child references to the family
             first_new_index = len(self.family.get_child_ref_list())
+            ref = None
             for person in people:
                 ref = ChildRef()
                 ref.ref = person.get_handle()
@@ -321,7 +322,7 @@ class ChildEmbedList(DbGUIElement, EmbeddedList):
                 first_new_index,
             )
             if len(people) == 1:
-                self.call_edit_childref(self.family.get_child_ref_list()[-1])
+                self.call_edit_childref(ref)
 
     def run(self, skip):
         skip_list = [_f for _f in skip if _f]

--- a/gramps/gui/selectors/selectperson.py
+++ b/gramps/gui/selectors/selectperson.py
@@ -61,6 +61,7 @@ class SelectPerson(BaseSelector):
         skip=set(),
         show_search_bar=True,
         default=None,
+        allow_multiple_selection=False,
     ):
         # SelectPerson may have a title passed to it which should be used
         # instead of the default defined for get_window_title()
@@ -85,6 +86,7 @@ class SelectPerson(BaseSelector):
             skip,
             show_search_bar,
             default,
+            allow_multiple_selection,
         )
 
     def _local_init(self):


### PR DESCRIPTION
Continuing on from PR #1836 which added multiple selection of media objects in the gallerytab, allow multiple selection of 
* children when editing a family
* notes in `NotesTab`
* events in `EventEmbedList`

As with the gallery tab, if multiple objects are selected, the references are added without showing the edit ref dialog.

It would be nice to permit multiple selection of citations but currently the multiple selection would permit multiple sources, or sources and citations, to be returned and it is not clear what the user experience should be in this scenario. So for now, I've left it as single selection.