### PR TITLE
Prevent Unhandled Exception in GuiPersonOption

### DIFF
--- a/gramps/gui/editors/editfamily.py
+++ b/gramps/gui/editors/editfamily.py
@@ -984,7 +984,7 @@ class EditFamily(EditPrimary):
             self.uistate,
             self.track,
             _("Select Mother"),
-            filter=(4, _("Female")),
+            search_or_filter=(4, _("Female")),
             skip=[x.ref for x in self.obj.get_child_ref_list()],
         )
         person = sel.run()
@@ -1033,7 +1033,7 @@ class EditFamily(EditPrimary):
             self.uistate,
             self.track,
             _("Select Father"),
-            filter=(4, _("Male")),
+            search_or_filter=(4, _("Male")),
             skip=[x.ref for x in self.obj.get_child_ref_list()],
         )
         person = sel.run()

--- a/gramps/gui/plug/_guioptions.py
+++ b/gramps/gui/plug/_guioptions.py
@@ -695,6 +695,7 @@ class GuiPersonOption(Gtk.Box):
         """
         # Create a filter for the person selector.
         rfilter = GenericFilter()
+        rfilter.set_name(_("Active, bookmarked or home people"))
         rfilter.set_logical_op("or")
         rfilter.add_rule(rules.person.IsBookmarked([]))
         rfilter.add_rule(rules.person.HasIdOf([self.__option.get_value()]))
@@ -718,7 +719,7 @@ class GuiPersonOption(Gtk.Box):
             self.__uistate,
             self.__track,
             title=_("Select a person for the report"),
-            filter=rfilter,
+            search_or_filter=rfilter,
         )
         person = sel.run()
         self.__update_person(person)
@@ -852,6 +853,8 @@ class GuiFamilyOption(Gtk.Box):
         """
         # Create a filter for the person selector.
         rfilter = GenericFilterFactory("Family")()
+        rfilter.set_name(_("Active or bookmarked families"))
+
         rfilter.set_logical_op("or")
 
         # Add the current family
@@ -881,7 +884,9 @@ class GuiFamilyOption(Gtk.Box):
         # rfilter.add_rule(rules.family.HasIdOf([gid]))
 
         select_class = SelectorFactory("Family")
-        sel = select_class(self.__dbstate, self.__uistate, self.__track, filter=rfilter)
+        sel = select_class(
+            self.__dbstate, self.__uistate, self.__track, search_or_filter=rfilter
+        )
         family = sel.run()
         if family:
             self.__update_family(family.get_handle())

--- a/gramps/gui/selectors/baseselector.py
+++ b/gramps/gui/selectors/baseselector.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2003-2006  Donald N. Allingham
 #               2009-2011  Gary Burton
+#               2025       Steve Youngs
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -45,6 +46,7 @@ from ..glade import Glade
 from ..widgets.interactivesearchbox import InteractiveSearchBox
 from ..display import display_help
 from gramps.gen.const import URL_MANUAL_PAGE
+from gramps.gen.filters import GenericFilter
 from gramps.gui.widgets.persistenttreeview import PersistentTreeView
 from gramps.gui.widgets.multitreeview import MultiTreeView
 
@@ -72,7 +74,9 @@ class BaseSelector(ManagedWindow):
         dbstate,
         uistate,
         track=[],
-        filter: tuple[int, str] | None = None,  # tuple[filter_id, search_string]
+        search_or_filter: (
+            tuple[int, str] | GenericFilter | None
+        ) = None,  # tuple[search_index, search_string]
         skip=set(),
         show_search_bar: bool = True,
         default=None,
@@ -131,9 +135,14 @@ class BaseSelector(ManagedWindow):
         self.search_bar = SearchBar(dbstate, uistate, self.build_tree)
         search_box = self.search_bar.build()
         self.setup_searches()
-        if filter:
-            self.search_bar.search_list.set_active(filter[0])
-            self.search_bar.search_text.set_text(filter[1])
+        if isinstance(search_or_filter, GenericFilter):
+            self.search_bar.append_filter(search_or_filter.name, search_or_filter)
+            self.search_bar.search_list.set_active(
+                self.search_bar.search_model.iter_n_children(None) - 1
+            )
+        elif isinstance(search_or_filter, tuple):
+            self.search_bar.search_list.set_active(search_or_filter[0])
+            self.search_bar.search_text.set_text(search_or_filter[1])
         vbox.pack_start(search_box, False, False, 0)
         vbox.reorder_child(search_box, 1)
 
