### PR TITLE
Fix crash in Citation View

### DIFF
--- a/gramps/gui/views/listview.py
+++ b/gramps/gui/views/listview.py
@@ -787,8 +787,13 @@ class ListView(NavigationView):
         if not self.search_bar.is_visible():
             filter_info = (True, self.generic_filter, False)
         else:
-            value = self.search_bar.get_value()
-            filter_info = (False, value, value[0] in self.exact_search())
+            filter_info = self.search_bar.get_value()
+            if not filter_info[0]:
+                filter_info = (
+                    filter_info[0],
+                    filter_info[1],
+                    filter_info[1][0] in self.exact_search(),
+                )
 
         if same_col:
             # activate when https://bugzilla.gnome.org/show_bug.cgi?id=684558


### PR DESCRIPTION
Fix a crash in Citation View will when sorting by "Last Changed" date.

To reproduce:

1. Start with Gramps60 branch with https://github.com/gramps-project/gramps/pull/2060 in place.
2. Preconditions: in Citation View, Sidebar turned off (Menu/View/Sidebar). Configure the view so "Last Changed" is visible.
3. Open a tree with some citations.
4. In Citation View, click on "Last Changed" column to resort it.

Fixes bug [0013796](https://gramps-project.org/bugs/view.php?id=13796)