### PR TITLE
Filter optimizer logical op "or" and "one"

### DIFF
--- a/gramps/gen/filters/__init__.py
+++ b/gramps/gen/filters/__init__.py
@@ -41,6 +41,10 @@ def reload_custom_filters():
     CustomFilters = FilterList(CUSTOM_FILTERS)
     CustomFilters.load()
 
+def set_custom_filters(filter_list):
+    global CustomFilters
+    CustomFilters = filter_list
+
 
 # if not CustomFilters:  # moved to viewmanager
 # reload_custom_filters()

--- a/gramps/gen/filters/__init__.py
+++ b/gramps/gen/filters/__init__.py
@@ -41,6 +41,7 @@ def reload_custom_filters():
     CustomFilters = FilterList(CUSTOM_FILTERS)
     CustomFilters.load()
 
+
 def set_custom_filters(filter_list):
     global CustomFilters
     CustomFilters = filter_list

--- a/gramps/gen/filters/_filterlist.py
+++ b/gramps/gen/filters/_filterlist.py
@@ -25,6 +25,7 @@
 # Standard Python modules
 #
 # -------------------------------------------------------------------------
+from io import StringIO
 from xml.sax import make_parser, SAXParseException
 import os
 from collections import abc
@@ -112,6 +113,15 @@ class FilterList:
                     parser.parse(the_file)
         except (IOError, OSError):
             print("IO/OSError in _filterlist.py")
+        except SAXParseException:
+            print("Parser error")
+
+    def loadString(self, string):
+        """load a custom filter from the provided string"""
+        try:
+            parser = make_parser()
+            parser.setContentHandler(FilterParser(self))
+            parser.parse(StringIO(string))
         except SAXParseException:
             print("Parser error")
 

--- a/gramps/gen/filters/_filterlist.py
+++ b/gramps/gen/filters/_filterlist.py
@@ -105,11 +105,13 @@ class FilterList:
     def remove(self, namespace, filter_name):
         """remove a custom filter from global list"""
         # Remove filter_name from namespace:
-        for item in self.filter_namespaces[namespace][:]:
-            if item.name == filter_name:
-                self.filter_namespaces[namespace].remove(item)
+        if namespace in self.filter_namespaces:
+            for item in self.filter_namespaces[namespace][:]:
+                if item.name == filter_name:
+                    self.filter_namespaces[namespace].remove(item)
         # Remove from cache:
-        del self._cached[namespace][filter_name]
+        if namespace in self._cached:
+            del self._cached[namespace][filter_name]
 
     def load(self):
         """load a custom filter"""

--- a/gramps/gen/filters/_filterlist.py
+++ b/gramps/gen/filters/_filterlist.py
@@ -102,17 +102,6 @@ class FilterList:
             self.filter_namespaces[namespace] = []
         self.filter_namespaces[namespace].append(filt)
 
-    def remove(self, namespace, filter_name):
-        """remove a custom filter from global list"""
-        # Remove filter_name from namespace:
-        if namespace in self.filter_namespaces:
-            for item in self.filter_namespaces[namespace][:]:
-                if item.name == filter_name:
-                    self.filter_namespaces[namespace].remove(item)
-        # Remove from cache:
-        if namespace in self._cached:
-            del self._cached[namespace][filter_name]
-
     def load(self):
         """load a custom filter"""
         try:

--- a/gramps/gen/filters/_filterlist.py
+++ b/gramps/gen/filters/_filterlist.py
@@ -102,6 +102,15 @@ class FilterList:
             self.filter_namespaces[namespace] = []
         self.filter_namespaces[namespace].append(filt)
 
+    def remove(self, namespace, filter_name):
+        """remove a custom filter from global list"""
+        # Remove filter_name from namespace:
+        for item in self.filter_namespaces[namespace][:]:
+            if item.name == filter_name:
+                self.filter_namespaces[namespace].remove(item)
+        # Remove from cache:
+        del self._cached[namespace][filter_name]
+
     def load(self):
         """load a custom filter"""
         try:

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -239,12 +239,21 @@ class GenericFilter:
     def apply(self, db, id_list=None, tupleind=None, user=None, tree=False):
         """
         Apply the filter using db.
-        If id_list given, the handles in id_list are used. If not given
-        a database cursor will be used over all entries.
 
-        If tupleind is given, id_list is supposed to consist of a list of
-        tuples, with the handle being index tupleind. So
-        handle_0 = id_list[0][tupleind]
+        If id_list and tupleind given, id_list is a list of tuples. tupleind is the
+        index of the object handle. So handle_0 = id_list[0][tupleind]. If multiple
+        tuples have the same handle, it is undefined which tuple is returned.
+
+        If id_list given and tupleind is None, id_list if the list of handles to use
+
+        If id_list is None and tree is False, all handles in the database are searched.
+        The order of handles in the result is not guaranteed
+
+        If id_list is None and tree is True, all handles in the database are searched.
+        The order of handles in the result matches the order of traversal
+        by get_tree_cursor
+
+        id_list takes precendence over tree
 
         user is optional. If present it must be an instance of a User class.
 

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -281,8 +281,8 @@ class GenericFilter:
 
         # build the starting set of possible_handles to be filtered
         possible_handles: Set[PrimaryObjectHandle]
-        if id_list:
-            if tupleind:
+        if id_list is not None:
+            if tupleind is not None:
                 # construct a dict from handle to corresponding tuple
                 # this is used to efficiently transform final_list from a list of
                 # handles to a list of tuples
@@ -301,7 +301,7 @@ class GenericFilter:
         res = self.apply_logical_op_to_all(db, possible_handles, apply_logical_op, user)
 
         # convert the filtered set of handles to the correct result type
-        if id_list and tupleind:
+        if id_list is not None and tupleind is not None:
             if len(res):
                 # convert the final_list of handles back to the corresponding final_list of tuples
                 res = [handle_tuple[handle] for handle in res]

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -58,7 +58,7 @@ from .optimizer import Optimizer
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import List, Set, Tuple
+from typing import Dict, List, Set, Tuple
 from ..db import Database
 from ..types import PrimaryObjectHandle
 
@@ -286,12 +286,10 @@ class GenericFilter:
                 # construct a dict from handle to corresponding tuple
                 # this is used to efficiently transform final_list from a list of
                 # handles to a list of tuples
-                handle_tuple = {data[tupleind]: data for data in id_list}
+                handle_tuple : Dict[PrimaryObjectHandle, Tuple]= {data[tupleind]: data for data in id_list}
                 possible_handles = set(handle_tuple.keys())
             else:
                 possible_handles = set(id_list)
-            # and make sure it does not include None
-            possible_handles.discard(None)
         elif tree:
             tree_handles = [handle for handle, obj in self.get_tree_cursor(db)]
             possible_handles = set(tree_handles)

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -242,8 +242,9 @@ class GenericFilter:
         Apply the filter using db.
 
         If id_list and tupleind given, id_list is a list of tuples. tupleind is the
-        index of the object handle. So handle_0 = id_list[0][tupleind]. If multiple
-        tuples have the same handle, it is undefined which tuple is returned.
+        index of the object handle. So handle_0 = id_list[0][tupleind]. The input
+        order in maintained in the output. If multiple tuples have the same handle,
+        it is undefined which tuple is returned.
 
         If id_list given and tupleind is None, id_list if the list of handles to use
 
@@ -304,7 +305,10 @@ class GenericFilter:
         if id_list is not None and tupleind is not None:
             if len(res):
                 # convert the final_list of handles back to the corresponding final_list of tuples
-                res = [handle_tuple[handle] for handle in res]
+                res = sorted(
+                    [handle_tuple[handle] for handle in res],
+                    key=lambda x: id_list.index(x),
+                )
         elif tree:
             # sort final_list into the same order as traversed by get_tree_cursor
             res = sorted(res, key=lambda x: tree_handles.index(x))

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -24,6 +24,12 @@
 Package providing filtering framework for Gramps.
 """
 
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+from __future__ import annotations
 import logging
 import time
 
@@ -45,6 +51,15 @@ from ..lib.tag import Tag
 from ..const import GRAMPS_LOCALE as glocale
 from .rules import Rule
 from .optimizer import Optimizer
+
+# -------------------------------------------------------------------------
+#
+# Typing modules
+#
+# -------------------------------------------------------------------------
+from typing import List, Tuple
+from ..db import Database
+from ..types import PrimaryObjectHandle
 
 _ = glocale.translation.gettext
 LOG = logging.getLogger(".filter.results")
@@ -143,7 +158,13 @@ class GenericFilter:
         return db.get_number_of_people()
 
     def apply_logical_op_to_all(
-        self, db, id_list, apply_logical_op, user=None, tupleind=None, tree=False
+        self,
+        db,
+        id_list: List[PrimaryObjectHandle | Tuple],
+        apply_logical_op,
+        user=None,
+        tupleind: int | None = None,
+        tree: bool = False,
     ):
         # build the starting set of possible_handles
         if id_list:
@@ -236,7 +257,14 @@ class GenericFilter:
             raise Exception("invalid operator: %r" % self.logical_op)
         return res != self.invert
 
