### PR TITLE
Pass an object rather than a handle to the note editor callback #2

### DIFF
--- a/gramps/gui/editors/displaytabs/notetab.py
+++ b/gramps/gui/editors/displaytabs/notetab.py
@@ -19,6 +19,13 @@
 
 # -------------------------------------------------------------------------
 #
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+from __future__ import annotations
+
+# -------------------------------------------------------------------------
+#
 # Python classes
 #
 # -------------------------------------------------------------------------
@@ -165,13 +172,13 @@ class NoteTab(EmbeddedList, DbGUIElement):
         except WindowActiveError:
             pass
 
-    def add_callback(self, name):
+    def add_callback(self, note: Note) -> None:
         """
         Called to update the screen when a new note is added
         """
         data = self.get_data()
-        data.append(name)
-        self.callman.register_handles({"note": [name]})
+        data.append(note.handle)
+        self.callman.register_handles({"note": [note.handle]})
         self.changed = True
         self.rebuild()
         GLib.idle_add(self.tree.scroll_to_cell, len(data) - 1)
@@ -208,7 +215,7 @@ class NoteTab(EmbeddedList, DbGUIElement):
         sel = SelectNote(self.dbstate, self.uistate, self.track)
         note = sel.run()
         if note:
-            self.add_callback(note.handle)
+            self.add_callback(note)
 
     def get_icon_name(self):
         """

--- a/gramps/gui/editors/editnote.py
+++ b/gramps/gui/editors/editnote.py
@@ -380,4 +380,4 @@ class EditNote(EditPrimary):
 
         self._do_close()
         if self.callback:
-            self.callback(self.obj.get_handle())
+            self.callback(self.obj)

--- a/gramps/plugins/gramplet/todo.py
+++ b/gramps/plugins/gramplet/todo.py
@@ -241,9 +241,9 @@ class PersonToDo(ToDo):
         else:
             self.set_has_data(False)
 
-    def created(self, handle):
+    def created(self, note):
         with DbTxn("Attach Note", self.dbstate.db) as trans:
-            self.obj.add_note(handle)
+            self.obj.add_note(note.handle)
             self.dbstate.db.commit_person(self.obj, trans)
 
 
@@ -276,9 +276,9 @@ class EventToDo(ToDo):
         else:
             self.set_has_data(False)
 
-    def created(self, handle):
+    def created(self, note):
         with DbTxn("Attach Note", self.dbstate.db) as trans:
-            self.obj.add_note(handle)
+            self.obj.add_note(note.handle)
             self.dbstate.db.commit_event(self.obj, trans)
 
 
@@ -311,9 +311,9 @@ class FamilyToDo(ToDo):
         else:
             self.set_has_data(False)
 
-    def created(self, handle):
+    def created(self, note):
         with DbTxn("Attach Note", self.dbstate.db) as trans:
-            self.obj.add_note(handle)
+            self.obj.add_note(note.handle)
             self.dbstate.db.commit_family(self.obj, trans)
 
 
@@ -346,9 +346,9 @@ class PlaceToDo(ToDo):
         else:
             self.set_has_data(False)
 
-    def created(self, handle):
+    def created(self, note):
         with DbTxn("Attach Note", self.dbstate.db) as trans:
-            self.obj.add_note(handle)
+            self.obj.add_note(note.handle)
             self.dbstate.db.commit_place(self.obj, trans)
 
 
@@ -381,9 +381,9 @@ class SourceToDo(ToDo):
         else:
             self.set_has_data(False)
 
-    def created(self, handle):
+    def created(self, note):
         with DbTxn("Attach Note", self.dbstate.db) as trans:
-            self.obj.add_note(handle)
+            self.obj.add_note(note.handle)
             self.dbstate.db.commit_source(self.obj, trans)
 
 
@@ -416,9 +416,9 @@ class CitationToDo(ToDo):
         else:
             self.set_has_data(False)
 
-    def created(self, handle):
+    def created(self, note):
         with DbTxn("Attach Note", self.dbstate.db) as trans:
-            self.obj.add_note(handle)
+            self.obj.add_note(note.handle)
             self.dbstate.db.commit_citation(self.obj, trans)
 
 
@@ -451,9 +451,9 @@ class RepositoryToDo(ToDo):
         else:
             self.set_has_data(False)
 
-    def created(self, handle):
+    def created(self, note):
         with DbTxn("Attach Note", self.dbstate.db) as trans:
-            self.obj.add_note(handle)
+            self.obj.add_note(note.handle)
             self.dbstate.db.commit_repository(self.obj, trans)
 
 
@@ -486,7 +486,7 @@ class MediaToDo(ToDo):
         else:
             self.set_has_data(False)
 
-    def created(self, handle):
+    def created(self, note):
         with DbTxn("Attach Note", self.dbstate.db) as trans:
-            self.obj.add_note(handle)
+            self.obj.add_note(note.handle)
             self.dbstate.db.commit_media(self.obj, trans)


### PR DESCRIPTION
Fix `EditNote` so that it passes the object when calling the callback function, rather than the object handle.
Fixes the error described in 13702 and gives consistency with other Edit classes.

To reproduce:

1. create a new note- type "a"
2. select "a" and click the Link button
3. Change the Link Type to Note and click New
4. type "a" and click ok

Related bugs:
- [#13884](https://gramps-project.org/bugs/view.php?id=13884)
- [#13702](https://gramps-project.org/bugs/view.php?id=13702)
- possibly [#12260](https://gramps-project.org/bugs/view.php?id=12260)

Reviewed and adjusted other places that create an `EditNote` instance with callback
Reviewed and adjusted other places that call `NoteTab.add_callback`

This was originally PR #2070 merged into 6.0.2
Rolled back in 6.0.3 due to [#13884](https://gramps-project.org/bugs/view.php?id=13884)
