### PR TITLE
Remove the outer progress meter from the filter prepare phase

### DIFF
--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -267,20 +267,10 @@ class GenericFilter:
                 if id_list not given, all items in the database that
                 match the filter are returned as a list of handles
         """
-        if user:
-            user.begin_progress(_("Filter"), _("Preparing ..."), len(self.flist) + 1)
-            # FIXME: this dialog doesn't show often. Adding a time.sleep(0.1) here
-            # can help on my machine
-
         start_time = time.time()
         for rule in self.flist:
-            if user:
-                user.step_progress()
             rule.requestprepare(db, user)
         LOG.debug("Prepare time: %s seconds", time.time() - start_time)
-
-        if user:
-            user.end_progress()
 
         if self.logical_op == "and":
             apply_logical_op = self.and_test


### PR DESCRIPTION
Some rules also contain a progress meter in their prepare methods. This prevents the outer progress meter from being closed and the modal dialog remains displayed.

In the future we may wish to use a dialog which can handle multiple operations.

Fixes [#13725](https://gramps-project.org/bugs/view.php?id=13725).