### PR TITLE
Ignore mypy error when setting sqlite3.paramstyle

### DIFF
--- a/gramps/plugins/db/dbapi/sqlite.py
+++ b/gramps/plugins/db/dbapi/sqlite.py
@@ -44,7 +44,7 @@ from gramps.plugins.db.dbapi.dbapi import DBAPI
 
 _ = glocale.translation.gettext
 
-sqlite3.paramstyle = "qmark"
+sqlite3.paramstyle = "qmark"  # type: ignore[misc]
 
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
This is a constant that is hard-coded to "qmark". See:

https://docs.python.org/3/library/sqlite3.html#sqlite3.paramstyle

We should remove this line in the _master_ branch.