### PR TITLE
Localized plugin for name guessing

### DIFF
--- a/gramps/gen/nameguesser.py
+++ b/gramps/gen/nameguesser.py
@@ -51,7 +51,7 @@ class NameGuesser:
     The name guesser guesses the names of a person based on their family members' names.
     """
 
-    def fathers_surname_from_child(self, db, family):
+    def fathers_name_from_child(self, db, family):
         """
         Find a child and return their name for the father.
         """
@@ -68,7 +68,7 @@ class NameGuesser:
 
         return name
 
-    def mothers_surname_from_child(self, db, family):
+    def mothers_name_from_child(self, db, family):
         """
         Mother's surname cannot be guessed in the default locale, return empty name.
         """
@@ -79,7 +79,7 @@ class NameGuesser:
 
         return name
 
-    def childs_surname(self, db, family):
+    def childs_name(self, db, family):
         """
         Child inherits name from father.
         """

--- a/gramps/gen/nameguesser.py
+++ b/gramps/gen/nameguesser.py
@@ -1,0 +1,147 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025 Christina Rauscher
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+# -------------------------------------------------------------------------
+#
+# Python modules
+#
+# -------------------------------------------------------------------------
+import logging
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from .lib import Name, Surname
+from .utils.db import preset_name
+from .plug import PluginRegister, BasePluginManager
+from .const import GRAMPS_LOCALE as glocale
+
+_ = glocale.translation.sgettext
+
+LOG = logging.getLogger("gen.relationship")
+LOG.addHandler(logging.StreamHandler())
+
+
+# -------------------------------------------------------------------------
+#
+# NameGuesser
+#
+# -------------------------------------------------------------------------
+class NameGuesser:
+    """
+    The name guesser guesses the names of a person based on their family members' names.
+    """
+
+    def fathers_surname_from_child(self, db, family):
+        """
+        Find a child and return their name for the father.
+        """
+        # for each child, find one with a last name
+        name = Name()
+        # the editor requires a surname
+        name.add_surname(Surname())
+        name.set_primary_surname(0)
+        for ref in family.get_child_ref_list():
+            child = db.get_person_from_handle(ref.ref)
+            if child:
+                preset_name(child, name)
+                return name
+
+        return name
+
+    def mothers_surname_from_child(self, db, family):
+        """
+        Mother's surname cannot be guessed in the default locale, return empty name.
+        """
+        name = Name()
+        # the editor requires a surname
+        name.add_surname(Surname())
+        name.set_primary_surname(0)
+
+        return name
+
+    def childs_surname(self, db, family):
+        """
+        Child inherits name from father.
+        """
+        name = Name()
+        name.add_surname(Surname())
+        name.set_primary_surname(0)
+        father_handle = family.get_father_handle()
+        if father_handle:
+            father = db.get_person_from_handle(father_handle)
+            preset_name(father, name)
+
+        return name
+
+
+# -------------------------------------------------------------------------
+#
+# define the default nameguesser
+#
+# -------------------------------------------------------------------------
+
+__NAMEGUESSER_CLASS = None
+
+
+def get_nameguesser(reinit=False, clocale=glocale):
+    """
+    Return the name guesser for the current language.
+
+    If clocale is passed in (a GrampsLocale) then that language will be used.
+
+    :param clocale: allow selection of the language
+    :type clocale: a GrampsLocale instance
+
+    """
+    global __NAMEGUESSER_CLASS
+
+    if __NAMEGUESSER_CLASS is None or reinit:
+        lang = clocale.language[0]
+        __NAMEGUESSER_CLASS = NameGuesser
+        # If lang not set default to English name guesser
+        # See if lang begins with en_, English_ or english_
+        # If so return standard name guesser.
+        if lang.startswith("en") or lang == "C":
+            return __NAMEGUESSER_CLASS()
+        # Set correct non English name guesser based on lang
+        nameguesser_translation_found = False
+        for plugin in PluginRegister.get_instance().nameguesser_plugins():
+            if lang in plugin.lang_list:
+                pmgr = BasePluginManager.get_instance()
+                # The loaded module is put in variable mod
+                mod = pmgr.load_plugin(plugin)
+                if mod:
+                    __NAMEGUESSER_CLASS = getattr(mod, plugin.nameguesserclass)
+                    nameguesser_translation_found = True
+                    break
+        if not nameguesser_translation_found and len(
+            PluginRegister.get_instance().nameguesser_plugins()
+        ):
+            LOG.warning(
+                _(
+                    "Name guesser not available for "
+                    "language '%s'. Using 'english' instead."
+                ),
+                lang,
+            )
+    return __NAMEGUESSER_CLASS()

--- a/gramps/gen/plug/_pluginreg.py
+++ b/gramps/gen/plug/_pluginreg.py
@@ -97,6 +97,7 @@ DATABASE = 12
 RULE = 13
 THUMBNAILER = 14
 CITE = 15
+NAMEGUESSER = 16
 PTYPE = [
     REPORT,
     QUICKREPORT,
@@ -114,6 +115,7 @@ PTYPE = [
     RULE,
     THUMBNAILER,
     CITE,
+    NAMEGUESSER
 ]
 PTYPE_STR = {
     REPORT: _("Report"),
@@ -132,6 +134,7 @@ PTYPE_STR = {
     RULE: _("Rule"),
     THUMBNAILER: _("Thumbnailer"),
     CITE: _("Citation formatter"),
+    NAMEGUESSER: _("Name guesser")
 }
 
 # possible report categories
@@ -447,6 +450,13 @@ class PluginData:
 
     .. attribute:: thumbnailer
        The exact class name of the thumbnailer
+       
+    Attributes for NAMEGUESSER plugins:
+
+    .. attribute:: nameguesserclass
+       The class in the module that is the NameGuesser class
+    .. attribute:: lang_list
+       List of languages this plugin handles
     """
 
     def __init__(self):
@@ -537,6 +547,8 @@ class PluginData:
         self._namespace = None
         # THUMBNAILER attr
         self._thumbnailer = None
+        # NAMEGUESSER attr
+        self._nameguesser = None
 
     @property
     def id(self):
@@ -807,8 +819,8 @@ class PluginData:
 
     @lang_list.setter
     def lang_list(self, lang_list):
-        if self._ptype != RELCALC:
-            raise ValueError("relcalcclass may only be set for RELCALC plugins")
+        if self._ptype != RELCALC and self._ptype != NAMEGUESSER:
+            raise ValueError("lang_list may only be set for RELCALC and NAMEGUESSER plugins")
         self._lang_list = lang_list
 
     # REPORT attributes
