### PR TITLE
Added new fieldtype 48 to support Pro-Gen version 3.5

### DIFF
--- a/gramps/plugins/lib/libprogen.py
+++ b/gramps/plugins/lib/libprogen.py
@@ -386,7 +386,7 @@ class PG30DefTable(object):
                 fmt += "i"
             elif fldtyp == 31:
                 pass
-            elif fldtyp == 32 or fldtyp == 44 or fldtyp == 45:
+            elif fldtyp == 32 or fldtyp == 44 or fldtyp == 45 or fldtyp == 48:
                 fmt += "%ds" % fld.size
             elif fldtyp == 41:
                 fmt += "h"


### PR DESCRIPTION
The Pro-Gen importer was originally written for Pro-Gen Version 3.0
With the change from Pro-Gen 3.0 to 3.5, the record length of the person table changed from 309 to 332/336 bytes (PG35-1D/PG35-2D) and a new field type 48 was introduced. The latter is crucial, as parsing for the 3.5 record format of the person table (recfmt) fails.
Added the new fieldtype 48 to support Pro-Gen version 3.5. Pro-Gen data definition files PG35-1D/PG35-2D