-    def apply(self, db, id_list=None, tupleind=None, user=None, tree=False):
+    def apply(
+        self,
+        db,
+        id_list: List[PrimaryObjectHandle | Tuple] = None,
+        tupleind: int | None = None,
+        user=None,
+        tree: bool = False,
+    ) -> List[PrimaryObjectHandle | Tuple]:
         """
         Apply the filter using db.
 

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -147,7 +147,10 @@ class GenericFilter:
     ):
         final_list = []
 
-        optimizer = Optimizer(set(self.get_all_handles(db)), self)
+        if id_list:
+            optimizer = Optimizer(set(id_list), self)
+        else:
+            optimizer = Optimizer(set(self.get_all_handles(db)), self)
         possible_handles = optimizer.get_possible_handles()
 
         LOG.debug(

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -148,13 +148,12 @@ class GenericFilter:
         final_list = []
 
         optimizer = Optimizer(set(self.get_all_handles(db)), self)
-        handles_in, handles_out = optimizer.get_handles()
+        handles_in = optimizer.get_handles()
 
         LOG.debug(
             "Optimizer handles_in: %s",
             len(handles_in),
         )
-        LOG.debug("Optimizer handles_out: %s", len(handles_out))
         if id_list is None:
             if user:
                 user.begin_progress(_("Filter"), _("Applying ..."), len(handles_in))

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -302,7 +302,7 @@ class GenericFilter:
         res = self.apply_logical_op_to_all(db, possible_handles, apply_logical_op, user)
 
         # convert the filtered set of handles to the correct result type
-        if id_list  is not None and tupleind is not None:
+        if id_list is not None and tupleind is not None:
             # convert the final_list of handles back to the corresponding final_list of tuples
             res = sorted(
                 [handle_tuple[handle] for handle in res],

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2002-2006  Donald N. Allingham
 # Copyright (C) 2011       Tim G L Lyons
 # Copyright (C) 2012,2024  Doug Blank <doug.blank@gmail.com>
+# Copyright (C) 2025       Steve Youngs <steve@youngs.cc>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -172,8 +173,6 @@ class GenericFilter:
         # use the Optimizer to refine the set of possible_handles
         optimizer = Optimizer(possible_handles, self)
         possible_handles = optimizer.get_possible_handles()
-        # and make sure it does not include None
-        possible_handles.discard(None)
 
         LOG.debug(
             "Optimizer possible_handles: %s",
@@ -290,6 +289,8 @@ class GenericFilter:
                 possible_handles = set(handle_tuple.keys())
             else:
                 possible_handles = set(id_list)
+            # and make sure it does not include None
+            possible_handles.discard(None)
         elif tree:
             tree_handles = [handle for handle, obj in self.get_tree_cursor(db)]
             possible_handles = set(tree_handles)

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -282,7 +282,7 @@ class GenericFilter:
 
         # build the starting set of possible_handles to be filtered
         possible_handles: Set[PrimaryObjectHandle]
-        if id_list:
+        if id_list is not None:
             if tupleind is not None:
                 # construct a dict from handle to corresponding tuple
                 # this is used to efficiently transform final_list from a list of
@@ -302,7 +302,7 @@ class GenericFilter:
         res = self.apply_logical_op_to_all(db, possible_handles, apply_logical_op, user)
 
         # convert the filtered set of handles to the correct result type
-        if id_list and tupleind is not None:
+        if id_list  is not None and tupleind is not None:
             # convert the final_list of handles back to the corresponding final_list of tuples
             res = sorted(
                 [handle_tuple[handle] for handle in res],

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -148,18 +148,20 @@ class GenericFilter:
         final_list = []
 
         optimizer = Optimizer(set(self.get_all_handles(db)), self)
-        handles_in = optimizer.get_handles()
+        possible_handles = optimizer.get_possible_handles()
 
         LOG.debug(
-            "Optimizer handles_in: %s",
-            len(handles_in),
+            "Optimizer possible_handles: %s",
+            len(possible_handles),
         )
         if id_list is None:
             if user:
-                user.begin_progress(_("Filter"), _("Applying ..."), len(handles_in))
+                user.begin_progress(
+                    _("Filter"), _("Applying ..."), len(possible_handles)
+                )
 
             # Use these rather than going through entire database
-            for handle in handles_in:
+            for handle in possible_handles:
                 if user:
                     user.step_progress()
 
@@ -183,7 +185,7 @@ class GenericFilter:
                 else:
                     handle = handle_data[tupleind]
 
-                if handle not in handles_in:
+                if handle not in possible_handles:
                     continue
 
                 obj = self.get_object(db, handle)

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -72,7 +72,7 @@ LOG = logging.getLogger(".filter.results")
 #
 # -------------------------------------------------------------------------
 class GenericFilter:
-    """Filter class that consists of several rules."""
+    """Filter class that consists of zero, one or more rules."""
 
     logical_functions = ["and", "or", "one"]
 
@@ -282,7 +282,7 @@ class GenericFilter:
 
         # build the starting set of possible_handles to be filtered
         possible_handles: Set[PrimaryObjectHandle]
-        if id_list is not None:
+        if id_list:
             if tupleind is not None:
                 # construct a dict from handle to corresponding tuple
                 # this is used to efficiently transform final_list from a list of
@@ -302,13 +302,12 @@ class GenericFilter:
         res = self.apply_logical_op_to_all(db, possible_handles, apply_logical_op, user)
 
         # convert the filtered set of handles to the correct result type
-        if id_list is not None and tupleind is not None:
-            if len(res):
-                # convert the final_list of handles back to the corresponding final_list of tuples
-                res = sorted(
-                    [handle_tuple[handle] for handle in res],
-                    key=lambda x: id_list.index(x),
-                )
+        if id_list and tupleind is not None:
+            # convert the final_list of handles back to the corresponding final_list of tuples
+            res = sorted(
+                [handle_tuple[handle] for handle in res],
+                key=lambda x: id_list.index(x),
+            )
         elif tree:
             # sort final_list into the same order as traversed by get_tree_cursor
             res = sorted(res, key=lambda x: tree_handles.index(x))

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -171,20 +171,25 @@ class GenericFilter:
         )
 
         # use the Optimizer to refine the set of possible_handles
-        optimizer = Optimizer(possible_handles, self)
-        possible_handles = optimizer.get_possible_handles()
+        optimizer = Optimizer()
+        handles_in, handles_out = optimizer.compute_potential_handles_for_filter(self)
 
-        LOG.debug(
-            "Optimizer possible_handles: %s",
-            len(possible_handles),
-        )
+        # LOG.debug(
+        #    "Optimizer possible_handles: %s",
+        #    len(possible_handles),
+        # )
 
-        if user:
-            user.begin_progress(_("Filter"), _("Applying ..."), len(possible_handles))
+        # if user:
+        #    user.begin_progress(_("Filter"), _("Applying ..."), len(possible_handles))
 
         # test each value in possible_handles to compute the final_list
         final_list = []
         for handle in possible_handles:
+            if handles_in is not None and handle not in handles_in:
+                continue
+            if handles_out is not None and handle in handles_out:
+                continue
+
             if user:
                 user.step_progress()
 

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -148,7 +148,11 @@ class GenericFilter:
         # build the starting set of possible_handles
         if id_list:
             if tupleind:
-                possible_handles = set(data[tupleind] for data in id_list)
+                # construct a dict from handle to corresponding tuple
+                # this is used to efficiently transform final_list from a list of
+                # handles to a list of tuples
+                handle_tuple = {data[tupleind]: data for data in id_list}
+                possible_handles = set(handle_tuple.keys())
             else:
                 possible_handles = set(id_list)
         elif tree:
@@ -187,7 +191,11 @@ class GenericFilter:
             if apply_logical_op(db, obj, self.flist) != self.invert:
                 final_list.append(obj.handle)
 
-        if tree:
+        if id_list and tupleind:
+            if len(final_list):
+                # convert the final_list of handles back to the corresponding final_list of tuples
+                final_list = [handle_tuple[handle] for handle in final_list]
+        elif tree:
             # sort final_list into the same order as traversed by get_tree_cursor
             final_list = sorted(final_list, key=lambda x: tree_handles.index(x))
 

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -58,7 +58,7 @@ from .optimizer import Optimizer
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import cast, Dict, List, Set, Tuple
+from typing import cast, Dict, List, Literal, Set, Tuple
 from ..db import Database
 from ..types import PrimaryObjectHandle
 
@@ -75,6 +75,7 @@ class GenericFilter:
     """Filter class that consists of zero, one or more rules."""
 
     logical_functions = ["and", "or", "one"]
+    logical_op: Literal["and", "or", "one"]
 
     def __init__(self, source=None):
         if source:

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -233,7 +233,7 @@ class GenericFilter:
     def apply(
         self,
         db,
-        id_list: List[PrimaryObjectHandle | Tuple] = None,
+        id_list: List[PrimaryObjectHandle | Tuple] | None = None,
         tupleind: int | None = None,
         user=None,
         tree: bool = False,
@@ -280,6 +280,7 @@ class GenericFilter:
         start_time = time.time()
 
         # build the starting set of possible_handles to be filtered
+        possible_handles: Set[PrimaryObjectHandle]
         if id_list:
             if tupleind:
                 # construct a dict from handle to corresponding tuple

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -151,6 +151,8 @@ class GenericFilter:
                 possible_handles = set(data[tupleind] for data in id_list)
             else:
                 possible_handles = set(id_list)
+        elif tree:
+            possible_handles = set(handle for handle, obj in self.get_tree_cursor(db))
         else:
             possible_handles = set(self.get_all_handles(db))
 

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -145,8 +145,6 @@ class GenericFilter:
     def apply_logical_op_to_all(
         self, db, id_list, apply_logical_op, user=None, tupleind=None, tree=False
     ):
-        final_list = []
-
         # build the starting set of possible_handles
         if id_list:
             if tupleind:
@@ -176,6 +174,7 @@ class GenericFilter:
             user.begin_progress(_("Filter"), _("Applying ..."), len(possible_handles))
 
         # test each value in possible_handles to compute the final_list
+        final_list = []
         for handle in possible_handles:
             if user:
                 user.step_progress()

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -155,8 +155,6 @@ class GenericFilter:
                 possible_handles = set(id_list)
         else:
             possible_handles = set(self.get_all_handles(db))
-        # and make sure no None values are present
-        possible_handles.discard(None)
 
         LOG.debug(
             "Starting possible_handles: %s",
@@ -166,6 +164,8 @@ class GenericFilter:
         # use the Optimizer to refine the set of possible_handles
         optimizer = Optimizer(possible_handles, self)
         possible_handles = optimizer.get_possible_handles()
+        # and make sure it does not include None
+        possible_handles.discard(None)
 
         LOG.debug(
             "Optimizer possible_handles: %s",
@@ -175,7 +175,7 @@ class GenericFilter:
         if user:
             user.begin_progress(_("Filter"), _("Applying ..."), len(possible_handles))
 
-        # Use these rather than going through entire database
+        # test each value in possible_handles to compute the final_list
         for handle in possible_handles:
             if user:
                 user.step_progress()

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -58,7 +58,7 @@ from .optimizer import Optimizer
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Dict, List, Set, Tuple
+from typing import cast, Dict, List, Set, Tuple
 from ..db import Database
 from ..types import PrimaryObjectHandle
 
@@ -286,10 +286,12 @@ class GenericFilter:
                 # construct a dict from handle to corresponding tuple
                 # this is used to efficiently transform final_list from a list of
                 # handles to a list of tuples
-                handle_tuple : Dict[PrimaryObjectHandle, Tuple]= {data[tupleind]: data for data in id_list}
+                handle_tuple: Dict[PrimaryObjectHandle, Tuple] = {
+                    data[tupleind]: data for data in cast(List[Tuple], id_list)
+                }
                 possible_handles = set(handle_tuple.keys())
             else:
-                possible_handles = set(id_list)
+                possible_handles = set(cast(List[PrimaryObjectHandle], id_list))
         elif tree:
             tree_handles = [handle for handle, obj in self.get_tree_cursor(db)]
             possible_handles = set(tree_handles)

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -124,6 +124,9 @@ class GenericFilter:
     def get_rules(self):
         return self.flist
 
+    def get_all_handles(self, db):
+        return db.get_person_handles()
+
     def get_cursor(self, db):
         return db.get_person_cursor()
 
@@ -144,7 +147,7 @@ class GenericFilter:
     ):
         final_list = []
 
-        optimizer = Optimizer(self)
+        optimizer = Optimizer(set(self.get_all_handles(db)), self)
         handles_in, handles_out = optimizer.get_handles()
 
         LOG.debug(
@@ -300,6 +303,9 @@ class GenericFamilyFilter(GenericFilter):
     def __init__(self, source=None):
         GenericFilter.__init__(self, source)
 
+    def get_all_handles(self, db):
+        return db.get_family_handles()
+
     def get_cursor(self, db):
         return db.get_family_cursor()
 
@@ -319,6 +325,9 @@ class GenericFamilyFilter(GenericFilter):
 class GenericEventFilter(GenericFilter):
     def __init__(self, source=None):
         GenericFilter.__init__(self, source)
+
+    def get_all_handles(self, db):
+        return db.get_event_handles()
 
     def get_cursor(self, db):
         return db.get_event_cursor()
@@ -340,6 +349,9 @@ class GenericSourceFilter(GenericFilter):
     def __init__(self, source=None):
         GenericFilter.__init__(self, source)
 
+    def get_all_handles(self, db):
+        return db.get_source_handles()
+
     def get_cursor(self, db):
         return db.get_source_cursor()
 
@@ -359,6 +371,9 @@ class GenericSourceFilter(GenericFilter):
 class GenericCitationFilter(GenericFilter):
     def __init__(self, source=None):
         GenericFilter.__init__(self, source)
+
+    def get_all_handles(self, db):
+        return db.get_citation_handles()
 
     def get_cursor(self, db):
         return db.get_citation_cursor()
@@ -383,6 +398,9 @@ class GenericPlaceFilter(GenericFilter):
     def __init__(self, source=None):
         GenericFilter.__init__(self, source)
 
+    def get_all_handles(self, db):
+        return db.get_place_handles()
+
     def get_cursor(self, db):
         return db.get_place_cursor()
 
@@ -406,6 +424,9 @@ class GenericMediaFilter(GenericFilter):
     def __init__(self, source=None):
         GenericFilter.__init__(self, source)
 
+    def get_all_handles(self, db):
+        return db.get_media_handles()
+
     def get_cursor(self, db):
         return db.get_media_cursor()
 
@@ -426,6 +447,9 @@ class GenericRepoFilter(GenericFilter):
     def __init__(self, source=None):
         GenericFilter.__init__(self, source)
 
+    def get_all_handles(self, db):
+        return db.get_repository_handles()
+
     def get_cursor(self, db):
         return db.get_repository_cursor()
 
@@ -445,6 +469,9 @@ class GenericRepoFilter(GenericFilter):
 class GenericNoteFilter(GenericFilter):
     def __init__(self, source=None):
         GenericFilter.__init__(self, source)
+
+    def get_all_handles(self, db):
+        return db.get_note_handles()
 
     def get_cursor(self, db):
         return db.get_note_cursor()

--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -152,7 +152,8 @@ class GenericFilter:
             else:
                 possible_handles = set(id_list)
         elif tree:
-            possible_handles = set(handle for handle, obj in self.get_tree_cursor(db))
+            tree_handles = [handle for handle, obj in self.get_tree_cursor(db)]
+            possible_handles = set(tree_handles)
         else:
             possible_handles = set(self.get_all_handles(db))
 
@@ -185,6 +186,10 @@ class GenericFilter:
 
             if apply_logical_op(db, obj, self.flist) != self.invert:
                 final_list.append(obj.handle)
+
+        if tree:
+            # sort final_list into the same order as traversed by get_tree_cursor
+            final_list = sorted(final_list, key=lambda x: tree_handles.index(x))
 
         if user:
             user.end_progress()

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -19,29 +19,18 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+from functools import reduce
 import logging
 
 LOG = logging.getLogger(".filter.optimizer")
 
 
 def intersection(sets):
-    if sets:
-        result = sets[0]
-        for s in sets[1:]:
-            result = result.intersection(s)
-        return result
-    else:
-        return set()
+    return reduce(lambda x, y: x & y, sets, sets[0] if sets else set())
 
 
 def union(sets):
-    if sets:
-        result = sets[0]
-        for s in sets[1:]:
-            result = result.union(s)
-        return result
-    else:
-        return set()
+    return reduce(lambda x, y: x | y, sets, set())
 
 
 class Optimizer:

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -62,15 +62,13 @@ class Optimizer:
             handles_out_set_op = set.union
             support_unoptimized_rule = True
         elif filter.logical_op == "or":
-            return (None, None)
-            # handles_in_set_op = set.union
-            # handles_out_set_op = set.intersection
-            # support_unoptimized_rule = False  # with a logical_op of "or" it is not possible to optimize this filter if any rule is unoptimized
+            handles_in_set_op = set.union
+            handles_out_set_op = set.intersection
+            support_unoptimized_rule = False  # with a logical_op of "or" it is not possible to optimize this filter if any rule is unoptimized
         elif filter.logical_op == "one":
-            return (None, None)
-            # handles_in_set_op = set.difference
-            # handles_out_set_op = set.intersection
-            # support_unoptimized_rule = False  # with a logical_op of "one" it is not possible to optimize this filter if any rule is unoptimized
+            handles_in_set_op = set.difference
+            handles_out_set_op = set.intersection
+            support_unoptimized_rule = False  # with a logical_op of "one" it is not possible to optimize this filter if any rule is unoptimized
         else:
             assert_never(filter.logical_op)
 

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -64,8 +64,10 @@ class Optimizer:
         """
         current_invert = parent_invert if not filter.invert else not parent_invert
         LOG.debug(
-            "walking, filter: %s, invert=%s, parent_logical_op=%s, parent_invert=%s",
+            "walking, filter: %s, name=%s, logical_op=%s, invert=%s, parent_logical_op=%s, parent_invert=%s",
             filter,
+            filter.name,
+            filter.logical_op,
             filter.invert,
             parent_logical_op,
             parent_invert,
@@ -85,8 +87,9 @@ class Optimizer:
                 rules_with_selected_handles.append(set(item.selected_handles))
         if rules_with_selected_handles:
             LOG.debug(
-                "filter %s: parent_logical_op=%s, parent_invert=%s, invert=%s, op=%s, number of rules with selected_handles=%s",
+                "filter %s: name: %s, parent_logical_op=%s, parent_invert=%s, invert=%s, op=%s, number of rules with selected_handles=%s",
                 filter,
+                filter.name,
                 parent_logical_op,
                 parent_invert,
                 filter.invert,

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -38,13 +38,14 @@ def union(sets):
 
 class Optimizer:
     """
-    Optimizer to use the filter's pre-selected selected_handles
-    to include or exclude.
+    Optimizer uses the filter's pre-selected selected_handles
+    for each rule to reduce the search space.
+    selected_handles is a superset of the final result.
     """
 
     def __init__(self, all_handles, filter):
         """
-        Initialize the collection of selected_handles in the filter list.
+        Compute handles_in for the filter list.
         """
         self.all_handles = all_handles
         self.handles_in = self.compute_potential_handles_for_filter(filter)

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -59,6 +59,9 @@ class Optimizer:
         self.handles_out = set()
 
     def compute_potential_handles_for_filter(self, filter):
+        """
+        Compute the superset of handles which are the result of the supplied filter
+        """
         if len(filter.flist) == 0:
             return self.all_handles
         handlesets = [
@@ -76,6 +79,9 @@ class Optimizer:
         return handles
 
     def compute_potential_handles_for_rule(self, rule):
+        """
+        Compute the superset of handles which are the result of the supplied rule
+        """
         if hasattr(rule, "selected_handles"):
             return rule.selected_handles  # this rule can be optimised
         if hasattr(rule, "find_filter"):

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -74,7 +74,7 @@ class Optimizer:
                     if handles_out is None:
                         handles_out = rule_out
                     else:
-                        handles_out.union(rule_out)
+                        handles_out.intersection(rule_out)
             # elif filter.logical_op in ("or", "one"):
             #    if rule_in is not None:
             #        if handles_in is None:

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -29,7 +29,7 @@ def intersection(sets):
     if len(sets) == 1:
         return sets[0]  # avoid computing x&x when we only have a single set
     else:
-        return reduce(lambda x, y: x & y, sets, set())
+        return reduce(lambda x, y: x & y, sorted(sets, lambda s: len(s)), set())
 
 
 def union(sets):

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -31,7 +31,7 @@ import logging
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import List, Set, TYPE_CHECKING, Tuple, Union
+from typing import List, Set, TYPE_CHECKING, Tuple
 from .rules import Rule
 
 if TYPE_CHECKING:

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -50,6 +50,7 @@ class Optimizer:
     def compute_potential_handles_for_filter(self, filter):
         """
         Compute the superset of handles which are the result of the supplied filter
+        In the worst case, this is self.all_handles
         """
         if len(filter.flist) == 0:
             return self.all_handles
@@ -58,8 +59,10 @@ class Optimizer:
         ]
 
         if filter.logical_op == "and":
+            # the result of filter is contained within the intersection of the sets in handlesets
             handles = intersection(handlesets)
         elif filter.logical_op in ("or", "one"):
+            # the result of filter is contained within the union of the sets in handlesets
             handles = union(handlesets)
 
         if filter.invert:
@@ -70,16 +73,19 @@ class Optimizer:
     def compute_potential_handles_for_rule(self, rule):
         """
         Compute the superset of handles which are the result of the supplied rule
+        In the worst case, this is self.all_handles
         """
         if hasattr(rule, "selected_handles"):
-            return rule.selected_handles  # this rule can be optimised
+            # this rule has provided a superset of handles that 
+            # contain the result of the rule
+            return rule.selected_handles
         if hasattr(rule, "find_filter"):
             filter = rule.find_filter()
             if filter:
                 return self.compute_potential_handles_for_filter(filter)
         return (
             self.all_handles
-        )  # no optimization possible so assume all handles could match the rule
+        )  # no optimization ispossible so assume all handles could match the rule
 
     def get_handles(self):
         """

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -56,9 +56,7 @@ def union(sets: List[Set[PrimaryObjectHandle]]) -> Set[PrimaryObjectHandle]:
 class Optimizer:
     def compute_potential_handles_for_filter(
         self, filter: GenericFilter
-    ) -> Tuple[
-        Set[PrimaryObjectHandle] | None, Set[PrimaryObjectHandle] | None
-    ]:
+    ) -> Tuple[Set[PrimaryObjectHandle] | None, Set[PrimaryObjectHandle] | None]:
         if len(filter.flist) == 0:
             return (None, None)
 
@@ -97,9 +95,7 @@ class Optimizer:
     def compute_potential_handles_for_rule(
         self,
         rule: Rule,
-    ) -> Tuple[
-        Set[PrimaryObjectHandle] |None, Set[PrimaryObjectHandle] | None
-    ]:
+    ) -> Tuple[Set[PrimaryObjectHandle] | None, Set[PrimaryObjectHandle] | None]:
         """ """
         if hasattr(rule, "selected_handles"):
             return (rule.selected_handles, None)

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -65,8 +65,8 @@ class Optimizer:
         handles_in = None
         handles_out = None
         for rule in filter.flist:
-            rule_in, rule_out = self.compute_potential_handles_for_rule(rule)
             if filter.logical_op == "and":
+                rule_in, rule_out = self.compute_potential_handles_for_rule(rule)
                 if rule_in is not None:
                     if handles_in is None:
                         handles_in = rule_in

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -31,9 +31,10 @@ import logging
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import List, Set
+from typing import List, Set, TYPE_CHECKING
 from .rules import Rule
-from . import GenericFilter
+if TYPE_CHECKING:
+    from ._genericfilter import GenericFilter
 from ..types import PrimaryObjectHandle
 
 LOG = logging.getLogger(".filter.optimizer")

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -79,7 +79,7 @@ class Optimizer:
                 if rule_filter is not None:
                     self.walk_filters(
                         rule_filter,
-                        filter.logical_op,
+                        parent_logical_op,
                         current_invert,
                         result,
                     )

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -33,7 +33,7 @@ def intersection(sets):
 
 
 def union(sets):
-    return reduce(lambda x, y: x | y, sets, set())
+    return set.union(*sets)
 
 
 class Optimizer:

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -31,7 +31,8 @@ import logging
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import List, Set, TYPE_CHECKING, Tuple
+from typing import Any, Callable, List, Set, TYPE_CHECKING, Tuple
+from typing_extensions import assert_never
 from .rules import Rule
 
 if TYPE_CHECKING:
@@ -45,24 +46,52 @@ class Optimizer:
     def compute_potential_handles_for_filter(
         self, filter: GenericFilter
     ) -> Tuple[Set[PrimaryObjectHandle] | None, Set[PrimaryObjectHandle] | None]:
-        if len(filter.flist) == 0:
-            return (None, None)
-
         handles_in = None
         handles_out = None
+
+        handles_in_set_op: Callable[
+            [Set[PrimaryObjectHandle], *Tuple[Set[PrimaryObjectHandle], ...]],
+            Set[PrimaryObjectHandle],
+        ]
+        handles_out_set_op: Callable[
+            [Set[PrimaryObjectHandle], *Tuple[Set[PrimaryObjectHandle], ...]],
+            Set[PrimaryObjectHandle],
+        ]
+        if filter.logical_op == "and" or len(filter.flist) == 1:
+            handles_in_set_op = set.intersection
+            handles_out_set_op = set.union
+            support_unoptimized_rule = True
+        elif filter.logical_op == "or":
+            handles_in_set_op = set.union
+            handles_out_set_op = set.intersection
+            support_unoptimized_rule = False  # with a logical_op of "or" it is not possible to optimize this filter if any rule is unoptimized
+        elif filter.logical_op == "one":
+            handles_in_set_op = set.difference
+            handles_out_set_op = set.intersection
+            support_unoptimized_rule = False  # with a logical_op of "one" it is not possible to optimize this filter if any rule is unoptimized
+        else:
+            assert_never(filter.logical_op)
+
         for rule in filter.flist:
-            if filter.logical_op == "and" or len(filter.flist) == 1:
-                rule_in, rule_out = self.compute_potential_handles_for_rule(rule)
-                if rule_in is not None:
-                    if handles_in is None:
-                        handles_in = rule_in
-                    else:
-                        handles_in = handles_in.intersection(rule_in)
-                if rule_out is not None:
-                    if handles_out is None:
-                        handles_out = rule_out
-                    else:
-                        handles_out = handles_out.union(rule_out)
+            rule_in, rule_out = self.compute_potential_handles_for_rule(rule)
+
+            if rule_in is not None:
+                if handles_in is None:
+                    handles_in = rule_in
+                else:
+                    handles_in = handles_in_set_op(handles_in, rule_in)
+            elif not support_unoptimized_rule:
+                # this rule is not optimized
+                # so break and return (None, None)
+                handles_in = None
+                handles_out = None
+                break
+
+            if rule_out is not None:
+                if handles_out is None:
+                    handles_out = rule_out
+                else:
+                    handles_out = handles_out_set_op(handles_out, rule_out)
 
         if filter.invert:
             handles_in, handles_out = handles_out, handles_in
@@ -70,14 +99,14 @@ class Optimizer:
         return handles_in, handles_out
 
     def compute_potential_handles_for_rule(
-        self,
-        rule: Rule,
+        self, rule: Rule
     ) -> Tuple[Set[PrimaryObjectHandle] | None, Set[PrimaryObjectHandle] | None]:
         """ """
         if hasattr(rule, "selected_handles"):
-            return (rule.selected_handles, None)
+            return (rule.selected_handles, set[PrimaryObjectHandle]())
         if hasattr(rule, "find_filter"):
             filter = rule.find_filter()
             if filter:
                 return self.compute_potential_handles_for_filter(filter)
+        # rule is not optimized so return (None, None)
         return (None, None)

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -45,10 +45,10 @@ class Optimizer:
 
     def __init__(self, all_handles, filter):
         """
-        Compute handles_in for the filter list.
+        Compute possible_handles for the filter list.
         """
         self.all_handles = all_handles
-        self.handles_in = self.compute_potential_handles_for_filter(filter)
+        self.possible_handles = self.compute_potential_handles_for_filter(filter)
 
     def compute_potential_handles_for_filter(self, filter):
         """
@@ -90,12 +90,12 @@ class Optimizer:
             self.all_handles
         )  # no optimization ispossible so assume all handles could match the rule
 
