### PR TITLE
Fix broken compound dates with bce year in XML import

### DIFF
--- a/gramps/plugins/importer/importxml.py
+++ b/gramps/plugins/importer/importxml.py
@@ -2547,11 +2547,16 @@ class GrampsParser(UpdateCallback):
         elif self.place_name:
             date_value = self.place_name.get_date_object()
 
-        start = attrs["start"].split("-")
-        stop = attrs["stop"].split("-")
+        start = attrs["start"]
+        stop = attrs["stop"]
 
+        bce = 1
+        if start[0] == "-":
+            bce = -1
+            start = start[1:]
+        start = start.split("-")
         try:
-            year = int(start[0])
+            year = int(start[0]) * bce
         except ValueError:
             year = 0
 
@@ -2565,8 +2570,13 @@ class GrampsParser(UpdateCallback):
         except:
             day = 0
 
+        bce = 1
+        if stop[0] == "-":
+            bce = -1
+            stop = stop[1:]
+        stop = stop.split("-")
         try:
-            rng_year = int(stop[0])
+            rng_year = int(stop[0]) * bce
         except:
             rng_year = 0
 


### PR DESCRIPTION
If date spans have a negative year, the import of the date fails and converts to a text string.

A similar issue was fixed for normal dates and I copied the solution.

The issue goes back a ways, I found it in gramps52...  Might want to look into back porting this.

Fixes [#13631](https://gramps-project.org/bugs/view.php?id=13631).