### PR TITLE
Dev version correctly reports the SHA of the local HEAD commit

### DIFF
--- a/gramps/gen/const.py
+++ b/gramps/gen/const.py
@@ -182,9 +182,7 @@ ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
 sys.path.insert(0, ROOT_DIR)
 if DEV_VERSION:
-    git_revision = get_git_revision(ROOT_DIR).replace("\n", "")
-    if sys.platform == "win32" and git_revision == "":
-        git_revision = get_git_revision(os.path.split(ROOT_DIR)[1])
+    git_revision = get_git_revision().replace("\n", "")
     VERSION += git_revision
 # VERSION += "-1"
 

--- a/gramps/gen/git_revision.py
+++ b/gramps/gen/git_revision.py
@@ -26,12 +26,12 @@ Find the latest git revision.
 import subprocess
 
 
-def get_git_revision(path=""):
+def get_git_revision():
     """
     Return the short commit hash of the latest commit.
     """
     stdout = ""
-    command = ["git", "log", "-1", "--format=%h", path]
+    command = ["git", "log", "-1", "--format=%h"]
     try:
         proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout, stderr) = proc.communicate()


### PR DESCRIPTION
Local builds report the Gramps version in the form of Major.Minor.Patch-SHA. However, the commit SHA reported did not correspond to the repo root, but that of the gramps/gramps folder which was unexpected. This change fixes that by removing the path argument to get_git_revision so the git log command does not limit commits, and the dev version is reported as expected.

A brief history: the path argument was a carry-over from SVN, and wasn't initially used (see commit 57daf4f), but a subsequent change attempted to use it (commit 6836dbd), and finally the path argument was appended to the git log command in commit f92ee32.

To test this change, run `python Gramps.py -v` from the root of the source directory, or other subfolders (adjusting the path to Gramps.py as required) and verify that the version reported matches the HEAD commit of your source.

Testing performed/needed
- [X] MSYS environment on Windows
- [X] Ubuntu (in a WSL environment)
- [ ] Apple MacOS
- [x] Linux