-    def get_handles(self):
+    def get_possible_handles(self):
         """
-        Returns handles_in
+        Returns possible_handles
 
-        `handles_in` is a set of handles to include.
+        `possible_handles` is a set of handles to include.
         Then those in the set are a superset of the items that will match.
         """
-        LOG.debug("optimizer handles_in: %s", len(self.handles_in))
-        return self.handles_in
+        LOG.debug("optimizer possible_handles: %s", len(self.possible_handles))
+        return self.possible_handles

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -44,16 +44,6 @@ def union(sets):
         return set()
 
 
-def symmetric_difference(sets):
-    if sets:
-        result = sets[0]
-        for s in sets[1:]:
-            result = result.symmetric_difference(s)
-        return result
-    else:
-        return set()
-
-
 class Optimizer:
     """
     Optimizer to use the filter's pre-selected selected_handles
@@ -77,10 +67,8 @@ class Optimizer:
 
         if filter.logical_op == "and":
             handles = intersection(handlesets)
-        elif filter.logical_op == "or":
+        elif filter.logical_op in ("or", "one"):
             handles = union(handlesets)
-        elif filter.logical_op == "one":
-            handles = symmetric_difference(handlesets)
 
         if filter.invert:
             handles = self.all_handles.difference(handles)

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -98,7 +98,7 @@ class Optimizer:
         self,
         rule: Rule,
     ) -> Tuple[
-        Union[Set[PrimaryObjectHandle], None], Union[Set[PrimaryObjectHandle], None]
+        Set[PrimaryObjectHandle] |None, Set[PrimaryObjectHandle] | None
     ]:
         """ """
         if hasattr(rule, "selected_handles"):

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -62,13 +62,15 @@ class Optimizer:
             handles_out_set_op = set.union
             support_unoptimized_rule = True
         elif filter.logical_op == "or":
-            handles_in_set_op = set.union
-            handles_out_set_op = set.intersection
-            support_unoptimized_rule = False  # with a logical_op of "or" it is not possible to optimize this filter if any rule is unoptimized
+            return (None, None)
+            # handles_in_set_op = set.union
+            # handles_out_set_op = set.intersection
+            # support_unoptimized_rule = False  # with a logical_op of "or" it is not possible to optimize this filter if any rule is unoptimized
         elif filter.logical_op == "one":
-            handles_in_set_op = set.difference
-            handles_out_set_op = set.intersection
-            support_unoptimized_rule = False  # with a logical_op of "one" it is not possible to optimize this filter if any rule is unoptimized
+            return (None, None)
+            # handles_in_set_op = set.difference
+            # handles_out_set_op = set.intersection
+            # support_unoptimized_rule = False  # with a logical_op of "one" it is not possible to optimize this filter if any rule is unoptimized
         else:
             assert_never(filter.logical_op)
 
@@ -103,7 +105,7 @@ class Optimizer:
     ) -> Tuple[Set[PrimaryObjectHandle] | None, Set[PrimaryObjectHandle] | None]:
         """ """
         if hasattr(rule, "selected_handles"):
-            return (rule.selected_handles, set[PrimaryObjectHandle]())
+            return (rule.selected_handles, None)
         if hasattr(rule, "find_filter"):
             filter = rule.find_filter()
             if filter:

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -19,7 +19,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from functools import reduce
 import logging
 
 LOG = logging.getLogger(".filter.optimizer")

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -74,7 +74,7 @@ class Optimizer:
                     if handles_out is None:
                         handles_out = rule_out
                     else:
-                        handles_out.intersection(rule_out)
+                        handles_out.union(rule_out)
             # elif filter.logical_op in ("or", "one"):
             #    if rule_in is not None:
             #        if handles_in is None:

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -33,6 +33,7 @@ import logging
 # -------------------------------------------------------------------------
 from typing import List, Set, TYPE_CHECKING
 from .rules import Rule
+
 if TYPE_CHECKING:
     from ._genericfilter import GenericFilter
 from ..types import PrimaryObjectHandle

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -97,7 +97,8 @@ class Optimizer:
         """
         Returns possible_handles
 
