### PR TITLE
Maclocale: Fix return value list for no locale.

### DIFF
--- a/gramps/gen/utils/maclocale.py
+++ b/gramps/gen/utils/maclocale.py
@@ -189,7 +189,7 @@ def mac_setup_localization(glocale):
                 return locale_values
             LOG.debug("Global defaults locale %s isn't supported", loc)
 
-        return (None, None, None)
+        return (None, None)
 
     def _mac_get_collation():
         """


### PR DESCRIPTION
Fixes https://gramps-project.org/bugs/view.php?id=13727