@@ -1232,6 +1244,17 @@ class PluginData:
         if self._ptype != THUMBNAILER:
             raise ValueError("thumbnailer may only be set for THUMBNAILER plugins")
         self._thumbnailer = data
+        
+    # NAMEGUESSER attr
+    @property
+    def nameguesserclass(self):
+        return self._nameguesserclass
+
+    @nameguesserclass.setter
+    def nameguesserclass(self, nameguesserclass):
+        if self._ptype != NAMEGUESSER:
+            raise ValueError("nameguesserclass may only be set for NAMEGUESSER plugins")
+        self._nameguesserclass = nameguesserclass
 
 
 def newplugin():
@@ -1334,6 +1357,7 @@ def make_environment(**kwargs):
         "START": START,
         "END": END,
         "IMAGE_DIR": IMAGE_DIR,
+        "NAMEGUESSER": NAMEGUESSER
     }
     env.update(kwargs)
     return env
@@ -1657,6 +1681,12 @@ class PluginRegister:
         Return a list of :class:`PluginData` that are of type CITE
         """
         return self.type_plugins(CITE)
+    
+    def nameguesser_plugins(self):
+        """
+        Return a list of :class:`PluginData` that are of type NAMEGUESSER
+        """
+        return self.type_plugins(NAMEGUESSER)
 
     def filter_load_on_reg(self):
         """

--- a/gramps/gui/editors/editfamily.py
+++ b/gramps/gui/editors/editfamily.py
@@ -63,6 +63,7 @@ from gramps.gen.lib import ChildRef, Family, Name, NoteType, Person, Surname
 from gramps.gen.db import DbTxn
 from gramps.gen.errors import WindowActiveError
 from gramps.gen.datehandler import displayer
+from gramps.gen.nameguesser import get_nameguesser
 from ..glade import Glade
 
 from .editprimary import EditPrimary
@@ -168,6 +169,8 @@ class ChildEmbedList(DbGUIElement, EmbeddedList):
             share_button=True,
             move_buttons=True,
         )
+        
+        self.nameguesser_class = get_nameguesser(clocale=glocale)
 
     def _connect_db_signals(self):
         """
@@ -256,17 +259,9 @@ class ChildEmbedList(DbGUIElement, EmbeddedList):
 
     def add_button_clicked(self, obj=None):
         person = Person()
-        autoname = config.get("behavior.surname-guessing")
-        # _("Father's surname"),
-        # _("None"),
-        # _("Combination of mother's and father's surname"),
-        # _("Icelandic style"),
-        if autoname == 0:
-            name = self.north_american()
-        elif autoname == 2:
-            name = self.latin_american()
-        else:
-            name = self.no_name()
+        
+        name = self.nameguesser_class.childs_name(self.dbstate.db, self.family)
+            
         person.set_primary_name(name)
 
         EditPerson(self.dbstate, self.uistate, self.track, person, self.new_child_added)
@@ -461,6 +456,8 @@ class EditFamily(EditPrimary):
                 )
         else:
             self.add_parent = False
+            
+        self.nameguesser_class = get_nameguesser(clocale=glocale)
 
     def _cleanup_on_exit(self):
         """Unset all things that can block garbage collection.
@@ -923,15 +920,8 @@ class EditFamily(EditPrimary):
     def add_mother_clicked(self, obj):
         person = Person()
         person.set_gender(Person.FEMALE)