-        `possible_handles` is a superset of the handles that will match the filter.
+        `possible_handles` is a superset of the handles in `all_handles` that will
+        match the filter.
         """
         LOG.debug("optimizer possible_handles: %s", len(self.possible_handles))
         return self.possible_handles

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -2,6 +2,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2024  Doug Blank <doug.blank@gmail.com>
+# Copyright (C) 2025  Steve Youngs <steve@youngs.cc>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -54,18 +55,19 @@ class Optimizer:
         Initialize the collection of selected_handles in the filter list.
         """
         self.all_selected_handles = []
-        self.walk_filters(filter, False, self.all_selected_handles)
+        self.walk_filters(filter, filter.logical_op, False, self.all_selected_handles)
 
-    def walk_filters(self, filter, parent_invert, result):
+    def walk_filters(self, filter, parent_logical_op, parent_invert, result):
         """
         Recursively walk all of the filters/rules and get
         rules with selected_handles
         """
         current_invert = parent_invert if not filter.invert else not parent_invert
         LOG.debug(
-            "walking, filter: %s, invert=%s, parent_invert=%s",
+            "walking, filter: %s, invert=%s, parent_logical_op=%s, parent_invert=%s",
             filter,
             filter.invert,
+            parent_logical_op,
             parent_invert,
         )
         rules_with_selected_handles = []
@@ -75,6 +77,7 @@ class Optimizer:
                 if rule_filter is not None:
                     self.walk_filters(
                         rule_filter,
+                        filter.logical_op,
                         current_invert,
                         result,
                     )