@@ -317,12 +326,13 @@ class BaseSelector(ManagedWindow):
         """
         Builds the selection people see in the Selector
         """
-        search_bar_filter = self.search_bar.get_value()
-        filter_info = (
-            0,
-            search_bar_filter if search_bar_filter[1] else None,
-            search_bar_filter[0] in self.exact_search(),
-        )
+        filter_info = self.search_bar.get_value()
+        if not filter_info[0]:
+            filter_info = (
+                filter_info[0],
+                filter_info[1],
+                filter_info[1][0] in self.exact_search(),
+            )
 
         if self.model:
             sel = self.first_selected()

--- a/gramps/gui/selectors/baseselector.py
+++ b/gramps/gui/selectors/baseselector.py
@@ -129,13 +129,13 @@ class BaseSelector(ManagedWindow):
 
         # add the search bar
         self.search_bar = SearchBar(dbstate, uistate, self.build_tree)
-        filter_box = self.search_bar.build()
-        self.setup_filter()
+        search_box = self.search_bar.build()
+        self.setup_searches()
         if filter:
-            self.search_bar.filter_list.set_active(filter[0])
-            self.search_bar.filter_text.set_text(filter[1])
-        vbox.pack_start(filter_box, False, False, 0)
-        vbox.reorder_child(filter_box, 1)
+            self.search_bar.search_list.set_active(filter[0])
+            self.search_bar.search_text.set_text(filter[1])
+        vbox.pack_start(search_box, False, False, 0)
+        vbox.reorder_child(search_box, 1)
 
         self.set_window(window, title_label, self.title)
 
@@ -302,16 +302,16 @@ class BaseSelector(ManagedWindow):
         """
         return ()
 
-    def setup_filter(self):
+    def setup_searches(self):
         """
-        Builds the default filters and add them to the filter bar.
+        Builds the default searches and add them to the search bar.
         """
         cols = [
             (pair[3], pair[1], pair[1] in self.exact_search())
             for pair in self.column_order()
             if pair[0]
         ]
-        self.search_bar.setup_filter(cols)
+        self.search_bar.setup_searches(cols)
 
     def build_tree(self):
         """

--- a/gramps/gui/selectors/selectperson.py
+++ b/gramps/gui/selectors/selectperson.py
@@ -58,7 +58,7 @@ class SelectPerson(BaseSelector):
         uistate,
         track=[],
         title=None,
-        filter=None,
+        search_or_filter=None,
         skip=set(),
         show_search_bar=True,
         default=None,
@@ -78,7 +78,14 @@ class SelectPerson(BaseSelector):
             self.WIKI_HELP_SEC = _("Select_Person_selector", "manual")
 
         BaseSelector.__init__(
-            self, dbstate, uistate, track, filter, skip, show_search_bar, default
+            self,
+            dbstate,
+            uistate,
+            track,
+            search_or_filter,
+            skip,
+            show_search_bar,
+            default,
         )
 
     def _local_init(self):

--- a/gramps/gui/selectors/selectplace.py
+++ b/gramps/gui/selectors/selectplace.py
@@ -75,8 +75,8 @@ class SelectPlace(BaseSelector):
     def get_from_handle_func(self):
         return self.db.get_place_from_handle
 
