### PR TITLE
MRU Improvements

### DIFF
--- a/gramps/gui/displaystate.py
+++ b/gramps/gui/displaystate.py
@@ -122,7 +122,7 @@ class History(Callback):
             if initial_person:
                 self.push(initial_person.get_handle())
 
-    def push(self, handle):
+    def push(self, handle, make_active=True):
         """
         Pushes the handle on the history stack
         """
@@ -132,8 +132,9 @@ class History(Callback):
             if handle in self.mru:
                 self.mru.remove(handle)
             self.mru.append(handle)
+            if make_active:
+                self.index += 1
             self.emit("mru-changed", (self.mru,))
-            self.index += 1
         if self.history:
             newact = self.history[self.index]
             if not isinstance(newact, str):

--- a/gramps/gui/views/navigationview.py
+++ b/gramps/gui/views/navigationview.py
@@ -212,6 +212,12 @@ class NavigationView(PageView):
         if handle and not hobj.lock and not (handle == hobj.present()):
             hobj.push(handle)
 
+    def new_object_added(self, object):
+        handle = object.get_handle()
+        hobj = self.get_history()
+        if handle and not hobj.lock and not (handle == hobj.present()):
+            hobj.push(handle, False)
+
     @abstractmethod
     def goto_handle(self, handle):
         """

--- a/gramps/gui/views/navigationview.py
+++ b/gramps/gui/views/navigationview.py
@@ -444,18 +444,22 @@ class NavigationView(PageView):
         nav_type = self.navigation_type()
         hobj = self.get_history()
         menu_len = min(len(items) - 1, MRU_SIZE)
-
+        active_handle = hobj.present()
+        hotkey_index = 0
         data = []
-        for index in range(menu_len - 1, -1, -1):
+        for index in range(menu_len, -1, -1):
             name, _obj = navigation_label(self.dbstate.db, nav_type, items[index])
             menus += menuitem % (nav_type, index, html.escape(name))
+            active = items[index] == active_handle
             data.append(
                 (
                     "%s%02d" % (nav_type, index),
                     make_callback(hobj.push, items[index]),
-                    "%s%d" % (mod_key(), menu_len - 1 - index),
+                    "%s%d" % (mod_key(), hotkey_index) if not active else "",
                 )
             )
+            if not active:
+                hotkey_index += 1
         self.mru_ui = [MRU_TOP + menus + MRU_BTM]
 
         self.mru_action = ActionGroup(name=self.title + "/MRU")

--- a/gramps/plugins/view/persontreeview.py
+++ b/gramps/plugins/view/persontreeview.py
@@ -134,7 +134,7 @@ class PersonTreeView(BasePersonView):
             preset_name(basepers, name)
         person.set_primary_name(name)
         try:
-            EditPerson(self.dbstate, self.uistate, [], person)
+            EditPerson(self.dbstate, self.uistate, [], person, self.new_object_added)
         except WindowActiveError:
             pass
 


### PR DESCRIPTION
When adding new objects, also add them to the MRU list.

For now this is a proof of concept and _only_ adds new people created via the `PersonTreeView` to the MRU.

In the screen shot below, of the example database, upon loading, Lewis was the active person. I manually clicked Allison followed by Amy. Amy is the active person at this point. I then added two additional people, Aaron and Aaron Jnr.
![image](https://github.com/user-attachments/assets/c1f35855-7983-4447-80d7-b44eef390467)

For now, the active person is shown in the MRU list as well. Whilst I initially did this for debug purposes, there is an argument for keeping it.

Related forum discussion starts here: https://gramps.discourse.group/t/add-a-recent-sub-menu/5760/82