@@ -82,8 +85,9 @@ class Optimizer:
                 rules_with_selected_handles.append(set(item.selected_handles))
         if rules_with_selected_handles:
             LOG.debug(
-                "filter %s: parent_invert=%s, invert=%s, op=%s, number of rules with selected_handles=%s",
+                "filter %s: parent_logical_op=%s, parent_invert=%s, invert=%s, op=%s, number of rules with selected_handles=%s",
                 filter,
+                parent_logical_op,
                 parent_invert,
                 filter.invert,
                 filter.logical_op,
@@ -92,7 +96,7 @@ class Optimizer:
             result.append(
                 (
                     current_invert,
-                    filter.logical_op,
+                    parent_logical_op,
                     rules_with_selected_handles,
                 )
             )

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -27,7 +27,7 @@ LOG = logging.getLogger(".filter.optimizer")
 
 def intersection(sets):
     # sort the sets by length, shortest first.
-    # with interrsection, the shortest of the starting sets determines the 
+    # with interrsection, the shortest of the starting sets determines the
     # maximum size of the result
     sorted_sets = sorted(sets, key=lambda s: len(s))
     return reduce(lambda x, y: x & y, sorted_sets[1:], sorted_sets[0])

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -29,7 +29,11 @@ def intersection(sets):
     if len(sets) == 1:
         return sets[0]  # avoid computing x&x when we only have a single set
     else:
-        return reduce(lambda x, y: x & y, sorted(sets, key=lambda s: len(s)), set())
+        # sort the sets by length, shortest first.
+        # with interrsection, the shortest of the starting sets determines the 
+        # maximum size of the result
+        sorted_sets = sorted(sets, key=lambda s: len(s))
+        return reduce(lambda x, y: x & y, sorted_sets[1:], sorted_sets[0])
 
 
 def union(sets):

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -26,7 +26,10 @@ LOG = logging.getLogger(".filter.optimizer")
 
 
 def intersection(sets):
-    return reduce(lambda x, y: x & y, sets, sets[0] if sets else set())
+    if len(sets) == 1:
+        return sets[0]  # avoid computing x&x when we only have a single set
+    else:
+        return reduce(lambda x, y: x & y, sets, set())
 
 
 def union(sets):

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -63,29 +63,18 @@ class Optimizer:
         handles_in = None
         handles_out = None
         for rule in filter.flist:
-            if filter.logical_op == "and":
+            if filter.logical_op == "and" or len(filter.flist) == 1:
                 rule_in, rule_out = self.compute_potential_handles_for_rule(rule)
                 if rule_in is not None:
                     if handles_in is None:
                         handles_in = rule_in
                     else:
-                        handles_in.intersection(rule_in)
+                        handles_in = handles_in.intersection(rule_in)
                 if rule_out is not None:
                     if handles_out is None:
                         handles_out = rule_out
                     else:
-                        handles_out.intersection(rule_out)
-            # elif filter.logical_op in ("or", "one"):
-            #    if rule_in is not None:
-            #        if handles_in is None:
-            #            handles_in = rule_in
-            #        else:
-            #            handles_in.union(rule_in)
-            #    if rule_out is not None:
-            #        if handles_out is None:
-            #            handles_out = rule_out
-            #        else:
-            #            handles_out.union(rule_out)
+                        handles_out = handles_out.union(rule_out)
 
         if filter.invert:
             handles_in, handles_out = handles_out, handles_in

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -40,7 +40,10 @@ class Optimizer:
     """
     Optimizer uses the filter's pre-selected selected_handles
     for each rule to reduce the search space.
-    selected_handles is a superset of the final result.
+    selected_handles is a superset of the final result of the rule.
+    the selected_handles of each rule in each filter of the filter list
+    are combined to create `possible_handles`, the superset of the result
+    of the filter list.
     """
 
     def __init__(self, all_handles, filter):
@@ -94,8 +97,7 @@ class Optimizer:
         """
         Returns possible_handles
 
-        `possible_handles` is a set of handles to include.
-        Then those in the set are a superset of the items that will match.
+        `possible_handles` is a superset of the handles that will match the filter.
         """
         LOG.debug("optimizer possible_handles: %s", len(self.possible_handles))
         return self.possible_handles

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -31,7 +31,7 @@ import logging
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import List, Set, TYPE_CHECKING
+from typing import List, Set, TYPE_CHECKING, Tuple, Union
 from .rules import Rule
 
 if TYPE_CHECKING:
@@ -56,7 +56,7 @@ def union(sets: List[Set[PrimaryObjectHandle]]) -> Set[PrimaryObjectHandle]:
 class Optimizer:
     def compute_potential_handles_for_filter(
         self, filter: GenericFilter
-    ) -> Set[PrimaryObjectHandle]:
+    ) -> Tuple[Union[Set[PrimaryObjectHandle], None], Union[Set[PrimaryObjectHandle], None]]:
         if len(filter.flist) == 0:
             return (None, None)
 
@@ -95,7 +95,7 @@ class Optimizer:
     def compute_potential_handles_for_rule(
         self,
         rule: Rule,
-    ) -> Set[PrimaryObjectHandle]:
+    ) -> Tuple[Union[Set[PrimaryObjectHandle], None], Union[Set[PrimaryObjectHandle], None]]:
         """ """
         if hasattr(rule, "selected_handles"):
             return (rule.selected_handles, None)

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -29,7 +29,7 @@ def intersection(sets):
     if len(sets) == 1:
         return sets[0]  # avoid computing x&x when we only have a single set
     else:
-        return reduce(lambda x, y: x & y, sorted(sets, lambda s: len(s)), set())
+        return reduce(lambda x, y: x & y, sorted(sets, key=lambda s: len(s)), set())
 
 
 def union(sets):

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -18,13 +18,28 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+from __future__ import annotations
 import logging
+
+# -------------------------------------------------------------------------
+#
+# Typing modules
+#
+# -------------------------------------------------------------------------
+from typing import List, Set
+from .rules import Rule
+from . import GenericFilter
+from ..types import PrimaryObjectHandle
 
 LOG = logging.getLogger(".filter.optimizer")
 
 
-def intersection(sets):
+def intersection(sets: List[Set[PrimaryObjectHandle]]) -> Set[PrimaryObjectHandle]:
     # sort the sets by length, shortest first.
     # with intersection, the shortest of the starting sets determines the
     # maximum size of the result
@@ -32,7 +47,7 @@ def intersection(sets):
     return set.intersection(*sorted_sets)
 
 
-def union(sets):
+def union(sets: List[Set[PrimaryObjectHandle]]) -> Set[PrimaryObjectHandle]:
     return set.union(*sets)
 
 
@@ -46,21 +61,23 @@ class Optimizer:
     of the filter list.
     """
 
-    def __init__(self, all_handles, filter):
+    def __init__(self, all_handles: Set[PrimaryObjectHandle], filter: GenericFilter):
         """
         Compute possible_handles for the filter list.
         """
         self.all_handles = all_handles
         self.possible_handles = self.compute_potential_handles_for_filter(filter)
 
-    def compute_potential_handles_for_filter(self, filter):
+    def compute_potential_handles_for_filter(
+        self, filter: GenericFilter
+    ) -> Set[PrimaryObjectHandle]:
         """
         Compute the superset of handles which are the result of the supplied filter
         In the worst case, this is self.all_handles
         """
         if len(filter.flist) == 0:
             return self.all_handles
-        handlesets = [
+        handlesets: List[Set[PrimaryObjectHandle]] = [
             self.compute_potential_handles_for_rule(rule) for rule in filter.flist
         ]
 
@@ -76,7 +93,9 @@ class Optimizer:
 
         return handles
 
-    def compute_potential_handles_for_rule(self, rule):
+    def compute_potential_handles_for_rule(
+        self, rule: Rule
+    ) -> Set[PrimaryObjectHandle]:
         """
         Compute the superset of handles which are the result of the supplied rule
         In the worst case, this is self.all_handles
@@ -94,7 +113,7 @@ class Optimizer:
         )  # no optimization is possible so assume all the handles in
         # `all_handles` could match the rule
 
-    def get_possible_handles(self):
+    def get_possible_handles(self) -> Set[PrimaryObjectHandle]:
         """
         Returns possible_handles
 

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -45,7 +45,6 @@ class Optimizer:
         """
         self.all_handles = all_handles
         self.handles_in = self.compute_potential_handles_for_filter(filter)
-        self.handles_out = set()
 
     def compute_potential_handles_for_filter(self, filter):
         """
@@ -89,17 +88,13 @@ class Optimizer:
 
     def get_handles(self):
         """
-        Returns handles_in, and handles_out.
+        Returns handles_in
 
         `handles_in` is a set of handles to include.
         Then those in the set are a superset of the items that will match.
-
-        `handles_out` is a set. If any handle is in the set, it will
-        not be included in the final results.
         """
         LOG.debug(
-            "optimizer handles_in: %s, handles_out: %s",
-            len(self.handles_in),
-            len(self.handles_out),
+            "optimizer handles_in: %s",
+            len(self.handles_in)
         )
-        return self.handles_in, self.handles_out
+        return self.handles_in

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -26,14 +26,11 @@ LOG = logging.getLogger(".filter.optimizer")
 
 
 def intersection(sets):
-    if len(sets) == 1:
-        return sets[0]  # avoid computing x&x when we only have a single set
-    else:
-        # sort the sets by length, shortest first.
-        # with interrsection, the shortest of the starting sets determines the 
-        # maximum size of the result
-        sorted_sets = sorted(sets, key=lambda s: len(s))
-        return reduce(lambda x, y: x & y, sorted_sets[1:], sorted_sets[0])
+    # sort the sets by length, shortest first.
+    # with interrsection, the shortest of the starting sets determines the 
+    # maximum size of the result
+    sorted_sets = sorted(sets, key=lambda s: len(s))
+    return reduce(lambda x, y: x & y, sorted_sets[1:], sorted_sets[0])
 
 
 def union(sets):

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -41,18 +41,6 @@ from ..types import PrimaryObjectHandle
 LOG = logging.getLogger(".filter.optimizer")
 
 
-def intersection(sets: List[Set[PrimaryObjectHandle]]) -> Set[PrimaryObjectHandle]:
-    # sort the sets by length, shortest first.
-    # with intersection, the shortest of the starting sets determines the
-    # maximum size of the result
-    sorted_sets = sorted(sets, key=lambda s: len(s))
-    return set.intersection(*sorted_sets)
-
-
-def union(sets: List[Set[PrimaryObjectHandle]]) -> Set[PrimaryObjectHandle]:
-    return set.union(*sets)
-
-
 class Optimizer:
     def compute_potential_handles_for_filter(
         self, filter: GenericFilter

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -30,7 +30,7 @@ def intersection(sets):
     # with interrsection, the shortest of the starting sets determines the
     # maximum size of the result
     sorted_sets = sorted(sets, key=lambda s: len(s))
-    return reduce(lambda x, y: x & y, sorted_sets[1:], sorted_sets[0])
+    return set.intersection(*sorted_sets)
 
 
 def union(sets):

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -75,7 +75,7 @@ class Optimizer:
         In the worst case, this is self.all_handles
         """
         if hasattr(rule, "selected_handles"):
-            # this rule has provided a superset of handles that 
+            # this rule has provided a superset of handles that
             # contain the result of the rule
             return rule.selected_handles
         if hasattr(rule, "find_filter"):
@@ -93,8 +93,5 @@ class Optimizer:
         `handles_in` is a set of handles to include.
         Then those in the set are a superset of the items that will match.
         """
-        LOG.debug(
-            "optimizer handles_in: %s",
-            len(self.handles_in)
-        )
+        LOG.debug("optimizer handles_in: %s", len(self.handles_in))
         return self.handles_in

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -57,7 +57,7 @@ class Optimizer:
     def compute_potential_handles_for_filter(
         self, filter: GenericFilter
     ) -> Tuple[
-        Union[Set[PrimaryObjectHandle], None], Union[Set[PrimaryObjectHandle], None]
+        Set[PrimaryObjectHandle] | None, Set[PrimaryObjectHandle] | None
     ]:
         if len(filter.flist) == 0:
             return (None, None)

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -91,7 +91,8 @@ class Optimizer:
                 return self.compute_potential_handles_for_filter(filter)
         return (
             self.all_handles
-        )  # no optimization ispossible so assume all handles could match the rule
+        )  # no optimization is possible so assume all the handles in
+        # `all_handles` could match the rule
 
     def get_possible_handles(self):
         """

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -44,6 +44,16 @@ def union(sets):
         return set()
 
 