-    def setup_filter(self):
-        """Build the default filters and add them to the filter menu.
+    def setup_searches(self):
+        """Build the default searches and add them to the search bar.
         This overrides the baseselector method because we use the hidden
         COL_SEARCH (11) that has alt names as well as primary name for name
         searching"""
@@ -85,7 +85,7 @@ class SelectPlace(BaseSelector):
             for pair in self.column_order()
             if pair[0]
         ]
-        self.search_bar.setup_filter(cols)
+        self.search_bar.setup_searches(cols)
 
     def get_config_name(self):
         return __name__

--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -207,7 +207,7 @@ class ListView(NavigationView):
             self.selection.set_mode(Gtk.SelectionMode.MULTIPLE)
         self.selection.connect("changed", self.row_changed)
 
-        self.setup_filter()
+        self.setup_searches()
         self.list.restore_column_size()
         return self.vbox
 
@@ -416,9 +416,9 @@ class ListView(NavigationView):
         except WindowActiveError:
             return
 
-    def setup_filter(self):
+    def setup_searches(self):
         """Build the default filters and add them to the filter menu."""
-        self.search_bar.setup_filter(
+        self.search_bar.setup_searches(
             [
                 (self.COLUMNS[pair[1]][0], pair[1], pair[1] in self.exact_search())
                 for pair in self.column_order()
@@ -556,7 +556,7 @@ class ListView(NavigationView):
         # column that was sorted on before is situated now.
         self.sort_col = 0
         self.sort_order = Gtk.SortType.ASCENDING
-        self.setup_filter()
+        self.setup_searches()
         self.build_tree(preserve_col=False)
 
     def column_order(self):

--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -336,8 +336,13 @@ class ListView(NavigationView):
             if not self.search_bar.is_visible():
                 filter_info = (True, self.generic_filter, False)
             else:
-                value = self.search_bar.get_value()
-                filter_info = (False, value, value[0] in self.exact_search())
+                filter_info = self.search_bar.get_value()
+                if not filter_info[0]:
+                    filter_info = (
+                        filter_info[0],
+                        filter_info[1],
+                        filter_info[1][0] in self.exact_search(),
+                    )
 
             if self.dirty or not self.model:
                 if self.model:

--- a/gramps/gui/views/treemodels/treebasemodel.py
+++ b/gramps/gui/views/treemodels/treebasemodel.py
@@ -458,14 +458,14 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
           with the new entries
         """
         if search:
-            if search[0] == 1:  # Filter
+            if search[0]:  # Filter
                 # following is None if no data given in filter sidebar
                 self.search = search[1]
                 if self.has_secondary:
                     self.search2 = search[1]
                     _LOG.debug("search2 filter %s %s" % (search[0], search[1]))
                 self._build_data = self._rebuild_filter
-            elif search[0] == 0:  # Search
+            else:  # Search
                 if search[1]:
                     # we have search[1] = (index, text_unicode, inversion)
                     col, text, inv = search[1]
@@ -485,12 +485,6 @@ class TreeBaseModel(GObject.GObject, Gtk.TreeModel, BaseModel):
                     if self.has_secondary:
                         self.search2 = None
                         _LOG.debug("search2 search with no data")
-                self._build_data = self._rebuild_search
-            else:  # Fast filter
-                self.search = search[1]
-                if self.has_secondary:
-                    self.search2 = search[2]
-                    _LOG.debug("search2 fast filter")
                 self._build_data = self._rebuild_search
         else:
             self.search = None

--- a/gramps/plugins/lib/libplaceview.py
+++ b/gramps/plugins/lib/libplaceview.py
@@ -155,12 +155,12 @@ class PlaceBaseView(ListView):
     def navigation_type(self):
         return "Place"
 
-    def setup_filter(self):
-        """Build the default filters and add them to the filter menu.
+    def setup_searches(self):
+        """Build the default searches and add them to the search bar.
         This overrides the listview method because we use the hidden
         COL_SEARCH that has alt names as well as primary name for name
         searching"""
-        self.search_bar.setup_filter(
+        self.search_bar.setup_searches(
             [
                 (
                     self.COLUMNS[pair[1]][0],

--- a/gramps/plugins/view/citationtreeview.py
+++ b/gramps/plugins/view/citationtreeview.py
@@ -180,13 +180,13 @@ class CitationTreeView(LibSourceView, ListView):
             # add in Bookmarks.CitationBookmarks
             pass
 
-    def setup_filter(self):
+    def setup_searches(self):
         """
         Override the setup of the default Search Bar in listview, so that only
         the searchable source fields are shown.
         """
 
-        self.search_bar.setup_filter(
+        self.search_bar.setup_searches(
             [
                 (self.COLUMNS[pair[1]][0], pair[1], pair[1] in self.exact_search())
                 for pair in self.column_order()


### PR DESCRIPTION
This PR has been heavily revised to restore the previous behaviour, See https://github.com/gramps-project/gramps/pull/2032#issuecomment-2770646907 for further information

**Initial PR description**
This is a quick fix to avoid gramps crashing. As such it simply removes the filter parameter from the call to SelectPerson. The SelectPerson dialog therefore shows all people in the DB. Previously it defaulted to showing the following people
- bookmarked
- home
- active

A longer term solution is still required to restore the previous people shown by default.

Fixes [#13720](https://gramps-project.org/bugs/view.php?id=13720).