### PR TITLE
Apply event place filters to the place not the event

### DIFF
--- a/gramps/gen/filters/rules/event/_matchesplacefilter.py
+++ b/gramps/gen/filters/rules/event/_matchesplacefilter.py
@@ -70,6 +70,8 @@ class MatchesPlaceFilter(MatchesFilterBase):
     def apply_to_one(self, db: Database, event: Event) -> bool:
         filt = self.find_filter()
         if filt:
-            if event and filt.apply_to_one(db, event):
-                return True
+            if event and event.place:
+                place = db.get_place_from_handle(event.place)
+                if filt.apply_to_one(db, place):
+                    return True
         return False


### PR DESCRIPTION
This fixes https://gramps-project.org/bugs/view.php?id=13797 by ensuring that when we are applying a place filter to an event we filter on the place attached the event (if any) rather than on the event itself.