+def symmetric_difference(sets):
+    if sets:
+        result = sets[0]
+        for s in sets[1:]:
+            result = result.symmetric_difference(s)
+        return result
+    else:
+        return set()
+
+
 class Optimizer:
     """
     Optimizer to use the filter's pre-selected selected_handles
@@ -67,8 +77,10 @@ class Optimizer:
 
         if filter.logical_op == "and":
             handles = intersection(handlesets)
-        elif filter.logical_op in ("or", "one"):
+        elif filter.logical_op == "or":
             handles = union(handlesets)
+        elif filter.logical_op == "one":
+            handles = symmetric_difference(handlesets)
 
         if filter.invert:
             handles = self.all_handles.difference(handles)

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -26,7 +26,7 @@ LOG = logging.getLogger(".filter.optimizer")
 
 def intersection(sets):
     # sort the sets by length, shortest first.
-    # with interrsection, the shortest of the starting sets determines the
+    # with intersection, the shortest of the starting sets determines the
     # maximum size of the result
     sorted_sets = sorted(sets, key=lambda s: len(s))
     return set.intersection(*sorted_sets)

--- a/gramps/gen/filters/optimizer.py
+++ b/gramps/gen/filters/optimizer.py
@@ -56,7 +56,9 @@ def union(sets: List[Set[PrimaryObjectHandle]]) -> Set[PrimaryObjectHandle]:
 class Optimizer:
     def compute_potential_handles_for_filter(
         self, filter: GenericFilter
-    ) -> Tuple[Union[Set[PrimaryObjectHandle], None], Union[Set[PrimaryObjectHandle], None]]:
+    ) -> Tuple[
+        Union[Set[PrimaryObjectHandle], None], Union[Set[PrimaryObjectHandle], None]
+    ]:
         if len(filter.flist) == 0:
             return (None, None)
 
@@ -95,7 +97,9 @@ class Optimizer:
     def compute_potential_handles_for_rule(
         self,
         rule: Rule,
-    ) -> Tuple[Union[Set[PrimaryObjectHandle], None], Union[Set[PrimaryObjectHandle], None]]:
+    ) -> Tuple[
+        Union[Set[PrimaryObjectHandle], None], Union[Set[PrimaryObjectHandle], None]
+    ]:
         """ """
         if hasattr(rule, "selected_handles"):
             return (rule.selected_handles, None)

--- a/gramps/gen/filters/rules/person/_isdescendantfamilyof.py
+++ b/gramps/gen/filters/rules/person/_isdescendantfamilyof.py
@@ -114,7 +114,8 @@ class IsDescendantFamilyOf(Rule):
                         spouse_handle = family.mother_handle
                     else:
                         spouse_handle = family.father_handle
-                    self.selected_handles.add(spouse_handle)
+                    if spouse_handle:
+                        self.selected_handles.add(spouse_handle)
 
     def exclude(self):
         # This removes root person and his/her spouses from the matches set

--- a/gramps/gen/filters/rules/test/place_rules_test.py
+++ b/gramps/gen/filters/rules/test/place_rules_test.py
@@ -70,13 +70,13 @@ class BaseTest(unittest.TestCase):
         """
         cls.db = import_as_dict(EXAMPLE, User())
 
-    def filter_with_rule(self, rule):
+    def filter_with_rule(self, rule, tree=False):
         """
         Apply a filter with the given rule.
         """
         filter_ = GenericPlaceFilter()
         filter_.add_rule(rule)
-        results = filter_.apply(self.db)
+        results = filter_.apply(self.db, tree=tree)
         return set(results)
 
     def test_allplaces(self):
@@ -86,6 +86,15 @@ class BaseTest(unittest.TestCase):
         rule = AllPlaces([])
         self.assertEqual(
             len(self.filter_with_rule(rule)), self.db.get_number_of_places()
+        )
+
+    def test_hascitation_with_tree(self):
+        """
+        Test AllPlaces rule.
+        """
+        rule = HasCitation(["page 23", "", ""])
+        self.assertEqual(
+            self.filter_with_rule(rule, tree=True), set(["YNUJQC8YM5EGRG868J"])
         )
 
     def test_hascitation(self):

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -90,47 +90,49 @@ class OptimizerTest(unittest.TestCase):
         fl = FilterList("")
         fl.loadString(custom_filters_xml)
 
-        filters.set_custom_filters(fl)
-        cls.the_custom_filters = filters.CustomFilters.get_filters_dict("Person")
-        cls.filters = fl.get_filters_dict("Person")
-        for filter_name in cls.filters:
-            cls.the_custom_filters[filter_name] = cls.filters[filter_name]
+        # filters.set_custom_filters(fl)
+        # cls.the_custom_filters = filters.CustomFilters.get_filters_dict("Person")
+        # cls.filters = fl.get_filters_dict("Person")
+        # for filter_name in cls.filters:
+        #     cls.the_custom_filters[filter_name] = cls.filters[filter_name]
 
     @classmethod
     def tearDownClass(self):
-        filters.set_custom_filters(None)
+        # filters.set_custom_filters(None)
+        pass
 
     def test_ancestors_of(self):
-        filter = self.filters["Ancestors of"]
-        results = filter.apply(self.db)
-        self.assertEqual(len(results), 7)
+        pass
+    #     filter = self.filters["Ancestors of"]
+    #     results = filter.apply(self.db)
+    #     self.assertEqual(len(results), 7)
 
-    def test_siblings_of_ancestors(self):
-        filter = self.filters["Siblings of Ancestors"]
-        results = filter.apply(self.db)
-        self.assertEqual(len(results), 18)
+    # def test_siblings_of_ancestors(self):
+    #     filter = self.filters["Siblings of Ancestors"]
+    #     results = filter.apply(self.db)
+    #     self.assertEqual(len(results), 18)
 
-    def test_family_and_their_spouses(self):
-        filter = self.filters["Family and their Spouses"]
-        results = filter.apply(self.db)
-        self.assertEqual(len(results), 25)
+    # def test_family_and_their_spouses(self):
+    #     filter = self.filters["Family and their Spouses"]
+    #     results = filter.apply(self.db)
+    #     self.assertEqual(len(results), 25)
 
-    def test_everyone(self):
-        filter = self.filters["Everyone"]
-        results = filter.apply(self.db)
-        self.assertEqual(len(results), 2128)
+    # def test_everyone(self):
+    #     filter = self.filters["Everyone"]
+    #     results = filter.apply(self.db)
+    #     self.assertEqual(len(results), 2128)
 
-    def test_f1(self):
-        filter = self.filters["F1"]
-        results = filter.apply(self.db)
-        self.assertEqual(len(results), 2128)
+    # def test_f1(self):
+    #     filter = self.filters["F1"]
+    #     results = filter.apply(self.db)
+    #     self.assertEqual(len(results), 2128)
 
-    def test_f2(self):
-        filter = self.filters["F2"]
-        results = filter.apply(self.db)
-        self.assertEqual(len(results), 16)
+    # def test_f2(self):
+    #     filter = self.filters["F2"]
+    #     results = filter.apply(self.db)
+    #     self.assertEqual(len(results), 16)
 
-    def test_f3(self):
-        filter = self.filters["F3"]
-        results = filter.apply(self.db)
-        self.assertEqual(len(results), 16)
+    # def test_f3(self):
+    #     filter = self.filters["F3"]
+    #     results = filter.apply(self.db)
+    #     self.assertEqual(len(results), 16)

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -1,0 +1,77 @@
+from gramps.gen.filters import FilterList
+import tempfile
+import os
+import unittest
+
+from ...const import DATA_DIR
+from ...db.utils import import_as_dict
+from ...user import User
+from ...filters import reload_custom_filters
+
+reload_custom_filters()
+
+from ...filters import CustomFilters
+
+
+custom_filters_xml = """<?xml version="1.0" encoding="utf-8"?>
+<filters>
+  <object type="Person">
+    <filter name="Ancestors of" function="and">
+      <rule class="IsAncestorOf" use_regex="False" use_case="False">
+        <arg value="I0044"/>
+        <arg value="1"/>
+      </rule>
+    </filter>
+    <filter name="Family and their Spouses" function="or">
+      <rule class="MatchesFilter" use_regex="False" use_case="False">
+        <arg value="Ancestors of"/>
+      </rule>
+      <rule class="MatchesFilter" use_regex="False" use_case="False">
+        <arg value="Siblings of Ancestors"/>
+      </rule>
+    </filter>
+    <filter name="Siblings of Ancestors" function="and">
+      <rule class="IsSiblingOfFilterMatch" use_regex="False" use_case="False">
+        <arg value="Ancestors of"/>
+      </rule>
+    </filter>
+  </object>
+</filters>
+"""
+TEST_DIR = os.path.abspath(os.path.join(DATA_DIR, "tests"))
+EXAMPLE = os.path.join(TEST_DIR, "example.gramps")
+
+
+class OptimizerTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """
+        Import example database.
+        """
+        cls.db = import_as_dict(EXAMPLE, User())
+
+        with tempfile.NamedTemporaryFile(mode="w+", encoding="utf8") as tmp_file:
+            tmp_file.write(custom_filters_xml)
+            tmp_file.seek(0)
+            fl = FilterList(tmp_file.name)
+            fl.load()
+
+        the_custom_filters = CustomFilters.get_filters_dict("Person")
+        cls.filters = fl.get_filters_dict("Person")
+        for filter_name in cls.filters:
+            the_custom_filters[filter_name] = cls.filters[filter_name]
+
+    def test_ancestors_of(self):
+        filter = self.filters["Ancestors of"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 7)
+
+    def test_siblings_of_ancestors(self):
+        filter = self.filters["Siblings of Ancestors"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 18)
+
+    def test_family_and_their_spouses(self):
+        filter = self.filters["Family and their Spouses"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 25)

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -21,7 +21,6 @@
 import tempfile
 import os
 import unittest
-import pytest
 
 from ...const import DATA_DIR
 from ...db.utils import import_as_dict
@@ -183,9 +182,12 @@ class OptimizerTest(unittest.TestCase):
         filter = self.filters["Everyone"]
         default_person = self.db.get_default_person()
         id_list = [(default_person, default_person.handle)]
-        with pytest.raises(IndexError) as excinfo:
+        raised = False
+        try:
             results = filter.apply(self.db, id_list=id_list, tupleind=3)
-        self.assertEqual(str(excinfo.value), "tuple index out of range")
+        except IndexError:
+            raised = True
+        self.assertTrue(raised)
 
     def test_everyone_with_id_list_empty(self):
         filter = self.filters["Everyone"]

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -156,6 +156,12 @@ class OptimizerTest(unittest.TestCase):
         results = filter.apply(self.db)
         self.assertEqual(len(results), 2128)
 
+    def test_everyone_with_id_list(self):
+        filter = self.filters["Everyone"]
+        id_list = [self.db.get_default_handle()]
+        results = filter.apply(self.db, id_list=id_list)
+        self.assertEqual(len(results), 1)
+
     def test_f1(self):
         filter = self.filters["F1"]
         results = filter.apply(self.db)

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -1,3 +1,23 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025 Doug Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
 import tempfile
 import os
 import unittest

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -72,7 +72,31 @@ custom_filters_xml = """<?xml version="1.0" encoding="utf-8"?>
         <arg value="0"/>
       </rule>
     </filter>
-  </object>
+    <filter name="I0001 xor I0002" function="one">
+      <rule class="HasIdOf" use_regex="False" use_case="False">
+        <arg value="I0001"/>
+      </rule>
+      <rule class="HasIdOf" use_regex="False" use_case="False">
+        <arg value="I0002"/>
+      </rule>
+    </filter>
+    <filter name="I0001 or I0002" function="or">
+      <rule class="HasIdOf" use_regex="False" use_case="False">
+        <arg value="I0001"/>
+      </rule>
+      <rule class="HasIdOf" use_regex="False" use_case="False">
+        <arg value="I0002"/>
+      </rule>
+    </filter>
+    <filter name="I0001 and I0002" function="and">
+      <rule class="HasIdOf" use_regex="False" use_case="False">
+        <arg value="I0001"/>
+      </rule>
+      <rule class="HasIdOf" use_regex="False" use_case="False">
+        <arg value="I0002"/>
+      </rule>
+    </filter>
+    </object>
 </filters>
 """
 TEST_DIR = os.path.abspath(os.path.join(DATA_DIR, "tests"))
