### PR TITLE
Fix icu/PyICU exception handling in narrated web report

### DIFF
--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -64,14 +64,12 @@ except ImportError:
         from PyICU import Locale
 
         HAVE_ICU = True
-        try:
-            from PyICU import AlphabeticIndex as icuAlphabeticIndex
 
-            HAVE_ALPHABETICINDEX = True
-        except ImportError:
-            from gramps.plugins.webreport.alphabeticindex import (
-                AlphabeticIndex as localAlphabeticIndex,
-            )
+        # Failure here is caught by the enclosing exception handling
+        from PyICU import AlphabeticIndex as icuAlphabeticIndex
+
+        HAVE_ALPHABETICINDEX = True
+
     except ImportError:
         from gramps.plugins.webreport.alphabeticindex import (
             AlphabeticIndex as localAlphabeticIndex,

--- a/gramps/plugins/webreport/common.py
+++ b/gramps/plugins/webreport/common.py
@@ -73,7 +73,9 @@ except ImportError:
                 AlphabeticIndex as localAlphabeticIndex,
             )
     except ImportError:
-        pass
+        from gramps.plugins.webreport.alphabeticindex import (
+            AlphabeticIndex as localAlphabeticIndex,
+        )
 
 LOG = logging.getLogger(".NarrativeWeb")
 


### PR DESCRIPTION
Exception handling is currently incomplete when both icu and PyICU are not installed.

First, fix the error in the most obvious way.  Then remove duplicate exception handling.

Fixes [#13407](https://gramps-project.org/bugs/view.php?id=13407).