### PR TITLE
Respect user choice of CSS files for existing narrated web site

### DIFF
--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -1269,7 +1269,7 @@ class NavWebReport(Report):
         # copy screen style sheet
         if CSS[self.css]["filename"]:
             fname = CSS[self.css]["filename"]
-            self.copy_file(fname, _NARRATIVESCREEN, "css")
+            self.copy_file(fname, _NARRATIVESCREEN, "css", True)
 
         # copy printer style sheet
         fname = CSS["Print-Default"]["filename"]
@@ -1904,7 +1904,7 @@ class NavWebReport(Report):
         )
         return real_path, thumb_path
 
-    def copy_file(self, from_fname, to_fname, to_dir=""):
+    def copy_file(self, from_fname, to_fname, to_dir="", clobber=False):
         """
         Copy a file from a source to a (report) destination.
         If to_dir is not present and if the target is not an archive,
@@ -1945,7 +1945,7 @@ class NavWebReport(Report):
                 os.makedirs(destdir)
 
             if from_fname != dest:
-                if not os.path.exists(dest):
+                if clobber or not os.path.exists(dest):
                     try:
                         shutil.copyfile(from_fname, dest)
                         os.utime(dest, (mtime, mtime))


### PR DESCRIPTION
Fixes [#13792](https://gramps-project.org/bugs/view.php?id=13792)

When a Narrated Web Site is generated to an existing folder and the CSS for the web pages is changed, the screen CSS would not be overwritten. This has been changed so that the user's choice of CSS is correctly copied to the output directory