@@ -134,3 +158,18 @@ class OptimizerTest(unittest.TestCase):
         filter = self.filters["F3"]
         results = filter.apply(self.db)
         self.assertEqual(len(results), 16)
+
+    def test_I0001xorI0002(self):
+        filter = self.filters["I0001 xor I0002"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2)
+
+    def test_I0001orI0002(self):
+        filter = self.filters["I0001 or I0002"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2)
+
+    def test_I0001andI0002(self):
+        filter = self.filters["I0001 and I0002"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2)

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -90,19 +90,20 @@ class OptimizerTest(unittest.TestCase):
         fl = FilterList("")
         fl.loadString(custom_filters_xml)
 
-        # filters.set_custom_filters(fl)
-        # cls.the_custom_filters = filters.CustomFilters.get_filters_dict("Person")
+        filters.set_custom_filters(fl)
+        cls.the_custom_filters = filters.CustomFilters.get_filters_dict("Person")
         # cls.filters = fl.get_filters_dict("Person")
         # for filter_name in cls.filters:
         #     cls.the_custom_filters[filter_name] = cls.filters[filter_name]
 
     @classmethod
     def tearDownClass(self):
-        # filters.set_custom_filters(None)
+        filters.set_custom_filters(None)
         pass
 
     def test_ancestors_of(self):
         pass
+
     #     filter = self.filters["Ancestors of"]
     #     results = filter.apply(self.db)
     #     self.assertEqual(len(results), 7)

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -91,48 +91,46 @@ class OptimizerTest(unittest.TestCase):
         fl.loadString(custom_filters_xml)
 
         filters.set_custom_filters(fl)
-        # cls.the_custom_filters = filters.CustomFilters.get_filters_dict("Person")
-        # cls.filters = fl.get_filters_dict("Person")
-        # for filter_name in cls.filters:
-        #     cls.the_custom_filters[filter_name] = cls.filters[filter_name]
+        cls.the_custom_filters = filters.CustomFilters.get_filters_dict("Person")
+        cls.filters = fl.get_filters_dict("Person")
+        for filter_name in cls.filters:
+            cls.the_custom_filters[filter_name] = cls.filters[filter_name]
 
     @classmethod
     def tearDownClass(self):
-        filters.set_custom_filters(None)
+        reload_custom_filters()
 
     def test_ancestors_of(self):
-        pass
+        filter = self.filters["Ancestors of"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 7)
 
-    #     filter = self.filters["Ancestors of"]
-    #     results = filter.apply(self.db)
-    #     self.assertEqual(len(results), 7)
+    def test_siblings_of_ancestors(self):
+        filter = self.filters["Siblings of Ancestors"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 18)
 
-    # def test_siblings_of_ancestors(self):
-    #     filter = self.filters["Siblings of Ancestors"]
-    #     results = filter.apply(self.db)
-    #     self.assertEqual(len(results), 18)
+    def test_family_and_their_spouses(self):
+        filter = self.filters["Family and their Spouses"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 25)
 
-    # def test_family_and_their_spouses(self):
-    #     filter = self.filters["Family and their Spouses"]
-    #     results = filter.apply(self.db)
-    #     self.assertEqual(len(results), 25)
+    def test_everyone(self):
+        filter = self.filters["Everyone"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2128)
 
-    # def test_everyone(self):
-    #     filter = self.filters["Everyone"]
-    #     results = filter.apply(self.db)
-    #     self.assertEqual(len(results), 2128)
+    def test_f1(self):
+        filter = self.filters["F1"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2128)
 
-    # def test_f1(self):
-    #     filter = self.filters["F1"]
-    #     results = filter.apply(self.db)
-    #     self.assertEqual(len(results), 2128)
+    def test_f2(self):
+        filter = self.filters["F2"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 16)
 
-    # def test_f2(self):
-    #     filter = self.filters["F2"]
-    #     results = filter.apply(self.db)
-    #     self.assertEqual(len(results), 16)
-
-    # def test_f3(self):
-    #     filter = self.filters["F3"]
-    #     results = filter.apply(self.db)
-    #     self.assertEqual(len(results), 16)
+    def test_f3(self):
+        filter = self.filters["F3"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 16)

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -182,12 +182,9 @@ class OptimizerTest(unittest.TestCase):
         filter = self.filters["Everyone"]
         default_person = self.db.get_default_person()
         id_list = [(default_person, default_person.handle)]
-        raised = False
-        try:
-            results = filter.apply(self.db, id_list=id_list, tupleind=3)
-        except IndexError:
-            raised = True
-        self.assertTrue(raised)
+        self.assertRaises(
+            IndexError, filter.apply, self.db, id_list=id_list, tupleind=3
+        )
 
     def test_everyone_with_id_list_empty(self):
         filter = self.filters["Everyone"]

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -91,7 +91,7 @@ class OptimizerTest(unittest.TestCase):
         fl.loadString(custom_filters_xml)
 
         filters.set_custom_filters(fl)
-        cls.the_custom_filters = filters.CustomFilters.get_filters_dict("Person")
+        # cls.the_custom_filters = filters.CustomFilters.get_filters_dict("Person")
         # cls.filters = fl.get_filters_dict("Person")
         # for filter_name in cls.filters:
         #     cls.the_custom_filters[filter_name] = cls.filters[filter_name]
