### PR TITLE
Avoid multiple copies of Rules after Plugin manager reload

### DIFF
--- a/gramps/gen/plug/_manager.py
+++ b/gramps/gen/plug/_manager.py
@@ -227,7 +227,8 @@ class BasePluginManager:
             # make the new rule findable via import statements
             setattr(obj_rules, plugin.ruleclass, r_class)
             # and add it to the correct fiter editor list
-            obj_rules.editor_rule_list.append(r_class)
+            if r_class not in obj_rules.editor_rule_list:
+                obj_rules.editor_rule_list.append(r_class)
 
     def is_loaded(self, pdata_id):
         """


### PR DESCRIPTION
If the Plugin Manager "Reload" button is used (to reload current plugins), then the filter rules list shown in the edit filter dialog add rule will get multiple copies of addon type rules.  This doesn't affect the standard plugin rules.

Fixes [#13844](https://gramps-project.org/bugs/view.php?id=13844).