### PR TITLE
Disambiguate name in glade strings

### DIFF
--- a/gramps/gui/glade/editfamily.glade
+++ b/gramps/gui/glade/editfamily.glade
@@ -113,7 +113,7 @@
                                 <property name="can-focus">False</property>
                                 <property name="halign">start</property>
                                 <property name="margin-start">6</property>
-                                <property name="label" translatable="yes">Name:</property>
+                                <property name="label" translatable="yes" context="family">Name:</property>
                               </object>
                               <packing>
                                 <property name="left-attach">0</property>
@@ -376,7 +376,7 @@
                                 <property name="can-focus">False</property>
                                 <property name="halign">start</property>
                                 <property name="margin-start">6</property>
-                                <property name="label" translatable="yes">Name:</property>
+                                <property name="label" translatable="yes" context="family">Name:</property>
                               </object>
                               <packing>
                                 <property name="left-attach">0</property>

--- a/gramps/gui/glade/editplaceformat.glade
+++ b/gramps/gui/glade/editplaceformat.glade
@@ -198,7 +198,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">Name:</property>
+                    <property name="label" translatable="yes" context="place">Name:</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>

--- a/gramps/gui/glade/editplacename.glade
+++ b/gramps/gui/glade/editplacename.glade
@@ -181,7 +181,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">Name:</property>
+                    <property name="label" translatable="yes" context="place">Name:</property>
                     <property name="use-underline">True</property>
                     <property name="justify">center</property>
                   </object>

--- a/gramps/gui/glade/editplaceref.glade
+++ b/gramps/gui/glade/editplaceref.glade
@@ -231,7 +231,7 @@
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">Name:</property>
+                        <property name="label" translatable="yes" context="place">Name:</property>
                         <property name="use-underline">True</property>
                         <property name="justify">center</property>
                       </object>

--- a/gramps/gui/glade/mergeperson.glade
+++ b/gramps/gui/glade/mergeperson.glade
@@ -215,7 +215,7 @@ primary data for the merged person.</property>
                         </child>
                         <child>
                           <object class="GtkRadioButton" id="name_btn1">
-                            <property name="label" translatable="yes">Name:</property>
+                            <property name="label" translatable="yes" context="person">Name:</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -230,7 +230,7 @@ primary data for the merged person.</property>
                         </child>
                         <child>
                           <object class="GtkRadioButton" id="name_btn2">
-                            <property name="label" translatable="yes">Name:</property>
+                            <property name="label" translatable="yes" context="person">Name:</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>

--- a/gramps/gui/glade/mergeplace.glade
+++ b/gramps/gui/glade/mergeplace.glade
@@ -423,7 +423,7 @@ primary data for the merged place.</property>
                         </child>
                         <child>
                           <object class="GtkRadioButton" id="name_btn1">
-                            <property name="label" translatable="yes">Name:</property>
+                            <property name="label" translatable="yes" context="place">Name:</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -440,7 +440,7 @@ primary data for the merged place.</property>
                         </child>
                         <child>
                           <object class="GtkRadioButton" id="name_btn2">
-                            <property name="label" translatable="yes">Name:</property>
+                            <property name="label" translatable="yes" context="place">Name:</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>


### PR DESCRIPTION
This PR adds context to the 'Name' strings in .glade files to enable disambiguation and using different translations depending on the context. The problem is described in bug [12527](https://gramps-project.org/bugs/view.php?id=12527). 

Here is problem example.

Currently there is context missing and in .po file there is e.g. for Polish localization:

#: ../gramps/gen/filters/rules/person/_hassoundexname.py:57
#: ../gramps/gui/glade/editfamily.glade:116
#: ../gramps/gui/glade/editfamily.glade:379
#: ../gramps/gui/glade/editplaceformat.glade:201
#: ../gramps/gui/glade/editplacename.glade:184
#: ../gramps/gui/glade/editplaceref.glade:234
#: ../gramps/gui/glade/mergeperson.glade:218
#: ../gramps/gui/glade/mergeperson.glade:233
#: ../gramps/gui/glade/mergeplace.glade:426
#: ../gramps/gui/glade/mergeplace.glade:443
#: ../gramps/plugins/gramplet/soundgen.py:68
msgid "Name:"
msgstr "Imię i nazwisko:"

The msgstr is correct in `person` context but is totally wrong in `place` context and they can't be translated separately dur to context missing.

This PR enables this distinction.
