### PR TITLE
Fix regex matches in filter match method

### DIFF
--- a/gramps/gen/filters/_genericfilter.py
+++ b/gramps/gen/filters/_genericfilter.py
@@ -98,7 +98,15 @@ class GenericFilter:
         Return True or False depending on whether the handle matches the filter.
         """
         obj = self.get_object(db, handle)
-        return self.apply_to_one(db, obj)
+        for rule in self.flist:
+            rule.requestprepare(db, user=None)
+
+        results = self.apply_to_one(db, obj)
+
+        for rule in self.flist:
+            rule.requestreset()
+
+        return results
 
     def is_empty(self):
         return (len(self.flist) == 0) or (

--- a/gramps/gen/filters/test/filter_optimizer_test.py
+++ b/gramps/gen/filters/test/filter_optimizer_test.py
@@ -215,7 +215,12 @@ custom_filters_xml = """<?xml version="1.0" encoding="utf-8"?>
       <rule class="MatchesEventFilter" use_regex="False" use_case="False">
         <arg value="Events of Home Person"/>
       </rule>
-    </filter>    
+    </filter>
+    <filter name="Regex Test" function="and">
+      <rule class="RegExpName" use_regex="True" use_case="False">
+        <arg value="Edwards|Daniels"/>
+      </rule>
+    </filter>
   </object>
   <object type="Event">
     <filter name="Events of Home Person" function="and">
@@ -459,3 +464,15 @@ class OptimizerTest(unittest.TestCase):
         results = filter.apply(self.db)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0], "GNUJQCL9MD64AM56OH")
+
+    def test_regex_person_name(self):
+        filter = self.filters["Regex Test"]
+        results = filter.apply(self.db)
+        self.assertEqual(len(results), 3)
+
+    def test_regex_person_name_match(self):
+        filter = self.filters["Regex Test"]
+        self.assertTrue(filter.match("W2DKQCV4H3EZUJ35DX", self.db))
+        self.assertTrue(filter.match("XZLKQCRQA9EHPBNZPT", self.db))
+        self.assertFalse(filter.match("GNUJQCL9MD64AM56OH", self.db))
+        self.assertTrue(filter.match("44WJQCLCQIPZUB0UH", self.db))


### PR DESCRIPTION
This PR fixes https://gramps-project.org/bugs/view.php?id=13926

The issue was that regex matches require `rule.requestprepare()` to be called, and apparently this was not properly called when `filter.match()` was called. 

This was not an issue of the filter optimizer, but appears to be a side effect of the refactoring. It only appeared in those places where `filter.match()` was used. I believe that the fanchart widget was the only place in core gramps.