### PR TITLE
Fixes #13807 bad surname list after upgrade from bsddb

### DIFF
--- a/gramps/gen/db/generic.py
+++ b/gramps/gen/db/generic.py
@@ -2799,6 +2799,7 @@ class DbGeneric(DbWriteBase, DbReadBase, UpdateCallback, Callback):
 
         self.rebuild_secondary(callback)
         self.reindex_reference_map(callback)
+        self.surname_list = self.get_surname_list()
         self.reset()
 
         self.set_schema_version(self.VERSION[0])


### PR DESCRIPTION
User was unable to add new person immediately after performing upgrade from older version.
```
File "C:\Program Files\GrampsAIO64-6.0.1\gramps\gen\db\generic.py", line 2605, in add_to_surname_list
    i = bisect.bisect(self.surname_list, name)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'str' and 'NoneType'
```
Turns out that upgrade from bsddb did not initialize the surname list; the upgrade code was saving json data with raw_commit, so the usual commit_person code which would have update the surname list was not executed.