### PR TITLE
Bug 13702: EditNote Callback: Pass object not handle

### DIFF
--- a/gramps/gui/editors/displaytabs/notetab.py
+++ b/gramps/gui/editors/displaytabs/notetab.py
@@ -166,13 +166,13 @@ class NoteTab(EmbeddedList, DbGUIElement):
         except WindowActiveError:
             pass
 
-    def add_callback(self, name):
+    def add_callback(self, note):
         """
         Called to update the screen when a new note is added
         """
         data = self.get_data()
-        data.append(name)
-        self.callman.register_handles({"note": [name]})
+        data.append(note.handle)
+        self.callman.register_handles({"note": [note.handle]})
         self.changed = True
         self.rebuild()
         GLib.idle_add(self.tree.scroll_to_cell, len(data) - 1)

--- a/gramps/gui/editors/editnote.py
+++ b/gramps/gui/editors/editnote.py
@@ -381,4 +381,4 @@ class EditNote(EditPrimary):
 
         self._do_close()
         if self.callback:
-            self.callback(self.obj.get_handle())
+            self.callback(self.obj)

--- a/gramps/plugins/gramplet/todo.py
+++ b/gramps/plugins/gramplet/todo.py
@@ -242,9 +242,9 @@ class PersonToDo(ToDo):
         else:
             self.set_has_data(False)
 
-    def created(self, handle):
+    def created(self, note):
         with DbTxn("Attach Note", self.dbstate.db) as trans:
-            self.obj.add_note(handle)
+            self.obj.add_note(note.handle)
             self.dbstate.db.commit_person(self.obj, trans)
 
 
@@ -277,9 +277,9 @@ class EventToDo(ToDo):
         else:
             self.set_has_data(False)
 
-    def created(self, handle):
+    def created(self, note):
         with DbTxn("Attach Note", self.dbstate.db) as trans:
-            self.obj.add_note(handle)
+            self.obj.add_note(note.handle)
             self.dbstate.db.commit_event(self.obj, trans)
 
 
@@ -312,9 +312,9 @@ class FamilyToDo(ToDo):
         else:
             self.set_has_data(False)
 
-    def created(self, handle):
+    def created(self, note):
         with DbTxn("Attach Note", self.dbstate.db) as trans:
-            self.obj.add_note(handle)
+            self.obj.add_note(note.handle)
             self.dbstate.db.commit_family(self.obj, trans)
 
 
@@ -347,9 +347,9 @@ class PlaceToDo(ToDo):
         else:
             self.set_has_data(False)
 
-    def created(self, handle):
+    def created(self, note):
         with DbTxn("Attach Note", self.dbstate.db) as trans:
-            self.obj.add_note(handle)
+            self.obj.add_note(note.handle)
             self.dbstate.db.commit_place(self.obj, trans)
 
 
@@ -382,9 +382,9 @@ class SourceToDo(ToDo):
         else:
             self.set_has_data(False)
 
-    def created(self, handle):
+    def created(self, note):
         with DbTxn("Attach Note", self.dbstate.db) as trans:
-            self.obj.add_note(handle)
+            self.obj.add_note(note.handle)
             self.dbstate.db.commit_source(self.obj, trans)
 
 
@@ -417,9 +417,9 @@ class CitationToDo(ToDo):
         else:
             self.set_has_data(False)
 
-    def created(self, handle):
+    def created(self, note):
         with DbTxn("Attach Note", self.dbstate.db) as trans:
-            self.obj.add_note(handle)
+            self.obj.add_note(note.handle)
             self.dbstate.db.commit_citation(self.obj, trans)
 
 
@@ -452,9 +452,9 @@ class RepositoryToDo(ToDo):
         else:
             self.set_has_data(False)
 
-    def created(self, handle):
+    def created(self, note):
         with DbTxn("Attach Note", self.dbstate.db) as trans:
-            self.obj.add_note(handle)
+            self.obj.add_note(note.handle)
             self.dbstate.db.commit_repository(self.obj, trans)
 
 
@@ -487,7 +487,7 @@ class MediaToDo(ToDo):
         else:
             self.set_has_data(False)
 
-    def created(self, handle):
+    def created(self, note):
         with DbTxn("Attach Note", self.dbstate.db) as trans:
-            self.obj.add_note(handle)
+            self.obj.add_note(note.handle)
             self.dbstate.db.commit_media(self.obj, trans)


### PR DESCRIPTION
Fix EditNote so that it passes the object when calling the callback function, rather than the object handle. 
Fixes the error described in 13702 and gives consistency with other Edit<Obj> classes.

To reproduce:
1. create a new note- type "a"
2. select "a" and click the Link button
3. Change the Link Type to Note and click New
4. type "a" and click ok

Fixes [#13702](https://gramps-project.org/bugs/view.php?id=13702) and possibly [#12260](https://gramps-project.org/bugs/view.php?id=12260)

Reviewed and adjusted other places that create an EditNote instance with callback
