### PR TITLE
Fix failure in event filter

### DIFF
--- a/gramps/gen/filters/rules/event/_matchespersonfilter.py
+++ b/gramps/gen/filters/rules/event/_matchespersonfilter.py
@@ -83,7 +83,7 @@ class MatchesPersonFilter(MatchesFilterBase):
         filt = self.find_filter()
         if filt:
             for classname, handle in db.find_backlink_handles(event.handle, ["Person"]):
-                person = db.method("get_%_from_handle", classname)(handle)
+                person = db.method("get_%s_from_handle", classname)(handle)
                 if filt.apply_to_one(db, person):
                     return True
             if self.MPF_famevents:


### PR DESCRIPTION
issue [#0013909](https://gramps-project.org/bugs/view.php?id=13909)  & [#0013923](https://gramps-project.org/bugs/view.php?id=13923) can be traced to an error in a format descriptor in: gramps\gen\filters\rules\event\\_matchespersonfilter.py

approximately line 86 has:
person = db.method("get_%_from_handle", classname)(handle)

should be:
person = db.method("get_%s_from_handle", classname)(handle)

That is: there should be an "s" after the "%".