### PR TITLE
Internet indexing for the Narrative Web.

### DIFF
--- a/gramps/plugins/webreport/basepage.py
+++ b/gramps/plugins/webreport/basepage.py
@@ -1835,9 +1835,12 @@ class BasePage:
             Html("meta", attr=_meta2, indent=False),
             Html("meta", attr=_meta3, indent=False),
             Html("meta", attr=_meta4, indent=False),
-            Html("meta", attr=_meta5, indent=False),
-            Html("meta", attr=_meta6, indent=False),
         )
+        if not self.report.options["internet_indexing"]:
+            meta += (
+                Html("meta", attr=_meta5, indent=False),
+                Html("meta", attr=_meta6, indent=False),
+            )
 
         # Link to _NARRATIVESCREEN  stylesheet
         sub_cal = cal + 1 if cal > 0 else 1

--- a/gramps/plugins/webreport/narrativeweb.py
+++ b/gramps/plugins/webreport/narrativeweb.py
@@ -2256,6 +2256,13 @@ class NavWebOptions(MenuReportOptions):
         )
         addopt("splitindex", self.__splitindex)
 
+        self.__indexi = BooleanOption(_("Allow internet indexation."), False)
+        self.__indexi.set_help(
+            # _("Check it if you want google, bing... to spy on your data")
+            _("Allow search engines (Google, Bing, etc.) to index your website.")
+        )
+        addopt("internet_indexing", self.__indexi)
+
     def __add_more_pages(self, menu):
         """
         Add more extra pages to the report


### PR DESCRIPTION
This was requested from https://gramps.discourse.group/t/can-you-make-the-noindex-html-meta-tags-optional-for-search-engines/5986/21