### PR TITLE
Preserve order in find_children

### DIFF
--- a/gramps/gen/utils/db.py
+++ b/gramps/gen/utils/db.py
@@ -374,13 +374,14 @@ def find_children(db, person):
     """
     Return the list of all children's IDs for a person.
     """
-    children = set()
+    children = []
     for family_handle in person.get_family_handle_list():
         family = db.get_family_from_handle(family_handle)
         if family:
             for child_ref in family.get_child_ref_list():
-                children.add(child_ref.ref)
-    return list(children)
+                children.append(child_ref.ref)
+    # return without duplicates, preserving order
+    return list(dict.fromkeys(children))
 
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
A user in the German Gramps forum [pointed out](https://discourse.genealogy.net/t/kinder-in-falscher-reihenfolge-in-ahnentafel-unter-diagramme/836721/7) that the order of children in the pedigree view (when clicking the left arrow) is seemingly random. I traced that back to the function `find_children`, which iterates over families and children and adds the handles to a set, eventually returning a list.

However, since sets are not ordered, the resulting order is random.

I fixed that by simply using a list instread of the set and removing duplicates in the end (using the [famous Stackoverflow trick](https://stackoverflow.com/questions/7961363/removing-duplicates-in-lists)).