@@ -99,7 +99,6 @@ class OptimizerTest(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         filters.set_custom_filters(None)
-        pass
 
     def test_ancestors_of(self):
         pass

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -1,4 +1,3 @@
-from gramps.gen.filters import FilterList
 import tempfile
 import os
 import unittest
@@ -6,12 +5,7 @@ import unittest
 from ...const import DATA_DIR
 from ...db.utils import import_as_dict
 from ...user import User
-from ...filters import reload_custom_filters
-
-reload_custom_filters()
-
-from ...filters import CustomFilters
-
+from ...filters import reload_custom_filters, CustomFilters, FilterList
 
 custom_filters_xml = """<?xml version="1.0" encoding="utf-8"?>
 <filters>
@@ -56,10 +50,16 @@ class OptimizerTest(unittest.TestCase):
             fl = FilterList(tmp_file.name)
             fl.load()
 
-        the_custom_filters = CustomFilters.get_filters_dict("Person")
+        cls.the_custom_filters = CustomFilters.get_filters_dict("Person")
         cls.filters = fl.get_filters_dict("Person")
-        for filter_name in cls.filters:
-            the_custom_filters[filter_name] = cls.filters[filter_name]
+
+    def setUp(self):
+        for filter_name in self.filters:
+            self.the_custom_filters[filter_name] = self.filters[filter_name]
+
+    def tearDown(self):
+        for filter_name in self.filters:
+            CustomFilters.remove("Person", filter_name)
 
     def test_ancestors_of(self):
         filter = self.filters["Ancestors of"]

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -375,3 +375,23 @@ class OptimizerTest(unittest.TestCase):
         filter = self.filters["not (I0001 and I0002)"]
         results = filter.apply(self.db)
         self.assertEqual(len(results), 2128)
+
+    def test_i0001(self):
+        filter = self.filters["I0001"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 1)
+
+    def test_not_i0001(self):
+        filter = self.filters["not I0001"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2127)
+
+    def test_i0002(self):
+        filter = self.filters["I0002"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 1)
+
+    def test_not_i0002(self):
+        filter = self.filters["not I0001"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2127)

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -108,6 +108,16 @@ custom_filters_xml = """<?xml version="1.0" encoding="utf-8"?>
     </filter>
     <filter name="Empty Filter one invert" function="one" invert="1">
     </filter>
+    <filter name="Tag = ToDo" function="and">
+      <rule class="HasTag" use_regex="False" use_case="False">
+        <arg value="ToDo"/>
+      </rule>
+    </filter>
+    <filter name="Tag = ToDo Invert" function="and" invert="1">
+      <rule class="HasTag" use_regex="False" use_case="False">
+        <arg value="ToDo"/>
+      </rule>
+    </filter>
     </object>
 </filters>
 """
@@ -251,3 +261,18 @@ class OptimizerTest(unittest.TestCase):
         filter = self.filters["Empty Filter one invert"]
         results = filter.apply(self.db)
         self.assertEqual(len(results), 2128)
+
+    def test_EmptyFilter_one_invert(self):
+        filter = self.filters["Empty Filter one invert"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2128)
+
+    def test_TagToDo(self):
+        filter = self.filters["Tag = ToDo"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 1)
+
+    def test_TagToDo_invert(self):
+        filter = self.filters["Tag = ToDo Invert"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2127)

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -172,4 +172,4 @@ class OptimizerTest(unittest.TestCase):
     def test_I0001andI0002(self):
         filter = self.filters["I0001 and I0002"]
         results = filter.apply(self.db)
-        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results), 0)

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -96,6 +96,18 @@ custom_filters_xml = """<?xml version="1.0" encoding="utf-8"?>
         <arg value="I0002"/>
       </rule>
     </filter>
+    <filter name="Empty Filter and" function="and">
+    </filter>
+    <filter name="Empty Filter and invert" function="and" invert="1">
+    </filter>
+    <filter name="Empty Filter or" function="or">
+    </filter>
+    <filter name="Empty Filter or invert" function="or" invert="1">
+    </filter>
+    <filter name="Empty Filter one" function="one">
+    </filter>
+    <filter name="Empty Filter one invert" function="one" invert="1">
+    </filter>
     </object>
 </filters>
 """
@@ -173,3 +185,33 @@ class OptimizerTest(unittest.TestCase):
         filter = self.filters["I0001 and I0002"]
         results = filter.apply(self.db)
         self.assertEqual(len(results), 0)
+
+    def test_EmptyFilter_and(self):
+        filter = self.filters["Empty Filter and"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2158)
+
+    def test_EmptyFilter_and_invert(self):
+        filter = self.filters["Empty Filter and invert"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 0)
+
+    def test_EmptyFilter_or(self):
+        filter = self.filters["Empty Filter or"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 0)
+
+    def test_EmptyFilter_or_invert(self):
+        filter = self.filters["Empty Filter or invert"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2158)
+
+    def test_EmptyFilter_one(self):
+        filter = self.filters["Empty Filter one"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 0)
+
+    def test_EmptyFilter_one_invert(self):
+        filter = self.filters["Empty Filter one invert"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2158)

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -87,11 +87,8 @@ class OptimizerTest(unittest.TestCase):
         """
         cls.db = import_as_dict(EXAMPLE, User())
 
-        with tempfile.NamedTemporaryFile(mode="w+", encoding="utf8") as tmp_file:
-            tmp_file.write(custom_filters_xml)
-            tmp_file.seek(0)
-            fl = FilterList(tmp_file.name)
-            fl.load()
+        fl = FilterList("")
+        fl.loadString(custom_filters_xml)
 
         filters.set_custom_filters(fl)
         cls.the_custom_filters = filters.CustomFilters.get_filters_dict("Person")

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -118,7 +118,27 @@ custom_filters_xml = """<?xml version="1.0" encoding="utf-8"?>
         <arg value="ToDo"/>
       </rule>
     </filter>
-    </object>
+    <filter name="Family Name" function="and">
+      <rule class="HasNameOf" use_regex="False" use_case="False">
+        <arg value=""/>
+        <arg value=""/>
+        <arg value=""/>
+        <arg value=""/>
+        <arg value=""/>
+        <arg value=""/>
+        <arg value=""/>
+        <arg value="Garner"/>
+        <arg value=""/>
+        <arg value=""/>
+        <arg value=""/>
+      </rule>
+    </filter>
+    <filter name="NOT Family Name" function="and" invert="1">
+      <rule class="MatchesFilter" use_regex="False" use_case="False">
+        <arg value="Family Name"/>
+      </rule>
+    </filter>
+  </object>
 </filters>
 """
 TEST_DIR = os.path.abspath(os.path.join(DATA_DIR, "tests"))
@@ -271,3 +291,13 @@ class OptimizerTest(unittest.TestCase):
         filter = self.filters["Tag = ToDo Invert"]
         results = filter.apply(self.db)
         self.assertEqual(len(results), 2127)
+
+    def test_family_name(self):
+        filter = self.filters["Family Name"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 71)
+
+    def test_not_family_name(self):
+        filter = self.filters["NOT Family Name"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2128 - 71)

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -96,6 +96,50 @@ custom_filters_xml = """<?xml version="1.0" encoding="utf-8"?>
         <arg value="I0002"/>
       </rule>
     </filter>
+    <filter name="not I0001" function="or" invert="1">
+      <rule class="HasIdOf" use_regex="False" use_case="False">
+        <arg value="I0001"/>
+      </rule>
+    </filter>
+    <filter name="not I0002" function="or" invert="1">
+      <rule class="HasIdOf" use_regex="False" use_case="False">
+        <arg value="I0002"/>
+      </rule>
+    </filter>
+    <filter name="(not I0001) and (not I0002)" function="and">
+      <rule class="MatchesFilter" use_regex="False" use_case="False">
+        <arg value="not I0001"/>
+      </rule>
+      <rule class="MatchesFilter" use_regex="False" use_case="False">
+        <arg value="not I0002"/>
+      </rule>
+    </filter>
+    <filter name="(not I0001) or (not I0002)" function="or">
+      <rule class="MatchesFilter" use_regex="False" use_case="False">
+        <arg value="not I0001"/>
+      </rule>
+      <rule class="MatchesFilter" use_regex="False" use_case="False">
+        <arg value="not I0002"/>
+      </rule>
+    </filter>
+
+    <filter name="not ((not I0001) and (not I0002))" function="and" invert="1">
+      <rule class="MatchesFilter" use_regex="False" use_case="False">
+        <arg value="not I0001"/>
+      </rule>
+      <rule class="MatchesFilter" use_regex="False" use_case="False">
+        <arg value="not I0002"/>
+      </rule>
+    </filter>
+
+    <filter name="not (I0001 and I0002)" function="and" invert="1">
+      <rule class="MatchesFilter" use_regex="False" use_case="False">
+        <arg value="I0001"/>
+      </rule>
+      <rule class="MatchesFilter" use_regex="False" use_case="False">
+        <arg value="I0002"/>
+      </rule>
+    </filter>
     <filter name="Empty Filter and" function="and">
     </filter>
     <filter name="Empty Filter and invert" function="and" invert="1">
@@ -301,3 +345,23 @@ class OptimizerTest(unittest.TestCase):
         filter = self.filters["NOT Family Name"]
         results = filter.apply(self.db)
         self.assertEqual(len(results), 2128 - 71)
+
+    def test_not_i0001_and_not_i0002(self):
+        filter = self.filters["(not I0001) and (not I0002)"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2128 - 2)
+
+    def test_not_i0001_or_not_i0002(self):
+        filter = self.filters["(not I0001) or (not I0002)"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2128)
+
+    def test_not_not_i0001_and_not_i0002(self):
+        filter = self.filters["not ((not I0001) and (not I0002))"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2)
+
+    def test_not_i0001_and_i0002(self):
+        filter = self.filters["not (I0001 and I0002)"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2128)

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -392,6 +392,6 @@ class OptimizerTest(unittest.TestCase):
         self.assertEqual(len(results), 1)
 
     def test_not_i0002(self):
-        filter = self.filters["not I0001"]
+        filter = self.filters["not I0002"]
         results = filter.apply(self.db)
         self.assertEqual(len(results), 2127)

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -189,7 +189,7 @@ class OptimizerTest(unittest.TestCase):
     def test_EmptyFilter_and(self):
         filter = self.filters["Empty Filter and"]
         results = filter.apply(self.db)
-        self.assertEqual(len(results), 2158)
+        self.assertEqual(len(results), 2128)
 
     def test_EmptyFilter_and_invert(self):
         filter = self.filters["Empty Filter and invert"]
@@ -204,7 +204,7 @@ class OptimizerTest(unittest.TestCase):
     def test_EmptyFilter_or_invert(self):
         filter = self.filters["Empty Filter or invert"]
         results = filter.apply(self.db)
-        self.assertEqual(len(results), 2158)
+        self.assertEqual(len(results), 2128)
 
     def test_EmptyFilter_one(self):
         filter = self.filters["Empty Filter one"]
@@ -214,4 +214,4 @@ class OptimizerTest(unittest.TestCase):
     def test_EmptyFilter_one_invert(self):
         filter = self.filters["Empty Filter one invert"]
         results = filter.apply(self.db)
-        self.assertEqual(len(results), 2158)
+        self.assertEqual(len(results), 2128)

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -96,6 +96,16 @@ custom_filters_xml = """<?xml version="1.0" encoding="utf-8"?>
         <arg value="I0002"/>
       </rule>
     </filter>
+    <filter name="I0001" function="or">
+      <rule class="HasIdOf" use_regex="False" use_case="False">
+        <arg value="I0001"/>
+      </rule>
+    </filter>
+    <filter name="I0002" function="or">
+      <rule class="HasIdOf" use_regex="False" use_case="False">
+        <arg value="I0002"/>
+      </rule>
+    </filter>
     <filter name="not I0001" function="or" invert="1">
       <rule class="HasIdOf" use_regex="False" use_case="False">
         <arg value="I0001"/>

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -21,6 +21,7 @@
 import tempfile
 import os
 import unittest
+import pytest
 
 from ...const import DATA_DIR
 from ...db.utils import import_as_dict
@@ -161,6 +162,36 @@ class OptimizerTest(unittest.TestCase):
         id_list = [self.db.get_default_handle()]
         results = filter.apply(self.db, id_list=id_list)
         self.assertEqual(len(results), 1)
+
+    def test_everyone_with_id_list_tupleind_0(self):
+        filter = self.filters["Everyone"]
+        default_person = self.db.get_default_person()
+        id_list = [(default_person.handle, default_person)]
+        results = filter.apply(self.db, id_list=id_list, tupleind=0)
+        self.assertEqual(results[0], id_list[0])
+        self.assertEqual(len(results), 1)
+
+    def test_everyone_with_id_list_tupleind_1(self):
+        filter = self.filters["Everyone"]
+        default_person = self.db.get_default_person()
+        id_list = [(default_person, default_person.handle)]
+        results = filter.apply(self.db, id_list=id_list, tupleind=1)
+        self.assertEqual(results[0], id_list[0])
+        self.assertEqual(len(results), 1)
+
+    def test_everyone_with_id_list_tupleind_3(self):
+        filter = self.filters["Everyone"]
+        default_person = self.db.get_default_person()
+        id_list = [(default_person, default_person.handle)]
+        with pytest.raises(IndexError) as excinfo:
+            results = filter.apply(self.db, id_list=id_list, tupleind=3)
+        self.assertEqual(str(excinfo.value), "tuple index out of range")
+
+    def test_everyone_with_id_list_empty(self):
+        filter = self.filters["Everyone"]
+        id_list = []
+        results = filter.apply(self.db, id_list=id_list)
+        self.assertEqual(len(results), 0)
 
     def test_f1(self):
         filter = self.filters["F1"]

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -192,6 +192,21 @@ custom_filters_xml = """<?xml version="1.0" encoding="utf-8"?>
         <arg value="Family Name"/>
       </rule>
     </filter>
+    <filter name="Person I1041" function="and">
+      <rule class="HasIdOf" use_regex="False" use_case="False">
+        <arg value="I1041"/>
+      </rule>
+    </filter>
+    <filter name="Parents of Person I1041" function="or">
+      <rule class="IsParentOfFilterMatch" use_regex="False" use_case="False">
+        <arg value="Person I1041"/>
+      </rule>
+    </filter>
+    <filter name="not Parents of Person I1041" function="or" invert="1">
+      <rule class="IsParentOfFilterMatch" use_regex="False" use_case="False">
+        <arg value="Person I1041"/>
+      </rule>
+    </filter>
   </object>
 </filters>
 """
@@ -395,3 +410,18 @@ class OptimizerTest(unittest.TestCase):
         filter = self.filters["not I0002"]
         results = filter.apply(self.db)
         self.assertEqual(len(results), 2127)
+
+    def test_person_I1041(self):
+        filter = self.filters["Person I1041"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 1)
+
+    def test_parents_of_person_I1041(self):
+        filter = self.filters["Parents of Person I1041"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2)
+
+    def test_not_parents_of_person_I1041(self):
+        filter = self.filters["not Parents of Person I1041"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 2128 - 2)

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -262,11 +262,6 @@ class OptimizerTest(unittest.TestCase):
         results = filter.apply(self.db)
         self.assertEqual(len(results), 2128)
 
-    def test_EmptyFilter_one_invert(self):
-        filter = self.filters["Empty Filter one invert"]
-        results = filter.apply(self.db)
-        self.assertEqual(len(results), 2128)
-
     def test_TagToDo(self):
         filter = self.filters["Tag = ToDo"]
         results = filter.apply(self.db)

--- a/gramps/plugins/test/reports_test.py
+++ b/gramps/plugins/test/reports_test.py
@@ -90,7 +90,7 @@ def dynamic_report_method(report_name, test_function, files, *args, **options):
 
     def test_method(self):  # This needs to have "test" in name
         out, err = self.call(*args)
-        self.assertTrue(test_function(out, err, report_name, **options))
+        self.assertTrue(test_function(out, err, report_name, **options), err)
 
     return test_method
 

--- a/gramps/plugins/test/reports_test.py
+++ b/gramps/plugins/test/reports_test.py
@@ -90,7 +90,7 @@ def dynamic_report_method(report_name, test_function, files, *args, **options):
 
     def test_method(self):  # This needs to have "test" in name
         out, err = self.call(*args)
-        self.assertTrue(test_function(out, err, report_name, **options), err)
+        self.assertTrue(test_function(out, err, report_name, **options), out + err)
 
     return test_method
 
@@ -100,7 +100,7 @@ def dynamic_cli_method(report_name, test_function, files, *args, **options):
 
     def test_method(self):  # This needs to have "test" in name
         out, err = self.call(*args)
-        self.assertTrue(test_function(out, err, report_name, **options))
+        self.assertTrue(test_function(out, err, report_name, **options), out + err)
 
     return test_method
 

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -154,6 +154,11 @@ gramps/gen/filters/rules/test/person_rules_test.py
 gramps/gen/filters/rules/test/place_rules_test.py
 gramps/gen/filters/rules/test/repository_rules_test.py
 #
+# gen.filters.test package
+#
+gramps/gen/filters/test/__init__.py
+gramps/gen/filters/test/filter_optimizer_test.py
+#
 # gen lib API
 #
 gramps/gen/lib/__init__.py


### PR DESCRIPTION
Enable the filter optimizer to optimize filters the use logical operations of "one" or "or"

Note: this branch needs to be rebased once #2052 is merged into maintenance/gramps60 and onward merged into master