### PR TITLE
Fix issue with empty metadata fields on new databases in Gramps 6.0

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -813,9 +813,10 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
             self.set_serializer("blob")
             self.has_changed = 1  # to make sure genderstats gets saved
             self._set_all_metadata()
-            self.has_changed = 0  # number of commits
             if self.use_json_data():
                 self.set_serializer("json")
+                self._set_all_metadata()
+            self.has_changed = 0  # number of commits
 
         self.db_is_open = True
 


### PR DESCRIPTION
See the discussion in https://github.com/gramps-project/gramps-web-api/issues/631.