### PR TITLE
Add Irish (ga) to the list of supported languages

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -13,6 +13,7 @@ eo
 es
 fi
 fr
+ga
 he
 hr
 hu


### PR DESCRIPTION
Irish is now 100% translated in Weblate.