### PR TITLE
Remove check for Gtk translations in Snap packages

### DIFF
--- a/gramps/gui/grampsgui.py
+++ b/gramps/gui/grampsgui.py
@@ -573,7 +573,12 @@ class Gramps:
         dbstate = DbState()
         self._vm = ViewManager(app, dbstate, config.get("interface.view-categories"))
 
-        if lin() and glocale.lang != "C" and not gettext.find(GTK_GETTEXT_DOMAIN):
+        if (
+            lin()
+            and "SNAP" not in os.environ
+            and glocale.lang != "C"
+            and not gettext.find(GTK_GETTEXT_DOMAIN)
+        ):
             _display_gtk_gettext_message(parent=self._vm.window)
 
         _display_translator_message(parent=self._vm.window)


### PR DESCRIPTION
These will not be found because they are not installed in the standard location.

The Snap package contains all the required language packs.