-        autoname = config.get("behavior.surname-guessing")
-        # _("Father's surname"),
-        # _("None"),
-        # _("Combination of mother's and father's surname"),
-        # _("Icelandic style"),
-        if autoname == 2:
-            name = self.latin_american_child("mother")
-        else:
-            name = self.no_name()
+        
+        name = self.nameguesser_class.mothers_name_from_child(self.db, self.obj)
         person.set_primary_name(name)
         EditPerson(
             self.dbstate, self.uistate, self.track, person, self.new_mother_added
@@ -940,17 +930,7 @@ class EditFamily(EditPrimary):
     def add_father_clicked(self, obj):
         person = Person()
         person.set_gender(Person.MALE)
-        autoname = config.get("behavior.surname-guessing")
-        # _("Father's surname"),
-        # _("None"),
-        # _("Combination of mother's and father's surname"),
-        # _("Icelandic style"),
-        if autoname == 0:
-            name = self.north_american_child()
-        elif autoname == 2:
-            name = self.latin_american_child("father")
-        else:
-            name = self.no_name()
+        name = self.nameguesser_class.fathers_name_from_child(self.db, self.obj)
         person.set_primary_name(name)
         EditPerson(
             self.dbstate, self.uistate, self.track, person, self.new_father_added

--- a/gramps/plugins/nameguesser/nameguesser_de.py
+++ b/gramps/plugins/nameguesser/nameguesser_de.py
@@ -40,7 +40,7 @@ class NameGuesser(gramps.gen.nameguesser.NameGuesser):
     The name guesser guesses the names of a person based on their relationships.
     """
 
-    def fathers_surname_from_child(self, db, family):
+    def fathers_name_from_child(self, db, family):
         """
         If family is not unmarried, get the surname from a child. Else, return empty name.
         """
@@ -57,7 +57,7 @@ class NameGuesser(gramps.gen.nameguesser.NameGuesser):
                     return name
         return name
 
-    def mothers_surname_from_child(self, db, family):
+    def mothers_name_from_child(self, db, family):
         """
         If family is unmarried, get the surname from a child. Else, return empty name.
         """
@@ -72,4 +72,25 @@ class NameGuesser(gramps.gen.nameguesser.NameGuesser):
                 if child:
                     preset_name(child, name)
                     return name
+        return name
+
+    def childs_name(self, db, family):
+        """
+        If family is unmarried, child inherits name from mother. Otherwise, child inherits name from father.
+        """
+        name = Name()
+        name.add_surname(Surname())
+        name.set_primary_surname(0)
+
+        if family.get_relationship() == FamilyRelType.UNMARRIED:
+            mother_handle = family.get_mother_handle()
+            if mother_handle:
+                mother = db.get_person_from_handle(mother_handle)
+                preset_name(mother, name)
+        else:
+            father_handle = family.get_father_handle()
+            if father_handle:
+                father = db.get_person_from_handle(father_handle)
+                preset_name(father, name)
+
         return name

--- a/gramps/plugins/nameguesser/nameguesser_de.py
+++ b/gramps/plugins/nameguesser/nameguesser_de.py
@@ -1,0 +1,75 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025 Christina Rauscher
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+
+from gramps.gen.lib import (
+    Name,
+    Surname,
+    FamilyRelType,
+)
+from gramps.gen.utils.db import (
+    preset_name,
+)
+import gramps.gen.nameguesser
+
+
+# -------------------------------------------------------------------------
+#
+# NameGuesser
+#
+# -------------------------------------------------------------------------
+class NameGuesser(gramps.gen.nameguesser.NameGuesser):
+    """
+    The name guesser guesses the names of a person based on their relationships.
+    """
+
+    def fathers_surname_from_child(self, db, family):
+        """
+        If family is not unmarried, get the surname from a child. Else, return empty name.
+        """
+        name = Name()
+        # the editor requires a surname
+        name.add_surname(Surname())
+        name.set_primary_surname(0)
+        if family.get_relationship() != FamilyRelType.UNMARRIED:
+            # for each child, find one with a last name
+            for ref in family.get_child_ref_list():
+                child = db.get_person_from_handle(ref.ref)
+                if child:
+                    preset_name(child, name)
+                    return name
+        return name
+
+    def mothers_surname_from_child(self, db, family):
+        """
+        If family is unmarried, get the surname from a child. Else, return empty name.
+        """
+        name = Name()
+        # the editor requires a surname
+        name.add_surname(Surname())
+        name.set_primary_surname(0)
+        if family.get_relationship() == FamilyRelType.UNMARRIED:
+            # for each child, find one with a last name
+            for ref in family.get_child_ref_list():
+                child = db.get_person_from_handle(ref.ref)
+                if child:
+                    preset_name(child, name)
+                    return name
+        return name

--- a/gramps/plugins/nameguesser/nameguesser_es.py
+++ b/gramps/plugins/nameguesser/nameguesser_es.py
@@ -1,0 +1,121 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025 Christina Rauscher
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+
+from gramps.gen.lib import (
+    Name,
+    Surname,
+    FamilyRelType,
+)
+from gramps.gen.lib.nameorigintype import NameOriginType
+from gramps.gen.utils.db import (
+    preset_name,
+)
+import gramps.gen.nameguesser
+
+
+# -------------------------------------------------------------------------
+#
+# NameGuesser
+#
+# -------------------------------------------------------------------------
+class NameGuesser(gramps.gen.nameguesser.NameGuesser):
+    """
+    The name guesser guesses the names of a person based on their relationships.
+    """
+
+    def fathers_name_from_child(self, db, family):
+        """
+        Usually, the child's first surname is the father's surname.
+        """
+        name = Name()
+        # the editor requires a surname
+        surname = Surname()
+        # for each child, find one with a last name
+        for ref in family.get_child_ref_list():
+            child = db.get_person_from_handle(ref.ref)
+            if child:
+                child_name = child.get_primary_name()
+                surname_list = child_name.get_surname_list()
+                if len(surname_list) > 0:
+                    surname = surname_list[0]
+                    # set surname to patrilineal because he probably gave his patrilineal surname to his child
+                    surname.origintype = NameOriginType(NameOriginType.PATRILINEAL)
+        name.add_surname(surname)
+        name.set_primary_surname(0)
+        return name
+
+    def mothers_name_from_child(self, db, family):
+        """
+        Usually, the child's second surname is the mother's surname.
+        """
+        name = Name()
+        # the editor requires a surname
+        surname = Surname()
+        # for each child, find one with a last name
+        for ref in family.get_child_ref_list():
+            child = db.get_person_from_handle(ref.ref)
+            if child:
+                child_name = child.get_primary_name()
+                surname_list = child_name.get_surname_list()
+                if len(surname_list) > 1:
+                    surname = surname_list[1]
+                    # set surname to patrilineal because she probably gave her patrilineal surname to her child
+                    surname.origintype = NameOriginType(NameOriginType.PATRILINEAL)
+        name.add_surname(surname)
+        name.set_primary_surname(0)
+        return name
+
+    def childs_name(self, db, family):
+        """
+        Child inherits name from father and mother
+        """
+        name = Name()
+        # the editor requires a surname
+        name.add_surname(Surname())
+        name.set_primary_surname(0)
+        if family:
+            father_handle = family.get_father_handle()
+            father = db.get_person_from_handle(father_handle) if father_handle else None
+            mother_handle = family.get_mother_handle()
+            mother = db.get_person_from_handle(mother_handle) if mother_handle else None
+            if not father and not mother:
+                return name
+            if not father:
+                preset_name(mother, name)
+                return name
+            if not mother:
+                preset_name(father, name)
+                return name
+            # we take first surname, and keep that
+            mothername = Name()
+            fathername = Name()
+            preset_name(mother, mothername)
+            preset_name(father, fathername)
+            mothersurname = mothername.get_surname_list()[0]
+            mothersurname.set_primary(False)
+            mothersurname.origintype = NameOriginType(NameOriginType.MATRILINEAL)
+            fathersurname = fathername.get_surname_list()[0]
+            fathersurname.set_primary(True)
+            fathersurname.origintype = NameOriginType(NameOriginType.PATRILINEAL)
+            name.set_surname_list([fathersurname, mothersurname])
+            return name
+        else:
+            return name

--- a/gramps/plugins/nameguesser/nameguesser_is.py
+++ b/gramps/plugins/nameguesser/nameguesser_is.py
@@ -1,0 +1,148 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025 Christina Rauscher
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+
+from gramps.gen.lib import (
+    Name,
+    Surname,
+    FamilyRelType,
+)
+from gramps.gen.lib.nameorigintype import NameOriginType
+import gramps.gen.nameguesser
+from gramps.gen.utils.db import preset_name
+
+
+# -------------------------------------------------------------------------
+#
+# NameGuesser
+#
+# -------------------------------------------------------------------------
+class NameGuesser(gramps.gen.nameguesser.NameGuesser):
+    """
+    The name guesser guesses the names of a person based on their relationships.
+    """
+
+    def fathers_name_from_child(self, db, family):
+        """
+        Get father's given name from child's surname.
+        """
+        name = Name()
+        name.add_surname(Surname())
+        name.set_primary_surname(0)
+        # for each child, find one with a non-matronymic last name
+        for ref in family.get_child_ref_list():
+            child = db.get_person_from_handle(ref.ref)
+            if child:
+                child_name = child.get_primary_name()
+                child_surname_list = child_name.get_surname_list()
+                for child_surname in child_surname_list:
+                    if int(child_surname.get_origintype()) != NameOriginType.MATRONYMIC:
+                        surname = child_surname.get_surname()
+                        father_given_name = ""
+                        if surname.endswith("sson"):
+                            father_given_name = surname.replace("sson", "")
+                        elif surname.endswith("sdóttir"):
+                            father_given_name = surname.replace("sdóttir", "")
+                        elif surname.endswith("sdottir"):
+                            father_given_name = surname.replace("sdottir", "")
+                        if len(father_given_name) > 0:
+                            name.set_first_name(father_given_name)
+                            return name
+
+        return name
+
+    def mothers_name_from_child(self, db, family):
+        """
+        If child's surname is matronymic, guess mother's given name based on the child's surname.
+        """
+        name = Name()
+        name.add_surname(Surname())
+        name.set_primary_surname(0)
+        # for each child, find one with a matronymic last name
+        for ref in family.get_child_ref_list():
+            child = db.get_person_from_handle(ref.ref)
+            if child:
+                child_name = child.get_primary_name()
+                child_surname_list = child_name.get_surname_list()
+                for child_surname in child_surname_list:
+                    if (
+                        child_surname.get_origintype().value
+                        == NameOriginType.MATRONYMIC
+                    ):
+                        matronymic_surname = child_surname.get_surname()
+                        mother_given_name = ""
+                        if matronymic_surname.endswith("sson"):
+                            mother_given_name = matronymic_surname.replace("sson", "")
+                        elif matronymic_surname.endswith("sdóttir"):
+                            mother_given_name = matronymic_surname.replace(
+                                "sdóttir", ""
+                            )
+                        elif matronymic_surname.endswith("sdottir"):
+                            mother_given_name = matronymic_surname.replace(
+                                "sdottir", ""
+                            )
+                        if len(mother_given_name) > 0:
+                            name.set_first_name(mother_given_name)
+                            return name
+
+        return name
+
+    def childs_name(self, db, family):
+        """
+        Child's family name is the father's given name + "sson" or "dóttir"
+        We don't know the gender of the child at this point, so it defaults to "sson".
+        """
+        name = Name()
+        name.add_surname(Surname())
+        name.set_primary_surname(0)
+
+        father_handle = family.get_father_handle()
+        father = db.get_person_from_handle(father_handle) if father_handle else None
+        mother_handle = family.get_mother_handle()
+        mother = db.get_person_from_handle(mother_handle) if mother_handle else None
+
+        if not father and not mother:
+            return name
+        if not father:
+            mother_name = mother.get_primary_name()
+            mother_given_name = mother_name.get_first_name()
+            if mother_given_name and len(mother_given_name) > 0:
+                matronymic = Surname()
+                matronymic.set_origintype(NameOriginType.MATRONYMIC)
+                if mother_given_name.endswith("s"):
+                    matronymic.set_surname(mother_given_name + "son")
+                else:
+                    matronymic.set_surname(mother_given_name + "sson")
+                name.set_surname_list([matronymic])
+        else:
+            father_name = father.get_primary_name()
+            father_given_name = father_name.get_first_name()
+
+            if father_given_name and len(father_given_name) > 0:
+                patronymic = Surname()
+                patronymic.set_origintype(NameOriginType.PATRONYMIC)
+                if father_given_name.endswith("s"):
+                    patronymic.set_surname(father_given_name + "son")
+                else:
+                    patronymic.set_surname(father_given_name + "sson")
+
+                name.set_surname_list([patronymic])
+
+        return name

--- a/gramps/plugins/nameguesser/nameguesser_pt.py
+++ b/gramps/plugins/nameguesser/nameguesser_pt.py
@@ -1,0 +1,121 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025 Christina Rauscher
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+
+from gramps.gen.lib import (
+    Name,
+    Surname,
+    FamilyRelType,
+)
+from gramps.gen.lib.nameorigintype import NameOriginType
+from gramps.gen.utils.db import (
+    preset_name,
+)
+import gramps.gen.nameguesser
+
+
+# -------------------------------------------------------------------------
+#
+# NameGuesser
+#
+# -------------------------------------------------------------------------
+class NameGuesser(gramps.gen.nameguesser.NameGuesser):
+    """
+    The name guesser guesses the names of a person based on their relationships.
+    """
+
+    def fathers_name_from_child(self, db, family):
+        """
+        Usually, the child's second surname is the father's surname.
+        """
+        name = Name()
+        # the editor requires a surname
+        surname = Surname()
+        # for each child, find one with a last name
+        for ref in family.get_child_ref_list():
+            child = db.get_person_from_handle(ref.ref)
+            if child:
+                child_name = child.get_primary_name()
+                surname_list = child_name.get_surname_list()
+                if len(surname_list) > 1:
+                    surname = surname_list[1]
+                    # set surname to matrilineal because he probably gave his matrilineal surname to his child
+                    surname.origintype = NameOriginType(NameOriginType.MATRILINEAL)
+        name.add_surname(surname)
+        name.set_primary_surname(0)
+        return name
+
+    def mothers_name_from_child(self, db, family):
+        """
+        Usually, the child's first surname is the mother's surname.
+        """
+        name = Name()
+        # the editor requires a surname
+        surname = Surname()
+        # for each child, find one with a last name
+        for ref in family.get_child_ref_list():
+            child = db.get_person_from_handle(ref.ref)
+            if child:
+                child_name = child.get_primary_name()
+                surname_list = child_name.get_surname_list()
+                if len(surname_list) > 0:
+                    surname = surname_list[0]
+                    # set surname to matrilineal because she probably gave her matrilineal surname to her child
+                    surname.origintype = NameOriginType(NameOriginType.MATRILINEAL)
+        name.add_surname(surname)
+        name.set_primary_surname(0)
+        return name
+
+    def childs_name(self, db, family):
+        """
+        Child inherits name from mother and father
+        """
+        name = Name()
+        # the editor requires a surname
+        name.add_surname(Surname())
+        name.set_primary_surname(0)
+        if family:
+            father_handle = family.get_father_handle()
+            father = db.get_person_from_handle(father_handle) if father_handle else None
+            mother_handle = family.get_mother_handle()
+            mother = db.get_person_from_handle(mother_handle) if mother_handle else None
+            if not father and not mother:
+                return name
+            if not father:
+                preset_name(mother, name)
+                return name
+            if not mother:
+                preset_name(father, name)
+                return name
+
+            mothername = Name()
+            fathername = Name()
+            preset_name(mother, mothername)
+            preset_name(father, fathername)
+            mothersurname = mothername.get_surname_list()[0]
+            mothersurname.set_primary(True)
+            mothersurname.origintype = NameOriginType(NameOriginType.MATRILINEAL)
+            fathersurname = fathername.get_surname_list()[0]
+            fathersurname.set_primary(False)
+            fathersurname.origintype = NameOriginType(NameOriginType.PATRILINEAL)
+            name.set_surname_list([mothersurname, fathersurname])
+            return name
+        else:
+            return name

--- a/gramps/plugins/nameguesser/nameplugins.gpr.py
+++ b/gramps/plugins/nameguesser/nameplugins.gpr.py
@@ -1,0 +1,42 @@
+from gramps.gen.plug._pluginreg import newplugin, STABLE, NAMEGUESSER
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+
+_ = glocale.translation.gettext
+
+MODULE_VERSION = "6.0"
+
+# de
+plg = newplugin()
+plg.id = "nameguesser_de"
+plg.name = _("German Name Guesser")
+plg.description = _("Guesses names when adding a person")
+plg.version = "1.0"
+plg.gramps_target_version = MODULE_VERSION
+plg.status = STABLE
+plg.fname = "nameguesser_de.py"
+plg.ptype = NAMEGUESSER
+plg.nameguesserclass = "NameGuesser"
+plg.lang_list = [
+    "de",
+    "DE",
+    "deutsch",
+    "Deutsch",
+    "de_DE.UTF8",
+    "de_DE@euro",
+    "de_DE.UTF8@euro",
+    "german",
+    "German",
+    "de_DE",
+    "de_DE.UTF-8",
+    "de_DE.utf-8",
+    "de_DE.utf8",
+    "de_CH",
+    "de_CH.UTF-8",
+    "de_CH.utf-8",
+    "de_CH.utf8",
+    "de_AT",
+    "de_AT.UTF-8",
+    "de_AT.utf-8",
+    "de_AT.utf8",
+    "de_AT.UTF8",
+]

--- a/gramps/plugins/nameguesser/nameplugins.gpr.py
+++ b/gramps/plugins/nameguesser/nameplugins.gpr.py
@@ -40,3 +40,75 @@ plg.lang_list = [
     "de_AT.utf8",
     "de_AT.UTF8",
 ]
+
+
+# es
+plg = newplugin()
+plg.id = "nameguesser_es"
+plg.name = _("Spanish Name Guesser")
+plg.description = _("Guesses names when adding a person")
+plg.version = "1.0"
+plg.gramps_target_version = MODULE_VERSION
+plg.status = STABLE
+plg.fname = "nameguesser_es.py"
+plg.ptype = NAMEGUESSER
+plg.nameguesserclass = "NameGuesser"
+plg.lang_list = [
+    "es",
+    "ES",
+    "es_ES",
+    "espanol",
+    "Espanol",
+    "es_ES.UTF8",
+    "es_ES@euro",
+    "es_ES.UTF8@euro",
+    "spanish",
+    "Spanish",
+    "es_ES.UTF-8",
+    "es_ES.utf-8",
+    "es_ES.utf8",
+]
+
+# is
+plg = newplugin()
+plg.id = "nameguesser_is"
+plg.name = _("Icelandic Name Guesser")
+plg.description = _("Guesses names when adding a person")
+plg.version = "1.0"
+plg.gramps_target_version = MODULE_VERSION
+plg.status = STABLE
+plg.fname = "nameguesser_is.py"
+plg.ptype = NAMEGUESSER
+plg.nameguesserclass = "NameGuesser"
+plg.lang_list = ["is", "IS", "is_IS", "is_IS@euro", "is_IS.utf8"]
+
+
+# pt
+plg = newplugin()
+plg.id = "nameguesser_pt"
+plg.name = _("Portuguese Name Guesser")
+plg.description = _("Guesses names when adding a person")
+plg.version = "1.0"
+plg.gramps_target_version = MODULE_VERSION
+plg.status = STABLE
+plg.fname = "nameguesser_pt.py"
+plg.ptype = NAMEGUESSER
+plg.nameguesserclass = "NameGuesser"
+plg.lang_list = [
+    "pt",
+    "PT",
+    "pt_PT",
+    "pt_BR",
+    "portugues",
+    "Portugues",
+    "pt_PT.UTF8",
+    "pt_BR.UTF8",
+    "pt_PT@euro",
+    "pt_PT.UTF8@euro",
+    "pt_PT.UTF-8",
+    "pt_BR.UTF-8",
+    "pt_PT.utf-8",
+    "pt_BR.utf-8",
+    "pt_PT.utf8",
+    "pt_BR.utf8",
+]

--- a/gramps/plugins/nameguesser/test/nameguesser_test.py
+++ b/gramps/plugins/nameguesser/test/nameguesser_test.py
@@ -1,0 +1,514 @@
+import random
+import unittest
+
+
+from gramps.gen.db.txn import DbTxn
+from gramps.gen.db.utils import make_database
+from gramps.gen.lib.childref import ChildRef
+from gramps.gen.lib.family import Family
+from gramps.gen.lib.familyreltype import FamilyRelType
+from gramps.gen.lib.nameorigintype import NameOriginType
+from gramps.gen.lib.person import Person
+from gramps.gen.lib.surname import Surname
+from gramps.gen.lib.name import Name
+from gramps.gen.nameguesser import NameGuesser
+from ..nameguesser_de import NameGuesser as NameGuesserDE
+from ..nameguesser_es import NameGuesser as NameGuesserES
+from ..nameguesser_is import NameGuesser as NameGuesserIS
+from ..nameguesser_pt import NameGuesser as NameGuesserPT
+
+
+class NameGuesserTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.db = make_database("sqlite")
+        cls.db.load(":memory:")
+
+    def setUp(self):
+        self.family_married = Family()
+        self.family_married.set_father_handle("123456")
+        self.family_married.set_mother_handle("654321")
+        self.family_married.set_relationship(FamilyRelType.MARRIED)
+
+        self.family_unmarried = Family()
+        self.family_unmarried.set_father_handle("123456")
+        self.family_unmarried.set_mother_handle("654321")
+        self.family_unmarried.set_relationship(FamilyRelType.UNMARRIED)
+
+        self.family_single_father = Family()
+        self.family_single_father.set_father_handle("123456")
+        self.family_single_father.set_relationship(FamilyRelType.UNKNOWN)
+
+        self.family_single_mother = Family()
+        self.family_single_mother.set_mother_handle("654321")
+        self.family_single_mother.set_relationship(FamilyRelType.UNKNOWN)
+
+    def test_example(self):
+        self.assertTrue(True)
+
+    def create_person_with_surname(self, surname_str):
+        person = Person()
+        person.set_handle(str(random.randint(100, 999)))
+        name = Name()
+        surname = Surname()
+        surname.set_surname(surname_str)
+        name.add_surname(surname)
+        name.set_primary_surname(0)
+        person.set_primary_name(name)
+        return person
+
+    def create_person_with_surnames(
+        self, surname_patrilineal_str, surname_matrilineal_str
+    ):
+        person = Person()
+        person.set_handle(str(random.randint(100, 999)))
+        name = Name()
+        surname_matr = Surname()
+        surname_matr.set_surname(surname_matrilineal_str)
+        surname_matr.set_origintype(NameOriginType(NameOriginType.MATRILINEAL))
+
+        surname_patr = Surname()
+        surname_patr.set_surname(surname_patrilineal_str)
+        surname_patr.set_origintype(NameOriginType(NameOriginType.PATRILINEAL))
+        name.set_surname_list([surname_patr, surname_matr])
+        name.set_primary_surname(0)
+        person.set_primary_name(name)
+        return person
+
+    def create_person_with_given_and_surname(
+        self, given_str, surname_str, surname_origin_type
+    ):
+        person = Person()
+        person.set_handle(str(random.randint(100, 999)))
+        name = Name()
+        surname = Surname()
+        surname.set_surname(surname_str)
+        surname.set_origintype(surname_origin_type)
+        name.add_surname(surname)
+        name.set_primary_surname(0)
+        name.set_first_name(given_str)
+        person.set_primary_name(name)
+        return person
+
+
+class NameGuesserTestES(NameGuesserTest):
+
+    def setUp(self):
+        self.nameguesser = NameGuesserES()
+        mother = self.create_person_with_surnames("García", "López")
+        father = self.create_person_with_surnames("Díaz", "Fernández")
+        child = self.create_person_with_surnames("Martínez", "Gómez")
+
+        with DbTxn("Add parents", self.db) as self.trans:
+            self.db.commit_person(father, self.trans)
+            self.db.commit_person(mother, self.trans)
+            self.db.commit_person(child, self.trans)
+
+        self.father = father
+        self.mother = mother
+        self.child = child
+
+    def __get_childs_surname_list(self, has_father, has_mother):
+        family = Family()
+        if has_father:
+            family.set_father_handle(self.father.handle)
+        if has_mother:
+            family.set_mother_handle(self.mother.handle)
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        child_name = self.nameguesser.childs_name(db=self.db, family=family)
+        return child_name.get_surname_list()
+
+    def test_child_surname(self):
+        surname_list = self.__get_childs_surname_list(True, True)
+        self.assertEqual(surname_list[0].get_surname(), "Díaz")
+        self.assertEqual(
+            int(surname_list[0].get_origintype()), NameOriginType.PATRILINEAL
+        )
+        self.assertEqual(surname_list[1].get_surname(), "García")
+        self.assertEqual(
+            int(surname_list[1].get_origintype()), NameOriginType.MATRILINEAL
+        )
+
+    def test_child_surname_with_single_mother(self):
+        surname_list = self.__get_childs_surname_list(False, True)
+        self.assertEqual(surname_list[0].get_surname(), "García")
+
+    def test_child_surname_with_single_father(self):
+        surname_list = self.__get_childs_surname_list(True, False)
+        self.assertEqual(surname_list[0].get_surname(), "Díaz")
+
+    def test_father_surname(self):
+        family = Family()
+        ref = ChildRef()
+        ref.ref = self.child.get_handle()
+        family.add_child_ref(ref)
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        father_name = self.nameguesser.fathers_name_from_child(
+            db=self.db, family=family
+        )
+        self.assertEqual(father_name.get_surname_list()[0].get_surname(), "Martínez")
+        self.assertEqual(
+            int(father_name.get_surname_list()[0].get_origintype()),
+            NameOriginType.PATRILINEAL,
+        )
+
+    def test_mother_surname(self):
+        family = Family()
+        ref = ChildRef()
+        ref.ref = self.child.get_handle()
+        family.add_child_ref(ref)
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        mother_name = self.nameguesser.mothers_name_from_child(
+            db=self.db, family=family
+        )
+        self.assertEqual(mother_name.get_surname_list()[0].get_surname(), "Gómez")
+        self.assertEqual(
+            int(mother_name.get_surname_list()[0].get_origintype()),
+            NameOriginType.PATRILINEAL,
+        )
+
+
+class NameGuesserTestDE(NameGuesserTest):
+
+    def setUp(self):
+        self.nameguesser = NameGuesserDE()
+        mother = self.create_person_with_surname("Meier")
+        father = self.create_person_with_surname("Müller")
+        child = self.create_person_with_surname("Schmidt")
+
+        with DbTxn("Add parents", self.db) as self.trans:
+            self.db.commit_person(father, self.trans)
+            self.db.commit_person(mother, self.trans)
+            self.db.commit_person(child, self.trans)
+
+        self.father = father
+        self.mother = mother
+        self.child = child
+
+    def __test_childs_surname(self, rel_type, expected_surname):
+        family = Family()
+        family.set_relationship(rel_type)
+        family.set_father_handle(self.father.handle)
+        family.set_mother_handle(self.mother.handle)
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        child_name = self.nameguesser.childs_name(db=self.db, family=family)
+        self.assertEqual(
+            child_name.get_surname_list()[0].get_surname(), expected_surname
+        )
+
+    def __test_father_surname(self, rel_type, expected_surname):
+        family = Family()
+        family.set_relationship(rel_type)
+        family.set_mother_handle(self.mother.handle)
+        ref = ChildRef()
+        ref.ref = self.child.get_handle()
+        family.add_child_ref(ref)
+
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        father_name = self.nameguesser.fathers_name_from_child(
+            db=self.db, family=family
+        )
+        self.assertEqual(
+            father_name.get_surname_list()[0].get_surname(), expected_surname
+        )
+
+    def __test_mother_surname(self, rel_type, expected_surname):
+        family = Family()
+        family.set_relationship(rel_type)
+        family.set_father_handle(self.father.handle)
+        ref = ChildRef()
+        ref.ref = self.child.get_handle()
+        family.add_child_ref(ref)
+
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        mother_name = self.nameguesser.mothers_name_from_child(
+            db=self.db, family=family
+        )
+        self.assertEqual(
+            mother_name.get_surname_list()[0].get_surname(), expected_surname
+        )
+
+    def test_childs_surname_unmarried(self):
+        self.__test_childs_surname(FamilyRelType.UNMARRIED, "Meier")
+
+    def test_childs_surname_married(self):
+        self.__test_childs_surname(FamilyRelType.MARRIED, "Müller")
+
+    def test_fathers_surname_unmarried(self):
+        self.__test_father_surname(FamilyRelType.UNMARRIED, "")
+
+    def test_fathers_surname_married(self):
+        self.__test_father_surname(FamilyRelType.MARRIED, "Schmidt")
+
+    def test_mothers_surname_unmarried(self):
+        self.__test_mother_surname(FamilyRelType.UNMARRIED, "Schmidt")
+
+    def test_mothers_surname_married(self):
+        self.__test_mother_surname(FamilyRelType.MARRIED, "")
+
+
+class NameGuesserTestPT(NameGuesserTest):
+
+    def setUp(self):
+        self.nameguesser = NameGuesserPT()
+        mother = self.create_person_with_surnames("Silva", "Santos")
+        father = self.create_person_with_surnames("Oliveira", "Sousa")
+        child = self.create_person_with_surnames("Alves", "Pereira")
+
+        with DbTxn("Add parents", self.db) as self.trans:
+            self.db.commit_person(father, self.trans)
+            self.db.commit_person(mother, self.trans)
+            self.db.commit_person(child, self.trans)
+
+        self.father = father
+        self.mother = mother
+        self.child = child
+
+    def __get_childs_surname_list(self, has_father, has_mother):
+        family = Family()
+        if has_father:
+            family.set_father_handle(self.father.handle)
+        if has_mother:
+            family.set_mother_handle(self.mother.handle)
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        child_name = self.nameguesser.childs_name(db=self.db, family=family)
+        return child_name.get_surname_list()
+
+    def test_child_surname(self):
+        surname_list = self.__get_childs_surname_list(True, True)
+        self.assertEqual(surname_list[0].get_surname(), "Silva")
+        self.assertEqual(
+            int(surname_list[0].get_origintype()), NameOriginType.MATRILINEAL
+        )
+        self.assertEqual(surname_list[1].get_surname(), "Oliveira")
+        self.assertEqual(
+            int(surname_list[1].get_origintype()), NameOriginType.PATRILINEAL
+        )
+
+    def test_child_surname_with_single_mother(self):
+        surname_list = self.__get_childs_surname_list(False, True)
+        self.assertEqual(surname_list[0].get_surname(), "Silva")
+
+    def test_child_surname_with_single_father(self):
+        surname_list = self.__get_childs_surname_list(True, False)
+        self.assertEqual(surname_list[0].get_surname(), "Oliveira")
+
+    def test_father_surname(self):
+        family = Family()
+        ref = ChildRef()
+        ref.ref = self.child.get_handle()
+        family.add_child_ref(ref)
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        father_name = self.nameguesser.fathers_name_from_child(
+            db=self.db, family=family
+        )
+        self.assertEqual(father_name.get_surname_list()[0].get_surname(), "Pereira")
+        self.assertEqual(
+            int(father_name.get_surname_list()[0].get_origintype()),
+            NameOriginType.MATRILINEAL,
+        )
+
+    def test_mother_surname(self):
+        family = Family()
+        ref = ChildRef()
+        ref.ref = self.child.get_handle()
+        family.add_child_ref(ref)
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        mother_name = self.nameguesser.mothers_name_from_child(
+            db=self.db, family=family
+        )
+        self.assertEqual(mother_name.get_surname_list()[0].get_surname(), "Alves")
+        self.assertEqual(
+            int(mother_name.get_surname_list()[0].get_origintype()),
+            NameOriginType.MATRILINEAL,
+        )
+
+
+class NameGuesserTestIS(NameGuesserTest):
+
+    def setUp(self):
+        self.nameguesser = NameGuesserIS()
+        mother = self.create_person_with_given_and_surname(
+            "Margrét", "Jóhannsdóttir", NameOriginType.PATRONYMIC
+        )
+        father = self.create_person_with_given_and_surname(
+            "Gunnar", "Björnsson", NameOriginType.PATRONYMIC
+        )
+        son_matr = self.create_person_with_given_and_surname(
+            "Jón", "Annasson", NameOriginType.MATRONYMIC
+        )
+        son_patr = self.create_person_with_given_and_surname(
+            "Jón", "Agnarsson", NameOriginType.PATRONYMIC
+        )
+        daughter_matr = self.create_person_with_given_and_surname(
+            "Anna", "Kristínsdóttir", NameOriginType.MATRONYMIC
+        )
+        daughter_patr = self.create_person_with_given_and_surname(
+            "Anna", "Alexandersdóttir", NameOriginType.PATRONYMIC
+        )
+
+        with DbTxn("Add persons", self.db) as self.trans:
+            self.db.commit_person(father, self.trans)
+            self.db.commit_person(mother, self.trans)
+            self.db.commit_person(son_matr, self.trans)
+            self.db.commit_person(son_patr, self.trans)
+            self.db.commit_person(daughter_matr, self.trans)
+            self.db.commit_person(daughter_patr, self.trans)
+
+        self.father = father
+        self.mother = mother
+        self.son_matr = son_matr
+        self.son_patr = son_patr
+        self.daughter_matr = daughter_matr
+        self.daughter_patr = daughter_patr
+
+    def test_child_surname(self):
+        family = Family()
+        family.set_father_handle(self.father.handle)
+        family.set_mother_handle(self.mother.handle)
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        child_name = self.nameguesser.childs_name(db=self.db, family=family)
+        self.assertEqual(child_name.get_surname(), "Gunnarsson")
+
+        self.assertEqual(
+            int(child_name.get_primary_surname().get_origintype()),
+            NameOriginType.PATRONYMIC,
+        )
+
+    def test_child_surname_with_single_mother(self):
+        family = Family()
+        family.set_mother_handle(self.mother.handle)
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        child_name = self.nameguesser.childs_name(db=self.db, family=family)
+        self.assertEqual(child_name.get_surname(), "Margrétsson")
+
+        self.assertEqual(
+            int(child_name.get_primary_surname().get_origintype()),
+            NameOriginType.MATRONYMIC,
+        )
+
+    def test_father_given_name_from_sons_patronymic_name(self):
+        family = Family()
+        ref = ChildRef()
+        ref.ref = self.son_patr.get_handle()
+        family.add_child_ref(ref)
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        father_name = self.nameguesser.fathers_name_from_child(
+            db=self.db, family=family
+        )
+        self.assertEqual(father_name.get_first_name(), "Agnar")
+
+    def test_father_given_name_from_sons_matronymic_name(self):
+        family = Family()
+        ref = ChildRef()
+        ref.ref = self.son_matr.get_handle()
+        family.add_child_ref(ref)
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        father_name = self.nameguesser.fathers_name_from_child(
+            db=self.db, family=family
+        )
+        self.assertEqual(father_name.get_first_name(), "")
+
+    def test_father_given_name_from_daughters_patronymic_name(self):
+        family = Family()
+        ref = ChildRef()
+        ref.ref = self.daughter_patr.get_handle()
+        family.add_child_ref(ref)
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        father_name = self.nameguesser.fathers_name_from_child(
+            db=self.db, family=family
+        )
+        self.assertEqual(father_name.get_first_name(), "Alexander")
+
+    def test_father_given_name_from_daughters_matronymic_name(self):
+        family = Family()
+        ref = ChildRef()
+        ref.ref = self.daughter_matr.get_handle()
+        family.add_child_ref(ref)
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        father_name = self.nameguesser.fathers_name_from_child(
+            db=self.db, family=family
+        )
+        self.assertEqual(father_name.get_first_name(), "")
+
+    def test_mother_given_name_from_sons_patronymic_name(self):
+        family = Family()
+        ref = ChildRef()
+        ref.ref = self.son_patr.get_handle()
+        family.add_child_ref(ref)
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        mother_name = self.nameguesser.mothers_name_from_child(
+            db=self.db, family=family
+        )
+        self.assertEqual(mother_name.get_first_name(), "")
+
+    def test_mother_given_name_from_sons_matronymic_name(self):
+        family = Family()
+        ref = ChildRef()
+        ref.ref = self.son_matr.get_handle()
+        family.add_child_ref(ref)
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        mother_name = self.nameguesser.mothers_name_from_child(
+            db=self.db, family=family
+        )
+        self.assertEqual(mother_name.get_first_name(), "Anna")
+
+    def test_mother_given_name_from_daughters_patronymic_name(self):
+        family = Family()
+        ref = ChildRef()
+        ref.ref = self.daughter_patr.get_handle()
+        family.add_child_ref(ref)
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        mother_name = self.nameguesser.mothers_name_from_child(
+            db=self.db, family=family
+        )
+        self.assertEqual(mother_name.get_first_name(), "")
+
+    def test_mother_given_name_from_daughters_matronymic_name(self):
+        family = Family()
+        ref = ChildRef()
+        ref.ref = self.daughter_matr.get_handle()
+        family.add_child_ref(ref)
+        with DbTxn("Add Family", self.db) as trans:
+            self.db.add_family(family, trans)
+
+        mother_name = self.nameguesser.mothers_name_from_child(
+            db=self.db, family=family
+        )
+        self.assertEqual(mother_name.get_first_name(), "Kristín")

--- a/gramps/plugins/view/relview.py
+++ b/gramps/plugins/view/relview.py
@@ -94,6 +94,7 @@ from gramps.gen.utils.db import (
 )
 from gramps.gui.ddtargets import DdTargets
 from gramps.gen.utils.symbols import Symbols
+from gramps.gen.nameguesser import get_nameguesser
 
 _NAME_START = 0
 _LABEL_START = 0
@@ -174,6 +175,7 @@ class RelationshipView(NavigationView):
         self.toolbar_visible = config.get("interface.toolbar-on")
         self.age_precision = config.get("preferences.age-display-precision")
         self.reload_symbols()
+        self.nameguesser_class = get_nameguesser(clocale=glocale)
 
     def get_handle_from_gramps_id(self, gid):
         """
@@ -1787,16 +1789,9 @@ class RelationshipView(NavigationView):
         if button_activated(event, _LEFT_BUTTON):
             callback = lambda x: self.callback_add_child(x, handle)
             person = Person()
-            name = Name()
-            # the editor requires a surname
-            name.add_surname(Surname())
-            name.set_primary_surname(0)
             family = self.dbstate.db.get_family_from_handle(handle)
-            father_h = family.get_father_handle()
-            if father_h:
-                father = self.dbstate.db.get_person_from_handle(father_h)
-                if father:
-                    preset_name(father, name)
+
+            name = self.nameguesser_class.childs_name(self.dbstate.db, family)
             person.set_primary_name(name)
             try:
                 EditPerson(self.dbstate, self.uistate, [], person, callback=callback)


### PR DESCRIPTION
Hello, 

the context to this pull request is this discussion: https://gramps.discourse.group/t/new-localized-options-for-surname-guessing/8204

I added a new NameGuesser plugin with localizations (for DE, ES, PT, IS).
The plugin is used when adding a new person to a family (in the classes EditFamily and RelationshipView).

Default locale (EN):

- Surname guessing is like the default before: When adding a child, it gets the father's surname; when adding a father, he gets the child's surname.

Locale DE:

- When adding a child, it gets the father's surname, unless the family is unmarried, then it gets the mother's surname.
- If unmarried, the mother gets the child's surname when adding the mother.
- If not unmarried, the father gets the child's surname when adding the father.

Locale ES:

- Surname guessing is like the Latin American surname guessing option that has existed before. The child's first surname is the father's first surname, the child's second surname is the mother's first surname.

Locale PT:
- Like ES, but reversed: The child's first surname is the mother's first surname, the child's second surname is the father's first surname.

Locale IS:
- When a child is added and a father exists in the family, the child's surname will be the father's given name + "sson" or "sdóttir"
- If a child has a matronymic surname and a mother is added to the family, the mother's given name will be the child's surname minus "sson" or "sdóttir"
- If a child has a non-matronymic surname and a father is added, the father's given name will be the child's surname minus "sson" or "sdóttir"
