### PR TITLE
Connect the Help button in the repository reference editor

### DIFF
--- a/gramps/gui/editors/editreporef.py
+++ b/gramps/gui/editors/editreporef.py
@@ -36,11 +36,21 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 from gramps.gen.lib import NoteType
 from gramps.gen.db import DbTxn
+from gramps.gen.const import URL_MANUAL_SECT2
 
 from .displaytabs import NoteTab, AddrEmbedList, WebEmbedList, SourceBackRefList
 from ..widgets import MonitoredEntry, PrivacyButton, MonitoredDataType
 from .editreference import RefTab, EditReference
 from ..glade import Glade
+
+# -------------------------------------------------------------------------
+#
+# Constants
+#
+# -------------------------------------------------------------------------
+
+WIKI_HELP_PAGE = URL_MANUAL_SECT2
+WIKI_HELP_SEC = "Repository_Reference_Editor"
 
 
 # -------------------------------------------------------------------------
@@ -84,6 +94,9 @@ class EditRepoRef(EditReference):
     def _connect_signals(self):
         self.define_ok_button(self.top.get_object("ok"), self.ok_clicked)
         self.define_cancel_button(self.top.get_object("cancel"))
+        self.define_help_button(
+            self.top.get_object("help"), WIKI_HELP_PAGE, WIKI_HELP_SEC
+        )
 
     def _connect_db_signals(self):
         """


### PR DESCRIPTION
Previously the button was displayed but not connected to anything

Fixes [0013352](https://gramps-project.org/bugs/view.php?id=13352)