### PR TITLE
Don't crash if a gramplet fails to load

### DIFF
--- a/gramps/gui/widgets/grampletbar.py
+++ b/gramps/gui/widgets/grampletbar.py
@@ -680,7 +680,8 @@ class TabGramplet(Gtk.ScrolledWindow, GuiGramplet):
         """
         Called when the gramplet orientation changes.
         """
-        self.pui.set_orientation(orientation)
+        if self.pui:
+            self.pui.set_orientation(orientation)
 
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
If a gramplet fails to load, `self.pui` is None, so do not call `self.pui.set_orientation` to avoid an error

Fixes bug [13820 ](https://gramps-project.org/bugs/view.php?id=13820)